### PR TITLE
Add VCPKG_DEFAULT_TRIPLET environment variable for build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         shell: pwsh
         env:
           VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+          VCPKG_DEFAULT_TRIPLET: x64-windows
         run: |
           cmake --preset vs2022-x64
 
@@ -61,6 +62,7 @@ jobs:
       - name: Configure
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+          VCPKG_DEFAULT_TRIPLET: x64-linux
         run: |
           cmake --preset linux-x64
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "lcdlln-engine",
+  "version": "0.1.0",
+  "description": "LCDLLN MMORPG Engine dependencies",
+  "dependencies": [
+    "vulkan",
+    "glfw3"
+  ]
+}


### PR DESCRIPTION
This commit introduces the VCPKG_DEFAULT_TRIPLET environment variable in both the Windows and Linux build configurations of the GitHub Actions workflow. This enhancement ensures that the correct triplet is used for package management, improving build consistency across different platforms.