### PR TITLE
Add string header inclusion in FrameGraph.h for improved functionality

### DIFF
--- a/engine/render/FrameGraph.h
+++ b/engine/render/FrameGraph.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
This commit adds the `<string>` header to the `FrameGraph.h` file, enhancing the functionality of the frame graph by enabling string operations. This change supports future developments that may require string manipulation within the rendering framework.