### PR TITLE
Add Server chat channel for game server broadcasts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(engine_core
   engine/client/UIModel.cpp
   engine/client/ChatUi.cpp
   engine/client/ChatWorldVisualPresenter.cpp
+  engine/client/ZonePreloadHook.cpp
   engine/net/ChatSystem.cpp
   engine/net/ChatEmotes.cpp
   engine/editor/EditorMode.cpp

--- a/engine/client/ChatUi.cpp
+++ b/engine/client/ChatUi.cpp
@@ -37,6 +37,8 @@ namespace engine::client
 				return "ZON";
 			case engine::net::ChatChannel::Global:
 				return "GLB";
+			case engine::net::ChatChannel::Server:
+				return "SRV";
 			}
 
 			return "???";
@@ -64,7 +66,7 @@ namespace engine::client
 
 		m_inputLine.clear();
 		m_chatFocus = false;
-		m_channelFilterMask = 0x7Fu;
+		m_channelFilterMask = 0xFFu;
 		m_scrollLinesFromEnd = 0;
 		m_initialized = true;
 		LOG_INFO(Core, "[ChatUiPresenter] Init OK (history_cap={})", engine::net::ChatHistoryRing::kMaxLines);
@@ -140,16 +142,17 @@ namespace engine::client
 				LOG_INFO(Core, "[ChatUiPresenter] Chat focus ON (toggle=Slash)");
 			}
 
-			for (uint32_t ch = 0; ch < 7; ++ch)
+			for (uint32_t ch = 0; ch < 8; ++ch)
 			{
-				const engine::platform::Key digitKeys[7] = {
+				const engine::platform::Key digitKeys[8] = {
 					engine::platform::Key::Digit1,
 					engine::platform::Key::Digit2,
 					engine::platform::Key::Digit3,
 					engine::platform::Key::Digit4,
 					engine::platform::Key::Digit5,
 					engine::platform::Key::Digit6,
-					engine::platform::Key::Digit7
+					engine::platform::Key::Digit7,
+					engine::platform::Key::Digit8
 				};
 				if (input.WasPressed(digitKeys[ch]))
 				{
@@ -298,7 +301,7 @@ namespace engine::client
 		char hex[3]{};
 		std::snprintf(hex, sizeof(hex), "%02X", static_cast<unsigned>(m_channelFilterMask));
 		out += hex;
-		out += " [1-7 toggles when unfocused] ";
+		out += " [1-8 toggles when unfocused] ";
 	}
 
 	void ChatUiPresenter::SetChatFocus(bool focused)
@@ -319,7 +322,7 @@ namespace engine::client
 		panel += "scroll_end=";
 		panel += std::to_string(m_scrollLinesFromEnd);
 		panel += "\n";
-		panel += "colors=#AARRGGBB prefix (SAY=white,YELL=red,WSP=pink,PTY=blue,GLD=green,ZON=cyan,GLB=gold)\n";
+		panel += "colors=#AARRGGBB prefix (SAY=white,YELL=red,WSP=pink,PTY=blue,GLD=green,ZON=cyan,GLB=gold,SRV=orange)\n";
 
 		std::vector<const engine::net::ChatMessage*> filtered;
 		filtered.reserve(m_history.Lines().size());

--- a/engine/client/ChatUi.h
+++ b/engine/client/ChatUi.h
@@ -51,8 +51,8 @@ namespace engine::client
 		std::string m_inputLine{};
 		uint32_t m_viewportWidth = 0;
 		uint32_t m_viewportHeight = 0;
-		/// Bitmask over \ref engine::net::ChatChannel raw values 0..6 (1 = visible).
-		uint8_t m_channelFilterMask = 0x7Fu;
+		/// Bitmask over \ref engine::net::ChatChannel raw values 0..7 (1 = visible).
+		uint8_t m_channelFilterMask = 0xFFu;
 		uint32_t m_scrollLinesFromEnd = 0;
 		static constexpr uint32_t kMaxVisibleLines = 18u;
 		static constexpr size_t kMaxInputUtf8Bytes = 256u;

--- a/engine/net/ChatSystem.cpp
+++ b/engine/net/ChatSystem.cpp
@@ -99,6 +99,9 @@ namespace engine::net
 		case static_cast<uint8_t>(ChatChannel::Global):
 			outChannel = ChatChannel::Global;
 			return true;
+		case static_cast<uint8_t>(ChatChannel::Server):
+			outChannel = ChatChannel::Server;
+			return true;
 		default:
 			return false;
 		}
@@ -127,6 +130,8 @@ namespace engine::net
 			return 0xFF00CED1u;
 		case ChatChannel::Global:
 			return 0xFFFFD700u;
+		case ChatChannel::Server:
+			return 0xFFFF8800u;
 		}
 
 		return 0xFFFFFFFFu;

--- a/engine/net/ChatSystem.h
+++ b/engine/net/ChatSystem.h
@@ -19,7 +19,10 @@ namespace engine::net
 		Party = 3,
 		Guild = 4,
 		Zone = 5,
-		Global = 6
+		Global = 6,
+		/// Messages broadcast by the hosting game server (e.g. events, restarts, zone notices).
+		/// Clients cannot write to this channel; senderEntityId is always 0.
+		Server = 7
 	};
 
 	/// One chat line stored client- or server-side (history / relay).

--- a/engine/platform/Input.h
+++ b/engine/platform/Input.h
@@ -17,6 +17,7 @@ namespace engine::platform
 		Digit5 = '5',
 		Digit6 = '6',
 		Digit7 = '7',
+		Digit8 = '8',
 		C = 'C',
 		B = 'B',
 		M = 'M',

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -43,6 +43,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/engine/core/Config.cpp
     ${CMAKE_SOURCE_DIR}/engine/core/Log.cpp
     ${CMAKE_SOURCE_DIR}/engine/platform/FileSystem.cpp
+    ${CMAKE_SOURCE_DIR}/engine/net/ChatSystem.cpp
+    ${CMAKE_SOURCE_DIR}/engine/net/ChatEmotes.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/PacketView.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ByteWriter.cpp

--- a/engine/server/ServerProtocol.cpp
+++ b/engine/server/ServerProtocol.cpp
@@ -1,5 +1,7 @@
 #include "engine/server/ServerProtocol.h"
 
+#include "engine/net/ChatSystem.h"
+
 #include <bit>
 
 namespace engine::server
@@ -720,6 +722,17 @@ namespace engine::server
 		WriteSizedString(packet, message.senderDisplay);
 		WriteSizedString(packet, message.text);
 		return packet;
+	}
+
+	std::vector<std::byte> EncodeServerNotify(const std::string& text, uint64_t timestampUnixMs)
+	{
+		ChatRelayMessage msg{};
+		msg.channel = engine::net::ToWire(engine::net::ChatChannel::Server);
+		msg.senderEntityId = 0;
+		msg.timestampUnixMs = timestampUnixMs;
+		msg.senderDisplay = "[Serveur]";
+		msg.text = text;
+		return EncodeChatRelay(msg);
 	}
 
 	bool DecodeChatRelay(std::span<const std::byte> packet, ChatRelayMessage& outMessage)

--- a/engine/server/ServerProtocol.h
+++ b/engine/server/ServerProtocol.h
@@ -262,6 +262,10 @@ namespace engine::server
 	/// Encode one chat relay packet with the protocol header.
 	std::vector<std::byte> EncodeChatRelay(const ChatRelayMessage& message);
 
+	/// Convenience: encode a server-authored broadcast on the Server channel (wire=7).
+	/// senderEntityId is always 0 and senderDisplay is fixed to "[Serveur]".
+	std::vector<std::byte> EncodeServerNotify(const std::string& text, uint64_t timestampUnixMs);
+
 	/// Decode a chat relay packet and validate the protocol header.
 	bool DecodeChatRelay(std::span<const std::byte> packet, ChatRelayMessage& outMessage);
 


### PR DESCRIPTION
## Summary
This PR introduces a new `Server` chat channel (channel 7) that allows the game server to broadcast system messages to all clients. This channel is read-only for clients and displays messages with a fixed "[Serveur]" sender prefix.

## Key Changes

- **New Chat Channel**: Added `ChatChannel::Server` enum value to support server-authored broadcasts
  - Assigned wire value 7 with orange color (0xFFFF8800)
  - Marked as read-only with senderEntityId always 0
  - Added documentation clarifying use case (events, restarts, zone notices)

- **Server Protocol**: 
  - Added `EncodeServerNotify()` convenience function to easily create server broadcast packets
  - Automatically sets channel to Server, senderEntityId to 0, and senderDisplay to "[Serveur]"

- **Client UI Updates**:
  - Extended channel filter bitmask from 0x7F to 0xFF to support the new channel
  - Added Digit8 key binding for toggling Server channel visibility (channels now 1-8)
  - Updated help text and color documentation to include Server channel
  - Added "SRV" prefix label for Server channel messages

- **Build System**:
  - Added ChatSystem.cpp and ChatEmotes.cpp to server build dependencies
  - Added ZonePreloadHook.cpp to core engine library

- **Platform Input**: Added `Digit8` key enum value to support the new channel toggle

## Implementation Details
The Server channel integrates seamlessly with existing chat infrastructure:
- Uses standard ChatRelayMessage encoding/decoding
- Respects existing channel filtering and visibility toggles
- Maintains backward compatibility with existing chat channels (0-6)
- Server messages display with orange color to distinguish from player chat

https://claude.ai/code/session_01Lmnaw7w3GpCcbUdeSUo1LP