### PR TITLE
feat(chat): ajouter canaux Raid et Amis (wire=8,9)

### DIFF
--- a/engine/client/ChatUi.cpp
+++ b/engine/client/ChatUi.cpp
@@ -39,12 +39,16 @@ namespace engine::client
 				return "GLB";
 			case engine::net::ChatChannel::Server:
 				return "SRV";
+			case engine::net::ChatChannel::Raid:
+				return "RAI";
+			case engine::net::ChatChannel::Friends:
+				return "AMI";
 			}
 
 			return "???";
 		}
 
-		bool ChannelFilterAllows(uint8_t mask, engine::net::ChatChannel channel)
+		bool ChannelFilterAllows(uint16_t mask, engine::net::ChatChannel channel)
 		{
 			const uint32_t bit = 1u << static_cast<uint32_t>(channel);
 			return (static_cast<uint32_t>(mask) & bit) != 0u;
@@ -66,7 +70,7 @@ namespace engine::client
 
 		m_inputLine.clear();
 		m_chatFocus = false;
-		m_channelFilterMask = 0xFFu;
+		m_channelFilterMask = 0x3FFu;
 		m_scrollLinesFromEnd = 0;
 		m_initialized = true;
 		LOG_INFO(Core, "[ChatUiPresenter] Init OK (history_cap={})", engine::net::ChatHistoryRing::kMaxLines);
@@ -142,9 +146,9 @@ namespace engine::client
 				LOG_INFO(Core, "[ChatUiPresenter] Chat focus ON (toggle=Slash)");
 			}
 
-			for (uint32_t ch = 0; ch < 8; ++ch)
+			for (uint32_t ch = 0; ch < 10; ++ch)
 			{
-				const engine::platform::Key digitKeys[8] = {
+				const engine::platform::Key digitKeys[10] = {
 					engine::platform::Key::Digit1,
 					engine::platform::Key::Digit2,
 					engine::platform::Key::Digit3,
@@ -152,13 +156,15 @@ namespace engine::client
 					engine::platform::Key::Digit5,
 					engine::platform::Key::Digit6,
 					engine::platform::Key::Digit7,
-					engine::platform::Key::Digit8
+					engine::platform::Key::Digit8,
+					engine::platform::Key::Digit9,
+					engine::platform::Key::Digit0
 				};
 				if (input.WasPressed(digitKeys[ch]))
 				{
 					const uint32_t bit = 1u << ch;
-					m_channelFilterMask ^= static_cast<uint8_t>(bit);
-					LOG_INFO(Core, "[ChatUiPresenter] Channel filter toggled (channel_index={}, mask=0x{:02X})",
+					m_channelFilterMask ^= static_cast<uint16_t>(bit);
+					LOG_INFO(Core, "[ChatUiPresenter] Channel filter toggled (channel_index={}, mask=0x{:04X})",
 						ch,
 						m_channelFilterMask);
 				}
@@ -298,10 +304,10 @@ namespace engine::client
 	void ChatUiPresenter::RebuildFilterLegend(std::string& out) const
 	{
 		out += "filter_mask=0x";
-		char hex[3]{};
-		std::snprintf(hex, sizeof(hex), "%02X", static_cast<unsigned>(m_channelFilterMask));
+		char hex[5]{};
+		std::snprintf(hex, sizeof(hex), "%04X", static_cast<unsigned>(m_channelFilterMask));
 		out += hex;
-		out += " [1-8 toggles when unfocused] ";
+		out += " [1-9,0 toggles when unfocused] ";
 	}
 
 	void ChatUiPresenter::SetChatFocus(bool focused)
@@ -322,7 +328,7 @@ namespace engine::client
 		panel += "scroll_end=";
 		panel += std::to_string(m_scrollLinesFromEnd);
 		panel += "\n";
-		panel += "colors=#AARRGGBB prefix (SAY=white,YELL=red,WSP=pink,PTY=blue,GLD=green,ZON=cyan,GLB=gold,SRV=orange)\n";
+		panel += "colors=#AARRGGBB prefix (SAY=white,YELL=red,WSP=pink,PTY=blue,GLD=green,ZON=cyan,GLB=gold,SRV=orange,RAI=red-orange,AMI=light-green)\n";
 
 		std::vector<const engine::net::ChatMessage*> filtered;
 		filtered.reserve(m_history.Lines().size());

--- a/engine/client/ChatUi.h
+++ b/engine/client/ChatUi.h
@@ -51,8 +51,8 @@ namespace engine::client
 		std::string m_inputLine{};
 		uint32_t m_viewportWidth = 0;
 		uint32_t m_viewportHeight = 0;
-		/// Bitmask over \ref engine::net::ChatChannel raw values 0..7 (1 = visible).
-		uint8_t m_channelFilterMask = 0xFFu;
+		/// Bitmask over \ref engine::net::ChatChannel raw values 0..9 (1 = visible).
+		uint16_t m_channelFilterMask = 0x3FFu;
 		uint32_t m_scrollLinesFromEnd = 0;
 		static constexpr uint32_t kMaxVisibleLines = 18u;
 		static constexpr size_t kMaxInputUtf8Bytes = 256u;

--- a/engine/net/ChatSystem.cpp
+++ b/engine/net/ChatSystem.cpp
@@ -102,6 +102,12 @@ namespace engine::net
 		case static_cast<uint8_t>(ChatChannel::Server):
 			outChannel = ChatChannel::Server;
 			return true;
+		case static_cast<uint8_t>(ChatChannel::Raid):
+			outChannel = ChatChannel::Raid;
+			return true;
+		case static_cast<uint8_t>(ChatChannel::Friends):
+			outChannel = ChatChannel::Friends;
+			return true;
 		default:
 			return false;
 		}
@@ -132,6 +138,10 @@ namespace engine::net
 			return 0xFFFFD700u;
 		case ChatChannel::Server:
 			return 0xFFFF8800u;
+		case ChatChannel::Raid:
+			return 0xFFFF4500u;
+		case ChatChannel::Friends:
+			return 0xFF90EE90u;
 		}
 
 		return 0xFFFFFFFFu;
@@ -259,6 +269,28 @@ namespace engine::net
 		}
 
 		if (TryApplySimplePrefix(line, "/z", ChatChannel::Zone, outParsed))
+		{
+			return true;
+		}
+
+		// /raid or /ra — canal raid (tester le préfixe le plus long en premier)
+		if (TryApplySimplePrefix(line, "/raid", ChatChannel::Raid, outParsed))
+		{
+			return true;
+		}
+
+		if (TryApplySimplePrefix(line, "/ra", ChatChannel::Raid, outParsed))
+		{
+			return true;
+		}
+
+		// /amis or /am — canal amis
+		if (TryApplySimplePrefix(line, "/amis", ChatChannel::Friends, outParsed))
+		{
+			return true;
+		}
+
+		if (TryApplySimplePrefix(line, "/am", ChatChannel::Friends, outParsed))
 		{
 			return true;
 		}

--- a/engine/net/ChatSystem.h
+++ b/engine/net/ChatSystem.h
@@ -22,7 +22,11 @@ namespace engine::net
 		Global = 6,
 		/// Messages broadcast by the hosting game server (e.g. events, restarts, zone notices).
 		/// Clients cannot write to this channel; senderEntityId is always 0.
-		Server = 7
+		Server = 7,
+		/// Multi-group raid channel (broadcast to all parties in the same raid).
+		Raid = 8,
+		/// Friends-list private channel (broadcast only to online friends of the sender).
+		Friends = 9
 	};
 
 	/// One chat line stored client- or server-side (history / relay).

--- a/engine/platform/Input.h
+++ b/engine/platform/Input.h
@@ -18,6 +18,8 @@ namespace engine::platform
 		Digit6 = '6',
 		Digit7 = '7',
 		Digit8 = '8',
+		Digit9 = '9',
+		Digit0 = '0',
 		C = 'C',
 		B = 'B',
 		M = 'M',


### PR DESCRIPTION
Canaux manquants ajoutés pour compléter le système de chat :
- ChatChannel::Raid = 8  — canal multi-équipe (raid)
- ChatChannel::Friends = 9 — canal amis (joueurs connectés de la liste d'amis)

Commandes slash :
- /raid ou /ra → canal Raid
- /amis ou /am → canal Amis

Couleurs client :
- Raid   : rouge-orangé (0xFFFF4500)
- Amis   : vert clair   (0xFF90EE90)

Tags panneau chat : RAI, AMI

Masque de filtre étendu de uint8_t (0xFF, 8 canaux) à uint16_t (0x3FF, 10 canaux). Touches de filtre : 1-9 + 0 (Digit9 → Raid, Digit0 → Amis). Digit9 et Digit0 ajoutés dans Input.h Key enum.

https://claude.ai/code/session_01Lmnaw7w3GpCcbUdeSUo1LP