### PR TITLE
Make log file output optional by defaulting filePath to empty

### DIFF
--- a/engine/core/Log.h
+++ b/engine/core/Log.h
@@ -21,7 +21,8 @@ namespace engine::core
         /// Minimum level that will be emitted.
         LogLevel level = LogLevel::Info;
         /// Relative path to the log file to append to (created if missing).
-        std::string filePath = "engine.log";
+        /// Empty string means no file output.
+        std::string filePath;
         /// If true, also write logs to stdout/stderr.
         bool console = true;
         /// If true, flush file output after each line (recommended for Debug builds).


### PR DESCRIPTION
## Summary
Changed the default behavior of the logging system to disable file output by default, while maintaining the ability to enable it by explicitly setting a file path.

## Key Changes
- Changed `LogConfig::filePath` default value from `"engine.log"` to empty string
- Added clarifying comment that empty string means no file output
- File logging is now opt-in rather than opt-out

## Implementation Details
This change makes the logging system more flexible by allowing users to choose whether they want file output. Previously, logs would always be written to "engine.log" by default. Now, users must explicitly configure a file path if they want file output, while console output remains enabled by default.

https://claude.ai/code/session_01BwLZRgquBERRMdTjUcxREo