### PR TITLE
feat(M32.3): guild system — creation, roster, ranks, permissions, gui…

### DIFF
--- a/db/migrations/0003_guilds.sql
+++ b/db/migrations/0003_guilds.sql
@@ -1,0 +1,60 @@
+-- M32.3 — Migration 0003: guild tables (guilds, guild_members, guild_ranks).
+-- guilds       : one row per guild (name unique, 3-20 chars).
+-- guild_members: one row per (guild, player) pair; rank_id references guild_ranks.
+-- guild_ranks  : rank definitions with permission bitfields per guild.
+-- Creation cost (1000 gold) and max-members (500) are enforced in the application layer.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------------
+-- guilds
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guilds (
+  id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT
+                   COMMENT 'guild id (auto-increment)',
+  name             VARCHAR(20)     NOT NULL
+                   COMMENT 'unique guild name, 3-20 characters',
+  motd             VARCHAR(512)    NOT NULL DEFAULT ''
+                   COMMENT 'message of the day, editable by Officer+',
+  master_player_id BIGINT UNSIGNED NOT NULL
+                   COMMENT 'account id of the current Guild Master',
+  created_at       TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_guilds_name (name),
+  KEY ix_guilds_master (master_player_id),
+  CONSTRAINT chk_guilds_name_length CHECK (CHAR_LENGTH(name) BETWEEN 3 AND 20)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- guild_members
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guild_members (
+  guild_id  BIGINT UNSIGNED  NOT NULL
+            COMMENT 'references guilds.id',
+  player_id BIGINT UNSIGNED  NOT NULL
+            COMMENT 'references accounts.id',
+  rank_id   TINYINT UNSIGNED NOT NULL DEFAULT 3
+            COMMENT '0=GuildMaster, 1=Officer, 2=Member, 3=Recruit',
+  joined_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id, player_id),
+  KEY ix_guild_members_player (player_id),
+  CONSTRAINT chk_guild_members_rank CHECK (rank_id <= 3)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- guild_ranks  (customizable rank definitions per guild)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guild_ranks (
+  guild_id             BIGINT UNSIGNED  NOT NULL
+                       COMMENT 'references guilds.id',
+  rank_id              TINYINT UNSIGNED NOT NULL
+                       COMMENT '0-3 in the default scheme; extensible',
+  rank_name            VARCHAR(32)      NOT NULL
+                       COMMENT 'display label for this rank',
+  permissions_bitfield INT UNSIGNED     NOT NULL DEFAULT 0
+                       COMMENT 'OR of GuildPermission bits: Invite=1, Kick=2, Promote=4, WithdrawBank=8, EditMotd=16',
+  PRIMARY KEY (guild_id, rank_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -11,6 +11,7 @@ if(WIN32)
     ServerProtocol.cpp
     FriendSystem.cpp
     PartySystem.cpp
+    GuildSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatEmotes.cpp
     CharacterPersistence.cpp
@@ -62,6 +63,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/engine/network/ServerListPayloads.cpp
     FriendSystem.cpp
     PartySystem.cpp
+    GuildSystem.cpp
     AccountValidation.cpp
     InMemoryAccountStore.cpp
     AuthRegisterHandler.cpp

--- a/engine/server/GuildSystem.cpp
+++ b/engine/server/GuildSystem.cpp
@@ -1,0 +1,713 @@
+// M32.3 — Server-side guild system implementation.
+// Handles creation, roster management, ranks, permissions and guild chat routing.
+// On platforms without MySQL (WIN32 game shard) the system operates in no-DB mode:
+// presence tracking and in-memory state are fully functional; DB operations are skipped.
+
+#include "engine/server/GuildSystem.h"
+#include "engine/core/Log.h"
+
+#if ENGINE_HAS_MYSQL
+#  include "engine/server/db/DbHelpers.h"
+#  include <mysql.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+namespace engine::server
+{
+	// =========================================================================
+	// Static helpers
+	// =========================================================================
+
+	/*static*/
+	std::vector<GuildRankRecord> GuildSystem::MakeDefaultRanks()
+	{
+		using P = GuildPermission;
+
+		constexpr uint32_t kAllPerms =
+			static_cast<uint32_t>(P::Invite)       |
+			static_cast<uint32_t>(P::Kick)         |
+			static_cast<uint32_t>(P::Promote)      |
+			static_cast<uint32_t>(P::WithdrawBank) |
+			static_cast<uint32_t>(P::EditMotd);
+
+		constexpr uint32_t kOfficerPerms =
+			static_cast<uint32_t>(P::Invite)  |
+			static_cast<uint32_t>(P::Kick)    |
+			static_cast<uint32_t>(P::Promote) |
+			static_cast<uint32_t>(P::EditMotd);
+
+		return {
+			{ static_cast<uint8_t>(DefaultGuildRank::GuildMaster), "Guild Master", kAllPerms     },
+			{ static_cast<uint8_t>(DefaultGuildRank::Officer),     "Officer",      kOfficerPerms },
+			{ static_cast<uint8_t>(DefaultGuildRank::Member),      "Member",       0u            },
+			{ static_cast<uint8_t>(DefaultGuildRank::Recruit),     "Recruit",      0u            },
+		};
+	}
+
+	// =========================================================================
+	// Init / Shutdown
+	// =========================================================================
+
+	bool GuildSystem::Init(MYSQL* mysql)
+	{
+		m_guilds.clear();
+		m_playerGuildMap.clear();
+		m_onlinePlayers.clear();
+		m_nextGuildId = 1;
+		m_initialized = true;
+
+#if ENGINE_HAS_MYSQL
+		if (!mysql)
+			LOG_WARN(Server, "[GuildSystem] Init in no-DB mode (mysql=null)");
+		else
+			LOG_INFO(Server, "[GuildSystem] Init OK (DB mode)");
+#else
+		(void)mysql;
+		LOG_INFO(Server, "[GuildSystem] Init OK (no-DB mode)");
+#endif
+		return true;
+	}
+
+	void GuildSystem::Shutdown()
+	{
+		m_guilds.clear();
+		m_playerGuildMap.clear();
+		m_onlinePlayers.clear();
+		m_initialized = false;
+		LOG_INFO(Server, "[GuildSystem] Shutdown");
+	}
+
+	// =========================================================================
+	// Private helpers
+	// =========================================================================
+
+	bool GuildSystem::ValidateGuildName(std::string_view name) const
+	{
+		if (name.size() < kGuildNameMinLen || name.size() > kGuildNameMaxLen)
+			return false;
+		for (char c : name)
+		{
+			if (!std::isalnum(static_cast<unsigned char>(c)) &&
+			    c != ' ' && c != '-' && c != '_')
+				return false;
+		}
+		return true;
+	}
+
+	GuildRecord* GuildSystem::FindGuild(uint64_t guildId)
+	{
+		auto it = m_guilds.find(guildId);
+		return (it != m_guilds.end()) ? &it->second : nullptr;
+	}
+
+	const GuildRecord* GuildSystem::FindGuild(uint64_t guildId) const
+	{
+		auto it = m_guilds.find(guildId);
+		return (it != m_guilds.end()) ? &it->second : nullptr;
+	}
+
+	GuildMemberRecord* GuildSystem::FindMember(GuildRecord& guild, uint64_t playerId)
+	{
+		for (auto& m : guild.members)
+			if (m.playerId == playerId) return &m;
+		return nullptr;
+	}
+
+	const GuildMemberRecord* GuildSystem::FindMember(const GuildRecord& guild, uint64_t playerId) const
+	{
+		for (const auto& m : guild.members)
+			if (m.playerId == playerId) return &m;
+		return nullptr;
+	}
+
+	const GuildRankRecord* GuildSystem::FindRank(const GuildRecord& guild, uint8_t rankId) const
+	{
+		for (const auto& r : guild.ranks)
+			if (r.rankId == rankId) return &r;
+		return nullptr;
+	}
+
+	// =========================================================================
+	// Queries
+	// =========================================================================
+
+	uint64_t GuildSystem::GetGuildIdForPlayer(uint64_t playerId) const
+	{
+		auto it = m_playerGuildMap.find(playerId);
+		return (it != m_playerGuildMap.end()) ? it->second : 0u;
+	}
+
+	const GuildRecord* GuildSystem::GetGuild(uint64_t guildId) const
+	{
+		return FindGuild(guildId);
+	}
+
+	bool GuildSystem::HasPermission(uint64_t guildId, uint64_t playerId, GuildPermission perm) const
+	{
+		const GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+			return false;
+		const GuildMemberRecord* member = FindMember(*guild, playerId);
+		if (!member)
+			return false;
+		// Guild Master implicitly holds all permissions.
+		if (member->rankId == static_cast<uint8_t>(DefaultGuildRank::GuildMaster))
+			return true;
+		const GuildRankRecord* rank = FindRank(*guild, member->rankId);
+		if (!rank)
+			return false;
+		return (rank->permissionsBitfield & static_cast<uint32_t>(perm)) != 0u;
+	}
+
+	std::vector<uint64_t> GuildSystem::GetOnlineMemberIds(uint64_t guildId) const
+	{
+		const GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+			return {};
+		std::vector<uint64_t> result;
+		result.reserve(guild->members.size());
+		for (const auto& m : guild->members)
+		{
+			if (m_onlinePlayers.count(m.playerId))
+				result.push_back(m.playerId);
+		}
+		return result;
+	}
+
+	// =========================================================================
+	// Online presence
+	// =========================================================================
+
+	void GuildSystem::SetOnline(uint64_t playerId, uint64_t guildId)
+	{
+		m_onlinePlayers.insert(playerId);
+		if (guildId != 0u)
+			m_playerGuildMap[playerId] = guildId;
+		LOG_DEBUG(Server, "[GuildSystem] Player {} online (guild={})", playerId, guildId);
+	}
+
+	void GuildSystem::SetOffline(uint64_t playerId)
+	{
+		m_onlinePlayers.erase(playerId);
+		LOG_DEBUG(Server, "[GuildSystem] Player {} offline", playerId);
+	}
+
+	// =========================================================================
+	// Guild lifecycle — CreateGuild
+	// =========================================================================
+
+	uint64_t GuildSystem::CreateGuild(uint64_t         founderId,
+	                                  std::string_view founderName,
+	                                  std::string_view guildName,
+	                                  MYSQL*           mysql)
+	{
+		if (!m_initialized)
+		{
+			LOG_ERROR(Server, "[GuildSystem] CreateGuild called before Init");
+			return 0u;
+		}
+
+		if (!ValidateGuildName(guildName))
+		{
+			LOG_WARN(Server, "[GuildSystem] CreateGuild rejected: invalid name '{}'", guildName);
+			return 0u;
+		}
+
+		if (m_playerGuildMap.count(founderId))
+		{
+			LOG_WARN(Server, "[GuildSystem] CreateGuild rejected: player {} already in a guild", founderId);
+			return 0u;
+		}
+
+		// In-memory uniqueness check (DB also enforces via UNIQUE KEY).
+		for (const auto& [id, g] : m_guilds)
+		{
+			if (g.name == guildName)
+			{
+				LOG_WARN(Server, "[GuildSystem] CreateGuild rejected: name '{}' already taken", guildName);
+				return 0u;
+			}
+		}
+
+		uint64_t newId = 0u;
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+		{
+			newId = DbInsertGuild(guildName, founderId, mysql);
+			if (newId == 0u)
+			{
+				LOG_ERROR(Server, "[GuildSystem] CreateGuild DB insert failed for '{}'", guildName);
+				return 0u;
+			}
+			DbInsertDefaultRanks(newId, mysql);
+			DbInsertMember(newId, founderId,
+			               static_cast<uint8_t>(DefaultGuildRank::GuildMaster), mysql);
+		}
+		else
+		{
+			newId = m_nextGuildId++;
+		}
+#else
+		(void)mysql;
+		newId = m_nextGuildId++;
+#endif
+
+		GuildRecord guild;
+		guild.guildId        = newId;
+		guild.name           = std::string(guildName);
+		guild.motd           = "";
+		guild.masterPlayerId = founderId;
+		guild.ranks          = MakeDefaultRanks();
+		guild.members.push_back({
+			founderId,
+			std::string(founderName),
+			static_cast<uint8_t>(DefaultGuildRank::GuildMaster)
+		});
+
+		m_playerGuildMap[founderId] = newId;
+		m_guilds.emplace(newId, std::move(guild));
+
+		LOG_INFO(Server, "[GuildSystem] Guild '{}' created (id={}, founder={}/{})",
+		         guildName, newId, founderId, founderName);
+		return newId;
+	}
+
+	// =========================================================================
+	// Guild lifecycle — DisbandGuild
+	// =========================================================================
+
+	bool GuildSystem::DisbandGuild(uint64_t guildId, uint64_t requesterId, MYSQL* mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] DisbandGuild: guild {} not found", guildId);
+			return false;
+		}
+
+		const GuildMemberRecord* requester = FindMember(*guild, requesterId);
+		if (!requester ||
+		    requester->rankId != static_cast<uint8_t>(DefaultGuildRank::GuildMaster))
+		{
+			LOG_WARN(Server, "[GuildSystem] DisbandGuild: player {} lacks GM rank in guild {}",
+			         requesterId, guildId);
+			return false;
+		}
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+			DbDeleteGuild(guildId, mysql);
+#else
+		(void)mysql;
+#endif
+
+		for (const auto& member : guild->members)
+			m_playerGuildMap.erase(member.playerId);
+
+		m_guilds.erase(guildId);
+		LOG_INFO(Server, "[GuildSystem] Guild {} disbanded by player {}", guildId, requesterId);
+		return true;
+	}
+
+	// =========================================================================
+	// Member management — AddMember
+	// =========================================================================
+
+	bool GuildSystem::AddMember(uint64_t         guildId,
+	                            uint64_t         inviterId,
+	                            uint64_t         targetId,
+	                            std::string_view targetName,
+	                            MYSQL*           mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] AddMember: guild {} not found", guildId);
+			return false;
+		}
+
+		if (!HasPermission(guildId, inviterId, GuildPermission::Invite))
+		{
+			LOG_WARN(Server, "[GuildSystem] AddMember: player {} lacks Invite permission in guild {}",
+			         inviterId, guildId);
+			return false;
+		}
+
+		if (guild->members.size() >= kMaxMembersPerGuild)
+		{
+			LOG_WARN(Server, "[GuildSystem] AddMember: guild {} at max capacity ({})",
+			         guildId, kMaxMembersPerGuild);
+			return false;
+		}
+
+		if (m_playerGuildMap.count(targetId))
+		{
+			LOG_WARN(Server, "[GuildSystem] AddMember: player {} already in a guild", targetId);
+			return false;
+		}
+
+		const uint8_t recruitRank = static_cast<uint8_t>(DefaultGuildRank::Recruit);
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+		{
+			if (!DbInsertMember(guildId, targetId, recruitRank, mysql))
+				return false;
+		}
+#else
+		(void)mysql;
+#endif
+
+		guild->members.push_back({ targetId, std::string(targetName), recruitRank });
+		m_playerGuildMap[targetId] = guildId;
+
+		LOG_INFO(Server, "[GuildSystem] Player {}/{} joined guild {} (invited by {})",
+		         targetId, targetName, guildId, inviterId);
+		return true;
+	}
+
+	// =========================================================================
+	// Member management — KickMember
+	// =========================================================================
+
+	bool GuildSystem::KickMember(uint64_t guildId,
+	                             uint64_t kickerId,
+	                             uint64_t targetId,
+	                             MYSQL*   mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] KickMember: guild {} not found", guildId);
+			return false;
+		}
+
+		if (!HasPermission(guildId, kickerId, GuildPermission::Kick))
+		{
+			LOG_WARN(Server, "[GuildSystem] KickMember: player {} lacks Kick permission in guild {}",
+			         kickerId, guildId);
+			return false;
+		}
+
+		const GuildMemberRecord* kicker = FindMember(*guild, kickerId);
+		const GuildMemberRecord* target = FindMember(*guild, targetId);
+
+		if (!kicker || !target)
+		{
+			LOG_WARN(Server, "[GuildSystem] KickMember: member not found in guild {}", guildId);
+			return false;
+		}
+
+		// Cannot kick the Guild Master.
+		if (target->rankId == static_cast<uint8_t>(DefaultGuildRank::GuildMaster))
+		{
+			LOG_WARN(Server, "[GuildSystem] KickMember: cannot kick Guild Master (player {})", targetId);
+			return false;
+		}
+
+		// Kicker must outrank target (lower rankId = higher authority).
+		if (kicker->rankId != static_cast<uint8_t>(DefaultGuildRank::GuildMaster) &&
+		    target->rankId <= kicker->rankId)
+		{
+			LOG_WARN(Server, "[GuildSystem] KickMember: player {} cannot kick {} (rank check)",
+			         kickerId, targetId);
+			return false;
+		}
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+			DbDeleteMember(guildId, targetId, mysql);
+#else
+		(void)mysql;
+#endif
+
+		auto& members = guild->members;
+		members.erase(
+			std::remove_if(members.begin(), members.end(),
+			               [targetId](const GuildMemberRecord& m) { return m.playerId == targetId; }),
+			members.end());
+
+		m_playerGuildMap.erase(targetId);
+
+		LOG_INFO(Server, "[GuildSystem] Player {} kicked from guild {} by {}",
+		         targetId, guildId, kickerId);
+		return true;
+	}
+
+	// =========================================================================
+	// Member management — PromoteMember
+	// =========================================================================
+
+	bool GuildSystem::PromoteMember(uint64_t guildId,
+	                                uint64_t promoterId,
+	                                uint64_t targetId,
+	                                MYSQL*   mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] PromoteMember: guild {} not found", guildId);
+			return false;
+		}
+
+		if (!HasPermission(guildId, promoterId, GuildPermission::Promote))
+		{
+			LOG_WARN(Server,
+			         "[GuildSystem] PromoteMember: player {} lacks Promote permission in guild {}",
+			         promoterId, guildId);
+			return false;
+		}
+
+		GuildMemberRecord* target = FindMember(*guild, targetId);
+		if (!target)
+		{
+			LOG_WARN(Server, "[GuildSystem] PromoteMember: player {} not in guild {}", targetId, guildId);
+			return false;
+		}
+
+		// Already Guild Master; cannot promote further.
+		if (target->rankId == static_cast<uint8_t>(DefaultGuildRank::GuildMaster))
+		{
+			LOG_WARN(Server, "[GuildSystem] PromoteMember: player {} is already Guild Master", targetId);
+			return false;
+		}
+
+		// Cannot promote to Guild Master via this path (reserved for explicit GM transfer).
+		if (target->rankId == static_cast<uint8_t>(DefaultGuildRank::Officer) &&
+		    promoterId != guild->masterPlayerId)
+		{
+			LOG_WARN(Server,
+			         "[GuildSystem] PromoteMember: only the Guild Master can promote to GM rank (player {})",
+			         targetId);
+			return false;
+		}
+
+		const uint8_t newRank = static_cast<uint8_t>(target->rankId - 1u);
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+			DbUpdateMemberRank(guildId, targetId, newRank, mysql);
+#else
+		(void)mysql;
+#endif
+
+		const uint8_t oldRank = target->rankId;
+		target->rankId = newRank;
+
+		LOG_INFO(Server, "[GuildSystem] Player {} promoted from rank {} to {} in guild {} by {}",
+		         targetId, oldRank, newRank, guildId, promoterId);
+		return true;
+	}
+
+	// =========================================================================
+	// MOTD
+	// =========================================================================
+
+	bool GuildSystem::SetMotd(uint64_t         guildId,
+	                          uint64_t         playerId,
+	                          std::string_view motd,
+	                          MYSQL*           mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] SetMotd: guild {} not found", guildId);
+			return false;
+		}
+
+		if (!HasPermission(guildId, playerId, GuildPermission::EditMotd))
+		{
+			LOG_WARN(Server, "[GuildSystem] SetMotd: player {} lacks EditMotd permission in guild {}",
+			         playerId, guildId);
+			return false;
+		}
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+		{
+			if (!DbUpdateMotd(guildId, motd, mysql))
+				return false;
+		}
+#else
+		(void)mysql;
+#endif
+
+		guild->motd = std::string(motd);
+		LOG_INFO(Server, "[GuildSystem] Guild {} MOTD updated by player {}", guildId, playerId);
+		return true;
+	}
+
+	// =========================================================================
+	// DB helpers (UNIX + ENGINE_HAS_MYSQL only)
+	// =========================================================================
+
+#if ENGINE_HAS_MYSQL
+
+	uint64_t GuildSystem::DbInsertGuild(std::string_view name,
+	                                    uint64_t         masterPlayerId,
+	                                    MYSQL*           mysql)
+	{
+		std::string escaped(name.size() * 2u + 1u, '\0');
+		unsigned long written = mysql_real_escape_string(
+			mysql, escaped.data(), name.data(),
+			static_cast<unsigned long>(name.size()));
+		escaped.resize(static_cast<size_t>(written));
+
+		std::string sql =
+			"INSERT INTO guilds (name, master_player_id, motd) VALUES ('"
+			+ escaped + "', "
+			+ std::to_string(masterPlayerId)
+			+ ", '')";
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbInsertGuild query failed: {}", mysql_error(mysql));
+			return 0u;
+		}
+		return static_cast<uint64_t>(mysql_insert_id(mysql));
+	}
+
+	void GuildSystem::DbDeleteGuild(uint64_t guildId, MYSQL* mysql)
+	{
+		std::string sql;
+
+		sql = "DELETE FROM guild_ranks WHERE guild_id = " + std::to_string(guildId);
+		if (mysql_query(mysql, sql.c_str()) != 0)
+			LOG_WARN(Server, "[GuildSystem] DbDeleteGuild ranks failed: {}", mysql_error(mysql));
+
+		sql = "DELETE FROM guild_members WHERE guild_id = " + std::to_string(guildId);
+		if (mysql_query(mysql, sql.c_str()) != 0)
+			LOG_WARN(Server, "[GuildSystem] DbDeleteGuild members failed: {}", mysql_error(mysql));
+
+		sql = "DELETE FROM guilds WHERE id = " + std::to_string(guildId);
+		if (mysql_query(mysql, sql.c_str()) != 0)
+			LOG_ERROR(Server, "[GuildSystem] DbDeleteGuild guilds row failed: {}", mysql_error(mysql));
+	}
+
+	bool GuildSystem::DbInsertMember(uint64_t guildId, uint64_t playerId,
+	                                 uint8_t rankId, MYSQL* mysql)
+	{
+		std::string sql =
+			"INSERT INTO guild_members (guild_id, player_id, rank_id) VALUES ("
+			+ std::to_string(guildId) + ", "
+			+ std::to_string(playerId) + ", "
+			+ std::to_string(static_cast<unsigned>(rankId)) + ")";
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbInsertMember failed: {}", mysql_error(mysql));
+			return false;
+		}
+		return true;
+	}
+
+	bool GuildSystem::DbDeleteMember(uint64_t guildId, uint64_t playerId, MYSQL* mysql)
+	{
+		std::string sql =
+			"DELETE FROM guild_members WHERE guild_id = "
+			+ std::to_string(guildId)
+			+ " AND player_id = "
+			+ std::to_string(playerId);
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbDeleteMember failed: {}", mysql_error(mysql));
+			return false;
+		}
+		return true;
+	}
+
+	bool GuildSystem::DbUpdateMemberRank(uint64_t guildId, uint64_t playerId,
+	                                     uint8_t rankId, MYSQL* mysql)
+	{
+		std::string sql =
+			"UPDATE guild_members SET rank_id = "
+			+ std::to_string(static_cast<unsigned>(rankId))
+			+ " WHERE guild_id = " + std::to_string(guildId)
+			+ " AND player_id = " + std::to_string(playerId);
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbUpdateMemberRank failed: {}", mysql_error(mysql));
+			return false;
+		}
+		return true;
+	}
+
+	bool GuildSystem::DbUpdateMotd(uint64_t guildId, std::string_view motd, MYSQL* mysql)
+	{
+		std::string escaped(motd.size() * 2u + 1u, '\0');
+		unsigned long written = mysql_real_escape_string(
+			mysql, escaped.data(), motd.data(),
+			static_cast<unsigned long>(motd.size()));
+		escaped.resize(static_cast<size_t>(written));
+
+		std::string sql =
+			"UPDATE guilds SET motd = '"
+			+ escaped
+			+ "' WHERE id = " + std::to_string(guildId);
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbUpdateMotd failed: {}", mysql_error(mysql));
+			return false;
+		}
+		return true;
+	}
+
+	void GuildSystem::DbInsertDefaultRanks(uint64_t guildId, MYSQL* mysql)
+	{
+		using P = GuildPermission;
+
+		constexpr uint32_t kAllPerms =
+			static_cast<uint32_t>(P::Invite)       |
+			static_cast<uint32_t>(P::Kick)         |
+			static_cast<uint32_t>(P::Promote)      |
+			static_cast<uint32_t>(P::WithdrawBank) |
+			static_cast<uint32_t>(P::EditMotd);
+
+		constexpr uint32_t kOfficerPerms =
+			static_cast<uint32_t>(P::Invite)  |
+			static_cast<uint32_t>(P::Kick)    |
+			static_cast<uint32_t>(P::Promote) |
+			static_cast<uint32_t>(P::EditMotd);
+
+		struct RankDef { uint8_t id; const char* name; uint32_t perms; };
+		constexpr RankDef kRanks[] = {
+			{ 0u, "Guild Master", kAllPerms     },
+			{ 1u, "Officer",      kOfficerPerms },
+			{ 2u, "Member",       0u            },
+			{ 3u, "Recruit",      0u            },
+		};
+
+		for (const auto& r : kRanks)
+		{
+			const size_t nameLen = std::strlen(r.name);
+			std::string escaped(nameLen * 2u + 1u, '\0');
+			unsigned long written = mysql_real_escape_string(
+				mysql, escaped.data(), r.name,
+				static_cast<unsigned long>(nameLen));
+			escaped.resize(static_cast<size_t>(written));
+
+			std::string sql =
+				"INSERT INTO guild_ranks (guild_id, rank_id, rank_name, permissions_bitfield) VALUES ("
+				+ std::to_string(guildId) + ", "
+				+ std::to_string(static_cast<unsigned>(r.id)) + ", '"
+				+ escaped + "', "
+				+ std::to_string(r.perms) + ")";
+
+			if (mysql_query(mysql, sql.c_str()) != 0)
+			{
+				LOG_WARN(Server, "[GuildSystem] DbInsertDefaultRanks rank {} failed: {}",
+				         r.id, mysql_error(mysql));
+			}
+		}
+	}
+
+#endif // ENGINE_HAS_MYSQL
+
+} // namespace engine::server

--- a/engine/server/GuildSystem.h
+++ b/engine/server/GuildSystem.h
@@ -1,0 +1,249 @@
+#pragma once
+// M32.3 — Server-side guild system: creation, roster, ranks, permissions, guild chat routing.
+// Depends on M13.1 (server core) and M14.4 (character persistence).
+// On platforms without MySQL (WIN32 game shard) the system operates in no-DB mode:
+// all data is in-memory only; DB operations are skipped.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+struct MYSQL;
+
+namespace engine::server
+{
+	/// Permission bits for guild ranks (M32.3).
+	/// These values are stored in guild_ranks.permissions_bitfield.
+	enum class GuildPermission : uint32_t
+	{
+		None         = 0,
+		Invite       = 1 << 0, ///< Can invite new members to the guild.
+		Kick         = 1 << 1, ///< Can kick members below their own rank.
+		Promote      = 1 << 2, ///< Can promote members below their own rank.
+		WithdrawBank = 1 << 3, ///< Can withdraw gold from the guild bank.
+		EditMotd     = 1 << 4, ///< Can edit the guild message of the day.
+	};
+
+	/// Built-in rank ids for the four default ranks (rank_id column, lower = higher authority).
+	enum class DefaultGuildRank : uint8_t
+	{
+		GuildMaster = 0, ///< Full permissions; may disband.
+		Officer     = 1, ///< Invite, kick, promote, edit MOTD.
+		Member      = 2, ///< No management permissions.
+		Recruit     = 3, ///< Trial rank; no management permissions.
+	};
+
+	/// One rank definition stored in guild_ranks (M32.3).
+	struct GuildRankRecord
+	{
+		uint8_t     rankId              = 0;
+		std::string rankName;
+		uint32_t    permissionsBitfield = 0; ///< OR of GuildPermission values.
+	};
+
+	/// One member entry loaded from guild_members (M32.3).
+	struct GuildMemberRecord
+	{
+		uint64_t    playerId   = 0;
+		std::string playerName;
+		uint8_t     rankId     = static_cast<uint8_t>(DefaultGuildRank::Recruit);
+	};
+
+	/// In-memory representation of one live guild (M32.3).
+	struct GuildRecord
+	{
+		uint64_t                       guildId        = 0;
+		std::string                    name;
+		std::string                    motd;
+		uint64_t                       masterPlayerId = 0;
+		std::vector<GuildMemberRecord> members;
+		std::vector<GuildRankRecord>   ranks;
+	};
+
+	/// Server-side guild manager (M32.3).
+	///
+	/// Handles /guild create <name>, /ginvite <name>, /gkick, /gpromote,
+	/// MOTD updates, guild chat routing to online members, and DB persistence.
+	///
+	/// All operations are single-threaded (server authoritative tick).
+	class GuildSystem final
+	{
+	public:
+		GuildSystem() = default;
+
+		/// Non-copyable, non-movable.
+		GuildSystem(const GuildSystem&)            = delete;
+		GuildSystem& operator=(const GuildSystem&) = delete;
+
+		/// Initialize the guild system.
+		/// \p mysql may be nullptr for no-DB mode (e.g. WIN32 game shard).
+		/// Emits LOG_INFO on success; LOG_WARN when no DB is available.
+		bool Init(MYSQL* mysql);
+
+		/// Shut down the guild system and release all in-memory state.
+		/// Emits LOG_INFO on completion.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ------------------------------------------------------------------
+		// Guild lifecycle
+		// ------------------------------------------------------------------
+
+		/// Create a new guild.
+		/// Validates the guild name (length 3-20, alphanumeric/space/dash/underscore),
+		/// checks uniqueness, inserts DB rows when available.
+		/// The caller is responsible for deducting the creation cost (1000 gold) before
+		/// calling this function.
+		/// Returns the new guild id (>0) on success; 0 on failure.
+		uint64_t CreateGuild(uint64_t         founderId,
+		                     std::string_view founderName,
+		                     std::string_view guildName,
+		                     MYSQL*           mysql);
+
+		/// Disband a guild (Guild Master only).
+		/// Removes all DB rows and in-memory state for the guild.
+		/// Returns true on success; false when requester is not the GM.
+		bool DisbandGuild(uint64_t guildId,
+		                  uint64_t requesterId,
+		                  MYSQL*   mysql);
+
+		// ------------------------------------------------------------------
+		// Member management
+		// ------------------------------------------------------------------
+
+		/// Add \p targetId to \p guildId after invite acceptance.
+		/// Validates Invite permission for \p inviterId and guild capacity.
+		/// New members receive the Recruit rank.
+		/// Returns true on success.
+		bool AddMember(uint64_t         guildId,
+		               uint64_t         inviterId,
+		               uint64_t         targetId,
+		               std::string_view targetName,
+		               MYSQL*           mysql);
+
+		/// Kick \p targetId from \p guildId.
+		/// Validates Kick permission for \p kickerId; kicker must outrank target.
+		/// Guild Master cannot be kicked.
+		/// Returns true on success.
+		bool KickMember(uint64_t guildId,
+		                uint64_t kickerId,
+		                uint64_t targetId,
+		                MYSQL*   mysql);
+
+		/// Promote \p targetId to the next higher rank within \p guildId.
+		/// Validates Promote permission for \p promoterId; promoter must outrank target.
+		/// Cannot promote beyond Officer via this path (only GM can assign GM rank).
+		/// Returns true on success.
+		bool PromoteMember(uint64_t guildId,
+		                   uint64_t promoterId,
+		                   uint64_t targetId,
+		                   MYSQL*   mysql);
+
+		// ------------------------------------------------------------------
+		// MOTD
+		// ------------------------------------------------------------------
+
+		/// Set the guild message of the day.
+		/// Validates EditMotd permission for \p playerId.
+		/// Returns true on success.
+		bool SetMotd(uint64_t         guildId,
+		             uint64_t         playerId,
+		             std::string_view motd,
+		             MYSQL*           mysql);
+
+		// ------------------------------------------------------------------
+		// Online presence (for guild chat routing)
+		// ------------------------------------------------------------------
+
+		/// Mark \p playerId as online and associate them with \p guildId (call on login).
+		void SetOnline(uint64_t playerId, uint64_t guildId);
+
+		/// Mark \p playerId as offline (call on disconnect/logout).
+		void SetOffline(uint64_t playerId);
+
+		// ------------------------------------------------------------------
+		// Queries
+		// ------------------------------------------------------------------
+
+		/// Return the guild id for \p playerId; 0 when not in any guild.
+		uint64_t GetGuildIdForPlayer(uint64_t playerId) const;
+
+		/// Return the account ids of all currently-online members of \p guildId.
+		/// Used to route guild chat messages and notifications.
+		std::vector<uint64_t> GetOnlineMemberIds(uint64_t guildId) const;
+
+		/// Return a const pointer to the guild record for \p guildId; nullptr when not found.
+		const GuildRecord* GetGuild(uint64_t guildId) const;
+
+		/// Return true when \p playerId in \p guildId has the given \p perm bit set.
+		bool HasPermission(uint64_t guildId, uint64_t playerId, GuildPermission perm) const;
+
+	private:
+		/// Maximum members allowed per guild (M32.3 spec: 500, configurable).
+		static constexpr size_t kMaxMembersPerGuild = 500;
+		/// Minimum guild name length (inclusive).
+		static constexpr size_t kGuildNameMinLen    = 3;
+		/// Maximum guild name length (inclusive).
+		static constexpr size_t kGuildNameMaxLen    = 20;
+
+		bool     m_initialized = false;
+		uint64_t m_nextGuildId = 1; ///< Monotonic id counter for no-DB mode.
+
+		/// In-memory guild registry: guildId → GuildRecord.
+		std::unordered_map<uint64_t, GuildRecord> m_guilds;
+		/// Reverse lookup: playerId → guildId (absent = not in a guild).
+		std::unordered_map<uint64_t, uint64_t>    m_playerGuildMap;
+		/// Set of currently-online player ids (for guild chat / notification routing).
+		std::unordered_set<uint64_t>              m_onlinePlayers;
+
+		/// Validate guild name: length and allowed characters.
+		bool ValidateGuildName(std::string_view name) const;
+
+		/// Non-const guild lookup by id; returns nullptr when not found.
+		GuildRecord*       FindGuild(uint64_t guildId);
+		/// Const guild lookup by id; returns nullptr when not found.
+		const GuildRecord* FindGuild(uint64_t guildId) const;
+
+		/// Find a member entry inside \p guild; returns nullptr when absent.
+		GuildMemberRecord*       FindMember(GuildRecord& guild, uint64_t playerId);
+		const GuildMemberRecord* FindMember(const GuildRecord& guild, uint64_t playerId) const;
+
+		/// Find a rank record inside \p guild by \p rankId; returns nullptr when absent.
+		const GuildRankRecord* FindRank(const GuildRecord& guild, uint8_t rankId) const;
+
+		/// Build the four default rank definitions for a freshly-created guild.
+		static std::vector<GuildRankRecord> MakeDefaultRanks();
+
+#if ENGINE_HAS_MYSQL
+		/// INSERT INTO guilds; returns the auto-increment id (>0) or 0 on error.
+		uint64_t DbInsertGuild(std::string_view name,
+		                       uint64_t         masterPlayerId,
+		                       MYSQL*           mysql);
+
+		/// DELETE guilds, guild_members, guild_ranks rows for \p guildId.
+		void DbDeleteGuild(uint64_t guildId, MYSQL* mysql);
+
+		/// INSERT INTO guild_members.
+		bool DbInsertMember(uint64_t guildId, uint64_t playerId,
+		                    uint8_t rankId, MYSQL* mysql);
+
+		/// DELETE FROM guild_members WHERE guild_id=… AND player_id=…
+		bool DbDeleteMember(uint64_t guildId, uint64_t playerId, MYSQL* mysql);
+
+		/// UPDATE guild_members SET rank_id=… WHERE guild_id=… AND player_id=…
+		bool DbUpdateMemberRank(uint64_t guildId, uint64_t playerId,
+		                        uint8_t rankId, MYSQL* mysql);
+
+		/// UPDATE guilds SET motd=… WHERE id=…
+		bool DbUpdateMotd(uint64_t guildId, std::string_view motd, MYSQL* mysql);
+
+		/// INSERT the four default rank rows into guild_ranks for \p guildId.
+		void DbInsertDefaultRanks(uint64_t guildId, MYSQL* mysql);
+#endif // ENGINE_HAS_MYSQL
+	};
+
+} // namespace engine::server

--- a/engine/server/ServerProtocol.h
+++ b/engine/server/ServerProtocol.h
@@ -68,7 +68,30 @@ namespace engine::server
 		/// Leader changes the party loot mode via /loot (M32.2).
 		PartyLootMode = 31,
 		/// Client voluntarily leaves their party via /leave (M32.2).
-		PartyLeave = 32
+		PartyLeave = 32,
+
+		// M32.3 — Guild system messages ----------------------------------------
+
+		/// Client sends /guild create <name> to the server (M32.3).
+		GuildCreate = 33,
+		/// Server result of a guild creation attempt (M32.3).
+		GuildCreateResult = 34,
+		/// Client sends /ginvite <name> to the server (M32.3).
+		GuildInvite = 35,
+		/// Server pushes an incoming guild invite notification to the target (M32.3).
+		GuildInviteNotify = 36,
+		/// Target accepts a pending guild invite (M32.3).
+		GuildInviteAccept = 37,
+		/// Target declines a pending guild invite (M32.3).
+		GuildInviteDecline = 38,
+		/// Leader kicks a member from the guild via /gkick (M32.3).
+		GuildKick = 39,
+		/// Leader/Officer promotes a member via /gpromote (M32.3).
+		GuildPromote = 40,
+		/// Server broadcasts full guild roster to all members after any change (M32.3).
+		GuildRosterSync = 41,
+		/// Client or Officer updates the guild MOTD (M32.3).
+		GuildMotdUpdate = 42
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -544,4 +567,90 @@ namespace engine::server
 
 	/// Decode a client party leave packet.
 	bool DecodePartyLeave(std::span<const std::byte> packet, PartyLeaveMessage& outMessage);
+
+	// -------------------------------------------------------------------------
+	// M32.3 — Guild system messages
+	// -------------------------------------------------------------------------
+
+	/// Client request to create a new guild via /guild create <name> (M32.3).
+	struct GuildCreateMessage
+	{
+		uint32_t    clientId  = 0;
+		std::string guildName; ///< Desired guild name, 3-20 chars.
+	};
+
+	/// Server result of a guild creation attempt (M32.3).
+	struct GuildCreateResultMessage
+	{
+		uint8_t     success  = 0; ///< 1 = created, 0 = failed.
+		uint64_t    guildId  = 0; ///< New guild id on success; 0 on failure.
+		std::string guildName;
+		std::string errorReason; ///< Human-readable reason on failure.
+	};
+
+	/// Client /ginvite <name> request (M32.3).
+	struct GuildInviteMessage
+	{
+		uint32_t    clientId   = 0;
+		std::string targetName; ///< Display name of the player to invite.
+	};
+
+	/// Server notification pushed to the invite target (M32.3).
+	struct GuildInviteNotifyMessage
+	{
+		std::string inviterName;
+		std::string guildName;
+	};
+
+	/// Target accepts a pending guild invite (M32.3).
+	struct GuildInviteAcceptMessage
+	{
+		uint32_t clientId = 0;
+	};
+
+	/// Target declines a pending guild invite (M32.3).
+	struct GuildInviteDeclineMessage
+	{
+		uint32_t clientId = 0;
+	};
+
+	/// Leader request to kick a member from the guild via /gkick (M32.3).
+	struct GuildKickMessage
+	{
+		uint32_t    clientId   = 0; ///< Kicker's clientId.
+		std::string targetName; ///< Display name of the member to kick.
+	};
+
+	/// Officer/Leader request to promote a member via /gpromote (M32.3).
+	struct GuildPromoteMessage
+	{
+		uint32_t    clientId   = 0; ///< Promoter's clientId.
+		std::string targetName; ///< Display name of the member to promote.
+	};
+
+	/// One entry in the guild roster sync packet (M32.3).
+	struct GuildRosterEntry
+	{
+		uint64_t    playerId = 0;
+		uint8_t     rankId   = 3; ///< 0=GM, 1=Officer, 2=Member, 3=Recruit.
+		uint8_t     online   = 0; ///< 1 when the member is currently online.
+		std::string playerName;
+		std::string rankName;
+	};
+
+	/// Full guild roster broadcast to all members after any change (M32.3).
+	struct GuildRosterSyncMessage
+	{
+		uint64_t                   guildId  = 0;
+		std::string                guildName;
+		std::string                motd;
+		std::vector<GuildRosterEntry> members;
+	};
+
+	/// Client/Officer MOTD update request (M32.3).
+	struct GuildMotdUpdateMessage
+	{
+		uint32_t    clientId = 0;
+		std::string motd;
+	};
 }


### PR DESCRIPTION
…ld chat

- db/migrations/0003_guilds.sql: three new tables (guilds, guild_members, guild_ranks)
- engine/server/GuildSystem.h/.cpp: CreateGuild, DisbandGuild, AddMember, KickMember, PromoteMember, SetMotd, online-presence tracking, GetOnlineMemberIds for guild chat routing
- engine/server/ServerProtocol.h: GuildCreate…GuildMotdUpdate MessageKind values (33-42) and matching message structs (GuildCreateMessage, GuildRosterSyncMessage, …)
- engine/server/CMakeLists.txt: GuildSystem.cpp added to WIN32 and UNIX server_app targets
- Compiles in no-DB mode (WIN32) and with ENGINE_HAS_MYSQL (UNIX)
- All init/shutdown/error paths emit LOG_INFO / LOG_WARN / LOG_ERROR per coding rules

https://claude.ai/code/session_01Ny4R3nXPREnKF8QbsDiVCB