### PR TITLE
feat(M32.4): guild tabard, emblem, and bank

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -12,6 +12,8 @@ if(WIN32)
     FriendSystem.cpp
     PartySystem.cpp
     GuildSystem.cpp
+    GuildTabard.cpp
+    GuildBank.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatEmotes.cpp
     CharacterPersistence.cpp
@@ -64,6 +66,8 @@ elseif(UNIX)
     FriendSystem.cpp
     PartySystem.cpp
     GuildSystem.cpp
+    GuildTabard.cpp
+    GuildBank.cpp
     AccountValidation.cpp
     InMemoryAccountStore.cpp
     AuthRegisterHandler.cpp

--- a/engine/server/GuildBank.cpp
+++ b/engine/server/GuildBank.cpp
@@ -1,0 +1,253 @@
+// M32.4 — Guild bank implementation.
+// Enforces per-rank per-tab permissions and appends an audit-log entry
+// for every successful withdrawal.
+
+#include "engine/server/GuildBank.h"
+#include "engine/core/Log.h"
+
+#include <ctime>
+
+namespace engine::server
+{
+    // =========================================================================
+    // Init / Shutdown
+    // =========================================================================
+
+    bool GuildBank::Init(uint64_t guildId, uint8_t tabCount)
+    {
+        if (guildId == 0u)
+        {
+            LOG_ERROR(Server, "[GuildBank] Init FAILED: guildId must be non-zero");
+            return false;
+        }
+
+        // Clamp tabCount to allowed range.
+        if (tabCount < kGuildBankMinTabs)
+            tabCount = kGuildBankMinTabs;
+        else if (tabCount > kGuildBankMaxTabs)
+            tabCount = kGuildBankMaxTabs;
+
+        m_guildId = guildId;
+        m_tabs.clear();
+        m_tabs.resize(tabCount);
+
+        // Default: give Guild Master (rankId=0) full permissions on every tab.
+        constexpr uint8_t kAllPerms =
+            static_cast<uint8_t>(GuildBankTabPermission::View)    |
+            static_cast<uint8_t>(GuildBankTabPermission::Deposit)  |
+            static_cast<uint8_t>(GuildBankTabPermission::Withdraw);
+
+        for (uint8_t i = 0u; i < tabCount; ++i)
+        {
+            m_tabs[i].name                 = std::string("Tab ") + std::to_string(i + 1u);
+            m_tabs[i].rankPermissions[0u]  = kAllPerms; // Guild Master has full access.
+        }
+
+        m_withdrawLog.clear();
+        m_initialized = true;
+        LOG_INFO(Server, "[GuildBank] Init OK (guild={}, tabs={})", guildId, tabCount);
+        return true;
+    }
+
+    void GuildBank::Shutdown()
+    {
+        m_tabs.clear();
+        m_withdrawLog.clear();
+        m_initialized = false;
+        LOG_INFO(Server, "[GuildBank] Shutdown (guild={})", m_guildId);
+    }
+
+    // =========================================================================
+    // Deposit
+    // =========================================================================
+
+    bool GuildBank::Deposit(uint64_t  playerId,
+                             uint8_t   rankId,
+                             uint8_t   tabIndex,
+                             uint8_t   slotIndex,
+                             ItemStack item)
+    {
+        if (!m_initialized)
+        {
+            LOG_ERROR(Server, "[GuildBank] Deposit: bank not initialized (guild={})", m_guildId);
+            return false;
+        }
+
+        if (tabIndex >= static_cast<uint8_t>(m_tabs.size()))
+        {
+            LOG_WARN(Server, "[GuildBank] Deposit: tabIndex {} out of range (guild={}, tabs={})",
+                     tabIndex, m_guildId, m_tabs.size());
+            return false;
+        }
+
+        if (!HasTabPermission(rankId, tabIndex, GuildBankTabPermission::Deposit))
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] Deposit: player {} rank {} lacks Deposit on tab {} (guild={})",
+                     playerId, rankId, tabIndex, m_guildId);
+            return false;
+        }
+
+        if (slotIndex >= kGuildBankSlotsPerTab)
+        {
+            LOG_WARN(Server, "[GuildBank] Deposit: slotIndex {} out of range (guild={}, tab={})",
+                     slotIndex, m_guildId, tabIndex);
+            return false;
+        }
+
+        if (item.itemId == 0u || item.quantity == 0u)
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] Deposit: invalid item (id={}, qty={}) by player {} (guild={})",
+                     item.itemId, item.quantity, playerId, m_guildId);
+            return false;
+        }
+
+        ItemStack& slot = m_tabs[tabIndex].slots[slotIndex];
+        if (slot.itemId != 0u)
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] Deposit: slot {}/{} already occupied by item {} (guild={})",
+                     tabIndex, slotIndex, slot.itemId, m_guildId);
+            return false;
+        }
+
+        slot = item;
+        LOG_INFO(Server,
+                 "[GuildBank] Deposit: player {} deposited item {} x{} into tab {}/slot {} (guild={})",
+                 playerId, item.itemId, item.quantity, tabIndex, slotIndex, m_guildId);
+        return true;
+    }
+
+    // =========================================================================
+    // Withdraw
+    // =========================================================================
+
+    bool GuildBank::Withdraw(uint64_t   playerId,
+                              uint8_t    rankId,
+                              uint8_t    tabIndex,
+                              uint8_t    slotIndex,
+                              uint32_t   quantity,
+                              ItemStack& outItem)
+    {
+        if (!m_initialized)
+        {
+            LOG_ERROR(Server, "[GuildBank] Withdraw: bank not initialized (guild={})", m_guildId);
+            return false;
+        }
+
+        if (tabIndex >= static_cast<uint8_t>(m_tabs.size()))
+        {
+            LOG_WARN(Server, "[GuildBank] Withdraw: tabIndex {} out of range (guild={}, tabs={})",
+                     tabIndex, m_guildId, m_tabs.size());
+            return false;
+        }
+
+        if (!HasTabPermission(rankId, tabIndex, GuildBankTabPermission::Withdraw))
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] Withdraw: player {} rank {} lacks Withdraw on tab {} (guild={})",
+                     playerId, rankId, tabIndex, m_guildId);
+            return false;
+        }
+
+        if (slotIndex >= kGuildBankSlotsPerTab)
+        {
+            LOG_WARN(Server, "[GuildBank] Withdraw: slotIndex {} out of range (guild={}, tab={})",
+                     slotIndex, m_guildId, tabIndex);
+            return false;
+        }
+
+        ItemStack& slot = m_tabs[tabIndex].slots[slotIndex];
+        if (slot.itemId == 0u || slot.quantity == 0u)
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] Withdraw: slot {}/{} is empty (guild={})",
+                     tabIndex, slotIndex, m_guildId);
+            return false;
+        }
+
+        // Quantity=0 means "take the full stack".
+        const uint32_t taken = (quantity == 0u || quantity > slot.quantity)
+                                   ? slot.quantity
+                                   : quantity;
+
+        outItem = { slot.itemId, taken };
+        slot.quantity -= taken;
+        if (slot.quantity == 0u)
+            slot.itemId = 0u;
+
+        // Append audit-log entry.
+        GuildBankWithdrawEntry entry;
+        entry.playerId         = playerId;
+        entry.timestampUnixSec = static_cast<uint64_t>(std::time(nullptr));
+        entry.tabIndex         = tabIndex;
+        entry.slotIndex        = slotIndex;
+        entry.itemId           = outItem.itemId;
+        entry.quantity         = taken;
+        m_withdrawLog.push_back(entry);
+
+        LOG_INFO(Server,
+                 "[GuildBank] Withdraw: player {} withdrew item {} x{} from tab {}/slot {} (guild={})",
+                 playerId, outItem.itemId, taken, tabIndex, slotIndex, m_guildId);
+        return true;
+    }
+
+    // =========================================================================
+    // Permissions
+    // =========================================================================
+
+    bool GuildBank::SetTabPermission(uint8_t tabIndex, uint8_t rankId, GuildBankTabPermission perms)
+    {
+        if (!m_initialized)
+        {
+            LOG_ERROR(Server, "[GuildBank] SetTabPermission: bank not initialized (guild={})", m_guildId);
+            return false;
+        }
+
+        if (tabIndex >= static_cast<uint8_t>(m_tabs.size()))
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] SetTabPermission: tabIndex {} out of range (guild={}, tabs={})",
+                     tabIndex, m_guildId, m_tabs.size());
+            return false;
+        }
+
+        if (rankId >= kGuildBankMaxRanks)
+        {
+            LOG_WARN(Server,
+                     "[GuildBank] SetTabPermission: rankId {} out of range (guild={})",
+                     rankId, m_guildId);
+            return false;
+        }
+
+        m_tabs[tabIndex].rankPermissions[rankId] = static_cast<uint8_t>(perms);
+        LOG_DEBUG(Server,
+                  "[GuildBank] SetTabPermission: tab {} rank {} perms={} (guild={})",
+                  tabIndex, rankId, static_cast<uint32_t>(perms), m_guildId);
+        return true;
+    }
+
+    bool GuildBank::HasTabPermission(uint8_t rankId,
+                                      uint8_t tabIndex,
+                                      GuildBankTabPermission perm) const
+    {
+        if (tabIndex >= static_cast<uint8_t>(m_tabs.size()))
+            return false;
+        if (rankId >= kGuildBankMaxRanks)
+            return false;
+        return (m_tabs[tabIndex].rankPermissions[rankId] & static_cast<uint8_t>(perm)) != 0u;
+    }
+
+    // =========================================================================
+    // Queries
+    // =========================================================================
+
+    const GuildBankTab* GuildBank::GetTab(uint8_t tabIndex) const
+    {
+        if (tabIndex >= static_cast<uint8_t>(m_tabs.size()))
+            return nullptr;
+        return &m_tabs[tabIndex];
+    }
+
+} // namespace engine::server

--- a/engine/server/GuildBank.h
+++ b/engine/server/GuildBank.h
@@ -1,0 +1,146 @@
+#pragma once
+// M32.4 — Guild bank: shared item storage across 6–8 tabs (98 slots each).
+// Each tab has per-rank access permissions (view, deposit, withdraw).
+// All withdrawals are appended to an in-memory audit log.
+
+#include "engine/server/ReplicationTypes.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server
+{
+    /// Access flags for one (rank, tab) pair in the guild bank (M32.4).
+    enum class GuildBankTabPermission : uint8_t
+    {
+        None     = 0,
+        View     = 1u << 0, ///< Can see items in this tab.
+        Deposit  = 1u << 1, ///< Can deposit items into this tab.
+        Withdraw = 1u << 2, ///< Can withdraw items from this tab.
+    };
+
+    /// Number of item slots per guild bank tab (M32.4 spec).
+    inline constexpr size_t kGuildBankSlotsPerTab = 98u;
+
+    /// Minimum number of tabs a guild bank must have (M32.4 spec: 6–8).
+    inline constexpr uint8_t kGuildBankMinTabs = 6u;
+
+    /// Maximum number of tabs a guild bank may have (M32.4 spec: 6–8).
+    inline constexpr uint8_t kGuildBankMaxTabs = 8u;
+
+    /// Maximum number of distinct rank indices whose permissions can be stored per tab.
+    inline constexpr uint8_t kGuildBankMaxRanks = 8u;
+
+    /// One tab of the guild bank (M32.4).
+    struct GuildBankTab
+    {
+        /// Human-readable tab label (e.g. "Tab 1", "Herbs & Ores").
+        std::string name;
+
+        /// Item stacks occupying each slot; ItemStack{0,0} means empty.
+        std::array<ItemStack, kGuildBankSlotsPerTab> slots{};
+
+        /// Bitmask permissions indexed by rankId (0..kGuildBankMaxRanks-1).
+        /// Each byte stores OR-combined GuildBankTabPermission bits for that rank.
+        std::array<uint8_t, kGuildBankMaxRanks> rankPermissions{};
+    };
+
+    /// One audit-log entry written when a player withdraws from the guild bank (M32.4).
+    struct GuildBankWithdrawEntry
+    {
+        uint64_t playerId         = 0u; ///< Player who performed the withdrawal.
+        uint64_t timestampUnixSec = 0u; ///< Wall-clock seconds since Unix epoch.
+        uint8_t  tabIndex         = 0u; ///< Tab from which the item was taken.
+        uint8_t  slotIndex        = 0u; ///< Slot from which the item was taken.
+        uint32_t itemId           = 0u; ///< Item type withdrawn.
+        uint32_t quantity         = 0u; ///< Amount withdrawn.
+    };
+
+    /// Server-side guild bank manager (M32.4).
+    ///
+    /// Manages 6–8 tabs of 98 slots each, enforces per-rank per-tab permissions,
+    /// and appends an audit-log entry for every successful withdrawal.
+    ///
+    /// One GuildBank instance per live guild; lifetime is managed by the caller
+    /// (e.g. GuildSystem or a higher-level guild manager).
+    class GuildBank final
+    {
+    public:
+        GuildBank() = default;
+
+        /// Non-copyable, non-movable.
+        GuildBank(const GuildBank&)            = delete;
+        GuildBank& operator=(const GuildBank&) = delete;
+
+        /// Initialize the bank for \p guildId with \p tabCount tabs (clamped to [6,8]).
+        /// Guild Master (rankId=0) is granted all permissions on every tab by default.
+        /// Emits LOG_INFO on success, LOG_ERROR on invalid guildId.
+        bool Init(uint64_t guildId, uint8_t tabCount = kGuildBankMinTabs);
+
+        /// Release all bank state.
+        /// Emits LOG_INFO on completion.
+        void Shutdown();
+
+        bool IsInitialized() const { return m_initialized; }
+
+        // ------------------------------------------------------------------
+        // Deposits / Withdrawals
+        // ------------------------------------------------------------------
+
+        /// Deposit \p item into \p tabIndex / \p slotIndex for \p playerId (rank \p rankId).
+        /// Validates Deposit permission and that the slot is currently empty.
+        /// Returns true on success.
+        bool Deposit(uint64_t  playerId,
+                     uint8_t   rankId,
+                     uint8_t   tabIndex,
+                     uint8_t   slotIndex,
+                     ItemStack item);
+
+        /// Withdraw up to \p quantity from \p tabIndex / \p slotIndex for \p playerId (rank \p rankId).
+        /// Validates Withdraw permission, fills \p outItem with the taken stack,
+        /// and appends an audit-log entry.
+        /// Pass quantity=0 to take the full stack.
+        /// Returns true on success.
+        bool Withdraw(uint64_t   playerId,
+                      uint8_t    rankId,
+                      uint8_t    tabIndex,
+                      uint8_t    slotIndex,
+                      uint32_t   quantity,
+                      ItemStack& outItem);
+
+        // ------------------------------------------------------------------
+        // Permissions
+        // ------------------------------------------------------------------
+
+        /// Override the permission bitmask for \p rankId on \p tabIndex.
+        /// Callers are responsible for verifying that the requesting player has
+        /// authority (e.g. Guild Master) before calling this function.
+        /// Returns true on success.
+        bool SetTabPermission(uint8_t tabIndex, uint8_t rankId, GuildBankTabPermission perms);
+
+        /// Return true when \p rankId holds \p perm on \p tabIndex.
+        bool HasTabPermission(uint8_t rankId, uint8_t tabIndex, GuildBankTabPermission perm) const;
+
+        // ------------------------------------------------------------------
+        // Queries
+        // ------------------------------------------------------------------
+
+        /// Return a const pointer to the tab at \p tabIndex; nullptr when out of range.
+        const GuildBankTab* GetTab(uint8_t tabIndex) const;
+
+        /// Return the complete audit log of all withdrawal operations.
+        const std::vector<GuildBankWithdrawEntry>& GetWithdrawLog() const { return m_withdrawLog; }
+
+        /// Return the number of active tabs in this bank.
+        uint8_t GetTabCount() const { return static_cast<uint8_t>(m_tabs.size()); }
+
+    private:
+        uint64_t                            m_guildId     = 0u;
+        std::vector<GuildBankTab>           m_tabs;
+        std::vector<GuildBankWithdrawEntry> m_withdrawLog;
+        bool                                m_initialized = false;
+    };
+
+} // namespace engine::server

--- a/engine/server/GuildSystem.cpp
+++ b/engine/server/GuildSystem.cpp
@@ -1,4 +1,5 @@
 // M32.3 — Server-side guild system implementation.
+// M32.4 — Extended with SetEmblem and DbUpdateEmblem.
 // Handles creation, roster management, ranks, permissions and guild chat routing.
 // On platforms without MySQL (WIN32 game shard) the system operates in no-DB mode:
 // presence tracking and in-memory state are fully functional; DB operations are skipped.
@@ -542,6 +543,50 @@ namespace engine::server
 	}
 
 	// =========================================================================
+	// Emblem (M32.4)
+	// =========================================================================
+
+	bool GuildSystem::SetEmblem(uint64_t           guildId,
+	                             uint64_t           playerId,
+	                             const GuildEmblem& emblem,
+	                             MYSQL*             mysql)
+	{
+		GuildRecord* guild = FindGuild(guildId);
+		if (!guild)
+		{
+			LOG_WARN(Server, "[GuildSystem] SetEmblem: guild {} not found", guildId);
+			return false;
+		}
+
+		// Only the Guild Master may change the emblem.
+		const GuildMemberRecord* member = FindMember(*guild, playerId);
+		if (!member ||
+		    member->rankId != static_cast<uint8_t>(DefaultGuildRank::GuildMaster))
+		{
+			LOG_WARN(Server, "[GuildSystem] SetEmblem: player {} is not Guild Master of guild {}",
+			         playerId, guildId);
+			return false;
+		}
+
+#if ENGINE_HAS_MYSQL
+		if (mysql)
+		{
+			const std::string emblemJson = SerializeEmblem(emblem);
+			if (!DbUpdateEmblem(guildId, emblemJson, mysql))
+				return false;
+		}
+#else
+		(void)mysql;
+#endif
+
+		guild->emblem = emblem;
+		LOG_INFO(Server, "[GuildSystem] SetEmblem: guild {} emblem updated by player {} "
+		         "(bg={:#010x}, border={:#010x}, sym={})",
+		         guildId, playerId, emblem.bgColor, emblem.borderColor, emblem.symbolId);
+		return true;
+	}
+
+	// =========================================================================
 	// DB helpers (UNIX + ENGINE_HAS_MYSQL only)
 	// =========================================================================
 
@@ -654,6 +699,30 @@ namespace engine::server
 		if (mysql_query(mysql, sql.c_str()) != 0)
 		{
 			LOG_ERROR(Server, "[GuildSystem] DbUpdateMotd failed: {}", mysql_error(mysql));
+			return false;
+		}
+		return true;
+	}
+
+	bool GuildSystem::DbUpdateEmblem(uint64_t guildId, std::string_view emblemJson, MYSQL* mysql)
+	{
+		// emblemJson is produced by SerializeEmblem and contains only digits, braces,
+		// colons and commas — no characters that need SQL escaping.
+		// We still escape defensively via mysql_real_escape_string.
+		std::string escaped(emblemJson.size() * 2u + 1u, '\0');
+		unsigned long written = mysql_real_escape_string(
+			mysql, escaped.data(), emblemJson.data(),
+			static_cast<unsigned long>(emblemJson.size()));
+		escaped.resize(static_cast<size_t>(written));
+
+		std::string sql =
+			"UPDATE guilds SET emblem = '"
+			+ escaped
+			+ "' WHERE id = " + std::to_string(guildId);
+
+		if (mysql_query(mysql, sql.c_str()) != 0)
+		{
+			LOG_ERROR(Server, "[GuildSystem] DbUpdateEmblem failed: {}", mysql_error(mysql));
 			return false;
 		}
 		return true;

--- a/engine/server/GuildSystem.h
+++ b/engine/server/GuildSystem.h
@@ -1,8 +1,11 @@
 #pragma once
 // M32.3 — Server-side guild system: creation, roster, ranks, permissions, guild chat routing.
+// M32.4 — Extended with guild emblem data (GuildEmblem stored in GuildRecord).
 // Depends on M13.1 (server core) and M14.4 (character persistence).
 // On platforms without MySQL (WIN32 game shard) the system operates in no-DB mode:
 // all data is in-memory only; DB operations are skipped.
+
+#include "engine/server/GuildTabard.h"
 
 #include <cstdint>
 #include <string>
@@ -52,7 +55,7 @@ namespace engine::server
 		uint8_t     rankId     = static_cast<uint8_t>(DefaultGuildRank::Recruit);
 	};
 
-	/// In-memory representation of one live guild (M32.3).
+	/// In-memory representation of one live guild (M32.3 + M32.4).
 	struct GuildRecord
 	{
 		uint64_t                       guildId        = 0;
@@ -61,6 +64,9 @@ namespace engine::server
 		uint64_t                       masterPlayerId = 0;
 		std::vector<GuildMemberRecord> members;
 		std::vector<GuildRankRecord>   ranks;
+		/// M32.4: Visual emblem (background color, border color, symbol atlas index).
+		/// Serialized via SerializeEmblem / ParseEmblem when persisting to DB.
+		GuildEmblem                    emblem{};
 	};
 
 	/// Server-side guild manager (M32.3).
@@ -156,6 +162,19 @@ namespace engine::server
 		             MYSQL*           mysql);
 
 		// ------------------------------------------------------------------
+		// Emblem (M32.4)
+		// ------------------------------------------------------------------
+
+		/// Set the guild emblem (background color, border color, symbol).
+		/// Only the Guild Master may change the emblem.
+		/// Persists the serialized emblem JSON to DB when available.
+		/// Returns true on success.
+		bool SetEmblem(uint64_t           guildId,
+		               uint64_t           playerId,
+		               const GuildEmblem& emblem,
+		               MYSQL*             mysql);
+
+		// ------------------------------------------------------------------
 		// Online presence (for guild chat routing)
 		// ------------------------------------------------------------------
 
@@ -240,6 +259,9 @@ namespace engine::server
 
 		/// UPDATE guilds SET motd=… WHERE id=…
 		bool DbUpdateMotd(uint64_t guildId, std::string_view motd, MYSQL* mysql);
+
+		/// UPDATE guilds SET emblem=… WHERE id=… (M32.4).
+		bool DbUpdateEmblem(uint64_t guildId, std::string_view emblemJson, MYSQL* mysql);
 
 		/// INSERT the four default rank rows into guild_ranks for \p guildId.
 		void DbInsertDefaultRanks(uint64_t guildId, MYSQL* mysql);

--- a/engine/server/GuildTabard.cpp
+++ b/engine/server/GuildTabard.cpp
@@ -1,0 +1,65 @@
+// M32.4 — Guild tabard item constants and emblem serialization.
+// Uses only standard C++20 facilities; no external JSON library required.
+
+#include "engine/server/GuildTabard.h"
+#include "engine/core/Log.h"
+
+#include <charconv>
+#include <format>
+
+namespace engine::server
+{
+    // =========================================================================
+    // SerializeEmblem
+    // =========================================================================
+
+    std::string SerializeEmblem(const GuildEmblem& emblem)
+    {
+        // Produces: {"bg":<u32>,"border":<u32>,"sym":<u32>}
+        return std::format(R"({{"bg":{},"border":{},"sym":{}}})",
+                           emblem.bgColor, emblem.borderColor, emblem.symbolId);
+    }
+
+    // =========================================================================
+    // ParseEmblem
+    // =========================================================================
+
+    bool ParseEmblem(std::string_view json, GuildEmblem& out)
+    {
+        // Minimal parser for the exact format produced by SerializeEmblem.
+        // Not a general JSON parser: only handles the three known keys.
+        auto parseField = [](std::string_view src,
+                             std::string_view key,
+                             uint32_t&        value) -> bool
+        {
+            // Build search needle: "key":
+            std::string needle;
+            needle.reserve(key.size() + 3u);
+            needle += '"';
+            needle += key;
+            needle += "\":";
+
+            const auto pos = src.find(needle);
+            if (pos == std::string_view::npos)
+                return false;
+
+            const char* start = src.data() + pos + needle.size();
+            const char* end   = src.data() + src.size();
+
+            auto [ptr, ec] = std::from_chars(start, end, value);
+            if (ec != std::errc{})
+                return false;
+
+            return true;
+        };
+
+        GuildEmblem tmp = out; // keep original on partial failure
+        if (!parseField(json, "bg",     tmp.bgColor))     { LOG_WARN(Server, "[GuildTabard] ParseEmblem: missing 'bg' field");     return false; }
+        if (!parseField(json, "border", tmp.borderColor)) { LOG_WARN(Server, "[GuildTabard] ParseEmblem: missing 'border' field"); return false; }
+        if (!parseField(json, "sym",    tmp.symbolId))    { LOG_WARN(Server, "[GuildTabard] ParseEmblem: missing 'sym' field");    return false; }
+
+        out = tmp;
+        return true;
+    }
+
+} // namespace engine::server

--- a/engine/server/GuildTabard.h
+++ b/engine/server/GuildTabard.h
@@ -1,0 +1,36 @@
+#pragma once
+// M32.4 — Tabard item constants and guild emblem data definition.
+// The tabard is an equippable chest item that carries the guild emblem overlay.
+// The emblem is serialized as compact JSON and stored in the guilds table.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace engine::server
+{
+    /// Item type id for the guild tabard (equippable chest slot, M32.4).
+    inline constexpr uint32_t kItemIdTabard = 9001u;
+
+    /// Equipment slot index for the chest (matches M16.3 equip slot layout).
+    inline constexpr uint32_t kEquipSlotChest = 4u;
+
+    /// Visual emblem definition stored per-guild (M32.4).
+    /// Serialized as compact JSON and persisted in the guilds.emblem column.
+    /// Client must cache this value; do NOT re-fetch every frame.
+    struct GuildEmblem
+    {
+        uint32_t bgColor     = 0xFF1A1A1Au; ///< ARGB background fill color.
+        uint32_t borderColor = 0xFFFFFFFFu; ///< ARGB border color.
+        uint32_t symbolId    = 0u;          ///< Atlas symbol index (0 = none / blank).
+    };
+
+    /// Serialize \p emblem to a compact JSON string.
+    /// Produces the format: {"bg":<u32>,"border":<u32>,"sym":<u32>}
+    std::string SerializeEmblem(const GuildEmblem& emblem);
+
+    /// Parse a GuildEmblem from the JSON string produced by SerializeEmblem.
+    /// Returns true on success; leaves \p out unchanged on parse failure.
+    bool ParseEmblem(std::string_view json, GuildEmblem& out);
+
+} // namespace engine::server

--- a/game/data/items/tabard.json
+++ b/game/data/items/tabard.json
@@ -1,0 +1,9 @@
+{
+  "itemId": 9001,
+  "name": "Guild Tabard",
+  "description": "A tabard bearing your guild's emblem. Displays the guild colors and symbol on the chest.",
+  "type": "tabard",
+  "equipSlot": "chest",
+  "stackable": false,
+  "iconPath": "items/tabard_icon.png"
+}


### PR DESCRIPTION
- Add GuildTabard.h/.cpp: kItemIdTabard constant (id=9001), kEquipSlotChest, GuildEmblem struct (bgColor/borderColor/symbolId), SerializeEmblem/ParseEmblem.
- Add GuildBank.h/.cpp: GuildBankTabPermission (View/Deposit/Withdraw), GuildBankTab (98 slots, per-rank permissions), GuildBankWithdrawEntry audit log, GuildBank class (6-8 tabs, Init/Shutdown/Deposit/Withdraw/SetTabPermission).
- Extend GuildRecord with GuildEmblem emblem field (M32.4).
- Add GuildSystem::SetEmblem (GM-only, persists to DB via DbUpdateEmblem).
- Add game/data/items/tabard.json (itemId=9001, chest slot).
- Register GuildTabard.cpp and GuildBank.cpp in server CMakeLists.txt (WIN32+UNIX).

https://claude.ai/code/session_01EUqB394APoa8mpGrqnoyvz