### PR TITLE
M33.3: Security rate limiting + anti-bot measures

### DIFF
--- a/engine/network/AuthRegisterPayloads.cpp
+++ b/engine/network/AuthRegisterPayloads.cpp
@@ -32,6 +32,12 @@ namespace engine::network
 			if (!r.ReadString(out.email))
 				return std::nullopt;
 		}
+		// M33.3: optional 4th field — CAPTCHA response token (backward-compatible).
+		if (r.Remaining() >= 2u)
+		{
+			if (!r.ReadString(out.captcha_token))
+				return std::nullopt;
+		}
 		return out;
 	}
 

--- a/engine/network/AuthRegisterPayloads.h
+++ b/engine/network/AuthRegisterPayloads.h
@@ -19,11 +19,13 @@ namespace engine::network
 	};
 
 	/// Parsed REGISTER_REQUEST payload: login, optional email, client_hash (password field).
+	/// M33.3: optional captcha_token appended as a 4th length-prefixed string (backward-compatible).
 	struct RegisterRequestPayload
 	{
 		std::string login;
 		std::string email;
 		std::string client_hash;
+		std::string captcha_token; ///< M33.3: CAPTCHA response token from client widget. Empty when absent.
 	};
 
 	/// Parses AUTH_REQUEST payload. Returns nullopt if truncated or invalid.

--- a/engine/server/AntiBotTests.cpp
+++ b/engine/server/AntiBotTests.cpp
@@ -1,0 +1,301 @@
+/**
+ * M33.3 — Unit tests for UserRateLimiter, CaptchaVerifier (bypass mode), and BotDetector.
+ * No external test framework; returns 0 if all pass, non-zero on failure.
+ */
+
+#include "engine/server/UserRateLimiter.h"
+#include "engine/server/CaptchaVerifier.h"
+#include "engine/server/BotDetector.h"
+#include "engine/core/Log.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+namespace
+{
+	static int s_failCount = 0;
+
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::server;
+using Clock = std::chrono::steady_clock;
+
+// ---------------------------------------------------------------------------
+// UserRateLimiter tests
+// ---------------------------------------------------------------------------
+
+static void TestChatRateLimit()
+{
+	UserRateLimiter rl;
+	UserRateLimiterConfig cfg;
+	cfg.chat_per_minute = 3;
+	cfg.skills_per_sec  = 100.0;
+	rl.SetConfig(cfg);
+
+	const uint64_t user = 42;
+	Assert(rl.TryConsumeChat(user), "Chat 1 allowed");
+	Assert(rl.TryConsumeChat(user), "Chat 2 allowed");
+	Assert(rl.TryConsumeChat(user), "Chat 3 allowed");
+	Assert(!rl.TryConsumeChat(user), "Chat 4 rate limited");
+	Assert(!rl.TryConsumeChat(user), "Chat 5 rate limited");
+
+	UserRateLimitCounters c;
+	rl.GetCounters(c);
+	Assert(c.chat_rate_limit_hits >= 2, "Chat counters record rate limit hits");
+}
+
+static void TestSkillRateLimit()
+{
+	UserRateLimiter rl;
+	UserRateLimiterConfig cfg;
+	cfg.chat_per_minute = 100;
+	cfg.skills_per_sec  = 3.0; // very low for test
+	rl.SetConfig(cfg);
+
+	const uint64_t user = 99;
+	Assert(rl.TryConsumeSkill(user), "Skill 1 allowed");
+	Assert(rl.TryConsumeSkill(user), "Skill 2 allowed");
+	Assert(rl.TryConsumeSkill(user), "Skill 3 allowed");
+	Assert(!rl.TryConsumeSkill(user), "Skill 4 rate limited (bucket empty)");
+
+	UserRateLimitCounters c;
+	rl.GetCounters(c);
+	Assert(c.skill_rate_limit_hits >= 1, "Skill counters record rate limit hits");
+}
+
+static void TestSkillBucketRefill()
+{
+	UserRateLimiter rl;
+	UserRateLimiterConfig cfg;
+	cfg.chat_per_minute = 100;
+	cfg.skills_per_sec  = 2.0;
+	rl.SetConfig(cfg);
+
+	const uint64_t user = 7;
+	Assert(rl.TryConsumeSkill(user), "Skill 1 allowed");
+	Assert(rl.TryConsumeSkill(user), "Skill 2 allowed");
+	Assert(!rl.TryConsumeSkill(user), "Skill 3 rate limited before refill");
+
+	// Wait for bucket to partially refill (1 token in 500 ms with 2/sec rate).
+	std::this_thread::sleep_for(std::chrono::milliseconds(600));
+	Assert(rl.TryConsumeSkill(user), "Skill allowed after 600ms refill");
+}
+
+static void TestUserRateLimiterPurge()
+{
+	UserRateLimiter rl;
+	UserRateLimiterConfig cfg;
+	cfg.chat_per_minute = 10;
+	cfg.max_entries     = 2;
+	rl.SetConfig(cfg);
+
+	rl.TryConsumeChat(1);
+	rl.TryConsumeChat(2);
+	rl.TryConsumeChat(3);
+	// No crash, purge runs within SetConfig limits.
+	rl.PurgeExpired(); // should not crash
+}
+
+// ---------------------------------------------------------------------------
+// CaptchaVerifier tests (bypass mode only — no real HTTP in unit tests)
+// ---------------------------------------------------------------------------
+
+static void TestCaptchaBypassMode()
+{
+	CaptchaVerifier cv;
+	CaptchaConfig cfg;
+	cfg.enabled = false; // bypass
+	cv.SetConfig(cfg);
+
+	Assert(!cv.IsEnabled(), "Bypass mode: not enabled");
+	Assert(cv.Verify("any_token", "1.2.3.4"), "Bypass mode accepts any token");
+	Assert(cv.Verify("", "1.2.3.4"),           "Bypass mode accepts empty token");
+}
+
+static void TestCaptchaEnabledEmptyToken()
+{
+	CaptchaVerifier cv;
+	CaptchaConfig cfg;
+	cfg.enabled    = true;
+	cfg.secret_key = "test_secret";
+	cv.SetConfig(cfg);
+
+	Assert(cv.IsEnabled(), "CAPTCHA enabled");
+	// Empty token must be rejected even before HTTP call.
+	Assert(!cv.Verify("", "1.2.3.4"), "Empty token rejected when enabled");
+}
+
+static void TestCaptchaTrustedIp()
+{
+	CaptchaVerifier cv;
+	CaptchaConfig cfg;
+	cfg.enabled    = true;
+	cfg.secret_key = "test_secret";
+	cfg.trusted_ips.push_back("127.0.0.1");
+	cv.SetConfig(cfg);
+
+	// Trusted IP bypasses CAPTCHA even when enabled.
+	Assert(cv.Verify("any_token", "127.0.0.1"), "Trusted IP bypasses CAPTCHA");
+	// Non-trusted IP with no secret_key would fail; use empty key to test reject path.
+	CaptchaVerifier cv2;
+	CaptchaConfig cfg2;
+	cfg2.enabled    = true;
+	cfg2.secret_key = ""; // no secret → reject
+	cv2.SetConfig(cfg2);
+	Assert(!cv2.Verify("token", "10.0.0.1"), "No secret_key -> token rejected");
+}
+
+// ---------------------------------------------------------------------------
+// BotDetector tests
+// ---------------------------------------------------------------------------
+
+static void TestBotDetectorClean()
+{
+	BotDetector bd;
+	BotDetectorConfig cfg;
+	cfg.window_size    = 10;
+	cfg.min_action_interval_ms = 100.0;
+	cfg.flag_threshold = 3;
+	cfg.autoban_threshold = 5;
+	bd.SetConfig(cfg);
+
+	const uint64_t user = 1001;
+	// Actions with large gaps (> 200ms) should not trigger anomalies.
+	auto t = Clock::now();
+	for (int i = 0; i < 5; ++i)
+	{
+		t += std::chrono::milliseconds(300 + i * 50); // varying, human-like
+		const auto sig = bd.RecordAction(user, BotActionType::SkillUse, t);
+		Assert(sig == BotSignal::Clean || sig == BotSignal::Suspicious,
+			"Clean/slow actions produce no autoban");
+	}
+	Assert(!bd.ShouldAutoBan(user), "No autoban for clean actions");
+}
+
+static void TestBotDetectorImpossibleSpeed()
+{
+	BotDetector bd;
+	BotDetectorConfig cfg;
+	cfg.window_size               = 10;
+	cfg.min_action_interval_ms    = 100.0;
+	cfg.flag_threshold            = 1;
+	cfg.autoban_threshold         = 5;
+	cfg.regularity_variance_threshold_ms2 = 9999.0; // disable variance check
+	bd.SetConfig(cfg);
+
+	const uint64_t user = 2002;
+	auto t = Clock::now();
+	// First action OK.
+	bd.RecordAction(user, BotActionType::SkillUse, t);
+	// Second action 10ms later — below 100ms threshold → suspicious.
+	t += std::chrono::milliseconds(10);
+	const auto sig = bd.RecordAction(user, BotActionType::SkillUse, t);
+	Assert(sig == BotSignal::Suspicious || sig == BotSignal::AutoBan,
+		"Impossible speed detected as suspicious");
+	Assert(bd.IsSuspicious(user), "User flagged after impossible speed");
+}
+
+static void TestBotDetectorAutoban()
+{
+	BotDetector bd;
+	BotDetectorConfig cfg;
+	cfg.window_size               = 20;
+	cfg.min_action_interval_ms    = 100.0;
+	cfg.flag_threshold            = 1;
+	cfg.autoban_threshold         = 3;
+	cfg.regularity_variance_threshold_ms2 = 9999.0;
+	bd.SetConfig(cfg);
+
+	const uint64_t user = 3003;
+	auto t = Clock::now();
+	BotSignal last = BotSignal::Clean;
+	// Send 5 actions with 5ms gaps — all below min_action_interval_ms.
+	for (int i = 0; i < 5; ++i)
+	{
+		t += std::chrono::milliseconds(5);
+		last = bd.RecordAction(user, BotActionType::SkillUse, t);
+	}
+	// Should have hit autoban threshold after 3 suspicious events.
+	Assert(last == BotSignal::AutoBan || bd.ShouldAutoBan(user),
+		"AutoBan threshold reached after repeated violations");
+}
+
+static void TestBotDetectorClearFlag()
+{
+	BotDetector bd;
+	BotDetectorConfig cfg;
+	cfg.window_size            = 10;
+	cfg.min_action_interval_ms = 100.0;
+	cfg.flag_threshold         = 1;
+	cfg.autoban_threshold      = 0; // disabled
+	cfg.regularity_variance_threshold_ms2 = 9999.0;
+	bd.SetConfig(cfg);
+
+	const uint64_t user = 4004;
+	auto t = Clock::now();
+	bd.RecordAction(user, BotActionType::SkillUse, t);
+	t += std::chrono::milliseconds(5);
+	bd.RecordAction(user, BotActionType::SkillUse, t);
+	Assert(bd.IsSuspicious(user), "User flagged");
+
+	bd.ClearFlag(user);
+	Assert(!bd.IsSuspicious(user),   "Flag cleared");
+	Assert(!bd.ShouldAutoBan(user),  "No autoban after clear");
+}
+
+static void TestBotDetectorPurge()
+{
+	BotDetector bd;
+	BotDetectorConfig cfg;
+	cfg.window_size    = 5;
+	cfg.idle_purge_sec = 1; // purge after 1 second idle
+	bd.SetConfig(cfg);
+
+	const uint64_t user = 5005;
+	auto t = Clock::now();
+	bd.RecordAction(user, BotActionType::ChatSend, t);
+
+	// Let the entry become stale and purge it.
+	std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+	bd.PurgeExpired(); // should not crash
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main()
+{
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Off;
+	engine::core::Log::Init(logSettings);
+
+	TestChatRateLimit();
+	TestSkillRateLimit();
+	TestSkillBucketRefill();
+	TestUserRateLimiterPurge();
+	TestCaptchaBypassMode();
+	TestCaptchaEnabledEmptyToken();
+	TestCaptchaTrustedIp();
+	TestBotDetectorClean();
+	TestBotDetectorImpossibleSpeed();
+	TestBotDetectorAutoban();
+	TestBotDetectorClearFlag();
+	TestBotDetectorPurge();
+
+	engine::core::Log::Shutdown();
+
+	if (s_failCount != 0)
+		return static_cast<int>(s_failCount);
+	return 0;
+}

--- a/engine/server/AuthRegisterHandler.cpp
+++ b/engine/server/AuthRegisterHandler.cpp
@@ -8,6 +8,7 @@
 #include "engine/server/AccountValidation.h"
 #include "engine/server/PasswordResetStore.h"
 #include "engine/server/SmtpMailer.h"
+#include "engine/server/CaptchaVerifier.h"    // M33.3
 #include "engine/network/AuthRegisterPayloads.h"
 #include "engine/network/ErrorPacket.h"
 #include "engine/network/NetErrorCode.h"
@@ -44,6 +45,7 @@ namespace engine::server
 	void AuthRegisterHandler::SetConnectionSessionMap(ConnectionSessionMap* map) { m_connectionSessionMap = map; }
 	void AuthRegisterHandler::SetPasswordResetStore(PasswordResetStore* rs) { m_resetStore = rs; }
 	void AuthRegisterHandler::SetSmtpConfig(const SmtpConfig* cfg) { m_smtpConfig = cfg; }
+	void AuthRegisterHandler::SetCaptchaVerifier(CaptchaVerifier* cv) { m_captchaVerifier = cv; } // M33.3
 
 	void AuthRegisterHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize)
@@ -93,6 +95,22 @@ namespace engine::server
 			if (!pkt.empty())
 				m_server->Send(connId, pkt);
 			return;
+		}
+
+		// M33.3: CAPTCHA verification on registration.
+		if (m_captchaVerifier && m_captchaVerifier->IsEnabled())
+		{
+			const bool captchaOk = m_captchaVerifier->Verify(parsed->captcha_token, "");
+			if (!captchaOk)
+			{
+				LOG_WARN(Auth, "[AuthRegisterHandler] Register: CAPTCHA verification failed (connId={})", connId);
+				if (m_auditLog) m_auditLog->LogRegisterFail(ipKey, "captcha_failed");
+				auto pkt = BuildErrorPacket(NetErrorCode::BAD_REQUEST, "captcha failed", requestId, sessionIdHeader);
+				if (!pkt.empty())
+					m_server->Send(connId, pkt);
+				return;
+			}
+			LOG_DEBUG(Auth, "[AuthRegisterHandler] Register: CAPTCHA OK (connId={})", connId);
 		}
 		std::string login_norm(NormaliseLoginView(parsed->login));
 		if (login_norm.empty())

--- a/engine/server/AuthRegisterHandler.h
+++ b/engine/server/AuthRegisterHandler.h
@@ -15,6 +15,7 @@ namespace engine::server
 	class SecurityAuditLog;
 	class ConnectionSessionMap;
 	class PasswordResetStore;
+	class CaptchaVerifier;   ///< M33.3
 	struct SmtpConfig;
 
 	/// Handles AUTH_REQUEST and REGISTER_REQUEST opcodes: validate, store/session, rate-limit, audit, send response.
@@ -35,6 +36,8 @@ namespace engine::server
 		void SetPasswordResetStore(PasswordResetStore* resetStore);
 		/// M33.2: Set SMTP configuration (optional; if null or host empty, emails are not sent).
 		void SetSmtpConfig(const SmtpConfig* smtpConfig);
+		/// M33.3: Set CAPTCHA verifier (optional; if null or not enabled, CAPTCHA check is skipped).
+		void SetCaptchaVerifier(CaptchaVerifier* captchaVerifier);
 
 		/// Handle one packet. Dispatches by opcode; sends response via NetServer::Send. Ignores unknown opcodes.
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
@@ -56,8 +59,9 @@ namespace engine::server
 		RateLimitAndBan* m_rateLimit = nullptr;
 		SecurityAuditLog* m_auditLog = nullptr;
 		ConnectionSessionMap* m_connectionSessionMap = nullptr;
-		PasswordResetStore* m_resetStore = nullptr;   ///< M33.2
-		const SmtpConfig*   m_smtpConfig = nullptr;  ///< M33.2
+		PasswordResetStore* m_resetStore = nullptr;        ///< M33.2
+		const SmtpConfig*   m_smtpConfig = nullptr;       ///< M33.2
+		CaptchaVerifier*    m_captchaVerifier = nullptr;  ///< M33.3
 		std::atomic<uint64_t> m_authSuccessTotal{ 0 };
 		std::atomic<uint64_t> m_authFailTotal{ 0 };
 	};

--- a/engine/server/BotDetector.cpp
+++ b/engine/server/BotDetector.cpp
@@ -1,0 +1,213 @@
+// M33.3 — Bot detection heuristics implementation.
+#include "engine/server/BotDetector.h"
+#include "engine/core/Log.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace engine::server
+{
+	// -----------------------------------------------------------------------
+	// Configuration
+	// -----------------------------------------------------------------------
+
+	void BotDetector::SetConfig(const BotDetectorConfig& config)
+	{
+		m_config = config;
+		LOG_INFO(Net,
+			"[BotDetector] Config set: window={} min_interval_ms={} variance_threshold={} "
+			"flag_threshold={} autoban_threshold={} idle_purge_sec={}",
+			m_config.window_size,
+			m_config.min_action_interval_ms,
+			m_config.regularity_variance_threshold_ms2,
+			m_config.flag_threshold,
+			m_config.autoban_threshold,
+			m_config.idle_purge_sec);
+	}
+
+	BotDetectorConfig BotDetector::LoadConfig(const engine::core::Config& config)
+	{
+		BotDetectorConfig c;
+		c.window_size                       = static_cast<size_t>(config.GetInt("bot_detect.window_size", 50));
+		c.min_action_interval_ms            = static_cast<double>(config.GetInt("bot_detect.min_action_interval_ms", 50));
+		c.regularity_variance_threshold_ms2 = static_cast<double>(config.GetInt("bot_detect.regularity_variance_threshold_ms2", 25));
+		c.flag_threshold                    = static_cast<uint32_t>(config.GetInt("bot_detect.flag_threshold", 3));
+		c.autoban_threshold                 = static_cast<uint32_t>(config.GetInt("bot_detect.autoban_threshold", 10));
+		c.idle_purge_sec                    = static_cast<uint32_t>(config.GetInt("bot_detect.idle_purge_sec", 600));
+		return c;
+	}
+
+	// -----------------------------------------------------------------------
+	// Action recording and heuristics
+	// -----------------------------------------------------------------------
+
+	BotSignal BotDetector::RecordAction(uint64_t userId, BotActionType type,
+		std::chrono::steady_clock::time_point now)
+	{
+		UserActionState& st = m_byUser[userId];
+		st.last_active = now;
+
+		// Keep window bounded.
+		if (st.timestamps.size() >= m_config.window_size)
+			st.timestamps.pop_front();
+		st.timestamps.push_back(now);
+
+		// Need at least 2 samples to compute intervals.
+		if (st.timestamps.size() < 2)
+			return BotSignal::Clean;
+
+		// Compute inter-action intervals in milliseconds.
+		std::deque<double> intervals;
+		for (size_t i = 1; i < st.timestamps.size(); ++i)
+		{
+			const double ms = std::chrono::duration<double, std::milli>(
+				st.timestamps[i] - st.timestamps[i - 1]).count();
+			intervals.push_back(ms);
+		}
+
+		bool anomaly = false;
+
+		// Heuristic 1: impossible speed — at least one interval below human minimum.
+		for (const double iv : intervals)
+		{
+			if (iv < m_config.min_action_interval_ms)
+			{
+				anomaly = true;
+				LOG_DEBUG(Net,
+					"[BotDetector] Impossible speed detected: userId={} interval_ms={:.1f} min_ms={:.1f}",
+					userId, iv, m_config.min_action_interval_ms);
+				break;
+			}
+		}
+
+		// Heuristic 2: too-regular timing (low variance).
+		if (!anomaly && intervals.size() >= 5)
+		{
+			const double mean     = Mean(intervals);
+			const double variance = Variance(intervals, mean);
+			if (variance < m_config.regularity_variance_threshold_ms2)
+			{
+				anomaly = true;
+				LOG_DEBUG(Net,
+					"[BotDetector] Regular timing detected: userId={} mean_ms={:.1f} variance={:.2f} threshold={}",
+					userId, mean, variance, m_config.regularity_variance_threshold_ms2);
+			}
+		}
+
+		if (!anomaly)
+			return BotSignal::Clean;
+
+		++st.suspicious_count;
+		LOG_INFO(Net,
+			"[BotDetector] Suspicious action: userId={} type={} count={} flag_threshold={} autoban_threshold={}",
+			userId,
+			static_cast<uint32_t>(type),
+			st.suspicious_count,
+			m_config.flag_threshold,
+			m_config.autoban_threshold);
+
+		// Auto-ban threshold.
+		if (m_config.autoban_threshold > 0 && st.suspicious_count >= m_config.autoban_threshold)
+		{
+			m_autoban.insert(userId);
+			m_flagged.insert(userId);
+			LOG_WARN(Net,
+				"[BotDetector] AUTO-BAN threshold reached: userId={} count={}",
+				userId, st.suspicious_count);
+			return BotSignal::AutoBan;
+		}
+
+		// Flag-for-review threshold.
+		if (st.suspicious_count >= m_config.flag_threshold)
+		{
+			m_flagged.insert(userId);
+			LOG_INFO(Net,
+				"[BotDetector] Account flagged for review: userId={} count={}",
+				userId, st.suspicious_count);
+			return BotSignal::Suspicious;
+		}
+
+		return BotSignal::Suspicious;
+	}
+
+	// -----------------------------------------------------------------------
+	// Query helpers
+	// -----------------------------------------------------------------------
+
+	bool BotDetector::IsSuspicious(uint64_t userId) const
+	{
+		return m_flagged.count(userId) > 0;
+	}
+
+	bool BotDetector::ShouldAutoBan(uint64_t userId) const
+	{
+		return m_autoban.count(userId) > 0;
+	}
+
+	void BotDetector::FlagForReview(uint64_t userId)
+	{
+		m_flagged.insert(userId);
+		LOG_INFO(Net, "[BotDetector] User manually flagged for review: userId={}", userId);
+	}
+
+	void BotDetector::ClearFlag(uint64_t userId)
+	{
+		m_flagged.erase(userId);
+		m_autoban.erase(userId);
+		auto it = m_byUser.find(userId);
+		if (it != m_byUser.end())
+			it->second.suspicious_count = 0;
+		LOG_INFO(Net, "[BotDetector] Flag cleared for userId={}", userId);
+	}
+
+	// -----------------------------------------------------------------------
+	// Maintenance
+	// -----------------------------------------------------------------------
+
+	void BotDetector::PurgeExpired()
+	{
+		const auto now    = std::chrono::steady_clock::now();
+		const auto cutoff = now - std::chrono::seconds(m_config.idle_purge_sec);
+
+		for (auto it = m_byUser.begin(); it != m_byUser.end(); )
+		{
+			if (it->second.last_active < cutoff)
+			{
+				// Preserve flagged / autoban status even after purge of timing state.
+				it = m_byUser.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+		LOG_DEBUG(Net, "[BotDetector] PurgeExpired: tracked_users={} flagged={} autoban={}",
+			m_byUser.size(), m_flagged.size(), m_autoban.size());
+	}
+
+	// -----------------------------------------------------------------------
+	// Math helpers
+	// -----------------------------------------------------------------------
+
+	double BotDetector::Mean(const std::deque<double>& v)
+	{
+		if (v.empty()) return 0.0;
+		double sum = 0.0;
+		for (double x : v) sum += x;
+		return sum / static_cast<double>(v.size());
+	}
+
+	double BotDetector::Variance(const std::deque<double>& v, double mean)
+	{
+		if (v.size() < 2) return 0.0;
+		double sq = 0.0;
+		for (double x : v)
+		{
+			const double d = x - mean;
+			sq += d * d;
+		}
+		return sq / static_cast<double>(v.size() - 1);
+	}
+
+} // namespace engine::server

--- a/engine/server/BotDetector.h
+++ b/engine/server/BotDetector.h
@@ -1,0 +1,120 @@
+#pragma once
+
+// M33.3 — Bot detection heuristics: track input timing, detect impossible actions.
+// Records per-user action timestamps and computes timing regularity.
+// Suspicious accounts are flagged for manual review or auto-banned.
+// Thread-safe only if caller serialises access (single-worker v1).
+
+#include "engine/core/Config.h"
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::server
+{
+	/// Identifies the category of action being tracked for bot detection.
+	enum class BotActionType : uint8_t
+	{
+		SkillUse    = 0, ///< Player used an ability/skill.
+		ChatSend    = 1, ///< Player sent a chat message.
+		MovementTick = 2, ///< Player reported a movement update.
+		AttackHit   = 3, ///< Player landed a combat hit.
+	};
+
+	/// Configuration for BotDetector.
+	struct BotDetectorConfig
+	{
+		/// Number of consecutive action timestamps to keep per user for timing analysis.
+		size_t window_size = 50;
+		/// Minimum plausible interval (ms) between two human actions (below = suspicious).
+		double min_action_interval_ms = 50.0;
+		/// Variance of inter-action intervals (ms²) below which the input is "too regular".
+		/// Humans have higher variance; bots tend to fire at near-constant intervals.
+		double regularity_variance_threshold_ms2 = 25.0;
+		/// Count of suspicious events that triggers a "flag for review".
+		uint32_t flag_threshold = 3;
+		/// Count of suspicious events that triggers auto-ban (0 = disabled).
+		uint32_t autoban_threshold = 10;
+		/// Inactivity period (seconds) after which user state is purged.
+		uint32_t idle_purge_sec = 600;
+	};
+
+	/// Bot detection result returned by RecordAction.
+	enum class BotSignal : uint8_t
+	{
+		Clean      = 0, ///< No anomaly detected.
+		Suspicious = 1, ///< Threshold crossed — flag for review.
+		AutoBan    = 2, ///< Hard threshold — auto-ban immediately.
+	};
+
+	/// Bot heuristics detector.
+	/// Wire RecordAction() into skill-use and chat handlers.
+	/// Call IsSuspicious() / ShouldAutoBan() to gate further processing.
+	class BotDetector
+	{
+	public:
+		BotDetector() = default;
+
+		/// Set configuration. Call before use.
+		void SetConfig(const BotDetectorConfig& config);
+
+		/// Build config from engine Config
+		/// (keys: bot_detect.window_size, bot_detect.min_action_interval_ms,
+		///        bot_detect.regularity_variance_threshold_ms2,
+		///        bot_detect.flag_threshold, bot_detect.autoban_threshold,
+		///        bot_detect.idle_purge_sec).
+		static BotDetectorConfig LoadConfig(const engine::core::Config& config);
+
+		/// Record one action from a user and evaluate heuristics.
+		/// Returns BotSignal::Clean, ::Suspicious, or ::AutoBan.
+		BotSignal RecordAction(uint64_t userId, BotActionType type,
+			std::chrono::steady_clock::time_point now);
+
+		/// Returns true if the user is currently flagged as suspicious.
+		bool IsSuspicious(uint64_t userId) const;
+
+		/// Returns true if the user crossed the auto-ban threshold.
+		bool ShouldAutoBan(uint64_t userId) const;
+
+		/// Manually flag a user for review (e.g., from a GM report).
+		void FlagForReview(uint64_t userId);
+
+		/// Clear the flag for a user (after successful manual review).
+		void ClearFlag(uint64_t userId);
+
+		/// Read-only view of currently flagged user IDs.
+		const std::unordered_set<uint64_t>& GetFlaggedUsers() const { return m_flagged; }
+
+		/// Read-only view of users that crossed the auto-ban threshold.
+		const std::unordered_set<uint64_t>& GetAutoBanUsers() const { return m_autoban; }
+
+		/// Purge stale user state. Call periodically (e.g., every few minutes).
+		void PurgeExpired();
+
+	private:
+		/// Compute mean of a deque of double values.
+		static double Mean(const std::deque<double>& v);
+
+		/// Compute variance of a deque of double values.
+		static double Variance(const std::deque<double>& v, double mean);
+
+		struct UserActionState
+		{
+			/// Ring buffer of recent action timestamps.
+			std::deque<std::chrono::steady_clock::time_point> timestamps;
+			/// Cumulative suspicious-event count.
+			uint32_t suspicious_count = 0;
+			/// Last recorded action time (for idle purge).
+			std::chrono::steady_clock::time_point last_active{};
+		};
+
+		BotDetectorConfig m_config;
+		std::unordered_map<uint64_t, UserActionState> m_byUser;
+		std::unordered_set<uint64_t> m_flagged;
+		std::unordered_set<uint64_t> m_autoban;
+	};
+}

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -31,6 +31,9 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/engine/server/SessionManager.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/RateLimitAndBan.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/SecurityAuditLog.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/UserRateLimiter.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/CaptchaVerifier.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/BotDetector.cpp
   )
   # M32.1: no MySQL on WIN32 game shard — FriendSystem compiles in no-DB mode.
   # Do NOT define ENGINE_HAS_MYSQL so #if ENGINE_HAS_MYSQL evaluates to false.
@@ -78,6 +81,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/engine/server/SessionManager.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/RateLimitAndBan.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/SecurityAuditLog.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/UserRateLimiter.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/CaptchaVerifier.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/BotDetector.cpp
     ShardRegistry.cpp
     ShardRegisterHandler.cpp
     ShardTicketCrypto.cpp
@@ -91,6 +97,20 @@ elseif(UNIX)
   # M32.1: MySQL available on UNIX — FriendSystem compiles with full DB support.
   target_compile_definitions(server_app PRIVATE ENGINE_HAS_MYSQL=1)
   target_link_libraries(server_app PRIVATE pthread OpenSSL::SSL engine_auth spdlog::spdlog ${MYSQL_LIBRARY})
+
+  # M33.3: Anti-bot unit tests (UserRateLimiter, CaptchaVerifier bypass, BotDetector).
+  add_executable(anti_bot_tests
+    AntiBotTests.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/UserRateLimiter.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/CaptchaVerifier.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/BotDetector.cpp
+    ${CMAKE_SOURCE_DIR}/engine/core/Config.cpp
+    ${CMAKE_SOURCE_DIR}/engine/core/Log.cpp
+  )
+  target_include_directories(anti_bot_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(anti_bot_tests PRIVATE OpenSSL::SSL spdlog::spdlog pthread)
+  target_compile_options(anti_bot_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME anti_bot_tests COMMAND anti_bot_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M21.6: DB layer smoke tests
   add_executable(db_layer_tests db/DbLayerTests.cpp db/ConnectionPool.cpp db/DbHelpers.cpp)

--- a/engine/server/CaptchaVerifier.cpp
+++ b/engine/server/CaptchaVerifier.cpp
@@ -1,0 +1,275 @@
+// M33.3 — CAPTCHA token verifier implementation.
+// UNIX: uses blocking POSIX socket + OpenSSL to POST to the provider verify endpoint.
+// Windows: HTTP layer not implemented — logs warning, returns true (bypass for local/dev builds).
+#include "engine/server/CaptchaVerifier.h"
+#include "engine/core/Log.h"
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+// OpenSSL-based HTTP POST is only compiled on UNIX where OpenSSL is available.
+#if defined(__unix__) || defined(__linux__) || defined(__APPLE__)
+#  define CAPTCHA_HAS_HTTP 1
+#  include <arpa/inet.h>
+#  include <netdb.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+#  include <openssl/ssl.h>
+#  include <openssl/err.h>
+#  include <cstring>
+#  include <sstream>
+#else
+#  define CAPTCHA_HAS_HTTP 0
+#endif
+
+namespace engine::server
+{
+	// -----------------------------------------------------------------------
+	// Configuration
+	// -----------------------------------------------------------------------
+
+	void CaptchaVerifier::SetConfig(const CaptchaConfig& config)
+	{
+		m_config = config;
+		if (m_config.enabled)
+		{
+			LOG_INFO(Net, "[CaptchaVerifier] Init OK (provider={} secret_key_set={} trusted_ips={})",
+				m_config.provider == CaptchaProvider::HCaptcha ? "hcaptcha" : "recaptcha",
+				!m_config.secret_key.empty(),
+				static_cast<uint32_t>(m_config.trusted_ips.size()));
+		}
+		else
+		{
+			LOG_WARN(Net, "[CaptchaVerifier] CAPTCHA disabled (bypass mode) — do not use in production");
+		}
+	}
+
+	CaptchaConfig CaptchaVerifier::LoadConfig(const engine::core::Config& config)
+	{
+		CaptchaConfig c;
+		c.enabled    = (config.GetInt("captcha.enabled", 0) != 0);
+		c.secret_key = config.GetString("captcha.secret_key", "");
+
+		const std::string provider = config.GetString("captcha.provider", "hcaptcha");
+		if (provider == "recaptcha")
+			c.provider = CaptchaProvider::ReCaptcha;
+		else
+			c.provider = CaptchaProvider::HCaptcha;
+
+		c.verify_url_override = config.GetString("captcha.verify_url_override", "");
+
+		// Parse comma-separated trusted IPs.
+		const std::string raw = config.GetString("captcha.trusted_ips", "");
+		if (!raw.empty())
+		{
+			std::string token;
+			for (char ch : raw)
+			{
+				if (ch == ',')
+				{
+					if (!token.empty())
+					{
+						c.trusted_ips.push_back(token);
+						token.clear();
+					}
+				}
+				else
+				{
+					token += ch;
+				}
+			}
+			if (!token.empty())
+				c.trusted_ips.push_back(token);
+		}
+		return c;
+	}
+
+	// -----------------------------------------------------------------------
+	// Public interface
+	// -----------------------------------------------------------------------
+
+	bool CaptchaVerifier::Verify(std::string_view token, std::string_view remoteIp) const
+	{
+		if (!m_config.enabled)
+		{
+			LOG_DEBUG(Net, "[CaptchaVerifier] Bypass mode — token accepted without verification");
+			return true;
+		}
+		if (token.empty())
+		{
+			LOG_WARN(Net, "[CaptchaVerifier] Verify FAILED: empty token (ip={})", remoteIp);
+			return false;
+		}
+		if (IsTrustedIp(remoteIp))
+		{
+			LOG_DEBUG(Net, "[CaptchaVerifier] Trusted IP bypass: ip={}", remoteIp);
+			return true;
+		}
+		if (m_config.secret_key.empty())
+		{
+			LOG_WARN(Net, "[CaptchaVerifier] Verify FAILED: no secret_key configured");
+			return false;
+		}
+		return VerifyHttp(token, remoteIp);
+	}
+
+	// -----------------------------------------------------------------------
+	// Private helpers
+	// -----------------------------------------------------------------------
+
+	bool CaptchaVerifier::IsTrustedIp(std::string_view ip) const
+	{
+		const std::string ipStr(ip);
+		for (const auto& trusted : m_config.trusted_ips)
+		{
+			if (trusted == ipStr)
+				return true;
+		}
+		return false;
+	}
+
+	std::string CaptchaVerifier::ResolveVerifyUrl() const
+	{
+		if (!m_config.verify_url_override.empty())
+			return m_config.verify_url_override;
+		if (m_config.provider == CaptchaProvider::HCaptcha)
+			return "https://hcaptcha.com/siteverify";
+		return "https://www.google.com/recaptcha/api/siteverify";
+	}
+
+#if CAPTCHA_HAS_HTTP
+
+	/// Minimal HTTPS POST to the CAPTCHA verify endpoint.
+	/// Parses the JSON response for {"success":true}.
+	bool CaptchaVerifier::VerifyHttp(std::string_view token, std::string_view remoteIp) const
+	{
+		// Parse host/path from verify URL.
+		const std::string url = ResolveVerifyUrl();
+		// Expected format: https://<host>/<path>
+		if (url.rfind("https://", 0) != 0)
+		{
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: unsupported URL scheme: {}", url);
+			return false;
+		}
+		const std::string hostAndPath = url.substr(8); // strip "https://"
+		const auto slashPos = hostAndPath.find('/');
+		const std::string host = (slashPos == std::string::npos)
+			? hostAndPath
+			: hostAndPath.substr(0, slashPos);
+		const std::string path = (slashPos == std::string::npos)
+			? "/"
+			: hostAndPath.substr(slashPos);
+
+		// Build POST body.
+		std::string body = "secret=";
+		body += m_config.secret_key;
+		body += "&response=";
+		body += std::string(token);
+		if (!remoteIp.empty())
+		{
+			body += "&remoteip=";
+			body += std::string(remoteIp);
+		}
+
+		// Build HTTP request.
+		std::ostringstream req;
+		req << "POST " << path << " HTTP/1.1\r\n"
+		    << "Host: " << host << "\r\n"
+		    << "Content-Type: application/x-www-form-urlencoded\r\n"
+		    << "Content-Length: " << body.size() << "\r\n"
+		    << "Connection: close\r\n"
+		    << "\r\n"
+		    << body;
+		const std::string reqStr = req.str();
+
+		// Resolve host.
+		struct addrinfo hints{};
+		hints.ai_family   = AF_UNSPEC;
+		hints.ai_socktype = SOCK_STREAM;
+		struct addrinfo* res = nullptr;
+		if (getaddrinfo(host.c_str(), "443", &hints, &res) != 0 || res == nullptr)
+		{
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: DNS resolution failed for host={}", host);
+			return false;
+		}
+
+		// Connect socket.
+		int fd = ::socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+		if (fd < 0)
+		{
+			freeaddrinfo(res);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: socket() failed");
+			return false;
+		}
+		if (::connect(fd, res->ai_addr, res->ai_addrlen) != 0)
+		{
+			freeaddrinfo(res);
+			::close(fd);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: connect() failed to host={}", host);
+			return false;
+		}
+		freeaddrinfo(res);
+
+		// TLS handshake.
+		SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+		if (!ctx)
+		{
+			::close(fd);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_CTX_new failed");
+			return false;
+		}
+		SSL* ssl = SSL_new(ctx);
+		SSL_set_fd(ssl, fd);
+		SSL_set_tlsext_host_name(ssl, host.c_str());
+		if (SSL_connect(ssl) != 1)
+		{
+			SSL_free(ssl);
+			SSL_CTX_free(ctx);
+			::close(fd);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: TLS handshake failed to host={}", host);
+			return false;
+		}
+
+		// Send request.
+		SSL_write(ssl, reqStr.data(), static_cast<int>(reqStr.size()));
+
+		// Read response (up to 4 KB).
+		char buf[4096]{};
+		int  read_len = SSL_read(ssl, buf, sizeof(buf) - 1);
+		buf[read_len > 0 ? read_len : 0] = '\0';
+
+		SSL_shutdown(ssl);
+		SSL_free(ssl);
+		SSL_CTX_free(ctx);
+		::close(fd);
+
+		// Look for "success":true in the JSON body (simple substring match).
+		const std::string response(buf, read_len > 0 ? static_cast<size_t>(read_len) : 0u);
+		const bool success = response.find("\"success\":true") != std::string::npos
+		                  || response.find("\"success\": true") != std::string::npos;
+
+		if (success)
+		{
+			LOG_DEBUG(Net, "[CaptchaVerifier] Token verified OK (host={})", host);
+		}
+		else
+		{
+			LOG_WARN(Net, "[CaptchaVerifier] Token verification FAILED (host={})", host);
+		}
+		return success;
+	}
+
+#else // Windows / unsupported platform
+
+	bool CaptchaVerifier::VerifyHttp(std::string_view /*token*/, std::string_view /*remoteIp*/) const
+	{
+		LOG_WARN(Net,
+			"[CaptchaVerifier] VerifyHttp: HTTP layer not implemented on this platform — "
+			"token accepted (bypass). Configure an external CAPTCHA proxy for production.");
+		return true;
+	}
+
+#endif // CAPTCHA_HAS_HTTP
+
+} // namespace engine::server

--- a/engine/server/CaptchaVerifier.h
+++ b/engine/server/CaptchaVerifier.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// M33.3 — Server-side CAPTCHA token verifier.
+// Supports hCaptcha and reCAPTCHA v2/v3 via their respective secret-verify endpoints.
+// In dev/bypass mode (enabled=false or trusted IP) all tokens are accepted without network call.
+// On Windows the HTTP verification layer emits a LOG_WARN and falls back to bypass.
+// Thread-safe only if caller serialises access (single-worker v1).
+
+#include "engine/core/Config.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::server
+{
+	/// CAPTCHA provider selection.
+	enum class CaptchaProvider
+	{
+		HCaptcha  = 0, ///< https://hcaptcha.com  — verify at https://hcaptcha.com/siteverify
+		ReCaptcha = 1, ///< https://google.com/recaptcha — verify at https://www.google.com/recaptcha/api/siteverify
+	};
+
+	/// Configuration for CaptchaVerifier.
+	struct CaptchaConfig
+	{
+		/// Enable CAPTCHA verification (false = bypass/dev mode).
+		bool enabled = false;
+		/// Provider to use.
+		CaptchaProvider provider = CaptchaProvider::HCaptcha;
+		/// Secret key from the CAPTCHA dashboard.
+		std::string secret_key;
+		/// Override verify URL (empty = use provider default).
+		std::string verify_url_override;
+		/// IPs that bypass CAPTCHA (trusted devs, admins, internal services).
+		std::vector<std::string> trusted_ips;
+	};
+
+	/// Server-side CAPTCHA token verifier.
+	/// Wire this into AuthRegisterHandler to gate registrations behind a CAPTCHA challenge.
+	class CaptchaVerifier
+	{
+	public:
+		CaptchaVerifier() = default;
+
+		/// Set configuration. Call before Verify.
+		void SetConfig(const CaptchaConfig& config);
+
+		/// Build config from engine Config
+		/// (keys: captcha.enabled, captcha.provider ["hcaptcha"|"recaptcha"],
+		///        captcha.secret_key, captcha.trusted_ips [comma-separated]).
+		static CaptchaConfig LoadConfig(const engine::core::Config& config);
+
+		/// Verify a CAPTCHA response token submitted by the client.
+		/// \param token      CAPTCHA response token from the client widget.
+		/// \param remoteIp   Client IP (forwarded to provider for fraud scoring, may be empty).
+		/// Returns true when the token is valid (or verification is bypassed / IP trusted).
+		/// Returns false when verification fails or encounters a network error.
+		bool Verify(std::string_view token, std::string_view remoteIp) const;
+
+		/// Returns true when CAPTCHA verification is enabled (not bypassed).
+		bool IsEnabled() const { return m_config.enabled; }
+
+	private:
+		/// Returns true when \a ip is in the trusted-IP whitelist.
+		bool IsTrustedIp(std::string_view ip) const;
+
+		/// Returns the verification URL for the configured provider.
+		std::string ResolveVerifyUrl() const;
+
+		/// Perform an HTTP POST to the provider verify endpoint and parse the "success" field.
+		/// Uses a blocking POSIX socket + OpenSSL handshake on UNIX.
+		/// On Windows this logs a warning and returns true (bypass).
+		bool VerifyHttp(std::string_view token, std::string_view remoteIp) const;
+
+		CaptchaConfig m_config;
+	};
+}

--- a/engine/server/UserRateLimiter.cpp
+++ b/engine/server/UserRateLimiter.cpp
@@ -1,0 +1,107 @@
+// M33.3 — User-based rate limiter implementation.
+#include "engine/server/UserRateLimiter.h"
+#include "engine/core/Log.h"
+
+#include <algorithm>
+#include <chrono>
+
+namespace engine::server
+{
+	void UserRateLimiter::SetConfig(const UserRateLimiterConfig& config)
+	{
+		m_config = config;
+		LOG_INFO(Net, "[UserRateLimiter] Config set: chat_per_minute={} skills_per_sec={} max_entries={}",
+			m_config.chat_per_minute, m_config.skills_per_sec, m_config.max_entries);
+	}
+
+	UserRateLimiterConfig UserRateLimiter::LoadConfig(const engine::core::Config& config)
+	{
+		UserRateLimiterConfig c;
+		c.chat_per_minute  = static_cast<uint32_t>(config.GetInt("security.chat_per_minute",  10));
+		c.skills_per_sec   = static_cast<double>(config.GetInt("security.skills_per_sec", 20));
+		c.max_entries      = static_cast<size_t>(config.GetInt("security.user_rl_max_entries", 50000));
+		return c;
+	}
+
+	bool UserRateLimiter::TryConsumeChat(uint64_t userId)
+	{
+		auto now = Clock::now();
+		UserState& st = m_byUser[userId];
+		st.last_active = now;
+
+		// Sliding window: remove timestamps older than 60 seconds.
+		const auto window_start = now - std::chrono::seconds(60);
+		auto& dq = st.chat.timestamps;
+		while (!dq.empty() && dq.front() < window_start)
+			dq.pop_front();
+
+		if (static_cast<uint32_t>(dq.size()) >= m_config.chat_per_minute)
+		{
+			++m_counters.chat_rate_limit_hits;
+			LOG_DEBUG(Net, "[UserRateLimiter] Chat rate limited: userId={}", userId);
+			return false;
+		}
+		dq.push_back(now);
+		return true;
+	}
+
+	bool UserRateLimiter::TryConsumeSkill(uint64_t userId)
+	{
+		auto now = Clock::now();
+		UserState& st = m_byUser[userId];
+		st.last_active = now;
+
+		SkillBucket& bucket = st.skills;
+		if (bucket.last_refill == Clock::time_point{})
+		{
+			// First use: fill bucket.
+			bucket.tokens     = m_config.skills_per_sec;
+			bucket.last_refill = now;
+		}
+		else
+		{
+			const double elapsed =
+				std::chrono::duration<double>(now - bucket.last_refill).count();
+			bucket.tokens = std::min(m_config.skills_per_sec,
+				bucket.tokens + elapsed * m_config.skills_per_sec);
+			bucket.last_refill = now;
+		}
+
+		if (bucket.tokens < 1.0)
+		{
+			++m_counters.skill_rate_limit_hits;
+			LOG_DEBUG(Net, "[UserRateLimiter] Skill rate limited: userId={}", userId);
+			return false;
+		}
+		bucket.tokens -= 1.0;
+		return true;
+	}
+
+	void UserRateLimiter::PurgeExpired()
+	{
+		const auto now    = Clock::now();
+		const auto cutoff = now - std::chrono::minutes(5);
+
+		for (auto it = m_byUser.begin(); it != m_byUser.end(); )
+		{
+			if (it->second.last_active < cutoff)
+				it = m_byUser.erase(it);
+			else
+				++it;
+		}
+
+		// Enforce max_entries by evicting oldest-touched entries.
+		if (m_config.max_entries > 0 && m_byUser.size() > m_config.max_entries)
+		{
+			while (m_byUser.size() > m_config.max_entries)
+				m_byUser.erase(m_byUser.begin());
+		}
+
+		LOG_DEBUG(Net, "[UserRateLimiter] PurgeExpired done: tracked_users={}", m_byUser.size());
+	}
+
+	void UserRateLimiter::GetCounters(UserRateLimitCounters& out) const
+	{
+		out = m_counters;
+	}
+}

--- a/engine/server/UserRateLimiter.h
+++ b/engine/server/UserRateLimiter.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// M33.3 — User-based rate limiter for in-game actions (chat 10 msg/min, skills 20/sec).
+// Token bucket for skills; sliding window for chat.
+// Thread-safe only if caller serialises access (single-worker v1).
+
+#include "engine/core/Config.h"
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <unordered_map>
+
+namespace engine::server
+{
+	/// Counters for user-based rate limiting (chat + skills).
+	struct UserRateLimitCounters
+	{
+		uint64_t chat_rate_limit_hits  = 0;
+		uint64_t skill_rate_limit_hits = 0;
+	};
+
+	/// Configuration for user-based rate limiting.
+	struct UserRateLimiterConfig
+	{
+		/// Max chat messages per minute per user (sliding window). Default: 10.
+		uint32_t chat_per_minute = 10;
+		/// Max skill uses per second per user (token bucket capacity). Default: 20.
+		double skills_per_sec = 20.0;
+		/// Max tracked user entries. Oldest entries purged when exceeded (0 = no limit).
+		size_t max_entries = 50000;
+	};
+
+	/// User-based rate limiter: chat (10/min sliding window) + skills (20/sec token bucket).
+	/// Apply per authenticated userId before processing costly game actions.
+	class UserRateLimiter
+	{
+	public:
+		UserRateLimiter() = default;
+
+		/// Set configuration. Call before use.
+		void SetConfig(const UserRateLimiterConfig& config);
+
+		/// Build config from engine Config
+		/// (keys: security.chat_per_minute, security.skills_per_sec, security.user_rl_max_entries).
+		static UserRateLimiterConfig LoadConfig(const engine::core::Config& config);
+
+		/// Returns true if chat message is allowed for this user. False = rate limited.
+		/// Records the attempt and advances the sliding window.
+		bool TryConsumeChat(uint64_t userId);
+
+		/// Returns true if skill use is allowed for this user. False = rate limited.
+		/// Consumes one token from the per-user bucket.
+		bool TryConsumeSkill(uint64_t userId);
+
+		/// Remove stale entries to limit memory growth. Call periodically (e.g., every minute).
+		void PurgeExpired();
+
+		/// Fill \a out with current counters for observability.
+		void GetCounters(UserRateLimitCounters& out) const;
+
+	private:
+		using Clock = std::chrono::steady_clock;
+
+		/// Sliding window of message timestamps within the last minute.
+		struct ChatWindow
+		{
+			std::deque<Clock::time_point> timestamps;
+		};
+
+		/// Token bucket for skills.
+		struct SkillBucket
+		{
+			double tokens    = 0.0;
+			Clock::time_point last_refill{};
+		};
+
+		struct UserState
+		{
+			ChatWindow  chat;
+			SkillBucket skills;
+			Clock::time_point last_active{};
+		};
+
+		UserRateLimiterConfig m_config;
+		mutable UserRateLimitCounters m_counters;
+		std::unordered_map<uint64_t, UserState> m_byUser;
+	};
+}


### PR DESCRIPTION
- UserRateLimiter: sliding-window chat rate (10 msg/min per user) and token-bucket skill rate (20/sec per user); LoadConfig from engine Config.
- CaptchaVerifier: server-side hCaptcha/reCAPTCHA token verification; bypass mode (dev), trusted-IP whitelist, blocking HTTPS POST on UNIX.
- BotDetector: timing heuristics (impossible speed < 50ms, low-variance regularity); flag-for-review and auto-ban thresholds; PurgeExpired.
- AuthRegisterPayloads: backward-compatible optional 4th field captcha_token in RegisterRequestPayload / ParseRegisterRequestPayload.
- AuthRegisterHandler: SetCaptchaVerifier(); CAPTCHA checked on registration before account creation when CaptchaVerifier is enabled.
- CMakeLists.txt: new sources added to WIN32 and UNIX server_app targets; anti_bot_tests executable + CTest entry added (UNIX).
- AntiBotTests.cpp: 12 unit tests covering all three new modules.

https://claude.ai/code/session_01PT34fZzvmeKK2CgRnrYiWJ