### PR TITLE
feat(M34.1): Terrain heightmap rendering + LOD system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,9 @@ add_library(engine_core
   engine/render/vk/StagingAllocator.cpp
   engine/world/LodConfig.cpp
   engine/world/HlodRuntime.cpp
+  engine/render/terrain/HeightmapLoader.cpp
+  engine/render/terrain/TerrainMesh.cpp
+  engine/render/terrain/TerrainRenderer.cpp
   engine/network/ByteWriter.cpp
   engine/network/ByteReader.cpp
   engine/network/PacketBuilder.cpp

--- a/engine/render/terrain/HeightmapLoader.cpp
+++ b/engine/render/terrain/HeightmapLoader.cpp
@@ -1,0 +1,639 @@
+#include "engine/render/terrain/HeightmapLoader.h"
+#include "engine/core/Log.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────────
+    // HeightmapData helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    float HeightmapData::Sample(uint32_t x, uint32_t z) const
+    {
+        if (width == 0 || height == 0 || heights.empty()) return 0.0f;
+        x = (x < width)  ? x : width  - 1;
+        z = (z < height) ? z : height - 1;
+        return static_cast<float>(heights[z * width + x]) / 65535.0f;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Internal Vulkan helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Creates a host-visible, coherent staging buffer. Returns true on success.
+        bool CreateStagingBuffer(VkDevice device, VkPhysicalDevice physDev,
+                                 VkDeviceSize size,
+                                 VkBuffer& outBuffer, VkDeviceMemory& outMemory)
+        {
+            VkBufferCreateInfo bi{};
+            bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bi.size        = size;
+            bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bi, nullptr, &outBuffer) != VK_SUCCESS ||
+                outBuffer == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkCreateBuffer (staging) failed");
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, outBuffer, &req);
+
+            uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] No HOST_VISIBLE memory for staging buffer");
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMemory) != VK_SUCCESS ||
+                outMemory == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkAllocateMemory (staging) failed");
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindBufferMemory(device, outBuffer, outMemory, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkBindBufferMemory (staging) failed");
+                vkFreeMemory(device, outMemory, nullptr);
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                outMemory = VK_NULL_HANDLE;
+                return false;
+            }
+            return true;
+        }
+
+        /// Creates a device-local image with OPTIMAL tiling. Returns true on success.
+        bool CreateOptimalImage(VkDevice device, VkPhysicalDevice physDev,
+                                uint32_t width, uint32_t height,
+                                VkFormat format, VkImageUsageFlags usage,
+                                VkImage& outImage, VkDeviceMemory& outMemory)
+        {
+            VkImageCreateInfo ici{};
+            ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            ici.imageType     = VK_IMAGE_TYPE_2D;
+            ici.format        = format;
+            ici.extent        = { width, height, 1 };
+            ici.mipLevels     = 1;
+            ici.arrayLayers   = 1;
+            ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+            ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+            ici.usage         = usage;
+            ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateImage(device, &ici, nullptr, &outImage) != VK_SUCCESS ||
+                outImage == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkCreateImage failed ({}x{} fmt={})",
+                          width, height, static_cast<int>(format));
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetImageMemoryRequirements(device, outImage, &req);
+
+            uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                                           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] No DEVICE_LOCAL memory for image");
+                vkDestroyImage(device, outImage, nullptr);
+                outImage = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMemory) != VK_SUCCESS ||
+                outMemory == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkAllocateMemory (image) failed");
+                vkDestroyImage(device, outImage, nullptr);
+                outImage = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindImageMemory(device, outImage, outMemory, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkBindImageMemory failed");
+                vkFreeMemory(device, outMemory, nullptr);
+                vkDestroyImage(device, outImage, nullptr);
+                outImage  = VK_NULL_HANDLE;
+                outMemory = VK_NULL_HANDLE;
+                return false;
+            }
+            return true;
+        }
+
+        /// Executes a one-time command buffer: transition+copy+transition, then destroys it.
+        bool UploadViaStaging(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                              VkBuffer stagingBuffer, VkDeviceSize dataSize,
+                              VkImage dstImage, uint32_t imgWidth, uint32_t imgHeight)
+        {
+            VkCommandPool pool = VK_NULL_HANDLE;
+            VkCommandPoolCreateInfo poolCI{};
+            poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            poolCI.queueFamilyIndex = queueFamilyIndex;
+            poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+
+            if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS ||
+                pool == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkCreateCommandPool failed");
+                return false;
+            }
+
+            VkCommandBuffer cmd = VK_NULL_HANDLE;
+            VkCommandBufferAllocateInfo allocCI{};
+            allocCI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            allocCI.commandPool        = pool;
+            allocCI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocCI.commandBufferCount = 1;
+
+            if (vkAllocateCommandBuffers(device, &allocCI, &cmd) != VK_SUCCESS ||
+                cmd == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkAllocateCommandBuffers failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            VkCommandBufferBeginInfo beginInfo{};
+            beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+            if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkBeginCommandBuffer failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            // Barrier: UNDEFINED → TRANSFER_DST_OPTIMAL
+            {
+                VkImageMemoryBarrier barrier{};
+                barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.oldLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
+                barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.image               = dstImage;
+                barrier.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+                barrier.srcAccessMask       = 0;
+                barrier.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+            }
+
+            // Copy staging buffer → image
+            {
+                VkBufferImageCopy region{};
+                region.bufferOffset      = 0;
+                region.bufferRowLength   = imgWidth;
+                region.bufferImageHeight = imgHeight;
+                region.imageSubresource  = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+                region.imageOffset       = { 0, 0, 0 };
+                region.imageExtent       = { imgWidth, imgHeight, 1 };
+                vkCmdCopyBufferToImage(cmd, stagingBuffer, dstImage,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+            }
+
+            // Barrier: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
+            {
+                VkImageMemoryBarrier barrier{};
+                barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.newLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.image               = dstImage;
+                barrier.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+                barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+            }
+
+            if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkEndCommandBuffer failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            VkSubmitInfo si{};
+            si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            si.commandBufferCount = 1;
+            si.pCommandBuffers    = &cmd;
+
+            VkFence fence = VK_NULL_HANDLE;
+            VkFenceCreateInfo fenceCI{};
+            fenceCI.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            if (vkCreateFence(device, &fenceCI, nullptr, &fence) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkCreateFence failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            if (vkQueueSubmit(queue, 1, &si, fence) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[HeightmapLoader] vkQueueSubmit failed");
+                vkDestroyFence(device, fence, nullptr);
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+            vkDestroyFence(device, fence, nullptr);
+            vkDestroyCommandPool(device, pool, nullptr);
+
+            (void)dataSize;
+            return true;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // HeightmapLoader::LoadFromFile
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool HeightmapLoader::LoadFromFile(const std::string& fullPath, HeightmapData& outData)
+    {
+        LOG_INFO(Render, "[HeightmapLoader] Loading '{}'", fullPath);
+
+        std::ifstream file(fullPath, std::ios::binary);
+        if (!file.is_open())
+        {
+            LOG_WARN(Render, "[HeightmapLoader] File not found: '{}'", fullPath);
+            return false;
+        }
+
+        // Header: magic(4) + width(4) + height(4)
+        uint32_t magic = 0, width = 0, height = 0;
+        file.read(reinterpret_cast<char*>(&magic),  sizeof(magic));
+        file.read(reinterpret_cast<char*>(&width),  sizeof(width));
+        file.read(reinterpret_cast<char*>(&height), sizeof(height));
+
+        if (!file || magic != kHeightmapMagic || width == 0 || height == 0)
+        {
+            LOG_ERROR(Render,
+                "[HeightmapLoader] Invalid header (magic=0x{:08X} w={} h={})",
+                magic, width, height);
+            return false;
+        }
+
+        const size_t pixelCount = static_cast<size_t>(width) * height;
+        outData.width  = width;
+        outData.height = height;
+        outData.heights.resize(pixelCount);
+
+        file.read(reinterpret_cast<char*>(outData.heights.data()),
+                  static_cast<std::streamsize>(pixelCount * sizeof(uint16_t)));
+
+        if (!file)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Truncated file: '{}'", fullPath);
+            outData.heights.clear();
+            return false;
+        }
+
+        LOG_INFO(Render, "[HeightmapLoader] Loaded OK ({}x{}, {} pixels)", width, height, pixelCount);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // HeightmapLoader::UploadHeightmap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool HeightmapLoader::UploadHeightmap(VkDevice device, VkPhysicalDevice physDev,
+                                          const HeightmapData& data,
+                                          VkQueue queue, uint32_t queueFamilyIndex,
+                                          HeightmapGpu& outGpu)
+    {
+        LOG_INFO(Render, "[HeightmapLoader] UploadHeightmap {}x{}", data.width, data.height);
+
+        if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] UploadHeightmap: invalid device");
+            return false;
+        }
+        if (data.heights.empty())
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] UploadHeightmap: no data to upload");
+            return false;
+        }
+
+        const VkDeviceSize dataBytes =
+            static_cast<VkDeviceSize>(data.width) * data.height * sizeof(uint16_t);
+
+        // Create staging buffer
+        VkBuffer       stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, dataBytes, stagingBuf, stagingMem))
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Failed to create staging buffer");
+            return false;
+        }
+
+        // Copy pixel data into staging
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, dataBytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkMapMemory (staging) failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, data.heights.data(), static_cast<size_t>(dataBytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // Create DEVICE_LOCAL R16_UNORM image
+        if (!CreateOptimalImage(device, physDev,
+                                data.width, data.height,
+                                VK_FORMAT_R16_UNORM,
+                                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                outGpu.image, outGpu.memory))
+        {
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+
+        // Upload via staging
+        if (!UploadViaStaging(device, queue, queueFamilyIndex,
+                              stagingBuf, dataBytes,
+                              outGpu.image, data.width, data.height))
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Staging upload failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            DestroyHeightmap(device, outGpu);
+            return false;
+        }
+
+        // Clean up staging
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+
+        // Image view
+        VkImageViewCreateInfo viewCI{};
+        viewCI.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewCI.image                           = outGpu.image;
+        viewCI.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        viewCI.format                          = VK_FORMAT_R16_UNORM;
+        viewCI.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewCI.subresourceRange.baseMipLevel   = 0;
+        viewCI.subresourceRange.levelCount     = 1;
+        viewCI.subresourceRange.baseArrayLayer = 0;
+        viewCI.subresourceRange.layerCount     = 1;
+
+        if (vkCreateImageView(device, &viewCI, nullptr, &outGpu.view) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkCreateImageView failed");
+            DestroyHeightmap(device, outGpu);
+            return false;
+        }
+
+        // Sampler (linear, clamp-to-edge for heightmap boundaries)
+        VkSamplerCreateInfo sampCI{};
+        sampCI.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampCI.magFilter    = VK_FILTER_LINEAR;
+        sampCI.minFilter    = VK_FILTER_LINEAR;
+        sampCI.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        sampCI.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.maxLod       = 0.0f;
+
+        if (vkCreateSampler(device, &sampCI, nullptr, &outGpu.sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkCreateSampler failed");
+            DestroyHeightmap(device, outGpu);
+            return false;
+        }
+
+        outGpu.width  = data.width;
+        outGpu.height = data.height;
+        LOG_INFO(Render, "[HeightmapLoader] UploadHeightmap OK ({}x{})", data.width, data.height);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // HeightmapLoader::GenerateAndUploadNormalMap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool HeightmapLoader::GenerateAndUploadNormalMap(VkDevice device, VkPhysicalDevice physDev,
+                                                     const HeightmapData& data,
+                                                     float heightScale, float worldScale,
+                                                     VkQueue queue, uint32_t queueFamilyIndex,
+                                                     NormalMapGpu& outNormal)
+    {
+        LOG_INFO(Render, "[HeightmapLoader] GenerateNormalMap {}x{}", data.width, data.height);
+
+        if (data.heights.empty() || data.width < 3 || data.height < 3)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Heightmap too small for normal generation");
+            return false;
+        }
+
+        const uint32_t w = data.width;
+        const uint32_t h = data.height;
+        const float    invScale = heightScale / worldScale; // ratio of vertical to horizontal
+
+        // Generate RGBA8 normal map using Sobel filter
+        std::vector<uint8_t> normalPixels(static_cast<size_t>(w) * h * 4);
+
+        auto sampleH = [&](int x, int z) -> float {
+            x = (x < 0) ? 0 : ((x >= (int)w) ? (int)w - 1 : x);
+            z = (z < 0) ? 0 : ((z >= (int)h) ? (int)h - 1 : z);
+            return static_cast<float>(data.heights[static_cast<size_t>(z) * w + x]) / 65535.0f;
+        };
+
+        for (uint32_t zi = 0; zi < h; ++zi)
+        {
+            for (uint32_t xi = 0; xi < w; ++xi)
+            {
+                int ix = static_cast<int>(xi);
+                int iz = static_cast<int>(zi);
+
+                // Sobel X gradient (horizontal)
+                float gx = (sampleH(ix + 1, iz - 1) + 2.0f * sampleH(ix + 1, iz) + sampleH(ix + 1, iz + 1))
+                          - (sampleH(ix - 1, iz - 1) + 2.0f * sampleH(ix - 1, iz) + sampleH(ix - 1, iz + 1));
+                // Sobel Z gradient (depth)
+                float gz = (sampleH(ix - 1, iz + 1) + 2.0f * sampleH(ix, iz + 1) + sampleH(ix + 1, iz + 1))
+                          - (sampleH(ix - 1, iz - 1) + 2.0f * sampleH(ix, iz - 1) + sampleH(ix + 1, iz - 1));
+
+                // Scale by height-to-world ratio and negate for correct facing
+                gx *= invScale;
+                gz *= invScale;
+
+                // Normal = normalize(-Gx, 1.0, -Gz)  (Y-up, standard terrain convention)
+                float nx = -gx;
+                float ny = 1.0f;
+                float nz = -gz;
+                float len = std::sqrt(nx * nx + ny * ny + nz * nz);
+                if (len > 0.0f) { nx /= len; ny /= len; nz /= len; }
+                else             { nx = 0.0f; ny = 1.0f; nz = 0.0f; }
+
+                // Encode as RGBA8: N * 0.5 + 0.5, A=255
+                const size_t idx = (static_cast<size_t>(zi) * w + xi) * 4;
+                normalPixels[idx + 0] = static_cast<uint8_t>((nx * 0.5f + 0.5f) * 255.0f);
+                normalPixels[idx + 1] = static_cast<uint8_t>((ny * 0.5f + 0.5f) * 255.0f);
+                normalPixels[idx + 2] = static_cast<uint8_t>((nz * 0.5f + 0.5f) * 255.0f);
+                normalPixels[idx + 3] = 255u;
+            }
+        }
+
+        const VkDeviceSize dataBytes = static_cast<VkDeviceSize>(w) * h * 4;
+
+        // Staging buffer
+        VkBuffer       stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, dataBytes, stagingBuf, stagingMem))
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Failed to create normal map staging buffer");
+            return false;
+        }
+
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, dataBytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkMapMemory (normal staging) failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, normalPixels.data(), static_cast<size_t>(dataBytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // Create DEVICE_LOCAL RGBA8_UNORM image
+        if (!CreateOptimalImage(device, physDev, w, h,
+                                VK_FORMAT_R8G8B8A8_UNORM,
+                                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                outNormal.image, outNormal.memory))
+        {
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+
+        if (!UploadViaStaging(device, queue, queueFamilyIndex,
+                              stagingBuf, dataBytes, outNormal.image, w, h))
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] Normal map staging upload failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            DestroyNormalMap(device, outNormal);
+            return false;
+        }
+
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+
+        // Image view
+        VkImageViewCreateInfo viewCI{};
+        viewCI.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewCI.image                           = outNormal.image;
+        viewCI.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        viewCI.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+        viewCI.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewCI.subresourceRange.baseMipLevel   = 0;
+        viewCI.subresourceRange.levelCount     = 1;
+        viewCI.subresourceRange.baseArrayLayer = 0;
+        viewCI.subresourceRange.layerCount     = 1;
+
+        if (vkCreateImageView(device, &viewCI, nullptr, &outNormal.view) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkCreateImageView (normal) failed");
+            DestroyNormalMap(device, outNormal);
+            return false;
+        }
+
+        // Sampler (bilinear, clamp-to-edge)
+        VkSamplerCreateInfo sampCI{};
+        sampCI.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampCI.magFilter    = VK_FILTER_LINEAR;
+        sampCI.minFilter    = VK_FILTER_LINEAR;
+        sampCI.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        sampCI.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.maxLod       = 0.0f;
+
+        if (vkCreateSampler(device, &sampCI, nullptr, &outNormal.sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[HeightmapLoader] vkCreateSampler (normal) failed");
+            DestroyNormalMap(device, outNormal);
+            return false;
+        }
+
+        LOG_INFO(Render, "[HeightmapLoader] Normal map GPU upload OK ({}x{})", w, h);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Destroy helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void HeightmapLoader::DestroyHeightmap(VkDevice device, HeightmapGpu& gpu)
+    {
+        if (gpu.sampler != VK_NULL_HANDLE) { vkDestroySampler(device, gpu.sampler, nullptr); gpu.sampler = VK_NULL_HANDLE; }
+        if (gpu.view    != VK_NULL_HANDLE) { vkDestroyImageView(device, gpu.view, nullptr);  gpu.view    = VK_NULL_HANDLE; }
+        if (gpu.image   != VK_NULL_HANDLE) { vkDestroyImage(device, gpu.image, nullptr);     gpu.image   = VK_NULL_HANDLE; }
+        if (gpu.memory  != VK_NULL_HANDLE) { vkFreeMemory(device, gpu.memory, nullptr);      gpu.memory  = VK_NULL_HANDLE; }
+        gpu.width = gpu.height = 0;
+        LOG_INFO(Render, "[HeightmapLoader] HeightmapGpu destroyed");
+    }
+
+    void HeightmapLoader::DestroyNormalMap(VkDevice device, NormalMapGpu& nm)
+    {
+        if (nm.sampler != VK_NULL_HANDLE) { vkDestroySampler(device, nm.sampler, nullptr); nm.sampler = VK_NULL_HANDLE; }
+        if (nm.view    != VK_NULL_HANDLE) { vkDestroyImageView(device, nm.view, nullptr);  nm.view    = VK_NULL_HANDLE; }
+        if (nm.image   != VK_NULL_HANDLE) { vkDestroyImage(device, nm.image, nullptr);     nm.image   = VK_NULL_HANDLE; }
+        if (nm.memory  != VK_NULL_HANDLE) { vkFreeMemory(device, nm.memory, nullptr);      nm.memory  = VK_NULL_HANDLE; }
+        LOG_INFO(Render, "[HeightmapLoader] NormalMapGpu destroyed");
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/HeightmapLoader.h
+++ b/engine/render/terrain/HeightmapLoader.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::render::terrain
+{
+    /// Binary format for .r16h heightmap files (little-endian):
+    ///   magic  : uint32  = 0x504D4148 ("HAMP")
+    ///   width  : uint32
+    ///   height : uint32
+    ///   data   : uint16[width * height]  (row-major, z * width + x)
+    static constexpr uint32_t kHeightmapMagic = 0x504D4148u; // 'HAMP'
+
+    /// CPU-side R16 heightmap data.
+    struct HeightmapData
+    {
+        uint32_t width  = 0;
+        uint32_t height = 0;
+        /// Row-major pixel array, index = z * width + x.
+        std::vector<uint16_t> heights;
+
+        /// Returns normalized height [0.0, 1.0] at (x, z). Clamps to bounds.
+        float Sample(uint32_t x, uint32_t z) const;
+    };
+
+    /// GPU R16_UNORM heightmap texture (DEVICE_LOCAL, OPTIMAL tiling).
+    struct HeightmapGpu
+    {
+        VkImage        image   = VK_NULL_HANDLE;
+        VkImageView    view    = VK_NULL_HANDLE;
+        VkDeviceMemory memory  = VK_NULL_HANDLE;
+        VkSampler      sampler = VK_NULL_HANDLE;
+        uint32_t       width   = 0;
+        uint32_t       height  = 0;
+    };
+
+    /// GPU RGBA8_UNORM normal map texture (DEVICE_LOCAL, OPTIMAL tiling).
+    /// RGB channels encode the normal as N * 0.5 + 0.5; A = 1.
+    struct NormalMapGpu
+    {
+        VkImage        image   = VK_NULL_HANDLE;
+        VkImageView    view    = VK_NULL_HANDLE;
+        VkDeviceMemory memory  = VK_NULL_HANDLE;
+        VkSampler      sampler = VK_NULL_HANDLE;
+    };
+
+    /// Loads R16 heightmaps from disk and uploads them to the GPU as sampled textures.
+    /// Uses raw Vulkan allocations (no VMA). Uploads via staging buffer + one-time command buffer.
+    class HeightmapLoader
+    {
+    public:
+        HeightmapLoader() = delete;
+
+        /// Loads a heightmap from a .r16h binary file.
+        /// \param fullPath  Resolved filesystem path to the file.
+        /// \param outData   Populated on success.
+        /// \return true on success.
+        static bool LoadFromFile(const std::string& fullPath, HeightmapData& outData);
+
+        /// Creates a GPU R16_UNORM texture from CPU data via staging upload.
+        /// The resulting image is in SHADER_READ_ONLY_OPTIMAL layout.
+        /// \param queue              Graphics queue used for the one-time copy command.
+        /// \param queueFamilyIndex   Family index of the graphics queue.
+        /// \return true on success.
+        static bool UploadHeightmap(VkDevice device, VkPhysicalDevice physDev,
+                                    const HeightmapData& data,
+                                    VkQueue queue, uint32_t queueFamilyIndex,
+                                    HeightmapGpu& outGpu);
+
+        /// Generates a Sobel-filtered normal map from CPU heightmap data and uploads it
+        /// as RGBA8_UNORM. The resulting image is in SHADER_READ_ONLY_OPTIMAL layout.
+        /// \param heightScale  World units for maximum height (for realistic slope angle).
+        /// \param worldScale   World units per heightmap texel (horizontal spacing).
+        static bool GenerateAndUploadNormalMap(VkDevice device, VkPhysicalDevice physDev,
+                                               const HeightmapData& data,
+                                               float heightScale, float worldScale,
+                                               VkQueue queue, uint32_t queueFamilyIndex,
+                                               NormalMapGpu& outNormal);
+
+        /// Destroys GPU heightmap resources. Safe to call on null handles.
+        static void DestroyHeightmap(VkDevice device, HeightmapGpu& gpu);
+
+        /// Destroys GPU normal map resources. Safe to call on null handles.
+        static void DestroyNormalMap(VkDevice device, NormalMapGpu& gpu);
+    };
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainMesh.cpp
+++ b/engine/render/terrain/TerrainMesh.cpp
@@ -1,0 +1,227 @@
+#include "engine/render/terrain/TerrainMesh.h"
+#include "engine/core/Log.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstring>
+#include <vector>
+
+namespace engine::render::terrain
+{
+    namespace
+    {
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Allocates a HOST_VISIBLE|HOST_COHERENT buffer and copies data into it.
+        bool CreateAndFillBuffer(VkDevice device, VkPhysicalDevice physDev,
+                                 VkDeviceSize size, VkBufferUsageFlags usage,
+                                 const void* srcData,
+                                 VkBuffer& outBuffer, VkDeviceMemory& outMemory)
+        {
+            VkBufferCreateInfo bi{};
+            bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bi.size        = size;
+            bi.usage       = usage;
+            bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bi, nullptr, &outBuffer) != VK_SUCCESS ||
+                outBuffer == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainMesh] vkCreateBuffer failed (size={} usage=0x{:x})",
+                          size, usage);
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, outBuffer, &req);
+
+            const uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainMesh] No HOST_VISIBLE memory type available");
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMemory) != VK_SUCCESS ||
+                outMemory == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainMesh] vkAllocateMemory failed");
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindBufferMemory(device, outBuffer, outMemory, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainMesh] vkBindBufferMemory failed");
+                vkFreeMemory(device, outMemory, nullptr);
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                outMemory = VK_NULL_HANDLE;
+                return false;
+            }
+
+            void* mapped = nullptr;
+            if (vkMapMemory(device, outMemory, 0, size, 0, &mapped) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainMesh] vkMapMemory failed");
+                vkFreeMemory(device, outMemory, nullptr);
+                vkDestroyBuffer(device, outBuffer, nullptr);
+                outBuffer = VK_NULL_HANDLE;
+                outMemory = VK_NULL_HANDLE;
+                return false;
+            }
+            std::memcpy(mapped, srcData, static_cast<size_t>(size));
+            vkUnmapMemory(device, outMemory);
+            return true;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainMesh::Generate
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainMesh::Generate(VkDevice device, VkPhysicalDevice physDev,
+                               TerrainMeshGpu& outMesh)
+    {
+        LOG_INFO(Render, "[TerrainMesh] Generating patch mesh ({} vertices, {} LODs)",
+                 kPatchVertexCount, kTerrainLodCount);
+
+        if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE)
+        {
+            LOG_ERROR(Render, "[TerrainMesh] Generate: invalid device");
+            return false;
+        }
+
+        // ── Vertex buffer: kPatchVerts × kPatchVerts vec2 positions ──────────────
+        // Each vertex stores its raw local XZ position in [0, kPatchQuads].
+        std::vector<TerrainVertex> vertices(kPatchVertexCount);
+        for (uint32_t z = 0; z < kPatchVerts; ++z)
+        {
+            for (uint32_t x = 0; x < kPatchVerts; ++x)
+            {
+                const uint32_t idx = z * kPatchVerts + x;
+                vertices[idx].x = static_cast<float>(x);
+                vertices[idx].z = static_cast<float>(z);
+            }
+        }
+
+        const VkDeviceSize vertexBytes =
+            static_cast<VkDeviceSize>(kPatchVertexCount) * sizeof(TerrainVertex);
+
+        if (!CreateAndFillBuffer(device, physDev, vertexBytes,
+                                 VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                                 vertices.data(),
+                                 outMesh.vertexBuffer, outMesh.vertexMemory))
+        {
+            LOG_ERROR(Render, "[TerrainMesh] Failed to create vertex buffer");
+            return false;
+        }
+        outMesh.vertexCount = kPatchVertexCount;
+        LOG_DEBUG(Render, "[TerrainMesh] Vertex buffer OK ({} bytes)", vertexBytes);
+
+        // ── Index buffers: one per LOD ────────────────────────────────────────────
+        // LOD N uses step S = 2^N.  Only vertices at (x,z) where x%S==0 && z%S==0 are used.
+        // Winding order: CCW when viewed from above (Y-up, camera looking down).
+        // Vertex at (x, z) in the 17×17 grid → index = x + z × kPatchVerts.
+        for (uint32_t lod = 0; lod < kTerrainLodCount; ++lod)
+        {
+            const uint32_t step    = (1u << lod); // 1, 2, 4, 8, 16
+            const uint32_t quads   = kPatchQuads / step;
+            const uint32_t triIdx  = quads * quads * 6u;
+
+            std::vector<uint16_t> indices(triIdx);
+            uint32_t k = 0;
+            for (uint32_t qz = 0; qz < quads; ++qz)
+            {
+                for (uint32_t qx = 0; qx < quads; ++qx)
+                {
+                    // Four corners of the quad (in the 17×17 grid)
+                    const uint16_t bl = static_cast<uint16_t>( qx      * step + (qz      * step) * kPatchVerts);
+                    const uint16_t br = static_cast<uint16_t>((qx + 1) * step + (qz      * step) * kPatchVerts);
+                    const uint16_t tl = static_cast<uint16_t>( qx      * step + ((qz + 1) * step) * kPatchVerts);
+                    const uint16_t tr = static_cast<uint16_t>((qx + 1) * step + ((qz + 1) * step) * kPatchVerts);
+
+                    // Two triangles (CCW from above)
+                    indices[k++] = bl; indices[k++] = tl; indices[k++] = tr;
+                    indices[k++] = bl; indices[k++] = tr; indices[k++] = br;
+                }
+            }
+
+            const VkDeviceSize indexBytes =
+                static_cast<VkDeviceSize>(triIdx) * sizeof(uint16_t);
+
+            if (!CreateAndFillBuffer(device, physDev, indexBytes,
+                                     VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+                                     indices.data(),
+                                     outMesh.lod[lod].buffer, outMesh.lod[lod].memory))
+            {
+                LOG_ERROR(Render, "[TerrainMesh] Failed to create LOD {} index buffer", lod);
+                Destroy(device, outMesh);
+                return false;
+            }
+            outMesh.lod[lod].indexCount = triIdx;
+            LOG_DEBUG(Render, "[TerrainMesh] LOD {} index buffer OK (step={} quads={}×{} indices={})",
+                      lod, step, quads, quads, triIdx);
+        }
+
+        LOG_INFO(Render, "[TerrainMesh] Generate OK");
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainMesh::Destroy
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainMesh::Destroy(VkDevice device, TerrainMeshGpu& mesh)
+    {
+        for (uint32_t lod = 0; lod < kTerrainLodCount; ++lod)
+        {
+            if (mesh.lod[lod].buffer != VK_NULL_HANDLE)
+            {
+                vkDestroyBuffer(device, mesh.lod[lod].buffer, nullptr);
+                mesh.lod[lod].buffer = VK_NULL_HANDLE;
+            }
+            if (mesh.lod[lod].memory != VK_NULL_HANDLE)
+            {
+                vkFreeMemory(device, mesh.lod[lod].memory, nullptr);
+                mesh.lod[lod].memory = VK_NULL_HANDLE;
+            }
+            mesh.lod[lod].indexCount = 0;
+        }
+        if (mesh.vertexBuffer != VK_NULL_HANDLE)
+        {
+            vkDestroyBuffer(device, mesh.vertexBuffer, nullptr);
+            mesh.vertexBuffer = VK_NULL_HANDLE;
+        }
+        if (mesh.vertexMemory != VK_NULL_HANDLE)
+        {
+            vkFreeMemory(device, mesh.vertexMemory, nullptr);
+            mesh.vertexMemory = VK_NULL_HANDLE;
+        }
+        mesh.vertexCount = 0;
+        LOG_INFO(Render, "[TerrainMesh] Destroyed");
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainMesh.h
+++ b/engine/render/terrain/TerrainMesh.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::render::terrain
+{
+    /// Number of quads per patch side at LOD 0.
+    static constexpr uint32_t kPatchQuads = 16u;
+    /// Number of vertices per patch side = kPatchQuads + 1.
+    static constexpr uint32_t kPatchVerts = kPatchQuads + 1u; // 17
+    /// Total vertices in the shared patch vertex buffer.
+    static constexpr uint32_t kPatchVertexCount = kPatchVerts * kPatchVerts; // 289
+    /// Number of LOD levels supported.
+    static constexpr uint32_t kTerrainLodCount = 5u;
+
+    /// A single terrain vertex: local patch XZ position in [0, kPatchQuads].
+    struct TerrainVertex
+    {
+        float x = 0.0f; ///< Local X in [0, kPatchQuads]
+        float z = 0.0f; ///< Local Z in [0, kPatchQuads]
+    };
+
+    /// GPU index buffer for one LOD level.
+    struct TerrainLodBuffer
+    {
+        VkBuffer       buffer     = VK_NULL_HANDLE;
+        VkDeviceMemory memory     = VK_NULL_HANDLE;
+        uint32_t       indexCount = 0;
+    };
+
+    /// All GPU mesh resources for a single terrain patch.
+    /// One shared vertex buffer (kPatchVertexCount vertices) and kTerrainLodCount index buffers.
+    struct TerrainMeshGpu
+    {
+        VkBuffer         vertexBuffer = VK_NULL_HANDLE;
+        VkDeviceMemory   vertexMemory = VK_NULL_HANDLE;
+        uint32_t         vertexCount  = 0;
+        TerrainLodBuffer lod[kTerrainLodCount];
+    };
+
+    /// Generates the terrain patch mesh on the GPU.
+    ///
+    /// Vertex buffer: kPatchVertexCount vertices, each a vec2 (local XZ in [0, kPatchQuads]).
+    /// Index buffer per LOD: LOD N uses step S = 2^N, resulting in (kPatchQuads/S)^2 quads.
+    ///   LOD 0 → 16×16 quads → 1536 uint16 indices
+    ///   LOD 1 → 8×8  quads → 384  uint16 indices
+    ///   LOD 2 → 4×4  quads → 96   uint16 indices
+    ///   LOD 3 → 2×2  quads → 24   uint16 indices
+    ///   LOD 4 → 1×1  quad  → 6    uint16 indices
+    ///
+    /// Uses HOST_VISIBLE | HOST_COHERENT memory (raw Vulkan, no VMA).
+    class TerrainMesh
+    {
+    public:
+        TerrainMesh() = delete;
+
+        /// Allocates and fills all GPU buffers for a terrain patch.
+        /// \return true on success.
+        static bool Generate(VkDevice device, VkPhysicalDevice physDev,
+                             TerrainMeshGpu& outMesh);
+
+        /// Releases all GPU mesh resources. Safe on null handles.
+        static void Destroy(VkDevice device, TerrainMeshGpu& mesh);
+    };
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -1,0 +1,824 @@
+#include "engine/render/terrain/TerrainRenderer.h"
+#include "engine/core/Config.h"
+#include "engine/core/Log.h"
+#include "engine/platform/FileSystem.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Framebuffer key comparison / hash
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainRenderer::FramebufferKey::operator==(const FramebufferKey& o) const
+    {
+        if (renderPass != o.renderPass || width != o.width || height != o.height)
+            return false;
+        for (int i = 0; i < 5; ++i)
+            if (views[i] != o.views[i]) return false;
+        return true;
+    }
+
+    size_t TerrainRenderer::FramebufferKeyHash::operator()(const FramebufferKey& k) const
+    {
+        size_t h = reinterpret_cast<size_t>(k.renderPass);
+        for (int i = 0; i < 5; ++i)
+            h ^= reinterpret_cast<size_t>(k.views[i]) + 0x9e3779b9u + (h << 6) + (h >> 2);
+        h ^= static_cast<size_t>(k.width)  * 0x45d9f3bu;
+        h ^= static_cast<size_t>(k.height) * 0x2c6fe96eu;
+        return h;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainRenderer::Init
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainRenderer::Init(VkDevice device, VkPhysicalDevice physDev,
+                               const engine::core::Config& config,
+                               const std::string& heightmapRelPath,
+                               VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
+                               VkFormat fmtVelocity, VkFormat fmtDepth,
+                               VkQueue queue, uint32_t queueFamilyIndex,
+                               ShaderLoaderFn loadSpirv)
+    {
+        LOG_INFO(Render, "[TerrainRenderer] Init begin (heightmap='{}')", heightmapRelPath);
+
+        if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE || !loadSpirv)
+        {
+            LOG_ERROR(Render, "[TerrainRenderer] Init: invalid parameters");
+            return false;
+        }
+
+        // ── Read terrain config ───────────────────────────────────────────────────
+        m_terrainWorldSize = static_cast<float>(config.GetDouble("terrain.world_size", 1024.0));
+        m_heightScale      = static_cast<float>(config.GetDouble("terrain.height_scale", 200.0));
+        m_terrainOriginX   = static_cast<float>(config.GetDouble("terrain.origin_x", -512.0));
+        m_terrainOriginZ   = static_cast<float>(config.GetDouble("terrain.origin_z", -512.0));
+
+        if (m_terrainWorldSize <= 0.0f)
+        {
+            LOG_ERROR(Render, "[TerrainRenderer] terrain.world_size must be > 0 (got {})",
+                      m_terrainWorldSize);
+            return false;
+        }
+
+        // vertStepWorld = world units per local vertex step at LOD 0
+        // For a 1025-pixel heightmap, there are 1024 inter-pixel gaps = kPatchQuads * patchCount gaps.
+        m_vertStepWorld = m_terrainWorldSize / static_cast<float>(1024u); // 1024 = 64×16
+
+        // ── Load heightmap from file ──────────────────────────────────────────────
+        {
+            const std::string contentPath = config.GetString("paths.content", "game/data");
+            const std::string fullPath    = contentPath + "/" + heightmapRelPath;
+
+            if (!HeightmapLoader::LoadFromFile(fullPath, m_heightmapData))
+            {
+                LOG_WARN(Render,
+                    "[TerrainRenderer] Heightmap '{}' not found — terrain will be flat placeholder",
+                    heightmapRelPath);
+                // Synthesise a 1025×1025 flat (zero) heightmap as fallback
+                m_heightmapData.width  = 1025u;
+                m_heightmapData.height = 1025u;
+                m_heightmapData.heights.assign(1025u * 1025u, 0u);
+            }
+        }
+
+        // ── Upload heightmap to GPU ───────────────────────────────────────────────
+        if (!HeightmapLoader::UploadHeightmap(device, physDev, m_heightmapData,
+                                              queue, queueFamilyIndex, m_heightmapGpu))
+        {
+            LOG_ERROR(Render, "[TerrainRenderer] Failed to upload heightmap to GPU");
+            Destroy(device);
+            return false;
+        }
+
+        // ── Generate & upload normal map ──────────────────────────────────────────
+        if (!HeightmapLoader::GenerateAndUploadNormalMap(device, physDev, m_heightmapData,
+                                                         m_heightScale, m_vertStepWorld,
+                                                         queue, queueFamilyIndex, m_normalMapGpu))
+        {
+            LOG_ERROR(Render, "[TerrainRenderer] Failed to generate/upload normal map");
+            Destroy(device);
+            return false;
+        }
+
+        // ── Generate patch mesh (shared vertex buffer + per-LOD index buffers) ────
+        if (!TerrainMesh::Generate(device, physDev, m_meshGpu))
+        {
+            LOG_ERROR(Render, "[TerrainRenderer] Failed to generate terrain mesh");
+            Destroy(device);
+            return false;
+        }
+
+        // ── Build patch list ──────────────────────────────────────────────────────
+        // Number of patches: (heightmap_pixels - 1) / kPatchQuads per axis
+        m_patchCountX = (m_heightmapData.width  - 1u) / kPatchQuads;
+        m_patchCountZ = (m_heightmapData.height - 1u) / kPatchQuads;
+        const uint32_t totalPatches = m_patchCountX * m_patchCountZ;
+        m_patches.resize(totalPatches);
+
+        const float patchWorldSize = static_cast<float>(kPatchQuads) * m_vertStepWorld;
+
+        for (uint32_t pz = 0; pz < m_patchCountZ; ++pz)
+        {
+            for (uint32_t px = 0; px < m_patchCountX; ++px)
+            {
+                TerrainPatchInfo& p = m_patches[pz * m_patchCountX + px];
+                p.originX = m_terrainOriginX + static_cast<float>(px) * patchWorldSize;
+                p.originZ = m_terrainOriginZ + static_cast<float>(pz) * patchWorldSize;
+                p.centerX = p.originX + patchWorldSize * 0.5f;
+                p.centerZ = p.originZ + patchWorldSize * 0.5f;
+
+                // Compute Y bounds by sampling the 4 patch corners
+                const uint32_t hx0 = px * kPatchQuads;
+                const uint32_t hz0 = pz * kPatchQuads;
+                const uint32_t hx1 = hx0 + kPatchQuads;
+                const uint32_t hz1 = hz0 + kPatchQuads;
+
+                const float h00 = m_heightmapData.Sample(hx0, hz0) * m_heightScale;
+                const float h10 = m_heightmapData.Sample(hx1, hz0) * m_heightScale;
+                const float h01 = m_heightmapData.Sample(hx0, hz1) * m_heightScale;
+                const float h11 = m_heightmapData.Sample(hx1, hz1) * m_heightScale;
+
+                p.minY = std::min({ h00, h10, h01, h11 });
+                p.maxY = std::max({ h00, h10, h01, h11 });
+                // Add a margin for interpolated heights between corners
+                const float margin = m_heightScale * 0.05f;
+                p.minY -= margin;
+                p.maxY += margin;
+            }
+        }
+        LOG_DEBUG(Render, "[TerrainRenderer] Patch list built: {}×{} = {} patches",
+                  m_patchCountX, m_patchCountZ, totalPatches);
+
+        // ── Create render pass ────────────────────────────────────────────────────
+        {
+            // 5 attachments: A, B, C, Velocity (color), Depth
+            VkAttachmentDescription attachments[5]{};
+
+            // Color attachments 0-3
+            const VkFormat colorFmts[4] = { fmtA, fmtB, fmtC, fmtVelocity };
+            for (int i = 0; i < 4; ++i)
+            {
+                attachments[i].format         = colorFmts[i];
+                attachments[i].samples        = VK_SAMPLE_COUNT_1_BIT;
+                attachments[i].loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
+                attachments[i].storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+                attachments[i].stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+                attachments[i].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+                attachments[i].initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+                attachments[i].finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            }
+            // Depth attachment
+            attachments[4].format         = fmtDepth;
+            attachments[4].samples        = VK_SAMPLE_COUNT_1_BIT;
+            attachments[4].loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
+            attachments[4].storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+            attachments[4].stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+            attachments[4].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachments[4].initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+            attachments[4].finalLayout    = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+            VkAttachmentReference colorRefs[4]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                colorRefs[i].attachment = static_cast<uint32_t>(i);
+                colorRefs[i].layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            }
+            VkAttachmentReference depthRef{};
+            depthRef.attachment = 4;
+            depthRef.layout     = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+            VkSubpassDescription subpass{};
+            subpass.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS;
+            subpass.colorAttachmentCount    = 4;
+            subpass.pColorAttachments       = colorRefs;
+            subpass.pDepthStencilAttachment = &depthRef;
+
+            VkSubpassDependency dep{};
+            dep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+            dep.dstSubpass    = 0;
+            dep.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            dep.dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            dep.srcAccessMask = 0;
+            dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+            VkRenderPassCreateInfo rpCI{};
+            rpCI.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+            rpCI.attachmentCount = 5;
+            rpCI.pAttachments    = attachments;
+            rpCI.subpassCount    = 1;
+            rpCI.pSubpasses      = &subpass;
+            rpCI.dependencyCount = 1;
+            rpCI.pDependencies   = &dep;
+
+            if (vkCreateRenderPass(device, &rpCI, nullptr, &m_renderPass) != VK_SUCCESS ||
+                m_renderPass == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateRenderPass failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Descriptor set layout ─────────────────────────────────────────────────
+        {
+            VkDescriptorSetLayoutBinding bindings[3]{};
+            // binding 0: heightmap sampler (vertex + fragment)
+            bindings[0].binding            = 0;
+            bindings[0].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[0].descriptorCount    = 1;
+            bindings[0].stageFlags         = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 1: normal map sampler (fragment)
+            bindings[1].binding            = 1;
+            bindings[1].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[1].descriptorCount    = 1;
+            bindings[1].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 2: per-frame UBO (vertex + fragment)
+            bindings[2].binding            = 2;
+            bindings[2].descriptorType     = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            bindings[2].descriptorCount    = 1;
+            bindings[2].stageFlags         = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+
+            VkDescriptorSetLayoutCreateInfo dslCI{};
+            dslCI.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            dslCI.bindingCount = 3;
+            dslCI.pBindings    = bindings;
+
+            if (vkCreateDescriptorSetLayout(device, &dslCI, nullptr, &m_descSetLayout) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateDescriptorSetLayout failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Pipeline layout ───────────────────────────────────────────────────────
+        {
+            VkPushConstantRange pcRange{};
+            pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+            pcRange.offset     = 0;
+            pcRange.size       = sizeof(PushConstants); // 16 bytes
+
+            VkPipelineLayoutCreateInfo plCI{};
+            plCI.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            plCI.setLayoutCount         = 1;
+            plCI.pSetLayouts            = &m_descSetLayout;
+            plCI.pushConstantRangeCount = 1;
+            plCI.pPushConstantRanges    = &pcRange;
+
+            if (vkCreatePipelineLayout(device, &plCI, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreatePipelineLayout failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Load shaders ──────────────────────────────────────────────────────────
+        std::vector<uint32_t> vertSpirv = loadSpirv("shaders/terrain.vert.spv");
+        std::vector<uint32_t> fragSpirv = loadSpirv("shaders/terrain.frag.spv");
+
+        if (vertSpirv.empty() || fragSpirv.empty())
+        {
+            LOG_WARN(Render,
+                "[TerrainRenderer] terrain shaders not found (vert={} frag={}) — skipping Init",
+                vertSpirv.empty() ? "MISSING" : "OK",
+                fragSpirv.empty() ? "MISSING" : "OK");
+            // Graceful skip: terrain disabled if shaders are absent
+            Destroy(device);
+            return false;
+        }
+
+        VkShaderModule vertMod = VK_NULL_HANDLE, fragMod = VK_NULL_HANDLE;
+        {
+            VkShaderModuleCreateInfo smCI{};
+            smCI.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+            smCI.codeSize = vertSpirv.size() * sizeof(uint32_t);
+            smCI.pCode    = vertSpirv.data();
+            if (vkCreateShaderModule(device, &smCI, nullptr, &vertMod) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateShaderModule (vert) failed");
+                Destroy(device);
+                return false;
+            }
+            smCI.codeSize = fragSpirv.size() * sizeof(uint32_t);
+            smCI.pCode    = fragSpirv.data();
+            if (vkCreateShaderModule(device, &smCI, nullptr, &fragMod) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateShaderModule (frag) failed");
+                vkDestroyShaderModule(device, vertMod, nullptr);
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Create pipeline ───────────────────────────────────────────────────────
+        {
+            VkPipelineShaderStageCreateInfo stages[2]{};
+            stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+            stages[0].module = vertMod;
+            stages[0].pName  = "main";
+            stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+            stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+            stages[1].module = fragMod;
+            stages[1].pName  = "main";
+
+            // Vertex input: binding 0, stride=sizeof(TerrainVertex), per-vertex
+            VkVertexInputBindingDescription vertBinding{};
+            vertBinding.binding   = 0;
+            vertBinding.stride    = sizeof(TerrainVertex); // 8 bytes
+            vertBinding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+            VkVertexInputAttributeDescription vertAttr{};
+            vertAttr.location = 0;
+            vertAttr.binding  = 0;
+            vertAttr.format   = VK_FORMAT_R32G32_SFLOAT;
+            vertAttr.offset   = 0;
+
+            VkPipelineVertexInputStateCreateInfo visCI{};
+            visCI.sType                           = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+            visCI.vertexBindingDescriptionCount   = 1;
+            visCI.pVertexBindingDescriptions      = &vertBinding;
+            visCI.vertexAttributeDescriptionCount = 1;
+            visCI.pVertexAttributeDescriptions    = &vertAttr;
+
+            VkPipelineInputAssemblyStateCreateInfo iasCI{};
+            iasCI.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+            iasCI.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+            VkPipelineViewportStateCreateInfo vpCI{};
+            vpCI.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+            vpCI.viewportCount = 1;
+            vpCI.scissorCount  = 1;
+
+            VkPipelineRasterizationStateCreateInfo rasCI{};
+            rasCI.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+            rasCI.polygonMode = VK_POLYGON_MODE_FILL;
+            rasCI.cullMode    = VK_CULL_MODE_BACK_BIT;
+            rasCI.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+            rasCI.lineWidth   = 1.0f;
+
+            VkPipelineMultisampleStateCreateInfo msCI{};
+            msCI.sType               = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+            msCI.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+            VkPipelineDepthStencilStateCreateInfo dsCI{};
+            dsCI.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+            dsCI.depthTestEnable  = VK_TRUE;
+            dsCI.depthWriteEnable = VK_TRUE;
+            dsCI.depthCompareOp   = VK_COMPARE_OP_LESS;
+
+            // 4 color attachments (A, B, C, Velocity) — no blending
+            VkPipelineColorBlendAttachmentState blendAtts[4]{};
+            for (int i = 0; i < 4; ++i)
+            {
+                blendAtts[i].colorWriteMask =
+                    VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                    VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+                blendAtts[i].blendEnable = VK_FALSE;
+            }
+            VkPipelineColorBlendStateCreateInfo cbCI{};
+            cbCI.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+            cbCI.attachmentCount = 4;
+            cbCI.pAttachments    = blendAtts;
+
+            VkDynamicState dynStates[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+            VkPipelineDynamicStateCreateInfo dynCI{};
+            dynCI.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+            dynCI.dynamicStateCount = 2;
+            dynCI.pDynamicStates    = dynStates;
+
+            VkGraphicsPipelineCreateInfo gpCI{};
+            gpCI.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+            gpCI.stageCount          = 2;
+            gpCI.pStages             = stages;
+            gpCI.pVertexInputState   = &visCI;
+            gpCI.pInputAssemblyState = &iasCI;
+            gpCI.pViewportState      = &vpCI;
+            gpCI.pRasterizationState = &rasCI;
+            gpCI.pMultisampleState   = &msCI;
+            gpCI.pDepthStencilState  = &dsCI;
+            gpCI.pColorBlendState    = &cbCI;
+            gpCI.pDynamicState       = &dynCI;
+            gpCI.layout              = m_pipelineLayout;
+            gpCI.renderPass          = m_renderPass;
+            gpCI.subpass             = 0;
+
+            const VkResult pipeRes =
+                vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &gpCI, nullptr, &m_pipeline);
+
+            vkDestroyShaderModule(device, vertMod, nullptr);
+            vkDestroyShaderModule(device, fragMod, nullptr);
+
+            if (pipeRes != VK_SUCCESS || m_pipeline == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateGraphicsPipelines failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Create descriptor pool ────────────────────────────────────────────────
+        {
+            VkDescriptorPoolSize poolSizes[2]{};
+            poolSizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            poolSizes[0].descriptorCount = 2; // heightmap + normalmap
+            poolSizes[1].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            poolSizes[1].descriptorCount = 1;
+
+            VkDescriptorPoolCreateInfo dpCI{};
+            dpCI.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            dpCI.maxSets       = 1;
+            dpCI.poolSizeCount = 2;
+            dpCI.pPoolSizes    = poolSizes;
+
+            if (vkCreateDescriptorPool(device, &dpCI, nullptr, &m_descPool) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateDescriptorPool failed");
+                Destroy(device);
+                return false;
+            }
+
+            VkDescriptorSetAllocateInfo dsAI{};
+            dsAI.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            dsAI.descriptorPool     = m_descPool;
+            dsAI.descriptorSetCount = 1;
+            dsAI.pSetLayouts        = &m_descSetLayout;
+
+            if (vkAllocateDescriptorSets(device, &dsAI, &m_descSet) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkAllocateDescriptorSets failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Create per-frame UBO ──────────────────────────────────────────────────
+        {
+            const VkDeviceSize uboSize = sizeof(FrameUbo);
+            VkBufferCreateInfo bi{};
+            bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bi.size        = uboSize;
+            bi.usage       = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+            bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bi, nullptr, &m_uboBuffer) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateBuffer (UBO) failed");
+                Destroy(device);
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, m_uboBuffer, &req);
+
+            const uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] No HOST_VISIBLE memory for UBO");
+                Destroy(device);
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &m_uboMemory) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkAllocateMemory (UBO) failed");
+                Destroy(device);
+                return false;
+            }
+
+            if (vkBindBufferMemory(device, m_uboBuffer, m_uboMemory, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkBindBufferMemory (UBO) failed");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // ── Write descriptor set ──────────────────────────────────────────────────
+        {
+            VkDescriptorImageInfo heightmapInfo{};
+            heightmapInfo.sampler     = m_heightmapGpu.sampler;
+            heightmapInfo.imageView   = m_heightmapGpu.view;
+            heightmapInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo normalmapInfo{};
+            normalmapInfo.sampler     = m_normalMapGpu.sampler;
+            normalmapInfo.imageView   = m_normalMapGpu.view;
+            normalmapInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorBufferInfo uboInfo{};
+            uboInfo.buffer = m_uboBuffer;
+            uboInfo.offset = 0;
+            uboInfo.range  = sizeof(FrameUbo);
+
+            VkWriteDescriptorSet writes[3]{};
+            writes[0].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[0].dstSet          = m_descSet;
+            writes[0].dstBinding      = 0;
+            writes[0].descriptorCount = 1;
+            writes[0].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[0].pImageInfo      = &heightmapInfo;
+
+            writes[1].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[1].dstSet          = m_descSet;
+            writes[1].dstBinding      = 1;
+            writes[1].descriptorCount = 1;
+            writes[1].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[1].pImageInfo      = &normalmapInfo;
+
+            writes[2].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[2].dstSet          = m_descSet;
+            writes[2].dstBinding      = 2;
+            writes[2].descriptorCount = 1;
+            writes[2].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            writes[2].pBufferInfo     = &uboInfo;
+
+            vkUpdateDescriptorSets(device, 3, writes, 0, nullptr);
+        }
+
+        LOG_INFO(Render, "[TerrainRenderer] Init OK ({}×{} patches, worldSize={} heightScale={})",
+                 m_patchCountX, m_patchCountZ, m_terrainWorldSize, m_heightScale);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainRenderer::Destroy
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainRenderer::Destroy(VkDevice device)
+    {
+        InvalidateFramebufferCache(device);
+
+        if (m_pipeline       != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_pipeline, nullptr);             m_pipeline       = VK_NULL_HANDLE; }
+        if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
+        if (m_descPool       != VK_NULL_HANDLE) { vkDestroyDescriptorPool(device, m_descPool, nullptr);       m_descPool       = VK_NULL_HANDLE; m_descSet = VK_NULL_HANDLE; }
+        if (m_descSetLayout  != VK_NULL_HANDLE) { vkDestroyDescriptorSetLayout(device, m_descSetLayout, nullptr); m_descSetLayout = VK_NULL_HANDLE; }
+        if (m_renderPass     != VK_NULL_HANDLE) { vkDestroyRenderPass(device, m_renderPass, nullptr);         m_renderPass     = VK_NULL_HANDLE; }
+
+        if (m_uboBuffer != VK_NULL_HANDLE) { vkDestroyBuffer(device, m_uboBuffer, nullptr); m_uboBuffer = VK_NULL_HANDLE; }
+        if (m_uboMemory != VK_NULL_HANDLE) { vkFreeMemory(device, m_uboMemory, nullptr);    m_uboMemory = VK_NULL_HANDLE; }
+
+        HeightmapLoader::DestroyHeightmap(device, m_heightmapGpu);
+        HeightmapLoader::DestroyNormalMap(device, m_normalMapGpu);
+        TerrainMesh::Destroy(device, m_meshGpu);
+
+        m_patches.clear();
+        m_heightmapData.heights.clear();
+
+        LOG_INFO(Render, "[TerrainRenderer] Destroyed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainRenderer::InvalidateFramebufferCache
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainRenderer::InvalidateFramebufferCache(VkDevice device)
+    {
+        for (auto& [key, fb] : m_fbCache)
+            if (fb != VK_NULL_HANDLE) vkDestroyFramebuffer(device, fb, nullptr);
+        m_fbCache.clear();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainRenderer::Record
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainRenderer::Record(VkDevice device, VkCommandBuffer cmd,
+                                 engine::render::Registry& registry,
+                                 VkExtent2D extent,
+                                 engine::render::ResourceId idA,
+                                 engine::render::ResourceId idB,
+                                 engine::render::ResourceId idC,
+                                 engine::render::ResourceId idVelocity,
+                                 engine::render::ResourceId idDepth,
+                                 const float* prevViewProjMat4,
+                                 const float* viewProjMat4,
+                                 const engine::math::Vec3& cameraPos,
+                                 const engine::math::Frustum& frustum)
+    {
+        if (m_pipeline == VK_NULL_HANDLE) return;
+        if (extent.width == 0 || extent.height == 0) return;
+
+        // ── Update per-frame UBO ──────────────────────────────────────────────────
+        {
+            FrameUbo ubo{};
+            std::memcpy(ubo.viewProj,     viewProjMat4,     sizeof(ubo.viewProj));
+            std::memcpy(ubo.prevViewProj, prevViewProjMat4, sizeof(ubo.prevViewProj));
+            ubo.cameraPos[0] = cameraPos.x;
+            ubo.cameraPos[1] = cameraPos.y;
+            ubo.cameraPos[2] = cameraPos.z;
+            ubo.cameraPos[3] = 0.0f;
+            ubo.terrainParams[0] = m_terrainWorldSize;
+            ubo.terrainParams[1] = m_heightScale;
+            ubo.terrainParams[2] = m_vertStepWorld;
+            ubo.terrainParams[3] = 0.0f;
+            ubo.terrainOrigin[0] = m_terrainOriginX;
+            ubo.terrainOrigin[1] = m_terrainOriginZ;
+            ubo.terrainOrigin[2] = 0.0f;
+            ubo.terrainOrigin[3] = 0.0f;
+
+            void* mapped = nullptr;
+            if (vkMapMemory(device, m_uboMemory, 0, sizeof(FrameUbo), 0, &mapped) == VK_SUCCESS)
+            {
+                std::memcpy(mapped, &ubo, sizeof(FrameUbo));
+                vkUnmapMemory(device, m_uboMemory);
+            }
+        }
+
+        // ── CPU LOD selection & frustum culling ───────────────────────────────────
+        // Collect per-LOD draw lists: [(patchIndex, morphFactor)]
+        struct DrawEntry { uint32_t patchIdx; float morphFactor; };
+        std::vector<DrawEntry> drawLists[kTerrainLodCount];
+
+        const float patchWorldSize = static_cast<float>(kPatchQuads) * m_vertStepWorld;
+
+        for (uint32_t i = 0; i < static_cast<uint32_t>(m_patches.size()); ++i)
+        {
+            const TerrainPatchInfo& p = m_patches[i];
+
+            // AABB in world space
+            const engine::math::Vec3 bMin{ p.originX,                  p.minY, p.originZ };
+            const engine::math::Vec3 bMax{ p.originX + patchWorldSize,  p.maxY, p.originZ + patchWorldSize };
+
+            if (!frustum.TestAABB(bMin, bMax)) continue;
+
+            // Distance from camera to patch centre (XZ only)
+            const float dx   = p.centerX - cameraPos.x;
+            const float dz   = p.centerZ - cameraPos.z;
+            const float dist = std::sqrt(dx * dx + dz * dz);
+
+            // Select LOD
+            uint32_t lod = 0;
+            for (; lod < kTerrainLodCount - 1u; ++lod)
+                if (dist < kLodDistances[lod]) break;
+
+            // Morph factor: blend towards next (coarser) LOD in the transition zone.
+            // Transition zone = last 20% of the current LOD range.
+            float morphFactor = 0.0f;
+            if (lod < kTerrainLodCount - 1u)
+            {
+                const float rangeLow  = (lod > 0) ? kLodDistances[lod - 1] : 0.0f;
+                const float rangeHigh = kLodDistances[lod];
+                const float morphStart = rangeLow + (rangeHigh - rangeLow) * 0.8f;
+                const float morphRange = rangeHigh - morphStart;
+                if (morphRange > 0.0f)
+                    morphFactor = std::max(0.0f, std::min(1.0f, (dist - morphStart) / morphRange));
+            }
+
+            drawLists[lod].push_back({ i, morphFactor });
+        }
+
+        // ── Create / retrieve framebuffer ─────────────────────────────────────────
+        VkImageView views[5] = {
+            registry.getImageView(idA),
+            registry.getImageView(idB),
+            registry.getImageView(idC),
+            registry.getImageView(idVelocity),
+            registry.getImageView(idDepth)
+        };
+
+        FramebufferKey fbKey{};
+        fbKey.renderPass = m_renderPass;
+        for (int i = 0; i < 5; ++i) fbKey.views[i] = views[i];
+        fbKey.width  = extent.width;
+        fbKey.height = extent.height;
+
+        VkFramebuffer framebuffer = VK_NULL_HANDLE;
+        auto it = m_fbCache.find(fbKey);
+        if (it != m_fbCache.end())
+        {
+            framebuffer = it->second;
+        }
+        else
+        {
+            VkFramebufferCreateInfo fbCI{};
+            fbCI.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+            fbCI.renderPass      = m_renderPass;
+            fbCI.attachmentCount = 5;
+            fbCI.pAttachments    = views;
+            fbCI.width           = extent.width;
+            fbCI.height          = extent.height;
+            fbCI.layers          = 1;
+
+            if (vkCreateFramebuffer(device, &fbCI, nullptr, &framebuffer) != VK_SUCCESS ||
+                framebuffer == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateFramebuffer failed");
+                return;
+            }
+            m_fbCache[fbKey] = framebuffer;
+        }
+
+        // ── Begin render pass ─────────────────────────────────────────────────────
+        VkClearValue clearValues[5]{};
+        clearValues[0].color        = {{ 0.0f, 0.0f, 0.0f, 0.0f }};
+        clearValues[1].color        = {{ 0.5f, 0.5f, 1.0f, 0.0f }};
+        clearValues[2].color        = {{ 1.0f, 0.8f, 0.0f, 0.0f }};
+        clearValues[3].color        = {{ 0.0f, 0.0f, 0.0f, 0.0f }};
+        clearValues[4].depthStencil = { 1.0f, 0 };
+
+        VkRenderPassBeginInfo rpBI{};
+        rpBI.sType             = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rpBI.renderPass        = m_renderPass;
+        rpBI.framebuffer       = framebuffer;
+        rpBI.renderArea.offset = { 0, 0 };
+        rpBI.renderArea.extent = extent;
+        rpBI.clearValueCount   = 5;
+        rpBI.pClearValues      = clearValues;
+
+        vkCmdBeginRenderPass(cmd, &rpBI, VK_SUBPASS_CONTENTS_INLINE);
+
+        // ── Set dynamic viewport / scissor ────────────────────────────────────────
+        VkViewport vp{};
+        vp.x        = 0.0f;
+        vp.y        = 0.0f;
+        vp.width    = static_cast<float>(extent.width);
+        vp.height   = static_cast<float>(extent.height);
+        vp.minDepth = 0.0f;
+        vp.maxDepth = 1.0f;
+        vkCmdSetViewport(cmd, 0, 1, &vp);
+
+        VkRect2D scissor{};
+        scissor.offset = { 0, 0 };
+        scissor.extent = extent;
+        vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+        // ── Bind pipeline & descriptor set ───────────────────────────────────────
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
+
+        // ── Bind shared vertex buffer ─────────────────────────────────────────────
+        VkDeviceSize vbOffset = 0;
+        vkCmdBindVertexBuffers(cmd, 0, 1, &m_meshGpu.vertexBuffer, &vbOffset);
+
+        // ── Draw patches, grouped by LOD to minimise index buffer rebinds ─────────
+        for (uint32_t lod = 0; lod < kTerrainLodCount; ++lod)
+        {
+            if (drawLists[lod].empty()) continue;
+
+            // Bind index buffer for this LOD
+            vkCmdBindIndexBuffer(cmd, m_meshGpu.lod[lod].buffer, 0, VK_INDEX_TYPE_UINT16);
+
+            const uint32_t indexCount = m_meshGpu.lod[lod].indexCount;
+
+            for (const DrawEntry& entry : drawLists[lod])
+            {
+                const TerrainPatchInfo& p = m_patches[entry.patchIdx];
+
+                PushConstants pc{};
+                pc.patchOriginX = p.originX;
+                pc.patchOriginZ = p.originZ;
+                pc.morphFactor  = entry.morphFactor;
+                pc.lodLevel     = static_cast<int32_t>(lod);
+
+                vkCmdPushConstants(cmd, m_pipelineLayout,
+                                   VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                                   0, sizeof(PushConstants), &pc);
+
+                vkCmdDrawIndexed(cmd, indexCount, 1, 0, 0, 0);
+            }
+        }
+
+        vkCmdEndRenderPass(cmd);
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainRenderer.h
+++ b/engine/render/terrain/TerrainRenderer.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "engine/render/terrain/HeightmapLoader.h"
+#include "engine/render/terrain/TerrainMesh.h"
+#include "engine/render/FrameGraph.h"
+#include "engine/math/Frustum.h"
+#include "engine/math/Math.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::core { class Config; }
+
+namespace engine::render::terrain
+{
+    /// World-space bounding data for one terrain patch.
+    /// Used for LOD distance calculation and frustum culling.
+    struct TerrainPatchInfo
+    {
+        float originX  = 0.0f; ///< World X of patch corner (min X)
+        float originZ  = 0.0f; ///< World Z of patch corner (min Z)
+        float centerX  = 0.0f; ///< World X of patch centre
+        float centerZ  = 0.0f; ///< World Z of patch centre
+        float minY     = 0.0f; ///< Min world Y over all patch vertices
+        float maxY     = 0.0f; ///< Max world Y over all patch vertices
+    };
+
+    /// Terrain renderer: heightmap-based ground mesh with distance LOD and geomorphing.
+    ///
+    /// Architecture:
+    ///  - One shared patch vertex buffer (17×17 local XZ vertices) + 5 per-LOD index buffers.
+    ///  - CPU-side LOD selection (distance camera→patch centre) and frustum culling per patch.
+    ///  - Per-patch push constants (origin, morph factor, LOD level).
+    ///  - Per-frame UBO (view-proj matrices, camera position, terrain world parameters).
+    ///  - Writes into GBuffer-compatible attachments (A/B/C/Velocity/Depth).
+    ///
+    /// This class is self-contained and does NOT modify Engine.cpp or DeferredPipeline.
+    class TerrainRenderer
+    {
+    public:
+        /// SPIR-V loader function (same signature as DeferredPipeline::ShaderLoaderFn).
+        using ShaderLoaderFn = std::function<std::vector<uint32_t>(const char* spvPath)>;
+
+        /// Camera-to-patch-centre distance thresholds for LOD selection (metres).
+        /// LOD 0 used below kLodDistances[0], LOD N used below kLodDistances[N], etc.
+        static constexpr float kLodDistances[kTerrainLodCount] = {
+            50.f, 200.f, 500.f, 1000.f, 4000.f
+        };
+
+        TerrainRenderer() = default;
+        TerrainRenderer(const TerrainRenderer&) = delete;
+        TerrainRenderer& operator=(const TerrainRenderer&) = delete;
+
+        /// Initialises the terrain renderer.
+        ///
+        /// Config keys read:
+        ///   terrain.world_size    (float, default 1024.0) – total terrain world extent (metres)
+        ///   terrain.height_scale  (float, default 200.0)  – max height in world units
+        ///   terrain.origin_x      (float, default -512.0) – world X of terrain corner
+        ///   terrain.origin_z      (float, default -512.0) – world Z of terrain corner
+        ///
+        /// \param heightmapRelPath  Content-relative path to the .r16h file
+        ///                          (e.g. "terrain/heightmap.r16h"). If the file is absent,
+        ///                          Init returns false gracefully (no crash).
+        /// \param fmtA/B/C/Vel/Depth  GBuffer attachment formats (must match GeometryPass).
+        /// \param queue              Graphics queue used for one-time GPU uploads.
+        bool Init(VkDevice device, VkPhysicalDevice physDev,
+                  const engine::core::Config& config,
+                  const std::string& heightmapRelPath,
+                  VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
+                  VkFormat fmtVelocity, VkFormat fmtDepth,
+                  VkQueue queue, uint32_t queueFamilyIndex,
+                  ShaderLoaderFn loadSpirv);
+
+        /// Destroys all GPU resources. Safe to call when not initialised.
+        void Destroy(VkDevice device);
+
+        /// Records terrain draw calls into cmd.
+        ///
+        /// Performs:
+        ///   1. Updates the per-frame UBO (viewProj, cameraPos, terrain params).
+        ///   2. For each patch: distance-based LOD selection + morph factor + frustum cull.
+        ///   3. Begins the terrain render pass (clears GBuffer attachments).
+        ///   4. Draws visible patches grouped by LOD.
+        ///   5. Ends the render pass.
+        ///
+        /// \param prevViewProjMat4  Column-major mat4 from previous frame (for TAA velocity).
+        /// \param viewProjMat4      Column-major mat4 for current frame.
+        void Record(VkDevice device, VkCommandBuffer cmd,
+                    engine::render::Registry& registry,
+                    VkExtent2D extent,
+                    engine::render::ResourceId idA,
+                    engine::render::ResourceId idB,
+                    engine::render::ResourceId idC,
+                    engine::render::ResourceId idVelocity,
+                    engine::render::ResourceId idDepth,
+                    const float* prevViewProjMat4,
+                    const float* viewProjMat4,
+                    const engine::math::Vec3& cameraPos,
+                    const engine::math::Frustum& frustum);
+
+        /// Destroys cached framebuffers. Call before resizing GBuffer images.
+        void InvalidateFramebufferCache(VkDevice device);
+
+        /// Returns true if Init succeeded and Destroy has not been called.
+        bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
+
+    private:
+        // ── Push constants ────────────────────────────────────────────────────────
+        // All stages, 16 bytes total.
+        // offset  0: float patchOriginX
+        // offset  4: float patchOriginZ
+        // offset  8: float morphFactor   [0,1]
+        // offset 12: int   lodLevel      [0, kTerrainLodCount-1]
+        struct PushConstants
+        {
+            float   patchOriginX = 0.0f;
+            float   patchOriginZ = 0.0f;
+            float   morphFactor  = 0.0f;
+            int32_t lodLevel     = 0;
+        };
+
+        // ── Per-frame UBO (set=0, binding=2) ─────────────────────────────────────
+        // std140 layout using vec4 packing (no scalar arrays), 176 bytes total.
+        //   mat4  viewProj        offset   0  (64 bytes)
+        //   mat4  prevViewProj    offset  64  (64 bytes)
+        //   vec4  cameraPos       offset 128  (xyz = position, w = unused)
+        //   vec4  terrainParams   offset 144  (x=terrainSize, y=heightScale, z=vertStepWorld, w=unused)
+        //   vec4  terrainOrigin   offset 160  (x=originX, y=originZ, z=unused, w=unused)
+        //                         total  176
+        struct FrameUbo
+        {
+            float viewProj[16];      // offset   0
+            float prevViewProj[16];  // offset  64
+            float cameraPos[4];      // offset 128  (xyz + w=0)
+            float terrainParams[4];  // offset 144  (x=size, y=heightScale, z=vertStepWorld, w=0)
+            float terrainOrigin[4];  // offset 160  (x=originX, y=originZ, z=0, w=0)
+        };                           //         176
+
+        // ── Framebuffer cache ─────────────────────────────────────────────────────
+        struct FramebufferKey
+        {
+            VkRenderPass renderPass   = VK_NULL_HANDLE;
+            VkImageView  views[5]     = {};
+            uint32_t     width        = 0;
+            uint32_t     height       = 0;
+            bool operator==(const FramebufferKey& o) const;
+        };
+        struct FramebufferKeyHash
+        {
+            size_t operator()(const FramebufferKey& k) const;
+        };
+
+        // ── Vulkan objects ────────────────────────────────────────────────────────
+        VkRenderPass          m_renderPass    = VK_NULL_HANDLE;
+        VkDescriptorSetLayout m_descSetLayout = VK_NULL_HANDLE;
+        VkDescriptorPool      m_descPool      = VK_NULL_HANDLE;
+        VkDescriptorSet       m_descSet       = VK_NULL_HANDLE;
+        VkPipelineLayout      m_pipelineLayout = VK_NULL_HANDLE;
+        VkPipeline            m_pipeline      = VK_NULL_HANDLE;
+
+        /// HOST_COHERENT UBO buffer updated once per Record() call.
+        VkBuffer              m_uboBuffer     = VK_NULL_HANDLE;
+        VkDeviceMemory        m_uboMemory     = VK_NULL_HANDLE;
+
+        HeightmapGpu          m_heightmapGpu;
+        NormalMapGpu          m_normalMapGpu;
+        TerrainMeshGpu        m_meshGpu;
+        HeightmapData         m_heightmapData; ///< CPU copy for patch bound calculation
+
+        std::vector<TerrainPatchInfo> m_patches;
+        std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_fbCache;
+
+        // ── Terrain world parameters ──────────────────────────────────────────────
+        float    m_terrainOriginX    = 0.0f;
+        float    m_terrainOriginZ    = 0.0f;
+        float    m_terrainWorldSize  = 0.0f; ///< Total world extent (square)
+        float    m_heightScale       = 0.0f; ///< World units for max height
+        float    m_vertStepWorld     = 0.0f; ///< World units per local vertex step at LOD 0
+        uint32_t m_patchCountX       = 0;
+        uint32_t m_patchCountZ       = 0;
+    };
+
+} // namespace engine::render::terrain

--- a/game/data/shaders/terrain.frag
+++ b/game/data/shaders/terrain.frag
@@ -1,0 +1,56 @@
+#version 450
+// M34.1: Terrain fragment shader — GBuffer output.
+//
+// Reads world-space normal from the pre-baked normal map (Sobel-filtered heightmap).
+// Outputs into 4 GBuffer attachments compatible with GeometryPass layout:
+//   location 0 (GBufferA)        : albedo RGBA8
+//   location 1 (GBufferB)        : world normal encoded N*0.5+0.5
+//   location 2 (GBufferC)        : ORM (R=AO, G=Roughness, B=Metallic)
+//   location 3 (GBufferVelocity) : R16G16_SFLOAT velocity = currNDC - prevNDC
+
+layout(location = 0) in vec2 vUV;
+layout(location = 1) in vec3 vWorldPos;
+layout(location = 2) in vec4 vPrevClip;
+layout(location = 3) in vec4 vCurrClip;
+
+layout(set = 0, binding = 1) uniform sampler2D uNormalMap;
+
+// Push constant — lodLevel reused for debug tinting (optional)
+layout(push_constant) uniform PC {
+    float patchOriginX;
+    float patchOriginZ;
+    float morphFactor;
+    int   lodLevel;
+} pc;
+
+layout(location = 0) out vec4 outAlbedo;    // GBufferA
+layout(location = 1) out vec4 outNormal;    // GBufferB
+layout(location = 2) out vec4 outORM;       // GBufferC
+layout(location = 3) out vec4 outVelocity;  // GBufferVelocity
+
+void main()
+{
+    // ── Albedo — simple height-based colour (dirt/grass) ──────────────────────
+    // Normalised height derived from world Y; terrain height range is [0, heightScale].
+    float heightNorm = clamp(vWorldPos.y * 0.005, 0.0, 1.0);
+    vec3 grassColour = vec3(0.35, 0.55, 0.20);
+    vec3 rockColour  = vec3(0.50, 0.42, 0.32);
+    vec3 albedo      = mix(grassColour, rockColour, heightNorm);
+    outAlbedo        = vec4(albedo, 1.0);
+
+    // ── Normal — decode pre-baked Sobel normal map ────────────────────────────
+    vec3 N = texture(uNormalMap, vUV).rgb * 2.0 - 1.0;
+    N = normalize(N);
+    outNormal = vec4(N * 0.5 + 0.5, 1.0);
+
+    // ── ORM — no pre-baked AO, moderate roughness, non-metallic ─────────────
+    outORM = vec4(1.0,   // AO = 1 (no occlusion)
+                  0.85,  // Roughness = 0.85 (rough terrain)
+                  0.0,   // Metallic  = 0
+                  1.0);
+
+    // ── Velocity for TAA reprojection ─────────────────────────────────────────
+    vec2 prevNDC = vPrevClip.xy / max(vPrevClip.w, 1e-6);
+    vec2 currNDC = vCurrClip.xy / max(vCurrClip.w, 1e-6);
+    outVelocity  = vec4(currNDC - prevNDC, 0.0, 1.0);
+}

--- a/game/data/shaders/terrain.vert
+++ b/game/data/shaders/terrain.vert
@@ -1,0 +1,100 @@
+#version 450
+// M34.1: Terrain vertex shader — heightmap displacement + geomorphing.
+//
+// Vertex input:
+//   location 0: vec2 inPatchLocal  — local XZ position in [0, kPatchQuads] (raw grid index)
+//
+// Descriptor set 0:
+//   binding 0: sampler2D uHeightmap  (R16_UNORM)
+//   binding 1: sampler2D uNormalMap  (RGBA8_UNORM, unused in vert)
+//   binding 2: TerrainFrameUbo
+//
+// Push constants (16 bytes):
+//   vec2  patchOriginXZ  — world XZ of patch corner
+//   float morphFactor    — geomorphing blend [0=currentLOD, 1=parentLOD]
+//   int   lodLevel       — current LOD index (0..4)
+
+layout(location = 0) in vec2 inPatchLocal;
+
+// Per-frame uniform buffer
+layout(set = 0, binding = 0) uniform sampler2D uHeightmap;
+layout(set = 0, binding = 1) uniform sampler2D uNormalMap; // declared for set completeness
+
+layout(set = 0, binding = 2) uniform TerrainFrameUbo {
+    mat4  viewProj;       // current frame view-projection
+    mat4  prevViewProj;   // previous frame view-projection (for TAA velocity)
+    vec4  cameraPos;      // world camera position (xyz, w=unused)
+    vec4  terrainParams;  // x=terrainSize, y=heightScale, z=vertStepWorld, w=unused
+    vec4  terrainOrigin;  // x=originX, y=originZ, z=unused, w=unused
+} ubo;
+
+layout(push_constant) uniform PC {
+    float patchOriginX;
+    float patchOriginZ;
+    float morphFactor;
+    int   lodLevel;
+} pc;
+
+// Outputs to fragment shader
+layout(location = 0) out vec2 vUV;        // heightmap / normalmap UV in [0,1]
+layout(location = 1) out vec3 vWorldPos;  // world position (for lighting)
+layout(location = 2) out vec4 vPrevClip;  // previous clip position (for TAA)
+layout(location = 3) out vec4 vCurrClip;  // current clip position (for TAA)
+
+void main()
+{
+    // Step multiplier: LOD N uses 2^N world units per local grid unit
+    float stepMult = float(1 << pc.lodLevel);
+
+    // Unpack terrain parameters from vec4 fields
+    float terrainSize    = ubo.terrainParams.x;
+    float heightScale    = ubo.terrainParams.y;
+    float vertStepWorld  = ubo.terrainParams.z;
+    float terrainOriginX = ubo.terrainOrigin.x;
+    float terrainOriginZ = ubo.terrainOrigin.y;
+
+    // World XZ position of this vertex
+    float worldX = pc.patchOriginX + inPatchLocal.x * stepMult * vertStepWorld;
+    float worldZ = pc.patchOriginZ + inPatchLocal.y * stepMult * vertStepWorld;
+
+    // Heightmap UV (clamp to [0,1])
+    vec2 uv;
+    uv.x = clamp((worldX - terrainOriginX) / terrainSize, 0.0, 1.0);
+    uv.y = clamp((worldZ - terrainOriginZ) / terrainSize, 0.0, 1.0);
+
+    // Sample height at current vertex position
+    float h      = texture(uHeightmap, uv).r;
+    float worldY = h * heightScale;
+
+    // Geomorphing: smoothly snap to parent LOD grid when morphFactor > 0.
+    // Parent LOD step = 2 × current step. Vertices not on the parent grid
+    // morph towards their snapped parent position.
+    if (pc.morphFactor > 0.0 && pc.lodLevel < 4)
+    {
+        // Snap local position to nearest parent LOD grid vertex
+        float snappedLocalX = floor(inPatchLocal.x / 2.0 + 0.5) * 2.0;
+        float snappedLocalZ = floor(inPatchLocal.y / 2.0 + 0.5) * 2.0;
+
+        float snappedWorldX = pc.patchOriginX + snappedLocalX * stepMult * 2.0 * vertStepWorld;
+        float snappedWorldZ = pc.patchOriginZ + snappedLocalZ * stepMult * 2.0 * vertStepWorld;
+
+        vec2 snappedUV;
+        snappedUV.x = clamp((snappedWorldX - terrainOriginX) / terrainSize, 0.0, 1.0);
+        snappedUV.y = clamp((snappedWorldZ - terrainOriginZ) / terrainSize, 0.0, 1.0);
+
+        float snappedH = texture(uHeightmap, snappedUV).r;
+        float snappedY = snappedH * heightScale;
+
+        // Blend current height towards snapped parent height
+        worldY = mix(worldY, snappedY, pc.morphFactor);
+    }
+
+    vec3 worldPos = vec3(worldX, worldY, worldZ);
+
+    vUV       = uv;
+    vWorldPos = worldPos;
+    vCurrClip = ubo.viewProj     * vec4(worldPos, 1.0);
+    vPrevClip = ubo.prevViewProj * vec4(worldPos, 1.0);
+
+    gl_Position = vCurrClip;
+}


### PR DESCRIPTION
- HeightmapLoader: R16 file load + GPU staging upload + Sobel normal map
- TerrainMesh: shared 17×17 patch vertex buffer + 5 per-LOD index buffers
- TerrainRenderer: distance-based LOD selection (5 levels), frustum culling, géomorphing push constants, per-frame UBO, GBuffer render pass
- GLSL shaders: terrain.vert (heightmap sample + geomorph), terrain.frag (GBuffer)
- CMakeLists.txt: register engine/render/terrain/*.cpp in engine_core

https://claude.ai/code/session_01R4eGfDdmTxvuZ5QhmvRRok