### PR TITLE
feat(M34.2): terrain texture splatting multi-layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_library(engine_core
   engine/world/HlodRuntime.cpp
   engine/render/terrain/HeightmapLoader.cpp
   engine/render/terrain/TerrainMesh.cpp
+  engine/render/terrain/TerrainSplatting.cpp
   engine/render/terrain/TerrainRenderer.cpp
   engine/network/ByteWriter.cpp
   engine/network/ByteReader.cpp

--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -62,12 +62,14 @@ namespace engine::render::terrain
     bool TerrainRenderer::Init(VkDevice device, VkPhysicalDevice physDev,
                                const engine::core::Config& config,
                                const std::string& heightmapRelPath,
+                               const std::string& splatmapRelPath,
                                VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
                                VkFormat fmtVelocity, VkFormat fmtDepth,
                                VkQueue queue, uint32_t queueFamilyIndex,
                                ShaderLoaderFn loadSpirv)
     {
-        LOG_INFO(Render, "[TerrainRenderer] Init begin (heightmap='{}')", heightmapRelPath);
+        LOG_INFO(Render, "[TerrainRenderer] Init begin (heightmap='{}' splatmap='{}')",
+                 heightmapRelPath, splatmapRelPath);
 
         if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE || !loadSpirv)
         {
@@ -132,6 +134,15 @@ namespace engine::render::terrain
         if (!TerrainMesh::Generate(device, physDev, m_meshGpu))
         {
             LOG_ERROR(Render, "[TerrainRenderer] Failed to generate terrain mesh");
+            Destroy(device);
+            return false;
+        }
+
+        // ── Initialise texture splatting (M34.2) ─────────────────────────────────
+        if (!m_splatting.Init(device, physDev, config, splatmapRelPath, queue, queueFamilyIndex))
+        {
+            LOG_WARN(Render,
+                "[TerrainRenderer] TerrainSplatting Init failed — terrain disabled");
             Destroy(device);
             return false;
         }
@@ -252,7 +263,7 @@ namespace engine::render::terrain
 
         // ── Descriptor set layout ─────────────────────────────────────────────────
         {
-            VkDescriptorSetLayoutBinding bindings[3]{};
+            VkDescriptorSetLayoutBinding bindings[7]{};
             // binding 0: heightmap sampler (vertex + fragment)
             bindings[0].binding            = 0;
             bindings[0].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -268,10 +279,30 @@ namespace engine::render::terrain
             bindings[2].descriptorType     = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             bindings[2].descriptorCount    = 1;
             bindings[2].stageFlags         = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 3: splat map sampler (fragment) — R=grass,G=dirt,B=rock,A=snow
+            bindings[3].binding            = 3;
+            bindings[3].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[3].descriptorCount    = 1;
+            bindings[3].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 4: albedo texture array (fragment) — 4 layers
+            bindings[4].binding            = 4;
+            bindings[4].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[4].descriptorCount    = 1;
+            bindings[4].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 5: normal texture array (fragment) — 4 layers
+            bindings[5].binding            = 5;
+            bindings[5].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[5].descriptorCount    = 1;
+            bindings[5].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 6: ORM texture array (fragment) — 4 layers (R=AO, G=Roughness, B=Metallic)
+            bindings[6].binding            = 6;
+            bindings[6].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[6].descriptorCount    = 1;
+            bindings[6].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
 
             VkDescriptorSetLayoutCreateInfo dslCI{};
             dslCI.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-            dslCI.bindingCount = 3;
+            dslCI.bindingCount = 7;
             dslCI.pBindings    = bindings;
 
             if (vkCreateDescriptorSetLayout(device, &dslCI, nullptr, &m_descSetLayout) != VK_SUCCESS)
@@ -453,7 +484,7 @@ namespace engine::render::terrain
         {
             VkDescriptorPoolSize poolSizes[2]{};
             poolSizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-            poolSizes[0].descriptorCount = 2; // heightmap + normalmap
+            poolSizes[0].descriptorCount = 6; // heightmap + normalmap + splatmap + albedoArr + normalArr + ormArr
             poolSizes[1].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             poolSizes[1].descriptorCount = 1;
 
@@ -549,7 +580,27 @@ namespace engine::render::terrain
             uboInfo.offset = 0;
             uboInfo.range  = sizeof(FrameUbo);
 
-            VkWriteDescriptorSet writes[3]{};
+            VkDescriptorImageInfo splatmapInfo{};
+            splatmapInfo.sampler     = m_splatting.GetSplatMap().sampler;
+            splatmapInfo.imageView   = m_splatting.GetSplatMap().view;
+            splatmapInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo albedoArrayInfo{};
+            albedoArrayInfo.sampler     = m_splatting.GetAlbedoArray().sampler;
+            albedoArrayInfo.imageView   = m_splatting.GetAlbedoArray().view;
+            albedoArrayInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo normalArrayInfo{};
+            normalArrayInfo.sampler     = m_splatting.GetNormalArray().sampler;
+            normalArrayInfo.imageView   = m_splatting.GetNormalArray().view;
+            normalArrayInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo ormArrayInfo{};
+            ormArrayInfo.sampler     = m_splatting.GetORMArray().sampler;
+            ormArrayInfo.imageView   = m_splatting.GetORMArray().view;
+            ormArrayInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkWriteDescriptorSet writes[7]{};
             writes[0].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writes[0].dstSet          = m_descSet;
             writes[0].dstBinding      = 0;
@@ -571,7 +622,35 @@ namespace engine::render::terrain
             writes[2].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             writes[2].pBufferInfo     = &uboInfo;
 
-            vkUpdateDescriptorSets(device, 3, writes, 0, nullptr);
+            writes[3].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[3].dstSet          = m_descSet;
+            writes[3].dstBinding      = 3;
+            writes[3].descriptorCount = 1;
+            writes[3].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[3].pImageInfo      = &splatmapInfo;
+
+            writes[4].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[4].dstSet          = m_descSet;
+            writes[4].dstBinding      = 4;
+            writes[4].descriptorCount = 1;
+            writes[4].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[4].pImageInfo      = &albedoArrayInfo;
+
+            writes[5].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[5].dstSet          = m_descSet;
+            writes[5].dstBinding      = 5;
+            writes[5].descriptorCount = 1;
+            writes[5].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[5].pImageInfo      = &normalArrayInfo;
+
+            writes[6].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[6].dstSet          = m_descSet;
+            writes[6].dstBinding      = 6;
+            writes[6].descriptorCount = 1;
+            writes[6].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[6].pImageInfo      = &ormArrayInfo;
+
+            vkUpdateDescriptorSets(device, 7, writes, 0, nullptr);
         }
 
         LOG_INFO(Render, "[TerrainRenderer] Init OK ({}×{} patches, worldSize={} heightScale={})",
@@ -599,6 +678,7 @@ namespace engine::render::terrain
         HeightmapLoader::DestroyHeightmap(device, m_heightmapGpu);
         HeightmapLoader::DestroyNormalMap(device, m_normalMapGpu);
         TerrainMesh::Destroy(device, m_meshGpu);
+        m_splatting.Destroy(device);
 
         m_patches.clear();
         m_heightmapData.heights.clear();
@@ -654,6 +734,10 @@ namespace engine::render::terrain
             ubo.terrainOrigin[1] = m_terrainOriginZ;
             ubo.terrainOrigin[2] = 0.0f;
             ubo.terrainOrigin[3] = 0.0f;
+            ubo.layerTiling[0]   = m_splatting.GetLayerTiling(0); // grass
+            ubo.layerTiling[1]   = m_splatting.GetLayerTiling(1); // dirt
+            ubo.layerTiling[2]   = m_splatting.GetLayerTiling(2); // rock
+            ubo.layerTiling[3]   = m_splatting.GetLayerTiling(3); // snow
 
             void* mapped = nullptr;
             if (vkMapMemory(device, m_uboMemory, 0, sizeof(FrameUbo), 0, &mapped) == VK_SUCCESS)

--- a/engine/render/terrain/TerrainRenderer.h
+++ b/engine/render/terrain/TerrainRenderer.h
@@ -2,6 +2,7 @@
 
 #include "engine/render/terrain/HeightmapLoader.h"
 #include "engine/render/terrain/TerrainMesh.h"
+#include "engine/render/terrain/TerrainSplatting.h"
 #include "engine/render/FrameGraph.h"
 #include "engine/math/Frustum.h"
 #include "engine/math/Math.h"
@@ -58,19 +59,26 @@ namespace engine::render::terrain
         /// Initialises the terrain renderer.
         ///
         /// Config keys read:
-        ///   terrain.world_size    (float, default 1024.0) – total terrain world extent (metres)
-        ///   terrain.height_scale  (float, default 200.0)  – max height in world units
-        ///   terrain.origin_x      (float, default -512.0) – world X of terrain corner
-        ///   terrain.origin_z      (float, default -512.0) – world Z of terrain corner
+        ///   terrain.world_size             (float, default 1024.0) – total terrain world extent (metres)
+        ///   terrain.height_scale           (float, default 200.0)  – max height in world units
+        ///   terrain.origin_x               (float, default -512.0) – world X of terrain corner
+        ///   terrain.origin_z               (float, default -512.0) – world Z of terrain corner
+        ///   terrain.splat.tiling_grass     (float, default 8.0)    – metres per tile, grass layer
+        ///   terrain.splat.tiling_dirt      (float, default 8.0)    – metres per tile, dirt layer
+        ///   terrain.splat.tiling_rock      (float, default 16.0)   – metres per tile, rock layer
+        ///   terrain.splat.tiling_snow      (float, default 12.0)   – metres per tile, snow layer
         ///
         /// \param heightmapRelPath  Content-relative path to the .r16h file
         ///                          (e.g. "terrain/heightmap.r16h"). If the file is absent,
         ///                          Init returns false gracefully (no crash).
+        /// \param splatmapRelPath   Content-relative path to the splat map (reserved for future
+        ///                          use; a default map is generated if empty or missing).
         /// \param fmtA/B/C/Vel/Depth  GBuffer attachment formats (must match GeometryPass).
         /// \param queue              Graphics queue used for one-time GPU uploads.
         bool Init(VkDevice device, VkPhysicalDevice physDev,
                   const engine::core::Config& config,
                   const std::string& heightmapRelPath,
+                  const std::string& splatmapRelPath,
                   VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
                   VkFormat fmtVelocity, VkFormat fmtDepth,
                   VkQueue queue, uint32_t queueFamilyIndex,
@@ -125,13 +133,14 @@ namespace engine::render::terrain
         };
 
         // ── Per-frame UBO (set=0, binding=2) ─────────────────────────────────────
-        // std140 layout using vec4 packing (no scalar arrays), 176 bytes total.
+        // std140 layout using vec4 packing (no scalar arrays), 192 bytes total.
         //   mat4  viewProj        offset   0  (64 bytes)
         //   mat4  prevViewProj    offset  64  (64 bytes)
         //   vec4  cameraPos       offset 128  (xyz = position, w = unused)
         //   vec4  terrainParams   offset 144  (x=terrainSize, y=heightScale, z=vertStepWorld, w=unused)
         //   vec4  terrainOrigin   offset 160  (x=originX, y=originZ, z=unused, w=unused)
-        //                         total  176
+        //   vec4  layerTiling     offset 176  (x=grass, y=dirt, z=rock, w=snow tiling metres/tile)
+        //                         total  192
         struct FrameUbo
         {
             float viewProj[16];      // offset   0
@@ -139,7 +148,8 @@ namespace engine::render::terrain
             float cameraPos[4];      // offset 128  (xyz + w=0)
             float terrainParams[4];  // offset 144  (x=size, y=heightScale, z=vertStepWorld, w=0)
             float terrainOrigin[4];  // offset 160  (x=originX, y=originZ, z=0, w=0)
-        };                           //         176
+            float layerTiling[4];    // offset 176  (x=grass, y=dirt, z=rock, w=snow tiling)
+        };                           //         192
 
         // ── Framebuffer cache ─────────────────────────────────────────────────────
         struct FramebufferKey
@@ -171,6 +181,7 @@ namespace engine::render::terrain
         NormalMapGpu          m_normalMapGpu;
         TerrainMeshGpu        m_meshGpu;
         HeightmapData         m_heightmapData; ///< CPU copy for patch bound calculation
+        TerrainSplatting      m_splatting;     ///< Splat map + texture arrays (M34.2)
 
         std::vector<TerrainPatchInfo> m_patches;
         std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_fbCache;

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -1,0 +1,691 @@
+#include "engine/render/terrain/TerrainSplatting.h"
+#include "engine/core/Config.h"
+#include "engine/core/Log.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstring>
+#include <vector>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Internal Vulkan helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        /// Finds a memory type index that satisfies the given property flags.
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Creates a HOST_VISIBLE | HOST_COHERENT staging buffer.
+        bool CreateStagingBuffer(VkDevice device, VkPhysicalDevice physDev,
+                                 VkDeviceSize size,
+                                 VkBuffer& outBuf, VkDeviceMemory& outMem)
+        {
+            VkBufferCreateInfo bi{};
+            bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bi.size        = size;
+            bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bi, nullptr, &outBuf) != VK_SUCCESS ||
+                outBuf == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkCreateBuffer (staging) failed");
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, outBuf, &req);
+
+            const uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] No HOST_VISIBLE memory for staging");
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMem) != VK_SUCCESS ||
+                outMem == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkAllocateMemory (staging) failed");
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindBufferMemory(device, outBuf, outMem, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkBindBufferMemory (staging) failed");
+                vkFreeMemory(device, outMem, nullptr);
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                outMem = VK_NULL_HANDLE;
+                return false;
+            }
+            return true;
+        }
+
+        /// Creates a DEVICE_LOCAL OPTIMAL image (array-capable).
+        bool CreateOptimalImage(VkDevice device, VkPhysicalDevice physDev,
+                                uint32_t width, uint32_t height, uint32_t layerCount,
+                                VkFormat format, VkImageUsageFlags usage,
+                                VkImage& outImage, VkDeviceMemory& outMemory)
+        {
+            VkImageCreateInfo ici{};
+            ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            ici.imageType     = VK_IMAGE_TYPE_2D;
+            ici.format        = format;
+            ici.extent        = { width, height, 1 };
+            ici.mipLevels     = 1;
+            ici.arrayLayers   = layerCount;
+            ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+            ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+            ici.usage         = usage;
+            ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateImage(device, &ici, nullptr, &outImage) != VK_SUCCESS ||
+                outImage == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkCreateImage failed ({}x{} layers={})",
+                          width, height, layerCount);
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetImageMemoryRequirements(device, outImage, &req);
+
+            const uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                                                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] No DEVICE_LOCAL memory for image");
+                vkDestroyImage(device, outImage, nullptr);
+                outImage = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMemory) != VK_SUCCESS ||
+                outMemory == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkAllocateMemory (image) failed");
+                vkDestroyImage(device, outImage, nullptr);
+                outImage = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindImageMemory(device, outImage, outMemory, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkBindImageMemory failed");
+                vkFreeMemory(device, outMemory, nullptr);
+                vkDestroyImage(device, outImage, nullptr);
+                outImage  = VK_NULL_HANDLE;
+                outMemory = VK_NULL_HANDLE;
+                return false;
+            }
+            return true;
+        }
+
+        /// Submits a one-time command buffer: barrier → copies → barrier, then waits.
+        /// Supports multi-layer images via the provided array of copy regions.
+        bool UploadViaStaging(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                              VkBuffer stagingBuffer,
+                              VkImage dstImage, uint32_t layerCount,
+                              const VkBufferImageCopy* regions)
+        {
+            VkCommandPool pool = VK_NULL_HANDLE;
+            {
+                VkCommandPoolCreateInfo poolCI{};
+                poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+                poolCI.queueFamilyIndex = queueFamilyIndex;
+                poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+                if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS ||
+                    pool == VK_NULL_HANDLE)
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] vkCreateCommandPool failed");
+                    return false;
+                }
+            }
+
+            VkCommandBuffer cmd = VK_NULL_HANDLE;
+            {
+                VkCommandBufferAllocateInfo allocCI{};
+                allocCI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+                allocCI.commandPool        = pool;
+                allocCI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+                allocCI.commandBufferCount = 1;
+                if (vkAllocateCommandBuffers(device, &allocCI, &cmd) != VK_SUCCESS ||
+                    cmd == VK_NULL_HANDLE)
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] vkAllocateCommandBuffers failed");
+                    vkDestroyCommandPool(device, pool, nullptr);
+                    return false;
+                }
+            }
+
+            VkCommandBufferBeginInfo beginInfo{};
+            beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkBeginCommandBuffer failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            // Barrier: UNDEFINED → TRANSFER_DST_OPTIMAL (all layers at once)
+            {
+                VkImageMemoryBarrier barrier{};
+                barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.oldLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
+                barrier.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.image               = dstImage;
+                barrier.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, layerCount };
+                barrier.srcAccessMask       = 0;
+                barrier.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+            }
+
+            // Copy all layers
+            vkCmdCopyBufferToImage(cmd, stagingBuffer, dstImage,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                   layerCount, regions);
+
+            // Barrier: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL (all layers)
+            {
+                VkImageMemoryBarrier barrier{};
+                barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.newLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                barrier.image               = dstImage;
+                barrier.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, layerCount };
+                barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+            }
+
+            if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkEndCommandBuffer failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            VkFence fence = VK_NULL_HANDLE;
+            {
+                VkFenceCreateInfo fenceCI{};
+                fenceCI.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+                if (vkCreateFence(device, &fenceCI, nullptr, &fence) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] vkCreateFence failed");
+                    vkDestroyCommandPool(device, pool, nullptr);
+                    return false;
+                }
+            }
+
+            VkSubmitInfo si{};
+            si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            si.commandBufferCount = 1;
+            si.pCommandBuffers    = &cmd;
+
+            if (vkQueueSubmit(queue, 1, &si, fence) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] vkQueueSubmit failed");
+                vkDestroyFence(device, fence, nullptr);
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+            vkDestroyFence(device, fence, nullptr);
+            vkDestroyCommandPool(device, pool, nullptr);
+            return true;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::GetLayerTiling
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    float TerrainSplatting::GetLayerTiling(uint32_t layer) const
+    {
+        return (layer < kSplatLayerCount) ? m_layerTiling[layer] : 8.0f;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::Init
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::Init(VkDevice device, VkPhysicalDevice physDev,
+                                const engine::core::Config& config,
+                                const std::string& splatmapRelPath,
+                                VkQueue queue, uint32_t queueFamilyIndex)
+    {
+        LOG_INFO(Render, "[TerrainSplatting] Init begin (splatmap='{}')", splatmapRelPath);
+
+        if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] Init: invalid device parameters");
+            return false;
+        }
+
+        // ── Read tiling config ────────────────────────────────────────────────────
+        m_layerTiling[0] = static_cast<float>(config.GetDouble("terrain.splat.tiling_grass",  8.0));
+        m_layerTiling[1] = static_cast<float>(config.GetDouble("terrain.splat.tiling_dirt",   8.0));
+        m_layerTiling[2] = static_cast<float>(config.GetDouble("terrain.splat.tiling_rock",  16.0));
+        m_layerTiling[3] = static_cast<float>(config.GetDouble("terrain.splat.tiling_snow",  12.0));
+
+        for (uint32_t i = 0; i < kSplatLayerCount; ++i)
+        {
+            if (m_layerTiling[i] <= 0.0f)
+            {
+                LOG_WARN(Render, "[TerrainSplatting] Layer {} tiling <= 0 ({}); clamped to 8.0",
+                         i, m_layerTiling[i]);
+                m_layerTiling[i] = 8.0f;
+            }
+        }
+
+        LOG_DEBUG(Render,
+            "[TerrainSplatting] Tiling: grass={} dirt={} rock={} snow={}",
+            m_layerTiling[0], m_layerTiling[1], m_layerTiling[2], m_layerTiling[3]);
+
+        // ── Build default splat map (all grass: R=255, G=B=A=0) ──────────────────
+        // MVP: generate a flat splat map. If splatmapRelPath is provided and the
+        // binary format is available, it could be loaded here in a future ticket.
+        (void)splatmapRelPath; // reserved for future file loading
+        constexpr uint32_t kSplatW = 1024u;
+        constexpr uint32_t kSplatH = 1024u;
+
+        std::vector<uint8_t> splatData(kSplatW * kSplatH * 4u, 0u);
+        for (uint32_t i = 0; i < kSplatW * kSplatH; ++i)
+        {
+            // RGBA: R=grass weight, G=dirt, B=rock, A=snow
+            splatData[i * 4 + 0] = 255u; // grass = 1.0
+            splatData[i * 4 + 1] = 0u;
+            splatData[i * 4 + 2] = 0u;
+            splatData[i * 4 + 3] = 0u;
+        }
+        LOG_DEBUG(Render, "[TerrainSplatting] Generated default splat map ({}x{}, all grass)",
+                  kSplatW, kSplatH);
+
+        // ── Upload splat map ──────────────────────────────────────────────────────
+        if (!UploadSplatMap(device, physDev, splatData, kSplatW, kSplatH,
+                            queue, queueFamilyIndex, m_splatMap))
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] Failed to upload splat map");
+            Destroy(device);
+            return false;
+        }
+
+        // ── Build placeholder texture arrays ──────────────────────────────────────
+        // Each array layer is a 4×4 solid-colour tile. Layers: grass, dirt, rock, snow.
+        constexpr uint32_t kTexW = 4u;
+        constexpr uint32_t kTexH = 4u;
+        constexpr uint32_t kPixels = kTexW * kTexH;
+
+        // Layer albedo colours (RGBA8, sRGB-ish but stored linear for GPU)
+        // 0=grass, 1=dirt, 2=rock, 3=snow
+        static const uint8_t kAlbedo[kSplatLayerCount][4] = {
+            {  89u, 140u,  51u, 255u },   // grass — green
+            { 128u,  82u,  38u, 255u },   // dirt  — brown
+            { 128u, 107u,  82u, 255u },   // rock  — grey-brown
+            { 242u, 242u, 250u, 255u },   // snow  — near-white
+        };
+
+        // Flat normal (pointing up in tangent space: RGB=128,128,255)
+        static const uint8_t kNormal[4] = { 128u, 128u, 255u, 255u };
+
+        // ORM: R=AO(255=1.0), G=Roughness(204≈0.8), B=Metallic(0)
+        static const uint8_t kORM[4] = { 255u, 204u, 0u, 255u };
+
+        // Build albedo array data (layerCount × width × height × 4 bytes)
+        {
+            std::vector<uint8_t> albedoData(kSplatLayerCount * kPixels * 4u);
+            for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+            {
+                const uint8_t* col = kAlbedo[layer];
+                for (uint32_t p = 0; p < kPixels; ++p)
+                {
+                    uint8_t* dst = albedoData.data() + (layer * kPixels + p) * 4u;
+                    dst[0] = col[0]; dst[1] = col[1]; dst[2] = col[2]; dst[3] = col[3];
+                }
+            }
+            if (!UploadTextureArray(device, physDev, albedoData, kTexW, kTexH, kSplatLayerCount,
+                                    queue, queueFamilyIndex, m_albedoArray))
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] Failed to upload albedo array");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // Build normal array data
+        {
+            std::vector<uint8_t> normalData(kSplatLayerCount * kPixels * 4u);
+            for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+                for (uint32_t p = 0; p < kPixels; ++p)
+                {
+                    uint8_t* dst = normalData.data() + (layer * kPixels + p) * 4u;
+                    dst[0] = kNormal[0]; dst[1] = kNormal[1];
+                    dst[2] = kNormal[2]; dst[3] = kNormal[3];
+                }
+            if (!UploadTextureArray(device, physDev, normalData, kTexW, kTexH, kSplatLayerCount,
+                                    queue, queueFamilyIndex, m_normalArray))
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] Failed to upload normal array");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        // Build ORM array data
+        {
+            std::vector<uint8_t> ormData(kSplatLayerCount * kPixels * 4u);
+            for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+                for (uint32_t p = 0; p < kPixels; ++p)
+                {
+                    uint8_t* dst = ormData.data() + (layer * kPixels + p) * 4u;
+                    dst[0] = kORM[0]; dst[1] = kORM[1]; dst[2] = kORM[2]; dst[3] = kORM[3];
+                }
+            if (!UploadTextureArray(device, physDev, ormData, kTexW, kTexH, kSplatLayerCount,
+                                    queue, queueFamilyIndex, m_ormArray))
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] Failed to upload ORM array");
+                Destroy(device);
+                return false;
+            }
+        }
+
+        LOG_INFO(Render,
+            "[TerrainSplatting] Init OK (splatmap={}x{}, texArrays={}x{}x{}layers)",
+            kSplatW, kSplatH, kTexW, kTexH, kSplatLayerCount);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::Destroy
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainSplatting::Destroy(VkDevice device)
+    {
+        DestroySplatMap(device, m_splatMap);
+        DestroyTextureArray(device, m_albedoArray);
+        DestroyTextureArray(device, m_normalArray);
+        DestroyTextureArray(device, m_ormArray);
+        LOG_INFO(Render, "[TerrainSplatting] Destroyed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::UploadSplatMap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::UploadSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                                          const std::vector<uint8_t>& rgba,
+                                          uint32_t width, uint32_t height,
+                                          VkQueue queue, uint32_t queueFamilyIndex,
+                                          SplatMapGpu& out)
+    {
+        const VkDeviceSize dataBytes = static_cast<VkDeviceSize>(width) * height * 4u;
+
+        // Create + fill staging buffer
+        VkBuffer       stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, dataBytes, stagingBuf, stagingMem))
+            return false;
+
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, dataBytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkMapMemory (splat staging) failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, rgba.data(), static_cast<size_t>(dataBytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // Create DEVICE_LOCAL RGBA8 image (single layer)
+        if (!CreateOptimalImage(device, physDev, width, height, 1u,
+                                VK_FORMAT_R8G8B8A8_UNORM,
+                                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                out.image, out.memory))
+        {
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+
+        // Upload (single copy region, single layer)
+        VkBufferImageCopy region{};
+        region.bufferOffset      = 0;
+        region.bufferRowLength   = width;
+        region.bufferImageHeight = height;
+        region.imageSubresource  = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+        region.imageOffset       = { 0, 0, 0 };
+        region.imageExtent       = { width, height, 1 };
+
+        if (!UploadViaStaging(device, queue, queueFamilyIndex, stagingBuf, out.image, 1u, &region))
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] Splat map staging upload failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            DestroySplatMap(device, out);
+            return false;
+        }
+
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+
+        // Image view (2D, single layer)
+        VkImageViewCreateInfo viewCI{};
+        viewCI.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewCI.image                           = out.image;
+        viewCI.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        viewCI.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+        viewCI.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewCI.subresourceRange.baseMipLevel   = 0;
+        viewCI.subresourceRange.levelCount     = 1;
+        viewCI.subresourceRange.baseArrayLayer = 0;
+        viewCI.subresourceRange.layerCount     = 1;
+
+        if (vkCreateImageView(device, &viewCI, nullptr, &out.view) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkCreateImageView (splat) failed");
+            DestroySplatMap(device, out);
+            return false;
+        }
+
+        // Sampler: linear, clamp-to-edge (splat map covers exactly [0,1] UV space)
+        VkSamplerCreateInfo sampCI{};
+        sampCI.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampCI.magFilter    = VK_FILTER_LINEAR;
+        sampCI.minFilter    = VK_FILTER_LINEAR;
+        sampCI.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        sampCI.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampCI.maxLod       = 0.0f;
+
+        if (vkCreateSampler(device, &sampCI, nullptr, &out.sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkCreateSampler (splat) failed");
+            DestroySplatMap(device, out);
+            return false;
+        }
+
+        out.width  = width;
+        out.height = height;
+        LOG_DEBUG(Render, "[TerrainSplatting] SplatMap uploaded OK ({}x{})", width, height);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::UploadTextureArray
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::UploadTextureArray(VkDevice device, VkPhysicalDevice physDev,
+                                              const std::vector<uint8_t>& rgba,
+                                              uint32_t width, uint32_t height,
+                                              uint32_t layerCount,
+                                              VkQueue queue, uint32_t queueFamilyIndex,
+                                              TextureArrayGpu& out)
+    {
+        const VkDeviceSize layerBytes = static_cast<VkDeviceSize>(width) * height * 4u;
+        const VkDeviceSize totalBytes = layerBytes * layerCount;
+
+        // Create + fill staging buffer (all layers contiguous)
+        VkBuffer       stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, totalBytes, stagingBuf, stagingMem))
+            return false;
+
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, totalBytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkMapMemory (texArray staging) failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, rgba.data(), static_cast<size_t>(totalBytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // Create DEVICE_LOCAL RGBA8 image array
+        if (!CreateOptimalImage(device, physDev, width, height, layerCount,
+                                VK_FORMAT_R8G8B8A8_UNORM,
+                                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                out.image, out.memory))
+        {
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+
+        // Build one copy region per layer
+        std::vector<VkBufferImageCopy> regions(layerCount);
+        for (uint32_t layer = 0; layer < layerCount; ++layer)
+        {
+            regions[layer].bufferOffset      = layerBytes * layer;
+            regions[layer].bufferRowLength   = width;
+            regions[layer].bufferImageHeight = height;
+            regions[layer].imageSubresource  = { VK_IMAGE_ASPECT_COLOR_BIT, 0, layer, 1 };
+            regions[layer].imageOffset       = { 0, 0, 0 };
+            regions[layer].imageExtent       = { width, height, 1 };
+        }
+
+        if (!UploadViaStaging(device, queue, queueFamilyIndex,
+                              stagingBuf, out.image, layerCount, regions.data()))
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] Texture array staging upload failed");
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            DestroyTextureArray(device, out);
+            return false;
+        }
+
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+
+        // Image view (2D_ARRAY, all layers)
+        VkImageViewCreateInfo viewCI{};
+        viewCI.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        viewCI.image                           = out.image;
+        viewCI.viewType                        = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        viewCI.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+        viewCI.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        viewCI.subresourceRange.baseMipLevel   = 0;
+        viewCI.subresourceRange.levelCount     = 1;
+        viewCI.subresourceRange.baseArrayLayer = 0;
+        viewCI.subresourceRange.layerCount     = layerCount;
+
+        if (vkCreateImageView(device, &viewCI, nullptr, &out.view) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkCreateImageView (texArray) failed");
+            DestroyTextureArray(device, out);
+            return false;
+        }
+
+        // Sampler: linear, repeat (texture tiles across terrain)
+        VkSamplerCreateInfo sampCI{};
+        sampCI.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampCI.magFilter    = VK_FILTER_LINEAR;
+        sampCI.minFilter    = VK_FILTER_LINEAR;
+        sampCI.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        sampCI.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        sampCI.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        sampCI.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        sampCI.maxLod       = 0.0f;
+
+        if (vkCreateSampler(device, &sampCI, nullptr, &out.sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] vkCreateSampler (texArray) failed");
+            DestroyTextureArray(device, out);
+            return false;
+        }
+
+        out.width      = width;
+        out.height     = height;
+        out.layerCount = layerCount;
+        LOG_DEBUG(Render, "[TerrainSplatting] TextureArray uploaded OK ({}x{} layers={})",
+                  width, height, layerCount);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::DestroySplatMap / DestroyTextureArray
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainSplatting::DestroySplatMap(VkDevice device, SplatMapGpu& g)
+    {
+        if (g.sampler != VK_NULL_HANDLE) { vkDestroySampler(device, g.sampler, nullptr);   g.sampler = VK_NULL_HANDLE; }
+        if (g.view    != VK_NULL_HANDLE) { vkDestroyImageView(device, g.view, nullptr);    g.view    = VK_NULL_HANDLE; }
+        if (g.image   != VK_NULL_HANDLE) { vkDestroyImage(device, g.image, nullptr);       g.image   = VK_NULL_HANDLE; }
+        if (g.memory  != VK_NULL_HANDLE) { vkFreeMemory(device, g.memory, nullptr);        g.memory  = VK_NULL_HANDLE; }
+        g.width = g.height = 0;
+    }
+
+    void TerrainSplatting::DestroyTextureArray(VkDevice device, TextureArrayGpu& g)
+    {
+        if (g.sampler != VK_NULL_HANDLE) { vkDestroySampler(device, g.sampler, nullptr);   g.sampler    = VK_NULL_HANDLE; }
+        if (g.view    != VK_NULL_HANDLE) { vkDestroyImageView(device, g.view, nullptr);    g.view       = VK_NULL_HANDLE; }
+        if (g.image   != VK_NULL_HANDLE) { vkDestroyImage(device, g.image, nullptr);       g.image      = VK_NULL_HANDLE; }
+        if (g.memory  != VK_NULL_HANDLE) { vkFreeMemory(device, g.memory, nullptr);        g.memory     = VK_NULL_HANDLE; }
+        g.width = g.height = g.layerCount = 0;
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::core { class Config; }
+
+namespace engine::render::terrain
+{
+    /// Number of splat layers (grass, dirt, rock, snow).
+    static constexpr uint32_t kSplatLayerCount = 4u;
+
+    /// GPU RGBA8_UNORM splat map texture (DEVICE_LOCAL, OPTIMAL tiling).
+    /// Channel mapping: R=grass, G=dirt, B=rock, A=snow.
+    struct SplatMapGpu
+    {
+        VkImage        image   = VK_NULL_HANDLE;
+        VkImageView    view    = VK_NULL_HANDLE;
+        VkDeviceMemory memory  = VK_NULL_HANDLE;
+        VkSampler      sampler = VK_NULL_HANDLE;
+        uint32_t       width   = 0;
+        uint32_t       height  = 0;
+    };
+
+    /// GPU RGBA8_UNORM texture array (kSplatLayerCount layers, DEVICE_LOCAL, OPTIMAL tiling).
+    /// Layer order: 0=grass, 1=dirt, 2=rock, 3=snow.
+    struct TextureArrayGpu
+    {
+        VkImage        image      = VK_NULL_HANDLE;
+        VkImageView    view       = VK_NULL_HANDLE;
+        VkDeviceMemory memory     = VK_NULL_HANDLE;
+        VkSampler      sampler    = VK_NULL_HANDLE;
+        uint32_t       width      = 0;
+        uint32_t       height     = 0;
+        uint32_t       layerCount = 0;
+    };
+
+    /// Manages terrain texture splatting resources:
+    ///   - Splat map (RGBA8, 1024×1024): R=grass, G=dirt, B=rock, A=snow
+    ///   - Three texture arrays (albedo, normal, ORM), each with kSplatLayerCount layers
+    ///   - Per-layer tiling scale in world metres per tile
+    ///
+    /// If the splat map file is absent or unreadable, a default is generated (all grass).
+    /// Texture array layers are generated as solid-colour placeholders (MVP).
+    class TerrainSplatting
+    {
+    public:
+        TerrainSplatting() = default;
+        TerrainSplatting(const TerrainSplatting&) = delete;
+        TerrainSplatting& operator=(const TerrainSplatting&) = delete;
+
+        /// Initialises splat map + texture arrays.
+        ///
+        /// Config keys read:
+        ///   terrain.splat.tiling_grass  (float, default 8.0)  – metres per tile, grass layer
+        ///   terrain.splat.tiling_dirt   (float, default 8.0)  – metres per tile, dirt layer
+        ///   terrain.splat.tiling_rock   (float, default 16.0) – metres per tile, rock layer
+        ///   terrain.splat.tiling_snow   (float, default 12.0) – metres per tile, snow layer
+        ///
+        /// \param splatmapRelPath  Content-relative path to the splat map image (e.g.
+        ///                         "terrain/splatmap.rgba8"). Empty = use default.
+        /// \param queue            Graphics queue used for one-time GPU uploads.
+        /// \return true on success.
+        bool Init(VkDevice device, VkPhysicalDevice physDev,
+                  const engine::core::Config& config,
+                  const std::string& splatmapRelPath,
+                  VkQueue queue, uint32_t queueFamilyIndex);
+
+        /// Destroys all GPU resources. Safe to call when not initialised.
+        void Destroy(VkDevice device);
+
+        /// Returns true if Init succeeded and Destroy has not been called.
+        bool IsValid() const { return m_splatMap.image != VK_NULL_HANDLE; }
+
+        const SplatMapGpu&    GetSplatMap()    const { return m_splatMap;    }
+        const TextureArrayGpu& GetAlbedoArray() const { return m_albedoArray; }
+        const TextureArrayGpu& GetNormalArray() const { return m_normalArray; }
+        const TextureArrayGpu& GetORMArray()    const { return m_ormArray;    }
+
+        /// Returns the tiling scale (metres per tile) for a given layer index [0, kSplatLayerCount).
+        float GetLayerTiling(uint32_t layer) const;
+
+    private:
+        SplatMapGpu    m_splatMap;
+        TextureArrayGpu m_albedoArray;
+        TextureArrayGpu m_normalArray;
+        TextureArrayGpu m_ormArray;
+
+        float m_layerTiling[kSplatLayerCount] = { 8.0f, 8.0f, 16.0f, 12.0f };
+
+        // ── Internal upload helpers ───────────────────────────────────────────────
+
+        /// Uploads a flat RGBA8 buffer as a 2D splat map texture.
+        static bool UploadSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                                   const std::vector<uint8_t>& rgba,
+                                   uint32_t width, uint32_t height,
+                                   VkQueue queue, uint32_t queueFamilyIndex,
+                                   SplatMapGpu& out);
+
+        /// Uploads a flat RGBA8 buffer as a 2D_ARRAY texture with layerCount layers.
+        /// The buffer must be exactly width * height * 4 * layerCount bytes,
+        /// with layers packed contiguously in memory.
+        static bool UploadTextureArray(VkDevice device, VkPhysicalDevice physDev,
+                                       const std::vector<uint8_t>& rgba,
+                                       uint32_t width, uint32_t height,
+                                       uint32_t layerCount,
+                                       VkQueue queue, uint32_t queueFamilyIndex,
+                                       TextureArrayGpu& out);
+
+        static void DestroySplatMap(VkDevice device, SplatMapGpu& g);
+        static void DestroyTextureArray(VkDevice device, TextureArrayGpu& g);
+    };
+
+} // namespace engine::render::terrain

--- a/game/data/shaders/terrain.frag
+++ b/game/data/shaders/terrain.frag
@@ -1,7 +1,10 @@
 #version 450
-// M34.1: Terrain fragment shader — GBuffer output.
+// M34.2: Terrain fragment shader — texture splatting with triplanar projection.
 //
-// Reads world-space normal from the pre-baked normal map (Sobel-filtered heightmap).
+// Reads per-layer weights from the splat map (R=grass, G=dirt, B=rock, A=snow),
+// samples albedo/normal/ORM from 2D texture arrays using triplanar projection
+// (avoids UV stretching on steep slopes), and blends by normalised splat weights.
+//
 // Outputs into 4 GBuffer attachments compatible with GeometryPass layout:
 //   location 0 (GBufferA)        : albedo RGBA8
 //   location 1 (GBufferB)        : world normal encoded N*0.5+0.5
@@ -13,9 +16,22 @@ layout(location = 1) in vec3 vWorldPos;
 layout(location = 2) in vec4 vPrevClip;
 layout(location = 3) in vec4 vCurrClip;
 
-layout(set = 0, binding = 1) uniform sampler2D uNormalMap;
+// ── Descriptor bindings ───────────────────────────────────────────────────────
+layout(set = 0, binding = 1) uniform sampler2D   uNormalMap;    // terrain macro normal (Sobel)
+layout(set = 0, binding = 2) uniform TerrainFrameUbo {
+    mat4  viewProj;
+    mat4  prevViewProj;
+    vec4  cameraPos;
+    vec4  terrainParams;
+    vec4  terrainOrigin;
+    vec4  layerTiling; // x=grass, y=dirt, z=rock, w=snow (metres per tile)
+} ubo;
+layout(set = 0, binding = 3) uniform sampler2D      uSplatMap;    // RGBA8: R=grass,G=dirt,B=rock,A=snow
+layout(set = 0, binding = 4) uniform sampler2DArray uAlbedoArray; // 4 layers RGBA8
+layout(set = 0, binding = 5) uniform sampler2DArray uNormalArray; // 4 layers RGBA8 tangent-space
+layout(set = 0, binding = 6) uniform sampler2DArray uORMArray;    // 4 layers RGBA8 (R=AO,G=rough,B=metal)
 
-// Push constant — lodLevel reused for debug tinting (optional)
+// ── Push constants ────────────────────────────────────────────────────────────
 layout(push_constant) uniform PC {
     float patchOriginX;
     float patchOriginZ;
@@ -23,31 +39,88 @@ layout(push_constant) uniform PC {
     int   lodLevel;
 } pc;
 
+// ── GBuffer outputs ───────────────────────────────────────────────────────────
 layout(location = 0) out vec4 outAlbedo;    // GBufferA
 layout(location = 1) out vec4 outNormal;    // GBufferB
 layout(location = 2) out vec4 outORM;       // GBufferC
 layout(location = 3) out vec4 outVelocity;  // GBufferVelocity
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Triplanar sampling helper
+//
+// Samples a texture array at the given layer index from three world-space planes
+// (YZ, XZ, XY) and blends the results by the absolute value of the surface normal.
+// The blend sharpness is controlled by the power applied to the blend weights.
+// The UV coordinates are scaled by (1.0 / tilingMetres) so that one tile spans
+// `tilingMetres` world units.
+// ─────────────────────────────────────────────────────────────────────────────
+vec4 triplanarSample(sampler2DArray arr, float layer,
+                     vec3 worldPos, vec3 normal, float tilingMetres)
+{
+    float invTiling = 1.0 / max(tilingMetres, 0.1);
+
+    // UVs for each projection plane
+    vec2 uvYZ = worldPos.yz * invTiling; // sampled along X axis
+    vec2 uvXZ = worldPos.xz * invTiling; // sampled along Y axis (top-down)
+    vec2 uvXY = worldPos.xy * invTiling; // sampled along Z axis
+
+    // Blend weights: absolute normal components, bias for sharper transitions
+    vec3 blend = abs(normal);
+    blend = max(blend - 0.2, 0.0);
+    float blendSum = blend.x + blend.y + blend.z;
+    blend /= max(blendSum, 1e-6);
+
+    vec4 xSample = texture(arr, vec3(uvYZ, layer));
+    vec4 ySample = texture(arr, vec3(uvXZ, layer));
+    vec4 zSample = texture(arr, vec3(uvXY, layer));
+
+    return xSample * blend.x + ySample * blend.y + zSample * blend.z;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 void main()
 {
-    // ── Albedo — simple height-based colour (dirt/grass) ──────────────────────
-    // Normalised height derived from world Y; terrain height range is [0, heightScale].
-    float heightNorm = clamp(vWorldPos.y * 0.005, 0.0, 1.0);
-    vec3 grassColour = vec3(0.35, 0.55, 0.20);
-    vec3 rockColour  = vec3(0.50, 0.42, 0.32);
-    vec3 albedo      = mix(grassColour, rockColour, heightNorm);
-    outAlbedo        = vec4(albedo, 1.0);
+    // ── Decode terrain macro normal ───────────────────────────────────────────
+    vec3 macroN = normalize(texture(uNormalMap, vUV).rgb * 2.0 - 1.0);
 
-    // ── Normal — decode pre-baked Sobel normal map ────────────────────────────
-    vec3 N = texture(uNormalMap, vUV).rgb * 2.0 - 1.0;
-    N = normalize(N);
-    outNormal = vec4(N * 0.5 + 0.5, 1.0);
+    // ── Read splat weights and normalise (Σ = 1) ─────────────────────────────
+    vec4 splat     = texture(uSplatMap, vUV);
+    float totalW   = splat.r + splat.g + splat.b + splat.a;
+    vec4  w        = splat / max(totalW, 1e-6);
 
-    // ── ORM — no pre-baked AO, moderate roughness, non-metallic ─────────────
-    outORM = vec4(1.0,   // AO = 1 (no occlusion)
-                  0.85,  // Roughness = 0.85 (rough terrain)
-                  0.0,   // Metallic  = 0
-                  1.0);
+    // ── Per-layer tiling ──────────────────────────────────────────────────────
+    float tilingGrass = ubo.layerTiling.x;
+    float tilingDirt  = ubo.layerTiling.y;
+    float tilingRock  = ubo.layerTiling.z;
+    float tilingSnow  = ubo.layerTiling.w;
+
+    // ── Sample and blend albedo (triplanar per layer) ─────────────────────────
+    vec3 albedo = vec3(0.0);
+    albedo += triplanarSample(uAlbedoArray, 0.0, vWorldPos, macroN, tilingGrass).rgb * w.r;
+    albedo += triplanarSample(uAlbedoArray, 1.0, vWorldPos, macroN, tilingDirt ).rgb * w.g;
+    albedo += triplanarSample(uAlbedoArray, 2.0, vWorldPos, macroN, tilingRock ).rgb * w.b;
+    albedo += triplanarSample(uAlbedoArray, 3.0, vWorldPos, macroN, tilingSnow ).rgb * w.a;
+    outAlbedo = vec4(albedo, 1.0);
+
+    // ── Sample and blend detail normals (triplanar per layer) ─────────────────
+    // Detail normals are stored as RGB tangent-space normals (N * 0.5 + 0.5).
+    vec3 detailN = vec3(0.0);
+    detailN += triplanarSample(uNormalArray, 0.0, vWorldPos, macroN, tilingGrass).rgb * w.r;
+    detailN += triplanarSample(uNormalArray, 1.0, vWorldPos, macroN, tilingDirt ).rgb * w.g;
+    detailN += triplanarSample(uNormalArray, 2.0, vWorldPos, macroN, tilingRock ).rgb * w.b;
+    detailN += triplanarSample(uNormalArray, 3.0, vWorldPos, macroN, tilingSnow ).rgb * w.a;
+    // Decode blended detail normal and combine with macro normal
+    vec3 detailNWorld = normalize(detailN * 2.0 - 1.0);
+    vec3 blendedN     = normalize(macroN + detailNWorld);
+    outNormal = vec4(blendedN * 0.5 + 0.5, 1.0);
+
+    // ── Sample and blend ORM (triplanar per layer) ────────────────────────────
+    vec4 orm = vec4(0.0);
+    orm += triplanarSample(uORMArray, 0.0, vWorldPos, macroN, tilingGrass) * w.r;
+    orm += triplanarSample(uORMArray, 1.0, vWorldPos, macroN, tilingDirt ) * w.g;
+    orm += triplanarSample(uORMArray, 2.0, vWorldPos, macroN, tilingRock ) * w.b;
+    orm += triplanarSample(uORMArray, 3.0, vWorldPos, macroN, tilingSnow ) * w.a;
+    outORM = orm;
 
     // ── Velocity for TAA reprojection ─────────────────────────────────────────
     vec2 prevNDC = vPrevClip.xy / max(vPrevClip.w, 1e-6);

--- a/game/data/shaders/terrain.vert
+++ b/game/data/shaders/terrain.vert
@@ -1,13 +1,17 @@
 #version 450
-// M34.1: Terrain vertex shader — heightmap displacement + geomorphing.
+// M34.1/M34.2: Terrain vertex shader — heightmap displacement + geomorphing.
 //
 // Vertex input:
 //   location 0: vec2 inPatchLocal  — local XZ position in [0, kPatchQuads] (raw grid index)
 //
 // Descriptor set 0:
-//   binding 0: sampler2D uHeightmap  (R16_UNORM)
-//   binding 1: sampler2D uNormalMap  (RGBA8_UNORM, unused in vert)
+//   binding 0: sampler2D uHeightmap      (R16_UNORM)
+//   binding 1: sampler2D uNormalMap      (RGBA8_UNORM, unused in vert)
 //   binding 2: TerrainFrameUbo
+//   binding 3: sampler2D uSplatMap       (RGBA8_UNORM, unused in vert)
+//   binding 4: sampler2DArray uAlbedoArray (RGBA8_UNORM, unused in vert)
+//   binding 5: sampler2DArray uNormalArray (RGBA8_UNORM, unused in vert)
+//   binding 6: sampler2DArray uORMArray    (RGBA8_UNORM, unused in vert)
 //
 // Push constants (16 bytes):
 //   vec2  patchOriginXZ  — world XZ of patch corner
@@ -26,6 +30,7 @@ layout(set = 0, binding = 2) uniform TerrainFrameUbo {
     vec4  cameraPos;      // world camera position (xyz, w=unused)
     vec4  terrainParams;  // x=terrainSize, y=heightScale, z=vertStepWorld, w=unused
     vec4  terrainOrigin;  // x=originX, y=originZ, z=unused, w=unused
+    vec4  layerTiling;    // x=grass, y=dirt, z=rock, w=snow tiling (metres per tile)
 } ubo;
 
 layout(push_constant) uniform PC {


### PR DESCRIPTION
- Add TerrainSplatting class (engine/render/terrain/):
  - SplatMapGpu: RGBA8 1024×1024 splat map (R=grass,G=dirt,B=rock,A=snow)
  - TextureArrayGpu: 2D_ARRAY with kSplatLayerCount=4 layers
  - Uploads albedo, normal, ORM texture arrays (solid-colour placeholders MVP)
  - Per-layer tiling config via terrain.splat.tiling_* keys
  - All GPU allocs use raw Vulkan (no VMA), consistent with BUILD_CHECK requirements
- Update TerrainRenderer:
  - Init signature adds splatmapRelPath parameter
  - Descriptor set layout extended to 7 bindings (3→7 samplers + 1 UBO)
  - Descriptor pool expanded (6 sampler descriptors)
  - FrameUbo extended with layerTiling vec4 (offset 176, total 192 bytes)
  - Record() fills layerTiling from TerrainSplatting::GetLayerTiling()
  - Destroy() calls m_splatting.Destroy()
- Update terrain shaders:
  - terrain.vert: add layerTiling to TerrainFrameUbo struct
  - terrain.frag: full splatting + triplanar projection (XY/XZ/YZ planes), blends albedo/normal/ORM by normalised splat weights per layer
- CMakeLists.txt: add TerrainSplatting.cpp to engine sources

https://claude.ai/code/session_01WjGyN8zast75nMoRQRGh6h