### PR TITLE
M34.3: Terrain holes + cliffs + overhangs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ add_library(engine_core
   engine/render/terrain/HeightmapLoader.cpp
   engine/render/terrain/TerrainMesh.cpp
   engine/render/terrain/TerrainSplatting.cpp
+  engine/render/terrain/TerrainHoleMask.cpp
+  engine/render/terrain/TerrainCliffMesh.cpp
   engine/render/terrain/TerrainRenderer.cpp
   engine/network/ByteWriter.cpp
   engine/network/ByteReader.cpp

--- a/engine/render/terrain/TerrainCliffMesh.cpp
+++ b/engine/render/terrain/TerrainCliffMesh.cpp
@@ -1,0 +1,204 @@
+#include "engine/render/terrain/TerrainCliffMesh.h"
+#include "engine/core/Log.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstring>
+#include <fstream>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Allocates a HOST_VISIBLE | HOST_COHERENT buffer, copies data into it.
+        /// Returns true on success; sets buf/mem to VK_NULL_HANDLE on failure.
+        bool AllocAndFill(VkDevice device, VkPhysicalDevice physDev,
+                          VkBufferUsageFlags usage,
+                          const void* src, VkDeviceSize size,
+                          VkBuffer& outBuf, VkDeviceMemory& outMem)
+        {
+            VkBufferCreateInfo bci{};
+            bci.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bci.size        = size;
+            bci.usage       = usage;
+            bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bci, nullptr, &outBuf) != VK_SUCCESS)
+                return false;
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, outBuf, &req);
+
+            const uint32_t mt = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (mt == UINT32_MAX)
+            {
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = mt;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMem) != VK_SUCCESS)
+            {
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            vkBindBufferMemory(device, outBuf, outMem, 0);
+
+            void* mapped = nullptr;
+            vkMapMemory(device, outMem, 0, size, 0, &mapped);
+            std::memcpy(mapped, src, static_cast<size_t>(size));
+            vkUnmapMemory(device, outMem);
+
+            return true;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainCliffMesh::LoadFromFile
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool TerrainCliffMesh::LoadFromFile(const std::string& fullPath, CliffMeshData& outData)
+    {
+        std::ifstream fs(fullPath, std::ios::binary);
+        if (!fs.is_open())
+        {
+            LOG_WARN(Render, "[TerrainCliffMesh] File not found: '{}'", fullPath);
+            return false;
+        }
+
+        uint32_t magic       = 0u;
+        uint32_t vertexCount = 0u;
+        uint32_t indexCount  = 0u;
+        fs.read(reinterpret_cast<char*>(&magic),       sizeof(magic));
+        fs.read(reinterpret_cast<char*>(&vertexCount), sizeof(vertexCount));
+        fs.read(reinterpret_cast<char*>(&indexCount),  sizeof(indexCount));
+
+        if (!fs || magic != kCliffMeshMagic)
+        {
+            LOG_WARN(Render, "[TerrainCliffMesh] Invalid magic in '{}' (got 0x{:08X}, expected 0x{:08X})",
+                     fullPath, magic, kCliffMeshMagic);
+            return false;
+        }
+
+        if (vertexCount == 0u || indexCount == 0u)
+        {
+            LOG_WARN(Render, "[TerrainCliffMesh] Empty mesh in '{}'", fullPath);
+            return false;
+        }
+
+        if (indexCount % 3u != 0u)
+        {
+            LOG_WARN(Render, "[TerrainCliffMesh] indexCount {} is not a multiple of 3 in '{}'",
+                     indexCount, fullPath);
+            return false;
+        }
+
+        outData.vertices.resize(vertexCount);
+        fs.read(reinterpret_cast<char*>(outData.vertices.data()),
+                static_cast<std::streamsize>(vertexCount * sizeof(CliffVertex)));
+
+        outData.indices.resize(indexCount);
+        fs.read(reinterpret_cast<char*>(outData.indices.data()),
+                static_cast<std::streamsize>(indexCount * sizeof(uint16_t)));
+
+        if (!fs)
+        {
+            LOG_WARN(Render, "[TerrainCliffMesh] Truncated data in '{}'", fullPath);
+            outData.vertices.clear();
+            outData.indices.clear();
+            return false;
+        }
+
+        LOG_INFO(Render, "[TerrainCliffMesh] Loaded '{}' ({} verts, {} tris)",
+                 fullPath, vertexCount, indexCount / 3u);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainCliffMesh::UploadToGpu
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool TerrainCliffMesh::UploadToGpu(VkDevice device, VkPhysicalDevice physDev,
+                                        const CliffMeshData& data,
+                                        CliffMeshGpu& outGpu)
+    {
+        if (data.vertices.empty() || data.indices.empty())
+        {
+            LOG_ERROR(Render, "[TerrainCliffMesh] UploadToGpu: empty mesh data");
+            return false;
+        }
+
+        const VkDeviceSize vbSize = static_cast<VkDeviceSize>(data.vertices.size()) * sizeof(CliffVertex);
+        const VkDeviceSize ibSize = static_cast<VkDeviceSize>(data.indices.size())  * sizeof(uint16_t);
+
+        if (!AllocAndFill(device, physDev, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                          data.vertices.data(), vbSize,
+                          outGpu.vertexBuffer, outGpu.vertexMemory))
+        {
+            LOG_ERROR(Render, "[TerrainCliffMesh] Failed to allocate vertex buffer");
+            return false;
+        }
+
+        if (!AllocAndFill(device, physDev, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+                          data.indices.data(), ibSize,
+                          outGpu.indexBuffer, outGpu.indexMemory))
+        {
+            LOG_ERROR(Render, "[TerrainCliffMesh] Failed to allocate index buffer");
+            // Clean up vertex buffer allocated above
+            vkDestroyBuffer(device, outGpu.vertexBuffer, nullptr);
+            vkFreeMemory(device, outGpu.vertexMemory, nullptr);
+            outGpu.vertexBuffer = VK_NULL_HANDLE;
+            outGpu.vertexMemory = VK_NULL_HANDLE;
+            return false;
+        }
+
+        outGpu.vertexCount = static_cast<uint32_t>(data.vertices.size());
+        outGpu.indexCount  = static_cast<uint32_t>(data.indices.size());
+
+        LOG_INFO(Render, "[TerrainCliffMesh] GPU upload OK ({} verts, {} tris)",
+                 outGpu.vertexCount, outGpu.indexCount / 3u);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainCliffMesh::DestroyGpu
+    // ─────────────────────────────────────────────────────────────────────────
+
+    void TerrainCliffMesh::DestroyGpu(VkDevice device, CliffMeshGpu& gpu)
+    {
+        if (gpu.indexBuffer  != VK_NULL_HANDLE) { vkDestroyBuffer(device, gpu.indexBuffer,  nullptr); gpu.indexBuffer  = VK_NULL_HANDLE; }
+        if (gpu.indexMemory  != VK_NULL_HANDLE) { vkFreeMemory(device, gpu.indexMemory,  nullptr);    gpu.indexMemory  = VK_NULL_HANDLE; }
+        if (gpu.vertexBuffer != VK_NULL_HANDLE) { vkDestroyBuffer(device, gpu.vertexBuffer, nullptr); gpu.vertexBuffer = VK_NULL_HANDLE; }
+        if (gpu.vertexMemory != VK_NULL_HANDLE) { vkFreeMemory(device, gpu.vertexMemory, nullptr);    gpu.vertexMemory = VK_NULL_HANDLE; }
+        gpu.vertexCount = 0u;
+        gpu.indexCount  = 0u;
+        LOG_INFO(Render, "[TerrainCliffMesh] GPU resources destroyed");
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainCliffMesh.h
+++ b/engine/render/terrain/TerrainCliffMesh.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::render::terrain
+{
+    /// Binary format for .cliff files (little-endian):
+    ///   magic       : uint32  = 0x46464C43 ('CLFF')
+    ///   vertexCount : uint32
+    ///   indexCount  : uint32  (must be multiple of 3)
+    ///   vertices    : CliffVertex[vertexCount]
+    ///   indices     : uint16[indexCount]
+    ///
+    /// The mesh is in world space. Vertices at the border between cliff and
+    /// terrain use blendWeight = 1.0 ("terrain side") so that the edge can
+    /// be hidden beneath the heightmap surface. Interior cliff vertices use
+    /// blendWeight = 0.0.
+    static constexpr uint32_t kCliffMeshMagic = 0x46464C43u; // 'CLFF'
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Cliff vertex format
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// A single cliff mesh vertex (36 bytes).
+    ///
+    /// Layout (used by terrain_cliff.vert):
+    ///   location 0: vec3 position    — world-space XYZ
+    ///   location 1: vec3 normal      — world-space vertex normal (unit)
+    ///   location 2: vec2 uv          — texture UV [0,1]
+    ///   location 3: float blendWeight — 0=cliff interior, 1=terrain-blended edge
+    struct CliffVertex
+    {
+        float position[3]  = { 0.f, 0.f, 0.f }; ///< World-space position
+        float normal[3]    = { 0.f, 1.f, 0.f }; ///< World-space normal (unit)
+        float uv[2]        = { 0.f, 0.f };       ///< Texture UV
+        float blendWeight  = 0.f;                 ///< 0=cliff, 1=terrain-edge blend
+    };
+    static_assert(sizeof(CliffVertex) == 36u, "CliffVertex must be 36 bytes");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CPU cliff mesh data
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// CPU-side cliff mesh data (after loading from a .cliff file).
+    struct CliffMeshData
+    {
+        std::vector<CliffVertex> vertices;
+        std::vector<uint16_t>    indices;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GPU cliff mesh resources
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// GPU resources for one cliff mesh instance.
+    struct CliffMeshGpu
+    {
+        VkBuffer       vertexBuffer = VK_NULL_HANDLE;
+        VkDeviceMemory vertexMemory = VK_NULL_HANDLE;
+        VkBuffer       indexBuffer  = VK_NULL_HANDLE;
+        VkDeviceMemory indexMemory  = VK_NULL_HANDLE;
+        uint32_t       vertexCount  = 0u;
+        uint32_t       indexCount   = 0u;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainCliffMesh — static utility class
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Loads and uploads manually-authored cliff mesh geometry.
+    ///
+    /// Cliff meshes are placed in world space and rendered into the same GBuffer
+    /// as terrain (using the terrain_cliff.vert / terrain_cliff.frag shaders).
+    /// Each cliff mesh file corresponds to one placed cliff section.
+    ///
+    /// The "blend edge" pattern is encoded in blendWeight:
+    ///   - Vertices at the junction between cliff and heightmap terrain have
+    ///     blendWeight = 1.0, indicating they should be snapped to the heightmap
+    ///     surface during rendering or dissolved into it.
+    ///   - Interior cliff vertices have blendWeight = 0.0.
+    class TerrainCliffMesh
+    {
+    public:
+        TerrainCliffMesh() = delete;
+
+        /// Loads a cliff mesh from a .cliff binary file.
+        ///
+        /// \param fullPath  Resolved filesystem path to the .cliff file.
+        /// \param outData   Populated on success.
+        /// \return true on success, false if file is missing or malformed.
+        static bool LoadFromFile(const std::string& fullPath, CliffMeshData& outData);
+
+        /// Uploads a CPU cliff mesh to the GPU.
+        ///
+        /// Both vertex and index buffers are allocated as HOST_VISIBLE | HOST_COHERENT
+        /// (raw Vulkan, no VMA). No staging upload needed for small cliff meshes.
+        ///
+        /// \return true on success.
+        static bool UploadToGpu(VkDevice device, VkPhysicalDevice physDev,
+                                 const CliffMeshData& data,
+                                 CliffMeshGpu& outGpu);
+
+        /// Destroys all GPU resources for a cliff mesh. Safe on null handles.
+        static void DestroyGpu(VkDevice device, CliffMeshGpu& gpu);
+    };
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainHoleMask.cpp
+++ b/engine/render/terrain/TerrainHoleMask.cpp
@@ -1,0 +1,407 @@
+#include "engine/render/terrain/TerrainHoleMask.h"
+#include "engine/core/Log.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstring>
+#include <fstream>
+#include <functional>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────
+    // HoleMaskData
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool HoleMaskData::IsHole(uint32_t qx, uint32_t qz) const
+    {
+        if (qx >= width || qz >= height) return false;
+        return mask[qz * width + qx] == 0u;
+    }
+
+    bool HoleMaskData::HasAnyHole() const
+    {
+        for (uint8_t v : mask)
+            if (v == 0u) return true;
+        return false;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Submits a one-time command buffer: begin → record(fn) → end → submit → wait.
+        bool OneTimeSubmit(VkDevice device, VkQueue queue,
+                           uint32_t queueFamilyIndex,
+                           const std::function<void(VkCommandBuffer)>& record)
+        {
+            VkCommandPoolCreateInfo poolCI{};
+            poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+            poolCI.queueFamilyIndex = queueFamilyIndex;
+
+            VkCommandPool pool = VK_NULL_HANDLE;
+            if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS)
+                return false;
+
+            VkCommandBufferAllocateInfo cbAI{};
+            cbAI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            cbAI.commandPool        = pool;
+            cbAI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            cbAI.commandBufferCount = 1;
+
+            VkCommandBuffer cmd = VK_NULL_HANDLE;
+            if (vkAllocateCommandBuffers(device, &cbAI, &cmd) != VK_SUCCESS)
+            {
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            VkCommandBufferBeginInfo beginInfo{};
+            beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkBeginCommandBuffer(cmd, &beginInfo);
+            record(cmd);
+            vkEndCommandBuffer(cmd);
+
+            VkSubmitInfo si{};
+            si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            si.commandBufferCount = 1;
+            si.pCommandBuffers    = &cmd;
+            vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE);
+            vkQueueWaitIdle(queue);
+
+            vkDestroyCommandPool(device, pool, nullptr);
+            return true;
+        }
+    } // namespace
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainHoleMask::LoadFromFile
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool TerrainHoleMask::LoadFromFile(const std::string& fullPath, HoleMaskData& outData)
+    {
+        std::ifstream fs(fullPath, std::ios::binary);
+        if (!fs.is_open())
+        {
+            LOG_WARN(Render, "[TerrainHoleMask] File not found: '{}'", fullPath);
+            return false;
+        }
+
+        uint32_t magic  = 0u;
+        uint32_t width  = 0u;
+        uint32_t height = 0u;
+        fs.read(reinterpret_cast<char*>(&magic),  sizeof(magic));
+        fs.read(reinterpret_cast<char*>(&width),  sizeof(width));
+        fs.read(reinterpret_cast<char*>(&height), sizeof(height));
+
+        if (!fs || magic != kHoleMaskMagic)
+        {
+            LOG_WARN(Render, "[TerrainHoleMask] Invalid magic in '{}' (got 0x{:08X}, expected 0x{:08X})",
+                     fullPath, magic, kHoleMaskMagic);
+            return false;
+        }
+
+        if (width == 0u || height == 0u)
+        {
+            LOG_WARN(Render, "[TerrainHoleMask] Zero-size mask in '{}'", fullPath);
+            return false;
+        }
+
+        const size_t dataSize = static_cast<size_t>(width) * height;
+        outData.mask.resize(dataSize);
+        fs.read(reinterpret_cast<char*>(outData.mask.data()), static_cast<std::streamsize>(dataSize));
+
+        if (!fs)
+        {
+            LOG_WARN(Render, "[TerrainHoleMask] Truncated data in '{}'", fullPath);
+            outData.mask.clear();
+            return false;
+        }
+
+        outData.width  = width;
+        outData.height = height;
+
+        const bool hasHoles = outData.HasAnyHole();
+        LOG_INFO(Render, "[TerrainHoleMask] Loaded '{}' ({}×{} quads, holes={})",
+                 fullPath, width, height, hasHoles ? "yes" : "no");
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainHoleMask::GenerateSolid
+    // ─────────────────────────────────────────────────────────────────────────
+
+    void TerrainHoleMask::GenerateSolid(uint32_t quadW, uint32_t quadH, HoleMaskData& outData)
+    {
+        outData.width  = quadW;
+        outData.height = quadH;
+        outData.mask.assign(static_cast<size_t>(quadW) * quadH, 255u);
+        LOG_DEBUG(Render, "[TerrainHoleMask] Generated solid fallback mask ({}×{} quads)", quadW, quadH);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainHoleMask::UploadToGpu
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool TerrainHoleMask::UploadToGpu(VkDevice device, VkPhysicalDevice physDev,
+                                      const HoleMaskData& data,
+                                      VkQueue queue, uint32_t queueFamilyIndex,
+                                      HoleMaskGpu& outGpu)
+    {
+        if (data.width == 0u || data.height == 0u || data.mask.empty())
+        {
+            LOG_ERROR(Render, "[TerrainHoleMask] UploadToGpu: empty data");
+            return false;
+        }
+
+        const VkDeviceSize dataBytes = static_cast<VkDeviceSize>(data.width) * data.height;
+
+        // ── Staging buffer (HOST_VISIBLE | HOST_COHERENT) ─────────────────────
+        VkBuffer       stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        {
+            VkBufferCreateInfo bci{};
+            bci.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bci.size        = dataBytes;
+            bci.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bci, nullptr, &stagingBuf) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkCreateBuffer (staging) failed");
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, stagingBuf, &req);
+
+            const uint32_t mt = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (mt == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] No HOST_VISIBLE memory for staging");
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = mt;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &stagingMem) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkAllocateMemory (staging) failed");
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                return false;
+            }
+            vkBindBufferMemory(device, stagingBuf, stagingMem, 0);
+
+            void* mapped = nullptr;
+            vkMapMemory(device, stagingMem, 0, dataBytes, 0, &mapped);
+            std::memcpy(mapped, data.mask.data(), static_cast<size_t>(dataBytes));
+            vkUnmapMemory(device, stagingMem);
+        }
+
+        // ── Device-local R8_UNORM image ──────────────────────────────────────
+        {
+            VkImageCreateInfo ici{};
+            ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            ici.imageType     = VK_IMAGE_TYPE_2D;
+            ici.format        = VK_FORMAT_R8_UNORM;
+            ici.extent        = { data.width, data.height, 1u };
+            ici.mipLevels     = 1u;
+            ici.arrayLayers   = 1u;
+            ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+            ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+            ici.usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+            ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+            ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+            if (vkCreateImage(device, &ici, nullptr, &outGpu.image) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkCreateImage failed");
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                vkFreeMemory(device, stagingMem, nullptr);
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetImageMemoryRequirements(device, outGpu.image, &req);
+
+            const uint32_t mt = FindMemType(physDev, req.memoryTypeBits,
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            if (mt == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] No DEVICE_LOCAL memory for image");
+                vkDestroyImage(device, outGpu.image, nullptr);
+                outGpu.image = VK_NULL_HANDLE;
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                vkFreeMemory(device, stagingMem, nullptr);
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = mt;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outGpu.memory) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkAllocateMemory (image) failed");
+                vkDestroyImage(device, outGpu.image, nullptr);
+                outGpu.image = VK_NULL_HANDLE;
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                vkFreeMemory(device, stagingMem, nullptr);
+                return false;
+            }
+            vkBindImageMemory(device, outGpu.image, outGpu.memory, 0);
+        }
+
+        // ── Upload via staging (UNDEFINED → TRANSFER_DST → SHADER_READ_ONLY) ─
+        const bool uploaded = OneTimeSubmit(device, queue, queueFamilyIndex,
+            [&](VkCommandBuffer cmd)
+            {
+                // Transition: UNDEFINED → TRANSFER_DST_OPTIMAL
+                VkImageMemoryBarrier barrier{};
+                barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.oldLayout                       = VK_IMAGE_LAYOUT_UNDEFINED;
+                barrier.newLayout                       = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                barrier.image                           = outGpu.image;
+                barrier.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                barrier.subresourceRange.baseMipLevel   = 0;
+                barrier.subresourceRange.levelCount     = 1;
+                barrier.subresourceRange.baseArrayLayer = 0;
+                barrier.subresourceRange.layerCount     = 1;
+                barrier.srcAccessMask                   = 0;
+                barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+                // Copy staging buffer → image
+                VkBufferImageCopy region{};
+                region.bufferOffset                    = 0;
+                region.bufferRowLength                 = 0;
+                region.bufferImageHeight               = 0;
+                region.imageSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                region.imageSubresource.mipLevel       = 0;
+                region.imageSubresource.baseArrayLayer = 0;
+                region.imageSubresource.layerCount     = 1;
+                region.imageOffset                     = { 0, 0, 0 };
+                region.imageExtent                     = { data.width, data.height, 1u };
+                vkCmdCopyBufferToImage(cmd, stagingBuf, outGpu.image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+                // Transition: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
+                barrier.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barrier.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &barrier);
+            });
+
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+
+        if (!uploaded)
+        {
+            LOG_ERROR(Render, "[TerrainHoleMask] OneTimeSubmit upload failed");
+            DestroyGpu(device, outGpu);
+            return false;
+        }
+
+        // ── Image view ────────────────────────────────────────────────────────
+        {
+            VkImageViewCreateInfo vci{};
+            vci.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            vci.image                           = outGpu.image;
+            vci.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+            vci.format                          = VK_FORMAT_R8_UNORM;
+            vci.components.r                    = VK_COMPONENT_SWIZZLE_R;
+            vci.components.g                    = VK_COMPONENT_SWIZZLE_ZERO;
+            vci.components.b                    = VK_COMPONENT_SWIZZLE_ZERO;
+            vci.components.a                    = VK_COMPONENT_SWIZZLE_ONE;
+            vci.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            vci.subresourceRange.baseMipLevel   = 0;
+            vci.subresourceRange.levelCount     = 1;
+            vci.subresourceRange.baseArrayLayer = 0;
+            vci.subresourceRange.layerCount     = 1;
+
+            if (vkCreateImageView(device, &vci, nullptr, &outGpu.view) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkCreateImageView failed");
+                DestroyGpu(device, outGpu);
+                return false;
+            }
+        }
+
+        // ── Sampler (NEAREST — one texel per quad, no interpolation) ─────────
+        {
+            VkSamplerCreateInfo sci{};
+            sci.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+            sci.magFilter    = VK_FILTER_NEAREST;
+            sci.minFilter    = VK_FILTER_NEAREST;
+            sci.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+            sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+            sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+            sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+            sci.minLod       = 0.0f;
+            sci.maxLod       = 0.0f;
+
+            if (vkCreateSampler(device, &sci, nullptr, &outGpu.sampler) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainHoleMask] vkCreateSampler failed");
+                DestroyGpu(device, outGpu);
+                return false;
+            }
+        }
+
+        outGpu.width  = data.width;
+        outGpu.height = data.height;
+
+        LOG_INFO(Render, "[TerrainHoleMask] GPU upload OK ({}×{} quads, R8_UNORM)",
+                 data.width, data.height);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainHoleMask::DestroyGpu
+    // ─────────────────────────────────────────────────────────────────────────
+
+    void TerrainHoleMask::DestroyGpu(VkDevice device, HoleMaskGpu& gpu)
+    {
+        if (gpu.sampler != VK_NULL_HANDLE) { vkDestroySampler(device, gpu.sampler, nullptr);   gpu.sampler = VK_NULL_HANDLE; }
+        if (gpu.view    != VK_NULL_HANDLE) { vkDestroyImageView(device, gpu.view, nullptr);    gpu.view    = VK_NULL_HANDLE; }
+        if (gpu.image   != VK_NULL_HANDLE) { vkDestroyImage(device, gpu.image, nullptr);       gpu.image   = VK_NULL_HANDLE; }
+        if (gpu.memory  != VK_NULL_HANDLE) { vkFreeMemory(device, gpu.memory, nullptr);        gpu.memory  = VK_NULL_HANDLE; }
+        gpu.width  = 0u;
+        gpu.height = 0u;
+        LOG_INFO(Render, "[TerrainHoleMask] GPU resources destroyed");
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainHoleMask.h
+++ b/engine/render/terrain/TerrainHoleMask.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::render::terrain
+{
+    /// Binary format for .hmask files (little-endian):
+    ///   magic  : uint32  = 0x4B534D48 ('HMSK')
+    ///   width  : uint32  (number of quads along X = heightmap.width  - 1)
+    ///   height : uint32  (number of quads along Z = heightmap.height - 1)
+    ///   data   : uint8[width * height]
+    ///            0   = hole (transparent, unwalkable)
+    ///            255 = solid (opaque, walkable)
+    ///
+    /// Pixel (qx, qz) addresses quad column qx, row qz (row-major: qz * width + qx).
+    static constexpr uint32_t kHoleMaskMagic = 0x4B534D48u; // 'HMSK'
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CPU-side hole mask data
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// CPU-side R8 hole mask.
+    struct HoleMaskData
+    {
+        uint32_t             width  = 0; ///< Number of quads along X
+        uint32_t             height = 0; ///< Number of quads along Z
+        std::vector<uint8_t> mask;       ///< Row-major, index = qz * width + qx
+
+        /// Returns true if the quad at (qx, qz) is a hole.
+        /// Returns false (solid) for out-of-bounds coordinates.
+        bool IsHole(uint32_t qx, uint32_t qz) const;
+
+        /// Returns true if any quad in the data is a hole (value == 0).
+        bool HasAnyHole() const;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GPU hole mask texture
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// GPU R8_UNORM hole mask texture (DEVICE_LOCAL, OPTIMAL tiling).
+    /// Sampled in the terrain fragment shader at binding 7.
+    /// Value 0.0 = hole (fragment discarded), 1.0 = solid (fragment kept).
+    struct HoleMaskGpu
+    {
+        VkImage        image   = VK_NULL_HANDLE;
+        VkImageView    view    = VK_NULL_HANDLE;
+        VkDeviceMemory memory  = VK_NULL_HANDLE;
+        VkSampler      sampler = VK_NULL_HANDLE;
+        uint32_t       width   = 0;
+        uint32_t       height  = 0;
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TerrainHoleMask — static utility class
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Manages terrain hole mask resources: file loading, GPU upload, and navmesh query.
+    ///
+    /// If the hole mask file is absent or invalid, a fully-solid fallback mask
+    /// is generated (all bytes = 255) so the terrain renders without holes.
+    class TerrainHoleMask
+    {
+    public:
+        TerrainHoleMask() = delete;
+
+        /// Loads a hole mask from a .hmask binary file.
+        ///
+        /// \param fullPath  Resolved filesystem path to the .hmask file.
+        /// \param outData   Populated on success.
+        /// \return true on success, false if file is missing or malformed.
+        static bool LoadFromFile(const std::string& fullPath, HoleMaskData& outData);
+
+        /// Generates a fully-solid fallback mask (all 255) for the given quad grid.
+        ///
+        /// Used when the hole mask file is absent so the system degrades gracefully.
+        /// \param quadW  Width in quads  (heightmap.width  - 1)
+        /// \param quadH  Height in quads (heightmap.height - 1)
+        static void GenerateSolid(uint32_t quadW, uint32_t quadH, HoleMaskData& outData);
+
+        /// Uploads the CPU hole mask to the GPU as an R8_UNORM sampled texture.
+        ///
+        /// The texture resolution matches the quad grid (one texel per quad).
+        /// Resulting image is in VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.
+        /// Uses raw Vulkan allocations (no VMA). Upload via staging buffer +
+        /// one-time command buffer.
+        ///
+        /// \param queue             Graphics queue for the one-time copy.
+        /// \param queueFamilyIndex  Family index of the graphics queue.
+        /// \return true on success.
+        static bool UploadToGpu(VkDevice device, VkPhysicalDevice physDev,
+                                 const HoleMaskData& data,
+                                 VkQueue queue, uint32_t queueFamilyIndex,
+                                 HoleMaskGpu& outGpu);
+
+        /// Destroys all GPU resources. Safe to call on null handles.
+        static void DestroyGpu(VkDevice device, HoleMaskGpu& gpu);
+    };
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <functional>
 
 namespace engine::render::terrain
 {
@@ -63,13 +64,17 @@ namespace engine::render::terrain
                                const engine::core::Config& config,
                                const std::string& heightmapRelPath,
                                const std::string& splatmapRelPath,
+                               const std::string& holeMaskRelPath,
+                               const std::vector<std::string>& cliffMeshRelPaths,
                                VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
                                VkFormat fmtVelocity, VkFormat fmtDepth,
                                VkQueue queue, uint32_t queueFamilyIndex,
                                ShaderLoaderFn loadSpirv)
     {
-        LOG_INFO(Render, "[TerrainRenderer] Init begin (heightmap='{}' splatmap='{}')",
-                 heightmapRelPath, splatmapRelPath);
+        LOG_INFO(Render,
+                 "[TerrainRenderer] Init begin (heightmap='{}' splatmap='{}' holemask='{}' cliffs={})",
+                 heightmapRelPath, splatmapRelPath, holeMaskRelPath,
+                 static_cast<uint32_t>(cliffMeshRelPaths.size()));
 
         if (device == VK_NULL_HANDLE || physDev == VK_NULL_HANDLE || !loadSpirv)
         {
@@ -145,6 +150,32 @@ namespace engine::render::terrain
                 "[TerrainRenderer] TerrainSplatting Init failed — terrain disabled");
             Destroy(device);
             return false;
+        }
+
+        // ── M34.3: Load hole mask (graceful fallback if absent) ───────────────────
+        {
+            const std::string contentPath = config.GetString("paths.content", "game/data");
+            const std::string fullPath    = contentPath + "/" + holeMaskRelPath;
+
+            if (holeMaskRelPath.empty() ||
+                !TerrainHoleMask::LoadFromFile(fullPath, m_holeMaskData))
+            {
+                LOG_WARN(Render,
+                    "[TerrainRenderer] Hole mask '{}' not found — using fully-solid fallback",
+                    holeMaskRelPath);
+                // Fallback: one entry per terrain quad, all solid (no holes).
+                const uint32_t quadW = (m_heightmapData.width  > 0u) ? m_heightmapData.width  - 1u : 0u;
+                const uint32_t quadH = (m_heightmapData.height > 0u) ? m_heightmapData.height - 1u : 0u;
+                TerrainHoleMask::GenerateSolid(quadW, quadH, m_holeMaskData);
+            }
+
+            if (!TerrainHoleMask::UploadToGpu(device, physDev, m_holeMaskData,
+                                               queue, queueFamilyIndex, m_holeMaskGpu))
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] Hole mask GPU upload failed");
+                Destroy(device);
+                return false;
+            }
         }
 
         // ── Build patch list ──────────────────────────────────────────────────────
@@ -263,7 +294,7 @@ namespace engine::render::terrain
 
         // ── Descriptor set layout ─────────────────────────────────────────────────
         {
-            VkDescriptorSetLayoutBinding bindings[7]{};
+            VkDescriptorSetLayoutBinding bindings[8]{};
             // binding 0: heightmap sampler (vertex + fragment)
             bindings[0].binding            = 0;
             bindings[0].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -299,10 +330,15 @@ namespace engine::render::terrain
             bindings[6].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             bindings[6].descriptorCount    = 1;
             bindings[6].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+            // binding 7: hole mask (fragment) — R8_UNORM, 0=hole, 1=solid (M34.3)
+            bindings[7].binding            = 7;
+            bindings[7].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[7].descriptorCount    = 1;
+            bindings[7].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
 
             VkDescriptorSetLayoutCreateInfo dslCI{};
             dslCI.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-            dslCI.bindingCount = 7;
+            dslCI.bindingCount = 8;
             dslCI.pBindings    = bindings;
 
             if (vkCreateDescriptorSetLayout(device, &dslCI, nullptr, &m_descSetLayout) != VK_SUCCESS)
@@ -484,7 +520,8 @@ namespace engine::render::terrain
         {
             VkDescriptorPoolSize poolSizes[2]{};
             poolSizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-            poolSizes[0].descriptorCount = 6; // heightmap + normalmap + splatmap + albedoArr + normalArr + ormArr
+            // heightmap + normalmap + splatmap + albedoArr + normalArr + ormArr + holeMask (M34.3)
+            poolSizes[0].descriptorCount = 7;
             poolSizes[1].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             poolSizes[1].descriptorCount = 1;
 
@@ -600,7 +637,13 @@ namespace engine::render::terrain
             ormArrayInfo.imageView   = m_splatting.GetORMArray().view;
             ormArrayInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-            VkWriteDescriptorSet writes[7]{};
+            // M34.3: hole mask descriptor info (binding 7)
+            VkDescriptorImageInfo holeMaskInfo{};
+            holeMaskInfo.sampler     = m_holeMaskGpu.sampler;
+            holeMaskInfo.imageView   = m_holeMaskGpu.view;
+            holeMaskInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkWriteDescriptorSet writes[8]{};
             writes[0].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writes[0].dstSet          = m_descSet;
             writes[0].dstBinding      = 0;
@@ -650,7 +693,474 @@ namespace engine::render::terrain
             writes[6].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             writes[6].pImageInfo      = &ormArrayInfo;
 
-            vkUpdateDescriptorSets(device, 7, writes, 0, nullptr);
+            // binding 7: hole mask (M34.3)
+            writes[7].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[7].dstSet          = m_descSet;
+            writes[7].dstBinding      = 7;
+            writes[7].descriptorCount = 1;
+            writes[7].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[7].pImageInfo      = &holeMaskInfo;
+
+            vkUpdateDescriptorSets(device, 8, writes, 0, nullptr);
+        }
+
+        // ── M34.3: Load cliff meshes ──────────────────────────────────────────────
+        {
+            const std::string contentPath = config.GetString("paths.content", "game/data");
+            for (const std::string& relPath : cliffMeshRelPaths)
+            {
+                const std::string fullPath = contentPath + "/" + relPath;
+                CliffMeshData data;
+                if (!TerrainCliffMesh::LoadFromFile(fullPath, data))
+                {
+                    LOG_WARN(Render, "[TerrainRenderer] Cliff mesh '{}' skipped (load failed)", relPath);
+                    continue;
+                }
+
+                CliffMeshGpu gpu;
+                if (!TerrainCliffMesh::UploadToGpu(device, physDev, data, gpu))
+                {
+                    LOG_WARN(Render, "[TerrainRenderer] Cliff mesh '{}' skipped (GPU upload failed)", relPath);
+                    continue;
+                }
+
+                m_cliffMeshes.push_back(gpu);
+                LOG_DEBUG(Render, "[TerrainRenderer] Cliff mesh '{}' loaded (slot {})",
+                          relPath, static_cast<uint32_t>(m_cliffMeshes.size()) - 1u);
+            }
+            LOG_INFO(Render, "[TerrainRenderer] Cliff meshes loaded: {}/{} OK",
+                     static_cast<uint32_t>(m_cliffMeshes.size()),
+                     static_cast<uint32_t>(cliffMeshRelPaths.size()));
+        }
+
+        // ── M34.3: Create cliff pipeline ─────────────────────────────────────────
+        // Only create the cliff pipeline when there are cliff meshes to render.
+        if (!m_cliffMeshes.empty())
+        {
+            // Descriptor set layout for cliff pipeline:
+            //   binding 0: CliffFrameUbo (vert + frag)
+            //   binding 1: cliff albedo sampler2D (frag)
+            VkDescriptorSetLayoutBinding cliffBindings[2]{};
+            cliffBindings[0].binding            = 0;
+            cliffBindings[0].descriptorType     = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            cliffBindings[0].descriptorCount    = 1;
+            cliffBindings[0].stageFlags         = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+            cliffBindings[1].binding            = 1;
+            cliffBindings[1].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            cliffBindings[1].descriptorCount    = 1;
+            cliffBindings[1].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+            VkDescriptorSetLayoutCreateInfo cliffDslCI{};
+            cliffDslCI.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+            cliffDslCI.bindingCount = 2;
+            cliffDslCI.pBindings    = cliffBindings;
+
+            if (vkCreateDescriptorSetLayout(device, &cliffDslCI, nullptr, &m_cliffDescSetLayout) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateDescriptorSetLayout (cliff) failed");
+                Destroy(device);
+                return false;
+            }
+
+            // Pipeline layout (no push constants for cliff pipeline)
+            VkPipelineLayoutCreateInfo cliffPlCI{};
+            cliffPlCI.sType          = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+            cliffPlCI.setLayoutCount = 1;
+            cliffPlCI.pSetLayouts    = &m_cliffDescSetLayout;
+
+            if (vkCreatePipelineLayout(device, &cliffPlCI, nullptr, &m_cliffPipelineLayout) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreatePipelineLayout (cliff) failed");
+                Destroy(device);
+                return false;
+            }
+
+            // Descriptor pool for cliff pipeline
+            VkDescriptorPoolSize cliffPoolSizes[2]{};
+            cliffPoolSizes[0].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            cliffPoolSizes[0].descriptorCount = 1;
+            cliffPoolSizes[1].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            cliffPoolSizes[1].descriptorCount = 1;
+
+            VkDescriptorPoolCreateInfo cliffDpCI{};
+            cliffDpCI.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            cliffDpCI.maxSets       = 1;
+            cliffDpCI.poolSizeCount = 2;
+            cliffDpCI.pPoolSizes    = cliffPoolSizes;
+
+            if (vkCreateDescriptorPool(device, &cliffDpCI, nullptr, &m_cliffDescPool) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkCreateDescriptorPool (cliff) failed");
+                Destroy(device);
+                return false;
+            }
+
+            VkDescriptorSetAllocateInfo cliffDsAI{};
+            cliffDsAI.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            cliffDsAI.descriptorPool     = m_cliffDescPool;
+            cliffDsAI.descriptorSetCount = 1;
+            cliffDsAI.pSetLayouts        = &m_cliffDescSetLayout;
+
+            if (vkAllocateDescriptorSets(device, &cliffDsAI, &m_cliffDescSet) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainRenderer] vkAllocateDescriptorSets (cliff) failed");
+                Destroy(device);
+                return false;
+            }
+
+            // Cliff UBO (CliffFrameUbo: 128 bytes)
+            {
+                const VkDeviceSize uboSize = sizeof(CliffFrameUbo);
+                VkBufferCreateInfo bi{};
+                bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+                bi.size        = uboSize;
+                bi.usage       = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+                bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+                if (vkCreateBuffer(device, &bi, nullptr, &m_cliffUboBuffer) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkCreateBuffer (cliff UBO) failed");
+                    Destroy(device);
+                    return false;
+                }
+
+                VkMemoryRequirements req{};
+                vkGetBufferMemoryRequirements(device, m_cliffUboBuffer, &req);
+                const uint32_t mt = FindMemType(physDev, req.memoryTypeBits,
+                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                if (mt == UINT32_MAX)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] No HOST_VISIBLE memory for cliff UBO");
+                    Destroy(device);
+                    return false;
+                }
+
+                VkMemoryAllocateInfo ai{};
+                ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+                ai.allocationSize  = req.size;
+                ai.memoryTypeIndex = mt;
+                if (vkAllocateMemory(device, &ai, nullptr, &m_cliffUboMemory) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkAllocateMemory (cliff UBO) failed");
+                    Destroy(device);
+                    return false;
+                }
+                vkBindBufferMemory(device, m_cliffUboBuffer, m_cliffUboMemory, 0);
+            }
+
+            // Cliff albedo placeholder: 1×1 grey-brown R8G8B8A8_UNORM texture (solid cliff rock)
+            {
+                // Create image
+                VkImageCreateInfo ici{};
+                ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+                ici.imageType     = VK_IMAGE_TYPE_2D;
+                ici.format        = VK_FORMAT_R8G8B8A8_UNORM;
+                ici.extent        = { 1u, 1u, 1u };
+                ici.mipLevels     = 1u;
+                ici.arrayLayers   = 1u;
+                ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+                ici.tiling        = VK_IMAGE_TILING_LINEAR; // 1×1 can be LINEAR for simplicity
+                ici.usage         = VK_IMAGE_USAGE_SAMPLED_BIT;
+                ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+                ici.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+
+                if (vkCreateImage(device, &ici, nullptr, &m_cliffAlbedoImage) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkCreateImage (cliff albedo) failed");
+                    Destroy(device);
+                    return false;
+                }
+
+                VkMemoryRequirements req{};
+                vkGetImageMemoryRequirements(device, m_cliffAlbedoImage, &req);
+                const uint32_t mt = FindMemType(physDev, req.memoryTypeBits,
+                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                if (mt == UINT32_MAX)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] No HOST_VISIBLE memory for cliff albedo");
+                    Destroy(device);
+                    return false;
+                }
+
+                VkMemoryAllocateInfo ai{};
+                ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+                ai.allocationSize  = req.size;
+                ai.memoryTypeIndex = mt;
+                if (vkAllocateMemory(device, &ai, nullptr, &m_cliffAlbedoMemory) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkAllocateMemory (cliff albedo) failed");
+                    Destroy(device);
+                    return false;
+                }
+                vkBindImageMemory(device, m_cliffAlbedoImage, m_cliffAlbedoMemory, 0);
+
+                // Write grey-brown pixel: R=120, G=110, B=100, A=255
+                VkImageSubresource sub{};
+                sub.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                VkSubresourceLayout layout{};
+                vkGetImageSubresourceLayout(device, m_cliffAlbedoImage, &sub, &layout);
+
+                void* mapped = nullptr;
+                vkMapMemory(device, m_cliffAlbedoMemory, layout.offset, 4u, 0, &mapped);
+                const uint8_t pixel[4] = { 120u, 110u, 100u, 255u };
+                std::memcpy(mapped, pixel, 4u);
+                vkUnmapMemory(device, m_cliffAlbedoMemory);
+
+                // Transition PREINITIALIZED → SHADER_READ_ONLY_OPTIMAL via one-time cmd
+                // (reuse the OneTimeSubmit helper from TerrainHoleMask — but it's in an anon ns)
+                // We do a simple manual submit here.
+                {
+                    VkCommandPoolCreateInfo poolCI{};
+                    poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+                    poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+                    poolCI.queueFamilyIndex = queueFamilyIndex;
+                    VkCommandPool tmpPool = VK_NULL_HANDLE;
+                    vkCreateCommandPool(device, &poolCI, nullptr, &tmpPool);
+
+                    VkCommandBufferAllocateInfo cbAI{};
+                    cbAI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+                    cbAI.commandPool        = tmpPool;
+                    cbAI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+                    cbAI.commandBufferCount = 1u;
+                    VkCommandBuffer tmpCmd = VK_NULL_HANDLE;
+                    vkAllocateCommandBuffers(device, &cbAI, &tmpCmd);
+
+                    VkCommandBufferBeginInfo beg{};
+                    beg.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+                    beg.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+                    vkBeginCommandBuffer(tmpCmd, &beg);
+
+                    VkImageMemoryBarrier barrier{};
+                    barrier.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                    barrier.oldLayout                       = VK_IMAGE_LAYOUT_PREINITIALIZED;
+                    barrier.newLayout                       = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                    barrier.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                    barrier.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+                    barrier.image                           = m_cliffAlbedoImage;
+                    barrier.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                    barrier.subresourceRange.baseMipLevel   = 0u;
+                    barrier.subresourceRange.levelCount     = 1u;
+                    barrier.subresourceRange.baseArrayLayer = 0u;
+                    barrier.subresourceRange.layerCount     = 1u;
+                    barrier.srcAccessMask                   = VK_ACCESS_HOST_WRITE_BIT;
+                    barrier.dstAccessMask                   = VK_ACCESS_SHADER_READ_BIT;
+                    vkCmdPipelineBarrier(tmpCmd,
+                        VK_PIPELINE_STAGE_HOST_BIT,
+                        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+                    vkEndCommandBuffer(tmpCmd);
+                    VkSubmitInfo si{};
+                    si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+                    si.commandBufferCount = 1u;
+                    si.pCommandBuffers    = &tmpCmd;
+                    vkQueueSubmit(queue, 1u, &si, VK_NULL_HANDLE);
+                    vkQueueWaitIdle(queue);
+                    vkDestroyCommandPool(device, tmpPool, nullptr);
+                }
+
+                // Image view
+                VkImageViewCreateInfo vci{};
+                vci.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+                vci.image                           = m_cliffAlbedoImage;
+                vci.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+                vci.format                          = VK_FORMAT_R8G8B8A8_UNORM;
+                vci.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                vci.subresourceRange.baseMipLevel   = 0u;
+                vci.subresourceRange.levelCount     = 1u;
+                vci.subresourceRange.baseArrayLayer = 0u;
+                vci.subresourceRange.layerCount     = 1u;
+                if (vkCreateImageView(device, &vci, nullptr, &m_cliffAlbedoView) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkCreateImageView (cliff albedo) failed");
+                    Destroy(device);
+                    return false;
+                }
+
+                // Sampler
+                VkSamplerCreateInfo sci{};
+                sci.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+                sci.magFilter    = VK_FILTER_LINEAR;
+                sci.minFilter    = VK_FILTER_LINEAR;
+                sci.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+                sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+                sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+                if (vkCreateSampler(device, &sci, nullptr, &m_cliffAlbedoSampler) != VK_SUCCESS)
+                {
+                    LOG_ERROR(Render, "[TerrainRenderer] vkCreateSampler (cliff albedo) failed");
+                    Destroy(device);
+                    return false;
+                }
+            }
+
+            // Write cliff descriptor set
+            {
+                VkDescriptorBufferInfo cliffUboInfo{};
+                cliffUboInfo.buffer = m_cliffUboBuffer;
+                cliffUboInfo.offset = 0;
+                cliffUboInfo.range  = sizeof(CliffFrameUbo);
+
+                VkDescriptorImageInfo cliffAlbedoInfo{};
+                cliffAlbedoInfo.sampler     = m_cliffAlbedoSampler;
+                cliffAlbedoInfo.imageView   = m_cliffAlbedoView;
+                cliffAlbedoInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+                VkWriteDescriptorSet cliffWrites[2]{};
+                cliffWrites[0].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                cliffWrites[0].dstSet          = m_cliffDescSet;
+                cliffWrites[0].dstBinding      = 0;
+                cliffWrites[0].descriptorCount = 1;
+                cliffWrites[0].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                cliffWrites[0].pBufferInfo     = &cliffUboInfo;
+
+                cliffWrites[1].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+                cliffWrites[1].dstSet          = m_cliffDescSet;
+                cliffWrites[1].dstBinding      = 1;
+                cliffWrites[1].descriptorCount = 1;
+                cliffWrites[1].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+                cliffWrites[1].pImageInfo      = &cliffAlbedoInfo;
+
+                vkUpdateDescriptorSets(device, 2, cliffWrites, 0, nullptr);
+            }
+
+            // Load cliff shaders and create pipeline
+            std::vector<uint32_t> cliffVertSpirv = loadSpirv("shaders/terrain_cliff.vert.spv");
+            std::vector<uint32_t> cliffFragSpirv = loadSpirv("shaders/terrain_cliff.frag.spv");
+
+            if (cliffVertSpirv.empty() || cliffFragSpirv.empty())
+            {
+                LOG_WARN(Render,
+                    "[TerrainRenderer] Cliff shaders not found (vert={} frag={}) — cliff rendering disabled",
+                    cliffVertSpirv.empty() ? "MISSING" : "OK",
+                    cliffFragSpirv.empty() ? "MISSING" : "OK");
+                // Cliff pipeline optional: no fatal error, meshes are loaded but won't draw.
+            }
+            else
+            {
+                VkShaderModule cliffVert = VK_NULL_HANDLE, cliffFrag = VK_NULL_HANDLE;
+                {
+                    VkShaderModuleCreateInfo smCI{};
+                    smCI.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+                    smCI.codeSize = cliffVertSpirv.size() * sizeof(uint32_t);
+                    smCI.pCode    = cliffVertSpirv.data();
+                    vkCreateShaderModule(device, &smCI, nullptr, &cliffVert);
+
+                    smCI.codeSize = cliffFragSpirv.size() * sizeof(uint32_t);
+                    smCI.pCode    = cliffFragSpirv.data();
+                    vkCreateShaderModule(device, &smCI, nullptr, &cliffFrag);
+                }
+
+                // Vertex input: CliffVertex layout (36 bytes per vertex)
+                // location 0: vec3 position    (offset 0)
+                // location 1: vec3 normal      (offset 12)
+                // location 2: vec2 uv          (offset 24)
+                // location 3: float blendWeight (offset 32)
+                VkVertexInputBindingDescription cliffBinding{};
+                cliffBinding.binding   = 0;
+                cliffBinding.stride    = sizeof(CliffVertex); // 36 bytes
+                cliffBinding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+                VkVertexInputAttributeDescription cliffAttribs[4]{};
+                cliffAttribs[0] = { 0u, 0u, VK_FORMAT_R32G32B32_SFLOAT,  0u  }; // position
+                cliffAttribs[1] = { 1u, 0u, VK_FORMAT_R32G32B32_SFLOAT,  12u }; // normal
+                cliffAttribs[2] = { 2u, 0u, VK_FORMAT_R32G32_SFLOAT,     24u }; // uv
+                cliffAttribs[3] = { 3u, 0u, VK_FORMAT_R32_SFLOAT,        32u }; // blendWeight
+
+                VkPipelineVertexInputStateCreateInfo cliffVisCI{};
+                cliffVisCI.sType                           = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+                cliffVisCI.vertexBindingDescriptionCount   = 1;
+                cliffVisCI.pVertexBindingDescriptions      = &cliffBinding;
+                cliffVisCI.vertexAttributeDescriptionCount = 4;
+                cliffVisCI.pVertexAttributeDescriptions    = cliffAttribs;
+
+                VkPipelineShaderStageCreateInfo cliffStages[2]{};
+                cliffStages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+                cliffStages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+                cliffStages[0].module = cliffVert;
+                cliffStages[0].pName  = "main";
+                cliffStages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+                cliffStages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+                cliffStages[1].module = cliffFrag;
+                cliffStages[1].pName  = "main";
+
+                VkPipelineInputAssemblyStateCreateInfo cliffIas{};
+                cliffIas.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+                cliffIas.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+                VkPipelineViewportStateCreateInfo cliffVp{};
+                cliffVp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+                cliffVp.viewportCount = 1;
+                cliffVp.scissorCount  = 1;
+
+                VkPipelineRasterizationStateCreateInfo cliffRas{};
+                cliffRas.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+                cliffRas.polygonMode = VK_POLYGON_MODE_FILL;
+                cliffRas.cullMode    = VK_CULL_MODE_BACK_BIT;
+                cliffRas.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+                cliffRas.lineWidth   = 1.0f;
+
+                VkPipelineMultisampleStateCreateInfo cliffMs{};
+                cliffMs.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+                cliffMs.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+                VkPipelineDepthStencilStateCreateInfo cliffDs{};
+                cliffDs.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+                cliffDs.depthTestEnable  = VK_TRUE;
+                cliffDs.depthWriteEnable = VK_TRUE;
+                cliffDs.depthCompareOp   = VK_COMPARE_OP_LESS;
+
+                VkPipelineColorBlendAttachmentState cliffBlendAtts[4]{};
+                for (int i = 0; i < 4; ++i)
+                {
+                    cliffBlendAtts[i].colorWriteMask =
+                        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                        VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+                    cliffBlendAtts[i].blendEnable = VK_FALSE;
+                }
+                VkPipelineColorBlendStateCreateInfo cliffCb{};
+                cliffCb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+                cliffCb.attachmentCount = 4;
+                cliffCb.pAttachments    = cliffBlendAtts;
+
+                VkDynamicState cliffDynStates[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+                VkPipelineDynamicStateCreateInfo cliffDyn{};
+                cliffDyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+                cliffDyn.dynamicStateCount = 2;
+                cliffDyn.pDynamicStates    = cliffDynStates;
+
+                VkGraphicsPipelineCreateInfo cliffGpCI{};
+                cliffGpCI.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+                cliffGpCI.stageCount          = 2;
+                cliffGpCI.pStages             = cliffStages;
+                cliffGpCI.pVertexInputState   = &cliffVisCI;
+                cliffGpCI.pInputAssemblyState = &cliffIas;
+                cliffGpCI.pViewportState      = &cliffVp;
+                cliffGpCI.pRasterizationState = &cliffRas;
+                cliffGpCI.pMultisampleState   = &cliffMs;
+                cliffGpCI.pDepthStencilState  = &cliffDs;
+                cliffGpCI.pColorBlendState    = &cliffCb;
+                cliffGpCI.pDynamicState       = &cliffDyn;
+                cliffGpCI.layout              = m_cliffPipelineLayout;
+                cliffGpCI.renderPass          = m_renderPass;
+                cliffGpCI.subpass             = 0;
+
+                const VkResult cliffRes = vkCreateGraphicsPipelines(
+                    device, VK_NULL_HANDLE, 1, &cliffGpCI, nullptr, &m_cliffPipeline);
+
+                vkDestroyShaderModule(device, cliffVert, nullptr);
+                vkDestroyShaderModule(device, cliffFrag, nullptr);
+
+                if (cliffRes != VK_SUCCESS)
+                {
+                    LOG_WARN(Render, "[TerrainRenderer] vkCreateGraphicsPipelines (cliff) failed — cliff rendering disabled");
+                    // Non-fatal: cliff meshes loaded but not rendered.
+                }
+                else
+                {
+                    LOG_INFO(Render, "[TerrainRenderer] Cliff pipeline OK");
+                }
+            }
         }
 
         LOG_INFO(Render, "[TerrainRenderer] Init OK ({}×{} patches, worldSize={} heightScale={})",
@@ -666,6 +1176,29 @@ namespace engine::render::terrain
     {
         InvalidateFramebufferCache(device);
 
+        // ── M34.3: Cliff pipeline & resources ────────────────────────────────────
+        for (CliffMeshGpu& gpu : m_cliffMeshes)
+            TerrainCliffMesh::DestroyGpu(device, gpu);
+        m_cliffMeshes.clear();
+
+        if (m_cliffPipeline       != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_cliffPipeline, nullptr);              m_cliffPipeline       = VK_NULL_HANDLE; }
+        if (m_cliffPipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_cliffPipelineLayout, nullptr);  m_cliffPipelineLayout = VK_NULL_HANDLE; }
+        if (m_cliffDescPool       != VK_NULL_HANDLE) { vkDestroyDescriptorPool(device, m_cliffDescPool, nullptr);        m_cliffDescPool       = VK_NULL_HANDLE; m_cliffDescSet = VK_NULL_HANDLE; }
+        if (m_cliffDescSetLayout  != VK_NULL_HANDLE) { vkDestroyDescriptorSetLayout(device, m_cliffDescSetLayout, nullptr); m_cliffDescSetLayout = VK_NULL_HANDLE; }
+
+        if (m_cliffUboBuffer != VK_NULL_HANDLE) { vkDestroyBuffer(device, m_cliffUboBuffer, nullptr); m_cliffUboBuffer = VK_NULL_HANDLE; }
+        if (m_cliffUboMemory != VK_NULL_HANDLE) { vkFreeMemory(device, m_cliffUboMemory, nullptr);    m_cliffUboMemory = VK_NULL_HANDLE; }
+
+        if (m_cliffAlbedoSampler != VK_NULL_HANDLE) { vkDestroySampler(device, m_cliffAlbedoSampler, nullptr);   m_cliffAlbedoSampler = VK_NULL_HANDLE; }
+        if (m_cliffAlbedoView    != VK_NULL_HANDLE) { vkDestroyImageView(device, m_cliffAlbedoView, nullptr);    m_cliffAlbedoView    = VK_NULL_HANDLE; }
+        if (m_cliffAlbedoImage   != VK_NULL_HANDLE) { vkDestroyImage(device, m_cliffAlbedoImage, nullptr);       m_cliffAlbedoImage   = VK_NULL_HANDLE; }
+        if (m_cliffAlbedoMemory  != VK_NULL_HANDLE) { vkFreeMemory(device, m_cliffAlbedoMemory, nullptr);        m_cliffAlbedoMemory  = VK_NULL_HANDLE; }
+
+        // ── M34.3: Hole mask ──────────────────────────────────────────────────────
+        TerrainHoleMask::DestroyGpu(device, m_holeMaskGpu);
+        m_holeMaskData.mask.clear();
+
+        // ── Terrain pipeline & resources ──────────────────────────────────────────
         if (m_pipeline       != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_pipeline, nullptr);             m_pipeline       = VK_NULL_HANDLE; }
         if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
         if (m_descPool       != VK_NULL_HANDLE) { vkDestroyDescriptorPool(device, m_descPool, nullptr);       m_descPool       = VK_NULL_HANDLE; m_descSet = VK_NULL_HANDLE; }
@@ -899,6 +1432,41 @@ namespace engine::render::terrain
                                    0, sizeof(PushConstants), &pc);
 
                 vkCmdDrawIndexed(cmd, indexCount, 1, 0, 0, 0);
+            }
+        }
+
+        // ── M34.3: Draw cliff meshes (same render pass, separate pipeline) ─────────
+        if (m_cliffPipeline != VK_NULL_HANDLE && !m_cliffMeshes.empty())
+        {
+            // Update cliff UBO (viewProj + prevViewProj)
+            {
+                CliffFrameUbo cliffUbo{};
+                std::memcpy(cliffUbo.viewProj,     viewProjMat4,     sizeof(cliffUbo.viewProj));
+                std::memcpy(cliffUbo.prevViewProj, prevViewProjMat4, sizeof(cliffUbo.prevViewProj));
+
+                void* mapped = nullptr;
+                if (vkMapMemory(device, m_cliffUboMemory, 0, sizeof(CliffFrameUbo), 0, &mapped) == VK_SUCCESS)
+                {
+                    std::memcpy(mapped, &cliffUbo, sizeof(CliffFrameUbo));
+                    vkUnmapMemory(device, m_cliffUboMemory);
+                }
+            }
+
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_cliffPipeline);
+            vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                    m_cliffPipelineLayout, 0, 1, &m_cliffDescSet, 0, nullptr);
+
+            // Viewport/scissor already set from terrain pass above
+
+            for (const CliffMeshGpu& cliff : m_cliffMeshes)
+            {
+                if (cliff.vertexBuffer == VK_NULL_HANDLE || cliff.indexBuffer == VK_NULL_HANDLE)
+                    continue;
+
+                VkDeviceSize vbOffset = 0;
+                vkCmdBindVertexBuffers(cmd, 0, 1, &cliff.vertexBuffer, &vbOffset);
+                vkCmdBindIndexBuffer(cmd, cliff.indexBuffer, 0, VK_INDEX_TYPE_UINT16);
+                vkCmdDrawIndexed(cmd, cliff.indexCount, 1, 0, 0, 0);
             }
         }
 

--- a/engine/render/terrain/TerrainRenderer.h
+++ b/engine/render/terrain/TerrainRenderer.h
@@ -3,6 +3,8 @@
 #include "engine/render/terrain/HeightmapLoader.h"
 #include "engine/render/terrain/TerrainMesh.h"
 #include "engine/render/terrain/TerrainSplatting.h"
+#include "engine/render/terrain/TerrainHoleMask.h"
+#include "engine/render/terrain/TerrainCliffMesh.h"
 #include "engine/render/FrameGraph.h"
 #include "engine/math/Frustum.h"
 #include "engine/math/Math.h"
@@ -68,17 +70,25 @@ namespace engine::render::terrain
         ///   terrain.splat.tiling_rock      (float, default 16.0)   – metres per tile, rock layer
         ///   terrain.splat.tiling_snow      (float, default 12.0)   – metres per tile, snow layer
         ///
-        /// \param heightmapRelPath  Content-relative path to the .r16h file
-        ///                          (e.g. "terrain/heightmap.r16h"). If the file is absent,
-        ///                          Init returns false gracefully (no crash).
-        /// \param splatmapRelPath   Content-relative path to the splat map (reserved for future
-        ///                          use; a default map is generated if empty or missing).
-        /// \param fmtA/B/C/Vel/Depth  GBuffer attachment formats (must match GeometryPass).
+        /// \param heightmapRelPath   Content-relative path to the .r16h file
+        ///                           (e.g. "terrain/heightmap.r16h"). If the file is absent,
+        ///                           Init returns false gracefully (no crash).
+        /// \param splatmapRelPath    Content-relative path to the splat map (reserved for future
+        ///                           use; a default map is generated if empty or missing).
+        /// \param holeMaskRelPath    Content-relative path to the .hmask file
+        ///                           (e.g. "terrain/holemask.hmask"). If absent, a fully-solid
+        ///                           fallback is used (no holes, no change to visible terrain).
+        /// \param cliffMeshRelPaths  Content-relative paths to .cliff mesh files
+        ///                           (e.g. {"terrain/cliff_a.cliff", "terrain/cliff_b.cliff"}).
+        ///                           May be empty. Missing files are skipped with a warning.
+        /// \param fmtA/B/C/Vel/Depth GBuffer attachment formats (must match GeometryPass).
         /// \param queue              Graphics queue used for one-time GPU uploads.
         bool Init(VkDevice device, VkPhysicalDevice physDev,
                   const engine::core::Config& config,
                   const std::string& heightmapRelPath,
                   const std::string& splatmapRelPath,
+                  const std::string& holeMaskRelPath,
+                  const std::vector<std::string>& cliffMeshRelPaths,
                   VkFormat fmtA, VkFormat fmtB, VkFormat fmtC,
                   VkFormat fmtVelocity, VkFormat fmtDepth,
                   VkQueue queue, uint32_t queueFamilyIndex,
@@ -117,6 +127,10 @@ namespace engine::render::terrain
         /// Returns true if Init succeeded and Destroy has not been called.
         bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
+        /// Returns the CPU hole mask data for navmesh / collision queries (M34.3).
+        /// IsHole(qx, qz) returns true when quad (qx, qz) is a hole (unwalkable).
+        const HoleMaskData& GetHoleMaskData() const { return m_holeMaskData; }
+
     private:
         // ── Push constants ────────────────────────────────────────────────────────
         // All stages, 16 bytes total.
@@ -151,6 +165,17 @@ namespace engine::render::terrain
             float layerTiling[4];    // offset 176  (x=grass, y=dirt, z=rock, w=snow tiling)
         };                           //         192
 
+        // ── Cliff per-frame UBO (cliff pipeline, set=0, binding=0) ───────────
+        // Minimal UBO for cliff pipeline: only view-proj matrices.
+        //   mat4  viewProj      offset  0  (64 bytes)
+        //   mat4  prevViewProj  offset 64  (64 bytes)
+        //                       total 128
+        struct CliffFrameUbo
+        {
+            float viewProj[16];     // offset  0
+            float prevViewProj[16]; // offset 64
+        };                          //       128
+
         // ── Framebuffer cache ─────────────────────────────────────────────────────
         struct FramebufferKey
         {
@@ -165,7 +190,7 @@ namespace engine::render::terrain
             size_t operator()(const FramebufferKey& k) const;
         };
 
-        // ── Vulkan objects ────────────────────────────────────────────────────────
+        // ── Vulkan objects — terrain pipeline ─────────────────────────────────────
         VkRenderPass          m_renderPass    = VK_NULL_HANDLE;
         VkDescriptorSetLayout m_descSetLayout = VK_NULL_HANDLE;
         VkDescriptorPool      m_descPool      = VK_NULL_HANDLE;
@@ -182,6 +207,28 @@ namespace engine::render::terrain
         TerrainMeshGpu        m_meshGpu;
         HeightmapData         m_heightmapData; ///< CPU copy for patch bound calculation
         TerrainSplatting      m_splatting;     ///< Splat map + texture arrays (M34.2)
+
+        // ── M34.3: Hole mask ──────────────────────────────────────────────────────
+        HoleMaskData          m_holeMaskData; ///< CPU hole mask for navmesh queries
+        HoleMaskGpu           m_holeMaskGpu;  ///< GPU R8_UNORM texture (binding 7)
+
+        // ── M34.3: Cliff pipeline ─────────────────────────────────────────────────
+        VkDescriptorSetLayout m_cliffDescSetLayout = VK_NULL_HANDLE;
+        VkDescriptorPool      m_cliffDescPool      = VK_NULL_HANDLE;
+        VkDescriptorSet       m_cliffDescSet       = VK_NULL_HANDLE;
+        VkPipelineLayout      m_cliffPipelineLayout = VK_NULL_HANDLE;
+        VkPipeline            m_cliffPipeline      = VK_NULL_HANDLE;
+        VkBuffer              m_cliffUboBuffer     = VK_NULL_HANDLE;
+        VkDeviceMemory        m_cliffUboMemory     = VK_NULL_HANDLE;
+
+        /// Cliff albedo placeholder texture (1×1 solid rock colour).
+        VkImage               m_cliffAlbedoImage   = VK_NULL_HANDLE;
+        VkImageView           m_cliffAlbedoView    = VK_NULL_HANDLE;
+        VkDeviceMemory        m_cliffAlbedoMemory  = VK_NULL_HANDLE;
+        VkSampler             m_cliffAlbedoSampler = VK_NULL_HANDLE;
+
+        /// Loaded and uploaded cliff meshes (one entry per .cliff file).
+        std::vector<CliffMeshGpu> m_cliffMeshes;
 
         std::vector<TerrainPatchInfo> m_patches;
         std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_fbCache;

--- a/game/data/shaders/terrain.frag
+++ b/game/data/shaders/terrain.frag
@@ -1,9 +1,13 @@
 #version 450
-// M34.2: Terrain fragment shader — texture splatting with triplanar projection.
+// M34.2/M34.3: Terrain fragment shader — texture splatting with triplanar projection
+//              + hole mask discard (M34.3).
 //
 // Reads per-layer weights from the splat map (R=grass, G=dirt, B=rock, A=snow),
 // samples albedo/normal/ORM from 2D texture arrays using triplanar projection
 // (avoids UV stretching on steep slopes), and blends by normalised splat weights.
+//
+// M34.3 addition: samples hole mask (R8_UNORM, binding 7). Fragments where the
+// mask value < 0.5 are discarded (holes / cave entrances).
 //
 // Outputs into 4 GBuffer attachments compatible with GeometryPass layout:
 //   location 0 (GBufferA)        : albedo RGBA8
@@ -30,6 +34,8 @@ layout(set = 0, binding = 3) uniform sampler2D      uSplatMap;    // RGBA8: R=gr
 layout(set = 0, binding = 4) uniform sampler2DArray uAlbedoArray; // 4 layers RGBA8
 layout(set = 0, binding = 5) uniform sampler2DArray uNormalArray; // 4 layers RGBA8 tangent-space
 layout(set = 0, binding = 6) uniform sampler2DArray uORMArray;    // 4 layers RGBA8 (R=AO,G=rough,B=metal)
+// M34.3: hole mask (R8_UNORM). 0.0 = hole (fragment discarded), 1.0 = solid.
+layout(set = 0, binding = 7) uniform sampler2D      uHoleMask;
 
 // ── Push constants ────────────────────────────────────────────────────────────
 layout(push_constant) uniform PC {
@@ -80,6 +86,13 @@ vec4 triplanarSample(sampler2DArray arr, float layer,
 // ─────────────────────────────────────────────────────────────────────────────
 void main()
 {
+    // ── M34.3: Hole mask discard ──────────────────────────────────────────────
+    // Sample the R8 hole mask. Value 0 = hole (discard), 1 = solid (keep).
+    // Uses NEAREST sampler so each texel maps exactly to one terrain quad.
+    float holeSolid = texture(uHoleMask, vUV).r;
+    if (holeSolid < 0.5)
+        discard;
+
     // ── Decode terrain macro normal ───────────────────────────────────────────
     vec3 macroN = normalize(texture(uNormalMap, vUV).rgb * 2.0 - 1.0);
 

--- a/game/data/shaders/terrain_cliff.frag
+++ b/game/data/shaders/terrain_cliff.frag
@@ -1,0 +1,62 @@
+#version 450
+// M34.3: Terrain cliff fragment shader.
+//
+// Writes cliff geometry into the GBuffer (same layout as GeometryPass).
+// Outputs 4 attachments:
+//   location 0 (GBufferA)        : albedo RGBA8   (cliff rock placeholder)
+//   location 1 (GBufferB)        : world normal   (N * 0.5 + 0.5)
+//   location 2 (GBufferC)        : ORM            (R=AO, G=Roughness, B=Metallic)
+//   location 3 (GBufferVelocity) : R16G16 velocity = currNDC - prevNDC
+//
+// blendWeight at 1.0 indicates a border vertex that matches the heightmap edge.
+// No alpha discard is applied here; cliff meshes are fully opaque solid geometry.
+
+layout(location = 0) in vec3  vWorldPos;
+layout(location = 1) in vec3  vWorldNormal;
+layout(location = 2) in vec2  vUV;
+layout(location = 3) in float vBlendWeight;
+layout(location = 4) in vec4  vPrevClip;
+layout(location = 5) in vec4  vCurrClip;
+
+// ── Descriptor bindings ───────────────────────────────────────────────────────
+layout(set = 0, binding = 0) uniform CliffFrameUbo {
+    mat4  viewProj;
+    mat4  prevViewProj;
+} ubo;
+
+// binding 1: cliff albedo texture (placeholder solid RGBA8).
+// If absent the shader falls back to the hard-coded rock colour below.
+layout(set = 0, binding = 1) uniform sampler2D uCliffAlbedo;
+
+// ── GBuffer outputs ───────────────────────────────────────────────────────────
+layout(location = 0) out vec4 outAlbedo;   // GBufferA
+layout(location = 1) out vec4 outNormal;   // GBufferB
+layout(location = 2) out vec4 outORM;      // GBufferC
+layout(location = 3) out vec4 outVelocity; // GBufferVelocity
+
+void main()
+{
+    // ── Albedo: sample cliff texture, tiling on UV ────────────────────────────
+    // UV tiling: 1 tile per 4 world units (cliffs typically 4–16 m tall).
+    vec2  tiledUV = vUV * 4.0;
+    vec3  albedo  = texture(uCliffAlbedo, tiledUV).rgb;
+
+    // Blend towards a neutral grey at terrain-junction edges (blendWeight = 1.0).
+    // This softens the seam where the cliff base meets the heightmap surface.
+    const vec3 edgeColor = vec3(0.45, 0.42, 0.40); // grey-brown blend
+    albedo = mix(albedo, edgeColor, vBlendWeight * 0.5);
+
+    outAlbedo = vec4(albedo, 1.0);
+
+    // ── Normal: encode world-space normal ────────────────────────────────────
+    vec3 n = normalize(vWorldNormal);
+    outNormal = vec4(n * 0.5 + 0.5, 1.0);
+
+    // ── ORM: rock-like default (AO=1, roughness=0.85, metallic=0) ────────────
+    outORM = vec4(1.0, 0.85, 0.0, 1.0);
+
+    // ── Velocity for TAA reprojection ─────────────────────────────────────────
+    vec2 prevNDC = vPrevClip.xy / max(vPrevClip.w, 1e-6);
+    vec2 currNDC = vCurrClip.xy / max(vCurrClip.w, 1e-6);
+    outVelocity  = vec4(currNDC - prevNDC, 0.0, 1.0);
+}

--- a/game/data/shaders/terrain_cliff.vert
+++ b/game/data/shaders/terrain_cliff.vert
@@ -1,0 +1,45 @@
+#version 450
+// M34.3: Terrain cliff vertex shader.
+//
+// Renders manually-authored cliff mesh geometry into the GBuffer.
+// Vertex format (CliffVertex, 36 bytes):
+//   location 0: vec3  position    — world-space XYZ
+//   location 1: vec3  normal      — world-space unit normal
+//   location 2: vec2  uv          — texture UV [0,1]
+//   location 3: float blendWeight — 0=cliff interior, 1=terrain-edge blend
+//
+// Descriptor set 0:
+//   binding 0: CliffFrameUbo  { mat4 viewProj; mat4 prevViewProj; }
+
+layout(location = 0) in vec3  inPosition;
+layout(location = 1) in vec3  inNormal;
+layout(location = 2) in vec2  inUV;
+layout(location = 3) in float inBlendWeight;
+
+// Per-frame UBO: view-projection matrices only (world-space mesh, no model matrix).
+layout(set = 0, binding = 0) uniform CliffFrameUbo {
+    mat4  viewProj;      // current frame view-projection
+    mat4  prevViewProj;  // previous frame view-projection (for TAA velocity)
+} ubo;
+
+// Outputs to fragment shader
+layout(location = 0) out vec3  vWorldPos;
+layout(location = 1) out vec3  vWorldNormal;
+layout(location = 2) out vec2  vUV;
+layout(location = 3) out float vBlendWeight;
+layout(location = 4) out vec4  vPrevClip;
+layout(location = 5) out vec4  vCurrClip;
+
+void main()
+{
+    vec4 worldPos4 = vec4(inPosition, 1.0);
+
+    vWorldPos    = inPosition;
+    vWorldNormal = normalize(inNormal);
+    vUV          = inUV;
+    vBlendWeight = inBlendWeight;
+    vCurrClip    = ubo.viewProj     * worldPos4;
+    vPrevClip    = ubo.prevViewProj * worldPos4;
+
+    gl_Position = vCurrClip;
+}


### PR DESCRIPTION
- TerrainHoleMask: R8_UNORM GPU texture (0=hole/discard, 255=solid)
  + CPU HoleMaskData with IsHole(qx,qz) for navmesh/collision queries. Graceful solid fallback when .hmask file is absent.
- TerrainCliffMesh: CliffVertex format (pos+normal+uv+blendWeight), binary .cliff loader, HOST_VISIBLE GPU vertex+index buffers. blendWeight=1.0 marks terrain-junction "blend edge" vertices.
- terrain.frag: binding 7 uHoleMask + discard if holeSolid < 0.5.
- terrain_cliff.vert / terrain_cliff.frag: cliff GBuffer pipeline (viewProj UBO + cliff albedo placeholder, outputs albedo/normal/ORM/velocity).
- TerrainRenderer::Init: new holeMaskRelPath + cliffMeshRelPaths params, cliff pipeline created in same render pass as terrain.
- CMakeLists.txt: add TerrainHoleMask.cpp + TerrainCliffMesh.cpp.

https://claude.ai/code/session_01WBWpiC4wqvEzW1y4pB9YSr