### PR TITLE
M34.4 — Terrain editing tools (heightmap brush + splat paint)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(engine_core
   engine/render/terrain/TerrainHoleMask.cpp
   engine/render/terrain/TerrainCliffMesh.cpp
   engine/render/terrain/TerrainRenderer.cpp
+  engine/render/terrain/TerrainEditingTools.cpp
   engine/network/ByteWriter.cpp
   engine/network/ByteReader.cpp
   engine/network/PacketBuilder.cpp

--- a/engine/render/terrain/TerrainEditingTools.cpp
+++ b/engine/render/terrain/TerrainEditingTools.cpp
@@ -1,0 +1,737 @@
+#include "engine/render/terrain/TerrainEditingTools.h"
+#include "engine/core/Config.h"
+#include "engine/core/Log.h"
+#include "engine/platform/FileSystem.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+namespace engine::render::terrain
+{
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Internal Vulkan helpers (raw, no VMA)
+    // ─────────────────────────────────────────────────────────────────────────────
+    namespace
+    {
+        /// Finds a memory type index matching the desired property flags.
+        uint32_t FindMemType(VkPhysicalDevice physDev,
+                             uint32_t typeBits,
+                             VkMemoryPropertyFlags desired)
+        {
+            VkPhysicalDeviceMemoryProperties props{};
+            vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+            for (uint32_t i = 0; i < props.memoryTypeCount; ++i)
+            {
+                if ((typeBits & (1u << i)) &&
+                    (props.memoryTypes[i].propertyFlags & desired) == desired)
+                    return i;
+            }
+            return UINT32_MAX;
+        }
+
+        /// Creates a HOST_VISIBLE | HOST_COHERENT staging buffer of `size` bytes.
+        bool CreateStagingBuffer(VkDevice device, VkPhysicalDevice physDev,
+                                 VkDeviceSize size,
+                                 VkBuffer& outBuf, VkDeviceMemory& outMem)
+        {
+            VkBufferCreateInfo bi{};
+            bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+            bi.size        = size;
+            bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+            if (vkCreateBuffer(device, &bi, nullptr, &outBuf) != VK_SUCCESS ||
+                outBuf == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainEditingTools] vkCreateBuffer (staging) failed");
+                return false;
+            }
+
+            VkMemoryRequirements req{};
+            vkGetBufferMemoryRequirements(device, outBuf, &req);
+
+            const uint32_t memType = FindMemType(physDev, req.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            if (memType == UINT32_MAX)
+            {
+                LOG_ERROR(Render, "[TerrainEditingTools] No HOST_VISIBLE memory for staging");
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            VkMemoryAllocateInfo ai{};
+            ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            ai.allocationSize  = req.size;
+            ai.memoryTypeIndex = memType;
+
+            if (vkAllocateMemory(device, &ai, nullptr, &outMem) != VK_SUCCESS ||
+                outMem == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainEditingTools] vkAllocateMemory (staging) failed");
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                return false;
+            }
+
+            if (vkBindBufferMemory(device, outBuf, outMem, 0) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainEditingTools] vkBindBufferMemory (staging) failed");
+                vkFreeMemory(device, outMem, nullptr);
+                vkDestroyBuffer(device, outBuf, nullptr);
+                outBuf = VK_NULL_HANDLE;
+                outMem = VK_NULL_HANDLE;
+                return false;
+            }
+            return true;
+        }
+
+        /// Submits a one-time command that:
+        ///   SHADER_READ_ONLY → TRANSFER_DST → copies staging→image → SHADER_READ_ONLY.
+        /// `format` must be R16_UNORM (heightmap) or B8G8R8A8/R8G8B8A8_UNORM (splatmap).
+        bool UploadToImage(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                           VkBuffer stagingBuf,
+                           VkImage dstImage,
+                           uint32_t width, uint32_t height)
+        {
+            VkCommandPool pool = VK_NULL_HANDLE;
+            {
+                VkCommandPoolCreateInfo poolCI{};
+                poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+                poolCI.queueFamilyIndex = queueFamilyIndex;
+                poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+                if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS ||
+                    pool == VK_NULL_HANDLE)
+                {
+                    LOG_ERROR(Render, "[TerrainEditingTools] vkCreateCommandPool failed");
+                    return false;
+                }
+            }
+
+            VkCommandBuffer cmd = VK_NULL_HANDLE;
+            {
+                VkCommandBufferAllocateInfo allocCI{};
+                allocCI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+                allocCI.commandPool        = pool;
+                allocCI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+                allocCI.commandBufferCount = 1;
+                if (vkAllocateCommandBuffers(device, &allocCI, &cmd) != VK_SUCCESS ||
+                    cmd == VK_NULL_HANDLE)
+                {
+                    LOG_ERROR(Render, "[TerrainEditingTools] vkAllocateCommandBuffers failed");
+                    vkDestroyCommandPool(device, pool, nullptr);
+                    return false;
+                }
+            }
+
+            VkCommandBufferBeginInfo beginInfo{};
+            beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+            beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+            {
+                LOG_ERROR(Render, "[TerrainEditingTools] vkBeginCommandBuffer failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                return false;
+            }
+
+            // Barrier: SHADER_READ_ONLY_OPTIMAL → TRANSFER_DST_OPTIMAL
+            {
+                VkImageMemoryBarrier b{};
+                b.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                b.oldLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                b.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.image               = dstImage;
+                b.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+                b.srcAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+                b.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &b);
+            }
+
+            // Copy staging buffer → image
+            {
+                VkBufferImageCopy region{};
+                region.bufferOffset                    = 0;
+                region.bufferRowLength                 = 0;
+                region.bufferImageHeight               = 0;
+                region.imageSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+                region.imageSubresource.mipLevel       = 0;
+                region.imageSubresource.baseArrayLayer = 0;
+                region.imageSubresource.layerCount     = 1;
+                region.imageOffset                     = { 0, 0, 0 };
+                region.imageExtent                     = { width, height, 1 };
+                vkCmdCopyBufferToImage(cmd, stagingBuf, dstImage,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+            }
+
+            // Barrier: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
+            {
+                VkImageMemoryBarrier b{};
+                b.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                b.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                b.newLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+                b.image               = dstImage;
+                b.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+                b.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+                b.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+                vkCmdPipelineBarrier(cmd,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    0, 0, nullptr, 0, nullptr, 1, &b);
+            }
+
+            vkEndCommandBuffer(cmd);
+
+            VkSubmitInfo si{};
+            si.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+            si.commandBufferCount   = 1;
+            si.pCommandBuffers      = &cmd;
+            vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE);
+            vkQueueWaitIdle(queue);
+
+            vkDestroyCommandPool(device, pool, nullptr);
+            return true;
+        }
+
+    } // anonymous namespace
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::Init / Shutdown
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainEditingTools::Init(HeightmapData*    heightmap,
+                                   TerrainSplatting* splatting,
+                                   float terrainOriginX,
+                                   float terrainOriginZ,
+                                   float terrainWorldSize,
+                                   float heightScale)
+    {
+        if (!heightmap || !splatting)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] Init: null heightmap or splatting pointer");
+            return false;
+        }
+        if (terrainWorldSize <= 0.0f)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] Init: terrainWorldSize must be > 0 (got {})",
+                      terrainWorldSize);
+            return false;
+        }
+        if (!splatting->HasCpuData())
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] Init: splatting has no CPU data — "
+                              "ensure TerrainSplatting was Init'd before TerrainEditingTools");
+            return false;
+        }
+
+        m_heightmap        = heightmap;
+        m_splatting        = splatting;
+        m_terrainOriginX   = terrainOriginX;
+        m_terrainOriginZ   = terrainOriginZ;
+        m_terrainWorldSize = terrainWorldSize;
+        m_heightScale      = heightScale;
+        m_dirtyHeightmap   = false;
+        m_dirtySplatMap    = false;
+        m_initialized      = true;
+
+        LOG_INFO(Render,
+                 "[TerrainEditingTools] Init OK (origin=({},{}) size={} hscale={} "
+                 "hmap={}x{} splat={}x{})",
+                 terrainOriginX, terrainOriginZ,
+                 terrainWorldSize, heightScale,
+                 heightmap->width, heightmap->height,
+                 splatting->GetSplatMapCpuWidth(),
+                 splatting->GetSplatMapCpuHeight());
+        return true;
+    }
+
+    void TerrainEditingTools::Shutdown()
+    {
+        m_heightmap      = nullptr;
+        m_splatting      = nullptr;
+        m_initialized    = false;
+        m_dirtyHeightmap = false;
+        m_dirtySplatMap  = false;
+        LOG_INFO(Render, "[TerrainEditingTools] Shutdown");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Internal coordinate helpers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    float TerrainEditingTools::ComputeKernel(float dist,
+                                              float radius,
+                                              float falloff) const
+    {
+        if (dist >= radius) return 0.0f;
+        const float t = 1.0f - (dist / radius); // [0, 1]
+        return std::pow(t, std::max(falloff, 0.01f));
+    }
+
+    void TerrainEditingTools::WorldToHeightmapPixel(float worldX, float worldZ,
+                                                     int32_t& outPx, int32_t& outPz) const
+    {
+        // Terrain spans [originX, originX + worldSize] × [originZ, originZ + worldSize].
+        // Heightmap pixel (0,0) is the corner at (originX, originZ).
+        const float relX = worldX - m_terrainOriginX;
+        const float relZ = worldZ - m_terrainOriginZ;
+        const float normX = relX / m_terrainWorldSize;
+        const float normZ = relZ / m_terrainWorldSize;
+        outPx = static_cast<int32_t>(normX * static_cast<float>(m_heightmap->width));
+        outPz = static_cast<int32_t>(normZ * static_cast<float>(m_heightmap->height));
+    }
+
+    void TerrainEditingTools::WorldToSplatPixel(float worldX, float worldZ,
+                                                 int32_t& outPx, int32_t& outPz) const
+    {
+        const float relX  = worldX - m_terrainOriginX;
+        const float relZ  = worldZ - m_terrainOriginZ;
+        const float normX = relX / m_terrainWorldSize;
+        const float normZ = relZ / m_terrainWorldSize;
+        outPx = static_cast<int32_t>(normX * static_cast<float>(m_splatting->GetSplatMapCpuWidth()));
+        outPz = static_cast<int32_t>(normZ * static_cast<float>(m_splatting->GetSplatMapCpuHeight()));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::ApplyBrush
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainEditingTools::ApplyBrush(float worldX, float worldZ,
+                                          BrushOp op, const BrushParams& params)
+    {
+        if (!m_initialized || !m_heightmap || m_heightmap->heights.empty())
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] ApplyBrush called on uninitialised tools");
+            return;
+        }
+
+        const uint32_t w = m_heightmap->width;
+        const uint32_t h = m_heightmap->height;
+
+        // World units per heightmap texel
+        const float worldStep = m_terrainWorldSize / static_cast<float>(w);
+
+        // Brush centre in heightmap pixel space
+        int32_t cx = 0, cz = 0;
+        WorldToHeightmapPixel(worldX, worldZ, cx, cz);
+
+        // Pixel radius (add 1 to cover partial texels at the boundary)
+        const int32_t iRadius = static_cast<int32_t>(params.radius / worldStep) + 1;
+
+        if (op == BrushOp::Smooth)
+        {
+            // Smooth needs a read-only snapshot to avoid propagating within one pass.
+            const std::vector<uint16_t> snapshot = m_heightmap->heights;
+
+            for (int32_t iz = cz - iRadius; iz <= cz + iRadius; ++iz)
+            {
+                for (int32_t ix = cx - iRadius; ix <= cx + iRadius; ++ix)
+                {
+                    if (ix < 0 || ix >= static_cast<int32_t>(w) ||
+                        iz < 0 || iz >= static_cast<int32_t>(h))
+                        continue;
+
+                    const float dx   = static_cast<float>(ix - cx) * worldStep;
+                    const float dz   = static_cast<float>(iz - cz) * worldStep;
+                    const float dist = std::sqrt(dx * dx + dz * dz);
+                    const float k    = ComputeKernel(dist, params.radius, params.falloff);
+                    if (k <= 0.0f) continue;
+
+                    // 3×3 neighbourhood average from snapshot
+                    float sum   = 0.0f;
+                    int   count = 0;
+                    for (int32_t nz = iz - 1; nz <= iz + 1; ++nz)
+                    {
+                        for (int32_t nx = ix - 1; nx <= ix + 1; ++nx)
+                        {
+                            const int32_t snx = std::clamp(nx, 0, static_cast<int32_t>(w) - 1);
+                            const int32_t snz = std::clamp(nz, 0, static_cast<int32_t>(h) - 1);
+                            sum   += static_cast<float>(snapshot[static_cast<uint32_t>(snz) * w +
+                                                                  static_cast<uint32_t>(snx)]);
+                            ++count;
+                        }
+                    }
+                    const float avg    = sum / static_cast<float>(count);
+                    const float orig   = static_cast<float>(
+                        m_heightmap->heights[static_cast<uint32_t>(iz) * w +
+                                             static_cast<uint32_t>(ix)]);
+                    const float result = orig + (avg - orig) * k * params.strength;
+                    m_heightmap->heights[static_cast<uint32_t>(iz) * w +
+                                         static_cast<uint32_t>(ix)] =
+                        static_cast<uint16_t>(std::clamp(result, 0.0f, 65535.0f));
+                }
+            }
+        }
+        else
+        {
+            for (int32_t iz = cz - iRadius; iz <= cz + iRadius; ++iz)
+            {
+                for (int32_t ix = cx - iRadius; ix <= cx + iRadius; ++ix)
+                {
+                    if (ix < 0 || ix >= static_cast<int32_t>(w) ||
+                        iz < 0 || iz >= static_cast<int32_t>(h))
+                        continue;
+
+                    const float dx   = static_cast<float>(ix - cx) * worldStep;
+                    const float dz   = static_cast<float>(iz - cz) * worldStep;
+                    const float dist = std::sqrt(dx * dx + dz * dz);
+                    const float k    = ComputeKernel(dist, params.radius, params.falloff);
+                    if (k <= 0.0f) continue;
+
+                    const uint32_t idx = static_cast<uint32_t>(iz) * w +
+                                         static_cast<uint32_t>(ix);
+                    float v = static_cast<float>(m_heightmap->heights[idx]);
+
+                    switch (op)
+                    {
+                    case BrushOp::Raise:
+                        v += params.strength * k * 65535.0f * 0.01f; // 1 % of range per unit strength
+                        break;
+                    case BrushOp::Lower:
+                        v -= params.strength * k * 65535.0f * 0.01f;
+                        break;
+                    case BrushOp::Flatten:
+                    {
+                        // Target in uint16 range
+                        const float target = params.flattenTarget * 65535.0f;
+                        v = v + (target - v) * k * params.strength;
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+
+                    m_heightmap->heights[idx] =
+                        static_cast<uint16_t>(std::clamp(v, 0.0f, 65535.0f));
+                }
+            }
+        }
+
+        m_dirtyHeightmap = true;
+        LOG_TRACE(Render, "[TerrainEditingTools] ApplyBrush op={} at ({},{}) r={}",
+                  static_cast<uint32_t>(op), worldX, worldZ, params.radius);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::PaintSplat
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainEditingTools::PaintSplat(float worldX, float worldZ,
+                                          uint32_t layer, const BrushParams& params)
+    {
+        if (!m_initialized || !m_splatting)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] PaintSplat called on uninitialised tools");
+            return;
+        }
+        if (layer >= kSplatLayerCount)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] PaintSplat: layer {} >= kSplatLayerCount ({})",
+                     layer, kSplatLayerCount);
+            return;
+        }
+
+        std::vector<uint8_t>& splat = m_splatting->GetMutableSplatMapCpu();
+        const uint32_t sw = m_splatting->GetSplatMapCpuWidth();
+        const uint32_t sh = m_splatting->GetSplatMapCpuHeight();
+
+        if (splat.empty() || sw == 0 || sh == 0)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] PaintSplat: empty CPU splat data");
+            return;
+        }
+
+        const float worldStep = m_terrainWorldSize / static_cast<float>(sw);
+
+        int32_t cx = 0, cz = 0;
+        WorldToSplatPixel(worldX, worldZ, cx, cz);
+
+        const int32_t iRadius = static_cast<int32_t>(params.radius / worldStep) + 1;
+
+        for (int32_t iz = cz - iRadius; iz <= cz + iRadius; ++iz)
+        {
+            for (int32_t ix = cx - iRadius; ix <= cx + iRadius; ++ix)
+            {
+                if (ix < 0 || ix >= static_cast<int32_t>(sw) ||
+                    iz < 0 || iz >= static_cast<int32_t>(sh))
+                    continue;
+
+                const float dx   = static_cast<float>(ix - cx) * worldStep;
+                const float dz   = static_cast<float>(iz - cz) * worldStep;
+                const float dist = std::sqrt(dx * dx + dz * dz);
+                const float k    = ComputeKernel(dist, params.radius, params.falloff);
+                if (k <= 0.0f) continue;
+
+                const uint32_t base = (static_cast<uint32_t>(iz) * sw +
+                                       static_cast<uint32_t>(ix)) * 4u;
+
+                // Read current weights as floats [0, 1]
+                float weights[kSplatLayerCount];
+                float total = 0.0f;
+                for (uint32_t li = 0; li < kSplatLayerCount; ++li)
+                {
+                    weights[li] = static_cast<float>(splat[base + li]) / 255.0f;
+                    total       += weights[li];
+                }
+                // Normalise if sum is very far from 1 (guard against corrupt data)
+                if (total > 0.001f && (total < 0.99f || total > 1.01f))
+                {
+                    for (uint32_t li = 0; li < kSplatLayerCount; ++li)
+                        weights[li] /= total;
+                }
+
+                // Increase the target layer weight
+                const float delta = params.strength * k;
+                weights[layer] = std::min(1.0f, weights[layer] + delta);
+
+                // Reduce other layers proportionally to keep sum = 1
+                const float excess = weights[layer] - (1.0f - (1.0f - weights[layer]));
+                // Simpler: renormalise all layers after boosting target
+                float newTotal = 0.0f;
+                for (uint32_t li = 0; li < kSplatLayerCount; ++li)
+                    newTotal += weights[li];
+                if (newTotal > 0.001f)
+                {
+                    for (uint32_t li = 0; li < kSplatLayerCount; ++li)
+                        weights[li] /= newTotal;
+                }
+                (void)excess; // handled by renormalise above
+
+                // Write back as uint8
+                for (uint32_t li = 0; li < kSplatLayerCount; ++li)
+                    splat[base + li] = static_cast<uint8_t>(
+                        std::clamp(weights[li] * 255.0f, 0.0f, 255.0f));
+            }
+        }
+
+        m_dirtySplatMap = true;
+        LOG_TRACE(Render, "[TerrainEditingTools] PaintSplat layer={} at ({},{}) r={}",
+                  layer, worldX, worldZ, params.radius);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::FlushHeightmap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainEditingTools::FlushHeightmap(VkDevice device, VkPhysicalDevice physDev,
+                                              VkQueue queue, uint32_t queueFamilyIndex,
+                                              VkImage heightmapImage)
+    {
+        if (!m_initialized || !m_heightmap)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] FlushHeightmap: tools not initialised");
+            return false;
+        }
+        if (heightmapImage == VK_NULL_HANDLE)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] FlushHeightmap: null GPU image");
+            return false;
+        }
+
+        const uint32_t w = m_heightmap->width;
+        const uint32_t h = m_heightmap->height;
+
+        if (w == 0 || h == 0 || m_heightmap->heights.empty())
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] FlushHeightmap: empty heightmap data");
+            return false;
+        }
+
+        const VkDeviceSize bytes = static_cast<VkDeviceSize>(w) * h * sizeof(uint16_t);
+
+        VkBuffer stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, bytes, stagingBuf, stagingMem))
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] FlushHeightmap: staging buffer failed");
+            return false;
+        }
+
+        // Map and copy CPU heightmap
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, bytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] FlushHeightmap: vkMapMemory failed");
+            vkFreeMemory(device, stagingMem, nullptr);
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, m_heightmap->heights.data(), static_cast<size_t>(bytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // Upload via one-time command buffer (SHADER_READ_ONLY → TRANSFER_DST → back)
+        const bool ok = UploadToImage(device, queue, queueFamilyIndex,
+                                       stagingBuf, heightmapImage, w, h);
+
+        vkFreeMemory(device, stagingMem, nullptr);
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+
+        if (ok)
+        {
+            m_dirtyHeightmap = false;
+            LOG_INFO(Render, "[TerrainEditingTools] FlushHeightmap OK ({}x{})", w, h);
+        }
+        else
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] FlushHeightmap: upload failed");
+        }
+        return ok;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::FlushSplatMap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainEditingTools::FlushSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                                             VkQueue queue, uint32_t queueFamilyIndex)
+    {
+        if (!m_initialized || !m_splatting)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] FlushSplatMap: tools not initialised");
+            return false;
+        }
+
+        const bool ok = m_splatting->ReuploadSplatMap(device, physDev, queue, queueFamilyIndex);
+        if (ok)
+        {
+            m_dirtySplatMap = false;
+            LOG_INFO(Render, "[TerrainEditingTools] FlushSplatMap OK");
+        }
+        else
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] FlushSplatMap: ReuploadSplatMap failed");
+        }
+        return ok;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::SaveHeightmap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainEditingTools::SaveHeightmap(const engine::core::Config& config,
+                                             const std::string& relPath)
+    {
+        if (!m_initialized || !m_heightmap || m_heightmap->heights.empty())
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] SaveHeightmap: no data to save");
+            return false;
+        }
+
+        const auto fullPath =
+            engine::platform::FileSystem::ResolveContentPath(config, relPath);
+
+        // Create parent directories if they do not exist
+        std::error_code ec;
+        std::filesystem::create_directories(fullPath.parent_path(), ec);
+        if (ec)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] SaveHeightmap: create_directories failed: {}",
+                     ec.message());
+            // Not fatal — try to open anyway
+        }
+
+        std::ofstream ofs(fullPath, std::ios::binary);
+        if (!ofs)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] SaveHeightmap: cannot open '{}' for writing",
+                      fullPath.string());
+            return false;
+        }
+
+        // Binary format: magic, width, height, uint16 data (little-endian)
+        const uint32_t magic  = kHeightmapMagic;
+        const uint32_t width  = m_heightmap->width;
+        const uint32_t height = m_heightmap->height;
+        ofs.write(reinterpret_cast<const char*>(&magic),  sizeof(magic));
+        ofs.write(reinterpret_cast<const char*>(&width),  sizeof(width));
+        ofs.write(reinterpret_cast<const char*>(&height), sizeof(height));
+        ofs.write(reinterpret_cast<const char*>(m_heightmap->heights.data()),
+                  static_cast<std::streamsize>(width * height * sizeof(uint16_t)));
+
+        if (!ofs)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] SaveHeightmap: write error on '{}'",
+                      fullPath.string());
+            return false;
+        }
+
+        LOG_INFO(Render, "[TerrainEditingTools] SaveHeightmap OK ('{}', {}x{})",
+                 relPath, width, height);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainEditingTools::SaveSplatMap
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainEditingTools::SaveSplatMap(const engine::core::Config& config,
+                                            const std::string& relPath)
+    {
+        if (!m_initialized || !m_splatting)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] SaveSplatMap: tools not initialised");
+            return false;
+        }
+
+        const std::vector<uint8_t>& cpuData = m_splatting->GetSplatMapCpu();
+        const uint32_t sw = m_splatting->GetSplatMapCpuWidth();
+        const uint32_t sh = m_splatting->GetSplatMapCpuHeight();
+
+        if (cpuData.empty() || sw == 0 || sh == 0)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] SaveSplatMap: no CPU splat data");
+            return false;
+        }
+
+        const auto fullPath =
+            engine::platform::FileSystem::ResolveContentPath(config, relPath);
+
+        std::error_code ec;
+        std::filesystem::create_directories(fullPath.parent_path(), ec);
+        if (ec)
+        {
+            LOG_WARN(Render, "[TerrainEditingTools] SaveSplatMap: create_directories failed: {}",
+                     ec.message());
+        }
+
+        std::ofstream ofs(fullPath, std::ios::binary);
+        if (!ofs)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] SaveSplatMap: cannot open '{}' for writing",
+                      fullPath.string());
+            return false;
+        }
+
+        // Binary format: magic, width, height, RGBA8 data (little-endian)
+        const uint32_t magic = kSplatFileMagic;
+        ofs.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+        ofs.write(reinterpret_cast<const char*>(&sw),    sizeof(sw));
+        ofs.write(reinterpret_cast<const char*>(&sh),    sizeof(sh));
+        ofs.write(reinterpret_cast<const char*>(cpuData.data()),
+                  static_cast<std::streamsize>(sw * sh * 4u));
+
+        if (!ofs)
+        {
+            LOG_ERROR(Render, "[TerrainEditingTools] SaveSplatMap: write error on '{}'",
+                      fullPath.string());
+            return false;
+        }
+
+        LOG_INFO(Render, "[TerrainEditingTools] SaveSplatMap OK ('{}', {}x{})",
+                 relPath, sw, sh);
+        return true;
+    }
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainEditingTools.h
+++ b/engine/render/terrain/TerrainEditingTools.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include "engine/render/terrain/HeightmapLoader.h"
+#include "engine/render/terrain/TerrainSplatting.h"
+
+#include <cstdint>
+#include <string>
+
+#include <vulkan/vulkan_core.h>
+
+namespace engine::core    { class Config; }
+
+namespace engine::render::terrain
+{
+    /// Brush operations supported by the terrain editor.
+    enum class BrushOp : uint32_t
+    {
+        Raise   = 0, ///< Raise height by strength × kernel weight.
+        Lower   = 1, ///< Lower height by strength × kernel weight.
+        Smooth  = 2, ///< Gaussian-weighted average of neighbouring pixels within the brush.
+        Flatten = 3, ///< Lerp toward a target normalised height.
+    };
+
+    /// Parameters shared by all brush operations.
+    struct BrushParams
+    {
+        float radius        = 10.0f; ///< World-space brush radius in metres.
+        float strength      = 0.10f; ///< Effect magnitude per call [0, 1].
+        float falloff       = 1.0f;  ///< Falloff exponent: 1=linear, 2=quadratic, …
+        float flattenTarget = 0.0f;  ///< Target normalised height [0, 1] used by Flatten.
+    };
+
+    /// Binary magic for exported splat map files ("SLAP", little-endian).
+    static constexpr uint32_t kSplatFileMagic = 0x50414C53u;
+
+    /// CPU-side terrain editing tools: heightmap brush and splat paint.
+    ///
+    /// Usage pattern:
+    ///   1. Obtain a TerrainRenderer that has been successfully Init'd.
+    ///   2. Call Init() passing the renderer's mutable CPU data + Vulkan context.
+    ///   3. Each editor frame: call ApplyBrush() / PaintSplat() with world-space coords.
+    ///   4. After editing: call FlushHeightmap() / FlushSplatMap() to push to GPU.
+    ///   5. To persist: call SaveHeightmap() / SaveSplatMap() with content-relative paths.
+    ///
+    /// Thread safety: all methods are NOT thread-safe. Call from the main/render thread only.
+    class TerrainEditingTools final
+    {
+    public:
+        TerrainEditingTools() = default;
+        TerrainEditingTools(const TerrainEditingTools&) = delete;
+        TerrainEditingTools& operator=(const TerrainEditingTools&) = delete;
+
+        /// Initialises the editing tools.
+        ///
+        /// \param heightmap        Mutable CPU heightmap owned by TerrainRenderer.
+        ///                         Must remain valid for the lifetime of this object.
+        /// \param splatting        TerrainSplatting instance that holds a CPU splat copy.
+        ///                         Must remain valid for the lifetime of this object.
+        /// \param terrainOriginX   World X of the terrain corner (config: terrain.origin_x).
+        /// \param terrainOriginZ   World Z of the terrain corner (config: terrain.origin_z).
+        /// \param terrainWorldSize Total world extent in metres (config: terrain.world_size).
+        /// \param heightScale      Max world height in metres (config: terrain.height_scale).
+        /// \return true on success.
+        bool Init(HeightmapData*    heightmap,
+                  TerrainSplatting* splatting,
+                  float terrainOriginX,
+                  float terrainOriginZ,
+                  float terrainWorldSize,
+                  float heightScale);
+
+        /// Releases all internal state. Calling Init() again is safe afterwards.
+        void Shutdown();
+
+        /// Returns true if Init() succeeded and Shutdown() has not been called.
+        bool IsValid() const { return m_initialized; }
+
+        // ── Heightmap brush ───────────────────────────────────────────────────────
+
+        /// Applies a heightmap brush at a world-space position.
+        ///
+        /// Modifies the CPU heightmap in place. Sets the dirty-heightmap flag.
+        /// Call FlushHeightmap() after all brush strokes to upload the result to the GPU.
+        ///
+        /// \param worldX   World X centre of the brush stroke.
+        /// \param worldZ   World Z centre of the brush stroke.
+        /// \param op       Brush operation (Raise / Lower / Smooth / Flatten).
+        /// \param params   Brush configuration (radius, strength, falloff, flattenTarget).
+        void ApplyBrush(float worldX, float worldZ,
+                        BrushOp op, const BrushParams& params);
+
+        // ── Splat paint ───────────────────────────────────────────────────────────
+
+        /// Paints a splat layer weight at a world-space position.
+        ///
+        /// Increases the weight of `layer` within the brush radius, then renormalises
+        /// all four layer weights so their sum equals 1 per pixel.
+        /// Sets the dirty-splatmap flag.
+        /// Call FlushSplatMap() after all paint strokes.
+        ///
+        /// \param worldX   World X centre of the brush stroke.
+        /// \param worldZ   World Z centre of the brush stroke.
+        /// \param layer    Layer index [0, kSplatLayerCount). 0=grass,1=dirt,2=rock,3=snow.
+        /// \param params   Brush configuration (radius, strength, falloff).
+        void PaintSplat(float worldX, float worldZ,
+                        uint32_t layer, const BrushParams& params);
+
+        // ── GPU upload ────────────────────────────────────────────────────────────
+
+        /// Uploads the full CPU heightmap to the provided GPU R16_UNORM image via staging.
+        ///
+        /// The image must be in VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL before the call.
+        /// It is returned to that layout on success. Clears the dirty-heightmap flag.
+        ///
+        /// \param heightmapImage  VkImage owned by TerrainRenderer (HeightmapGpu::image).
+        /// \return true on success.
+        bool FlushHeightmap(VkDevice device, VkPhysicalDevice physDev,
+                            VkQueue queue, uint32_t queueFamilyIndex,
+                            VkImage heightmapImage);
+
+        /// Uploads the full CPU splat map to the GPU via TerrainSplatting::ReuploadSplatMap().
+        ///
+        /// Clears the dirty-splatmap flag on success.
+        /// \return true on success.
+        bool FlushSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                           VkQueue queue, uint32_t queueFamilyIndex);
+
+        // ── Save / export ─────────────────────────────────────────────────────────
+
+        /// Exports the CPU heightmap to a .r16h binary file.
+        ///
+        /// File format (all little-endian):
+        ///   magic  : uint32 = kHeightmapMagic (0x504D4148, "HAMP")
+        ///   width  : uint32
+        ///   height : uint32
+        ///   data   : uint16[width * height]  (row-major, z * width + x)
+        ///
+        /// Parent directories are created automatically if missing.
+        ///
+        /// \param config   Used to resolve paths.content.
+        /// \param relPath  Content-relative path (e.g. "terrain/heightmap.r16h").
+        /// \return true on success.
+        bool SaveHeightmap(const engine::core::Config& config,
+                           const std::string& relPath);
+
+        /// Exports the CPU splat map to a .rgba8 binary file.
+        ///
+        /// File format (all little-endian):
+        ///   magic  : uint32 = kSplatFileMagic (0x50414C53, "SLAP")
+        ///   width  : uint32
+        ///   height : uint32
+        ///   data   : uint8[width * height * 4]  (RGBA, row-major)
+        ///
+        /// Parent directories are created automatically if missing.
+        ///
+        /// \param config   Used to resolve paths.content.
+        /// \param relPath  Content-relative path (e.g. "terrain/splatmap.rgba8").
+        /// \return true on success.
+        bool SaveSplatMap(const engine::core::Config& config,
+                          const std::string& relPath);
+
+        // ── Dirty flags ───────────────────────────────────────────────────────────
+
+        /// Returns true if the CPU heightmap has been modified since the last flush/clear.
+        bool IsDirtyHeightmap() const { return m_dirtyHeightmap; }
+        /// Returns true if the CPU splat map has been modified since the last flush/clear.
+        bool IsDirtySplatMap()  const { return m_dirtySplatMap;  }
+        /// Resets both dirty flags without uploading.
+        void ClearDirtyFlags()  { m_dirtyHeightmap = false; m_dirtySplatMap = false; }
+
+    private:
+        /// Returns the brush kernel weight [0, 1] for a pixel at world-distance `dist`
+        /// from the brush centre. Returns 0 when dist >= radius.
+        float ComputeKernel(float dist, float radius, float falloff) const;
+
+        /// Converts world X/Z to heightmap pixel coordinates (may be out of bounds).
+        void WorldToHeightmapPixel(float worldX, float worldZ,
+                                   int32_t& outPx, int32_t& outPz) const;
+
+        /// Converts world X/Z to splat map pixel coordinates (may be out of bounds).
+        void WorldToSplatPixel(float worldX, float worldZ,
+                               int32_t& outPx, int32_t& outPz) const;
+
+        HeightmapData*    m_heightmap        = nullptr;
+        TerrainSplatting* m_splatting        = nullptr;
+        float             m_terrainOriginX   = 0.0f;
+        float             m_terrainOriginZ   = 0.0f;
+        float             m_terrainWorldSize = 0.0f;
+        float             m_heightScale      = 0.0f;
+        bool              m_initialized      = false;
+        bool              m_dirtyHeightmap   = false;
+        bool              m_dirtySplatMap    = false;
+    };
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainRenderer.h
+++ b/engine/render/terrain/TerrainRenderer.h
@@ -131,6 +131,28 @@ namespace engine::render::terrain
         /// IsHole(qx, qz) returns true when quad (qx, qz) is a hole (unwalkable).
         const HoleMaskData& GetHoleMaskData() const { return m_holeMaskData; }
 
+        // ── M34.4: terrain editing accessors ─────────────────────────────────────
+
+        /// Returns a mutable reference to the CPU heightmap.
+        /// Used by TerrainEditingTools to apply brush operations.
+        HeightmapData& GetMutableHeightmapData() { return m_heightmapData; }
+
+        /// Returns the GPU heightmap resources.
+        /// Pass HeightmapGpu::image to TerrainEditingTools::FlushHeightmap().
+        const HeightmapGpu& GetHeightmapGpu() const { return m_heightmapGpu; }
+
+        /// Returns the TerrainSplatting instance for editing and re-upload.
+        TerrainSplatting& GetSplatting() { return m_splatting; }
+
+        /// Returns the world X origin of the terrain (config: terrain.origin_x).
+        float GetTerrainOriginX()   const { return m_terrainOriginX;   }
+        /// Returns the world Z origin of the terrain (config: terrain.origin_z).
+        float GetTerrainOriginZ()   const { return m_terrainOriginZ;   }
+        /// Returns the total world extent of the terrain in metres (config: terrain.world_size).
+        float GetTerrainWorldSize() const { return m_terrainWorldSize; }
+        /// Returns the maximum height in world units (config: terrain.height_scale).
+        float GetHeightScale()      const { return m_heightScale;      }
+
     private:
         // ── Push constants ────────────────────────────────────────────────────────
         // All stages, 16 bytes total.

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -343,6 +343,11 @@ namespace engine::render::terrain
         LOG_DEBUG(Render, "[TerrainSplatting] Generated default splat map ({}x{}, all grass)",
                   kSplatW, kSplatH);
 
+        // ── Keep CPU copy for M34.4 editing tools ─────────────────────────────────
+        m_cpuData   = splatData;
+        m_cpuWidth  = kSplatW;
+        m_cpuHeight = kSplatH;
+
         // ── Upload splat map ──────────────────────────────────────────────────────
         if (!UploadSplatMap(device, physDev, splatData, kSplatW, kSplatH,
                             queue, queueFamilyIndex, m_splatMap))
@@ -447,7 +452,168 @@ namespace engine::render::terrain
         DestroyTextureArray(device, m_albedoArray);
         DestroyTextureArray(device, m_normalArray);
         DestroyTextureArray(device, m_ormArray);
+        m_cpuData.clear();
+        m_cpuWidth  = 0;
+        m_cpuHeight = 0;
         LOG_INFO(Render, "[TerrainSplatting] Destroyed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::ReuploadSplatMap  (M34.4)
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::ReuploadSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                                             VkQueue queue, uint32_t queueFamilyIndex)
+    {
+        if (m_cpuData.empty() || m_cpuWidth == 0 || m_cpuHeight == 0)
+        {
+            LOG_WARN(Render, "[TerrainSplatting] ReuploadSplatMap: no CPU data available");
+            return false;
+        }
+        if (m_splatMap.image == VK_NULL_HANDLE)
+        {
+            LOG_WARN(Render, "[TerrainSplatting] ReuploadSplatMap: GPU image not initialised");
+            return false;
+        }
+
+        const VkDeviceSize dataBytes =
+            static_cast<VkDeviceSize>(m_cpuWidth) * m_cpuHeight * 4u;
+
+        // ── Staging buffer ────────────────────────────────────────────────────────
+        VkBuffer stagingBuf = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, dataBytes, stagingBuf, stagingMem))
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] ReuploadSplatMap: staging buffer failed");
+            return false;
+        }
+
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, dataBytes, 0, &mapped) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] ReuploadSplatMap: vkMapMemory failed");
+            vkFreeMemory(device, stagingMem, nullptr);
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, m_cpuData.data(), static_cast<size_t>(dataBytes));
+        vkUnmapMemory(device, stagingMem);
+
+        // ── One-time command buffer ───────────────────────────────────────────────
+        VkCommandPool pool = VK_NULL_HANDLE;
+        {
+            VkCommandPoolCreateInfo poolCI{};
+            poolCI.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            poolCI.queueFamilyIndex = queueFamilyIndex;
+            poolCI.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+            if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS ||
+                pool == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] ReuploadSplatMap: vkCreateCommandPool failed");
+                vkFreeMemory(device, stagingMem, nullptr);
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                return false;
+            }
+        }
+
+        VkCommandBuffer cmd = VK_NULL_HANDLE;
+        {
+            VkCommandBufferAllocateInfo allocCI{};
+            allocCI.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            allocCI.commandPool        = pool;
+            allocCI.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocCI.commandBufferCount = 1;
+            if (vkAllocateCommandBuffers(device, &allocCI, &cmd) != VK_SUCCESS ||
+                cmd == VK_NULL_HANDLE)
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] ReuploadSplatMap: vkAllocateCommandBuffers failed");
+                vkDestroyCommandPool(device, pool, nullptr);
+                vkFreeMemory(device, stagingMem, nullptr);
+                vkDestroyBuffer(device, stagingBuf, nullptr);
+                return false;
+            }
+        }
+
+        VkCommandBufferBeginInfo beginInfo{};
+        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] ReuploadSplatMap: vkBeginCommandBuffer failed");
+            vkDestroyCommandPool(device, pool, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            vkDestroyBuffer(device, stagingBuf, nullptr);
+            return false;
+        }
+
+        // Barrier: SHADER_READ_ONLY_OPTIMAL → TRANSFER_DST_OPTIMAL
+        {
+            VkImageMemoryBarrier b{};
+            b.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image               = m_splatMap.image;
+            b.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            b.srcAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+            b.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        // Copy staging → image
+        {
+            VkBufferImageCopy region{};
+            region.bufferOffset                    = 0;
+            region.bufferRowLength                 = 0;
+            region.bufferImageHeight               = 0;
+            region.imageSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            region.imageSubresource.mipLevel       = 0;
+            region.imageSubresource.baseArrayLayer = 0;
+            region.imageSubresource.layerCount     = 1;
+            region.imageOffset                     = { 0, 0, 0 };
+            region.imageExtent                     = { m_cpuWidth, m_cpuHeight, 1 };
+            vkCmdCopyBufferToImage(cmd, stagingBuf, m_splatMap.image,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+        }
+
+        // Barrier: TRANSFER_DST_OPTIMAL → SHADER_READ_ONLY_OPTIMAL
+        {
+            VkImageMemoryBarrier b{};
+            b.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.newLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image               = m_splatMap.image;
+            b.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+            b.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+            b.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        vkEndCommandBuffer(cmd);
+
+        VkSubmitInfo si{};
+        si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        si.commandBufferCount = 1;
+        si.pCommandBuffers    = &cmd;
+        vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE);
+        vkQueueWaitIdle(queue);
+
+        vkDestroyCommandPool(device, pool, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+        vkDestroyBuffer(device, stagingBuf, nullptr);
+
+        LOG_DEBUG(Render, "[TerrainSplatting] ReuploadSplatMap OK ({}x{})",
+                  m_cpuWidth, m_cpuHeight);
+        return true;
     }
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -75,6 +75,9 @@ namespace engine::render::terrain
         /// Returns true if Init succeeded and Destroy has not been called.
         bool IsValid() const { return m_splatMap.image != VK_NULL_HANDLE; }
 
+        /// Returns true when a CPU copy of the splat map is available (after Init).
+        bool HasCpuData() const { return !m_cpuData.empty(); }
+
         const SplatMapGpu&    GetSplatMap()    const { return m_splatMap;    }
         const TextureArrayGpu& GetAlbedoArray() const { return m_albedoArray; }
         const TextureArrayGpu& GetNormalArray() const { return m_normalArray; }
@@ -83,6 +86,30 @@ namespace engine::render::terrain
         /// Returns the tiling scale (metres per tile) for a given layer index [0, kSplatLayerCount).
         float GetLayerTiling(uint32_t layer) const;
 
+        // ── CPU data accessors (M34.4 editing tools) ──────────────────────────────
+
+        /// Returns a mutable reference to the CPU RGBA8 splat map buffer.
+        /// The buffer is row-major, width × height × 4 bytes (R=grass,G=dirt,B=rock,A=snow).
+        /// Call ReuploadSplatMap() to push changes to the GPU.
+        std::vector<uint8_t>& GetMutableSplatMapCpu() { return m_cpuData; }
+
+        /// Returns a read-only reference to the CPU splat map buffer.
+        const std::vector<uint8_t>& GetSplatMapCpu() const { return m_cpuData; }
+
+        /// Returns the width of the CPU splat map in pixels.
+        uint32_t GetSplatMapCpuWidth()  const { return m_cpuWidth;  }
+
+        /// Returns the height of the CPU splat map in pixels.
+        uint32_t GetSplatMapCpuHeight() const { return m_cpuHeight; }
+
+        /// Re-uploads the full CPU splat map to the existing GPU image via staging.
+        ///
+        /// The GPU splat map image must be in SHADER_READ_ONLY_OPTIMAL layout before the call.
+        /// It is returned to that layout on success.
+        /// \return true on success.
+        bool ReuploadSplatMap(VkDevice device, VkPhysicalDevice physDev,
+                              VkQueue queue, uint32_t queueFamilyIndex);
+
     private:
         SplatMapGpu    m_splatMap;
         TextureArrayGpu m_albedoArray;
@@ -90,6 +117,11 @@ namespace engine::render::terrain
         TextureArrayGpu m_ormArray;
 
         float m_layerTiling[kSplatLayerCount] = { 8.0f, 8.0f, 16.0f, 12.0f };
+
+        /// CPU copy of the splat map retained after Init for editing (M34.4).
+        std::vector<uint8_t> m_cpuData;
+        uint32_t             m_cpuWidth  = 0;
+        uint32_t             m_cpuHeight = 0;
 
         // ── Internal upload helpers ───────────────────────────────────────────────
 


### PR DESCRIPTION
- Add TerrainEditingTools (raise/lower/smooth/flatten brush, splat paint, FlushHeightmap, FlushSplatMap, SaveHeightmap, SaveSplatMap)
- TerrainSplatting: retain CPU copy of splat map after Init; add GetMutableSplatMapCpu / GetSplatMapCpu / HasCpuData and ReuploadSplatMap
- TerrainRenderer: expose editing accessors (GetMutableHeightmapData, GetHeightmapGpu, GetSplatting, terrain world params)
- CMakeLists.txt: register TerrainEditingTools.cpp in engine_core

https://claude.ai/code/session_011KfpZytrpbhQoSS6xocGFj