### PR TITLE
feat(M35.2): Vendors buy/sell items + shop UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(engine_core
   engine/client/FriendsUi.cpp
   engine/client/PartyHud.cpp
   engine/client/ZonePreloadHook.cpp
+  engine/client/ShopUi.cpp
   engine/net/ChatSystem.cpp
   engine/net/ChatEmotes.cpp
   engine/editor/EditorMode.cpp

--- a/engine/client/ShopUi.cpp
+++ b/engine/client/ShopUi.cpp
@@ -1,0 +1,322 @@
+#include "engine/client/ShopUi.h"
+
+#include "engine/core/Log.h"
+#include "engine/platform/FileSystem.h"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Trim leading/trailing spaces and tabs from a text view.
+		std::string_view Trim(std::string_view value)
+		{
+			size_t begin = 0;
+			size_t end   = value.size();
+			while (begin < end && (value[begin] == ' ' || value[begin] == '\t' || value[begin] == '\r'))
+			{
+				++begin;
+			}
+			while (end > begin && (value[end - 1] == ' ' || value[end - 1] == '\t' || value[end - 1] == '\r'))
+			{
+				--end;
+			}
+			return value.substr(begin, end - begin);
+		}
+
+		/// Split a line into at most four `|`-separated columns.
+		std::array<std::string_view, 4> SplitColumns(std::string_view line, size_t& outCount)
+		{
+			std::array<std::string_view, 4> cols{};
+			outCount = 0;
+			size_t start = 0;
+			while (start <= line.size() && outCount < cols.size())
+			{
+				const size_t sep = line.find('|', start);
+				if (sep == std::string_view::npos)
+				{
+					cols[outCount++] = line.substr(start);
+					break;
+				}
+				cols[outCount++] = line.substr(start, sep - start);
+				start = sep + 1;
+			}
+			return cols;
+		}
+	}
+
+	ShopUiPresenter::~ShopUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool ShopUiPresenter::Init(const engine::core::Config& config)
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[ShopUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+
+		// Reuse the same inventory metadata file so item names/icons are shared.
+		m_metadataRelPath = config.GetString("ui.inventory_items_path", "ui/inventory_items.txt");
+		if (!LoadMetadata(config))
+		{
+			LOG_ERROR(Core, "[ShopUiPresenter] Init FAILED: metadata load failed ({})", m_metadataRelPath);
+			return false;
+		}
+
+		m_initialized = true;
+		RebuildLayout();
+		RebuildDebugText();
+		LOG_INFO(Core, "[ShopUiPresenter] Init OK (meta_entries={}, path={})", m_metadata.size(), m_metadataRelPath);
+		return true;
+	}
+
+	void ShopUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+		{
+			return;
+		}
+		m_initialized    = false;
+		m_state          = {};
+		m_metadata.clear();
+		m_viewportWidth  = 0;
+		m_viewportHeight = 0;
+		m_metadataRelPath.clear();
+		LOG_INFO(Core, "[ShopUiPresenter] Destroyed");
+	}
+
+	bool ShopUiPresenter::SetViewportSize(uint32_t width, uint32_t height)
+	{
+		if (!m_initialized)
+		{
+			LOG_ERROR(Core, "[ShopUiPresenter] SetViewportSize FAILED: not initialized");
+			return false;
+		}
+		if (width == 0 || height == 0)
+		{
+			LOG_WARN(Core, "[ShopUiPresenter] SetViewportSize FAILED: invalid size {}x{}", width, height);
+			return false;
+		}
+		m_viewportWidth  = width;
+		m_viewportHeight = height;
+		RebuildLayout();
+		RebuildDebugText();
+		LOG_INFO(Core, "[ShopUiPresenter] Viewport updated ({}x{})", width, height);
+		return true;
+	}
+
+	bool ShopUiPresenter::ApplyModel(const UIModel& model, uint32_t changeMask)
+	{
+		if (!m_initialized)
+		{
+			LOG_ERROR(Core, "[ShopUiPresenter] ApplyModel FAILED: not initialized");
+			return false;
+		}
+
+		if ((changeMask & UIModelChangeShop) == 0u && (changeMask & UIModelChangeWallet) == 0u)
+		{
+			return true;
+		}
+
+		if (!m_state.layoutValid)
+		{
+			RebuildLayout();
+		}
+
+		RebuildItems(model);
+		RebuildDebugText();
+		LOG_DEBUG(Core, "[ShopUiPresenter] Model applied (vendor={}, items={}, gold={}, open={})",
+			model.shop.vendorId,
+			model.shop.items.size(),
+			model.wallet.gold,
+			model.shop.isOpen ? "true" : "false");
+		return true;
+	}
+
+	bool ShopUiPresenter::SelectItem(uint32_t itemId)
+	{
+		if (!m_initialized)
+		{
+			LOG_ERROR(Core, "[ShopUiPresenter] SelectItem FAILED: not initialized");
+			return false;
+		}
+		m_state.selectedItemId = itemId;
+		for (ShopItemView& view : m_state.items)
+		{
+			view.selected = (view.itemId == itemId);
+		}
+		RebuildDebugText();
+		LOG_DEBUG(Core, "[ShopUiPresenter] SelectItem (item_id={})", itemId);
+		return true;
+	}
+
+	bool ShopUiPresenter::LoadMetadata(const engine::core::Config& config)
+	{
+		const std::string text = engine::platform::FileSystem::ReadAllTextContent(config, m_metadataRelPath);
+		if (text.empty())
+		{
+			LOG_WARN(Core, "[ShopUiPresenter] Metadata missing or empty ({}); shop will show item ids only", m_metadataRelPath);
+			// Not a hard failure — shop is still functional without display names.
+			return true;
+		}
+
+		m_metadata.clear();
+		size_t lineStart = 0;
+		while (lineStart <= text.size())
+		{
+			const size_t lineEnd    = text.find('\n', lineStart);
+			const std::string_view rawLine = (lineEnd == std::string::npos)
+				? std::string_view(text).substr(lineStart)
+				: std::string_view(text).substr(lineStart, lineEnd - lineStart);
+			const std::string_view line = Trim(rawLine);
+			if (!line.empty() && !line.starts_with('#'))
+			{
+				uint32_t    itemId = 0;
+				std::string icon;
+				std::string name;
+				if (ParseMetadataLine(line, itemId, icon, name))
+				{
+					ItemMetaEntry entry{};
+					entry.itemId      = itemId;
+					entry.iconPath    = std::move(icon);
+					entry.displayName = std::move(name);
+					m_metadata.push_back(std::move(entry));
+				}
+			}
+			if (lineEnd == std::string::npos)
+			{
+				break;
+			}
+			lineStart = lineEnd + 1;
+		}
+
+		LOG_INFO(Core, "[ShopUiPresenter] Metadata loaded (entries={}, path={})", m_metadata.size(), m_metadataRelPath);
+		return true;
+	}
+
+	bool ShopUiPresenter::ParseMetadataLine(std::string_view line, uint32_t& outItemId, std::string& outIcon, std::string& outName) const
+	{
+		size_t colCount = 0;
+		const auto cols = SplitColumns(line, colCount);
+		if (colCount < 3)
+		{
+			return false;
+		}
+		const std::string_view idView = Trim(cols[0]);
+		if (idView.empty())
+		{
+			return false;
+		}
+		uint32_t id = 0;
+		for (const char ch : idView)
+		{
+			if (ch < '0' || ch > '9')
+			{
+				return false;
+			}
+			id = (id * 10u) + static_cast<uint32_t>(ch - '0');
+		}
+		outItemId = id;
+		outIcon   = std::string(Trim(cols[1]));
+		outName   = std::string(Trim(cols[2]));
+		return !outName.empty();
+	}
+
+	void ShopUiPresenter::RebuildLayout()
+	{
+		const float vw = static_cast<float>(m_viewportWidth  == 0 ? 1280u : m_viewportWidth);
+		const float vh = static_cast<float>(m_viewportHeight == 0 ? 720u  : m_viewportHeight);
+
+		// Centre of screen, slightly left of centre.
+		const float panelWidth  = std::clamp(vw * 0.40f, 380.0f, 560.0f);
+		const float panelHeight = std::clamp(vh * 0.60f, 360.0f, 520.0f);
+		const float panelX      = (vw - panelWidth) * 0.5f;
+		const float panelY      = (vh - panelHeight) * 0.5f;
+
+		m_state.panelBounds = { panelX, panelY, panelWidth, panelHeight };
+		m_state.layoutValid = true;
+	}
+
+	void ShopUiPresenter::RebuildItems(const UIModel& model)
+	{
+		m_state.visible    = model.shop.isOpen;
+		m_state.vendorId   = model.shop.vendorId;
+		m_state.playerGold = model.wallet.gold;
+
+		m_state.items.clear();
+		m_state.items.reserve(model.shop.items.size());
+
+		for (const UIShopItemEntry& entry : model.shop.items)
+		{
+			ShopItemView view{};
+			view.itemId      = entry.itemId;
+			view.buyPrice    = entry.buyPrice;
+			view.sellPrice   = entry.sellPrice;
+			view.stock       = entry.stock;
+			view.displayName = FindDisplayName(entry.itemId);
+			view.iconPath    = FindIconPath(entry.itemId);
+			view.selected    = (entry.itemId == m_state.selectedItemId);
+			view.canAfford   = (model.wallet.gold >= entry.buyPrice);
+			m_state.items.push_back(std::move(view));
+		}
+	}
+
+	void ShopUiPresenter::RebuildDebugText()
+	{
+		m_state.debugText.clear();
+		m_state.debugText += "[ShopUi]\n";
+		m_state.debugText += "vendor=";
+		m_state.debugText += m_state.vendorId.empty() ? "(none)" : m_state.vendorId;
+		m_state.debugText += " open=";
+		m_state.debugText += m_state.visible ? "true" : "false";
+		m_state.debugText += " gold=";
+		m_state.debugText += std::to_string(m_state.playerGold);
+		m_state.debugText += " items=";
+		m_state.debugText += std::to_string(m_state.items.size());
+		m_state.debugText += "\n";
+		for (const ShopItemView& item : m_state.items)
+		{
+			m_state.debugText += " item_id=";
+			m_state.debugText += std::to_string(item.itemId);
+			m_state.debugText += " buy=";
+			m_state.debugText += std::to_string(item.buyPrice);
+			m_state.debugText += " sell=";
+			m_state.debugText += std::to_string(item.sellPrice);
+			m_state.debugText += " stock=";
+			m_state.debugText += (item.stock == -1) ? "inf" : std::to_string(item.stock);
+			m_state.debugText += " name=";
+			m_state.debugText += item.displayName.empty() ? "?" : item.displayName;
+			m_state.debugText += "\n";
+		}
+	}
+
+	std::string ShopUiPresenter::FindDisplayName(uint32_t itemId) const
+	{
+		for (const ItemMetaEntry& entry : m_metadata)
+		{
+			if (entry.itemId == itemId)
+			{
+				return entry.displayName;
+			}
+		}
+		return "Item " + std::to_string(itemId);
+	}
+
+	std::string ShopUiPresenter::FindIconPath(uint32_t itemId) const
+	{
+		for (const ItemMetaEntry& entry : m_metadata)
+		{
+			if (entry.itemId == itemId)
+			{
+				return entry.iconPath;
+			}
+		}
+		return {};
+	}
+}

--- a/engine/client/ShopUi.h
+++ b/engine/client/ShopUi.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "engine/client/UIModel.h"
+#include "engine/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::client
+{
+	/// Pixel-space rectangle used by the shop panel layout.
+	struct ShopRect
+	{
+		float x      = 0.0f;
+		float y      = 0.0f;
+		float width  = 0.0f;
+		float height = 0.0f;
+	};
+
+	/// One vendor item entry ready for a shop panel row.
+	struct ShopItemView
+	{
+		uint32_t    itemId     = 0;
+		uint32_t    buyPrice   = 0;    ///< Gold cost to buy.
+		uint32_t    sellPrice  = 0;    ///< Gold received when selling back.
+		int32_t     stock      = -1;   ///< -1 means infinite.
+		std::string displayName;
+		std::string iconPath;
+		bool        selected   = false;
+		bool        canAfford  = false; ///< True when player gold >= buyPrice.
+	};
+
+	/// Fully resolved shop panel state for a rendering layer (M35.2).
+	struct ShopPanelState
+	{
+		ShopRect               panelBounds{};
+		std::string            vendorId;
+		std::vector<ShopItemView> items;
+		uint32_t               playerGold    = 0;
+		uint32_t               selectedItemId = 0; ///< 0 when nothing is selected.
+		std::string            debugText;
+		bool                   visible       = false;
+		bool                   layoutValid   = false;
+	};
+
+	/// Builds a vendor shop panel state from the shared UI model (M35.2).
+	class ShopUiPresenter final
+	{
+	public:
+		/// Construct an uninitialized shop presenter.
+		ShopUiPresenter() = default;
+
+		/// Release presenter resources.
+		~ShopUiPresenter();
+
+		/// Initialize the presenter and load item display metadata from content.
+		bool Init(const engine::core::Config& config);
+
+		/// Shutdown the presenter and release cached state.
+		void Shutdown();
+
+		/// Update the viewport-dependent layout for the shop panel.
+		bool SetViewportSize(uint32_t width, uint32_t height);
+
+		/// Apply one UI model snapshot and rebuild the shop panel state.
+		bool ApplyModel(const UIModel& model, uint32_t changeMask);
+
+		/// Select one shop item by itemId for detail display (0 to deselect).
+		bool SelectItem(uint32_t itemId);
+
+		/// Return the immutable resolved shop panel state.
+		const ShopPanelState& GetState() const { return m_state; }
+
+	private:
+		/// Load item display metadata from the inventory items metadata file.
+		bool LoadMetadata(const engine::core::Config& config);
+
+		/// Parse one metadata line using the `item|icon|name|description` format.
+		bool ParseMetadataLine(std::string_view line, uint32_t& outItemId, std::string& outIcon, std::string& outName) const;
+
+		/// Recompute panel rectangle after a viewport change.
+		void RebuildLayout();
+
+		/// Rebuild item rows from the current shop state.
+		void RebuildItems(const UIModel& model);
+
+		/// Rebuild textual debug dump of the shop panel state.
+		void RebuildDebugText();
+
+		/// Return the display name for one item id, or empty when metadata is absent.
+		std::string FindDisplayName(uint32_t itemId) const;
+
+		/// Return the icon path for one item id, or empty when metadata is absent.
+		std::string FindIconPath(uint32_t itemId) const;
+
+		struct ItemMetaEntry
+		{
+			uint32_t    itemId = 0;
+			std::string iconPath;
+			std::string displayName;
+		};
+
+		ShopPanelState           m_state{};
+		std::vector<ItemMetaEntry> m_metadata;
+		uint32_t                 m_viewportWidth  = 0;
+		uint32_t                 m_viewportHeight = 0;
+		std::string              m_metadataRelPath;
+		bool                     m_initialized    = false;
+	};
+}

--- a/engine/client/UIModel.cpp
+++ b/engine/client/UIModel.cpp
@@ -451,6 +451,11 @@ namespace engine::client
 			return ApplyPartyUpdate(packet);
 		case engine::server::MessageKind::WalletUpdate:
 			return ApplyWalletUpdate(packet);
+		// M35.2 — Vendor shop
+		case engine::server::MessageKind::VendorShopSync:
+			return ApplyVendorShopSync(packet);
+		case engine::server::MessageKind::VendorTransactionResult:
+			return ApplyVendorTransactionResult(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -883,6 +888,67 @@ namespace engine::client
 			m_walletScratch.premiumCurrency);
 
 		NotifyObservers(UIModelChangeWallet);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// M35.2 — Vendor shop
+	// -------------------------------------------------------------------------
+
+	bool UIModelBinding::ApplyVendorShopSync(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeVendorShopSync(packet, m_vendorShopScratch))
+		{
+			LOG_WARN(Net, "[UIModelBinding] VendorShopSync FAILED: decode error");
+			return false;
+		}
+
+		m_model.shop.vendorId = m_vendorShopScratch.vendorId;
+		m_model.shop.items.clear();
+		m_model.shop.items.reserve(m_vendorShopScratch.items.size());
+		for (const engine::server::VendorShopItemEntry& entry : m_vendorShopScratch.items)
+		{
+			UIShopItemEntry item{};
+			item.itemId    = entry.itemId;
+			item.buyPrice  = entry.buyPrice;
+			item.sellPrice = entry.sellPrice;
+			item.stock     = entry.stock;
+			m_model.shop.items.push_back(item);
+		}
+		m_model.shop.isOpen = true;
+
+		LOG_INFO(Net, "[UIModelBinding] VendorShopSync applied (client_id={}, vendor={}, items={})",
+			m_vendorShopScratch.clientId,
+			m_vendorShopScratch.vendorId,
+			m_vendorShopScratch.items.size());
+
+		NotifyObservers(UIModelChangeShop);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyVendorTransactionResult(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeVendorTransactionResult(packet, m_vendorTxScratch))
+		{
+			LOG_WARN(Net, "[UIModelBinding] VendorTransactionResult FAILED: decode error");
+			return false;
+		}
+
+		if (m_vendorTxScratch.success != 0u)
+		{
+			// Update the wallet gold balance from the transaction result.
+			m_model.wallet.gold = m_vendorTxScratch.newGold;
+			m_model.wallet.hasWallet = true;
+			LOG_INFO(Net, "[UIModelBinding] VendorTransactionResult: success, new_gold={}",
+				m_vendorTxScratch.newGold);
+			NotifyObservers(UIModelChangeShop | UIModelChangeWallet);
+		}
+		else
+		{
+			LOG_WARN(Net, "[UIModelBinding] VendorTransactionResult: failed (reason={})",
+				m_vendorTxScratch.errorReason);
+			NotifyObservers(UIModelChangeShop);
+		}
 		return true;
 	}
 }

--- a/engine/client/UIModel.h
+++ b/engine/client/UIModel.h
@@ -32,7 +32,9 @@ namespace engine::client
 		/// M32.2: party composition, member HP/mana, loot mode.
 		UIModelChangeParty     = 1u << 9,
 		/// M35.1 — wallet balances (gold, honor, badges, premium).
-		UIModelChangeWallet    = 1u << 10
+		UIModelChangeWallet    = 1u << 10,
+		/// M35.2 — vendor shop catalog opened or closed.
+		UIModelChangeShop      = 1u << 11
 	};
 
 	/// M35.1 — wallet balances replicated from \ref WalletUpdateMessage.
@@ -43,6 +45,23 @@ namespace engine::client
 		uint32_t badges = 0;
 		uint32_t premiumCurrency = 0;
 		bool hasWallet = false;
+	};
+
+	/// M35.2 — one item entry inside the open vendor shop catalog.
+	struct UIShopItemEntry
+	{
+		uint32_t itemId    = 0;
+		uint32_t buyPrice  = 0; ///< Gold cost to purchase from the vendor.
+		uint32_t sellPrice = 0; ///< Gold received when selling back (25% of buyPrice).
+		int32_t  stock     = -1; ///< Remaining stock; -1 means infinite.
+	};
+
+	/// M35.2 — vendor shop state replicated from \ref VendorShopSyncMessage.
+	struct UIShopState
+	{
+		std::string                   vendorId;
+		std::vector<UIShopItemEntry>  items;
+		bool                          isOpen = false; ///< True while a vendor shop is displayed.
 	};
 
 	/// Player-focused runtime stats mirrored from server-authoritative packets.
@@ -177,6 +196,8 @@ namespace engine::client
 		uint32_t    partyLeaderId    = 0;
 		/// M35.1 — multi-currency wallet snapshot for HUD/debug.
 		UIWalletState wallet{};
+		/// M35.2 — currently open vendor shop catalog (isOpen=false when no shop is active).
+		UIShopState shop{};
 		std::string debugDump;
 
 		/// Build a text dump suitable for a debug widget or logs.
@@ -268,6 +289,12 @@ namespace engine::client
 		/// Apply one decoded WalletUpdate message (M35.1).
 		bool ApplyWalletUpdate(std::span<const std::byte> packet);
 
+		/// Apply one decoded VendorShopSync message and populate the shop state (M35.2).
+		bool ApplyVendorShopSync(std::span<const std::byte> packet);
+
+		/// Apply one decoded VendorTransactionResult and refresh the wallet gold (M35.2).
+		bool ApplyVendorTransactionResult(std::span<const std::byte> packet);
+
 		/// Advance world presenter ages (wall clock clamped).
 		void PumpWorldPresenterAge();
 
@@ -285,6 +312,8 @@ namespace engine::client
 		engine::server::ChatRelayMessage m_chatRelayScratch{};
 		engine::server::EmoteRelayMessage m_emoteRelayScratch{};
 		engine::server::WalletUpdateMessage m_walletScratch{};
+		engine::server::VendorShopSyncMessage m_vendorShopScratch{};
+		engine::server::VendorTransactionResultMessage m_vendorTxScratch{};
 		ChatWorldVisualPresenter m_chatWorld{};
 		size_t m_nextObserverHandle = 1;
 		bool m_initialized = false;

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -21,6 +21,7 @@ if(WIN32)
     PlayerWalletService.cpp
     QuestRuntime.cpp
     SpawnerRuntime.cpp
+    VendorRuntime.cpp
     EventRuntime.cpp
     UdpTransport.cpp
     TickScheduler.cpp

--- a/engine/server/ServerApp.cpp
+++ b/engine/server/ServerApp.cpp
@@ -146,6 +146,7 @@ namespace engine::server
 		, m_eventRuntime(m_config)
 		, m_questRuntime(m_config)
 		, m_spawnerRuntime(m_config)
+		, m_vendorRuntime(m_config)
 	{
 		LOG_INFO(Core, "[ServerApp] Constructed");
 	}
@@ -243,6 +244,13 @@ namespace engine::server
 		if (!InitDynamicEvents())
 		{
 			LOG_ERROR(Core, "[ServerApp] Init FAILED: dynamic event bootstrap failed");
+			Shutdown();
+			return false;
+		}
+
+		if (!InitVendors())
+		{
+			LOG_ERROR(Core, "[ServerApp] Init FAILED: vendor runtime startup failed");
 			Shutdown();
 			return false;
 		}
@@ -358,6 +366,7 @@ namespace engine::server
 		m_tickScheduler.Shutdown();
 		m_transport.Shutdown();
 		m_zoneTransitionMap.Shutdown();
+		m_vendorRuntime.Shutdown();
 		m_spawnerRuntime.Shutdown();
 		m_eventRuntime.Shutdown();
 		m_questRuntime.Shutdown();
@@ -451,6 +460,28 @@ namespace engine::server
 		if (DecodeTalkRequest(packetBytes, talkRequest))
 		{
 			HandleTalkRequest(datagram.endpoint, talkRequest.clientId, talkRequest.targetId);
+			return;
+		}
+
+		// M35.2 — Vendor shop requests
+		VendorOpenMessage vendorOpen{};
+		if (DecodeVendorOpen(packetBytes, vendorOpen))
+		{
+			HandleVendorOpen(datagram.endpoint, vendorOpen);
+			return;
+		}
+
+		VendorBuyMessage vendorBuy{};
+		if (DecodeVendorBuy(packetBytes, vendorBuy))
+		{
+			HandleVendorBuy(datagram.endpoint, vendorBuy);
+			return;
+		}
+
+		VendorSellMessage vendorSell{};
+		if (DecodeVendorSell(packetBytes, vendorSell))
+		{
+			HandleVendorSell(datagram.endpoint, vendorSell);
 			return;
 		}
 
@@ -2072,6 +2103,349 @@ namespace engine::server
 
 		LOG_INFO(Net, "[ServerApp] TalkRequest accepted (client_id={}, target={})", client->clientId, targetId);
 		ApplyQuestEvent(*client, QuestStepType::Talk, targetId, 1, "talk");
+	}
+
+	// -------------------------------------------------------------------------
+	// M35.2 — Vendor shop
+	// -------------------------------------------------------------------------
+
+	bool ServerApp::InitVendors()
+	{
+		if (!m_vendorRuntime.Init())
+		{
+			LOG_ERROR(Net, "[ServerApp] InitVendors FAILED: vendor runtime init failed");
+			return false;
+		}
+
+		// Pre-populate mutable runtime stock tables from the loaded definitions.
+		m_vendorStocks.clear();
+		for (const VendorDefinition& def : m_vendorRuntime.GetDefinitions())
+		{
+			std::vector<int32_t> stocks;
+			stocks.reserve(def.items.size());
+			for (const VendorItemDefinition& item : def.items)
+			{
+				stocks.push_back(item.stock);
+			}
+			m_vendorStocks.emplace(def.vendorId, std::move(stocks));
+		}
+
+		LOG_INFO(Net, "[ServerApp] InitVendors OK (vendors={})", m_vendorRuntime.GetDefinitions().size());
+		return true;
+	}
+
+	void ServerApp::HandleVendorOpen(const Endpoint& endpoint, const VendorOpenMessage& request)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorOpen ignored: unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != request.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorOpen ignored: client_id mismatch (expected={}, got={}, endpoint={})",
+				client->clientId, request.clientId, UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (request.vendorId.empty())
+		{
+			LOG_WARN(Net, "[ServerApp] VendorOpen rejected: empty vendor_id (client_id={})", client->clientId);
+			return;
+		}
+
+		const VendorDefinition* def = m_vendorRuntime.FindVendor(request.vendorId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorOpen rejected: unknown vendor '{}' (client_id={})",
+				request.vendorId, client->clientId);
+			return;
+		}
+
+		LOG_INFO(Net, "[ServerApp] VendorOpen accepted (client_id={}, vendor={})", client->clientId, request.vendorId);
+		(void)SendVendorShopSync(*client, request.vendorId);
+	}
+
+	void ServerApp::HandleVendorBuy(const Endpoint& endpoint, const VendorBuyMessage& request)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy ignored: unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != request.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy ignored: client_id mismatch (expected={}, got={}, endpoint={})",
+				client->clientId, request.clientId, UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (request.quantity == 0)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy rejected: quantity=0 (client_id={})", client->clientId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "invalid_quantity");
+			return;
+		}
+
+		const VendorDefinition* def = m_vendorRuntime.FindVendor(request.vendorId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy rejected: unknown vendor '{}' (client_id={})",
+				request.vendorId, client->clientId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "unknown_vendor");
+			return;
+		}
+
+		// Locate the item in the definition.
+		size_t itemIndex = def->items.size(); // sentinel: not found
+		for (size_t i = 0; i < def->items.size(); ++i)
+		{
+			if (def->items[i].itemId == request.itemId)
+			{
+				itemIndex = i;
+				break;
+			}
+		}
+		if (itemIndex == def->items.size())
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy rejected: item_id={} not sold by vendor '{}' (client_id={})",
+				request.itemId, request.vendorId, client->clientId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "item_not_sold");
+			return;
+		}
+
+		const VendorItemDefinition& itemDef = def->items[itemIndex];
+		const uint64_t totalCost = static_cast<uint64_t>(itemDef.buyPrice) * static_cast<uint64_t>(request.quantity);
+
+		// Validate gold (anti-overdraft).
+		if (static_cast<uint64_t>(client->gold) < totalCost)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorBuy rejected: insufficient gold (client_id={}, have={}, need={})",
+				client->clientId, client->gold, totalCost);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "insufficient_gold");
+			return;
+		}
+
+		// Check stock (anti-dupe: stock must be >0 or infinite).
+		const auto stockIt = m_vendorStocks.find(request.vendorId);
+		if (stockIt == m_vendorStocks.end() || itemIndex >= stockIt->second.size())
+		{
+			LOG_ERROR(Net, "[ServerApp] VendorBuy FAILED: stock table missing for vendor '{}'", request.vendorId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "server_error");
+			return;
+		}
+		int32_t& runtimeStock = stockIt->second[itemIndex];
+		if (runtimeStock != -1)
+		{
+			if (runtimeStock < static_cast<int32_t>(request.quantity))
+			{
+				LOG_WARN(Net, "[ServerApp] VendorBuy rejected: out of stock (client_id={}, vendor={}, item_id={}, stock={}, want={})",
+					client->clientId, request.vendorId, request.itemId, runtimeStock, request.quantity);
+				(void)SendVendorTransactionResult(*client, false, client->gold, "out_of_stock");
+				return;
+			}
+			runtimeStock -= static_cast<int32_t>(request.quantity);
+		}
+
+		// Deduct gold.
+		std::string walletErr;
+		if (!m_playerWallet.SubtractCurrency(*client, kCurrencyGold, totalCost, walletErr))
+		{
+			// Roll back stock decrement.
+			if (runtimeStock != -1)
+			{
+				runtimeStock += static_cast<int32_t>(request.quantity);
+			}
+			LOG_ERROR(Net, "[ServerApp] VendorBuy FAILED: wallet subtract error (client_id={}, reason={})",
+				client->clientId, walletErr);
+			(void)SendVendorTransactionResult(*client, false, client->gold, walletErr);
+			return;
+		}
+
+		// Add item to player inventory.
+		const ItemStack purchasedStack{ request.itemId, request.quantity };
+		AddItemToInventory(*client, purchasedStack);
+
+		// Persist and notify.
+		SaveConnectedClient(*client, "vendor_buy");
+		(void)SendInventoryDelta(*client, std::span<const ItemStack>(&purchasedStack, 1));
+		(void)SendWalletUpdate(*client);
+		(void)SendVendorTransactionResult(*client, true, client->gold, {});
+
+		LOG_INFO(Net, "[ServerApp] VendorBuy OK (client_id={}, vendor={}, item_id={}, qty={}, cost={}, new_gold={})",
+			client->clientId, request.vendorId, request.itemId, request.quantity, totalCost, client->gold);
+	}
+
+	void ServerApp::HandleVendorSell(const Endpoint& endpoint, const VendorSellMessage& request)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorSell ignored: unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != request.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorSell ignored: client_id mismatch (expected={}, got={}, endpoint={})",
+				client->clientId, request.clientId, UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (request.quantity == 0)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorSell rejected: quantity=0 (client_id={})", client->clientId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "invalid_quantity");
+			return;
+		}
+
+		const VendorDefinition* def = m_vendorRuntime.FindVendor(request.vendorId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorSell rejected: unknown vendor '{}' (client_id={})",
+				request.vendorId, client->clientId);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "unknown_vendor");
+			return;
+		}
+
+		// Locate buy price for sell-back calculation (sell = 25% of buy price).
+		uint32_t buyPrice = 0;
+		for (const VendorItemDefinition& item : def->items)
+		{
+			if (item.itemId == request.itemId)
+			{
+				buyPrice = item.buyPrice;
+				break;
+			}
+		}
+		// Any item may be sold back (even if not currently in the vendor catalog), but price is 0
+		// for items the vendor doesn't know. Only items with a defined buy price yield sell gold.
+		const uint32_t sellPricePerUnit = buyPrice / 4u; // 25% of buy price.
+		const uint64_t totalSellGold    = static_cast<uint64_t>(sellPricePerUnit) * static_cast<uint64_t>(request.quantity);
+
+		// Verify the player actually has the item in sufficient quantity (anti-dupe).
+		uint32_t playerQuantity = 0;
+		for (const ItemStack& stack : client->inventory)
+		{
+			if (stack.itemId == request.itemId)
+			{
+				playerQuantity = stack.quantity;
+				break;
+			}
+		}
+		if (playerQuantity < request.quantity)
+		{
+			LOG_WARN(Net, "[ServerApp] VendorSell rejected: not enough items (client_id={}, item_id={}, have={}, want={})",
+				client->clientId, request.itemId, playerQuantity, request.quantity);
+			(void)SendVendorTransactionResult(*client, false, client->gold, "insufficient_items");
+			return;
+		}
+
+		// Remove item from inventory.
+		for (ItemStack& stack : client->inventory)
+		{
+			if (stack.itemId == request.itemId)
+			{
+				stack.quantity -= request.quantity;
+				break;
+			}
+		}
+		// Erase empty stacks.
+		client->inventory.erase(
+			std::remove_if(client->inventory.begin(), client->inventory.end(),
+				[](const ItemStack& s) { return s.quantity == 0; }),
+			client->inventory.end());
+
+		// Credit gold (capped by wallet service).
+		if (totalSellGold > 0u)
+		{
+			std::string walletErr;
+			if (!m_playerWallet.AddCurrency(*client, kCurrencyGold, totalSellGold, walletErr))
+			{
+				LOG_WARN(Net, "[ServerApp] VendorSell: gold credit failed (client_id={}, reason={}); item already removed",
+					client->clientId, walletErr);
+			}
+		}
+
+		// Persist and notify.
+		SaveConnectedClient(*client, "vendor_sell");
+		(void)SendInventoryDelta(*client, client->inventory);
+		(void)SendWalletUpdate(*client);
+		(void)SendVendorTransactionResult(*client, true, client->gold, {});
+
+		LOG_INFO(Net, "[ServerApp] VendorSell OK (client_id={}, vendor={}, item_id={}, qty={}, gold_credited={}, new_gold={})",
+			client->clientId, request.vendorId, request.itemId, request.quantity, totalSellGold, client->gold);
+	}
+
+	bool ServerApp::SendVendorShopSync(const ConnectedClient& receiver, std::string_view vendorId)
+	{
+		const VendorDefinition* def = m_vendorRuntime.FindVendor(vendorId);
+		if (def == nullptr)
+		{
+			LOG_ERROR(Net, "[ServerApp] SendVendorShopSync FAILED: vendor '{}' not found", vendorId);
+			return false;
+		}
+
+		const auto stockIt = m_vendorStocks.find(std::string(vendorId));
+
+		VendorShopSyncMessage msg{};
+		msg.clientId = receiver.clientId;
+		msg.vendorId = def->vendorId;
+		msg.items.reserve(def->items.size());
+		for (size_t i = 0; i < def->items.size(); ++i)
+		{
+			const VendorItemDefinition& item = def->items[i];
+			VendorShopItemEntry entry{};
+			entry.itemId    = item.itemId;
+			entry.buyPrice  = item.buyPrice;
+			entry.sellPrice = item.buyPrice / 4u; // 25% sell-back mechanic.
+			entry.stock     = (stockIt != m_vendorStocks.end() && i < stockIt->second.size())
+				? stockIt->second[i]
+				: item.stock;
+			msg.items.push_back(entry);
+		}
+
+		const std::vector<std::byte> packet = EncodeVendorShopSync(msg);
+		if (!m_transport.Send(receiver.endpoint, packet))
+		{
+			LOG_ERROR(Net, "[ServerApp] SendVendorShopSync FAILED: transport error (client_id={})", receiver.clientId);
+			return false;
+		}
+
+		LOG_INFO(Net, "[ServerApp] SendVendorShopSync OK (client_id={}, vendor={}, items={})",
+			receiver.clientId, vendorId, msg.items.size());
+		return true;
+	}
+
+	bool ServerApp::SendVendorTransactionResult(
+		const ConnectedClient& receiver,
+		bool success,
+		uint32_t newGold,
+		std::string_view errorReason)
+	{
+		VendorTransactionResultMessage msg{};
+		msg.clientId    = receiver.clientId;
+		msg.success     = success ? 1u : 0u;
+		msg.newGold     = newGold;
+		msg.errorReason = std::string(errorReason);
+
+		const std::vector<std::byte> packet = EncodeVendorTransactionResult(msg);
+		if (!m_transport.Send(receiver.endpoint, packet))
+		{
+			LOG_ERROR(Net, "[ServerApp] SendVendorTransactionResult FAILED: transport error (client_id={})", receiver.clientId);
+			return false;
+		}
+
+		LOG_DEBUG(Net, "[ServerApp] SendVendorTransactionResult (client_id={}, success={}, new_gold={})",
+			receiver.clientId, success, newGold);
+		return true;
 	}
 
 	void ServerApp::HandleChatSend(const Endpoint& endpoint, const ChatSendRequestMessage& request)

--- a/engine/server/ServerApp.h
+++ b/engine/server/ServerApp.h
@@ -8,6 +8,7 @@
 #include "engine/server/PartySystem.h"
 #include "engine/server/QuestRuntime.h"
 #include "engine/server/SpawnerRuntime.h"
+#include "engine/server/VendorRuntime.h"
 #include "engine/core/Config.h"
 #include "engine/net/ChatSystem.h"
 #include "engine/server/ChatCommandParser.h"
@@ -358,6 +359,26 @@ namespace engine::server
 		/// Validate one talk request and forward it to the quest runtime.
 		void HandleTalkRequest(const Endpoint& endpoint, uint32_t clientId, std::string_view targetId);
 
+		// M35.2 — Vendor shop handlers --------------------------------------------
+
+		/// Load vendor definitions from content and prepare runtime stock tables.
+		bool InitVendors();
+
+		/// Validate and open a vendor shop for the requesting client.
+		void HandleVendorOpen(const Endpoint& endpoint, const VendorOpenMessage& request);
+
+		/// Validate gold, deduct cost, add item to inventory and update stock.
+		void HandleVendorBuy(const Endpoint& endpoint, const VendorBuyMessage& request);
+
+		/// Validate item ownership, credit sell price and remove item from inventory.
+		void HandleVendorSell(const Endpoint& endpoint, const VendorSellMessage& request);
+
+		/// Build and send a VendorShopSync packet for the given vendor to the client.
+		bool SendVendorShopSync(const ConnectedClient& receiver, std::string_view vendorId);
+
+		/// Build and send a VendorTransactionResult packet to the client.
+		bool SendVendorTransactionResult(const ConnectedClient& receiver, bool success, uint32_t newGold, std::string_view errorReason);
+
 		/// Validate one chat send request, apply rate limiting, route by channel, emit relays.
 		void HandleChatSend(const Endpoint& endpoint, const ChatSendRequestMessage& request);
 
@@ -600,6 +621,10 @@ namespace engine::server
 		EventRuntime m_eventRuntime;
 		QuestRuntime m_questRuntime;
 		SpawnerRuntime m_spawnerRuntime;
+		/// M35.2 — vendor definitions (loaded at Init).
+		VendorRuntime m_vendorRuntime;
+		/// M35.2 — per-vendor mutable stock: map vendorId → per-item stock array (index matches definition order).
+		std::unordered_map<std::string, std::vector<int32_t>> m_vendorStocks;
 		ZoneTransitionMap m_zoneTransitionMap;
 		TickScheduler m_tickScheduler;
 		UdpTransport m_transport;

--- a/engine/server/ServerProtocol.cpp
+++ b/engine/server/ServerProtocol.cpp
@@ -1250,4 +1250,195 @@ namespace engine::server
 		outMessage.premiumCurrency = ReadU32(payload, 16);
 		return true;
 	}
+
+	// -------------------------------------------------------------------------
+	// M35.2 — Vendor shop encode/decode
+	// -------------------------------------------------------------------------
+
+	std::vector<std::byte> EncodeVendorOpen(const VendorOpenMessage& message)
+	{
+		const uint16_t vendorIdLen = static_cast<uint16_t>(message.vendorId.size());
+		std::vector<std::byte> packet = BeginPacket(MessageKind::VendorOpen, 4 + 2 + vendorIdLen);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.vendorId);
+		return packet;
+	}
+
+	bool DecodeVendorOpen(std::span<const std::byte> packet, VendorOpenMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::VendorOpen, payload) || payload.size() < 6)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.vendorId) || outMessage.vendorId.empty())
+		{
+			return false;
+		}
+		return offset == payload.size();
+	}
+
+	std::vector<std::byte> EncodeVendorShopSync(const VendorShopSyncMessage& message)
+	{
+		const uint16_t vendorIdLen = static_cast<uint16_t>(message.vendorId.size());
+		const uint16_t itemCount   = static_cast<uint16_t>(message.items.size());
+		// clientId(4) + vendorId(2+len) + itemCount(2) + per item: itemId(4) buyPrice(4) sellPrice(4) stock(4)
+		const size_t payloadSize = 4 + 2 + vendorIdLen + 2 + static_cast<size_t>(itemCount) * 16;
+		std::vector<std::byte> packet = BeginPacket(MessageKind::VendorShopSync, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.vendorId);
+		WriteU16(packet, itemCount);
+		for (const VendorShopItemEntry& item : message.items)
+		{
+			WriteU32(packet, item.itemId);
+			WriteU32(packet, item.buyPrice);
+			WriteU32(packet, item.sellPrice);
+			WriteU32(packet, static_cast<uint32_t>(item.stock));
+		}
+		return packet;
+	}
+
+	bool DecodeVendorShopSync(std::span<const std::byte> packet, VendorShopSyncMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::VendorShopSync, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.vendorId) || outMessage.vendorId.empty())
+		{
+			return false;
+		}
+		if (offset + 2 > payload.size())
+		{
+			return false;
+		}
+		const uint16_t itemCount = ReadU16(payload, offset);
+		offset += 2;
+		if (offset + static_cast<size_t>(itemCount) * 16 > payload.size())
+		{
+			return false;
+		}
+		outMessage.items.clear();
+		outMessage.items.resize(itemCount);
+		for (uint16_t i = 0; i < itemCount; ++i)
+		{
+			outMessage.items[i].itemId    = ReadU32(payload, offset + 0);
+			outMessage.items[i].buyPrice  = ReadU32(payload, offset + 4);
+			outMessage.items[i].sellPrice = ReadU32(payload, offset + 8);
+			outMessage.items[i].stock     = static_cast<int32_t>(ReadU32(payload, offset + 12));
+			offset += 16;
+		}
+		return offset == payload.size();
+	}
+
+	std::vector<std::byte> EncodeVendorBuy(const VendorBuyMessage& message)
+	{
+		const uint16_t vendorIdLen = static_cast<uint16_t>(message.vendorId.size());
+		std::vector<std::byte> packet = BeginPacket(MessageKind::VendorBuy, 4 + 2 + vendorIdLen + 4 + 4);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.vendorId);
+		WriteU32(packet, message.itemId);
+		WriteU32(packet, message.quantity);
+		return packet;
+	}
+
+	bool DecodeVendorBuy(std::span<const std::byte> packet, VendorBuyMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::VendorBuy, payload) || payload.size() < 14)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.vendorId) || outMessage.vendorId.empty())
+		{
+			return false;
+		}
+		if (offset + 8 > payload.size())
+		{
+			return false;
+		}
+		outMessage.itemId   = ReadU32(payload, offset);
+		offset += 4;
+		outMessage.quantity = ReadU32(payload, offset);
+		offset += 4;
+		return offset == payload.size();
+	}
+
+	std::vector<std::byte> EncodeVendorSell(const VendorSellMessage& message)
+	{
+		const uint16_t vendorIdLen = static_cast<uint16_t>(message.vendorId.size());
+		std::vector<std::byte> packet = BeginPacket(MessageKind::VendorSell, 4 + 2 + vendorIdLen + 4 + 4);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.vendorId);
+		WriteU32(packet, message.itemId);
+		WriteU32(packet, message.quantity);
+		return packet;
+	}
+
+	bool DecodeVendorSell(std::span<const std::byte> packet, VendorSellMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::VendorSell, payload) || payload.size() < 14)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.vendorId) || outMessage.vendorId.empty())
+		{
+			return false;
+		}
+		if (offset + 8 > payload.size())
+		{
+			return false;
+		}
+		outMessage.itemId   = ReadU32(payload, offset);
+		offset += 4;
+		outMessage.quantity = ReadU32(payload, offset);
+		offset += 4;
+		return offset == payload.size();
+	}
+
+	std::vector<std::byte> EncodeVendorTransactionResult(const VendorTransactionResultMessage& message)
+	{
+		const uint16_t reasonLen = static_cast<uint16_t>(message.errorReason.size());
+		std::vector<std::byte> packet = BeginPacket(MessageKind::VendorTransactionResult, 4 + 1 + 4 + 2 + reasonLen);
+		WriteU32(packet, message.clientId);
+		WriteU8(packet, message.success);
+		WriteU32(packet, message.newGold);
+		WriteSizedString(packet, message.errorReason);
+		return packet;
+	}
+
+	bool DecodeVendorTransactionResult(std::span<const std::byte> packet, VendorTransactionResultMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::VendorTransactionResult, payload) || payload.size() < 9)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		outMessage.success = ReadU8(payload, offset);
+		offset += 1;
+		outMessage.newGold = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.errorReason))
+		{
+			return false;
+		}
+		return offset == payload.size();
+	}
 }

--- a/engine/server/ServerProtocol.h
+++ b/engine/server/ServerProtocol.h
@@ -96,7 +96,20 @@ namespace engine::server
 		// M35.1 — Multi-currency wallet ----------------------------------------
 
 		/// Server pushes current wallet balances to the owning client.
-		WalletUpdate = 43
+		WalletUpdate = 43,
+
+		// M35.2 — Vendor shop messages ----------------------------------------
+
+		/// Client requests to open a vendor's shop (M35.2).
+		VendorOpen = 44,
+		/// Server pushes vendor catalog + prices to the requesting client (M35.2).
+		VendorShopSync = 45,
+		/// Client requests to buy one item from a vendor (M35.2).
+		VendorBuy = 46,
+		/// Client requests to sell one item to a vendor (M35.2).
+		VendorSell = 47,
+		/// Server acknowledges a buy/sell transaction with result + new gold balance (M35.2).
+		VendorTransactionResult = 48
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -678,4 +691,89 @@ namespace engine::server
 
 	/// Decode a wallet update packet.
 	bool DecodeWalletUpdate(std::span<const std::byte> packet, WalletUpdateMessage& outMessage);
+
+	// -------------------------------------------------------------------------
+	// M35.2 — Vendor shop messages
+	// -------------------------------------------------------------------------
+
+	/// Client request to open a vendor shop by vendor id.
+	struct VendorOpenMessage
+	{
+		uint32_t    clientId = 0;
+		std::string vendorId; ///< Stable vendor identifier matching vendor_definitions.json.
+	};
+
+	/// One item entry replicated inside a VendorShopSync packet.
+	struct VendorShopItemEntry
+	{
+		uint32_t itemId    = 0;
+		uint32_t buyPrice  = 0; ///< Gold cost to buy from the vendor.
+		uint32_t sellPrice = 0; ///< Gold received when selling back (25% of buyPrice).
+		int32_t  stock     = -1; ///< Remaining stock; -1 means infinite.
+	};
+
+	/// Server → client snapshot of a vendor's catalog after VendorOpen is validated.
+	struct VendorShopSyncMessage
+	{
+		uint32_t                       clientId = 0;
+		std::string                    vendorId;
+		std::vector<VendorShopItemEntry> items;
+	};
+
+	/// Client request to buy one item stack from a vendor.
+	struct VendorBuyMessage
+	{
+		uint32_t    clientId = 0;
+		std::string vendorId;
+		uint32_t    itemId   = 0;
+		uint32_t    quantity = 1;
+	};
+
+	/// Client request to sell one item stack to a vendor.
+	struct VendorSellMessage
+	{
+		uint32_t    clientId = 0;
+		std::string vendorId;
+		uint32_t    itemId   = 0;
+		uint32_t    quantity = 1;
+	};
+
+	/// Server acknowledgement of a vendor buy or sell transaction.
+	struct VendorTransactionResultMessage
+	{
+		uint32_t    clientId    = 0;
+		uint8_t     success     = 0; ///< 1 on success, 0 on failure.
+		uint32_t    newGold     = 0; ///< Player gold balance after the transaction.
+		std::string errorReason;     ///< Human-readable reason on failure.
+	};
+
+	/// Encode a client vendor-open request packet.
+	std::vector<std::byte> EncodeVendorOpen(const VendorOpenMessage& message);
+
+	/// Decode a client vendor-open request packet.
+	bool DecodeVendorOpen(std::span<const std::byte> packet, VendorOpenMessage& outMessage);
+
+	/// Encode a server vendor shop sync packet.
+	std::vector<std::byte> EncodeVendorShopSync(const VendorShopSyncMessage& message);
+
+	/// Decode a server vendor shop sync packet.
+	bool DecodeVendorShopSync(std::span<const std::byte> packet, VendorShopSyncMessage& outMessage);
+
+	/// Encode a client vendor buy request packet.
+	std::vector<std::byte> EncodeVendorBuy(const VendorBuyMessage& message);
+
+	/// Decode a client vendor buy request packet.
+	bool DecodeVendorBuy(std::span<const std::byte> packet, VendorBuyMessage& outMessage);
+
+	/// Encode a client vendor sell request packet.
+	std::vector<std::byte> EncodeVendorSell(const VendorSellMessage& message);
+
+	/// Decode a client vendor sell request packet.
+	bool DecodeVendorSell(std::span<const std::byte> packet, VendorSellMessage& outMessage);
+
+	/// Encode a server vendor transaction result packet.
+	std::vector<std::byte> EncodeVendorTransactionResult(const VendorTransactionResultMessage& message);
+
+	/// Decode a server vendor transaction result packet.
+	bool DecodeVendorTransactionResult(std::span<const std::byte> packet, VendorTransactionResultMessage& outMessage);
 }

--- a/engine/server/VendorRuntime.cpp
+++ b/engine/server/VendorRuntime.cpp
@@ -1,0 +1,566 @@
+#include "engine/server/VendorRuntime.h"
+
+#include "engine/core/Log.h"
+#include "engine/platform/FileSystem.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace engine::server
+{
+	namespace
+	{
+		// -------------------------------------------------------------------------
+		// Minimal JSON parser (self-contained, no new dependencies).
+		// -------------------------------------------------------------------------
+
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		class JsonParser final
+		{
+		public:
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+				return true;
+			}
+
+		private:
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+				++m_pos;
+				return true;
+			}
+
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+				switch (m_input[m_pos])
+				{
+				case '{': return ParseObject(outValue, outError);
+				case '[': return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default: break;
+				}
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+				return ParseNumber(outValue, outError);
+			}
+
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"':  outValue.push_back('"');  break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/':  outValue.push_back('/');  break;
+					case 'b':  outValue.push_back('\b'); break;
+					case 'f':  outValue.push_back('\f'); break;
+					case 'n':  outValue.push_back('\n'); break;
+					case 'r':  outValue.push_back('\r'); break;
+					case 't':  outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+				outError = "unterminated string";
+				return false;
+			}
+
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Return one object member or nullptr when the key is absent.
+		const JsonValue* FindMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+			const auto it = object.objectValue.find(std::string(key));
+			return (it == object.objectValue.end()) ? nullptr : &it->second;
+		}
+
+		/// Convert one JSON number to a validated non-negative 32-bit integer.
+		bool TryGetUint32(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+
+		/// Convert one JSON number to a validated signed 32-bit integer (allows -1 for infinite stock).
+		bool TryGetInt32(const JsonValue& value, int32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < static_cast<double>(std::numeric_limits<int32_t>::min())
+				|| value.numberValue > static_cast<double>(std::numeric_limits<int32_t>::max()))
+			{
+				return false;
+			}
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+			outValue = static_cast<int32_t>(truncated);
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// VendorRuntime implementation
+	// -------------------------------------------------------------------------
+
+	VendorRuntime::VendorRuntime(const engine::core::Config& config)
+		: m_config(config)
+	{
+		LOG_INFO(Net, "[VendorRuntime] Constructed");
+	}
+
+	VendorRuntime::~VendorRuntime()
+	{
+		Shutdown();
+	}
+
+	bool VendorRuntime::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Net, "[VendorRuntime] Init ignored: already initialized");
+			return true;
+		}
+
+		if (!LoadDefinitions())
+		{
+			LOG_ERROR(Net, "[VendorRuntime] Init FAILED: definition load failed");
+			return false;
+		}
+
+		m_initialized = true;
+		LOG_INFO(Net, "[VendorRuntime] Init OK (vendors={})", m_definitions.size());
+		return true;
+	}
+
+	void VendorRuntime::Shutdown()
+	{
+		if (!m_initialized && m_definitions.empty())
+		{
+			return;
+		}
+		const size_t count = m_definitions.size();
+		m_definitions.clear();
+		m_initialized = false;
+		LOG_INFO(Net, "[VendorRuntime] Destroyed (vendors={})", count);
+	}
+
+	const VendorDefinition* VendorRuntime::FindVendor(std::string_view vendorId) const
+	{
+		for (const VendorDefinition& def : m_definitions)
+		{
+			if (def.vendorId == vendorId)
+			{
+				return &def;
+			}
+		}
+		return nullptr;
+	}
+
+	bool VendorRuntime::LoadDefinitions()
+	{
+		m_definitions.clear();
+
+		constexpr std::string_view kRelativePath = "vendors/vendor_definitions.json";
+		const std::string jsonText = engine::platform::FileSystem::ReadAllTextContent(m_config, std::string(kRelativePath));
+		if (jsonText.empty())
+		{
+			LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: empty or missing file ({})", kRelativePath);
+			return false;
+		}
+
+		JsonValue root;
+		std::string parseError;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, parseError))
+		{
+			LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: parse error '{}' ({})", parseError, kRelativePath);
+			return false;
+		}
+
+		const JsonValue* vendorsValue = FindMember(root, "vendors");
+		if (vendorsValue == nullptr || vendorsValue->type != JsonType::Array || vendorsValue->arrayValue.empty())
+		{
+			LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: root.vendors must be a non-empty array ({})", kRelativePath);
+			return false;
+		}
+
+		std::unordered_set<std::string> seenIds;
+		for (size_t vi = 0; vi < vendorsValue->arrayValue.size(); ++vi)
+		{
+			const JsonValue& vendorValue = vendorsValue->arrayValue[vi];
+			if (vendorValue.type != JsonType::Object)
+			{
+				LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: vendors[{}] must be an object ({})", vi, kRelativePath);
+				m_definitions.clear();
+				return false;
+			}
+
+			const JsonValue* idValue       = FindMember(vendorValue, "vendorId");
+			const JsonValue* typeValue     = FindMember(vendorValue, "vendorType");
+			const JsonValue* itemsValue    = FindMember(vendorValue, "items");
+
+			if (idValue == nullptr || idValue->type != JsonType::String || idValue->stringValue.empty())
+			{
+				LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: vendors[{}].vendorId must be a non-empty string ({})", vi, kRelativePath);
+				m_definitions.clear();
+				return false;
+			}
+
+			if (!seenIds.emplace(idValue->stringValue).second)
+			{
+				LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: duplicate vendorId '{}' ({})", idValue->stringValue, kRelativePath);
+				m_definitions.clear();
+				return false;
+			}
+
+			if (itemsValue == nullptr || itemsValue->type != JsonType::Array || itemsValue->arrayValue.empty())
+			{
+				LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: vendor '{}' items must be a non-empty array ({})",
+					idValue->stringValue, kRelativePath);
+				m_definitions.clear();
+				return false;
+			}
+
+			VendorDefinition def{};
+			def.vendorId   = idValue->stringValue;
+			def.vendorType = (typeValue != nullptr && typeValue->type == JsonType::String)
+				? typeValue->stringValue
+				: "general";
+
+			for (size_t ii = 0; ii < itemsValue->arrayValue.size(); ++ii)
+			{
+				const JsonValue& itemValue = itemsValue->arrayValue[ii];
+				if (itemValue.type != JsonType::Object)
+				{
+					LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: vendor '{}' items[{}] must be an object ({})",
+						def.vendorId, ii, kRelativePath);
+					m_definitions.clear();
+					return false;
+				}
+
+				const JsonValue* itemIdValue   = FindMember(itemValue, "itemId");
+				const JsonValue* priceValue    = FindMember(itemValue, "buyPrice");
+				const JsonValue* stockValue    = FindMember(itemValue, "stock");
+
+				VendorItemDefinition item{};
+
+				if (itemIdValue == nullptr || !TryGetUint32(*itemIdValue, item.itemId) || item.itemId == 0)
+				{
+					LOG_ERROR(Net,
+						"[VendorRuntime] Definition load FAILED: vendor '{}' items[{}].itemId must be a positive integer ({})",
+						def.vendorId, ii, kRelativePath);
+					m_definitions.clear();
+					return false;
+				}
+
+				if (priceValue == nullptr || !TryGetUint32(*priceValue, item.buyPrice))
+				{
+					LOG_ERROR(Net,
+						"[VendorRuntime] Definition load FAILED: vendor '{}' items[{}].buyPrice must be a non-negative integer ({})",
+						def.vendorId, ii, kRelativePath);
+					m_definitions.clear();
+					return false;
+				}
+
+				// stock is optional; omitting it (or setting -1) means infinite supply.
+				if (stockValue != nullptr)
+				{
+					if (!TryGetInt32(*stockValue, item.stock) || item.stock < -1)
+					{
+						LOG_WARN(Net, "[VendorRuntime] vendor '{}' items[{}].stock invalid; defaulting to infinite",
+							def.vendorId, ii);
+						item.stock = -1;
+					}
+				}
+
+				LOG_DEBUG(Net, "[VendorRuntime] Loaded vendor item (vendor={}, item_id={}, buy_price={}, stock={})",
+					def.vendorId, item.itemId, item.buyPrice, item.stock);
+				def.items.push_back(item);
+			}
+
+			LOG_INFO(Net, "[VendorRuntime] Loaded vendor (id={}, type={}, items={})",
+				def.vendorId, def.vendorType, def.items.size());
+			m_definitions.push_back(std::move(def));
+		}
+
+		if (m_definitions.empty())
+		{
+			LOG_ERROR(Net, "[VendorRuntime] Definition load FAILED: no vendors loaded ({})", kRelativePath);
+			return false;
+		}
+
+		LOG_INFO(Net, "[VendorRuntime] Definition load OK (vendors={}, path={})", m_definitions.size(), kRelativePath);
+		return true;
+	}
+}

--- a/engine/server/VendorRuntime.h
+++ b/engine/server/VendorRuntime.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "engine/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::server
+{
+	/// One item sold by a vendor with its base buy price and optional stock limit.
+	struct VendorItemDefinition
+	{
+		uint32_t itemId   = 0;
+		uint32_t buyPrice = 0;  ///< Gold cost to buy from this vendor.
+		int32_t  stock    = -1; ///< Initial stock; -1 means infinite (never depleted).
+	};
+
+	/// One vendor NPC loaded from content data (M35.2).
+	struct VendorDefinition
+	{
+		std::string                    vendorId;   ///< Stable unique identifier (e.g. "vendor_blacksmith_z1").
+		std::string                    vendorType; ///< Semantic type for UI grouping (e.g. "weapons", "potions").
+		std::vector<VendorItemDefinition> items;
+	};
+
+	/// Server-side vendor runtime: loads vendor JSON definitions from `paths.content` (M35.2).
+	class VendorRuntime final
+	{
+	public:
+		/// Capture the config used to resolve vendor definition files.
+		explicit VendorRuntime(const engine::core::Config& config);
+
+		/// Emit shutdown logs when the vendor runtime is destroyed.
+		~VendorRuntime();
+
+		/// Load all vendor definitions from `vendors/vendor_definitions.json`.
+		bool Init();
+
+		/// Release loaded definitions and emit shutdown logs.
+		void Shutdown();
+
+		/// Return a pointer to the definition matching \p vendorId, or nullptr when absent.
+		const VendorDefinition* FindVendor(std::string_view vendorId) const;
+
+		/// Return the full list of loaded vendor definitions.
+		const std::vector<VendorDefinition>& GetDefinitions() const { return m_definitions; }
+
+	private:
+		/// Parse and load vendor definitions from the configured content-relative JSON path.
+		bool LoadDefinitions();
+
+		engine::core::Config           m_config;
+		std::vector<VendorDefinition>  m_definitions;
+		bool                           m_initialized = false;
+	};
+}

--- a/game/data/vendors/vendor_definitions.json
+++ b/game/data/vendors/vendor_definitions.json
@@ -1,0 +1,40 @@
+{
+  "vendors": [
+    {
+      "vendorId": "vendor_general_z0",
+      "vendorType": "general",
+      "items": [
+        { "itemId": 1001, "buyPrice": 10, "stock": -1 },
+        { "itemId": 1002, "buyPrice": 25, "stock": -1 },
+        { "itemId": 1003, "buyPrice": 50, "stock": 20 }
+      ]
+    },
+    {
+      "vendorId": "vendor_weapons_z1",
+      "vendorType": "weapons",
+      "items": [
+        { "itemId": 2001, "buyPrice": 150, "stock": -1 },
+        { "itemId": 2002, "buyPrice": 300, "stock": 10 },
+        { "itemId": 2003, "buyPrice": 500, "stock": 5 }
+      ]
+    },
+    {
+      "vendorId": "vendor_potions_z1",
+      "vendorType": "potions",
+      "items": [
+        { "itemId": 3001, "buyPrice": 5,  "stock": -1 },
+        { "itemId": 3002, "buyPrice": 15, "stock": -1 },
+        { "itemId": 3003, "buyPrice": 40, "stock": -1 }
+      ]
+    },
+    {
+      "vendorId": "vendor_armor_z2",
+      "vendorType": "armor",
+      "items": [
+        { "itemId": 4001, "buyPrice": 200, "stock": -1 },
+        { "itemId": 4002, "buyPrice": 450, "stock": 8 },
+        { "itemId": 4003, "buyPrice": 800, "stock": 3 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- VendorRuntime: loads vendors/vendor_definitions.json (vendorId, items, buyPrice, stock=-1 for infinite); mutable runtime stock per vendor.
- ServerProtocol: 5 new MessageKind values (VendorOpen/ShopSync/Buy/Sell/ TransactionResult) with encode/decode (little-endian, sized strings).
- ServerApp: InitVendors, HandleVendorOpen/Buy/Sell, SendVendorShopSync, SendVendorTransactionResult; gold validation, stock decrement, anti-dupe via inventory check; sell-back at 25% buy price.
- UIModel: UIShopState + UIModelChangeShop flag; ApplyVendorShopSync and ApplyVendorTransactionResult dispatched from ApplyPacket.
- ShopUiPresenter: panel layout, item rows with name/icon/prices/stock, canAfford flag, SelectItem, ApplyModel; reuses inventory_items.txt metadata.
- game/data/vendors/vendor_definitions.json: 4 sample vendors (general, weapons, potions, armor) across zones 0-2.
- CMakeLists: ShopUi.cpp → engine_core; VendorRuntime.cpp → server_app (WIN32).

https://claude.ai/code/session_014ckYGxQAD8uP9xoPVYpEkt