### PR TITLE
docs: ajoute CLAUDE.md (règle persistante de coordination déploiement client/serveur)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Instructions persistantes pour Claude (LCDLLN)
+
+## Coordination de déploiement client/serveur
+
+Le projet a un cycle de release séparé client (Windows, Vulkan) ↔ serveur (Linux,
+master + shard). L'utilisateur peut oublier de redéployer le serveur quand un
+changement client le requiert. À la fin de **chaque PR / changement** je dois
+**lui dire explicitement** si un redéploiement serveur (master et/ou shard) est
+nécessaire ou non.
+
+### Indique « **REDÉPLOIEMENT SERVEUR REQUIS** » si la PR contient l'une de :
+
+- **Wire-breaking** : nouveau opcode, payload modifié, ordre des champs changé,
+  taille fixe modifiée, bump `kProtocolVersion` (UDP gameplay) ou tout changement
+  qui rend un client neuf incompatible avec un serveur ancien (ou inverse).
+- **Nouveau handler côté serveur** : un handler master/shard qui répond à un
+  nouvel opcode (sinon le client envoie dans le vide et reçoit BAD_REQUEST).
+- **Migration DB** : tout fichier `engine/server/migrations/00xx_*.sql` ajouté
+  ou modifié (idempotent ou pas — il faut quand même rejouer le binaire serveur
+  pour que la migration s'applique au boot).
+- **Modification de gating sécurité** : changement dans SessionManager,
+  ConnectionSessionMap, AuthRegisterHandler, AccountStore qui change le
+  comportement à l'AUTH ou la session.
+- **Config serveur** : nouvelle clé lue par le serveur depuis `config.json`
+  qui doit être renseignée pour que la feature fonctionne.
+
+### Indique « **redéploiement serveur PAS nécessaire** » si la PR est :
+
+- Purement client : rendu (Vulkan, ImGui, fonts, shaders), UI (auth screens,
+  chat panel, HUD), localization, animations, son.
+- Purement docs : CODEBASE_MAP.md, README, commentaires.
+- Tests : tests unitaires sans nouveau handler serveur.
+- Refactoring interne client : presenter / renderer split, accesseurs,
+  callbacks UI, sans changement protocole.
+
+### Format de la mention
+
+À la fin du résumé de PR (dans le message de réponse, et si possible aussi
+dans la description GitHub de la PR), inclure une ligne claire :
+
+> **Déploiement** : ⚠️ redéploiement serveur (master) requis — nouveau opcode 47.
+ou
+> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur.
+
+Si la PR change à la fois client ET serveur (cas fréquent), préciser
+**les deux côtés** doivent être déployés en lock-step (le client neuf parlerait
+à un serveur ancien sinon).
+
+### Cas particulier : chat MVP (PR #402)
+
+A introduit opcodes 45/46 + ChatRelayHandler côté master → **redéploiement
+serveur master requis** pour que le chat fonctionne.


### PR DESCRIPTION
## CLAUDE.md — règle persistante de coordination de déploiement

L'utilisateur a un cycle de release client/serveur séparé et veut être prévenu **à la fin de chaque PR** si un redéploiement serveur (master/shard) est nécessaire — sinon le serveur peut être oublié quand une PR introduit un wire-breaking ou un nouveau handler.

Ce `CLAUDE.md` documente la règle pour que toutes les sessions Claude futures la suivent automatiquement, sans avoir à re-demander.

### Triggers documentés

- Wire-breaking (opcode/payload modifié, `kProtocolVersion` bumpé)
- Nouveau handler côté serveur
- Migration DB (`engine/server/migrations/00xx_*.sql`)
- Modification gating sécurité (Session/Connection/Auth)
- Nouvelle clé de config serveur

### Format de la mention de fin

> **Déploiement** : ⚠️ redéploiement serveur (master) requis — nouveau opcode 47.
>
> ou
>
> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

### Note de session

PR #402 (chat MVP) a été ouverte avant cette règle — elle requiert un redéploiement master (nouvel opcode 45/46 + `ChatRelayHandler`). À noter pour le prochain déploiement.

---

**Déploiement** : ✅ documentation pure, pas de code, pas de redéploiement serveur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv)_