### PR TITLE
fix(world-editor): forcer ASCII pur dans les libelles UI

### DIFF
--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -32,7 +32,7 @@
 #	include "imgui.h"
 #	include "imgui_impl_vulkan.h"
 #	include "imgui_impl_win32.h"
-	// ImGui 1.91+ : la déclaration n’est plus dans l’en-tête (#if 0) pour éviter HWND dans l’API publique.
+	// ImGui 1.91+ : la declaration n'est plus dans l'en-tete (#if 0) pour eviter HWND dans l'API publique.
 	extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 #	include <vulkan/vulkan.h>
@@ -74,7 +74,7 @@ namespace engine::editor
 			std::ofstream out(path, std::ios::binary | std::ios::trunc);
 			if (!out)
 			{
-				LOG_WARN(Core, "[WorldEditor] Écriture impossible : {} (déplacement non persisté)", path);
+				LOG_WARN(Core, "[WorldEditor] Ecriture impossible : {} (deplacement non persiste)", path);
 				return;
 			}
 			out << json;
@@ -168,8 +168,8 @@ namespace engine::editor
 	namespace
 	{
 		// Plafond du nombre de lignes de grille par axe (surimpression ImGui). Sans cela, une maille
-		// fine sur un grand terrain génère trop de primitives ; un plafond trop bas rend la maille
-		// « figée » (espacement minimal ≈ tailleTerrain / (plafond - 1)).
+		// fine sur un grand terrain genere trop de primitives ; un plafond trop bas rend la maille
+		// "figee" (espacement minimal ~= tailleTerrain / (plafond - 1)).
 		constexpr int kWorldEditorGridMaxLinesPerAxis = 2048;
 
 		bool WorldToScreen(const float vp[16], float wx, float wy, float wz, int vw, int vh, float& sx, float& sy)
@@ -354,7 +354,7 @@ namespace engine::editor
 #if defined(_WIN32)
 		if (m_ready)
 		{
-			LOG_WARN(Render, "[WorldEditorImGui] Shutdown non appelé avant destruction");
+			LOG_WARN(Render, "[WorldEditorImGui] Shutdown non appele avant destruction");
 		}
 #endif
 	}
@@ -383,13 +383,13 @@ namespace engine::editor
 		}
 		if (!deviceContext.IsValid() || !deviceContext.SupportsDynamicRendering())
 		{
-			LOG_WARN(Render, "[WorldEditorImGui] Init ignoré: device ou dynamic rendering indisponible");
+			LOG_WARN(Render, "[WorldEditorImGui] Init ignore: device ou dynamic rendering indisponible");
 			return false;
 		}
 		HWND hwnd = hwndNative ? static_cast<HWND>(hwndNative) : nullptr;
 		if (!hwnd)
 		{
-			LOG_WARN(Render, "[WorldEditorImGui] Init ignoré: HWND nul");
+			LOG_WARN(Render, "[WorldEditorImGui] Init ignore: HWND nul");
 			return false;
 		}
 		const uint32_t imgCount = std::max(2u, swapchainImageCount);
@@ -405,7 +405,7 @@ namespace engine::editor
 		poolInfo.pPoolSizes = poolSizes;
 		if (vkCreateDescriptorPool(deviceContext.GetDevice(), &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
 		{
-			LOG_ERROR(Render, "[WorldEditorImGui] vkCreateDescriptorPool a échoué");
+			LOG_ERROR(Render, "[WorldEditorImGui] vkCreateDescriptorPool a echoue");
 			return false;
 		}
 
@@ -414,14 +414,14 @@ namespace engine::editor
 		ImGuiIO& io = ImGui::GetIO();
 		io.IniFilename = "world_editor_imgui.ini";
 		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-		// Pas de NavEnableKeyboard : sinon io.WantCaptureKeyboard reste souvent vrai et bloque WASD (caméra FPS).
+		// Pas de NavEnableKeyboard : sinon io.WantCaptureKeyboard reste souvent vrai et bloque WASD (camera FPS).
 		ImGui::StyleColorsDark();
 
-		// Polices auth (Windlass / Morpheus) chargées dans l'atlas ImGui AVANT ImGui_ImplVulkan_Init —
-		// celui-ci construit la texture des fonts une seule fois à partir de l'atlas. Sans ce chargement,
-		// l'UI auth utilise la police ImGui par défaut (ProggyClean ~13 px) qui ne ressemble pas à la
-		// maquette Lune Noire. La piste Vulkan/AuthGlyphPass utilise déjà ces mêmes fichiers (Engine.cpp).
-		// On charge Windlass en premier : elle devient la police par défaut d'ImGui.
+		// Polices auth (Windlass / Morpheus) chargees dans l'atlas ImGui AVANT ImGui_ImplVulkan_Init -
+		// celui-ci construit la texture des fonts une seule fois a partir de l'atlas. Sans ce chargement,
+		// l'UI auth utilise la police ImGui par defaut (ProggyClean ~13 px) qui ne ressemble pas a la
+		// maquette Lune Noire. La piste Vulkan/AuthGlyphPass utilise deja ces memes fichiers (Engine.cpp).
+		// On charge Windlass en premier : elle devient la police par defaut d'ImGui.
 		auto loadAuthFontFromConfig = [&io, cfg](std::string_view relativePath, float pixelHeight, const char* role) -> bool {
 			if (cfg == nullptr || relativePath.empty())
 			{
@@ -433,9 +433,9 @@ namespace engine::editor
 				LOG_WARN(Render, "[WorldEditorImGui] Police {} introuvable ou vide : {}", role, relativePath);
 				return false;
 			}
-			// L'atlas ImGui prend la propriété du buffer (FontDataOwnedByAtlas par défaut = true) et le
-			// libérera via IM_FREE — on doit donc l'allouer via IM_ALLOC, pas réutiliser le std::vector
-			// (sinon UB : la mémoire serait libérée deux fois ou utilisée après libération).
+			// L'atlas ImGui prend la propriete du buffer (FontDataOwnedByAtlas par defaut = true) et le
+			// liberera via IM_FREE - on doit donc l'allouer via IM_ALLOC, pas reutiliser le std::vector
+			// (sinon UB : la memoire serait liberee deux fois ou utilisee apres liberation).
 			void* atlasOwned = IM_ALLOC(bytes.size());
 			std::memcpy(atlasOwned, bytes.data(), bytes.size());
 			ImFontConfig fcfg{};
@@ -444,22 +444,22 @@ namespace engine::editor
 			if (font == nullptr)
 			{
 				IM_FREE(atlasOwned);
-				LOG_WARN(Render, "[WorldEditorImGui] Police {} : AddFontFromMemoryTTF a échoué pour {}", role, relativePath);
+				LOG_WARN(Render, "[WorldEditorImGui] Police {} : AddFontFromMemoryTTF a echoue pour {}", role, relativePath);
 				return false;
 			}
-			LOG_INFO(Render, "[WorldEditorImGui] Police {} chargée dans l'atlas ImGui : {} ({}px)", role, relativePath, pixelHeight);
+			LOG_INFO(Render, "[WorldEditorImGui] Police {} chargee dans l'atlas ImGui : {} ({}px)", role, relativePath, pixelHeight);
 			return true;
 		};
 
 		if (cfg != nullptr)
 		{
-			// Clés spécifiques à la piste ImGui (la piste Vulkan/AuthGlyphPass garde sa propre
+			// Cles specifiques a la piste ImGui (la piste Vulkan/AuthGlyphPass garde sa propre
 			// taille via render.auth_ui.font_pixel_height = 28). En ImGui les facteurs
 			// SetWindowFontScale (1.62 pour le titre, 1.12 pour le sous-titre, 1.15 pour le titre
-			// du panneau, 0.78–0.95 pour les libellés…) sont calibrés pour la police par défaut
-			// ProggyClean ~13 px ; charger Windlass à la même taille respecte donc tous les
+			// du panneau, 0.78-0.95 pour les libelles...) sont calibres pour la police par defaut
+			// ProggyClean ~13 px ; charger Windlass a la meme taille respecte donc tous les
 			// gabarits existants. On peut surcharger via render.auth_ui.imgui.font_pixel_height
-			// si on veut grossir/réduire globalement l'UI auth ImGui sans toucher aux scales.
+			// si on veut grossir/reduire globalement l'UI auth ImGui sans toucher aux scales.
 			const std::string uiFontPath = cfg->GetString("render.auth_ui.font_path", "");
 			const float uiFontPx = static_cast<float>(std::clamp<int64_t>(
 				cfg->GetInt("render.auth_ui.imgui.font_pixel_height", 13), 11, 32));
@@ -499,7 +499,7 @@ namespace engine::editor
 
 		if (!ImGui_ImplVulkan_Init(&vulkanInfo))
 		{
-			LOG_ERROR(Render, "[WorldEditorImGui] ImGui_ImplVulkan_Init a échoué");
+			LOG_ERROR(Render, "[WorldEditorImGui] ImGui_ImplVulkan_Init a echoue");
 			ImGui_ImplWin32_Shutdown();
 			ImGui::DestroyContext();
 			vkDestroyDescriptorPool(deviceContext.GetDevice(), m_descriptorPool, nullptr);
@@ -591,12 +591,12 @@ namespace engine::editor
 					(void)m_session->ActionExportRuntime(*m_cfg);
 				}
 				ImGui::Separator();
-				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)…", nullptr, false, m_session != nullptr && m_cfg != nullptr)
+				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
 					&& m_session && m_cfg)
 				{
 					(void)m_session->ActionImportTexture(*m_cfg);
 				}
-				if (ImGui::MenuItem("Importer un son (WAV/OGG)…", nullptr, false, m_session != nullptr && m_cfg != nullptr)
+				if (ImGui::MenuItem("Importer un son (WAV/OGG)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
 					&& m_session && m_cfg)
 				{
 					(void)m_session->ActionImportAudio(*m_cfg);
@@ -607,57 +607,57 @@ namespace engine::editor
 			}
 			if (ImGui::BeginMenu("Vue"))
 			{
-				if (ImGui::MenuItem("Réinitialiser la disposition des fenêtres"))
+				if (ImGui::MenuItem("Reinitialiser la disposition des fenetres"))
 				{
-					// Supprime le fichier .ini ; ImGui ne réécrit pas la disposition tant que le contexte
-					// vit. La réinitialisation visible prend effet au prochain lancement de l'éditeur.
-					// (ImGui::ClearIniSettings n'est pas disponible dans la version d'ImGui utilisée ici.)
+					// Supprime le fichier .ini ; ImGui ne reecrit pas la disposition tant que le contexte
+					// vit. La reinitialisation visible prend effet au prochain lancement de l'editeur.
+					// (ImGui::ClearIniSettings n'est pas disponible dans la version d'ImGui utilisee ici.)
 					std::error_code ec;
 					std::filesystem::remove("world_editor_imgui.ini", ec);
 					if (m_session)
 					{
-						m_session->SetStatus("Disposition réinitialisée — l'effet sera visible au prochain démarrage.");
+						m_session->SetStatus("Disposition reinitialisee - l'effet sera visible au prochain demarrage.");
 					}
 				}
 				ImGui::Separator();
 				if (m_cfg)
 				{
 					float mult = static_cast<float>(m_cfg->GetDouble("controls.editor_camera_speed_multiplier", 1.0));
-					ImGui::TextDisabled("Vitesse de déplacement (Shift = course) :");
-					if (ImGui::SliderFloat("Vitesse caméra (x)", &mult, 0.25f, 5.0f, "%.2f"))
+					ImGui::TextDisabled("Vitesse de deplacement (Shift = course) :");
+					if (ImGui::SliderFloat("Vitesse camera (x)", &mult, 0.25f, 5.0f, "%.2f"))
 					{
 						mult = std::clamp(mult, 0.25f, 5.0f);
 						m_cfg->SetValue("controls.editor_camera_speed_multiplier", static_cast<double>(mult));
 					}
 					ImGui::TextDisabled("Astuce : montez ce curseur pour traverser plus vite les");
-					ImGui::TextDisabled("grandes cartes pendant la création.");
+					ImGui::TextDisabled("grandes cartes pendant la creation.");
 					ImGui::Separator();
 				}
-				ImGui::TextDisabled("Astuce : faites glisser une fenêtre par sa barre de titre");
-				ImGui::TextDisabled("pour la docker à gauche, à droite ou en bas.");
+				ImGui::TextDisabled("Astuce : faites glisser une fenetre par sa barre de titre");
+				ImGui::TextDisabled("pour la docker a gauche, a droite ou en bas.");
 				ImGui::EndMenu();
 			}
 			if (m_cfg && ImGui::BeginMenu("Options"))
 			{
 				const std::string cur = m_cfg->GetString("controls.movement_layout", "wasd");
 				const bool zqsdActive = (cur == "zqsd");
-				if (ImGui::MenuItem("Déplacement : QWERTY (WASD)", nullptr, !zqsdActive))
+				if (ImGui::MenuItem("Deplacement : QWERTY (WASD)", nullptr, !zqsdActive))
 				{
 					m_cfg->SetValue("controls.movement_layout", std::string("wasd"));
 					TryPersistMovementLayoutToUserSettings("wasd");
 				}
-				if (ImGui::MenuItem("Déplacement : AZERTY (ZQSD)", nullptr, zqsdActive))
+				if (ImGui::MenuItem("Deplacement : AZERTY (ZQSD)", nullptr, zqsdActive))
 				{
 					m_cfg->SetValue("controls.movement_layout", std::string("zqsd"));
 					TryPersistMovementLayoutToUserSettings("zqsd");
 				}
 				ImGui::EndMenu();
 			}
-			// Barre d'outils rapide à droite du menu : sauvegarde 1-clic + chargement carte.
+			// Barre d'outils rapide a droite du menu : sauvegarde 1-clic + chargement carte.
 			if (m_session != nullptr && m_cfg != nullptr)
 			{
 				ImGui::Separator();
-				if (ImGui::MenuItem("[Sauvegarder]"))
+				if (ImGui::MenuItem("Sauvegarder"))
 				{
 					(void)m_session->ActionSaveCurrentMap(*m_cfg);
 				}
@@ -665,12 +665,12 @@ namespace engine::editor
 				{
 					m_session->RefreshAvailableMaps(*m_cfg);
 				}
-				if (ImGui::BeginMenu("[Charger une carte]"))
+				if (ImGui::BeginMenu("Charger une carte"))
 				{
 					const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
 					if (mapIds.empty())
 					{
-						ImGui::TextDisabled("Aucune carte. Créez-en une via le panneau « Carte ».");
+						ImGui::TextDisabled("Aucune carte. Creez-en une via le panneau 'Carte'.");
 					}
 					else
 					{
@@ -684,13 +684,13 @@ namespace engine::editor
 						}
 					}
 					ImGui::Separator();
-					if (ImGui::MenuItem("Rafraîchir la liste"))
+					if (ImGui::MenuItem("Rafraichir la liste"))
 					{
 						m_session->RefreshAvailableMaps(*m_cfg);
 					}
 					ImGui::EndMenu();
 				}
-				// Statut court à droite
+				// Statut court a droite
 				if (!m_session->Status().empty())
 				{
 					ImGui::Separator();
@@ -713,34 +713,34 @@ namespace engine::editor
 		if (ImGui::Begin("WorldEditorDockSpaceHost", nullptr, hostFlags))
 		{
 			const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpace");
-			// ImGuiDockNodeFlags_PassthroughCentralNode (1<<4) — littéral pour éviter les divergences d’en-têtes.
+			// ImGuiDockNodeFlags_PassthroughCentralNode (1<<4) - litteral pour eviter les divergences d'en-tetes.
 			ImGui::DockSpace(dockId, ImVec2(0.f, 0.f), static_cast<ImGuiDockNodeFlags>(1u << 4));
 		}
 		ImGui::End();
 		ImGui::PopStyleVar(3);
 
-		ImGui::Begin("Scène", nullptr, ImGuiWindowFlags_NoMouseInputs);
-		ImGui::TextUnformatted("Vue 3D Vulkan (même moteur que le jeu).");
+		ImGui::Begin("Scene", nullptr, ImGuiWindowFlags_NoMouseInputs);
+		ImGui::TextUnformatted("Vue 3D Vulkan (meme moteur que le jeu).");
 		ImGui::TextUnformatted(
-			"Déplacement : menu « Options » → QWERTY (WASD) ou AZERTY (ZQSD), un seul à la fois. Shift = plus rapide ; "
-			"vitesse de base augmente avec la taille du terrain chargé.");
+			"Deplacement : menu 'Options' -> QWERTY (WASD) ou AZERTY (ZQSD), un seul a la fois. Shift = plus rapide ; "
+			"vitesse de base augmente avec la taille du terrain charge.");
 		ImGui::TextUnformatted(
-			"Orientation : maintenez le clic droit et déplacez la souris (même au-dessus des fenêtres ImGui) ; "
-			"sinon la souris n’oriente que lorsqu’ImGui ne la capture pas. Molette : zoom FOV.");
+			"Orientation : maintenez le clic droit et deplacez la souris (meme au-dessus des fenetres ImGui) ; "
+			"sinon la souris n'oriente que lorsqu'ImGui ne la capture pas. Molette : zoom FOV.");
 		ImGui::TextUnformatted(
 			"Si la vue monte quand vous baissez la souris : dans user_settings.json ou options client, "
 			"activez controls.invert_y.");
 		if (viewportOverlay != nullptr && viewportOverlay->viewProjColMajor != nullptr)
 		{
 			ImGui::Separator();
-			ImGui::Text("Caméra (monde) : (%.2f, %.2f, %.2f) m", static_cast<double>(viewportOverlay->cameraWorldX),
+			ImGui::Text("Camera (monde) : (%.2f, %.2f, %.2f) m", static_cast<double>(viewportOverlay->cameraWorldX),
 				static_cast<double>(viewportOverlay->cameraWorldY), static_cast<double>(viewportOverlay->cameraWorldZ));
-			ImGui::Text("Orientation : yaw %.1f°, pitch %.1f°", static_cast<double>(viewportOverlay->cameraYawDeg),
+			ImGui::Text("Orientation : yaw %.1fdeg, pitch %.1fdeg", static_cast<double>(viewportOverlay->cameraYawDeg),
 				static_cast<double>(viewportOverlay->cameraPitchDeg));
 			ImGui::TextDisabled(
-				"La grille et le rendu 3D utilisent la même matrice vue×projection chaque frame : ce n’est pas une grille « figée » "
-				"qui oublierait de se rafraîchir. Si ces nombres ne bougent pas avec WASD / souris, la caméra ne reçoit pas l’entrée "
-				"(focus ImGui, etc.). S’ils bougent mais l’image ne change pas, il s’agit d’un autre problème de rendu.");
+				"La grille et le rendu 3D utilisent la meme matrice vue x projection chaque frame : ce n'est pas une grille 'figee' "
+				"qui oublierait de se rafraichir. Si ces nombres ne bougent pas avec WASD / souris, la camera ne recoit pas l'entree "
+				"(focus ImGui, etc.). S'ils bougent mais l'image ne change pas, il s'agit d'un autre probleme de rendu.");
 		}
 		ImGui::End();
 
@@ -753,16 +753,16 @@ namespace engine::editor
 
 			ImGui::Begin("Carte");
 
-			// Section 1 — Cartes existantes (chemin canonique world_editor/maps/<zone_id>/).
+			// Section 1 - Cartes existantes (chemin canonique world_editor/maps/<zone_id>/).
 			ImGui::TextUnformatted("Cartes disponibles");
-			if (ImGui::Button("Rafraîchir la liste"))
+			if (ImGui::Button("Rafraichir la liste"))
 			{
 				m_session->RefreshAvailableMaps(*m_cfg);
 			}
 			const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
 			if (mapIds.empty())
 			{
-				ImGui::TextDisabled("Aucune carte trouvée. Créez-en une ci-dessous, ou cliquez sur « Rafraîchir la liste ».");
+				ImGui::TextDisabled("Aucune carte trouvee. Creez-en une ci-dessous, ou cliquez sur 'Rafraichir la liste'.");
 			}
 			else
 			{
@@ -777,14 +777,14 @@ namespace engine::editor
 				sel = std::clamp(sel, 0, static_cast<int>(mapIds.size()) - 1);
 				ImGui::Combo("Carte", &sel, itemsZ.c_str());
 				sel = std::clamp(sel, 0, static_cast<int>(mapIds.size()) - 1);
-				if (ImGui::Button("Charger la carte sélectionnée"))
+				if (ImGui::Button("Charger la carte selectionnee"))
 				{
 					(void)m_session->ActionLoadMapByZoneId(*m_cfg, mapIds[static_cast<size_t>(sel)]);
 				}
 			}
 			ImGui::Separator();
 
-			// Section 2 — Sauvegarde 1-clic dans le chemin canonique de la carte courante.
+			// Section 2 - Sauvegarde 1-clic dans le chemin canonique de la carte courante.
 			ImGui::TextUnformatted("Carte courante");
 			ImGui::InputText("Nom (zone_id)", m_session->BufZoneId().data(), m_session->BufZoneId().size());
 			if (ImGui::Button("Sauvegarder"))
@@ -802,12 +802,12 @@ namespace engine::editor
 			}
 			ImGui::Separator();
 
-			// Section 3 — Création d'une nouvelle carte.
+			// Section 3 - Creation d'une nouvelle carte.
 			ImGui::TextUnformatted("Nouvelle carte");
-			ImGui::InputText("Taille (N×N)", m_session->BufSize().data(), m_session->BufSize().size());
-			ImGui::InputTextWithHint("Seed (optionnel)", "vide = aléatoire non fixé",
+			ImGui::InputText("Taille (NxN)", m_session->BufSize().data(), m_session->BufSize().size());
+			ImGui::InputTextWithHint("Seed (optionnel)", "vide = aleatoire non fixe",
 				m_session->BufSeed().data(), m_session->BufSeed().size());
-			if (ImGui::Button("Créer une nouvelle carte"))
+			if (ImGui::Button("Creer une nouvelle carte"))
 			{
 				if (m_session->ActionNewMap(*m_cfg))
 				{
@@ -816,8 +816,8 @@ namespace engine::editor
 			}
 			ImGui::Separator();
 
-			// Section 4 — Détails fichiers + recharge terrain GPU (avancé, replié par défaut).
-			if (ImGui::CollapsingHeader("Détails fichiers (avancé)"))
+			// Section 4 - Details fichiers + recharge terrain GPU (avance, replie par defaut).
+			if (ImGui::CollapsingHeader("Details fichiers (avance)"))
 			{
 				ImGui::TextUnformatted("Heightmap (relatif content):");
 				ImGui::TextWrapped("%s", m_session->Doc().heightmapContentRelativePath.c_str());
@@ -836,7 +836,7 @@ namespace engine::editor
 			ImGui::End();
 
 			ImGui::Begin("Affichage & grille");
-			ImGui::Checkbox("Grille (aperçu écran)", &m_session->ShowGrid());
+			ImGui::Checkbox("Grille (apercu ecran)", &m_session->ShowGrid());
 			ImGui::SliderFloat("Maille grille (m)", &m_session->GridCellMeters(), 1.f, 128.f, "%.1f");
 			if (viewportOverlay && viewportOverlay->heightmap && viewportOverlay->terrainWorldSize > 0.f)
 			{
@@ -848,28 +848,28 @@ namespace engine::editor
 					const float minSpacing =
 						ws / static_cast<float>(std::max(1, kWorldEditorGridMaxLinesPerAxis - 1));
 					ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f),
-						"La grille est limitée à %d lignes par axe (performances). Avec un terrain de %.0f m, "
-						"la maille affichée ne peut pas être plus fine qu’environ %.1f m tant que ce plafond s’applique.",
+						"La grille est limitee a %d lignes par axe (performances). Avec un terrain de %.0f m, "
+						"la maille affichee ne peut pas etre plus fine qu'environ %.1f m tant que ce plafond s'applique.",
 						kWorldEditorGridMaxLinesPerAxis, static_cast<double>(ws), static_cast<double>(minSpacing));
 				}
 			}
-			ImGui::TextUnformatted("La grille est dessinée en surimpression (projection caméra) lorsque le terrain GPU est chargé.");
+			ImGui::TextUnformatted("La grille est dessinee en surimpression (projection camera) lorsque le terrain GPU est charge.");
 			ImGui::End();
 
 			ImGui::Begin("Outils");
-			// État du terrain — visible en permanence, pour expliquer pourquoi le clic peut être inactif.
+			// Etat du terrain - visible en permanence, pour expliquer pourquoi le clic peut etre inactif.
 			{
 				const bool terrainReady = !m_session->Doc().heightmapContentRelativePath.empty();
 				if (terrainReady)
 				{
-					ImGui::TextColored(ImVec4(0.5f, 0.95f, 0.55f, 1.f), "Terrain : prêt");
+					ImGui::TextColored(ImVec4(0.5f, 0.95f, 0.55f, 1.f), "Terrain : pret");
 				}
 				else
 				{
 					ImGui::TextColored(ImVec4(1.f, 0.55f, 0.3f, 1.f),
-						"Terrain : aucun. Créez ou chargez une carte avant de peindre / sculpter.");
+						"Terrain : aucun. Creez ou chargez une carte avant de peindre / sculpter.");
 				}
-				ImGui::TextDisabled("Le clic gauche est ignoré quand la souris est au-dessus de l'UI ; visez la zone 3D.");
+				ImGui::TextDisabled("Le clic gauche est ignore quand la souris est au-dessus de l'UI ; visez la zone 3D.");
 				ImGui::Separator();
 			}
 			if (ImGui::BeginTabBar("OutilsTabs"))
@@ -899,13 +899,13 @@ namespace engine::editor
 					ImGui::SliderFloat("Force", &m_session->BrushStrength(), 0.01f, 1.f, "%.2f");
 
 					ImGui::Separator();
-					if (ImGui::CollapsingHeader("Textures personnalisées (par couche)"))
+					if (ImGui::CollapsingHeader("Textures personnalisees (par couche)"))
 					{
-						ImGui::TextDisabled("Associez une texture importée à chaque type de sol.");
+						ImGui::TextDisabled("Associez une texture importee a chaque type de sol.");
 						const std::vector<std::string>& imported = m_session->Doc().textureAssets;
 						std::array<std::string, 4>& refs = m_session->MutableDoc().splatLayerTextureRefs;
 						std::string itemsZ;
-						itemsZ += "(par défaut moteur)";
+						itemsZ += "(par defaut moteur)";
 						itemsZ.push_back('\0');
 						for (const std::string& t : imported)
 						{
@@ -941,7 +941,7 @@ namespace engine::editor
 								}
 							}
 						}
-						ImGui::TextDisabled("Le mapping est persisté dans la carte (champ JSON splat_layer_texture_refs).");
+						ImGui::TextDisabled("Le mapping est persiste dans la carte (champ JSON splat_layer_texture_refs).");
 					}
 
 					if (ImGui::CollapsingHeader("Sons de pas (par couche)"))
@@ -961,7 +961,7 @@ namespace engine::editor
 						if (imported.empty())
 						{
 							ImGui::TextColored(ImVec4(1.f, 0.7f, 0.3f, 1.f),
-								"Importez d'abord des sons via le panneau « Import assets ».");
+								"Importez d'abord des sons via le panneau 'Import assets'.");
 						}
 						for (int li = 0; li < 4; ++li)
 						{
@@ -992,24 +992,24 @@ namespace engine::editor
 							}
 						}
 						ImGui::TextDisabled(
-							"Persisté en JSON. Lecture côté gameplay (déplacement joueur → couche splat dominante)"
-							" sera branchée dans une itération moteur ultérieure.");
+							"Persiste en JSON. Lecture cote gameplay (deplacement joueur -> couche splat dominante)"
+							" sera branchee dans une iteration moteur ulterieure.");
 					}
 
 					ImGui::Separator();
-					ImGui::TextWrapped("Maintenez le clic gauche sur le sol pour peindre. La sauvegarde écrit le fichier splat.");
+					ImGui::TextWrapped("Maintenez le clic gauche sur le sol pour peindre. La sauvegarde ecrit le fichier splat.");
 					ImGui::EndTabItem();
 				}
 
 				if (ImGui::BeginTabItem("Herbe"))
 				{
 					tm = 2;
-					ImGui::TextDisabled("Définit où des touffes d'herbe poussent.");
+					ImGui::TextDisabled("Definit ou des touffes d'herbe poussent.");
 					ImGui::Checkbox("Mode gomme (efface l'herbe)", &m_session->GrassMaskEraseBrush());
 					ImGui::SliderFloat("Rayon du pinceau (m)", &m_session->BrushRadius(), 0.5f, 200.f, "%.1f");
 					ImGui::SliderFloat("Force", &m_session->BrushStrength(), 0.01f, 1.f, "%.2f");
 					ImGui::Separator();
-					ImGui::TextWrapped("Maintenez le clic gauche pour appliquer. La sauvegarde écrit grass.grms.");
+					ImGui::TextWrapped("Maintenez le clic gauche pour appliquer. La sauvegarde ecrit grass.grms.");
 					ImGui::EndTabItem();
 				}
 
@@ -1018,17 +1018,17 @@ namespace engine::editor
 					tm = 3;
 					ImGui::TextDisabled("Pose des arbres, rochers ou autres objets.");
 					ImGui::TextWrapped(
-						"Choisissez le type d'objet dans le panneau « Objets sur la carte » à droite.");
+						"Choisissez le type d'objet dans le panneau 'Objets sur la carte' a droite.");
 					ImGui::Separator();
 					ImGui::TextWrapped(
-						"Clic gauche sur le sol : pose un nouvel objet, ou déplace l'objet sélectionné dans la liste.");
+						"Clic gauche sur le sol : pose un nouvel objet, ou deplace l'objet selectionne dans la liste.");
 					ImGui::EndTabItem();
 				}
 
 				if (ImGui::BeginTabItem("Eau"))
 				{
 					// Pas un mode de pinceau : on ne change pas tm.
-					ImGui::TextDisabled("Active une surface d'eau plane à un Y donné (lac, mer).");
+					ImGui::TextDisabled("Active une surface d'eau plane a un Y donne (lac, mer).");
 					bool waterOn = m_session->Doc().waterEnabled;
 					if (ImGui::Checkbox("Eau active", &waterOn))
 					{
@@ -1041,11 +1041,11 @@ namespace engine::editor
 					}
 					ImGui::Separator();
 					ImGui::TextDisabled(
-						"Ces réglages sont persistés dans la carte (champs JSON water_enabled,");
+						"Ces reglages sont persistes dans la carte (champs JSON water_enabled,");
 					ImGui::TextDisabled(
 						"water_level_m). La passe Vulkan eau (surface transparente, reflets simples)");
 					ImGui::TextDisabled(
-						"sera branchée dans une itération moteur ultérieure.");
+						"sera branchee dans une iteration moteur ulterieure.");
 					ImGui::EndTabItem();
 				}
 
@@ -1060,7 +1060,7 @@ namespace engine::editor
 						rl = std::clamp(rl, 0, 3);
 					}
 					ImGui::SliderFloat("Largeur (m)", &m_session->RouteStripWidthM(), 0.5f, 64.f, "%.1f");
-					ImGui::SliderFloat("Intensité", &m_session->BrushStrength(), 0.01f, 1.f, "%.2f");
+					ImGui::SliderFloat("Intensite", &m_session->BrushStrength(), 0.01f, 1.f, "%.2f");
 					ImGui::Separator();
 					if (ImGui::Button("Effacer les points"))
 					{
@@ -1071,10 +1071,10 @@ namespace engine::editor
 					{
 						m_session->RequestApplyRouteDraftToSplat();
 					}
-					ImGui::Text("Points placés : %zu", m_session->RouteDraftPoints().size());
-					ImGui::Text("Routes enregistrées : %zu", m_session->Doc().routes.size());
+					ImGui::Text("Points places : %zu", m_session->RouteDraftPoints().size());
+					ImGui::Text("Routes enregistrees : %zu", m_session->Doc().routes.size());
 					ImGui::Separator();
-					ImGui::TextWrapped("Cliquez sur le sol pour ajouter un sommet de la route, puis « Tracer la route ».");
+					ImGui::TextWrapped("Cliquez sur le sol pour ajouter un sommet de la route, puis 'Tracer la route'.");
 					ImGui::EndTabItem();
 				}
 
@@ -1085,30 +1085,30 @@ namespace engine::editor
 
 			ImGui::Begin("Import assets");
 			ImGui::TextUnformatted("Texture (PNG / JPG / TGA / BMP)");
-			ImGui::InputTextWithHint("Source", "C:/chemin/vers/image.png (guillemets autorisés)",
+			ImGui::InputTextWithHint("Source", "C:/chemin/vers/image.png (guillemets autorises)",
 				m_session->BufPngPath().data(), m_session->BufPngPath().size());
-			ImGui::InputTextWithHint("Nom dans textures/", "vide = déduit automatiquement (ex: image.texr)",
+			ImGui::InputTextWithHint("Nom dans textures/", "vide = deduit automatiquement (ex: image.texr)",
 				m_session->BufTexrName().data(), m_session->BufTexrName().size());
 			if (ImGui::Button("Importer cette texture"))
 			{
 				(void)m_session->ActionImportTexture(*m_cfg);
 			}
-			ImGui::TextDisabled("L'extension .texr est ajoutée si absente. Le fichier est écrit dans <content>/textures/.");
+			ImGui::TextDisabled("L'extension .texr est ajoutee si absente. Le fichier est ecrit dans <content>/textures/.");
 			ImGui::Separator();
 
 			ImGui::TextUnformatted("Audio (WAV / OGG)");
-			ImGui::InputTextWithHint("Source##audio", "C:/chemin/vers/son.wav (guillemets autorisés)",
+			ImGui::InputTextWithHint("Source##audio", "C:/chemin/vers/son.wav (guillemets autorises)",
 				m_session->BufAudioSrc().data(), m_session->BufAudioSrc().size());
-			ImGui::InputTextWithHint("Nom dans audio/", "vide = même nom que la source (ex: footstep/sand.wav)",
+			ImGui::InputTextWithHint("Nom dans audio/", "vide = meme nom que la source (ex: footstep/sand.wav)",
 				m_session->BufAudioDest().data(), m_session->BufAudioDest().size());
 			if (ImGui::Button("Importer cet audio"))
 			{
 				(void)m_session->ActionImportAudio(*m_cfg);
 			}
-			ImGui::TextDisabled("Le fichier est copié dans <content>/audio/. Aucune transcompression.");
+			ImGui::TextDisabled("Le fichier est copie dans <content>/audio/. Aucune transcompression.");
 			ImGui::Separator();
 
-			ImGui::TextUnformatted("Textures déjà importées sur cette carte:");
+			ImGui::TextUnformatted("Textures deja importees sur cette carte:");
 			if (m_session->Doc().textureAssets.empty())
 			{
 				ImGui::TextDisabled("(aucune)");
@@ -1130,7 +1130,7 @@ namespace engine::editor
 			const char* placeKinds[] = { "Arbre (catalogue 013)", "Rocher (legacy zone_1)" };
 			{
 				int& pk = m_session->InstancePlacementKind();
-				ImGui::Combo("Type à placer", &pk, placeKinds, IM_ARRAYSIZE(placeKinds));
+				ImGui::Combo("Type a placer", &pk, placeKinds, IM_ARRAYSIZE(placeKinds));
 				pk = std::clamp(pk, 0, 1);
 			}
 			if (m_session->InstancePlacementKind() == 0)
@@ -1153,7 +1153,7 @@ namespace engine::editor
 					int& si = m_session->TreeSpeciesUiIndex();
 					const int prevSi = si;
 					si = std::clamp(si, 0, static_cast<int>(specs.size()) - 1);
-					ImGui::Combo("Espèce", &si, speciesItems.c_str());
+					ImGui::Combo("Espece", &si, speciesItems.c_str());
 					si = std::clamp(si, 0, static_cast<int>(specs.size()) - 1);
 					if (si != prevSi)
 					{
@@ -1177,20 +1177,20 @@ namespace engine::editor
 					shi = std::clamp(shi, 0, static_cast<int>(sp.shapes.size()) - 1);
 					ImGui::Combo("Forme (variante glTF)", &shi, shapeItems.c_str());
 					shi = std::clamp(shi, 0, static_cast<int>(sp.shapes.size()) - 1);
-					ImGui::SliderFloat("Taille (min–max espèce)", &m_session->TreeScaleT01(), 0.f, 1.f, "%.2f");
-					ImGui::Checkbox("Échelle aléatoire à la pose", &m_session->TreeRandomizeScaleOnPlace());
+					ImGui::SliderFloat("Taille (min-max espece)", &m_session->TreeScaleT01(), 0.f, 1.f, "%.2f");
+					ImGui::Checkbox("Echelle aleatoire a la pose", &m_session->TreeRandomizeScaleOnPlace());
 					if (m_session->TreeRandomizeScaleOnPlace())
 					{
-						ImGui::TextDisabled("Le curseur taille est ignoré si aléatoire est coché.");
+						ImGui::TextDisabled("Le curseur taille est ignore si aleatoire est coche.");
 					}
 				}
 			}
 			else
 			{
-				ImGui::TextUnformatted("Pose un rocher (zones/zone_1/zone_1.gltf), sans espèce catalogue.");
+				ImGui::TextUnformatted("Pose un rocher (zones/zone_1/zone_1.gltf), sans espece catalogue.");
 			}
 			ImGui::TextUnformatted(
-				"Sélectionnez une ligne pour déplacer au prochain clic. Sans sélection : nouvelle instance. Coordonnées monde + snap hauteur MNT.");
+				"Selectionnez une ligne pour deplacer au prochain clic. Sans selection : nouvelle instance. Coordonnees monde + snap hauteur MNT.");
 			ImGui::Separator();
 			for (size_t i = 0; i < m_session->MutableDoc().layoutInstances.size(); ++i)
 			{
@@ -1198,12 +1198,12 @@ namespace engine::editor
 				char label[256];
 				if (!inst.speciesId.empty())
 				{
-					std::snprintf(label, sizeof(label), "%s — %s #%u — scale %.3f##instrow%zu", inst.guid.c_str(), inst.speciesId.c_str(),
+					std::snprintf(label, sizeof(label), "%s - %s #%u - scale %.3f##instrow%zu", inst.guid.c_str(), inst.speciesId.c_str(),
 						static_cast<unsigned>(inst.shapeVariantIndex), inst.uniformScale, i);
 				}
 				else
 				{
-					std::snprintf(label, sizeof(label), "%s — %s##instrow%zu", inst.guid.c_str(), inst.gltfContentRelativePath.c_str(), i);
+					std::snprintf(label, sizeof(label), "%s - %s##instrow%zu", inst.guid.c_str(), inst.gltfContentRelativePath.c_str(), i);
 				}
 				const bool sel = (m_session->SelectedLayoutInstanceIndex() == static_cast<int>(i));
 				if (ImGui::Selectable(label, sel))
@@ -1230,7 +1230,7 @@ namespace engine::editor
 						if (spec != nullptr && !spec->shapes.empty())
 						{
 							ImGui::Separator();
-							ImGui::TextUnformatted("Édition instance sélectionnée (arbre)");
+							ImGui::TextUnformatted("Edition instance selectionnee (arbre)");
 							std::string shapeItemsSel;
 							for (const TreeSpeciesShapeSpec& sh : spec->shapes)
 							{
@@ -1251,14 +1251,14 @@ namespace engine::editor
 							inst.shapeVariantIndex = static_cast<uint32_t>(sh);
 							inst.gltfContentRelativePath = spec->shapes[static_cast<size_t>(sh)].gltfContentRelativePath;
 							float scf = static_cast<float>(inst.uniformScale);
-							(void)ImGui::SliderFloat("Échelle##edit_sel", &scf, static_cast<float>(spec->scaleMin), static_cast<float>(spec->scaleMax),
+							(void)ImGui::SliderFloat("Echelle##edit_sel", &scf, static_cast<float>(spec->scaleMin), static_cast<float>(spec->scaleMax),
 								"%.3f");
 							inst.uniformScale = static_cast<double>(scf);
 						}
 					}
 				}
 			}
-			if (ImGui::Button("Aucune sélection (pose toujours une nouvelle instance)"))
+			if (ImGui::Button("Aucune selection (pose toujours une nouvelle instance)"))
 			{
 				m_session->SelectedLayoutInstanceIndex() = -1;
 			}
@@ -1270,8 +1270,8 @@ namespace engine::editor
 		}
 		else
 		{
-			ImGui::Begin("Propriétés", nullptr, ImGuiWindowFlags_NoMouseInputs);
-			ImGui::TextUnformatted("Session éditeur non initialisée.");
+			ImGui::Begin("Proprietes", nullptr, ImGuiWindowFlags_NoMouseInputs);
+			ImGui::TextUnformatted("Session editeur non initialisee.");
 			ImGui::End();
 		}
 

--- a/engine/editor/WorldEditorSession.cpp
+++ b/engine/editor/WorldEditorSession.cpp
@@ -69,7 +69,7 @@ namespace engine::editor
 			return std::string(buf);
 		}
 
-		/// Normalise un chemin saisi à la main : strip espaces et guillemets entourants
+		/// Normalise un chemin saisi a la main : strip espaces et guillemets entourants
 		/// (typiquement quand l'utilisateur fait copier-coller depuis l'Explorateur Windows).
 		std::string NormalizeUserPath(std::string s)
 		{
@@ -94,8 +94,8 @@ namespace engine::editor
 			return s;
 		}
 
-		/// Bascule l'extension d'un nom de fichier (ex. "sand.png" → "sand.texr"). Si pas
-		/// d'extension, l'ajoute. Préserve les répertoires antérieurs.
+		/// Bascule l'extension d'un nom de fichier (ex. "sand.png" -> "sand.texr"). Si pas
+		/// d'extension, l'ajoute. Preserve les repertoires anterieurs.
 		std::string ReplaceExtension(std::string_view nameWithMaybeDirs, std::string_view newExtNoDot)
 		{
 			std::string out(nameWithMaybeDirs);
@@ -196,7 +196,7 @@ namespace engine::editor
 			inst.worldX = worldX;
 			inst.worldY = worldY;
 			inst.worldZ = worldZ;
-			SetStatus("Instance déplacée.");
+			SetStatus("Instance deplacee.");
 			return;
 		}
 		const int kind = std::clamp(m_instancePlacementKind, 0, 1);
@@ -213,7 +213,7 @@ namespace engine::editor
 		{
 			if (m_treeCatalog.Species().empty())
 			{
-				SetStatus("Aucune espèce d’arbre valide (catalogue absent ou sans 2+ glTF par espèce). Utilisez « Rocher » ou corrigez le JSON.");
+				SetStatus("Aucune espece d'arbre valide (catalogue absent ou sans 2+ glTF par espece). Utilisez 'Rocher' ou corrigez le JSON.");
 				return;
 			}
 			const int si = std::clamp(m_treeSpeciesUiIndex, 0, static_cast<int>(m_treeCatalog.Species().size()) - 1);
@@ -240,7 +240,7 @@ namespace engine::editor
 		inst.worldY = worldY;
 		inst.worldZ = worldZ;
 		m_doc.layoutInstances.push_back(std::move(inst));
-		SetStatus(kind == 1 ? "Rocher placé." : "Arbre placé.");
+		SetStatus(kind == 1 ? "Rocher place." : "Arbre place.");
 	}
 
 	void WorldEditorSession::RemoveLayoutInstance(size_t index)
@@ -258,7 +258,7 @@ namespace engine::editor
 		{
 			--m_selectedLayoutInstance;
 		}
-		SetStatus("Instance supprimée.");
+		SetStatus("Instance supprimee.");
 	}
 
 	void WorldEditorSession::SyncBuffersFromDoc()
@@ -354,7 +354,7 @@ namespace engine::editor
 			engine::render::terrain::TerrainGrassDetail::GenerateZeros(1024u, 1024u, gm);
 			if (!engine::render::terrain::TerrainGrassDetail::SaveToFile(grassAbs.string(), gm))
 			{
-				SetStatus("Nouvelle carte: écriture grass.grms impossible");
+				SetStatus("Nouvelle carte: ecriture grass.grms impossible");
 				LOG_ERROR(Core, "[WorldEditor] grass.grms write failed: {}", grassAbs.string());
 				return false;
 			}
@@ -383,12 +383,12 @@ namespace engine::editor
 		SetBuf(m_bufSavePath, m_editJsonAbsolutePath);
 		if (!SaveEditDocumentJson(jsonAbs, m_doc, err))
 		{
-			SetStatus("Carte créée mais sauvegarde JSON échouée: " + err);
+			SetStatus("Carte creee mais sauvegarde JSON echouee: " + err);
 			LOG_WARN(Core, "[WorldEditor] {}", err);
 			RequestTerrainGpuReload();
 			return true;
 		}
-		SetStatus("Nouvelle carte OK — " + hmRel);
+		SetStatus("Nouvelle carte OK - " + hmRel);
 		RequestTerrainGpuReload();
 		SyncBuffersFromDoc();
 		LOG_INFO(Core, "[WorldEditor] New map OK zone={} size={}", zid, sz);
@@ -408,7 +408,7 @@ namespace engine::editor
 		}
 		if (m_terrainSaveHook && !m_terrainSaveHook(cfg, m_doc))
 		{
-			SetStatus("Sauvegarde: échec écriture des fichiers terrain (heightmap / splat / grass).");
+			SetStatus("Sauvegarde: echec ecriture des fichiers terrain (heightmap / splat / grass).");
 			return false;
 		}
 		std::string err;
@@ -418,7 +418,7 @@ namespace engine::editor
 			return false;
 		}
 		m_editJsonAbsolutePath = path;
-		SetStatus("Sauvegardé: " + path);
+		SetStatus("Sauvegarde: " + path);
 		return true;
 	}
 
@@ -440,7 +440,7 @@ namespace engine::editor
 		m_treeCatalogLoadAttempted = false;
 		m_editJsonAbsolutePath = path;
 		SetBuf(m_bufSavePath, m_editJsonAbsolutePath);
-		SetStatus("Chargé: " + path);
+		SetStatus("Charge: " + path);
 		m_selectedLayoutInstance = -1;
 		m_routeDraftXz.clear();
 		m_routeApplyDraftRequested = false;
@@ -460,7 +460,7 @@ namespace engine::editor
 			SetStatus("Export: " + err);
 			return false;
 		}
-		SetStatus("Export runtime OK → game/data/zones/" + SanitizeZoneId(m_doc.zoneId) + "/");
+		SetStatus("Export runtime OK -> game/data/zones/" + SanitizeZoneId(m_doc.zoneId) + "/");
 		return true;
 	}
 
@@ -528,7 +528,7 @@ namespace engine::editor
 		std::filesystem::create_directories(jsonAbs.parent_path(), ec);
 		if (m_terrainSaveHook && !m_terrainSaveHook(cfg, m_doc))
 		{
-			SetStatus("Sauvegarde: échec écriture des fichiers terrain (heightmap / splat / grass).");
+			SetStatus("Sauvegarde: echec ecriture des fichiers terrain (heightmap / splat / grass).");
 			return false;
 		}
 		std::string err;
@@ -539,7 +539,7 @@ namespace engine::editor
 		}
 		m_editJsonAbsolutePath = jsonAbs.string();
 		SetBuf(m_bufSavePath, m_editJsonAbsolutePath);
-		SetStatus("Carte sauvegardée: " + zid);
+		SetStatus("Carte sauvegardee: " + zid);
 		LOG_INFO(Core, "[WorldEditor] Saved map zone={} -> {}", zid, m_editJsonAbsolutePath);
 		RefreshAvailableMaps(cfg);
 		for (int i = 0; i < static_cast<int>(m_availableMapIds.size()); ++i)
@@ -579,7 +579,7 @@ namespace engine::editor
 		m_editJsonAbsolutePath = jsonAbs.string();
 		SetBuf(m_bufSavePath, m_editJsonAbsolutePath);
 		SetBuf(m_bufLoadPath, m_editJsonAbsolutePath);
-		SetStatus("Carte chargée: " + zid);
+		SetStatus("Carte chargee: " + zid);
 		LOG_INFO(Core, "[WorldEditor] Loaded map zone={} -> {}", zid, m_editJsonAbsolutePath);
 		m_selectedLayoutInstance = -1;
 		m_routeDraftXz.clear();
@@ -608,7 +608,7 @@ namespace engine::editor
 			SetStatus("Import texture: chemin PNG source requis (chemin absolu).");
 			return false;
 		}
-		// Auto-dérive un nom destination si vide, depuis le basename de la source.
+		// Auto-derive un nom destination si vide, depuis le basename de la source.
 		if (dest.empty())
 		{
 			const std::filesystem::path srcPath(png);
@@ -636,7 +636,7 @@ namespace engine::editor
 				dest = ReplaceExtension(dest, "texr");
 			}
 		}
-		// Reflète la normalisation dans le buffer UI pour aider l'utilisateur.
+		// Reflete la normalisation dans le buffer UI pour aider l'utilisateur.
 		SetBuf(m_bufPngPath, png);
 		SetBuf(m_bufTexrName, dest);
 
@@ -648,13 +648,13 @@ namespace engine::editor
 			return false;
 		}
 		const std::string rel = std::string("textures/") + dest;
-		// Évite les doublons dans la liste (ré-import du même nom).
+		// Evite les doublons dans la liste (re-import du meme nom).
 		const auto it = std::find(m_doc.textureAssets.begin(), m_doc.textureAssets.end(), rel);
 		if (it == m_doc.textureAssets.end())
 		{
 			m_doc.textureAssets.push_back(rel);
 		}
-		SetStatus("Texture importée: " + rel);
+		SetStatus("Texture importee: " + rel);
 		return true;
 	}
 
@@ -667,7 +667,7 @@ namespace engine::editor
 			SetStatus("Import audio: chemin source requis (chemin absolu).");
 			return false;
 		}
-		// Auto-dérive un nom destination si vide, depuis le basename de la source.
+		// Auto-derive un nom destination si vide, depuis le basename de la source.
 		if (dst.empty())
 		{
 			const std::filesystem::path srcPath(src);
@@ -678,7 +678,7 @@ namespace engine::editor
 				return false;
 			}
 		}
-		// Reflète la normalisation dans le buffer UI.
+		// Reflete la normalisation dans le buffer UI.
 		SetBuf(m_bufAudioSrc, src);
 		SetBuf(m_bufAudioDest, dst);
 
@@ -690,13 +690,13 @@ namespace engine::editor
 			return false;
 		}
 		const std::string rel = std::string("audio/") + dst;
-		// Évite les doublons dans la liste (ré-import du même nom).
+		// Evite les doublons dans la liste (re-import du meme nom).
 		const auto it = std::find(m_doc.audioAssets.begin(), m_doc.audioAssets.end(), rel);
 		if (it == m_doc.audioAssets.end())
 		{
 			m_doc.audioAssets.push_back(rel);
 		}
-		SetStatus("Audio importé: " + rel);
+		SetStatus("Audio importe: " + rel);
 		return true;
 	}
 

--- a/engine/editor/WorldEditorSession.h
+++ b/engine/editor/WorldEditorSession.h
@@ -20,7 +20,7 @@ namespace engine::core
 
 namespace engine::editor
 {
-	/// État éditeur (carte, chemins, brosses, grille) — logique sans ImGui.
+	/// Etat editeur (carte, chemins, brosses, grille) - logique sans ImGui.
 	class WorldEditorSession final
 	{
 	public:
@@ -34,11 +34,11 @@ namespace engine::editor
 
 		void SetStatus(std::string_view message);
 
-		/// Fichier JSON d’édition absolu (vide si jamais sauvegardé).
+		/// Fichier JSON d'edition absolu (vide si jamais sauvegarde).
 		const std::string& EditFileAbsolutePath() const { return m_editJsonAbsolutePath; }
 		void SetEditFileAbsolutePath(std::string path) { m_editJsonAbsolutePath = std::move(path); }
 
-		// Tampons pour l’UI (ImGui InputText)
+		// Tampons pour l'UI (ImGui InputText)
 		std::array<char, 128>& BufZoneId() { return m_bufZoneId; }
 		std::array<char, 32>& BufSize() { return m_bufSize; }
 		std::array<char, 32>& BufSeed() { return m_bufSeed; }
@@ -67,34 +67,34 @@ namespace engine::editor
 		[[nodiscard]] const TreeSpeciesCatalog& TreeCatalog() const { return m_treeCatalog; }
 		/// Charge une fois `world_editor/tree_species_catalog.json` et resynchronise les instances (clamp).
 		void EnsureTreeCatalogLoaded(const engine::core::Config& cfg);
-		/// Sélection liste instances (−1 = aucune) : prochain clic pose une nouvelle instance, sinon déplace la sélectionnée.
+		/// Selection liste instances (-1 = aucune) : prochain clic pose une nouvelle instance, sinon deplace la selectionnee.
 		int& SelectedLayoutInstanceIndex() { return m_selectedLayoutInstance; }
 
-		/// Mode herbe : si vrai, la brosse retire le masque au lieu de l’ajouter.
+		/// Mode herbe : si vrai, la brosse retire le masque au lieu de l'ajouter.
 		bool& GrassMaskEraseBrush() { return m_grassMaskEraseBrush; }
 
 		/// Brouillon polyligne route (011) : points monde XZ (clics terrain).
 		std::vector<std::pair<double, double>>& RouteDraftPoints() { return m_routeDraftXz; }
 		const std::vector<std::pair<double, double>>& RouteDraftPoints() const { return m_routeDraftXz; }
 		void ClearRouteDraft();
-		/// Ajoute un point (déjà clampé côté moteur aux limites du terrain).
+		/// Ajoute un point (deja clampe cote moteur aux limites du terrain).
 		void AddRouteDraftPoint(double worldX, double worldZ);
-		/// Largeur bande route (m) et couche splat cible pour l’application sur le SLAP.
+		/// Largeur bande route (m) et couche splat cible pour l'application sur le SLAP.
 		float& RouteStripWidthM() { return m_routeStripWidthM; }
 		int& RouteSplatLayer() { return m_routeSplatLayer; }
 
-		/// UI « Appliquer sur splat » : traité par l’Engine (peinture + flush + doc.routes).
+		/// UI " Appliquer sur splat " : traite par l'Engine (peinture + flush + doc.routes).
 		void RequestApplyRouteDraftToSplat();
 		[[nodiscard]] bool ConsumeRouteApplyDraftRequest();
 
-		/// Place une nouvelle instance ou déplace celle sélectionnée (coords monde, Y au sol).
+		/// Place une nouvelle instance ou deplace celle selectionnee (coords monde, Y au sol).
 		void PlaceOrMoveLayoutInstanceAtTerrainHit(const engine::core::Config& cfg, double worldX, double worldY, double worldZ);
 		void RemoveLayoutInstance(size_t index);
 
-		/// Appelé avant l’écriture du JSON d’édition pour persister heightmap / splat sur disque (Vulkan).
+		/// Appele avant l'ecriture du JSON d'edition pour persister heightmap / splat sur disque (Vulkan).
 		void SetTerrainSaveHook(std::function<bool(const engine::core::Config&, const WorldMapEditDocument&)> hook);
 
-		/// Crée une carte plate sous \c world_editor/maps/<id>/ (content).
+		/// Cree une carte plate sous \c world_editor/maps/<id>/ (content).
 		bool ActionNewMap(const engine::core::Config& cfg);
 
 		bool ActionSaveEditJson(const engine::core::Config& cfg);
@@ -104,21 +104,21 @@ namespace engine::editor
 		bool ActionImportAudio(const engine::core::Config& cfg);
 
 		/// Sauvegarde dans le chemin canonique \c world_editor/maps/<zone_id>/map.lcdlln_edit.json
-		/// (déduit de \c m_doc.zoneId — pas besoin de saisir un chemin).
+		/// (deduit de \c m_doc.zoneId - pas besoin de saisir un chemin).
 		bool ActionSaveCurrentMap(const engine::core::Config& cfg);
 
 		/// Charge \c world_editor/maps/<zoneId>/map.lcdlln_edit.json (chemin canonique).
 		bool ActionLoadMapByZoneId(const engine::core::Config& cfg, std::string_view zoneId);
 
-		/// Sous-répertoire du content où vivent toutes les cartes de l'éditeur.
+		/// Sous-repertoire du content ou vivent toutes les cartes de l'editeur.
 		static constexpr const char* kMapsContentRelativeDir = "world_editor/maps";
-		/// Nom de fichier canonique du JSON d'édition d'une carte.
+		/// Nom de fichier canonique du JSON d'edition d'une carte.
 		static constexpr const char* kEditDocFilename = "map.lcdlln_edit.json";
 
-		/// Chemin canonique absolu de la carte \p zoneId (inexistant ≠ erreur ; aucune E/S ici).
+		/// Chemin canonique absolu de la carte \p zoneId (inexistant != erreur ; aucune E/S ici).
 		static std::filesystem::path CanonicalMapJsonPath(const engine::core::Config& cfg, std::string_view zoneId);
 
-		/// Re-scan de \c world_editor/maps/ : remplit \ref AvailableMapIds() (zoneIds triés alphabétiquement).
+		/// Re-scan de \c world_editor/maps/ : remplit \ref AvailableMapIds() (zoneIds tries alphabetiquement).
 		void RefreshAvailableMaps(const engine::core::Config& cfg);
 		const std::vector<std::string>& AvailableMapIds() const { return m_availableMapIds; }
 		int& SelectedAvailableMapIndex() { return m_selectedAvailableMapIndex; }
@@ -126,9 +126,9 @@ namespace engine::editor
 		void SyncBuffersFromDoc();
 		void SyncDocIdFromBuffer();
 
-		/// Demande un rechargement du terrain GPU (après nouvelle carte / chargement JSON).
+		/// Demande un rechargement du terrain GPU (apres nouvelle carte / chargement JSON).
 		void RequestTerrainGpuReload();
-		/// \return true une fois par demande consommée (pour l’Engine).
+		/// \return true une fois par demande consommee (pour l'Engine).
 		bool ConsumeTerrainGpuReloadRequest();
 
 	private:

--- a/engine/editor/WorldMapEditDocument.h
+++ b/engine/editor/WorldMapEditDocument.h
@@ -8,78 +8,78 @@
 
 namespace engine::editor
 {
-	/// Polyligne « route » (ticket **011** branche A) : points monde XZ + largeur ; peinture sur une couche splat (ex. terre = macadam).
+	/// Polyligne " route " (ticket **011** branche A) : points monde XZ + largeur ; peinture sur une couche splat (ex. terre = macadam).
 	struct WorldMapRoutePolyline
 	{
 		std::vector<std::pair<double, double>> pointsXz;
 		double     widthM     = 4.0;
-		uint32_t splatLayer = 1u; ///< 0–3 (R,G,B,A) — défaut 1 = terre.
+		uint32_t splatLayer = 1u; ///< 0-3 (R,G,B,A) - defaut 1 = terre.
 	};
 
-	/// Instance décor / prop pour export `layout_from_editor.json` (schéma minimal \c zone_builder : \c guid, \c gltf, \c position).
+	/// Instance decor / prop pour export `layout_from_editor.json` (schema minimal \c zone_builder : \c guid, \c gltf, \c position).
 	struct WorldMapEditLayoutInstance
 	{
 		std::string guid;
 		/// Chemin glTF relatif au content (ex. \c zones/zone_0/zone_0.gltf).
 		std::string gltfContentRelativePath;
-		/// Position monde mètres (snap sol) — convertie à l’export en coordonnées attendues par \c LayoutImporter.
+		/// Position monde metres (snap sol) - convertie a l'export en coordonnees attendues par \c LayoutImporter.
 		double worldX = 0.0;
 		double worldY = 0.0;
 		double worldZ = 0.0;
 		double yawDegrees = 0.0;
 		double uniformScale = 1.0;
-		/// Ticket **013** : catalogue arbres (vide = prop générique type rocher / ancien combo 009).
+		/// Ticket **013** : catalogue arbres (vide = prop generique type rocher / ancien combo 009).
 		std::string speciesId;
 		uint32_t shapeVariantIndex = 0u;
 	};
 
-	/// Document d’édition carte (JSON lisible, versionné). Les chemins \c heightmap* sont relatifs à \c paths.content.
+	/// Document d'edition carte (JSON lisible, versionne). Les chemins \c heightmap* sont relatifs a \c paths.content.
 	struct WorldMapEditDocument
 	{
 		static constexpr int kFormatVersion = 1;
 
 		std::string zoneId = "untitled_zone";
 		int formatVersion = kFormatVersion;
-		/// Résolution N×N du heightmap (fichier .r16h).
+		/// Resolution NxN du heightmap (fichier .r16h).
 		uint32_t heightmapResolution = 256;
 		bool hasSeed = false;
 		int64_t seed = 0;
 		std::string heightmapContentRelativePath;
-		/// Splat RGBA (fichier SLAP, voir `TerrainEditingTools::SaveSplatMap`), relatif à \c paths.content.
+		/// Splat RGBA (fichier SLAP, voir `TerrainEditingTools::SaveSplatMap`), relatif a \c paths.content.
 		std::string splatmapContentRelativePath;
-		/// Masque herbe / détail surface R8 (fichier GRMS, ticket 010), même résolution que la splat, relatif au content.
+		/// Masque herbe / detail surface R8 (fichier GRMS, ticket 010), meme resolution que la splat, relatif au content.
 		std::string grassMaskContentRelativePath;
 		std::vector<std::string> textureAssets;
-		/// Liste des sons importés par l'éditeur (chemins relatifs au content, ex. \c audio/footstep/sand.wav).
-		/// Persisté en JSON (clé \c audio_assets). Sert de catalogue pour les dropdowns « son de pas par couche »
-		/// et pour la persistance générale des sons utilisés par cette carte.
+		/// Liste des sons importes par l'editeur (chemins relatifs au content, ex. \c audio/footstep/sand.wav).
+		/// Persiste en JSON (cle \c audio_assets). Sert de catalogue pour les dropdowns " son de pas par couche "
+		/// et pour la persistance generale des sons utilises par cette carte.
 		std::vector<std::string> audioAssets;
-		/// Mapping couche splat → texture importée (référence un chemin présent dans \c textureAssets).
-		/// Index : 0=Herbe (R), 1=Terre (G), 2=Roc (B), 3=Neige (A). Vide = couche par défaut moteur.
-		/// Persisté en JSON (clé \c splat_layer_texture_refs). Utilisé par l'export runtime pour
+		/// Mapping couche splat -> texture importee (reference un chemin present dans \c textureAssets).
+		/// Index : 0=Herbe (R), 1=Terre (G), 2=Roc (B), 3=Neige (A). Vide = couche par defaut moteur.
+		/// Persiste en JSON (cle \c splat_layer_texture_refs). Utilise par l'export runtime pour
 		/// substituer la texture engine-default par celle choisie par l'utilisateur.
 		std::array<std::string, 4> splatLayerTextureRefs{};
-		/// Mapping couche splat → son de pas (référence un chemin présent dans \c audioAssets).
-		/// Index : 0=Herbe (R), 1=Terre (G), 2=Roc (B), 3=Neige (A). Vide = aucun son spécifique.
-		/// Persisté en JSON (clé \c splat_layer_footstep_audio_refs). Le branchement gameplay (lecture
-		/// au déplacement du joueur en lisant la couche splat dominante sous ses pieds) sera fait dans
-		/// une itération ultérieure côté runtime du jeu — l'éditeur en assure déjà la persistance.
+		/// Mapping couche splat -> son de pas (reference un chemin present dans \c audioAssets).
+		/// Index : 0=Herbe (R), 1=Terre (G), 2=Roc (B), 3=Neige (A). Vide = aucun son specifique.
+		/// Persiste en JSON (cle \c splat_layer_footstep_audio_refs). Le branchement gameplay (lecture
+		/// au deplacement du joueur en lisant la couche splat dominante sous ses pieds) sera fait dans
+		/// une iteration ulterieure cote runtime du jeu - l'editeur en assure deja la persistance.
 		std::array<std::string, 4> splatLayerFootstepAudioRefs{};
-		/// Identifiants de préfabs / objets (MVP : chaînes libres).
+		/// Identifiants de prefabs / objets (MVP : chaines libres).
 		std::vector<std::string> objectPrefabIds;
 		/// Instances pour \c layout_from_editor.json (ticket 009).
 		std::vector<WorldMapEditLayoutInstance> layoutInstances;
-		/// Routes splat (ticket **011** A) : métadonnées ; le rendu persistant est dans le fichier SLAP.
+		/// Routes splat (ticket **011** A) : metadonnees ; le rendu persistant est dans le fichier SLAP.
 		std::vector<WorldMapRoutePolyline> routes;
 
-		/// Si vrai, \ref terrainWorldSizeM remplace `terrain.world_size` pour l’init terrain du World Editor (alignement zone logique).
+		/// Si vrai, \ref terrainWorldSizeM remplace `terrain.world_size` pour l'init terrain du World Editor (alignement zone logique).
 		bool   hasTerrainWorldSizeM = false;
 		double terrainWorldSizeM    = 10000.0;
 
-		/// Eau (Lot G) : si \c waterEnabled, une surface plane à \c waterLevelMeters (Y monde) doit être rendue.
-		/// Persisté en JSON (clés \c water_enabled, \c water_level_m). Le rendu effectif (passe Vulkan
-		/// transparent + shader simple) sera branché dans une itération moteur ultérieure — l'éditeur
-		/// expose déjà la donnée pour que la création de cartes avec eau soit possible dès maintenant.
+		/// Eau (Lot G) : si \c waterEnabled, une surface plane a \c waterLevelMeters (Y monde) doit etre rendue.
+		/// Persiste en JSON (cles \c water_enabled, \c water_level_m). Le rendu effectif (passe Vulkan
+		/// transparent + shader simple) sera branche dans une iteration moteur ulterieure - l'editeur
+		/// expose deja la donnee pour que la creation de cartes avec eau soit possible des maintenant.
 		bool   waterEnabled    = false;
 		double waterLevelMeters = 0.0;
 	};

--- a/engine/editor/WorldMapIo.cpp
+++ b/engine/editor/WorldMapIo.cpp
@@ -24,7 +24,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4505)
 #endif
-// Implémentation STB déjà dans AssetRegistry.cpp — pas de second STB_IMAGE_IMPLEMENTATION.
+// Implementation STB deja dans AssetRegistry.cpp - pas de second STB_IMAGE_IMPLEMENTATION.
 #include "stb_image.h"
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -239,12 +239,12 @@ namespace engine::editor
 
 		constexpr size_t kMaxJsonStringArrayEntries = 4096;
 
-		/// Lit une chaîne JSON à partir du guillemet ouvrant (avance \p p après le guillemet fermant).
+		/// Lit une chaine JSON a partir du guillemet ouvrant (avance \p p apres le guillemet fermant).
 		bool ReadJsonStringLiteral(std::string_view json, size_t& p, std::string& out, std::string& outError, std::string_view contextKey)
 		{
 			if (p >= json.size() || json[p] != '"')
 			{
-				outError = std::string(contextKey) + ": valeur chaîne attendue (guillemet ouvrant)";
+				outError = std::string(contextKey) + ": valeur chaine attendue (guillemet ouvrant)";
 				return false;
 			}
 			++p;
@@ -255,7 +255,7 @@ namespace engine::editor
 				{
 					if (p + 1 >= json.size())
 					{
-						outError = std::string(contextKey) + ": échappement '\\' incomplet";
+						outError = std::string(contextKey) + ": echappement '\\' incomplet";
 						return false;
 					}
 					p += 2;
@@ -269,11 +269,11 @@ namespace engine::editor
 				}
 				++p;
 			}
-			outError = std::string(contextKey) + ": chaîne JSON non terminée";
+			outError = std::string(contextKey) + ": chaine JSON non terminee";
 			return false;
 		}
 
-		/// Parse un tableau JSON de chaînes uniquement pour la clé \p key. Clé absente ou valeur `null` → \p out vide, succès.
+		/// Parse un tableau JSON de chaines uniquement pour la cle \p key. Cle absente ou valeur `null` -> \p out vide, succes.
 		bool ParseJsonStringArray(std::string_view json, std::string_view key, std::vector<std::string>& out, std::string& outError)
 		{
 			out.clear();
@@ -286,7 +286,7 @@ namespace engine::editor
 			size_t p = json.find(':', keyPos + needle.size());
 			if (p == std::string::npos)
 			{
-				outError = std::string(key) + ": ':' manquant après la clé";
+				outError = std::string(key) + ": ':' manquant apres la cle";
 				return false;
 			}
 			++p;
@@ -316,7 +316,7 @@ namespace engine::editor
 				}
 				if (out.size() >= kMaxJsonStringArrayEntries)
 				{
-					outError = std::string(key) + ": trop d'entrées (max " + std::to_string(kMaxJsonStringArrayEntries) + ")";
+					outError = std::string(key) + ": trop d'entrees (max " + std::to_string(kMaxJsonStringArrayEntries) + ")";
 					return false;
 				}
 				out.push_back(std::move(item));
@@ -331,7 +331,7 @@ namespace engine::editor
 					++p;
 					return true;
 				}
-				outError = std::string(key) + ": ',' ou ']' attendu après un élément";
+				outError = std::string(key) + ": ',' ou ']' attendu apres un element";
 				return false;
 			}
 		}
@@ -436,7 +436,7 @@ namespace engine::editor
 			return true;
 		}
 
-		/// Parse `terrain_world_size_m` (nombre ou null). Clé absente → pas d’override (succès).
+		/// Parse `terrain_world_size_m` (nombre ou null). Cle absente -> pas d'override (succes).
 		bool ParseOptionalTerrainWorldSizeM(std::string_view json, WorldMapEditDocument& d, std::string& outError)
 		{
 			constexpr std::string_view kKey = "terrain_world_size_m";
@@ -450,7 +450,7 @@ namespace engine::editor
 			size_t p = json.find(':', keyPos + needle.size());
 			if (p == std::string::npos)
 			{
-				outError = std::string(kKey) + ": ':' manquant après la clé";
+				outError = std::string(kKey) + ": ':' manquant apres la cle";
 				return false;
 			}
 			++p;
@@ -486,7 +486,7 @@ namespace engine::editor
 			}
 			if (v <= 0.0 || v > 1.0e7)
 			{
-				outError = std::string(kKey) + ": valeur hors plage (]0, 1e7] mètres)";
+				outError = std::string(kKey) + ": valeur hors plage (]0, 1e7] metres)";
 				return false;
 			}
 			d.hasTerrainWorldSizeM = true;
@@ -552,7 +552,7 @@ namespace engine::editor
 			SkipWs(obj, p);
 			if (p >= obj.size() || obj[p] != ',')
 			{
-				outError = std::string(key) + ": ',' après X";
+				outError = std::string(key) + ": ',' apres X";
 				return false;
 			}
 			++p;
@@ -564,7 +564,7 @@ namespace engine::editor
 			SkipWs(obj, p);
 			if (p >= obj.size() || obj[p] != ',')
 			{
-				outError = std::string(key) + ": ',' après Y";
+				outError = std::string(key) + ": ',' apres Y";
 				return false;
 			}
 			++p;
@@ -637,14 +637,14 @@ namespace engine::editor
 			p = obj.find(':', p + needle.size());
 			if (p == std::string::npos)
 			{
-				outError = "instance: ':' après clé optionnelle";
+				outError = "instance: ':' apres cle optionnelle";
 				return false;
 			}
 			++p;
 			SkipWs(obj, p);
 			if (p >= obj.size() || obj[p] != '"')
 			{
-				outError = std::string("instance: chaîne JSON attendue pour ") + std::string(key);
+				outError = std::string("instance: chaine JSON attendue pour ") + std::string(key);
 				return false;
 			}
 			++p;
@@ -655,7 +655,7 @@ namespace engine::editor
 				{
 					if (p + 1 >= obj.size())
 					{
-						outError = "instance: échappement incomplet";
+						outError = "instance: echappement incomplet";
 						return false;
 					}
 					p += 2;
@@ -687,7 +687,7 @@ namespace engine::editor
 			p = obj.find(':', p + needle.size());
 			if (p == std::string::npos)
 			{
-				outError = "instance: ':' après shape_variant";
+				outError = "instance: ':' apres shape_variant";
 				return false;
 			}
 			++p;
@@ -817,7 +817,7 @@ namespace engine::editor
 				}
 				if (p >= json.size())
 				{
-					outError = "instances: tableau non terminé";
+					outError = "instances: tableau non termine";
 					return false;
 				}
 				if (json[p] != '{')
@@ -831,7 +831,7 @@ namespace engine::editor
 				{
 					if (p >= json.size())
 					{
-						outError = "instances: accolade non fermée";
+						outError = "instances: accolade non fermee";
 						return false;
 					}
 					if (json[p] == '{')
@@ -861,7 +861,7 @@ namespace engine::editor
 				{
 					return true;
 				}
-				outError = "instances: ',' ou ']' attendu après un objet";
+				outError = "instances: ',' ou ']' attendu apres un objet";
 				return false;
 			}
 		}
@@ -879,7 +879,7 @@ namespace engine::editor
 			size_t p = obj.find(':', keyPos + needle.size());
 			if (p == std::string::npos)
 			{
-				outError = "route: ':' après points";
+				outError = "route: ':' apres points";
 				return false;
 			}
 			++p;
@@ -931,7 +931,7 @@ namespace engine::editor
 				}
 				if (p >= obj.size())
 				{
-					outError = "route: tableau points non terminé";
+					outError = "route: tableau points non termine";
 					return false;
 				}
 				if (obj[p] != '[')
@@ -944,25 +944,25 @@ namespace engine::editor
 				double vz = 0.0;
 				if (!readOneDouble(vx))
 				{
-					outError = "route: coordonnée X invalide";
+					outError = "route: coordonnee X invalide";
 					return false;
 				}
 				SkipWs(obj, p);
 				if (p >= obj.size() || obj[p] != ',')
 				{
-					outError = "route: ',' après X";
+					outError = "route: ',' apres X";
 					return false;
 				}
 				++p;
 				if (!readOneDouble(vz))
 				{
-					outError = "route: coordonnée Z invalide";
+					outError = "route: coordonnee Z invalide";
 					return false;
 				}
 				SkipWs(obj, p);
 				if (p >= obj.size() || obj[p] != ']')
 				{
-					outError = "route: ']' attendu après Z";
+					outError = "route: ']' attendu apres Z";
 					return false;
 				}
 				++p;
@@ -982,7 +982,7 @@ namespace engine::editor
 					}
 					return true;
 				}
-				outError = "route: ',' ou ']' attendu après un point";
+				outError = "route: ',' ou ']' attendu apres un point";
 				return false;
 			}
 		}
@@ -1052,7 +1052,7 @@ namespace engine::editor
 				}
 				if (p >= json.size())
 				{
-					outError = "routes: tableau non terminé";
+					outError = "routes: tableau non termine";
 					return false;
 				}
 				if (json[p] != '{')
@@ -1066,7 +1066,7 @@ namespace engine::editor
 				{
 					if (p >= json.size())
 					{
-						outError = "routes: accolade non fermée";
+						outError = "routes: accolade non fermee";
 						return false;
 					}
 					if (json[p] == '{')
@@ -1262,7 +1262,7 @@ namespace engine::editor
 		std::ofstream out(absolutePath, std::ios::binary | std::ios::trunc);
 		if (!out.is_open())
 		{
-			outError = "impossible d’ouvrir le fichier en écriture";
+			outError = "impossible d'ouvrir le fichier en ecriture";
 			return false;
 		}
 		out << "{\n";
@@ -1306,7 +1306,7 @@ namespace engine::editor
 		out << "}\n";
 		if (!out.good())
 		{
-			outError = "erreur d’écriture";
+			outError = "erreur d'ecriture";
 			return false;
 		}
 		return true;
@@ -1347,7 +1347,7 @@ namespace engine::editor
 		}
 		if (d.formatVersion > WorldMapEditDocument::kFormatVersion)
 		{
-			outError = "version document non supportée: " + std::to_string(d.formatVersion) + " (max " +
+			outError = "version document non supportee: " + std::to_string(d.formatVersion) + " (max " +
 			           std::to_string(WorldMapEditDocument::kFormatVersion) + ")";
 			return false;
 		}
@@ -1395,7 +1395,7 @@ namespace engine::editor
 		{
 			std::string parseErr;
 			(void)ParseJsonStringArray(json, "audio_assets", d.audioAssets, parseErr);
-			// Champ optionnel : absent dans les vieux JSON, on n'échoue pas.
+			// Champ optionnel : absent dans les vieux JSON, on n'echoue pas.
 		}
 		{
 			std::vector<std::string> refs;
@@ -1407,7 +1407,7 @@ namespace engine::editor
 					d.splatLayerTextureRefs[i] = refs[i];
 				}
 			}
-			// Champ optionnel : absent dans les vieux JSON, on n'échoue pas.
+			// Champ optionnel : absent dans les vieux JSON, on n'echoue pas.
 		}
 		{
 			std::vector<std::string> refs;
@@ -1419,7 +1419,7 @@ namespace engine::editor
 					d.splatLayerFootstepAudioRefs[i] = refs[i];
 				}
 			}
-			// Champ optionnel : absent dans les vieux JSON, on n'échoue pas.
+			// Champ optionnel : absent dans les vieux JSON, on n'echoue pas.
 		}
 		if (!ParseJsonLayoutInstances(json, d.layoutInstances, outError))
 		{
@@ -1433,7 +1433,7 @@ namespace engine::editor
 		{
 			return false;
 		}
-		// Eau (Lot G) — optionnel, défaut désactivé.
+		// Eau (Lot G) - optionnel, defaut desactive.
 		{
 			bool wEnabled = false;
 			if (ParseJsonBoolValue(json, "water_enabled", wEnabled))
@@ -1467,7 +1467,7 @@ namespace engine::editor
 		std::ofstream out(absolutePath, std::ios::binary | std::ios::trunc);
 		if (!out.is_open())
 		{
-			outError = "création heightmap impossible";
+			outError = "creation heightmap impossible";
 			return false;
 		}
 		const uint32_t magic = engine::render::terrain::kHeightmapMagic;
@@ -1481,7 +1481,7 @@ namespace engine::editor
 		}
 		if (!out.good())
 		{
-			outError = "écriture heightmap incomplète";
+			outError = "ecriture heightmap incomplete";
 			return false;
 		}
 		return true;
@@ -1499,7 +1499,7 @@ namespace engine::editor
 		std::ofstream out(absolutePath, std::ios::binary | std::ios::trunc);
 		if (!out.is_open())
 		{
-			outError = "création splat impossible";
+			outError = "creation splat impossible";
 			return false;
 		}
 		const uint32_t magic = engine::render::terrain::kTerrainSplatFileMagic;
@@ -1517,7 +1517,7 @@ namespace engine::editor
 		}
 		if (!out.good())
 		{
-			outError = "écriture splat incomplète";
+			outError = "ecriture splat incomplete";
 			return false;
 		}
 		return true;
@@ -1539,7 +1539,7 @@ namespace engine::editor
 		std::filesystem::copy_file(srcHm, dstHm, std::filesystem::copy_options::overwrite_existing, ec);
 		if (ec)
 		{
-			outError = "copie heightmap échouée: " + ec.message();
+			outError = "copie heightmap echouee: " + ec.message();
 			return false;
 		}
 
@@ -1551,13 +1551,13 @@ namespace engine::editor
 			{
 				if (!ContentRelativePathHasNoTraversal(relSm))
 				{
-					outError = "chemin splatmap refusé (relatif au content, sans ..) : " + doc.splatmapContentRelativePath;
+					outError = "chemin splatmap refuse (relatif au content, sans ..) : " + doc.splatmapContentRelativePath;
 					return false;
 				}
 				const std::filesystem::path srcSm = engine::platform::FileSystem::ResolveContentPath(cfg, relSm);
 				if (!engine::platform::FileSystem::Exists(srcSm))
 				{
-					LOG_WARN(Core, "[WorldEditor] Export runtime : splatmap absent, ignoré → {} (terrain_splatmap=null)",
+					LOG_WARN(Core, "[WorldEditor] Export runtime : splatmap absent, ignore -> {} (terrain_splatmap=null)",
 						srcSm.string());
 				}
 				else
@@ -1566,7 +1566,7 @@ namespace engine::editor
 					std::filesystem::copy_file(srcSm, dstSm, std::filesystem::copy_options::overwrite_existing, ec);
 					if (ec)
 					{
-						outError = "copie splatmap échouée: " + ec.message();
+						outError = "copie splatmap echouee: " + ec.message();
 						return false;
 					}
 					terrainSplatBundledPosix = std::string("zones/") + zid + "/terrain_splat.slap";
@@ -1582,13 +1582,13 @@ namespace engine::editor
 			{
 				if (!ContentRelativePathHasNoTraversal(relGm))
 				{
-					outError = "chemin grass_mask refusé (relatif au content, sans ..) : " + doc.grassMaskContentRelativePath;
+					outError = "chemin grass_mask refuse (relatif au content, sans ..) : " + doc.grassMaskContentRelativePath;
 					return false;
 				}
 				const std::filesystem::path srcGm = engine::platform::FileSystem::ResolveContentPath(cfg, relGm);
 				if (!engine::platform::FileSystem::Exists(srcGm))
 				{
-					LOG_WARN(Core, "[WorldEditor] Export runtime : grass_mask absent, ignoré → {} (terrain_grass_mask=null)",
+					LOG_WARN(Core, "[WorldEditor] Export runtime : grass_mask absent, ignore -> {} (terrain_grass_mask=null)",
 						srcGm.string());
 				}
 				else
@@ -1597,7 +1597,7 @@ namespace engine::editor
 					std::filesystem::copy_file(srcGm, dstGm, std::filesystem::copy_options::overwrite_existing, ec);
 					if (ec)
 					{
-						outError = "copie grass_mask échouée: " + ec.message();
+						outError = "copie grass_mask echouee: " + ec.message();
 						return false;
 					}
 					terrainGrassBundledPosix = std::string("zones/") + zid + "/terrain_grass.grms";
@@ -1610,7 +1610,7 @@ namespace engine::editor
 			std::ofstream meta(metaPath, std::ios::binary | std::ios::trunc);
 			if (!meta.is_open())
 			{
-				outError = "écriture zone.meta impossible";
+				outError = "ecriture zone.meta impossible";
 				return false;
 			}
 			engine::world::OutputVersionHeader hdr{};
@@ -1639,13 +1639,13 @@ namespace engine::editor
 			}
 			if (!ContentRelativePathHasNoTraversal(rel))
 			{
-				outError = "chemin texture refusé (relatif au content, sans ..) : " + raw;
+				outError = "chemin texture refuse (relatif au content, sans ..) : " + raw;
 				return false;
 			}
 			const std::filesystem::path srcTex = engine::platform::FileSystem::ResolveContentPath(cfg, rel);
 			if (!engine::platform::FileSystem::Exists(srcTex))
 			{
-				LOG_WARN(Core, "[WorldEditor] Export runtime : texture absente, ignorée → {}", rel);
+				LOG_WARN(Core, "[WorldEditor] Export runtime : texture absente, ignoree -> {}", rel);
 				missingTextureRelPosix.push_back(rel);
 				continue;
 			}
@@ -1654,7 +1654,7 @@ namespace engine::editor
 			std::filesystem::create_directories(dstTex.parent_path(), ec);
 			if (ec)
 			{
-				outError = "création dossier export textures : " + ec.message();
+				outError = "creation dossier export textures : " + ec.message();
 				return false;
 			}
 			std::filesystem::copy_file(srcTex, dstTex, std::filesystem::copy_options::overwrite_existing, ec);
@@ -1671,7 +1671,7 @@ namespace engine::editor
 			std::ofstream man(manifestPath, std::ios::binary | std::ios::trunc);
 			if (!man.is_open())
 			{
-				outError = "écriture manifest impossible";
+				outError = "ecriture manifest impossible";
 				return false;
 			}
 			man << "{\n";
@@ -1707,7 +1707,7 @@ namespace engine::editor
 			man << "  \"exported_textures\": " << SerializeTexturesArray(exportedTextureRelPosix) << ",\n";
 			man << "  \"texture_assets_source_missing\": " << SerializeTexturesArray(missingTextureRelPosix) << ",\n";
 			man << "  \"object_prefab_ids\": " << SerializeTexturesArray(doc.objectPrefabIds) << ",\n";
-			man << "  \"note\": \"Paquet produit par lcdlln_world_editor — textures copiées sous exported_textures/ ; brancher zone_builder / streaming selon pipeline jeu.\"\n";
+			man << "  \"note\": \"Paquet produit par lcdlln_world_editor - textures copiees sous exported_textures/ ; brancher zone_builder / streaming selon pipeline jeu.\"\n";
 			man << "}\n";
 		}
 
@@ -1716,7 +1716,7 @@ namespace engine::editor
 			std::ofstream lay(layoutPath, std::ios::binary | std::ios::trunc);
 			if (!lay.is_open())
 			{
-				outError = "écriture layout_from_editor.json impossible";
+				outError = "ecriture layout_from_editor.json impossible";
 				return false;
 			}
 			const double originX = cfg.GetDouble("terrain.origin_x", -512.0);
@@ -1724,12 +1724,12 @@ namespace engine::editor
 			WriteLayoutForZoneBuilder(lay, doc, originX, originZ);
 			if (!lay.good())
 			{
-				outError = "écriture layout_from_editor.json incomplète";
+				outError = "ecriture layout_from_editor.json incomplete";
 				return false;
 			}
 		}
 
-		LOG_INFO(Core, "[WorldEditor] Export runtime OK → {} (textures exportées: {}, absentes: {})", zoneDir.string(),
+		LOG_INFO(Core, "[WorldEditor] Export runtime OK -> {} (textures exportees: {}, absentes: {})", zoneDir.string(),
 			exportedTextureRelPosix.size(), missingTextureRelPosix.size());
 		return true;
 	}
@@ -1756,7 +1756,7 @@ namespace engine::editor
 		}
 		if (rel.find("..") != std::string::npos)
 		{
-			outError = "nom destination invalide (traversée '..' interdite)";
+			outError = "nom destination invalide (traversee '..' interdite)";
 			return false;
 		}
 
@@ -1767,7 +1767,7 @@ namespace engine::editor
 		if (!pixels || w <= 0 || h <= 0)
 		{
 			const char* reason = stbi_failure_reason();
-			outError = std::string("lecture image échouée: ") + (reason ? reason : "format non supporté (PNG/JPG/TGA/BMP attendu)");
+			outError = std::string("lecture image echouee: ") + (reason ? reason : "format non supporte (PNG/JPG/TGA/BMP attendu)");
 			if (pixels)
 			{
 				stbi_image_free(pixels);
@@ -1800,10 +1800,10 @@ namespace engine::editor
 		stbi_image_free(pixels);
 		if (!out.good())
 		{
-			outError = "écriture .texr incomplète";
+			outError = "ecriture .texr incomplete";
 			return false;
 		}
-		LOG_INFO(Core, "[WorldEditor] Import PNG → TEXR OK: {}", destAbs.string());
+		LOG_INFO(Core, "[WorldEditor] Import PNG -> TEXR OK: {}", destAbs.string());
 		return true;
 	}
 
@@ -1828,7 +1828,7 @@ namespace engine::editor
 		}
 		if (rel.find("..") != std::string::npos)
 		{
-			outError = "nom destination invalide (traversée '..' interdite)";
+			outError = "nom destination invalide (traversee '..' interdite)";
 			return false;
 		}
 		const std::filesystem::path destRel = std::filesystem::path("audio") / rel;
@@ -1838,10 +1838,10 @@ namespace engine::editor
 		std::filesystem::copy_file(srcAbsolutePath, destAbs, std::filesystem::copy_options::overwrite_existing, ec);
 		if (ec)
 		{
-			outError = "copie audio échouée: " + ec.message() + " (vers " + destAbs.string() + ")";
+			outError = "copie audio echouee: " + ec.message() + " (vers " + destAbs.string() + ")";
 			return false;
 		}
-		LOG_INFO(Core, "[WorldEditor] Import audio OK → {}", destAbs.string());
+		LOG_INFO(Core, "[WorldEditor] Import audio OK -> {}", destAbs.string());
 		return true;
 	}
 


### PR DESCRIPTION
La police Windlass.ttf utilisee par l'editeur ne couvre pas le Latin-1 supplement (E majuscule accentue, e accent grave/aigu, c cedille, a accent grave, guillemets francais, fleches, em-dash, etc.) ni les crochets droits dans certaines variantes. Tous les caracteres absents s'affichaient en '?' dans l'UI (visible sur la capture utilisateur : "?SAUVEGARDER?", "RAFRA?CHIR", "TROUV?E", "CR?ER", "ESP?CE", etc.).

Convention de la base : voir CODEBASE_MAP.md sec. 13.5 "Limitations Windlass.ttf" - les libelles UI doivent rester en ASCII pur jusqu'a ce qu'une font fallback couvrant 0x0080-0x00FF soit fusionnee dans l'atlas ImGui.

Ce commit applique la meme regle a tous les fichiers touches par les Lots A-H : remplacement systematique des caracteres accentues par leur equivalent ASCII (a, e, i, o, u, c, n - majuscules et minuscules), des guillemets francais << >> par ' (ou suppression), des fleches -> par ->, em/en-dash par -, points de suspension par '...', symbole degree par 'deg', x mathematique par 'x', signes != / ~= remplaces.

Couvre :
- Tous les libelles ImGui (TextUnformatted, TextDisabled, Button, MenuItem, BeginMenu, BeginTabItem, Begin, InputTextWithHint, CollapsingHeader, Combo labels, Slider labels, Checkbox labels)
- Tous les SetStatus(...) renvoyes a l'utilisateur
- Tous les commentaires et messages de log (laisses ASCII pour coherence visuelle dans les editeurs de code)

Bonus : retrait des crochets droits des libelles "[Sauvegarder]" et "[Charger une carte]" dans la barre de menu (Windlass ne rend pas non plus '[' et ']' correctement dans les boutons MainMenuBar).

Egalement corrigees : les chaines C++ qui contenaient des guillemets francais << X >> et que la translitteration mecanique a transforme en '" X "' (ce qui rompait le litteral string) - remplacees par 'X' ou similaire :
  - WorldEditorSession.cpp:216 'Utilisez Rocher'
  - WorldEditorImGui.cpp:673  panneau 'Carte'
  - WorldEditorImGui.cpp:725  menu 'Options'
  - WorldEditorImGui.cpp:741  grille 'figee'
  - WorldEditorImGui.cpp:765  cliquez sur 'Rafraichir la liste'
  - WorldEditorImGui.cpp:964  panneau 'Import assets'
  - WorldEditorImGui.cpp:1021 panneau 'Objets sur la carte'
  - WorldEditorImGui.cpp:1077 puis 'Tracer la route'

Verification finale : python3 -c 'sum(b>127 for b in open(f,"rb").read())' renvoie 0 pour les 5 fichiers editeur touches.

https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR