### PR TITLE
feat(world-editor): disposition par defaut docked au demarrage (P1)

### DIFF
--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -30,6 +30,7 @@
 #	include <windows.h>
 
 #	include "imgui.h"
+#	include "imgui_internal.h" // DockBuilder* (public mais declare dans l'en-tete internal)
 #	include "imgui_impl_vulkan.h"
 #	include "imgui_impl_win32.h"
 	// ImGui 1.91+ : la declaration n'est plus dans l'en-tete (#if 0) pour eviter HWND dans l'API publique.
@@ -609,14 +610,19 @@ namespace engine::editor
 			{
 				if (ImGui::MenuItem("Reinitialiser la disposition des fenetres"))
 				{
-					// Supprime le fichier .ini ; ImGui ne reecrit pas la disposition tant que le contexte
-					// vit. La reinitialisation visible prend effet au prochain lancement de l'editeur.
-					// (ImGui::ClearIniSettings n'est pas disponible dans la version d'ImGui utilisee ici.)
+					// Reinitialisation in-process : on retire le node DockBuilder courant et on
+					// repasse m_defaultLayoutAttempted a false. La frame suivante reconstruit la
+					// disposition par defaut via le bloc DockBuilder en haut de BuildUi().
+					const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpace");
+					ImGui::DockBuilderRemoveNode(dockId);
+					m_defaultLayoutAttempted = false;
+					// Supprime aussi le fichier .ini pour que la reinitialisation persiste apres
+					// le redemarrage (sinon ImGui rechargerait l'ancienne disposition au prochain run).
 					std::error_code ec;
 					std::filesystem::remove("world_editor_imgui.ini", ec);
 					if (m_session)
 					{
-						m_session->SetStatus("Disposition reinitialisee - l'effet sera visible au prochain demarrage.");
+						m_session->SetStatus("Disposition reinitialisee.");
 					}
 				}
 				ImGui::Separator();
@@ -714,7 +720,53 @@ namespace engine::editor
 		{
 			const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpace");
 			// ImGuiDockNodeFlags_PassthroughCentralNode (1<<4) - litteral pour eviter les divergences d'en-tetes.
-			ImGui::DockSpace(dockId, ImVec2(0.f, 0.f), static_cast<ImGuiDockNodeFlags>(1u << 4));
+			constexpr ImGuiDockNodeFlags kDockSpaceFlags = static_cast<ImGuiDockNodeFlags>(1u << 4);
+
+			// Disposition par defaut : si ImGui n'a pas charge de layout depuis world_editor_imgui.ini
+			// (premier demarrage, fichier supprime via le menu Vue, ou nouveau dockId), on pose une
+			// disposition propre (palette gauche, inspecteur droite, scene centrale, statut bas) via
+			// l'API DockBuilder. La tentative ne se fait qu'une fois par session - sinon, l'utilisateur
+			// qui re-dispose ses panneaux les verrait reposer chaque frame.
+			if (!m_defaultLayoutAttempted)
+			{
+				m_defaultLayoutAttempted = true;
+				if (ImGui::DockBuilderGetNode(dockId) == nullptr)
+				{
+					ImGui::DockBuilderRemoveNode(dockId);
+					ImGui::DockBuilderAddNode(dockId, kDockSpaceFlags | ImGuiDockNodeFlags_DockSpace);
+					ImGui::DockBuilderSetNodeSize(dockId, vp->WorkSize);
+
+					ImGuiID idLeft = 0;
+					ImGuiID idCenter = dockId;
+					ImGui::DockBuilderSplitNode(idCenter, ImGuiDir_Left, 0.22f, &idLeft, &idCenter);
+
+					ImGuiID idRight = 0;
+					ImGui::DockBuilderSplitNode(idCenter, ImGuiDir_Right, 0.30f, &idRight, &idCenter);
+
+					ImGuiID idBottom = 0;
+					ImGui::DockBuilderSplitNode(idCenter, ImGuiDir_Down, 0.18f, &idBottom, &idCenter);
+
+					// Palette outils : a gauche, c'est la zone d'action principale.
+					ImGui::DockBuilderDockWindow("Outils", idLeft);
+
+					// Inspecteur : panneaux carte / affichage / import / objets sont des onglets a droite.
+					ImGui::DockBuilderDockWindow("Carte", idRight);
+					ImGui::DockBuilderDockWindow("Affichage & grille", idRight);
+					ImGui::DockBuilderDockWindow("Import assets", idRight);
+					ImGui::DockBuilderDockWindow("Objets sur la carte", idRight);
+
+					// Statut en bas, plein largeur.
+					ImGui::DockBuilderDockWindow("Statut", idBottom);
+
+					// La fenetre Scene ne capture pas la souris (ImGuiWindowFlags_NoMouseInputs) ;
+					// on la place dans le node central pour qu'elle remplisse l'espace 3D restant.
+					ImGui::DockBuilderDockWindow("Scene", idCenter);
+
+					ImGui::DockBuilderFinish(dockId);
+				}
+			}
+
+			ImGui::DockSpace(dockId, ImVec2(0.f, 0.f), kDockSpaceFlags);
 		}
 		ImGui::End();
 		ImGui::PopStyleVar(3);

--- a/engine/editor/WorldEditorImGui.h
+++ b/engine/editor/WorldEditorImGui.h
@@ -111,6 +111,10 @@ namespace engine::editor
 		void* m_hwnd = nullptr;
 		WorldEditorSession* m_session = nullptr;
 		engine::core::Config* m_cfg = nullptr;
+		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
+		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
+		/// repassé à true après la pose.
+		bool m_defaultLayoutAttempted = false;
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 #endif


### PR DESCRIPTION
## Contexte

Suite directe de la PR #403 (refonte World Editor 8 lots) et de la PR #406 (fix ASCII glyphs).

Sur la capture d'écran utilisateur post-merge #403, on voyait que tous les panneaux ImGui de l'éditeur (Carte, Outils, Affichage & grille, Import assets, Objets sur la carte, Statut, Scène) **flottaient tous au même endroit, en pile**, parce qu'aucune disposition par défaut n'était posée. L'utilisateur devait dragger chaque panneau à la main par sa barre de titre pour obtenir une disposition utilisable.

## Changement

Au premier lancement (ou après un « Vue → Réinitialiser la disposition »), pose d'une disposition par défaut via l'API `ImGui::DockBuilder*` (branche docking de Dear ImGui) :

```
+----------+--------------------------------+----------+
|          |                                |  Carte   |
|          |                                |  Aff/grl |  
| Outils   |          Scene (3D)            |  Import  |
| (left    |          (center,              |  Objets  |
|  ~22%)   |        passthrough)            |  (right  |
|          |                                |   ~30%,  |
|          |                                | onglets) |
|          +--------------------------------+----------+
|          |             Statut (bas, ~18%)            |
+----------+-------------------------------------------+
```

## Mécanique

- `WorldEditorImGui` acquiert un membre `m_defaultLayoutAttempted` (bool).
- Au premier appel à `BuildUi()` après init, si `DockBuilderGetNode(dockId) == nullptr` (i.e. ni `.ini` chargé, ni layout déjà posé), on construit via :
  1. `DockBuilderRemoveNode(dockId)` (clean)
  2. `DockBuilderAddNode(dockId, kFlags | DockSpace)`
  3. `DockBuilderSetNodeSize(dockId, vp->WorkSize)`
  4. 3× `DockBuilderSplitNode` (gauche → droite → bas)
  5. `DockBuilderDockWindow` pour chaque panneau
  6. `DockBuilderFinish(dockId)`
- Le flag est verrouillé à `true` pour la session, sinon les re-arrangements utilisateur seraient écrasés chaque frame.

## Bonus : reset fonctionnel en process

Le menu **Vue → Réinitialiser la disposition des fenêtres** devient enfin opérationnel sans redémarrage : `DockBuilderRemoveNode` + remise du flag à `false` déclenche la reconstruction au prochain frame. Le `.ini` est aussi supprimé pour persistance.

## Test plan

- [ ] Build Windows + Linux passent
- [ ] Lancer l'éditeur **sans** `world_editor_imgui.ini` existant → la disposition se présente directement avec Outils à gauche, Carte/Import/Objets en onglets à droite, Statut en bas, Scene au centre
- [ ] Dragger un panneau à un autre endroit → fermer/relancer → la disposition utilisateur est persistée (le `.ini` est lu en priorité, pas écrasé)
- [ ] Cliquer Vue → Réinitialiser la disposition → la disposition par défaut est restaurée immédiatement (pas besoin de redémarrer)
- [ ] Vérifier que la branche `claude/fix-world-editor-ascii-glyphs` (PR #406) est toujours mergeable après ce changement (les deux modifient `WorldEditorImGui.cpp` mais à des endroits disjoints)

## À planifier ensuite (suite de la file P1→P5)

- P2 — Passe Vulkan eau (rendu surface plane transparente à `waterLevelMeters` Y)
- P3 — Footstep audio runtime (sample splat sous le joueur + lecture)
- P4 — Skip bloom/TAA en mode éditeur (perfs)
- P5 — Fallback font Latin-1 dans l'atlas ImGui (réintroduction des accents)

https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR)_