### PR TITLE
feat(world-editor): export footstep audio refs dans manifest (P3.1)

### DIFF
--- a/engine/editor/WorldMapIo.cpp
+++ b/engine/editor/WorldMapIo.cpp
@@ -1675,7 +1675,7 @@ namespace engine::editor
 				return false;
 			}
 			man << "{\n";
-			man << "  \"lcdlln_runtime_manifest_version\": 3,\n";
+			man << "  \"lcdlln_runtime_manifest_version\": 4,\n";
 			man << "  \"zone_id\": \"" << EscapeJson(zid) << "\",\n";
 			man << "  \"terrain_heightmap\": \"zones/" << EscapeJson(zid) << "/terrain_height.r16h\",\n";
 			if (!terrainSplatBundledPosix.empty())
@@ -1706,6 +1706,15 @@ namespace engine::editor
 			man << "  \"texture_assets\": " << SerializeTexturesArray(doc.textureAssets) << ",\n";
 			man << "  \"exported_textures\": " << SerializeTexturesArray(exportedTextureRelPosix) << ",\n";
 			man << "  \"texture_assets_source_missing\": " << SerializeTexturesArray(missingTextureRelPosix) << ",\n";
+			// P3.1 (Lot E runtime) : reference catalogue audio + mapping son-de-pas par couche splat.
+			// Le runtime jeu utilisera ces references pour enregistrer dynamiquement les sons dans
+			// AudioEngine et les declencher au sampling de la splat dominante sous le joueur.
+			// Le manifest bump 3 -> 4 traduit l'ajout ; les anciens runtimes (v3) ignorent ces clefs.
+			man << "  \"audio_assets\": " << SerializeTexturesArray(doc.audioAssets) << ",\n";
+			{
+				std::vector<std::string> footstepRefs(doc.splatLayerFootstepAudioRefs.begin(), doc.splatLayerFootstepAudioRefs.end());
+				man << "  \"splat_layer_footstep_audio_refs\": " << SerializeTexturesArray(footstepRefs) << ",\n";
+			}
 			man << "  \"object_prefab_ids\": " << SerializeTexturesArray(doc.objectPrefabIds) << ",\n";
 			man << "  \"note\": \"Paquet produit par lcdlln_world_editor - textures copiees sous exported_textures/ ; brancher zone_builder / streaming selon pipeline jeu.\"\n";
 			man << "}\n";


### PR DESCRIPTION
## Contexte

Premier sous-lot de **P3 — Footstep audio runtime** (l'utilisateur entend un son de pas adapté à la couche splat sous ses pieds : sable, neige, herbe, cailloux).

P3 est découpé en 5 sous-PRs indépendantes :

- **P3.1** — Export du mapping dans `runtime_manifest.json` *(cette PR)*
- P3.2 — Lecture runtime + enregistrement dynamique dans `AudioEngine`
- P3.3 — Utilitaire CPU `SampleDominantSplatLayerAtWorldXZ` + accès splat CPU côté game
- P3.4 — Hook `CharacterController` (cadence pas par vélocité + `Play3D`)
- P3.5 — Tests unitaires (sampling + cadence)

## Changement

L'éditeur persistait déjà le mapping splat→son de pas dans le JSON d'édition (Lot E, champs `WorldMapEditDocument::audioAssets` et `splatLayerFootstepAudioRefs[4]`). Mais `ExportRuntimeBundle` ignorait ces champs lors de la production de `runtime_manifest.json` → le runtime jeu n'avait aucune information pour déclencher les sons.

Ajout de deux clefs dans `runtime_manifest.json` :

| Clef | Valeur | Description |
|---|---|---|
| `audio_assets` | `[ "audio/footstep/sand.wav", ... ]` | Catalogue complet des sons importés (chemins content-relatifs) |
| `splat_layer_footstep_audio_refs` | `[ "audio/grass.wav", "audio/dirt.wav", "audio/rock.wav", "audio/snow.wav" ]` | Tableau de 4 chaînes, une par couche (R/G/B/A = herbe/terre/roc/neige). Chaîne vide = aucun son |

**Bump manifest version : 3 → 4**. Les runtimes pré-P3.2 (v3 reader) ignorent simplement les nouvelles clefs — aucune régression sur l'existant.

## Test plan

- [ ] CI Linux + Windows verts (build seul)
- [ ] Manuel : lancer l'éditeur, importer un audio (panneau Import assets), assigner ce son à une couche splat (panneau Outils → Peindre → Sons de pas), cliquer **Exporter en runtime**
- [ ] Ouvrir `<content>/zones/<zone_id>/runtime_manifest.json` → vérifier que `lcdlln_runtime_manifest_version: 4`, `audio_assets: [...]`, `splat_layer_footstep_audio_refs: [...]`

## Note

Cette PR ne modifie aucun comportement runtime — c'est purement une extension du format d'export. Le hook gameplay viendra dans P3.2 → P3.4.

https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR)_