### PR TITLE
feat(audio): registration dynamique des sons de pas depuis manifest (P3.2)

### DIFF
--- a/engine/audio/AudioEngine.cpp
+++ b/engine/audio/AudioEngine.cpp
@@ -64,11 +64,104 @@ namespace engine::audio
 			return false;
 		}
 
+		// P3.2 -- Sons de pas par couche splat : si la config pointe sur un runtime_manifest.json
+		// produit par lcdlln_world_editor, on enregistre les 4 sons _footstep_layer_<n>.
+		// Echec ici n'est pas fatal : le jeu peut tourner sans sons de pas (ex. zone neutre).
+		const std::string footstepManifestRel = config.GetString("audio.footstep_manifest_path", "");
+		if (!footstepManifestRel.empty())
+		{
+			const std::filesystem::path manifestAbs =
+				engine::platform::FileSystem::ResolveContentPath(config, footstepManifestRel);
+			if (!RegisterFootstepSoundsFromManifest(manifestAbs))
+			{
+				LOG_WARN(Core, "[AudioEngine] Footstep manifest registration failed (path='{}')",
+					footstepManifestRel);
+			}
+		}
+
 		m_initialized = true;
 		LOG_INFO(Core, "[AudioEngine] Init OK (3D=logical, menu_music=miniaudio if used, buses={}, sounds={}, zones={})",
 			static_cast<uint32_t>(m_buses.size()),
 			static_cast<uint32_t>(m_sounds.size()),
 			static_cast<uint32_t>(m_zoneAmbience.size()));
+		return true;
+	}
+
+	std::string AudioEngine::FootstepSoundIdForLayer(uint32_t layer)
+	{
+		return std::string("_footstep_layer_") + std::to_string(layer);
+	}
+
+	bool AudioEngine::RegisterFootstepSoundsFromManifest(const std::filesystem::path& manifestAbsolutePath)
+	{
+		if (m_config == nullptr)
+		{
+			LOG_ERROR(Core, "[AudioEngine] RegisterFootstepSoundsFromManifest FAILED: missing config (call Init first)");
+			return false;
+		}
+		engine::core::Config manifest;
+		if (!manifest.LoadFromFile(manifestAbsolutePath.string()))
+		{
+			LOG_ERROR(Core, "[AudioEngine] RegisterFootstepSoundsFromManifest FAILED: unable to read '{}'",
+				manifestAbsolutePath.string());
+			return false;
+		}
+		const int64_t manifestVersion = manifest.GetInt("lcdlln_runtime_manifest_version", 0);
+		if (manifestVersion < 4)
+		{
+			LOG_WARN(Core,
+				"[AudioEngine] Footstep manifest version {} < 4 (clef splat_layer_footstep_audio_refs absente) ; aucun son de pas enregistre",
+				manifestVersion);
+			return false;
+		}
+
+		// Bus par defaut : "SFX" si present, sinon le premier bus disponible (l'audio sortira
+		// quand meme, juste sans le mixage SFX dedie).
+		std::string defaultBusId = "SFX";
+		if (m_buses.find(defaultBusId) == m_buses.end() && !m_buses.empty())
+		{
+			defaultBusId = m_buses.begin()->first;
+		}
+
+		uint32_t registeredCount = 0;
+		for (uint32_t layer = 0; layer < 4u; ++layer)
+		{
+			const std::string key = "splat_layer_footstep_audio_refs[" + std::to_string(layer) + "]";
+			const std::string relPath = manifest.GetString(key, "");
+			if (relPath.empty())
+			{
+				continue;
+			}
+			AudioSoundDefinition sound{};
+			sound.id = FootstepSoundIdForLayer(layer);
+			sound.relativePath = relPath;
+			sound.busId = defaultBusId;
+			sound.minDistanceMeters = 0.5f;
+			sound.maxDistanceMeters = 12.0f;
+			sound.loop = false;
+
+			const std::filesystem::path soundPath =
+				engine::platform::FileSystem::ResolveContentPath(*m_config, relPath);
+			if (!engine::platform::FileSystem::Exists(soundPath))
+			{
+				LOG_WARN(Core,
+					"[AudioEngine] Footstep audio missing on disk (layer={}, path='{}') ; metadata enregistree, lecture echouera silencieusement",
+					layer, relPath);
+			}
+
+			m_sounds[sound.id] = sound;
+			++registeredCount;
+			LOG_INFO(Core, "[AudioEngine] Registered footstep sound (layer={}, id='{}', path='{}')",
+				layer, sound.id, sound.relativePath);
+		}
+
+		if (registeredCount == 0u)
+		{
+			LOG_INFO(Core,
+				"[AudioEngine] Footstep manifest charge mais aucune couche n'avait de son assigne (champ vide) ; aucun son enregistre");
+			return false;
+		}
+		LOG_INFO(Core, "[AudioEngine] Footstep registration OK ({} couches sur 4)", registeredCount);
 		return true;
 	}
 

--- a/engine/audio/AudioEngine.h
+++ b/engine/audio/AudioEngine.h
@@ -98,6 +98,21 @@ namespace engine::audio
 		bool StartMenuMusic(const std::filesystem::path& filePathUtf8);
 		void StopMenuMusic();
 
+		/// P3.2 — Lit \c runtime_manifest.json (v4+) produit par lcdlln_world_editor et enregistre
+		/// dynamiquement les sons de pas par couche splat. Le manifeste expose
+		/// \c splat_layer_footstep_audio_refs : un tableau de 4 chemins (R/G/B/A = herbe/terre/roc/neige).
+		/// Chaque entrée non-vide devient un \c AudioSoundDefinition avec l'id synthétique
+		/// \c "_footstep_layer_<n>" (n = 0..3), sur le bus \c "SFX", attenuation 0.5–12 m, non-loop.
+		/// Les ré-appels écrasent les enregistrements précédents (ré-export = ré-application propre).
+		/// \return true si au moins une couche a été enregistrée ; false sur erreur d'I/O ou
+		/// manifeste incompatible (clef absente, mauvaise version).
+		bool RegisterFootstepSoundsFromManifest(const std::filesystem::path& manifestAbsolutePath);
+
+		/// Construit l'id conventionnel d'un son de pas pour la couche splat \p layer (0..3).
+		/// Forme : \c "_footstep_layer_<n>". Préfixe \c '_' pour ne pas entrer en collision avec
+		/// les ids exposés par les sons utilisateur (lesquels sont, par convention, alphanumériques).
+		static std::string FootstepSoundIdForLayer(uint32_t layer);
+
 	private:
 		/// Load zone audio data from the configured content-relative JSON file.
 		bool LoadZoneAudio();


### PR DESCRIPTION
## Contexte

Deuxième sous-lot de **P3 — Footstep audio runtime** (suite de #409).

Séquence : P3.1 (mergée) a ajouté les clefs `splat_layer_footstep_audio_refs` + `audio_assets` dans `runtime_manifest.json` (bump v3→v4). P3.2 (cette PR) ajoute le **lecteur côté runtime jeu** : `AudioEngine` sait désormais charger ce mapping et enregistrer chaque son sous un id synthétique.

## Changement

### Nouvelle API publique sur `AudioEngine`

```cpp
bool RegisterFootstepSoundsFromManifest(const std::filesystem::path& manifestAbsolutePath);
static std::string FootstepSoundIdForLayer(uint32_t layer); // "_footstep_layer_<n>"
```

`RegisterFootstepSoundsFromManifest` :

- Lit le `runtime_manifest.json` produit par l'éditeur (v4+ requis).
- Parse `splat_layer_footstep_audio_refs[0..3]` (R/G/B/A = herbe/terre/roc/neige).
- Pour chaque entrée non-vide, crée un `AudioSoundDefinition` :
  - id = `_footstep_layer_<n>` (préfixe `_` pour ne pas collisionner avec les ids utilisateur)
  - bus = `"SFX"` si présent, sinon le premier bus disponible
  - atténuation 0.5 m – 12 m, non-loop
- Ré-appels = remplacement propre (re-export = ré-application clean, pas de duplication).

### Auto-déclenchement depuis `Init`

Nouvelle clef config `audio.footstep_manifest_path` (string, content-relative, défaut vide). Si renseignée, `AudioEngine::Init` appelle automatiquement `RegisterFootstepSoundsFromManifest` après `LoadZoneAudio`. Échec non-fatal : le jeu continue sans sons de pas.

### Robustesse

- `manifest_version < 4` détecté explicitement → log WARN + skip sans erreur fatale (compat ancien export).
- Fichiers audio absents du disque → log WARN, métadata conservée (Play3D échouera silencieusement, pas de crash).
- Erreur d'I/O sur le manifest → log ERROR, return false, mais Init continue.

## Test plan

- [ ] CI Linux + Windows verts
- [ ] Manuel (post-merge) : configurer `audio.footstep_manifest_path: "zones/test_a/runtime_manifest.json"` dans `config.json`, lancer le jeu, vérifier les logs `[AudioEngine] Registered footstep sound (layer=...)` puis `Footstep registration OK (N couches sur 4)`.
- [ ] Vérifier qu'un manifest v3 produit `Footstep manifest version 3 < 4` en WARN (pas ERROR).

## À venir

- **P3.3** — utilitaire CPU `SampleDominantSplatLayerAtWorldXZ` pour échantillonner la splat sous le joueur
- **P3.4** — hook `CharacterController` (cadence pas par vélocité + appel `Play3D`)
- **P3.5** — tests unitaires

https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR)_