### PR TITLE
feat(terrain): SampleDominantSplatLayerAtWorldXZ utility (P3.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ add_library(engine_core
   engine/render/terrain/HeightmapLoader.cpp
   engine/render/terrain/TerrainMesh.cpp
   engine/render/terrain/TerrainSplatting.cpp
+  engine/render/terrain/SplatSampling.cpp
   engine/render/terrain/TerrainHoleMask.cpp
   engine/render/terrain/TerrainGrassDetail.cpp
   engine/render/terrain/TerrainCliffMesh.cpp

--- a/engine/render/terrain/SplatSampling.cpp
+++ b/engine/render/terrain/SplatSampling.cpp
@@ -1,0 +1,61 @@
+#include "engine/render/terrain/SplatSampling.h"
+
+namespace engine::render::terrain
+{
+	SplatSampleResult SampleDominantSplatLayerAtWorldXZ(const uint8_t* splatRgba,
+		uint32_t splatWidth,
+		uint32_t splatHeight,
+		float terrainOriginX,
+		float terrainOriginZ,
+		float terrainWorldSize,
+		float worldX,
+		float worldZ)
+	{
+		SplatSampleResult out{};
+		if (splatRgba == nullptr || splatWidth == 0u || splatHeight == 0u || terrainWorldSize <= 0.0f)
+		{
+			return out;
+		}
+
+		// Conversion monde -> UV (origine (originX, originZ), couvre [origine, origine + worldSize]).
+		const float u = (worldX - terrainOriginX) / terrainWorldSize;
+		const float v = (worldZ - terrainOriginZ) / terrainWorldSize;
+		if (u < 0.0f || u > 1.0f || v < 0.0f || v > 1.0f)
+		{
+			// Hors du carre terrain : on ne tente meme pas un clamp (le caller doit pouvoir
+			// distinguer "hors zone" de "dans zone, pas de son" via valid=false).
+			return out;
+		}
+
+		// Sampling nearest (cf. doxy : transitions splat suffisamment graduelles vs cadence du pas).
+		// Conversion UV -> indice texel : u * width donne un float dans [0, width], on clamp a [0, width-1].
+		uint32_t tx = static_cast<uint32_t>(u * static_cast<float>(splatWidth));
+		uint32_t ty = static_cast<uint32_t>(v * static_cast<float>(splatHeight));
+		if (tx >= splatWidth)  { tx = splatWidth - 1u; }
+		if (ty >= splatHeight) { ty = splatHeight - 1u; }
+
+		const size_t pixelOffset = (static_cast<size_t>(ty) * splatWidth + tx) * 4u;
+		const uint8_t r = splatRgba[pixelOffset + 0u];
+		const uint8_t g = splatRgba[pixelOffset + 1u];
+		const uint8_t b = splatRgba[pixelOffset + 2u];
+		const uint8_t a = splatRgba[pixelOffset + 3u];
+
+		// Identifie la couche dominante (channel max). Egalite : ordre stable R > G > B > A.
+		uint8_t maxValue = r;
+		uint32_t maxLayer = 0u;
+		if (g > maxValue) { maxValue = g; maxLayer = 1u; }
+		if (b > maxValue) { maxValue = b; maxLayer = 2u; }
+		if (a > maxValue) { maxValue = a; maxLayer = 3u; }
+
+		// Poids normalise : valeur du dominant / somme des 4 channels (0..1).
+		const float sum = static_cast<float>(r) + static_cast<float>(g)
+			+ static_cast<float>(b) + static_cast<float>(a);
+		const float weight = (sum > 0.0f) ? (static_cast<float>(maxValue) / sum) : 0.0f;
+
+		out.dominantLayer = maxLayer;
+		out.dominantWeight = weight;
+		out.valid = true;
+		return out;
+	}
+
+} // namespace engine::render::terrain

--- a/engine/render/terrain/SplatSampling.cpp
+++ b/engine/render/terrain/SplatSampling.cpp
@@ -1,5 +1,7 @@
 #include "engine/render/terrain/SplatSampling.h"
 
+#include <cstddef>
+
 namespace engine::render::terrain
 {
 	SplatSampleResult SampleDominantSplatLayerAtWorldXZ(const uint8_t* splatRgba,

--- a/engine/render/terrain/SplatSampling.h
+++ b/engine/render/terrain/SplatSampling.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+
+namespace engine::render::terrain
+{
+	/// Resultat d'un sampling splat : couche dominante + poids (0..1, normalise) + flag valide.
+	struct SplatSampleResult
+	{
+		/// Index de la couche dominante (0=herbe / R, 1=terre / G, 2=roc / B, 3=neige / A).
+		/// 0 par defaut quand le sampling echoue (point hors terrain, donnees absentes...).
+		uint32_t dominantLayer = 0u;
+		/// Poids de la couche dominante apres normalisation des 4 channels (0..1).
+		/// Permet a l'appelant de decider si le sampling est concluant (ex. seuil 0.5).
+		float dominantWeight = 0.0f;
+		/// Faux si la position est hors des bornes du terrain ou si les donnees CPU sont absentes.
+		bool valid = false;
+	};
+
+	/// Echantillonne le splat RGBA sous la position monde (\p worldX, \p worldZ) et retourne
+	/// la couche dominante. Sampling nearest (suffisant pour decider du son de pas - les
+	/// transitions splat sont graduelles, le pas du joueur fait au moins 0.5 m).
+	///
+	/// Convention canaux : R = couche 0 (herbe), G = couche 1 (terre), B = couche 2 (roc),
+	///                     A = couche 3 (neige). Identique a kSplatLayerCount = 4.
+	///
+	/// \param splatRgba         Buffer CPU RGBA8 (width * height * 4 octets, row-major).
+	/// \param splatWidth        Largeur du splat en texels.
+	/// \param splatHeight       Hauteur du splat en texels.
+	/// \param terrainOriginX    Coordonnee monde X du coin (u=0, v=0) du splat.
+	/// \param terrainOriginZ    Coordonnee monde Z du coin (u=0, v=0) du splat.
+	/// \param terrainWorldSize  Taille monde du carre couvert par le splat (en metres).
+	/// \param worldX, worldZ    Point monde a echantillonner.
+	/// \return Resultat. \c valid == false si hors terrain / donnees absentes / parametres invalides.
+	SplatSampleResult SampleDominantSplatLayerAtWorldXZ(const uint8_t* splatRgba,
+		uint32_t splatWidth,
+		uint32_t splatHeight,
+		float terrainOriginX,
+		float terrainOriginZ,
+		float terrainWorldSize,
+		float worldX,
+		float worldZ);
+
+} // namespace engine::render::terrain


### PR DESCRIPTION
## Contexte

Troisième sous-lot de **P3 — Footstep audio runtime** (suite de #409, #411).

Séquence cumulative :
- P3.1 (#409, mergée) — Export `splat_layer_footstep_audio_refs` dans `runtime_manifest.json` v4
- P3.2 (#411, mergée) — `AudioEngine::RegisterFootstepSoundsFromManifest` + `FootstepSoundIdForLayer`
- **P3.3** (cette PR) — Utilitaire CPU `SampleDominantSplatLayerAtWorldXZ`
- P3.4 — Hook `CharacterController` (cadence pas + `Play3D` avec l'id de P3.2 et la couche de P3.3)
- P3.5 — Tests unitaires

## Changement

Nouveau module **autonome et testable** `engine/render/terrain/SplatSampling.{h,cpp}` :

```cpp
struct SplatSampleResult {
    uint32_t dominantLayer;   // 0=R/herbe, 1=G/terre, 2=B/roc, 3=A/neige
    float    dominantWeight;  // 0..1, max / somme
    bool     valid;           // false si hors terrain ou data nulle
};

SplatSampleResult SampleDominantSplatLayerAtWorldXZ(
    const uint8_t* splatRgba, uint32_t w, uint32_t h,
    float originX, float originZ, float worldSize,
    float worldX, float worldZ);
```

### Mécanique

1. Conversion monde → UV via origine du terrain + taille en mètres
2. Hors-bornes → `valid = false` (caller distingue "hors zone" vs "dans zone, pas de son")
3. Sampling nearest (transitions splat graduelles vs cadence pas joueur ≥ 0.5 m)
4. Identification du channel max → `dominantLayer` (égalité stable R > G > B > A)
5. Poids normalisé = `max / somme` des 4 channels — permet au caller un seuil d'éligibilité (ex. ne déclencher le son que si `dominantWeight > 0.5`)

### CPU accès splat (préalable P3.3)

Bonne surprise : `TerrainSplatting::HasCpuData()` + `GetSplatMapCpu()` + `GetSplatMapCpuWidth()` / `GetSplatMapCpuHeight()` existent déjà (M34.4 editing tools). Cette PR n'a donc rien à modifier côté `TerrainSplatting` — le CPU access était déjà résolu.

## Test plan

- [ ] CI Linux + Windows verts (build seul ; tests unitaires arrivent en P3.5)
- [ ] Pas de comportement runtime modifié — utilitaire dormant jusqu'à P3.4

## À venir

- **P3.4** — Hook `CharacterController` : compteur distance parcourue, à chaque pas franchi (~1.0 m marche, ~1.7 m course), appel `splatSampling.Sample(...)` puis `audioEngine.Play3D(pos, FootstepSoundIdForLayer(layer))`
- **P3.5** — Tests unitaires (sampling sur splat synthétique connu + cadence avec velocity simulée)

https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbytRuQyfwMXQJSkAY4cWR)_