### PR TITLE
feat(editor): M43.4 — Editor Hub overlay ImGui pour mode --editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ add_library(engine_core
   engine/render/LnTheme.h
   engine/render/AuthImGuiRenderer.cpp
   engine/render/ChatImGuiRenderer.cpp
+  engine/render/EditorHubImGuiRenderer.cpp
   engine/render/DecalSystem.cpp
   engine/render/DecalPass.cpp
   engine/render/ParticleSystem.cpp

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -10,6 +10,7 @@
 #include "engine/network/ProtocolV1Constants.h"
 #include "engine/render/AuthImGuiRenderer.h"
 #include "engine/render/ChatImGuiRenderer.h"
+#include "engine/render/EditorHubImGuiRenderer.h"
 #include "engine/render/AuthUiRenderer.h"
 #include "engine/render/DeferredPipeline.h"
 #include "engine/render/ShaderCompiler.h"
@@ -2411,11 +2412,14 @@ namespace engine
 													const bool chatImguiActive = m_chatImGui && m_chatUi.IsInitialized()
 														&& !authVisualState.active && !m_worldEditorExe
 														&& m_cfg.GetBool("render.chat_imgui.enabled", true);
+													// M43.4 — RecordToBackbuffer également quand --editor (sans world-editor).
+													const bool editorHubActive = m_editorHubImGui && m_editorEnabled && !m_worldEditorExe;
 													if (m_worldEditorImGui && m_worldEditorImGui->IsReady()
 														&& (m_worldEditorExe
 															|| (m_authImGui && authVisualState.active
 																&& m_cfg.GetBool("render.auth_ui.imgui.enabled", false))
-															|| chatImguiActive)
+															|| chatImguiActive
+															|| editorHubActive)
 														&& m_vkDeviceContext.SupportsDynamicRendering() && backbufferView != VK_NULL_HANDLE
 														&& !presentSolidColorDebug)
 													{
@@ -2738,6 +2742,11 @@ namespace engine
 				// Phase 3.11.1 — partage du même contexte ImGui (NewFrame/Render gérés par m_worldEditorImGui).
 				m_chatImGui = std::make_unique<engine::render::ChatImGuiRenderer>();
 				m_chatImGui->BindChatUi(&m_chatUi, &m_cfg);
+				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
+				// si --editor est actif (cf. condition Render branch plus bas).
+				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
+				if (m_editorMode)
+					m_editorHubImGui->BindEditorMode(m_editorMode.get());
 			}
 			else
 			{
@@ -3163,7 +3172,10 @@ namespace engine
 		const bool chatImguiOverlayNewFrame = m_chatImGui && m_chatUi.IsInitialized()
 			&& !authGateActive && !m_worldEditorExe
 			&& m_cfg.GetBool("render.chat_imgui.enabled", true);
-		if (m_worldEditorImGui && m_worldEditorImGui->IsReady() && (m_worldEditorExe || authImguiOverlayNewFrame || chatImguiOverlayNewFrame))
+		// M43.4 — NewFrame également quand --editor (sans world-editor exe) actif.
+		const bool editorHubOverlayNewFrame = m_editorHubImGui && m_editorEnabled && !m_worldEditorExe;
+		if (m_worldEditorImGui && m_worldEditorImGui->IsReady()
+			&& (m_worldEditorExe || authImguiOverlayNewFrame || chatImguiOverlayNewFrame || editorHubOverlayNewFrame))
 		{
 			float imguiDw = static_cast<float>(std::max(1, m_width));
 			float imguiDh = static_cast<float>(std::max(1, m_height));
@@ -3495,6 +3507,24 @@ namespace engine
 				}
 			}
 			m_chatImGui->Render(dw, dh);
+			ImGui::Render();
+		}
+		else if (m_worldEditorImGui && m_worldEditorImGui->IsReady() && m_editorHubImGui
+			&& m_editorEnabled && !m_worldEditorExe)
+		{
+			// M43.4 — Rendu du panneau Editor Hub overlay quand --editor (sans world-editor).
+			float dw = static_cast<float>(std::max(1, m_width));
+			float dh = static_cast<float>(std::max(1, m_height));
+			if (m_vkSwapchain.IsValid())
+			{
+				const VkExtent2D extUi = m_vkSwapchain.GetExtent();
+				if (extUi.width > 0 && extUi.height > 0)
+				{
+					dw = static_cast<float>(extUi.width);
+					dh = static_cast<float>(extUi.height);
+				}
+			}
+			m_editorHubImGui->Render(dw, dh);
 			ImGui::Render();
 		}
 #endif

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -58,6 +58,7 @@ namespace engine::render
 {
 	class AuthImGuiRenderer;
 	class ChatImGuiRenderer;
+	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
 namespace engine::editor
@@ -243,6 +244,8 @@ namespace engine
 		std::unique_ptr<engine::render::AuthImGuiRenderer> m_authImGui;
 		/// Phase 3.11.1 — Panneau chat Dear ImGui (post-auth, partage le même contexte ImGui que m_authImGui).
 		std::unique_ptr<engine::render::ChatImGuiRenderer> m_chatImGui;
+		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
+		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
 		std::unique_ptr<engine::editor::WorldEditorSession> m_worldEditorSession;
 		/// Terrain décalé (jeu + world editor exclusif : un seul actif selon le binaire / reload).

--- a/engine/editor/EditorMode.h
+++ b/engine/editor/EditorMode.h
@@ -109,6 +109,13 @@ namespace engine::editor
 		/// Returns true when the editable object layer is visible.
 		bool IsObjectVisible() const;
 
+		/// M43.4 — Lecteurs publics pour le panneau ImGui "Editor Hub" (overlay).
+		/// Le hub affiche le titre déjà composé par RefreshShell (Scene/Inspector/Assets +
+		/// flag dirty) sans re-construire la chaîne, donc 100% cohérent avec l'ancien
+		/// affichage en window title.
+		const std::string& GetHubTitle() const { return m_lastWindowTitle; }
+		bool IsDirty() const { return m_dirty; }
+
 	private:
 		/// Creates one gameplay volume of the requested type at the current editor pivot.
 		bool CreateVolume(VolumeType type);

--- a/engine/render/EditorHubImGuiRenderer.cpp
+++ b/engine/render/EditorHubImGuiRenderer.cpp
@@ -1,0 +1,79 @@
+#include "engine/render/EditorHubImGuiRenderer.h"
+
+#include "engine/editor/EditorMode.h"
+#include "engine/render/LnTheme.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+	}
+
+	void EditorHubImGuiRenderer::Render(float viewportW, float viewportH)
+	{
+		(void)viewportW;
+		(void)viewportH;
+		if (m_editor == nullptr)
+			return;
+
+		// Ancrage haut-gauche, marge 12 px ; auto-resize, non-modal, pas de move.
+		const float margin = 12.f;
+		ImGui::SetNextWindowPos(ImVec2(margin, margin));
+		ImGui::SetNextWindowBgAlpha(0.78f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.78f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoBringToFrontOnFocus
+			| ImGuiWindowFlags_NoNav
+			| ImGuiWindowFlags_AlwaysAutoResize;
+
+		if (ImGui::Begin("##ln_editor_hub", nullptr, flags))
+		{
+			// Header LCDLLN Editor + indicator dirty.
+			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			if (m_editor->IsDirty())
+				ImGui::TextUnformatted("[LCDLLN Editor] *dirty*");
+			else
+				ImGui::TextUnformatted("[LCDLLN Editor]");
+			ImGui::PopStyleColor();
+
+			ImGui::Separator();
+
+			// Le titre composé contient déjà Scene/Inspector/AssetBrowser.
+			// On l'affiche tel quel — cohérence garantie avec l'ancien window-title.
+			const std::string& title = m_editor->GetHubTitle();
+			if (!title.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+				ImGui::TextWrapped("%s", title.c_str());
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::TextUnformatted("(en attente du premier RefreshShell...)");
+				ImGui::PopStyleColor();
+			}
+		}
+		ImGui::End();
+
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void EditorHubImGuiRenderer::Render(float, float) {}
+}
+
+#endif

--- a/engine/render/EditorHubImGuiRenderer.h
+++ b/engine/render/EditorHubImGuiRenderer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace engine::editor { class EditorMode; }
+
+namespace engine::render
+{
+	/// M43.4 — Panneau "Editor Hub" overlay pour le mode `--editor`.
+	///
+	/// Remplace l'affichage dans le titre de la fenêtre par un panneau ImGui non-modal
+	/// ancré en haut-gauche. Lit `EditorMode::GetHubTitle()` (déjà composé par
+	/// `RefreshShell`) et `EditorMode::IsDirty()`.
+	///
+	/// Windows uniquement — le contexte ImGui est porté par `WorldEditorImGui` qui
+	/// n'existe que sous WIN32 (cf. `ChatImGuiRenderer` pour le pattern).
+	///
+	/// Pas de mutation de l'état éditeur : panneau strictement read-only.
+	class EditorHubImGuiRenderer final
+	{
+	public:
+		void BindEditorMode(engine::editor::EditorMode* editor) { m_editor = editor; }
+		void Render(float viewportW, float viewportH);
+
+	private:
+		engine::editor::EditorMode* m_editor = nullptr;
+	};
+}


### PR DESCRIPTION
## M43.4 — Editor Hub overlay ImGui pour le mode `--editor`

### Effet utilisateur

Avant : `EditorMode` utilisait `window.SetTitle(...)` pour afficher l'état Scene/Inspector/Assets + flag dirty.
Après : un panneau ImGui non-modal ancré en haut-gauche affiche les mêmes infos en overlay dans la fenêtre, sans polluer le titre.

```
┌───────────────────────────────────────┐
│ [LCDLLN Editor] *dirty*               │
│ ─────────────────────────────────     │
│ LCDLLN Engine --editor *dirty* |      │
│ Scene: obj=1 sel=1 vol=2 |            │
│ Inspector: pos=(2.0,1.0,3.0) ...      │
│ Asset Browser: mesh=test.mesh tex=1   │
└───────────────────────────────────────┘
```

### Architecture

| Couche | Changement |
|---|---|
| `engine/editor/EditorMode.h` | 2 getters publics : `GetHubTitle()` / `IsDirty()`. `RefreshShell` et `m_lastWindowTitle` inchangés (compat préservée). |
| `engine/render/EditorHubImGuiRenderer.h/.cpp` | Renderer Windows uniquement (stub no-op Linux). Pattern identique à `ChatImGuiRenderer`. Lit `EditorMode::GetHubTitle()` et l'affiche dans un panneau auto-resize / non-decoration / non-move ancré en haut-gauche (marge 12 px). |
| `engine/Engine.h` | `m_editorHubImGui` (unique_ptr). |
| `engine/Engine.cpp` | Création alongside `m_chatImGui` quand le contexte ImGui shared est prêt. Condition `NewFrame` étendue (`editorHubOverlayNewFrame`). Nouvelle branche `else if (editor hub actif)` Render + `ImGui::Render`. `RecordToBackbuffer` étendu pareil. |
| `CMakeLists.txt` | `EditorHubImGuiRenderer.cpp` ajouté à `engine_core`. |

### Limites assumées

- Le hub est **read-only** (lit `GetHubTitle()` composé par `RefreshShell` chaque frame). Pas de boutons ni d'interaction directe — c'est le rôle de M43.5+ (audio zone, FX events, loot table, UI theme).
- Visible seulement si `--editor` sans `--world-editor` (le world editor a déjà sa propre UI ImGui complète via `m_worldEditorImGui`).

### Test plan

- [ ] CI Linux/Windows verts.
- [ ] `lcdlln.exe --editor` → panneau "Editor Hub" visible en haut-gauche, contenu cohérent avec ce qui était dans le titre window.
- [ ] `lcdlln.exe` (sans --editor) → pas de panneau Editor Hub.
- [ ] `lcdlln_world_editor.exe` → pas de panneau Editor Hub (le world editor a sa propre UI).
- [ ] Régression : tout le reste du rendu (auth UI, chat panel, world editor UI) inchangé.

---

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv)_