### PR TITLE
feat(web-portal/security): cookies signes HMAC + rate-limit login + p…

### DIFF
--- a/web-portal/app/api/admin/bugs/[id]/route.ts
+++ b/web-portal/app/api/admin/bugs/[id]/route.ts
@@ -9,14 +9,9 @@
 //  4. Set exploit_awarded = 1 on the bug report.
 
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
 
 const VALID_STATUSES = ['pending', 'confirmed', 'in_progress', 'resolved', 'not_a_bug'] as const
 type AdminStatus = (typeof VALID_STATUSES)[number]
@@ -40,7 +35,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
 

--- a/web-portal/app/api/admin/cgu/[id]/publish/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/publish/route.ts
@@ -1,7 +1,7 @@
 // POST /api/admin/cgu/[id]/publish
 // Publishes a draft CGU edition
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
@@ -9,8 +9,7 @@ export async function POST(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  if (jar.get('lcdlln_portal_role')?.value !== 'admin') {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ ok: false }, { status: 403 })
   }
 

--- a/web-portal/app/api/admin/cgu/[id]/retire/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/retire/route.ts
@@ -2,7 +2,7 @@
 // Body: { reason: string } — required, non-empty
 // Retires a published CGU edition
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
@@ -10,8 +10,7 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  if (jar.get('lcdlln_portal_role')?.value !== 'admin') {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ ok: false }, { status: 403 })
   }
 

--- a/web-portal/app/api/admin/cgu/[id]/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/route.ts
@@ -1,14 +1,9 @@
 // PATCH /api/admin/cgu/[id] — update draft edition
 // DELETE /api/admin/cgu/[id] — delete draft edition
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
 
 async function getEdition(id: number) {
   const rows = await query<Array<RowDataPacket & { id: number; status: string }>>(
@@ -22,7 +17,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await isAuthenticatedAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
@@ -94,7 +89,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await isAuthenticatedAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/route.ts
+++ b/web-portal/app/api/admin/cgu/route.ts
@@ -2,17 +2,12 @@
 // Body: { versionLabel, titleFr, contentFr, titleEn?, contentEn? }
 // Creates a new terms_edition (status='draft') + terms_localizations entries
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { ResultSetHeader } from 'mysql2/promise'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
-
 export async function POST(request: Request) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await isAuthenticatedAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   try {
     const body = await request.json() as {

--- a/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
+++ b/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
@@ -1,15 +1,10 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!await isAuthenticatedAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/faq/[id]/route.ts
+++ b/web-portal/app/api/admin/faq/[id]/route.ts
@@ -1,19 +1,14 @@
 // PATCH /api/admin/faq/[id] — update faq item fields
 // DELETE /api/admin/faq/[id] — delete faq item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -59,7 +54,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/faq/route.ts
+++ b/web-portal/app/api/admin/faq/route.ts
@@ -1,17 +1,12 @@
 // GET /api/admin/faq — returns all faq items ordered by display_order
 // POST /api/admin/faq — creates a new faq item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
-
 export async function GET() {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -25,7 +20,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/app/api/admin/players/[id]/activate/route.ts
+++ b/web-portal/app/api/admin/players/[id]/activate/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!await isAuthenticatedAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/players/[id]/characters/route.ts
+++ b/web-portal/app/api/admin/players/[id]/characters/route.ts
@@ -1,15 +1,10 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
-}
-
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!await isAuthenticatedAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/disable/route.ts
+++ b/web-portal/app/api/admin/players/[id]/disable/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import { sendAccountDisabled } from '@/lib/email'
 import type { RowDataPacket } from 'mysql2/promise'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
-}
-
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!await isAuthenticatedAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/verify-email/route.ts
+++ b/web-portal/app/api/admin/players/[id]/verify-email/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!await isAuthenticatedAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/roadmap/[id]/route.ts
+++ b/web-portal/app/api/admin/roadmap/[id]/route.ts
@@ -1,19 +1,14 @@
 // PATCH /api/admin/roadmap/[id] — update roadmap item fields
 // DELETE /api/admin/roadmap/[id] — delete roadmap item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -59,7 +54,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/roadmap/route.ts
+++ b/web-portal/app/api/admin/roadmap/route.ts
@@ -1,17 +1,12 @@
 // GET /api/admin/roadmap — returns all roadmap items ordered by display_order
 // POST /api/admin/roadmap — creates a new roadmap item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { isAuthenticatedAdmin } from '@/lib/apiAuth'
 import { query } from '@/lib/db'
 import type { RowDataPacket } from 'mysql2/promise'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
-}
-
 export async function GET() {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -25,7 +20,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAdmin()) {
+  if (!(await isAuthenticatedAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/app/api/auth/login/route.ts
+++ b/web-portal/app/api/auth/login/route.ts
@@ -2,12 +2,24 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { verifyPortalCredentials } from "@/lib/portalLogin";
 import { query } from "@/lib/db";
+import { signCookieValue } from "@/lib/cookieSigning";
+import { checkRateLimit, getClientIp, recordFailure, recordSuccess } from "@/lib/rateLimit";
 import type { RowDataPacket } from "mysql2/promise";
 
 const COOKIE_NAME = "lcdlln_portal_account";
 const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 7;
 
 export async function POST(request: Request) {
+  const ipKey = `login:${getClientIp(request)}`;
+  const limit = checkRateLimit(ipKey);
+  if (!limit.allowed) {
+    const retryAfterSec = Math.ceil(limit.retryAfterMs / 1000);
+    return NextResponse.json(
+      { ok: false, message: "Trop de tentatives. Reessayez plus tard." },
+      { status: 429, headers: { "Retry-After": String(retryAfterSec) } },
+    );
+  }
+
   try {
     const body = (await request.json()) as { identifier?: string; password?: string };
     const identifier = typeof body.identifier === "string" ? body.identifier : "";
@@ -15,6 +27,7 @@ export async function POST(request: Request) {
 
     const result = await verifyPortalCredentials(identifier, password);
     if (!result.ok) {
+      if (result.code !== "missing") recordFailure(ipKey);
       const status = result.code === "db" ? 503 : 401;
       const message =
         result.code === "missing"
@@ -25,6 +38,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: false, message }, { status });
     }
 
+    recordSuccess(ipKey);
+
     const accountRows = await query<Array<RowDataPacket & { role: string; tag_id: string | null }>>(
       'SELECT role, tag_id FROM accounts WHERE id = ? LIMIT 1',
       [result.accountId]
@@ -32,15 +47,18 @@ export async function POST(request: Request) {
     const accountRole = accountRows[0]?.role ?? 'player';
     const accountTagId = accountRows[0]?.tag_id ?? null;
 
+    const signedAccount = await signCookieValue(String(result.accountId));
+    const signedRole = await signCookieValue(accountRole);
+
     const jar = cookies();
-    jar.set(COOKIE_NAME, String(result.accountId), {
+    jar.set(COOKIE_NAME, signedAccount, {
       httpOnly: true,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",
       path: "/",
       maxAge: COOKIE_MAX_AGE_SEC,
     });
-    jar.set('lcdlln_portal_role', accountRole, {
+    jar.set('lcdlln_portal_role', signedRole, {
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',

--- a/web-portal/app/api/bugs/route.ts
+++ b/web-portal/app/api/bugs/route.ts
@@ -1,18 +1,15 @@
 // POST /api/bugs
 // Body: { title, body, category }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 import type { ResultSetHeader } from 'mysql2/promise'
 
 const VALID_CATEGORIES = ['gameplay', 'graphique', 'reseau', 'interface', 'autre'] as const
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { title?: string; body?: string; category?: string }
@@ -34,7 +31,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, id: result.insertId }, { status: 201 })
   } catch (err) {
     console.error('[POST /api/bugs]', err)
-    const msg = err instanceof Error ? err.message : 'Erreur serveur'
-    return NextResponse.json({ ok: false, message: msg }, { status: 500 })
+    return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/password-recovery/reset/route.ts
+++ b/web-portal/app/api/password-recovery/reset/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
     const result = await resetPasswordWithToken(body.token || "", body.newPassword || "");
     return NextResponse.json(result, { status: result.ok ? 200 : 400 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Erreur inconnue.";
-    return NextResponse.json({ ok: false, message }, { status: 500 });
+    console.error("[POST /api/password-recovery/reset]", error);
+    return NextResponse.json({ ok: false, message: "Erreur serveur" }, { status: 500 });
   }
 }

--- a/web-portal/app/api/player/account/cancel-email-change/route.ts
+++ b/web-portal/app/api/player/account/cancel-email-change/route.ts
@@ -1,14 +1,11 @@
 // POST /api/player/account/cancel-email-change
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 
 export async function POST() {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     await query(

--- a/web-portal/app/api/player/account/request-email-change/route.ts
+++ b/web-portal/app/api/player/account/request-email-change/route.ts
@@ -1,18 +1,15 @@
 // POST /api/player/account/request-email-change
 // Body: { newEmail: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
 import { sendEmailChange } from '@/lib/email'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { newEmail?: string }

--- a/web-portal/app/api/player/account/route.ts
+++ b/web-portal/app/api/player/account/route.ts
@@ -1,15 +1,12 @@
 // PATCH /api/player/account
 // Body: { firstName?, lastName?, addressStreet?, addressCity?, addressZip?, addressCountry? }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 
 export async function PATCH(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false, message: 'Session invalide' }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
 
   try {
     const body = await request.json() as Record<string, string>

--- a/web-portal/app/api/player/cgu/accept/route.ts
+++ b/web-portal/app/api/player/cgu/accept/route.ts
@@ -1,16 +1,13 @@
 // POST /api/player/cgu/accept
 // Body: { editionId: number }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { editionId?: number }

--- a/web-portal/app/api/player/characters/[id]/delete/route.ts
+++ b/web-portal/app/api/player/characters/[id]/delete/route.ts
@@ -1,19 +1,17 @@
 // PATCH /api/player/characters/[id]/delete
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function PATCH(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
   const characterId = parseInt(params.id, 10)
-  if (isNaN(accountId) || isNaN(characterId)) return NextResponse.json({ ok: false }, { status: 400 })
+  if (isNaN(characterId)) return NextResponse.json({ ok: false }, { status: 400 })
 
   try {
     // Verify ownership

--- a/web-portal/app/api/player/parental/request/route.ts
+++ b/web-portal/app/api/player/parental/request/route.ts
@@ -1,18 +1,15 @@
 // POST /api/player/parental/request
 // Body: { parentalEmail: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
 import { sendParentalValidation } from '@/lib/email'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { parentalEmail?: string }

--- a/web-portal/app/api/player/password/route.ts
+++ b/web-portal/app/api/player/password/route.ts
@@ -1,17 +1,15 @@
 // POST /api/player/password
 // Body: { currentPassword: string, newPassword: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
 import { verifyGameMasterPassword, hashPasswordForGameMaster } from '@/lib/gamePasswordHash'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
+import { verifyPasswordStrength } from '@/lib/passwordPolicy'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { currentPassword?: string; newPassword?: string }
@@ -19,8 +17,9 @@ export async function POST(request: Request) {
     if (!currentPassword || !newPassword) {
       return NextResponse.json({ ok: false, message: 'Champs requis manquants' }, { status: 400 })
     }
-    if (newPassword.length < 8) {
-      return NextResponse.json({ ok: false, message: 'Le nouveau mot de passe doit contenir au moins 8 caractères' }, { status: 400 })
+    const strengthError = verifyPasswordStrength(newPassword)
+    if (strengthError) {
+      return NextResponse.json({ ok: false, message: strengthError }, { status: 400 })
     }
 
     const rows = await query<Array<RowDataPacket & { login: string; password_hash: string }>>(

--- a/web-portal/app/api/player/privacy/route.ts
+++ b/web-portal/app/api/player/privacy/route.ts
@@ -1,15 +1,12 @@
 // PATCH /api/player/privacy
 // Body: { visibility: 'public' | 'friends' | 'none' }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { getAuthenticatedAccountId } from '@/lib/apiAuth'
 
 export async function PATCH(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = await getAuthenticatedAccountId()
+  if (!accountId) return NextResponse.json({ ok: false }, { status: 401 })
 
   try {
     const body = await request.json() as { visibility?: string }
@@ -28,7 +25,6 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('[PATCH /api/player/privacy]', err)
-    const msg = err instanceof Error ? err.message : 'Erreur serveur'
-    return NextResponse.json({ ok: false, message: msg }, { status: 500 })
+    return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/password-recovery/reset/page.tsx
+++ b/web-portal/app/password-recovery/reset/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { ResetPasswordForm } from "@/components/ResetPasswordForm";
+
+// Empêche que le token de reset ne fuite via le header Referer vers d'éventuelles
+// ressources tierces chargées par cette page.
+export const metadata: Metadata = {
+  referrer: "no-referrer",
+};
 
 export default function PasswordRecoveryResetPage({
   searchParams,

--- a/web-portal/lib/apiAuth.ts
+++ b/web-portal/lib/apiAuth.ts
@@ -1,0 +1,19 @@
+// Helpers d'authentification pour les route handlers API : lisent les cookies signés,
+// vérifient le HMAC, retournent les valeurs de confiance.
+import { cookies } from "next/headers";
+import { verifyCookieValue } from "@/lib/cookieSigning";
+
+export async function getAuthenticatedAccountId(): Promise<number | null> {
+  const jar = cookies();
+  const raw = await verifyCookieValue(jar.get("lcdlln_portal_account")?.value);
+  if (!raw) return null;
+  const accountId = parseInt(raw, 10);
+  if (isNaN(accountId) || accountId <= 0) return null;
+  return accountId;
+}
+
+export async function isAuthenticatedAdmin(): Promise<boolean> {
+  const jar = cookies();
+  const role = await verifyCookieValue(jar.get("lcdlln_portal_role")?.value);
+  return role === "admin";
+}

--- a/web-portal/lib/cookieSigning.ts
+++ b/web-portal/lib/cookieSigning.ts
@@ -36,7 +36,9 @@ function bytesToHex(bytes: ArrayBuffer): string {
 
 function hexToBytes(hex: string): Uint8Array | null {
   if (hex.length % 2 !== 0) return null;
-  const out = new Uint8Array(hex.length / 2);
+  // Backing buffer typé explicitement ArrayBuffer (et non ArrayBufferLike) pour
+  // satisfaire la signature BufferSource de crypto.subtle.verify avec @types/node 22+.
+  const out = new Uint8Array(new ArrayBuffer(hex.length / 2));
   for (let i = 0; i < out.length; i += 1) {
     const byte = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
     if (Number.isNaN(byte)) return null;

--- a/web-portal/lib/cookieSigning.ts
+++ b/web-portal/lib/cookieSigning.ts
@@ -1,0 +1,68 @@
+// HMAC-SHA256 sur les valeurs de cookie sensibles (lcdlln_portal_account / role).
+// Web Crypto API : utilisable à la fois en Edge Runtime (middleware Next.js) et en
+// Node runtime (Server Components / route handlers).
+
+function getAuthSecret(): string {
+  return process.env.AUTH_SECRET || "lcdlln-dev-recovery-secret";
+}
+
+let cachedKey: CryptoKey | null = null;
+let cachedKeySecret: string | null = null;
+
+async function getKey(): Promise<CryptoKey> {
+  const secret = getAuthSecret();
+  if (cachedKey && cachedKeySecret === secret) return cachedKey;
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+  cachedKey = key;
+  cachedKeySecret = secret;
+  return key;
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let out = "";
+  for (let i = 0; i < view.length; i += 1) {
+    out += view[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    const byte = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) return null;
+    out[i] = byte;
+  }
+  return out;
+}
+
+export async function signCookieValue(rawValue: string): Promise<string> {
+  const key = await getKey();
+  const enc = new TextEncoder();
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(rawValue));
+  return `${rawValue}.${bytesToHex(sig)}`;
+}
+
+export async function verifyCookieValue(signedValue: string | undefined): Promise<string | null> {
+  if (!signedValue) return null;
+  const dot = signedValue.lastIndexOf(".");
+  if (dot <= 0 || dot === signedValue.length - 1) return null;
+  const rawValue = signedValue.substring(0, dot);
+  const providedHex = signedValue.substring(dot + 1);
+  if (!/^[a-f0-9]{64}$/i.test(providedHex)) return null;
+  const providedBytes = hexToBytes(providedHex);
+  if (!providedBytes) return null;
+  const key = await getKey();
+  const enc = new TextEncoder();
+  const ok = await crypto.subtle.verify("HMAC", key, providedBytes, enc.encode(rawValue));
+  return ok ? rawValue : null;
+}

--- a/web-portal/lib/cookieSigning.ts
+++ b/web-portal/lib/cookieSigning.ts
@@ -34,17 +34,16 @@ function bytesToHex(bytes: ArrayBuffer): string {
   return out;
 }
 
-function hexToBytes(hex: string): Uint8Array | null {
+function hexToArrayBuffer(hex: string): ArrayBuffer | null {
   if (hex.length % 2 !== 0) return null;
-  // Backing buffer typé explicitement ArrayBuffer (et non ArrayBufferLike) pour
-  // satisfaire la signature BufferSource de crypto.subtle.verify avec @types/node 22+.
-  const out = new Uint8Array(new ArrayBuffer(hex.length / 2));
-  for (let i = 0; i < out.length; i += 1) {
+  const buffer = new ArrayBuffer(hex.length / 2);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < view.length; i += 1) {
     const byte = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
     if (Number.isNaN(byte)) return null;
-    out[i] = byte;
+    view[i] = byte;
   }
-  return out;
+  return buffer;
 }
 
 export async function signCookieValue(rawValue: string): Promise<string> {
@@ -61,10 +60,12 @@ export async function verifyCookieValue(signedValue: string | undefined): Promis
   const rawValue = signedValue.substring(0, dot);
   const providedHex = signedValue.substring(dot + 1);
   if (!/^[a-f0-9]{64}$/i.test(providedHex)) return null;
-  const providedBytes = hexToBytes(providedHex);
-  if (!providedBytes) return null;
+  // ArrayBuffer (vs Uint8Array) satisfait la signature BufferSource stricte de
+  // crypto.subtle.verify avec @types/node 22+ sans cast.
+  const providedSignature = hexToArrayBuffer(providedHex);
+  if (!providedSignature) return null;
   const key = await getKey();
   const enc = new TextEncoder();
-  const ok = await crypto.subtle.verify("HMAC", key, providedBytes, enc.encode(rawValue));
+  const ok = await crypto.subtle.verify("HMAC", key, providedSignature, enc.encode(rawValue));
   return ok ? rawValue : null;
 }

--- a/web-portal/lib/passwordPolicy.ts
+++ b/web-portal/lib/passwordPolicy.ts
@@ -1,0 +1,19 @@
+// Politique commune de force du mot de passe : utilisée à l'inscription/reset
+// (lib/passwordRecovery.ts) ET au changement connecté (api/player/password).
+
+const MIN_LENGTH = 8;
+const MAX_LENGTH = 256;
+
+export function verifyPasswordStrength(password: string): string | null {
+  if (typeof password !== "string") return "Mot de passe invalide.";
+  if (password.length < MIN_LENGTH) {
+    return `Le mot de passe doit contenir au moins ${MIN_LENGTH} caracteres.`;
+  }
+  if (password.length > MAX_LENGTH) {
+    return "Le mot de passe depasse la longueur maximale autorisee.";
+  }
+  if (!/[A-Za-z]/.test(password) || !/\d/.test(password)) {
+    return "Le mot de passe doit contenir au moins une lettre et un chiffre.";
+  }
+  return null;
+}

--- a/web-portal/lib/passwordRecovery.ts
+++ b/web-portal/lib/passwordRecovery.ts
@@ -2,6 +2,7 @@ import type { ResultSetHeader, RowDataPacket } from "mysql2/promise";
 import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { query } from "@/lib/db";
 import { hashPasswordForGameMaster } from "@/lib/gamePasswordHash";
+import { verifyPasswordStrength } from "@/lib/passwordPolicy";
 
 type AccountRow = RowDataPacket & {
   id: number;
@@ -100,15 +101,6 @@ function computeAgeYears(birthDate: string): number | null {
     age -= 1;
   }
   return age >= 0 ? age : null;
-}
-
-function verifyPasswordStrength(password: string): string | null {
-  if (password.length < 8) return "Le mot de passe doit contenir au moins 8 caracteres.";
-  if (password.length > 256) return "Le mot de passe depasse la longueur maximale autorisee.";
-  if (!/[A-Za-z]/.test(password) || !/\d/.test(password)) {
-    return "Le mot de passe doit contenir au moins une lettre et un chiffre.";
-  }
-  return null;
 }
 
 export async function ensurePasswordRecoveryTables(): Promise<void> {

--- a/web-portal/lib/portalLogin.ts
+++ b/web-portal/lib/portalLogin.ts
@@ -1,11 +1,19 @@
 import { scryptSync, timingSafeEqual } from "node:crypto";
 import type { RowDataPacket } from "mysql2/promise";
 import { query } from "@/lib/db";
-import { verifyGameMasterPassword } from "@/lib/gamePasswordHash";
+import { hashPasswordForGameMaster, verifyGameMasterPassword } from "@/lib/gamePasswordHash";
 
 function normalizeLower(value: string): string {
   return value.trim().toLowerCase();
 }
+
+// Hash bidon (Argon2id valide) précalculé au chargement du module. Sert à égaliser
+// le temps de réponse quand le compte n'existe pas, pour empêcher l'énumération de
+// logins/emails par mesure de timing. Le résultat de la verify n'est jamais utilisé.
+const dummyHashPromise: Promise<string> = hashPasswordForGameMaster(
+  "__dummy_login__",
+  "__dummy_password__",
+);
 
 function verifyLegacyScryptPassword(password: string, stored: string): boolean {
   if (!stored.startsWith("scrypt$")) return false;
@@ -50,6 +58,11 @@ export async function verifyPortalCredentials(
     );
     const row = rows[0];
     if (!row) {
+      // Égalise le temps avec un compte trouvé : on lance un Argon2id factice
+      // pour rendre l'énumération par timing impraticable.
+      try {
+        await verifyGameMasterPassword("__dummy_login__", plainPassword, await dummyHashPromise);
+      } catch { /* ignore */ }
       return { ok: false, code: "invalid" };
     }
     const dbLogin = row.login.trim();

--- a/web-portal/lib/rateLimit.ts
+++ b/web-portal/lib/rateLimit.ts
@@ -1,0 +1,76 @@
+// In-memory rate limiter: sliding-window failure counter with exponential lockout.
+// Buckets are keyed by IP (or any caller-provided string). Reset on success.
+// Note: per-process state — in a multi-replica deployment, prefer a shared store.
+
+type Bucket = {
+  fails: number;
+  lockedUntilMs: number;
+  lastFailMs: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+const FAIL_WINDOW_MS = 15 * 60 * 1000;
+const MAX_FAILS_BEFORE_LOCK = 5;
+const BASE_LOCK_MS = 30 * 1000;
+const MAX_LOCK_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+let lastCleanupMs = Date.now();
+
+function cleanup(now: number): void {
+  if (now - lastCleanupMs < CLEANUP_INTERVAL_MS) return;
+  lastCleanupMs = now;
+  for (const [key, bucket] of buckets.entries()) {
+    const stale = now - bucket.lastFailMs > FAIL_WINDOW_MS && bucket.lockedUntilMs <= now;
+    if (stale) buckets.delete(key);
+  }
+}
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterMs: number };
+
+export function checkRateLimit(key: string): RateLimitResult {
+  const now = Date.now();
+  cleanup(now);
+  const bucket = buckets.get(key);
+  if (!bucket) return { allowed: true };
+  if (bucket.lockedUntilMs > now) {
+    return { allowed: false, retryAfterMs: bucket.lockedUntilMs - now };
+  }
+  if (now - bucket.lastFailMs > FAIL_WINDOW_MS) {
+    buckets.delete(key);
+    return { allowed: true };
+  }
+  return { allowed: true };
+}
+
+export function recordFailure(key: string): void {
+  const now = Date.now();
+  const existing = buckets.get(key);
+  const inWindow = existing && now - existing.lastFailMs <= FAIL_WINDOW_MS;
+  const fails = inWindow ? existing!.fails + 1 : 1;
+  let lockedUntilMs = 0;
+  if (fails >= MAX_FAILS_BEFORE_LOCK) {
+    const overflow = fails - MAX_FAILS_BEFORE_LOCK;
+    const lock = Math.min(BASE_LOCK_MS * Math.pow(2, overflow), MAX_LOCK_MS);
+    lockedUntilMs = now + lock;
+  }
+  buckets.set(key, { fails, lockedUntilMs, lastFailMs: now });
+}
+
+export function recordSuccess(key: string): void {
+  buckets.delete(key);
+}
+
+export function getClientIp(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = request.headers.get("x-real-ip");
+  if (real) return real.trim();
+  return "unknown";
+}

--- a/web-portal/lib/session.ts
+++ b/web-portal/lib/session.ts
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db'
+import { verifyCookieValue } from '@/lib/cookieSigning'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export type Session = {
@@ -11,7 +12,8 @@ export type Session = {
 
 export async function getSession(): Promise<Session> {
   const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
+  const signed = jar.get('lcdlln_portal_account')?.value
+  const raw = await verifyCookieValue(signed)
   if (!raw) return null
   const accountId = parseInt(raw, 10)
   if (isNaN(accountId) || accountId <= 0) return null

--- a/web-portal/middleware.ts
+++ b/web-portal/middleware.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { verifyCookieValue } from '@/lib/cookieSigning'
 
-export function middleware(request: NextRequest) {
-  const accountId = request.cookies.get('lcdlln_portal_account')?.value
-  const role = request.cookies.get('lcdlln_portal_role')?.value
+export async function middleware(request: NextRequest) {
+  const accountId = await verifyCookieValue(request.cookies.get('lcdlln_portal_account')?.value)
+  const role = await verifyCookieValue(request.cookies.get('lcdlln_portal_role')?.value)
   const { pathname } = request.nextUrl
 
   if (pathname.startsWith('/player')) {


### PR DESCRIPTION
…olitique mdp unifiee

- Signe les cookies lcdlln_portal_account et lcdlln_portal_role avec HMAC-SHA256 (Web Crypto API, compatible Edge runtime du middleware et Node runtime des routes API). Toutes les routes /api/player/* et /api/admin/* verifient desormais la signature avant de faire confiance a la valeur, empechant la forge de session par ecriture de cookie (XSS, extension, devtools).
- Rate-limit en memoire sur /api/auth/login (5 echecs en 15 min -> lockout exponentiel jusqu'a 30 min, par IP) (lib/rateLimit.ts).
- Egalise le timing de verifyPortalCredentials quand le compte n'existe pas (Argon2id factice precalcule), pour empecher l'enumeration de logins/emails par mesure de timing.
- Unifie la politique de force du mot de passe via lib/passwordPolicy.ts (min 8, lettre + chiffre, max 256), appliquee au reset comme au changement connecte (avant : 8 chars secs au changement).
- <meta referrer=no-referrer> sur la page password-recovery/reset pour ne pas fuiter le token via le header Referer vers d'eventuels assets tiers.
- Stoppe la fuite de err.message dans les reponses 500 de /api/password-recovery/reset, /api/player/privacy, /api/bugs (le message brut MySQL exposait le schema).

Nouveaux modules : lib/cookieSigning.ts, lib/rateLimit.ts, lib/passwordPolicy.ts, lib/apiAuth.ts (helpers centralises getAuthenticatedAccountId / isAuthenticatedAdmin utilises par toutes les routes API).

Toutes les sessions actives seront invalidees au deploiement (cookies non signes rejetes par le HMAC). AUTH_SECRET doit etre pose en variable d'environnement de production (sinon fallback dev).

Hors scope (tickets separes) : prepared statements MysqlAccountStore C++, passage du token de reset en URL fragment (refacto Server -> Client component), auth manquante sur /api/player/exploits (decouvert au passage).

Deploiement : redeploiement web-portal requis. Pas de redeploiement master/shard. AUTH_SECRET doit etre configure avant le deploiement.