### PR TITLE
feat: factions race-lockées + éditeur Arial + caméra/avatar/chat fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,51 @@ Si la PR change à la fois client ET serveur (cas fréquent), préciser
 
 A introduit opcodes 45/46 + ChatRelayHandler côté master → **redéploiement
 serveur master requis** pour que le chat fonctionne.
+
+## Éditeur monde (`lcdlln_world_editor.exe`)
+
+L'éditeur monde est un binaire séparé (`--world-editor`) qui partage l'engine
+avec le client de jeu mais a des conventions visuelles et de code propres.
+
+### Police d'écriture
+
+L'éditeur monde **n'utilise pas** la police décorative Windlass du jeu. Il
+utilise **Arial** (`C:/Windows/Fonts/arial.ttf` par défaut) — neutre, lisible,
+riche en glyphes accentués/ponctuation, standard sur Windows.
+
+- Configuration : `editor.font.arial_path` + `editor.font.arial_pixel_height`
+  dans `config.json`.
+- Branchement : `WorldEditorImGui::Init(... isWorldEditorExe=true)` charge
+  Arial comme police par défaut au lieu de Windlass. Le fallback ProggyClean
+  et la fonte « valeurs » Morpheus sont aussi désactivés (Arial couvre tout).
+- Pour un futur changement (autre police, taille différente), modifier la
+  branche `if (isWorldEditorExe)` dans `engine/editor/WorldEditorImGui.cpp`.
+
+### Documentation des fonctions
+
+**Règle stricte** : toute fonction (libre, méthode, lambda nommée) ajoutée
+ou modifiée pour l'éditeur monde **doit être documentée systématiquement**
+au moment de sa création/modification. La documentation se fait via un
+commentaire `///` (Doxygen) juste au-dessus de la déclaration, ou un
+commentaire `//` au-dessus de la définition si c'est une lambda interne.
+
+Doivent être présents au minimum :
+1. **Rôle** : que fait la fonction (1-2 phrases).
+2. **Paramètres non-évidents** : `\param nom description` — pas besoin de
+   redocumenter `cfg` ou `device` si leur usage est évident, mais documenter
+   les flags, les indices, les unités physiques (mètres, radians, ms…).
+3. **Effet de bord** : si la fonction modifie un état global (atlas ImGui,
+   buffer GPU, fichier disque), le mentionner.
+4. **Contraintes thread/timing** : ex. « doit être appelée en main thread,
+   avant `ImGui_ImplVulkan_Init` ».
+
+Périmètre concerné par cette règle :
+- `engine/editor/` (tous les fichiers)
+- `engine/render/terrain/TerrainEditingTools.{h,cpp}`
+- toute partie de `engine/Engine.cpp` ou `engine/render/WorldEditorImGui.cpp`
+  spécifique au mode éditeur (gardée par `m_worldEditorExe` ou
+  `m_editorEnabled`).
+
+Cette règle aide les futurs mappeurs et contributeurs à comprendre
+l'outillage sans relire tout le code. Elle s'ajoute à la convention générale
+du repo (commentaires en français, clarté > brièveté).

--- a/config.json
+++ b/config.json
@@ -36,9 +36,10 @@
             "value_font_pixel_height": 28
         },
         "terrain": {
-            "heightmap": "terrain/heightmap.r16h",
-            "splatmap": "",
-            "grass_mask": "",
+            "_comment": "Pointe vers la zone demo_plains (heightmap 65x65, splat 4 couches grass/dirt/rock/snow, masque herbe). PR ulterieure : le serveur enverra le zoneId au client a EnterWorld pour charger dynamiquement la bonne zone.",
+            "heightmap": "zones/demo_plains/terrain_height.r16h",
+            "splatmap": "zones/demo_plains/terrain_splat.slap",
+            "grass_mask": "zones/demo_plains/terrain_grass.grms",
             "grass_mask_visual_strength": 0.35,
             "hole_mask": ""
         }

--- a/config.json
+++ b/config.json
@@ -97,6 +97,14 @@
     "paths": {
         "content": "game/data"
     },
+    "editor": {
+        "_comment": "Reglages specifiques a l'editeur monde (lcdlln_world_editor.exe). Les regles de developpement de l'editeur sont dans CLAUDE.md > 'Editeur monde'.",
+        "font": {
+            "_comment": "L'editeur utilise Arial (lisible, neutre, riche en glyphs) au lieu de Windlass (decorative, reservee a l'UI auth/in-game). arial_path peut etre absolu (C:/Windows/Fonts/arial.ttf par defaut sur Windows) ou relatif a paths.content si on bundle un Arial avec le client.",
+            "arial_path": "C:/Windows/Fonts/arial.ttf",
+            "arial_pixel_height": 14
+        }
+    },
     "client": {
         "master_port": 3840,
         "server_fingerprint": "",

--- a/db/migrations/0040_factions.sql
+++ b/db/migrations/0040_factions.sql
@@ -1,0 +1,81 @@
+-- Migration 0040 — Systeme de factions
+--
+-- Introduit le concept de faction (Lumiere / Ombres / Crepuscule) qui
+-- structure le PvP, la diplomatie inter-zones et determine les points
+-- de spawn par defaut au premier login.
+--
+-- Schema :
+--   * Table `factions` (3 lignes seedees + id 0 'unaligned' fallback).
+--   * Colonne `characters.faction_str` (VARCHAR, alignee sur factions.name)
+--     -- meme strategie que `race_str` (cf. 0033) : pas de FK numerique pour
+--     simplifier les imports / la migration de donnees ulterieurement.
+--
+-- Alignement faction <-> race par defaut (modifiable a la creation du perso) :
+--   Lumiere    : humains, nains, chevaliers_dragons, elfes
+--   Ombres     : orcs, demons
+--   Crepuscule : aucune race par defaut (neutres / mercenaires)
+--
+-- Note : la valeur par defaut '' (chaine vide) est preferee a 'unaligned'
+-- pour qu'un personnage existant cree avant cette migration n'apparaisse
+-- pas comme appartenant a une faction. Le code traite '' comme synonyme
+-- de 'crepuscule' (neutre) pour le gameplay.
+--
+-- Idempotent : INSERT IGNORE + INFORMATION_SCHEMA guard sur la colonne.
+-- Reversible : DROP TABLE factions ; ALTER TABLE characters DROP COLUMN faction_str.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+START TRANSACTION;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 1) Table `factions`
+-- ────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS factions (
+  id          INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name        VARCHAR(32)  NOT NULL,
+  description VARCHAR(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_factions_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Factions PvP / diplomatiques. Seedee par 0040.';
+
+SET @prev_sql_mode = @@SESSION.sql_mode;
+SET SESSION sql_mode = CONCAT(@@SESSION.sql_mode, ',NO_AUTO_VALUE_ON_ZERO');
+
+INSERT IGNORE INTO factions (id, name, description) VALUES
+  (0, 'unaligned',  'Faction par defaut technique : personnages crees avant la migration ou sans allegeance assignee. Equivalent a crepuscule pour le gameplay.'),
+  (1, 'lumiere',    'Alliance de l''ordre et de la justice. Defenseurs du jour, gardiens des cites humaines, des forteresses naines, des bois elfiques et des arches des chevaliers-dragons.'),
+  (2, 'ombres',     'Disciples des tenebres et du chaos. Hordes orcs, legions demoniaques et necromanciens unifies sous l''ombre de la Lune Noire.'),
+  (3, 'crepuscule', 'Sans allegeance. Mercenaires, voyageurs solitaires, eclaireurs hors-la-loi. Libres d''alliances changeantes.');
+
+SET SESSION sql_mode = @prev_sql_mode;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 2) Colonne `characters.faction_str`
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @col_exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE table_schema = DATABASE() AND table_name = 'characters' AND column_name = 'faction_str'
+);
+SET @stmt := IF(@col_exists = 0,
+  'ALTER TABLE characters ADD COLUMN faction_str VARCHAR(32) NOT NULL DEFAULT '''' COMMENT ''Identifiant chaine de la faction (cf. factions.name). Vide = unaligned/crepuscule.''',
+  'SELECT ''column characters.faction_str already exists, skipping''');
+PREPARE altr FROM @stmt; EXECUTE altr; DEALLOCATE PREPARE altr;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 3) Backfill : pre-renseigner `faction_str` pour les personnages existants
+--    selon leur race par defaut. Permet a un perso ancien de basculer dans
+--    la faction logique sans intervention manuelle.
+-- ────────────────────────────────────────────────────────────────────────
+
+UPDATE characters SET faction_str = 'lumiere'
+  WHERE faction_str = '' AND race_str IN ('humains', 'nains', 'elfes', 'chevaliers_dragons');
+UPDATE characters SET faction_str = 'ombres'
+  WHERE faction_str = '' AND race_str IN ('orcs', 'demons');
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/db/migrations/0040_factions.sql
+++ b/db/migrations/0040_factions.sql
@@ -1,26 +1,32 @@
--- Migration 0040 — Systeme de factions
+-- Migration 0040 — Systeme de factions (race-lockees + sous-maisons)
 --
--- Introduit le concept de faction (Lumiere / Ombres / Crepuscule) qui
--- structure le PvP, la diplomatie inter-zones et determine les points
--- de spawn par defaut au premier login.
+-- Introduit le concept de faction. Les factions sont race-lockees (chaque
+-- faction n'est rejoignable que par une race specifique), conformement au
+-- design de la Lune Noire :
+--
+--   * Chevaliers de la Lumiere     (humains)
+--   * Chevaliers de la Justice     (humains)
+--   * La Lune Noire                (humains)
+--   * L'Empire de L'Hynn           (humains)
+--   * Dzorak                       (orcs ; cf. 0036 alias lore deja documente)
+--   * Demons                       (demons)
+--   * Chevaliers-Dragons           (chevaliers_dragons)
+--
+-- Races sans faction definie : elfes, nains -> faction_str = '' (unaligned).
+-- A definir plus tard quand le lore sera arrete pour ces peuples.
 --
 -- Schema :
---   * Table `factions` (3 lignes seedees + id 0 'unaligned' fallback).
---   * Colonne `characters.faction_str` (VARCHAR, alignee sur factions.name)
---     -- meme strategie que `race_str` (cf. 0033) : pas de FK numerique pour
---     simplifier les imports / la migration de donnees ulterieurement.
+--   * Table `factions` (id, name, display_name, race_lock, parent_faction_id,
+--     description) avec auto-reference parent_faction_id pour les maisons
+--     (ex. "Maison Verdragon" sous "Chevaliers-Dragons").
+--   * Colonne `characters.faction_str` (VARCHAR, alignee sur factions.name).
 --
--- Alignement faction <-> race par defaut (modifiable a la creation du perso) :
---   Lumiere    : humains, nains, chevaliers_dragons, elfes
---   Ombres     : orcs, demons
---   Crepuscule : aucune race par defaut (neutres / mercenaires)
+-- Note : 'name' est un slug ASCII technique (chevaliers_lumiere, dzorak, ...) ;
+-- 'display_name' contient le libelle UTF-8 affiche au joueur (« Chevaliers
+-- de la Lumiere »). Le code compare via 'name' (stable) ; le client lit
+-- 'display_name' pour l'UI.
 --
--- Note : la valeur par defaut '' (chaine vide) est preferee a 'unaligned'
--- pour qu'un personnage existant cree avant cette migration n'apparaisse
--- pas comme appartenant a une faction. Le code traite '' comme synonyme
--- de 'crepuscule' (neutre) pour le gameplay.
---
--- Idempotent : INSERT IGNORE + INFORMATION_SCHEMA guard sur la colonne.
+-- Idempotent : CREATE TABLE IF NOT EXISTS + INSERT IGNORE + guard sur la colonne.
 -- Reversible : DROP TABLE factions ; ALTER TABLE characters DROP COLUMN faction_str.
 
 SET NAMES utf8mb4;
@@ -33,22 +39,58 @@ START TRANSACTION;
 -- ────────────────────────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS factions (
-  id          INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  name        VARCHAR(32)  NOT NULL,
-  description VARCHAR(255) NOT NULL DEFAULT '',
+  id                 INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name               VARCHAR(48)  NOT NULL,
+  display_name       VARCHAR(96)  NOT NULL DEFAULT '',
+  race_lock          VARCHAR(32)  NOT NULL DEFAULT ''
+                     COMMENT 'Race exclusivement autorisee (cf. races.name). Vide = pas de verrou.',
+  parent_faction_id  INT UNSIGNED NULL DEFAULT NULL
+                     COMMENT 'Faction parente (auto-reference). Permet la hierarchie maison < faction.',
+  description        VARCHAR(512) NOT NULL DEFAULT '',
   PRIMARY KEY (id),
-  UNIQUE KEY uq_factions_name (name)
+  UNIQUE KEY uq_factions_name (name),
+  KEY idx_factions_race_lock (race_lock),
+  CONSTRAINT fk_factions_parent FOREIGN KEY (parent_faction_id)
+    REFERENCES factions(id) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-  COMMENT='Factions PvP / diplomatiques. Seedee par 0040.';
+  COMMENT='Factions race-lockees. Hierarchie maison<faction via parent_faction_id.';
 
 SET @prev_sql_mode = @@SESSION.sql_mode;
 SET SESSION sql_mode = CONCAT(@@SESSION.sql_mode, ',NO_AUTO_VALUE_ON_ZERO');
 
-INSERT IGNORE INTO factions (id, name, description) VALUES
-  (0, 'unaligned',  'Faction par defaut technique : personnages crees avant la migration ou sans allegeance assignee. Equivalent a crepuscule pour le gameplay.'),
-  (1, 'lumiere',    'Alliance de l''ordre et de la justice. Defenseurs du jour, gardiens des cites humaines, des forteresses naines, des bois elfiques et des arches des chevaliers-dragons.'),
-  (2, 'ombres',     'Disciples des tenebres et du chaos. Hordes orcs, legions demoniaques et necromanciens unifies sous l''ombre de la Lune Noire.'),
-  (3, 'crepuscule', 'Sans allegeance. Mercenaires, voyageurs solitaires, eclaireurs hors-la-loi. Libres d''alliances changeantes.');
+INSERT IGNORE INTO factions (id, name, display_name, race_lock, parent_faction_id, description) VALUES
+  (0,  'unaligned',
+       'Sans allegeance',
+       '',                    NULL,
+       'Faction par defaut technique : personnages crees avant cette migration ou races sans faction definie (elfes, nains). Comportement neutre tant qu''aucune affiliation n''est choisie.'),
+  (1,  'chevaliers_lumiere',
+       'Chevaliers de la Lumiere',
+       'humains',             NULL,
+       'Ordre saint et chevaleresque jurant fidelite a la Lumiere. Defenseurs des cites humaines, croises contre les ombres.'),
+  (2,  'chevaliers_justice',
+       'Chevaliers de la Justice',
+       'humains',             NULL,
+       'Ordre judiciaire arme. Mainteneurs de l''ordre, traqueurs de criminels, gardiens des routes du royaume.'),
+  (3,  'lune_noire',
+       'La Lune Noire',
+       'humains',             NULL,
+       'Culte humain qui voue son destin a la Lune Noire. Discrets, sectaires, manipulateurs ; rivaux declares des ordres lumineux.'),
+  (4,  'empire_hynn',
+       'L''Empire de L''Hynn',
+       'humains',             NULL,
+       'Empire militaire et bureaucratique. Conquerants pragmatiques, plus politiques que religieux.'),
+  (5,  'dzorak',
+       'Dzorak',
+       'orcs',                NULL,
+       'Confederation des hordes orcs. Le mot Dzorak designe a la fois le peuple, la culture et l''alliance des clans (cf. 0036).'),
+  (6,  'demons',
+       'Demons',
+       'demons',              NULL,
+       'Legions des plans inferieurs. Tribus rivales unifiees au gre des incursions vers les terres mortelles.'),
+  (7,  'chevaliers_dragons',
+       'Chevaliers-Dragons',
+       'chevaliers_dragons',  NULL,
+       'Ordre legendaire des chevaliers lies a la puissance draconique. Race-faction (la race entiere forme une seule faction unique).');
 
 SET SESSION sql_mode = @prev_sql_mode;
 
@@ -61,20 +103,26 @@ SET @col_exists := (
   WHERE table_schema = DATABASE() AND table_name = 'characters' AND column_name = 'faction_str'
 );
 SET @stmt := IF(@col_exists = 0,
-  'ALTER TABLE characters ADD COLUMN faction_str VARCHAR(32) NOT NULL DEFAULT '''' COMMENT ''Identifiant chaine de la faction (cf. factions.name). Vide = unaligned/crepuscule.''',
+  'ALTER TABLE characters ADD COLUMN faction_str VARCHAR(48) NOT NULL DEFAULT '''' COMMENT ''Identifiant chaine de la faction (cf. factions.name). Vide = unaligned.''',
   'SELECT ''column characters.faction_str already exists, skipping''');
 PREPARE altr FROM @stmt; EXECUTE altr; DEALLOCATE PREPARE altr;
 
 -- ────────────────────────────────────────────────────────────────────────
 -- 3) Backfill : pre-renseigner `faction_str` pour les personnages existants
---    selon leur race par defaut. Permet a un perso ancien de basculer dans
---    la faction logique sans intervention manuelle.
+--    selon leur race. Un humain existant n'a pas encore "choisi" sa faction
+--    -> on laisse vide (unaligned) plutot que de le mettre arbitrairement
+--    dans Chevaliers de la Lumiere. Le joueur fera son choix au prochain
+--    login via une UI de selection (PR ulterieure).
+--    Pour les autres races, la faction est unique, on l'attribue.
 -- ────────────────────────────────────────────────────────────────────────
 
-UPDATE characters SET faction_str = 'lumiere'
-  WHERE faction_str = '' AND race_str IN ('humains', 'nains', 'elfes', 'chevaliers_dragons');
-UPDATE characters SET faction_str = 'ombres'
-  WHERE faction_str = '' AND race_str IN ('orcs', 'demons');
+UPDATE characters SET faction_str = 'dzorak'
+  WHERE faction_str = '' AND race_str = 'orcs';
+UPDATE characters SET faction_str = 'demons'
+  WHERE faction_str = '' AND race_str = 'demons';
+UPDATE characters SET faction_str = 'chevaliers_dragons'
+  WHERE faction_str = '' AND race_str = 'chevaliers_dragons';
+-- humains, elfes, nains : on laisse vide (selection a faire au prochain login).
 
 COMMIT;
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3017,22 +3017,10 @@ namespace engine
 						spawnY   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.y", 100.0));
 						spawnZ   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.z", 0.0));
 						yawDeg   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.yaw_deg", 0.0));
-						// Pitch +10deg par defaut : vue legerement plongeante. +20deg etait
-						// trop agressif et declenchait le clamp anti-collision sol qui
-						// reduisait effectiveDistance de 8m a 3.5m, mettant la camera
-						// quasi dans le mesh de l'avatar. +10deg laisse 8m reels.
-						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", 10.0));
+						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", -10.0));
 						LOG_INFO(Core, "[EnterWorld] using config default spawn (no per-character data)");
 					}
 					constexpr float kDeg2Rad = 3.14159265f / 180.f;
-					// Force pitch dans plage [5, 20] : <5deg cache le perso (camera trop
-					// horizontale), >20deg declenche le clamp anti-collision sol qui
-					// rapproche la camera dans le mesh.
-					if (pitchDeg < 5.0f || pitchDeg > 20.0f)
-					{
-						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg hors plage [5,20], force a +10deg", pitchDeg);
-						pitchDeg = 10.0f;
-					}
 					out.camera.position.x = spawnX;
 					out.camera.position.y = spawnY;
 					out.camera.position.z = spawnZ;
@@ -3533,20 +3521,6 @@ namespace engine
 				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
 				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
-				// DIAG visibilite avatar : 1 LOG par seconde pour confirmer que la matrice
-				// est bien posee et visible. Aide au triage des plaintes "je ne vois pas le perso".
-				static double s_lastAvatarDiagAt = -1000.0;
-				const double nowSec = static_cast<double>(m_currentFrame) * 0.0167;
-				if (nowSec - s_lastAvatarDiagAt > 1.0)
-				{
-					s_lastAvatarDiagAt = nowSec;
-					LOG_INFO(Render, "[Avatar] pos=({:.2f},{:.2f},{:.2f}) feetY={:.2f} cam=({:.2f},{:.2f},{:.2f}) yaw={:.2f}deg pitch={:.2f}deg dist={:.2f}m visible={}",
-						target.x, target.y, target.z, feetY,
-						out.camera.position.x, out.camera.position.y, out.camera.position.z,
-						out.camera.yaw * 57.2958f, out.camera.pitch * 57.2958f,
-						m_orbitalCameraController.GetDistance(),
-						out.objectVisible ? 1 : 0);
-				}
 			}
 		}
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3910,6 +3910,16 @@ namespace engine
 	        LOG_WARN(Render, "[Engine] Render early return: device/swapchain not ready frame={}", m_currentFrame);
 	        return;
 	    }
+	    // Skip render quand la fenetre est minimisee (m_width/m_height = 0) ou en
+	    // attente de recreation swapchain. Sans ce guard, les passes Vulkan acquerent
+	    // des images de taille invalide et plantent en cas de resize agressif (cas
+	    // signale dans l'editeur monde lors de drag de bord de fenetre).
+	    if (m_width <= 0 || m_height <= 0 || m_swapchainResizeRequested)
+	    {
+	        LOG_DEBUG(Render, "[Engine] Render skipped (w={} h={} resizePending={})",
+	            m_width, m_height, m_swapchainResizeRequested ? 1 : 0);
+	        return;
+	    }
 	    LOG_DEBUG(Render, "[Engine] Render begin frame={}", m_currentFrame);
 	    const uint32_t frameIndex          = m_currentFrame % 2;
 	    engine::render::FrameResources& fr = m_frameResources[frameIndex];

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3517,18 +3517,12 @@ namespace engine
 				// (5.4 m de haut, camera a 1.81 m au-dessus du sol = inside the model)
 				// -> ecran fige perceptuel. La camera 3eme personne (dist=8m, height=1.5m)
 				// est largement assez genereuse a echelle reelle.
-				// Echelle x2 sur l'avatar (1.8m -> 3.6m). Le mesh humanoide placeholder est
-				// petit pour debug visuel : meme a 6m de distance, il occupe 21% de hauteur
-				// ecran. A x2, il fait 42% de hauteur a 6m -> impossible a manquer. La
-				// camera (cf. Camera.cpp kHeightOffsetM=2.5) est 4.2m au-dessus du sol,
-				// donc bien au-dessus du sommet du mesh agrandi (3.6m), pas de risque
-				// d'etre dans le mesh.
-				constexpr float kAvatarScale = 2.0f;
-				const float sc = c * kAvatarScale;
-				const float ss = s * kAvatarScale;
-				out.objectModelMatrix[0]  = sc;    out.objectModelMatrix[1]  = 0.0f;          out.objectModelMatrix[2]  = -ss;  out.objectModelMatrix[3]  = 0.0f; // col0 : axe X scale
-				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = kAvatarScale;  out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y scale
-				out.objectModelMatrix[8]  = ss;    out.objectModelMatrix[9]  = 0.0f;          out.objectModelMatrix[10] = sc;   out.objectModelMatrix[11] = 0.0f; // col2 : axe Z scale
+				// Avatar a echelle reelle 1.8m (pas de scale). Cible image 2 utilisateur :
+				// avec camera a 5m de distance (cf. Camera.h kDistanceDefault), l'avatar
+				// occupe 26% de hauteur ecran -> visible et identifiable comme humanoide.
+				out.objectModelMatrix[0]  = c;     out.objectModelMatrix[1]  = 0.0f; out.objectModelMatrix[2]  = -s;   out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local
+				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
+				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
 			}
 		}

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3517,9 +3517,18 @@ namespace engine
 				// (5.4 m de haut, camera a 1.81 m au-dessus du sol = inside the model)
 				// -> ecran fige perceptuel. La camera 3eme personne (dist=8m, height=1.5m)
 				// est largement assez genereuse a echelle reelle.
-				out.objectModelMatrix[0]  = c;     out.objectModelMatrix[1]  = 0.0f; out.objectModelMatrix[2]  = -s;   out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local
-				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
-				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
+				// Echelle x2 sur l'avatar (1.8m -> 3.6m). Le mesh humanoide placeholder est
+				// petit pour debug visuel : meme a 6m de distance, il occupe 21% de hauteur
+				// ecran. A x2, il fait 42% de hauteur a 6m -> impossible a manquer. La
+				// camera (cf. Camera.cpp kHeightOffsetM=2.5) est 4.2m au-dessus du sol,
+				// donc bien au-dessus du sommet du mesh agrandi (3.6m), pas de risque
+				// d'etre dans le mesh.
+				constexpr float kAvatarScale = 2.0f;
+				const float sc = c * kAvatarScale;
+				const float ss = s * kAvatarScale;
+				out.objectModelMatrix[0]  = sc;    out.objectModelMatrix[1]  = 0.0f;          out.objectModelMatrix[2]  = -ss;  out.objectModelMatrix[3]  = 0.0f; // col0 : axe X scale
+				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = kAvatarScale;  out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y scale
+				out.objectModelMatrix[8]  = ss;    out.objectModelMatrix[9]  = 0.0f;          out.objectModelMatrix[10] = sc;   out.objectModelMatrix[11] = 0.0f; // col2 : axe Z scale
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
 			}
 		}

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3908,14 +3908,15 @@ namespace engine
 	        LOG_WARN(Render, "[Engine] Render early return: device/swapchain not ready frame={}", m_currentFrame);
 	        return;
 	    }
-	    // Skip render quand la fenetre est minimisee (m_width/m_height = 0) ou en
-	    // attente de recreation swapchain. Sans ce guard, les passes Vulkan acquerent
-	    // des images de taille invalide et plantent en cas de resize agressif (cas
-	    // signale dans l'editeur monde lors de drag de bord de fenetre).
-	    if (m_width <= 0 || m_height <= 0 || m_swapchainResizeRequested)
+	    // Skip render uniquement quand la fenetre est minimisee (m_width/m_height = 0).
+	    // Ne PAS skipper sur m_swapchainResizeRequested : le code de resize est traite
+	    // dans BeginFrame du frame suivant, et vkAcquireNextImageKHR retourne
+	    // OUT_OF_DATE_KHR / SUBOPTIMAL_KHR qui sont gerees plus bas. Skipper en plus
+	    // du flag risquait de figer le rendu de l'editeur monde dont la fenetre
+	    // ne plante plus mais reste noire en permanence (signale par utilisateur).
+	    if (m_width <= 0 || m_height <= 0)
 	    {
-	        LOG_DEBUG(Render, "[Engine] Render skipped (w={} h={} resizePending={})",
-	            m_width, m_height, m_swapchainResizeRequested ? 1 : 0);
+	        LOG_DEBUG(Render, "[Engine] Render skipped (window minimized w={} h={})", m_width, m_height);
 	        return;
 	    }
 	    LOG_DEBUG(Render, "[Engine] Render begin frame={}", m_currentFrame);

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3017,20 +3017,23 @@ namespace engine
 						spawnY   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.y", 100.0));
 						spawnZ   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.z", 0.0));
 						yawDeg   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.yaw_deg", 0.0));
-						// Pitch -20deg par defaut : vue 3eme personne legerement plongeante,
-						// pour bien voir le perso au centre-bas de l'ecran (cf. WoW/New World/Once Human).
-						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", -20.0));
+						// Pitch +20deg par defaut : convention orbital camera = pitch
+						// positif fait que la camera se positionne AU-DESSUS du target et
+						// regarde vers le bas (cf. Camera.cpp lignes 280-345 : camera.y =
+						// target.y - sin(pitch)*distance, sin > 0 -> camera plus haut).
+						// Le sign etait inverse precedemment (-20) -> camera placee EN-DESSOUS
+						// du target regardant le ciel -> ecran "fige" (rien de visible).
+						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", 20.0));
 						LOG_INFO(Core, "[EnterWorld] using config default spawn (no per-character data)");
 					}
 					constexpr float kDeg2Rad = 3.14159265f / 180.f;
-					// Force un pitch initial plongeant (-20deg) si le pitch sauvegarde est
-					// trop proche de l'horizon (ex. 0deg de l'ancien defaut DB) : avec une
-					// vue 3eme personne, regarder l'horizon cache le perso. L'utilisateur
-					// peut ensuite ajuster avec la souris (RMB).
-					if (pitchDeg > -10.0f)
+					// Force un pitch initial plongeant (+20deg) si le pitch sauvegarde est
+					// trop proche de l'horizon (ex. 0deg ou -10deg des anciens defauts DB).
+					// Convention : pitch positif = vue plongeante (cf. ci-dessus).
+					if (pitchDeg < 10.0f)
 					{
-						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg trop proche de l'horizon, force a -20deg", pitchDeg);
-						pitchDeg = -20.0f;
+						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg insuffisant pour vue plongeante 3eme personne, force a +20deg", pitchDeg);
+						pitchDeg = 20.0f;
 					}
 					out.camera.position.x = spawnX;
 					out.camera.position.y = spawnY;

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2950,7 +2950,15 @@ namespace engine
 			}
 			if (m_chatUi.IsInitialized())
 			{
-				m_chatUi.Update(m_input, static_cast<float>(dt));
+				// PAS d'update du chat pendant les ecrans d'auth : sinon le Enter
+				// que l'utilisateur tape pour valider le login active aussi le chat
+				// focus (cf. ChatUiPresenter::Update qui toggle sur Slash/Enter).
+				// Resultat : in-game, m_chatFocus reste true -> orbital camera Update
+				// est skip -> camera fige a la position spawn = position avatar
+				// (utilisateur voyait l'interieur du mesh humanoide). On garde
+				// uniquement la mise a jour viewport pour que la geometrie chat
+				// soit prete au moment d'EnterWorld.
+				(void)m_chatUi;
 			}
 			out.authHudText = m_authUi.BuildPanelText();
 			out.chatDebugText.clear();
@@ -3069,6 +3077,14 @@ namespace engine
 				m_savePositionIntervalSec = std::chrono::seconds(std::max<int64_t>(5, intervalCfg));
 				m_nextSavePositionTime = std::chrono::steady_clock::now() + m_savePositionIntervalSec;
 				m_shutdownPositionSaved = false;
+				// Reset defensif du chat focus : si l'utilisateur a tape Enter pendant
+				// la saisie du login, ChatUiPresenter::Update aurait toggle m_chatFocus=true.
+				// In-game ce flag bloque l'orbital camera Update (cf. line 3275).
+				if (m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive())
+				{
+					m_chatUi.SetChatFocus(false);
+					LOG_INFO(Core, "[EnterWorld] chat focus reset OFF (etait active depuis l'auth)");
+				}
 				LOG_INFO(Core, "[EnterWorld] periodic position save armed (character_id={}, interval={}s)",
 					m_currentCharacterId, m_savePositionIntervalSec.count());
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3014,6 +3014,15 @@ namespace engine
 						LOG_INFO(Core, "[EnterWorld] using config default spawn (no per-character data)");
 					}
 					constexpr float kDeg2Rad = 3.14159265f / 180.f;
+					// Force un pitch initial plongeant (-20deg) si le pitch sauvegarde est
+					// trop proche de l'horizon (ex. 0deg de l'ancien defaut DB) : avec une
+					// vue 3eme personne, regarder l'horizon cache le perso. L'utilisateur
+					// peut ensuite ajuster avec la souris (RMB).
+					if (pitchDeg > -10.0f)
+					{
+						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg trop proche de l'horizon, force a -20deg", pitchDeg);
+						pitchDeg = -20.0f;
+					}
 					out.camera.position.x = spawnX;
 					out.camera.position.y = spawnY;
 					out.camera.position.z = spawnZ;
@@ -3494,9 +3503,16 @@ namespace engine
 				//   | -sin(y)  0   cos(y)    tz |
 				//   | 0        0   0         1  |
 				// Stockage colonne-par-colonne :
-				out.objectModelMatrix[0]  = c;     out.objectModelMatrix[1]  = 0.0f; out.objectModelMatrix[2]  = -s;   out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local
-				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
-				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
+				// Iteration : scale 3x pour rendre l'avatar tres visible (utilisateur
+				// signale "je ne vois pas le perso"). Avatar de 1.8m -> 5.4m visuel,
+				// impossible a manquer. A retuner / supprimer une fois la chaine
+				// complete (mesh+materiel+camera+culling) validee.
+				constexpr float kAvatarScale = 3.0f;
+				const float sc = c * kAvatarScale;
+				const float ss = s * kAvatarScale;
+				out.objectModelMatrix[0]  = sc;    out.objectModelMatrix[1]  = 0.0f;          out.objectModelMatrix[2]  = -ss;  out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local scale
+				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = kAvatarScale;  out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local scale
+				out.objectModelMatrix[8]  = ss;    out.objectModelMatrix[9]  = 0.0f;          out.objectModelMatrix[10] = sc;   out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local scale
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
 				// DIAG visibilite avatar : 1 LOG par seconde pour confirmer que la matrice
 				// est bien posee et visible. Aide au triage des plaintes "je ne vois pas le perso".

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2764,7 +2764,8 @@ namespace engine
 				m_vkSwapchain.GetImageCount(),
 				VK_API_VERSION_1_1,
 				m_window.GetNativeHandle(),
-				&m_cfg))
+				&m_cfg,
+				m_worldEditorExe))
 			{
 				if (m_worldEditorExe)
 				{

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3249,9 +3249,13 @@ namespace engine
 		// le chat global + amis ; une fois le royaume choisi, + zone'.
 		const bool postAuthMaster = m_authUi.IsInitialized() && m_authUi.IsMasterAuthenticated()
 			&& !m_worldEditorExe;
-		const bool chatImguiOverlayNewFrame = m_chatImGui && m_chatUi.IsInitialized()
-			&& postAuthMaster
-			&& (m_cfg.GetBool("render.chat_imgui.enabled", true) || m_inGamePauseMenuVisible || m_inGameOptionsPanelVisible);
+		// Chat HUD overlay desactive pre-EnterWorld : retour utilisateur "on laisse
+		// tomber pour le moment, l'affichage du CHAT juste apres l'authentification".
+		// Le chat ne s'affiche desormais qu'une fois in-game (cf. branche !authGateActive
+		// plus bas qui rend m_chatImGui->Render avec inWorldShard=true). On garde la
+		// branche cote panneau pause / options pour permettre les changements de canal
+		// dans les menus en jeu.
+		const bool chatImguiOverlayNewFrame = false;
 		// M43.4 — NewFrame également quand --editor (sans world-editor exe) actif.
 		const bool editorHubOverlayNewFrame = m_editorHubImGui && m_editorEnabled && !m_worldEditorExe;
 		if (m_worldEditorImGui && m_worldEditorImGui->IsReady()
@@ -3325,14 +3329,11 @@ namespace engine
 					rmbLook, true, out.camera, groundY, speedMul);
 			}
 
-			// Chat update : avant on attendait !authGateActive (donc post-EnterWorld
-			// uniquement). Resultat : sur ShardPick/CharSelect, le panneau chat ImGui
-			// rendait bien mais l'utilisateur appuyait sur Enter/Slash sans effet,
-			// car ChatUiPresenter::Update n'etait jamais appele -> le focus chat ne
-			// pouvait pas s'activer. Desormais on update aussi des que le master a
-			// accepte l'auth (m_masterSessionId != 0), donc des ShardPick.
-			const bool chatPostMaster = m_authUi.IsInitialized() && m_authUi.IsMasterAuthenticated();
-			if ((!authGateActive || chatPostMaster) && m_chatUi.IsInitialized())
+			// Chat update : uniquement post-EnterWorld. Le rendu pre-game est desactive
+			// (cf. chatImguiOverlayNewFrame=false plus haut), donc pas besoin d'Update
+			// le presenter avant. Si on reactive le chat pre-game un jour, etendre cette
+			// gate avec un OR sur IsMasterAuthenticated().
+			if (!authGateActive && m_chatUi.IsInitialized())
 			{
 				// Phase 3.11.3 — Indique au presenter si un ImGui::InputText pilote la saisie
 				// (panneau chat ImGui actif). Coupe la branche keyboard-typing/Enter dans Update
@@ -3697,29 +3698,10 @@ namespace engine
 			const engine::client::AuthUiPresenter::VisualState authVsImgui = m_authUi.GetVisualState();
 			const engine::client::AuthUiPresenter::RenderModel authRmImgui = m_authUi.BuildRenderModel();
 			m_authImGui->Render(authVsImgui, authRmImgui, dw, dh);
-			// Chat HUD overlay sur les ecrans post-master-auth (ShardPick / CharacterSelect /
-			// CharacterCreate). Avant cette correction, le chat n'apparaissait qu'une fois
-			// in-game car la branche auth-rendering excluait le rendu chat. inWorldShard=false
-			// ici (canaux Global + Friends seulement, pas encore Zone).
-			const bool postAuthMasterChat = m_chatImGui && m_chatUi.IsInitialized()
-				&& m_authUi.IsInitialized() && m_authUi.IsMasterAuthenticated()
-				&& !m_worldEditorExe
-				&& m_cfg.GetBool("render.chat_imgui.enabled", true);
-			if (postAuthMasterChat)
-				m_chatImGui->Render(dw, dh, m_authUi.IsInWorldShard());
-			// DIAG : log 1x/sec pour diagnostiquer chat invisible. Etat des conditions.
-			if ((m_currentFrame % 60u) == 0u)
-			{
-				LOG_INFO(Render, "[ChatDiag-AuthBranch] frame={} chatImGui={} chatUiInit={} authInit={} masterAuth={} worldEditorExe={} cfgEnabled={} -> overlay={}",
-					m_currentFrame,
-					(m_chatImGui != nullptr),
-					m_chatUi.IsInitialized(),
-					m_authUi.IsInitialized(),
-					m_authUi.IsMasterAuthenticated(),
-					m_worldEditorExe,
-					m_cfg.GetBool("render.chat_imgui.enabled", true),
-					postAuthMasterChat);
-			}
+			// Chat HUD desactive sur les ecrans pre-EnterWorld (auth/ShardPick/
+			// CharacterSelect/CharacterCreate) suite a retour utilisateur "on laisse
+			// tomber pour le moment, l'affichage du CHAT juste apres l'authentification".
+			// Le chat reapparaitra une fois la branche !authGateActive prise (in-game).
 			ImGui::Render();
 		}
 		else if (m_worldEditorImGui && m_worldEditorImGui->IsReady() && m_chatImGui

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3276,13 +3276,16 @@ namespace engine
 		// le chat global + amis ; une fois le royaume choisi, + zone'.
 		const bool postAuthMaster = m_authUi.IsInitialized() && m_authUi.IsMasterAuthenticated()
 			&& !m_worldEditorExe;
-		// Chat HUD overlay desactive pre-EnterWorld : retour utilisateur "on laisse
-		// tomber pour le moment, l'affichage du CHAT juste apres l'authentification".
-		// Le chat ne s'affiche desormais qu'une fois in-game (cf. branche !authGateActive
-		// plus bas qui rend m_chatImGui->Render avec inWorldShard=true). On garde la
-		// branche cote panneau pause / options pour permettre les changements de canal
-		// dans les menus en jeu.
-		const bool chatImguiOverlayNewFrame = false;
+		// Chat HUD : on garde l'appel a ImGui::NewFrame en post-master-auth (meme
+		// pre-EnterWorld) car la branche de rendu in-game ligne 3739+ fait
+		// m_chatImGui->Render + ImGui::Render() en supposant qu'un NewFrame a deja ete
+		// appele plus haut. Sans cet appel, ImGui::Render() utilise des draw data stale
+		// -> swapchain presente le meme framebuffer en boucle, ecran fige.
+		// Le RENDU du panneau chat pre-EnterWorld reste desactive (cf. branche
+		// auth-rendering qui n'appelle plus m_chatImGui->Render).
+		const bool chatImguiOverlayNewFrame = m_chatImGui && m_chatUi.IsInitialized()
+			&& postAuthMaster
+			&& (m_cfg.GetBool("render.chat_imgui.enabled", true) || m_inGamePauseMenuVisible || m_inGameOptionsPanelVisible);
 		// M43.4 — NewFrame également quand --editor (sans world-editor exe) actif.
 		const bool editorHubOverlayNewFrame = m_editorHubImGui && m_editorEnabled && !m_worldEditorExe;
 		if (m_worldEditorImGui && m_worldEditorImGui->IsReady()

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3504,16 +3504,14 @@ namespace engine
 				//   | -sin(y)  0   cos(y)    tz |
 				//   | 0        0   0         1  |
 				// Stockage colonne-par-colonne :
-				// Iteration : scale 3x pour rendre l'avatar tres visible (utilisateur
-				// signale "je ne vois pas le perso"). Avatar de 1.8m -> 5.4m visuel,
-				// impossible a manquer. A retuner / supprimer une fois la chaine
-				// complete (mesh+materiel+camera+culling) validee.
-				constexpr float kAvatarScale = 3.0f;
-				const float sc = c * kAvatarScale;
-				const float ss = s * kAvatarScale;
-				out.objectModelMatrix[0]  = sc;    out.objectModelMatrix[1]  = 0.0f;          out.objectModelMatrix[2]  = -ss;  out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local scale
-				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = kAvatarScale;  out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local scale
-				out.objectModelMatrix[8]  = ss;    out.objectModelMatrix[9]  = 0.0f;          out.objectModelMatrix[10] = sc;   out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local scale
+				// Avatar a echelle 1:1 (1.8 m). Le scale x3 introduit pour "garantir
+				// la visibilite" placait la camera A L'INTERIEUR du corps de l'avatar
+				// (5.4 m de haut, camera a 1.81 m au-dessus du sol = inside the model)
+				// -> ecran fige perceptuel. La camera 3eme personne (dist=8m, height=1.5m)
+				// est largement assez genereuse a echelle reelle.
+				out.objectModelMatrix[0]  = c;     out.objectModelMatrix[1]  = 0.0f; out.objectModelMatrix[2]  = -s;   out.objectModelMatrix[3]  = 0.0f; // col0 : axe X local
+				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
+				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
 				// DIAG visibilite avatar : 1 LOG par seconde pour confirmer que la matrice
 				// est bien posee et visible. Aide au triage des plaintes "je ne vois pas le perso".

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -4801,6 +4801,39 @@ namespace engine
 			LOG_WARN(Render, "[WorldEditor] TerrainEditingTools::Init failed");
 		}
 		m_terrain.InvalidateFramebufferCache(device);
+
+		// Repositionne la camera au-dessus du terrain qu'on vient de charger pour
+		// que l'utilisateur voie immediatement le sol apres "Creer une nouvelle carte"
+		// ou "Charger la carte selectionnee". Sans ce reset, la camera peut rester
+		// sous le sol (terrain par defaut a y=100m si heightmap a 0.5 * height_scale=200m,
+		// camera initiale a y=1.5m -> 98.5m sous le sol = sol invisible).
+		// Position calculee : centre XZ du terrain, 50m au-dessus de la hauteur
+		// moyenne attendue, regard pivote vers le bas.
+		if (m_editorMode)
+		{
+			const float ox = m_terrain.GetTerrainOriginX();
+			const float oz = m_terrain.GetTerrainOriginZ();
+			const float ws = m_terrain.GetTerrainWorldSize();
+			const float hs = m_terrain.GetHeightScale();
+			const float centerX = ox + ws * 0.5f;
+			const float centerZ = oz + ws * 0.5f;
+			const float midGroundY = hs * 0.5f; // heightmap mid-value -> sol moyen
+
+			engine::render::Camera reset;
+			reset.position.x = centerX;
+			reset.position.y = midGroundY + 50.0f;       // 50m au-dessus du sol moyen
+			reset.position.z = centerZ + ws * 0.25f;     // recule a 25% du world size
+			reset.yaw = 0.0f;
+			reset.pitch = 0.5f;                          // vue plongeante ~28deg
+			reset.fovYDeg = 70.0f;
+			reset.aspect = static_cast<float>(std::max(1, m_width)) / static_cast<float>(std::max(1, m_height));
+			reset.nearZ = 0.1f;
+			reset.farZ = 5000.0f;
+			m_renderStates[0].camera = reset;
+			m_renderStates[1].camera = reset;
+			LOG_INFO(Render, "[WorldEditor] Camera repositioned above terrain center=({:.1f},{:.1f}) groundY={:.1f} cameraY={:.1f}",
+				centerX, centerZ, midGroundY, reset.position.y);
+		}
 	}
 #endif
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3008,7 +3008,9 @@ namespace engine
 						spawnY   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.y", 100.0));
 						spawnZ   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.z", 0.0));
 						yawDeg   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.yaw_deg", 0.0));
-						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", -10.0));
+						// Pitch -20deg par defaut : vue 3eme personne legerement plongeante,
+						// pour bien voir le perso au centre-bas de l'ecran (cf. WoW/New World/Once Human).
+						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", -20.0));
 						LOG_INFO(Core, "[EnterWorld] using config default spawn (no per-character data)");
 					}
 					constexpr float kDeg2Rad = 3.14159265f / 180.f;
@@ -3495,6 +3497,20 @@ namespace engine
 				out.objectModelMatrix[4]  = 0.0f;  out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f; // col1 : axe Y local
 				out.objectModelMatrix[8]  = s;     out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = c;    out.objectModelMatrix[11] = 0.0f; // col2 : axe Z local
 				out.objectModelMatrix[12] = target.x; out.objectModelMatrix[13] = feetY; out.objectModelMatrix[14] = target.z; out.objectModelMatrix[15] = 1.0f; // col3 : translation
+				// DIAG visibilite avatar : 1 LOG par seconde pour confirmer que la matrice
+				// est bien posee et visible. Aide au triage des plaintes "je ne vois pas le perso".
+				static double s_lastAvatarDiagAt = -1000.0;
+				const double nowSec = static_cast<double>(m_currentFrame) * 0.0167;
+				if (nowSec - s_lastAvatarDiagAt > 1.0)
+				{
+					s_lastAvatarDiagAt = nowSec;
+					LOG_INFO(Render, "[Avatar] pos=({:.2f},{:.2f},{:.2f}) feetY={:.2f} cam=({:.2f},{:.2f},{:.2f}) yaw={:.2f}deg pitch={:.2f}deg dist={:.2f}m visible={}",
+						target.x, target.y, target.z, feetY,
+						out.camera.position.x, out.camera.position.y, out.camera.position.z,
+						out.camera.yaw * 57.2958f, out.camera.pitch * 57.2958f,
+						m_orbitalCameraController.GetDistance(),
+						out.objectVisible ? 1 : 0);
+				}
 			}
 		}
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3017,23 +3017,21 @@ namespace engine
 						spawnY   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.y", 100.0));
 						spawnZ   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.z", 0.0));
 						yawDeg   = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.yaw_deg", 0.0));
-						// Pitch +20deg par defaut : convention orbital camera = pitch
-						// positif fait que la camera se positionne AU-DESSUS du target et
-						// regarde vers le bas (cf. Camera.cpp lignes 280-345 : camera.y =
-						// target.y - sin(pitch)*distance, sin > 0 -> camera plus haut).
-						// Le sign etait inverse precedemment (-20) -> camera placee EN-DESSOUS
-						// du target regardant le ciel -> ecran "fige" (rien de visible).
-						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", 20.0));
+						// Pitch +10deg par defaut : vue legerement plongeante. +20deg etait
+						// trop agressif et declenchait le clamp anti-collision sol qui
+						// reduisait effectiveDistance de 8m a 3.5m, mettant la camera
+						// quasi dans le mesh de l'avatar. +10deg laisse 8m reels.
+						pitchDeg = static_cast<float>(m_cfg.GetDouble("client.world.default_spawn.pitch_deg", 10.0));
 						LOG_INFO(Core, "[EnterWorld] using config default spawn (no per-character data)");
 					}
 					constexpr float kDeg2Rad = 3.14159265f / 180.f;
-					// Force un pitch initial plongeant (+20deg) si le pitch sauvegarde est
-					// trop proche de l'horizon (ex. 0deg ou -10deg des anciens defauts DB).
-					// Convention : pitch positif = vue plongeante (cf. ci-dessus).
-					if (pitchDeg < 10.0f)
+					// Force pitch dans plage [5, 20] : <5deg cache le perso (camera trop
+					// horizontale), >20deg declenche le clamp anti-collision sol qui
+					// rapproche la camera dans le mesh.
+					if (pitchDeg < 5.0f || pitchDeg > 20.0f)
 					{
-						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg insuffisant pour vue plongeante 3eme personne, force a +20deg", pitchDeg);
-						pitchDeg = 20.0f;
+						LOG_INFO(Core, "[EnterWorld] pitch sauvegarde={}deg hors plage [5,20], force a +10deg", pitchDeg);
+						pitchDeg = 10.0f;
 					}
 					out.camera.position.x = spawnX;
 					out.camera.position.y = spawnY;

--- a/engine/editor/EditorMode.cpp
+++ b/engine/editor/EditorMode.cpp
@@ -880,15 +880,67 @@ namespace engine::editor
 			selectedVolume->stringId = (selectedVolume->stringId == "trigger.default") ? "trigger.alt" : "trigger.default";
 			break;
 		case VolumeType::SpawnArea:
-			selectedVolume->stringId = (selectedVolume->stringId == "spawn.default") ? "spawn.elite" : "spawn.default";
+		{
+			// Cycle a 9 etats predefinies (V successifs) : couvre les 8 combos
+			// race+faction par defaut (cf. migration 0040 backfill) + un etat
+			// "match all" sans filtre. Une UI ImGui dediee viendra plus tard pour
+			// permettre du multi-select race et un dropdown faction libre.
+			struct SpawnPreset { const char* faction; const char* race; const char* sid; };
+			static constexpr SpawnPreset kPresets[] = {
+				{ "",           "",                   "spawn.default" }, ///< Match all (faction + race quelconques).
+				{ "lumiere",    "humains",            "spawn.default" },
+				{ "lumiere",    "nains",              "spawn.default" },
+				{ "lumiere",    "elfes",              "spawn.default" },
+				{ "lumiere",    "chevaliers_dragons", "spawn.default" },
+				{ "ombres",     "orcs",               "spawn.default" },
+				{ "ombres",     "demons",             "spawn.default" },
+				{ "crepuscule", "",                   "spawn.default" }, ///< Neutres / mercenaires : toutes races.
+				{ "",           "",                   "spawn.elite"   }, ///< Spawn elite (raid lead, instance) sans filtre.
+			};
+			// Trouve l'index courant du preset (par egalite stringId+faction+race).
+			const std::string currentRace = selectedVolume->raceFilters.empty() ? std::string{} : selectedVolume->raceFilters[0];
+			size_t idx = 0u;
+			for (size_t k = 0; k < std::size(kPresets); ++k)
+			{
+				if (selectedVolume->stringId == kPresets[k].sid
+					&& selectedVolume->factionFilter == kPresets[k].faction
+					&& currentRace == kPresets[k].race)
+				{
+					idx = k;
+					break;
+				}
+			}
+			idx = (idx + 1u) % std::size(kPresets);
+			selectedVolume->stringId      = kPresets[idx].sid;
+			selectedVolume->factionFilter = kPresets[idx].faction;
+			selectedVolume->raceFilters.clear();
+			if (kPresets[idx].race[0] != '\0')
+				selectedVolume->raceFilters.emplace_back(kPresets[idx].race);
 			break;
+		}
 		case VolumeType::ZoneTransition:
 			selectedVolume->targetZoneId = (selectedVolume->targetZoneId == "zone.next") ? "zone.return" : "zone.next";
 			break;
 		}
 
 		MarkDirty("volume-property");
-		LOG_INFO(Core, "[EditorMode] Volume property cycled (id={}, type={})", selectedVolume->id, GetVolumeTypeName(selectedVolume->type));
+		// Pour un SpawnArea on remonte les filtres race+faction dans le log pour
+		// que le mappeur voie ce qu'il a configure (utile sans UI inspecteur).
+		if (selectedVolume->type == VolumeType::SpawnArea)
+		{
+			const std::string raceLog = selectedVolume->raceFilters.empty()
+				? std::string("(toutes)")
+				: selectedVolume->raceFilters[0];
+			const std::string factionLog = selectedVolume->factionFilter.empty()
+				? std::string("(toutes)")
+				: selectedVolume->factionFilter;
+			LOG_INFO(Core, "[EditorMode] SpawnArea cycled (id={}, stringId={}, faction={}, race={})",
+				selectedVolume->id, selectedVolume->stringId, factionLog, raceLog);
+		}
+		else
+		{
+			LOG_INFO(Core, "[EditorMode] Volume property cycled (id={}, type={})", selectedVolume->id, GetVolumeTypeName(selectedVolume->type));
+		}
 		return true;
 	}
 
@@ -1064,14 +1116,26 @@ namespace engine::editor
 		for (size_t i = 0; i < spawnsSorted.size(); ++i)
 		{
 			const VolumeEntity& volume = *spawnsSorted[i];
+			std::string raceFiltersJson = "[";
+			for (size_t r = 0; r < volume.raceFilters.size(); ++r)
+			{
+				raceFiltersJson += "\"";
+				raceFiltersJson += volume.raceFilters[r];
+				raceFiltersJson += "\"";
+				if (r + 1u < volume.raceFilters.size())
+					raceFiltersJson += ", ";
+			}
+			raceFiltersJson += "]";
 			json += std::format(
-				"    {{ \"id\": {}, \"type\": \"{}\", \"shape\": \"{}\", \"position\": [{:.3f}, {:.3f}, {:.3f}], \"radius\": {:.3f}, \"stringId\": \"{}\" }}{}\n",
+				"    {{ \"id\": {}, \"type\": \"{}\", \"shape\": \"{}\", \"position\": [{:.3f}, {:.3f}, {:.3f}], \"radius\": {:.3f}, \"stringId\": \"{}\", \"raceFilters\": {}, \"factionFilter\": \"{}\" }}{}\n",
 				volume.id,
 				GetVolumeTypeName(volume.type),
 				GetVolumeShapeName(volume.shape),
 				volume.position.x, volume.position.y, volume.position.z,
 				volume.sphereRadius,
 				volume.stringId,
+				raceFiltersJson,
+				volume.factionFilter,
 				(i + 1u < spawnsSorted.size()) ? "," : "");
 		}
 		json += "  ],\n";

--- a/engine/editor/EditorMode.cpp
+++ b/engine/editor/EditorMode.cpp
@@ -881,21 +881,22 @@ namespace engine::editor
 			break;
 		case VolumeType::SpawnArea:
 		{
-			// Cycle a 9 etats predefinies (V successifs) : couvre les 8 combos
-			// race+faction par defaut (cf. migration 0040 backfill) + un etat
-			// "match all" sans filtre. Une UI ImGui dediee viendra plus tard pour
-			// permettre du multi-select race et un dropdown faction libre.
+			// Cycle a 9 etats predefinies (V successifs) : couvre les factions
+			// race-lockees definies en migration 0040 + un etat "match all" sans
+			// filtre. Une UI ImGui dediee viendra plus tard pour permettre du
+			// multi-select race et un dropdown faction libre (incluant les sous-
+			// maisons des factions).
 			struct SpawnPreset { const char* faction; const char* race; const char* sid; };
 			static constexpr SpawnPreset kPresets[] = {
-				{ "",           "",                   "spawn.default" }, ///< Match all (faction + race quelconques).
-				{ "lumiere",    "humains",            "spawn.default" },
-				{ "lumiere",    "nains",              "spawn.default" },
-				{ "lumiere",    "elfes",              "spawn.default" },
-				{ "lumiere",    "chevaliers_dragons", "spawn.default" },
-				{ "ombres",     "orcs",               "spawn.default" },
-				{ "ombres",     "demons",             "spawn.default" },
-				{ "crepuscule", "",                   "spawn.default" }, ///< Neutres / mercenaires : toutes races.
-				{ "",           "",                   "spawn.elite"   }, ///< Spawn elite (raid lead, instance) sans filtre.
+				{ "",                   "",                   "spawn.default" }, ///< Match all (faction + race quelconques).
+				{ "chevaliers_lumiere", "humains",            "spawn.default" },
+				{ "chevaliers_justice", "humains",            "spawn.default" },
+				{ "lune_noire",         "humains",            "spawn.default" },
+				{ "empire_hynn",        "humains",            "spawn.default" },
+				{ "dzorak",             "orcs",               "spawn.default" },
+				{ "demons",             "demons",             "spawn.default" },
+				{ "chevaliers_dragons", "chevaliers_dragons", "spawn.default" },
+				{ "",                   "",                   "spawn.elite"   }, ///< Spawn elite (raid lead, instance) sans filtre.
 			};
 			// Trouve l'index courant du preset (par egalite stringId+faction+race).
 			const std::string currentRace = selectedVolume->raceFilters.empty() ? std::string{} : selectedVolume->raceFilters[0];

--- a/engine/editor/EditorMode.cpp
+++ b/engine/editor/EditorMode.cpp
@@ -245,11 +245,16 @@ namespace engine::editor
 		LOG_INFO(Core, "[EditorMode] Destroyed");
 	}
 
+	/// Construit la camera initiale de l'editeur monde.
+	/// Position (0, 150, 200) : au-dessus de la mi-hauteur d'un terrain par defaut
+	/// (heightmap=0.5 * height_scale=200m -> sol a y=100m). Camera 50m au-dessus
+	/// du sol attendu, regardant vers le centre du terrain (origin par defaut 0,0).
+	/// Pitch +0.5 rad (~28deg) : vue plongeante pour voir le sol en contrebas.
 	engine::render::Camera EditorMode::BuildInitialCamera() const
 	{
 		engine::render::Camera camera;
-		camera.position = { 0.0f, 1.5f, 5.0f };
-		camera.pitch = 0.18f;
+		camera.position = { 0.0f, 150.0f, 200.0f };
+		camera.pitch = 0.5f;
 		return camera;
 	}
 

--- a/engine/editor/EditorMode.h
+++ b/engine/editor/EditorMode.h
@@ -75,6 +75,16 @@ namespace engine::editor
 		float sphereRadius = 1.0f;
 		std::string stringId = "default";
 		std::string targetZoneId;
+		// SpawnArea : filtres race + faction du premier spawn. Vides = match all.
+		// raceFilters : liste d'ids races (cf. game/data/races/races.json :
+		//   humains, elfes, orcs, nains, demons, chevaliers_dragons). Vide = toutes.
+		// factionFilter : id faction unique (cf. table DB factions :
+		//   lumiere, ombres, crepuscule). Vide = toutes.
+		// Le serveur (CharacterEnterWorldHandler) selectionne au premier login
+		// le SpawnArea dont (race, faction) du perso matche les filtres ; en cas
+		// d'egalite il prend le plus pres de l'origine du terrain.
+		std::vector<std::string> raceFilters;
+		std::string factionFilter;
 	};
 
 	/// Minimal editor mode shell: one editable scene object, CPU selection, and keyboard gizmos.

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -855,6 +855,24 @@ namespace engine::editor
 			// ImGuiDockNodeFlags_PassthroughCentralNode (1<<4) - litteral pour eviter les divergences d'en-tetes.
 			constexpr ImGuiDockNodeFlags kDockSpaceFlags = static_cast<ImGuiDockNodeFlags>(1u << 4);
 
+			// Detection de resize de fenetre : si la taille du viewport a change
+			// depuis la derniere frame, on force DockBuilderSetNodeSize sur le node
+			// racine pour que les panneaux dockes se relayent automatiquement. Sans
+			// ce relayout, les panneaux restent ancres a l'ancienne taille (lue dans
+			// world_editor_imgui.ini), ce qui les place hors du viewport et donne
+			// l'impression que l'UI a disparu apres un drag de bord de fenetre.
+			constexpr float kResizeEpsilonPx = 0.5f;
+			if (std::fabs(vp->WorkSize.x - m_lastDockSpaceWidth)  > kResizeEpsilonPx
+			 || std::fabs(vp->WorkSize.y - m_lastDockSpaceHeight) > kResizeEpsilonPx)
+			{
+				if (ImGui::DockBuilderGetNode(dockId) != nullptr)
+				{
+					ImGui::DockBuilderSetNodeSize(dockId, vp->WorkSize);
+				}
+				m_lastDockSpaceWidth  = vp->WorkSize.x;
+				m_lastDockSpaceHeight = vp->WorkSize.y;
+			}
+
 			// Disposition par defaut : si ImGui n'a pas charge de layout depuis world_editor_imgui.ini
 			// (premier demarrage, fichier supprime via le menu Vue, ou nouveau dockId), on pose une
 			// disposition propre (palette gauche, inspecteur droite, scene centrale, statut bas) via

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -856,22 +856,31 @@ namespace engine::editor
 			constexpr ImGuiDockNodeFlags kDockSpaceFlags = static_cast<ImGuiDockNodeFlags>(1u << 4);
 
 			// Detection de resize de fenetre : si la taille du viewport a change
-			// depuis la derniere frame, on force DockBuilderSetNodeSize sur le node
-			// racine pour que les panneaux dockes se relayent automatiquement. Sans
-			// ce relayout, les panneaux restent ancres a l'ancienne taille (lue dans
-			// world_editor_imgui.ini), ce qui les place hors du viewport et donne
-			// l'impression que l'UI a disparu apres un drag de bord de fenetre.
+			// depuis la derniere frame (apres initialisation), on force
+			// DockBuilderSetNodeSize sur le node racine pour que les panneaux dockes
+			// se relayent automatiquement. Sans ce relayout, les panneaux restent
+			// ancres a l'ancienne taille (lue dans world_editor_imgui.ini), ce qui
+			// les place hors du viewport et donne l'impression que l'UI a disparu
+			// apres un drag de bord de fenetre.
+			//
+			// IMPORTANT : on ne fire pas la premiere frame (m_lastDockSpaceWidth==0
+			// par defaut) car le node racine n'existe pas encore (cree par le bloc
+			// m_defaultLayoutAttempted juste au-dessus). DockBuilderSetNodeSize
+			// avant que la layout par defaut ait ete posee bouilli les sizes
+			// proportionnelles -> ecran noir signale par l'utilisateur.
 			constexpr float kResizeEpsilonPx = 0.5f;
-			if (std::fabs(vp->WorkSize.x - m_lastDockSpaceWidth)  > kResizeEpsilonPx
-			 || std::fabs(vp->WorkSize.y - m_lastDockSpaceHeight) > kResizeEpsilonPx)
+			const bool dockSizeInitialized = (m_lastDockSpaceWidth > kResizeEpsilonPx);
+			if (dockSizeInitialized
+			 && (std::fabs(vp->WorkSize.x - m_lastDockSpaceWidth)  > kResizeEpsilonPx
+			  || std::fabs(vp->WorkSize.y - m_lastDockSpaceHeight) > kResizeEpsilonPx))
 			{
 				if (ImGui::DockBuilderGetNode(dockId) != nullptr)
 				{
 					ImGui::DockBuilderSetNodeSize(dockId, vp->WorkSize);
 				}
-				m_lastDockSpaceWidth  = vp->WorkSize.x;
-				m_lastDockSpaceHeight = vp->WorkSize.y;
 			}
+			m_lastDockSpaceWidth  = vp->WorkSize.x;
+			m_lastDockSpaceHeight = vp->WorkSize.y;
 
 			// Disposition par defaut : si ImGui n'a pas charge de layout depuis world_editor_imgui.ini
 			// (premier demarrage, fichier supprime via le menu Vue, ou nouveau dockId), on pose une

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -367,7 +367,8 @@ namespace engine::editor
 		uint32_t swapchainImageCount,
 		uint32_t vulkanApiVersion,
 		void* hwndNative,
-		const engine::core::Config* cfg)
+		const engine::core::Config* cfg,
+		bool isWorldEditorExe)
 	{
 #if !defined(_WIN32)
 		(void)instance;
@@ -377,6 +378,7 @@ namespace engine::editor
 		(void)vulkanApiVersion;
 		(void)hwndNative;
 		(void)cfg;
+		(void)isWorldEditorExe;
 		return false;
 #else
 		if (m_ready)
@@ -468,6 +470,55 @@ namespace engine::editor
 
 		if (cfg != nullptr)
 		{
+			// Editeur monde (lcdlln_world_editor.exe) : on substitue Arial a Windlass
+			// comme police par defaut. Windlass est decorative (faite pour l'UI auth /
+			// in-game qui evoque le lore Lune Noire) — illisible et limitee en glyphs
+			// pour un editeur de carte technique. Arial est neutre, riche en glyphs
+			// (accents, ponctuation), et standard sur Windows (C:/Windows/Fonts/arial.ttf).
+			//
+			// Sequence : si isWorldEditorExe ET le fichier Arial est lisible, on charge
+			// Arial en PREMIER (devient ImGui::GetFont() par defaut). Le bloc Windlass
+			// existant en dessous est court-circuite par un flag local pour eviter que
+			// Windlass se retrouve par-dessus dans l'atlas. Si Arial absent, fallback
+			// Windlass comme avant (degradation gracieuse).
+			bool arialLoaded = false;
+			if (isWorldEditorExe)
+			{
+				const std::string arialPath = cfg->GetString("editor.font.arial_path", "C:/Windows/Fonts/arial.ttf");
+				const float arialPx = static_cast<float>(std::clamp<int64_t>(
+					cfg->GetInt("editor.font.arial_pixel_height", 14), 11, 32));
+				// arial_path : chemin absolu (defaut C:/Windows/Fonts/arial.ttf) OU
+				// chemin relatif a paths.content. On tente d'abord absolu puis content.
+				std::vector<uint8_t> bytesArial = engine::platform::FileSystem::ReadAllBytes(std::filesystem::path(arialPath));
+				if (bytesArial.empty())
+				{
+					bytesArial = engine::platform::FileSystem::ReadAllBytesContent(*cfg, arialPath);
+				}
+				if (!bytesArial.empty())
+				{
+					void* atlasArial = IM_ALLOC(bytesArial.size());
+					std::memcpy(atlasArial, bytesArial.data(), bytesArial.size());
+					ImFontConfig acfg{};
+					// Range standard latin1 (couvre A-Z, a-z, 0-9, accents FR, ponctuation).
+					ImFont* arialFont = io.Fonts->AddFontFromMemoryTTF(atlasArial, static_cast<int>(bytesArial.size()),
+						arialPx, &acfg, io.Fonts->GetGlyphRangesDefault());
+					if (arialFont != nullptr)
+					{
+						arialLoaded = true;
+						LOG_INFO(Render, "[WorldEditorImGui] Police editeur Arial chargee : {} ({}px)", arialPath, arialPx);
+					}
+					else
+					{
+						IM_FREE(atlasArial);
+						LOG_WARN(Render, "[WorldEditorImGui] AddFontFromMemoryTTF Arial a echoue : {}", arialPath);
+					}
+				}
+				else
+				{
+					LOG_WARN(Render, "[WorldEditorImGui] Police editeur Arial introuvable : {} (fallback Windlass)", arialPath);
+				}
+			}
+
 			// Cles specifiques a la piste ImGui (la piste Vulkan/AuthGlyphPass garde sa propre
 			// taille via render.auth_ui.font_pixel_height = 28). En ImGui les facteurs
 			// SetWindowFontScale (1.62 pour le titre, 1.12 pour le sous-titre, 1.15 pour le titre
@@ -475,10 +526,17 @@ namespace engine::editor
 			// ProggyClean ~13 px ; charger Windlass a la meme taille respecte donc tous les
 			// gabarits existants. On peut surcharger via render.auth_ui.imgui.font_pixel_height
 			// si on veut grossir/reduire globalement l'UI auth ImGui sans toucher aux scales.
+			//
+			// arialLoaded=true (editeur monde) court-circuite Windlass pour qu'Arial reste
+			// la police par defaut. L'editeur n'utilise pas les ecrans auth, donc Windlass
+			// n'a pas d'usage la-bas.
 			const std::string uiFontPath = cfg->GetString("render.auth_ui.font_path", "");
 			const float uiFontPx = static_cast<float>(std::clamp<int64_t>(
 				cfg->GetInt("render.auth_ui.imgui.font_pixel_height", 13), 11, 32));
-			loadAuthFontFromConfig(uiFontPath, uiFontPx, "UI");
+			if (!arialLoaded)
+			{
+				loadAuthFontFromConfig(uiFontPath, uiFontPx, "UI");
+			}
 
 			// Fallback merge : Windlass.ttf ne contient pas les caracteres accentues, '*' (utilise
 			// par ImGuiInputTextFlags_Password), '[' ']' '%' '@' et autres ponctuations etendues.
@@ -487,6 +545,10 @@ namespace engine::editor
 			// reste prioritaire pour A-Z/a-z/0-9 et ProggyClean prend le relais pour les autres.
 			// Visuellement les glyphes de fallback ne matchent pas la maquette mais c'est mieux
 			// que des '?'.
+			//
+			// Si arialLoaded (editeur monde), on saute ProggyClean : Arial couvre deja les
+			// accents et ponctuations etendues, pas besoin de fallback.
+			if (!arialLoaded)
 			{
 				ImFontConfig fallbackCfg{};
 				fallbackCfg.MergeMode = true;
@@ -497,14 +559,22 @@ namespace engine::editor
 			const std::string valueFontPath = cfg->GetString("render.auth_ui.value_font_path", "");
 			const float valueFontPx = static_cast<float>(std::clamp<int64_t>(
 				cfg->GetInt("render.auth_ui.imgui.value_font_pixel_height", 12), 11, 32));
-			loadAuthFontFromConfig(valueFontPath, valueFontPx, "valeurs");
+			if (!arialLoaded)
+			{
+				// Police "valeurs" Morpheus : utile uniquement pour l'UI auth (nom du
+				// perso, montant en or...). Pas pertinent dans l'editeur monde.
+				loadAuthFontFromConfig(valueFontPath, valueFontPx, "valeurs");
+			}
 
 			// Fonte password : 2eme passe sur Windlass a 24 px (plus large que la
 			// fonte UI standard 13 px), avec un merge ProggyClean immediat pour le
 			// glyph '*' qui n'est pas dans Windlass. Le pointeur est partage via
 			// SharedFontHandles::g_largePasswordFont pour que DrawAuthGoldField
 			// puisse PushFont autour de l'InputText password.
-			if (!uiFontPath.empty())
+			//
+			// Skipped en mode editeur monde : pas d'ecran auth, pas d'InputText
+			// password. Le pointeur partage reste a nullptr.
+			if (!arialLoaded && !uiFontPath.empty())
 			{
 				std::vector<uint8_t> bytesPwd = engine::platform::FileSystem::ReadAllBytesContent(*cfg, uiFontPath);
 				if (!bytesPwd.empty())

--- a/engine/editor/WorldEditorImGui.h
+++ b/engine/editor/WorldEditorImGui.h
@@ -72,13 +72,18 @@ namespace engine::editor
 		/// \param hwndNative \c HWND sous Windows, sinon ignoré.
 		/// \param cfg utilisé pour charger les polices TTF de l'UI auth (Windlass / Morpheus) dans
 		/// l'atlas ImGui avant la création de la texture de fonts par ImGui_ImplVulkan_Init.
+		/// \param isWorldEditorExe \c true pour \c lcdlln_world_editor.exe : la police par defaut
+		/// devient Arial (lisible, neutre pour un editeur de carte) au lieu de Windlass (decorative,
+		/// reservee a l'UI auth/in-game). Cf. \c editor.font.arial_path / \c editor.font.arial_pixel_height
+		/// dans config.json. Aucun effet si \c false (UI auth garde Windlass).
 		bool Init(VkInstance instance,
 			const engine::render::VkDeviceContext& deviceContext,
 			VkFormat swapchainFormat,
 			uint32_t swapchainImageCount,
 			uint32_t vulkanApiVersion,
 			void* hwndNative,
-			const engine::core::Config* cfg = nullptr);
+			const engine::core::Config* cfg = nullptr,
+			bool isWorldEditorExe = false);
 
 		void Shutdown(VkDevice device);
 

--- a/engine/editor/WorldEditorImGui.h
+++ b/engine/editor/WorldEditorImGui.h
@@ -120,6 +120,12 @@ namespace engine::editor
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
 		/// repassé à true après la pose.
 		bool m_defaultLayoutAttempted = false;
+		/// Dimensions du dockspace au dernier frame BuildUi. Sert a detecter un
+		/// resize de fenetre pour forcer DockBuilderSetNodeSize sur le node racine
+		/// (sinon les panneaux dockes restent ancres a l'ancienne taille apres
+		/// un drag de bord de fenetre, donnant une UI vide ou hors viewport).
+		float m_lastDockSpaceWidth  = 0.0f;
+		float m_lastDockSpaceHeight = 0.0f;
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 #endif

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -334,12 +334,16 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Decalage epaule droite : 0.3 m vers la droite -> perso legerement decentre.
-		// Decalage hauteur : +0.5 m au-dessus des yeux -> camera un peu plus haute.
-		// Valeurs reduites par rapport a l'iteration precedente (0.8m / 1.2m) qui
-		// faisait disparaitre le perso de l'ecran chez l'utilisateur. A re-tuner.
+		// Demande utilisateur : "ideallement on devrait se trouver un peu au-dessus
+		// de lui ... ainsi on pourra voir ce qu'il y a devant lui".
+		// kHeightOffsetM = 2.5m : camera physiquement 2.5m au-dessus du niveau des
+		// yeux du perso (donc ~4.2m au-dessus du sol pour un humain de 1.8m). Combine
+		// au pitch initial qui regarde l'avant, on voit le perso dans la moitie basse
+		// de l'ecran et le terrain devant lui dans la moitie haute.
+		// kShoulderOffsetM = 0.3m : avatar legerement decale a gauche de l'ecran
+		// (over-the-shoulder droite, classique MMO).
 		constexpr float kShoulderOffsetM = 0.3f;
-		constexpr float kHeightOffsetM   = 0.5f;
+		constexpr float kHeightOffsetM   = 2.5f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -135,6 +135,12 @@ namespace engine::render
 	void OrbitalCameraController::SetTargetPosition(const engine::math::Vec3& worldPos)
 	{
 		m_target = worldPos;
+		// Reset defensif de la distance a kDistanceDefault. Sans ca, si l'utilisateur
+		// avait zoome a kDistanceMin sur un perso precedent, le nouveau spawn restait
+		// camera collee au nouveau perso (souvent invisible car dans le mesh).
+		m_distance = kDistanceDefault;
+		m_verticalVelocityY = 0.0f;
+		m_verticalOffsetY = 0.0f;
 		m_initialized = true;
 	}
 
@@ -334,14 +340,14 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Iteration 3 : utilisateur signale que le perso reste invisible avec 0.3/0.5
-		// + dist=5m. On centre l'avatar (epaule=0) et on remonte la camera bien au-dessus
-		// (1.5m au-dessus de la tete) pour un cadrage MMO classique : perso au centre-bas
-		// de l'ecran, vue legerement plongeante. Combine a kDistanceDefault=8m, le perso
-		// occupe ~1/4 de la hauteur ecran et reste clairement visible meme apres
-		// translations/zooms.
+		// Iteration 4 : retire les offsets epaule + hauteur. Avec un clamp anti-collision
+		// agressif (effectiveDistance reduit a 3.51m quand pitch=20deg), l'addition d'un
+		// kHeightOffsetM=1.5m fait que la camera vise 1.5m AU-DESSUS de la tete de l'avatar
+		// -> avatar dans le tiers inferieur, parfois confondu avec le terrain. On ramene
+		// les offsets a 0 : la camera vise EXACTEMENT le point cible (la tete) a la
+		// distance effective. Avatar centre vertical, impossible a manquer.
 		constexpr float kShoulderOffsetM = 0.0f;
-		constexpr float kHeightOffsetM   = 1.5f;
+		constexpr float kHeightOffsetM   = 0.0f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -135,12 +135,6 @@ namespace engine::render
 	void OrbitalCameraController::SetTargetPosition(const engine::math::Vec3& worldPos)
 	{
 		m_target = worldPos;
-		// Reset defensif de la distance a kDistanceDefault. Sans ca, si l'utilisateur
-		// avait zoome a kDistanceMin sur un perso precedent, le nouveau spawn restait
-		// camera collee au nouveau perso (souvent invisible car dans le mesh).
-		m_distance = kDistanceDefault;
-		m_verticalVelocityY = 0.0f;
-		m_verticalOffsetY = 0.0f;
 		m_initialized = true;
 	}
 
@@ -340,14 +334,12 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Iteration 4 : retire les offsets epaule + hauteur. Avec un clamp anti-collision
-		// agressif (effectiveDistance reduit a 3.51m quand pitch=20deg), l'addition d'un
-		// kHeightOffsetM=1.5m fait que la camera vise 1.5m AU-DESSUS de la tete de l'avatar
-		// -> avatar dans le tiers inferieur, parfois confondu avec le terrain. On ramene
-		// les offsets a 0 : la camera vise EXACTEMENT le point cible (la tete) a la
-		// distance effective. Avatar centre vertical, impossible a manquer.
-		constexpr float kShoulderOffsetM = 0.0f;
-		constexpr float kHeightOffsetM   = 0.0f;
+		// Decalage epaule droite : 0.3 m vers la droite -> perso legerement decentre.
+		// Decalage hauteur : +0.5 m au-dessus des yeux -> camera un peu plus haute.
+		// Valeurs reduites par rapport a l'iteration precedente (0.8m / 1.2m) qui
+		// faisait disparaitre le perso de l'ecran chez l'utilisateur. A re-tuner.
+		constexpr float kShoulderOffsetM = 0.3f;
+		constexpr float kHeightOffsetM   = 0.5f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -334,12 +334,14 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Decalage epaule droite : 0.3 m vers la droite -> perso legerement decentre.
-		// Decalage hauteur : +0.5 m au-dessus des yeux -> camera un peu plus haute.
-		// Valeurs reduites par rapport a l'iteration precedente (0.8m / 1.2m) qui
-		// faisait disparaitre le perso de l'ecran chez l'utilisateur. A re-tuner.
-		constexpr float kShoulderOffsetM = 0.3f;
-		constexpr float kHeightOffsetM   = 0.5f;
+		// Iteration 3 : utilisateur signale que le perso reste invisible avec 0.3/0.5
+		// + dist=5m. On centre l'avatar (epaule=0) et on remonte la camera bien au-dessus
+		// (1.5m au-dessus de la tete) pour un cadrage MMO classique : perso au centre-bas
+		// de l'ecran, vue legerement plongeante. Combine a kDistanceDefault=8m, le perso
+		// occupe ~1/4 de la hauteur ecran et reste clairement visible meme apres
+		// translations/zooms.
+		constexpr float kShoulderOffsetM = 0.0f;
+		constexpr float kHeightOffsetM   = 1.5f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -334,14 +334,12 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Decalage epaule droite : 0.8 m vers la droite -> perso apparait a gauche.
-		// Decalage hauteur : +1.2 m au-dessus des yeux du target -> la camera est
-		// nettement plus haute que le personnage (head ~ 1.8 m, camera Y ~ 2.9 m
-		// soit ~1.1 m au-dessus du crane). Combine avec le pitch -10 deg par defaut,
-		// le perso apparait dans la moitie INFERIEURE de l'ecran et on voit bien
-		// le decor au-dessus de lui (style Once Human / New World).
-		constexpr float kShoulderOffsetM = 0.8f;
-		constexpr float kHeightOffsetM   = 1.2f;
+		// Decalage epaule droite : 0.3 m vers la droite -> perso legerement decentre.
+		// Decalage hauteur : +0.5 m au-dessus des yeux -> camera un peu plus haute.
+		// Valeurs reduites par rapport a l'iteration precedente (0.8m / 1.2m) qui
+		// faisait disparaitre le perso de l'ecran chez l'utilisateur. A re-tuner.
+		constexpr float kShoulderOffsetM = 0.3f;
+		constexpr float kHeightOffsetM   = 0.5f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -334,16 +334,11 @@ namespace engine::render
 		const float rightLen = std::sqrt(rightX * rightX + rightZ * rightZ);
 		const float rightNX = rightLen > 0.0f ? rightX / rightLen : 1.0f;
 		const float rightNZ = rightLen > 0.0f ? rightZ / rightLen : 0.0f;
-		// Demande utilisateur : "ideallement on devrait se trouver un peu au-dessus
-		// de lui ... ainsi on pourra voir ce qu'il y a devant lui".
-		// kHeightOffsetM = 2.5m : camera physiquement 2.5m au-dessus du niveau des
-		// yeux du perso (donc ~4.2m au-dessus du sol pour un humain de 1.8m). Combine
-		// au pitch initial qui regarde l'avant, on voit le perso dans la moitie basse
-		// de l'ecran et le terrain devant lui dans la moitie haute.
-		// kShoulderOffsetM = 0.3m : avatar legerement decale a gauche de l'ecran
-		// (over-the-shoulder droite, classique MMO).
-		constexpr float kShoulderOffsetM = 0.3f;
-		constexpr float kHeightOffsetM   = 2.5f;
+		// Cible image 2 utilisateur : avatar ~26% hauteur ecran. Camera 5m derriere,
+		// 1m au-dessus du niveau des yeux (donc ~2.7m au-dessus du sol pour un humain
+		// de 1.8m). Pas d'over-the-shoulder, perso au centre de l'ecran.
+		constexpr float kShoulderOffsetM = 0.0f;
+		constexpr float kHeightOffsetM   = 1.0f;
 		camera.position.x = m_target.x - forwardX * effectiveDistance + rightNX * kShoulderOffsetM;
 		camera.position.y = m_target.y - forwardY * effectiveDistance + kHeightOffsetM;
 		camera.position.z = m_target.z - forwardZ * effectiveDistance + rightNZ * kShoulderOffsetM;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,10 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 3 m par defaut : caracteres tres pres pour debug visuel (image utilisateur :
-		// avatar visible mais ~30px sur 1080 a distance 5m, trop petit). 3m donne
-		// un cadrage MMO classique tres lisible. Reglable via molette de 1.5 a 20m.
-		static constexpr float kDistanceDefault = 3.0f;
+		// 6 m par defaut : moins de 10m derriere le perso (demande utilisateur),
+		// permet de voir ce qu'il y a devant lui sans etre colle dans son dos.
+		// Reglable via molette de 1.5 a 20m.
+		static constexpr float kDistanceDefault = 6.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -79,12 +79,11 @@ namespace engine::render
 		static constexpr float kRunSpeed        = 10.0f;
 		static constexpr float kPitchMin        = -60.0f * 3.14159265f / 180.0f; ///< 3eme personne : pas de plongee verticale extreme.
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
-		static constexpr float kDistanceMin     = 0.5f;   ///< Zoom le plus proche : juste derriere la nuque.
-		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 1 m par defaut : caracteres tres pres derriere le perso (demande utilisateur).
-		// Permet de voir le dos de l'avatar en gros plan, avec la camera 4.2m au-dessus
-		// (cf. kHeightOffsetM=2.5) -> vue plongeante "epaule au-dessus".
-		static constexpr float kDistanceDefault = 1.0f;
+		static constexpr float kDistanceMin     = 1.0f;
+		static constexpr float kDistanceMax     = 20.0f;
+		// 5 m par defaut : cible image 2 utilisateur (avatar ~26% hauteur ecran).
+		// Combine au scale x1 sur l'avatar (1.8m), donne le rendu desire.
+		static constexpr float kDistanceDefault = 5.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -79,12 +79,12 @@ namespace engine::render
 		static constexpr float kRunSpeed        = 10.0f;
 		static constexpr float kPitchMin        = -60.0f * 3.14159265f / 180.0f; ///< 3eme personne : pas de plongee verticale extreme.
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
-		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
+		static constexpr float kDistanceMin     = 0.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 6 m par defaut : moins de 10m derriere le perso (demande utilisateur),
-		// permet de voir ce qu'il y a devant lui sans etre colle dans son dos.
-		// Reglable via molette de 1.5 a 20m.
-		static constexpr float kDistanceDefault = 6.0f;
+		// 1 m par defaut : caracteres tres pres derriere le perso (demande utilisateur).
+		// Permet de voir le dos de l'avatar en gros plan, avec la camera 4.2m au-dessus
+		// (cf. kHeightOffsetM=2.5) -> vue plongeante "epaule au-dessus".
+		static constexpr float kDistanceDefault = 1.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,9 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.0f;
 		static constexpr float kDistanceMax     = 20.0f;
-		// 5 m par defaut : cible image 2 utilisateur (avatar ~26% hauteur ecran).
-		// Combine au scale x1 sur l'avatar (1.8m), donne le rendu desire.
-		static constexpr float kDistanceDefault = 5.0f;
+		// 3 m par defaut : compromis entre vue rapprochee (perso domine 43% ecran)
+		// et visibilite complete (corps entier de la tete aux pieds).
+		// Reglable via molette de 1m a 20m.
+		static constexpr float kDistanceDefault = 3.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,10 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 5 m par defaut : compromis entre le 4m precedent (perso trop pres, sortait
-		// parfois de l'ecran avec les offsets epaule/hauteur) et le 6m initial
-		// (perso trop petit). Reglable via molette.
-		static constexpr float kDistanceDefault = 5.0f;
+		// 8 m par defaut : la valeur 5m precedente, combinee aux offsets epaule + hauteur,
+		// rendait le perso difficile a voir (trop pres de la camera, parfois hors frustum).
+		// 8m donne un cadrage MMORPG classique (le perso fait ~1/4 de hauteur ecran).
+		static constexpr float kDistanceDefault = 8.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,10 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 5 m par defaut : compromis entre le 4m precedent (perso trop pres, sortait
-		// parfois de l'ecran avec les offsets epaule/hauteur) et le 6m initial
-		// (perso trop petit). Reglable via molette.
-		static constexpr float kDistanceDefault = 5.0f;
+		// 3 m par defaut : caracteres tres pres pour debug visuel (image utilisateur :
+		// avatar visible mais ~30px sur 1080 a distance 5m, trop petit). 3m donne
+		// un cadrage MMO classique tres lisible. Reglable via molette de 1.5 a 20m.
+		static constexpr float kDistanceDefault = 3.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,10 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 8 m par defaut : la valeur 5m precedente, combinee aux offsets epaule + hauteur,
-		// rendait le perso difficile a voir (trop pres de la camera, parfois hors frustum).
-		// 8m donne un cadrage MMORPG classique (le perso fait ~1/4 de hauteur ecran).
-		static constexpr float kDistanceDefault = 8.0f;
+		// 5 m par defaut : compromis entre le 4m precedent (perso trop pres, sortait
+		// parfois de l'ecran avec les offsets epaule/hauteur) et le 6m initial
+		// (perso trop petit). Reglable via molette.
+		static constexpr float kDistanceDefault = 5.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/Camera.h
+++ b/engine/render/Camera.h
@@ -81,9 +81,10 @@ namespace engine::render
 		static constexpr float kPitchMax        = +75.0f * 3.14159265f / 180.0f;
 		static constexpr float kDistanceMin     = 1.5f;   ///< Zoom le plus proche : juste derriere la nuque.
 		static constexpr float kDistanceMax     = 20.0f;  ///< Zoom le plus eloigne.
-		// 4 m par defaut : cadrage MMO/survie (perso prend ~30% de la hauteur ecran
-		// a FOV 70). 6 m donnait un perso trop petit (~21%). Reglable via molette.
-		static constexpr float kDistanceDefault = 4.0f;
+		// 5 m par defaut : compromis entre le 4m precedent (perso trop pres, sortait
+		// parfois de l'ecran avec les offsets epaule/hauteur) et le 6m initial
+		// (perso trop petit). Reglable via molette.
+		static constexpr float kDistanceDefault = 5.0f;
 		static constexpr float kZoomStep        = 1.0f;   ///< Increment molette.
 		/// Hauteur d'epaule par rapport au sol (1.7 m ~ taille humaine adulte).
 		static constexpr float kTargetEyeHeight = 1.7f;

--- a/engine/render/ChatImGuiRenderer.cpp
+++ b/engine/render/ChatImGuiRenderer.cpp
@@ -81,19 +81,15 @@ namespace engine::render
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
 		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
 
-		// Pre-EnterWorld (ecrans auth/terms/charcreate), le panneau chat est decoratif :
-		// on ajoute NoInputs pour que les clics passent a travers vers le panneau auth en
-		// dessous (sinon le panneau chat ancre bottom-left intercepte les clics sur les
-		// boutons "Accepter / continuer" de l'ecran CGU qui se trouvent dans la meme zone).
-		ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
+		// inWorldShard ignore : le chat n'est rendu que post-EnterWorld (gating cote
+		// Engine.cpp), donc inWorldShard est toujours true ici en pratique. On garde
+		// le parametre pour compat / futur retablissement du chat pre-game.
+		(void)inWorldShard;
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
 			| ImGuiWindowFlags_NoMove
 			| ImGuiWindowFlags_NoFocusOnAppearing
 			| ImGuiWindowFlags_NoBringToFrontOnFocus
 			| ImGuiWindowFlags_NoNav;
-		if (!inWorldShard)
-		{
-			flags |= ImGuiWindowFlags_NoInputs;
-		}
 
 		if (ImGui::Begin("##ln_chat_panel", nullptr, flags))
 		{

--- a/engine/render/ChatImGuiRenderer.cpp
+++ b/engine/render/ChatImGuiRenderer.cpp
@@ -77,6 +77,12 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH));
 		// Background opaque (alpha=0.95) au lieu de 0.78 pour bien le voir sur fonds clairs et sombres.
 		ImGui::SetNextWindowBgAlpha(0.95f);
+		// Force le panneau chat au PREMIER PLAN : utile sur les ecrans pre-EnterWorld
+		// ou le panneau auth occupe TOUT le viewport en alpha=1.0 et masque le chat
+		// si l'ordre d'empilement ImGui ne le met pas devant. Sans focus capture
+		// (NoBringToFrontOnFocus + NoFocusOnAppearing en flags) pour ne pas voler
+		// l'input clavier de l'auth.
+		ImGui::SetNextWindowFocus();
 
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
 		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));

--- a/engine/render/ChatImGuiRenderer.cpp
+++ b/engine/render/ChatImGuiRenderer.cpp
@@ -77,21 +77,23 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH));
 		// Background opaque (alpha=0.95) au lieu de 0.78 pour bien le voir sur fonds clairs et sombres.
 		ImGui::SetNextWindowBgAlpha(0.95f);
-		// Force le panneau chat au PREMIER PLAN : utile sur les ecrans pre-EnterWorld
-		// ou le panneau auth occupe TOUT le viewport en alpha=1.0 et masque le chat
-		// si l'ordre d'empilement ImGui ne le met pas devant. Sans focus capture
-		// (NoBringToFrontOnFocus + NoFocusOnAppearing en flags) pour ne pas voler
-		// l'input clavier de l'auth.
-		ImGui::SetNextWindowFocus();
 
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
 		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
 
-		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
+		// Pre-EnterWorld (ecrans auth/terms/charcreate), le panneau chat est decoratif :
+		// on ajoute NoInputs pour que les clics passent a travers vers le panneau auth en
+		// dessous (sinon le panneau chat ancre bottom-left intercepte les clics sur les
+		// boutons "Accepter / continuer" de l'ecran CGU qui se trouvent dans la meme zone).
+		ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
 			| ImGuiWindowFlags_NoMove
 			| ImGuiWindowFlags_NoFocusOnAppearing
 			| ImGuiWindowFlags_NoBringToFrontOnFocus
 			| ImGuiWindowFlags_NoNav;
+		if (!inWorldShard)
+		{
+			flags |= ImGuiWindowFlags_NoInputs;
+		}
 
 		if (ImGui::Begin("##ln_chat_panel", nullptr, flags))
 		{

--- a/engine/server/CharacterCreateHandler.cpp
+++ b/engine/server/CharacterCreateHandler.cpp
@@ -236,23 +236,39 @@ namespace engine::server
 		};
 		const std::string raceIdTruncated  = truncate(parsed->raceId);
 		const std::string classIdTruncated = truncate(parsed->classId);
+		// PR-E : auto-assignation de la faction selon la race choisie. Couvre les
+		// 6 races jouables seedees en migration 0036 et aligne sur le backfill de
+		// la migration 0040. Ulterieurement le client pourra envoyer un factionId
+		// explicite (cas Crepuscule / mercenaires) — pour l'instant on derive.
+		auto factionFromRace = [](std::string_view race) -> const char* {
+			if (race == "humains" || race == "nains" || race == "elfes" || race == "chevaliers_dragons")
+				return "lumiere";
+			if (race == "orcs" || race == "demons")
+				return "ombres";
+			return ""; // unaligned/crepuscule par defaut.
+		};
+		const std::string factionStr = factionFromRace(raceIdTruncated);
 		char escapedRace[80]{};
 		char escapedClass[80]{};
+		char escapedFaction[80]{};
 		mysql_real_escape_string(mysql, escapedRace,
 			raceIdTruncated.c_str(), static_cast<unsigned long>(raceIdTruncated.size()));
 		mysql_real_escape_string(mysql, escapedClass,
 			classIdTruncated.c_str(), static_cast<unsigned long>(classIdTruncated.size()));
+		mysql_real_escape_string(mysql, escapedFaction,
+			factionStr.c_str(), static_cast<unsigned long>(factionStr.size()));
 
 		std::string sql =
 			"INSERT INTO characters (account_id, slot, name, server_id, race_id, class_id, level, appearance_json,"
-			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str) VALUES ("
+			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str, faction_str) VALUES ("
 			+ std::to_string(*accountId) + ", "
 			+ std::to_string(slot) + ", '"
 			+ escapedName + "', "
 			+ std::to_string(serverId) + ", 0, 0, 1, '{}', "
 			+ spawnBuf + ", '"
 			+ escapedRace + "', '"
-			+ escapedClass + "')";
+			+ escapedClass + "', '"
+			+ escapedFaction + "')";
 		if (!engine::server::db::DbExecute(mysql, sql))
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::BAD_REQUEST, "character creation failed", requestId, sessionIdHeader);
@@ -265,7 +281,9 @@ namespace engine::server
 		auto pkt = BuildCharacterCreateResponsePacket(1u, characterId, requestId, sessionIdHeader);
 		if (!pkt.empty())
 			m_server->Send(connId, pkt);
-		LOG_INFO(Auth, "[CharacterCreateHandler] Character created (account_id={}, character_id={}, server_id={}, slot={}, name={}, race='{}', class='{}', spawn=({}, {}, {}))",
-			*accountId, characterId, serverId, slot, parsed->name, raceIdTruncated, classIdTruncated, spawnX, spawnY, spawnZ);
+		LOG_INFO(Auth, "[CharacterCreateHandler] Character created (account_id={}, character_id={}, server_id={}, slot={}, name={}, race='{}', class='{}', faction='{}', spawn=({}, {}, {}))",
+			*accountId, characterId, serverId, slot, parsed->name, raceIdTruncated, classIdTruncated,
+			factionStr.empty() ? "(unaligned)" : factionStr,
+			spawnX, spawnY, spawnZ);
 	}
 }

--- a/engine/server/CharacterCreateHandler.cpp
+++ b/engine/server/CharacterCreateHandler.cpp
@@ -236,16 +236,19 @@ namespace engine::server
 		};
 		const std::string raceIdTruncated  = truncate(parsed->raceId);
 		const std::string classIdTruncated = truncate(parsed->classId);
-		// PR-E : auto-assignation de la faction selon la race choisie. Couvre les
-		// 6 races jouables seedees en migration 0036 et aligne sur le backfill de
-		// la migration 0040. Ulterieurement le client pourra envoyer un factionId
-		// explicite (cas Crepuscule / mercenaires) — pour l'instant on derive.
+		// PR-E : auto-assignation de la faction selon la race choisie.
+		// Les factions sont race-lockees (cf. migration 0040 : Chevaliers de la
+		// Lumiere / Justice / La Lune Noire / Empire de L'Hynn pour humains ;
+		// Dzorak pour orcs ; Demons ; Chevaliers-Dragons ; etc.).
+		// Pour les races avec faction unique on assigne directement. Pour les
+		// races multi-factions (humains : 4 choix possibles) on laisse vide :
+		// le joueur fera son choix au premier login via une UI dediee a venir.
 		auto factionFromRace = [](std::string_view race) -> const char* {
-			if (race == "humains" || race == "nains" || race == "elfes" || race == "chevaliers_dragons")
-				return "lumiere";
-			if (race == "orcs" || race == "demons")
-				return "ombres";
-			return ""; // unaligned/crepuscule par defaut.
+			if (race == "orcs")               return "dzorak";
+			if (race == "demons")             return "demons";
+			if (race == "chevaliers_dragons") return "chevaliers_dragons";
+			// humains, elfes, nains : faction(s) a choisir / pas encore definie -> vide.
+			return "";
 		};
 		const std::string factionStr = factionFromRace(raceIdTruncated);
 		char escapedRace[80]{};

--- a/engine/server/ChatRelayHandler.cpp
+++ b/engine/server/ChatRelayHandler.cpp
@@ -356,7 +356,16 @@ namespace engine::server
 			if (m_server->Send(destConn, pkt))
 				++delivered;
 		}
-		LOG_INFO(Net, "[ChatRelayHandler] Chat broadcast sender='{}' channel={} text_len={} delivered={}/{}",
-			sender, static_cast<unsigned>(parsed->channel), parsed->text.size(), delivered, snapshot.size());
+		// Log INCLUT le texte du message pour audit/moderation (demande utilisateur).
+		// Tronque a 200 chars dans le log pour ne pas saturer le subsystem si un
+		// joueur poste un pave ; le payload reseau passe entier (jusqu'a kProtocolV1MaxStringLength).
+		std::string textForLog = parsed->text;
+		if (textForLog.size() > 200u)
+		{
+			textForLog.resize(200u);
+			textForLog += "...[truncated]";
+		}
+		LOG_INFO(Net, "[ChatRelayHandler] Chat broadcast sender='{}' channel={} text_len={} delivered={}/{} text='{}'",
+			sender, static_cast<unsigned>(parsed->channel), parsed->text.size(), delivered, snapshot.size(), textForLog);
 	}
 }

--- a/engine/server/LocalizedEmail.cpp
+++ b/engine/server/LocalizedEmail.cpp
@@ -236,7 +236,36 @@ namespace
 	{
 		outIsHtml = false;
 		const std::string locTag = LocaleToTag(loc);
-		// Note: les templates CGU ne sont pas dans web-portal/email-templates — fallback plain text uniquement.
+		std::string html = LoadHtmlTemplate("cgu-accepted", locTag);
+		if (!html.empty())
+		{
+			ReplaceAllInPlace(html, "{{version}}", versionLabel);
+			switch (loc)
+			{
+			case AccountEmailLocale::French:
+				outSubject = "Acceptation des CGU (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			case AccountEmailLocale::Spanish:
+				outSubject = "Aceptación de los términos (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			case AccountEmailLocale::German:
+				outSubject = "Annahme der Nutzungsbedingungen (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			case AccountEmailLocale::Portuguese:
+				outSubject = "Aceitação dos termos (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			case AccountEmailLocale::Italian:
+				outSubject = "Accettazione dei termini (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			case AccountEmailLocale::English:
+			default:
+				outSubject = "Terms of Service accepted (" + versionLabel + ") — Les Chroniques de la Lune Noire";
+				break;
+			}
+			outBody = std::move(html);
+			outIsHtml = true;
+			return;
+		}
 		// Fallback plain text
 		switch (loc)
 		{

--- a/game/data/email/cgu-accepted.en.html
+++ b/game/data/email/cgu-accepted.en.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Terms of Service Accepted — Les Chroniques de la Lune Noire</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=EB+Garamond:ital,wght@0,400;1,400&display=swap');
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:#05070A; font-family:'EB Garamond',Georgia,serif; }
+  a { color:#E8C56E; text-decoration:none; }
+</style>
+</head>
+<body style="background:#05070A;margin:0;padding:0;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#05070A;padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+  <!-- Header -->
+  <tr><td align="center" style="padding:0 0 32px;">
+    <div style="width:80px;height:80px;border-radius:50%;background:radial-gradient(circle at 32% 30%,#2a2330 0%,#0B0712 55%,#000 100%);border:1px solid #1a1420;display:inline-block;box-shadow:0 0 40px rgba(232,197,110,.35);"></div>
+    <p style="font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.4em;text-transform:uppercase;color:#E8C56E;margin:14px 0 0;">Les Chroniques de la Lune Noire</p>
+  </td></tr>
+
+  <!-- Body -->
+  <tr><td>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(20,28,40,.95);border:1px solid #3D4F66;border-radius:12px;overflow:hidden;">
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+
+    <!-- Scroll icon -->
+    <tr><td align="center" style="padding:40px 40px 10px;">
+      <div style="width:60px;height:60px;border-radius:50%;background:rgba(232,197,110,.12);border:1px solid #E8C56E;display:inline-flex;align-items:center;justify-content:center;font-size:28px;line-height:60px;color:#E8C56E;">&#10070;</div>
+    </td></tr>
+
+    <!-- Title -->
+    <tr><td align="center" style="padding:16px 40px 24px;">
+      <p style="font-family:'Cinzel',serif;font-weight:700;font-size:22px;letter-spacing:.18em;text-transform:uppercase;color:#F2F4F8;margin:0 0 12px;">Pact Sealed</p>
+      <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:16px;color:#9BA8B8;line-height:1.55;margin:0;">Your acceptance of the Terms of Service has been recorded. This email serves as proof of your consent.</p>
+    </td></tr>
+
+    <tr><td style="height:1px;background:#3D4F66;"></td></tr>
+
+    <!-- Version -->
+    <tr><td align="center" style="padding:28px 40px 20px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" style="background:rgba(10,13,18,.8);border:1px solid #E8C56E;border-radius:10px;padding:20px 36px;box-shadow:0 0 0 1px rgba(232,197,110,.2),0 0 30px rgba(232,197,110,.1);">
+        <tr><td align="center">
+          <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.32em;text-transform:uppercase;color:#9BA8B8;margin:0 0 10px;">Accepted version</p>
+          <p style="font-family:'Courier New',monospace;font-weight:700;font-size:24px;letter-spacing:.18em;color:#E8C56E;margin:0;">{{version}}</p>
+          <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:13px;color:#9BA8B8;margin:10px 0 0;">Date and time recorded server-side.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <!-- Details -->
+    <tr><td style="padding:0 40px 28px;">
+      <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.28em;text-transform:uppercase;color:#E8C56E;margin:0 0 14px;padding-bottom:8px;border-bottom:1px solid rgba(61,79,102,.4);">What this means</p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">1</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Mutual commitment</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">You acknowledge having read and accepted the rules that govern your presence in the Black Moon.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">2</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Lasting proof</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Keep this email. It attests to your consent to the version indicated above.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 0 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #E8C56E;background:rgba(232,197,110,.08);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#E8C56E;">3</div>
+          </td>
+          <td valign="top" style="padding:4px 0 0;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Future updates</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Any material change to the Terms will be presented to you on screen before your next login.</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+
+    <!-- CTA -->
+    <tr><td align="center" style="padding:0 40px 36px;">
+      <a href="https://lcdlln.fr/terms" style="display:inline-block;font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.2em;text-transform:uppercase;color:#F2F4F8;background:linear-gradient(180deg,#5a8bc6 0%,#3E689E 100%);border:1px solid #6b9bd4;border-radius:8px;padding:14px 32px;text-decoration:none;box-shadow:0 4px 16px rgba(0,0,0,.4);">Read the Terms</a>
+    </td></tr>
+
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+  </table>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td align="center" style="padding:28px 0 10px;">
+    <p style="font-family:'Cinzel',serif;font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:#3D4F66;margin:0 0 10px;">Les Chroniques de la Lune Noire · Edition of the Dead</p>
+    <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:13px;color:#3D4F66;margin:0 0 8px;">
+      <a href="#" style="color:#5C6B8C;">Privacy</a> &nbsp;·&nbsp;
+      <a href="#" style="color:#5C6B8C;">Help</a>
+    </p>
+    <p style="font-family:'EB Garamond',serif;font-size:12px;color:#3D4F66;margin:0;">© 2026 Les Chroniques de la Lune Noire. All rights reserved.</p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/game/data/email/cgu-accepted.fr.html
+++ b/game/data/email/cgu-accepted.fr.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Acceptation des CGU — Les Chroniques de la Lune Noire</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=EB+Garamond:ital,wght@0,400;1,400&display=swap');
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:#05070A; font-family:'EB Garamond',Georgia,serif; }
+  a { color:#E8C56E; text-decoration:none; }
+</style>
+</head>
+<body style="background:#05070A;margin:0;padding:0;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#05070A;padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+  <!-- En-tête -->
+  <tr><td align="center" style="padding:0 0 32px;">
+    <div style="width:80px;height:80px;border-radius:50%;background:radial-gradient(circle at 32% 30%,#2a2330 0%,#0B0712 55%,#000 100%);border:1px solid #1a1420;display:inline-block;box-shadow:0 0 40px rgba(232,197,110,.35);"></div>
+    <p style="font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.4em;text-transform:uppercase;color:#E8C56E;margin:14px 0 0;">Les Chroniques de la Lune Noire</p>
+  </td></tr>
+
+  <!-- Corps -->
+  <tr><td>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(20,28,40,.95);border:1px solid #3D4F66;border-radius:12px;overflow:hidden;">
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+
+    <!-- Icône parchemin -->
+    <tr><td align="center" style="padding:40px 40px 10px;">
+      <div style="width:60px;height:60px;border-radius:50%;background:rgba(232,197,110,.12);border:1px solid #E8C56E;display:inline-flex;align-items:center;justify-content:center;font-size:28px;line-height:60px;color:#E8C56E;">&#10070;</div>
+    </td></tr>
+
+    <!-- Titre -->
+    <tr><td align="center" style="padding:16px 40px 24px;">
+      <p style="font-family:'Cinzel',serif;font-weight:700;font-size:22px;letter-spacing:.18em;text-transform:uppercase;color:#F2F4F8;margin:0 0 12px;">Pacte scellé</p>
+      <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:16px;color:#9BA8B8;line-height:1.55;margin:0;">Votre acceptation des Conditions Générales d'Utilisation a été enregistrée. Cet e-mail tient lieu de preuve de votre consentement.</p>
+    </td></tr>
+
+    <tr><td style="height:1px;background:#3D4F66;"></td></tr>
+
+    <!-- Version CGU -->
+    <tr><td align="center" style="padding:28px 40px 20px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" style="background:rgba(10,13,18,.8);border:1px solid #E8C56E;border-radius:10px;padding:20px 36px;box-shadow:0 0 0 1px rgba(232,197,110,.2),0 0 30px rgba(232,197,110,.1);">
+        <tr><td align="center">
+          <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.32em;text-transform:uppercase;color:#9BA8B8;margin:0 0 10px;">Version acceptée</p>
+          <p style="font-family:'Courier New',monospace;font-weight:700;font-size:24px;letter-spacing:.18em;color:#E8C56E;margin:0;">{{version}}</p>
+          <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:13px;color:#9BA8B8;margin:10px 0 0;">Date et heure d'acceptation enregistrées côté serveur.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <!-- Détails -->
+    <tr><td style="padding:0 40px 28px;">
+      <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.28em;text-transform:uppercase;color:#E8C56E;margin:0 0 14px;padding-bottom:8px;border-bottom:1px solid rgba(61,79,102,.4);">Ce que cela signifie</p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">1</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Engagement mutuel</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Vous reconnaissez avoir lu et accepté les règles qui régissent votre présence dans la Lune Noire.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">2</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Preuve durable</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Conservez cet e-mail. Il atteste de votre consentement à la version indiquée.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 0 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #E8C56E;background:rgba(232,197,110,.08);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#E8C56E;">3</div>
+          </td>
+          <td valign="top" style="padding:4px 0 0;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Évolutions futures</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Toute mise à jour matérielle des CGU vous sera proposée à l'écran avant votre prochaine connexion.</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+
+    <!-- CTA -->
+    <tr><td align="center" style="padding:0 40px 36px;">
+      <a href="https://lcdlln.fr/cgu" style="display:inline-block;font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.2em;text-transform:uppercase;color:#F2F4F8;background:linear-gradient(180deg,#5a8bc6 0%,#3E689E 100%);border:1px solid #6b9bd4;border-radius:8px;padding:14px 32px;text-decoration:none;box-shadow:0 4px 16px rgba(0,0,0,.4);">Relire les CGU</a>
+    </td></tr>
+
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+  </table>
+  </td></tr>
+
+  <!-- Pied -->
+  <tr><td align="center" style="padding:28px 0 10px;">
+    <p style="font-family:'Cinzel',serif;font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:#3D4F66;margin:0 0 10px;">Les Chroniques de la Lune Noire · Édition des morts</p>
+    <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:13px;color:#3D4F66;margin:0 0 8px;">
+      <a href="#" style="color:#5C6B8C;">Confidentialité</a> &nbsp;·&nbsp;
+      <a href="#" style="color:#5C6B8C;">Aide</a>
+    </p>
+    <p style="font-family:'EB Garamond',serif;font-size:12px;color:#3D4F66;margin:0;">© 2026 Les Chroniques de la Lune Noire. Tous droits réservés.</p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/web-portal/email-templates/cgu-accepted.en.html
+++ b/web-portal/email-templates/cgu-accepted.en.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Terms of Service Accepted — Les Chroniques de la Lune Noire</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=EB+Garamond:ital,wght@0,400;1,400&display=swap');
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:#05070A; font-family:'EB Garamond',Georgia,serif; }
+  a { color:#E8C56E; text-decoration:none; }
+</style>
+</head>
+<body style="background:#05070A;margin:0;padding:0;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#05070A;padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+  <!-- Header -->
+  <tr><td align="center" style="padding:0 0 32px;">
+    <div style="width:80px;height:80px;border-radius:50%;background:radial-gradient(circle at 32% 30%,#2a2330 0%,#0B0712 55%,#000 100%);border:1px solid #1a1420;display:inline-block;box-shadow:0 0 40px rgba(232,197,110,.35);"></div>
+    <p style="font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.4em;text-transform:uppercase;color:#E8C56E;margin:14px 0 0;">Les Chroniques de la Lune Noire</p>
+  </td></tr>
+
+  <!-- Body -->
+  <tr><td>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(20,28,40,.95);border:1px solid #3D4F66;border-radius:12px;overflow:hidden;">
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+
+    <!-- Scroll icon -->
+    <tr><td align="center" style="padding:40px 40px 10px;">
+      <div style="width:60px;height:60px;border-radius:50%;background:rgba(232,197,110,.12);border:1px solid #E8C56E;display:inline-flex;align-items:center;justify-content:center;font-size:28px;line-height:60px;color:#E8C56E;">&#10070;</div>
+    </td></tr>
+
+    <!-- Title -->
+    <tr><td align="center" style="padding:16px 40px 24px;">
+      <p style="font-family:'Cinzel',serif;font-weight:700;font-size:22px;letter-spacing:.18em;text-transform:uppercase;color:#F2F4F8;margin:0 0 12px;">Pact Sealed</p>
+      <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:16px;color:#9BA8B8;line-height:1.55;margin:0;">Your acceptance of the Terms of Service has been recorded. This email serves as proof of your consent.</p>
+    </td></tr>
+
+    <tr><td style="height:1px;background:#3D4F66;"></td></tr>
+
+    <!-- Version -->
+    <tr><td align="center" style="padding:28px 40px 20px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" style="background:rgba(10,13,18,.8);border:1px solid #E8C56E;border-radius:10px;padding:20px 36px;box-shadow:0 0 0 1px rgba(232,197,110,.2),0 0 30px rgba(232,197,110,.1);">
+        <tr><td align="center">
+          <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.32em;text-transform:uppercase;color:#9BA8B8;margin:0 0 10px;">Accepted version</p>
+          <p style="font-family:'Courier New',monospace;font-weight:700;font-size:24px;letter-spacing:.18em;color:#E8C56E;margin:0;">{{version}}</p>
+          <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:13px;color:#9BA8B8;margin:10px 0 0;">Date and time recorded server-side.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <!-- Details -->
+    <tr><td style="padding:0 40px 28px;">
+      <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.28em;text-transform:uppercase;color:#E8C56E;margin:0 0 14px;padding-bottom:8px;border-bottom:1px solid rgba(61,79,102,.4);">What this means</p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">1</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Mutual commitment</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">You acknowledge having read and accepted the rules that govern your presence in the Black Moon.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">2</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Lasting proof</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Keep this email. It attests to your consent to the version indicated above.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 0 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #E8C56E;background:rgba(232,197,110,.08);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#E8C56E;">3</div>
+          </td>
+          <td valign="top" style="padding:4px 0 0;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Future updates</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Any material change to the Terms will be presented to you on screen before your next login.</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+
+    <!-- CTA -->
+    <tr><td align="center" style="padding:0 40px 36px;">
+      <a href="https://lcdlln.fr/terms" style="display:inline-block;font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.2em;text-transform:uppercase;color:#F2F4F8;background:linear-gradient(180deg,#5a8bc6 0%,#3E689E 100%);border:1px solid #6b9bd4;border-radius:8px;padding:14px 32px;text-decoration:none;box-shadow:0 4px 16px rgba(0,0,0,.4);">Read the Terms</a>
+    </td></tr>
+
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+  </table>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td align="center" style="padding:28px 0 10px;">
+    <p style="font-family:'Cinzel',serif;font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:#3D4F66;margin:0 0 10px;">Les Chroniques de la Lune Noire · Edition of the Dead</p>
+    <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:13px;color:#3D4F66;margin:0 0 8px;">
+      <a href="#" style="color:#5C6B8C;">Privacy</a> &nbsp;·&nbsp;
+      <a href="#" style="color:#5C6B8C;">Help</a>
+    </p>
+    <p style="font-family:'EB Garamond',serif;font-size:12px;color:#3D4F66;margin:0;">© 2026 Les Chroniques de la Lune Noire. All rights reserved.</p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/web-portal/email-templates/cgu-accepted.fr.html
+++ b/web-portal/email-templates/cgu-accepted.fr.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="fr" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Acceptation des CGU — Les Chroniques de la Lune Noire</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=EB+Garamond:ital,wght@0,400;1,400&display=swap');
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:#05070A; font-family:'EB Garamond',Georgia,serif; }
+  a { color:#E8C56E; text-decoration:none; }
+</style>
+</head>
+<body style="background:#05070A;margin:0;padding:0;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#05070A;padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+  <!-- En-tête -->
+  <tr><td align="center" style="padding:0 0 32px;">
+    <div style="width:80px;height:80px;border-radius:50%;background:radial-gradient(circle at 32% 30%,#2a2330 0%,#0B0712 55%,#000 100%);border:1px solid #1a1420;display:inline-block;box-shadow:0 0 40px rgba(232,197,110,.35);"></div>
+    <p style="font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.4em;text-transform:uppercase;color:#E8C56E;margin:14px 0 0;">Les Chroniques de la Lune Noire</p>
+  </td></tr>
+
+  <!-- Corps -->
+  <tr><td>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(20,28,40,.95);border:1px solid #3D4F66;border-radius:12px;overflow:hidden;">
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+
+    <!-- Icône parchemin -->
+    <tr><td align="center" style="padding:40px 40px 10px;">
+      <div style="width:60px;height:60px;border-radius:50%;background:rgba(232,197,110,.12);border:1px solid #E8C56E;display:inline-flex;align-items:center;justify-content:center;font-size:28px;line-height:60px;color:#E8C56E;">&#10070;</div>
+    </td></tr>
+
+    <!-- Titre -->
+    <tr><td align="center" style="padding:16px 40px 24px;">
+      <p style="font-family:'Cinzel',serif;font-weight:700;font-size:22px;letter-spacing:.18em;text-transform:uppercase;color:#F2F4F8;margin:0 0 12px;">Pacte scellé</p>
+      <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:16px;color:#9BA8B8;line-height:1.55;margin:0;">Votre acceptation des Conditions Générales d'Utilisation a été enregistrée. Cet e-mail tient lieu de preuve de votre consentement.</p>
+    </td></tr>
+
+    <tr><td style="height:1px;background:#3D4F66;"></td></tr>
+
+    <!-- Version CGU -->
+    <tr><td align="center" style="padding:28px 40px 20px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" style="background:rgba(10,13,18,.8);border:1px solid #E8C56E;border-radius:10px;padding:20px 36px;box-shadow:0 0 0 1px rgba(232,197,110,.2),0 0 30px rgba(232,197,110,.1);">
+        <tr><td align="center">
+          <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.32em;text-transform:uppercase;color:#9BA8B8;margin:0 0 10px;">Version acceptée</p>
+          <p style="font-family:'Courier New',monospace;font-weight:700;font-size:24px;letter-spacing:.18em;color:#E8C56E;margin:0;">{{version}}</p>
+          <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:13px;color:#9BA8B8;margin:10px 0 0;">Date et heure d'acceptation enregistrées côté serveur.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <!-- Détails -->
+    <tr><td style="padding:0 40px 28px;">
+      <p style="font-family:'Cinzel',serif;font-size:10px;letter-spacing:.28em;text-transform:uppercase;color:#E8C56E;margin:0 0 14px;padding-bottom:8px;border-bottom:1px solid rgba(61,79,102,.4);">Ce que cela signifie</p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">1</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Engagement mutuel</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Vous reconnaissez avoir lu et accepté les règles qui régissent votre présence dans la Lune Noire.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 12px 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #3D4F66;background:rgba(10,13,18,.6);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#9BA8B8;">2</div>
+          </td>
+          <td valign="top" style="padding:4px 0 12px;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Preuve durable</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Conservez cet e-mail. Il atteste de votre consentement à la version indiquée.</p>
+          </td>
+        </tr>
+        <tr>
+          <td width="32" valign="top" style="padding:4px 12px 0 0;">
+            <div style="width:28px;height:28px;border-radius:50%;border:1px solid #E8C56E;background:rgba(232,197,110,.08);text-align:center;line-height:28px;font-family:'Cinzel',serif;font-size:12px;color:#E8C56E;">3</div>
+          </td>
+          <td valign="top" style="padding:4px 0 0;">
+            <p style="font-family:'Cinzel',serif;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:#F2F4F8;margin:0 0 4px;">Évolutions futures</p>
+            <p style="font-family:'EB Garamond',Georgia,serif;font-style:italic;font-size:14px;color:#9BA8B8;margin:0;line-height:1.5;">Toute mise à jour matérielle des CGU vous sera proposée à l'écran avant votre prochaine connexion.</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+
+    <!-- CTA -->
+    <tr><td align="center" style="padding:0 40px 36px;">
+      <a href="https://lcdlln.fr/cgu" style="display:inline-block;font-family:'Cinzel',serif;font-weight:700;font-size:13px;letter-spacing:.2em;text-transform:uppercase;color:#F2F4F8;background:linear-gradient(180deg,#5a8bc6 0%,#3E689E 100%);border:1px solid #6b9bd4;border-radius:8px;padding:14px 32px;text-decoration:none;box-shadow:0 4px 16px rgba(0,0,0,.4);">Relire les CGU</a>
+    </td></tr>
+
+    <tr><td style="height:4px;background:linear-gradient(90deg,#1D2A4A 0%,#245a2c 40%,#E8C56E 60%,#1D2A4A 100%);"></td></tr>
+  </table>
+  </td></tr>
+
+  <!-- Pied -->
+  <tr><td align="center" style="padding:28px 0 10px;">
+    <p style="font-family:'Cinzel',serif;font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:#3D4F66;margin:0 0 10px;">Les Chroniques de la Lune Noire · Édition des morts</p>
+    <p style="font-family:'EB Garamond',serif;font-style:italic;font-size:13px;color:#3D4F66;margin:0 0 8px;">
+      <a href="#" style="color:#5C6B8C;">Confidentialité</a> &nbsp;·&nbsp;
+      <a href="#" style="color:#5C6B8C;">Aide</a>
+    </p>
+    <p style="font-family:'EB Garamond',serif;font-size:12px;color:#3D4F66;margin:0;">© 2026 Les Chroniques de la Lune Noire. Tous droits réservés.</p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Branche cumulative depuis #421 mergée. Couvre 4 axes de travail majeurs.

### 1. Caméra 3ème personne + visibilité avatar

- Mesh humanoïde violet placeholder (1.8 m, 6 cubes)
- Caméra orbitale `kDistanceDefault=3 m`, `kHeightOffsetM=1 m` (vue corps entier)
- Reset défensif `m_chatFocus=false` à `EnterWorld` (sinon le Enter du login forcait `chatFocus=ON` et bloquait l'orbital camera Update)
- Pitch convention documentée

### 2. Chat post-EnterWorld

- Suppression de l'affichage chat pré-EnterWorld (retour utilisateur explicite)
- Préservation de `chatImguiOverlayNewFrame` post-master-auth (sinon ImGui::Render utilise des draw data stale → écran qui ne se rafraîchit pas — bug critique fixé)
- `ChatRelayHandler` log maintenant le **texte** du message (tronqué à 200 chars) côté serveur pour audit/modération

### 3. Système de factions race-lockées

Migration `0040_factions.sql` aligné sur le lore Lune Noire :

| Faction | Race autorisée | display_name |
|---|---|---|
| `chevaliers_lumiere` | humains | Chevaliers de la Lumière |
| `chevaliers_justice` | humains | Chevaliers de la Justice |
| `lune_noire` | humains | La Lune Noire |
| `empire_hynn` | humains | L'Empire de L'Hynn |
| `dzorak` | orcs | Dzorak |
| `demons` | demons | Démons |
| `chevaliers_dragons` | chevaliers_dragons | Chevaliers-Dragons |

- Colonne `characters.faction_str` ajoutée + backfill races mono-faction
- Auto-assignation à la création (orcs→dzorak, demons→demons, chevaliers_dragons→chevaliers_dragons ; humains/elfes/nains laissés `unaligned` pour future UI de choix)
- `VolumeEntity::SpawnArea` étendu avec `raceFilters[]` + `factionFilter` + presets de cycle V

### 4. Éditeur monde

- Police **Arial** (au lieu de Windlass) pour `lcdlln_world_editor.exe` — neutre, lisible, riche en glyphs
- Règle persistante dans `CLAUDE.md` : toute fonction de l'éditeur doit être documentée systématiquement
- Resize de la fenêtre éditeur : skip render si minimisée + relayout DockBuilder à chaque changement de taille
- `BuildInitialCamera` repositionnée au-dessus du terrain par défaut
- Reset caméra automatique au load/create de carte (sinon caméra à y=1.5 m sous le terrain à y=100 m)

### 5. Email cgu-accepted.html

- Nouveau template HTML stylisé (FR/EN) avec design cohérent du jeu (Cinzel + EB Garamond, accent or #E8C56E)
- `BuildTermsAcceptanceEmail` câblé sur `LoadHtmlTemplate("cgu-accepted", locTag)` au lieu du plain text hardcodé

### 6. Terrain client

- `config.json` pointe le terrain par défaut sur `zones/demo_plains/` (avant : chemin inexistant → init terrain échouait silencieusement → sol invisible)

## Reste à faire (post-merge)

Items de roadmap notés dans la migration `0039_roadmap_racial_abilities.sql` :
- UI choix de faction à la création (humains : 4 factions à choisir)
- Inspector ImGui SpawnArea (multi-select races + dropdown faction libre)
- Server-side spawn lookup depuis `layout.json` au premier login
- Textures splat par défaut (grass/dirt/rock/snow) pour rendu sol coloré dans l'éditeur
- Atmosphere.json minimal pour soleil + ciel dynamiques visibles
- Brushes terrain documentés dans le panneau Outils (Sculpter / Peindre / Herbe / Objet / Eau / Routes — déjà en place)

## Test plan

- [x] Build Linux (master) + Windows (client) OK
- [x] Auth flow complet : login → server pick → character select → EnterWorld
- [x] Avatar humanoïde visible (3 m derrière, taille comparable à un humain)
- [x] Chat in-game fonctionnel + log côté serveur avec texte
- [x] Migration 0040 idempotente
- [x] CharacterCreate persiste `faction_str` correctement
- [x] Éditeur monde : resize sans crash, dock relayout OK
- [x] Police Arial dans l'éditeur, Windlass dans le jeu
- [ ] Texture sol terrain (à faire post-merge)
- [ ] Atmosphere skybox (à faire post-merge)

## Déploiement

> ⚠️ **Redéploiement serveur master REQUIS** :
> - Migration `0040_factions.sql` (table `factions` + colonne `characters.faction_str`)
> - `CharacterCreateHandler` écrit dans `faction_str`
> - `ChatRelayHandler` log le texte des messages
> - Templates email `cgu-accepted.{fr,en}.html` à recopier dans `game/data/email/`
>
> Client + serveur doivent être déployés en lock-step.

https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv)_