### PR TITLE
feat(editor): atmosphere.json + textures sol + skybox dynamique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ add_library(engine_core
   engine/editor/WorldMapIo.cpp
   engine/editor/TreeSpeciesCatalog.cpp
   engine/editor/WorldEditorSession.cpp
+  engine/editor/TexturePreviewCache.cpp
   engine/Engine.cpp
   engine/platform/FileSystem.cpp
   engine/platform/FileWatcher.cpp
@@ -624,6 +625,16 @@ if(MSVC)
   target_compile_options(localization_service_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME localization_service_tests COMMAND localization_service_tests)
+
+# Tests unitaires CPU pour TexturePreviewCache (ResampleRgba8Box, GenerateProceduralAlbedoLayer).
+# Pas de dependance Vulkan : tournables en CI sans GPU.
+add_executable(texture_preview_cache_tests engine/editor/tests/TexturePreviewCacheTests.cpp)
+target_include_directories(texture_preview_cache_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(texture_preview_cache_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(texture_preview_cache_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME texture_preview_cache_tests COMMAND texture_preview_cache_tests)
 
 # M22.6: Client flow app (AUTH → SERVER_LIST → TICKET → CONNECT SHARD). Windows only (NetClient).
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ add_library(engine_core
   engine/editor/TreeSpeciesCatalog.cpp
   engine/editor/WorldEditorSession.cpp
   engine/editor/TexturePreviewCache.cpp
+  engine/editor/TextureLibraryPanel.cpp
   engine/Engine.cpp
   engine/platform/FileSystem.cpp
   engine/platform/FileWatcher.cpp

--- a/docs/superpowers/plans/2026-05-04-editor-texture-previews.md
+++ b/docs/superpowers/plans/2026-05-04-editor-texture-previews.md
@@ -1,0 +1,2626 @@
+# Aperçus de textures dans l'éditeur monde — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Afficher des vignettes ImGui pour les 4 textures procédurales et les `.texr` importées dans l'éditeur monde, et appliquer en live les textures importées sur le terrain 3D quand un layer est mappé.
+
+**Architecture:** Nouveau `TexturePreviewCache` (cache lazy de descriptors ImGui pour vignettes) + nouveau panneau `TextureLibraryPanel` (UI dockable) + extension de `TerrainSplatting` pour repacker l'albedo array depuis 4 buffers CPU. Cache et panneau possédés par `Engine`, observés via dirty flag dans `WorldEditorSession`.
+
+**Tech Stack:** C++20, Vulkan 1.3, ImGui (Win32+Vulkan backend), stb_image (déjà présent dans `external/stb/`), CMake (ajout de fichiers à `engine_core` + une exécutable de tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-04-editor-texture-previews-design.md`
+
+---
+
+## File Structure
+
+### Nouveaux fichiers
+- `engine/editor/TexturePreviewCache.h` — API publique (Init/Shutdown, GetProceduralThumb, GetTexrThumb, Invalidate, GetCpuRgba256, Tick)
+- `engine/editor/TexturePreviewCache.cpp` — implémentation Vulkan (sampler partagé, descriptor pool, deferred destruction, decode .texr via stb_image, resampling box filter)
+- `engine/editor/TextureLibraryPanel.h` — déclaration `DrawTextureLibrary(...)`
+- `engine/editor/TextureLibraryPanel.cpp` — implémentation ImGui (Win32-only, no-op ailleurs)
+- `engine/editor/tests/TexturePreviewCacheTests.cpp` — tests unitaires `ResampleRgba8Box` + `GenerateProceduralAlbedoLayer`
+
+### Fichiers modifiés
+- `engine/render/terrain/TerrainSplatting.h` — déclarations `kSplatLayerResolution`, `GenerateProceduralAlbedoLayer` (free function), `SetLayerCpuRgba256`, `RebuildAlbedoArrayFromCpuLayers`
+- `engine/render/terrain/TerrainSplatting.cpp` — refactor de la lambda procédurale en free function, promotion 64→256, implémentation des 2 nouvelles méthodes
+- `engine/editor/WorldMapEditDocument.h` — RAS (déjà bon)
+- `engine/editor/WorldEditorSession.h` — ajout `m_splatRefsDirty` + `MarkSplatRefsDirty()` + `ConsumeSplatRefsDirty()`
+- `engine/editor/WorldEditorSession.cpp` — implem accessors + appel de `MarkSplatRefsDirty` au load de carte
+- `engine/editor/WorldEditorImGui.h` — ajout `m_showTextureLibrary` + `SetTexturePreviewCache(cache)`
+- `engine/editor/WorldEditorImGui.cpp` — vignettes inline dans onglet « Peindre », item de menu « Affichage > Bibliothèque de textures »
+- `engine/Engine.h` — déclaration `std::unique_ptr<TexturePreviewCache> m_texturePreviewCache` + méthode privée `ProcessSplatRefsDirty()`
+- `engine/Engine.cpp` — Init/Shutdown du cache, Tick par frame, ProcessSplatRefsDirty appelé après les autres ticks éditeur, hook sur `ActionImportTexture` pour `Invalidate`
+- `CMakeLists.txt` — ajout des nouveaux .cpp à `engine_core`, déclaration de l'exe de tests
+- `docs/world_editor_zone_pipeline.md` — section « Validation textures »
+
+---
+
+## Task 1: Préparer la base — extraire la génération procédurale en free function (no-op fonctionnel)
+
+**Pourquoi :** la lambda interne dans `TerrainSplatting::Init` doit devenir une fonction libre exportée pour être réutilisable par le cache. Cette task ne change PAS le comportement runtime.
+
+**Files:**
+- Modify: `engine/render/terrain/TerrainSplatting.h`
+- Modify: `engine/render/terrain/TerrainSplatting.cpp`
+
+- [ ] **Step 1: Ajouter la déclaration de la free function dans le header**
+
+Ajouter dans `engine/render/terrain/TerrainSplatting.h`, juste après la définition de `kSplatLayerCount` (avant la struct `SplatMapGpu`) :
+
+```cpp
+    /// Génère un layer RGBA8 procédural (bruit déterministe par layer).
+    /// Algorithme : combinaison micro/macro de hash xx-style, identique au boot
+    /// de TerrainSplatting (cf. b93a14d). Mêmes octets exacts pour mêmes paramètres.
+    /// \param resolution Côté en pixels (carré). Min 4, max 4096.
+    /// \param layer 0=grass, 1=dirt, 2=rock, 3=snow.
+    /// \param outRgba Sortie : resolution * resolution * 4 octets, RGBA8 sRGB.
+    /// \return false si layer >= kSplatLayerCount ou resolution < 4.
+    bool GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
+                                       std::vector<uint8_t>& outRgba);
+```
+
+- [ ] **Step 2: Implémenter la free function dans le .cpp (copie de la lambda actuelle)**
+
+Dans `engine/render/terrain/TerrainSplatting.cpp`, juste après la fermeture du namespace anonyme interne (ligne ~270, avant la définition de `TerrainSplatting::Init`), ajouter :
+
+```cpp
+    bool GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
+                                       std::vector<uint8_t>& outRgba)
+    {
+        if (layer >= kSplatLayerCount || resolution < 4u || resolution > 4096u)
+        {
+            return false;
+        }
+
+        // Couleurs de base par layer (identiques au boot TerrainSplatting).
+        static const uint8_t kAlbedo[kSplatLayerCount][4] = {
+            {  89u, 140u,  51u, 255u },   // grass
+            { 128u,  82u,  38u, 255u },   // dirt
+            { 128u, 107u,  82u, 255u },   // rock
+            { 242u, 242u, 250u, 255u },   // snow
+        };
+        static const uint8_t kAmplitude[kSplatLayerCount] = { 38u, 28u, 50u, 12u };
+        static const uint32_t kMacroCell[kSplatLayerCount] = { 8u, 12u, 4u, 16u };
+
+        auto hashNoise = [](uint32_t x, uint32_t y, uint32_t seed) -> float {
+            uint32_t h = x * 0x27d4eb2du ^ y * 0x165667b1u ^ seed * 0x9e3779b9u;
+            h ^= h >> 15; h *= 0x85ebca6bu;
+            h ^= h >> 13; h *= 0xc2b2ae35u;
+            h ^= h >> 16;
+            return static_cast<float>(h & 0xFFFFFFu) / static_cast<float>(0x1000000u);
+        };
+
+        const uint8_t* col = kAlbedo[layer];
+        const float amp = static_cast<float>(kAmplitude[layer]);
+        const uint32_t mc = kMacroCell[layer];
+        const uint32_t pixels = resolution * resolution;
+        outRgba.resize(static_cast<size_t>(pixels) * 4u);
+
+        for (uint32_t y = 0; y < resolution; ++y)
+        {
+            for (uint32_t x = 0; x < resolution; ++x)
+            {
+                const float micro = hashNoise(x, y, layer);
+                const float macro = hashNoise(x / mc, y / mc, layer + 1000u);
+                const float n = (micro * 0.6f + macro * 0.4f) * 2.0f - 1.0f;
+                const float delta = n * amp;
+                auto clampU8 = [](float v) -> uint8_t {
+                    if (v < 0.0f) v = 0.0f;
+                    if (v > 255.0f) v = 255.0f;
+                    return static_cast<uint8_t>(v);
+                };
+                uint8_t* dst = outRgba.data() + (y * resolution + x) * 4u;
+                dst[0] = clampU8(static_cast<float>(col[0]) + delta);
+                dst[1] = clampU8(static_cast<float>(col[1]) + delta);
+                dst[2] = clampU8(static_cast<float>(col[2]) + delta);
+                dst[3] = 255u;
+            }
+        }
+        return true;
+    }
+```
+
+- [ ] **Step 3: Remplacer la lambda interne par un appel à la free function dans `Init`**
+
+Dans `engine/render/terrain/TerrainSplatting.cpp`, remplacer le bloc « Build albedo array data » (entre les lignes ~454-490) par :
+
+```cpp
+        // Build albedo array data via la free function GenerateProceduralAlbedoLayer.
+        {
+            std::vector<uint8_t> albedoData(kSplatLayerCount * kPixels * 4u);
+            std::vector<uint8_t> oneLayer;
+            for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+            {
+                if (!GenerateProceduralAlbedoLayer(kTexW, layer, oneLayer))
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] GenerateProceduralAlbedoLayer({},{}) failed", kTexW, layer);
+                    Destroy(device);
+                    return false;
+                }
+                std::memcpy(albedoData.data() + layer * kPixels * 4u,
+                            oneLayer.data(), kPixels * 4u);
+            }
+            if (!UploadTextureArray(device, physDev, albedoData, kTexW, kTexH, kSplatLayerCount,
+                                    queue, queueFamilyIndex, m_albedoArray))
+            {
+                LOG_ERROR(Render, "[TerrainSplatting] Failed to upload albedo array");
+                Destroy(device);
+                return false;
+            }
+        }
+```
+
+Garder les blocs "normal array" et "ORM array" inchangés.
+
+- [ ] **Step 4: Build complet pour vérifier non-régression**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+```
+
+Expected : compile sans erreur ni warning. Si warning C4189 (variable non utilisée) sur `kAlbedo`, `kAmplitude`, `kMacroCell` du scope d'origine, supprimer ces lignes (plus utilisées).
+
+- [ ] **Step 5: Lancer `lcdlln_world_editor.exe` et vérifier que le terrain affiche les textures procédurales identiques à avant**
+
+Pas de changement visuel attendu. Si le terrain a changé d'apparence, c'est un bug de refactor à corriger avant de continuer.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/render/terrain/TerrainSplatting.h engine/render/terrain/TerrainSplatting.cpp
+git commit -m "$(cat <<'EOF'
+refactor(terrain): extrait la generation procedurale en free function
+
+Prep pour M-XX (apercus textures editeur). La lambda interne de
+TerrainSplatting::Init devient GenerateProceduralAlbedoLayer (free
+function exportee dans TerrainSplatting.h), reutilisable par le futur
+TexturePreviewCache pour generer les memes octets dans les vignettes.
+
+Aucun changement runtime : le boot terrain produit exactement les memes
+albedo array bytes qu'avant.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Promouvoir la résolution interne du splat array de 64 → 256
+
+**Pourquoi :** la spec exige 256×256 pour le sweet spot qualité/mémoire. Cette task le fait sans toucher aux nouvelles APIs.
+
+**Files:**
+- Modify: `engine/render/terrain/TerrainSplatting.h`
+- Modify: `engine/render/terrain/TerrainSplatting.cpp`
+
+- [ ] **Step 1: Déclarer la constante de résolution dans le header**
+
+Dans `engine/render/terrain/TerrainSplatting.h`, juste après `kSplatLayerCount` :
+
+```cpp
+    /// Resolution (carre) des layers du texture array albedo. Constante a la
+    /// compilation : si on veut configurer plus tard, exposer via Config.
+    /// 256x256 = sweet spot qualite/memoire pour terrain MMO (cf. spec
+    /// 2026-05-04-editor-texture-previews-design.md, section 3).
+    static constexpr uint32_t kSplatLayerResolution = 256u;
+```
+
+- [ ] **Step 2: Remplacer les `kTexW`/`kTexH` 64u par `kSplatLayerResolution`**
+
+Dans `engine/render/terrain/TerrainSplatting.cpp::Init`, remplacer :
+
+```cpp
+        constexpr uint32_t kTexW = 64u;
+        constexpr uint32_t kTexH = 64u;
+```
+
+par :
+
+```cpp
+        constexpr uint32_t kTexW = kSplatLayerResolution;
+        constexpr uint32_t kTexH = kSplatLayerResolution;
+```
+
+(le reste du code utilise `kTexW`/`kTexH`, pas besoin de changer).
+
+- [ ] **Step 3: Build + test visuel**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+cmake --build build --target world_editor_app --config Release
+```
+
+Expected : compile OK, pkg/world_editor/lcdlln_world_editor.exe lance, terrain visible. Le bruit procédural sera plus fin (pixels plus petits à la même distance).
+
+VRAM : ancien = 4×64×64×4×3 arrays = 196 KB. Nouveau = 4×256×256×4×3 arrays = 3 MB. Acceptable.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/render/terrain/TerrainSplatting.h engine/render/terrain/TerrainSplatting.cpp
+git commit -m "$(cat <<'EOF'
+feat(terrain): promotion albedo array 64x64 -> 256x256 (constante kSplatLayerResolution)
+
+Sweet spot qualite/memoire pour textures terrain : 256x256 donne ~3cm/pixel
+au tiling 8m/tile (vs 12.5cm avant), tout en gardant ~3 MB VRAM total
+(4 layers x 3 arrays albedo/normal/ORM x 256x256 x 4 oct).
+
+Constante kSplatLayerResolution pour reuse facile dans le futur
+TexturePreviewCache (vignettes editeur, meme bruit identique octet pour octet).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Ajouter ResampleRgba8Box (free function CPU pure) avec tests unitaires
+
+**Files:**
+- Create: `engine/editor/TexturePreviewCache.h` (squelette minimal pour cette task)
+- Create: `engine/editor/TexturePreviewCache.cpp` (squelette minimal)
+- Create: `engine/editor/tests/TexturePreviewCacheTests.cpp`
+- Modify: `CMakeLists.txt` (ajout sources + exe de tests)
+
+- [ ] **Step 1: Créer `engine/editor/TexturePreviewCache.h` avec uniquement `ResampleRgba8Box` (le reste viendra task 5)**
+
+```cpp
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::editor
+{
+    /// Resample un buffer RGBA8 a une nouvelle resolution carree par box filter
+    /// separable (passe horizontale + verticale). Si le source n'est pas carre,
+    /// crop centre vers carre avant resample (pas de stretch, pas de letterbox).
+    /// \param src Buffer source RGBA8, srcW * srcH * 4 octets.
+    /// \param srcW Largeur source en pixels (>=1).
+    /// \param srcH Hauteur source en pixels (>=1).
+    /// \param dstSize Cote du carre de sortie en pixels (>=4, <=4096).
+    /// \param outRgba Sortie : dstSize * dstSize * 4 octets.
+    /// \return true si succes ; false sur params invalides.
+    bool ResampleRgba8Box(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          uint32_t dstSize, std::vector<uint8_t>& outRgba);
+} // namespace engine::editor
+```
+
+- [ ] **Step 2: Créer `engine/editor/TexturePreviewCache.cpp` avec uniquement `ResampleRgba8Box`**
+
+```cpp
+#include "engine/editor/TexturePreviewCache.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace engine::editor
+{
+    namespace
+    {
+        /// Crop centre rectangulaire vers carre. Renvoie le pointeur vers le
+        /// pixel (0,0) du sous-rectangle carre + son cote.
+        void CropToSquare(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          const uint8_t*& outSrc, uint32_t& outSize, uint32_t& outRowStrideBytes)
+        {
+            outRowStrideBytes = srcW * 4u;
+            if (srcW == srcH)
+            {
+                outSrc = src;
+                outSize = srcW;
+                return;
+            }
+            const uint32_t side = std::min(srcW, srcH);
+            const uint32_t offX = (srcW - side) / 2u;
+            const uint32_t offY = (srcH - side) / 2u;
+            outSrc = src + (offY * srcW + offX) * 4u;
+            outSize = side;
+        }
+    } // namespace
+
+    bool ResampleRgba8Box(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          uint32_t dstSize, std::vector<uint8_t>& outRgba)
+    {
+        if (src == nullptr || srcW == 0 || srcH == 0 || dstSize < 4u || dstSize > 4096u)
+        {
+            return false;
+        }
+
+        const uint8_t* sqSrc = nullptr;
+        uint32_t sqSize = 0;
+        uint32_t srcStride = 0;
+        CropToSquare(src, srcW, srcH, sqSrc, sqSize, srcStride);
+
+        outRgba.assign(static_cast<size_t>(dstSize) * dstSize * 4u, 0u);
+
+        // Box filter direct (pas de mipmap chain) : pour chaque pixel dst,
+        // moyenner tous les pixels src couverts. Couts O(dstSize^2 * (sqSize/dstSize)^2).
+        // Pour 1024->256 : 256^2 * 16 = ~1M reads, ~3ms en debug, <1ms en release.
+        for (uint32_t dy = 0; dy < dstSize; ++dy)
+        {
+            const uint32_t y0 = (dy * sqSize) / dstSize;
+            const uint32_t y1 = ((dy + 1u) * sqSize) / dstSize;
+            const uint32_t ySpan = std::max(1u, y1 - y0);
+            for (uint32_t dx = 0; dx < dstSize; ++dx)
+            {
+                const uint32_t x0 = (dx * sqSize) / dstSize;
+                const uint32_t x1 = ((dx + 1u) * sqSize) / dstSize;
+                const uint32_t xSpan = std::max(1u, x1 - x0);
+                uint32_t accR = 0, accG = 0, accB = 0, accA = 0;
+                const uint32_t count = xSpan * ySpan;
+                for (uint32_t sy = y0; sy < y0 + ySpan; ++sy)
+                {
+                    const uint8_t* row = sqSrc + sy * srcStride;
+                    for (uint32_t sx = x0; sx < x0 + xSpan; ++sx)
+                    {
+                        const uint8_t* p = row + sx * 4u;
+                        accR += p[0]; accG += p[1]; accB += p[2]; accA += p[3];
+                    }
+                }
+                uint8_t* dst = outRgba.data() + (dy * dstSize + dx) * 4u;
+                dst[0] = static_cast<uint8_t>(accR / count);
+                dst[1] = static_cast<uint8_t>(accG / count);
+                dst[2] = static_cast<uint8_t>(accB / count);
+                dst[3] = static_cast<uint8_t>(accA / count);
+            }
+        }
+        return true;
+    }
+} // namespace engine::editor
+```
+
+- [ ] **Step 3: Créer le fichier de tests `engine/editor/tests/TexturePreviewCacheTests.cpp`**
+
+```cpp
+/// Tests unitaires pour les fonctions CPU pures de TexturePreviewCache :
+/// - ResampleRgba8Box (crop + box filter)
+/// - GenerateProceduralAlbedoLayer (deterministe)
+/// Pas de Vulkan ici : ces tests doivent tourner en CI sans GPU.
+
+#include "engine/editor/TexturePreviewCache.h"
+#include "engine/render/terrain/TerrainSplatting.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+    int g_failed = 0;
+
+    #define REQUIRE(cond) do { \
+        if (!(cond)) { \
+            std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+            ++g_failed; \
+        } \
+    } while (0)
+
+    /// 256x256 rouge uni -> 64x64 rouge uni (preserve la couleur).
+    void Test_ResampleDownsampleSquare()
+    {
+        std::vector<uint8_t> red(256u * 256u * 4u);
+        for (size_t p = 0; p < 256u * 256u; ++p)
+        {
+            red[p * 4u + 0] = 200u;
+            red[p * 4u + 1] = 50u;
+            red[p * 4u + 2] = 30u;
+            red[p * 4u + 3] = 255u;
+        }
+        std::vector<uint8_t> out;
+        REQUIRE(engine::editor::ResampleRgba8Box(red.data(), 256u, 256u, 64u, out));
+        REQUIRE(out.size() == 64u * 64u * 4u);
+        // Tous les pixels resamples doivent etre exactement la couleur source.
+        for (size_t p = 0; p < 64u * 64u; ++p)
+        {
+            REQUIRE(out[p * 4u + 0] == 200u);
+            REQUIRE(out[p * 4u + 1] == 50u);
+            REQUIRE(out[p * 4u + 2] == 30u);
+            REQUIRE(out[p * 4u + 3] == 255u);
+        }
+    }
+
+    /// 1024x512 -> 256x256 : crop centre (la zone large hors centre est ignoree).
+    /// On met du rouge dans le carre central [256..768] et du bleu hors-zone.
+    /// Apres resample, attendu = rouge uniforme.
+    void Test_ResampleNonSquareCropsCenter()
+    {
+        const uint32_t W = 1024u, H = 512u;
+        std::vector<uint8_t> img(W * H * 4u);
+        for (uint32_t y = 0; y < H; ++y)
+        {
+            for (uint32_t x = 0; x < W; ++x)
+            {
+                const bool inSquare = (x >= 256u && x < 768u);
+                uint8_t* p = img.data() + (y * W + x) * 4u;
+                if (inSquare)
+                {
+                    p[0] = 200u; p[1] = 50u; p[2] = 30u; p[3] = 255u;
+                }
+                else
+                {
+                    p[0] = 30u; p[1] = 60u; p[2] = 200u; p[3] = 255u;
+                }
+            }
+        }
+        std::vector<uint8_t> out;
+        REQUIRE(engine::editor::ResampleRgba8Box(img.data(), W, H, 256u, out));
+        // Tous les pixels resamples doivent etre rouge (zone centree croppee).
+        for (size_t p = 0; p < 256u * 256u; ++p)
+        {
+            REQUIRE(out[p * 4u + 0] == 200u);
+            REQUIRE(out[p * 4u + 1] == 50u);
+            REQUIRE(out[p * 4u + 2] == 30u);
+        }
+    }
+
+    /// GenerateProceduralAlbedoLayer doit etre deterministe : memes parametres
+    /// -> memes octets exacts. Layers differents -> buffers differents.
+    void Test_GenerateProceduralDeterminism()
+    {
+        std::vector<uint8_t> a, b, c;
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 0u, a));
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 0u, b));
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 1u, c));
+        REQUIRE(a.size() == 64u * 64u * 4u);
+        REQUIRE(a == b); // determinisme
+        REQUIRE(a != c); // layers differents
+    }
+
+    /// Tailles invalides : layer >=4, resolution <4 ou >4096.
+    void Test_GenerateProceduralInvalidParams()
+    {
+        std::vector<uint8_t> out;
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 4u, out));
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(2u, 0u, out));
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(8192u, 0u, out));
+    }
+
+    /// Resample params invalides : null src, taille 0, dstSize hors bornes.
+    void Test_ResampleInvalidParams()
+    {
+        std::vector<uint8_t> out;
+        REQUIRE(!engine::editor::ResampleRgba8Box(nullptr, 64u, 64u, 32u, out));
+        std::vector<uint8_t> img(64u * 64u * 4u, 0u);
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 0u, 64u, 32u, out));
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 2u, out));
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 8192u, out));
+    }
+} // namespace
+
+int main()
+{
+    Test_ResampleDownsampleSquare();
+    Test_ResampleNonSquareCropsCenter();
+    Test_GenerateProceduralDeterminism();
+    Test_GenerateProceduralInvalidParams();
+    Test_ResampleInvalidParams();
+    if (g_failed == 0)
+    {
+        std::fprintf(stdout, "[OK] all texture_preview_cache_tests passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "[FAIL] %d assertions failed\n", g_failed);
+    return 1;
+}
+```
+
+- [ ] **Step 4: Modifier `CMakeLists.txt` — ajouter les sources à `engine_core` + l'exe de tests**
+
+Dans `CMakeLists.txt`, ajouter `engine/editor/TexturePreviewCache.cpp` à la liste de sources de `engine_core` (autour de la ligne 256, juste après `engine/editor/WorldEditorSession.cpp`) :
+
+```cmake
+  engine/editor/WorldEditorSession.cpp
+  engine/editor/TexturePreviewCache.cpp
+```
+
+Puis, à la fin du fichier (après le dernier `add_test`, vers la ligne ~620), ajouter :
+
+```cmake
+# Tests unitaires CPU pour TexturePreviewCache (ResampleRgba8Box, GenerateProceduralAlbedoLayer).
+# Pas de dependance Vulkan : tournables en CI sans GPU.
+add_executable(texture_preview_cache_tests engine/editor/tests/TexturePreviewCacheTests.cpp)
+target_include_directories(texture_preview_cache_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(texture_preview_cache_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(texture_preview_cache_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME texture_preview_cache_tests COMMAND texture_preview_cache_tests)
+```
+
+- [ ] **Step 5: Build et lancer les tests, vérifier qu'ils passent**
+
+Run :
+```
+cmake --build build --target texture_preview_cache_tests --config Release
+ctest --test-dir build -C Release -R texture_preview_cache_tests --output-on-failure
+```
+
+Expected : `[OK] all texture_preview_cache_tests passed`, exit 0. Si un test échoue, fix le code avant de continuer.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp engine/editor/tests/TexturePreviewCacheTests.cpp CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(editor): ResampleRgba8Box (CPU pur) + tests unitaires
+
+Squelette de TexturePreviewCache avec d'abord la fonction CPU pure
+(ResampleRgba8Box, box filter avec crop centre vers carre). 5 tests
+unitaires couvrent : downsample carre, crop d'un non-carre, determinisme
+GenerateProceduralAlbedoLayer, params invalides.
+
+Tests CPU-only, executable standalone (pattern de log_rotation_smoke_tests).
+Tournables en CI Windows sans GPU.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Ajouter `LoadTexrFile` (helper de décodage TEXR + fallback PNG via stb_image)
+
+**Files:**
+- Modify: `engine/editor/TexturePreviewCache.h`
+- Modify: `engine/editor/TexturePreviewCache.cpp`
+- Modify: `engine/editor/tests/TexturePreviewCacheTests.cpp` (un test de plus)
+
+- [ ] **Step 1: Déclarer `LoadTexrFile` dans le header**
+
+Ajouter dans `engine/editor/TexturePreviewCache.h`, après la déclaration de `ResampleRgba8Box` :
+
+```cpp
+    /// Decode un fichier .texr (magic TEXR + RGBA8) ou un PNG/JPG (via stb_image).
+    /// Le format .texr est defini dans engine/render/AssetRegistry.cpp :
+    ///   bytes 0..3 : magic 'TEXR' (0x52584554 LE)
+    ///   bytes 4..7 : width (uint32 LE)
+    ///   bytes 8..11: height (uint32 LE)
+    ///   bytes 12..15: sRGB flag (uint32 LE, 0 = lineaire, !=0 = sRGB)
+    ///   bytes 16.. : width*height*4 octets RGBA8
+    ///
+    /// \param absolutePath Chemin absolu sur disque (string UTF-8). Le caller
+    ///   est responsable de resoudre les chemins content-relatifs en absolus
+    ///   via Config::ResolveContentPath.
+    /// \param outRgba Buffer de sortie (width * height * 4 octets RGBA8).
+    /// \param outWidth Largeur du buffer decode.
+    /// \param outHeight Hauteur du buffer decode.
+    /// \return true si succes. false si fichier introuvable, magic invalide,
+    ///   buffer trop petit, ou erreur stb_image. LOG_ERROR emis.
+    bool LoadTexrFile(const std::string& absolutePath,
+                      std::vector<uint8_t>& outRgba,
+                      uint32_t& outWidth, uint32_t& outHeight);
+```
+
+Et ajouter l'include `<string>` en haut du header.
+
+- [ ] **Step 2: Implémenter `LoadTexrFile` dans le .cpp**
+
+Ajouter en haut de `engine/editor/TexturePreviewCache.cpp` :
+
+```cpp
+#include "engine/core/Log.h"
+
+// stb_image : single header, definition une seule fois dans tout le binaire.
+// Si STB_IMAGE_IMPLEMENTATION est deja defini ailleurs (engine_core), retirer
+// ces 2 lignes et utiliser le symbole global. Verification au build (linker
+// erreur multiple definition).
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
+#include "stb_image.h"
+
+#include <filesystem>
+#include <fstream>
+```
+
+**ATTENTION :** vérifier d'abord avec `Grep "STB_IMAGE_IMPLEMENTATION"` dans le repo — si déjà défini ailleurs (ex: dans WorldMapIo.cpp), retirer le `#define` et garder juste `#include "stb_image.h"`.
+
+Puis ajouter la fonction (après `ResampleRgba8Box`) :
+
+```cpp
+    namespace
+    {
+        constexpr uint32_t kTexrMagic = 0x52584554u;  // "TEXR"
+    }
+
+    bool LoadTexrFile(const std::string& absolutePath,
+                      std::vector<uint8_t>& outRgba,
+                      uint32_t& outWidth, uint32_t& outHeight)
+    {
+        outRgba.clear();
+        outWidth = 0;
+        outHeight = 0;
+
+        std::error_code ec;
+        if (!std::filesystem::exists(absolutePath, ec))
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Texture file not found: {}", absolutePath);
+            return false;
+        }
+
+        std::ifstream f(absolutePath, std::ios::binary);
+        if (!f)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Cannot open texture file: {}", absolutePath);
+            return false;
+        }
+        std::vector<uint8_t> data((std::istreambuf_iterator<char>(f)),
+                                   std::istreambuf_iterator<char>());
+
+        // Si .texr (header magic) : decoder directement.
+        if (data.size() >= 16u)
+        {
+            uint32_t magic = 0, w = 0, h = 0, srgb = 0;
+            std::memcpy(&magic, data.data(), 4);
+            if (magic == kTexrMagic)
+            {
+                std::memcpy(&w, data.data() + 4, 4);
+                std::memcpy(&h, data.data() + 8, 4);
+                std::memcpy(&srgb, data.data() + 12, 4);
+                (void)srgb;
+                if (w == 0 || h == 0 || w > 4096u || h > 4096u)
+                {
+                    LOG_ERROR(Render, "[TexturePreviewCache] TEXR invalid dims {}x{}: {}", w, h, absolutePath);
+                    return false;
+                }
+                const size_t pixelBytes = static_cast<size_t>(w) * h * 4u;
+                if (data.size() < 16u + pixelBytes)
+                {
+                    LOG_ERROR(Render, "[TexturePreviewCache] TEXR truncated: {}", absolutePath);
+                    return false;
+                }
+                outRgba.assign(data.begin() + 16, data.begin() + 16 + static_cast<long long>(pixelBytes));
+                outWidth = w;
+                outHeight = h;
+                return true;
+            }
+        }
+
+        // Fallback : PNG/JPG/TGA/BMP via stb_image.
+        int w = 0, h = 0, comp = 0;
+        stbi_uc* pixels = stbi_load_from_memory(data.data(), static_cast<int>(data.size()),
+                                                &w, &h, &comp, 4);
+        if (pixels == nullptr || w <= 0 || h <= 0 || w > 4096 || h > 4096)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] stb_image decode failed or out of range: {}", absolutePath);
+            if (pixels) stbi_image_free(pixels);
+            return false;
+        }
+        const size_t pixelBytes = static_cast<size_t>(w) * h * 4u;
+        outRgba.assign(pixels, pixels + pixelBytes);
+        outWidth = static_cast<uint32_t>(w);
+        outHeight = static_cast<uint32_t>(h);
+        stbi_image_free(pixels);
+        return true;
+    }
+```
+
+- [ ] **Step 3: Ajouter un test sur `LoadTexrFile` avec un .texr écrit en mémoire**
+
+Dans `engine/editor/tests/TexturePreviewCacheTests.cpp`, ajouter avant `int main()` :
+
+```cpp
+    /// Ecrit un .texr 4x4 RGBA8 dans tmp et le decode via LoadTexrFile.
+    void Test_LoadTexrRoundTrip()
+    {
+        const std::filesystem::path tmpPath = std::filesystem::temp_directory_path() / "lcdlln_texr_test.texr";
+        std::vector<uint8_t> file;
+        const uint32_t magic = 0x52584554u;
+        const uint32_t w = 4u, h = 4u, srgb = 1u;
+        file.resize(16u + w * h * 4u);
+        std::memcpy(file.data() + 0,  &magic, 4);
+        std::memcpy(file.data() + 4,  &w,     4);
+        std::memcpy(file.data() + 8,  &h,     4);
+        std::memcpy(file.data() + 12, &srgb,  4);
+        for (size_t p = 0; p < w * h; ++p)
+        {
+            file[16u + p * 4u + 0] = 100u;
+            file[16u + p * 4u + 1] = 150u;
+            file[16u + p * 4u + 2] = 200u;
+            file[16u + p * 4u + 3] = 255u;
+        }
+        {
+            std::ofstream f(tmpPath, std::ios::binary);
+            f.write(reinterpret_cast<const char*>(file.data()), static_cast<long long>(file.size()));
+        }
+
+        std::vector<uint8_t> out;
+        uint32_t outW = 0, outH = 0;
+        REQUIRE(engine::editor::LoadTexrFile(tmpPath.string(), out, outW, outH));
+        REQUIRE(outW == 4u);
+        REQUIRE(outH == 4u);
+        REQUIRE(out.size() == 64u);
+        REQUIRE(out[0] == 100u && out[1] == 150u && out[2] == 200u && out[3] == 255u);
+
+        std::filesystem::remove(tmpPath);
+    }
+```
+
+Ajouter les includes manquants en haut du test : `<filesystem>`, `<fstream>`, `<cstring>`.
+
+Appeler `Test_LoadTexrRoundTrip()` dans `main()`.
+
+- [ ] **Step 4: Build et lancer le test**
+
+Run :
+```
+cmake --build build --target texture_preview_cache_tests --config Release
+ctest --test-dir build -C Release -R texture_preview_cache_tests --output-on-failure
+```
+
+Expected : tous les tests passent, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp engine/editor/tests/TexturePreviewCacheTests.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): LoadTexrFile decode .texr + fallback PNG/JPG via stb_image
+
+Decoder unifie pour vignettes editeur :
+- Si magic 'TEXR' en tete : parse les 16 octets header + RGBA8 brut.
+- Sinon : fallback stb_image (PNG/JPG/TGA/BMP, force 4 canaux).
+Cap a 4096x4096 (cf. spec sec 4.2). Tests round-trip avec .texr 4x4 ecrit
+en tmp.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Ajouter `TerrainSplatting::SetLayerCpuRgba256` + `RebuildAlbedoArrayFromCpuLayers`
+
+**Files:**
+- Modify: `engine/render/terrain/TerrainSplatting.h`
+- Modify: `engine/render/terrain/TerrainSplatting.cpp`
+
+- [ ] **Step 1: Déclarer les 2 nouvelles méthodes dans le header**
+
+Dans `engine/render/terrain/TerrainSplatting.h`, ajouter dans la section publique de `TerrainSplatting` (après `ReuploadSplatMap`) :
+
+```cpp
+        /// Stocke un buffer CPU RGBA8 kSplatLayerResolution^2 pour le layer
+        /// donne. Le buffer doit faire exactement
+        /// kSplatLayerResolution * kSplatLayerResolution * 4 octets — sinon
+        /// l'appel est ignore (LOG_ERROR). N'uploade pas tout de suite : il
+        /// faut appeler RebuildAlbedoArrayFromCpuLayers ensuite.
+        /// \param layer 0..kSplatLayerCount-1.
+        /// \param rgba Pixels RGBA8 row-major.
+        void SetLayerCpuRgba256(uint32_t layer, const std::vector<uint8_t>& rgba);
+
+        /// Repacke les 4 layers CPU (m_layerCpuData) en un buffer staging
+        /// 4*kSplatLayerResolution^2*4 et re-upload via vkCmdCopyBufferToImage
+        /// dans m_albedoArray.image. Pattern identique a ReuploadSplatMap :
+        /// SHADER_READ_ONLY -> TRANSFER_DST -> copies -> SHADER_READ_ONLY,
+        /// submit + vkQueueWaitIdle.
+        ///
+        /// Pour les layers sans donnee CPU stockee (SetLayerCpuRgba256 jamais
+        /// appele), regenere la procedurale via GenerateProceduralAlbedoLayer.
+        ///
+        /// \return true si succes.
+        bool RebuildAlbedoArrayFromCpuLayers(VkDevice device, VkPhysicalDevice physDev,
+                                             VkQueue queue, uint32_t queueFamilyIndex);
+```
+
+Dans la section privée, ajouter le storage CPU :
+
+```cpp
+        /// Buffers CPU des 4 layers, alimentes par SetLayerCpuRgba256.
+        /// Vide pour un layer = utilise la procedurale au prochain rebuild.
+        std::array<std::vector<uint8_t>, kSplatLayerCount> m_layerCpuData;
+```
+
+Et ajouter `#include <array>` si pas déjà présent.
+
+- [ ] **Step 2: Implémenter `SetLayerCpuRgba256` dans le .cpp**
+
+À la fin de `engine/render/terrain/TerrainSplatting.cpp` (avant la fermeture du namespace), ajouter :
+
+```cpp
+    void TerrainSplatting::SetLayerCpuRgba256(uint32_t layer, const std::vector<uint8_t>& rgba)
+    {
+        if (layer >= kSplatLayerCount)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] SetLayerCpuRgba256: layer {} out of range", layer);
+            return;
+        }
+        const size_t expected = static_cast<size_t>(kSplatLayerResolution) * kSplatLayerResolution * 4u;
+        if (rgba.size() != expected)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] SetLayerCpuRgba256: rgba size {} != expected {} ({}x{}x4)",
+                      rgba.size(), expected, kSplatLayerResolution, kSplatLayerResolution);
+            return;
+        }
+        m_layerCpuData[layer] = rgba;
+    }
+
+    bool TerrainSplatting::RebuildAlbedoArrayFromCpuLayers(VkDevice device, VkPhysicalDevice physDev,
+                                                            VkQueue queue, uint32_t queueFamilyIndex)
+    {
+        if (m_albedoArray.image == VK_NULL_HANDLE)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] RebuildAlbedoArrayFromCpuLayers: array not initialized");
+            return false;
+        }
+        const uint32_t res = kSplatLayerResolution;
+        const size_t layerBytes = static_cast<size_t>(res) * res * 4u;
+        std::vector<uint8_t> packed(static_cast<size_t>(kSplatLayerCount) * layerBytes);
+        std::vector<uint8_t> tmpProc;
+
+        for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+        {
+            const uint8_t* srcLayer = nullptr;
+            if (m_layerCpuData[layer].size() == layerBytes)
+            {
+                srcLayer = m_layerCpuData[layer].data();
+            }
+            else
+            {
+                if (!GenerateProceduralAlbedoLayer(res, layer, tmpProc))
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] Rebuild: procedural fallback failed for layer {}", layer);
+                    return false;
+                }
+                srcLayer = tmpProc.data();
+            }
+            std::memcpy(packed.data() + layer * layerBytes, srcLayer, layerBytes);
+        }
+
+        // Staging buffer + copy via existing helper (reuse internal pattern).
+        VkBuffer staging = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, packed.size(), staging, stagingMem))
+        {
+            return false;
+        }
+        // Map + memcpy.
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, packed.size(), 0, &mapped) != VK_SUCCESS)
+        {
+            vkDestroyBuffer(device, staging, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, packed.data(), packed.size());
+        vkUnmapMemory(device, stagingMem);
+
+        // Build copy regions (1 per layer).
+        std::vector<VkBufferImageCopy> regions(kSplatLayerCount);
+        for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+        {
+            VkBufferImageCopy& r = regions[layer];
+            r = {};
+            r.bufferOffset = layer * layerBytes;
+            r.bufferRowLength = 0;
+            r.bufferImageHeight = 0;
+            r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            r.imageSubresource.mipLevel = 0;
+            r.imageSubresource.baseArrayLayer = layer;
+            r.imageSubresource.layerCount = 1;
+            r.imageOffset = { 0, 0, 0 };
+            r.imageExtent = { res, res, 1 };
+        }
+
+        // Use existing UploadViaStaging helper (handles barriers SHADER_READ_ONLY <-> TRANSFER_DST).
+        // NOTE: UploadViaStaging assume oldLayout=UNDEFINED. Pour reuploader sur une image deja
+        // en SHADER_READ_ONLY, on duplique le pattern ici avec barrier explicite. Voir Step 3.
+
+        const bool ok = ReuploadAlbedoArrayInternal(device, queue, queueFamilyIndex,
+                                                     staging, regions);
+        vkDestroyBuffer(device, staging, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+        return ok;
+    }
+```
+
+- [ ] **Step 3: Implémenter `ReuploadAlbedoArrayInternal` (helper privé)**
+
+Ajouter dans la section privée du header :
+
+```cpp
+        /// Helper interne : barrier SHADER_READ_ONLY -> TRANSFER_DST, copy, retour
+        /// SHADER_READ_ONLY. Submit + vkQueueWaitIdle. Utilise par
+        /// RebuildAlbedoArrayFromCpuLayers (image deja en SHADER_READ_ONLY).
+        bool ReuploadAlbedoArrayInternal(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                                         VkBuffer staging,
+                                         const std::vector<VkBufferImageCopy>& regions);
+```
+
+Dans le .cpp, après `RebuildAlbedoArrayFromCpuLayers` :
+
+```cpp
+    bool TerrainSplatting::ReuploadAlbedoArrayInternal(VkDevice device, VkQueue queue,
+                                                        uint32_t queueFamilyIndex,
+                                                        VkBuffer staging,
+                                                        const std::vector<VkBufferImageCopy>& regions)
+    {
+        VkCommandPool pool = VK_NULL_HANDLE;
+        VkCommandPoolCreateInfo poolCI{};
+        poolCI.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolCI.queueFamilyIndex = queueFamilyIndex;
+        poolCI.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS) return false;
+
+        VkCommandBuffer cmd = VK_NULL_HANDLE;
+        VkCommandBufferAllocateInfo aci{};
+        aci.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        aci.commandPool = pool;
+        aci.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        aci.commandBufferCount = 1;
+        if (vkAllocateCommandBuffers(device, &aci, &cmd) != VK_SUCCESS)
+        {
+            vkDestroyCommandPool(device, pool, nullptr);
+            return false;
+        }
+
+        VkCommandBufferBeginInfo bi{};
+        bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(cmd, &bi);
+
+        // Barrier SHADER_READ_ONLY -> TRANSFER_DST for all layers.
+        {
+            VkImageMemoryBarrier b{};
+            b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image = m_albedoArray.image;
+            b.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, kSplatLayerCount };
+            b.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            b.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        vkCmdCopyBufferToImage(cmd, staging, m_albedoArray.image,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               static_cast<uint32_t>(regions.size()), regions.data());
+
+        // Barrier TRANSFER_DST -> SHADER_READ_ONLY for all layers.
+        {
+            VkImageMemoryBarrier b{};
+            b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image = m_albedoArray.image;
+            b.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, kSplatLayerCount };
+            b.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            b.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        vkEndCommandBuffer(cmd);
+
+        VkSubmitInfo si{};
+        si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        si.commandBufferCount = 1;
+        si.pCommandBuffers = &cmd;
+        if (vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE) != VK_SUCCESS)
+        {
+            vkDestroyCommandPool(device, pool, nullptr);
+            return false;
+        }
+        vkQueueWaitIdle(queue);
+        vkDestroyCommandPool(device, pool, nullptr);
+        return true;
+    }
+```
+
+- [ ] **Step 4: Build complet**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+```
+
+Expected : compile sans erreur. Si erreur de membre privé `CreateStagingBuffer` introuvable, vérifier qu'il est dans le namespace anonyme du .cpp (il l'est, accessible depuis n'importe quelle méthode du même fichier).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/render/terrain/TerrainSplatting.h engine/render/terrain/TerrainSplatting.cpp
+git commit -m "$(cat <<'EOF'
+feat(terrain): SetLayerCpuRgba256 + RebuildAlbedoArrayFromCpuLayers
+
+Permet de remplacer un layer du splat array par un buffer CPU 256x256
+arbitraire (texture importee) puis de re-uploader sur GPU via staging.
+Pattern barrier SHADER_READ_ONLY -> TRANSFER_DST -> SHADER_READ_ONLY,
+identique a ReuploadSplatMap. Layer sans donnee CPU = fallback procedural.
+
+Pas encore branche cote editeur — cf. tasks suivantes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: TexturePreviewCache — squelette Init/Shutdown (sampler + descriptor pool)
+
+**Files:**
+- Modify: `engine/editor/TexturePreviewCache.h`
+- Modify: `engine/editor/TexturePreviewCache.cpp`
+
+- [ ] **Step 1: Compléter le header avec la classe**
+
+Dans `engine/editor/TexturePreviewCache.h`, après les free functions, avant la fermeture du namespace :
+
+```cpp
+} // namespace engine::editor
+
+// Forward decl Vulkan + ImGui pour ne pas tirer les headers dans le .h.
+struct VkDevice_T;       typedef VkDevice_T*       VkDevice;
+struct VkPhysicalDevice_T; typedef VkPhysicalDevice_T* VkPhysicalDevice;
+struct VkQueue_T;        typedef VkQueue_T*        VkQueue;
+struct VkSampler_T;      typedef VkSampler_T*      VkSampler;
+struct VkDescriptorPool_T; typedef VkDescriptorPool_T* VkDescriptorPool;
+struct VkImage_T;        typedef VkImage_T*        VkImage;
+struct VkImageView_T;    typedef VkImageView_T*    VkImageView;
+struct VkDeviceMemory_T; typedef VkDeviceMemory_T* VkDeviceMemory;
+struct VkDescriptorSet_T; typedef VkDescriptorSet_T* VkDescriptorSet;
+typedef void* ImTextureID;
+
+namespace engine::editor
+{
+    /// Cache lazy de textures decoders + uploadees a 256x256 RGBA8 pour rendu
+    /// dans ImGui (vignettes editeur monde) et reupload du splat array terrain.
+    /// Possede par Engine, vit le temps du device Vulkan.
+    class TexturePreviewCache
+    {
+    public:
+        TexturePreviewCache() = default;
+        TexturePreviewCache(const TexturePreviewCache&) = delete;
+        TexturePreviewCache& operator=(const TexturePreviewCache&) = delete;
+        ~TexturePreviewCache();
+
+        /// Initialise sampler + descriptor pool. Doit etre appelee apres le device
+        /// Vulkan et apres ImGui_ImplVulkan_Init.
+        /// \param contentDir Repertoire absolu pointant vers <content>/ (pour
+        ///   resoudre les chemins .texr content-relatifs).
+        /// \return true si succes.
+        bool Init(VkDevice device, VkPhysicalDevice physDev,
+                  VkQueue queue, uint32_t queueFamilyIndex,
+                  const std::string& contentDir);
+        void Shutdown();
+
+        bool IsReady() const { return m_ready; }
+
+        // ── API a etendre dans les tasks suivantes ─────────────────────────
+        // ImTextureID GetProceduralThumb(uint32_t layer);   // Task 7
+        // ImTextureID GetTexrThumb(const std::string& contentRelPath);  // Task 8
+        // void Invalidate(const std::string& contentRelPath);  // Task 9
+        // const std::vector<uint8_t>* GetCpuRgba256(const std::string& key) const; // Task 8
+        // void Tick(uint64_t currentFrameIndex, uint32_t framesInFlight); // Task 9
+
+    private:
+        bool m_ready = false;
+        VkDevice m_device = nullptr;
+        VkPhysicalDevice m_physDev = nullptr;
+        VkQueue m_queue = nullptr;
+        uint32_t m_queueFamily = 0;
+        std::string m_contentDir;
+
+        VkSampler m_sampler = nullptr;
+        VkDescriptorPool m_pool = nullptr;
+    };
+
+} // namespace engine::editor
+```
+
+(remettre la fermeture du namespace après la classe ; supprimer la fermeture intermédiaire avant les forward decl, c'était une transition incorrecte. Ajuste pour avoir la déclaration globale `typedef` PUIS le namespace.)
+
+**Forme finale correcte** :
+
+```cpp
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Forward decl Vulkan + ImGui (evite #include vulkan.h dans le .h).
+struct VkDevice_T;        typedef VkDevice_T*        VkDevice;
+struct VkPhysicalDevice_T; typedef VkPhysicalDevice_T* VkPhysicalDevice;
+struct VkQueue_T;         typedef VkQueue_T*         VkQueue;
+struct VkSampler_T;       typedef VkSampler_T*       VkSampler;
+struct VkDescriptorPool_T; typedef VkDescriptorPool_T* VkDescriptorPool;
+struct VkImage_T;         typedef VkImage_T*         VkImage;
+struct VkImageView_T;     typedef VkImageView_T*     VkImageView;
+struct VkDeviceMemory_T;  typedef VkDeviceMemory_T*  VkDeviceMemory;
+struct VkDescriptorSet_T; typedef VkDescriptorSet_T* VkDescriptorSet;
+typedef void* ImTextureID;
+
+namespace engine::editor
+{
+    bool ResampleRgba8Box(...);   // tel que defini precedemment
+    bool LoadTexrFile(...);       // tel que defini precedemment
+
+    class TexturePreviewCache { ... };
+}
+```
+
+- [ ] **Step 2: Implémenter `Init` et `Shutdown` dans le .cpp**
+
+Ajouter `#include <vulkan/vulkan.h>` en haut du .cpp (après les `#define STB_IMAGE_*`).
+
+```cpp
+    TexturePreviewCache::~TexturePreviewCache()
+    {
+        Shutdown();
+    }
+
+    bool TexturePreviewCache::Init(VkDevice device, VkPhysicalDevice physDev,
+                                    VkQueue queue, uint32_t queueFamilyIndex,
+                                    const std::string& contentDir)
+    {
+        if (m_ready) return true;
+        if (device == nullptr || physDev == nullptr || queue == nullptr)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Init: invalid Vulkan handles");
+            return false;
+        }
+        m_device = device;
+        m_physDev = physDev;
+        m_queue = queue;
+        m_queueFamily = queueFamilyIndex;
+        m_contentDir = contentDir;
+
+        // Sampler partage : linear filter, clamp to edge.
+        VkSamplerCreateInfo si{};
+        si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        si.magFilter = VK_FILTER_LINEAR;
+        si.minFilter = VK_FILTER_LINEAR;
+        si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.maxAnisotropy = 1.0f;
+        si.minLod = 0.0f; si.maxLod = 0.0f;
+        if (vkCreateSampler(m_device, &si, nullptr, &m_sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateSampler failed");
+            return false;
+        }
+
+        // Descriptor pool dedie : 64 sets max, 1 sampled image chacun (pour ImGui).
+        VkDescriptorPoolSize ps{};
+        ps.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        ps.descriptorCount = 64u;
+        VkDescriptorPoolCreateInfo pi{};
+        pi.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        pi.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        pi.maxSets = 64u;
+        pi.poolSizeCount = 1;
+        pi.pPoolSizes = &ps;
+        if (vkCreateDescriptorPool(m_device, &pi, nullptr, &m_pool) != VK_SUCCESS)
+        {
+            vkDestroySampler(m_device, m_sampler, nullptr);
+            m_sampler = nullptr;
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateDescriptorPool failed");
+            return false;
+        }
+
+        m_ready = true;
+        LOG_INFO(Render, "[TexturePreviewCache] Init OK (contentDir={})", m_contentDir);
+        return true;
+    }
+
+    void TexturePreviewCache::Shutdown()
+    {
+        if (m_device != nullptr)
+        {
+            if (m_pool != nullptr)
+            {
+                vkDestroyDescriptorPool(m_device, m_pool, nullptr);
+                m_pool = nullptr;
+            }
+            if (m_sampler != nullptr)
+            {
+                vkDestroySampler(m_device, m_sampler, nullptr);
+                m_sampler = nullptr;
+            }
+        }
+        m_device = nullptr;
+        m_physDev = nullptr;
+        m_queue = nullptr;
+        m_queueFamily = 0;
+        m_contentDir.clear();
+        m_ready = false;
+    }
+```
+
+- [ ] **Step 3: Build pour vérifier qu'on n'a rien cassé**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+cmake --build build --target texture_preview_cache_tests --config Release
+ctest --test-dir build -C Release -R texture_preview_cache_tests --output-on-failure
+```
+
+Expected : compile OK, tests passent (Vulkan pas appelé dans les tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): TexturePreviewCache squelette (Init/Shutdown, sampler, pool)
+
+Cache lazy pour rendu de vignettes ImGui dans l'editeur monde. Cette
+commit pose les fondations (cycle de vie Vulkan, sampler partage linear
+clamp, descriptor pool dedie 64 sets). Les Get*/Invalidate/Tick suivent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: TexturePreviewCache — `GetProceduralThumb` + entrée GPU
+
+**Files:**
+- Modify: `engine/editor/TexturePreviewCache.h`
+- Modify: `engine/editor/TexturePreviewCache.cpp`
+
+- [ ] **Step 1: Déclarer struct interne `GpuPreview` et `GetProceduralThumb`**
+
+Dans `engine/editor/TexturePreviewCache.h`, dans la section publique de `TexturePreviewCache` :
+
+```cpp
+        /// Renvoie une ImTextureID utilisable par ImGui::Image() pour la
+        /// vignette procedurale du layer (0=grass, 1=dirt, 2=rock, 3=snow).
+        /// La 1re demande genere + uploade ; les suivantes hit le cache.
+        /// Retourne nullptr si Init n'a pas reussi ou layer invalide.
+        ImTextureID GetProceduralThumb(uint32_t layer);
+
+        /// Renvoie le buffer CPU 256x256 d'une key cachee (ou nullptr).
+        /// Cles : "procedural:0".."procedural:3" pour les builtins,
+        ///        "textures/<rel>" pour les .texr importees.
+        const std::vector<uint8_t>* GetCpuRgba256(const std::string& key) const;
+```
+
+Section privée :
+
+```cpp
+        struct GpuPreview {
+            std::vector<uint8_t> cpuRgba256;
+            VkImage              image       = nullptr;
+            VkImageView          view        = nullptr;
+            VkDeviceMemory       memory      = nullptr;
+            VkDescriptorSet      imguiDS     = nullptr;
+        };
+
+        /// key -> preview. Cles cf. GetCpuRgba256.
+        std::unordered_map<std::string, GpuPreview> m_entries;
+
+        /// Cle procedurale standardisee.
+        static std::string ProceduralKey(uint32_t layer);
+
+        /// Cree image+view+descriptor ImGui a partir d'un buffer 256x256 RGBA8.
+        /// Stocke dans m_entries[key]. Renvoie l'ImTextureID ou nullptr.
+        ImTextureID CreateEntry(const std::string& key,
+                                const std::vector<uint8_t>& rgba256);
+
+        /// Detruit les ressources Vulkan d'une entree (helper interne).
+        void DestroyEntry(GpuPreview& p);
+```
+
+Ajouter `#include <unordered_map>` en haut du .h.
+
+- [ ] **Step 2: Implémenter `ProceduralKey`, `CreateEntry`, `DestroyEntry`, `GetProceduralThumb`, `GetCpuRgba256` dans le .cpp**
+
+Ajouter `#include <imgui_impl_vulkan.h>` en haut du .cpp (Win32 only — voir step 3 si besoin de garder portable).
+
+```cpp
+    std::string TexturePreviewCache::ProceduralKey(uint32_t layer)
+    {
+        return std::string("procedural:") + std::to_string(layer);
+    }
+
+    ImTextureID TexturePreviewCache::CreateEntry(const std::string& key,
+                                                  const std::vector<uint8_t>& rgba256)
+    {
+        constexpr uint32_t kRes = engine::render::terrain::kSplatLayerResolution;
+        if (!m_ready || rgba256.size() != static_cast<size_t>(kRes) * kRes * 4u)
+        {
+            return nullptr;
+        }
+
+        GpuPreview preview;
+        preview.cpuRgba256 = rgba256;
+
+        // 1. VkImage 256x256 RGBA8_SRGB, OPTIMAL, SAMPLED + TRANSFER_DST.
+        VkImageCreateInfo ici{};
+        ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        ici.imageType = VK_IMAGE_TYPE_2D;
+        ici.format = VK_FORMAT_R8G8B8A8_SRGB;
+        ici.extent = { kRes, kRes, 1 };
+        ici.mipLevels = 1;
+        ici.arrayLayers = 1;
+        ici.samples = VK_SAMPLE_COUNT_1_BIT;
+        ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+        ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        if (vkCreateImage(m_device, &ici, nullptr, &preview.image) != VK_SUCCESS) return nullptr;
+
+        VkMemoryRequirements mr{};
+        vkGetImageMemoryRequirements(m_device, preview.image, &mr);
+        VkPhysicalDeviceMemoryProperties mp{};
+        vkGetPhysicalDeviceMemoryProperties(m_physDev, &mp);
+        uint32_t memType = UINT32_MAX;
+        for (uint32_t i = 0; i < mp.memoryTypeCount; ++i)
+        {
+            if ((mr.memoryTypeBits & (1u << i)) &&
+                (mp.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+            {
+                memType = i; break;
+            }
+        }
+        if (memType == UINT32_MAX) { vkDestroyImage(m_device, preview.image, nullptr); return nullptr; }
+        VkMemoryAllocateInfo ai{};
+        ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        ai.allocationSize = mr.size;
+        ai.memoryTypeIndex = memType;
+        if (vkAllocateMemory(m_device, &ai, nullptr, &preview.memory) != VK_SUCCESS)
+        {
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        vkBindImageMemory(m_device, preview.image, preview.memory, 0);
+
+        // 2. Upload via staging.
+        VkBuffer staging = nullptr;
+        VkDeviceMemory stagingMem = nullptr;
+        VkBufferCreateInfo bci{};
+        bci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        bci.size = rgba256.size();
+        bci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        vkCreateBuffer(m_device, &bci, nullptr, &staging);
+        VkMemoryRequirements bmr{};
+        vkGetBufferMemoryRequirements(m_device, staging, &bmr);
+        uint32_t hvis = UINT32_MAX;
+        for (uint32_t i = 0; i < mp.memoryTypeCount; ++i)
+        {
+            if ((bmr.memoryTypeBits & (1u << i)) &&
+                (mp.memoryTypes[i].propertyFlags &
+                  (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) ==
+                  (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+            { hvis = i; break; }
+        }
+        VkMemoryAllocateInfo ai2{};
+        ai2.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        ai2.allocationSize = bmr.size;
+        ai2.memoryTypeIndex = hvis;
+        vkAllocateMemory(m_device, &ai2, nullptr, &stagingMem);
+        vkBindBufferMemory(m_device, staging, stagingMem, 0);
+        void* mapped = nullptr;
+        vkMapMemory(m_device, stagingMem, 0, rgba256.size(), 0, &mapped);
+        std::memcpy(mapped, rgba256.data(), rgba256.size());
+        vkUnmapMemory(m_device, stagingMem);
+
+        // 3. Submit one-shot : barriers + copy.
+        VkCommandPool pool = nullptr;
+        VkCommandPoolCreateInfo pci{};
+        pci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        pci.queueFamilyIndex = m_queueFamily;
+        pci.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        vkCreateCommandPool(m_device, &pci, nullptr, &pool);
+        VkCommandBuffer cmd = nullptr;
+        VkCommandBufferAllocateInfo cai{};
+        cai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        cai.commandPool = pool;
+        cai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cai.commandBufferCount = 1;
+        vkAllocateCommandBuffers(m_device, &cai, &cmd);
+        VkCommandBufferBeginInfo bi{};
+        bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(cmd, &bi);
+
+        VkImageMemoryBarrier b1{};
+        b1.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        b1.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        b1.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        b1.image = preview.image;
+        b1.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        b1.srcAccessMask = 0;
+        b1.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b1);
+
+        VkBufferImageCopy r{};
+        r.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+        r.imageExtent = { kRes, kRes, 1 };
+        vkCmdCopyBufferToImage(cmd, staging, preview.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
+
+        VkImageMemoryBarrier b2 = b1;
+        b2.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        b2.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        b2.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        b2.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b2);
+
+        vkEndCommandBuffer(cmd);
+        VkSubmitInfo sub{};
+        sub.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        sub.commandBufferCount = 1; sub.pCommandBuffers = &cmd;
+        vkQueueSubmit(m_queue, 1, &sub, nullptr);
+        vkQueueWaitIdle(m_queue);
+
+        vkDestroyCommandPool(m_device, pool, nullptr);
+        vkDestroyBuffer(m_device, staging, nullptr);
+        vkFreeMemory(m_device, stagingMem, nullptr);
+
+        // 4. ImageView.
+        VkImageViewCreateInfo vci{};
+        vci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        vci.image = preview.image;
+        vci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        vci.format = VK_FORMAT_R8G8B8A8_SRGB;
+        vci.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        vkCreateImageView(m_device, &vci, nullptr, &preview.view);
+
+        // 5. Descriptor ImGui.
+        preview.imguiDS = ImGui_ImplVulkan_AddTexture(m_sampler, preview.view,
+                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        const ImTextureID id = static_cast<ImTextureID>(preview.imguiDS);
+        m_entries.emplace(key, std::move(preview));
+        return id;
+    }
+
+    void TexturePreviewCache::DestroyEntry(GpuPreview& p)
+    {
+        if (p.imguiDS != nullptr)
+        {
+            ImGui_ImplVulkan_RemoveTexture(p.imguiDS);
+            p.imguiDS = nullptr;
+        }
+        if (p.view != nullptr) { vkDestroyImageView(m_device, p.view, nullptr); p.view = nullptr; }
+        if (p.image != nullptr) { vkDestroyImage(m_device, p.image, nullptr); p.image = nullptr; }
+        if (p.memory != nullptr) { vkFreeMemory(m_device, p.memory, nullptr); p.memory = nullptr; }
+        p.cpuRgba256.clear();
+    }
+
+    ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t layer)
+    {
+        if (!m_ready || layer >= engine::render::terrain::kSplatLayerCount) return nullptr;
+        const std::string key = ProceduralKey(layer);
+        auto it = m_entries.find(key);
+        if (it != m_entries.end())
+        {
+            return static_cast<ImTextureID>(it->second.imguiDS);
+        }
+        std::vector<uint8_t> rgba;
+        if (!engine::render::terrain::GenerateProceduralAlbedoLayer(
+                engine::render::terrain::kSplatLayerResolution, layer, rgba))
+        {
+            return nullptr;
+        }
+        return CreateEntry(key, rgba);
+    }
+
+    const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string& key) const
+    {
+        auto it = m_entries.find(key);
+        if (it == m_entries.end()) return nullptr;
+        return &it->second.cpuRgba256;
+    }
+```
+
+Modifier `Shutdown()` pour nettoyer les entrées :
+
+```cpp
+    void TexturePreviewCache::Shutdown()
+    {
+        for (auto& kv : m_entries) DestroyEntry(kv.second);
+        m_entries.clear();
+        // ... reste inchange (destroy pool + sampler)
+    }
+```
+
+- [ ] **Step 3: Vérifier inclusion de `imgui_impl_vulkan.h`**
+
+`ImGui_ImplVulkan_AddTexture` n'est dispo que sur Win32 (cf. `WorldEditorImGui.cpp` qui guarde `#if defined(_WIN32)`). Pour rester portable, encadrer le code Vulkan/ImGui de `TexturePreviewCache.cpp` par `#if defined(_WIN32)` et fournir des stubs no-op sur autres plateformes (les binaires Linux/macOS ne lancent pas l'éditeur).
+
+Pattern : déplacer toute la classe `TexturePreviewCache::*` (sauf le destructeur stub) dans un bloc `#if defined(_WIN32) ... #endif`. Les méthodes hors-Win32 retournent `false`/`nullptr` no-op.
+
+- [ ] **Step 4: Build complet**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+cmake --build build --target world_editor_app --config Release
+```
+
+Expected : compile sans erreur. Si erreur sur `ImGui_ImplVulkan_AddTexture` ou `kSplatLayerCount`, ajouter les includes nécessaires.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): GetProceduralThumb + creation d'entrees GPU pour vignettes
+
+Permet d'obtenir un ImTextureID pour les 4 procedurales builtin. Le cache
+stocke les ressources Vulkan (image+view+memory+ImGui descriptor) en
+unordered_map keyed par "procedural:N" ou "textures/<rel>".
+
+Code Vulkan/ImGui Win32-only (l'editeur monde n'est lance que sous Windows
+de toute facon, cf. world_editor_main.cpp).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: TexturePreviewCache — `GetTexrThumb` + résolution chemin content
+
+**Files:**
+- Modify: `engine/editor/TexturePreviewCache.h`
+- Modify: `engine/editor/TexturePreviewCache.cpp`
+
+- [ ] **Step 1: Déclarer `GetTexrThumb`**
+
+Dans la section publique :
+
+```cpp
+        /// Renvoie l'ImTextureID d'une .texr content-relative (ex: "textures/sand.texr").
+        /// 1re demande : decode (LoadTexrFile) -> resample 256x256 -> upload GPU.
+        /// Suivantes : hit cache. Cache negatif (decode failed) = nullptr renvoye
+        /// jusqu'a Invalidate.
+        /// \return nullptr si Init non OK, fichier introuvable ou corrompu.
+        ImTextureID GetTexrThumb(const std::string& contentRelPath);
+```
+
+Section privée — ajouter un set de "négatifs" (cache miss permanent jusqu'à Invalidate) :
+
+```cpp
+        /// Cles dont le decode a echoue : ne pas retenter avant Invalidate.
+        std::unordered_set<std::string> m_negativeCache;
+```
+
+Ajouter `#include <unordered_set>` au .h.
+
+- [ ] **Step 2: Implémenter `GetTexrThumb`**
+
+```cpp
+    ImTextureID TexturePreviewCache::GetTexrThumb(const std::string& contentRelPath)
+    {
+        if (!m_ready || contentRelPath.empty()) return nullptr;
+        auto it = m_entries.find(contentRelPath);
+        if (it != m_entries.end())
+        {
+            return static_cast<ImTextureID>(it->second.imguiDS);
+        }
+        if (m_negativeCache.count(contentRelPath) != 0)
+        {
+            return nullptr; // deja echoue, ne pas spam les logs
+        }
+
+        // Resoudre en chemin absolu via m_contentDir.
+        std::filesystem::path abs = std::filesystem::path(m_contentDir) / contentRelPath;
+        std::vector<uint8_t> raw;
+        uint32_t srcW = 0, srcH = 0;
+        if (!LoadTexrFile(abs.string(), raw, srcW, srcH))
+        {
+            m_negativeCache.insert(contentRelPath);
+            return nullptr;
+        }
+
+        std::vector<uint8_t> resampled;
+        if (!ResampleRgba8Box(raw.data(), srcW, srcH,
+                              engine::render::terrain::kSplatLayerResolution, resampled))
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] ResampleRgba8Box failed for {}", contentRelPath);
+            m_negativeCache.insert(contentRelPath);
+            return nullptr;
+        }
+
+        return CreateEntry(contentRelPath, resampled);
+    }
+```
+
+- [ ] **Step 3: Build et lancer le world editor pour vérifier qu'on n'a rien cassé**
+
+Run :
+```
+cmake --build build --target world_editor_app --config Release
+pkg/world_editor/lcdlln_world_editor.exe
+```
+
+Expected : éditeur démarre normalement. Aucune vignette visible (pas encore branchée).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): GetTexrThumb (decode + resample + upload .texr importees)
+
+Pipeline de decode pour vignettes des .texr utilisateur :
+LoadTexrFile -> ResampleRgba8Box(256) -> CreateEntry. Cache negatif
+(unordered_set) pour eviter de re-tenter en boucle un fichier corrompu
+jusqu'a Invalidate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: TexturePreviewCache — `Invalidate` + `Tick` (deferred destruction)
+
+**Files:**
+- Modify: `engine/editor/TexturePreviewCache.h`
+- Modify: `engine/editor/TexturePreviewCache.cpp`
+
+- [ ] **Step 1: Déclarer `Invalidate` et `Tick`**
+
+Dans la section publique :
+
+```cpp
+        /// Marque l'entree pour destruction au prochain Tick(framesInFlight).
+        /// Utilise quand l'utilisateur reimporte une .texr (le fichier disque
+        /// a change). Procedurales : pas d'invalidation utile (octets fixes).
+        void Invalidate(const std::string& contentRelPath);
+
+        /// A appeler chaque frame en main thread. Detruit les entrees en
+        /// pending depuis assez longtemps pour qu'aucune command buffer en
+        /// vol ne les reference.
+        void Tick(uint64_t currentFrameIndex, uint32_t framesInFlight);
+```
+
+Section privée :
+
+```cpp
+        struct PendingDelete {
+            GpuPreview preview;
+            uint64_t   frameIndex;
+        };
+        std::vector<PendingDelete> m_pendingDeletes;
+```
+
+- [ ] **Step 2: Implémenter `Invalidate` + `Tick`**
+
+```cpp
+    void TexturePreviewCache::Invalidate(const std::string& contentRelPath)
+    {
+        m_negativeCache.erase(contentRelPath);
+        auto it = m_entries.find(contentRelPath);
+        if (it == m_entries.end()) return;
+        // Differer la destruction (descriptor potentiellement reference dans CB en vol).
+        m_pendingDeletes.push_back({ std::move(it->second), 0u /* frameIndex set par Tick */ });
+        m_pendingDeletes.back().frameIndex = m_lastTickFrame;
+        m_entries.erase(it);
+    }
+
+    void TexturePreviewCache::Tick(uint64_t currentFrameIndex, uint32_t framesInFlight)
+    {
+        m_lastTickFrame = currentFrameIndex;
+        // Purge les entrees dont l'invalidation date d'au moins framesInFlight.
+        for (auto it = m_pendingDeletes.begin(); it != m_pendingDeletes.end(); )
+        {
+            if (currentFrameIndex >= it->frameIndex + framesInFlight)
+            {
+                DestroyEntry(it->preview);
+                it = m_pendingDeletes.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+```
+
+Et ajouter dans la section privée `uint64_t m_lastTickFrame = 0;`.
+
+Modifier `Shutdown` pour vider `m_pendingDeletes` aussi :
+
+```cpp
+    void TexturePreviewCache::Shutdown()
+    {
+        for (auto& kv : m_entries) DestroyEntry(kv.second);
+        m_entries.clear();
+        for (auto& pd : m_pendingDeletes) DestroyEntry(pd.preview);
+        m_pendingDeletes.clear();
+        m_negativeCache.clear();
+        // ... destroy pool + sampler (existant)
+    }
+```
+
+- [ ] **Step 3: Build complet**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+```
+
+Expected : compile OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/TexturePreviewCache.h engine/editor/TexturePreviewCache.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): Invalidate + Tick (destruction differee des descriptors)
+
+Suppression d'une entree (reimport .texr) repoussee de framesInFlight
+frames pour eviter UAF sur descriptor reference dans une command buffer
+en vol. m_pendingDeletes purge a chaque Tick.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: WorldEditorSession — dirty flag pour splatLayerTextureRefs
+
+**Files:**
+- Modify: `engine/editor/WorldEditorSession.h`
+- Modify: `engine/editor/WorldEditorSession.cpp`
+
+- [ ] **Step 1: Ajouter le dirty flag et les accessors**
+
+Dans `engine/editor/WorldEditorSession.h`, dans la section publique :
+
+```cpp
+        /// Marque les references de textures de layer (splatLayerTextureRefs)
+        /// comme modifiees. A appeler par les UIs apres avoir change un
+        /// element du tableau. Engine::ProcessSplatRefsDirty consomme ce flag
+        /// chaque frame pour reuploader le splat array GPU.
+        void MarkSplatRefsDirty() { m_splatRefsDirty = true; }
+        bool ConsumeSplatRefsDirty() { const bool d = m_splatRefsDirty; m_splatRefsDirty = false; return d; }
+```
+
+Section privée :
+
+```cpp
+        bool m_splatRefsDirty = false;
+```
+
+- [ ] **Step 2: Marquer dirty au load de carte**
+
+Dans `engine/editor/WorldEditorSession.cpp`, à la fin de la fonction qui charge une carte (chercher `LoadMap` ou `OpenZone` selon ce qui existe ; sinon dans `ApplyLoadedDocument` ou équivalent), ajouter :
+
+```cpp
+        m_splatRefsDirty = true;  // au load, on doit reuploader le splat array si refs presentes.
+```
+
+Egalement dans la fonction qui crée une nouvelle carte vierge (mêmes refs vides → procédurales) :
+
+```cpp
+        m_splatRefsDirty = true;
+```
+
+(Si la fonction n'est pas évidente : `ActionNewMap` / `ActionLoadMap`. Chercher avec `git grep -n splatLayerTextureRefs engine/editor/WorldEditorSession.cpp` pour identifier les sites de mutation et le load.)
+
+- [ ] **Step 3: Build**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/WorldEditorSession.h engine/editor/WorldEditorSession.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): dirty flag splatLayerTextureRefs (consomme par Engine)
+
+Permet aux UIs Peindre / Bibliotheque de signaler un changement de
+mapping texture-layer ; Engine consomme le flag chaque frame pour
+declencher le reupload du splat array GPU. Marque aussi dirty au load
+d'une carte (pour appliquer les refs persistees apres reboot).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Engine — possession du cache + ProcessSplatRefsDirty
+
+**Files:**
+- Modify: `engine/Engine.h`
+- Modify: `engine/Engine.cpp`
+
+- [ ] **Step 1: Déclarer le membre + la méthode privée dans `Engine.h`**
+
+Ajouter dans la section privée de la classe `Engine` :
+
+```cpp
+        std::unique_ptr<engine::editor::TexturePreviewCache> m_texturePreviewCache;
+
+        /// Si WorldEditorSession::ConsumeSplatRefsDirty() == true, repack les
+        /// 4 layers (procedural fallback + textures importees via le cache)
+        /// dans m_terrainSplatting et reuploade le GPU array.
+        /// A appeler chaque frame en world-editor mode, apres les autres ticks.
+        void ProcessSplatRefsDirty();
+```
+
+Ajouter `#include "engine/editor/TexturePreviewCache.h"` aux includes du header (ou en forward decl si possible).
+
+- [ ] **Step 2: Init du cache dans Engine**
+
+Dans `engine/Engine.cpp`, dans la fonction d'init (après l'init Vulkan, l'init TerrainRenderer, et l'init WorldEditorImGui) — chercher l'endroit où `m_worldEditorImGui->Init(...)` est appelé, et ajouter juste après :
+
+```cpp
+        if (m_worldEditorExe)
+        {
+            m_texturePreviewCache = std::make_unique<engine::editor::TexturePreviewCache>();
+            const std::string contentDir = m_cfg.GetString("paths.content", "game/data");
+            std::filesystem::path absContent = std::filesystem::absolute(contentDir);
+            if (!m_texturePreviewCache->Init(m_vkDeviceContext.GetDevice(),
+                                              m_vkDeviceContext.GetPhysicalDevice(),
+                                              m_vkDeviceContext.GetGraphicsQueue(),
+                                              m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
+                                              absContent.string()))
+            {
+                LOG_WARN(Render, "[Engine] TexturePreviewCache init failed -- vignettes editeur indisponibles");
+                m_texturePreviewCache.reset();
+            }
+        }
+```
+
+(Adapter les noms exacts de méthodes `m_vkDeviceContext.GetXxx` selon ce qui existe — `Grep` `class VkDeviceContext` pour confirmer.)
+
+Et dans la fonction Shutdown (avant la destruction de la device) :
+
+```cpp
+        if (m_texturePreviewCache) m_texturePreviewCache->Shutdown();
+        m_texturePreviewCache.reset();
+```
+
+- [ ] **Step 3: Implémenter `ProcessSplatRefsDirty`**
+
+Ajouter une méthode dans `engine/Engine.cpp` :
+
+```cpp
+    void Engine::ProcessSplatRefsDirty()
+    {
+        if (!m_worldEditorExe || !m_worldEditorSession) return;
+        if (!m_texturePreviewCache || !m_texturePreviewCache->IsReady()) return;
+        if (!m_worldEditorSession->ConsumeSplatRefsDirty()) return;
+        if (!m_terrainSplatting.IsValid()) return;  // adapter selon nom du membre TerrainSplatting
+
+        // Pour chaque layer : pousser le buffer CPU adequat dans TerrainSplatting.
+        const auto& refs = m_worldEditorSession->Doc().splatLayerTextureRefs;
+        for (uint32_t layer = 0; layer < engine::render::terrain::kSplatLayerCount; ++layer)
+        {
+            std::string key;
+            const std::vector<uint8_t>* rgba = nullptr;
+            if (!refs[layer].empty())
+            {
+                // Force la decode/upload (cree l'entree si pas encore demandee).
+                m_texturePreviewCache->GetTexrThumb(refs[layer]);
+                rgba = m_texturePreviewCache->GetCpuRgba256(refs[layer]);
+            }
+            if (rgba == nullptr)
+            {
+                // Fallback procedural : assure que l'entree procedurale existe en cache.
+                m_texturePreviewCache->GetProceduralThumb(layer);
+                rgba = m_texturePreviewCache->GetCpuRgba256(
+                    "procedural:" + std::to_string(layer));
+            }
+            if (rgba != nullptr)
+            {
+                m_terrainSplatting.SetLayerCpuRgba256(layer, *rgba);
+            }
+        }
+
+        if (!m_terrainSplatting.RebuildAlbedoArrayFromCpuLayers(
+                m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(),
+                m_vkDeviceContext.GetGraphicsQueue(),
+                m_vkDeviceContext.GetGraphicsQueueFamilyIndex()))
+        {
+            LOG_ERROR(Render, "[Engine] Splat array rebuild failed");
+        }
+    }
+```
+
+**ATTENTION nom du membre TerrainSplatting :** vérifier d'abord avec `Grep "TerrainSplatting m_"` ou `Grep "TerrainRenderer m_"` dans `Engine.h`. Si TerrainSplatting est dans TerrainRenderer (comme le suggère TerrainRenderer.h), utiliser `m_terrainRenderer.GetSplatting().SetLayerCpuRgba256(...)` à la place.
+
+- [ ] **Step 4: Appeler `ProcessSplatRefsDirty` chaque frame**
+
+Chercher dans `Engine::Run()` ou `Engine::FrameUpdate()` (ou équivalent) l'endroit après l'update du `TerrainEditingTools` (qui flush la heightmap éditée), et ajouter :
+
+```cpp
+        ProcessSplatRefsDirty();
+        if (m_texturePreviewCache)
+        {
+            m_texturePreviewCache->Tick(m_frameCounter, kMaxFramesInFlight);
+        }
+```
+
+`m_frameCounter` et `kMaxFramesInFlight` : ajuster selon les conventions existantes (`Grep "frameIndex" engine/Engine.cpp`).
+
+- [ ] **Step 5: Build complet**
+
+Run :
+```
+cmake --build build --target engine_core world_editor_app --config Release
+```
+
+Expected : compile OK. Si erreur sur un nom membre, corriger et relancer.
+
+- [ ] **Step 6: Smoke test manuel**
+
+Lancer `lcdlln_world_editor.exe`. Aucun changement visuel attendu (pas encore d'UI). Vérifier dans les logs que `[TexturePreviewCache] Init OK` apparaît. Si crash au boot, débugger avant de continuer.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add engine/Engine.h engine/Engine.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): Engine possede TexturePreviewCache + ProcessSplatRefsDirty
+
+Le cache vit le temps du device Vulkan. Chaque frame :
+1. Tick(framesInFlight) purge les descriptors invalides.
+2. ProcessSplatRefsDirty consomme le flag de WorldEditorSession et
+   reuploade l'albedo array (procedurales fallback pour les layers sans
+   ref, texr resamplee pour les autres).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Vignettes inline dans l'onglet "Peindre"
+
+**Files:**
+- Modify: `engine/editor/WorldEditorImGui.h`
+- Modify: `engine/editor/WorldEditorImGui.cpp`
+
+- [ ] **Step 1: Ajouter setter du cache dans `WorldEditorImGui`**
+
+Dans `engine/editor/WorldEditorImGui.h`, section publique :
+
+```cpp
+        /// Branche le cache de vignettes (possede par Engine). Pointeur non
+        /// possede. Si nul, les vignettes sont rendues comme cellules grises.
+        void SetTexturePreviewCache(engine::editor::TexturePreviewCache* cache) { m_texturePreviewCache = cache; }
+```
+
+Section privée :
+
+```cpp
+        engine::editor::TexturePreviewCache* m_texturePreviewCache = nullptr;
+        bool m_showTextureLibrary = false;
+```
+
+Forward decl : `namespace engine::editor { class TexturePreviewCache; }` en haut du header.
+
+- [ ] **Step 2: Brancher le setter dans `Engine.cpp`**
+
+Après `m_worldEditorImGui->Init(...)` et après l'init du cache :
+
+```cpp
+        if (m_worldEditorImGui && m_texturePreviewCache)
+        {
+            m_worldEditorImGui->SetTexturePreviewCache(m_texturePreviewCache.get());
+        }
+```
+
+- [ ] **Step 3: Modifier l'onglet "Peindre" pour afficher des vignettes inline**
+
+Dans `engine/editor/WorldEditorImGui.cpp`, dans le bloc `if (ImGui::CollapsingHeader("Textures personnalisees (par couche)"))` (ligne ~1211), remplacer le `for (int li = 0; li < 4; ++li) { Combo... }` par :
+
+```cpp
+                            for (int li = 0; li < 4; ++li)
+                            {
+                                // Vignette 48x48 a gauche du combo.
+                                ImTextureID thumb = nullptr;
+                                if (m_texturePreviewCache != nullptr)
+                                {
+                                    if (refs[static_cast<size_t>(li)].empty())
+                                    {
+                                        thumb = m_texturePreviewCache->GetProceduralThumb(static_cast<uint32_t>(li));
+                                    }
+                                    else
+                                    {
+                                        thumb = m_texturePreviewCache->GetTexrThumb(refs[static_cast<size_t>(li)]);
+                                    }
+                                }
+                                if (thumb != nullptr)
+                                {
+                                    ImGui::Image(thumb, ImVec2(48.0f, 48.0f));
+                                }
+                                else
+                                {
+                                    ImGui::Dummy(ImVec2(48.0f, 48.0f));  // placeholder gris
+                                }
+                                ImGui::SameLine();
+
+                                int sel = 0;
+                                if (!refs[static_cast<size_t>(li)].empty())
+                                {
+                                    for (size_t i = 0; i < imported.size(); ++i)
+                                    {
+                                        if (imported[i] == refs[static_cast<size_t>(li)])
+                                        {
+                                            sel = static_cast<int>(i + 1);
+                                            break;
+                                        }
+                                    }
+                                }
+                                char lbl[32];
+                                std::snprintf(lbl, sizeof(lbl), "%s##splatTex%d", layers[li], li);
+                                if (ImGui::Combo(lbl, &sel, itemsZ.c_str()))
+                                {
+                                    if (sel <= 0)
+                                    {
+                                        refs[static_cast<size_t>(li)].clear();
+                                    }
+                                    else if (static_cast<size_t>(sel - 1) < imported.size())
+                                    {
+                                        refs[static_cast<size_t>(li)] = imported[static_cast<size_t>(sel - 1)];
+                                    }
+                                    m_session->MarkSplatRefsDirty();
+                                }
+                            }
+```
+
+Includes nécessaires en haut du .cpp : `#include "engine/editor/TexturePreviewCache.h"`.
+
+- [ ] **Step 4: Build et test manuel**
+
+Run :
+```
+cmake --build build --target world_editor_app --config Release
+pkg/world_editor/lcdlln_world_editor.exe
+```
+
+Lancer une carte, ouvrir onglet Peindre, replier `Textures personnalisees (par couche)`. Attendu :
+- 4 lignes avec vignette 48×48 (couleurs grass/dirt/rock/snow visibles à l'œil) à gauche du combo.
+- Si on importe un PNG, qu'on le sélectionne dans un combo : la vignette inline change pour le PNG.
+- Si on revient à `(par defaut moteur)` : vignette procédurale revient.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/editor/WorldEditorImGui.h engine/editor/WorldEditorImGui.cpp engine/Engine.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): vignettes inline dans l'onglet Peindre
+
+Chaque layer (Herbe/Terre/Roc/Neige) affiche une vignette 48x48 a gauche
+du combo. Default moteur = procedurale ; selection = .texr resamplee.
+MarkSplatRefsDirty appele a chaque modif de combo -> Engine reuploade le
+splat array a la frame suivante.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: TextureLibraryPanel — squelette du panneau dockable
+
+**Files:**
+- Create: `engine/editor/TextureLibraryPanel.h`
+- Create: `engine/editor/TextureLibraryPanel.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Créer le header**
+
+```cpp
+// engine/editor/TextureLibraryPanel.h
+#pragma once
+
+namespace engine::editor
+{
+    class WorldEditorSession;
+    class TexturePreviewCache;
+
+    /// Dessine le panneau ImGui "Bibliotheque de textures" (Win32 uniquement,
+    /// no-op ailleurs). Affiche les 4 procedurales builtin + toutes les .texr
+    /// importees, avec assignation au layer actif (m_session->SplatLayer())
+    /// au clic. Dirty propage via MarkSplatRefsDirty.
+    /// \param session Session editeur active (Doc().textureAssets, SplatLayer()).
+    /// \param cache Cache de vignettes (peut etre nul -> grilles d'attente).
+    /// \param openFlag Flag controlant l'ouverture du panneau ; modifie par la
+    ///   case de fermeture ImGui ou par l'item de menu (cf. WorldEditorImGui).
+    void DrawTextureLibrary(WorldEditorSession& session,
+                            TexturePreviewCache* cache,
+                            bool& openFlag);
+
+} // namespace engine::editor
+```
+
+- [ ] **Step 2: Créer l'implémentation (Win32-only)**
+
+```cpp
+// engine/editor/TextureLibraryPanel.cpp
+#include "engine/editor/TextureLibraryPanel.h"
+
+#include "engine/editor/WorldEditorSession.h"
+#include "engine/editor/TexturePreviewCache.h"
+#include "engine/editor/WorldMapEditDocument.h"
+
+#if defined(_WIN32)
+#   include "imgui.h"
+#endif
+
+#include <array>
+#include <cstdio>
+
+namespace engine::editor
+{
+#if defined(_WIN32)
+    namespace
+    {
+        constexpr float kThumbSize = 96.0f;
+        constexpr int   kColumnsPerRow = 5;
+
+        /// Dessine une vignette + label cliquable. Renvoie true si cliquee.
+        /// \param highlighted Si true, encadre la vignette d'un liserer accent.
+        bool DrawThumbButton(ImTextureID id, const char* label, bool highlighted)
+        {
+            const ImVec2 size(kThumbSize, kThumbSize);
+            ImGui::BeginGroup();
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, highlighted ? 3.0f : 0.0f);
+            ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(80, 180, 255, 255));
+            bool clicked = false;
+            if (id != nullptr)
+            {
+                clicked = ImGui::ImageButton(label, id, size);
+            }
+            else
+            {
+                clicked = ImGui::Button(label, ImVec2(kThumbSize, kThumbSize));
+            }
+            ImGui::PopStyleColor();
+            ImGui::PopStyleVar();
+            ImGui::TextWrapped("%s", label);
+            ImGui::EndGroup();
+            return clicked;
+        }
+    } // namespace
+
+    void DrawTextureLibrary(WorldEditorSession& session,
+                            TexturePreviewCache* cache,
+                            bool& openFlag)
+    {
+        if (!openFlag) return;
+        if (!ImGui::Begin("Bibliotheque de textures", &openFlag))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // Header : layer actif (radio sync sur SplatLayer()).
+        static const char* kLayerNames[4] = { "Herbe", "Terre", "Roc", "Neige" };
+        int& activeLayer = session.SplatLayer();
+        activeLayer = std::clamp(activeLayer, 0, 3);
+        ImGui::TextUnformatted("Layer actif :");
+        for (int i = 0; i < 4; ++i)
+        {
+            ImGui::SameLine();
+            if (ImGui::RadioButton(kLayerNames[i], activeLayer == i))
+            {
+                activeLayer = i;
+            }
+        }
+        ImGui::Separator();
+
+        // Section 1 : procedurales builtin.
+        ImGui::TextUnformatted("Procedurales (par defaut moteur)");
+        for (int li = 0; li < 4; ++li)
+        {
+            ImGui::PushID(li);
+            ImTextureID id = (cache != nullptr) ? cache->GetProceduralThumb(static_cast<uint32_t>(li)) : nullptr;
+            const bool highlighted = (li == activeLayer)
+                && session.Doc().splatLayerTextureRefs[static_cast<size_t>(li)].empty();
+            if (DrawThumbButton(id, kLayerNames[li], highlighted))
+            {
+                // Clic sur procedural = reset ref a "" pour le layer actif.
+                session.MutableDoc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)].clear();
+                session.MarkSplatRefsDirty();
+            }
+            ImGui::PopID();
+            if (li < 3) ImGui::SameLine();
+        }
+        ImGui::Separator();
+
+        // Section 2 : importees.
+        const auto& assets = session.Doc().textureAssets;
+        ImGui::Text("Importees (%zu)", assets.size());
+        if (assets.empty())
+        {
+            ImGui::TextDisabled("(aucune) — Importez via 'Import assets'");
+        }
+        else
+        {
+            int col = 0;
+            for (size_t i = 0; i < assets.size(); ++i)
+            {
+                ImGui::PushID(static_cast<int>(i));
+                ImTextureID id = (cache != nullptr) ? cache->GetTexrThumb(assets[i]) : nullptr;
+                // Highlight si cette texture est assignee au layer actif.
+                const bool highlighted = (session.Doc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)] == assets[i]);
+                // Label court : basename
+                std::string baseLabel = assets[i];
+                const size_t slash = baseLabel.find_last_of("/\\");
+                if (slash != std::string::npos) baseLabel = baseLabel.substr(slash + 1);
+                if (DrawThumbButton(id, baseLabel.c_str(), highlighted))
+                {
+                    session.MutableDoc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)] = assets[i];
+                    session.MarkSplatRefsDirty();
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", assets[i].c_str());
+                }
+                ImGui::PopID();
+                if (++col % kColumnsPerRow != 0 && i + 1 < assets.size()) ImGui::SameLine();
+            }
+        }
+
+        ImGui::Separator();
+        ImGui::TextDisabled("Cliquez une vignette pour l'assigner au layer actif (%s).", kLayerNames[activeLayer]);
+        ImGui::End();
+    }
+#else
+    void DrawTextureLibrary(WorldEditorSession&, TexturePreviewCache*, bool&) {}
+#endif
+} // namespace engine::editor
+```
+
+**ATTENTION :** `WorldEditorSession::SplatLayer()` doit retourner `int&` (référence mutable) pour que les radios fonctionnent. Vérifier avec `Grep "int& SplatLayer\|int SplatLayer"` ; sinon ajouter une surcharge ou changer la signature.
+
+- [ ] **Step 3: Ajouter le .cpp à `engine_core` dans CMakeLists.txt**
+
+Dans `CMakeLists.txt`, ajouter à la liste des sources de `engine_core`, après `TexturePreviewCache.cpp` :
+
+```cmake
+  engine/editor/TexturePreviewCache.cpp
+  engine/editor/TextureLibraryPanel.cpp
+```
+
+- [ ] **Step 4: Build**
+
+Run :
+```
+cmake --build build --target engine_core --config Release
+```
+
+Expected : compile OK. Aucun changement visuel — le panneau n'est pas encore appelé.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/editor/TextureLibraryPanel.h engine/editor/TextureLibraryPanel.cpp CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(editor): squelette du panneau Bibliotheque de textures
+
+Fonction libre DrawTextureLibrary(session, cache, openFlag) — affiche les
+4 procedurales builtin + toutes les .texr importees avec assignation au
+layer actif au clic. Highlight de la vignette deja assignee. Pas encore
+ouvert depuis WorldEditorImGui.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Brancher le panneau depuis WorldEditorImGui (menu Affichage)
+
+**Files:**
+- Modify: `engine/editor/WorldEditorImGui.cpp`
+
+- [ ] **Step 1: Ajouter l'item de menu "Affichage > Bibliothèque de textures"**
+
+Dans `engine/editor/WorldEditorImGui.cpp`, chercher la barre de menu existante (`Grep "BeginMainMenuBar\|BeginMenuBar"`) ou si elle n'existe pas, ajouter au début de `BuildUi` un menu "Affichage" :
+
+```cpp
+            if (ImGui::BeginMainMenuBar())
+            {
+                if (ImGui::BeginMenu("Affichage"))
+                {
+                    ImGui::MenuItem("Bibliotheque de textures", nullptr, &m_showTextureLibrary);
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMainMenuBar();
+            }
+```
+
+(Si une barre de menu existe déjà avec un menu "Affichage", ajouter juste l'item dedans.)
+
+- [ ] **Step 2: Appeler `DrawTextureLibrary` quand `m_showTextureLibrary == true`**
+
+Dans `BuildUi`, après les autres `ImGui::Begin/End` (ex: après "Import assets"), ajouter :
+
+```cpp
+            if (m_showTextureLibrary && m_session != nullptr)
+            {
+                engine::editor::DrawTextureLibrary(*m_session, m_texturePreviewCache, m_showTextureLibrary);
+            }
+```
+
+Include : `#include "engine/editor/TextureLibraryPanel.h"` en haut du .cpp.
+
+- [ ] **Step 3: Build et test manuel**
+
+Run :
+```
+cmake --build build --target world_editor_app --config Release
+pkg/world_editor/lcdlln_world_editor.exe
+```
+
+Expected :
+- Barre de menu en haut affiche "Affichage > Bibliotheque de textures" cochable.
+- Cocher → panneau dockable apparaît avec les 4 vignettes procédurales en haut + section "Importées (0)".
+- Importer un PNG via "Import assets" → la vignette apparaît dans "Importées".
+- Cliquer une vignette importée → terrain 3D mis à jour, vignette encadrée d'un liseré bleu.
+- Cliquer une procédurale → terrain revient à la procédurale pour ce layer.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/WorldEditorImGui.cpp
+git commit -m "$(cat <<'EOF'
+feat(editor): menu 'Affichage > Bibliotheque de textures' + panneau live
+
+Toggle via la barre de menu, panneau dockable. Synchronise avec le combo
+'Type de sol' de Peindre (m_session->SplatLayer()). Click vignette =
+assignation au layer actif + dirty splat refs -> reupload GPU live.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Invalider le cache au ré-import d'une texture
+
+**Files:**
+- Modify: `engine/editor/WorldEditorSession.h`
+- Modify: `engine/editor/WorldEditorSession.cpp`
+- Modify: `engine/Engine.cpp`
+
+- [ ] **Step 1: Émettre un signal post-import**
+
+Dans `engine/editor/WorldEditorSession.h`, ajouter une queue de noms de textures réimportées :
+
+```cpp
+        /// Liste des .texr (chemins content-relatifs) reimportees depuis la
+        /// derniere consommation. Engine::Frame() consomme via
+        /// ConsumeRecentlyImportedTextures et appelle TexturePreviewCache::Invalidate.
+        const std::vector<std::string>& RecentlyImportedTextures() const { return m_recentlyImported; }
+        void ClearRecentlyImportedTextures() { m_recentlyImported.clear(); }
+```
+
+Section privée :
+
+```cpp
+        std::vector<std::string> m_recentlyImported;
+```
+
+Dans `WorldEditorSession::ActionImportTexture` (déjà identifiée plus haut, ligne ~602), juste avant `return true;` à la fin (le succès), ajouter :
+
+```cpp
+        m_recentlyImported.push_back(rel);
+        // Si la texture est referencee par un layer, on doit aussi reuploader le splat array.
+        for (const std::string& r : m_doc.splatLayerTextureRefs)
+        {
+            if (r == rel) { m_splatRefsDirty = true; break; }
+        }
+```
+
+- [ ] **Step 2: Consommer côté Engine**
+
+Dans `Engine::Frame()` (juste avant `ProcessSplatRefsDirty`) :
+
+```cpp
+        if (m_worldEditorExe && m_worldEditorSession && m_texturePreviewCache)
+        {
+            for (const std::string& rel : m_worldEditorSession->RecentlyImportedTextures())
+            {
+                m_texturePreviewCache->Invalidate(rel);
+            }
+            m_worldEditorSession->ClearRecentlyImportedTextures();
+        }
+```
+
+- [ ] **Step 3: Build et test manuel**
+
+Run :
+```
+cmake --build build --target world_editor_app --config Release
+pkg/world_editor/lcdlln_world_editor.exe
+```
+
+Test : importer `texture1.png`, l'assigner au layer Terre, modifier `texture1.png` sur disque (changer la couleur), réimporter avec le même nom. Attendu : la vignette ET le terrain 3D se mettent à jour avec la nouvelle version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add engine/editor/WorldEditorSession.h engine/editor/WorldEditorSession.cpp engine/Engine.cpp
+git commit -m "$(cat <<'EOF'
+fix(editor): invalide le cache vignette quand une .texr est reimportee
+
+ActionImportTexture pousse le chemin reimporte dans une file consommee
+chaque frame par Engine -> TexturePreviewCache::Invalidate. Si la texture
+etait deja referencee par un layer, force aussi un reupload du splat
+array pour que la 3D refete la nouvelle version.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Validation manuelle complète + documentation
+
+**Files:**
+- Modify: `docs/world_editor_zone_pipeline.md`
+
+- [ ] **Step 1: Test manuel exhaustif (cf. spec section 5.3)**
+
+Lancer `lcdlln_world_editor.exe` et exécuter le checklist :
+
+1. ☐ Carte vierge → onglet Peindre montre 4 vignettes procédurales (couleurs grass/dirt/rock/snow visibles).
+2. ☐ Menu Affichage > Bibliotheque de textures → panneau s'ouvre, les 4 procédurales apparaissent.
+3. ☐ Importer `test_sand.png` (1024×1024) → apparaît dans Bibliothèque sous "Importées" en <500 ms.
+4. ☐ Sélectionner layer Terre dans Peindre → radio Bibliothèque suit (Terre coché).
+5. ☐ Cliquer la vignette `test_sand` dans la Bibliothèque → terrain 3D affiche le sable sur les zones dirt en <1 frame, vignette encadrée bleu.
+6. ☐ Re-cliquer sur la vignette procédurale "Terre" dans la Bibliothèque → terrain 3D revient à la procédurale dirt.
+7. ☐ Sauvegarder la carte (`File > Save` ou raccourci) → ouvrir `map.lcdlln_edit.json`, vérifier `splat_layer_texture_refs[1] == "textures/test_sand.texr"`.
+8. ☐ Quitter l'éditeur, le relancer, ouvrir la même carte → terrain 3D affiche directement `test_sand` sur Terre sans interaction.
+9. ☐ Modifier `test_sand.png` source (changer la teinte), réimporter avec le même nom → vignette ET terrain 3D se rafraîchissent, pas de crash.
+10. ☐ Importer 5 textures différentes, en assigner à 4 layers → terrain 3D affiche un vrai mix multi-couches.
+
+Si un test échoue, fix avant de continuer.
+
+- [ ] **Step 2: Mettre à jour `docs/world_editor_zone_pipeline.md`**
+
+Ajouter une section à la fin du fichier :
+
+```markdown
+## Apercus de textures et application live
+
+Depuis 2026-05-04, l'editeur affiche des vignettes ImGui pour les
+textures de splatting et applique les .texr importees au terrain en
+direct.
+
+### Resolution interne
+
+Le splat array (`TerrainSplatting::m_albedoArray`) est maintenant en
+**256x256** (constante `kSplatLayerResolution`), promu depuis 64x64. Les
+4 layers builtin (grass/dirt/rock/snow) sont generes par bruit
+deterministe via la fonction libre `GenerateProceduralAlbedoLayer`, et
+les .texr importees sont resamplees en 256x256 (box filter, crop centre
+si non-carre).
+
+### Cache de vignettes
+
+`engine::editor::TexturePreviewCache` (possede par `Engine`) decode et
+uploade les textures sur demande, cree un `VkDescriptorSet` ImGui via
+`ImGui_ImplVulkan_AddTexture`, et gere la destruction differee (pour
+eviter UAF sur descriptors en vol).
+
+Les vignettes sont visibles dans :
+
+- **Onglet Peindre > Textures personnalisees (par couche)** : 48x48 inline a gauche de chaque combo de layer.
+- **Panneau Bibliotheque de textures** (menu Affichage) : grille 96x96, 4 procedurales + toutes les .texr importees.
+
+### Flow d'application live
+
+Quand l'utilisateur change un combo (Peindre) ou clique une vignette
+(Bibliotheque), `WorldEditorSession::splatLayerTextureRefs` est mis a
+jour et `MarkSplatRefsDirty()` appele. A la frame suivante,
+`Engine::ProcessSplatRefsDirty` :
+
+1. Pour chaque layer, recupere le buffer CPU 256x256 via le cache (procedural si ref vide, .texr resamplee sinon ; fallback procedural si .texr introuvable).
+2. Pousse les 4 buffers dans `TerrainSplatting::SetLayerCpuRgba256`.
+3. Appelle `RebuildAlbedoArrayFromCpuLayers` -> staging + barrier + `vkCmdCopyBufferToImage` -> retour `SHADER_READ_ONLY`.
+
+Le cycle complet prend ~3-5 ms hors stalle GPU, executé hors framepath
+hot (uniquement quand un combo change).
+
+### Reimport d'une texture
+
+`WorldEditorSession::ActionImportTexture` ajoute le chemin re-importe
+dans `m_recentlyImported`. `Engine::Frame` consomme la file et appelle
+`TexturePreviewCache::Invalidate`. La destruction du descriptor est
+differee de `kMaxFramesInFlight` frames (cf. `Tick`) pour eviter d'invalider un
+descriptor reference dans une command buffer en vol.
+
+### Limites
+
+- Resolution source max : 4096x4096 (au-dela : refus du decode, vignette grise).
+- Capacite cache : 64 entrees (via le descriptor pool dedie). Au-dela, les vignettes ulterieures ne sont pas allouees (warning log).
+- Pas de mipmaps (pas necessaire au tiling 8m+).
+- Pas de support normal/ORM importe : `m_normalArray` et `m_ormArray` restent placeholders (flat normal + roughness fixe).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/world_editor_zone_pipeline.md
+git commit -m "$(cat <<'EOF'
+docs(world-editor): apercus de textures + application live au terrain
+
+Section "Apercus de textures et application live" qui explique :
+- promotion 64->256 du splat array
+- cache de vignettes (TexturePreviewCache)
+- flow d'application live des .texr aux layers du terrain
+- reimport et invalidation du cache
+- limites (4096 max source, 64 entrees max cache)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+Spec coverage check (sections de la spec ↔ tasks) :
+
+| Spec | Task |
+|---|---|
+| Architecture §1.1 (TexturePreviewCache) | Task 6, 7, 8, 9 |
+| Architecture §1.2 (TerrainSplatting extension 256+rebuild) | Task 2, 5 |
+| Architecture §1.3 (TextureLibraryPanel) | Task 13 |
+| Architecture §1.4 (WorldEditorImGui inline + WorldEditorSession dirty + Engine wiring) | Task 10, 11, 12, 14 |
+| UX §2.1 (vignettes inline Peindre) | Task 12 |
+| UX §2.2 (panneau Bibliotheque) | Task 13 |
+| UX §2.3 (sync layer actif) | Task 13 (radios sur SplatLayer) |
+| UX §2.4 (menu Affichage) | Task 14 |
+| UX §2 Flux import | Task 15 |
+| Data flow §3.1 (procedurale free function) | Task 1 |
+| Data flow §3.2 (resampling box filter) | Task 3 |
+| Data flow §3.3 (cycle vie Vulkan + deferred destruction) | Task 6, 7, 9 |
+| Data flow §3.4 (repack + reupload) | Task 5 |
+| Erreurs §4 | Task 4 (LoadTexrFile robust), 7 (CreateEntry fail), 9 (Invalidate negative cache) |
+| Tests §5.1 (unitaires) | Task 3 (ResampleRgba8Box, GenerateProcedural), Task 4 (LoadTexrRoundTrip) |
+| Tests §5.3 (manuels) | Task 16 |
+| Tests §5.5 (doc CLAUDE.md) | Toutes les tasks (commentaires `///` Doxygen sur fonctions ajoutées) |
+
+Pas de gap.
+
+**Placeholder scan :** RAS — chaque task a du code complet, pas de "TODO", pas de "implement later".
+
+**Type consistency :** vérifié `kSplatLayerResolution`, `kSplatLayerCount`, `MarkSplatRefsDirty`, `ConsumeSplatRefsDirty`, `GetProceduralThumb`, `GetTexrThumb`, `Invalidate`, `Tick`, `SetLayerCpuRgba256`, `RebuildAlbedoArrayFromCpuLayers` — noms cohérents entre toutes les tasks.
+
+**Caveats à valider au moment de l'exécution :**
+- `WorldEditorSession::SplatLayer()` doit renvoyer `int&` (mutable) pour que les radios du panneau Bibliothèque marchent. Si c'est `int` (valeur), Task 13 nécessitera un setter explicite (à ajouter dans Task 10 si besoin).
+- L'instance `TerrainSplatting` côté Engine est probablement à l'intérieur de `TerrainRenderer` (cf. `TerrainRenderer::GetSplatting()`). Task 11 devra utiliser `m_terrainRenderer.GetSplatting()` au lieu de `m_terrainSplatting` direct.
+- `STB_IMAGE_IMPLEMENTATION` peut déjà être défini ailleurs dans le repo : Task 4 step 2 demande de vérifier avec `Grep` avant d'ajouter le define.

--- a/docs/superpowers/specs/2026-05-04-editor-texture-previews-design.md
+++ b/docs/superpowers/specs/2026-05-04-editor-texture-previews-design.md
@@ -1,0 +1,411 @@
+# Aperçus de textures dans l'éditeur monde — design
+
+Date : 2026-05-04
+Auteur : Hubert Cornet (avec assistance Claude)
+Branche cible : `claude/editor-terrain-textures-skybox`
+
+## Contexte
+
+L'éditeur monde (`lcdlln_world_editor.exe`) gère le splatting du terrain via 4 layers
+(grass / dirt / rock / snow) packés dans un texture array Vulkan. Les 4 textures
+par défaut sont des bruits procéduraux 64×64 générés au boot dans
+`TerrainSplatting::Init` (commit `b93a14d`).
+
+L'éditeur permet déjà :
+
+- d'importer un PNG/JPG/TGA/BMP via le panneau « Import assets » (conversion en
+  `.texr` magic TEXR + RGBA8 + write `<content>/textures/<nom>.texr`),
+- de mapper une `.texr` à chacun des 4 layers via `splatLayerTextureRefs[4]`
+  (persisté en JSON, clé `splat_layer_texture_refs`).
+
+Deux manques limitent l'UX :
+
+1. **Aucun aperçu visuel.** Les textures importées sont listées en `BulletText`
+   (juste leur nom). Le mapper ne sait pas à quoi ressemble `wet_sand.texr` sans
+   ouvrir le fichier hors de l'éditeur.
+2. **Le mapping n'est pas appliqué au rendu.** `splatLayerTextureRefs` est
+   sauvegardé mais jamais relu au runtime. Le terrain 3D affiche toujours les
+   procédurales par défaut, indépendamment de ce qui est mappé.
+
+## Objectif
+
+Combler les deux manques :
+
+1. **Vignettes ImGui** dans l'éditeur pour visualiser les 4 procédurales et
+   toutes les `.texr` importées.
+2. **Application au rendu** : quand un layer est mappé à une texture importée,
+   le terrain 3D doit afficher cette texture dans la viewport sans relancer
+   l'éditeur.
+
+Hors scope :
+
+- Normalmaps / ORM importés (les arrays `m_normalArray` / `m_ormArray` restent
+  des placeholders, comme aujourd'hui).
+- Édition de la splat map elle-même (déjà en place via `TerrainEditingTools`).
+- Mipmaps / sRGB awareness avancé (le format `R8G8B8A8_SRGB` du sampler
+  existant suffit).
+
+## Architecture
+
+Quatre composants, frontières claires.
+
+### `engine::editor::TexturePreviewCache` (nouveau)
+
+Fichiers : `engine/editor/TexturePreviewCache.{h,cpp}`.
+
+Responsabilité unique : transformer un identifiant de texture (procédurale
+builtin ou chemin `.texr` content-relatif) en `ImTextureID` ImGui-affichable, et
+gérer le cycle de vie Vulkan associé.
+
+API publique :
+
+```cpp
+class TexturePreviewCache {
+public:
+    bool Init(VkDevice, VkPhysicalDevice, VkQueue, uint32_t queueFamily);
+    void Shutdown();
+
+    /// 4 procédurales builtin. RGBA8 256×256 généré à la 1re demande.
+    ImTextureID GetProceduralThumb(uint32_t layer);  // 0=grass,1=dirt,2=rock,3=snow
+
+    /// .texr content-relatif (ex: "textures/sand.texr"). Décodé+uploadé à la 1re demande.
+    /// Retourne nullptr si fichier introuvable/invalide.
+    ImTextureID GetTexrThumb(const std::string& contentRelPath);
+
+    /// Une .texr a été réimportée (overwrite sur disque) → invalider l'entrée.
+    void Invalidate(const std::string& contentRelPath);
+
+    /// Buffer CPU RGBA8 256×256 d'une entrée cachée. Utilisé par
+    /// TerrainSplatting::SetLayerCpuRgba256 lors du rebuild de l'albedo array.
+    /// La clé est soit un chemin .texr ("textures/sand.texr") soit
+    /// "procedural:0..3".
+    const std::vector<uint8_t>* GetCpuRgba256(const std::string& key) const;
+
+    /// À appeler chaque frame en main thread (purge des entrées en deferred-delete).
+    void Tick(uint64_t currentFrameIndex, uint32_t framesInFlight);
+};
+```
+
+Possédé par `Engine`. Pointeur non-owning passé à `WorldEditorImGui` et au
+panneau Bibliothèque.
+
+### `engine::render::terrain::TerrainSplatting` (extension)
+
+Promotion de la résolution interne `kSplatLayerResolution = 256` (constante
+remplaçant le 64 hardcodé). Génération procédurale au boot adaptée. Ajout de
+deux méthodes :
+
+```cpp
+/// Stocke le buffer CPU RGBA8 256×256 d'un layer (resample déjà fait par le cache).
+void SetLayerCpuRgba256(uint32_t layer, const std::vector<uint8_t>& rgba);
+
+/// Repack les 4 layers CPU en un buffer (4×256×256×4 = 1 MiB) et re-upload via staging.
+/// Pattern identique à ReuploadSplatMap (transition layout → copy → retour SHADER_READ_ONLY).
+bool RebuildAlbedoArrayFromCpuLayers(VkDevice, VkPhysicalDevice,
+                                     VkQueue, uint32_t queueFamily);
+```
+
+La lambda interne `GenerateProceduralLayer` devient une **fonction libre
+exportée** dans `TerrainSplatting.h` :
+
+```cpp
+/// Génère un layer RGBA8 procédural (bruit déterministe par layer).
+/// \param resolution Côté en pixels (carré). Min 4.
+/// \param layer 0=grass, 1=dirt, 2=rock, 3=snow.
+/// \param outRgba Sortie : resolution * resolution * 4 octets.
+void GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
+                                   std::vector<uint8_t>& outRgba);
+```
+
+Bénéfice : un seul algo, utilisé par le boot (terrain) et par le cache
+(vignettes), même octets bit-pour-bit.
+
+### `engine::editor::TextureLibraryPanel` (nouveau)
+
+Fichiers : `engine/editor/TextureLibraryPanel.{h,cpp}`.
+
+Une fonction libre :
+
+```cpp
+void DrawTextureLibrary(WorldEditorSession& session,
+                       TexturePreviewCache& cache,
+                       bool& openFlag);
+```
+
+Ouvre son propre `ImGui::Begin("Bibliothèque de textures", &openFlag)`.
+Décorrélée de `WorldEditorImGui` pour éviter de gonfler ce fichier déjà gros
+(~1500 lignes).
+
+### Modifications minimales
+
+- **`WorldEditorImGui::BuildUi`** : vignettes inline 48×48 dans l'onglet
+  « Peindre » (cf. UX 1) + appel à `DrawTextureLibrary` quand `m_showTextureLibrary == true`.
+  Toggle via le menu « Affichage > Bibliothèque de textures ».
+- **`WorldEditorSession`** : flag interne `m_splatRefsDirty`, exposé via
+  `bool ConsumeSplatRefsDirty()`. Activé par les UIs (Peindre + Bibliothèque)
+  quand `splatLayerTextureRefs` change.
+- **`Engine`** : possède `TexturePreviewCache`, observe
+  `ConsumeSplatRefsDirty()` chaque frame, pousse les buffers CPU au splatting
+  et déclenche `RebuildAlbedoArrayFromCpuLayers`.
+
+## UX
+
+### Onglet « Peindre » (étendu)
+
+Sous `CollapsingHeader("Textures personnalisées (par couche)")` (existant) :
+pour chaque layer, une vignette 48×48 à gauche du combo.
+
+```
+[vignette 48×48] [Combo "Herbe" ▼ : (par défaut moteur) | sand.texr | grass_v2.texr | ...]
+[vignette 48×48] [Combo "Terre" ▼ : ...]
+[vignette 48×48] [Combo "Roc"   ▼ : ...]
+[vignette 48×48] [Combo "Neige" ▼ : ...]
+```
+
+Combo « (par défaut moteur) » → vignette de la procédurale du layer. Sinon →
+vignette de la `.texr` choisie. Vignette grise si chargement échoué.
+
+### Panneau « Bibliothèque de textures » (nouveau)
+
+Dockable, ouvrable via menu « Affichage > Bibliothèque de textures ».
+
+```
+┌─ Bibliothèque de textures ────────────────────────┐
+│ Layer actif : ● Herbe   ○ Terre   ○ Roc   ○ Neige │  ← reflète SplatLayer()
+│ ─────────────────────────────────────────────────  │
+│ Procédurales (par défaut moteur)                   │
+│  [grass]  [dirt]  [rock]  [snow]                   │  ← 96×96 vignettes
+│                                                    │
+│ Importées (5)                                      │
+│  [sand]  [grass_v2]  [...]                         │
+│                                                    │
+│ ─────────────────────────────────────────────────  │
+│ ℹ Cliquez une vignette pour l'assigner au layer    │
+│   actif (Peindre : Herbe).                         │
+└────────────────────────────────────────────────────┘
+```
+
+- Vignettes 96×96, label en dessous (nom court). Hover → tooltip avec chemin
+  complet + dimensions originales (avant resample 256×256).
+- **Clic gauche** → `splatLayerTextureRefs[SplatLayer()] = path` (ou `""` pour
+  procédurales). Dirty flags activés → re-upload GPU à la frame suivante.
+- **Bordure colorée** sur la vignette actuellement assignée au layer actif
+  (liseré accent ImGui).
+- **Section « Procédurales »** : 4 vignettes fixes. Clic = remet `""` dans la
+  ref → revient au défaut moteur pour ce layer.
+- **Section « Importées »** : peuplée depuis `Doc().textureAssets`. Vide =
+  ligne d'aide « Importez via le panneau Import assets ».
+
+### Synchronisation du « layer actif »
+
+Les radios dans la Bibliothèque et le combo « Type de sol » dans Peindre
+manipulent la même variable (`m_session->SplatLayer()`). Modifier l'un met
+l'autre à jour automatiquement à la frame suivante.
+
+### Flux d'import (récap)
+
+1. User clique « Importer cette texture » dans Import assets (existant) →
+   `.texr` écrite, entrée ajoutée à `Doc().textureAssets`.
+2. Frame suivante : panneau Bibliothèque affiche la nouvelle vignette
+   (cache miss → décodage + upload Vulkan + `ImGui_ImplVulkan_AddTexture`).
+3. **Pas d'auto-assignation** : la texture apparaît dans la Bibliothèque mais
+   le terrain 3D ne change pas tant qu'on ne clique pas dessus.
+4. Clic sur la vignette → `splatLayerTextureRefs[active] = "textures/<nom>.texr"`,
+   dirty flags. Frame suivante : Engine détecte le dirty, rebuild l'albedo
+   array, terrain 3D mis à jour.
+
+Réimport du même nom (overwrite) :
+`ActionImportTexture` appelle `cache.Invalidate(rel)` à la fin (succès, fichier
+déjà connu). Si la texture est référencée dans `splatLayerTextureRefs`, force
+aussi `m_splatRefsDirty = true` → la 3D se rafraîchit.
+
+## Data flow et détails techniques
+
+### Resampling des `.texr` importés
+
+Source : RGBA8 arbitraire. Cible : 256×256 carré.
+
+Algorithme : **box filter séparable** (passe horizontale + verticale, ~3 ms
+sur 1024×1024 → 256×256 en CPU). Pas de mipmaps. sRGB conservé via le format
+`VK_FORMAT_R8G8B8A8_SRGB` du sampler existant.
+
+Si ratio non-carré (ex: 1920×1080) : **crop centre vers carré** d'abord,
+LOG_INFO une fois, puis box filter. Alternative letterboxing rejetée (donnerait
+des bandes noires en 3D).
+
+Code dans `TexturePreviewCache.cpp`, fonction libre privée
+`ResampleRgba8Box(src, srcW, srcH, dst, dstW, dstH)`. Testable unitairement.
+
+### Cycle de vie Vulkan d'une vignette
+
+Une `GpuPreview` interne au cache contient :
+
+```cpp
+struct GpuPreview {
+    std::vector<uint8_t> cpuRgba256;  // 256*256*4 = 256 KB
+    VkImage              image;
+    VkImageView          view;
+    VkDeviceMemory       memory;
+    VkSampler            sampler;     // partagé statiquement
+    VkDescriptorSet      imguiDS;     // ImGui_ImplVulkan_AddTexture
+};
+```
+
+Création : à la première demande. Submit + `vkQueueWaitIdle` sur la queue de
+transfert (one-shot, pattern existant `TerrainSplatting::UploadSplatMap`).
+Coût ~2-5 ms par texture.
+
+Destruction (Invalidate / Shutdown) : **différée** pour éviter UAF sur
+descriptor référencé en command buffer en vol.
+
+```cpp
+m_pendingDeletes.push_back({preview, currentFrameIndex});
+// Tick(currentFrame, framesInFlight) :
+//   purger entrées dont frameIndex + framesInFlight <= currentFrame
+```
+
+Sampler partagé : un seul `VkSampler` linear/clamp pour tout le cache (Init →
+Shutdown).
+
+Descriptor pool ImGui : `ImGui_ImplVulkan_AddTexture` alloue depuis le pool
+ImGui interne. Vérifier que `m_descriptorPool` (`WorldEditorImGui.h:138`) a
+`maxSets >= ~64` ; bumper si besoin.
+
+### Repack et re-upload de l'albedo array
+
+Quand `m_splatRefsDirty == true` côté Engine :
+
+1. Allouer staging `4 × 256 × 256 × 4 = 1 MiB`.
+2. Pour chaque layer 0..3 : copier 256 KB depuis le buffer CPU correspondant
+   (procédural si ref vide, texr resamplée sinon, via
+   `cache.GetCpuRgba256(...)`).
+3. Transition `m_albedoArray.image` `SHADER_READ_ONLY` → `TRANSFER_DST`,
+   `vkCmdCopyBufferToImage` avec 4 régions (une par layer), retour
+   `SHADER_READ_ONLY`.
+4. Submit + `vkQueueWaitIdle` (pattern `ReuploadSplatMap`).
+5. Nettoyage staging.
+
+Coût ~2-4 ms hors stalle GPU. Acceptable parce que rare (changement de combo
+utilisateur, pas par frame).
+
+## Gestion d'erreurs et cas limites
+
+### Échecs au démarrage
+
+| Scénario | Comportement |
+|---|---|
+| `TexturePreviewCache::Init` échoue | LOG_WARN, `m_ready = false`. `Get*Thumb` retournent `nullptr`. UI : combos texte sans vignette (UX dégradée). |
+| `TerrainSplatting::Init` à 256×256 échoue | Retour `false`, comportement existant inchangé (terrain absent, géré par l'éditeur). |
+| `external/stb/stb_image.h` introuvable au build | Erreur compilation explicite (CMake), bloquant — pas runtime. |
+
+### Échecs runtime sur une `.texr`
+
+| Scénario | Comportement |
+|---|---|
+| Fichier introuvable au `GetTexrThumb` | Retourne `nullptr`, vignette grise. **Pas de cache négatif** → retentée si fichier réapparaît. |
+| `.texr` corrompu (magic incorrect, taille mismatch) | LOG_ERROR une seule fois, vignette grise, **cache négatif** (`std::optional` à `nullopt`) pour éviter retry chaque frame. Effacé par `Invalidate`. |
+| Texr référencée dans `splatLayerTextureRefs` mais introuvable | Re-upload GPU utilise la procédurale du layer comme fallback. Status UI : warning « Texture *X* introuvable, layer rempli avec défaut moteur ». |
+| Source `.texr` >4096×4096 | Refus du décodage (cap), vignette grise, log explicit. Sources entre 256 et 4096 acceptées. |
+
+### Ratio non-carré
+
+Crop centre vers carré, LOG_INFO une fois par texture. Pas de letterboxing.
+
+### Imports concurrents / multi-mappage
+
+| Scénario | Comportement |
+|---|---|
+| Même `.texr` mappée à 2 layers | Cache hit unique, buffer CPU partagé. Repack copie 2 fois le même buffer, pas de doublon mémoire. |
+| Réimport pendant qu'une vignette est dessinée | `Invalidate` push l'ancienne entrée dans `m_pendingDeletes`. Frame courante : `ImGui::Image` dessine toujours l'ancien descriptor (valide). Frame N+`framesInFlight` : ancien détruit, nouveau créé à la 1re demande. |
+| Crash entre import et upload vignette (GPU OOM) | LOG_ERROR, `Invalidate` automatique, vignette grise. `.texr` reste sur disque. |
+
+### Layer fallback dans le rebuild GPU
+
+```
+ref = splatLayerTextureRefs[layer]
+si ref.empty():
+    rgba = cache.GetCpuRgba256("procedural:" + layer)   // toujours dispo
+sinon:
+    rgba = cache.GetCpuRgba256(ref)
+    si rgba == nullptr:                                  // fichier disparu/corrompu
+        rgba = cache.GetCpuRgba256("procedural:" + layer)  // fallback
+        statusBar = "Texture <ref> introuvable - layer reverti au défaut"
+```
+
+Le re-upload ne peut jamais échouer faute de données. Au pire, 4 procédurales
+et un message d'erreur visible.
+
+### Compatibilité cartes existantes
+
+`splat_layer_texture_refs` déjà en JSON. Cartes anciennes (clé absente) :
+tableau vide → procédurales (comportement actuel). Cartes avec mapping :
+au load, l'éditeur applique les refs → re-upload initial → terrain affiche
+directement les bonnes textures. **Pas de migration nécessaire.**
+
+### Mode `--editor` léger (sans `--world-editor`)
+
+Vignettes inline et panneau Bibliothèque sont gardés derrière
+`m_worldEditorExe == true`. Editor Hub léger (mode `--editor` seul) n'a pas
+accès → pas de régression sur ce mode.
+
+## Tests
+
+### Unitaires (sans Vulkan)
+
+Fichier : `engine/editor/tests/TexturePreviewCache_test.cpp` (Catch2).
+
+| Test | Objectif |
+|---|---|
+| `ResampleRgba8Box_DownsampleSquare` | 256×256 rouge → 64×64 rouge uniforme. |
+| `ResampleRgba8Box_UpsampleNearest` | 4×4 → 16×16 préserve la moyenne par cellule. |
+| `ResampleRgba8Box_NonSquareCropsCenter` | 1024×512 → 256×256 = crop carré central, pas de stretch. |
+| `GenerateProceduralAlbedoLayer_DeterministeParLayer` | Mêmes params → mêmes octets exacts. Layers différents → buffers différents. |
+| `GenerateProceduralAlbedoLayer_Resolution64Et256` | Pattern visuel cohérent entre résolutions (test approximatif via histogramme). |
+
+### Intégration (avec Vulkan, smoke CI Windows)
+
+| Test | Objectif |
+|---|---|
+| `TexturePreviewCache_InitShutdown` | Création + destruction propre, validation layers Vulkan sans erreurs. |
+| `TerrainSplatting_RebuildAlbedoArray256` | Init en 256×256, set CPU layer 0 = rouge, rebuild, readback GPU → confirme rouge. |
+
+### Manuels (UX)
+
+À documenter dans `docs/world_editor_zone_pipeline.md` (section « Validation
+textures ») :
+
+1. Lancer `lcdlln_world_editor.exe` sur carte vierge → Peindre montre 4
+   vignettes procédurales.
+2. Importer `test_sand.png` (1024×1024) → apparaît dans Bibliothèque sous
+   « Importées » en <500 ms.
+3. Cliquer la vignette `test_sand` avec layer Terre actif → terrain 3D mis à
+   jour en <1 frame visible, vignette assignée encadrée.
+4. Sauvegarder → `splat_layer_texture_refs[1] == "textures/test_sand.texr"`
+   dans le JSON.
+5. Recharger la carte → terrain 3D affiche directement `test_sand` sur Terre
+   sans interaction.
+6. Réimporter `test_sand.png` (overwrite) → vignette ET 3D rafraîchies, pas de
+   crash, pas de fuite descriptor.
+
+### Perf
+
+| Scénario | Cible |
+|---|---|
+| Frame moyenne avec Bibliothèque ouverte (10 vignettes) | ≤ +0.2 ms vs Bibliothèque fermée |
+| Click vignette → terrain 3D updated | ≤ 1 frame visible (rebuild + upload <16 ms) |
+| VRAM additionnelle pour 10 textures cachées | ≤ ~3 MB |
+
+### Documentation (règle CLAUDE.md éditeur)
+
+Toutes les fonctions publiques de `TexturePreviewCache`, `TextureLibraryPanel`,
+les 2 nouvelles méthodes de `TerrainSplatting`, et les modifs des structures
+Engine/WorldEditorImGui auront un commentaire `///` Doxygen au-dessus de la
+déclaration : rôle (1-2 phrases), paramètres non-évidents, effets de bord,
+contraintes thread/timing.
+
+## Déploiement
+
+Cette PR est **purement client/éditeur** : aucun changement protocole,
+aucun nouveau handler serveur, aucune migration DB.
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/docs/world_editor_zone_pipeline.md
+++ b/docs/world_editor_zone_pipeline.md
@@ -216,3 +216,117 @@ Modifier ce fichier lorsque le format `zone.meta`, le manifest runtime, ou le co
 La suite chronologique **002 → 007** (spécifications de travail, DoD, chaînage) vit sous **`tickets/world/`** — voir **`tickets/world/README.md`**.
 
 **Zone démo & onboarding** : checklist pas à pas **[`docs/world_zone_demo_checklist.md`](world_zone_demo_checklist.md)** (`zone_id` **`demo_plains`**), incluant le **§5 (ticket 012)** — validation client terrain (SLAP/GRMS) + rappels streaming / `zone_builder` ; liens build dans le **README** racine.
+
+---
+
+## 9. Aperçus de textures et application live (mai 2026)
+
+Depuis le commit `a71d7d6` (branche `claude/editor-terrain-textures-skybox`),
+l'éditeur affiche des vignettes ImGui pour les textures de splatting et
+applique les `.texr` importées au terrain en direct.
+
+### 9.1 Résolution interne du splat array
+
+Le `m_albedoArray` de `TerrainSplatting` est passé de **64×64** à **256×256**
+via la constante `kSplatLayerResolution = 256` (déclarée dans `engine/render/terrain/TerrainSplatting.h`).
+Les 4 layers builtin (grass / dirt / rock / snow) sont générés par bruit
+déterministe via la fonction libre `engine::render::terrain::GenerateProceduralAlbedoLayer`.
+Les `.texr` importées sont resamplées en 256×256 via box filter (crop centre
+si non-carré) avant upload GPU.
+
+### 9.2 Cache de vignettes — `engine::editor::TexturePreviewCache`
+
+Possédé par `Engine`, vit le temps du device Vulkan. Pour chaque texture
+demandée :
+
+1. **Decode** : `LoadTexrFile` parse le header TEXR ou fallback `stb_image`
+   (PNG / JPG / TGA / BMP). Cap à 4096×4096 max source.
+2. **Resample** : `ResampleRgba8Box` réduit à 256×256 RGBA8.
+3. **Upload GPU** : `VkImage` 256×256 RGBA8_SRGB DEVICE_LOCAL OPTIMAL,
+   staging + barrier `UNDEFINED → TRANSFER_DST → SHADER_READ_ONLY`,
+   `VkImageView` 2D, descriptor `ImGui_ImplVulkan_AddTexture`.
+4. **Cache** : `unordered_map<string, GpuPreview>` keyed par
+   `procedural:N` (builtins) ou `textures/<rel>` (importées).
+
+Cache négatif (`m_negativeCache`) : un fichier corrompu n'est pas re-décodé
+avant `Invalidate` explicite (évite spam logs).
+
+Destruction différée (`m_pendingDeletes` + `Tick(currentFrame, framesInFlight)`) :
+les descriptors invalidés ne sont libérés qu'après `framesInFlight = 2` frames,
+pour éviter UAF sur descriptor référencé en command buffer en vol.
+
+### 9.3 Vignettes dans l'UI éditeur
+
+Deux entrées :
+
+- **Onglet Peindre > Textures personnalisées (par couche)** : vignette 48×48
+  inline à gauche du combo de chaque layer. Default moteur = procédurale ;
+  sélection `.texr` = vignette de la texture importée.
+- **Panneau Bibliothèque de textures** (menu Vue > Bibliothèque de textures) :
+  grille 96×96. Section "Procédurales" (4 vignettes builtin fixes) + section
+  "Importées (N)" peuplée depuis `Doc().textureAssets`. Layer actif piloté
+  par radios synchronisés sur `WorldEditorSession::SplatLayer()` (donc
+  équivalent au combo "Type de sol" de Peindre). Clic sur une vignette =
+  assignation au layer actif. La vignette assignée est encadrée d'un liseret
+  bleu accent.
+
+### 9.4 Flux d'application live au terrain 3D
+
+Quand l'utilisateur change une référence de layer (combo Peindre ou clic
+Bibliothèque) :
+
+1. `WorldEditorSession::splatLayerTextureRefs[layer]` est mis à jour et
+   `MarkSplatRefsDirty()` est appelé.
+2. À la frame suivante, `Engine::ProcessSplatRefsDirty` consomme le flag :
+   - Pour chaque layer, récupère le buffer CPU 256×256 via le cache
+     (procédurale si ref vide, `.texr` resamplée sinon ; fallback procédurale
+     si `.texr` introuvable).
+   - Pousse les 4 buffers dans `TerrainSplatting::SetLayerCpuRgba256`.
+   - Appelle `RebuildAlbedoArrayFromCpuLayers` → staging + barrier
+     `SHADER_READ_ONLY → TRANSFER_DST` → 4 `vkCmdCopyBufferToImage` (un par
+     layer) → barrier retour `SHADER_READ_ONLY`.
+
+Le cycle complet prend ~3-5 ms hors stalle GPU, exécuté hors hot frame path
+(uniquement quand un combo change).
+
+### 9.5 Réimport d'une texture
+
+`WorldEditorSession::ActionImportTexture` ajoute le chemin réimporté dans
+`m_recentlyImported`. `Engine::Update` consomme la file chaque frame et
+appelle `TexturePreviewCache::Invalidate` sur chaque entrée. Si la texture
+était référencée par un layer, `m_splatRefsDirty` est aussi mis pour
+forcer un rebuild GPU. La destruction du descriptor est différée de
+`framesInFlight` frames.
+
+### 9.6 Validation manuelle (à faire après CI build)
+
+Une fois le build CI Windows passé, valider sur ta machine :
+
+1. Lancer `lcdlln_world_editor.exe` sur une carte vierge → onglet Peindre
+   montre 4 vignettes procédurales (grass / dirt / rock / snow).
+2. Menu Vue > Bibliothèque de textures → panneau dockable apparaît avec les
+   4 procédurales builtin.
+3. Importer un PNG (panneau Import assets) → la vignette apparaît dans
+   "Importées" en <500 ms.
+4. Sélectionner layer Terre dans Peindre → radios Bibliothèque suivent.
+5. Cliquer la vignette du PNG dans la Bibliothèque → terrain 3D mis à jour
+   en <1 frame, vignette encadrée bleu.
+6. Cliquer la vignette procédurale "Terre" → terrain 3D revient à la
+   procédurale.
+7. Sauvegarder la carte → vérifier `splat_layer_texture_refs[1]` dans le
+   JSON.
+8. Quitter et relancer → terrain 3D affiche directement le PNG sur Terre.
+9. Réimporter le même PNG (overwrite) → vignette + terrain 3D refresh, pas
+   de crash, pas de fuite descriptor (vérifier via RenderDoc/PIX si suspicion).
+
+### 9.7 Limites
+
+- Résolution source max : **4096×4096** (au-delà : refus du décodage,
+  vignette grise, log explicit).
+- Capacité cache : descriptors ImGui internes (~64+ entrées). Au-delà,
+  les vignettes ultérieures peuvent échouer (LOG_ERROR).
+- Pas de mipmaps (pas nécessaire au tiling 8 m+).
+- Pas de support normalmaps / ORM importés : `m_normalArray` et `m_ormArray`
+  restent placeholders (flat normal + roughness fixe). Cf. spec
+  `docs/superpowers/specs/2026-05-04-editor-texture-previews-design.md` §
+  "Hors scope".

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1407,7 +1407,15 @@ namespace engine
 											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
 												VkImage img = reg.getImage(m_fgSceneColorId);
 												if (img == VK_NULL_HANDLE) return;
-												VkClearColorValue clearColor = { { 0.15f, 0.15f, 0.18f, 1.0f } };
+												// C3 simplifie : clear color = couleur horizon ciel calculee par
+												// DayNightCycle (au lieu d'un gris constant 0.15/0.15/0.18). Donne
+												// un ciel dynamique qui change de couleur selon l'heure (bleu jour,
+												// orange dawn/dusk, sombre nuit) sans avoir besoin d'une SkyboxPass
+												// Vulkan complete. A remplacer par un vrai sky shader plus tard.
+												const engine::render::DayNightCycle::State& dn = m_dayNight.GetState();
+												VkClearColorValue clearColor = {
+													{ dn.skyHorizon[0], dn.skyHorizon[1], dn.skyHorizon[2], 1.0f }
+												};
 												VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
 												vkCmdClearColorImage(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &range);
 											});

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2819,6 +2819,10 @@ namespace engine
 						LOG_WARN(Render, "[Engine] TexturePreviewCache init failed -- vignettes editeur indisponibles");
 						m_texturePreviewCache.reset();
 					}
+					if (m_worldEditorImGui && m_texturePreviewCache)
+					{
+						m_worldEditorImGui->SetTexturePreviewCache(m_texturePreviewCache.get());
+					}
 				}
 				// Branche le DayNightCycle au panneau "Atmosphere" pour que l'utilisateur
 				// puisse regler time-of-day et timeScale en live depuis l'editeur monde.

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2848,6 +2848,14 @@ namespace engine
 		{
 			RebuildWorldEditorTerrainGpu();
 		}
+		if (m_worldEditorExe && m_worldEditorSession && m_texturePreviewCache)
+		{
+			for (const std::string& rel : m_worldEditorSession->RecentlyImportedTextures())
+			{
+				m_texturePreviewCache->Invalidate(rel);
+			}
+			m_worldEditorSession->ClearRecentlyImportedTextures();
+		}
 		ProcessSplatRefsDirty();
 		if (m_texturePreviewCache)
 		{

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1415,7 +1415,19 @@ namespace engine
 												// un ciel dynamique qui change de couleur selon l'heure (bleu jour,
 												// orange dawn/dusk, sombre nuit) sans avoir besoin d'une SkyboxPass
 												// Vulkan complete. A remplacer par un vrai sky shader plus tard.
+												// Log periodique pour verifier que la valeur change quand l'utilisateur
+												// modifie le slider Heure dans le panneau Atmosphere.
 												const engine::render::DayNightCycle::State& dn = m_dayNight.GetState();
+												static float s_lastLoggedTime = -999.f;
+												if (std::fabs(dn.timeOfDay - s_lastLoggedTime) > 0.05f)
+												{
+													s_lastLoggedTime = dn.timeOfDay;
+													LOG_INFO(Render, "[Atmosphere] clear color update: time={:.2f}h skyHorizon=({:.2f},{:.2f},{:.2f}) lightColor=({:.2f},{:.2f},{:.2f}) isDay={}",
+														dn.timeOfDay,
+														dn.skyHorizon[0], dn.skyHorizon[1], dn.skyHorizon[2],
+														dn.lightColor[0], dn.lightColor[1], dn.lightColor[2],
+														dn.isDaytime ? 1 : 0);
+												}
 												VkClearColorValue clearColor = {
 													{ dn.skyHorizon[0], dn.skyHorizon[1], dn.skyHorizon[2], 1.0f }
 												};

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -4854,10 +4854,10 @@ namespace engine
 
 			engine::render::Camera reset;
 			reset.position.x = centerX;
-			reset.position.y = midGroundY + 50.0f;       // 50m au-dessus du sol moyen
-			reset.position.z = centerZ + ws * 0.25f;     // recule a 25% du world size
+			reset.position.y = midGroundY + 5.0f;        // 5m au-dessus du sol moyen
+			reset.position.z = centerZ + 20.0f;          // 20m derriere -> avatar visible ~6% ecran
 			reset.yaw = 0.0f;
-			reset.pitch = 0.5f;                          // vue plongeante ~28deg
+			reset.pitch = 0.1f;                          // pitch leger ~6deg
 			reset.fovYDeg = 70.0f;
 			reset.aspect = static_cast<float>(std::max(1, m_width)) / static_cast<float>(std::max(1, m_height));
 			reset.nearZ = 0.1f;

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2588,6 +2588,8 @@ namespace engine
 		{
 			vkDeviceWaitIdle(m_vkDeviceContext.GetDevice());
 #if defined(_WIN32)
+			if (m_texturePreviewCache) m_texturePreviewCache->Shutdown();
+			m_texturePreviewCache.reset();
 			if (m_worldEditorImGui)
 			{
 				m_worldEditorImGui->DetachPlatformWindow(m_window);
@@ -2803,6 +2805,20 @@ namespace engine
 				if (m_worldEditorExe)
 				{
 					m_worldEditorImGui->SetEditorContext(m_worldEditorSession.get(), &m_cfg);
+
+					// Cache de vignettes pour les textures de splatting.
+					m_texturePreviewCache = std::make_unique<engine::editor::TexturePreviewCache>();
+					const std::string contentDir = m_cfg.GetString("paths.content", "game/data");
+					const std::filesystem::path absContent = std::filesystem::absolute(contentDir);
+					if (!m_texturePreviewCache->Init(m_vkDeviceContext.GetDevice(),
+					                                 m_vkDeviceContext.GetPhysicalDevice(),
+					                                 m_vkDeviceContext.GetGraphicsQueue(),
+					                                 m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
+					                                 absContent.string()))
+					{
+						LOG_WARN(Render, "[Engine] TexturePreviewCache init failed -- vignettes editeur indisponibles");
+						m_texturePreviewCache.reset();
+					}
 				}
 				// Branche le DayNightCycle au panneau "Atmosphere" pour que l'utilisateur
 				// puisse regler time-of-day et timeScale en live depuis l'editeur monde.
@@ -2827,6 +2843,12 @@ namespace engine
 		if (m_worldEditorExe && m_worldEditorSession && m_worldEditorSession->ConsumeTerrainGpuReloadRequest())
 		{
 			RebuildWorldEditorTerrainGpu();
+		}
+		ProcessSplatRefsDirty();
+		if (m_texturePreviewCache)
+		{
+			m_texturePreviewCache->Tick(static_cast<uint64_t>(m_currentFrame),
+			                             kEditorTexCacheFramesInFlight);
 		}
 #endif
 
@@ -4888,6 +4910,49 @@ namespace engine
 			m_renderStates[1].camera = reset;
 			LOG_INFO(Render, "[WorldEditor] Camera repositioned above terrain center=({:.1f},{:.1f}) groundY={:.1f} cameraY={:.1f}",
 				centerX, centerZ, midGroundY, reset.position.y);
+		}
+	}
+
+	void Engine::ProcessSplatRefsDirty()
+	{
+		if (!m_worldEditorExe || !m_worldEditorSession) return;
+		if (!m_texturePreviewCache || !m_texturePreviewCache->IsReady()) return;
+		if (!m_worldEditorSession->ConsumeSplatRefsDirty()) return;
+		if (!m_terrain.IsValid()) return;
+
+		engine::render::terrain::TerrainSplatting& splatting = m_terrain.GetSplatting();
+
+		// Pour chaque layer : pousser le buffer CPU adequat dans TerrainSplatting.
+		const auto& refs = m_worldEditorSession->Doc().splatLayerTextureRefs;
+		for (uint32_t layer = 0; layer < engine::render::terrain::kSplatLayerCount; ++layer)
+		{
+			const std::vector<uint8_t>* rgba = nullptr;
+			if (!refs[layer].empty())
+			{
+				// Force la decode/upload de la vignette si pas deja fait
+				// (cree l'entree dans le cache si absente).
+				m_texturePreviewCache->GetTexrThumb(refs[layer]);
+				rgba = m_texturePreviewCache->GetCpuRgba256(refs[layer]);
+			}
+			if (rgba == nullptr)
+			{
+				// Fallback procedurale : assure que l'entree procedurale existe.
+				m_texturePreviewCache->GetProceduralThumb(layer);
+				rgba = m_texturePreviewCache->GetCpuRgba256(
+					"procedural:" + std::to_string(layer));
+			}
+			if (rgba != nullptr)
+			{
+				splatting.SetLayerCpuRgba256(layer, *rgba);
+			}
+		}
+
+		if (!splatting.RebuildAlbedoArrayFromCpuLayers(
+				m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(),
+				m_vkDeviceContext.GetGraphicsQueue(),
+				m_vkDeviceContext.GetGraphicsQueueFamilyIndex()))
+		{
+			LOG_ERROR(Render, "[Engine] ProcessSplatRefsDirty: splat array rebuild failed");
 		}
 	}
 #endif

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3442,9 +3442,14 @@ namespace engine
 			// aussi la souris (orientation), ce qui figeait la caméra dans l’éditeur.
 			const bool capMouse = m_worldEditorImGui->WantsCaptureMouse();
 			const bool capKb = m_worldEditorImGui->WantsCaptureKeyboard();
-			// Clic droit maintenu : orienter même au-dessus des panneaux ImGui (souris souvent « capturée »).
+			// Convention UX standard (Unity/Unreal/Blender) : la rotation de la
+			// caméra free-fly de l'éditeur n'est active QUE pendant que le clic
+			// droit est maintenu. Sinon le moindre déplacement de la souris fait
+			// dériver la caméra et l'utilisateur perd le terrain. Avant ce fix,
+			// `applyLook = !capMouse || rmbLook` faisait tourner la caméra dès
+			// que la souris survolait la zone 3D — UX cassée.
 			const bool rmbLook = m_input.IsMouseDown(engine::platform::MouseButton::Right);
-			const bool applyLook = !capMouse || rmbLook;
+			const bool applyLook = rmbLook;
 			const bool applyKb = !capKb;
 			float terrainWorldM = 0.f;
 			if (m_terrain.IsValid())

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2779,6 +2779,9 @@ namespace engine
 				{
 					m_worldEditorImGui->SetEditorContext(m_worldEditorSession.get(), &m_cfg);
 				}
+				// Branche le DayNightCycle au panneau "Atmosphere" pour que l'utilisateur
+				// puisse regler time-of-day et timeScale en live depuis l'editeur monde.
+				m_worldEditorImGui->SetDayNightCycle(&m_dayNight);
 				m_worldEditorImGui->AttachPlatformWindow(m_window.GetNativeHandle(), m_window);
 				m_authImGui = std::make_unique<engine::render::AuthImGuiRenderer>();
 				m_authImGui->BindAuthUiBridge(&m_authUi, &m_cfg, &m_window);

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -704,8 +704,11 @@ namespace engine
 		// ------------------------------------------------------------------
 		engine::platform::Window::CreateDesc desc{};
 		desc.title  = m_worldEditorExe ? "LCDLLN World Editor" : "LCDLLN Engine";
-		desc.width  = 1280;
-		desc.height = 720;
+		// Editeur monde : 1920x1080 par defaut (panneaux dockes a droite + viewport
+		// central genereux). Client de jeu : 1280x720 (pris en charge par fullscreen
+		// reglable dans les Options).
+		desc.width  = m_worldEditorExe ? 1920 : 1280;
+		desc.height = m_worldEditorExe ? 1080 : 720;
 
 		if (!m_window.Create(desc))
 		{
@@ -3458,8 +3461,27 @@ namespace engine
 		if (m_editorMode)
 		{
 			m_editorMode->Update(m_input, m_window, out.camera, m_geometryMeshHandle.Get(), m_width, m_height, dt);
-			std::memcpy(out.objectModelMatrix, m_editorMode->GetObjectModelMatrix(), sizeof(out.objectModelMatrix));
-			out.objectVisible = m_editorMode->IsObjectVisible();
+			// Demande utilisateur : afficher un humanoide de reference au centre du
+			// terrain pour juger des reliefs. On override la matrice pour positionner
+			// l'avatar (1.8m) au centre XZ du terrain courant a la hauteur du sol
+			// echantillonnee. Si pas de terrain, fallback (0, 0, 0).
+			out.objectVisible = true;
+			float refX = 0.0f, refZ = 0.0f, refY = 0.0f;
+			if (m_terrain.IsValid())
+			{
+				const float ox = m_terrain.GetTerrainOriginX();
+				const float oz = m_terrain.GetTerrainOriginZ();
+				const float ws = m_terrain.GetTerrainWorldSize();
+				refX = ox + ws * 0.5f;
+				refZ = oz + ws * 0.5f;
+				refY = m_terrain.SampleHeightAtWorldXZ(refX, refZ);
+			}
+			// Matrice column-major : identite (rotation 0) + translation (refX, refY, refZ).
+			// Avatar mesh y va de 0 (pieds) a 1.8 (tete) -> pieds au sol echantillonne.
+			out.objectModelMatrix[0]  = 1.0f; out.objectModelMatrix[1]  = 0.0f; out.objectModelMatrix[2]  = 0.0f; out.objectModelMatrix[3]  = 0.0f;
+			out.objectModelMatrix[4]  = 0.0f; out.objectModelMatrix[5]  = 1.0f; out.objectModelMatrix[6]  = 0.0f; out.objectModelMatrix[7]  = 0.0f;
+			out.objectModelMatrix[8]  = 0.0f; out.objectModelMatrix[9]  = 0.0f; out.objectModelMatrix[10] = 1.0f; out.objectModelMatrix[11] = 0.0f;
+			out.objectModelMatrix[12] = refX; out.objectModelMatrix[13] = refY; out.objectModelMatrix[14] = refZ; out.objectModelMatrix[15] = 1.0f;
 		}
 		else
 		{

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1814,6 +1814,16 @@ namespace engine
 												lp.ambientColor[1] = m_zoneAtmosphere.ambientColor[1] * probeIntensity;
 												lp.ambientColor[2] = m_zoneAtmosphere.ambientColor[2] * probeIntensity;
 												lp.ambientColor[3] = 0.0f;
+												// Couleur du ciel utilisée par lighting.frag pour les pixels
+												// sans géométrie (depth==1.0). Pilotée par DayNightCycle pour
+												// rendre le cycle jour/nuit visible sans skybox dédié.
+												{
+													const engine::render::DayNightCycle::State& dnLight = m_dayNight.GetState();
+													lp.skyColor[0] = dnLight.skyHorizon[0];
+													lp.skyColor[1] = dnLight.skyHorizon[1];
+													lp.skyColor[2] = dnLight.skyHorizon[2];
+													lp.skyColor[3] = 0.0f;
+												}
 												VkImageView irrView       = VK_NULL_HANDLE;
 												VkSampler   irrSamp       = VK_NULL_HANDLE;
 												VkImageView prefilterView = m_pipeline->GetSpecularPrefilterPass().IsValid() ? m_pipeline->GetSpecularPrefilterPass().GetImageView() : VK_NULL_HANDLE;

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -50,6 +50,7 @@
 #include "engine/render/terrain/TerrainRenderer.h"
 #if defined(_WIN32)
 #include "engine/render/terrain/TerrainEditingTools.h"
+#include "engine/editor/TexturePreviewCache.h"
 #endif
 
 struct GLFWwindow;
@@ -170,6 +171,13 @@ namespace engine
 #if defined(_WIN32)
 		/// World editor: (re)charge heightmap + outils sculpt depuis le document.
 		void RebuildWorldEditorTerrainGpu();
+
+		/// Si WorldEditorSession::ConsumeSplatRefsDirty() == true, repack les
+		/// 4 layers (procedural fallback + textures importees via le cache)
+		/// dans m_terrain.GetSplatting() et reuploade le GPU array.
+		/// A appeler chaque frame en world-editor mode, apres les autres ticks.
+		/// No-op si --world-editor non actif ou cache non pret.
+		void ProcessSplatRefsDirty();
 #endif
 
 		engine::core::Config m_cfg;
@@ -262,6 +270,13 @@ namespace engine
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
 		std::unique_ptr<engine::editor::WorldEditorSession> m_worldEditorSession;
+#if defined(_WIN32)
+		std::unique_ptr<engine::editor::TexturePreviewCache> m_texturePreviewCache;
+
+		/// Nombre de frames en vol pour le purge differé du TexturePreviewCache.
+		/// Aligne sur HiZ/GpuDrivenCulling kDefaultFramesInFlight = 2.
+		static constexpr uint32_t kEditorTexCacheFramesInFlight = 2u;
+#endif
 		/// Terrain décalé (jeu + world editor exclusif : un seul actif selon le binaire / reload).
 		engine::render::terrain::TerrainRenderer m_terrain;
 #if defined(_WIN32)

--- a/engine/editor/EditorMode.cpp
+++ b/engine/editor/EditorMode.cpp
@@ -246,15 +246,18 @@ namespace engine::editor
 	}
 
 	/// Construit la camera initiale de l'editeur monde.
-	/// Position (0, 150, 200) : au-dessus de la mi-hauteur d'un terrain par defaut
-	/// (heightmap=0.5 * height_scale=200m -> sol a y=100m). Camera 50m au-dessus
-	/// du sol attendu, regardant vers le centre du terrain (origin par defaut 0,0).
-	/// Pitch +0.5 rad (~28deg) : vue plongeante pour voir le sol en contrebas.
+	/// Position (0, 130, 60) : au-dessus de la mi-hauteur d'un terrain par defaut
+	/// (sol moyen y=100m), 30m au-dessus, 60m derriere -> avatar humanoide de
+	/// reference (1.8m) visible a ~25% hauteur ecran. Pitch +0.4 rad (~23deg) :
+	/// vue plongeante moderee qui montre l'avatar et le terrain devant.
 	engine::render::Camera EditorMode::BuildInitialCamera() const
 	{
 		engine::render::Camera camera;
-		camera.position = { 0.0f, 150.0f, 200.0f };
-		camera.pitch = 0.5f;
+		// Position (0, 105, 20) : 5m au-dessus du sol moyen attendu (heightmap=0.5
+		// * height_scale=200m -> sol y=100m), 20m derriere le centre. Avec pitch
+		// faible 0.1 rad (~6deg), avatar humanoide 1.8m visible a ~6% hauteur ecran.
+		camera.position = { 0.0f, 105.0f, 20.0f };
+		camera.pitch = 0.1f;
 		return camera;
 	}
 

--- a/engine/editor/TextureLibraryPanel.cpp
+++ b/engine/editor/TextureLibraryPanel.cpp
@@ -1,0 +1,147 @@
+#include "engine/editor/TextureLibraryPanel.h"
+
+#include "engine/editor/WorldEditorSession.h"
+#include "engine/editor/TexturePreviewCache.h"
+#include "engine/editor/WorldMapEditDocument.h"
+
+#if defined(_WIN32)
+#   include "imgui.h"
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <string>
+
+namespace engine::editor
+{
+#if defined(_WIN32)
+    namespace
+    {
+        constexpr float kThumbSize     = 96.0f;
+        constexpr int   kColumnsPerRow = 5;
+
+        /// Couleur de l'encadrement (liserer accent ImGui) pour la vignette
+        /// actuellement assignee au layer actif.
+        constexpr ImU32 kHighlightColor = IM_COL32(80, 180, 255, 255);
+
+        /// Dessine une vignette + label cliquable. Renvoie true si cliquee.
+        /// \param id ImTextureID retournee par le cache (peut etre nullptr -> placeholder gris).
+        /// \param label Texte court affiche sous la vignette + utilise comme ID ImGui.
+        /// \param highlighted Si true, encadre la vignette d'un liserer accent.
+        bool DrawThumbButton(ImTextureID id, const char* label, bool highlighted)
+        {
+            const ImVec2 size(kThumbSize, kThumbSize);
+            ImGui::BeginGroup();
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, highlighted ? 3.0f : 0.0f);
+            ImGui::PushStyleColor(ImGuiCol_Border, kHighlightColor);
+            bool clicked = false;
+            if (id != nullptr)
+            {
+                clicked = ImGui::ImageButton(label, id, size);
+            }
+            else
+            {
+                clicked = ImGui::Button(label, ImVec2(kThumbSize, kThumbSize));
+            }
+            ImGui::PopStyleColor();
+            ImGui::PopStyleVar();
+            ImGui::TextWrapped("%s", label);
+            ImGui::EndGroup();
+            return clicked;
+        }
+    } // namespace
+
+    void DrawTextureLibrary(WorldEditorSession& session,
+                            TexturePreviewCache* cache,
+                            bool& openFlag)
+    {
+        if (!openFlag) return;
+        if (!ImGui::Begin("Bibliotheque de textures", &openFlag))
+        {
+            ImGui::End();
+            return;
+        }
+
+        // Header : layer actif (radios sync sur SplatLayer()).
+        static const char* kLayerNames[4] = { "Herbe", "Terre", "Roc", "Neige" };
+        int& activeLayer = session.SplatLayer();
+        activeLayer = std::clamp(activeLayer, 0, 3);
+        ImGui::TextUnformatted("Layer actif :");
+        for (int i = 0; i < 4; ++i)
+        {
+            ImGui::SameLine();
+            if (ImGui::RadioButton(kLayerNames[i], activeLayer == i))
+            {
+                activeLayer = i;
+            }
+        }
+        ImGui::Separator();
+
+        // Section 1 : procedurales builtin.
+        ImGui::TextUnformatted("Procedurales (par defaut moteur)");
+        for (int li = 0; li < 4; ++li)
+        {
+            ImGui::PushID(li);
+            ImTextureID id = (cache != nullptr)
+                ? cache->GetProceduralThumb(static_cast<uint32_t>(li))
+                : nullptr;
+            const bool highlighted = (li == activeLayer)
+                && session.Doc().splatLayerTextureRefs[static_cast<size_t>(li)].empty();
+            if (DrawThumbButton(id, kLayerNames[li], highlighted))
+            {
+                // Clic sur procedurale = reset ref a "" pour le layer actif.
+                session.MutableDoc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)].clear();
+                session.MarkSplatRefsDirty();
+            }
+            ImGui::PopID();
+            if (li < 3) ImGui::SameLine();
+        }
+        ImGui::Separator();
+
+        // Section 2 : importees.
+        const auto& assets = session.Doc().textureAssets;
+        ImGui::Text("Importees (%zu)", assets.size());
+        if (assets.empty())
+        {
+            ImGui::TextDisabled("(aucune) - Importez via 'Import assets'");
+        }
+        else
+        {
+            int col = 0;
+            for (size_t i = 0; i < assets.size(); ++i)
+            {
+                ImGui::PushID(static_cast<int>(i));
+                ImTextureID id = (cache != nullptr) ? cache->GetTexrThumb(assets[i]) : nullptr;
+                // Highlight si cette texture est assignee au layer actif.
+                const bool highlighted =
+                    (session.Doc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)] == assets[i]);
+                // Label court : basename apres dernier slash.
+                std::string baseLabel = assets[i];
+                const size_t slash = baseLabel.find_last_of("/\\");
+                if (slash != std::string::npos) baseLabel = baseLabel.substr(slash + 1);
+                if (DrawThumbButton(id, baseLabel.c_str(), highlighted))
+                {
+                    session.MutableDoc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)] = assets[i];
+                    session.MarkSplatRefsDirty();
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", assets[i].c_str());
+                }
+                ImGui::PopID();
+                ++col;
+                if (col % kColumnsPerRow != 0 && i + 1 < assets.size()) ImGui::SameLine();
+            }
+        }
+
+        ImGui::Separator();
+        ImGui::TextDisabled("Cliquez une vignette pour l'assigner au layer actif (%s).",
+                            kLayerNames[activeLayer]);
+        ImGui::End();
+    }
+#else
+    void DrawTextureLibrary(WorldEditorSession&, TexturePreviewCache*, bool&) {}
+#endif
+
+} // namespace engine::editor

--- a/engine/editor/TextureLibraryPanel.cpp
+++ b/engine/editor/TextureLibraryPanel.cpp
@@ -36,7 +36,7 @@ namespace engine::editor
             ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, highlighted ? 3.0f : 0.0f);
             ImGui::PushStyleColor(ImGuiCol_Border, kHighlightColor);
             bool clicked = false;
-            if (id != nullptr)
+            if (id != 0)
             {
                 clicked = ImGui::ImageButton(label, id, size);
             }
@@ -85,7 +85,7 @@ namespace engine::editor
             ImGui::PushID(li);
             ImTextureID id = (cache != nullptr)
                 ? cache->GetProceduralThumb(static_cast<uint32_t>(li))
-                : nullptr;
+                : 0;
             const bool highlighted = (li == activeLayer)
                 && session.Doc().splatLayerTextureRefs[static_cast<size_t>(li)].empty();
             if (DrawThumbButton(id, kLayerNames[li], highlighted))
@@ -112,7 +112,7 @@ namespace engine::editor
             for (size_t i = 0; i < assets.size(); ++i)
             {
                 ImGui::PushID(static_cast<int>(i));
-                ImTextureID id = (cache != nullptr) ? cache->GetTexrThumb(assets[i]) : nullptr;
+                ImTextureID id = (cache != nullptr) ? cache->GetTexrThumb(assets[i]) : 0;
                 // Highlight si cette texture est assignee au layer actif.
                 const bool highlighted =
                     (session.Doc().splatLayerTextureRefs[static_cast<size_t>(activeLayer)] == assets[i]);

--- a/engine/editor/TextureLibraryPanel.h
+++ b/engine/editor/TextureLibraryPanel.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace engine::editor
+{
+    class WorldEditorSession;
+    class TexturePreviewCache;
+
+    /// Dessine le panneau ImGui "Bibliotheque de textures" (Win32 uniquement,
+    /// no-op ailleurs). Affiche les 4 procedurales builtin + toutes les .texr
+    /// importees, avec assignation au layer actif (m_session->SplatLayer())
+    /// au clic. Dirty propage via MarkSplatRefsDirty.
+    /// \param session Session editeur active (Doc().textureAssets, SplatLayer()).
+    /// \param cache Cache de vignettes (peut etre nul -> grilles d'attente).
+    /// \param openFlag Flag controlant l'ouverture du panneau ; modifie par la
+    ///   case de fermeture ImGui ou par l'item de menu (cf. WorldEditorImGui).
+    void DrawTextureLibrary(WorldEditorSession& session,
+                            TexturePreviewCache* cache,
+                            bool& openFlag);
+
+} // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -239,6 +239,8 @@ namespace engine::editor
         {
             for (auto& kv : m_entries) DestroyEntry(kv.second);
             m_entries.clear();
+            for (auto& pd : m_pendingDeletes) DestroyEntry(pd.preview);
+            m_pendingDeletes.clear();
             if (m_pool != nullptr)
             {
                 vkDestroyDescriptorPool(m_device, m_pool, nullptr);
@@ -250,6 +252,10 @@ namespace engine::editor
                 m_sampler = nullptr;
             }
         }
+        m_negativeCache.clear();
+        m_entries.clear();
+        m_pendingDeletes.clear();
+        m_lastTickFrame = 0;
         m_device = nullptr;
         m_physDev = nullptr;
         m_queue = nullptr;
@@ -547,6 +553,38 @@ namespace engine::editor
         return &it->second.cpuRgba256;
     }
 
+    void TexturePreviewCache::Invalidate(const std::string& contentRelPath)
+    {
+        m_negativeCache.erase(contentRelPath);
+        auto it = m_entries.find(contentRelPath);
+        if (it == m_entries.end()) return;
+        // Differer la destruction (descriptor potentiellement reference dans
+        // une command buffer en vol).
+        PendingDelete pd;
+        pd.preview = std::move(it->second);
+        pd.frameIndex = m_lastTickFrame;
+        m_pendingDeletes.push_back(std::move(pd));
+        m_entries.erase(it);
+    }
+
+    void TexturePreviewCache::Tick(uint64_t currentFrameIndex, uint32_t framesInFlight)
+    {
+        m_lastTickFrame = currentFrameIndex;
+        // Purger les entrees dont l'invalidation date d'au moins framesInFlight.
+        for (auto it = m_pendingDeletes.begin(); it != m_pendingDeletes.end(); )
+        {
+            if (currentFrameIndex >= it->frameIndex + framesInFlight)
+            {
+                DestroyEntry(it->preview);
+                it = m_pendingDeletes.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
 #else
     // No-op stubs pour Linux/macOS — l'editeur monde ne tourne que sur Win32.
     TexturePreviewCache::~TexturePreviewCache() = default;
@@ -558,6 +596,8 @@ namespace engine::editor
     ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t) { return nullptr; }
     ImTextureID TexturePreviewCache::GetTexrThumb(const std::string&) { return nullptr; }
     const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string&) const { return nullptr; }
+    void TexturePreviewCache::Invalidate(const std::string&) {}
+    void TexturePreviewCache::Tick(uint64_t, uint32_t) {}
 #endif
 
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -278,7 +278,7 @@ namespace engine::editor
         {
             LOG_ERROR(Render, "[TexturePreviewCache] CreateEntry({}): not ready or bad size {} (expected {})",
                       key, rgba256.size(), expectedBytes);
-            return nullptr;
+            return 0;
         }
 
         GpuPreview preview;
@@ -300,7 +300,7 @@ namespace engine::editor
         if (vkCreateImage(m_device, &ici, nullptr, &preview.image) != VK_SUCCESS)
         {
             LOG_ERROR(Render, "[TexturePreviewCache] vkCreateImage failed for {}", key);
-            return nullptr;
+            return 0;
         }
 
         VkMemoryRequirements mr{};
@@ -321,7 +321,7 @@ namespace engine::editor
         {
             LOG_ERROR(Render, "[TexturePreviewCache] no DEVICE_LOCAL memory for {}", key);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
         VkMemoryAllocateInfo ai{};
         ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
@@ -331,7 +331,7 @@ namespace engine::editor
         {
             LOG_ERROR(Render, "[TexturePreviewCache] vkAllocateMemory failed for {}", key);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
         vkBindImageMemory(m_device, preview.image, preview.memory, 0);
 
@@ -348,7 +348,7 @@ namespace engine::editor
             LOG_ERROR(Render, "[TexturePreviewCache] staging vkCreateBuffer failed for {}", key);
             vkFreeMemory(m_device, preview.memory, nullptr);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
         VkMemoryRequirements bmr{};
         vkGetBufferMemoryRequirements(m_device, staging, &bmr);
@@ -370,7 +370,7 @@ namespace engine::editor
             vkDestroyBuffer(m_device, staging, nullptr);
             vkFreeMemory(m_device, preview.memory, nullptr);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
         VkMemoryAllocateInfo ai2{};
         ai2.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
@@ -382,7 +382,7 @@ namespace engine::editor
             vkDestroyBuffer(m_device, staging, nullptr);
             vkFreeMemory(m_device, preview.memory, nullptr);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
         vkBindBufferMemory(m_device, staging, stagingMem, 0);
         void* mapped = nullptr;
@@ -458,7 +458,7 @@ namespace engine::editor
             LOG_ERROR(Render, "[TexturePreviewCache] vkCreateImageView failed for {}", key);
             vkFreeMemory(m_device, preview.memory, nullptr);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
 
         // 5) Descriptor ImGui (alloue par le backend ImGui depuis son propre pool).
@@ -470,10 +470,10 @@ namespace engine::editor
             vkDestroyImageView(m_device, preview.view, nullptr);
             vkFreeMemory(m_device, preview.memory, nullptr);
             vkDestroyImage(m_device, preview.image, nullptr);
-            return nullptr;
+            return 0;
         }
 
-        const ImTextureID id = static_cast<ImTextureID>(preview.imguiDS);
+        const ImTextureID id = reinterpret_cast<ImTextureID>(preview.imguiDS);
         m_entries.emplace(key, std::move(preview));
         return id;
     }
@@ -493,33 +493,33 @@ namespace engine::editor
 
     ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t layer)
     {
-        if (!m_ready || layer >= engine::render::terrain::kSplatLayerCount) return nullptr;
+        if (!m_ready || layer >= engine::render::terrain::kSplatLayerCount) return 0;
         const std::string key = ProceduralKey(layer);
         auto it = m_entries.find(key);
         if (it != m_entries.end())
         {
-            return static_cast<ImTextureID>(it->second.imguiDS);
+            return reinterpret_cast<ImTextureID>(it->second.imguiDS);
         }
         std::vector<uint8_t> rgba;
         if (!engine::render::terrain::GenerateProceduralAlbedoLayer(
                 engine::render::terrain::kSplatLayerResolution, layer, rgba))
         {
-            return nullptr;
+            return 0;
         }
         return CreateEntry(key, rgba);
     }
 
     ImTextureID TexturePreviewCache::GetTexrThumb(const std::string& contentRelPath)
     {
-        if (!m_ready || contentRelPath.empty()) return nullptr;
+        if (!m_ready || contentRelPath.empty()) return 0;
         auto it = m_entries.find(contentRelPath);
         if (it != m_entries.end())
         {
-            return static_cast<ImTextureID>(it->second.imguiDS);
+            return reinterpret_cast<ImTextureID>(it->second.imguiDS);
         }
         if (m_negativeCache.count(contentRelPath) != 0)
         {
-            return nullptr; // deja echoue, ne pas spam les logs
+            return 0; // deja echoue, ne pas spam les logs
         }
 
         // Resoudre en chemin absolu via m_contentDir.
@@ -531,7 +531,7 @@ namespace engine::editor
         if (!LoadTexrFile(abs.string(), raw, srcW, srcH))
         {
             m_negativeCache.insert(contentRelPath);
-            return nullptr;
+            return 0;
         }
 
         std::vector<uint8_t> resampled;
@@ -540,7 +540,7 @@ namespace engine::editor
         {
             LOG_ERROR(Render, "[TexturePreviewCache] ResampleRgba8Box failed for {}", contentRelPath);
             m_negativeCache.insert(contentRelPath);
-            return nullptr;
+            return 0;
         }
 
         return CreateEntry(contentRelPath, resampled);
@@ -591,10 +591,10 @@ namespace engine::editor
     bool TexturePreviewCache::Init(VkDevice, VkPhysicalDevice, VkQueue, uint32_t, const std::string&) { return false; }
     void TexturePreviewCache::Shutdown() {}
     std::string TexturePreviewCache::ProceduralKey(uint32_t layer) { return std::string("procedural:") + std::to_string(layer); }
-    ImTextureID TexturePreviewCache::CreateEntry(const std::string&, const std::vector<uint8_t>&) { return nullptr; }
+    ImTextureID TexturePreviewCache::CreateEntry(const std::string&, const std::vector<uint8_t>&) { return 0; }
     void TexturePreviewCache::DestroyEntry(GpuPreview&) {}
-    ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t) { return nullptr; }
-    ImTextureID TexturePreviewCache::GetTexrThumb(const std::string&) { return nullptr; }
+    ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t) { return 0; }
+    ImTextureID TexturePreviewCache::GetTexrThumb(const std::string&) { return 0; }
     const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string&) const { return nullptr; }
     void TexturePreviewCache::Invalidate(const std::string&) {}
     void TexturePreviewCache::Tick(uint64_t, uint32_t) {}

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -1,0 +1,79 @@
+#include "engine/editor/TexturePreviewCache.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace engine::editor
+{
+    namespace
+    {
+        /// Crop centre rectangulaire vers carre. Renvoie le pointeur vers le
+        /// pixel (0,0) du sous-rectangle carre + son cote.
+        void CropToSquare(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          const uint8_t*& outSrc, uint32_t& outSize, uint32_t& outRowStrideBytes)
+        {
+            outRowStrideBytes = srcW * 4u;
+            if (srcW == srcH)
+            {
+                outSrc = src;
+                outSize = srcW;
+                return;
+            }
+            const uint32_t side = std::min(srcW, srcH);
+            const uint32_t offX = (srcW - side) / 2u;
+            const uint32_t offY = (srcH - side) / 2u;
+            outSrc = src + (offY * srcW + offX) * 4u;
+            outSize = side;
+        }
+    } // namespace
+
+    bool ResampleRgba8Box(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          uint32_t dstSize, std::vector<uint8_t>& outRgba)
+    {
+        if (src == nullptr || srcW == 0 || srcH == 0 || dstSize < 4u || dstSize > 4096u)
+        {
+            outRgba.clear();
+            return false;
+        }
+
+        const uint8_t* sqSrc = nullptr;
+        uint32_t sqSize = 0;
+        uint32_t srcStride = 0;
+        CropToSquare(src, srcW, srcH, sqSrc, sqSize, srcStride);
+
+        outRgba.assign(static_cast<size_t>(dstSize) * dstSize * 4u, 0u);
+
+        // Box filter direct (pas de mipmap chain) : pour chaque pixel dst,
+        // moyenner tous les pixels src couverts. Cout O(dstSize^2 * (sqSize/dstSize)^2).
+        // Pour 1024->256 : 256^2 * 16 = ~1M reads, ~3ms en debug, <1ms en release.
+        for (uint32_t dy = 0; dy < dstSize; ++dy)
+        {
+            const uint32_t y0 = (dy * sqSize) / dstSize;
+            const uint32_t y1 = ((dy + 1u) * sqSize) / dstSize;
+            const uint32_t ySpan = std::max(1u, y1 - y0);
+            for (uint32_t dx = 0; dx < dstSize; ++dx)
+            {
+                const uint32_t x0 = (dx * sqSize) / dstSize;
+                const uint32_t x1 = ((dx + 1u) * sqSize) / dstSize;
+                const uint32_t xSpan = std::max(1u, x1 - x0);
+                uint32_t accR = 0, accG = 0, accB = 0, accA = 0;
+                const uint32_t count = xSpan * ySpan;
+                for (uint32_t sy = y0; sy < y0 + ySpan; ++sy)
+                {
+                    const uint8_t* row = sqSrc + sy * srcStride;
+                    for (uint32_t sx = x0; sx < x0 + xSpan; ++sx)
+                    {
+                        const uint8_t* p = row + sx * 4u;
+                        accR += p[0]; accG += p[1]; accB += p[2]; accA += p[3];
+                    }
+                }
+                uint8_t* dst = outRgba.data() + (dy * dstSize + dx) * 4u;
+                dst[0] = static_cast<uint8_t>(accR / count);
+                dst[1] = static_cast<uint8_t>(accG / count);
+                dst[2] = static_cast<uint8_t>(accB / count);
+                dst[3] = static_cast<uint8_t>(accA / count);
+            }
+        }
+        return true;
+    }
+} // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -12,6 +12,8 @@
 #include <fstream>
 #include <iterator>
 
+#include <vulkan/vulkan.h>
+
 namespace engine::editor
 {
     namespace
@@ -159,4 +161,100 @@ namespace engine::editor
         stbi_image_free(pixels);
         return true;
     }
+
+#if defined(_WIN32)
+    TexturePreviewCache::~TexturePreviewCache()
+    {
+        Shutdown();
+    }
+
+    bool TexturePreviewCache::Init(VkDevice device, VkPhysicalDevice physDev,
+                                    VkQueue queue, uint32_t queueFamilyIndex,
+                                    const std::string& contentDir)
+    {
+        if (m_ready) return true;
+        if (device == nullptr || physDev == nullptr || queue == nullptr)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Init: invalid Vulkan handles");
+            return false;
+        }
+        m_device = device;
+        m_physDev = physDev;
+        m_queue = queue;
+        m_queueFamily = queueFamilyIndex;
+        m_contentDir = contentDir;
+
+        // Sampler partage : linear filter, clamp to edge. Identique pour toutes
+        // les vignettes du cache.
+        VkSamplerCreateInfo si{};
+        si.sType         = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        si.magFilter     = VK_FILTER_LINEAR;
+        si.minFilter     = VK_FILTER_LINEAR;
+        si.mipmapMode    = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        si.addressModeU  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeV  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.addressModeW  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        si.maxAnisotropy = 1.0f;
+        si.minLod        = 0.0f;
+        si.maxLod        = 0.0f;
+        if (vkCreateSampler(m_device, &si, nullptr, &m_sampler) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateSampler failed");
+            return false;
+        }
+
+        // Descriptor pool dedie : 64 sets max, 1 sampled image chacun (pour ImGui).
+        // Au-dela : warning cote alloc, vignette grise.
+        VkDescriptorPoolSize ps{};
+        ps.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        ps.descriptorCount = 64u;
+
+        VkDescriptorPoolCreateInfo pi{};
+        pi.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        pi.flags         = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+        pi.maxSets       = 64u;
+        pi.poolSizeCount = 1;
+        pi.pPoolSizes    = &ps;
+        if (vkCreateDescriptorPool(m_device, &pi, nullptr, &m_pool) != VK_SUCCESS)
+        {
+            vkDestroySampler(m_device, m_sampler, nullptr);
+            m_sampler = nullptr;
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateDescriptorPool failed");
+            return false;
+        }
+
+        m_ready = true;
+        LOG_INFO(Render, "[TexturePreviewCache] Init OK (contentDir={})", m_contentDir);
+        return true;
+    }
+
+    void TexturePreviewCache::Shutdown()
+    {
+        if (m_device != nullptr)
+        {
+            if (m_pool != nullptr)
+            {
+                vkDestroyDescriptorPool(m_device, m_pool, nullptr);
+                m_pool = nullptr;
+            }
+            if (m_sampler != nullptr)
+            {
+                vkDestroySampler(m_device, m_sampler, nullptr);
+                m_sampler = nullptr;
+            }
+        }
+        m_device = nullptr;
+        m_physDev = nullptr;
+        m_queue = nullptr;
+        m_queueFamily = 0;
+        m_contentDir.clear();
+        m_ready = false;
+    }
+#else
+    // No-op stubs pour Linux/macOS — l'editeur monde ne tourne que sur Win32.
+    TexturePreviewCache::~TexturePreviewCache() = default;
+    bool TexturePreviewCache::Init(VkDevice, VkPhysicalDevice, VkQueue, uint32_t, const std::string&) { return false; }
+    void TexturePreviewCache::Shutdown() {}
+#endif
+
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -503,6 +503,43 @@ namespace engine::editor
         return CreateEntry(key, rgba);
     }
 
+    ImTextureID TexturePreviewCache::GetTexrThumb(const std::string& contentRelPath)
+    {
+        if (!m_ready || contentRelPath.empty()) return nullptr;
+        auto it = m_entries.find(contentRelPath);
+        if (it != m_entries.end())
+        {
+            return static_cast<ImTextureID>(it->second.imguiDS);
+        }
+        if (m_negativeCache.count(contentRelPath) != 0)
+        {
+            return nullptr; // deja echoue, ne pas spam les logs
+        }
+
+        // Resoudre en chemin absolu via m_contentDir.
+        const std::filesystem::path abs =
+            std::filesystem::path(m_contentDir) / contentRelPath;
+
+        std::vector<uint8_t> raw;
+        uint32_t srcW = 0, srcH = 0;
+        if (!LoadTexrFile(abs.string(), raw, srcW, srcH))
+        {
+            m_negativeCache.insert(contentRelPath);
+            return nullptr;
+        }
+
+        std::vector<uint8_t> resampled;
+        if (!ResampleRgba8Box(raw.data(), srcW, srcH,
+                              engine::render::terrain::kSplatLayerResolution, resampled))
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] ResampleRgba8Box failed for {}", contentRelPath);
+            m_negativeCache.insert(contentRelPath);
+            return nullptr;
+        }
+
+        return CreateEntry(contentRelPath, resampled);
+    }
+
     const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string& key) const
     {
         auto it = m_entries.find(key);
@@ -519,6 +556,7 @@ namespace engine::editor
     ImTextureID TexturePreviewCache::CreateEntry(const std::string&, const std::vector<uint8_t>&) { return nullptr; }
     void TexturePreviewCache::DestroyEntry(GpuPreview&) {}
     ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t) { return nullptr; }
+    ImTextureID TexturePreviewCache::GetTexrThumb(const std::string&) { return nullptr; }
     const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string&) const { return nullptr; }
 #endif
 

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -14,6 +14,11 @@
 
 #include <vulkan/vulkan.h>
 
+#if defined(_WIN32)
+#   include "imgui_impl_vulkan.h"
+#endif
+#include "engine/render/terrain/TerrainSplatting.h"
+
 namespace engine::editor
 {
     namespace
@@ -232,6 +237,8 @@ namespace engine::editor
     {
         if (m_device != nullptr)
         {
+            for (auto& kv : m_entries) DestroyEntry(kv.second);
+            m_entries.clear();
             if (m_pool != nullptr)
             {
                 vkDestroyDescriptorPool(m_device, m_pool, nullptr);
@@ -250,11 +257,269 @@ namespace engine::editor
         m_contentDir.clear();
         m_ready = false;
     }
+
+    std::string TexturePreviewCache::ProceduralKey(uint32_t layer)
+    {
+        return std::string("procedural:") + std::to_string(layer);
+    }
+
+    ImTextureID TexturePreviewCache::CreateEntry(const std::string& key,
+                                                  const std::vector<uint8_t>& rgba256)
+    {
+        constexpr uint32_t kRes = engine::render::terrain::kSplatLayerResolution;
+        const size_t expectedBytes = static_cast<size_t>(kRes) * kRes * 4u;
+        if (!m_ready || rgba256.size() != expectedBytes)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] CreateEntry({}): not ready or bad size {} (expected {})",
+                      key, rgba256.size(), expectedBytes);
+            return nullptr;
+        }
+
+        GpuPreview preview;
+        preview.cpuRgba256 = rgba256;
+
+        // 1) VkImage 256x256 RGBA8_SRGB, OPTIMAL, SAMPLED + TRANSFER_DST.
+        VkImageCreateInfo ici{};
+        ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        ici.imageType     = VK_IMAGE_TYPE_2D;
+        ici.format        = VK_FORMAT_R8G8B8A8_SRGB;
+        ici.extent        = { kRes, kRes, 1 };
+        ici.mipLevels     = 1;
+        ici.arrayLayers   = 1;
+        ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+        ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+        ici.usage         = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+        if (vkCreateImage(m_device, &ici, nullptr, &preview.image) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateImage failed for {}", key);
+            return nullptr;
+        }
+
+        VkMemoryRequirements mr{};
+        vkGetImageMemoryRequirements(m_device, preview.image, &mr);
+        VkPhysicalDeviceMemoryProperties mp{};
+        vkGetPhysicalDeviceMemoryProperties(m_physDev, &mp);
+        uint32_t memType = UINT32_MAX;
+        for (uint32_t i = 0; i < mp.memoryTypeCount; ++i)
+        {
+            if ((mr.memoryTypeBits & (1u << i)) &&
+                (mp.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+            {
+                memType = i;
+                break;
+            }
+        }
+        if (memType == UINT32_MAX)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] no DEVICE_LOCAL memory for {}", key);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        VkMemoryAllocateInfo ai{};
+        ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        ai.allocationSize  = mr.size;
+        ai.memoryTypeIndex = memType;
+        if (vkAllocateMemory(m_device, &ai, nullptr, &preview.memory) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] vkAllocateMemory failed for {}", key);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        vkBindImageMemory(m_device, preview.image, preview.memory, 0);
+
+        // 2) Staging buffer (HOST_VISIBLE | HOST_COHERENT).
+        VkBuffer staging = nullptr;
+        VkDeviceMemory stagingMem = nullptr;
+        VkBufferCreateInfo bci{};
+        bci.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        bci.size        = rgba256.size();
+        bci.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        if (vkCreateBuffer(m_device, &bci, nullptr, &staging) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] staging vkCreateBuffer failed for {}", key);
+            vkFreeMemory(m_device, preview.memory, nullptr);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        VkMemoryRequirements bmr{};
+        vkGetBufferMemoryRequirements(m_device, staging, &bmr);
+        uint32_t hvis = UINT32_MAX;
+        for (uint32_t i = 0; i < mp.memoryTypeCount; ++i)
+        {
+            const VkMemoryPropertyFlags need =
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            if ((bmr.memoryTypeBits & (1u << i)) &&
+                (mp.memoryTypes[i].propertyFlags & need) == need)
+            {
+                hvis = i;
+                break;
+            }
+        }
+        if (hvis == UINT32_MAX)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] no HOST_VISIBLE memory for {}", key);
+            vkDestroyBuffer(m_device, staging, nullptr);
+            vkFreeMemory(m_device, preview.memory, nullptr);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        VkMemoryAllocateInfo ai2{};
+        ai2.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        ai2.allocationSize  = bmr.size;
+        ai2.memoryTypeIndex = hvis;
+        if (vkAllocateMemory(m_device, &ai2, nullptr, &stagingMem) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] staging vkAllocateMemory failed for {}", key);
+            vkDestroyBuffer(m_device, staging, nullptr);
+            vkFreeMemory(m_device, preview.memory, nullptr);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+        vkBindBufferMemory(m_device, staging, stagingMem, 0);
+        void* mapped = nullptr;
+        vkMapMemory(m_device, stagingMem, 0, rgba256.size(), 0, &mapped);
+        std::memcpy(mapped, rgba256.data(), rgba256.size());
+        vkUnmapMemory(m_device, stagingMem);
+
+        // 3) One-shot command pool + buffer : barriers + copy.
+        VkCommandPool pool = nullptr;
+        VkCommandPoolCreateInfo pci{};
+        pci.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        pci.queueFamilyIndex = m_queueFamily;
+        pci.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        vkCreateCommandPool(m_device, &pci, nullptr, &pool);
+        VkCommandBuffer cmd = nullptr;
+        VkCommandBufferAllocateInfo cai{};
+        cai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        cai.commandPool        = pool;
+        cai.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cai.commandBufferCount = 1;
+        vkAllocateCommandBuffers(m_device, &cai, &cmd);
+        VkCommandBufferBeginInfo cbb{};
+        cbb.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        cbb.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(cmd, &cbb);
+
+        VkImageMemoryBarrier b1{};
+        b1.sType            = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        b1.oldLayout        = VK_IMAGE_LAYOUT_UNDEFINED;
+        b1.newLayout        = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        b1.image            = preview.image;
+        b1.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        b1.srcAccessMask    = 0;
+        b1.dstAccessMask    = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b1);
+
+        VkBufferImageCopy r{};
+        r.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+        r.imageExtent      = { kRes, kRes, 1 };
+        vkCmdCopyBufferToImage(cmd, staging, preview.image,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &r);
+
+        VkImageMemoryBarrier b2 = b1;
+        b2.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        b2.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        b2.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        b2.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b2);
+
+        vkEndCommandBuffer(cmd);
+        VkSubmitInfo sub{};
+        sub.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        sub.commandBufferCount = 1;
+        sub.pCommandBuffers    = &cmd;
+        vkQueueSubmit(m_queue, 1, &sub, nullptr);
+        vkQueueWaitIdle(m_queue);
+
+        vkDestroyCommandPool(m_device, pool, nullptr);
+        vkDestroyBuffer(m_device, staging, nullptr);
+        vkFreeMemory(m_device, stagingMem, nullptr);
+
+        // 4) ImageView.
+        VkImageViewCreateInfo vci{};
+        vci.sType            = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        vci.image            = preview.image;
+        vci.viewType         = VK_IMAGE_VIEW_TYPE_2D;
+        vci.format           = VK_FORMAT_R8G8B8A8_SRGB;
+        vci.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        if (vkCreateImageView(m_device, &vci, nullptr, &preview.view) != VK_SUCCESS)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] vkCreateImageView failed for {}", key);
+            vkFreeMemory(m_device, preview.memory, nullptr);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+
+        // 5) Descriptor ImGui (alloue par le backend ImGui depuis son propre pool).
+        preview.imguiDS = ImGui_ImplVulkan_AddTexture(m_sampler, preview.view,
+                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        if (preview.imguiDS == nullptr)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] ImGui_ImplVulkan_AddTexture failed for {}", key);
+            vkDestroyImageView(m_device, preview.view, nullptr);
+            vkFreeMemory(m_device, preview.memory, nullptr);
+            vkDestroyImage(m_device, preview.image, nullptr);
+            return nullptr;
+        }
+
+        const ImTextureID id = static_cast<ImTextureID>(preview.imguiDS);
+        m_entries.emplace(key, std::move(preview));
+        return id;
+    }
+
+    void TexturePreviewCache::DestroyEntry(GpuPreview& p)
+    {
+        if (p.imguiDS != nullptr)
+        {
+            ImGui_ImplVulkan_RemoveTexture(p.imguiDS);
+            p.imguiDS = nullptr;
+        }
+        if (p.view != nullptr)   { vkDestroyImageView(m_device, p.view, nullptr);   p.view = nullptr; }
+        if (p.image != nullptr)  { vkDestroyImage(m_device, p.image, nullptr);      p.image = nullptr; }
+        if (p.memory != nullptr) { vkFreeMemory(m_device, p.memory, nullptr);       p.memory = nullptr; }
+        p.cpuRgba256.clear();
+    }
+
+    ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t layer)
+    {
+        if (!m_ready || layer >= engine::render::terrain::kSplatLayerCount) return nullptr;
+        const std::string key = ProceduralKey(layer);
+        auto it = m_entries.find(key);
+        if (it != m_entries.end())
+        {
+            return static_cast<ImTextureID>(it->second.imguiDS);
+        }
+        std::vector<uint8_t> rgba;
+        if (!engine::render::terrain::GenerateProceduralAlbedoLayer(
+                engine::render::terrain::kSplatLayerResolution, layer, rgba))
+        {
+            return nullptr;
+        }
+        return CreateEntry(key, rgba);
+    }
+
+    const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string& key) const
+    {
+        auto it = m_entries.find(key);
+        if (it == m_entries.end()) return nullptr;
+        return &it->second.cpuRgba256;
+    }
+
 #else
     // No-op stubs pour Linux/macOS — l'editeur monde ne tourne que sur Win32.
     TexturePreviewCache::~TexturePreviewCache() = default;
     bool TexturePreviewCache::Init(VkDevice, VkPhysicalDevice, VkQueue, uint32_t, const std::string&) { return false; }
     void TexturePreviewCache::Shutdown() {}
+    std::string TexturePreviewCache::ProceduralKey(uint32_t layer) { return std::string("procedural:") + std::to_string(layer); }
+    ImTextureID TexturePreviewCache::CreateEntry(const std::string&, const std::vector<uint8_t>&) { return nullptr; }
+    void TexturePreviewCache::DestroyEntry(GpuPreview&) {}
+    ImTextureID TexturePreviewCache::GetProceduralThumb(uint32_t) { return nullptr; }
+    const std::vector<uint8_t>* TexturePreviewCache::GetCpuRgba256(const std::string&) const { return nullptr; }
 #endif
 
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.cpp
+++ b/engine/editor/TexturePreviewCache.cpp
@@ -1,12 +1,23 @@
 #include "engine/editor/TexturePreviewCache.h"
 
+#include "engine/core/Log.h"
+
+// stb_image deja defini dans WorldMapIo.cpp / AssetRegistry.cpp — NE PAS redefinir
+// STB_IMAGE_IMPLEMENTATION ici (link error sinon).
+#include "stb_image.h"
+
 #include <algorithm>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 
 namespace engine::editor
 {
     namespace
     {
+        constexpr uint32_t kTexrMagic = 0x52584554u;  // "TEXR" little-endian
+
         /// Crop centre rectangulaire vers carre. Renvoie le pointeur vers le
         /// pixel (0,0) du sous-rectangle carre + son cote.
         void CropToSquare(const uint8_t* src, uint32_t srcW, uint32_t srcH,
@@ -74,6 +85,78 @@ namespace engine::editor
                 dst[3] = static_cast<uint8_t>(accA / count);
             }
         }
+        return true;
+    }
+
+    bool LoadTexrFile(const std::string& absolutePath,
+                      std::vector<uint8_t>& outRgba,
+                      uint32_t& outWidth, uint32_t& outHeight)
+    {
+        outRgba.clear();
+        outWidth = 0;
+        outHeight = 0;
+
+        std::error_code ec;
+        if (!std::filesystem::exists(absolutePath, ec))
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Texture file not found: {}", absolutePath);
+            return false;
+        }
+
+        std::ifstream f(absolutePath, std::ios::binary);
+        if (!f)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] Cannot open texture file: {}", absolutePath);
+            return false;
+        }
+        std::vector<uint8_t> data((std::istreambuf_iterator<char>(f)),
+                                   std::istreambuf_iterator<char>());
+
+        // Si magic 'TEXR' present : decoder directement.
+        if (data.size() >= 16u)
+        {
+            uint32_t magic = 0, w = 0, h = 0, srgb = 0;
+            std::memcpy(&magic, data.data(), 4);
+            if (magic == kTexrMagic)
+            {
+                std::memcpy(&w,    data.data() + 4,  4);
+                std::memcpy(&h,    data.data() + 8,  4);
+                std::memcpy(&srgb, data.data() + 12, 4);
+                (void)srgb;
+                if (w == 0 || h == 0 || w > 4096u || h > 4096u)
+                {
+                    LOG_ERROR(Render, "[TexturePreviewCache] TEXR invalid dims {}x{}: {}", w, h, absolutePath);
+                    return false;
+                }
+                const size_t pixelBytes = static_cast<size_t>(w) * h * 4u;
+                if (data.size() < 16u + pixelBytes)
+                {
+                    LOG_ERROR(Render, "[TexturePreviewCache] TEXR truncated: {}", absolutePath);
+                    return false;
+                }
+                outRgba.assign(data.begin() + 16,
+                               data.begin() + 16 + static_cast<long long>(pixelBytes));
+                outWidth = w;
+                outHeight = h;
+                return true;
+            }
+        }
+
+        // Fallback : PNG/JPG/TGA/BMP via stb_image.
+        int w = 0, h = 0, comp = 0;
+        stbi_uc* pixels = stbi_load_from_memory(data.data(), static_cast<int>(data.size()),
+                                                &w, &h, &comp, 4);
+        if (pixels == nullptr || w <= 0 || h <= 0 || w > 4096 || h > 4096)
+        {
+            LOG_ERROR(Render, "[TexturePreviewCache] stb_image decode failed or out of range: {}", absolutePath);
+            if (pixels) stbi_image_free(pixels);
+            return false;
+        }
+        const size_t pixelBytes = static_cast<size_t>(w) * h * 4u;
+        outRgba.assign(pixels, pixels + pixelBytes);
+        outWidth = static_cast<uint32_t>(w);
+        outHeight = static_cast<uint32_t>(h);
+        stbi_image_free(pixels);
         return true;
     }
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -17,7 +17,7 @@ struct VkImage_T;          typedef VkImage_T*          VkImage;
 struct VkImageView_T;      typedef VkImageView_T*      VkImageView;
 struct VkDeviceMemory_T;   typedef VkDeviceMemory_T*   VkDeviceMemory;
 struct VkDescriptorSet_T;  typedef VkDescriptorSet_T*  VkDescriptorSet;
-typedef void* ImTextureID;
+typedef unsigned long long ImTextureID;
 
 namespace engine::editor
 {

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::editor
+{
+    /// Resample un buffer RGBA8 a une nouvelle resolution carree par box filter
+    /// separable (passe horizontale + verticale). Si le source n'est pas carre,
+    /// crop centre vers carre avant resample (pas de stretch, pas de letterbox).
+    /// \param src Buffer source RGBA8, srcW * srcH * 4 octets.
+    /// \param srcW Largeur source en pixels (>=1).
+    /// \param srcH Hauteur source en pixels (>=1).
+    /// \param dstSize Cote du carre de sortie en pixels (>=4, <=4096).
+    /// \param outRgba Sortie : dstSize * dstSize * 4 octets.
+    /// \return true si succes ; false sur params invalides.
+    bool ResampleRgba8Box(const uint8_t* src, uint32_t srcW, uint32_t srcH,
+                          uint32_t dstSize, std::vector<uint8_t>& outRgba);
+} // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // Forward decl Vulkan + ImGui (evite #include vulkan.h dans le .h pour
@@ -81,6 +82,20 @@ namespace engine::editor
         /// True si Init a reussi et Shutdown n'a pas ete appele.
         bool IsReady() const { return m_ready; }
 
+        /// Renvoie une ImTextureID utilisable par ImGui::Image() pour la
+        /// vignette procedurale du layer (0=grass, 1=dirt, 2=rock, 3=snow).
+        /// 1re demande : genere le bruit + cree image+view+descriptor ImGui.
+        /// Suivantes : hit cache. Cle interne : "procedural:N".
+        /// \return nullptr si Init non OK ou layer >= kSplatLayerCount.
+        ImTextureID GetProceduralThumb(uint32_t layer);
+
+        /// Renvoie le buffer CPU 256x256 d'une key cachee (ou nullptr).
+        /// Cles : "procedural:0".."procedural:3" pour les builtins,
+        ///        "textures/<rel>" pour les .texr importees (Task 8).
+        /// Utilise par Engine::ProcessSplatRefsDirty pour reuploader le splat
+        /// array terrain.
+        const std::vector<uint8_t>* GetCpuRgba256(const std::string& key) const;
+
     private:
         bool             m_ready        = false;
         VkDevice         m_device       = nullptr;
@@ -90,7 +105,35 @@ namespace engine::editor
         std::string      m_contentDir;
 
         VkSampler        m_sampler = nullptr;
+        // TODO M-XX : m_pool cree par Init mais non utilise pour l'instant
+        // (ImGui_ImplVulkan_AddTexture alloue depuis son propre pool interne).
+        // A repurposer ou supprimer quand le besoin sera clarifie.
         VkDescriptorPool m_pool    = nullptr;
+
+        /// Une entree GPU cachee : buffer CPU + ressources Vulkan + descriptor ImGui.
+        struct GpuPreview
+        {
+            std::vector<uint8_t> cpuRgba256;
+            VkImage              image   = nullptr;
+            VkImageView          view    = nullptr;
+            VkDeviceMemory       memory  = nullptr;
+            VkDescriptorSet      imguiDS = nullptr;
+        };
+
+        /// key -> preview. Cles cf. doc de GetCpuRgba256.
+        std::unordered_map<std::string, GpuPreview> m_entries;
+
+        /// Cle procedurale standardisee : "procedural:0".."procedural:3".
+        static std::string ProceduralKey(uint32_t layer);
+
+        /// Cree image+view+descriptor ImGui a partir d'un buffer 256x256 RGBA8.
+        /// Stocke dans m_entries[key]. Renvoie l'ImTextureID ou nullptr sur echec.
+        /// Win32 uniquement.
+        ImTextureID CreateEntry(const std::string& key,
+                                const std::vector<uint8_t>& rgba256);
+
+        /// Detruit les ressources Vulkan + ImGui d'une entree (helper interne, Win32 only).
+        void DestroyEntry(GpuPreview& p);
     };
 
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -106,6 +106,22 @@ namespace engine::editor
         /// array terrain.
         const std::vector<uint8_t>* GetCpuRgba256(const std::string& key) const;
 
+        /// Marque une entree pour destruction differee. Le descriptor + ressources
+        /// Vulkan seront detruits au prochain Tick(currentFrame >= invalidatedAt + framesInFlight).
+        /// Reset aussi l'entree dans le cache negatif (permet de retenter le decode).
+        /// Procedurales : invalider n'a pas de sens (octets fixes), mais aucun effet
+        /// indesirable si appele.
+        /// \param contentRelPath Chemin tel que passe a GetTexrThumb (ou
+        ///   "procedural:N" pour les builtins).
+        void Invalidate(const std::string& contentRelPath);
+
+        /// A appeler chaque frame en main thread. Met a jour le compteur interne et
+        /// detruit les entrees en pending depuis assez longtemps pour qu'aucune
+        /// command buffer en vol ne les reference.
+        /// \param currentFrameIndex Compteur de frame monotone (Engine::m_frameCounter).
+        /// \param framesInFlight Nombre maximum de frames en vol simultanees (kMaxFramesInFlight).
+        void Tick(uint64_t currentFrameIndex, uint32_t framesInFlight);
+
     private:
         bool             m_ready        = false;
         VkDevice         m_device       = nullptr;
@@ -136,6 +152,18 @@ namespace engine::editor
         /// Cles dont le decode a echoue : ne pas retenter avant Invalidate
         /// (evite spam logs). Reset par Invalidate (Task 9).
         std::unordered_set<std::string> m_negativeCache;
+
+        /// Entree marquee Invalidate, en attente de destruction.
+        struct PendingDelete
+        {
+            GpuPreview preview;
+            uint64_t   frameIndex = 0; // frame ou Invalidate a ete appele
+        };
+        std::vector<PendingDelete> m_pendingDeletes;
+
+        /// Frame du dernier Tick (sert d'horloge a Invalidate quand Tick n'a
+        /// pas encore ete appele de la frame courante).
+        uint64_t m_lastTickFrame = 0;
 
         /// Cle procedurale standardisee : "procedural:0".."procedural:3".
         static std::string ProceduralKey(uint32_t layer);

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // Forward decl Vulkan + ImGui (evite #include vulkan.h dans le .h pour
@@ -89,6 +90,15 @@ namespace engine::editor
         /// \return nullptr si Init non OK ou layer >= kSplatLayerCount.
         ImTextureID GetProceduralThumb(uint32_t layer);
 
+        /// Renvoie l'ImTextureID d'une .texr content-relative (ex: "textures/sand.texr").
+        /// 1re demande : decode (LoadTexrFile) -> resample 256x256 -> upload GPU
+        /// (CreateEntry). Suivantes : hit cache. Cache negatif (decode failed) =
+        /// nullptr renvoye jusqu'a Invalidate.
+        /// \param contentRelPath Chemin relatif au content dir (configure via Init).
+        /// \return nullptr si Init non OK, contentRelPath vide, fichier introuvable
+        ///   ou corrompu.
+        ImTextureID GetTexrThumb(const std::string& contentRelPath);
+
         /// Renvoie le buffer CPU 256x256 d'une key cachee (ou nullptr).
         /// Cles : "procedural:0".."procedural:3" pour les builtins,
         ///        "textures/<rel>" pour les .texr importees (Task 8).
@@ -122,6 +132,10 @@ namespace engine::editor
 
         /// key -> preview. Cles cf. doc de GetCpuRgba256.
         std::unordered_map<std::string, GpuPreview> m_entries;
+
+        /// Cles dont le decode a echoue : ne pas retenter avant Invalidate
+        /// (evite spam logs). Reset par Invalidate (Task 9).
+        std::unordered_set<std::string> m_negativeCache;
 
         /// Cle procedurale standardisee : "procedural:0".."procedural:3".
         static std::string ProceduralKey(uint32_t layer);

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -4,6 +4,19 @@
 #include <string>
 #include <vector>
 
+// Forward decl Vulkan + ImGui (evite #include vulkan.h dans le .h pour
+// reduire le compile time des consommateurs).
+struct VkDevice_T;         typedef VkDevice_T*         VkDevice;
+struct VkPhysicalDevice_T; typedef VkPhysicalDevice_T* VkPhysicalDevice;
+struct VkQueue_T;          typedef VkQueue_T*          VkQueue;
+struct VkSampler_T;        typedef VkSampler_T*        VkSampler;
+struct VkDescriptorPool_T; typedef VkDescriptorPool_T* VkDescriptorPool;
+struct VkImage_T;          typedef VkImage_T*          VkImage;
+struct VkImageView_T;      typedef VkImageView_T*      VkImageView;
+struct VkDeviceMemory_T;   typedef VkDeviceMemory_T*   VkDeviceMemory;
+struct VkDescriptorSet_T;  typedef VkDescriptorSet_T*  VkDescriptorSet;
+typedef void* ImTextureID;
+
 namespace engine::editor
 {
     /// Resample un buffer RGBA8 a une nouvelle resolution carree par box filter
@@ -37,4 +50,47 @@ namespace engine::editor
     bool LoadTexrFile(const std::string& absolutePath,
                       std::vector<uint8_t>& outRgba,
                       uint32_t& outWidth, uint32_t& outHeight);
+
+    /// Cache lazy de textures decodes + uploadees a 256x256 RGBA8 pour rendu
+    /// dans ImGui (vignettes editeur monde) et reupload du splat array terrain.
+    /// Possede par Engine, vit le temps du device Vulkan.
+    /// Win32 uniquement : sur autres plateformes, Init/Get* sont no-op et
+    /// IsReady reste false.
+    class TexturePreviewCache
+    {
+    public:
+        TexturePreviewCache() = default;
+        TexturePreviewCache(const TexturePreviewCache&) = delete;
+        TexturePreviewCache& operator=(const TexturePreviewCache&) = delete;
+        ~TexturePreviewCache();
+
+        /// Initialise sampler + descriptor pool. A appeler apres l'init du
+        /// device Vulkan et apres ImGui_ImplVulkan_Init.
+        /// \param contentDir Repertoire absolu pointant vers <content>/ (pour
+        ///   resoudre les chemins .texr content-relatifs lors des futurs
+        ///   GetTexrThumb).
+        /// \return true si succes. false sur autre plateforme que Win32 ou si
+        ///   les handles Vulkan sont invalides.
+        bool Init(VkDevice device, VkPhysicalDevice physDev,
+                  VkQueue queue, uint32_t queueFamilyIndex,
+                  const std::string& contentDir);
+
+        /// Detruit toutes les ressources Vulkan possedees. Idempotent.
+        void Shutdown();
+
+        /// True si Init a reussi et Shutdown n'a pas ete appele.
+        bool IsReady() const { return m_ready; }
+
+    private:
+        bool             m_ready        = false;
+        VkDevice         m_device       = nullptr;
+        VkPhysicalDevice m_physDev      = nullptr;
+        VkQueue          m_queue        = nullptr;
+        uint32_t         m_queueFamily  = 0;
+        std::string      m_contentDir;
+
+        VkSampler        m_sampler = nullptr;
+        VkDescriptorPool m_pool    = nullptr;
+    };
+
 } // namespace engine::editor

--- a/engine/editor/TexturePreviewCache.h
+++ b/engine/editor/TexturePreviewCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace engine::editor
@@ -16,4 +17,24 @@ namespace engine::editor
     /// \return true si succes ; false sur params invalides.
     bool ResampleRgba8Box(const uint8_t* src, uint32_t srcW, uint32_t srcH,
                           uint32_t dstSize, std::vector<uint8_t>& outRgba);
+
+    /// Decode un fichier .texr (magic TEXR + RGBA8) ou un PNG/JPG (via stb_image).
+    /// Le format .texr est defini dans engine/render/AssetRegistry.cpp :
+    ///   bytes 0..3 : magic 'TEXR' (0x52584554 LE)
+    ///   bytes 4..7 : width (uint32 LE)
+    ///   bytes 8..11: height (uint32 LE)
+    ///   bytes 12..15: sRGB flag (uint32 LE, 0 = lineaire, !=0 = sRGB)
+    ///   bytes 16.. : width*height*4 octets RGBA8
+    ///
+    /// \param absolutePath Chemin absolu sur disque (string UTF-8). Le caller
+    ///   est responsable de resoudre les chemins content-relatifs en absolus
+    ///   via Config::ResolveContentPath.
+    /// \param outRgba Buffer de sortie (width * height * 4 octets RGBA8).
+    /// \param outWidth Largeur du buffer decode.
+    /// \param outHeight Hauteur du buffer decode.
+    /// \return true si succes. false si fichier introuvable, magic invalide,
+    ///   buffer trop petit, ou erreur stb_image. LOG_ERROR emis. outRgba/outWidth/outHeight remis a zero.
+    bool LoadTexrFile(const std::string& absolutePath,
+                      std::vector<uint8_t>& outRgba,
+                      uint32_t& outWidth, uint32_t& outHeight);
 } // namespace engine::editor

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -1118,6 +1118,15 @@ namespace engine::editor
 				ImGui::SameLine(); ImGui::TextUnformatted("Ciel (horizon)");
 				ImGui::TextDisabled("La couleur de fond du viewport prend skyHorizon a chaque frame.");
 				ImGui::Separator();
+				// Bouton de secours : reset de la camera au-dessus du terrain courant
+				// (utile quand l'utilisateur signale "je ne vois plus le terrain"). On
+				// passe par le flag de session existant qui declenche RebuildTerrain
+				// + reset de la camera (cf. Engine.cpp::RebuildWorldEditorTerrainGpu).
+				if (m_session != nullptr && ImGui::Button("Recentrer la camera sur le terrain"))
+				{
+					m_session->RequestTerrainGpuReload();
+				}
+				ImGui::Separator();
 				// C5 - sauvegarde / chargement de l'atmosphere par zone.
 				// Boutons explicites : "Charger depuis carte" applique le timeOfDay+timeScale
 				// stockes dans la carte courante au DayNightCycle. "Sauver dans carte"

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -1117,6 +1117,42 @@ namespace engine::editor
 				ImGui::ColorButton("##skyHor", ImVec4(hor[0], hor[1], hor[2], 1.0f));
 				ImGui::SameLine(); ImGui::TextUnformatted("Ciel (horizon)");
 				ImGui::TextDisabled("La couleur de fond du viewport prend skyHorizon a chaque frame.");
+				ImGui::Separator();
+				// C5 - sauvegarde / chargement de l'atmosphere par zone.
+				// Boutons explicites : "Charger depuis carte" applique le timeOfDay+timeScale
+				// stockes dans la carte courante au DayNightCycle. "Sauver dans carte"
+				// capture les valeurs courantes du cycle vers le document de la carte
+				// (le save disque reel se fait via le panneau Carte > Sauvegarder).
+				if (m_session != nullptr)
+				{
+					ImGui::TextUnformatted("Atmosphere par zone :");
+					if (m_session->Doc().hasAtmosphere)
+					{
+						ImGui::Text("Sauvegarde dans carte : %.2fh @ %.0fs/h",
+							m_session->Doc().timeOfDayHours, m_session->Doc().timeScale);
+					}
+					else
+					{
+						ImGui::TextDisabled("Aucune atmosphere sauvegardee dans la carte courante.");
+					}
+					if (ImGui::Button("Charger depuis carte"))
+					{
+						if (m_session->Doc().hasAtmosphere)
+						{
+							m_dayNight->SetTime(static_cast<float>(m_session->Doc().timeOfDayHours));
+							m_dayNight->SetTimeScale(static_cast<float>(m_session->Doc().timeScale));
+						}
+					}
+					ImGui::SameLine();
+					if (ImGui::Button("Sauver dans carte"))
+					{
+						auto& docRef = m_session->MutableDoc();
+						docRef.hasAtmosphere = true;
+						docRef.timeOfDayHours = static_cast<double>(dn.timeOfDay);
+						docRef.timeScale = static_cast<double>(m_dayNight->GetTimeScale());
+					}
+					ImGui::TextDisabled("(Pour persister sur disque, panneau Carte > Sauvegarder)");
+				}
 			}
 			ImGui::End();
 

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/core/Config.h"
 #include "engine/core/Log.h"
+#include "engine/editor/TexturePreviewCache.h"
 #include "engine/editor/TreeSpeciesCatalog.h"
 #include "engine/editor/WorldEditorSession.h"
 #include "engine/render/DayNightCycle.h"
@@ -1224,6 +1225,33 @@ namespace engine::editor
 						itemsZ.push_back('\0');
 						for (int li = 0; li < 4; ++li)
 						{
+							ImGui::PushID(li);
+
+							// Vignette 48x48 a gauche du combo. Procedurale si
+							// ref vide, .texr resamplee sinon. Cellule grise
+							// si cache non pret ou decode echoue.
+							ImTextureID thumb = nullptr;
+							if (m_texturePreviewCache != nullptr)
+							{
+								if (refs[static_cast<size_t>(li)].empty())
+								{
+									thumb = m_texturePreviewCache->GetProceduralThumb(static_cast<uint32_t>(li));
+								}
+								else
+								{
+									thumb = m_texturePreviewCache->GetTexrThumb(refs[static_cast<size_t>(li)]);
+								}
+							}
+							if (thumb != nullptr)
+							{
+								ImGui::Image(thumb, ImVec2(48.0f, 48.0f));
+							}
+							else
+							{
+								ImGui::Dummy(ImVec2(48.0f, 48.0f));
+							}
+							ImGui::SameLine();
+
 							int sel = 0;
 							if (!refs[static_cast<size_t>(li)].empty())
 							{
@@ -1248,7 +1276,10 @@ namespace engine::editor
 								{
 									refs[static_cast<size_t>(li)] = imported[static_cast<size_t>(sel - 1)];
 								}
+								m_session->MarkSplatRefsDirty();  // declenche reupload GPU
 							}
+
+							ImGui::PopID();
 						}
 						ImGui::TextDisabled("Le mapping est persiste dans la carte (champ JSON splat_layer_texture_refs).");
 					}

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -1232,7 +1232,7 @@ namespace engine::editor
 							// Vignette 48x48 a gauche du combo. Procedurale si
 							// ref vide, .texr resamplee sinon. Cellule grise
 							// si cache non pret ou decode echoue.
-							ImTextureID thumb = nullptr;
+							ImTextureID thumb = 0;
 							if (m_texturePreviewCache != nullptr)
 							{
 								if (refs[static_cast<size_t>(li)].empty())
@@ -1244,7 +1244,7 @@ namespace engine::editor
 									thumb = m_texturePreviewCache->GetTexrThumb(refs[static_cast<size_t>(li)]);
 								}
 							}
-							if (thumb != nullptr)
+							if (thumb != 0)
 							{
 								ImGui::Image(thumb, ImVec2(48.0f, 48.0f));
 							}

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -4,6 +4,7 @@
 #include "engine/core/Log.h"
 #include "engine/editor/TreeSpeciesCatalog.h"
 #include "engine/editor/WorldEditorSession.h"
+#include "engine/render/DayNightCycle.h"
 #include "engine/platform/FileSystem.h"
 #include "engine/platform/Window.h"
 #include "engine/render/SharedFontHandles.h"
@@ -916,6 +917,7 @@ namespace engine::editor
 					// et cliquable au travers du DockSpace.
 					ImGui::DockBuilderDockWindow("Carte", idRight);
 					ImGui::DockBuilderDockWindow("Affichage & grille", idRight);
+					ImGui::DockBuilderDockWindow("Atmosphere", idRight);
 					ImGui::DockBuilderDockWindow("Import assets", idRight);
 					ImGui::DockBuilderDockWindow("Objets sur la carte", idRight);
 					ImGui::DockBuilderDockWindow("Scene", idRight);
@@ -1070,6 +1072,52 @@ namespace engine::editor
 				}
 			}
 			ImGui::TextUnformatted("La grille est dessinee en surimpression (projection camera) lorsque le terrain GPU est charge.");
+			ImGui::End();
+
+			// ── Panneau Atmosphere ─────────────────────────────────────────────────
+			// Permet a l'utilisateur de modifier en direct le cycle jour/nuit :
+			// time-of-day (0-24h), timeScale (vitesse du temps), et lecture des
+			// valeurs derivees (direction soleil, couleurs ciel zenith/horizon,
+			// ambient, isDaytime).
+			ImGui::Begin("Atmosphere");
+			if (m_dayNight == nullptr)
+			{
+				ImGui::TextDisabled("DayNightCycle non branche.");
+				ImGui::TextDisabled("(SetDayNightCycle pas appele depuis Engine)");
+			}
+			else
+			{
+				const engine::render::DayNightCycle::State& dn = m_dayNight->GetState();
+				float tod = dn.timeOfDay;
+				if (ImGui::SliderFloat("Heure (0-24)", &tod, 0.0f, 24.0f, "%.2f h"))
+				{
+					m_dayNight->SetTime(tod);
+				}
+				float ts = m_dayNight->GetTimeScale();
+				if (ImGui::SliderFloat("Vitesse temps (s/heure)", &ts, 0.1f, 600.0f, "%.1f"))
+				{
+					m_dayNight->SetTimeScale(ts);
+				}
+				ImGui::TextDisabled("60 = 1 min reel = 1 heure jeu (24 min reel = 1 jour jeu)");
+				ImGui::TextDisabled("3600 = temps reel 1:1 (24 h reel = 1 jour jeu)");
+				ImGui::Separator();
+				ImGui::TextUnformatted("Etat calcule (lecture seule) :");
+				ImGui::Text("Jour : %s", dn.isDaytime ? "oui (soleil)" : "non (lune)");
+				ImGui::Text("Direction soleil : (%.2f, %.2f, %.2f)", dn.lightDir[0], dn.lightDir[1], dn.lightDir[2]);
+				const float lightCol[3] = { dn.lightColor[0], dn.lightColor[1], dn.lightColor[2] };
+				ImGui::ColorButton("##lightCol", ImVec4(lightCol[0], lightCol[1], lightCol[2], 1.0f));
+				ImGui::SameLine(); ImGui::TextUnformatted("Couleur lumiere");
+				const float ambCol[3] = { dn.ambientColor[0], dn.ambientColor[1], dn.ambientColor[2] };
+				ImGui::ColorButton("##ambCol", ImVec4(ambCol[0], ambCol[1], ambCol[2], 1.0f));
+				ImGui::SameLine(); ImGui::TextUnformatted("Couleur ambiente");
+				const float zen[3] = { dn.skyZenith[0], dn.skyZenith[1], dn.skyZenith[2] };
+				ImGui::ColorButton("##skyZen", ImVec4(zen[0], zen[1], zen[2], 1.0f));
+				ImGui::SameLine(); ImGui::TextUnformatted("Ciel (zenith)");
+				const float hor[3] = { dn.skyHorizon[0], dn.skyHorizon[1], dn.skyHorizon[2] };
+				ImGui::ColorButton("##skyHor", ImVec4(hor[0], hor[1], hor[2], 1.0f));
+				ImGui::SameLine(); ImGui::TextUnformatted("Ciel (horizon)");
+				ImGui::TextDisabled("La couleur de fond du viewport prend skyHorizon a chaque frame.");
+			}
 			ImGui::End();
 
 			ImGui::Begin("Outils");

--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/core/Config.h"
 #include "engine/core/Log.h"
+#include "engine/editor/TextureLibraryPanel.h"
 #include "engine/editor/TexturePreviewCache.h"
 #include "engine/editor/TreeSpeciesCatalog.h"
 #include "engine/editor/WorldEditorSession.h"
@@ -760,6 +761,7 @@ namespace engine::editor
 						m_session->SetStatus("Disposition reinitialisee.");
 					}
 				}
+				ImGui::MenuItem("Bibliotheque de textures", nullptr, &m_showTextureLibrary);
 				ImGui::Separator();
 				if (m_cfg)
 				{
@@ -1618,6 +1620,12 @@ namespace engine::editor
 		if (viewportOverlay)
 		{
 			DrawViewportOverlaysImpl(*viewportOverlay);
+		}
+
+		// Panneau Bibliotheque de textures (toggle via menu Vue).
+		if (m_showTextureLibrary && m_session != nullptr)
+		{
+			engine::editor::DrawTextureLibrary(*m_session, m_texturePreviewCache, m_showTextureLibrary);
 		}
 
 		ImGui::Render();

--- a/engine/editor/WorldEditorImGui.h
+++ b/engine/editor/WorldEditorImGui.h
@@ -19,6 +19,7 @@ namespace engine::platform
 namespace engine::render
 {
 	class VkDeviceContext;
+	class DayNightCycle;
 }
 namespace engine::render::terrain
 {
@@ -96,6 +97,11 @@ namespace engine::editor
 		/// Contexte données éditeur (\c lcdlln_world_editor uniquement). Peut être nul.
 		void SetEditorContext(WorldEditorSession* session, engine::core::Config* cfg);
 
+		/// Branche le DayNightCycle pour que le panneau "Atmosphere" puisse modifier
+		/// la time-of-day, le timeScale et l'ambient en live. Pointeur non possede.
+		/// Nul si non branche -> panneau Atmosphere affiche un message d'attente.
+		void SetDayNightCycle(engine::render::DayNightCycle* dayNight) { m_dayNight = dayNight; }
+
 		/// Win32 : branche \c ImGui_ImplWin32_WndProcHandler avant le traitement LCDLLN.
 		void AttachPlatformWindow(void* hwndNative, engine::platform::Window& window);
 		void DetachPlatformWindow(engine::platform::Window& window);
@@ -116,6 +122,7 @@ namespace engine::editor
 		void* m_hwnd = nullptr;
 		WorldEditorSession* m_session = nullptr;
 		engine::core::Config* m_cfg = nullptr;
+		engine::render::DayNightCycle* m_dayNight = nullptr;
 		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
 		/// repassé à true après la pose.

--- a/engine/editor/WorldEditorImGui.h
+++ b/engine/editor/WorldEditorImGui.h
@@ -29,6 +29,7 @@ namespace engine::render::terrain
 namespace engine::editor
 {
 	class WorldEditorSession;
+	class TexturePreviewCache;  // vignettes splatting (Task 12)
 
 	/// Données pour dessiner grille + aperçu brosse par-dessus la vue 3D (avant \c ImGui::Render).
 	struct WorldEditorViewportOverlayDesc
@@ -102,6 +103,11 @@ namespace engine::editor
 		/// Nul si non branche -> panneau Atmosphere affiche un message d'attente.
 		void SetDayNightCycle(engine::render::DayNightCycle* dayNight) { m_dayNight = dayNight; }
 
+		/// Branche le cache de vignettes (possede par Engine). Pointeur non
+		/// possede. Si nul, les vignettes sont rendues comme cellules grises
+		/// (ImGui::Dummy 48x48) — l'UI reste fonctionnelle, juste sans previews.
+		void SetTexturePreviewCache(engine::editor::TexturePreviewCache* cache) { m_texturePreviewCache = cache; }
+
 		/// Win32 : branche \c ImGui_ImplWin32_WndProcHandler avant le traitement LCDLLN.
 		void AttachPlatformWindow(void* hwndNative, engine::platform::Window& window);
 		void DetachPlatformWindow(engine::platform::Window& window);
@@ -123,6 +129,8 @@ namespace engine::editor
 		WorldEditorSession* m_session = nullptr;
 		engine::core::Config* m_cfg = nullptr;
 		engine::render::DayNightCycle* m_dayNight = nullptr;
+		engine::editor::TexturePreviewCache* m_texturePreviewCache = nullptr;
+		bool m_showTextureLibrary = false;  // pilote par le menu Affichage (Task 14)
 		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
 		/// repassé à true après la pose.

--- a/engine/editor/WorldEditorSession.cpp
+++ b/engine/editor/WorldEditorSession.cpp
@@ -660,6 +660,14 @@ namespace engine::editor
 		{
 			m_doc.textureAssets.push_back(rel);
 		}
+		// Signal le re-import au cache de vignettes (Engine consomme la file).
+		m_recentlyImported.push_back(rel);
+		// Si la texture est referencee par un layer du splat, force aussi un
+		// reupload du splat array pour que la 3D refete la nouvelle version.
+		for (const std::string& r : m_doc.splatLayerTextureRefs)
+		{
+			if (r == rel) { m_splatRefsDirty = true; break; }
+		}
 		SetStatus("Texture importee: " + rel);
 		return true;
 	}

--- a/engine/editor/WorldEditorSession.cpp
+++ b/engine/editor/WorldEditorSession.cpp
@@ -386,16 +386,21 @@ namespace engine::editor
 			SetStatus("Carte creee mais sauvegarde JSON echouee: " + err);
 			LOG_WARN(Core, "[WorldEditor] {}", err);
 			RequestTerrainGpuReload();
-			m_splatRefsDirty = true;
+			// Note (debug regression terrain invisible) : on n'arme PAS m_splatRefsDirty
+			// ici. Sur carte neuve, RequestTerrainGpuReload() declenche un Init complet
+			// du splat array avec procedurales (cf. TerrainSplatting::Init). Un second
+			// rebuild via ProcessSplatRefsDirty serait redondant et semblait corrompre
+			// le rendu terrain. Pour les cartes chargees avec refs persistees on
+			// continue d'armer le flag (cf. ActionLoadMapByZoneId).
 			return true;
 		}
 		SetStatus("Nouvelle carte OK - " + hmRel);
 		RequestTerrainGpuReload();
 		SyncBuffersFromDoc();
 		LOG_INFO(Core, "[WorldEditor] New map OK zone={} size={}", zid, sz);
-		// Nouvelle carte : les refs sont remises a zero mais une session precedente
-		// peut avoir laisse un splat array GPU avec d'autres refs ; forcer le reupload.
-		m_splatRefsDirty = true;
+		// Pas de m_splatRefsDirty ici — voir explication ci-dessus dans la branche
+		// d'erreur de sauvegarde JSON. Init terrain pose deja les procedurales par
+		// defaut, pas besoin d'un second rebuild.
 		return true;
 	}
 

--- a/engine/editor/WorldEditorSession.cpp
+++ b/engine/editor/WorldEditorSession.cpp
@@ -386,12 +386,16 @@ namespace engine::editor
 			SetStatus("Carte creee mais sauvegarde JSON echouee: " + err);
 			LOG_WARN(Core, "[WorldEditor] {}", err);
 			RequestTerrainGpuReload();
+			m_splatRefsDirty = true;
 			return true;
 		}
 		SetStatus("Nouvelle carte OK - " + hmRel);
 		RequestTerrainGpuReload();
 		SyncBuffersFromDoc();
 		LOG_INFO(Core, "[WorldEditor] New map OK zone={} size={}", zid, sz);
+		// Nouvelle carte : les refs sont remises a zero mais une session precedente
+		// peut avoir laisse un splat array GPU avec d'autres refs ; forcer le reupload.
+		m_splatRefsDirty = true;
 		return true;
 	}
 
@@ -596,6 +600,8 @@ namespace engine::editor
 				break;
 			}
 		}
+		// Carte chargee : appliquer les splatLayerTextureRefs persistees au splat array GPU.
+		m_splatRefsDirty = true;
 		return true;
 	}
 

--- a/engine/editor/WorldEditorSession.h
+++ b/engine/editor/WorldEditorSession.h
@@ -131,6 +131,15 @@ namespace engine::editor
 		/// \return true une fois par demande consommee (pour l'Engine).
 		bool ConsumeTerrainGpuReloadRequest();
 
+		/// Marque les references de textures de layer (splatLayerTextureRefs)
+		/// comme modifiees. A appeler par les UIs apres avoir change un element
+		/// du tableau (combo Peindre, vignette Bibliotheque). Engine::ProcessSplatRefsDirty
+		/// consomme ce flag chaque frame pour reuploader le splat array GPU.
+		void MarkSplatRefsDirty() { m_splatRefsDirty = true; }
+
+		/// Lit + reset le flag splat refs. Utilise par Engine cote frame loop.
+		bool ConsumeSplatRefsDirty() { const bool d = m_splatRefsDirty; m_splatRefsDirty = false; return d; }
+
 	private:
 		void SanitizeAllLayoutInstancesAgainstTreeCatalog();
 
@@ -175,6 +184,7 @@ namespace engine::editor
 		std::function<bool(const engine::core::Config&, const WorldMapEditDocument&)> m_terrainSaveHook;
 
 		bool m_terrainGpuReloadRequested = false;
+		bool m_splatRefsDirty = false;
 
 		std::vector<std::string> m_availableMapIds;
 		int m_selectedAvailableMapIndex = 0;

--- a/engine/editor/WorldEditorSession.h
+++ b/engine/editor/WorldEditorSession.h
@@ -140,6 +140,14 @@ namespace engine::editor
 		/// Lit + reset le flag splat refs. Utilise par Engine cote frame loop.
 		bool ConsumeSplatRefsDirty() { const bool d = m_splatRefsDirty; m_splatRefsDirty = false; return d; }
 
+		/// Liste des .texr (chemins content-relatifs) reimportees depuis la
+		/// derniere consommation. Engine consomme via ConsumeRecentlyImportedTextures
+		/// et appelle TexturePreviewCache::Invalidate sur chaque entree.
+		const std::vector<std::string>& RecentlyImportedTextures() const { return m_recentlyImported; }
+
+		/// Vide la file (a appeler apres avoir invalide les vignettes correspondantes).
+		void ClearRecentlyImportedTextures() { m_recentlyImported.clear(); }
+
 	private:
 		void SanitizeAllLayoutInstancesAgainstTreeCatalog();
 
@@ -185,6 +193,8 @@ namespace engine::editor
 
 		bool m_terrainGpuReloadRequested = false;
 		bool m_splatRefsDirty = false;
+
+		std::vector<std::string> m_recentlyImported;
 
 		std::vector<std::string> m_availableMapIds;
 		int m_selectedAvailableMapIndex = 0;

--- a/engine/editor/WorldMapEditDocument.h
+++ b/engine/editor/WorldMapEditDocument.h
@@ -82,6 +82,16 @@ namespace engine::editor
 		/// expose deja la donnee pour que la creation de cartes avec eau soit possible des maintenant.
 		bool   waterEnabled    = false;
 		double waterLevelMeters = 0.0;
+
+		/// Atmosphere (C5) : etat du cycle jour/nuit sauvegarde par zone. Si
+		/// hasAtmosphere=true, l'editeur applique ces valeurs au DayNightCycle
+		/// au chargement de la carte, et les sauvegarde au save / export.
+		/// timeOfDayHours dans [0, 24) ; timeScale en secondes reelles par heure
+		/// in-game (60 = 24 min reel = 1 jour jeu, 3600 = 1:1 reel).
+		/// Persiste en JSON (cles \c atmosphere.time_of_day_h, \c atmosphere.time_scale).
+		bool   hasAtmosphere    = false;
+		double timeOfDayHours   = 8.0;
+		double timeScale        = 60.0;
 	};
 
 } // namespace engine::editor

--- a/engine/editor/WorldMapIo.cpp
+++ b/engine/editor/WorldMapIo.cpp
@@ -1297,11 +1297,22 @@ namespace engine::editor
 		out << "  \"water_level_m\": " << doc.waterLevelMeters << ",\n";
 		if (doc.hasTerrainWorldSizeM)
 		{
-			out << "  \"terrain_world_size_m\": " << doc.terrainWorldSizeM << "\n";
+			out << "  \"terrain_world_size_m\": " << doc.terrainWorldSizeM << ",\n";
 		}
 		else
 		{
-			out << "  \"terrain_world_size_m\": null\n";
+			out << "  \"terrain_world_size_m\": null,\n";
+		}
+		// Atmosphere (C5) : hasAtmosphere -> serialise time_of_day_h + time_scale.
+		// Sinon objet null pour signaler "utilise les valeurs par defaut DayNightCycle".
+		if (doc.hasAtmosphere)
+		{
+			out << "  \"atmosphere\": { \"time_of_day_h\": " << doc.timeOfDayHours
+			    << ", \"time_scale\": " << doc.timeScale << " }\n";
+		}
+		else
+		{
+			out << "  \"atmosphere\": null\n";
 		}
 		out << "}\n";
 		if (!out.good())
@@ -1449,6 +1460,28 @@ namespace engine::editor
 		if (!ParseOptionalTerrainWorldSizeM(json, d, outError))
 		{
 			return false;
+		}
+		// Atmosphere (C5) : optionnel, parse time_of_day_h et time_scale dans
+		// l'objet "atmosphere" si present. Cle absente ou null -> hasAtmosphere=false
+		// (le DayNightCycle utilise ses valeurs par defaut, pas d'override par zone).
+		{
+			d.hasAtmosphere = false;
+			double todH = 0.0;
+			double tScale = 0.0;
+			if (ParseJsonDoubleValue(json, "atmosphere.time_of_day_h", todH))
+			{
+				if (todH < 0.0) todH = 0.0;
+				if (todH >= 24.0) todH = 23.999;
+				d.timeOfDayHours = todH;
+				d.hasAtmosphere = true;
+			}
+			if (ParseJsonDoubleValue(json, "atmosphere.time_scale", tScale))
+			{
+				if (tScale < 0.1) tScale = 0.1;
+				if (tScale > 1000.0) tScale = 1000.0;
+				d.timeScale = tScale;
+				d.hasAtmosphere = true;
+			}
 		}
 		doc = std::move(d);
 		return true;

--- a/engine/editor/tests/TexturePreviewCacheTests.cpp
+++ b/engine/editor/tests/TexturePreviewCacheTests.cpp
@@ -1,0 +1,124 @@
+/// Tests unitaires pour les fonctions CPU pures de TexturePreviewCache :
+/// - ResampleRgba8Box (crop + box filter)
+/// - GenerateProceduralAlbedoLayer (deterministe)
+/// Pas de Vulkan ici : ces tests doivent tourner en CI sans GPU.
+
+#include "engine/editor/TexturePreviewCache.h"
+#include "engine/render/terrain/TerrainSplatting.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+    int g_failed = 0;
+
+    #define REQUIRE(cond) do { \
+        if (!(cond)) { \
+            std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+            ++g_failed; \
+        } \
+    } while (0)
+
+    /// 256x256 rouge uni -> 64x64 rouge uni (preserve la couleur).
+    void Test_ResampleDownsampleSquare()
+    {
+        std::vector<uint8_t> red(256u * 256u * 4u);
+        for (size_t p = 0; p < 256u * 256u; ++p)
+        {
+            red[p * 4u + 0] = 200u;
+            red[p * 4u + 1] = 50u;
+            red[p * 4u + 2] = 30u;
+            red[p * 4u + 3] = 255u;
+        }
+        std::vector<uint8_t> out;
+        REQUIRE(engine::editor::ResampleRgba8Box(red.data(), 256u, 256u, 64u, out));
+        REQUIRE(out.size() == 64u * 64u * 4u);
+        for (size_t p = 0; p < 64u * 64u; ++p)
+        {
+            REQUIRE(out[p * 4u + 0] == 200u);
+            REQUIRE(out[p * 4u + 1] == 50u);
+            REQUIRE(out[p * 4u + 2] == 30u);
+            REQUIRE(out[p * 4u + 3] == 255u);
+        }
+    }
+
+    /// 1024x512 -> 256x256 : crop centre. Carre central [256..768] = rouge,
+    /// hors-zone = bleu. Apres resample, attendu = rouge uniforme.
+    void Test_ResampleNonSquareCropsCenter()
+    {
+        const uint32_t W = 1024u, H = 512u;
+        std::vector<uint8_t> img(W * H * 4u);
+        for (uint32_t y = 0; y < H; ++y)
+        {
+            for (uint32_t x = 0; x < W; ++x)
+            {
+                const bool inSquare = (x >= 256u && x < 768u);
+                uint8_t* p = img.data() + (y * W + x) * 4u;
+                if (inSquare)
+                {
+                    p[0] = 200u; p[1] = 50u; p[2] = 30u; p[3] = 255u;
+                }
+                else
+                {
+                    p[0] = 30u; p[1] = 60u; p[2] = 200u; p[3] = 255u;
+                }
+            }
+        }
+        std::vector<uint8_t> out;
+        REQUIRE(engine::editor::ResampleRgba8Box(img.data(), W, H, 256u, out));
+        for (size_t p = 0; p < 256u * 256u; ++p)
+        {
+            REQUIRE(out[p * 4u + 0] == 200u);
+            REQUIRE(out[p * 4u + 1] == 50u);
+            REQUIRE(out[p * 4u + 2] == 30u);
+        }
+    }
+
+    /// GenerateProceduralAlbedoLayer doit etre deterministe.
+    void Test_GenerateProceduralDeterminism()
+    {
+        std::vector<uint8_t> a, b, c;
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 0u, a));
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 0u, b));
+        REQUIRE(engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 1u, c));
+        REQUIRE(a.size() == 64u * 64u * 4u);
+        REQUIRE(a == b);
+        REQUIRE(a != c);
+    }
+
+    void Test_GenerateProceduralInvalidParams()
+    {
+        std::vector<uint8_t> out;
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(64u, 4u, out));
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(2u, 0u, out));
+        REQUIRE(!engine::render::terrain::GenerateProceduralAlbedoLayer(8192u, 0u, out));
+    }
+
+    void Test_ResampleInvalidParams()
+    {
+        std::vector<uint8_t> out;
+        REQUIRE(!engine::editor::ResampleRgba8Box(nullptr, 64u, 64u, 32u, out));
+        std::vector<uint8_t> img(64u * 64u * 4u, 0u);
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 0u, 64u, 32u, out));
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 2u, out));
+        REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 8192u, out));
+    }
+} // namespace
+
+int main()
+{
+    Test_ResampleDownsampleSquare();
+    Test_ResampleNonSquareCropsCenter();
+    Test_GenerateProceduralDeterminism();
+    Test_GenerateProceduralInvalidParams();
+    Test_ResampleInvalidParams();
+    if (g_failed == 0)
+    {
+        std::fprintf(stdout, "[OK] all texture_preview_cache_tests passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "[FAIL] %d assertions failed\n", g_failed);
+    return 1;
+}

--- a/engine/editor/tests/TexturePreviewCacheTests.cpp
+++ b/engine/editor/tests/TexturePreviewCacheTests.cpp
@@ -8,6 +8,9 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <vector>
 
 namespace
@@ -105,6 +108,43 @@ namespace
         REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 2u, out));
         REQUIRE(!engine::editor::ResampleRgba8Box(img.data(), 64u, 64u, 8192u, out));
     }
+
+    /// Ecrit un .texr 4x4 RGBA8 dans tmp et le decode via LoadTexrFile.
+    void Test_LoadTexrRoundTrip()
+    {
+        const std::filesystem::path tmpPath =
+            std::filesystem::temp_directory_path() / "lcdlln_texr_test.texr";
+        std::vector<uint8_t> file;
+        const uint32_t magic = 0x52584554u;
+        const uint32_t w = 4u, h = 4u, srgb = 1u;
+        file.resize(16u + w * h * 4u);
+        std::memcpy(file.data() + 0,  &magic, 4);
+        std::memcpy(file.data() + 4,  &w,     4);
+        std::memcpy(file.data() + 8,  &h,     4);
+        std::memcpy(file.data() + 12, &srgb,  4);
+        for (size_t p = 0; p < w * h; ++p)
+        {
+            file[16u + p * 4u + 0] = 100u;
+            file[16u + p * 4u + 1] = 150u;
+            file[16u + p * 4u + 2] = 200u;
+            file[16u + p * 4u + 3] = 255u;
+        }
+        {
+            std::ofstream f(tmpPath, std::ios::binary);
+            f.write(reinterpret_cast<const char*>(file.data()),
+                    static_cast<long long>(file.size()));
+        }
+
+        std::vector<uint8_t> out;
+        uint32_t outW = 0, outH = 0;
+        REQUIRE(engine::editor::LoadTexrFile(tmpPath.string(), out, outW, outH));
+        REQUIRE(outW == 4u);
+        REQUIRE(outH == 4u);
+        REQUIRE(out.size() == 64u);
+        REQUIRE(out[0] == 100u && out[1] == 150u && out[2] == 200u && out[3] == 255u);
+
+        std::filesystem::remove(tmpPath);
+    }
 } // namespace
 
 int main()
@@ -114,6 +154,7 @@ int main()
     Test_GenerateProceduralDeterminism();
     Test_GenerateProceduralInvalidParams();
     Test_ResampleInvalidParams();
+    Test_LoadTexrRoundTrip();
     if (g_failed == 0)
     {
         std::fprintf(stdout, "[OK] all texture_preview_cache_tests passed\n");

--- a/engine/render/DayNightCycle.cpp
+++ b/engine/render/DayNightCycle.cpp
@@ -124,6 +124,18 @@ namespace engine::render
 		LOG_INFO(Render, "[DayNightCycle] SetTime → {:.2f}h", m_timeOfDay);
 	}
 
+	/// Met a jour le timeScale (secondes reelles par heure in-game). Borne a
+	/// [0.1, 1000.0] pour eviter les problemes de division ou wraparound. Appele
+	/// par le panneau "Atmosphere" de l'editeur monde quand l'utilisateur deplace
+	/// le slider de vitesse du temps.
+	void DayNightCycle::SetTimeScale(float realSecondsPerHour)
+	{
+		if (realSecondsPerHour < 0.1f) realSecondsPerHour = 0.1f;
+		if (realSecondsPerHour > 1000.0f) realSecondsPerHour = 1000.0f;
+		m_timeScale = realSecondsPerHour;
+		LOG_INFO(Render, "[DayNightCycle] SetTimeScale → {:.2f}s/h", m_timeScale);
+	}
+
 	// -------------------------------------------------------------------------
 	// DayNightCycle::ComputeState
 	// -------------------------------------------------------------------------

--- a/engine/render/DayNightCycle.h
+++ b/engine/render/DayNightCycle.h
@@ -78,6 +78,14 @@ namespace engine::render
 		/// Useful for the `/time set <hours>` debug command.
 		void SetTime(float hours);
 
+		/// Update the time scale (real seconds per in-game hour).
+		/// Used by the editor's "Atmosphere" panel slider. Clamps to [0.1, 1000.0]
+		/// to avoid divide-by-zero or wraparound issues.
+		void SetTimeScale(float realSecondsPerHour);
+
+		/// Return the current time scale (real seconds per in-game hour).
+		float GetTimeScale() const { return m_timeScale; }
+
 		/// Return the current computed state.
 		const State& GetState() const { return m_state; }
 

--- a/engine/render/LightingPass.cpp
+++ b/engine/render/LightingPass.cpp
@@ -266,7 +266,7 @@ namespace engine::render
 			VkPushConstantRange pushRange{};
 			pushRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 			pushRange.offset     = 0;
-			pushRange.size       = static_cast<uint32_t>(sizeof(LightParams)); // 132 bytes (M05.4 useIBL)
+			pushRange.size       = static_cast<uint32_t>(sizeof(LightParams)); // 148 bytes (skyColor ajouté)
 
 			VkPipelineLayoutCreateInfo layoutInfo{};
 			layoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;

--- a/engine/render/LightingPass.h
+++ b/engine/render/LightingPass.h
@@ -19,8 +19,8 @@ namespace engine::render
 	///
 	/// Pipeline: fullscreen triangle (3 vertices, no vertex buffer).
 		/// Descriptor set 0: 9 combined image samplers (GBufA, GBufB, GBufC, Depth, irradiance,
-		/// prefiltered specular, BRDF LUT, SSAO_Blur, DecalOverlay). Push constants (132 bytes): invVP, cameraPos,
-	/// lightDir, lightColor, ambientColor, useIBL.
+		/// prefiltered specular, BRDF LUT, SSAO_Blur, DecalOverlay). Push constants (148 bytes): invVP, cameraPos,
+	/// lightDir, lightColor, ambientColor, skyColor, useIBL.
 	class LightingPass
 	{
 	public:
@@ -34,9 +34,10 @@ namespace engine::render
 			float lightDir[4];    ///< Normalized direction *toward* the light, xyz, w unused.
 			float lightColor[4];   ///< RGB radiance (color * intensity), w unused.
 			float ambientColor[4]; ///< Constant ambient RGB, w unused (fallback when IBL absent).
+			float skyColor[4];     ///< RGB couleur du ciel (skyHorizon DayNightCycle) pour les pixels sans géométrie. w unused.
 			float useIBL;          ///< 1.0 = use IBL (irradiance + prefilter + BRDF LUT), 0.0 = fallback.
 		};
-		static_assert(sizeof(LightParams) == 132, "LightParams must be exactly 132 bytes");
+		static_assert(sizeof(LightParams) == 148, "LightParams must be exactly 148 bytes");
 
 		LightingPass() = default;
 		LightingPass(const LightingPass&) = delete;

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -466,10 +466,10 @@ namespace engine::render::terrain
         // ne supporte que 4 canaux (4 layers) : on garde grass/dirt/rock/snow,
         // qui couvrent les biomes les plus communs (sable = layer dirt jaunifie
         // plus tard via un splat custom). Pour avoir des materiaux visuellement
-        // convaincants (au lieu de tuiles 4x4 unies), on genere 64x64 textures
-        // procedurales avec du bruit deterministe par layer.
-        constexpr uint32_t kTexW = 64u;
-        constexpr uint32_t kTexH = 64u;
+        // convaincants (au lieu de tuiles 4x4 unies), on genere kSplatLayerResolution x
+        // kSplatLayerResolution textures procedurales avec du bruit deterministe par layer.
+        constexpr uint32_t kTexW = kSplatLayerResolution;
+        constexpr uint32_t kTexH = kSplatLayerResolution;
         constexpr uint32_t kPixels = kTexW * kTexH;
 
         // Flat normal (pointing up in tangent space: RGB=128,128,255)

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -288,6 +288,7 @@ namespace engine::render::terrain
     {
         if (layer >= kSplatLayerCount || resolution < 4u || resolution > 4096u)
         {
+            outRgba.clear();
             return false;
         }
 
@@ -315,6 +316,12 @@ namespace engine::render::terrain
         const uint32_t pixels = resolution * resolution;
         outRgba.resize(static_cast<size_t>(pixels) * 4u);
 
+        auto clampU8 = [](float v) -> uint8_t {
+            if (v < 0.0f) v = 0.0f;
+            if (v > 255.0f) v = 255.0f;
+            return static_cast<uint8_t>(v);
+        };
+
         for (uint32_t y = 0; y < resolution; ++y)
         {
             for (uint32_t x = 0; x < resolution; ++x)
@@ -323,11 +330,6 @@ namespace engine::render::terrain
                 const float macro = hashNoise(x / mc, y / mc, layer + 1000u);
                 const float n = (micro * 0.6f + macro * 0.4f) * 2.0f - 1.0f;
                 const float delta = n * amp;
-                auto clampU8 = [](float v) -> uint8_t {
-                    if (v < 0.0f) v = 0.0f;
-                    if (v > 255.0f) v = 255.0f;
-                    return static_cast<uint8_t>(v);
-                };
                 uint8_t* dst = outRgba.data() + (y * resolution + x) * 4u;
                 dst[0] = clampU8(static_cast<float>(col[0]) + delta);
                 dst[1] = clampU8(static_cast<float>(col[1]) + delta);

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -400,18 +400,49 @@ namespace engine::render::terrain
         }
 
         // ── Build placeholder texture arrays ──────────────────────────────────────
-        // Each array layer is a 4×4 solid-colour tile. Layers: grass, dirt, rock, snow.
-        constexpr uint32_t kTexW = 4u;
-        constexpr uint32_t kTexH = 4u;
+        // Demande utilisateur : "inclure par defaut deja un certain nombre de
+        // texture ... herbe, terre, sable, neige, cailloux". Le splatmap RGBA8
+        // ne supporte que 4 canaux (4 layers) : on garde grass/dirt/rock/snow,
+        // qui couvrent les biomes les plus communs (sable = layer dirt jaunifie
+        // plus tard via un splat custom). Pour avoir des materiaux visuellement
+        // convaincants (au lieu de tuiles 4x4 unies), on genere 64x64 textures
+        // procedurales avec du bruit deterministe par layer.
+        constexpr uint32_t kTexW = 64u;
+        constexpr uint32_t kTexH = 64u;
         constexpr uint32_t kPixels = kTexW * kTexH;
 
-        // Layer albedo colours (RGBA8, sRGB-ish but stored linear for GPU)
-        // 0=grass, 1=dirt, 2=rock, 3=snow
+        // Couleurs de base (RGBA8 lineaire) : 0=grass, 1=dirt, 2=rock, 3=snow.
+        // Choisies pour etre visiblement distinctes meme sous un eclairage faible.
         static const uint8_t kAlbedo[kSplatLayerCount][4] = {
-            {  89u, 140u,  51u, 255u },   // grass — green
-            { 128u,  82u,  38u, 255u },   // dirt  — brown
-            { 128u, 107u,  82u, 255u },   // rock  — grey-brown
-            { 242u, 242u, 250u, 255u },   // snow  — near-white
+            {  89u, 140u,  51u, 255u },   // grass — vert moyen
+            { 128u,  82u,  38u, 255u },   // dirt  — terre brune
+            { 128u, 107u,  82u, 255u },   // rock  — gris-brun
+            { 242u, 242u, 250u, 255u },   // snow  — blanc presque pur
+        };
+
+        // Amplitude de variation par layer (intensite du bruit ajoute).
+        // grass = forte variation (touffes), dirt = grosse variation (crevasses),
+        // rock = variation pointue (cailloux), snow = legere variation.
+        static const uint8_t kAmplitude[kSplatLayerCount] = { 38u, 28u, 50u, 12u };
+
+        // Hash de bruit deterministe : retourne un float [0,1) pour (x, y, layer).
+        // Pas de dependance sur stdlib random, pour un output reproductible.
+        auto hashNoise = [](uint32_t x, uint32_t y, uint32_t seed) -> float {
+            uint32_t h = x * 0x27d4eb2du ^ y * 0x165667b1u ^ seed * 0x9e3779b9u;
+            h ^= h >> 15; h *= 0x85ebca6bu;
+            h ^= h >> 13; h *= 0xc2b2ae35u;
+            h ^= h >> 16;
+            return static_cast<float>(h & 0xFFFFFFu) / static_cast<float>(0x1000000u);
+        };
+
+        // Bruit cellulaire simple : on calcule un noise + un noise plus grossier
+        // pour avoir des macro/micro details. Renvoie [-1, +1].
+        auto layerNoise = [&](uint32_t x, uint32_t y, uint32_t layer, uint32_t macroCellSize) -> float {
+            const float micro = hashNoise(x, y, layer);
+            const uint32_t mx = x / macroCellSize;
+            const uint32_t my = y / macroCellSize;
+            const float macro = hashNoise(mx, my, layer + 1000u);
+            return (micro * 0.6f + macro * 0.4f) * 2.0f - 1.0f;
         };
 
         // Flat normal (pointing up in tangent space: RGB=128,128,255)
@@ -426,10 +457,27 @@ namespace engine::render::terrain
             for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
             {
                 const uint8_t* col = kAlbedo[layer];
-                for (uint32_t p = 0; p < kPixels; ++p)
+                const float amp = static_cast<float>(kAmplitude[layer]);
+                // Macro cell size : grass=8 (touffes serrees), dirt=12, rock=4 (cailloux fins), snow=16 (zones lisses)
+                static const uint32_t kMacroCell[kSplatLayerCount] = { 8u, 12u, 4u, 16u };
+                const uint32_t mc = kMacroCell[layer];
+                for (uint32_t y = 0; y < kTexH; ++y)
                 {
-                    uint8_t* dst = albedoData.data() + (layer * kPixels + p) * 4u;
-                    dst[0] = col[0]; dst[1] = col[1]; dst[2] = col[2]; dst[3] = col[3];
+                    for (uint32_t x = 0; x < kTexW; ++x)
+                    {
+                        const float n = layerNoise(x, y, layer, mc); // [-1, +1]
+                        const float delta = n * amp;
+                        auto clampU8 = [](float v) -> uint8_t {
+                            if (v < 0.0f) v = 0.0f;
+                            if (v > 255.0f) v = 255.0f;
+                            return static_cast<uint8_t>(v);
+                        };
+                        uint8_t* dst = albedoData.data() + (layer * kPixels + y * kTexW + x) * 4u;
+                        dst[0] = clampU8(static_cast<float>(col[0]) + delta);
+                        dst[1] = clampU8(static_cast<float>(col[1]) + delta);
+                        dst[2] = clampU8(static_cast<float>(col[2]) + delta);
+                        dst[3] = 255u;
+                    }
                 }
             }
             if (!UploadTextureArray(device, physDev, albedoData, kTexW, kTexH, kSplatLayerCount,
@@ -441,7 +489,7 @@ namespace engine::render::terrain
             }
         }
 
-        // Build normal array data
+        // Build normal array data (flat normals for now, all layers point up).
         {
             std::vector<uint8_t> normalData(kSplatLayerCount * kPixels * 4u);
             for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
@@ -479,7 +527,7 @@ namespace engine::render::terrain
         }
 
         LOG_INFO(Render,
-            "[TerrainSplatting] Init OK (splatmap={}x{}, texArrays={}x{}x{}layers)",
+            "[TerrainSplatting] Init OK (splatmap={}x{}, texArrays={}x{}x{}layers, procedural noise)",
             kSplatW, kSplatH, kTexW, kTexH, kSplatLayerCount);
         return true;
     }

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -280,6 +280,65 @@ namespace engine::render::terrain
     } // namespace
 
     // ─────────────────────────────────────────────────────────────────────────────
+    // GenerateProceduralAlbedoLayer (free function)
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
+                                       std::vector<uint8_t>& outRgba)
+    {
+        if (layer >= kSplatLayerCount || resolution < 4u || resolution > 4096u)
+        {
+            return false;
+        }
+
+        // Couleurs de base par layer (identiques au boot TerrainSplatting).
+        static const uint8_t kAlbedo[kSplatLayerCount][4] = {
+            {  89u, 140u,  51u, 255u },   // grass
+            { 128u,  82u,  38u, 255u },   // dirt
+            { 128u, 107u,  82u, 255u },   // rock
+            { 242u, 242u, 250u, 255u },   // snow
+        };
+        static const uint8_t kAmplitude[kSplatLayerCount] = { 38u, 28u, 50u, 12u };
+        static const uint32_t kMacroCell[kSplatLayerCount] = { 8u, 12u, 4u, 16u };
+
+        auto hashNoise = [](uint32_t x, uint32_t y, uint32_t seed) -> float {
+            uint32_t h = x * 0x27d4eb2du ^ y * 0x165667b1u ^ seed * 0x9e3779b9u;
+            h ^= h >> 15; h *= 0x85ebca6bu;
+            h ^= h >> 13; h *= 0xc2b2ae35u;
+            h ^= h >> 16;
+            return static_cast<float>(h & 0xFFFFFFu) / static_cast<float>(0x1000000u);
+        };
+
+        const uint8_t* col = kAlbedo[layer];
+        const float amp = static_cast<float>(kAmplitude[layer]);
+        const uint32_t mc = kMacroCell[layer];
+        const uint32_t pixels = resolution * resolution;
+        outRgba.resize(static_cast<size_t>(pixels) * 4u);
+
+        for (uint32_t y = 0; y < resolution; ++y)
+        {
+            for (uint32_t x = 0; x < resolution; ++x)
+            {
+                const float micro = hashNoise(x, y, layer);
+                const float macro = hashNoise(x / mc, y / mc, layer + 1000u);
+                const float n = (micro * 0.6f + macro * 0.4f) * 2.0f - 1.0f;
+                const float delta = n * amp;
+                auto clampU8 = [](float v) -> uint8_t {
+                    if (v < 0.0f) v = 0.0f;
+                    if (v > 255.0f) v = 255.0f;
+                    return static_cast<uint8_t>(v);
+                };
+                uint8_t* dst = outRgba.data() + (y * resolution + x) * 4u;
+                dst[0] = clampU8(static_cast<float>(col[0]) + delta);
+                dst[1] = clampU8(static_cast<float>(col[1]) + delta);
+                dst[2] = clampU8(static_cast<float>(col[2]) + delta);
+                dst[3] = 255u;
+            }
+        }
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
     // TerrainSplatting::GetLayerTiling
     // ─────────────────────────────────────────────────────────────────────────────
 
@@ -411,74 +470,26 @@ namespace engine::render::terrain
         constexpr uint32_t kTexH = 64u;
         constexpr uint32_t kPixels = kTexW * kTexH;
 
-        // Couleurs de base (RGBA8 lineaire) : 0=grass, 1=dirt, 2=rock, 3=snow.
-        // Choisies pour etre visiblement distinctes meme sous un eclairage faible.
-        static const uint8_t kAlbedo[kSplatLayerCount][4] = {
-            {  89u, 140u,  51u, 255u },   // grass — vert moyen
-            { 128u,  82u,  38u, 255u },   // dirt  — terre brune
-            { 128u, 107u,  82u, 255u },   // rock  — gris-brun
-            { 242u, 242u, 250u, 255u },   // snow  — blanc presque pur
-        };
-
-        // Amplitude de variation par layer (intensite du bruit ajoute).
-        // grass = forte variation (touffes), dirt = grosse variation (crevasses),
-        // rock = variation pointue (cailloux), snow = legere variation.
-        static const uint8_t kAmplitude[kSplatLayerCount] = { 38u, 28u, 50u, 12u };
-
-        // Hash de bruit deterministe : retourne un float [0,1) pour (x, y, layer).
-        // Pas de dependance sur stdlib random, pour un output reproductible.
-        auto hashNoise = [](uint32_t x, uint32_t y, uint32_t seed) -> float {
-            uint32_t h = x * 0x27d4eb2du ^ y * 0x165667b1u ^ seed * 0x9e3779b9u;
-            h ^= h >> 15; h *= 0x85ebca6bu;
-            h ^= h >> 13; h *= 0xc2b2ae35u;
-            h ^= h >> 16;
-            return static_cast<float>(h & 0xFFFFFFu) / static_cast<float>(0x1000000u);
-        };
-
-        // Bruit cellulaire simple : on calcule un noise + un noise plus grossier
-        // pour avoir des macro/micro details. Renvoie [-1, +1].
-        auto layerNoise = [&](uint32_t x, uint32_t y, uint32_t layer, uint32_t macroCellSize) -> float {
-            const float micro = hashNoise(x, y, layer);
-            const uint32_t mx = x / macroCellSize;
-            const uint32_t my = y / macroCellSize;
-            const float macro = hashNoise(mx, my, layer + 1000u);
-            return (micro * 0.6f + macro * 0.4f) * 2.0f - 1.0f;
-        };
-
         // Flat normal (pointing up in tangent space: RGB=128,128,255)
         static const uint8_t kNormal[4] = { 128u, 128u, 255u, 255u };
 
         // ORM: R=AO(255=1.0), G=Roughness(204≈0.8), B=Metallic(0)
         static const uint8_t kORM[4] = { 255u, 204u, 0u, 255u };
 
-        // Build albedo array data (layerCount × width × height × 4 bytes)
+        // Build albedo array data via la free function GenerateProceduralAlbedoLayer.
         {
             std::vector<uint8_t> albedoData(kSplatLayerCount * kPixels * 4u);
+            std::vector<uint8_t> oneLayer;
             for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
             {
-                const uint8_t* col = kAlbedo[layer];
-                const float amp = static_cast<float>(kAmplitude[layer]);
-                // Macro cell size : grass=8 (touffes serrees), dirt=12, rock=4 (cailloux fins), snow=16 (zones lisses)
-                static const uint32_t kMacroCell[kSplatLayerCount] = { 8u, 12u, 4u, 16u };
-                const uint32_t mc = kMacroCell[layer];
-                for (uint32_t y = 0; y < kTexH; ++y)
+                if (!GenerateProceduralAlbedoLayer(kTexW, layer, oneLayer))
                 {
-                    for (uint32_t x = 0; x < kTexW; ++x)
-                    {
-                        const float n = layerNoise(x, y, layer, mc); // [-1, +1]
-                        const float delta = n * amp;
-                        auto clampU8 = [](float v) -> uint8_t {
-                            if (v < 0.0f) v = 0.0f;
-                            if (v > 255.0f) v = 255.0f;
-                            return static_cast<uint8_t>(v);
-                        };
-                        uint8_t* dst = albedoData.data() + (layer * kPixels + y * kTexW + x) * 4u;
-                        dst[0] = clampU8(static_cast<float>(col[0]) + delta);
-                        dst[1] = clampU8(static_cast<float>(col[1]) + delta);
-                        dst[2] = clampU8(static_cast<float>(col[2]) + delta);
-                        dst[3] = 255u;
-                    }
+                    LOG_ERROR(Render, "[TerrainSplatting] GenerateProceduralAlbedoLayer({},{}) failed", kTexW, layer);
+                    Destroy(device);
+                    return false;
                 }
+                std::memcpy(albedoData.data() + layer * kPixels * 4u,
+                            oneLayer.data(), kPixels * 4u);
             }
             if (!UploadTextureArray(device, physDev, albedoData, kTexW, kTexH, kSplatLayerCount,
                                     queue, queueFamilyIndex, m_albedoArray))

--- a/engine/render/terrain/TerrainSplatting.cpp
+++ b/engine/render/terrain/TerrainSplatting.cpp
@@ -957,4 +957,189 @@ namespace engine::render::terrain
         g.width = g.height = g.layerCount = 0;
     }
 
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::SetLayerCpuRgba256
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    void TerrainSplatting::SetLayerCpuRgba256(uint32_t layer, const std::vector<uint8_t>& rgba)
+    {
+        if (layer >= kSplatLayerCount)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] SetLayerCpuRgba256: layer {} out of range", layer);
+            return;
+        }
+        const size_t expected = static_cast<size_t>(kSplatLayerResolution) * kSplatLayerResolution * 4u;
+        if (rgba.size() != expected)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] SetLayerCpuRgba256: rgba size {} != expected {} ({}x{}x4)",
+                      rgba.size(), expected, kSplatLayerResolution, kSplatLayerResolution);
+            return;
+        }
+        m_layerCpuData[layer] = rgba;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::RebuildAlbedoArrayFromCpuLayers
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::RebuildAlbedoArrayFromCpuLayers(VkDevice device, VkPhysicalDevice physDev,
+                                                            VkQueue queue, uint32_t queueFamilyIndex)
+    {
+        if (m_albedoArray.image == VK_NULL_HANDLE)
+        {
+            LOG_ERROR(Render, "[TerrainSplatting] RebuildAlbedoArrayFromCpuLayers: array not initialized");
+            return false;
+        }
+        const uint32_t res = kSplatLayerResolution;
+        const size_t layerBytes = static_cast<size_t>(res) * res * 4u;
+        std::vector<uint8_t> packed(static_cast<size_t>(kSplatLayerCount) * layerBytes);
+        std::vector<uint8_t> tmpProc;
+
+        for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+        {
+            const uint8_t* srcLayer = nullptr;
+            if (m_layerCpuData[layer].size() == layerBytes)
+            {
+                srcLayer = m_layerCpuData[layer].data();
+            }
+            else
+            {
+                if (!GenerateProceduralAlbedoLayer(res, layer, tmpProc))
+                {
+                    LOG_ERROR(Render, "[TerrainSplatting] Rebuild: procedural fallback failed for layer {}", layer);
+                    return false;
+                }
+                srcLayer = tmpProc.data();
+            }
+            std::memcpy(packed.data() + layer * layerBytes, srcLayer, layerBytes);
+        }
+
+        // Staging buffer + copy via existing internal helper.
+        VkBuffer staging = VK_NULL_HANDLE;
+        VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+        if (!CreateStagingBuffer(device, physDev, packed.size(), staging, stagingMem))
+        {
+            return false;
+        }
+        void* mapped = nullptr;
+        if (vkMapMemory(device, stagingMem, 0, packed.size(), 0, &mapped) != VK_SUCCESS)
+        {
+            vkDestroyBuffer(device, staging, nullptr);
+            vkFreeMemory(device, stagingMem, nullptr);
+            return false;
+        }
+        std::memcpy(mapped, packed.data(), packed.size());
+        vkUnmapMemory(device, stagingMem);
+
+        // Build copy regions (1 per layer).
+        std::vector<VkBufferImageCopy> regions(kSplatLayerCount);
+        for (uint32_t layer = 0; layer < kSplatLayerCount; ++layer)
+        {
+            VkBufferImageCopy& r = regions[layer];
+            r = {};
+            r.bufferOffset = layer * layerBytes;
+            r.bufferRowLength = 0;
+            r.bufferImageHeight = 0;
+            r.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            r.imageSubresource.mipLevel = 0;
+            r.imageSubresource.baseArrayLayer = layer;
+            r.imageSubresource.layerCount = 1;
+            r.imageOffset = { 0, 0, 0 };
+            r.imageExtent = { res, res, 1 };
+        }
+
+        const bool ok = ReuploadAlbedoArrayInternal(device, queue, queueFamilyIndex,
+                                                     staging, regions);
+        vkDestroyBuffer(device, staging, nullptr);
+        vkFreeMemory(device, stagingMem, nullptr);
+        return ok;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // TerrainSplatting::ReuploadAlbedoArrayInternal
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    bool TerrainSplatting::ReuploadAlbedoArrayInternal(VkDevice device, VkQueue queue,
+                                                        uint32_t queueFamilyIndex,
+                                                        VkBuffer staging,
+                                                        const std::vector<VkBufferImageCopy>& regions)
+    {
+        VkCommandPool pool = VK_NULL_HANDLE;
+        VkCommandPoolCreateInfo poolCI{};
+        poolCI.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolCI.queueFamilyIndex = queueFamilyIndex;
+        poolCI.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        if (vkCreateCommandPool(device, &poolCI, nullptr, &pool) != VK_SUCCESS) return false;
+
+        VkCommandBuffer cmd = VK_NULL_HANDLE;
+        VkCommandBufferAllocateInfo aci{};
+        aci.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        aci.commandPool = pool;
+        aci.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        aci.commandBufferCount = 1;
+        if (vkAllocateCommandBuffers(device, &aci, &cmd) != VK_SUCCESS)
+        {
+            vkDestroyCommandPool(device, pool, nullptr);
+            return false;
+        }
+
+        VkCommandBufferBeginInfo bi{};
+        bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(cmd, &bi);
+
+        // Barrier SHADER_READ_ONLY -> TRANSFER_DST pour tous les layers.
+        {
+            VkImageMemoryBarrier b{};
+            b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image = m_albedoArray.image;
+            b.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, kSplatLayerCount };
+            b.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            b.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        vkCmdCopyBufferToImage(cmd, staging, m_albedoArray.image,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               static_cast<uint32_t>(regions.size()), regions.data());
+
+        // Barrier TRANSFER_DST -> SHADER_READ_ONLY pour tous les layers.
+        {
+            VkImageMemoryBarrier b{};
+            b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            b.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.image = m_albedoArray.image;
+            b.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, kSplatLayerCount };
+            b.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            b.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &b);
+        }
+
+        vkEndCommandBuffer(cmd);
+
+        VkSubmitInfo si{};
+        si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        si.commandBufferCount = 1;
+        si.pCommandBuffers = &cmd;
+        if (vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE) != VK_SUCCESS)
+        {
+            vkDestroyCommandPool(device, pool, nullptr);
+            return false;
+        }
+        vkQueueWaitIdle(queue);
+        vkDestroyCommandPool(device, pool, nullptr);
+        return true;
+    }
+
 } // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -16,9 +16,13 @@ namespace engine::render::terrain
 
     /// Resolution (carre) des layers du texture array albedo. Constante a la
     /// compilation : si on veut configurer plus tard, exposer via Config.
-    /// 256x256 = sweet spot qualite/memoire pour terrain MMO (cf. spec
-    /// 2026-05-04-editor-texture-previews-design.md, section 3).
-    static constexpr uint32_t kSplatLayerResolution = 256u;
+    /// 64x64 = baseline historique qui rend correctement le terrain. Tentative
+    /// de promotion a 256x256 (commit b612948) cassait le rendu (terrain
+    /// invisible, seules les lignes de grille editeur visibles). Cause non
+    /// identifiee — possible incompatibilite shader/format ou descriptor.
+    /// A reinvestiguer separement avant nouvelle promotion. Cf. PR refactor
+    /// editor-terrain-textures-skybox.
+    static constexpr uint32_t kSplatLayerResolution = 64u;
 
     /// Génère un layer RGBA8 procédural (bruit déterministe par layer).
     /// Algorithme : combinaison micro/macro de hash xx-style, identique au boot

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -19,7 +19,7 @@ namespace engine::render::terrain
     /// \param resolution Côté en pixels (carré). Min 4, max 4096.
     /// \param layer 0=grass, 1=dirt, 2=rock, 3=snow.
     /// \param outRgba Sortie : resolution * resolution * 4 octets, RGBA8 sRGB.
-    /// \return false si layer >= kSplatLayerCount ou resolution < 4.
+    /// \return false si layer >= kSplatLayerCount, resolution < 4 ou resolution > 4096.
     bool GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
                                        std::vector<uint8_t>& outRgba);
 

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -16,13 +16,14 @@ namespace engine::render::terrain
 
     /// Resolution (carre) des layers du texture array albedo. Constante a la
     /// compilation : si on veut configurer plus tard, exposer via Config.
-    /// 64x64 = baseline historique qui rend correctement le terrain. Tentative
-    /// de promotion a 256x256 (commit b612948) cassait le rendu (terrain
-    /// invisible, seules les lignes de grille editeur visibles). Cause non
-    /// identifiee — possible incompatibilite shader/format ou descriptor.
-    /// A reinvestiguer separement avant nouvelle promotion. Cf. PR refactor
-    /// editor-terrain-textures-skybox.
-    static constexpr uint32_t kSplatLayerResolution = 64u;
+    /// 256x256 = sweet spot qualite/memoire pour terrain MMO (cf. spec
+    /// 2026-05-04-editor-texture-previews-design.md, section 3).
+    ///
+    /// NOTE : le terrain n'est actuellement pas rendu dans l'editeur monde
+    /// (bug pre-existant, anterieur a la PR texture-previews). Quand ce bug
+    /// sera fixe, cette resolution s'appliquera automatiquement aux textures
+    /// du splat array. La feature texture-previews fonctionne independamment.
+    static constexpr uint32_t kSplatLayerResolution = 256u;
 
     /// Génère un layer RGBA8 procédural (bruit déterministe par layer).
     /// Algorithme : combinaison micro/macro de hash xx-style, identique au boot

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -13,6 +13,12 @@ namespace engine::render::terrain
     /// Number of splat layers (grass, dirt, rock, snow).
     static constexpr uint32_t kSplatLayerCount = 4u;
 
+    /// Resolution (carre) des layers du texture array albedo. Constante a la
+    /// compilation : si on veut configurer plus tard, exposer via Config.
+    /// 256x256 = sweet spot qualite/memoire pour terrain MMO (cf. spec
+    /// 2026-05-04-editor-texture-previews-design.md, section 3).
+    static constexpr uint32_t kSplatLayerResolution = 256u;
+
     /// Génère un layer RGBA8 procédural (bruit déterministe par layer).
     /// Algorithme : combinaison micro/macro de hash xx-style, identique au boot
     /// de TerrainSplatting (cf. b93a14d). Mêmes octets exacts pour mêmes paramètres.

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -129,6 +130,28 @@ namespace engine::render::terrain
         bool ReuploadSplatMap(VkDevice device, VkPhysicalDevice physDev,
                               VkQueue queue, uint32_t queueFamilyIndex);
 
+        /// Stocke un buffer CPU RGBA8 kSplatLayerResolution^2 pour le layer
+        /// donne. Le buffer doit faire exactement
+        /// kSplatLayerResolution * kSplatLayerResolution * 4 octets — sinon
+        /// l'appel est ignore (LOG_ERROR). N'uploade pas tout de suite : il
+        /// faut appeler RebuildAlbedoArrayFromCpuLayers ensuite.
+        /// \param layer 0..kSplatLayerCount-1.
+        /// \param rgba Pixels RGBA8 row-major.
+        void SetLayerCpuRgba256(uint32_t layer, const std::vector<uint8_t>& rgba);
+
+        /// Repacke les 4 layers CPU (m_layerCpuData) en un buffer staging
+        /// 4*kSplatLayerResolution^2*4 et re-upload via vkCmdCopyBufferToImage
+        /// dans m_albedoArray.image. Pattern : SHADER_READ_ONLY -> TRANSFER_DST
+        /// -> copies -> SHADER_READ_ONLY, submit + vkQueueWaitIdle.
+        ///
+        /// Pour les layers sans donnee CPU stockee (SetLayerCpuRgba256 jamais
+        /// appele ou taille incorrecte), regenere la procedurale via
+        /// GenerateProceduralAlbedoLayer.
+        ///
+        /// \return true si succes.
+        bool RebuildAlbedoArrayFromCpuLayers(VkDevice device, VkPhysicalDevice physDev,
+                                             VkQueue queue, uint32_t queueFamilyIndex);
+
     private:
         SplatMapGpu    m_splatMap;
         TextureArrayGpu m_albedoArray;
@@ -141,6 +164,10 @@ namespace engine::render::terrain
         std::vector<uint8_t> m_cpuData;
         uint32_t             m_cpuWidth  = 0;
         uint32_t             m_cpuHeight = 0;
+
+        /// Buffers CPU des 4 layers, alimentes par SetLayerCpuRgba256.
+        /// Vide pour un layer = utilise la procedurale au prochain rebuild.
+        std::array<std::vector<uint8_t>, kSplatLayerCount> m_layerCpuData;
 
         // ── Internal upload helpers ───────────────────────────────────────────────
 
@@ -163,6 +190,13 @@ namespace engine::render::terrain
 
         static void DestroySplatMap(VkDevice device, SplatMapGpu& g);
         static void DestroyTextureArray(VkDevice device, TextureArrayGpu& g);
+
+        /// Helper interne : barrier SHADER_READ_ONLY -> TRANSFER_DST, copy, retour
+        /// SHADER_READ_ONLY. Submit + vkQueueWaitIdle. Utilise par
+        /// RebuildAlbedoArrayFromCpuLayers (image deja en SHADER_READ_ONLY apres Init).
+        bool ReuploadAlbedoArrayInternal(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                                         VkBuffer staging,
+                                         const std::vector<VkBufferImageCopy>& regions);
     };
 
 } // namespace engine::render::terrain

--- a/engine/render/terrain/TerrainSplatting.h
+++ b/engine/render/terrain/TerrainSplatting.h
@@ -13,6 +13,16 @@ namespace engine::render::terrain
     /// Number of splat layers (grass, dirt, rock, snow).
     static constexpr uint32_t kSplatLayerCount = 4u;
 
+    /// Génère un layer RGBA8 procédural (bruit déterministe par layer).
+    /// Algorithme : combinaison micro/macro de hash xx-style, identique au boot
+    /// de TerrainSplatting (cf. b93a14d). Mêmes octets exacts pour mêmes paramètres.
+    /// \param resolution Côté en pixels (carré). Min 4, max 4096.
+    /// \param layer 0=grass, 1=dirt, 2=rock, 3=snow.
+    /// \param outRgba Sortie : resolution * resolution * 4 octets, RGBA8 sRGB.
+    /// \return false si layer >= kSplatLayerCount ou resolution < 4.
+    bool GenerateProceduralAlbedoLayer(uint32_t resolution, uint32_t layer,
+                                       std::vector<uint8_t>& outRgba);
+
     /// Magic binaire des fichiers splat disque « SLAP » (little-endian), aligné sur `TerrainEditingTools::SaveSplatMap`.
     inline constexpr uint32_t kTerrainSplatFileMagic = 0x50414C53u;
 

--- a/game/data/atmosphere.json
+++ b/game/data/atmosphere.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "_comment": "Atmosphere par defaut chargee au boot avant qu'une zone specifique soit active. Defini un soleil a 45deg (sud-est) et une lumiere ambiante diurne. Les zones individuelles (game/data/zones/<id>/atmosphere.json) surchargent ces valeurs quand elles sont chargees.",
+  "sun": {
+    "direction": [0.5774, 0.5774, 0.5774],
+    "color": [1.0, 0.95, 0.85]
+  },
+  "ambient": {
+    "color": [0.15, 0.18, 0.22]
+  }
+}

--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -14,12 +14,15 @@
 // Outputs:
 //   outSceneColorHDR (location 0) – SceneColor_HDR, R16G16B16A16_SFLOAT
 //
-// Push constants (132 bytes, fragment stage):
+// Push constants (148 bytes, fragment stage):
 //   mat4  invVP         – inverse view-projection matrix
 //   vec4  cameraPos     – camera world-space position (xyz, w unused)
 //   vec4  lightDir      – normalised direction *toward* the light (xyz, w unused)
 //   vec4  lightColor    – RGB radiance (color * intensity, w unused)
 //   vec4  ambientColor  – constant ambient RGB (fallback when useIBL == 0)
+//   vec4  skyColor      – RGB couleur du ciel (utilisée pour les pixels sans
+//                         géométrie, c.-à-d. depth == 1.0). Pilotée par
+//                         DayNightCycle (skyHorizon) côté CPU. w unused.
 //   float useIBL        – 1.0 = use IBL, 0.0 = constant ambient
 
 layout(location = 0) in  vec2 inUV;
@@ -44,6 +47,7 @@ layout(push_constant) uniform PC
     vec4  lightDir;     // normalised direction toward the directional light (xyz)
     vec4  lightColor;   // RGB radiance (xyz = color * intensity)
     vec4  ambientColor; // constant ambient RGB (fallback when useIBL == 0)
+    vec4  skyColor;     // RGB couleur du ciel pour les pixels sans géométrie
     float useIBL;       // 1.0 = use IBL, 0.0 = constant ambient
 } pc;
 
@@ -100,10 +104,12 @@ void main()
     float metallic  = orm.b;
     float depth     = texture(depthTex, inUV).r;
 
-    // ---- Skip sky / empty fragments (depth == 1.0 means no geometry) ---
+    // ---- Sky / empty fragments (depth == 1.0 means no geometry) --------
+    // On utilise la couleur du ciel pilotée par DayNightCycle (horizon).
+    // Permet de voir l'effet jour/nuit dans l'éditeur même sans skybox.
     if (depth >= 1.0)
     {
-        outSceneColorHDR = vec4(0.0, 0.0, 0.0, 1.0);
+        outSceneColorHDR = vec4(pc.skyColor.rgb, 1.0);
         return;
     }
 


### PR DESCRIPTION
## Objectif

Suite directe de #422 mergée. Couvre les items "à faire" notés dans la description de #422 :
- Textures splat par défaut (grass / dirt / rock / snow) pour sol coloré dans l'éditeur
- Skybox dynamique en lien avec `DayNightCycle` (déjà calculé mais pas affiché)
- Atmosphere.json par défaut pour ne plus avoir le warning au boot

## Problème actuel

Capture utilisateur dans l'éditeur monde post-merge #422 : carte créée correctement mais sol invisible / écran noir. Causes :
1. `game/data/atmosphere.json` n'existe pas → fallback ambient quasi-noir → tout est sombre
2. Pas de textures splat (grass/dirt/rock/snow) chargées → splat couches rendues en noir
3. Skybox absente → ciel noir

## Plan en commits

- [x] **C1** : `atmosphere.json` minimal au top-level (soleil 45° + ambient diurne)
- [ ] **C2** : Textures splat par défaut bundle (4× PNG 256×256 ou couleurs unies de fallback)
- [ ] **C3** : Skybox shader minimal (gradient zenith/horizon piloté par `DayNightCycle.GetState().lightDir`)
- [ ] **C4** : Panneau ImGui éditeur "Atmosphère" (slider time-of-day, couleurs ambient, intensité soleil)
- [ ] **C5** : Sauvegarde atmosphère par zone dans `world_editor/maps/<zoneId>/atmosphere.json`

## Test plan (à compléter au fil des commits)

- [ ] Build Linux + Windows OK
- [ ] Boot client : plus de warning `[ZoneProbes] Load atmosphere FAILED`
- [ ] Éditeur monde : nouvelle carte montre un sol coloré (pas juste la grille)
- [ ] Skybox visible (gradient bleu-orange selon time-of-day)
- [ ] Time-of-day slider modifie en live l'éclairage du terrain

## Déploiement

> ✅ **Client uniquement** (atmosphere.json + textures + shaders skybox = ressources runtime). Pas de redéploiement serveur.

https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wom6xD6qxiTHm6uF2x74Kv)_