### PR TITLE
diag(terrain): instrumentation CI suite PR #427 (lighting hack 4-quad…

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -1513,6 +1513,29 @@ namespace engine
 												const engine::RenderState& rs = m_renderStates[readIdx];
 												const bool terrainBeforeGeometry = m_terrain.IsValid()
 													&& m_pipeline->GetGeometryPass().HasLoadPass();
+												// DIAG TEMP (PR #427 follow-up) : log one-shot pour
+												// confirmer que la branche terrainBeforeGeometry est prise
+												// et que les ResourceIds passes a terrain.Record() puis
+												// GeometryPass.RecordIndirect() sont bien identiques (sinon
+												// chacun ecrit dans un VkImage different => terrain ecrit
+												// mais lighting lit autre chose).
+												static bool s_geometryPassDiagOnce = true;
+												if (s_geometryPassDiagOnce)
+												{
+													s_geometryPassDiagOnce = false;
+													LOG_INFO(Render,
+														"[Geometry pass] DIAG: m_terrain.IsValid={} HasLoadPass={} terrainBeforeGeometry={}",
+														m_terrain.IsValid() ? 1 : 0,
+														m_pipeline->GetGeometryPass().HasLoadPass() ? 1 : 0,
+														terrainBeforeGeometry ? 1 : 0);
+													LOG_INFO(Render,
+														"[Geometry pass] DIAG: ResourceIds A={} B={} C={} V={} D={}",
+														static_cast<uint32_t>(m_fgGBufferAId),
+														static_cast<uint32_t>(m_fgGBufferBId),
+														static_cast<uint32_t>(m_fgGBufferCId),
+														static_cast<uint32_t>(m_fgGBufferVelocityId),
+														static_cast<uint32_t>(m_fgDepthId));
+												}
 												if (terrainBeforeGeometry)
 												{
 													m_terrain.Record(
@@ -4913,6 +4936,22 @@ namespace engine
 			for (const std::string& r : refs)
 			{
 				if (!r.empty()) { noUserTextures = false; break; }
+			}
+			// DIAG TEMP (PR #427 follow-up) : log les refs de texture splat
+			// + verdict noUserTextures pour confirmer que le push-constant
+			// terrain.frag::pc.noUserTextures sera bien a 1 (sinon outAlbedo
+			// utilise les textures placeholder => potentiellement noir).
+			LOG_INFO(Render,
+				"[WorldEditor] DIAG splat refs ({} layers): noUserTextures={}",
+				static_cast<uint32_t>(refs.size()),
+				noUserTextures ? 1 : 0);
+			for (size_t i = 0; i < refs.size(); ++i)
+			{
+				LOG_INFO(Render,
+					"[WorldEditor] DIAG   refs[{}]=\"{}\" (empty={})",
+					static_cast<uint32_t>(i),
+					refs[i],
+					refs[i].empty() ? 1 : 0);
 			}
 		}
 		m_terrain.SetNoUserTexturesFallback(noUserTextures);

--- a/engine/render/terrain/TerrainHoleMask.cpp
+++ b/engine/render/terrain/TerrainHoleMask.cpp
@@ -154,7 +154,16 @@ namespace engine::render::terrain
         outData.width  = quadW;
         outData.height = quadH;
         outData.mask.assign(static_cast<size_t>(quadW) * quadH, 255u);
-        LOG_DEBUG(Render, "[TerrainHoleMask] Generated solid fallback mask ({}×{} quads)", quadW, quadH);
+        // DIAG TEMP (PR #427 follow-up) : passe DEBUG -> INFO + sanity check sur les
+        // bytes generes. Si le mask n'est pas "tout 255", terrain.frag::main()
+        // declenche `discard` sur tous les fragments (cf. INVESTIGATION sec. NEW).
+        const uint8_t firstByte = outData.mask.empty() ? 0u : outData.mask.front();
+        const uint8_t lastByte  = outData.mask.empty() ? 0u : outData.mask.back();
+        LOG_INFO(Render,
+            "[TerrainHoleMask] GenerateSolid OK ({}x{} quads, total={} bytes, "
+            "first={} last={}) [doit etre 255/255 sinon discard total]",
+            quadW, quadH, static_cast<uint32_t>(outData.mask.size()),
+            static_cast<uint32_t>(firstByte), static_cast<uint32_t>(lastByte));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -173,6 +182,16 @@ namespace engine::render::terrain
         }
 
         const VkDeviceSize dataBytes = static_cast<VkDeviceSize>(data.width) * data.height;
+
+        // DIAG TEMP (PR #427 follow-up) : log le contenu CPU avant upload.
+        // Permet de verifier qu'on n'envoie pas un buffer de zeros (qui causerait
+        // discard total dans terrain.frag).
+        const uint8_t firstByte = data.mask.front();
+        const uint8_t lastByte  = data.mask.back();
+        LOG_INFO(Render,
+            "[TerrainHoleMask] UploadToGpu start ({}x{} = {} bytes CPU, first={} last={})",
+            data.width, data.height, static_cast<uint64_t>(dataBytes),
+            static_cast<uint32_t>(firstByte), static_cast<uint32_t>(lastByte));
 
         // ── Staging buffer (HOST_VISIBLE | HOST_COHERENT) ─────────────────────
         VkBuffer       stagingBuf = VK_NULL_HANDLE;

--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -286,6 +286,35 @@ namespace engine::render::terrain
         LOG_DEBUG(Render, "[TerrainRenderer] Patch list built: {}×{} = {} patches",
                   m_patchCountX, m_patchCountZ, totalPatches);
 
+        // DIAG TEMP (PR #427 follow-up) : confirme que toutes les ressources GPU
+        // critiques pour le rendu sont bien creees apres Init. Si l'une est NULL
+        // ou que le hole mask data n'est pas tout 255, on a la cause directe du
+        // terrain invisible (cf. INVESTIGATION_terrain_invisible.md).
+        {
+            const uint8_t hmFirst = m_holeMaskData.mask.empty() ? 0u : m_holeMaskData.mask.front();
+            const uint8_t hmLast  = m_holeMaskData.mask.empty() ? 0u : m_holeMaskData.mask.back();
+            LOG_INFO(Render,
+                "[TerrainRenderer] Init DIAG: heightmap={}x{} patches={} fmt(A={}/B={}/C={}/V={}/D={})",
+                m_heightmapData.width, m_heightmapData.height, totalPatches,
+                static_cast<int>(fmtA), static_cast<int>(fmtB), static_cast<int>(fmtC),
+                static_cast<int>(fmtVelocity), static_cast<int>(fmtDepth));
+            LOG_INFO(Render,
+                "[TerrainRenderer] Init DIAG: holeMaskData={}x{} (first={} last={}) "
+                "[doivent etre 255/255 - autrement discard total]",
+                m_holeMaskData.width, m_holeMaskData.height,
+                static_cast<uint32_t>(hmFirst), static_cast<uint32_t>(hmLast));
+            LOG_INFO(Render,
+                "[TerrainRenderer] Init DIAG: holeMaskGpu image={} view={} sampler={}",
+                (void*)m_holeMaskGpu.image,
+                (void*)m_holeMaskGpu.view,
+                (void*)m_holeMaskGpu.sampler);
+            LOG_INFO(Render,
+                "[TerrainRenderer] Init DIAG: grassMaskData={}x{} grassMaskGpu image={} view={}",
+                m_grassMaskData.width, m_grassMaskData.height,
+                (void*)m_grassMaskGpu.image,
+                (void*)m_grassMaskGpu.view);
+        }
+
         // ── Create render pass ────────────────────────────────────────────────────
         {
             // 5 attachments: A, B, C, Velocity (color), Depth
@@ -1603,6 +1632,22 @@ namespace engine::render::terrain
             registry.getImageView(idVelocity),
             registry.getImageView(idDepth)
         };
+
+        // DIAG TEMP (PR #427 follow-up) : confirme une seule fois que les 5
+        // VkImageView fournies par le frame graph sont non-NULL et matchent
+        // l'extent attendu. Une view NULL ici provoquerait silencieusement
+        // un terrain invisible (vkCreateFramebuffer echouerait, return early).
+        static bool s_recordViewsLogged = false;
+        if (!s_recordViewsLogged)
+        {
+            s_recordViewsLogged = true;
+            LOG_INFO(Render,
+                "[TerrainRenderer] Record DIAG: extent={}x{} views A={} B={} C={} V={} D={}",
+                extent.width, extent.height,
+                (void*)views[0], (void*)views[1],
+                (void*)views[2], (void*)views[3],
+                (void*)views[4]);
+        }
 
         FramebufferKey fbKey{};
         fbKey.renderPass = m_renderPass;

--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -90,6 +90,68 @@ vec3 F_Schlick(float cosTheta, vec3 F0)
 // ---- Main -------------------------------------------------------------------
 void main()
 {
+    // ============================================================================
+    // === DIAG TEMP — PR #427 follow-up — A REVERTER apres diagnostic terrain ====
+    // ============================================================================
+    // Visualisation 4 quadrants pour isoler ou la pipeline rendu lache :
+    //   Top-Left   : GBufferA (albedo brut). Si on voit l'orange (1, 0.55, 0.1) =>
+    //                terrain.frag a bien tourne et ecrit son albedo. Si noir (clear
+    //                = 0,0,0,0) => aucun fragment terrain n'a ete shade (vertex
+    //                clipped GPU, ou hole mask discard).
+    //   Top-Right  : GBufferB (normale encodee N*0.5+0.5). Si couleurs vives
+    //                visibles => normales ecrites par le terrain. Sinon
+    //                gris-bleu uniforme (clear = 0.5, 0.5, 1.0) => idem TL.
+    //   Bottom-Left: depth visualisee. Magenta (1,0,1) => depth >= 1.0 (clear =>
+    //                aucune geometrie n'a ecrit la depth a ce pixel). Gris =>
+    //                depth ecrite par une geometrie (terrain ou autre).
+    //   Bottom-Right: verdict de l'early-return de la lighting pass : vert =>
+    //                depth < 1.0 (lighting aurait shade un pixel reel). Magenta
+    //                => depth >= 1.0 (lighting court-circuite vers skyColor).
+    //
+    // En un seul screenshot du World Editor on identifie immediatement laquelle
+    // des 4 hypotheses (cf. INVESTIGATION_terrain_invisible.md sec.4) est en
+    // cause.
+    // ----------------------------------------------------------------------------
+    {
+        vec2 uv = inUV;
+        vec4 dbg;
+        if (uv.x < 0.5 && uv.y < 0.5) {
+            // Top-Left : GBufferA brut
+            vec2 quv = vec2(uv.x * 2.0, uv.y * 2.0);
+            dbg = texture(gbufA, quv);
+            dbg.a = 1.0;
+        } else if (uv.x >= 0.5 && uv.y < 0.5) {
+            // Top-Right : GBufferB (normale encodee)
+            vec2 quv = vec2((uv.x - 0.5) * 2.0, uv.y * 2.0);
+            dbg = vec4(texture(gbufB, quv).rgb, 1.0);
+        } else if (uv.x < 0.5 && uv.y >= 0.5) {
+            // Bottom-Left : depth grayscale + magenta si == 1.0 (sky)
+            vec2 quv = vec2(uv.x * 2.0, (uv.y - 0.5) * 2.0);
+            float d = texture(depthTex, quv).r;
+            if (d >= 1.0) {
+                dbg = vec4(1.0, 0.0, 1.0, 1.0);
+            } else {
+                // Etale [0.95, 1.0] sur [0,1] pour mieux voir les variations
+                float dd = clamp((d - 0.95) / 0.05, 0.0, 1.0);
+                dbg = vec4(dd, dd, dd, 1.0);
+            }
+        } else {
+            // Bottom-Right : verdict lighting (vert = OK, magenta = court-circuit sky)
+            vec2 quv = vec2((uv.x - 0.5) * 2.0, (uv.y - 0.5) * 2.0);
+            float d = texture(depthTex, quv).r;
+            if (d >= 1.0) {
+                dbg = vec4(1.0, 0.0, 1.0, 1.0);
+            } else {
+                dbg = vec4(0.0, 1.0, 0.0, 1.0);
+            }
+        }
+        outSceneColorHDR = dbg;
+        return;
+    }
+    // ============================================================================
+    // === FIN DIAG TEMP ==========================================================
+    // ============================================================================
+
     // ---- Sample GBuffer ------------------------------------------------
     vec4  baseAlbedo = texture(gbufA, inUV);
     vec4  decalOverlay = texture(decalOverlayTex, inUV);


### PR DESCRIPTION
…rants + logs)

Suite a la PR #427 mergee, le terrain reste invisible dans le World Editor (symptome : viewport gris/beige uniforme). Cette branche est une instrumentation DIAGNOSTIC pour isoler la cause via un seul build CI :

1. game/data/shaders/lighting.frag : hack visuel 4 quadrants (court-circuite le PBR pour afficher GBufferA / GBufferB / depth / verdict early-return). Permet d'identifier en un screenshot lequel des etages de pipeline echoue.

2. engine/render/terrain/TerrainHoleMask.cpp : logs INFO sur GenerateSolid + UploadToGpu (taille, premier/dernier byte) — verifie qu'on n'envoie pas un buffer de zeros qui declencherait `discard` total dans terrain.frag.

3. engine/render/terrain/TerrainRenderer.cpp :
   - log INFO post-Init : formats GBuffer recus + dimensions hole/grass mask + handles GPU non-NULL.
   - log INFO one-shot dans Record() : 5 VkImageView fournies par le frame graph, pour confirmer qu'aucune n'est NULL silencieusement.

4. engine/Engine.cpp :
   - log INFO dans RebuildWorldEditorTerrainGpu : etat des splatLayerTextureRefs + verdict noUserTextures (push-constant).
   - log INFO one-shot dans le callback FrameGraph "Geometry" : confirme que terrainBeforeGeometry=true et liste les ResourceIds.

Tous les blocs sont marques `DIAG TEMP (PR #427 follow-up)` pour faciliter le revert une fois le bug identifie.

**Deploiement** : OK client uniquement, pas de redeploiement serveur.