### PR TITLE
fix(world-editor): DockSpace passthru flag (cause racine terrain invi…

### DIFF
--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -856,8 +856,19 @@ namespace engine::editor
 		if (ImGui::Begin("WorldEditorDockSpaceHost", nullptr, hostFlags))
 		{
 			const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpaceV2");
-			// ImGuiDockNodeFlags_PassthroughCentralNode (1<<4) - litteral pour eviter les divergences d'en-tetes.
-			constexpr ImGuiDockNodeFlags kDockSpaceFlags = static_cast<ImGuiDockNodeFlags>(1u << 4);
+			// PR #427 follow-up : cause racine du "terrain invisible".
+			// L'auteur initial avait ecrit (1u << 4) en pensant que c'etait
+			// ImGuiDockNodeFlags_PassthruCentralNode, mais (1u << 4) est en fait
+			// ImGuiDockNodeFlags_NoDockingSplit dans ImGui v1.91.9-docking. La
+			// bonne valeur est (1u << 3) = ImGuiDockNodeFlags_PassthruCentralNode.
+			// Sans ce flag, le node central du DockSpace est dessine avec un fond
+			// opaque (couleur ImGuiCol_DockingEmptyBg) qui MASQUE la pipeline 3D
+			// rendue dans le swapchain, d'ou la couleur "brun-rose" / "gris" uniforme
+			// observee dans le viewport central depuis PR #427. La pipeline 3D
+			// (terrain, lighting, tonemap) fonctionnait correctement, mais son
+			// resultat n'etait jamais visible. Voir docs/INVESTIGATION_terrain_invisible.md
+			// pour le detail des PR7/PR8/PR9 qui ont permis d'isoler la cause.
+			constexpr ImGuiDockNodeFlags kDockSpaceFlags = static_cast<ImGuiDockNodeFlags>(1u << 3);
 
 			// Detection de resize de fenetre : si la taille du viewport a change
 			// depuis la derniere frame (apres initialisation), on force


### PR DESCRIPTION
…sible PR #427)

WorldEditorImGui::DrawDockSpace utilise (1u << 4) en pensant que c'est ImGuiDockNodeFlags_PassthruCentralNode. C'est faux : dans ImGui v1.91.9-docking (version utilisee via FetchContent CMakeLists.txt:167), les valeurs sont :

  ImGuiDockNodeFlags_PassthruCentralNode = 1 << 3   (= 8)
  ImGuiDockNodeFlags_NoDockingSplit      = 1 << 4   (= 16)  <-- pas le bon flag

Sans PassthruCentralNode, le node central du DockSpace est dessine avec un fond opaque (couleur ImGuiCol_DockingEmptyBg) qui MASQUE la pipeline 3D rendue dans le swapchain. La pipeline (terrain, lighting, tonemap) fonctionne correctement, mais son resultat n'est jamais visible : on voit uniquement la couleur opaque du DockSpace (gris ou brun-rose selon le theme).

Le commentaire d'origine du code, et les commentaires alentours qui parlent de "node central reste vide -> 3D visible et cliquable au travers du DockSpace", confirment l'intention de l'auteur. Une typo (1u << 4 au lieu de 1u << 3) a casse le World Editor depuis PR #427.

Confirmation experimentale via PR #427 follow-ups :
- PR7 : logs subroutines confirment terrain.Record() execute 225 drawcalls dans la bonne renderpass, vues VkImageView identiques entre TerrainRenderer et LightingPass.
- PR8 : bypass post-process (copie GBufferA -> swapchain). Resultat visuel : panneaux UI ImGui passent au BLEU (clearValue ROUGE byte-inverted en BGR R8G8B8A8 -> B8G8R8A8) car ils ont un fond semi-transparent. Le viewport central reste GRIS car couvert par un widget DockSpace opaque -> preuve finale que le bug est dans la composition UI, pas dans le rendu 3D.

Fix : 1u << 4 -> 1u << 3, soit une seule ligne.

Deploiement : client uniquement, pas de redeploiement serveur.