### PR TITLE
diag(lighting): test skip sky branch (PR #427 follow-up post-PR10)

### DIFF
--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -105,9 +105,15 @@ void main()
     float depth     = texture(depthTex, inUV).r;
 
     // ---- Sky / empty fragments (depth == 1.0 means no geometry) --------
-    // On utilise la couleur du ciel pilotée par DayNightCycle (horizon).
-    // Permet de voir l'effet jour/nuit dans l'éditeur même sans skybox.
-    if (depth >= 1.0)
+    // DIAG TEMP (PR #427 follow-up post-PR10) : test "skip sky branch".
+    // On force le shading PBR sur tous les pixels en mettant `false` au lieu
+    // de `depth >= 1.0`. Si le viewport central affiche le terrain shade
+    // (gradient gris/oranger/rouge selon lightDir et albedo), la depth etait
+    // bien le coupable : terrain ecrit la depth mais lighting voit 1.0
+    // (probleme de propagation depth via barrier/layout). Si toujours gris
+    // uniforme, le bug est en aval (tonemap, copy present). A REVERTER une
+    // fois le diagnostic confirme.
+    if (false /* DIAG: was: depth >= 1.0 */)
     {
         outSceneColorHDR = vec4(pc.skyColor.rgb, 1.0);
         return;


### PR DESCRIPTION
PR10 a fix la cause racine "DockSpace passthru" mais le viewport central affiche encore du gris uniforme au lieu du terrain. Le test PR8 avait prouve que terrain ecrit bien dans GBufferA. Le test magenta a confirme que le swapchain est bien la cible du DockSpace passthru.

Reste a savoir si lighting voit la depth ecrite par terrain. lighting.frag fait actuellement :

    if (depth >= 1.0) outSceneColorHDR = skyColor; return;

Si terrain n'ecrit pas la depth visible par lighting, alors depth=1.0 partout -> branche prise -> skyColor partout -> apres tonemap = gris/brun uniforme dans le swapchain.

Test : remplacer la condition par `false` pour forcer le shading PBR sur tous les pixels (en ignorant la depth).

Lecture du resultat visuel attendu :
- Terrain shade visible (gradient orange/gris selon NdotL et albedo) => la depth etait le coupable : il faut fixer la propagation depth -> sampler lighting (probleme barrier/layout/aspect bit).
- Toujours gris uniforme => bug en aval (tonemap, autoExposure, taa, copy present).

A REVERTER une fois le diagnostic confirme.