### PR TITLE
diag(lighting): force RED HDR output (PR #427 follow-up post-PR10)

### DIFF
--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -90,6 +90,19 @@ vec3 F_Schlick(float cosTheta, vec3 F0)
 // ---- Main -------------------------------------------------------------------
 void main()
 {
+    // DIAG TEMP (PR #427 follow-up post-PR10) : test "force red".
+    // On ecrit ROUGE PUR HDR (1,0,0,1) sans rien sampler ni calculer. Permet
+    // d'isoler la chaine lighting -> tonemap -> taa -> copy -> swapchain.
+    //   - Si on voit ROUGE/orange/quelque chose de chaud dans le viewport
+    //     central : la chaine fonctionne. Le bug est dans le calcul PBR
+    //     (depth, normal sampling, IBL, descriptor binding) en aval.
+    //   - Si on voit toujours gris uniforme : le bug est en aval de lighting.
+    //     Le HDR (R16G16B16A16_SFLOAT) ne se propage pas correctement vers
+    //     le swapchain (tonemap clamp, autoExposure, TAA, ou CopyPresent).
+    // A REVERTER une fois le diagnostic confirme.
+    outSceneColorHDR = vec4(1.0, 0.0, 0.0, 1.0);
+    return;
+
     // ---- Sample GBuffer ------------------------------------------------
     vec4  baseAlbedo = texture(gbufA, inUV);
     vec4  decalOverlay = texture(decalOverlayTex, inUV);


### PR DESCRIPTION
PR12 (skip sky branch) ne tranche pas le diagnostic : le viewport reste gris meme avec la branche skyColor desactivee. Cela peut signifier soit un bug dans le calcul PBR (depth garbage -> posWorld faux -> shading n'importe quoi -> resultat gris), soit un bug en aval (tonemap, TAA, copy present).

Test plus tranchant : on ecrit ROUGE PUR HDR (1,0,0,1) en premiere instruction de lighting.frag, ignorant tous les samplers et le calcul PBR. Si la chaine lighting -> tonemap -> taa -> copy -> swapchain fonctionne, le viewport central doit etre rouge / orange (apres tonemap qui peut desaturer).

Lecture du resultat visuel :
- Couleur chaude visible (rouge / orange / saumon selon tonemap) : chaine OK, bug est dans le calcul PBR de lighting.frag (depth, sampling normales, IBL, descriptor binding).
- Toujours gris uniforme : bug en aval de lighting (HDR R16G16B16A16 ne se propage pas vers le swapchain LDR : tonemap clamp violent, autoExposure, TAA, ou CopyPresent).

A REVERTER une fois le diagnostic confirme.