### PR TITLE
diag(fg): trace one-shot de toutes les passes FrameGraph (PR #427 fol…

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -2075,7 +2075,30 @@ namespace engine
 												engine::render::ResourceId srcId = m_pipeline->GetTaaPass().IsValid() ? GetTaaHistoryNextId() : m_fgSceneColorLDRId;
 												VkImage srcImg = reg.getImage(srcId);
 												VkImage dstImg = reg.getImage(m_fgBackbufferId);
-												if (srcImg == VK_NULL_HANDLE || dstImg == VK_NULL_HANDLE) return;
+												// DIAG TEMP (PR #427 follow-up post-PR10) : log one-shot pour confirmer
+												// que CopyPresent execute avec des handles valides. Si on n'a pas ce log,
+												// le pass est skipped (srcImg ou dstImg null).
+												static bool s_copyPresentLogged = false;
+												if (!s_copyPresentLogged) {
+													s_copyPresentLogged = true;
+													LOG_INFO(Render,
+														"[CopyPresent] DIAG ENTREE : srcId={} srcImg={} dstImg={} TaaValid={} fgSceneColorLDRId={} fgBackbufferId={}",
+														static_cast<uint32_t>(srcId),
+														(void*)srcImg, (void*)dstImg,
+														m_pipeline->GetTaaPass().IsValid() ? 1 : 0,
+														static_cast<uint32_t>(m_fgSceneColorLDRId),
+														static_cast<uint32_t>(m_fgBackbufferId));
+												}
+												if (srcImg == VK_NULL_HANDLE || dstImg == VK_NULL_HANDLE) {
+													static bool s_copyPresentNullLogged = false;
+													if (!s_copyPresentNullLogged) {
+														s_copyPresentNullLogged = true;
+														LOG_WARN(Render,
+															"[CopyPresent] DIAG SKIP : srcImg={} dstImg={} - copy non execute !",
+															(void*)srcImg, (void*)dstImg);
+													}
+													return;
+												}
 												VkExtent2D ext = m_vkSwapchain.GetExtent();
 												bool authPhotoBackdrop = false;
 												const bool presentSolidColorDebug = m_cfg.GetBool("render.debug_present_solid_color.enabled", false);

--- a/engine/render/FrameGraph.cpp
+++ b/engine/render/FrameGraph.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <string>
+#include <unordered_set>
 
 namespace engine::render
 {
@@ -456,12 +458,36 @@ namespace engine::render
 	    ensureImageResources(device, physicalDevice, vmaAllocator, frameIndex, extent, framesInFlight);
 	    ensureBufferResources(device, vmaAllocator, frameIndex, framesInFlight);
 	    fillRegistry(registry, frameIndex);
-	
+
+	    // DIAG TEMP (PR #427 follow-up post-PR10) : trace ONE-SHOT par passe.
+	    // Le viewport central reste gris dans le World Editor : ni terrain, ni
+	    // ciel, ni pinceau ne s'affichent. Comme terrain et ciel sortent de
+	    // lighting puis convergent dans la meme chaine bloom -> tonemap -> taa
+	    // -> copy, le bug est forcement aval de lighting. On trace chaque pass
+	    // a la premiere fois qu'elle execute pour voir laquelle saute / fail
+	    // silencieusement. A REVERTER une fois le bug identifie.
+	    static std::unordered_set<std::string> s_loggedPasses;
+	    static bool s_loggedExecuteOrder = false;
+	    if (!s_loggedExecuteOrder)
+	    {
+	        s_loggedExecuteOrder = true;
+	        std::string orderStr;
+	        for (size_t passIdx : m_compiledOrder)
+	        {
+	            if (!orderStr.empty()) orderStr += " -> ";
+	            orderStr += m_passes[passIdx].name;
+	        }
+	        LOG_INFO(Render, "[FG-EXEC] order ({} passes): {}", m_compiledOrder.size(), orderStr);
+	    }
+
 	    std::unordered_map<ResourceId, ResourceUsageState> lastUsage;
 	    for (size_t passIdx : m_compiledOrder)
 	    {
 	        const Pass& pass = m_passes[passIdx];
 	        engine::core::ProfilerScope passScope(pass.name);
+	        const bool firstTime = s_loggedPasses.insert(pass.name).second;
+	        if (firstTime)
+	            LOG_INFO(Render, "[FG-EXEC] pass '{}' BEGIN (executor={})", pass.name, pass.execute ? 1 : 0);
 	        LOG_DEBUG(Render, "[FrameGraph] pass '{}' begin barriers", pass.name);
 	        emitBarriersBeforePass(cmd, pass, registry, lastUsage, sync2Supported, device);
 	        LOG_DEBUG(Render, "[FrameGraph] pass '{}' barriers done", pass.name);
@@ -475,6 +501,8 @@ namespace engine::render
 	            profiler->EndGpuPass(cmd, frameIndex);
 	        }
 	        LOG_DEBUG(Render, "[FrameGraph] pass '{}' fully done (profiler closed)", pass.name);
+	        if (firstTime)
+	            LOG_INFO(Render, "[FG-EXEC] pass '{}' END", pass.name);
 	    }
 	    LOG_DEBUG(Render, "[FrameGraph] execute() ALL passes done — returning to Engine::Render");
 	}


### PR DESCRIPTION
…low-up)

Insight critique de l'utilisateur : ni terrain, ni ciel, ni pinceau ne s'affichent dans le viewport central. Comme terrain et ciel sortent tous deux de lighting puis convergent dans la meme chaine (bloom -> tonemap -> taa -> copy -> swapchain), le bug est forcement EN AVAL de lighting.

Pour identifier OU la chaine lache, on trace chaque pass FrameGraph a la premiere fois qu'elle execute (one-shot pour ne pas spammer apres init) :
- Liste complete des passes dans l'ordre topologique compile
- BEGIN/END de chaque pass avec executor != nullptr ou non
- DIAG ENTREE/SKIP du callback CopyPresent (handles srcImg/dstImg)

Lecture attendue : on doit voir 30 BEGIN + 30 END dans les logs si tout execute correctement. Si une pass manque, ou si CopyPresent skip avec srcImg=null, on saura precisement ou regarder.

A REVERTER une fois le bug identifie.