### PR TITLE
fix(world-editor): force DockingEmptyBg transparent (cause #2 terrain…

### DIFF
--- a/engine/editor/WorldEditorImGui.cpp
+++ b/engine/editor/WorldEditorImGui.cpp
@@ -932,7 +932,16 @@ namespace engine::editor
 				}
 			}
 
+			// PR #427 follow-up post-PR10 : malgre le flag PassthruCentralNode (1<<3, fixe par PR10),
+			// le node central du DockSpace continue de dessiner un fond opaque gris qui masque le
+			// rendu 3D du viewport. Diagnostic confirme par les logs PR14 : la pipeline 3D s'execute
+			// completement (30/30 passes BEGIN+END, CopyPresent OK), et le test visuel "force red"
+			// PR13 a montre que le rouge du swapchain transparait a travers les panneaux ImGui semi-
+			// transparents mais PAS dans le central node. Ce qui confirme que le DockSpace dessine
+			// son propre fond opaque a cet endroit. On le force a transparent en plus du flag.
+			ImGui::PushStyleColor(ImGuiCol_DockingEmptyBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
 			ImGui::DockSpace(dockId, ImVec2(0.f, 0.f), kDockSpaceFlags);
+			ImGui::PopStyleColor();
 		}
 		ImGui::End();
 		ImGui::PopStyleVar(3);


### PR DESCRIPTION
… invisible PR #427)

Suite a PR10 (fix flag PassthruCentralNode 1u<<3) le viewport central du World Editor restait gris uniforme malgre une pipeline 3D fonctionnelle.

Diagnostic PR12-PR14 :
- PR13 (force RED dans lighting.frag) : le ROUGE du swapchain transparait a travers les panneaux ImGui semi-transparents mais PAS dans le central node => le swapchain contient bien le rendu 3D, mais quelque chose dessine un fond opaque par-dessus.
- PR14 (trace one-shot toutes les passes FrameGraph) : 30/30 passes BEGIN+END dans l'ordre topologique, CopyPresent execute avec srcImg et dstImg valides => la pipeline 3D fonctionne, le bug n'est PAS dedans.

Conclusion : le flag PassthruCentralNode seul ne suffit pas dans cette configuration ImGui v1.91.9-docking. Le node central continue de dessiner ImGuiCol_DockingEmptyBg (gris). On le force explicitement a transparent via PushStyleColor avant l'appel a DockSpace.

Fix : 3 lignes (PushStyleColor + appel DockSpace + PopStyleColor).

Deploiement : client uniquement, pas de redeploiement serveur.