### PR TITLE
fix(terrain): frontFace CCW -> CW (cause racine du terrain invisible)…

### DIFF
--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -525,7 +525,16 @@ namespace engine::render::terrain
             rasCI.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
             rasCI.polygonMode = VK_POLYGON_MODE_FILL;
             rasCI.cullMode    = VK_CULL_MODE_BACK_BIT;
-            rasCI.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+            // PR #427 follow-up : winding apparent en clip space inverse depuis le commit
+            // ee181da (Reapply view matrix transposee, convention Vulkan LH +Z forward).
+            // Le mesh terrain est genere en CCW dans le plan XZ world space, mais la nouvelle
+            // matrice view fait apparaitre les triangles en CW dans le clip space. Avec
+            // frontFace=CCW, le pipeline rejetait silencieusement TOUS les patches (terrain
+            // invisible malgre patches kept=225 cote CPU frustum cull). Confirme par PR
+            // diag avec cullMode=NONE : terrain visible (depth<1 = bleu, sky=rouge dans la
+            // viz depth). Fix permanent : passer frontFace en CLOCKWISE pour matcher la
+            // nouvelle convention du clip space sans toucher au mesh.
+            rasCI.frontFace   = VK_FRONT_FACE_CLOCKWISE;
             rasCI.lineWidth   = 1.0f;
 
             VkPipelineMultisampleStateCreateInfo msCI{};
@@ -1181,7 +1190,12 @@ namespace engine::render::terrain
                 cliffRas.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
                 cliffRas.polygonMode = VK_POLYGON_MODE_FILL;
                 cliffRas.cullMode    = VK_CULL_MODE_BACK_BIT;
-                cliffRas.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+                // PR #427 follow-up : meme correction que pour le pipeline terrain principal
+                // (ligne 528). Convention Vulkan LH +Z forward (ee181da) -> winding apparent
+                // CW en clip space -> frontFace doit etre CLOCKWISE pour ne pas rejeter les
+                // faces avant. La map de test n'a pas de cliffs (log "Cliff meshes loaded:
+                // 0/0"), mais on aligne la cohérence pour les maps futures.
+                cliffRas.frontFace   = VK_FRONT_FACE_CLOCKWISE;
                 cliffRas.lineWidth   = 1.0f;
 
                 VkPipelineMultisampleStateCreateInfo cliffMs{};


### PR DESCRIPTION
… PR24

Fix permanent du bug "terrain invisible dans le World Editor" qui faisait suite a la PR #427 (et au commit ee181da "Reapply view matrix transposee").

Cause racine confirmee par les diagnostics PR #427 follow-up :
  - PR16 (DockSpace passthru flag) : a leve le voile UI mais le viewport central restait gris-beige. Mergee dans main (commit b1d6a86).
  - PR21 (visualisation depth dans lighting.frag) : tout rouge plein ecran confirme que tous les pixels avaient depth=1.0, donc le terrain n'ecrivait jamais dans le depth buffer.
  - PR22 (cullMode=VK_CULL_MODE_NONE) : terrain visible (rouge=sky en haut, bleu=terrain en bas) -> piste backface culling confirmee.

Mecanisme : le commit ee181da a change la convention de stockage des basis vectors dans Camera::ComputeViewMatrix (column -> row). La nouvelle matrice view, combinee avec la projection PerspectiveVulkan (LH +Z forward), fait apparaitre les triangles terrain en CW dans le clip space. Avec frontFace=CCW + cullMode=BACK_BIT, le pipeline rejetait silencieusement les 225 patches du terrain malgre patches kept=225 cote CPU frustum cull.

Fix : passer frontFace de VK_FRONT_FACE_COUNTER_CLOCKWISE a VK_FRONT_FACE_CLOCKWISE pour le pipeline terrain principal et le pipeline cliffs (TerrainRenderer.cpp:528 et :1193). Le mesh terrain reste inchange (genere CCW dans le plan XZ world space).

Note : la regression "humanoide invisible dans le client de jeu" notee le 2026-05-05 a probablement la meme cause racine (winding inverse apres ee181da). Sera traitee separement, le pipeline avatar n'est pas dans ce diff.

Deploiement : ✅ client uniquement, pas de redeploiement serveur (touche seulement le pipeline graphics terrain dans lcdlln_world_editor.exe et lcdlln_client.exe via TerrainRenderer.cpp).