### PR TITLE
feat(world-editor): finalisation cam + grille + avatar visible (PR25)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -727,6 +727,41 @@ Bascule automatique : dès qu'une texture est posée sur une couche, le
 prochain rebuild via le bouton « Recharger terrain GPU » repasse en rendu
 normal sans intervention.
 
+### Cause racine "terrain invisible" — fix permanent (PR24, 2026-05-05)
+
+Le commit `ee181da` ("Reapply view matrix transposee") a changé la convention
+de `Camera::ComputeViewMatrix` vers Vulkan LH +Z forward. Conséquence :
+les meshes générés en CCW world-space apparaissent en **CW** dans le clip
+space. Tous les pipelines configurés `frontFace=CCW + cullMode=BACK_BIT`
+rejetaient silencieusement leurs triangles (terrain, avatar, etc.) malgré
+un frustum cull CPU qui passait.
+
+Pipelines fixés par PR24 puis PR25 (2026-05-06) :
+| Pipeline | Fichier | Ligne du fix | Symptôme avant fix |
+|---|---|---|---|
+| Terrain principal | `engine/render/terrain/TerrainRenderer.cpp` | 528 | Sol invisible (viewport gris-beige uniforme = sky tonemappée) |
+| Terrain falaises | `engine/render/terrain/TerrainRenderer.cpp` | 1193 | Pas de cliffs sur la map de test, fix préventif |
+| Geometry (avatar / props) | `engine/render/GeometryPass.cpp` | 376 | Humanoïde invisible (mode éditeur ET client de jeu post-EnterWorld) |
+
+Si après une régression future un mesh world-space disparaît, vérifier en
+priorité `frontFace` du pipeline concerné. Tous les fix utilisent
+`VK_FRONT_FACE_CLOCKWISE` (au lieu de `_COUNTER_CLOCKWISE`).
+`ShadowMapPass`, `WaterRenderer`, `DecalPass` utilisent encore CCW —
+applicable seulement si on observe des ombres / eau / decals invisibles.
+
+### Finalisation éditeur (PR25, 2026-05-06)
+
+Plusieurs ajustements demandés par l'utilisateur après validation PR24 :
+
+| Item | Fichier | Modif |
+|---|---|---|
+| Caméra : monter/descendre | `engine/render/Camera.cpp:117-145` | `FpsCameraController::Update` lit **R** (Y+=) et **F** (Y-=) en mode éditeur |
+| Grille : maille 5 m | `engine/editor/WorldEditorSession.h:171` | `m_gridCellMeters` défaut 8 → 5 |
+| Avatar humanoïde visible en éditeur | `engine/Engine.cpp:3525-3548` | Déjà en place (avant PR25). Le fix `GeometryPass.cpp:376` (frontFace=CW) le rend effectivement visible. |
+| Grille collée au sol | `engine/editor/WorldEditorImGui.cpp:269-306` | Déjà en place : chaque ligne échantillonne `TerrainWorldY` aux extrémités via la heightmap. **Note** : le rendu utilise `ImGui::GetForegroundDrawList()` (overlay 2D sans depth test contre le 3D), donc visuellement la grille est toujours dessinée par-dessus le sol même quand elle est mathématiquement au même niveau Y. Pour avoir un depth test correct il faudrait un line mesh 3D dédié (refactor non fait). |
+
+Items 6 (sculpt terrain) et 7 (paint splat) restent en investigation — voir PR26.
+
 ---
 
 ## Aide-mémoire : comment trouver un écran

--- a/engine/editor/WorldEditorSession.h
+++ b/engine/editor/WorldEditorSession.h
@@ -166,7 +166,10 @@ namespace engine::editor
 		std::array<char, 256> m_bufAudioDest{};
 
 		bool m_showGrid = true;
-		float m_gridCellMeters = 8.f;
+		// PR25 (M??.?) : valeur d'origine 8 m -> 5 m. Demande utilisateur pour
+		// avoir une maille plus fine (repere visuel au sol). La cellule reste
+		// modifiable a la volee dans l'UI (panneau "Affichage & grille").
+		float m_gridCellMeters = 5.f;
 		float m_brushRadius = 10.f;
 		float m_brushStrength = 0.1f;
 		int m_brushOp = 0;

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -124,6 +124,25 @@ namespace engine::render
 				camera.position.x -= rightX * dist;
 				camera.position.z -= rightZ * dist;
 			}
+			// PR25 (M??.?) : ajout d'un controle vertical world-space pour la
+			// camera free-fly de l'editeur monde. R = monter, F = descendre.
+			// Le pas vertical est strictement aligne sur l'axe Y world (pas de
+			// composante pitch), pour que l'utilisateur garde la meme cible
+			// horizontale en prenant de l'alttitude (cas typique : repositionner
+			// la camera au-dessus du terrain pour vue d'ensemble). Touches
+			// choisies pour rester en main gauche cote ZQSD/WASD : R/F adjacents
+			// sur AZERTY et QWERTY, et n'entrent pas en conflit avec d'eventuels
+			// raccourcis editeur Ctrl-X. Les touches s'appliquent uniquement
+			// quand applyKeyboardMove est vrai (i.e. mode editeur, pas pendant
+			// que la souris est capturee par un panneau ImGui).
+			if (input.IsDown(engine::platform::Key::R))
+			{
+				camera.position.y += dist;
+			}
+			if (input.IsDown(engine::platform::Key::F))
+			{
+				camera.position.y -= dist;
+			}
 		}
 
 		if (scrollWheelAdjustsFov && applyMouseLook)

--- a/engine/render/GeometryPass.cpp
+++ b/engine/render/GeometryPass.cpp
@@ -373,7 +373,16 @@ namespace engine::render
 		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 		rs.polygonMode = VK_POLYGON_MODE_FILL;
 		rs.cullMode    = VK_CULL_MODE_BACK_BIT;
-		rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		// PR25 (M??.?) : meme correction que TerrainRenderer.cpp:528 (PR24).
+		// Le commit ee181da (Reapply view matrix transposee) a change la
+		// convention de Camera::ComputeViewMatrix vers Vulkan LH +Z forward.
+		// Avec cette nouvelle matrice, les meshes generes en CCW world-space
+		// apparaissent en CW dans le clip space. Avec frontFace=CCW +
+		// cullMode=BACK_BIT, le pipeline rejetait silencieusement TOUS les
+		// triangles -> avatar humanoide invisible en mode editeur (item 2 de
+		// la finalisation editeur 2026-05-06) ET dans le client de jeu post-
+		// EnterWorld (regression notee 2026-05-05). Fix : frontFace=CW.
+		rs.frontFace   = VK_FRONT_FACE_CLOCKWISE;
 		rs.lineWidth   = 1.0f;
 
 		VkPipelineMultisampleStateCreateInfo ms = {};


### PR DESCRIPTION
5 des 7 items demandes par l'utilisateur apres validation PR24. Items 6/7 (sculpt + splat ne fonctionnent pas) seront traites en PR26 separee avec des logs diag pour identifier la cause precise.

Item 2 — Avatar humanoide visible en mode editeur :
  GeometryPass.cpp:376 : `frontFace=COUNTER_CLOCKWISE` -> `CLOCKWISE`.
  Meme cause racine que PR24 (ee181da view matrix LH inverse le winding
  apparent des meshes en clip space). Tous les meshes rendus via
  GeometryPass (avatar, props) etaient silencieusement backface-culled.
  BONUS : ce meme fix corrige aussi la regression "humanoide invisible
  dans le client de jeu" notee 2026-05-05 (memoire projet) — le pipeline
  GeometryPass est partage entre editeur et client.

Item 3 — Camera : monter / descendre :
  Camera.cpp `FpsCameraController::Update` ajoute deux nouvelles touches :
    R = Y += dist  (monter, world-space)
    F = Y -= dist  (descendre, world-space)
  Touches choisies adjacentes sur AZERTY/QWERTY, en main gauche cote
  ZQSD/WASD, sans conflit avec Ctrl-X (reserve pour raccourcis editeur
  futurs). Le pas est aligne strictement Y-world (pas de pitch) pour que
  l'utilisateur garde sa cible horizontale en prenant de l'altitude. La
  vitesse beneficie deja du multiplicateur Shift (run) et des
  multiplicateurs editor-camera-speed / terrain-scale.

Item 4 — Grille : maille 8 m -> 5 m :
  WorldEditorSession.h:171 : `m_gridCellMeters = 5.f` (etait 8.f). Demande
  utilisateur pour avoir un repere visuel plus fin au sol. La cellule
  reste modifiable a la volee dans l'UI panneau "Affichage & grille".

Item 5 — Grille collee au sol :
  Aucun changement de code requis. Le rendu existant (WorldEditorImGui.cpp
  L269-306) echantillonne deja `TerrainWorldY()` aux extremites de chaque
  ligne, donc la grille suit la heightmap. Note dans CODEBASE_MAP.md
  section 17 : la grille utilise `ImGui::GetForegroundDrawList()` (overlay
  2D sans depth test contre le 3D), donc visuellement elle est toujours
  dessinee par-dessus le sol meme au meme Y. Pour un vrai depth test il
  faudrait un line mesh 3D dedie (refactor non couvert ici).

Item 1 — Documentation :
  Chaque modif est commentee inline avec le tag "PR25 (M??.?)" pour
  faciliter le grep futur. CODEBASE_MAP.md section 17 etendue avec :
    - Section "Cause racine terrain invisible" : table des pipelines fixes (Terrain x2, GeometryPass), avec ligne et symptome.
    - Section "Finalisation editeur (PR25)" : table des 5 items couverts avec fichiers et numeros de ligne.

Items 6+7 (sculpt + splat ne fonctionnent pas) — A SUIVRE en PR26 :
  Le pipeline d'input est branche (Engine.cpp:3752 -> ApplyBrush /
  PaintSplat / Flush*), mais l'utilisateur signale que rien ne se passe
  visuellement au clic gauche maintenu. Trois hypotheses a debugger avec
  des logs DIAG en PR26 :
   1. `terrainPick=false` : le raycast camera->heightmap echoue (heightmap plate -> diff Y stable -> pas de transition detectee a 0.015).
   2. `WantsCaptureMouse=true` a tort sur le central node passthrough (PR16 a fixe le visuel mais pas necessairement l'input gating).
   3. `IsMouseDown(Left)=false` parce que ImGui consomme l'event en premier dans la chaine d'input.

Deploiement : ✅ client uniquement, pas de redeploiement serveur.