### PR TITLE
fix(render): frontFace=CW sur ShadowMapPass + WaterRenderer + DecalPa…

### DIFF
--- a/engine/render/DecalPass.cpp
+++ b/engine/render/DecalPass.cpp
@@ -227,7 +227,12 @@ namespace engine::render
 			rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 			rs.polygonMode = VK_POLYGON_MODE_FILL;
 			rs.cullMode = VK_CULL_MODE_NONE;
-			rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+			// PR26 (M??.?) : alignement de convention avec les autres pipelines
+			// fixes par PR24/PR25 (TerrainRenderer, GeometryPass, ShadowMapPass).
+			// Ici cullMode=NONE rend le frontFace inactif, donc pas de bug
+			// visuel actuel. Fix preventif au cas ou cullMode passerait a
+			// BACK_BIT plus tard pour une optimisation.
+			rs.frontFace = VK_FRONT_FACE_CLOCKWISE;
 			rs.lineWidth = 1.0f;
 
 			VkPipelineMultisampleStateCreateInfo ms{};

--- a/engine/render/ShadowMapPass.cpp
+++ b/engine/render/ShadowMapPass.cpp
@@ -197,7 +197,16 @@ namespace engine::render
 		rs.sType                   = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 		rs.polygonMode             = VK_POLYGON_MODE_FILL;
 		rs.cullMode                = VK_CULL_MODE_BACK_BIT; // actual mode selected at Record via dynamic state if needed.
-		rs.frontFace               = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		// PR26 (M??.?) : meme correction de winding apparent en clip space que
+		// PR24 (TerrainRenderer) et PR25 (GeometryPass). Le commit ee181da a
+		// change la convention de Camera::ComputeViewMatrix vers Vulkan LH +Z
+		// forward ; les meshes generes en CCW world-space apparaissent en CW
+		// dans le clip space. Avec cullMode=BACK_BIT + frontFace=CCW, les
+		// shadow casters etaient silencieusement rejetes -> aucune ombre
+		// projetee, et plus tard quand un mesh casterait des ombres, le bug
+		// serait inexplicable. Fix preventif : frontFace=CW pour aligner avec
+		// les pipelines deja corriges.
+		rs.frontFace               = VK_FRONT_FACE_CLOCKWISE;
 		rs.depthClampEnable        = VK_FALSE;
 		rs.depthBiasEnable         = VK_TRUE;
 		rs.lineWidth               = 1.0f;

--- a/engine/render/WaterRenderer.cpp
+++ b/engine/render/WaterRenderer.cpp
@@ -955,7 +955,12 @@ namespace engine::render
 		rsState.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 		rsState.polygonMode = VK_POLYGON_MODE_FILL;
 		rsState.cullMode    = VK_CULL_MODE_NONE; // water is two-sided (above + below)
-		rsState.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		// PR26 (M??.?) : alignement de convention avec les autres pipelines
+		// fixes par PR24/PR25 (TerrainRenderer, GeometryPass, ShadowMapPass).
+		// Ici cullMode=NONE rend le frontFace inactif (les deux faces sont
+		// rasterisees), donc pas de bug visuel actuel. Fix preventif au cas
+		// ou cullMode passerait a BACK_BIT plus tard pour une optimisation.
+		rsState.frontFace   = VK_FRONT_FACE_CLOCKWISE;
 		rsState.lineWidth   = 1.0f;
 
 		VkPipelineMultisampleStateCreateInfo msState{};


### PR DESCRIPTION
…ss (PR26)

Suite logique de PR24 (TerrainRenderer) et PR25 (GeometryPass). Le commit ee181da (Reapply view matrix transposee) a change la convention de Camera::ComputeViewMatrix vers Vulkan LH +Z forward ; les meshes generes en CCW world-space apparaissent en CW dans le clip space. Tous les pipelines configures `frontFace=CCW + cullMode=BACK_BIT` rejetaient silencieusement leurs triangles.

3 pipelines world-space restants alignes sur la convention CW :

1. ShadowMapPass (engine/render/ShadowMapPass.cpp:200) : VRAI BUG ACTIF `cullMode=BACK_BIT + frontFace=CCW` -> shadow casters silencieusement rejetes -> aucune ombre projetee. Pas observable sur la map test plate sans relief, mais le bug se serait revele des qu'un objet aurait du projeter une ombre.

2. WaterRenderer (engine/render/WaterRenderer.cpp:958) : PREVENTIF `cullMode=NONE` rendait deja le `frontFace` inactif (les deux faces du mesh d'eau sont rasterisees, comportement voulu). Pas de bug visuel actuel. Fix preventif au cas ou cullMode passerait a BACK_BIT plus tard pour une optimisation.

3. DecalPass (engine/render/DecalPass.cpp:230) : PREVENTIF Idem WaterRenderer (`cullMode=NONE`). Fix preventif.

Tous les graphics pipelines connus de l'engine sont desormais alignes sur `VK_FRONT_FACE_CLOCKWISE`. Si une regression future fait disparaitre un mesh world-space, verifier en priorite le `frontFace` du pipeline concerne.

Note : CODEBASE_MAP.md sera maj globalement apres merge de PR25 v2 + PR26
+ PR26.5 (fix Q/D), pour avoir une vue d'ensemble coherente. Les commentaires inline dans chaque fichier suffisent a tracer la motivation.

Pas de modification de comportement visible attendu sur la map de test (pas de cliffs, pas d'eau, pas de decals actifs en editeur). Le fix sera observable des qu'on activera ces features.

Deploiement : ✅ client uniquement, pas de redeploiement serveur.