### PR TITLE
fix(camera): right vector inverse — Q et D produisaient mouvement inv…

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -86,14 +86,24 @@ namespace engine
 			const float sp = std::sin(camera.pitch);
 
 			engine::math::Vec3 forward(-sy * cp, -sp, -cy * cp);
-			engine::math::Vec3 right(forward.z, 0.0f, -forward.x);
+			// PR26.5 (M??.?) : alignement avec le fix Camera.cpp:22. La fonction
+			// CameraViewportWorldDirection sert a calculer la direction du ray
+			// pour le raycast camera->terrain (RaycastTerrainFromCamera). Doit
+			// utiliser exactement les memes conventions que ComputeViewMatrix
+			// pour que le raycast aligne avec ce que la camera voit a l'ecran.
+			// Sans ce fix, le raycast utilisait un right_inverse alors que la
+			// matrice view (post-PR26.5) a un right_standard, donc le pickX/Z
+			// retourne par le raycast etait decale en X (souris a droite ->
+			// pickX a gauche du sol). Possible cause partielle des items 6+7
+			// (sculpt + splat ne fonctionnent pas) — a confirmer en PR27.
+			engine::math::Vec3 right(-forward.z, 0.0f, forward.x);
 			const float rightLen = right.Length();
 			right = rightLen > 0.0f ? right * (1.0f / rightLen) : engine::math::Vec3(1.0f, 0.0f, 0.0f);
 
 			engine::math::Vec3 up(
-				forward.y * right.z - forward.z * right.y,
-				forward.z * right.x - forward.x * right.z,
-				forward.x * right.y - forward.y * right.x);
+				right.y * forward.z - right.z * forward.y,
+				right.z * forward.x - right.x * forward.z,
+				right.x * forward.y - right.y * forward.x);
 			const float upLen = up.Length();
 			up = upLen > 0.0f ? up * (1.0f / upLen) : engine::math::Vec3(0.0f, 1.0f, 0.0f);
 

--- a/engine/render/Camera.cpp
+++ b/engine/render/Camera.cpp
@@ -18,15 +18,24 @@ namespace engine::render
 		const float sp = std::sin(pitch);
 		// Forward in world (camera looks along -Z in camera space, so forward = -view direction).
 		const engine::math::Vec3 forward(-sy * cp, -sp, -cy * cp);
-		// Right = cross(world up, forward); world up = (0, 1, 0).
-		engine::math::Vec3 right(forward.z, 0.0f, -forward.x);
+		// PR26.5 (M??.?) : right vector via convention standard cross(forward, world_up)
+		// au lieu de cross(world_up, forward). L'ancien calcul donnait un right
+		// inverse (-X au lieu de +X pour yaw=0), ce qui se traduisait par les
+		// touches Q et D produisant un mouvement world inverse (D allait a
+		// gauche, Q allait a droite). Confirme par l'utilisateur 2026-05-06.
+		// Le up calcule via cross(right, forward) ci-dessous donne LE MEME
+		// vecteur up qu'avant (cross(right_new, forward) = -cross(forward, right_new)
+		// = -cross(forward, -right_old) = cross(forward, right_old) = up_old),
+		// donc le rendu Y reste inchange. Seul le mouvement horizontal Q/D est
+		// corrige.
+		engine::math::Vec3 right(-forward.z, 0.0f, forward.x);
 		float rlen = right.Length();
 		if (rlen > 0.0f) right = right * (1.0f / rlen);
 		else right = engine::math::Vec3(1.0f, 0.0f, 0.0f);
-		// Up = cross(forward, right).
-		engine::math::Vec3 up(forward.y * right.z - forward.z * right.y,
-			forward.z * right.x - forward.x * right.z,
-			forward.x * right.y - forward.y * right.x);
+		// Up = cross(right, forward) (convention RH standard du triedre).
+		engine::math::Vec3 up(right.y * forward.z - right.z * forward.y,
+			right.z * forward.x - right.x * forward.z,
+			right.x * forward.y - right.y * forward.x);
 		float ulen = up.Length();
 		if (ulen > 0.0f) up = up * (1.0f / ulen);
 		else up = engine::math::Vec3(0.0f, 1.0f, 0.0f);


### PR DESCRIPTION
…erse (PR26.5)

User confirme apres test PR25 v2 (2026-05-06) : "il y a que les mouvements de Q et D a corriger". Cause identifiee par calcul :

`Camera::ComputeViewMatrix` (engine/render/Camera.cpp:22) calculait :
    right = (forward.z, 0, -forward.x)
soit `cross(world_up, forward)` au lieu de la convention RH standard `cross(forward, world_up)`. Pour yaw=0 pitch=0.35 :
    forward = (0, -0.343, -0.939)
    right_old = (-0.939, 0, 0)  -> normalise (-1, 0, 0) = -X (inverse)
    right_new = (0.939, 0, 0)   -> normalise (+1, 0, 0) = +X (correct)

Consequence cote mouvement clavier :
    D (rightKey) -> position += rightX * dist = -dist sur X -> camera va a GAUCHE
    Q (leftKey)  -> position -= rightX * dist = +dist sur X -> camera va a DROITE
Q et D etaient donc inverses dans leur effet world-space.

Fix Camera.cpp:22 :
    right = (-forward.z, 0, forward.x)  // cross(forward, world_up)

Le vecteur up est aussi mis a jour pour passer de cross(forward, right) a cross(right, forward) — cela donne LE MEME resultat numerique qu'avant (cross(right_new, forward) = -cross(forward, right_new) = -cross(forward, -right_old) = cross(forward, right_old) = up_old). Donc le rendu Y reste strictement identique a PR25 v2 ; seul le sens horizontal Q/D change.

Fix Engine.cpp:88-89 (CameraViewportWorldDirection) : meme correction appliquee pour que le raycast camera->terrain reste coherent avec la matrice view. Le raycast est utilise par RaycastTerrainFromCamera (item brush picking pour sculpt/splat). Sans ce fix, le ray aurait un right inverse par rapport a la matrice projection -> pickX retourne decale en X, possible cause partielle des items 6+7 (sculpt + splat ne fonctionnent pas). A confirmer en PR27.

Verification triedre RH apres fix (yaw=0, pitch=0.35) :
    right   = (1, 0, 0)         -> +X ✓
    up      = (0, 0.939, -0.343) -> +Y dominant (rendu vertical inchange) ✓
    forward = (0, -0.343, -0.939) -> -Z dominant (regarde devant + vers le bas) ✓
    cross(right, up).normalized() = (0, 0.343, 0.939) -> oppose a forward ✓
    -> triedre RH (right, up, -forward) coherent.

Pas de modif de comportement vertical attendue (R/F continuent de fonctionner normalement, R = monter, F = descendre). Seul Q et D changent.

Deploiement : ✅ client uniquement (Camera et raycast sont cote rendu / input client). Pas de redeploiement serveur.