### PR TITLE
diag(lighting): court-circuit GBufferA direct (PR29 - terrain invisible)

### DIFF
--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -113,6 +113,20 @@ void main()
         return;
     }
 
+    // ====================================================================
+    // PR29 DIAG (TERRAIN INVISIBLE) — court-circuit §6.3 du doc
+    // docs/INVESTIGATION_terrain_invisible.md
+    // - Si on voit l'orange (1.0, 0.55, 0.1) sur la zone terrain :
+    //     => terrain ECRIT bien GBufferA, bug en aval (lighting/PBR/IBL).
+    // - Si on voit toujours gris/beige uniforme :
+    //     => terrain n'ECRIT PAS GBufferA OU la depth reste a 1.0
+    //        (depth>=1 early-out plus haut). Bug en amont (pipeline,
+    //         framebuffer, winding, barriere). Branche DIAG-ONLY, ne
+    //         JAMAIS merger sur main : ce shader saute toute la lighting.
+    // ====================================================================
+    outSceneColorHDR = vec4(albedo, 1.0);
+    return;
+
     // ---- Reconstruct world-space position from depth -------------------
     // NDC xy in [-1,+1]; depth in [0,1] (Vulkan convention).
     vec2  ndcXY  = inUV * 2.0 - 1.0;


### PR DESCRIPTION
Apply hack section 6.3 du document docs/INVESTIGATION_terrain_invisible.md. Le terrain reste invisible dans World Editor malgre PR #427 (matrix view fix ee181da) et PR #450 (frontFace=CW). Symptome : viewport gris/beige uniforme (skyColor) au lieu de l'albedo orange (1.0, 0.55, 0.1) ecrit par le fallback noUserTextures du fragment terrain.

Cette branche est DIAG-ONLY, ne JAMAIS merger sur main. Le shader saute toute la lighting/PBR/IBL et affiche directement albedo apres l'early-out depth>=1.

Lecture du resultat sur le binaire CI :
- Pixels ORANGE sur la zone terrain => terrain ecrit bien GBufferA, depth est < 1.0 sur ces pixels. => bug aval : lighting math (PBR/IBL/skyColor early-out residuel). => prochain PR cible lighting.frag.
- Toujours gris/beige uniforme => depth reste >= 1.0 (terrain n'ecrit pas la depth, ou pas de fragment rasterise du tout : pipeline KO, winding, barriere, framebuffer). => prochain PR active validation layers + capture RenderDoc.