### PR TITLE
fix(render): revert frontFace CW->CCW (PR31, terrain et avatar invisi…

### DIFF
--- a/engine/render/GeometryPass.cpp
+++ b/engine/render/GeometryPass.cpp
@@ -373,16 +373,15 @@ namespace engine::render
 		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 		rs.polygonMode = VK_POLYGON_MODE_FILL;
 		rs.cullMode    = VK_CULL_MODE_BACK_BIT;
-		// PR25 (M??.?) : meme correction que TerrainRenderer.cpp:528 (PR24).
-		// Le commit ee181da (Reapply view matrix transposee) a change la
-		// convention de Camera::ComputeViewMatrix vers Vulkan LH +Z forward.
-		// Avec cette nouvelle matrice, les meshes generes en CCW world-space
-		// apparaissent en CW dans le clip space. Avec frontFace=CCW +
-		// cullMode=BACK_BIT, le pipeline rejetait silencieusement TOUS les
-		// triangles -> avatar humanoide invisible en mode editeur (item 2 de
-		// la finalisation editeur 2026-05-06) ET dans le client de jeu post-
-		// EnterWorld (regression notee 2026-05-05). Fix : frontFace=CW.
-		rs.frontFace   = VK_FRONT_FACE_CLOCKWISE;
+		// PR31 (revert PR #450 / PR24) : retour a CCW pour les meshes geometry
+		// (avatar humanoide, props). Meme cause/fix que TerrainRenderer.cpp:527 :
+		// la PR #457 (b470873) a corrige le vecteur right de la camera, ce qui
+		// mirror X dans la matrice view et flippe le winding clip-space par
+		// rapport a l'epoque de PR #450. frontFace=CW cullait silencieusement
+		// l'avatar et les props depuis 8787970 (8787970 = merge PR #457).
+		// Avec PR31, l'avatar humanoide redevient visible dans World Editor
+		// (item 2 finalisation 2026-05-06) ET en client post-EnterWorld.
+		rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
 		rs.lineWidth   = 1.0f;
 
 		VkPipelineMultisampleStateCreateInfo ms = {};

--- a/engine/render/terrain/TerrainRenderer.cpp
+++ b/engine/render/terrain/TerrainRenderer.cpp
@@ -525,16 +525,25 @@ namespace engine::render::terrain
             rasCI.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
             rasCI.polygonMode = VK_POLYGON_MODE_FILL;
             rasCI.cullMode    = VK_CULL_MODE_BACK_BIT;
-            // PR #427 follow-up : winding apparent en clip space inverse depuis le commit
-            // ee181da (Reapply view matrix transposee, convention Vulkan LH +Z forward).
-            // Le mesh terrain est genere en CCW dans le plan XZ world space, mais la nouvelle
-            // matrice view fait apparaitre les triangles en CW dans le clip space. Avec
-            // frontFace=CCW, le pipeline rejetait silencieusement TOUS les patches (terrain
-            // invisible malgre patches kept=225 cote CPU frustum cull). Confirme par PR
-            // diag avec cullMode=NONE : terrain visible (depth<1 = bleu, sky=rouge dans la
-            // viz depth). Fix permanent : passer frontFace en CLOCKWISE pour matcher la
-            // nouvelle convention du clip space sans toucher au mesh.
-            rasCI.frontFace   = VK_FRONT_FACE_CLOCKWISE;
+            // PR31 (revert PR #450 / PR24) : retour a CCW.
+            //
+            // Historique : PR #450 (49d462b) avait pose frontFace=CW pour compenser un
+            // winding clip-space cense etre devenu CW apres le matrix view fix ee181da.
+            // PR #457 (b470873) a ensuite corrige le vecteur right de la camera
+            // (cross(forward, world_up) au lieu de cross(world_up, forward)). Cette
+            // correction mirror l'axe X dans la matrice view -> le winding apparent en
+            // clip space est repasse en CCW (chirality inversee par le mirror X).
+            //
+            // Resultat : a partir de PR #457 (sur main depuis 8787970), frontFace=CW
+            // cullait silencieusement tous les patches terrain meme avec patches
+            // kept=225 cote CPU. Symptome : viewport gris uniforme dans World Editor
+            // (toute la lighting prend la branche depth>=1 -> skyColor partout).
+            //
+            // Fix : repasser a CCW (convention Vulkan par defaut). Coherent avec un
+            // triedre RH (right=cross(forward, up), up=cross(right, forward),
+            // forward = -view_dir) pour un mesh CCW en world-space comme les patches
+            // terrain (cf. TerrainMeshGenerator).
+            rasCI.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
             rasCI.lineWidth   = 1.0f;
 
             VkPipelineMultisampleStateCreateInfo msCI{};
@@ -1190,12 +1199,11 @@ namespace engine::render::terrain
                 cliffRas.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
                 cliffRas.polygonMode = VK_POLYGON_MODE_FILL;
                 cliffRas.cullMode    = VK_CULL_MODE_BACK_BIT;
-                // PR #427 follow-up : meme correction que pour le pipeline terrain principal
-                // (ligne 528). Convention Vulkan LH +Z forward (ee181da) -> winding apparent
-                // CW en clip space -> frontFace doit etre CLOCKWISE pour ne pas rejeter les
-                // faces avant. La map de test n'a pas de cliffs (log "Cliff meshes loaded:
-                // 0/0"), mais on aligne la cohérence pour les maps futures.
-                cliffRas.frontFace   = VK_FRONT_FACE_CLOCKWISE;
+                // PR31 (revert PR #450) : meme retour a CCW que pour le pipeline terrain
+                // principal (cf. commentaire detaille ligne 527). Coherence avec la matrice
+                // view post-PR #457 (b470873) qui mirror X et flippe le winding clip-space
+                // par rapport a l'epoque de PR #450.
+                cliffRas.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
                 cliffRas.lineWidth   = 1.0f;
 
                 VkPipelineMultisampleStateCreateInfo cliffMs{};


### PR DESCRIPTION
…bles)

Cause racine identifiee de la regression "terrain invisible dans World Editor" (et avatar humanoide invisible) post-merge PR #457 :

Chaine causale :
1. ee181da (PR #427) : matrix view fix, winding clip-space devenu CW.
2. PR #450 / PR24 (49d462b) : pose frontFace=CW partout pour compenser. Terrain et avatar visibles a ce stade. ✅
3. PR #457 / PR26.5 (b470873) : corrige le vecteur right de la camera (cross(forward, world_up) au lieu de cross(world_up, forward)). Cette correction mirror l'axe X dans la matrice view, ce qui flippe la chirality des triangles dans le clip space → winding apparent repasse en CCW. ⛔ Terrain et avatar de nouveau invisibles.

User confirme empiriquement : "à PR #453 (50251cb) le sol semble fonctionnel". Les seuls commits entre 50251cb et HEAD sont b470873 (PR #457) puis le merge 8787970 → la regression est bien introduite par PR #457.

Diagnostic confirme par hack §6.3 du doc INVESTIGATION_terrain_invisible (PR29 lighting court-circuit -> GBufferA direct) : viewport uniformement gris = TOUS les pixels passent par la branche depth>=1 du shader, donc zero fragment terrain rasterise malgre patches kept=225 cote CPU.

Fix : repasser frontFace en CCW (convention Vulkan par defaut), coherent avec un triedre RH standard et un mesh CCW en world-space. Trois sites :

- engine/render/terrain/TerrainRenderer.cpp:537 (pipeline terrain main)
- engine/render/terrain/TerrainRenderer.cpp:1207 (pipeline cliffs)
- engine/render/GeometryPass.cpp:385 (pipeline avatar / props)

Bonus attendu : avatar humanoide redevient visible (item 2 finalisation editeur 2026-05-06), et regression EnterWorld du client jeu probablement ferme aussi (meme cause).

Deploiement : ✅ client uniquement (pipelines de rendu, pas de protocole). Pas de redeploiement serveur.