### PR TITLE
fix(terrain-editing): items 6+7 — sculpt + splat paint visibles (PR32)

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -3723,6 +3723,10 @@ namespace engine
 							m_vkDeviceContext.GetPhysicalDevice(),
 							m_vkDeviceContext.GetGraphicsQueue(),
 							m_vkDeviceContext.GetGraphicsQueueFamilyIndex());
+						// PR32 : meme raison que le brush splat (mode==1). Une bande de route
+						// vient d'etre peinte, on coupe l'orange fallback pour rendre
+						// visible la modification splat sous la route.
+						m_terrain.SetNoUserTexturesFallback(false);
 						ws.MutableDoc().routes.push_back(std::move(rp));
 						ws.ClearRouteDraft();
 						ws.SetStatus("Routes: bande splat appliquée — sauvegardez l’édition pour persister SLAP + JSON.");
@@ -3775,6 +3779,13 @@ namespace engine
 							m_vkDeviceContext.GetPhysicalDevice(),
 							m_vkDeviceContext.GetGraphicsQueue(),
 							m_vkDeviceContext.GetGraphicsQueueFamilyIndex());
+						// PR32 : des qu'on peint splat, l'utilisateur veut voir le resultat.
+						// Or le push-constant noUserTextures=1 (pose au boot quand aucune
+						// texture user n'est assignee) court-circuite le sampling splat dans
+						// terrain.frag et affiche orange partout. On le desactive ici pour
+						// laisser passer la couche procedurale modulee par le splat peint.
+						// Item 7 finalisation editeur 2026-05-06.
+						m_terrain.SetNoUserTexturesFallback(false);
 					}
 					else if (ws.TerrainEditMode() == 2)
 					{
@@ -3784,6 +3795,9 @@ namespace engine
 							m_vkDeviceContext.GetPhysicalDevice(),
 							m_vkDeviceContext.GetGraphicsQueue(),
 							m_vkDeviceContext.GetGraphicsQueueFamilyIndex());
+						// PR32 : meme raison que mode==1 (splat). Le grass mask est lu
+						// dans terrain.frag aussi et l'orange le masque.
+						m_terrain.SetNoUserTexturesFallback(false);
 					}
 					else
 					{

--- a/engine/render/terrain/TerrainEditingTools.cpp
+++ b/engine/render/terrain/TerrainEditingTools.cpp
@@ -29,6 +29,17 @@ namespace engine::render::terrain
             return;
         }
 
+        // PR32 : barriers heightmap doivent inclure VERTEX_SHADER. La heightmap
+        // (R16_UNORM, binding 0) est echantillonnee dans terrain.vert ligne 72
+        // (`texture(uHeightmap, uv).r`) pour deplacer les sommets ; le fragment
+        // shader ne la lit PAS. Avec dstStage=FRAGMENT_SHADER seul, le vertex
+        // shader peut lire des donnees stale apres un upload (cache L1 non flush
+        // pour la pipeline stage non listee) -> sculpt invisible cote user
+        // alors que l'upload GPU est correct. Inclure VERTEX_SHADER + FRAGMENT
+        // pour robustesse future si la frag finit par sampler aussi.
+        constexpr VkPipelineStageFlags kHeightmapShaderStages =
+            VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+
         VkImageMemoryBarrier toTransfer{};
         toTransfer.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         toTransfer.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -40,7 +51,7 @@ namespace engine::render::terrain
         toTransfer.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
         toTransfer.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vkCmdPipelineBarrier(cmd,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+            kHeightmapShaderStages,
             VK_PIPELINE_STAGE_TRANSFER_BIT,
             0, 0, nullptr, 0, nullptr, 1, &toTransfer);
 
@@ -66,9 +77,11 @@ namespace engine::render::terrain
         toSample.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
         toSample.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         toSample.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        // PR32 : meme commentaire que pour toTransfer ci-dessus. dstStage doit
+        // inclure VERTEX_SHADER puisque c'est la qu'on sample uHeightmap.
         vkCmdPipelineBarrier(cmd,
             VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+            kHeightmapShaderStages,
             0, 0, nullptr, 0, nullptr, 1, &toSample);
     }
 
@@ -198,6 +211,13 @@ namespace engine::render::terrain
                 return false;
             }
 
+            // PR32 : meme correction que dans RecordHeightmapR16UploadCommands.
+            // UploadToImage est utilise par FlushHeightmap (fallback synchrone)
+            // pour la heightmap. La heightmap est lue par terrain.vert (vertex
+            // shader) -> les barriers doivent inclure VERTEX_SHADER.
+            constexpr VkPipelineStageFlags kHeightmapShaderStages =
+                VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+
             // Barrier: SHADER_READ_ONLY_OPTIMAL → TRANSFER_DST_OPTIMAL
             {
                 VkImageMemoryBarrier b{};
@@ -211,7 +231,7 @@ namespace engine::render::terrain
                 b.srcAccessMask       = VK_ACCESS_SHADER_READ_BIT;
                 b.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
                 vkCmdPipelineBarrier(cmd,
-                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    kHeightmapShaderStages,
                     VK_PIPELINE_STAGE_TRANSFER_BIT,
                     0, 0, nullptr, 0, nullptr, 1, &b);
             }
@@ -244,9 +264,10 @@ namespace engine::render::terrain
                 b.subresourceRange    = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
                 b.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
                 b.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+                // PR32 : dstStage doit inclure VERTEX_SHADER (cf. ci-dessus).
                 vkCmdPipelineBarrier(cmd,
                     VK_PIPELINE_STAGE_TRANSFER_BIT,
-                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                    kHeightmapShaderStages,
                     0, 0, nullptr, 0, nullptr, 1, &b);
             }
 


### PR DESCRIPTION
Deux bugs distincts cumules empechaient les outils brush du World Editor de montrer leur effet visuellement.

== Item 6 : sculpt (BrushOp Raise/Lower/Smooth/Flatten) ==

ApplyBrush modifiait bien le CPU et FlushHeightmap (ou son equivalent inline RecordHeightmapR16UploadCommands cote Engine.cpp:4153) uploadait bien les nouvelles donnees via vkCmdCopyBufferToImage. Le bug etait dans les barriers qui encadrent l'upload : les deux barriers (toTransfer et toSample) utilisaient VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT comme src/dst stage cote shader.

Or `uHeightmap` (binding 0, R16_UNORM) est echantillonne UNIQUEMENT dans terrain.vert (ligne 72: `texture(uHeightmap, uv).r` pour deplacer les sommets, puis ligne 91 pour le geomorphing parent LOD). Le fragment shader ne le lit pas. Avec dstStage=FRAGMENT_SHADER seul, le vertex shader peut continuer a lire la heightmap stale apres l'upload (la pipeline stage VERTEX_SHADER n'est pas synchronisee par le barrier). Symptome : l'utilisateur clique le brush, le CPU + GPU montrent le bon delta dans les logs/RenderDoc, mais le rendu suivant utilise les anciennes hauteurs -> sculpt invisible.

Fix : utiliser VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | FRAGMENT_SHADER_BIT (constante kHeightmapShaderStages) sur les deux fonctions :
- RecordHeightmapR16UploadCommands (Engine.cpp:4153 path principal)
- UploadToImage (FlushHeightmap path fallback synchrone)

== Item 7 : splat paint (PaintSplat / PaintGrassMask / Routes) ==

PaintSplat modifiait bien le CPU splat data, FlushSplatMap uploadait bien au GPU (ReuploadSplatMap, sync via vkQueueWaitIdle, dstStage=FRAGMENT correct puisque uSplatMap est lu dans terrain.frag). Les modifications etaient donc bien presentes sur GPU.

Mais terrain.frag court-circuite tout le sampling splat des que le push- constant `pc.noUserTextures != 0` (cf. PR #427) :

  if (pc.noUserTextures != 0) {
      outAlbedo = vec4(1.0, 0.55, 0.1, 1.0);  // orange uniforme
  } else {
      outAlbedo = vec4(albedo, 1.0);  // sample splat normal
  }

Et ce flag est pose une fois pour toutes au boot/map-load (Engine::Rebuild WorldEditorTerrainGpu :4928) quand la map de test n'a aucune texture user assignee aux 4 layers splat. Resultat : les pixels peints en splat etaient masques par l'orange et l'utilisateur avait l'impression que rien ne se passait.

Fix : au moment ou l'utilisateur DECLENCHE une peinture (mode 1 splat, mode 2 grass mask, ou apply route polyline), couper le fallback orange via m_terrain.SetNoUserTexturesFallback(false). La couche procedurale (texArrays d'init) module le splat peint et devient visible.

Le flag est repose a son etat correct au prochain ReloadTerrainGpu (nouvelle carte / chargement carte) puisque RebuildWorldEditorTerrainGpu re-evalue les splatLayerTextureRefs.

== Tests user attendus ==

- Mode sculpt (TerrainEditMode == 0) + brush radius 10m strength 0.10 : cliquer-glisser sur le terrain -> deformation visible (raise/lower selon BrushOp), idem smooth et flatten.
- Mode splat (TerrainEditMode == 1) + layer 0..3 : cliquer-glisser ->
  l'orange disparait au premier clic, la texture procedurale du layer selectionne apparait sous le brush.
- Mode grass mask (TerrainEditMode == 2) + erase toggle : idem orange off et la densite d'herbe varie.
- Routes (TerrainEditMode == 4) -> apply : l'orange disparait, la bande splat de la route est visible.

== Hors scope ==

- Avatar humanoide invisible reste un autre bug (item 2 finalisation, sera PR33 dediee).
- Le strength=0.10 par defaut est conservatif : 0.2m world-height par clic au centre du brush. Si trop faible visuellement, l'UI permet de monter jusqu'a 1.0.

Deploiement : ✅ client uniquement (rendu pur + edition terrain locale). Pas de redeploiement serveur.