### PR TITLE
tickets(M100): éditeur de monde 3D AAA + systèmes environnementaux (34 tickets)

### DIFF
--- a/tickets/M100/INDEX.md
+++ b/tickets/M100/INDEX.md
@@ -1,0 +1,122 @@
+# Milestone M100 — Éditeur de monde 3D AAA et systèmes environnementaux
+
+> **Cluster M100.** Distinct de M43 (panneaux ImGui spécialisés) et de M44 (infrastructure
+> serveur). M100 livre **l'éditeur de monde 3D** et **toute la simulation
+> environnementale gameplay côté client** (surfaces, hazards, saisons, météo,
+> ombre thermique, interaction joueur ↔ végétation, objets interactifs sobres).
+>
+> **Pré-requis livré :** M43.4 — ImGui foundation.
+
+## Principes architecturaux structurants
+
+| Couche | Rôle | Ne fait PAS |
+|--------|------|-------------|
+| **Client (`engine_core` + Vulkan)** | Tout le rendu, toute la simulation gameplay locale, lecture des chunk packages, déclenchement réseau. | Rien d'autre que ce qui est listé. |
+| **Éditeur (`world_editor_app`, `--editor`)** | Création/modification de la carte. Écriture des chunk packages. Mode playtest F5 utilisant le code client de prod. | Pas de pipeline de rendu séparé. Pas de format "preview". Pas de logique gameplay propriétaire. |
+| **Serveur (`server_app`)** | Auth + relais des messages multi-clients (positions, actions, broadcasts saison/météo). | Aucune simulation environnementale. Aucun chargement de splat / shade / thermal. Aucun calcul de surface. |
+
+**Contrat de parité éditeur ↔ client.** Tout ce que l'éditeur écrit est lu et rendu
+identiquement par le client en mode jeu normal. Pipeline Vulkan unique. Format
+binaire unique. Shaders uniques. Versions strictement alignées. Tests de round-trip
+obligatoires.
+
+## Liste des tickets
+
+| Ticket | Titre | Phase | Dépendances directes | Statut |
+|--------|-------|-------|----------------------|--------|
+| M100.1  | World Editor Bootstrap | 1 — Fondations | M43.4 | Ready |
+| M100.2  | Command Stack & Undo/Redo | 1 — Fondations | M100.1 | Ready |
+| M100.3  | Zone Builder Library Extraction | 1 — Fondations | M100.1 | Ready |
+| M100.4  | Editor Camera Modes | 1 — Fondations | M100.1 | Ready |
+| M100.5  | Heightmap Data Structure | 2 — Terrain | M100.3, M100.4 | Ready |
+| M100.6  | Terrain Sculpting Brushes | 2 — Terrain | M100.2, M100.5 | Ready |
+| M100.7  | Terrain Stamps & Procedural Generators | 2 — Terrain | M100.6 | Ready |
+| M100.8  | Terrain LOD Regeneration | 2 — Terrain | M100.5 | Ready |
+| M100.9  | Splat Map System | 3 — Splat / Surfaces / Collision | M100.5 | Ready |
+| M100.10 | Splat Painting Brushes | 3 — Splat / Surfaces / Collision | M100.2, M100.9 | Ready |
+| M100.11 | Surface Material System & SurfaceQuery (client) | 3 — Splat / Surfaces / Collision | M100.9 | Ready |
+| M100.12 | Collision Proxy System | 3 — Splat / Surfaces / Collision | M100.1 | Ready |
+| M100.13 | Water Surfaces (Lakes & Rivers) | 4 — Hydrologie & Hazards | M100.5, M100.6 | Ready |
+| M100.14 | Water Render Pass | 4 — Hydrologie & Hazards | M100.13 | Ready |
+| M100.15 | Water Surface Hook (Wading & Swimming) | 4 — Hydrologie & Hazards | M100.11, M100.13 | Ready |
+| M100.16 | Hazard Volume System | 4 — Hydrologie & Hazards | M100.11 | Ready |
+| M100.17 | Easy Placement Tool | 5 — Placement & Végétation | M100.2, M100.5, M100.12 | Ready |
+| M100.18 | Vegetation Library & Density Painting | 5 — Placement & Végétation | M100.5, M100.17 | Ready |
+| M100.19 | Procedural Forest & Field Tools | 5 — Placement & Végétation | M100.11, M100.18 | Ready |
+| M100.20 | Vegetation Wind Animation | 5 — Placement & Végétation | M100.18 | Ready |
+| M100.21 | Vegetation Player Interaction Shader | 5 — Placement & Végétation | M100.20 | Ready |
+| M100.22 | Volumetric Fog Volumes | 6 — Atmosphère & Brouillard | M100.4 | Ready |
+| M100.23 | Distance Fog & Height Fog Tuning | 6 — Atmosphère & Brouillard | M100.22 | Ready |
+| M100.24 | Sun, Sky & Probes Editor | 6 — Atmosphère & Brouillard | M100.23 | Ready |
+| M100.25 | Season System & Time-of-Year | 7 — Saisons / Météo / Thermal | M100.24 | Ready |
+| M100.26 | Weather System & Dynamic Surface Modifiers | 7 — Saisons / Météo / Thermal | M100.11, M100.25 | Ready |
+| M100.27 | Shade Map & Thermal Map (`ThermalQuery`) | 7 — Saisons / Météo / Thermal | M100.18, M100.25, M100.26 | Ready |
+| M100.28 | Gameplay Zones & Weather Zones | 7 — Saisons / Météo / Thermal | M100.26 | Ready |
+| M100.29 | Spline Tool & Roads | 8 — Routes / Ponts / Structures | M100.10, M100.17 | Ready |
+| M100.30 | Bridges & Modular Walls | 8 — Routes / Ponts / Structures | M100.17, M100.29 | Ready |
+| M100.31 | Hamlet Generator | 8 — Routes / Ponts / Structures | M100.17 | Ready |
+| M100.32 | Interactive Props (Doors, Windows, Trapdoors, Simple Chests) | 9 — Objets interactifs | M100.12, M100.17 | Ready |
+| M100.33 | Footstep Audio Surface Hook & Playtest Mode (F5) | 10 — Polissage final | M100.11, M100.16, M100.26, M100.27 | Ready |
+| M100.34 | Selection, Layers, Minimap & Save/Load Zone | 10 — Polissage final | M100.5, M100.9, M100.16, M100.27, M100.28, M100.32 | Ready |
+
+## Ordre d'implémentation recommandé
+
+L'ordre des tickets reflète l'ordre d'implémentation. Trois remarques :
+
+1. **Phase 1 doit être livrée avant tout le reste** (shell, Command stack, lib zone_builder
+   commune, modes caméra) sinon les phases suivantes n'ont pas de surface UI ni de
+   sérialisation propre.
+2. **M100.11 (`SurfaceType` + `SurfaceQuery`) est le pivot gameplay** ; M100.15, M100.16,
+   M100.19, M100.26, M100.27, M100.33 en dépendent. Ne pas le retarder.
+3. **Phase 7 (saisons/météo/thermal) doit attendre la végétation (M100.18)** pour
+   pouvoir générer la shade map à partir de la canopée.
+
+## Risques techniques connus
+
+| Risque | Ticket | Atténuation |
+|--------|--------|-------------|
+| Budget perf foliage interaction (< 0.5 ms sur 100k instances) | M100.21 | Buffer GPU compact, 32 influences max par chunk, shader simplifié, mesure obligatoire avec `engine::core::Profiler`. |
+| Transitions saisonnières fluides | M100.25 | LUT 4×N + interpolation linéaire sur 2 jours in-game. Pas de blend per-asset, on bascule des paramètres globaux. |
+| Génération automatique de proxies de collision sur meshes complexes | M100.12 | Trois niveaux explicites (capsule / convex hull / triangle mesh). Heuristique d'auto-fit + édition manuelle obligatoire pour les meshes irréguliers. |
+| Latence réseau de l'animation des objets interactifs | M100.32 | Animation locale immédiate à la décision client. Réception distante avec interpolation de phase d'animation. Aucune validation serveur. |
+| Régénération LOD coûteuse en édition continue | M100.8 | Régénération en arrière-plan + LOD0 immédiat ; LODs N>0 retardés au commit du brushstroke. |
+| Cohérence des coutures inter-chunks en peinture splat | M100.10 | Gather sur le chunk voisin lu en lecture seule, écriture des deux côtés dans la même commande. |
+
+## Contrats partagés (référencés transversalement)
+
+| Contrat | Défini dans | Consommé par |
+|---------|-------------|--------------|
+| `TerrainChunk` (heightmap binaire) | M100.5 | M100.6, M100.7, M100.8, M100.9, M100.13, M100.27, M100.34 |
+| `surface_table.json` + enum `SurfaceType` | M100.11 | M100.15, M100.16, M100.19, M100.26, M100.29, M100.30, M100.33, M100.34 |
+| Shade map binaire `shade.bin` | M100.27 | M100.27, M100.34 |
+| Thermal map (calculée client, pas persistée) | M100.27 | M100.33 |
+| `*.collision.bin` (format proxy) | M100.12 | M100.17, M100.30, M100.32, M100.34 |
+| `instances/hazards.bin` | M100.16 | M100.34 |
+| `instances/interactives.bin` | M100.32 | M100.34 |
+| `instances/zones.bin` | M100.28 | M100.26, M100.34 |
+| `weather_modifiers.json` | M100.26 | M100.11, M100.27, M100.33 |
+| Protocole `InteractiveStateChange` | M100.32 | (relais serveur) |
+| Protocole `SeasonBroadcast` | M100.25 | (relais serveur) |
+| Protocole `WeatherBroadcast` | M100.26 | (relais serveur) |
+| Splat-map binaire `splat.bin` | M100.9 | M100.10, M100.11, M100.27, M100.34 |
+| `WindParams` constant buffer | M100.20 | M100.21 |
+
+## Format des tickets
+
+Chaque ticket suit le contrat de la section 7 du prompt directeur (titre, résumé,
+dépendances, portée, spec fonctionnelle, spec technique, diff CMake, schéma
+d'interaction, critères d'acceptation, tests, hors scope). Les fichiers C++ /
+shaders sont décrits **complets** (pas de patch/diff). Seul le `CMakeLists.txt`
+racine est modifié sous forme de blocs `before` / `after`.
+
+Les tickets qui exposent une surface ImGui ont un fichier compagnon
+`visuals/M100.x-Nom.html` reproduisant la mise en page exacte.
+
+## Déploiement
+
+> **Déploiement** : ⚠️ M100 introduit trois nouveaux protocoles relais
+> (`InteractiveStateChange` — opcode à allouer dans le ticket M100.32,
+> `SeasonBroadcast` — M100.25, `WeatherBroadcast` — M100.26). **Redéploiement
+> serveur (master + shard) requis** au moment où chaque ticket réseau est mergé
+> (M100.25, M100.26, M100.32). Tous les autres tickets de M100 sont
+> client/éditeur-only et ne nécessitent pas de redéploiement serveur.

--- a/tickets/M100/M100.1-WorldEditorBootstrap.md
+++ b/tickets/M100/M100.1-WorldEditorBootstrap.md
@@ -1,0 +1,294 @@
+# M100.1 — World Editor Bootstrap
+
+## Résumé
+
+Pose la coquille ImGui dédiée à l'éditeur de monde 3D : menu bar, dockspace
+persistant, panneaux vides ancrables (Scene, Inspector, Asset Browser, Outliner,
+Console), raccourcis clavier F1–F12, catégorie de log dédiée. Aucun outil
+d'édition n'est livré ; le ticket fournit la fondation sur laquelle tous les
+suivants se branchent.
+
+## Dépendances
+
+- **M43.4** — ImGui foundation (`engine::render::WorldEditorImGui`).
+- **M19.4** — `engine::core::Config` (`config.json` runtime).
+
+## Portée
+
+### Inclus
+- Nouvelle classe `engine::editor::world::WorldEditorShell`.
+- Dockspace persistant sauvegardé dans `editor.layout.ini` (chemin via
+  `paths.editorLayout` dans `config.json`).
+- Menu bar : `File`, `Edit`, `View`, `Tools`, `Window`, `Help`.
+- Panneaux vides : `Scene`, `Inspector`, `Asset Browser`, `Outliner`, `Console`,
+  `Tool Properties`. Chaque panneau est une classe séparée héritée de
+  `engine::editor::world::IPanel`.
+- Raccourcis F1 (Scene focus), F2 (Inspector focus), F3 (Asset Browser focus),
+  F4 (Outliner focus), F5 (réservé Playtest, no-op pour l'instant), F6
+  (Console), F11 (toggle plein écran de la fenêtre éditeur), F12 (toggle Tool
+  Properties).
+- Catégorie de log `Editor` (déjà existante) + sous-catégorie `EditorWorld`
+  ajoutée à `engine::core::LogCategory`.
+- Shell n'est instancié que si `--editor-world` (nouveau flag) ou
+  `editor.world.enabled = true` dans `config.json`. Sinon le shell ImGui
+  classique reste actif.
+
+### Hors scope
+- Aucun outil d'édition (sculpture, splat, placement) — tickets dédiés.
+- Pas de fenêtre playtest F5 (ticket M100.33).
+- Pas de gestion d'undo/redo (ticket M100.2).
+
+## Spécification fonctionnelle
+
+### Lancement
+
+```
+lcdlln_world_editor.exe --editor-world
+```
+ou via `config.json` :
+```json
+{ "editor": { "world": { "enabled": true, "layout_path": "editor_world_layout.ini" } } }
+```
+
+### Layout par défaut
+
+```
++-------------------------------------------------------------+
+|  File   Edit   View   Tools   Window   Help                 |
++----------------+--------------------+-----------------------+
+|                |                    |                       |
+|   Outliner     |     Scene (3D)     |     Inspector         |
+|   (F4)         |     (F1)           |     (F2)              |
+|                |                    |                       |
++----------------+--------------------+-----------------------+
+| Asset Browser (F3) | Tool Properties (F12)| Console (F6)    |
++--------------------+----------------------+-----------------+
+```
+
+Le layout est persisté entre sessions via `ImGui::SaveIniSettingsToDisk`.
+
+### Raccourcis
+
+| Touche | Action |
+|--------|--------|
+| F1 | Focus panneau Scene |
+| F2 | Focus panneau Inspector |
+| F3 | Focus panneau Asset Browser |
+| F4 | Focus panneau Outliner |
+| F5 | Réservé Playtest (no-op M100.1) |
+| F6 | Focus panneau Console |
+| F11 | Toggle plein écran fenêtre éditeur |
+| F12 | Toggle visibilité Tool Properties |
+| Ctrl+S | `MarkDirty` no-op + log "save not yet implemented" |
+| Ctrl+Q | Quitter (avec dialog de confirmation si `m_dirty`) |
+
+### Menu bar
+
+| Menu | Items M100.1 |
+|------|--------------|
+| File | New (no-op log), Open (no-op log), Save (no-op log), Exit |
+| Edit | Undo/Redo grisés (activés en M100.2) |
+| View | Toggle de chaque panneau, Reset Layout |
+| Tools | (vide ; rempli par les tickets suivants) |
+| Window | Layouts pré-définis : Default, Sculpting, Painting, Placement (les 3 derniers identiques au Default en M100.1) |
+| Help | About : version + commit hash |
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/WorldEditorShell.h` | Déclaration `WorldEditorShell`. |
+| `engine/editor/world/WorldEditorShell.cpp` | Implémentation : menu bar, dockspace, dispatch F1–F12. |
+| `engine/editor/world/IPanel.h` | Interface de panneau (`Render`, `GetName`, `IsVisible`, `SetVisible`). |
+| `engine/editor/world/panels/ScenePanel.h/.cpp` | Panneau 3D (vide, juste un placeholder texte "Scene viewport"). |
+| `engine/editor/world/panels/InspectorPanel.h/.cpp` | Panneau Inspector (vide). |
+| `engine/editor/world/panels/AssetBrowserPanel.h/.cpp` | Panneau Asset Browser (vide). |
+| `engine/editor/world/panels/OutlinerPanel.h/.cpp` | Panneau Outliner (vide). |
+| `engine/editor/world/panels/ConsolePanel.h/.cpp` | Panneau Console : reflète les `LOG_*(EditorWorld, …)` via un sink `engine::core::Log`. |
+| `engine/editor/world/panels/ToolPropertiesPanel.h/.cpp` | Panneau Tool Properties (vide ; futurs outils s'enregistrent ici). |
+| `engine/editor/world/tests/WorldEditorShellTests.cpp` | Tests unitaires (cf. § Tests). |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/core/LogCategory.h` | Ajouter `EditorWorld`. |
+| `engine/Engine.cpp` | Si `editor.world.enabled` ou `--editor-world`, instancier `WorldEditorShell` au lieu (ou en plus) du shell M43.4 existant. |
+| `engine/editor/EditorMode.h/.cpp` | Ajouter accesseur `IsWorldEditorWorld()` (retourne `m_worldEditorWorld`). |
+| `config.json` | Ajouter section `editor.world` (`enabled: false`, `layout_path: "editor_world_layout.ini"`). |
+| `CMakeLists.txt` | Cf. § Diff CMake. |
+
+### Structures de données
+
+```cpp
+namespace engine::editor::world
+{
+	/// Interface commune à tous les panneaux ancrables du shell.
+	class IPanel
+	{
+	public:
+		virtual ~IPanel() = default;
+		/// Identifiant stable du panneau, utilisé comme nom de window ImGui.
+		virtual const char* GetName() const = 0;
+		/// Rend le contenu via ImGui::Begin/End. Le shell gère la visibilité.
+		virtual void Render() = 0;
+		virtual bool IsVisible() const = 0;
+		virtual void SetVisible(bool visible) = 0;
+	};
+
+	/// Coquille principale de l'éditeur de monde. Instanciée une fois par
+	/// processus quand `editor.world.enabled` est vrai.
+	class WorldEditorShell
+	{
+	public:
+		bool Init(const engine::core::Config& cfg);
+		void Shutdown();
+
+		/// Appelé chaque frame depuis Engine::DrawFrame avant la passe ImGui.
+		void RenderFrame();
+
+		/// Routes F1..F12 vers les panneaux. Retourne true si la touche a été consommée.
+		bool HandleShortcut(int virtualKey);
+
+		/// Marque le document éditeur comme modifié.
+		void MarkDirty(std::string_view reason);
+		bool IsDirty() const { return m_dirty; }
+
+	private:
+		void RenderMenuBar();
+		void RenderDockspace();
+		void EnsureLayoutPersisted();
+		void ResetLayoutToDefault();
+
+		std::vector<std::unique_ptr<IPanel>> m_panels;
+		std::string m_layoutPath;
+		bool m_dirty = false;
+		bool m_initialized = false;
+	};
+}
+```
+
+Toute fonction (libre, méthode, lambda nommée) ajoutée par ce ticket **doit
+être documentée** par un commentaire `///` Doxygen au-dessus de sa déclaration
+(rôle, paramètres non-évidents, effets de bord, contraintes thread/timing),
+conformément à `CLAUDE.md`.
+
+### Format de sérialisation
+
+`editor_world_layout.ini` est un fichier ImGui standard. Aucun format custom
+n'est introduit.
+
+### Passes frame graph ajoutées
+
+Aucune. Le shell s'appuie sur la passe ImGui existante (M43.4).
+
+### Shaders ajoutés
+
+Aucun.
+
+### Code client / parité
+
+Pas applicable : ce ticket ne produit aucune donnée chunk.
+
+### Réseau
+
+Aucun trafic réseau introduit.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/EditorMode.cpp
+    engine/editor/WorldEditorImGui.cpp
+    engine/editor/WorldEditorSession.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/EditorMode.cpp
+    engine/editor/WorldEditorImGui.cpp
+    engine/editor/WorldEditorSession.cpp
+    engine/editor/world/WorldEditorShell.cpp
+    engine/editor/world/panels/ScenePanel.cpp
+    engine/editor/world/panels/InspectorPanel.cpp
+    engine/editor/world/panels/AssetBrowserPanel.cpp
+    engine/editor/world/panels/OutlinerPanel.cpp
+    engine/editor/world/panels/ConsolePanel.cpp
+    engine/editor/world/panels/ToolPropertiesPanel.cpp
+    ...
+)
+
+# Tests
+add_executable(world_editor_shell_tests engine/editor/world/tests/WorldEditorShellTests.cpp)
+target_link_libraries(world_editor_shell_tests PRIVATE engine_core)
+add_test(NAME world_editor_shell_tests COMMAND world_editor_shell_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Démarrage]
+  └─> lcdlln_world_editor.exe --editor-world
+       └─> WorldEditorShell::Init
+            ├─> charge editor_world_layout.ini (ou layout par défaut)
+            └─> instancie 6 panneaux
+
+[Boucle frame]
+  └─> Engine::DrawFrame
+       └─> WorldEditorShell::RenderFrame
+            ├─> RenderMenuBar
+            ├─> RenderDockspace
+            └─> pour chaque panneau visible : panel->Render()
+
+[Touche F2]
+  └─> WorldEditorShell::HandleShortcut(VK_F2)
+       └─> InspectorPanel::SetVisible(true) + ImGui::SetWindowFocus("Inspector")
+```
+
+## Critères d'acceptation
+
+- [ ] `lcdlln_world_editor.exe --editor-world` démarre avec un dockspace visible.
+- [ ] Les 6 panneaux apparaissent et sont ancrables/dégroupables à la souris.
+- [ ] Le layout est sauvegardé à la fermeture et restauré au prochain lancement.
+- [ ] `View → Reset Layout` rétablit le layout par défaut décrit ci-dessus.
+- [ ] Toutes les touches F1..F4, F6, F12 ouvrent / focalisent le panneau correspondant.
+- [ ] F11 bascule la fenêtre éditeur entre fenêtré et plein écran.
+- [ ] La catégorie de log `EditorWorld` est visible dans le panneau Console et
+  dans la sortie standard / fichier.
+- [ ] Aucune passe Vulkan n'est conditionnée à `m_worldEditorWorld` (vérification :
+  `grep -RIn "m_worldEditorWorld\|editor.world" engine/render/` retourne 0 résultat
+  dans les passes de rendu).
+- [ ] Le shell ne touche pas à `engine_core` lié au target `server_app` (le
+  serveur ne compile pas `WorldEditorShell.cpp` ; vérifié par CMake).
+
+## Tests
+
+- `engine/editor/world/tests/WorldEditorShellTests.cpp` :
+  - `Test_Init_LoadsDefaultLayout_WhenIniMissing` : init sans fichier ini →
+    layout par défaut chargé.
+  - `Test_Init_PersistsLayoutOnShutdown` : init + Shutdown → fichier ini écrit.
+  - `Test_HandleShortcut_FocusesPanel` : F2 → InspectorPanel reçoit `SetVisible(true)`.
+  - `Test_MarkDirty_SetsFlag` : `MarkDirty("test")` → `IsDirty() == true`.
+
+## Hors scope explicite
+
+- Pas de chargement de scène, pas de heightmap, pas d'asset réel.
+- Pas d'intégration Playtest (F5 reste no-op).
+- Pas de menu Tools renseigné.
+- Pas d'undo/redo (M100.2).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.1-WorldEditorBootstrap.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.10-SplatPaintingBrushes.md
+++ b/tickets/M100/M100.10-SplatPaintingBrushes.md
@@ -1,0 +1,200 @@
+# M100.10 — Splat Painting Brushes
+
+## Résumé
+
+Outils de peinture splat manuelle (brosse circulaire pondérée par cellule)
+et automatique par règles (pente, altitude, voisinage). Toutes opérations
+sont des `ICommand` qui maintiennent l'invariant somme=255 par cellule.
+Préservation des coutures inter-chunks.
+
+## Dépendances
+
+- **M100.2** — Command Stack & Undo/Redo.
+- **M100.9** — Splat Map System.
+
+## Portée
+
+### Inclus
+- Outil `SplatPaintTool` (raccourci **P**).
+- Brosse manuelle : sélectionne une layer cible, peint avec radius + falloff + strength.
+- Brosse auto-rules : pente min/max, altitude min/max, layer cible, force.
+- Coutures inter-chunks (gather voisin → écriture symétrique).
+- Undo coalescé par stroke.
+
+### Hors scope
+- Procéduralisation à l'échelle de la zone (futur).
+- Tampons / stencil par PNG (futur).
+
+## Spécification fonctionnelle
+
+### Tool Properties (Splat Paint)
+
+```
+Mode  (•) Manual    ( ) Auto-Rules
+
+Active layer  [combo : 0 dirt ▼]
+
+Radius     |■■■■■■□□□□|  6.0 m
+Strength   |■■■■■□□□□□|  0.5 (0..1)
+Falloff    |■■■■■■■□□□|  0.7
+
+[Auto-Rules — only if mode == Auto-Rules]
+Slope min  |■■□□□□□□□□|  0°
+Slope max  |■■■■■■□□□□|  35°
+Alt   min  |□□□□□□□□□□|  -inf
+Alt   max  |■■■■■■■■■■|  +inf
+```
+
+### Workflow manuel
+
+- Sélectionner layer 5 (rock) → press → drag → relâche → stroke poussé.
+
+### Workflow auto-rules
+
+- Configurer rules → **Apply to chunk** ou **Apply to selection**.
+
+## Spécification technique
+
+### Algorithme manuel par tick
+
+```cpp
+for (cell in disk(P, radius)):
+    weight = falloff(dist, radius) * strength * dt    // 0..1
+    delta = uint8(weight * 255)
+    splat[cell][activeLayer] += delta                 // saturé
+    // redistribuer pour maintenir somme = 255 :
+    excess = sum(splat[cell]) - 255
+    if (excess > 0) decrement_other_layers_proportionally(splat[cell], excess)
+```
+
+### Algorithme auto-rules
+
+```cpp
+for (cell in chunk):
+    slope = slope_at(cell)            // calculé depuis terrain.bin
+    alt   = height_at(cell)
+    if (slope in [slopeMin..slopeMax] && alt in [altMin..altMax]):
+        weight = strength
+        splat[cell][activeLayer] += uint8(weight * 255)
+        renormalize(splat[cell])
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/SplatPaintTool.h/.cpp` | Outil. |
+| `engine/editor/world/SplatPaintCommand.h/.cpp` | `ICommand` delta sparse. |
+| `engine/editor/world/SplatRules.h/.cpp` | Règles auto. |
+| `engine/editor/world/tests/SplatPaintTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/ToolPropertiesPanel.cpp` | UI pour SplatPaintTool. |
+| `engine/editor/world/WorldEditorShell.cpp` | Raccourci P. |
+| `engine/editor/world/TerrainDocument.cpp` | Maintient l'invariant somme=255 après chaque commit. |
+
+### Structures
+
+```cpp
+struct SplatPaintParams
+{
+	bool autoRules = false;
+	uint8_t activeLayer = 0;
+	float radiusMeters = 6.0f;
+	float strength = 0.5f;
+	float falloff  = 0.7f;
+	float slopeMinDeg = 0.0f;
+	float slopeMaxDeg = 90.0f;
+	float altMin = -1024.0f;
+	float altMax =  8192.0f;
+};
+
+struct SplatDeltaCell { uint16_t x, z; uint8_t prev[8]; uint8_t next[8]; };
+struct SplatDeltaChunk { engine::world::GlobalChunkCoord coord; std::vector<SplatDeltaCell> cells; };
+
+class SplatPaintCommand : public ICommand { /* ... */ };
+```
+
+### Coutures inter-chunks
+
+Identique à M100.6 : la rangée bord d'un chunk est dupliquée dans le chunk
+voisin. Le brush écrit explicitement les deux cellules quand il touche un
+bord.
+
+### Parité éditeur ↔ client
+
+Pas de nouveau format ; les écritures vont dans `splat.bin` (M100.9).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainStampTool.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainStampTool.cpp
+    engine/editor/world/SplatPaintTool.cpp
+    engine/editor/world/SplatPaintCommand.cpp
+    engine/editor/world/SplatRules.cpp
+    ...
+)
+
+add_executable(splat_paint_tests engine/editor/world/tests/SplatPaintTests.cpp)
+target_link_libraries(splat_paint_tests PRIVATE engine_core)
+add_test(NAME splat_paint_tests COMMAND splat_paint_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+P → SplatPaintTool actif
+Select layer 5 (rock)
+Drag sur terrain → cellules visées passent de "70 % dirt + 30 % grass" à "60 % dirt + 25 % grass + 15 % rock", invariant somme=255 conservé
+Mouse up → SplatPaintCommand pushé
+```
+
+## Critères d'acceptation
+
+- [ ] Après n'importe quel coup de brosse, **toute** cellule a une somme de 255.
+- [ ] Les auto-rules pente/altitude produisent un résultat reproductible.
+- [ ] Les coutures inter-chunks restent visuellement continues (pas de ligne de couture visible).
+- [ ] Un brushstroke complet est une seule entrée d'historique.
+- [ ] Le mode Manual et le mode Auto-Rules sont commutables sans rechargement.
+- [ ] Tests `splat_paint_tests` passent.
+
+## Tests
+
+- `Test_ManualBrush_PreservesSum255`.
+- `Test_AutoRules_PaintsOnlyMatchingCells`.
+- `Test_Falloff_RadialMonotone`.
+- `Test_CrossChunk_PreservesSeam`.
+- `Test_Stroke_OneHistoryEntry`.
+
+## Hors scope explicite
+
+- Pas de blend basé hauteur ou normale dans la brosse (futur).
+- Pas de stencil PNG par-dessus la brosse.
+- Pas de procéduralisation par "biome".
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.10-SplatPaintingBrushes.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.11-SurfaceMaterialSystemAndSurfaceQuery.md
+++ b/tickets/M100/M100.11-SurfaceMaterialSystemAndSurfaceQuery.md
@@ -1,0 +1,303 @@
+# M100.11 — Surface Material System & SurfaceQuery (client)
+
+## Résumé
+
+Définit l'enum `SurfaceType`, la table de surfaces (`assets/gameplay/surface_table.json`),
+la struct `SurfaceModifiers`, et le service **côté client uniquement**
+`SurfaceQuery(pos)` qui retourne `(SurfaceType, SurfaceModifiers)` à partir
+de la splat-map dominante locale. Branchement avec le mouvement joueur
+(stub si `CharacterController` n'expose pas encore le hook).
+
+## Dépendances
+
+- **M100.9** — Splat Map System.
+
+## Portée
+
+### Inclus
+- Enum `SurfaceType` complet (Dirt..Bridge), aligné sur la table du prompt directeur.
+- Fichier `assets/gameplay/surface_table.json` (vitesse de base, audio, tag visuel).
+- Struct `SurfaceModifiers` (slippery, wet, frozen, seasonalSnow, speedMultiplier, audioPitchShift).
+- Service `engine::world::surface::SurfaceQuery` qui prend une `Vec3` monde et retourne `(SurfaceType, SurfaceModifiers)`.
+- Branchement dans `engine::gameplay::CharacterController::ApplyGroundFriction` (le hook recombine vitesse base × multiplier modifier).
+- Panneau éditeur `SurfaceTablePanel` pour visualiser la table (lecture seule en M100.11 ; édition libre via texte JSON).
+
+### Hors scope
+- Pas d'application de modificateurs météo / saison (M100.25, M100.26).
+- Pas de hazards (M100.16).
+
+## Spécification fonctionnelle
+
+Aucune édition runtime. Le service est utilisé en interne par le moteur de
+mouvement.
+
+Le panneau éditeur affiche la table :
+```
+SurfaceType    Speed  Audio                      VisualTag
+Dirt           1.00   step_dirt                  dust_sprint
+Grass          0.95   step_grass                 grass_bend
+Mud            0.55   step_mud_squelch           splash_mud
+Sand           0.70   step_sand                  footprint_decal_fade
+Rock           1.05   step_rock                  -
+Snow           0.50   step_snow_crunch           footprint_decal_persistent
+ShallowWater   0.40   step_water                 splash_water
+DeepWater      0.25   swim_stroke                swim_mode
+LavaCooled     0.85   step_rock                  heat_emission
+WheatField     0.85   step_wheat_rustle          wheat_part
+CornField      0.80   step_corn_rustle           corn_part
+Road           1.10   step_gravel                -
+Bridge         1.10   step_wood                  -
+```
+
+## Spécification technique
+
+### Enum
+
+```cpp
+namespace engine::world::surface
+{
+	enum class SurfaceType : uint16_t
+	{
+		Dirt = 0,
+		Grass,
+		Mud,
+		Sand,
+		Rock,
+		Snow,
+		ShallowWater,
+		DeepWater,
+		LavaCooled,
+		WheatField,
+		CornField,
+		Road,
+		Bridge,
+		_Count
+	};
+}
+```
+
+L'ordre est gelé. Tout ajout futur doit ajouter avant `_Count`.
+
+### Format `assets/gameplay/surface_table.json`
+
+```json
+{
+  "version": 1,
+  "surfaces": [
+    { "type": "Dirt",         "baseSpeed": 1.00, "audioStep": "step_dirt",
+      "visualTag": "dust_sprint" },
+    { "type": "Grass",        "baseSpeed": 0.95, "audioStep": "step_grass",
+      "visualTag": "grass_bend" },
+    { "type": "Mud",          "baseSpeed": 0.55, "audioStep": "step_mud_squelch",
+      "visualTag": "splash_mud" },
+    { "type": "Sand",         "baseSpeed": 0.70, "audioStep": "step_sand",
+      "visualTag": "footprint_decal_fade" },
+    { "type": "Rock",         "baseSpeed": 1.05, "audioStep": "step_rock",
+      "visualTag": "" },
+    { "type": "Snow",         "baseSpeed": 0.50, "audioStep": "step_snow_crunch",
+      "visualTag": "footprint_decal_persistent" },
+    { "type": "ShallowWater", "baseSpeed": 0.40, "audioStep": "step_water",
+      "visualTag": "splash_water" },
+    { "type": "DeepWater",    "baseSpeed": 0.25, "audioStep": "swim_stroke",
+      "visualTag": "swim_mode" },
+    { "type": "LavaCooled",   "baseSpeed": 0.85, "audioStep": "step_rock",
+      "visualTag": "heat_emission" },
+    { "type": "WheatField",   "baseSpeed": 0.85, "audioStep": "step_wheat_rustle",
+      "visualTag": "wheat_part" },
+    { "type": "CornField",    "baseSpeed": 0.80, "audioStep": "step_corn_rustle",
+      "visualTag": "corn_part" },
+    { "type": "Road",         "baseSpeed": 1.10, "audioStep": "step_gravel",
+      "visualTag": "" },
+    { "type": "Bridge",       "baseSpeed": 1.10, "audioStep": "step_wood",
+      "visualTag": "" }
+  ]
+}
+```
+
+### Structures
+
+```cpp
+namespace engine::world::surface
+{
+	struct SurfaceModifiers
+	{
+		bool slippery = false;
+		bool wet = false;
+		bool frozen = false;
+		bool seasonalSnow = false;
+		float speedMultiplier = 1.0f;
+		float audioPitchShift = 1.0f;
+	};
+
+	struct SurfaceTableEntry
+	{
+		SurfaceType type;
+		float baseSpeed;
+		std::string audioStep;
+		std::string visualTag;
+	};
+
+	class SurfaceTable
+	{
+	public:
+		bool LoadFromJson(std::string_view path);
+		const SurfaceTableEntry& Get(SurfaceType t) const;
+	};
+
+	struct SurfaceQueryResult
+	{
+		SurfaceType base;
+		SurfaceModifiers modifiers;
+	};
+
+	class SurfaceQueryService
+	{
+	public:
+		bool Init(const SurfaceTable& table);
+		/// Lit la splat-map locale via `StreamCache`. Lance la requête en
+		/// O(1) à partir de la cellule splat dominante.
+		SurfaceQueryResult Query(engine::math::Vec3 worldPos) const;
+	};
+}
+```
+
+### Algorithme de Query
+
+1. `worldPos` → `(GlobalChunkCoord, localCellX, localCellZ)`.
+2. Charger `splat.bin` du chunk via `StreamCache::LoadSplatMap` (déjà résident en jeu normal).
+3. Trouver la layer de poids max parmi les 8.
+4. Lire `surfaceType` de cette layer dans `LayerPalette` → `base`.
+5. `modifiers` = `{}` (M100.11 ne calcule pas de modifiers ; M100.26 les calcule à partir du `WeatherSystem`).
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/surface/SurfaceType.h` | Enum + helpers. |
+| `engine/world/surface/SurfaceTable.h/.cpp` | JSON loader. |
+| `engine/world/surface/SurfaceQueryService.h/.cpp` | Service. |
+| `engine/editor/world/panels/SurfaceTablePanel.h/.cpp` | UI lecture seule. |
+| `engine/world/surface/tests/SurfaceQueryTests.cpp` | Tests. |
+| `assets/gameplay/surface_table.json` | Table. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/terrain/LayerPalette.h/.cpp` | Expose `SurfaceType GetSurfaceTypeForLayer(uint8_t layer)`. |
+| `engine/gameplay/CharacterController.h/.cpp` | Utilise `SurfaceQueryService` au lieu d'une vitesse constante. Si pas encore prêt, ajoute un stub paramétrable. |
+| `engine/world/StreamCache.cpp` | (rien) |
+
+### Anti-duplication serveur
+
+Le serveur **ne compile pas** `SurfaceQueryService.cpp`. Vérification CMake :
+le target `server_app` ne lie pas `engine_core` directement (il lie un sous-set).
+On crée un sous-target `engine_core_server` qui exclut `engine/world/surface/`,
+`engine/world/terrain/SplatMap.cpp`, `engine/world/terrain/LayerPalette.cpp` et
+qui est lié au target serveur. Le client lie `engine_core` complet.
+
+> Note : si le code base utilise actuellement `engine_core` directement côté
+> serveur, ce ticket introduit la séparation. Les fichiers ci-dessus doivent
+> rester strictement client.
+
+### Parité éditeur ↔ client
+
+Pas de nouveau format binaire. Le panneau éditeur lit la même `surface_table.json`
+que le client.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+target_link_libraries(server_app PRIVATE engine_core)
+```
+
+### after
+```
+# Set des fichiers strictement client (Vulkan, splat, surfaces...)
+set(ENGINE_CORE_CLIENT_ONLY
+    engine/world/surface/SurfaceTable.cpp
+    engine/world/surface/SurfaceQueryService.cpp
+    engine/world/terrain/SplatMap.cpp
+    engine/world/terrain/LayerPalette.cpp
+)
+
+add_library(engine_core
+    ...
+    ${ENGINE_CORE_CLIENT_ONLY}
+)
+
+# Sous-target serveur qui ré-exporte les sources de engine_core SAUF
+# les fichiers strictement client. Le serveur ne lie que celui-ci.
+add_library(engine_core_server STATIC
+    # mêmes sources que engine_core, modulo ENGINE_CORE_CLIENT_ONLY
+)
+
+target_link_libraries(server_app PRIVATE engine_core_server)
+
+# Tests
+add_executable(surface_query_tests engine/world/surface/tests/SurfaceQueryTests.cpp)
+target_link_libraries(surface_query_tests PRIVATE engine_core)
+add_test(NAME surface_query_tests COMMAND surface_query_tests)
+```
+
+(Pour le détail des sources `engine_core_server`, le ticket d'implémentation
+extrait la liste depuis le `add_library(engine_core ...)` actuel ; aucune
+duplication de code source — uniquement deux targets buildant des sources
+choisies.)
+
+## Schéma d'interaction utilisateur
+
+```
+[Editor]  Tools → Surface Table
+  └─> SurfaceTablePanel : tableau lecture seule (ouverture du JSON pour édit)
+
+[Client en jeu]  CharacterController::Update
+  └─> SurfaceQueryService::Query(playerPos)
+       └─> StreamCache::LoadSplatMap(chunkCoord)
+            └─> dominant layer index → LayerPalette → SurfaceType
+       └─> retourne SurfaceQueryResult
+  └─> apply baseSpeed × modifiers.speedMultiplier
+```
+
+## Critères d'acceptation
+
+- [ ] L'enum `SurfaceType` contient exactement les 13 entrées listées (+ `_Count`).
+- [ ] `SurfaceTable::LoadFromJson` parse `surface_table.json` sans erreur.
+- [ ] `SurfaceQueryService::Query` retourne `Dirt` au-dessus d'une zone peinte 100% layer 0 (dirt) et `Rock` au-dessus de 100% layer 5 (rock).
+- [ ] `engine_core_server` ne contient **pas** `SurfaceQueryService.cpp`.
+- [ ] `grep -RIn "SurfaceQueryService" engine/server/` retourne 0 résultat.
+- [ ] Le panneau Surface Table affiche les 13 entrées avec leurs valeurs.
+- [ ] La vitesse joueur est divisée par 2 quand il marche sur une cellule à 100% Snow par rapport à 100% Dirt (ratio cohérent avec la table).
+
+## Tests
+
+- `Test_SurfaceTable_LoadJson_Has13Entries`.
+- `Test_SurfaceTable_BaseSpeed_DirtIs1p0`.
+- `Test_Query_DominantLayerWins`.
+- `Test_Query_DefaultModifiersAreNeutral`.
+- `Test_CharacterController_AppliesBaseSpeed`.
+
+## Hors scope explicite
+
+- Pas de modificateurs météo (M100.26).
+- Pas d'audio de pas (M100.33).
+- Pas d'overrides hazards (M100.16).
+- Pas de calcul serveur (jamais).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.11-SurfaceMaterialSystemAndSurfaceQuery.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur
+> (le serveur **ne compile pas** ces fichiers). La séparation `engine_core` /
+> `engine_core_server` est introduite par ce ticket.

--- a/tickets/M100/M100.12-CollisionProxySystem.md
+++ b/tickets/M100/M100.12-CollisionProxySystem.md
@@ -1,0 +1,240 @@
+# M100.12 — Collision Proxy System
+
+## Résumé
+
+Chaque mesh a un proxy de collision dédié à trois niveaux : **capsule**,
+**convex hull**, **triangle mesh**. Stocké dans un fichier compagnon
+`mesh_name.collision.bin` versionné. Auto-fit à l'import. Édition manuelle
+via le panneau **Collision Editor**. Visualisation overlay wireframe vert
+dans le viewport éditeur. Côté client en jeu, la physique utilise les
+proxies, jamais les meshes de rendu.
+
+## Dépendances
+
+- **M100.1** — World Editor Bootstrap.
+
+## Portée
+
+### Inclus
+- Trois primitives : `Capsule { Vec3 a, Vec3 b, float radius }`, `ConvexHull { vertices }`, `TriMesh { vertices, indices }`.
+- Format binaire `*.collision.bin` versionné.
+- Heuristique d'auto-fit : pour un mesh trèss vertical (height/width > 3) → capsule. Pour un mesh "compact" → convex hull V-HACD-like (single pass). Pour les statiques complexes (>500 verts ou marqué `static`) → triangle mesh.
+- Panneau éditeur "Collision Editor" : choisit le niveau, ajuste manuellement.
+- Overlay wireframe vert dans le viewport (passe additive, **jamais conditionnée à `m_editorEnabled` dans `GeometryPass`** — c'est une passe distincte `EditorOverlayPass` réservée à l'éditeur).
+- **Pas de collision rigide entre props lors du placement.** Détection d'overlap purement informationnelle (compteur).
+
+### Hors scope
+- Solveur physique (existe ailleurs).
+- Compound collisions (kits modulaires : ticket M100.30 utilise plusieurs proxies en parallèle, mais pas de "compound shape" unique).
+
+## Spécification fonctionnelle
+
+### Asset workflow
+
+À l'import d'un nouveau mesh :
+1. Auto-fit choisit le niveau et écrit `<asset>.collision.bin` à côté.
+2. L'éditeur indique : `Auto-collision : convex hull (28 verts)`.
+3. L'utilisateur peut basculer manuellement vers un autre niveau.
+
+### Panneau Collision Editor
+
+```
+Asset: rock_large_01.glb
+Auto-fit suggested: ConvexHull (28 verts)
+
+Type:  ( ) Capsule    (•) ConvexHull    ( ) TriMesh
+
+[Capsule fields disabled]
+
+ConvexHull
+  Vertex count: 28
+  [Re-run V-HACD]    [Edit vertices…]
+
+[Save .collision.bin]   [Discard]
+```
+
+### Visualisation viewport
+
+- Toggle **Show Collision Proxies** dans le View menu (raccourci **V**).
+- Wireframe vert overlay sur tous les props sélectionnés.
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kCollisionMagic = 0x4C4C4F43u; // "COLL"
+constexpr uint32_t kCollisionVersion = 1u;
+```
+
+### Layout binaire `<asset>.collision.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 proxyType (0 = Capsule, 1 = ConvexHull, 2 = TriMesh)
+
+If Capsule:
+  [28..39]  float a[3]
+  [40..51]  float b[3]
+  [52..55]  float radius
+
+If ConvexHull:
+  [28..31]  uint32 vertexCount
+  [32..N]   float[3] vertices
+
+If TriMesh:
+  [28..31]  uint32 vertexCount
+  [32..35]  uint32 indexCount
+  [36....] float[3] vertices
+  [..]      uint32[] indices
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/collision/CollisionProxy.h/.cpp` | Structures + sérialisation. |
+| `engine/world/collision/AutoFitProxy.h/.cpp` | Heuristique d'auto-fit + V-HACD wrap. |
+| `engine/editor/world/panels/CollisionEditorPanel.h/.cpp` | UI. |
+| `engine/render/EditorOverlayPass.h/.cpp` | Passe overlay wireframe. |
+| `engine/render/shaders/editor_overlay.vert` | Shader minimal. |
+| `engine/render/shaders/editor_overlay.frag` | Shader minimal vert solide. |
+| `engine/world/collision/tests/CollisionProxyTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/FrameGraph.cpp` | `EditorOverlayPass` enregistrée **après** `Tonemap`, **uniquement** si `WorldEditorShell` actif (le frame graph la skippe sinon). |
+| `engine/editor/world/panels/AssetBrowserPanel.cpp` | À l'import, déclenche `AutoFitProxy`. |
+| `engine/editor/world/PlacementOverlapInfo.h/.cpp` | Compteur d'overlaps non bloquant. |
+
+### Structures C++
+
+```cpp
+namespace engine::world::collision
+{
+	enum class ProxyType : uint32_t { Capsule = 0, ConvexHull = 1, TriMesh = 2 };
+
+	struct CollisionProxy
+	{
+		ProxyType type = ProxyType::Capsule;
+		// Capsule:
+		engine::math::Vec3 capsuleA{};
+		engine::math::Vec3 capsuleB{};
+		float capsuleRadius = 0.5f;
+		// ConvexHull / TriMesh:
+		std::vector<engine::math::Vec3> vertices;
+		std::vector<uint32_t> indices;       // TriMesh only
+
+		bool LoadFromFile(std::string_view path, std::string& outError);
+		bool SaveToFile(std::string_view path, std::string& outError) const;
+	};
+
+	CollisionProxy AutoFit(const engine::render::MeshAsset& mesh);
+}
+```
+
+### `EditorOverlayPass`
+
+```cpp
+class EditorOverlayPass
+{
+public:
+	void Register(engine::render::FrameGraph& fg, engine::render::ResourceId colorTarget);
+	// La passe lit les proxies des assets sélectionnés et émet un drawcall wireframe vert.
+private:
+	// pas de state Vulkan stocké (alloué au premier register)
+};
+```
+
+**Important** : cette passe n'est jamais lancée en mode jeu normal. Elle
+n'est enregistrée par le frame graph que si `WorldEditorShell::IsActive()`. Le
+pipeline de rendu de base reste **identique** pour client et éditeur.
+
+### Parité éditeur ↔ client
+
+Les `*.collision.bin` écrits par l'éditeur sont lus par le client (le solveur
+physique runtime). Test de parité round-trip : écrire les trois types de
+proxies, recharger, vérifier `memcmp` du payload.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/render/GeometryPass.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/render/GeometryPass.cpp
+    engine/render/EditorOverlayPass.cpp
+    engine/world/collision/CollisionProxy.cpp
+    engine/world/collision/AutoFitProxy.cpp
+    engine/editor/world/panels/CollisionEditorPanel.cpp
+    engine/editor/world/PlacementOverlapInfo.cpp
+    ...
+)
+
+# EditorOverlayPass est compilée mais ne s'enregistre pas si pas d'éditeur actif.
+# Pas dans engine_core_server.
+
+add_executable(collision_proxy_tests engine/world/collision/tests/CollisionProxyTests.cpp)
+target_link_libraries(collision_proxy_tests PRIVATE engine_core)
+add_test(NAME collision_proxy_tests COMMAND collision_proxy_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Asset Browser] Drop rock.glb
+  └─> AutoFit(rock.glb) → ConvexHull(28 verts) → écrit rock.collision.bin
+[Collision Editor] sélection rock.glb
+  └─> Panneau ouvert, type ConvexHull, bouton Re-run V-HACD
+[Viewport]  V → toggle wireframe overlay (vert)
+```
+
+## Critères d'acceptation
+
+- [ ] À l'import d'un mesh, un fichier `.collision.bin` est créé automatiquement.
+- [ ] Trois types de proxies sérialisables (Capsule / ConvexHull / TriMesh) avec round-trip parfait.
+- [ ] Le panneau Collision Editor permet de basculer entre les trois types.
+- [ ] L'overlay wireframe est rendu **uniquement** quand `WorldEditorShell` est actif.
+- [ ] `GeometryPass` ne contient **aucune** branche `m_editorEnabled` (vérifié par grep).
+- [ ] Le placement de props **ne refuse pas** la superposition ; le compteur d'overlap incrémente.
+- [ ] Le solveur runtime (physique client) consomme les `.collision.bin` produits par l'éditeur (test : raycast contre une capsule produit le hit attendu).
+
+## Tests
+
+- `Test_CollisionProxy_RoundtripCapsule`.
+- `Test_CollisionProxy_RoundtripConvexHull`.
+- `Test_CollisionProxy_RoundtripTriMesh`.
+- `Test_AutoFit_TallSlim_PicksCapsule`.
+- `Test_AutoFit_Compact_PicksConvexHull`.
+- `Test_AutoFit_StaticComplex_PicksTriMesh`.
+- `Test_OverlayPass_NotRegisteredWhenNoEditor`.
+
+## Hors scope explicite
+
+- Pas de compound shape unique.
+- Pas de soft body / cloth / fluid.
+- Pas de collision dynamique entre props placés (volontairement libre).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.12-CollisionProxySystem.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.
+> Le serveur ne charge pas les `.collision.bin` (la physique reste client).

--- a/tickets/M100/M100.13-WaterSurfaces.md
+++ b/tickets/M100/M100.13-WaterSurfaces.md
@@ -1,0 +1,214 @@
+# M100.13 — Water Surfaces (Lakes & Rivers)
+
+## Résumé
+
+Édition de plans d'eau : lacs (zones polygonales fermées) et rivières
+(splines accrochées au terrain). Génération automatique du mesh d'eau,
+calcul du sens d'écoulement à partir de la pente terrain. Sérialisation
+dans `instances/water.bin` versionné.
+
+## Dépendances
+
+- **M100.5** — Heightmap Data Structure.
+- **M100.6** — Terrain Sculpting (préalable pour les lits de rivière).
+
+## Portée
+
+### Inclus
+- Outil `LakeTool` : polygone 2D + niveau d'eau (Y constant) + couleur de fond + turbidité.
+- Outil `RiverTool` : spline 3D, calcul du flot par projection sur la pente.
+- Format binaire `instances/water.bin` versionné.
+- Calcul automatique du mesh triangulaire (Delaunay 2D pour lac, ribbon pour rivière).
+- Inspector : profondeur moyenne, surface totale, vitesse d'écoulement (rivière).
+
+### Hors scope
+- Rendu eau (M100.14).
+- Hook gameplay nage (M100.15).
+
+## Spécification fonctionnelle
+
+### Lake tool
+
+- Click dans le viewport → ajoute un point au polygone.
+- Double-click → ferme le polygone.
+- Inspector : `waterLevelY`, `bottomColor`, `turbidity`, `name`.
+
+### River tool
+
+- Click successifs → spline.
+- `widthMeters` par point (gizmo orthogonal) ; transition linéaire entre points.
+- `depthMeters` par point.
+- Le sens d'écoulement est déduit de la différence d'altitude entre points.
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kWaterMagic = 0x52544157u; // "WATR"
+constexpr uint32_t kWaterVersion = 1u;
+```
+
+### Layout binaire `instances/water.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 lakeCount
+[28..31]  uint32 riverCount
+
+For each lake:
+  [4]   uint32 nameLen
+  [N]   char[] name
+  [4]   uint32 vertexCount
+  [12*N] float[3] polygon vertices (XYZ, Y = waterLevelY)
+  [12]  float bottomColor[3]
+  [4]   float turbidity (0..1)
+  [4]   float waterLevelY
+
+For each river:
+  [4]   uint32 nameLen
+  [N]   char[] name
+  [4]   uint32 nodeCount
+  Per node:
+    [12]  float position[3]
+    [4]   float widthMeters
+    [4]   float depthMeters
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/water/WaterSurfaces.h/.cpp` | Structures `LakeInstance`, `RiverInstance`, sérialisation. |
+| `engine/world/water/WaterMeshBuilder.h/.cpp` | Triangulation Delaunay 2D (lac) + ribbon (rivière). |
+| `engine/editor/world/LakeTool.h/.cpp` | Outil édition lac. |
+| `engine/editor/world/RiverTool.h/.cpp` | Outil édition rivière. |
+| `engine/editor/world/WaterDocument.h/.cpp` | État monde. |
+| `engine/world/water/tests/WaterSurfacesTests.cpp` | Tests + parité. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/StreamCache.cpp` | `LoadWater(zone)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteWater(...)`. |
+
+### Structures
+
+```cpp
+namespace engine::world::water
+{
+	struct LakeInstance
+	{
+		std::string name;
+		std::vector<engine::math::Vec3> polygon; // CCW
+		engine::math::Vec3 bottomColor{ 0.05f, 0.20f, 0.30f };
+		float turbidity = 0.4f;
+		float waterLevelY = 0.0f;
+	};
+
+	struct RiverNode { engine::math::Vec3 position; float widthMeters; float depthMeters; };
+	struct RiverInstance
+	{
+		std::string name;
+		std::vector<RiverNode> nodes;
+	};
+
+	struct WaterScene
+	{
+		std::vector<LakeInstance> lakes;
+		std::vector<RiverInstance> rivers;
+	};
+
+	bool SaveWaterBin(const WaterScene& scene, std::vector<uint8_t>& outBytes, std::string& err);
+	bool LoadWaterBin(std::span<const uint8_t> bytes, WaterScene& outScene, std::string& err);
+}
+```
+
+### Algorithme de triangulation
+
+- **Lac** : Delaunay 2D (sweep simple) avec contrainte du polygone (clip externe).
+- **Rivière** : ribbon, deux rangées de vertices `node.position ± widthMeters/2 * tangent_perpendicular`. Le mesh est posé sur la heightmap (Y = `terrain.SampleHeight(x, z)`) avec offset `depth/2` vers le bas pour le fond et `0` pour la surface.
+
+### Calcul du sens d'écoulement
+
+Pour chaque rivière, parcourir les nodes : `flow_direction[i] = normalize(node[i+1] - node[i])`. La vitesse est constante en M100.13 (`flowSpeed = 1.0 m/s` par défaut). M100.14 utilise `flowSpeed` pour animer les normales du shader eau.
+
+### Parité éditeur ↔ client
+
+| Étape | Code |
+|-------|------|
+| Éditeur écrit | `engine::editor::world::WaterDocument::SaveToDisk` |
+| Sérialisation | `engine::world::water::SaveWaterBin` |
+| Client lit | `engine::world::StreamCache::LoadWater` |
+| Désérialisation | `engine::world::water::LoadWaterBin` |
+
+Test de parité : crée un lac + une rivière, sauvegarde, recharge, compare.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/water/WaterSurfaces.cpp
+    engine/world/water/WaterMeshBuilder.cpp
+    engine/editor/world/LakeTool.cpp
+    engine/editor/world/RiverTool.cpp
+    engine/editor/world/WaterDocument.cpp
+    ...
+)
+
+add_executable(water_surfaces_tests engine/world/water/tests/WaterSurfacesTests.cpp)
+target_link_libraries(water_surfaces_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME water_surfaces_tests COMMAND water_surfaces_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+LakeTool actif → click click click double-click → polygone fermé → mesh généré
+RiverTool actif → click click ... Entrée → spline acceptée → ribbon mesh
+Inspector → ajuste waterLevelY ou widthMeters par node
+Save zone → instances/water.bin écrit
+```
+
+## Critères d'acceptation
+
+- [ ] Un lac fermé correctement (polygone CCW) produit un mesh triangulaire couvrant la zone.
+- [ ] Une rivière à 4 nodes produit un ribbon de 6 quads (3 segments × 2 quads) suivant la heightmap.
+- [ ] La sérialisation `water.bin` est round-trip parfaite.
+- [ ] Le client lit le format via `StreamCache` sans branche éditeur.
+- [ ] Le sens d'écoulement est cohérent : `flow_direction` pointe du node amont vers le node aval.
+
+## Tests
+
+- `Test_LakeMesh_Triangulation_AllVerticesInside`.
+- `Test_River_RibbonHas2NPlus2Vertices`.
+- `Test_SaveLoad_Roundtrip`.
+- `Test_FlowDirection_AlignsWithSlope`.
+
+## Hors scope explicite
+
+- Pas de simulation hydraulique (montée/descente de niveau).
+- Pas de cascades / tombées d'eau (ticket dédié futur).
+- Pas de marais (M100.16 — c'est un hazard, pas un water surface ici).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.13-WaterSurfaces.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.14-WaterRenderPass.md
+++ b/tickets/M100/M100.14-WaterRenderPass.md
@@ -1,0 +1,166 @@
+# M100.14 — Water Render Pass
+
+## Résumé
+
+Passe `Water` enregistrée dans le frame graph **après** `Geometry` et **avant**
+`Tonemap`, qui rend les meshes d'eau (M100.13) avec normales animées,
+réflexion screen-space (SSR mince) et réfraction par lecture du
+`SceneColor` lu en arrière. Shader `water.vert/.frag`. **Aucune branche
+éditeur** dans la passe.
+
+## Dépendances
+
+- **M100.13** — Water Surfaces.
+
+## Portée
+
+### Inclus
+- Passe `WaterPass` registree dans `FrameGraph`.
+- Shaders `water.vert`, `water.frag`.
+- Réflexion SSR (max 32 raymarch steps, fallback `skyboxColor`).
+- Réfraction : sample `SceneColor` à `screenUV + normal.xz * refractionAmount`.
+- Animation de 2 octaves de normales scrollées par `flowSpeed` (rivière) ou un vent constant (lac).
+- Constant buffer `WaterParams` par instance (turbidity, bottomColor, flowSpeed, time).
+
+### Hors scope
+- Caustiques au sol (futur ticket).
+- Splash de pluie (M100.26).
+
+## Spécification fonctionnelle
+
+L'utilisateur ne fait rien de nouveau ; le rendu est automatique sur les
+meshes d'eau du chunk.
+
+## Spécification technique
+
+### Frame graph
+
+```
+... → Geometry → SSAO_Blur → Decals → Water (NEW) → VolumetricFog → TAA → Tonemap → ...
+```
+
+`WaterPass`:
+- **Reads** : `SceneColorAfterDecals` (SampledRead), `SceneDepth` (SampledRead), `SkyboxCube` (SampledRead).
+- **Writes** : `SceneColorAfterWater` (ColorWrite).
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/render/WaterPass.h/.cpp` | Passe. |
+| `engine/render/shaders/water.vert` | Vertex shader. |
+| `engine/render/shaders/water.frag` | Fragment shader. |
+| `engine/render/tests/WaterPassTests.cpp` | Tests (golden image). |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/FrameGraph.cpp` | Insérer `WaterPass` après `DecalPass`. |
+| `engine/Engine.cpp` | Configure `WaterParams` chaque frame depuis `WaterScene`. |
+
+### Constant buffer
+
+```glsl
+layout(set=1, binding=0) uniform WaterParams {
+    vec3  bottomColor;
+    float turbidity;
+    vec2  flowDirection;
+    float flowSpeed;
+    float timeSeconds;
+    float refractionAmount;
+    float fresnelPower;
+    float reflectionStrength;
+} u_water;
+```
+
+### Shader fragment (résumé)
+
+```glsl
+void main()
+{
+    // Normales animées
+    vec2 uv1 = vUv * 8.0  + u_water.flowDirection * u_water.flowSpeed * u_water.timeSeconds;
+    vec2 uv2 = vUv * 16.0 - u_water.flowDirection * u_water.flowSpeed * u_water.timeSeconds * 0.5;
+    vec3 n  = normalize(unpackNormal(texture(normalMap, uv1)) + unpackNormal(texture(normalMap, uv2)));
+
+    // Réfraction
+    vec2 screenUv = gl_FragCoord.xy / u_screenSize;
+    vec3 refr = texture(sceneColor, screenUv + n.xz * u_water.refractionAmount).rgb;
+    refr = mix(refr, u_water.bottomColor, u_water.turbidity);
+
+    // Réflexion SSR mince + fallback skybox
+    vec3 refl = ssrTrace(reflectDir, sceneDepth, sceneColor, fallback=texture(skybox, reflectDir).rgb);
+
+    // Fresnel
+    float f = pow(1.0 - max(0.0, dot(n, viewDir)), u_water.fresnelPower);
+    fragColor = mix(refr, refl, f * u_water.reflectionStrength);
+}
+```
+
+### Parité éditeur ↔ client
+
+Pas de nouveau format. Le shader est strictement le même côté éditeur (pas
+de variante).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/render/DecalPass.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/render/DecalPass.cpp
+    engine/render/WaterPass.cpp
+    ...
+)
+
+add_executable(water_pass_tests engine/render/tests/WaterPassTests.cpp)
+target_link_libraries(water_pass_tests PRIVATE engine_core)
+add_test(NAME water_pass_tests COMMAND water_pass_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+Aucune surface UI ; le résultat est visuel.
+
+## Critères d'acceptation
+
+- [ ] Le frame graph contient `WaterPass` entre `Decals` et `VolumetricFog` (qui sera ajouté en M100.22 ; pour l'instant entre `Decals` et `TAA`).
+- [ ] Un lac affiche des vagues animées (vérifié visuellement et par test screenshot).
+- [ ] Une rivière affiche des normales scrollées dans le sens d'écoulement.
+- [ ] `WaterPass` ne contient **aucune** branche `m_editorEnabled`.
+- [ ] La réflexion SSR fallback à la skybox quand le ray sort de l'écran.
+- [ ] Performance : `WaterPass` < 1.0 ms sur GPU mid-range avec un lac de 100×100 m visible.
+
+## Tests
+
+- `Test_WaterPass_RegistersInFrameGraph`.
+- `Test_WaterPass_ReadsSceneColorAfterDecals`.
+- `Test_WaterPass_GoldenImage` (test golden screenshot).
+
+## Hors scope explicite
+
+- Pas de caustiques.
+- Pas de tessellation Gerstner.
+- Pas de mode tropical / aurora.
+
+## Référence visuelle
+
+Pas de panneau ImGui propre. Pas de fichier HTML.
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.15-WaterSurfaceHook.md
+++ b/tickets/M100/M100.15-WaterSurfaceHook.md
@@ -1,0 +1,165 @@
+# M100.15 — Water Surface Hook (Wading & Swimming)
+
+## Résumé
+
+Branche les volumes d'eau de M100.13 dans `SurfaceQueryService`. Détection
+de profondeur en temps réel (capsule joueur ∩ surface lac/rivière), override
+du `SurfaceType` vers `ShallowWater` (< 1.0 m) ou `DeepWater` (≥ 1.0 m),
+transition fluide. Activation du mode nage en `DeepWater`.
+
+## Dépendances
+
+- **M100.11** — SurfaceQuery service.
+- **M100.13** — Water Surfaces.
+
+## Portée
+
+### Inclus
+- Helper `WaterPenetration(pos, capsule)` retournant `submergedDepthMeters`.
+- Override de `SurfaceQueryService::Query` quand le joueur est dans un water surface.
+- Mode nage : si `submergedDepth >= 1.0 m` → `CharacterController::EnterSwimMode()`.
+- Transition par hystérésis : sortie de mode nage à `submergedDepth < 0.7 m` pour éviter le flicker à la limite.
+- Audio : déclenchement de `splash_water_enter` à l'entrée et `splash_water_exit` à la sortie.
+
+### Hors scope
+- Animation nage propre (le ticket utilise l'animation nage existante de `CharacterController`, sinon stub).
+- Hazards Bog (M100.16).
+
+## Spécification fonctionnelle
+
+Aucune surface UI nouvelle. Comportement runtime client.
+
+## Spécification technique
+
+### Algorithme
+
+```cpp
+SurfaceQueryResult SurfaceQueryService::Query(Vec3 pos)
+{
+    // 1. Splat-map dominante (M100.11)
+    auto base = QueryFromSplat(pos);
+
+    // 2. Override water
+    auto water = m_waterScene->Sample(pos);     // null si hors plan d'eau
+    if (water.has_value())
+    {
+        float depth = water->surfaceY - pos.y;  // pos.y = pieds joueur
+        if (depth > 0.0f)
+        {
+            base.base = (depth >= 1.0f) ? SurfaceType::DeepWater
+                                        : SurfaceType::ShallowWater;
+        }
+    }
+    return base;
+}
+```
+
+```cpp
+void CharacterController::Update(...)
+{
+    auto sq = surfaceQuery.Query(playerFeetPos);
+    if (sq.base == SurfaceType::DeepWater && !m_swimming)
+    {
+        m_swimming = true;
+        audio.PlayOneShot("splash_water_enter");
+    }
+    else if (m_swimming && (depth < 0.7f || sq.base != SurfaceType::DeepWater))
+    {
+        m_swimming = false;
+        audio.PlayOneShot("splash_water_exit");
+    }
+}
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/water/WaterSampler.h/.cpp` | `Sample(pos) → optional<WaterSample>`. |
+| `engine/world/surface/tests/WaterHookTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/surface/SurfaceQueryService.h/.cpp` | Connaît `WaterSampler*`, override comme ci-dessus. |
+| `engine/gameplay/CharacterController.h/.cpp` | Gère `m_swimming`, transitions. |
+| `engine/world/water/WaterSurfaces.h` | Ajoute `WaterSample { float surfaceY; }`. |
+
+### Algorithme de sampling
+
+- **Lac** : pour chaque lac, point-in-polygon 2D (XZ). Si dedans, retourne `surfaceY = waterLevelY`.
+- **Rivière** : projeter `pos.xz` sur la spline (closest segment). Si distance ≤ `widthMeters/2`, retourne `surfaceY` interpolé entre les deux nodes.
+
+### Parité éditeur ↔ client
+
+Pas de nouveau format. Le sampler lit la même `WaterScene` que l'éditeur.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/surface/SurfaceQueryService.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/surface/SurfaceQueryService.cpp
+    engine/world/water/WaterSampler.cpp
+    ...
+)
+
+add_executable(water_hook_tests engine/world/surface/tests/WaterHookTests.cpp)
+target_link_libraries(water_hook_tests PRIVATE engine_core)
+add_test(NAME water_hook_tests COMMAND water_hook_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+(Comportement runtime, pas d'UI.)
+
+```
+Joueur entre dans le lac à pieds → depth=0.3m → ShallowWater (vitesse 0.40)
+Joueur progresse → depth=1.2m → DeepWater (vitesse 0.25, mode nage activé, splash entrée)
+Joueur sort → depth=0.6m → mode nage désactivé (splash sortie), surface = ShallowWater
+```
+
+## Critères d'acceptation
+
+- [ ] À depth = 0.3 m, le `SurfaceType` retourné est `ShallowWater`.
+- [ ] À depth = 1.2 m, le `SurfaceType` retourné est `DeepWater` et le mode nage s'active.
+- [ ] Le mode nage se désactive à depth < 0.7 m (hystérésis).
+- [ ] L'audio `splash_water_enter/exit` est déclenché aux transitions.
+- [ ] Le sampling fonctionne pour les rivières (point projeté sur spline ≤ widthMeters/2).
+- [ ] Aucune simulation côté serveur (vérifié : `engine/server/` ne compile pas `WaterSampler.cpp`).
+
+## Tests
+
+- `Test_Lake_PointInside_ReturnsSurfaceY`.
+- `Test_River_ProjectionOnSegment`.
+- `Test_DepthBelow1m_IsShallowWater`.
+- `Test_DepthAbove1m_IsDeepWater_EntersSwimMode`.
+- `Test_Hysteresis_ExitAt0p7m`.
+
+## Hors scope explicite
+
+- Pas de natation contre courant (faite côté `CharacterController` via `flowSpeed`, dans un futur ticket gameplay).
+- Pas de noyade (le hazard Lava de M100.16 fait la mort scriptée ; la noyade pure n'est pas dans M100).
+
+## Référence visuelle
+
+Pas de UI propre.
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.16-HazardVolumeSystem.md
+++ b/tickets/M100/M100.16-HazardVolumeSystem.md
@@ -1,0 +1,203 @@
+# M100.16 — Hazard Volume System
+
+## Résumé
+
+Volumes 3D (boîtes ou cylindres) appliquant un effet d'enfoncement progressif
+et une mécanique d'évasion. Quatre types : `Quicksand`, `Bog`, `Tar`,
+`LavaSurface`. Sérialisés dans `instances/hazards.bin`. Simulation
+**strictement côté client** ; le serveur n'arbitre pas.
+
+## Dépendances
+
+- **M100.11** — SurfaceQuery service.
+
+## Portée
+
+### Inclus
+- Outil `HazardTool` : pose une boîte ou un cylindre, configure le type et les paramètres.
+- Format binaire `instances/hazards.bin` versionné.
+- Système client `HazardSimulator` : détection d'entrée du joueur, enfoncement progressif (Y diminue), animation procédurale (bras qui battent), évasion par type (mash bouton, mouvement latéral, requirement objet), mort scriptée si profondeur max dépassée sans évasion.
+
+### Hors scope
+- Audio loops complets (placeholder en M100.16, mix complet en M100.33).
+- Hazards de type "trap" (futur).
+
+## Spécification fonctionnelle
+
+### Tool Properties (Hazard)
+
+```
+Type:    [combo: Quicksand ▼]
+Shape:   ( ) Box   (•) Cylinder
+Size:    radius 4.0 m   |  height 2.0 m
+Sink rate (m/s):  0.15
+Max depth (m):    1.8
+Slowdown × :      0.10
+Escape:  (•) MashButton (10 in 5s)
+         ( ) LateralMove
+         ( ) MashButton + RequireItem [item id]
+         ( ) None (drowning)
+[Apply]
+```
+
+### Comportement runtime (client)
+
+- Le joueur entre dans le volume → `m_sinking = true`, capsule descend à `sinkRate` m/s, vitesse modifiée par `slowdown`.
+- Caméra tierce reste à hauteur d'origine (`ThirdPersonCamera::SetGroundOffset(headOriginalY - feetCurrentY)`).
+- Animation procédurale active (`CharacterController::ActivateStruggleAnim`).
+- Évasion :
+  - `MashButton` : compter les appuis "Action" sur 5 s ; ≥ 10 → sortie (animation pull-up + 0.5 s d'invulnérabilité).
+  - `LateralMove` : déplacement horizontal cumulé ≥ 2 m → sortie.
+  - `MashButton + RequireItem` : idem MashButton mais nécessite un item de l'inventaire local (couteau, torche).
+- Si `currentDepth ≥ maxDepth` sans escape → `Die("hazard_drowning")`.
+- `LavaSurface` est spécial : `Die("lava_burning")` après 3 s, pas d'enfoncement ni d'escape.
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kHazardsMagic   = 0x5A415748u; // "HAZA"
+constexpr uint32_t kHazardsVersion = 1u;
+```
+
+### Layout binaire `instances/hazards.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 hazardCount
+
+For each hazard:
+  [4]   uint32 type   (0=Quicksand, 1=Bog, 2=Tar, 3=Lava)
+  [4]   uint32 shape  (0=Box, 1=Cylinder)
+  [12]  float position[3]
+  [12]  float boxHalfExtents[3]   (utilisé si shape == Box)
+  [4]   float cylRadius           (utilisé si Cylinder)
+  [4]   float cylHeight           (utilisé si Cylinder)
+  [4]   float sinkRateMps
+  [4]   float maxDepthMeters
+  [4]   float slowdownMul
+  [4]   uint32 escapeMode  (0=None, 1=MashButton, 2=LateralMove, 3=MashButton+Item)
+  [4]   uint32 requiredItemId      (0 si aucun)
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/hazard/HazardVolumes.h/.cpp` | Structures + sérialisation. |
+| `engine/world/hazard/HazardSimulator.h/.cpp` | Logique simulation client. |
+| `engine/editor/world/HazardTool.h/.cpp` | Outil. |
+| `engine/editor/world/HazardDocument.h/.cpp` | État monde. |
+| `engine/world/hazard/tests/HazardTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/gameplay/CharacterController.h/.cpp` | Hook `OnHazardEnter/Update/Exit`. |
+| `engine/render/ThirdPersonCamera.cpp` | Compensation `SetGroundOffset`. |
+| `engine/world/StreamCache.cpp` | `LoadHazards(zone)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteHazards`. |
+
+### Tableau des paramètres par défaut
+
+| Type | sinkRate (m/s) | maxDepth (m) | slowdown | Escape |
+|------|----------------|--------------|----------|--------|
+| Quicksand | 0.15 | 1.8 | 0.10 | MashButton (10/5s) |
+| Bog | 0.08 | 1.2 | 0.20 | LateralMove (2 m) |
+| Tar | 0.05 | 0.8 | 0.05 | MashButton + RequireItem |
+| LavaSurface | n/a | n/a | 0.00 | None (mort en 3 s) |
+
+### Anti-duplication serveur
+
+`HazardSimulator.cpp`, `HazardVolumes.cpp` ne sont pas dans `engine_core_server`. Le serveur reçoit éventuellement la mort joueur via le protocole position/death existant, mais ne calcule rien.
+
+### Parité éditeur ↔ client
+
+| Étape | Code |
+|-------|------|
+| Éditeur écrit | `HazardDocument::SaveToDisk` |
+| Sérialisation | `SaveHazardsBin` |
+| Client lit | `StreamCache::LoadHazards` |
+| Désérialisation | `LoadHazardsBin` |
+
+Test de parité round-trip.
+
+### Réseau
+
+Aucun trafic spécifique. La mort éventuelle utilise le protocole existant
+de mort joueur.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/hazard/HazardVolumes.cpp
+    engine/world/hazard/HazardSimulator.cpp
+    engine/editor/world/HazardTool.cpp
+    engine/editor/world/HazardDocument.cpp
+    ...
+)
+
+add_executable(hazard_tests engine/world/hazard/tests/HazardTests.cpp)
+target_link_libraries(hazard_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME hazard_tests COMMAND hazard_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Editor] HazardTool → Cylinder, type=Quicksand, place sur le terrain
+Save zone → instances/hazards.bin écrit
+
+[Client] joueur marche → entre dans le volume
+  → HazardSimulator.OnEnter
+  → cap descend à 0.15 m/s, animation struggle
+  → joueur tape "Action" 10 fois → escape, animation pull-up
+  → ou : depth ≥ 1.8 m → Die("hazard_drowning")
+```
+
+## Critères d'acceptation
+
+- [ ] Les 4 types de hazards sont sélectionnables et sauvegardés correctement.
+- [ ] Round-trip `hazards.bin` parfait.
+- [ ] Le joueur s'enfonce à `sinkRate` m/s mesurés (vérifié par test).
+- [ ] La caméra tierce reste à hauteur de tête originale pendant l'enfoncement.
+- [ ] Mash button compté correctement (10 appuis en 5 s → escape).
+- [ ] LavaSurface tue après exactement 3 s (test temporel).
+- [ ] Aucun fichier hazard n'est compilé dans `engine_core_server`.
+- [ ] Aucun message réseau spécifique aux hazards n'est introduit.
+
+## Tests
+
+- `Test_Hazards_RoundtripBin`.
+- `Test_HazardSimulator_SinkRate`.
+- `Test_HazardSimulator_MashEscape`.
+- `Test_HazardSimulator_LateralEscape`.
+- `Test_HazardSimulator_LavaKills3s`.
+- `Test_HazardSimulator_DeathOnMaxDepth`.
+
+## Hors scope explicite
+
+- Pas de hazards type "spike trap" / "saw blade" / "fall damage".
+- Pas de logique de "rescue par PNJ".
+- Pas de validation serveur de la mort hazard (le client envoie sa mort via le protocole existant).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.16-HazardVolumeSystem.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.
+> La simulation hazard est strictement client.

--- a/tickets/M100/M100.17-EasyPlacementTool.md
+++ b/tickets/M100/M100.17-EasyPlacementTool.md
@@ -1,0 +1,267 @@
+# M100.17 — Easy Placement Tool
+
+## Résumé
+
+Outil universel de placement de props avec ghost preview, snapping, random
+rotation/scale, modes single click / drag-line / scatter. Cible **toutes** les
+catégories de props (rochers, arbres modulaires, modular kits villes/hameaux,
+objets interactifs futurs). **≤ 3 clics pour le cas nominal.** Performance
+garantie : ghost preview < 5 ms, commit < 16 ms.
+
+## Dépendances
+
+- **M100.2** — Command Stack & Undo/Redo.
+- **M100.5** — Heightmap (pour snap au sol).
+- **M100.12** — Collision Proxies (pour le compteur d'overlap informationnel).
+
+## Portée
+
+### Inclus
+- Outil `PlacementTool` (raccourci **G** comme "ground").
+- Ghost preview suivant le curseur, semi-transparent.
+- Auto-orientation à la normale du terrain (toggle Y world).
+- Random rotation Y (range configurable, défaut [0°, 360°]).
+- Random scale (range configurable, défaut [0.95, 1.05]).
+- Modes : Single click / Drag-line (espacement réglable) / Scatter (cercle).
+- Snap au sol (défaut), à la grille, ou aux faces du prop voisin (modular kits).
+- Ctrl+Z annule la dernière pose.
+- Tab cycle entre meshes proches dans la même catégorie.
+- Format binaire `instances/props.bin` versionné.
+
+### Hors scope
+- Bibliothèque végétale (M100.18).
+- Interactives (M100.32).
+- Splines / routes (M100.29).
+
+## Spécification fonctionnelle
+
+### Tool Properties
+
+```
+Asset      [browse → rock_large_03.glb]   (Tab: cycle in category)
+
+Mode       (•) Single  ( ) Drag-line  ( ) Scatter
+
+Snap       (•) Ground   ( ) Grid (1 m)   ( ) Face (Alt)
+Align      (•) Terrain normal   ( ) World up
+
+Random rotation Y    [□..□]  0..360°
+Random scale         [0.95..1.05]
+
+Drag-line spacing       2.0 m   (Drag-line only)
+
+Scatter radius          5.0 m   (Scatter only)
+Scatter count           12      (Scatter only)
+Scatter assets          [list multi-select with weights]
+
+[Ghost preview always live]
+```
+
+### Workflow nominal (≤ 3 clics)
+
+| Cas | Clics |
+|-----|-------|
+| Pose un rocher | 1 (sélection asset) + 1 (click pose) = **2 clics**. |
+| Trace une ligne de poteaux | 1 (sélection) + 1 (start drag) + 1 (release) = **3 clics**. |
+| Scatter buisson | 1 (sélection multi-asset) + 1 (click scatter) = **2 clics**. |
+
+### Inputs souris
+
+| Input | Effet |
+|-------|-------|
+| Mouse Move | Déplace la ghost preview. |
+| Single click | Pose 1 instance (Single mode). |
+| Mouse down + drag + release | Drag-line ou Scatter. |
+| Wheel | Rotation Y de la ghost. |
+| Ctrl+Wheel | Échelle de la ghost. |
+| Alt | Active snap aux faces du prop voisin. |
+| Tab | Asset suivant dans la catégorie. |
+| Ctrl+Z | Annule la dernière commande de pose. |
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kPropsMagic   = 0x504F5250u; // "PROP"
+constexpr uint32_t kPropsVersion = 1u;
+```
+
+### Layout `instances/props.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 propCount
+For each prop:
+  [4]   uint32 assetId           (xxhash64 trunc to 32 bits, lookup table fournie)
+  [12]  float position[3]
+  [16]  float rotationQuat[4]
+  [12]  float scale[3]
+  [4]   uint32 layerTag           (PlacementLayer)
+  [4]   uint32 instanceId         (incremental, unique zone)
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/PlacementTool.h/.cpp` | Outil principal + ghost preview. |
+| `engine/editor/world/PlacementCommand.h/.cpp` | `ICommand` : poses + suppressions. |
+| `engine/editor/world/PlacementGhost.h/.cpp` | Drawcall de la ghost. |
+| `engine/editor/world/PlacementSnapping.h/.cpp` | Ground / Grid / Face snap. |
+| `engine/world/instances/PropInstances.h/.cpp` | Sérialisation `instances/props.bin`. |
+| `engine/editor/world/tests/PlacementTests.cpp` | Tests + perf. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/AssetBrowserPanel.cpp` | Sélection d'asset → préchargement par PlacementTool. |
+| `engine/editor/world/panels/ToolPropertiesPanel.cpp` | UI Tool Properties pour PlacementTool. |
+| `engine/world/StreamCache.cpp` | `LoadProps(zone)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteProps`. |
+
+### Structures
+
+```cpp
+namespace engine::editor::world
+{
+	enum class PlacementMode : uint8_t { Single, DragLine, Scatter };
+	enum class PlacementSnap : uint8_t { Ground, Grid, Face };
+	enum class PlacementAlign : uint8_t { TerrainNormal, WorldUp };
+
+	struct PlacementParams
+	{
+		std::string assetPath;
+		PlacementMode mode = PlacementMode::Single;
+		PlacementSnap snap = PlacementSnap::Ground;
+		PlacementAlign align = PlacementAlign::TerrainNormal;
+		float gridSizeMeters = 1.0f;
+		float dragLineSpacing = 2.0f;
+		float scatterRadius = 5.0f;
+		uint32_t scatterCount = 12;
+		std::vector<std::pair<std::string, float>> scatterAssets; // weighted
+		float rotMinDeg = 0.0f, rotMaxDeg = 360.0f;
+		float scaleMin = 0.95f, scaleMax = 1.05f;
+		uint64_t rngSeed = 0;        // 0 = time-based
+	};
+
+	class PlacementTool
+	{
+	public:
+		bool Init(CommandStack& stack, AssetBrowser& browser);
+		void SetParams(const PlacementParams& p);
+
+		void OnMouseMove(...);  // met à jour la ghost
+		void OnMouseDown(...);
+		void OnMouseUp(...);
+		void OnWheel(int delta, bool ctrl);
+		void OnTab();           // cycle asset
+
+		/// Pose une instance et la pousse via PlacementCommand. Doit s'exécuter en < 16 ms.
+		void Commit(const std::vector<PropInstance>& instances);
+
+	private:
+		PlacementParams m_params;
+		std::optional<PropInstance> m_ghost;
+		// ...
+	};
+}
+```
+
+### Performance
+
+- Ghost preview : pas de génération de mesh — réutilisation du mesh asset, drawcall additionnel avec multiplicateur alpha. Mesure : < 5 ms.
+- Commit : `Commit` fait un seul `ICommand::Execute` qui `push_back` dans le vecteur d'instances et incrémente le version counter du chunk → invalidation côté streaming. Mesure : < 16 ms (test perf obligatoire).
+
+### Snap aux faces
+
+Quand `Alt` est pressé et que la ghost touche un prop voisin :
+1. Raycast contre la collision proxy du prop voisin (M100.12).
+2. Le hit retourne une face (normale + plan).
+3. La ghost est positionnée sur cette face avec sa propre face de "snap" alignée (la face de snap est marquée dans le metadata du modular kit).
+
+### Parité éditeur ↔ client
+
+`instances/props.bin` est lu par le client via `StreamCache::LoadProps`,
+même format que celui écrit par l'éditeur.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/PlacementTool.cpp
+    engine/editor/world/PlacementCommand.cpp
+    engine/editor/world/PlacementGhost.cpp
+    engine/editor/world/PlacementSnapping.cpp
+    engine/world/instances/PropInstances.cpp
+    ...
+)
+
+add_executable(placement_tests engine/editor/world/tests/PlacementTests.cpp)
+target_link_libraries(placement_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME placement_tests COMMAND placement_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+G → PlacementTool actif
+[Asset Browser] click rock_large_03 → ghost apparaît au curseur
+Mouse move → ghost suit, snap au terrain, normale alignée
+Wheel → rotation Y de la ghost
+Click → pose. Random rotation/scale appliqués. PlacementCommand pushé.
+Drag (mode Drag-line) → ligne de copies espacées de 2.0 m.
+```
+
+## Critères d'acceptation
+
+- [ ] Pose nominale en 2 clics (sélection asset + clic terrain).
+- [ ] Ghost preview rendue en < 5 ms (mesuré en test perf).
+- [ ] Commit en < 16 ms pour 1 prop, < 50 ms pour 50 props (scatter).
+- [ ] Snap au sol fonctionne sur terrain pentu (la ghost suit la normale).
+- [ ] Snap à la grille fonctionne au pas configuré.
+- [ ] Alt + ghost touchant un prop voisin → snap face-à-face.
+- [ ] Tab cycle entre les assets de la même catégorie.
+- [ ] Ctrl+Z annule la dernière pose (avec random rotation/scale exact restoré).
+- [ ] Round-trip `props.bin` parfait.
+- [ ] Pas de collision rigide entre props (compteur d'overlap incrémenté seulement).
+
+## Tests
+
+- `Test_Single_Placement_PushesOneCommand`.
+- `Test_DragLine_GeneratesCorrectSpacing`.
+- `Test_Scatter_RespectsCountAndRadius`.
+- `Test_RandomRotation_DeterministicWithSeed`.
+- `Test_GroundSnap_AlignsToTerrainNormal`.
+- `Test_FaceSnap_HitsAdjacentPropFace`.
+- `Test_Performance_GhostUnder5ms`.
+- `Test_Performance_ScatterCommitUnder50ms`.
+- `Test_Roundtrip_PropsBin`.
+
+## Hors scope explicite
+
+- Pas de placement multi-asset hiérarchique (parents/enfants).
+- Pas de pré-visualisation HLOD.
+- Pas de drag depuis l'asset browser (la sélection est obligatoire avant).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.17-EasyPlacementTool.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.18-VegetationLibraryAndDensityPainting.md
+++ b/tickets/M100/M100.18-VegetationLibraryAndDensityPainting.md
@@ -1,0 +1,213 @@
+# M100.18 — Vegetation Library & Density Painting
+
+## Résumé
+
+Bibliothèque végétale (herbe, blé, maïs, fougère, ronces, jeunes/matures
+arbres dont sapin, conifère mort, "arbre noir torturé" propre à Lune Noire,
+buissons, champignons), peinture par densité, instancing GPU. Format
+`instances/foliage.bin` versionné. Le rendu passe par le `GpuDrivenCullingPass`
+existant.
+
+## Dépendances
+
+- **M100.5** — Heightmap.
+- **M100.17** — Placement Tool (référence ; pas de duplication de code).
+
+## Portée
+
+### Inclus
+- Catalogue d'assets : `assets/vegetation/library.json`.
+- Outil `FoliagePaintTool` (raccourci **F**).
+- Brosse de densité 0..1 par cellule fine (résolution 1025×1025 par chunk = 1 cellule / m).
+- Format `instances/foliage.bin` versionné (positions Poisson-disk + assetId + scale + rotation).
+- Règles de placement : pente min/max, altitude min/max, splat dominante.
+- Instancing GPU via `GpuDrivenCullingPass`.
+
+### Hors scope
+- Animation de vent (M100.20).
+- Interaction joueur (M100.21).
+- Forêt procédurale et champs alignés (M100.19).
+
+## Spécification fonctionnelle
+
+### Catalogue
+
+```json
+{
+  "version": 1,
+  "categories": [
+    { "id": "grass",      "label": "Herbes" },
+    { "id": "wheat",      "label": "Blé" },
+    { "id": "corn",       "label": "Maïs" },
+    { "id": "fern",       "label": "Fougère" },
+    { "id": "thorn",      "label": "Ronces" },
+    { "id": "tree_young", "label": "Jeunes arbres" },
+    { "id": "tree_oak",   "label": "Chêne mature" },
+    { "id": "tree_pine",  "label": "Sapin / conifère" },
+    { "id": "tree_dead",  "label": "Conifère mort" },
+    { "id": "tree_dark",  "label": "Arbre noir torturé" },
+    { "id": "bush",       "label": "Buisson" },
+    { "id": "mushroom",   "label": "Champignon" }
+  ],
+  "assets": [
+    { "id": "grass_01",   "category": "grass", "mesh": "veg/grass_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 35.0, "altMin": -200.0, "altMax": 2500.0, "splatLayers": [1, 2] } },
+    { "id": "tree_oak_01","category": "tree_oak","mesh": "veg/tree_oak_01.glb",
+      "rules": { "slopeMaxDeg": 25.0, "altMin": 0.0, "altMax": 1800.0, "splatLayers": [1, 2] } }
+    /* ... */
+  ]
+}
+```
+
+### Tool Properties
+
+```
+Active asset    [combo: grass_01 ▼]   Tab cycles category
+Brush radius    |■■■■■■□□□□|  6.0 m
+Density target  |■■■■■■■□□□|  0.7   (0..1)
+Strength        |■■■■■□□□□□|  0.5
+Falloff         |■■■■■■■□□□|  0.7
+
+Rules (read from library.json, editable per stroke)
+  Slope max     35°
+  Alt min/max   -200..2500 m
+  Splat layers  [1 grass_dry] [2 grass_wet]
+
+Mode  (•) Add density   ( ) Erase density
+```
+
+### Workflow
+
+- F → outil actif.
+- Press → brush augmente la densité cible.
+- Au commit (mouse up), la densité finale est résamplée en positions Poisson-disk
+  (`min_radius` configurable par asset, défaut 0.4 m) puis sérialisée dans `foliage.bin`.
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kFoliageMagic = 0x47494C46u; // "FLIG"
+constexpr uint32_t kFoliageVersion = 1u;
+constexpr uint32_t kFoliageDensityResolution = 1025; // par chunk
+```
+
+### Layout `instances/foliage.bin` (par chunk)
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 instanceCount
+For each instance:
+  [4]   uint32 assetIdHash
+  [12]  float position[3]    (chunk-local)
+  [4]   float rotationY
+  [4]   float scale
+```
+
+Une density map N×N optionnelle peut être conservée dans le chunk
+(`foliage_density.bin`) pour permettre l'édition non destructive ; en M100.18
+on stocke uniquement les positions résolues. La density map RAM vit dans
+`FoliageDocument`.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/foliage/FoliageLibrary.h/.cpp` | JSON loader + cache. |
+| `engine/world/foliage/FoliageInstances.h/.cpp` | Sérialisation. |
+| `engine/editor/world/FoliagePaintTool.h/.cpp` | Outil. |
+| `engine/editor/world/FoliagePaintCommand.h/.cpp` | `ICommand`. |
+| `engine/editor/world/FoliageDocument.h/.cpp` | État. |
+| `engine/world/foliage/PoissonDiskSampler.h/.cpp` | Sampler 2D. |
+| `engine/world/foliage/tests/FoliageTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/GpuDrivenCullingPass.cpp` | Ajouter le bucket "foliage" : InstanceBuffer chargé depuis `FoliageInstances`. |
+| `engine/world/StreamCache.cpp` | `LoadFoliage(chunkCoord)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteFoliage`. |
+
+### Performance
+
+- Cible : 100 000 instances visibles à 60 fps sur GPU mid-range, en s'appuyant sur le GPU-driven culling existant.
+
+### Parité éditeur ↔ client
+
+`instances/foliage.bin` lu par `StreamCache::LoadFoliage` côté client.
+Round-trip testé.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/foliage/FoliageLibrary.cpp
+    engine/world/foliage/FoliageInstances.cpp
+    engine/world/foliage/PoissonDiskSampler.cpp
+    engine/editor/world/FoliagePaintTool.cpp
+    engine/editor/world/FoliagePaintCommand.cpp
+    engine/editor/world/FoliageDocument.cpp
+    ...
+)
+
+add_executable(foliage_tests engine/world/foliage/tests/FoliageTests.cpp)
+target_link_libraries(foliage_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME foliage_tests COMMAND foliage_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+F → FoliagePaintTool actif
+Select grass_01
+Brush press → density map cellules à 0.7
+Mouse up → Poisson-disk sampler génère positions, push FoliagePaintCommand
+Result : 100..500 instances peintes par stroke
+```
+
+## Critères d'acceptation
+
+- [ ] La bibliothèque `library.json` charge les 12 catégories sans erreur.
+- [ ] Le brush peint la densité ; les règles `slopeMax` / `altMin/Max` / `splatLayers` filtrent les cellules.
+- [ ] Le Poisson-disk sampler garantit `min_radius` (test : pas deux instances < min_radius l'une de l'autre).
+- [ ] `foliage.bin` round-trip parfait.
+- [ ] Le rendu passe par `GpuDrivenCullingPass`.
+- [ ] Performance : 100 k instances visibles à ≥ 60 fps mid-range (mesure perf).
+- [ ] L'éditeur et le client lisent strictement le même format.
+
+## Tests
+
+- `Test_Library_LoadsAllCategories`.
+- `Test_PoissonDisk_RespectsMinRadius`.
+- `Test_RuleFilter_RejectsSteepCells`.
+- `Test_Roundtrip_FoliageBin`.
+- `Test_Performance_100kInstances`.
+
+## Hors scope explicite
+
+- Pas d'animation vent (M100.20).
+- Pas d'interaction joueur (M100.21).
+- Pas de forêts procédurales (M100.19).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.18-VegetationLibraryAndDensityPainting.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.19-ProceduralForestAndFieldTools.md
+++ b/tickets/M100/M100.19-ProceduralForestAndFieldTools.md
@@ -1,0 +1,174 @@
+# M100.19 — Procedural Forest & Field Tools
+
+## Résumé
+
+Deux outils macroscopiques : **Forest tool** (zone polygonale + recette
+d'essence avec proportions) et **Field tool** (rectangle aligné, blé ou
+maïs, alignement régulier). Les deux outils émettent des `FoliageInstances`
+existantes (M100.18) et **taggent automatiquement** la splat-map avec
+`SurfaceType::WheatField` ou `CornField` pour activer le hook gameplay.
+
+## Dépendances
+
+- **M100.11** — Surface table (tags WheatField/CornField).
+- **M100.18** — Vegetation Library & Density Painting.
+
+## Portée
+
+### Inclus
+- Outil `ForestTool` (raccourci **Shift+F**).
+- Outil `FieldTool` (raccourci **Shift+W** pour Wheat, Shift+C pour Corn).
+- Forest : polygone fermé + recette `[(asset_id, weight, density), ...]`.
+- Field : rectangle aligné à un axe, espacement régulier, alignement Y selon terrain.
+- Tag automatique splat : Field tool peint la splat layer correspondante (WheatField → layer "wheat" si présente, sinon dirt avec un override metadata `surfaceTag`).
+
+### Hors scope
+- Édition fine post-génération (utiliser M100.18 ensuite).
+- Forêts saisonnières (M100.25).
+
+## Spécification fonctionnelle
+
+### Forest Tool — Tool Properties
+
+```
+Recipe
+  + tree_oak_01     weight 0.5  density 0.05/m²
+  + tree_pine_02    weight 0.3  density 0.04/m²
+  + bush_03         weight 0.2  density 0.10/m²
+  +
+Polygon : [click points, double-click to close]
+Seed   : 42
+[Generate]   [Cancel]
+```
+
+### Field Tool — Tool Properties
+
+```
+Crop      (•) Wheat   ( ) Corn
+Spacing   |■■■■□□□□□□|  0.6 m
+Rotation  |■□□□□□□□□□|   12.5°
+Rectangle: click 2 corners, drag to size
+
+Auto-tag splat layer  [✓]  → SurfaceType::WheatField
+[Generate]
+```
+
+## Spécification technique
+
+### Algorithmes
+
+**Forest** :
+1. Triangulation polygone.
+2. Pour chaque triangle : nombre d'instances = `area * sum(density)`.
+3. Génération uniforme par triangle, sélection asset par poids cumulé, application des `rules` de M100.18 (slope, alt, splat).
+4. Push d'un `ForestCommand` (paste de toutes les instances + tag splat optionnel).
+
+**Field** :
+1. Maille régulière dans le rectangle (rotation appliquée).
+2. Une instance par cellule (pas d'aléa sur la position pour conserver l'alignement régulier ; aléa léger sur scale [0.95..1.05]).
+3. Peinture splat de la layer cible avec poids 200 (sur 255), redistribution des autres (cf. M100.10).
+4. Push d'un `FieldCommand` (instances + delta splat).
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/ForestTool.h/.cpp` | Outil. |
+| `engine/editor/world/FieldTool.h/.cpp` | Outil. |
+| `engine/editor/world/ForestRecipe.h/.cpp` | Recette + sérialisation JSON pour les recettes prédéfinies. |
+| `engine/editor/world/ForestCommand.h/.cpp` | `ICommand` composite (instances + splat optionnel). |
+| `engine/editor/world/FieldCommand.h/.cpp` | `ICommand` composite. |
+| `engine/editor/world/tests/ForestFieldTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/FoliageDocument.h/.cpp` | API `BulkPaste(instances)`. |
+| `engine/editor/world/TerrainDocument.h/.cpp` | API `PaintSplatRectangle(rect, layerIndex)`. |
+| `assets/terrain/layer_palette.json` | Ajouter layer "wheat" et "corn" (surfaceType=WheatField/CornField) si pas déjà présentes. |
+
+### Format / parité
+
+Pas de nouveau format. Réutilise `instances/foliage.bin` (M100.18) et
+`splat.bin` (M100.9).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/FoliagePaintTool.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/FoliagePaintTool.cpp
+    engine/editor/world/ForestTool.cpp
+    engine/editor/world/FieldTool.cpp
+    engine/editor/world/ForestRecipe.cpp
+    engine/editor/world/ForestCommand.cpp
+    engine/editor/world/FieldCommand.cpp
+    ...
+)
+
+add_executable(forest_field_tests engine/editor/world/tests/ForestFieldTests.cpp)
+target_link_libraries(forest_field_tests PRIVATE engine_core)
+add_test(NAME forest_field_tests COMMAND forest_field_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+Shift+F → ForestTool actif
+Click click click ... double-click → polygone fermé
+Recipe : tree_oak 0.5, tree_pine 0.3, bush 0.2 → Generate
+→ ~5 000 instances générées en < 200 ms
+
+Shift+W → FieldTool actif (Wheat)
+Click bas-gauche, drag haut-droit → rectangle 50×30 m
+Spacing 0.6 → 50/0.6 * 30/0.6 = ~4 166 instances
++ splat layer "wheat" peinte sur tout le rectangle → SurfaceType::WheatField
+```
+
+## Critères d'acceptation
+
+- [ ] Forest : la densité totale du recette correspond bien à la somme des densités demandées (± 5 %).
+- [ ] Forest : les règles per-asset (slope, alt, splat) filtrent correctement les positions.
+- [ ] Forest : le seed est respecté (régénération identique).
+- [ ] Field : alignement régulier (variance de position ≈ 0).
+- [ ] Field : la splat-map est taggée WheatField / CornField partout sous le rectangle.
+- [ ] Field : la rotation orientee bien la grille.
+- [ ] Une zone champ est correctement détectée par `SurfaceQuery` côté client.
+- [ ] Tests passent.
+
+## Tests
+
+- `Test_Forest_DensityMatchesRecipe`.
+- `Test_Forest_RulesFilterSlope`.
+- `Test_Forest_DeterministicWithSeed`.
+- `Test_Field_RegularSpacing`.
+- `Test_Field_TagsSplatLayer`.
+- `Test_Field_SurfaceQueryReturnsWheatField`.
+
+## Hors scope explicite
+
+- Pas de génération de "biomes" globaux (tundra/savane). Forest est local.
+- Pas d'irrégularités saisonnières (champs en jachère).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.19-ProceduralForestAndFieldTools.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.2-CommandStackUndoRedo.md
+++ b/tickets/M100/M100.2-CommandStackUndoRedo.md
@@ -1,0 +1,228 @@
+# M100.2 — Command Stack & Undo/Redo
+
+## Résumé
+
+Introduit un Command Pattern centralisé (`engine::editor::world::CommandStack`)
+avec piles undo/redo en RAM, raccourcis Ctrl+Z / Ctrl+Shift+Z, et historique
+visible dans un panneau dédié. Toutes les opérations d'édition produites par
+les tickets suivants passent obligatoirement par cette pile.
+
+## Dépendances
+
+- **M100.1** — World Editor Bootstrap.
+
+## Portée
+
+### Inclus
+- Interface `ICommand`.
+- Classe `CommandStack` avec piles `std::vector<std::unique_ptr<ICommand>>` undo/redo.
+- Politique de mémoire : pile undo capée à 256 commandes ou 256 MiB de coalesced state, configurable via `editor.world.undo.capacity` et `editor.world.undo.maxBytes`.
+- Raccourcis Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y.
+- Panneau `HistoryPanel` listant les commandes avec leur timestamp et leur taille mémoire.
+- Système de coalescing : commandes consécutives marquées avec le même `mergeKey` fusionnent (ex. plusieurs traits de pinceau d'un même brushstroke).
+
+### Hors scope
+- Sérialisation de la pile undo sur disque.
+- Branchement d'outils concrets (les tickets aval enregistrent leurs `ICommand`).
+
+## Spécification fonctionnelle
+
+| Action | Raccourci | Effet |
+|--------|-----------|-------|
+| Undo | Ctrl+Z | Dépile la dernière commande, appelle `Undo`, l'empile dans la pile redo. |
+| Redo | Ctrl+Shift+Z ou Ctrl+Y | Symétrique. |
+| Clear | Bouton "Clear History" | Vide les deux piles. |
+
+Le panneau `History` affiche :
+```
+[12:03:21]  Sculpt brush stroke           (3.2 MB)   [active]
+[12:03:18]  Splat paint stroke            (1.1 MB)
+[12:03:12]  Place tree                    (4 KB)
+```
+
+L'item `[active]` est la position courante. Cliquer sur une ligne plus
+ancienne effectue undo en cascade jusqu'à elle.
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/CommandStack.h` | `ICommand`, `CommandStack`. |
+| `engine/editor/world/CommandStack.cpp` | Implémentation. |
+| `engine/editor/world/panels/HistoryPanel.h/.cpp` | UI historique. |
+| `engine/editor/world/tests/CommandStackTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/WorldEditorShell.h/.cpp` | Possède `m_commandStack`, le passe aux outils, branche les raccourcis Ctrl+Z/Y, ajoute `HistoryPanel` à la liste de panneaux. |
+| `engine/editor/EditorMode.h/.cpp` | (rien) |
+| `config.json` | Ajouter `editor.world.undo.capacity` (défaut 256), `editor.world.undo.maxBytes` (défaut 256 MiB). |
+
+### Structures
+
+```cpp
+namespace engine::editor::world
+{
+	/// Identifiant de fusion des commandes consécutives. 0 = pas de fusion.
+	using CommandMergeKey = uint64_t;
+
+	/// Toute opération d'édition réversible passe par cette interface.
+	class ICommand
+	{
+	public:
+		virtual ~ICommand() = default;
+		/// Description courte affichée dans le panneau History.
+		virtual const char* GetLabel() const = 0;
+		/// Empreinte mémoire approximative (octets), pour la politique d'éviction.
+		virtual size_t GetMemoryFootprint() const = 0;
+		/// Clé de fusion. Deux commandes consécutives avec la même clé non-nulle
+		/// sont coalescées (cf. CommandStack::Push).
+		virtual CommandMergeKey GetMergeKey() const { return 0; }
+		/// Applique la commande. Appelé une fois à Push, puis à chaque Redo.
+		virtual void Execute() = 0;
+		/// Inverse de Execute.
+		virtual void Undo() = 0;
+		/// Optionnel : fusionne `other` dans `this` (other sera détruit).
+		virtual bool TryMerge(const ICommand& other) { (void)other; return false; }
+	};
+
+	struct CommandStackConfig
+	{
+		size_t capacity = 256;
+		size_t maxBytes = 256ull * 1024ull * 1024ull;
+	};
+
+	class CommandStack
+	{
+	public:
+		void Configure(const CommandStackConfig& cfg);
+
+		/// Exécute `cmd` puis l'empile. Coalesce avec le sommet si même mergeKey.
+		void Push(std::unique_ptr<ICommand> cmd);
+
+		bool CanUndo() const;
+		bool CanRedo() const;
+		void Undo();
+		void Redo();
+
+		/// Annule en cascade jusqu'à la commande d'index `targetIndex` (exclu).
+		void RewindTo(size_t targetIndex);
+
+		void Clear();
+
+		size_t UndoSize() const;
+		size_t RedoSize() const;
+		size_t TotalBytes() const;
+
+		struct HistoryEntry { std::string label; size_t bytes; uint64_t timestampMs; };
+		std::vector<HistoryEntry> SnapshotHistory() const;
+
+	private:
+		void EvictOldest();
+		std::vector<std::unique_ptr<ICommand>> m_undo;
+		std::vector<std::unique_ptr<ICommand>> m_redo;
+		std::vector<uint64_t> m_undoTimestamps;
+		std::vector<uint64_t> m_redoTimestamps;
+		size_t m_totalBytes = 0;
+		CommandStackConfig m_cfg;
+	};
+}
+```
+
+### Format de sérialisation
+
+Aucun. Pile RAM uniquement.
+
+### Passes / Shaders
+
+Aucune.
+
+### Parité éditeur ↔ client
+
+Pas applicable.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/WorldEditorShell.cpp
+    engine/editor/world/panels/ScenePanel.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/WorldEditorShell.cpp
+    engine/editor/world/CommandStack.cpp
+    engine/editor/world/panels/ScenePanel.cpp
+    engine/editor/world/panels/HistoryPanel.cpp
+    ...
+)
+
+add_executable(command_stack_tests engine/editor/world/tests/CommandStackTests.cpp)
+target_link_libraries(command_stack_tests PRIVATE engine_core)
+add_test(NAME command_stack_tests COMMAND command_stack_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+Brushstroke 1 ─┐
+Brushstroke 2 ─┼─ même mergeKey ─> coalesce ─┐
+Brushstroke 3 ─┘                              │
+                                              v
+                                 [Push ICommand "Sculpt stroke"]
+                                              │
+                  Ctrl+Z ───> CommandStack::Undo() ─> ICommand::Undo
+                                              │
+                  Ctrl+Shift+Z ───> CommandStack::Redo() ─> ICommand::Execute
+```
+
+## Critères d'acceptation
+
+- [ ] Ctrl+Z annule la dernière commande et la déplace dans la pile redo.
+- [ ] Ctrl+Shift+Z rejoue la dernière annulation.
+- [ ] Toute nouvelle commande poussée vide la pile redo.
+- [ ] Le panneau History liste toutes les commandes avec leur taille mémoire.
+- [ ] Cliquer sur une ligne ancienne dans le panneau exécute Undo en cascade jusqu'à elle.
+- [ ] L'éviction se déclenche dès que `TotalBytes() > maxBytes` ou `UndoSize() > capacity`.
+- [ ] Deux commandes avec le même `mergeKey` consécutif sont fusionnées (vérifié par test unitaire).
+- [ ] Aucune référence à `CommandStack` n'apparaît dans le target `server_app`.
+
+## Tests
+
+- `engine/editor/world/tests/CommandStackTests.cpp` :
+  - `Test_PushExecutesAndStores`.
+  - `Test_UndoRedoRoundtrip`.
+  - `Test_CapacityEvictsOldest`.
+  - `Test_MaxBytesEvictsOldest`.
+  - `Test_MergeKeyCoalescesConsecutive`.
+  - `Test_PushClearsRedoStack`.
+  - `Test_RewindToReplaysCascade`.
+
+## Hors scope explicite
+
+- Pas de persistance disque de l'historique.
+- Pas de checkpoints multi-document.
+- Pas d'undo cross-process / cross-session.
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.2-CommandStackUndoRedo.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.20-VegetationWindAnimation.md
+++ b/tickets/M100/M100.20-VegetationWindAnimation.md
@@ -1,0 +1,201 @@
+# M100.20 — Vegetation Wind Animation
+
+## Résumé
+
+Champ de vent global (direction + force + turbulence) éditable, plus champs
+locaux par zone polygonale. Shader d'instance végétation : amplitude
+proportionnelle à la hauteur du brin, propagation en vagues à travers les
+champs cultivés. Constant buffer `WindParams` mis à jour chaque frame côté
+client.
+
+## Dépendances
+
+- **M100.18** — Vegetation Library & Density Painting.
+
+## Portée
+
+### Inclus
+- Constant buffer `WindParams` global (direction.xz, force, turbulenceFreq, turbulenceAmp, timeSeconds).
+- Variantes shader pour les meshes végétation (vert : `foliage.vert`).
+- Édition globale dans le panneau "Atmosphere → Wind".
+- Champs locaux par zone polygonale (sérialisés dans `instances/wind_zones.bin`).
+- Vagues sur champs cultivés (frequency, amplitude, direction d'écoulement).
+
+### Hors scope
+- Interaction joueur (M100.21).
+- Audio du vent (futur).
+
+## Spécification fonctionnelle
+
+### Panneau Wind (sous Atmosphere)
+
+```
+Global Wind
+  Direction         |■■■■■■■□□□|  azimuth 60°
+  Force             |■■■■□□□□□□|  4.0 m/s
+  Turbulence freq   |■■■□□□□□□□|  0.2 Hz
+  Turbulence amp    |■■□□□□□□□□|  0.5 m
+
+Wave on cultivated fields
+  Wave speed        |■■■■□□□□□□|  3.0 m/s
+  Wave length       |■■■■■□□□□□|  6.0 m
+  Wave amplitude    |■■■□□□□□□□|  0.3
+```
+
+### Local wind zones
+
+Outil `WindZoneTool` (Tools menu, pas de raccourci dédié) : polygone +
+override `direction`, `force`. Quand le joueur (ou la caméra) est dans la zone,
+les paramètres locaux remplacent les globaux pour les instances de cette zone.
+
+## Spécification technique
+
+### Constant buffer
+
+```glsl
+layout(set=0, binding=4) uniform WindParams {
+    vec2  direction;             // normalized
+    float forceMps;
+    float turbulenceFreq;
+    float turbulenceAmp;
+    float waveSpeed;
+    float waveLengthMeters;
+    float waveAmplitude;
+    float timeSeconds;
+} u_wind;
+```
+
+### Shader vertex (résumé) `foliage.vert`
+
+```glsl
+void main()
+{
+    vec3 localPos = a_position;
+    float h = localPos.y;                   // hauteur dans l'instance
+    float heightWeight = smoothstep(0.0, 1.0, h);  // racines = 0, sommet = 1
+
+    vec2 worldXZ = (model * vec4(localPos, 1.0)).xz;
+    float wavePhase = dot(worldXZ, u_wind.direction) / u_wind.waveLengthMeters
+                    - u_wind.waveSpeed * u_wind.timeSeconds;
+    float wave = sin(wavePhase) * u_wind.waveAmplitude;
+
+    float turb = (sin(u_wind.timeSeconds * u_wind.turbulenceFreq * 6.28 + worldXZ.x) +
+                  sin(u_wind.timeSeconds * u_wind.turbulenceFreq * 6.28 + worldXZ.y))
+                 * u_wind.turbulenceAmp;
+
+    vec2 sway = u_wind.direction * (u_wind.forceMps * 0.05 + wave + turb) * heightWeight;
+    localPos.x += sway.x;
+    localPos.z += sway.y;
+
+    gl_Position = viewProj * model * vec4(localPos, 1.0);
+}
+```
+
+### Constantes & layout binaire
+
+```cpp
+constexpr uint32_t kWindZonesMagic = 0x444E4957u; // "WIND"
+constexpr uint32_t kWindZonesVersion = 1u;
+```
+
+`instances/wind_zones.bin`:
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 zoneCount
+For each zone:
+  [4]   uint32 vertexCount
+  [12*N] float[3] polygon
+  [8]   float direction[2]
+  [4]   float forceMps
+  [4]   float turbulenceFreq
+  [4]   float turbulenceAmp
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/wind/WindParams.h` | Struct shared C++ / GLSL. |
+| `engine/world/wind/WindZones.h/.cpp` | Sérialisation. |
+| `engine/world/wind/WindSystem.h/.cpp` | Évalue WindParams effectifs (global ± local). |
+| `engine/editor/world/WindZoneTool.h/.cpp` | Outil polygone. |
+| `engine/render/shaders/foliage.vert` | Shader vertex foliage avec vent. |
+| `engine/world/wind/tests/WindTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/GeometryPass.cpp` | Bind `WindParams` au pipeline foliage. |
+| `engine/Engine.cpp` | Update `timeSeconds` chaque frame. |
+| `engine/editor/world/panels/AtmospherePanel.h/.cpp` | Sous-panneau Wind. |
+
+### Parité éditeur ↔ client
+
+`wind_zones.bin` lu par le client. Le shader est strictement le même.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/wind/WindZones.cpp
+    engine/world/wind/WindSystem.cpp
+    engine/editor/world/WindZoneTool.cpp
+    ...
+)
+
+add_executable(wind_tests engine/world/wind/tests/WindTests.cpp)
+target_link_libraries(wind_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME wind_tests COMMAND wind_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Atmosphere → Wind] sliders → WindParams global mis à jour live
+Tools → WindZoneTool → polygone + override
+[Save] → instances/wind_zones.bin écrit
+[Foliage rendu] → shader applique sway proportionnel à la hauteur, vague sur champs
+```
+
+## Critères d'acceptation
+
+- [ ] Le sway visible sur l'herbe est proportionnel à la hauteur (racines fixes, sommets ondulent).
+- [ ] La vague sur le blé est visible et propage dans la direction `u_wind.direction`.
+- [ ] Une wind zone locale override correctement les paramètres globaux quand la caméra est dedans.
+- [ ] Les paramètres globaux sont édités live et reflétés sans rechargement.
+- [ ] Round-trip `wind_zones.bin` parfait.
+- [ ] Aucune branche éditeur dans `foliage.vert`.
+
+## Tests
+
+- `Test_WindParams_SwayProportionalToHeight`.
+- `Test_LocalZone_OverridesGlobal`.
+- `Test_Roundtrip_WindZonesBin`.
+- `Test_AtmosphereJson_PreservesWindOnReload`.
+
+## Hors scope explicite
+
+- Pas d'audio (futur).
+- Pas de physique (le sway est pure visualisation shader).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.20-VegetationWindAnimation.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.21-VegetationPlayerInteractionShader.md
+++ b/tickets/M100/M100.21-VegetationPlayerInteractionShader.md
@@ -1,0 +1,164 @@
+# M100.21 — Vegetation Player Interaction Shader
+
+## Résumé
+
+Buffer GPU des positions d'entités proches (joueur local + autres + PNJ),
+max 32 par chunk visible. Shader d'instance : flexion radiale autour de
+chaque entité, relaxation ~0.5 s. Le joueur **doit voir** son personnage
+écarter le blé. Budget perf : < 0.5 ms additionnel sur 100 k instances
+visibles.
+
+## Dépendances
+
+- **M100.20** — Vegetation Wind Animation.
+
+## Portée
+
+### Inclus
+- SSBO `EntityInfluences` (32 × `vec4 (x, z, radius, falloffPower)`).
+- Shader `foliage.vert` enrichi : pour chaque influence, ajoute une flexion
+  radiale décrémentale en fonction de la distance.
+- Relaxation : la position de l'influence est lerpée par `WindSystem` vers la
+  position courante de l'entité avec un coefficient `relaxRate = 1 / 0.5 s`.
+- Système client `EntityInfluenceCollector` : à chaque frame, collecte les
+  capsules des entités à < 30 m de la caméra, les sérialise dans le SSBO.
+- Budget : 32 entités × 1 sin + 1 distance ≈ trivial. Mesure obligatoire.
+
+### Hors scope
+- Effet sur les arbres (les troncs ne fléchissent pas). Limité aux meshes
+  marqués `flexible` dans la library.
+- Empreintes au sol (le décal d'empreinte est dans M100.33 / déjà existant).
+
+## Spécification fonctionnelle
+
+Aucune surface UI. L'effet est visible runtime.
+
+## Spécification technique
+
+### SSBO
+
+```glsl
+struct EntityInfluence {
+    vec2  positionXZ;
+    float radiusMeters;
+    float falloffPower;
+};
+layout(set=0, binding=5, std430) readonly buffer Entities {
+    uint     count;
+    EntityInfluence data[32];
+} u_entities;
+```
+
+### Shader vertex (suite de M100.20)
+
+```glsl
+// Après le calcul de sway dû au vent
+for (uint i = 0u; i < u_entities.count; ++i)
+{
+    vec2 toEntity = worldXZ - u_entities.data[i].positionXZ;
+    float dist = length(toEntity);
+    float r = u_entities.data[i].radiusMeters;
+    if (dist < r)
+    {
+        float w = pow(1.0 - dist / r, u_entities.data[i].falloffPower);
+        vec2 push = normalize(toEntity) * w * 0.6 * heightWeight;
+        localPos.x += push.x;
+        localPos.z += push.y;
+    }
+}
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/foliage/EntityInfluenceCollector.h/.cpp` | Collecte + upload SSBO. |
+| `engine/world/foliage/tests/EntityInfluenceTests.cpp` | Tests + perf. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/shaders/foliage.vert` | Ajout du loop d'influences. |
+| `engine/render/GpuDrivenCullingPass.cpp` | Bind du SSBO `Entities` sur le pipeline foliage. |
+| `engine/Engine.cpp` | Frame setup : `EntityInfluenceCollector::Update`. |
+
+### Performance
+
+Cible mesurée : **< 0.5 ms additionnel** sur 100 k instances foliage visibles
+sur GPU mid-range (RTX 2060 ou équivalent). Test perf bloquant.
+
+### Parité éditeur ↔ client
+
+Le shader est strictement le même côté éditeur. Pas de format binaire nouveau.
+
+### Réseau
+
+Aucun. Les autres joueurs / PNJ sont déjà visibles via le protocole position
+existant ; le ticket lit ces positions runtime.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/wind/WindSystem.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/wind/WindSystem.cpp
+    engine/world/foliage/EntityInfluenceCollector.cpp
+    ...
+)
+
+add_executable(entity_influence_tests engine/world/foliage/tests/EntityInfluenceTests.cpp)
+target_link_libraries(entity_influence_tests PRIVATE engine_core)
+add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+(Comportement runtime.)
+
+```
+Joueur traverse un champ de blé
+  → EntityInfluenceCollector.Update : remplit SSBO avec sa position
+  → Shader fléchit le blé radialement autour du joueur
+  → Quand il s'éloigne, position relaxe sur 0.5 s, sway revient à pure-vent
+```
+
+## Critères d'acceptation
+
+- [ ] Le joueur voit son personnage écarter visiblement le blé sur 100 k instances.
+- [ ] Jusqu'à 32 entités proches simultanées sont prises en compte.
+- [ ] Le budget shader additionnel est < 0.5 ms (mesure perf, mid-range GPU).
+- [ ] La relaxation se fait sur ~0.5 s après que l'entité s'éloigne.
+- [ ] Les arbres marqués `flexible=false` n'ont pas l'effet (test visuel).
+- [ ] Aucune branche éditeur dans le shader.
+- [ ] Aucun trafic réseau spécifique.
+
+## Tests
+
+- `Test_Collector_FiltersEntitiesByRange30m`.
+- `Test_Collector_TruncatesAt32`.
+- `Test_Shader_FlexionMonotoneWithDistance`.
+- `Test_Performance_Under0p5ms_100kInstances`.
+
+## Hors scope explicite
+
+- Pas d'effet sur arbres rigides.
+- Pas de réaction dynamique des physiques propres (couches, capes — autre système).
+
+## Référence visuelle
+
+Pas de panneau ImGui ; le résultat est visuel.
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.22-VolumetricFogVolumes.md
+++ b/tickets/M100/M100.22-VolumetricFogVolumes.md
@@ -1,0 +1,176 @@
+# M100.22 — Volumetric Fog Volumes
+
+## Résumé
+
+Volumes 3D (boîtes ou ellipsoïdes) éditables qui injectent du brouillard
+volumique dans une passe `VolumetricFog` dédiée, insérée entre `SSAO_Blur`
+et `Tonemap`. Implementation froxel grid 160×88×64 (résolution standard
+adaptée au framebuffer).
+
+## Dépendances
+
+- **M100.4** — Editor Camera Modes.
+
+## Portée
+
+### Inclus
+- Outil `VolumetricFogVolumeTool` (Tools menu).
+- Format `instances/fog_volumes.bin` versionné.
+- Passe `VolumetricFogPass` (compute injection + scatter raymarch + apply).
+- Constant buffer global `FogParams` (densité, color, anisotropy g de Henyey-Greenstein).
+- Preview live dans le viewport.
+
+### Hors scope
+- Distance + height fog (M100.23).
+- Variations saisonnières / météo (M100.25, M100.26).
+
+## Spécification fonctionnelle
+
+### Tool Properties
+
+```
+Shape    (•) Box   ( ) Ellipsoid
+Position [-10.0, 1.0, -3.0]
+Size     [12.0, 4.0, 8.0]
+Rotation Y    0°
+
+Density       |■■■□□□□□□□|  0.05
+Color         RGB picker  → vec3(0.7, 0.75, 0.85)
+Anisotropy g  |■■■■■□□□□□|  0.0  (-1..1)
+
+[Apply]
+```
+
+### Workflow
+
+1. Pose un volume.
+2. Ajuste density / color.
+3. Voit le brouillard apparaître localement.
+4. Sauvegarde zone.
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kFogVolumesMagic = 0x47444F46u; // "FODG"
+constexpr uint32_t kFogVolumesVersion = 1u;
+constexpr uint32_t kFroxelGridX = 160;
+constexpr uint32_t kFroxelGridY = 88;
+constexpr uint32_t kFroxelGridZ = 64;
+```
+
+### Layout `instances/fog_volumes.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 volumeCount
+
+For each volume:
+  [4]   uint32 shape (0=Box, 1=Ellipsoid)
+  [12]  float position[3]
+  [12]  float halfExtents[3]   (Box) ou radii[3] (Ellipsoid)
+  [4]   float rotationYDeg
+  [4]   float density
+  [12]  float color[3]
+  [4]   float anisotropy
+```
+
+### Frame graph
+
+```
+... → SSAO_Blur → Decals → Water → VolumetricFog (NEW: 3 sub-passes : Inject, Scatter, Apply)
+                                  → TAA → Tonemap → ...
+```
+
+`VolumetricFogPass` :
+- **Inject** (compute) : pour chaque froxel, injecte la contribution des volumes intersectant.
+- **Scatter** (compute) : raymarch dans la grille 3D, accumule scattering en avant.
+- **Apply** (fragment) : blend le résultat sur `SceneColor`.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/render/VolumetricFogPass.h/.cpp` | Passe. |
+| `engine/render/shaders/fog_inject.comp` | Compute injection. |
+| `engine/render/shaders/fog_scatter.comp` | Compute scatter. |
+| `engine/render/shaders/fog_apply.frag` | Apply. |
+| `engine/world/atmosphere/FogVolumes.h/.cpp` | Sérialisation. |
+| `engine/editor/world/VolumetricFogVolumeTool.h/.cpp` | Outil. |
+| `engine/world/atmosphere/tests/FogVolumesTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/render/FrameGraph.cpp` | Insère `VolumetricFogPass`. |
+| `engine/world/StreamCache.cpp` | `LoadFogVolumes(zone)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteFogVolumes`. |
+
+### Parité éditeur ↔ client
+
+Round-trip `fog_volumes.bin`. Shader strictement le même.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/render/VolumetricFogPass.cpp
+    engine/world/atmosphere/FogVolumes.cpp
+    engine/editor/world/VolumetricFogVolumeTool.cpp
+    ...
+)
+
+add_executable(fog_volumes_tests engine/world/atmosphere/tests/FogVolumesTests.cpp)
+target_link_libraries(fog_volumes_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME fog_volumes_tests COMMAND fog_volumes_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+Tools → Volumetric Fog Volume → drop a box at cursor
+Inspector → density 0.05, color (0.7, 0.75, 0.85), anisotropy 0.0
+Save → instances/fog_volumes.bin écrit
+```
+
+## Critères d'acceptation
+
+- [ ] Un volume Box visible produit un brouillard local cohérent (test screenshot).
+- [ ] Plusieurs volumes additifs produisent un cumul correct.
+- [ ] Round-trip `fog_volumes.bin` parfait.
+- [ ] Performance : `VolumetricFogPass` < 1.5 ms sur GPU mid-range avec 4 volumes actifs.
+- [ ] La passe est inscrite après `Water` et avant `TAA`.
+
+## Tests
+
+- `Test_FogVolumes_RoundtripBin`.
+- `Test_VolumetricFog_RegistersInFrameGraph`.
+- `Test_VolumetricFog_GoldenImage`.
+
+## Hors scope explicite
+
+- Pas de simulation physique (advection, vortex).
+- Pas de fog de profondeur global (M100.23).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.22-VolumetricFogVolumes.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.23-DistanceFogAndHeightFogTuning.md
+++ b/tickets/M100/M100.23-DistanceFogAndHeightFogTuning.md
@@ -1,0 +1,183 @@
+# M100.23 — Distance Fog & Height Fog Tuning
+
+## Résumé
+
+Étend `atmosphere.json` avec deux couches additionnelles de brouillard
+**globales** : `distanceFog` (exponentiel) et `heightFog` (nappe basse).
+Ces deux couches **plus** les volumes 3D de M100.22 sont composées dans la
+même passe (`VolumetricFogPass` est étendue). Panneau Atmosphere expose les
+3 couches, courbe densité-vs-distance, et override par zone (zones de
+M100.28 si présent, sinon valeurs globales).
+
+## Dépendances
+
+- **M100.22** — Volumetric Fog Volumes.
+
+## Portée
+
+### Inclus
+- Extension JSON `atmosphere.json` : `distanceFog` (density, color, start, falloff), `heightFog` (densityAtY0, falloff, color, baseY).
+- Override par zone : `instances/atmosphere_zones.bin` (zones polygonales avec leurs propres `atmosphere`).
+- Panneau Atmosphere : trois sous-panneaux Distance / Height / Volumes.
+- Courbe densité-vs-distance (graphique ImGui) en lecture seule.
+
+### Hors scope
+- Couches météo dynamiques (M100.26).
+
+## Spécification fonctionnelle
+
+### Atmosphere panel
+
+```
+[Distance Fog]
+  Density        |■■■□□□□□□□|  0.0035
+  Color          (0.62, 0.70, 0.78)
+  Start (m)      |■□□□□□□□□□|  150
+  Falloff        |■■■■□□□□□□|  0.6
+
+[Height Fog]
+  Density at Y=0 |■■■■□□□□□□|  0.18
+  Falloff (1/m)  |■■■□□□□□□□|  0.25
+  Base Y (m)     |■■□□□□□□□□|  3.0
+  Color          (0.45, 0.55, 0.62)
+
+[Volumes 3D]                (cf. M100.22)
+  ...
+
+[Curve preview]                 visible chart (density vs depth)
+
+[+ Override per zone] → ouvre AtmosphereZoneTool
+```
+
+## Spécification technique
+
+### Schéma `atmosphere.json`
+
+```json
+{
+  "version": 2,
+  "distanceFog": {
+    "density": 0.0035,
+    "color": [0.62, 0.70, 0.78],
+    "startMeters": 150.0,
+    "falloff": 0.6
+  },
+  "heightFog": {
+    "densityAtY0": 0.18,
+    "falloffPerMeter": 0.25,
+    "baseY": 3.0,
+    "color": [0.45, 0.55, 0.62]
+  },
+  "volumes": [ /* M100.22 inline ou référence à fog_volumes.bin */ ]
+}
+```
+
+Le bump `"version": 2` impose une migration : `LoadAtmosphereSettings`
+détecte version=1 et complète les sections manquantes avec des valeurs par
+défaut.
+
+### Constantes
+
+```cpp
+constexpr uint32_t kAtmosphereZonesMagic = 0x4E5A5441u; // "ATZN"
+constexpr uint32_t kAtmosphereZonesVersion = 1u;
+```
+
+### Layout `instances/atmosphere_zones.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 zoneCount
+For each zone:
+  [4]   uint32 vertexCount
+  [12*N] float[3] polygon
+  [N]   AtmosphereSettings inline (taille fixe ~80 octets, layout C++)
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/atmosphere/AtmosphereZones.h/.cpp` | Sérialisation. |
+| `engine/editor/world/AtmosphereZoneTool.h/.cpp` | Outil polygone. |
+| `engine/render/shaders/fog_apply.frag` (modifié) | Compose distanceFog + heightFog + volumes. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/AtmosphereSettings.h/.cpp` (existant) | Bump version, charge distance/height. |
+| `engine/render/VolumetricFogPass.cpp` | Compose les 3 sources. |
+| `engine/editor/world/panels/AtmospherePanel.cpp` | UI 3 sous-panneaux + courbe. |
+| `engine/world/StreamCache.cpp` | `LoadAtmosphereZones(zone)`. |
+
+### Parité éditeur ↔ client
+
+Migration `atmosphere.json` v1 → v2 testée. Round-trip `atmosphere_zones.bin`.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/render/VolumetricFogPass.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/render/VolumetricFogPass.cpp
+    engine/world/atmosphere/AtmosphereZones.cpp
+    engine/editor/world/AtmosphereZoneTool.cpp
+    ...
+)
+
+add_executable(atmosphere_zones_tests engine/world/atmosphere/tests/AtmosphereZonesTests.cpp)
+target_link_libraries(atmosphere_zones_tests PRIVATE engine_core)
+add_test(NAME atmosphere_zones_tests COMMAND atmosphere_zones_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Atmosphere Panel] sliders Distance / Height → preview live
++ Override per zone → AtmosphereZoneTool dessine un polygone
+Save → atmosphere.json v2 + instances/atmosphere_zones.bin
+```
+
+## Critères d'acceptation
+
+- [ ] Un fichier `atmosphere.json` v1 charge sans erreur (migration auto).
+- [ ] Le distance fog densifie avec la profondeur de manière exponentielle.
+- [ ] Le height fog respecte `baseY` et `falloffPerMeter`.
+- [ ] Override par zone : à l'intérieur du polygone, les paramètres locaux remplacent les globaux ; transition adoucie sur 5 m de bord.
+- [ ] Courbe densité-vs-distance affichée correctement.
+- [ ] Round-trip `atmosphere.json` v2 et `atmosphere_zones.bin` parfaits.
+
+## Tests
+
+- `Test_AtmosphereJson_V1ToV2Migration`.
+- `Test_DistanceFog_DensityIncreaseWithDepth`.
+- `Test_HeightFog_RespectsBaseYAndFalloff`.
+- `Test_AtmosphereZones_RoundtripBin`.
+
+## Hors scope explicite
+
+- Pas de fog dynamique (météo, M100.26).
+- Pas de couches optiques avancées (rayleigh, mie complets).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.23-DistanceFogAndHeightFogTuning.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.24-SunSkyAndProbesEditor.md
+++ b/tickets/M100/M100.24-SunSkyAndProbesEditor.md
@@ -1,0 +1,167 @@
+# M100.24 — Sun, Sky & Probes Editor
+
+## Résumé
+
+Édition du soleil (direction, couleur, intensité) avec courbe heure-du-jour
+× jour-de-l'année (ToD × ToY). Placement et cuisson de probes IBL via le
+système existant. Branche le `DayNightCycle` runtime sur la courbe éditée.
+
+## Dépendances
+
+- **M100.23** — Distance Fog & Height Fog Tuning (cohérence atmosphère).
+
+## Portée
+
+### Inclus
+- Panneau "Sun & Sky" sous Atmosphere.
+- Sliders heure (0..24) et jour (1..360, par défaut 360 jours = 1 an).
+- Courbe ToD × ToY 24×N (où N = 4 saisons interpolées) éditable point par point.
+- Couleurs ambiantes, intensités, élévation/azimuth du soleil paramétrables.
+- Placement de probes IBL via outil `ProbeTool` (déjà partiellement existant via `ProbeData`) ; cuisson déclenchée par bouton.
+- Persistance dans `atmosphere.json` (extension v3).
+
+### Hors scope
+- Saisons gameplay (M100.25 : c'est M100.24 qui fournit les données, M100.25 les pilote).
+
+## Spécification fonctionnelle
+
+```
+[Sun & Sky]
+  Day-of-year (1..360) :  120
+  Time-of-day (0..24)  :  14.5
+
+  Sun azimuth          :  168°
+  Sun elevation        :  62°  (calculé auto à partir de ToD/ToY, override possible)
+
+  Sun color            :  (1.0, 0.95, 0.88)
+  Sun intensity (lux)  :  90 000
+
+  Ambient color        :  (0.55, 0.62, 0.72)
+  Ambient intensity    :  3 200
+
+  [Curve editor : ToD × ToY (4 columns: Spring, Summer, Autumn, Winter, 24 rows)]
+
+[Probes]
+  Active probes (count) : 12
+  [Place probe]   [Bake all]   [Show probes overlay]
+```
+
+## Spécification technique
+
+### Schéma `atmosphere.json` v3
+
+```json
+{
+  "version": 3,
+  "distanceFog": { ... },
+  "heightFog": { ... },
+  "volumes": [ ... ],
+  "sun": {
+    "tod_toy_curves": {
+      "rows": 24,
+      "columns": 4,
+      "samples": [
+        { "azimuth": 90, "elevation": 0, "sunColor": [1, 0.4, 0.2], "sunLux": 0,
+          "ambient": [0.05, 0.06, 0.10], "ambientLux": 200 },
+        /* 96 entries total (24 ToD × 4 saisons) */
+      ]
+    }
+  }
+}
+```
+
+### Constantes
+
+```cpp
+constexpr uint32_t kAtmosphereJsonVersion = 3u;
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/atmosphere/SunCurve.h/.cpp` | Lit la matrice 24×4, interpole pour `(tod, toy, season)`. |
+| `engine/editor/world/SunSkyPanel.h/.cpp` | UI courbe + sliders. |
+| `engine/editor/world/ProbeBakeTrigger.h/.cpp` | Bouton "Bake all". |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/AtmosphereSettings.h/.cpp` | Charge la courbe v3. |
+| `engine/render/DayNightCycle.cpp` | Évalue couleur/intensité depuis `SunCurve` + ToD courant. |
+| `engine/world/ProbeData.h/.cpp` | (rien) |
+| `engine/editor/world/panels/AtmospherePanel.cpp` | Inclut `SunSkyPanel`. |
+
+### Parité éditeur ↔ client
+
+Le client lit la même `atmosphere.json` v3. Migration v2 → v3 fournie
+(remplit la matrice par défaut si absente).
+
+### Réseau
+
+Aucun (M100.25 ajoutera le broadcast saison ; pas dans ce ticket).
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/render/DayNightCycle.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/render/DayNightCycle.cpp
+    engine/world/atmosphere/SunCurve.cpp
+    engine/editor/world/SunSkyPanel.cpp
+    engine/editor/world/ProbeBakeTrigger.cpp
+    ...
+)
+
+add_executable(sun_curve_tests engine/world/atmosphere/tests/SunCurveTests.cpp)
+target_link_libraries(sun_curve_tests PRIVATE engine_core)
+add_test(NAME sun_curve_tests COMMAND sun_curve_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Sun & Sky] slider ToD = 14.5 → DayNightCycle évalue couleur/intensité interpolées
+[Curve editor] click sur cellule (ToD=14, season=Summer) → édite couleur sun
+[Probes] Bake all → cuisson IBL déclenchée
+Save → atmosphere.json v3 écrit
+```
+
+## Critères d'acceptation
+
+- [ ] Le panneau ToD × ToY édite 96 cellules (24 × 4) sans crash.
+- [ ] L'interpolation entre ToD voisins et entre saisons est lisse.
+- [ ] La migration `atmosphere.json` v2 → v3 ne perd pas les paramètres existants.
+- [ ] Les probes existantes peuvent être cuites depuis le bouton.
+- [ ] `DayNightCycle` consomme correctement la courbe éditée.
+- [ ] Round-trip `atmosphere.json` v3 parfait.
+
+## Tests
+
+- `Test_SunCurve_Interpolation`.
+- `Test_AtmosphereJson_V2ToV3Migration`.
+- `Test_DayNightCycle_UsesCurve`.
+
+## Hors scope explicite
+
+- Pas de simulation astronomique précise (équinoxes, etc.).
+- Pas de cuisson volumétrique de probes (futur).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.24-SunSkyAndProbesEditor.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.25-SeasonSystemAndTimeOfYear.md
+++ b/tickets/M100/M100.25-SeasonSystemAndTimeOfYear.md
@@ -1,0 +1,205 @@
+# M100.25 — Season System & Time-of-Year
+
+## Résumé
+
+Service `SeasonClock` côté client qui pilote la saison courante en fonction
+d'une horloge in-game (par défaut 7 jours réels = 1 saison). Transition
+interpolée sur les 2 derniers jours in-game. Variantes saisonnières d'assets
+ou paramètres saisonniers. Slider de preview dans l'éditeur. **Broadcast
+serveur périodique** du `Season` courant (relais simple) pour synchroniser
+tous les clients.
+
+## Dépendances
+
+- **M100.24** — Sun, Sky & Probes Editor.
+
+## Portée
+
+### Inclus
+- Enum `Season` (Spring, Summer, Autumn, Winter).
+- Service client `SeasonClock` : maintient `(seasonCurrent, seasonNext, blendT)`.
+- Variantes saisonnières d'assets : la `FoliageLibrary` accepte un sub-asset par saison ou un coefficient de teinte.
+- Slider "Preview Season" dans le panneau Atmosphere.
+- **Protocole `SeasonBroadcast`** : opcode à allouer côté master (cf. `engine/network/ProtocolV1Constants.h`), envoyé toutes les 60 s par le master, broadcast à tous les clients d'une zone. Le serveur **ne calcule rien** : il a un `Season` et une horloge maintenue purement par compteur (le ticket fournit un script d'admin pour la fixer).
+
+### Hors scope
+- Météo (M100.26).
+- Thermal (M100.27).
+- Effets gameplay des saisons sur les surfaces (vue par M100.26 via `SurfaceModifiers`).
+
+## Spécification fonctionnelle
+
+### Panneau preview
+
+```
+[Atmosphere → Season]
+  Current season    : Summer
+  Day in season     : 4 / 7
+  Blend to next     : 0.0 (Autumn)
+  [Slider preview]  Spring ─●── Summer ─── Autumn ─── Winter
+```
+
+### Variantes saisonnières d'assets
+
+`library.json` étendu :
+```json
+{ "id": "tree_oak_01", "category": "tree_oak", "mesh": "veg/tree_oak_01.glb",
+  "seasonalTints": {
+    "Spring": [0.6, 0.85, 0.4],
+    "Summer": [0.45, 0.70, 0.25],
+    "Autumn": [0.85, 0.55, 0.15],
+    "Winter": [0.50, 0.45, 0.40]
+  }
+}
+```
+
+Le shader foliage applique un tint multiplicatif lerpé entre `seasonCurrent`
+et `seasonNext` selon `blendT`.
+
+## Spécification technique
+
+### Enum
+
+```cpp
+namespace engine::world::season
+{
+	enum class Season : uint8_t { Spring = 0, Summer = 1, Autumn = 2, Winter = 3 };
+}
+```
+
+### Service
+
+```cpp
+class SeasonClock
+{
+public:
+	void Configure(double secondsPerSeason);  // par défaut 7 jours réels
+	void Update(double dtSeconds);
+	void OverridePreview(Season s, float blendT);  // depuis l'éditeur
+	void OnNetworkBroadcast(Season s, double serverElapsedInSeasonSec);  // relais master
+
+	Season Current() const;
+	Season Next() const;
+	float  BlendT() const;       // 0..1 ; 1 = transition complète vers Next
+};
+```
+
+La transition est active sur les 2 derniers jours in-game : `blendT = clamp((dayInSeason - 5) / 2, 0, 1)` (avec 7 jours par saison).
+
+### Protocole `SeasonBroadcast`
+
+```
+Master → tous clients de la zone (UDP gameplay)
+Opcode  : <à allouer dans ProtocolV1Constants.h, M100.25>
+Payload : uint8 season, uint64 serverElapsedInSeasonSec
+Period  : 60 s
+```
+
+**Côté serveur** : un compteur en RAM (incrementé à chaque tick) avec un
+seuil = `secondsPerSeason`. Au franchissement, `season = (season + 1) % 4`,
+broadcast immédiat. Pas de DB.
+
+**Côté client** : `SeasonClock::OnNetworkBroadcast` recale l'horloge locale
+sur le serveur. Si latence < 1 s, pas de visible jump.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/season/Season.h` | Enum + helpers. |
+| `engine/world/season/SeasonClock.h/.cpp` | Service client. |
+| `engine/network/SeasonBroadcastPayloads.h/.cpp` | Sérialisation paquet. |
+| `engine/server/SeasonBroadcaster.h/.cpp` | Relais master (compteur + broadcast). |
+| `engine/world/season/tests/SeasonClockTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/network/ProtocolV1Constants.h` | Ajouter `kOpSeasonBroadcast` (opcode). |
+| `engine/render/shaders/foliage.vert` (ou `.frag`) | Apply tint saisonnier. |
+| `engine/editor/world/panels/AtmospherePanel.cpp` | Slider preview. |
+| `engine/server/MasterServer.cpp` | Démarre `SeasonBroadcaster` au boot. |
+
+### Parité éditeur ↔ client
+
+Le client en jeu normal applique la même fonction `Tint(season, blendT)` que
+le mode preview de l'éditeur.
+
+### Anti-duplication serveur
+
+`SeasonBroadcaster.cpp` est dans `engine_core_server` (rôle relais simple).
+Pas de logique d'effet (modificateurs surfaces) côté serveur.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+target_link_libraries(server_app PRIVATE engine_core_server)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/season/SeasonClock.cpp
+    engine/network/SeasonBroadcastPayloads.cpp
+    ...
+)
+
+add_library(engine_core_server STATIC
+    ...
+    engine/server/SeasonBroadcaster.cpp
+    engine/network/SeasonBroadcastPayloads.cpp
+    ...
+)
+
+target_link_libraries(server_app PRIVATE engine_core_server)
+
+add_executable(season_clock_tests engine/world/season/tests/SeasonClockTests.cpp)
+target_link_libraries(season_clock_tests PRIVATE engine_core)
+add_test(NAME season_clock_tests COMMAND season_clock_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Editor] slider Preview Season → SeasonClock.OverridePreview → variantes appliquées immédiatement
+[Game]  Master broadcast Season=Autumn, blendT=0.4 → tous clients alignés visuellement
+```
+
+## Critères d'acceptation
+
+- [ ] La saison cycle Spring→Summer→Autumn→Winter→Spring sur la durée configurée.
+- [ ] La transition est lissée sur les 2 derniers jours in-game.
+- [ ] L'éditeur peut prévisualiser n'importe quelle saison sans modifier le serveur.
+- [ ] Le master broadcaste `SeasonBroadcast` toutes les 60 s.
+- [ ] À la connexion d'un nouveau client, il reçoit immédiatement le `SeasonBroadcast` courant.
+- [ ] Le serveur ne calcule **aucun** modificateur de surface (vérifié par grep : `engine/server/` ne référence pas `SurfaceModifiers`).
+- [ ] Tests passent.
+
+## Tests
+
+- `Test_SeasonClock_CyclesAcross4Seasons`.
+- `Test_SeasonClock_BlendTAtTransitionWindow`.
+- `Test_SeasonBroadcast_Roundtrip`.
+- `Test_Editor_PreviewOverrideVisible`.
+- `Test_Server_NoSurfaceModifierLogic`.
+
+## Hors scope explicite
+
+- Pas de cycles annuels longs (>360 jours).
+- Pas de météo / thermal (M100.26, M100.27).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.25-SeasonSystemAndTimeOfYear.html`
+
+## Déploiement
+
+> **Déploiement** : ⚠️ **redéploiement serveur (master) requis** — nouveau
+> opcode `kOpSeasonBroadcast` et nouveau composant `SeasonBroadcaster`. Côté
+> client/éditeur, livraison en lock-step.

--- a/tickets/M100/M100.26-WeatherSystemAndDynamicSurfaceModifiers.md
+++ b/tickets/M100/M100.26-WeatherSystemAndDynamicSurfaceModifiers.md
@@ -1,0 +1,243 @@
+# M100.26 — Weather System & Dynamic Surface Modifiers
+
+## Résumé
+
+Système global `WeatherSystem` côté client : Clear, Rain, Storm, Snow,
+Drought, Fog. Particules, audio, modifications du fog, et application des
+`SurfaceModifiers` (pluie → Rock=Slippery, Dirt=Wet, Snow=Slush, etc.).
+Édition : panneau "Weather Preview" + "Weather Timeline" éditable par
+scénario. **Broadcast réseau du `WeatherType` courant** (relais simple).
+
+## Dépendances
+
+- **M100.11** — SurfaceQuery service.
+- **M100.25** — Season System.
+
+## Portée
+
+### Inclus
+- Enum `WeatherType` (Clear, Rain, Storm, Snow, Drought, Fog).
+- Service client `WeatherSystem` qui maintient `(currentType, nextType, blendT)`.
+- Particules (rain drops, snow flakes, dust) via le système particules existant (M43.2).
+- Audio loops (déclenchements via le système audio existant).
+- Override fog : densité du distance fog augmente sous Fog/Storm.
+- Application des `SurfaceModifiers` à `SurfaceQueryService` à partir de `weather_modifiers.json`.
+- Panneau Weather Preview (slider type + blendT).
+- Panneau Weather Timeline éditeur : courbe `(jour-de-l'année, heure, weather, probability)`.
+- **Protocole `WeatherBroadcast`** : opcode dédié, broadcast périodique 30 s.
+
+### Hors scope
+- Foudre interactive (futur).
+- Inondations (futur).
+- Hazards de météo (chute d'arbre par tempête).
+
+## Spécification fonctionnelle
+
+### Panneau Weather Preview
+
+```
+[Weather Preview]
+  Current  : Rain
+  Blend to : Storm   (blendT = 0.3)
+
+  [Slider]  Clear ─ Rain ─●─ Storm ─ Snow ─ Drought ─ Fog
+  [Apply preview]    [Reset to live]
+```
+
+### Weather Timeline
+
+```
+[Weather Timeline]
+  Scenario  [combo: "default" ▼  + New / Delete]
+  Probabilities (per season):
+
+       Clear  Rain  Storm  Snow  Drought  Fog
+Spring   55%   25%    8%     0%     2%   10%
+Summer   70%    8%   10%     0%    10%    2%
+Autumn   45%   28%   12%     0%     2%   13%
+Winter   30%    8%   12%    35%     0%   15%
+```
+
+### `weather_modifiers.json`
+
+```json
+{
+  "version": 1,
+  "modifiers": {
+    "Rain": {
+      "Rock":   { "slippery": true,  "wet": true,  "speedMultiplier": 1.0 },
+      "Dirt":   { "wet": true,  "speedMultiplier": 0.85 },
+      "Snow":   { "wet": true,  "speedMultiplier": 0.55, "audioPitchShift": 0.95 }
+    },
+    "Drought": {
+      "Mud":    { "speedMultiplier": 1.45 }
+    },
+    "Snow": {
+      "Outdoor": { "seasonalSnow": true, "speedMultiplier": 0.6 }
+    }
+  }
+}
+```
+
+`Outdoor` est un alias couvrant Dirt, Grass, Rock, Sand sous tempête de
+neige (override le SurfaceType retourné en `Snow` côté query).
+
+## Spécification technique
+
+### Enum
+
+```cpp
+enum class WeatherType : uint8_t { Clear, Rain, Storm, Snow, Drought, Fog };
+```
+
+### Service
+
+```cpp
+class WeatherSystem
+{
+public:
+	bool Init(const std::string& modifiersJsonPath);
+	void Update(double dt);
+	void OverridePreview(WeatherType t, float blend);
+	void OnNetworkBroadcast(WeatherType t, float blend, double serverTime);
+
+	WeatherType Current() const;
+	WeatherType Next() const;
+	float       BlendT() const;
+
+	/// Calcule les modifiers à appliquer pour un SurfaceType donné.
+	SurfaceModifiers ComputeModifiers(SurfaceType base) const;
+};
+```
+
+### Connexion à `SurfaceQueryService`
+
+```cpp
+SurfaceQueryResult SurfaceQueryService::Query(Vec3 pos)
+{
+    auto base = QueryFromSplat(pos);
+    base = WaterOverride(pos, base);                // M100.15
+    base.modifiers = m_weather->ComputeModifiers(base.base);
+    return base;
+}
+```
+
+### Protocole `WeatherBroadcast`
+
+```
+Master → tous clients (UDP gameplay)
+Opcode  : kOpWeatherBroadcast (à allouer)
+Payload : uint8 type, float blendT, uint64 serverTimeMs
+Period  : 30 s
+```
+
+Le serveur **ne décide pas** de la météo. Le master maintient un tirage
+aléatoire pondéré par la table de probabilités courante (saison courante)
+toutes les 5 minutes ; il broadcast à 30 s. Aucune simulation client ;
+seulement un tirage simple `roll * probsTable[season]`.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/weather/WeatherType.h` | Enum + helpers. |
+| `engine/world/weather/WeatherSystem.h/.cpp` | Service client. |
+| `engine/world/weather/WeatherModifiers.h/.cpp` | Loader JSON + ComputeModifiers. |
+| `engine/network/WeatherBroadcastPayloads.h/.cpp` | Sérialisation. |
+| `engine/server/WeatherBroadcaster.h/.cpp` | Relais master + tirage. |
+| `engine/editor/world/panels/WeatherPanel.h/.cpp` | UI Preview + Timeline. |
+| `engine/world/weather/tests/WeatherTests.cpp` | Tests. |
+| `assets/gameplay/weather_modifiers.json` | Table modifiers. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/network/ProtocolV1Constants.h` | Ajouter `kOpWeatherBroadcast`. |
+| `engine/world/surface/SurfaceQueryService.cpp` | Branche `WeatherSystem`. |
+| `engine/render/VolumetricFogPass.cpp` | Override densité sous Fog/Storm (multiplicateur lerpé). |
+| `engine/server/MasterServer.cpp` | Démarre `WeatherBroadcaster`. |
+
+### Parité éditeur ↔ client
+
+Le panneau Weather Preview utilise exactement le même code que le client :
+`WeatherSystem::OverridePreview` court-circuite le réseau, mais l'effet est
+généré par le même chemin. Aucune branche éditeur dans `ComputeModifiers`.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/surface/SurfaceQueryService.cpp
+    ...
+)
+add_library(engine_core_server STATIC ... )
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/surface/SurfaceQueryService.cpp
+    engine/world/weather/WeatherSystem.cpp
+    engine/world/weather/WeatherModifiers.cpp
+    engine/network/WeatherBroadcastPayloads.cpp
+    engine/editor/world/panels/WeatherPanel.cpp
+    ...
+)
+
+add_library(engine_core_server STATIC
+    ...
+    engine/server/WeatherBroadcaster.cpp
+    engine/network/WeatherBroadcastPayloads.cpp
+    ...
+)
+
+add_executable(weather_tests engine/world/weather/tests/WeatherTests.cpp)
+target_link_libraries(weather_tests PRIVATE engine_core)
+add_test(NAME weather_tests COMMAND weather_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Editor] Weather Preview slider → effets immédiats côté client (particules, modifiers)
+[Game]   Master tire (5 min) Storm + 0.0 → broadcast 30s → tous clients à Storm
+[Joueur sur rock pendant Rain] → SurfaceQuery retourne Rock + slippery=true
+```
+
+## Critères d'acceptation
+
+- [ ] Les 6 types météo s'appliquent correctement (visuels + audio).
+- [ ] `weather_modifiers.json` charge sans erreur et produit les bons modifiers.
+- [ ] Sous Rain, marcher sur Rock retourne `slippery=true`.
+- [ ] Sous Snow tempête, marcher sur Dirt en extérieur retourne `seasonalSnow=true` et SurfaceType=Snow.
+- [ ] Le master broadcaste `WeatherBroadcast` toutes les 30 s.
+- [ ] Le serveur ne contient aucun calcul de modifiers (uniquement le tirage).
+- [ ] Round-trip `WeatherBroadcast` parfait.
+- [ ] Tests passent.
+
+## Tests
+
+- `Test_WeatherSystem_AppliesModifiersUnderRain`.
+- `Test_WeatherSystem_SnowOverridesOutdoorSurface`.
+- `Test_WeatherBroadcast_Roundtrip`.
+- `Test_Server_NoModifierComputation`.
+- `Test_FogPass_DensityIncreasesUnderStorm`.
+
+## Hors scope explicite
+
+- Pas de "weather effect on plants" (pas de plante qui se ferme sous la pluie).
+- Pas de transitions inter-zones complexes (chevauchement zones météo géré par M100.28).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.26-WeatherSystemAndDynamicSurfaceModifiers.html`
+
+## Déploiement
+
+> **Déploiement** : ⚠️ **redéploiement serveur (master) requis** — nouveau
+> opcode `kOpWeatherBroadcast` et composant `WeatherBroadcaster`. À déployer
+> en lock-step avec le client.

--- a/tickets/M100/M100.27-ShadeMapAndThermalMap.md
+++ b/tickets/M100/M100.27-ShadeMapAndThermalMap.md
@@ -1,0 +1,212 @@
+# M100.27 — Shade Map & Thermal Map (`ThermalQuery`)
+
+## Résumé
+
+**Shade map** par chunk (couvert arboré, calculée à l'export depuis l'éditeur).
+**Thermal map** dynamique côté client (recalculée à chaque changement saison
+ou météo). Service `ThermalQuery(pos)` retournant la température en °C.
+Panneau "Thermal Debug" overlay heatmap pour visualisation éditeur.
+
+## Dépendances
+
+- **M100.18** — Vegetation Library & Density Painting (canopée).
+- **M100.25** — Season System.
+- **M100.26** — Weather System.
+
+## Portée
+
+### Inclus
+- Shade map binaire `chunks/chunk_i_j/shade.bin` (résolution 64×64 par chunk, R8).
+- Calcul shade map à l'export par raycast vertical depuis chaque cellule (échantillonne la canopée arborée).
+- Thermal map RAM côté client, recalculée à la transition saison ou météo.
+- Service `ThermalQuery(pos)` côté client.
+- Panneau "Thermal Debug" : heatmap overlay sur le viewport éditeur, slider de saison/météo.
+
+### Hors scope
+- HUD joueur runtime (température affichée en jeu : ticket gameplay futur).
+- Effets stamina/hypothermie (gameplay futur).
+
+## Spécification fonctionnelle
+
+### Panneau Thermal Debug
+
+```
+[Thermal Debug]
+  Display      [✓] Heatmap overlay
+  Time of day      14.0
+  Season           [combo: Summer ▼]
+  Weather          [combo: Clear ▼]
+
+  Sample at cursor : 28.4 °C
+  Min/Max          : 12.1 °C / 32.8 °C
+```
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kShadeMapMagic = 0x44484153u; // "SHAD"
+constexpr uint32_t kShadeMapVersion = 1u;
+constexpr uint32_t kShadeMapResolution = 64;     // par chunk (256m → ~4 m / cellule)
+```
+
+### Layout `chunks/chunk_i_j/shade.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 resolution (=64)
+[28..N]   uint8[resolution * resolution]  shadeCoverage 0..255 (255 = canopée pleine)
+```
+
+`N = 28 + 64 * 64 = 4 124 octets`.
+
+### Calcul shade map (export éditeur)
+
+Pour chaque cellule (4 m × 4 m) :
+```cpp
+int hits = 0;
+for (sample in 16 samples):
+    Vec3 origin = cellCenter + jitterXZ;
+    origin.y = terrain.SampleHeight(origin.xz);
+    if (raycastUp(origin, 30.0f).hits)
+        hits++;
+shade = uint8(hits * 16);  // 0..255
+```
+
+`raycastUp` teste contre les capsules/triangles des arbres (proxies M100.12)
+seulement, pas l'herbe. Délégué à un worker (calcul long).
+
+### Thermal map (RAM client)
+
+```cpp
+struct ThermalContext { Season s; WeatherType w; float todHours; };
+struct ThermalCell { float celsius; };
+
+class ThermalMap
+{
+public:
+	void RebuildForChunk(GlobalChunkCoord, const TerrainChunk&, const ShadeMap&, const ThermalContext&);
+	float Sample(Vec3 worldPos) const;
+};
+
+float ComputeTemperature(const ThermalContext& ctx, float altitudeM, float shade01,
+                         float distanceToWaterM)
+{
+	float base = SeasonBaseTemp(ctx.s);            // ex Summer = 22°C
+	float diurnal = -8 * cos((ctx.todHours - 14) / 24 * 6.28); // pic 14h, creux 4h
+	float altGrad = -altitudeM * 0.0065f;          // -6.5°C/1000m
+	float canopy  = lerp(0.0f, IsSummer(ctx.s) ? -8.0f : +3.0f, shade01);
+	float weather = WeatherDelta(ctx.w);            // Rain -3, Snow -5, Drought +2
+	float water   = (distanceToWaterM < 30.0f) ? -1.0f : 0.0f;
+	return base + diurnal + altGrad + canopy + weather + water;
+}
+```
+
+### Service `ThermalQuery`
+
+```cpp
+class ThermalQueryService
+{
+public:
+	bool Init(...);                               // charge ShadeMaps streaming
+	void OnSeasonChanged(Season s);
+	void OnWeatherChanged(WeatherType w);
+	float Query(Vec3 worldPos) const;             // retourne °C
+};
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/thermal/ShadeMap.h/.cpp` | Sérialisation shade. |
+| `engine/world/thermal/ShadeMapBuilder.h/.cpp` | Calcul shade à l'export. |
+| `engine/world/thermal/ThermalMap.h/.cpp` | RAM dynamic. |
+| `engine/world/thermal/ThermalQueryService.h/.cpp` | Service. |
+| `engine/editor/world/panels/ThermalDebugPanel.h/.cpp` | UI debug. |
+| `engine/world/thermal/tests/ThermalTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/WorldEditorExporter.cpp` (ou équivalent) | Au save zone, déclenche `ShadeMapBuilder` puis écrit `shade.bin`. |
+| `engine/world/StreamCache.cpp` | `LoadShadeMap`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteShadeMap`. |
+
+### Parité éditeur ↔ client
+
+Round-trip `shade.bin`. Le client charge la même map que celle générée à
+l'export. Le calcul de température utilise exactement la même fonction
+`ComputeTemperature` côté éditeur (debug panel) et côté client (gameplay
+runtime).
+
+### Réseau
+
+Aucun trafic propre. Saison et météo proviennent des broadcasts M100.25/26.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/thermal/ShadeMap.cpp
+    engine/world/thermal/ShadeMapBuilder.cpp
+    engine/world/thermal/ThermalMap.cpp
+    engine/world/thermal/ThermalQueryService.cpp
+    engine/editor/world/panels/ThermalDebugPanel.cpp
+    ...
+)
+
+add_executable(thermal_tests engine/world/thermal/tests/ThermalTests.cpp)
+target_link_libraries(thermal_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME thermal_tests COMMAND thermal_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Save zone] → ShadeMapBuilder calcule shade.bin pour chaque chunk (worker)
+[Editor]   Thermal Debug → overlay heatmap visible
+[Client]   au boot, charge shade.bin via StreamCache
+           ThermalQuery utilisé par le HUD futur, par les particules de buée, etc.
+```
+
+## Critères d'acceptation
+
+- [ ] Shade map produite à l'export pour chaque chunk avec arbres : valeur élevée sous canopée dense, ~0 en plaine.
+- [ ] Round-trip `shade.bin` parfait.
+- [ ] `ComputeTemperature` retourne des valeurs cohérentes par cas de référence (test table).
+- [ ] À la transition saison ou météo, la thermal map est rebuild dans la frame.
+- [ ] Le panneau Thermal Debug overlay heatmap est visible.
+- [ ] Aucune simulation thermal côté serveur (vérifié).
+
+## Tests
+
+- `Test_ShadeMap_Roundtrip`.
+- `Test_ShadeMapBuilder_DenseCanopy_HighShade`.
+- `Test_ComputeTemperature_SummerNoonOpenAt0m_Is22Plus8`.
+- `Test_ComputeTemperature_WinterNightDenseAt500m_Is_neg5`.
+- `Test_ThermalQuery_OnSeasonChange_RebuildsMap`.
+
+## Hors scope explicite
+
+- Pas de simulation atmosphérique avancée.
+- Pas de gradient inversé (inversions de température).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.27-ShadeMapAndThermalMap.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.28-GameplayZonesAndWeatherZones.md
+++ b/tickets/M100/M100.28-GameplayZonesAndWeatherZones.md
@@ -1,0 +1,166 @@
+# M100.28 — Gameplay Zones & Weather Zones
+
+## Résumé
+
+Zones polygonales typées : Safe Zone, PvP Zone, Raid Zone, NoBuild Zone,
+Quest Trigger Zone, Weather Override Zone. Sérialisation dans
+`instances/zones.bin` versionné. Une zone Weather Override force localement
+un `WeatherType` (avec blendT), surchargeant le broadcast global pour les
+clients dedans.
+
+## Dépendances
+
+- **M100.26** — Weather System.
+
+## Portée
+
+### Inclus
+- Outil `ZoneTool` polygonal multi-types.
+- Format `instances/zones.bin` versionné.
+- Hook côté client : `WeatherSystem` consomme l'override quand le joueur entre dans une Weather Zone.
+- UI : panneau "Zones" listant les zones de la zone éditée, type + couleur d'overlay.
+
+### Hors scope
+- Logique de combat PvP/raid (autre système).
+- Quêtes (M43.3 — déjà existant).
+
+## Spécification fonctionnelle
+
+### Zone Tool
+
+```
+Type      [combo: SafeZone | PvPZone | RaidZone | NoBuild | QuestTrigger | WeatherOverride ▼]
+Name      [string]
+Polygon   [click points, double-click to close]
+
+If type == WeatherOverride:
+  Override weather  [combo: Rain ▼]
+  BlendT            |■■■■□□□□□□|  0.4
+  Transition margin (m)  5.0
+
+[Apply]
+```
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kZonesMagic = 0x534E4F5Au; // "ZONS"
+constexpr uint32_t kZonesVersion = 1u;
+
+enum class ZoneType : uint32_t {
+    SafeZone = 0,
+    PvPZone = 1,
+    RaidZone = 2,
+    NoBuild = 3,
+    QuestTrigger = 4,
+    WeatherOverride = 5
+};
+```
+
+### Layout `instances/zones.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 zoneCount
+For each zone:
+  [4]   uint32 type
+  [4]   uint32 nameLen
+  [N]   char[] name
+  [4]   uint32 vertexCount
+  [12*N] float[3] polygon
+  [4]   float transitionMarginMeters    (utilisé par WeatherOverride)
+  [4]   uint32 weatherType              (utilisé par WeatherOverride)
+  [4]   float weatherBlendT             (utilisé par WeatherOverride)
+  [4]   uint32 questId                  (utilisé par QuestTrigger)
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/zones/Zones.h/.cpp` | Sérialisation. |
+| `engine/editor/world/ZoneTool.h/.cpp` | Outil. |
+| `engine/editor/world/panels/ZonesPanel.h/.cpp` | UI liste + couleur d'overlay. |
+| `engine/world/zones/tests/ZonesTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/StreamCache.cpp` | `LoadZones`. |
+| `engine/world/weather/WeatherSystem.cpp` | À chaque frame, cherche si la pos joueur est dans une WeatherOverride et applique. Transition lerpée sur `transitionMarginMeters`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteZones`. |
+
+### Parité éditeur ↔ client
+
+Round-trip parfait. Le client lit la même `zones.bin` que l'éditeur écrit.
+
+### Réseau
+
+Aucun trafic spécifique. Les overrides sont déterministes côté client à
+partir de la position joueur.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/zones/Zones.cpp
+    engine/editor/world/ZoneTool.cpp
+    engine/editor/world/panels/ZonesPanel.cpp
+    ...
+)
+
+add_executable(zones_tests engine/world/zones/tests/ZonesTests.cpp)
+target_link_libraries(zones_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME zones_tests COMMAND zones_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+ZoneTool → polygone fermé, type=WeatherOverride, weather=Rain blendT=0.4
+Save → instances/zones.bin écrit
+
+[Client] joueur entre dans la zone
+  → WeatherSystem détecte override, lerp sur 5 m de bord
+  → Particules pluie apparaissent localement, modifiers Wet/Slippery actifs
+```
+
+## Critères d'acceptation
+
+- [ ] Les 6 types de zone se sérialisent et se relisent identiquement.
+- [ ] Une WeatherOverride dans une scène Clear active correctement la pluie locale.
+- [ ] La transition est lerpée sur le margin défini.
+- [ ] Le panneau Zones affiche les zones avec couleur d'overlay.
+- [ ] Round-trip `zones.bin` parfait.
+
+## Tests
+
+- `Test_Zones_Roundtrip`.
+- `Test_WeatherOverride_TransitionAtBorder`.
+- `Test_QuestTrigger_FieldsPreserved`.
+- `Test_ZonesPanel_LayerVisibility`.
+
+## Hors scope explicite
+
+- Pas d'override de saison local (saison est globale).
+- Pas de zones 3D (uniquement polygones 2D extrudés implicitement).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.28-GameplayZonesAndWeatherZones.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.29-SplineToolAndRoads.md
+++ b/tickets/M100/M100.29-SplineToolAndRoads.md
@@ -1,0 +1,192 @@
+# M100.29 — Spline Tool & Roads
+
+## Résumé
+
+Outil spline 3D générique, utilisé en premier lieu pour les routes : tracé
+suivant la heightmap, gizmo `widthMeters` par point, peinture splat
+automatique sous la route avec tag `SurfaceType::Road`. Sérialisation
+`instances/splines.bin` versionné.
+
+## Dépendances
+
+- **M100.10** — Splat Painting Brushes (peinture sous la route).
+- **M100.17** — Easy Placement Tool (réutilisation des conventions UX).
+
+## Portée
+
+### Inclus
+- Outil `SplineTool` (raccourci **L** — line).
+- Catmull-Rom centripète par défaut, option Bezier.
+- Gizmo width par point (orthogonal local).
+- Auto-fit terrain : XZ posés par l'utilisateur, Y calculé sur la heightmap.
+- Peinture splat live sous la spline pendant l'édition.
+- Tag automatique `SurfaceType::Road` pour les splines de type Road.
+- Format binaire `instances/splines.bin` versionné.
+
+### Hors scope
+- Mesh modulaire de pont (M100.30).
+- Murs (M100.30).
+
+## Spécification fonctionnelle
+
+### Spline Tool
+
+```
+Type      [combo: Road | Path | Wall (M100.30) | River (M100.13) ▼]
+Curve     (•) Catmull-Rom    ( ) Bezier
+Closed    [ ]
+
+Points:
+  [0]  pos (12.0, 4.5, -3.2)   width 6.0 m
+  [1]  pos (24.0, 5.2, -8.1)   width 6.0 m
+  ...
+
+Splat under road
+  Layer  [combo: gravel ▼]   strength 1.0   feather 0.5 m
+
+[Apply]   [Cancel preview]
+```
+
+### Édition
+
+- Click sur le terrain → ajoute un point.
+- Double-click ou Entrée → termine.
+- Sélection point → gizmo translation/rotation.
+- Suppr → supprime le point.
+- Drag du gizmo width orthogonal → ajuste `widthMeters` du point.
+- Preview live de la peinture splat et de la déformation terrain (terrain reste à plat ; juste la peinture).
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+constexpr uint32_t kSplinesMagic = 0x4C50534Eu; // "NSPL"
+constexpr uint32_t kSplinesVersion = 1u;
+
+enum class SplineType : uint32_t { Road = 0, Path = 1, Wall = 2, RiverRef = 3 };
+enum class SplineCurve : uint32_t { CatmullRom = 0, Bezier = 1 };
+```
+
+### Layout `instances/splines.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 splineCount
+
+For each spline:
+  [4]   uint32 type
+  [4]   uint32 curve
+  [4]   uint32 closed
+  [4]   uint32 nodeCount
+  Per node:
+    [12]  float position[3]
+    [4]   float widthMeters
+    [4]   float tangentMagnitude (Bezier only)
+  [4]   uint32 splatLayerIndex     (couche peinte sous Road/Path)
+  [4]   float splatStrength
+  [4]   float splatFeatherMeters
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/SplineTool.h/.cpp` | Outil. |
+| `engine/editor/world/SplineCommand.h/.cpp` | `ICommand`. |
+| `engine/world/spline/SplineInstances.h/.cpp` | Sérialisation. |
+| `engine/world/spline/SplineSampler.h/.cpp` | Évalue spline + tangentes + offsets latéraux. |
+| `engine/world/spline/tests/SplineTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/StreamCache.cpp` | `LoadSplines(zone)`. |
+| `engine/editor/world/TerrainDocument.cpp` | API `PaintSplatAlongSpline(spline, layer, strength, feather)`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteSplines`. |
+
+### Algorithme peinture sous Road
+
+1. Échantillonner la spline tous les 0.5 m.
+2. Pour chaque sample, parcourir les cellules splat dans `±widthMeters/2 ± feather`.
+3. Augmenter le poids de la layer Road, redistribuer les autres pour préserver somme=255.
+4. La cellule au centre reçoit `strength * 255` ; le bord reçoit lerp jusqu'à 0.
+5. À la fin, taguer `SurfaceType::Road` est implicite via la layer (pas de write metadata séparé ; M100.11 lit le SurfaceType depuis la dominante).
+
+### Parité éditeur ↔ client
+
+Round-trip `splines.bin`. Le client charge les splines pour le rendu lisseur
+(pas de logique gameplay nouvelle ; SurfaceQuery passe par la splat-map déjà
+écrite).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/SplineTool.cpp
+    engine/editor/world/SplineCommand.cpp
+    engine/world/spline/SplineInstances.cpp
+    engine/world/spline/SplineSampler.cpp
+    ...
+)
+
+add_executable(spline_tests engine/world/spline/tests/SplineTests.cpp)
+target_link_libraries(spline_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME spline_tests COMMAND spline_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+L → SplineTool
+Click click click ... double-click → spline créée
+Ajuster width par point via gizmo
+Apply → SplineCommand pushé : spline ajoutée + peinture splat
+Save → instances/splines.bin écrit
+[Client] SurfaceQuery sous la route retourne SurfaceType::Road
+```
+
+## Critères d'acceptation
+
+- [ ] La spline suit le terrain (Y calculé par `SampleHeight`).
+- [ ] Le gizmo width par point fonctionne et est persistant.
+- [ ] La peinture splat sous la route préserve l'invariant somme=255.
+- [ ] `SurfaceQuery` au-dessus d'une route retourne `SurfaceType::Road`.
+- [ ] Round-trip `splines.bin` parfait.
+- [ ] Édition après coup possible (sélection point, suppression, ajout).
+
+## Tests
+
+- `Test_Spline_CatmullRom_Continuity`.
+- `Test_Spline_GroundAutoFit`.
+- `Test_PaintAlongSpline_PreservesSum255`.
+- `Test_SurfaceQuery_OverRoad_ReturnsRoad`.
+- `Test_Roundtrip_SplinesBin`.
+
+## Hors scope explicite
+
+- Pas de jonction T entre routes.
+- Pas de signalisation routière (panneaux).
+- Pas de routes pavées vs non pavées (autre layer si besoin).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.29-SplineToolAndRoads.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.3-ZoneBuilderLibraryExtraction.md
+++ b/tickets/M100/M100.3-ZoneBuilderLibraryExtraction.md
@@ -1,0 +1,153 @@
+# M100.3 — Zone Builder Library Extraction
+
+## Résumé
+
+Extrait les écrivains de chunk packages (`tools/zone_builder/ChunkPackageWriter.*`,
+`LayoutImporter.*`, `JsonDocument.*`) dans une bibliothèque statique
+**`zone_builder_lib`** sans Vulkan. L'éditeur (M100.5+) et l'outil offline
+`zone_builder` la consomment en parallèle, garantissant que **les deux écrivent
+exactement le même format binaire**.
+
+## Dépendances
+
+- **M100.1** — World Editor Bootstrap (pour le chemin de sortie éditeur).
+
+## Portée
+
+### Inclus
+- Création du target CMake `zone_builder_lib` (statique, sans Vulkan, sans GLFW).
+- Déplacement de tous les writers et utilitaires partagés dans `tools/zone_builder/lib/`.
+- L'exécutable `zone_builder` (offline) et le futur code éditeur `WorldEditorExporter` linkent tous deux `zone_builder_lib`.
+- Test de comparaison bit-à-bit : un même layout JSON passé deux fois (une fois via le binaire `zone_builder`, une fois via un test qui lie `zone_builder_lib` et appelle directement les writers) produit exactement les mêmes octets.
+
+### Hors scope
+- Aucune nouvelle structure de fichier monde.
+- Aucune nouvelle UI.
+
+## Spécification fonctionnelle
+
+Aucune surface utilisateur.
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `tools/zone_builder/lib/CMakeLists.txt` | Déclaration du target `zone_builder_lib`. |
+| `tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h` | Header public re-exporté. |
+| `tools/zone_builder/lib/Public/zone_builder/LayoutImporter.h` | idem. |
+| `tools/zone_builder/lib/Public/zone_builder/JsonDocument.h` | idem. |
+| `tools/zone_builder/lib/Public/zone_builder/GltfImporter.h` | idem. |
+| `tools/zone_builder/lib/tests/RoundtripTests.cpp` | Test bit-à-bit. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `tools/zone_builder/CMakeLists.txt` | L'exécutable `zone_builder` link `zone_builder_lib` au lieu de compiler directement les `.cpp`. |
+| `tools/zone_builder/main.cpp` | `#include <zone_builder/...>` au lieu de chemins relatifs. |
+| `CMakeLists.txt` (racine) | Ajouter `add_subdirectory(tools/zone_builder/lib)`. |
+
+### Structures
+
+Inchangées (réutilisation stricte des structures existantes : `LayoutDocument`,
+`WriteChunkPackage`, `WriteChunkedZoneOutputs`).
+
+### Format de sérialisation
+
+Inchangé. Magic numbers (`kZoneMetaMagic`, `kChunkMetaMagic`, `kInstancesMagic`)
+et versions (`kZoneMetaVersion`, `kChunkMetaVersion`, `kInstancesVersion`) sont
+réutilisés tels quels via `engine::world::OutputVersion` (qui reste dans
+`engine_core`).
+
+### Dépendances de la bibliothèque
+
+`zone_builder_lib` link **uniquement** :
+- `engine_core` (pour `engine::world::OutputVersion`, `engine::core::Config`).
+- pas de Vulkan, pas de GLFW, pas d'ImGui.
+
+### Parité éditeur ↔ client
+
+Ce ticket est l'**outil** de la parité. Il garantit qu'un même appel à
+`WriteChunkPackage` produit le même fichier qu'on l'invoque depuis l'éditeur ou
+depuis le binaire `zone_builder`.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+# tools/zone_builder/CMakeLists.txt
+add_executable(zone_builder
+    ChunkPackageWriter.cpp
+    GltfImporter.cpp
+    JsonDocument.cpp
+    LayoutImporter.cpp
+    main.cpp
+)
+target_link_libraries(zone_builder PRIVATE engine_core)
+```
+
+### after
+```
+# tools/zone_builder/lib/CMakeLists.txt (nouveau)
+add_library(zone_builder_lib STATIC
+    ChunkPackageWriter.cpp
+    GltfImporter.cpp
+    JsonDocument.cpp
+    LayoutImporter.cpp
+)
+target_include_directories(zone_builder_lib PUBLIC Public)
+target_link_libraries(zone_builder_lib PUBLIC engine_core)
+
+# tools/zone_builder/CMakeLists.txt
+add_executable(zone_builder main.cpp)
+target_link_libraries(zone_builder PRIVATE zone_builder_lib)
+
+# CMakeLists.txt racine — ajouter avant le subdir tools/zone_builder
+add_subdirectory(tools/zone_builder/lib)
+
+# Tests
+add_executable(zone_builder_roundtrip_tests tools/zone_builder/lib/tests/RoundtripTests.cpp)
+target_link_libraries(zone_builder_roundtrip_tests PRIVATE zone_builder_lib)
+add_test(NAME zone_builder_roundtrip_tests COMMAND zone_builder_roundtrip_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+Aucune surface UI.
+
+## Critères d'acceptation
+
+- [ ] Le target `zone_builder_lib` compile en statique, sans Vulkan, sans GLFW.
+- [ ] L'exécutable `zone_builder` continue de produire un zone_0/ identique à la baseline (ancien build comparé via `cmp`).
+- [ ] Un test indépendant linké contre `zone_builder_lib` produit le même output bit-à-bit.
+- [ ] `engine_core` ne dépend pas de `zone_builder_lib` (anti-cycle).
+- [ ] Le serveur (`server_app`) ne link **pas** `zone_builder_lib`.
+- [ ] `grep -RIn "zone_builder_lib" engine/server/` retourne 0 résultat.
+
+## Tests
+
+- `tools/zone_builder/lib/tests/RoundtripTests.cpp` :
+  - `Test_WriteThenReadHeader_RoundtripExact` (header `OutputVersionHeader`).
+  - `Test_WriteChunkPackage_DeterministicBytes` (deux appels successifs avec le même input → même hash).
+  - `Test_LayoutDocument_JsonRoundtrip`.
+- Test d'intégration shell : `scripts/test_zone_builder_baseline.sh` qui compare l'output de `zone_builder` à un baseline versionné.
+
+## Hors scope explicite
+
+- Pas de modification des magic / versions.
+- Pas d'ajout d'écrivains pour heightmap / splat (faits dans M100.5 et M100.9).
+- Pas d'API de lecture côté éditeur (l'éditeur réutilise `engine::world::StreamCache` directement).
+
+## Référence visuelle
+
+Aucune (pas d'UI). Pas de fichier HTML.
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.30-BridgesAndModularWalls.md
+++ b/tickets/M100/M100.30-BridgesAndModularWalls.md
@@ -1,0 +1,190 @@
+# M100.30 — Bridges & Modular Walls
+
+## Résumé
+
+Construction le long d'une spline (M100.29) à partir de kits modulaires.
+**Pont** : segment ignorant le terrain (Y constant ou paramétré), instance
+de mesh modulaire répété, tag `SurfaceType::Bridge` sur la surface
+marchable. **Mur / palissade** : spline 2D + hauteur, instancing modulaire
+avec poteaux, panneaux et coins.
+
+## Dépendances
+
+- **M100.17** — Easy Placement Tool.
+- **M100.29** — Spline Tool & Roads.
+
+## Portée
+
+### Inclus
+- Outil `BridgeTool` (Tools menu) : transforme une spline existante en pont.
+- Outil `WallTool` (Tools menu) : transforme une spline existante en mur, hauteur paramétrable.
+- Kits modulaires : références d'asset par "type de tronçon" (segment droit, arc, coin 90°, poteau, terminaison).
+- Le pont émet une "marchable surface" : un quad par segment avec `SurfaceType::Bridge` baked dans une lookup spéciale (le hook gameplay sait que cette surface est un Bridge).
+- Sérialisation dans le même `instances/splines.bin` (drapeau `kit` ajouté).
+
+### Hors scope
+- Effondrement / dégât.
+- Murs avec portails (les portes sont en M100.32 : on les pose séparément).
+
+## Spécification fonctionnelle
+
+### Bridge Tool
+
+```
+Source spline   [combo: spline_017 ▼]
+Kit             [combo: stone_bridge_kit ▼]
+Segment length  |■■■■■□□□□□|  4.0 m
+Y mode          (•) Constant (waterLevel + 1.0)   ( ) Spline Y
+Width           |■■■■■■□□□□|  6.0 m
+
+[Generate]
+```
+
+### Wall Tool
+
+```
+Source spline   [combo: spline_021 ▼]
+Kit             [combo: palissade_kit ▼]
+Segment length  |■■■□□□□□□□|  2.0 m
+Height          |■■■■□□□□□□|  3.5 m
+Post spacing    |■■■■■□□□□□|  4.0 m
+
+[Generate]
+```
+
+## Spécification technique
+
+### Format
+
+Pas de nouveau fichier ; on **étend** `instances/splines.bin` (M100.29) en
+ajoutant un `bumpVersion` à 2 et un bloc additionnel par spline si elle est
+un Wall ou un Bridge :
+
+```
+... champs M100.29 ...
+[4]   uint32 kitMode (0 = none, 1 = Bridge, 2 = Wall)
+
+If Bridge:
+  [4]  uint32 kitNameHash
+  [4]  float segmentLengthMeters
+  [4]  uint32 yMode (0 = constant, 1 = follow spline)
+  [4]  float yConstant
+  [4]  float widthMeters
+
+If Wall:
+  [4]  uint32 kitNameHash
+  [4]  float segmentLengthMeters
+  [4]  float heightMeters
+  [4]  float postSpacingMeters
+```
+
+`kBuildSplineVersion = 2`. Migration v1 → v2 par défaut `kitMode = 0`.
+
+### Génération d'instances
+
+Au save, ou en preview live :
+1. Échantillonner la spline tous les `segmentLengthMeters`.
+2. Pour chaque sample, instancier le mesh segment principal.
+3. Insérer poteaux tous les `postSpacingMeters` (Wall).
+4. Détecter coins ≥ 70° et substituer par `corner` du kit.
+5. Émettre `BulkPaste` dans `FoliageDocument` ? Non — dans `PropDocument` (M100.17).
+6. Ajouter une "marchable surface" pour Bridge : nouvelle structure `BridgeWalkable { Vec3 a, Vec3 b, float widthM }` pour que `SurfaceQuery` sache.
+
+### Surface lookup pour Bridge
+
+Le `SurfaceQueryService` interroge en plus `m_bridges` : pour chaque pont,
+projeter `pos.xz` sur le segment central, si distance ≤ `widthM/2` et
+`|pos.y - bridgeY| ≤ 0.3 m` → SurfaceType = Bridge.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/BridgeTool.h/.cpp` | Outil. |
+| `engine/editor/world/WallTool.h/.cpp` | Outil. |
+| `engine/world/structures/Kits.h/.cpp` | Lookup kits modulaires. |
+| `engine/world/structures/BridgeSurfaces.h/.cpp` | `BridgeWalkable`. |
+| `engine/world/structures/tests/StructuresTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/spline/SplineInstances.h/.cpp` | Bump version, sérialise extension Bridge/Wall. |
+| `engine/world/surface/SurfaceQueryService.cpp` | Override Bridge. |
+| `engine/world/instances/PropInstances.cpp` | Reçoit les instances générées par BridgeTool/WallTool (paste atomique). |
+
+### Parité éditeur ↔ client
+
+Round-trip splines v2. Hooks gameplay côté client identiques à l'éditeur.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/spline/SplineInstances.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/spline/SplineInstances.cpp
+    engine/editor/world/BridgeTool.cpp
+    engine/editor/world/WallTool.cpp
+    engine/world/structures/Kits.cpp
+    engine/world/structures/BridgeSurfaces.cpp
+    ...
+)
+
+add_executable(structures_tests engine/world/structures/tests/StructuresTests.cpp)
+target_link_libraries(structures_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME structures_tests COMMAND structures_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[BridgeTool] → spline existante + kit stone_bridge → Generate
+  → 50 instances de segment + 4 poteaux placées
+  → BridgeWalkable enregistré
+[Client] joueur traverse le pont → SurfaceQuery retourne Bridge
+```
+
+## Critères d'acceptation
+
+- [ ] La génération de pont produit le bon nombre d'instances pour la longueur.
+- [ ] Les coins de mur ≥ 70° utilisent le mesh `corner`.
+- [ ] `SurfaceQuery` retourne `Bridge` au-dessus de la surface marchable d'un pont.
+- [ ] Migration `splines.bin` v1 → v2 sans perte.
+- [ ] Round-trip v2 parfait.
+
+## Tests
+
+- `Test_Bridge_GeneratesCorrectSegmentCount`.
+- `Test_Wall_PostSpacingApplied`.
+- `Test_Wall_DetectsCornersOver70deg`.
+- `Test_Bridge_SurfaceQueryReturnsBridge`.
+- `Test_SplinesBin_V1ToV2Migration`.
+
+## Hors scope explicite
+
+- Pas de pont suspendu / modulaire sur câbles.
+- Pas de murailles complexes (mâchicoulis, créneaux animés).
+- Pas de génération auto de portails.
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.30-BridgesAndModularWalls.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.31-HamletGenerator.md
+++ b/tickets/M100/M100.31-HamletGenerator.md
@@ -1,0 +1,160 @@
+# M100.31 — Hamlet Generator
+
+## Résumé
+
+Outil **Hamlet Generator** : sème N maisons d'un kit dans une zone polygonale,
+en respectant un placement plausible (espacement min, alignement à une route
+si présente, orientation vers la place centrale ou vers la rue). Utilise
+`PlacementTool` (M100.17) sous le capot pour la pose effective.
+
+## Dépendances
+
+- **M100.17** — Easy Placement Tool.
+
+## Portée
+
+### Inclus
+- Outil `HamletGeneratorTool` (Tools menu).
+- Recette d'hameau : kit (race + biome), N maisons cible, espacement min, distance route, orientation.
+- Bibliothèque de kits par race : Humains, Elfes, Orcs, Nains, Démons, Chevaliers-Dragons, Orkhs, Gobelins.
+- Génération déterministe par seed.
+- Push d'un `HamletCommand` agrégeant toutes les poses (annulable en bloc).
+
+### Hors scope
+- Génération de villes complètes.
+- Génération de routes internes (l'utilisateur trace les routes ensuite si voulu).
+
+## Spécification fonctionnelle
+
+```
+[Hamlet Generator]
+  Kit               [combo: human_village_kit_01 ▼]
+  House count       12
+  Min spacing       8.0 m
+  Snap to road      [✓]
+  Orient toward     (•) Nearest road    ( ) Centroid
+  Seed              42
+  Polygon           [click points, double-click to close]
+
+[Generate]   [Cancel]
+```
+
+### Algorithme
+
+1. Triangulation polygone.
+2. Points candidats : Poisson-disk avec `min_spacing` et seed.
+3. Pour chaque candidat :
+   - Vérifier slope < 15°.
+   - Vérifier altitude bornée.
+   - Si "Snap to road" et une route existe à < 30 m : projeter sur la route, offset de `4.0 m` côté terrain.
+4. Sélectionner les premiers `houseCount` candidats valides.
+5. Pour chaque, instancier mesh aléatoire du kit, orientation selon `Orient toward`.
+6. Push `HamletCommand` (toutes les poses).
+
+## Spécification technique
+
+### Format kit
+
+`assets/structures/kits/<kit_name>.json` :
+```json
+{
+  "race": "Humains",
+  "biome": "plains",
+  "houses": [
+    { "mesh": "structures/human_house_01.glb", "weight": 0.5 },
+    { "mesh": "structures/human_house_02.glb", "weight": 0.3 },
+    { "mesh": "structures/human_house_03.glb", "weight": 0.2 }
+  ],
+  "minSpacingDefault": 8.0,
+  "footprintRadius": 5.0
+}
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/HamletGeneratorTool.h/.cpp` | Outil. |
+| `engine/editor/world/HamletCommand.h/.cpp` | `ICommand` paste atomique. |
+| `engine/world/structures/HamletKitLibrary.h/.cpp` | Charge les kits. |
+| `engine/editor/world/tests/HamletTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+Aucun (utilise `PropInstances`, `PlacementTool` existants).
+
+### Parité éditeur ↔ client
+
+Pas de nouveau format. Les instances vont dans `instances/props.bin` (M100.17).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/PlacementTool.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/PlacementTool.cpp
+    engine/editor/world/HamletGeneratorTool.cpp
+    engine/editor/world/HamletCommand.cpp
+    engine/world/structures/HamletKitLibrary.cpp
+    ...
+)
+
+add_executable(hamlet_tests engine/editor/world/tests/HamletTests.cpp)
+target_link_libraries(hamlet_tests PRIVATE engine_core)
+add_test(NAME hamlet_tests COMMAND hamlet_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Tools] → Hamlet Generator
+Polygon → 4-6 points
+Kit human_village_kit_01, count 12, seed 42, snap road ON
+[Generate] → 12 maisons placées, snappées au sol, orientées vers la route
+Ctrl+Z → tout annulé en un clic
+```
+
+## Critères d'acceptation
+
+- [ ] Génération déterministe avec le même seed.
+- [ ] Espacement minimum respecté entre maisons.
+- [ ] Snap à la route fonctionne quand une route existe à ≤ 30 m.
+- [ ] Toute la génération est une seule entrée d'historique (Ctrl+Z annule en bloc).
+- [ ] Le kit charge correctement les meshes pondérés.
+- [ ] Slope > 15° rejette le candidat.
+
+## Tests
+
+- `Test_Hamlet_DeterministicWithSeed`.
+- `Test_Hamlet_RespectsMinSpacing`.
+- `Test_Hamlet_SnapsToRoadWhenAvailable`.
+- `Test_Hamlet_OneHistoryEntry`.
+- `Test_HamletKit_LoadsHumanKit`.
+
+## Hors scope explicite
+
+- Pas de génération de villes (>50 maisons).
+- Pas de routes internes générées automatiquement.
+- Pas de variations climatiques (igloo / tente du désert) en M100.31 (ajout futur en étendant les kits).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.31-HamletGenerator.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.32-InteractiveProps.md
+++ b/tickets/M100/M100.32-InteractiveProps.md
@@ -1,0 +1,278 @@
+# M100.32 — Interactive Props (Doors, Windows, Trapdoors, Simple Chests)
+
+## Résumé
+
+Périmètre **strictement borné** : porte battante, porte coulissante, fenêtre
+battante, trappe, coffre simple. Aucun autre type. Modèle de données fermé,
+sérialisation `instances/interactives.bin` versionné, animation client locale,
+audio, **protocole `InteractiveStateChange`** relayé par le serveur (pas de
+validation gameplay).
+
+## Dépendances
+
+- **M100.12** — Collision Proxy System (les portes ouvertes/fermées ont des
+  proxies différents).
+- **M100.17** — Easy Placement Tool (workflow de pose).
+
+## Portée
+
+### Inclus
+- Enum `InteractiveType` borné.
+- Struct `InteractivePropInstance` (cf. spec ci-dessous).
+- Format `instances/interactives.bin` versionné.
+- Édition : panneau secondaire qui apparaît si l'asset placé est marqué `interactive` dans la library.
+- Animation client locale (pivot ou translation, durée par anim).
+- Audio open/close.
+- Protocole `InteractiveStateChange` (relais master).
+- À la connexion d'un nouveau client, le serveur lui envoie l'état courant des objets de la zone.
+
+### Hors scope (formellement)
+- Aucune autre interaction (leviers, rouages, mécanismes en chaîne, portes magiques, objets transportables, inventaire dans coffre — un autre milestone gérera l'inventaire).
+- Pas de "scripting" par utilisateur.
+
+## Spécification fonctionnelle
+
+### Asset library
+
+Un asset déclare `interactive: true` dans la library (extension JSON) avec
+les défauts suggérés (pivot local, axe local). À la pose dans `PlacementTool`,
+si l'asset est interactive, un panneau secondaire apparaît :
+
+```
+[Interactive Props]
+  Type        [combo: DoorHinge ▼]
+  Pivot local [-0.40, 0.0, 0.0]
+  Axis local  [0, 1, 0]
+  Open angle  90°
+  Anim duration 0.5 s
+  Initial state  ( ) Closed   (•) Opened (rare)
+  Audio open      [combo: door_creak_open ▼]
+  Audio close     [combo: door_thud_close ▼]
+[Trigger]  ← test live
+```
+
+### Comportement runtime client
+
+- Détection proximité joueur (rayon 2 m).
+- Affichage prompt "Appuyer sur E pour ouvrir/fermer".
+- Sur trigger :
+  1. Animation locale immédiate (durée `animDurationSec`).
+  2. Audio local.
+  3. Envoi `InteractiveStateChange(id, newState)` au serveur.
+- Sur réception du message côté autres clients :
+  - Animation distante avec compensation de latence (commencer la phase d'animation à `now - latency` si l'événement est récent).
+
+## Spécification technique
+
+### Enum & struct (gelé)
+
+```cpp
+namespace engine::world::interactive
+{
+	enum class InteractiveType : uint16_t
+	{
+		DoorHinge = 0,
+		DoorSliding = 1,
+		WindowHinge = 2,
+		Trapdoor = 3,
+		ChestSimple = 4
+		// VOLONTAIREMENT FIGÉ. Tout ajout doit être fait par un futur ticket
+		// dédié, en bumpant kInteractivesVersion.
+	};
+
+	struct InteractivePropInstance
+	{
+		uint64_t id;
+		InteractiveType type;
+		engine::math::Vec3 position;
+		float rotationY;
+		uint32_t meshAssetId;
+		engine::math::Vec3 pivotLocal;
+		engine::math::Vec3 axisLocal;
+		float openAngleDeg;        // ou openTranslation pour DoorSliding
+		float animDurationSec;
+		uint8_t initialState;      // 0 = closed, 1 = opened
+		std::string audioOpenEvent;
+		std::string audioCloseEvent;
+	};
+}
+```
+
+### Constantes
+
+```cpp
+constexpr uint32_t kInteractivesMagic = 0x54434E49u; // "INCT"
+constexpr uint32_t kInteractivesVersion = 1u;
+```
+
+### Layout `instances/interactives.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 instanceCount
+
+For each instance:
+  [8]   uint64 id
+  [4]   uint16 type
+  [12]  float position[3]
+  [4]   float rotationY
+  [4]   uint32 meshAssetId
+  [12]  float pivotLocal[3]
+  [12]  float axisLocal[3]
+  [4]   float openAngleDeg
+  [4]   float animDurationSec
+  [1]   uint8 initialState
+  [4+N] uint32 strLen + audioOpenEvent
+  [4+N] uint32 strLen + audioCloseEvent
+```
+
+### Protocole `InteractiveStateChange`
+
+```
+Client → Master (UDP gameplay)
+Opcode  : kOpInteractiveStateChange  (à allouer)
+Payload : uint64 id, uint8 newState (0/1), uint64 clientTimeMs
+
+Master → all other clients of zone (broadcast)
+Opcode  : kOpInteractiveStateBroadcast
+Payload : uint64 id, uint8 newState, uint64 serverTimeMs
+
+Master → newly connecting client (initial sync)
+Opcode  : kOpInteractiveStateSync
+Payload : uint16 count, then count × { uint64 id, uint8 state }
+```
+
+**Côté master** : maintient une `std::unordered_map<uint64_t, uint8_t>` par
+zone. Reçoit `StateChange`, écrit l'état, broadcast. Aucune validation
+"peut-il ouvrir cette porte ?". Aucun test de portée. Aucun anti-triche.
+**Pas de logique gameplay.**
+
+À la connexion d'un client, le master lui envoie le set complet via
+`StateSync`.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/interactive/InteractiveTypes.h` | Enum + struct (gelé). |
+| `engine/world/interactive/InteractiveInstances.h/.cpp` | Sérialisation. |
+| `engine/world/interactive/InteractiveSimulator.h/.cpp` | Animation locale + prompt. |
+| `engine/network/InteractivePayloads.h/.cpp` | Sérialisation paquets. |
+| `engine/server/InteractiveStateRelay.h/.cpp` | Master relais (map + broadcast + initial sync). |
+| `engine/editor/world/InteractivePanel.h/.cpp` | Panneau secondaire. |
+| `engine/world/interactive/tests/InteractiveTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/network/ProtocolV1Constants.h` | Ajouter `kOpInteractiveStateChange`, `kOpInteractiveStateBroadcast`, `kOpInteractiveStateSync`. |
+| `engine/world/StreamCache.cpp` | `LoadInteractives`. |
+| `engine/server/MasterServer.cpp` | Démarre `InteractiveStateRelay`. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteInteractives`. |
+
+### Anti-duplication serveur
+
+`InteractiveSimulator` (animation, audio, prompt) est **strictement client**.
+`InteractiveStateRelay` est dans `engine_core_server`.
+
+### Parité éditeur ↔ client
+
+Round-trip `interactives.bin`. Le bouton "Trigger" de l'éditeur appelle le
+même `InteractiveSimulator` que le client en jeu (juste sans envoi réseau).
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+add_library(engine_core_server STATIC ... )
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/interactive/InteractiveInstances.cpp
+    engine/world/interactive/InteractiveSimulator.cpp
+    engine/network/InteractivePayloads.cpp
+    engine/editor/world/InteractivePanel.cpp
+    ...
+)
+
+add_library(engine_core_server STATIC
+    ...
+    engine/server/InteractiveStateRelay.cpp
+    engine/network/InteractivePayloads.cpp
+    ...
+)
+
+add_executable(interactive_tests engine/world/interactive/tests/InteractiveTests.cpp)
+target_link_libraries(interactive_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME interactive_tests COMMAND interactive_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Editor] place door asset → InteractivePanel apparaît
+  → configure pivot, axis, angle, audios
+  → Trigger button → joue animation localement
+Save → instances/interactives.bin écrit
+
+[Client A] approche d'une porte → prompt "E"
+  → Press E → animation locale, audio
+  → Envoi kOpInteractiveStateChange(id=42, state=1)
+
+[Master] reçoit, persist en mémoire, broadcast à client B/C/D
+
+[Client B] reçoit kOpInteractiveStateBroadcast
+  → InteractiveSimulator anime la porte chez lui (compensation latence)
+
+[Nouveau client E] connecte → reçoit kOpInteractiveStateSync
+  → toutes les portes en zone sont initialisées au bon state
+```
+
+## Critères d'acceptation
+
+- [ ] L'enum `InteractiveType` contient exactement 5 valeurs et est commenté gelé.
+- [ ] La sérialisation `interactives.bin` est round-trip parfaite.
+- [ ] Le panneau Interactive n'apparaît que pour les assets `interactive: true`.
+- [ ] Le bouton Trigger en éditeur joue la bonne animation.
+- [ ] Animation côté client A immédiate (≤ 1 frame).
+- [ ] Sur réception, client B anime la porte avec compensation de latence visible (la porte ne saute pas sans transition).
+- [ ] À la connexion, un nouveau client reçoit le sync initial et voit toutes les portes au bon état.
+- [ ] Le master ne fait **aucune** validation : un message StateChange pour un id inconnu loggue un warning et est ignoré, sans erreur de protocole.
+- [ ] Aucun autre type d'interaction n'est ajouté (vérifié par grep `InteractiveType::`).
+
+## Tests
+
+- `Test_Interactives_Roundtrip`.
+- `Test_Simulator_AnimatesDoorHinge`.
+- `Test_Simulator_AnimatesSliding`.
+- `Test_Simulator_AnimatesTrapdoor`.
+- `Test_Simulator_AnimatesChest`.
+- `Test_Network_StateChangeRoundtrip`.
+- `Test_Server_NoGameplayValidation`.
+- `Test_Server_InitialSyncOnConnect`.
+- `Test_Client_RemoteAnimationLatencyCompensation`.
+
+## Hors scope explicite (formellement)
+
+- Aucun autre type d'interaction (pas de levier, pas de mécanisme à clés, pas de coffre avec inventaire, pas de portes magiques, pas de portes verrouillées par quête).
+- Pas de validation serveur de la portée joueur ↔ porte.
+- Pas de logique anti-triche.
+- Pas de persistance disque côté serveur (l'état est RAM ; à la coupure du serveur, l'état est perdu et ré-broadcasté à partir de l'`initialState` au prochain démarrage).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.32-InteractiveProps.html`
+
+## Déploiement
+
+> **Déploiement** : ⚠️ **redéploiement serveur (master) requis** — trois
+> nouveaux opcodes (`kOpInteractiveStateChange`, `kOpInteractiveStateBroadcast`,
+> `kOpInteractiveStateSync`) et nouveau composant `InteractiveStateRelay`. À
+> déployer en lock-step avec le client.

--- a/tickets/M100/M100.33-FootstepAudioAndPlaytestMode.md
+++ b/tickets/M100/M100.33-FootstepAudioAndPlaytestMode.md
@@ -1,0 +1,182 @@
+# M100.33 — Footstep Audio Surface Hook & Playtest Mode (F5)
+
+## Résumé
+
+Branche l'audio de pas sur `(SurfaceType, SurfaceModifiers)` (table de
+M100.11 + pitch shift de M100.26). Implémente le **mode Playtest** activé
+par F5 : capsule joueur factice à la position du curseur, simulation
+gameplay complète **utilisant le code client de production**, overlay HUD
+debug (vitesse, surface, modificateurs météo, température, saison).
+
+## Dépendances
+
+- **M100.11** — SurfaceQuery service.
+- **M100.16** — Hazard Volume System.
+- **M100.26** — Weather System & Modifiers.
+- **M100.27** — Thermal Map.
+
+## Portée
+
+### Inclus
+- Hook audio : `CharacterController` consomme `surfaceTable[base].audioStep` et applique `modifiers.audioPitchShift`.
+- Mode Playtest activé par F5 :
+  - Capsule joueur factice (mesh basique fourni par l'éditeur).
+  - Position initiale = position curseur au moment du F5.
+  - WASD pour bouger, espace saute, etc. — utilise `CharacterController` du client.
+  - Caméra change en `ThirdPersonCamera` runtime (le code production).
+  - **Aucune simulation alternative** : le ticket impose explicitement que la simulation utilisée pendant le playtest est strictement celle du client en jeu normal.
+  - F5 à nouveau → quitte le playtest, restaure l'éditeur caméra.
+- Overlay debug visible pendant playtest :
+  ```
+  Speed         : 4.30 m/s
+  Surface       : Grass (modifiers: wet, slippery=false)
+  Temperature   : 18.4 °C
+  Season        : Autumn (blendT 0.0)
+  Weather       : Rain
+  Hazards       : (none)
+  ```
+
+### Hors scope
+- Multijoueur dans le playtest (le playtest est solo, local).
+- Recording / replay.
+
+## Spécification fonctionnelle
+
+### Audio de pas
+
+À chaque "footstep event" du système d'animation existant, le code lit la
+`SurfaceQueryResult` courante :
+- Si `base = ShallowWater` → joue `step_water` avec splash particule.
+- Si `base = Snow` + `wet = true` → joue `step_snow_crunch` avec pitch +5%
+  (modifier sluch).
+
+Le panneau audio (M43.5 — déjà existant) référence ces ids, ce ticket les
+mappe via `surface_table.json`.
+
+### Playtest mode
+
+```
+[F5] → Playtest mode ON
+  Capsule placée au curseur (raycast terrain)
+  Editor camera désactivée, ThirdPersonCamera de prod activée
+  Input gameplay actif (WASD, jump, sprint, action)
+  HUD overlay débogue visible (top-left)
+
+[F5] → Playtest mode OFF
+  Editor camera restaurée, position préservée
+  Capsule joueur supprimée
+```
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/audio/FootstepAudioSurfaceHook.h/.cpp` | Mappe `(SurfaceType, modifiers)` → audio event. |
+| `engine/editor/world/PlaytestMode.h/.cpp` | Gère entrée/sortie playtest. |
+| `engine/editor/world/PlaytestHUDOverlay.h/.cpp` | HUD debug. |
+| `engine/editor/world/tests/PlaytestTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/gameplay/CharacterController.cpp` | Hooks footstep events (déjà existants) → consomme `FootstepAudioSurfaceHook`. |
+| `engine/editor/world/WorldEditorShell.cpp` | Branche F5 sur `PlaytestMode::Toggle`. |
+| `engine/editor/world/EditorCameraController.cpp` | `Suspend()` / `Resume()` quand playtest. |
+
+### Algorithme footstep audio
+
+```cpp
+void FootstepAudioSurfaceHook::OnFootstep(Vec3 footPos)
+{
+    auto sq = m_surfaceQuery->Query(footPos);
+    auto& entry = m_surfaceTable->Get(sq.base);
+    AudioEvent ev;
+    ev.id = entry.audioStep;
+    ev.pitch = sq.modifiers.audioPitchShift;
+    ev.position = footPos;
+    m_audio->PlayOneShot(ev);
+}
+```
+
+### Mode Playtest — anti-duplication
+
+`PlaytestMode` instancie `engine::gameplay::CharacterController` **directement**
+(pas de fork ni de wrapper). C'est le contrat : le playtest ne peut pas
+diverger du jeu normal.
+
+### Parité éditeur ↔ client
+
+Le playtest **est** le client. Aucune divergence possible.
+
+### Réseau
+
+Aucun (playtest solo).
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/audio/FootstepAudioSurfaceHook.cpp
+    engine/editor/world/PlaytestMode.cpp
+    engine/editor/world/PlaytestHUDOverlay.cpp
+    ...
+)
+
+add_executable(playtest_tests engine/editor/world/tests/PlaytestTests.cpp)
+target_link_libraries(playtest_tests PRIVATE engine_core)
+add_test(NAME playtest_tests COMMAND playtest_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+F5 → Playtest mode actif
+  Capsule joueur apparait au curseur
+  Caméra passe à ThirdPersonCamera production
+  Mouvement WASD → CharacterController
+  Footstep events → FootstepAudioSurfaceHook → audio mappé sur surface
+  HUD overlay : speed, surface, temp, season, weather, hazards
+F5 → Playtest mode quitté, retour éditeur caméra
+```
+
+## Critères d'acceptation
+
+- [ ] Marcher sur Grass joue `step_grass` ; sur Snow joue `step_snow_crunch`.
+- [ ] Sous Rain, marcher sur Rock joue le même `step_rock` mais avec une vitesse réduite et `slippery` actif (effet sur la dérive du joueur).
+- [ ] F5 entre/sort du playtest sans crash, en préservant la position éditeur.
+- [ ] Le playtest utilise `engine::gameplay::CharacterController` non modifié (pas de fork).
+- [ ] L'overlay HUD affiche les 6 champs listés.
+- [ ] Tests passent.
+
+## Tests
+
+- `Test_FootstepHook_GrassPlaysStepGrass`.
+- `Test_FootstepHook_RainOnRockPitchShift`.
+- `Test_PlaytestMode_TogglePreservesEditorState`.
+- `Test_PlaytestMode_UsesProductionCharacterController`.
+
+## Hors scope explicite
+
+- Pas de mode "playtest réseau" (ni serveur dédié de test ni spectateur multijoueur).
+- Pas de scénarios scriptés.
+- Pas de spawn d'NPCs depuis le playtest.
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.33-FootstepAudioAndPlaytestMode.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.34-SelectionLayersMinimapSaveLoadZone.md
+++ b/tickets/M100/M100.34-SelectionLayersMinimapSaveLoadZone.md
@@ -1,0 +1,269 @@
+# M100.34 — Selection, Layers, Minimap & Save/Load Zone
+
+## Résumé
+
+Ticket de polissage final : sélection rect/lasso, gestion des calques
+(visibles/masqués/verrouillés), mini-carte 2D, et **export complet de zone
+vers chunk packages versionnés**, incluant **toutes** les données produites
+par les tickets précédents (terrain, splat, props, foliage, hazards,
+interactives, zones, water, fog volumes, atmosphere zones, splines,
+shade map, collision proxies). Test d'export → re-load → comparaison
+complète.
+
+## Dépendances
+
+- **M100.5** — Heightmap.
+- **M100.9** — Splat Map.
+- **M100.16** — Hazard Volume System.
+- **M100.27** — Shade Map.
+- **M100.28** — Gameplay Zones.
+- **M100.32** — Interactive Props.
+
+## Portée
+
+### Inclus
+- Sélection rect : drag rectangle dans le viewport, sélectionne tous les props inscrits.
+- Sélection lasso : drag main levée.
+- Calques (`Layer`) : 16 calques nommés, visibilité + lock + couleur d'overlay. Chaque prop / chaque hazard / chaque zone est assigné à un layer.
+- Mini-carte 2D dans un panneau dédié, vue top-down du chunk courant et voisins.
+- **Export complet de zone** : un bouton "Save Zone" qui passe par `zone_builder_lib` et écrit une arborescence chunk packages complète.
+- Tests round-trip : export → re-import dans un autre `World` → comparaison field-by-field de toutes les structures.
+
+### Hors scope
+- Versioning git du monde (autre système).
+- Export incrémental (ce ticket fait full export).
+
+## Spécification fonctionnelle
+
+### Outliner & Layers
+
+```
+[Outliner]
+  ▼ Layer Default      [👁] [🔒]
+      └── prop rock_01.glb (id=42)
+      └── prop tree_oak (id=43)
+  ▼ Layer Buildings    [👁] [🔒]
+      └── prop house_01.glb (id=51)
+  ▶ Layer Hidden       [ ⊘ ] [🔒]
+```
+
+### Sélection
+
+- Click vide + drag → rectangle.
+- Shift+click vide + drag → lasso.
+- Suppr → supprime sélection (push `DeleteCommand` réversible).
+
+### Mini-map
+
+```
++--------------------------------+
+|     ░ ░ ▓ ▓ ░         (chunks visibles)
+|     ░ █ ░ ░ ░         █ = chunk courant
+|     ░ ░ ░ ▓ ▓
+|       ●                          ● = position joueur ou caméra
++--------------------------------+
+zoom : 1 cell = 1 chunk
+```
+
+### Save Zone
+
+```
+File → Save Zone As...
+  Output dir : build/zone_<name>/
+  [✓] Terrain         (terrain.bin + terrain_lods.bin par chunk)
+  [✓] Splat           (splat.bin par chunk)
+  [✓] Props           (instances/props.bin)
+  [✓] Foliage         (instances/foliage.bin par chunk)
+  [✓] Hazards         (instances/hazards.bin)
+  [✓] Interactives    (instances/interactives.bin)
+  [✓] Zones           (instances/zones.bin)
+  [✓] Water           (instances/water.bin)
+  [✓] Fog volumes     (instances/fog_volumes.bin)
+  [✓] Atmosphere zones (instances/atmosphere_zones.bin)
+  [✓] Splines         (instances/splines.bin)
+  [✓] Shade maps      (chunks/.../shade.bin)
+  [✓] Collision proxies (mesh-side, déjà à côté des assets)
+  [✓] zone.meta + atmosphere.json + probes.bin
+
+  [Save Zone]
+```
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/SelectionTool.h/.cpp` | Rect + lasso. |
+| `engine/editor/world/LayersDocument.h/.cpp` | 16 calques + assignment. |
+| `engine/editor/world/panels/MinimapPanel.h/.cpp` | UI minimap. |
+| `engine/editor/world/WorldEditorExporter.h/.cpp` | Orchestrateur "Save Zone". |
+| `engine/editor/world/DeleteCommand.h/.cpp` | `ICommand`. |
+| `engine/editor/world/tests/ExportZoneTests.cpp` | Round-trip end-to-end. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/OutlinerPanel.cpp` | Affiche calques + assignment. |
+| `engine/world/instances/PropInstances.h` | Ajout d'un champ `layerIndex` (uint8 ; reste compatible v1 via padding). |
+| `engine/world/hazard/HazardVolumes.h` | idem. |
+| `engine/world/zones/Zones.h` | idem. |
+| `engine/editor/world/WorldEditorShell.cpp` | Ajoute `MinimapPanel`, raccourci Suppr. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | API agrégée `WriteFullZone(...)` qui appelle tous les writers. |
+
+### Format
+
+Le ticket bumpe les versions des structures qui acquièrent `layerIndex` ;
+chaque writer fournit sa migration (lecture v1 → fill `layerIndex = 0`).
+
+### Algorithme Save Zone
+
+```cpp
+bool WorldEditorExporter::SaveZone(const std::string& outputDir)
+{
+    Ensure(outputDir);
+    // Master files
+    WriteZoneMeta(outputDir, ...);
+    WriteAtmosphereJson(outputDir, ...);
+    WriteProbes(outputDir, ...);
+
+    // Per-chunk
+    for (chunk in zone.chunks):
+        std::string chunkDir = outputDir + "/chunks/chunk_" + ix + "_" + iz;
+        WriteTerrainChunk(chunkDir, ...);
+        WriteTerrainLods(chunkDir, ...);
+        WriteSplatMap(chunkDir, ...);
+        WriteFoliage(chunkDir, ...);
+        WriteShadeMap(chunkDir, ...);
+
+    // Zone-wide
+    WriteProps(outputDir + "/instances/props.bin", ...);
+    WriteHazards(outputDir + "/instances/hazards.bin", ...);
+    WriteInteractives(outputDir + "/instances/interactives.bin", ...);
+    WriteZones(outputDir + "/instances/zones.bin", ...);
+    WriteWater(outputDir + "/instances/water.bin", ...);
+    WriteFogVolumes(outputDir + "/instances/fog_volumes.bin", ...);
+    WriteAtmosphereZones(outputDir + "/instances/atmosphere_zones.bin", ...);
+    WriteSplines(outputDir + "/instances/splines.bin", ...);
+    WriteWindZones(outputDir + "/instances/wind_zones.bin", ...);
+
+    return true;
+}
+```
+
+### Test de parité round-trip global
+
+```cpp
+TEST(ExportZoneTests, FullRoundtrip)
+{
+    World w1 = MakeSyntheticWorld(seed=42);  // crée 4 chunks avec données complètes
+    Save(w1, tempDir);
+    World w2 = LoadFromDir(tempDir);          // utilise StreamCache + loaders
+    AssertEquals(w1.terrain, w2.terrain);     // par chunk
+    AssertEquals(w1.splat, w2.splat);
+    AssertEquals(w1.props, w2.props);
+    AssertEquals(w1.foliage, w2.foliage);
+    AssertEquals(w1.hazards, w2.hazards);
+    AssertEquals(w1.interactives, w2.interactives);
+    AssertEquals(w1.zones, w2.zones);
+    AssertEquals(w1.water, w2.water);
+    AssertEquals(w1.fogVolumes, w2.fogVolumes);
+    AssertEquals(w1.atmosphereZones, w2.atmosphereZones);
+    AssertEquals(w1.splines, w2.splines);
+    AssertEquals(w1.windZones, w2.windZones);
+    AssertEquals(w1.shadeMaps, w2.shadeMaps);
+}
+```
+
+### Parité éditeur ↔ client
+
+Une zone exportée par l'éditeur est lue par le client en jeu normal sans
+divergence. Le test ci-dessus l'assure structurellement.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/SelectionTool.cpp
+    engine/editor/world/LayersDocument.cpp
+    engine/editor/world/panels/MinimapPanel.cpp
+    engine/editor/world/WorldEditorExporter.cpp
+    engine/editor/world/DeleteCommand.cpp
+    ...
+)
+
+add_executable(export_zone_tests engine/editor/world/tests/ExportZoneTests.cpp)
+target_link_libraries(export_zone_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME export_zone_tests COMMAND export_zone_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Selection rect] drag → 12 props sélectionnés
+Suppr → DeleteCommand pushé, props retirés
+
+[Outliner] Layer Buildings → toggle visibility → tous les props du layer cachés
+[Layer lock] toggle → édition bloquée
+
+[Minimap] zoom × 4 → vue plus large
+
+[File → Save Zone As...] → output dir → arborescence chunk packages écrite
+[Test round-trip] → World exporté → World relu → égalité champ à champ
+```
+
+## Critères d'acceptation
+
+- [ ] Sélection rectangulaire et lasso fonctionnent.
+- [ ] Suppr sur sélection est annulable (Ctrl+Z restaure tout).
+- [ ] Calques : 16 max, toggle visibility et lock fonctionnels.
+- [ ] Minimap affiche les chunks visibles et la position caméra.
+- [ ] **Save Zone** écrit une arborescence chunk packages complète sans erreur.
+- [ ] Le test `export_zone_tests::FullRoundtrip` passe : tous les champs de toutes les structures sont préservés.
+- [ ] Le client (jeu normal) charge la zone exportée et la rend identiquement.
+- [ ] Aucune duplication de code entre éditeur et client (les writers passent par `zone_builder_lib`).
+- [ ] Aucune simulation environnementale ajoutée côté serveur.
+
+## Tests
+
+- `Test_Selection_Rect_SelectsContainedProps`.
+- `Test_Selection_Lasso_SelectsContainedProps`.
+- `Test_Layer_Visibility_HidesPropsInOutliner`.
+- `Test_Layer_Lock_BlocksEdits`.
+- `Test_Minimap_RendersCurrentChunk`.
+- `Test_DeleteCommand_RoundTrip`.
+- `Test_ExportZone_FullRoundtrip` (test d'intégration end-to-end).
+- `Test_ExportZone_ConsumedByClient` (loaders client lisent la sortie sans warning).
+
+## Hors scope explicite
+
+- Pas d'export incrémental.
+- Pas de versioning git intégré.
+- Pas de pré-visualisation de l'export (l'utilisateur lance, attend, re-load).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.34-SelectionLayersMinimapSaveLoadZone.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.
+> Néanmoins, attention : **après merge de M100.32**, la zone exportée par
+> M100.34 inclut `instances/interactives.bin`, dont l'opcode réseau associé
+> (`kOpInteractiveStateChange`) suppose que le serveur (master) a été
+> redéployé en M100.32. Pas de nouveau redéploiement requis ici si M100.32
+> est déjà déployé.

--- a/tickets/M100/M100.4-EditorCameraModes.md
+++ b/tickets/M100/M100.4-EditorCameraModes.md
@@ -1,0 +1,185 @@
+# M100.4 — Editor Camera Modes
+
+## Résumé
+
+Trois modes caméra dans le panneau Scene : FPS (WASD + souris), orbital
+(rotation autour d'un point pivot, molette = zoom), top-down ortho (vue de
+dessus, axes XZ). Toggle par numpad 1/3/7 ou bouton ImGui dans la barre de la
+viewport. La caméra survit au switch de mode (préservation du focus).
+
+## Dépendances
+
+- **M100.1** — World Editor Bootstrap (panneau Scene).
+
+## Portée
+
+### Inclus
+- Classe `engine::editor::world::EditorCameraController`.
+- Trois modes : `FPS`, `Orbital`, `TopDownOrtho`.
+- Switch à chaud avec préservation du point d'intérêt (`m_focusPoint`).
+- Speed multipliers (Shift = ×3, Ctrl = ×0.25).
+- Navigation tactile : Alt+drag = orbit (Maya-style) en mode Orbital.
+- Le mode actif est persisté dans `editor.world.camera.lastMode`.
+
+### Hors scope
+- Caméra runtime gameplay (déjà gérée par `engine::gameplay::ThirdPersonCamera`).
+- Bookmarks de caméra (no-op M100.4, futur).
+
+## Spécification fonctionnelle
+
+| Mode | Touche | Mouvement |
+|------|--------|-----------|
+| FPS | Numpad 1 | WASD horizontal, QE vertical, souris droite = look. |
+| Orbital | Numpad 3 | Alt+gauche = rotate, Alt+milieu = pan, molette = dolly, F = focus sur sélection. |
+| TopDown ortho | Numpad 7 | Pan via flèches ou drag milieu, molette = zoom (variation de l'extent ortho). |
+
+Bouton dans la barre du panneau Scene : `[FPS] [Orbital] [Top]` avec radio actif.
+
+Indicateur HUD coin haut-gauche : `Mode: Orbital | Focus: (12.0, 4.5, -3.2) | Speed: 1.0×`.
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/EditorCameraController.h` | Classe + enum `EditorCameraMode`. |
+| `engine/editor/world/EditorCameraController.cpp` | Implémentation. |
+| `engine/editor/world/tests/EditorCameraControllerTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/ScenePanel.h/.cpp` | Détient un `EditorCameraController`, dispatch input. |
+| `engine/editor/world/WorldEditorShell.cpp` | Branchement des Numpad 1/3/7 dans `HandleShortcut`. |
+| `config.json` | Ajouter `editor.world.camera.lastMode` (string), `editor.world.camera.fpsSpeed` (m/s). |
+
+### Structures
+
+```cpp
+namespace engine::editor::world
+{
+	enum class EditorCameraMode : uint8_t { FPS = 0, Orbital = 1, TopDownOrtho = 2 };
+
+	struct EditorCameraConfig
+	{
+		float fpsSpeedMps = 8.0f;
+		float orbitalDistanceMin = 0.5f;
+		float orbitalDistanceMax = 5000.0f;
+		float topDownExtentMin = 5.0f;
+		float topDownExtentMax = 5000.0f;
+	};
+
+	class EditorCameraController
+	{
+	public:
+		void Configure(const EditorCameraConfig& cfg);
+		void SetMode(EditorCameraMode mode);
+		EditorCameraMode GetMode() const { return m_mode; }
+
+		/// Construit la `engine::render::Camera` pour la frame courante.
+		/// Doit être appelée une fois par frame depuis ScenePanel::Render.
+		engine::render::Camera BuildCamera(int viewportWidth, int viewportHeight) const;
+
+		/// Consomme les inputs souris/clavier pour la frame.
+		void Update(engine::platform::Input& input, double dtSeconds);
+
+		void FocusOn(engine::math::Vec3 target);
+		engine::math::Vec3 GetFocusPoint() const { return m_focusPoint; }
+
+	private:
+		void UpdateFPS(engine::platform::Input& input, double dt);
+		void UpdateOrbital(engine::platform::Input& input, double dt);
+		void UpdateTopDownOrtho(engine::platform::Input& input, double dt);
+
+		EditorCameraMode m_mode = EditorCameraMode::FPS;
+		engine::math::Vec3 m_position{ 0.0f, 5.0f, 10.0f };
+		engine::math::Vec3 m_focusPoint{ 0.0f, 0.0f, 0.0f };
+		float m_yawDeg = 0.0f;
+		float m_pitchDeg = -15.0f;
+		float m_orbitalDistance = 10.0f;
+		float m_topDownExtent = 50.0f;
+		EditorCameraConfig m_cfg;
+	};
+}
+```
+
+### Format / passes / shaders
+
+Aucun nouveau format, pas de passe, pas de shader.
+
+### Parité éditeur ↔ client
+
+Pas applicable (la caméra éditeur n'est jamais utilisée en jeu normal).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/CommandStack.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/CommandStack.cpp
+    engine/editor/world/EditorCameraController.cpp
+    ...
+)
+
+add_executable(editor_camera_controller_tests engine/editor/world/tests/EditorCameraControllerTests.cpp)
+target_link_libraries(editor_camera_controller_tests PRIVATE engine_core)
+add_test(NAME editor_camera_controller_tests COMMAND editor_camera_controller_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+Numpad 1 → SetMode(FPS)        → input WASD applique translation locale
+Numpad 3 → SetMode(Orbital)    → Alt+drag rotation autour de m_focusPoint
+Numpad 7 → SetMode(TopDown)    → flèches pan, molette zoom ortho
+F        → FocusOn(currentSelection)
+```
+
+## Critères d'acceptation
+
+- [ ] Numpad 1 / 3 / 7 commute le mode caméra.
+- [ ] Les boutons `[FPS] [Orbital] [Top]` dans la barre du panneau Scene reflètent le mode actif.
+- [ ] Le focus point est conservé lors du switch de mode.
+- [ ] En mode Orbital, F recentre la caméra sur la sélection courante (M100.34) ou sur l'origine si rien n'est sélectionné.
+- [ ] Le mode actif est persisté entre sessions.
+- [ ] Aucune passe de rendu n'est ajoutée ou modifiée.
+- [ ] Aucune dépendance ajoutée à `server_app`.
+
+## Tests
+
+- `engine/editor/world/tests/EditorCameraControllerTests.cpp` :
+  - `Test_SetMode_PreservesFocusPoint`.
+  - `Test_BuildCamera_FPS_Position`.
+  - `Test_BuildCamera_Orbital_OrientedTowardFocus`.
+  - `Test_BuildCamera_TopDown_OrthoExtent`.
+  - `Test_FocusOn_RecentersCamera`.
+
+## Hors scope explicite
+
+- Pas de bookmarks ("Save view 1..9").
+- Pas de caméra cinématique (path).
+- Pas de "fly-through" enregistré.
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.4-EditorCameraModes.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.5-HeightmapDataStructure.md
+++ b/tickets/M100/M100.5-HeightmapDataStructure.md
@@ -1,0 +1,246 @@
+# M100.5 — Heightmap Data Structure
+
+## Résumé
+
+Définit la structure de heightmap éditable par chunk (`TerrainChunk`,
+257×257 vertices), son format binaire `terrain.bin` versionné, sa conversion
+en mesh GPU LOD0, et son intégration dans le streaming runtime client. Le
+ticket inclut le test de parité round-trip éditeur ↔ client : l'éditeur écrit
+un `terrain.bin`, le client le charge via `StreamCache`, le mesh généré est
+identique.
+
+## Dépendances
+
+- **M100.3** — Zone Builder Library Extraction (writers communs).
+- **M100.4** — Editor Camera Modes (pour la viewport).
+
+## Portée
+
+### Inclus
+- Structure C++ `engine::world::terrain::TerrainChunk` (header + storage 257×257 floats).
+- Fichier binaire `chunks/chunk_i_j/terrain.bin` versionné (`kTerrainMagic`, `kTerrainVersion`).
+- Lecture côté client (`engine::world::terrain::TerrainChunkLoader`) branchée dans `StreamCache`.
+- Génération du mesh GPU LOD0 (vertex buffer + index buffer triangle strip).
+- Réutilisation par l'éditeur via `engine::editor::world::TerrainDocument`.
+- Test de parité round-trip éditeur → client.
+
+### Hors scope
+- Édition de la heightmap (sculpting → M100.6).
+- LODs N>0 (M100.8).
+- Splat-map (M100.9).
+
+## Spécification fonctionnelle
+
+L'éditeur charge un chunk vide (heightmap plate) ou existant. Le panneau Inspector affiche :
+- Coordonnées globales du chunk (`chunkX`, `chunkZ`).
+- Résolution (257×257, fixe en M100).
+- Min/Max de hauteur courants.
+- Bouton "Reload from disk".
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+namespace engine::world::terrain
+{
+	constexpr uint32_t kTerrainResolution = 257;             // 256 quads + 1 vertex de bord
+	constexpr float    kTerrainCellSizeMeters = 1.0f;        // 1 m par cellule
+	constexpr float    kTerrainHeightMinMeters = -1024.0f;
+	constexpr float    kTerrainHeightMaxMeters = 8192.0f;
+	constexpr uint32_t kTerrainMagic   = 0x4E525254u; // "TRRN"
+	constexpr uint32_t kTerrainVersion = 1u;
+}
+```
+
+### Layout binaire `chunks/chunk_i_j/terrain.bin`
+
+```
+[0..23]   OutputVersionHeader (magic=kTerrainMagic, formatVersion=kTerrainVersion, contentHash=xxhash64(payload))
+[24..27]  uint32 resolutionX     (vaut kTerrainResolution)
+[28..31]  uint32 resolutionZ     (vaut kTerrainResolution)
+[32..35]  float  cellSizeMeters  (vaut kTerrainCellSizeMeters)
+[36..39]  float  heightMin       (min observé)
+[40..43]  float  heightMax       (max observé)
+[44..47]  uint32 reserved (=0)
+[48..N]   float[resolutionX * resolutionZ] heights (row-major, Z-major)
+```
+
+`N = 48 + 257*257*4 = 48 + 264 196 = 264 244 octets`.
+
+Stockage en `float` (pas de 16-bit en M100) pour précision sculpting et
+simplicité. La compression est laissée à un futur ticket d'optimisation.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/terrain/TerrainChunk.h` | Structure + constantes + helpers (sample, gradient). |
+| `engine/world/terrain/TerrainChunk.cpp` | Implémentation (lecture/écriture binaire, validation). |
+| `engine/world/terrain/TerrainChunkLoader.h/.cpp` | Adapter `StreamCache`. |
+| `engine/world/terrain/TerrainMeshBuilder.h/.cpp` | Conversion heightmap → vertex/index buffers. |
+| `engine/editor/world/TerrainDocument.h/.cpp` | Wrapper éditeur. |
+| `engine/world/terrain/tests/TerrainChunkTests.cpp` | Tests unitaires. |
+| `engine/world/terrain/tests/TerrainParityTests.cpp` | Round-trip éditeur ↔ client. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/StreamCache.h/.cpp` | Ajouter `LoadTerrainChunk(GlobalChunkCoord)` qui retourne un `std::shared_ptr<TerrainChunk>`. |
+| `engine/world/StreamingScheduler.cpp` | Inclure `terrain.bin` dans le set de fichiers requis par chunk. |
+| `engine/render/GeometryPass.cpp` | Lire les `TerrainMeshGpu` du chunk si présent et soumettre le drawcall. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | Ajouter `WriteTerrainChunk(outputDir, chunkX, chunkZ, const TerrainChunk&)`. |
+
+### Structures C++
+
+```cpp
+namespace engine::world::terrain
+{
+	/// Heightmap éditable (LOD0) d'un chunk monde.
+	/// Layout row-major en Z (heights[z * resolutionX + x]).
+	struct TerrainChunk
+	{
+		uint32_t resolutionX = kTerrainResolution;
+		uint32_t resolutionZ = kTerrainResolution;
+		float    cellSizeMeters = kTerrainCellSizeMeters;
+		float    heightMin = 0.0f;
+		float    heightMax = 0.0f;
+		std::vector<float> heights;   // taille = resolutionX * resolutionZ
+
+		/// Initialise un chunk plat à `height` mètres.
+		static TerrainChunk MakeFlat(float height = 0.0f);
+
+		/// Échantillonne la hauteur en coordonnées chunk-locales (mètres).
+		/// Bilinéaire. Hors-bornes → clamp.
+		float SampleHeight(float localX, float localZ) const;
+
+		/// Recalcule heightMin/heightMax à partir de `heights`.
+		void RecomputeBounds();
+	};
+
+	struct TerrainMeshGpu
+	{
+		VkBuffer vertexBuffer = VK_NULL_HANDLE;
+		VkBuffer indexBuffer  = VK_NULL_HANDLE;
+		uint32_t indexCount   = 0;
+	};
+
+	bool LoadTerrainBin(std::span<const uint8_t> bytes, TerrainChunk& outChunk, std::string& outError);
+	bool SaveTerrainBin(const TerrainChunk& chunk, std::vector<uint8_t>& outBytes, std::string& outError);
+}
+```
+
+### Conversion mesh
+
+Vertices : `(x, height, z, nx, ny, nz, u, v)` = 32 octets, position en mètres
+chunk-local. Normales calculées depuis le gradient bilinéaire. UVs en 0..1
+sur le chunk.
+
+Indices : triangle list 16-bit (257² = 66049 < 65536 ❌ — donc **32-bit index
+buffer obligatoire**), 256×256×6 = 393 216 indices.
+
+### Parité éditeur ↔ client
+
+| Étape | Code | Chemin |
+|-------|------|--------|
+| Éditeur écrit | `engine::editor::world::TerrainDocument::SaveToDisk` | `engine/editor/world/TerrainDocument.cpp` |
+| Sérialisation | `engine::world::terrain::SaveTerrainBin` | `engine/world/terrain/TerrainChunk.cpp` |
+| Client lit | `engine::world::terrain::TerrainChunkLoader::Load` via `StreamCache::LoadTerrainChunk` | `engine/world/terrain/TerrainChunkLoader.cpp`, `engine/world/StreamCache.cpp` |
+| Désérialisation | `engine::world::terrain::LoadTerrainBin` | idem |
+
+Test de parité : `TerrainParityTests.cpp` :
+1. Construit un `TerrainChunk` en RAM avec un pattern déterministe (`heights[z * R + x] = sin(x*0.1)*cos(z*0.1)`).
+2. Écrit via `SaveTerrainBin`.
+3. Relit via `LoadTerrainBin`.
+4. Compare champ à champ + `memcmp` sur `heights` → octets identiques.
+5. Construit deux `TerrainMeshBuilder` à partir du chunk original et du chunk re-lu, compare vertex buffers bit-à-bit.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/StreamCache.cpp
+    engine/world/StreamingScheduler.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/StreamCache.cpp
+    engine/world/StreamingScheduler.cpp
+    engine/world/terrain/TerrainChunk.cpp
+    engine/world/terrain/TerrainChunkLoader.cpp
+    engine/world/terrain/TerrainMeshBuilder.cpp
+    engine/editor/world/TerrainDocument.cpp
+    ...
+)
+
+add_executable(terrain_chunk_tests
+    engine/world/terrain/tests/TerrainChunkTests.cpp)
+target_link_libraries(terrain_chunk_tests PRIVATE engine_core)
+add_test(NAME terrain_chunk_tests COMMAND terrain_chunk_tests)
+
+add_executable(terrain_parity_tests
+    engine/world/terrain/tests/TerrainParityTests.cpp)
+target_link_libraries(terrain_parity_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME terrain_parity_tests COMMAND terrain_parity_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Inspector] Chunk (5, -3)         [Reload from disk]
+  Resolution: 257 × 257
+  Cell size : 1.0 m
+  Height min: -3.42 m
+  Height max:  18.71 m
+```
+
+## Critères d'acceptation
+
+- [ ] `TerrainChunk::MakeFlat(0)` produit une heightmap 257×257 à 0 m.
+- [ ] `SaveTerrainBin` puis `LoadTerrainBin` redonnent une structure identique champ à champ.
+- [ ] `Sha256(terrain.bin)` du même `TerrainChunk` est identique entre deux exécutions (déterministe).
+- [ ] `StreamCache::LoadTerrainChunk` charge la heightmap depuis `chunks/chunk_i_j/terrain.bin` produit par l'éditeur, **sans branche conditionnelle "preview / production"**.
+- [ ] La passe `Geometry` consomme le mesh terrain produit par `TerrainMeshBuilder`, **sans branche `m_editorEnabled`**.
+- [ ] Le test `terrain_parity_tests` passe (round-trip + comparaison vertex buffers).
+- [ ] `engine/server/` ne contient aucune référence à `TerrainChunk`.
+- [ ] La validation des bornes (`heightMin <= heightMax`, `resolution == 257`) rejette un fichier corrompu avec un message clair.
+
+## Tests
+
+- `terrain_chunk_tests` :
+  - `Test_MakeFlat_ProducesUniformHeights`.
+  - `Test_SampleHeight_BilinearInterior`.
+  - `Test_SampleHeight_ClampsOutOfBounds`.
+  - `Test_SaveLoad_Roundtrip`.
+  - `Test_Load_RejectsBadMagic`.
+  - `Test_Load_RejectsBadVersion`.
+- `terrain_parity_tests` :
+  - `Test_EditorWritesClientReadsIdentical`.
+  - `Test_MeshBuilder_DeterministicVertexBuffer`.
+
+## Hors scope explicite
+
+- Pas d'édition (M100.6).
+- Pas de LOD chain (M100.8).
+- Pas de compression (futur).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.5-HeightmapDataStructure.html` (panneau Inspector).
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.
+> Le serveur ne charge ni `terrain.bin` ni les meshes terrain.

--- a/tickets/M100/M100.6-TerrainSculptingBrushes.md
+++ b/tickets/M100/M100.6-TerrainSculptingBrushes.md
@@ -1,0 +1,250 @@
+# M100.6 — Terrain Sculpting Brushes
+
+## Résumé
+
+Cinq brosses de sculpture (Raise, Lower, Smooth, Flatten, Noise) appliquées
+sur la heightmap par raycast écran→terrain. Chaque brushstroke produit un
+`ICommand` regroupant les modifications, garantissant un undo/redo propre.
+La brosse Noise utilise un Simplex 2D paramétrable.
+
+## Dépendances
+
+- **M100.2** — Command Stack & Undo/Redo.
+- **M100.5** — Heightmap Data Structure.
+
+## Portée
+
+### Inclus
+- Outil `engine::editor::world::TerrainSculptTool`.
+- 5 brosses : Raise, Lower, Smooth (3×3 box blur), Flatten (vers la hauteur sous le curseur), Noise (simplex).
+- Paramètres : radius (mètres), strength (m/s), falloff (smoothstep).
+- Raycast écran → ground via `TerrainChunk::SampleHeight` (Newton 4 itérations sur le rayon).
+- Application multi-chunk : un brushstroke chevauchant deux chunks édite les deux et préserve les coutures (gather + scatter dans la même opération).
+- Undo via `TerrainSculptCommand` qui stocke uniquement les bytes modifiés (delta sparse par cellule).
+
+### Hors scope
+- Erosion hydraulique (M100.7 ou plus tard).
+- Stamps PNG (M100.7).
+- Régénération LOD (M100.8).
+
+## Spécification fonctionnelle
+
+### Activation
+
+`Tools → Terrain Sculpt` ou raccourci **B** (brush).
+
+### Brosses
+
+| Brosse | Effet |
+|--------|-------|
+| Raise | Augmente la hauteur sous la brosse. |
+| Lower | Diminue. |
+| Smooth | Applique un box blur 3×3 par cellule pondéré par le poids de brosse. |
+| Flatten | Tire chaque cellule vers la hauteur sous le centre de la brosse. |
+| Noise | Ajoute `simplex2(x*freq, z*freq) * strength * weight`. Paramètres `frequency`, `octaves`. |
+
+### Tool Properties
+
+```
+[ Raise ] [ Lower ] [ Smooth ] [ Flatten ] [ Noise ]
+
+Radius      |■■■■■■□□□□|  6.0 m
+Strength    |■■■□□□□□□□|  3.0 m/s
+Falloff     |■■■■■■■□□□|  0.7
+Noise freq  |■■□□□□□□□□|  0.05  (Noise only)
+Noise octs  |3|                  (Noise only)
+
+[ ] Mirror X    [ ] Mirror Z
+```
+
+### Interaction
+
+- Maintien clic gauche = applique la brosse à 60 Hz tant que pressé.
+- Tous les ticks d'une même session "press → release" partagent le même
+  `mergeKey` ⇒ une seule entrée dans l'historique.
+- Curseur affiche un cercle décal sur le terrain, opaque côté épaisseur, semi-transparent au-delà.
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/TerrainSculptTool.h/.cpp` | Outil principal + dispatch d'inputs. |
+| `engine/editor/world/TerrainSculptCommand.h/.cpp` | `ICommand` qui stocke un delta sparse. |
+| `engine/editor/world/TerrainBrush.h/.cpp` | Modes (Raise/Lower/...) + Simplex2D. |
+| `engine/editor/world/TerrainRaycast.h/.cpp` | Raycast caméra → heightmap. |
+| `engine/editor/world/tests/TerrainSculptTests.cpp` | Tests unitaires. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/ToolPropertiesPanel.cpp` | Affiche les paramètres si `TerrainSculptTool` est actif. |
+| `engine/editor/world/WorldEditorShell.cpp` | Branche le shortcut `B` sur `Tools::SetActiveTool(TerrainSculpt)`. |
+
+### Structures
+
+```cpp
+namespace engine::editor::world
+{
+	enum class TerrainBrushMode : uint8_t { Raise, Lower, Smooth, Flatten, Noise };
+
+	struct TerrainBrushParams
+	{
+		TerrainBrushMode mode = TerrainBrushMode::Raise;
+		float radiusMeters = 6.0f;
+		float strengthMps  = 3.0f;
+		float falloff      = 0.7f;
+		float noiseFreq    = 0.05f;
+		uint8_t noiseOctaves = 3;
+		bool mirrorX = false;
+		bool mirrorZ = false;
+	};
+
+	struct TerrainSculptDeltaCell
+	{
+		uint16_t x;       // chunk-local
+		uint16_t z;
+		float deltaMeters;
+	};
+
+	struct TerrainSculptDeltaChunk
+	{
+		engine::world::GlobalChunkCoord coord;
+		std::vector<TerrainSculptDeltaCell> cells;
+	};
+
+	class TerrainSculptCommand : public ICommand
+	{
+	public:
+		explicit TerrainSculptCommand(std::vector<TerrainSculptDeltaChunk> deltas);
+		const char* GetLabel() const override { return "Sculpt brush stroke"; }
+		size_t GetMemoryFootprint() const override;
+		CommandMergeKey GetMergeKey() const override { return m_mergeKey; }
+		void Execute() override;
+		void Undo() override;
+		bool TryMerge(const ICommand& other) override;
+
+	private:
+		std::vector<TerrainSculptDeltaChunk> m_deltas;
+		CommandMergeKey m_mergeKey = 0;
+	};
+
+	class TerrainSculptTool
+	{
+	public:
+		bool Init(CommandStack& stack);
+		void SetParams(const TerrainBrushParams& params);
+		void OnMouseDown(const engine::render::Camera& cam, int sx, int sy, int vw, int vh);
+		void OnMouseMove(const engine::render::Camera& cam, int sx, int sy, int vw, int vh);
+		void OnMouseUp();
+		void RenderViewportOverlay(/* dépose un decal cercle */);
+	private:
+		CommandStack* m_stack = nullptr;
+		TerrainBrushParams m_params;
+		std::vector<TerrainSculptDeltaChunk> m_inFlight;
+		bool m_pressing = false;
+		uint64_t m_strokeId = 0;
+	};
+}
+```
+
+### Algorithme par stroke tick
+
+1. Raycast → point monde `P`.
+2. Convertir en `(GlobalChunkCoord, localX, localZ)`.
+3. Pour chaque chunk dans le carré `[radius]` autour de `P` :
+   - Charger la heightmap éditeur si pas déjà résidente.
+   - Pour chaque cellule à distance ≤ radius : `weight = smoothstep(1, 1-falloff, dist/radius)`.
+   - Appliquer le mode (delta float).
+   - Accumuler dans `m_inFlight` (delta cell).
+   - **Si la cellule touche le bord du chunk, écrire aussi la cellule miroir du chunk voisin** pour préserver la couture.
+4. Marquer `TerrainDocument` dirty.
+
+### Coutures inter-chunks
+
+Règle : la rangée `x = 256` du chunk `(i, j)` doit toujours valoir la rangée `x = 0` du chunk `(i+1, j)`. Le brush écrit explicitement les deux.
+
+### Parité éditeur ↔ client
+
+Le client ne consomme que `terrain.bin` (M100.5). La brosse n'introduit
+aucun nouveau format.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainDocument.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainDocument.cpp
+    engine/editor/world/TerrainSculptTool.cpp
+    engine/editor/world/TerrainSculptCommand.cpp
+    engine/editor/world/TerrainBrush.cpp
+    engine/editor/world/TerrainRaycast.cpp
+    ...
+)
+
+add_executable(terrain_sculpt_tests engine/editor/world/tests/TerrainSculptTests.cpp)
+target_link_libraries(terrain_sculpt_tests PRIVATE engine_core)
+add_test(NAME terrain_sculpt_tests COMMAND terrain_sculpt_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[B]  → Tools active = TerrainSculpt
+Mouse down → OnMouseDown : démarre stroke, ICommand en attente
+Mouse move (held) → OnMouseMove : applique tick (60 Hz)
+Mouse up → OnMouseUp : pousse TerrainSculptCommand sur la pile (1 entrée historique)
+Ctrl+Z → ICommand::Undo réapplique les deltas inverses cellule par cellule
+```
+
+## Critères d'acceptation
+
+- [ ] Les 5 brosses fonctionnent et leur effet est visible immédiatement.
+- [ ] Un brushstroke complet (press → release) produit **une seule** entrée dans le panneau History.
+- [ ] Le delta stocké est sparse (uniquement les cellules touchées).
+- [ ] Ctrl+Z annule le stroke entier.
+- [ ] Un brushstroke à cheval sur deux chunks préserve la couture (test : `chunk(i,j).heights[256][k] == chunk(i+1,j).heights[0][k]` pour tout k après stroke).
+- [ ] La brosse `Mirror X` symétrise correctement le delta autour de l'axe `X = chunkOriginX`.
+- [ ] Aucune branche `m_editorEnabled` n'apparaît dans `engine/render/`.
+- [ ] Le test `terrain_sculpt_tests` passe.
+
+## Tests
+
+- `terrain_sculpt_tests` :
+  - `Test_RaiseBrush_AddsExpectedDelta`.
+  - `Test_LowerBrush_NegatesRaise`.
+  - `Test_SmoothBrush_LimitsExtremaToNeighborhood`.
+  - `Test_FlattenBrush_ConvergesToCenterHeight`.
+  - `Test_NoiseBrush_DeterministicForSameSeed`.
+  - `Test_Stroke_MergesIntoOneCommand`.
+  - `Test_CrossChunk_PreservesSeam`.
+
+## Hors scope explicite
+
+- Pas d'érosion (procédurale ou simulée).
+- Pas de stamps importés (M100.7).
+- Pas de palettes de presets (futur ticket).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.6-TerrainSculptingBrushes.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.7-TerrainStampsAndProceduralGenerators.md
+++ b/tickets/M100/M100.7-TerrainStampsAndProceduralGenerators.md
@@ -1,0 +1,189 @@
+# M100.7 — Terrain Stamps & Procedural Generators
+
+## Résumé
+
+Importation de stamps PNG 16-bit comme "tampons" appliqués sur la heightmap, et
+trois générateurs procéduraux paramétrables (Mountain, Valley, Crater). Tout
+applicable est une `ICommand` réversible.
+
+## Dépendances
+
+- **M100.6** — Terrain Sculpting Brushes.
+
+## Portée
+
+### Inclus
+- Importation de PNG 16-bit grayscale comme stamp (ratio 0..1 → 0..stampHeight).
+- Bibliothèque de stamps stockée dans `assets/editor/stamps/*.png`.
+- Trois générateurs procéduraux : Mountain (cône lissé), Valley (cône inversé), Crater (anneau lissé).
+- Application via outil dédié `TerrainStampTool` (raccourci **N** = stamp).
+
+### Hors scope
+- Erosion hydraulique (futur).
+- Génération à l'échelle de la zone entière (le ticket édite chunk par chunk).
+
+## Spécification fonctionnelle
+
+### Tool Properties (Stamp)
+
+```
+Stamp source:
+  ( ) Library     [combo: mountain.png ▼]
+  (•) Procedural  [Mountain | Valley | Crater]
+
+Footprint  |■■■■■■■□□□|  120 m
+Strength   |■■■■■■□□□□|  60 m
+Rotation Y |■■□□□□□□□□|  45°
+Mode       (•) Add  ( ) Replace  ( ) Max  ( ) Min
+
+[Apply] [Cancel preview]
+```
+
+### Workflow
+
+1. Activer outil via **N**.
+2. Configurer footprint et strength.
+3. Click sur le terrain → preview semi-transparent.
+4. **Apply** → push `TerrainStampCommand` (réversible).
+5. **Cancel preview** ou **Esc** → annule la preview sans rien committer.
+
+## Spécification technique
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/editor/world/TerrainStampTool.h/.cpp` | Outil. |
+| `engine/editor/world/TerrainStampCommand.h/.cpp` | `ICommand` (delta sparse). |
+| `engine/editor/world/StampLibrary.h/.cpp` | Énumère et charge les PNG sous `assets/editor/stamps/`. |
+| `engine/editor/world/ProceduralStampGenerators.h/.cpp` | Mountain, Valley, Crater. |
+| `engine/editor/world/tests/TerrainStampTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/editor/world/panels/ToolPropertiesPanel.cpp` | UI quand StampTool actif. |
+| `engine/editor/world/WorldEditorShell.cpp` | Branchement raccourci `N`. |
+
+### Structures
+
+```cpp
+namespace engine::editor::world
+{
+	enum class StampMode : uint8_t { Add, Replace, Max, Min };
+	enum class ProceduralStamp : uint8_t { Mountain, Valley, Crater };
+
+	struct StampParams
+	{
+		bool useProcedural = true;
+		ProceduralStamp procedural = ProceduralStamp::Mountain;
+		std::string libraryPngPath;             // si !useProcedural
+		float footprintMeters = 120.0f;
+		float strengthMeters = 60.0f;
+		float rotationYDeg = 0.0f;
+		StampMode mode = StampMode::Add;
+	};
+
+	/// Génère une grille `outResolution × outResolution` de poids 0..1.
+	std::vector<float> RasterizeStamp(const StampParams& params, uint32_t outResolution);
+}
+```
+
+### Générateurs procéduraux
+
+```cpp
+// Mountain : weight(d) = smoothstep(1, 0, d / radius), d = distance au centre.
+// Valley   : weight(d) = -smoothstep(1, 0, d / radius).
+// Crater   : weight(d) = -smoothstep(0.6, 0.8, d/radius) + smoothstep(0.8, 1.0, d/radius).
+```
+
+### Application
+
+```cpp
+for (cell in stamp_grid_intersected_with_chunk):
+    weight = stamp_grid[cell] * strength
+    switch mode:
+        Add:     h += weight
+        Replace: h  = weight
+        Max:     h  = max(h, weight)
+        Min:     h  = min(h, weight)
+```
+
+### Format / parité
+
+Pas de nouveau format binaire ; les stamps modifient `terrain.bin` (M100.5).
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainSculptTool.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/editor/world/TerrainSculptTool.cpp
+    engine/editor/world/TerrainStampTool.cpp
+    engine/editor/world/TerrainStampCommand.cpp
+    engine/editor/world/StampLibrary.cpp
+    engine/editor/world/ProceduralStampGenerators.cpp
+    ...
+)
+
+add_executable(terrain_stamp_tests engine/editor/world/tests/TerrainStampTests.cpp)
+target_link_libraries(terrain_stamp_tests PRIVATE engine_core)
+add_test(NAME terrain_stamp_tests COMMAND terrain_stamp_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+N → outil StampTool actif
+Click sur terrain → preview overlay (couleur ambre)
+Tweak Footprint / Strength / Rotation → preview se met à jour live
+Apply → TerrainStampCommand pushé sur la pile
+Esc → preview annulée
+```
+
+## Critères d'acceptation
+
+- [ ] Charger un PNG 16-bit grayscale et l'appliquer reproduit le pattern attendu sur la heightmap.
+- [ ] Les 3 générateurs procéduraux produisent des silhouettes radialement symétriques (vérifié par test sur `RasterizeStamp`).
+- [ ] Les modes Add / Replace / Max / Min sont implémentés et réversibles via Ctrl+Z.
+- [ ] La preview ne modifie pas le `TerrainChunk` tant qu'`Apply` n'a pas été cliqué.
+- [ ] Esc annule la preview sans pushser de commande.
+- [ ] Les tests `terrain_stamp_tests` passent.
+
+## Tests
+
+- `Test_RasterizeStamp_Mountain_PeakAtCenter`.
+- `Test_RasterizeStamp_Valley_TroughAtCenter`.
+- `Test_RasterizeStamp_Crater_RingMaxAt0p8`.
+- `Test_StampLibrary_LoadsPng16BitGrayscale`.
+- `Test_StampCommand_UndoRestoresPriorHeights`.
+- `Test_Mode_Replace_OverwritesNotAdds`.
+
+## Hors scope explicite
+
+- Pas d'export de stamps depuis la heightmap courante.
+- Pas de packs de stamps tiers.
+- Pas de PNG 8-bit (qualité insuffisante pour heightmap).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.7-TerrainStampsAndProceduralGenerators.html`
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.8-TerrainLODRegeneration.md
+++ b/tickets/M100/M100.8-TerrainLODRegeneration.md
@@ -1,0 +1,154 @@
+# M100.8 — Terrain LOD Regeneration
+
+## Résumé
+
+Génère et persiste 4 niveaux de LOD (LOD0..LOD3) pour la heightmap d'un chunk,
+re-déclenchés automatiquement quand la heightmap change. La régénération est
+asynchrone : LOD0 est mis à jour à chaque tick de brushstroke, les LOD>0 sont
+calculés en arrière-plan au commit du `ICommand`.
+
+## Dépendances
+
+- **M100.5** — Heightmap Data Structure.
+
+## Portée
+
+### Inclus
+- 4 niveaux : LOD0 (257²), LOD1 (129²), LOD2 (65²), LOD3 (33²).
+- Filtrage : box filter 2×2 + skirt aux bords pour masquer les fissures.
+- Persistance dans `chunks/chunk_i_j/terrain_lods.bin` versionné.
+- Sélection runtime via le `LodConfig` existant.
+- Worker thread pool (taille = `editor.world.terrain.lodWorkers`, défaut = `std::thread::hardware_concurrency() - 2`).
+
+### Hors scope
+- LOD continu / morphing inter-LOD.
+- HLOD inter-chunks (déjà géré ailleurs).
+
+## Spécification fonctionnelle
+
+L'utilisateur ne voit pas l'opération. Indicateur passif dans la barre du
+panneau Console : `Regenerating LODs for chunk (5,-3)... done (12 ms)`.
+
+## Spécification technique
+
+### Layout binaire `chunks/chunk_i_j/terrain_lods.bin`
+
+```
+[0..23]   OutputVersionHeader (magic=kTerrainLodsMagic, version=kTerrainLodsVersion)
+[24..27]  uint32 lodCount (= 3, on ne stocke pas LOD0 qui est dans terrain.bin)
+For each LOD level [1..3]:
+  [4 bytes] uint32 resolution (129, 65, 33)
+  [4 bytes] float  cellSizeMeters (2.0, 4.0, 8.0)
+  [resolution*resolution*4] float[] heights
+```
+
+```cpp
+constexpr uint32_t kTerrainLodsMagic = 0x4F4C5254u; // "TRLO"
+constexpr uint32_t kTerrainLodsVersion = 1u;
+```
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/terrain/TerrainLodChain.h/.cpp` | Génération + sérialisation des LODs. |
+| `engine/world/terrain/TerrainLodWorker.h/.cpp` | Thread pool + queue. |
+| `engine/world/terrain/tests/TerrainLodTests.cpp` | Tests. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/terrain/TerrainChunk.h` | Ajouter `struct TerrainLod { uint32_t resolution; float cellSizeMeters; std::vector<float> heights; };` |
+| `engine/world/StreamCache.cpp` | Charger `terrain_lods.bin` à la demande LOD. |
+| `engine/editor/world/TerrainDocument.cpp` | Au commit d'un `ICommand` terrain, enqueue dans `TerrainLodWorker`. |
+| `engine/world/terrain/TerrainMeshBuilder.cpp` | Génère un mesh par niveau de LOD à partir de `TerrainLod`. |
+| `engine/render/LodConfig.cpp` | Aucune (réutilisation). |
+
+### Algorithme
+
+```cpp
+// LOD N+1 = box filter 2×2 sur LOD N
+for (z = 0; z < res_next; z++)
+  for (x = 0; x < res_next; x++)
+    h_next[z][x] = (h[2z][2x] + h[2z][2x+1] + h[2z+1][2x] + h[2z+1][2x+1]) * 0.25f
+```
+
+Une "skirt" géométrique (2 m sous le bord) est ajoutée au mesh runtime au moment de `TerrainMeshBuilder::BuildLodMesh` pour masquer les T-junctions entre chunks de LOD différent. La skirt n'est pas persistée dans `terrain_lods.bin`.
+
+### Parité éditeur ↔ client
+
+Le client lit `terrain_lods.bin` via `StreamCache`, exactement comme l'éditeur (et le binaire `zone_builder` offline). Test de parité : un `TerrainChunk` générant 3 LODs côté éditeur, puis le client charge → comparaison `memcmp` heights LOD1/LOD2/LOD3.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/terrain/TerrainChunk.cpp
+    engine/world/terrain/TerrainMeshBuilder.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/terrain/TerrainChunk.cpp
+    engine/world/terrain/TerrainMeshBuilder.cpp
+    engine/world/terrain/TerrainLodChain.cpp
+    engine/world/terrain/TerrainLodWorker.cpp
+    ...
+)
+
+add_executable(terrain_lod_tests engine/world/terrain/tests/TerrainLodTests.cpp)
+target_link_libraries(terrain_lod_tests PRIVATE engine_core)
+add_test(NAME terrain_lod_tests COMMAND terrain_lod_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+```
+[Brushstroke commit]
+  └─> TerrainDocument::OnCommit
+       └─> TerrainLodWorker.enqueue(chunk_coord)
+            └─> worker thread :
+                 1. Génère LOD1, LOD2, LOD3 par box filter
+                 2. Sérialise terrain_lods.bin
+                 3. Notifie le main thread → invalidation cache GPU
+```
+
+## Critères d'acceptation
+
+- [ ] Après chaque commit d'un `ICommand` terrain, `terrain_lods.bin` est mis à jour.
+- [ ] Le main thread n'est jamais bloqué > 1 ms par le worker.
+- [ ] Le client (mode jeu normal) lit `terrain_lods.bin` via `StreamCache` sans branche éditeur.
+- [ ] La hauteur `LOD1[z][x]` est strictement la moyenne 2×2 de `LOD0`.
+- [ ] Le test de parité round-trip passe.
+- [ ] Aucune passe de rendu n'est dupliquée pour l'éditeur.
+
+## Tests
+
+- `Test_GenerateLodChain_BoxFilterMatch`.
+- `Test_SaveLoadLods_Roundtrip`.
+- `Test_ParityWithClient_Identical`.
+- `Test_LodWorker_AsyncDoesNotBlockMain`.
+
+## Hors scope explicite
+
+- Pas de morphing géométrique entre LOD.
+- Pas d'imposteurs de chunk lointains.
+
+## Référence visuelle
+
+Aucune (pas de surface UI propre, juste un message console). Pas de fichier HTML.
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/M100.9-SplatMapSystem.md
+++ b/tickets/M100/M100.9-SplatMapSystem.md
@@ -1,0 +1,223 @@
+# M100.9 — Splat Map System
+
+## Résumé
+
+Définit la splat-map 8 couches par chunk (résolution 257×257, 8 octets par
+cellule = poids des 8 couches), son fichier binaire `splat.bin` versionné,
+le shader terrain qui mélange 8 textures PBR pondérées, et l'intégration
+dans `GeometryPass`. Toute couche pointe vers une slot de la table de surfaces
+(M100.11) pour le hook gameplay.
+
+## Dépendances
+
+- **M100.5** — Heightmap Data Structure.
+
+## Portée
+
+### Inclus
+- Format `splat.bin` 8×u8 par cellule, 257×257 cellules.
+- 8 layers nommées dans `assets/terrain/layer_palette.json` (albedo + normal + ARM + tag SurfaceType).
+- Shader terrain GLSL `terrain.vert` / `terrain.frag` mixant les 8 layers.
+- Modification du `TerrainMeshBuilder` pour exposer un sampler `splatMap` et `layerArray` (texture 2D array).
+- Lecture côté client via `StreamCache::LoadSplatMap`.
+- Test de parité round-trip.
+
+### Hors scope
+- Outils de peinture (M100.10).
+- Logique gameplay `SurfaceQuery` (M100.11).
+
+## Spécification fonctionnelle
+
+L'utilisateur ne peint pas dans ce ticket ; il voit le résultat (terrain par
+défaut peint avec layer 0 = "dirt").
+
+L'inspector du chunk affiche :
+```
+Splat layers active: 1 / 8
+  [✓] Layer 0  dirt          (100.0 %)
+  [ ] Layer 1  grass_dry     (0.0 %)
+  …
+```
+
+## Spécification technique
+
+### Constantes
+
+```cpp
+namespace engine::world::terrain
+{
+	constexpr uint32_t kSplatMagic   = 0x54414C53u; // "SLAT"
+	constexpr uint32_t kSplatVersion = 1u;
+	constexpr uint32_t kSplatResolution = 257;
+	constexpr uint32_t kSplatLayerCount = 8;
+}
+```
+
+### Layout binaire `chunks/chunk_i_j/splat.bin`
+
+```
+[0..23]   OutputVersionHeader
+[24..27]  uint32 resolution (=257)
+[28..31]  uint32 layerCount (=8)
+[32..N]   uint8[resolution * resolution * layerCount]  poids row-major Z-major (somme par cellule = 255)
+```
+
+`N = 32 + 257*257*8 = 528 424 octets`.
+
+Invariant : pour chaque cellule `(x, z)`, la somme des 8 poids vaut 255. La
+peinture (M100.10) garantit ce contrat.
+
+### Format JSON `assets/terrain/layer_palette.json`
+
+```json
+{
+  "version": 1,
+  "layers": [
+    { "index": 0, "name": "dirt",         "albedo": "tex/terrain/dirt_albedo.texr",
+      "normal": "tex/terrain/dirt_normal.texr", "arm": "tex/terrain/dirt_arm.texr",
+      "tilingMeters": 4.0, "surfaceType": "Dirt" },
+    { "index": 1, "name": "grass_dry",    "albedo": "...", "normal": "...", "arm": "...",
+      "tilingMeters": 3.0, "surfaceType": "Grass" },
+    { "index": 2, "name": "grass_wet",    "...": "...", "surfaceType": "Grass" },
+    { "index": 3, "name": "mud",          "...": "...", "surfaceType": "Mud" },
+    { "index": 4, "name": "sand",         "...": "...", "surfaceType": "Sand" },
+    { "index": 5, "name": "rock",         "...": "...", "surfaceType": "Rock" },
+    { "index": 6, "name": "snow",         "...": "...", "surfaceType": "Snow" },
+    { "index": 7, "name": "lava_cooled",  "...": "...", "surfaceType": "LavaCooled" }
+  ]
+}
+```
+
+`surfaceType` est consommé en M100.11.
+
+### Fichiers à créer
+
+| Chemin | Rôle |
+|--------|------|
+| `engine/world/terrain/SplatMap.h/.cpp` | Structure + sérialisation. |
+| `engine/world/terrain/LayerPalette.h/.cpp` | Lecture du JSON + cache textures. |
+| `engine/render/shaders/terrain.vert` | Shader vertex terrain. |
+| `engine/render/shaders/terrain.frag` | Shader fragment 8-layer blend. |
+| `engine/world/terrain/tests/SplatMapTests.cpp` | Tests + parité. |
+
+### Fichiers à modifier
+
+| Chemin | Modification |
+|--------|--------------|
+| `engine/world/StreamCache.h/.cpp` | `LoadSplatMap(GlobalChunkCoord)`. |
+| `engine/world/terrain/TerrainMeshBuilder.cpp` | Bind `splatMap` + `layerArray` sur le drawcall. |
+| `engine/render/GeometryPass.cpp` | Ajouter le pipeline terrain et le drawcall par chunk visible. |
+| `tools/zone_builder/lib/ChunkPackageWriter.cpp` | `WriteSplatMap`. |
+
+### Structures
+
+```cpp
+struct SplatMap
+{
+	uint32_t resolution = kSplatResolution;
+	uint32_t layerCount = kSplatLayerCount;
+	std::vector<uint8_t> weights;   // R*R*L bytes, somme par cellule = 255
+
+	static SplatMap MakeUniform(uint32_t layerIndex);
+	bool IsValid() const;            // vérifie l'invariant somme=255
+};
+```
+
+### Shader fragment (résumé)
+
+```glsl
+layout(set=2, binding=0) uniform sampler2D splatMap;          // 257x257, R8G8B8A8 + RGBA second sampler
+layout(set=2, binding=1) uniform sampler2DArray layerArray;   // 8 layers PBR (albedo)
+layout(set=2, binding=2) uniform sampler2DArray normalArray;
+layout(set=2, binding=3) uniform sampler2DArray armArray;
+
+void main()
+{
+    // splatMap → 8 poids normalisés
+    vec4 a = texture(splatMap0, uv); // layers 0..3 weights
+    vec4 b = texture(splatMap1, uv); // layers 4..7 weights
+    float w[8] = { a.r, a.g, a.b, a.a, b.r, b.g, b.b, b.a };
+    vec3 albedo = vec3(0);
+    for (int i = 0; i < 8; ++i)
+        albedo += texture(layerArray, vec3(uv * tilingScale[i], i)).rgb * w[i];
+    // ... idem normal, ARM
+}
+```
+
+### Parité éditeur ↔ client
+
+| Étape | Code |
+|-------|------|
+| Éditeur écrit | `engine::editor::world::TerrainDocument::SaveSplat` |
+| Sérialisation | `engine::world::terrain::SaveSplatBin` |
+| Client lit | `engine::world::StreamCache::LoadSplatMap` |
+| Désérialisation | `engine::world::terrain::LoadSplatBin` |
+
+Test de parité : crée une `SplatMap` synthétique (gradient), sauvegarde, recharge, compare bit-à-bit.
+
+### Réseau
+
+Aucun.
+
+## Diff CMake
+
+### before
+```
+add_library(engine_core
+    ...
+    engine/world/terrain/TerrainMeshBuilder.cpp
+    ...
+)
+```
+
+### after
+```
+add_library(engine_core
+    ...
+    engine/world/terrain/TerrainMeshBuilder.cpp
+    engine/world/terrain/SplatMap.cpp
+    engine/world/terrain/LayerPalette.cpp
+    ...
+)
+
+# Shader compilation (intégré au système GLSL existant)
+
+add_executable(splat_map_tests engine/world/terrain/tests/SplatMapTests.cpp)
+target_link_libraries(splat_map_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME splat_map_tests COMMAND splat_map_tests)
+```
+
+## Schéma d'interaction utilisateur
+
+Pas d'outil dans ce ticket. Le visuel se manifeste par le rendu terrain.
+
+## Critères d'acceptation
+
+- [ ] Un chunk avec splat-map "uniforme layer 0" est rendu avec la texture dirt.
+- [ ] L'invariant somme=255 est validé au chargement (rejet sinon).
+- [ ] Le shader supporte 8 layers actifs simultanément (test : gradient 4 layers visible).
+- [ ] Le format `splat.bin` est lu **par le même code** côté éditeur et côté client (`StreamCache`).
+- [ ] Le test de parité round-trip passe.
+- [ ] Aucune branche `m_editorEnabled` dans `terrain.frag` ni dans `GeometryPass`.
+
+## Tests
+
+- `Test_SplatMap_MakeUniform_SumIs255`.
+- `Test_SaveLoad_Roundtrip`.
+- `Test_LayerPalette_LoadJson`.
+- `Test_Parity_EditorWritesClientReadsIdentical`.
+- `Test_Shader_8LayersBlendVisualBaseline` (test screenshot vs baseline PNG).
+
+## Hors scope explicite
+
+- Pas d'outil de peinture (M100.10).
+- Pas de connexion au gameplay (M100.11).
+- Pas de variantes saisonnières (M100.25).
+
+## Référence visuelle
+
+`tickets/M100/visuals/M100.9-SplatMapSystem.html` (Inspector des layers).
+
+## Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur.

--- a/tickets/M100/visuals/M100.1-WorldEditorBootstrap.html
+++ b/tickets/M100/visuals/M100.1-WorldEditorBootstrap.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="fr"><head><meta charset="utf-8"><title>M100.1 — World Editor Bootstrap</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="shell">
+  <div class="menubar">
+    <span class="item">File</span><span class="item">Edit</span><span class="item">View</span>
+    <span class="item">Tools</span><span class="item">Window</span><span class="item">Help</span>
+  </div>
+  <div class="dock">
+    <div class="panel"><div class="title">Outliner (F4)</div>
+      <div class="body" style="color:#888">(empty — no scene loaded yet)</div></div>
+    <div class="panel"><div class="title">Scene (F1)</div>
+      <div class="viewport">
+        <div class="toolbar"><span class="btn active">FPS</span><span class="btn">Orbital</span><span class="btn">Top</span></div>
+        <div class="hud">Mode: FPS<br>Focus: (0.0, 0.0, 0.0)<br>Speed: 1.0×</div>
+        Scene viewport
+      </div></div>
+    <div class="panel"><div class="title">Inspector (F2)</div>
+      <div class="body" style="color:#888">(no selection)</div></div>
+  </div>
+  <div class="dock-bottom">
+    <div class="panel"><div class="title blue">Asset Browser (F3)</div>
+      <div class="body" style="color:#888">(empty)</div></div>
+    <div class="panel"><div class="title green">Tool Properties (F12)</div>
+      <div class="body" style="color:#888">No active tool.</div></div>
+    <div class="panel"><div class="title amber">Console (F6)</div>
+      <div class="body" style="font-size:11px;color:#9c9">
+        [12:00:00] [EditorWorld] WorldEditorShell init OK<br>
+        [12:00:00] [EditorWorld] Loaded layout from editor_world_layout.ini<br>
+        [12:00:01] [EditorWorld] 6 panels registered
+      </div></div>
+  </div>
+</div>
+<footer>M100.1 — World Editor Bootstrap · LCDLLN</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.10-SplatPaintingBrushes.html
+++ b/tickets/M100/visuals/M100.10-SplatPaintingBrushes.html
@@ -1,0 +1,17 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.10 — Splat Paint</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:440px"><div class="title green">Tool Properties — Splat Paint</div><div class="body">
+  <div class="row"><span>Mode</span><div><span class="radio checked">Manual</span> <span class="radio">Auto-Rules</span></div></div>
+  <div class="row"><span>Active layer</span><span class="combo">0 dirt</span></div>
+  <div class="row"><span>Radius</span><div class="slider"><div class="fill" style="width:60%"></div></div></div>
+  <div class="row"><span>Strength</span><div class="slider"><div class="fill amber" style="width:50%"></div></div></div>
+  <div class="row"><span>Falloff</span><div class="slider"><div class="fill" style="width:70%"></div></div></div>
+  <div style="margin:8px 0;color:#888">Auto-Rules</div>
+  <div class="row"><span>Slope min</span><div class="slider"><div class="fill" style="width:0%"></div></div></div>
+  <div class="row"><span>Slope max</span><div class="slider"><div class="fill" style="width:39%"></div></div></div>
+  <div class="row"><span>Alt min</span><span style="color:#888">-inf</span></div>
+  <div class="row"><span>Alt max</span><span style="color:#888">+inf</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">P = activate · sum=255 invariant preserved · seam-aware</div>
+</div></div>
+<footer>M100.10 — Splat Painting Brushes</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.11-SurfaceMaterialSystemAndSurfaceQuery.html
+++ b/tickets/M100/visuals/M100.11-SurfaceMaterialSystemAndSurfaceQuery.html
@@ -1,0 +1,23 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.11 — Surface Table</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:680px"><div class="title">Surface Table (read-only)</div><div class="body">
+<table>
+<tr><th>SurfaceType</th><th>Speed</th><th>Audio</th><th>Visual tag</th></tr>
+<tr><td>Dirt</td><td>1.00</td><td>step_dirt</td><td>dust_sprint</td></tr>
+<tr><td>Grass</td><td>0.95</td><td>step_grass</td><td>grass_bend</td></tr>
+<tr><td>Mud</td><td>0.55</td><td>step_mud_squelch</td><td>splash_mud</td></tr>
+<tr><td>Sand</td><td>0.70</td><td>step_sand</td><td>footprint_decal_fade</td></tr>
+<tr><td>Rock</td><td>1.05</td><td>step_rock</td><td>—</td></tr>
+<tr><td>Snow</td><td>0.50</td><td>step_snow_crunch</td><td>footprint_decal_persistent</td></tr>
+<tr><td>ShallowWater</td><td>0.40</td><td>step_water</td><td>splash_water</td></tr>
+<tr><td>DeepWater</td><td>0.25</td><td>swim_stroke</td><td>swim_mode</td></tr>
+<tr><td>LavaCooled</td><td>0.85</td><td>step_rock</td><td>heat_emission</td></tr>
+<tr><td>WheatField</td><td>0.85</td><td>step_wheat_rustle</td><td>wheat_part</td></tr>
+<tr><td>CornField</td><td>0.80</td><td>step_corn_rustle</td><td>corn_part</td></tr>
+<tr><td>Road</td><td>1.10</td><td>step_gravel</td><td>—</td></tr>
+<tr><td>Bridge</td><td>1.10</td><td>step_wood</td><td>—</td></tr>
+</table>
+<div style="margin-top:10px;color:#888;font-size:11px">surface_table.json · v1 · 13 entries</div>
+</div></div>
+<footer>M100.11 — Surface Material System & SurfaceQuery</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.12-CollisionProxySystem.html
+++ b/tickets/M100/visuals/M100.12-CollisionProxySystem.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.12 — Collision Editor</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title">Collision Editor</div><div class="body">
+  <div class="row"><span>Asset</span><span>rock_large_01.glb</span></div>
+  <div class="row"><span>Auto-fit suggested</span><span style="color:#6cf">ConvexHull (28 verts)</span></div>
+  <div class="row"><span>Type</span><div>
+    <span class="radio">Capsule</span> <span class="radio checked">ConvexHull</span> <span class="radio">TriMesh</span>
+  </div></div>
+  <div style="margin:10px 0;color:#888">Capsule fields disabled</div>
+  <div class="row"><span>Vertex count</span><span>28</span></div>
+  <div style="margin-top:8px"><span class="btn">Re-run V-HACD</span> <span class="btn">Edit vertices…</span></div>
+  <div style="margin-top:14px"><span class="btn active">Save .collision.bin</span> <span class="btn danger">Discard</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">V toggles wireframe overlay · placement allows overlap (counter only)</div>
+</div></div>
+<footer>M100.12 — Collision Proxy System</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.13-WaterSurfaces.html
+++ b/tickets/M100/visuals/M100.13-WaterSurfaces.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.13 — Water Surfaces</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title">Inspector — Lake / River</div><div class="body">
+  <div style="margin-bottom:10px"><span class="btn active">Lake</span><span class="btn">River</span></div>
+  <div class="row"><span>Name</span><span>lake_main</span></div>
+  <div class="row"><span>Water level Y</span><span>2.50 m</span></div>
+  <div class="row"><span>Bottom color</span><span style="background:#0d3344;color:#fff;padding:2px 6px">RGB(0.05, 0.20, 0.30)</span></div>
+  <div class="row"><span>Turbidity</span><div class="slider"><div class="fill" style="width:40%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.40</span></div>
+  <div class="row"><span>Polygon vertices</span><span>14</span></div>
+  <div style="margin:8px 0;color:#888;font-size:11px">Click in viewport to add point · Double-click to close</div>
+  <div style="margin:10px 0;color:#888">River-only fields</div>
+  <div class="row"><span>Node count</span><span>—</span></div>
+  <div class="row"><span>Width / depth</span><span>—</span></div>
+  <div class="row"><span>Flow speed</span><span>—</span></div>
+</div></div>
+<footer>M100.13 — Water Surfaces (Lakes & Rivers)</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.16-HazardVolumeSystem.html
+++ b/tickets/M100/visuals/M100.16-HazardVolumeSystem.html
@@ -1,0 +1,21 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.16 — Hazard</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title green">Tool Properties — Hazard</div><div class="body">
+  <div class="row"><span>Type</span><span class="combo">Quicksand</span></div>
+  <div class="row"><span>Shape</span><div><span class="radio">Box</span> <span class="radio checked">Cylinder</span></div></div>
+  <div class="row"><span>Radius</span><span>4.0 m</span></div>
+  <div class="row"><span>Height</span><span>2.0 m</span></div>
+  <div class="row"><span>Sink rate</span><span>0.15 m/s</span></div>
+  <div class="row"><span>Max depth</span><span>1.8 m</span></div>
+  <div class="row"><span>Slowdown ×</span><span>0.10</span></div>
+  <div class="row"><span>Escape</span><div>
+    <span class="radio checked">MashButton (10 in 5s)</span><br>
+    <span class="radio">LateralMove (2 m)</span><br>
+    <span class="radio">MashButton + RequireItem</span><br>
+    <span class="radio">None (drowning)</span>
+  </div></div>
+  <div style="margin-top:10px"><span class="btn active">Apply</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">Lava : kill in 3s, no escape, slowdown × 0</div>
+</div></div>
+<footer>M100.16 — Hazard Volume System</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.17-EasyPlacementTool.html
+++ b/tickets/M100/visuals/M100.17-EasyPlacementTool.html
@@ -1,0 +1,25 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.17 — Placement</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title green">Tool Properties — Placement</div><div class="body">
+  <div class="row"><span>Asset</span><span class="combo">rock_large_03.glb</span></div>
+  <div class="row"><span></span><span style="color:#888;font-size:11px">Tab cycles category</span></div>
+  <div class="row"><span>Mode</span><div>
+    <span class="radio checked">Single</span> <span class="radio">Drag-line</span> <span class="radio">Scatter</span>
+  </div></div>
+  <div class="row"><span>Snap</span><div>
+    <span class="radio checked">Ground</span> <span class="radio">Grid (1m)</span> <span class="radio">Face (Alt)</span>
+  </div></div>
+  <div class="row"><span>Align</span><div>
+    <span class="radio checked">Terrain normal</span> <span class="radio">World up</span>
+  </div></div>
+  <div class="row"><span>Random rot Y</span><span>0..360°</span></div>
+  <div class="row"><span>Random scale</span><span>0.95..1.05</span></div>
+  <div style="margin:8px 0;color:#888">Drag-line</div>
+  <div class="row"><span>Spacing</span><span>2.0 m</span></div>
+  <div style="margin:8px 0;color:#888">Scatter</div>
+  <div class="row"><span>Radius</span><span>5.0 m</span></div>
+  <div class="row"><span>Count</span><span>12</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">G = activate · Wheel = rotation · Ctrl+Wheel = scale · Tab = next asset · Ctrl+Z undo</div>
+</div></div>
+<footer>M100.17 — Easy Placement Tool</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.18-VegetationLibraryAndDensityPainting.html
+++ b/tickets/M100/visuals/M100.18-VegetationLibraryAndDensityPainting.html
@@ -1,0 +1,20 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.18 — Vegetation</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title green">Tool Properties — Foliage Paint</div><div class="body">
+  <div class="row"><span>Active asset</span><span class="combo">grass_01</span></div>
+  <div class="row"><span></span><span style="color:#888;font-size:11px">Tab cycles category</span></div>
+  <div class="row"><span>Brush radius</span><div class="slider"><div class="fill" style="width:60%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">6.0 m</span></div>
+  <div class="row"><span>Density target</span><div class="slider"><div class="fill green" style="width:70%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.7</span></div>
+  <div class="row"><span>Strength</span><div class="slider"><div class="fill amber" style="width:50%"></div></div></div>
+  <div class="row"><span>Falloff</span><div class="slider"><div class="fill" style="width:70%"></div></div></div>
+  <div style="margin:10px 0;color:#888">Rules (from library.json)</div>
+  <div class="row"><span>Slope max</span><span>35°</span></div>
+  <div class="row"><span>Alt min/max</span><span>-200..2500 m</span></div>
+  <div class="row"><span>Splat layers</span><span>1 grass_dry, 2 grass_wet</span></div>
+  <div class="row"><span>Mode</span><div><span class="radio checked">Add density</span> <span class="radio">Erase</span></div></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">F = activate · Poisson-disk min radius applied at commit</div>
+</div></div>
+<footer>M100.18 — Vegetation Library & Density Painting</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.19-ProceduralForestAndFieldTools.html
+++ b/tickets/M100/visuals/M100.19-ProceduralForestAndFieldTools.html
@@ -1,0 +1,26 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.19 — Forest & Field</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;max-width:980px">
+<div class="panel"><div class="title green">Forest Tool</div><div class="body">
+  <div style="color:#888;margin-bottom:8px">Recipe</div>
+  <div class="row three"><span>tree_oak_01</span><div class="slider"><div class="fill" style="width:50%"></div></div><span>0.5 / 0.05/m²</span></div>
+  <div class="row three"><span>tree_pine_02</span><div class="slider"><div class="fill" style="width:30%"></div></div><span>0.3 / 0.04/m²</span></div>
+  <div class="row three"><span>bush_03</span><div class="slider"><div class="fill" style="width:20%"></div></div><span>0.2 / 0.10/m²</span></div>
+  <div class="row"><span>+ Add asset</span><span><span class="btn">+</span></span></div>
+  <div class="row"><span>Polygon</span><span style="color:#888">click to add, double-click to close</span></div>
+  <div class="row"><span>Seed</span><span>42</span></div>
+  <div style="margin-top:10px"><span class="btn active">Generate</span> <span class="btn danger">Cancel</span></div>
+</div></div>
+<div class="panel"><div class="title green">Field Tool</div><div class="body">
+  <div class="row"><span>Crop</span><div><span class="radio checked">Wheat</span> <span class="radio">Corn</span></div></div>
+  <div class="row"><span>Spacing</span><div class="slider"><div class="fill" style="width:40%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.6 m</span></div>
+  <div class="row"><span>Rotation</span><span>12.5°</span></div>
+  <div class="row"><span>Rectangle</span><span style="color:#888">click 2 corners</span></div>
+  <div style="margin:8px 0"><span class="checkbox checked">Auto-tag splat layer → SurfaceType::WheatField</span></div>
+  <div style="margin-top:10px"><span class="btn active">Generate</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">Shift+W = Wheat · Shift+C = Corn · Shift+F = Forest</div>
+</div></div>
+</div>
+<footer>M100.19 — Procedural Forest & Field Tools</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.2-CommandStackUndoRedo.html
+++ b/tickets/M100/visuals/M100.2-CommandStackUndoRedo.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.2 — History</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title">History</div><div class="body">
+  <div style="margin-bottom:8px"><span class="btn">Clear History</span> <span style="color:#888">256 / 256 commands · 31.4 / 256.0 MiB</span></div>
+  <div class="hist-row active"><span>12:03:21</span><span>Sculpt brush stroke</span><span>3.2 MB</span><span>[active]</span></div>
+  <div class="hist-row"><span>12:03:18</span><span>Splat paint stroke</span><span>1.1 MB</span><span></span></div>
+  <div class="hist-row"><span>12:03:12</span><span>Place tree</span><span>4 KB</span><span></span></div>
+  <div class="hist-row"><span>12:03:05</span><span>Stamp Mountain</span><span>7.2 MB</span><span></span></div>
+  <div class="hist-row"><span>12:02:50</span><span>River node</span><span>1 KB</span><span></span></div>
+  <div class="hist-row"><span>12:02:30</span><span>Layer rename</span><span>0 KB</span><span></span></div>
+  <div style="margin-top:10px;color:#888">Ctrl+Z = undo · Ctrl+Shift+Z / Ctrl+Y = redo · Click any row to rewind</div>
+</div></div>
+<footer>M100.2 — Command Stack & Undo/Redo</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.20-VegetationWindAnimation.html
+++ b/tickets/M100/visuals/M100.20-VegetationWindAnimation.html
@@ -1,0 +1,20 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.20 — Wind</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title">Atmosphere → Wind</div><div class="body">
+  <div style="color:#888;margin-bottom:8px">Global Wind</div>
+  <div class="row"><span>Direction</span><div class="slider"><div class="fill" style="width:70%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">azimuth 60°</span></div>
+  <div class="row"><span>Force</span><div class="slider"><div class="fill amber" style="width:40%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">4.0 m/s</span></div>
+  <div class="row"><span>Turbulence freq</span><div class="slider"><div class="fill green" style="width:30%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.2 Hz</span></div>
+  <div class="row"><span>Turbulence amp</span><div class="slider"><div class="fill green" style="width:20%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.5 m</span></div>
+  <div style="color:#888;margin:10px 0">Wave on cultivated fields</div>
+  <div class="row"><span>Wave speed</span><span>3.0 m/s</span></div>
+  <div class="row"><span>Wave length</span><span>6.0 m</span></div>
+  <div class="row"><span>Wave amplitude</span><span>0.3</span></div>
+  <div style="margin-top:12px"><span class="btn">+ Local wind zone</span></div>
+</div></div>
+<footer>M100.20 — Vegetation Wind Animation</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.22-VolumetricFogVolumes.html
+++ b/tickets/M100/visuals/M100.22-VolumetricFogVolumes.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.22 — Fog Volume</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:460px"><div class="title green">Tool Properties — Volumetric Fog Volume</div><div class="body">
+  <div class="row"><span>Shape</span><div><span class="radio checked">Box</span> <span class="radio">Ellipsoid</span></div></div>
+  <div class="row"><span>Position</span><span>(-10.0, 1.0, -3.0)</span></div>
+  <div class="row"><span>Size</span><span>(12.0, 4.0, 8.0)</span></div>
+  <div class="row"><span>Rotation Y</span><span>0°</span></div>
+  <div class="row"><span>Density</span><div class="slider"><div class="fill" style="width:30%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.05</span></div>
+  <div class="row"><span>Color</span><span style="background:#b3bfd9;color:#000;padding:2px 6px">RGB(0.7, 0.75, 0.85)</span></div>
+  <div class="row"><span>Anisotropy g</span><div class="slider"><div class="fill" style="width:50%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.0 (-1..1)</span></div>
+  <div style="margin-top:10px"><span class="btn active">Apply</span></div>
+</div></div>
+<footer>M100.22 — Volumetric Fog Volumes</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.23-DistanceFogAndHeightFogTuning.html
+++ b/tickets/M100/visuals/M100.23-DistanceFogAndHeightFogTuning.html
@@ -1,0 +1,21 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.23 — Atmosphere Fog</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:560px"><div class="title">Atmosphere — Fog (3 layers)</div><div class="body">
+  <div style="color:#888;margin-bottom:8px">Distance Fog</div>
+  <div class="row"><span>Density</span><div class="slider"><div class="fill" style="width:30%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.0035</span></div>
+  <div class="row"><span>Color</span><span style="background:#9eb3c8;color:#000;padding:2px 6px">RGB(0.62, 0.70, 0.78)</span></div>
+  <div class="row"><span>Start (m)</span><span>150</span></div>
+  <div class="row"><span>Falloff</span><span>0.6</span></div>
+  <div style="color:#888;margin:10px 0">Height Fog</div>
+  <div class="row"><span>Density at Y=0</span><span>0.18</span></div>
+  <div class="row"><span>Falloff (1/m)</span><span>0.25</span></div>
+  <div class="row"><span>Base Y</span><span>3.0 m</span></div>
+  <div class="row"><span>Color</span><span style="background:#73879e;color:#fff;padding:2px 6px">RGB(0.45, 0.55, 0.62)</span></div>
+  <div style="color:#888;margin:10px 0">Volumes 3D</div>
+  <div class="row"><span>Active volumes</span><span>4</span></div>
+  <div style="margin:10px 0;height:80px;background:linear-gradient(90deg,#1e1e1e,#5076a0);border:1px solid #333;display:flex;align-items:center;justify-content:center;color:#cdcdcd;font-size:11px">density vs depth (preview chart)</div>
+  <div style="margin-top:10px"><span class="btn">+ Override per zone</span></div>
+</div></div>
+<footer>M100.23 — Distance Fog & Height Fog Tuning</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.24-SunSkyAndProbesEditor.html
+++ b/tickets/M100/visuals/M100.24-SunSkyAndProbesEditor.html
@@ -1,0 +1,25 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.24 — Sun & Sky</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:580px"><div class="title">Sun & Sky</div><div class="body">
+  <div class="row"><span>Day-of-year</span><span>120 / 360</span></div>
+  <div class="row"><span>Time-of-day</span><span>14.5</span></div>
+  <div class="row"><span>Sun azimuth</span><span>168°</span></div>
+  <div class="row"><span>Sun elevation</span><span>62° (auto)</span></div>
+  <div class="row"><span>Sun color</span><span style="background:#ffe0b3;color:#000;padding:2px 6px">RGB(1.0, 0.95, 0.88)</span></div>
+  <div class="row"><span>Sun intensity</span><span>90 000 lux</span></div>
+  <div class="row"><span>Ambient color</span><span style="background:#8c9bb3;color:#fff;padding:2px 6px">RGB(0.55, 0.62, 0.72)</span></div>
+  <div class="row"><span>Ambient lux</span><span>3 200</span></div>
+  <div style="margin:10px 0;color:#888">ToD × ToY curve (24 × 4)</div>
+  <table style="font-size:11px">
+    <tr><th>ToD</th><th>Spring</th><th>Summer</th><th>Autumn</th><th>Winter</th></tr>
+    <tr><td>06</td><td>amber</td><td>warm</td><td>amber</td><td>cool</td></tr>
+    <tr><td>14</td><td>warm</td><td><b>active</b></td><td>warm</td><td>warm</td></tr>
+    <tr><td>20</td><td>orange</td><td>orange</td><td>orange</td><td>blue</td></tr>
+    <tr><td>02</td><td>blue</td><td>blue</td><td>blue</td><td>cold</td></tr>
+  </table>
+  <div style="margin:12px 0;color:#888">Probes</div>
+  <div class="row"><span>Active probes</span><span>12</span></div>
+  <div><span class="btn">Place probe</span> <span class="btn active">Bake all</span> <span class="btn">Show overlay</span></div>
+</div></div>
+<footer>M100.24 — Sun, Sky & Probes Editor</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.25-SeasonSystemAndTimeOfYear.html
+++ b/tickets/M100/visuals/M100.25-SeasonSystemAndTimeOfYear.html
@@ -1,0 +1,19 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.25 — Season</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title">Atmosphere → Season</div><div class="body">
+  <div class="row"><span>Current season</span><span style="color:#d90">Summer</span></div>
+  <div class="row"><span>Day in season</span><span>4 / 7</span></div>
+  <div class="row"><span>Blend to next</span><span>0.0 (Autumn)</span></div>
+  <div style="margin:14px 0;background:#2a2a2a;padding:10px;border:1px solid #444">
+    <span style="color:#6c6">Spring</span> ─
+    <span style="color:#d90;font-weight:bold">●Summer●</span> ─
+    <span style="color:#a60">Autumn</span> ─
+    <span style="color:#6cf">Winter</span>
+  </div>
+  <div style="margin:8px 0"><span class="btn">Apply preview</span> <span class="btn">Reset to live</span></div>
+  <div style="margin-top:14px;color:#888;font-size:11px">
+    Server broadcasts SeasonBroadcast every 60s · client-only effects · no server-side simulation
+  </div>
+</div></div>
+<footer>M100.25 — Season System & Time-of-Year</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.26-WeatherSystemAndDynamicSurfaceModifiers.html
+++ b/tickets/M100/visuals/M100.26-WeatherSystemAndDynamicSurfaceModifiers.html
@@ -1,0 +1,25 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.26 — Weather</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;max-width:980px">
+<div class="panel"><div class="title">Weather Preview</div><div class="body">
+  <div class="row"><span>Current</span><span>Rain</span></div>
+  <div class="row"><span>Blend to</span><span>Storm (blendT 0.3)</span></div>
+  <div style="margin:14px 0;background:#2a2a2a;padding:10px;border:1px solid #444">
+    Clear ─ <b>Rain</b> ─●─ Storm ─ Snow ─ Drought ─ Fog
+  </div>
+  <div><span class="btn">Apply preview</span> <span class="btn">Reset to live</span></div>
+</div></div>
+<div class="panel"><div class="title">Weather Timeline</div><div class="body">
+  <div class="row"><span>Scenario</span><span class="combo">default</span></div>
+  <table style="font-size:11px">
+    <tr><th></th><th>Clear</th><th>Rain</th><th>Storm</th><th>Snow</th><th>Drought</th><th>Fog</th></tr>
+    <tr><td>Spring</td><td>55%</td><td>25%</td><td>8%</td><td>0%</td><td>2%</td><td>10%</td></tr>
+    <tr><td>Summer</td><td>70%</td><td>8%</td><td>10%</td><td>0%</td><td>10%</td><td>2%</td></tr>
+    <tr><td>Autumn</td><td>45%</td><td>28%</td><td>12%</td><td>0%</td><td>2%</td><td>13%</td></tr>
+    <tr><td>Winter</td><td>30%</td><td>8%</td><td>12%</td><td>35%</td><td>0%</td><td>15%</td></tr>
+  </table>
+  <div style="margin-top:10px;color:#888;font-size:11px">Server broadcasts WeatherBroadcast every 30s · modifiers computed client-side</div>
+</div></div>
+</div>
+<footer>M100.26 — Weather System & Dynamic Surface Modifiers</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.27-ShadeMapAndThermalMap.html
+++ b/tickets/M100/visuals/M100.27-ShadeMapAndThermalMap.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.27 — Thermal Debug</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:560px"><div class="title">Thermal Debug</div><div class="body">
+  <div class="row"><span>Display</span><span class="checkbox checked">Heatmap overlay</span></div>
+  <div class="row"><span>Time of day</span><span>14.0</span></div>
+  <div class="row"><span>Season</span><span class="combo">Summer</span></div>
+  <div class="row"><span>Weather</span><span class="combo">Clear</span></div>
+  <div style="margin:10px 0;height:140px;background:linear-gradient(90deg,#3060a0,#80c060,#d09040,#d04040);border:1px solid #444;display:flex;align-items:center;justify-content:center;color:#fff">
+    Heatmap (cold → hot)
+  </div>
+  <div class="row"><span>Sample at cursor</span><span style="color:#d90">28.4 °C</span></div>
+  <div class="row"><span>Min / Max</span><span>12.1 °C / 32.8 °C</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">
+    Shade map baked at export · Thermal recomputed on season/weather change
+  </div>
+</div></div>
+<footer>M100.27 — Shade Map & Thermal Map</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.28-GameplayZonesAndWeatherZones.html
+++ b/tickets/M100/visuals/M100.28-GameplayZonesAndWeatherZones.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.28 — Zones</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title green">Tool Properties — Zone</div><div class="body">
+  <div class="row"><span>Type</span><span class="combo">WeatherOverride</span></div>
+  <div class="row"><span>Name</span><span>storm_pocket_west</span></div>
+  <div class="row"><span>Polygon</span><span style="color:#888">click points, double-click to close</span></div>
+  <div style="margin:10px 0;color:#888">If WeatherOverride</div>
+  <div class="row"><span>Override weather</span><span class="combo">Rain</span></div>
+  <div class="row"><span>BlendT</span><div class="slider"><div class="fill amber" style="width:40%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.4</span></div>
+  <div class="row"><span>Transition margin</span><span>5.0 m</span></div>
+  <div style="margin:10px 0;color:#888">Other types: SafeZone · PvPZone · RaidZone · NoBuild · QuestTrigger</div>
+  <div style="margin-top:10px"><span class="btn active">Apply</span></div>
+</div></div>
+<footer>M100.28 — Gameplay Zones & Weather Zones</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.29-SplineToolAndRoads.html
+++ b/tickets/M100/visuals/M100.29-SplineToolAndRoads.html
@@ -1,0 +1,23 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.29 — Spline / Road</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title green">Tool Properties — Spline / Road</div><div class="body">
+  <div class="row"><span>Type</span><span class="combo">Road</span></div>
+  <div class="row"><span>Curve</span><div><span class="radio checked">Catmull-Rom</span> <span class="radio">Bezier</span></div></div>
+  <div class="row"><span>Closed</span><span class="checkbox">Closed loop</span></div>
+  <div style="margin:10px 0;color:#888">Points</div>
+  <table style="font-size:11px">
+    <tr><th>#</th><th>Position</th><th>Width</th></tr>
+    <tr><td>0</td><td>(12.0, 4.5, -3.2)</td><td>6.0 m</td></tr>
+    <tr><td>1</td><td>(24.0, 5.2, -8.1)</td><td>6.0 m</td></tr>
+    <tr><td>2</td><td>(35.5, 6.0, -14.7)</td><td>5.5 m</td></tr>
+    <tr><td>3</td><td>(48.1, 5.4, -19.0)</td><td>6.0 m</td></tr>
+  </table>
+  <div style="margin:10px 0;color:#888">Splat under road</div>
+  <div class="row"><span>Layer</span><span class="combo">gravel</span></div>
+  <div class="row"><span>Strength</span><span>1.0</span></div>
+  <div class="row"><span>Feather</span><span>0.5 m</span></div>
+  <div style="margin-top:10px"><span class="btn active">Apply</span> <span class="btn danger">Cancel preview</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">L = activate · click adds point · double-click closes · F=focus</div>
+</div></div>
+<footer>M100.29 — Spline Tool & Roads</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.30-BridgesAndModularWalls.html
+++ b/tickets/M100/visuals/M100.30-BridgesAndModularWalls.html
@@ -1,0 +1,22 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.30 — Bridges & Walls</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;max-width:980px">
+<div class="panel"><div class="title green">Bridge Tool</div><div class="body">
+  <div class="row"><span>Source spline</span><span class="combo">spline_017</span></div>
+  <div class="row"><span>Kit</span><span class="combo">stone_bridge_kit</span></div>
+  <div class="row"><span>Segment length</span><span>4.0 m</span></div>
+  <div class="row"><span>Y mode</span><div><span class="radio checked">Constant (waterLevel + 1.0)</span><br><span class="radio">Spline Y</span></div></div>
+  <div class="row"><span>Width</span><span>6.0 m</span></div>
+  <div style="margin-top:10px"><span class="btn active">Generate</span></div>
+</div></div>
+<div class="panel"><div class="title green">Wall Tool</div><div class="body">
+  <div class="row"><span>Source spline</span><span class="combo">spline_021</span></div>
+  <div class="row"><span>Kit</span><span class="combo">palissade_kit</span></div>
+  <div class="row"><span>Segment length</span><span>2.0 m</span></div>
+  <div class="row"><span>Height</span><span>3.5 m</span></div>
+  <div class="row"><span>Post spacing</span><span>4.0 m</span></div>
+  <div style="margin-top:10px"><span class="btn active">Generate</span></div>
+</div></div>
+</div>
+<footer>M100.30 — Bridges & Modular Walls</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.31-HamletGenerator.html
+++ b/tickets/M100/visuals/M100.31-HamletGenerator.html
@@ -1,0 +1,17 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.31 — Hamlet</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title green">Hamlet Generator</div><div class="body">
+  <div class="row"><span>Kit</span><span class="combo">human_village_kit_01</span></div>
+  <div class="row"><span>House count</span><span>12</span></div>
+  <div class="row"><span>Min spacing</span><span>8.0 m</span></div>
+  <div class="row"><span>Snap to road</span><span class="checkbox checked">enabled</span></div>
+  <div class="row"><span>Orient toward</span><div><span class="radio checked">Nearest road</span> <span class="radio">Centroid</span></div></div>
+  <div class="row"><span>Seed</span><span>42</span></div>
+  <div class="row"><span>Polygon</span><span style="color:#888">click points, double-click to close</span></div>
+  <div style="margin-top:10px"><span class="btn active">Generate</span> <span class="btn danger">Cancel</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">
+    Slope &lt; 15° required · candidates filtered · single Ctrl+Z reverts whole hamlet
+  </div>
+</div></div>
+<footer>M100.31 — Hamlet Generator</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.32-InteractiveProps.html
+++ b/tickets/M100/visuals/M100.32-InteractiveProps.html
@@ -1,0 +1,19 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.32 — Interactive Props</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:520px"><div class="title green">Interactive Props</div><div class="body">
+  <div class="row"><span>Type</span><span class="combo">DoorHinge</span></div>
+  <div style="color:#888;font-size:11px;margin-bottom:8px">DoorHinge · DoorSliding · WindowHinge · Trapdoor · ChestSimple (closed enum)</div>
+  <div class="row"><span>Pivot local</span><span>(-0.40, 0.0, 0.0)</span></div>
+  <div class="row"><span>Axis local</span><span>(0, 1, 0)</span></div>
+  <div class="row"><span>Open angle</span><span>90°</span></div>
+  <div class="row"><span>Anim duration</span><span>0.5 s</span></div>
+  <div class="row"><span>Initial state</span><div><span class="radio checked">Closed</span> <span class="radio">Opened</span></div></div>
+  <div class="row"><span>Audio open</span><span class="combo">door_creak_open</span></div>
+  <div class="row"><span>Audio close</span><span class="combo">door_thud_close</span></div>
+  <div style="margin-top:12px"><span class="btn active">Trigger (live test)</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">
+    Animation client local · master relays InteractiveStateChange · no gameplay validation server-side
+  </div>
+</div></div>
+<footer>M100.32 — Interactive Props (Doors, Windows, Trapdoors, Simple Chests)</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.33-FootstepAudioAndPlaytestMode.html
+++ b/tickets/M100/visuals/M100.33-FootstepAudioAndPlaytestMode.html
@@ -1,0 +1,21 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.33 — Playtest HUD</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:560px"><div class="title amber">Playtest Mode (F5) — Debug HUD</div>
+  <div class="viewport" style="height:340px">
+    <div class="hud" style="left:12px;right:auto;font-size:12px;line-height:1.7">
+      Speed         : 4.30 m/s<br>
+      Surface       : Grass (modifiers: wet)<br>
+      Slippery      : false<br>
+      Temperature   : 18.4 °C<br>
+      Season        : Autumn (blendT 0.0)<br>
+      Weather       : Rain<br>
+      Hazards       : (none)
+    </div>
+    Production camera + production CharacterController
+  </div>
+  <div style="padding:10px;color:#888;font-size:11px">
+    F5 toggles · uses production code (no separate simulation) · solo, no network · Ctrl+Z does NOT apply during playtest
+  </div>
+</div>
+<footer>M100.33 — Footstep Audio Surface Hook & Playtest Mode (F5)</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.34-SelectionLayersMinimapSaveLoadZone.html
+++ b/tickets/M100/visuals/M100.34-SelectionLayersMinimapSaveLoadZone.html
@@ -1,0 +1,46 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.34 — Selection / Layers / Minimap / Save</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;max-width:980px">
+<div class="panel"><div class="title pink">Outliner — Layers</div><div class="body" style="font-size:12px">
+  ▼ Layer Default <span style="color:#6cf">[👁]</span> <span style="color:#888">[🔒]</span><br>
+  &nbsp;&nbsp;&nbsp;└── prop rock_01.glb <span style="color:#888">(id=42)</span><br>
+  &nbsp;&nbsp;&nbsp;└── prop tree_oak <span style="color:#888">(id=43)</span><br>
+  ▼ Layer Buildings <span style="color:#6cf">[👁]</span> <span style="color:#888">[🔒]</span><br>
+  &nbsp;&nbsp;&nbsp;└── prop house_01.glb <span style="color:#888">(id=51)</span><br>
+  ▶ Layer Hidden <span style="color:#888">[ ⊘ ]</span> <span style="color:#f88">[🔒]</span>
+</div></div>
+<div class="panel"><div class="title blue">Minimap</div><div class="body">
+  <pre style="font-family:monospace;font-size:14px;color:#cdcdcd;line-height:1">
++---------------------------+
+|     ░ ░ ▓ ▓ ░             |
+|     ░ █ ░ ░ ░             |
+|     ░ ░ ░ ▓ ▓             |
+|       ●                   |
++---------------------------+
+  </pre>
+  <div style="color:#888;font-size:11px">█ current chunk · ▓ visible · ● camera</div>
+</div></div>
+</div>
+
+<div class="panel" style="max-width:980px;margin-top:12px"><div class="title green">Save Zone As…</div><div class="body">
+  <div class="row"><span>Output dir</span><span>build/zone_main/</span></div>
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:10px 0">
+    <span class="checkbox checked">Terrain (terrain.bin + terrain_lods.bin)</span>
+    <span class="checkbox checked">Splat (splat.bin)</span>
+    <span class="checkbox checked">Props (instances/props.bin)</span>
+    <span class="checkbox checked">Foliage (instances/foliage.bin)</span>
+    <span class="checkbox checked">Hazards (instances/hazards.bin)</span>
+    <span class="checkbox checked">Interactives (instances/interactives.bin)</span>
+    <span class="checkbox checked">Zones (instances/zones.bin)</span>
+    <span class="checkbox checked">Water (instances/water.bin)</span>
+    <span class="checkbox checked">Fog volumes (instances/fog_volumes.bin)</span>
+    <span class="checkbox checked">Atmosphere zones</span>
+    <span class="checkbox checked">Splines (instances/splines.bin)</span>
+    <span class="checkbox checked">Shade maps (chunks/.../shade.bin)</span>
+    <span class="checkbox checked">Collision proxies (per-asset)</span>
+    <span class="checkbox checked">zone.meta + atmosphere.json + probes.bin</span>
+  </div>
+  <div style="margin-top:10px"><span class="btn active">Save Zone</span></div>
+</div></div>
+<footer>M100.34 — Selection, Layers, Minimap & Save/Load Zone</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.4-EditorCameraModes.html
+++ b/tickets/M100/visuals/M100.4-EditorCameraModes.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.4 — Camera Modes</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:780px"><div class="title">Scene viewport — camera</div>
+  <div class="viewport" style="height:380px">
+    <div class="toolbar"><span class="btn">FPS</span><span class="btn active">Orbital</span><span class="btn">Top</span></div>
+    <div class="hud">Mode: Orbital<br>Focus: (12.0, 4.5, -3.2)<br>Speed: 1.0×<br>Distance: 18.4 m</div>
+    <div style="position:absolute;bottom:10px;left:10px;color:#888;font-size:11px">
+      Numpad 1 = FPS · Numpad 3 = Orbital · Numpad 7 = Top · F = Focus selection · Shift × 3 · Ctrl × 0.25
+    </div>
+    Orbital around focus
+  </div>
+</div>
+<footer>M100.4 — Editor Camera Modes</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.5-HeightmapDataStructure.html
+++ b/tickets/M100/visuals/M100.5-HeightmapDataStructure.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.5 — Heightmap Inspector</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:480px"><div class="title">Inspector — Terrain Chunk</div><div class="body">
+  <div class="row"><span>Chunk coord</span><span>(5, -3)</span></div>
+  <div class="row"><span>Resolution</span><span>257 × 257</span></div>
+  <div class="row"><span>Cell size</span><span>1.00 m</span></div>
+  <div class="row"><span>Height min</span><span>-3.42 m</span></div>
+  <div class="row"><span>Height max</span><span>18.71 m</span></div>
+  <div class="row"><span>Storage</span><span>264 244 bytes</span></div>
+  <div class="row"><span>Magic / Version</span><span>TRRN / v1</span></div>
+  <div style="margin-top:10px"><span class="btn">Reload from disk</span></div>
+</div></div>
+<footer>M100.5 — Heightmap Data Structure</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.6-TerrainSculptingBrushes.html
+++ b/tickets/M100/visuals/M100.6-TerrainSculptingBrushes.html
@@ -1,0 +1,19 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.6 — Terrain Sculpt</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:420px"><div class="title green">Tool Properties — Terrain Sculpt</div><div class="body">
+  <div style="margin-bottom:10px">
+    <span class="btn active">Raise</span><span class="btn">Lower</span><span class="btn">Smooth</span><span class="btn">Flatten</span><span class="btn">Noise</span>
+  </div>
+  <div class="row"><span>Radius</span><div class="slider"><div class="fill" style="width:60%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">6.0 m</span></div>
+  <div class="row"><span>Strength</span><div class="slider"><div class="fill amber" style="width:30%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">3.0 m/s</span></div>
+  <div class="row"><span>Falloff</span><div class="slider"><div class="fill" style="width:70%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">0.7</span></div>
+  <div class="row"><span>Noise freq</span><div class="slider"><div class="fill green" style="width:20%"></div></div></div>
+  <div class="row"><span>Noise octaves</span><span>3</span></div>
+  <div style="margin-top:10px"><span class="checkbox">Mirror X</span> &nbsp; <span class="checkbox">Mirror Z</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">B = activate · hold mouse to sculpt · Ctrl+Z to undo stroke</div>
+</div></div>
+<footer>M100.6 — Terrain Sculpting Brushes</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.7-TerrainStampsAndProceduralGenerators.html
+++ b/tickets/M100/visuals/M100.7-TerrainStampsAndProceduralGenerators.html
@@ -1,0 +1,20 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.7 — Stamps</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:440px"><div class="title green">Tool Properties — Terrain Stamp</div><div class="body">
+  <div class="row"><span>Stamp source</span><div>
+    <span class="radio">Library</span> <span class="combo">mountain.png</span><br>
+    <span class="radio checked">Procedural</span> <span class="btn active">Mountain</span><span class="btn">Valley</span><span class="btn">Crater</span>
+  </div></div>
+  <div class="row"><span>Footprint</span><div class="slider"><div class="fill" style="width:75%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">120 m</span></div>
+  <div class="row"><span>Strength</span><div class="slider"><div class="fill amber" style="width:60%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">60 m</span></div>
+  <div class="row"><span>Rotation Y</span><div class="slider"><div class="fill" style="width:13%"></div></div></div>
+  <div class="row"><span></span><span style="font-size:11px;color:#888">45°</span></div>
+  <div class="row"><span>Mode</span><div>
+    <span class="radio checked">Add</span> <span class="radio">Replace</span> <span class="radio">Max</span> <span class="radio">Min</span>
+  </div></div>
+  <div style="margin-top:10px"><span class="btn active">Apply</span><span class="btn danger">Cancel preview</span></div>
+</div></div>
+<footer>M100.7 — Terrain Stamps & Procedural Generators</footer>
+</body></html>

--- a/tickets/M100/visuals/M100.9-SplatMapSystem.html
+++ b/tickets/M100/visuals/M100.9-SplatMapSystem.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><title>M100.9 — Splat Map</title>
+<link rel="stylesheet" href="_style.css"></head><body>
+<div class="panel" style="max-width:460px"><div class="title">Inspector — Splat Layers</div><div class="body">
+  <div style="margin-bottom:10px;color:#888">Active layers: 1 / 8</div>
+  <div class="row"><span class="checkbox checked">0 dirt</span><span style="color:#888">100.0 %</span></div>
+  <div class="row"><span class="checkbox">1 grass_dry</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">2 grass_wet</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">3 mud</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">4 sand</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">5 rock</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">6 snow</span><span style="color:#888">0.0 %</span></div>
+  <div class="row"><span class="checkbox">7 lava_cooled</span><span style="color:#888">0.0 %</span></div>
+  <div style="margin-top:10px;color:#888;font-size:11px">splat.bin · 257×257 · 8 layers · sum = 255 per cell</div>
+</div></div>
+<footer>M100.9 — Splat Map System</footer>
+</body></html>

--- a/tickets/M100/visuals/_style.css
+++ b/tickets/M100/visuals/_style.css
@@ -1,0 +1,91 @@
+/* Shared style for M100 visual mockups (ImGui dark, monospace).
+   Each HTML file inlines this via <link> or duplicates the relevant block. */
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 24px;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', monospace;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.shell { display: grid; gap: 12px; }
+.menubar {
+  background: #2b2b2b; border: 1px solid #3a3a3a; padding: 6px 12px;
+  display: flex; gap: 18px;
+}
+.menubar .item { color: #cdcdcd; cursor: default; }
+.menubar .item:hover { color: #fff; }
+
+.dock { display: grid; grid-template-columns: 240px 1fr 320px; gap: 12px; min-height: 580px; }
+.dock-bottom { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+
+.panel {
+  background: #252526; border: 1px solid #3a3a3a; border-radius: 2px;
+  display: flex; flex-direction: column;
+}
+.panel .title {
+  background: #2d2d30; padding: 6px 10px; border-bottom: 1px solid #3a3a3a;
+  color: #f0a; font-weight: bold; letter-spacing: 0.5px;
+}
+.panel .title.pink   { color: #d6a; }
+.panel .title.blue   { color: #6cf; }
+.panel .title.green  { color: #6c6; }
+.panel .title.amber  { color: #d90; }
+.panel .body { padding: 10px; flex: 1; overflow: auto; }
+
+.row { display: grid; grid-template-columns: 130px 1fr; gap: 10px; align-items: center; margin-bottom: 6px; }
+.row.three { grid-template-columns: 130px 1fr auto; }
+
+.slider {
+  background: #3a3a3a; height: 8px; position: relative; border-radius: 1px;
+}
+.slider .fill { background: #4080d0; height: 100%; }
+.slider .fill.amber { background: #d09040; }
+.slider .fill.green { background: #40a060; }
+
+.btn {
+  display: inline-block; padding: 4px 10px; background: #3a3a3a;
+  border: 1px solid #555; color: #ddd; cursor: pointer; margin-right: 6px;
+}
+.btn.active { background: #4080d0; color: #fff; border-color: #5090e0; }
+.btn.danger { color: #f88; }
+.btn:hover  { background: #444; }
+
+.checkbox::before { content: "[ ]"; color: #888; margin-right: 6px; }
+.checkbox.checked::before { content: "[✓]"; color: #6cf; }
+
+.radio::before { content: "( )"; color: #888; margin-right: 6px; }
+.radio.checked::before { content: "(•)"; color: #6cf; }
+
+table { border-collapse: collapse; width: 100%; }
+table td, table th { border-bottom: 1px solid #333; padding: 4px 8px; text-align: left; }
+table th { color: #6cf; }
+
+.viewport {
+  background: linear-gradient(180deg, #2c3540, #1a1f25);
+  display: flex; align-items: center; justify-content: center;
+  color: #555; font-style: italic; min-height: 360px;
+  position: relative;
+}
+.viewport .toolbar {
+  position: absolute; top: 8px; left: 8px;
+  background: rgba(0,0,0,0.5); padding: 4px 8px; display: flex; gap: 6px;
+}
+.viewport .hud {
+  position: absolute; top: 8px; right: 8px; background: rgba(0,0,0,0.6);
+  padding: 6px 10px; font-size: 11px; color: #cdcdcd;
+}
+
+.combo {
+  background: #2b2b2b; border: 1px solid #555; padding: 2px 8px;
+  display: inline-block; min-width: 140px;
+}
+.combo::after { content: " ▼"; color: #888; float: right; }
+
+.hist-row { display: grid; grid-template-columns: 90px 1fr 80px 60px; gap: 8px; padding: 3px 0; border-bottom: 1px dotted #333; }
+.hist-row.active { background: #2a3a4a; color: #fff; }
+
+footer { margin-top: 14px; color: #666; font-size: 11px; text-align: center; }


### PR DESCRIPTION
## Summary

Génère **`tickets/M100/INDEX.md`** + **34 tickets `M100.1..M100.34`** + **29 maquettes HTML** sous `tickets/M100/visuals/`. Aucun code C++ produit — l'objectif est uniquement la spécification.

Le cluster M100 est **distinct de M43**. Numérotation continue à partir de 1.

## Architecture imposée par les tickets

| Couche | Rôle | Restriction |
|--------|------|-------------|
| **Client** (`engine_core` + Vulkan) | Tout le rendu, toute la simulation gameplay locale, lecture des chunk packages. | — |
| **Éditeur** (`world_editor_app`, `--editor-world`) | Création/modification de la carte, écriture chunk packages, mode Playtest F5 utilisant **le code client de prod**. | Pas de pipeline séparé. Pas de format "preview". Pas de logique gameplay propriétaire. |
| **Serveur** (`server_app`) | Auth + relais des messages (positions, actions, broadcasts saison/météo, état objets interactifs). | **Aucune simulation environnementale.** Pas de SurfaceQuery, pas de Thermal, pas de Weather modifiers, pas de Hazards. |

**Contrat de parité éditeur ↔ client** : tout fichier écrit par l'éditeur (`terrain.bin`, `splat.bin`, `instances/*.bin`, `shade.bin`, `*.collision.bin`, `atmosphere.json`) est lu par le client en jeu normal sans branche conditionnelle. Tests round-trip systématiques par ticket.

## Découpage en phases (34 tickets)

- **Phase 1 — Fondations** (M100.1–4) : shell ImGui dédié, Command stack undo/redo, extraction `zone_builder_lib` (anti-duplication éditeur/offline), modes caméra.
- **Phase 2 — Terrain** (M100.5–8) : `TerrainChunk` 257×257, sculpting 5 brosses, stamps PNG + 3 générateurs procéduraux, LODs background.
- **Phase 3 — Splat / Surfaces / Collision** (M100.9–12) : splat-map 8 couches (invariant somme=255), peinture brosses + auto-rules, **`SurfaceType`/`SurfaceQuery` côté client**, proxies de collision (capsule/convex/trimesh, V-HACD auto-fit).
- **Phase 4 — Hydrologie & Hazards** (M100.13–16) : lacs/rivières (Delaunay/ribbon), passe `Water`, hook nage avec hystérésis, hazards volumétriques (Quicksand/Bog/Tar/Lava) avec mécaniques d'évasion.
- **Phase 5 — Placement & Végétation** (M100.17–21) : `PlacementTool` ≤ 3 clics (ghost preview < 5 ms), bibliothèque 12 catégories, forêts/champs procéduraux, vent global+local, **interaction joueur ↔ végétation < 0.5 ms sur 100k instances**.
- **Phase 6 — Atmosphère & Brouillard** (M100.22–24) : volumes 3D froxel grid, distance/height fog avec override par zone, sun/sky courbe ToD × ToY (24×4) + probes IBL.
- **Phase 7 — Saisons / Météo / Thermal** (M100.25–28) : `SeasonClock` + **broadcast `SeasonBroadcast`** (60 s), `WeatherSystem` 6 types + modifiers + **broadcast `WeatherBroadcast`** (30 s), shade map à l'export + thermal map dynamique client + `ThermalQuery`, gameplay zones (6 types incluant WeatherOverride).
- **Phase 8 — Routes / Ponts / Structures** (M100.29–31) : splines Catmull-Rom + tag `SurfaceType::Road`, ponts/murs modulaires + tag `Bridge`, hameaux procéduraux par kit (8 races).
- **Phase 9 — Objets interactifs** (M100.32) : **enum strictement borné** (DoorHinge, DoorSliding, WindowHinge, Trapdoor, ChestSimple) + **protocole `InteractiveStateChange`** (relais master sans validation gameplay) + sync initial à la connexion.
- **Phase 10 — Polissage final** (M100.33–34) : audio de pas par `(SurfaceType, SurfaceModifiers)`, **mode Playtest F5** utilisant `engine::gameplay::CharacterController` non modifié, sélection rect/lasso, calques, minimap, **export complet de zone** avec test round-trip end-to-end.

## Format des tickets

Chaque ticket suit la même structure :
1. Titre + résumé (3 phrases)
2. Dépendances explicites
3. Portée (inclus / hors scope)
4. Spec fonctionnelle (raccourcis, panneaux, paramètres)
5. Spec technique (fichiers à créer/modifier en chemins exacts, structures C++, formats binaires/JSON, passes frame graph, shaders GLSL, **code client/éditeur qui lit/écrit, test de parité round-trip si données chunk**, protocoles réseau si applicable)
6. Diff CMake `before` / `after`
7. Schéma d'interaction utilisateur
8. Critères d'acceptation booléens (incluant la parité)
9. Tests unitaires (chemin + cas)
10. Hors scope explicite
11. Mention déploiement (✅ ou ⚠️)

Les fichiers C++/shaders sont décrits **complets** (pas de patch unifié). Seul `CMakeLists.txt` est en `before/after`.

## Test plan

- [ ] Vérifier que `tickets/M100/INDEX.md` liste les 34 tickets avec dépendances, ordre d'implémentation et risques techniques.
- [ ] Vérifier la cohérence cross-tickets des contrats partagés : `TerrainChunk`, `SurfaceType`, `SurfaceModifiers`, magic/version des formats binaires.
- [ ] Vérifier que **aucun ticket** ne référence un ticket non listé en dépendance.
- [ ] Vérifier que **aucune simulation environnementale** n'est attribuée au serveur (uniquement relais des 3 nouveaux opcodes).
- [ ] Vérifier que **aucun ticket** ne dépasse le périmètre déclaré pour les objets interactifs.
- [ ] Ouvrir les 29 fichiers HTML sous `tickets/M100/visuals/` pour vérifier la lisibilité des maquettes.
- [ ] Confirmer la numérotation continue M100.1..M100.34 sans trou.

## Déploiement

> **Déploiement** : ⚠️ **redéploiement serveur (master) requis** au moment de l'implémentation des tickets **M100.25** (`SeasonBroadcast`), **M100.26** (`WeatherBroadcast`), **M100.32** (`InteractiveStateChange*`). Les 31 autres tickets sont client/éditeur uniquement. Cette PR (tickets uniquement) n'introduit **aucun** changement runtime — pas de redéploiement nécessaire pour le merge.

https://claude.ai/code/session_01AftNfiojBMjYUXaux2nS2c


---
_Generated by [Claude Code](https://claude.ai/code/session_01AftNfiojBMjYUXaux2nS2c)_