### PR TITLE
feat(log): port des features cmangos manquantes au logger serveur (M45)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ add_library(engine_core
   engine/core/Profiler.cpp
   engine/core/jobs/JobSystem.cpp
   engine/core/Log.cpp
+  engine/core/LogConfig.cpp
   engine/core/Time.cpp
   engine/audio/AudioEngine.cpp
   engine/audio/MaMenuMusic.cpp

--- a/config.json
+++ b/config.json
@@ -1,10 +1,45 @@
 {
     "log": {
         "level": "Info",
+        "_comment_file_level": "M45 — Seuil distinct pour le fichier (peut etre plus permissif que la console). Vide = suit log.level.",
+        "file_level": "",
         "rotation_size_mb": 10,
         "retention_days": 7,
+        "console_colors": true,
         "subsystem_files": {
             "Smtp": "lcdlln-SMTP.log"
+        },
+        "_comment_specialized_files": "M45 — Fichiers spécialisés (cmangos-style). Chaque ligne va aussi dans le log principal. Laisser vide pour désactiver.",
+        "gm_log_file": "",
+        "gm_log_per_account": false,
+        "gm_log_dir": "",
+        "char_log_file": "",
+        "db_error_log_file": "",
+        "packet_log_file": "",
+        "custom_log_file": "",
+        "_comment_filters": "M45 — Filtres bitmask par catégorie. Activer un seul bit suffit à passer LOG_FILTERED, indépendamment de log.level. Tous les filtres sont a false par défaut.",
+        "filters": {
+            "transport_moves": false,
+            "creature_moves": false,
+            "visibility_changes": false,
+            "weather": false,
+            "player_stats": false,
+            "sql_text": false,
+            "player_moves": false,
+            "damage": false,
+            "combat": false,
+            "spell_cast": false,
+            "pathfinding": false,
+            "map_loading": false,
+            "event_ai_dev": false,
+            "db_scripts_dev": false,
+            "packet_io": false,
+            "chat_relay": false,
+            "auth": false,
+            "session": false,
+            "db": false,
+            "migration": false,
+            "custom": false
         }
     },
     "render": {

--- a/engine/core/Log.cpp
+++ b/engine/core/Log.cpp
@@ -12,8 +12,10 @@
 #if defined(_WIN32)
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
+#  include <io.h>
 #else
 #  include <mutex>
+#  include <unistd.h>
 #endif
 
 namespace engine::core
@@ -24,10 +26,26 @@ namespace engine::core
 		bool          s_consoleEnabled = false;
 		/// M44.4 — Si true, formate chaque ligne en JSON (jsonl) au lieu du format bracketé.
 		bool          s_jsonOutput = false;
+		/// M45 — Seuil distinct pour le fichier principal. Si \c LogLevel::Off, suit \c s_level.
+		LogLevel      s_fileLevel = LogLevel::Off;
+		/// M45 — Couleurs console actives (n'est vrai que si stdout est un TTY ET \c consoleColors=true).
+		bool          s_consoleColors = false;
 		/// Chemins résolus → flux (un fichier peut servir plusieurs sous-systèmes).
 		std::unordered_map<std::string, std::ofstream> s_extraFilesByPath;
 		/// Sous-système (chaîne du macro LOG_*) → chemin résolu dans \c s_extraFilesByPath.
 		std::unordered_map<std::string, std::string> s_subsystemToResolvedPath;
+
+		/// M45 — Fichiers spécialisés (cmangos GMLog / CharLog / DBError / WorldPacket / Custom).
+		/// Tous sont indépendants du système \c subsystemFiles ci-dessus.
+		std::ofstream s_gmLogFile;
+		std::ofstream s_charLogFile;
+		std::ofstream s_dbErrorFile;
+		std::ofstream s_packetFile;
+		std::ofstream s_customFile;
+		bool          s_gmLogPerAccount = false;
+		std::filesystem::path s_gmLogDir;
+		/// M45 — Cache des flux per-account ouverts à la volée. Clé : accountId.
+		std::unordered_map<uint32_t, std::ofstream> s_gmFilesByAccount;
 
 #if defined(_WIN32)
 		CRITICAL_SECTION s_cs;
@@ -40,12 +58,20 @@ namespace engine::core
 		{
 			if (s_csInit) { DeleteCriticalSection(&s_cs); s_csInit = false; }
 		}
+		bool StdoutIsTty()
+		{
+			return _isatty(_fileno(stdout)) != 0;
+		}
 #else
 		std::mutex& GetMutex() { static std::mutex m; return m; }
 		void LockLog()    { GetMutex().lock(); }
 		void UnlockLog()  { GetMutex().unlock(); }
 		void InitLock()   {}
 		void DestroyLock(){}
+		bool StdoutIsTty()
+		{
+			return ::isatty(fileno(stdout)) != 0;
+		}
 #endif
 
 		const char* LevelToString(LogLevel level)
@@ -62,10 +88,71 @@ namespace engine::core
 			default:              return "UNKNOWN";
 			}
 		}
+
+		/// M45 — Couleur ANSI/Win32 par niveau (cmangos-style).
+		/// POSIX : code SGR (ex. "31" = rouge). Win32 : attribut FOREGROUND_*.
+#if defined(_WIN32)
+		WORD LevelToWinColor(LogLevel level)
+		{
+			switch (level)
+			{
+			case LogLevel::Trace: return FOREGROUND_INTENSITY;                                                       // gris
+			case LogLevel::Debug: return FOREGROUND_GREEN | FOREGROUND_BLUE;                                         // cyan
+			case LogLevel::Info:  return FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY; // blanc vif
+			case LogLevel::Warn:  return FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;                   // jaune
+			case LogLevel::Error: return FOREGROUND_RED | FOREGROUND_INTENSITY;                                      // rouge vif
+			case LogLevel::Fatal: return FOREGROUND_RED | FOREGROUND_INTENSITY | BACKGROUND_RED;                     // rouge sur fond rouge éteint
+			default:              return FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE;
+			}
+		}
+#endif
+		const char* LevelToAnsi(LogLevel level)
+		{
+			switch (level)
+			{
+			case LogLevel::Trace: return "\x1b[90m";       // gris
+			case LogLevel::Debug: return "\x1b[36m";       // cyan
+			case LogLevel::Info:  return "\x1b[37;1m";     // blanc vif
+			case LogLevel::Warn:  return "\x1b[33;1m";     // jaune
+			case LogLevel::Error: return "\x1b[31;1m";     // rouge
+			case LogLevel::Fatal: return "\x1b[97;41;1m";  // blanc sur rouge
+			default:              return "\x1b[0m";
+			}
+		}
+
+		void WriteConsoleColored(const std::string& line, LogLevel level)
+		{
+			if (!s_consoleColors)
+			{
+				std::fputs(line.c_str(), stdout);
+				std::fflush(stdout);
+				return;
+			}
+#if defined(_WIN32)
+			HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+			CONSOLE_SCREEN_BUFFER_INFO csbi{};
+			WORD prev = 0;
+			if (h != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(h, &csbi))
+			{
+				prev = csbi.wAttributes;
+				SetConsoleTextAttribute(h, LevelToWinColor(level));
+			}
+			std::fputs(line.c_str(), stdout);
+			std::fflush(stdout);
+			if (h != INVALID_HANDLE_VALUE)
+				SetConsoleTextAttribute(h, prev != 0 ? prev : (FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE));
+#else
+			std::fputs(LevelToAnsi(level), stdout);
+			std::fputs(line.c_str(), stdout);
+			std::fputs("\x1b[0m", stdout);
+			std::fflush(stdout);
+#endif
+		}
 	}
 
 	std::atomic<LogLevel> Log::s_level{ LogLevel::Info };
 	std::atomic<bool>     Log::s_active{ false };
+	std::atomic<uint64_t> Log::s_filters{ 0 };
 
 	std::string Log::MakeTimestampedFilename(std::string_view prefix)
 	{
@@ -80,6 +167,40 @@ namespace engine::core
 		char buf[64]{};
 		std::strftime(buf, sizeof(buf), "-%Y%m%d-%H%M%S.log", &tm);
 		return std::string(prefix) + buf;
+	}
+
+	LogFilter LogFilterFromName(std::string_view name)
+	{
+		struct Pair { std::string_view k; LogFilter v; };
+		static constexpr Pair kTable[] = {
+			{"transport_moves",     LogFilter::TransportMoves},
+			{"creature_moves",      LogFilter::CreatureMoves},
+			{"visibility_changes",  LogFilter::VisibilityChanges},
+			{"weather",             LogFilter::Weather},
+			{"player_stats",        LogFilter::PlayerStats},
+			{"sql_text",            LogFilter::SqlText},
+			{"player_moves",        LogFilter::PlayerMoves},
+			{"damage",              LogFilter::Damage},
+			{"combat",              LogFilter::Combat},
+			{"spell_cast",          LogFilter::SpellCast},
+			{"pathfinding",         LogFilter::Pathfinding},
+			{"map_loading",         LogFilter::MapLoading},
+			{"event_ai_dev",        LogFilter::EventAiDev},
+			{"db_scripts_dev",      LogFilter::DbScriptsDev},
+			{"packet_io",           LogFilter::PacketIo},
+			{"chat_relay",          LogFilter::ChatRelay},
+			{"auth",                LogFilter::Auth},
+			{"session",             LogFilter::Session},
+			{"db",                  LogFilter::Db},
+			{"migration",           LogFilter::Migration},
+			{"custom",              LogFilter::Custom},
+		};
+		for (const auto& p : kTable)
+		{
+			if (p.k == name)
+				return p.v;
+		}
+		return LogFilter::None;
 	}
 
 	namespace
@@ -116,6 +237,50 @@ namespace engine::core
 				}
 			}
 		}
+
+		/// M45 — Ouvre un fichier de log spécialisé (mode append, BOM UTF-8 si vide).
+		/// Renvoie true si \p out est utilisable après l'appel.
+		bool OpenSpecializedFile(std::ofstream& out, const std::filesystem::path& full)
+		{
+			if (full.empty())
+				return false;
+			std::error_code ec;
+			if (full.has_parent_path())
+				std::filesystem::create_directories(full.parent_path(), ec);
+			out.open(full, std::ios::out | std::ios::app);
+			if (!out.is_open())
+			{
+				std::fprintf(stderr, "[Log] Cannot open specialized log file: %s\n", full.generic_string().c_str());
+				std::fflush(stderr);
+				return false;
+			}
+			if (out.tellp() == 0)
+			{
+				static const unsigned char kUtf8Bom[] = { 0xEF, 0xBB, 0xBF };
+				out.write(reinterpret_cast<const char*>(kUtf8Bom), sizeof(kUtf8Bom));
+				out.flush();
+			}
+			return true;
+		}
+
+		/// M45 — Renvoie le timestamp local formaté \c "[DD/MM/YYYY][HH:MM:SS] " utilisé
+		/// par les fichiers spécialisés (les logs principaux gardent le format historique).
+		std::string TimestampPrefix()
+		{
+			const auto now = std::chrono::system_clock::now();
+			const std::time_t t = std::chrono::system_clock::to_time_t(now);
+			std::tm tm{};
+#if defined(_WIN32)
+			localtime_s(&tm, &t);
+#else
+			localtime_r(&t, &tm);
+#endif
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "[%02d/%02d/%04d][%02d:%02d:%02d] ",
+				tm.tm_mday, tm.tm_mon + 1, tm.tm_year + 1900,
+				tm.tm_hour, tm.tm_min, tm.tm_sec);
+			return std::string(buf);
+		}
 	}
 
 	void Log::Init(const LogSettings& settings)
@@ -126,6 +291,9 @@ namespace engine::core
 		s_level.store(settings.level, std::memory_order_relaxed);
 		s_consoleEnabled = settings.console;
 		s_jsonOutput = settings.jsonOutput;
+		s_fileLevel = settings.fileLevel;
+		s_filters.store(settings.enabledFilters, std::memory_order_relaxed);
+		s_consoleColors = settings.consoleColors && settings.console && StdoutIsTty();
 
 		if (!settings.filePath.empty())
 		{
@@ -147,11 +315,11 @@ namespace engine::core
 
 		s_extraFilesByPath.clear();
 		s_subsystemToResolvedPath.clear();
+		const std::filesystem::path mainPath(settings.filePath);
+		const std::filesystem::path baseDir =
+			settings.filePath.empty() ? std::filesystem::path(".") :
+			(mainPath.has_parent_path() ? mainPath.parent_path() : std::filesystem::path("."));
 		{
-			const std::filesystem::path mainPath(settings.filePath);
-			const std::filesystem::path baseDir =
-				settings.filePath.empty() ? std::filesystem::path(".") :
-				(mainPath.has_parent_path() ? mainPath.parent_path() : std::filesystem::path("."));
 			static const unsigned char kUtf8Bom[] = { 0xEF, 0xBB, 0xBF };
 			for (const auto& [subsystem, relName] : settings.subsystemFiles)
 			{
@@ -180,6 +348,40 @@ namespace engine::core
 				}
 				s_subsystemToResolvedPath.emplace(subsystem, fullStr);
 			}
+		}
+
+		// M45 — Fichiers spécialisés (GM/Char/DBError/Packet/Custom).
+		s_gmLogPerAccount = settings.gmLogPerAccount;
+		s_gmLogDir = settings.gmLogDir.empty() ? (baseDir / "gmlogs") : std::filesystem::path(settings.gmLogDir);
+		if (s_gmLogPerAccount)
+		{
+			std::error_code ec;
+			std::filesystem::create_directories(s_gmLogDir, ec);
+		}
+		else if (!settings.gmLogFile.empty())
+		{
+			const std::filesystem::path p(settings.gmLogFile);
+			OpenSpecializedFile(s_gmLogFile, p.is_absolute() ? p : (baseDir / p));
+		}
+		if (!settings.charLogFile.empty())
+		{
+			const std::filesystem::path p(settings.charLogFile);
+			OpenSpecializedFile(s_charLogFile, p.is_absolute() ? p : (baseDir / p));
+		}
+		if (!settings.dbErrorLogFile.empty())
+		{
+			const std::filesystem::path p(settings.dbErrorLogFile);
+			OpenSpecializedFile(s_dbErrorFile, p.is_absolute() ? p : (baseDir / p));
+		}
+		if (!settings.packetLogFile.empty())
+		{
+			const std::filesystem::path p(settings.packetLogFile);
+			OpenSpecializedFile(s_packetFile, p.is_absolute() ? p : (baseDir / p));
+		}
+		if (!settings.customLogFile.empty())
+		{
+			const std::filesystem::path p(settings.customLogFile);
+			OpenSpecializedFile(s_customFile, p.is_absolute() ? p : (baseDir / p));
 		}
 
 #if defined(_WIN32)
@@ -218,8 +420,25 @@ namespace engine::core
 		}
 		s_extraFilesByPath.clear();
 		s_subsystemToResolvedPath.clear();
+		auto closeIfOpen = [](std::ofstream& f) { if (f.is_open()) { f.flush(); f.close(); } };
+		closeIfOpen(s_gmLogFile);
+		closeIfOpen(s_charLogFile);
+		closeIfOpen(s_dbErrorFile);
+		closeIfOpen(s_packetFile);
+		closeIfOpen(s_customFile);
+		for (auto& [id, f] : s_gmFilesByAccount)
+		{
+			(void)id;
+			closeIfOpen(f);
+		}
+		s_gmFilesByAccount.clear();
+		s_gmLogPerAccount = false;
+		s_gmLogDir.clear();
 		s_consoleEnabled = false;
 		s_jsonOutput = false;
+		s_consoleColors = false;
+		s_fileLevel = LogLevel::Off;
+		s_filters.store(0, std::memory_order_relaxed);
 		UnlockLog();
 		DestroyLock();
 	}
@@ -237,6 +456,37 @@ namespace engine::core
 	void Log::SetLevel(LogLevel level)
 	{
 		s_level.store(level, std::memory_order_relaxed);
+	}
+
+	bool Log::HasFilter(LogFilter f)
+	{
+		const uint64_t bits = static_cast<uint64_t>(f);
+		if (bits == 0)
+			return false;
+		return (s_filters.load(std::memory_order_relaxed) & bits) != 0;
+	}
+
+	void Log::SetFilter(LogFilter f, bool enabled)
+	{
+		const uint64_t bits = static_cast<uint64_t>(f);
+		if (bits == 0)
+			return;
+		uint64_t cur = s_filters.load(std::memory_order_relaxed);
+		uint64_t next;
+		do
+		{
+			next = enabled ? (cur | bits) : (cur & ~bits);
+		} while (!s_filters.compare_exchange_weak(cur, next, std::memory_order_relaxed));
+	}
+
+	void Log::SetFilters(uint64_t mask)
+	{
+		s_filters.store(mask, std::memory_order_relaxed);
+	}
+
+	uint64_t Log::GetFilters()
+	{
+		return s_filters.load(std::memory_order_relaxed);
 	}
 
 	void Log::WriteLine(LogLevel level, const char* subsystem, std::string_view message)
@@ -294,25 +544,204 @@ namespace engine::core
 		}
 
 		LockLog();
-		if (s_file.is_open())
+		// M45 — Le seuil fichier peut être plus permissif que le seuil console.
+		const LogLevel fileSeuil = (s_fileLevel == LogLevel::Off) ? s_level.load(std::memory_order_relaxed) : s_fileLevel;
+		const bool fileAllowed = (level >= fileSeuil);
+		if (fileAllowed && s_file.is_open())
 		{
 			s_file << line;
 			s_file.flush();
 		}
-		if (const auto it = s_subsystemToResolvedPath.find(sys); it != s_subsystemToResolvedPath.end())
+		if (fileAllowed)
 		{
-			if (const auto fit = s_extraFilesByPath.find(it->second); fit != s_extraFilesByPath.end() && fit->second.is_open())
+			if (const auto it = s_subsystemToResolvedPath.find(sys); it != s_subsystemToResolvedPath.end())
 			{
-				fit->second << line;
-				fit->second.flush();
+				if (const auto fit = s_extraFilesByPath.find(it->second); fit != s_extraFilesByPath.end() && fit->second.is_open())
+				{
+					fit->second << line;
+					fit->second.flush();
+				}
 			}
 		}
 		if (s_consoleEnabled)
 		{
-			std::fputs(line.c_str(), stdout);
+			WriteConsoleColored(line, level);
 			// Docker / pipe : stdout est souvent fully-buffered sans TTY ; sans flush les logs
 			// n'apparaissent pas dans `docker compose logs` pendant longtemps.
-			std::fflush(stdout);
+		}
+		UnlockLog();
+	}
+
+	void Log::WriteGmCommand(uint32_t accountId, std::string_view characterName, std::string_view command)
+	{
+		if (!s_active.load(std::memory_order_acquire))
+			return;
+		// Toujours dans le log principal (sous-système GM) pour traçabilité agrégée.
+		Write(LogLevel::Info, "GM", "[acct={} char='{}'] {}", accountId, characterName, command);
+
+		if (!s_gmLogPerAccount && !s_gmLogFile.is_open())
+			return;
+
+		std::string line = TimestampPrefix();
+		line += "[acct=";
+		line += std::to_string(accountId);
+		line += " char='";
+		line.append(characterName);
+		line += "'] ";
+		line.append(command);
+		line += "\n";
+
+		LockLog();
+		if (s_gmLogPerAccount)
+		{
+			auto it = s_gmFilesByAccount.find(accountId);
+			if (it == s_gmFilesByAccount.end())
+			{
+				std::ofstream ofs;
+				const std::filesystem::path full = s_gmLogDir / ("account_" + std::to_string(accountId) + ".log");
+				if (OpenSpecializedFile(ofs, full))
+				{
+					it = s_gmFilesByAccount.emplace(accountId, std::move(ofs)).first;
+				}
+			}
+			if (it != s_gmFilesByAccount.end() && it->second.is_open())
+			{
+				it->second << line;
+				it->second.flush();
+			}
+		}
+		else if (s_gmLogFile.is_open())
+		{
+			s_gmLogFile << line;
+			s_gmLogFile.flush();
+		}
+		UnlockLog();
+	}
+
+	void Log::WriteCharLog(uint32_t accountId, uint64_t characterId, std::string_view event)
+	{
+		if (!s_active.load(std::memory_order_acquire))
+			return;
+		Write(LogLevel::Info, "Char", "[acct={} char_id={}] {}", accountId, characterId, event);
+		if (!s_charLogFile.is_open())
+			return;
+		std::string line = TimestampPrefix();
+		line += "[acct=";
+		line += std::to_string(accountId);
+		line += " char_id=";
+		line += std::to_string(characterId);
+		line += "] ";
+		line.append(event);
+		line += "\n";
+		LockLog();
+		if (s_charLogFile.is_open())
+		{
+			s_charLogFile << line;
+			s_charLogFile.flush();
+		}
+		UnlockLog();
+	}
+
+	void Log::WriteDbError(std::string_view message)
+	{
+		if (!s_active.load(std::memory_order_acquire))
+			return;
+		Write(LogLevel::Error, "DBError", "{}", message);
+		if (!s_dbErrorFile.is_open())
+			return;
+		std::string line = TimestampPrefix();
+		line.append(message);
+		line += "\n";
+		LockLog();
+		if (s_dbErrorFile.is_open())
+		{
+			s_dbErrorFile << line;
+			s_dbErrorFile.flush();
+		}
+		UnlockLog();
+	}
+
+	void Log::WriteCustom(std::string_view message)
+	{
+		if (!s_active.load(std::memory_order_acquire))
+			return;
+		Write(LogLevel::Info, "Custom", "{}", message);
+		if (!s_customFile.is_open())
+			return;
+		std::string line = TimestampPrefix();
+		line.append(message);
+		line += "\n";
+		LockLog();
+		if (s_customFile.is_open())
+		{
+			s_customFile << line;
+			s_customFile.flush();
+		}
+		UnlockLog();
+	}
+
+	void Log::WritePacketDump(std::string_view direction, uint16_t opcode,
+	                          const void* data, size_t size, uint32_t connId)
+	{
+		if (!s_active.load(std::memory_order_acquire))
+			return;
+		// M45 — Gating par filtre PacketIo : zéro coût si désactivé.
+		if (!HasFilter(LogFilter::PacketIo))
+			return;
+
+		const uint8_t* bytes = static_cast<const uint8_t*>(data);
+		std::string body;
+		body.reserve(size * 4u + 64u);
+		// Entête lisible.
+		char header[96]{};
+		std::snprintf(header, sizeof(header),
+			"PACKET %.3s connId=%u opcode=0x%04x (%u) size=%zu\n",
+			direction.data(), connId, opcode, opcode, size);
+		body += header;
+		// 16 octets/ligne avec offset, hex et gutter ASCII.
+		for (size_t i = 0; i < size; i += 16u)
+		{
+			char off[16]{};
+			std::snprintf(off, sizeof(off), "  %04zx  ", i);
+			body += off;
+			// Hex.
+			for (size_t j = 0; j < 16u; ++j)
+			{
+				if (i + j < size)
+				{
+					char hx[4]{};
+					std::snprintf(hx, sizeof(hx), "%02x ", bytes[i + j]);
+					body += hx;
+				}
+				else
+				{
+					body += "   ";
+				}
+				if (j == 7u)
+					body += ' ';
+			}
+			// Gutter ASCII.
+			body += " |";
+			for (size_t j = 0; j < 16u && (i + j) < size; ++j)
+			{
+				const uint8_t c = bytes[i + j];
+				body += (c >= 0x20u && c < 0x7Fu) ? static_cast<char>(c) : '.';
+			}
+			body += "|\n";
+		}
+
+		// Toujours dans le log principal (sous-système Packet) pour visibilité immédiate.
+		Write(LogLevel::Debug, "Packet", "{}", body);
+
+		if (!s_packetFile.is_open())
+			return;
+		std::string line = TimestampPrefix();
+		line += body;
+		LockLog();
+		if (s_packetFile.is_open())
+		{
+			s_packetFile << line;
+			s_packetFile.flush();
 		}
 		UnlockLog();
 	}

--- a/engine/core/Log.h
+++ b/engine/core/Log.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <atomic>
+#include <cstdint>
 #include <cstdlib>
 #include <format>
 #include <string>
@@ -17,10 +18,48 @@ namespace engine::core
         Fatal = 5,
         Off = 6
     };
+
+    /// M45 — Filtres bitmask par catégorie (inspiré cmangos Log.h LogFilters).
+    /// Permet de tracer une seule sous-feature en debug sans polluer les autres.
+    /// Un filtre est un seul bit ; le masque global est un \c uint64_t.
+    /// Activation via \c log.filters.<name> = true dans \c config.json
+    /// (où \c <name> est en snake_case, voir \c LogFilterFromName).
+    enum class LogFilter : uint64_t
+    {
+        None              = 0,
+        TransportMoves    = 1ull << 0,
+        CreatureMoves     = 1ull << 1,
+        VisibilityChanges = 1ull << 2,
+        Weather           = 1ull << 3,
+        PlayerStats       = 1ull << 4,
+        SqlText           = 1ull << 5,
+        PlayerMoves       = 1ull << 6,
+        Damage            = 1ull << 7,
+        Combat            = 1ull << 8,
+        SpellCast         = 1ull << 9,
+        Pathfinding       = 1ull << 10,
+        MapLoading        = 1ull << 11,
+        EventAiDev        = 1ull << 12,
+        DbScriptsDev      = 1ull << 13,
+        PacketIo          = 1ull << 14,
+        ChatRelay         = 1ull << 15,
+        Auth              = 1ull << 16,
+        Session           = 1ull << 17,
+        Db                = 1ull << 18,
+        Migration         = 1ull << 19,
+        Custom            = 1ull << 20,
+    };
+
+    /// Nom snake_case → bit. Renvoie \c LogFilter::None si inconnu.
+    LogFilter LogFilterFromName(std::string_view name);
+
     struct LogSettings
     {
-        /// Minimum level that will be emitted.
+        /// Minimum level that will be emitted (console + file).
         LogLevel level = LogLevel::Info;
+        /// Seuil distinct pour le fichier principal (cmangos LogFileLevel).
+        /// Si \c LogLevel::Off (par défaut), suit \c level.
+        LogLevel fileLevel = LogLevel::Off;
         /// Relative path to the log file to append to (created if missing).
         /// Empty string means no file output.
         std::string filePath;
@@ -40,6 +79,29 @@ namespace engine::core
         /// Le timestamp est en UTC ISO-8601. Les caractères spéciaux JSON (quote, backslash,
         /// newline, contrôle) sont échappés dans \c subsystem et \c message.
         bool jsonOutput = false;
+        /// M45 — Masque initial des filtres bitmask. Mettre les bits de \c LogFilter à 1 pour
+        /// activer la catégorie correspondante. Voir \c LOG_FILTERED.
+        uint64_t enabledFilters = 0;
+        /// M45 — Couleurs ANSI (POSIX) ou attributs Win32 sur la console pour différencier
+        /// les niveaux. Désactivé automatiquement si stdout n'est pas un TTY (pipe, fichier, Docker).
+        bool consoleColors = true;
+        /// M45 — Fichier dédié aux commandes GM (mode global). Vide = pas de log GM dédié.
+        /// Ignoré si \c gmLogPerAccount est true.
+        std::string gmLogFile;
+        /// M45 — Si \c true, chaque commande GM est écrite dans un fichier nommé
+        /// \c <gmLogDir>/account_<id>.log (un fichier par compte GM).
+        bool gmLogPerAccount = false;
+        /// M45 — Dossier des logs GM per-account (créé s'il n'existe pas). Défaut : \c gmlogs.
+        std::string gmLogDir;
+        /// M45 — Fichier dédié aux événements personnages (création / suppression / login).
+        std::string charLogFile;
+        /// M45 — Fichier dédié aux erreurs DB (mauvais data, contraintes, etc.).
+        std::string dbErrorLogFile;
+        /// M45 — Fichier dédié aux dumps de paquets réseau (16 octets/ligne + ASCII).
+        /// Si vide, les dumps vont dans le log principal sous le sous-système \c "Packet".
+        std::string packetLogFile;
+        /// M45 — Fichier dédié aux logs custom (Log::WriteCustom).
+        std::string customLogFile;
     };
     class Log final
     {
@@ -56,6 +118,17 @@ namespace engine::core
         static LogLevel GetLevel();
         /// Set current minimum log level.
         static void SetLevel(LogLevel level);
+
+        /// M45 — Test si un filtre bitmask est actif (atomique, sans verrou).
+        /// Utiliser via la macro \c LOG_FILTERED qui court-circuite le \c std::format si false.
+        static bool HasFilter(LogFilter f);
+        /// M45 — Active ou désactive un filtre (bit unique).
+        static void SetFilter(LogFilter f, bool enabled);
+        /// M45 — Remplace tout le masque des filtres.
+        static void SetFilters(uint64_t mask);
+        /// M45 — Renvoie le masque courant.
+        static uint64_t GetFilters();
+
         /// Write a log line for the given level/subsystem and already-formatted message.
         static void WriteLine(LogLevel level, const char* subsystem, std::string_view message);
         /// Format + write a log line.
@@ -68,9 +141,34 @@ namespace engine::core
                 return;
             WriteLine(level, subsystem, std::format(fmt, std::forward<Args>(args)...));
         }
+
+        /// M45 — Log d'une commande GM. Mode global (gmLogFile) ou per-account (gmLogDir/account_<id>.log)
+        /// selon \c LogSettings::gmLogPerAccount. La ligne va aussi dans le log principal sous \c "GM".
+        /// \param accountId Identifiant compte (utilisé pour le fichier per-account).
+        /// \param characterName Nom du personnage qui exécute la commande (peut être vide hors world).
+        /// \param command Texte intégral de la commande (ex. \c ".tele Stormwind").
+        static void WriteGmCommand(uint32_t accountId, std::string_view characterName, std::string_view command);
+        /// M45 — Log d'un événement personnage (création, suppression, EnterWorld, save).
+        static void WriteCharLog(uint32_t accountId, uint64_t characterId, std::string_view event);
+        /// M45 — Erreur DB persistée dans un fichier dédié (\c dbErrorLogFile).
+        static void WriteDbError(std::string_view message);
+        /// M45 — Log custom libre (\c customLogFile).
+        static void WriteCustom(std::string_view message);
+        /// M45 — Dump hex d'un paquet réseau (cmangos outWorldPacketDump).
+        /// Format : timestamp + entête (\c connId, direction, opcode, taille) puis hex 16 octets/ligne
+        /// avec gutter ASCII. Émis uniquement si \c LogFilter::PacketIo est actif.
+        /// \param direction \c "IN" ou \c "OUT".
+        /// \param opcode Code opération (numéro logique du paquet).
+        /// \param data Pointeur sur le payload (peut être nul si size=0).
+        /// \param size Taille en octets.
+        /// \param connId Identifiant connexion (0 si inconnu).
+        static void WritePacketDump(std::string_view direction, uint16_t opcode,
+                                    const void* data, size_t size, uint32_t connId = 0);
+
     private:
         static std::atomic<LogLevel> s_level;
         static std::atomic<bool>     s_active;
+        static std::atomic<uint64_t> s_filters;
     };
 }
 #define LOG_TRACE(subsystem, format, ...) ::engine::core::Log::Write(::engine::core::LogLevel::Trace, #subsystem, format __VA_OPT__(,) __VA_ARGS__)
@@ -83,4 +181,15 @@ namespace engine::core
     {                                                        \
         ::engine::core::Log::Write(::engine::core::LogLevel::Fatal, #subsystem, format __VA_OPT__(,) __VA_ARGS__); \
         ::std::abort();                                      \
+    } while (false)
+
+/// M45 — Émet une ligne uniquement si le filtre est actif ET le niveau passe le seuil.
+/// Le test \c HasFilter est atomique sans verrou ; le \c std::format est court-circuité
+/// quand le filtre est désactivé (zéro coût en hot path).
+/// Usage : \c LOG_FILTERED(Debug, CreatureMoves, AI, "creature {} -> {}", id, pos);
+#define LOG_FILTERED(level, filter, subsystem, format, ...)                                          \
+    do                                                                                               \
+    {                                                                                                \
+        if (::engine::core::Log::HasFilter(::engine::core::LogFilter::filter))                       \
+            ::engine::core::Log::Write(::engine::core::LogLevel::level, #subsystem, format __VA_OPT__(,) __VA_ARGS__); \
     } while (false)

--- a/engine/core/LogConfig.cpp
+++ b/engine/core/LogConfig.cpp
@@ -1,0 +1,80 @@
+#include "engine/core/LogConfig.h"
+
+#include "engine/core/Config.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace engine::core
+{
+	namespace
+	{
+		LogLevel ParseLogLevelText(std::string_view text)
+		{
+			if (text == "Trace" || text == "trace") return LogLevel::Trace;
+			if (text == "Debug" || text == "debug") return LogLevel::Debug;
+			if (text == "Info"  || text == "info")  return LogLevel::Info;
+			if (text == "Warn"  || text == "warn")  return LogLevel::Warn;
+			if (text == "Error" || text == "error") return LogLevel::Error;
+			if (text == "Fatal" || text == "fatal") return LogLevel::Fatal;
+			if (text == "Off"   || text == "off")   return LogLevel::Off;
+			return LogLevel::Info;
+		}
+
+		/// Liste exhaustive des noms de filtres reconnus (snake_case). Tout ajout
+		/// d'un \c LogFilter doit aussi être référencé ici sinon le bit ne sera
+		/// jamais activé via la config.
+		constexpr const char* kFilterNames[] = {
+			"transport_moves", "creature_moves", "visibility_changes", "weather",
+			"player_stats",    "sql_text",       "player_moves",       "damage",
+			"combat",          "spell_cast",     "pathfinding",        "map_loading",
+			"event_ai_dev",    "db_scripts_dev", "packet_io",          "chat_relay",
+			"auth",            "session",        "db",                 "migration",
+			"custom"
+		};
+	}
+
+	LogSettings BuildLogSettingsFromConfig(const Config& cfg, std::string_view defaultLogFile)
+	{
+		LogSettings s;
+		s.level       = ParseLogLevelText(cfg.GetString("log.level", "Info"));
+		// Si log.file_level absent, suit log.level (s_fileLevel = Off → fallback runtime).
+		const std::string fileLevelText = cfg.GetString("log.file_level", "");
+		s.fileLevel   = fileLevelText.empty() ? LogLevel::Off : ParseLogLevelText(fileLevelText);
+		s.console     = cfg.GetBool("log.console", true);
+		s.flushAlways = cfg.GetBool("log.flush_always", true);
+		s.filePath    = cfg.GetString("log.file", std::string(defaultLogFile));
+		s.rotation_size_mb = static_cast<size_t>(std::max<int64_t>(0, cfg.GetInt("log.rotation_size_mb", 10)));
+		s.retention_days   = static_cast<int>(cfg.GetInt("log.retention_days", 7));
+		s.subsystemFiles   = cfg.GetStringMapUnderPrefix("log.subsystem_files");
+		s.jsonOutput  = cfg.GetBool("log.json", false);
+
+		// M45 — Couleurs console (ANSI/Win32). Auto-désactivé si stdout non-TTY.
+		s.consoleColors = cfg.GetBool("log.console_colors", true);
+
+		// M45 — Fichiers spécialisés.
+		s.gmLogFile        = cfg.GetString("log.gm_log_file", "");
+		s.gmLogPerAccount  = cfg.GetBool("log.gm_log_per_account", false);
+		s.gmLogDir         = cfg.GetString("log.gm_log_dir", "");
+		s.charLogFile      = cfg.GetString("log.char_log_file", "");
+		s.dbErrorLogFile   = cfg.GetString("log.db_error_log_file", "");
+		s.packetLogFile    = cfg.GetString("log.packet_log_file", "");
+		s.customLogFile    = cfg.GetString("log.custom_log_file", "");
+
+		// M45 — Filtres bitmask : chaque bit est activé séparément via
+		// \c log.filters.<snake_case_name> = true. Les noms inconnus sont ignorés.
+		uint64_t mask = 0;
+		for (const char* name : kFilterNames)
+		{
+			std::string key = std::string("log.filters.") + name;
+			if (cfg.GetBool(key, false))
+			{
+				const LogFilter f = LogFilterFromName(name);
+				mask |= static_cast<uint64_t>(f);
+			}
+		}
+		s.enabledFilters = mask;
+		return s;
+	}
+}

--- a/engine/core/LogConfig.h
+++ b/engine/core/LogConfig.h
@@ -1,0 +1,24 @@
+#pragma once
+
+/// @file engine/core/LogConfig.h
+/// @brief M45 — Pont Config → LogSettings : factorise la lecture de toutes les
+/// clés \c log.* (filtres bitmask, fichiers spécialisés GM/Char/DBError/Packet/Custom,
+/// couleurs console, seuil fichier distinct) entre les binaires master et shard.
+
+#include "engine/core/Log.h"
+
+#include <string_view>
+
+namespace engine::core
+{
+	class Config;
+
+	/// Construit un \c LogSettings complet à partir de la configuration chargée.
+	/// Toutes les clés \c log.* sont optionnelles ; les défauts reproduisent
+	/// le comportement antérieur (Info, console, rotation 10 MB, 7 fichiers retenus).
+	/// \param cfg Configuration déjà chargée (Config::Load).
+	/// \param defaultLogFile Nom du fichier principal si \c log.file n'est pas défini
+	///        (typiquement \c "engine.log" pour le master, \c "shard.log" pour le shard).
+	/// \return Structure \c LogSettings prête à passer à \c Log::Init.
+	LogSettings BuildLogSettingsFromConfig(const Config& cfg, std::string_view defaultLogFile);
+}

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -34,6 +34,7 @@ if(WIN32)
     LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/engine/core/Config.cpp
     ${CMAKE_SOURCE_DIR}/engine/core/Log.cpp
+    ${CMAKE_SOURCE_DIR}/engine/core/LogConfig.cpp
     ${CMAKE_SOURCE_DIR}/engine/platform/FileSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/SessionManager.cpp
     ${CMAKE_SOURCE_DIR}/engine/server/RateLimitAndBan.cpp
@@ -61,6 +62,7 @@ elseif(UNIX)
     LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/engine/core/Config.cpp
     ${CMAKE_SOURCE_DIR}/engine/core/Log.cpp
+    ${CMAKE_SOURCE_DIR}/engine/core/LogConfig.cpp
     ${CMAKE_SOURCE_DIR}/engine/platform/FileSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatSystem.cpp
     ${CMAKE_SOURCE_DIR}/engine/net/ChatEmotes.cpp

--- a/engine/server/main_server_linux.cpp
+++ b/engine/server/main_server_linux.cpp
@@ -38,6 +38,7 @@
 
 #include "engine/core/Config.h"
 #include "engine/core/Log.h"
+#include "engine/core/LogConfig.h"
 
 #include <csignal>
 #include <chrono>
@@ -78,18 +79,6 @@ namespace
 		LOG_INFO(Server, "###############################################################");
 	}
 
-	engine::core::LogLevel ParseLogLevel(std::string_view text)
-	{
-		if (text == "Trace" || text == "trace") return engine::core::LogLevel::Trace;
-		if (text == "Debug" || text == "debug") return engine::core::LogLevel::Debug;
-		if (text == "Info" || text == "info") return engine::core::LogLevel::Info;
-		if (text == "Warn" || text == "warn") return engine::core::LogLevel::Warn;
-		if (text == "Error" || text == "error") return engine::core::LogLevel::Error;
-		if (text == "Fatal" || text == "fatal") return engine::core::LogLevel::Fatal;
-		if (text == "Off" || text == "off") return engine::core::LogLevel::Off;
-		return engine::core::LogLevel::Info;
-	}
-
 	/// Returns true if \a argv contains --net.stats (or -net.stats).
 	bool ParseNetStatsFlag(int argc, char** argv)
 	{
@@ -116,16 +105,9 @@ int main(int argc, char** argv)
 
 	g_net_stats = ParseNetStatsFlag(argc, argv);
 
-	engine::core::LogSettings logSettings;
-	logSettings.level = ParseLogLevel(config.GetString("log.level", "Info"));
-	logSettings.console = true;
-	logSettings.flushAlways = true;
-	logSettings.filePath = config.GetString("log.file", "engine.log");
-	logSettings.rotation_size_mb = static_cast<size_t>(std::max(static_cast<int64_t>(0), config.GetInt("log.rotation_size_mb", 10)));
-	logSettings.retention_days = static_cast<int>(config.GetInt("log.retention_days", 7));
-	logSettings.subsystemFiles = config.GetStringMapUnderPrefix("log.subsystem_files");
-	// M44.4 — Format JSONL pour ingestion Loki/ELK. Activer en prod via config.
-	logSettings.jsonOutput = config.GetBool("log.json", false);
+	// M45 — Construction centralisée des LogSettings (filtres bitmask, fichiers spécialisés
+	// GM/Char/DBError/Packet/Custom, couleurs console, seuil fichier distinct).
+	engine::core::LogSettings logSettings = engine::core::BuildLogSettingsFromConfig(config, "engine.log");
 	engine::core::Log::Init(logSettings);
 
 	LOG_INFO(Net, "[ServerMain] Linux TCP server starting...");

--- a/engine/server/main_shard_linux.cpp
+++ b/engine/server/main_shard_linux.cpp
@@ -9,6 +9,7 @@
 #include "engine/network/ShardToMasterClient.h"
 #include "engine/core/Config.h"
 #include "engine/core/Log.h"
+#include "engine/core/LogConfig.h"
 
 #include <csignal>
 #include <chrono>
@@ -24,12 +25,8 @@ namespace
 int main(int argc, char** argv)
 {
 	engine::core::Config config = engine::core::Config::Load("config.json", argc, argv);
-	engine::core::LogSettings logSettings;
-	logSettings.level = engine::core::LogLevel::Info;
-	logSettings.console = true;
-	logSettings.flushAlways = true;
-	logSettings.filePath = config.GetString("log.file", "shard.log");
-	logSettings.subsystemFiles = config.GetStringMapUnderPrefix("log.subsystem_files");
+	// M45 — Construction centralisée des LogSettings (filtres, fichiers spécialisés, couleurs).
+	engine::core::LogSettings logSettings = engine::core::BuildLogSettingsFromConfig(config, "shard.log");
 	engine::core::Log::Init(logSettings);
 
 	LOG_INFO(Net, "[ShardMain] Shard server starting...");


### PR DESCRIPTION
## Résumé

Étend `engine::core::Log` avec les features du logger cmangos (`mangos-tbc/src/shared/Log`) absentes du logger maison, **sans toucher aux 1344 sites d'appel existants**. Les nouveaux comportements sont opt-in via `config.json` ; le défaut reproduit le comportement antérieur.

## Features ajoutées

| Feature cmangos | Implémentation LCDLLN |
|---|---|
| Filtres bitmask par catégorie | `enum class LogFilter` (21 bits) + `LOG_FILTERED(level, filter, subsystem, fmt, ...)` avec court-circuit zéro-coût |
| Seuil fichier distinct (`LogFileLevel`) | `LogSettings::fileLevel` (vide = suit `level`) |
| Couleurs console | ANSI POSIX + `SetConsoleTextAttribute` Win32 par niveau, auto-désactivées si stdout non-TTY |
| Fichiers de sortie spécialisés | GM log, char log, DB error, packet, custom — chaque ligne va **aussi** dans le log principal |
| GM log per-account | `<gm_log_dir>/account_<id>.log` avec cache de flux ouverts |
| Packet hex dump | `Log::WritePacketDump(direction, opcode, data, size, connId)` 16 octets/ligne + gutter ASCII, gating via `LogFilter::PacketIo` |

## Fichiers modifiés

- `engine/core/Log.{h,cpp}` — extension de `LogSettings`, helpers `WriteGmCommand` / `WriteCharLog` / `WriteDbError` / `WriteCustom` / `WritePacketDump`, atomique `s_filters`, gestion des fichiers spécialisés et de la couleur console.
- `engine/core/LogConfig.{h,cpp}` — nouveau pont `Config → LogSettings` (factorise la lecture des clés `log.*` entre master et shard).
- `engine/server/main_server_linux.cpp` — utilise `BuildLogSettingsFromConfig`.
- `engine/server/main_shard_linux.cpp` — idem.
- `config.json` — ajout des clés `log.file_level`, `log.console_colors`, `log.gm_log_*`, `log.char_log_file`, `log.db_error_log_file`, `log.packet_log_file`, `log.custom_log_file`, `log.filters.*` (toutes off par défaut).
- `CMakeLists.txt` — ajout de `engine/core/LogConfig.cpp` à la lib `engine_core`.

## Compatibilité

- Aucun call site `LOG_TRACE/DEBUG/INFO/WARN/ERROR/FATAL` modifié.
- Tous les nouveaux champs de `LogSettings` ont des défauts qui reproduisent le comportement actuel.
- Les helpers spécialisés sont silencieux si leur fichier dédié n'est pas configuré (et la ligne va quand même dans le log principal sous le sous-système approprié `GM`/`Char`/`DBError`/`Packet`/`Custom`).
- Tests existants (`AntiBotTests`, `SecurityTests`, `LogRotationSmokeTest`) compilent sans modification.

## Test plan

- [ ] `cmake --preset linux-x64 && cmake --build build/linux-x64 --target lcdlln_server lcdlln_shard` (vcpkg requis, indisponible dans cet environnement ; `g++ -fsyntax-only` passe sur les 4 fichiers modifiés + 3 fichiers de tests existants)
- [ ] Lancer `lcdlln_server` avec `config.json` par défaut → comportement identique à avant (couleurs auto si TTY, sinon désactivées)
- [ ] Activer `log.filters.packet_io = true` + `log.packet_log_file = "packets.log"` → vérifier le dump hex
- [ ] Activer `log.gm_log_per_account = true` + `log.gm_log_dir = "gmlogs"` puis appeler `Log::WriteGmCommand(42, "Toto", ".tele Stormwind")` → vérifier `gmlogs/account_42.log`
- [ ] Activer `log.file_level = "Debug"` avec `log.level = "Info"` → console garde Info, fichier capture Debug

## Déploiement

> **Déploiement** : ⚠️ redéploiement serveur requis (master + shard) — nouvelles clés config lues, nouveaux fichiers spécialisés. Pas de wire-breaking, pas de migration DB ; mais les binaires master/shard doivent être rebuilds pour bénéficier des features. Le client n'est pas affecté.

https://claude.ai/code/session_015eo9wyXRCUt18E7otnrx6X

---
_Generated by [Claude Code](https://claude.ai/code/session_015eo9wyXRCUt18E7otnrx6X)_