### PR TITLE
docs(tickets): 44 tickets cmangos détaillés pour LCDLLN (P1+P2+P3+P4 partiel)

### DIFF
--- a/tickets/CMANGOS/CMANGOS.01_Chat_routing_safety_commands_split.md
+++ b/tickets/CMANGOS/CMANGOS.01_Chat_routing_safety_commands_split.md
@@ -1,0 +1,192 @@
+# CMANGOS.01_Chat_routing_safety_commands_split
+
+## Objectif
+
+Solidifier le système de chat LCDLLN (actuellement MVP avec opcodes 45/46
+relayés par `ChatRelayHandler` côté master) en portant 5 patterns éprouvés
+de cmangos `src/game/Chat`. Trois objectifs simultanés :
+
+1. **Sécurité** : protéger l'envoi public contre les exploits classiques
+   (item links forgés, hyperlinks fake, caractères invisibles, messages
+   trop longs).
+2. **Architecture** : formaliser le **split master/shard** (relay sur
+   master, proximité sur shard) pour ne pas charger inutilement le master
+   de paquets `say/yell/emote` localisés.
+3. **Extensibilité** : préparer le terrain pour les futures slash commands
+   GM avec un dispatch table-driven hiérarchique, et pour des canaux
+   thématiques dynamiques (`/join recrutement-guilde`).
+
+C'est un **déblocant MVP** — sans ces protections, l'ouverture publique du
+chat est risquée.
+
+## Dépendances
+
+- M00.1 (build base)
+- M44.4 (logger avec filtres bitmask, déjà fait — le filtre `LogFilter::ChatRelay` peut être activé pour debug)
+- Le `ChatRelayHandler` existant côté master (opcodes 45/46) reste la couche d'entrée.
+
+## Livrables
+
+### Côté master (`engine/server/`)
+
+- `engine/server/chat/ChatGate.{h,cpp}` — équivalent de `Player::CanSpeak()`, agrège tous les checks (mute, anti-flood, restrictions niveau, ban global). Une seule fonction `bool ChatGate::CanSpeak(uint32_t accountId, ChatChannel ch, std::string& denyReason)`.
+- `engine/server/chat/ChatSanitizer.{h,cpp}` — équivalent de `CheckEscapeSequences()` + truncation UTF-8 + strip caractères invisibles. API : `bool ChatSanitizer::Sanitize(std::string_view in, std::string& out, std::string& rejectReason)`.
+- `engine/server/chat/ChatChannelRegistry.{h,cpp}` — gestion des canaux dynamiques (création, ownership, ban-list, password optionnel, transfert auto).
+- `engine/server/chat/ChatCommandRouter.{h,cpp}` — dispatch table-driven hiérarchique pour slash commands GM. Tableau statique de `{name, security_level, handler, sub_table*}` parcouru récursivement.
+- Modifications dans `ChatRelayHandler.cpp` pour passer chaque message par `ChatGate` puis `ChatSanitizer` avant routage.
+
+### Côté shard (`engine/server/shard/` ou équivalent)
+
+- `engine/server/shard/ChatLocalRelay.{h,cpp}` — gestion exclusive de `say/yell/emote` (proximité 3D). Filtrage par AoI (à câbler quand Grids arrive) ; fallback en broadcast shard tant que pas d'AoI.
+- Le shard expose un opcode dédié `kOpcodeChatLocal` (à allouer, ex. 47/48) pour différencier des messages relay master.
+
+### Configuration (`config.json`)
+
+```json
+"chat": {
+  "max_message_bytes": 255,
+  "anti_flood": {
+    "max_messages_per_10s": 10,
+    "max_messages_per_60s": 30
+  },
+  "min_level_to_use_world": 5,
+  "min_level_to_create_channel": 1,
+  "channel_password_required": false,
+  "command_prefix": "."
+}
+```
+
+### Tests
+
+- `engine/server/chat/ChatSanitizerTests.cpp` — couvre : truncation à 255 octets sur frontière UTF-8 (pas couper un codepoint multi-byte), rejet de `|H...|h`, rejet de zero-width-joiner, échappement de backslashes, message vide.
+- `engine/server/chat/ChatGateTests.cpp` — couvre : mute global → false, anti-flood seuil dépassé → false, restriction niveau → false, joueur en règle → true.
+- `engine/server/chat/ChatCommandRouterTests.cpp` — couvre : `.ban account toto` route bien dans la sous-table `ban`, niveau de sécurité insuffisant → rejet, commande inexistante → message d'erreur.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A (pas d'asset)
+- Outils offline : N/A
+- Tous les chemins dans la config relatifs à `paths.content` si besoin (pas de chemin absolu)
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. `ChatGate::CanSpeak`
+
+Agrège **dans cet ordre** (court-circuite à la première raison de refus) :
+
+1. Le compte est-il banni globalement ? (`AccountStore::IsBanned`)
+2. Le compte/personnage est-il muté ? (table `chat_mutes` à créer, colonnes `account_id`, `until_ts`, `reason`)
+3. Anti-flood : compteur sliding-window (10s et 60s) par accountId. Implémentation `std::deque<int64_t>` des timestamps des N derniers messages.
+4. Niveau minimum requis pour le canal (ex. world chat ≥ 5).
+5. Restriction de canal (membre de la guilde pour guild chat, dans le groupe pour party chat, etc.).
+
+Retourne `true` + `denyReason = ""` ou `false` + `denyReason` rempli pour log/erreur client.
+
+### 2. `ChatSanitizer::Sanitize`
+
+Étapes en série :
+
+1. **Truncation UTF-8 safe** : on cherche le dernier byte dont le high bit est 0 ou la frontière de codepoint avant 255 octets. Tronque à cette position, jamais au milieu d'un codepoint.
+2. **Strip caractères invisibles** : zéro-width joiner (U+200B-U+200F, U+FEFF, U+202A-U+202E). Optionnel via config.
+3. **Rejet des hyperlinks forgés** : pattern `|H<type>:<args>|h<text>|h` — autorisé uniquement si `<type>` est dans la whitelist (`item:`, `quest:`, `achievement:`, `spell:`). Tout autre = rejet du message.
+4. **Échappement** : aucun (les hyperlinks valides passent tels quels au client).
+5. **Limite finale** : si après strip le message est vide, rejet.
+
+### 3. `ChatChannelRegistry`
+
+- Map `channelName → ChannelState`.
+- `ChannelState` : `ownerAccountId`, `password` (vide = pas de password), `bannedAccounts: std::unordered_set<uint32>`, `members: std::unordered_set<uint32>`.
+- `Join(accountId, name, password)` :
+  - Crée le canal si inexistant et l'`accountId` devient owner.
+  - Si existant : vérifie password, vérifie pas dans ban-list.
+- `Leave(accountId, name)` :
+  - Si l'owner part : transfert au plus ancien membre (priorité aux modérateurs si jamais on en ajoute).
+- Channels persistés ? **Non au début** — purement runtime master. Persistance différée à un futur ticket.
+
+### 4. `ChatCommandRouter`
+
+```cpp
+struct ChatCommand {
+  std::string_view name;
+  AccountRole minRole;          // de Accounts (P2)
+  bool (*handler)(const ChatContext&, std::string_view args);
+  const ChatCommand* subTable;  // nullptr si feuille
+  size_t subTableSize;
+};
+
+static const ChatCommand kCommandsBan[] = {
+  {"account", AccountRole::Moderator, HandleBanAccount, nullptr, 0},
+  {"ip",      AccountRole::Admin,     HandleBanIp,      nullptr, 0},
+};
+
+static const ChatCommand kCommandsRoot[] = {
+  {"ban",   AccountRole::Moderator, nullptr, kCommandsBan, std::size(kCommandsBan)},
+  {"kick",  AccountRole::Moderator, HandleKick, nullptr, 0},
+  {"help",  AccountRole::Player,    HandleHelp, nullptr, 0},
+};
+```
+
+`Resolve(input)` parse `.ban account toto` → recherche `ban` dans root → puis `account` dans subTable → vérifie `minRole` ≤ rôle de l'appelant → invoque `HandleBanAccount`.
+
+Note : `AccountRole` vient du ticket Accounts (CMANGOS.06) — câbler une fois ce dernier livré.
+
+### 5. Split master/shard
+
+| Type de message | Cible | Opcode | Justification |
+|---|---|---|---|
+| `say` | shard | `kOpcodeChatLocal` (nouveau) | Proximité 3D, broadcast aux joueurs dans X mètres |
+| `yell` | shard | `kOpcodeChatLocal` (nouveau) | Proximité étendue, X×3 mètres |
+| `emote` | shard | `kOpcodeChatLocal` (nouveau) | Proximité 3D |
+| `whisper` | master | `kOpcodeChatRelay` (existant) | Routage par session, master connaît qui est en ligne |
+| `party` | master | `kOpcodeChatRelay` (existant) | Master connaît la composition du groupe |
+| `guild` | master | `kOpcodeChatRelay` (existant) | Master connaît les membres |
+| `channel` | master | `kOpcodeChatRelay` (existant) | Channel est master-side |
+| `world` | master | `kOpcodeChatRelay` (existant) | Broadcast cross-shard |
+
+Le client envoie l'opcode adapté selon le type. Le `ChatRelayHandler` côté master rejette `say/yell/emote` (réponse erreur dirigeant vers le shard). Le `ChatLocalRelay` côté shard rejette `whisper/party/guild/channel/world` (réponse erreur dirigeant vers le master).
+
+## Étapes d'implémentation
+
+1. **Allouer les nouveaux opcodes** (`kOpcodeChatLocal`, `kOpcodeChatLocalEcho`) dans `engine/network/ProtocolV1Constants.h` et bumper `kProtocolVersion` (wire-breaking).
+2. **Créer `engine/server/chat/`** avec les 4 fichiers `.{h,cpp}` (Gate, Sanitizer, ChannelRegistry, CommandRouter).
+3. **Implémenter `ChatSanitizer`** en premier (le plus testable, isolé).
+4. **Implémenter `ChatGate`** ; ajouter la migration DB `00xx_chat_mutes.sql`.
+5. **Implémenter `ChatChannelRegistry`** ; ajouter handlers pour les nouveaux opcodes (`JoinChannel`, `LeaveChannel`, `SendChannelMessage`).
+6. **Implémenter `ChatCommandRouter`** avec un set initial minimal (`.help`, `.kick`, `.mute`).
+7. **Modifier `ChatRelayHandler`** pour passer chaque message par `ChatGate::CanSpeak` puis `ChatSanitizer::Sanitize` avant routage. Rejeter explicitement `say/yell/emote`.
+8. **Créer `ChatLocalRelay`** côté shard pour `say/yell/emote`. Pas d'AoI au début — broadcast shard simple en fallback (tag TODO pour intégration AoI quand Grids arrive).
+9. **Câbler la config** dans `engine/core/Config` (lecture des clés `chat.*`).
+10. **Tests** : 3 fichiers de tests listés dans Livrables.
+11. **Doc** : ajouter un paragraphe « Chat — split master/shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard) via presets existants
+- [ ] Build Windows OK (client) via presets existants
+- [ ] Tous les tests `Chat*Tests` passent
+- [ ] Smoke test : 2 clients connectés peuvent s'envoyer un whisper, un party message, un say (proximité), et `.help` côté client GM
+- [ ] Tentative d'injection `|Hbadtype:foo|hbar|h` → message rejeté avec `denyReason` loggé via `LOG_FILTERED(Warn, ChatRelay, ...)`
+- [ ] Tentative de message > 255 octets → tronqué proprement à la frontière UTF-8
+- [ ] Tentative anti-flood : 11 messages en 10 secondes → 11ᵉ rejeté
+- [ ] Migration DB `chat_mutes` appliquée et idempotente
+- [ ] `kProtocolVersion` bumpé, master + shard + client redéployés en lock-step
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **UTF-8 truncation** : ne **jamais** tronquer au milieu d'un codepoint multi-byte — sinon le client affiche `?` ou crashe selon le moteur de texte. Tester avec emoji 4-bytes (`U+1F600` = 😀).
+- **Split master/shard wire-breaking** : c'est un changement de protocole. Les clients pré-PR ne pourront pas envoyer `say/yell` ; bumper `kProtocolVersion` et redéployer master + shard + client en lock-step (cf. CLAUDE.md).
+- **Persistance des channels** : volontairement **pas** persistés au début. Si le master redémarre, tous les canaux dynamiques sont perdus. C'est acceptable pour la v1 ; à reconsidérer si les guildes utilisent massivement des canaux thématiques (futur ticket).
+- **Anti-flood = état par accountId mais sliding window** : ne pas utiliser un simple compteur reset à chaque seconde, sinon attaque trivialisée par burst en début de fenêtre. `std::deque<int64_t>` purgé à chaque check est la bonne structure.
+- **Command security** : ne jamais router une commande sans avoir vérifié `minRole`. Le routeur **doit** être le seul point qui fait ce check, pas le handler — sinon une commande oubliera de check et créera une escalade de privilèges.
+- **Hyperlink whitelist** : démarrer **strict** (4 types). Élargir uniquement après audit de chaque nouveau type. Un type non-whitelisté = rejet, pas strip silencieux (le strip silencieux casse l'UX, le rejet apprend au joueur).
+- **Mode debug** : activer `log.filters.chat_relay = true` (déjà disponible via PR #468) pour tracer le routage en cas de bug.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Chat (P1 cross master+shard)
+- cmangos `src/game/Chat/Chat.cpp`, `src/game/Chat/ChannelMgr.cpp`, `src/game/Chat/Level0.cpp` à `Level3.cpp`
+- PR #468 (logger avec filtres bitmask) — la PR suivante peut activer `LogFilter::ChatRelay`

--- a/tickets/CMANGOS/CMANGOS.02_Entities_hierarchy_objectguid_updatefields.md
+++ b/tickets/CMANGOS/CMANGOS.02_Entities_hierarchy_objectguid_updatefields.md
@@ -1,0 +1,272 @@
+# CMANGOS.02_Entities_hierarchy_objectguid_updatefields
+
+## Objectif
+
+Mettre en place le **socle d'entités du shard** LCDLLN, inspiré de
+`src/game/Entities` cmangos, qui sert de fondation à toute la simulation
+côté serveur :
+
+1. Une **hiérarchie Object → WorldObject → Unit → Player/Creature/Pet** +
+   `GameObject`/`Item`/`Corpse` partageant des concepts communs (position,
+   GUID, état actif).
+2. Un **`ObjectGuid` universel** (64 bits) avec le type encodé dans les
+   bits hauts, routeable entre master ↔ shard sans table de lookup
+   secondaire.
+3. **`UpdateFields` + `UpdateMask`** : sérialisation par delta des champs
+   réseau (chaque champ a un index dans un tableau, un bitmask marque les
+   « dirty »). Pré-requis #1 pour AoI scalable — sans ça, la bande
+   passante explose dès 50 joueurs co-localisés.
+4. **`TemporarySpawn`** comme classe dédiée pour les entités à durée de
+   vie limitée (projectiles persistants, summons, totems) — évite de
+   polluer le spawn pool persistant.
+5. **`CreatureLinkingMgr`** data-driven : « si A meurt alors B respawn /
+   B aggro » décrit en table DB, pas en code.
+
+C'est un **P1 squelette** : la majorité des features gameplay (combat,
+spells, AoI, mouvement) en dépendent.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.03 (Grids — pour exposer `WorldObject::AddToWorld()` qui insère dans la grille)
+- CMANGOS.05 (Movement — `WorldObject` porte la position que Movement met à jour)
+
+L'ordre conseillé d'implémentation est : Entities (squelette des classes
+sans persistance complète) → Grids → Movement, en allant et venant.
+
+## Livrables
+
+### Côté shard (`engine/server/shard/entities/`)
+
+- `Object.{h,cpp}` — racine de la hiérarchie, porte le `ObjectGuid` et le
+  tableau `UpdateFields`.
+- `WorldObject.{h,cpp}` — ajoute position 3D (x, y, z, orientation),
+  zoneId, mapId, et l'API `AddToWorld()` / `RemoveFromWorld()`.
+- `Unit.{h,cpp}` — ajoute stats (HP, mana, level, faction), state combat,
+  équipement minimal, mouvement (référence vers MotionMaster, à arriver
+  plus tard).
+- `Player.{h,cpp}` — sous-classe de Unit avec session client.
+- `Creature.{h,cpp}` — sous-classe de Unit, IA + spawn pool.
+- `GameObject.{h,cpp}` — sous-classe de WorldObject (portes, coffres,
+  panneaux).
+- `Item.{h,cpp}` — sous-classe de Object (pas de position monde
+  directement, vit dans un inventaire).
+- `Corpse.{h,cpp}` — sous-classe de WorldObject (corps de joueur mort).
+- `TemporarySpawn.{h,cpp}` — classe utilitaire pour spawn éphémère
+  (durée, owner, despawn auto).
+- `CreatureLinkingMgr.{h,cpp}` — singleton chargé au boot depuis la DB.
+
+### Système GUID & UpdateFields (`engine/server/shard/entities/`)
+
+- `ObjectGuid.{h,cpp}` — wrapper 64 bits, encode `(uint8 type, uint16 entry, uint64 counter)`.
+  - Types : Player, Creature, Pet, GameObject, Item, Corpse, DynamicObject.
+  - Méthodes : `IsPlayer()`, `IsCreature()`, `GetEntry()`, `GetCounter()`,
+    `ToString()`, `FromString()`, `operator<<` pour `ByteBuffer`.
+- `UpdateFields.h` — enum centralisée des indices de champs réseau, par
+  type d'entité (`PLAYER_FIELD_HEALTH`, `UNIT_FIELD_LEVEL`,
+  `OBJECT_FIELD_GUID`…).
+- `UpdateMask.{h,cpp}` — bitmask compact, API `SetBit(idx)`, `GetBit(idx)`,
+  `Serialize(ByteBuffer&)`, `Reset()`.
+
+### Snapshot delta réseau
+
+- `engine/server/shard/snapshot/SnapshotBuilder.{h,cpp}` — pour chaque
+  joueur cible, parcourt les `WorldObject` dans son AoI (via Grids) et
+  construit un payload `UPDATE_OBJECT` ne contenant que les champs dirty
+  de chaque entité dirty. Reset des masks à la fin du tick.
+
+### Configuration (`config.json`)
+
+```json
+"entities": {
+  "max_active_per_grid": 200,
+  "creature_linking_enabled": true,
+  "temporary_spawn_default_lifetime_sec": 60
+}
+```
+
+### Migration DB
+
+- `engine/server/migrations/00xx_creature_linking.sql` :
+  ```sql
+  CREATE TABLE creature_linking_template (
+    entry          INT UNSIGNED NOT NULL,
+    master_entry   INT UNSIGNED NOT NULL,
+    flags          INT UNSIGNED NOT NULL,  -- bitmask: ON_DEATH_RESPAWN, ON_AGGRO_AGGRO, ...
+    search_range   FLOAT NOT NULL DEFAULT 0,
+    PRIMARY KEY (entry, master_entry)
+  );
+  ```
+
+### Tests
+
+- `engine/server/shard/entities/ObjectGuidTests.cpp` — round-trip
+  encode/decode, `ToString` round-trip, ordering.
+- `engine/server/shard/entities/UpdateMaskTests.cpp` — set/get, sérialisation
+  compacte (un seul bit set ne devrait pas envoyer 32 bits).
+- `engine/server/shard/snapshot/SnapshotBuilderTests.cpp` — un Unit dont
+  seul HP change ne génère qu'un payload contenant l'index `UNIT_FIELD_HEALTH`.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A
+- Outils offline : N/A
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. `ObjectGuid` (64 bits)
+
+```
+[ 8 bits type | 16 bits entry (template id) | 40 bits counter ]
+```
+
+- `type` : `Player=1, Creature=2, Pet=3, GameObject=4, Item=5, Corpse=6, DynamicObject=7`.
+- `entry` : `creature_template.entry` ou `gameobject_template.entry`.
+  Pour Player/Item/Corpse, `entry = 0`.
+- `counter` : auto-incrémenté à la création, unique par type. Persisté
+  pour Player/Item (DB primary key), volatile pour Creature/Pet/Corpse
+  (compteur runtime, reset au reboot du shard).
+
+Routage master/shard : un `ObjectGuid` est self-describing — le master
+peut router un message vers le bon shard sans avoir une table secondaire
+si une convention `counter % nbShards = shardId` est appliquée pour les
+entités shard-locales (à débattre dans un futur ticket).
+
+### 2. `UpdateFields` + `UpdateMask`
+
+Inspiré directement de cmangos mais adapté C++20 :
+
+```cpp
+enum class ObjectField : uint16_t {
+  Guid           = 0,  // 8 bytes (= 2 slots de 32 bits)
+  Type           = 2,
+  Entry          = 3,
+  ScaleX         = 4,
+  Padding        = 5,
+  ObjectFieldEnd = 6
+};
+
+enum class UnitField : uint16_t {
+  Health = ObjectField::ObjectFieldEnd,
+  MaxHealth,
+  Level,
+  Faction,
+  ...
+  UnitFieldEnd
+};
+```
+
+Chaque entité tient un `std::array<uint32_t, kFieldCount>` + un
+`UpdateMask` de même taille. Modifier un champ via `SetField(idx, value)`
+qui met `mask.SetBit(idx)`.
+
+À chaque tick AoI :
+
+```cpp
+for (auto* obj : visibleObjects) {
+  if (obj->HasDirtyFields()) {
+    builder.AppendUpdate(obj);  // ne sérialise que les dirty
+  }
+}
+// puis :
+for (auto* obj : objects) obj->ResetDirtyFields();
+```
+
+**Format de sérialisation `UPDATE_OBJECT`** :
+
+```
+[ uint16 opcode ][ varint nbObjects ]
+  pour chaque objet :
+    [ ObjectGuid (8 bytes) ]
+    [ UpdateMask compact (longueur variable) ]
+    [ pour chaque bit set, valeur 4 bytes (ou 8 pour les champs 64 bits) ]
+```
+
+`UpdateMask compact` : RLE-encodé ou tableau de `uint32` avec préfixe de
+longueur (à benchmarker). cmangos utilise un préfixe de longueur en
+nombre de blocs de 32 bits + le tableau brut — démarrer pareil, optimiser
+si la profilage montre que le mask domine.
+
+### 3. `WorldObject::AddToWorld()` / `RemoveFromWorld()`
+
+Une fois Grids livré (CMANGOS.03), `AddToWorld()` insère l'entité dans la
+cellule appropriée et la marque pour notification AoI. `RemoveFromWorld()`
+inverse.
+
+Avant Grids : ces méthodes sont des stubs qui marquent juste un flag
+`m_inWorld`. Tag `// TODO(CMANGOS.03)` clairement.
+
+### 4. `TemporarySpawn`
+
+Sous-classe de `Creature` (ou `WorldObject` selon usage) avec :
+
+- `m_lifetimeMs` : durée de vie maximale.
+- `m_ownerGuid` : qui a invoqué (utilisé pour cleanup à la mort/déco du owner).
+- `m_despawnReason` : enum (`Lifetime`, `OwnerGone`, `Combat`, `Manual`).
+
+Auto-despawn dans le tick si `now > spawnTime + lifetime` ou
+`owner == nullptr`.
+
+### 5. `CreatureLinkingMgr`
+
+Charge `creature_linking_template` au boot. API :
+
+```cpp
+class CreatureLinkingMgr {
+public:
+  void Load(ConnectionPool& db);
+  // À l'événement, retourne la liste de creatures liées à exécuter.
+  std::vector<LinkAction> GetLinksFor(uint32_t entry, LinkEvent event) const;
+};
+```
+
+`LinkEvent` : `OnDeath`, `OnAggro`, `OnRespawn`, `OnEvade`.
+
+Câblé dans `Creature::OnDeath()`, etc., pour déclencher les actions
+liées (`RESPAWN_LINKED`, `AGGRO_LINKED`).
+
+## Étapes d'implémentation
+
+1. Créer le dossier `engine/server/shard/entities/`.
+2. **Implémenter `ObjectGuid`** + ses tests (le plus isolé, le plus testable).
+3. **Implémenter `UpdateMask`** + ses tests.
+4. **Implémenter `Object`** (header avec `m_guid`, `m_updateFields`, `m_updateMask`).
+5. **Implémenter `WorldObject`** (Object + position).
+6. **Implémenter `Unit`** + `Player` + `Creature` minimaux (champs réseau, pas de gameplay).
+7. **Implémenter `GameObject`, `Item`, `Corpse`** comme stubs.
+8. **Implémenter `SnapshotBuilder`** côté serveur shard (peut être stubbé sans Grids : itère tous les WorldObject de la map).
+9. **Définir l'opcode `kOpcodeUpdateObject`** côté wire (master+shard+client).
+10. **Implémenter `TemporarySpawn`** (peut attendre une feature qui le requiert ; au minimum la classe + cleanup tick).
+11. **Migration DB + `CreatureLinkingMgr`**.
+12. **Tests** : 3 fichiers listés.
+13. **Doc** : ajouter une section « Entités shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) via presets existants
+- [ ] Tests `ObjectGuidTests`, `UpdateMaskTests`, `SnapshotBuilderTests` passent
+- [ ] Smoke test : créer un Player+Creature côté shard, modifier 2 champs, vérifier que le snapshot ne contient que ces 2 champs (pas le tableau complet)
+- [ ] Round-trip `ObjectGuid::ToString()` + `FromString()` ok pour les 7 types
+- [ ] Migration `creature_linking_template` appliquée et idempotente
+- [ ] `kOpcodeUpdateObject` documenté côté master/shard/client (même valeur, même format)
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Sizing des UpdateFields** : cmangos a des champs réseau **et** des champs runtime (cooldowns, threats…). Ne jamais sérialiser les champs runtime — sinon fuite d'info ou bande passante gaspillée. Garder les deux séparés (`UpdateFields` réseau ; membres C++ classiques pour le runtime).
+- **Reset du mask** : appeler `ResetDirtyFields()` **après** que tous les joueurs cibles aient reçu le snapshot. Si on reset trop tôt (au milieu du tick), des cibles loupent les updates.
+- **GUID counter overflow** : 40 bits = 1 trillion, suffisant pour des décennies. Mais le compteur Creature/Pet est volatile (reset au reboot) — si un client ressuscite avec un GUID stale, il faut renvoyer un `OBJECT_DESTROYED` avant le nouveau `OBJECT_CREATED`. Le snapshot builder doit gérer ça.
+- **Hiérarchie virtuelle** : Object → WorldObject → Unit → Player. **6 niveaux d'héritage** est tolérable mais à ne pas étendre à la légère ; chaque niveau ajoute un offset et complique le debug. Garder Camera **hors** hiérarchie (composition, pas héritage) pour ne pas alourdir.
+- **TemporarySpawn et Creature::OnDeath** : si une TemporarySpawn meurt en combat, **ne pas** déclencher le respawn timer normal de Creature. Override explicite.
+- **`CreatureLinkingMgr` : éviter les cycles** : si A meurt → B aggro et B meurt → A respawn, on a une boucle infinie. Le mgr doit détecter les cycles au load et les rejeter avec un log d'erreur.
+- **ObjectGuid 64 bits vs `uint64_t` brut** : utiliser une **classe** (pas un alias), pour bloquer les conversions implicites accidentelles (`uint64_t` à `int` perd les bits hauts). Définir `operator==`, `operator<`, `std::hash<ObjectGuid>`.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Entities (P1 shard)
+- cmangos `src/game/Entities/Object.h`, `ObjectGuid.h`, `UpdateData.cpp`,
+  `UpdateMask.h`, `Unit.h`, `Player.h`, `Creature.h`, `TemporarySpawn.h`,
+  `CreatureLinkingMgr.h`

--- a/tickets/CMANGOS/CMANGOS.03_Grids_spatial_partitioning_aoi.md
+++ b/tickets/CMANGOS/CMANGOS.03_Grids_spatial_partitioning_aoi.md
@@ -1,0 +1,248 @@
+# CMANGOS.03_Grids_spatial_partitioning_aoi
+
+## Objectif
+
+Mettre en place le **partitionnement spatial 2D** du monde côté shard
+LCDLLN, base de toute simulation MMO scalable :
+
+1. **Grille 2D de taille fixe** sur chaque `Map` du shard. Chaque cellule
+   contient les `WorldObject` qui s'y trouvent.
+2. **Visitor pattern templated** sur les types contenus (Player, Creature,
+   GameObject, …) : dispatch statique compile-time, zéro virtual call dans
+   le hot path d'AoI.
+3. **Searchers / Workers / Checks composables** : foncteurs paramétrant
+   les searchers — on écrit `NearestAttackableUnitInObjectRangeCheck`
+   une fois et on le passe à n'importe quel searcher.
+4. **GridStates state machine** (`Loaded` / `Active` / `Idle` / `Removal`) :
+   chargement/déchargement dynamique selon la présence de joueurs. On
+   n'update que les cellules `Active`.
+5. **`GridNotifiers` pour broadcast spatial** : `MessageDistDeliverer` ne
+   parcourt que les cellules dans le rayon, jamais la map entière.
+
+C'est le ticket **fondateur** pour l'AoI : toute boucle sur les
+`WorldObject` (snapshot, broadcast chat de proximité, recherche de
+cibles, AoE de sort) doit passer par les grids. Sans ça, dès 100 joueurs
+co-localisés on a un O(N²) qui tue le tick.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `WorldObject::AddToWorld()` insère dans la grille
+- Pré-requis pour : CMANGOS.04 (Movement), CMANGOS.05 (vmap), CMANGOS.13 (Maps), tout le PvE/PvP
+
+## Livrables
+
+### Côté shard (`engine/server/shard/grid/`)
+
+- `GridDefines.h` — constantes : `kCellSize` (mètres), `kCellsPerMap`,
+  enums `GridState` (`Loaded`, `Active`, `Idle`, `Removal`).
+- `GridRefManager.h` (templated) — intrusive list reference manager :
+  chaque WorldObject porte un `GridReference<T>` qui s'auto-invalide à
+  la suppression. Évite les dangling pointers sans coût atomique
+  `shared_ptr`.
+- `Grid.{h,cpp}` (templated) — une cellule. Contient `GridRefManager` par
+  type d'entité présent.
+- `GridMap.{h,cpp}` — la grille 2D entière de la Map. API
+  `GetGrid(x, y)`, `LoadGrid(x, y)`, `UnloadGrid(x, y)`.
+- `GridStateMachine.{h,cpp}` — gestion des transitions Loaded ↔ Active ↔
+  Idle ↔ Removal selon présence joueurs et timers.
+
+### Visitor / Searchers / Notifiers (`engine/server/shard/grid/`)
+
+- `GridVisitors.h` — templates `Visitor<T>` qui visitent un type spécifique.
+- `GridSearchers.h` — templates `WorldObjectSearcher<Check>`,
+  `CreatureListSearcher<Check>`, etc. paramétrés par un Check (foncteur).
+- `GridChecks.h` — foncteurs prêts à l'emploi :
+  `NearestAttackableUnitInObjectRangeCheck`,
+  `AnyPlayerInObjectRangeCheck`,
+  `MostHpMissingNotSelfFriendlyCheck`, …
+- `GridNotifiers.{h,cpp}` :
+  - `MessageDistDeliverer` — broadcast un paquet aux joueurs dans rayon.
+  - `VisibleNotifier` — recompute la visibility pour un joueur (qui voit
+    qui).
+
+### Configuration (`config.json`)
+
+```json
+"grid": {
+  "cell_size_meters": 100.0,
+  "active_distance_meters": 200.0,
+  "idle_timeout_sec": 300,
+  "unload_timeout_sec": 1800
+}
+```
+
+### Tests
+
+- `engine/server/shard/grid/GridMapTests.cpp` — insertion/retrait
+  d'entités, voisinage correct.
+- `engine/server/shard/grid/GridStateTests.cpp` — transitions, timers.
+- `engine/server/shard/grid/GridSearcherTests.cpp` — searcher avec un
+  Check synthétique trouve les bonnes entités.
+- `engine/server/shard/grid/GridNotifierTests.cpp` — `MessageDistDeliverer`
+  ne livre qu'aux joueurs dans le rayon, ignore les cellules hors range.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A
+- Outils offline : N/A
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Géométrie de la grille
+
+- Chaque `Map` a une grille `kCellsPerMap × kCellsPerMap` cellules.
+- Cellule = carré de `kCellSize` mètres (défaut 100 m).
+- Coordonnées cellule : `(cx, cy) = (floor(worldX / kCellSize), floor(worldY / kCellSize))`.
+- Indexation : `gridIndex = cy * kCellsPerMap + cx` (1D pour cache-friendly).
+- Z ignoré au niveau de la grille (toujours 2D ; vmap gère la 3D LOS).
+
+### 2. `GridReference<T>` (intrusive list)
+
+```cpp
+template <class T>
+class GridReference {
+public:
+  GridReference() = default;
+  ~GridReference() { unlink(); }
+  GridReference(const GridReference&) = delete;
+  // move ok
+  void link(T* obj, GridRefManager<T>* mgr);
+  void unlink();
+  T*   getTarget() const { return m_target; }
+private:
+  T*                   m_target = nullptr;
+  GridRefManager<T>*   m_mgr    = nullptr;
+  GridReference*       m_prev   = nullptr;
+  GridReference*       m_next   = nullptr;
+};
+```
+
+- Quand un `WorldObject` est détruit, son `GridReference` se détache
+  automatiquement de la liste — pas de dangling pointer.
+
+### 3. Visitor pattern templated
+
+```cpp
+template <class VISITOR, class TYPE_CONTAINER>
+struct ContainerVisitor {
+  VISITOR& visitor;
+  void Visit(GridRefManager<TYPE_CONTAINER>& m) {
+    for (auto& ref : m) {
+      visitor.Visit(*ref.getTarget());
+    }
+  }
+};
+```
+
+Le visitor a une méthode `Visit(Player&)`, `Visit(Creature&)` etc. — le
+compilateur sélectionne la bonne au compile-time. Pas de virtual call.
+
+### 4. Searcher composable
+
+```cpp
+template <class CHECK>
+class CreatureSearcher {
+public:
+  CreatureSearcher(Creature*& result, CHECK& check)
+    : m_result(result), m_check(check) {}
+  void Visit(Creature& c) {
+    if (m_check(c)) m_result = &c;  // ou conserve le meilleur
+  }
+private:
+  Creature*& m_result;
+  CHECK&     m_check;
+};
+```
+
+Usage :
+
+```cpp
+NearestAttackableUnitInObjectRangeCheck check(self, 30.0f);
+Creature* nearest = nullptr;
+CreatureSearcher searcher(nearest, check);
+gridMap.VisitNeighbours(self->GetPosition(), 30.0f, searcher);
+```
+
+### 5. State machine `GridState`
+
+| État | Quand | Update | Mémoire |
+|---|---|---|---|
+| `Loaded` | Cellule en RAM mais aucun joueur ne la regarde | Non | Oui |
+| `Active` | Au moins 1 joueur dans `active_distance_meters` | **Oui** | Oui |
+| `Idle` | Plus de joueur depuis `idle_timeout_sec` | Non (mais entités gardées) | Oui |
+| `Removal` | Idle depuis `unload_timeout_sec` | Non | **Non**, déchargée du DB cache |
+
+Transitions :
+
+- `Loaded → Active` : un joueur entre.
+- `Active → Idle` : tous les joueurs partent + délai.
+- `Idle → Active` : un joueur revient.
+- `Idle → Removal` : timeout dépassé sans joueur.
+
+Le tick de la `Map` (CMANGOS.13) ne visite **que** les cellules `Active`
+pour mouvements/IA. Économie majeure de CPU sur les zones désertes.
+
+### 6. `MessageDistDeliverer`
+
+```cpp
+class MessageDistDeliverer {
+public:
+  MessageDistDeliverer(WorldObject const& source, ByteBuffer&& packet, float dist);
+  void Visit(Player& target);
+  void Visit(Creature& target);  // no-op pour broadcast joueur uniquement
+private:
+  WorldObject const&  m_source;
+  ByteBuffer          m_packet;
+  float               m_distSq;
+};
+```
+
+`gridMap.VisitNeighbours(source.pos, dist, deliverer)` envoie le packet à
+chaque Player dans le rayon, sans toucher aux cellules hors range.
+
+Utilisé par : chat de proximité (`say`/`yell`/`emote` côté shard, cf.
+CMANGOS.01), broadcast d'animation, snapshot AoI.
+
+## Étapes d'implémentation
+
+1. **Créer `engine/server/shard/grid/`**.
+2. **Implémenter `GridReference` + `GridRefManager`** (templated, intrusive list).
+3. **Implémenter `Grid<T>` + `GridMap`** : insertion/retrait, lookup par coord, voisinage 3×3 cellules.
+4. **Implémenter `ContainerVisitor`** + un visitor de test trivial.
+5. **Implémenter le 1er searcher (`CreatureSearcher`)** + 1er check (`NearestAttackableUnitInObjectRangeCheck`).
+6. **Implémenter `MessageDistDeliverer`** + test : broadcast à 3 joueurs dont 1 hors range → 2 reçoivent.
+7. **Implémenter `GridStateMachine`** : transitions selon présence joueurs + timers.
+8. **Câbler `WorldObject::AddToWorld()`** (CMANGOS.02) : insère le WorldObject dans la grille appropriée.
+9. **Câbler `Map::Update()`** : ne visite que les cellules `Active`.
+10. **Tests** : 4 fichiers listés.
+11. **Doc** : section « Grid spatial / AoI » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) via presets existants
+- [ ] Tests `Grid*Tests` passent
+- [ ] Smoke test : 100 entités spawned aléatoirement sur une map ; un searcher avec rayon 50 m ne visite que les cellules pertinentes (mesurable via compteur)
+- [ ] `MessageDistDeliverer` envoie à exactement les joueurs dans le rayon (test paramétré)
+- [ ] State machine : 1 cellule passe `Loaded → Active` en entrée joueur, `Active → Idle` après timeout, `Idle → Removal` après timeout
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Cell size** : 100 m est un défaut raisonnable pour un MMO (joueur voit ~50-80 m, donc voisinage 3×3 cellules ≈ 300×300 m ≈ couvre 99% des AoI). Trop petit = trop de cellules à visiter (overhead). Trop grand = chaque cellule trop chargée. **Profilage avant ajustement.**
+- **Voisinage 3×3 vs 5×5** : pour la plupart des recherches AoI, 3×3 cellules autour du source suffit (rayon < 1.5 × cellSize). Les recherches à grand rayon (broadcast world chat, AoE sort epic) doivent demander 5×5 ou plus — exposer un paramètre `radius` à `VisitNeighbours`, pas une constante.
+- **Dispatch statique** : ne **jamais** introduire de virtual call dans le visitor. Si on a besoin d'un dispatch dynamique (rare), utiliser `std::variant` ou un visitor concret par type — pas une classe abstraite avec `virtual Visit()`.
+- **Z ignoré** : la grille est 2D. Un dragon volant à 100 m d'altitude est dans la même cellule que le joueur au sol. Pour les requêtes 3D précises (LOS, height), passer par vmap (CMANGOS.05). La grille est uniquement un filtre grossier.
+- **GridReference ≠ pointeur partagé** : si du code conserve un `WorldObject*` brut au-delà du tick, c'est un bug. Toute référence longue durée doit utiliser un `ObjectGuid` (CMANGOS.02) + lookup à chaque utilisation.
+- **State machine timers** : utiliser une horloge monotone (`std::chrono::steady_clock`), pas wall clock — sinon un changement d'heure système peut faire decharger toute la map d'un coup.
+- **Persistance des entités à l'unload** : à l'`Idle → Removal`, les Creatures non-spawned-pool doivent être sauvegardées en DB si elles ont un état modifié (HP bas, position non-default). À détailler dans un futur ticket Map (CMANGOS.13).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Grids (P1 shard)
+- cmangos `src/game/Grids/GridDefines.h`, `GridRefManager.h`,
+  `GridNotifiers.cpp`, `GridSearchers.h`, `GridStates.cpp`
+- cmangos `src/game/Maps/Map.cpp` (utilisateur principal des grids)

--- a/tickets/CMANGOS/CMANGOS.04_Movement_server_authoritative_splines.md
+++ b/tickets/CMANGOS/CMANGOS.04_Movement_server_authoritative_splines.md
@@ -1,0 +1,287 @@
+# CMANGOS.04_Movement_server_authoritative_splines
+
+## Objectif
+
+Mettre en place un système de mouvement **server-authoritative basé sur
+des splines** entre shard et client, inspiré de `src/game/Movement` de
+cmangos. Bénéfices visés :
+
+1. **Économie de bande passante massive** vs streaming de positions à
+   chaque tick. Un déplacement de 50 m en ligne droite = 1 paquet
+   (control points + durée) au lieu de 50-100 packets de position. Ratio
+   typique ×10 à ×50.
+2. **Moins de jitter visuel** côté client : l'interpolation locale entre
+   control points est lisse même si quelques paquets sont perdus.
+3. **AoI scalable** : avec moins de packets/seconde par entité, le shard
+   peut diffuser le mouvement de centaines d'entités sans saturer.
+4. **Validation anticheat** : le serveur connaît à l'avance le chemin
+   nominal d'une créature, peut détecter facilement un client qui
+   essaie de raccourcir.
+
+Ce ticket couvre les 5 patterns clés cmangos :
+
+- `MoveSpline` server-side (état, durée, points de contrôle)
+- `MoveSplineFlag` bitmask multi-modes (walk/fly/swim/falling/cyclic)
+- `packet_builder` isolé (sérialisation pure, testable)
+- Math des splines (Catmull-Rom, Bézier) header-only templated
+- `typedefs.h` centralisé pour `Vector3`/`Vector4`
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `Unit` porte le `MoveSpline`
+- CMANGOS.03 (Grids) — broadcast du paquet `SMSG_MONSTER_MOVE` via `MessageDistDeliverer`
+
+## Livrables
+
+### Côté shard (`engine/server/shard/movement/`)
+
+- `MoveSpline.{h,cpp}` — état d'une spline en cours d'exécution sur un
+  Unit : control points, vélocité, durée, mode (run/walk/fly/swim),
+  flags, time elapsed, callback de fin.
+- `MoveSplineInit.{h,cpp}` — **builder pattern** : configuration fluente
+  d'une nouvelle spline avant `Launch()`.
+- `MoveSplineFlag.h` — `enum class` bitmask 32 bits.
+- `Spline.h` (header-only templated) — math des splines :
+  `template <typename T> class Spline { ... }` avec spécialisations
+  Catmull-Rom et Bézier. T = Vector3 le plus souvent.
+- `MoveSplinePacketBuilder.{h,cpp}` — sérialisation pure d'un
+  `MoveSpline` vers un `ByteBuffer`. Testable sans serveur.
+
+### Côté client (`engine/client/movement/`)
+
+- `MoveSplineInterpolator.{h,cpp}` — reçoit un paquet `SMSG_MONSTER_MOVE`,
+  interpole localement la position du WorldObject à chaque frame.
+- `MoveSplineState.{h,cpp}` — état local par entité : spline en cours,
+  time elapsed, position courante, position attendue (pour smoothing).
+
+### Couche partagée (`engine/network/movement/`)
+
+- `MoveSplinePayloads.{h,cpp}` — schéma binaire du paquet, partagé entre
+  shard et client. Encapsule format wire et format CPU.
+- `MovementTypedefs.h` — `using Vector3 = ...`, `using Vector4 = ...`,
+  `using Quat = ...`. **Single source of truth** : un changement de
+  backend (glm, types SIMD custom) se fait dans ce fichier seulement.
+
+### Opcodes
+
+- `kOpcodeMonsterMove` (shard → client) : envoi d'une nouvelle spline.
+- `kOpcodeMonsterMoveStop` (shard → client) : interruption immédiate.
+- `kOpcodeMoveTeleportAck` (client → shard) : confirmation de téléport.
+
+### Tests
+
+- `engine/network/movement/MoveSplinePayloadsTests.cpp` — round-trip
+  serialize/deserialize d'une spline 5 points avec flags.
+- `engine/server/shard/movement/SplineMathTests.cpp` — Catmull-Rom passe
+  bien par les control points, Bézier convexe.
+- `engine/server/shard/movement/MoveSplineInitTests.cpp` — builder ;
+  `MoveTo(p1).MoveTo(p2).Launch()` produit la spline attendue.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A
+- Outils offline : N/A
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. `MoveSpline`
+
+```cpp
+class MoveSpline {
+public:
+  struct Config {
+    float                       velocity = 0.0f;     // m/s
+    MoveSplineFlag              flags = MoveSplineFlag::None;
+    std::vector<Vector3>        points;
+    std::optional<Vector3>      finalFacing;
+    std::optional<ObjectGuid>   facingTarget;
+    int32_t                     animationId = 0;
+  };
+
+  bool   IsActive() const;
+  bool   Finalized() const;
+  Vector3 ComputePosition() const;        // selon time elapsed
+  void    Update(int32_t deltaMs);
+  void    Initialize(Config&& cfg);
+  void    Stop();
+
+private:
+  Config              m_cfg;
+  Spline<Vector3>     m_spline;            // math
+  int32_t             m_timeElapsedMs = 0;
+  int32_t             m_durationMs = 0;
+};
+```
+
+### 2. `MoveSplineFlag` (bitmask 32 bits)
+
+```cpp
+enum class MoveSplineFlag : uint32_t {
+  None            = 0,
+  Walk            = 1u << 0,
+  Flying          = 1u << 1,
+  Swimming        = 1u << 2,
+  Falling         = 1u << 3,
+  NoSpline        = 1u << 4,    // ligne droite, pas de smoothing
+  Cyclic          = 1u << 5,    // boucle (patrouilles)
+  EnterCycle      = 1u << 6,    // démarre puis devient cyclique
+  Frozen          = 1u << 7,    // entité immobile (mais a une orientation)
+  TransportEnter  = 1u << 8,
+  TransportExit   = 1u << 9,
+  OrientationFixed= 1u << 10,
+  Backward        = 1u << 11,
+};
+```
+
+`operator|`, `operator&`, `operator~` overloadés pour usage type-safe.
+
+### 3. `MoveSplineInit` (builder)
+
+```cpp
+class MoveSplineInit {
+public:
+  explicit MoveSplineInit(Unit& target);
+  MoveSplineInit& MoveTo(Vector3 p);
+  MoveSplineInit& MovebyPath(std::vector<Vector3> path);
+  MoveSplineInit& SetVelocity(float v);
+  MoveSplineInit& SetFlags(MoveSplineFlag f);
+  MoveSplineInit& SetFacing(Vector3 dir);
+  MoveSplineInit& SetFacing(ObjectGuid target);
+  MoveSplineInit& SetCyclic();
+  int32_t Launch();   // calcule durée, applique au Unit, broadcast SMSG_MONSTER_MOVE
+};
+```
+
+Usage :
+
+```cpp
+MoveSplineInit(creature)
+  .MoveTo({100, 200, 50})
+  .MoveTo({110, 220, 50})
+  .SetVelocity(5.0f)
+  .SetFlags(MoveSplineFlag::Walk)
+  .Launch();
+```
+
+### 4. Math des splines (`Spline.h`)
+
+Header-only templated :
+
+```cpp
+template <typename T>
+class Spline {
+public:
+  enum class EvaluationMode { Linear, CatmullRom, Bezier3 };
+  void   Init(std::vector<T> points, EvaluationMode mode);
+  T      Evaluate(float t) const;       // t in [0, 1]
+  float  Length() const;                 // approximé par sampling
+  T      EvaluateDerivative(float t) const;
+private:
+  std::vector<T>  m_points;
+  EvaluationMode  m_mode = EvaluationMode::Linear;
+  std::vector<float> m_segmentLengths;
+};
+```
+
+Spécialisé pour `Vector3`, instanciable pour 2D ou 4D si besoin futur
+(animation de skeleton, par ex.).
+
+### 5. `MoveSplinePacketBuilder`
+
+Couche **pure** : prend un `MoveSpline`, retourne un `ByteBuffer`.
+Aucune dépendance vers le `Unit` ou le réseau. Testable trivialement.
+
+```cpp
+class MoveSplinePacketBuilder {
+public:
+  static void WriteMonsterMove(ByteBuffer& out,
+                                ObjectGuid sourceGuid,
+                                Vector3 startPos,
+                                MoveSpline const& spline);
+  static bool ParseMonsterMove(ByteBuffer& in,
+                                ObjectGuid& outGuid,
+                                Vector3& outStartPos,
+                                MoveSpline::Config& outCfg);
+};
+```
+
+### 6. Format wire `SMSG_MONSTER_MOVE`
+
+```
+[ uint16 opcode = kOpcodeMonsterMove ]
+[ ObjectGuid (8 bytes) ]
+[ Vector3 startPos (12 bytes) ]
+[ uint32 splineId (incrémente à chaque envoi pour le client) ]
+[ uint32 flags ]
+[ uint32 durationMs ]
+[ uint8  mode (0=Linear, 1=CatmullRom, 2=Bezier3) ]
+[ uint16 nbPoints ]
+[ Vector3 × nbPoints ]
+[ optional uint8 facingType + payload ]
+```
+
+### 7. Côté client : interpolation locale
+
+```cpp
+class MoveSplineInterpolator {
+public:
+  void OnMonsterMovePacket(ByteBuffer& in);
+  Vector3 GetCurrentPosition(ObjectGuid guid, double clientTimeMs);
+private:
+  std::unordered_map<ObjectGuid, MoveSplineState> m_states;
+};
+```
+
+À chaque frame, le client interpole la position de chaque entité visible
+selon sa spline en cours et le temps écoulé. **Aucune communication
+réseau** entre les paquets. Si l'entité change de direction, le serveur
+envoie une nouvelle `SMSG_MONSTER_MOVE` qui remplace l'ancienne.
+
+## Étapes d'implémentation
+
+1. **Créer `engine/network/movement/`** + `MovementTypedefs.h` (centralise `Vector3`).
+2. **Implémenter `MoveSplineFlag`** + tests basiques d'opérateurs bitmask.
+3. **Implémenter `Spline<T>`** header-only avec Linear + CatmullRom + Bezier3 ; tests math.
+4. **Implémenter `MoveSpline`** côté shard (état runtime).
+5. **Implémenter `MoveSplineInit`** (builder).
+6. **Implémenter `MoveSplinePacketBuilder`** + tests round-trip.
+7. **Allouer l'opcode `kOpcodeMonsterMove`** côté wire (master+shard+client) ; bumper `kProtocolVersion`.
+8. **Câbler côté shard** : `Unit::Update()` appelle `MoveSpline::Update(dt)`, applique la position calculée. Au `Launch()`, broadcast `MessageDistDeliverer` (CMANGOS.03).
+9. **Implémenter `MoveSplineInterpolator`** côté client.
+10. **Smoke test end-to-end** : un Creature côté shard se déplace en ligne droite ; le client affiche un mouvement lisse sans envoi continu de positions.
+11. **Tests** : 3 fichiers listés.
+12. **Doc** : section « Movement / splines » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) et Windows OK (client) via presets existants
+- [ ] Tests `MoveSplinePayloadsTests`, `SplineMathTests`, `MoveSplineInitTests` passent
+- [ ] Smoke test : 1 Creature traverse 100 m en 10 s, le client reçoit **1 seul** paquet `SMSG_MONSTER_MOVE` (vs 100+ avec snapshot positions actuel) — vérifié via `LogFilter::PacketIo` activé
+- [ ] L'interpolation client est lisse à 60 Hz sans nouveaux paquets pendant 10 s
+- [ ] Une nouvelle `SMSG_MONSTER_MOVE` interrompt proprement l'ancienne (pas de saut visuel)
+- [ ] `kProtocolVersion` bumpé, master + shard + client redéployés en lock-step
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Cohérence horloge client/serveur** : l'interpolation client utilise un temps local. Si le RTT varie, le client peut être en avance ou en retard. Stratégie standard : envoyer un timestamp serveur dans chaque packet, le client maintient un offset (`clientClock - serverTime`) lissé. **Ne pas** ignorer cette synchro, sinon mouvements saccadés en cas de jitter réseau.
+- **Spline ID** : chaque `MoveSpline` a un ID unique (incrément monotone). Le client, en recevant un paquet avec un ID < à celui en cours, l'ignore (out-of-order). Important sur UDP.
+- **NoSpline** : pour les téléports ou les forces brusques (knockback), utiliser le flag `NoSpline` qui désactive l'interpolation et force le client à snap. Sinon le client met 50ms à arriver et le combat est désynchro.
+- **Cyclic / EnterCycle** : pour les patrouilles infinies, ne **pas** envoyer un nouveau paquet à chaque cycle — le client doit savoir boucler localement. Le flag `Cyclic` indique « rejoue indéfiniment ».
+- **Falling** : la chute libre n'est pas une spline. Quand un joueur saute d'une falaise, envoyer un paquet `Falling` avec la vélocité initiale ; le client applique la gravité localement. Le serveur revérifie périodiquement la position pour anticheat.
+- **`packet_builder` côté serveur ≠ côté client** : on a deux implémentations qui doivent **rester d'accord** sur le format wire. Le test round-trip dans `MoveSplinePayloadsTests` doit être lancé dans la CI sur les **deux** côtés (côté shard linux et côté client windows). Toute désync = bug critique.
+- **Floats vs fixed-point sur le wire** : 12 bytes par Vector3 (3 × float32) est généreux. cmangos optimise parfois en fixed-point 16 bits par axe. **Démarrer avec floats**, profiler la bande passante en charge avant d'optimiser.
+- **Interaction avec MotionGenerators (futur ticket)** : `MoveSpline` est la **couche transport** ; `MotionGenerator` est la **couche IA** qui décide où aller. Ne pas mélanger. Un `MotionGenerator` produit un nouveau `MoveSplineInit` quand il veut bouger, point.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Movement (P1 cross master+shard)
+- cmangos `src/game/Movement/MoveSpline.cpp`,
+  `MoveSplineInit.cpp`, `MoveSplineFlag.h`,
+  `spline.h`/`spline.impl.h`, `packet_builder.cpp`,
+  `typedefs.h`
+- À coordonner avec : CMANGOS.13 (Maps tick), CMANGOS.14 (MotionGenerators)

--- a/tickets/CMANGOS/CMANGOS.05_vmap_collisions_los_height_dynamictree.md
+++ b/tickets/CMANGOS/CMANGOS.05_vmap_collisions_los_height_dynamictree.md
@@ -1,0 +1,282 @@
+# CMANGOS.05_vmap_collisions_los_height_dynamictree
+
+## Objectif
+
+Mettre en place un système de **collisions 3D server-authoritative** côté
+shard LCDLLN, inspiré de `src/game/vmap` cmangos, pour répondre aux
+besoins de gameplay :
+
+1. **Line-of-sight (LOS)** : « le joueur A peut-il voir le joueur B
+   malgré ce mur ? » — pré-requis pour combat à distance crédible et
+   sorts ciblés.
+2. **Height query** : « quelle est la hauteur du sol à (x, y) ? » —
+   pré-requis pour spawn de loot, téléport, pathfinding 2D, validation
+   anticheat de chute.
+3. **Projectile / object hit** : « le projectile lancé de A vers B
+   touche-t-il un obstacle avant ? » — pré-requis pour flèches, sorts
+   directionnels.
+4. **DynamicTree pour portes / objets transformables** : ouvrir/fermer
+   une porte sans rebuild du tile.
+5. **Tile streaming + refcount** : ne charger en RAM que les tiles avec
+   présence joueur, scaler à des mondes massifs.
+
+C'est le module avec le plus gros **ROI réutilisable directement** selon
+l'analyse cmangos. Sans ça, pas de combat distance crédible, pas de
+portes vraiment fermées, anticheat de mouvement très limité.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `WorldObject::CanSeeObject(target)` câble vmap
+- CMANGOS.03 (Grids) — déclenche le streaming des tiles vmap selon les
+  cellules `Active`
+
+## Livrables
+
+### Côté shard (`engine/server/shard/vmap/`)
+
+- `VMapManager.{h,cpp}` — singleton qui gère le cache de tiles chargés et
+  les 3 requêtes principales :
+  - `bool IsInLineOfSight(MapId, Vector3 from, Vector3 to)`
+  - `float GetHeight(MapId, Vector3 from, float maxSearchDist)`
+  - `bool GetObjectHitPos(MapId, Vector3 from, Vector3 to, Vector3& outHit)`
+- `VMapTile.{h,cpp}` — contient la géométrie d'un tile (16 km × 16 km
+  par exemple) chargée depuis disque, indexée par BIH.
+- `BIH.{h,cpp}` — Bounding Interval Hierarchy templated. Plus compact
+  qu'un BVH classique, optimisé pour scènes statiques.
+- `ManagedModel.{h,cpp}` — wrapper refcount autour d'un modèle
+  géométrique chargé en RAM. `acquire()` incrémente le refcount,
+  `release()` décrémente. Décharge si refcount tombe à 0 + délai.
+- `DynamicTree.{h,cpp}` — BSP/BVH séparé pour les `GameObject`
+  transformables (portes, ponts, blocages d'évents). Fusionné aux
+  requêtes du tile statique.
+- `VMapStreamer.{h,cpp}` — réagit aux transitions `Loaded ↔ Active`
+  des cellules grid (CMANGOS.03) pour `acquire()` / `release()` les
+  tiles.
+
+### Outil offline (`tools/vmap_extractor/`)
+
+- `tools/vmap_extractor/vmap_extractor.cpp` — outil `lcdlln_vmap_extractor`
+  qui prend des assets sources (mesh exports OBJ/GLTF + heightmaps déjà
+  utilisées côté client) et produit des `.vmap` optimisés (BIH bake).
+  Conversion **offline**, pas runtime.
+- `tools/vmap_extractor/CMakeLists.txt` — build standalone.
+
+### Format `.vmap` (`engine/server/shard/vmap/`)
+
+- `VMapFormat.{h,cpp}` — schéma binaire d'un tile compilé : header,
+  table de modèles, BIH compactée, index spatial.
+
+### Configuration (`config.json`)
+
+```json
+"vmap": {
+  "tiles_dir": "vmap",
+  "max_loaded_tiles": 64,
+  "release_delay_sec": 60,
+  "los_ray_thickness": 0.0,
+  "height_search_dist_default": 50.0
+}
+```
+
+`tiles_dir` est relatif à `paths.content`. Aucun chemin absolu.
+
+### Tests
+
+- `engine/server/shard/vmap/BIHTests.cpp` — raycast contre une scène
+  synthétique (cubes), résultats attendus.
+- `engine/server/shard/vmap/VMapManagerTests.cpp` — `IsInLineOfSight`
+  avec un mur entre A et B → false ; sans mur → true.
+- `engine/server/shard/vmap/DynamicTreeTests.cpp` — porte fermée bloque,
+  ouverte ne bloque pas, rebuild en O(1) sur état.
+- `engine/server/shard/vmap/ManagedModelTests.cpp` — refcount monte et
+  descend, décharge après délai.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : tiles `.vmap` sous `/game/data/vmap/`
+- Outils offline : uniquement sous `/tools` (`tools/vmap_extractor/`)
+- Tous les chemins de tiles relatifs à `paths.content` (config.json)
+- ❌ Interdit : créer un dossier racine non autorisé (`/vmaps`, `/collision`, etc.)
+
+## Spécification technique
+
+### 1. BIH (Bounding Interval Hierarchy)
+
+Structure compacte pour raycast static :
+
+- Chaque nœud interne contient 2 plans parallèles à un axe (x ou y ou z)
+  et 2 indices de fils (left, right).
+- Feuilles : indices d'objets (triangles ou modèles).
+
+Avantages vs BVH classique :
+- ~30% moins de mémoire (pas besoin de stocker des bounding boxes
+  complètes par nœud).
+- Cache-friendly (les plans tiennent dans 2 floats par axe).
+
+```cpp
+struct BIHNode {
+  uint32_t axis : 2;      // 0=x, 1=y, 2=z, 3=leaf
+  uint32_t firstChild : 30;
+  float    leftMax;       // plan max du fils gauche
+  float    rightMin;      // plan min du fils droit
+};
+```
+
+### 2. Trois requêtes canoniques
+
+```cpp
+class VMapManager {
+public:
+  // True si la ligne entre from et to ne croise aucun obstacle.
+  // Inclut DynamicTree (portes ouvertes/fermées).
+  bool IsInLineOfSight(MapId mapId, Vector3 from, Vector3 to) const;
+
+  // Height du terrain au point (from.x, from.y), en cherchant
+  // dans une fenêtre verticale de from.z ± maxSearchDist.
+  // Retourne -FLT_MAX si rien trouvé.
+  float GetHeight(MapId mapId, Vector3 from, float maxSearchDist) const;
+
+  // Si le ray from→to touche un obstacle, retourne true et remplit
+  // outHit avec le point d'impact. Sinon false.
+  bool GetObjectHitPos(MapId mapId, Vector3 from, Vector3 to,
+                        Vector3& outHit) const;
+};
+```
+
+Ces 3 requêtes couvrent 95% des besoins gameplay (cf. cmangos).
+
+### 3. `ManagedModel` (refcount)
+
+```cpp
+class ManagedModel {
+public:
+  void Acquire();
+  void Release();   // décrémente, schedule unload si = 0
+  bool IsLoaded() const;
+private:
+  std::atomic<int> m_refCount{0};
+  std::unique_ptr<VMapTile> m_tile;
+  int64_t m_releaseTime = 0;
+};
+```
+
+Au `Release()` avec refcount = 0, on enregistre le timestamp. Le
+`VMapStreamer` parcourt périodiquement ses ManagedModel et libère ceux
+dont le `releaseTime` est dépassé de `release_delay_sec`. Le délai évite
+le yo-yo charge/décharge si un joueur passe rapidement.
+
+### 4. `DynamicTree`
+
+Stockage des GameObject transformables (portes, ponts) :
+
+```cpp
+class DynamicTree {
+public:
+  void Insert(ObjectGuid guid, BoundingBox bbox, GeometryHandle geom);
+  void Remove(ObjectGuid guid);
+  void SetActive(ObjectGuid guid, bool active);   // porte ouverte/fermée
+  bool IsInLineOfSight(Vector3 from, Vector3 to) const;
+};
+```
+
+Quand `SetActive(guid, false)` est appelé (porte ouverte), le node est
+**désactivé** mais pas supprimé — préserve le BSP. Une porte fermée
+réactive simplement le node.
+
+### 5. `VMapStreamer`
+
+Câblé sur les transitions de `GridState` (CMANGOS.03) :
+
+- `Grid → Active` : `streamer.AcquireTilesAround(grid.center, range)`.
+- `Grid → Idle` : `streamer.ReleaseTilesAround(grid.center, range)` (avec
+  délai).
+
+`range` est calculé pour couvrir la distance LOS max d'un joueur
+(typiquement 100-150 m selon le jeu).
+
+### 6. Format `.vmap` (offline-baked)
+
+- Header : magic number, version, mapId, tile coords (cx, cy), AABB
+  global du tile.
+- Table de modèles : pour chaque mesh distinct référencé, une entrée
+  contenant ses sommets et triangles.
+- BIH : structure d'accélération sérialisée (nodes + indices).
+- DynamicGOs initiaux : positions + AABB + handle vers leur géométrie
+  source (utilisé au load par DynamicTree).
+
+Le format est **read-only au runtime** : les modifs runtime (porte
+ouverte) ne touchent pas le fichier, juste le DynamicTree en RAM.
+
+### 7. Outil offline `lcdlln_vmap_extractor`
+
+Inputs :
+
+- Une liste de meshes sources (OBJ ou GLTF) déjà utilisés par le client
+  pour le rendu (à coordonner avec ce qui existe dans `game/data/`).
+- Heightmap `.r16h` du terrain (déjà existant dans
+  `game/data/zones/<zone>/terrain_height.r16h`).
+
+Process :
+
+1. Charge tous les meshes sources.
+2. Pour chaque tile (découpage X×Y selon paramètre), extrait les
+   triangles intersectant l'AABB du tile.
+3. Construit le BIH du tile.
+4. Sérialise en `.vmap` dans `game/data/vmap/<zone>/tile_<cx>_<cy>.vmap`.
+
+Le terrain (heightmap) peut être inclus comme un mesh dégénéré (chaque
+quad → 2 triangles) ou stocké séparément avec un raycast spécifique
+(plus efficace mais double système). **Démarrer avec mesh dégénéré**,
+optimiser si nécessaire.
+
+## Étapes d'implémentation
+
+1. **Créer `engine/server/shard/vmap/`**.
+2. **Implémenter `BIH`** templated + tests math (raycast contre cubes synthétiques).
+3. **Implémenter `VMapTile`** (chargement format binaire + accès au BIH).
+4. **Implémenter `VMapFormat`** (header + sérialisation, pour bootstrap des tests).
+5. **Implémenter `VMapManager`** : les 3 requêtes principales.
+6. **Implémenter `ManagedModel`** + `VMapStreamer` (refcount + délai release).
+7. **Implémenter `DynamicTree`** + intégrer dans `IsInLineOfSight`.
+8. **Câbler avec Grids** : transition `Active` → acquire tiles voisins.
+9. **Créer `tools/vmap_extractor/`** : version minimale qui prend un OBJ + heightmap → produit un `.vmap`.
+10. **Smoke test** : LOS entre 2 entités séparées par un mur (mesh OBJ simple) → false ; LOS sans obstacle → true.
+11. **Tests** : 4 fichiers listés.
+12. **Doc** : section « Collisions vmap » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) et build outil `lcdlln_vmap_extractor` OK
+- [ ] Tests `BIHTests`, `VMapManagerTests`, `DynamicTreeTests`, `ManagedModelTests` passent
+- [ ] Smoke test : 2 entités séparées par un mur (mesh OBJ simple converti en `.vmap`) → `IsInLineOfSight()` retourne `false`. Sans mur → `true`.
+- [ ] `GetHeight` retourne la bonne altitude au sol pour 5 points de test (heightmap zone demo_plains)
+- [ ] Une porte (DynamicTree) bloque LOS quand fermée, ne bloque pas quand ouverte
+- [ ] Refcount `ManagedModel` : tile chargé à l'entrée joueur, déchargé après timeout
+- [ ] Aucun chemin absolu dans le code (tout passe par `paths.content`)
+- [ ] Aucun nouveau dossier racine non autorisé créé (sauf `tools/vmap_extractor/` qui est sous `/tools`)
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Précision float** : les requêtes LOS sur de longues distances (100+ m) avec des coordonnées world (peuvent être en dizaines de milliers) accumulent des erreurs float. **Toujours** travailler en coordonnées **locales au tile** dans le BIH ; convertir en local au début de la requête, traduire à la fin.
+- **Threading** : `VMapManager` doit être **thread-safe pour les requêtes** (lectures concurrentes ok), mais le **streaming** (acquire/release) doit être sériallisé. Un `std::shared_mutex` autour du cache de tiles suffit. **Ne pas** mettre un mutex sur chaque requête (perf).
+- **Edge cases LOS** :
+  - Ray exactement parallèle à un plan : test avec epsilon, pas exact.
+  - Ray partant d'un point exactement sur la surface : décaler de epsilon dans la direction.
+  - Ray length 0 : retourner `true` (pas d'obstacle).
+- **DynamicTree memory** : si on a 10 000 GameObject sur une map (raid), le BSP peut devenir gros. **Ne pas** rebuild à chaque insertion ; utiliser une rebuild différée (batch) ou un BVH dynamique (Bullet, Box2D ont des refs).
+- **Coordination avec terrain client** : le client a sa propre représentation du terrain (`engine/render/terrain/`). Le tile vmap **doit** rester cohérent avec ce que le client voit. Si le designer modifie une heightmap, le `.vmap` correspondant doit être rebake — ajouter dans `tools/vmap_extractor/` un mode **incrémental** qui ne rebake que les tiles affectés.
+- **Format .vmap : versioning** : prévoir un magic number et un champ `version` dès le début. À chaque évolution du format, bumper la version + le `lcdlln_vmap_extractor` produit le nouveau format ; le shard refuse les vieux fichiers avec un log explicite.
+- **Mesh dégénéré pour terrain** : 65×65 = 4096 quads × 2 = 8192 triangles par tile heightmap. C'est gros mais OK pour le BIH. Optimisation future : raycast direct sur heightmap (3 multiplications par cellule au lieu de tester N triangles).
+- **Pas de glm en dépendance shard** : le client utilise probablement glm pour Vector3, mais le shard n'a pas besoin de la lib complète. Réutiliser `MovementTypedefs.h` (CMANGOS.04) qui définit `Vector3` localement, ou créer un `engine/math/Geom.h` minimal côté serveur.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § vmap (P1 shard)
+- cmangos `src/game/vmap/VMapManager2.cpp`, `BIH.h`,
+  `ManagedModel.h`, `DynamicTree.cpp`, `WorldModel.cpp`,
+  `TileAssembler.cpp` (outil)
+- À coordonner avec : `engine/render/terrain/` côté client (cohérence du
+  terrain), CMANGOS.13 (Maps), CMANGOS.03 (Grids streaming)

--- a/tickets/CMANGOS/CMANGOS.06_Accounts_roles_security_levels.md
+++ b/tickets/CMANGOS/CMANGOS.06_Accounts_roles_security_levels.md
@@ -1,0 +1,241 @@
+# CMANGOS.06_Accounts_roles_security_levels
+
+## Objectif
+
+Doter le système de comptes LCDLLN d'une **hiérarchie de rôles** au-delà
+du simple booléen `is_gm`, inspiré de `src/game/Accounts/AccountMgr` de
+cmangos. Bénéfices :
+
+1. **Granularité** : un modérateur peut mute/kick mais pas ban ; un GM
+   peut spawn des items en test mais pas en prod ; etc.
+2. **Pré-requis Chat** : le `ChatCommandRouter` (CMANGOS.01) attend une
+   fonction `GetAccountRole(accountId)` pour vérifier `minRole` par
+   commande.
+3. **`HasLowerSecurity` invariant** : helper unique câblé devant **toute**
+   action affectant un autre compte (kick, mute, whisper privé d'un GM
+   caché). Empêche les escalades de privilèges même quand un handler a
+   un bug logique.
+4. **Séparation logique / persistance** : `AccountStore` continue de
+   gérer la persistance ; un nouvel `AccountRoleService` (ou méthodes
+   dans AccountStore) expose la logique.
+
+C'est un **P2 master**, pré-requis pour Chat (CMANGOS.01) et tout futur
+système GM in-game.
+
+## Dépendances
+
+- M00.1 (build base)
+- `engine/server/AccountStore` (déjà existant)
+- Pré-requis pour : CMANGOS.01 (Chat), tout futur ticket GM (CMANGOS.31 GMTickets, etc.)
+
+## Livrables
+
+### Côté master (`engine/server/`)
+
+- `AccountRole.h` — enum class C++20 type-safe :
+
+  ```cpp
+  enum class AccountRole : uint8_t {
+    Player        = 0,
+    Moderator     = 1,
+    GameMaster    = 2,
+    Administrator = 3,
+    Console       = 4,    // commandes lancées depuis stdin du process serveur
+  };
+  ```
+
+  Constraints :
+  - Numérotation **monotone croissante** (un rôle plus haut a plus de droits).
+  - **Toujours** comparer via `static_cast<uint8>(a) >= static_cast<uint8>(b)` ou helper.
+
+- `AccountRoleService.{h,cpp}` (ou intégré dans `AccountStore`) :
+
+  ```cpp
+  class AccountRoleService {
+  public:
+    AccountRole GetRole(uint32_t accountId) const;
+    void SetRole(uint32_t accountId, AccountRole newRole);
+    bool HasLowerSecurity(uint32_t targetAccountId, uint32_t sourceAccountId) const;
+    bool RequireMinRole(uint32_t accountId, AccountRole min) const;
+  };
+  ```
+
+  - `HasLowerSecurity(target, source)` retourne `true` si `target.role < source.role`.
+    **Inverse** : si target ≥ source → false (refus de l'action).
+  - `RequireMinRole(account, min)` retourne `true` si `account.role >= min`.
+
+- Cache mémoire dans `AccountStore` : `std::unordered_map<uint32_t, AccountRole>`,
+  chargé au boot, rafraîchi à `SetRole`. Évite N requêtes DB par session GM
+  active.
+
+### Migration DB
+
+- `engine/server/migrations/00xx_account_roles.sql` :
+
+  ```sql
+  ALTER TABLE accounts
+    ADD COLUMN role TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER email_verified;
+
+  -- Migration des données : si is_gm existait, le mapper.
+  UPDATE accounts SET role = 2 WHERE is_gm = 1;   -- GameMaster
+  -- (suppression de is_gm dans une migration ultérieure pour garder backward compat).
+
+  CREATE INDEX idx_accounts_role ON accounts(role);
+  ```
+
+  Idempotente (`IF NOT EXISTS` patterns à suivre).
+
+### Configuration (`config.json`)
+
+```json
+"accounts": {
+  "console_role_required": true,
+  "default_new_account_role": "Player",
+  "role_change_audit": true
+}
+```
+
+### Audit log
+
+- Toute appel à `SetRole` produit une ligne dans le SecurityAuditLog
+  existant (déjà en place côté master) : `[AUDIT] role_change account_id=X
+  old=Player new=Moderator by=accountId=42`.
+
+### Tests
+
+- `engine/server/AccountRoleServiceTests.cpp` :
+  - `GetRole` retourne le rôle stocké.
+  - `SetRole` met à jour DB + cache.
+  - `HasLowerSecurity` :
+    - Player vs Moderator → true
+    - Moderator vs Player → false
+    - GameMaster vs GameMaster → false (égalité = refus)
+  - `RequireMinRole(Player, Moderator)` → false ; `RequireMinRole(GM, Moderator)` → true.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A
+- Outils offline : N/A
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Sémantique des rôles
+
+| Rôle | Valeur | Capacités typiques |
+|---|---|---|
+| `Player` | 0 | Aucune commande GM. Chat normal, gameplay. |
+| `Moderator` | 1 | `.mute`, `.kick`, `.warn`. Pas de ban, pas de spawn. |
+| `GameMaster` | 2 | Commandes Moderator + `.ban`, `.tele`, `.spawn` (test items), `.go`. |
+| `Administrator` | 3 | Commandes GM + `.account create`, `.account delete`, `.set role`, accès aux logs. |
+| `Console` | 4 | Toutes commandes + opérations dangereuses (shutdown, reload all). Réservé au stdin du process serveur. |
+
+### 2. `HasLowerSecurity` — règle d'or
+
+**Toute** action affectant un autre compte :
+- ban / unban
+- kick
+- mute / unmute
+- whisper à un GM caché (`.gm visible off`) — refus si GM a rôle plus haut
+- inspect inventaire / mail
+- set role
+
+doit appeler `HasLowerSecurity(targetAccountId, sourceAccountId)` au début
+du handler. Si `false` → refuser avec message d'erreur + log audit.
+
+```cpp
+bool HandleBanAccount(ChatContext const& ctx, std::string_view args) {
+  uint32_t targetId = ParseAccountId(args);
+  if (!g_accountRoles.HasLowerSecurity(targetId, ctx.callerAccountId)) {
+    ctx.Reply("Permission denied: target has equal or higher security.");
+    LOG_WARN(Auth, "[AUDIT] denied_ban target={} by={}", targetId, ctx.callerAccountId);
+    return false;
+  }
+  // ... ban logic
+}
+```
+
+### 3. Égalité = refus
+
+Choix délibéré : un GM ne peut pas ban un autre GM. Ça force l'usage du
+rôle Administrator pour les actions inter-GM, qui est plus rarement
+attribué et nécessite une autorité explicite.
+
+### 4. Console role
+
+Le rôle `Console` n'est **jamais** stocké en DB. Il est attribué
+runtime à un caller spécial qui exécute des commandes depuis stdin du
+process serveur (équivalent du « rcon » de cmangos). Une commande de
+console n'a pas d'`accountId` — utiliser un sentinel `0xFFFFFFFF` ou
+flag dédié dans le `ChatContext`.
+
+### 5. Cache + invalidation
+
+- Cache chargé au boot via `LoadAllRoles()` (1 requête : `SELECT id, role FROM accounts`).
+- À `SetRole(id, role)` : update DB + update cache.
+- Si une autre instance master modifie le rôle (improbable mais possible
+  dans un futur multi-master), pas de propagation pour l'instant.
+  **TODO** : ajouter un canal pub/sub Redis ou notification SQL si
+  multi-master arrive.
+
+## Étapes d'implémentation
+
+1. **Créer `engine/server/AccountRole.h`** avec l'enum.
+2. **Créer la migration** `00xx_account_roles.sql` (idempotente).
+3. **Implémenter `AccountRoleService`** ou intégrer dans `AccountStore`.
+4. **Charger le cache au boot** (`AccountStore::LoadAllRoles()`).
+5. **Implémenter `HasLowerSecurity` + `RequireMinRole`** + tests.
+6. **Câbler dans `SecurityAuditLog`** pour tracer les `SetRole`.
+7. **Exposer via Config** (`accounts.default_new_account_role`).
+8. **Doc** : section « AccountRole » dans `CODEBASE_MAP.md` + lister les commandes par rôle.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master) via presets existants
+- [ ] Tests `AccountRoleServiceTests` passent (5+ cas)
+- [ ] Migration `00xx_account_roles.sql` appliquée et idempotente
+- [ ] Cache rôles chargé au boot, log info `[AccountRoles] loaded N entries`
+- [ ] Smoke test : `SetRole(42, GameMaster)` → `GetRole(42) == GameMaster` + ligne audit log
+- [ ] `HasLowerSecurity(playerA, gmB)` → true ; `HasLowerSecurity(gmA, gmB)` → false
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Comparaison de rôles** : ne **jamais** comparer des `AccountRole` via
+  `==`/`!=` pour des contrôles d'accès. Toujours `static_cast<uint8>(a)
+  >= static_cast<uint8>(b)` ou le helper. `==` sur enum class est ok
+  pour vérifier un rôle exact mais sémantiquement faux pour autoriser.
+- **Sentinel `0xFFFFFFFF` pour Console** : ne pas le persister en DB.
+  Si un bug le persiste, le `LoadAllRoles` doit le rejeter avec un
+  warning et le traiter comme `Player` par défaut.
+- **Migration des données existantes** : la table `accounts` actuelle
+  n'a probablement pas de colonne `is_gm`. Adapter le `UPDATE` dans la
+  migration au schéma réel (potentiellement aucun update — tous les
+  comptes existants restent `Player` = 0).
+- **Backward compat handler GM existants** : si du code actuel teste
+  `account.is_gm`, le wrapper `IsGm()` sur `AccountStore` peut renvoyer
+  `role >= GameMaster`. À supprimer une fois tout migré.
+- **Audit log** : ne pas mettre le `role_change` dans le log standard
+  bruyant ; utiliser un sous-système dédié (`SecurityAuditLog` existe
+  déjà côté master). Filtrable via `LogFilter::Auth` (déjà dispo PR #468).
+- **UX d'erreur** : un message « Permission denied: target has equal or
+  higher security » est explicite mais peut leak l'existence du target.
+  Pour les whisper à GM caché, retourner « Player not found » à la
+  place — pas d'info-leak.
+- **Rôle dans le token de session** : ne **pas** dupliquer le rôle dans
+  le SessionToken. Le master fait toujours le lookup via
+  `AccountRoleService.GetRole(accountId)` à chaque action sensible.
+  Sinon une élévation de privilège ne prend pas effet immédiatement.
+- **Pas de règle « plus haut peut tout faire de plus bas » côté code** :
+  ne pas écrire `if (role >= GameMaster) { all_moderator_commands = true }`.
+  Plutôt enregistrer chaque commande avec son `minRole` dans le
+  `ChatCommandRouter` ; lire le rôle requis depuis la table.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Accounts (P2 master)
+- cmangos `src/game/Accounts/AccountMgr.cpp`, `AccountMgr.h`
+- À coordonner avec : CMANGOS.01 (Chat — `ChatCommandRouter` consomme
+  `AccountRole`), `engine/server/SecurityAuditLog`

--- a/tickets/CMANGOS/CMANGOS.07_AI_creature_registry_eventai_dbdriven.md
+++ b/tickets/CMANGOS/CMANGOS.07_AI_creature_registry_eventai_dbdriven.md
@@ -1,0 +1,190 @@
+# CMANGOS.07_AI_creature_registry_eventai_dbdriven
+
+## Objectif
+
+Mettre en place un **framework d'IA pour PNJ** côté shard LCDLLN inspiré
+de `src/game/AI` cmangos. Trois piliers :
+
+1. **Registry + Selector pattern** : chaque IA s'auto-enregistre par nom
+   au boot, le sélecteur instancie via factory `string→ctor` selon
+   `creature_template.AIName` ou un flag scripts. Ajout d'une nouvelle
+   IA = ajout dans le registry, pas de modification du cœur.
+2. **`EventAI` piloté par DB** : table `creature_ai_scripts`
+   `(entry, event_type, event_param, action_type, action_param,
+   chance, repeat_min, repeat_max)` interprétée par un moteur
+   générique. Permet de scripter un boss simple sans recompiler.
+3. **`PlayerAI`** comme contrepartie : même interface que CreatureAI mais
+   sur Player (utilisé pour mind control, fear, charm).
+4. **`ScriptDevAI`** comme couche séparée pour les boss complexes en C++,
+   isolant le code "contenu" du code "moteur" — bon découpage si le
+   contenu PvE devient riche.
+
+C'est un **P2 shard**, pré-requis dès le premier PNJ avec comportement
+non trivial.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `Creature` porte un `CreatureAI*`
+- CMANGOS.04 (Movement) — l'IA pousse des `MoveSplineInit` au mouvement
+- CMANGOS.11 (Combat) — l'IA réagit aux events `OnAggro`, `OnDamageDealt`,
+  `OnDamageTaken`
+- CMANGOS.20 (MotionGenerators) — l'IA pousse/pop des générateurs sur
+  le `MotionMaster`
+
+## Livrables
+
+### Côté shard (`engine/server/shard/ai/`)
+
+- `CreatureAI.{h,cpp}` — interface abstraite. Méthodes virtuelles vides
+  par défaut :
+  - `OnAggro(Unit& enemy)`
+  - `OnDamageTaken(Unit& attacker, uint32 damage)`
+  - `OnDamageDealt(Unit& victim, uint32 damage)`
+  - `OnEvade()` — sortie de combat anormale
+  - `OnDeath(Unit* killer)`
+  - `OnSpellHit(Unit& caster, SpellTemplate const&)`
+  - `Update(int32 deltaMs)` — appelé chaque tick par la Map
+- `BaseAI.{h,cpp}` — implémentation no-op (aggressive sur tout joueur dans
+  le rayon, melee uniquement). IA par défaut.
+- `EventAI.{h,cpp}` — interpréteur de scripts DB.
+- `PlayerAI.{h,cpp}` — sous-classe pour Player charmé/fear (à activer/
+  désactiver à la volée).
+- `CreatureAIRegistry.{h,cpp}` — map `aiName → factory`. API
+  `Register(name, factory)`, `Create(name, creature)`.
+- `CreatureAISelector.{h,cpp}` — sélectionne l'IA pour une Creature
+  spawnée :
+  1. Si `creature.AIName` dans la DB est non-vide → instancier cette IA.
+  2. Sinon, si `creature.HasEventAIScript()` → `EventAI`.
+  3. Sinon → `BaseAI`.
+
+### Migration DB
+
+- `engine/server/migrations/00xx_creature_ai.sql` :
+  ```sql
+  ALTER TABLE creature_template
+    ADD COLUMN ai_name VARCHAR(64) NOT NULL DEFAULT '' AFTER faction;
+
+  CREATE TABLE creature_ai_scripts (
+    creature_entry  INT UNSIGNED NOT NULL,
+    event_id        INT UNSIGNED NOT NULL,
+    event_type      TINYINT UNSIGNED NOT NULL,    -- enum EventAIEventType
+    event_param1    INT NOT NULL DEFAULT 0,
+    event_param2    INT NOT NULL DEFAULT 0,
+    chance          TINYINT UNSIGNED NOT NULL DEFAULT 100,
+    repeat_min_ms   INT UNSIGNED NOT NULL DEFAULT 0,
+    repeat_max_ms   INT UNSIGNED NOT NULL DEFAULT 0,
+    action_type     TINYINT UNSIGNED NOT NULL,    -- enum EventAIActionType
+    action_param1   INT NOT NULL DEFAULT 0,
+    action_param2   INT NOT NULL DEFAULT 0,
+    action_param3   INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (creature_entry, event_id)
+  );
+  ```
+
+### Tests
+
+- `engine/server/shard/ai/CreatureAIRegistryTests.cpp` — register +
+  retrieve.
+- `engine/server/shard/ai/EventAITests.cpp` — un script
+  `OnAggro → CastSpell` produit l'action attendue ; cooldown respecté.
+- `engine/server/shard/ai/CreatureAISelectorTests.cpp` — sélection
+  correcte selon AIName / scripts / fallback.
+
+### Configuration (`config.json`)
+
+```json
+"ai": {
+  "default_aggro_range_m": 20.0,
+  "evade_distance_m": 50.0,
+  "evade_full_heal": true,
+  "event_ai_enabled": true
+}
+```
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : N/A
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. EventAI events de référence
+
+| Event type | Event param | Trigger |
+|---|---|---|
+| OnAggro | — | Premier joueur aggro |
+| OnDamageTaken_HpBelow | hp_pct | Quand HP descend sous X% |
+| OnTargetCasting | spell_id | Cible commence un cast |
+| OnSpawn | — | À l'apparition |
+| OnTimer | period_ms | Périodique (utilise `repeat_min/max`) |
+| OnDeath | — | Au moment de mourir |
+| OnEnemyOOM | — | Cible cible plus de mana |
+
+### 2. EventAI actions de référence
+
+| Action type | Params | Effet |
+|---|---|---|
+| CastSpell | spell_id, target | Lance un sort |
+| Say | text_id | Dit un message localisé |
+| Yell | text_id | Cri (zone broadcast) |
+| Despawn | delay_ms | Disparait |
+| FleeForAssistance | — | Fuit chercher renfort |
+| CallForHelp | radius_m | Appelle créatures alliées proches |
+| ChangePhase | phase_id | Bascule la phase d'IA |
+
+Set initial minimaliste — extensible par ticket ultérieur.
+
+### 3. Registry + Selector
+
+```cpp
+using CreatureAIFactory = std::function<std::unique_ptr<CreatureAI>(Creature&)>;
+
+class CreatureAIRegistry {
+public:
+  void Register(std::string name, CreatureAIFactory factory);
+  std::unique_ptr<CreatureAI> Create(std::string_view name, Creature& c) const;
+};
+
+// au boot :
+g_aiRegistry.Register("EventAI", [](Creature& c){ return std::make_unique<EventAI>(c); });
+g_aiRegistry.Register("BaseAI",  [](Creature& c){ return std::make_unique<BaseAI>(c); });
+// futur : "Boss_Ragnaros", etc., enregistrés par ScriptDevAI module
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/ai/` + interfaces.
+2. Implémenter `CreatureAI` (interface) + `BaseAI` (impl basique).
+3. Implémenter `CreatureAIRegistry` + `CreatureAISelector`.
+4. Câbler `Creature` (CMANGOS.02) pour porter `m_ai` et l'appeler dans `Update()`.
+5. Migration DB `00xx_creature_ai.sql`.
+6. Implémenter `EventAI` : load scripts au boot, dispatch events, exécute actions.
+7. Implémenter `PlayerAI` (charm/fear/possession).
+8. Tests : 3 fichiers listés.
+9. Doc : section « AI shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests `CreatureAI*Tests`, `EventAITests` passent
+- [ ] Smoke test : un PNJ avec script `OnAggro → Yell + CastSpell` exécute les 2 actions à la prise d'aggro
+- [ ] PlayerAI : charme un joueur, son input est ignoré, l'IA prend le contrôle ; fin du charme, contrôle restauré
+- [ ] Migration `00xx_creature_ai.sql` appliquée et idempotente
+- [ ] Aucun nouveau dossier racine non autorisé créé
+- [ ] Rapport final : fichiers modifiés + commandes + résultats + DoD
+
+## Notes / pièges à éviter
+
+- **Cooldowns** : ne **pas** câbler les cooldowns des actions dans EventAI globalement ; chaque event a son `repeat_min_ms / repeat_max_ms`. Sinon une IA sophistiquée se bloque avec un cooldown global.
+- **Threading** : l'IA tourne dans le tick Map (CMANGOS.13). `BaseAI::Update` ne doit **pas** prendre de lock global. Si l'IA accède à des données partagées (météo, world state), passer par un cache thread-local ou une queue.
+- **PlayerAI lifecycle** : à l'activation (charme), sauvegarder l'AIController courant ; à la fin, restaurer. Ne **pas** détruire l'IA d'origine.
+- **Cycles d'aggro** : si l'IA appelle `CallForHelp` et que les renforts appellent à leur tour → boucle. Ajouter un timestamp `lastCallForHelp` pour debounce.
+- **Hot-reload** : pour itérer sur du contenu, prévoir une commande GM `.reload event_ai_scripts` qui purge le cache + recharge la table sans restart shard. À ajouter quand la commande router (CMANGOS.01) est en place.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § AI (P2 shard)
+- cmangos `src/game/AI/CreatureAI.cpp`, `EventAI/`, `BaseAI.cpp`,
+  `PlayerAI.cpp`, `CreatureAIRegistry.cpp`, `CreatureAISelector.cpp`

--- a/tickets/CMANGOS/CMANGOS.08_Arena_team_mmr_weekly_colisee.md
+++ b/tickets/CMANGOS/CMANGOS.08_Arena_team_mmr_weekly_colisee.md
@@ -1,0 +1,228 @@
+# CMANGOS.08_Arena_team_mmr_weekly_colisee
+
+## Objectif
+
+Mettre en place le **système d'arène** côté master+shard LCDLLN, adapté
+de `src/game/Arena` cmangos pour le concept LCDLLN spécifique :
+**colisée dans une ville**, pas de file d'attente cross-realm. Quatre
+piliers :
+
+1. **Séparation `ArenaTeam` (entité persistante) / `BattleGround`
+   (instance de match)** : l'équipe survit aux matches, le match est
+   jeté. Applicable au colisée local LCDLLN.
+2. **MMR + rating glicko-like par équipe** stocké en DB, recalculé
+   après chaque match — réutilisable tel quel pour le ladder du
+   colisée.
+3. **`ArenaTeamHandler` traite les opcodes spécifiques** (invite, kick,
+   disband, query stats) séparément de la logique métier.
+4. **Distribution hebdo via `WeeklyMaintenance`** : les points sont
+   calculés en cron serveur, pas à chaque match — pattern propre pour
+   les récompenses différées.
+
+C'est un **P2 master+shard**, pré-requis pour ton concept de colisée.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts)
+- CMANGOS.10 (BattleGround) — instance de match
+- CMANGOS.13 (Database)
+- CMANGOS.18 (Mails) — distribution récompenses
+
+## Livrables
+
+### Côté master (`engine/server/arena/`)
+
+- `ArenaTeam.{h,cpp}` :
+  ```cpp
+  class ArenaTeam {
+  public:
+    bool AddMember(uint32_t accountId, uint64_t charId);
+    bool RemoveMember(uint32_t accountId);
+    void Disband();
+    void OnMatchResult(bool win, int32_t teamMmrDelta);
+    int32_t GetMMR() const;
+    int32_t GetRating() const;     // visible vs invisible MMR
+    int32_t GetWeeklyPoints() const;
+  private:
+    uint64_t m_teamId;
+    ArenaTeamSize m_size;          // 2v2, 3v3, 5v5
+    std::string m_name;
+    uint32_t m_captainAccountId;
+    std::vector<ArenaTeamMember> m_members;
+    int32_t m_mmr = 1500;          // hidden
+    int32_t m_rating = 0;          // visible
+    int32_t m_weeklyPoints = 0;
+    int m_seasonGames = 0;
+    int m_seasonWins = 0;
+  };
+  ```
+- `ArenaTeamManager.{h,cpp}` :
+  - `Load(ConnectionPool&)`
+  - `ArenaTeam* CreateTeam(captainId, size, name)`
+  - `ArenaTeam* GetTeamForAccount(accountId, size)` — un account peut être dans 3 équipes (1 par taille)
+- `ArenaTeamHandler.{h,cpp}` — opcodes :
+  - `kOpcodeArenaTeamCreate`, `kOpcodeArenaTeamInvite`, etc.
+  - `kOpcodeArenaTeamQueryStats`
+  - `kOpcodeArenaTeamDisband`
+- `ArenaMmrEngine.{h,cpp}` — calcul Glicko-2 ou Elo simplifié :
+  - `int32_t ComputeMmrDelta(int32_t teamMmr, int32_t opponentMmr, bool win)`
+  - `int32_t ComputeRatingDelta(int32_t mmr, int32_t rating, bool win)`
+- `WeeklyMaintenance.{h,cpp}` — cron weekly :
+  - `Run()` — distribue les arena points aux teams selon `weeklyPoints`, livre via mail.
+
+### Côté shard (`engine/server/shard/colosseum/`) — pour le colisée local
+
+- `ColosseumArena.{h,cpp}` (sous-classe de `BattleGround`, CMANGOS.10) :
+  spawn point, zone bornée, 2v2/3v3/5v5, win conditions (last team standing OU score).
+- `ColosseumEntrance.{h,cpp}` — interaction PNJ portier dans la ville :
+  vérifie team formed + opposing team présente → démarre match.
+
+### Migration DB
+
+```sql
+CREATE TABLE arena_team (
+  team_id           BIGINT UNSIGNED NOT NULL,
+  size              TINYINT UNSIGNED NOT NULL,    -- 2, 3, 5
+  name              VARCHAR(64) NOT NULL UNIQUE,
+  captain_account_id INT UNSIGNED NOT NULL,
+  mmr               INT NOT NULL DEFAULT 1500,
+  rating            INT NOT NULL DEFAULT 0,
+  weekly_points     INT NOT NULL DEFAULT 0,
+  season_games      INT NOT NULL DEFAULT 0,
+  season_wins       INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (team_id)
+);
+
+CREATE TABLE arena_team_member (
+  team_id           BIGINT UNSIGNED NOT NULL,
+  account_id        INT UNSIGNED NOT NULL,
+  character_id      BIGINT UNSIGNED NOT NULL,
+  joined_ts         BIGINT NOT NULL,
+  personal_rating   INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (team_id, account_id)
+);
+
+CREATE TABLE arena_match_log (
+  match_id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  team_a_id         BIGINT UNSIGNED NOT NULL,
+  team_b_id         BIGINT UNSIGNED NOT NULL,
+  winner_team_id    BIGINT UNSIGNED,
+  duration_sec      INT UNSIGNED NOT NULL,
+  team_a_mmr_before INT NOT NULL,
+  team_b_mmr_before INT NOT NULL,
+  team_a_mmr_delta  INT NOT NULL,
+  team_b_mmr_delta  INT NOT NULL,
+  ts                BIGINT NOT NULL,
+  PRIMARY KEY (match_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"arena": {
+  "starting_mmr": 1500,
+  "starting_rating": 0,
+  "match_durations_sec": 600,
+  "weekly_points_per_win": 10,
+  "weekly_maintenance_day": "Tuesday",
+  "weekly_maintenance_hour_utc": 7,
+  "colosseum_zone_id": 1234,
+  "max_teams_per_account_per_size": 1
+}
+```
+
+### Tests
+
+- `ArenaTeamTests.cpp` — create + add + kick + disband.
+- `ArenaMmrTests.cpp` — Elo : équipe 1500 bat équipe 1500 → +K, perd → -K.
+- `WeeklyMaintenanceTests.cpp` — distribution points proportionnelle aux victoires.
+- `ColosseumArenaTests.cpp` — spawn 2 teams, last team standing wins.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. MMR vs Rating
+
+- **MMR (matchmaking)** : invisible, utilisé pour matchmaking.
+- **Rating** : visible joueur. Diverge du MMR pour incentiver les
+  joueurs sous-classés à jouer (gain rating > gain MMR si on gagne
+  contre + fort).
+
+### 2. Spécificité LCDLLN — pas de queue cross-realm
+
+cmangos utilise un `BattleGroundQueue` pour matchmaker à travers tous
+les joueurs online. LCDLLN simplifié :
+
+- Joueur A et son équipe entrent dans le **colisée** (zone physique
+  d'une ville).
+- Le portier (PNJ) propose : « il y a une équipe en attente, lancer le
+  match ? »
+- Si oui → instance de `ColosseumArena` créée sur le shard, transfert
+  des 2 équipes dedans.
+
+Pas de queue, pas de matchmaking à grande échelle. Plus simple, plus
+local, RP-friendly.
+
+### 3. Distribution récompenses
+
+À la fin d'un match :
+- Update `weekly_points` côté DB (juste un += 10 si victoire).
+- Pas de gold immédiat — c'est `WeeklyMaintenance` qui livre les
+  récompenses.
+
+`WeeklyMaintenance` (cron) :
+- Calcule pour chaque team : `points_to_award = weeklyPoints × multiplier`.
+- Envoie à chaque membre actif via Mail (CMANGOS.18) : « Récompense
+  hebdomadaire arène : 100 jetons ».
+- Reset `weekly_points = 0`.
+
+### 4. Cohérence avec BattleGround (CMANGOS.10)
+
+`ColosseumArena` hérite de `BattleGround` (framework générique). Les
+spécificités arène : zone bornée, win condition "last team standing",
+durée max 10 min sinon match nul.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/arena/` (master) et `engine/server/shard/colosseum/` (shard).
+2. Migrations DB.
+3. Implémenter `ArenaTeam` + `ArenaTeamManager`.
+4. Implémenter `ArenaMmrEngine` (Glicko-2 ou Elo simplifié).
+5. Implémenter `ArenaTeamHandler` + opcodes.
+6. Implémenter `WeeklyMaintenance` (cron).
+7. Implémenter `ColosseumArena` (sous-classe de BG).
+8. Implémenter `ColosseumEntrance` (PNJ portier).
+9. Tests : 4 fichiers.
+10. Doc : section « Arena (colisée LCDLLN) » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard)
+- [ ] Tests passent
+- [ ] Smoke test : team A 2v2 entre colisée, match contre team B, victoire → MMR/rating updated, weekly_points +10
+- [ ] Cron WeeklyMaintenance distribue récompenses via mail
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Personal rating** : par membre, pas seulement par team. Permet "tu as joué que 5 matches → ton rating personnel restreint à 80% du team rating" (anti-carry).
+- **Disband** : team avec membres actifs → demander confirmation captaine ; mark disbanded mais conserver match_log pour l'historique.
+- **Match nul** : timer 10min expire avec les 2 équipes vivantes → MMR ne change pas (ou change peu). Évite stalling.
+- **Pas de queue automatique** : LCDLLN spec ; si un jour tu veux ajouter cross-realm, c'est un autre ticket.
+- **Replay** : le `arena_match_log` permet de stocker le replay (paquets PacketLog → CMANGOS.12 Server) pour rejouer les matches en spectateur. Reportable.
+- **Spectator mode** : pas dans ce ticket, mais le design doit permettre l'ajout (laisser la zone du colisée publique en read-only).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Arena (P2 master+shard)
+- cmangos `src/game/Arena/ArenaTeam.cpp`, `ArenaTeamHandler.cpp`,
+  `ArenaTeamMgr.cpp`
+- Glicko-2 : http://www.glicko.net/glicko/glicko2.pdf

--- a/tickets/CMANGOS/CMANGOS.09_AuctionHouse_master_side_tick_mail_delivery.md
+++ b/tickets/CMANGOS/CMANGOS.09_AuctionHouse_master_side_tick_mail_delivery.md
@@ -1,0 +1,203 @@
+# CMANGOS.09_AuctionHouse_master_side_tick_mail_delivery
+
+## Objectif
+
+Mettre en place l'**hôtel des ventes** (HV) côté master LCDLLN, inspiré
+de `src/game/AuctionHouse` cmangos. Master-side car cross-shard naturel
+(acheteur et vendeur peuvent être sur des shards différents). Quatre
+piliers :
+
+1. **3 maisons séparées** (variantes faction/région) avec taux de
+   commission différents — pattern « instance par faction/zone »
+   adaptable.
+2. **Update tick globale** balayant les enchères expirées (vs un timer
+   par enchère) — scalable à 100k items.
+3. **Livraison via système mail** (CMANGOS.18) plutôt que retour direct
+   dans l'inventaire : découple le HV de la session du joueur (acheteur
+   peut être offline).
+4. **Index secondaire en RAM** (par item entry, par owner, par
+   expiration) reconstruit au boot — recherches O(1) sans hit DB.
+
+C'est un **P2 master**, à activer quand l'économie est en place
+(crafting / loot / monnaie).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage et async)
+- CMANGOS.18 (Mails) — livraison
+- Économie existante (item, gold) — pré-requis fonctionnel.
+
+## Livrables
+
+### Côté master (`engine/server/auction/`)
+
+- `AuctionEntry.h` — struct enchère :
+  ```cpp
+  struct AuctionEntry {
+    uint32_t auctionId;
+    uint32_t houseId;
+    ObjectGuid itemGuid;
+    uint32_t ownerAccountId;
+    uint64_t startBid;
+    uint64_t buyout;
+    uint64_t currentBid;
+    uint32_t bidderAccountId;    // 0 = no bid
+    int64_t  expirationTs;
+    uint32_t deposit;
+  };
+  ```
+- `AuctionHouseManager.{h,cpp}` :
+  - `Load(ConnectionPool&)`
+  - `uint32_t PostAuction(houseId, sellerAccountId, itemGuid, startBid, buyout, durationSec)`
+  - `bool BidAuction(auctionId, bidderAccountId, amount)`
+  - `void ResolveExpired(int64_t nowMs)` — appelé chaque tick
+  - `std::vector<AuctionEntry> Search(houseId, filter)`
+- `AuctionHouseHandler.{h,cpp}` — opcodes :
+  - `kOpcodeAhPostAuction` (client → master)
+  - `kOpcodeAhBidAuction`
+  - `kOpcodeAhSearchAuctions`
+  - `kOpcodeAhCancelAuction`
+- `AuctionIndex.{h,cpp}` — index secondaire RAM :
+  - `byItem` : `std::unordered_multimap<itemEntry, auctionId>`
+  - `byOwner` : `std::unordered_multimap<accountId, auctionId>`
+  - `byExpiration` : `std::set<expirationTs, auctionId>` (pour resolve périodique)
+
+### Migration DB
+
+```sql
+CREATE TABLE auction_house (
+  house_id        TINYINT UNSIGNED NOT NULL,
+  name            VARCHAR(64) NOT NULL,
+  commission_pct  TINYINT UNSIGNED NOT NULL DEFAULT 5,
+  faction_filter  TINYINT UNSIGNED NOT NULL DEFAULT 0,    -- 0 = neutre
+  PRIMARY KEY (house_id)
+);
+
+CREATE TABLE auctions (
+  auction_id        INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  house_id          TINYINT UNSIGNED NOT NULL,
+  item_guid         BIGINT UNSIGNED NOT NULL,
+  item_entry        INT UNSIGNED NOT NULL,
+  owner_account_id  INT UNSIGNED NOT NULL,
+  start_bid         BIGINT UNSIGNED NOT NULL,
+  buyout            BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  current_bid       BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  bidder_account_id INT UNSIGNED NOT NULL DEFAULT 0,
+  expiration_ts     BIGINT NOT NULL,
+  deposit           BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (auction_id),
+  KEY idx_house (house_id),
+  KEY idx_owner (owner_account_id),
+  KEY idx_expiration (expiration_ts)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"auction": {
+  "expired_check_interval_sec": 60,
+  "max_auctions_per_player": 50,
+  "deposit_pct": 5,
+  "commission_pct_default": 5,
+  "min_duration_sec": 7200,
+  "max_duration_sec": 172800
+}
+```
+
+### Tests
+
+- `AuctionHouseTests.cpp` — post + bid + resolve.
+- `AuctionIndexTests.cpp` — index `byItem` retourne les enchères du même item.
+- `AuctionExpirationTests.cpp` — `ResolveExpired` traite toutes les expirées.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Tick global d'expirations
+
+Toutes les `expired_check_interval_sec`, parcourir `byExpiration` (set
+trié) et résoudre les expirées :
+
+- Pas de bidder → item retourné au seller via mail.
+- Bidder → item livré au bidder, gold (current_bid - commission) au seller, deposit retourné, le tout via mails.
+
+### 2. Livraison via mail
+
+Pas d'écriture directe dans l'inventaire. Toujours via `MailManager::Send`
+(CMANGOS.18). Bénéfices :
+- Joueur offline : reçoit le mail au prochain login.
+- Pas de lock cross-shard sur l'inventaire.
+- Trace écrite : le mail est une preuve pour les disputes.
+
+### 3. Multi-maisons
+
+`house_id = 0` : maison neutre (commission haute, accessible à tous).
+`house_id = 1` : maison faction A.
+`house_id = 2` : maison faction B.
+
+Chaque maison a sa table `auctions` filtrée par `house_id`. Joueur faction A
+ne voit pas les auctions de la maison faction B (sauf neutre).
+
+### 4. Search
+
+```cpp
+struct AuctionFilter {
+  std::optional<uint32_t> itemEntryFilter;
+  std::optional<std::string> nameLike;
+  std::optional<uint32_t> minLevelFilter;
+  std::optional<uint8_t> qualityFilter;
+  uint32_t pageOffset = 0;
+  uint32_t pageSize = 50;
+};
+```
+
+Lookup via `byItem` index si itemEntry précis ; sinon scan filtré
+(coût plus élevé, à mitiger via cache).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/auction/`.
+2. Migrations DB.
+3. Implémenter `AuctionEntry` + `AuctionIndex`.
+4. Implémenter `AuctionHouseManager::Load` (depuis DB + reconstruct index).
+5. Implémenter `PostAuction`, `BidAuction`, `CancelAuction`.
+6. Implémenter `ResolveExpired` (tick périodique).
+7. Câbler livraison via Mail (dépendance CMANGOS.18).
+8. Implémenter `Search` avec filtres.
+9. Allouer opcodes + handler.
+10. Tests : 3 fichiers.
+11. Doc : section « Auction master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : post auction → bid → buyout → item livré au bidder, gold au seller
+- [ ] Smoke test expiration : auction sans bidder expire → item retourne au seller via mail
+- [ ] Search par itemEntry est O(1) (vérifier via timing)
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Locks** : `BidAuction` est sensible à la concurrence (2 joueurs bid en même temps). Lock par `auction_id` (mutex map ou row lock DB).
+- **Index reconstruction** : au boot, `Load` itère 100k+ rows + reconstruit l'index. Mesurer le temps. Si > 30s, lazy load.
+- **Snipe** : un bid dans les dernières 30s prolonge l'expiration de 30s (anti-snipe) ? Convention WoW classique : oui. À implémenter ou non selon vision LCDLLN.
+- **Deposit refund** : si seller cancel avant expiration, deposit perdu (pénalité anti-spam). Si cancel après bid, **interdit** (déjà engagé).
+- **Item delete protection** : un item en auction ne doit **pas** être supprimable de l'inventaire. Marqueur `is_in_auction` ou détacher l'item de l'inventaire dès le post.
+- **Double-spending** : entre `PostAuction` et le commit DB, l'item ne doit pas être tradeable. Lock côté master.
+- **Search performance** : si pas de cache, chaque search = scan 100k auctions. Indexer côté DB (`KEY idx_item_entry`) + cache RAM.
+- **Mail chain** : un winner reçoit 1 mail (item) ; un loser bidder reçoit 1 mail (refund de son bid) ; le seller reçoit 1 mail (gold). 3 mails par auction résolue. À 100k expirations/tick, ça fait 300k mails — batcher via `MassMailMgr` (CMANGOS.18).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § AuctionHouse (P2 master)
+- cmangos `src/game/AuctionHouse/AuctionHouseMgr.cpp`,
+  `AuctionHouseHandler.cpp`, `AuctionHouseBot/` (à ignorer pour P4)

--- a/tickets/CMANGOS/CMANGOS.10_BattleGround_framework_instances_score.md
+++ b/tickets/CMANGOS/CMANGOS.10_BattleGround_framework_instances_score.md
@@ -1,0 +1,192 @@
+# CMANGOS.10_BattleGround_framework_instances_score
+
+## Objectif
+
+Mettre en place le **framework PvP instancié** côté shard LCDLLN,
+inspiré de `src/game/BattleGround` cmangos. Cinq piliers :
+
+1. **Hiérarchie de classe** : `BattleGround` virtuelle + 1 classe par
+   variante (`BattleGroundColosseum`, `BattleGroundCaptureFlag`, etc.).
+   Pattern « moteur générique + contenu spécifique ».
+2. **`BattleGroundQueue` séparé du `BattleGroundMgr`** : la file vit en
+   dehors de l'instance, peut être interrogée sans avoir d'instance
+   active. Utilisable pour LCDLLN même sans cross-realm.
+3. **Score per-player via `BattleGroundScore`** sous-classé par BG
+   (kills, flags, captures) — généralisation du concept "stats de
+   match".
+4. **`EventPlayerLoggedIn` / `EventPlayerLoggedOut`** sur l'instance
+   pour gérer reconnexion en plein match — critique pour MMORPG.
+5. **Reset automatique** des instances vides plutôt que persistance —
+   simplifie la gestion mémoire shard-side.
+
+C'est un **P2 shard**, pré-requis pour CMANGOS.08 (Arena/Colisée) et
+tout futur PvP instancié.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.19 (Maps — `BattleGroundMap` est une sous-classe de Map)
+- CMANGOS.08 (Arena) — utilise BattleGround
+
+## Livrables
+
+### Côté shard (`engine/server/shard/battleground/`)
+
+- `BattleGround.{h,cpp}` (abstract) :
+  ```cpp
+  class BattleGround {
+  public:
+    virtual void OnStart() = 0;
+    virtual void OnTick(int32_t dtMs) = 0;
+    virtual void OnEnd(BgWinner winner) = 0;
+    virtual void OnPlayerJoin(Player&) = 0;
+    virtual void OnPlayerLeave(Player&) = 0;
+    virtual void OnPlayerLoggedIn(Player&) = 0;       // reconnexion
+    virtual void OnPlayerLoggedOut(Player&) = 0;      // déconnexion temporaire
+    virtual void OnPlayerKilled(Player& victim, Unit* killer) = 0;
+    virtual void OnFlagCaptured(Player& capturer, FlagId flag) {}    // optional
+    virtual BattleGroundScore CreateScore(Player&) = 0;
+    BgState GetState() const;
+  protected:
+    BgState m_state;       // WaitingForPlayers, InProgress, Ended
+    int64_t m_startTs;
+    std::unordered_map<uint64_t, std::unique_ptr<BattleGroundScore>> m_scores;
+  };
+  ```
+- `BattleGroundScore.{h,cpp}` — stats per-player ; sous-classé par BG.
+- `BattleGroundQueue.{h,cpp}` :
+  - `Enqueue(uint32_t accountId, BgType, GroupId? group)`
+  - `Dequeue(...)` (cancel)
+  - `std::optional<BgMatch> TryFormMatch()` — appelé périodiquement.
+- `BattleGroundManager.{h,cpp}` :
+  - `BattleGround* CreateInstance(BgType, BgMatchInfo)`
+  - `void DestroyInstance(uint64_t instanceId)`
+  - `BattleGround* GetInstance(uint64_t instanceId)`
+- `BattleGroundColosseum.{h,cpp}` (premier impl) — sous-classe minimale
+  pour le colisée LCDLLN.
+
+### Configuration (`config.json`)
+
+```json
+"battleground": {
+  "wait_for_players_timeout_sec": 120,
+  "match_max_duration_sec": 1800,
+  "reconnect_grace_sec": 60,
+  "auto_kick_offline_at_match_end": true
+}
+```
+
+### Tests
+
+- `BattleGroundTests.cpp` — start → tick → end states.
+- `BattleGroundQueueTests.cpp` — match formation 5v5 avec 10 joueurs en queue.
+- `BattleGroundScoreTests.cpp` — sous-classe avec stats spécifiques (kills + flags).
+- `BattleGroundReconnectTests.cpp` — joueur logout/login pendant match → reprend sa place.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. State machine BG
+
+```
+WaitingForPlayers (timeout 2min) → si min_players atteint → InProgress
+InProgress (timeout 30min) → OnEnd(timeout) ou OnEnd(team_winner)
+Ended → 1 minute pour récupérer rewards → instance détruite
+```
+
+### 2. Score sous-classé
+
+```cpp
+struct ColosseumScore : public BattleGroundScore {
+  int kills = 0;
+  int deaths = 0;
+  int damageDealt = 0;
+  int healingDone = 0;
+};
+
+struct CaptureFlagScore : public BattleGroundScore {
+  int flagsCaptured = 0;
+  int flagsReturned = 0;
+  int kills = 0;
+};
+```
+
+Le BG sous-classé override `CreateScore(player)` pour retourner le
+bon type.
+
+### 3. Reconnexion
+
+```cpp
+void BattleGroundColosseum::OnPlayerLoggedOut(Player& p) {
+  // Ne pas remove du BG immédiatement.
+  // Marquer "absent", démarrer timer reconnect_grace_sec.
+  m_absentPlayers[p.GetId()] = now() + reconnectGraceSec * 1000;
+}
+
+void BattleGroundColosseum::OnPlayerLoggedIn(Player& p) {
+  if (m_absentPlayers.contains(p.GetId())) {
+    m_absentPlayers.erase(p.GetId());
+    p.TeleportTo(m_spawnPosition);    // re-place dans la zone
+  }
+}
+
+void BattleGroundColosseum::OnTick(int32_t dtMs) {
+  for (auto& [id, deadline] : m_absentPlayers) {
+    if (now() > deadline) {
+      // Considérer le joueur définitivement parti
+      RemoveFromBg(id);
+    }
+  }
+}
+```
+
+### 4. BattleGroundQueue séparée
+
+Pas couplée à une instance — vit dans un `BattleGroundManager`. Chaque
+tick, `TryFormMatch()` regarde si min_players * 2 (les 2 équipes) sont
+en queue → forme un match → crée une instance.
+
+Pour LCDLLN colisée local : queue trivialement résolue par le portier
+PNJ (CMANGOS.08).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/battleground/`.
+2. Implémenter `BattleGround` abstract.
+3. Implémenter `BattleGroundScore` base + une sous-classe.
+4. Implémenter `BattleGroundQueue` (file FIFO simple).
+5. Implémenter `BattleGroundManager` (create/destroy instances).
+6. Implémenter `BattleGroundColosseum` (premier impl concret).
+7. Implémenter reconnect/logout handling.
+8. Tests : 4 fichiers.
+9. Doc : section « BattleGround framework » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : 5 vs 5 entrent en colisée, match start, kills tracked, end → score visible
+- [ ] Reconnect : player logout pendant match → login dans 60s → reprend sa place
+- [ ] Logout > 60s → kick définitif
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **State machine strict** : transitions `WaitingForPlayers → InProgress → Ended` uniquement. Pas de retour en arrière. Évite bugs.
+- **Score persistance** : sauvegarder en DB pour les matches arène (CMANGOS.08), volatile pour les autres.
+- **min_players_per_team** : exposer en config par BgType. Colisée 2v2 = 2 par équipe ; futur grand BG = 10+.
+- **Joueur quitte volontairement** : « `LeaveBg` » → désertion = forfait + pénalité (debuff "Deserter" 15min). Anti-leave abuse.
+- **Match crée et personne ne join** : timeout `wait_for_players_timeout_sec` → cancel + retour en queue.
+- **Cross-shard BG** : si LCDLLN scale et veut une queue cross-shard, le `BattleGroundManager` devient master-side avec instances créées sur les shards. Pas pour le MVP.
+- **`std::unique_ptr<BattleGroundScore>`** : permet sous-classes virtuelles. Coût acceptable (pointer indirection) car peu d'updates de scores par tick.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § BattleGround (P2 shard)
+- cmangos `src/game/BattleGround/BattleGround.cpp`, `BattleGroundMgr.cpp`,
+  `BattleGroundQueue.cpp`, `BattleGroundWS.cpp` (Warsong example)

--- a/tickets/CMANGOS/CMANGOS.11_Combat_threat_hostile_decomposition.md
+++ b/tickets/CMANGOS/CMANGOS.11_Combat_threat_hostile_decomposition.md
@@ -1,0 +1,151 @@
+# CMANGOS.11_Combat_threat_hostile_decomposition
+
+## Objectif
+
+Mettre en place le **cœur du combat** côté shard LCDLLN, inspiré de la
+décomposition canonique cmangos `src/game/Combat` :
+
+1. **`CombatManager`** par Unit : gère l'entrée/sortie de combat, le
+   timer "leaving combat", les ennemis actuels.
+2. **`ThreatManager`** par Creature : ordering des cibles selon une
+   table de threat (qui aggro le plus). Distinct de "être en combat".
+3. **`HostileRefManager`** : graphe **bidirectionnel** "qui menace qui"
+   pour O(1) cleanup quand un acteur meurt ou despawn — évite les
+   "fantômes d'aggro" sur PNJ orphelins.
+4. **State machine** : `OutOfCombat → Combat → LeavingCombat (5s) →
+   OutOfCombat` — délai de sortie évite "PvE skip" instantané.
+5. **`DuelHandler`** comme mode opt-in séparé du PvP général : duel = zone
+   bornée + timer + win-condition à 1 HP. Bon précédent pour "mode arène
+   1v1 amical" dans une ville LCDLLN.
+
+C'est un **P2 shard**, pré-requis dès le premier PNJ hostile.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `Unit` porte `CombatManager`, `Creature` porte aussi `ThreatManager`
+- CMANGOS.03 (Grids) — `MessageDistDeliverer` pour broadcast "X est en combat"
+- CMANGOS.07 (AI) — l'IA réagit aux events combat
+
+## Livrables
+
+### Côté shard (`engine/server/shard/combat/`)
+
+- `CombatManager.{h,cpp}` — état combat par Unit. API :
+  - `EnterCombat(Unit& enemy)` — set state Combat, démarre timer `leaving`
+  - `LeaveCombat(LeaveReason reason)` — passe LeavingCombat puis OutOfCombat après délai
+  - `IsInCombat() const`
+  - `Update(int32 dtMs)` — tick le timer
+- `ThreatManager.{h,cpp}` — table de menace par Creature :
+  - `AddThreat(Unit& source, float amount)`
+  - `GetTopThreatTarget()` — pour aggro
+  - `Reset()`
+  - `RemoveTarget(Unit& target)` — ex. si target meurt
+- `HostileRef.{h,cpp}` — référence bidirectionnelle (intrusive list) entre 2 Units en hostilité.
+- `HostileRefManager.{h,cpp}` — gestion par Unit du set d'`HostileRef`. À la mort d'un acteur, `HostileRefManager::DeleteAllReferences()` invalide proprement tous les côtés.
+- `DuelHandler.{h,cpp}` — opt-in 1v1 :
+  - `StartDuel(Unit& a, Unit& b, Vector3 zoneCenter, float radius, int durationSec)`
+  - tick : si un joueur sort de la zone → forfait ; HP < 1 → victoire
+  - broadcast `SMSG_DUEL_REQUEST`, `SMSG_DUEL_COMPLETE` (opcodes à allouer)
+
+### Tests
+
+- `engine/server/shard/combat/CombatManagerTests.cpp` — entrée combat, leaving timer, sortie après 5s sans dégât.
+- `engine/server/shard/combat/ThreatManagerTests.cpp` — ordering des cibles ; un dégât remet en tête ; reset.
+- `engine/server/shard/combat/HostileRefTests.cpp` — A menace B + B menace A → delete A → B a plus de ref vers A.
+- `engine/server/shard/combat/DuelHandlerTests.cpp` — sortie de zone = forfait ; HP=1 = victoire.
+
+### Configuration (`config.json`)
+
+```json
+"combat": {
+  "leaving_combat_timeout_sec": 5,
+  "duel_default_duration_sec": 60,
+  "duel_default_radius_m": 30.0,
+  "threat_decay_per_sec": 0.0
+}
+```
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. State machine combat
+
+```
+OutOfCombat ----enemy attacks----> Combat
+Combat ----no damage 5s----> LeavingCombat
+LeavingCombat ----receive damage---> Combat (cancel timer)
+LeavingCombat ----timer expire----> OutOfCombat
+```
+
+### 2. Graphe HostileRef bidirectionnel
+
+```
+Player A ---HostileRef---> Creature B
+Player A <--HostileRef--- Creature B
+```
+
+Quand Creature B meurt :
+```cpp
+B.GetHostileRefManager().DeleteAllReferences();
+// → invalide les HostileRef côté B (trivial : son set est vidé)
+// → invalide aussi les HostileRef côté A (chaque ref est intrusive sur A et B)
+```
+
+Pas de fantômes : si A consultait `m_threats[guid_B]` après la mort de B, le lookup échoue proprement.
+
+### 3. ThreatManager ordering
+
+Liste triée par threat décroissant. À chaque dégât :
+```cpp
+m_threats[guid_attacker] += damageAmount;
+ResortIfNeeded();
+```
+
+`GetTopThreatTarget()` est utilisé par `BaseAI::SelectTarget()` (CMANGOS.07).
+
+### 4. DuelHandler
+
+Distinct du PvP général :
+- Zone bornée : test `distance(player, zoneCenter) < radius` à chaque tick. Sortie = forfait, HP restauré.
+- Timer : `durationSec`. Égalité au timer = match nul (pas de gain rep, pas de gold).
+- Win condition : un joueur < 1 HP → victoire. Pas mort, pas de butin, juste un message.
+- Pas de `HostileRefManager` standard : duel utilise un mode `DuelMode` séparé pour ne pas polluer le combat système.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/combat/`.
+2. Implémenter `HostileRef` + `HostileRefManager` (le plus isolé).
+3. Implémenter `ThreatManager` (Creature uniquement).
+4. Implémenter `CombatManager` (par Unit, state machine).
+5. Câbler `Unit::DealDamage` → met les deux côtés en combat + ajoute threat si Creature.
+6. Implémenter `DuelHandler` + opcodes nouveaux (`SMSG_DUEL_REQUEST/ACCEPT/COMPLETE`).
+7. Tests : 4 fichiers listés.
+8. Doc : section « Combat shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent (4 fichiers)
+- [ ] Smoke test : 1 player attaque 1 Creature → les 2 en combat ; player s'éloigne 5s sans dégât → out of combat
+- [ ] Smoke test duel : 2 players acceptent duel, l'un sort de la zone → forfait
+- [ ] HostileRef cleanup : Creature meurt → l'attaquant n'a plus la ref
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **PvE skip** : sans le timer `LeavingCombat`, un joueur sort instantanément du combat dès qu'il fuit l'attaquant pendant 1 tick → exploit régen full HP. Le timer 5s est crucial.
+- **Threat decay** : optionnel (défaut 0). Si activé, un PNJ peut "oublier" un attaquant inactif. Évite les chains d'aggro à perpétuité, mais peut casser l'équilibre raid. **Démarrer à 0**, profiler avant d'activer.
+- **Duel et chat** : pendant un duel, désactiver les whispers (sinon abus de macro distraction). Hook côté `ChatGate` (CMANGOS.01) avec un état `IsInDuel`.
+- **Reconnexion en combat** : si un joueur déconnecte en combat, la Creature continue d'attaquer son fantôme → bug. Au logout, soit réussir LeaveCombat (reconnexion = reset), soit auto-mort (cmangos style "logout in combat = die").
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Combat (P2 shard)
+- cmangos `src/game/Combat/CombatManager.cpp`, `ThreatManager.cpp`,
+  `HostileRefManager.cpp`, `DuelHandler.cpp`

--- a/tickets/CMANGOS/CMANGOS.12_Server_packetlog_opcodetable_dbcstores.md
+++ b/tickets/CMANGOS/CMANGOS.12_Server_packetlog_opcodetable_dbcstores.md
@@ -1,0 +1,178 @@
+# CMANGOS.12_Server_packetlog_opcodetable_dbcstores
+
+## Objectif
+
+Mettre en place les **patterns infra serveur** pour LCDLLN, inspirés de
+`src/game/Server` cmangos. Trois piliers :
+
+1. **`PacketLog` rejouable** : capture binaire de toutes les frames
+   réseau, rejouable offline. Inestimable pour debug protocole et
+   reproduire des bugs joueurs ("envoie-moi ton .pktlog").
+2. **Table d'opcodes typée** : `Opcodes.cpp` = tableau statique
+   `{opcode, name, status, processing, handler}`. Permet logging
+   unifié, throttling par opcode, stats. Modèle direct pour
+   `OpcodeRegistry` côté master/shard.
+3. **`DBCStores`** : préchargement RAM-mapped des fichiers de données
+   statiques au boot. Pour LCDLLN équivalent = vos data tables compilées
+   (terrain, items, sorts) chargées une fois au boot du shard.
+
+C'est un **P2 cross master+shard**, gain QoL prod important.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — pour les vraies stores SQL)
+- Logger (PR #468) — pour activer/désactiver via `LogFilter::PacketIo`
+
+## Livrables
+
+### Couche partagée (`engine/network/`)
+
+- `OpcodeRegistry.{h,cpp}` :
+  ```cpp
+  enum class OpcodeStatus : uint8 {
+    Loaded,           // pas encore handler-bound
+    UnHandled,        // ignored intentionnellement
+    Active,           // dispatché normalement
+    Deprecated,       // log warning si reçu
+  };
+  enum class OpcodeProcessing : uint8 {
+    InPlace,          // exécuté tout de suite dans le worker IO
+    InMapTick,        // queue pour tick map (si shard)
+    InMasterTick,     // queue pour tick master
+  };
+  struct OpcodeMeta {
+    uint16_t code;
+    std::string_view name;
+    OpcodeStatus status;
+    OpcodeProcessing processing;
+  };
+  class OpcodeRegistry {
+  public:
+    static void Register(OpcodeMeta meta);
+    static OpcodeMeta const* Get(uint16_t code);
+  };
+  ```
+- `PacketLog.{h,cpp}` :
+  - `void Open(std::filesystem::path file)` — démarre la capture.
+  - `void Close()`
+  - `void LogPacket(Direction dir, uint16_t opcode, std::span<const uint8_t> payload)` — append au fichier.
+  - `void Replay(std::filesystem::path file, std::function<void(Direction, uint16_t, std::span<const uint8_t>)> consumer)` — rejouer offline.
+
+### Outil offline (`tools/packet_replay/`)
+
+- `tools/packet_replay/packet_replay.cpp` — outil qui prend un `.pktlog`
+  + un fichier de breakpoints, rejoue dans un mock client, affiche
+  l'état observable.
+
+### Configuration (`config.json`)
+
+```json
+"server": {
+  "packet_log_enabled": false,
+  "packet_log_path": "logs/packets.pktlog",
+  "packet_log_max_size_mb": 100,
+  "opcode_stats_enabled": false
+}
+```
+
+### Tests
+
+- `OpcodeRegistryTests.cpp` — register + lookup, double register détecté.
+- `PacketLogTests.cpp` — round-trip : enregistrer N paquets, replay, vérifier identique.
+- `PacketLogRotationTests.cpp` — taille max → rotation.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Outils offline : uniquement sous `/tools` (`tools/packet_replay/`)
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Format `.pktlog`
+
+```
+[ Magic 4 bytes "LPKT" ]
+[ Version uint16 ]
+[ Header 16 bytes : start_ts, server_id, etc. ]
+[ Records sequentiels :
+    [ Direction 1 byte (0=IN, 1=OUT) ]
+    [ Timestamp delta ms (uint32) ]
+    [ Connection ID (uint32) ]
+    [ Opcode (uint16) ]
+    [ Payload size (uint16) ]
+    [ Payload (bytes) ]
+]
+```
+
+Compact, append-only. Rotation à `packet_log_max_size_mb`.
+
+### 2. OpcodeRegistry
+
+Au boot, chaque module (auth, chat, character, etc.) appelle
+`OpcodeRegistry::Register({kOpcodeXxx, "XXX", Active, InPlace})`. Le
+registry valide l'unicité.
+
+Gain :
+- Logging unifié : `LOG_FILTERED(Debug, PacketIo, Net, "RX {} (0x{:04x})", reg->name, opcode)`.
+- Throttling : si un opcode reçoit > N msgs/sec, log warn.
+- Stats : compteur par opcode, exposable via `/metrics`.
+
+### 3. Replay
+
+```cpp
+PacketLog::Replay("crash.pktlog", [](Direction dir, uint16_t opcode, auto payload) {
+  // Reproduire l'état avec tous les paquets pré-crash
+  if (dir == Direction::In) {
+    g_master->HandlePacket(opcode, payload);
+  }
+});
+```
+
+Cas d'usage : un joueur reproduit un crash, télécharge son `.pktlog`,
+tu lances localement avec `replay foo.pktlog --break-at=line=1234`,
+tu vois exactement ce qui plante.
+
+### 4. DBCStores équivalent
+
+Pour LCDLLN, pas de fichiers DBC du client (cmangos lit des fichiers
+extraits du client WoW). Mais pattern réutilisable : préchargement RAM
+de tables statiques DB au boot via `SQLStorage` (CMANGOS.13). Donc
+**rien de spécifique à coder pour DBCStores** — c'est déjà couvert par
+le ticket Database.
+
+## Étapes d'implémentation
+
+1. Créer `engine/network/OpcodeRegistry.{h,cpp}`.
+2. Migrer la définition des opcodes existants (PR #468 pattern, AuthRegister, Chat etc.) vers `OpcodeRegistry::Register(...)` dans un init module.
+3. Implémenter `PacketLog` (open / close / log / rotation).
+4. Câbler `NetServer` pour appeler `PacketLog::LogPacket` quand actif.
+5. Implémenter `Replay`.
+6. Créer `tools/packet_replay/` minimal.
+7. Tests : 3 fichiers.
+8. Doc : section « Server infra » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard) + outil packet_replay
+- [ ] Tests passent
+- [ ] Smoke test : activer `packet_log_enabled = true`, faire un échange client-serveur, le `.pktlog` est valide et replay reproduit la séquence
+- [ ] OpcodeRegistry : double-register détecté (assert ou log error)
+- [ ] Aucun dossier racine non autorisé (sauf `/tools/packet_replay/`)
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Coût packet log** : append-only à chaque paquet — perf OK si async write. Désactivé par défaut, activable via config.
+- **Données sensibles** : `.pktlog` peut contenir mots de passe (au handshake initial). **Sanitize** côté logger (skip auth opcodes ou mask).
+- **Format wire-locked** : un .pktlog v1 ne peut pas être rejoué par un serveur v2 avec opcodes différents. Inclure `version` dans le header pour détecter et rejeter avec un message clair.
+- **Replay deterministic** : le replay ne reproduit pas la timing exact (un paquet sleep 10s est rejoué instantanément). Pour les bugs liés au timing, utiliser un mode "real-time" qui respecte les delta ts.
+- **OpcodeRegistry et duplication maître/shard** : les deux processus doivent enregistrer les mêmes opcodes pour interpréter pareillement. Mettre les `Register(...)` dans une lib commune `engine/network/OpcodeDefinitions.cpp`.
+- **DBCStores** : pas de DBC chez nous — n'introduit pas un système séparé de SQLStorage. Si demain on a des fichiers binaires (ex. `.lod` pour terrain), créer `BinaryStores` à part, pas confondre.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Server (P2 cross)
+- cmangos `src/game/Server/Opcodes.cpp`, `WorldPacket.h`,
+  `WorldSocket.cpp`, `PacketLog.cpp`, `DBCStores.cpp`

--- a/tickets/CMANGOS/CMANGOS.13_Database_sqlstorage_async_prepared.md
+++ b/tickets/CMANGOS/CMANGOS.13_Database_sqlstorage_async_prepared.md
@@ -1,0 +1,171 @@
+# CMANGOS.13_Database_sqlstorage_async_prepared
+
+## Objectif
+
+Étendre la couche d'accès DB LCDLLN avec 3 patterns cmangos
+`src/shared/Database` :
+
+1. **`SQLStorage` / `SQLStorageImpl`** : cache RAM typé read-only chargé
+   une fois au boot depuis une table SQL, indexé par PK, accédé en O(1)
+   sans relock. Idéal pour tables statiques (loot, items, spells,
+   creature_template).
+2. **`SqlDelayThread`** : worker dédié qui consomme une file
+   d'opérations SQL asynchrones (callback + futures). Le caller reçoit
+   un `QueryResultFuture` non-bloquant.
+3. **`SqlPreparedStatement`** : abstraction binding-typed avec cache
+   des statements préparés par connexion. Réduit le parsing SQL côté
+   serveur MySQL.
+
+C'est un **P2 cross master+shard** — patterns réutilisables côté master
+(accounts, characters) et côté shard (creature/spell/loot templates).
+
+## Dépendances
+
+- M00.1 (build base)
+- `engine/server/db/ConnectionPool` (déjà existant, MySQL)
+- `engine/server/db/DbHelpers` (déjà existant)
+
+## Livrables
+
+### Côté shared (`engine/server/db/`)
+
+- `SQLStorage.{h,cpp}` (templated) — cache typé d'une table read-only :
+  ```cpp
+  template <typename T>
+  class SQLStorage {
+  public:
+    void Load(ConnectionPool& pool, std::string_view tableName, std::string_view pkColumn);
+    T const* Find(uint32_t pk) const;
+    size_t Size() const;
+    auto begin() const, end() const;  // itération
+  };
+  ```
+  - Charge une fois au boot (1 SELECT *).
+  - Stocke en `std::unordered_map<uint32_t, T>`.
+  - Accès O(1) sans lock (read-only post-load).
+  - Hot-reload optionnel via commande GM `.reload <storage_name>`.
+- `SQLStorageDecl.h` — macro/templates aidant à déclarer le mapping
+  table → struct. Ex : `DECLARE_SQL_FIELD(creature_template, level, INT)`.
+- `SqlDelayThread.{h,cpp}` — worker async :
+  ```cpp
+  class SqlDelayThread {
+  public:
+    void Start();
+    void Stop();
+    QueryResultFuture EnqueueQuery(std::string sql);
+    void EnqueueExecute(std::string sql, std::function<void(bool ok)> callback);
+  };
+  ```
+- `SqlPreparedStatement.{h,cpp}` — wrapper de `MYSQL_STMT` avec API
+  binding typed (`statement.Bind(0, accountId).Bind(1, "login").Execute()`).
+
+### Tests
+
+- `SQLStorageTests.cpp` — load + find ; ré-load (cache invalidé).
+- `SqlDelayThreadTests.cpp` — enqueue 100 queries → toutes complètent.
+- `SqlPreparedStatementTests.cpp` — bind 5 types (int, string, blob, float, datetime) → exec.
+
+### Configuration (`config.json`)
+
+```json
+"db": {
+  "delay_thread_enabled": true,
+  "delay_thread_queue_size": 1024,
+  "prepared_statement_cache_size_per_conn": 64,
+  "sql_storage_log_load_durations": true
+}
+```
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. SQLStorage usage type
+
+```cpp
+struct CreatureTemplate {
+  uint32_t entry;
+  std::string name;
+  int32_t level;
+  uint32_t faction;
+  // ...
+};
+
+SQLStorage<CreatureTemplate> g_creatureTemplates;
+
+// au boot du shard :
+g_creatureTemplates.Load(dbPool, "creature_template", "entry");
+
+// au runtime :
+if (auto* tpl = g_creatureTemplates.Find(creature.GetEntry())) {
+  // utiliser tpl->level, tpl->name, ...
+}
+```
+
+Pour des centaines de milliers d'entrées (ex. `item_template`), le coût
+RAM est de l'ordre de 100-200 MB. Acceptable pour un shard.
+
+### 2. SqlDelayThread
+
+Pour les **écritures** non critiques (ex. logs d'activité, statistiques)
+qui peuvent être différées 100ms sans impact gameplay.
+
+```cpp
+g_dbDelay.EnqueueExecute(
+  "INSERT INTO player_login_log (...) VALUES (...)",
+  [](bool ok) { if (!ok) LOG_ERROR(Db, "login log failed"); }
+);
+```
+
+**Pas pour** les écritures critiques (auth, achat HV) — synchrone reste.
+
+### 3. SqlPreparedStatement
+
+Cache par connexion : la 1ʳᵉ exécution prépare, les suivantes
+réutilisent le statement compilé côté MySQL.
+
+```cpp
+auto stmt = conn.Prepare("SELECT * FROM accounts WHERE id = ?");
+stmt.Bind(0, accountId);
+auto result = stmt.Execute();
+```
+
+Gain : 30-50% de débit DB sur les requêtes répétitives.
+
+## Étapes d'implémentation
+
+1. **Implémenter `SQLStorage`** templated header-only.
+2. **Câbler chargement au boot** dans `main_shard_linux.cpp` pour 1-2 tables initiales (creature_template, item_template).
+3. **Implémenter `SqlDelayThread`** + tests.
+4. **Implémenter `SqlPreparedStatement`** + cache.
+5. **Migration progressive** : remplacer les `SELECT * FROM creature_template WHERE entry = ?` ad hoc par `g_creatureTemplates.Find(entry)`.
+6. Tests : 3 fichiers listés.
+7. Doc : section « DB layer » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard)
+- [ ] Tests passent (3 fichiers)
+- [ ] Smoke test : 100k entries dans `item_template` chargées en < 5s
+- [ ] `SqlDelayThread` traite 1000 queries sans bloquer le tick
+- [ ] PreparedStatement réutilisé : check via log SQL count (devrait diminuer)
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **SQLStorage = read-only après load** : si une commande GM modifie une row, il faut **ré-load** complet. Ne pas tenter de patcher en RAM (incohérence garantie).
+- **DelayThread et shutdown** : à l'arrêt, drainer la file (exécuter le restant) avant de fermer les connexions. Sinon perte d'écritures.
+- **Connection per thread** : le SqlDelayThread tient sa propre connexion (séparée du pool). Pas de partage entre threads, pas de mutex.
+- **PreparedStatement et schéma** : si une migration ajoute une colonne, les statements préparés peuvent devenir invalides. Recréer le cache au reload schema.
+- **MySQL specific** : ces patterns assument MySQL. Si on veut PostgreSQL plus tard, rewrap. Cmangos a une couche multi-backend, on **ignore** par simplicité.
+- **Mémoire** : 100-200 MB de cache RAM est raisonnable mais pas gratuit. Pour des tables énormes (loot avec 10M rows), envisager un cache LRU au lieu de tout charger.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Database (P2 cross)
+- cmangos `src/shared/Database/SQLStorage.h`, `SqlDelayThread.cpp`,
+  `SqlPreparedStatement.cpp`

--- a/tickets/CMANGOS/CMANGOS.14_DBScripts_dsl_data_driven_hot_reload.md
+++ b/tickets/CMANGOS/CMANGOS.14_DBScripts_dsl_data_driven_hot_reload.md
@@ -1,0 +1,177 @@
+# CMANGOS.14_DBScripts_dsl_data_driven_hot_reload
+
+## Objectif
+
+Mettre en place un **moteur d'événements scriptés piloté par DB** côté
+shard LCDLLN, inspiré de `src/game/DBScripts` cmangos. Quatre piliers :
+
+1. **Tables `*_scripts` génériques** : `quest_start_scripts`,
+   `quest_end_scripts`, `gameobject_use_scripts`, `event_scripts`,
+   `spell_scripts` avec colonnes communes
+   `(id, delay, command, data1, data2, data3, target_type)`.
+2. **DSL minimaliste à ~30 commandes** : TALK, MOVE_TO, KILL_CREDIT,
+   CAST_SPELL, RESPAWN_GO, OPEN_DOOR, DESPAWN, SUMMON, TELEPORT, …
+   suffisamment expressif pour 95% du contenu PvE narratif **sans
+   embarquer Lua/JS**.
+3. **Délais entre commandes** (`delay` en secondes) : permet des
+   séquences chronométrées (PNJ parle, attend 3s, marche, attend 2s,
+   despawn) sans coroutines ni state machine ad hoc.
+4. **Hot-reload via `.reload all_scripts`** GM command : itération
+   contenu sans restart serveur — feature critique pour les game
+   designers.
+
+C'est un **P2 shard** quand le contenu PvE narratif arrive.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage pour cache des scripts)
+- CMANGOS.07 (AI — script peut être déclenché par event AI)
+- CMANGOS.16 (Globals/Conditions — `condition_id` filtre l'exécution)
+- CMANGOS.01 (Chat — commande `.reload`)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/scripts/`)
+
+- `ScriptCommand.h` — enum centralisée des commandes (`SCRIPT_TALK`,
+  `SCRIPT_MOVE_TO`, `SCRIPT_CAST_SPELL`, …).
+- `ScriptTargetType.h` — enum des targets (`TARGET_SELF`,
+  `TARGET_NEAREST_CREATURE`, `TARGET_PLAYER_SOURCE`, …).
+- `ScriptEntry.h` — struct row de la table : id, delay, command, params,
+  target_type, condition_id.
+- `ScriptMgr.{h,cpp}` — singleton :
+  - `Load(ConnectionPool&)` — charge toutes les tables de scripts.
+  - `Run(scriptType, scriptId, source, target)` — démarre l'exécution
+    asynchrone d'un script.
+  - `Tick(int32 dtMs)` — ticke les scripts en cours, exécute les
+    commandes dont le delay est écoulé.
+  - `ReloadAll()` — re-load DB.
+- `ScriptInstance.{h,cpp}` — instance d'un script en cours : référence
+  vers le ScriptEntry, source/target résolus, position courante (idx
+  de la commande), timer.
+
+### Migration DB
+
+```sql
+CREATE TABLE event_scripts (
+  id            INT UNSIGNED NOT NULL,
+  delay_sec     INT UNSIGNED NOT NULL DEFAULT 0,
+  command       TINYINT UNSIGNED NOT NULL,
+  data1         INT NOT NULL DEFAULT 0,
+  data2         INT NOT NULL DEFAULT 0,
+  data3         INT NOT NULL DEFAULT 0,
+  target_type   TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  condition_id  INT UNSIGNED NOT NULL DEFAULT 0,
+  comment       VARCHAR(255),
+  PRIMARY KEY (id, delay_sec, command, data1)  -- composite, plusieurs commandes par script
+);
+
+-- 4 autres tables avec même schéma : quest_start_scripts, quest_end_scripts,
+-- gameobject_use_scripts, spell_scripts.
+```
+
+### Configuration (`config.json`)
+
+```json
+"scripts": {
+  "max_concurrent_instances": 1000,
+  "tick_interval_ms": 100,
+  "log_command_execution": false
+}
+```
+
+### Tests
+
+- `ScriptMgrTests.cpp` — load/reload, run avec délai 3s exécute la 2ᵉ commande après ticks correspondants.
+- `ScriptCommandsTests.cpp` — chaque commande supportée a un test minimal.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Set initial de commandes (15+)
+
+| Command | data1 | data2 | data3 | Effet |
+|---|---|---|---|---|
+| TALK | text_id | chat_type | — | PNJ parle |
+| EMOTE | emote_id | — | — | PNJ joue émote |
+| FIELD_SET | field_idx | value | — | Modifie UpdateField |
+| MOVE_TO | x | y | z | PNJ va à un point |
+| FLAG_SET | field_idx | flag | — | Set bit flag |
+| FLAG_REMOVE | field_idx | flag | — | Clear bit flag |
+| TELEPORT_TO | map_id | x_y_packed | z | TP joueur target |
+| KILL_CREDIT | creature_entry | — | — | Donne kill credit pour quête |
+| RESPAWN_GO | go_guid | despawn_delay | — | Respawn un GameObject |
+| OPEN_DOOR | go_guid | reset_delay | — | Ouvre une porte |
+| CLOSE_DOOR | go_guid | reset_delay | — | Ferme |
+| DESPAWN | delay | — | — | Despawn target |
+| SUMMON_CREATURE | entry | duration | — | Spawn créature |
+| CAST_SPELL | spell_id | flags | — | Cast un sort |
+| QUEST_COMPLETE | quest_id | — | — | Marque quête comme complète |
+| ACTIVATE_OBJECT | — | — | — | Active GO trigger |
+| RUN_SCRIPT | other_script_id | — | — | Chaîne sur un autre script |
+
+À étendre selon besoins.
+
+### 2. Targeting
+
+```cpp
+enum class ScriptTargetType : uint8 {
+  Self,
+  Source,
+  NearestCreature,    // data2 = entry, data3 = max_radius
+  PlayerSource,
+  GameObject,         // data3 = go_guid
+};
+```
+
+Résolution au runtime quand la commande s'exécute (pas au load), pour
+gérer les entités spawned dynamiquement.
+
+### 3. Hot-reload
+
+Commande GM `.reload event_scripts` (ou `all_scripts`) :
+1. Stoppe les ScriptInstance en cours (ou les laisse finir avec l'ancien template, choisir).
+2. Vide le cache `ScriptMgr::m_scripts`.
+3. Recharge la DB.
+4. Log : `[ScriptMgr] reloaded N scripts in M ms`.
+
+## Étapes d'implémentation
+
+1. Migration DB des 5 tables.
+2. Implémenter `ScriptMgr::Load`.
+3. Implémenter `ScriptInstance::Tick` avec dispatch sur commande.
+4. Implémenter 5 commandes minimales (TALK, MOVE_TO, CAST_SPELL, DESPAWN, RUN_SCRIPT) — étendre ensuite.
+5. Câbler `Quest::OnAccept` → `ScriptMgr::Run("quest_start_scripts", quest.start_script_id, player, npc)`.
+6. Implémenter hot-reload + commande GM `.reload event_scripts`.
+7. Tests : 2 fichiers.
+8. Doc : section « DBScripts shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : script "TALK 'Hello' → MOVE_TO (10,20,5) → DESPAWN" exécute les 3 commandes dans l'ordre avec les delays
+- [ ] `.reload event_scripts` recharge sans restart shard
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Cas d'échec** : si `MOVE_TO` ne peut pas atteindre la position (path bloqué), continuer ? Abort ? Choisir : par défaut, continuer après un timeout (5s) avec un log warning. Sinon un script bug bloque la séquence indéfiniment.
+- **Cycles** : un script qui RUN_SCRIPT vers lui-même → boucle. Ajouter un `max_depth = 8` dans `ScriptInstance` pour break.
+- **Threading** : `ScriptMgr::Tick` est appelé par la Map. Pas de lock à prendre — chaque ScriptInstance vit dans la Map de sa source.
+- **Localization** : `TALK` avec `text_id` doit pointer vers une table `localized_text` (i18n) ; pas de string littérale.
+- **Hot-reload sans race** : pendant le reload, un script en cours peut référencer un `ScriptEntry` dont l'adresse mémoire change. Soit (a) attendre que les instances en cours finissent avant de purger, soit (b) faire un swap atomique des pointeurs et garder l'ancien jusqu'au prochain tick.
+- **Pas de Lua / pas de JS** : volontairement minimaliste. Si un designer demande "je veux du if/else complexe", c'est probablement le moment d'écrire un C++ ScriptDevAI (CMANGOS.07) — pas d'étendre le DSL en VM.
+- **Logging** : `log_command_execution` actif uniquement en dev (très verbeux). Filtrer via `LogFilter::DbScriptsDev` (déjà disponible PR #468).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § DBScripts (P2 shard)
+- cmangos `src/game/DBScripts/ScriptMgr.cpp`, `ScriptMgrDefines.h`

--- a/tickets/CMANGOS/CMANGOS.15_Groups_groupref_loot_rules_master.md
+++ b/tickets/CMANGOS/CMANGOS.15_Groups_groupref_loot_rules_master.md
@@ -1,0 +1,205 @@
+# CMANGOS.15_Groups_groupref_loot_rules_master
+
+## Objectif
+
+Mettre en place les **groupes/raids de joueurs** côté master LCDLLN,
+inspirés de `src/game/Groups` cmangos. Quatre piliers :
+
+1. **`GroupReference` / `GroupRefManager` intrusive list** : un Player
+   détient une `GroupReference` qui s'invalide automatiquement quand
+   le groupe se dissout. Pattern intrusive list évitant les dangling
+   pointers, sans coût atomique `shared_ptr`.
+2. **Loot rules par groupe** (FreeForAll, RoundRobin, MasterLooter,
+   NeedBeforeGreed) encodées comme enum + politique pluggable. Ajouter
+   une nouvelle règle = ajouter une stratégie.
+3. **Persistance partielle** : seuls les raids permanents sont en DB,
+   les groupes 5-man sont in-memory volatiles — économise des
+   écritures.
+4. **Cross-shard ready** : un groupe est un objet **master-side**
+   (logique sociale), les positions des membres viennent du shard —
+   séparation naturelle pour LCDLLN.
+
+C'est un **P2 master**, pré-requis pour PvE de groupe et raid.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts)
+- CMANGOS.13 (Database — pour persistance raid permanente)
+- CMANGOS.17 (Loot — règles de groupe)
+
+## Livrables
+
+### Côté master (`engine/server/groups/`)
+
+- `Group.{h,cpp}` :
+  ```cpp
+  class Group {
+  public:
+    enum class Type : uint8 { Party, Raid };
+    enum class LootMethod : uint8 { FreeForAll, RoundRobin, MasterLooter, NeedBeforeGreed };
+
+    bool AddMember(uint32_t accountId, uint64_t characterId);
+    bool RemoveMember(uint32_t accountId);
+    void Disband();
+    void SetLeader(uint32_t accountId);
+    void SetLootMethod(LootMethod m);
+    bool ConvertToRaid();
+    Type GetType() const;
+    LootMethod GetLootMethod() const;
+    std::span<GroupMember const> GetMembers() const;
+  private:
+    uint64_t m_groupId;
+    Type m_type;
+    LootMethod m_lootMethod;
+    uint32_t m_leaderAccountId;
+    std::vector<GroupMember> m_members;
+    bool m_persistent;        // raid persisté
+  };
+  ```
+- `GroupReference.{h,cpp}` (templated intrusive list) — quand un Player
+  rejoint un Group, il porte un `GroupReference` qui pointe vers Group.
+  Auto-removed à la destruction.
+- `GroupManager.{h,cpp}` :
+  - `Group* CreateGroup(leaderAccountId, Type)`
+  - `void DisbandGroup(uint64_t groupId)`
+  - `Group* GetGroupForAccount(uint32_t accountId)`
+- `GroupHandler.{h,cpp}` — opcodes :
+  - `kOpcodeGroupInvite`, `kOpcodeGroupAccept`, `kOpcodeGroupDecline`
+  - `kOpcodeGroupKick`, `kOpcodeGroupLeave`
+  - `kOpcodeGroupLootMethod`, `kOpcodeGroupSetLeader`
+  - `kOpcodeGroupConvertToRaid`
+
+### Migration DB
+
+```sql
+CREATE TABLE persistent_group (
+  group_id            BIGINT UNSIGNED NOT NULL,
+  type                TINYINT UNSIGNED NOT NULL,
+  loot_method         TINYINT UNSIGNED NOT NULL,
+  leader_account_id   INT UNSIGNED NOT NULL,
+  created_ts          BIGINT NOT NULL,
+  PRIMARY KEY (group_id)
+);
+
+CREATE TABLE persistent_group_member (
+  group_id            BIGINT UNSIGNED NOT NULL,
+  account_id          INT UNSIGNED NOT NULL,
+  character_id        BIGINT UNSIGNED NOT NULL,
+  joined_ts           BIGINT NOT NULL,
+  PRIMARY KEY (group_id, account_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"group": {
+  "max_party_members": 5,
+  "max_raid_members": 40,
+  "default_loot_method": "RoundRobin",
+  "raid_persistence_default": false,
+  "invite_timeout_sec": 60
+}
+```
+
+### Tests
+
+- `GroupReferenceTests.cpp` — invalidation automatique à Disband.
+- `GroupManagerTests.cpp` — create + add + kick + leave.
+- `GroupLootRulesTests.cpp` — chaque rule applique correctement.
+- `GroupPersistenceTests.cpp` — raid permanent survit reboot.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. GroupReference intrusive
+
+```cpp
+template <class T>
+class GroupReference {
+public:
+  ~GroupReference() { Unlink(); }
+  void Link(T* group);
+  void Unlink();
+private:
+  T* m_target = nullptr;
+  GroupReference* m_next = nullptr;
+  GroupReference* m_prev = nullptr;
+};
+```
+
+Quand `Group::Disband()` est appelé, parcours les `GroupReference` de
+ses membres et les unlink. Aucun pointeur dangling, pas besoin d'atomic.
+
+### 2. Persistance partielle
+
+| Type | Persisté |
+|---|---|
+| Party (5-man) | Non — disparait au logout du dernier membre |
+| Raid (40-man) | Optionnel : si `raid_persistence_default` true ou commande explicite, persiste en DB |
+
+Cohérent avec WoW : groupes éphémères = pas de trace ; raids = lock à
+la mort d'un boss = persistance.
+
+### 3. Cross-shard
+
+Groupe vit sur le master, **pas** sur le shard. Le shard a une vue
+read-only « ce joueur appartient au groupe X », via une notification
+master → shard à chaque changement.
+
+Conséquence : pour calculer `IsInGroupWith(player)` côté shard, on
+maintient une copie locale du groupId par session shard. Push depuis
+master au login + à chaque join/leave.
+
+### 4. Loot rule application
+
+```cpp
+// CMANGOS.17 (Loot) consulte le group du killer pour déterminer la rule.
+auto* group = g_groups.GetGroupForAccount(killer.GetAccountId());
+auto rule = group ? group->GetLootMethod() : LootMethod::FreeForAll;
+ApplyLootRule(rule, group->GetMembers(), lootPile);
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/groups/`.
+2. Implémenter `GroupReference` (intrusive list).
+3. Implémenter `Group` + `GroupMember`.
+4. Implémenter `GroupManager` (create/destroy/lookup).
+5. Implémenter opcodes + handler (invite/accept/leave/kick/etc.).
+6. Implémenter persistance raid.
+7. Câbler avec Loot (CMANGOS.17).
+8. Tests : 4 fichiers.
+9. Doc : section « Groups master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : create party → invite + accept → leader passe les loot rules → kick fonctionne
+- [ ] GroupReference auto-cleanup à Disband (pas de dangling pointer)
+- [ ] Raid permanent : member kill boss → boss-kill enregistré pour tous les membres présents
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Invite timeout** : un invite non accepté en 60s expire. Cleanup côté master.
+- **Invite cross-account** : un account peut être dans plusieurs personnages mais un seul group à la fois.
+- **Logout in group** : si tous les membres logout, le party (volatile) disparait. Le raid persistant reste en DB.
+- **Kick from raid lock** : un joueur kick d'un raid avec lock de boss reste lock — il garde l'instance, ne peut plus rentrer mais le ID raid reste.
+- **Master Looter offline** : si le master looter logout, fall back à RoundRobin pour cette session.
+- **GroupReference threading** : le master est mono-thread pour la logique groupe (typique). Si on parallèlise, mutex sur Group + GroupRefManager.
+- **Notif shard** : à chaque change groupe, batcher les notifs (ne pas envoyer 5 paquets à 5 shards si tout est local).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Groups (P2 master)
+- cmangos `src/game/Groups/Group.cpp`, `GroupHandler.cpp`,
+  `GroupReference.h`, `GroupRefManager.h`

--- a/tickets/CMANGOS/CMANGOS.16_Globals_conditions_objectaccessor_locales.md
+++ b/tickets/CMANGOS/CMANGOS.16_Globals_conditions_objectaccessor_locales.md
@@ -1,0 +1,241 @@
+# CMANGOS.16_Globals_conditions_objectaccessor_locales
+
+## Objectif
+
+Mettre en place la **couche de globaux et de prédicats data-driven**
+côté shard LCDLLN, inspirée de `src/game/Globals` cmangos. Quatre
+piliers :
+
+1. **`Conditions` data-driven** : un mini-DSL pour exprimer des
+   prédicats (« a tel buff », « est en groupe », « niveau ≥ X ») avec
+   composition AND/OR/NOT. Réutilisé par quêtes, loot, scripts,
+   events. **Évite mille `if` en C++** disséminés dans le code métier.
+2. **`ObjectAccessor`** : façade thread-safe pour
+   `GetPlayer(guid)`/`GetCreature(guid)`/`GetGameObject(guid)`. Évite
+   que chaque système maintienne sa propre map.
+3. **`GraveyardManager`** : table de points de respawn liée aux zones +
+   faction, requêtable par « plus proche graveyard valide pour ce
+   joueur ».
+4. **`Locales`** : strings localisées chargées en RAM par
+   `(stringId, locale)`, fallback sur la locale par défaut. Pour les
+   broadcasts serveur, system messages, noms de PNJ.
+
+C'est un **P2 shard**, et le système Conditions est un game-changer pour
+tout le contenu data-driven.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage pour cache)
+- Pré-requis pour : CMANGOS.17 (Loot), CMANGOS.23 (Quests), CMANGOS.14 (DBScripts), CMANGOS.07 (AI/EventAI), CMANGOS.26 (Spells)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/globals/`)
+
+- `Condition.h` — struct + enum :
+  ```cpp
+  enum class ConditionType : uint8 {
+    None,
+    HasAura,            // value1 = aura_spell_id
+    LevelGE,            // value1 = min_level
+    LevelLE,            // value1 = max_level
+    InGroup,
+    InRaid,
+    InGuild,            // value1 = guild_id (0 = any)
+    HasItem,            // value1 = item_id, value2 = count
+    QuestState,         // value1 = quest_id, value2 = QuestState enum
+    ZoneId,             // value1 = zone_id
+    Reputation,         // value1 = faction_id, value2 = min_rank
+    HealthPctBelow,     // value1 = pct
+    NotInCombat,
+    Custom,             // value1 = handler_id pour scripts spéciaux
+  };
+  struct Condition {
+    uint32_t conditionId;
+    ConditionType type;
+    int32_t value1, value2, value3;
+  };
+  ```
+- `ConditionGroup.h` — composition logique :
+  ```cpp
+  enum class ConditionLogic : uint8 { And, Or, Not };
+  struct ConditionGroup {
+    uint32_t groupId;
+    ConditionLogic logic;
+    std::vector<uint32_t> conditionIds;     // ou subgroup ids
+  };
+  ```
+- `ConditionMgr.{h,cpp}` — singleton :
+  - `Load(ConnectionPool&)` — charge `conditions` + `condition_groups`.
+  - `bool Evaluate(uint32_t conditionId, Player const* source, WorldObject const* target = nullptr) const`.
+- `ObjectAccessor.{h,cpp}` — façade :
+  - `Player* GetPlayer(ObjectGuid)`
+  - `Creature* GetCreature(MapId, ObjectGuid)`
+  - Thread-safe via `std::shared_mutex` autour des registries.
+- `GraveyardManager.{h,cpp}` — :
+  - `Load(ConnectionPool&)`
+  - `Vector3 ClosestGraveyard(MapId, Vector3 pos, FactionId faction)`
+- `LocaleStrings.{h,cpp}` — cache `(stringId, localeId) → string`
+  + `GetString(stringId, localeId)` avec fallback.
+
+### Migration DB
+
+```sql
+CREATE TABLE conditions (
+  condition_id  INT UNSIGNED NOT NULL,
+  type          TINYINT UNSIGNED NOT NULL,
+  value1        INT NOT NULL DEFAULT 0,
+  value2        INT NOT NULL DEFAULT 0,
+  value3        INT NOT NULL DEFAULT 0,
+  description   VARCHAR(255),
+  PRIMARY KEY (condition_id)
+);
+
+CREATE TABLE condition_groups (
+  group_id      INT UNSIGNED NOT NULL,
+  logic         TINYINT UNSIGNED NOT NULL,    -- And/Or/Not
+  member_id     INT UNSIGNED NOT NULL,        -- condition_id ou autre group_id
+  member_type   TINYINT UNSIGNED NOT NULL,    -- 0=condition, 1=group
+  PRIMARY KEY (group_id, member_id, member_type)
+);
+
+CREATE TABLE graveyards (
+  id          INT UNSIGNED NOT NULL,
+  map_id      INT UNSIGNED NOT NULL,
+  position_x  FLOAT NOT NULL,
+  position_y  FLOAT NOT NULL,
+  position_z  FLOAT NOT NULL,
+  faction     TINYINT UNSIGNED NOT NULL DEFAULT 0,    -- 0 = neutral
+  zone_id     INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE locale_strings (
+  string_id   INT UNSIGNED NOT NULL,
+  locale_id   TINYINT UNSIGNED NOT NULL,    -- 0=fr_FR (default LCDLLN), 1=en_US, ...
+  text        TEXT NOT NULL,
+  PRIMARY KEY (string_id, locale_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"globals": {
+  "default_locale": "fr_FR",
+  "fallback_locale": "fr_FR",
+  "graveyard_default_faction_neutral_radius_m": 500.0
+}
+```
+
+### Tests
+
+- `ConditionMgrTests.cpp` — chaque ConditionType simple ; combine via group AND/OR.
+- `ObjectAccessorTests.cpp` — get/set, lookup multi-thread.
+- `GraveyardManagerTests.cpp` — closest graveyard avec filtrage faction.
+- `LocaleStringsTests.cpp` — fallback locale manquante.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. ConditionMgr usage
+
+```cpp
+// Loot drop conditionnel : un item ne tombe que si le joueur a la quête active.
+auto* lootEntry = GetLootEntry(...);
+if (lootEntry->condition_id != 0
+ && !g_conditions.Evaluate(lootEntry->condition_id, looter)) {
+  // skip
+}
+```
+
+```cpp
+// Quest accept : ne propose la quête que si conditions remplies.
+if (!g_conditions.Evaluate(quest.required_condition_id, player)) {
+  return false;  // not eligible
+}
+```
+
+### 2. ObjectAccessor cache
+
+```cpp
+class ObjectAccessor {
+public:
+  Player* FindPlayer(ObjectGuid guid);  // par GUID
+  Player* FindPlayerByName(std::string_view name);
+  Creature* FindCreature(MapId mapId, ObjectGuid guid);
+private:
+  std::unordered_map<ObjectGuid, Player*> m_players;
+  mutable std::shared_mutex m_mutex;
+};
+```
+
+Inscription auto au login, désinscription au logout.
+
+### 3. GraveyardManager
+
+À la mort d'un joueur, on cherche le graveyard valide (faction
+correspondante OU neutre dans un rayon) le plus proche.
+
+```cpp
+Vector3 ClosestGraveyard(MapId mapId, Vector3 pos, FactionId faction) {
+  auto candidates = m_graveyards[mapId];
+  // filter par faction (ou neutre)
+  // tri par distance
+  return closest;
+}
+```
+
+### 4. Locales
+
+Format de string avec placeholders :
+```
+"Bienvenue {0}, niveau {1}!"
+```
+
+Helper `Format(stringId, locale, args...)` interpolant les `{N}`.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/globals/`.
+2. Migration DB des 4 tables.
+3. Implémenter `ConditionMgr` + 5 ConditionTypes initiaux.
+4. Implémenter `ObjectAccessor`.
+5. Implémenter `GraveyardManager`.
+6. Implémenter `LocaleStrings`.
+7. Tests : 4 fichiers.
+8. Doc : section « Globals shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : créer condition `LevelGE 10`, l'évaluer pour un Player niveau 5 → false ; niveau 15 → true
+- [ ] Smoke test composition : `(LevelGE 10) AND (HasAura 100)` filtre correctement
+- [ ] `ObjectAccessor::FindPlayer(guid)` retourne le bon Player en multi-thread
+- [ ] Closest graveyard sur 3 candidats donne le bon (test avec coordonnées connues)
+- [ ] LocaleStrings : si `fr_FR` manquant, fallback `default_locale`
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Performance ConditionMgr** : `Evaluate` peut être appelé des milliers de fois par tick (loot, AoE). **Pas de virtual call** — switch sur ConditionType directement.
+- **Chargement ConditionMgr** : 10k+ conditions OK, 1M = problème. Si LCDLLN scale, paginer/lazy-load.
+- **Cache ObjectAccessor** : invalider au logout est critique. Sinon `FindPlayer` retourne un pointeur dangling.
+- **Locale fallback chain** : ne pas faire `fr_FR → en_US → fail`. Faire `fr_FR → default_locale → string_id_as_text` (pour ne jamais retourner empty).
+- **Conditions composables** : démarrer avec AND/OR/NOT simples. Si vous voulez `EXACTLY_N_OF (a, b, c, d) >= 2`, c'est un autre niveau de complexité — le reporter.
+- **Custom condition handler** : pour les cas non prévus, `ConditionType::Custom + handler_id` permet d'enregistrer un foncteur en C++. À utiliser sparingly, sinon on perd le data-driven.
+- **Thread safety** : `ObjectAccessor` partagé entre Map threads — `shared_mutex` (multiple readers, exclusive writer). `ConditionMgr` est read-only post-load, donc lock-free.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Globals (P2 shard)
+- cmangos `src/game/Globals/ObjectMgr.cpp`, `ObjectAccessor.cpp`,
+  `Conditions.cpp`, `GraveyardManager.cpp`, `Locales.cpp`

--- a/tickets/CMANGOS/CMANGOS.17_Loot_templates_groups_reference.md
+++ b/tickets/CMANGOS/CMANGOS.17_Loot_templates_groups_reference.md
@@ -1,0 +1,189 @@
+# CMANGOS.17_Loot_templates_groups_reference
+
+## Objectif
+
+Mettre en place le **système de butin (loot)** côté shard LCDLLN,
+inspiré de `src/game/Loot` cmangos. Cinq piliers :
+
+1. **Loot templates en DB** : `creature_loottemplate`,
+   `gameobject_loottemplate`, `fishing_loottemplate`,
+   `pickpocketing_loottemplate` — **même schéma générique**
+   `(entry, item, chance, group, mincount, maxcount, condition_id)`
+   réutilisé partout.
+2. **Loot groups** : à l'intérieur d'un template, des items partagent
+   un `group` qui garantit qu'**exactement un drop** (somme des chances
+   dans le groupe = 100%) — sépare loot garanti et loot bonus.
+3. **Reference loot** : un template peut référencer un autre par
+   convention (`item < 0` → reference) — DRY pour les loot tables
+   partagées entre boss similaires.
+4. **Conditions par drop** : un item ne tombe que si le looter remplit
+   une `Condition` (CMANGOS.16) — composabilité avec quêtes/factions.
+5. **Round-robin / need-greed runtime** : la résolution dépend de la
+   `GroupLootMethod`, pas du template — orthogonalité données/règles.
+
+C'est un **P2 shard**, pré-requis dès le premier PNJ avec drops.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage cache pour les templates)
+- CMANGOS.16 (Globals/Conditions — condition_id par drop)
+- CMANGOS.15 (Groups — loot rules par groupe)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/loot/`)
+
+- `LootEntry.h` — struct row :
+  ```cpp
+  struct LootEntry {
+    int32_t  itemId;      // <0 = reference vers autre template
+    float    chance;
+    uint8_t  groupId;     // 0 = pas dans un groupe
+    uint8_t  minCount;
+    uint8_t  maxCount;
+    uint32_t conditionId; // 0 = pas de condition
+  };
+  ```
+- `LootTemplate.h` — collection de `LootEntry` indexée par `entry`.
+- `LootMgr.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge les 4 tables avec SQLStorage.
+  - `Loot Generate(LootTemplateType type, uint32_t entry, Player const* looter)` — génère le butin selon les rolls + conditions.
+- `Loot.{h,cpp}` — pile de loot active sur une entité morte/coffre :
+  - `std::vector<LootItem>` items générés.
+  - Tracking « qui a vu / qui a pris ».
+- `LootRoll.{h,cpp}` — rolls (Need, Greed, Pass, Disenchant) côté groupe.
+
+### Migration DB
+
+```sql
+-- 4 tables avec schéma identique
+CREATE TABLE creature_loottemplate (
+  entry         INT UNSIGNED NOT NULL,
+  item          INT NOT NULL,                  -- <0 = reference
+  chance        FLOAT NOT NULL,
+  group_id      TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  min_count     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  max_count     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  condition_id  INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (entry, item)
+);
+-- mêmes pour gameobject_loottemplate, fishing_loottemplate, pickpocketing_loottemplate
+
+CREATE TABLE reference_loot_template (
+  entry         INT UNSIGNED NOT NULL,    -- ref entry positif
+  item          INT UNSIGNED NOT NULL,
+  chance        FLOAT NOT NULL,
+  group_id      TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  min_count     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  max_count     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  condition_id  INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (entry, item)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"loot": {
+  "default_drop_factor": 1.0,
+  "show_chance_in_log": false,
+  "max_drops_per_loot": 16,
+  "fish_loot_enabled": true
+}
+```
+
+### Tests
+
+- `LootMgrTests.cpp` — generate avec template simple.
+- `LootGroupTests.cpp` — group avec 3 items chance 50/30/20 → toujours exactement 1 drop.
+- `LootReferenceTests.cpp` — `itemId < 0` redirige vers reference template.
+- `LootConditionTests.cpp` — drop conditionné sur `LevelGE 10` filtre correctement.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Génération
+
+```cpp
+Loot LootMgr::Generate(LootTemplateType type, uint32_t entry, Player const* looter) {
+  auto* tmpl = GetTemplate(type, entry);
+  Loot result;
+  // 1. Items hors group : roll chacun individuellement
+  for (auto& e : tmpl->ungroupedEntries) {
+    if (e.conditionId && !g_conditions.Evaluate(e.conditionId, looter)) continue;
+    if (RollFloat() <= e.chance) {
+      result.AddItem(ResolveItemRef(e), RollCount(e.minCount, e.maxCount));
+    }
+  }
+  // 2. Items en group : un seul drop par group (cumulative)
+  for (auto& [groupId, members] : tmpl->groupedEntries) {
+    auto chosen = SelectFromGroup(members, looter);
+    if (chosen) result.AddItem(ResolveItemRef(*chosen), RollCount(...));
+  }
+  return result;
+}
+```
+
+### 2. Reference resolution
+
+`itemId < 0` → on traite `-itemId` comme `entry` dans `reference_loot_template`. Récursif possible (ref → ref) — limiter profondeur à 3.
+
+### 3. Loot pile (sur cadavre)
+
+À la mort d'une Creature, `LootMgr::Generate` produit un `Loot` qui est attaché au Corpse. Les joueurs autorisés (selon GroupLoot) voient le contenu via `kOpcodeLootContents`.
+
+### 4. Group loot rules
+
+| Method | Description |
+|---|---|
+| FreeForAll | Premier arrivé = preneur |
+| RoundRobin | Cycle parmi les membres |
+| MasterLoot | Le master looter assigne |
+| NeedBeforeGreed | Vote Need (priorité) → Greed → Pass → DE |
+
+Géré par `LootRoll` côté Group (CMANGOS.15).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/loot/`.
+2. Migrations DB.
+3. Implémenter `LootMgr::Load` avec SQLStorage.
+4. Implémenter `Generate` avec rolls + groups + conditions.
+5. Implémenter reference resolution.
+6. Implémenter `Loot` pile (attaché à un Corpse).
+7. Implémenter `LootRoll` pour les groupes.
+8. Allouer opcodes (`kOpcodeLootContents`, `kOpcodeLootTake`).
+9. Tests : 4 fichiers.
+10. Doc : section « Loot shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : creature avec loot template (3 items, 1 group de 2) → drops cohérents stat sur 1000 kills
+- [ ] Reference loot : `itemId = -42` → fetch dans `reference_loot_template[42]`
+- [ ] Drop conditionné : seul un Player niveau ≥ 10 voit l'item
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Group sum != 100%** : si la somme des chances d'un group < 100%, parfois rien ne drop (bug). Si > 100%, comportement indéfini. **Validation au load** : warning si group != 100% (pas reject — utile en dev).
+- **Reference cycles** : ref A → ref B → ref A → boucle. Détecter au load.
+- **Conditions performance** : 100 entries × 50 conditions evaluations = 5000 evals par mob mort. Profiler. Si lent, cache les conditions évaluées par looter pour la session.
+- **Reroll RNG** : pour des drops symboliques (legendary), le RNG doit être audit-able. Stocker le seed du roll en log debug.
+- **Drop factor config** : `default_drop_factor` permet d'ajuster globalement (ex. event x2 drops). Ne **pas** mettre en hard-coded — toujours via config.
+- **Pickpocket loot** : seulement si la cible est non hostile et fait par un Rogue. Distinct du loot de cadavre.
+- **Fishing** : table à part car les "entries" sont des `area_id`, pas des `creature_entry`.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Loot (P2 shard)
+- cmangos `src/game/Loot/LootMgr.cpp`, `LootHandler.cpp`,
+  schémas `creature_loottemplate.sql` etc.

--- a/tickets/CMANGOS/CMANGOS.18_Mails_master_side_cod_expiration_massmail.md
+++ b/tickets/CMANGOS/CMANGOS.18_Mails_master_side_cod_expiration_massmail.md
@@ -1,0 +1,211 @@
+# CMANGOS.18_Mails_master_side_cod_expiration_massmail
+
+## Objectif
+
+Mettre en place la **messagerie asynchrone in-game** côté master LCDLLN,
+inspirée de `src/game/Mails` cmangos. Master-side car cross-shard
+naturel. Quatre piliers :
+
+1. **Schéma `mail` + `mail_items`** : un mail = 1 row + N rows attachements.
+2. **Workflow COD (Cash On Delivery)** : pièce jointe libérée seulement
+   après paiement, sinon retour à l'expéditeur — pattern transactionnel
+   utile pour AH/trade asynchrone.
+3. **Expiration auto** avec tâche périodique qui retourne ou supprime
+   les mails périmés.
+4. **`MassMailMgr`** : envoi en masse (events serveur, GM broadcasts,
+   retours auction house) avec batching DB pour éviter N inserts.
+
+C'est un **P2 master**, pré-requis dès qu'on a 2 joueurs (whisper
+asynchrone) et requis pour AuctionHouse (CMANGOS.09).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- CMANGOS.06 (Accounts — sender/receiver = accountId)
+- Item system existant (pré-requis fonctionnel)
+
+## Livrables
+
+### Côté master (`engine/server/mail/`)
+
+- `Mail.h` — struct :
+  ```cpp
+  struct Mail {
+    uint64_t mailId;
+    uint32_t senderAccountId;       // 0 = system mail
+    uint32_t receiverAccountId;
+    std::string subject;
+    std::string body;
+    std::vector<ObjectGuid> items;
+    uint64_t copperGold;            // gold attaché (en copper)
+    uint64_t copperCod;              // si != 0, montant à payer pour récupérer items
+    int64_t  sentTs;
+    int64_t  expirationTs;
+    MailState state;                 // Unread, Read, ReturnedToSender, Deleted
+  };
+  ```
+- `MailManager.{h,cpp}` :
+  - `uint64_t Send(Mail&& mail)` — persist DB, notify receiver si online.
+  - `bool TakeItem(mailId, itemIdx, accountId)` — paye COD si applicable, transfère item.
+  - `bool TakeGold(mailId, accountId)`.
+  - `bool DeleteMail(mailId, accountId)` (mark deleted).
+  - `void ResolveExpired(int64_t nowMs)` — tick périodique.
+  - `std::vector<Mail> GetMailsForAccount(accountId, limit)` — pagination.
+- `MassMailMgr.{h,cpp}` — envoi en masse :
+  - `void SendToAllAccounts(Mail templateMail, std::vector<accountId> targets)` — batch INSERT.
+- `MailHandler.{h,cpp}` — opcodes (cf. ci-dessous).
+
+### Migration DB
+
+```sql
+CREATE TABLE mail (
+  mail_id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  sender_account_id    INT UNSIGNED NOT NULL DEFAULT 0,
+  receiver_account_id  INT UNSIGNED NOT NULL,
+  subject              VARCHAR(128) NOT NULL DEFAULT '',
+  body                 TEXT,
+  copper_gold          BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  copper_cod           BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  sent_ts              BIGINT NOT NULL,
+  expiration_ts        BIGINT NOT NULL,
+  state                TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (mail_id),
+  KEY idx_receiver_state (receiver_account_id, state),
+  KEY idx_expiration (expiration_ts)
+);
+
+CREATE TABLE mail_items (
+  mail_id     BIGINT UNSIGNED NOT NULL,
+  item_guid   BIGINT UNSIGNED NOT NULL,
+  taken       TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (mail_id, item_guid)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"mail": {
+  "default_expiration_days": 30,
+  "system_mail_expiration_days": 7,
+  "max_mails_per_player": 100,
+  "expiration_check_interval_min": 60
+}
+```
+
+### Opcodes
+
+- `kOpcodeMailListRequest` (client → master)
+- `kOpcodeMailSend` (avec attachments)
+- `kOpcodeMailTakeItem`
+- `kOpcodeMailTakeGold`
+- `kOpcodeMailDelete`
+- `kOpcodeMailMarkRead`
+
+### Tests
+
+- `MailManagerTests.cpp` — send + receive + take.
+- `MailCodTests.cpp` — COD : take refusé sans gold, accepté avec gold.
+- `MailExpirationTests.cpp` — expired retourne au sender.
+- `MassMailTests.cpp` — batch INSERT 1000 mails en 1 transaction.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. COD workflow
+
+```
+Sender: Send(items, cod=100g)
+Mail expiration_ts = now + 3d  (COD shorter than normal mails)
+Receiver TakeItem:
+  - if cod > 0: deduct cod from receiver, send gold to sender (new mail)
+  - transfer item to receiver inventory
+  - mark item as "taken"
+Receiver Delete:
+  - if items still attached → REFUSE (ne peut pas delete tant qu'items unclaimed)
+  - if no items → mark deleted
+```
+
+### 2. Expiration
+
+```cpp
+void ResolveExpired(int64_t nowMs) {
+  auto expired = QueryExpired(nowMs);
+  for (auto& mail : expired) {
+    if (mail.HasUntakenItems() || mail.copperGold > 0) {
+      // Retour à l'expéditeur (sauf system mail = sender 0)
+      if (mail.senderAccountId != 0) {
+        ReturnToSender(mail);
+      } else {
+        DropItems(mail);    // system mail expiré : items perdus
+      }
+    }
+    mail.state = Deleted;
+    UpdateDb(mail);
+  }
+}
+```
+
+### 3. MassMail batched
+
+```cpp
+void MassMailMgr::SendToAllAccounts(Mail tmpl, std::vector<uint32_t> targets) {
+  // 1 transaction DB pour N mails
+  BeginTransaction();
+  for (auto accountId : targets) {
+    auto m = tmpl;
+    m.receiverAccountId = accountId;
+    m.mailId = NextId();
+    InsertMailRow(m);
+    InsertItemRows(m);
+  }
+  CommitTransaction();
+  // notify online receivers in batch
+}
+```
+
+Évite 1000 INSERTs séparés (catastrophique pour MySQL) → 1 INSERT bulk.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/mail/`.
+2. Migrations DB.
+3. Implémenter `MailManager` + opcodes.
+4. Implémenter `MassMailMgr` (batch INSERT).
+5. Câbler `ResolveExpired` dans le tick master.
+6. Implémenter COD workflow.
+7. Tests : 4 fichiers.
+8. Doc : section « Mail master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : envoi mail avec item → receiver le récupère
+- [ ] COD : take refusé sans gold, accepté avec gold + transfert au sender
+- [ ] Expiration : mail avec items expire → retour sender
+- [ ] MassMail 1000 destinataires en 1 transaction
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Items en mail = inventaire fantôme** : les items attachés ne sont pas dans l'inventaire du sender ni du receiver. Tracker explicitement (table `mail_items`) sinon double-spend.
+- **Sender offline** : si receiver take un item COD → gold à transférer au sender. Sender peut être offline. → Créer un mail système au sender avec le gold.
+- **Cycles de retour** : si retour sender → expire à nouveau → retour again ? Limiter : un mail "ReturnedToSender" qui expire est **deleted**, pas re-renvoyé.
+- **Performance list mails** : un joueur avec 100 mails → query lourde au login. Paginer (`limit + offset`) côté handler.
+- **Multi-shard delivery** : le master sait qu'un receiver est online sur shard X via `SessionManager`. Push une notification "New mail" via le shard.
+- **Item GUID stale** : si un item attaché en mail est référencé ailleurs (oubli de detach), corruption. Toujours `Detach(itemGuid)` avant `Send`.
+- **Anti-spam** : `max_mails_per_player = 100`. Au delà, refuser. Empêcher les bots d'inonder.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Mails (P2 master)
+- cmangos `src/game/Mails/Mail.cpp`, `MailHandler.cpp`,
+  `MassMailMgr.cpp`

--- a/tickets/CMANGOS/CMANGOS.19_Maps_thread_per_map_subclasses_spawngroup.md
+++ b/tickets/CMANGOS/CMANGOS.19_Maps_thread_per_map_subclasses_spawngroup.md
@@ -1,0 +1,188 @@
+# CMANGOS.19_Maps_thread_per_map_subclasses_spawngroup
+
+## Objectif
+
+Mettre en place le **squelette de la simulation par instance** côté
+shard LCDLLN, inspiré de `src/game/Maps` cmangos. Quatre piliers :
+
+1. **« Map = un thread logique »** : tout le gameplay d'une instance
+   tourne mono-thread, supprimant 90% des locks. Le parallélisme se fait
+   **entre maps** (`MapUpdater` / pool de workers), pas dans une map.
+2. **Sous-classes spécialisées** (`DungeonMap`, `BattleGroundMap`,
+   `WorldMap`) avec policies différentes (lifecycle, persistance, joueur
+   cap) — éviter un `Map` monolithique avec 50 flags.
+3. **`MapPersistentState`** : les instances sauvegardées (raids loot
+   lockés) ont un état DB séparé du runtime — recharge un raid après
+   reboot avec progression intacte.
+4. **`SpawnGroup`** : groupes de spawns coordonnés (« patrouille de 3 »,
+   « pop l'un OU l'autre ») data-driven, pas scripté.
+5. **`ObjectPosSelector`** : trouve une position libre autour d'un point
+   sans collision — utile pour summons, loot piles, téléports de groupe.
+
+C'est un **P2 shard**, fondation de la simulation à plusieurs instances.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — Map contient des `WorldObject`
+- CMANGOS.03 (Grids) — chaque Map a sa GridMap
+- CMANGOS.05 (vmap) — collisions par Map
+- CMANGOS.07 (AI), CMANGOS.11 (Combat), CMANGOS.20 (MotionGenerators) — tickés par Map
+
+## Livrables
+
+### Côté shard (`engine/server/shard/maps/`)
+
+- `Map.{h,cpp}` — base abstraite. Méthodes `Update(int32 dtMs)`, `Add(WorldObject*)`, `Remove(WorldObject*)`, `Tick()` qui orchestre dans l'ordre : grids → AI → motion → combat → snapshot.
+- `WorldMap.{h,cpp}` — sous-classe pour le monde ouvert. Une seule instance par mapId, lifetime infini.
+- `DungeonMap.{h,cpp}` — sous-classe pour donjons 5-man. Lifetime borné par présence joueurs ; persistance optionnelle si binding raid.
+- `BattleGroundMap.{h,cpp}` — sous-classe pour BG/colisée (CMANGOS.10). Lifetime = match.
+- `MapManager.{h,cpp}` — singleton, gère la création/destruction des Map instances. API `GetOrCreate(mapId, instanceId)`.
+- `MapUpdater.{h,cpp}` — pool de threads workers qui ticke les maps en parallèle. Une map = un thread à un instant donné, mais différentes maps en parallèle.
+- `MapPersistentState.{h,cpp}` — état DB par instance (loot locks, boss kills, timers).
+- `SpawnGroup.{h,cpp}` — descripteur de spawn coordonné chargé depuis DB.
+- `ObjectPosSelector.{h,cpp}` — utilitaire de placement.
+
+### Migration DB
+
+```sql
+CREATE TABLE map_persistent_state (
+  instance_id     INT UNSIGNED NOT NULL,
+  map_id          INT UNSIGNED NOT NULL,
+  reset_time      BIGINT NOT NULL DEFAULT 0,
+  bosses_killed   INT UNSIGNED NOT NULL DEFAULT 0,
+  data_blob       MEDIUMBLOB,
+  PRIMARY KEY (instance_id)
+);
+
+CREATE TABLE spawn_group_template (
+  group_id      INT UNSIGNED NOT NULL,
+  name          VARCHAR(64) NOT NULL,
+  type          TINYINT UNSIGNED NOT NULL,    -- creature=0, gameobject=1
+  max_active    INT UNSIGNED NOT NULL DEFAULT 1,
+  PRIMARY KEY (group_id)
+);
+
+CREATE TABLE spawn_group_member (
+  group_id      INT UNSIGNED NOT NULL,
+  member_entry  INT UNSIGNED NOT NULL,         -- creature_template.entry
+  chance        TINYINT UNSIGNED NOT NULL DEFAULT 100,
+  PRIMARY KEY (group_id, member_entry)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"map": {
+  "updater_thread_count": 4,
+  "tick_target_ms": 100,
+  "world_map_idle_grace_sec": 600,
+  "dungeon_map_empty_unload_sec": 300
+}
+```
+
+### Tests
+
+- `MapManagerTests.cpp` — get/create/destroy ; ne pas créer 2 instances pour le même `mapId+instanceId`.
+- `SpawnGroupTests.cpp` — `max_active=2` avec 5 candidats : exactement 2 spawnés en simultané.
+- `ObjectPosSelectorTests.cpp` — autour d'un point avec 8 entités proches, trouve la 9ᵉ position libre.
+- `MapPersistentStateTests.cpp` — round-trip save/load DB.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. « Map = un thread logique »
+
+Au lieu de protéger chaque WorldObject avec des mutex, on garantit que :
+- Une Map à un instant donné est tickée par **exactement un thread**.
+- Tout accès aux WorldObject d'une Map doit se faire **depuis** ce
+  thread.
+- Communication inter-Map (téléport joueur, mail livré, broadcast world)
+  via `Messager` (CMANGOS.36, P3) — file de fonctions cross-thread.
+
+### 2. Sous-classes Map
+
+```
+Map (abstract)
+├── WorldMap         // mapId fixe, instanceId=0, infinite lifetime
+├── DungeonMap       // mapId fixe, instanceId unique, bound or not
+└── BattleGroundMap  // mapId fixe, instanceId per-match, ephemeral
+```
+
+Override des hooks :
+- `OnPlayerEnter`, `OnPlayerLeave`
+- `OnBossKilled` (DungeonMap : sauvegarde dans `MapPersistentState`)
+- `OnEnd` (BG : reset, distribution récompenses)
+
+### 3. SpawnGroup
+
+```cpp
+struct SpawnGroup {
+  uint32_t groupId;
+  uint32_t maxActive;
+  std::vector<SpawnGroupMember> members;  // entry + chance
+};
+
+// au respawn d'un membre, le mgr décide si on respawne
+// (selon maxActive et chances)
+```
+
+Évite de coder « 3 patrouilleurs spawnent ensemble + un seul rare » en C++ ; tout en data.
+
+### 4. ObjectPosSelector
+
+```cpp
+class ObjectPosSelector {
+public:
+  ObjectPosSelector(Map& map, Vector3 center, float searchRadius);
+  std::optional<Vector3> FindFreePosition(float minDistFromOthers);
+};
+```
+
+Utilisé par : summon (placer le minion à côté du caster), loot drop (placer la pile pas au milieu d'un PNJ vivant), tp de groupe (chacun à sa position autour du leader).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/maps/`.
+2. Implémenter `Map` abstract + `WorldMap` minimal (juste add/remove, pas de tick gameplay).
+3. Implémenter `MapManager` + `MapUpdater` (thread pool).
+4. Câbler le tick : Grids → AI → MotionGenerators → Combat → SnapshotBuilder (CMANGOS.02 §SnapshotBuilder).
+5. Implémenter `DungeonMap` + `BattleGroundMap` stubs (overrides).
+6. Implémenter `MapPersistentState` + migration `map_persistent_state`.
+7. Implémenter `SpawnGroup` + migrations `spawn_group_*`.
+8. Implémenter `ObjectPosSelector`.
+9. Tests : 4 fichiers listés.
+10. Doc : section « Maps shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests `Map*Tests`, `SpawnGroupTests`, `ObjectPosSelectorTests` passent
+- [ ] Smoke test : 4 maps en parallèle (4 threads), chacune avec 100 entités, tick stable à 10 Hz pendant 60 s sans drift
+- [ ] DungeonMap : binding raid persiste après reboot (loot lock OK)
+- [ ] SpawnGroup : `max_active=2` respecté avec 5 candidats
+- [ ] Migrations appliquées et idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Pas de mutex sur WorldObject** : le modèle « Map = thread » repose là-dessus. Si quelqu'un ajoute `std::mutex m_pos;` sur un Unit "par sécurité", ça réintroduit la contention. Code review strict.
+- **Tick stabilité** : viser `tick_target_ms` (100ms = 10 Hz) en moyenne, jamais en hard real-time. Si une map mange 200ms ponctuellement, ne pas paniquer ; logger un warning si > 2× target.
+- **Téléport inter-map** : ne **jamais** déplacer un WorldObject d'une Map à une autre directement. Stratégie : `Remove(obj)` de la map source → push une fonction sur le `Messager` de la map cible qui fait `Add(reconstructed obj)`. Sinon le worker source touche aux données du worker cible = race.
+- **MapPersistentState save** : ne pas sauvegarder à chaque tick. Triggers : boss killed, loot looted, joueur leave. Sinon I/O DB sature.
+- **DungeonMap timeouts** : un donjon vide se décharge après `dungeon_map_empty_unload_sec`. Si un joueur revient, recréer la map (avec restauration de l'état persistent si binding) — coût acceptable sur entrée.
+- **BattleGroundMap fin de match** : cleanup explicite (remove all players, despawn all). Ne **pas** s'appuyer sur le timeout d'idle, sinon des matches "fantômes" avec un score figé persistent.
+- **Tick order matters** : Grids (déplacements en cellules) avant AI (qui consulte les voisins) avant MotionGenerators (qui pousse les splines) avant Combat (qui résout les dégâts) avant SnapshotBuilder (qui sérialise l'état final). Inverser cet ordre = comportements bizarres (un PNJ aggro un joueur déjà bougé, etc.).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Maps (P2 shard)
+- cmangos `src/game/Maps/Map.cpp`, `MapManager.cpp`, `MapUpdater.cpp`,
+  `DungeonMap.cpp`, `BattleGroundMap.cpp`, `MapPersistentStateMgr.cpp`,
+  `SpawnGroup.cpp`, `ObjectPosSelector.cpp`

--- a/tickets/CMANGOS/CMANGOS.20_MotionGenerators_stack_navmesh_waypoints.md
+++ b/tickets/CMANGOS/CMANGOS.20_MotionGenerators_stack_navmesh_waypoints.md
@@ -1,0 +1,217 @@
+# CMANGOS.20_MotionGenerators_stack_navmesh_waypoints
+
+## Objectif
+
+Mettre en place la **pile de générateurs de mouvement** côté shard
+LCDLLN, inspirée de `src/game/MotionGenerators` cmangos. Cinq piliers :
+
+1. **`MotionMaster = std::stack<MovementGenerator*>`** : on push un
+   Chase pendant un combat, on pop quand il finit, le Random idle
+   reprend automatiquement. État comportemental sans state machine
+   explicite.
+2. **Cleanup différé via flags** : si on `Clear()` pendant un `Update()`,
+   on marque pour cleanup au prochain tick — évite use-after-free.
+3. **MoveMap (navmeshes Detour)** chargés par tile à la demande, partagés
+   entre toutes les créatures de la map.
+4. **`MoveSplineInit` builder pattern** (déjà couvert par CMANGOS.04
+   Movement) — l'IA produit un MoveSplineInit, le générateur le Launch.
+5. **`WaypointManager` + DB** : patrouilles décrites en data
+   (`creature_movement_template`), pas en C++.
+
+C'est un **P2 shard**, le cœur de l'IA de mouvement.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — `Unit` porte un `MotionMaster`
+- CMANGOS.04 (Movement) — `MoveSplineInit` est l'API de sortie des générateurs
+- CMANGOS.07 (AI) — l'IA pousse/pop des générateurs sur le `MotionMaster`
+- CMANGOS.13 (Maps) — chaque Map charge les navmeshes des tiles actifs
+
+## Livrables
+
+### Côté shard (`engine/server/shard/motion/`)
+
+- `MovementGenerator.{h,cpp}` — interface abstraite. Méthodes virtuelles :
+  - `Initialize(Unit&)`, `Reset(Unit&)`, `Finalize(Unit&)`
+  - `Update(Unit&, int32 dtMs) → bool` — retourne `false` quand fini
+  - `GetType() → MovementGeneratorType` (enum)
+- `IdleMovementGenerator.{h,cpp}` — base, ne fait rien (pour PNJ frozen).
+- `RandomMovementGenerator.{h,cpp}` — déplacement aléatoire dans un rayon.
+- `WaypointMovementGenerator.{h,cpp}` — patrouille selon
+  `creature_movement_template`.
+- `ChaseMovementGenerator.{h,cpp}` — poursuit une cible (Unit) à une
+  distance min/max.
+- `FollowMovementGenerator.{h,cpp}` — suit une cible avec un offset.
+- `PointMovementGenerator.{h,cpp}` — atteint un point précis puis fini.
+- `FleeMovementGenerator.{h,cpp}` — fuit une cible.
+- `MotionMaster.{h,cpp}` — la pile. API :
+  - `MoveIdle()`, `MoveRandom(radius)`, `MoveTargetedHome()`, `MoveChase(Unit&, range)`, `MoveFollow(Unit&, dist, angle)`, `MovePoint(id, pos)`, `MoveFleeing(Unit&)`, `MoveWaypoint(pathId)`
+  - `Update(Unit&, int32 dtMs)` — appelé par `Map::Tick`
+  - `Clear(MovementSlot)` — supprime des générateurs mais reporte si dans Update
+- `MoveMap.{h,cpp}` — wrapper Detour (navmesh recast). Charge `.mmap`
+  par tile. Requêtes : `FindPath(start, end) → vector<Vector3>`.
+
+### Outil offline (`tools/mmap_extractor/`)
+
+- `tools/mmap_extractor/mmap_extractor.cpp` — bake offline : prend les
+  meshes + heightmap (mêmes inputs que `vmap_extractor`, CMANGOS.05) →
+  produit des `.mmap` Recast.
+
+### Migration DB
+
+```sql
+CREATE TABLE creature_movement_template (
+  entry         INT UNSIGNED NOT NULL,
+  point         INT UNSIGNED NOT NULL,
+  position_x    FLOAT NOT NULL,
+  position_y    FLOAT NOT NULL,
+  position_z    FLOAT NOT NULL,
+  delay_ms      INT UNSIGNED NOT NULL DEFAULT 0,
+  script_id     INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (entry, point)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"motion": {
+  "navmesh_dir": "mmap",
+  "navmesh_max_loaded_tiles": 64,
+  "random_movement_default_radius_m": 10.0,
+  "chase_default_range_m": 5.0,
+  "follow_default_distance_m": 3.0
+}
+```
+
+### Tests
+
+- `MotionMasterTests.cpp` — push Chase puis Clear → cleanup différé OK.
+- `WaypointMovementTests.cpp` — patrouille passe par tous les points.
+- `ChaseMovementTests.cpp` — créature suit la cible jusqu'à `range`.
+- `MoveMapTests.cpp` — pathfinding sur navmesh synthétique.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Contenu : navmeshes `.mmap` sous `/game/data/mmap/`
+- Outils offline : `/tools/mmap_extractor/`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Stack de générateurs
+
+```cpp
+class MotionMaster {
+public:
+  void MoveChase(Unit& target, float range);  // push ChaseGenerator
+  void Clear(MovementSlot slot = MOTION_SLOT_ACTIVE);
+  void Update(Unit& owner, int32 dtMs) {
+    if (m_inUpdate) { m_pendingClear = true; return; }
+    m_inUpdate = true;
+    auto& top = m_stack.top();
+    if (!top.Update(owner, dtMs)) {
+      m_stack.pop();
+      // pop expose le générateur en-dessous (Random idle, par ex.)
+    }
+    m_inUpdate = false;
+    if (m_pendingClear) ApplyDelayedClear();
+  }
+private:
+  std::stack<std::unique_ptr<MovementGenerator>> m_stack;
+  bool m_inUpdate = false;
+  bool m_pendingClear = false;
+};
+```
+
+### 2. Cleanup différé
+
+Si `Clear()` est appelé pendant un `Update()` (par ex. un `OnDeath`
+trigger un Clear), on **diffère** au prochain tick. Sinon on détruit
+le générateur en cours d'exécution = use-after-free immédiat.
+
+### 3. MoveMap (Recast/Detour)
+
+```cpp
+class MoveMap {
+public:
+  void LoadTile(MapId mapId, int32 tileX, int32 tileY);
+  void UnloadTile(MapId mapId, int32 tileX, int32 tileY);
+  std::vector<Vector3> FindPath(MapId mapId, Vector3 start, Vector3 end);
+};
+```
+
+Charge des `.mmap` (format Recast) à la demande, partage le navmesh
+entre toutes les Creature de la map. 1 navmesh par tile, refcounted
+comme les `vmap` (CMANGOS.05).
+
+Utilisé par : `WaypointMovementGenerator` (pathfinding entre waypoints
+si obstacle), `ChaseMovementGenerator` (path autour des murs).
+
+### 4. WaypointMovementGenerator + DB
+
+```cpp
+void Init() {
+  m_waypoints = WaypointManager::GetWaypoints(m_owner.GetEntry());
+  m_currentIdx = 0;
+}
+bool Update(Unit& owner, int32 dtMs) {
+  if (CurrentReached()) {
+    if (m_waypoints[m_currentIdx].delay_ms > 0) Wait();
+    if (m_waypoints[m_currentIdx].script_id) RunScript(...);
+    m_currentIdx = (m_currentIdx + 1) % m_waypoints.size();
+    StartMoveTo(m_waypoints[m_currentIdx].pos);
+  }
+  return true;  // jamais fini (boucle)
+}
+```
+
+### 5. Outil `lcdlln_mmap_extractor`
+
+Inputs : meshes + heightmap (mêmes que `vmap_extractor`).
+
+Process :
+1. Construire un Recast nav-mesh par tile via lib Recast (vendored ou submodule).
+2. Sérialiser au format `.mmap` (header + Detour data).
+3. Output : `game/data/mmap/<zone>/tile_<cx>_<cy>.mmap`.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/motion/`.
+2. Implémenter `MovementGenerator` interface + `IdleMovementGenerator`.
+3. Implémenter `MotionMaster` (stack + cleanup différé).
+4. Implémenter `RandomMovementGenerator`, `PointMovementGenerator`.
+5. Implémenter `MoveMap` (vendor Recast/Detour ou submodule).
+6. Implémenter `WaypointMovementGenerator` + migration `creature_movement_template`.
+7. Implémenter `ChaseMovementGenerator`, `FollowMovementGenerator`, `FleeMovementGenerator`.
+8. Créer `tools/mmap_extractor/` (peut être stub initial qui produit un `.mmap` dégénéré "tout est marchable").
+9. Tests : 4 fichiers listés.
+10. Doc : section « Motion shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) + outil mmap_extractor
+- [ ] Tests passent (4 fichiers)
+- [ ] Smoke test : 1 Creature avec waypoints (3 points) patrouille en boucle ; cleanup OK quand `MoveChase` push pendant l'`Update`
+- [ ] Pathfinding navmesh : Creature contourne un mur synthétique
+- [ ] Migration `creature_movement_template` appliquée et idempotente
+- [ ] Aucun dossier racine non autorisé (sauf `/tools/mmap_extractor/`)
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Use-after-free** : le cleanup différé est **non-négociable**. Sans lui, un `OnDeath` qui clear le motion master = crash systématique.
+- **Slots** : cmangos a `MOTION_SLOT_IDLE`, `MOTION_SLOT_ACTIVE`, `MOTION_SLOT_CONTROLLED`. Permet de garder un Random idle "en arrière-plan" pendant qu'un Chase est actif. **Démarrer simple** (1 seul slot) ; étendre quand nécessaire.
+- **Detour licensing** : Recast/Detour est zlib-licensed (compatible commercial). Vendor en submodule ou copie locale.
+- **Navmesh size** : un `.mmap` peut faire 1-10 MB par tile. Avec 64 tiles loaded, ça monte à ~500 MB en RAM. Compresser au boot ou stream agressivement (release_delay_sec dans config).
+- **Waypoint script_id** : si une patrouille déclenche un script (`script_id != 0`), le script est exécuté côté shard. Coordonner avec CMANGOS.12 (DBScripts) — `script_id` doit pointer vers une row de `creature_movement_scripts` (ou même table que les autres scripts).
+- **Chase et range** : si la cible est plus rapide que le chaser, le chaser ne rattrape jamais — il faut un timeout ou une condition d'évade. Géré côté `CombatManager` (CMANGOS.11).
+- **FleeMovementGenerator** : ne pas fuir aveuglément (peut foncer dans un mur). Toujours passer par `MoveMap::FindPath` pour valider la fuite.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § MotionGenerators (P2 shard)
+- cmangos `src/game/MotionGenerators/` (tout le dossier)
+- Recast/Detour : https://github.com/recastnavigation/recastnavigation

--- a/tickets/CMANGOS/CMANGOS.21_Guilds_schema_permissions_bank.md
+++ b/tickets/CMANGOS/CMANGOS.21_Guilds_schema_permissions_bank.md
@@ -1,0 +1,253 @@
+# CMANGOS.21_Guilds_schema_permissions_bank
+
+## Objectif
+
+Mettre en place le **système de guildes persistantes** côté master
+LCDLLN, inspiré de `src/game/Guilds` cmangos. Cinq piliers :
+
+1. **Schéma DB séparé** : `guild`, `guild_member`, `guild_rank`,
+   `guild_bank_item`, `guild_bank_tab`, `guild_eventlog` —
+   séparation propre rank/membre/banque.
+2. **Permissions par rank en bitmask** : chaque rank a un bitfield
+   (kick, invite, withdraw_money, edit_motd…) ; ajouter une perm =
+   ajouter un bit, pas une colonne.
+3. **Event log circulaire en DB** : table avec rotation par taille max,
+   sert d'audit + d'UI client.
+4. **`GuildMgr` singleton** charge toutes les guildes au boot —
+   acceptable car peu nombreuses (~100k max sur un serveur AAA).
+5. **Banque multi-onglets** avec permissions par onglet par rank —
+   flexibilité forte pour peu de complexité.
+
+C'est un **P2 master**, pré-requis dès qu'on veut une vie sociale
+durable.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts)
+- CMANGOS.13 (Database)
+- CMANGOS.18 (Mails) — invitations / messages broadcast
+- Économie (gold/items) existante.
+
+## Livrables
+
+### Côté master (`engine/server/guilds/`)
+
+- `Guild.{h,cpp}` :
+  ```cpp
+  class Guild {
+  public:
+    bool AddMember(uint32_t accountId, std::string_view rankName);
+    bool RemoveMember(uint32_t accountId);
+    bool ChangeRank(uint32_t accountId, std::string_view newRank);
+    bool DepositBank(uint32_t accountId, uint8_t tabIdx, ObjectGuid item);
+    bool WithdrawBank(uint32_t accountId, uint8_t tabIdx, ObjectGuid item);
+    void LogEvent(GuildEvent event, uint32_t actorAccountId, std::string_view detail);
+    bool HasPermission(uint32_t accountId, GuildPermission perm) const;
+  private:
+    uint64_t m_guildId;
+    std::string m_name;
+    std::string m_motd;
+    std::string m_charter;
+    uint32_t m_leaderAccountId;
+    std::vector<GuildRank> m_ranks;
+    std::vector<GuildMember> m_members;
+    std::vector<GuildBankTab> m_bankTabs;
+    GuildEventLog m_eventLog;
+  };
+  ```
+- `GuildRank.h` :
+  ```cpp
+  struct GuildRank {
+    std::string name;
+    GuildPermissionMask permissions;     // bitmask
+    std::array<GuildBankTabPermissions, 6> bankTabPermissions;
+  };
+  ```
+- `GuildPermission.h` — enum class bitmask :
+  ```cpp
+  enum class GuildPermission : uint32 {
+    None         = 0,
+    Invite       = 1u << 0,
+    Kick         = 1u << 1,
+    EditMotd     = 1u << 2,
+    Promote      = 1u << 3,
+    Demote       = 1u << 4,
+    EditRanks    = 1u << 5,
+    DepositBank  = 1u << 6,
+    WithdrawBank = 1u << 7,
+    EditCharter  = 1u << 8,
+    KickHigher   = 1u << 9,    // peut kick un rank égal/supérieur (admin)
+  };
+  ```
+- `GuildManager.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge toutes les guildes au boot.
+  - `Guild* CreateGuild(uint32_t leaderAccountId, std::string_view name)`
+  - `void Disband(uint64_t guildId)`
+  - `Guild* GetGuildForAccount(uint32_t accountId)`
+- `GuildHandler.{h,cpp}` — opcodes (15+).
+
+### Migration DB
+
+```sql
+CREATE TABLE guild (
+  guild_id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name              VARCHAR(64) NOT NULL UNIQUE,
+  motd              VARCHAR(255),
+  charter           TEXT,
+  leader_account_id INT UNSIGNED NOT NULL,
+  created_ts        BIGINT NOT NULL,
+  PRIMARY KEY (guild_id)
+);
+
+CREATE TABLE guild_rank (
+  guild_id      BIGINT UNSIGNED NOT NULL,
+  rank_idx      TINYINT UNSIGNED NOT NULL,
+  name          VARCHAR(32) NOT NULL,
+  permissions   BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (guild_id, rank_idx)
+);
+
+CREATE TABLE guild_member (
+  guild_id      BIGINT UNSIGNED NOT NULL,
+  account_id    INT UNSIGNED NOT NULL,
+  rank_idx      TINYINT UNSIGNED NOT NULL,
+  joined_ts     BIGINT NOT NULL,
+  public_note   VARCHAR(255),
+  officer_note  VARCHAR(255),
+  PRIMARY KEY (account_id),                        -- 1 account = 1 guilde max
+  KEY idx_guild (guild_id)
+);
+
+CREATE TABLE guild_bank_tab (
+  guild_id      BIGINT UNSIGNED NOT NULL,
+  tab_idx       TINYINT UNSIGNED NOT NULL,
+  name          VARCHAR(32),
+  icon          VARCHAR(64),
+  PRIMARY KEY (guild_id, tab_idx)
+);
+
+CREATE TABLE guild_bank_item (
+  guild_id      BIGINT UNSIGNED NOT NULL,
+  tab_idx       TINYINT UNSIGNED NOT NULL,
+  slot_idx      SMALLINT UNSIGNED NOT NULL,
+  item_guid     BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY (guild_id, tab_idx, slot_idx)
+);
+
+CREATE TABLE guild_eventlog (
+  log_id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  guild_id      BIGINT UNSIGNED NOT NULL,
+  event_type    TINYINT UNSIGNED NOT NULL,    -- enum GuildEvent
+  actor_id      INT UNSIGNED NOT NULL,
+  target_id     INT UNSIGNED,
+  detail        VARCHAR(255),
+  ts            BIGINT NOT NULL,
+  PRIMARY KEY (log_id),
+  KEY idx_guild_ts (guild_id, ts)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"guild": {
+  "max_members": 1000,
+  "max_ranks": 10,
+  "default_ranks": ["Recrue", "Membre", "Vétéran", "Officier", "Maître de guilde"],
+  "max_bank_tabs": 6,
+  "eventlog_retention_count": 200
+}
+```
+
+### Tests
+
+- `GuildManagerTests.cpp` — create + add member + kick.
+- `GuildPermissionsTests.cpp` — bitmask : un membre sans `Invite` ne peut pas inviter.
+- `GuildBankTests.cpp` — deposit/withdraw avec permission par tab.
+- `GuildEventLogTests.cpp` — rotation : > 200 events → purge des plus anciens.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Permissions bitmask + rank
+
+```cpp
+GuildRank rankMembre {
+  .name = "Membre",
+  .permissions = GuildPermission::DepositBank,    // peut deposit, pas withdraw
+};
+```
+
+Un check : `if (!guild->HasPermission(accountId, GuildPermission::Kick)) return reject;`
+
+### 2. Event log circulaire
+
+```cpp
+void LogEvent(GuildEvent type, uint32_t actor, std::string_view detail) {
+  m_log.push_back({type, actor, detail, now()});
+  if (m_log.size() > kMaxLogEntries) {
+    m_log.erase(m_log.begin(), m_log.begin() + (m_log.size() - kMaxLogEntries));
+    DeleteOldestFromDb();   // purge async via SqlDelayThread
+  }
+}
+```
+
+### 3. Bank tab permissions
+
+Chaque rank a 6 sous-perms par tab :
+```cpp
+struct GuildBankTabPermissions {
+  bool canView;
+  bool canDeposit;
+  bool canWithdraw;
+  uint32_t withdrawDailyLimit;     // gold + items
+};
+```
+
+Permet « les officiers ont accès au tab 4 (loot raid), les membres
+non ».
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/guilds/`.
+2. Migrations DB (6 tables).
+3. Implémenter `Guild` + `GuildRank` + `GuildPermission`.
+4. Implémenter `GuildManager::Load` (charge toutes au boot).
+5. Implémenter opcodes + handler.
+6. Implémenter banque multi-onglets.
+7. Implémenter event log avec rotation.
+8. Tests : 4 fichiers.
+9. Doc : section « Guilds master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : create guild → invite → promote → set bank perms → withdraw item
+- [ ] Permissions : membre sans `Kick` ne peut pas kick
+- [ ] Eventlog rotation : > 200 events → 200 plus récents conservés
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **`KickHigher` permission** : un Officier ne peut pas kick le GM. Sauf si `KickHigher` activé sur son rank — réservé aux admins.
+- **Permissions cumulatives** : un GM a forcément toutes les perms (sinon il peut se piéger lui-même).
+- **Banque race** : 2 membres deposit en même temps dans le même slot → un seul réussit, l'autre erreur.
+- **Daily withdraw limit** : reset quotidien à `daily_reset_hour_utc` (cf. quests config).
+- **MOTD diffusion** : changement MOTD → broadcast à tous les membres online via opcode chat.
+- **Disband** : disband d'une guilde retourne tous les items de banque par mail à leur dernier déposant si trackable, sinon au GM. Décider la politique.
+- **Guild charter** : à la création, le founder doit signer avec X membres (10 dans WoW). À adapter selon vision LCDLLN.
+- **Cross-shard guild chat** : le guild chat passe par le `ChatRelayHandler` (CMANGOS.01) — déjà master-side, naturel.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Guilds (P2 master)
+- cmangos `src/game/Guilds/Guild.cpp`, `GuildMgr.cpp`,
+  `GuildBank*.cpp`, `GuildEventLogEntry.h`

--- a/tickets/CMANGOS/CMANGOS.22_Pools_weighted_spawns_nested.md
+++ b/tickets/CMANGOS/CMANGOS.22_Pools_weighted_spawns_nested.md
@@ -1,0 +1,177 @@
+# CMANGOS.22_Pools_weighted_spawns_nested
+
+## Objectif
+
+Mettre en place un **système de spawns aléatoires groupés** côté shard
+LCDLLN, inspiré de `src/game/Pools` cmangos. Trois piliers :
+
+1. **Spawn pool pondéré** : table `pool_template` (max_active) +
+   `pool_creature`/`pool_gameobject` avec `chance`. Permet rareté
+   contrôlée (rare spawns) sans logique custom par mob.
+2. **Pools imbriqués (`pool_pool`)** : un pool peut contenir d'autres
+   pools, créant des hiérarchies « zone → sous-zone → mob ». Élégant
+   pour scaling éditorial.
+3. **Sélection cryptographiquement non biaisée** : alias method ou
+   roulette wheel selon poids — utile dès qu'on a des loot tables ou
+   spawns de boss.
+
+C'est un **P2 shard** dès qu'on a 10+ creatures différentes à spawner
+dans une zone avec des règles de rareté.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — pool spawne des Creature/GameObject
+- CMANGOS.13 (Database — SQLStorage cache)
+- CMANGOS.19 (Maps — pool persisté par instance via MapPersistentState)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/pools/`)
+
+- `PoolTemplate.h` — struct row de la table.
+- `PoolMember.h` — entry + chance + type.
+- `PoolManager.{h,cpp}` :
+  - `Load(ConnectionPool&)`
+  - `void SpawnPool(MapId, uint32_t poolId)` — sélectionne `max_active`
+    membres pondérés et les spawn.
+  - `void OnMemberDespawn(uint32_t poolId, uint32_t memberId)` — le
+    membre revient au "viable pool" pour le prochain respawn.
+- `PoolState.{h,cpp}` — état runtime d'un pool dans une Map :
+  membres actuellement actifs, prochain respawn timestamp.
+- `WeightedSelector.h` — alias method O(1) sampling :
+  ```cpp
+  template <typename T>
+  class WeightedSelector {
+  public:
+    void Init(std::vector<std::pair<T, float>> weighted);
+    T const& Sample(RandomEngine& rng) const;
+  };
+  ```
+
+### Migration DB
+
+```sql
+CREATE TABLE pool_template (
+  pool_id     INT UNSIGNED NOT NULL,
+  max_active  INT UNSIGNED NOT NULL DEFAULT 1,
+  description VARCHAR(255),
+  PRIMARY KEY (pool_id)
+);
+
+CREATE TABLE pool_creature (
+  pool_id     INT UNSIGNED NOT NULL,
+  guid        INT UNSIGNED NOT NULL,           -- creature spawn guid (du table creature)
+  chance      FLOAT NOT NULL DEFAULT 100,
+  description VARCHAR(255),
+  PRIMARY KEY (pool_id, guid)
+);
+
+CREATE TABLE pool_gameobject (
+  pool_id     INT UNSIGNED NOT NULL,
+  guid        INT UNSIGNED NOT NULL,
+  chance      FLOAT NOT NULL DEFAULT 100,
+  description VARCHAR(255),
+  PRIMARY KEY (pool_id, guid)
+);
+
+CREATE TABLE pool_pool (
+  parent_pool   INT UNSIGNED NOT NULL,
+  child_pool    INT UNSIGNED NOT NULL,
+  chance        FLOAT NOT NULL DEFAULT 100,
+  description   VARCHAR(255),
+  PRIMARY KEY (parent_pool, child_pool)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"pools": {
+  "respawn_check_interval_sec": 30,
+  "log_pool_spawns": false
+}
+```
+
+### Tests
+
+- `WeightedSelectorTests.cpp` — distribution uniforme à 1000 samples avec poids inégaux respecte les ratios (±5%).
+- `PoolManagerTests.cpp` — pool max_active=2, 5 candidats pondérés → exactement 2 spawnés ; à mort d'un, respawn d'un autre selon poids.
+- `PoolPoolTests.cpp` — pool parent A contient B et C (sous-pools), spawn de A déclenche spawn de B ou C selon chance.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. WeightedSelector (alias method)
+
+L'alias method permet O(1) sampling pour distribution discrète. À la
+construction, on précompute deux tables (probability + alias). Au sample,
+on tire un index uniforme + un float uniforme, on dispatch selon la
+table.
+
+Avantage vs roulette wheel naïve (linéaire en N) : critique quand on
+spawn 1000s de pools.
+
+### 2. Pool nesting
+
+Un pool A peut référencer des pools B/C/D dans `pool_pool`. À l'évaluation
+de A : on tire selon les poids les éléments de A (creatures + gos +
+sous-pools), et pour chaque sous-pool tiré, on récurse.
+
+```
+pool_zone_dragoncrest (max_active = 5)
+  ├── pool_dragoncrest_north (chance 50%)  // sous-pool
+  │     ├── creature_dragoncrest_pup (×3 spots, chance 100%)
+  │     └── creature_dragoncrest_alpha (×1 spot, chance 5%)  // rare spawn
+  └── pool_dragoncrest_south (chance 50%)
+        └── creature_dragoncrest_drone (×4 spots, chance 100%)
+```
+
+### 3. Persistance
+
+Pour les pools dans `WorldMap` : volatile (reset au reboot ok).
+
+Pour les pools dans `DungeonMap` (raids permanents) : peut être persisté
+via `MapPersistentState` (CMANGOS.19) — sauvegarde quels GUIDs sont
+"actifs" pour ne pas reset après reboot.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/pools/`.
+2. Migrations DB (4 tables).
+3. Implémenter `WeightedSelector` + tests.
+4. Implémenter `PoolManager::Load` (avec SQLStorage cache).
+5. Implémenter `PoolManager::SpawnPool` (sélection + spawn via Map).
+6. Implémenter `OnMemberDespawn` (respawn timer).
+7. Implémenter pool nesting (pool_pool).
+8. Tests : 3 fichiers.
+9. Doc : section « Pools shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : pool max_active=2 avec 5 candidats → 2 spawnés ; despawn de l'un → 3ᵉ spawne après timer
+- [ ] Pool nesting : parent A → 50% B / 50% C, tirage 1000 fois donne ratios ~50/50
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Cycles dans pool_pool** : pool A référence B référence A → boucle infinie. Détecter au load + reject.
+- **Chance = 0** : autorisé (membre désactivé temporairement) ; éviter division par zéro dans WeightedSelector.
+- **Total chance = 0** : dégénéré (tous désactivés) → ne rien spawner, log warning.
+- **Respawn timing** : ne **pas** respawn juste à la mort. Délai (`creature.respawn_time` du template) — sinon farm exploit.
+- **Performance** : 10k pools × 30s tick = 333 pool checks/s. OK. Si 1M pools, profiler.
+- **Persistance volatile vs persistante** : par défaut **volatile** côté `WorldMap`. La persistance arrive avec CMANGOS.19 (MapPersistentState) pour les raids.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Pools (P2 shard)
+- cmangos `src/game/Pools/PoolManager.cpp`
+- Alias method : Vose's algorithm

--- a/tickets/CMANGOS/CMANGOS.23_Quests_template_status_objectives_variant.md
+++ b/tickets/CMANGOS/CMANGOS.23_Quests_template_status_objectives_variant.md
@@ -1,0 +1,304 @@
+# CMANGOS.23_Quests_template_status_objectives_variant
+
+## Objectif
+
+Mettre en place le **système de quêtes** côté master+shard LCDLLN,
+inspiré de `src/game/Quests` cmangos mais **modernisé C++20**. Cinq
+piliers :
+
+1. **Split static def / dynamic state** : `QuestTemplate` (immuable,
+   chargé DB une fois côté master+shard via SQLStorage) vs
+   `QuestStatusData` (par joueur, en RAM/DB). Pattern essentiel pour
+   économiser la RAM sur 100k+ comptes × 1000 quêtes.
+2. **Objectifs hétérogènes via `std::variant`** au lieu d'arrays
+   parallèles old-school cmangos (`RequiredItemId[4]`,
+   `RequiredCreatureId[4]`, etc.). Plus C++20 idiomatique, type-safe.
+3. **Flags bitmask pour variantes** : `Daily`, `Weekly`, `Repeatable`,
+   `AutoComplete` cohabitent sur un même `Quest` → un seul type au
+   lieu de classes dérivées.
+4. **Reward avec choix client** : 6 « choice items » + 4 « given items ».
+   Le client choisit ; le serveur valide.
+5. **Chaînes via `prevQuestId / nextQuestId`** : graphe orienté résolu
+   au load, pas de récursion runtime.
+
+C'est un **P2 cross master+shard**, pré-requis dès qu'on veut du
+contenu PvE narratif (quêtes ↔ kill credit ↔ items ↔ rewards).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage)
+- CMANGOS.16 (Globals/Conditions — `requiredCondition`)
+- CMANGOS.14 (DBScripts — `quest_start_scripts`, `quest_end_scripts`)
+- CMANGOS.17 (Loot — `kill credit` interagit avec drop)
+- CMANGOS.18 (Mails — récompenses livrées par mail si offline)
+
+## Livrables
+
+### Côté master+shard (`engine/server/quests/`)
+
+- `QuestObjective.h` — variant typé :
+  ```cpp
+  struct KillCreditObjective {
+    uint32_t creatureEntry;
+    uint32_t requiredCount;
+  };
+  struct CollectItemObjective {
+    uint32_t itemEntry;
+    uint32_t requiredCount;
+  };
+  struct InteractGameObjectObjective {
+    uint32_t gameObjectEntry;
+    uint32_t requiredCount;
+  };
+  struct VisitAreaObjective {
+    uint32_t zoneId;
+  };
+  struct CastSpellObjective {
+    uint32_t spellId;
+    uint32_t requiredCount;
+  };
+  using QuestObjective = std::variant<
+    KillCreditObjective,
+    CollectItemObjective,
+    InteractGameObjectObjective,
+    VisitAreaObjective,
+    CastSpellObjective
+  >;
+  ```
+- `QuestTemplate.h` — struct immuable :
+  ```cpp
+  struct QuestTemplate {
+    uint32_t questId;
+    std::string title;
+    std::string description;
+    std::string objectiveText;
+    int32_t  minLevel;
+    int32_t  maxLevel;        // -1 = no max
+    QuestFlags flags;          // bitmask
+    std::vector<QuestObjective> objectives;
+    QuestRewards rewards;
+    uint32_t prevQuestId;
+    uint32_t nextQuestId;
+    uint32_t requiredConditionId;
+    uint32_t startScriptId;    // DBScripts
+    uint32_t endScriptId;
+  };
+  ```
+- `QuestRewards.h` :
+  ```cpp
+  struct QuestRewards {
+    std::vector<RewardItem> givenItems;            // tous reçus
+    std::vector<RewardItem> choiceItems;           // un seul reçu (choix client)
+    uint64_t copperGold;
+    uint32_t experience;
+    uint32_t reputationFactionId;
+    int32_t reputationAmount;
+  };
+  ```
+- `QuestStatusData.h` — état per-player :
+  ```cpp
+  enum class QuestState : uint8 {
+    None,
+    Available,        // visible mais pas accept
+    Incomplete,       // accept en cours
+    Complete,         // objectifs OK, reward pas pris
+    Rewarded,         // terminé
+    Failed,
+  };
+  struct QuestStatusData {
+    uint32_t questId;
+    QuestState state;
+    int64_t  acceptedTs;
+    std::vector<uint32_t> objectiveProgress;       // count par objectif
+  };
+  ```
+- `QuestManager.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge `QuestTemplate` via SQLStorage.
+  - `bool TryAccept(Player&, uint32_t questId)`
+  - `void OnKill(Player&, Creature& killed)` — incrémente kill credits
+  - `void OnItemAdded(Player&, ItemId, count)`
+  - `void OnGameObjectInteract(Player&, GameObject&)`
+  - `bool IsObjectiveComplete(QuestStatusData const&) const`
+  - `bool TryComplete(Player&, uint32_t questId)` — vérifie + transitions
+  - `bool TryReward(Player&, uint32_t questId, int choiceItemIdx)` — applique rewards
+- `QuestGiver.{h,cpp}` — interface implémentée par Creature/GameObject pour offrir des quêtes (querelist).
+
+### Migration DB
+
+```sql
+CREATE TABLE quest_template (
+  quest_id              INT UNSIGNED NOT NULL,
+  title                 VARCHAR(255) NOT NULL,
+  description           TEXT,
+  objective_text        TEXT,
+  min_level             INT NOT NULL DEFAULT 1,
+  max_level             INT NOT NULL DEFAULT -1,
+  flags                 INT UNSIGNED NOT NULL DEFAULT 0,
+  prev_quest_id         INT UNSIGNED NOT NULL DEFAULT 0,
+  next_quest_id         INT UNSIGNED NOT NULL DEFAULT 0,
+  required_condition_id INT UNSIGNED NOT NULL DEFAULT 0,
+  start_script_id       INT UNSIGNED NOT NULL DEFAULT 0,
+  end_script_id         INT UNSIGNED NOT NULL DEFAULT 0,
+  reward_gold           BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  reward_xp             INT UNSIGNED NOT NULL DEFAULT 0,
+  reward_rep_faction    INT UNSIGNED NOT NULL DEFAULT 0,
+  reward_rep_amount     INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (quest_id)
+);
+
+CREATE TABLE quest_objectives (
+  quest_id      INT UNSIGNED NOT NULL,
+  objective_idx TINYINT UNSIGNED NOT NULL,
+  type          TINYINT UNSIGNED NOT NULL,    -- enum (Kill, Collect, Interact, Visit, Cast)
+  param1        INT NOT NULL,
+  param2        INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (quest_id, objective_idx)
+);
+
+CREATE TABLE quest_rewards_items (
+  quest_id      INT UNSIGNED NOT NULL,
+  item_id       INT UNSIGNED NOT NULL,
+  count         INT UNSIGNED NOT NULL DEFAULT 1,
+  is_choice     TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  slot          TINYINT UNSIGNED NOT NULL,
+  PRIMARY KEY (quest_id, slot)
+);
+
+CREATE TABLE character_quest_status (
+  character_id          BIGINT UNSIGNED NOT NULL,
+  quest_id              INT UNSIGNED NOT NULL,
+  state                 TINYINT UNSIGNED NOT NULL,
+  accepted_ts           BIGINT NOT NULL DEFAULT 0,
+  objective_progress    BLOB,                          -- serialized vector<uint32>
+  PRIMARY KEY (character_id, quest_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"quests": {
+  "max_active_quests_per_player": 25,
+  "daily_reset_hour_utc": 7,
+  "weekly_reset_day": "Tuesday",
+  "auto_complete_grace_sec": 5
+}
+```
+
+### Tests
+
+- `QuestManagerTests.cpp` — accept + progress + complete + reward.
+- `QuestObjectiveVariantTests.cpp` — chaque type d'objectif progress correctement.
+- `QuestStatusPersistenceTests.cpp` — load/save round-trip.
+- `QuestChainTests.cpp` — `prevQuestId` non terminé → quête suivante invisible.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Variant d'objectifs
+
+Modernisation par rapport à cmangos (qui utilise des arrays parallèles
+`RequiredItemId[4]` / `RequiredItemCount[4]`). En C++20 `std::variant`
+avec `std::visit` permet :
+
+```cpp
+void QuestManager::OnKill(Player& p, Creature& c) {
+  for (auto& [questId, status] : p.GetQuestStatus()) {
+    if (status.state != QuestState::Incomplete) continue;
+    auto* tmpl = GetTemplate(questId);
+    for (size_t i = 0; i < tmpl->objectives.size(); ++i) {
+      std::visit([&](auto&& obj) {
+        using T = std::decay_t<decltype(obj)>;
+        if constexpr (std::is_same_v<T, KillCreditObjective>) {
+          if (obj.creatureEntry == c.GetEntry() && status.objectiveProgress[i] < obj.requiredCount) {
+            status.objectiveProgress[i]++;
+            NotifyClient(p, questId, i, status.objectiveProgress[i]);
+          }
+        }
+      }, tmpl->objectives[i]);
+    }
+  }
+}
+```
+
+Avantages :
+- Type-safe : le compilateur garantit qu'on traite chaque variant case.
+- Pas de switch/cast.
+- Extensible : ajouter `EscortObjective` = ajouter un type au variant + une branche `if constexpr`.
+
+### 2. Flags bitmask
+
+```cpp
+enum class QuestFlags : uint32 {
+  None         = 0,
+  Daily        = 1u << 0,
+  Weekly       = 1u << 1,
+  Repeatable   = 1u << 2,
+  AutoComplete = 1u << 3,    // pas besoin de retour au quest giver
+  PartyShared  = 1u << 4,    // tous les membres en groupe progress
+  Sharable     = 1u << 5,    // partageable avec d'autres
+};
+```
+
+### 3. Persistance
+
+Sérialiser `objectiveProgress` (vector<uint32>) en BLOB (4 bytes × N
+objectifs, max ~16 = 64 bytes) ou JSON. **BLOB** plus compact.
+
+### 4. Reset Daily/Weekly
+
+Tâche cron côté master :
+- À `daily_reset_hour_utc` UTC : pour chaque `QuestStatusData` avec `Daily` et `state == Rewarded`, reset à `Available`.
+- Le mardi à `daily_reset_hour_utc` : idem pour `Weekly`.
+
+### 5. Master vs Shard
+
+- `QuestTemplate` : chargé sur master ET shard (même DB).
+- `QuestStatusData` : per-character, vit côté master (entre les sessions) MAIS doit être consulté côté shard pour les hooks `OnKill`/`OnItemAdded`. Solution : à `EnterWorld`, master push le QuestStatusData du joueur au shard. Modifications côté shard syncées avec master (write-through).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/quests/`.
+2. Migrations DB.
+3. Implémenter `QuestTemplate` + `QuestStatusData`.
+4. Implémenter `QuestManager::Load` (master+shard).
+5. Implémenter `TryAccept` / `TryComplete` / `TryReward`.
+6. Implémenter hooks `OnKill` / `OnItemAdded` / `OnGameObjectInteract`.
+7. Implémenter sync master ↔ shard (à coordonner avec CMANGOS.02).
+8. Implémenter daily/weekly reset (master cron).
+9. Tests : 4 fichiers.
+10. Doc : section « Quests cross master+shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard)
+- [ ] Tests passent
+- [ ] Smoke test : accept quête "Tuer 5 sangliers" → kill 5 sangliers → état Complete → reward
+- [ ] Daily quest re-disponible au reset 7h UTC
+- [ ] Quest chain : prev non terminé → next invisible
+- [ ] Persistance : status survit reboot shard et master
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Variant overhead** : `std::variant` a un coût léger (tag + payload). Si profilage montre une regression sur `OnKill` à haute charge, considérer un dispatch manuel via enum + struct uniforme.
+- **Quest accept conditions** : 5 checks séquentiels (level, prev quest, condition, max_active, available). Tous au même endroit (`TryAccept`), pas dispersés.
+- **Quest sharing** : un joueur en groupe peut partager une `Sharable` quest. Implique re-vérifier conditions pour chaque membre.
+- **Auto-complete** : quêtes simples sans objectifs (« Visite le donjon ») se complètent automatiquement à l'acceptation. UX : l'animation "quest accepted" avant le "quest complete" doit être lisible côté client (délai `auto_complete_grace_sec`).
+- **PartyShared progress** : kill credit pour tous les membres en groupe dans le rayon X. Hook côté shard : `OnKill` parcourt le groupe, pas juste le killer.
+- **Quest giver questlist** : un PNJ peut avoir plusieurs quêtes. Le client demande la liste, le serveur retourne celles éligibles (level, prev, condition).
+- **Reward inventory full** : si l'inventaire est plein au moment de prendre la reward, **ne pas** dropper l'item au sol. Refuser et demander de libérer de la place.
+- **Choice item** : envoyer la liste au client, attendre `kOpcodeQuestChoiceReward(choiceIdx)`, valider l'index, donner UNIQUEMENT cet item. Sinon exploit (donner tous).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Quests (P2 cross)
+- cmangos `src/game/Quests/Quest.cpp`, `QuestHandler.cpp`,
+  `QuestDef.h`

--- a/tickets/CMANGOS/CMANGOS.24_Reputation_faction_template_matrix.md
+++ b/tickets/CMANGOS/CMANGOS.24_Reputation_faction_template_matrix.md
@@ -1,0 +1,244 @@
+# CMANGOS.24_Reputation_faction_template_matrix
+
+## Objectif
+
+Mettre en place le **système de réputation joueur ↔ factions** côté
+shard LCDLLN, inspiré de `src/game/Reputation` cmangos. Cinq piliers :
+
+1. **Faction template DB** : matrice (faction_a × faction_b) →
+   `at_war` / `can_attack` / `can_assist`. Lookup O(1). Élégant pour
+   gérer hostilités sans coder par paire.
+2. **Bitmask flags par faction** : `AT_WAR`, `VISIBLE`, `INACTIVE`,
+   `HIDDEN` cohabitent sur un seul `uint8`.
+3. **Paliers calculés, pas stockés** : seul le « rep total » est
+   persisté ; le rang (Hostile/Unfriendly/Neutral/Friendly/Honored/
+   Revered/Exalted) est dérivé via `ReputationToRank()`. Évite désync
+   DB.
+4. **Spillover via faction parent** : gain dans une faction enfant
+   remonte au parent via `ParentFactionId` + ratio.
+5. **Réplication delta** : seules les factions modifiées sont envoyées
+   au client, pas la table entière.
+
+C'est un **P2 shard** avec sync master pour persistance, à activer
+quand on a des factions PvE/PvP.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — SQLStorage)
+- CMANGOS.02 (Entities — Unit a `factionId`)
+- CMANGOS.11 (Combat — `CanAttack(other)` consulte les flags)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/reputation/`)
+
+- `Faction.h` — struct row de faction :
+  ```cpp
+  struct Faction {
+    uint32_t factionId;
+    std::string name;
+    int32_t parentFactionId;        // 0 = root
+    float parentSpilloverRatio;     // ex. 0.5 = 50% du gain transmis
+    int32_t reputationCap;          // ex. Exalted = +42999
+    int32_t reputationFloor;        // ex. Hated = -42000
+  };
+  ```
+- `FactionTemplate.h` — relations faction × faction :
+  ```cpp
+  struct FactionTemplate {
+    uint32_t templateId;
+    uint32_t factionId;
+    uint32_t friendsFactions[4];     // 0 = unused
+    uint32_t enemiesFactions[4];
+    uint8_t  flags;                   // AT_WAR | etc.
+  };
+  ```
+- `ReputationManager.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge factions + templates.
+  - `bool CanAttack(Unit const& a, Unit const& b)` — consulte templates.
+  - `bool CanAssist(Unit const& a, Unit const& b)`
+- `PlayerReputation.{h,cpp}` — état per-player :
+  ```cpp
+  class PlayerReputation {
+  public:
+    int32_t GetReputation(uint32_t factionId) const;
+    Rank GetRank(uint32_t factionId) const;
+    void GainReputation(uint32_t factionId, int32_t amount, bool spillover = true);
+    bool IsAtWar(uint32_t factionId) const;
+    void SetFlag(uint32_t factionId, ReputationFlag flag, bool value);
+    std::vector<ReputationDelta> CollectChanged() const;    // pour réplication delta
+  private:
+    std::unordered_map<uint32_t, FactionState> m_states;
+    std::unordered_map<uint32_t, FactionState> m_dirty;
+  };
+  ```
+- `ReputationToRank.h` — fonction pure de conversion :
+  ```cpp
+  enum class Rank : uint8 { Hated, Hostile, Unfriendly, Neutral, Friendly, Honored, Revered, Exalted };
+  Rank ReputationToRank(int32_t rep);
+  ```
+
+### Migration DB
+
+```sql
+CREATE TABLE faction (
+  faction_id              INT UNSIGNED NOT NULL,
+  name                    VARCHAR(64) NOT NULL,
+  parent_faction_id       INT UNSIGNED NOT NULL DEFAULT 0,
+  parent_spillover_ratio  FLOAT NOT NULL DEFAULT 0,
+  cap                     INT NOT NULL DEFAULT 42999,
+  floor                   INT NOT NULL DEFAULT -42000,
+  PRIMARY KEY (faction_id)
+);
+
+CREATE TABLE faction_template (
+  template_id     INT UNSIGNED NOT NULL,
+  faction_id      INT UNSIGNED NOT NULL,
+  friend_1        INT UNSIGNED NOT NULL DEFAULT 0,
+  friend_2        INT UNSIGNED NOT NULL DEFAULT 0,
+  friend_3        INT UNSIGNED NOT NULL DEFAULT 0,
+  friend_4        INT UNSIGNED NOT NULL DEFAULT 0,
+  enemy_1         INT UNSIGNED NOT NULL DEFAULT 0,
+  enemy_2         INT UNSIGNED NOT NULL DEFAULT 0,
+  enemy_3         INT UNSIGNED NOT NULL DEFAULT 0,
+  enemy_4         INT UNSIGNED NOT NULL DEFAULT 0,
+  flags           TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (template_id)
+);
+
+CREATE TABLE character_reputation (
+  character_id    BIGINT UNSIGNED NOT NULL,
+  faction_id      INT UNSIGNED NOT NULL,
+  reputation      INT NOT NULL DEFAULT 0,
+  flags           TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (character_id, faction_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"reputation": {
+  "spillover_enabled": true,
+  "rep_event_log": false,
+  "default_starting_rep": 0
+}
+```
+
+### Tests
+
+- `ReputationManagerTests.cpp` — `CanAttack` consulte la matrice.
+- `PlayerReputationTests.cpp` — `GainReputation(+100)` met à jour rank dynamiquement.
+- `RanksTests.cpp` — `ReputationToRank` retourne le bon rank pour les 7 paliers.
+- `SpilloverTests.cpp` — gain dans faction enfant transmet `× ratio` au parent.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. CanAttack via FactionTemplate
+
+```cpp
+bool ReputationManager::CanAttack(Unit const& a, Unit const& b) const {
+  auto* tplA = GetTemplate(a.GetFactionTemplateId());
+  auto* tplB = GetTemplate(b.GetFactionTemplateId());
+  // Si A déclare B comme ennemi (dans enemies_*) → true
+  for (auto enemyId : tplA->enemies) {
+    if (b.GetFactionId() == enemyId) return true;
+  }
+  // Sinon : flag AT_WAR (joueur a explicitement déclaré la guerre)
+  if (a.IsPlayer() && a.AsPlayer()->Reputation().IsAtWar(b.GetFactionId())) return true;
+  return false;
+}
+```
+
+### 2. Paliers calculés
+
+```cpp
+Rank ReputationToRank(int32_t rep) {
+  if (rep <= -42000) return Rank::Hated;
+  if (rep <= -6000)  return Rank::Hostile;
+  if (rep <= -3000)  return Rank::Unfriendly;
+  if (rep < 3000)    return Rank::Neutral;
+  if (rep < 9000)    return Rank::Friendly;
+  if (rep < 21000)   return Rank::Honored;
+  if (rep < 42000)   return Rank::Revered;
+  return Rank::Exalted;
+}
+```
+
+Ne **jamais** stocker le rank en DB. Recompute on read.
+
+### 3. Spillover
+
+```cpp
+void GainReputation(uint32_t factionId, int32_t amount, bool spillover) {
+  m_states[factionId].rep += amount;
+  m_dirty[factionId] = m_states[factionId];
+
+  if (spillover) {
+    auto* faction = g_reputationMgr.GetFaction(factionId);
+    if (faction->parentFactionId != 0) {
+      int32_t spilloverAmount = amount * faction->parentSpilloverRatio;
+      GainReputation(faction->parentFactionId, spilloverAmount, true);  // récursif
+    }
+  }
+}
+```
+
+### 4. Réplication delta
+
+Au tick (ou à chaque action significant), envoyer au client uniquement
+`m_dirty` (les changements depuis le dernier sync). Reset après envoi.
+
+```cpp
+auto changed = playerRep.CollectChanged();
+if (!changed.empty()) {
+  Send(kOpcodeReputationUpdate, changed);
+}
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/reputation/`.
+2. Migrations DB (3 tables).
+3. Implémenter `Faction` + `FactionTemplate` + `ReputationManager::Load`.
+4. Implémenter `CanAttack` / `CanAssist`.
+5. Implémenter `PlayerReputation` (per-player).
+6. Implémenter `ReputationToRank`.
+7. Implémenter spillover.
+8. Implémenter réplication delta + opcode `kOpcodeReputationUpdate`.
+9. Tests : 4 fichiers.
+10. Doc : section « Reputation shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : kill PNJ faction X → rep +50 → rank Friendly
+- [ ] Spillover : gain faction "Stormwind" → parent "Alliance" gagne 50%
+- [ ] CanAttack : 2 unit factions ennemies → true
+- [ ] Réplication delta : seul le delta envoyé, pas la table complète
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Pas de stockage du rank** : si un patch rééquilibre les paliers, tous les joueurs voient leur rank changer instantanément (car derived). Stocker le rank casse ça.
+- **Spillover récursif** : si parent → grandparent → ... → boucle (mauvaise data). Limiter récursion à 5 niveaux.
+- **Cap reputation** : ne **jamais** dépasser `cap`. Clamp avant écriture.
+- **Réplication initiale** : au login, envoyer **toutes** les factions visibles (pas juste delta). Le delta arrive après.
+- **Faction Hidden** : `Hidden` flag = pas affiché côté client. Encore en RAM/DB, mais le client ne reçoit pas les updates.
+- **CanAttack et flag AT_WAR** : le joueur peut déclarer guerre à une faction Friendly (cf. WoW). Le AT_WAR override la matrice.
+- **Performance CanAttack** : appelé à chaque dégât / sort hostile. **Pas de virtual call**, retourner bool inlinable. Cache template pointers.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Reputation (P2 shard)
+- cmangos `src/game/Reputation/ReputationMgr.cpp`,
+  `Faction.h`, `Player.cpp` (intégration)

--- a/tickets/CMANGOS/CMANGOS.25_Social_friends_ignored_presence.md
+++ b/tickets/CMANGOS/CMANGOS.25_Social_friends_ignored_presence.md
@@ -1,0 +1,195 @@
+# CMANGOS.25_Social_friends_ignored_presence
+
+## Objectif
+
+Mettre en place le **système social** (amis / ignorés / notes / présence)
+côté master LCDLLN, inspiré de `src/game/Social` cmangos. Quatre piliers :
+
+1. **Manager singleton + objet par joueur** : `PlayerSocial` chargé à
+   login, déchargé à logout, persisté en DB delta.
+2. **Broadcast de présence** : login/logout d'un joueur déclenche
+   `BroadcastToFriends()` qui pousse à tous les amis online.
+3. **Liste ignorés appliquée côté chat-relay** : filtrage à l'expéditeur
+   (pas au récepteur) — économie réseau quand un joueur ignore beaucoup
+   de monde.
+4. **Notes privées par contact** : champ texte attaché au mapping
+   (ami → note). Petit feature mais très demandé.
+
+C'est un **P2 master**, pré-requis dès qu'on a 2+ joueurs et chat
+fonctionnel.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts)
+- CMANGOS.13 (Database)
+- CMANGOS.01 (Chat) — pour intégration côté ChatGate (filtrage ignored)
+
+## Livrables
+
+### Côté master (`engine/server/social/`)
+
+- `PlayerSocial.{h,cpp}` :
+  ```cpp
+  class PlayerSocial {
+  public:
+    bool AddFriend(uint64_t targetCharacterId, std::string_view note);
+    bool RemoveFriend(uint64_t targetCharacterId);
+    bool AddIgnore(uint64_t targetCharacterId);
+    bool RemoveIgnore(uint64_t targetCharacterId);
+    void SetNote(uint64_t targetCharacterId, std::string_view note);
+    bool IsFriend(uint64_t targetCharacterId) const;
+    bool IsIgnored(uint64_t targetCharacterId) const;
+    std::span<const SocialEntry> GetFriends() const;
+    std::span<const SocialEntry> GetIgnored() const;
+  private:
+    uint64_t m_ownerCharacterId;
+    std::vector<SocialEntry> m_friends;
+    std::vector<SocialEntry> m_ignored;
+    bool m_dirty = false;
+  };
+  ```
+- `SocialEntry.h` :
+  ```cpp
+  struct SocialEntry {
+    uint64_t targetCharacterId;
+    std::string targetName;          // cache pour affichage
+    std::string note;                 // private note
+    int64_t addedTs;
+  };
+  ```
+- `SocialManager.{h,cpp}` :
+  - `Load(uint64_t characterId)` — load au login.
+  - `Save(uint64_t characterId)` — write delta au logout/idle.
+  - `void OnPlayerLogin(uint64_t characterId)` — broadcast présence aux amis.
+  - `void OnPlayerLogout(uint64_t characterId)` — idem.
+- `SocialHandler.{h,cpp}` — opcodes :
+  - `kOpcodeFriendList`, `kOpcodeFriendAdd`, `kOpcodeFriendRemove`
+  - `kOpcodeIgnoreList`, `kOpcodeIgnoreAdd`, `kOpcodeIgnoreRemove`
+  - `kOpcodeFriendNote`
+  - `kOpcodeFriendStatusUpdate` (notification online/offline)
+
+### Migration DB
+
+```sql
+CREATE TABLE character_social (
+  owner_character_id    BIGINT UNSIGNED NOT NULL,
+  target_character_id   BIGINT UNSIGNED NOT NULL,
+  type                  TINYINT UNSIGNED NOT NULL,    -- 0=friend, 1=ignored
+  note                  VARCHAR(64),
+  added_ts              BIGINT NOT NULL,
+  PRIMARY KEY (owner_character_id, target_character_id, type),
+  KEY idx_owner (owner_character_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"social": {
+  "max_friends_per_character": 50,
+  "max_ignored_per_character": 50,
+  "broadcast_login_logout": true,
+  "fuzzy_search_min_chars": 3
+}
+```
+
+### Tests
+
+- `PlayerSocialTests.cpp` — add/remove friend ; add/remove ignored ; note.
+- `SocialManagerTests.cpp` — login broadcast aux amis online.
+- `SocialIgnoreFilterTests.cpp` — message d'un joueur ignoré filtré côté ChatGate.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Filtrage ignored côté expéditeur
+
+Quand A envoie un whisper à B :
+
+```cpp
+// Côté ChatRelayHandler (master) :
+if (g_social.GetForCharacter(B).IsIgnored(A)) {
+  // Au lieu de jeter le message côté B (réception), refuser côté A (envoi).
+  // L'expéditeur reçoit "[Player B] is ignoring you" ou silence selon politique.
+  return;
+}
+```
+
+Économie : si un raid de 25 personnes a 10 ignorant un troll, ce dernier
+envoie 25 paquets pour 15 receivers — préférable que tout passe par
+serveur qui filtre, mais déjà 10 paquets économisés en filtrant à
+l'envoi via le `ChatGate` (CMANGOS.01).
+
+### 2. Broadcast présence
+
+```cpp
+void OnPlayerLogin(uint64_t charId) {
+  auto* social = g_social.GetForCharacter(charId);
+  for (auto& entry : social->GetFriends()) {
+    auto friendSession = g_sessionMgr.FindSessionForCharacter(entry.targetCharacterId);
+    if (friendSession) {
+      friendSession->Send(kOpcodeFriendStatusUpdate, charId, /* online= */ true);
+    }
+  }
+  // Inverse : envoyer la liste actuelle (avec online flag) au login player.
+}
+```
+
+### 3. Note privée
+
+```
+[Friend list]
+- Toto (Online)  -- "Tank de raid, dispo le mercredi"
+- Tata (Offline) -- "Pickpocket farm partner"
+```
+
+Stockée par le owner uniquement. Le target ne voit pas la note.
+
+### 4. Persistance
+
+Pas un write par modification — write delta au logout ou periodically
+(toutes les 5 min) si dirty. Réduit l'I/O DB pour les joueurs qui
+toggle ami/ignored fréquemment.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/social/`.
+2. Migration DB.
+3. Implémenter `PlayerSocial`.
+4. Implémenter `SocialManager` + load/save delta.
+5. Implémenter opcodes + handler.
+6. Implémenter broadcast présence.
+7. Câbler filtrage ignored dans `ChatGate` (CMANGOS.01).
+8. Tests : 3 fichiers.
+9. Doc : section « Social master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : 2 players, A ajoute B en friend → A login → B reçoit "A online"
+- [ ] A ignore B → B whisper à A → message filtré côté master, pas livré à A
+- [ ] Note privée affichée uniquement chez le owner
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Cross-shard** : les amis peuvent être sur des shards différents. Le master gère, les shards relayent juste. Naturel.
+- **Friend mutual** : pas de confirmation requise (cmangos style). Si LCDLLN veut Discord-style mutual, ajouter un état `Pending`.
+- **Limite raisonnable** : 50 friends + 50 ignored = 100 entrées max par char. Plus = abuse / bot. Refuser au-delà.
+- **Fuzzy search** : pour l'auto-complétion (ajout par nom partiel), `fuzzy_search_min_chars = 3`. Évite de scanner tous les players à chaque touche.
+- **Renommage character** : si un char est renommé, son nom dans `character_social.target_name` devient stale. Refresh au prochain load ou via hook.
+- **Politique ignore-feedback** : silencieux ("vous lui parlez dans le vide") ou explicite ("X vous ignore") ? **Silencieux par défaut** (anti-stalking).
+- **Performance broadcast** : 1000 amis online d'un même joueur populaire = 1000 notifs au login. Batcher en 1 paquet `FriendStatusUpdateBatch`.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Social (P2 master)
+- cmangos `src/game/Social/SocialMgr.cpp`, `SocialHandler.cpp`

--- a/tickets/CMANGOS/CMANGOS.26_Spells_split_template_aura_proc.md
+++ b/tickets/CMANGOS/CMANGOS.26_Spells_split_template_aura_proc.md
@@ -1,0 +1,247 @@
+# CMANGOS.26_Spells_split_template_aura_proc
+
+## Objectif
+
+Mettre en place le **système de sorts/abilities** côté shard LCDLLN
+inspiré de `src/game/Spells` cmangos. Cinq piliers :
+
+1. **Split `Spell` / `SpellTemplate` / `SpellAura` / `ProcEvent`** :
+   séparation claire entre l'**instance** (cast en cours, durée), la
+   **définition immuable** (DB), l'**effet appliqué** (buff/debuff
+   actif sur une cible) et la **réactivité** (proc on hit/crit/etc.).
+2. **State machine de cast** : `PREPARING → CASTING → FINISHED` avec
+   timers (cast time, GCD, channel). Modèle générique applicable à
+   toute action joueur à durée non-instantanée (récolte, build, drink).
+3. **Aura proc system** : `SpellProcEventEntry` (procFlags bitmask,
+   ppmRate, cooldown) déclenche effects sur events (melee hit, spell
+   crit). Pattern « réactivité data-driven ».
+4. **`SpellFamily` + `ClassFamilyMask`** : permet « ce talent buffe
+   tous les sorts feu du mage » sans énumérer chaque sort.
+5. **Stacking rules séparées** (`SpellStacking.cpp` isolé) : algèbre des
+   buffs (replace, refresh, sum) raisonnable indépendamment des
+   effects.
+
+C'est un **P2 shard**, pré-requis dès le premier sort/ability joueur ou
+PNJ. **Gros morceau** — ce ticket trace le découpage canonique mais ne
+porte pas le contenu (chaque sort sera un suivi).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities) — Unit porte la liste d'auras actives
+- CMANGOS.04 (Movement) — un cast peut être interrompu par mouvement
+- CMANGOS.05 (vmap) — LOS check avant le cast
+- CMANGOS.11 (Combat) — un cast hostile met en combat
+- CMANGOS.13 (Maps) — `Spell::Update` tickté par la Map
+- CMANGOS.16 (Globals/Conditions) — `SpellTemplate.required_condition`
+
+## Livrables
+
+### Côté shard (`engine/server/shard/spells/`)
+
+- `SpellTemplate.{h,cpp}` — définition immuable d'un sort. Chargée DB au
+  boot via `SQLStorage` cache (CMANGOS.13). Champs : id, name, school,
+  family, family_mask, range, cast_time, cooldown, gcd, mana_cost,
+  effects[3] (effect_type, effect_param, target_type, base_value),
+  proc_chance, proc_flags, attributes (bitmask), required_condition_id,
+  cast_interrupted_by_movement.
+- `Spell.{h,cpp}` — **instance** d'un cast en cours sur un Unit. Tient
+  l'état machine (Preparing/Casting/Finished), timers, target résolu,
+  payload final.
+- `SpellAura.{h,cpp}` — **effet appliqué** sur une cible : référence vers
+  SpellTemplate, durée restante, stacks, source (qui a appliqué), tick
+  périodique pour DoT/HoT.
+- `SpellAuraHolder.{h,cpp}` — collection d'auras d'un Unit, indexée par
+  SpellTemplate id pour stacking O(1).
+- `SpellProcEvent.{h,cpp}` — système réactif. Quand un event (melee hit,
+  spell crit, target dies) survient, parcourt les auras de la source/
+  cible cherchant des `SpellAura` dont les `procFlags` matchent.
+- `SpellTargeting.{h,cpp}` — targeting matrix : un `target_type` (enum :
+  TARGET_UNIT_ENEMY, TARGET_AREA_FRIEND…) résout en liste d'Units selon
+  filtres. Centralise la logique au lieu de switch géants.
+- `SpellStacking.{h,cpp}` — règles de cumul : replace, refresh, sum,
+  reject. Algèbre testable isolément.
+- `SpellEffects.{h,cpp}` — registry des effects (`EFFECT_DAMAGE`,
+  `EFFECT_HEAL`, `EFFECT_APPLY_AURA`, `EFFECT_TELEPORT`, `EFFECT_SUMMON`,
+  …). Chaque effect = une fonction `void Apply(Unit& caster, Unit&
+  target, SpellTemplate const&, int effectIdx)`.
+
+### Migration DB
+
+```sql
+CREATE TABLE spell_template (
+  id              INT UNSIGNED NOT NULL,
+  name            VARCHAR(128) NOT NULL,
+  school          TINYINT UNSIGNED NOT NULL,
+  family          TINYINT UNSIGNED NOT NULL,
+  family_mask_lo  BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  family_mask_hi  BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  range_yds       FLOAT NOT NULL DEFAULT 0,
+  cast_time_ms    INT UNSIGNED NOT NULL DEFAULT 0,
+  cooldown_ms     INT UNSIGNED NOT NULL DEFAULT 0,
+  gcd_ms          INT UNSIGNED NOT NULL DEFAULT 1500,
+  mana_cost       INT UNSIGNED NOT NULL DEFAULT 0,
+  duration_ms     INT NOT NULL DEFAULT 0,    -- <0 = passif
+  effect1_type    TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  effect1_target  TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  effect1_value   INT NOT NULL DEFAULT 0,
+  effect1_param   INT NOT NULL DEFAULT 0,
+  effect2_*, effect3_*  -- idem
+  proc_chance     TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  proc_flags      INT UNSIGNED NOT NULL DEFAULT 0,
+  attributes      INT UNSIGNED NOT NULL DEFAULT 0,
+  required_condition_id INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE creature_spell (
+  creature_entry  INT UNSIGNED NOT NULL,
+  spell_id        INT UNSIGNED NOT NULL,
+  PRIMARY KEY (creature_entry, spell_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"spells": {
+  "max_simultaneous_auras_per_unit": 50,
+  "default_gcd_ms": 1500,
+  "los_check_required": true,
+  "movement_interrupts_cast": true
+}
+```
+
+### Tests
+
+- `SpellTargetingTests.cpp` — TARGET_UNIT_ENEMY filtre les amis ; TARGET_AREA_FRIEND inclut alliés en zone.
+- `SpellStackingTests.cpp` — cumul `replace` remplace ; `refresh` reset durée ; `sum` additionne ; `reject` ignore.
+- `SpellAuraTests.cpp` — DoT tick toutes les 3s, expire à durée 0.
+- `SpellProcEventTests.cpp` — `procFlags = ON_MELEE_HIT_TAKEN` déclenche bien l'effect au coup reçu, respecte cooldown.
+- `SpellTemplateLoadTests.cpp` — round-trip DB load.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. State machine cast
+
+```
+            cast_time>0
+PREPARING --------------> CASTING (channel ou not)
+   |                          |
+   |  (cast_time=0 instant)   |
+   v                          v
+FINISHED <-----------------+ Apply effects
+   |                          |
+   |    (interrupt)           |
+   +--------------------------+
+```
+
+Interrupts : mouvement (si `cast_interrupted_by_movement`), dégât pris,
+silence.
+
+### 2. Aura lifecycle
+
+```cpp
+class SpellAura {
+public:
+  void Apply(Unit& target, Unit& source, SpellTemplate const&);
+  void Update(int32 dtMs);   // tick si DoT/HoT, decrement duration
+  bool Expired() const;
+  void Remove(AuraRemoveMode mode);    // EXPIRED, DISPELLED, OVERWRITTEN
+};
+```
+
+### 3. Stacking rules
+
+```cpp
+enum class StackingRule : uint8 {
+  Replace,    // nouveau remplace ancien (1 stack)
+  Refresh,    // reset duration, max 1 stack
+  Sum,        // accumule jusqu'à max_stacks
+  Reject,     // si déjà présent, refuse l'application
+  PerCaster,  // 1 par caster, pas de fusion entre casters
+};
+```
+
+### 4. Family mask
+
+```cpp
+struct SpellFamilyFlag {
+  uint64_t lo;
+  uint64_t hi;
+};
+```
+
+Permet `talent.affects = SpellFamilyFlag{lo: 0x000F, hi: 0}` pour buffer
+tous les sorts feu du mage sans énumérer leurs IDs.
+
+### 5. Proc system
+
+```cpp
+enum class ProcFlag : uint32 {
+  OnMeleeHitDealt    = 1u << 0,
+  OnMeleeHitTaken    = 1u << 1,
+  OnSpellHitDealt    = 1u << 2,
+  OnSpellHitTaken    = 1u << 3,
+  OnSpellCritDealt   = 1u << 4,
+  OnSpellCritTaken   = 1u << 5,
+  OnTargetDeath      = 1u << 6,
+  OnSelfDeath        = 1u << 7,
+  // ...
+};
+```
+
+À chaque event combat, parcourir les auras avec ProcFlag matchant ;
+tirer une RNG vs `proc_chance` ; respecter cooldown intra-aura ;
+appliquer l'effect.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/spells/`.
+2. Migration DB `spell_template` + chargement via SQLStorage (CMANGOS.13).
+3. Implémenter `SpellTemplate` + chargement.
+4. Implémenter `Spell` (instance, state machine cast).
+5. Implémenter `SpellEffects` (registry des effect types — démarrer avec DAMAGE, HEAL, APPLY_AURA).
+6. Implémenter `SpellAura` + `SpellAuraHolder`.
+7. Implémenter `SpellTargeting` (registry des target types).
+8. Implémenter `SpellStacking` (règles isolées).
+9. Implémenter `SpellProcEvent` (réactivité).
+10. Câbler `Unit::CastSpell(spellId, target)` qui crée un `Spell`, l'ajoute au tick.
+11. Tests : 5 fichiers listés.
+12. Doc : section « Spells shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent (5 fichiers)
+- [ ] Smoke test : 1 player cast "Fireball" 1.5s, applique damage à la cible ; mouvement pendant cast → interruption
+- [ ] Smoke test DoT : applique 12s/tick 3s → 4 ticks puis expire
+- [ ] Smoke test proc : aura "ProcOnMeleeHitTaken → Heal 50" déclenchée à chaque coup reçu (avec proc_chance = 100)
+- [ ] Stacking : `Refresh` reset la durée
+- [ ] Migration `spell_template` appliquée et idempotente
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Ne pas porter les sorts WoW** : copier le **découpage** est légitime, copier les contenus (ID 133 = Fireball avec 1.5s cast 30 yards…) est juridiquement risqué. Créer **vos propres** sorts dans `spell_template`.
+- **Performance** : le proc system est appelé à chaque hit/crit/melee. **Pas de virtual call dans la hot path**. Itérer sur un `std::vector<SpellAura*>` plutôt que `std::map`.
+- **Aura limit per unit** : sans plafond, un boss peut accumuler 1000 auras → tick coûteux. `max_simultaneous_auras_per_unit = 50` évite ça (dépasser = remove le plus ancien dispellable).
+- **Channeled spells** : différents de cast classiques (effect appliqué périodiquement pendant le cast). State `CASTING` avec ticks dédiés. À gérer mais reportable au début.
+- **GCD vs cooldown** : 2 timers distincts. GCD (Global Cooldown ~1.5s) bloque tous les sorts ; le cooldown spécifique bloque ce sort. Le mage caste Fireball → GCD 1.5s, mais Fireball cooldown peut être 0 (insta-recast).
+- **Targeting Z-axis** : pour les AoE au sol (TARGET_DEST_DEST), le ground point validé via `vmap.GetHeight` (CMANGOS.05).
+- **Spell range vs LOS** : range OK ne signifie pas LOS OK. Toujours vérifier les deux. Erreur classique = "j'ai range mais le mur me bloque" → frustrant côté joueur.
+- **Auras passives** : `duration_ms < 0` = passif (talent permanent). Ne pas tick, ne pas expirer. Filtrage dans `Update`.
+- **Stacking PerCaster vs Sum** : un Bleed appliqué par 2 rogues ne stack pas en `Sum` (=2× damage) mais en `PerCaster` (2 instances séparées). Sinon multi-rogue exploit.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Spells (P2 shard)
+- cmangos `src/game/Spells/Spell.cpp`, `SpellAuras.cpp`, `SpellEffects.cpp`,
+  `SpellMgr.cpp`, `SpellStacking.cpp`, `SpellTargeting.cpp`, `Unit.cpp`
+  (proc dispatch)

--- a/tickets/CMANGOS/CMANGOS.27_Trade_two_phase_commit_anti_scam.md
+++ b/tickets/CMANGOS/CMANGOS.27_Trade_two_phase_commit_anti_scam.md
@@ -1,0 +1,189 @@
+# CMANGOS.27_Trade_two_phase_commit_anti_scam
+
+## Objectif
+
+Mettre en place le **système de trade fenêtre-à-fenêtre entre 2
+joueurs**, inspiré de `src/game/Trade` cmangos. Quatre piliers :
+
+1. **State machine 2-phase commit** : both-must-accept avant exécution,
+   un changement quelconque reset les checkboxes.
+2. **`TradeData` attachée au Player** : chaque joueur a un `TradeData*`
+   (null si pas en trade), évite les maps globales.
+3. **Validation atomique côté serveur uniquement** : le client envoie
+   « j'accepte », le serveur revérifie inventaire + gold + bag space
+   pour les deux côtés en une transaction DB, rollback si échec.
+4. **Anti-scam** : fenêtre de 6 s avant validation finale après dernier
+   changement (« lock-and-confirm »), prévient le swap d'items en
+   dernière seconde.
+
+C'est un **P2 master**, à activer dès qu'on a inventaire + monnaie + 2
+joueurs.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts)
+- Inventory + currency existants
+- CMANGOS.13 (Database — transaction atomique)
+
+## Livrables
+
+### Côté master (`engine/server/trade/`)
+
+- `TradeData.h` :
+  ```cpp
+  struct TradeSlot {
+    ObjectGuid itemGuid;
+    uint32_t itemEntry;     // copie pour anti-stale
+    uint32_t count;
+  };
+  struct TradeData {
+    uint32_t initiatorAccountId;
+    uint32_t partnerAccountId;
+    std::array<TradeSlot, 7> myItems;     // slot 0-6
+    std::array<TradeSlot, 7> partnerItems;
+    uint64_t myGold;
+    uint64_t partnerGold;
+    bool myAccepted = false;
+    bool partnerAccepted = false;
+    int64_t lastChangeTs;
+    TradeState state;
+  };
+  enum class TradeState : uint8 {
+    Initiating,
+    Active,
+    LockingIn,           // 6s anti-scam window
+    Completing,          // both accepted + lock expired
+    Cancelled,
+  };
+  ```
+- `TradeManager.{h,cpp}` :
+  - `bool BeginTrade(initiatorId, partnerId)` — push TradeRequest au partner.
+  - `bool AcceptTradeRequest(partnerId)` — passes Active.
+  - `bool SetItemSlot(accountId, slot, ObjectGuid item)` — modifie un slot, reset accepted.
+  - `bool SetGold(accountId, gold)`
+  - `bool ToggleAccept(accountId)` — bascule own accepted ; si both → LockingIn, démarre timer.
+  - `void Tick(int64_t nowMs)` — gère timer 6s ; à expiration → Completing → exécution atomique.
+  - `void CancelTrade(accountId, reason)`.
+- `TradeHandler.{h,cpp}` — opcodes :
+  - `kOpcodeTradeInitiate`, `kOpcodeTradeAccept`, `kOpcodeTradeReject`
+  - `kOpcodeTradeSetSlot`, `kOpcodeTradeSetGold`
+  - `kOpcodeTradeToggleAccept`, `kOpcodeTradeCancel`
+  - Notifications client : `kOpcodeTradeUpdate` (état complet),
+    `kOpcodeTradeCompleted`, `kOpcodeTradeFailed(reason)`.
+
+### Configuration (`config.json`)
+
+```json
+"trade": {
+  "lockin_seconds": 6,
+  "max_distance_meters": 11.11,
+  "allow_same_account_trade": false
+}
+```
+
+### Tests
+
+- `TradeStateMachineTests.cpp` — transitions Active → LockingIn → Completing.
+- `TradeCancelOnChangeTests.cpp` — un slot modifié pendant LockingIn reset accepted, retour Active.
+- `TradeAtomicCommitTests.cpp` — exécution = transfert items + gold dans une seule transaction.
+- `TradeAntiScamTests.cpp` — modification dans la fenêtre 6s reset la validation.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. State machine
+
+```
+None ----initiate----> Initiating
+Initiating ----partner accepts----> Active
+Active <----both accepted----> LockingIn (6s)
+LockingIn ----any change----> Active (reset accepted)
+LockingIn ----6s elapsed----> Completing
+Completing ----all valid----> Done
+Completing ----item missing----> Cancelled
+Active ----cancel----> Cancelled
+```
+
+### 2. Atomic commit
+
+```cpp
+bool ExecuteTrade(TradeData const& td) {
+  BeginTransaction();
+  // Validate inventory of both sides
+  for (auto& slot : td.myItems) {
+    if (!ValidateItemOwnership(td.initiatorAccountId, slot.itemGuid)) {
+      Rollback();
+      return false;
+    }
+  }
+  // Same for partner
+  // Validate gold
+  if (GetGold(td.initiatorAccountId) < td.myGold) { Rollback(); return false; }
+  if (GetGold(td.partnerAccountId) < td.partnerGold) { Rollback(); return false; }
+  // Validate inventory space
+  if (!HasFreeSlots(td.partnerAccountId, td.myItems.size())) { Rollback(); return false; }
+  // Same other side
+  // Transfer
+  TransferItems(td.initiatorAccountId, td.partnerAccountId, td.myItems);
+  TransferItems(td.partnerAccountId, td.initiatorAccountId, td.partnerItems);
+  TransferGold(td.initiatorAccountId, td.partnerAccountId, td.myGold);
+  TransferGold(td.partnerAccountId, td.initiatorAccountId, td.partnerGold);
+  Commit();
+  return true;
+}
+```
+
+### 3. Anti-scam timer
+
+Quand both accepted → `LockingIn` + start timer 6s. Toute modification
+(SetSlot, SetGold) → reset à `Active` + reset checkboxes.
+
+UX : le client affiche un compte à rebours (6 → 0) ; les boutons
+"Accept" sont grisés pendant ce temps.
+
+### 4. Distance check
+
+Trade = face à face. Vérifier que les 2 joueurs sont dans
+`max_distance_meters` à chaque action. Sortie de portée = cancel auto.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/trade/`.
+2. Implémenter `TradeData` + `TradeState`.
+3. Implémenter `TradeManager` + state machine.
+4. Implémenter opcodes + handlers.
+5. Implémenter `ExecuteTrade` atomic.
+6. Implémenter timer anti-scam.
+7. Tests : 4 fichiers.
+8. Doc : section « Trade master » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : trade items entre 2 joueurs → both accepted → 6s → exécution
+- [ ] Anti-scam : changement dans la fenêtre 6s reset accepted
+- [ ] Échec validation (item manquant) → rollback complet
+- [ ] Sortie portée → cancel auto
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Item locking pendant trade** : un item dans un slot trade ne doit pas être supprimable de l'inventaire (sell, vendor, drop). Marquer `is_in_trade` ou refuser les ops.
+- **Anti-cheat** : si le client envoie `SetSlot` avec un `ObjectGuid` qu'il ne possède pas → kick + log audit.
+- **Trade et logout** : si un des 2 joueurs déconnecte → cancel auto.
+- **Trade et combat** : interdire de démarrer un trade en combat (anti exploit).
+- **Trade cross-shard** : 2 joueurs sur shards différents ? Plus complexe (besoin du master comme intermédiaire). **Démarrer same-shard only**, le master refuse cross-shard ou route vers même shard physique.
+- **Bag space failure mid-commit** : si la transaction échoue à cause d'un manque de place, rollback DB + retour items aux propriétaires d'origine + notification "trade failed: not enough space".
+- **Same-account trade** : par défaut **désactivé** (anti-mule). Activer via config si LCDLLN veut le permettre.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Trade (P2 master)
+- cmangos `src/game/Trade/TradeHandler.cpp`

--- a/tickets/CMANGOS/CMANGOS.28_World_state_expression_dsl.md
+++ b/tickets/CMANGOS/CMANGOS.28_World_state_expression_dsl.md
@@ -1,0 +1,203 @@
+# CMANGOS.28_World_state_expression_dsl
+
+## Objectif
+
+Mettre en place le **système de world state + mini-DSL d'expressions**
+côté shard LCDLLN, inspiré de `src/game/World` cmangos. Trois piliers :
+
+1. **`WorldStateVariableManager`** : registre clé→valeur typé,
+   observable (subscribe par zone/joueur), persistable. Pattern
+   « shared blackboard » excellent pour events serveur-wide
+   (compteurs de captures BG, score arène, progression event saisonnier).
+2. **`WorldStateExpression` mini-DSL** : parse des formules
+   (`worldstate_42 > 100 AND worldstate_43 == 1`) évaluables runtime
+   depuis DB. **Énorme leverage éditorial** : conditions de quêtes/
+   events sans recompiler. Particulièrement utile pour LCDLLN avec son
+   `lcdlln_world_editor.exe`.
+3. **Tick global multi-niveaux** : World tick → Map tick → Object tick,
+   chacun à fréquence propre (1s / 100ms / variable). Modèle
+   hiérarchique pour maîtriser le coût CPU.
+4. **Shutdown gracieux** : broadcast countdown 5min/1min/30s, kick safe,
+   flush DB. Évite la perte de données.
+
+C'est un **P2 shard** + intégration master pour broadcast.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database — persistance)
+- CMANGOS.16 (Globals/Conditions — alternative ciblée pour les prédicats simples)
+- CMANGOS.19 (Maps — tick hiérarchique)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/world/`)
+
+- `WorldState.{h,cpp}` — singleton global :
+  - `Get(stateId) → int32`
+  - `Set(stateId, value)` — broadcast aux subscribers
+  - `Subscribe(stateId, callback)` — pour notifications
+- `WorldStateExpression.{h,cpp}` — parseur + évaluateur du DSL :
+  ```cpp
+  ExpressionId Parse(std::string_view formula);
+  bool Evaluate(ExpressionId, EvaluationContext const&) const;
+  ```
+- `WorldStateExpressionLexer.{h,cpp}` — tokenize.
+- `WorldStateExpressionAst.h` — AST nodes.
+- `World.{h,cpp}` — singleton orchestrateur :
+  - `Tick(int64 nowMs)` — appelé par le main loop, dispatch aux Maps via MapManager.
+  - `Shutdown(int countdownSec)` — broadcast + kick + flush DB.
+
+### Migration DB
+
+```sql
+CREATE TABLE world_states (
+  state_id      INT UNSIGNED NOT NULL,
+  value         INT NOT NULL DEFAULT 0,
+  description   VARCHAR(255),
+  persistent    TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (state_id)
+);
+
+CREATE TABLE world_state_expressions (
+  expression_id INT UNSIGNED NOT NULL,
+  formula       TEXT NOT NULL,
+  description   VARCHAR(255),
+  PRIMARY KEY (expression_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"world": {
+  "tick_interval_ms": 1000,
+  "shutdown_default_countdown_sec": 300,
+  "world_state_persist_interval_sec": 60
+}
+```
+
+### Tests
+
+- `WorldStateTests.cpp` — Get/Set ; subscribe + notification.
+- `WorldStateExpressionTests.cpp` — parse `worldstate_42 > 100`,
+  parse expression composite avec AND/OR/NOT/parenthèses, gestion des erreurs syntaxe.
+- `WorldShutdownTests.cpp` — countdown produit broadcasts aux 5min/1min/30s.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. DSL grammaire (BNF simplifié)
+
+```
+expression  := term (('AND' | 'OR') term)*
+term        := factor | 'NOT' factor | '(' expression ')'
+factor      := worldstate cmp_op literal
+worldstate  := 'worldstate_' INT
+cmp_op      := '==' | '!=' | '<' | '<=' | '>' | '>='
+literal     := INT
+```
+
+Exemples valides :
+
+- `worldstate_42 == 1`
+- `worldstate_10 > 100 AND worldstate_11 == 0`
+- `(worldstate_5 > 0 OR worldstate_6 > 0) AND NOT worldstate_7 == 1`
+
+### 2. Parsing
+
+Lexer simple (régex/scan), parser récursif descendant (pas besoin de
+Bison). AST en `std::variant` ou hiérarchie classes :
+
+```cpp
+struct ExprBinaryOp { ExprPtr lhs; BinOp op; ExprPtr rhs; };
+struct ExprUnaryOp  { UnaryOp op; ExprPtr operand; };
+struct ExprWsCompare { uint32_t stateId; CmpOp op; int32_t value; };
+using Expr = std::variant<ExprBinaryOp, ExprUnaryOp, ExprWsCompare>;
+```
+
+### 3. Évaluation
+
+```cpp
+bool Evaluate(Expr const& e, EvaluationContext const& ctx) {
+  return std::visit(EvalVisitor{ctx}, e);
+}
+```
+
+`EvaluationContext` contient `WorldState const&` (pour les `worldstate_X`)
+et potentiellement le joueur courant pour des extensions (`player_level`, `player_class`).
+
+### 4. Tick hiérarchique
+
+```cpp
+void World::Tick(int64 nowMs) {
+  // 1s : world state save batched, broadcast cluster summary, expirations
+  if (nowMs - m_lastWorldTick >= 1000) {
+    PersistWorldStates();
+    BroadcastClusterSummary();
+    m_lastWorldTick = nowMs;
+  }
+  // 100ms : delegate to map tick (CMANGOS.19)
+  g_mapManager.UpdateAllMaps(nowMs);
+}
+```
+
+### 5. Shutdown gracieux
+
+```cpp
+void World::Shutdown(int countdownSec) {
+  for (int t : {300, 60, 30, 10, 5, 1}) {
+    if (t <= countdownSec) {
+      ScheduleBroadcast(t, "Server shutdown in " + format_time(t));
+    }
+  }
+  ScheduleAt(countdownSec, [] {
+    KickAllPlayers();
+    FlushAllDb();
+    ExitProcess();
+  });
+}
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/world/`.
+2. Migration DB des 2 tables.
+3. Implémenter `WorldState` (singleton + subscribe).
+4. Implémenter `WorldStateExpressionLexer` + parser récursif.
+5. Implémenter `Evaluate(Expr, ctx)`.
+6. Implémenter tick hiérarchique dans `World::Tick`.
+7. Implémenter `Shutdown` gracieux.
+8. Tests : 3 fichiers.
+9. Doc : section « World state + DSL » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test DSL : parse + eval `worldstate_5 > 0 AND worldstate_6 == 1` avec valeurs connues
+- [ ] Smoke test shutdown : `Shutdown(60)` produit broadcasts à 60/30/10/5/1s
+- [ ] WorldState persiste via `world_states.persistent = 1` après reboot
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Erreurs DSL** : si une expression contient une syntaxe invalide, ne **pas** crash. Logger un warning et retourner `false` à l'évaluation. Le parsing se fait au load, idéalement on rejette la mauvaise expression dès là.
+- **Performance évaluation** : si une expression est évaluée à chaque tick (ex. boss enrage timer), profiler. Cache l'AST (parse une fois, évalue N fois).
+- **Subscribe/notify** : éviter callback chains à 10 niveaux. Si un callback `Set` un autre worldstate qui re-notify, on a un cycle. Détecter avec un compteur de récursion local.
+- **Shutdown abuse** : la commande GM `.shutdown N` doit être réservée à `Administrator`. Sinon un GM peut crasher le shard.
+- **Broadcasts pendant shutdown** : pendant le countdown, **désactiver** les broadcasts non critiques (météo, cluster summary). Seuls les "shutdown imminent" passent.
+- **Compatibilité avec Conditions** : si `WorldStateExpression` est trop puissant et `Conditions` (CMANGOS.16) trop simple, on a deux DSL en parallèle. Choisir : `Conditions` pour les prédicats joueur (level, has_aura), `WorldStateExpression` pour les états globaux. Documenter clairement la séparation.
+- **DSL extensibility** : démarrer **strict** (worldstate_X et int literal). Étendre seulement quand un cas concret le demande (`player_level`, `is_in_zone`). Sinon on réinvente Lua.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § World (P2 shard)
+- cmangos `src/game/World/World.cpp`, `WorldState.cpp`,
+  `WorldStateExpression.cpp`, `WorldStateExpressionDefines.h`

--- a/tickets/CMANGOS/CMANGOS.29_Anticheat_plugin_interface_position_deltas.md
+++ b/tickets/CMANGOS/CMANGOS.29_Anticheat_plugin_interface_position_deltas.md
@@ -1,0 +1,147 @@
+# CMANGOS.29_Anticheat_plugin_interface_position_deltas
+
+## Objectif
+
+Réserver une **interface plugin anticheat** côté shard LCDLLN, inspirée
+de `src/game/Anticheat` cmangos. Trois piliers :
+
+1. **Architecture plugin** (interface abstraite `IServerSideValidator`
+   + impl chargeable) — permet une nouvelle heuristique sans rebuild
+   du shard.
+2. **Validation deltas de position** côté serveur : recalcul de la
+   vitesse réelle entre deux paquets `MoveUpdate` et comparaison au
+   max théorique du joueur (buffs inclus). Pattern critique pour le
+   shard.
+3. **Hook sur les commandes chat** — l'anticheat peut intercepter pour
+   logger/bloquer ; utile pour détecter spam de slash commands ou
+   exploits par macros.
+
+C'est un **P3 shard**. Pas prioritaire MVP, mais **réserver l'interface
+maintenant** évite une refonte plus tard quand les premières triches
+apparaîtront.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.04 (Movement) — l'anticheat consulte les MoveSpline pour
+  vitesse théorique
+- CMANGOS.05 (vmap) — anti-fly-hack via height check
+- CMANGOS.01 (Chat) — hook intercept
+
+## Livrables
+
+### Côté shard (`engine/server/shard/anticheat/`)
+
+- `IServerSideValidator.{h,cpp}` — interface abstraite :
+  ```cpp
+  class IServerSideValidator {
+  public:
+    virtual ~IServerSideValidator() = default;
+    virtual bool ValidateMove(Player& p, Vector3 newPos, int64_t serverTimeMs) = 0;
+    virtual bool ValidateChat(Player& p, ChatChannel ch, std::string_view msg) = 0;
+    virtual bool ValidateSpellCast(Player& p, SpellId spell, Unit* target) = 0;
+    virtual void OnViolation(Player& p, ViolationType, std::string_view detail) = 0;
+  };
+  ```
+- `NoOpValidator.{h,cpp}` — impl par défaut, valide tout. Utilisée si
+  `anticheat.enabled = false`.
+- `BaseValidator.{h,cpp}` — impl minimale :
+  - ValidateMove : compare vitesse réelle vs `Player::GetMaxSpeed`.
+  - ValidateSpellCast : vérifie cooldown + range + LOS (vmap).
+  - ValidateChat : passe (CMANGOS.01 ChatGate fait déjà l'essentiel).
+- `ValidatorRegistry.{h,cpp}` — singleton, permet de remplacer le
+  validator runtime via config.
+
+### Configuration (`config.json`)
+
+```json
+"anticheat": {
+  "enabled": false,
+  "validator_name": "BaseValidator",
+  "speed_tolerance_factor": 1.10,
+  "speed_violation_threshold_count": 5,
+  "violation_action": "log_only",     // log_only | kick | ban_24h
+  "fly_hack_height_threshold_m": 50.0
+}
+```
+
+### Tests
+
+- `BaseValidatorTests.cpp` — speed hack détecté (déplacement > maxSpeed × tolerance).
+- `BaseValidatorChatTests.cpp` — passes through (déjà filtré par ChatGate).
+- `ValidatorRegistryTests.cpp` — swap validator runtime.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Validation des deltas de position
+
+```cpp
+bool BaseValidator::ValidateMove(Player& p, Vector3 newPos, int64_t serverTimeMs) {
+  auto last = p.GetLastValidatedPosition();
+  auto deltaTime = (serverTimeMs - last.timestampMs) / 1000.0;
+  auto distance = (newPos - last.pos).Length();
+  auto observedSpeed = distance / deltaTime;
+  auto maxSpeed = p.GetMaxSpeed() * config.speed_tolerance_factor;
+  if (observedSpeed > maxSpeed) {
+    OnViolation(p, ViolationType::SpeedHack,
+                std::format("observed={:.2f} max={:.2f}", observedSpeed, maxSpeed));
+    return false;
+  }
+  return true;
+}
+```
+
+Tolérance configurable (défaut +10%) pour éviter faux positifs sur
+RTT/jitter.
+
+### 2. Violation count
+
+Un seul faux positif n'est pas une preuve. Compter sur
+`speed_violation_threshold_count` violations consécutives avant action.
+
+### 3. Action sur violation
+
+- `log_only` (défaut) : log warning, pas de sanction.
+- `kick` : déconnecte le joueur, audit log.
+- `ban_24h` : ban temporaire compte.
+
+Toutes les violations vont dans `SecurityAuditLog` (existant côté master)
++ `LogFilter::Auth`.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/anticheat/`.
+2. Implémenter `IServerSideValidator` interface.
+3. Implémenter `NoOpValidator` (default).
+4. Implémenter `BaseValidator` (speed check + spell sanity).
+5. Implémenter `ValidatorRegistry` (lookup par nom config).
+6. Câbler `Player::OnMoveUpdate` → `validator.ValidateMove(...)`.
+7. Tests : 3 fichiers.
+8. Doc : section « Anticheat shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : avec `enabled=true`, déplacement à 2× speed → violation log + count incrémenté
+- [ ] `enabled=false` → comportement identique avant ce ticket (NoOpValidator)
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Faux positifs RTT** : un client avec 200ms ping peut envoyer 2 paquets de mouvement séparés par 50ms réels mais 250ms perçus. Tolérance + lissage de la vélocité observée sur N samples.
+- **Téléport légitime** : un sort de téléport, un knockback PvP sont des changements abrupts mais valides. Le validator doit consulter `Player::GetLastTeleport()` ou un flag "expecting teleport" pour ignorer un saut prévu.
+- **Plugin chargeable runtime** : pour vraiment "remplacer sans rebuild", il faudrait `dlopen`/`LoadLibrary`. Compromis : recompile + restart shard suffit pour la v1, plugin runtime = futur ticket.
+- **Privacy log** : un ban audit doit contenir l'IP + l'accountId mais pas la position complète (privacy mineure).
+- **Double check serveur** : `vmap.GetHeight` peut être utilisé pour un anti-fly-hack basique. Si le joueur reste à > `fly_hack_height_threshold_m` au-dessus du sol pendant N secondes sans buff Flying → violation.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Anticheat (P3 shard)
+- cmangos `src/game/Anticheat/Anticheat.hpp`, `module/`

--- a/tickets/CMANGOS/CMANGOS.30_Cinematics_trigger_opcode_camera_validation.md
+++ b/tickets/CMANGOS/CMANGOS.30_Cinematics_trigger_opcode_camera_validation.md
@@ -1,0 +1,123 @@
+# CMANGOS.30_Cinematics_trigger_opcode_camera_validation
+
+## Objectif
+
+Mettre en place le **système de cinématiques** côté shard+client LCDLLN,
+inspiré de `src/game/Cinematics` cmangos. Trois piliers :
+
+1. **Trigger via opcode** `SMSG_TRIGGER_CINEMATIC` avec un ID : le
+   serveur ne stream rien, le client a déjà l'asset. Pattern « le
+   serveur nomme, le client joue ».
+2. **Asset client-side** : la cinématique (vidéo, scripted camera path)
+   est packagée avec le client.
+3. **Parsing M2/cinematic-data côté serveur** uniquement pour les
+   chemins de caméra (anticheat : empêcher un téléport pendant la
+   cinématique).
+
+C'est un **P3 cross**, pas pour le MVP.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.05 (vmap) — anticheat consulte la position prévue de la caméra
+
+## Livrables
+
+### Côté shard (`engine/server/shard/cinematics/`)
+
+- `CinematicMgr.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge les métadonnées des cinématiques.
+  - `Trigger(Player&, uint32_t cinematicId)` — envoie l'opcode + démarre validation.
+  - `Update(int32_t dtMs)` — tick : pour chaque cinématique active,
+    vérifie que la position du joueur correspond au path attendu (à `± epsilon`).
+- `CinematicCameraPath.{h,cpp}` — descripteur de path :
+  ```cpp
+  struct CinematicCameraPath {
+    uint32_t cinematicId;
+    std::vector<Vector3> waypoints;
+    std::vector<float> timestampsSec;
+  };
+  ```
+
+### Côté client (`engine/client/cinematics/`)
+
+- `CinematicPlayer.{h,cpp}` — reçoit `SMSG_TRIGGER_CINEMATIC`, joue
+  l'asset (vidéo ou scripted camera + animation).
+
+### Migration DB
+
+```sql
+CREATE TABLE cinematic_template (
+  cinematic_id    INT UNSIGNED NOT NULL,
+  asset_path      VARCHAR(255) NOT NULL,    -- relatif paths.content
+  duration_ms     INT UNSIGNED NOT NULL,
+  description     VARCHAR(255),
+  PRIMARY KEY (cinematic_id)
+);
+
+CREATE TABLE cinematic_camera_path (
+  cinematic_id    INT UNSIGNED NOT NULL,
+  point_idx       INT UNSIGNED NOT NULL,
+  position_x      FLOAT NOT NULL,
+  position_y      FLOAT NOT NULL,
+  position_z      FLOAT NOT NULL,
+  timestamp_sec   FLOAT NOT NULL,
+  PRIMARY KEY (cinematic_id, point_idx)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"cinematics": {
+  "enabled": true,
+  "anticheat_position_tolerance_m": 5.0,
+  "max_concurrent_per_player": 1
+}
+```
+
+### Tests
+
+- `CinematicMgrTests.cpp` — trigger envoie l'opcode + démarre
+  surveillance position.
+- `CinematicAnticheatTests.cpp` — joueur s'éloigne du path attendu →
+  flag violation.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Assets cinématique : sous `paths.content + cinematics/`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/cinematics/` et `engine/client/cinematics/`.
+2. Migrations DB.
+3. Implémenter `CinematicMgr` côté shard.
+4. Allouer opcode `kOpcodeTriggerCinematic`.
+5. Implémenter `CinematicPlayer` côté client (stub pour MVP, juste `printf` reçu).
+6. Implémenter validation anti-téléport.
+7. Tests : 2 fichiers.
+8. Doc : section « Cinematics » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard) + Windows OK (client)
+- [ ] Tests passent
+- [ ] Smoke test : trigger cinematic ID 1 → opcode envoyé, client log "received cinematic 1"
+- [ ] Si joueur déclenche un téléport pendant cinematic → violation log
+- [ ] Migrations idempotentes
+- [ ] Aucun chemin absolu (assets via `paths.content`)
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Asset loading client** : la cinématique = vidéo `.mp4` ou un format scripted. Pour MVP, juste un opcode + ID. Le rendu réel (cutscene Vulkan) est un autre ticket.
+- **Pause / skip** : un joueur peut skip une cinématique. Notifier le serveur (`kOpcodeCinematicEnd`) pour stop la validation.
+- **Multi-cinematic** : interdit (`max_concurrent_per_player = 1`). Si déjà active, le nouveau trigger remplace.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Cinematics (P3 cross)
+- cmangos `src/game/Cinematics/CinematicMgr.cpp`, `M2Stores.cpp`

--- a/tickets/CMANGOS/CMANGOS.31_GameEvents_seasonal_scheduler_cascading.md
+++ b/tickets/CMANGOS/CMANGOS.31_GameEvents_seasonal_scheduler_cascading.md
@@ -1,0 +1,126 @@
+# CMANGOS.31_GameEvents_seasonal_scheduler_cascading
+
+## Objectif
+
+Mettre en place un **gestionnaire d'events de monde planifiés** côté
+shard LCDLLN, inspiré de `src/game/GameEvents` cmangos. Trois piliers :
+
+1. **Activation par `event_id`** sur les spawns : un même monde DB
+   porte plusieurs variantes saisonnières filtrées au load time, sans
+   dupliquer la table.
+2. **Scheduler central** avec start/end timestamps et récurrence —
+   un seul tick global décide ce qui est actif, pas de polling
+   distribué.
+3. **Events en cascade** : un event peut en déclencher d'autres
+   (parent/child), utile pour les festivals à étapes.
+
+C'est un **P3 shard**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- CMANGOS.19 (Maps — events filtrent les spawns par event_id)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/events/`)
+
+- `GameEvent.h` :
+  ```cpp
+  struct GameEvent {
+    uint32_t eventId;
+    std::string name;
+    std::optional<int64_t> startTs;        // null = non planifié
+    std::optional<int64_t> endTs;
+    int64_t   recurrenceSec;                // 0 = non récurrent
+    std::vector<uint32_t> childEvents;      // events à déclencher en cascade
+    bool      active = false;
+  };
+  ```
+- `GameEventMgr.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge events.
+  - `Update(int64_t nowMs)` — tick : check start/end, cascade child events.
+  - `void StartEvent(uint32_t eventId)` — manuel (commande GM).
+  - `void StopEvent(uint32_t eventId)`.
+- Hook spawn : `Map::ShouldSpawnByEvent(spawn.eventId)` — un spawn n'est
+  matérialisé que si son event est actif (ou eventId=0 = always-on).
+
+### Migration DB
+
+```sql
+CREATE TABLE game_event (
+  event_id        INT UNSIGNED NOT NULL,
+  name            VARCHAR(64) NOT NULL,
+  start_ts        BIGINT,                   -- nullable
+  end_ts          BIGINT,
+  recurrence_sec  BIGINT NOT NULL DEFAULT 0,
+  description     VARCHAR(255),
+  PRIMARY KEY (event_id)
+);
+
+CREATE TABLE game_event_cascade (
+  parent_event_id INT UNSIGNED NOT NULL,
+  child_event_id  INT UNSIGNED NOT NULL,
+  delay_sec       INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (parent_event_id, child_event_id)
+);
+
+ALTER TABLE creature_spawn  ADD COLUMN event_id INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE gameobject_spawn ADD COLUMN event_id INT UNSIGNED NOT NULL DEFAULT 0;
+```
+
+### Configuration (`config.json`)
+
+```json
+"game_events": {
+  "enabled": true,
+  "tick_interval_sec": 60,
+  "log_events_state_changes": true
+}
+```
+
+### Tests
+
+- `GameEventMgrTests.cpp` — start/stop manuel, cascade child events.
+- `GameEventScheduleTests.cpp` — start_ts dépassé → event activé automatiquement.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/events/`.
+2. Migrations DB (3 tables + 2 colonnes).
+3. Implémenter `GameEventMgr::Load`.
+4. Implémenter `Update` avec scheduler.
+5. Implémenter cascade child events.
+6. Câbler `Map::ShouldSpawnByEvent` au load des spawns.
+7. Implémenter commandes GM `.event start <id>` / `.event stop <id>`.
+8. Tests : 2 fichiers.
+9. Doc : section « Game events » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : event "Halloween" avec start_ts et end_ts → activation/désactivation auto + spawns event_id=halloween apparaissent
+- [ ] Cascade : event A start → child B activé après delay
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Recurrence overlap** : si recurrence_sec < (endTs - startTs), event n'est jamais désactivé. Détecter et log warning au load.
+- **Spawns en transition** : à l'activation d'un event, spawn les nouveaux PNJ ; à la désactivation, despawn proprement (pas snap).
+- **Cascade cycles** : A → B → A. Détecter et reject au load.
+- **Mass-spawn** : activation d'un gros event (1000 PNJ saisonniers) peut spike CPU. Étaler sur 5-10 secondes au lieu de tout spawner d'un coup.
+- **Persistance state** : si shard reboot pendant un event, le state doit être recalculé au boot (`now > startTs && now < endTs` → event actif). Pas de stockage `is_active` séparé en DB.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § GameEvents (P3 shard)
+- cmangos `src/game/GameEvents/GameEventMgr.cpp`, `moon.cpp`

--- a/tickets/CMANGOS/CMANGOS.32_GMTickets_support_in_game.md
+++ b/tickets/CMANGOS/CMANGOS.32_GMTickets_support_in_game.md
@@ -1,0 +1,124 @@
+# CMANGOS.32_GMTickets_support_in_game
+
+## Objectif
+
+Mettre en place un **système de tickets de support en jeu** côté master
+LCDLLN, inspiré de `src/game/GMTickets` cmangos. Trois piliers :
+
+1. **Persistence simple** : un ticket = une row DB avec état
+   (open/in_progress/closed), pas de file in-memory à reconstruire.
+2. **Handler dédié séparé du Mgr** : le réseau (handler) ne touche que
+   le manager, le manager ne touche que la DB.
+3. **Notification asymétrique** : le joueur ne voit que son ticket, le
+   GM voit la file globale.
+
+C'est un **P3 master**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.06 (Accounts — flag GM)
+- CMANGOS.13 (Database)
+
+## Livrables
+
+### Côté master (`engine/server/gmtickets/`)
+
+- `GMTicket.h` :
+  ```cpp
+  enum class TicketState : uint8 { Open, InProgress, Closed };
+  struct GMTicket {
+    uint64_t ticketId;
+    uint32_t reporterAccountId;
+    std::string subject;
+    std::string body;
+    TicketState state;
+    uint32_t assignedGmAccountId;       // 0 si non assigné
+    int64_t createdTs;
+    int64_t lastUpdateTs;
+    std::string gmResponse;
+  };
+  ```
+- `GMTicketManager.{h,cpp}` :
+  - `Create(reporterId, subject, body)`
+  - `void TakeOwnership(ticketId, gmAccountId)`
+  - `void Respond(ticketId, gmAccountId, response)`
+  - `void Close(ticketId)`
+  - `std::vector<GMTicket> ListOpen()` — pour l'UI GM.
+  - `std::optional<GMTicket> GetForReporter(accountId)` — un seul ticket actif par reporter.
+- `GMTicketHandler.{h,cpp}` — opcodes :
+  - `kOpcodeGMTicketCreate`
+  - `kOpcodeGMTicketStatus`
+  - `kOpcodeGMTicketClose`
+  - `kOpcodeGMTicketGmList` (GM only)
+  - `kOpcodeGMTicketGmRespond` (GM only)
+
+### Migration DB
+
+```sql
+CREATE TABLE gm_ticket (
+  ticket_id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  reporter_account_id    INT UNSIGNED NOT NULL,
+  subject                VARCHAR(128) NOT NULL,
+  body                   TEXT,
+  state                  TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  assigned_gm_account_id INT UNSIGNED NOT NULL DEFAULT 0,
+  gm_response            TEXT,
+  created_ts             BIGINT NOT NULL,
+  last_update_ts         BIGINT NOT NULL,
+  PRIMARY KEY (ticket_id),
+  KEY idx_reporter (reporter_account_id),
+  KEY idx_state (state)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"gm_tickets": {
+  "max_per_reporter": 1,
+  "auto_close_inactive_days": 30
+}
+```
+
+### Tests
+
+- `GMTicketManagerTests.cpp` — create, take ownership, respond, close.
+- `GMTicketAuthTests.cpp` — joueur ne peut pas voir tickets d'autres ; GM voit tous.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/gmtickets/`.
+2. Migration DB.
+3. Implémenter `GMTicketManager`.
+4. Implémenter handler + opcodes.
+5. Câbler check rôle GM (CMANGOS.06).
+6. Tests : 2 fichiers.
+7. Doc : section « GM Tickets » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : joueur create ticket → GM list voit le ticket → GM répond → joueur reçoit notif
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Spam protection** : `max_per_reporter = 1` empêche un joueur d'inonder. Doit fermer son ticket avant d'en créer un nouveau.
+- **GM offline notification** : si aucun GM en ligne, ticket reste en queue. Notif Discord/Slack via webhook si urgence ? Reportable.
+- **Visibilité** : une commande GM `.gmticket list` permet de voir la file ; un joueur n'a accès qu'à sa propre commande `.ticket status`.
+- **Auto-close** : `auto_close_inactive_days` empêche les tickets de pourrir indéfiniment. Cron périodique.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § GMTickets (P3 master)
+- cmangos `src/game/GMTickets/GMTicketMgr.cpp`,
+  `GMTicketHandler.cpp`

--- a/tickets/CMANGOS/CMANGOS.33_LFG_queue_role_matchmaking.md
+++ b/tickets/CMANGOS/CMANGOS.33_LFG_queue_role_matchmaking.md
@@ -1,0 +1,120 @@
+# CMANGOS.33_LFG_queue_role_matchmaking
+
+## Objectif
+
+Mettre en place un **système Looking-For-Group / matchmaking** côté
+master LCDLLN, inspiré de `src/game/LFG` cmangos. Quatre piliers :
+
+1. **`LFGQueue` séparée du `LFGMgr`** : la file (structure de données +
+   algo de matching) est isolée du manager (état joueur, téléport,
+   récompenses) — testable à part.
+2. **Matching par rôles requis** : chaque slot d'un dungeon demande un
+   set de rôles, l'algo cherche la plus petite combinaison qui remplit.
+3. **State machine joueur** : Idle / Queued / Proposal / Boot / InDungeon
+   — transitions explicites évitent les bugs de "joueur fantôme dans
+   la file".
+4. **Timeout proposals** : si un joueur ne confirme pas en N secondes,
+   sa place est rendue à la file.
+
+C'est un **P3 master**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- CMANGOS.15 (Groups — création de groupe au match formé)
+
+## Livrables
+
+### Côté master (`engine/server/lfg/`)
+
+- `LFGRole.h` — enum `Tank, Heal, Dps, Filler` + flags (un joueur peut être multi-rôle).
+- `LFGEntry.h` :
+  ```cpp
+  struct LFGEntry {
+    uint32_t accountId;
+    uint64_t characterId;
+    LFGRoleFlags rolesAvailable;
+    std::vector<uint32_t> dungeonsRequested;
+    int64_t enqueuedTs;
+  };
+  ```
+- `LFGQueue.{h,cpp}` :
+  - `void Enqueue(LFGEntry)`
+  - `void Dequeue(uint32_t accountId)`
+  - `std::optional<LFGMatch> TryFormMatch(uint32_t dungeonId)` — algo bin-packing
+- `LFGMgr.{h,cpp}` (state machine) :
+  - `OnPlayerJoinQueue`, `OnPlayerLeaveQueue`
+  - `OnMatchProposal(LFGMatch)` — envoie proposal aux 5 joueurs
+  - `OnProposalAccepted(accountId)` ou `OnProposalDeclined`
+  - `OnAllAccepted` → crée Group + tp dans dungeon
+- `LFGHandler.{h,cpp}` — opcodes.
+
+### Migration DB
+
+```sql
+CREATE TABLE lfg_dungeon (
+  dungeon_id          INT UNSIGNED NOT NULL,
+  name                VARCHAR(64) NOT NULL,
+  required_tanks      TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  required_heals      TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  required_dps        TINYINT UNSIGNED NOT NULL DEFAULT 3,
+  min_level           INT NOT NULL DEFAULT 1,
+  max_level           INT NOT NULL DEFAULT 60,
+  PRIMARY KEY (dungeon_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"lfg": {
+  "proposal_timeout_sec": 60,
+  "boot_grace_sec": 90,
+  "match_check_interval_sec": 5
+}
+```
+
+### Tests
+
+- `LFGQueueTests.cpp` — match avec 5 joueurs (1T/1H/3D) → match formé.
+- `LFGMgrStateMachineTests.cpp` — Queued → Proposal → si timeout → retour Queued.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/lfg/`.
+2. Migration DB.
+3. Implémenter `LFGQueue` (algo matching).
+4. Implémenter `LFGMgr` (state machine).
+5. Implémenter handler + opcodes.
+6. Tests : 2 fichiers.
+7. Doc : section « LFG » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : 5 joueurs en queue (rôles complémentaires) → proposal envoyée → tous acceptent → Group créé + tp dungeon
+- [ ] Timeout proposal : 1 joueur ne répond pas → autres rendus à la queue
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Algo bin-packing** : pas trivial à scaler à 1000s de joueurs en queue. Démarrer simple (greedy par rôle), optimiser plus tard.
+- **Boot vote** : un joueur en groupe peut être kické par vote majoritaire. State machine `Boot` couvre ça.
+- **Cross-shard** : oui, naturellement master-side. Une queue unique pour tous les shards.
+- **Penalty leaver** : un joueur qui quitte un dungeon en cours = debuff "Deserter" 30 min. Géré côté master à la sortie inattendue.
+- **Reactive matchmaking** : `match_check_interval_sec = 5` → délai max 5s entre rôle complète et proposition. Acceptable. Pas besoin du temps réel.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § LFG (P3 master)
+- cmangos `src/game/LFG/LFGMgr.cpp`, `LFGQueue.cpp`,
+  `LFGHandler.cpp`

--- a/tickets/CMANGOS/CMANGOS.34_Metric_influxdb_measurement_raii.md
+++ b/tickets/CMANGOS/CMANGOS.34_Metric_influxdb_measurement_raii.md
@@ -1,0 +1,140 @@
+# CMANGOS.34_Metric_influxdb_measurement_raii
+
+## Objectif
+
+Mettre en place un **collecteur de métriques** prod LCDLLN inspiré de
+`src/shared/Metric` cmangos. Trois piliers :
+
+1. **Modèle InfluxDB line-protocol** (tags + fields + timestamp) :
+   standard de facto, lisible par Grafana/Telegraf out-of-the-box.
+2. **`Measurement` RAII** : `{ Measurement m("LoginHandler"); ... }` →
+   durée poussée automatiquement à la sortie de scope. Pattern
+   ergonomique pour profiler du code chaud sans intrusion.
+3. **Flush asynchrone batché** : queue protégée par mutex, scheduled
+   timer qui envoie en lot — évite N petits packets HTTP à chaque
+   measurement.
+
+C'est un **P3 cross master+shard**, observabilité prod (latence
+handlers, taille queues, ticks/sec).
+
+## Dépendances
+
+- M00.1 (build base)
+- Logger (PR #468) — pour debug si la connexion InfluxDB tombe
+
+## Livrables
+
+### Couche partagée (`engine/core/metric/`)
+
+- `MetricPoint.h` :
+  ```cpp
+  struct MetricPoint {
+    std::string measurement;        // "handler_latency"
+    std::vector<std::pair<std::string, std::string>> tags;
+    std::vector<std::pair<std::string, double>> fields;
+    int64_t timestampNs;
+  };
+  ```
+- `MetricCollector.{h,cpp}` :
+  - `void Push(MetricPoint p)` — non bloquant (push dans queue).
+  - `void Start(MetricConnectionInfo info)`
+  - `void Stop()`
+- `Measurement.h` (RAII) :
+  ```cpp
+  class Measurement {
+  public:
+    explicit Measurement(std::string_view name);
+    Measurement& Tag(std::string_view key, std::string_view value);
+    Measurement& Field(std::string_view key, double value);
+    ~Measurement();
+  private:
+    MetricPoint m_point;
+  };
+  ```
+  À la destruction, calcule la durée et push automatiquement.
+
+### Configuration (`config.json`)
+
+```json
+"metric": {
+  "enabled": false,
+  "influxdb_host": "127.0.0.1",
+  "influxdb_port": 8086,
+  "influxdb_database": "lcdlln",
+  "flush_interval_ms": 5000,
+  "max_queue_size": 10000
+}
+```
+
+### Tests
+
+- `MeasurementTests.cpp` — sortie de scope produit un point avec durée.
+- `MetricCollectorTests.cpp` — push 1000 points, flush bat 1 batch.
+- `LineProtocolTests.cpp` — sérialise un point au format InfluxDB ligne.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Format InfluxDB line-protocol
+
+```
+handler_latency,handler=Auth,server=master latency_ms=12.5 1715067600000000000
+```
+
+Format : `<measurement>,<tag1>=<v1>,<tag2>=<v2> <field1>=<v1>,<field2>=<v2> <timestamp_ns>`
+
+### 2. Measurement usage
+
+```cpp
+void HandleAuthRequest(...) {
+  Measurement m("auth_handler");
+  m.Tag("type", "register");
+  // ... travail ...
+  m.Field("custom_metric", 42.0);
+  // à la sortie : ajout automatique du field "duration_ns"
+}
+```
+
+### 3. Flush async
+
+Worker thread dédié qui dort `flush_interval_ms` ms, puis :
+1. Swap la queue locale avec une nouvelle.
+2. Sérialise tous les points en line-protocol.
+3. POST HTTP vers `{host}:{port}/write?db={database}`.
+4. En cas d'échec : retry 3× avec backoff, puis log error et drop.
+
+## Étapes d'implémentation
+
+1. Créer `engine/core/metric/`.
+2. Implémenter `MetricPoint` + line-protocol serializer.
+3. Implémenter `MetricCollector` (queue + flush thread).
+4. Implémenter `Measurement` RAII.
+5. Câbler dans 5-10 hot paths existants (auth handler, NetServer pump, DB query, Map tick).
+6. Tests : 3 fichiers.
+7. Doc : section « Metric » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK
+- [ ] Tests passent
+- [ ] Smoke test : InfluxDB local lancé, le flush envoie les points, Grafana les voit
+- [ ] `metric.enabled = false` → pas d'overhead (push devient no-op)
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Disabled = no-op total** : si `metric.enabled = false`, `Measurement::~Measurement` ne fait absolument rien. Sinon overhead inutile.
+- **Cardinality** : ne **jamais** mettre des values explosives en tag (ex. `accountId=...`). Tags sont indexés côté InfluxDB, cardinality élevée = explosion mémoire DB. Utiliser fields à la place pour les IDs.
+- **Buffer overflow** : si la queue dépasse `max_queue_size`, drop les plus anciens (FIFO). Log warn.
+- **Network failures** : InfluxDB indisponible → garder en queue, retry. Si la queue overflow, drop. Pas de blocage du process serveur pour cause de monitoring HS.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Metric (P3 cross)
+- cmangos `src/shared/Metric/Metric.cpp`
+- InfluxDB line protocol : https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/

--- a/tickets/CMANGOS/CMANGOS.35_Multithreading_messager_swap_execute.md
+++ b/tickets/CMANGOS/CMANGOS.35_Multithreading_messager_swap_execute.md
@@ -1,0 +1,120 @@
+# CMANGOS.35_Multithreading_messager_swap_execute
+
+## Objectif
+
+Implémenter le pattern **`Messager`** inspiré de
+`src/shared/Multithreading` cmangos. Pattern : au lieu de protéger un
+état partagé par mutex prolongé, le thread propriétaire vide
+périodiquement une queue de fonctions qui modifient son état localement
+("swap-and-execute"). Élimine la contention.
+
+Cas d'usage LCDLLN :
+- master → shard : « exécute ceci dans ton tick »
+- IO thread → game thread : « voici un paquet à dispatcher »
+- shard A → shard B : « migre ce joueur »
+
+C'est un **P3 cross**.
+
+## Dépendances
+
+- M00.1 (build base)
+
+## Livrables
+
+### Couche partagée (`engine/core/multithreading/`)
+
+- `Messager.{h,cpp}` (templated) :
+  ```cpp
+  template <class Owner>
+  class Messager {
+  public:
+    using Message = std::function<void(Owner&)>;
+    void Send(Message msg);          // appelable depuis n'importe quel thread
+    void Execute(Owner& owner);      // doit être appelé par owner thread uniquement
+  private:
+    std::mutex m_mutex;
+    std::vector<Message> m_pending;
+    std::vector<Message> m_local;    // swap target (réutilisé pour éviter alloc)
+  };
+  ```
+
+### Tests
+
+- `MessagerTests.cpp` :
+  - Multi-thread push 1000 messages → owner thread `Execute` les exécute tous.
+  - Verify : owner state mutated correctement.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### Swap-and-execute
+
+```cpp
+template <class Owner>
+void Messager<Owner>::Send(Message msg) {
+  std::lock_guard lk(m_mutex);
+  m_pending.push_back(std::move(msg));
+}
+
+template <class Owner>
+void Messager<Owner>::Execute(Owner& owner) {
+  m_local.clear();
+  {
+    std::lock_guard lk(m_mutex);
+    std::swap(m_pending, m_local);     // O(1), held lock briefly
+  }
+  for (auto& msg : m_local) {
+    msg(owner);                        // exécuté hors lock
+  }
+}
+```
+
+Le lock est tenu uniquement pendant le swap (très court). L'exécution
+des fonctions se fait hors lock — pas de blocage des producteurs.
+
+### Usage type
+
+```cpp
+// shard A
+g_shardB.Messager().Send([playerData](Shard& dest) {
+  dest.AddIncomingPlayer(playerData);
+});
+
+// shard B (owner thread):
+void Shard::Tick() {
+  m_messager.Execute(*this);    // applique les Send() reçus
+  // ... logique normale du tick
+}
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/core/multithreading/Messager.{h,cpp}`.
+2. Tests basiques + multi-thread.
+3. Câbler côté shard : chaque Map a un Messager pour réception cross-thread.
+4. Câbler côté master : Messager pour réception depuis IO thread.
+5. Doc : section « Messager pattern » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK
+- [ ] Tests multi-thread passent (1000 producers × 100 messages)
+- [ ] Smoke test : un Map reçoit un message cross-thread et l'applique au tick
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Owner-only Execute** : `Execute` n'est appelable que par le thread propriétaire. Si appelé par un autre, race sur `m_local`. Documenter clairement.
+- **Reentrancy** : si une Message contient un `Send` vers la même Messager, le nouveau message attendra le prochain `Execute` (correct — pas de pile).
+- **`std::function` cost** : une allocation heap par Send (sauf SBO). Pour les hot paths, considérer un `inplace_function<sizeof(void*)*4>` ou un pool.
+- **Drop on shutdown** : à la fermeture, drainer la queue (`Execute` une dernière fois) avant de détruire l'owner.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Multithreading (P3 cross)
+- cmangos `src/shared/Multithreading/Messager.h`

--- a/tickets/CMANGOS/CMANGOS.36_OutdoorPvP_zone_plugins_objectives.md
+++ b/tickets/CMANGOS/CMANGOS.36_OutdoorPvP_zone_plugins_objectives.md
@@ -1,0 +1,154 @@
+# CMANGOS.36_OutdoorPvP_zone_plugins_objectives
+
+## Objectif
+
+Mettre en place un framework **PvP en zones ouvertes** côté shard
+LCDLLN, inspiré de `src/game/OutdoorPvP` cmangos. Quatre piliers :
+
+1. **Pattern Manager + plugin polymorphe par zone** : `OutdoorPvPMgr`
+   enregistre des `OutdoorPvP*` polymorphes au démarrage et dispatch
+   les events `OnPlayerEnterZone`, `OnGameObjectCreate`, `OnPlayerKill`.
+2. **State machine par objectif** : chaque tour/banner = mini-FSM
+   (neutre → capture en cours → capturé) avec timer et progression.
+3. **WorldState broadcast** : compteurs de score diffusés via variables
+   nommées (CMANGOS.28 World) à tous les clients de la zone.
+4. **Découplage triggers/règles** : déclencheurs (entrée AreaTrigger
+   géographique) séparés de la logique de scoring — data-driven via
+   DB.
+
+C'est un **P3 shard**. Pas pour le MVP, mais pattern réutilisable pour
+des futurs events scriptés (festivals, invasions saisonnières).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.28 (World) — WorldState broadcast
+- CMANGOS.07 (AI) — réactions des PNJ aux changements
+- CMANGOS.16 (Globals/Conditions)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/outdoorpvp/`)
+
+- `OutdoorPvP.{h,cpp}` (abstract) :
+  ```cpp
+  class OutdoorPvP {
+  public:
+    virtual ~OutdoorPvP() = default;
+    virtual void OnPlayerEnterZone(Player&) {}
+    virtual void OnPlayerLeaveZone(Player&) {}
+    virtual void OnPlayerKilledByPlayer(Player& victim, Player& killer) {}
+    virtual void OnGameObjectInteract(GameObject&, Player&) {}
+    virtual void Update(int32_t dtMs) {}
+    uint32_t GetZoneId() const;
+    uint32_t GetMapId() const;
+  };
+  ```
+- `OutdoorPvPMgr.{h,cpp}` :
+  - `Register(std::unique_ptr<OutdoorPvP>)` — un par zone supportée.
+  - `void OnPlayerEnterZone(Player&, uint32_t newZoneId)` — dispatch.
+  - `void Update(int32_t dtMs)` — tick tous les zones actives.
+- `OutdoorPvPObjective.{h,cpp}` (utilitaire) :
+  ```cpp
+  class OutdoorPvPObjective {
+  public:
+    enum class State { Neutral, Capturing, Captured };
+    void OnPlayerProgressTick(Player&);
+    State GetState() const;
+    uint32_t GetWorldStateId() const;     // pour broadcast
+  };
+  ```
+
+### Configuration (`config.json`)
+
+```json
+"outdoor_pvp": {
+  "enabled": false,
+  "capture_default_duration_sec": 60,
+  "capture_radius_m": 30.0,
+  "scoreboard_broadcast_interval_sec": 10
+}
+```
+
+### Tests
+
+- `OutdoorPvPMgrTests.cpp` — register + OnPlayerEnterZone dispatch.
+- `OutdoorPvPObjectiveTests.cpp` — state machine Neutral → Capturing → Captured.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Plugin par zone
+
+```cpp
+class HellfireOutdoorPvP : public OutdoorPvP {
+public:
+  HellfireOutdoorPvP() : OutdoorPvP(/*mapId*/100, /*zoneId*/200) {}
+  void OnPlayerEnterZone(Player& p) override {
+    BroadcastCurrentScore(p);
+  }
+  void OnPlayerKilledByPlayer(Player& v, Player& k) override {
+    if (k.GetFaction() != v.GetFaction()) {
+      m_score[k.GetFaction()] += 1;
+      BroadcastScoreUpdate();
+    }
+  }
+private:
+  std::array<int32_t, 2> m_score = {};
+};
+```
+
+### 2. State machine objectif
+
+```
+Neutral ----enemy faction enters----> Capturing
+Capturing ----timer expires + faction holds----> Captured (faction X)
+Capturing ----enemy faction enters----> Capturing (autre faction, reset timer)
+Captured ----enemy faction starts capture----> Capturing
+```
+
+### 3. WorldState broadcast
+
+Chaque objectif a un `worldStateId`. Quand state change :
+
+```cpp
+g_worldState.Set(myWsId, encodedState);
+// Tous les clients dans la zone reçoivent automatiquement (CMANGOS.28).
+```
+
+UI client : la zone affiche les scores en haut écran (similaire BG).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/outdoorpvp/`.
+2. Implémenter `OutdoorPvP` interface.
+3. Implémenter `OutdoorPvPMgr`.
+4. Implémenter `OutdoorPvPObjective` (state machine).
+5. Câbler `Player::OnZoneChange` → mgr dispatch.
+6. Tests : 2 fichiers.
+7. Doc : section « OutdoorPvP framework » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : un OutdoorPvP custom (test) enregistré, joueur entre zone → callback déclenché
+- [ ] State machine objectif : 60s de capture continue → state = Captured + worldstate broadcast
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Pas pour le MVP** : ce ticket pose le **framework**. L'implémentation d'une zone PvP réelle vient plus tard, par module dédié.
+- **Conflits avec OnPlayerKill** : un PvP zone hook + un BattleGround hook peuvent traiter le même kill. Documenter l'ordre de dispatch (OutdoorPvPMgr d'abord, BG ensuite, par exemple).
+- **Performance** : le framework lui-même est gratuit (vide tant qu'aucune zone enregistrée). Activer module par module.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § OutdoorPvP (P3 shard)
+- cmangos `src/game/OutdoorPvP/OutdoorPvP.cpp`,
+  `OutdoorPvPMgr.cpp`, exemples zones `OutdoorPvPHP.cpp` etc.

--- a/tickets/CMANGOS/CMANGOS.37_Platform_crash_dump_windows_client.md
+++ b/tickets/CMANGOS/CMANGOS.37_Platform_crash_dump_windows_client.md
@@ -1,0 +1,132 @@
+# CMANGOS.37_Platform_crash_dump_windows_client
+
+## Objectif
+
+Adapter `WheatyExceptionReport` cmangos pour le **client Windows
+LCDLLN** : crash dump auto-généré sur exception non catchée, avec types
+et valeurs des variables locales via DbgHelp. **Très précieux** quand un
+joueur crash : on récupère un rapport exploitable sans symboles externes.
+
+Avantage vs Crashpad/Breakpad : zéro dépendance externe, intégration
+native Win32, format texte lisible.
+
+C'est un **P3 client**.
+
+## Dépendances
+
+- M00.1 (build base Windows)
+- DbgHelp (Win32 API, livré avec Windows SDK)
+
+## Livrables
+
+### Côté client (`engine/client/platform/`)
+
+- `WheatyCrashReport.{h,cpp}` (Windows-only) — adapter cmangos :
+  - `Install()` — installe `SetUnhandledExceptionFilter`.
+  - `static LONG WINAPI Filter(EXCEPTION_POINTERS* ep)` — handler.
+  - Génère un fichier `crash_<timestamp>.txt` :
+    ```
+    [Header] LCDLLN client crash, version, date, OS info
+    [Exception] code, address
+    [Modules] all loaded DLLs with base + size
+    [Stack] frames avec symbols si .pdb dispo
+    [Locals] pour chaque frame, variables locales avec types et valeurs
+    [Registers] EAX/EBX/...
+    [Memory dump] context mémoire autour de l'exception
+    ```
+- `engine/client/platform/CrashReportConfig.h` — chemins, max files
+  retenus.
+
+### Configuration (`config.json`)
+
+```json
+"client": {
+  "crash_dump": {
+    "enabled": true,
+    "directory": "crashes",
+    "max_files": 20,
+    "include_memory_context": true
+  }
+}
+```
+
+### Tests
+
+- Manuel uniquement : provoquer un crash deliberé (`*nullptr = 0`),
+  vérifier qu'un `crash_*.txt` est généré et lisible.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Crash dumps : sous `paths.content + crashes/` (relatif)
+- ❌ Interdit : chemins absolus, dossier racine non autorisé
+
+## Spécification technique
+
+### Format dump (extrait simplifié)
+
+```
+=== LCDLLN Client Crash Report ===
+Version: 0.1.0
+Build:   2026-05-07 12:34:56
+OS:      Windows 11 (Build 22621)
+CPU:     Intel(R) Core(TM) i7-12700K
+RAM:     32 GB
+
+Exception Code: 0xC0000005 (ACCESS_VIOLATION)
+Exception Address: 0x00007FF7A1234567 (lcdlln_client.exe + 0x1234567)
+
+=== Module List ===
+0x00007FF7A1000000 lcdlln_client.exe (build 0.1.0)
+0x00007FFE12340000 vulkan-1.dll
+0x00007FFE12450000 ntdll.dll
+...
+
+=== Stack Trace (Thread 12345) ===
+#00 0x00007FF7A1234567 lcdlln_client.exe!engine::render::TerrainRenderer::Render+0x123 (TerrainRenderer.cpp:456)
+    Locals:
+      this    = 0x000001A234567890 (TerrainRenderer*)
+      device  = 0x000001A234567A00 (VkDevice)
+      cmd     = 0x000001A234567B00 (VkCommandBuffer)
+      heightmap = nullptr (HeightmapData*)        <-- LIKELY CULPRIT
+
+#01 0x00007FF7A1234600 lcdlln_client.exe!engine::Engine::RenderFrame+0x42 (Engine.cpp:1234)
+...
+```
+
+`heightmap = nullptr` est exactement le genre d'info précieuse pour
+diagnostiquer sans avoir le repro.
+
+## Étapes d'implémentation
+
+1. Créer `engine/client/platform/WheatyCrashReport.{h,cpp}` (Windows-only via `#ifdef _WIN32`).
+2. Câbler `SetUnhandledExceptionFilter(WheatyCrashReport::Filter)` au boot client.
+3. Ajouter `dbghelp.lib` au link pour le client Windows.
+4. Implémenter formatage : modules, stack walking, locals via DbgHelp.
+5. Smoke test manuel : injecter `*((int*)0) = 0;` en debug → vérifier dump.
+6. Doc : section « Client crash reports » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Windows OK (client uniquement, server non concerné)
+- [ ] Crash provoqué → fichier `crash_*.txt` généré dans `crashes/`
+- [ ] Le dump contient stack trace lisible avec symbols (.pdb chargé)
+- [ ] Locals exposés (au moins 1-2 frames hors libs système)
+- [ ] Limite `max_files` respectée (purge des plus anciens)
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Symbols .pdb** : sans .pdb à côté de l'exe, pas de noms de fonctions ni de locals. Distribuer `lcdlln_client.pdb` dans le pkg ou le déposer sur un symbol server interne pour les builds publics.
+- **Stripped builds** : ne **pas** stripper la table de symbols dans le build Release distribué — sinon dump inutilisable. Ou alors, garder un build "debug-symbols" parallèle pour les crash dumps.
+- **Re-entrant crash** : si le handler crash lui-même, infinite loop. Wrap en try/catch avec fallback "minimal dump".
+- **Privacy** : un dump peut contenir des données sensibles (noms de fichiers ouverts, contenu de strings). Avant upload externe, audit par l'utilisateur.
+- **Upload auto** : pas dans ce ticket. Pour MVP, le joueur partage manuellement ; plus tard, upload optionnel vers un serveur de crash reports.
+- **Linux client** ? Pas couvert ici (LCDLLN client = Windows uniquement). Si un jour Linux/Mac, utiliser `signal(SIGSEGV)` + `backtrace()` (autre ticket).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Platform (P3 client)
+- cmangos `src/shared/Platform/WheatyExceptionReport.cpp`
+- DbgHelp API : https://learn.microsoft.com/en-us/windows/win32/debug/dbghelp-functions

--- a/tickets/CMANGOS/CMANGOS.38_PlayerBot_headless_session_load_test.md
+++ b/tickets/CMANGOS/CMANGOS.38_PlayerBot_headless_session_load_test.md
@@ -1,0 +1,145 @@
+# CMANGOS.38_PlayerBot_headless_session_load_test
+
+## Objectif
+
+Implémenter un mode **bot headless** côté shard LCDLLN, inspiré de
+`src/game/PlayerBot` cmangos. Adapté à LCDLLN : **pas un binaire séparé**,
+mais un mode `--headless-bot` dans le shard qui spawn N `PlayerSession`
+factices.
+
+Pilier principal : **WorldSession headless** réutilisant les vrais
+handlers serveur — load testing du shard sans client réel, **10× à 100×
+plus de bots qu'un vrai client** (pas de sérialisation réseau, pas de
+rendu, pas de client process).
+
+C'est un **P3 shard** (outil dev/QA, pas pour prod).
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.02 (Entities — Player headless)
+- CMANGOS.04 (Movement — bot peut se déplacer)
+- CMANGOS.07 (AI — bot a une stratégie)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/headless/`)
+
+- `HeadlessSession.{h,cpp}` :
+  ```cpp
+  class HeadlessSession : public PlayerSession {
+  public:
+    HeadlessSession(uint32_t botId, BotStrategy strat);
+    void Tick(int32_t dtMs);            // décide actions, push opcodes
+    // Override Send : ne sérialise pas, accumule en RAM si nécessaire
+    void Send(uint16_t opcode, std::span<const uint8_t> payload) override;
+  private:
+    BotStrategy m_strategy;
+    uint32_t m_botId;
+  };
+  ```
+- `BotStrategy.h` (interface composable) :
+  ```cpp
+  class BotStrategy {
+  public:
+    virtual void OnTick(HeadlessSession&) = 0;
+  };
+  // Stratégies concrètes :
+  class IdleStrategy        : public BotStrategy {};
+  class RandomMoveStrategy  : public BotStrategy {};
+  class CombatTrainingStrategy : public BotStrategy {};
+  class FollowPathStrategy  : public BotStrategy {};
+  ```
+- `HeadlessBotManager.{h,cpp}` :
+  - `void SpawnBots(int count, BotConfig cfg)`
+  - `void DespawnAll()`
+  - `void Tick(int32_t dtMs)` — ticke tous les bots.
+- `--headless-bot=N` CLI option dans `main_shard_linux.cpp`.
+
+### Configuration (`config.json`)
+
+```json
+"headless_bot": {
+  "enabled": false,
+  "default_count": 0,
+  "spawn_position_x": 0.0,
+  "spawn_position_y": 0.0,
+  "spawn_position_z": 100.0,
+  "default_strategy": "RandomMove",
+  "tick_rate_hz": 10
+}
+```
+
+### Tests
+
+- `HeadlessSessionTests.cpp` — créer 100 sessions, ticke, vérifier déplacements.
+- `HeadlessBotLoadTest.cpp` — load test 1000 bots, mesurer latence du tick.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. WorldSession headless
+
+Hérite de la `PlayerSession` standard mais :
+
+- `Send()` ne fait rien (ou stocke localement pour vérif tests).
+- Pas de socket, pas de TLS, pas d'écriture réseau.
+- Les opcodes que le bot envoie passent directement aux handlers serveur
+  via une fonction commune (pas via la pipe socket).
+
+Gain : 1 bot ≈ 100 KB RAM vs 5-20 MB pour un vrai client. 10× à 100×
+plus de bots possibles.
+
+### 2. BotStrategy composable
+
+Permet de tester différents profils de charge :
+
+- `IdleStrategy` : login, stay AFK. Test : combien de connexions idle peut tenir le shard.
+- `RandomMoveStrategy` : se déplace aléatoirement dans la zone. Test : charge mouvement + AoI.
+- `CombatTrainingStrategy` : aggro un PNJ d'entraînement, cycle attack/heal. Test : charge combat + spell.
+- `FollowPathStrategy` : suit un waypoint preset. Test : déterministe, replay.
+
+### 3. CLI
+
+```
+./lcdlln_shard --headless-bot=500 --bot-strategy=RandomMove
+```
+
+Spawn 500 bots à l'enter world. Utile pour CI ou benchmark local.
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/headless/`.
+2. Implémenter `HeadlessSession` (hérite PlayerSession, override Send).
+3. Implémenter `BotStrategy` interface + 2-3 stratégies.
+4. Implémenter `HeadlessBotManager` + tick.
+5. Câbler CLI `--headless-bot=N` dans `main_shard_linux.cpp`.
+6. Tests : 2 fichiers.
+7. Doc : section « Headless bots » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : `--headless-bot=100` spawn 100 sessions, le shard tick stable à 10 Hz, RAM raisonnable
+- [ ] Load test : 1000 bots `RandomMove` → tick < 200ms p99
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Pas un vrai client** : un bot ne valide pas la chaîne complète client-serveur. Les bugs purement client (rendu Vulkan, ImGui) ne sont pas détectables. Bot = test charge serveur uniquement.
+- **Authentification** : les bots doivent avoir des comptes en DB (créer N comptes test). Ne **pas** by-passer l'auth — le bot teste la chaîne réelle.
+- **Cleanup** : à `DespawnAll`, properly logout chaque bot pour ne pas laisser de sessions fantômes.
+- **Compétition avec vrais joueurs** : ne **pas** activer en prod. Verrou via config + log warning si activé en prod.
+- **Stratégies mixtes** : à terme, mixer 30% Idle / 50% RandomMove / 20% Combat pour simuler un workload réaliste.
+- **Réinjection des paquets** : le bot court-circuite la couche réseau. Ça veut dire que les bugs liés à la sérialisation/désérialisation ne sont pas testés — utiliser un vrai client pour ces cas.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § PlayerBot (P3 shard)
+- cmangos `src/game/PlayerBot/Base/`, `AI/`

--- a/tickets/CMANGOS/CMANGOS.39_Skills_craft_discovery_extra_item_proc.md
+++ b/tickets/CMANGOS/CMANGOS.39_Skills_craft_discovery_extra_item_proc.md
@@ -1,0 +1,112 @@
+# CMANGOS.39_Skills_craft_discovery_extra_item_proc
+
+## Objectif
+
+Mettre en place les **hooks data-driven du craft** côté shard LCDLLN,
+inspirés de `src/game/Skills` cmangos. Deux piliers :
+
+1. **Discovery** : `skill_discovery_template` (spell_required,
+   spell_discovered, chance) — unlock probabiliste de recettes via
+   crafting. Pattern « progression cachée » sympa.
+2. **Extra item proc** : `skill_extra_item_template` (chance,
+   items_per_craft) appliqué post-craft. Découple « la recette donne
+   X » de « parfois bonus Y ».
+
+Tout en SQL : zéro hardcoded, designers ajoutent recettes sans toucher
+au code.
+
+C'est un **P3 shard**, **uniquement si LCDLLN prévoit du craft**. Sinon
+ignorer.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- Système de craft existant (préalable fonctionnel)
+- CMANGOS.26 (Spells — la recette EST un sort)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/skills/`)
+
+- `SkillDiscovery.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge les rows.
+  - `bool TryDiscover(Player&, uint32_t spellRequiredId)` — appelé
+    après un craft réussi ; tire vs chance ; si succès, apprend
+    `spellDiscoveredId` au joueur.
+- `SkillExtraItem.{h,cpp}` :
+  - `Load(ConnectionPool&)`.
+  - `int RollExtraItems(Player&, uint32_t spellId)` — retourne le
+    nombre additionnel à donner (0 si pas de proc).
+
+### Migration DB
+
+```sql
+CREATE TABLE skill_discovery_template (
+  spell_required_id   INT UNSIGNED NOT NULL,
+  spell_discovered_id INT UNSIGNED NOT NULL,
+  chance              FLOAT NOT NULL,
+  description         VARCHAR(255),
+  PRIMARY KEY (spell_required_id, spell_discovered_id)
+);
+
+CREATE TABLE skill_extra_item_template (
+  spell_id            INT UNSIGNED NOT NULL,
+  chance              FLOAT NOT NULL,
+  min_extra_items     TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  max_extra_items     TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  PRIMARY KEY (spell_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"craft": {
+  "discovery_enabled": true,
+  "extra_item_enabled": true
+}
+```
+
+### Tests
+
+- `SkillDiscoveryTests.cpp` — chance 100% → discovery garantie ;
+  chance 0% → jamais.
+- `SkillExtraItemTests.cpp` — proc retourne dans la range min/max.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/skills/`.
+2. Migrations DB.
+3. Implémenter `SkillDiscovery` + `SkillExtraItem`.
+4. Câbler dans le hook craft : `OnCraftSuccess(player, spell)` →
+   `TryDiscover(...)` + `RollExtraItems(...)`.
+5. Tests : 2 fichiers.
+6. Doc : section « Skills hooks » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : recipe X craftée 1000 fois, discovery moyenne ≈ chance config
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Discovery déjà connue** : si le joueur a déjà appris `spellDiscoveredId`, ne pas re-tirer.
+- **Faim de chance** : les designers vont vouloir des chances très basses (0.01% pour la recette ultime). RNG correct, pas de pseudo-bad luck protection sauf décision.
+- **Extra item rarity** : un proc à 100% = bonus systématique (économie inflatée). Surveiller via metrics.
+- **Pas pour le MVP si pas de craft** : si LCDLLN n'a pas (encore) de système de craft, ce ticket attend.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Skills (P3 shard)
+- cmangos `src/game/Skills/SkillDiscovery.cpp`,
+  `SkillExtraItems.cpp`

--- a/tickets/CMANGOS/CMANGOS.40_Tools_playerdump_cleaner_formulas_language.md
+++ b/tickets/CMANGOS/CMANGOS.40_Tools_playerdump_cleaner_formulas_language.md
@@ -1,0 +1,168 @@
+# CMANGOS.40_Tools_playerdump_cleaner_formulas_language
+
+## Objectif
+
+Mettre en place 4 utilitaires d'administration côté master+shard
+LCDLLN, inspirés de `src/game/Tools` cmangos. Quatre piliers :
+
+1. **`PlayerDump` format texte** : sérialisation human-readable d'un
+   perso entier (perso + items + quêtes + skills + …) → restorable sur
+   un autre shard. Pattern de migration inter-shard très propre.
+2. **`CharacterDatabaseCleaner` périodique** : scan des orphelins
+   (item sans owner, mail sans expéditeur) en tâche async.
+3. **`Formulas.h` centralisé** : XP per kill, money loot, level
+   penalty… une seule source de vérité, facile à équilibrer.
+4. **`Language.h` server-side** : i18n côté serveur (broadcasts,
+   commandes GM messages).
+
+C'est un **P3 cross**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- CMANGOS.16 (Globals — `LocaleStrings` est l'équivalent runtime)
+
+## Livrables
+
+### Côté master (`engine/server/tools/`)
+
+- `PlayerDump.{h,cpp}` :
+  - `std::string Dump(uint64_t characterId)` — sérialise tout en texte (JSON ou format custom).
+  - `bool Restore(std::string_view dump, uint32_t newAccountId)` — applique sur DB.
+- `CharacterDatabaseCleaner.{h,cpp}` :
+  - `void RunFullScan()` — async, balaie les tables, identifie orphelins.
+  - `void DeleteOrphans()` — applique le cleanup.
+- `Formulas.h` (header-only) :
+  ```cpp
+  namespace lcdlln::formulas {
+    int32_t XpForKill(int playerLevel, int targetLevel);
+    int64_t MoneyDropAt(int targetLevel);
+    int32_t LevelPenaltyXp(int playerLevel, int targetLevel);
+    float CritChanceFromAgility(float agility);
+    // ...
+  }
+  ```
+- `ServerLanguage.{h,cpp}` :
+  - Charge `server_string` (i18n côté serveur) depuis DB.
+  - `std::string Get(uint32_t stringId, std::string_view locale)`.
+
+### Outil offline (`tools/player_migration/`)
+
+- `tools/player_migration/player_migration.cpp` — outil
+  `lcdlln_player_migration` qui :
+  - lit un dump JSON,
+  - se connecte à un autre shard DB,
+  - restaure le perso.
+
+### Migration DB
+
+```sql
+CREATE TABLE server_string (
+  string_id   INT UNSIGNED NOT NULL,
+  locale_id   TINYINT UNSIGNED NOT NULL,
+  text        TEXT NOT NULL,
+  PRIMARY KEY (string_id, locale_id)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"tools": {
+  "db_cleanup_interval_hours": 24,
+  "player_dump_format_version": 1,
+  "default_server_locale": "fr_FR"
+}
+```
+
+### Tests
+
+- `PlayerDumpTests.cpp` — round-trip dump/restore.
+- `DbCleanerTests.cpp` — scan détecte orphelins synthétiques.
+- `FormulasTests.cpp` — quelques cas : XP normal, level penalty.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- Outils offline : uniquement sous `/tools` (`tools/player_migration/`)
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. PlayerDump format
+
+JSON (ou JSONL) human-readable :
+
+```json
+{
+  "version": 1,
+  "exported_at": "2026-05-07T12:34:56Z",
+  "character": { "id": 123, "name": "Toto", "level": 10, "x": ..., "y": ..., "z": ... },
+  "items": [ { "guid": ..., "entry": ..., "slot": ..., "count": ... }, ... ],
+  "quest_status": [ ... ],
+  "spells_known": [ ... ],
+  "social": { "friends": [...], "ignored": [...] },
+  "reputation": [ ... ],
+  "money": 12345
+}
+```
+
+Restore = transactional : tout-ou-rien. En cas de conflit (charId déjà
+présent), reject + log.
+
+### 2. CharacterDatabaseCleaner
+
+Detecting orphans :
+
+- `mail_items` row sans `mail` correspondant.
+- `character_inventory` row pointant vers un `item_instance` qui n'existe pas.
+- `quest_status` pour un `character_id` supprimé.
+
+Tâche async via SqlDelayThread (CMANGOS.13). Cron quotidien.
+
+### 3. Formulas centralisé
+
+**Pas** de magic numbers dispersés. Tout dans un header lu par toutes
+les couches. Un changement d'équilibrage = 1 fichier modifié.
+
+### 4. ServerLanguage
+
+Pour les broadcasts type :
+- "Le serveur va redémarrer dans 5 minutes" → multi-locale.
+- Messages d'erreur GM commands en français.
+- Messages système (welcome, MOTD).
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/tools/`.
+2. Implémenter `PlayerDump` (export/import).
+3. Implémenter `CharacterDatabaseCleaner` (cron).
+4. Créer `Formulas.h`.
+5. Migration DB `server_string` + impl `ServerLanguage`.
+6. Créer `tools/player_migration/`.
+7. Tests : 3 fichiers.
+8. Doc : section « Admin tools » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + outil player_migration)
+- [ ] Tests passent
+- [ ] Smoke test : dump perso → restore sur DB séparée → contenu identique
+- [ ] Cleaner détecte orphelins synthétiques + delete
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé (sauf `/tools/player_migration/`)
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Dump format versioning** : inclure version dans le JSON. Restore refuse les versions inconnues avec un message clair.
+- **Item GUID conflict** : à la restore, soit re-issuer de nouveaux GUIDs (sécurisé), soit utiliser les GUIDs originaux (cohérent mais conflit possible). Choisir : **re-issue** par défaut.
+- **Cleaner timing** : pas pendant peak hours. Cron à 4h du matin UTC.
+- **ServerLanguage vs LocaleStrings** : les 2 patterns coexistent. Choisir clairement : LocaleStrings pour les noms d'items/PNJ, ServerLanguage pour les broadcasts/GM messages. Documenter.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Tools (P3 cross)
+- cmangos `src/game/Tools/PlayerDump.cpp`,
+  `CharacterDatabaseCleaner.cpp`, `Formulas.h`, `Language.h`

--- a/tickets/CMANGOS/CMANGOS.41_Util_bytebuffer_pcqueue_trackable.md
+++ b/tickets/CMANGOS/CMANGOS.41_Util_bytebuffer_pcqueue_trackable.md
@@ -1,0 +1,158 @@
+# CMANGOS.41_Util_bytebuffer_pcqueue_trackable
+
+## Objectif
+
+Mettre en place 3 utilitaires C++ inspirés de `src/shared/Util` cmangos :
+
+1. **`ByteBuffer`** : sérialisation packet ergonomique avec
+   `operator<<` / `operator>>` typés, position read/write séparées,
+   gestion bit-level. Si nos sérialisations actuelles utilisent
+   `memcpy` brut, c'est un upgrade ergonomique majeur.
+2. **`ProducerConsumerQueue<T>`** : queue thread-safe générique avec
+   `WaitAndPop` (condition variable). Réutilisable pour file de logs
+   async, file de tasks DB, message bus interne.
+3. **`UniqueTrackablePtr`** : smart pointer avec compteur de
+   références faibles (sans coût atomique d'un `shared_ptr`). Utile
+   pour tracker des entités du monde sans cycle.
+
+C'est un **P3 cross**.
+
+## Dépendances
+
+- M00.1 (build base)
+
+## Livrables
+
+### Couche partagée (`engine/core/util/`)
+
+- `ByteBuffer.{h,cpp}` :
+  ```cpp
+  class ByteBuffer {
+  public:
+    ByteBuffer();
+    explicit ByteBuffer(size_t reserve);
+
+    // Write
+    template <typename T> ByteBuffer& operator<<(T value);
+    ByteBuffer& operator<<(std::string_view s);
+    void WriteBit(bool b);
+    void FlushBits();
+
+    // Read
+    template <typename T> ByteBuffer& operator>>(T& value);
+    bool ReadBit();
+    std::string ReadString();
+
+    // Positions
+    size_t WritePos() const;
+    size_t ReadPos() const;
+    void SeekRead(size_t pos);
+    std::span<const uint8_t> Data() const;
+    bool HasError() const;            // overflow read
+  };
+  ```
+- `ProducerConsumerQueue.{h,cpp}` (templated header-only) :
+  ```cpp
+  template <class T>
+  class ProducerConsumerQueue {
+  public:
+    void Push(T item);
+    bool TryPop(T& out);
+    bool WaitAndPop(T& out, std::chrono::milliseconds timeout = ...);
+    void Cancel();    // unblock all WaitAndPop
+    size_t Size() const;
+  private:
+    std::mutex m_mtx;
+    std::condition_variable m_cv;
+    std::deque<T> m_q;
+    bool m_cancelled = false;
+  };
+  ```
+- `UniqueTrackablePtr.{h,cpp}` (templated) :
+  ```cpp
+  template <class T>
+  class TrackerRef {
+  public:
+    T* Get() const;            // nullptr si target détruit
+    explicit operator bool() const;
+  };
+  template <class T>
+  class UniqueTrackablePtr {
+  public:
+    explicit UniqueTrackablePtr(T* obj);
+    ~UniqueTrackablePtr();
+    TrackerRef<T> Track() const;
+    T* Get() const;
+  };
+  ```
+
+### Tests
+
+- `ByteBufferTests.cpp` — round-trip read/write de tous les types ;
+  bit-level write/read aligné ; détection overflow.
+- `ProducerConsumerQueueTests.cpp` — N producers + M consumers, pas de
+  perte de message ; cancel libère les waiters.
+- `UniqueTrackablePtrTests.cpp` — Tracker reste valide tant que owner
+  vit, devient null après destruction.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. ByteBuffer endianness
+
+Little-endian sur le wire (cohérence avec la couche réseau actuelle).
+Wrapper sur `std::vector<uint8_t>`. Ne pas utiliser `memcpy` direct côté
+appelant ; passer par `<<`.
+
+### 2. Bit-level
+
+Utile pour les flags compactés (cmangos l'utilise pour les masques de
+mouvement). Les bits sont accumulés dans un buffer interne de 8 bits ;
+`FlushBits` pad à octet entier.
+
+### 3. UniqueTrackablePtr design
+
+Inspiré de cmangos : un `Tracker` partagé entre l'owner et les
+TrackerRef. À la destruction de l'owner, le Tracker est marqué "expired".
+Coût : 1 ptr + 1 atomic bool, vs `shared_ptr<weak_ptr>` 2 atomics +
+control block.
+
+Cas d'usage : un `Spell` cible un `Unit`. Si l'`Unit` meurt avant que le
+sort se résolve, le `TrackerRef<Unit>` retourne nullptr — on évite le
+crash.
+
+## Étapes d'implémentation
+
+1. Créer `engine/core/util/`.
+2. Implémenter `ByteBuffer` + tests.
+3. Implémenter `ProducerConsumerQueue` + tests.
+4. Implémenter `UniqueTrackablePtr` + tests.
+5. Migrer 2-3 sites existants pour utiliser `ByteBuffer` au lieu de `memcpy` pur (si applicable).
+6. Doc : section « Util » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master + shard + client)
+- [ ] Tous les tests passent
+- [ ] Smoke test ProducerConsumerQueue : 4 producteurs × 100 messages, 2 consommateurs reçoivent les 400 sans perte
+- [ ] UniqueTrackablePtr : owner détruit → tracker = nullptr
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **ByteBuffer overflow** : un read au-delà du buffer doit retourner false / set flag d'erreur, pas crash. Toujours vérifier `HasError()` après une séquence de reads sur du data externe.
+- **Bit-level alignment** : ne jamais mélanger reads/writes octet et bit dans la même séquence sans `FlushBits` explicite. Confusion garantie sinon.
+- **PCQueue contention** : si beaucoup de consommateurs, un seul mutex peut goulotter. Pour les hot paths (>10k push/s), considérer une lock-free queue (moodycamel::ConcurrentQueue) — mais commencer simple.
+- **TrackablePtr cycles** : pas de cycles possibles par construction (le tracker est unidirectionnel owner → trackers). Pas de leak.
+- **Performance Track()** : `Track()` est O(1) mais fait un atomic load. Ne pas tracker dans une boucle hot — caches le tracker.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Util (P3 cross)
+- cmangos `src/shared/Util/ByteBuffer.h`,
+  `ProducerConsumerQueue.h`, `UniqueTrackablePtr.h`

--- a/tickets/CMANGOS/CMANGOS.42_Weather_markov_zones_authoritative.md
+++ b/tickets/CMANGOS/CMANGOS.42_Weather_markov_zones_authoritative.md
@@ -1,0 +1,166 @@
+# CMANGOS.42_Weather_markov_zones_authoritative
+
+## Objectif
+
+Mettre en place un **système météo par zone** côté shard LCDLLN,
+inspiré de `src/game/Weather` cmangos. Quatre piliers :
+
+1. **Markov chain par zone** : table `game_weather` (zone, season, type,
+   chance) → chaque tick rotation aléatoire pondérée. Très peu de code,
+   beaucoup d'ambiance.
+2. **Server-authoritative** : le serveur décide, broadcast à tous les
+   clients de la zone → cohérence multi-joueurs ("regarde la pluie
+   là-bas"). Crucial vs météo client-locale.
+3. **Update lazy** : pas de tick haute fréquence, juste un timer 10min
+   par zone occupée, désactivé si zone vide.
+4. **Transition douce** : `grade` de 0.0 à 1.0 envoyé au client pour
+   fade in/out, pas de cuts brutaux.
+
+C'est un **P3 shard**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.13 (Database)
+- CMANGOS.03 (Grids — connaitre quelles zones sont occupées)
+
+## Livrables
+
+### Côté shard (`engine/server/shard/weather/`)
+
+- `WeatherType.h` — enum :
+  ```cpp
+  enum class WeatherType : uint8 {
+    Fine,         // beau temps
+    LightRain,
+    HeavyRain,
+    Snow,
+    Storm,
+    Fog,
+    BlackSnow,    // contenu thématique LCDLLN
+  };
+  ```
+- `WeatherTransition.h` :
+  ```cpp
+  struct WeatherTransition {
+    uint32_t zoneId;
+    WeatherType from;
+    WeatherType to;
+    float chance;
+  };
+  ```
+- `WeatherMgr.{h,cpp}` :
+  - `Load(ConnectionPool&)` — charge les transitions.
+  - `Update(int64_t nowMs)` — pour chaque zone occupée, ticke (10min) et tire la prochaine météo.
+  - `WeatherType GetCurrent(uint32_t zoneId)`
+  - `void OnZoneEnter(Player&, uint32_t zoneId)` — push état actuel au joueur.
+
+### Migration DB
+
+```sql
+CREATE TABLE game_weather (
+  zone_id     INT UNSIGNED NOT NULL,
+  season      TINYINT UNSIGNED NOT NULL DEFAULT 0,    -- 0=any, 1=spring, 2=summer, 3=autumn, 4=winter
+  from_type   TINYINT UNSIGNED NOT NULL,
+  to_type     TINYINT UNSIGNED NOT NULL,
+  chance      FLOAT NOT NULL,
+  PRIMARY KEY (zone_id, season, from_type, to_type)
+);
+```
+
+### Configuration (`config.json`)
+
+```json
+"weather": {
+  "enabled": true,
+  "tick_interval_min": 10,
+  "transition_grade_seconds": 30,
+  "default_season": 0,
+  "skip_unoccupied_zones": true
+}
+```
+
+### Tests
+
+- `WeatherMgrTests.cpp` — markov : 1000 tirages avec table simple → fréquences ~ chances config.
+- `WeatherTransitionTests.cpp` — joueur entre zone X → reçoit weather actuel ; tick → broadcast nouveau weather.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Markov chain
+
+Pour chaque zone, transitions probabilistes :
+
+```
+zone Stormwind, summer:
+  from Fine → to LightRain  (chance 30%)
+  from Fine → to Fine       (chance 70%)
+  from LightRain → to Fine  (chance 50%)
+  from LightRain → to HeavyRain (chance 20%)
+  from LightRain → to LightRain (chance 30%)
+```
+
+Tick : chaque 10min, on regarde l'état actuel + on tire selon
+`game_weather` filtrée par `from_type`.
+
+### 2. Server-authoritative broadcast
+
+```cpp
+// changement de weather dans zone X
+auto* msg = BuildSMSGWeather(zoneId, newWeather, grade);
+g_grids.MessageDistDeliverer(msg, /*for all players in zone*/);
+```
+
+### 3. Transition douce
+
+À chaque changement, `grade` part de 0.0 et augmente vers 1.0 sur
+`transition_grade_seconds`. Le client interpole l'effet visuel
+(densité de pluie, opacité brouillard).
+
+```cpp
+// Tick :
+float grade = std::min(1.0f, (now - transitionStartTs) / transitionGradeSec);
+if (grade > lastSentGrade + 0.1f) {
+  Broadcast(grade);   // pas trop de paquets
+  lastSentGrade = grade;
+}
+```
+
+## Étapes d'implémentation
+
+1. Créer `engine/server/shard/weather/`.
+2. Migration DB.
+3. Implémenter `WeatherMgr::Load` + tick.
+4. Allouer opcode `kOpcodeWeatherUpdate`.
+5. Câbler `Player::OnZoneEnter` → push current state.
+6. Implémenter transition douce.
+7. Tests : 2 fichiers.
+8. Doc : section « Weather shard » dans `CODEBASE_MAP.md`.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (shard)
+- [ ] Tests passent
+- [ ] Smoke test : Stormwind avec table `Fine 70% / LightRain 30%` → après 100 ticks, ratio observé proche
+- [ ] Joueur entre zone → reçoit weather actuel
+- [ ] Transition de Fine → LightRain envoyée avec grade animé sur 30s
+- [ ] Migrations idempotentes
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Zones inoccupées** : `skip_unoccupied_zones = true` → pas de tick si personne dedans. Le state est figé. À l'entrée d'un joueur, soit on accepte le state vieux, soit on retick une fois.
+- **Cohérence cross-shard** : même zone sur 2 shards → météo différente possible. Pas grave (zones distinctes par instance map).
+- **Pas trop de variétés** : 5-7 types de weather suffit. Au-delà, table complexe à équilibrer.
+- **Saisons** : `season` permet du contenu saisonnier (neige en hiver). Si LCDLLN n'a pas de cycle saisonnier, ignorer (toujours `season=0`).
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Weather (P3 shard)
+- cmangos `src/game/Weather/Weather.cpp`, `WeatherMgr.cpp`

--- a/tickets/CMANGOS/CMANGOS.44_AuctionHouseBot_internal_client_low_pop.md
+++ b/tickets/CMANGOS/CMANGOS.44_AuctionHouseBot_internal_client_low_pop.md
@@ -1,0 +1,116 @@
+# CMANGOS.44_AuctionHouseBot_internal_client_low_pop
+
+## Objectif
+
+Mettre en place un **bot interne** alimentant l'hôtel des ventes en
+items/enchères pour simuler une économie active sur serveur low-pop.
+Inspiré de `src/game/AuctionHouseBot` cmangos.
+
+**À activer uniquement si la pop tombe trop bas** pour avoir un HV
+organique. Sinon ignorer.
+
+C'est un **P4 master**.
+
+## Dépendances
+
+- M00.1 (build base)
+- CMANGOS.09 (AuctionHouse)
+- CMANGOS.13 (Database)
+
+## Livrables
+
+### Côté master (`engine/server/auction/bot/`)
+
+- `AuctionHouseBot.{h,cpp}` :
+  - `Run()` — démarré au boot si activé. Tick périodique :
+    - Maintenir N enchères actives par HV, par catégorie d'item.
+    - Si trop peu : poster de nouvelles enchères avec items aléatoires
+      (tirés selon rareté config) et prix simulés.
+    - Périodiquement, "acheter" des enchères organiques (prix
+      raisonnable) pour donner l'illusion de transactions.
+- `AuctionBotConfig.{h,cpp}` — config externe :
+  ```
+  [auction_house_bot]
+  enabled = false
+  target_active_auctions_per_house = 100
+  category_weights_armor = 25
+  category_weights_weapon = 20
+  ...
+  ```
+
+### Configuration (`config.json`)
+
+```json
+"auction_bot": {
+  "enabled": false,
+  "target_active_auctions_per_house": 100,
+  "post_interval_min": 30,
+  "buy_interval_min": 60,
+  "max_post_per_tick": 5,
+  "price_variance_pct": 20
+}
+```
+
+### Tests
+
+- `AuctionBotTests.cpp` — start, génération d'enchères, achat simulé.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### 1. Bot = client interne via opcodes
+
+**Pas** d'écriture DB directe. Le bot envoie les **mêmes opcodes** que
+les vrais joueurs (`kOpcodeAhPostAuction`, `kOpcodeAhBidAuction`). Toute
+correction de bug HV s'applique aussi au bot, et la prod stress-test
+le code en permanence.
+
+### 2. Tirage pondéré par rareté
+
+```
+quality   weight    price_min    price_max
+common    50        1g           5g
+uncommon  30        5g           20g
+rare      15        20g          200g
+epic      4         200g         5000g
+legendary 1         5000g        100000g
+```
+
+Tirage selon `weight`. Génération d'un prix aléatoire dans `[min, max]`.
+
+### 3. Désactivation par défaut
+
+`enabled = false`. À activer manuellement seulement.
+
+## Étapes d'implémentation
+
+1. (Décision GO) Créer `engine/server/auction/bot/`.
+2. Implémenter `AuctionHouseBot`.
+3. Câbler avec `AuctionHouseManager` (CMANGOS.09).
+4. Tests.
+5. Doc.
+
+## Definition of Done (DoD)
+
+- [ ] Build Linux OK (master)
+- [ ] Tests passent
+- [ ] Smoke test : `enabled=true` → 100 enchères actives apparaissent en HV en quelques minutes
+- [ ] Désactivation via config = no-op
+- [ ] Aucun dossier racine non autorisé
+- [ ] Rapport final
+
+## Notes / pièges à éviter
+
+- **Économie inflatée** : si bot post sans cesse, prix montent. Calibrer pour qu'il **achète** aussi (vide les enchères vieilles) pour stabiliser.
+- **Items uniques** : ne pas générer 100× le même item legendary, ça casse la rareté perçue. Anti-spam par item entry.
+- **Bot detection** : un joueur avancé peut détecter les patterns (toujours même posteur via `auction.owner`). Soit créer plusieurs comptes "bots", soit accepter la transparence.
+- **Décision activation** : ne pas activer en alpha/beta. Production avec pop < 50 joueurs en ligne après 1 mois → considérer.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § AuctionHouseBot (P4 master)
+- cmangos `src/game/AuctionHouseBot/AuctionHouseBot.cpp`

--- a/tickets/CMANGOS/CMANGOS.45_Auth_srp6_zero_knowledge_optional.md
+++ b/tickets/CMANGOS/CMANGOS.45_Auth_srp6_zero_knowledge_optional.md
@@ -1,0 +1,118 @@
+# CMANGOS.45_Auth_srp6_zero_knowledge_optional
+
+## Objectif
+
+Documenter et **réserver le design** d'un éventuel passage à un
+protocole d'authentification **zero-knowledge** type SRP6, inspiré de
+`src/shared/Auth` cmangos. **Pas une implémentation immédiate** — ce
+ticket sert de référence si LCDLLN décide un jour de quitter le
+mot-de-passe-hashé-en-base actuel pour un protocole où le mot de passe
+ne transite **jamais** sur le wire.
+
+C'est un **P4 master**, marginal. À ne réaliser que si une raison
+spécifique le justifie (audit sécurité, exigence régulation, etc.).
+
+## Dépendances
+
+- M00.1 (build base)
+- AccountStore (existant)
+- OpenSSL (déjà disponible)
+
+## Livrables (si décision GO)
+
+### Côté master (`engine/server/auth/srp6/`)
+
+- `BigNumber.{h,cpp}` — wrapper RAII autour de `BIGNUM` OpenSSL avec
+  opérateurs surchargés (`+`, `*`, `**=`, etc.).
+- `Srp6.{h,cpp}` — flux SRP-6a complet :
+  - `RegisterFlow` : à la création de compte, calcul de `verifier =
+    g^x mod N` côté client, envoi `(salt, verifier)` au serveur. **Le
+    mot de passe ne transite jamais.**
+  - `LoginFlow` : challenge-response classique SRP-6a (A, B, M1, M2).
+  - À la fin, les 2 partis dérivent une `sessionKey` partagée.
+- `CryptoHash.{h,cpp}` — wrapper SHA-256 streaming.
+- Modification `accounts` table : remplacer `password_hash` par
+  `(salt, verifier)`.
+
+### Migration DB
+
+```sql
+ALTER TABLE accounts
+  ADD COLUMN srp6_salt BLOB,
+  ADD COLUMN srp6_verifier BLOB;
+-- Période de migration : les 2 schémas coexistent ; au login, fallback
+-- sur ancien hash si nouveaux champs absents.
+```
+
+### Tests
+
+- `BigNumberTests.cpp` — opérations modulaires.
+- `Srp6FlowTests.cpp` — register + login round-trip.
+
+## Structure & chemins (verrouillé)
+
+- Code moteur : uniquement sous `/engine`
+- ❌ Interdit : créer un dossier racine non autorisé
+
+## Spécification technique
+
+### Flux register (zero-knowledge)
+
+```
+Client:
+  x = SHA256(salt | username | password)
+  verifier = g^x mod N
+  → envoie (salt, verifier) au serveur
+Serveur:
+  stocke (salt, verifier) en DB. Pas de password!
+```
+
+### Flux login
+
+```
+Client:
+  a = random
+  A = g^a mod N
+  → envoie (username, A) au serveur
+Serveur:
+  récupère (salt, verifier)
+  b = random
+  B = (k*verifier + g^b) mod N
+  → envoie (salt, B) au client
+Client:
+  reçoit B, calcule sessionKey via SRP6 algo
+  M1 = HMAC(sessionKey, ...)
+  → envoie M1 au serveur
+Serveur:
+  vérifie M1, si OK → envoie M2
+  Les 2 ont la même sessionKey, ne s'est jamais transmise.
+```
+
+## Étapes d'implémentation
+
+1. (Décision GO) Créer `engine/server/auth/srp6/`.
+2. Implémenter `BigNumber` + `CryptoHash`.
+3. Implémenter flux register + login.
+4. Migration DB avec coexistence ancien/nouveau hash.
+5. Période de transition : lors d'un login réussi avec ancien hash,
+   demander au client de fournir `(salt, verifier)` puis migrer.
+6. Doc.
+
+## Definition of Done (DoD)
+
+- [ ] Décision GO/NO-GO documentée.
+- [ ] (Si GO) tests passent.
+- [ ] (Si GO) coexistence ancien/nouveau hash fonctionne.
+
+## Notes / pièges à éviter
+
+- **Pas de regret en cas de NO-GO** : le hash en base avec Argon2 (ou bcrypt) actuellement utilisé est **largement** sécurisé. SRP6 répond à des exigences spécifiques (zero-knowledge, MITM resistance avancée).
+- **Coût de migration** : 1000 lignes de code crypto, période de migration utilisateurs. Effort substantiel, gain marginal.
+- **Compat client** : le client actuel envoie probablement `password` au serveur (handshake actuel). Migrer = update client + serveur en lock-step.
+
+## Références
+
+- `CMANGOS_ANALYSIS.md` § Auth (P4 master)
+- cmangos `src/shared/Auth/SRP6/`, `BigNumber.h`,
+  `CryptoHash.h`
+- RFC 5054 : SRP for TLS authentication

--- a/tickets/CMANGOS/CMANGOS.INDEX.md
+++ b/tickets/CMANGOS/CMANGOS.INDEX.md
@@ -1,0 +1,152 @@
+# CMANGOS — Index des tickets
+
+44 tickets issus de l'analyse de cmangos-tbc (`CMANGOS_ANALYSIS.md`).
+Chaque ticket reprend un module/concept de cmangos, **adapté pour
+LCDLLN** (pas de port littéral).
+
+> **Format ticket** : Objectif / Dépendances / Livrables / Spec / Étapes
+> / DoD / Notes — aligné sur la convention `tickets/M44/`.
+
+> **Convention de nommage** : `CMANGOS.NN_<Module>_<keywords>.md`. La
+> numérotation suit l'ordre alphabétique global (49 modules cmangos),
+> avec gaps pour les modules **non ticketés** (5 modules P4 considérés
+> non actionnables).
+
+## Synthèse par priorité
+
+| Priorité | Description | Tickets |
+|---|---|---|
+| **P1** | Squelette & déblocants | 5 |
+| **P2** | Gameplay essentiel | 23 |
+| **P3** | Ajouts à valeur | 14 |
+| **P4** | Cas spécifiques (subset) | 2 |
+| **Skip** | Déjà couvert / non actionnables | 5 |
+| **Total** | — | 44 ticketés / 49 modules |
+
+## P1 — Squelette & déblocants (5 tickets)
+
+| # | Ticket | Cible | Idée principale |
+|---|---|---|---|
+| 01 | [Chat](./CMANGOS.01_Chat_routing_safety_commands_split.md) | cross | `CanSpeak()` + `CheckEscapeSequences` + dispatch table-driven + split master(relay)/shard(proximité). **Déblocant MVP.** |
+| 02 | [Entities](./CMANGOS.02_Entities_hierarchy_objectguid_updatefields.md) | shard | Hiérarchie Object→Unit + ObjectGuid 64 bits + UpdateFields/UpdateMask delta réseau. |
+| 03 | [Grids](./CMANGOS.03_Grids_spatial_partitioning_aoi.md) | shard | Partitionnement spatial 2D + Visitor templated + GridStates + GridNotifiers. Base AoI scalable. |
+| 04 | [Movement](./CMANGOS.04_Movement_server_authoritative_splines.md) | cross | Spline server-authoritative + interpolation client + MoveSplineFlag bitmask. |
+| 05 | [vmap](./CMANGOS.05_vmap_collisions_los_height_dynamictree.md) | shard | LOS + height + tile streaming + BIH/BVH + DynamicTree (portes). |
+
+## P2 — Gameplay essentiel (23 tickets)
+
+| # | Ticket | Cible | Idée principale |
+|---|---|---|---|
+| 06 | [Accounts](./CMANGOS.06_Accounts_roles_security_levels.md) | master | Enum AccountRole 5 niveaux + HasLowerSecurity systématique. **Pré-requis Chat.** |
+| 07 | [AI](./CMANGOS.07_AI_creature_registry_eventai_dbdriven.md) | shard | Registry+Selector pour CreatureAI + EventAI DB-driven. |
+| 08 | [Arena](./CMANGOS.08_Arena_team_mmr_weekly_colisee.md) | master+shard | ArenaTeam persistant + MMR/rating + WeeklyMaintenance. **Spécifique colisée LCDLLN.** |
+| 09 | [AuctionHouse](./CMANGOS.09_AuctionHouse_master_side_tick_mail_delivery.md) | master | Tick global + livraison mail + index RAM + multi-maisons. |
+| 10 | [BattleGround](./CMANGOS.10_BattleGround_framework_instances_score.md) | shard | Framework hiérarchique + score sous-classé + reconnect. |
+| 11 | [Combat](./CMANGOS.11_Combat_threat_hostile_decomposition.md) | shard | Décomposition CombatManager / ThreatManager / HostileRefManager bidirectionnel. |
+| 12 | [Server](./CMANGOS.12_Server_packetlog_opcodetable_dbcstores.md) | cross | PacketLog rejouable + OpcodeRegistry typé. |
+| 13 | [Database](./CMANGOS.13_Database_sqlstorage_async_prepared.md) | cross | SQLStorage cache RAM + SqlDelayThread async + prepared statements. |
+| 14 | [DBScripts](./CMANGOS.14_DBScripts_dsl_data_driven_hot_reload.md) | shard | DSL ~30 commandes + délais + hot-reload. |
+| 15 | [Groups](./CMANGOS.15_Groups_groupref_loot_rules_master.md) | master | GroupReference intrusive + loot rules pluggables + persistance partielle. |
+| 16 | [Globals](./CMANGOS.16_Globals_conditions_objectaccessor_locales.md) | shard | Conditions data-driven + ObjectAccessor + GraveyardManager + Locales. |
+| 17 | [Loot](./CMANGOS.17_Loot_templates_groups_reference.md) | shard | Templates DB génériques + loot groups + reference loot + conditions par drop. |
+| 18 | [Mails](./CMANGOS.18_Mails_master_side_cod_expiration_massmail.md) | master | Schéma mail+items + COD + expiration auto + MassMailMgr. |
+| 19 | [Maps](./CMANGOS.19_Maps_thread_per_map_subclasses_spawngroup.md) | shard | « Map = thread » + sous-classes (Dungeon/BG/World) + SpawnGroup + PersistentState. |
+| 20 | [MotionGenerators](./CMANGOS.20_MotionGenerators_stack_navmesh_waypoints.md) | shard | Stack de générateurs + Detour navmesh + WaypointManager DB. |
+| 21 | [Guilds](./CMANGOS.21_Guilds_schema_permissions_bank.md) | master | Schéma DB + permissions bitmask par rank + banque multi-onglets. |
+| 22 | [Pools](./CMANGOS.22_Pools_weighted_spawns_nested.md) | shard | pool_template + nested pools + sélection pondérée. |
+| 23 | [Quests](./CMANGOS.23_Quests_template_status_objectives_variant.md) | cross | Split QuestTemplate/Status + objectifs hétérogènes via std::variant + flags bitmask. |
+| 24 | [Reputation](./CMANGOS.24_Reputation_faction_template_matrix.md) | shard | Faction template matrix + bitmask flags + paliers calculés + spillover parent. |
+| 25 | [Social](./CMANGOS.25_Social_friends_ignored_presence.md) | master | FriendsManager + broadcast présence + ignored filtré expéditeur. |
+| 26 | [Spells](./CMANGOS.26_Spells_split_template_aura_proc.md) | shard | Split Spell/Template/Aura/Proc + state machine cast + targeting matrix. |
+| 27 | [Trade](./CMANGOS.27_Trade_two_phase_commit_anti_scam.md) | master | 2-phase commit + revérification serveur + timer anti-scam 6s. |
+| 28 | [World](./CMANGOS.28_World_state_expression_dsl.md) | shard | WorldStateExpression mini-DSL conditions data-driven. |
+
+## P3 — Ajouts à valeur (14 tickets)
+
+| # | Ticket | Cible | Idée principale |
+|---|---|---|---|
+| 29 | [Anticheat](./CMANGOS.29_Anticheat_plugin_interface_position_deltas.md) | shard | Interface IServerSideValidator + validation deltas position. |
+| 30 | [Cinematics](./CMANGOS.30_Cinematics_trigger_opcode_camera_validation.md) | cross | Trigger opcode + asset client-side + parsing serveur anticheat. |
+| 31 | [GameEvents](./CMANGOS.31_GameEvents_seasonal_scheduler_cascading.md) | shard | Activation par event_id + scheduler central + events cascade. |
+| 32 | [GMTickets](./CMANGOS.32_GMTickets_support_in_game.md) | master | Ticket = row DB + handler/Mgr séparés. |
+| 33 | [LFG](./CMANGOS.33_LFG_queue_role_matchmaking.md) | master | Queue séparée du Mgr + matching par rôles + state machine joueur. |
+| 34 | [Metric](./CMANGOS.34_Metric_influxdb_measurement_raii.md) | cross | InfluxDB line-protocol + Measurement RAII + flush async. |
+| 35 | [Multithreading](./CMANGOS.35_Multithreading_messager_swap_execute.md) | cross | Pattern Messager (queue cross-thread, swap-and-execute). |
+| 36 | [OutdoorPvP](./CMANGOS.36_OutdoorPvP_zone_plugins_objectives.md) | shard | Manager+ZonePlugin polymorphe + state machine par objectif. |
+| 37 | [Platform](./CMANGOS.37_Platform_crash_dump_windows_client.md) | client | WheatyExceptionReport adapté pour crash dumps client Windows. |
+| 38 | [PlayerBot](./CMANGOS.38_PlayerBot_headless_session_load_test.md) | shard | WorldSession headless via opcodes (load testing). |
+| 39 | [Skills](./CMANGOS.39_Skills_craft_discovery_extra_item_proc.md) | shard | Hooks data-driven post-action (discovery, extra item). |
+| 40 | [Tools](./CMANGOS.40_Tools_playerdump_cleaner_formulas_language.md) | cross | PlayerDump migration + Cleaner DB + Formulas + ServerLanguage. |
+| 41 | [Util](./CMANGOS.41_Util_bytebuffer_pcqueue_trackable.md) | cross | ByteBuffer typé + ProducerConsumerQueue + UniqueTrackablePtr. |
+| 42 | [Weather](./CMANGOS.42_Weather_markov_zones_authoritative.md) | shard | Markov chain par zone + server-authoritative + transition douce. |
+
+## P4 — Cas spécifiques (2 tickets)
+
+| # | Ticket | Cible | Idée principale |
+|---|---|---|---|
+| 44 | [AuctionHouseBot](./CMANGOS.44_AuctionHouseBot_internal_client_low_pop.md) | master | Bot interne via opcodes pour low-pop. **Conditionnel.** |
+| 45 | [Auth](./CMANGOS.45_Auth_srp6_zero_knowledge_optional.md) | master | SRP6 zero-knowledge en remplacement du hash actuel. **Optionnel.** |
+
+## Modules non ticketés (5)
+
+Ces modules n'ont pas généré de ticket car déjà couverts ou très
+spécifiques :
+
+| Module | Source cmangos | Pourquoi pas de ticket |
+|---|---|---|
+| Addons | game/Addons | Pattern « version handshake » déjà couvert par `kProtocolVersion`. À reconsidérer si addons UI client deviennent scriptables. |
+| Auth (déjà couvert) | shared/Auth | Voir CMANGOS.45 (optional). Le hash actuel suffit. |
+| Config | shared/Config | Stack JSON+CLI hiérarchique déjà strictement plus expressive que INI cmangos. |
+| Log | shared/Log | Déjà couvert par PR #468 (filtres, fichiers spécialisés, GM per-account, packet dump, couleurs). |
+| Network | shared/Network | NetServer epoll TCP custom déjà mieux adapté aux opcodes binaires Linux que Boost.Asio cmangos. |
+| VoiceChat | game/VoiceChat | Stub TBC vide — à intégrer via service externe (LiveKit, Mumble) plutôt que master/shard. |
+
+## Ordre d'implémentation suggéré
+
+L'ordre suit les **dépendances** déclarées dans chaque ticket. Voici le
+chemin minimal pour aller du squelette aux features visibles joueur :
+
+```
+01 Chat (déblocant MVP, bypass dépendances strictes)
+06 Accounts (pré-requis Chat dispatch)
+13 Database (SQLStorage, utilisé partout)
+12 Server (PacketLog, OpcodeRegistry)
+02 Entities (squelette WorldObject)
+03 Grids (AoI base)
+04 Movement (splines)
+05 vmap (LOS)
+19 Maps (« Map = thread »)
+20 MotionGenerators (mouvement IA)
+07 AI (premier PNJ scripté)
+11 Combat (premier PNJ hostile)
+22 Pools (spawns)
+17 Loot (drops)
+16 Globals (Conditions)
+14 DBScripts (contenu narratif)
+26 Spells (gameplay magique)
+23 Quests (contenu narratif joueur)
+24 Reputation (factions)
+28 World (DSL conditions)
+... (puis le reste selon priorités du moment)
+```
+
+## Convention de DoD
+
+Tous les tickets héritent de `tickets/DEFINITION_OF_DONE.md` :
+
+- Build OK (configure + build) via presets
+- Aucun dossier racine non autorisé
+- Aucun chemin absolu hardcodé
+- Tout chemin de contenu via `paths.content`
+- Tests + smoke test
+- Migrations DB idempotentes (où applicable)
+- Rapport final : fichiers modifiés + commandes + résultats
+
+## Mises à jour
+
+Quand un ticket est commencé / terminé / annulé, mettre à jour cet
+INDEX avec un statut visible (✅ ⌛ ❌) en début de ligne.
+
+---
+
+*Index généré le 2026-05-07 — basé sur `CMANGOS_ANALYSIS.md`.*


### PR DESCRIPTION
## Résumé

44 tickets détaillés issus de l'analyse cmangos (`CMANGOS_ANALYSIS.md`), créés via flow Q&R interactif sur les 49 modules. Chaque ticket reprend un module/concept de cmangos-tbc, **adapté pour LCDLLN** (pas de port littéral).

## Contenu

### Par priorité

| Priorité | Description | Tickets |
|---|---|---|
| **P1** | Squelette & déblocants | 5 |
| **P2** | Gameplay essentiel | 23 |
| **P3** | Ajouts à valeur | 14 |
| **P4** | Cas spécifiques (subset) | 2 |
| **Skip** | Déjà couvert / non actionnables | 5 |
| **Total** | — | **44 ticketés / 49 modules** |

### P1 (déblocants)
Chat, Entities, Grids, Movement, vmap.

### P2 (gameplay essentiel)
Accounts, AI, Arena, AuctionHouse, BattleGround, Combat, Database, DBScripts, Globals, Groups, Guilds, Loot, Mails, Maps, MotionGenerators, Pools, Quests, Reputation, Server, Social, Spells, Trade, World.

### P3 (ajouts à valeur)
Anticheat, Cinematics, GameEvents, GMTickets, LFG, Metric, Multithreading, OutdoorPvP, Platform, PlayerBot, Skills, Tools, Util, Weather.

### P4 (cas spécifiques)
AuctionHouseBot (low-pop conditional), Auth (SRP6 zero-knowledge optionnel).

### Non ticketés (5)
Addons, Config, Log (PR #468), Network, VoiceChat — déjà couverts ou non actionnables.

## Format ticket

Aligné sur convention `tickets/M44/` :
- Objectif
- Dépendances
- Livrables (code + DB migrations + tests + config)
- Spécification technique
- Étapes d'implémentation
- Definition of Done (DoD)
- Notes / pièges à éviter
- Références

Chaque ticket inclut **dépendances explicites** vers d'autres tickets CMANGOS — permet de tracer l'ordre d'implémentation.

## Index

`CMANGOS.INDEX.md` à la racine du dossier récapitule :
- Synthèse par priorité
- Table de tous les tickets avec lien direct
- Liste des modules non ticketés (avec raison)
- Ordre d'implémentation suggéré (chemin minimal squelette → features visibles)
- Convention DoD partagée

## Déploiement

> **Déploiement** : ✅ aucune modification de code — tickets documentaires uniquement, pas de redéploiement serveur.

## Test plan

- [ ] Vérifier que les 44 tickets se chargent dans l'UI GitHub sans erreur de markdown
- [ ] Vérifier les liens internes dans l'INDEX (44 fichiers `CMANGOS.NN_*.md`)
- [ ] Confirmer que la convention DoD existante est respectée

https://claude.ai/code/session_015eo9wyXRCUt18E7otnrx6X

---
_Generated by [Claude Code](https://claude.ai/code/session_015eo9wyXRCUt18E7otnrx6X)_