### PR TITLE
Phase 2 CMANGOS.01 sub-PR 1 : Chat hardening (Sanitizer + Gate)

### DIFF
--- a/config.json
+++ b/config.json
@@ -195,5 +195,17 @@
     "accounts": {
         "default_new_account_role": "player",
         "role_change_audit": true
+    },
+    "chat": {
+        "_comment": "Phase 2 CMANGOS.01 — sanitizer + gate cote master. sanitizer.max_message_bytes : limite UTF-8 safe (cf. ChatSanitizer). gate.flood_window_ms / flood_max_messages : sliding window anti-flood par account. gate.max_tracked_accounts : cap soft de la table interne (0 = illimite). Toutes les cles sont relues au boot du master uniquement.",
+        "sanitizer": {
+            "max_message_bytes": 255,
+            "strip_zero_width": true
+        },
+        "gate": {
+            "flood_window_ms": 5000,
+            "flood_max_messages": 5,
+            "max_tracked_accounts": 4096
+        }
     }
 }

--- a/db/migrations/0044_chat_mutes.sql
+++ b/db/migrations/0044_chat_mutes.sql
@@ -1,0 +1,11 @@
+-- 0044 — Phase 2 CMANGOS.01 Chat (sub-PR 1) : table chat_mutes pour
+-- ChatGate. Un compte peut être muté jusqu'à `until_ts` (epoch ms UTC),
+-- avec une raison libre (audit). Idempotent.
+
+CREATE TABLE IF NOT EXISTS chat_mutes (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  until_ts    BIGINT NOT NULL,           -- epoch ms UTC ; 0 = mute permanent
+  reason      VARCHAR(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (account_id),
+  KEY ix_chat_mutes_until (until_ts)
+);

--- a/docs/db_sql_guidelines.md
+++ b/docs/db_sql_guidelines.md
@@ -214,3 +214,75 @@ qui force `RequireMinRole` à retourner `true` quel que soit le min.
 `Console` n'est **jamais** stocké en DB. Si une ligne y est trouvée
 (corruption), le store doit la rejeter au load avec un warning et la
 traiter comme `Player`.
+
+## Phase 2.01a — Chat sanitizer + gate (CMANGOS.01 sub-PR 1)
+
+Couche de validation côté master, en série avant tout routage par
+`ChatRelayHandler`. Pas de wire-breaking : le protocole n'a pas
+changé, seuls les rejets côté serveur sont nouveaux.
+
+### `ChatSanitizer` — pure function
+
+`engine/server/chat/ChatSanitizer.h`. Étapes en série :
+
+1. Reject si vide → `"empty"`.
+2. UTF-8 safe truncation à `cfg.maxMessageBytes` (défaut 255). Ne coupe
+   **jamais** au milieu d'un codepoint multi-byte. Recule depuis
+   `maxBytes` jusqu'au premier byte non-continuation (`& 0xC0 != 0x80`).
+3. Strip zero-width characters si `cfg.stripZeroWidth` :
+   `U+200B..U+200F`, `U+FEFF`, `U+202A..U+202E`. Re-encode en UTF-8 sans
+   les codepoints filtrés.
+4. Reject si hyperlink `|H<type>:...|h<text>|h` avec `<type>` hors
+   whitelist `{item, quest, achievement, spell}` → `"hyperlink_blocked"`.
+   Hyperlink mal formé (pas de `:` après `|H`) aussi rejeté.
+5. Reject si post-strip le texte est vide → `"post_strip_empty"`.
+
+Aucune dépendance externe (DB, pool, réseau) : thread-safe par nature,
+appelable depuis n'importe quel thread.
+
+### `ChatGate` — décision ban/mute/anti-flood
+
+`engine/server/chat/ChatGate.h`. Trois rejets possibles, ordre de
+priorité descendant :
+
+| Décision | Source | Action côté client |
+|---|---|---|
+| `Banned` | `AccountStore.FindByAccountId().status == Locked` | silencieux (court-circuit) |
+| `Muted` | table `chat_mutes` (PK `account_id`, `until_ts ms UTC`) | notice "Server" + raison |
+| `Flooding` | sliding window RAM (default 5 msg / 5s) | notice "Slow down" |
+
+**API publique** :
+- `Decide(accountId, nowMs)` : check pur, sans mutation. Pour preview.
+- `DecideAndRecord(accountId, nowMs)` : check + record atomique. C'est
+  l'API pour le hot path.
+- `WireProduction(pool, accounts)` : câble les callbacks SQL+Store en
+  prod (un seul appel au boot dans `main_server_linux.cpp`).
+
+**Tuning** dans `ChatGateConfig` : `floodWindowMs`, `floodMaxMessages`,
+`maxTrackedAccounts` (cap soft pour la mémoire).
+
+### Table `chat_mutes`
+
+```sql
+CREATE TABLE IF NOT EXISTS chat_mutes (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  until_ts    BIGINT NOT NULL,           -- 0 = permanent
+  reason      VARCHAR(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (account_id),
+  KEY ix_chat_mutes_until (until_ts)
+);
+```
+
+Migration `0044_chat_mutes.sql`. Idempotente. Insertion d'un mute :
+```sql
+REPLACE INTO chat_mutes (account_id, until_ts, reason) VALUES (?, ?, ?);
+```
+
+`until_ts = 0` = mute permanent (jamais expiré). Sinon epoch ms UTC.
+
+### Intégration
+
+`ChatRelayHandler::HandlePacket` appelle `Sanitize` puis `Gate` avant
+tout routage de canal (Say/Whisper/Guild/Friends/...). Le sanitizer
+opère sur `parsed->text` ; le gate utilise `*accountId`. Les notices
+"Server" muted/flooding ne sont visibles que par l'expéditeur.

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -100,6 +100,8 @@ elseif(UNIX)
     CharacterEnterWorldHandler.cpp
     SessionCharacterMap.cpp
     ChatRelayHandler.cpp
+    chat/ChatSanitizer.cpp
+    chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp
@@ -245,6 +247,31 @@ elseif(UNIX)
   target_link_libraries(locale_strings_tests PRIVATE engine_core ${MYSQL_LIBRARY} pthread)
   target_compile_options(locale_strings_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME locale_strings_tests COMMAND locale_strings_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # CMANGOS.01 (Phase 2.01a) : ChatSanitizer pure unit tests (no DB)
+  add_executable(chat_sanitizer_tests
+    chat/ChatSanitizerTests.cpp
+    chat/ChatSanitizer.cpp
+  )
+  target_include_directories(chat_sanitizer_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(chat_sanitizer_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(chat_sanitizer_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME chat_sanitizer_tests COMMAND chat_sanitizer_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # CMANGOS.01 (Phase 2.01a) : ChatGate tests (mock callbacks ; pas de
+  # DB ni d'AccountStore réel — ChatGate.cpp embarque les helpers SQL et
+  # AccountStore-banned mais les tests injectent directement des
+  # std::function. On link MySQL/DbHelpers à cause des helpers compilés.
+  add_executable(chat_gate_tests
+    chat/ChatGateTests.cpp
+    chat/ChatGate.cpp
+    db/ConnectionPool.cpp
+    db/DbHelpers.cpp
+  )
+  target_include_directories(chat_gate_tests PRIVATE ${CMAKE_SOURCE_DIR} ${MYSQL_INCLUDE_DIR})
+  target_link_libraries(chat_gate_tests PRIVATE engine_core spdlog::spdlog ${MYSQL_LIBRARY} pthread)
+  target_compile_options(chat_gate_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME chat_gate_tests COMMAND chat_gate_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M22.4: Shard ticket validation tests
   add_executable(shard_ticket_tests

--- a/engine/server/ChatRelayHandler.cpp
+++ b/engine/server/ChatRelayHandler.cpp
@@ -44,6 +44,7 @@ namespace engine::server
 	void ChatRelayHandler::SetSessionCharacterMap(SessionCharacterMap* charMap) { m_charMap = charMap; }
 	void ChatRelayHandler::SetAccountStore(AccountStore* accounts)            { m_accounts = accounts; }
 	void ChatRelayHandler::SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_pool = pool; }
+	void ChatRelayHandler::SetSanitizerConfig(const chat::ChatSanitizerConfig& cfg) { m_sanitizerCfg = cfg; }
 
 	void ChatRelayHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize)
@@ -75,6 +76,26 @@ namespace engine::server
 			// doute juste pressé Entrée sans contenu).
 			return;
 		}
+
+		// Phase 2 CMANGOS.01 — Sanitization avant tout routage : UTF-8 safe truncation
+		// (jamais couper au milieu d'un codepoint), strip zero-width chars, hyperlinks
+		// whitelist (item/quest/achievement/spell). Si rejet, on consume silencieusement
+		// (équivalent à "Empty message" — pas d'erreur réseau pour ne pas leaker la
+		// règle exacte au client). Le sanitizer remplace l'ancienne troncature brute
+		// à kMaxChatTextBytes, qui pouvait couper en plein milieu d'un caractère UTF-8.
+		{
+			auto sanitized = chat::Sanitize(parsed->text, m_sanitizerCfg);
+			if (!sanitized.accepted)
+			{
+				LOG_INFO(Net, "[ChatRelayHandler] sanitize rejected reason='{}' text_len={}",
+					sanitized.rejectReason, parsed->text.size());
+				return;
+			}
+			parsed->text = std::move(sanitized.text);
+		}
+		// Garde-fou supplémentaire : si jamais maxMessageBytes était trop laxiste pour
+		// kMaxChatTextBytes (limite wire), on resize encore (UTF-8 safe par construction
+		// puisque le sanitizer a déjà coupé sur frontière).
 		if (parsed->text.size() > kMaxChatTextBytes)
 		{
 			parsed->text.resize(kMaxChatTextBytes);
@@ -95,6 +116,52 @@ namespace engine::server
 			if (!pkt.empty())
 				m_server->Send(connId, pkt);
 			return;
+		}
+
+		// Phase 2 CMANGOS.01 — ChatGate : check ban / mute (DB) / anti-flood (RAM)
+		// avant tout routage. Banned : silencieux (court-circuit, pas d'info au client).
+		// Muted : notice "Server" avec la raison (et l'expiration si non permanente).
+		// Flooding : notice générique "Slow down".
+		{
+			const uint64_t nowMs = NowUnixMsUtc();
+			const auto gateResult = m_gate.DecideAndRecord(*accountId, nowMs);
+			switch (gateResult.decision)
+			{
+				case chat::ChatGateDecision::Banned:
+					LOG_INFO(Net, "[ChatRelayHandler] gate banned account={} text_len={}",
+						*accountId, parsed->text.size());
+					return;
+				case chat::ChatGateDecision::Muted:
+				{
+					std::string body = "You are muted";
+					if (!gateResult.reason.empty())
+						body += " (" + gateResult.reason + ")";
+					if (gateResult.untilTsMs == 0)
+						body += " : permanent.";
+					else
+						body += ".";
+					auto notice = BuildChatRelayPacket(nowMs,
+						static_cast<uint8_t>(engine::net::ChatChannel::Server),
+						"system", body, sessionIdHeader);
+					if (!notice.empty())
+						m_server->Send(connId, notice);
+					LOG_INFO(Net, "[ChatRelayHandler] gate muted account={} until={} reason='{}'",
+						*accountId, gateResult.untilTsMs, gateResult.reason);
+					return;
+				}
+				case chat::ChatGateDecision::Flooding:
+				{
+					auto notice = BuildChatRelayPacket(nowMs,
+						static_cast<uint8_t>(engine::net::ChatChannel::Server),
+						"system", "Slow down — too many messages.", sessionIdHeader);
+					if (!notice.empty())
+						m_server->Send(connId, notice);
+					LOG_INFO(Net, "[ChatRelayHandler] gate flooding account={}", *accountId);
+					return;
+				}
+				case chat::ChatGateDecision::Allowed:
+					break;
+			}
 		}
 
 		// Phase 4 — Sender display name : preference au character_name (post-EnterWorld)

--- a/engine/server/ChatRelayHandler.h
+++ b/engine/server/ChatRelayHandler.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "engine/server/chat/ChatGate.h"
+#include "engine/server/chat/ChatSanitizer.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -50,6 +53,15 @@ namespace engine::server
 		void SetAccountStore(AccountStore* accounts);
 		void SetConnectionPool(engine::server::db::ConnectionPool* pool);
 
+		/// Phase 2 CMANGOS.01 : configure le sanitizer (UTF-8 safe trunc,
+		/// strip zero-width, hyperlinks whitelist). Idempotent.
+		void SetSanitizerConfig(const chat::ChatSanitizerConfig& cfg);
+
+		/// Phase 2 CMANGOS.01 : retourne le ChatGate interne (ban/mute/anti-flood)
+		/// pour le câbler à la production via `WireProduction(pool, accounts)`
+		/// au boot de ServerApp.
+		chat::ChatGate& Gate() { return m_gate; }
+
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
 
@@ -60,5 +72,8 @@ namespace engine::server
 		SessionCharacterMap*                m_charMap  = nullptr;
 		AccountStore*                       m_accounts = nullptr;
 		engine::server::db::ConnectionPool* m_pool     = nullptr;
+
+		chat::ChatSanitizerConfig           m_sanitizerCfg{};
+		chat::ChatGate                      m_gate{};
 	};
 }

--- a/engine/server/chat/ChatGate.cpp
+++ b/engine/server/chat/ChatGate.cpp
@@ -1,0 +1,238 @@
+#include "engine/server/chat/ChatGate.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/AccountRecord.h"
+#include "engine/server/AccountStore.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <mysql.h>
+#endif
+
+#include <cstdlib>
+#include <cstring>
+
+namespace engine::server::chat
+{
+	ChatGate::ChatGate(ChatGateConfig cfg) : m_cfg(std::move(cfg)) {}
+
+	void ChatGate::SetMuteLookup(ChatMuteLookupFn fn)
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_muteLookup = std::move(fn);
+	}
+
+	void ChatGate::SetBannedCheck(AccountBannedFn fn)
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_bannedCheck = std::move(fn);
+	}
+
+	void ChatGate::ResetState()
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_windows.clear();
+	}
+
+	void ChatGate::PurgeWindow(WindowState& w, uint64_t nowMs) const
+	{
+		// `nowMs - floodWindowMs` peut underflow si la fenêtre est plus
+		// large que le now (quasi impossible en prod : nowMs est l'epoch
+		// ms, ~1.7e12 actuellement). On s'en protège quand même.
+		const uint64_t cutoff = (nowMs > m_cfg.floodWindowMs)
+			? (nowMs - m_cfg.floodWindowMs) : 0ULL;
+		while (!w.tsMs.empty() && w.tsMs.front() < cutoff)
+			w.tsMs.pop_front();
+	}
+
+	ChatGateResult ChatGate::Decide(uint64_t accountId, uint64_t nowMs) const
+	{
+		ChatGateResult r;
+
+		// Snapshot des callbacks sous lock — on les copie pour pouvoir
+		// les invoquer hors-lock (les callbacks DB peuvent prendre du
+		// temps et on ne veut pas bloquer toutes les autres décisions).
+		ChatMuteLookupFn muteFn;
+		AccountBannedFn  banFn;
+		{
+			std::lock_guard<std::mutex> lk(m_mutex);
+			muteFn = m_muteLookup;
+			banFn  = m_bannedCheck;
+		}
+
+		// 1. Banni : court-circuit (priorité la plus haute).
+		if (banFn && banFn(accountId))
+		{
+			r.decision = ChatGateDecision::Banned;
+			return r;
+		}
+
+		// 2. Mute : si présent ET non expiré.
+		if (muteFn)
+		{
+			if (auto m = muteFn(accountId))
+			{
+				const bool permanent = (m->untilTsMs == 0);
+				if (permanent || m->untilTsMs > nowMs)
+				{
+					r.decision  = ChatGateDecision::Muted;
+					r.reason    = std::move(m->reason);
+					r.untilTsMs = m->untilTsMs;
+					return r;
+				}
+			}
+		}
+
+		// 3. Anti-flood : sliding window. On lit l'état SANS le modifier
+		// (Decide est const). DecideAndRecord, en revanche, met à jour.
+		{
+			std::lock_guard<std::mutex> lk(m_mutex);
+			auto it = m_windows.find(accountId);
+			if (it != m_windows.end())
+			{
+				WindowState copy = it->second;
+				PurgeWindow(copy, nowMs);
+				if (copy.tsMs.size() >= m_cfg.floodMaxMessages)
+				{
+					r.decision = ChatGateDecision::Flooding;
+					return r;
+				}
+			}
+		}
+
+		r.decision = ChatGateDecision::Allowed;
+		return r;
+	}
+
+	ChatGateResult ChatGate::DecideAndRecord(uint64_t accountId, uint64_t nowMs)
+	{
+		// On effectue la même séquence que Decide, mais en gardant le
+		// lock anti-flood pour la mise à jour atomique check+record.
+
+		ChatMuteLookupFn muteFn;
+		AccountBannedFn  banFn;
+		{
+			std::lock_guard<std::mutex> lk(m_mutex);
+			muteFn = m_muteLookup;
+			banFn  = m_bannedCheck;
+		}
+
+		ChatGateResult r;
+
+		if (banFn && banFn(accountId))
+		{
+			r.decision = ChatGateDecision::Banned;
+			return r;
+		}
+
+		if (muteFn)
+		{
+			if (auto m = muteFn(accountId))
+			{
+				const bool permanent = (m->untilTsMs == 0);
+				if (permanent || m->untilTsMs > nowMs)
+				{
+					r.decision  = ChatGateDecision::Muted;
+					r.reason    = std::move(m->reason);
+					r.untilTsMs = m->untilTsMs;
+					return r;
+				}
+			}
+		}
+
+		std::lock_guard<std::mutex> lk(m_mutex);
+
+		// Cap soft de la table (on n'évince pas activement ; on refuse
+		// d'ajouter une nouvelle entrée si on a déjà plein de comptes
+		// actifs trackés). En pratique avec maxTrackedAccounts = 4096 et
+		// floodWindowMs = 5000 ms, ça couvre largement le besoin réel.
+		auto it = m_windows.find(accountId);
+		if (it == m_windows.end())
+		{
+			if (m_cfg.maxTrackedAccounts > 0 && m_windows.size() >= m_cfg.maxTrackedAccounts)
+			{
+				// Full : on refuse pour ne pas grossir indéfiniment.
+				// Comportement conservateur : on autorise quand même le
+				// message (on ne pénalise pas un nouvel account juste
+				// parce que la table est pleine), mais on logge un warn.
+				LOG_WARN(Core, "[ChatGate] tracked accounts cap reached ({}); skipping flood window for new account {}",
+					m_cfg.maxTrackedAccounts, accountId);
+				r.decision = ChatGateDecision::Allowed;
+				return r;
+			}
+			it = m_windows.emplace(accountId, WindowState{}).first;
+		}
+
+		WindowState& w = it->second;
+		PurgeWindow(w, nowMs);
+		if (w.tsMs.size() >= m_cfg.floodMaxMessages)
+		{
+			r.decision = ChatGateDecision::Flooding;
+			return r;
+		}
+
+		w.tsMs.push_back(nowMs);
+		r.decision = ChatGateDecision::Allowed;
+		return r;
+	}
+
+	void ChatGate::WireProduction(engine::server::db::ConnectionPool* pool, AccountStore* accounts)
+	{
+		SetMuteLookup(MakeSqlMuteLookup(pool));
+		SetBannedCheck(MakeAccountStoreBannedCheck(accounts));
+	}
+
+	ChatMuteLookupFn MakeSqlMuteLookup(engine::server::db::ConnectionPool* pool)
+	{
+#if defined(__unix__) || defined(__APPLE__)
+		return [pool](uint64_t accountId) -> std::optional<ChatMute>
+		{
+			if (!pool || !pool->IsInitialized())
+				return std::nullopt;
+
+			auto guard = pool->Acquire();
+			MYSQL* mysql = guard.get();
+			if (!mysql)
+				return std::nullopt;
+
+			char sql[256];
+			std::snprintf(sql, sizeof(sql),
+				"SELECT until_ts, reason FROM chat_mutes WHERE account_id = %llu LIMIT 1",
+				static_cast<unsigned long long>(accountId));
+
+			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+			if (!res)
+				return std::nullopt;
+
+			std::optional<ChatMute> out;
+			if (MYSQL_ROW row = mysql_fetch_row(res))
+			{
+				ChatMute m;
+				m.untilTsMs = row[0] ? std::strtoull(row[0], nullptr, 10) : 0ULL;
+				m.reason    = row[1] ? row[1] : "";
+				out = std::move(m);
+			}
+			mysql_free_result(res);
+			return out;
+		};
+#else
+		(void)pool;
+		// Sur Windows/build sans MySQL : pas de DB, jamais muté.
+		return [](uint64_t) -> std::optional<ChatMute> { return std::nullopt; };
+#endif
+	}
+
+	AccountBannedFn MakeAccountStoreBannedCheck(AccountStore* accounts)
+	{
+		return [accounts](uint64_t accountId) -> bool
+		{
+			if (!accounts)
+				return false;
+			auto rec = accounts->FindByAccountId(accountId);
+			if (!rec)
+				return false;
+			return rec->status == AccountStatus::Locked;
+		};
+	}
+}

--- a/engine/server/chat/ChatGate.cpp
+++ b/engine/server/chat/ChatGate.cpp
@@ -35,6 +35,13 @@ namespace engine::server::chat
 		m_windows.clear();
 	}
 
+	void ChatGate::Reconfigure(ChatGateConfig cfg)
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_cfg = std::move(cfg);
+		m_windows.clear();
+	}
+
 	void ChatGate::PurgeWindow(WindowState& w, uint64_t nowMs) const
 	{
 		// `nowMs - floodWindowMs` peut underflow si la fenêtre est plus

--- a/engine/server/chat/ChatGate.h
+++ b/engine/server/chat/ChatGate.h
@@ -123,6 +123,11 @@ namespace engine::server::chat
 		/// Reset complet de l'état runtime (anti-flood). Utile en tests.
 		void ResetState();
 
+		/// Remplace la config (ne peut pas se faire via operator= : la mutex
+		/// rend ChatGate non-copiable/non-movable). Garde les callbacks
+		/// déjà câblés. Reset l'état runtime.
+		void Reconfigure(ChatGateConfig cfg);
+
 	private:
 		struct WindowState
 		{

--- a/engine/server/chat/ChatGate.h
+++ b/engine/server/chat/ChatGate.h
@@ -1,0 +1,153 @@
+#pragma once
+// CMANGOS.01 (Phase 2.01a) — ChatGate : moteur de décision avant relai d'un
+// message chat. Vérifie l'état du compte (banni / mute persistant en DB) et
+// applique un anti-flood en mémoire (sliding window par account).
+//
+// Sépare la sanitization (ChatSanitizer.h) de la décision d'autorisation.
+// Pure logique : la sanitization ne modifie JAMAIS l'autorisation, et
+// l'autorisation ne modifie JAMAIS le texte. Les deux étapes sont
+// orthogonales et appelables en série depuis ChatRelayHandler.
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server::db
+{
+	class ConnectionPool;
+}
+
+namespace engine::server
+{
+	class AccountStore;
+}
+
+namespace engine::server::chat
+{
+	/// Information sur un mute persistant en DB (table `chat_mutes`).
+	struct ChatMute
+	{
+		/// Epoch ms UTC ; 0 = mute permanent (jamais expiré).
+		uint64_t untilTsMs = 0;
+		/// Raison libre (audit, affichée à l'utilisateur).
+		std::string reason;
+	};
+
+	/// Décision finale du gate.
+	enum class ChatGateDecision : uint8_t
+	{
+		/// Autorisé — l'appelant peut router le message.
+		Allowed = 0,
+		/// Compte banni (`AccountStatus::Locked`). Pas de message à l'utilisateur.
+		Banned = 1,
+		/// Mute actif (DB). `reason` est rempli avec le motif.
+		Muted = 2,
+		/// Anti-flood déclenché : trop de messages dans la fenêtre.
+		Flooding = 3,
+	};
+
+	struct ChatGateResult
+	{
+		ChatGateDecision decision = ChatGateDecision::Allowed;
+		/// Si `Muted`, la raison telle que stockée en DB. Sinon vide.
+		std::string reason;
+		/// Si `Muted`, l'epoch ms d'expiration (0 = permanent). Sinon 0.
+		uint64_t untilTsMs = 0;
+	};
+
+	/// Configuration runtime du gate.
+	struct ChatGateConfig
+	{
+		/// Fenêtre de surveillance anti-flood (ms).
+		uint64_t floodWindowMs = 5000;
+		/// Nombre max de messages **dans** la fenêtre. Le N+1 est rejeté.
+		size_t floodMaxMessages = 5;
+		/// Capacité max de la table interne de fenêtres par account
+		/// (protection mémoire si beaucoup d'accounts spamment). Au-delà,
+		/// les entrées les plus anciennes (purgées car hors fenêtre) sont
+		/// laissées tomber. 0 = illimité.
+		size_t maxTrackedAccounts = 4096;
+	};
+
+	/// Callback pour récupérer un mute. Retourne `nullopt` si pas mute
+	/// actif. Injectable (production = SQL via ConnectionPool ; tests =
+	/// mock RAM). Doit être thread-safe.
+	using ChatMuteLookupFn = std::function<std::optional<ChatMute>(uint64_t accountId)>;
+
+	/// Callback pour vérifier le statut "banni". Retourne true si le compte
+	/// est verrouillé (`AccountStatus::Locked`). Injectable.
+	using AccountBannedFn = std::function<bool(uint64_t accountId)>;
+
+	/// Gate thread-safe : appelable concurremment depuis plusieurs threads
+	/// du master. Tient une fenêtre coulissante par account_id.
+	///
+	/// Cycle de vie typique :
+	///   1. Construire avec une config.
+	///   2. Câbler les callbacks (production : SqlChatMuteSource + AccountStore).
+	///   3. Pour chaque message : `Decide(accountId, nowMs)`.
+	///   4. Si `Allowed`, le caller appelle `RecordSent(accountId, nowMs)`
+	///      (séparé pour permettre des dry-runs ; en pratique
+	///      `DecideAndRecord` est l'API simple).
+	class ChatGate
+	{
+	public:
+		explicit ChatGate(ChatGateConfig cfg = {});
+
+		/// Câble le lookup de mute. Si non câblé, `Decide` retourne
+		/// toujours `Allowed` pour la part mute (autres checks restent
+		/// actifs). Idempotent.
+		void SetMuteLookup(ChatMuteLookupFn fn);
+
+		/// Câble le check de ban. Si non câblé, `Decide` retourne toujours
+		/// `Allowed` pour la part ban.
+		void SetBannedCheck(AccountBannedFn fn);
+
+		/// Décide sans modifier l'état (utile pour preview / debug).
+		ChatGateResult Decide(uint64_t accountId, uint64_t nowMs) const;
+
+		/// Décide ET enregistre le tick si `Allowed`. C'est l'API à
+		/// utiliser dans le hot path. Si la décision est `Allowed`, l'état
+		/// interne est mis à jour ; sinon non.
+		ChatGateResult DecideAndRecord(uint64_t accountId, uint64_t nowMs);
+
+		/// Helper de configuration : remplace les callbacks par des
+		/// implémentations basées sur ConnectionPool (mute) + AccountStore
+		/// (ban). Pratique pour le câblage en production.
+		void WireProduction(engine::server::db::ConnectionPool* pool, AccountStore* accounts);
+
+		/// Reset complet de l'état runtime (anti-flood). Utile en tests.
+		void ResetState();
+
+	private:
+		struct WindowState
+		{
+			/// Timestamps (ms UTC) des messages envoyés ; tronqués à
+			/// `floodWindowMs` avant chaque check.
+			std::deque<uint64_t> tsMs;
+		};
+
+		/// Purge les timestamps hors fenêtre. Caller doit tenir le lock.
+		void PurgeWindow(WindowState& w, uint64_t nowMs) const;
+
+		ChatGateConfig                           m_cfg;
+		mutable std::mutex                       m_mutex;
+		std::unordered_map<uint64_t, WindowState> m_windows;
+		ChatMuteLookupFn                         m_muteLookup;
+		AccountBannedFn                          m_bannedCheck;
+	};
+
+	/// Helper : crée une `ChatMuteLookupFn` qui interroge `chat_mutes` via
+	/// le pool. Mute permanent (`until_ts=0`) toujours actif. Mute expiré
+	/// (`until_ts < nowMs`) ignoré (l'appelant compare nowMs lui-même via
+	/// `Decide`). Le lookup retourne UN mute (le plus récent) — la table
+	/// a une PK sur account_id donc au plus une ligne.
+	ChatMuteLookupFn MakeSqlMuteLookup(engine::server::db::ConnectionPool* pool);
+
+	/// Helper : crée un `AccountBannedFn` qui interroge un AccountStore.
+	AccountBannedFn MakeAccountStoreBannedCheck(AccountStore* accounts);
+}

--- a/engine/server/chat/ChatGateTests.cpp
+++ b/engine/server/chat/ChatGateTests.cpp
@@ -1,0 +1,296 @@
+// CMANGOS.01 (Phase 2.01a) — Tests ChatGate.
+// Pas de dépendance MySQL : on injecte des callbacks mock pour simuler
+// la DB et le store. Couvre : ban / mute permanent / mute expiré /
+// anti-flood / sliding window / Decide vs DecideAndRecord.
+
+#include "engine/server/chat/ChatGate.h"
+#include "engine/core/Log.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
+	using engine::server::chat::ChatGate;
+	using engine::server::chat::ChatGateConfig;
+	using engine::server::chat::ChatGateDecision;
+	using engine::server::chat::ChatMute;
+
+	bool TestAllowedDefault()
+	{
+		ChatGate g;
+		const auto r = g.DecideAndRecord(42, 1000);
+		if (r.decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] expected Allowed (no callbacks), got decision={}",
+				static_cast<int>(r.decision));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatGateTests] default Allowed OK");
+		return true;
+	}
+
+	bool TestBannedShortCircuits()
+	{
+		ChatGate g;
+		g.SetBannedCheck([](uint64_t id) { return id == 7; });
+		// Mute aussi câblé : on vérifie que le ban a la priorité.
+		g.SetMuteLookup([](uint64_t) -> std::optional<ChatMute> {
+			ChatMute m; m.untilTsMs = 0; m.reason = "should not surface";
+			return m;
+		});
+
+		const auto r = g.DecideAndRecord(7, 1000);
+		if (r.decision != ChatGateDecision::Banned)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] expected Banned, got {}", static_cast<int>(r.decision));
+			return false;
+		}
+		if (!r.reason.empty())
+		{
+			LOG_ERROR(Core, "[ChatGateTests] Banned should have empty reason, got '{}'", r.reason);
+			return false;
+		}
+
+		// Compte non banni → pas Banned (mute persiste).
+		const auto r2 = g.DecideAndRecord(8, 1000);
+		if (r2.decision != ChatGateDecision::Muted)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] non-banned account should fall through to Muted, got {}",
+				static_cast<int>(r2.decision));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatGateTests] ban short-circuit OK");
+		return true;
+	}
+
+	bool TestMutePermanent()
+	{
+		ChatGate g;
+		g.SetMuteLookup([](uint64_t id) -> std::optional<ChatMute> {
+			if (id != 99) return std::nullopt;
+			ChatMute m; m.untilTsMs = 0; m.reason = "spam"; return m;
+		});
+
+		const auto r = g.DecideAndRecord(99, 1000);
+		if (r.decision != ChatGateDecision::Muted)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] expected Muted permanent, got {}", static_cast<int>(r.decision));
+			return false;
+		}
+		if (r.reason != "spam" || r.untilTsMs != 0)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] mute fields wrong (reason='{}' until={})", r.reason, r.untilTsMs);
+			return false;
+		}
+		LOG_INFO(Core, "[ChatGateTests] mute permanent OK");
+		return true;
+	}
+
+	bool TestMuteExpired()
+	{
+		ChatGate g;
+		// Mute jusqu'à t=500. On query à t=1000 → expiré → fallthrough.
+		g.SetMuteLookup([](uint64_t) -> std::optional<ChatMute> {
+			ChatMute m; m.untilTsMs = 500; m.reason = "old"; return m;
+		});
+
+		const auto r = g.DecideAndRecord(1, 1000);
+		if (r.decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] expected Allowed (mute expired), got {}",
+				static_cast<int>(r.decision));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatGateTests] mute expired OK");
+		return true;
+	}
+
+	bool TestMuteActive()
+	{
+		ChatGate g;
+		// Mute jusqu'à t=2000. Query à t=1000 → encore actif.
+		g.SetMuteLookup([](uint64_t) -> std::optional<ChatMute> {
+			ChatMute m; m.untilTsMs = 2000; m.reason = "warning"; return m;
+		});
+
+		const auto r = g.DecideAndRecord(1, 1000);
+		if (r.decision != ChatGateDecision::Muted || r.untilTsMs != 2000)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] mute active failed (decision={} until={})",
+				static_cast<int>(r.decision), r.untilTsMs);
+			return false;
+		}
+		LOG_INFO(Core, "[ChatGateTests] mute active OK");
+		return true;
+	}
+
+	bool TestAntiFlood()
+	{
+		ChatGateConfig cfg;
+		cfg.floodWindowMs    = 1000;
+		cfg.floodMaxMessages = 3;
+		ChatGate g(cfg);
+
+		// 3 messages dans la fenêtre : tous OK.
+		for (int i = 0; i < 3; ++i)
+		{
+			const auto r = g.DecideAndRecord(42, 100 + static_cast<uint64_t>(i) * 100);
+			if (r.decision != ChatGateDecision::Allowed)
+			{
+				LOG_ERROR(Core, "[ChatGateTests] msg #{} should be Allowed, got {}",
+					i, static_cast<int>(r.decision));
+				return false;
+			}
+		}
+
+		// 4ᵉ message à t=400 (dans la fenêtre) → Flooding.
+		const auto r4 = g.DecideAndRecord(42, 400);
+		if (r4.decision != ChatGateDecision::Flooding)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] msg #4 should be Flooding, got {}",
+				static_cast<int>(r4.decision));
+			return false;
+		}
+
+		// À t=1500, fenêtre = [500, 1500]. Les 3 messages (100, 200, 300)
+		// sont hors fenêtre → tous purgés → Allowed.
+		const auto r5 = g.DecideAndRecord(42, 1500);
+		if (r5.decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] after window expiry should be Allowed, got {}",
+				static_cast<int>(r5.decision));
+			return false;
+		}
+
+		LOG_INFO(Core, "[ChatGateTests] anti-flood OK");
+		return true;
+	}
+
+	bool TestDecideDoesNotMutate()
+	{
+		ChatGateConfig cfg;
+		cfg.floodWindowMs    = 1000;
+		cfg.floodMaxMessages = 2;
+		ChatGate g(cfg);
+
+		// 100 calls à Decide : ne doit jamais incrémenter la fenêtre.
+		for (int i = 0; i < 100; ++i)
+		{
+			const auto r = g.Decide(7, 100);
+			if (r.decision != ChatGateDecision::Allowed)
+			{
+				LOG_ERROR(Core, "[ChatGateTests] Decide should be pure Allowed, got {} on iter {}",
+					static_cast<int>(r.decision), i);
+				return false;
+			}
+		}
+
+		// Maintenant 2 DecideAndRecord → Allowed, le 3ᵉ → Flooding.
+		if (g.DecideAndRecord(7, 200).decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] 1st record should be Allowed");
+			return false;
+		}
+		if (g.DecideAndRecord(7, 201).decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] 2nd record should be Allowed");
+			return false;
+		}
+		if (g.DecideAndRecord(7, 202).decision != ChatGateDecision::Flooding)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] 3rd record should be Flooding");
+			return false;
+		}
+
+		LOG_INFO(Core, "[ChatGateTests] Decide pure (no state mutation) OK");
+		return true;
+	}
+
+	bool TestPerAccountIsolation()
+	{
+		ChatGateConfig cfg;
+		cfg.floodWindowMs    = 1000;
+		cfg.floodMaxMessages = 1;
+		ChatGate g(cfg);
+
+		// account 1 envoie un message → Allowed.
+		if (g.DecideAndRecord(1, 100).decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] account 1 first msg should be Allowed");
+			return false;
+		}
+		// account 2 envoie un message → Allowed (compteur séparé).
+		if (g.DecideAndRecord(2, 100).decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] account 2 first msg should be Allowed");
+			return false;
+		}
+		// account 1 deuxième message → Flooding (max=1).
+		if (g.DecideAndRecord(1, 100).decision != ChatGateDecision::Flooding)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] account 1 second msg should be Flooding");
+			return false;
+		}
+		// account 2 deuxième message → Flooding aussi (mais indépendant).
+		if (g.DecideAndRecord(2, 100).decision != ChatGateDecision::Flooding)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] account 2 second msg should be Flooding");
+			return false;
+		}
+
+		LOG_INFO(Core, "[ChatGateTests] per-account isolation OK");
+		return true;
+	}
+
+	bool TestResetState()
+	{
+		ChatGateConfig cfg;
+		cfg.floodWindowMs    = 1000;
+		cfg.floodMaxMessages = 1;
+		ChatGate g(cfg);
+
+		g.DecideAndRecord(1, 100);  // Allowed
+		if (g.DecideAndRecord(1, 100).decision != ChatGateDecision::Flooding)
+			return false;
+
+		g.ResetState();
+
+		if (g.DecideAndRecord(1, 100).decision != ChatGateDecision::Allowed)
+		{
+			LOG_ERROR(Core, "[ChatGateTests] after Reset should be Allowed");
+			return false;
+		}
+
+		LOG_INFO(Core, "[ChatGateTests] ResetState OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestAllowedDefault()
+		&& TestBannedShortCircuits()
+		&& TestMutePermanent()
+		&& TestMuteExpired()
+		&& TestMuteActive()
+		&& TestAntiFlood()
+		&& TestDecideDoesNotMutate()
+		&& TestPerAccountIsolation()
+		&& TestResetState();
+
+	if (ok)
+		LOG_INFO(Core, "[ChatGateTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ChatGateTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/chat/ChatSanitizer.cpp
+++ b/engine/server/chat/ChatSanitizer.cpp
@@ -1,0 +1,174 @@
+#include "engine/server/chat/ChatSanitizer.h"
+
+#include <array>
+#include <cstdint>
+
+namespace engine::server::chat
+{
+	namespace
+	{
+		/// Whitelist des types d'hyperlink autorisés (cf. spec ticket
+		/// CMANGOS.01 §Sanitizer Step 3). Démarrer strict — élargir uniquement
+		/// après audit de chaque nouveau type.
+		constexpr std::array<std::string_view, 4> kAllowedHyperlinkTypes = {
+			"item", "quest", "achievement", "spell"
+		};
+
+		/// Trouve la dernière frontière de codepoint UTF-8 valide ≤ maxBytes.
+		/// Garantit qu'on ne coupe jamais au milieu d'un codepoint multi-byte.
+		///
+		/// UTF-8 layout :
+		///   0xxxxxxx → ASCII 1-byte
+		///   10xxxxxx → continuation byte (jamais début de codepoint)
+		///   110xxxxx → début 2-byte
+		///   1110xxxx → début 3-byte
+		///   11110xxx → début 4-byte
+		size_t Utf8SafeTruncatePoint(std::string_view s, size_t maxBytes)
+		{
+			if (s.size() <= maxBytes)
+				return s.size();
+			// Reculer depuis maxBytes jusqu'à un byte qui n'est PAS continuation (10xxxxxx).
+			size_t cut = maxBytes;
+			while (cut > 0)
+			{
+				const auto byte = static_cast<uint8_t>(s[cut]);
+				// Si on est sur un byte de début de codepoint (high bit 0 ou 110/1110/11110), on coupe ICI.
+				// `0xxxxxxx` (ASCII) ou `11xxxxxx` (start of multi-byte) : OK pour couper avant.
+				if ((byte & 0xC0) != 0x80)
+					return cut;
+				--cut;
+			}
+			return 0;
+		}
+
+		/// Vérifie si codepoint est un caractère "invisible" zero-width / bidi.
+		/// Liste basée sur la spec ticket : U+200B..U+200F, U+FEFF, U+202A..U+202E.
+		bool IsZeroWidthCodepoint(uint32_t cp) noexcept
+		{
+			if (cp >= 0x200B && cp <= 0x200F) return true;
+			if (cp == 0xFEFF) return true;
+			if (cp >= 0x202A && cp <= 0x202E) return true;
+			return false;
+		}
+
+		/// Décode un codepoint UTF-8 à la position `pos`. Retourne le codepoint
+		/// + le nombre de bytes consommés. Sur erreur (séquence invalide),
+		/// retourne (cp=byte, consumed=1) — comportement gracieux : on ne
+		/// reject pas le message pour une séquence invalide, on traite le
+		/// byte comme ASCII.
+		struct Utf8Decoded { uint32_t cp; size_t consumed; };
+		Utf8Decoded DecodeUtf8(std::string_view s, size_t pos) noexcept
+		{
+			if (pos >= s.size())
+				return {0, 0};
+			const auto b0 = static_cast<uint8_t>(s[pos]);
+			if (b0 < 0x80) return {b0, 1};
+			if ((b0 & 0xE0) == 0xC0 && pos + 1 < s.size())
+			{
+				const auto b1 = static_cast<uint8_t>(s[pos + 1]);
+				if ((b1 & 0xC0) == 0x80)
+					return {static_cast<uint32_t>((b0 & 0x1F) << 6 | (b1 & 0x3F)), 2};
+			}
+			if ((b0 & 0xF0) == 0xE0 && pos + 2 < s.size())
+			{
+				const auto b1 = static_cast<uint8_t>(s[pos + 1]);
+				const auto b2 = static_cast<uint8_t>(s[pos + 2]);
+				if ((b1 & 0xC0) == 0x80 && (b2 & 0xC0) == 0x80)
+					return {static_cast<uint32_t>((b0 & 0x0F) << 12 | (b1 & 0x3F) << 6 | (b2 & 0x3F)), 3};
+			}
+			if ((b0 & 0xF8) == 0xF0 && pos + 3 < s.size())
+			{
+				const auto b1 = static_cast<uint8_t>(s[pos + 1]);
+				const auto b2 = static_cast<uint8_t>(s[pos + 2]);
+				const auto b3 = static_cast<uint8_t>(s[pos + 3]);
+				if ((b1 & 0xC0) == 0x80 && (b2 & 0xC0) == 0x80 && (b3 & 0xC0) == 0x80)
+					return {static_cast<uint32_t>((b0 & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | (b3 & 0x3F)), 4};
+			}
+			// Séquence invalide : traiter byte comme ASCII (graceful fallback).
+			return {b0, 1};
+		}
+
+		/// Strip les zero-width characters (Step 3). Re-encode en UTF-8 sans
+		/// les codepoints filtrés.
+		std::string StripZeroWidth(std::string_view in)
+		{
+			std::string out;
+			out.reserve(in.size());
+			for (size_t i = 0; i < in.size(); )
+			{
+				const auto [cp, n] = DecodeUtf8(in, i);
+				if (n == 0) break;
+				if (!IsZeroWidthCodepoint(cp))
+					out.append(in.substr(i, n));
+				i += n;
+			}
+			return out;
+		}
+
+		/// Vérifie que tous les hyperlinks `|H<type>:...|h<text>|h` ont un
+		/// `<type>` whitelisté. Retourne false si au moins un type interdit
+		/// est présent. Si aucun hyperlink, retourne true.
+		///
+		/// Format reconnu : `|H<type>:<args>|h<text>|h`. Pas de validation
+		/// stricte du contenu interne (args/text peuvent contenir n'importe
+		/// quoi tant que le `<type>` est whitelisté).
+		bool ValidateHyperlinks(std::string_view s) noexcept
+		{
+			size_t pos = 0;
+			while ((pos = s.find("|H", pos)) != std::string_view::npos)
+			{
+				const size_t typeStart = pos + 2;
+				const size_t colonPos = s.find(':', typeStart);
+				if (colonPos == std::string_view::npos)
+					return false;  // mal formé
+				const std::string_view type = s.substr(typeStart, colonPos - typeStart);
+				bool allowed = false;
+				for (const auto& w : kAllowedHyperlinkTypes)
+				{
+					if (type == w) { allowed = true; break; }
+				}
+				if (!allowed)
+					return false;
+				pos = colonPos + 1;
+			}
+			return true;
+		}
+	}
+
+	ChatSanitizeResult Sanitize(std::string_view input, const ChatSanitizerConfig& cfg)
+	{
+		ChatSanitizeResult result;
+
+		// Step 1 : reject si vide.
+		if (input.empty())
+		{
+			result.rejectReason = "empty";
+			return result;
+		}
+
+		// Step 2 : UTF-8 safe truncation.
+		const size_t cut = Utf8SafeTruncatePoint(input, cfg.maxMessageBytes);
+		std::string truncated(input.substr(0, cut));
+
+		// Step 3 : strip zero-width.
+		std::string stripped = cfg.stripZeroWidth ? StripZeroWidth(truncated) : std::move(truncated);
+
+		// Step 4 : hyperlinks whitelist.
+		if (!ValidateHyperlinks(stripped))
+		{
+			result.rejectReason = "hyperlink_blocked";
+			return result;
+		}
+
+		// Step 5 : reject si post-strip vide.
+		if (stripped.empty())
+		{
+			result.rejectReason = "post_strip_empty";
+			return result;
+		}
+
+		result.text = std::move(stripped);
+		result.accepted = true;
+		return result;
+	}
+}

--- a/engine/server/chat/ChatSanitizer.h
+++ b/engine/server/chat/ChatSanitizer.h
@@ -1,0 +1,53 @@
+#pragma once
+// CMANGOS.01 (Phase 2.01a) — ChatSanitizer : validation pure de chaîne
+// avant routage (UTF-8 safe truncation + hyperlinks whitelist + strip
+// zero-width). Pure function, testable sans dépendance.
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace engine::server::chat
+{
+	/// Configuration du sanitizer.
+	struct ChatSanitizerConfig
+	{
+		/// Limite max en octets (UTF-8 safe truncation à cette taille).
+		size_t maxMessageBytes = 255;
+
+		/// Strip des caractères invisibles (zero-width joiner U+200B..U+200F,
+		/// U+FEFF, bidi U+202A..U+202E).
+		bool stripZeroWidth = true;
+	};
+
+	/// Résultat du sanitize.
+	struct ChatSanitizeResult
+	{
+		/// Texte sanitizé (vide si rejeté). Tronqué UTF-8 safe + zero-width
+		/// strippés selon config.
+		std::string text;
+
+		/// True si le message est accepté (texte non vide + hyperlinks
+		/// whitelistés + post-truncation non vide). False sinon.
+		bool accepted = false;
+
+		/// Raison du rejet (court tag pour log/audit). Vide si accepté.
+		/// Valeurs : "empty", "hyperlink_blocked", "post_strip_empty".
+		std::string rejectReason;
+	};
+
+	/// Sanitize un message chat.
+	///
+	/// Étapes (en série) :
+	/// 1. Reject si vide.
+	/// 2. UTF-8 safe truncation à `cfg.maxMessageBytes` (jamais couper au
+	///    milieu d'un codepoint multi-byte).
+	/// 3. Strip zero-width characters si `cfg.stripZeroWidth`.
+	/// 4. Reject si hyperlinks `|H<type>:<args>|h<text>|h` avec `<type>`
+	///    hors whitelist {item, quest, achievement, spell}. Hyperlinks
+	///    valides passent tels quels.
+	/// 5. Reject si post-strip le texte est vide.
+	///
+	/// Pure function : aucune dépendance externe, thread-safe par nature.
+	ChatSanitizeResult Sanitize(std::string_view input, const ChatSanitizerConfig& cfg);
+}

--- a/engine/server/chat/ChatSanitizerTests.cpp
+++ b/engine/server/chat/ChatSanitizerTests.cpp
@@ -1,0 +1,208 @@
+// CMANGOS.01 (Phase 2.01a) — Tests ChatSanitizer.
+// Pure : aucune dépendance DB / pool / réseau.
+
+#include "engine/server/chat/ChatSanitizer.h"
+#include "engine/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::server::chat::ChatSanitizerConfig;
+	using engine::server::chat::ChatSanitizeResult;
+	using engine::server::chat::Sanitize;
+
+	bool ExpectAccepted(const std::string& label, const std::string_view input,
+		const std::string_view expectedText, const ChatSanitizerConfig& cfg)
+	{
+		const auto r = Sanitize(input, cfg);
+		if (!r.accepted)
+		{
+			LOG_ERROR(Core, "[ChatSanitizerTests] {}: expected accepted, got rejected ({})",
+				label, r.rejectReason);
+			return false;
+		}
+		if (r.text != expectedText)
+		{
+			LOG_ERROR(Core, "[ChatSanitizerTests] {}: text mismatch (got '{}' expected '{}')",
+				label, r.text, std::string(expectedText));
+			return false;
+		}
+		return true;
+	}
+
+	bool ExpectRejected(const std::string& label, const std::string_view input,
+		const std::string_view expectedReason, const ChatSanitizerConfig& cfg)
+	{
+		const auto r = Sanitize(input, cfg);
+		if (r.accepted)
+		{
+			LOG_ERROR(Core, "[ChatSanitizerTests] {}: expected rejected, got accepted", label);
+			return false;
+		}
+		if (r.rejectReason != expectedReason)
+		{
+			LOG_ERROR(Core, "[ChatSanitizerTests] {}: reject reason '{}' expected '{}'",
+				label, r.rejectReason, std::string(expectedReason));
+			return false;
+		}
+		return true;
+	}
+
+	bool TestEmpty()
+	{
+		ChatSanitizerConfig cfg;
+		if (!ExpectRejected("empty", "", "empty", cfg)) return false;
+		LOG_INFO(Core, "[ChatSanitizerTests] empty OK");
+		return true;
+	}
+
+	bool TestSimpleAscii()
+	{
+		ChatSanitizerConfig cfg;
+		if (!ExpectAccepted("ascii basic", "hello world", "hello world", cfg)) return false;
+		LOG_INFO(Core, "[ChatSanitizerTests] simple ascii OK");
+		return true;
+	}
+
+	bool TestUtf8SafeTruncation()
+	{
+		// "héllo" en UTF-8 : h=0x68, é=0xC3 0xA9, l=0x6C, l=0x6C, o=0x6F → 6 bytes.
+		// maxBytes=4 → on doit couper APRÈS 'h' + 'é' (3 bytes) ou avant 'é' (1 byte),
+		// jamais entre 0xC3 et 0xA9. Le code recule depuis maxBytes=4 jusqu'à un byte
+		// non-continuation. À l'index 4 le byte est 'l' (0x6C) qui n'est PAS
+		// continuation → coupe à 4 → "hé" + "l" = "héll"... attendons :
+		// indexes : 0=h 1=0xC3 2=0xA9 3=l 4=l 5=o
+		// maxBytes=4 → cut=4 → s[4]=0x6C (non-continuation) → coupe à 4 → "héll" (4 bytes).
+		ChatSanitizerConfig cfg;
+		cfg.maxMessageBytes = 4;
+		if (!ExpectAccepted("utf8 safe trunc 4", "h\xC3\xA9llo", "h\xC3\xA9ll", cfg))
+			return false;
+
+		// maxBytes=2 → cut=2, s[2]=0xA9 (continuation 10xxxxxx) → recule à 1, s[1]=0xC3
+		// (start 110xxxxx, NON-continuation) → coupe à 1 → "h".
+		cfg.maxMessageBytes = 2;
+		if (!ExpectAccepted("utf8 safe trunc 2", "h\xC3\xA9llo", "h", cfg))
+			return false;
+
+		// maxBytes=3 → cut=3, s[3]='l' (non-continuation) → coupe à 3 → "hé".
+		cfg.maxMessageBytes = 3;
+		if (!ExpectAccepted("utf8 safe trunc 3", "h\xC3\xA9llo", "h\xC3\xA9", cfg))
+			return false;
+
+		LOG_INFO(Core, "[ChatSanitizerTests] utf8 safe truncation OK");
+		return true;
+	}
+
+	bool TestStripZeroWidth()
+	{
+		// U+200B (zero-width space) en UTF-8 : 0xE2 0x80 0x8B.
+		// "ab" + ZWSP + "cd" → "abcd" attendu.
+		ChatSanitizerConfig cfg;
+		const std::string in = std::string("ab") + "\xE2\x80\x8B" + "cd";
+		if (!ExpectAccepted("strip ZWSP", in, "abcd", cfg)) return false;
+
+		// U+FEFF (BOM) : 0xEF 0xBB 0xBF.
+		const std::string in2 = std::string("hi") + "\xEF\xBB\xBF" + "there";
+		if (!ExpectAccepted("strip BOM", in2, "hithere", cfg)) return false;
+
+		// U+202E (RTL override) : 0xE2 0x80 0xAE.
+		const std::string in3 = std::string("safe") + "\xE2\x80\xAE" + "evil";
+		if (!ExpectAccepted("strip bidi", in3, "safeevil", cfg)) return false;
+
+		// stripZeroWidth = false → on garde les ZW.
+		cfg.stripZeroWidth = false;
+		if (!ExpectAccepted("keep ZWSP when disabled", in, in, cfg)) return false;
+
+		LOG_INFO(Core, "[ChatSanitizerTests] strip zero-width OK");
+		return true;
+	}
+
+	bool TestPostStripEmpty()
+	{
+		// Message qui n'est QUE des zero-width chars → après strip = "" → reject.
+		ChatSanitizerConfig cfg;
+		const std::string in = std::string("\xE2\x80\x8B") + "\xEF\xBB\xBF";
+		if (!ExpectRejected("post strip empty", in, "post_strip_empty", cfg))
+			return false;
+		LOG_INFO(Core, "[ChatSanitizerTests] post-strip empty OK");
+		return true;
+	}
+
+	bool TestHyperlinkAllowed()
+	{
+		ChatSanitizerConfig cfg;
+		const std::string in = "Look at |Hitem:12345:0:0:0:0:0:0:0|h[Sword]|h !";
+		if (!ExpectAccepted("hyperlink item", in, in, cfg)) return false;
+
+		const std::string in2 = "Quest: |Hquest:99|h[Wanted]|h";
+		if (!ExpectAccepted("hyperlink quest", in2, in2, cfg)) return false;
+
+		const std::string in3 = "|Hachievement:1234|h[Hero]|h";
+		if (!ExpectAccepted("hyperlink achievement", in3, in3, cfg)) return false;
+
+		const std::string in4 = "|Hspell:42|h[Magic]|h";
+		if (!ExpectAccepted("hyperlink spell", in4, in4, cfg)) return false;
+
+		LOG_INFO(Core, "[ChatSanitizerTests] hyperlink allowed OK");
+		return true;
+	}
+
+	bool TestHyperlinkBlocked()
+	{
+		ChatSanitizerConfig cfg;
+		// "trade" n'est PAS dans la whitelist.
+		const std::string in = "Cheat: |Htrade:foo|h[click]|h";
+		if (!ExpectRejected("hyperlink trade blocked", in, "hyperlink_blocked", cfg))
+			return false;
+
+		// Hyperlink mal formé (pas de ':' après |H) → rejet.
+		const std::string in2 = "broken |H no colon |h";
+		if (!ExpectRejected("hyperlink malformed", in2, "hyperlink_blocked", cfg))
+			return false;
+
+		// Type vide entre |H et : → ne match aucun whitelisted → reject.
+		const std::string in3 = "empty |H:foo|h[x]|h";
+		if (!ExpectRejected("hyperlink empty type", in3, "hyperlink_blocked", cfg))
+			return false;
+
+		LOG_INFO(Core, "[ChatSanitizerTests] hyperlink blocked OK");
+		return true;
+	}
+
+	bool TestNoHyperlinkPasses()
+	{
+		ChatSanitizerConfig cfg;
+		// Message normal sans hyperlink → accepté.
+		if (!ExpectAccepted("no hyperlink", "no link here", "no link here", cfg))
+			return false;
+		LOG_INFO(Core, "[ChatSanitizerTests] no hyperlink passes OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty()
+		&& TestSimpleAscii()
+		&& TestUtf8SafeTruncation()
+		&& TestStripZeroWidth()
+		&& TestPostStripEmpty()
+		&& TestHyperlinkAllowed()
+		&& TestHyperlinkBlocked()
+		&& TestNoHyperlinkPasses();
+
+	if (ok)
+		LOG_INFO(Core, "[ChatSanitizerTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ChatSanitizerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/main_server_linux.cpp
+++ b/engine/server/main_server_linux.cpp
@@ -310,10 +310,26 @@ int main(int argc, char** argv)
 	chatRelayHandler.SetAccountStore(accountStore);
 	// Phase 5.1 — pool DB pour le routage guild (SQL guild_members).
 	chatRelayHandler.SetConnectionPool(&dbPool);
-	// Phase 2 CMANGOS.01 — câblage du gate (ban via AccountStore +
-	// mute via SQL chat_mutes). Pas de wire-breaking : effet seulement
-	// sur les rejets côté master.
-	chatRelayHandler.Gate().WireProduction(&dbPool, accountStore);
+	// Phase 2 CMANGOS.01 — sanitizer + gate (chat hardening).
+	{
+		engine::server::chat::ChatSanitizerConfig sanCfg;
+		sanCfg.maxMessageBytes = static_cast<size_t>(std::max<int64_t>(
+			16, config.GetInt("chat.sanitizer.max_message_bytes", 255)));
+		sanCfg.stripZeroWidth = config.GetBool("chat.sanitizer.strip_zero_width", true);
+		chatRelayHandler.SetSanitizerConfig(sanCfg);
+
+		engine::server::chat::ChatGateConfig gateCfg;
+		gateCfg.floodWindowMs = static_cast<uint64_t>(std::max<int64_t>(
+			0, config.GetInt("chat.gate.flood_window_ms", 5000)));
+		gateCfg.floodMaxMessages = static_cast<size_t>(std::max<int64_t>(
+			1, config.GetInt("chat.gate.flood_max_messages", 5)));
+		gateCfg.maxTrackedAccounts = static_cast<size_t>(std::max<int64_t>(
+			0, config.GetInt("chat.gate.max_tracked_accounts", 4096)));
+		chatRelayHandler.Gate().Reconfigure(gateCfg);
+		chatRelayHandler.Gate().WireProduction(&dbPool, accountStore);
+		LOG_INFO(Net, "[ServerMain] ChatGate configured (window={}ms max={}/win) (CMANGOS.01)",
+			gateCfg.floodWindowMs, gateCfg.floodMaxMessages);
+	}
 
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);

--- a/engine/server/main_server_linux.cpp
+++ b/engine/server/main_server_linux.cpp
@@ -310,6 +310,10 @@ int main(int argc, char** argv)
 	chatRelayHandler.SetAccountStore(accountStore);
 	// Phase 5.1 — pool DB pour le routage guild (SQL guild_members).
 	chatRelayHandler.SetConnectionPool(&dbPool);
+	// Phase 2 CMANGOS.01 — câblage du gate (ban via AccountStore +
+	// mute via SQL chat_mutes). Pas de wire-breaking : effet seulement
+	// sur les rejets côté master.
+	chatRelayHandler.Gate().WireProduction(&dbPool, accountStore);
 
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);


### PR DESCRIPTION
## Summary

Premier livrable de la **Phase 2** du roadmap CMANGOS — durcissement du chat côté master AVANT tout routage. Pas de wire-breaking : le protocole reste identique, seuls les rejets côté serveur sont nouveaux.

### Composants

- **`ChatSanitizer`** (pure function) : UTF-8 safe truncation (jamais couper au milieu d'un codepoint), strip zero-width/bidi (U+200B–U+200F, U+FEFF, U+202A–U+202E), hyperlinks whitelist (`item`/`quest`/`achievement`/`spell`).
- **`ChatGate`** (decision engine) : ban → mute (DB) → anti-flood (RAM sliding window). Callbacks injectables pour la testabilité.
- **`chat_mutes` table** (migration 0044) : `account_id` (PK), `until_ts` ms UTC (0 = permanent), `reason`.
- **Intégration `ChatRelayHandler`** : sanitize après le check empty(), gate après résolution `account_id`. Notice ""Server"" visible uniquement par l'expéditeur en cas de Muted/Flooding ; Banned silencieux.

### Tests

- `chat_sanitizer_tests` : 8 cas (empty, ASCII, UTF-8 trunc à 4/3/2 bytes, strip ZWSP/BOM/bidi, post-strip empty, hyperlinks allowed/blocked).
- `chat_gate_tests` : 9 cas (Allowed default, Banned priorité, Mute permanent/expiré/actif, anti-flood sliding, isolation par account, Decide pure, Reset).

Aucune dépendance MySQL pour les tests : `Sanitize` est pure, `ChatGate` accepte des callbacks mock.

### Configuration

```json
""chat"": {
  ""sanitizer"": { ""max_message_bytes"": 255, ""strip_zero_width"": true },
  ""gate"":      { ""flood_window_ms"": 5000, ""flood_max_messages"": 5, ""max_tracked_accounts"": 4096 }
}
```

Lu au boot par `main_server_linux` ; `Reconfigure` permet de changer à chaud.

## Test plan

- [x] Migration 0044 idempotente (`CREATE TABLE IF NOT EXISTS`).
- [x] Sanitizer ne casse pas les messages ASCII / UTF-8 valides.
- [x] Truncation jamais au milieu d'un codepoint (vérifié à 2/3/4 bytes pour ""h+é+l..."").
- [x] Hyperlinks whitelist : item/quest/achievement/spell passent ; trade rejeté.
- [x] Ban → silencieux. Mute (permanent + temporel) → notice + log. Flooding → notice + log.
- [x] Sliding window per-account ; isolation entre comptes.
- [x] CMakeLists 2 nouveaux test targets enregistrés via `add_test`.
- [ ] CI Linux verte (en attente).

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR REQUIS** (master uniquement) — migration 0044 + nouveau code de sanitization/gate dans `ChatRelayHandler`. Pas de redéploiement client (protocole inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)