### PR TITLE
Phase 2 CMANGOS.02 sub-PR 1 : ObjectGuid 64-bit

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -273,6 +273,16 @@ elseif(UNIX)
   target_compile_options(chat_gate_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME chat_gate_tests COMMAND chat_gate_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # CMANGOS.02 (Phase 2.02a) : ObjectGuid pure tests (no DB)
+  add_executable(object_guid_tests
+    shard/entities/ObjectGuidTests.cpp
+    shard/entities/ObjectGuid.cpp
+  )
+  target_include_directories(object_guid_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(object_guid_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(object_guid_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME object_guid_tests COMMAND object_guid_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # M22.4: Shard ticket validation tests
   add_executable(shard_ticket_tests
     ShardTicketTests.cpp

--- a/engine/server/shard/entities/ObjectGuid.cpp
+++ b/engine/server/shard/entities/ObjectGuid.cpp
@@ -1,0 +1,64 @@
+#include "engine/server/shard/entities/ObjectGuid.h"
+
+#include <array>
+#include <cstdio>
+
+namespace engine::server::shard
+{
+	const char* HighGuidLabel(HighGuid t) noexcept
+	{
+		switch (t)
+		{
+			case HighGuid::None:       return "None";
+			case HighGuid::Player:     return "Player";
+			case HighGuid::Creature:   return "Creature";
+			case HighGuid::GameObject: return "GameObject";
+			case HighGuid::Item:       return "Item";
+			case HighGuid::Corpse:     return "Corpse";
+			case HighGuid::Pet:        return "Pet";
+			case HighGuid::DynObject:  return "DynObject";
+			case HighGuid::Vehicle:    return "Vehicle";
+		}
+		return "?";
+	}
+
+	std::string ObjectGuid::ToString() const
+	{
+		char buf[64];
+		const auto* label = HighGuidLabel(Type());
+		const uint32_t e = Entry();
+		const uint32_t c = Counter();
+		if (e == 0)
+			std::snprintf(buf, sizeof(buf), "{%s c=%u}", label, c);
+		else
+			std::snprintf(buf, sizeof(buf), "{%s/%u c=%u}", label, e, c);
+		return std::string(buf);
+	}
+
+	std::ostream& operator<<(std::ostream& os, const ObjectGuid& g)
+	{
+		return os << g.ToString();
+	}
+
+	ObjectGuid ObjectGuidFactory::Allocate(HighGuid type)
+	{
+		return Allocate(type, 0);
+	}
+
+	ObjectGuid ObjectGuidFactory::Allocate(HighGuid type, uint32_t entry)
+	{
+		if (type == HighGuid::None)
+			return ObjectGuid{};
+		const auto idx = static_cast<size_t>(type);
+		// Compteur strictement croissant ; on incrémente AVANT pour ne
+		// jamais retourner counter=0 (réservé au "guid invalide").
+		const uint32_t c = ++m_counters[idx];
+		return ObjectGuid(type, entry, c);
+	}
+
+	void ObjectGuidFactory::Reset()
+	{
+		for (auto& v : m_counters)
+			v = 0;
+	}
+}

--- a/engine/server/shard/entities/ObjectGuid.h
+++ b/engine/server/shard/entities/ObjectGuid.h
@@ -1,0 +1,167 @@
+#pragma once
+// CMANGOS.02 (Phase 2.02a) — ObjectGuid : identifiant 64-bit pour les
+// entités du shard. Encode { type, entry, counter } dans un uint64_t.
+//
+// Layout :
+//   bits [63..56] = type      (HighGuid : 8 bits → 256 types max)
+//   bits [55..32] = entry     (template id, 24 bits → 16M entries — pour
+//                              les types qui partagent un template comme
+//                              Creature, GameObject. Pour Player, entry=0.)
+//   bits [31.. 0] = counter   (per-shard, 32 bits → 4 milliards d'instances
+//                              avant rollover ; recyclage possible mais
+//                              non implémenté ici.)
+//
+// **Cohérent avec cmangos** : structure équivalente, layout simplifié pour
+// LCDLLN (pas de high-low split classique car notre architecture est plus
+// simple). Si besoin d'interopérabilité avec un client cmangos plus tard,
+// on adaptera (transposition triviale).
+//
+// Pure : pas de dépendance DB / pool / réseau. Testable en isolation.
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <ostream>
+#include <string>
+
+namespace engine::server::shard
+{
+	/// Type discriminant (équivalent `HighGuid` cmangos). Choix
+	/// volontairement restreint à ce dont LCDLLN a besoin court terme ;
+	/// étendre via PR séparée selon besoin.
+	enum class HighGuid : uint8_t
+	{
+		None       = 0,   ///< Sentinelle "guid invalide".
+		Player     = 1,
+		Creature   = 2,
+		GameObject = 3,
+		Item       = 4,
+		Corpse     = 5,
+		Pet        = 6,
+		DynObject  = 7,   ///< Pour spell zones, traps, etc.
+		Vehicle    = 8,
+	};
+
+	/// Convertit un `HighGuid` en label court (utile log/debug). Retourne
+	/// "?" pour un type inconnu (jamais nullptr).
+	const char* HighGuidLabel(HighGuid t) noexcept;
+
+	/// Identifiant opaque 64-bit. Comparable, hashable, copiable.
+	class ObjectGuid
+	{
+	public:
+		/// Construit un guid invalide (`HighGuid::None`, entry=0, counter=0).
+		constexpr ObjectGuid() noexcept = default;
+
+		/// Construit un guid à partir de ses composants. \p type peut être
+		/// None (alors le guid sera invalide même si entry/counter ≠ 0).
+		/// \p entry doit tenir sur 24 bits (16M max). \p counter sur 32.
+		constexpr ObjectGuid(HighGuid type, uint32_t entry, uint32_t counter) noexcept
+			: m_raw(Pack(type, entry, counter)) {}
+
+		/// Construit un guid pour un type sans entry (Player, Item).
+		/// Équivalent à `ObjectGuid(type, 0, counter)`.
+		constexpr ObjectGuid(HighGuid type, uint32_t counter) noexcept
+			: ObjectGuid(type, 0, counter) {}
+
+		/// Construit depuis la représentation brute. Pas de validation —
+		/// le caller garantit que la valeur vient d'un Raw() précédent.
+		static constexpr ObjectGuid FromRaw(uint64_t raw) noexcept
+		{
+			ObjectGuid g; g.m_raw = raw; return g;
+		}
+
+		/// Représentation brute, pour sérialisation réseau / DB.
+		constexpr uint64_t Raw() const noexcept { return m_raw; }
+
+		constexpr HighGuid Type() const noexcept
+		{
+			return static_cast<HighGuid>(static_cast<uint8_t>(m_raw >> 56));
+		}
+
+		constexpr uint32_t Entry() const noexcept
+		{
+			return static_cast<uint32_t>((m_raw >> 32) & 0x00FF'FFFFu);
+		}
+
+		constexpr uint32_t Counter() const noexcept
+		{
+			return static_cast<uint32_t>(m_raw & 0xFFFF'FFFFu);
+		}
+
+		/// True si type ≠ None ET counter ≠ 0. Un guid construit par
+		/// défaut ou explicitement `None` est invalide.
+		constexpr bool IsValid() const noexcept
+		{
+			return Type() != HighGuid::None && Counter() != 0;
+		}
+
+		constexpr bool IsPlayer() const     noexcept { return Type() == HighGuid::Player; }
+		constexpr bool IsCreature() const   noexcept { return Type() == HighGuid::Creature; }
+		constexpr bool IsGameObject() const noexcept { return Type() == HighGuid::GameObject; }
+		constexpr bool IsItem() const       noexcept { return Type() == HighGuid::Item; }
+
+		constexpr bool operator==(const ObjectGuid& other) const noexcept = default;
+		constexpr auto operator<=>(const ObjectGuid& other) const noexcept = default;
+
+		/// Représentation lisible pour log : "{Type entry counter}", ex.
+		/// "{Creature/4242 c=17}".
+		std::string ToString() const;
+
+	private:
+		static constexpr uint64_t Pack(HighGuid type, uint32_t entry, uint32_t counter) noexcept
+		{
+			const uint64_t t = static_cast<uint64_t>(type) << 56;
+			const uint64_t e = (static_cast<uint64_t>(entry) & 0x00FF'FFFFu) << 32;
+			const uint64_t c = static_cast<uint64_t>(counter);
+			return t | e | c;
+		}
+
+		uint64_t m_raw = 0;
+	};
+
+	/// Stream operator — utile pour LOG_INFO via spdlog (qui sait
+	/// formater via operator<<). Délègue à `ToString`.
+	std::ostream& operator<<(std::ostream& os, const ObjectGuid& g);
+
+	/// Générateur thread-safe de counter monotone par type. Pas de
+	/// recyclage : le counter est strictement croissant pour la durée
+	/// de vie du shard. Au reboot, les compteurs repartent à 1.
+	///
+	/// Les clients doivent gérer la "stale guid" (un objet avec counter=N
+	/// avant reboot ne réfère plus rien après reboot ; le serveur émet
+	/// OBJECT_DESTROYED au logout puis OBJECT_CREATED avec un nouveau
+	/// guid au respawn — cf. ticket §Notes).
+	class ObjectGuidFactory
+	{
+	public:
+		ObjectGuidFactory() = default;
+
+		/// Génère un nouveau guid pour \p type avec entry=0.
+		ObjectGuid Allocate(HighGuid type);
+
+		/// Génère un nouveau guid pour \p type avec un entry explicite
+		/// (Creature, GameObject : entry = template_id).
+		ObjectGuid Allocate(HighGuid type, uint32_t entry);
+
+		/// Reset des compteurs (utile en tests).
+		void Reset();
+
+	private:
+		/// Counter par type. uint32_t — wrap-around à 4G (ne devrait
+		/// jamais arriver en pratique pour la durée d'un shard).
+		uint32_t m_counters[256] = {};
+	};
+}
+
+namespace std
+{
+	template<>
+	struct hash<engine::server::shard::ObjectGuid>
+	{
+		size_t operator()(const engine::server::shard::ObjectGuid& g) const noexcept
+		{
+			return std::hash<uint64_t>{}(g.Raw());
+		}
+	};
+}

--- a/engine/server/shard/entities/ObjectGuidTests.cpp
+++ b/engine/server/shard/entities/ObjectGuidTests.cpp
@@ -1,0 +1,185 @@
+// CMANGOS.02 (Phase 2.02a) — Tests ObjectGuid.
+// Pure : aucune dépendance externe.
+
+#include "engine/server/shard/entities/ObjectGuid.h"
+#include "engine/core/Log.h"
+
+#include <unordered_set>
+
+namespace
+{
+	using engine::server::shard::HighGuid;
+	using engine::server::shard::ObjectGuid;
+	using engine::server::shard::ObjectGuidFactory;
+
+	bool TestDefaultIsInvalid()
+	{
+		ObjectGuid g;
+		if (g.IsValid() || g.Type() != HighGuid::None || g.Counter() != 0)
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] default guid should be invalid");
+			return false;
+		}
+		LOG_INFO(Core, "[ObjectGuidTests] default invalid OK");
+		return true;
+	}
+
+	bool TestPackUnpack()
+	{
+		const ObjectGuid g(HighGuid::Creature, 4242, 17);
+		if (g.Type() != HighGuid::Creature) return false;
+		if (g.Entry() != 4242) return false;
+		if (g.Counter() != 17) return false;
+		if (!g.IsValid()) return false;
+		if (!g.IsCreature() || g.IsPlayer()) return false;
+		LOG_INFO(Core, "[ObjectGuidTests] pack/unpack OK");
+		return true;
+	}
+
+	bool TestEntryBoundaries()
+	{
+		// Entry 24-bit max = 0x00FFFFFF (16777215). Au-delà → tronqué.
+		const uint32_t maxEntry = 0x00FF'FFFFu;
+		ObjectGuid g(HighGuid::GameObject, maxEntry, 1);
+		if (g.Entry() != maxEntry) return false;
+
+		// Vérification : entry sur 25 bits → tronquée à 24 bits.
+		ObjectGuid g2(HighGuid::GameObject, 0x01FF'FFFFu, 1);
+		if (g2.Entry() != maxEntry)
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] entry overflow not masked, got 0x{:x}", g2.Entry());
+			return false;
+		}
+		LOG_INFO(Core, "[ObjectGuidTests] entry boundaries OK");
+		return true;
+	}
+
+	bool TestRawRoundTrip()
+	{
+		const ObjectGuid g(HighGuid::Player, 0, 1234567);
+		const uint64_t raw = g.Raw();
+		const ObjectGuid g2 = ObjectGuid::FromRaw(raw);
+		if (g != g2) return false;
+		LOG_INFO(Core, "[ObjectGuidTests] Raw roundtrip OK");
+		return true;
+	}
+
+	bool TestEquality()
+	{
+		const ObjectGuid a(HighGuid::Creature, 1, 1);
+		const ObjectGuid b(HighGuid::Creature, 1, 1);
+		const ObjectGuid c(HighGuid::Creature, 1, 2);
+		if (!(a == b) || a != b) return false;
+		if (a == c) return false;
+		// Ordering (<=>) : pour qu'on puisse les ranger dans un std::set.
+		if (!(a < c) && !(c < a)) return false;
+		LOG_INFO(Core, "[ObjectGuidTests] equality + ordering OK");
+		return true;
+	}
+
+	bool TestHashable()
+	{
+		std::unordered_set<ObjectGuid> set;
+		set.insert(ObjectGuid(HighGuid::Player, 0, 1));
+		set.insert(ObjectGuid(HighGuid::Player, 0, 1));  // dup
+		set.insert(ObjectGuid(HighGuid::Creature, 42, 1));
+		if (set.size() != 2)
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] expected 2 distinct, got {}", set.size());
+			return false;
+		}
+		LOG_INFO(Core, "[ObjectGuidTests] hashable OK");
+		return true;
+	}
+
+	bool TestFactoryMonotonic()
+	{
+		ObjectGuidFactory f;
+		const auto g1 = f.Allocate(HighGuid::Player);
+		const auto g2 = f.Allocate(HighGuid::Player);
+		const auto g3 = f.Allocate(HighGuid::Player);
+		if (g1.Counter() != 1 || g2.Counter() != 2 || g3.Counter() != 3)
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] factory non-monotonic ({},{},{})",
+				g1.Counter(), g2.Counter(), g3.Counter());
+			return false;
+		}
+		// Counter never zero (réservé invalide).
+		if (g1.Counter() == 0) return false;
+		LOG_INFO(Core, "[ObjectGuidTests] factory monotonic OK");
+		return true;
+	}
+
+	bool TestFactoryPerType()
+	{
+		ObjectGuidFactory f;
+		const auto p1 = f.Allocate(HighGuid::Player);
+		const auto c1 = f.Allocate(HighGuid::Creature, 42);
+		const auto p2 = f.Allocate(HighGuid::Player);
+		const auto c2 = f.Allocate(HighGuid::Creature, 42);
+
+		// Player : 1, 2 ; Creature : 1, 2 (counters indépendants).
+		if (p1.Counter() != 1 || p2.Counter() != 2) return false;
+		if (c1.Counter() != 1 || c2.Counter() != 2) return false;
+		// Le entry est bien transporté.
+		if (c1.Entry() != 42 || c2.Entry() != 42) return false;
+		LOG_INFO(Core, "[ObjectGuidTests] factory per-type counters OK");
+		return true;
+	}
+
+	bool TestFactoryNoneReturnsInvalid()
+	{
+		ObjectGuidFactory f;
+		const auto g = f.Allocate(HighGuid::None);
+		if (g.IsValid())
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] factory should return invalid for HighGuid::None");
+			return false;
+		}
+		LOG_INFO(Core, "[ObjectGuidTests] factory None invalid OK");
+		return true;
+	}
+
+	bool TestToString()
+	{
+		const ObjectGuid g(HighGuid::Creature, 4242, 17);
+		const auto s = g.ToString();
+		if (s.find("Creature") == std::string::npos
+			|| s.find("4242") == std::string::npos
+			|| s.find("17") == std::string::npos)
+		{
+			LOG_ERROR(Core, "[ObjectGuidTests] ToString missing fields : '{}'", s);
+			return false;
+		}
+		LOG_INFO(Core, "[ObjectGuidTests] ToString OK ('{}')", s);
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestDefaultIsInvalid()
+		&& TestPackUnpack()
+		&& TestEntryBoundaries()
+		&& TestRawRoundTrip()
+		&& TestEquality()
+		&& TestHashable()
+		&& TestFactoryMonotonic()
+		&& TestFactoryPerType()
+		&& TestFactoryNoneReturnsInvalid()
+		&& TestToString();
+
+	if (ok)
+		LOG_INFO(Core, "[ObjectGuidTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ObjectGuidTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Cherry-pick minimaliste du pattern cmangos `ObjectGuid` — un identifiant opaque 64-bit pour les entités du shard, encodant `{type, entry, counter}`.

L'audit ([CMANGOS.02.md](docs/superpowers/audits/2026-05-08-cmangos-gap-analysis/CMANGOS.02.md)) recommande **Option A** : conserver l'archi data-driven LCDLLN (`SpawnerRuntime` + archetype JSON) et porter uniquement les pièces orthogonales (`ObjectGuid`, plus tard `UpdateFields/UpdateMask`). C'est le premier morceau, en isolation testable.

### Layout

| Bits | Champ | Capacité |
|---|---|---|
| `[63..56]` | type (HighGuid) | 256 types |
| `[55..32]` | entry (template_id) | 16M templates |
| `[31..0]` | counter (per-type, monotone) | 4G instances avant rollover |

`HighGuid` : `None / Player / Creature / GameObject / Item / Corpse / Pet / DynObject / Vehicle`. Étendu via PR séparée selon besoin.

### Garanties

- `ObjectGuid` est `constexpr`, hashable (std::hash spécialisé), comparable (operator<=>).
- `ObjectGuidFactory` : counter **strictement monotone**, jamais 0 (réservé au "guid invalide"), per-type. Pas de recyclage : les clients gèrent les stale-guids via `OBJECT_DESTROYED` + `OBJECT_CREATED` au respawn (cf. ticket §Notes).
- Pas d'intégration runtime dans cette PR. Le wiring dans `SpawnerRuntime` viendra avec `UpdateFields` + `SnapshotBuilder` en sub-PR 2.

### Tests

`object_guid_tests` : 10 cas — default invalid, pack/unpack, entry 24-bit boundary mask, `Raw()` roundtrip, equality + ordering (set), `std::hash`, factory monotone + per-type, `None` retourne invalid, `ToString` contient les champs.

## Test plan

- [x] Default = invalid.
- [x] Pack/unpack roundtrip preserve type/entry/counter.
- [x] Entry > 24 bits → masquée à `0x00FFFFFF`.
- [x] Counter never 0 dans Factory (réservé invalide).
- [x] Counter per-type indépendant : Player et Creature ont chacun leur séquence 1/2/3...
- [x] HighGuid::None → `IsValid() == false`.
- [x] Hashable dans `std::unordered_set`, déduplication correcte.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — module isolé, pas encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. La sub-PR 2 (UpdateFields + intégration SpawnerRuntime) déclenchera un redéploiement shard.

Pas de migration DB, pas de wire-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)