### PR TITLE
Phase 2 CMANGOS.01 sub-PR 2 : ChatCommandRouter + ChatChannelRegistry

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -103,6 +103,8 @@ elseif(UNIX)
     ChatRelayHandler.cpp
     chat/ChatSanitizer.cpp
     chat/ChatGate.cpp
+    chat/ChatCommandRouter.cpp
+    chat/ChatChannelRegistry.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp
@@ -314,6 +316,31 @@ elseif(UNIX)
   target_link_libraries(vmap_format_tests PRIVATE engine_core spdlog::spdlog pthread)
   target_compile_options(vmap_format_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME vmap_format_tests COMMAND vmap_format_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
+  add_executable(chat_command_router_tests
+    chat/ChatCommandRouterTests.cpp
+    chat/ChatCommandRouter.cpp
+    AccountRoleService.cpp
+    AccountRole.cpp
+    InMemoryAccountStore.cpp
+    AccountValidation.cpp
+    ${CMAKE_SOURCE_DIR}/engine/server/SecurityAuditLog.cpp
+  )
+  target_include_directories(chat_command_router_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(chat_command_router_tests PRIVATE engine_core engine_auth OpenSSL::SSL spdlog::spdlog pthread)
+  target_compile_options(chat_command_router_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME chat_command_router_tests COMMAND chat_command_router_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # CMANGOS.01 (Phase 2.01b) : ChatChannelRegistry pure tests
+  add_executable(chat_channel_registry_tests
+    chat/ChatChannelRegistryTests.cpp
+    chat/ChatChannelRegistry.cpp
+  )
+  target_include_directories(chat_channel_registry_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(chat_channel_registry_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(chat_channel_registry_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME chat_channel_registry_tests COMMAND chat_channel_registry_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M22.4: Shard ticket validation tests
   add_executable(shard_ticket_tests

--- a/engine/server/ChatRelayHandler.cpp
+++ b/engine/server/ChatRelayHandler.cpp
@@ -164,6 +164,57 @@ namespace engine::server
 			}
 		}
 
+		// Phase 2 CMANGOS.01 sub-PR 2 — ChatCommandRouter : si le texte
+		// commence par '/', on tente un dispatch avant le routage de canal.
+		// Si Dispatched ou InsufficientRole/UnknownCommand, on consume le
+		// message (pas de broadcast). Si NotACommand (pas un '/'), on
+		// continue le flot normal. Si le router est vide (pas de commande
+		// enregistrée), tout '/foo' devient UnknownCommand → on coupe la
+		// chaîne avec une notice — politique conservative : ne pas
+		// broadcaster un slash-command non géré.
+		if (!parsed->text.empty() && parsed->text.front() == '/' && m_accounts)
+		{
+			std::string cmdName;
+			const auto callerRole = m_accounts->GetRole(*accountId);
+			const auto dispatch = m_commandRouter.Dispatch(parsed->text, *accountId,
+				callerRole, &cmdName);
+			switch (dispatch)
+			{
+				case chat::CommandDispatchResult::Dispatched:
+					LOG_INFO(Net, "[ChatRelayHandler] cmd dispatched account={} cmd='/{}'",
+						*accountId, cmdName);
+					return;
+				case chat::CommandDispatchResult::InsufficientRole:
+				{
+					const uint64_t ts0 = NowUnixMsUtc();
+					auto notice = BuildChatRelayPacket(ts0,
+						static_cast<uint8_t>(engine::net::ChatChannel::Server),
+						"system", "Insufficient permissions for that command.",
+						sessionIdHeader);
+					if (!notice.empty())
+						m_server->Send(connId, notice);
+					LOG_INFO(Net, "[ChatRelayHandler] cmd denied account={} cmd='/{}' role={}",
+						*accountId, cmdName, static_cast<int>(callerRole));
+					return;
+				}
+				case chat::CommandDispatchResult::UnknownCommand:
+				{
+					const uint64_t ts0 = NowUnixMsUtc();
+					auto notice = BuildChatRelayPacket(ts0,
+						static_cast<uint8_t>(engine::net::ChatChannel::Server),
+						"system", "Unknown command : /" + cmdName,
+						sessionIdHeader);
+					if (!notice.empty())
+						m_server->Send(connId, notice);
+					return;
+				}
+				case chat::CommandDispatchResult::NotACommand:
+					// Ne devrait pas arriver vu le check '/' au-dessus,
+					// mais par sûreté : on continue le routage.
+					break;
+			}
+		}
+
 		// Phase 4 — Sender display name : preference au character_name (post-EnterWorld)
 		// via SessionCharacterMap, fallback au login d'account si le client n'a pas encore
 		// declaré son perso (ex. message envoyé entre EnterWorld et la confirmation du

--- a/engine/server/ChatRelayHandler.h
+++ b/engine/server/ChatRelayHandler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "engine/server/chat/ChatChannelRegistry.h"
+#include "engine/server/chat/ChatCommandRouter.h"
 #include "engine/server/chat/ChatGate.h"
 #include "engine/server/chat/ChatSanitizer.h"
 
@@ -62,6 +64,16 @@ namespace engine::server
 		/// au boot de ServerApp.
 		chat::ChatGate& Gate() { return m_gate; }
 
+		/// Phase 2 CMANGOS.01 sub-PR 2 : router de slash-commands. Si non
+		/// peuplé via Register(...), tout slash-command est laissé passer
+		/// au routage de canal classique.
+		chat::ChatCommandRouter& CommandRouter() { return m_commandRouter; }
+
+		/// Phase 2 CMANGOS.01 sub-PR 2 : registry des canaux dynamiques.
+		/// Pas encore exploité par HandlePacket (ChatChannel::Custom à
+		/// venir) ; exposé pour câblage par les handlers /join, /leave.
+		chat::ChatChannelRegistry& Channels() { return m_channels; }
+
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
 
@@ -75,5 +87,7 @@ namespace engine::server
 
 		chat::ChatSanitizerConfig           m_sanitizerCfg{};
 		chat::ChatGate                      m_gate{};
+		chat::ChatCommandRouter             m_commandRouter{};
+		chat::ChatChannelRegistry           m_channels{};
 	};
 }

--- a/engine/server/chat/ChatChannelRegistry.cpp
+++ b/engine/server/chat/ChatChannelRegistry.cpp
@@ -1,0 +1,236 @@
+#include "engine/server/chat/ChatChannelRegistry.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace engine::server::chat
+{
+	namespace
+	{
+		constexpr size_t kMinNameLen = 1;
+		constexpr size_t kMaxNameLen = 32;
+
+		/// Caractère ASCII printable non-espace, non-'/' ?
+		bool IsValidNameChar(char c) noexcept
+		{
+			const auto u = static_cast<unsigned char>(c);
+			if (u <= 0x20 || u >= 0x7F) return false; // ASCII printable strict
+			if (c == '/') return false;
+			return true;
+		}
+	}
+
+	std::string ChatChannelRegistry::NormalizeName(std::string_view name)
+	{
+		if (name.size() < kMinNameLen || name.size() > kMaxNameLen)
+			return {};
+		std::string out;
+		out.reserve(name.size());
+		for (char c : name)
+		{
+			if (!IsValidNameChar(c))
+				return {};
+			const auto u = static_cast<unsigned char>(c);
+			if (u >= 'A' && u <= 'Z')
+				out.push_back(static_cast<char>(u + ('a' - 'A')));
+			else
+				out.push_back(c);
+		}
+		return out;
+	}
+
+	ChannelJoinResult ChatChannelRegistry::Join(uint64_t accountId,
+		std::string_view channel, std::string_view password)
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return ChannelJoinResult::InvalidName;
+
+		std::lock_guard<std::mutex> lk(m_mutex);
+
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+		{
+			// Création : accountId devient owner. Pas de password initial
+			// (l'owner peut le set ensuite via SetPassword). Pas de bans.
+			Channel ch;
+			ch.name  = key;
+			ch.owner = accountId;
+			ch.members.insert(accountId);
+			m_channels.emplace(key, std::move(ch));
+			return ChannelJoinResult::OK;
+		}
+
+		Channel& ch = it->second;
+		if (ch.bans.count(accountId) != 0)
+			return ChannelJoinResult::Banned;
+
+		if (!ch.password.empty() && password != ch.password)
+			return ChannelJoinResult::WrongPassword;
+
+		const auto inserted = ch.members.insert(accountId).second;
+		return inserted ? ChannelJoinResult::OK : ChannelJoinResult::AlreadyMember;
+	}
+
+	void ChatChannelRegistry::Leave(uint64_t accountId, std::string_view channel)
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return;
+
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return;
+		Channel& ch = it->second;
+		ch.members.erase(accountId);
+		if (ch.members.empty())
+		{
+			m_channels.erase(it);
+			return;
+		}
+		// Transfert d'ownership si owner sortant.
+		if (ch.owner == accountId)
+		{
+			// Premier membre dans l'unordered_set (ordre non-stable mais
+			// déterministe pour une session donnée).
+			ch.owner = *ch.members.begin();
+		}
+	}
+
+	void ChatChannelRegistry::LeaveAll(uint64_t accountId)
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		// Itère + collecte les canaux à supprimer pour ne pas invalider
+		// l'itérateur principal pendant l'effacement.
+		for (auto it = m_channels.begin(); it != m_channels.end(); )
+		{
+			Channel& ch = it->second;
+			ch.members.erase(accountId);
+			if (ch.members.empty())
+			{
+				it = m_channels.erase(it);
+				continue;
+			}
+			if (ch.owner == accountId)
+				ch.owner = *ch.members.begin();
+			++it;
+		}
+	}
+
+	std::vector<uint64_t> ChatChannelRegistry::Members(std::string_view channel) const
+	{
+		std::vector<uint64_t> out;
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return out;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return out;
+		out.reserve(it->second.members.size());
+		for (auto id : it->second.members)
+			out.push_back(id);
+		return out;
+	}
+
+	bool ChatChannelRegistry::IsMember(uint64_t accountId, std::string_view channel) const
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return false;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return false;
+		return it->second.members.count(accountId) != 0;
+	}
+
+	bool ChatChannelRegistry::SetPassword(uint64_t actor, std::string_view channel,
+		std::string_view password)
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return false;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return false;
+		if (it->second.owner != actor)
+			return false;
+		it->second.password = std::string(password);
+		return true;
+	}
+
+	bool ChatChannelRegistry::Ban(uint64_t actor, std::string_view channel, uint64_t target)
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return false;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return false;
+		Channel& ch = it->second;
+		if (ch.owner != actor)
+			return false;
+		// L'owner ne peut pas se ban lui-même (no-op).
+		if (target == actor)
+			return false;
+		ch.bans.insert(target);
+		ch.members.erase(target);
+		// Si on bannit le seul autre membre alors qu'on est l'owner, on
+		// reste seul ; ne pas effacer le canal (l'owner est encore là).
+		return true;
+	}
+
+	bool ChatChannelRegistry::Unban(uint64_t actor, std::string_view channel, uint64_t target)
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return false;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return false;
+		if (it->second.owner != actor)
+			return false;
+		it->second.bans.erase(target);
+		return true;
+	}
+
+	bool ChatChannelRegistry::IsBanned(uint64_t accountId, std::string_view channel) const
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return false;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return false;
+		return it->second.bans.count(accountId) != 0;
+	}
+
+	std::optional<ChannelInfo> ChatChannelRegistry::Info(std::string_view channel) const
+	{
+		const auto key = NormalizeName(channel);
+		if (key.empty())
+			return std::nullopt;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_channels.find(key);
+		if (it == m_channels.end())
+			return std::nullopt;
+		ChannelInfo info;
+		info.name           = it->second.name;
+		info.ownerAccountId = it->second.owner;
+		info.hasPassword    = !it->second.password.empty();
+		info.memberCount    = it->second.members.size();
+		return info;
+	}
+
+	size_t ChatChannelRegistry::ChannelCount() const
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		return m_channels.size();
+	}
+}

--- a/engine/server/chat/ChatChannelRegistry.h
+++ b/engine/server/chat/ChatChannelRegistry.h
@@ -1,0 +1,124 @@
+#pragma once
+// CMANGOS.01 (Phase 2.01b) — ChatChannelRegistry : canaux dynamiques
+// in-memory côté master. Permet aux joueurs de /join un canal nommé
+// (avec password optionnel), maintient la liste des membres, applique
+// une ban-list par canal.
+//
+// Pas de persistance dans cette PR : tous les canaux dynamiques sont
+// volatils (perdus au reboot du master). Les canaux "système"
+// (Say/Yell/Guild/...) ne passent PAS par ce registry — ils sont
+// résolus directement dans `ChatRelayHandler`.
+//
+// Design :
+//   - Canal identifié par son nom normalisé (lower-case ASCII).
+//   - Owner : premier joueur à `Join` un canal qui n'existe pas. Peut
+//     `SetPassword`, `Ban`, `Unban`. Si l'owner se déconnecte, son rôle
+//     est transféré au plus ancien membre encore présent.
+//   - Password : stocké en clair côté master (RAM). Vide = canal libre.
+//   - Ban-list : set d'`account_id` ; `Join` retourne `Banned`.
+//   - Membership : set d'`account_id` par canal.
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::server::chat
+{
+	enum class ChannelJoinResult : uint8_t
+	{
+		/// Joueur ajouté (création du canal le cas échéant).
+		OK = 0,
+		/// Mot de passe incorrect.
+		WrongPassword = 1,
+		/// Joueur banni du canal par l'owner.
+		Banned = 2,
+		/// Nom invalide (vide, trop long, ou caractères interdits).
+		InvalidName = 3,
+		/// Le joueur est déjà membre — no-op idempotent.
+		AlreadyMember = 4,
+	};
+
+	struct ChannelInfo
+	{
+		std::string                       name;            // normalisé
+		uint64_t                          ownerAccountId;
+		bool                              hasPassword;
+		size_t                            memberCount;
+	};
+
+	class ChatChannelRegistry
+	{
+	public:
+		ChatChannelRegistry() = default;
+
+		/// Ajoute \p accountId au canal \p channel. Crée le canal si
+		/// inexistant (dans ce cas \p accountId devient l'owner).
+		///
+		/// \param channel  Nom case-insensitive (sera normalisé). 1..32 chars,
+		///                 ASCII printable hors espace/'/'.
+		/// \param password Optionnel. Si le canal a un password set et que
+		///                 \p password ne match pas → `WrongPassword`.
+		ChannelJoinResult Join(uint64_t accountId,
+			std::string_view channel,
+			std::string_view password = {});
+
+		/// Retire \p accountId du canal. Idempotent. Si l'owner part et
+		/// que d'autres membres restent, l'ownership passe au prochain
+		/// (premier dans la table interne — ordre non-stable mais
+		/// déterministe pour une session). Si plus aucun membre, le
+		/// canal est supprimé du registry.
+		void Leave(uint64_t accountId, std::string_view channel);
+
+		/// Retire \p accountId de TOUS les canaux. Pour le logout/déconnexion.
+		void LeaveAll(uint64_t accountId);
+
+		/// Membres d'un canal (snapshot, ordre non-spécifié).
+		std::vector<uint64_t> Members(std::string_view channel) const;
+
+		/// True si \p accountId est membre du canal \p channel.
+		bool IsMember(uint64_t accountId, std::string_view channel) const;
+
+		/// Set / clear le password. Réservé à l'owner du canal.
+		/// Retourne true si OK ; false si \p actor n'est pas l'owner.
+		/// Password vide = clear (canal libre).
+		bool SetPassword(uint64_t actor, std::string_view channel, std::string_view password);
+
+		/// Ban un account du canal. Réservé à l'owner. Le banni sort
+		/// automatiquement du canal s'il y est encore.
+		bool Ban(uint64_t actor, std::string_view channel, uint64_t target);
+
+		/// Unban un account. Réservé à l'owner.
+		bool Unban(uint64_t actor, std::string_view channel, uint64_t target);
+
+		/// True si \p accountId est banni du canal.
+		bool IsBanned(uint64_t accountId, std::string_view channel) const;
+
+		/// Information publique sur un canal (nullopt si inexistant).
+		std::optional<ChannelInfo> Info(std::string_view channel) const;
+
+		/// Nombre de canaux actifs (utile pour métriques / debug).
+		size_t ChannelCount() const;
+
+	private:
+		struct Channel
+		{
+			std::string                     name;          // normalisé
+			uint64_t                        owner = 0;
+			std::string                     password;      // vide = pas de password
+			std::unordered_set<uint64_t>    members;
+			std::unordered_set<uint64_t>    bans;
+		};
+
+		/// Normalise + valide un nom de canal. Retourne la chaîne vide si
+		/// invalide.
+		static std::string NormalizeName(std::string_view name);
+
+		mutable std::mutex                          m_mutex;
+		std::unordered_map<std::string, Channel>    m_channels;
+	};
+}

--- a/engine/server/chat/ChatChannelRegistryTests.cpp
+++ b/engine/server/chat/ChatChannelRegistryTests.cpp
@@ -1,0 +1,253 @@
+// CMANGOS.01 (Phase 2.01b) — Tests ChatChannelRegistry.
+// Pure : aucune dépendance externe. RAM-only.
+
+#include "engine/server/chat/ChatChannelRegistry.h"
+#include "engine/core/Log.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace
+{
+	using engine::server::chat::ChannelJoinResult;
+	using engine::server::chat::ChatChannelRegistry;
+
+	bool TestJoinCreatesChannel()
+	{
+		ChatChannelRegistry r;
+		const auto j = r.Join(1, "world");
+		if (j != ChannelJoinResult::OK)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] Join expected OK, got {}",
+				static_cast<int>(j));
+			return false;
+		}
+		auto info = r.Info("world");
+		if (!info || info->ownerAccountId != 1 || info->memberCount != 1
+			|| info->hasPassword)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] info wrong after first Join");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatChannelRegistryTests] Join creates channel + ownership OK");
+		return true;
+	}
+
+	bool TestJoinIdempotent()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "trade");
+		const auto j2 = r.Join(1, "trade");
+		if (j2 != ChannelJoinResult::AlreadyMember)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] re-Join should be AlreadyMember, got {}",
+				static_cast<int>(j2));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatChannelRegistryTests] Join idempotent OK");
+		return true;
+	}
+
+	bool TestPasswordWrong()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "secret");
+		if (!r.SetPassword(1, "secret", "hush"))
+			return false;
+		const auto j = r.Join(2, "secret", "wrong");
+		if (j != ChannelJoinResult::WrongPassword)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] wrong password should be rejected");
+			return false;
+		}
+		const auto j2 = r.Join(2, "secret", "hush");
+		if (j2 != ChannelJoinResult::OK)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] correct password should accept");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatChannelRegistryTests] password OK");
+		return true;
+	}
+
+	bool TestBanFlow()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "elite");
+		r.Join(2, "elite");
+		// Owner=1 bannit 2.
+		if (!r.Ban(1, "elite", 2))
+			return false;
+		if (!r.IsBanned(2, "elite"))
+			return false;
+		if (r.IsMember(2, "elite"))
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] banned member should be ejected");
+			return false;
+		}
+		// 2 tente de rejoindre → Banned.
+		if (r.Join(2, "elite") != ChannelJoinResult::Banned)
+			return false;
+
+		// Non-owner tente de bannir → refus.
+		r.Join(3, "elite");
+		if (r.Ban(3, "elite", 1))
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] non-owner Ban should fail");
+			return false;
+		}
+
+		// Unban remet en jeu.
+		if (!r.Unban(1, "elite", 2))
+			return false;
+		if (r.IsBanned(2, "elite"))
+			return false;
+		if (r.Join(2, "elite") != ChannelJoinResult::OK)
+			return false;
+
+		LOG_INFO(Core, "[ChatChannelRegistryTests] ban/unban flow OK");
+		return true;
+	}
+
+	bool TestLeaveAndOwnerTransfer()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "lobby");
+		r.Join(2, "lobby");
+		r.Join(3, "lobby");
+		auto info = r.Info("lobby");
+		if (!info || info->ownerAccountId != 1)
+			return false;
+
+		// Owner part : transfer.
+		r.Leave(1, "lobby");
+		info = r.Info("lobby");
+		if (!info)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] channel should still exist after owner leave");
+			return false;
+		}
+		if (info->ownerAccountId == 1)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] ownership should have transferred");
+			return false;
+		}
+		if (info->ownerAccountId != 2 && info->ownerAccountId != 3)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] new owner unexpected");
+			return false;
+		}
+
+		// Tous partent : canal supprimé.
+		r.Leave(2, "lobby");
+		r.Leave(3, "lobby");
+		if (r.Info("lobby"))
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] channel should be deleted after last leave");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatChannelRegistryTests] Leave + owner transfer OK");
+		return true;
+	}
+
+	bool TestLeaveAll()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "a");
+		r.Join(1, "b");
+		r.Join(1, "c");
+		r.Join(2, "a");
+
+		r.LeaveAll(1);
+		// b et c étaient solo (1 seul membre = owner) → supprimés.
+		// a avait aussi 2 → reste, ownership transféré à 2.
+		if (r.Info("b") || r.Info("c"))
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] solo channels of LeaveAll should be deleted");
+			return false;
+		}
+		auto info = r.Info("a");
+		if (!info || info->ownerAccountId != 2)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] LeaveAll : a should still exist with owner=2");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatChannelRegistryTests] LeaveAll OK");
+		return true;
+	}
+
+	bool TestNameNormalizationAndValidation()
+	{
+		ChatChannelRegistry r;
+		// Case-insensitive : "World" et "world" sont le même canal.
+		r.Join(1, "World");
+		const auto j2 = r.Join(2, "WORLD");
+		if (j2 != ChannelJoinResult::OK)
+			return false;
+		auto info = r.Info("world");
+		if (!info || info->memberCount != 2)
+			return false;
+
+		// Nom invalide (vide).
+		if (r.Join(1, "") != ChannelJoinResult::InvalidName)
+			return false;
+		// Nom invalide (trop long).
+		std::string tooLong(33, 'a');
+		if (r.Join(1, tooLong) != ChannelJoinResult::InvalidName)
+			return false;
+		// Nom invalide ('/').
+		if (r.Join(1, "ab/cd") != ChannelJoinResult::InvalidName)
+			return false;
+		// Nom invalide (espace).
+		if (r.Join(1, "ab cd") != ChannelJoinResult::InvalidName)
+			return false;
+
+		LOG_INFO(Core, "[ChatChannelRegistryTests] name normalization + validation OK");
+		return true;
+	}
+
+	bool TestMembersAndCount()
+	{
+		ChatChannelRegistry r;
+		r.Join(1, "x");
+		r.Join(2, "x");
+		r.Join(3, "x");
+		auto m = r.Members("x");
+		std::sort(m.begin(), m.end());
+		if (m.size() != 3 || m[0] != 1 || m[1] != 2 || m[2] != 3)
+		{
+			LOG_ERROR(Core, "[ChatChannelRegistryTests] Members snapshot wrong");
+			return false;
+		}
+		if (r.ChannelCount() != 1)
+			return false;
+		LOG_INFO(Core, "[ChatChannelRegistryTests] Members + ChannelCount OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestJoinCreatesChannel()
+		&& TestJoinIdempotent()
+		&& TestPasswordWrong()
+		&& TestBanFlow()
+		&& TestLeaveAndOwnerTransfer()
+		&& TestLeaveAll()
+		&& TestNameNormalizationAndValidation()
+		&& TestMembersAndCount();
+
+	if (ok)
+		LOG_INFO(Core, "[ChatChannelRegistryTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ChatChannelRegistryTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/chat/ChatCommandRouter.cpp
+++ b/engine/server/chat/ChatCommandRouter.cpp
@@ -1,0 +1,93 @@
+#include "engine/server/chat/ChatCommandRouter.h"
+#include "engine/server/AccountRoleService.h"
+
+#include <cctype>
+
+namespace engine::server::chat
+{
+	std::string ChatCommandRouter::Normalize(std::string_view name)
+	{
+		std::string out;
+		out.reserve(name.size());
+		size_t i = 0;
+		// Strip leading '/' (au moins un, au plus un — '/'+'/' devient '/'+'rest')
+		if (i < name.size() && name[i] == '/')
+			++i;
+		for (; i < name.size(); ++i)
+		{
+			const auto c = static_cast<unsigned char>(name[i]);
+			if (c >= 'A' && c <= 'Z')
+				out.push_back(static_cast<char>(c + ('a' - 'A')));
+			else
+				out.push_back(static_cast<char>(c));
+		}
+		return out;
+	}
+
+	void ChatCommandRouter::Register(std::string_view name, AccountRole minRole, CommandHandlerFn handler)
+	{
+		const auto key = Normalize(name);
+		if (key.empty())
+			return;
+		m_table[key] = CommandEntry{minRole, std::move(handler)};
+	}
+
+	void ChatCommandRouter::Unregister(std::string_view name)
+	{
+		const auto key = Normalize(name);
+		if (key.empty())
+			return;
+		m_table.erase(key);
+	}
+
+	bool ChatCommandRouter::IsRegistered(std::string_view name) const
+	{
+		return m_table.find(Normalize(name)) != m_table.end();
+	}
+
+	CommandDispatchResult ChatCommandRouter::Dispatch(std::string_view text,
+		uint64_t accountId, AccountRole role, std::string* outName) const
+	{
+		// Doit commencer par '/' — sinon pas une commande, le caller
+		// continue le routage normal.
+		if (text.empty() || text.front() != '/')
+			return CommandDispatchResult::NotACommand;
+
+		// Skip leading '/'. Si juste '/' tout seul → unknown.
+		text.remove_prefix(1);
+		if (text.empty())
+			return CommandDispatchResult::UnknownCommand;
+
+		// Sépare nom et args. Le premier "mot" (jusqu'au premier espace)
+		// est le nom ; le reste est les args. ASCII space + tab.
+		size_t end = 0;
+		while (end < text.size() && text[end] != ' ' && text[end] != '\t')
+			++end;
+
+		const std::string_view rawName = text.substr(0, end);
+		std::string_view args = (end < text.size()) ? text.substr(end + 1) : std::string_view{};
+
+		// Trim leading whitespace from args.
+		while (!args.empty() && (args.front() == ' ' || args.front() == '\t'))
+			args.remove_prefix(1);
+		while (!args.empty() && (args.back() == ' ' || args.back() == '\t'))
+			args.remove_suffix(1);
+
+		const auto key = Normalize(rawName);
+		if (outName)
+			*outName = key;
+
+		auto it = m_table.find(key);
+		if (it == m_table.end())
+			return CommandDispatchResult::UnknownCommand;
+
+		// Check rôle.
+		if (!engine::server::AccountRoleService::RequireMinRole(role, it->second.minRole))
+			return CommandDispatchResult::InsufficientRole;
+
+		// Dispatch.
+		if (it->second.handler)
+			it->second.handler(accountId, args);
+		return CommandDispatchResult::Dispatched;
+	}
+}

--- a/engine/server/chat/ChatCommandRouter.h
+++ b/engine/server/chat/ChatCommandRouter.h
@@ -1,0 +1,93 @@
+#pragma once
+// CMANGOS.01 (Phase 2.01b) — ChatCommandRouter : dispatcher table-driven
+// pour les slash-commands côté master, avec contrôle de rôle minimal.
+//
+// Le master reçoit un `kOpcodeChatSendRequest` (cf. ChatRelayHandler).
+// Si le texte commence par '/', on le confie à ChatCommandRouter avant
+// le routage de canal. Si la commande est connue ET le rôle suffisant,
+// on dispatche au handler enregistré ; sinon on rejette (`UnknownCommand`
+// ou `InsufficientRole`) et le caller décide quoi montrer à l'utilisateur.
+
+#include "engine/server/AccountRole.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace engine::server::chat
+{
+	/// Résultat d'un appel `Dispatch`.
+	enum class CommandDispatchResult : uint8_t
+	{
+		/// Le texte ne commence PAS par '/' → pas une commande, le caller
+		/// continue le routage de canal normal.
+		NotACommand = 0,
+		/// Commande non enregistrée (orthographe, casse, etc.).
+		UnknownCommand = 1,
+		/// Commande connue mais rôle insuffisant (audit log côté caller).
+		InsufficientRole = 2,
+		/// Dispatch effectué — le handler a été appelé.
+		Dispatched = 3,
+	};
+
+	/// Handler invoqué après dispatch. `args` est le reste du texte après
+	/// le nom de la commande, déjà trimé (espaces de début/fin retirés).
+	using CommandHandlerFn = std::function<void(uint64_t accountId, std::string_view args)>;
+
+	/// Entry de la table interne. minRole inclus : un GM peut appeler une
+	/// commande de minRole=Moderator (cf. RequireMinRole).
+	struct CommandEntry
+	{
+		AccountRole       minRole;
+		CommandHandlerFn  handler;
+	};
+
+	class ChatCommandRouter
+	{
+	public:
+		ChatCommandRouter() = default;
+
+		/// Enregistre une commande. \param name doit commencer par '/'
+		/// (sinon ajout automatique). Le nom est stocké en lower-case
+		/// ASCII pour matcher case-insensitive. Idempotent : un appel
+		/// avec le même nom remplace l'entry précédente.
+		void Register(std::string_view name, AccountRole minRole, CommandHandlerFn handler);
+
+		/// Désinscrit une commande. Idempotent : no-op si pas trouvée.
+		void Unregister(std::string_view name);
+
+		/// Tente de dispatcher un texte. Si \p text ne commence pas par
+		/// '/' → `NotACommand`. Si commande inconnue → `UnknownCommand`.
+		/// Si rôle insuffisant → `InsufficientRole`. Si OK → invoque le
+		/// handler enregistré et retourne `Dispatched`. \p text peut
+		/// être déjà sanitizé en amont.
+		///
+		/// La commande est extraite du premier "mot" (jusqu'au premier
+		/// espace), comparée case-insensitive, et le reste devient \p args.
+		///
+		/// \param text       Message brut, ex. "/kick BadGuy spam".
+		/// \param accountId  Account ID de l'expéditeur.
+		/// \param role       Rôle de l'expéditeur, comparé à minRole via
+		///                   `AccountRoleService::RequireMinRole(role, minRole)`.
+		/// \param outName    Optionnel : reçoit le nom de la commande
+		///                   parsée (lower-case, sans le '/'). Pratique
+		///                   pour log et audit du caller.
+		CommandDispatchResult Dispatch(std::string_view text,
+			uint64_t accountId, AccountRole role,
+			std::string* outName = nullptr) const;
+
+		/// Retourne true si une commande est enregistrée (case-insensitive).
+		bool IsRegistered(std::string_view name) const;
+
+		/// Nombre de commandes enregistrées (utile pour tests/debug).
+		size_t Size() const { return m_table.size(); }
+
+	private:
+		/// Normalise un nom de commande : strip leading '/' + lower-case ASCII.
+		static std::string Normalize(std::string_view name);
+
+		std::unordered_map<std::string, CommandEntry> m_table;
+	};
+}

--- a/engine/server/chat/ChatCommandRouterTests.cpp
+++ b/engine/server/chat/ChatCommandRouterTests.cpp
@@ -1,0 +1,241 @@
+// CMANGOS.01 (Phase 2.01b) — Tests ChatCommandRouter.
+// Pure : aucune dépendance DB.
+
+#include "engine/server/chat/ChatCommandRouter.h"
+#include "engine/core/Log.h"
+
+#include <atomic>
+#include <string>
+
+namespace
+{
+	using engine::server::AccountRole;
+	using engine::server::chat::ChatCommandRouter;
+	using engine::server::chat::CommandDispatchResult;
+
+	bool TestNotACommand()
+	{
+		ChatCommandRouter r;
+		r.Register("/foo", AccountRole::Player, [](uint64_t, std::string_view) {});
+		const auto d = r.Dispatch("hello world", 1, AccountRole::Player);
+		if (d != CommandDispatchResult::NotACommand)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] expected NotACommand, got {}",
+				static_cast<int>(d));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] NotACommand OK");
+		return true;
+	}
+
+	bool TestUnknownCommand()
+	{
+		ChatCommandRouter r;
+		const auto d = r.Dispatch("/nope arg", 1, AccountRole::Administrator);
+		if (d != CommandDispatchResult::UnknownCommand)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] expected UnknownCommand, got {}",
+				static_cast<int>(d));
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] UnknownCommand OK");
+		return true;
+	}
+
+	bool TestDispatchOK()
+	{
+		ChatCommandRouter r;
+		std::atomic<int> seenCalls{0};
+		std::string seenArgs;
+		uint64_t seenId = 0;
+		r.Register("/who", AccountRole::Player,
+			[&](uint64_t accountId, std::string_view args) {
+				++seenCalls;
+				seenArgs = std::string(args);
+				seenId = accountId;
+			});
+
+		const auto d = r.Dispatch("/who   alice  ", 42, AccountRole::Player);
+		if (d != CommandDispatchResult::Dispatched)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] expected Dispatched, got {}",
+				static_cast<int>(d));
+			return false;
+		}
+		if (seenCalls.load() != 1 || seenId != 42 || seenArgs != "alice")
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] handler params wrong (calls={} id={} args='{}')",
+				seenCalls.load(), seenId, seenArgs);
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] Dispatch OK + args trimmed");
+		return true;
+	}
+
+	bool TestCaseInsensitive()
+	{
+		ChatCommandRouter r;
+		std::atomic<int> calls{0};
+		r.Register("/Kick", AccountRole::Moderator, [&](uint64_t, std::string_view) { ++calls; });
+
+		// Mod calls /KICK
+		const auto d = r.Dispatch("/KICK badguy", 1, AccountRole::Moderator);
+		if (d != CommandDispatchResult::Dispatched || calls.load() != 1)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] case-insensitive dispatch failed");
+			return false;
+		}
+		// Vérifie aussi via IsRegistered.
+		if (!r.IsRegistered("/kick") || !r.IsRegistered("/KICK") || !r.IsRegistered("kick"))
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] IsRegistered case-insensitive failed");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] case-insensitive OK");
+		return true;
+	}
+
+	bool TestInsufficientRole()
+	{
+		ChatCommandRouter r;
+		std::atomic<int> calls{0};
+		r.Register("/ban", AccountRole::GameMaster,
+			[&](uint64_t, std::string_view) { ++calls; });
+
+		// Player tente /ban → refus.
+		const auto d = r.Dispatch("/ban alice", 1, AccountRole::Player);
+		if (d != CommandDispatchResult::InsufficientRole)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] expected InsufficientRole for Player /ban, got {}",
+				static_cast<int>(d));
+			return false;
+		}
+		if (calls.load() != 0)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] handler should NOT have been called");
+			return false;
+		}
+
+		// Mod tente /ban → toujours refus (minRole=GM).
+		const auto d2 = r.Dispatch("/ban alice", 1, AccountRole::Moderator);
+		if (d2 != CommandDispatchResult::InsufficientRole)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] expected InsufficientRole for Moderator /ban");
+			return false;
+		}
+
+		// GM tente /ban → OK.
+		const auto d3 = r.Dispatch("/ban alice", 1, AccountRole::GameMaster);
+		if (d3 != CommandDispatchResult::Dispatched || calls.load() != 1)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] GM /ban should dispatch");
+			return false;
+		}
+
+		// Admin tente /ban → OK aussi (rôle plus élevé).
+		const auto d4 = r.Dispatch("/ban alice", 1, AccountRole::Administrator);
+		if (d4 != CommandDispatchResult::Dispatched || calls.load() != 2)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] Admin /ban should dispatch");
+			return false;
+		}
+
+		LOG_INFO(Core, "[ChatCommandRouterTests] InsufficientRole OK");
+		return true;
+	}
+
+	bool TestUnregister()
+	{
+		ChatCommandRouter r;
+		r.Register("/foo", AccountRole::Player, [](uint64_t, std::string_view) {});
+		if (!r.IsRegistered("/foo")) return false;
+		r.Unregister("/foo");
+		if (r.IsRegistered("/foo")) return false;
+
+		// Unregister idempotent.
+		r.Unregister("/foo");
+		if (r.Size() != 0) return false;
+
+		LOG_INFO(Core, "[ChatCommandRouterTests] Unregister OK");
+		return true;
+	}
+
+	bool TestSlashOnly()
+	{
+		ChatCommandRouter r;
+		const auto d = r.Dispatch("/", 1, AccountRole::Administrator);
+		if (d != CommandDispatchResult::UnknownCommand)
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] '/' alone should be UnknownCommand");
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] '/' alone OK");
+		return true;
+	}
+
+	bool TestOutName()
+	{
+		ChatCommandRouter r;
+		r.Register("/who", AccountRole::Player, [](uint64_t, std::string_view) {});
+		std::string seen;
+		r.Dispatch("/WHO alice", 1, AccountRole::Player, &seen);
+		if (seen != "who")
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] outName expected 'who', got '{}'", seen);
+			return false;
+		}
+		// Même pour UnknownCommand on remplit outName (pratique pour audit).
+		std::string seen2;
+		r.Dispatch("/Bogus", 1, AccountRole::Player, &seen2);
+		if (seen2 != "bogus")
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] outName for unknown expected 'bogus', got '{}'", seen2);
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] outName OK");
+		return true;
+	}
+
+	bool TestEmptyArgs()
+	{
+		ChatCommandRouter r;
+		std::string seenArgs = "<unset>";
+		r.Register("/ping", AccountRole::Player,
+			[&](uint64_t, std::string_view args) { seenArgs = std::string(args); });
+		r.Dispatch("/ping", 1, AccountRole::Player);
+		if (seenArgs != "")
+		{
+			LOG_ERROR(Core, "[ChatCommandRouterTests] /ping no args : expected empty, got '{}'", seenArgs);
+			return false;
+		}
+		LOG_INFO(Core, "[ChatCommandRouterTests] empty args OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestNotACommand()
+		&& TestUnknownCommand()
+		&& TestDispatchOK()
+		&& TestCaseInsensitive()
+		&& TestInsufficientRole()
+		&& TestUnregister()
+		&& TestSlashOnly()
+		&& TestOutName()
+		&& TestEmptyArgs();
+
+	if (ok)
+		LOG_INFO(Core, "[ChatCommandRouterTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ChatCommandRouterTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Deuxième livrable du chat hardening (suite de [#486](https://github.com/tips-of-mine/LCDLLN-test/pull/486)). Master-only, pas de wire-breaking.

### `ChatCommandRouter` — dispatcher table-driven

Hierarchical slash-commands avec contrôle de rôle minimal (`AccountRole`) via `AccountRoleService::RequireMinRole`. 4 issues :

| Décision | Cause | Action ChatRelayHandler |
|---|---|---|
| `Dispatched` | commande connue + rôle suffisant | handler invoqué |
| `InsufficientRole` | commande connue mais rôle < minRole | notice ""Insufficient permissions"" |
| `UnknownCommand` | pas dans la table | notice ""Unknown command : /<name>"" |
| `NotACommand` | texte ne commence pas par '/' | continue routage de canal |

`Register(name, minRole, handler)` : nom case-insensitive, '/' optionnel, idempotent.

### `ChatChannelRegistry` — canaux dynamiques in-memory

Volatils (perdus au reboot du master). Pas de persistance dans cette PR — KISS.

- `Join(account, name, password)` : 5 issues (OK / WrongPassword / Banned / InvalidName / AlreadyMember). Crée le canal + ownership pour le premier joueur.
- `Leave / LeaveAll` : retrait, transfert d'ownership si l'owner part, suppression du canal si plus aucun membre.
- `SetPassword / Ban / Unban` : réservé à l'owner.
- Validation noms : 1–32 ASCII printable hors espace + '/'. Lower-case auto.

### Intégration `ChatRelayHandler`

Ajout d'une étape entre ChatGate.DecideAndRecord et le routage de canal : si le texte commence par '/', on tente un dispatch via `m_commandRouter`. Politique conservative : tant qu'aucune commande n'est enregistrée via `Register(...)`, tout `/foo` devient `UnknownCommand` → notice (pas de broadcast d'un slash-command non géré).

### Tests

- `chat_command_router_tests` : 9 cas (NotACommand, UnknownCommand, dispatch + args trim, case-insensitive, role hiérarchique GM/Admin > Mod > Player, Unregister, '/' tout seul, outName populated, args vides).
- `chat_channel_registry_tests` : 8 cas (création + ownership, idempotence, password OK/KO, ban+ejection+rejoin refus, owner transfer, LeaveAll, normalisation/validation, Members snapshot).

## Test plan

- [x] `/who alice` dispatched (Player rôle).
- [x] `/ban alice` refusé pour Player/Mod, accepté pour GM/Admin.
- [x] `/nope` (non enregistré) → UnknownCommand → notice ""Unknown command"".
- [x] `Join` du premier = owner ; le 2ᵉ peut Join sans password ; password set par owner = bloque les sans-password.
- [x] Owner ban un membre → membre éjecté + Join refusé.
- [x] Owner part → ownership transféré au prochain membre.
- [ ] CI Linux verte (en attente).

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR REQUIS** (master) — nouveau code de dispatch + canaux. Pas de redéploiement client. Pas de migration DB. Pas de wire-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)