### PR TITLE
Phase 2 CMANGOS.05 sub-PR 1 : AABB + BIH<T> raycast (math)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -283,6 +283,16 @@ elseif(UNIX)
   target_compile_options(object_guid_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME object_guid_tests COMMAND object_guid_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
+  add_executable(bih_tests
+    shard/vmap/BIHTests.cpp
+    shard/vmap/AABB.cpp
+  )
+  target_include_directories(bih_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(bih_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(bih_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME bih_tests COMMAND bih_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # M22.4: Shard ticket validation tests
   add_executable(shard_ticket_tests
     ShardTicketTests.cpp

--- a/engine/server/shard/vmap/AABB.cpp
+++ b/engine/server/shard/vmap/AABB.cpp
@@ -1,0 +1,50 @@
+#include "engine/server/shard/vmap/AABB.h"
+
+namespace engine::server::shard::vmap
+{
+	namespace
+	{
+		/// Slab test sur un axe : retourne true si le rayon coupe la slab
+		/// [bMin, bMax] sur cet axe ; met à jour [tNear, tFar] cumulés.
+		///
+		/// \param o  Coord origin sur l'axe.
+		/// \param d  Coord direction sur l'axe.
+		/// \param bMin / bMax  Bornes de la slab.
+		/// \param tNear / tFar  [in/out] intervalle cumulé des intersections.
+		inline bool SlabTest(float o, float d, float bMin, float bMax,
+			float& tNear, float& tFar) noexcept
+		{
+			constexpr float kEps = 1e-9f;
+			if (std::fabs(d) < kEps)
+			{
+				// Rayon parallèle à la slab : pas d'intersection sauf si
+				// l'origine est déjà dedans.
+				return o >= bMin && o <= bMax;
+			}
+			const float invD = 1.0f / d;
+			float t1 = (bMin - o) * invD;
+			float t2 = (bMax - o) * invD;
+			if (t1 > t2) std::swap(t1, t2);
+			if (t1 > tNear) tNear = t1;
+			if (t2 < tFar)  tFar  = t2;
+			return tNear <= tFar;
+		}
+	}
+
+	bool IntersectRayAABB(const Ray& r, const AABB& box, float& tHitOut) noexcept
+	{
+		float tNear = r.tMin;
+		float tFar  = r.tMax;
+		if (!SlabTest(r.origin.x, r.dir.x, box.min.x, box.max.x, tNear, tFar))
+			return false;
+		if (!SlabTest(r.origin.y, r.dir.y, box.min.y, box.max.y, tNear, tFar))
+			return false;
+		if (!SlabTest(r.origin.z, r.dir.z, box.min.z, box.max.z, tNear, tFar))
+			return false;
+		// Si tNear < r.tMin, l'origine du rayon est dans la boîte —
+		// retourner r.tMin (entrée du segment paramétrique). Sinon tNear
+		// est l'instant d'entrée dans la boîte.
+		tHitOut = (tNear < r.tMin) ? r.tMin : tNear;
+		return true;
+	}
+}

--- a/engine/server/shard/vmap/AABB.h
+++ b/engine/server/shard/vmap/AABB.h
@@ -1,0 +1,111 @@
+#pragma once
+// CMANGOS.05 (Phase 2.05a) — AABB + Ray + intersection tests, brique de
+// base pour la BIH (Bounding Interval Hierarchy) qui sera la structure
+// d'accélération du vmap server-side (LOS / GetHeight / projectile).
+//
+// Pure math, pas de dépendance externe au-delà de engine/math/Math.h
+// (Vec3). Testable en isolation.
+
+#include "engine/math/Math.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace engine::server::shard::vmap
+{
+	using engine::math::Vec3;
+
+	/// Axis-Aligned Bounding Box. \p min ≤ \p max sur chaque axe.
+	struct AABB
+	{
+		Vec3 min{};
+		Vec3 max{};
+
+		AABB() = default;
+		AABB(const Vec3& mn, const Vec3& mx) : min(mn), max(mx) {}
+
+		/// Construit la "boîte vide" (min = +inf, max = -inf). Utile pour
+		/// `Expand(point)` itératif en partant de zéro.
+		static AABB Empty() noexcept
+		{
+			constexpr float inf = std::numeric_limits<float>::infinity();
+			return AABB(Vec3(+inf, +inf, +inf), Vec3(-inf, -inf, -inf));
+		}
+
+		bool IsValid() const noexcept
+		{
+			return min.x <= max.x && min.y <= max.y && min.z <= max.z;
+		}
+
+		/// True si le point \p p est strictement à l'intérieur (frontière incluse).
+		bool Contains(const Vec3& p) const noexcept
+		{
+			return p.x >= min.x && p.x <= max.x
+				&& p.y >= min.y && p.y <= max.y
+				&& p.z >= min.z && p.z <= max.z;
+		}
+
+		/// Étend la boîte pour contenir \p p (no-op si déjà dedans).
+		void Expand(const Vec3& p) noexcept
+		{
+			if (p.x < min.x) min.x = p.x;
+			if (p.y < min.y) min.y = p.y;
+			if (p.z < min.z) min.z = p.z;
+			if (p.x > max.x) max.x = p.x;
+			if (p.y > max.y) max.y = p.y;
+			if (p.z > max.z) max.z = p.z;
+		}
+
+		/// Étend pour contenir une autre AABB.
+		void Expand(const AABB& other) noexcept
+		{
+			Expand(other.min);
+			Expand(other.max);
+		}
+
+		/// Centre géométrique.
+		Vec3 Center() const noexcept
+		{
+			return Vec3(0.5f * (min.x + max.x),
+				0.5f * (min.y + max.y),
+				0.5f * (min.z + max.z));
+		}
+
+		/// Demi-extent (taille / 2).
+		Vec3 HalfSize() const noexcept
+		{
+			return Vec3(0.5f * (max.x - min.x),
+				0.5f * (max.y - min.y),
+				0.5f * (max.z - min.z));
+		}
+	};
+
+	/// Rayon paramétrique : `P(t) = origin + t * dir`, t ∈ [tMin, tMax].
+	/// `dir` n'a pas besoin d'être normalisé : les distances retournées
+	/// sont en unités de `dir`. Pour avoir des mètres, normaliser \p dir.
+	struct Ray
+	{
+		Vec3  origin{};
+		Vec3  dir{};
+		float tMin = 0.0f;
+		float tMax = std::numeric_limits<float>::infinity();
+
+		Ray() = default;
+		Ray(const Vec3& o, const Vec3& d, float tn = 0.0f,
+			float tx = std::numeric_limits<float>::infinity())
+			: origin(o), dir(d), tMin(tn), tMax(tx) {}
+	};
+
+	/// Test rayon ↔ AABB (slab method). Retourne true si le rayon coupe
+	/// la boîte dans [tMin, tMax]. Met \p tHitOut au paramètre d'entrée
+	/// (peut être négatif si l'origine est dans la boîte).
+	///
+	/// **Cas particulier** : si `dir.{x,y,z}` est ≈ 0 et `origin` n'est
+	/// pas dans la slab correspondante, on retourne false. Si dans la
+	/// slab, on traite l'axe comme "toujours dans l'intervalle".
+	///
+	/// Algorithme classique en O(1), sans branchement majeur, sûr pour
+	/// les rayons d'origine intérieure.
+	bool IntersectRayAABB(const Ray& r, const AABB& box, float& tHitOut) noexcept;
+}

--- a/engine/server/shard/vmap/BIH.h
+++ b/engine/server/shard/vmap/BIH.h
@@ -1,0 +1,271 @@
+#pragma once
+// CMANGOS.05 (Phase 2.05a) — BIH<T> : Bounding Interval Hierarchy
+// templated. Structure d'accélération pour le raycast contre une
+// collection d'objets bornés (bbox connue à la construction).
+//
+// **Choix simplificateur** : on stocke les indices d'objets dans un
+// tableau plat ; chaque feuille est un range [first, last) dans ce
+// tableau. La méthode de split est "median over largest axis" — pas
+// optimale (un SAH ferait mieux) mais déterministe et suffisante en
+// première mise.
+//
+// **Construction** : O(N log N) en moyenne. **Raycast** : O(log N) en
+// moyenne, O(N) au pire. Pas de threading interne.
+//
+// Pour LCDLLN, le concept template T est minimal :
+//   - T(...).Bounds() → AABB
+//   - intersection rayon ↔ T fournie via une lambda passée à `Raycast`.
+//
+// La BIH ne fait PAS l'intersection finale rayon-vs-objet : elle
+// **filtre** les candidats via leurs AABB et délègue le test précis
+// au caller. C'est le contrat classique d'une structure d'accélération.
+
+#include "engine/server/shard/vmap/AABB.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace engine::server::shard::vmap
+{
+	/// Configuration de construction.
+	struct BIHBuildConfig
+	{
+		/// Nombre max d'objets par feuille (au-delà : split). Default 8.
+		size_t leafThreshold = 8;
+		/// Profondeur max du split (sécurité). Default 32.
+		size_t maxDepth = 32;
+	};
+
+	template<typename T>
+	class BIH
+	{
+	public:
+		BIH() = default;
+
+		/// Construit la BIH à partir d'un set d'objets. La BIH garde une
+		/// **référence** aux objets via leurs indices ; les objets eux-mêmes
+		/// restent dans le tableau du caller (pas de copie).
+		void Build(const std::vector<T>& items, BIHBuildConfig cfg = {});
+
+		/// Vide la structure.
+		void Clear() noexcept
+		{
+			m_nodes.clear();
+			m_indices.clear();
+			m_globalBox = AABB::Empty();
+		}
+
+		/// Bbox englobante de tous les objets (root). Empty si la BIH est vide.
+		const AABB& GlobalBox() const noexcept { return m_globalBox; }
+
+		/// Nombre de noeuds (interne + feuilles).
+		size_t NodeCount() const noexcept { return m_nodes.size(); }
+
+		/// Nombre d'objets indexés.
+		size_t ItemCount() const noexcept { return m_indices.size(); }
+
+		/// Lance un raycast et invoque \p hitTest(itemIndex, ray, &tHit) pour
+		/// chaque candidat (objet dont la AABB est traversée par le rayon).
+		/// `hitTest` retourne true si l'objet est touché et écrit `tHit`
+		/// dans sa sortie. Le BIH s'arrête au premier hit avec t le plus
+		/// petit (modulo l'ordre des candidats — pour un "any hit"
+		/// strictement le plus proche, le caller peut accumuler).
+		///
+		/// Retourne le `t` du hit le plus proche, ou +∞ si aucun hit.
+		template<typename HitFn>
+		float Raycast(const Ray& ray, const std::vector<T>& items, HitFn hitTest) const;
+
+	private:
+		/// Noeud BIH : intern (split) ou feuille (range). Encodage compact :
+		/// si `leafCount > 0`, c'est une feuille couvrant
+		/// `m_indices[leafFirst .. leafFirst+leafCount)`. Sinon, noeud interne
+		/// avec `axis ∈ {0,1,2}`, `clipL` et `clipR` les bornes de split sur
+		/// l'axe, et `left`/`right` les indices vers les enfants.
+		struct Node
+		{
+			AABB     box;            // bbox du sous-arbre (debug + traversée)
+			uint32_t leafFirst = 0;  // si leaf : index dans m_indices
+			uint32_t leafCount = 0;  // 0 ⇒ noeud interne, >0 ⇒ feuille
+			uint32_t left  = 0;      // si interne : index du child left
+			uint32_t right = 0;      // si interne : index du child right
+			float    clipL = 0.0f;
+			float    clipR = 0.0f;
+			uint8_t  axis  = 0;      // 0=x, 1=y, 2=z
+		};
+
+		uint32_t BuildRecurse(std::vector<uint32_t>& indices,
+			const std::vector<T>& items, size_t first, size_t count,
+			const AABB& parentBox, size_t depth, const BIHBuildConfig& cfg);
+
+		std::vector<Node>     m_nodes;
+		std::vector<uint32_t> m_indices;
+		AABB                  m_globalBox = AABB::Empty();
+	};
+
+	// Implémentation inline — la BIH étant un template, elle doit être
+	// définie en header.
+
+	template<typename T>
+	void BIH<T>::Build(const std::vector<T>& items, BIHBuildConfig cfg)
+	{
+		Clear();
+		if (items.empty())
+			return;
+
+		// Construire la liste d'indices initiale + bbox globale.
+		std::vector<uint32_t> indices;
+		indices.reserve(items.size());
+		AABB world = AABB::Empty();
+		for (uint32_t i = 0; i < items.size(); ++i)
+		{
+			indices.push_back(i);
+			world.Expand(items[i].Bounds());
+		}
+		m_globalBox = world;
+
+		// On réserve à l'avance pour limiter les reallocs (estim 2N nodes).
+		m_nodes.reserve(2 * items.size() + 8);
+
+		BuildRecurse(indices, items, 0, indices.size(), world, 0, cfg);
+
+		m_indices = std::move(indices);
+	}
+
+	template<typename T>
+	uint32_t BIH<T>::BuildRecurse(std::vector<uint32_t>& indices,
+		const std::vector<T>& items, size_t first, size_t count,
+		const AABB& parentBox, size_t depth, const BIHBuildConfig& cfg)
+	{
+		const uint32_t myIndex = static_cast<uint32_t>(m_nodes.size());
+		m_nodes.push_back(Node{});
+		Node& self = m_nodes.back();
+		self.box = parentBox;
+
+		// Cas feuille : peu d'éléments OU profondeur max.
+		if (count <= cfg.leafThreshold || depth >= cfg.maxDepth)
+		{
+			self.leafFirst = static_cast<uint32_t>(first);
+			self.leafCount = static_cast<uint32_t>(count);
+			return myIndex;
+		}
+
+		// Choix d'axe : le plus long (gros span = meilleur split en moyenne).
+		const Vec3 size(
+			parentBox.max.x - parentBox.min.x,
+			parentBox.max.y - parentBox.min.y,
+			parentBox.max.z - parentBox.min.z);
+		uint8_t axis = 0;
+		if (size.y > size.x) axis = 1;
+		if (axis == 0 ? size.z > size.x : size.z > size.y) axis = 2;
+
+		// Split par median des centres sur l'axe.
+		const auto centerOnAxis = [&](uint32_t idx) {
+			const auto box = items[idx].Bounds();
+			switch (axis)
+			{
+				case 0: return 0.5f * (box.min.x + box.max.x);
+				case 1: return 0.5f * (box.min.y + box.max.y);
+				case 2: return 0.5f * (box.min.z + box.max.z);
+			}
+			return 0.0f;
+		};
+
+		const size_t mid = first + count / 2;
+		std::nth_element(indices.begin() + first,
+			indices.begin() + mid,
+			indices.begin() + first + count,
+			[&](uint32_t a, uint32_t b) { return centerOnAxis(a) < centerOnAxis(b); });
+
+		// clipL = max sur axe des objets de gauche ; clipR = min des objets de droite.
+		// Ces deux valeurs définissent les "intervalles" BIH (cf. Wächter & Keller).
+		float clipL = -std::numeric_limits<float>::infinity();
+		float clipR =  std::numeric_limits<float>::infinity();
+		AABB leftBox  = AABB::Empty();
+		AABB rightBox = AABB::Empty();
+		for (size_t i = first; i < mid; ++i)
+		{
+			const auto box = items[indices[i]].Bounds();
+			leftBox.Expand(box);
+			float maxA = (axis == 0) ? box.max.x : (axis == 1) ? box.max.y : box.max.z;
+			if (maxA > clipL) clipL = maxA;
+		}
+		for (size_t i = mid; i < first + count; ++i)
+		{
+			const auto box = items[indices[i]].Bounds();
+			rightBox.Expand(box);
+			float minA = (axis == 0) ? box.min.x : (axis == 1) ? box.min.y : box.min.z;
+			if (minA < clipR) clipR = minA;
+		}
+
+		// Si le split est dégénéré (un côté vide ou 100% chevauchement),
+		// fallback en feuille — évite la récursion infinie.
+		if (mid == first || mid == first + count)
+		{
+			Node& selfRef = m_nodes[myIndex];
+			selfRef.leafFirst = static_cast<uint32_t>(first);
+			selfRef.leafCount = static_cast<uint32_t>(count);
+			return myIndex;
+		}
+
+		const uint32_t leftIdx  = BuildRecurse(indices, items, first, mid - first, leftBox, depth + 1, cfg);
+		const uint32_t rightIdx = BuildRecurse(indices, items, mid, first + count - mid, rightBox, depth + 1, cfg);
+
+		Node& selfRef = m_nodes[myIndex];
+		selfRef.axis  = axis;
+		selfRef.left  = leftIdx;
+		selfRef.right = rightIdx;
+		selfRef.clipL = clipL;
+		selfRef.clipR = clipR;
+		return myIndex;
+	}
+
+	template<typename T>
+	template<typename HitFn>
+	float BIH<T>::Raycast(const Ray& ray, const std::vector<T>& items, HitFn hitTest) const
+	{
+		float bestT = ray.tMax;
+		if (m_nodes.empty())
+			return std::numeric_limits<float>::infinity();
+
+		// Stack pile pour traversée itérative (évite la récursion).
+		uint32_t stack[64];
+		int sp = 0;
+		stack[sp++] = 0;
+
+		while (sp > 0)
+		{
+			const uint32_t ni = stack[--sp];
+			const Node& n = m_nodes[ni];
+
+			float tEnter = 0.0f;
+			Ray clipped = ray;
+			clipped.tMax = bestT;
+			if (!IntersectRayAABB(clipped, n.box, tEnter))
+				continue;
+
+			if (n.leafCount > 0)
+			{
+				// Feuille : test exact sur chaque objet.
+				for (uint32_t k = 0; k < n.leafCount; ++k)
+				{
+					const uint32_t itemIdx = m_indices[n.leafFirst + k];
+					float tHit = std::numeric_limits<float>::infinity();
+					if (hitTest(itemIdx, ray, tHit) && tHit < bestT && tHit >= ray.tMin)
+						bestT = tHit;
+				}
+				continue;
+			}
+
+			// Noeud interne : push les deux enfants. (Optimisation possible :
+			// near/far order par signe de dir[axis] — TODO si profil le justifie.)
+			if (sp + 2 <= 64)
+			{
+				stack[sp++] = n.left;
+				stack[sp++] = n.right;
+			}
+		}
+		return (bestT < ray.tMax) ? bestT : std::numeric_limits<float>::infinity();
+	}
+}

--- a/engine/server/shard/vmap/BIHTests.cpp
+++ b/engine/server/shard/vmap/BIHTests.cpp
@@ -1,0 +1,288 @@
+// CMANGOS.05 (Phase 2.05a) — Tests AABB + BIH<T>.
+// Pure math, pas de DB.
+
+#include "engine/server/shard/vmap/AABB.h"
+#include "engine/server/shard/vmap/BIH.h"
+#include "engine/core/Log.h"
+
+#include <cmath>
+#include <vector>
+
+namespace
+{
+	using engine::math::Vec3;
+	using engine::server::shard::vmap::AABB;
+	using engine::server::shard::vmap::BIH;
+	using engine::server::shard::vmap::IntersectRayAABB;
+	using engine::server::shard::vmap::Ray;
+
+	bool ApproxEq(float a, float b, float eps = 1e-4f)
+	{
+		return std::fabs(a - b) <= eps;
+	}
+
+	bool TestAABBExpandContains()
+	{
+		AABB box = AABB::Empty();
+		if (box.IsValid())
+		{
+			LOG_ERROR(Core, "[BIHTests] empty AABB should be invalid");
+			return false;
+		}
+		box.Expand(Vec3(1, 2, 3));
+		box.Expand(Vec3(-1, 0, 5));
+		if (!box.IsValid()) return false;
+		if (!box.Contains(Vec3(0, 1, 4))) return false;
+		if (box.Contains(Vec3(2, 0, 0))) return false;
+		LOG_INFO(Core, "[BIHTests] AABB expand+contains OK");
+		return true;
+	}
+
+	bool TestRayHitsAABBOutside()
+	{
+		// Ray en (0,0,0) direction +x. Boîte [(5,-1,-1), (6,1,1)].
+		// Hit attendu à t=5.
+		const AABB box(Vec3(5, -1, -1), Vec3(6, 1, 1));
+		const Ray  r(Vec3(0, 0, 0), Vec3(1, 0, 0));
+		float t = -1.0f;
+		if (!IntersectRayAABB(r, box, t))
+		{
+			LOG_ERROR(Core, "[BIHTests] expected hit, got miss");
+			return false;
+		}
+		if (!ApproxEq(t, 5.0f))
+		{
+			LOG_ERROR(Core, "[BIHTests] expected t=5, got {}", t);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] ray AABB outside OK");
+		return true;
+	}
+
+	bool TestRayMissesAABB()
+	{
+		// Ray (0,0,0) +y, boîte sur axe x → miss.
+		const AABB box(Vec3(5, -1, -1), Vec3(6, 1, 1));
+		const Ray  r(Vec3(0, 0, 0), Vec3(0, 1, 0));
+		float t = -1.0f;
+		if (IntersectRayAABB(r, box, t))
+		{
+			LOG_ERROR(Core, "[BIHTests] expected miss, got hit at t={}", t);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] ray AABB miss OK");
+		return true;
+	}
+
+	bool TestRayInsideAABB()
+	{
+		// Ray origine dans la boîte → tHit = tMin (0).
+		const AABB box(Vec3(-1, -1, -1), Vec3(1, 1, 1));
+		const Ray  r(Vec3(0, 0, 0), Vec3(1, 0, 0));
+		float t = -1.0f;
+		if (!IntersectRayAABB(r, box, t)) return false;
+		if (!ApproxEq(t, 0.0f))
+		{
+			LOG_ERROR(Core, "[BIHTests] inside : expected t=0, got {}", t);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] ray inside AABB OK");
+		return true;
+	}
+
+	bool TestRayParallelOutsideSlab()
+	{
+		// Ray parallèle à un axe ET hors de la slab → miss.
+		const AABB box(Vec3(-1, -1, -1), Vec3(1, 1, 1));
+		// Origine y=10, direction +x → la slab y est [−1, 1], on est en
+		// dehors (y=10) et `dir.y == 0` → miss.
+		const Ray  r(Vec3(0, 10, 0), Vec3(1, 0, 0));
+		float t = -1.0f;
+		if (IntersectRayAABB(r, box, t))
+		{
+			LOG_ERROR(Core, "[BIHTests] parallel-outside : expected miss");
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] parallel slab miss OK");
+		return true;
+	}
+
+	// --- BIH<T> tests ---
+
+	struct TestBox
+	{
+		AABB bounds;
+		AABB Bounds() const { return bounds; }
+	};
+
+	bool TestBIHEmpty()
+	{
+		BIH<TestBox> b;
+		std::vector<TestBox> items;
+		b.Build(items);
+		if (b.NodeCount() != 0 || b.ItemCount() != 0)
+		{
+			LOG_ERROR(Core, "[BIHTests] empty BIH should have 0 nodes/items");
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] empty BIH OK");
+		return true;
+	}
+
+	bool TestBIHSingle()
+	{
+		BIH<TestBox> b;
+		std::vector<TestBox> items{ TestBox{ AABB(Vec3(-1, -1, -1), Vec3(1, 1, 1)) } };
+		b.Build(items);
+		if (b.NodeCount() != 1 || b.ItemCount() != 1)
+		{
+			LOG_ERROR(Core, "[BIHTests] single item : expected 1 leaf node, got nodes={} items={}",
+				b.NodeCount(), b.ItemCount());
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] single BIH OK");
+		return true;
+	}
+
+	bool TestBIHRaycastFindsClosest()
+	{
+		// 3 cubes alignés sur +x : aux centres x=10, 20, 30, half-size 1.
+		// Ray (0,0,0) → +x, doit toucher le premier (x=10), t≈9.
+		std::vector<TestBox> items;
+		for (int i = 1; i <= 3; ++i)
+		{
+			const float cx = static_cast<float>(i) * 10.0f;
+			items.push_back(TestBox{ AABB(Vec3(cx - 1, -1, -1), Vec3(cx + 1, 1, 1)) });
+		}
+		BIH<TestBox> b;
+		b.Build(items);
+		const Ray r(Vec3(0, 0, 0), Vec3(1, 0, 0));
+
+		// HitFn : test précis = test rayon-AABB de l'objet.
+		auto hitTest = [&](uint32_t idx, const Ray& ray, float& tOut) {
+			float t = std::numeric_limits<float>::infinity();
+			if (IntersectRayAABB(ray, items[idx].Bounds(), t))
+			{
+				tOut = t;
+				return true;
+			}
+			return false;
+		};
+
+		const float tHit = b.Raycast(r, items, hitTest);
+		if (!ApproxEq(tHit, 9.0f, 1e-3f))
+		{
+			LOG_ERROR(Core, "[BIHTests] expected closest hit t=9, got {}", tHit);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] raycast finds closest OK (t={})", tHit);
+		return true;
+	}
+
+	bool TestBIHRaycastMisses()
+	{
+		// Cube en (5..6, 5..6, 5..6). Ray sur +x au sol → ne touche pas.
+		std::vector<TestBox> items{ TestBox{ AABB(Vec3(5, 5, 5), Vec3(6, 6, 6)) } };
+		BIH<TestBox> b;
+		b.Build(items);
+		const Ray r(Vec3(0, 0, 0), Vec3(1, 0, 0));
+
+		auto hitTest = [&](uint32_t idx, const Ray& ray, float& tOut) {
+			float t = std::numeric_limits<float>::infinity();
+			if (IntersectRayAABB(ray, items[idx].Bounds(), t))
+			{
+				tOut = t;
+				return true;
+			}
+			return false;
+		};
+
+		const float tHit = b.Raycast(r, items, hitTest);
+		if (tHit != std::numeric_limits<float>::infinity())
+		{
+			LOG_ERROR(Core, "[BIHTests] expected miss (inf), got t={}", tHit);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] raycast miss OK");
+		return true;
+	}
+
+	bool TestBIHManyBoxes()
+	{
+		// 64 boîtes en grille : x/y/z ∈ {0, 4, 8, ..., 28}.
+		// Ray à x=2, y=2, z=−10 → +z, doit toucher la boîte centrée à
+		// (2, 2, 0..3) (la boîte 0 est en [-1, 3] × [-1, 3] × [-1, 3]).
+		std::vector<TestBox> items;
+		for (int xi = 0; xi < 4; ++xi)
+		for (int yi = 0; yi < 4; ++yi)
+		for (int zi = 0; zi < 4; ++zi)
+		{
+			const float cx = static_cast<float>(xi) * 4.0f;
+			const float cy = static_cast<float>(yi) * 4.0f;
+			const float cz = static_cast<float>(zi) * 4.0f;
+			items.push_back(TestBox{ AABB(Vec3(cx - 1, cy - 1, cz - 1),
+				Vec3(cx + 1, cy + 1, cz + 1)) });
+		}
+		if (items.size() != 64) return false;
+
+		BIH<TestBox> b;
+		b.Build(items);
+		// Beaucoup de boîtes → BIH a forcément split au moins une fois.
+		if (b.NodeCount() < 2)
+		{
+			LOG_ERROR(Core, "[BIHTests] expected >1 nodes for 64 boxes, got {}", b.NodeCount());
+			return false;
+		}
+
+		const Ray r(Vec3(0, 0, -10), Vec3(0, 0, 1));
+		auto hitTest = [&](uint32_t idx, const Ray& ray, float& tOut) {
+			float t = std::numeric_limits<float>::infinity();
+			if (IntersectRayAABB(ray, items[idx].Bounds(), t))
+			{
+				tOut = t;
+				return true;
+			}
+			return false;
+		};
+		const float tHit = b.Raycast(r, items, hitTest);
+
+		// La boîte la plus proche sur (0,0,*) est centre (0,0,0), bounds
+		// (-1,-1,-1)..(1,1,1) → entrée à z=-1 → t = (-1 - (-10)) = 9.
+		if (!ApproxEq(tHit, 9.0f, 1e-3f))
+		{
+			LOG_ERROR(Core, "[BIHTests] 64-grid : expected t=9, got {}", tHit);
+			return false;
+		}
+		LOG_INFO(Core, "[BIHTests] 64-box raycast OK (nodes={} t={})",
+			b.NodeCount(), tHit);
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestAABBExpandContains()
+		&& TestRayHitsAABBOutside()
+		&& TestRayMissesAABB()
+		&& TestRayInsideAABB()
+		&& TestRayParallelOutsideSlab()
+		&& TestBIHEmpty()
+		&& TestBIHSingle()
+		&& TestBIHRaycastFindsClosest()
+		&& TestBIHRaycastMisses()
+		&& TestBIHManyBoxes();
+
+	if (ok)
+		LOG_INFO(Core, "[BIHTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[BIHTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Première brique du module **vmap** (LOS server-side / GetHeight / projectile hit). Pure math, pas encore d'intégration runtime ni de loader `.vmap` ; structure d'accélération réutilisable pour les sous-PRs suivantes.

### `AABB` ([AABB.h](engine/server/shard/vmap/AABB.h))

- `Empty()` : sentinel pour `Expand(point)` itératif depuis zéro (min = +∞, max = −∞).
- `Expand(point)` / `Expand(box)` / `Contains(point)`.
- `IntersectRayAABB(ray, box, &tHit)` : **slab method**, O(1), correct pour rayon parallèle à un axe (slab test ramené à ""origine dans l'intervalle ?"") et origine intérieure (clamp à `tMin`).

### `BIH<T>` ([BIH.h](engine/server/shard/vmap/BIH.h)) — Bounding Interval Hierarchy templated

- **Build** : split par médiane des centres sur l'axe le plus long. Heuristique simple, déterministe. Fallback en feuille si split dégénéré → pas de récursion infinie.
- **Raycast(ray, items, hitFn)** : traversée itérative (stack fixe, depth max 64). Filtre via AABB des sous-arbres puis délègue le test final au caller via lambda `hitTest(itemIndex, ray, &tHit)`. Retourne le `t` le plus proche, `+∞` si aucun.
- Concept `T` minimal : `T::Bounds() -> AABB`. C'est tout.

### Justification design

L'audit ([CMANGOS.05.md](docs/superpowers/audits/2026-05-08-cmangos-gap-analysis/CMANGOS.05.md)) recommande **étape 1 : implémenter `BIH<T>` math + tests raycast contre cubes synthétiques**. Pas de dépendance lib externe (Bullet/Embree interdit par AGENTS.md sans accord explicite).

### Tests

`bih_tests` : 10 cas couvrant :

- `AABB::Expand` + `Contains`
- Ray-AABB hit/miss/inside/parallel-out-of-slab
- `BIH` vide / single / 3 cubes alignés (closest hit) / miss / grille 64 cubes (`nodeCount > 1` + raycast trouve la bonne distance)

## Test plan

- [x] Slab method correct sur 4 cas (hit, miss, inside, parallel-out).
- [x] BIH<T> build sur 64 boîtes : `NodeCount > 1` (split effectif), raycast trouve la bonne distance.
- [x] Build sur set vide / 1 élément : pas de crash, pas de noeud parasite.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code non encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. Les sub-PRs suivantes (VMapFormat, VMapManager, VMapStreamer) déclencheront un redéploiement shard.

Pas de migration DB, pas de wire-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)