### PR TITLE
Phase 2 CMANGOS.05 sub-PR 2 : VMapFormat binaire (.vmap)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -305,6 +305,16 @@ elseif(UNIX)
   target_compile_options(grid_state_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME grid_state_tests COMMAND grid_state_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # CMANGOS.05 (Phase 2.05b) : VMapFormat encode/decode tests (no DB, no I/O)
+  add_executable(vmap_format_tests
+    shard/vmap/VMapFormatTests.cpp
+    shard/vmap/VMapFormat.cpp
+  )
+  target_include_directories(vmap_format_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(vmap_format_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(vmap_format_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME vmap_format_tests COMMAND vmap_format_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # M22.4: Shard ticket validation tests
   add_executable(shard_ticket_tests
     ShardTicketTests.cpp

--- a/engine/server/shard/vmap/VMapFormat.cpp
+++ b/engine/server/shard/vmap/VMapFormat.cpp
@@ -1,0 +1,133 @@
+#include "engine/server/shard/vmap/VMapFormat.h"
+
+#include <cstring>
+
+namespace engine::server::shard::vmap
+{
+	namespace
+	{
+		/// Append little-endian raw bytes — on suppose un host
+		/// little-endian (cas pratique : x86_64 + ARM64). Si on porte
+		/// jamais sur un host big-endian, ce helper devient un swap
+		/// explicite, mais ce n'est pas notre cas serveur (Linux x86_64).
+		template<typename T>
+		void Append(std::vector<uint8_t>& out, const T& v)
+		{
+			static_assert(std::is_trivially_copyable_v<T>,
+				"Append needs a trivially-copyable type");
+			const auto* p = reinterpret_cast<const uint8_t*>(&v);
+			out.insert(out.end(), p, p + sizeof(T));
+		}
+
+		/// Lecture little-endian. Retourne false si pas assez de bytes.
+		template<typename T>
+		bool Read(std::span<const uint8_t> in, size_t& off, T& out)
+		{
+			static_assert(std::is_trivially_copyable_v<T>,
+				"Read needs a trivially-copyable type");
+			if (off + sizeof(T) > in.size())
+				return false;
+			std::memcpy(&out, in.data() + off, sizeof(T));
+			off += sizeof(T);
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> EncodeVMapTile(const VMapTile& tile)
+	{
+		std::vector<uint8_t> out;
+		// Header : 6 floats + 4 uint32 = 24 + 16 = 40 bytes
+		// Data : vertices*12 + triangles*12
+		const size_t expected = 40
+			+ tile.vertices.size() * sizeof(engine::math::Vec3)
+			+ tile.triangles.size() * sizeof(VMapTri);
+		out.reserve(expected);
+
+		Append(out, kVMapMagic);
+		Append(out, kVMapVersion);
+		Append(out, tile.bbox.min.x);
+		Append(out, tile.bbox.min.y);
+		Append(out, tile.bbox.min.z);
+		Append(out, tile.bbox.max.x);
+		Append(out, tile.bbox.max.y);
+		Append(out, tile.bbox.max.z);
+		const auto nv = static_cast<uint32_t>(tile.vertices.size());
+		const auto nt = static_cast<uint32_t>(tile.triangles.size());
+		Append(out, nv);
+		Append(out, nt);
+
+		for (const auto& v : tile.vertices)
+		{
+			Append(out, v.x);
+			Append(out, v.y);
+			Append(out, v.z);
+		}
+		for (const auto& t : tile.triangles)
+		{
+			Append(out, t.a);
+			Append(out, t.b);
+			Append(out, t.c);
+		}
+		return out;
+	}
+
+	VMapDecodeResult DecodeVMapTile(std::span<const uint8_t> in, VMapTile& out,
+		uint32_t* outErrVersion)
+	{
+		size_t off = 0;
+		uint32_t magic = 0;
+		if (!Read(in, off, magic))
+			return VMapDecodeResult::BufferTooSmall;
+		if (magic != kVMapMagic)
+			return VMapDecodeResult::BadMagic;
+
+		uint32_t version = 0;
+		if (!Read(in, off, version))
+			return VMapDecodeResult::BufferTooSmall;
+		if (outErrVersion)
+			*outErrVersion = version;
+		if (version != kVMapVersion)
+			return VMapDecodeResult::WrongVersion;
+
+		float minX = 0, minY = 0, minZ = 0, maxX = 0, maxY = 0, maxZ = 0;
+		if (!Read(in, off, minX) || !Read(in, off, minY) || !Read(in, off, minZ)
+			|| !Read(in, off, maxX) || !Read(in, off, maxY) || !Read(in, off, maxZ))
+			return VMapDecodeResult::BufferTooSmall;
+
+		uint32_t nv = 0, nt = 0;
+		if (!Read(in, off, nv) || !Read(in, off, nt))
+			return VMapDecodeResult::BufferTooSmall;
+
+		// Vérifier qu'on a assez de bytes pour vertices + triangles
+		// AVANT de réserver — protection contre un fichier corrompu
+		// qui annoncerait des nombres énormes.
+		const size_t needVerts = static_cast<size_t>(nv) * sizeof(engine::math::Vec3);
+		const size_t needTris  = static_cast<size_t>(nt) * sizeof(VMapTri);
+		if (off + needVerts + needTris > in.size())
+			return VMapDecodeResult::BufferTooSmall;
+
+		out.bbox.min = engine::math::Vec3(minX, minY, minZ);
+		out.bbox.max = engine::math::Vec3(maxX, maxY, maxZ);
+		out.vertices.resize(nv);
+		out.triangles.resize(nt);
+
+		for (uint32_t i = 0; i < nv; ++i)
+		{
+			Read(in, off, out.vertices[i].x);
+			Read(in, off, out.vertices[i].y);
+			Read(in, off, out.vertices[i].z);
+		}
+		for (uint32_t i = 0; i < nt; ++i)
+		{
+			VMapTri t{};
+			Read(in, off, t.a);
+			Read(in, off, t.b);
+			Read(in, off, t.c);
+			// Validation : indices < vertexCount.
+			if (t.a >= nv || t.b >= nv || t.c >= nv)
+				return VMapDecodeResult::IndexOutOfRange;
+			out.triangles[i] = t;
+		}
+		return VMapDecodeResult::OK;
+	}
+}

--- a/engine/server/shard/vmap/VMapFormat.h
+++ b/engine/server/shard/vmap/VMapFormat.h
@@ -1,0 +1,90 @@
+#pragma once
+// CMANGOS.05 (Phase 2.05b) — VMapFormat : sérialisation binaire d'un
+// "tile vmap" (mesh triangulaire + bbox), produit par l'outil offline
+// `vmap_extractor` et consommé par le shard au runtime.
+//
+// **Principes** :
+//   - Magic number + version dans l'en-tête → le shard refuse les
+//     vieux fichiers avec un log explicite (cf. audit §8 "Format .vmap
+//     versioning").
+//   - Pas de dépendance lib externe (pas de protobuf, etc.).
+//   - Tout passe par `std::byte` / `std::span` ou `std::vector<uint8_t>`
+//     pour éviter `iostream` lourds — on accepte un blob mémoire ou
+//     un chemin ; la lecture disque est laissée au caller (la couche
+//     `engine::platform::FileSystem` est l'API de lecture canonique).
+//   - Coordonnées **locales au tile** (cf. audit §8 "Précision float").
+//
+// **Layout binaire** (little-endian, sans padding) :
+//
+//   header :
+//     uint32_t   magic            // 'L', 'V', 'M', '1' = 0x314D564C
+//     uint32_t   version          // bumper à chaque changement
+//     float      tileMinX, MinY, MinZ
+//     float      tileMaxX, MaxY, MaxZ
+//     uint32_t   vertexCount
+//     uint32_t   triangleCount
+//   data :
+//     vertexCount × { float x, y, z }
+//     triangleCount × { uint32_t a, b, c }   // indices vers vertices
+//
+// Toutes les coordonnées sont **relatives** au tile (origine du tile
+// = (0,0,0) local, mais la bbox `tileMin/Max` est en world). Les
+// opérations LOS/raycast côté shard travaillent en local au tile et
+// transforment au moment du `IsInLineOfSight(world_p1, world_p2)`.
+
+#include "engine/server/shard/vmap/AABB.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace engine::server::shard::vmap
+{
+	/// Magic number ASCII "LVM1" en little-endian.
+	inline constexpr uint32_t kVMapMagic = 0x314D564Cu;
+
+	/// Version actuelle du format. À bumper à chaque évolution
+	/// breaking. Le loader rejette les fichiers de version != celle-ci
+	/// avec un log explicite.
+	inline constexpr uint32_t kVMapVersion = 1u;
+
+	/// Triangle indexé sur 3 vertex. Indices 32-bit pour supporter les
+	/// gros tiles (heightmap 65×65 = 8192 tris OK ; mesh statique
+	/// importé peut être plus gros).
+	struct VMapTri
+	{
+		uint32_t a = 0, b = 0, c = 0;
+	};
+
+	/// Tile vmap décodé en mémoire. Pas thread-safe (lecture seule
+	/// après chargement → caller peut partager via shared_ptr).
+	struct VMapTile
+	{
+		AABB                  bbox;       // world coords
+		std::vector<engine::math::Vec3> vertices;   // local coords (tile origin)
+		std::vector<VMapTri>  triangles;
+	};
+
+	enum class VMapDecodeResult : uint8_t
+	{
+		OK = 0,
+		BufferTooSmall  = 1,
+		BadMagic        = 2,
+		WrongVersion    = 3,
+		IndexOutOfRange = 4,
+	};
+
+	/// Sérialise un VMapTile vers un buffer binaire (little-endian).
+	/// Retourne le buffer (jamais d'erreur en encodage : la structure
+	/// est forcément valide à la sortie de l'extracteur). Caller écrit
+	/// ensuite sur disque.
+	std::vector<uint8_t> EncodeVMapTile(const VMapTile& tile);
+
+	/// Décode un buffer en VMapTile. \p out est rempli en cas de succès.
+	/// Si \p outErrVersion != nullptr, reçoit la version trouvée même
+	/// en cas de WrongVersion (utile log).
+	VMapDecodeResult DecodeVMapTile(std::span<const uint8_t> in, VMapTile& out,
+		uint32_t* outErrVersion = nullptr);
+}

--- a/engine/server/shard/vmap/VMapFormatTests.cpp
+++ b/engine/server/shard/vmap/VMapFormatTests.cpp
@@ -1,0 +1,222 @@
+// CMANGOS.05 (Phase 2.05b) — Tests VMapFormat encode/decode round-trip.
+// Pure : pas de DB, pas d'I/O disque.
+
+#include "engine/server/shard/vmap/VMapFormat.h"
+#include "engine/core/Log.h"
+
+#include <cstring>
+
+namespace
+{
+	using engine::math::Vec3;
+	using engine::server::shard::vmap::AABB;
+	using engine::server::shard::vmap::DecodeVMapTile;
+	using engine::server::shard::vmap::EncodeVMapTile;
+	using engine::server::shard::vmap::kVMapMagic;
+	using engine::server::shard::vmap::kVMapVersion;
+	using engine::server::shard::vmap::VMapDecodeResult;
+	using engine::server::shard::vmap::VMapTile;
+	using engine::server::shard::vmap::VMapTri;
+
+	bool ApproxEq(float a, float b, float eps = 1e-6f)
+	{
+		float d = a - b; if (d < 0) d = -d;
+		return d <= eps;
+	}
+
+	bool TestRoundTripEmpty()
+	{
+		VMapTile t;
+		t.bbox.min = Vec3(0, 0, 0);
+		t.bbox.max = Vec3(0, 0, 0);
+		const auto blob = EncodeVMapTile(t);
+		// header = 4+4+24+8 = 40 bytes
+		if (blob.size() != 40)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] empty tile : expected 40 bytes, got {}", blob.size());
+			return false;
+		}
+
+		VMapTile decoded;
+		const auto r = DecodeVMapTile(blob, decoded);
+		if (r != VMapDecodeResult::OK) return false;
+		if (!decoded.vertices.empty() || !decoded.triangles.empty()) return false;
+		LOG_INFO(Core, "[VMapFormatTests] empty roundtrip OK");
+		return true;
+	}
+
+	bool TestRoundTripCube()
+	{
+		VMapTile t;
+		t.bbox.min = Vec3(-1, -1, -1);
+		t.bbox.max = Vec3(1, 1, 1);
+		// 8 vertices d'un cube unitaire, 12 triangles (2 par face × 6).
+		t.vertices = {
+			Vec3(-1, -1, -1), Vec3( 1, -1, -1), Vec3( 1,  1, -1), Vec3(-1,  1, -1),
+			Vec3(-1, -1,  1), Vec3( 1, -1,  1), Vec3( 1,  1,  1), Vec3(-1,  1,  1),
+		};
+		t.triangles = {
+			{0,1,2},{0,2,3}, {4,6,5},{4,7,6},
+			{0,4,5},{0,5,1}, {1,5,6},{1,6,2},
+			{2,6,7},{2,7,3}, {3,7,4},{3,4,0},
+		};
+
+		const auto blob = EncodeVMapTile(t);
+		VMapTile decoded;
+		const auto r = DecodeVMapTile(blob, decoded);
+		if (r != VMapDecodeResult::OK)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] cube decode result={}", static_cast<int>(r));
+			return false;
+		}
+		if (decoded.vertices.size() != 8 || decoded.triangles.size() != 12)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] cube counts wrong (V={} T={})",
+				decoded.vertices.size(), decoded.triangles.size());
+			return false;
+		}
+		// Spot check : le vertex 0 doit être (-1,-1,-1).
+		if (!ApproxEq(decoded.vertices[0].x, -1) || !ApproxEq(decoded.vertices[0].y, -1)
+			|| !ApproxEq(decoded.vertices[0].z, -1))
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] cube vertex[0] wrong");
+			return false;
+		}
+		// Spot check : triangle[3] = {4,7,6}.
+		if (decoded.triangles[3].a != 4 || decoded.triangles[3].b != 7
+			|| decoded.triangles[3].c != 6)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] cube triangle[3] wrong");
+			return false;
+		}
+		// bbox preserved.
+		if (!ApproxEq(decoded.bbox.min.x, -1) || !ApproxEq(decoded.bbox.max.z, 1)) return false;
+
+		LOG_INFO(Core, "[VMapFormatTests] cube roundtrip OK ({} bytes)", blob.size());
+		return true;
+	}
+
+	bool TestBufferTooSmall()
+	{
+		std::vector<uint8_t> tooShort(8, 0);  // header needs 40 bytes
+		VMapTile decoded;
+		const auto r = DecodeVMapTile(tooShort, decoded);
+		if (r != VMapDecodeResult::BufferTooSmall)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] expected BufferTooSmall, got {}", static_cast<int>(r));
+			return false;
+		}
+		LOG_INFO(Core, "[VMapFormatTests] BufferTooSmall OK");
+		return true;
+	}
+
+	bool TestBadMagic()
+	{
+		std::vector<uint8_t> blob(40, 0);
+		uint32_t bad = 0xDEADBEEF;
+		std::memcpy(blob.data(), &bad, 4);
+		VMapTile decoded;
+		const auto r = DecodeVMapTile(blob, decoded);
+		if (r != VMapDecodeResult::BadMagic)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] expected BadMagic, got {}", static_cast<int>(r));
+			return false;
+		}
+		LOG_INFO(Core, "[VMapFormatTests] BadMagic OK");
+		return true;
+	}
+
+	bool TestWrongVersion()
+	{
+		// Encode normal tile, puis bumper la version dans le buffer.
+		VMapTile t;
+		t.bbox.min = Vec3(-1, -1, -1);
+		t.bbox.max = Vec3(1, 1, 1);
+		auto blob = EncodeVMapTile(t);
+
+		// Version = bytes [4..7].
+		uint32_t fakeVersion = 999;
+		std::memcpy(blob.data() + 4, &fakeVersion, 4);
+
+		VMapTile decoded;
+		uint32_t errVer = 0;
+		const auto r = DecodeVMapTile(blob, decoded, &errVer);
+		if (r != VMapDecodeResult::WrongVersion)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] expected WrongVersion, got {}", static_cast<int>(r));
+			return false;
+		}
+		if (errVer != 999)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] outErrVersion wrong (got {})", errVer);
+			return false;
+		}
+		LOG_INFO(Core, "[VMapFormatTests] WrongVersion OK");
+		return true;
+	}
+
+	bool TestIndexOutOfRange()
+	{
+		// Tile avec 2 vertices mais triangle référencant index 5 → invalide.
+		VMapTile t;
+		t.bbox.min = Vec3(0, 0, 0);
+		t.bbox.max = Vec3(1, 1, 1);
+		t.vertices = { Vec3(0, 0, 0), Vec3(1, 0, 0) };
+		t.triangles = { VMapTri{0, 1, 5} };
+		auto blob = EncodeVMapTile(t);
+
+		VMapTile decoded;
+		const auto r = DecodeVMapTile(blob, decoded);
+		if (r != VMapDecodeResult::IndexOutOfRange)
+		{
+			LOG_ERROR(Core, "[VMapFormatTests] expected IndexOutOfRange, got {}", static_cast<int>(r));
+			return false;
+		}
+		LOG_INFO(Core, "[VMapFormatTests] IndexOutOfRange OK");
+		return true;
+	}
+
+	bool TestMagicValue()
+	{
+		// Le magic = 'L','V','M','1' little-endian = 0x314D564C.
+		// Vérifie que les caractères ASCII tombent au bon endroit.
+		const uint8_t expected[4] = {'L', 'V', 'M', '1'};
+		uint8_t actual[4];
+		std::memcpy(actual, &kVMapMagic, 4);
+		for (int i = 0; i < 4; ++i)
+		{
+			if (actual[i] != expected[i])
+			{
+				LOG_ERROR(Core, "[VMapFormatTests] magic byte[{}] wrong (got 0x{:x})", i, actual[i]);
+				return false;
+			}
+		}
+		LOG_INFO(Core, "[VMapFormatTests] magic ASCII = LVM1 OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestMagicValue()
+		&& TestRoundTripEmpty()
+		&& TestRoundTripCube()
+		&& TestBufferTooSmall()
+		&& TestBadMagic()
+		&& TestWrongVersion()
+		&& TestIndexOutOfRange();
+
+	if (ok)
+		LOG_INFO(Core, "[VMapFormatTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[VMapFormatTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Deuxième brique du module **vmap** (suite de [#490](https://github.com/tips-of-mine/LCDLLN-test/pull/490) BIH+AABB) — format binaire `.vmap` pour les tiles produits par l'outil offline `vmap_extractor` (à venir) et consommés par le shard au runtime via `VMapManager` (à venir).

### Layout binaire (little-endian, sans padding)

| Offset | Champ | Type |
|---|---|---|
| 0 | `magic` | `uint32` = `0x314D564Cu` (ASCII ""LVM1"") |
| 4 | `version` | `uint32` = `1` |
| 8..32 | `bbox` | 6 × `float` (min XYZ + max XYZ, world coords) |
| 32 | `vertexCount` | `uint32` |
| 36 | `triangleCount` | `uint32` |
| 40+ | `vertices` | N × `Vec3` (local coords, 12 bytes) |
| ... | `triangles` | M × `{a,b,c}` (3 × `uint32`, 12 bytes) |

Header = **40 bytes**. Tile vide encodé fait exactement 40 bytes.

### Validation au décodage

- `BadMagic` : pas `LVM1` → reject + log explicite (caller).
- `WrongVersion` : reject avec `outErrVersion` rempli (audit + alerte ops).
- `BufferTooSmall` : header tronqué ou tableaux annonçant > buffer.
- `IndexOutOfRange` : triangle référençant un vertex hors plage → protection contre fichier corrompu.

### Tests

`vmap_format_tests` : 7 cas — magic ASCII = `LVM1`, roundtrip empty / cube (8 vertices, 12 triangles), `BufferTooSmall`, `BadMagic`, `WrongVersion` (préserve la version trouvée), `IndexOutOfRange`.

## Test plan

- [x] Cube unitaire (8v, 12t) round-trip strict (vertices + triangles préservés).
- [x] `BufferTooSmall` : 8 bytes < 40 header → reject sans crash.
- [x] `BadMagic` : `0xDEADBEEF` au lieu de `LVM1` → reject.
- [x] `WrongVersion` : version=999 → reject + `outErrVersion=999`.
- [x] `IndexOutOfRange` : `{0,1,5}` avec seulement 2 vertices → reject.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code non encore wiré dans le runtime shard. Compilé seulement comme test sur Linux.

Pas de migration DB, pas de wire-breaking. Le **shard refusera les vieux fichiers** au load (audit §8 ""Format .vmap versioning"").

🤖 Generated with [Claude Code](https://claude.com/claude-code)