### PR TITLE
build(server): helper CMake lcdlln_add_simple_test (anti-conflits)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -3,6 +3,30 @@
 cmake_minimum_required(VERSION 3.20)
 set(CMAKE_CXX_STANDARD 20)
 
+# Helper pour declarer un test simple sans deps externes (engine_core +
+# spdlog + pthread suffisent).  Cible le pattern recurrent des tests
+# CMANGOS Phase 2 (BIH, ObjectGuid, VMapFormat, ChatChannelRegistry,
+# GridState, ChatSanitizer...) ou chaque target faisait ~9 lignes de
+# boilerplate identique. Avec ce helper, declarer un test devient :
+#
+#   lcdlln_add_simple_test(my_thing_tests
+#     foo/MyThingTests.cpp
+#     foo/MyThing.cpp
+#     foo/MyDep.cpp)
+#
+# Les tests qui ont besoin de MySQL, OpenSSL, ou d'autres libs gardent
+# leur add_executable manuel (pas la majorite). Ce helper reduit la
+# zone de conflit dans CMakeLists.txt entre PRs paralleles : chaque
+# nouvelle test target = 1 appel sur 4-5 lignes au lieu de 9-10 lignes
+# d'equivalent inline.
+function(lcdlln_add_simple_test target_name)
+  add_executable(${target_name} ${ARGN})
+  target_include_directories(${target_name} PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(${target_name} PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME ${target_name} COMMAND ${target_name} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endfunction()
+
 if(WIN32)
   add_executable(server_app
     main_server.cpp


### PR DESCRIPTION
## Summary

**Leçon de la Phase 2** : 6 PRs ouvertes en parallèle, toutes ajoutaient ~9 lignes de boilerplate identique pour déclarer un test target au même endroit dans `engine/server/CMakeLists.txt`. Conflits systématiques après chaque squash-merge → rebase + force-push + CI rerun. PR [#489](https://github.com/tips-of-mine/LCDLLN-test/pull/489) a été poussée **5 fois** pour cette seule raison (initial + 4 rebases).

Ce commit ajoute une fonction helper en haut du CMakeLists qui encapsule le boilerplate pour les tests simples (`engine_core + spdlog + pthread`, pas de MySQL ni d'OpenSSL).

### Avant

```cmake
add_executable(my_thing_tests
  foo/MyThingTests.cpp
  foo/MyThing.cpp
)
target_include_directories(my_thing_tests PRIVATE ${CMAKE_SOURCE_DIR})
target_link_libraries(my_thing_tests PRIVATE engine_core spdlog::spdlog pthread)
target_compile_options(my_thing_tests PRIVATE -Wall -Wextra -Wpedantic)
add_test(NAME my_thing_tests COMMAND my_thing_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
```

### Après

```cmake
lcdlln_add_simple_test(my_thing_tests
  foo/MyThingTests.cpp
  foo/MyThing.cpp)
```

**1 ligne de déclaration au lieu de 9** → divise la zone de conflit par ~5 entre PRs parallèles.

### Tests qui bénéficieraient en migration (incrémental)

`bih_tests`, `object_guid_tests`, `vmap_format_tests`, `chat_sanitizer_tests`, `chat_channel_registry_tests`, `grid_state_tests`, `session_character_map_tests` → toutes utilisent exactement le même pattern (engine_core + spdlog + pthread).

Pas de migration dans cette PR pour ne pas re-créer un conflit avec [#489](https://github.com/tips-of-mine/LCDLLN-test/pull/489) en CI. Migration incrémentale plus tard quand on touchera déjà à ces blocs.

### Tests avec deps complexes (gardent `add_executable` explicite)

`chat_gate_tests` (MySQL), `chat_command_router_tests` (OpenSSL + 5 .cpp), `account_role_service_tests` (idem), `db_layer_tests`, `sql_*_tests`, etc.

## Test plan

- [x] Le helper est défini avant `if(WIN32)/elseif(UNIX)` → disponible dans les deux blocs.
- [x] Aucun changement de comportement runtime ni de wire.
- [x] Aucun test existant n'est modifié (compatible).
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — pure build/CMake. Aucun runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)