### PR TITLE
Phase 2 CMANGOS.04 step 1 : MovementTypedefs + Spline<T> math

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -341,6 +341,10 @@ elseif(UNIX)
   target_compile_options(vmap_format_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME vmap_format_tests COMMAND vmap_format_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # CMANGOS.04 (Phase 2.04a) : Spline<T> + MovementTypedefs (header-only).
+  lcdlln_add_simple_test(spline_tests
+    shard/movement/SplineTests.cpp)
+
   # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
   add_executable(chat_command_router_tests
     chat/ChatCommandRouterTests.cpp

--- a/engine/server/shard/movement/MovementTypedefs.h
+++ b/engine/server/shard/movement/MovementTypedefs.h
@@ -1,0 +1,81 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04a) — MovementTypedefs : centralisation des
+// types vectoriels utilises par le sous-systeme `MoveSpline`. On
+// reutilise `engine::math::Vec3` existant + on ajoute `Vec4` et `Quat`
+// minimaux. Pas de dependance externe (math header-only).
+//
+// Quaternion : utilise pour l'orientation (yaw/pitch/roll) le long
+// d'une spline. Implementation minimale (somme + produit scalaire,
+// pas de slerp dans cette PR — viendra avec MoveSpline runtime).
+
+#include "engine/math/Math.h"
+
+#include <cmath>
+
+namespace engine::server::shard::movement
+{
+	using Vec3 = engine::math::Vec3;
+
+	/// Vec4 (xyz + w). Pas de namespace partage avec engine::math pour
+	/// rester local au sous-systeme movement (audit §1 : on ne veut PAS
+	/// pousser un Vec4 generique avant d'avoir un usage cote client).
+	struct Vec4
+	{
+		float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
+
+		constexpr Vec4() = default;
+		constexpr Vec4(float xv, float yv, float zv, float wv) noexcept
+			: x(xv), y(yv), z(zv), w(wv) {}
+
+		constexpr Vec4 operator+(const Vec4& o) const noexcept
+		{
+			return Vec4(x + o.x, y + o.y, z + o.z, w + o.w);
+		}
+		constexpr Vec4 operator-(const Vec4& o) const noexcept
+		{
+			return Vec4(x - o.x, y - o.y, z - o.z, w - o.w);
+		}
+		constexpr Vec4 operator*(float s) const noexcept
+		{
+			return Vec4(x * s, y * s, z * s, w * s);
+		}
+
+		constexpr float Dot(const Vec4& o) const noexcept
+		{
+			return x * o.x + y * o.y + z * o.z + w * o.w;
+		}
+		float Length() const noexcept { return std::sqrt(Dot(*this)); }
+	};
+
+	constexpr Vec4 operator*(float s, const Vec4& v) noexcept { return v * s; }
+
+	/// Quaternion (qx, qy, qz, qw). Convention {x,y,z}=axis*sin(angle/2),
+	/// w=cos(angle/2). Identite = (0,0,0,1).
+	struct Quat
+	{
+		float x = 0.0f, y = 0.0f, z = 0.0f, w = 1.0f;
+
+		constexpr Quat() = default;
+		constexpr Quat(float xv, float yv, float zv, float wv) noexcept
+			: x(xv), y(yv), z(zv), w(wv) {}
+
+		static constexpr Quat Identity() noexcept { return Quat(0, 0, 0, 1); }
+
+		/// Normalise le quaternion. No-op si len = 0.
+		Quat Normalized() const noexcept
+		{
+			const float len2 = x * x + y * y + z * z + w * w;
+			if (len2 <= 0.0f) return Identity();
+			const float invLen = 1.0f / std::sqrt(len2);
+			return Quat(x * invLen, y * invLen, z * invLen, w * invLen);
+		}
+
+		/// Construit un quaternion a partir d'un yaw (rotation autour
+		/// de l'axe vertical Y, en radians). Convention "yaw" cmangos.
+		static Quat FromYaw(float yawRad) noexcept
+		{
+			const float h = yawRad * 0.5f;
+			return Quat(0.0f, std::sin(h), 0.0f, std::cos(h));
+		}
+	};
+}

--- a/engine/server/shard/movement/Spline.h
+++ b/engine/server/shard/movement/Spline.h
@@ -1,0 +1,157 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04a) — Spline<T> : interpolation de controle
+// points pour les chemins de NPCs (patrouilles, IA, scripts). Header-
+// only, testable en isolation.
+//
+// **Modes supportes** :
+//   - Linear : interpolation droite point-a-point. Tres simple, jamais
+//     de smooth corner.
+//   - CatmullRom : passe par chaque control point (sauf le premier et
+//     le dernier qui servent de "tangentes virtuelles"). C'est le mode
+//     classique des chemins cmangos.
+//
+// **Convention** : la spline a N control points. Le parametre global
+// t s'etend sur [0, segmentCount()] ou segmentCount() depend du mode :
+//   - Linear     : N-1 segments (entre chaque paire consecutive)
+//   - CatmullRom : N-3 segments (premier et dernier point = tangentes)
+//
+// `Evaluate(t)` decompose t en {segment_index, local_t} et appelle la
+// formule appropriee. `LengthApprox(steps)` retourne la longueur en
+// echantillonnant N pas (utile pour parametriser par distance).
+//
+// Pure : pas d'allocation hors le vector des control points. Concept
+// requis sur T :
+//   - T() default-constructible
+//   - T operator+(T)
+//   - T operator-(T)
+//   - T operator*(float)
+//   - T.LengthSq() ou .Length() pour LengthApprox (Vec3 OK).
+
+#include "engine/server/shard/movement/MovementTypedefs.h"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace engine::server::shard::movement
+{
+	enum class SplineMode : uint8_t
+	{
+		Linear     = 0,
+		CatmullRom = 1,
+	};
+
+	template<typename T>
+	class Spline
+	{
+	public:
+		Spline() = default;
+
+		void SetMode(SplineMode m) noexcept { m_mode = m; }
+		SplineMode Mode() const noexcept { return m_mode; }
+
+		void SetPoints(std::vector<T> pts) { m_points = std::move(pts); }
+		const std::vector<T>& Points() const noexcept { return m_points; }
+
+		/// Nombre de segments evaluables. 0 si pas assez de points pour
+		/// le mode courant (Linear : need ≥ 2 ; CatmullRom : need ≥ 4).
+		size_t SegmentCount() const noexcept
+		{
+			switch (m_mode)
+			{
+				case SplineMode::Linear:
+					return m_points.size() < 2 ? 0 : m_points.size() - 1;
+				case SplineMode::CatmullRom:
+					return m_points.size() < 4 ? 0 : m_points.size() - 3;
+			}
+			return 0;
+		}
+
+		/// Echantillonne la spline a un parametre global t ∈ [0, SegmentCount()].
+		/// Hors de cet intervalle, t est clampe.
+		T Evaluate(float t) const
+		{
+			const size_t segs = SegmentCount();
+			if (segs == 0)
+				return m_points.empty() ? T{} : m_points.front();
+
+			if (t < 0.0f) t = 0.0f;
+			if (t > static_cast<float>(segs)) t = static_cast<float>(segs);
+
+			size_t segIdx = static_cast<size_t>(t);
+			if (segIdx >= segs) segIdx = segs - 1;
+			const float localT = t - static_cast<float>(segIdx);
+
+			switch (m_mode)
+			{
+				case SplineMode::Linear:
+					return EvalLinear(segIdx, localT);
+				case SplineMode::CatmullRom:
+					return EvalCatmullRom(segIdx, localT);
+			}
+			return T{};
+		}
+
+		/// Approxime la longueur totale en echantillonnant la spline en
+		/// `stepsPerSegment` morceaux uniformes. Plus on monte, plus
+		/// c'est precis. 16 est un bon defaut pour des chemins cmangos.
+		///
+		/// Concept additionnel sur T : T.Length() doit exister.
+		float LengthApprox(size_t stepsPerSegment = 16) const
+		{
+			if (stepsPerSegment == 0)
+				stepsPerSegment = 1;
+			const size_t segs = SegmentCount();
+			if (segs == 0)
+				return 0.0f;
+			float total = 0.0f;
+			const size_t totalSteps = segs * stepsPerSegment;
+			T prev = Evaluate(0.0f);
+			for (size_t i = 1; i <= totalSteps; ++i)
+			{
+				const float t = (static_cast<float>(i) / static_cast<float>(totalSteps))
+					* static_cast<float>(segs);
+				T cur = Evaluate(t);
+				const T diff = cur - prev;
+				total += diff.Length();
+				prev = cur;
+			}
+			return total;
+		}
+
+	private:
+		T EvalLinear(size_t segIdx, float localT) const
+		{
+			const T& p0 = m_points[segIdx];
+			const T& p1 = m_points[segIdx + 1];
+			return p0 + (p1 - p0) * localT;
+		}
+
+		/// Catmull-Rom uniforme, 4 control points par segment.
+		/// segIdx ∈ [0, N-4]. Les points utilises sont [segIdx ..segIdx+3].
+		/// Le segment retourne va de m_points[segIdx+1] a m_points[segIdx+2].
+		T EvalCatmullRom(size_t segIdx, float t) const
+		{
+			const T& p0 = m_points[segIdx + 0];
+			const T& p1 = m_points[segIdx + 1];
+			const T& p2 = m_points[segIdx + 2];
+			const T& p3 = m_points[segIdx + 3];
+
+			const float t2 = t * t;
+			const float t3 = t2 * t;
+
+			// Formule classique : 0.5 * ((2*P1) + (-P0+P2)*t +
+			//                            (2*P0-5*P1+4*P2-P3)*t^2 +
+			//                            (-P0+3*P1-3*P2+P3)*t^3)
+			T result =
+				p1 * 2.0f
+				+ (p2 - p0) * t
+				+ (p0 * 2.0f - p1 * 5.0f + p2 * 4.0f - p3) * t2
+				+ (p1 * 3.0f - p0 - p2 * 3.0f + p3) * t3;
+			return result * 0.5f;
+		}
+
+		std::vector<T> m_points;
+		SplineMode     m_mode = SplineMode::Linear;
+	};
+}

--- a/engine/server/shard/movement/SplineTests.cpp
+++ b/engine/server/shard/movement/SplineTests.cpp
@@ -1,0 +1,225 @@
+// CMANGOS.04 (Phase 2.04a) — Tests Spline<T> + MovementTypedefs.
+// Pure math, pas de DB.
+
+#include "engine/server/shard/movement/MovementTypedefs.h"
+#include "engine/server/shard/movement/Spline.h"
+#include "engine/core/Log.h"
+
+#include <cmath>
+
+namespace
+{
+	using engine::server::shard::movement::Quat;
+	using engine::server::shard::movement::Spline;
+	using engine::server::shard::movement::SplineMode;
+	using engine::server::shard::movement::Vec3;
+	using engine::server::shard::movement::Vec4;
+
+	bool ApproxEq(float a, float b, float eps = 1e-4f)
+	{
+		float d = a - b; if (d < 0) d = -d;
+		return d <= eps;
+	}
+
+	bool ApproxEqVec3(const Vec3& a, const Vec3& b, float eps = 1e-3f)
+	{
+		return ApproxEq(a.x, b.x, eps) && ApproxEq(a.y, b.y, eps) && ApproxEq(a.z, b.z, eps);
+	}
+
+	// --- Vec4 / Quat tests ---
+
+	bool TestVec4Arithmetic()
+	{
+		Vec4 a(1, 2, 3, 4);
+		Vec4 b(0, 1, 0, 1);
+		Vec4 sum = a + b;
+		if (!ApproxEq(sum.x, 1) || !ApproxEq(sum.y, 3) || !ApproxEq(sum.z, 3) || !ApproxEq(sum.w, 5))
+			return false;
+		Vec4 scaled = a * 2.0f;
+		if (!ApproxEq(scaled.x, 2) || !ApproxEq(scaled.w, 8)) return false;
+		// Dot product : a.b = 1*0 + 2*1 + 3*0 + 4*1 = 6
+		if (!ApproxEq(a.Dot(b), 6.0f)) return false;
+		LOG_INFO(Core, "[SplineTests] Vec4 arithmetic OK");
+		return true;
+	}
+
+	bool TestQuatIdentity()
+	{
+		const Quat id = Quat::Identity();
+		if (id.x != 0 || id.y != 0 || id.z != 0 || id.w != 1) return false;
+
+		const Quat yaw0 = Quat::FromYaw(0.0f);
+		// yaw=0 → sin(0)=0, cos(0)=1 → identity.
+		if (!ApproxEq(yaw0.x, 0) || !ApproxEq(yaw0.y, 0)
+			|| !ApproxEq(yaw0.z, 0) || !ApproxEq(yaw0.w, 1))
+			return false;
+
+		// yaw=π → sin(π/2)=1, cos(π/2)=0 → (0, 1, 0, 0)
+		const Quat yawPi = Quat::FromYaw(static_cast<float>(M_PI));
+		if (!ApproxEq(yawPi.y, 1.0f, 1e-3f) || !ApproxEq(yawPi.w, 0.0f, 1e-3f))
+		{
+			LOG_ERROR(Core, "[SplineTests] yawPi expected (0,1,0,0), got ({},{},{},{})",
+				yawPi.x, yawPi.y, yawPi.z, yawPi.w);
+			return false;
+		}
+
+		// Normalize d'un quaternion non-unitaire.
+		Quat raw(1, 2, 3, 4);
+		Quat n = raw.Normalized();
+		const float len2 = n.x * n.x + n.y * n.y + n.z * n.z + n.w * n.w;
+		if (!ApproxEq(len2, 1.0f, 1e-4f))
+		{
+			LOG_ERROR(Core, "[SplineTests] normalized len2={} expected 1", len2);
+			return false;
+		}
+
+		LOG_INFO(Core, "[SplineTests] Quat identity + FromYaw + Normalize OK");
+		return true;
+	}
+
+	// --- Spline<Vec3> Linear ---
+
+	bool TestSplineLinearBasic()
+	{
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::Linear);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(10, 0, 0), Vec3(20, 0, 0)});
+
+		if (s.SegmentCount() != 2) return false;
+		if (!ApproxEqVec3(s.Evaluate(0.0f), Vec3(0, 0, 0))) return false;
+		if (!ApproxEqVec3(s.Evaluate(1.0f), Vec3(10, 0, 0))) return false;
+		if (!ApproxEqVec3(s.Evaluate(2.0f), Vec3(20, 0, 0))) return false;
+		// Mid-segment.
+		if (!ApproxEqVec3(s.Evaluate(0.5f), Vec3(5, 0, 0))) return false;
+		if (!ApproxEqVec3(s.Evaluate(1.5f), Vec3(15, 0, 0))) return false;
+		LOG_INFO(Core, "[SplineTests] linear basic OK");
+		return true;
+	}
+
+	bool TestSplineLinearClamp()
+	{
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::Linear);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(1, 0, 0)});
+		// t hors [0, 1] est clampe.
+		if (!ApproxEqVec3(s.Evaluate(-5.0f), Vec3(0, 0, 0))) return false;
+		if (!ApproxEqVec3(s.Evaluate(99.0f), Vec3(1, 0, 0))) return false;
+		LOG_INFO(Core, "[SplineTests] linear clamp OK");
+		return true;
+	}
+
+	bool TestSplineLinearLength()
+	{
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::Linear);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(3, 4, 0)});  // distance = 5
+		const float len = s.LengthApprox(8);
+		if (!ApproxEq(len, 5.0f, 0.001f))
+		{
+			LOG_ERROR(Core, "[SplineTests] linear length expected ~5, got {}", len);
+			return false;
+		}
+		LOG_INFO(Core, "[SplineTests] linear length OK");
+		return true;
+	}
+
+	// --- Spline<Vec3> CatmullRom ---
+
+	bool TestSplineCatmullRomNeedsFour()
+	{
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::CatmullRom);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(1, 0, 0), Vec3(2, 0, 0)});
+		if (s.SegmentCount() != 0)
+		{
+			LOG_ERROR(Core, "[SplineTests] CR with 3 points should have 0 segments");
+			return false;
+		}
+		LOG_INFO(Core, "[SplineTests] CR needs ≥ 4 points OK");
+		return true;
+	}
+
+	bool TestSplineCatmullRomPassesThroughInner()
+	{
+		// 4 points alignés sur l'axe X. Catmull-Rom doit passer
+		// EXACTEMENT par P1 (à t=0) et P2 (à t=1).
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::CatmullRom);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(1, 0, 0), Vec3(2, 0, 0), Vec3(3, 0, 0)});
+
+		if (s.SegmentCount() != 1) return false;
+		if (!ApproxEqVec3(s.Evaluate(0.0f), Vec3(1, 0, 0)))
+		{
+			LOG_ERROR(Core, "[SplineTests] CR t=0 expected P1=(1,0,0), got ({},{},{})",
+				s.Evaluate(0.0f).x, s.Evaluate(0.0f).y, s.Evaluate(0.0f).z);
+			return false;
+		}
+		if (!ApproxEqVec3(s.Evaluate(1.0f), Vec3(2, 0, 0)))
+		{
+			LOG_ERROR(Core, "[SplineTests] CR t=1 expected P2=(2,0,0)");
+			return false;
+		}
+		// Mid-point sur axe X linéaire : doit être (1.5, 0, 0).
+		if (!ApproxEqVec3(s.Evaluate(0.5f), Vec3(1.5f, 0, 0), 1e-3f))
+		{
+			LOG_ERROR(Core, "[SplineTests] CR mid expected (1.5,0,0), got ({},{},{})",
+				s.Evaluate(0.5f).x, s.Evaluate(0.5f).y, s.Evaluate(0.5f).z);
+			return false;
+		}
+		LOG_INFO(Core, "[SplineTests] CR passes through P1/P2 OK");
+		return true;
+	}
+
+	bool TestSplineCatmullRomCurve()
+	{
+		// 4 points : (0,0,0), (1,0,0), (1,1,0), (0,1,0) — forment un L.
+		// La Catmull-Rom doit passer par P1=(1,0,0) et P2=(1,1,0).
+		// À t=0.5, la courbe est entre les deux mais pas sur la droite
+		// directe : on doit avoir z=0 et y entre 0 et 1, x proche mais
+		// PAS exactement 1 (la courbure pousse).
+		Spline<Vec3> s;
+		s.SetMode(SplineMode::CatmullRom);
+		s.SetPoints({Vec3(0, 0, 0), Vec3(1, 0, 0), Vec3(1, 1, 0), Vec3(0, 1, 0)});
+
+		const Vec3 mid = s.Evaluate(0.5f);
+		if (!ApproxEq(mid.z, 0.0f)) return false;          // reste 2D
+		if (mid.y < 0.0f || mid.y > 1.0f) return false;    // y in [0,1]
+		// La courbure rend mid.x > 1 (la courbe "déborde" vers l'extérieur
+		// du virage en L pour rester smooth).
+		if (mid.x <= 1.0f)
+		{
+			LOG_ERROR(Core, "[SplineTests] expected curve overshoot x>1 at L-corner, got x={}",
+				mid.x);
+			return false;
+		}
+		LOG_INFO(Core, "[SplineTests] CR L-curve overshoot OK (mid=({}, {}, {}))",
+			mid.x, mid.y, mid.z);
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestVec4Arithmetic()
+		&& TestQuatIdentity()
+		&& TestSplineLinearBasic()
+		&& TestSplineLinearClamp()
+		&& TestSplineLinearLength()
+		&& TestSplineCatmullRomNeedsFour()
+		&& TestSplineCatmullRomPassesThroughInner()
+		&& TestSplineCatmullRomCurve();
+
+	if (ok)
+		LOG_INFO(Core, "[SplineTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[SplineTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Première brique du système **MoveSpline** cmangos pour les NPCs / IA — math header-only, testable en isolation. **Aucune intégration runtime, aucun opcode, aucun wire-breaking** dans cette PR. Les bricks suivantes (`MoveSpline` runtime, `MoveSplinePacketBuilder`, opcodes `kOpcodeMonsterMove`) viendront en PRs ultérieures.

### `MovementTypedefs.h`

- `Vec3` = alias de `engine::math::Vec3` (déjà en place)
- `Vec4` (xyzw, `+/-/*scalar`, `Dot`, `Length`)
- `Quat` (xyzw, `Identity`, `FromYaw(rad)`, `Normalized`)

### `Spline<T>` templated

Deux modes :

| Mode | Segments | Caractéristique |
|---|---|---|
| `Linear` | N-1 | Interpolation droite point-à-point |
| `CatmullRom` | N-3 | Premier+dernier = tangentes ; passe **exactement** par chaque control point intérieur |

API :
- `SetMode` / `SetPoints` / `SegmentCount`
- `Evaluate(t)` : `t ∈ [0, SegmentCount()]`, clampé hors plage, décompose en `{segIdx, localT}` et applique la formule du mode
- `LengthApprox(stepsPerSegment=16)` : approximation par échantillonnage uniforme

Concept `T` minimal : default-construct, `+/-/*float`. Pour `LengthApprox` : `T.Length()`. `Vec3` valide.

### Première PR utilisant le nouveau helper

Cette PR utilise `lcdlln_add_simple_test(...)` ajouté en [#492](https://github.com/tips-of-mine/LCDLLN-test/pull/492) — **1 appel sur 2 lignes** au lieu de 9 lignes de boilerplate.

```cmake
lcdlln_add_simple_test(spline_tests
  shard/movement/SplineTests.cpp)
```

### Tests

`spline_tests` : 8 cas couvrant :

- `Vec4` arithmétique + `Dot`
- `Quat::Identity` + `FromYaw(0)`/`FromYaw(π)` + `Normalized` retourne unit
- `Spline<Vec3>` Linear basic (3 points alignés, mid-segment exact)
- Linear clamp (t hors plage)
- Linear length 3-4-5 = 5 (via `LengthApprox`)
- CatmullRom refuse < 4 points (`SegmentCount = 0`)
- CatmullRom passe **exactement** par P1 (t=0) et P2 (t=1)
- CatmullRom L-curve : overshoot attendu (la courbe déborde du virage pour rester smooth)

## Test plan

- [x] Vec4/Quat arithmetic conforme.
- [x] `Spline<Vec3>` linear : segments à mi-chemin précis.
- [x] CR : à t=0 = P1, à t=1 = P2 (passage exact par les control points intérieurs).
- [x] CR sur L-shape : `mid.x > 1` (smooth overshoot, pas de droite directe).
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code header-only non encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. La sub-PR suivante (MoveSpline runtime) déclenchera un redéploiement shard. La PR encore d'après (opcodes wire) déclenchera un redéploiement lock-step **client + master + shard**.

Pas de migration DB, pas de wire-breaking ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)