### PR TITLE
Phase 2 CMANGOS.05 step 3 : VMapManager + IsInLineOfSight + GetHeight

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -345,6 +345,13 @@ elseif(UNIX)
   lcdlln_add_simple_test(spline_tests
     shard/movement/SplineTests.cpp)
 
+  # CMANGOS.05 (Phase 2.05c) : VMapManager LOS + GetHeight tests.
+  lcdlln_add_simple_test(vmap_manager_tests
+    shard/vmap/VMapManagerTests.cpp
+    shard/vmap/VMapManager.cpp
+    shard/vmap/VMapFormat.cpp
+    shard/vmap/AABB.cpp)
+
   # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
   add_executable(chat_command_router_tests
     chat/ChatCommandRouterTests.cpp

--- a/engine/server/shard/vmap/VMapManager.cpp
+++ b/engine/server/shard/vmap/VMapManager.cpp
@@ -1,0 +1,137 @@
+#include "engine/server/shard/vmap/VMapManager.h"
+
+#include <cmath>
+#include <limits>
+
+namespace engine::server::shard::vmap
+{
+	bool VMapManager::LoadTile(std::span<const uint8_t> blob)
+	{
+		VMapTile tile;
+		if (DecodeVMapTile(blob, tile) != VMapDecodeResult::OK)
+			return false;
+		LoadTileDecoded(std::move(tile));
+		return true;
+	}
+
+	void VMapManager::LoadTileDecoded(VMapTile tile)
+	{
+		Clear();
+
+		// Construire la liste des triangles "objet" pour la BIH.
+		m_triangles.reserve(tile.triangles.size());
+		for (const auto& t : tile.triangles)
+		{
+			VMapTriObject obj;
+			obj.v0 = tile.vertices[t.a];
+			obj.v1 = tile.vertices[t.b];
+			obj.v2 = tile.vertices[t.c];
+			obj.bounds = AABB::Empty();
+			obj.bounds.Expand(obj.v0);
+			obj.bounds.Expand(obj.v1);
+			obj.bounds.Expand(obj.v2);
+			m_triangles.push_back(obj);
+		}
+
+		m_bbox = tile.bbox;
+		m_bih.Build(m_triangles);
+	}
+
+	void VMapManager::Clear()
+	{
+		m_triangles.clear();
+		m_bih.Clear();
+		m_bbox = AABB::Empty();
+	}
+
+	bool VMapManager::IsInLineOfSight(const Vec3& p1, const Vec3& p2) const
+	{
+		if (!IsLoaded())
+			return true;  // pas d'obstruction connue
+
+		const Vec3 dir = p2 - p1;
+		const float segLen = dir.Length();
+		if (segLen <= 0.0f)
+			return true;  // p1 == p2 → trivialement visible
+
+		Ray r(p1, dir);
+		r.tMin = 0.0f;
+		r.tMax = 1.0f;  // segment paramétrique [0,1] : on s'arrete a p2
+
+		auto hitTest = [&](uint32_t idx, const Ray& ray, float& tOut) {
+			return IntersectRayTri(ray, m_triangles[idx], tOut);
+		};
+
+		const float tHit = m_bih.Raycast(r, m_triangles, hitTest);
+		// Si tHit ∈ [0, 1], il y a un triangle entre p1 et p2 → bloque.
+		return tHit > 1.0f || std::isinf(tHit);
+	}
+
+	std::optional<float> VMapManager::GetHeight(float x, float z,
+		float maxSearchHeight) const
+	{
+		if (!IsLoaded())
+			return std::nullopt;
+
+		// Raycast vertical descendant : origine = (x, maxY, z), dir = -Y.
+		const Vec3 origin(x, maxSearchHeight, z);
+		Ray r(origin, Vec3(0.0f, -1.0f, 0.0f));
+		r.tMin = 0.0f;
+		r.tMax = std::numeric_limits<float>::infinity();
+
+		auto hitTest = [&](uint32_t idx, const Ray& ray, float& tOut) {
+			return IntersectRayTri(ray, m_triangles[idx], tOut);
+		};
+
+		const float tHit = m_bih.Raycast(r, m_triangles, hitTest);
+		if (std::isinf(tHit))
+			return std::nullopt;
+
+		// Point d'impact sur l'axe Y : origine.y - tHit.
+		return maxSearchHeight - tHit;
+	}
+
+	bool VMapManager::IntersectRayTri(const Ray& r, const VMapTriObject& tri,
+		float& tHit) noexcept
+	{
+		// Möller-Trumbore. Reference :
+		// https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
+		constexpr float kEps = 1e-7f;
+
+		const Vec3 e1 = tri.v1 - tri.v0;
+		const Vec3 e2 = tri.v2 - tri.v0;
+
+		// Pvec = ray.dir × e2
+		const Vec3 pvec(
+			r.dir.y * e2.z - r.dir.z * e2.y,
+			r.dir.z * e2.x - r.dir.x * e2.z,
+			r.dir.x * e2.y - r.dir.y * e2.x);
+
+		const float det = e1.x * pvec.x + e1.y * pvec.y + e1.z * pvec.z;
+		if (std::fabs(det) < kEps)
+			return false;  // rayon parallèle au triangle
+		const float invDet = 1.0f / det;
+
+		const Vec3 tvec = r.origin - tri.v0;
+		const float u = (tvec.x * pvec.x + tvec.y * pvec.y + tvec.z * pvec.z) * invDet;
+		if (u < 0.0f || u > 1.0f)
+			return false;
+
+		// qvec = tvec × e1
+		const Vec3 qvec(
+			tvec.y * e1.z - tvec.z * e1.y,
+			tvec.z * e1.x - tvec.x * e1.z,
+			tvec.x * e1.y - tvec.y * e1.x);
+
+		const float v = (r.dir.x * qvec.x + r.dir.y * qvec.y + r.dir.z * qvec.z) * invDet;
+		if (v < 0.0f || u + v > 1.0f)
+			return false;
+
+		const float t = (e2.x * qvec.x + e2.y * qvec.y + e2.z * qvec.z) * invDet;
+		if (t < r.tMin || t > r.tMax)
+			return false;
+
+		tHit = t;
+		return true;
+	}
+}

--- a/engine/server/shard/vmap/VMapManager.h
+++ b/engine/server/shard/vmap/VMapManager.h
@@ -1,0 +1,99 @@
+#pragma once
+// CMANGOS.05 (Phase 2.05c) — VMapManager : facade pour les requetes
+// LOS / GetHeight / projectile contre les tiles vmap charges.
+//
+// Cette PR couvre :
+//   - Charger un VMapTile (cf. VMapFormat) et construire la BIH des
+//     triangles.
+//   - IsInLineOfSight(p1, p2) : segment de droite, true si pas de
+//     mesh entre les deux points.
+//   - GetHeight(x, z) : hauteur Y du sol au-dessous de (x, z), via
+//     raycast vertical descendant. Retourne nullopt si rien sous le
+//     point ou hors tile.
+//
+// **Hors scope** :
+//   - Multi-tile streaming (un seul tile pour cette PR — le manager
+//     accepte un set de tiles mais ne les charge/decharge pas
+//     automatiquement).
+//   - DynamicTree (objets transformables) — viendra apres.
+//   - Threading : non thread-safe pour cette PR. La BIH est immutable
+//     une fois Load OK, donc lectures concurrentes sans modification
+//     pourraient marcher en pratique mais on documente non-safe.
+
+#include "engine/server/shard/vmap/AABB.h"
+#include "engine/server/shard/vmap/BIH.h"
+#include "engine/server/shard/vmap/VMapFormat.h"
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::shard::vmap
+{
+	/// Wrapper "objet" autour d'un triangle pour la BIH. Stocke ses
+	/// 3 sommets (par valeur) + une bbox precalculee. Cout : 3 Vec3 +
+	/// 2 Vec3 = 60 octets par triangle.
+	struct VMapTriObject
+	{
+		Vec3 v0{}, v1{}, v2{};
+		AABB bounds{};
+
+		AABB Bounds() const noexcept { return bounds; }
+	};
+
+	/// Manager d'un OU plusieurs tiles. Pour cette PR, charger un seul
+	/// tile suffit (Load(tile) construit la BIH globale).
+	class VMapManager
+	{
+	public:
+		VMapManager() = default;
+
+		/// Decode un buffer .vmap et construit la BIH. Retourne true sur
+		/// succes. En cas d'echec (BadMagic, WrongVersion, etc.), l'etat
+		/// interne reste vide.
+		bool LoadTile(std::span<const uint8_t> blob);
+
+		/// Charge directement depuis un VMapTile deja decode. Plus
+		/// pratique pour les tests.
+		void LoadTileDecoded(VMapTile tile);
+
+		/// Retire le tile et libere la BIH.
+		void Clear();
+
+		/// True si un tile est charge.
+		bool IsLoaded() const noexcept { return !m_triangles.empty(); }
+
+		/// Bbox du tile charge (ou empty si vide).
+		const AABB& Bounds() const noexcept { return m_bbox; }
+
+		/// Test ligne-de-vue entre deux points world. Retourne true si
+		/// AUCUN triangle n'intercepte le segment. Si pas de tile charge,
+		/// retourne true (pas d'obstruction connue).
+		bool IsInLineOfSight(const Vec3& p1, const Vec3& p2) const;
+
+		/// Hauteur Y du sol au-dessous de (\p x, \p z), en raycastant
+		/// depuis (\p x, maxY, \p z) vers le bas. Retourne le Y de la
+		/// premiere intersection (le "sol"). nullopt si rien sous le
+		/// point ou si pas de tile charge.
+		///
+		/// \param maxSearchHeight Hauteur de depart du raycast. Default
+		///                       1000m (largement au-dessus de tout).
+		std::optional<float> GetHeight(float x, float z,
+			float maxSearchHeight = 1000.0f) const;
+
+		/// Nombre de triangles indexes (utile pour metriques).
+		size_t TriangleCount() const noexcept { return m_triangles.size(); }
+
+	private:
+		/// Test rayon-vs-triangle (Moller-Trumbore). Retourne true et
+		/// remplit \p tHit si le rayon coupe le triangle.
+		static bool IntersectRayTri(const Ray& r, const VMapTriObject& tri,
+			float& tHit) noexcept;
+
+		std::vector<VMapTriObject> m_triangles;
+		BIH<VMapTriObject>         m_bih;
+		AABB                       m_bbox = AABB::Empty();
+	};
+}

--- a/engine/server/shard/vmap/VMapManagerTests.cpp
+++ b/engine/server/shard/vmap/VMapManagerTests.cpp
@@ -1,0 +1,217 @@
+// CMANGOS.05 (Phase 2.05c) — Tests VMapManager IsInLineOfSight + GetHeight.
+// Pure : pas de DB, pas d'I/O disque (tile fabriqué en mémoire).
+
+#include "engine/server/shard/vmap/VMapFormat.h"
+#include "engine/server/shard/vmap/VMapManager.h"
+#include "engine/core/Log.h"
+
+#include <cmath>
+
+namespace
+{
+	using engine::math::Vec3;
+	using engine::server::shard::vmap::AABB;
+	using engine::server::shard::vmap::VMapManager;
+	using engine::server::shard::vmap::VMapTile;
+	using engine::server::shard::vmap::VMapTri;
+
+	bool ApproxEq(float a, float b, float eps = 1e-2f)
+	{
+		float d = a - b; if (d < 0) d = -d;
+		return d <= eps;
+	}
+
+	/// Crée un tile contenant un mur vertical en plan x=5, s'étendant
+	/// y ∈ [0, 10], z ∈ [-5, 5]. 2 triangles formant un quad.
+	VMapTile MakeWallTile()
+	{
+		VMapTile t;
+		t.bbox.min = Vec3(5, 0, -5);
+		t.bbox.max = Vec3(5, 10, 5);
+		t.vertices = {
+			Vec3(5, 0, -5),  // 0 : bottom-left
+			Vec3(5, 0,  5),  // 1 : bottom-right
+			Vec3(5, 10, 5),  // 2 : top-right
+			Vec3(5, 10,-5),  // 3 : top-left
+		};
+		t.triangles = { VMapTri{0, 1, 2}, VMapTri{0, 2, 3} };
+		return t;
+	}
+
+	/// Crée un tile avec un sol horizontal à y=0, étendu sur [-10,10] × [-10,10].
+	VMapTile MakeFloorTile()
+	{
+		VMapTile t;
+		t.bbox.min = Vec3(-10, 0, -10);
+		t.bbox.max = Vec3( 10, 0,  10);
+		t.vertices = {
+			Vec3(-10, 0, -10), // 0
+			Vec3( 10, 0, -10), // 1
+			Vec3( 10, 0,  10), // 2
+			Vec3(-10, 0,  10), // 3
+		};
+		t.triangles = { VMapTri{0, 1, 2}, VMapTri{0, 2, 3} };
+		return t;
+	}
+
+	bool TestEmptyManagerLOS()
+	{
+		VMapManager mgr;
+		// Pas de tile chargé → pas d'obstruction connue → toujours LOS.
+		if (!mgr.IsInLineOfSight(Vec3(0, 0, 0), Vec3(10, 0, 0))) return false;
+		LOG_INFO(Core, "[VMapManagerTests] empty manager LOS=true OK");
+		return true;
+	}
+
+	bool TestLoadAndCount()
+	{
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeWallTile());
+		if (!mgr.IsLoaded()) return false;
+		if (mgr.TriangleCount() != 2) return false;
+		LOG_INFO(Core, "[VMapManagerTests] load 2 tris OK");
+		return true;
+	}
+
+	bool TestLOSBlocked()
+	{
+		// Mur en x=5. Rayon (0,5,0) → (10,5,0) doit le traverser.
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeWallTile());
+		const bool los = mgr.IsInLineOfSight(Vec3(0, 5, 0), Vec3(10, 5, 0));
+		if (los)
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] expected LOS=false (wall in path)");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] LOS blocked by wall OK");
+		return true;
+	}
+
+	bool TestLOSClear()
+	{
+		// Mur en x=5, hauteur [0..10]. Rayon en y=15 (au-dessus) doit
+		// passer.
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeWallTile());
+		const bool los = mgr.IsInLineOfSight(Vec3(0, 15, 0), Vec3(10, 15, 0));
+		if (!los)
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] expected LOS=true (above wall)");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] LOS clear above wall OK");
+		return true;
+	}
+
+	bool TestLOSStopsBeforeWall()
+	{
+		// Mur en x=5. Rayon (0,5,0) → (4,5,0) — s'arrête avant le mur.
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeWallTile());
+		const bool los = mgr.IsInLineOfSight(Vec3(0, 5, 0), Vec3(4, 5, 0));
+		if (!los)
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] expected LOS=true (segment ends before wall)");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] LOS stops before wall OK");
+		return true;
+	}
+
+	bool TestGetHeightOnFloor()
+	{
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeFloorTile());
+		// Sol y=0. Le raycast depuis (0, 1000, 0) vers le bas doit
+		// retourner y=0.
+		auto h = mgr.GetHeight(0.0f, 0.0f);
+		if (!h)
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] GetHeight expected value, got nullopt");
+			return false;
+		}
+		if (!ApproxEq(*h, 0.0f))
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] GetHeight expected 0, got {}", *h);
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] GetHeight=0 on floor OK");
+		return true;
+	}
+
+	bool TestGetHeightOutOfBounds()
+	{
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeFloorTile());
+		// Tile = [-10,10] × [-10,10]. (50, 0, 0) hors plage → nullopt.
+		auto h = mgr.GetHeight(50.0f, 0.0f);
+		if (h)
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] expected nullopt out of bounds, got {}", *h);
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] GetHeight nullopt out-of-bounds OK");
+		return true;
+	}
+
+	bool TestEncodeDecodeBlobRoundTrip()
+	{
+		// Encode → decode via VMapFormat → load via LoadTile (blob).
+		const auto blob = engine::server::shard::vmap::EncodeVMapTile(MakeWallTile());
+		VMapManager mgr;
+		if (!mgr.LoadTile(blob))
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] LoadTile from blob failed");
+			return false;
+		}
+		// Doit bloquer comme avant.
+		if (mgr.IsInLineOfSight(Vec3(0, 5, 0), Vec3(10, 5, 0)))
+		{
+			LOG_ERROR(Core, "[VMapManagerTests] LoadTile blob : LOS still expected blocked");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapManagerTests] LoadTile from blob roundtrip OK");
+		return true;
+	}
+
+	bool TestClear()
+	{
+		VMapManager mgr;
+		mgr.LoadTileDecoded(MakeWallTile());
+		mgr.Clear();
+		if (mgr.IsLoaded()) return false;
+		if (mgr.TriangleCount() != 0) return false;
+		// Après Clear : LOS toujours true (pas d'obstruction).
+		if (!mgr.IsInLineOfSight(Vec3(0, 5, 0), Vec3(10, 5, 0))) return false;
+		LOG_INFO(Core, "[VMapManagerTests] Clear OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmptyManagerLOS()
+		&& TestLoadAndCount()
+		&& TestLOSBlocked()
+		&& TestLOSClear()
+		&& TestLOSStopsBeforeWall()
+		&& TestGetHeightOnFloor()
+		&& TestGetHeightOutOfBounds()
+		&& TestEncodeDecodeBlobRoundTrip()
+		&& TestClear();
+
+	if (ok)
+		LOG_INFO(Core, "[VMapManagerTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[VMapManagerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Troisième brique du module **vmap** : `VMapManager` qui encapsule un tile chargé (via `VMapFormat` de [#491](https://github.com/tips-of-mine/LCDLLN-test/pull/491)) + une `BIH` (de [#490](https://github.com/tips-of-mine/LCDLLN-test/pull/490)) sur ses triangles, et expose les **3 requêtes vmap canoniques** côté shard :

### Requêtes

| API | Sémantique |
|---|---|
| `IsInLineOfSight(p1, p2)` | `true` si **aucun** triangle n'intercepte le segment. `true` si pas de tile chargé (pas d'obstruction connue). |
| `GetHeight(x, z, maxSearchHeight=1000)` | Raycast vertical descendant. Retourne le Y du sol (1ère intersection) ou `nullopt`. |
| `IntersectRayTri` | Möller-Trumbore O(1), no sqrt. |

### Architecture

- BIH filtre les candidats via leur AABB → triangle test seulement sur les feuilles.
- 1 tile par manager (pour cette PR — multi-tile streaming en sub-PR ultérieure).
- Non thread-safe (immuable après `Load`, lectures concurrentes OK en pratique).

### Hors scope

- Multi-tile streaming (`VMapStreamer`).
- DynamicTree pour portes / GameObjects transformables.
- Wiring dans combat / spell / anti-cheat — viendra avec `ManagedModel` + `VMapStreamer`.

### Tests

`vmap_manager_tests` (utilise le helper `lcdlln_add_simple_test`) : 9 cas — empty manager LOS true, load 2 tris, LOS bloqué par mur, LOS libre au-dessus du mur, segment qui s'arrête avant le mur, GetHeight=0 sur sol, GetHeight nullopt hors-plage, encode/decode roundtrip via blob, Clear.

### Cas test concret : ""mur invisible""

- Mur en plan x=5, y∈[0,10], z∈[-5,5] (2 triangles formant un quad).
- Rayon (0, 5, 0) → (10, 5, 0) : **bloqué** ✗
- Rayon (0, 15, 0) → (10, 15, 0) : **libre** (au-dessus du mur) ✓
- Rayon (0, 5, 0) → (4, 5, 0) : **libre** (segment s'arrête avant le mur) ✓

## Test plan

- [x] `IsLoaded == false` initialement, `LOS == true` (pas d'obstruction).
- [x] `LoadTile(blob)` puis `LoadTileDecoded(tile)` produisent le même résultat (roundtrip via `VMapFormat`).
- [x] Mur 2 tris : LOS bloqué par segment qui le traverse, libre au-dessus.
- [x] Sol horizontal : `GetHeight(0,0) == 0`. Hors plage `nullopt`.
- [x] `Clear()` → `IsLoaded == false`, LOS toujours `true`.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — module isolé, pas encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. Le wiring dans Combat/Spell viendra avec `ManagedModel` + `VMapStreamer` en PR ultérieure (déclenchera redéploiement shard).

Pas de migration DB, pas de wire-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)