### PR TITLE
Phase 2 CMANGOS.04 step 2 : MoveSpline runtime + MoveSplineInit builder

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -352,6 +352,11 @@ elseif(UNIX)
     shard/vmap/VMapFormat.cpp
     shard/vmap/AABB.cpp)
 
+  # CMANGOS.04 (Phase 2.04b) : MoveSpline runtime + MoveSplineInit builder.
+  lcdlln_add_simple_test(move_spline_tests
+    shard/movement/MoveSplineTests.cpp
+    shard/movement/MoveSpline.cpp)
+
   # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
   add_executable(chat_command_router_tests
     chat/ChatCommandRouterTests.cpp

--- a/engine/server/shard/movement/MoveSpline.cpp
+++ b/engine/server/shard/movement/MoveSpline.cpp
@@ -1,0 +1,71 @@
+#include "engine/server/shard/movement/MoveSpline.h"
+
+#include <cmath>
+
+namespace engine::server::shard::movement
+{
+	void MoveSpline::Launch(uint32_t id, Spline<Vec3> path, MoveSplineFlag flags,
+		float velocity, TimePoint startTime)
+	{
+		m_path      = std::move(path);
+		m_flags     = flags;
+		m_splineId  = id;
+		m_velocity  = velocity;
+		m_startTime = startTime;
+		m_distance  = 0.0f;
+		m_finished  = false;
+
+		// Mode CR si flag, sinon Linear.
+		m_path.SetMode(HasFlag(flags, MoveSplineFlag::Catmullrom)
+			? SplineMode::CatmullRom : SplineMode::Linear);
+
+		m_totalLen = m_path.LengthApprox(16);
+
+		// Position initiale = debut de la spline. En CR, c'est P1
+		// (premier point intérieur), pas P0.
+		m_currentPos = m_path.Evaluate(0.0f);
+	}
+
+	bool MoveSpline::UpdatePosition(TimePoint now)
+	{
+		if (m_finished || m_velocity <= 0.0f || m_totalLen <= 0.0f)
+			return !m_finished;
+
+		const auto elapsedSec = std::chrono::duration_cast<
+			std::chrono::duration<float>>(now - m_startTime).count();
+		if (elapsedSec < 0.0f)
+			return true;  // before launch — pas de progression
+
+		float traveled = elapsedSec * m_velocity;
+
+		// Cyclic : on enroule sur la longueur totale.
+		const bool cyclic = HasFlag(m_flags, MoveSplineFlag::Cyclic);
+		if (cyclic && m_totalLen > 0.0f)
+		{
+			traveled = std::fmod(traveled, m_totalLen);
+		}
+		else if (traveled >= m_totalLen)
+		{
+			// Fin du mouvement (mode non-cyclic).
+			m_distance = m_totalLen;
+			const float segs = static_cast<float>(m_path.SegmentCount());
+			m_currentPos = m_path.Evaluate(segs);
+			m_finished = true;
+			return false;
+		}
+
+		m_distance = traveled;
+
+		// Mapper la distance lineaire sur le parametre global [0, segCount].
+		// Approximation : distance / totalLen * segCount. Pour des splines
+		// CR avec courbure variable, c'est inexact mais suffisant en
+		// premiere mise (les chemins typiques cmangos ont peu de courbure
+		// extreme).
+		const float segs = static_cast<float>(m_path.SegmentCount());
+		const float t = (m_totalLen > 0.0f)
+			? (traveled / m_totalLen) * segs
+			: 0.0f;
+		m_currentPos = m_path.Evaluate(t);
+		return true;
+	}
+}

--- a/engine/server/shard/movement/MoveSpline.h
+++ b/engine/server/shard/movement/MoveSpline.h
@@ -1,0 +1,96 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04b) — MoveSpline : runtime state d'un
+// deplacement scriptable (NPC / IA). S'appuie sur Spline<Vec3> (#493)
+// pour la geometrie + MoveSplineFlag pour le mode.
+//
+// **Couvre** :
+//   - Etat runtime : spline + parametre courant + vitesse + flags +
+//     identifiant monotone (`splineId`).
+//   - `UpdatePosition(now)` : avance le parametre selon le temps
+//     ecoule et la vitesse. Retourne true tant que le mouvement n'est
+//     pas termine.
+//   - `CurrentPosition()` : interpolation Vec3 actuelle.
+//   - `IsFinished()` : true si on a atteint la fin (ou jamais lance).
+//   - Cyclic : boucle au lieu de finir.
+//
+// **Hors scope** :
+//   - Builder fluide `MoveSplineInit` (cf. MoveSplineInit.h).
+//   - Sérialisation reseau (sub-PR ulterieure : MoveSplinePacketBuilder).
+//   - Interpolation client (sub-PR client : MoveSplineInterpolator).
+
+#include "engine/server/shard/movement/MoveSplineFlag.h"
+#include "engine/server/shard/movement/MovementTypedefs.h"
+#include "engine/server/shard/movement/Spline.h"
+
+#include <chrono>
+#include <cstdint>
+
+namespace engine::server::shard::movement
+{
+	class MoveSpline
+	{
+	public:
+		using Clock     = std::chrono::steady_clock;
+		using TimePoint = Clock::time_point;
+
+		MoveSpline() = default;
+
+		/// Identifiant monotone strictement croissant. Permet au client
+		/// d'ignorer les paquets out-of-order (cf. audit §8 "Spline ID
+		/// monotone").
+		uint32_t SplineId() const noexcept { return m_splineId; }
+
+		/// Flags bitmask. Default `None`.
+		MoveSplineFlag Flags() const noexcept { return m_flags; }
+
+		/// Acces direct a la spline geometrique (debug / serialisation).
+		const Spline<Vec3>& Path() const noexcept { return m_path; }
+
+		/// Vitesse en unites/sec (typiquement m/s). 0 → mouvement fige.
+		float Velocity() const noexcept { return m_velocity; }
+
+		/// Temps de depart (steady_clock).
+		TimePoint StartTime() const noexcept { return m_startTime; }
+
+		/// Position courante apres `UpdatePosition(now)`. Si le
+		/// mouvement n'a pas encore commence, retourne le premier
+		/// control point (ou Vec3 zero si la spline est vide).
+		Vec3 CurrentPosition() const noexcept { return m_currentPos; }
+
+		/// Distance parcourue (cumulee depuis StartTime).
+		float DistanceTraveled() const noexcept { return m_distance; }
+
+		/// True si le mouvement est arrive a la fin (et que cyclic est
+		/// false). False pour un mouvement en cours OU pour une spline
+		/// non encore lancee.
+		bool IsFinished() const noexcept { return m_finished; }
+
+		/// Avance la simulation jusqu'au temps \p now. A appeler chaque
+		/// tick depuis le shard. Premier appel = "Launch" implicite si
+		/// SplineId != 0. Retourne `true` si le mouvement est encore
+		/// actif (peut etre re-tick), `false` une fois termine.
+		bool UpdatePosition(TimePoint now);
+
+		/// Setup interne — utilise par MoveSplineInit::Launch.
+		///
+		/// \param id      Identifiant monotone (caller doit garantir
+		///                strictement croissant cote shard).
+		/// \param path    Spline geometrique (deja peuplee).
+		/// \param flags   Bitmask MoveSplineFlag.
+		/// \param velocity Unites/sec. > 0.
+		/// \param startTime Temps de depart (steady_clock).
+		void Launch(uint32_t id, Spline<Vec3> path, MoveSplineFlag flags,
+			float velocity, TimePoint startTime);
+
+	private:
+		Spline<Vec3>    m_path;
+		MoveSplineFlag  m_flags     = MoveSplineFlag::None;
+		uint32_t        m_splineId  = 0;
+		float           m_velocity  = 0.0f;
+		TimePoint       m_startTime{};
+		Vec3            m_currentPos{};
+		float           m_distance  = 0.0f;     ///< distance cumulee parcourue
+		float           m_totalLen  = 0.0f;     ///< longueur totale de la spline
+		bool            m_finished  = true;     ///< true tant qu'on n'est pas Launch
+	};
+}

--- a/engine/server/shard/movement/MoveSplineFlag.h
+++ b/engine/server/shard/movement/MoveSplineFlag.h
@@ -1,0 +1,54 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04b) — MoveSplineFlag : flags bitmask 32-bit
+// pour decrire le mode de deplacement (Walk/Flying/Swimming/Falling/
+// Cyclic, etc.). Aligne sur le pattern cmangos pour interoperabilite
+// future, mais reduit aux flags utiles a LCDLLN.
+
+#include <cstdint>
+
+namespace engine::server::shard::movement
+{
+	/// Bitmask 32 bits. Plusieurs flags peuvent etre combines (ex.
+	/// `Walking | Backward` pour reculer).
+	enum class MoveSplineFlag : uint32_t
+	{
+		None       = 0u,
+
+		// --- Locomotion mode (un seul a la fois normalement) ---
+		Walking    = 1u << 0,   ///< Marche au sol (default).
+		Flying     = 1u << 1,   ///< Vol — ignore la gravite.
+		Swimming   = 1u << 2,   ///< Nage — gravite reduite.
+		Falling    = 1u << 3,   ///< Chute libre — gravite + velocite initiale.
+
+		// --- Modificateurs ---
+		Backward   = 1u << 8,   ///< Recule (orientation inversee).
+		Cyclic     = 1u << 9,   ///< Boucle a la fin du chemin.
+		EnterCycle = 1u << 10,  ///< Premier passage avant boucle.
+		Frozen     = 1u << 11,  ///< Pause — pas de progression mais conserve l'etat.
+
+		// --- Hints client ---
+		Catmullrom = 1u << 16,  ///< Interpolation lisse (sinon Linear).
+		FacingTarget = 1u << 17, ///< Oriente vers une cible mobile.
+	};
+
+	constexpr MoveSplineFlag operator|(MoveSplineFlag a, MoveSplineFlag b) noexcept
+	{
+		return static_cast<MoveSplineFlag>(
+			static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+	}
+	constexpr MoveSplineFlag operator&(MoveSplineFlag a, MoveSplineFlag b) noexcept
+	{
+		return static_cast<MoveSplineFlag>(
+			static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+	}
+	constexpr MoveSplineFlag& operator|=(MoveSplineFlag& a, MoveSplineFlag b) noexcept
+	{
+		a = a | b; return a;
+	}
+
+	/// True si \p f contient au moins un des flags de \p mask.
+	constexpr bool HasFlag(MoveSplineFlag f, MoveSplineFlag mask) noexcept
+	{
+		return (static_cast<uint32_t>(f) & static_cast<uint32_t>(mask)) != 0;
+	}
+}

--- a/engine/server/shard/movement/MoveSplineInit.h
+++ b/engine/server/shard/movement/MoveSplineInit.h
@@ -1,0 +1,83 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04b) — MoveSplineInit : builder fluide pour
+// configurer un MoveSpline avant de le lancer. Pattern classique
+// cmangos (`MoveSplineInit init(unit); init.MoveTo(p); init.Launch();`).
+//
+// Pas de side-effect avant `Launch` : on accumule les points et les
+// flags, puis `Launch` configure le MoveSpline du caller. Le builder
+// est jetable (un par mouvement).
+
+#include "engine/server/shard/movement/MoveSpline.h"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace engine::server::shard::movement
+{
+	class MoveSplineInit
+	{
+	public:
+		MoveSplineInit() = default;
+
+		/// Ajoute un control point a la trajectoire.
+		MoveSplineInit& MoveTo(const Vec3& point)
+		{
+			m_points.push_back(point);
+			return *this;
+		}
+
+		/// Definit la vitesse (unites/sec). Default 0 = inerte.
+		MoveSplineInit& SetVelocity(float v)
+		{
+			m_velocity = v;
+			return *this;
+		}
+
+		/// Active un flag (cumulatif).
+		MoveSplineInit& AddFlag(MoveSplineFlag f)
+		{
+			m_flags = m_flags | f;
+			return *this;
+		}
+
+		/// Sucre syntaxique pour les flags les plus courants.
+		MoveSplineInit& SetWalking()      { return AddFlag(MoveSplineFlag::Walking); }
+		MoveSplineInit& SetFlying()       { return AddFlag(MoveSplineFlag::Flying); }
+		MoveSplineInit& SetSwimming()     { return AddFlag(MoveSplineFlag::Swimming); }
+		MoveSplineInit& SetCyclic()       { return AddFlag(MoveSplineFlag::Cyclic); }
+		MoveSplineInit& SetCatmullRom()   { return AddFlag(MoveSplineFlag::Catmullrom); }
+
+		/// Configure le \p out MoveSpline avec les valeurs accumulees.
+		/// \param newId Identifiant monotone strictement croissant
+		///              (caller responsable).
+		/// \param now   Temps de depart (steady_clock).
+		/// \return false si la configuration est invalide (pas assez de
+		///         points pour le mode choisi). Dans ce cas, \p out
+		///         n'est pas modifie.
+		bool Launch(MoveSpline& out, uint32_t newId, MoveSpline::TimePoint now) const
+		{
+			// Validation : Linear needs ≥ 2 points, CR ≥ 4.
+			const bool cr = HasFlag(m_flags, MoveSplineFlag::Catmullrom);
+			const size_t minPoints = cr ? 4 : 2;
+			if (m_points.size() < minPoints)
+				return false;
+
+			Spline<Vec3> path;
+			path.SetMode(cr ? SplineMode::CatmullRom : SplineMode::Linear);
+			path.SetPoints(m_points);
+			out.Launch(newId, std::move(path), m_flags, m_velocity, now);
+			return true;
+		}
+
+		/// Acces aux donnees accumulees (pour tests/debug).
+		const std::vector<Vec3>& Points() const noexcept { return m_points; }
+		MoveSplineFlag Flags() const noexcept { return m_flags; }
+		float Velocity() const noexcept { return m_velocity; }
+
+	private:
+		std::vector<Vec3> m_points;
+		MoveSplineFlag    m_flags    = MoveSplineFlag::None;
+		float             m_velocity = 0.0f;
+	};
+}

--- a/engine/server/shard/movement/MoveSplineTests.cpp
+++ b/engine/server/shard/movement/MoveSplineTests.cpp
@@ -1,0 +1,236 @@
+// CMANGOS.04 (Phase 2.04b) — Tests MoveSpline runtime + MoveSplineInit.
+// Pas de DB ni de threading.
+
+#include "engine/server/shard/movement/MoveSpline.h"
+#include "engine/server/shard/movement/MoveSplineInit.h"
+#include "engine/core/Log.h"
+
+#include <chrono>
+
+namespace
+{
+	using engine::server::shard::movement::HasFlag;
+	using engine::server::shard::movement::MoveSpline;
+	using engine::server::shard::movement::MoveSplineFlag;
+	using engine::server::shard::movement::MoveSplineInit;
+	using engine::server::shard::movement::Vec3;
+	using namespace std::chrono_literals;
+
+	using TP = MoveSpline::TimePoint;
+
+	bool ApproxEq(float a, float b, float eps = 0.05f)
+	{
+		float d = a - b; if (d < 0) d = -d;
+		return d <= eps;
+	}
+
+	bool TestFlagsBitwise()
+	{
+		auto f = MoveSplineFlag::Walking | MoveSplineFlag::Cyclic;
+		if (!HasFlag(f, MoveSplineFlag::Walking)) return false;
+		if (!HasFlag(f, MoveSplineFlag::Cyclic)) return false;
+		if (HasFlag(f, MoveSplineFlag::Flying)) return false;
+		LOG_INFO(Core, "[MoveSplineTests] flag bitwise OK");
+		return true;
+	}
+
+	bool TestInitRejectsTooFewPoints()
+	{
+		MoveSplineInit init;
+		MoveSpline ms;
+		// 1 point seulement → invalide pour Linear (besoin ≥ 2).
+		init.MoveTo(Vec3(0, 0, 0));
+		init.SetVelocity(5.0f);
+		const TP now{};
+		if (init.Launch(ms, 1, now))
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] Launch should refuse 1 point");
+			return false;
+		}
+		LOG_INFO(Core, "[MoveSplineTests] reject too few points OK");
+		return true;
+	}
+
+	bool TestInitLinearLaunch()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .SetVelocity(5.0f)
+		    .SetWalking();
+		MoveSpline ms;
+		const TP t0{};
+		if (!init.Launch(ms, 42, t0))
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] Launch should succeed (2 points, linear)");
+			return false;
+		}
+		if (ms.SplineId() != 42 || ms.IsFinished())
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] post-launch state wrong");
+			return false;
+		}
+		// Position initiale = premier control point (0,0,0).
+		const Vec3 p0 = ms.CurrentPosition();
+		if (!ApproxEq(p0.x, 0) || !ApproxEq(p0.y, 0) || !ApproxEq(p0.z, 0)) return false;
+		LOG_INFO(Core, "[MoveSplineTests] linear launch OK");
+		return true;
+	}
+
+	bool TestUpdatePositionMidpoint()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .SetVelocity(5.0f);  // 5 m/s sur 10m → trajet en 2s
+		MoveSpline ms;
+		const TP t0{};
+		init.Launch(ms, 1, t0);
+
+		// A t=1s : on devrait etre a (5, 0, 0).
+		const TP t1 = t0 + std::chrono::seconds(1);
+		const bool stillActive = ms.UpdatePosition(t1);
+		if (!stillActive)
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] should still be active at 1s");
+			return false;
+		}
+		const Vec3 pos = ms.CurrentPosition();
+		if (!ApproxEq(pos.x, 5.0f, 0.1f))
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] mid expected x=5, got x={}", pos.x);
+			return false;
+		}
+		LOG_INFO(Core, "[MoveSplineTests] mid-trajectory OK");
+		return true;
+	}
+
+	bool TestFinishesAtEnd()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .SetVelocity(5.0f);  // 2s pour finir
+		MoveSpline ms;
+		const TP t0{};
+		init.Launch(ms, 1, t0);
+
+		// A t=3s : termine.
+		const bool active = ms.UpdatePosition(t0 + 3s);
+		if (active)
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] should be finished at 3s");
+			return false;
+		}
+		if (!ms.IsFinished())
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] IsFinished should be true");
+			return false;
+		}
+		// Position finale = derniere point.
+		const Vec3 pos = ms.CurrentPosition();
+		if (!ApproxEq(pos.x, 10.0f))
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] end pos expected x=10, got x={}", pos.x);
+			return false;
+		}
+		LOG_INFO(Core, "[MoveSplineTests] finishes at end OK");
+		return true;
+	}
+
+	bool TestCyclicLoops()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .SetVelocity(10.0f)  // 1s pour finir
+		    .SetCyclic();
+		MoveSpline ms;
+		const TP t0{};
+		init.Launch(ms, 1, t0);
+
+		// A t=0.5s : milieu (~5m).
+		ms.UpdatePosition(t0 + std::chrono::milliseconds(500));
+		if (!ApproxEq(ms.CurrentPosition().x, 5.0f, 0.5f)) return false;
+
+		// A t=1.5s : le mouvement aurait fini en non-cyclic, mais cyclic →
+		// retour a 0.5s du cycle suivant → milieu.
+		ms.UpdatePosition(t0 + std::chrono::milliseconds(1500));
+		if (ms.IsFinished())
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] cyclic should never finish");
+			return false;
+		}
+		// Position attendue : 0.5s de cycle suivant → ~5m.
+		if (!ApproxEq(ms.CurrentPosition().x, 5.0f, 0.5f))
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] cyclic mid expected x~5, got x={}",
+				ms.CurrentPosition().x);
+			return false;
+		}
+		LOG_INFO(Core, "[MoveSplineTests] cyclic loops OK");
+		return true;
+	}
+
+	bool TestVelocityZeroFreeze()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .SetVelocity(0.0f);
+		MoveSpline ms;
+		const TP t0{};
+		init.Launch(ms, 1, t0);
+
+		ms.UpdatePosition(t0 + 100s);
+		// Velocity 0 → pas de progression. Position reste au depart.
+		if (ms.IsFinished())
+		{
+			LOG_ERROR(Core, "[MoveSplineTests] velocity 0 → should not finish");
+			return false;
+		}
+		if (!ApproxEq(ms.CurrentPosition().x, 0.0f, 0.01f)) return false;
+		LOG_INFO(Core, "[MoveSplineTests] velocity 0 freeze OK");
+		return true;
+	}
+
+	bool TestSplineIdMonotoneCallerResponsibility()
+	{
+		// Le caller est responsable de l'unicite. On vérifie juste que
+		// SplineId est bien transporté tel quel.
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0)).MoveTo(Vec3(1, 0, 0)).SetVelocity(1.0f);
+		MoveSpline ms;
+		const TP t0{};
+		init.Launch(ms, 999u, t0);
+		if (ms.SplineId() != 999u) return false;
+		LOG_INFO(Core, "[MoveSplineTests] SplineId carried OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestFlagsBitwise()
+		&& TestInitRejectsTooFewPoints()
+		&& TestInitLinearLaunch()
+		&& TestUpdatePositionMidpoint()
+		&& TestFinishesAtEnd()
+		&& TestCyclicLoops()
+		&& TestVelocityZeroFreeze()
+		&& TestSplineIdMonotoneCallerResponsibility();
+
+	if (ok)
+		LOG_INFO(Core, "[MoveSplineTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[MoveSplineTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Runtime de déplacement scriptable au-dessus du `Spline<T>` math de [#493](https://github.com/tips-of-mine/LCDLLN-test/pull/493). Pattern cmangos classique pour les chemins de NPCs / IA.

### Nouveaux fichiers

- `MoveSplineFlag.h` — bitmask 32-bit (`Walking / Flying / Swimming / Falling / Backward / Cyclic / EnterCycle / Frozen / Catmullrom / FacingTarget`).
- `MoveSpline.h/.cpp` — état runtime + `Launch` + `UpdatePosition(now)` + `CurrentPosition` + `IsFinished` + `SplineId` (monotone, audit §8).
- `MoveSplineInit.h` — builder fluide header-only :
  ```cpp
  MoveSplineInit init;
  init.MoveTo(start)
      .MoveTo(waypoint1)
      .MoveTo(end)
      .SetVelocity(5.0f)
      .SetWalking()
      .SetCatmullRom();
  init.Launch(creature.MovementSpline(), nextId++, steady_clock::now());
  ```

### Sémantique runtime

- `UpdatePosition(now)` calcule `traveled = elapsed * velocity` puis le mappe sur `[0, segCount]` via la longueur approximée. Approximation linéaire de la spline → précision suffisante pour les chemins typiques cmangos (peu de courbure extrême).
- `Cyclic` → `fmod(traveled, totalLen)` → boucle sans jamais `IsFinished`.
- `Velocity = 0` → mouvement gelé (utile `Frozen` flag).

### Hors scope

- **Wire** (opcodes `kOpcodeMonsterMove*` + bump `kProtocolVersion`) → sub-PR ultérieure (déploiement lock-step **client + master + shard**).
- **Intégration runtime shard** : `SpawnerRuntime` / `MotionGenerator` (CMANGOS.20) qui invoqueront `MoveSplineInit` viendront après.

### Tests

`move_spline_tests` (utilise `lcdlln_add_simple_test`) : 8 cas — flag bitwise, `Init` refuse 1 point, `Init` Linear Launch OK, mi-trajet (0→10 à 5 m/s à t=1s ⇒ x≈5), finit à la fin (non-cyclic), cyclic boucle (jamais `IsFinished`), velocity=0 gèle la position, `SplineId` carried à 999.

## Test plan

- [x] Flag bitmask : `Walking | Cyclic` contient les deux.
- [x] `Init` refuse 1 point (Linear needs ≥ 2).
- [x] Trajet 10m à 5 m/s : à t=1s, position x ≈ 5.
- [x] Trajet terminé à t > totalLen/v : `IsFinished == true`, position = dernier point.
- [x] Cyclic : à t=1.5s sur cycle 1s, position ≈ mid-cycle, jamais `IsFinished`.
- [x] Velocity 0 : pas de progression même après 100s.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code non encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. La sub-PR suivante (opcodes `MonsterMove*`) déclenchera un redéploiement **lock-step client + master + shard** (wire-breaking).

Pas de migration DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)