### PR TITLE
Phase 2 CMANGOS.05 step 4 : VMapStreamer + ManagedModel

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -357,6 +357,14 @@ elseif(UNIX)
     shard/movement/MoveSplineTests.cpp
     shard/movement/MoveSpline.cpp)
 
+  # CMANGOS.05 (Phase 2.05d) : VMapStreamer + ManagedModel (refcount + delayed unload).
+  lcdlln_add_simple_test(vmap_streamer_tests
+    shard/vmap/VMapStreamerTests.cpp
+    shard/vmap/VMapStreamer.cpp
+    shard/vmap/VMapManager.cpp
+    shard/vmap/VMapFormat.cpp
+    shard/vmap/AABB.cpp)
+
   # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
   add_executable(chat_command_router_tests
     chat/ChatCommandRouterTests.cpp

--- a/engine/server/shard/vmap/VMapStreamer.cpp
+++ b/engine/server/shard/vmap/VMapStreamer.cpp
@@ -1,0 +1,57 @@
+#include "engine/server/shard/vmap/VMapStreamer.h"
+
+namespace engine::server::shard::vmap
+{
+	ManagedModel* VMapStreamer::Acquire(std::string_view key)
+	{
+		const std::string skey(key);
+		auto it = m_tiles.find(skey);
+		if (it != m_tiles.end())
+		{
+			it->second->IncRef();
+			return it->second.get();
+		}
+
+		// Nouveau tile : charger via le loader.
+		if (!m_loader)
+			return nullptr;
+		auto blob = m_loader(key);
+		if (blob.empty())
+			return nullptr;
+
+		auto model = std::make_unique<ManagedModel>();
+		if (!model->LoadFromBuffer(blob))
+			return nullptr;
+
+		model->IncRef();
+		auto* raw = model.get();
+		m_tiles.emplace(skey, std::move(model));
+		return raw;
+	}
+
+	void VMapStreamer::Release(std::string_view key, TimePoint now)
+	{
+		auto it = m_tiles.find(std::string(key));
+		if (it == m_tiles.end())
+			return;
+		it->second->DecRef(now);
+	}
+
+	size_t VMapStreamer::Tick(TimePoint now)
+	{
+		size_t freed = 0;
+		for (auto it = m_tiles.begin(); it != m_tiles.end(); )
+		{
+			if (it->second->ShouldRelease(now, m_cfg.releaseDelay))
+			{
+				it = m_tiles.erase(it);
+				++freed;
+			}
+			else
+			{
+				++it;
+			}
+		}
+		return freed;
+	}
+}

--- a/engine/server/shard/vmap/VMapStreamer.h
+++ b/engine/server/shard/vmap/VMapStreamer.h
@@ -1,0 +1,140 @@
+#pragma once
+// CMANGOS.05 (Phase 2.05d) — VMapStreamer + ManagedModel : streaming
+// dynamique des tiles vmap. Acquire au passage d'une cellule en mode
+// "Active" (cf. GridState), Release quand tous les joueurs sont
+// partis. Decharge differee pour eviter le ping-pong load/unload.
+//
+// **Design** :
+//   - Un tile est identifie par une cle string (typiquement un chemin
+//     relatif type "zone1/tile_0_0.vmap"). Le streamer ne connait pas
+//     l'arborescence ; un loader callback fourni par le caller
+//     transforme la cle → buffer .vmap (typiquement via FileSystem).
+//   - ManagedModel = VMapManager + refcount + last-zero-ref timestamp.
+//     Quand refcount tombe a 0, on demarre un timer ; apres
+//     `releaseDelay`, le tile est decharge.
+//   - Le streamer expose `Acquire(key)` et `Release(key)`. Il faut
+//     appeler `Tick(now)` regulierement pour declencher les decharges.
+//
+// **Hors scope** : limite par memoire RAM/GPU (audit §8 "DynamicTree
+// memory" — pas applicable au vmap statique). Eviction LRU automatique
+// si on depasse `maxLoadedTiles` viendra plus tard.
+
+#include "engine/server/shard/vmap/VMapManager.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::shard::vmap
+{
+	/// Loader callback : prend une cle de tile, retourne un buffer
+	/// `.vmap`. Doit retourner un buffer vide si la cle est inconnue.
+	using VMapTileLoader = std::function<std::vector<uint8_t>(std::string_view key)>;
+
+	struct VMapStreamerConfig
+	{
+		using Duration = std::chrono::steady_clock::duration;
+		/// Delai apres `refcount = 0` avant decharge effective. Default
+		/// 30s : un joueur qui sort puis rentre dans la cellule
+		/// (ping-pong au bord d'un chunk) ne paie pas le cout de
+		/// reload.
+		Duration releaseDelay = std::chrono::seconds(30);
+	};
+
+	/// VMapManager wrappe + refcount + timer. Possede par le streamer.
+	class ManagedModel
+	{
+	public:
+		using TimePoint = std::chrono::steady_clock::time_point;
+
+		ManagedModel() = default;
+
+		bool LoadFromBuffer(std::span<const uint8_t> blob)
+		{
+			return m_manager.LoadTile(blob);
+		}
+
+		const VMapManager& Manager() const noexcept { return m_manager; }
+		VMapManager& Manager() noexcept { return m_manager; }
+
+		uint32_t RefCount() const noexcept { return m_refCount; }
+		void IncRef() noexcept
+		{
+			++m_refCount;
+			m_zeroRefSince = TimePoint{};
+		}
+		/// Decremente. Si retombe a 0, demarre le timer no-ref a \p now.
+		void DecRef(TimePoint now) noexcept
+		{
+			if (m_refCount > 0)
+				--m_refCount;
+			if (m_refCount == 0)
+				m_zeroRefSince = now;
+		}
+
+		/// True si refcount = 0 ET le timer "no-ref" est ecoule depuis
+		/// au moins \p delay.
+		bool ShouldRelease(TimePoint now, VMapStreamerConfig::Duration delay) const noexcept
+		{
+			if (m_refCount > 0) return false;
+			if (m_zeroRefSince == TimePoint{}) return false;
+			return (now - m_zeroRefSince) >= delay;
+		}
+
+	private:
+		VMapManager m_manager;
+		uint32_t    m_refCount = 0;
+		TimePoint   m_zeroRefSince{};  ///< 0 si refcount > 0
+	};
+
+	class VMapStreamer
+	{
+	public:
+		using TimePoint = ManagedModel::TimePoint;
+
+		VMapStreamer() = default;
+
+		/// Configure le loader (obligatoire avant Acquire).
+		void SetLoader(VMapTileLoader loader) { m_loader = std::move(loader); }
+
+		void SetConfig(VMapStreamerConfig cfg) noexcept { m_cfg = cfg; }
+		const VMapStreamerConfig& Config() const noexcept { return m_cfg; }
+
+		/// Acquire une reference sur le tile \p key. Charge si pas encore
+		/// en RAM. Retourne pointeur vers le ManagedModel ou nullptr si
+		/// le loader echoue.
+		ManagedModel* Acquire(std::string_view key);
+
+		/// Release la reference. Le tile reste en RAM jusqu'a ce que
+		/// `Tick(now)` decharge apres `releaseDelay`.
+		void Release(std::string_view key, TimePoint now);
+
+		/// Decharge tous les tiles dont le timer "no-ref" a expire.
+		/// Retourne le nombre de tiles decharges.
+		size_t Tick(TimePoint now);
+
+		/// Nombre de tiles actuellement en RAM (compte tout, ref ou pas).
+		size_t LoadedTileCount() const noexcept { return m_tiles.size(); }
+
+		/// Lookup direct sans bumping refcount (lectures).
+		const ManagedModel* Find(std::string_view key) const noexcept
+		{
+			auto it = m_tiles.find(std::string(key));
+			return (it == m_tiles.end()) ? nullptr : it->second.get();
+		}
+
+		/// Reset complet (decharge tous les tiles immediatement).
+		void Clear() { m_tiles.clear(); }
+
+	private:
+		VMapTileLoader     m_loader;
+		VMapStreamerConfig m_cfg{};
+		std::unordered_map<std::string, std::unique_ptr<ManagedModel>> m_tiles;
+	};
+}

--- a/engine/server/shard/vmap/VMapStreamerTests.cpp
+++ b/engine/server/shard/vmap/VMapStreamerTests.cpp
@@ -1,0 +1,243 @@
+// CMANGOS.05 (Phase 2.05d) — Tests VMapStreamer + ManagedModel.
+// Loader callback simule en RAM (un dict in-memory de blobs).
+
+#include "engine/server/shard/vmap/VMapFormat.h"
+#include "engine/server/shard/vmap/VMapStreamer.h"
+#include "engine/core/Log.h"
+
+#include <chrono>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+	using engine::math::Vec3;
+	using engine::server::shard::vmap::AABB;
+	using engine::server::shard::vmap::ManagedModel;
+	using engine::server::shard::vmap::VMapStreamer;
+	using engine::server::shard::vmap::VMapStreamerConfig;
+	using engine::server::shard::vmap::VMapTile;
+	using engine::server::shard::vmap::VMapTri;
+	using namespace std::chrono_literals;
+	using TP = ManagedModel::TimePoint;
+
+	/// Fabrique un tile minimal (1 triangle au plan z=0).
+	VMapTile MakeMiniTile()
+	{
+		VMapTile t;
+		t.bbox.min = Vec3(0, 0, 0);
+		t.bbox.max = Vec3(1, 0, 1);
+		t.vertices = { Vec3(0, 0, 0), Vec3(1, 0, 0), Vec3(0, 0, 1) };
+		t.triangles = { VMapTri{0, 1, 2} };
+		return t;
+	}
+
+	/// Loader in-memory : map<key, blob>.
+	struct InMemoryStore
+	{
+		std::unordered_map<std::string, std::vector<uint8_t>> blobs;
+		void Add(std::string key, const VMapTile& tile)
+		{
+			blobs[std::move(key)] = engine::server::shard::vmap::EncodeVMapTile(tile);
+		}
+		auto Loader()
+		{
+			return [this](std::string_view key) -> std::vector<uint8_t> {
+				auto it = blobs.find(std::string(key));
+				return (it == blobs.end()) ? std::vector<uint8_t>{} : it->second;
+			};
+		}
+	};
+
+	bool TestAcquireLoadsAndIncrefs()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+
+		auto* m = s.Acquire("a");
+		if (!m) { LOG_ERROR(Core, "[VMapStreamerTests] Acquire returned null"); return false; }
+		if (m->RefCount() != 1) return false;
+		if (s.LoadedTileCount() != 1) return false;
+		if (!m->Manager().IsLoaded()) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] Acquire loads + refcount=1 OK");
+		return true;
+	}
+
+	bool TestAcquireSecondTimeJustBumps()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+
+		s.Acquire("a");
+		auto* m = s.Acquire("a");
+		if (m->RefCount() != 2)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] expected refcount=2, got {}", m->RefCount());
+			return false;
+		}
+		if (s.LoadedTileCount() != 1)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] should still be 1 tile loaded");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapStreamerTests] Acquire 2x increfs without reload OK");
+		return true;
+	}
+
+	bool TestUnknownKeyFails()
+	{
+		InMemoryStore store;
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+		auto* m = s.Acquire("bogus");
+		if (m != nullptr)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] expected nullptr for unknown key");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapStreamerTests] unknown key returns nullptr OK");
+		return true;
+	}
+
+	bool TestReleaseStartsTimerThenTickUnloads()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+
+		VMapStreamerConfig cfg;
+		cfg.releaseDelay = 5s;
+		s.SetConfig(cfg);
+
+		const TP t0{};
+		s.Acquire("a");
+		s.Release("a", t0);
+		// Timer demarre a t0. Tick a t0+3s : pas encore expire.
+		if (s.Tick(t0 + 3s) != 0) return false;
+		if (s.LoadedTileCount() != 1) return false;
+
+		// Tick a t0+10s : expire → unload.
+		const auto freed = s.Tick(t0 + 10s);
+		if (freed != 1)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] expected 1 freed, got {}", freed);
+			return false;
+		}
+		if (s.LoadedTileCount() != 0) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] Release+Tick unloads after delay OK");
+		return true;
+	}
+
+	bool TestReAcquireBeforeUnloadCancelsTimer()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+
+		VMapStreamerConfig cfg;
+		cfg.releaseDelay = 5s;
+		s.SetConfig(cfg);
+
+		const TP t0{};
+		s.Acquire("a");
+		s.Release("a", t0);
+		// 3s plus tard : pas encore expire. Re-acquire → timer reset.
+		s.Acquire("a");
+		// Tick 100s plus tard : ne doit RIEN decharger (refcount=1).
+		if (s.Tick(t0 + 100s) != 0)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] re-Acquire should cancel unload timer");
+			return false;
+		}
+		if (s.LoadedTileCount() != 1) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] re-Acquire cancels timer OK");
+		return true;
+	}
+
+	bool TestReleaseUnknownKeyNoOp()
+	{
+		VMapStreamer s;
+		const TP t0{};
+		// Release sur cle inconnue → silent no-op.
+		s.Release("nope", t0);
+		if (s.LoadedTileCount() != 0) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] Release unknown key no-op OK");
+		return true;
+	}
+
+	bool TestFindReadOnly()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+		s.Acquire("a");
+		const auto* m = s.Find("a");
+		if (!m) return false;
+		if (m->RefCount() != 1)
+		{
+			LOG_ERROR(Core, "[VMapStreamerTests] Find should not bump refcount");
+			return false;
+		}
+		LOG_INFO(Core, "[VMapStreamerTests] Find read-only OK");
+		return true;
+	}
+
+	bool TestClear()
+	{
+		InMemoryStore store;
+		store.Add("a", MakeMiniTile());
+		store.Add("b", MakeMiniTile());
+		VMapStreamer s;
+		s.SetLoader(store.Loader());
+		s.Acquire("a");
+		s.Acquire("b");
+		s.Clear();
+		if (s.LoadedTileCount() != 0) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] Clear OK");
+		return true;
+	}
+
+	bool TestNoLoaderFails()
+	{
+		VMapStreamer s;
+		// Pas de SetLoader → Acquire retourne nullptr.
+		auto* m = s.Acquire("a");
+		if (m != nullptr) return false;
+		LOG_INFO(Core, "[VMapStreamerTests] no loader → nullptr OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestAcquireLoadsAndIncrefs()
+		&& TestAcquireSecondTimeJustBumps()
+		&& TestUnknownKeyFails()
+		&& TestReleaseStartsTimerThenTickUnloads()
+		&& TestReAcquireBeforeUnloadCancelsTimer()
+		&& TestReleaseUnknownKeyNoOp()
+		&& TestFindReadOnly()
+		&& TestClear()
+		&& TestNoLoaderFails();
+
+	if (ok)
+		LOG_INFO(Core, "[VMapStreamerTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[VMapStreamerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Quatrième brique du module **vmap** : streaming dynamique des tiles. `Acquire`/`Release` par clé string + refcount + déchargement différé (30s par défaut après refcount=0).

### Pourquoi le délai

Quand un joueur sort puis rentre dans une cellule au bord d'un chunk, sans délai on aurait un ping-pong load/unload. Avec `releaseDelay=30s`, le tile reste en RAM le temps que le joueur revienne ; pas de re-load coûteux.

### `ManagedModel`

- `VMapManager` (de [#494](https://github.com/tips-of-mine/LCDLLN-test/pull/494)) + refcount + timestamp last-zero-ref.
- `IncRef` reset le timer ; `DecRef(now)` démarre le timer si refcount tombe à 0 ; `ShouldRelease(now, delay)` = true si refcount=0 ET timer ≥ delay.

### `VMapStreamer`

- `map<key, ManagedModel>` indexé par chemin relatif (e.g. `""world/zone1/tile_0_0.vmap""`).
- **Loader callback** injectable : `function<vector<uint8_t>(string_view)>`. Production wirera `FileSystem` ; tests utilisent un dict in-memory.
- `Acquire(key)` charge si pas en RAM, incrémente, retourne `ManagedModel*`.
- `Release(key, now)` décrémente, démarre le timer si refcount tombe à 0.
- `Tick(now)` décharge tous les tiles dont le timer a expiré. Retourne le compte déchargé.
- `Find(key)` lookup read-only sans bump.

### Hors scope

- Éviction LRU si `maxLoadedTiles` dépassé — viendra si profilage justifie.
- Pas thread-safe (caller sérialise — typiquement appelé depuis le tick shard).
- Wiring runtime (combat / spell / anti-cheat) viendra avec l'intégration à `GridState` (cf. CMANGOS.03).

### Tests

`vmap_streamer_tests` : 9 cas — Acquire load + refcount=1, 2× Acquire increfs sans reload, clé inconnue → nullptr, Release+Tick décharge après delay, re-Acquire avant unload annule le timer, Release clé inconnue no-op, Find sans bump, Clear, sans loader → nullptr.

## Test plan

- [x] `Acquire(""a"")` charge le tile (1 fois) puis refcount=1.
- [x] 2ᵉ `Acquire(""a"")` → refcount=2, pas de reload.
- [x] `Release(""a"", t0)` puis `Tick(t0+10s)` avec delay=5s → décharge.
- [x] `Release(""a"", t0)` puis `Acquire(""a"")` à t0+3s → timer annulé, jamais déchargé.
- [x] Loader manquant ou clé inconnue → `Acquire` retourne nullptr proprement.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code non encore wiré dans le runtime shard. Compilé seulement comme test sur Linux. Le wiring dans `GridState` (acquire au passage `Loaded → Active`) viendra en PR ultérieure et déclenchera un redéploiement shard.

Pas de migration DB, pas de wire-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)