### PR TITLE
Phase 2 CMANGOS.04 step 3 + .01 sub-PR 3 part 1 : packet builders purs

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -370,6 +370,17 @@ elseif(UNIX)
     shard/vmap/VMapFormat.cpp
     shard/vmap/AABB.cpp)
 
+  # CMANGOS.04 (Phase 2.04c) : MoveSplinePacketBuilder pure encode/decode.
+  lcdlln_add_simple_test(move_spline_packet_tests
+    shard/movement/MoveSplinePacketBuilderTests.cpp
+    shard/movement/MoveSplinePacketBuilder.cpp
+    shard/movement/MoveSpline.cpp)
+
+  # CMANGOS.01 (Phase 2.01c) : ChatLocalPayload pure encode/decode.
+  lcdlln_add_simple_test(chat_local_payload_tests
+    shard/chat/ChatLocalPayloadTests.cpp
+    shard/chat/ChatLocalPayload.cpp)
+
   # CMANGOS.01 (Phase 2.01b) : ChatCommandRouter pure tests
   add_executable(chat_command_router_tests
     chat/ChatCommandRouterTests.cpp

--- a/engine/server/shard/chat/ChatLocalPayload.cpp
+++ b/engine/server/shard/chat/ChatLocalPayload.cpp
@@ -1,0 +1,102 @@
+#include "engine/server/shard/chat/ChatLocalPayload.h"
+
+#include <cstring>
+
+namespace engine::server::shard::chat
+{
+	namespace
+	{
+		template<typename T>
+		void Append(std::vector<uint8_t>& out, const T& v)
+		{
+			static_assert(std::is_trivially_copyable_v<T>);
+			const auto* p = reinterpret_cast<const uint8_t*>(&v);
+			out.insert(out.end(), p, p + sizeof(T));
+		}
+
+		template<typename T>
+		bool Read(std::span<const uint8_t> in, size_t& off, T& out)
+		{
+			static_assert(std::is_trivially_copyable_v<T>);
+			if (off + sizeof(T) > in.size())
+				return false;
+			std::memcpy(&out, in.data() + off, sizeof(T));
+			off += sizeof(T);
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> EncodeChatLocal(const ChatLocalPayload& msg)
+	{
+		std::vector<uint8_t> out;
+		// Header fixe = 8 + 1 + 12 + 2 + 2 = 25 bytes + 2 strings.
+		out.reserve(25 + msg.senderName.size() + msg.text.size());
+
+		Append(out, msg.senderGuid);
+		Append(out, msg.channel);
+		Append(out, msg.posX);
+		Append(out, msg.posY);
+		Append(out, msg.posZ);
+
+		const auto sn = static_cast<uint16_t>(
+			msg.senderName.size() > kMaxChatLocalSenderNameBytes
+				? kMaxChatLocalSenderNameBytes : msg.senderName.size());
+		Append(out, sn);
+		for (size_t i = 0; i < sn; ++i)
+			out.push_back(static_cast<uint8_t>(msg.senderName[i]));
+
+		const auto tl = static_cast<uint16_t>(
+			msg.text.size() > kMaxChatLocalTextBytes
+				? kMaxChatLocalTextBytes : msg.text.size());
+		Append(out, tl);
+		for (size_t i = 0; i < tl; ++i)
+			out.push_back(static_cast<uint8_t>(msg.text[i]));
+
+		return out;
+	}
+
+	ChatLocalDecodeResult DecodeChatLocal(std::span<const uint8_t> in,
+		ChatLocalPayload& out)
+	{
+		size_t off = 0;
+		uint64_t guid = 0;
+		uint8_t  channel = 0;
+		float    px = 0, py = 0, pz = 0;
+		uint16_t snLen = 0;
+
+		if (!Read(in, off, guid)
+			|| !Read(in, off, channel)
+			|| !Read(in, off, px)
+			|| !Read(in, off, py)
+			|| !Read(in, off, pz)
+			|| !Read(in, off, snLen))
+			return ChatLocalDecodeResult::BufferTooSmall;
+
+		if (snLen > kMaxChatLocalSenderNameBytes)
+			return ChatLocalDecodeResult::SenderNameTooLong;
+		if (off + snLen + 2 > in.size())
+			return ChatLocalDecodeResult::BufferTooSmall;
+
+		std::string senderName(reinterpret_cast<const char*>(in.data() + off), snLen);
+		off += snLen;
+
+		uint16_t txtLen = 0;
+		if (!Read(in, off, txtLen))
+			return ChatLocalDecodeResult::BufferTooSmall;
+		if (txtLen > kMaxChatLocalTextBytes)
+			return ChatLocalDecodeResult::TextTooLong;
+		if (off + txtLen != in.size())
+			return ChatLocalDecodeResult::LengthMismatch;
+
+		std::string text(reinterpret_cast<const char*>(in.data() + off), txtLen);
+
+		out.senderGuid = guid;
+		out.channel    = channel;
+		out.posX       = px;
+		out.posY       = py;
+		out.posZ       = pz;
+		out.senderName = std::move(senderName);
+		out.text       = std::move(text);
+		return ChatLocalDecodeResult::OK;
+	}
+}

--- a/engine/server/shard/chat/ChatLocalPayload.h
+++ b/engine/server/shard/chat/ChatLocalPayload.h
@@ -1,0 +1,62 @@
+#pragma once
+// CMANGOS.01 (Phase 2.01c) — ChatLocalPayload : encodage / decodage
+// pur du payload `ChatLocal` (proximity chat shard-side : say / yell /
+// emote). Diffuse aux clients dans le rayon d'audibilite (cf. audit).
+//
+// **Pur** dans cette PR : pas encore d'integration ServerProtocol
+// (pas de MessageKind alloue, pas de bump kProtocolVersion). C'est le
+// builder en isolation testable. L'integration wire viendra dans une
+// PR finale dediee.
+//
+// **Layout** binaire little-endian, sans padding :
+//
+//   uint64 senderGuid          // ObjectGuid de l'emetteur (cf. CMANGOS.02)
+//   uint8  channel             // ChatChannel byte (Say/Yell/Emote)
+//   float  posX, posY, posZ    // position de l'emetteur (pour culling client)
+//   uint16 senderNameLen
+//   senderNameLen bytes        // sender display name (UTF-8)
+//   uint16 textLen
+//   textLen bytes              // chat text (UTF-8, sanitized par CMANGOS.01 sub-PR 1)
+//
+// Le shard (ChatLocalRelay) decide de la liste de destinataires
+// (proximity check via SpatialPartition). Pas de DB, pas de validation
+// sender ici — sanitize/gate sont applique au master AVANT que le
+// shard ne broadcaste.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace engine::server::shard::chat
+{
+	/// Limite text en bytes (UTF-8). Aligne sur le sanitizer master
+	/// (#486, default 255). Le decode rejette au-dela.
+	inline constexpr uint16_t kMaxChatLocalTextBytes = 1024;
+
+	/// Limite nom expediteur (cf. character_name max).
+	inline constexpr uint16_t kMaxChatLocalSenderNameBytes = 64;
+
+	struct ChatLocalPayload
+	{
+		uint64_t    senderGuid = 0;
+		uint8_t     channel    = 0;     ///< Say=0, Yell=1, Emote=2 (cf. ChatChannel byte)
+		float       posX = 0.0f, posY = 0.0f, posZ = 0.0f;
+		std::string senderName;
+		std::string text;
+	};
+
+	enum class ChatLocalDecodeResult : uint8_t
+	{
+		OK = 0,
+		BufferTooSmall   = 1,
+		SenderNameTooLong = 2,
+		TextTooLong      = 3,
+		LengthMismatch   = 4,
+	};
+
+	std::vector<uint8_t> EncodeChatLocal(const ChatLocalPayload& msg);
+	ChatLocalDecodeResult DecodeChatLocal(std::span<const uint8_t> in,
+		ChatLocalPayload& out);
+}

--- a/engine/server/shard/chat/ChatLocalPayloadTests.cpp
+++ b/engine/server/shard/chat/ChatLocalPayloadTests.cpp
@@ -1,0 +1,136 @@
+// CMANGOS.01 (Phase 2.01c) — Tests ChatLocalPayload round-trip.
+
+#include "engine/server/shard/chat/ChatLocalPayload.h"
+#include "engine/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::server::shard::chat::ChatLocalDecodeResult;
+	using engine::server::shard::chat::ChatLocalPayload;
+	using engine::server::shard::chat::DecodeChatLocal;
+	using engine::server::shard::chat::EncodeChatLocal;
+	using engine::server::shard::chat::kMaxChatLocalSenderNameBytes;
+	using engine::server::shard::chat::kMaxChatLocalTextBytes;
+
+	bool TestRoundTripBasic()
+	{
+		ChatLocalPayload p;
+		p.senderGuid = 0xCAFEBABEDEADBEEFull;
+		p.channel = 1;       // Yell
+		p.posX = 100.0f;
+		p.posY = 0.0f;
+		p.posZ = -50.5f;
+		p.senderName = "Hero";
+		p.text = "Hello world! caractères accentués é ñ";
+
+		const auto blob = EncodeChatLocal(p);
+		ChatLocalPayload r;
+		if (DecodeChatLocal(blob, r) != ChatLocalDecodeResult::OK) return false;
+		if (r.senderGuid != p.senderGuid) return false;
+		if (r.channel != 1) return false;
+		if (r.posX != 100.0f || r.posZ != -50.5f) return false;
+		if (r.senderName != "Hero") return false;
+		if (r.text != p.text) return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] basic roundtrip OK");
+		return true;
+	}
+
+	bool TestEmptyText()
+	{
+		ChatLocalPayload p;
+		p.senderGuid = 1;
+		p.senderName = "X";
+		// Texte vide : valide.
+		const auto blob = EncodeChatLocal(p);
+		ChatLocalPayload r;
+		if (DecodeChatLocal(blob, r) != ChatLocalDecodeResult::OK) return false;
+		if (!r.text.empty()) return false;
+		if (r.senderName != "X") return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] empty text OK");
+		return true;
+	}
+
+	bool TestBufferTooSmall()
+	{
+		std::vector<uint8_t> tooShort(10, 0);
+		ChatLocalPayload r;
+		if (DecodeChatLocal(tooShort, r) != ChatLocalDecodeResult::BufferTooSmall)
+			return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] buffer too small OK");
+		return true;
+	}
+
+	bool TestSenderNameTooLong()
+	{
+		// Forge a la main : senderNameLen = 65 (> max 64).
+		std::vector<uint8_t> blob;
+		for (int i = 0; i < 21; ++i) blob.push_back(0);  // header (8+1+12)
+		// senderNameLen = 65 little-endian.
+		blob.push_back(65);
+		blob.push_back(0);
+		// Pas besoin du contenu — le decoder valide AVANT de lire.
+		ChatLocalPayload r;
+		if (DecodeChatLocal(blob, r) != ChatLocalDecodeResult::SenderNameTooLong)
+			return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] sender name too long detected OK");
+		return true;
+	}
+
+	bool TestCapsAtMax()
+	{
+		// Le encode cap a kMaxChatLocalTextBytes, donc on peut envoyer
+		// 9999 chars et la sortie sera tronquee a kMaxChatLocalTextBytes.
+		ChatLocalPayload p;
+		p.senderGuid = 1;
+		p.senderName = "Hero";
+		p.text = std::string(kMaxChatLocalTextBytes + 100, 'A');
+
+		const auto blob = EncodeChatLocal(p);
+		ChatLocalPayload r;
+		if (DecodeChatLocal(blob, r) != ChatLocalDecodeResult::OK) return false;
+		if (r.text.size() != kMaxChatLocalTextBytes) return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] cap at max OK");
+		return true;
+	}
+
+	bool TestLengthMismatch()
+	{
+		ChatLocalPayload p;
+		p.senderGuid = 1;
+		p.senderName = "X";
+		p.text = "ok";
+		auto blob = EncodeChatLocal(p);
+		blob.push_back(0xFF);  // byte parasite
+		ChatLocalPayload r;
+		if (DecodeChatLocal(blob, r) != ChatLocalDecodeResult::LengthMismatch)
+			return false;
+		LOG_INFO(Core, "[ChatLocalPayloadTests] length mismatch detected OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestRoundTripBasic()
+		&& TestEmptyText()
+		&& TestBufferTooSmall()
+		&& TestSenderNameTooLong()
+		&& TestCapsAtMax()
+		&& TestLengthMismatch();
+
+	if (ok)
+		LOG_INFO(Core, "[ChatLocalPayloadTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[ChatLocalPayloadTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/shard/movement/MoveSplinePacketBuilder.cpp
+++ b/engine/server/shard/movement/MoveSplinePacketBuilder.cpp
@@ -1,0 +1,106 @@
+#include "engine/server/shard/movement/MoveSplinePacketBuilder.h"
+
+#include <cstring>
+
+namespace engine::server::shard::movement
+{
+	namespace
+	{
+		template<typename T>
+		void Append(std::vector<uint8_t>& out, const T& v)
+		{
+			static_assert(std::is_trivially_copyable_v<T>);
+			const auto* p = reinterpret_cast<const uint8_t*>(&v);
+			out.insert(out.end(), p, p + sizeof(T));
+		}
+
+		template<typename T>
+		bool Read(std::span<const uint8_t> in, size_t& off, T& out)
+		{
+			static_assert(std::is_trivially_copyable_v<T>);
+			if (off + sizeof(T) > in.size())
+				return false;
+			std::memcpy(&out, in.data() + off, sizeof(T));
+			off += sizeof(T);
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> EncodeMonsterMove(const MonsterMovePayload& msg)
+	{
+		std::vector<uint8_t> out;
+		// Header fixe = 8 + 4 + 4 + 4 + 2 = 22 bytes.
+		out.reserve(22 + msg.points.size() * sizeof(Vec3));
+
+		Append(out, msg.entityGuid);
+		Append(out, msg.splineId);
+		const auto rawFlags = static_cast<uint32_t>(msg.flags);
+		Append(out, rawFlags);
+		Append(out, msg.velocity);
+		const auto pc = static_cast<uint16_t>(
+			msg.points.size() > kMaxMonsterMovePoints
+				? kMaxMonsterMovePoints
+				: msg.points.size());
+		Append(out, pc);
+
+		const size_t toWrite = pc;
+		for (size_t i = 0; i < toWrite; ++i)
+		{
+			Append(out, msg.points[i].x);
+			Append(out, msg.points[i].y);
+			Append(out, msg.points[i].z);
+		}
+		return out;
+	}
+
+	MonsterMoveDecodeResult DecodeMonsterMove(std::span<const uint8_t> in,
+		MonsterMovePayload& out)
+	{
+		size_t off = 0;
+		uint64_t guid = 0;
+		uint32_t splineId = 0;
+		uint32_t flags = 0;
+		float    velocity = 0.0f;
+		uint16_t pointCount = 0;
+
+		if (!Read(in, off, guid)
+			|| !Read(in, off, splineId)
+			|| !Read(in, off, flags)
+			|| !Read(in, off, velocity)
+			|| !Read(in, off, pointCount))
+			return MonsterMoveDecodeResult::BufferTooSmall;
+
+		if (pointCount > kMaxMonsterMovePoints)
+			return MonsterMoveDecodeResult::TooManyPoints;
+
+		const size_t needBytes = static_cast<size_t>(pointCount) * sizeof(Vec3);
+		if (off + needBytes != in.size())
+			return MonsterMoveDecodeResult::PointCountMismatch;
+
+		out.entityGuid = guid;
+		out.splineId   = splineId;
+		out.flags      = static_cast<MoveSplineFlag>(flags);
+		out.velocity   = velocity;
+		out.points.clear();
+		out.points.resize(pointCount);
+		for (uint16_t i = 0; i < pointCount; ++i)
+		{
+			Read(in, off, out.points[i].x);
+			Read(in, off, out.points[i].y);
+			Read(in, off, out.points[i].z);
+		}
+		return MonsterMoveDecodeResult::OK;
+	}
+
+	MonsterMovePayload BuildPayloadFromSpline(uint64_t entityGuid,
+		const MoveSpline& spline)
+	{
+		MonsterMovePayload p;
+		p.entityGuid = entityGuid;
+		p.splineId   = spline.SplineId();
+		p.flags      = spline.Flags();
+		p.velocity   = spline.Velocity();
+		p.points     = spline.Path().Points();
+		return p;
+	}
+}

--- a/engine/server/shard/movement/MoveSplinePacketBuilder.h
+++ b/engine/server/shard/movement/MoveSplinePacketBuilder.h
@@ -1,0 +1,78 @@
+#pragma once
+// CMANGOS.04 (Phase 2.04c) — MoveSplinePacketBuilder : encodage /
+// decodage pur du payload `MonsterMove` (un MoveSpline lance par le
+// shard, broadcaste aux clients en interest set).
+//
+// **Pur** dans cette PR : pas encore d'integration ServerProtocol
+// (pas de MessageKind alloue, pas de header magic+version+kind, pas
+// de bump kProtocolVersion). C'est le builder en isolation testable
+// — l'integration wire viendra dans une PR finale dediee qui bumpera
+// la version + ajoutera les MessageKind values + cablera dans
+// ServerProtocol.cpp.
+//
+// **Layout** binaire little-endian, sans padding :
+//
+//   uint64 entityGuid          // ObjectGuid de l'entite (cf. CMANGOS.02)
+//   uint32 splineId            // monotone strictement croissant
+//   uint32 flags               // MoveSplineFlag bitmask
+//   float  velocity            // unites/sec
+//   uint16 pointCount          // nombre de control points (max 256)
+//   pointCount × { float x, y, z }
+//
+// Empty/invalide rejete au decode. Le serveur emet une seule fois ;
+// le client interpole jusqu'a la prochaine update (cf. audit §8 :
+// pour un trajet de 100m a 10 m/s, **1 paquet** au lieu de 100+ en
+// streaming positions).
+//
+// **Hors scope** : MonsterMoveStop (separation logique), TeleportAck
+// (separation logique). Viendront avec leurs propres builders puis
+// l'integration wire commune.
+
+#include "engine/server/shard/movement/MoveSpline.h"
+#include "engine/server/shard/movement/MoveSplineFlag.h"
+#include "engine/server/shard/movement/MovementTypedefs.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace engine::server::shard::movement
+{
+	/// Limite : 256 control points par paquet (UDP MTU = 1500 bytes max ;
+	/// header 14 + payload max ~1486 ; chaque point = 12 bytes ; payload
+	/// fixe = 22 bytes → max ~120 points pour rester sous MTU. Cap a 256
+	/// pour validation defensive ; un paquet bien dimensionne tient en
+	/// 1 MTU). Le caller decoupe les chemins longs en plusieurs paquets.
+	inline constexpr uint16_t kMaxMonsterMovePoints = 256;
+
+	struct MonsterMovePayload
+	{
+		uint64_t       entityGuid = 0;
+		uint32_t       splineId   = 0;
+		MoveSplineFlag flags      = MoveSplineFlag::None;
+		float          velocity   = 0.0f;
+		std::vector<Vec3> points;
+	};
+
+	enum class MonsterMoveDecodeResult : uint8_t
+	{
+		OK = 0,
+		BufferTooSmall   = 1,
+		TooManyPoints    = 2,
+		PointCountMismatch = 3,
+	};
+
+	/// Encode un MonsterMove vers un buffer binaire (sans header ni
+	/// MessageKind — pure payload, l'integration wire ajoutera le
+	/// header standard).
+	std::vector<uint8_t> EncodeMonsterMove(const MonsterMovePayload& msg);
+
+	/// Decode un payload vers \p out. Retourne `OK` ou un code d'erreur.
+	MonsterMoveDecodeResult DecodeMonsterMove(std::span<const uint8_t> in,
+		MonsterMovePayload& out);
+
+	/// Helper : extrait un MonsterMovePayload depuis un MoveSpline runtime
+	/// (utile pour wirer cote shard une fois l'integration prete).
+	MonsterMovePayload BuildPayloadFromSpline(uint64_t entityGuid, const MoveSpline& spline);
+}

--- a/engine/server/shard/movement/MoveSplinePacketBuilderTests.cpp
+++ b/engine/server/shard/movement/MoveSplinePacketBuilderTests.cpp
@@ -1,0 +1,156 @@
+// CMANGOS.04 (Phase 2.04c) — Tests MoveSplinePacketBuilder.
+// Round-trip pure (encode → decode → equality).
+
+#include "engine/server/shard/movement/MoveSpline.h"
+#include "engine/server/shard/movement/MoveSplineInit.h"
+#include "engine/server/shard/movement/MoveSplinePacketBuilder.h"
+#include "engine/core/Log.h"
+
+#include <chrono>
+
+namespace
+{
+	using engine::server::shard::movement::BuildPayloadFromSpline;
+	using engine::server::shard::movement::DecodeMonsterMove;
+	using engine::server::shard::movement::EncodeMonsterMove;
+	using engine::server::shard::movement::HasFlag;
+	using engine::server::shard::movement::MonsterMoveDecodeResult;
+	using engine::server::shard::movement::MonsterMovePayload;
+	using engine::server::shard::movement::MoveSpline;
+	using engine::server::shard::movement::MoveSplineFlag;
+	using engine::server::shard::movement::MoveSplineInit;
+	using engine::server::shard::movement::Vec3;
+	using engine::server::shard::movement::kMaxMonsterMovePoints;
+
+	bool TestRoundTripBasic()
+	{
+		MonsterMovePayload p;
+		p.entityGuid = 0xDEADBEEFCAFEBABEull;
+		p.splineId   = 42;
+		p.flags      = MoveSplineFlag::Walking | MoveSplineFlag::Cyclic;
+		p.velocity   = 5.5f;
+		p.points = { Vec3(0, 0, 0), Vec3(10, 1, 0), Vec3(20, 2, 0) };
+
+		const auto blob = EncodeMonsterMove(p);
+		MonsterMovePayload r;
+		if (DecodeMonsterMove(blob, r) != MonsterMoveDecodeResult::OK)
+		{
+			LOG_ERROR(Core, "[MoveSplinePacketTests] decode failed");
+			return false;
+		}
+		if (r.entityGuid != p.entityGuid) return false;
+		if (r.splineId != p.splineId) return false;
+		if (static_cast<uint32_t>(r.flags) != static_cast<uint32_t>(p.flags)) return false;
+		if (r.velocity != p.velocity) return false;
+		if (r.points.size() != 3) return false;
+		if (r.points[1].x != 10.0f || r.points[1].y != 1.0f) return false;
+		LOG_INFO(Core, "[MoveSplinePacketTests] roundtrip basic OK");
+		return true;
+	}
+
+	bool TestRoundTripEmptyPoints()
+	{
+		MonsterMovePayload p;
+		p.entityGuid = 1;
+		p.splineId = 1;
+		// Pas de points (cas degenere : payload minimal valide).
+		const auto blob = EncodeMonsterMove(p);
+		MonsterMovePayload r;
+		if (DecodeMonsterMove(blob, r) != MonsterMoveDecodeResult::OK) return false;
+		if (!r.points.empty()) return false;
+		LOG_INFO(Core, "[MoveSplinePacketTests] roundtrip empty points OK");
+		return true;
+	}
+
+	bool TestBufferTooSmall()
+	{
+		std::vector<uint8_t> tooShort(8, 0);
+		MonsterMovePayload r;
+		if (DecodeMonsterMove(tooShort, r) != MonsterMoveDecodeResult::BufferTooSmall)
+			return false;
+		LOG_INFO(Core, "[MoveSplinePacketTests] buffer too small OK");
+		return true;
+	}
+
+	bool TestBuildFromSpline()
+	{
+		MoveSplineInit init;
+		init.MoveTo(Vec3(0, 0, 0))
+		    .MoveTo(Vec3(10, 0, 0))
+		    .MoveTo(Vec3(20, 0, 0))
+		    .SetVelocity(8.0f)
+		    .SetWalking()
+		    .SetCyclic();
+		MoveSpline ms;
+		init.Launch(ms, 999u, MoveSpline::TimePoint{});
+
+		const auto p = BuildPayloadFromSpline(0xCAFEull, ms);
+		if (p.entityGuid != 0xCAFEull) return false;
+		if (p.splineId != 999u) return false;
+		if (p.points.size() != 3) return false;
+		if (!HasFlag(p.flags, MoveSplineFlag::Walking)) return false;
+		if (!HasFlag(p.flags, MoveSplineFlag::Cyclic)) return false;
+		LOG_INFO(Core, "[MoveSplinePacketTests] BuildFromSpline OK");
+		return true;
+	}
+
+	bool TestPointCountMismatch()
+	{
+		// Encode 1 point, mais ajoute un byte parasite a la fin → mismatch.
+		MonsterMovePayload p;
+		p.entityGuid = 1;
+		p.splineId = 1;
+		p.points = { Vec3(0, 0, 0) };
+		auto blob = EncodeMonsterMove(p);
+		blob.push_back(0xFF);
+		MonsterMovePayload r;
+		if (DecodeMonsterMove(blob, r) != MonsterMoveDecodeResult::PointCountMismatch)
+			return false;
+		LOG_INFO(Core, "[MoveSplinePacketTests] PointCountMismatch detected OK");
+		return true;
+	}
+
+	bool TestMaxPointsCap()
+	{
+		MonsterMovePayload p;
+		p.entityGuid = 1;
+		p.splineId = 1;
+		// 300 points : encode cap a kMaxMonsterMovePoints (256).
+		p.points.resize(300, Vec3(1, 2, 3));
+		const auto blob = EncodeMonsterMove(p);
+		MonsterMovePayload r;
+		if (DecodeMonsterMove(blob, r) != MonsterMoveDecodeResult::OK) return false;
+		if (r.points.size() != kMaxMonsterMovePoints)
+		{
+			LOG_ERROR(Core, "[MoveSplinePacketTests] expected cap to {} points, got {}",
+				kMaxMonsterMovePoints, r.points.size());
+			return false;
+		}
+		LOG_INFO(Core, "[MoveSplinePacketTests] cap to kMaxMonsterMovePoints OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestRoundTripBasic()
+		&& TestRoundTripEmptyPoints()
+		&& TestBufferTooSmall()
+		&& TestBuildFromSpline()
+		&& TestPointCountMismatch()
+		&& TestMaxPointsCap();
+
+	if (ok)
+		LOG_INFO(Core, "[MoveSplinePacketTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[MoveSplinePacketTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Builders de payload purs (encode/decode) pour la wire integration finale. **Pas de bump `kProtocolVersion`, pas d'allocation de `MessageKind`** — cette PR livre le **scaffolding testable** ; l'intégration wire (MessageKind + bump + handler shard) viendra dans une **PR finale dédiée** qui consommera ces builders.

### `MoveSplinePacketBuilder` (CMANGOS.04 step 3)

| Champ | Type | Notes |
|---|---|---|
| `entityGuid` | `uint64` | `ObjectGuid` (cf. CMANGOS.02) |
| `splineId` | `uint32` | monotone strictement croissant |
| `flags` | `uint32` | `MoveSplineFlag` bitmask |
| `velocity` | `float` | unités/sec |
| `pointCount` | `uint16` | cap à `kMaxMonsterMovePoints` (256) |
| `points` | `pointCount × Vec3` | local au tile |

- `BuildPayloadFromSpline(guid, ms)` : helper qui extrait depuis un `MoveSpline` runtime.
- Decode results : `OK / BufferTooSmall / TooManyPoints / PointCountMismatch`.

### `ChatLocalPayload` (CMANGOS.01 sub-PR 3 part 1)

| Champ | Type | Notes |
|---|---|---|
| `senderGuid` | `uint64` | |
| `channel` | `uint8` | `Say=0 / Yell=1 / Emote=2` |
| `posX/Y/Z` | `float×3` | position pour culling client |
| `senderName` | `uint16 + bytes` | cap 64 |
| `text` | `uint16 + bytes` | cap 1024 (déjà sanitizé par master) |

Le shard fera le proximity broadcast (rayon d'audibilité) — viendra avec l'intégration wire.

### Tests

- `move_spline_packet_tests` : 6 cas — roundtrip basic + empty points + buffer too small + `BuildFromSpline` + `PointCountMismatch` + cap à 256 points.
- `chat_local_payload_tests` : 6 cas — roundtrip avec UTF-8 accentué + empty text + buffer too small + sender name > 64 → `SenderNameTooLong` + cap text à 1024 + length mismatch.

## Test plan

- [x] MoveSpline : 3 points roundtrip exact (guid, splineId, flags, velocity, points).
- [x] MoveSpline : 300 points → cap à 256 (encode tronque).
- [x] MoveSpline : `BuildPayloadFromSpline` extrait correctement depuis `MoveSpline` runtime.
- [x] ChatLocal : caractères accentués UTF-8 (é, ñ) round-trip.
- [x] ChatLocal : sender name > 64 → `SenderNameTooLong`.
- [x] ChatLocal : byte parasite après payload → `LengthMismatch`.
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code en isolation, pas wiré dans le runtime shard. La **PR finale wire integration** (MessageKind values 78-81 + bump kProtocolVersion 2→3 + handlers) déclenchera le redéploiement **lock-step client + master + shard**.

Pas de migration DB, pas de wire-breaking ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)