### PR TITLE
Phase 3 CMANGOS.18 step 1 : MailManager core (Mails in-game)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -310,6 +310,11 @@ elseif(UNIX)
   target_compile_options(object_guid_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME object_guid_tests COMMAND object_guid_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # CMANGOS.18 (Phase 3.18a) : MailManager core (workflow Send/Take/COD/expire).
+  lcdlln_add_simple_test(mail_manager_tests
+    mail/MailManagerTests.cpp
+    mail/MailManager.cpp)
+
   # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
   add_executable(bih_tests
     shard/vmap/BIHTests.cpp

--- a/engine/server/mail/InMemoryMailStore.h
+++ b/engine/server/mail/InMemoryMailStore.h
@@ -1,0 +1,68 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18a) — InMemoryMailStore : implementation RAM
+// d'IMailStore pour les tests + fallback dev sans MySQL.
+
+#include "engine/server/mail/MailManager.h"
+
+#include <unordered_map>
+
+namespace engine::server::mail
+{
+	class InMemoryMailStore final : public IMailStore
+	{
+	public:
+		uint64_t Insert(Mail& out) override
+		{
+			out.mailId = m_nextId++;
+			m_mails[out.mailId] = out;
+			return out.mailId;
+		}
+
+		std::optional<Mail> Find(uint64_t mailId) const override
+		{
+			auto it = m_mails.find(mailId);
+			return (it == m_mails.end()) ? std::nullopt : std::optional<Mail>(it->second);
+		}
+
+		std::vector<Mail> ListInbox(uint64_t receiverAccountId) const override
+		{
+			std::vector<Mail> out;
+			for (const auto& [id, m] : m_mails)
+			{
+				if (m.receiverAccountId == receiverAccountId)
+					out.push_back(m);
+			}
+			return out;
+		}
+
+		bool Update(const Mail& mail) override
+		{
+			auto it = m_mails.find(mail.mailId);
+			if (it == m_mails.end()) return false;
+			it->second = mail;
+			return true;
+		}
+
+		bool Delete(uint64_t mailId) override
+		{
+			return m_mails.erase(mailId) > 0;
+		}
+
+		std::vector<uint64_t> FindExpired(uint64_t nowMs) const override
+		{
+			std::vector<uint64_t> out;
+			for (const auto& [id, m] : m_mails)
+			{
+				if (m.expiresTsMs > 0 && m.expiresTsMs <= nowMs)
+					out.push_back(id);
+			}
+			return out;
+		}
+
+		size_t Size() const noexcept { return m_mails.size(); }
+
+	private:
+		std::unordered_map<uint64_t, Mail> m_mails;
+		uint64_t m_nextId = 1;
+	};
+}

--- a/engine/server/mail/Mail.h
+++ b/engine/server/mail/Mail.h
@@ -1,0 +1,59 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18a) — Mail core types : Mail struct + ItemAttachment.
+// Minimal data structures pour la messagerie in-game cmangos.
+// **Pur** : pas de DB persistence dans cette PR. MailManager utilise
+// un store abstrait (cf. AbstractMailStore.h, InMemoryMailStore.h).
+//
+// Wire integration + persistance MySQL viendront en sub-PRs ulterieures.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::mail
+{
+	/// Item attache a un mail. Reference le template item + count.
+	/// Pas de stat / proprietes ici — juste de quoi instancier l'item
+	/// chez le destinataire au moment du Take.
+	struct MailItemAttachment
+	{
+		uint32_t itemTemplateId = 0;
+		uint32_t count          = 1;
+	};
+
+	/// Etat d'un mail dans la boite. Aligne sur le pattern cmangos.
+	enum class MailState : uint8_t
+	{
+		Unread   = 0,  ///< Recu, pas encore ouvert.
+		Read     = 1,  ///< Ouvert mais attachments encore presents.
+		Returned = 2,  ///< Refuse → retourne expediteur (ex. boite pleine).
+		Deleted  = 3,  ///< Supprime par le destinataire (placeholder).
+	};
+
+	/// Mail complet en memoire / serialise.
+	struct Mail
+	{
+		uint64_t mailId       = 0;       ///< PK auto-increment.
+		uint64_t senderAccountId   = 0;
+		uint64_t receiverAccountId = 0;
+		std::string subject;             ///< UTF-8, max 255 bytes.
+		std::string body;                ///< UTF-8, max ~16k bytes.
+		std::vector<MailItemAttachment> items;
+
+		/// Or transferé (en copper, monnaie LCDLLN). 0 = pas de gold.
+		uint64_t copperGold   = 0;
+
+		/// Cash on Delivery — montant du a payer par le destinataire
+		/// AVANT de retirer les items. 0 = pas de COD.
+		uint64_t copperCod    = 0;
+
+		uint64_t sentTsMs     = 0;       ///< epoch ms UTC.
+		uint64_t expiresTsMs  = 0;       ///< epoch ms UTC ; 0 = jamais.
+		MailState state       = MailState::Unread;
+	};
+
+	/// Limites canoniques (alignes sur les tables DB qui viendront).
+	inline constexpr size_t kMaxMailSubjectBytes = 255;
+	inline constexpr size_t kMaxMailBodyBytes    = 16 * 1024;
+	inline constexpr size_t kMaxMailAttachments  = 12;
+}

--- a/engine/server/mail/MailManager.cpp
+++ b/engine/server/mail/MailManager.cpp
@@ -1,0 +1,139 @@
+#include "engine/server/mail/MailManager.h"
+
+#include <algorithm>
+
+namespace engine::server::mail
+{
+	MailManager::MailManager(IMailStore* store, MailManagerConfig cfg)
+		: m_store(store), m_cfg(cfg) {}
+
+	uint64_t MailManager::Send(uint64_t senderAccountId, uint64_t receiverAccountId,
+		std::string_view subject, std::string_view body,
+		std::vector<MailItemAttachment> items,
+		uint64_t copperGold, uint64_t copperCod,
+		uint64_t nowMs, uint64_t expiresTsMs,
+		MailOpResult* outErr)
+	{
+		if (!m_store) return 0;
+
+		if (subject.size() > kMaxMailSubjectBytes)
+		{
+			if (outErr) *outErr = MailOpResult::SubjectTooLong;
+			return 0;
+		}
+		if (body.size() > kMaxMailBodyBytes)
+		{
+			if (outErr) *outErr = MailOpResult::BodyTooLong;
+			return 0;
+		}
+		if (items.size() > kMaxMailAttachments)
+		{
+			if (outErr) *outErr = MailOpResult::AttachmentsTooMany;
+			return 0;
+		}
+
+		Mail m;
+		m.senderAccountId   = senderAccountId;
+		m.receiverAccountId = receiverAccountId;
+		m.subject           = std::string(subject);
+		m.body              = std::string(body);
+		m.items             = std::move(items);
+		m.copperGold        = copperGold;
+		m.copperCod         = copperCod;
+		m.sentTsMs          = nowMs;
+		m.expiresTsMs       = (expiresTsMs > 0) ? expiresTsMs
+			: (nowMs + m_cfg.defaultExpirationMs);
+		m.state             = MailState::Unread;
+
+		if (outErr) *outErr = MailOpResult::OK;
+		return m_store->Insert(m);
+	}
+
+	MailOpResult MailManager::MarkRead(uint64_t mailId, uint64_t receiverAccountId)
+	{
+		if (!m_store) return MailOpResult::MailNotFound;
+		auto opt = m_store->Find(mailId);
+		if (!opt) return MailOpResult::MailNotFound;
+		if (opt->receiverAccountId != receiverAccountId)
+			return MailOpResult::WrongReceiver;
+		if (opt->state == MailState::Unread)
+		{
+			opt->state = MailState::Read;
+			m_store->Update(*opt);
+		}
+		return MailOpResult::OK;
+	}
+
+	MailOpResult MailManager::TakeItems(uint64_t mailId, uint64_t receiverAccountId,
+		uint64_t paidCopper, std::vector<MailItemAttachment>& outItems)
+	{
+		outItems.clear();
+		if (!m_store) return MailOpResult::MailNotFound;
+		auto opt = m_store->Find(mailId);
+		if (!opt) return MailOpResult::MailNotFound;
+		if (opt->receiverAccountId != receiverAccountId)
+			return MailOpResult::WrongReceiver;
+		if (opt->items.empty()) return MailOpResult::AlreadyTaken;
+		if (opt->copperCod > 0 && paidCopper < opt->copperCod)
+			return MailOpResult::CodNotPaid;
+
+		outItems = std::move(opt->items);
+		opt->items.clear();
+		// Une fois COD paye et items retires, on remet le COD a 0 pour
+		// eviter un double prelevement si le caller re-Take.
+		opt->copperCod = 0;
+		// Marque comme lu si pas deja.
+		if (opt->state == MailState::Unread)
+			opt->state = MailState::Read;
+		m_store->Update(*opt);
+		return MailOpResult::OK;
+	}
+
+	MailOpResult MailManager::TakeGold(uint64_t mailId, uint64_t receiverAccountId,
+		uint64_t& outCopper)
+	{
+		outCopper = 0;
+		if (!m_store) return MailOpResult::MailNotFound;
+		auto opt = m_store->Find(mailId);
+		if (!opt) return MailOpResult::MailNotFound;
+		if (opt->receiverAccountId != receiverAccountId)
+			return MailOpResult::WrongReceiver;
+		if (opt->copperGold == 0) return MailOpResult::AlreadyTaken;
+
+		outCopper = opt->copperGold;
+		opt->copperGold = 0;
+		if (opt->state == MailState::Unread)
+			opt->state = MailState::Read;
+		m_store->Update(*opt);
+		return MailOpResult::OK;
+	}
+
+	MailOpResult MailManager::Delete(uint64_t mailId, uint64_t receiverAccountId)
+	{
+		if (!m_store) return MailOpResult::MailNotFound;
+		auto opt = m_store->Find(mailId);
+		if (!opt) return MailOpResult::MailNotFound;
+		if (opt->receiverAccountId != receiverAccountId)
+			return MailOpResult::WrongReceiver;
+		if (!opt->items.empty() || opt->copperGold > 0)
+			return MailOpResult::AlreadyTaken;  // require Take avant Delete
+		m_store->Delete(mailId);
+		return MailOpResult::OK;
+	}
+
+	std::vector<Mail> MailManager::Inbox(uint64_t receiverAccountId) const
+	{
+		if (!m_store) return {};
+		auto v = m_store->ListInbox(receiverAccountId);
+		// Tri par sentTsMs decroissant (plus recent d'abord).
+		std::sort(v.begin(), v.end(),
+			[](const Mail& a, const Mail& b) { return a.sentTsMs > b.sentTsMs; });
+		return v;
+	}
+
+	std::vector<uint64_t> MailManager::ResolveExpired(uint64_t nowMs) const
+	{
+		if (!m_store) return {};
+		return m_store->FindExpired(nowMs);
+	}
+}

--- a/engine/server/mail/MailManager.h
+++ b/engine/server/mail/MailManager.h
@@ -1,0 +1,124 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18a) — MailManager : logique metier de la
+// messagerie in-game. Validation + workflow Send / Take / Delete /
+// ResolveExpired.
+//
+// **Pur dans cette PR** : pas de wiring opcodes, pas de notification
+// reseau. Le manager opere sur un store abstrait (testable avec
+// InMemoryMailStore). La couche reseau (MailHandler + opcodes wire)
+// + la persistance MySQL viendront en sub-PRs ulterieures.
+
+#include "engine/server/mail/Mail.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace engine::server::mail
+{
+	/// Interface du store de mails. Production = MySqlMailStore (a
+	/// venir), tests = InMemoryMailStore.
+	class IMailStore
+	{
+	public:
+		virtual ~IMailStore() = default;
+
+		/// Insere un nouveau mail. Le store assigne le `mailId` et le
+		/// retourne (ecrit dans `out.mailId`). Echec → 0.
+		virtual uint64_t Insert(Mail& out) = 0;
+
+		/// Cherche un mail par id. nullopt si pas trouve.
+		virtual std::optional<Mail> Find(uint64_t mailId) const = 0;
+
+		/// Tous les mails recus par \p receiverAccountId. Ordre indefini.
+		virtual std::vector<Mail> ListInbox(uint64_t receiverAccountId) const = 0;
+
+		/// Met a jour un mail existant (state, items, gold). Retourne false
+		/// si pas trouve.
+		virtual bool Update(const Mail& mail) = 0;
+
+		/// Supprime un mail par id. Retourne false si pas trouve.
+		virtual bool Delete(uint64_t mailId) = 0;
+
+		/// Retourne les mailIds expires (expiresTsMs <= nowMs ET expiresTsMs > 0).
+		/// Pas de side-effect — c'est `MailManager::ResolveExpired` qui
+		/// les retourne ou les supprime.
+		virtual std::vector<uint64_t> FindExpired(uint64_t nowMs) const = 0;
+	};
+
+	/// Resultat d'une operation MailManager.
+	enum class MailOpResult : uint8_t
+	{
+		OK = 0,
+		MailNotFound          = 1,
+		WrongReceiver         = 2,    ///< Le mailId existe mais pas pour cet account.
+		AlreadyTaken          = 3,    ///< Items / gold deja retires.
+		CodNotPaid            = 4,    ///< COD requis avant Take.
+		AttachmentsTooMany    = 5,
+		SubjectTooLong        = 6,
+		BodyTooLong           = 7,
+	};
+
+	struct MailManagerConfig
+	{
+		/// Duree par defaut avant expiration d'un mail recu (ms UTC).
+		/// Default 30 jours. Caller peut override par mail via `expiresTsMs`.
+		uint64_t defaultExpirationMs = 30ull * 24 * 60 * 60 * 1000;
+	};
+
+	class MailManager
+	{
+	public:
+		explicit MailManager(IMailStore* store, MailManagerConfig cfg = {});
+
+		const MailManagerConfig& Config() const noexcept { return m_cfg; }
+
+		/// Envoie un mail. Valide les limites (subject/body/attachments).
+		/// Si \p expiresTsMs == 0, le manager applique
+		/// `nowMs + defaultExpirationMs`. Retourne `mailId` (>0) en cas
+		/// de succes, 0 en cas d'echec.
+		uint64_t Send(uint64_t senderAccountId, uint64_t receiverAccountId,
+			std::string_view subject, std::string_view body,
+			std::vector<MailItemAttachment> items,
+			uint64_t copperGold, uint64_t copperCod,
+			uint64_t nowMs, uint64_t expiresTsMs = 0,
+			MailOpResult* outErr = nullptr);
+
+		/// Marque un mail comme `Read`. Idempotent.
+		MailOpResult MarkRead(uint64_t mailId, uint64_t receiverAccountId);
+
+		/// Retire les items du mail. Avant retrait :
+		/// - si `copperCod > 0`, exige `paidCopper >= copperCod` (le caller
+		///   a deja preleve le gold du wallet du receiver et l'a credite
+		///   au sender).
+		/// - vide la liste d'items du mail (atomic en RAM ; le caller doit
+		///   wrapper en transaction DB en production).
+		/// Retourne les items extraits dans \p outItems en cas de succes.
+		MailOpResult TakeItems(uint64_t mailId, uint64_t receiverAccountId,
+			uint64_t paidCopper, std::vector<MailItemAttachment>& outItems);
+
+		/// Retire le gold du mail. Met `copperGold` a 0.
+		MailOpResult TakeGold(uint64_t mailId, uint64_t receiverAccountId,
+			uint64_t& outCopper);
+
+		/// Supprime un mail. Echec si items / gold encore presents (le
+		/// caller doit Take avant Delete). Use case : delete vide = retrait
+		/// final apres Take.
+		MailOpResult Delete(uint64_t mailId, uint64_t receiverAccountId);
+
+		/// Retourne tous les mails de l'inbox du receveur, tries par
+		/// `sentTsMs` decroissant (plus recent en premier).
+		std::vector<Mail> Inbox(uint64_t receiverAccountId) const;
+
+		/// Resout les mails expires : items + gold non retires retournent
+		/// au sender (sub-PR ulterieure : pour cette PR, on retourne juste
+		/// les mailIds candidates, le caller decide quoi faire).
+		std::vector<uint64_t> ResolveExpired(uint64_t nowMs) const;
+
+	private:
+		IMailStore*       m_store;
+		MailManagerConfig m_cfg;
+	};
+}

--- a/engine/server/mail/MailManagerTests.cpp
+++ b/engine/server/mail/MailManagerTests.cpp
@@ -1,0 +1,220 @@
+// CMANGOS.18 (Phase 3.18a) — Tests MailManager workflow (Send/Take/Delete/COD/expire).
+
+#include "engine/server/mail/InMemoryMailStore.h"
+#include "engine/server/mail/MailManager.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::mail::InMemoryMailStore;
+	using engine::server::mail::Mail;
+	using engine::server::mail::MailItemAttachment;
+	using engine::server::mail::MailManager;
+	using engine::server::mail::MailManagerConfig;
+	using engine::server::mail::MailOpResult;
+	using engine::server::mail::MailState;
+
+	bool TestSendBasic()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		const uint64_t id = mgr.Send(1, 2, "Hi", "Body", {}, 0, 0, 1000);
+		if (id == 0) return false;
+		if (store.Size() != 1) return false;
+
+		auto inbox = mgr.Inbox(2);
+		if (inbox.size() != 1) return false;
+		if (inbox[0].subject != "Hi") return false;
+		if (inbox[0].state != MailState::Unread) return false;
+		// Expiration auto = 30 jours.
+		if (inbox[0].expiresTsMs == 0) return false;
+		LOG_INFO(Core, "[MailManagerTests] Send basic OK");
+		return true;
+	}
+
+	bool TestSendValidation()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		MailOpResult err = MailOpResult::OK;
+
+		// Subject trop long.
+		std::string longSubject(300, 'A');
+		mgr.Send(1, 2, longSubject, "body", {}, 0, 0, 1000, 0, &err);
+		if (err != MailOpResult::SubjectTooLong) return false;
+
+		// Body trop long.
+		std::string longBody(20000, 'A');
+		mgr.Send(1, 2, "ok", longBody, {}, 0, 0, 1000, 0, &err);
+		if (err != MailOpResult::BodyTooLong) return false;
+
+		// Trop d'attachments.
+		std::vector<MailItemAttachment> tooMany(20);
+		mgr.Send(1, 2, "ok", "ok", tooMany, 0, 0, 1000, 0, &err);
+		if (err != MailOpResult::AttachmentsTooMany) return false;
+
+		LOG_INFO(Core, "[MailManagerTests] validation OK");
+		return true;
+	}
+
+	bool TestMarkRead()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		const uint64_t id = mgr.Send(1, 2, "Hi", "B", {}, 0, 0, 100);
+
+		// Bon receiver.
+		if (mgr.MarkRead(id, 2) != MailOpResult::OK) return false;
+		auto inbox = mgr.Inbox(2);
+		if (inbox[0].state != MailState::Read) return false;
+
+		// Mauvais receiver.
+		if (mgr.MarkRead(id, 999) != MailOpResult::WrongReceiver) return false;
+
+		// Mail inexistant.
+		if (mgr.MarkRead(99999, 2) != MailOpResult::MailNotFound) return false;
+
+		LOG_INFO(Core, "[MailManagerTests] MarkRead OK");
+		return true;
+	}
+
+	bool TestTakeItemsBasic()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		std::vector<MailItemAttachment> items{
+			{42, 5}, {99, 1}
+		};
+		const uint64_t id = mgr.Send(1, 2, "loot", "enjoy", items, 0, 0, 100);
+
+		std::vector<MailItemAttachment> out;
+		if (mgr.TakeItems(id, 2, 0, out) != MailOpResult::OK) return false;
+		if (out.size() != 2) return false;
+		if (out[0].itemTemplateId != 42 || out[0].count != 5) return false;
+
+		// Re-Take → AlreadyTaken (vide).
+		if (mgr.TakeItems(id, 2, 0, out) != MailOpResult::AlreadyTaken) return false;
+
+		// Mail marque Read.
+		auto inbox = mgr.Inbox(2);
+		if (inbox[0].state != MailState::Read) return false;
+		LOG_INFO(Core, "[MailManagerTests] TakeItems basic OK");
+		return true;
+	}
+
+	bool TestTakeItemsCodFlow()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		std::vector<MailItemAttachment> items{ {7, 1} };
+		// COD = 100 copper required.
+		const uint64_t id = mgr.Send(1, 2, "for sale", "100c", items, 0, 100, 1000);
+
+		std::vector<MailItemAttachment> out;
+		// Pas paye → CodNotPaid.
+		if (mgr.TakeItems(id, 2, 0, out) != MailOpResult::CodNotPaid) return false;
+		if (mgr.TakeItems(id, 2, 50, out) != MailOpResult::CodNotPaid) return false;
+
+		// Paye exact → OK.
+		if (mgr.TakeItems(id, 2, 100, out) != MailOpResult::OK) return false;
+		if (out.size() != 1) return false;
+
+		// Re-Take après paiement → AlreadyTaken (items vidés, pas de double-COD).
+		if (mgr.TakeItems(id, 2, 100, out) != MailOpResult::AlreadyTaken) return false;
+		LOG_INFO(Core, "[MailManagerTests] COD flow OK");
+		return true;
+	}
+
+	bool TestTakeGold()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		const uint64_t id = mgr.Send(1, 2, "gift", "", {}, 5000, 0, 100);
+		uint64_t copper = 0;
+		if (mgr.TakeGold(id, 2, copper) != MailOpResult::OK) return false;
+		if (copper != 5000) return false;
+		// Re-take → AlreadyTaken.
+		if (mgr.TakeGold(id, 2, copper) != MailOpResult::AlreadyTaken) return false;
+		LOG_INFO(Core, "[MailManagerTests] TakeGold OK");
+		return true;
+	}
+
+	bool TestDeleteRequiresEmpty()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		const uint64_t id = mgr.Send(1, 2, "x", "", {}, 100, 0, 100);
+		// Gold pas encore retire → Delete refuse.
+		if (mgr.Delete(id, 2) != MailOpResult::AlreadyTaken) return false;
+
+		uint64_t copper = 0;
+		mgr.TakeGold(id, 2, copper);
+		// Maintenant on peut Delete.
+		if (mgr.Delete(id, 2) != MailOpResult::OK) return false;
+		if (store.Size() != 0) return false;
+		LOG_INFO(Core, "[MailManagerTests] Delete requires empty OK");
+		return true;
+	}
+
+	bool TestExpireDetection()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		mgr.Send(1, 2, "old", "", {}, 0, 0, 100, /*expiresTsMs=*/200);
+		mgr.Send(1, 2, "new", "", {}, 0, 0, 1000, /*expiresTsMs=*/2000);
+
+		// A nowMs=300 : seul le premier est expire.
+		auto exp = mgr.ResolveExpired(300);
+		if (exp.size() != 1) return false;
+
+		// A nowMs=2500 : les deux sont expires.
+		exp = mgr.ResolveExpired(2500);
+		if (exp.size() != 2) return false;
+		LOG_INFO(Core, "[MailManagerTests] Expire detection OK");
+		return true;
+	}
+
+	bool TestInboxSorting()
+	{
+		InMemoryMailStore store;
+		MailManager mgr(&store);
+		mgr.Send(1, 2, "old", "", {}, 0, 0, /*nowMs=*/100);
+		mgr.Send(1, 2, "mid", "", {}, 0, 0, /*nowMs=*/500);
+		mgr.Send(1, 2, "new", "", {}, 0, 0, /*nowMs=*/900);
+
+		auto inbox = mgr.Inbox(2);
+		if (inbox.size() != 3) return false;
+		if (inbox[0].subject != "new") return false;
+		if (inbox[1].subject != "mid") return false;
+		if (inbox[2].subject != "old") return false;
+		LOG_INFO(Core, "[MailManagerTests] inbox sorted desc by sentTs OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestSendBasic()
+		&& TestSendValidation()
+		&& TestMarkRead()
+		&& TestTakeItemsBasic()
+		&& TestTakeItemsCodFlow()
+		&& TestTakeGold()
+		&& TestDeleteRequiresEmpty()
+		&& TestExpireDetection()
+		&& TestInboxSorting();
+
+	if (ok)
+		LOG_INFO(Core, "[MailManagerTests] ALL OK");
+	else
+		LOG_ERROR(Core, "[MailManagerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Premier livrable **Phase 3** : `MailManager` core de la messagerie in-game cmangos. Logique métier pure : validation + workflow `Send` / `TakeItems` / `TakeGold` / `Delete` / `ResolveExpired` / `MarkRead`.

Pas encore de DB persistence ni d'opcode wire — ces sub-PRs ultérieures consommeront ce manager.

### Workflow COD (Cash On Delivery)

| Étape | Comportement |
|---|---|
| `Send(..., copperCod=100, ...)` | mail créé avec COD pending |
| `TakeItems(id, recv, paidCopper=0)` | → `CodNotPaid` |
| `TakeItems(id, recv, paidCopper=50)` | → `CodNotPaid` |
| `TakeItems(id, recv, paidCopper=100)` | → `OK` + items extraits, `copperCod=0` (pas de double-paiement) |

### API

- `IMailStore` interface (Insert / Find / ListInbox / Update / Delete / FindExpired).
- `InMemoryMailStore` impl RAM pour tests + fallback dev. `MysqlMailStore` viendra plus tard.
- `Mail` struct : mailId, sender/receiverAccountId, subject, body, items, copperGold, copperCod, sentTs, expiresTs, state.
- Limites canoniques : subject ≤ 255B, body ≤ 16KB, ≤ 12 attachments.
- Expiration default 30 jours si non spécifiée.

### Tests

`mail_manager_tests` : 9 cas — Send basic + validation (subject/body/attachments caps), MarkRead (wrong receiver / mail inexistant), TakeItems basic + AlreadyTaken, COD flow (refus pas payé / refus partiel / OK paiement exact / pas de double-COD), TakeGold + AlreadyTaken, Delete refuse si items/gold pendants, Expire detection à 2 instants, Inbox tri desc par `sentTsMs`.

## Test plan

- [x] `Send` valide limites (300 chars subject → `SubjectTooLong`).
- [x] COD = 100 : refuse `paidCopper=50`, accepte `paidCopper=100`, ne re-prélève pas si `Take` 2× après paiement.
- [x] `Delete` refuse tant que items ou gold pendants — sécurité contre la perte d'attachs.
- [x] `Inbox` tri desc par `sentTsMs`.
- [x] `ResolveExpired` retourne les mailIds dont `expiresTsMs <= nowMs` (et `> 0`).
- [ ] CI Linux verte (en attente).

## Déploiement

✅ **Pas de redéploiement requis** — code en isolation, pas wiré dans le runtime master. Compilé seulement comme test sur Linux. Les sub-PRs suivantes (MysqlMailStore + MailHandler opcodes + bump kProtocolVersion) déclencheront les redéploiements.

Pas de migration DB dans cette PR (les tables `mail` + `mail_items` viendront avec `MysqlMailStore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)