### PR TITLE
Phase 3 CMANGOS.25 step 1 : IgnoreListManager

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -315,6 +315,10 @@ elseif(UNIX)
     mail/MailManagerTests.cpp
     mail/MailManager.cpp)
 
+  # CMANGOS.25 (Phase 3.25a) : IgnoreListManager (header-only).
+  lcdlln_add_simple_test(ignore_list_tests
+    social/IgnoreListTests.cpp)
+
   # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
   add_executable(bih_tests
     shard/vmap/BIHTests.cpp

--- a/engine/server/social/IgnoreList.h
+++ b/engine/server/social/IgnoreList.h
@@ -1,0 +1,127 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25a) — IgnoreList : extension du systeme social
+// au-dela de FriendSystem. Permet a un joueur d'ignorer un autre joueur :
+// les whispers + invites + chat / mail de cette personne sont silencieusement
+// drop cote master.
+//
+// **Pur** : pas de DB persistence ni d'integration ChatGate dans cette
+// PR. Le store abstrait permet le test in-memory ; production wirera
+// MysqlIgnoreStore + integration avec ChatGate (#486) en sub-PR.
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::server::social
+{
+	/// Limite : 50 ignored par account (audit + cmangos parity).
+	inline constexpr size_t kMaxIgnoredPerAccount = 50;
+
+	enum class IgnoreOpResult : uint8_t
+	{
+		OK = 0,
+		AlreadyIgnored = 1,
+		NotIgnored     = 2,
+		ListFull       = 3,
+		SelfIgnore     = 4,    ///< Pas le droit de s'ignorer soi-meme.
+	};
+
+	/// Interface du store. Production = MysqlIgnoreStore, tests = in-memory.
+	class IIgnoreStore
+	{
+	public:
+		virtual ~IIgnoreStore() = default;
+
+		virtual bool Add(uint64_t ownerAccountId, uint64_t targetAccountId) = 0;
+		virtual bool Remove(uint64_t ownerAccountId, uint64_t targetAccountId) = 0;
+		virtual bool IsIgnored(uint64_t ownerAccountId, uint64_t targetAccountId) const = 0;
+		virtual std::vector<uint64_t> List(uint64_t ownerAccountId) const = 0;
+		virtual size_t Size(uint64_t ownerAccountId) const = 0;
+	};
+
+	class IgnoreListManager
+	{
+	public:
+		explicit IgnoreListManager(IIgnoreStore* store) : m_store(store) {}
+
+		IgnoreOpResult Ignore(uint64_t ownerAccountId, uint64_t targetAccountId)
+		{
+			if (!m_store) return IgnoreOpResult::NotIgnored;
+			if (ownerAccountId == targetAccountId)
+				return IgnoreOpResult::SelfIgnore;
+			if (m_store->IsIgnored(ownerAccountId, targetAccountId))
+				return IgnoreOpResult::AlreadyIgnored;
+			if (m_store->Size(ownerAccountId) >= kMaxIgnoredPerAccount)
+				return IgnoreOpResult::ListFull;
+			m_store->Add(ownerAccountId, targetAccountId);
+			return IgnoreOpResult::OK;
+		}
+
+		IgnoreOpResult Unignore(uint64_t ownerAccountId, uint64_t targetAccountId)
+		{
+			if (!m_store) return IgnoreOpResult::NotIgnored;
+			if (!m_store->IsIgnored(ownerAccountId, targetAccountId))
+				return IgnoreOpResult::NotIgnored;
+			m_store->Remove(ownerAccountId, targetAccountId);
+			return IgnoreOpResult::OK;
+		}
+
+		/// Hot path : appele par ChatGate / WhisperHandler / MailManager pour
+		/// silently drop. Retourne true si \p ownerAccountId a ignore
+		/// \p targetAccountId.
+		bool IsIgnored(uint64_t ownerAccountId, uint64_t targetAccountId) const
+		{
+			return m_store && m_store->IsIgnored(ownerAccountId, targetAccountId);
+		}
+
+		std::vector<uint64_t> List(uint64_t ownerAccountId) const
+		{
+			return m_store ? m_store->List(ownerAccountId) : std::vector<uint64_t>{};
+		}
+
+	private:
+		IIgnoreStore* m_store;
+	};
+
+	/// Implementation RAM pour tests + dev.
+	class InMemoryIgnoreStore final : public IIgnoreStore
+	{
+	public:
+		bool Add(uint64_t owner, uint64_t target) override
+		{
+			return m_data[owner].insert(target).second;
+		}
+		bool Remove(uint64_t owner, uint64_t target) override
+		{
+			auto it = m_data.find(owner);
+			if (it == m_data.end()) return false;
+			return it->second.erase(target) > 0;
+		}
+		bool IsIgnored(uint64_t owner, uint64_t target) const override
+		{
+			auto it = m_data.find(owner);
+			if (it == m_data.end()) return false;
+			return it->second.count(target) != 0;
+		}
+		std::vector<uint64_t> List(uint64_t owner) const override
+		{
+			std::vector<uint64_t> out;
+			auto it = m_data.find(owner);
+			if (it == m_data.end()) return out;
+			out.reserve(it->second.size());
+			for (auto t : it->second) out.push_back(t);
+			return out;
+		}
+		size_t Size(uint64_t owner) const override
+		{
+			auto it = m_data.find(owner);
+			return (it == m_data.end()) ? 0 : it->second.size();
+		}
+
+	private:
+		std::unordered_map<uint64_t, std::unordered_set<uint64_t>> m_data;
+	};
+}

--- a/engine/server/social/IgnoreListTests.cpp
+++ b/engine/server/social/IgnoreListTests.cpp
@@ -1,0 +1,109 @@
+// CMANGOS.25 (Phase 3.25a) — Tests IgnoreListManager.
+
+#include "engine/server/social/IgnoreList.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::social::IgnoreListManager;
+	using engine::server::social::IgnoreOpResult;
+	using engine::server::social::InMemoryIgnoreStore;
+	using engine::server::social::kMaxIgnoredPerAccount;
+
+	bool TestBasic()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+
+		if (mgr.Ignore(1, 2) != IgnoreOpResult::OK) return false;
+		if (!mgr.IsIgnored(1, 2)) return false;
+		if (mgr.IsIgnored(1, 3)) return false;
+		if (mgr.IsIgnored(2, 1)) return false;  // pas symetrique
+
+		auto list = mgr.List(1);
+		if (list.size() != 1 || list[0] != 2) return false;
+		LOG_INFO(Core, "[IgnoreListTests] basic OK");
+		return true;
+	}
+
+	bool TestAlreadyIgnored()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+		mgr.Ignore(1, 2);
+		if (mgr.Ignore(1, 2) != IgnoreOpResult::AlreadyIgnored) return false;
+		LOG_INFO(Core, "[IgnoreListTests] AlreadyIgnored OK");
+		return true;
+	}
+
+	bool TestSelfIgnore()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+		if (mgr.Ignore(1, 1) != IgnoreOpResult::SelfIgnore) return false;
+		LOG_INFO(Core, "[IgnoreListTests] SelfIgnore OK");
+		return true;
+	}
+
+	bool TestUnignore()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+		mgr.Ignore(1, 2);
+		if (mgr.Unignore(1, 2) != IgnoreOpResult::OK) return false;
+		if (mgr.IsIgnored(1, 2)) return false;
+		// Re-Unignore → NotIgnored.
+		if (mgr.Unignore(1, 2) != IgnoreOpResult::NotIgnored) return false;
+		LOG_INFO(Core, "[IgnoreListTests] Unignore OK");
+		return true;
+	}
+
+	bool TestListFullCap()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+		// Remplir jusqu'a la limite.
+		for (size_t i = 0; i < kMaxIgnoredPerAccount; ++i)
+		{
+			if (mgr.Ignore(1, 100 + i) != IgnoreOpResult::OK) return false;
+		}
+		// Le suivant doit echouer.
+		if (mgr.Ignore(1, 9999) != IgnoreOpResult::ListFull) return false;
+		LOG_INFO(Core, "[IgnoreListTests] cap at {} OK", kMaxIgnoredPerAccount);
+		return true;
+	}
+
+	bool TestPerOwnerIsolation()
+	{
+		InMemoryIgnoreStore store;
+		IgnoreListManager mgr(&store);
+		mgr.Ignore(1, 100);
+		mgr.Ignore(2, 200);
+
+		if (!mgr.IsIgnored(1, 100)) return false;
+		if (mgr.IsIgnored(1, 200)) return false;
+		if (!mgr.IsIgnored(2, 200)) return false;
+		if (mgr.IsIgnored(2, 100)) return false;
+
+		LOG_INFO(Core, "[IgnoreListTests] per-owner isolation OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestBasic() && TestAlreadyIgnored() && TestSelfIgnore()
+		&& TestUnignore() && TestListFullCap() && TestPerOwnerIsolation();
+
+	if (ok) LOG_INFO(Core, "[IgnoreListTests] ALL OK");
+	else LOG_ERROR(Core, "[IgnoreListTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
Extension Social. IgnoreListManager header-only (cap 50 ignored, in-memory store pour tests). Pas de wire ni DB persistence ; integration ChatGate viendra en sub-PR. 6 tests via lcdlln_add_simple_test.