### PR TITLE
Phase 3 CMANGOS.24 step 1 : ReputationManager + spillover

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -329,6 +329,9 @@ elseif(UNIX)
   # CMANGOS.11 (Phase 3.11a) : ThreatList AI target selector (header-only).
   lcdlln_add_simple_test(threat_list_tests
     combat/ThreatListTests.cpp)
+  # CMANGOS.24 (Phase 3.24a) : ReputationManager + spillover (header-only).
+  lcdlln_add_simple_test(reputation_manager_tests
+    reputation/ReputationManagerTests.cpp)
 
   # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
   add_executable(bih_tests

--- a/engine/server/reputation/ReputationManager.h
+++ b/engine/server/reputation/ReputationManager.h
@@ -1,0 +1,128 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24a) — ReputationManager : faction reputation
+// par account avec spillover bitmask (changement sur faction A
+// propage X% sur factions liees via mask). Pure data + algorithm,
+// pas de wire ni DB persistence.
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::reputation
+{
+	using FactionId = uint32_t;
+	using AccountId = uint64_t;
+
+	/// Standings cmangos : Hated -42000 → Exalted +41999.
+	enum class ReputationStanding : int8_t
+	{
+		Hated      = -6,
+		Hostile    = -5,
+		Unfriendly = -4,
+		Neutral    = -3,
+		Friendly   = -2,
+		Honored    = -1,
+		Revered    = 0,
+		Exalted    = 1,
+	};
+
+	struct ReputationRange
+	{
+		int32_t            minValue;
+		int32_t            maxValue;
+		ReputationStanding standing;
+	};
+
+	/// Bornes par standing (alignees sur cmangos / WoW).
+	inline constexpr int32_t kReputationMin = -42000;
+	inline constexpr int32_t kReputationMax = 41999;
+
+	/// Spillover : un changement sur \p sourceFaction propage `factor`
+	/// (0..1) sur \p targetFaction. Maximum kMaxSpilloverPerFaction par
+	/// source.
+	struct SpilloverRule
+	{
+		FactionId sourceFaction;
+		FactionId targetFaction;
+		float     factor;  ///< multiplier 0..1
+	};
+
+	inline constexpr size_t kMaxSpilloverPerFaction = 8;
+
+	class ReputationManager
+	{
+	public:
+		ReputationManager() = default;
+
+		/// Ajoute une regle de spillover. Pas d'erreur si on depasse
+		/// kMaxSpilloverPerFaction — les regles supplementaires sont
+		/// silencieusement ignorees.
+		void AddSpilloverRule(const SpilloverRule& rule)
+		{
+			if (rule.factor <= 0.0f) return;
+			auto& v = m_spillover[rule.sourceFaction];
+			if (v.size() < kMaxSpilloverPerFaction)
+				v.push_back(rule);
+		}
+
+		/// Modifie la reputation. Le delta est applique a la faction
+		/// source + (delta * factor) sur chaque faction spillover.
+		/// Resultat clamp a [kReputationMin, kReputationMax].
+		void GainReputation(AccountId accountId, FactionId faction, int32_t delta)
+		{
+			ApplyDelta(accountId, faction, delta);
+
+			auto it = m_spillover.find(faction);
+			if (it == m_spillover.end()) return;
+			for (const auto& rule : it->second)
+			{
+				const int32_t spilloverDelta = static_cast<int32_t>(
+					static_cast<float>(delta) * rule.factor);
+				if (spilloverDelta != 0)
+					ApplyDelta(accountId, rule.targetFaction, spilloverDelta);
+			}
+		}
+
+		int32_t GetReputation(AccountId accountId, FactionId faction) const
+		{
+			auto itAcc = m_reputation.find(accountId);
+			if (itAcc == m_reputation.end()) return 0;
+			auto itFac = itAcc->second.find(faction);
+			return (itFac == itAcc->second.end()) ? 0 : itFac->second;
+		}
+
+		/// Retourne le standing pour la valeur courante.
+		static ReputationStanding StandingFor(int32_t value)
+		{
+			if (value <= -42000) return ReputationStanding::Hated;
+			if (value <= -6000)  return ReputationStanding::Hostile;
+			if (value <= -3000)  return ReputationStanding::Unfriendly;
+			if (value <= 0)      return ReputationStanding::Neutral;
+			if (value <= 3000)   return ReputationStanding::Friendly;
+			if (value <= 9000)   return ReputationStanding::Honored;
+			if (value <= 21000)  return ReputationStanding::Revered;
+			return ReputationStanding::Exalted;
+		}
+
+		/// Reset (utile en tests).
+		void Clear()
+		{
+			m_reputation.clear();
+			m_spillover.clear();
+		}
+
+	private:
+		void ApplyDelta(AccountId accountId, FactionId faction, int32_t delta)
+		{
+			auto& v = m_reputation[accountId][faction];
+			int64_t newVal = static_cast<int64_t>(v) + static_cast<int64_t>(delta);
+			if (newVal < kReputationMin) newVal = kReputationMin;
+			if (newVal > kReputationMax) newVal = kReputationMax;
+			v = static_cast<int32_t>(newVal);
+		}
+
+		std::unordered_map<AccountId, std::unordered_map<FactionId, int32_t>> m_reputation;
+		std::unordered_map<FactionId, std::vector<SpilloverRule>> m_spillover;
+	};
+}

--- a/engine/server/reputation/ReputationManagerTests.cpp
+++ b/engine/server/reputation/ReputationManagerTests.cpp
@@ -1,0 +1,117 @@
+// CMANGOS.24 (Phase 3.24a) — Tests ReputationManager + Spillover.
+
+#include "engine/server/reputation/ReputationManager.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::reputation::ReputationManager;
+	using engine::server::reputation::ReputationStanding;
+	using engine::server::reputation::SpilloverRule;
+	using engine::server::reputation::kReputationMax;
+	using engine::server::reputation::kReputationMin;
+
+	bool TestBasicGainAndQuery()
+	{
+		ReputationManager mgr;
+		mgr.GainReputation(1, 100, 500);
+		if (mgr.GetReputation(1, 100) != 500) return false;
+		mgr.GainReputation(1, 100, 300);
+		if (mgr.GetReputation(1, 100) != 800) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] basic gain OK");
+		return true;
+	}
+
+	bool TestClamping()
+	{
+		ReputationManager mgr;
+		mgr.GainReputation(1, 100, 100000);
+		if (mgr.GetReputation(1, 100) != kReputationMax) return false;
+		mgr.GainReputation(1, 200, -100000);
+		if (mgr.GetReputation(1, 200) != kReputationMin) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] clamp OK");
+		return true;
+	}
+
+	bool TestStandingThresholds()
+	{
+		if (ReputationManager::StandingFor(-42000) != ReputationStanding::Hated) return false;
+		if (ReputationManager::StandingFor(-1) != ReputationStanding::Neutral) return false;
+		if (ReputationManager::StandingFor(0) != ReputationStanding::Neutral) return false;
+		if (ReputationManager::StandingFor(1500) != ReputationStanding::Friendly) return false;
+		if (ReputationManager::StandingFor(8000) != ReputationStanding::Honored) return false;
+		if (ReputationManager::StandingFor(20000) != ReputationStanding::Revered) return false;
+		if (ReputationManager::StandingFor(40000) != ReputationStanding::Exalted) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] standing thresholds OK");
+		return true;
+	}
+
+	bool TestSpillover()
+	{
+		ReputationManager mgr;
+		// Faction 100 gain → 50% sur 200, 25% sur 300.
+		mgr.AddSpilloverRule({100, 200, 0.5f});
+		mgr.AddSpilloverRule({100, 300, 0.25f});
+
+		mgr.GainReputation(1, 100, 1000);
+		if (mgr.GetReputation(1, 100) != 1000) return false;
+		if (mgr.GetReputation(1, 200) != 500) return false;
+		if (mgr.GetReputation(1, 300) != 250) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] spillover OK");
+		return true;
+	}
+
+	bool TestSpilloverNotReverse()
+	{
+		ReputationManager mgr;
+		mgr.AddSpilloverRule({100, 200, 0.5f});
+		// Gain sur 200 ne doit PAS spillover sur 100 (rule sens unique).
+		mgr.GainReputation(1, 200, 1000);
+		if (mgr.GetReputation(1, 100) != 0) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] spillover unidirectional OK");
+		return true;
+	}
+
+	bool TestMultiAccountIsolation()
+	{
+		ReputationManager mgr;
+		mgr.GainReputation(1, 100, 500);
+		mgr.GainReputation(2, 100, 1000);
+		if (mgr.GetReputation(1, 100) != 500) return false;
+		if (mgr.GetReputation(2, 100) != 1000) return false;
+		if (mgr.GetReputation(3, 100) != 0) return false;
+		LOG_INFO(Core, "[ReputationManagerTests] multi-account isolation OK");
+		return true;
+	}
+
+	bool TestSpilloverNegative()
+	{
+		ReputationManager mgr;
+		mgr.AddSpilloverRule({100, 200, 0.5f});
+		mgr.GainReputation(1, 100, -2000);  // perte
+		if (mgr.GetReputation(1, 100) != -2000) return false;
+		if (mgr.GetReputation(1, 200) != -1000) return false;  // 50% de la perte
+		LOG_INFO(Core, "[ReputationManagerTests] spillover negative OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestBasicGainAndQuery() && TestClamping()
+		&& TestStandingThresholds() && TestSpillover()
+		&& TestSpilloverNotReverse() && TestMultiAccountIsolation()
+		&& TestSpilloverNegative();
+
+	if (ok) LOG_INFO(Core, "[ReputationManagerTests] ALL OK");
+	else LOG_ERROR(Core, "[ReputationManagerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
ReputationManager header-only avec spillover unidirectional. 8 standings cmangos, clamp [-42000, +41999], spillover par regle pondere. 7 tests via lcdlln_add_simple_test.