### PR TITLE
Phase 3 CMANGOS.26 step 1 : SpellFamilyMask 128-bit + ProcEvent

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -347,6 +347,9 @@ elseif(UNIX)
   lcdlln_add_simple_test(event_ai_tests
     ai/EventAITests.cpp
     ai/EventAI.cpp)
+  # CMANGOS.26 (Phase 3.26a) : SpellFamilyMask 128-bit + ProcEvent matching.
+  lcdlln_add_simple_test(spell_family_mask_tests
+    spell/SpellFamilyMaskTests.cpp)
 
   # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
   add_executable(bih_tests

--- a/engine/server/spell/SpellFamilyMask.h
+++ b/engine/server/spell/SpellFamilyMask.h
@@ -1,0 +1,93 @@
+#pragma once
+// CMANGOS.26 (Phase 3.26a) — SpellFamilyMask : bitmask 128-bit pour
+// classifier les sorts d'une famille (Mage / Warrior / etc). Utilise
+// pour les ProcEvent (un sort qui trigger seulement sur "Fire spells
+// du Mage" se filtre via mask intersection).
+//
+// Pure data + bitwise ops. Header-only.
+
+#include <cstdint>
+
+namespace engine::server::spell
+{
+	enum class SpellFamily : uint8_t
+	{
+		Generic   = 0,
+		Mage      = 1,
+		Warrior   = 2,
+		Warlock   = 3,
+		Priest    = 4,
+		Druid     = 5,
+		Rogue     = 6,
+		Hunter    = 7,
+		Paladin   = 8,
+		Shaman    = 9,
+		DeathKnight = 10,
+	};
+
+	/// Bitmask 128 bits decoupe en 4 uint32. La spec cmangos utilise
+	/// 96 bits (3 × uint32) pour TBC ; on prevoit 128 pour extension.
+	struct SpellFamilyMask
+	{
+		uint32_t parts[4] = {0, 0, 0, 0};
+
+		constexpr SpellFamilyMask() = default;
+		constexpr SpellFamilyMask(uint32_t a, uint32_t b = 0, uint32_t c = 0, uint32_t d = 0) noexcept
+			: parts{a, b, c, d} {}
+
+		constexpr bool IsEmpty() const noexcept
+		{
+			return parts[0] == 0 && parts[1] == 0 && parts[2] == 0 && parts[3] == 0;
+		}
+
+		/// True si l'un des bits set dans \p other est aussi set dans this.
+		constexpr bool IntersectsWith(const SpellFamilyMask& other) const noexcept
+		{
+			return (parts[0] & other.parts[0]) != 0
+				|| (parts[1] & other.parts[1]) != 0
+				|| (parts[2] & other.parts[2]) != 0
+				|| (parts[3] & other.parts[3]) != 0;
+		}
+
+		/// True si TOUS les bits set dans \p subset sont aussi set dans this.
+		constexpr bool Contains(const SpellFamilyMask& subset) const noexcept
+		{
+			return (parts[0] & subset.parts[0]) == subset.parts[0]
+				&& (parts[1] & subset.parts[1]) == subset.parts[1]
+				&& (parts[2] & subset.parts[2]) == subset.parts[2]
+				&& (parts[3] & subset.parts[3]) == subset.parts[3];
+		}
+
+		constexpr SpellFamilyMask operator|(const SpellFamilyMask& o) const noexcept
+		{
+			return SpellFamilyMask(parts[0] | o.parts[0], parts[1] | o.parts[1],
+				parts[2] | o.parts[2], parts[3] | o.parts[3]);
+		}
+		constexpr SpellFamilyMask operator&(const SpellFamilyMask& o) const noexcept
+		{
+			return SpellFamilyMask(parts[0] & o.parts[0], parts[1] & o.parts[1],
+				parts[2] & o.parts[2], parts[3] & o.parts[3]);
+		}
+		constexpr bool operator==(const SpellFamilyMask& o) const noexcept = default;
+	};
+
+	/// Information minimale sur un sort cote serveur. Etendre avec
+	/// damage / cooldown / effect_type au fil des besoins.
+	struct SpellInfo
+	{
+		uint32_t        spellId = 0;
+		SpellFamily     family  = SpellFamily::Generic;
+		SpellFamilyMask familyMask;  ///< pour ProcEvent matching
+	};
+
+	/// Helper : true si \p triggeringSpell match les criteres ProcEvent
+	/// \p mustHaveFamily + \p anyOfMask. Si anyOfMask est vide, tout sort
+	/// de la famille match.
+	inline bool SpellMatchesProcCriteria(const SpellInfo& triggeringSpell,
+		SpellFamily mustHaveFamily, const SpellFamilyMask& anyOfMask) noexcept
+	{
+		if (triggeringSpell.family != mustHaveFamily) return false;
+		if (anyOfMask.IsEmpty()) return true;
+		return triggeringSpell.familyMask.IntersectsWith(anyOfMask);
+	}
+}

--- a/engine/server/spell/SpellFamilyMaskTests.cpp
+++ b/engine/server/spell/SpellFamilyMaskTests.cpp
@@ -1,0 +1,100 @@
+#include "engine/server/spell/SpellFamilyMask.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::spell::SpellFamily;
+	using engine::server::spell::SpellFamilyMask;
+	using engine::server::spell::SpellInfo;
+	using engine::server::spell::SpellMatchesProcCriteria;
+
+	bool TestEmpty()
+	{
+		SpellFamilyMask m;
+		if (!m.IsEmpty()) return false;
+		SpellFamilyMask m2(1);
+		if (m2.IsEmpty()) return false;
+		LOG_INFO(Core, "[SpellFamilyMaskTests] empty OK");
+		return true;
+	}
+
+	bool TestIntersect()
+	{
+		SpellFamilyMask a(0xFF00, 0, 0, 0);
+		SpellFamilyMask b(0x0F00, 0, 0, 0);
+		SpellFamilyMask c(0x0001, 0, 0, 0);
+		if (!a.IntersectsWith(b)) return false;  // 0xFF00 & 0x0F00 = 0x0F00 ≠ 0
+		if (a.IntersectsWith(c)) return false;    // 0xFF00 & 0x0001 = 0
+		LOG_INFO(Core, "[SpellFamilyMaskTests] Intersects OK");
+		return true;
+	}
+
+	bool TestContains()
+	{
+		SpellFamilyMask superset(0xFFFF, 0xFFFF, 0, 0);
+		SpellFamilyMask subset(0x00FF, 0x0F00, 0, 0);
+		SpellFamilyMask notSubset(0x10000, 0, 0, 0);
+		if (!superset.Contains(subset)) return false;
+		if (superset.Contains(notSubset)) return false;
+		LOG_INFO(Core, "[SpellFamilyMaskTests] Contains OK");
+		return true;
+	}
+
+	bool TestBitwiseOps()
+	{
+		SpellFamilyMask a(0xF0, 0, 0, 0);
+		SpellFamilyMask b(0x0F, 0, 0, 0);
+		auto orResult = a | b;
+		if (orResult.parts[0] != 0xFF) return false;
+		auto andResult = a & b;
+		if (andResult.parts[0] != 0) return false;
+		LOG_INFO(Core, "[SpellFamilyMaskTests] bitwise ops OK");
+		return true;
+	}
+
+	bool TestProcMatching()
+	{
+		// Triggering spell : Mage, mask 0x10 (e.g. Fireball).
+		SpellInfo trigger;
+		trigger.spellId = 100;
+		trigger.family = SpellFamily::Mage;
+		trigger.familyMask = SpellFamilyMask(0x10);
+
+		// ProcEvent : "any Mage spell" (anyOfMask vide).
+		if (!SpellMatchesProcCriteria(trigger, SpellFamily::Mage, SpellFamilyMask()))
+			return false;
+
+		// ProcEvent : "Mage spells with mask 0x10" (Fire).
+		if (!SpellMatchesProcCriteria(trigger, SpellFamily::Mage, SpellFamilyMask(0x10)))
+			return false;
+
+		// ProcEvent : "Mage spells with mask 0x20" (Frost) → no match.
+		if (SpellMatchesProcCriteria(trigger, SpellFamily::Mage, SpellFamilyMask(0x20)))
+			return false;
+
+		// ProcEvent : "Warrior" → no match (wrong family).
+		if (SpellMatchesProcCriteria(trigger, SpellFamily::Warrior, SpellFamilyMask()))
+			return false;
+
+		LOG_INFO(Core, "[SpellFamilyMaskTests] Proc matching OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestIntersect() && TestContains()
+		&& TestBitwiseOps() && TestProcMatching();
+
+	if (ok) LOG_INFO(Core, "[SpellFamilyMaskTests] ALL OK");
+	else LOG_ERROR(Core, "[SpellFamilyMaskTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
SpellFamilyMask 128-bit (4×uint32) pour ProcEvent matching cmangos-style. SpellInfo minimal + helper SpellMatchesProcCriteria. 5 tests via lcdlln_add_simple_test.