### PR TITLE
Phase 3 CMANGOS.14 step 1 : DBScript VM step-by-step

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -364,6 +364,10 @@ elseif(UNIX)
   # CMANGOS.26 (Phase 3.26a) : SpellFamilyMask 128-bit + ProcEvent matching.
   lcdlln_add_simple_test(spell_family_mask_tests
     spell/SpellFamilyMaskTests.cpp)
+  # CMANGOS.14 (Phase 3.14a) : DBScripts VM step-by-step.
+  lcdlln_add_simple_test(dbscript_tests
+    dbscripts/DBScriptTests.cpp
+    dbscripts/DBScript.cpp)
 
   # CMANGOS.05 (Phase 2.05a) : BIH<T> + AABB pure math tests (no DB)
   add_executable(bih_tests

--- a/engine/server/dbscripts/DBScript.cpp
+++ b/engine/server/dbscripts/DBScript.cpp
@@ -1,0 +1,36 @@
+#include "engine/server/dbscripts/DBScript.h"
+
+namespace engine::server::dbscripts
+{
+	void ScriptVM::Start(ScriptVMState& state, const Script& script, uint64_t nowMs)
+	{
+		state.scriptId       = script.scriptId;
+		state.nextCommandIdx = 0;
+		state.nextRunTickMs  = (script.commands.empty()) ? nowMs
+			: nowMs + script.commands[0].delayMs;
+		state.finished       = script.commands.empty();
+	}
+
+	bool ScriptVM::Step(ScriptVMState& state, const Script& script, uint64_t nowMs,
+		std::vector<size_t>& outFiredCommands)
+	{
+		outFiredCommands.clear();
+		if (state.finished) return false;
+
+		while (state.nextCommandIdx < script.commands.size()
+			&& nowMs >= state.nextRunTickMs)
+		{
+			outFiredCommands.push_back(state.nextCommandIdx);
+			++state.nextCommandIdx;
+			if (state.nextCommandIdx < script.commands.size())
+			{
+				state.nextRunTickMs += script.commands[state.nextCommandIdx].delayMs;
+			}
+			else
+			{
+				state.finished = true;
+			}
+		}
+		return !state.finished;
+	}
+}

--- a/engine/server/dbscripts/DBScript.h
+++ b/engine/server/dbscripts/DBScript.h
@@ -1,0 +1,69 @@
+#pragma once
+// CMANGOS.14 (Phase 3.14a) — DBScripts : DSL minimal data-driven pour
+// scripts narratifs (talk to NPC → say + give item + start quest).
+// Chaque script est une liste de commandes typees, chargee depuis DB
+// puis executee par un VM step-by-step.
+//
+// Cette PR : data structures + VM step-by-step. Pas encore de loader
+// DB ni d'integration QuestRuntime / talk handler.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::dbscripts
+{
+	enum class CommandKind : uint8_t
+	{
+		Say          = 0,   ///< NPC dit un texte (param: stringId; data: text)
+		Emote        = 1,   ///< NPC fait un emote (param: emoteId)
+		MoveTo       = 2,   ///< NPC se deplace (param: waypointId)
+		Wait         = 3,   ///< Attendre param ms avant la prochaine commande
+		GiveItem     = 4,   ///< Donne item (param: itemTemplateId, count)
+		StartQuest   = 5,   ///< Start quest (param: questId)
+		FinishQuest  = 6,   ///< Complete quest
+		PlaySound    = 7,   ///< (param: soundId)
+		Teleport     = 8,   ///< (param: mapId, posX, posY, posZ packed)
+		Custom       = 99,
+	};
+
+	struct ScriptCommand
+	{
+		CommandKind kind        = CommandKind::Custom;
+		uint32_t    delayMs     = 0;       ///< delai avant execution
+		uint32_t    param1      = 0;       ///< depend du kind
+		uint32_t    param2      = 0;
+		uint32_t    param3      = 0;
+		std::string dataString;            ///< pour Say + Custom
+	};
+
+	struct Script
+	{
+		uint32_t              scriptId = 0;
+		std::vector<ScriptCommand> commands;
+	};
+
+	/// Etat d'execution d'un script.
+	struct ScriptVMState
+	{
+		uint32_t scriptId       = 0;
+		size_t   nextCommandIdx = 0;
+		uint64_t nextRunTickMs  = 0;
+		bool     finished       = false;
+	};
+
+	/// Step-by-step VM. A chaque tick, appeler `Step(state, script,
+	/// nowMs, outFiredCommands)` qui execute toutes les commandes dont
+	/// le delay est ecoule. \p outFiredCommands recoit les indices des
+	/// commandes a appliquer (le caller dispatch les side-effects).
+	class ScriptVM
+	{
+	public:
+		void Start(ScriptVMState& state, const Script& script, uint64_t nowMs);
+
+		/// Avance le state machine. Retourne false quand le script est
+		/// termine.
+		bool Step(ScriptVMState& state, const Script& script, uint64_t nowMs,
+			std::vector<size_t>& outFiredCommands);
+	};
+}

--- a/engine/server/dbscripts/DBScriptTests.cpp
+++ b/engine/server/dbscripts/DBScriptTests.cpp
@@ -1,0 +1,100 @@
+#include "engine/server/dbscripts/DBScript.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::dbscripts::CommandKind;
+	using engine::server::dbscripts::Script;
+	using engine::server::dbscripts::ScriptCommand;
+	using engine::server::dbscripts::ScriptVM;
+	using engine::server::dbscripts::ScriptVMState;
+
+	bool TestEmptyScriptFinishesImmediately()
+	{
+		Script s;
+		s.scriptId = 1;
+		ScriptVMState state;
+		ScriptVM vm;
+		vm.Start(state, s, 0);
+		std::vector<size_t> fired;
+		if (vm.Step(state, s, 100, fired)) return false;  // already finished
+		if (!fired.empty()) return false;
+		LOG_INFO(Core, "[DBScriptTests] empty script OK");
+		return true;
+	}
+
+	bool TestSequenceWithDelays()
+	{
+		Script s;
+		s.scriptId = 1;
+		s.commands.push_back({CommandKind::Say, 0, 1, 0, 0, "Hi"});
+		s.commands.push_back({CommandKind::Wait, 100, 0, 0, 0, ""});
+		s.commands.push_back({CommandKind::Emote, 50, 5, 0, 0, ""});
+
+		ScriptVMState state;
+		ScriptVM vm;
+		vm.Start(state, s, 0);
+		std::vector<size_t> fired;
+
+		// t=0 : commande 0 fire (delay 0).
+		vm.Step(state, s, 0, fired);
+		if (fired.size() != 1 || fired[0] != 0) return false;
+
+		// t=50 : pas encore (cmd 1 a delay 100).
+		vm.Step(state, s, 50, fired);
+		if (!fired.empty()) return false;
+
+		// t=100 : cmd 1 fire (Wait).
+		vm.Step(state, s, 100, fired);
+		if (fired.size() != 1 || fired[0] != 1) return false;
+
+		// t=150 : cmd 2 fire (Emote, delay 50 ⇒ run at 100+50=150).
+		vm.Step(state, s, 150, fired);
+		if (fired.size() != 1 || fired[0] != 2) return false;
+
+		// t=200 : termine.
+		bool stillRunning = vm.Step(state, s, 200, fired);
+		if (stillRunning) return false;
+		if (!state.finished) return false;
+		LOG_INFO(Core, "[DBScriptTests] sequence with delays OK");
+		return true;
+	}
+
+	bool TestCatchUpMultipleCommands()
+	{
+		// Si on Step apres un long gap, plusieurs commandes peuvent
+		// fire dans le meme appel.
+		Script s;
+		s.scriptId = 1;
+		for (int i = 0; i < 5; ++i)
+			s.commands.push_back({CommandKind::Say, 100, static_cast<uint32_t>(i), 0, 0, ""});
+
+		ScriptVMState state;
+		ScriptVM vm;
+		vm.Start(state, s, 0);
+		std::vector<size_t> fired;
+		// Step at t=10000 : tous les 5 doivent avoir fire.
+		vm.Step(state, s, 10000, fired);
+		if (fired.size() != 5) return false;
+		LOG_INFO(Core, "[DBScriptTests] catch-up OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmptyScriptFinishesImmediately()
+		&& TestSequenceWithDelays() && TestCatchUpMultipleCommands();
+
+	if (ok) LOG_INFO(Core, "[DBScriptTests] ALL OK");
+	else LOG_ERROR(Core, "[DBScriptTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
DBScript DSL minimal data-driven (Say/Emote/MoveTo/Wait/GiveItem/StartQuest/FinishQuest/PlaySound/Teleport/Custom). Script=liste de ScriptCommand avec delayMs. ScriptVM step-by-step + catch-up. 3 tests.