### PR TITLE
feat(server/cinematics): CinematicSequence (Phase 5 CMANGOS.30 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -342,6 +342,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(game_event_manager_tests
     events/GameEventManagerTests.cpp)
 
+  # CMANGOS.30 (Phase 5.30a) : CinematicSequence (header-only, camera keyframe interp).
+  lcdlln_add_simple_test(cinematic_sequence_tests
+    cinematics/CinematicSequenceTests.cpp)
+
   # CMANGOS.25 (Phase 3.25a) : IgnoreListManager (header-only).
   lcdlln_add_simple_test(ignore_list_tests
     social/IgnoreListTests.cpp)

--- a/engine/server/cinematics/CinematicSequence.h
+++ b/engine/server/cinematics/CinematicSequence.h
@@ -1,0 +1,61 @@
+#pragma once
+// CMANGOS.30 (Phase 5.30a) — CinematicSequence : timeline de keyframes
+// (camera position + look-at + sons) déclenchée par event narratif.
+// Header-only.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::cinematics
+{
+	using SequenceId = uint32_t;
+
+	struct CameraKeyframe
+	{
+		uint64_t tsMs;            ///< absolu depuis le début de la séquence
+		float    posX, posY, posZ;
+		float    lookX, lookY, lookZ;
+		std::string soundCue;     ///< vide si pas de son à ce keyframe
+	};
+
+	struct CinematicSequence
+	{
+		SequenceId id = 0;
+		std::vector<CameraKeyframe> keyframes;
+	};
+
+	/// Interpole linéairement entre 2 keyframes successifs au temps \p tMs.
+	/// Retourne false si tMs est hors de la séquence ou pas assez de keyframes.
+	struct InterpolatedFrame
+	{
+		float    posX, posY, posZ;
+		float    lookX, lookY, lookZ;
+	};
+
+	inline bool SampleAt(const CinematicSequence& seq, uint64_t tMs, InterpolatedFrame& out)
+	{
+		if (seq.keyframes.size() < 2) return false;
+		if (tMs < seq.keyframes.front().tsMs) return false;
+		if (tMs > seq.keyframes.back().tsMs) return false;
+
+		for (size_t i = 0; i + 1 < seq.keyframes.size(); ++i)
+		{
+			const auto& a = seq.keyframes[i];
+			const auto& b = seq.keyframes[i + 1];
+			if (tMs >= a.tsMs && tMs <= b.tsMs)
+			{
+				const auto dt = b.tsMs - a.tsMs;
+				const float t = (dt == 0) ? 0.0f : static_cast<float>(tMs - a.tsMs) / static_cast<float>(dt);
+				out.posX  = a.posX  + (b.posX  - a.posX)  * t;
+				out.posY  = a.posY  + (b.posY  - a.posY)  * t;
+				out.posZ  = a.posZ  + (b.posZ  - a.posZ)  * t;
+				out.lookX = a.lookX + (b.lookX - a.lookX) * t;
+				out.lookY = a.lookY + (b.lookY - a.lookY) * t;
+				out.lookZ = a.lookZ + (b.lookZ - a.lookZ) * t;
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/engine/server/cinematics/CinematicSequenceTests.cpp
+++ b/engine/server/cinematics/CinematicSequenceTests.cpp
@@ -1,0 +1,67 @@
+#include "engine/server/cinematics/CinematicSequence.h"
+#include "engine/core/Log.h"
+
+#include <cmath>
+
+namespace
+{
+	using engine::server::cinematics::CameraKeyframe;
+	using engine::server::cinematics::CinematicSequence;
+	using engine::server::cinematics::InterpolatedFrame;
+	using engine::server::cinematics::SampleAt;
+
+	bool ApproxEq(float a, float b, float eps = 1e-3f)
+	{ return std::fabs(a - b) <= eps; }
+
+	bool TestEmpty()
+	{
+		CinematicSequence s;
+		InterpolatedFrame f;
+		if (SampleAt(s, 0, f)) return false;
+		s.keyframes.push_back({0, 0,0,0, 1,0,0, ""});
+		if (SampleAt(s, 0, f)) return false;  // need 2 keyframes
+		LOG_INFO(Core, "[CinematicTests] empty/single OK");
+		return true;
+	}
+
+	bool TestInterpolation()
+	{
+		CinematicSequence s;
+		s.keyframes.push_back({0, 0,0,0, 1,0,0, ""});
+		s.keyframes.push_back({1000, 10,5,0, 0,1,0, ""});
+
+		InterpolatedFrame f;
+		if (!SampleAt(s, 500, f)) return false;
+		if (!ApproxEq(f.posX, 5) || !ApproxEq(f.posY, 2.5f)) return false;
+		LOG_INFO(Core, "[CinematicTests] linear interp OK");
+		return true;
+	}
+
+	bool TestOutOfRange()
+	{
+		CinematicSequence s;
+		s.keyframes.push_back({100, 0,0,0, 0,0,0, ""});
+		s.keyframes.push_back({200, 1,1,1, 0,0,0, ""});
+
+		InterpolatedFrame f;
+		if (SampleAt(s, 50, f)) return false;   // before
+		if (SampleAt(s, 300, f)) return false;  // after
+		LOG_INFO(Core, "[CinematicTests] out of range OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestInterpolation() && TestOutOfRange();
+	if (ok) LOG_INFO(Core, "[CinematicTests] ALL OK");
+	else LOG_ERROR(Core, "[CinematicTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.30 Cinematics step 1

Header-only timeline de keyframes camera (position + look-at + sound cue) avec interpolation lineaire entre keyframes successifs.

### Inclus
- engine/server/cinematics/CinematicSequence.h — CameraKeyframe, CinematicSequence, InterpolatedFrame, SampleAt(seq, tMs, &out) lineaire.
- engine/server/cinematics/CinematicSequenceTests.cpp — 3 tests : empty/single keyframe rejete, interp lineaire au midpoint, hors range rejete.
- engine/server/CMakeLists.txt — test target cinematic_sequence_tests via lcdlln_add_simple_test.

### Test plan
- [x] Build Linux : cinematic_sequence_tests compile et passe.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only, pas de nouveau handler ni opcode ni migration DB).

Generated with Claude Code