### PR TITLE
feat(server/outdoorpvp): OutdoorPvPManager (Phase 5 CMANGOS.36 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.36 (Phase 5.36a) : OutdoorPvPManager (header-only, zones contestees).
+  lcdlln_add_simple_test(outdoor_pvp_manager_tests
+    outdoorpvp/OutdoorPvPManagerTests.cpp)
+
   # CMANGOS.25 (Phase 3.25a) : IgnoreListManager (header-only).
   lcdlln_add_simple_test(ignore_list_tests
     social/IgnoreListTests.cpp)

--- a/engine/server/outdoorpvp/OutdoorPvPManager.h
+++ b/engine/server/outdoorpvp/OutdoorPvPManager.h
@@ -1,0 +1,109 @@
+#pragma once
+// CMANGOS.36 (Phase 5.36a) — OutdoorPvPManager : zones contestees a objectifs
+// (towers/captures) avec score par faction et reset configurable. Header-only.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::outdoorpvp
+{
+	using ZoneId      = uint32_t;
+	using ObjectiveId = uint32_t;
+	using FactionId   = uint8_t;  ///< 0 = Alliance, 1 = Horde, 0xFF = neutre
+
+	struct Objective
+	{
+		ObjectiveId id        = 0;
+		FactionId   owner     = 0xFF; ///< 0xFF = neutre/contested
+		uint32_t    capturePct = 0;   ///< 0..100, progression de la capture en cours
+		FactionId   capturingBy = 0xFF; ///< faction qui progresse (0xFF si aucune)
+	};
+
+	struct Zone
+	{
+		ZoneId id = 0;
+		std::vector<Objective> objectives;
+		std::unordered_map<FactionId, uint32_t> score; ///< score par faction
+	};
+
+	/// Etat du gestionnaire OutdoorPvP. Header-only, zero dep externe.
+	class OutdoorPvPManager
+	{
+	public:
+		void RegisterZone(const Zone& z) { m_zones[z.id] = z; }
+		bool HasZone(ZoneId zid) const { return m_zones.count(zid) > 0; }
+
+		/// Demarre une capture par \p fac sur l'objectif \p oid de la zone \p zid.
+		/// Reset capturePct si la faction change. Retourne false si zone/objectif inconnu.
+		bool BeginCapture(ZoneId zid, ObjectiveId oid, FactionId fac)
+		{
+			auto* obj = FindObjective(zid, oid);
+			if (!obj) return false;
+			if (obj->capturingBy != fac)
+			{
+				obj->capturingBy = fac;
+				obj->capturePct  = 0;
+			}
+			return true;
+		}
+
+		/// Avance la capture en cours de \p deltaPct (0..100). Si capturePct atteint
+		/// 100, l'objectif change de proprietaire et la faction gagne 1 point de score.
+		/// Retourne true si capture terminee dans cet appel (transition d'owner).
+		bool TickCapture(ZoneId zid, ObjectiveId oid, uint32_t deltaPct)
+		{
+			auto* obj = FindObjective(zid, oid);
+			if (!obj) return false;
+			if (obj->capturingBy == 0xFF) return false;
+			obj->capturePct += deltaPct;
+			if (obj->capturePct >= 100)
+			{
+				obj->capturePct = 0;
+				const auto fac  = obj->capturingBy;
+				obj->owner       = fac;
+				obj->capturingBy = 0xFF;
+				m_zones[zid].score[fac] += 1;
+				return true;
+			}
+			return false;
+		}
+
+		/// Score actuel d'une faction dans une zone (0 si zone/faction absente).
+		uint32_t Score(ZoneId zid, FactionId fac) const
+		{
+			auto it = m_zones.find(zid);
+			if (it == m_zones.end()) return 0;
+			auto sit = it->second.score.find(fac);
+			return (sit == it->second.score.end()) ? 0 : sit->second;
+		}
+
+		/// Reset complet d'une zone (score + objectifs neutres). Utilise au reset
+		/// hebdomadaire ou pour tests.
+		void ResetZone(ZoneId zid)
+		{
+			auto it = m_zones.find(zid);
+			if (it == m_zones.end()) return;
+			it->second.score.clear();
+			for (auto& o : it->second.objectives)
+			{
+				o.owner       = 0xFF;
+				o.capturePct  = 0;
+				o.capturingBy = 0xFF;
+			}
+		}
+
+	private:
+		Objective* FindObjective(ZoneId zid, ObjectiveId oid)
+		{
+			auto it = m_zones.find(zid);
+			if (it == m_zones.end()) return nullptr;
+			for (auto& o : it->second.objectives)
+				if (o.id == oid) return &o;
+			return nullptr;
+		}
+
+		std::unordered_map<ZoneId, Zone> m_zones;
+	};
+}

--- a/engine/server/outdoorpvp/OutdoorPvPManagerTests.cpp
+++ b/engine/server/outdoorpvp/OutdoorPvPManagerTests.cpp
@@ -1,0 +1,85 @@
+#include "engine/server/outdoorpvp/OutdoorPvPManager.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::outdoorpvp::OutdoorPvPManager;
+	using engine::server::outdoorpvp::Zone;
+	using engine::server::outdoorpvp::Objective;
+
+	bool TestUnknown()
+	{
+		OutdoorPvPManager m;
+		if (m.BeginCapture(1, 1, 0)) return false;
+		if (m.TickCapture(1, 1, 50)) return false;
+		if (m.Score(1, 0) != 0) return false;
+		LOG_INFO(Core, "[OutdoorPvPTests] unknown zone OK");
+		return true;
+	}
+
+	bool TestCaptureFlow()
+	{
+		OutdoorPvPManager m;
+		Zone z;
+		z.id = 10;
+		z.objectives.push_back(Objective{1, 0xFF, 0, 0xFF});
+		m.RegisterZone(z);
+
+		if (!m.BeginCapture(10, 1, 0)) return false;     // Alliance commence
+		if (m.TickCapture(10, 1, 40)) return false;      // pas encore complet
+		if (m.TickCapture(10, 1, 30)) return false;      // total 70
+		if (!m.TickCapture(10, 1, 30)) return false;     // 100 -> capture terminee
+		if (m.Score(10, 0) != 1) return false;
+		LOG_INFO(Core, "[OutdoorPvPTests] capture flow OK");
+		return true;
+	}
+
+	bool TestSwitchFactionResets()
+	{
+		OutdoorPvPManager m;
+		Zone z;
+		z.id = 20;
+		z.objectives.push_back(Objective{2, 0xFF, 0, 0xFF});
+		m.RegisterZone(z);
+
+		m.BeginCapture(20, 2, 0);
+		m.TickCapture(20, 2, 60); // Alliance a 60
+		m.BeginCapture(20, 2, 1); // Horde reprend -> reset a 0
+		// Si pas reset, 60 + 50 = 110 -> capture immediate. Avec reset, 50 < 100.
+		if (m.TickCapture(20, 2, 50)) return false;
+		if (m.Score(20, 1) != 0) return false;
+		LOG_INFO(Core, "[OutdoorPvPTests] switch faction resets OK");
+		return true;
+	}
+
+	bool TestReset()
+	{
+		OutdoorPvPManager m;
+		Zone z;
+		z.id = 30;
+		z.objectives.push_back(Objective{3, 0xFF, 0, 0xFF});
+		m.RegisterZone(z);
+		m.BeginCapture(30, 3, 0);
+		m.TickCapture(30, 3, 100); // Alliance gagne, score=1
+		if (m.Score(30, 0) != 1) return false;
+		m.ResetZone(30);
+		if (m.Score(30, 0) != 0) return false;
+		LOG_INFO(Core, "[OutdoorPvPTests] reset OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestUnknown() && TestCaptureFlow() && TestSwitchFactionResets() && TestReset();
+	if (ok) LOG_INFO(Core, "[OutdoorPvPTests] ALL OK");
+	else LOG_ERROR(Core, "[OutdoorPvPTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.36 OutdoorPvP step 1

Header-only manager de zones contestees a objectifs (towers/captures) avec score par faction et reset hebdomadaire. Pas de wire/UI cote client a ce stade — c'est le scaffolding data structures + algo qui sera consomme par un dispatcher serveur (Phase 5.36b).

### Inclus
- engine/server/outdoorpvp/OutdoorPvPManager.h — Zone, Objective, BeginCapture, TickCapture, Score, ResetZone.
- engine/server/outdoorpvp/OutdoorPvPManagerTests.cpp — 4 tests : unknown zone, capture flow complet, switch faction reset capturePct, reset zone vide score.
- engine/server/CMakeLists.txt — test target outdoor_pvp_manager_tests.

### Test plan
- [x] Build Linux : outdoor_pvp_manager_tests compile et passe les 4 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only, pas de nouveau handler ni opcode ni migration DB).

Generated with Claude Code