### PR TITLE
feat(server/arena): ArenaTeam + ELO (Phase 5 CMANGOS.08 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.08 (Phase 5.08a) : ArenaTeam + ELO (header-only).
+  lcdlln_add_simple_test(arena_team_tests
+    arena/ArenaTeamTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/arena/ArenaTeam.h
+++ b/engine/server/arena/ArenaTeam.h
@@ -1,0 +1,91 @@
+#pragma once
+// CMANGOS.08 (Phase 5.08a) — ArenaTeam : equipe d'arene 2v2/3v3/5v5 avec
+// rating ELO + match history. Header-only.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+
+namespace engine::server::arena
+{
+	using TeamId    = uint32_t;
+	using ToonGuid  = uint64_t;
+
+	enum class TeamSize : uint8_t { v2 = 2, v3 = 3, v5 = 5 };
+
+	struct ArenaTeam
+	{
+		TeamId   id          = 0;
+		TeamSize size        = TeamSize::v2;
+		std::string name;
+		std::vector<ToonGuid> roster;
+		uint32_t rating       = 1500; ///< ELO de depart standard
+		uint32_t weeklyGames  = 0;
+		uint32_t weeklyWins   = 0;
+		uint32_t seasonGames  = 0;
+		uint32_t seasonWins   = 0;
+	};
+
+	/// Calcule la nouvelle paire de ratings ELO apres un match.
+	/// \param k        K-factor (typiquement 32 dans WoW arena)
+	/// \param winner   nouveau rating du gagnant (sortie)
+	/// \param loser    nouveau rating du perdant (sortie)
+	inline void ApplyEloUpdate(uint32_t winnerRating, uint32_t loserRating, uint32_t k,
+	                            uint32_t& winner, uint32_t& loser)
+	{
+		const double rW = static_cast<double>(winnerRating);
+		const double rL = static_cast<double>(loserRating);
+		const double expectedW = 1.0 / (1.0 + std::pow(10.0, (rL - rW) / 400.0));
+		const double expectedL = 1.0 - expectedW;
+		const double newW = rW + k * (1.0 - expectedW);
+		const double newL = rL + k * (0.0 - expectedL);
+		// Floor a 0 pour eviter underflow uint32 si match catastrophique.
+		winner = static_cast<uint32_t>(std::max(0.0, newW));
+		loser  = static_cast<uint32_t>(std::max(0.0, newL));
+	}
+
+	/// Registry simple en memoire pour tests/donnees seed.
+	class ArenaTeamRegistry
+	{
+	public:
+		void AddTeam(const ArenaTeam& t) { m_teams[t.id] = t; }
+		ArenaTeam* Get(TeamId id)
+		{
+			auto it = m_teams.find(id);
+			return (it == m_teams.end()) ? nullptr : &it->second;
+		}
+
+		/// Enregistre un match : met a jour ratings (ELO) + stats hebdo/saison.
+		/// Retourne true si les 2 equipes existent.
+		bool RecordMatch(TeamId winnerId, TeamId loserId, uint32_t k = 32)
+		{
+			auto* w = Get(winnerId);
+			auto* l = Get(loserId);
+			if (!w || !l) return false;
+			uint32_t newW, newL;
+			ApplyEloUpdate(w->rating, l->rating, k, newW, newL);
+			w->rating = newW;
+			l->rating = newL;
+			w->weeklyGames++; w->seasonGames++;
+			w->weeklyWins++;  w->seasonWins++;
+			l->weeklyGames++; l->seasonGames++;
+			return true;
+		}
+
+		/// Reset compteurs hebdo (lance le lundi serveur en theorie).
+		void ResetWeekly()
+		{
+			for (auto& [_, t] : m_teams)
+			{
+				t.weeklyGames = 0;
+				t.weeklyWins  = 0;
+			}
+		}
+
+	private:
+		std::unordered_map<TeamId, ArenaTeam> m_teams;
+	};
+}

--- a/engine/server/arena/ArenaTeamTests.cpp
+++ b/engine/server/arena/ArenaTeamTests.cpp
@@ -1,0 +1,90 @@
+#include "engine/server/arena/ArenaTeam.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::arena::ArenaTeam;
+	using engine::server::arena::ArenaTeamRegistry;
+	using engine::server::arena::TeamSize;
+	using engine::server::arena::ApplyEloUpdate;
+
+	bool TestEloEqual()
+	{
+		// Deux equipes a 1500. Gagnant +16, perdant -16 avec K=32.
+		uint32_t w, l;
+		ApplyEloUpdate(1500, 1500, 32, w, l);
+		if (w != 1516 || l != 1484) return false;
+		LOG_INFO(Core, "[ArenaTests] ELO equal OK");
+		return true;
+	}
+
+	bool TestEloFavoriteWins()
+	{
+		// 1700 bat 1300 : gagne tres peu (favori attendu).
+		uint32_t w, l;
+		ApplyEloUpdate(1700, 1300, 32, w, l);
+		// expected ~0.91, gain ~32*0.09 ~= 3
+		if (!(w >= 1701 && w <= 1706)) return false;
+		if (!(l >= 1294 && l <= 1299)) return false;
+		LOG_INFO(Core, "[ArenaTests] ELO favorite wins OK");
+		return true;
+	}
+
+	bool TestRecordMatch()
+	{
+		ArenaTeamRegistry r;
+		ArenaTeam a{1, TeamSize::v2, "A", {}, 1500, 0, 0, 0, 0};
+		ArenaTeam b{2, TeamSize::v2, "B", {}, 1500, 0, 0, 0, 0};
+		r.AddTeam(a);
+		r.AddTeam(b);
+		if (!r.RecordMatch(1, 2)) return false;
+		auto* aa = r.Get(1);
+		auto* bb = r.Get(2);
+		if (aa->rating != 1516) return false;
+		if (bb->rating != 1484) return false;
+		if (aa->seasonWins != 1 || aa->seasonGames != 1) return false;
+		if (bb->seasonWins != 0 || bb->seasonGames != 1) return false;
+		LOG_INFO(Core, "[ArenaTests] record match OK");
+		return true;
+	}
+
+	bool TestUnknownMatch()
+	{
+		ArenaTeamRegistry r;
+		if (r.RecordMatch(99, 100)) return false;
+		LOG_INFO(Core, "[ArenaTests] unknown match OK");
+		return true;
+	}
+
+	bool TestResetWeekly()
+	{
+		ArenaTeamRegistry r;
+		r.AddTeam(ArenaTeam{1, TeamSize::v3, "X", {}, 1500, 0, 0, 0, 0});
+		r.AddTeam(ArenaTeam{2, TeamSize::v3, "Y", {}, 1500, 0, 0, 0, 0});
+		r.RecordMatch(1, 2);
+		auto* x = r.Get(1);
+		if (x->weeklyGames != 1 || x->seasonGames != 1) return false;
+		r.ResetWeekly();
+		x = r.Get(1);
+		if (x->weeklyGames != 0) return false;
+		if (x->seasonGames != 1) return false; // saison preservee
+		LOG_INFO(Core, "[ArenaTests] reset weekly OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEloEqual() && TestEloFavoriteWins() && TestRecordMatch()
+	             && TestUnknownMatch() && TestResetWeekly();
+	if (ok) LOG_INFO(Core, "[ArenaTests] ALL OK");
+	else LOG_ERROR(Core, "[ArenaTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.08 Arena step 1

Header-only ArenaTeam (2v2/3v3/5v5) avec rating ELO classique (base 1500, K=32) + registry in-memory. Pas encore de matchmaking ni wire client.

### Inclus
- engine/server/arena/ArenaTeam.h — TeamSize, ArenaTeam, ApplyEloUpdate, ArenaTeamRegistry::RecordMatch + ResetWeekly.
- engine/server/arena/ArenaTeamTests.cpp — 5 tests (ELO egal ±16, favori gagne peu, RecordMatch stats, match equipe inconnue rejete, reset hebdo preserve saison).
- engine/server/CMakeLists.txt — test target arena_team_tests.

### Test plan
- [x] Build Linux : arena_team_tests compile et passe les 5 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only, pas de migration DB ni nouveau handler).

Generated with Claude Code