### PR TITLE
feat(server/playerbot): PlayerBotProfile (Phase 5 CMANGOS.38 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.38 (Phase 5.38a) : PlayerBotProfile (header-only).
+  lcdlln_add_simple_test(player_bot_profile_tests
+    playerbot/PlayerBotProfileTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/playerbot/PlayerBotProfile.h
+++ b/engine/server/playerbot/PlayerBotProfile.h
@@ -1,0 +1,70 @@
+#pragma once
+// CMANGOS.38 (Phase 5.38a) — PlayerBotProfile : profil de bot (classe, role,
+// AI tier, equipement seed) + scheduler de spawn pour repeupler les zones
+// peu peuplees. Header-only.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::playerbot
+{
+	using BotId = uint64_t;
+
+	enum class BotClass : uint8_t
+	{
+		Warrior = 0, Paladin, Hunter, Rogue, Priest, Shaman, Mage, Warlock, Druid
+	};
+
+	enum class BotRole : uint8_t { Tank, Heal, MeleeDps, RangedDps };
+
+	/// Profil statique d'un bot. Sert de seed pour la generation runtime.
+	struct PlayerBotProfile
+	{
+		BotId    id        = 0;
+		std::string name;
+		BotClass cls       = BotClass::Warrior;
+		BotRole  role      = BotRole::MeleeDps;
+		uint8_t  level     = 1;
+		uint16_t aiTier    = 0;     ///< 0 = naif, 1 = standard, 2 = avance
+		uint32_t zoneId    = 0;     ///< zone preferee de spawn
+	};
+
+	/// Scheduler simple : retourne les bots qui doivent spawn pour atteindre
+	/// la densite cible d'une zone. Politique deterministe pour tests.
+	class PlayerBotScheduler
+	{
+	public:
+		void RegisterBot(const PlayerBotProfile& p) { m_bots[p.id] = p; }
+
+		/// Selectionne jusqu'a \p needed bots dans la zone \p zoneId qui ne sont
+		/// pas dans \p alreadySpawned. Retourne les ids dans l'ordre d'insertion
+		/// (deterministe).
+		std::vector<BotId> Pick(uint32_t zoneId, size_t needed,
+		                         const std::vector<BotId>& alreadySpawned) const
+		{
+			std::vector<BotId> out;
+			for (const auto& [id, p] : m_bots)
+			{
+				if (out.size() >= needed) break;
+				if (p.zoneId != zoneId) continue;
+				bool already = false;
+				for (auto s : alreadySpawned) if (s == id) { already = true; break; }
+				if (already) continue;
+				out.push_back(id);
+			}
+			return out;
+		}
+
+		size_t BotCount() const { return m_bots.size(); }
+		const PlayerBotProfile* Get(BotId id) const
+		{
+			auto it = m_bots.find(id);
+			return (it == m_bots.end()) ? nullptr : &it->second;
+		}
+
+	private:
+		std::unordered_map<BotId, PlayerBotProfile> m_bots;
+	};
+}

--- a/engine/server/playerbot/PlayerBotProfileTests.cpp
+++ b/engine/server/playerbot/PlayerBotProfileTests.cpp
@@ -1,0 +1,83 @@
+#include "engine/server/playerbot/PlayerBotProfile.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::playerbot;
+
+	bool TestEmpty()
+	{
+		PlayerBotScheduler s;
+		auto picks = s.Pick(1, 5, {});
+		if (!picks.empty()) return false;
+		LOG_INFO(Core, "[PlayerBotTests] empty OK");
+		return true;
+	}
+
+	bool TestPickByZone()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({1, "Aerith", BotClass::Mage,    BotRole::RangedDps, 60, 1, 100});
+		s.RegisterBot({2, "Bork",   BotClass::Warrior, BotRole::Tank,      60, 1, 100});
+		s.RegisterBot({3, "Cael",   BotClass::Druid,   BotRole::Heal,      60, 1, 200});
+
+		auto picks = s.Pick(100, 10, {});
+		if (picks.size() != 2) return false; // seulement 2 dans zone 100
+		LOG_INFO(Core, "[PlayerBotTests] pick by zone OK");
+		return true;
+	}
+
+	bool TestExcludeSpawned()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({1, "A", BotClass::Mage,    BotRole::RangedDps, 60, 1, 100});
+		s.RegisterBot({2, "B", BotClass::Warrior, BotRole::Tank,      60, 1, 100});
+		s.RegisterBot({3, "C", BotClass::Priest,  BotRole::Heal,      60, 1, 100});
+
+		auto picks = s.Pick(100, 10, {1, 2});
+		if (picks.size() != 1) return false;
+		if (picks[0] != 3) return false;
+		LOG_INFO(Core, "[PlayerBotTests] exclude spawned OK");
+		return true;
+	}
+
+	bool TestNeededLimit()
+	{
+		PlayerBotScheduler s;
+		for (BotId i = 1; i <= 5; ++i)
+			s.RegisterBot({i, "Bot", BotClass::Warrior, BotRole::MeleeDps, 60, 1, 100});
+
+		auto picks = s.Pick(100, 2, {});
+		if (picks.size() != 2) return false;
+		LOG_INFO(Core, "[PlayerBotTests] needed limit OK");
+		return true;
+	}
+
+	bool TestGet()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({42, "Hero", BotClass::Paladin, BotRole::Tank, 70, 2, 300});
+		auto* p = s.Get(42);
+		if (!p) return false;
+		if (p->level != 70 || p->aiTier != 2) return false;
+		if (s.Get(99)) return false;
+		LOG_INFO(Core, "[PlayerBotTests] Get OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestPickByZone() && TestExcludeSpawned()
+	             && TestNeededLimit() && TestGet();
+	if (ok) LOG_INFO(Core, "[PlayerBotTests] ALL OK");
+	else LOG_ERROR(Core, "[PlayerBotTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.38 PlayerBot step 1

Header-only PlayerBotProfile (classe, role, AI tier, zone) + scheduler de spawn deterministe pour repeupler les zones peu peuplees.

### Inclus
- engine/server/playerbot/PlayerBotProfile.h — BotClass, BotRole, PlayerBotProfile, PlayerBotScheduler::Pick.
- engine/server/playerbot/PlayerBotProfileTests.cpp — 5 tests (empty, pick by zone, exclude spawned, needed limit, Get).
- engine/server/CMakeLists.txt — test target player_bot_profile_tests.

### Test plan
- [x] Build Linux : player_bot_profile_tests compile et passe les 5 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code