### PR TITLE
feat(server/util): ServerUtil (Phase 5 CMANGOS.41 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.41 (Phase 5.41a) : ServerUtil (header-only).
+  lcdlln_add_simple_test(server_util_tests
+    util/ServerUtilTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/util/ServerUtil.h
+++ b/engine/server/util/ServerUtil.h
@@ -1,0 +1,82 @@
+#pragma once
+// CMANGOS.41 (Phase 5.41a) — ServerUtil : utilitaires serveur reutilisables
+// (random deterministe, parse helpers, time helpers). Header-only.
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <optional>
+
+namespace engine::server::util
+{
+	/// Generateur deterministe (Mersenne Twister) pour seedable random.
+	/// Utile pour tests reproductibles et loot/spawn deterministes.
+	class DeterministicRng
+	{
+	public:
+		explicit DeterministicRng(uint64_t seed) : m_rng(seed) {}
+
+		/// Entier uniforme dans [lo, hi] inclus.
+		int32_t IntRange(int32_t lo, int32_t hi)
+		{
+			std::uniform_int_distribution<int32_t> d(lo, hi);
+			return d(m_rng);
+		}
+
+		/// Float uniforme dans [0, 1).
+		float Unit() { std::uniform_real_distribution<float> d(0.0f, 1.0f); return d(m_rng); }
+
+		/// Retourne true avec probabilite p (0..1).
+		bool Chance(float p) { return Unit() < p; }
+
+	private:
+		std::mt19937_64 m_rng;
+	};
+
+	/// Split d'une chaine sur un separateur. Tokens vides preserves.
+	inline std::vector<std::string_view> Split(std::string_view s, char sep)
+	{
+		std::vector<std::string_view> out;
+		size_t start = 0;
+		for (size_t i = 0; i < s.size(); ++i)
+		{
+			if (s[i] == sep)
+			{
+				out.push_back(s.substr(start, i - start));
+				start = i + 1;
+			}
+		}
+		out.push_back(s.substr(start));
+		return out;
+	}
+
+	/// Parse un entier non signe simple. Retourne nullopt si invalide.
+	inline std::optional<uint64_t> ParseU64(std::string_view s)
+	{
+		if (s.empty()) return std::nullopt;
+		uint64_t v = 0;
+		for (char c : s)
+		{
+			if (c < '0' || c > '9') return std::nullopt;
+			v = v * 10 + static_cast<uint64_t>(c - '0');
+		}
+		return v;
+	}
+
+	/// Format duree ms -> "HH:MM:SS" (depasse 24h, format reste 99:59:59 max).
+	inline std::string FormatDurationMs(uint64_t ms)
+	{
+		uint64_t s = ms / 1000;
+		uint64_t h = s / 3600; s %= 3600;
+		uint64_t m = s / 60;   s %= 60;
+		if (h > 99) h = 99;
+		char buf[16];
+		std::snprintf(buf, sizeof(buf), "%02llu:%02llu:%02llu",
+		              static_cast<unsigned long long>(h),
+		              static_cast<unsigned long long>(m),
+		              static_cast<unsigned long long>(s));
+		return std::string(buf);
+	}
+}

--- a/engine/server/util/ServerUtilTests.cpp
+++ b/engine/server/util/ServerUtilTests.cpp
@@ -1,0 +1,83 @@
+#include "engine/server/util/ServerUtil.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::util;
+
+	bool TestDeterministicSeed()
+	{
+		DeterministicRng a(42);
+		DeterministicRng b(42);
+		for (int i = 0; i < 50; ++i)
+			if (a.IntRange(0, 1000) != b.IntRange(0, 1000)) return false;
+		LOG_INFO(Core, "[UtilTests] deterministic RNG OK");
+		return true;
+	}
+
+	bool TestUnitRange()
+	{
+		DeterministicRng r(7);
+		for (int i = 0; i < 100; ++i)
+		{
+			float u = r.Unit();
+			if (u < 0.0f || u >= 1.0f) return false;
+		}
+		LOG_INFO(Core, "[UtilTests] unit range OK");
+		return true;
+	}
+
+	bool TestSplit()
+	{
+		auto v = Split("a,b,c", ',');
+		if (v.size() != 3) return false;
+		if (v[0] != "a" || v[1] != "b" || v[2] != "c") return false;
+
+		auto v2 = Split(",a,", ',');
+		if (v2.size() != 3) return false;
+		if (!v2[0].empty()) return false;
+		if (v2[1] != "a") return false;
+		if (!v2[2].empty()) return false;
+		LOG_INFO(Core, "[UtilTests] split OK");
+		return true;
+	}
+
+	bool TestParseU64()
+	{
+		auto a = ParseU64("12345");
+		if (!a || *a != 12345) return false;
+		auto b = ParseU64("0");
+		if (!b || *b != 0) return false;
+		if (ParseU64("").has_value()) return false;
+		if (ParseU64("12a3").has_value()) return false;
+		if (ParseU64("-1").has_value()) return false;
+		LOG_INFO(Core, "[UtilTests] parse u64 OK");
+		return true;
+	}
+
+	bool TestFormatDuration()
+	{
+		if (FormatDurationMs(0) != "00:00:00") return false;
+		if (FormatDurationMs(1500) != "00:00:01") return false;
+		if (FormatDurationMs(60'000) != "00:01:00") return false;
+		if (FormatDurationMs(3'661'000) != "01:01:01") return false;
+		LOG_INFO(Core, "[UtilTests] format duration OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestDeterministicSeed() && TestUnitRange() && TestSplit()
+	             && TestParseU64() && TestFormatDuration();
+	if (ok) LOG_INFO(Core, "[UtilTests] ALL OK");
+	else LOG_ERROR(Core, "[UtilTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.41 Util step 1

Header-only ServerUtil : DeterministicRng (mt19937_64 seedable), Split, ParseU64, FormatDurationMs. Briques utilitaires reutilisables par les autres tickets serveur.

### Inclus
- engine/server/util/ServerUtil.h — DeterministicRng, Split, ParseU64, FormatDurationMs.
- engine/server/util/ServerUtilTests.cpp — 5 tests (deterministic seed, unit range, split, parse u64, format duration).
- engine/server/CMakeLists.txt — test target server_util_tests.

### Test plan
- [x] Build Linux : server_util_tests compile et passe les 5 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code