### PR TITLE
feat(server/metric): MetricRegistry (Phase 4 CMANGOS.34 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
+  lcdlln_add_simple_test(metric_registry_tests
+    metric/MetricRegistryTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/metric/MetricRegistry.h
+++ b/engine/server/metric/MetricRegistry.h
@@ -1,0 +1,93 @@
+#pragma once
+// CMANGOS.34 (Phase 4.34a) — MetricRegistry : compteurs et histogrammes
+// internes (ticks/sec, queries/sec, AI updates/sec) pour observabilite.
+// Header-only. Differe de PrometheusMetrics (deja present) en exposant un
+// registry generic interrogeable a tout instant pour debug/admin.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+
+namespace engine::server::metric
+{
+	/// Compteur monotone (incremente uniquement). Sert a quantifier les
+	/// evenements cumules.
+	struct Counter
+	{
+		uint64_t value = 0;
+		void Inc(uint64_t n = 1) { value += n; }
+	};
+
+	/// Gauge : valeur instantanee (peut monter ou descendre). Sessions actives,
+	/// memoire residente, etc.
+	struct Gauge
+	{
+		int64_t value = 0;
+		void Set(int64_t v) { value = v; }
+		void Add(int64_t d) { value += d; }
+	};
+
+	/// Histogramme simple (buckets fixes, fournis a la creation). Pour
+	/// distribution de latence, taille de paquet, etc.
+	struct Histogram
+	{
+		std::vector<uint64_t> bounds;     ///< borne sup inclusive de chaque bucket
+		std::vector<uint64_t> bucketCount;///< meme taille que bounds + 1 (overflow)
+		uint64_t totalCount = 0;
+		double   sum        = 0.0;
+
+		void Observe(double v)
+		{
+			totalCount++;
+			sum += v;
+			for (size_t i = 0; i < bounds.size(); ++i)
+			{
+				if (v <= static_cast<double>(bounds[i]))
+				{
+					bucketCount[i]++;
+					return;
+				}
+			}
+			bucketCount.back()++;
+		}
+
+		double Mean() const
+		{
+			return totalCount ? sum / static_cast<double>(totalCount) : 0.0;
+		}
+	};
+
+	class MetricRegistry
+	{
+	public:
+		Counter& GetCounter(const std::string& name) { return m_counters[name]; }
+		Gauge&   GetGauge(const std::string& name)   { return m_gauges[name]; }
+
+		Histogram& CreateHistogram(const std::string& name, std::vector<uint64_t> bounds)
+		{
+			auto& h = m_histograms[name];
+			h.bounds = std::move(bounds);
+			h.bucketCount.assign(h.bounds.size() + 1, 0);
+			h.totalCount = 0;
+			h.sum = 0.0;
+			return h;
+		}
+
+		Histogram* GetHistogram(const std::string& name)
+		{
+			auto it = m_histograms.find(name);
+			return (it == m_histograms.end()) ? nullptr : &it->second;
+		}
+
+		size_t CounterCount() const   { return m_counters.size(); }
+		size_t GaugeCount() const     { return m_gauges.size(); }
+		size_t HistogramCount() const { return m_histograms.size(); }
+
+	private:
+		std::unordered_map<std::string, Counter>   m_counters;
+		std::unordered_map<std::string, Gauge>     m_gauges;
+		std::unordered_map<std::string, Histogram> m_histograms;
+	};
+}

--- a/engine/server/metric/MetricRegistryTests.cpp
+++ b/engine/server/metric/MetricRegistryTests.cpp
@@ -1,0 +1,81 @@
+#include "engine/server/metric/MetricRegistry.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::metric;
+
+	bool TestCounter()
+	{
+		MetricRegistry r;
+		auto& c = r.GetCounter("ticks");
+		c.Inc();
+		c.Inc(5);
+		if (c.value != 6) return false;
+		// meme nom retourne meme compteur
+		auto& c2 = r.GetCounter("ticks");
+		if (c2.value != 6) return false;
+		LOG_INFO(Core, "[MetricTests] counter OK");
+		return true;
+	}
+
+	bool TestGauge()
+	{
+		MetricRegistry r;
+		auto& g = r.GetGauge("sessions");
+		g.Set(10);
+		g.Add(-3);
+		if (g.value != 7) return false;
+		LOG_INFO(Core, "[MetricTests] gauge OK");
+		return true;
+	}
+
+	bool TestHistogramBuckets()
+	{
+		MetricRegistry r;
+		auto& h = r.CreateHistogram("lat_ms", {10, 50, 100, 500});
+		h.Observe(5);   // bucket 0
+		h.Observe(10);  // bucket 0 (inclusif)
+		h.Observe(30);  // bucket 1
+		h.Observe(200); // bucket 3
+		h.Observe(1000);// overflow bucket
+		if (h.totalCount != 5) return false;
+		if (h.bucketCount.size() != 5) return false;
+		if (h.bucketCount[0] != 2) return false;
+		if (h.bucketCount[1] != 1) return false;
+		if (h.bucketCount[2] != 0) return false;
+		if (h.bucketCount[3] != 1) return false;
+		if (h.bucketCount[4] != 1) return false; // overflow
+		// mean = (5+10+30+200+1000)/5 = 249
+		if (h.Mean() < 248.5 || h.Mean() > 249.5) return false;
+		LOG_INFO(Core, "[MetricTests] histogram buckets OK");
+		return true;
+	}
+
+	bool TestRegistrySize()
+	{
+		MetricRegistry r;
+		r.GetCounter("a"); r.GetCounter("b");
+		r.GetGauge("g");
+		r.CreateHistogram("h", {1, 2});
+		if (r.CounterCount() != 2 || r.GaugeCount() != 1 || r.HistogramCount() != 1)
+			return false;
+		LOG_INFO(Core, "[MetricTests] registry size OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestCounter() && TestGauge() && TestHistogramBuckets() && TestRegistrySize();
+	if (ok) LOG_INFO(Core, "[MetricTests] ALL OK");
+	else LOG_ERROR(Core, "[MetricTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.34 Metric step 1

Header-only MetricRegistry : Counter / Gauge / Histogram avec buckets fixes. Registry interrogeable a tout instant pour debug/admin (complementaire a PrometheusMetrics qui ne fait que l'export).

### Inclus
- engine/server/metric/MetricRegistry.h — Counter (Inc), Gauge (Set/Add), Histogram (Observe/Mean).
- engine/server/metric/MetricRegistryTests.cpp — 4 tests (counter cumulatif, gauge set/add, histogram buckets/overflow/mean, registry size).
- engine/server/CMakeLists.txt — test target metric_registry_tests.

### Test plan
- [x] Build Linux : metric_registry_tests compile et passe les 4 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code