### PR TITLE
feat(server/messager): Messager MPSC (Phase 4 CMANGOS.35 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.35 (Phase 4.35a) : Messager MPSC (header-only).
+  lcdlln_add_simple_test(messager_tests
+    messager/MessagerTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/messager/Messager.h
+++ b/engine/server/messager/Messager.h
@@ -1,0 +1,51 @@
+#pragma once
+// CMANGOS.35 (Phase 4.35a) — Messager : queue MPSC simple (multi producer
+// single consumer) pour passer des messages entre threads sans verrou par
+// message dans le hot path. Header-only, std::mutex (pas de lock-free).
+//
+// Usage typique : workers async (DB, AI tick, scripts) postent des messages,
+// le main game loop draine la queue 1x par tick.
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+#include <utility>
+
+namespace engine::server::messager
+{
+	template<typename T>
+	class Messager
+	{
+	public:
+		void Post(T msg)
+		{
+			std::lock_guard<std::mutex> lk(m_mtx);
+			m_queue.push_back(std::move(msg));
+		}
+
+		/// Vide la queue dans \p out. Retourne le nombre de messages drainees.
+		/// \p out est append-only (les anciens elements sont conserves).
+		size_t Drain(std::vector<T>& out)
+		{
+			std::vector<T> tmp;
+			{
+				std::lock_guard<std::mutex> lk(m_mtx);
+				tmp.swap(m_queue);
+			}
+			out.insert(out.end(),
+			           std::make_move_iterator(tmp.begin()),
+			           std::make_move_iterator(tmp.end()));
+			return tmp.size();
+		}
+
+		size_t Size() const
+		{
+			std::lock_guard<std::mutex> lk(m_mtx);
+			return m_queue.size();
+		}
+
+	private:
+		mutable std::mutex m_mtx;
+		std::vector<T>     m_queue;
+	};
+}

--- a/engine/server/messager/MessagerTests.cpp
+++ b/engine/server/messager/MessagerTests.cpp
@@ -1,0 +1,82 @@
+#include "engine/server/messager/Messager.h"
+#include "engine/core/Log.h"
+
+#include <thread>
+#include <atomic>
+#include <vector>
+
+namespace
+{
+	using engine::server::messager::Messager;
+
+	bool TestSingleThreaded()
+	{
+		Messager<int> m;
+		m.Post(1);
+		m.Post(2);
+		m.Post(3);
+		if (m.Size() != 3) return false;
+
+		std::vector<int> drained;
+		auto n = m.Drain(drained);
+		if (n != 3 || drained.size() != 3) return false;
+		if (drained[0] != 1 || drained[1] != 2 || drained[2] != 3) return false;
+		if (m.Size() != 0) return false;
+
+		std::vector<int> drained2;
+		if (m.Drain(drained2) != 0) return false;
+		LOG_INFO(Core, "[MessagerTests] single thread OK");
+		return true;
+	}
+
+	bool TestMultiProducer()
+	{
+		Messager<uint64_t> m;
+		const int producers = 4;
+		const int perProducer = 1000;
+
+		std::vector<std::thread> threads;
+		for (int p = 0; p < producers; ++p)
+		{
+			threads.emplace_back([&m, p]() {
+				for (int i = 0; i < perProducer; ++i)
+					m.Post(static_cast<uint64_t>(p) * 100000 + i);
+			});
+		}
+		for (auto& t : threads) t.join();
+
+		std::vector<uint64_t> drained;
+		m.Drain(drained);
+		if (drained.size() != static_cast<size_t>(producers * perProducer)) return false;
+		LOG_INFO(Core, "[MessagerTests] multi producer OK");
+		return true;
+	}
+
+	bool TestMoveOnly()
+	{
+		Messager<std::vector<int>> m;
+		std::vector<int> v = {1, 2, 3};
+		m.Post(std::move(v));
+		std::vector<std::vector<int>> drained;
+		m.Drain(drained);
+		if (drained.size() != 1) return false;
+		if (drained[0].size() != 3) return false;
+		LOG_INFO(Core, "[MessagerTests] move-only payload OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestSingleThreaded() && TestMultiProducer() && TestMoveOnly();
+	if (ok) LOG_INFO(Core, "[MessagerTests] ALL OK");
+	else LOG_ERROR(Core, "[MessagerTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.35 Multithreading Messager step 1

Header-only queue MPSC mutex-based pour passer des messages entre threads (pattern CMANGOS standard) : workers async postent, main loop draine 1x/tick.

### Inclus
- engine/server/messager/Messager.h — Messager<T>::Post/Drain/Size, swap-based drain (move-only friendly).
- engine/server/messager/MessagerTests.cpp — 3 tests (single-thread post/drain/empty, 4 producers x 1000 messages concurrent, payload move-only std::vector).
- engine/server/CMakeLists.txt — test target messager_tests.

### Test plan
- [x] Build Linux : messager_tests compile et passe les 3 cas (multi-thread inclus).
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code