### PR TITLE
feat(server/battleground): BattleGroundQueue (Phase 4 CMANGOS.10 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.10 (Phase 4.10a) : BattleGroundQueue (header-only).
+  lcdlln_add_simple_test(battle_ground_queue_tests
+    battleground/BattleGroundQueueTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/battleground/BattleGroundQueue.h
+++ b/engine/server/battleground/BattleGroundQueue.h
@@ -1,0 +1,85 @@
+#pragma once
+// CMANGOS.10 (Phase 4.10a) — BattleGroundQueue : matchmaking de file
+// d'attente PvP instancie (BG type, taille equipe, faction-balanced).
+// Header-only.
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::battleground
+{
+	using BgType    = uint16_t;
+	using PlayerId  = uint64_t;
+	using FactionId = uint8_t;  ///< 0 = Alliance, 1 = Horde
+
+	struct QueueEntry
+	{
+		PlayerId  player = 0;
+		FactionId fac    = 0;
+		uint64_t  enqueueMs = 0;
+	};
+
+	struct MatchProposal
+	{
+		BgType                     bg;
+		std::vector<PlayerId>      alliance;
+		std::vector<PlayerId>      horde;
+	};
+
+	/// Queue par bg type. Politique : equipes equilibrees par faction,
+	/// FIFO sur l'ordre d'arrivee.
+	class BattleGroundQueue
+	{
+	public:
+		void Enqueue(BgType bg, PlayerId p, FactionId fac, uint64_t nowMs)
+		{
+			m_queues[bg].push_back({p, fac, nowMs});
+		}
+
+		size_t Size(BgType bg) const
+		{
+			auto it = m_queues.find(bg);
+			return (it == m_queues.end()) ? 0 : it->second.size();
+		}
+
+		/// Tente de former un match avec \p teamSize joueurs par cote.
+		/// Retourne nullopt si pas assez de candidats par faction.
+		/// Retire les joueurs selectionnes de la queue.
+		std::optional<MatchProposal> TryMakeMatch(BgType bg, size_t teamSize)
+		{
+			auto it = m_queues.find(bg);
+			if (it == m_queues.end()) return std::nullopt;
+
+			std::vector<size_t> aIdx, hIdx;
+			auto& q = it->second;
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].fac == 0 && aIdx.size() < teamSize) aIdx.push_back(i);
+				else if (q[i].fac == 1 && hIdx.size() < teamSize) hIdx.push_back(i);
+				if (aIdx.size() == teamSize && hIdx.size() == teamSize) break;
+			}
+			if (aIdx.size() != teamSize || hIdx.size() != teamSize) return std::nullopt;
+
+			MatchProposal p;
+			p.bg = bg;
+			for (auto i : aIdx) p.alliance.push_back(q[i].player);
+			for (auto i : hIdx) p.horde.push_back(q[i].player);
+
+			// Retire en ordre decroissant pour preserver les indices.
+			std::vector<size_t> all;
+			all.insert(all.end(), aIdx.begin(), aIdx.end());
+			all.insert(all.end(), hIdx.begin(), hIdx.end());
+			std::sort(all.begin(), all.end(), std::greater<size_t>());
+			for (auto i : all) q.erase(q.begin() + i);
+
+			return p;
+		}
+
+	private:
+		std::unordered_map<BgType, std::vector<QueueEntry>> m_queues;
+	};
+}

--- a/engine/server/battleground/BattleGroundQueueTests.cpp
+++ b/engine/server/battleground/BattleGroundQueueTests.cpp
@@ -1,0 +1,75 @@
+#include "engine/server/battleground/BattleGroundQueue.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::battleground;
+
+	bool TestEmpty()
+	{
+		BattleGroundQueue q;
+		if (q.Size(1) != 0) return false;
+		auto m = q.TryMakeMatch(1, 5);
+		if (m.has_value()) return false;
+		LOG_INFO(Core, "[BgQueueTests] empty OK");
+		return true;
+	}
+
+	bool TestImbalanced()
+	{
+		BattleGroundQueue q;
+		// 4 alliance, 0 horde => pas de match
+		for (int i = 0; i < 4; ++i) q.Enqueue(1, 100 + i, 0, 1000 + i);
+		auto m = q.TryMakeMatch(1, 2);
+		if (m.has_value()) return false;
+		if (q.Size(1) != 4) return false;
+		LOG_INFO(Core, "[BgQueueTests] imbalanced rejected OK");
+		return true;
+	}
+
+	bool TestMatch5v5()
+	{
+		BattleGroundQueue q;
+		// 7 alliance + 6 horde => peut former 5v5, restent 2A + 1H
+		for (int i = 0; i < 7; ++i) q.Enqueue(2, 100 + i, 0, 1000 + i);
+		for (int i = 0; i < 6; ++i) q.Enqueue(2, 200 + i, 1, 2000 + i);
+		auto m = q.TryMakeMatch(2, 5);
+		if (!m) return false;
+		if (m->alliance.size() != 5 || m->horde.size() != 5) return false;
+		// FIFO : alliance picks should be 100..104
+		if (m->alliance[0] != 100 || m->alliance[4] != 104) return false;
+		if (m->horde[0]    != 200 || m->horde[4]    != 204) return false;
+		// Restent 2 alliance + 1 horde
+		if (q.Size(2) != 3) return false;
+		LOG_INFO(Core, "[BgQueueTests] match 5v5 OK");
+		return true;
+	}
+
+	bool TestExactSize()
+	{
+		BattleGroundQueue q;
+		q.Enqueue(3, 1, 0, 100);
+		q.Enqueue(3, 2, 1, 101);
+		auto m = q.TryMakeMatch(3, 1);
+		if (!m) return false;
+		if (m->alliance.size() != 1 || m->horde.size() != 1) return false;
+		if (q.Size(3) != 0) return false;
+		LOG_INFO(Core, "[BgQueueTests] exact size OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestImbalanced() && TestMatch5v5() && TestExactSize();
+	if (ok) LOG_INFO(Core, "[BgQueueTests] ALL OK");
+	else LOG_ERROR(Core, "[BgQueueTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.10 BattleGround step 1

Header-only BattleGroundQueue : queue de matchmaking PvP instancie, FIFO par bg type + faction-balanced. Pas de plomberie de spawn instance — c'est le selecteur d'equipes.

### Inclus
- engine/server/battleground/BattleGroundQueue.h — Enqueue, Size, TryMakeMatch (retire les joueurs selectionnes).
- engine/server/battleground/BattleGroundQueueTests.cpp — 4 tests (vide, imbalanced rejetee, 5v5 avec restes, match exact 1v1).
- engine/server/CMakeLists.txt — test target battle_ground_queue_tests.

### Test plan
- [x] Build Linux : battle_ground_queue_tests compile et passe les 4 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code