### PR TITLE
feat(server/trade): TradeSession FSM (Phase 4 CMANGOS.27 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.27 (Phase 4.27a) : TradeSession FSM (header-only).
+  lcdlln_add_simple_test(trade_session_tests
+    trade/TradeSessionTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/trade/TradeSession.h
+++ b/engine/server/trade/TradeSession.h
@@ -1,0 +1,112 @@
+#pragma once
+// CMANGOS.27 (Phase 4.27a) — TradeSession : echange direct entre 2 joueurs
+// avec gates de confirmation (offer -> lock -> mutual confirm -> commit).
+// Header-only. Ne touche pas a l'inventaire reel : retourne le delta validee
+// au caller pour application atomique cote shard.
+
+#include <cstdint>
+#include <vector>
+#include <utility>
+
+namespace engine::server::trade
+{
+	using PlayerId = uint64_t;
+	using ItemGuid = uint64_t;
+
+	enum class TradeState : uint8_t
+	{
+		Open,        ///< les 2 joueurs editent l'offer
+		LockedA,     ///< A a verrouille, B peut encore editer
+		LockedB,     ///< B a verrouille, A peut encore editer
+		BothLocked,  ///< les 2 ont verrouille, en attente de confirmation
+		Committed,   ///< echange execute (etat terminal)
+		Cancelled    ///< un des deux a annule (etat terminal)
+	};
+
+	struct TradeOffer
+	{
+		std::vector<ItemGuid> items;
+		uint64_t              copper = 0;
+	};
+
+	class TradeSession
+	{
+	public:
+		TradeSession(PlayerId a, PlayerId b) : m_a(a), m_b(b) {}
+
+		PlayerId    PlayerA()  const { return m_a; }
+		PlayerId    PlayerB()  const { return m_b; }
+		TradeState  State()    const { return m_state; }
+		const TradeOffer& OfferA() const { return m_offerA; }
+		const TradeOffer& OfferB() const { return m_offerB; }
+
+		/// Edition d'offer (interdit si lock cote auteur ou etat terminal).
+		bool SetOffer(PlayerId who, TradeOffer o)
+		{
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			if (who == m_a)
+			{
+				if (m_state == TradeState::LockedA || m_state == TradeState::BothLocked)
+					return false;
+				m_offerA = std::move(o);
+				return true;
+			}
+			if (who == m_b)
+			{
+				if (m_state == TradeState::LockedB || m_state == TradeState::BothLocked)
+					return false;
+				m_offerB = std::move(o);
+				return true;
+			}
+			return false;
+		}
+
+		/// Lock cote \p who. Si les 2 sont locked passe a BothLocked.
+		bool Lock(PlayerId who)
+		{
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			if (who == m_a)
+			{
+				if (m_state == TradeState::Open)     m_state = TradeState::LockedA;
+				else if (m_state == TradeState::LockedB) m_state = TradeState::BothLocked;
+				else return false;
+				return true;
+			}
+			if (who == m_b)
+			{
+				if (m_state == TradeState::Open)     m_state = TradeState::LockedB;
+				else if (m_state == TradeState::LockedA) m_state = TradeState::BothLocked;
+				else return false;
+				return true;
+			}
+			return false;
+		}
+
+		/// Commit n'est valide qu'a partir de BothLocked.
+		bool Commit()
+		{
+			if (m_state != TradeState::BothLocked) return false;
+			m_state = TradeState::Committed;
+			return true;
+		}
+
+		/// Cancel possible a tout moment non-terminal.
+		bool Cancel(PlayerId who)
+		{
+			if (who != m_a && who != m_b) return false;
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			m_state = TradeState::Cancelled;
+			return true;
+		}
+
+	private:
+		PlayerId   m_a;
+		PlayerId   m_b;
+		TradeOffer m_offerA;
+		TradeOffer m_offerB;
+		TradeState m_state = TradeState::Open;
+	};
+}

--- a/engine/server/trade/TradeSessionTests.cpp
+++ b/engine/server/trade/TradeSessionTests.cpp
@@ -1,0 +1,92 @@
+#include "engine/server/trade/TradeSession.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::trade;
+
+	bool TestHappyPath()
+	{
+		TradeSession s(1, 2);
+		if (s.State() != TradeState::Open) return false;
+
+		TradeOffer oa; oa.items = {100, 101}; oa.copper = 50;
+		TradeOffer ob; ob.items = {200};
+		if (!s.SetOffer(1, oa)) return false;
+		if (!s.SetOffer(2, ob)) return false;
+
+		if (!s.Lock(1)) return false;  // -> LockedA
+		if (s.State() != TradeState::LockedA) return false;
+		if (!s.Lock(2)) return false;  // -> BothLocked
+		if (s.State() != TradeState::BothLocked) return false;
+
+		if (!s.Commit()) return false;
+		if (s.State() != TradeState::Committed) return false;
+		LOG_INFO(Core, "[TradeTests] happy path OK");
+		return true;
+	}
+
+	bool TestEditAfterLockRejected()
+	{
+		TradeSession s(1, 2);
+		s.Lock(1);
+		TradeOffer o; o.copper = 10;
+		if (s.SetOffer(1, o)) return false; // edition apres lock A interdit
+		// B peut toujours editer
+		if (!s.SetOffer(2, o)) return false;
+		LOG_INFO(Core, "[TradeTests] edit after lock rejected OK");
+		return true;
+	}
+
+	bool TestCommitBeforeBothLocked()
+	{
+		TradeSession s(1, 2);
+		if (s.Commit()) return false;
+		s.Lock(1);
+		if (s.Commit()) return false;
+		s.Lock(2);
+		if (!s.Commit()) return false;
+		LOG_INFO(Core, "[TradeTests] commit gate OK");
+		return true;
+	}
+
+	bool TestCancel()
+	{
+		TradeSession s(1, 2);
+		s.Lock(1);
+		if (!s.Cancel(2)) return false;
+		if (s.State() != TradeState::Cancelled) return false;
+		// no-op apres cancel
+		if (s.Lock(1)) return false;
+		if (s.Commit()) return false;
+		LOG_INFO(Core, "[TradeTests] cancel OK");
+		return true;
+	}
+
+	bool TestUnknownPlayer()
+	{
+		TradeSession s(1, 2);
+		TradeOffer o;
+		if (s.SetOffer(99, o)) return false;
+		if (s.Lock(99)) return false;
+		if (s.Cancel(99)) return false;
+		LOG_INFO(Core, "[TradeTests] unknown player rejected OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestHappyPath() && TestEditAfterLockRejected()
+	             && TestCommitBeforeBothLocked() && TestCancel() && TestUnknownPlayer();
+	if (ok) LOG_INFO(Core, "[TradeTests] ALL OK");
+	else LOG_ERROR(Core, "[TradeTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.27 Trade step 1

Header-only TradeSession : FSM echange direct P2P avec gates de confirmation (Open -> LockedA/LockedB -> BothLocked -> Committed/Cancelled). Distinct du TradeSystem.cpp existant qui couvre vendor/PNJ.

### Inclus
- engine/server/trade/TradeSession.h — TradeState, TradeOffer, SetOffer/Lock/Commit/Cancel.
- engine/server/trade/TradeSessionTests.cpp — 5 tests (happy path, edit apres lock rejete, commit avant BothLocked rejete, cancel + freeze, joueur inconnu).
- engine/server/CMakeLists.txt — test target trade_session_tests.

### Test plan
- [x] Build Linux : trade_session_tests compile et passe les 5 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only, FSM ne touche pas a l'inventaire ; le shard appliquera le delta atomiquement quand on cablera 27b).

Generated with Claude Code