### PR TITLE
feat(server/skills): SkillBook (Phase 4 CMANGOS.39 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.39 (Phase 4.39a) : SkillBook (header-only).
+  lcdlln_add_simple_test(skill_book_tests
+    skills/SkillBookTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/skills/SkillBook.h
+++ b/engine/server/skills/SkillBook.h
@@ -1,0 +1,73 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39a) — SkillBook : skills d'un personnage (cooking,
+// herbalism, mining, lockpicking, weapon skills) avec progression
+// jusqu'a un cap. Header-only.
+
+#include <cstdint>
+#include <unordered_map>
+#include <algorithm>
+
+namespace engine::server::skills
+{
+	using SkillId = uint16_t;
+
+	struct SkillEntry
+	{
+		uint16_t value = 0;  ///< niveau actuel
+		uint16_t cap   = 0;  ///< cap dur (max attribuable a ce moment)
+		uint16_t bonus = 0;  ///< bonus temporaire (potion, equipement)
+	};
+
+	class SkillBook
+	{
+	public:
+		void Set(SkillId id, uint16_t value, uint16_t cap)
+		{
+			auto& e = m_skills[id];
+			e.cap   = cap;
+			e.value = std::min(value, cap);
+		}
+
+		bool Has(SkillId id) const { return m_skills.count(id) > 0; }
+
+		const SkillEntry* Get(SkillId id) const
+		{
+			auto it = m_skills.find(id);
+			return (it == m_skills.end()) ? nullptr : &it->second;
+		}
+
+		/// Ajoute \p delta points au skill, clampe a cap. Retourne le delta
+		/// effectivement applique.
+		uint16_t Gain(SkillId id, uint16_t delta)
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return 0;
+			auto& e = it->second;
+			const uint16_t before = e.value;
+			const uint32_t after = std::min<uint32_t>(e.cap, static_cast<uint32_t>(e.value) + delta);
+			e.value = static_cast<uint16_t>(after);
+			return e.value - before;
+		}
+
+		void SetBonus(SkillId id, uint16_t bonus)
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return;
+			it->second.bonus = bonus;
+		}
+
+		/// Valeur effective = value + bonus (clamp a 0xFFFF par securite).
+		uint16_t Effective(SkillId id) const
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return 0;
+			const uint32_t e = static_cast<uint32_t>(it->second.value) + it->second.bonus;
+			return e > 0xFFFFu ? 0xFFFFu : static_cast<uint16_t>(e);
+		}
+
+		size_t Count() const { return m_skills.size(); }
+
+	private:
+		std::unordered_map<SkillId, SkillEntry> m_skills;
+	};
+}

--- a/engine/server/skills/SkillBookTests.cpp
+++ b/engine/server/skills/SkillBookTests.cpp
@@ -1,0 +1,72 @@
+#include "engine/server/skills/SkillBook.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::skills;
+
+	bool TestSetClampedToCap()
+	{
+		SkillBook b;
+		b.Set(1, 250, 150); // demande 250 mais cap a 150
+		auto* e = b.Get(1);
+		if (!e || e->value != 150 || e->cap != 150) return false;
+		LOG_INFO(Core, "[SkillTests] set clamped OK");
+		return true;
+	}
+
+	bool TestGain()
+	{
+		SkillBook b;
+		b.Set(2, 100, 200);
+		// gain 50 -> 150
+		if (b.Gain(2, 50) != 50) return false;
+		if (b.Get(2)->value != 150) return false;
+		// gain 100 -> clampe a 200, applique 50
+		if (b.Gain(2, 100) != 50) return false;
+		if (b.Get(2)->value != 200) return false;
+		// gain sur skill inconnu = 0
+		if (b.Gain(99, 10) != 0) return false;
+		LOG_INFO(Core, "[SkillTests] gain OK");
+		return true;
+	}
+
+	bool TestEffectiveWithBonus()
+	{
+		SkillBook b;
+		b.Set(3, 100, 300);
+		b.SetBonus(3, 25);
+		if (b.Effective(3) != 125) return false;
+		// skill inconnu : 0
+		if (b.Effective(99) != 0) return false;
+		LOG_INFO(Core, "[SkillTests] effective with bonus OK");
+		return true;
+	}
+
+	bool TestEffectiveOverflowSafe()
+	{
+		SkillBook b;
+		b.Set(4, 60000, 65000);
+		b.SetBonus(4, 60000);
+		// 60000 + 60000 = 120000 > 65535, clampe a 65535
+		if (b.Effective(4) != 0xFFFFu) return false;
+		LOG_INFO(Core, "[SkillTests] effective overflow safe OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestSetClampedToCap() && TestGain() && TestEffectiveWithBonus()
+	             && TestEffectiveOverflowSafe();
+	if (ok) LOG_INFO(Core, "[SkillTests] ALL OK");
+	else LOG_ERROR(Core, "[SkillTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.39 Skills step 1

Header-only SkillBook : skills d'un character (cooking, herbalism, mining, weapon skills) avec progression + bonus temporaire (potion/equipement).

### Inclus
- engine/server/skills/SkillBook.h — Set/Get/Has/Gain/SetBonus/Effective.
- engine/server/skills/SkillBookTests.cpp — 4 tests (set clampe a cap, gain clampe a cap, effective avec bonus, effective overflow safe).
- engine/server/CMakeLists.txt — test target skill_book_tests.

### Test plan
- [x] Build Linux : skill_book_tests compile et passe les 4 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code