### PR TITLE
feat(server/packetlog): PacketLog ring buffer (Phase 4 CMANGOS.12 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.12 (Phase 4.12a) : PacketLog ring buffer (header-only).
+  lcdlln_add_simple_test(packet_log_tests
+    packetlog/PacketLogTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/packetlog/PacketLog.h
+++ b/engine/server/packetlog/PacketLog.h
@@ -1,0 +1,86 @@
+#pragma once
+// CMANGOS.12 (Phase 4.12a) — PacketLog : ring buffer in-memory des derniers
+// paquets recus/envoyes par session, pour debug/post-mortem. Header-only.
+//
+// Usage : sur un crash ou un kick suspect, dump du PacketLog d'une session
+// dans le crash report. Volontairement simple : pas de fichier disque, pas
+// de filtrage runtime — c'est un buffer pour observation, pas de l'audit.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace engine::server::packetlog
+{
+	enum class Direction : uint8_t { In, Out };
+
+	struct Entry
+	{
+		uint64_t  tsMs    = 0;
+		uint16_t  opcode  = 0;
+		uint32_t  size    = 0;
+		Direction dir     = Direction::In;
+		// On conserve un prefix de payload (premieres N octets) pour debug
+		// sans peter la memoire. Reste tronque dans Push.
+		std::vector<uint8_t> prefix;
+	};
+
+	class PacketLog
+	{
+	public:
+		explicit PacketLog(size_t capacity = 256, size_t prefixBytes = 32)
+			: m_cap(capacity), m_prefixBytes(prefixBytes)
+		{
+			m_ring.reserve(capacity);
+		}
+
+		void Push(Direction dir, uint16_t opcode, uint64_t tsMs,
+		          const uint8_t* data, uint32_t size)
+		{
+			Entry e;
+			e.tsMs   = tsMs;
+			e.opcode = opcode;
+			e.size   = size;
+			e.dir    = dir;
+			const uint32_t take = (size < m_prefixBytes) ? size : static_cast<uint32_t>(m_prefixBytes);
+			e.prefix.assign(data, data + take);
+
+			if (m_ring.size() < m_cap)
+			{
+				m_ring.push_back(std::move(e));
+			}
+			else
+			{
+				m_ring[m_head] = std::move(e);
+			}
+			m_head = (m_head + 1) % m_cap;
+		}
+
+		size_t Size() const { return m_ring.size(); }
+		size_t Capacity() const { return m_cap; }
+
+		/// Snapshot dans l'ordre chronologique (du plus ancien au plus recent).
+		std::vector<Entry> Snapshot() const
+		{
+			std::vector<Entry> out;
+			out.reserve(m_ring.size());
+			if (m_ring.size() < m_cap)
+			{
+				out = m_ring;
+				return out;
+			}
+			// buffer plein : tete = oldest
+			for (size_t i = 0; i < m_ring.size(); ++i)
+			{
+				out.push_back(m_ring[(m_head + i) % m_cap]);
+			}
+			return out;
+		}
+
+	private:
+		size_t  m_cap;
+		size_t  m_prefixBytes;
+		size_t  m_head = 0;     ///< prochain slot a ecrire (et donc oldest si plein)
+		std::vector<Entry> m_ring;
+	};
+}

--- a/engine/server/packetlog/PacketLogTests.cpp
+++ b/engine/server/packetlog/PacketLogTests.cpp
@@ -1,0 +1,67 @@
+#include "engine/server/packetlog/PacketLog.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::packetlog;
+
+	bool TestPushAndSnapshot()
+	{
+		PacketLog l(4, 8);
+		uint8_t data[] = {1, 2, 3, 4, 5};
+		l.Push(Direction::In,  10, 1000, data, 5);
+		l.Push(Direction::Out, 20, 1100, data, 5);
+		l.Push(Direction::In,  30, 1200, data, 5);
+		auto snap = l.Snapshot();
+		if (snap.size() != 3) return false;
+		if (snap[0].opcode != 10 || snap[1].opcode != 20 || snap[2].opcode != 30) return false;
+		LOG_INFO(Core, "[PacketLogTests] push+snapshot OK");
+		return true;
+	}
+
+	bool TestRingOverflow()
+	{
+		PacketLog l(3, 4);
+		uint8_t data[] = {0xFF};
+		// Push 5 elements dans un ring de 3 : doit garder les 3 derniers
+		for (uint16_t i = 1; i <= 5; ++i)
+			l.Push(Direction::In, i, 1000 + i, data, 1);
+		auto snap = l.Snapshot();
+		if (snap.size() != 3) return false;
+		// snap doit contenir 3, 4, 5 dans l'ordre
+		if (snap[0].opcode != 3 || snap[1].opcode != 4 || snap[2].opcode != 5) return false;
+		LOG_INFO(Core, "[PacketLogTests] ring overflow OK");
+		return true;
+	}
+
+	bool TestPrefixTruncation()
+	{
+		PacketLog l(2, 4);
+		uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+		l.Push(Direction::In, 1, 1000, data, 8);
+		auto snap = l.Snapshot();
+		if (snap.size() != 1) return false;
+		// taille originale conservee
+		if (snap[0].size != 8) return false;
+		// prefix tronque a 4 octets
+		if (snap[0].prefix.size() != 4) return false;
+		if (snap[0].prefix[0] != 1 || snap[0].prefix[3] != 4) return false;
+		LOG_INFO(Core, "[PacketLogTests] prefix truncation OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestPushAndSnapshot() && TestRingOverflow() && TestPrefixTruncation();
+	if (ok) LOG_INFO(Core, "[PacketLogTests] ALL OK");
+	else LOG_ERROR(Core, "[PacketLogTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.12 PacketLog step 1

Header-only PacketLog : ring buffer in-memory des derniers paquets recus/envoyes par session, pour debug/post-mortem (dump dans crash report). Tronque le prefix payload pour eviter d'exploser la memoire.

### Inclus
- engine/server/packetlog/PacketLog.h — Push, Size, Capacity, Snapshot (ordre chronologique).
- engine/server/packetlog/PacketLogTests.cpp — 3 tests (push + snapshot ordre, ring overflow garde les N derniers, prefix tronque mais size originale conservee).
- engine/server/CMakeLists.txt — test target packet_log_tests.

### Test plan
- [x] Build Linux : packet_log_tests compile et passe les 3 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code