### PR TITLE
feat(server/world): WorldClock (Phase 3 CMANGOS.28 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.28 (Phase 3.28a) : WorldClock (header-only).
+  lcdlln_add_simple_test(world_clock_tests
+    world/WorldClockTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/world/WorldClock.h
+++ b/engine/server/world/WorldClock.h
@@ -1,0 +1,52 @@
+#pragma once
+// CMANGOS.28 (Phase 3.28a) — WorldClock : horloge serveur (game time, day/night
+// cycle, speed multiplier admin) et utilities derives. Header-only.
+
+#include <cstdint>
+#include <algorithm>
+
+namespace engine::server::world
+{
+	/// Phase de la journee selon l'heure (heures locales 0..23).
+	enum class DayPhase : uint8_t { Night, Dawn, Day, Dusk };
+
+	class WorldClock
+	{
+	public:
+		/// \param epochMs   debut du temps serveur (timestamp ms)
+		/// \param speed     multiplicateur (1.0 = realtime, 60.0 = 1h reel = 60h jeu)
+		WorldClock(uint64_t epochMs, double speed)
+			: m_epochMs(epochMs), m_speed(speed) {}
+
+		/// Temps en jeu ecoule depuis epoch en ms.
+		uint64_t GameTimeMs(uint64_t realNowMs) const
+		{
+			if (realNowMs <= m_epochMs) return 0;
+			return static_cast<uint64_t>(static_cast<double>(realNowMs - m_epochMs) * m_speed);
+		}
+
+		/// Heure en jeu modulo 24h, en heures (0..23).
+		uint8_t HourOfDay(uint64_t realNowMs) const
+		{
+			const uint64_t gameMs = GameTimeMs(realNowMs);
+			const uint64_t hourMs = 60ull * 60ull * 1000ull;
+			return static_cast<uint8_t>((gameMs / hourMs) % 24);
+		}
+
+		DayPhase Phase(uint64_t realNowMs) const
+		{
+			const uint8_t h = HourOfDay(realNowMs);
+			if (h >= 22 || h < 5)  return DayPhase::Night;
+			if (h < 7)             return DayPhase::Dawn;
+			if (h < 19)            return DayPhase::Day;
+			return DayPhase::Dusk; // 19..21
+		}
+
+		double Speed() const { return m_speed; }
+		void   SetSpeed(double s) { m_speed = std::max(0.0, s); }
+
+	private:
+		uint64_t m_epochMs;
+		double   m_speed;
+	};
+}

--- a/engine/server/world/WorldClockTests.cpp
+++ b/engine/server/world/WorldClockTests.cpp
@@ -1,0 +1,84 @@
+#include "engine/server/world/WorldClock.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::world;
+
+	bool TestRealtime()
+	{
+		WorldClock c(1000, 1.0);
+		// 1h plus tard reel = 1h plus tard en jeu
+		const uint64_t hour = 3600ull * 1000ull;
+		if (c.GameTimeMs(1000 + hour) != hour) return false;
+		if (c.HourOfDay(1000 + hour)  != 1) return false;
+		LOG_INFO(Core, "[WorldClockTests] realtime OK");
+		return true;
+	}
+
+	bool TestSpeedX60()
+	{
+		WorldClock c(0, 60.0);
+		// 1 minute reelle = 1 heure en jeu
+		const uint64_t minute = 60ull * 1000ull;
+		if (c.HourOfDay(minute) != 1) return false;
+		// 24 minutes = 1 jour complet -> hour 0
+		if (c.HourOfDay(24 * minute) != 0) return false;
+		LOG_INFO(Core, "[WorldClockTests] speed x60 OK");
+		return true;
+	}
+
+	bool TestPhases()
+	{
+		WorldClock c(0, 60.0);
+		// 1 min reelle = 1h jeu
+		const uint64_t minute = 60ull * 1000ull;
+		// 0h = Night
+		if (c.Phase(0)         != DayPhase::Night) return false;
+		// 6h = Dawn
+		if (c.Phase(6 * minute) != DayPhase::Dawn) return false;
+		// 12h = Day
+		if (c.Phase(12 * minute) != DayPhase::Day) return false;
+		// 19h = Dusk
+		if (c.Phase(19 * minute) != DayPhase::Dusk) return false;
+		// 23h = Night
+		if (c.Phase(23 * minute) != DayPhase::Night) return false;
+		LOG_INFO(Core, "[WorldClockTests] phases OK");
+		return true;
+	}
+
+	bool TestBeforeEpoch()
+	{
+		WorldClock c(1000, 1.0);
+		if (c.GameTimeMs(500) != 0) return false;
+		LOG_INFO(Core, "[WorldClockTests] before epoch OK");
+		return true;
+	}
+
+	bool TestSetSpeed()
+	{
+		WorldClock c(0, 1.0);
+		c.SetSpeed(-5.0);
+		if (c.Speed() != 0.0) return false; // floor a 0
+		c.SetSpeed(2.5);
+		if (c.Speed() != 2.5) return false;
+		LOG_INFO(Core, "[WorldClockTests] set speed OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestRealtime() && TestSpeedX60() && TestPhases()
+	             && TestBeforeEpoch() && TestSetSpeed();
+	if (ok) LOG_INFO(Core, "[WorldClockTests] ALL OK");
+	else LOG_ERROR(Core, "[WorldClockTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 3 — CMANGOS.28 World step 1

Header-only WorldClock : horloge serveur (game time, day/night cycle, speed multiplier admin).

### Inclus
- engine/server/world/WorldClock.h — GameTimeMs, HourOfDay, Phase (Night/Dawn/Day/Dusk), SetSpeed.
- engine/server/world/WorldClockTests.cpp — 5 tests (realtime, speed x60 = 1 jour en 24min, transitions de phases, before epoch, SetSpeed floor 0).
- engine/server/CMakeLists.txt — test target world_clock_tests.

### Test plan
- [x] Build Linux : world_clock_tests compile et passe les 5 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code