### PR TITLE
feat(server/guild): GuildPermissionMatrix (Phase 3 CMANGOS.21 step 1)

### DIFF
--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -349,6 +349,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(cinematic_sequence_tests
     cinematics/CinematicSequenceTests.cpp)
 
+  # CMANGOS.21 (Phase 3.21a) : GuildPermissionMatrix (header-only).
+  lcdlln_add_simple_test(guild_permission_matrix_tests
+    guild/GuildPermissionMatrixTests.cpp)
+
   # CMANGOS.19 (Phase 3.19a) : InstanceManager (header-only).
   lcdlln_add_simple_test(instance_manager_tests
     maps/InstanceManagerTests.cpp)

--- a/engine/server/guild/GuildPermissionMatrix.h
+++ b/engine/server/guild/GuildPermissionMatrix.h
@@ -1,0 +1,82 @@
+#pragma once
+// CMANGOS.21 (Phase 3.21a) — GuildPermissionMatrix : matrice de permissions
+// par rang de guilde (data-driven). Differe de GuildSystem.cpp deja present
+// en se focalisant sur la check de permission, pas la persistance/wire.
+// Header-only.
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace engine::server::guild
+{
+	using GuildId = uint32_t;
+	using RankId  = uint8_t;  ///< 0 = Guild Master, 9 = Initiate (a la WoW)
+
+	enum class Permission : uint32_t
+	{
+		None         = 0,
+		Invite       = 1u << 0,
+		Remove       = 1u << 1,
+		Promote      = 1u << 2,
+		Demote       = 1u << 3,
+		EditMotd     = 1u << 4,
+		EditTabard   = 1u << 5,
+		WithdrawGold = 1u << 6,
+		BankView     = 1u << 7,
+		BankDeposit  = 1u << 8,
+		BankWithdraw = 1u << 9,
+		Disband      = 1u << 10,
+	};
+
+	inline uint32_t Bit(Permission p) { return static_cast<uint32_t>(p); }
+
+	struct RankPerms
+	{
+		uint32_t mask = 0; ///< OR de Permission::* bits
+	};
+
+	class GuildPermissionMatrix
+	{
+	public:
+		void SetRank(GuildId g, RankId r, uint32_t mask) { m_perms[g][r].mask = mask; }
+
+		bool HasPerm(GuildId g, RankId r, Permission p) const
+		{
+			auto git = m_perms.find(g);
+			if (git == m_perms.end()) return false;
+			auto rit = git->second.find(r);
+			if (rit == git->second.end()) return false;
+			return (rit->second.mask & Bit(p)) != 0;
+		}
+
+		/// Configure le defaut WoW-like : GM=tout, Officer=invite/remove/promote +
+		/// bank, Member=bank view/deposit, Initiate=rien.
+		void SetupWowDefaults(GuildId g)
+		{
+			const uint32_t all =
+				Bit(Permission::Invite) | Bit(Permission::Remove) |
+				Bit(Permission::Promote) | Bit(Permission::Demote) |
+				Bit(Permission::EditMotd) | Bit(Permission::EditTabard) |
+				Bit(Permission::WithdrawGold) | Bit(Permission::BankView) |
+				Bit(Permission::BankDeposit) | Bit(Permission::BankWithdraw) |
+				Bit(Permission::Disband);
+			SetRank(g, 0, all);
+
+			const uint32_t officer =
+				Bit(Permission::Invite) | Bit(Permission::Remove) |
+				Bit(Permission::Promote) | Bit(Permission::Demote) |
+				Bit(Permission::BankView) | Bit(Permission::BankDeposit) |
+				Bit(Permission::BankWithdraw);
+			SetRank(g, 1, officer);
+
+			const uint32_t member =
+				Bit(Permission::BankView) | Bit(Permission::BankDeposit);
+			SetRank(g, 5, member);
+
+			SetRank(g, 9, 0); // Initiate
+		}
+
+	private:
+		std::unordered_map<GuildId, std::unordered_map<RankId, RankPerms>> m_perms;
+	};
+}

--- a/engine/server/guild/GuildPermissionMatrixTests.cpp
+++ b/engine/server/guild/GuildPermissionMatrixTests.cpp
@@ -1,0 +1,60 @@
+#include "engine/server/guild/GuildPermissionMatrix.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::guild;
+
+	bool TestUnknown()
+	{
+		GuildPermissionMatrix m;
+		if (m.HasPerm(1, 0, Permission::Invite)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] unknown rejected OK");
+		return true;
+	}
+
+	bool TestExplicitMask()
+	{
+		GuildPermissionMatrix m;
+		m.SetRank(10, 5, Bit(Permission::BankView) | Bit(Permission::Invite));
+		if (!m.HasPerm(10, 5, Permission::BankView)) return false;
+		if (!m.HasPerm(10, 5, Permission::Invite)) return false;
+		if (m.HasPerm(10, 5, Permission::Disband)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] explicit mask OK");
+		return true;
+	}
+
+	bool TestWowDefaults()
+	{
+		GuildPermissionMatrix m;
+		m.SetupWowDefaults(20);
+		// GM (rank 0) : tout
+		if (!m.HasPerm(20, 0, Permission::Disband)) return false;
+		if (!m.HasPerm(20, 0, Permission::Invite)) return false;
+		// Officer (rank 1) : pas Disband
+		if (m.HasPerm(20, 1, Permission::Disband)) return false;
+		if (!m.HasPerm(20, 1, Permission::Invite)) return false;
+		// Member (rank 5) : pas Invite
+		if (m.HasPerm(20, 5, Permission::Invite)) return false;
+		if (!m.HasPerm(20, 5, Permission::BankView)) return false;
+		// Initiate (rank 9) : rien
+		if (m.HasPerm(20, 9, Permission::BankView)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] WoW defaults OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestUnknown() && TestExplicitMask() && TestWowDefaults();
+	if (ok) LOG_INFO(Core, "[GuildPermsTests] ALL OK");
+	else LOG_ERROR(Core, "[GuildPermsTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 3 — CMANGOS.21 Guilds step 1 (permission matrix)

Header-only matrice de permissions data-driven par rang de guilde. Distinct du GuildSystem.cpp existant (persistance/wire) en isolant la check de permission pure et reutilisable. Phase 3.21a focalise sur le check, pas la persistance.

### Inclus
- engine/server/guild/GuildPermissionMatrix.h — Permission bits (Invite/Remove/Promote/Demote/EditMotd/EditTabard/WithdrawGold/BankView/BankDeposit/BankWithdraw/Disband), SetRank, HasPerm, SetupWowDefaults.
- engine/server/guild/GuildPermissionMatrixTests.cpp — 3 tests (guilde inconnue rejetee, mask explicite, WoW defaults niveau par niveau).
- engine/server/CMakeLists.txt — test target guild_permission_matrix_tests.

### Test plan
- [x] Build Linux : guild_permission_matrix_tests compile et passe les 3 cas.
- [ ] Pas de wire / opcode / DB / handler ajoute.

**Deploiement** : pas de redeploiement serveur necessaire (header-only).

Generated with Claude Code