### PR TITLE
feat(server/gmtickets): MysqlGmTicketStore + migration 0046 (Phase 5 CMANGOS.32 step 2)

### DIFF
--- a/db/migrations/0046_gm_tickets.sql
+++ b/db/migrations/0046_gm_tickets.sql
@@ -1,0 +1,16 @@
+-- 0046 — Phase 5 CMANGOS.32 GmTickets : table `gm_tickets` pour la queue
+-- de support GM (reporter, body, etat, GM assigne, timestamps). Idempotent.
+
+CREATE TABLE IF NOT EXISTS gm_tickets (
+  ticket_id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  reporter_account_id  BIGINT UNSIGNED NOT NULL,
+  body                 MEDIUMTEXT      NOT NULL,
+  created_ts_ms        BIGINT UNSIGNED NOT NULL,
+  resolved_ts_ms       BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  assigned_gm          BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  state                TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (ticket_id),
+  KEY ix_gm_tickets_state    (state),
+  KEY ix_gm_tickets_assigned (assigned_gm),
+  KEY ix_gm_tickets_reporter (reporter_account_id)
+);

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -131,6 +131,7 @@ elseif(UNIX)
     chat/ChatChannelRegistry.cpp
     mail/MailManager.cpp
     mail/MysqlMailStore.cpp
+    gmtickets/MysqlGmTicketStore.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp

--- a/engine/server/gmtickets/MysqlGmTicketStore.cpp
+++ b/engine/server/gmtickets/MysqlGmTicketStore.cpp
@@ -1,0 +1,147 @@
+#include "engine/server/gmtickets/MysqlGmTicketStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::gmtickets
+{
+	namespace
+	{
+		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+
+		GmTicket RowToTicket(MYSQL_ROW row)
+		{
+			GmTicket t;
+			if (row[0]) t.id           = std::strtoull(row[0], nullptr, 10);
+			if (row[1]) t.reporter     = std::strtoull(row[1], nullptr, 10);
+			if (row[2]) t.body         = row[2];
+			if (row[3]) t.createdTsMs  = std::strtoull(row[3], nullptr, 10);
+			if (row[4]) t.resolvedTsMs = std::strtoull(row[4], nullptr, 10);
+			if (row[5]) t.assignedGm   = std::strtoull(row[5], nullptr, 10);
+			if (row[6])
+			{
+				const auto st = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+				t.state = static_cast<TicketState>(std::min<uint32_t>(st, 3));
+			}
+			return t;
+		}
+	}
+
+	uint64_t MysqlGmTicketStore::Insert(GmTicket& out)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0;
+
+		const std::string body = EscapeMysql(mysql, out.body);
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO gm_tickets (reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state) "
+			"VALUES (%llu, '%s', %llu, %llu, %llu, %u)",
+			static_cast<unsigned long long>(out.reporter),
+			body.c_str(),
+			static_cast<unsigned long long>(out.createdTsMs),
+			static_cast<unsigned long long>(out.resolvedTsMs),
+			static_cast<unsigned long long>(out.assignedGm),
+			static_cast<unsigned>(out.state));
+
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_ERROR(Core, "[MysqlGmTicketStore] Insert failed");
+			return 0;
+		}
+		out.id = mysql_insert_id(mysql);
+		return out.id;
+	}
+
+	bool MysqlGmTicketStore::Update(const GmTicket& t)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		const std::string body = EscapeMysql(mysql, t.body);
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"UPDATE gm_tickets SET body = '%s', resolved_ts_ms = %llu, "
+			"assigned_gm = %llu, state = %u WHERE ticket_id = %llu",
+			body.c_str(),
+			static_cast<unsigned long long>(t.resolvedTsMs),
+			static_cast<unsigned long long>(t.assignedGm),
+			static_cast<unsigned>(t.state),
+			static_cast<unsigned long long>(t.id));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlGmTicketStore::Delete(TicketId id)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+		char sql[128];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM gm_tickets WHERE ticket_id = %llu",
+			static_cast<unsigned long long>(id));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::optional<GmTicket> MysqlGmTicketStore::Find(TicketId id) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return std::nullopt;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return std::nullopt;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state "
+			"FROM gm_tickets WHERE ticket_id = %llu LIMIT 1",
+			static_cast<unsigned long long>(id));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return std::nullopt;
+		std::optional<GmTicket> out;
+		if (MYSQL_ROW row = mysql_fetch_row(res))
+			out = RowToTicket(row);
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	std::vector<GmTicket> MysqlGmTicketStore::ListOpen() const
+	{
+		std::vector<GmTicket> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql =
+			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state "
+			"FROM gm_tickets WHERE state = 0 ORDER BY created_ts_ms ASC";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+			out.push_back(RowToTicket(row));
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/gmtickets/MysqlGmTicketStore.h
+++ b/engine/server/gmtickets/MysqlGmTicketStore.h
@@ -1,0 +1,37 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32b) — MysqlGmTicketStore : persistance MySQL des
+// tickets GM (table gm_tickets, migration 0046). Cible UNIX shard.
+// Le WIN32 sandbox utilise GmTicketSystem (header-only en memoire).
+
+#include "engine/server/gmtickets/GmTicketSystem.h"
+
+#include <optional>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::gmtickets
+{
+	class MysqlGmTicketStore
+	{
+	public:
+		explicit MysqlGmTicketStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Insert : remplit \p out.id avec l'AUTO_INCREMENT genere par MySQL.
+		/// Retourne 0 en cas d'echec.
+		uint64_t Insert(GmTicket& out);
+
+		/// Update tous les champs mutables (state, assignedGm, resolvedTsMs, body).
+		bool Update(const GmTicket& t);
+
+		bool Delete(TicketId id);
+		std::optional<GmTicket> Find(TicketId id) const;
+
+		/// Tous les tickets dans state == Open (queue support GM).
+		std::vector<GmTicket> ListOpen() const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.32 GmTickets step 2 (DB persistence)

Persistance MySQL pour la queue de tickets support GM, suivant le pattern de MysqlMailStore (#508). Le sandbox WIN32 continue d'utiliser GmTicketSystem (header-only en memoire) ; le shard Linux utilisera MysqlGmTicketStore.

### Inclus
- db/migrations/0046_gm_tickets.sql — table idempotente (CREATE IF NOT EXISTS) avec index state/assigned/reporter.
- engine/server/gmtickets/MysqlGmTicketStore.h/.cpp — Insert/Update/Delete/Find/ListOpen via ConnectionPool + DbHelpers.
- engine/server/CMakeLists.txt — ajoute MysqlGmTicketStore.cpp aux sources UNIX server_app.

### Test plan
- [x] Build Linux : compile (CI).
- [ ] Tests d'integration MySQL deferres (pattern MailManager : tests in-memory uniquement, le store MySQL est valide en production).

**Deploiement** : ⚠️ REDEPLOIEMENT SERVEUR REQUIS — la migration 0046 doit etre appliquee au boot du serveur Linux pour creer la table gm_tickets.

Generated with Claude Code