### PR TITLE
feat(server/reputation): MysqlReputationStore + migration 0047 (Phase 3 CMANGOS.24 step 2)

### DIFF
--- a/db/migrations/0047_reputation.sql
+++ b/db/migrations/0047_reputation.sql
@@ -1,0 +1,15 @@
+-- 0047 — Phase 3 CMANGOS.24 Reputation : table account_reputation pour
+-- persister la valeur de reputation par (account, faction). Idempotent.
+--
+-- Une ligne par (account_id, faction_id), value -42000..41999 (signed int).
+-- Le ReputationManager runtime gere les bornes/clamp ; cette table est
+-- juste le store. Les regles de spillover restent code-driven (pas
+-- en DB) car elles dependent de la version de jeu, pas de l'account.
+
+CREATE TABLE IF NOT EXISTS account_reputation (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  faction_id  INT UNSIGNED   NOT NULL,
+  value       INT             NOT NULL DEFAULT 0,
+  PRIMARY KEY (account_id, faction_id),
+  KEY ix_account_reputation_account (account_id)
+);

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -131,6 +131,7 @@ elseif(UNIX)
     chat/ChatChannelRegistry.cpp
     mail/MailManager.cpp
     mail/MysqlMailStore.cpp
+    reputation/MysqlReputationStore.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp

--- a/engine/server/reputation/MysqlReputationStore.cpp
+++ b/engine/server/reputation/MysqlReputationStore.cpp
@@ -1,0 +1,59 @@
+#include "engine/server/reputation/MysqlReputationStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::reputation
+{
+	bool MysqlReputationStore::Upsert(AccountId accountId, FactionId factionId, int32_t value)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		// MySQL upsert : INSERT ... ON DUPLICATE KEY UPDATE.
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO account_reputation (account_id, faction_id, value) "
+			"VALUES (%llu, %u, %d) "
+			"ON DUPLICATE KEY UPDATE value = VALUES(value)",
+			static_cast<unsigned long long>(accountId),
+			factionId,
+			value);
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::vector<ReputationRow> MysqlReputationStore::Load(AccountId accountId) const
+	{
+		std::vector<ReputationRow> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT account_id, faction_id, value FROM account_reputation "
+			"WHERE account_id = %llu",
+			static_cast<unsigned long long>(accountId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			ReputationRow r;
+			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
+			r.factionId = row[1] ? static_cast<FactionId>(std::strtoul(row[1], nullptr, 10)) : 0;
+			r.value     = row[2] ? std::atoi(row[2]) : 0;
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/reputation/MysqlReputationStore.h
+++ b/engine/server/reputation/MysqlReputationStore.h
@@ -1,0 +1,38 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24b) — MysqlReputationStore : persistance MySQL
+// des valeurs de reputation par (account, faction). Migration 0047.
+// Cible UNIX shard.
+
+#include "engine/server/reputation/ReputationManager.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::reputation
+{
+	struct ReputationRow
+	{
+		AccountId accountId;
+		FactionId factionId;
+		int32_t   value;
+	};
+
+	class MysqlReputationStore
+	{
+	public:
+		explicit MysqlReputationStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Upsert d'une ligne (faction, account, value). Insert si absent
+		/// sinon update value.
+		bool Upsert(AccountId accountId, FactionId factionId, int32_t value);
+
+		/// Charge toutes les lignes pour un account (typiquement au login).
+		std::vector<ReputationRow> Load(AccountId accountId) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}


### PR DESCRIPTION
## Phase 3 — CMANGOS.24 Reputation step 2 (DB persistence)

Persistance MySQL des valeurs de reputation par (account, faction). Pattern MysqlMailStore (#508).

### Inclus
- db/migrations/0047_reputation.sql — table account_reputation, PK composite (account_id, faction_id), value signed -42000..41999.
- engine/server/reputation/MysqlReputationStore.h/.cpp — Upsert (INSERT ON DUPLICATE KEY UPDATE), Load(accountId).
- engine/server/CMakeLists.txt — ajoute MysqlReputationStore.cpp aux sources UNIX server_app.

### Test plan
- [x] Build Linux : compile (CI).

**Deploiement** : ⚠️ REDEPLOIEMENT SERVEUR REQUIS — migration 0047 cree account_reputation au boot Linux.

Generated with Claude Code