### PR TITLE
feat(server/quests): MysqlQuestStateStore + migration 0048 (Phase 5 CMANGOS.23 step 2)

### DIFF
--- a/db/migrations/0048_quest_state.sql
+++ b/db/migrations/0048_quest_state.sql
@@ -1,0 +1,11 @@
+-- 0048 — Phase 5 CMANGOS.23 QuestState : table account_quest_state pour
+-- la machine d'etat (None/Available/Accepted/Completed/Rewarded/Failed).
+-- Idempotent. PK composite (account_id, quest_id).
+
+CREATE TABLE IF NOT EXISTS account_quest_state (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  quest_id    INT UNSIGNED    NOT NULL,
+  status      TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (account_id, quest_id),
+  KEY ix_account_quest_state_account (account_id)
+);

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -131,6 +131,7 @@ elseif(UNIX)
     chat/ChatChannelRegistry.cpp
     mail/MailManager.cpp
     mail/MysqlMailStore.cpp
+    quests/MysqlQuestStateStore.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp

--- a/engine/server/quests/MysqlQuestStateStore.cpp
+++ b/engine/server/quests/MysqlQuestStateStore.cpp
@@ -1,0 +1,74 @@
+#include "engine/server/quests/MysqlQuestStateStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::quests
+{
+	bool MysqlQuestStateStore::Upsert(AccountId accountId, QuestId questId, QuestStatus status)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO account_quest_state (account_id, quest_id, status) "
+			"VALUES (%llu, %u, %u) "
+			"ON DUPLICATE KEY UPDATE status = VALUES(status)",
+			static_cast<unsigned long long>(accountId),
+			questId,
+			static_cast<unsigned>(status));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlQuestStateStore::Delete(AccountId accountId, QuestId questId)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM account_quest_state WHERE account_id = %llu AND quest_id = %u",
+			static_cast<unsigned long long>(accountId),
+			questId);
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::vector<QuestStateRow> MysqlQuestStateStore::Load(AccountId accountId) const
+	{
+		std::vector<QuestStateRow> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT account_id, quest_id, status FROM account_quest_state "
+			"WHERE account_id = %llu",
+			static_cast<unsigned long long>(accountId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			QuestStateRow r;
+			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
+			r.questId   = row[1] ? static_cast<QuestId>(std::strtoul(row[1], nullptr, 10)) : 0;
+			const auto st = row[2] ? static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10)) : 0u;
+			r.status    = static_cast<QuestStatus>(std::min<uint32_t>(st, 5u));
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/quests/MysqlQuestStateStore.h
+++ b/engine/server/quests/MysqlQuestStateStore.h
@@ -1,0 +1,40 @@
+#pragma once
+// CMANGOS.23 (Phase 5.23b) — MysqlQuestStateStore : persistance MySQL
+// du QuestStateTracker (table account_quest_state, migration 0048).
+// Cible UNIX shard.
+
+#include "engine/server/quests/QuestState.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::quests
+{
+	struct QuestStateRow
+	{
+		AccountId   accountId;
+		QuestId     questId;
+		QuestStatus status;
+	};
+
+	class MysqlQuestStateStore
+	{
+	public:
+		explicit MysqlQuestStateStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Upsert d'un (account, quest, status). Insert si absent sinon update.
+		bool Upsert(AccountId accountId, QuestId questId, QuestStatus status);
+
+		/// Suppression d'une ligne (utile pour reset quest cote admin).
+		bool Delete(AccountId accountId, QuestId questId);
+
+		/// Charge toutes les lignes pour un account (au login).
+		std::vector<QuestStateRow> Load(AccountId accountId) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}


### PR DESCRIPTION
## Phase 5 — CMANGOS.23 QuestState step 2 (DB persistence)

Persistance MySQL du QuestStateTracker. QuestStateTracker (header-only) reste utilise par le sandbox WIN32 ; le shard Linux utilisera MysqlQuestStateStore.

### Inclus
- db/migrations/0048_quest_state.sql — account_quest_state idempotent, PK (account_id, quest_id).
- engine/server/quests/MysqlQuestStateStore.h/.cpp — Upsert (INSERT ON DUPLICATE KEY UPDATE), Delete, Load(accountId).
- engine/server/CMakeLists.txt — ajoute MysqlQuestStateStore.cpp aux sources UNIX server_app.

**Deploiement** : ⚠️ REDEPLOIEMENT SERVEUR REQUIS — migration 0048 cree account_quest_state au boot Linux.

Generated with Claude Code