### PR TITLE
feat(server/social): MysqlIgnoreStore + migration 0049 (Phase 3 CMANGOS.25 step 2)

### DIFF
--- a/db/migrations/0049_ignore_list.sql
+++ b/db/migrations/0049_ignore_list.sql
@@ -1,0 +1,10 @@
+-- 0049 — Phase 3 CMANGOS.25 IgnoreList : table account_ignore_list
+-- (chaque ligne = 1 paire owner -> target ignored). Idempotent.
+-- Limite logique 50 ignored par account (verifiee dans IgnoreListManager).
+
+CREATE TABLE IF NOT EXISTS account_ignore_list (
+  owner_account_id    BIGINT UNSIGNED NOT NULL,
+  target_account_id   BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY (owner_account_id, target_account_id),
+  KEY ix_ignore_list_owner (owner_account_id)
+);

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -131,6 +131,7 @@ elseif(UNIX)
     chat/ChatChannelRegistry.cpp
     mail/MailManager.cpp
     mail/MysqlMailStore.cpp
+    social/MysqlIgnoreStore.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp

--- a/engine/server/social/MysqlIgnoreStore.cpp
+++ b/engine/server/social/MysqlIgnoreStore.cpp
@@ -1,0 +1,112 @@
+#include "engine/server/social/MysqlIgnoreStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::social
+{
+	bool MysqlIgnoreStore::Add(uint64_t owner, uint64_t target)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		// INSERT IGNORE : si la PK (owner, target) existe deja, no-op.
+		// Le cap de 50 ignored est applique cote IgnoreListManager runtime.
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT IGNORE INTO account_ignore_list (owner_account_id, target_account_id) "
+			"VALUES (%llu, %llu)",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlIgnoreStore::Remove(uint64_t owner, uint64_t target)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM account_ignore_list "
+			"WHERE owner_account_id = %llu AND target_account_id = %llu",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlIgnoreStore::IsIgnored(uint64_t owner, uint64_t target) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT 1 FROM account_ignore_list "
+			"WHERE owner_account_id = %llu AND target_account_id = %llu LIMIT 1",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return false;
+		const bool found = (mysql_fetch_row(res) != nullptr);
+		engine::server::db::DbFreeResult(res);
+		return found;
+	}
+
+	std::vector<uint64_t> MysqlIgnoreStore::List(uint64_t owner) const
+	{
+		std::vector<uint64_t> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT target_account_id FROM account_ignore_list "
+			"WHERE owner_account_id = %llu ORDER BY target_account_id ASC",
+			static_cast<unsigned long long>(owner));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			if (row[0]) out.push_back(std::strtoull(row[0], nullptr, 10));
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	size_t MysqlIgnoreStore::Size(uint64_t owner) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT COUNT(*) FROM account_ignore_list WHERE owner_account_id = %llu",
+			static_cast<unsigned long long>(owner));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return 0;
+		size_t count = 0;
+		if (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			if (row[0]) count = static_cast<size_t>(std::strtoull(row[0], nullptr, 10));
+		}
+		engine::server::db::DbFreeResult(res);
+		return count;
+	}
+}

--- a/engine/server/social/MysqlIgnoreStore.h
+++ b/engine/server/social/MysqlIgnoreStore.h
@@ -1,0 +1,27 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25b) — MysqlIgnoreStore : implementation MySQL
+// d'IIgnoreStore pour persistance production. Cible UNIX shard.
+// (WIN32 sandbox utilise InMemoryIgnoreStore.)
+
+#include "engine/server/social/IgnoreList.h"
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::social
+{
+	class MysqlIgnoreStore final : public IIgnoreStore
+	{
+	public:
+		explicit MysqlIgnoreStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		bool Add(uint64_t ownerAccountId, uint64_t targetAccountId) override;
+		bool Remove(uint64_t ownerAccountId, uint64_t targetAccountId) override;
+		bool IsIgnored(uint64_t ownerAccountId, uint64_t targetAccountId) const override;
+		std::vector<uint64_t> List(uint64_t ownerAccountId) const override;
+		size_t Size(uint64_t ownerAccountId) const override;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}


### PR DESCRIPTION
## Phase 3 — CMANGOS.25 IgnoreList step 2 (DB persistence)

Implementation MySQL de l'IIgnoreStore deja defini dans IgnoreList.h. InMemoryIgnoreStore reste utilise pour les tests et le sandbox WIN32.

### Inclus
- db/migrations/0049_ignore_list.sql — account_ignore_list idempotent, PK (owner, target).
- engine/server/social/MysqlIgnoreStore.h/.cpp — Add (INSERT IGNORE), Remove, IsIgnored, List, Size.
- engine/server/CMakeLists.txt — ajoute MysqlIgnoreStore.cpp aux sources UNIX server_app.

**Deploiement** : ⚠️ REDEPLOIEMENT SERVEUR REQUIS — migration 0049 cree account_ignore_list au boot Linux.

Generated with Claude Code