### PR TITLE
feat(server): Phase 3-5 step 1+2 DB consolidation (CMANGOS bulk, 19 tickets)

### DIFF
--- a/db/migrations/0046_gm_tickets.sql
+++ b/db/migrations/0046_gm_tickets.sql
@@ -1,0 +1,16 @@
+-- 0046 — Phase 5 CMANGOS.32 GmTickets : table `gm_tickets` pour la queue
+-- de support GM (reporter, body, etat, GM assigne, timestamps). Idempotent.
+
+CREATE TABLE IF NOT EXISTS gm_tickets (
+  ticket_id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  reporter_account_id  BIGINT UNSIGNED NOT NULL,
+  body                 MEDIUMTEXT      NOT NULL,
+  created_ts_ms        BIGINT UNSIGNED NOT NULL,
+  resolved_ts_ms       BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  assigned_gm          BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  state                TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (ticket_id),
+  KEY ix_gm_tickets_state    (state),
+  KEY ix_gm_tickets_assigned (assigned_gm),
+  KEY ix_gm_tickets_reporter (reporter_account_id)
+);

--- a/db/migrations/0047_reputation.sql
+++ b/db/migrations/0047_reputation.sql
@@ -1,0 +1,15 @@
+-- 0047 — Phase 3 CMANGOS.24 Reputation : table account_reputation pour
+-- persister la valeur de reputation par (account, faction). Idempotent.
+--
+-- Une ligne par (account_id, faction_id), value -42000..41999 (signed int).
+-- Le ReputationManager runtime gere les bornes/clamp ; cette table est
+-- juste le store. Les regles de spillover restent code-driven (pas
+-- en DB) car elles dependent de la version de jeu, pas de l'account.
+
+CREATE TABLE IF NOT EXISTS account_reputation (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  faction_id  INT UNSIGNED   NOT NULL,
+  value       INT             NOT NULL DEFAULT 0,
+  PRIMARY KEY (account_id, faction_id),
+  KEY ix_account_reputation_account (account_id)
+);

--- a/db/migrations/0048_quest_state.sql
+++ b/db/migrations/0048_quest_state.sql
@@ -1,0 +1,11 @@
+-- 0048 — Phase 5 CMANGOS.23 QuestState : table account_quest_state pour
+-- la machine d'etat (None/Available/Accepted/Completed/Rewarded/Failed).
+-- Idempotent. PK composite (account_id, quest_id).
+
+CREATE TABLE IF NOT EXISTS account_quest_state (
+  account_id  BIGINT UNSIGNED NOT NULL,
+  quest_id    INT UNSIGNED    NOT NULL,
+  status      TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (account_id, quest_id),
+  KEY ix_account_quest_state_account (account_id)
+);

--- a/db/migrations/0049_ignore_list.sql
+++ b/db/migrations/0049_ignore_list.sql
@@ -1,0 +1,10 @@
+-- 0049 — Phase 3 CMANGOS.25 IgnoreList : table account_ignore_list
+-- (chaque ligne = 1 paire owner -> target ignored). Idempotent.
+-- Limite logique 50 ignored par account (verifiee dans IgnoreListManager).
+
+CREATE TABLE IF NOT EXISTS account_ignore_list (
+  owner_account_id    BIGINT UNSIGNED NOT NULL,
+  target_account_id   BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY (owner_account_id, target_account_id),
+  KEY ix_ignore_list_owner (owner_account_id)
+);

--- a/engine/server/CMakeLists.txt
+++ b/engine/server/CMakeLists.txt
@@ -131,6 +131,10 @@ elseif(UNIX)
     chat/ChatChannelRegistry.cpp
     mail/MailManager.cpp
     mail/MysqlMailStore.cpp
+    gmtickets/MysqlGmTicketStore.cpp
+    reputation/MysqlReputationStore.cpp
+    quests/MysqlQuestStateStore.cpp
+    social/MysqlIgnoreStore.cpp
     ${CMAKE_SOURCE_DIR}/engine/network/ChatPayloads.cpp
     PasswordResetStore.cpp
     PasswordResetHandler.cpp
@@ -356,6 +360,66 @@ elseif(UNIX)
   # CMANGOS.36 (Phase 5.36a) : OutdoorPvPManager (header-only, zones contestees).
   lcdlln_add_simple_test(outdoor_pvp_manager_tests
     outdoorpvp/OutdoorPvPManagerTests.cpp)
+
+  # CMANGOS.22 (Phase 4.22a) : PoolManager weighted spawn (header-only).
+  lcdlln_add_simple_test(pool_manager_tests
+    pools/PoolManagerTests.cpp)
+
+  # CMANGOS.08 (Phase 5.08a) : ArenaTeam + ELO (header-only).
+  lcdlln_add_simple_test(arena_team_tests
+    arena/ArenaTeamTests.cpp)
+
+  # CMANGOS.38 (Phase 5.38a) : PlayerBotProfile (header-only).
+  lcdlln_add_simple_test(player_bot_profile_tests
+    playerbot/PlayerBotProfileTests.cpp)
+
+  # CMANGOS.41 (Phase 5.41a) : ServerUtil (header-only).
+  lcdlln_add_simple_test(server_util_tests
+    util/ServerUtilTests.cpp)
+
+  # CMANGOS.40 (Phase 4.40a) : Formulas (header-only).
+  lcdlln_add_simple_test(formulas_tests
+    formulas/FormulasTests.cpp)
+
+  # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
+  lcdlln_add_simple_test(metric_registry_tests
+    metric/MetricRegistryTests.cpp)
+
+  # CMANGOS.37 (Phase 4.37a) : CrashContext (header-only).
+  lcdlln_add_simple_test(crash_context_tests
+    platform/CrashContextTests.cpp)
+
+  # CMANGOS.35 (Phase 4.35a) : Messager MPSC (header-only).
+  lcdlln_add_simple_test(messager_tests
+    messager/MessagerTests.cpp)
+
+  # CMANGOS.10 (Phase 4.10a) : BattleGroundQueue (header-only).
+  lcdlln_add_simple_test(battle_ground_queue_tests
+    battleground/BattleGroundQueueTests.cpp)
+
+  # CMANGOS.27 (Phase 4.27a) : TradeSession FSM (header-only).
+  lcdlln_add_simple_test(trade_session_tests
+    trade/TradeSessionTests.cpp)
+
+  # CMANGOS.39 (Phase 4.39a) : SkillBook (header-only).
+  lcdlln_add_simple_test(skill_book_tests
+    skills/SkillBookTests.cpp)
+
+  # CMANGOS.12 (Phase 4.12a) : PacketLog ring buffer (header-only).
+  lcdlln_add_simple_test(packet_log_tests
+    packetlog/PacketLogTests.cpp)
+
+  # CMANGOS.28 (Phase 3.28a) : WorldClock (header-only).
+  lcdlln_add_simple_test(world_clock_tests
+    world/WorldClockTests.cpp)
+
+  # CMANGOS.21 (Phase 3.21a) : GuildPermissionMatrix (header-only).
+  lcdlln_add_simple_test(guild_permission_matrix_tests
+    guild/GuildPermissionMatrixTests.cpp)
+
+  # CMANGOS.44 (Phase 5.44a) : AuctionHouseBot (header-only, low-pop AH filler).
+  lcdlln_add_simple_test(auction_house_bot_tests
+    auction/AuctionHouseBotTests.cpp)
 
   # CMANGOS.25 (Phase 3.25a) : IgnoreListManager (header-only).
   lcdlln_add_simple_test(ignore_list_tests

--- a/engine/server/arena/ArenaTeam.h
+++ b/engine/server/arena/ArenaTeam.h
@@ -1,0 +1,91 @@
+#pragma once
+// CMANGOS.08 (Phase 5.08a) — ArenaTeam : equipe d'arene 2v2/3v3/5v5 avec
+// rating ELO + match history. Header-only.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+
+namespace engine::server::arena
+{
+	using TeamId    = uint32_t;
+	using ToonGuid  = uint64_t;
+
+	enum class TeamSize : uint8_t { v2 = 2, v3 = 3, v5 = 5 };
+
+	struct ArenaTeam
+	{
+		TeamId   id          = 0;
+		TeamSize size        = TeamSize::v2;
+		std::string name;
+		std::vector<ToonGuid> roster;
+		uint32_t rating       = 1500; ///< ELO de depart standard
+		uint32_t weeklyGames  = 0;
+		uint32_t weeklyWins   = 0;
+		uint32_t seasonGames  = 0;
+		uint32_t seasonWins   = 0;
+	};
+
+	/// Calcule la nouvelle paire de ratings ELO apres un match.
+	/// \param k        K-factor (typiquement 32 dans WoW arena)
+	/// \param winner   nouveau rating du gagnant (sortie)
+	/// \param loser    nouveau rating du perdant (sortie)
+	inline void ApplyEloUpdate(uint32_t winnerRating, uint32_t loserRating, uint32_t k,
+	                            uint32_t& winner, uint32_t& loser)
+	{
+		const double rW = static_cast<double>(winnerRating);
+		const double rL = static_cast<double>(loserRating);
+		const double expectedW = 1.0 / (1.0 + std::pow(10.0, (rL - rW) / 400.0));
+		const double expectedL = 1.0 - expectedW;
+		const double newW = rW + k * (1.0 - expectedW);
+		const double newL = rL + k * (0.0 - expectedL);
+		// Floor a 0 pour eviter underflow uint32 si match catastrophique.
+		winner = static_cast<uint32_t>(std::max(0.0, newW));
+		loser  = static_cast<uint32_t>(std::max(0.0, newL));
+	}
+
+	/// Registry simple en memoire pour tests/donnees seed.
+	class ArenaTeamRegistry
+	{
+	public:
+		void AddTeam(const ArenaTeam& t) { m_teams[t.id] = t; }
+		ArenaTeam* Get(TeamId id)
+		{
+			auto it = m_teams.find(id);
+			return (it == m_teams.end()) ? nullptr : &it->second;
+		}
+
+		/// Enregistre un match : met a jour ratings (ELO) + stats hebdo/saison.
+		/// Retourne true si les 2 equipes existent.
+		bool RecordMatch(TeamId winnerId, TeamId loserId, uint32_t k = 32)
+		{
+			auto* w = Get(winnerId);
+			auto* l = Get(loserId);
+			if (!w || !l) return false;
+			uint32_t newW, newL;
+			ApplyEloUpdate(w->rating, l->rating, k, newW, newL);
+			w->rating = newW;
+			l->rating = newL;
+			w->weeklyGames++; w->seasonGames++;
+			w->weeklyWins++;  w->seasonWins++;
+			l->weeklyGames++; l->seasonGames++;
+			return true;
+		}
+
+		/// Reset compteurs hebdo (lance le lundi serveur en theorie).
+		void ResetWeekly()
+		{
+			for (auto& [_, t] : m_teams)
+			{
+				t.weeklyGames = 0;
+				t.weeklyWins  = 0;
+			}
+		}
+
+	private:
+		std::unordered_map<TeamId, ArenaTeam> m_teams;
+	};
+}

--- a/engine/server/arena/ArenaTeamTests.cpp
+++ b/engine/server/arena/ArenaTeamTests.cpp
@@ -1,0 +1,90 @@
+#include "engine/server/arena/ArenaTeam.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using engine::server::arena::ArenaTeam;
+	using engine::server::arena::ArenaTeamRegistry;
+	using engine::server::arena::TeamSize;
+	using engine::server::arena::ApplyEloUpdate;
+
+	bool TestEloEqual()
+	{
+		// Deux equipes a 1500. Gagnant +16, perdant -16 avec K=32.
+		uint32_t w, l;
+		ApplyEloUpdate(1500, 1500, 32, w, l);
+		if (w != 1516 || l != 1484) return false;
+		LOG_INFO(Core, "[ArenaTests] ELO equal OK");
+		return true;
+	}
+
+	bool TestEloFavoriteWins()
+	{
+		// 1700 bat 1300 : gagne tres peu (favori attendu).
+		uint32_t w, l;
+		ApplyEloUpdate(1700, 1300, 32, w, l);
+		// expected ~0.91, gain ~32*0.09 ~= 3
+		if (!(w >= 1701 && w <= 1706)) return false;
+		if (!(l >= 1294 && l <= 1299)) return false;
+		LOG_INFO(Core, "[ArenaTests] ELO favorite wins OK");
+		return true;
+	}
+
+	bool TestRecordMatch()
+	{
+		ArenaTeamRegistry r;
+		ArenaTeam a{1, TeamSize::v2, "A", {}, 1500, 0, 0, 0, 0};
+		ArenaTeam b{2, TeamSize::v2, "B", {}, 1500, 0, 0, 0, 0};
+		r.AddTeam(a);
+		r.AddTeam(b);
+		if (!r.RecordMatch(1, 2)) return false;
+		auto* aa = r.Get(1);
+		auto* bb = r.Get(2);
+		if (aa->rating != 1516) return false;
+		if (bb->rating != 1484) return false;
+		if (aa->seasonWins != 1 || aa->seasonGames != 1) return false;
+		if (bb->seasonWins != 0 || bb->seasonGames != 1) return false;
+		LOG_INFO(Core, "[ArenaTests] record match OK");
+		return true;
+	}
+
+	bool TestUnknownMatch()
+	{
+		ArenaTeamRegistry r;
+		if (r.RecordMatch(99, 100)) return false;
+		LOG_INFO(Core, "[ArenaTests] unknown match OK");
+		return true;
+	}
+
+	bool TestResetWeekly()
+	{
+		ArenaTeamRegistry r;
+		r.AddTeam(ArenaTeam{1, TeamSize::v3, "X", {}, 1500, 0, 0, 0, 0});
+		r.AddTeam(ArenaTeam{2, TeamSize::v3, "Y", {}, 1500, 0, 0, 0, 0});
+		r.RecordMatch(1, 2);
+		auto* x = r.Get(1);
+		if (x->weeklyGames != 1 || x->seasonGames != 1) return false;
+		r.ResetWeekly();
+		x = r.Get(1);
+		if (x->weeklyGames != 0) return false;
+		if (x->seasonGames != 1) return false; // saison preservee
+		LOG_INFO(Core, "[ArenaTests] reset weekly OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEloEqual() && TestEloFavoriteWins() && TestRecordMatch()
+	             && TestUnknownMatch() && TestResetWeekly();
+	if (ok) LOG_INFO(Core, "[ArenaTests] ALL OK");
+	else LOG_ERROR(Core, "[ArenaTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/auction/AuctionHouseBot.h
+++ b/engine/server/auction/AuctionHouseBot.h
@@ -1,0 +1,70 @@
+#pragma once
+// CMANGOS.44 (Phase 5.44a) — AuctionHouseBot : alimente l'hotel des
+// ventes en items/encheres simulees pour serveur low-pop. Header-only.
+//
+// Activation conditionnelle (config) — dort si la pop est suffisante.
+// Genere des listings deterministes (seed-based) pour faciliter tests.
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace engine::server::auction
+{
+	using ItemTemplateId = uint32_t;
+
+	struct AhBotListing
+	{
+		ItemTemplateId  itemTemplateId;
+		uint32_t        count;
+		uint64_t        startBidCopper;
+		uint64_t        buyoutCopper;     ///< 0 = pas de buyout
+		uint64_t        durationMs;       ///< 12h, 24h, 48h
+	};
+
+	struct AhBotConfig
+	{
+		uint32_t targetActiveListings = 50;  ///< cible totale d'encheres actives
+		uint32_t maxListingsPerTick   = 5;   ///< rate-limit par tick (eviter spam)
+		uint64_t seed                 = 0;
+	};
+
+	class AuctionHouseBot
+	{
+	public:
+		explicit AuctionHouseBot(AhBotConfig cfg)
+			: m_cfg(cfg), m_rng(cfg.seed) {}
+
+		/// Genere jusqu'a \p missing nouveaux listings (clamp a maxListingsPerTick).
+		std::vector<AhBotListing> Tick(uint32_t currentActive)
+		{
+			std::vector<AhBotListing> out;
+			if (currentActive >= m_cfg.targetActiveListings) return out;
+
+			uint32_t deficit = m_cfg.targetActiveListings - currentActive;
+			if (deficit > m_cfg.maxListingsPerTick) deficit = m_cfg.maxListingsPerTick;
+
+			std::uniform_int_distribution<uint32_t> itemDist(1, 10000);
+			std::uniform_int_distribution<uint32_t> countDist(1, 5);
+			std::uniform_int_distribution<uint64_t> bidDist(1, 100);
+			for (uint32_t i = 0; i < deficit; ++i)
+			{
+				AhBotListing l;
+				l.itemTemplateId = itemDist(m_rng);
+				l.count          = countDist(m_rng);
+				l.startBidCopper = bidDist(m_rng) * 10000ull;        // 1-100 silver
+				l.buyoutCopper   = l.startBidCopper * 3;
+				l.durationMs     = 24ull * 3600ull * 1000ull;        // 24h
+				out.push_back(l);
+			}
+			return out;
+		}
+
+		const AhBotConfig& Config() const { return m_cfg; }
+
+	private:
+		AhBotConfig    m_cfg;
+		std::mt19937_64 m_rng;
+	};
+}

--- a/engine/server/auction/AuctionHouseBotTests.cpp
+++ b/engine/server/auction/AuctionHouseBotTests.cpp
@@ -1,0 +1,87 @@
+#include "engine/server/auction/AuctionHouseBot.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::auction;
+
+	bool TestNoOpWhenAtTarget()
+	{
+		AhBotConfig cfg;
+		cfg.targetActiveListings = 50;
+		cfg.maxListingsPerTick   = 10;
+		cfg.seed                 = 42;
+		AuctionHouseBot b(cfg);
+		auto listings = b.Tick(50);
+		if (!listings.empty()) return false;
+		listings = b.Tick(100);
+		if (!listings.empty()) return false;
+		LOG_INFO(Core, "[AhBotTests] noop at target OK");
+		return true;
+	}
+
+	bool TestRateLimited()
+	{
+		AhBotConfig cfg;
+		cfg.targetActiveListings = 100;
+		cfg.maxListingsPerTick   = 5;
+		cfg.seed                 = 1;
+		AuctionHouseBot b(cfg);
+		// 0 actif, target 100, max par tick 5 => 5 listings
+		auto listings = b.Tick(0);
+		if (listings.size() != 5) return false;
+		LOG_INFO(Core, "[AhBotTests] rate limit OK");
+		return true;
+	}
+
+	bool TestDeficitSmallerThanMax()
+	{
+		AhBotConfig cfg;
+		cfg.targetActiveListings = 50;
+		cfg.maxListingsPerTick   = 10;
+		cfg.seed                 = 7;
+		AuctionHouseBot b(cfg);
+		// 47 actif, target 50, max 10 => 3 listings (deficit < max)
+		auto listings = b.Tick(47);
+		if (listings.size() != 3) return false;
+		LOG_INFO(Core, "[AhBotTests] deficit smaller than max OK");
+		return true;
+	}
+
+	bool TestDeterministicSeed()
+	{
+		AhBotConfig cfg;
+		cfg.targetActiveListings = 100;
+		cfg.maxListingsPerTick   = 3;
+		cfg.seed                 = 1234;
+		AuctionHouseBot b1(cfg);
+		AuctionHouseBot b2(cfg);
+		auto a = b1.Tick(0);
+		auto b = b2.Tick(0);
+		if (a.size() != b.size()) return false;
+		for (size_t i = 0; i < a.size(); ++i)
+		{
+			if (a[i].itemTemplateId != b[i].itemTemplateId) return false;
+			if (a[i].count          != b[i].count) return false;
+			if (a[i].startBidCopper != b[i].startBidCopper) return false;
+		}
+		LOG_INFO(Core, "[AhBotTests] deterministic seed OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestNoOpWhenAtTarget() && TestRateLimited()
+	             && TestDeficitSmallerThanMax() && TestDeterministicSeed();
+	if (ok) LOG_INFO(Core, "[AhBotTests] ALL OK");
+	else LOG_ERROR(Core, "[AhBotTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/battleground/BattleGroundQueue.h
+++ b/engine/server/battleground/BattleGroundQueue.h
@@ -1,0 +1,85 @@
+#pragma once
+// CMANGOS.10 (Phase 4.10a) — BattleGroundQueue : matchmaking de file
+// d'attente PvP instancie (BG type, taille equipe, faction-balanced).
+// Header-only.
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::battleground
+{
+	using BgType    = uint16_t;
+	using PlayerId  = uint64_t;
+	using FactionId = uint8_t;  ///< 0 = Alliance, 1 = Horde
+
+	struct QueueEntry
+	{
+		PlayerId  player = 0;
+		FactionId fac    = 0;
+		uint64_t  enqueueMs = 0;
+	};
+
+	struct MatchProposal
+	{
+		BgType                     bg;
+		std::vector<PlayerId>      alliance;
+		std::vector<PlayerId>      horde;
+	};
+
+	/// Queue par bg type. Politique : equipes equilibrees par faction,
+	/// FIFO sur l'ordre d'arrivee.
+	class BattleGroundQueue
+	{
+	public:
+		void Enqueue(BgType bg, PlayerId p, FactionId fac, uint64_t nowMs)
+		{
+			m_queues[bg].push_back({p, fac, nowMs});
+		}
+
+		size_t Size(BgType bg) const
+		{
+			auto it = m_queues.find(bg);
+			return (it == m_queues.end()) ? 0 : it->second.size();
+		}
+
+		/// Tente de former un match avec \p teamSize joueurs par cote.
+		/// Retourne nullopt si pas assez de candidats par faction.
+		/// Retire les joueurs selectionnes de la queue.
+		std::optional<MatchProposal> TryMakeMatch(BgType bg, size_t teamSize)
+		{
+			auto it = m_queues.find(bg);
+			if (it == m_queues.end()) return std::nullopt;
+
+			std::vector<size_t> aIdx, hIdx;
+			auto& q = it->second;
+			for (size_t i = 0; i < q.size(); ++i)
+			{
+				if (q[i].fac == 0 && aIdx.size() < teamSize) aIdx.push_back(i);
+				else if (q[i].fac == 1 && hIdx.size() < teamSize) hIdx.push_back(i);
+				if (aIdx.size() == teamSize && hIdx.size() == teamSize) break;
+			}
+			if (aIdx.size() != teamSize || hIdx.size() != teamSize) return std::nullopt;
+
+			MatchProposal p;
+			p.bg = bg;
+			for (auto i : aIdx) p.alliance.push_back(q[i].player);
+			for (auto i : hIdx) p.horde.push_back(q[i].player);
+
+			// Retire en ordre decroissant pour preserver les indices.
+			std::vector<size_t> all;
+			all.insert(all.end(), aIdx.begin(), aIdx.end());
+			all.insert(all.end(), hIdx.begin(), hIdx.end());
+			std::sort(all.begin(), all.end(), std::greater<size_t>());
+			for (auto i : all) q.erase(q.begin() + i);
+
+			return p;
+		}
+
+	private:
+		std::unordered_map<BgType, std::vector<QueueEntry>> m_queues;
+	};
+}

--- a/engine/server/battleground/BattleGroundQueueTests.cpp
+++ b/engine/server/battleground/BattleGroundQueueTests.cpp
@@ -1,0 +1,75 @@
+#include "engine/server/battleground/BattleGroundQueue.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::battleground;
+
+	bool TestEmpty()
+	{
+		BattleGroundQueue q;
+		if (q.Size(1) != 0) return false;
+		auto m = q.TryMakeMatch(1, 5);
+		if (m.has_value()) return false;
+		LOG_INFO(Core, "[BgQueueTests] empty OK");
+		return true;
+	}
+
+	bool TestImbalanced()
+	{
+		BattleGroundQueue q;
+		// 4 alliance, 0 horde => pas de match
+		for (int i = 0; i < 4; ++i) q.Enqueue(1, 100 + i, 0, 1000 + i);
+		auto m = q.TryMakeMatch(1, 2);
+		if (m.has_value()) return false;
+		if (q.Size(1) != 4) return false;
+		LOG_INFO(Core, "[BgQueueTests] imbalanced rejected OK");
+		return true;
+	}
+
+	bool TestMatch5v5()
+	{
+		BattleGroundQueue q;
+		// 7 alliance + 6 horde => peut former 5v5, restent 2A + 1H
+		for (int i = 0; i < 7; ++i) q.Enqueue(2, 100 + i, 0, 1000 + i);
+		for (int i = 0; i < 6; ++i) q.Enqueue(2, 200 + i, 1, 2000 + i);
+		auto m = q.TryMakeMatch(2, 5);
+		if (!m) return false;
+		if (m->alliance.size() != 5 || m->horde.size() != 5) return false;
+		// FIFO : alliance picks should be 100..104
+		if (m->alliance[0] != 100 || m->alliance[4] != 104) return false;
+		if (m->horde[0]    != 200 || m->horde[4]    != 204) return false;
+		// Restent 2 alliance + 1 horde
+		if (q.Size(2) != 3) return false;
+		LOG_INFO(Core, "[BgQueueTests] match 5v5 OK");
+		return true;
+	}
+
+	bool TestExactSize()
+	{
+		BattleGroundQueue q;
+		q.Enqueue(3, 1, 0, 100);
+		q.Enqueue(3, 2, 1, 101);
+		auto m = q.TryMakeMatch(3, 1);
+		if (!m) return false;
+		if (m->alliance.size() != 1 || m->horde.size() != 1) return false;
+		if (q.Size(3) != 0) return false;
+		LOG_INFO(Core, "[BgQueueTests] exact size OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestImbalanced() && TestMatch5v5() && TestExactSize();
+	if (ok) LOG_INFO(Core, "[BgQueueTests] ALL OK");
+	else LOG_ERROR(Core, "[BgQueueTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/formulas/Formulas.h
+++ b/engine/server/formulas/Formulas.h
@@ -1,0 +1,52 @@
+#pragma once
+// CMANGOS.40 (Phase 4.40a) — Formulas : table de constantes/formules de jeu
+// (XP par niveau, drop bonus, dist agro, base stats par classe). Header-only.
+
+#include <cstdint>
+#include <algorithm>
+
+namespace engine::server::formulas
+{
+	/// XP requis pour passer du niveau \p level au level+1.
+	/// Approximation cubique douce : 100 * level^2 + 200 * level.
+	/// Cap a niveau 80 (XP = 0 au-dela).
+	inline uint32_t XpToNextLevel(uint8_t level)
+	{
+		if (level == 0 || level >= 80) return 0;
+		const uint32_t l = level;
+		return 100u * l * l + 200u * l;
+	}
+
+	/// Distance d'agro (yards) selon difference de niveau (mob - player).
+	/// Mob plus haut niveau => detecte de plus loin.
+	inline float AggroRadiusYards(int8_t levelDiff)
+	{
+		// base 20 yards, +/- 1 yard par niveau, clamp [5, 45].
+		float r = 20.0f + static_cast<float>(levelDiff);
+		if (r < 5.0f)  r = 5.0f;
+		if (r > 45.0f) r = 45.0f;
+		return r;
+	}
+
+	/// Bonus de drop (multiplicateur) en fonction du nombre de joueurs en groupe.
+	/// 1 joueur = 1.0, 2 = 1.0, 3+ = 1.0 (le drop ne change pas, c'est le partage
+	/// qui change). Mais si le mob est elite, x1.5. Petite formule consolidee.
+	inline float DropQuantityMultiplier(uint8_t partySize, bool eliteMob)
+	{
+		float m = 1.0f;
+		if (eliteMob) m *= 1.5f;
+		if (partySize >= 5) m *= 1.1f; // raid bonus minimal
+		return m;
+	}
+
+	/// Base health par niveau pour une classe approximative (warrior).
+	/// Utilise comme baseline avant stat bonuses.
+	inline uint32_t WarriorBaseHealth(uint8_t level)
+	{
+		if (level == 0) return 0;
+		// 100 base + 50 par niveau, +5 par niveau au-dessus de 60.
+		uint32_t hp = 100u + 50u * level;
+		if (level > 60) hp += 5u * (level - 60u);
+		return hp;
+	}
+}

--- a/engine/server/formulas/FormulasTests.cpp
+++ b/engine/server/formulas/FormulasTests.cpp
@@ -1,0 +1,69 @@
+#include "engine/server/formulas/Formulas.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::formulas;
+
+	bool TestXpProgression()
+	{
+		if (XpToNextLevel(0)  != 0) return false;
+		if (XpToNextLevel(80) != 0) return false;
+		if (XpToNextLevel(100)!= 0) return false;
+		// progression : level 1 < level 2 < level 79
+		if (!(XpToNextLevel(1) < XpToNextLevel(2))) return false;
+		if (!(XpToNextLevel(2) < XpToNextLevel(79))) return false;
+		LOG_INFO(Core, "[FormulasTests] xp progression OK");
+		return true;
+	}
+
+	bool TestAggroRadius()
+	{
+		if (AggroRadiusYards(0)  != 20.0f) return false;
+		if (AggroRadiusYards(5)  != 25.0f) return false;
+		if (AggroRadiusYards(-5) != 15.0f) return false;
+		// clamp
+		if (AggroRadiusYards(100) != 45.0f) return false;
+		if (AggroRadiusYards(-100)!= 5.0f)  return false;
+		LOG_INFO(Core, "[FormulasTests] aggro radius OK");
+		return true;
+	}
+
+	bool TestDropMultiplier()
+	{
+		if (DropQuantityMultiplier(1, false) != 1.0f) return false;
+		if (DropQuantityMultiplier(1, true)  != 1.5f) return false;
+		// 5 joueurs + elite : 1.0 * 1.5 * 1.1 = 1.65
+		float m = DropQuantityMultiplier(5, true);
+		if (m < 1.64f || m > 1.66f) return false;
+		LOG_INFO(Core, "[FormulasTests] drop multiplier OK");
+		return true;
+	}
+
+	bool TestWarriorHp()
+	{
+		if (WarriorBaseHealth(0)  != 0) return false;
+		if (WarriorBaseHealth(1)  != 150) return false;
+		if (WarriorBaseHealth(60) != 100u + 50u*60u) return false;
+		// au niveau 70 : 100 + 50*70 + 5*10 = 3650
+		if (WarriorBaseHealth(70) != 3650) return false;
+		LOG_INFO(Core, "[FormulasTests] warrior HP OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestXpProgression() && TestAggroRadius() && TestDropMultiplier()
+	             && TestWarriorHp();
+	if (ok) LOG_INFO(Core, "[FormulasTests] ALL OK");
+	else LOG_ERROR(Core, "[FormulasTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/gmtickets/MysqlGmTicketStore.cpp
+++ b/engine/server/gmtickets/MysqlGmTicketStore.cpp
@@ -1,0 +1,147 @@
+#include "engine/server/gmtickets/MysqlGmTicketStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::gmtickets
+{
+	namespace
+	{
+		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+
+		GmTicket RowToTicket(MYSQL_ROW row)
+		{
+			GmTicket t;
+			if (row[0]) t.id           = std::strtoull(row[0], nullptr, 10);
+			if (row[1]) t.reporter     = std::strtoull(row[1], nullptr, 10);
+			if (row[2]) t.body         = row[2];
+			if (row[3]) t.createdTsMs  = std::strtoull(row[3], nullptr, 10);
+			if (row[4]) t.resolvedTsMs = std::strtoull(row[4], nullptr, 10);
+			if (row[5]) t.assignedGm   = std::strtoull(row[5], nullptr, 10);
+			if (row[6])
+			{
+				const auto st = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+				t.state = static_cast<TicketState>(std::min<uint32_t>(st, 3));
+			}
+			return t;
+		}
+	}
+
+	uint64_t MysqlGmTicketStore::Insert(GmTicket& out)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0;
+
+		const std::string body = EscapeMysql(mysql, out.body);
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO gm_tickets (reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state) "
+			"VALUES (%llu, '%s', %llu, %llu, %llu, %u)",
+			static_cast<unsigned long long>(out.reporter),
+			body.c_str(),
+			static_cast<unsigned long long>(out.createdTsMs),
+			static_cast<unsigned long long>(out.resolvedTsMs),
+			static_cast<unsigned long long>(out.assignedGm),
+			static_cast<unsigned>(out.state));
+
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_ERROR(Core, "[MysqlGmTicketStore] Insert failed");
+			return 0;
+		}
+		out.id = mysql_insert_id(mysql);
+		return out.id;
+	}
+
+	bool MysqlGmTicketStore::Update(const GmTicket& t)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		const std::string body = EscapeMysql(mysql, t.body);
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"UPDATE gm_tickets SET body = '%s', resolved_ts_ms = %llu, "
+			"assigned_gm = %llu, state = %u WHERE ticket_id = %llu",
+			body.c_str(),
+			static_cast<unsigned long long>(t.resolvedTsMs),
+			static_cast<unsigned long long>(t.assignedGm),
+			static_cast<unsigned>(t.state),
+			static_cast<unsigned long long>(t.id));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlGmTicketStore::Delete(TicketId id)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+		char sql[128];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM gm_tickets WHERE ticket_id = %llu",
+			static_cast<unsigned long long>(id));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::optional<GmTicket> MysqlGmTicketStore::Find(TicketId id) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return std::nullopt;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return std::nullopt;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state "
+			"FROM gm_tickets WHERE ticket_id = %llu LIMIT 1",
+			static_cast<unsigned long long>(id));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return std::nullopt;
+		std::optional<GmTicket> out;
+		if (MYSQL_ROW row = mysql_fetch_row(res))
+			out = RowToTicket(row);
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	std::vector<GmTicket> MysqlGmTicketStore::ListOpen() const
+	{
+		std::vector<GmTicket> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql =
+			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
+			"resolved_ts_ms, assigned_gm, state "
+			"FROM gm_tickets WHERE state = 0 ORDER BY created_ts_ms ASC";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+			out.push_back(RowToTicket(row));
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/gmtickets/MysqlGmTicketStore.h
+++ b/engine/server/gmtickets/MysqlGmTicketStore.h
@@ -1,0 +1,37 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32b) — MysqlGmTicketStore : persistance MySQL des
+// tickets GM (table gm_tickets, migration 0046). Cible UNIX shard.
+// Le WIN32 sandbox utilise GmTicketSystem (header-only en memoire).
+
+#include "engine/server/gmtickets/GmTicketSystem.h"
+
+#include <optional>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::gmtickets
+{
+	class MysqlGmTicketStore
+	{
+	public:
+		explicit MysqlGmTicketStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Insert : remplit \p out.id avec l'AUTO_INCREMENT genere par MySQL.
+		/// Retourne 0 en cas d'echec.
+		uint64_t Insert(GmTicket& out);
+
+		/// Update tous les champs mutables (state, assignedGm, resolvedTsMs, body).
+		bool Update(const GmTicket& t);
+
+		bool Delete(TicketId id);
+		std::optional<GmTicket> Find(TicketId id) const;
+
+		/// Tous les tickets dans state == Open (queue support GM).
+		std::vector<GmTicket> ListOpen() const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}

--- a/engine/server/guild/GuildPermissionMatrix.h
+++ b/engine/server/guild/GuildPermissionMatrix.h
@@ -1,0 +1,82 @@
+#pragma once
+// CMANGOS.21 (Phase 3.21a) — GuildPermissionMatrix : matrice de permissions
+// par rang de guilde (data-driven). Differe de GuildSystem.cpp deja present
+// en se focalisant sur la check de permission, pas la persistance/wire.
+// Header-only.
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace engine::server::guild
+{
+	using GuildId = uint32_t;
+	using RankId  = uint8_t;  ///< 0 = Guild Master, 9 = Initiate (a la WoW)
+
+	enum class Permission : uint32_t
+	{
+		None         = 0,
+		Invite       = 1u << 0,
+		Remove       = 1u << 1,
+		Promote      = 1u << 2,
+		Demote       = 1u << 3,
+		EditMotd     = 1u << 4,
+		EditTabard   = 1u << 5,
+		WithdrawGold = 1u << 6,
+		BankView     = 1u << 7,
+		BankDeposit  = 1u << 8,
+		BankWithdraw = 1u << 9,
+		Disband      = 1u << 10,
+	};
+
+	inline uint32_t Bit(Permission p) { return static_cast<uint32_t>(p); }
+
+	struct RankPerms
+	{
+		uint32_t mask = 0; ///< OR de Permission::* bits
+	};
+
+	class GuildPermissionMatrix
+	{
+	public:
+		void SetRank(GuildId g, RankId r, uint32_t mask) { m_perms[g][r].mask = mask; }
+
+		bool HasPerm(GuildId g, RankId r, Permission p) const
+		{
+			auto git = m_perms.find(g);
+			if (git == m_perms.end()) return false;
+			auto rit = git->second.find(r);
+			if (rit == git->second.end()) return false;
+			return (rit->second.mask & Bit(p)) != 0;
+		}
+
+		/// Configure le defaut WoW-like : GM=tout, Officer=invite/remove/promote +
+		/// bank, Member=bank view/deposit, Initiate=rien.
+		void SetupWowDefaults(GuildId g)
+		{
+			const uint32_t all =
+				Bit(Permission::Invite) | Bit(Permission::Remove) |
+				Bit(Permission::Promote) | Bit(Permission::Demote) |
+				Bit(Permission::EditMotd) | Bit(Permission::EditTabard) |
+				Bit(Permission::WithdrawGold) | Bit(Permission::BankView) |
+				Bit(Permission::BankDeposit) | Bit(Permission::BankWithdraw) |
+				Bit(Permission::Disband);
+			SetRank(g, 0, all);
+
+			const uint32_t officer =
+				Bit(Permission::Invite) | Bit(Permission::Remove) |
+				Bit(Permission::Promote) | Bit(Permission::Demote) |
+				Bit(Permission::BankView) | Bit(Permission::BankDeposit) |
+				Bit(Permission::BankWithdraw);
+			SetRank(g, 1, officer);
+
+			const uint32_t member =
+				Bit(Permission::BankView) | Bit(Permission::BankDeposit);
+			SetRank(g, 5, member);
+
+			SetRank(g, 9, 0); // Initiate
+		}
+
+	private:
+		std::unordered_map<GuildId, std::unordered_map<RankId, RankPerms>> m_perms;
+	};
+}

--- a/engine/server/guild/GuildPermissionMatrixTests.cpp
+++ b/engine/server/guild/GuildPermissionMatrixTests.cpp
@@ -1,0 +1,60 @@
+#include "engine/server/guild/GuildPermissionMatrix.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::guild;
+
+	bool TestUnknown()
+	{
+		GuildPermissionMatrix m;
+		if (m.HasPerm(1, 0, Permission::Invite)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] unknown rejected OK");
+		return true;
+	}
+
+	bool TestExplicitMask()
+	{
+		GuildPermissionMatrix m;
+		m.SetRank(10, 5, Bit(Permission::BankView) | Bit(Permission::Invite));
+		if (!m.HasPerm(10, 5, Permission::BankView)) return false;
+		if (!m.HasPerm(10, 5, Permission::Invite)) return false;
+		if (m.HasPerm(10, 5, Permission::Disband)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] explicit mask OK");
+		return true;
+	}
+
+	bool TestWowDefaults()
+	{
+		GuildPermissionMatrix m;
+		m.SetupWowDefaults(20);
+		// GM (rank 0) : tout
+		if (!m.HasPerm(20, 0, Permission::Disband)) return false;
+		if (!m.HasPerm(20, 0, Permission::Invite)) return false;
+		// Officer (rank 1) : pas Disband
+		if (m.HasPerm(20, 1, Permission::Disband)) return false;
+		if (!m.HasPerm(20, 1, Permission::Invite)) return false;
+		// Member (rank 5) : pas Invite
+		if (m.HasPerm(20, 5, Permission::Invite)) return false;
+		if (!m.HasPerm(20, 5, Permission::BankView)) return false;
+		// Initiate (rank 9) : rien
+		if (m.HasPerm(20, 9, Permission::BankView)) return false;
+		LOG_INFO(Core, "[GuildPermsTests] WoW defaults OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestUnknown() && TestExplicitMask() && TestWowDefaults();
+	if (ok) LOG_INFO(Core, "[GuildPermsTests] ALL OK");
+	else LOG_ERROR(Core, "[GuildPermsTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/messager/Messager.h
+++ b/engine/server/messager/Messager.h
@@ -1,0 +1,51 @@
+#pragma once
+// CMANGOS.35 (Phase 4.35a) — Messager : queue MPSC simple (multi producer
+// single consumer) pour passer des messages entre threads sans verrou par
+// message dans le hot path. Header-only, std::mutex (pas de lock-free).
+//
+// Usage typique : workers async (DB, AI tick, scripts) postent des messages,
+// le main game loop draine la queue 1x par tick.
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+#include <utility>
+
+namespace engine::server::messager
+{
+	template<typename T>
+	class Messager
+	{
+	public:
+		void Post(T msg)
+		{
+			std::lock_guard<std::mutex> lk(m_mtx);
+			m_queue.push_back(std::move(msg));
+		}
+
+		/// Vide la queue dans \p out. Retourne le nombre de messages drainees.
+		/// \p out est append-only (les anciens elements sont conserves).
+		size_t Drain(std::vector<T>& out)
+		{
+			std::vector<T> tmp;
+			{
+				std::lock_guard<std::mutex> lk(m_mtx);
+				tmp.swap(m_queue);
+			}
+			out.insert(out.end(),
+			           std::make_move_iterator(tmp.begin()),
+			           std::make_move_iterator(tmp.end()));
+			return tmp.size();
+		}
+
+		size_t Size() const
+		{
+			std::lock_guard<std::mutex> lk(m_mtx);
+			return m_queue.size();
+		}
+
+	private:
+		mutable std::mutex m_mtx;
+		std::vector<T>     m_queue;
+	};
+}

--- a/engine/server/messager/MessagerTests.cpp
+++ b/engine/server/messager/MessagerTests.cpp
@@ -1,0 +1,82 @@
+#include "engine/server/messager/Messager.h"
+#include "engine/core/Log.h"
+
+#include <thread>
+#include <atomic>
+#include <vector>
+
+namespace
+{
+	using engine::server::messager::Messager;
+
+	bool TestSingleThreaded()
+	{
+		Messager<int> m;
+		m.Post(1);
+		m.Post(2);
+		m.Post(3);
+		if (m.Size() != 3) return false;
+
+		std::vector<int> drained;
+		auto n = m.Drain(drained);
+		if (n != 3 || drained.size() != 3) return false;
+		if (drained[0] != 1 || drained[1] != 2 || drained[2] != 3) return false;
+		if (m.Size() != 0) return false;
+
+		std::vector<int> drained2;
+		if (m.Drain(drained2) != 0) return false;
+		LOG_INFO(Core, "[MessagerTests] single thread OK");
+		return true;
+	}
+
+	bool TestMultiProducer()
+	{
+		Messager<uint64_t> m;
+		const int producers = 4;
+		const int perProducer = 1000;
+
+		std::vector<std::thread> threads;
+		for (int p = 0; p < producers; ++p)
+		{
+			threads.emplace_back([&m, p]() {
+				for (int i = 0; i < perProducer; ++i)
+					m.Post(static_cast<uint64_t>(p) * 100000 + i);
+			});
+		}
+		for (auto& t : threads) t.join();
+
+		std::vector<uint64_t> drained;
+		m.Drain(drained);
+		if (drained.size() != static_cast<size_t>(producers * perProducer)) return false;
+		LOG_INFO(Core, "[MessagerTests] multi producer OK");
+		return true;
+	}
+
+	bool TestMoveOnly()
+	{
+		Messager<std::vector<int>> m;
+		std::vector<int> v = {1, 2, 3};
+		m.Post(std::move(v));
+		std::vector<std::vector<int>> drained;
+		m.Drain(drained);
+		if (drained.size() != 1) return false;
+		if (drained[0].size() != 3) return false;
+		LOG_INFO(Core, "[MessagerTests] move-only payload OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestSingleThreaded() && TestMultiProducer() && TestMoveOnly();
+	if (ok) LOG_INFO(Core, "[MessagerTests] ALL OK");
+	else LOG_ERROR(Core, "[MessagerTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/metric/MetricRegistry.h
+++ b/engine/server/metric/MetricRegistry.h
@@ -1,0 +1,93 @@
+#pragma once
+// CMANGOS.34 (Phase 4.34a) — MetricRegistry : compteurs et histogrammes
+// internes (ticks/sec, queries/sec, AI updates/sec) pour observabilite.
+// Header-only. Differe de PrometheusMetrics (deja present) en exposant un
+// registry generic interrogeable a tout instant pour debug/admin.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+
+namespace engine::server::metric
+{
+	/// Compteur monotone (incremente uniquement). Sert a quantifier les
+	/// evenements cumules.
+	struct Counter
+	{
+		uint64_t value = 0;
+		void Inc(uint64_t n = 1) { value += n; }
+	};
+
+	/// Gauge : valeur instantanee (peut monter ou descendre). Sessions actives,
+	/// memoire residente, etc.
+	struct Gauge
+	{
+		int64_t value = 0;
+		void Set(int64_t v) { value = v; }
+		void Add(int64_t d) { value += d; }
+	};
+
+	/// Histogramme simple (buckets fixes, fournis a la creation). Pour
+	/// distribution de latence, taille de paquet, etc.
+	struct Histogram
+	{
+		std::vector<uint64_t> bounds;     ///< borne sup inclusive de chaque bucket
+		std::vector<uint64_t> bucketCount;///< meme taille que bounds + 1 (overflow)
+		uint64_t totalCount = 0;
+		double   sum        = 0.0;
+
+		void Observe(double v)
+		{
+			totalCount++;
+			sum += v;
+			for (size_t i = 0; i < bounds.size(); ++i)
+			{
+				if (v <= static_cast<double>(bounds[i]))
+				{
+					bucketCount[i]++;
+					return;
+				}
+			}
+			bucketCount.back()++;
+		}
+
+		double Mean() const
+		{
+			return totalCount ? sum / static_cast<double>(totalCount) : 0.0;
+		}
+	};
+
+	class MetricRegistry
+	{
+	public:
+		Counter& GetCounter(const std::string& name) { return m_counters[name]; }
+		Gauge&   GetGauge(const std::string& name)   { return m_gauges[name]; }
+
+		Histogram& CreateHistogram(const std::string& name, std::vector<uint64_t> bounds)
+		{
+			auto& h = m_histograms[name];
+			h.bounds = std::move(bounds);
+			h.bucketCount.assign(h.bounds.size() + 1, 0);
+			h.totalCount = 0;
+			h.sum = 0.0;
+			return h;
+		}
+
+		Histogram* GetHistogram(const std::string& name)
+		{
+			auto it = m_histograms.find(name);
+			return (it == m_histograms.end()) ? nullptr : &it->second;
+		}
+
+		size_t CounterCount() const   { return m_counters.size(); }
+		size_t GaugeCount() const     { return m_gauges.size(); }
+		size_t HistogramCount() const { return m_histograms.size(); }
+
+	private:
+		std::unordered_map<std::string, Counter>   m_counters;
+		std::unordered_map<std::string, Gauge>     m_gauges;
+		std::unordered_map<std::string, Histogram> m_histograms;
+	};
+}

--- a/engine/server/metric/MetricRegistryTests.cpp
+++ b/engine/server/metric/MetricRegistryTests.cpp
@@ -1,0 +1,81 @@
+#include "engine/server/metric/MetricRegistry.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::metric;
+
+	bool TestCounter()
+	{
+		MetricRegistry r;
+		auto& c = r.GetCounter("ticks");
+		c.Inc();
+		c.Inc(5);
+		if (c.value != 6) return false;
+		// meme nom retourne meme compteur
+		auto& c2 = r.GetCounter("ticks");
+		if (c2.value != 6) return false;
+		LOG_INFO(Core, "[MetricTests] counter OK");
+		return true;
+	}
+
+	bool TestGauge()
+	{
+		MetricRegistry r;
+		auto& g = r.GetGauge("sessions");
+		g.Set(10);
+		g.Add(-3);
+		if (g.value != 7) return false;
+		LOG_INFO(Core, "[MetricTests] gauge OK");
+		return true;
+	}
+
+	bool TestHistogramBuckets()
+	{
+		MetricRegistry r;
+		auto& h = r.CreateHistogram("lat_ms", {10, 50, 100, 500});
+		h.Observe(5);   // bucket 0
+		h.Observe(10);  // bucket 0 (inclusif)
+		h.Observe(30);  // bucket 1
+		h.Observe(200); // bucket 3
+		h.Observe(1000);// overflow bucket
+		if (h.totalCount != 5) return false;
+		if (h.bucketCount.size() != 5) return false;
+		if (h.bucketCount[0] != 2) return false;
+		if (h.bucketCount[1] != 1) return false;
+		if (h.bucketCount[2] != 0) return false;
+		if (h.bucketCount[3] != 1) return false;
+		if (h.bucketCount[4] != 1) return false; // overflow
+		// mean = (5+10+30+200+1000)/5 = 249
+		if (h.Mean() < 248.5 || h.Mean() > 249.5) return false;
+		LOG_INFO(Core, "[MetricTests] histogram buckets OK");
+		return true;
+	}
+
+	bool TestRegistrySize()
+	{
+		MetricRegistry r;
+		r.GetCounter("a"); r.GetCounter("b");
+		r.GetGauge("g");
+		r.CreateHistogram("h", {1, 2});
+		if (r.CounterCount() != 2 || r.GaugeCount() != 1 || r.HistogramCount() != 1)
+			return false;
+		LOG_INFO(Core, "[MetricTests] registry size OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestCounter() && TestGauge() && TestHistogramBuckets() && TestRegistrySize();
+	if (ok) LOG_INFO(Core, "[MetricTests] ALL OK");
+	else LOG_ERROR(Core, "[MetricTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/packetlog/PacketLog.h
+++ b/engine/server/packetlog/PacketLog.h
@@ -1,0 +1,86 @@
+#pragma once
+// CMANGOS.12 (Phase 4.12a) — PacketLog : ring buffer in-memory des derniers
+// paquets recus/envoyes par session, pour debug/post-mortem. Header-only.
+//
+// Usage : sur un crash ou un kick suspect, dump du PacketLog d'une session
+// dans le crash report. Volontairement simple : pas de fichier disque, pas
+// de filtrage runtime — c'est un buffer pour observation, pas de l'audit.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace engine::server::packetlog
+{
+	enum class Direction : uint8_t { In, Out };
+
+	struct Entry
+	{
+		uint64_t  tsMs    = 0;
+		uint16_t  opcode  = 0;
+		uint32_t  size    = 0;
+		Direction dir     = Direction::In;
+		// On conserve un prefix de payload (premieres N octets) pour debug
+		// sans peter la memoire. Reste tronque dans Push.
+		std::vector<uint8_t> prefix;
+	};
+
+	class PacketLog
+	{
+	public:
+		explicit PacketLog(size_t capacity = 256, size_t prefixBytes = 32)
+			: m_cap(capacity), m_prefixBytes(prefixBytes)
+		{
+			m_ring.reserve(capacity);
+		}
+
+		void Push(Direction dir, uint16_t opcode, uint64_t tsMs,
+		          const uint8_t* data, uint32_t size)
+		{
+			Entry e;
+			e.tsMs   = tsMs;
+			e.opcode = opcode;
+			e.size   = size;
+			e.dir    = dir;
+			const uint32_t take = (size < m_prefixBytes) ? size : static_cast<uint32_t>(m_prefixBytes);
+			e.prefix.assign(data, data + take);
+
+			if (m_ring.size() < m_cap)
+			{
+				m_ring.push_back(std::move(e));
+			}
+			else
+			{
+				m_ring[m_head] = std::move(e);
+			}
+			m_head = (m_head + 1) % m_cap;
+		}
+
+		size_t Size() const { return m_ring.size(); }
+		size_t Capacity() const { return m_cap; }
+
+		/// Snapshot dans l'ordre chronologique (du plus ancien au plus recent).
+		std::vector<Entry> Snapshot() const
+		{
+			std::vector<Entry> out;
+			out.reserve(m_ring.size());
+			if (m_ring.size() < m_cap)
+			{
+				out = m_ring;
+				return out;
+			}
+			// buffer plein : tete = oldest
+			for (size_t i = 0; i < m_ring.size(); ++i)
+			{
+				out.push_back(m_ring[(m_head + i) % m_cap]);
+			}
+			return out;
+		}
+
+	private:
+		size_t  m_cap;
+		size_t  m_prefixBytes;
+		size_t  m_head = 0;     ///< prochain slot a ecrire (et donc oldest si plein)
+		std::vector<Entry> m_ring;
+	};
+}

--- a/engine/server/packetlog/PacketLogTests.cpp
+++ b/engine/server/packetlog/PacketLogTests.cpp
@@ -1,0 +1,67 @@
+#include "engine/server/packetlog/PacketLog.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::packetlog;
+
+	bool TestPushAndSnapshot()
+	{
+		PacketLog l(4, 8);
+		uint8_t data[] = {1, 2, 3, 4, 5};
+		l.Push(Direction::In,  10, 1000, data, 5);
+		l.Push(Direction::Out, 20, 1100, data, 5);
+		l.Push(Direction::In,  30, 1200, data, 5);
+		auto snap = l.Snapshot();
+		if (snap.size() != 3) return false;
+		if (snap[0].opcode != 10 || snap[1].opcode != 20 || snap[2].opcode != 30) return false;
+		LOG_INFO(Core, "[PacketLogTests] push+snapshot OK");
+		return true;
+	}
+
+	bool TestRingOverflow()
+	{
+		PacketLog l(3, 4);
+		uint8_t data[] = {0xFF};
+		// Push 5 elements dans un ring de 3 : doit garder les 3 derniers
+		for (uint16_t i = 1; i <= 5; ++i)
+			l.Push(Direction::In, i, 1000 + i, data, 1);
+		auto snap = l.Snapshot();
+		if (snap.size() != 3) return false;
+		// snap doit contenir 3, 4, 5 dans l'ordre
+		if (snap[0].opcode != 3 || snap[1].opcode != 4 || snap[2].opcode != 5) return false;
+		LOG_INFO(Core, "[PacketLogTests] ring overflow OK");
+		return true;
+	}
+
+	bool TestPrefixTruncation()
+	{
+		PacketLog l(2, 4);
+		uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+		l.Push(Direction::In, 1, 1000, data, 8);
+		auto snap = l.Snapshot();
+		if (snap.size() != 1) return false;
+		// taille originale conservee
+		if (snap[0].size != 8) return false;
+		// prefix tronque a 4 octets
+		if (snap[0].prefix.size() != 4) return false;
+		if (snap[0].prefix[0] != 1 || snap[0].prefix[3] != 4) return false;
+		LOG_INFO(Core, "[PacketLogTests] prefix truncation OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestPushAndSnapshot() && TestRingOverflow() && TestPrefixTruncation();
+	if (ok) LOG_INFO(Core, "[PacketLogTests] ALL OK");
+	else LOG_ERROR(Core, "[PacketLogTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/platform/CrashContext.h
+++ b/engine/server/platform/CrashContext.h
@@ -1,0 +1,46 @@
+#pragma once
+// CMANGOS.37 (Phase 4.37a) — CrashContext : metadata enregistree par le
+// serveur (build hash, uptime, derniere tick, derniere zone, etc.) au moment
+// d'une signal de crash, pour produire un crash report structure pre-dump.
+// La plomberie minidump/coredump native (signal handler, SetUnhandledFilter)
+// est deferree — c'est le format texte du contexte que ce module valide.
+// Header-only.
+
+#include <cstdint>
+#include <string>
+#include <sstream>
+
+namespace engine::server::platform
+{
+	struct CrashContext
+	{
+		std::string buildHash;
+		uint64_t    uptimeMs   = 0;
+		uint64_t    lastTickMs = 0;
+		std::string lastZone;
+		uint32_t    activeSessions = 0;
+		std::string signalName;     ///< "SIGSEGV", "SIGABRT", "Unhandled exception", etc.
+	};
+
+	/// Serialize en texte multi-ligne (key: value). Format simple pour
+	/// piper dans un fichier disque ou un log avant que le process meurt.
+	inline std::string Format(const CrashContext& c)
+	{
+		std::ostringstream os;
+		os << "buildHash: "      << c.buildHash      << "\n";
+		os << "uptimeMs: "       << c.uptimeMs       << "\n";
+		os << "lastTickMs: "     << c.lastTickMs     << "\n";
+		os << "lastZone: "       << c.lastZone       << "\n";
+		os << "activeSessions: " << c.activeSessions << "\n";
+		os << "signal: "         << c.signalName     << "\n";
+		return os.str();
+	}
+
+	/// Verifie que le contexte contient le minimum acceptable avant d'ecrire
+	/// le rapport (eviter de polluer le disque avec des entrees vides apres
+	/// un crash precoce ou.le buildHash n'a pas eu le temps d'etre rempli).
+	inline bool IsValid(const CrashContext& c)
+	{
+		return !c.buildHash.empty() && !c.signalName.empty();
+	}
+}

--- a/engine/server/platform/CrashContextTests.cpp
+++ b/engine/server/platform/CrashContextTests.cpp
@@ -1,0 +1,53 @@
+#include "engine/server/platform/CrashContext.h"
+#include "engine/core/Log.h"
+#include <string>
+
+namespace
+{
+	using namespace engine::server::platform;
+
+	bool TestFormat()
+	{
+		CrashContext c;
+		c.buildHash      = "deadbeef";
+		c.uptimeMs       = 12345;
+		c.lastTickMs     = 12340;
+		c.lastZone       = "Stranglethorn";
+		c.activeSessions = 17;
+		c.signalName     = "SIGSEGV";
+		auto s = Format(c);
+		if (s.find("buildHash: deadbeef") == std::string::npos) return false;
+		if (s.find("uptimeMs: 12345")     == std::string::npos) return false;
+		if (s.find("lastZone: Stranglethorn") == std::string::npos) return false;
+		if (s.find("signal: SIGSEGV")     == std::string::npos) return false;
+		LOG_INFO(Core, "[CrashContextTests] format OK");
+		return true;
+	}
+
+	bool TestIsValid()
+	{
+		CrashContext c;
+		if (IsValid(c)) return false; // vide
+		c.buildHash = "abc";
+		if (IsValid(c)) return false; // signal manquant
+		c.signalName = "SIGABRT";
+		if (!IsValid(c)) return false;
+		LOG_INFO(Core, "[CrashContextTests] isvalid OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestFormat() && TestIsValid();
+	if (ok) LOG_INFO(Core, "[CrashContextTests] ALL OK");
+	else LOG_ERROR(Core, "[CrashContextTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/playerbot/PlayerBotProfile.h
+++ b/engine/server/playerbot/PlayerBotProfile.h
@@ -1,0 +1,70 @@
+#pragma once
+// CMANGOS.38 (Phase 5.38a) — PlayerBotProfile : profil de bot (classe, role,
+// AI tier, equipement seed) + scheduler de spawn pour repeupler les zones
+// peu peuplees. Header-only.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::playerbot
+{
+	using BotId = uint64_t;
+
+	enum class BotClass : uint8_t
+	{
+		Warrior = 0, Paladin, Hunter, Rogue, Priest, Shaman, Mage, Warlock, Druid
+	};
+
+	enum class BotRole : uint8_t { Tank, Heal, MeleeDps, RangedDps };
+
+	/// Profil statique d'un bot. Sert de seed pour la generation runtime.
+	struct PlayerBotProfile
+	{
+		BotId    id        = 0;
+		std::string name;
+		BotClass cls       = BotClass::Warrior;
+		BotRole  role      = BotRole::MeleeDps;
+		uint8_t  level     = 1;
+		uint16_t aiTier    = 0;     ///< 0 = naif, 1 = standard, 2 = avance
+		uint32_t zoneId    = 0;     ///< zone preferee de spawn
+	};
+
+	/// Scheduler simple : retourne les bots qui doivent spawn pour atteindre
+	/// la densite cible d'une zone. Politique deterministe pour tests.
+	class PlayerBotScheduler
+	{
+	public:
+		void RegisterBot(const PlayerBotProfile& p) { m_bots[p.id] = p; }
+
+		/// Selectionne jusqu'a \p needed bots dans la zone \p zoneId qui ne sont
+		/// pas dans \p alreadySpawned. Retourne les ids dans l'ordre d'insertion
+		/// (deterministe).
+		std::vector<BotId> Pick(uint32_t zoneId, size_t needed,
+		                         const std::vector<BotId>& alreadySpawned) const
+		{
+			std::vector<BotId> out;
+			for (const auto& [id, p] : m_bots)
+			{
+				if (out.size() >= needed) break;
+				if (p.zoneId != zoneId) continue;
+				bool already = false;
+				for (auto s : alreadySpawned) if (s == id) { already = true; break; }
+				if (already) continue;
+				out.push_back(id);
+			}
+			return out;
+		}
+
+		size_t BotCount() const { return m_bots.size(); }
+		const PlayerBotProfile* Get(BotId id) const
+		{
+			auto it = m_bots.find(id);
+			return (it == m_bots.end()) ? nullptr : &it->second;
+		}
+
+	private:
+		std::unordered_map<BotId, PlayerBotProfile> m_bots;
+	};
+}

--- a/engine/server/playerbot/PlayerBotProfileTests.cpp
+++ b/engine/server/playerbot/PlayerBotProfileTests.cpp
@@ -1,0 +1,83 @@
+#include "engine/server/playerbot/PlayerBotProfile.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::playerbot;
+
+	bool TestEmpty()
+	{
+		PlayerBotScheduler s;
+		auto picks = s.Pick(1, 5, {});
+		if (!picks.empty()) return false;
+		LOG_INFO(Core, "[PlayerBotTests] empty OK");
+		return true;
+	}
+
+	bool TestPickByZone()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({1, "Aerith", BotClass::Mage,    BotRole::RangedDps, 60, 1, 100});
+		s.RegisterBot({2, "Bork",   BotClass::Warrior, BotRole::Tank,      60, 1, 100});
+		s.RegisterBot({3, "Cael",   BotClass::Druid,   BotRole::Heal,      60, 1, 200});
+
+		auto picks = s.Pick(100, 10, {});
+		if (picks.size() != 2) return false; // seulement 2 dans zone 100
+		LOG_INFO(Core, "[PlayerBotTests] pick by zone OK");
+		return true;
+	}
+
+	bool TestExcludeSpawned()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({1, "A", BotClass::Mage,    BotRole::RangedDps, 60, 1, 100});
+		s.RegisterBot({2, "B", BotClass::Warrior, BotRole::Tank,      60, 1, 100});
+		s.RegisterBot({3, "C", BotClass::Priest,  BotRole::Heal,      60, 1, 100});
+
+		auto picks = s.Pick(100, 10, {1, 2});
+		if (picks.size() != 1) return false;
+		if (picks[0] != 3) return false;
+		LOG_INFO(Core, "[PlayerBotTests] exclude spawned OK");
+		return true;
+	}
+
+	bool TestNeededLimit()
+	{
+		PlayerBotScheduler s;
+		for (BotId i = 1; i <= 5; ++i)
+			s.RegisterBot({i, "Bot", BotClass::Warrior, BotRole::MeleeDps, 60, 1, 100});
+
+		auto picks = s.Pick(100, 2, {});
+		if (picks.size() != 2) return false;
+		LOG_INFO(Core, "[PlayerBotTests] needed limit OK");
+		return true;
+	}
+
+	bool TestGet()
+	{
+		PlayerBotScheduler s;
+		s.RegisterBot({42, "Hero", BotClass::Paladin, BotRole::Tank, 70, 2, 300});
+		auto* p = s.Get(42);
+		if (!p) return false;
+		if (p->level != 70 || p->aiTier != 2) return false;
+		if (s.Get(99)) return false;
+		LOG_INFO(Core, "[PlayerBotTests] Get OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmpty() && TestPickByZone() && TestExcludeSpawned()
+	             && TestNeededLimit() && TestGet();
+	if (ok) LOG_INFO(Core, "[PlayerBotTests] ALL OK");
+	else LOG_ERROR(Core, "[PlayerBotTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/pools/PoolManager.h
+++ b/engine/server/pools/PoolManager.h
@@ -1,0 +1,80 @@
+#pragma once
+// CMANGOS.22 (Phase 4.22a) — PoolManager : weighted random spawn pour
+// rare spawns. Une pool a N candidats avec poids et un slot maxActive.
+// L'algorithm choisit weighted-random sans replacement parmi les
+// candidats.
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::pools
+{
+	using PoolId   = uint32_t;
+	using SpawnId  = uint32_t;
+
+	struct PoolEntry
+	{
+		SpawnId spawnId = 0;
+		float   weight  = 1.0f;  ///< plus eleve = plus probable
+	};
+
+	struct Pool
+	{
+		PoolId                 poolId     = 0;
+		uint32_t               maxActive  = 1;
+		std::vector<PoolEntry> entries;
+	};
+
+	class PoolManager
+	{
+	public:
+		PoolManager() = default;
+
+		void Register(Pool pool) { m_pools[pool.poolId] = std::move(pool); }
+
+		/// Roll \p count spawns parmi la pool \p poolId. Retourne les
+		/// SpawnIds choisis (sans replacement). Si count > entries.size(),
+		/// retourne tous les entries. Si pool inconnue ou maxActive=0,
+		/// retourne vide.
+		std::vector<SpawnId> Roll(PoolId poolId, std::mt19937& rng) const
+		{
+			auto it = m_pools.find(poolId);
+			if (it == m_pools.end()) return {};
+			const Pool& p = it->second;
+			if (p.maxActive == 0 || p.entries.empty()) return {};
+
+			// Copy + weighted shuffle.
+			std::vector<PoolEntry> copy = p.entries;
+			std::vector<SpawnId> out;
+			out.reserve(std::min<size_t>(p.maxActive, copy.size()));
+
+			for (uint32_t i = 0; i < p.maxActive && !copy.empty(); ++i)
+			{
+				float total = 0.0f;
+				for (const auto& e : copy) total += std::max(0.0f, e.weight);
+				if (total <= 0.0f) break;
+
+				std::uniform_real_distribution<float> d(0.0f, total);
+				const float pick = d(rng);
+				float acc = 0.0f;
+				size_t pickedIdx = 0;
+				for (size_t k = 0; k < copy.size(); ++k)
+				{
+					acc += std::max(0.0f, copy[k].weight);
+					if (pick <= acc) { pickedIdx = k; break; }
+				}
+				out.push_back(copy[pickedIdx].spawnId);
+				copy.erase(copy.begin() + pickedIdx);  // sans replacement
+			}
+			return out;
+		}
+
+		size_t PoolCount() const noexcept { return m_pools.size(); }
+
+	private:
+		std::unordered_map<PoolId, Pool> m_pools;
+	};
+}

--- a/engine/server/pools/PoolManagerTests.cpp
+++ b/engine/server/pools/PoolManagerTests.cpp
@@ -1,0 +1,103 @@
+#include "engine/server/pools/PoolManager.h"
+#include "engine/core/Log.h"
+
+#include <random>
+#include <unordered_set>
+
+namespace
+{
+	using engine::server::pools::Pool;
+	using engine::server::pools::PoolEntry;
+	using engine::server::pools::PoolManager;
+	using engine::server::pools::SpawnId;
+
+	bool TestEmptyPool()
+	{
+		PoolManager mgr;
+		std::mt19937 rng(1);
+		auto out = mgr.Roll(99, rng);
+		if (!out.empty()) return false;
+		LOG_INFO(Core, "[PoolManagerTests] empty/unknown OK");
+		return true;
+	}
+
+	bool TestSinglePick()
+	{
+		PoolManager mgr;
+		Pool p;
+		p.poolId = 1;
+		p.maxActive = 1;
+		p.entries = {{100, 1.0f}, {200, 1.0f}, {300, 1.0f}};
+		mgr.Register(p);
+		std::mt19937 rng(42);
+		auto out = mgr.Roll(1, rng);
+		if (out.size() != 1) return false;
+		if (out[0] != 100 && out[0] != 200 && out[0] != 300) return false;
+		LOG_INFO(Core, "[PoolManagerTests] single pick OK");
+		return true;
+	}
+
+	bool TestNoReplacement()
+	{
+		PoolManager mgr;
+		Pool p;
+		p.poolId = 1;
+		p.maxActive = 3;
+		p.entries = {{100, 1.0f}, {200, 1.0f}, {300, 1.0f}};
+		mgr.Register(p);
+		std::mt19937 rng(42);
+		auto out = mgr.Roll(1, rng);
+		if (out.size() != 3) return false;
+		std::unordered_set<SpawnId> set(out.begin(), out.end());
+		if (set.size() != 3) return false;  // unique
+		LOG_INFO(Core, "[PoolManagerTests] no replacement OK");
+		return true;
+	}
+
+	bool TestWeightedDistribution()
+	{
+		// 1000 rolls : entry weight 99 doit dominer.
+		PoolManager mgr;
+		Pool p;
+		p.poolId = 1;
+		p.maxActive = 1;
+		p.entries = {{100, 99.0f}, {200, 1.0f}};
+		mgr.Register(p);
+
+		std::mt19937 rng(1);
+		int count100 = 0, count200 = 0;
+		for (int i = 0; i < 1000; ++i)
+		{
+			auto out = mgr.Roll(1, rng);
+			if (out[0] == 100) ++count100;
+			else if (out[0] == 200) ++count200;
+		}
+		// Avec 99/1, on attend ~990/10. Tolerance large.
+		if (count100 < 950 || count200 > 60)
+		{
+			LOG_ERROR(Core, "[PoolManagerTests] weighted dist out of bounds: 100={} 200={}",
+				count100, count200);
+			return false;
+		}
+		LOG_INFO(Core, "[PoolManagerTests] weighted dist OK (100={}, 200={})", count100, count200);
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestEmptyPool() && TestSinglePick()
+		&& TestNoReplacement() && TestWeightedDistribution();
+
+	if (ok) LOG_INFO(Core, "[PoolManagerTests] ALL OK");
+	else LOG_ERROR(Core, "[PoolManagerTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/quests/MysqlQuestStateStore.cpp
+++ b/engine/server/quests/MysqlQuestStateStore.cpp
@@ -1,0 +1,74 @@
+#include "engine/server/quests/MysqlQuestStateStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::quests
+{
+	bool MysqlQuestStateStore::Upsert(AccountId accountId, QuestId questId, QuestStatus status)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO account_quest_state (account_id, quest_id, status) "
+			"VALUES (%llu, %u, %u) "
+			"ON DUPLICATE KEY UPDATE status = VALUES(status)",
+			static_cast<unsigned long long>(accountId),
+			questId,
+			static_cast<unsigned>(status));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlQuestStateStore::Delete(AccountId accountId, QuestId questId)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM account_quest_state WHERE account_id = %llu AND quest_id = %u",
+			static_cast<unsigned long long>(accountId),
+			questId);
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::vector<QuestStateRow> MysqlQuestStateStore::Load(AccountId accountId) const
+	{
+		std::vector<QuestStateRow> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT account_id, quest_id, status FROM account_quest_state "
+			"WHERE account_id = %llu",
+			static_cast<unsigned long long>(accountId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			QuestStateRow r;
+			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
+			r.questId   = row[1] ? static_cast<QuestId>(std::strtoul(row[1], nullptr, 10)) : 0;
+			const auto st = row[2] ? static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10)) : 0u;
+			r.status    = static_cast<QuestStatus>(std::min<uint32_t>(st, 5u));
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/quests/MysqlQuestStateStore.h
+++ b/engine/server/quests/MysqlQuestStateStore.h
@@ -1,0 +1,40 @@
+#pragma once
+// CMANGOS.23 (Phase 5.23b) — MysqlQuestStateStore : persistance MySQL
+// du QuestStateTracker (table account_quest_state, migration 0048).
+// Cible UNIX shard.
+
+#include "engine/server/quests/QuestState.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::quests
+{
+	struct QuestStateRow
+	{
+		AccountId   accountId;
+		QuestId     questId;
+		QuestStatus status;
+	};
+
+	class MysqlQuestStateStore
+	{
+	public:
+		explicit MysqlQuestStateStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Upsert d'un (account, quest, status). Insert si absent sinon update.
+		bool Upsert(AccountId accountId, QuestId questId, QuestStatus status);
+
+		/// Suppression d'une ligne (utile pour reset quest cote admin).
+		bool Delete(AccountId accountId, QuestId questId);
+
+		/// Charge toutes les lignes pour un account (au login).
+		std::vector<QuestStateRow> Load(AccountId accountId) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}

--- a/engine/server/reputation/MysqlReputationStore.cpp
+++ b/engine/server/reputation/MysqlReputationStore.cpp
@@ -1,0 +1,59 @@
+#include "engine/server/reputation/MysqlReputationStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::reputation
+{
+	bool MysqlReputationStore::Upsert(AccountId accountId, FactionId factionId, int32_t value)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		// MySQL upsert : INSERT ... ON DUPLICATE KEY UPDATE.
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO account_reputation (account_id, faction_id, value) "
+			"VALUES (%llu, %u, %d) "
+			"ON DUPLICATE KEY UPDATE value = VALUES(value)",
+			static_cast<unsigned long long>(accountId),
+			factionId,
+			value);
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	std::vector<ReputationRow> MysqlReputationStore::Load(AccountId accountId) const
+	{
+		std::vector<ReputationRow> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT account_id, faction_id, value FROM account_reputation "
+			"WHERE account_id = %llu",
+			static_cast<unsigned long long>(accountId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			ReputationRow r;
+			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
+			r.factionId = row[1] ? static_cast<FactionId>(std::strtoul(row[1], nullptr, 10)) : 0;
+			r.value     = row[2] ? std::atoi(row[2]) : 0;
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/engine/server/reputation/MysqlReputationStore.h
+++ b/engine/server/reputation/MysqlReputationStore.h
@@ -1,0 +1,38 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24b) — MysqlReputationStore : persistance MySQL
+// des valeurs de reputation par (account, faction). Migration 0047.
+// Cible UNIX shard.
+
+#include "engine/server/reputation/ReputationManager.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::reputation
+{
+	struct ReputationRow
+	{
+		AccountId accountId;
+		FactionId factionId;
+		int32_t   value;
+	};
+
+	class MysqlReputationStore
+	{
+	public:
+		explicit MysqlReputationStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Upsert d'une ligne (faction, account, value). Insert si absent
+		/// sinon update value.
+		bool Upsert(AccountId accountId, FactionId factionId, int32_t value);
+
+		/// Charge toutes les lignes pour un account (typiquement au login).
+		std::vector<ReputationRow> Load(AccountId accountId) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}

--- a/engine/server/skills/SkillBook.h
+++ b/engine/server/skills/SkillBook.h
@@ -1,0 +1,73 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39a) — SkillBook : skills d'un personnage (cooking,
+// herbalism, mining, lockpicking, weapon skills) avec progression
+// jusqu'a un cap. Header-only.
+
+#include <cstdint>
+#include <unordered_map>
+#include <algorithm>
+
+namespace engine::server::skills
+{
+	using SkillId = uint16_t;
+
+	struct SkillEntry
+	{
+		uint16_t value = 0;  ///< niveau actuel
+		uint16_t cap   = 0;  ///< cap dur (max attribuable a ce moment)
+		uint16_t bonus = 0;  ///< bonus temporaire (potion, equipement)
+	};
+
+	class SkillBook
+	{
+	public:
+		void Set(SkillId id, uint16_t value, uint16_t cap)
+		{
+			auto& e = m_skills[id];
+			e.cap   = cap;
+			e.value = std::min(value, cap);
+		}
+
+		bool Has(SkillId id) const { return m_skills.count(id) > 0; }
+
+		const SkillEntry* Get(SkillId id) const
+		{
+			auto it = m_skills.find(id);
+			return (it == m_skills.end()) ? nullptr : &it->second;
+		}
+
+		/// Ajoute \p delta points au skill, clampe a cap. Retourne le delta
+		/// effectivement applique.
+		uint16_t Gain(SkillId id, uint16_t delta)
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return 0;
+			auto& e = it->second;
+			const uint16_t before = e.value;
+			const uint32_t after = std::min<uint32_t>(e.cap, static_cast<uint32_t>(e.value) + delta);
+			e.value = static_cast<uint16_t>(after);
+			return e.value - before;
+		}
+
+		void SetBonus(SkillId id, uint16_t bonus)
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return;
+			it->second.bonus = bonus;
+		}
+
+		/// Valeur effective = value + bonus (clamp a 0xFFFF par securite).
+		uint16_t Effective(SkillId id) const
+		{
+			auto it = m_skills.find(id);
+			if (it == m_skills.end()) return 0;
+			const uint32_t e = static_cast<uint32_t>(it->second.value) + it->second.bonus;
+			return e > 0xFFFFu ? 0xFFFFu : static_cast<uint16_t>(e);
+		}
+
+		size_t Count() const { return m_skills.size(); }
+
+	private:
+		std::unordered_map<SkillId, SkillEntry> m_skills;
+	};
+}

--- a/engine/server/skills/SkillBookTests.cpp
+++ b/engine/server/skills/SkillBookTests.cpp
@@ -1,0 +1,72 @@
+#include "engine/server/skills/SkillBook.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::skills;
+
+	bool TestSetClampedToCap()
+	{
+		SkillBook b;
+		b.Set(1, 250, 150); // demande 250 mais cap a 150
+		auto* e = b.Get(1);
+		if (!e || e->value != 150 || e->cap != 150) return false;
+		LOG_INFO(Core, "[SkillTests] set clamped OK");
+		return true;
+	}
+
+	bool TestGain()
+	{
+		SkillBook b;
+		b.Set(2, 100, 200);
+		// gain 50 -> 150
+		if (b.Gain(2, 50) != 50) return false;
+		if (b.Get(2)->value != 150) return false;
+		// gain 100 -> clampe a 200, applique 50
+		if (b.Gain(2, 100) != 50) return false;
+		if (b.Get(2)->value != 200) return false;
+		// gain sur skill inconnu = 0
+		if (b.Gain(99, 10) != 0) return false;
+		LOG_INFO(Core, "[SkillTests] gain OK");
+		return true;
+	}
+
+	bool TestEffectiveWithBonus()
+	{
+		SkillBook b;
+		b.Set(3, 100, 300);
+		b.SetBonus(3, 25);
+		if (b.Effective(3) != 125) return false;
+		// skill inconnu : 0
+		if (b.Effective(99) != 0) return false;
+		LOG_INFO(Core, "[SkillTests] effective with bonus OK");
+		return true;
+	}
+
+	bool TestEffectiveOverflowSafe()
+	{
+		SkillBook b;
+		b.Set(4, 60000, 65000);
+		b.SetBonus(4, 60000);
+		// 60000 + 60000 = 120000 > 65535, clampe a 65535
+		if (b.Effective(4) != 0xFFFFu) return false;
+		LOG_INFO(Core, "[SkillTests] effective overflow safe OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestSetClampedToCap() && TestGain() && TestEffectiveWithBonus()
+	             && TestEffectiveOverflowSafe();
+	if (ok) LOG_INFO(Core, "[SkillTests] ALL OK");
+	else LOG_ERROR(Core, "[SkillTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/social/MysqlIgnoreStore.cpp
+++ b/engine/server/social/MysqlIgnoreStore.cpp
@@ -1,0 +1,112 @@
+#include "engine/server/social/MysqlIgnoreStore.h"
+
+#include "engine/core/Log.h"
+#include "engine/server/db/ConnectionPool.h"
+#include "engine/server/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::social
+{
+	bool MysqlIgnoreStore::Add(uint64_t owner, uint64_t target)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		// INSERT IGNORE : si la PK (owner, target) existe deja, no-op.
+		// Le cap de 50 ignored est applique cote IgnoreListManager runtime.
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT IGNORE INTO account_ignore_list (owner_account_id, target_account_id) "
+			"VALUES (%llu, %llu)",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlIgnoreStore::Remove(uint64_t owner, uint64_t target)
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"DELETE FROM account_ignore_list "
+			"WHERE owner_account_id = %llu AND target_account_id = %llu",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		return engine::server::db::DbExecute(mysql, sql);
+	}
+
+	bool MysqlIgnoreStore::IsIgnored(uint64_t owner, uint64_t target) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT 1 FROM account_ignore_list "
+			"WHERE owner_account_id = %llu AND target_account_id = %llu LIMIT 1",
+			static_cast<unsigned long long>(owner),
+			static_cast<unsigned long long>(target));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return false;
+		const bool found = (mysql_fetch_row(res) != nullptr);
+		engine::server::db::DbFreeResult(res);
+		return found;
+	}
+
+	std::vector<uint64_t> MysqlIgnoreStore::List(uint64_t owner) const
+	{
+		std::vector<uint64_t> out;
+		if (!m_pool || !m_pool->IsInitialized()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT target_account_id FROM account_ignore_list "
+			"WHERE owner_account_id = %llu ORDER BY target_account_id ASC",
+			static_cast<unsigned long long>(owner));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return out;
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			if (row[0]) out.push_back(std::strtoull(row[0], nullptr, 10));
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	size_t MysqlIgnoreStore::Size(uint64_t owner) const
+	{
+		if (!m_pool || !m_pool->IsInitialized()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT COUNT(*) FROM account_ignore_list WHERE owner_account_id = %llu",
+			static_cast<unsigned long long>(owner));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res) return 0;
+		size_t count = 0;
+		if (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			if (row[0]) count = static_cast<size_t>(std::strtoull(row[0], nullptr, 10));
+		}
+		engine::server::db::DbFreeResult(res);
+		return count;
+	}
+}

--- a/engine/server/social/MysqlIgnoreStore.h
+++ b/engine/server/social/MysqlIgnoreStore.h
@@ -1,0 +1,27 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25b) — MysqlIgnoreStore : implementation MySQL
+// d'IIgnoreStore pour persistance production. Cible UNIX shard.
+// (WIN32 sandbox utilise InMemoryIgnoreStore.)
+
+#include "engine/server/social/IgnoreList.h"
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::social
+{
+	class MysqlIgnoreStore final : public IIgnoreStore
+	{
+	public:
+		explicit MysqlIgnoreStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		bool Add(uint64_t ownerAccountId, uint64_t targetAccountId) override;
+		bool Remove(uint64_t ownerAccountId, uint64_t targetAccountId) override;
+		bool IsIgnored(uint64_t ownerAccountId, uint64_t targetAccountId) const override;
+		std::vector<uint64_t> List(uint64_t ownerAccountId) const override;
+		size_t Size(uint64_t ownerAccountId) const override;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool;
+	};
+}

--- a/engine/server/trade/TradeSession.h
+++ b/engine/server/trade/TradeSession.h
@@ -1,0 +1,112 @@
+#pragma once
+// CMANGOS.27 (Phase 4.27a) — TradeSession : echange direct entre 2 joueurs
+// avec gates de confirmation (offer -> lock -> mutual confirm -> commit).
+// Header-only. Ne touche pas a l'inventaire reel : retourne le delta validee
+// au caller pour application atomique cote shard.
+
+#include <cstdint>
+#include <vector>
+#include <utility>
+
+namespace engine::server::trade
+{
+	using PlayerId = uint64_t;
+	using ItemGuid = uint64_t;
+
+	enum class TradeState : uint8_t
+	{
+		Open,        ///< les 2 joueurs editent l'offer
+		LockedA,     ///< A a verrouille, B peut encore editer
+		LockedB,     ///< B a verrouille, A peut encore editer
+		BothLocked,  ///< les 2 ont verrouille, en attente de confirmation
+		Committed,   ///< echange execute (etat terminal)
+		Cancelled    ///< un des deux a annule (etat terminal)
+	};
+
+	struct TradeOffer
+	{
+		std::vector<ItemGuid> items;
+		uint64_t              copper = 0;
+	};
+
+	class TradeSession
+	{
+	public:
+		TradeSession(PlayerId a, PlayerId b) : m_a(a), m_b(b) {}
+
+		PlayerId    PlayerA()  const { return m_a; }
+		PlayerId    PlayerB()  const { return m_b; }
+		TradeState  State()    const { return m_state; }
+		const TradeOffer& OfferA() const { return m_offerA; }
+		const TradeOffer& OfferB() const { return m_offerB; }
+
+		/// Edition d'offer (interdit si lock cote auteur ou etat terminal).
+		bool SetOffer(PlayerId who, TradeOffer o)
+		{
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			if (who == m_a)
+			{
+				if (m_state == TradeState::LockedA || m_state == TradeState::BothLocked)
+					return false;
+				m_offerA = std::move(o);
+				return true;
+			}
+			if (who == m_b)
+			{
+				if (m_state == TradeState::LockedB || m_state == TradeState::BothLocked)
+					return false;
+				m_offerB = std::move(o);
+				return true;
+			}
+			return false;
+		}
+
+		/// Lock cote \p who. Si les 2 sont locked passe a BothLocked.
+		bool Lock(PlayerId who)
+		{
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			if (who == m_a)
+			{
+				if (m_state == TradeState::Open)     m_state = TradeState::LockedA;
+				else if (m_state == TradeState::LockedB) m_state = TradeState::BothLocked;
+				else return false;
+				return true;
+			}
+			if (who == m_b)
+			{
+				if (m_state == TradeState::Open)     m_state = TradeState::LockedB;
+				else if (m_state == TradeState::LockedA) m_state = TradeState::BothLocked;
+				else return false;
+				return true;
+			}
+			return false;
+		}
+
+		/// Commit n'est valide qu'a partir de BothLocked.
+		bool Commit()
+		{
+			if (m_state != TradeState::BothLocked) return false;
+			m_state = TradeState::Committed;
+			return true;
+		}
+
+		/// Cancel possible a tout moment non-terminal.
+		bool Cancel(PlayerId who)
+		{
+			if (who != m_a && who != m_b) return false;
+			if (m_state == TradeState::Committed || m_state == TradeState::Cancelled)
+				return false;
+			m_state = TradeState::Cancelled;
+			return true;
+		}
+
+	private:
+		PlayerId   m_a;
+		PlayerId   m_b;
+		TradeOffer m_offerA;
+		TradeOffer m_offerB;
+		TradeState m_state = TradeState::Open;
+	};
+}

--- a/engine/server/trade/TradeSessionTests.cpp
+++ b/engine/server/trade/TradeSessionTests.cpp
@@ -1,0 +1,92 @@
+#include "engine/server/trade/TradeSession.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::trade;
+
+	bool TestHappyPath()
+	{
+		TradeSession s(1, 2);
+		if (s.State() != TradeState::Open) return false;
+
+		TradeOffer oa; oa.items = {100, 101}; oa.copper = 50;
+		TradeOffer ob; ob.items = {200};
+		if (!s.SetOffer(1, oa)) return false;
+		if (!s.SetOffer(2, ob)) return false;
+
+		if (!s.Lock(1)) return false;  // -> LockedA
+		if (s.State() != TradeState::LockedA) return false;
+		if (!s.Lock(2)) return false;  // -> BothLocked
+		if (s.State() != TradeState::BothLocked) return false;
+
+		if (!s.Commit()) return false;
+		if (s.State() != TradeState::Committed) return false;
+		LOG_INFO(Core, "[TradeTests] happy path OK");
+		return true;
+	}
+
+	bool TestEditAfterLockRejected()
+	{
+		TradeSession s(1, 2);
+		s.Lock(1);
+		TradeOffer o; o.copper = 10;
+		if (s.SetOffer(1, o)) return false; // edition apres lock A interdit
+		// B peut toujours editer
+		if (!s.SetOffer(2, o)) return false;
+		LOG_INFO(Core, "[TradeTests] edit after lock rejected OK");
+		return true;
+	}
+
+	bool TestCommitBeforeBothLocked()
+	{
+		TradeSession s(1, 2);
+		if (s.Commit()) return false;
+		s.Lock(1);
+		if (s.Commit()) return false;
+		s.Lock(2);
+		if (!s.Commit()) return false;
+		LOG_INFO(Core, "[TradeTests] commit gate OK");
+		return true;
+	}
+
+	bool TestCancel()
+	{
+		TradeSession s(1, 2);
+		s.Lock(1);
+		if (!s.Cancel(2)) return false;
+		if (s.State() != TradeState::Cancelled) return false;
+		// no-op apres cancel
+		if (s.Lock(1)) return false;
+		if (s.Commit()) return false;
+		LOG_INFO(Core, "[TradeTests] cancel OK");
+		return true;
+	}
+
+	bool TestUnknownPlayer()
+	{
+		TradeSession s(1, 2);
+		TradeOffer o;
+		if (s.SetOffer(99, o)) return false;
+		if (s.Lock(99)) return false;
+		if (s.Cancel(99)) return false;
+		LOG_INFO(Core, "[TradeTests] unknown player rejected OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestHappyPath() && TestEditAfterLockRejected()
+	             && TestCommitBeforeBothLocked() && TestCancel() && TestUnknownPlayer();
+	if (ok) LOG_INFO(Core, "[TradeTests] ALL OK");
+	else LOG_ERROR(Core, "[TradeTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/util/ServerUtil.h
+++ b/engine/server/util/ServerUtil.h
@@ -1,0 +1,82 @@
+#pragma once
+// CMANGOS.41 (Phase 5.41a) — ServerUtil : utilitaires serveur reutilisables
+// (random deterministe, parse helpers, time helpers). Header-only.
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <optional>
+
+namespace engine::server::util
+{
+	/// Generateur deterministe (Mersenne Twister) pour seedable random.
+	/// Utile pour tests reproductibles et loot/spawn deterministes.
+	class DeterministicRng
+	{
+	public:
+		explicit DeterministicRng(uint64_t seed) : m_rng(seed) {}
+
+		/// Entier uniforme dans [lo, hi] inclus.
+		int32_t IntRange(int32_t lo, int32_t hi)
+		{
+			std::uniform_int_distribution<int32_t> d(lo, hi);
+			return d(m_rng);
+		}
+
+		/// Float uniforme dans [0, 1).
+		float Unit() { std::uniform_real_distribution<float> d(0.0f, 1.0f); return d(m_rng); }
+
+		/// Retourne true avec probabilite p (0..1).
+		bool Chance(float p) { return Unit() < p; }
+
+	private:
+		std::mt19937_64 m_rng;
+	};
+
+	/// Split d'une chaine sur un separateur. Tokens vides preserves.
+	inline std::vector<std::string_view> Split(std::string_view s, char sep)
+	{
+		std::vector<std::string_view> out;
+		size_t start = 0;
+		for (size_t i = 0; i < s.size(); ++i)
+		{
+			if (s[i] == sep)
+			{
+				out.push_back(s.substr(start, i - start));
+				start = i + 1;
+			}
+		}
+		out.push_back(s.substr(start));
+		return out;
+	}
+
+	/// Parse un entier non signe simple. Retourne nullopt si invalide.
+	inline std::optional<uint64_t> ParseU64(std::string_view s)
+	{
+		if (s.empty()) return std::nullopt;
+		uint64_t v = 0;
+		for (char c : s)
+		{
+			if (c < '0' || c > '9') return std::nullopt;
+			v = v * 10 + static_cast<uint64_t>(c - '0');
+		}
+		return v;
+	}
+
+	/// Format duree ms -> "HH:MM:SS" (depasse 24h, format reste 99:59:59 max).
+	inline std::string FormatDurationMs(uint64_t ms)
+	{
+		uint64_t s = ms / 1000;
+		uint64_t h = s / 3600; s %= 3600;
+		uint64_t m = s / 60;   s %= 60;
+		if (h > 99) h = 99;
+		char buf[16];
+		std::snprintf(buf, sizeof(buf), "%02llu:%02llu:%02llu",
+		              static_cast<unsigned long long>(h),
+		              static_cast<unsigned long long>(m),
+		              static_cast<unsigned long long>(s));
+		return std::string(buf);
+	}
+}

--- a/engine/server/util/ServerUtilTests.cpp
+++ b/engine/server/util/ServerUtilTests.cpp
@@ -1,0 +1,83 @@
+#include "engine/server/util/ServerUtil.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::util;
+
+	bool TestDeterministicSeed()
+	{
+		DeterministicRng a(42);
+		DeterministicRng b(42);
+		for (int i = 0; i < 50; ++i)
+			if (a.IntRange(0, 1000) != b.IntRange(0, 1000)) return false;
+		LOG_INFO(Core, "[UtilTests] deterministic RNG OK");
+		return true;
+	}
+
+	bool TestUnitRange()
+	{
+		DeterministicRng r(7);
+		for (int i = 0; i < 100; ++i)
+		{
+			float u = r.Unit();
+			if (u < 0.0f || u >= 1.0f) return false;
+		}
+		LOG_INFO(Core, "[UtilTests] unit range OK");
+		return true;
+	}
+
+	bool TestSplit()
+	{
+		auto v = Split("a,b,c", ',');
+		if (v.size() != 3) return false;
+		if (v[0] != "a" || v[1] != "b" || v[2] != "c") return false;
+
+		auto v2 = Split(",a,", ',');
+		if (v2.size() != 3) return false;
+		if (!v2[0].empty()) return false;
+		if (v2[1] != "a") return false;
+		if (!v2[2].empty()) return false;
+		LOG_INFO(Core, "[UtilTests] split OK");
+		return true;
+	}
+
+	bool TestParseU64()
+	{
+		auto a = ParseU64("12345");
+		if (!a || *a != 12345) return false;
+		auto b = ParseU64("0");
+		if (!b || *b != 0) return false;
+		if (ParseU64("").has_value()) return false;
+		if (ParseU64("12a3").has_value()) return false;
+		if (ParseU64("-1").has_value()) return false;
+		LOG_INFO(Core, "[UtilTests] parse u64 OK");
+		return true;
+	}
+
+	bool TestFormatDuration()
+	{
+		if (FormatDurationMs(0) != "00:00:00") return false;
+		if (FormatDurationMs(1500) != "00:00:01") return false;
+		if (FormatDurationMs(60'000) != "00:01:00") return false;
+		if (FormatDurationMs(3'661'000) != "01:01:01") return false;
+		LOG_INFO(Core, "[UtilTests] format duration OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestDeterministicSeed() && TestUnitRange() && TestSplit()
+	             && TestParseU64() && TestFormatDuration();
+	if (ok) LOG_INFO(Core, "[UtilTests] ALL OK");
+	else LOG_ERROR(Core, "[UtilTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/engine/server/world/WorldClock.h
+++ b/engine/server/world/WorldClock.h
@@ -1,0 +1,52 @@
+#pragma once
+// CMANGOS.28 (Phase 3.28a) — WorldClock : horloge serveur (game time, day/night
+// cycle, speed multiplier admin) et utilities derives. Header-only.
+
+#include <cstdint>
+#include <algorithm>
+
+namespace engine::server::world
+{
+	/// Phase de la journee selon l'heure (heures locales 0..23).
+	enum class DayPhase : uint8_t { Night, Dawn, Day, Dusk };
+
+	class WorldClock
+	{
+	public:
+		/// \param epochMs   debut du temps serveur (timestamp ms)
+		/// \param speed     multiplicateur (1.0 = realtime, 60.0 = 1h reel = 60h jeu)
+		WorldClock(uint64_t epochMs, double speed)
+			: m_epochMs(epochMs), m_speed(speed) {}
+
+		/// Temps en jeu ecoule depuis epoch en ms.
+		uint64_t GameTimeMs(uint64_t realNowMs) const
+		{
+			if (realNowMs <= m_epochMs) return 0;
+			return static_cast<uint64_t>(static_cast<double>(realNowMs - m_epochMs) * m_speed);
+		}
+
+		/// Heure en jeu modulo 24h, en heures (0..23).
+		uint8_t HourOfDay(uint64_t realNowMs) const
+		{
+			const uint64_t gameMs = GameTimeMs(realNowMs);
+			const uint64_t hourMs = 60ull * 60ull * 1000ull;
+			return static_cast<uint8_t>((gameMs / hourMs) % 24);
+		}
+
+		DayPhase Phase(uint64_t realNowMs) const
+		{
+			const uint8_t h = HourOfDay(realNowMs);
+			if (h >= 22 || h < 5)  return DayPhase::Night;
+			if (h < 7)             return DayPhase::Dawn;
+			if (h < 19)            return DayPhase::Day;
+			return DayPhase::Dusk; // 19..21
+		}
+
+		double Speed() const { return m_speed; }
+		void   SetSpeed(double s) { m_speed = std::max(0.0, s); }
+
+	private:
+		uint64_t m_epochMs;
+		double   m_speed;
+	};
+}

--- a/engine/server/world/WorldClockTests.cpp
+++ b/engine/server/world/WorldClockTests.cpp
@@ -1,0 +1,84 @@
+#include "engine/server/world/WorldClock.h"
+#include "engine/core/Log.h"
+
+namespace
+{
+	using namespace engine::server::world;
+
+	bool TestRealtime()
+	{
+		WorldClock c(1000, 1.0);
+		// 1h plus tard reel = 1h plus tard en jeu
+		const uint64_t hour = 3600ull * 1000ull;
+		if (c.GameTimeMs(1000 + hour) != hour) return false;
+		if (c.HourOfDay(1000 + hour)  != 1) return false;
+		LOG_INFO(Core, "[WorldClockTests] realtime OK");
+		return true;
+	}
+
+	bool TestSpeedX60()
+	{
+		WorldClock c(0, 60.0);
+		// 1 minute reelle = 1 heure en jeu
+		const uint64_t minute = 60ull * 1000ull;
+		if (c.HourOfDay(minute) != 1) return false;
+		// 24 minutes = 1 jour complet -> hour 0
+		if (c.HourOfDay(24 * minute) != 0) return false;
+		LOG_INFO(Core, "[WorldClockTests] speed x60 OK");
+		return true;
+	}
+
+	bool TestPhases()
+	{
+		WorldClock c(0, 60.0);
+		// 1 min reelle = 1h jeu
+		const uint64_t minute = 60ull * 1000ull;
+		// 0h = Night
+		if (c.Phase(0)         != DayPhase::Night) return false;
+		// 6h = Dawn
+		if (c.Phase(6 * minute) != DayPhase::Dawn) return false;
+		// 12h = Day
+		if (c.Phase(12 * minute) != DayPhase::Day) return false;
+		// 19h = Dusk
+		if (c.Phase(19 * minute) != DayPhase::Dusk) return false;
+		// 23h = Night
+		if (c.Phase(23 * minute) != DayPhase::Night) return false;
+		LOG_INFO(Core, "[WorldClockTests] phases OK");
+		return true;
+	}
+
+	bool TestBeforeEpoch()
+	{
+		WorldClock c(1000, 1.0);
+		if (c.GameTimeMs(500) != 0) return false;
+		LOG_INFO(Core, "[WorldClockTests] before epoch OK");
+		return true;
+	}
+
+	bool TestSetSpeed()
+	{
+		WorldClock c(0, 1.0);
+		c.SetSpeed(-5.0);
+		if (c.Speed() != 0.0) return false; // floor a 0
+		c.SetSpeed(2.5);
+		if (c.Speed() != 2.5) return false;
+		LOG_INFO(Core, "[WorldClockTests] set speed OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestRealtime() && TestSpeedX60() && TestPhases()
+	             && TestBeforeEpoch() && TestSetSpeed();
+	if (ok) LOG_INFO(Core, "[WorldClockTests] ALL OK");
+	else LOG_ERROR(Core, "[WorldClockTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Consolidation des PRs ouverts CMANGOS

**Pourquoi cette PR** : avoir 19 PRs simultanees ouvertes provoquait un rebase-cascade infini sur engine/server/CMakeLists.txt — chaque merge invalidait les 18 autres. Cette PR de consolidation merge l'ensemble en 1 cycle CI au lieu de 19.

Les 19 PRs originales (#506, #507, #519-#536) seront fermees apres merge avec un comment pointant vers cette PR.

## Phase 3 step 1
- CMANGOS.21 GuildPermissionMatrix (engine/server/guild/)
- CMANGOS.28 WorldClock (engine/server/world/WorldClock.h — distinct du WorldStateRegistry deja merge)

## Phase 4 step 1
- CMANGOS.10 BattleGroundQueue (engine/server/battleground/)
- CMANGOS.12 PacketLog ring buffer (engine/server/packetlog/)
- CMANGOS.22 PoolManager weighted spawn (engine/server/pools/)
- CMANGOS.27 TradeSession FSM (engine/server/trade/)
- CMANGOS.34 MetricRegistry (engine/server/metric/)
- CMANGOS.35 Messager MPSC queue (engine/server/messager/)
- CMANGOS.37 CrashContext (engine/server/platform/)
- CMANGOS.39 SkillBook (engine/server/skills/)
- CMANGOS.40 Formulas (engine/server/formulas/)

## Phase 5 step 1
- CMANGOS.08 ArenaTeam + ELO (engine/server/arena/)
- CMANGOS.38 PlayerBotProfile (engine/server/playerbot/)
- CMANGOS.41 ServerUtil (engine/server/util/)
- CMANGOS.44 AuctionHouseBot (engine/server/auction/)

## Step 2 DB persistence
- CMANGOS.23 MysqlQuestStateStore + db/migrations/0048_quest_state.sql
- CMANGOS.24 MysqlReputationStore + db/migrations/0047_reputation.sql
- CMANGOS.25 MysqlIgnoreStore + db/migrations/0049_ignore_list.sql
- CMANGOS.32 MysqlGmTicketStore + db/migrations/0046_gm_tickets.sql

## Test plan
- [x] Build Linux : 15 nouvelles test targets compilent et passent (cf. CI).
- [x] Build Windows : compile (les Mysql*Store.cpp sont en section UNIX uniquement).
- [ ] Tests integration MySQL deferres (pattern Mail : tests in-memory uniquement, store MySQL valide en prod).

**Deploiement** : ⚠️ **REDEPLOIEMENT SERVEUR REQUIS** — 4 nouvelles migrations SQL (0046, 0047, 0048, 0049) doivent etre appliquees au boot Linux pour creer les tables `gm_tickets`, `account_reputation`, `account_quest_state`, `account_ignore_list`. Sans ces tables, les Mysql*Store retournent silencieusement false (pas de crash mais pas de persistance).

Generated with Claude Code