### PR TITLE
refactor(cmake): extract helpers to cmake/ folder (parite cmangos)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ if(MSVC)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 endif()
 
+# Modules CMake reutilisables (parite cmangos-tbc/cmake/).
+# Charger AVANT add_subdirectory(src) pour que les helpers comme
+# lcdlln_add_simple_test() soient disponibles dans les sous-CMakeLists.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(LCDLLNHelpers)
+
 find_package(Vulkan REQUIRED)
 find_package(glfw3 CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -320,10 +320,19 @@ Les clés utilisées dans les écrans auth commencent par `auth.`, `common.`, `l
 | `.github/workflows/build-windows.yml` | CI build Windows (MSVC). |
 | `.github/workflows/build-linux.yml` | CI build Linux (GCC/Clang). |
 | `.gitea/workflows/build-test-linux.yml` | Tests Linux sur Gitea. |
+| `cmake/LCDLLNHelpers.cmake` | Helpers CMake réutilisables (`lcdlln_add_simple_test()`). Parité [cmangos-tbc/cmake/](https://github.com/cmangos/mangos-tbc/tree/master/cmake). |
+| `cmake/README.md` | Doc des modules CMake (chargement, ajout d'un nouveau module). |
 | `tools/hlod_builder/` | Génère les niveaux de détail (HLOD) pour les zones 3D. |
 | `tools/zone_builder/` | Construit les packages de zones (chunks, GLTF → PAK). |
 | `tools/load_tester/` | Simule des connexions massives pour tester la charge serveur. |
 | `tools/migration_checksum/` | Vérifie l'intégrité des migrations SQL. |
+
+**Modules CMake** : le `CMakeLists.txt` racine charge les helpers via :
+```cmake
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(LCDLLNHelpers)
+```
+`lcdlln_add_simple_test(target_name srcs...)` est ainsi disponible partout (racine + sous-CMakeLists). Pour ajouter un helper : créer `cmake/<NomModule>.cmake` avec un `include_guard(GLOBAL)` puis l'inclure depuis le racine.
 
 ---
 

--- a/cmake/LCDLLNHelpers.cmake
+++ b/cmake/LCDLLNHelpers.cmake
@@ -1,0 +1,35 @@
+# cmake/LCDLLNHelpers.cmake
+# Helpers CMake reutilisables pour le projet LCDLLN.
+# Chargement : include(LCDLLNHelpers) dans le CMakeLists racine apres
+#   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake").
+#
+# Inspire de la structure cmangos (cmangos-tbc/cmake/) qui isole les
+# helpers dans des modules dediés, hors du CMakeLists racine.
+
+include_guard(GLOBAL)
+
+# Helper pour declarer un test simple sans deps externes (engine_core +
+# spdlog + pthread suffisent). Cible le pattern recurrent des tests
+# CMANGOS Phase 2+ (BIH, ObjectGuid, VMapFormat, GridState, ChatSanitizer,
+# Metric, Messager, PacketLog, Formulas, Util, etc.) ou chaque target
+# faisait ~9 lignes de boilerplate identique. Avec ce helper, declarer
+# un test devient :
+#
+#   lcdlln_add_simple_test(my_thing_tests
+#     foo/MyThingTests.cpp
+#     foo/MyThing.cpp
+#     foo/MyDep.cpp)
+#
+# Les tests qui ont besoin de MySQL, OpenSSL, ou d'autres libs gardent
+# leur add_executable manuel. Ce helper reduit la zone de conflit dans
+# CMakeLists.txt entre PRs paralleles : chaque nouvelle test target =
+# 1 appel sur 4-5 lignes au lieu de 9-10 lignes d'equivalent inline.
+#
+# Exige que la cible engine_core soit deja declaree.
+function(lcdlln_add_simple_test target_name)
+  add_executable(${target_name} ${ARGN})
+  target_include_directories(${target_name} PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(${target_name} PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME ${target_name} COMMAND ${target_name} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endfunction()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,27 @@
+# cmake/
+
+Modules CMake reutilisables pour le projet LCDLLN.
+
+Inspire de la structure [cmangos-tbc/cmake/](https://github.com/cmangos/mangos-tbc/tree/master/cmake) qui isole les helpers dans des modules dedies, hors du `CMakeLists.txt` racine.
+
+## Modules
+
+| Fichier | Role |
+|---|---|
+| [`LCDLLNHelpers.cmake`](./LCDLLNHelpers.cmake) | Helpers de declaration de cibles : `lcdlln_add_simple_test()`. |
+
+## Chargement
+
+Le `CMakeLists.txt` racine charge ces modules via :
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(LCDLLNHelpers)
+```
+
+## Ajout d'un nouveau module
+
+1. Creer `cmake/<NomModule>.cmake` avec un `include_guard(GLOBAL)` en tete.
+2. Documenter le role et les preconditions dans le fichier (commentaires `#`).
+3. Charger le module dans `CMakeLists.txt` racine (apres `list(APPEND CMAKE_MODULE_PATH ...)`) via `include(<NomModule>)`.
+4. Mettre a jour ce README + `CODEBASE_MAP.md` section "Outils et CI".

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,29 +7,12 @@
 cmake_minimum_required(VERSION 3.20)
 set(CMAKE_CXX_STANDARD 20)
 
-# Helper pour declarer un test simple sans deps externes (engine_core +
-# spdlog + pthread suffisent).  Cible le pattern recurrent des tests
-# CMANGOS Phase 2 (BIH, ObjectGuid, VMapFormat, ChatChannelRegistry,
-# GridState, ChatSanitizer...) ou chaque target faisait ~9 lignes de
-# boilerplate identique. Avec ce helper, declarer un test devient :
-#
-#   lcdlln_add_simple_test(my_thing_tests
-#     foo/MyThingTests.cpp
-#     foo/MyThing.cpp
-#     foo/MyDep.cpp)
-#
-# Les tests qui ont besoin de MySQL, OpenSSL, ou d'autres libs gardent
-# leur add_executable manuel (pas la majorite). Ce helper reduit la
-# zone de conflit dans CMakeLists.txt entre PRs paralleles : chaque
-# nouvelle test target = 1 appel sur 4-5 lignes au lieu de 9-10 lignes
-# d'equivalent inline.
-function(lcdlln_add_simple_test target_name)
-  add_executable(${target_name} ${ARGN})
-  target_include_directories(${target_name} PRIVATE ${CMAKE_SOURCE_DIR})
-  target_link_libraries(${target_name} PRIVATE engine_core spdlog::spdlog pthread)
-  target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wpedantic)
-  add_test(NAME ${target_name} COMMAND ${target_name} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-endfunction()
+# Le helper lcdlln_add_simple_test() vit dans cmake/LCDLLNHelpers.cmake
+# (parite avec la structure cmangos-tbc/cmake/). Il est charge depuis le
+# CMakeLists.txt racine via :
+#   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+#   include(LCDLLNHelpers)
+# Le helper est donc disponible ici sans redefinition.
 
 if(WIN32)
   add_executable(server_app


### PR DESCRIPTION
## Top-level cmake/ folder (parité cmangos)

Suite de la réorganisation cmangos-style mergée dans #538. Cmangos a un dossier `cmake/` au top-level pour ses modules CMake (helpers, find scripts), distinct du `CMakeLists.txt` racine. Cette PR ajoute la même convention chez nous.

## Inclus

- `cmake/LCDLLNHelpers.cmake` — extrait la fonction `lcdlln_add_simple_test()` qui vivait inline dans `src/CMakeLists.txt` depuis la Phase B.
- `cmake/README.md` — doc de la convention (chargement, ajout d'un nouveau module).
- `CMakeLists.txt` racine : charge le module via `list(APPEND CMAKE_MODULE_PATH ...)` + `include(LCDLLNHelpers)` **avant** `add_subdirectory(src)` pour que le helper soit disponible dans tous les sous-CMakeLists.
- `src/CMakeLists.txt` : retire la redéfinition locale (commentaire pointe vers `cmake/LCDLLNHelpers.cmake`).
- `CODEBASE_MAP.md` section 10 : ajout des entrées + bloc explicatif sur la convention.

## Test plan

- [ ] CI Linux : `lcdlln-docker-linux-<sha>` artifact produit.
- [ ] CI Windows : `windows-release-<sha>` artifact produit.
- [ ] ctest passe (les tests utilisent `lcdlln_add_simple_test()` dans `src/CMakeLists.txt` — doit continuer à marcher avec le helper depuis `cmake/`).

**Déploiement** : ✅ client/serveur uniquement build infra, **pas de redéploiement serveur** (aucun changement de protocole, handler, migration, ou code applicatif).

Generated with Claude Code