### PR TITLE
ci(windows): filter test/junk .exe from artifact bundle

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -107,12 +107,25 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\artifacts"
 
           # Copie les binaires produits (hors vcpkg et hors debug) "*.exe" "*.dll" "*.pdb" 
+          # Filtres successifs :
+          #  - vcpkg, debug : sources externes ou builds debug, pas du release
+          #  - *_tests.exe : test executables (tournent en ctest, pas a shipper)
+          #  - CompilerId*.exe : fichiers cmake pour detection compilo
+          #  - VmaSample* : sample du Vulkan Memory Allocator (dependance externe)
+          #  - client_flow_app.exe : test d'integration headless, pas outil utilisateur
+          # Ce qui reste : lcdlln.exe, lcdlln_world_editor.exe, lcdlln_server.exe,
+          # zone_builder.exe, hlod_builder.exe, migration_checksum.exe,
+          # gen_terrain_placeholders.exe, load_tester.exe + DLLs.
           Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE" `
             -Include "*.exe","*.dll" |
             Where-Object {
               $_.FullName -notlike "*\vcpkg\*" -and
               $_.FullName -notlike "*\debug\*" -and
-              $_.FullName -notlike "*\Debug\*"
+              $_.FullName -notlike "*\Debug\*" -and
+              $_.Name -notlike "*_tests.exe" -and
+              $_.Name -notlike "CompilerId*.exe" -and
+              $_.Name -notlike "VmaSample*" -and
+              $_.Name -ne "client_flow_app.exe"
             } |
             Copy-Item -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
 


### PR DESCRIPTION
## Problème

L'artifact \`windows-release-<sha>\` contenait **53 fichiers .exe** dont l'utilisateur ne savait pas distinguer ceux de prod du reste. Détail :

- **3 binaires prod** : \`lcdlln.exe\`, \`lcdlln_world_editor.exe\`, \`lcdlln_server.exe\`
- **5 outils dev** (utiles) : \`zone_builder\`, \`hlod_builder\`, \`migration_checksum\`, \`gen_terrain_placeholders\`, \`load_tester\`
- **~38 \`*_tests.exe\`** : test executables qui tournent en ctest, ne devraient PAS être shippés
- **3 junk** : \`CompilerIdC.exe\`, \`CompilerIdCXX.exe\` (cmake compiler detection), \`VmaSample_Release_vs2019.exe\` (sample d'une dépendance vendored)
- **1 test d'intégration** : \`client_flow_app.exe\` (test du flow d'auth headless, pas un outil utilisateur)

## Fix

Ajoute 4 filtres au step \"Collect artifacts\" du workflow Windows :
- \`*_tests.exe\` exclu
- \`CompilerId*.exe\` exclu
- \`VmaSample*\` exclu
- \`client_flow_app.exe\` exclu

Après merge, l'artifact contiendra uniquement les **8 .exe utiles** (3 prod + 5 outils) + DLLs runtime + assets + game/data + config.json.

## Test plan

- [ ] CI Windows produit \`windows-release-<sha>\` artifact
- [ ] Inspecter le artifact : devrait contenir 8 .exe (au lieu de 53)
- [ ] \`lcdlln.exe\` lance le client correctement
- [ ] \`lcdlln_world_editor.exe\` lance l'éditeur correctement

**Déploiement** : ✅ CI uniquement, **pas de redéploiement serveur**.

Generated with Claude Code