### PR TITLE
feat(mail): wire server (Phase 3 CMANGOS.18 step 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,7 @@ add_library(engine_core
   src/shared/network/AuthRegisterPayloads.cpp
   src/shared/network/CharacterPayloads.cpp
   src/shared/network/ChatPayloads.cpp
+  src/shared/network/MailPayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
 )
@@ -623,6 +624,11 @@ add_test(NAME character_save_position_payloads_tests COMMAND character_save_posi
 add_executable(chat_payloads_tests src/shared/network/ChatPayloadsTests.cpp)
 target_link_libraries(chat_payloads_tests PRIVATE engine_core)
 add_test(NAME chat_payloads_tests COMMAND chat_payloads_tests)
+
+# CMANGOS.18 (Phase 3.18 step 3): MAIL_*_REQUEST/RESPONSE payload round-trip tests
+add_executable(mail_payloads_tests src/shared/network/MailPayloadsTests.cpp)
+target_link_libraries(mail_payloads_tests PRIVATE engine_core)
+add_test(NAME mail_payloads_tests COMMAND mail_payloads_tests)
 
 # M23.4: Log rotation smoke test (runtime logger)
 add_executable(log_rotation_smoke_tests src/shared/core/LogRotationSmokeTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/session/SessionCharacterMap.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/chat/ChatRelayHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/mail/MailHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/masterd/handlers/mail/MailHandler.cpp
+++ b/src/masterd/handlers/mail/MailHandler.cpp
@@ -1,0 +1,383 @@
+// CMANGOS.18 (Phase 3.18 step 3) — Implementation MailHandler.
+
+#include "src/masterd/handlers/mail/MailHandler.h"
+
+#include "src/masterd/mail/Mail.h"
+#include "src/masterd/mail/MailManager.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/MailPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Renvoie l'epoch ms UTC. Aligné sur les autres handlers (ex. ChatRelayHandler).
+		uint64_t NowUnixMsUtc()
+		{
+			using namespace std::chrono;
+			return static_cast<uint64_t>(
+				duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+		}
+
+		/// Convertit un MailOpResult (côté manager) en MailSendErrorCode (côté wire).
+		uint8_t MapSendError(engine::server::mail::MailOpResult r)
+		{
+			using engine::server::mail::MailOpResult;
+			using engine::network::MailSendErrorCode;
+			switch (r)
+			{
+			case MailOpResult::OK:                  return static_cast<uint8_t>(MailSendErrorCode::Ok);
+			case MailOpResult::SubjectTooLong:      return static_cast<uint8_t>(MailSendErrorCode::SubjectTooLong);
+			case MailOpResult::BodyTooLong:         return static_cast<uint8_t>(MailSendErrorCode::BodyTooLong);
+			case MailOpResult::AttachmentsTooMany:  return static_cast<uint8_t>(MailSendErrorCode::AttachmentsTooMany);
+			default:
+				// Le manager peut retourner MailNotFound / WrongReceiver / AlreadyTaken /
+				// CodNotPaid pour Send (ne devrait pas dans les faits) — on les rabat sur
+				// RecipientNotFound car c'est ce qui s'en rapproche côté UI.
+				return static_cast<uint8_t>(MailSendErrorCode::RecipientNotFound);
+			}
+		}
+
+		/// Convertit un MailOpResult en MailDeleteErrorCode wire.
+		uint8_t MapDeleteError(engine::server::mail::MailOpResult r)
+		{
+			using engine::server::mail::MailOpResult;
+			using engine::network::MailDeleteErrorCode;
+			switch (r)
+			{
+			case MailOpResult::OK:            return static_cast<uint8_t>(MailDeleteErrorCode::Ok);
+			case MailOpResult::MailNotFound:  return static_cast<uint8_t>(MailDeleteErrorCode::NotFound);
+			case MailOpResult::WrongReceiver: return static_cast<uint8_t>(MailDeleteErrorCode::WrongReceiver);
+			case MailOpResult::AlreadyTaken:  return static_cast<uint8_t>(MailDeleteErrorCode::HasAttachments);
+			default:                          return static_cast<uint8_t>(MailDeleteErrorCode::NotFound);
+			}
+		}
+	}
+
+	void MailHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_mgr || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[MailHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Résolution session/account. Si l'un manque, on retourne une réponse
+		// type-specific avec error=Unauthorized (le client peut alors prompter
+		// une re-auth). Pas d'ErrorPacket générique : la réponse mail est
+		// plus simple à exploiter dans l'UI mailbox.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			// Construire la réponse Unauthorized type-specific selon l'opcode.
+			std::vector<uint8_t> pkt;
+			switch (opcode)
+			{
+			case kOpcodeMailSendRequest:
+				pkt = BuildMailSendResponsePacket(
+					static_cast<uint8_t>(MailSendErrorCode::Unauthorized), 0ull,
+					requestId, sessionIdHeader);
+				break;
+			case kOpcodeMailListInboxRequest:
+				pkt = BuildMailListInboxResponsePacket(
+					static_cast<uint8_t>(MailSendErrorCode::Unauthorized), {},
+					requestId, sessionIdHeader);
+				break;
+			case kOpcodeMailReadRequest:
+				pkt = BuildMailReadResponsePacket(
+					static_cast<uint8_t>(MailReadErrorCode::Unauthorized), 0ull, "",
+					requestId, sessionIdHeader);
+				break;
+			case kOpcodeMailTakeAttachmentsRequest:
+				pkt = BuildMailTakeAttachmentsResponsePacket(
+					static_cast<uint8_t>(MailTakeErrorCode::Unauthorized), 0ull, 0ull,
+					requestId, sessionIdHeader);
+				break;
+			case kOpcodeMailDeleteRequest:
+				pkt = BuildMailDeleteResponsePacket(
+					static_cast<uint8_t>(MailDeleteErrorCode::Unauthorized), 0ull,
+					requestId, sessionIdHeader);
+				break;
+			default:
+				return; // pas un opcode Mail : ignore.
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeMailSendRequest:
+			HandleSend(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeMailListInboxRequest:
+			HandleListInbox(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeMailReadRequest:
+			HandleRead(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeMailTakeAttachmentsRequest:
+			HandleTakeAttachments(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeMailDeleteRequest:
+			HandleDelete(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			// Pas un opcode Mail : ignore silencieusement.
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void MailHandler::HandleSend(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t senderAccountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseMailSendRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildMailSendResponsePacket(
+				static_cast<uint8_t>(MailSendErrorCode::RecipientNotFound), 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// MailManager::Send valide les limites subject/body/attachments. Pour
+		// la résolution recipient → exists check : si le store DB renvoie 0
+		// d'inserts à cause d'une FK violation, on retournera RecipientNotFound.
+		// Le manager actuel insère sans vérifier l'existence du receiver côté
+		// accounts — TBD step 3.b si on veut un précheck explicite (perf : un
+		// SELECT id FROM accounts WHERE id=? avant Insert).
+		engine::server::mail::MailOpResult opErr = engine::server::mail::MailOpResult::OK;
+		const uint64_t mailId = m_mgr->Send(
+			senderAccountId,
+			parsed->recipientAccountId,
+			parsed->subject,
+			parsed->body,
+			/*items*/ {},
+			parsed->copperGold,
+			parsed->copperCod,
+			NowUnixMsUtc(),
+			/*expiresTsMs*/ 0ull,
+			&opErr);
+
+		uint8_t errCode = MapSendError(opErr);
+		if (mailId == 0ull && opErr == engine::server::mail::MailOpResult::OK)
+		{
+			// Insert DB a échoué (FK invalide, store down, …). Le manager retourne
+			// 0 sans set outErr dans ce chemin → on rabat sur RecipientNotFound.
+			errCode = static_cast<uint8_t>(MailSendErrorCode::RecipientNotFound);
+		}
+
+		LOG_INFO(Net, "[MailHandler] Send sender={} recipient={} mailId={} err={}",
+			senderAccountId, parsed->recipientAccountId, mailId, static_cast<int>(opErr));
+
+		auto pkt = BuildMailSendResponsePacket(errCode, mailId, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void MailHandler::HandleListInbox(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+		std::vector<engine::server::mail::Mail> inbox = m_mgr->Inbox(accountId);
+		std::vector<MailInboxEntry> entries;
+		entries.reserve(inbox.size());
+		for (const auto& m : inbox)
+		{
+			MailInboxEntry e;
+			e.mailId          = m.mailId;
+			e.senderAccountId = m.senderAccountId;
+			e.subject         = m.subject;
+			e.sentTsMs        = m.sentTsMs;
+			e.expiresTsMs     = m.expiresTsMs;
+			e.state           = static_cast<uint8_t>(m.state);
+			e.copperGold      = m.copperGold;
+			e.copperCod       = m.copperCod;
+			entries.push_back(std::move(e));
+		}
+
+		LOG_INFO(Net, "[MailHandler] ListInbox account={} count={}", accountId, entries.size());
+
+		auto pkt = BuildMailListInboxResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void MailHandler::HandleRead(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseMailReadRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildMailReadResponsePacket(
+				static_cast<uint8_t>(MailReadErrorCode::NotFound), 0ull, "",
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const auto opErr = m_mgr->MarkRead(parsed->mailId, accountId);
+		if (opErr != engine::server::mail::MailOpResult::OK)
+		{
+			using engine::server::mail::MailOpResult;
+			uint8_t code = static_cast<uint8_t>(MailReadErrorCode::NotFound);
+			if (opErr == MailOpResult::WrongReceiver)
+				code = static_cast<uint8_t>(MailReadErrorCode::WrongReceiver);
+			auto pkt = BuildMailReadResponsePacket(code, parsed->mailId, "",
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Pour récupérer le body, on relit l'inbox du destinataire et on cherche
+		// le mailId. C'est suboptimal (full-scan), mais le MailManager actuel
+		// ne fournit pas de Find direct par (mailId, receiverAccountId).
+		// step 3.b : ajouter un IMailStore::FindForReceiver pour éviter le scan.
+		std::string body;
+		const auto inbox = m_mgr->Inbox(accountId);
+		for (const auto& m : inbox)
+		{
+			if (m.mailId == parsed->mailId)
+			{
+				body = m.body;
+				break;
+			}
+		}
+
+		LOG_INFO(Net, "[MailHandler] Read account={} mailId={} bodyLen={}",
+			accountId, parsed->mailId, body.size());
+
+		auto pkt = BuildMailReadResponsePacket(
+			static_cast<uint8_t>(MailReadErrorCode::Ok), parsed->mailId, body,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void MailHandler::HandleTakeAttachments(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseMailTakeAttachmentsRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildMailTakeAttachmentsResponsePacket(
+				static_cast<uint8_t>(MailTakeErrorCode::NotFound), 0ull, 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Cette PR ne câble que le retrait du gold. Les items seront wirés en
+		// step 3.b une fois la spec d'inventaire stabilisée. On appelle quand
+		// même TakeItems pour valider COD + retirer les items côté store (s'ils
+		// existent), mais on ignore outItems pour la réponse wire.
+		std::vector<engine::server::mail::MailItemAttachment> outItems;
+		const auto itemsErr = m_mgr->TakeItems(parsed->mailId, accountId,
+			parsed->paidCopperCod, outItems);
+
+		// On accepte AlreadyTaken pour les items (mail vide d'items, juste du
+		// gold) — on enchaîne sur TakeGold dans tous les cas où l'erreur n'est
+		// pas un blocage receiver/COD.
+		using engine::server::mail::MailOpResult;
+		if (itemsErr != MailOpResult::OK
+			&& itemsErr != MailOpResult::AlreadyTaken)
+		{
+			uint8_t code;
+			switch (itemsErr)
+			{
+			case MailOpResult::MailNotFound:  code = static_cast<uint8_t>(MailTakeErrorCode::NotFound); break;
+			case MailOpResult::WrongReceiver: code = static_cast<uint8_t>(MailTakeErrorCode::WrongReceiver); break;
+			case MailOpResult::CodNotPaid:    code = static_cast<uint8_t>(MailTakeErrorCode::CodNotPaid); break;
+			default:                          code = static_cast<uint8_t>(MailTakeErrorCode::NotFound); break;
+			}
+			auto pkt = BuildMailTakeAttachmentsResponsePacket(code, parsed->mailId, 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		uint64_t goldTaken = 0ull;
+		const auto goldErr = m_mgr->TakeGold(parsed->mailId, accountId, goldTaken);
+		// AlreadyTaken pour le gold = mail sans gold → OK quand même (le caller
+		// a peut-être seulement voulu prendre les items).
+		uint8_t code = static_cast<uint8_t>(MailTakeErrorCode::Ok);
+		if (goldErr != MailOpResult::OK && goldErr != MailOpResult::AlreadyTaken)
+		{
+			switch (goldErr)
+			{
+			case MailOpResult::MailNotFound:  code = static_cast<uint8_t>(MailTakeErrorCode::NotFound); break;
+			case MailOpResult::WrongReceiver: code = static_cast<uint8_t>(MailTakeErrorCode::WrongReceiver); break;
+			default:                          code = static_cast<uint8_t>(MailTakeErrorCode::NotFound); break;
+			}
+		}
+
+		LOG_INFO(Net, "[MailHandler] Take account={} mailId={} goldTaken={} code={}",
+			accountId, parsed->mailId, goldTaken, static_cast<int>(code));
+
+		auto pkt = BuildMailTakeAttachmentsResponsePacket(code, parsed->mailId, goldTaken,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void MailHandler::HandleDelete(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseMailDeleteRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildMailDeleteResponsePacket(
+				static_cast<uint8_t>(MailDeleteErrorCode::NotFound), 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+		const auto opErr = m_mgr->Delete(parsed->mailId, accountId);
+		const uint8_t code = MapDeleteError(opErr);
+
+		LOG_INFO(Net, "[MailHandler] Delete account={} mailId={} code={}",
+			accountId, parsed->mailId, static_cast<int>(code));
+
+		auto pkt = BuildMailDeleteResponsePacket(code, parsed->mailId,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+}

--- a/src/masterd/handlers/mail/MailHandler.h
+++ b/src/masterd/handlers/mail/MailHandler.h
@@ -1,0 +1,92 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18 step 3) — MailHandler : dispatch des opcodes Mail
+// (49–58) et appel des methodes correspondantes de MailManager.
+//
+// Le handler est instancié dans main_linux.cpp au boot du master, câblé via
+// SetXxx(...), puis enregistré dans le packetHandler du NetServer pour les
+// opcodes 49/51/53/55/57 (les requests). Les responses sont émises avec
+// le même requestId / sessionId que la request reçue (cf. RequestResponseDispatcher
+// pour le contrat client).
+//
+// Validation session : chaque opcode exige une session authentifiée. Le
+// handler résout connId → sessionId via ConnectionSessionMap, puis sessionId
+// → accountId via SessionManager. Si l'un échoue, on répond avec
+// error=Unauthorized (pas un ErrorPacket — pour le client UI le code 6
+// dans la réponse type-specific est plus exploitable qu'un BAD_REQUEST
+// générique).
+
+#include <cstdint>
+#include <cstddef>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::mail
+{
+	class MailManager;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Mail. Doit être configuré via Set*() avant tout HandlePacket.
+	class MailHandler
+	{
+	public:
+		/// Branche le manager de mails (logique métier + store).
+		void SetMailManager(engine::server::mail::MailManager* mgr) { m_mgr = mgr; }
+		/// Branche le NetServer pour pouvoir envoyer les réponses.
+		void SetServer(NetServer* server) { m_server = server; }
+		/// Branche le SessionManager pour résoudre sessionId → accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId → sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entrée appelé par NetServer pour les opcodes Mail. Dispatch
+		/// vers HandleSend/HandleListInbox/etc. selon l'opcode. Si l'opcode
+		/// n'est pas un opcode Mail, ignore silencieusement (filtrage déjà
+		/// fait côté main_linux).
+		///
+		/// \param connId         identifiant de connexion TCP (pour Send response).
+		/// \param opcode         opcode du paquet entrant (49/51/53/55/57).
+		/// \param requestId      request_id du paquet entrant ; renvoyé tel quel dans la réponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoyé tel quel dans la réponse.
+		/// \param payload        pointeur sur le payload (sans header).
+		/// \param payloadSize    taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// Traite MAIL_SEND_REQUEST : parse + appel MailManager::Send + emit response.
+		void HandleSend(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t senderAccountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite MAIL_LIST_INBOX_REQUEST : appel MailManager::Inbox + emit response
+		/// avec la liste convertie en MailInboxEntry.
+		void HandleListInbox(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite MAIL_READ_REQUEST : marque comme lu + retourne le body.
+		void HandleRead(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite MAIL_TAKE_ATTACHMENTS_REQUEST : retire le gold (et valide COD).
+		/// Cette PR ne câble pas les items attachés (cf. step 3.b). On retire
+		/// uniquement le gold et on retourne le montant pris.
+		void HandleTakeAttachments(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite MAIL_DELETE_REQUEST : appel MailManager::Delete et map les codes erreur.
+		void HandleDelete(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		engine::server::mail::MailManager* m_mgr        = nullptr;
+		NetServer*                          m_server     = nullptr;
+		SessionManager*                     m_sessionMgr = nullptr;
+		ConnectionSessionMap*               m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -34,6 +34,9 @@
 #include "src/masterd/handlers/character/CharacterSavePositionHandler.h"
 #include "src/masterd/handlers/character/CharacterEnterWorldHandler.h"
 #include "src/masterd/handlers/chat/ChatRelayHandler.h"
+#include "src/masterd/handlers/mail/MailHandler.h"
+#include "src/masterd/mail/MailManager.h"
+#include "src/masterd/mail/MysqlMailStore.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
 #include "src/shared/core/Config.h"
@@ -331,6 +334,29 @@ int main(int argc, char** argv)
 			gateCfg.floodWindowMs, gateCfg.floodMaxMessages);
 	}
 
+	// CMANGOS.18 (Phase 3.18 step 3) — Mail wire server.
+	// Le store DB est instancié seulement si dbPool est dispo (sinon le master
+	// tourne en mode "no-DB" — accountStoreMem — et on ne peut pas persister
+	// de mails). Dans ce mode dégradé, on laisse m_mgr=nullptr côté handler →
+	// HandlePacket logge un warning et drop. C'est cohérent avec le fait qu'en
+	// mode no-DB, l'auth n'est pas non plus persistée et la mailbox n'a pas
+	// de raison d'être réellement utilisable.
+	engine::server::mail::MysqlMailStore mailStore(&dbPool);
+	engine::server::mail::MailManager mailManager(&mailStore);
+	engine::server::MailHandler mailHandler;
+	if (dbPool.IsInitialized())
+	{
+		mailHandler.SetMailManager(&mailManager);
+		mailHandler.SetServer(&server);
+		mailHandler.SetSessionManager(&sessionManager);
+		mailHandler.SetConnectionSessionMap(&connSessionMap);
+		LOG_INFO(Net, "[ServerMain] MailHandler configured (CMANGOS.18 step 3)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] MailHandler skipped (DB pool unavailable)");
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -370,7 +396,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -397,6 +423,12 @@ int main(int argc, char** argv)
 			chatRelayHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeCharacterEnterWorldRequest)
 			characterEnterWorldHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeMailSendRequest
+		      || opcode == kOpcodeMailListInboxRequest
+		      || opcode == kOpcodeMailReadRequest
+		      || opcode == kOpcodeMailTakeAttachmentsRequest
+		      || opcode == kOpcodeMailDeleteRequest)
+			mailHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/MailPayloads.cpp
+++ b/src/shared/network/MailPayloads.cpp
@@ -1,0 +1,404 @@
+// CMANGOS.18 (Phase 3.18 step 3) — Implementation Parse/Build des payloads Mail.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilisé côté tests round-trip et
+//     côté client pour les requests (envoyé via NetClient::SendRequest qui
+//     ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, prêt à passer à NetServer::Send. Le
+//     requestId vient du paquet d'origine (cf. RequestResponseDispatcher).
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/MailPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Helper : construit un payload dans un buffer scratch dimensionné à la
+		/// limite protocole, puis le tronque à l'offset réel. Évite de penser à la
+		/// taille exacte d'avance pour les payloads contenant des strings/vector.
+		std::vector<uint8_t> MakeScratchBuffer()
+		{
+			return std::vector<uint8_t>(kProtocolV1MaxPacketSize, 0u);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// MAIL_SEND
+	// -------------------------------------------------------------------------
+
+	std::optional<MailSendRequestPayload> ParseMailSendRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 recipient (8) + uint16 subject_len (2) + uint16 body_len (2)
+		//       + uint64 gold (8) + uint64 cod (8) = 28 octets si subject/body vides.
+		if (!payload || payloadSize < 28u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailSendRequestPayload out;
+		if (!r.ReadU64(out.recipientAccountId))
+			return std::nullopt;
+		if (!r.ReadString(out.subject))
+			return std::nullopt;
+		if (!r.ReadString(out.body))
+			return std::nullopt;
+		if (!r.ReadU64(out.copperGold))
+			return std::nullopt;
+		if (!r.ReadU64(out.copperCod))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailSendRequestPayload(uint64_t recipientAccountId,
+	                                                 std::string_view subject,
+	                                                 std::string_view body,
+	                                                 uint64_t copperGold,
+	                                                 uint64_t copperCod)
+	{
+		// Tronque défensivement avant l'appel ByteWriter pour éviter qu'une string
+		// > kProtocolV1MaxStringLength fasse échouer WriteString.
+		if (subject.size() > kMaxMailSubjectBytes)
+			subject = subject.substr(0, kMaxMailSubjectBytes);
+		if (body.size() > kMaxMailBodyBytes)
+			body = body.substr(0, kMaxMailBodyBytes);
+
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(recipientAccountId))      return {};
+		if (!w.WriteString(subject))              return {};
+		if (!w.WriteString(body))                 return {};
+		if (!w.WriteU64(copperGold))              return {};
+		if (!w.WriteU64(copperCod))               return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<MailSendResponsePayload> ParseMailSendResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 mailId (8) = 9 octets.
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailSendResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (!r.ReadU64(out.mailId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailSendResponsePayload(uint8_t error, uint64_t mailId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildMailSendResponsePacket(uint8_t error, uint64_t mailId,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeMailSendResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// MAIL_LIST_INBOX
+	// -------------------------------------------------------------------------
+
+	std::optional<MailListInboxRequestPayload> ParseMailListInboxRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepté (0 octet ou plus, ignore le reste).
+		return MailListInboxRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildMailListInboxRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	std::optional<MailListInboxResponsePayload> ParseMailListInboxResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1). Si error=0, on continue avec uint16 count + entries.
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailListInboxResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.mails.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			MailInboxEntry e;
+			if (!r.ReadU64(e.mailId))           return std::nullopt;
+			if (!r.ReadU64(e.senderAccountId))  return std::nullopt;
+			if (!r.ReadString(e.subject))       return std::nullopt;
+			if (!r.ReadU64(e.sentTsMs))         return std::nullopt;
+			if (!r.ReadU64(e.expiresTsMs))      return std::nullopt;
+			if (!r.ReadBytes(&e.state, 1u))     return std::nullopt;
+			if (!r.ReadU64(e.copperGold))       return std::nullopt;
+			if (!r.ReadU64(e.copperCod))        return std::nullopt;
+			out.mails.push_back(std::move(e));
+		}
+		return out;
+	}
+
+	namespace
+	{
+		/// Sérialise la partie « après error » de MAIL_LIST_INBOX_RESPONSE.
+		/// Mutualisé entre payload-only et packet builder.
+		bool WriteListInboxBody(ByteWriter& w, uint8_t error, const std::vector<MailInboxEntry>& mails)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(mails.size())))
+				return false;
+			for (const auto& e : mails)
+			{
+				if (!w.WriteU64(e.mailId))           return false;
+				if (!w.WriteU64(e.senderAccountId))  return false;
+				if (!w.WriteString(e.subject))       return false;
+				if (!w.WriteU64(e.sentTsMs))         return false;
+				if (!w.WriteU64(e.expiresTsMs))      return false;
+				if (!w.WriteBytes(&e.state, 1u))     return false;
+				if (!w.WriteU64(e.copperGold))       return false;
+				if (!w.WriteU64(e.copperCod))        return false;
+			}
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> BuildMailListInboxResponsePayload(uint8_t error, const std::vector<MailInboxEntry>& mails)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListInboxBody(w, error, mails))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildMailListInboxResponsePacket(uint8_t error, const std::vector<MailInboxEntry>& mails,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListInboxBody(w, error, mails))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeMailListInboxResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// MAIL_READ
+	// -------------------------------------------------------------------------
+
+	std::optional<MailReadRequestPayload> ParseMailReadRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailReadRequestPayload out;
+		if (!r.ReadU64(out.mailId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailReadRequestPayload(uint64_t mailId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(mailId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<MailReadResponsePayload> ParseMailReadResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1) + uint64 mailId (8) + uint16 body_len (2) = 11.
+		if (!payload || payloadSize < 11u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailReadResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))    return std::nullopt;
+		if (!r.ReadU64(out.mailId))          return std::nullopt;
+		if (!r.ReadString(out.body))         return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailReadResponsePayload(uint8_t error, uint64_t mailId, std::string_view body)
+	{
+		if (body.size() > kMaxMailBodyBytes)
+			body = body.substr(0, kMaxMailBodyBytes);
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		if (!w.WriteString(body))        return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildMailReadResponsePacket(uint8_t error, uint64_t mailId, std::string_view body,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		if (body.size() > kMaxMailBodyBytes)
+			body = body.substr(0, kMaxMailBodyBytes);
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		if (!w.WriteString(body))        return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeMailReadResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// MAIL_TAKE_ATTACHMENTS
+	// -------------------------------------------------------------------------
+
+	std::optional<MailTakeAttachmentsRequestPayload> ParseMailTakeAttachmentsRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 16u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailTakeAttachmentsRequestPayload out;
+		if (!r.ReadU64(out.mailId))         return std::nullopt;
+		if (!r.ReadU64(out.paidCopperCod))  return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailTakeAttachmentsRequestPayload(uint64_t mailId, uint64_t paidCopperCod)
+	{
+		std::vector<uint8_t> buf(16u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(mailId))         return {};
+		if (!w.WriteU64(paidCopperCod))  return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<MailTakeAttachmentsResponsePayload> ParseMailTakeAttachmentsResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 mailId (8) + uint64 copperGoldTaken (8) = 17.
+		if (!payload || payloadSize < 17u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailTakeAttachmentsResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))     return std::nullopt;
+		if (!r.ReadU64(out.mailId))           return std::nullopt;
+		if (!r.ReadU64(out.copperGoldTaken))  return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailTakeAttachmentsResponsePayload(uint8_t error, uint64_t mailId, uint64_t copperGoldTaken)
+	{
+		std::vector<uint8_t> buf(17u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))     return {};
+		if (!w.WriteU64(mailId))           return {};
+		if (!w.WriteU64(copperGoldTaken))  return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildMailTakeAttachmentsResponsePacket(uint8_t error, uint64_t mailId, uint64_t copperGoldTaken,
+	                                                             uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))     return {};
+		if (!w.WriteU64(mailId))           return {};
+		if (!w.WriteU64(copperGoldTaken))  return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeMailTakeAttachmentsResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// MAIL_DELETE
+	// -------------------------------------------------------------------------
+
+	std::optional<MailDeleteRequestPayload> ParseMailDeleteRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailDeleteRequestPayload out;
+		if (!r.ReadU64(out.mailId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailDeleteRequestPayload(uint64_t mailId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(mailId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<MailDeleteResponsePayload> ParseMailDeleteResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 mailId (8) = 9.
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		MailDeleteResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))   return std::nullopt;
+		if (!r.ReadU64(out.mailId))         return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildMailDeleteResponsePayload(uint8_t error, uint64_t mailId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildMailDeleteResponsePacket(uint8_t error, uint64_t mailId,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(mailId))         return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeMailDeleteResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/MailPayloads.h
+++ b/src/shared/network/MailPayloads.h
@@ -1,0 +1,284 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18 step 3) — Wire payloads pour les opcodes Mail (49–58).
+//
+// Cinq paires Request/Response :
+//   - Send (49/50)
+//   - ListInbox (51/52)
+//   - Read (53/54)
+//   - TakeAttachments (55/56)
+//   - Delete (57/58)
+//
+// Format wire : ByteReader/ByteWriter little-endian, strings length-prefixed UTF-8
+// (uint16 length puis octets bruts), vectors préfixés par un uint16 count via
+// WriteArrayCount/ReadArrayCount (cf. ProtocolV1).
+//
+// Cette PR ne câble pas d'items attachés sur le wire — la MVP du step 3 se
+// limite à gold + COD + texte. Les items pourront être ajoutés en step 3.b
+// (ré-utilisation des helpers Inventory déjà spécifiés dans le ticket).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// MAIL_SEND — Client → Master : envoi d'un mail.
+	// =========================================================================
+
+	/// Code d'erreur retourné dans \ref MailSendResponsePayload.
+	/// 0 = OK, mailId valide. Sinon mailId = 0.
+	enum class MailSendErrorCode : uint8_t
+	{
+		Ok                  = 0,
+		RecipientNotFound   = 1, ///< accountId destinataire inconnu côté master.
+		SubjectTooLong      = 2, ///< > kMaxMailSubjectBytes.
+		BodyTooLong         = 3, ///< > kMaxMailBodyBytes.
+		InsufficientGold    = 4, ///< wallet sender insuffisant pour copperGold + frais.
+		AttachmentsTooMany  = 5,
+		Unauthorized        = 6, ///< pas de session valide.
+	};
+
+	/// Wire format :
+	///   uint64 recipientAccountId
+	///   string subject
+	///   string body
+	///   uint64 copperGold
+	///   uint64 copperCod
+	struct MailSendRequestPayload
+	{
+		uint64_t    recipientAccountId = 0; ///< Le client a déjà résolu le login → account_id.
+		std::string subject;
+		std::string body;
+		uint64_t    copperGold = 0;
+		uint64_t    copperCod  = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error (cf. MailSendErrorCode)
+	///   uint64 mailId  (0 si error != Ok)
+	struct MailSendResponsePayload
+	{
+		uint8_t  error  = 0;
+		uint64_t mailId = 0;
+	};
+
+	// =========================================================================
+	// MAIL_LIST_INBOX — Client → Master : liste les mails de l'account courant.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est dérivé de la session côté master,
+	/// jamais transmis par le client (anti-énumération).
+	struct MailListInboxRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entrée résumée de la boîte de réception (sans body).
+	/// Le body complet n'est servi que sur MAIL_READ (économise la bande passante).
+	struct MailInboxEntry
+	{
+		uint64_t    mailId           = 0;
+		uint64_t    senderAccountId  = 0;
+		std::string subject;
+		uint64_t    sentTsMs         = 0;
+		uint64_t    expiresTsMs      = 0;
+		uint8_t     state            = 0; ///< 0=Unread, 1=Read, 2=Returned, 3=Deleted (cf. MailState).
+		uint64_t    copperGold       = 0;
+		uint64_t    copperCod        = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error (0=Ok, 6=Unauthorized)
+	///   uint16 count
+	///   <count> entries
+	struct MailListInboxResponsePayload
+	{
+		uint8_t                     error = 0;
+		std::vector<MailInboxEntry> mails;
+	};
+
+	// =========================================================================
+	// MAIL_READ — Client → Master : marque comme lu et récupère le body.
+	// =========================================================================
+
+	enum class MailReadErrorCode : uint8_t
+	{
+		Ok            = 0,
+		NotFound      = 1,
+		WrongReceiver = 2,
+		Unauthorized  = 6,
+	};
+
+	/// Wire format : uint64 mailId (8 octets).
+	struct MailReadRequestPayload
+	{
+		uint64_t mailId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 mailId
+	///   string body  (vide si error != Ok)
+	struct MailReadResponsePayload
+	{
+		uint8_t     error  = 0;
+		uint64_t    mailId = 0;
+		std::string body;
+	};
+
+	// =========================================================================
+	// MAIL_TAKE_ATTACHMENTS — Client → Master : retire gold (et COD si requis).
+	// =========================================================================
+
+	enum class MailTakeErrorCode : uint8_t
+	{
+		Ok            = 0,
+		NotFound      = 1,
+		WrongReceiver = 2,
+		AlreadyTaken  = 3, ///< Gold déjà retiré.
+		CodNotPaid    = 4, ///< paidCopperCod < copperCod du mail.
+		Unauthorized  = 6,
+	};
+
+	/// Wire format :
+	///   uint64 mailId
+	///   uint64 paidCopperCod  (gold que le client confirme avoir prélevé pour le COD)
+	struct MailTakeAttachmentsRequestPayload
+	{
+		uint64_t mailId        = 0;
+		uint64_t paidCopperCod = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 mailId
+	///   uint64 copperGoldTaken
+	struct MailTakeAttachmentsResponsePayload
+	{
+		uint8_t  error            = 0;
+		uint64_t mailId           = 0;
+		uint64_t copperGoldTaken  = 0;
+	};
+
+	// =========================================================================
+	// MAIL_DELETE — Client → Master : supprime un mail.
+	// =========================================================================
+
+	enum class MailDeleteErrorCode : uint8_t
+	{
+		Ok              = 0,
+		NotFound        = 1,
+		WrongReceiver   = 2,
+		HasAttachments  = 3, ///< Items / gold encore présents (faire Take avant Delete).
+		Unauthorized    = 6,
+	};
+
+	/// Wire format : uint64 mailId.
+	struct MailDeleteRequestPayload
+	{
+		uint64_t mailId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 mailId
+	struct MailDeleteResponsePayload
+	{
+		uint8_t  error  = 0;
+		uint64_t mailId = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Plafonds canoniques wire (alignés sur src/masterd/mail/Mail.h pour
+	// kMaxMailSubjectBytes, mais le body wire est plafonné à
+	// kProtocolV1MaxStringLength = 8192. Si le storage DB autorise plus, le
+	// client recevra ce qui rentre dans la string protocol_v1 et tronquera
+	// silencieusement. Pour cette MVP step 3 c'est suffisant.
+	// -------------------------------------------------------------------------
+	inline constexpr size_t kMaxMailSubjectBytes = 255u;
+	inline constexpr size_t kMaxMailBodyBytes    = 8192u;
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un MAIL_SEND_REQUEST.
+	/// \return nullopt si le payload est tronqué ou malformé.
+	std::optional<MailSendRequestPayload> ParseMailSendRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un MAIL_LIST_INBOX_REQUEST. Toujours OK (payload vide accepté).
+	std::optional<MailListInboxRequestPayload> ParseMailListInboxRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un MAIL_READ_REQUEST. \return nullopt si payloadSize < 8.
+	std::optional<MailReadRequestPayload> ParseMailReadRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un MAIL_TAKE_ATTACHMENTS_REQUEST. \return nullopt si payloadSize < 16.
+	std::optional<MailTakeAttachmentsRequestPayload> ParseMailTakeAttachmentsRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un MAIL_DELETE_REQUEST. \return nullopt si payloadSize < 8.
+	std::optional<MailDeleteRequestPayload> ParseMailDeleteRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Construit le payload (sans header) d'un MAIL_SEND_REQUEST.
+	std::vector<uint8_t> BuildMailSendRequestPayload(uint64_t recipientAccountId,
+	                                                 std::string_view subject,
+	                                                 std::string_view body,
+	                                                 uint64_t copperGold,
+	                                                 uint64_t copperCod);
+
+	/// Construit le payload (vide) d'un MAIL_LIST_INBOX_REQUEST.
+	std::vector<uint8_t> BuildMailListInboxRequestPayload();
+
+	/// Construit le payload d'un MAIL_READ_REQUEST.
+	std::vector<uint8_t> BuildMailReadRequestPayload(uint64_t mailId);
+
+	/// Construit le payload d'un MAIL_TAKE_ATTACHMENTS_REQUEST.
+	std::vector<uint8_t> BuildMailTakeAttachmentsRequestPayload(uint64_t mailId, uint64_t paidCopperCod);
+
+	/// Construit le payload d'un MAIL_DELETE_REQUEST.
+	std::vector<uint8_t> BuildMailDeleteRequestPayload(uint64_t mailId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses
+	// -------------------------------------------------------------------------
+
+	std::optional<MailSendResponsePayload>             ParseMailSendResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<MailListInboxResponsePayload>        ParseMailListInboxResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<MailReadResponsePayload>             ParseMailReadResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<MailTakeAttachmentsResponsePayload>  ParseMailTakeAttachmentsResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<MailDeleteResponsePayload>           ParseMailDeleteResponsePayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Construit un paquet complet (header + payload) MAIL_SEND_RESPONSE prêt à envoyer.
+	std::vector<uint8_t> BuildMailSendResponsePacket(uint8_t error, uint64_t mailId,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet MAIL_LIST_INBOX_RESPONSE.
+	std::vector<uint8_t> BuildMailListInboxResponsePacket(uint8_t error, const std::vector<MailInboxEntry>& mails,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet MAIL_READ_RESPONSE.
+	std::vector<uint8_t> BuildMailReadResponsePacket(uint8_t error, uint64_t mailId, std::string_view body,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet MAIL_TAKE_ATTACHMENTS_RESPONSE.
+	std::vector<uint8_t> BuildMailTakeAttachmentsResponsePacket(uint8_t error, uint64_t mailId, uint64_t copperGoldTaken,
+	                                                             uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet MAIL_DELETE_RESPONSE.
+	std::vector<uint8_t> BuildMailDeleteResponsePacket(uint8_t error, uint64_t mailId,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader);
+
+	// -------------------------------------------------------------------------
+	// Build payload-only (utile côté tests round-trip — symétrie avec les
+	// Parse*Response qui lisent le payload nu, sans header).
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildMailSendResponsePayload(uint8_t error, uint64_t mailId);
+	std::vector<uint8_t> BuildMailListInboxResponsePayload(uint8_t error, const std::vector<MailInboxEntry>& mails);
+	std::vector<uint8_t> BuildMailReadResponsePayload(uint8_t error, uint64_t mailId, std::string_view body);
+	std::vector<uint8_t> BuildMailTakeAttachmentsResponsePayload(uint8_t error, uint64_t mailId, uint64_t copperGoldTaken);
+	std::vector<uint8_t> BuildMailDeleteResponsePayload(uint8_t error, uint64_t mailId);
+}

--- a/src/shared/network/MailPayloadsTests.cpp
+++ b/src/shared/network/MailPayloadsTests.cpp
@@ -324,10 +324,12 @@ static void TestDeleteResponseHasAttachments()
 static void TestSendRequestUtf8()
 {
 	// Wire format byte-pour-byte : on encode des octets >= 0x80 directement
-	// (\xc3\xa9 = 'é' UTF-8). Pas de literal UTF-8 dans la source pour rester
-	// portable MSVC sans /utf-8.
-	const std::string subjectUtf8 = "Re: \xc3\xa9p\xc3\xa9e";
-	const std::string bodyUtf8    = "L'\xc3\xa9p\xc3\xa9e brille \xc3\xa0 la lune.";
+	// (\xc3\xa9 = 'e' acute UTF-8). MSVC parse \xHH greedy (lit tous les
+	// hex digits adjacents), donc "\xc3\xa9p" devient "\xc3\xa9p" entier
+	// puis "\xa9p" out of range. Solution : casser via concatenation de
+	// string literals adjacents pour forcer la fin de l'escape.
+	const std::string subjectUtf8 = "Re: " "\xc3\xa9" "p" "\xc3\xa9" "e";
+	const std::string bodyUtf8    = "L'" "\xc3\xa9" "p" "\xc3\xa9" "e brille " "\xc3\xa0" " la lune.";
 	auto buf = BuildMailSendRequestPayload(1ull, subjectUtf8, bodyUtf8, 0ull, 0ull);
 	auto parsed = ParseMailSendRequestPayload(buf.data(), buf.size());
 	Assert(parsed.has_value(), "UTF-8 parses");

--- a/src/shared/network/MailPayloadsTests.cpp
+++ b/src/shared/network/MailPayloadsTests.cpp
@@ -1,0 +1,396 @@
+/**
+ * CMANGOS.18 (Phase 3.18 step 3) — Round-trip tests for MAIL_*_REQUEST /
+ * MAIL_*_RESPONSE payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ *
+ * Test policy : symétrique aux ChatPayloadsTests.cpp — pas de framework de
+ * test externe, juste un Assert local + main() qui appelle chaque suite.
+ */
+
+#include "src/shared/network/MailPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// MAIL_SEND
+// -----------------------------------------------------------------------------
+
+static void TestSendRequestRoundTrip()
+{
+	auto buf = BuildMailSendRequestPayload(42ull, "Hello", "Test body content", 1000ull, 250ull);
+	Assert(!buf.empty(), "Send request build not empty");
+	auto parsed = ParseMailSendRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Send request parses OK");
+	if (parsed)
+	{
+		Assert(parsed->recipientAccountId == 42ull, "recipient round-trips");
+		Assert(parsed->subject == "Hello", "subject round-trips");
+		Assert(parsed->body == "Test body content", "body round-trips");
+		Assert(parsed->copperGold == 1000ull, "gold round-trips");
+		Assert(parsed->copperCod == 250ull, "cod round-trips");
+	}
+}
+
+static void TestSendRequestEmptyStrings()
+{
+	auto buf = BuildMailSendRequestPayload(0ull, "", "", 0ull, 0ull);
+	auto parsed = ParseMailSendRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Send request with empty strings parses");
+	if (parsed)
+	{
+		Assert(parsed->subject.empty() && parsed->body.empty(), "Empty subject/body round-trip");
+		Assert(parsed->recipientAccountId == 0ull && parsed->copperGold == 0ull && parsed->copperCod == 0ull,
+		       "Zero numerics round-trip");
+	}
+}
+
+static void TestSendRequestRejectsShort()
+{
+	auto parsed = ParseMailSendRequestPayload(nullptr, 28u);
+	Assert(!parsed.has_value(), "Send request rejects nullptr");
+	uint8_t shortBuf[8]{};
+	auto parsed2 = ParseMailSendRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Send request rejects truncated buf");
+}
+
+static void TestSendResponseRoundTrip()
+{
+	auto buf = BuildMailSendResponsePayload(0u, 0xDEADBEEFull);
+	auto parsed = ParseMailSendResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Send response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "OK error code");
+		Assert(parsed->mailId == 0xDEADBEEFull, "mailId round-trips");
+	}
+
+	auto bufErr = BuildMailSendResponsePayload(static_cast<uint8_t>(MailSendErrorCode::RecipientNotFound), 0ull);
+	auto parsedErr = ParseMailSendResponsePayload(bufErr.data(), bufErr.size());
+	Assert(parsedErr.has_value() && parsedErr->error == 1u, "Error code round-trips");
+	Assert(parsedErr && parsedErr->mailId == 0ull, "mailId is 0 on error");
+}
+
+static void TestSendResponsePacket()
+{
+	// Le packet builder produit un paquet complet (header + payload). On le
+	// décode en deux temps : PacketView pour le header, puis ParseMailSendResponse
+	// pour le payload.
+	auto pkt = BuildMailSendResponsePacket(0u, 99ull, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Send response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeMailSendResponse, "Packet opcode is MailSendResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseMailSendResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->mailId == 99ull, "Payload decodes from packet");
+}
+
+// -----------------------------------------------------------------------------
+// MAIL_LIST_INBOX
+// -----------------------------------------------------------------------------
+
+static void TestListInboxRequest()
+{
+	auto buf = BuildMailListInboxRequestPayload();
+	Assert(buf.empty(), "ListInbox request payload is empty");
+	auto parsed = ParseMailListInboxRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "ListInbox request accepts empty payload");
+}
+
+static void TestListInboxResponseEmpty()
+{
+	auto buf = BuildMailListInboxResponsePayload(0u, {});
+	auto parsed = ParseMailListInboxResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ListInbox response (empty) parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Empty inbox is OK");
+		Assert(parsed->mails.empty(), "Empty inbox has no mails");
+	}
+}
+
+static void TestListInboxResponseUnauthorized()
+{
+	// Quand error != 0, on ne sérialise pas le count (économie de bande passante
+	// sur le cas d'erreur). Le parser doit retourner error=Unauthorized sans crasher.
+	auto buf = BuildMailListInboxResponsePayload(static_cast<uint8_t>(MailSendErrorCode::Unauthorized), {});
+	auto parsed = ParseMailListInboxResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "Unauthorized error decodes");
+	Assert(parsed && parsed->mails.empty(), "No entries decoded on error");
+}
+
+static void TestListInboxResponseMultiple()
+{
+	std::vector<MailInboxEntry> mails;
+	{
+		MailInboxEntry e1;
+		e1.mailId = 1ull;
+		e1.senderAccountId = 100ull;
+		e1.subject = "Subject A";
+		e1.sentTsMs = 1700000000000ull;
+		e1.expiresTsMs = 1700001000000ull;
+		e1.state = 0u;
+		e1.copperGold = 50ull;
+		e1.copperCod = 0ull;
+		mails.push_back(e1);
+	}
+	{
+		MailInboxEntry e2;
+		e2.mailId = 2ull;
+		e2.senderAccountId = 200ull;
+		e2.subject = "";
+		e2.sentTsMs = 1700000050000ull;
+		e2.expiresTsMs = 0ull;
+		e2.state = 1u;
+		e2.copperGold = 0ull;
+		e2.copperCod = 999ull;
+		mails.push_back(e2);
+	}
+
+	auto buf = BuildMailListInboxResponsePayload(0u, mails);
+	auto parsed = ParseMailListInboxResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ListInbox response (2 entries) parses OK");
+	if (parsed && parsed->mails.size() == 2u)
+	{
+		Assert(parsed->mails[0].mailId == 1ull, "entry[0] id");
+		Assert(parsed->mails[0].subject == "Subject A", "entry[0] subject");
+		Assert(parsed->mails[0].copperGold == 50ull, "entry[0] gold");
+		Assert(parsed->mails[1].mailId == 2ull, "entry[1] id");
+		Assert(parsed->mails[1].subject.empty(), "entry[1] empty subject");
+		Assert(parsed->mails[1].state == 1u, "entry[1] state Read");
+		Assert(parsed->mails[1].copperCod == 999ull, "entry[1] cod");
+	}
+	else
+	{
+		Assert(false, "ListInbox response should have 2 entries");
+	}
+}
+
+static void TestListInboxResponseRejectsShort()
+{
+	auto parsed = ParseMailListInboxResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "ListInbox response rejects nullptr");
+	// 1-octet buffer with size 0 is rejected as well.
+	uint8_t one[1]{0};
+	auto parsed2 = ParseMailListInboxResponsePayload(one, 0u);
+	Assert(!parsed2.has_value(), "ListInbox response rejects size 0");
+}
+
+// -----------------------------------------------------------------------------
+// MAIL_READ
+// -----------------------------------------------------------------------------
+
+static void TestReadRequestRoundTrip()
+{
+	auto buf = BuildMailReadRequestPayload(123456789ull);
+	Assert(buf.size() == 8u, "Read request is 8 bytes");
+	auto parsed = ParseMailReadRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->mailId == 123456789ull, "Read request round-trips");
+}
+
+static void TestReadRequestRejectsShort()
+{
+	uint8_t shortBuf[7]{};
+	auto parsed = ParseMailReadRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "Read request rejects 7 bytes");
+}
+
+static void TestReadResponseRoundTrip()
+{
+	auto buf = BuildMailReadResponsePayload(0u, 42ull, "The full body of the mail.\nWith newlines.");
+	auto parsed = ParseMailReadResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Read response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Read response error 0");
+		Assert(parsed->mailId == 42ull, "Read response mailId round-trips");
+		Assert(parsed->body == "The full body of the mail.\nWith newlines.", "Read response body round-trips");
+	}
+}
+
+static void TestReadResponseError()
+{
+	auto buf = BuildMailReadResponsePayload(static_cast<uint8_t>(MailReadErrorCode::NotFound), 0ull, "");
+	auto parsed = ParseMailReadResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Read response error decodes");
+	Assert(parsed && parsed->body.empty(), "Read response body empty on error");
+}
+
+// -----------------------------------------------------------------------------
+// MAIL_TAKE_ATTACHMENTS
+// -----------------------------------------------------------------------------
+
+static void TestTakeRequestRoundTrip()
+{
+	auto buf = BuildMailTakeAttachmentsRequestPayload(7ull, 500ull);
+	Assert(buf.size() == 16u, "Take request is 16 bytes");
+	auto parsed = ParseMailTakeAttachmentsRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Take request parses OK");
+	if (parsed)
+	{
+		Assert(parsed->mailId == 7ull, "Take request mailId");
+		Assert(parsed->paidCopperCod == 500ull, "Take request paidCod");
+	}
+}
+
+static void TestTakeRequestRejectsShort()
+{
+	uint8_t shortBuf[15]{};
+	auto parsed = ParseMailTakeAttachmentsRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "Take request rejects 15 bytes");
+}
+
+static void TestTakeResponseRoundTrip()
+{
+	auto buf = BuildMailTakeAttachmentsResponsePayload(0u, 7ull, 1234ull);
+	Assert(buf.size() == 17u, "Take response is 17 bytes");
+	auto parsed = ParseMailTakeAttachmentsResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Take response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Take response OK");
+		Assert(parsed->mailId == 7ull, "Take response mailId");
+		Assert(parsed->copperGoldTaken == 1234ull, "Take response gold taken");
+	}
+}
+
+static void TestTakeResponseCodNotPaid()
+{
+	auto buf = BuildMailTakeAttachmentsResponsePayload(
+		static_cast<uint8_t>(MailTakeErrorCode::CodNotPaid), 7ull, 0ull);
+	auto parsed = ParseMailTakeAttachmentsResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 4u, "Take response CodNotPaid decodes");
+}
+
+// -----------------------------------------------------------------------------
+// MAIL_DELETE
+// -----------------------------------------------------------------------------
+
+static void TestDeleteRequestRoundTrip()
+{
+	auto buf = BuildMailDeleteRequestPayload(99ull);
+	Assert(buf.size() == 8u, "Delete request is 8 bytes");
+	auto parsed = ParseMailDeleteRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->mailId == 99ull, "Delete request round-trips");
+}
+
+static void TestDeleteResponseRoundTrip()
+{
+	auto buf = BuildMailDeleteResponsePayload(0u, 99ull);
+	auto parsed = ParseMailDeleteResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Delete response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Delete response error 0");
+		Assert(parsed->mailId == 99ull, "Delete response mailId");
+	}
+}
+
+static void TestDeleteResponseHasAttachments()
+{
+	auto buf = BuildMailDeleteResponsePayload(
+		static_cast<uint8_t>(MailDeleteErrorCode::HasAttachments), 99ull);
+	auto parsed = ParseMailDeleteResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "Delete response HasAttachments decodes");
+}
+
+// -----------------------------------------------------------------------------
+// UTF-8 / boundary
+// -----------------------------------------------------------------------------
+
+static void TestSendRequestUtf8()
+{
+	// Wire format byte-pour-byte : on encode des octets >= 0x80 directement
+	// (\xc3\xa9 = 'é' UTF-8). Pas de literal UTF-8 dans la source pour rester
+	// portable MSVC sans /utf-8.
+	const std::string subjectUtf8 = "Re: \xc3\xa9p\xc3\xa9e";
+	const std::string bodyUtf8    = "L'\xc3\xa9p\xc3\xa9e brille \xc3\xa0 la lune.";
+	auto buf = BuildMailSendRequestPayload(1ull, subjectUtf8, bodyUtf8, 0ull, 0ull);
+	auto parsed = ParseMailSendRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "UTF-8 parses");
+	Assert(parsed && parsed->subject == subjectUtf8, "UTF-8 subject byte-perfect");
+	Assert(parsed && parsed->body == bodyUtf8, "UTF-8 body byte-perfect");
+}
+
+static void TestBoundaryValues()
+{
+	// 0xFFFFFFFFFFFFFFFFull pour vérifier qu'on n'a pas de signe-extension cachée.
+	auto buf = BuildMailSendRequestPayload(0xFFFFFFFFFFFFFFFFull, "", "",
+	                                       0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseMailSendRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Boundary uint64 parses");
+	if (parsed)
+	{
+		Assert(parsed->recipientAccountId == 0xFFFFFFFFFFFFFFFFull, "uint64 max recipient");
+		Assert(parsed->copperGold == 0xFFFFFFFFFFFFFFFFull, "uint64 max gold");
+		Assert(parsed->copperCod == 0xFFFFFFFFFFFFFFFFull, "uint64 max cod");
+	}
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	// MAIL_SEND
+	TestSendRequestRoundTrip();
+	TestSendRequestEmptyStrings();
+	TestSendRequestRejectsShort();
+	TestSendResponseRoundTrip();
+	TestSendResponsePacket();
+
+	// MAIL_LIST_INBOX
+	TestListInboxRequest();
+	TestListInboxResponseEmpty();
+	TestListInboxResponseUnauthorized();
+	TestListInboxResponseMultiple();
+	TestListInboxResponseRejectsShort();
+
+	// MAIL_READ
+	TestReadRequestRoundTrip();
+	TestReadRequestRejectsShort();
+	TestReadResponseRoundTrip();
+	TestReadResponseError();
+
+	// MAIL_TAKE_ATTACHMENTS
+	TestTakeRequestRoundTrip();
+	TestTakeRequestRejectsShort();
+	TestTakeResponseRoundTrip();
+	TestTakeResponseCodNotPaid();
+
+	// MAIL_DELETE
+	TestDeleteRequestRoundTrip();
+	TestDeleteResponseRoundTrip();
+	TestDeleteResponseHasAttachments();
+
+	// Edge cases
+	TestSendRequestUtf8();
+	TestBoundaryValues();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all mail payload tests passed\n" : "[FAIL] some mail tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -193,4 +193,23 @@ namespace engine::network
 
 	constexpr uint16_t kOpcodeCharacterEnterWorldRequest  = 47u; ///< Client→Master : déclare le personnage actif après EnterWorld.
 	constexpr uint16_t kOpcodeCharacterEnterWorldResponse = 48u; ///< Master→Client : ACK ou erreur (NOT_OWNED, NAME_MISMATCH, …).
+
+	// -------------------------------------------------------------------------
+	// Opcodes Mail (valeurs 49–58)
+	// Référence : Phase 3 CMANGOS.18 step 3. Wire client→master pour la
+	// messagerie in-game. Le step 1 (MailManager + Mail.h) et le step 2
+	// (MysqlMailStore + migration 0045) sont déjà mergés ; cette série
+	// expose les opérations CRUD au client via 5 paires request/response.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeMailSendRequest             = 49u; ///< Client→Master : envoie un mail (subject, body, recipient, copperGold/Cod).
+	constexpr uint16_t kOpcodeMailSendResponse            = 50u; ///< Master→Client : ACK avec mail_id ou erreur (RECIPIENT_NOT_FOUND, INSUFFICIENT_GOLD, …).
+	constexpr uint16_t kOpcodeMailListInboxRequest        = 51u; ///< Client→Master : demande la liste des mails reçus du compte courant.
+	constexpr uint16_t kOpcodeMailListInboxResponse       = 52u; ///< Master→Client : liste des mails (id, sender, subject, sent_ts, expires_ts, state).
+	constexpr uint16_t kOpcodeMailReadRequest             = 53u; ///< Client→Master : demande le body complet d'un mail (marque comme lu).
+	constexpr uint16_t kOpcodeMailReadResponse            = 54u; ///< Master→Client : body + items attachés.
+	constexpr uint16_t kOpcodeMailTakeAttachmentsRequest  = 55u; ///< Client→Master : récupère les items + gold attachés à un mail.
+	constexpr uint16_t kOpcodeMailTakeAttachmentsResponse = 56u; ///< Master→Client : ACK avec liste items pris + gold versé, ou erreur.
+	constexpr uint16_t kOpcodeMailDeleteRequest           = 57u; ///< Client→Master : supprime un mail de l'inbox.
+	constexpr uint16_t kOpcodeMailDeleteResponse          = 58u; ///< Master→Client : ACK ou erreur (NOT_FOUND, NOT_OWNER).
 }


### PR DESCRIPTION
## Summary

Step 3 du ticket Mail (Phase 3 CMANGOS.18). Expose les operations CRUD du `MailManager` (mergees en PR #508 step 1+2) via 5 paires d'opcodes (49-58) au client.

- Wire payloads (Parse/Build) + round-trip tests
- `MailHandler` dispatcher cote master, resout `connId -> sessionId -> accountId`, retourne `Unauthorized` type-specific (code 6) si session manquante (plus exploitable UI qu'un ErrorPacket generique)
- Cablage dans `main_linux.cpp` (handler garde par `dbPool.IsInitialized()`)

## Opcodes

| Op | Direction | Payload |
|----|-----------|---------|
| 49 | C->S | MailSendRequest (recipient, subject, body, gold, cod) |
| 50 | S->C | MailSendResponse (error, mailId) |
| 51 | C->S | MailListInboxRequest (vide, account derive de session) |
| 52 | S->C | MailListInboxResponse (error, [{mailId, sender, subject, sentTs, expiresTs, state, gold, cod}]) |
| 53 | C->S | MailReadRequest (mailId) |
| 54 | S->C | MailReadResponse (error, mailId, body) |
| 55 | C->S | MailTakeAttachmentsRequest (mailId, paidCopperCod) |
| 56 | S->C | MailTakeAttachmentsResponse (error, mailId, copperGoldTaken) |
| 57 | C->S | MailDeleteRequest (mailId) |
| 58 | S->C | MailDeleteResponse (error, mailId) |

## Limitations cette PR

- Pas d'items attaches sur le wire (gold + COD + texte seulement). TBD step 3.b.
- `HandleRead` fait un full-scan de l'inbox pour recuperer le body car `MailManager` n'a pas de `Find(mailId, receiverAccountId)` direct. Optimisation triviale a faire en suivant en ajoutant `IMailStore::FindForReceiver`.

## Test plan

- [x] Round-trip tests `mail_payloads_tests` couvrent les 5 paires Request/Response, cas d'erreur (payload tronque, nullptr), UTF-8 byte-perfect, boundary uint64 max
- [ ] CI valide la compilation (pas de cmake local dans l'env worktree)
- [ ] Smoke test integration : envoyer un mail bidon via un client modifie + verifier que `mailHandler.HandleSend` insere bien dans la table `mails`

## Deploiement

**REDEPLOIEMENT SERVEUR REQUIS** (master Linux) - nouveaux opcodes 49-58 + `MailHandler`. Les clients existants ne sont pas impactes (ils n'envoient pas encore ces opcodes ; le step 4 ajoutera l'UI mailbox cote client dans une PR separee).

Le step 4 (client UI mailbox + compose) suivra dans une PR distincte.