### PR TITLE
feat(mail): UI client mailbox + compose (Phase 3 CMANGOS.18 step 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ add_library(engine_core
   src/client/ui_common/UIModel.cpp
   src/client/chat/ChatUi.cpp
   src/client/chat/ChatWorldVisualPresenter.cpp
+  src/client/mail/MailUi.cpp
   src/client/social/FriendsUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
@@ -329,6 +330,7 @@ add_library(engine_core
   src/client/render/LnTheme.h
   src/client/render/AuthImGuiRenderer.cpp
   src/client/render/ChatImGuiRenderer.cpp
+  src/client/render/MailImGuiRenderer.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp
   src/client/render/DecalPass.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8,9 +8,12 @@
 #include "src/shared/core/memory/Memory.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/network/ChatPayloads.h"
+#include "src/shared/network/MailPayloads.h"
+#include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/client/render/AuthImGuiRenderer.h"
 #include "src/client/render/ChatImGuiRenderer.h"
+#include "src/client/render/MailImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -794,15 +797,110 @@ namespace engine
 			LOG_WARN(Core, "[Boot] AuthUiPresenter viewport FAILED — using fallback layout");
 		}
 
+		// CMANGOS.18 (Phase 3.18 step 4) — Init du presenter Mail. Doit etre
+		// fait avant l'installation du push handler ci-dessous (qui dispatche
+		// les opcodes Mail vers ce presenter).
+		if (!m_mailUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] MailUiPresenter init FAILED — boite mail desactivee");
+		}
+		else
+		{
+			m_mailUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendMailRequestAsync(opcode, payload);
+			});
+		}
+
 		// Chat MVP — câblage bidirectionnel ChatUi <-> AuthUi (master TCP).
 		// Send : ChatUi::SubmitInputLine appelle AuthUi::SendChatAsync sur la connexion master vivante.
 		// Receive : AuthUi::PumpPostAuthEvents dispatche les paquets push (CHAT_RELAY notamment)
 		// vers un handler qui parse et appelle ChatUi::PushNetworkLine.
 		m_chatUi.SetSendCallback([this](uint8_t channel, std::string_view targetToken, std::string_view text) -> bool {
+			// CMANGOS.18 (Phase 3.18 step 4) — Intercept /mail avant l'envoi
+			// chat. ParseSlashPrefixes ne connait pas /mail, donc le texte
+			// arrive sur le canal Say avec text == "/mail" (ou "/mail ...").
+			// On consomme le slash command localement et retourne true (le
+			// chat presenter pense que c'est envoye et clear l'input).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/mail" || text.starts_with("/mail ") || text.starts_with("/mail\t")))
+			{
+				m_mailVisible = !m_mailVisible;
+				if (m_mailVisible)
+				{
+					m_mailUi.RequestInbox();
+				}
+				LOG_INFO(Core, "[Engine] /mail toggle (visible={})", m_mailVisible);
+				return true;
+			}
 			return m_authUi.SendChatAsync(channel, targetToken, text);
 		});
 		m_authUi.SetMasterPushHandler([this](uint16_t opcode, const uint8_t* payload, size_t payloadSize) {
 			using namespace engine::network;
+			// CMANGOS.18 (Phase 3.18 step 4) — Dispatch des reponses Mail. Les
+			// reponses (opcodes 50/52/54/56/58) ne sont pas des push purs mais
+			// arrivent via le meme mecanisme PacketReceived puisque le client
+			// n'utilise pas de RequestResponseDispatcher pour Mail (requestId=0
+			// fire-and-forget cote envoi). On parse + dispatche ici.
+			switch (opcode)
+			{
+			case kOpcodeMailListInboxResponse:
+			{
+				auto parsed = ParseMailListInboxResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] MAIL_LIST_INBOX_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_mailUi.OnInboxResponse(*parsed);
+				return;
+			}
+			case kOpcodeMailReadResponse:
+			{
+				auto parsed = ParseMailReadResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] MAIL_READ_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_mailUi.OnReadResponse(*parsed);
+				return;
+			}
+			case kOpcodeMailSendResponse:
+			{
+				auto parsed = ParseMailSendResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] MAIL_SEND_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_mailUi.OnSendResponse(*parsed);
+				return;
+			}
+			case kOpcodeMailTakeAttachmentsResponse:
+			{
+				auto parsed = ParseMailTakeAttachmentsResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] MAIL_TAKE_ATTACHMENTS_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_mailUi.OnTakeAttachmentsResponse(*parsed);
+				return;
+			}
+			case kOpcodeMailDeleteResponse:
+			{
+				auto parsed = ParseMailDeleteResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] MAIL_DELETE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_mailUi.OnDeleteResponse(*parsed);
+				return;
+			}
+			default:
+				break;
+			}
 			if (opcode != kOpcodeChatRelay)
 				return;
 			auto parsed = ParseChatRelayPayload(payload, payloadSize);
@@ -2932,6 +3030,7 @@ namespace engine
 		ShutdownGameplayNet();
 		m_authUi.Shutdown();
 		m_chatUi.Shutdown();
+		m_mailUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3129,6 +3228,12 @@ namespace engine
 				// Phase 3.11.1 — partage du même contexte ImGui (NewFrame/Render gérés par m_worldEditorImGui).
 				m_chatImGui = std::make_unique<engine::render::ChatImGuiRenderer>();
 				m_chatImGui->BindChatUi(&m_chatUi, &m_cfg);
+				// CMANGOS.18 (Phase 3.18 step 4) — Renderer ImGui de la boite mail.
+				// Partage le contexte ImGui avec auth/chat. Visible uniquement quand
+				// m_mailVisible (toggle via /mail). La taille viewport est mise a
+				// jour dans le boucle Render plus bas.
+				m_mailImGui = std::make_unique<engine::render::MailImGuiRenderer>();
+				m_mailImGui->SetPresenter(&m_mailUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -4141,6 +4246,16 @@ namespace engine
 			}
 			// `inWorldShard` = true uniquement post-EnterWorld : ajoute le canal Zone.
 			m_chatImGui->Render(dw, dh, m_authUi.IsInWorldShard());
+			// CMANGOS.18 (Phase 3.18 step 4) — Render du panneau Mail si visible.
+			// Le panneau partage la frame ImGui en cours (NewFrame deja appele
+			// par chatImguiOverlayNewFrame plus haut). Visible uniquement quand
+			// l'utilisateur a fait /mail (toggle dans le SendCallback du chat).
+			if (m_mailVisible && m_mailImGui && m_mailUi.IsInitialized())
+			{
+				m_mailImGui->SetEnabled(true);
+				m_mailImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_mailImGui->Render();
+			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)
 			{

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -7,6 +7,7 @@
 #include "src/client/audio/AudioEngine.h"
 #include "src/client/auth/AuthUi.h"
 #include "src/client/chat/ChatUi.h"
+#include "src/client/mail/MailUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
@@ -62,6 +63,7 @@ namespace engine::render
 {
 	class AuthImGuiRenderer;
 	class ChatImGuiRenderer;
+	class MailImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -314,6 +316,10 @@ namespace engine
 		std::unique_ptr<engine::render::AuthImGuiRenderer> m_authImGui;
 		/// Phase 3.11.1 — Panneau chat Dear ImGui (post-auth, partage le même contexte ImGui que m_authImGui).
 		std::unique_ptr<engine::render::ChatImGuiRenderer> m_chatImGui;
+		/// CMANGOS.18 (Phase 3.18 step 4) — Panneau boite mail (post-auth, ImGui).
+		/// Partage le contexte ImGui avec m_authImGui / m_chatImGui. Visibilite
+		/// pilotee par \c m_mailVisible (toggle via slash command /mail).
+		std::unique_ptr<engine::render::MailImGuiRenderer> m_mailImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -373,6 +379,13 @@ namespace engine
 		engine::client::ProfilerHudPresenter m_profilerHud;
 		engine::client::AuthUiPresenter m_authUi;
 		engine::client::ChatUiPresenter m_chatUi;
+		/// CMANGOS.18 (Phase 3.18 step 4) — Presenter boite mail. Recoit les
+		/// reponses opcodes 50/52/54/56/58 via le push handler du master ;
+		/// fire-and-forget des requetes 49/51/53/55/57 via \c m_authUi.
+		engine::client::MailUiPresenter m_mailUi;
+		/// CMANGOS.18 (Phase 3.18 step 4) — Visibilite du panneau mail
+		/// (toggle via slash command \c /mail). Faux par defaut.
+		bool                            m_mailVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -444,6 +444,14 @@ namespace engine::client
 		/// payload vide, ou Send rejeté.
 		bool SendChatAsync(uint8_t channel, std::string_view targetToken, std::string_view text);
 
+		/// CMANGOS.18 (Phase 3.18 step 4) — Envoi fire-and-forget d'une requete
+		/// Mail (opcodes 49, 51, 53, 55, 57) sur la connexion master active.
+		/// Le payload doit deja etre serialise via les helpers
+		/// \c BuildMail*RequestPayload de \ref MailPayloads.h. requestId=0
+		/// (les reponses correspondantes sont dispatched via le push handler
+		/// du master). Retourne \c false si pas de session ou Send rejete.
+		bool SendMailRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload);
+
 		/// Phase 4 chat — Annonce au master le personnage actif après EnterWorld.
 		/// Master valide ownership (account_id + character_id en DB) et enregistre le binding
 		/// connId → (character_id, character_name) pour le sender display dans CHAT_RELAY +

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -362,6 +362,49 @@ namespace engine::client
 		return true;
 	}
 
+	bool AuthUiPresenter::SendMailRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload)
+	{
+		// CMANGOS.18 (Phase 3.18 step 4) — Wrapper generique pour les opcodes Mail
+		// (49, 51, 53, 55, 57). Mirror de SendChatAsync : meme pattern PacketBuilder /
+		// Send, requestId=0 (les reponses sont dispatched via le push handler).
+		if (!m_masterClient || m_masterSessionId == 0u)
+		{
+			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: no master session (opcode={})",
+				static_cast<unsigned>(opcode));
+			return false;
+		}
+		engine::network::PacketBuilder builder;
+		auto w = builder.PayloadWriter();
+		if (!payload.empty() && !w.WriteBytes(payload.data(), payload.size()))
+		{
+			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: WriteBytes failed (opcode={})",
+				static_cast<unsigned>(opcode));
+			return false;
+		}
+		if (!builder.Finalize(opcode, /*flags=*/0u, /*requestId=*/0u, m_masterSessionId, payload.size()))
+		{
+			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: Finalize failed (opcode={})",
+				static_cast<unsigned>(opcode));
+			return false;
+		}
+		const auto& packet = builder.Data();
+		if (packet.empty())
+		{
+			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: empty packet (opcode={})",
+				static_cast<unsigned>(opcode));
+			return false;
+		}
+		if (!m_masterClient->Send(std::span<const uint8_t>(packet.data(), packet.size())))
+		{
+			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: Send failed (opcode={})",
+				static_cast<unsigned>(opcode));
+			return false;
+		}
+		LOG_DEBUG(Net, "[AuthUiPresenter] SendMailRequestAsync queued (opcode={}, payload_size={})",
+			static_cast<unsigned>(opcode), payload.size());
+		return true;
+	}
+
 	bool AuthUiPresenter::SendEnterWorldAsync(uint64_t characterId, std::string_view characterName)
 	{
 		if (!m_masterClient || m_masterSessionId == 0u || characterId == 0u || characterName.empty())

--- a/src/client/mail/MailUi.cpp
+++ b/src/client/mail/MailUi.cpp
@@ -1,0 +1,402 @@
+#include "src/client/mail/MailUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Resout le code MailSendErrorCode en chaine localizable (FR pour V1).
+		/// Utilise par \ref MailUiPresenter::OnSendResponse.
+		std::string_view DescribeSendError(uint8_t code)
+		{
+			using engine::network::MailSendErrorCode;
+			switch (static_cast<MailSendErrorCode>(code))
+			{
+			case MailSendErrorCode::Ok:                 return "";
+			case MailSendErrorCode::RecipientNotFound:  return "Destinataire introuvable.";
+			case MailSendErrorCode::SubjectTooLong:     return "Sujet trop long.";
+			case MailSendErrorCode::BodyTooLong:        return "Corps trop long.";
+			case MailSendErrorCode::InsufficientGold:   return "Or insuffisant.";
+			case MailSendErrorCode::AttachmentsTooMany: return "Trop de pieces jointes.";
+			case MailSendErrorCode::Unauthorized:       return "Session expiree, reconnexion requise.";
+			}
+			return "Erreur inconnue.";
+		}
+
+		/// Localise les codes MailReadErrorCode en chaine FR pour le bandeau erreur.
+		std::string_view DescribeReadError(uint8_t code)
+		{
+			using engine::network::MailReadErrorCode;
+			switch (static_cast<MailReadErrorCode>(code))
+			{
+			case MailReadErrorCode::Ok:            return "";
+			case MailReadErrorCode::NotFound:      return "Mail introuvable.";
+			case MailReadErrorCode::WrongReceiver: return "Vous n'etes pas le destinataire.";
+			case MailReadErrorCode::Unauthorized:  return "Session expiree, reconnexion requise.";
+			}
+			return "Erreur inconnue.";
+		}
+
+		/// Localise les codes MailTakeErrorCode en chaine FR.
+		std::string_view DescribeTakeError(uint8_t code)
+		{
+			using engine::network::MailTakeErrorCode;
+			switch (static_cast<MailTakeErrorCode>(code))
+			{
+			case MailTakeErrorCode::Ok:            return "";
+			case MailTakeErrorCode::NotFound:      return "Mail introuvable.";
+			case MailTakeErrorCode::WrongReceiver: return "Vous n'etes pas le destinataire.";
+			case MailTakeErrorCode::AlreadyTaken:  return "Or deja retire.";
+			case MailTakeErrorCode::CodNotPaid:    return "Frais COD non regles : payez d'abord les frais.";
+			case MailTakeErrorCode::Unauthorized:  return "Session expiree, reconnexion requise.";
+			}
+			return "Erreur inconnue.";
+		}
+
+		/// Localise les codes MailDeleteErrorCode en chaine FR.
+		std::string_view DescribeDeleteError(uint8_t code)
+		{
+			using engine::network::MailDeleteErrorCode;
+			switch (static_cast<MailDeleteErrorCode>(code))
+			{
+			case MailDeleteErrorCode::Ok:             return "";
+			case MailDeleteErrorCode::NotFound:       return "Mail introuvable.";
+			case MailDeleteErrorCode::WrongReceiver:  return "Vous n'etes pas le destinataire.";
+			case MailDeleteErrorCode::HasAttachments: return "Retirez d'abord les pieces jointes.";
+			case MailDeleteErrorCode::Unauthorized:   return "Session expiree, reconnexion requise.";
+			}
+			return "Erreur inconnue.";
+		}
+
+		/// Tente de parser un \c string_view comme un uint64 decimal entier sans
+		/// signe. Retourne \c std::nullopt si la chaine est vide, contient un
+		/// caractere non numerique ou deborde.
+		std::optional<uint64_t> ParseUint64Decimal(std::string_view text)
+		{
+			if (text.empty())
+				return std::nullopt;
+			uint64_t value = 0;
+			const char* first = text.data();
+			const char* last  = text.data() + text.size();
+			auto [ptr, ec] = std::from_chars(first, last, value, 10);
+			if (ec != std::errc{} || ptr != last)
+				return std::nullopt;
+			return value;
+		}
+	}
+
+	bool MailUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[MailUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_state = {};
+		m_initialized = true;
+		LOG_INFO(Core, "[MailUiPresenter] Init OK");
+		return true;
+	}
+
+	void MailUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		m_send  = {};
+		LOG_INFO(Core, "[MailUiPresenter] Shutdown");
+	}
+
+	void MailUiPresenter::RequestInbox()
+	{
+		if (!m_initialized)
+			return;
+		if (!m_send)
+		{
+			m_state.lastErrorText = "Pas de connexion au serveur.";
+			LOG_WARN(Net, "[MailUiPresenter] RequestInbox: no send callback");
+			return;
+		}
+		m_state.isInboxLoading = true;
+		m_state.lastErrorText.clear();
+		const auto payload = engine::network::BuildMailListInboxRequestPayload();
+		if (!m_send(engine::network::kOpcodeMailListInboxRequest, payload))
+		{
+			m_state.isInboxLoading = false;
+			m_state.lastErrorText  = "Envoi de la requete inbox echoue.";
+			LOG_WARN(Net, "[MailUiPresenter] RequestInbox: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[MailUiPresenter] RequestInbox queued");
+	}
+
+	void MailUiPresenter::SelectMail(uint64_t mailId)
+	{
+		if (!m_initialized)
+			return;
+		m_state.selectedMailId = mailId;
+		// Si le body est deja en cache, rien a faire : le renderer le lira directement.
+		auto it = std::find_if(m_state.inbox.begin(), m_state.inbox.end(),
+			[mailId](const MailUiInboxEntry& e) { return e.mailId == mailId; });
+		if (it == m_state.inbox.end())
+		{
+			LOG_WARN(Net, "[MailUiPresenter] SelectMail: unknown mail_id={}", mailId);
+			return;
+		}
+		if (it->bodyLoaded)
+		{
+			LOG_DEBUG(Net, "[MailUiPresenter] SelectMail: body cache hit (mail_id={})", mailId);
+			return;
+		}
+		if (!m_send)
+		{
+			m_state.lastErrorText = "Pas de connexion au serveur.";
+			return;
+		}
+		const auto payload = engine::network::BuildMailReadRequestPayload(mailId);
+		if (!m_send(engine::network::kOpcodeMailReadRequest, payload))
+		{
+			m_state.lastErrorText = "Envoi de la requete lecture echoue.";
+			LOG_WARN(Net, "[MailUiPresenter] SelectMail: send failed (mail_id={})", mailId);
+			return;
+		}
+		LOG_DEBUG(Net, "[MailUiPresenter] MailReadRequest queued (mail_id={})", mailId);
+	}
+
+	void MailUiPresenter::SubmitCompose()
+	{
+		if (!m_initialized)
+			return;
+		const auto recipientOpt = ParseUint64Decimal(m_state.composeRecipient);
+		if (!recipientOpt)
+		{
+			m_state.lastErrorText = "Destinataire invalide : entrez un account_id (entier).";
+			LOG_WARN(Net, "[MailUiPresenter] SubmitCompose: invalid recipient '{}'", m_state.composeRecipient);
+			return;
+		}
+		if (!m_send)
+		{
+			m_state.lastErrorText = "Pas de connexion au serveur.";
+			return;
+		}
+		if (m_state.composeSubject.size() > engine::network::kMaxMailSubjectBytes)
+		{
+			m_state.lastErrorText = "Sujet trop long (max 255 octets).";
+			return;
+		}
+		if (m_state.composeBody.size() > engine::network::kMaxMailBodyBytes)
+		{
+			m_state.lastErrorText = "Corps trop long.";
+			return;
+		}
+		const auto payload = engine::network::BuildMailSendRequestPayload(
+			*recipientOpt,
+			m_state.composeSubject,
+			m_state.composeBody,
+			m_state.composeGold,
+			m_state.composeCod);
+		if (payload.empty() || !m_send(engine::network::kOpcodeMailSendRequest, payload))
+		{
+			m_state.lastErrorText = "Envoi du mail echoue.";
+			LOG_WARN(Net, "[MailUiPresenter] SubmitCompose: send failed (recipient={})", *recipientOpt);
+			return;
+		}
+		LOG_INFO(Net, "[MailUiPresenter] MailSendRequest queued (recipient={}, subj_len={}, body_len={}, gold={}, cod={})",
+			*recipientOpt, m_state.composeSubject.size(), m_state.composeBody.size(),
+			m_state.composeGold, m_state.composeCod);
+		// Reset des champs + ferme la dialog. On reouvrira automatiquement au prochain
+		// OpenCompose (qui re-clear de toute facon, mais c'est plus propre).
+		m_state.composeRecipient.clear();
+		m_state.composeSubject.clear();
+		m_state.composeBody.clear();
+		m_state.composeGold = 0;
+		m_state.composeCod  = 0;
+		m_state.isComposeOpen = false;
+	}
+
+	void MailUiPresenter::TakeAttachments(uint64_t mailId)
+	{
+		if (!m_initialized || !m_send)
+			return;
+		// V1 : on n'envoie pas de paidCopperCod, le wallet client n'existe pas encore.
+		// Le serveur retournera CodNotPaid si copperCod > 0.
+		const auto payload = engine::network::BuildMailTakeAttachmentsRequestPayload(mailId, /*paidCopperCod=*/0u);
+		if (!m_send(engine::network::kOpcodeMailTakeAttachmentsRequest, payload))
+		{
+			m_state.lastErrorText = "Envoi prendre-piece-jointe echoue.";
+			LOG_WARN(Net, "[MailUiPresenter] TakeAttachments: send failed (mail_id={})", mailId);
+			return;
+		}
+		LOG_DEBUG(Net, "[MailUiPresenter] MailTakeAttachmentsRequest queued (mail_id={})", mailId);
+	}
+
+	void MailUiPresenter::DeleteMail(uint64_t mailId)
+	{
+		if (!m_initialized || !m_send)
+			return;
+		const auto payload = engine::network::BuildMailDeleteRequestPayload(mailId);
+		if (!m_send(engine::network::kOpcodeMailDeleteRequest, payload))
+		{
+			m_state.lastErrorText = "Envoi suppression echoue.";
+			LOG_WARN(Net, "[MailUiPresenter] DeleteMail: send failed (mail_id={})", mailId);
+			return;
+		}
+		LOG_DEBUG(Net, "[MailUiPresenter] MailDeleteRequest queued (mail_id={})", mailId);
+	}
+
+	void MailUiPresenter::OpenCompose()
+	{
+		if (!m_initialized)
+			return;
+		m_state.composeRecipient.clear();
+		m_state.composeSubject.clear();
+		m_state.composeBody.clear();
+		m_state.composeGold = 0;
+		m_state.composeCod  = 0;
+		m_state.isComposeOpen = true;
+	}
+
+	void MailUiPresenter::CloseCompose()
+	{
+		if (!m_initialized)
+			return;
+		m_state.isComposeOpen = false;
+	}
+
+	void MailUiPresenter::OnInboxResponse(const engine::network::MailListInboxResponsePayload& resp)
+	{
+		m_state.isInboxLoading = false;
+		if (resp.error != 0)
+		{
+			// Seul code documente : Unauthorized (6).
+			m_state.lastErrorText = "Inbox indisponible (session ?).";
+			LOG_WARN(Net, "[MailUiPresenter] OnInboxResponse: server error code={}", static_cast<unsigned>(resp.error));
+			return;
+		}
+		// Conversion network::MailInboxEntry -> MailUiInboxEntry. On preserve les bodies
+		// deja telecharges pour les mailId presents dans les deux listes (rare mais utile
+		// quand le client refresh apres un Send qui a vide l'inbox affichee).
+		std::vector<MailUiInboxEntry> next;
+		next.reserve(resp.mails.size());
+		for (const auto& src : resp.mails)
+		{
+			MailUiInboxEntry dst{};
+			dst.mailId          = src.mailId;
+			dst.senderAccountId = src.senderAccountId;
+			dst.subject         = src.subject;
+			dst.sentTsMs        = src.sentTsMs;
+			dst.expiresTsMs     = src.expiresTsMs;
+			dst.state           = src.state;
+			dst.copperGold      = src.copperGold;
+			dst.copperCod       = src.copperCod;
+			// Cherche une eventuelle entree precedente pour reutiliser le body.
+			auto prev = std::find_if(m_state.inbox.begin(), m_state.inbox.end(),
+				[id = src.mailId](const MailUiInboxEntry& e) { return e.mailId == id; });
+			if (prev != m_state.inbox.end() && prev->bodyLoaded)
+			{
+				dst.body       = std::move(prev->body);
+				dst.bodyLoaded = true;
+			}
+			next.push_back(std::move(dst));
+		}
+		m_state.inbox = std::move(next);
+		// Si le mail selectionne n'existe plus, on de-selectionne.
+		if (m_state.selectedMailId)
+		{
+			const uint64_t selId = *m_state.selectedMailId;
+			auto it = std::find_if(m_state.inbox.begin(), m_state.inbox.end(),
+				[selId](const MailUiInboxEntry& e) { return e.mailId == selId; });
+			if (it == m_state.inbox.end())
+				m_state.selectedMailId.reset();
+		}
+		LOG_INFO(Net, "[MailUiPresenter] OnInboxResponse: {} entries", m_state.inbox.size());
+	}
+
+	void MailUiPresenter::OnReadResponse(const engine::network::MailReadResponsePayload& resp)
+	{
+		if (resp.error != 0)
+		{
+			m_state.lastErrorText.assign(DescribeReadError(resp.error));
+			LOG_WARN(Net, "[MailUiPresenter] OnReadResponse: error code={} mail_id={}",
+				static_cast<unsigned>(resp.error), resp.mailId);
+			return;
+		}
+		auto it = std::find_if(m_state.inbox.begin(), m_state.inbox.end(),
+			[id = resp.mailId](const MailUiInboxEntry& e) { return e.mailId == id; });
+		if (it == m_state.inbox.end())
+		{
+			LOG_WARN(Net, "[MailUiPresenter] OnReadResponse: unknown mail_id={}", resp.mailId);
+			return;
+		}
+		it->body       = resp.body;
+		it->bodyLoaded = true;
+		// Le serveur a marque le mail comme lu en DB ; on reflete cote client (state=1).
+		if (it->state == 0)
+			it->state = 1;
+		LOG_DEBUG(Net, "[MailUiPresenter] OnReadResponse: body cached (mail_id={}, body_len={})",
+			resp.mailId, resp.body.size());
+	}
+
+	void MailUiPresenter::OnSendResponse(const engine::network::MailSendResponsePayload& resp)
+	{
+		if (resp.error != 0)
+		{
+			m_state.lastErrorText.assign(DescribeSendError(resp.error));
+			LOG_WARN(Net, "[MailUiPresenter] OnSendResponse: error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		LOG_INFO(Net, "[MailUiPresenter] OnSendResponse: OK mail_id={}", resp.mailId);
+		// Refresh inbox automatique : si le mail s'est envoye a nous-memes
+		// (cas tests / dev), on le verra apparaitre. Sinon c'est un no-op visible.
+		RequestInbox();
+	}
+
+	void MailUiPresenter::OnTakeAttachmentsResponse(const engine::network::MailTakeAttachmentsResponsePayload& resp)
+	{
+		if (resp.error != 0)
+		{
+			m_state.lastErrorText.assign(DescribeTakeError(resp.error));
+			LOG_WARN(Net, "[MailUiPresenter] OnTakeAttachmentsResponse: error code={} mail_id={}",
+				static_cast<unsigned>(resp.error), resp.mailId);
+			return;
+		}
+		auto it = std::find_if(m_state.inbox.begin(), m_state.inbox.end(),
+			[id = resp.mailId](const MailUiInboxEntry& e) { return e.mailId == id; });
+		if (it != m_state.inbox.end())
+		{
+			it->copperGold = 0; // Le serveur a viree l'or attache.
+		}
+		LOG_INFO(Net, "[MailUiPresenter] OnTakeAttachmentsResponse: OK mail_id={} gold_taken={}",
+			resp.mailId, resp.copperGoldTaken);
+	}
+
+	void MailUiPresenter::OnDeleteResponse(const engine::network::MailDeleteResponsePayload& resp)
+	{
+		if (resp.error != 0)
+		{
+			m_state.lastErrorText.assign(DescribeDeleteError(resp.error));
+			LOG_WARN(Net, "[MailUiPresenter] OnDeleteResponse: error code={} mail_id={}",
+				static_cast<unsigned>(resp.error), resp.mailId);
+			return;
+		}
+		const auto before = m_state.inbox.size();
+		m_state.inbox.erase(std::remove_if(m_state.inbox.begin(), m_state.inbox.end(),
+			[id = resp.mailId](const MailUiInboxEntry& e) { return e.mailId == id; }),
+			m_state.inbox.end());
+		if (m_state.selectedMailId && *m_state.selectedMailId == resp.mailId)
+			m_state.selectedMailId.reset();
+		LOG_INFO(Net, "[MailUiPresenter] OnDeleteResponse: OK mail_id={} (inbox {} -> {})",
+			resp.mailId, before, m_state.inbox.size());
+	}
+}

--- a/src/client/mail/MailUi.h
+++ b/src/client/mail/MailUi.h
@@ -1,0 +1,138 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18 step 4) — MailUi : presenter cote client de
+// la boite mail. Recoit les MailListInboxResponse / MailReadResponse
+// du master, expose un model immuable au renderer, et fire-and-forget
+// les requetes (Send / List / Read / TakeAttachments / Delete).
+
+#include "src/shared/network/MailPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::client
+{
+	/// Une entree affichee dans la liste inbox. Miroir cote client de
+	/// \ref engine::network::MailInboxEntry, augmente d'un cache local pour
+	/// le body (rempli a la volee apres MailReadResponse) afin d'eviter de
+	/// re-interroger le serveur quand l'utilisateur reclique sur le mail.
+	struct MailUiInboxEntry
+	{
+		uint64_t    mailId         = 0;
+		uint64_t    senderAccountId = 0;
+		std::string subject;
+		uint64_t    sentTsMs       = 0;
+		uint64_t    expiresTsMs    = 0;
+		uint8_t     state          = 0; ///< 0=Unread, 1=Read, 2=Returned, 3=Deleted
+		uint64_t    copperGold     = 0;
+		uint64_t    copperCod      = 0;
+		bool        bodyLoaded     = false;
+		std::string body;             ///< rempli apres MailReadResponse
+	};
+
+	/// Etat global du panel Mail. Toutes les mutations passent par
+	/// \ref MailUiPresenter ; le renderer ne fait que lire \ref GetState.
+	struct MailUiState
+	{
+		std::vector<MailUiInboxEntry> inbox;
+		std::optional<uint64_t>       selectedMailId; ///< vide si rien selectionne
+		bool                          isInboxLoading = false;
+		bool                          isComposeOpen  = false;
+		std::string                   composeRecipient;  ///< saisie utilisateur (account_id sous forme decimale)
+		std::string                   composeSubject;
+		std::string                   composeBody;
+		uint64_t                      composeGold     = 0;
+		uint64_t                      composeCod      = 0;
+		std::string                   lastErrorText;     ///< affichage non bloquant (pourrait devenir une queue plus tard)
+	};
+
+	/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+	/// Cable via \ref MailUiPresenter::SetSendCallback. Doit retourner
+	/// \c true si le paquet a ete queue, \c false sinon (pas de session, build
+	/// echoue). Dans ce dernier cas le presenter remplit \c lastErrorText et
+	/// reset \c isInboxLoading le cas echeant.
+	using MailSendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+	/// Presenter de la boite mail cote client (Phase 3 CMANGOS.18 step 4).
+	/// Branche les opcodes Mail (49-58) sur une UI ImGui ; partage la connexion
+	/// master du \ref AuthUiPresenter via un callback fire-and-forget.
+	class MailUiPresenter final
+	{
+	public:
+		MailUiPresenter() = default;
+		MailUiPresenter(const MailUiPresenter&)            = delete;
+		MailUiPresenter& operator=(const MailUiPresenter&) = delete;
+
+		/// Initialise l'etat (vide). LOG_INFO sur succes. Idempotent : une seconde
+		/// init renvoie \c true sans toucher l'etat.
+		bool Init();
+		/// Libere l'etat. LOG_INFO. Apres Shutdown il faut re-Init avant d'envoyer.
+		void Shutdown();
+
+		/// Cable le callback pour fire-and-forget des requetes au master. Doit
+		/// etre appele avant tout RequestInbox / SubmitCompose.
+		void SetSendCallback(MailSendCallback cb) { m_send = std::move(cb); }
+
+		/// Demande l'inbox au master (envoie MailListInboxRequest). Met
+		/// \c isInboxLoading=true. La reponse est consommee via \ref OnInboxResponse.
+		void RequestInbox();
+
+		/// Selectionne un mail dans la liste. Si pas encore charge, envoie
+		/// MailReadRequest. Sinon affiche directement le body cache.
+		/// \param mailId identifiant du mail (cf. \ref MailUiInboxEntry::mailId).
+		void SelectMail(uint64_t mailId);
+
+		/// Envoie un mail (compose dialog confirmed). Tente de parser
+		/// \c composeRecipient comme un uint64 (account_id). En cas d'echec,
+		/// remplit \c lastErrorText et n'envoie pas. Sur succes reseau, reset
+		/// les champs compose et ferme la dialog ; \ref OnSendResponse fera le
+		/// refresh inbox automatique si le serveur accepte.
+		void SubmitCompose();
+
+		/// Take attachments (gold + COD). \param mailId identifiant cible.
+		/// Pour V1 on envoie \c paidCopperCod=0 (le wallet client n'est pas
+		/// encore branche) : le serveur retournera \c CodNotPaid si COD > 0,
+		/// affiche dans \c lastErrorText.
+		void TakeAttachments(uint64_t mailId);
+
+		/// Supprime un mail (admin / janitor user-side). Si le mail a encore
+		/// des attachments, le serveur retournera \c HasAttachments.
+		void DeleteMail(uint64_t mailId);
+
+		/// Open / close le compose dialog. Ouvrir reset les champs compose
+		/// (recipient, subject, body, gold, cod). Fermer ne touche pas aux
+		/// champs (l'utilisateur peut reouvrir et continuer).
+		void OpenCompose();
+		void CloseCompose();
+
+		/// Setters compose (relayes par le renderer ImGui).
+		void SetComposeRecipient(std::string_view text) { m_state.composeRecipient.assign(text); }
+		void SetComposeSubject(std::string_view text)   { m_state.composeSubject.assign(text); }
+		void SetComposeBody(std::string_view text)      { m_state.composeBody.assign(text); }
+		void SetComposeGold(uint64_t copperGold)        { m_state.composeGold = copperGold; }
+		void SetComposeCod(uint64_t copperCod)          { m_state.composeCod = copperCod; }
+
+		/// Recoit une reponse master : appel par le push handler du Engine.
+		/// Chaque OnXxxResponse mute l'etat (et eventuellement \c lastErrorText)
+		/// puis logue le succes ou la cause de l'echec.
+		void OnInboxResponse(const engine::network::MailListInboxResponsePayload& resp);
+		void OnReadResponse(const engine::network::MailReadResponsePayload& resp);
+		void OnSendResponse(const engine::network::MailSendResponsePayload& resp);
+		void OnTakeAttachmentsResponse(const engine::network::MailTakeAttachmentsResponsePayload& resp);
+		void OnDeleteResponse(const engine::network::MailDeleteResponsePayload& resp);
+
+		/// Etat immuable pour le renderer.
+		const MailUiState& GetState() const { return m_state; }
+
+		/// Utile pour le renderer ImGui (init paresseuse une fois la session active).
+		bool IsInitialized() const { return m_initialized; }
+
+	private:
+		MailUiState      m_state;
+		MailSendCallback m_send;
+		bool             m_initialized = false;
+	};
+}

--- a/src/client/render/MailImGuiRenderer.cpp
+++ b/src/client/render/MailImGuiRenderer.cpp
@@ -1,0 +1,327 @@
+#include "src/client/render/MailImGuiRenderer.h"
+
+#include "src/client/mail/MailUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Rend une chaine "il y a X minutes/heures/jours" a partir d'un timestamp UTC ms.
+		/// Pour V1 on reste simple : pas d'i18n, hardcode FR. Si timestamp vide ou futur,
+		/// retourne "—".
+		std::string FormatRelativeTime(uint64_t sentTsMs)
+		{
+			if (sentTsMs == 0)
+				return "—";
+			using namespace std::chrono;
+			const uint64_t nowMs = static_cast<uint64_t>(
+				duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+			if (sentTsMs > nowMs)
+				return "a l'instant";
+			const uint64_t deltaMs = nowMs - sentTsMs;
+			const uint64_t deltaSec = deltaMs / 1000ull;
+			char buf[64]{};
+			if (deltaSec < 60ull)
+				std::snprintf(buf, sizeof(buf), "il y a %us", static_cast<unsigned>(deltaSec));
+			else if (deltaSec < 3600ull)
+				std::snprintf(buf, sizeof(buf), "il y a %u min", static_cast<unsigned>(deltaSec / 60ull));
+			else if (deltaSec < 86400ull)
+				std::snprintf(buf, sizeof(buf), "il y a %uh", static_cast<unsigned>(deltaSec / 3600ull));
+			else
+				std::snprintf(buf, sizeof(buf), "il y a %uj", static_cast<unsigned>(deltaSec / 86400ull));
+			return buf;
+		}
+
+		/// Charge proprement un std::string dans un buffer C-string fixe (avec NUL).
+		void LoadStringIntoBuffer(const std::string& src, char* dst, size_t dstSize)
+		{
+			if (dstSize == 0)
+				return;
+			const size_t n = (src.size() < dstSize - 1) ? src.size() : (dstSize - 1);
+			if (n > 0)
+				std::memcpy(dst, src.data(), n);
+			dst[n] = '\0';
+		}
+	}
+
+	void MailImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderInboxPanel();
+		RenderComposeDialog();
+	}
+
+	void MailImGuiRenderer::RenderInboxPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre bottom-right (taille 600x400 par defaut).
+		const float panelW = 600.f;
+		const float panelH = 400.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, vpH - panelH - margin);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Boite mail##ln_mail_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge) — non bloquante.
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Toolbar : Nouveau message + Refresh.
+			if (ImGui::Button("Nouveau message"))
+			{
+				m_presenter->OpenCompose();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Rafraichir"))
+			{
+				m_presenter->RequestInbox();
+			}
+			ImGui::SameLine();
+			ImGui::TextDisabled("(%zu mail%s)", state.inbox.size(), state.inbox.size() > 1 ? "s" : "");
+
+			ImGui::Separator();
+
+			if (state.isInboxLoading)
+			{
+				ImGui::TextUnformatted("Chargement...");
+			}
+			else if (state.inbox.empty())
+			{
+				ImGui::TextDisabled("Aucun mail.");
+			}
+			else
+			{
+				// Tableau inbox.
+				const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+					| ImGuiTableFlags_RowBg
+					| ImGuiTableFlags_ScrollY
+					| ImGuiTableFlags_Resizable;
+				const float tableH = 180.f;
+				if (ImGui::BeginTable("##ln_mail_inbox", 5, tableFlags, ImVec2(0.f, tableH)))
+				{
+					ImGui::TableSetupColumn("Expediteur", ImGuiTableColumnFlags_WidthFixed, 110.f);
+					ImGui::TableSetupColumn("Sujet",      ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableSetupColumn("Recu",       ImGuiTableColumnFlags_WidthFixed, 90.f);
+					ImGui::TableSetupColumn("Statut",     ImGuiTableColumnFlags_WidthFixed, 60.f);
+					ImGui::TableSetupColumn("Actions",    ImGuiTableColumnFlags_WidthFixed, 120.f);
+					ImGui::TableHeadersRow();
+
+					for (const auto& m : state.inbox)
+					{
+						ImGui::TableNextRow();
+						ImGui::PushID(static_cast<int>(m.mailId));
+
+						ImGui::TableSetColumnIndex(0);
+						char senderBuf[64];
+						std::snprintf(senderBuf, sizeof(senderBuf), "Account #%" PRIu64, m.senderAccountId);
+						ImGui::TextUnformatted(senderBuf);
+
+						ImGui::TableSetColumnIndex(1);
+						{
+							const bool selected = state.selectedMailId.has_value()
+								&& *state.selectedMailId == m.mailId;
+							const std::string label = m.subject.empty() ? std::string("(sans sujet)") : m.subject;
+							if (ImGui::Selectable(label.c_str(), selected, ImGuiSelectableFlags_SpanAllColumns))
+							{
+								m_presenter->SelectMail(m.mailId);
+							}
+						}
+
+						ImGui::TableSetColumnIndex(2);
+						ImGui::TextUnformatted(FormatRelativeTime(m.sentTsMs).c_str());
+
+						ImGui::TableSetColumnIndex(3);
+						ImGui::TextUnformatted(m.state == 0 ? "Non lu" : "Lu");
+
+						ImGui::TableSetColumnIndex(4);
+						const bool hasAttach = (m.copperGold > 0) || (m.copperCod > 0);
+						if (hasAttach)
+						{
+							if (ImGui::SmallButton("Prendre"))
+							{
+								m_presenter->TakeAttachments(m.mailId);
+							}
+							ImGui::SameLine();
+						}
+						if (ImGui::SmallButton("Supprimer"))
+						{
+							m_presenter->DeleteMail(m.mailId);
+						}
+
+						ImGui::PopID();
+					}
+					ImGui::EndTable();
+				}
+			}
+
+			// Panneau detail : sujet / corps du mail selectionne.
+			if (state.selectedMailId.has_value())
+			{
+				const uint64_t selId = *state.selectedMailId;
+				auto it = std::find_if(state.inbox.begin(), state.inbox.end(),
+					[selId](const engine::client::MailUiInboxEntry& e) { return e.mailId == selId; });
+				if (it != state.inbox.end())
+				{
+					ImGui::Separator();
+					char header[256];
+					std::snprintf(header, sizeof(header), "De Account #%" PRIu64 " — %s",
+						it->senderAccountId,
+						it->subject.empty() ? "(sans sujet)" : it->subject.c_str());
+					ImGui::TextWrapped("%s", header);
+					ImGui::TextDisabled("Recu %s", FormatRelativeTime(it->sentTsMs).c_str());
+
+					ImGui::Spacing();
+					if (it->bodyLoaded)
+					{
+						ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
+						ImGui::BeginChild("##ln_mail_body", ImVec2(0.f, 100.f), true,
+							ImGuiWindowFlags_HorizontalScrollbar);
+						ImGui::TextWrapped("%s", it->body.c_str());
+						ImGui::EndChild();
+						ImGui::PopStyleColor();
+					}
+					else
+					{
+						ImGui::TextDisabled("Chargement du corps...");
+					}
+
+					ImGui::Spacing();
+					if ((it->copperGold > 0) || (it->copperCod > 0))
+					{
+						if (ImGui::Button("Prendre les pieces jointes"))
+						{
+							m_presenter->TakeAttachments(it->mailId);
+						}
+						ImGui::SameLine();
+					}
+					if (ImGui::Button("Supprimer ce mail"))
+					{
+						m_presenter->DeleteMail(it->mailId);
+					}
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void MailImGuiRenderer::RenderComposeDialog()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Synchro buffers ImGui <- presenter quand la dialog s'ouvre.
+		// Une fois ouverte, on laisse ImGui controller les buffers (push -> presenter via setters
+		// chaque frame) sans re-charger l'etat depuis le presenter sinon on ecraserait la saisie.
+		static bool s_wasOpen = false;
+		if (state.isComposeOpen && !s_wasOpen)
+		{
+			LoadStringIntoBuffer(state.composeRecipient, m_recipientBuf, sizeof(m_recipientBuf));
+			LoadStringIntoBuffer(state.composeSubject,   m_subjectBuf,   sizeof(m_subjectBuf));
+			LoadStringIntoBuffer(state.composeBody,      m_bodyBuf,      sizeof(m_bodyBuf));
+			ImGui::OpenPopup("Composer un mail##ln_mail_compose");
+		}
+		s_wasOpen = state.isComposeOpen;
+
+		// Centre la fenetre modale.
+		ImVec2 center;
+		center.x = (m_viewportW > 0) ? static_cast<float>(m_viewportW) * 0.5f : 640.f;
+		center.y = (m_viewportH > 0) ? static_cast<float>(m_viewportH) * 0.5f : 360.f;
+		ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(520.f, 420.f), ImGuiCond_Appearing);
+
+		if (ImGui::BeginPopupModal("Composer un mail##ln_mail_compose", nullptr,
+			ImGuiWindowFlags_NoSavedSettings))
+		{
+			// Destinataire (account_id direct pour V1 ; resolution par login a venir).
+			if (ImGui::InputText("Destinataire (account_id)", m_recipientBuf, sizeof(m_recipientBuf)))
+			{
+				m_presenter->SetComposeRecipient(m_recipientBuf);
+			}
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Saisir l'account_id numerique du destinataire (V1).");
+
+			if (ImGui::InputText("Sujet", m_subjectBuf, sizeof(m_subjectBuf)))
+			{
+				m_presenter->SetComposeSubject(m_subjectBuf);
+			}
+
+			if (ImGui::InputTextMultiline("Corps", m_bodyBuf, sizeof(m_bodyBuf),
+				ImVec2(-FLT_MIN, 180.f)))
+			{
+				m_presenter->SetComposeBody(m_bodyBuf);
+			}
+
+			// Or attache + COD : input scalar U64.
+			uint64_t goldVal = state.composeGold;
+			if (ImGui::InputScalar("Or (copper)", ImGuiDataType_U64, &goldVal))
+			{
+				m_presenter->SetComposeGold(goldVal);
+			}
+			uint64_t codVal = state.composeCod;
+			if (ImGui::InputScalar("COD (copper)", ImGuiDataType_U64, &codVal))
+			{
+				m_presenter->SetComposeCod(codVal);
+			}
+
+			ImGui::Separator();
+			if (ImGui::Button("Envoyer", ImVec2(120.f, 0.f)))
+			{
+				m_presenter->SubmitCompose();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Annuler", ImVec2(120.f, 0.f)))
+			{
+				m_presenter->CloseCompose();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void MailImGuiRenderer::Render()                  {}
+	void MailImGuiRenderer::RenderInboxPanel()        {}
+	void MailImGuiRenderer::RenderComposeDialog()     {}
+}
+
+#endif

--- a/src/client/render/MailImGuiRenderer.h
+++ b/src/client/render/MailImGuiRenderer.h
@@ -1,0 +1,50 @@
+#pragma once
+// CMANGOS.18 (Phase 3.18 step 4) — MailImGuiRenderer : panel ImGui
+// pour la boite mail. Lit l'etat d'un MailUiPresenter, dispatch les
+// inputs UI vers le presenter via accesseurs.
+
+#include <cstdint>
+
+namespace engine::client { class MailUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui de la boite mail. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::MailUiPresenter. Le renderer ne
+	/// fait que dessiner l'etat courant et propager les inputs UI vers le
+	/// presenter via setters / methodes.
+	class MailImGuiRenderer
+	{
+	public:
+		MailImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::MailUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel mailbox + compose dialog (si \c isComposeOpen). A appeler
+		/// entre \c ImGui::NewFrame() et \c ImGui::Render(), apres NewFrame, si
+		/// le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		void RenderInboxPanel();
+		void RenderComposeDialog();
+
+		engine::client::MailUiPresenter* m_presenter = nullptr;
+		bool                              m_enabled  = false;
+		uint32_t                          m_viewportW = 0;
+		uint32_t                          m_viewportH = 0;
+
+		/// Buffers C-string consommes par ImGui::InputText. Synchronises depuis
+		/// le presenter chaque frame (sens UI -> presenter via setters).
+		char m_recipientBuf[64]{};
+		char m_subjectBuf[256]{};
+		char m_bodyBuf[8192]{};
+	};
+}


### PR DESCRIPTION
## Summary

UI client (ImGui) pour la boite mail, branchee sur les opcodes 49-58 du wire server merge en PR #542.

- `src/client/mail/MailUi.{h,cpp}` : presenter (state + callbacks fire-and-forget vers le master + handlers de reponse).
- `src/client/render/MailImGuiRenderer.{h,cpp}` : panneau ancre bottom-right + dialog modal Compose.
- `src/client/app/Engine.{h,cpp}` : instanciation + cablage send/dispatch + slash command `/mail` (toggle visibilite + RequestInbox au premier ouvrage).
- `AuthUiPresenter::SendMailRequestAsync(opcode, payload)` : helper generique mirror de SendChatAsync.
- `CMakeLists.txt` : sources ajoutees a engine_core.

### Slash command

L'utilisateur tape `/mail` dans le chat post-EnterWorld → le panneau s'ouvre/se ferme. A l'ouverture, RequestInbox est appele automatiquement (le presenter pousse `MAIL_LIST_INBOX_REQUEST` au master). L'intercept se fait dans le SendCallback du chat avant l'envoi reel a SendChatAsync — comme `/mail` n'est pas un prefixe canal connu, il aurait sinon ete envoye sur le canal Say comme un message texte normal.

### V1 limitations volontaires

- Recipient en account_id direct (resolution login → account_id viendra avec un ticket dedie).
- Pas d'items attaches (juste gold + COD + texte).
- Sender display = "Account #ID" (resolution login → name pas encore cote client).
- COD non paye automatiquement (paidCopperCod=0). Le serveur retourne `CodNotPaid` si COD > 0 ; l'utilisateur voit le message d'erreur dans le panneau (le wallet client n'est pas encore branche).

### Architecture

```
Chat /mail (text)            User actions in panel
        |                              |
        v                              v
ChatUi.SendCallback ----+        MailUiPresenter
   intercepts /mail     |              |
   toggles m_mailVisible|     SetSendCallback
                        |              |
                        +---> AuthUiPresenter::SendMailRequestAsync
                                       |
                                  master TCP (opcodes 49,51,53,55,57)

master responses (opcodes 50,52,54,56,58)
        |
        v
AuthUiPresenter::PumpPostAuthEvents
        |
        v
m_masterPushHandler (Engine.cpp lambda)
        |
        +-> MailUiPresenter::OnXxxResponse(parsed)
        |
        v
MailImGuiRenderer reads MailUiPresenter::GetState()
```

## Deploiement

Client uniquement, pas de redeploiement serveur. Le master deja deploye expose les opcodes 49-58 via PR #542.

## Test plan

- [ ] CI build Linux + Windows passes (pas de build local possible cote Windows ici).
- [ ] Verifier post-EnterWorld que `/mail` ouvre le panneau et que `RequestInbox` est envoye.
- [ ] Verifier qu'envoyer un mail (compose) avec un account_id valide affiche bien le mail dans l'inbox apres refresh auto (OnSendResponse appelle RequestInbox).
- [ ] Verifier que selectionner un mail non-lu envoie `MAIL_READ_REQUEST` et que le body apparait apres OnReadResponse.
- [ ] Verifier que `Prendre` et `Supprimer` fonctionnent et que les erreurs (CodNotPaid, HasAttachments) s'affichent dans `lastErrorText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)