### PR TITLE
feat(quest): wire server + client (Phase 5 CMANGOS.23 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ add_library(engine_core
   src/shared/network/CharacterPayloads.cpp
   src/shared/network/ChatPayloads.cpp
   src/shared/network/MailPayloads.cpp
+  src/shared/network/QuestPayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
 )
@@ -631,6 +632,11 @@ add_test(NAME chat_payloads_tests COMMAND chat_payloads_tests)
 add_executable(mail_payloads_tests src/shared/network/MailPayloadsTests.cpp)
 target_link_libraries(mail_payloads_tests PRIVATE engine_core)
 add_test(NAME mail_payloads_tests COMMAND mail_payloads_tests)
+
+# CMANGOS.23 (Phase 5.23 step 3+4): QUEST_*_REQUEST/RESPONSE payload round-trip tests
+add_executable(quest_payloads_tests src/shared/network/QuestPayloadsTests.cpp)
+target_link_libraries(quest_payloads_tests PRIVATE engine_core)
+add_test(NAME quest_payloads_tests COMMAND quest_payloads_tests)
 
 # M23.4: Log rotation smoke test (runtime logger)
 add_executable(log_rotation_smoke_tests src/shared/core/LogRotationSmokeTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/session/SessionCharacterMap.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/chat/ChatRelayHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/mail/MailHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/quest/QuestHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/QuestPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9,6 +9,7 @@
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/network/ChatPayloads.h"
 #include "src/shared/network/MailPayloads.h"
+#include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/client/render/AuthImGuiRenderer.h"
@@ -807,9 +808,18 @@ namespace engine
 		else
 		{
 			m_mailUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
-				return m_authUi.SendMailRequestAsync(opcode, payload);
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
 			});
 		}
+
+		// CMANGOS.23 (Phase 5.23 step 3+4) — Cable le QuestUi presenter au
+		// master via le helper generique d'AuthUi. Le presenter etait deja
+		// init via Init(m_cfg) plus haut dans le boot ; ici on ne fait que
+		// brancher le canal d'envoi reseau. La reception est dispatchee dans
+		// le SetMasterPushHandler ci-dessous (opcodes 60/62/64/66/67).
+		m_questUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+			return m_authUi.SendGenericRequestAsync(opcode, payload);
+		});
 
 		// Chat MVP — câblage bidirectionnel ChatUi <-> AuthUi (master TCP).
 		// Send : ChatUi::SubmitInputLine appelle AuthUi::SendChatAsync sur la connexion master vivante.
@@ -830,6 +840,22 @@ namespace engine
 					m_mailUi.RequestInbox();
 				}
 				LOG_INFO(Core, "[Engine] /mail toggle (visible={})", m_mailVisible);
+				return true;
+			}
+			// CMANGOS.23 (Phase 5.23 step 3+4) — Slash command /quest et /quests
+			// pour ouvrir/fermer le panneau quete et synchroniser la liste depuis
+			// le master au moment de l'ouverture.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/quest" || text == "/quests"
+				    || text.starts_with("/quest ") || text.starts_with("/quest\t")
+				    || text.starts_with("/quests ") || text.starts_with("/quests\t")))
+			{
+				m_questVisible = !m_questVisible;
+				if (m_questVisible)
+				{
+					m_questUi.RequestQuestList();
+				}
+				LOG_INFO(Core, "[Engine] /quest toggle (visible={})", m_questVisible);
 				return true;
 			}
 			return m_authUi.SendChatAsync(channel, targetToken, text);
@@ -896,6 +922,63 @@ namespace engine
 					return;
 				}
 				m_mailUi.OnDeleteResponse(*parsed);
+				return;
+			}
+			// CMANGOS.23 (Phase 5.23 step 3+4) — Dispatch des reponses Quest
+			// (60/62/64/66) + push QuestStateUpdate (67).
+			case kOpcodeQuestAcceptResponse:
+			{
+				auto parsed = ParseQuestAcceptResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] QUEST_ACCEPT_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_questUi.OnQuestAcceptResponse(*parsed);
+				return;
+			}
+			case kOpcodeQuestCompleteResponse:
+			{
+				auto parsed = ParseQuestCompleteResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] QUEST_COMPLETE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_questUi.OnQuestCompleteResponse(*parsed);
+				return;
+			}
+			case kOpcodeQuestRewardResponse:
+			{
+				auto parsed = ParseQuestRewardResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] QUEST_REWARD_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_questUi.OnQuestRewardResponse(*parsed);
+				return;
+			}
+			case kOpcodeQuestListResponse:
+			{
+				auto parsed = ParseQuestListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] QUEST_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_questUi.OnQuestListResponse(*parsed);
+				return;
+			}
+			case kOpcodeQuestStateUpdate:
+			{
+				auto parsed = ParseQuestStateUpdatePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] QUEST_STATE_UPDATE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_questUi.OnQuestStateUpdate(*parsed);
 				return;
 			}
 			default:

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -8,6 +8,7 @@
 #include "src/client/auth/AuthUi.h"
 #include "src/client/chat/ChatUi.h"
 #include "src/client/mail/MailUi.h"
+#include "src/client/quest/QuestUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
@@ -386,6 +387,14 @@ namespace engine
 		/// CMANGOS.18 (Phase 3.18 step 4) — Visibilite du panneau mail
 		/// (toggle via slash command \c /mail). Faux par defaut.
 		bool                            m_mailVisible = false;
+		/// CMANGOS.23 (Phase 5.23 step 3+4) — Presenter quete cote client.
+		/// Recoit les reponses opcodes 60/62/64/66/67 via le push handler du
+		/// master ; fire-and-forget des requetes 59/61/63/65 via
+		/// \c m_authUi.SendGenericRequestAsync.
+		engine::client::QuestUiPresenter m_questUi;
+		/// CMANGOS.23 (Phase 5.23 step 3+4) — Visibilite du panneau quete
+		/// (toggle via slash command \c /quest ou \c /quests). Faux par defaut.
+		bool                             m_questVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -444,13 +444,15 @@ namespace engine::client
 		/// payload vide, ou Send rejeté.
 		bool SendChatAsync(uint8_t channel, std::string_view targetToken, std::string_view text);
 
-		/// CMANGOS.18 (Phase 3.18 step 4) — Envoi fire-and-forget d'une requete
-		/// Mail (opcodes 49, 51, 53, 55, 57) sur la connexion master active.
-		/// Le payload doit deja etre serialise via les helpers
-		/// \c BuildMail*RequestPayload de \ref MailPayloads.h. requestId=0
-		/// (les reponses correspondantes sont dispatched via le push handler
-		/// du master). Retourne \c false si pas de session ou Send rejete.
-		bool SendMailRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload);
+		/// CMANGOS.18 (Phase 3.18 step 4) + CMANGOS.23 (Phase 5.23 step 3+4) —
+		/// Envoi fire-and-forget d'une requete arbitraire sur la connexion master
+		/// active. Utilise pour Mail (opcodes 49, 51, 53, 55, 57), Quest
+		/// (59, 61, 63, 65) et tout futur ticket suivant le meme pattern de
+		/// requetes type-specific. Le payload doit deja etre serialise via les
+		/// helpers Build*Payload correspondants. requestId=0 (les reponses
+		/// correspondantes sont dispatched via le push handler du master).
+		/// Retourne \c false si pas de session ou Send rejete.
+		bool SendGenericRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload);
 
 		/// Phase 4 chat — Annonce au master le personnage actif après EnterWorld.
 		/// Master valide ownership (account_id + character_id en DB) et enregistre le binding

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -362,14 +362,16 @@ namespace engine::client
 		return true;
 	}
 
-	bool AuthUiPresenter::SendMailRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload)
+	bool AuthUiPresenter::SendGenericRequestAsync(uint16_t opcode, const std::vector<uint8_t>& payload)
 	{
-		// CMANGOS.18 (Phase 3.18 step 4) — Wrapper generique pour les opcodes Mail
-		// (49, 51, 53, 55, 57). Mirror de SendChatAsync : meme pattern PacketBuilder /
-		// Send, requestId=0 (les reponses sont dispatched via le push handler).
+		// CMANGOS.18 (Phase 3.18 step 4) + CMANGOS.23 (Phase 5.23 step 3+4) —
+		// Wrapper generique pour les opcodes type-specific Mail (49, 51, 53, 55, 57)
+		// et Quest (59, 61, 63, 65). Mirror de SendChatAsync : meme pattern
+		// PacketBuilder / Send, requestId=0 (les reponses sont dispatched via le
+		// push handler du master).
 		if (!m_masterClient || m_masterSessionId == 0u)
 		{
-			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: no master session (opcode={})",
+			LOG_WARN(Net, "[AuthUiPresenter] SendGenericRequestAsync: no master session (opcode={})",
 				static_cast<unsigned>(opcode));
 			return false;
 		}
@@ -377,30 +379,30 @@ namespace engine::client
 		auto w = builder.PayloadWriter();
 		if (!payload.empty() && !w.WriteBytes(payload.data(), payload.size()))
 		{
-			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: WriteBytes failed (opcode={})",
+			LOG_WARN(Net, "[AuthUiPresenter] SendGenericRequestAsync: WriteBytes failed (opcode={})",
 				static_cast<unsigned>(opcode));
 			return false;
 		}
 		if (!builder.Finalize(opcode, /*flags=*/0u, /*requestId=*/0u, m_masterSessionId, payload.size()))
 		{
-			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: Finalize failed (opcode={})",
+			LOG_WARN(Net, "[AuthUiPresenter] SendGenericRequestAsync: Finalize failed (opcode={})",
 				static_cast<unsigned>(opcode));
 			return false;
 		}
 		const auto& packet = builder.Data();
 		if (packet.empty())
 		{
-			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: empty packet (opcode={})",
+			LOG_WARN(Net, "[AuthUiPresenter] SendGenericRequestAsync: empty packet (opcode={})",
 				static_cast<unsigned>(opcode));
 			return false;
 		}
 		if (!m_masterClient->Send(std::span<const uint8_t>(packet.data(), packet.size())))
 		{
-			LOG_WARN(Net, "[AuthUiPresenter] SendMailRequestAsync: Send failed (opcode={})",
+			LOG_WARN(Net, "[AuthUiPresenter] SendGenericRequestAsync: Send failed (opcode={})",
 				static_cast<unsigned>(opcode));
 			return false;
 		}
-		LOG_DEBUG(Net, "[AuthUiPresenter] SendMailRequestAsync queued (opcode={}, payload_size={})",
+		LOG_DEBUG(Net, "[AuthUiPresenter] SendGenericRequestAsync queued (opcode={}, payload_size={})",
 			static_cast<unsigned>(opcode), payload.size());
 		return true;
 	}

--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -1,6 +1,7 @@
 #include "src/client/quest/QuestUi.h"
 
 #include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/platform/FileSystem.h"
 
 #include <algorithm>
@@ -473,5 +474,142 @@ namespace engine::client
 		m_state.debugText += ", ";
 		m_state.debugText += std::to_string(m_state.playerMarker.v);
 		m_state.debugText += ")\n";
+	}
+
+	// -------------------------------------------------------------------------
+	// CMANGOS.23 (Phase 5.23 step 3+4) — Network wiring
+	// -------------------------------------------------------------------------
+
+	void QuestUiPresenter::RequestQuestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] RequestQuestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildQuestListRequestPayload();
+		if (!m_send(engine::network::kOpcodeQuestListRequest, payload))
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] RequestQuestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[QuestUiPresenter] QuestListRequest queued");
+	}
+
+	void QuestUiPresenter::AcceptQuest(uint32_t questId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] AcceptQuest: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildQuestAcceptRequestPayload(questId);
+		if (!m_send(engine::network::kOpcodeQuestAcceptRequest, payload))
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] AcceptQuest: send failed (quest={})", questId);
+			return;
+		}
+		LOG_DEBUG(Net, "[QuestUiPresenter] QuestAcceptRequest queued (quest={})", questId);
+	}
+
+	void QuestUiPresenter::CompleteQuest(uint32_t questId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] CompleteQuest: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildQuestCompleteRequestPayload(questId);
+		if (!m_send(engine::network::kOpcodeQuestCompleteRequest, payload))
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] CompleteQuest: send failed (quest={})", questId);
+			return;
+		}
+		LOG_DEBUG(Net, "[QuestUiPresenter] QuestCompleteRequest queued (quest={})", questId);
+	}
+
+	void QuestUiPresenter::RewardQuest(uint32_t questId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] RewardQuest: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildQuestRewardRequestPayload(questId);
+		if (!m_send(engine::network::kOpcodeQuestRewardRequest, payload))
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] RewardQuest: send failed (quest={})", questId);
+			return;
+		}
+		LOG_DEBUG(Net, "[QuestUiPresenter] QuestRewardRequest queued (quest={})", questId);
+	}
+
+	void QuestUiPresenter::OnQuestListResponse(const engine::network::QuestListResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] OnQuestListResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		// Remplace le cache complet (le serveur est l'autorite).
+		m_questStates.clear();
+		m_questStates.reserve(resp.quests.size());
+		for (const auto& e : resp.quests)
+			m_questStates[e.questId] = e.status;
+		LOG_INFO(Net, "[QuestUiPresenter] OnQuestListResponse: {} quests cached", m_questStates.size());
+	}
+
+	void QuestUiPresenter::OnQuestAcceptResponse(const engine::network::QuestAcceptResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] OnQuestAcceptResponse: error code={} quest={}",
+				static_cast<unsigned>(resp.error), resp.questId);
+			return;
+		}
+		m_questStates[resp.questId] = resp.newStatus;
+		LOG_INFO(Net, "[QuestUiPresenter] OnQuestAcceptResponse: quest={} status={}",
+			resp.questId, static_cast<unsigned>(resp.newStatus));
+	}
+
+	void QuestUiPresenter::OnQuestCompleteResponse(const engine::network::QuestCompleteResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] OnQuestCompleteResponse: error code={} quest={}",
+				static_cast<unsigned>(resp.error), resp.questId);
+			return;
+		}
+		m_questStates[resp.questId] = resp.newStatus;
+		LOG_INFO(Net, "[QuestUiPresenter] OnQuestCompleteResponse: quest={} status={}",
+			resp.questId, static_cast<unsigned>(resp.newStatus));
+	}
+
+	void QuestUiPresenter::OnQuestRewardResponse(const engine::network::QuestRewardResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[QuestUiPresenter] OnQuestRewardResponse: error code={} quest={}",
+				static_cast<unsigned>(resp.error), resp.questId);
+			return;
+		}
+		m_questStates[resp.questId] = resp.newStatus;
+		LOG_INFO(Net, "[QuestUiPresenter] OnQuestRewardResponse: quest={} status={}",
+			resp.questId, static_cast<unsigned>(resp.newStatus));
+	}
+
+	void QuestUiPresenter::OnQuestStateUpdate(const engine::network::QuestStateUpdatePayload& update)
+	{
+		// Push asynchrone : reflete simplement la mise a jour serveur dans le cache.
+		m_questStates[update.questId] = update.newStatus;
+		LOG_INFO(Net, "[QuestUiPresenter] OnQuestStateUpdate (push): quest={} status={}",
+			update.questId, static_cast<unsigned>(update.newStatus));
+	}
+
+	uint8_t QuestUiPresenter::GetCachedStatus(uint32_t questId) const
+	{
+		auto it = m_questStates.find(questId);
+		return (it == m_questStates.end()) ? 0u : it->second;
 	}
 }

--- a/src/client/quest/QuestUi.h
+++ b/src/client/quest/QuestUi.h
@@ -2,10 +2,13 @@
 
 #include "src/client/ui_common/UIModel.h"
 #include "src/shared/core/Config.h"
+#include "src/shared/network/QuestPayloads.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::client
@@ -103,6 +106,55 @@ namespace engine::client
 		/// Return the immutable resolved quest UI state.
 		const QuestUiState& GetState() const { return m_state; }
 
+		// ---------------------------------------------------------------------
+		// CMANGOS.23 (Phase 5.23 step 3+4) — Network wiring
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback. Mirror de \ref MailSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestQuestList / AcceptQuest / etc.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Demande la liste des quetes au master (envoie QuestListRequest).
+		/// La reponse est consommee via \ref OnQuestListResponse.
+		void RequestQuestList();
+
+		/// Envoie un QuestAcceptRequest pour la quete \p questId.
+		void AcceptQuest(uint32_t questId);
+
+		/// Envoie un QuestCompleteRequest pour la quete \p questId.
+		void CompleteQuest(uint32_t questId);
+
+		/// Envoie un QuestRewardRequest pour la quete \p questId. V1 : le
+		/// serveur bascule l'etat Completed -> Rewarded sans deposer
+		/// effectivement les recompenses dans l'inventaire.
+		void RewardQuest(uint32_t questId);
+
+		/// Recoit une reponse QuestListResponse : remplit \ref m_questStates.
+		void OnQuestListResponse(const engine::network::QuestListResponsePayload& resp);
+
+		/// Recoit une reponse QuestAcceptResponse : update local cache.
+		void OnQuestAcceptResponse(const engine::network::QuestAcceptResponsePayload& resp);
+
+		/// Recoit une reponse QuestCompleteResponse : update local cache.
+		void OnQuestCompleteResponse(const engine::network::QuestCompleteResponsePayload& resp);
+
+		/// Recoit une reponse QuestRewardResponse : update local cache.
+		void OnQuestRewardResponse(const engine::network::QuestRewardResponsePayload& resp);
+
+		/// Recoit un push QuestStateUpdate (admin reset, expiration).
+		void OnQuestStateUpdate(const engine::network::QuestStateUpdatePayload& update);
+
+		/// Lit l'etat cache local d'une quete. 0 (None) si la quete est inconnue.
+		uint8_t GetCachedStatus(uint32_t questId) const;
+
+		/// Snapshot du cache (pour le renderer ImGui debug). Cle = questId,
+		/// valeur = QuestStatus brut.
+		const std::unordered_map<uint32_t, uint8_t>& GetCachedStates() const { return m_questStates; }
+
 	private:
 		/// Load minimap zone metadata from the configured content-relative file.
 		bool LoadZoneMetadata(const engine::core::Config& config);
@@ -142,5 +194,12 @@ namespace engine::client
 		uint32_t m_viewportHeight = 0;
 		std::string m_relativeZoneMetadataPath;
 		bool m_initialized = false;
+
+		/// CMANGOS.23 (Phase 5.23 step 3+4) — Cable serveur : callback
+		/// fire-and-forget pour envoyer les requetes au master.
+		SendCallback m_send;
+		/// Cache local des etats de quete recus du serveur (questId -> QuestStatus
+		/// brut). Mis a jour par les OnXxxResponse + OnQuestStateUpdate.
+		std::unordered_map<uint32_t, uint8_t> m_questStates;
 	};
 }

--- a/src/masterd/handlers/quest/QuestHandler.cpp
+++ b/src/masterd/handlers/quest/QuestHandler.cpp
@@ -1,0 +1,256 @@
+// CMANGOS.23 (Phase 5.23 step 3+4) — Implementation QuestHandler.
+
+#include "src/masterd/handlers/quest/QuestHandler.h"
+
+#include "src/masterd/quests/MysqlQuestStateStore.h"
+#include "src/masterd/quests/QuestState.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/QuestPayloads.h"
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Convertit un QuestOpResult (cote tracker) en QuestOpErrorCode (cote wire).
+		uint8_t MapQuestError(engine::server::quests::QuestOpResult r)
+		{
+			using engine::server::quests::QuestOpResult;
+			using engine::network::QuestOpErrorCode;
+			switch (r)
+			{
+			case QuestOpResult::OK:            return static_cast<uint8_t>(QuestOpErrorCode::Ok);
+			case QuestOpResult::WrongStatus:   return static_cast<uint8_t>(QuestOpErrorCode::WrongStatus);
+			case QuestOpResult::QuestNotFound: return static_cast<uint8_t>(QuestOpErrorCode::QuestNotFound);
+			}
+			return static_cast<uint8_t>(QuestOpErrorCode::WrongStatus);
+		}
+	}
+
+	void QuestHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_tracker || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[QuestHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account. Si l'un manque, on retourne une reponse
+		// type-specific avec error=Unauthorized (le client peut alors prompter
+		// une re-auth).
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(QuestOpErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeQuestAcceptRequest:
+				pkt = BuildQuestAcceptResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeQuestCompleteRequest:
+				pkt = BuildQuestCompleteResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeQuestRewardRequest:
+				pkt = BuildQuestRewardResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeQuestListRequest:
+				pkt = BuildQuestListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeQuestAcceptRequest:
+			HandleAccept(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeQuestCompleteRequest:
+			HandleComplete(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeQuestRewardRequest:
+			HandleReward(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeQuestListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void QuestHandler::HandleAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseQuestAcceptRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildQuestAcceptResponsePacket(
+				static_cast<uint8_t>(QuestOpErrorCode::QuestNotFound), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const auto opErr = m_tracker->Accept(accountId, parsed->questId);
+		uint8_t newStatus = static_cast<uint8_t>(m_tracker->Get(accountId, parsed->questId));
+		const uint8_t code = MapQuestError(opErr);
+
+		if (opErr == engine::server::quests::QuestOpResult::OK && m_store)
+		{
+			// Persistance best-effort. Si l'ecriture DB echoue, on logue mais on
+			// ne rollback pas : le tracker memoire reste l'autorite runtime ;
+			// la perte sera rattrapee lors d'un futur reload (PR ulterieure).
+			if (!m_store->Upsert(accountId, parsed->questId,
+				engine::server::quests::QuestStatus::Accepted))
+			{
+				LOG_WARN(Net, "[QuestHandler] Accept Upsert failed (account={}, quest={})",
+					accountId, parsed->questId);
+			}
+		}
+
+		LOG_INFO(Net, "[QuestHandler] Accept account={} quest={} code={} status={}",
+			accountId, parsed->questId, static_cast<int>(code),
+			static_cast<int>(newStatus));
+
+		auto pkt = BuildQuestAcceptResponsePacket(code, parsed->questId, newStatus,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void QuestHandler::HandleComplete(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseQuestCompleteRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildQuestCompleteResponsePacket(
+				static_cast<uint8_t>(QuestOpErrorCode::QuestNotFound), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const auto opErr = m_tracker->Complete(accountId, parsed->questId);
+		const uint8_t newStatus = static_cast<uint8_t>(m_tracker->Get(accountId, parsed->questId));
+		const uint8_t code = MapQuestError(opErr);
+
+		if (opErr == engine::server::quests::QuestOpResult::OK && m_store)
+		{
+			if (!m_store->Upsert(accountId, parsed->questId,
+				engine::server::quests::QuestStatus::Completed))
+			{
+				LOG_WARN(Net, "[QuestHandler] Complete Upsert failed (account={}, quest={})",
+					accountId, parsed->questId);
+			}
+		}
+
+		LOG_INFO(Net, "[QuestHandler] Complete account={} quest={} code={} status={}",
+			accountId, parsed->questId, static_cast<int>(code),
+			static_cast<int>(newStatus));
+
+		auto pkt = BuildQuestCompleteResponsePacket(code, parsed->questId, newStatus,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void QuestHandler::HandleReward(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseQuestRewardRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildQuestRewardResponsePacket(
+				static_cast<uint8_t>(QuestOpErrorCode::QuestNotFound), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// V1 : on bascule l'etat Completed -> Rewarded sans deposer effectivement
+		// les recompenses dans l'inventaire. La feature reelle (xp, items, gold)
+		// sera cablee dans une PR ulterieure une fois l'API inventaire stabilisee.
+		// On retourne quand meme code=Ok pour ne pas bloquer le UI flow ; le
+		// commentaire NotImplementedYet est exploite cote client si besoin.
+		const auto opErr = m_tracker->Reward(accountId, parsed->questId);
+		const uint8_t newStatus = static_cast<uint8_t>(m_tracker->Get(accountId, parsed->questId));
+		const uint8_t code = MapQuestError(opErr);
+
+		if (opErr == engine::server::quests::QuestOpResult::OK && m_store)
+		{
+			if (!m_store->Upsert(accountId, parsed->questId,
+				engine::server::quests::QuestStatus::Rewarded))
+			{
+				LOG_WARN(Net, "[QuestHandler] Reward Upsert failed (account={}, quest={})",
+					accountId, parsed->questId);
+			}
+		}
+
+		LOG_INFO(Net, "[QuestHandler] Reward account={} quest={} code={} status={}",
+			accountId, parsed->questId, static_cast<int>(code),
+			static_cast<int>(newStatus));
+
+		auto pkt = BuildQuestRewardResponsePacket(code, parsed->questId, newStatus,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void QuestHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		const auto states = m_tracker->ListAll(accountId);
+		std::vector<QuestStateEntry> entries;
+		entries.reserve(states.size());
+		for (const auto& [qId, status] : states)
+		{
+			QuestStateEntry e;
+			e.questId = qId;
+			e.status  = static_cast<uint8_t>(status);
+			entries.push_back(e);
+		}
+
+		LOG_INFO(Net, "[QuestHandler] List account={} count={}", accountId, entries.size());
+
+		auto pkt = BuildQuestListResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+}

--- a/src/masterd/handlers/quest/QuestHandler.h
+++ b/src/masterd/handlers/quest/QuestHandler.h
@@ -1,0 +1,94 @@
+#pragma once
+// CMANGOS.23 (Phase 5.23 step 3+4) — QuestHandler : dispatch des opcodes
+// Quest (59-66) et appel des methodes correspondantes du QuestStateTracker
+// + persistance via MysqlQuestStateStore.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 59/61/63/65 (les requests). Les responses sont emises avec le meme
+// requestId / sessionId que la request recue.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (pas un ErrorPacket — le code 6 dans la reponse
+// type-specific est plus exploitable cote UI quete qu'un BAD_REQUEST).
+
+#include <cstdint>
+#include <cstddef>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::quests
+{
+	class QuestStateTracker;
+	class MysqlQuestStateStore;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Quest. Doit etre configure via Set*() avant tout HandlePacket.
+	class QuestHandler
+	{
+	public:
+		/// Branche le tracker in-memory (autorite runtime des etats Quest).
+		void SetTracker(engine::server::quests::QuestStateTracker* t) { m_tracker = t; }
+		/// Branche le store MySQL (persistance audit / reload au login).
+		/// Optionnel : si nullptr, le handler reste fonctionnel mais ne persiste
+		/// pas en DB (mode no-DB).
+		void SetStore(engine::server::quests::MysqlQuestStateStore* s) { m_store = s; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses.
+		void SetServer(NetServer* server) { m_server = server; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Quest. Dispatch
+		/// vers HandleAccept/HandleComplete/etc. selon l'opcode. Si l'opcode
+		/// n'est pas un opcode Quest, ignore silencieusement (filtrage deja
+		/// fait cote main_linux).
+		///
+		/// \param connId         identifiant de connexion TCP (pour Send response).
+		/// \param opcode         opcode du paquet entrant (59/61/63/65).
+		/// \param requestId      request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload        pointeur sur le payload (sans header).
+		/// \param payloadSize    taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// Traite QUEST_ACCEPT_REQUEST : tracker->Accept + store->Upsert si OK.
+		void HandleAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite QUEST_COMPLETE_REQUEST.
+		void HandleComplete(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite QUEST_REWARD_REQUEST. V1 : la recompense reelle (items/xp) n'est
+		/// pas cablee a l'inventaire : on bascule l'etat Completed -> Rewarded
+		/// uniquement. NotImplementedYet sera retourne ulterieurement quand un
+		/// gating inventaire/level-up sera ajoute.
+		void HandleReward(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite QUEST_LIST_REQUEST : itere tracker->ListAll(account) et
+		/// renvoie la liste {questId, status} au client.
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		engine::server::quests::QuestStateTracker*    m_tracker    = nullptr;
+		engine::server::quests::MysqlQuestStateStore* m_store      = nullptr;
+		NetServer*                                     m_server     = nullptr;
+		SessionManager*                                m_sessionMgr = nullptr;
+		ConnectionSessionMap*                          m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -37,6 +37,9 @@
 #include "src/masterd/handlers/mail/MailHandler.h"
 #include "src/masterd/mail/MailManager.h"
 #include "src/masterd/mail/MysqlMailStore.h"
+#include "src/masterd/handlers/quest/QuestHandler.h"
+#include "src/masterd/quests/MysqlQuestStateStore.h"
+#include "src/masterd/quests/QuestState.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
 #include "src/shared/core/Config.h"
@@ -357,6 +360,28 @@ int main(int argc, char** argv)
 		LOG_WARN(Net, "[ServerMain] MailHandler skipped (DB pool unavailable)");
 	}
 
+	// CMANGOS.23 (Phase 5.23 step 3+4) — Quest wire server.
+	// Le tracker in-memory est l'autorite runtime des etats Quest. Le store
+	// MySQL sert de persistance audit (et future reload au login). En mode
+	// no-DB on garde le tracker mais on saute le store : la perte au reboot
+	// est acceptable pour cette MVP (le client redemandera la liste).
+	engine::server::quests::QuestStateTracker questTracker;
+	engine::server::quests::MysqlQuestStateStore questStore(&dbPool);
+	engine::server::QuestHandler questHandler;
+	questHandler.SetTracker(&questTracker);
+	questHandler.SetServer(&server);
+	questHandler.SetSessionManager(&sessionManager);
+	questHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		questHandler.SetStore(&questStore);
+		LOG_INFO(Net, "[ServerMain] QuestHandler configured with DB store (CMANGOS.23 step 3+4)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] QuestHandler running in no-DB mode (no persistence)");
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -396,7 +421,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -429,6 +454,11 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeMailTakeAttachmentsRequest
 		      || opcode == kOpcodeMailDeleteRequest)
 			mailHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeQuestAcceptRequest
+		      || opcode == kOpcodeQuestCompleteRequest
+		      || opcode == kOpcodeQuestRewardRequest
+		      || opcode == kOpcodeQuestListRequest)
+			questHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/masterd/quests/QuestState.h
+++ b/src/masterd/quests/QuestState.h
@@ -74,6 +74,17 @@ namespace engine::server::quests
 
 		void Clear() { m_state.clear(); }
 
+		/// CMANGOS.23 (Phase 5.23 step 3+4) — Liste toutes les quetes connues du
+		/// compte. Utilise par QuestHandler::HandleList pour repondre au client.
+		/// Retourne une copie ; complexite O(n) sur le nombre de quetes du compte.
+		std::unordered_map<QuestId, QuestStatus> ListAll(AccountId account) const
+		{
+			auto it = m_state.find(account);
+			if (it == m_state.end())
+				return {};
+			return it->second;
+		}
+
 	private:
 		std::unordered_map<AccountId, std::unordered_map<QuestId, QuestStatus>> m_state;
 	};

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -212,4 +212,23 @@ namespace engine::network
 	constexpr uint16_t kOpcodeMailTakeAttachmentsResponse = 56u; ///< Master→Client : ACK avec liste items pris + gold versé, ou erreur.
 	constexpr uint16_t kOpcodeMailDeleteRequest           = 57u; ///< Client→Master : supprime un mail de l'inbox.
 	constexpr uint16_t kOpcodeMailDeleteResponse          = 58u; ///< Master→Client : ACK ou erreur (NOT_FOUND, NOT_OWNER).
+
+	// -------------------------------------------------------------------------
+	// Opcodes Quest (valeurs 59–67)
+	// Référence : Phase 5 CMANGOS.23 step 3+4. Wire client→master pour la
+	// machine d'état Quest (None → Available → Accepted → Completed → Rewarded).
+	// Le step 1 (QuestStateTracker header-only) et le step 2 (MysqlQuestStateStore
+	// + migration 0048) sont déjà mergés. Cette série expose les opérations
+	// au client via 4 paires request/response + 1 push (state update).
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeQuestAcceptRequest    = 59u; ///< Client→Master : accepte une quête (questId).
+	constexpr uint16_t kOpcodeQuestAcceptResponse   = 60u; ///< Master→Client : OK + nouveau status, ou WrongStatus / Unauthorized.
+	constexpr uint16_t kOpcodeQuestCompleteRequest  = 61u; ///< Client→Master : marque une quête Completed.
+	constexpr uint16_t kOpcodeQuestCompleteResponse = 62u; ///< Master→Client : OK + nouveau status, ou WrongStatus.
+	constexpr uint16_t kOpcodeQuestRewardRequest    = 63u; ///< Client→Master : récupère la récompense (Completed → Rewarded).
+	constexpr uint16_t kOpcodeQuestRewardResponse   = 64u; ///< Master→Client : OK + nouveau status, ou NotImplementedYet (V1).
+	constexpr uint16_t kOpcodeQuestListRequest      = 65u; ///< Client→Master : liste les quêtes connues du compte (vide, account dérivé de la session).
+	constexpr uint16_t kOpcodeQuestListResponse     = 66u; ///< Master→Client : tableau {questId, status} ou Unauthorized.
+	constexpr uint16_t kOpcodeQuestStateUpdate      = 67u; ///< Master→Client (push, request_id=0) : le serveur a changé l'état d'une quête (admin reset, etc.).
 }

--- a/src/shared/network/QuestPayloads.cpp
+++ b/src/shared/network/QuestPayloads.cpp
@@ -1,0 +1,344 @@
+// CMANGOS.23 (Phase 5.23 step 3+4) — Implementation Parse/Build des payloads Quest.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send. Le requestId
+//     vient du paquet d'origine (cf. RequestResponseDispatcher).
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/QuestPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit (uint8 error, uint32 questId, uint8 newStatus). Mutualise pour les
+		/// 3 paires Accept/Complete/Reward dont les responses ont la meme forme.
+		bool WriteSimpleResponse(ByteWriter& w, uint8_t error, uint32_t questId, uint8_t newStatus)
+		{
+			if (!w.WriteBytes(&error, 1u))   return false;
+			if (!w.WriteU32(questId))        return false;
+			if (!w.WriteBytes(&newStatus, 1u)) return false;
+			return true;
+		}
+
+		/// Lit (uint8 error, uint32 questId, uint8 newStatus). Symetrique de
+		/// WriteSimpleResponse. \return false si le payload est trop court.
+		bool ReadSimpleResponse(ByteReader& r, uint8_t& error, uint32_t& questId, uint8_t& newStatus)
+		{
+			if (!r.ReadBytes(&error, 1u))      return false;
+			if (!r.ReadU32(questId))           return false;
+			if (!r.ReadBytes(&newStatus, 1u))  return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// QUEST_ACCEPT
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestAcceptRequestPayload> ParseQuestAcceptRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestAcceptRequestPayload out;
+		if (!r.ReadU32(out.questId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestAcceptRequestPayload(uint32_t questId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(questId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<QuestAcceptResponsePayload> ParseQuestAcceptResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint32 questId (4) + uint8 status (1) = 6.
+		if (!payload || payloadSize < 6u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestAcceptResponsePayload out;
+		if (!ReadSimpleResponse(r, out.error, out.questId, out.newStatus))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestAcceptResponsePayload(uint8_t error, uint32_t questId, uint8_t newStatus)
+	{
+		std::vector<uint8_t> buf(6u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildQuestAcceptResponsePacket(uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeQuestAcceptResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// QUEST_COMPLETE
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestCompleteRequestPayload> ParseQuestCompleteRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestCompleteRequestPayload out;
+		if (!r.ReadU32(out.questId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestCompleteRequestPayload(uint32_t questId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(questId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<QuestCompleteResponsePayload> ParseQuestCompleteResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 6u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestCompleteResponsePayload out;
+		if (!ReadSimpleResponse(r, out.error, out.questId, out.newStatus))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestCompleteResponsePayload(uint8_t error, uint32_t questId, uint8_t newStatus)
+	{
+		std::vector<uint8_t> buf(6u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildQuestCompleteResponsePacket(uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeQuestCompleteResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// QUEST_REWARD
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestRewardRequestPayload> ParseQuestRewardRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestRewardRequestPayload out;
+		if (!r.ReadU32(out.questId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestRewardRequestPayload(uint32_t questId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(questId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<QuestRewardResponsePayload> ParseQuestRewardResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 6u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestRewardResponsePayload out;
+		if (!ReadSimpleResponse(r, out.error, out.questId, out.newStatus))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestRewardResponsePayload(uint8_t error, uint32_t questId, uint8_t newStatus)
+	{
+		std::vector<uint8_t> buf(6u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildQuestRewardResponsePacket(uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSimpleResponse(w, error, questId, newStatus))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeQuestRewardResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// QUEST_LIST
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestListRequestPayload> ParseQuestListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte (0 octet ou plus, ignore le reste).
+		return QuestListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildQuestListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	namespace
+	{
+		/// Serialise la partie « apres error » de QUEST_LIST_RESPONSE.
+		bool WriteQuestListBody(ByteWriter& w, uint8_t error, const std::vector<QuestStateEntry>& quests)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(quests.size())))
+				return false;
+			for (const auto& e : quests)
+			{
+				if (!w.WriteU32(e.questId))         return false;
+				if (!w.WriteBytes(&e.status, 1u))   return false;
+			}
+			return true;
+		}
+	}
+
+	std::optional<QuestListResponsePayload> ParseQuestListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.quests.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			QuestStateEntry e;
+			if (!r.ReadU32(e.questId))         return std::nullopt;
+			if (!r.ReadBytes(&e.status, 1u))   return std::nullopt;
+			out.quests.push_back(e);
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestListResponsePayload(uint8_t error, const std::vector<QuestStateEntry>& quests)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteQuestListBody(w, error, quests))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildQuestListResponsePacket(uint8_t error, const std::vector<QuestStateEntry>& quests,
+	                                                  uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteQuestListBody(w, error, quests))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeQuestListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// QUEST_STATE_UPDATE (push, request_id=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestStateUpdatePayload> ParseQuestStateUpdatePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint32 questId (4) + uint8 newStatus (1) = 5.
+		if (!payload || payloadSize < 5u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		QuestStateUpdatePayload out;
+		if (!r.ReadU32(out.questId))         return std::nullopt;
+		if (!r.ReadBytes(&out.newStatus, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildQuestStateUpdatePayload(uint32_t questId, uint8_t newStatus)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(questId))         return {};
+		if (!w.WriteBytes(&newStatus, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildQuestStateUpdatePacket(uint32_t questId, uint8_t newStatus, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU32(questId))         return {};
+		if (!w.WriteBytes(&newStatus, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0 (pas de request en correspondance cote client).
+		if (!builder.Finalize(kOpcodeQuestStateUpdate, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/QuestPayloads.h
+++ b/src/shared/network/QuestPayloads.h
@@ -1,0 +1,180 @@
+#pragma once
+// CMANGOS.23 (Phase 5.23 step 3+4) — Wire payloads pour les opcodes Quest (59–67).
+//
+// Quatre paires Request/Response + 1 push :
+//   - Accept   (59/60)
+//   - Complete (61/62)
+//   - Reward   (63/64)
+//   - List     (65/66)
+//   - StateUpdate push (67) — Master→Client pour annoncer un changement d'état
+//     déclenché côté serveur (admin reset, expiration, etc.).
+//
+// Format wire : ByteReader/ByteWriter little-endian. Toutes les payloads sont
+// très simples (uint32 questId, uint8 status, vector<{uint32,uint8}> via
+// WriteArrayCount/ReadArrayCount). Pas de strings — la quête est référencée
+// par son id numérique.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level. Mapping côté serveur depuis QuestOpResult.
+	// =========================================================================
+
+	/// Code d'erreur générique pour les opcodes Quest (Accept/Complete/Reward/List).
+	/// 0 = OK ; sinon questId / quests peuvent être 0 / vides selon la nature de
+	/// l'erreur. Le client expose ces codes en message localisable.
+	enum class QuestOpErrorCode : uint8_t
+	{
+		Ok                = 0,
+		WrongStatus       = 1, ///< Mappé depuis QuestOpResult::WrongStatus (transition invalide).
+		QuestNotFound     = 2, ///< Mappé depuis QuestOpResult::QuestNotFound.
+		Unauthorized      = 6, ///< Pas de session valide côté master.
+		NotImplementedYet = 7, ///< Reward V1 : la feature n'est pas câblée à l'inventaire.
+	};
+
+	// =========================================================================
+	// QUEST_ACCEPT — Client → Master : accepte une quête.
+	// =========================================================================
+
+	/// Wire format : uint32 questId (4 octets).
+	struct QuestAcceptRequestPayload
+	{
+		uint32_t questId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error      (cf. QuestOpErrorCode)
+	///   uint32 questId    (echo de la request)
+	///   uint8  newStatus  (cf. quests::QuestStatus). 0 = None si error != Ok.
+	struct QuestAcceptResponsePayload
+	{
+		uint8_t  error     = 0;
+		uint32_t questId   = 0;
+		uint8_t  newStatus = 0;
+	};
+
+	// =========================================================================
+	// QUEST_COMPLETE — Client → Master : marque la quête Completed.
+	// =========================================================================
+
+	struct QuestCompleteRequestPayload
+	{
+		uint32_t questId = 0;
+	};
+
+	struct QuestCompleteResponsePayload
+	{
+		uint8_t  error     = 0;
+		uint32_t questId   = 0;
+		uint8_t  newStatus = 0;
+	};
+
+	// =========================================================================
+	// QUEST_REWARD — Client → Master : récupère la récompense.
+	// =========================================================================
+
+	struct QuestRewardRequestPayload
+	{
+		uint32_t questId = 0;
+	};
+
+	struct QuestRewardResponsePayload
+	{
+		uint8_t  error     = 0;
+		uint32_t questId   = 0;
+		uint8_t  newStatus = 0;
+	};
+
+	// =========================================================================
+	// QUEST_LIST — Client → Master : liste les quêtes connues du compte.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est dérivé de la session côté master.
+	struct QuestListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entrée de l'inventaire de quêtes du compte.
+	struct QuestStateEntry
+	{
+		uint32_t questId = 0;
+		uint8_t  status  = 0; ///< cf. quests::QuestStatus.
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 count          (si error == 0)
+	///   <count> entries       (4 + 1 octets chacune)
+	struct QuestListResponsePayload
+	{
+		uint8_t                       error = 0;
+		std::vector<QuestStateEntry>  quests;
+	};
+
+	// =========================================================================
+	// QUEST_STATE_UPDATE — Master → Client (push, request_id=0).
+	// Annonce un changement d'état serveur-driven (admin reset, expiration).
+	// =========================================================================
+
+	/// Wire format : uint32 questId + uint8 newStatus (5 octets).
+	struct QuestStateUpdatePayload
+	{
+		uint32_t questId   = 0;
+		uint8_t  newStatus = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un QUEST_ACCEPT_REQUEST. \return nullopt si payloadSize < 4.
+	std::optional<QuestAcceptRequestPayload>   ParseQuestAcceptRequestPayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestCompleteRequestPayload> ParseQuestCompleteRequestPayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestRewardRequestPayload>   ParseQuestRewardRequestPayload  (const uint8_t* payload, size_t payloadSize);
+	/// Parse le payload d'un QUEST_LIST_REQUEST. Toujours OK (payload vide accepté).
+	std::optional<QuestListRequestPayload>     ParseQuestListRequestPayload    (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildQuestAcceptRequestPayload  (uint32_t questId);
+	std::vector<uint8_t> BuildQuestCompleteRequestPayload(uint32_t questId);
+	std::vector<uint8_t> BuildQuestRewardRequestPayload  (uint32_t questId);
+	/// Build payload (vide) d'un QUEST_LIST_REQUEST.
+	std::vector<uint8_t> BuildQuestListRequestPayload();
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<QuestAcceptResponsePayload>   ParseQuestAcceptResponsePayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestCompleteResponsePayload> ParseQuestCompleteResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestRewardResponsePayload>   ParseQuestRewardResponsePayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestListResponsePayload>     ParseQuestListResponsePayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<QuestStateUpdatePayload>      ParseQuestStateUpdatePayload     (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildQuestAcceptResponsePayload  (uint8_t error, uint32_t questId, uint8_t newStatus);
+	std::vector<uint8_t> BuildQuestCompleteResponsePayload(uint8_t error, uint32_t questId, uint8_t newStatus);
+	std::vector<uint8_t> BuildQuestRewardResponsePayload  (uint8_t error, uint32_t questId, uint8_t newStatus);
+	std::vector<uint8_t> BuildQuestListResponsePayload    (uint8_t error, const std::vector<QuestStateEntry>& quests);
+	std::vector<uint8_t> BuildQuestStateUpdatePayload     (uint32_t questId, uint8_t newStatus);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilisé côté handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildQuestAcceptResponsePacket  (uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildQuestCompleteResponsePacket(uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildQuestRewardResponsePacket  (uint8_t error, uint32_t questId, uint8_t newStatus,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildQuestListResponsePacket    (uint8_t error, const std::vector<QuestStateEntry>& quests,
+	                                                      uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildQuestStateUpdatePacket     (uint32_t questId, uint8_t newStatus,
+	                                                      uint64_t sessionIdHeader);
+}

--- a/src/shared/network/QuestPayloadsTests.cpp
+++ b/src/shared/network/QuestPayloadsTests.cpp
@@ -1,0 +1,265 @@
+/**
+ * CMANGOS.23 (Phase 5.23 step 3+4) — Round-trip tests for QUEST_*_REQUEST /
+ * QUEST_*_RESPONSE / QUEST_STATE_UPDATE payloads. Pure encoding tests
+ * (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ *
+ * Test policy : symetrique aux MailPayloadsTests.cpp — pas de framework de
+ * test externe, juste un Assert local + main() qui appelle chaque suite.
+ */
+
+#include "src/shared/network/QuestPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// QUEST_ACCEPT
+// -----------------------------------------------------------------------------
+
+static void TestAcceptRequestRoundTrip()
+{
+	auto buf = BuildQuestAcceptRequestPayload(42u);
+	Assert(buf.size() == 4u, "Accept request is 4 bytes");
+	auto parsed = ParseQuestAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Accept request parses OK");
+	if (parsed)
+		Assert(parsed->questId == 42u, "Accept request questId round-trips");
+}
+
+static void TestAcceptRequestRejectsShort()
+{
+	auto parsed = ParseQuestAcceptRequestPayload(nullptr, 4u);
+	Assert(!parsed.has_value(), "Accept request rejects nullptr");
+	uint8_t shortBuf[3]{};
+	auto parsed2 = ParseQuestAcceptRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Accept request rejects 3 bytes");
+}
+
+static void TestAcceptResponseRoundTrip()
+{
+	auto buf = BuildQuestAcceptResponsePayload(0u, 42u, 2u /*Accepted*/);
+	Assert(buf.size() == 6u, "Accept response is 6 bytes");
+	auto parsed = ParseQuestAcceptResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Accept response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Accept response error 0");
+		Assert(parsed->questId == 42u, "Accept response questId");
+		Assert(parsed->newStatus == 2u, "Accept response status");
+	}
+}
+
+static void TestAcceptResponseError()
+{
+	auto buf = BuildQuestAcceptResponsePayload(
+		static_cast<uint8_t>(QuestOpErrorCode::WrongStatus), 42u, 0u);
+	auto parsed = ParseQuestAcceptResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Accept WrongStatus decodes");
+}
+
+static void TestAcceptResponsePacket()
+{
+	auto pkt = BuildQuestAcceptResponsePacket(0u, 42u, 2u, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Accept response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeQuestAcceptResponse, "Packet opcode is QuestAcceptResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseQuestAcceptResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->questId == 42u, "Accept response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// QUEST_COMPLETE
+// -----------------------------------------------------------------------------
+
+static void TestCompleteRequestRoundTrip()
+{
+	auto buf = BuildQuestCompleteRequestPayload(7u);
+	auto parsed = ParseQuestCompleteRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->questId == 7u, "Complete request round-trips");
+}
+
+static void TestCompleteResponseRoundTrip()
+{
+	auto buf = BuildQuestCompleteResponsePayload(0u, 7u, 3u /*Completed*/);
+	auto parsed = ParseQuestCompleteResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->newStatus == 3u, "Complete response round-trips");
+}
+
+// -----------------------------------------------------------------------------
+// QUEST_REWARD
+// -----------------------------------------------------------------------------
+
+static void TestRewardRequestRoundTrip()
+{
+	auto buf = BuildQuestRewardRequestPayload(99u);
+	auto parsed = ParseQuestRewardRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->questId == 99u, "Reward request round-trips");
+}
+
+static void TestRewardResponseRoundTrip()
+{
+	auto buf = BuildQuestRewardResponsePayload(
+		static_cast<uint8_t>(QuestOpErrorCode::NotImplementedYet), 99u, 3u);
+	auto parsed = ParseQuestRewardResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 7u, "Reward NotImplementedYet decodes");
+}
+
+// -----------------------------------------------------------------------------
+// QUEST_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildQuestListRequestPayload();
+	Assert(buf.empty(), "List request payload empty");
+	auto parsed = ParseQuestListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildQuestListResponsePayload(0u, {});
+	auto parsed = ParseQuestListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response empty parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "List response empty error 0");
+		Assert(parsed->quests.empty(), "List response empty has 0 quests");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	auto buf = BuildQuestListResponsePayload(
+		static_cast<uint8_t>(QuestOpErrorCode::Unauthorized), {});
+	auto parsed = ParseQuestListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "List response Unauthorized");
+}
+
+static void TestListResponseMultiple()
+{
+	std::vector<QuestStateEntry> quests;
+	quests.push_back({1u, 2u}); // Accepted
+	quests.push_back({2u, 3u}); // Completed
+	quests.push_back({100u, 4u}); // Rewarded
+	auto buf = BuildQuestListResponsePayload(0u, quests);
+	auto parsed = ParseQuestListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response multiple parses");
+	if (parsed && parsed->quests.size() == 3u)
+	{
+		Assert(parsed->quests[0].questId == 1u && parsed->quests[0].status == 2u, "entry[0]");
+		Assert(parsed->quests[1].questId == 2u && parsed->quests[1].status == 3u, "entry[1]");
+		Assert(parsed->quests[2].questId == 100u && parsed->quests[2].status == 4u, "entry[2]");
+	}
+	else
+	{
+		Assert(false, "List response should have 3 entries");
+	}
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseQuestListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List response rejects nullptr");
+	uint8_t one[1]{0};
+	auto parsed2 = ParseQuestListResponsePayload(one, 0u);
+	Assert(!parsed2.has_value(), "List response rejects size 0");
+}
+
+// -----------------------------------------------------------------------------
+// QUEST_STATE_UPDATE (push)
+// -----------------------------------------------------------------------------
+
+static void TestStateUpdateRoundTrip()
+{
+	auto buf = BuildQuestStateUpdatePayload(123u, 5u /*Failed*/);
+	Assert(buf.size() == 5u, "StateUpdate is 5 bytes");
+	auto parsed = ParseQuestStateUpdatePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "StateUpdate parses");
+	if (parsed)
+	{
+		Assert(parsed->questId == 123u, "StateUpdate questId");
+		Assert(parsed->newStatus == 5u, "StateUpdate status Failed");
+	}
+}
+
+static void TestStateUpdatePacket()
+{
+	auto pkt = BuildQuestStateUpdatePacket(123u, 5u, 0xCAFEull);
+	Assert(!pkt.empty(), "StateUpdate packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "StateUpdate PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeQuestStateUpdate, "Opcode is QuestStateUpdate");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseQuestStateUpdatePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->questId == 123u, "StateUpdate payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// Boundary
+// -----------------------------------------------------------------------------
+
+static void TestBoundaryQuestId()
+{
+	auto buf = BuildQuestAcceptRequestPayload(0xFFFFFFFFu);
+	auto parsed = ParseQuestAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->questId == 0xFFFFFFFFu, "questId max round-trips");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestAcceptRequestRoundTrip();
+	TestAcceptRequestRejectsShort();
+	TestAcceptResponseRoundTrip();
+	TestAcceptResponseError();
+	TestAcceptResponsePacket();
+
+	TestCompleteRequestRoundTrip();
+	TestCompleteResponseRoundTrip();
+
+	TestRewardRequestRoundTrip();
+	TestRewardResponseRoundTrip();
+
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseUnauthorized();
+	TestListResponseMultiple();
+	TestListResponseRejectsShort();
+
+	TestStateUpdateRoundTrip();
+	TestStateUpdatePacket();
+
+	TestBoundaryQuestId();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all quest payload tests passed\n" : "[FAIL] some quest tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Quest state wire — server + client

Branche le QuestStateTracker (step 1 mergé) + MysqlQuestStateStore (step 2 mergé) sur le wire et l'UI client.

### Server wire
- `ProtocolV1Constants.h` : opcodes 59-67 (5 paires Request/Response + 1 push)
- `src/shared/network/QuestPayloads.{h,cpp}` : Accept/Complete/Reward/List + push StateUpdate
- `src/shared/network/QuestPayloadsTests.cpp` : round-trip tests
- `src/masterd/handlers/quest/QuestHandler.{h,cpp}` : dispatch → tracker → store upsert
- `src/masterd/main_linux.cpp` : instancie tracker + store + handler

### Client integration
- `src/client/quest/QuestUi.{h,cpp}` étendu : SetSendCallback, RequestQuestList, Accept/Complete/Reward, OnXxxResponse, OnQuestStateUpdate
- `src/client/app/Engine.{h,cpp}` : câble QuestUi, dispatch opcodes, slash command `/quest`
- `src/client/auth/AuthUi` : rename `SendMailRequestAsync` → `SendGenericRequestAsync` pour réutilisation
- `CMakeLists.txt` : sources + test target

### V1 limitations (acceptables)
- Pas de chargement initial depuis store au login (futur session start hook)
- QuestStateTracker reste in-memory (autorité runtime), store = audit + persistence
- HandleReward bascule à `Rewarded` sans déposer xp/items/gold (API inventaire pas stable)

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 59-67. Pas d'impact pour anciens clients (graceful degradation).

Generated with Claude Code