### PR TITLE
feat(ignorelist): wire server + client + chat filter (Phase 3 CMANGOS.25 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(engine_core
   src/client/chat/ChatWorldVisualPresenter.cpp
   src/client/mail/MailUi.cpp
   src/client/social/FriendsUi.cpp
+  src/client/social/IgnoreListUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
   src/shared/net/ChatSystem.cpp
@@ -419,6 +420,7 @@ add_library(engine_core
   src/shared/network/AuthRegisterPayloads.cpp
   src/shared/network/CharacterPayloads.cpp
   src/shared/network/ChatPayloads.cpp
+  src/shared/network/IgnoreListPayloads.cpp
   src/shared/network/MailPayloads.cpp
   src/shared/network/QuestPayloads.cpp
   src/shared/network/ShardPayloads.cpp
@@ -637,6 +639,11 @@ add_test(NAME mail_payloads_tests COMMAND mail_payloads_tests)
 add_executable(quest_payloads_tests src/shared/network/QuestPayloadsTests.cpp)
 target_link_libraries(quest_payloads_tests PRIVATE engine_core)
 add_test(NAME quest_payloads_tests COMMAND quest_payloads_tests)
+
+# CMANGOS.25 (Phase 3.25 step 3+4): IGNORE_*_REQUEST/RESPONSE payload round-trip tests
+add_executable(ignore_list_payloads_tests src/shared/network/IgnoreListPayloadsTests.cpp)
+target_link_libraries(ignore_list_payloads_tests PRIVATE engine_core)
+add_test(NAME ignore_list_payloads_tests COMMAND ignore_list_payloads_tests)
 
 # M23.4: Log rotation smoke test (runtime logger)
 add_executable(log_rotation_smoke_tests src/shared/core/LogRotationSmokeTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/chat/ChatRelayHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/mail/MailHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/quest/QuestHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/social/IgnoreListHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/QuestPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8,6 +8,7 @@
 #include "src/shared/core/memory/Memory.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/network/ChatPayloads.h"
+#include "src/shared/network/IgnoreListPayloads.h"
 #include "src/shared/network/MailPayloads.h"
 #include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/PacketBuilder.h"
@@ -821,6 +822,21 @@ namespace engine
 			return m_authUi.SendGenericRequestAsync(opcode, payload);
 		});
 
+		// CMANGOS.25 (Phase 3.25 step 3+4) — Init du presenter IgnoreList +
+		// cable du send callback. La reception est dispatchee dans le
+		// SetMasterPushHandler ci-dessous (opcodes 69/71/73). Le presenter
+		// maintient une cache locale m_ignoredAccountIds.
+		if (!m_ignoreListUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] IgnoreListUiPresenter init FAILED — feature ignore desactivee");
+		}
+		else
+		{
+			m_ignoreListUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// Chat MVP — câblage bidirectionnel ChatUi <-> AuthUi (master TCP).
 		// Send : ChatUi::SubmitInputLine appelle AuthUi::SendChatAsync sur la connexion master vivante.
 		// Receive : AuthUi::PumpPostAuthEvents dispatche les paquets push (CHAT_RELAY notamment)
@@ -856,6 +872,84 @@ namespace engine
 					m_questUi.RequestQuestList();
 				}
 				LOG_INFO(Core, "[Engine] /quest toggle (visible={})", m_questVisible);
+				return true;
+			}
+			// CMANGOS.25 (Phase 3.25 step 3+4) — Slash commands /ignore et /unignore.
+			// Format V1 : "/ignore <account_id>" et "/unignore <account_id>" — la
+			// resolution par character_name viendra avec PartySystem display.
+			// "/ignore list" sans argument refresh la cache depuis le master.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/ignore" || text.starts_with("/ignore ") || text.starts_with("/ignore\t")))
+			{
+				const auto spaceIdx = text.find_first_of(" \t");
+				if (spaceIdx == std::string_view::npos)
+				{
+					// "/ignore" tout seul : refresh la liste.
+					m_ignoreListUi.RequestIgnoreList();
+					LOG_INFO(Core, "[Engine] /ignore (refresh list)");
+					return true;
+				}
+				std::string_view arg = text.substr(spaceIdx + 1);
+				while (!arg.empty() && (arg.front() == ' ' || arg.front() == '\t'))
+					arg.remove_prefix(1u);
+				if (arg == "list" || arg.empty())
+				{
+					m_ignoreListUi.RequestIgnoreList();
+					LOG_INFO(Core, "[Engine] /ignore list");
+					return true;
+				}
+				// Parse account_id en uint64 (base 10).
+				uint64_t targetAccountId = 0u;
+				bool parsed = false;
+				try
+				{
+					size_t pos = 0;
+					const std::string argStr(arg);
+					targetAccountId = std::stoull(argStr, &pos, 10);
+					parsed = (pos > 0u && targetAccountId != 0u);
+				}
+				catch (...)
+				{
+					parsed = false;
+				}
+				if (!parsed)
+				{
+					LOG_WARN(Core, "[Engine] /ignore : argument '{}' n'est pas un account_id valide",
+						std::string(arg));
+					return true;
+				}
+				m_ignoreListUi.IgnoreAccount(targetAccountId);
+				LOG_INFO(Core, "[Engine] /ignore {}", targetAccountId);
+				return true;
+			}
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text.starts_with("/unignore ") || text.starts_with("/unignore\t")))
+			{
+				const auto spaceIdx = text.find_first_of(" \t");
+				std::string_view arg = text.substr(spaceIdx + 1);
+				while (!arg.empty() && (arg.front() == ' ' || arg.front() == '\t'))
+					arg.remove_prefix(1u);
+				uint64_t targetAccountId = 0u;
+				bool parsed = false;
+				try
+				{
+					size_t pos = 0;
+					const std::string argStr(arg);
+					targetAccountId = std::stoull(argStr, &pos, 10);
+					parsed = (pos > 0u && targetAccountId != 0u);
+				}
+				catch (...)
+				{
+					parsed = false;
+				}
+				if (!parsed)
+				{
+					LOG_WARN(Core, "[Engine] /unignore : argument '{}' n'est pas un account_id valide",
+						std::string(arg));
+					return true;
+				}
+				m_ignoreListUi.UnignoreAccount(targetAccountId);
+				LOG_INFO(Core, "[Engine] /unignore {}", targetAccountId);
 				return true;
 			}
 			return m_authUi.SendChatAsync(channel, targetToken, text);
@@ -979,6 +1073,41 @@ namespace engine
 					return;
 				}
 				m_questUi.OnQuestStateUpdate(*parsed);
+				return;
+			}
+			// CMANGOS.25 (Phase 3.25 step 3+4) — Dispatch des reponses IgnoreList
+			// (69/71/73). La cache locale du presenter est mise a jour ici.
+			case kOpcodeIgnoreAddResponse:
+			{
+				auto parsed = ParseIgnoreAddResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] IGNORE_ADD_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_ignoreListUi.OnIgnoreAddResponse(*parsed);
+				return;
+			}
+			case kOpcodeIgnoreRemoveResponse:
+			{
+				auto parsed = ParseIgnoreRemoveResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] IGNORE_REMOVE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_ignoreListUi.OnIgnoreRemoveResponse(*parsed);
+				return;
+			}
+			case kOpcodeIgnoreListResponse:
+			{
+				auto parsed = ParseIgnoreListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] IGNORE_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_ignoreListUi.OnIgnoreListResponse(*parsed);
 				return;
 			}
 			default:

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -9,6 +9,7 @@
 #include "src/client/chat/ChatUi.h"
 #include "src/client/mail/MailUi.h"
 #include "src/client/quest/QuestUi.h"
+#include "src/client/social/IgnoreListUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
@@ -395,6 +396,11 @@ namespace engine
 		/// CMANGOS.23 (Phase 5.23 step 3+4) — Visibilite du panneau quete
 		/// (toggle via slash command \c /quest ou \c /quests). Faux par defaut.
 		bool                             m_questVisible = false;
+		/// CMANGOS.25 (Phase 3.25 step 3+4) — Presenter liste d'ignore. Recoit
+		/// les reponses opcodes 69/71/73 via le push handler du master ;
+		/// fire-and-forget des requetes 68/70/72 via
+		/// \c m_authUi.SendGenericRequestAsync.
+		engine::client::IgnoreListUiPresenter m_ignoreListUi;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/social/IgnoreListUi.cpp
+++ b/src/client/social/IgnoreListUi.cpp
@@ -1,0 +1,149 @@
+// CMANGOS.25 (Phase 3.25 step 3+4) — Implementation IgnoreListUiPresenter.
+
+#include "src/client/social/IgnoreListUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	IgnoreListUiPresenter::~IgnoreListUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool IgnoreListUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[IgnoreListUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_state.layoutValid = true;
+		m_ignoredAccountIds.clear();
+		LOG_INFO(Core, "[IgnoreListUiPresenter] Init OK");
+		return true;
+	}
+
+	void IgnoreListUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		m_ignoredAccountIds.clear();
+		// Ne pas reset m_send : il est cable une fois au boot et on garde la
+		// reference (Engine::Shutdown sera responsable du teardown ordonne).
+		LOG_INFO(Core, "[IgnoreListUiPresenter] Destroyed");
+	}
+
+	void IgnoreListUiPresenter::IgnoreAccount(uint64_t targetAccountId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] IgnoreAccount: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildIgnoreAddRequestPayload(targetAccountId);
+		if (!m_send(engine::network::kOpcodeIgnoreAddRequest, payload))
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] IgnoreAccount: send failed (target={})", targetAccountId);
+			return;
+		}
+		LOG_DEBUG(Net, "[IgnoreListUiPresenter] IgnoreAddRequest queued (target={})", targetAccountId);
+	}
+
+	void IgnoreListUiPresenter::UnignoreAccount(uint64_t targetAccountId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] UnignoreAccount: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildIgnoreRemoveRequestPayload(targetAccountId);
+		if (!m_send(engine::network::kOpcodeIgnoreRemoveRequest, payload))
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] UnignoreAccount: send failed (target={})", targetAccountId);
+			return;
+		}
+		LOG_DEBUG(Net, "[IgnoreListUiPresenter] IgnoreRemoveRequest queued (target={})", targetAccountId);
+	}
+
+	void IgnoreListUiPresenter::RequestIgnoreList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] RequestIgnoreList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildIgnoreListRequestPayload();
+		if (!m_send(engine::network::kOpcodeIgnoreListRequest, payload))
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] RequestIgnoreList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[IgnoreListUiPresenter] IgnoreListRequest queued");
+	}
+
+	void IgnoreListUiPresenter::OnIgnoreAddResponse(const engine::network::IgnoreAddResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] OnIgnoreAddResponse: server error code={} target={}",
+				static_cast<unsigned>(resp.error), resp.targetAccountId);
+			return;
+		}
+		m_ignoredAccountIds.insert(resp.targetAccountId);
+		RebuildState();
+		LOG_INFO(Net, "[IgnoreListUiPresenter] OnIgnoreAddResponse: target={} cached size={}",
+			resp.targetAccountId, m_ignoredAccountIds.size());
+	}
+
+	void IgnoreListUiPresenter::OnIgnoreRemoveResponse(const engine::network::IgnoreRemoveResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] OnIgnoreRemoveResponse: server error code={} target={}",
+				static_cast<unsigned>(resp.error), resp.targetAccountId);
+			return;
+		}
+		m_ignoredAccountIds.erase(resp.targetAccountId);
+		RebuildState();
+		LOG_INFO(Net, "[IgnoreListUiPresenter] OnIgnoreRemoveResponse: target={} cached size={}",
+			resp.targetAccountId, m_ignoredAccountIds.size());
+	}
+
+	void IgnoreListUiPresenter::OnIgnoreListResponse(const engine::network::IgnoreListResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[IgnoreListUiPresenter] OnIgnoreListResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		// Le serveur est l'autorite : on remplace la cache complete.
+		m_ignoredAccountIds.clear();
+		m_ignoredAccountIds.reserve(resp.ignoredAccountIds.size());
+		for (auto id : resp.ignoredAccountIds)
+			m_ignoredAccountIds.insert(id);
+		RebuildState();
+		LOG_INFO(Net, "[IgnoreListUiPresenter] OnIgnoreListResponse: {} accounts cached",
+			m_ignoredAccountIds.size());
+	}
+
+	bool IgnoreListUiPresenter::IsIgnoredLocal(uint64_t accountId) const
+	{
+		return m_ignoredAccountIds.count(accountId) != 0u;
+	}
+
+	void IgnoreListUiPresenter::RebuildState()
+	{
+		m_state.ignoredAccountIds.clear();
+		m_state.ignoredAccountIds.reserve(m_ignoredAccountIds.size());
+		for (auto id : m_ignoredAccountIds)
+			m_state.ignoredAccountIds.push_back(id);
+		m_state.layoutValid = true;
+	}
+}

--- a/src/client/social/IgnoreListUi.h
+++ b/src/client/social/IgnoreListUi.h
@@ -1,0 +1,100 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25 step 3+4) — Presenter client de la liste d'ignore.
+// Maintient un cache local des account_id ignores recu via IGNORE_LIST_RESPONSE,
+// et expose Ignore/Unignore/RequestIgnoreList qui envoient les requests via un
+// callback fire-and-forget (cf. m_send dans QuestUiPresenter).
+//
+// Le presenter ne fait pas de rendu ImGui directement (le panneau Friends
+// pourrait l'afficher dans une PR ulterieure). Sa principale utilite cote
+// client est la cache locale (`IsIgnoredLocal`) — utile par exemple pour
+// griser un bouton "ignorer" dans un menu contextuel ou afficher visuellement
+// les whispers consommes mais bloques.
+
+#include "src/shared/network/IgnoreListPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::client
+{
+	/// Etat snapshot exposable au layer UI. La V1 ne fait que lister les
+	/// account_id ; un futur enrichissement pourra resoudre name/last_seen.
+	struct IgnoreListPanelState
+	{
+		std::vector<uint64_t> ignoredAccountIds;
+		bool                  layoutValid = false;
+	};
+
+	/// Presenter pour la liste d'ignore client-side. Doit etre Init() avant tout
+	/// usage du callback. Thread : main (comme les autres presenters UI).
+	class IgnoreListUiPresenter final
+	{
+	public:
+		IgnoreListUiPresenter() = default;
+
+		IgnoreListUiPresenter(const IgnoreListUiPresenter&)            = delete;
+		IgnoreListUiPresenter& operator=(const IgnoreListUiPresenter&) = delete;
+
+		~IgnoreListUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.25 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback. Mirror du pattern QuestUi/MailUi.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant Ignore/Unignore/RequestIgnoreList.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie un IGNORE_ADD_REQUEST au master.
+		void IgnoreAccount(uint64_t targetAccountId);
+
+		/// Envoie un IGNORE_REMOVE_REQUEST au master.
+		void UnignoreAccount(uint64_t targetAccountId);
+
+		/// Envoie un IGNORE_LIST_REQUEST (a faire au login + manuellement via /ignore list).
+		void RequestIgnoreList();
+
+		/// Recoit IGNORE_ADD_RESPONSE : insere dans la cache locale si OK.
+		void OnIgnoreAddResponse(const engine::network::IgnoreAddResponsePayload& resp);
+
+		/// Recoit IGNORE_REMOVE_RESPONSE : retire de la cache locale si OK.
+		void OnIgnoreRemoveResponse(const engine::network::IgnoreRemoveResponsePayload& resp);
+
+		/// Recoit IGNORE_LIST_RESPONSE : remplace la cache locale.
+		void OnIgnoreListResponse(const engine::network::IgnoreListResponsePayload& resp);
+
+		/// Indique si \p accountId est dans la cache locale d'ignore. Utilise pour
+		/// filtrer cote client (par ex. griser un bouton "envoyer un whisper").
+		/// Le serveur applique aussi le filtre (autoritaire) dans ChatRelayHandler.
+		bool IsIgnoredLocal(uint64_t accountId) const;
+
+		/// Acces lecture seule au snapshot pour un layer ImGui de panneau social.
+		const IgnoreListPanelState& GetState() const { return m_state; }
+
+		/// Snapshot brut du set (utile pour debug overlay et tests).
+		const std::unordered_set<uint64_t>& GetCachedSet() const { return m_ignoredAccountIds; }
+
+	private:
+		/// Met a jour \ref m_state.ignoredAccountIds depuis \ref m_ignoredAccountIds.
+		void RebuildState();
+
+		bool                          m_initialized = false;
+		IgnoreListPanelState          m_state{};
+		std::unordered_set<uint64_t>  m_ignoredAccountIds;
+		SendCallback                  m_send;
+	};
+}

--- a/src/masterd/handlers/chat/ChatRelayHandler.cpp
+++ b/src/masterd/handlers/chat/ChatRelayHandler.cpp
@@ -11,6 +11,7 @@
 #include "src/shared/network/NetServer.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 #include "src/masterd/session/SessionManager.h"
+#include "src/masterd/social/IgnoreList.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
 
@@ -277,11 +278,29 @@ namespace engine::server
 			auto destSessionOpt = m_connMap->GetSessionId(destConn);
 			if (destSessionOpt)
 			{
-				// Texte vu par le destinataire : "[from sender] body" — pour qu'il sache de qui ca vient.
-				const std::string toRecipient = "[from " + sender + "] " + parsed->text;
-				auto pktDest = BuildChatRelayPacket(ts, parsed->channel, sender, toRecipient, *destSessionOpt);
-				if (!pktDest.empty())
-					m_server->Send(destConn, pktDest);
+				// CMANGOS.25 (Phase 3.25 step 3+4) — IgnoreList filter : si le
+				// destinataire a ignore l'expediteur, on drop silencieusement
+				// l'envoi vers le destinataire. L'echo a l'expediteur est conserve
+				// (le but du ticket : l'expediteur ne sait pas qu'il est ignore).
+				bool dropForRecipient = false;
+				if (m_ignoreMgr)
+				{
+					auto destAccountOpt = m_sessions->GetAccountId(*destSessionOpt);
+					if (destAccountOpt && m_ignoreMgr->IsIgnored(*destAccountOpt, *accountId))
+					{
+						dropForRecipient = true;
+						LOG_INFO(Net, "[ChatRelayHandler] Whisper drop for recipient (ignored) sender_acc={} dest_acc={}",
+							*accountId, *destAccountOpt);
+					}
+				}
+				if (!dropForRecipient)
+				{
+					// Texte vu par le destinataire : "[from sender] body" — pour qu'il sache de qui ca vient.
+					const std::string toRecipient = "[from " + sender + "] " + parsed->text;
+					auto pktDest = BuildChatRelayPacket(ts, parsed->channel, sender, toRecipient, *destSessionOpt);
+					if (!pktDest.empty())
+						m_server->Send(destConn, pktDest);
+				}
 			}
 
 			// Echo expéditeur : "[to target] body" — confirmation que le whisper est bien parti.
@@ -466,8 +485,22 @@ namespace engine::server
 		const uint64_t ts = NowUnixMsUtc();
 		const auto snapshot = m_connMap->Snapshot();
 		size_t delivered = 0;
+		size_t droppedByIgnore = 0;
 		for (const auto& [destConn, destSession] : snapshot)
 		{
+			// CMANGOS.25 (Phase 3.25 step 3+4) — IgnoreList filter : skip
+			// destinataires qui ont ignore l'expediteur. Le sender ne s'ignore
+			// pas lui-meme (verifie cote IgnoreListManager::Ignore via SelfIgnore),
+			// donc l'echo personnel passe toujours.
+			if (m_ignoreMgr)
+			{
+				auto destAccountOpt = m_sessions->GetAccountId(destSession);
+				if (destAccountOpt && m_ignoreMgr->IsIgnored(*destAccountOpt, *accountId))
+				{
+					++droppedByIgnore;
+					continue;
+				}
+			}
 			auto pkt = BuildChatRelayPacket(ts, parsed->channel, sender, parsed->text, destSession);
 			if (pkt.empty())
 				continue;
@@ -483,7 +516,7 @@ namespace engine::server
 			textForLog.resize(200u);
 			textForLog += "...[truncated]";
 		}
-		LOG_INFO(Net, "[ChatRelayHandler] Chat broadcast sender='{}' channel={} text_len={} delivered={}/{} text='{}'",
-			sender, static_cast<unsigned>(parsed->channel), parsed->text.size(), delivered, snapshot.size(), textForLog);
+		LOG_INFO(Net, "[ChatRelayHandler] Chat broadcast sender='{}' channel={} text_len={} delivered={}/{} dropped_ignore={} text='{}'",
+			sender, static_cast<unsigned>(parsed->channel), parsed->text.size(), delivered, snapshot.size(), droppedByIgnore, textForLog);
 	}
 }

--- a/src/masterd/handlers/chat/ChatRelayHandler.h
+++ b/src/masterd/handlers/chat/ChatRelayHandler.h
@@ -13,6 +13,11 @@ namespace engine::server::db
 	class ConnectionPool;
 }
 
+namespace engine::server::social
+{
+	class IgnoreListManager;
+}
+
 namespace engine::server
 {
 	class NetServer;
@@ -55,6 +60,11 @@ namespace engine::server
 		void SetAccountStore(AccountStore* accounts);
 		void SetConnectionPool(engine::server::db::ConnectionPool* pool);
 
+		/// CMANGOS.25 (Phase 3.25 step 3+4) — branche le manager IgnoreList pour
+		/// que les whispers et chat soient silencieusement drop si le destinataire
+		/// a ignore l'expediteur. Optionnel : si nullptr, aucun filtre n'est applique.
+		void SetIgnoreManager(engine::server::social::IgnoreListManager* mgr) { m_ignoreMgr = mgr; }
+
 		/// Phase 2 CMANGOS.01 : configure le sanitizer (UTF-8 safe trunc,
 		/// strip zero-width, hyperlinks whitelist). Idempotent.
 		void SetSanitizerConfig(const chat::ChatSanitizerConfig& cfg);
@@ -78,12 +88,13 @@ namespace engine::server
 			const uint8_t* payload, size_t payloadSize);
 
 	private:
-		NetServer*                          m_server   = nullptr;
-		SessionManager*                     m_sessions = nullptr;
-		ConnectionSessionMap*               m_connMap  = nullptr;
-		SessionCharacterMap*                m_charMap  = nullptr;
-		AccountStore*                       m_accounts = nullptr;
-		engine::server::db::ConnectionPool* m_pool     = nullptr;
+		NetServer*                                m_server    = nullptr;
+		SessionManager*                           m_sessions  = nullptr;
+		ConnectionSessionMap*                     m_connMap   = nullptr;
+		SessionCharacterMap*                      m_charMap   = nullptr;
+		AccountStore*                             m_accounts  = nullptr;
+		engine::server::db::ConnectionPool*       m_pool      = nullptr;
+		engine::server::social::IgnoreListManager* m_ignoreMgr = nullptr;
 
 		chat::ChatSanitizerConfig           m_sanitizerCfg{};
 		chat::ChatGate                      m_gate{};

--- a/src/masterd/handlers/social/IgnoreListHandler.cpp
+++ b/src/masterd/handlers/social/IgnoreListHandler.cpp
@@ -1,0 +1,172 @@
+// CMANGOS.25 (Phase 3.25 step 3+4) — Implementation IgnoreListHandler.
+
+#include "src/masterd/handlers/social/IgnoreListHandler.h"
+
+#include "src/masterd/social/IgnoreList.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/IgnoreListPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Convertit un IgnoreOpResult (cote manager) en IgnoreOpErrorCode (cote wire).
+		uint8_t MapIgnoreError(engine::server::social::IgnoreOpResult r)
+		{
+			using engine::server::social::IgnoreOpResult;
+			using engine::network::IgnoreOpErrorCode;
+			switch (r)
+			{
+			case IgnoreOpResult::OK:             return static_cast<uint8_t>(IgnoreOpErrorCode::Ok);
+			case IgnoreOpResult::AlreadyIgnored: return static_cast<uint8_t>(IgnoreOpErrorCode::AlreadyIgnored);
+			case IgnoreOpResult::NotIgnored:     return static_cast<uint8_t>(IgnoreOpErrorCode::NotIgnored);
+			case IgnoreOpResult::ListFull:       return static_cast<uint8_t>(IgnoreOpErrorCode::ListFull);
+			case IgnoreOpResult::SelfIgnore:     return static_cast<uint8_t>(IgnoreOpErrorCode::SelfIgnore);
+			}
+			return static_cast<uint8_t>(IgnoreOpErrorCode::NotIgnored);
+		}
+	}
+
+	void IgnoreListHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_mgr || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[IgnoreListHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account. Si l'un manque, on retourne une reponse
+		// type-specific avec error=Unauthorized.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(IgnoreOpErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeIgnoreAddRequest:
+				pkt = BuildIgnoreAddResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeIgnoreRemoveRequest:
+				pkt = BuildIgnoreRemoveResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeIgnoreListRequest:
+				pkt = BuildIgnoreListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeIgnoreAddRequest:
+			HandleAdd(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeIgnoreRemoveRequest:
+			HandleRemove(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeIgnoreListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void IgnoreListHandler::HandleAdd(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseIgnoreAddRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			// Payload malforme : on retourne un AlreadyIgnored generique avec
+			// targetAccountId=0. Pas une vraie info utile, mais coherent avec
+			// le reste des handlers (un Unauthorized serait moins precis).
+			auto pkt = BuildIgnoreAddResponsePacket(
+				static_cast<uint8_t>(IgnoreOpErrorCode::NotIgnored), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const auto opErr = m_mgr->Ignore(accountId, parsed->targetAccountId);
+		const uint8_t code = MapIgnoreError(opErr);
+
+		LOG_INFO(Net, "[IgnoreListHandler] Add owner={} target={} code={}",
+			accountId, parsed->targetAccountId, static_cast<int>(code));
+
+		auto pkt = BuildIgnoreAddResponsePacket(code, parsed->targetAccountId,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void IgnoreListHandler::HandleRemove(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseIgnoreRemoveRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildIgnoreRemoveResponsePacket(
+				static_cast<uint8_t>(IgnoreOpErrorCode::NotIgnored), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const auto opErr = m_mgr->Unignore(accountId, parsed->targetAccountId);
+		const uint8_t code = MapIgnoreError(opErr);
+
+		LOG_INFO(Net, "[IgnoreListHandler] Remove owner={} target={} code={}",
+			accountId, parsed->targetAccountId, static_cast<int>(code));
+
+		auto pkt = BuildIgnoreRemoveResponsePacket(code, parsed->targetAccountId,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void IgnoreListHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		const auto ids = m_mgr->List(accountId);
+		LOG_INFO(Net, "[IgnoreListHandler] List owner={} count={}", accountId, ids.size());
+
+		auto pkt = BuildIgnoreListResponsePacket(0u, ids, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+}

--- a/src/masterd/handlers/social/IgnoreListHandler.h
+++ b/src/masterd/handlers/social/IgnoreListHandler.h
@@ -1,0 +1,81 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25 step 3+4) — IgnoreListHandler : dispatch des opcodes
+// IgnoreList (68-73) et appel des methodes correspondantes du
+// IgnoreListManager (lui-meme branche sur MysqlIgnoreStore en production).
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 68/70/72 (les requests). Les responses sont emises avec le meme
+// requestId / sessionId que la request recue.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 6 dans la reponse type-specific, plus exploitable
+// cote UI sociale qu'un BAD_REQUEST generique).
+
+#include <cstdint>
+#include <cstddef>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::social
+{
+	class IgnoreListManager;
+}
+
+namespace engine::server
+{
+	/// Dispatcher IgnoreList. Doit etre configure via Set*() avant tout HandlePacket.
+	class IgnoreListHandler
+	{
+	public:
+		/// Branche le manager (autorite runtime des listes ignore + cap a 50).
+		/// Le manager wrappe le store (MysqlIgnoreStore en production, in-memory en tests).
+		void SetManager(engine::server::social::IgnoreListManager* mgr) { m_mgr = mgr; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses.
+		void SetServer(NetServer* server) { m_server = server; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes IgnoreList. Dispatch
+		/// vers HandleAdd/HandleRemove/HandleList selon l'opcode. Si l'opcode n'est
+		/// pas un opcode IgnoreList, ignore silencieusement (filtrage deja fait
+		/// cote main_linux).
+		///
+		/// \param connId         identifiant de connexion TCP (pour Send response).
+		/// \param opcode         opcode du paquet entrant (68/70/72).
+		/// \param requestId      request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload        pointeur sur le payload (sans header).
+		/// \param payloadSize    taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// Traite IGNORE_ADD_REQUEST : manager->Ignore + retourne IgnoreOpErrorCode.
+		void HandleAdd(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite IGNORE_REMOVE_REQUEST : manager->Unignore.
+		void HandleRemove(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite IGNORE_LIST_REQUEST : manager->List et renvoie le tableau d'ids.
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		engine::server::social::IgnoreListManager* m_mgr        = nullptr;
+		NetServer*                                  m_server     = nullptr;
+		SessionManager*                             m_sessionMgr = nullptr;
+		ConnectionSessionMap*                       m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -40,6 +40,9 @@
 #include "src/masterd/handlers/quest/QuestHandler.h"
 #include "src/masterd/quests/MysqlQuestStateStore.h"
 #include "src/masterd/quests/QuestState.h"
+#include "src/masterd/handlers/social/IgnoreListHandler.h"
+#include "src/masterd/social/IgnoreList.h"
+#include "src/masterd/social/MysqlIgnoreStore.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
 #include "src/shared/core/Config.h"
@@ -382,6 +385,29 @@ int main(int argc, char** argv)
 		LOG_WARN(Net, "[ServerMain] QuestHandler running in no-DB mode (no persistence)");
 	}
 
+	// CMANGOS.25 (Phase 3.25 step 3+4) — IgnoreList wire server.
+	// Le store DB est instancie seulement si dbPool est dispo (sinon mode no-DB :
+	// le manager prend un store nul -> opErr toujours NotIgnored, ce qui est
+	// coherent avec le ticket : feature desactivee silencieusement en mode degrade).
+	// Le manager est aussi cable sur ChatRelayHandler pour le filter whisper/chat.
+	engine::server::social::MysqlIgnoreStore ignoreStore(&dbPool);
+	engine::server::social::IgnoreListManager ignoreManager(&ignoreStore);
+	engine::server::IgnoreListHandler ignoreListHandler;
+	if (dbPool.IsInitialized())
+	{
+		ignoreListHandler.SetManager(&ignoreManager);
+		ignoreListHandler.SetServer(&server);
+		ignoreListHandler.SetSessionManager(&sessionManager);
+		ignoreListHandler.SetConnectionSessionMap(&connSessionMap);
+		// Cable le manager sur ChatRelayHandler pour le filter ignore lors des whispers.
+		chatRelayHandler.SetIgnoreManager(&ignoreManager);
+		LOG_INFO(Net, "[ServerMain] IgnoreListHandler configured + ChatRelayHandler ignore filter armed (CMANGOS.25 step 3+4)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] IgnoreListHandler skipped (DB pool unavailable)");
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -421,7 +447,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -459,6 +485,10 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeQuestRewardRequest
 		      || opcode == kOpcodeQuestListRequest)
 			questHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeIgnoreAddRequest
+		      || opcode == kOpcodeIgnoreRemoveRequest
+		      || opcode == kOpcodeIgnoreListRequest)
+			ignoreListHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/IgnoreListPayloads.cpp
+++ b/src/shared/network/IgnoreListPayloads.cpp
@@ -1,0 +1,226 @@
+// CMANGOS.25 (Phase 3.25 step 3+4) — Implémentation Parse/Build des payloads
+// IgnoreList. Convention symétrique aux autres *Payloads.cpp du repo.
+
+#include "src/shared/network/IgnoreListPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Helper : scratch buffer dimensionné à la limite protocole pour les
+		/// payloads contenant un vector (List). Tronqué à l'offset réel via resize.
+		std::vector<uint8_t> MakeScratchBuffer()
+		{
+			return std::vector<uint8_t>(kProtocolV1MaxPacketSize, 0u);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// IGNORE_ADD
+	// -------------------------------------------------------------------------
+
+	std::optional<IgnoreAddRequestPayload> ParseIgnoreAddRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		IgnoreAddRequestPayload out;
+		if (!r.ReadU64(out.targetAccountId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildIgnoreAddRequestPayload(uint64_t targetAccountId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(targetAccountId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<IgnoreAddResponsePayload> ParseIgnoreAddResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 targetAccountId (8) = 9 octets.
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		IgnoreAddResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))         return std::nullopt;
+		if (!r.ReadU64(out.targetAccountId))      return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildIgnoreAddResponsePayload(uint8_t error, uint64_t targetAccountId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))           return {};
+		if (!w.WriteU64(targetAccountId))        return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildIgnoreAddResponsePacket(uint8_t error, uint64_t targetAccountId,
+	                                                  uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))           return {};
+		if (!w.WriteU64(targetAccountId))        return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeIgnoreAddResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// IGNORE_REMOVE
+	// -------------------------------------------------------------------------
+
+	std::optional<IgnoreRemoveRequestPayload> ParseIgnoreRemoveRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		IgnoreRemoveRequestPayload out;
+		if (!r.ReadU64(out.targetAccountId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildIgnoreRemoveRequestPayload(uint64_t targetAccountId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(targetAccountId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<IgnoreRemoveResponsePayload> ParseIgnoreRemoveResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		IgnoreRemoveResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))        return std::nullopt;
+		if (!r.ReadU64(out.targetAccountId))     return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildIgnoreRemoveResponsePayload(uint8_t error, uint64_t targetAccountId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))           return {};
+		if (!w.WriteU64(targetAccountId))        return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildIgnoreRemoveResponsePacket(uint8_t error, uint64_t targetAccountId,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))           return {};
+		if (!w.WriteU64(targetAccountId))        return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeIgnoreRemoveResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// IGNORE_LIST
+	// -------------------------------------------------------------------------
+
+	std::optional<IgnoreListRequestPayload> ParseIgnoreListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepté (0 octet ou plus, ignore le reste).
+		return IgnoreListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildIgnoreListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	std::optional<IgnoreListResponsePayload> ParseIgnoreListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1). Si error=0, on continue avec uint16 count + uint64 * count.
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		IgnoreListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.ignoredAccountIds.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			uint64_t accId = 0;
+			if (!r.ReadU64(accId))
+				return std::nullopt;
+			out.ignoredAccountIds.push_back(accId);
+		}
+		return out;
+	}
+
+	namespace
+	{
+		/// Sérialise la partie « après error » de IGNORE_LIST_RESPONSE.
+		/// Mutualisé entre payload-only et packet builder.
+		bool WriteListBody(ByteWriter& w, uint8_t error, const std::vector<uint64_t>& ignored)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(ignored.size())))
+				return false;
+			for (const auto accId : ignored)
+			{
+				if (!w.WriteU64(accId))
+					return false;
+			}
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> BuildIgnoreListResponsePayload(uint8_t error, const std::vector<uint64_t>& ignoredAccountIds)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListBody(w, error, ignoredAccountIds))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildIgnoreListResponsePacket(uint8_t error,
+	                                                    const std::vector<uint64_t>& ignoredAccountIds,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListBody(w, error, ignoredAccountIds))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeIgnoreListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/IgnoreListPayloads.h
+++ b/src/shared/network/IgnoreListPayloads.h
@@ -1,0 +1,152 @@
+#pragma once
+// CMANGOS.25 (Phase 3.25 step 3+4) — Wire payloads pour les opcodes IgnoreList
+// (68–73).
+//
+// Trois paires Request/Response :
+//   - Add (68/69)
+//   - Remove (70/71)
+//   - List (72/73)
+//
+// Format wire : ByteReader/ByteWriter little-endian. Pour le List response,
+// le vector<uint64> est encodé via WriteArrayCount (uint16) puis count fois
+// uint64 (compatible MailListInbox).
+//
+// Le step 1 (IgnoreListManager + IIgnoreStore + InMemoryIgnoreStore) et le
+// step 2 (MysqlIgnoreStore + migration 0049) sont déjà mergés. Cette PR
+// ajoute le wire et l'UI client.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Code d'erreur commun aux 3 réponses Ignore (Add / Remove / List).
+	// La cardinalité est petite et stable ; on garde un seul enum.
+	// =========================================================================
+
+	/// Codes d'erreur retournés dans les *ResponsePayload IgnoreList.
+	/// Aligné sur engine::server::social::IgnoreOpResult (cf. IgnoreList.h)
+	/// avec en plus l'erreur Unauthorized propre au wire (session manquante).
+	enum class IgnoreOpErrorCode : uint8_t
+	{
+		Ok              = 0,
+		AlreadyIgnored  = 1, ///< Cas Add : l'account est déjà dans la liste.
+		NotIgnored      = 2, ///< Cas Remove : l'account n'est pas dans la liste.
+		ListFull        = 3, ///< Cap kMaxIgnoredPerAccount (50) atteint.
+		SelfIgnore      = 4, ///< Pas le droit de s'ignorer soi-même.
+		Unauthorized    = 6, ///< Pas de session valide.
+	};
+
+	// =========================================================================
+	// IGNORE_ADD — Client → Master : ajoute un account à la liste d'ignore.
+	// =========================================================================
+
+	/// Wire format : uint64 targetAccountId (8 octets).
+	struct IgnoreAddRequestPayload
+	{
+		uint64_t targetAccountId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error (cf. IgnoreOpErrorCode)
+	///   uint64 targetAccountId  (echo de la request, pour correlation côté UI)
+	struct IgnoreAddResponsePayload
+	{
+		uint8_t  error           = 0;
+		uint64_t targetAccountId = 0;
+	};
+
+	// =========================================================================
+	// IGNORE_REMOVE — Client → Master : retire un account de la liste d'ignore.
+	// =========================================================================
+
+	/// Wire format : uint64 targetAccountId (8 octets).
+	struct IgnoreRemoveRequestPayload
+	{
+		uint64_t targetAccountId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 targetAccountId
+	struct IgnoreRemoveResponsePayload
+	{
+		uint8_t  error           = 0;
+		uint64_t targetAccountId = 0;
+	};
+
+	// =========================================================================
+	// IGNORE_LIST — Client → Master : demande la liste complète des account_id
+	// ignorés. L'account propriétaire est dérivé de la session côté master.
+	// =========================================================================
+
+	/// Wire format : (vide).
+	struct IgnoreListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 count
+	///   <count> * uint64 ignoredAccountId
+	struct IgnoreListResponsePayload
+	{
+		uint8_t                 error = 0;
+		std::vector<uint64_t>   ignoredAccountIds;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un IGNORE_ADD_REQUEST. \return nullopt si payloadSize < 8.
+	std::optional<IgnoreAddRequestPayload> ParseIgnoreAddRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un IGNORE_REMOVE_REQUEST. \return nullopt si payloadSize < 8.
+	std::optional<IgnoreRemoveRequestPayload> ParseIgnoreRemoveRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un IGNORE_LIST_REQUEST. Toujours OK (payload vide accepté).
+	std::optional<IgnoreListRequestPayload> ParseIgnoreListRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Construit le payload (sans header) d'un IGNORE_ADD_REQUEST.
+	std::vector<uint8_t> BuildIgnoreAddRequestPayload(uint64_t targetAccountId);
+
+	/// Construit le payload (sans header) d'un IGNORE_REMOVE_REQUEST.
+	std::vector<uint8_t> BuildIgnoreRemoveRequestPayload(uint64_t targetAccountId);
+
+	/// Construit le payload (vide) d'un IGNORE_LIST_REQUEST.
+	std::vector<uint8_t> BuildIgnoreListRequestPayload();
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses
+	// -------------------------------------------------------------------------
+
+	std::optional<IgnoreAddResponsePayload>     ParseIgnoreAddResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<IgnoreRemoveResponsePayload>  ParseIgnoreRemoveResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<IgnoreListResponsePayload>    ParseIgnoreListResponsePayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Construit un paquet complet IGNORE_ADD_RESPONSE prêt à envoyer.
+	std::vector<uint8_t> BuildIgnoreAddResponsePacket(uint8_t error, uint64_t targetAccountId,
+	                                                  uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet IGNORE_REMOVE_RESPONSE.
+	std::vector<uint8_t> BuildIgnoreRemoveResponsePacket(uint8_t error, uint64_t targetAccountId,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Construit un paquet complet IGNORE_LIST_RESPONSE.
+	std::vector<uint8_t> BuildIgnoreListResponsePacket(uint8_t error,
+	                                                    const std::vector<uint64_t>& ignoredAccountIds,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader);
+
+	// -------------------------------------------------------------------------
+	// Build payload-only (utile côté tests round-trip).
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildIgnoreAddResponsePayload(uint8_t error, uint64_t targetAccountId);
+	std::vector<uint8_t> BuildIgnoreRemoveResponsePayload(uint8_t error, uint64_t targetAccountId);
+	std::vector<uint8_t> BuildIgnoreListResponsePayload(uint8_t error, const std::vector<uint64_t>& ignoredAccountIds);
+}

--- a/src/shared/network/IgnoreListPayloadsTests.cpp
+++ b/src/shared/network/IgnoreListPayloadsTests.cpp
@@ -1,0 +1,250 @@
+/**
+ * CMANGOS.25 (Phase 3.25 step 3+4) — Round-trip tests pour IGNORE_*_REQUEST /
+ * IGNORE_*_RESPONSE payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ *
+ * Test policy : symétrique aux MailPayloadsTests.cpp / QuestPayloadsTests.cpp.
+ */
+
+#include "src/shared/network/IgnoreListPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// IGNORE_ADD
+// -----------------------------------------------------------------------------
+
+static void TestAddRequestRoundTrip()
+{
+	auto buf = BuildIgnoreAddRequestPayload(424242ull);
+	Assert(buf.size() == 8u, "Add request is 8 bytes");
+	auto parsed = ParseIgnoreAddRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Add request parses OK");
+	if (parsed)
+	{
+		Assert(parsed->targetAccountId == 424242ull, "Add request targetAccountId round-trips");
+	}
+}
+
+static void TestAddRequestRejectsShort()
+{
+	auto parsed = ParseIgnoreAddRequestPayload(nullptr, 8u);
+	Assert(!parsed.has_value(), "Add request rejects nullptr");
+	uint8_t shortBuf[7]{};
+	auto parsed2 = ParseIgnoreAddRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Add request rejects 7 bytes");
+}
+
+static void TestAddResponseRoundTrip()
+{
+	auto buf = BuildIgnoreAddResponsePayload(0u, 0xDEADBEEFull);
+	auto parsed = ParseIgnoreAddResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Add response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "OK error code");
+		Assert(parsed->targetAccountId == 0xDEADBEEFull, "targetAccountId round-trips");
+	}
+
+	auto bufErr = BuildIgnoreAddResponsePayload(static_cast<uint8_t>(IgnoreOpErrorCode::AlreadyIgnored), 7ull);
+	auto parsedErr = ParseIgnoreAddResponsePayload(bufErr.data(), bufErr.size());
+	Assert(parsedErr.has_value() && parsedErr->error == 1u, "AlreadyIgnored decodes");
+	Assert(parsedErr && parsedErr->targetAccountId == 7ull, "Echo target on error");
+}
+
+static void TestAddResponsePacket()
+{
+	auto pkt = BuildIgnoreAddResponsePacket(0u, 99ull, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Add response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeIgnoreAddResponse, "Packet opcode is IgnoreAddResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseIgnoreAddResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->targetAccountId == 99ull, "Payload decodes from packet");
+}
+
+// -----------------------------------------------------------------------------
+// IGNORE_REMOVE
+// -----------------------------------------------------------------------------
+
+static void TestRemoveRequestRoundTrip()
+{
+	auto buf = BuildIgnoreRemoveRequestPayload(123ull);
+	Assert(buf.size() == 8u, "Remove request is 8 bytes");
+	auto parsed = ParseIgnoreRemoveRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->targetAccountId == 123ull, "Remove request round-trips");
+}
+
+static void TestRemoveRequestRejectsShort()
+{
+	uint8_t shortBuf[7]{};
+	auto parsed = ParseIgnoreRemoveRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "Remove request rejects 7 bytes");
+}
+
+static void TestRemoveResponseRoundTrip()
+{
+	auto buf = BuildIgnoreRemoveResponsePayload(0u, 5ull);
+	auto parsed = ParseIgnoreRemoveResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Remove response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Remove OK");
+		Assert(parsed->targetAccountId == 5ull, "Remove echo target");
+	}
+
+	auto bufErr = BuildIgnoreRemoveResponsePayload(
+		static_cast<uint8_t>(IgnoreOpErrorCode::NotIgnored), 5ull);
+	auto parsedErr = ParseIgnoreRemoveResponsePayload(bufErr.data(), bufErr.size());
+	Assert(parsedErr.has_value() && parsedErr->error == 2u, "NotIgnored decodes");
+}
+
+// -----------------------------------------------------------------------------
+// IGNORE_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequest()
+{
+	auto buf = BuildIgnoreListRequestPayload();
+	Assert(buf.empty(), "List request payload is empty");
+	auto parsed = ParseIgnoreListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildIgnoreListResponsePayload(0u, {});
+	auto parsed = ParseIgnoreListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response (empty) parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Empty list is OK");
+		Assert(parsed->ignoredAccountIds.empty(), "Empty list has no entries");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	// Quand error != 0, on ne sérialise pas le count (économie de bande passante).
+	auto buf = BuildIgnoreListResponsePayload(static_cast<uint8_t>(IgnoreOpErrorCode::Unauthorized), {});
+	auto parsed = ParseIgnoreListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "Unauthorized decodes");
+	Assert(parsed && parsed->ignoredAccountIds.empty(), "No entries on error");
+}
+
+static void TestListResponseMultiple()
+{
+	std::vector<uint64_t> ids;
+	ids.push_back(100ull);
+	ids.push_back(200ull);
+	ids.push_back(0xFFFFFFFFFFFFFFFFull);
+
+	auto buf = BuildIgnoreListResponsePayload(0u, ids);
+	auto parsed = ParseIgnoreListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response (3 entries) parses OK");
+	if (parsed && parsed->ignoredAccountIds.size() == 3u)
+	{
+		Assert(parsed->ignoredAccountIds[0] == 100ull, "id[0]");
+		Assert(parsed->ignoredAccountIds[1] == 200ull, "id[1]");
+		Assert(parsed->ignoredAccountIds[2] == 0xFFFFFFFFFFFFFFFFull, "id[2] uint64 max");
+	}
+	else
+	{
+		Assert(false, "List response should have 3 entries");
+	}
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseIgnoreListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List response rejects nullptr");
+	uint8_t one[1]{0};
+	auto parsed2 = ParseIgnoreListResponsePayload(one, 0u);
+	Assert(!parsed2.has_value(), "List response rejects size 0");
+}
+
+static void TestListResponsePacket()
+{
+	std::vector<uint64_t> ids;
+	ids.push_back(42ull);
+	auto pkt = BuildIgnoreListResponsePacket(0u, ids, 999u, 0xBEEFull);
+	Assert(!pkt.empty(), "List response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeIgnoreListResponse, "Packet opcode is IgnoreListResponse");
+	Assert(view.RequestId() == 999u, "RequestId preserved");
+	auto parsed = ParseIgnoreListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->ignoredAccountIds.size() == 1u, "Payload decodes");
+	Assert(parsed && parsed->ignoredAccountIds[0] == 42ull, "List entry round-trips");
+}
+
+// -----------------------------------------------------------------------------
+// Boundary
+// -----------------------------------------------------------------------------
+
+static void TestBoundaryValues()
+{
+	auto buf = BuildIgnoreAddRequestPayload(0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseIgnoreAddRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Boundary uint64 parses");
+	if (parsed)
+	{
+		Assert(parsed->targetAccountId == 0xFFFFFFFFFFFFFFFFull, "uint64 max target");
+	}
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	// IGNORE_ADD
+	TestAddRequestRoundTrip();
+	TestAddRequestRejectsShort();
+	TestAddResponseRoundTrip();
+	TestAddResponsePacket();
+
+	// IGNORE_REMOVE
+	TestRemoveRequestRoundTrip();
+	TestRemoveRequestRejectsShort();
+	TestRemoveResponseRoundTrip();
+
+	// IGNORE_LIST
+	TestListRequest();
+	TestListResponseEmpty();
+	TestListResponseUnauthorized();
+	TestListResponseMultiple();
+	TestListResponseRejectsShort();
+	TestListResponsePacket();
+
+	// Edge cases
+	TestBoundaryValues();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all ignore_list payload tests passed\n"
+	                                : "[FAIL] some ignore_list tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -231,4 +231,25 @@ namespace engine::network
 	constexpr uint16_t kOpcodeQuestListRequest      = 65u; ///< Client→Master : liste les quêtes connues du compte (vide, account dérivé de la session).
 	constexpr uint16_t kOpcodeQuestListResponse     = 66u; ///< Master→Client : tableau {questId, status} ou Unauthorized.
 	constexpr uint16_t kOpcodeQuestStateUpdate      = 67u; ///< Master→Client (push, request_id=0) : le serveur a changé l'état d'une quête (admin reset, etc.).
+
+	// -------------------------------------------------------------------------
+	// Opcodes IgnoreList (valeurs 68–73)
+	// Référence : Phase 3 CMANGOS.25 step 3+4. Wire client→master pour la liste
+	// d'ignore : un joueur peut silencieusement bloquer les whispers/chat
+	// venant d'un autre account. Le step 1 (IgnoreListManager + IIgnoreStore)
+	// et le step 2 (MysqlIgnoreStore + migration 0049) sont déjà mergés.
+	// Cette série expose les opérations au client via 3 paires request/response :
+	//   - Add (68/69)
+	//   - Remove (70/71)
+	//   - List (72/73)
+	// La résolution se fait par account_id direct (V1) — la résolution par
+	// character_name viendra avec PartySystem display ultérieurement.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeIgnoreAddRequest     = 68u; ///< Client→Master : ajoute un account_id à la liste d'ignore.
+	constexpr uint16_t kOpcodeIgnoreAddResponse    = 69u; ///< Master→Client : OK ou AlreadyIgnored / ListFull / SelfIgnore.
+	constexpr uint16_t kOpcodeIgnoreRemoveRequest  = 70u; ///< Client→Master : retire un account_id de la liste d'ignore.
+	constexpr uint16_t kOpcodeIgnoreRemoveResponse = 71u; ///< Master→Client : OK ou NotIgnored.
+	constexpr uint16_t kOpcodeIgnoreListRequest    = 72u; ///< Client→Master : demande la liste complète des account_id ignorés (vide).
+	constexpr uint16_t kOpcodeIgnoreListResponse   = 73u; ///< Master→Client : tableau d'account_id ignorés ou Unauthorized.
 }


### PR DESCRIPTION
## IgnoreList wire — server + client + chat filter

Branche `IgnoreListManager` (step 1 mergé) + `MysqlIgnoreStore` (step 2 mergé) sur le wire et l'UI client. Intègre le filter `ChatRelayHandler` pour drop silencieusement les whispers venant d'un account ignoré.

### Server wire
- `ProtocolV1Constants.h` : opcodes 68-73 (3 paires Add/Remove/List)
- `src/shared/network/IgnoreListPayloads.{h,cpp,Tests.cpp}`
- `src/masterd/handlers/social/IgnoreListHandler.{h,cpp}`
- `src/masterd/main_linux.cpp` : instancie + dispatch + câble IgnoreManager → ChatRelayHandler

### Chat filter
- `src/masterd/handlers/chat/ChatRelayHandler` : `SetIgnoreManager` + filter whisper + filter broadcast catch-all
- **Partiel** : Guild/Friends routing paths n'appliquent pas encore le filter (sub-PR éventuelle)

### Client integration
- `src/client/social/IgnoreListUi.{h,cpp}` : presenter avec cache locale + slash commands `/ignore <id>` et `/unignore <id>`
- `src/client/app/Engine` : dispatch opcodes 69/71/73, câble callback
- `src/client/auth/AuthUi` : helper `SendGenericRequestAsync` (déjà ajouté #544)

### V1 limitations
- Résolution par account_id direct (résolution par character_name viendra avec PartySystem display)
- Cap 50 ignored par account déjà appliqué côté IgnoreListManager
- Filter dans Guild/Friends routing : à compléter en sub-PR

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 68-73 + filter ChatRelayHandler. Pas d'impact ancien client.

Generated with Claude Code