### PR TITLE
feat(gmtickets): wire server + client (Phase 5 CMANGOS.32 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ add_library(engine_core
   src/client/mail/MailUi.cpp
   src/client/social/FriendsUi.cpp
   src/client/social/IgnoreListUi.cpp
+  src/client/gmtickets/GmTicketUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
   src/shared/net/ChatSystem.cpp
@@ -332,6 +333,7 @@ add_library(engine_core
   src/client/render/AuthImGuiRenderer.cpp
   src/client/render/ChatImGuiRenderer.cpp
   src/client/render/MailImGuiRenderer.cpp
+  src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp
   src/client/render/DecalPass.cpp
@@ -423,6 +425,7 @@ add_library(engine_core
   src/shared/network/IgnoreListPayloads.cpp
   src/shared/network/MailPayloads.cpp
   src/shared/network/QuestPayloads.cpp
+  src/shared/network/GmTicketPayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
 )
@@ -644,6 +647,11 @@ add_test(NAME quest_payloads_tests COMMAND quest_payloads_tests)
 add_executable(ignore_list_payloads_tests src/shared/network/IgnoreListPayloadsTests.cpp)
 target_link_libraries(ignore_list_payloads_tests PRIVATE engine_core)
 add_test(NAME ignore_list_payloads_tests COMMAND ignore_list_payloads_tests)
+
+# CMANGOS.32 (Phase 5.32 step 3+4): GMTICKET_*_REQUEST/RESPONSE payload round-trip tests
+add_executable(gm_ticket_payloads_tests src/shared/network/GmTicketPayloadsTests.cpp)
+target_link_libraries(gm_ticket_payloads_tests PRIVATE engine_core)
+add_test(NAME gm_ticket_payloads_tests COMMAND gm_ticket_payloads_tests)
 
 # M23.4: Log rotation smoke test (runtime logger)
 add_executable(log_rotation_smoke_tests src/shared/core/LogRotationSmokeTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,9 +115,11 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/mail/MailHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/quest/QuestHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/social/IgnoreListHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/QuestPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/GmTicketPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11,11 +11,13 @@
 #include "src/shared/network/IgnoreListPayloads.h"
 #include "src/shared/network/MailPayloads.h"
 #include "src/shared/network/QuestPayloads.h"
+#include "src/shared/network/GmTicketPayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/client/render/AuthImGuiRenderer.h"
 #include "src/client/render/ChatImGuiRenderer.h"
 #include "src/client/render/MailImGuiRenderer.h"
+#include "src/client/render/GmTicketImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -837,6 +839,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.32 (Phase 5.32 step 3+4) — Init du presenter GmTickets +
+		// cable du send callback. Reception dispatchee dans le push handler
+		// ci-dessous (opcodes 77/79/81/82). Fire-and-forget des requetes
+		// 76/78/80 via SendGenericRequestAsync.
+		if (!m_gmTicketUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] GmTicketUiPresenter init FAILED — support GM desactive");
+		}
+		else
+		{
+			m_gmTicketUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// Chat MVP — câblage bidirectionnel ChatUi <-> AuthUi (master TCP).
 		// Send : ChatUi::SubmitInputLine appelle AuthUi::SendChatAsync sur la connexion master vivante.
 		// Receive : AuthUi::PumpPostAuthEvents dispatche les paquets push (CHAT_RELAY notamment)
@@ -872,6 +889,22 @@ namespace engine
 					m_questUi.RequestQuestList();
 				}
 				LOG_INFO(Core, "[Engine] /quest toggle (visible={})", m_questVisible);
+				return true;
+			}
+			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
+			// pour ouvrir/fermer le panneau Support GM et synchroniser la liste
+			// depuis le master au moment de l'ouverture.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/ticket" || text == "/gmticket"
+				    || text.starts_with("/ticket ") || text.starts_with("/ticket\t")
+				    || text.starts_with("/gmticket ") || text.starts_with("/gmticket\t")))
+			{
+				m_gmTicketsVisible = !m_gmTicketsVisible;
+				if (m_gmTicketsVisible)
+				{
+					m_gmTicketUi.RequestMyTickets();
+				}
+				LOG_INFO(Core, "[Engine] /ticket toggle (visible={})", m_gmTicketsVisible);
 				return true;
 			}
 			// CMANGOS.25 (Phase 3.25 step 3+4) — Slash commands /ignore et /unignore.
@@ -1108,6 +1141,52 @@ namespace engine
 					return;
 				}
 				m_ignoreListUi.OnIgnoreListResponse(*parsed);
+				return;
+			}
+			// CMANGOS.32 (Phase 5.32 step 3+4) — Dispatch des reponses GmTickets
+			// (77/79/81) + push GmTicketResolvedNotification (82).
+			case kOpcodeGmTicketOpenResponse:
+			{
+				auto parsed = ParseGmTicketOpenResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GMTICKET_OPEN_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gmTicketUi.OnOpenResponse(*parsed);
+				return;
+			}
+			case kOpcodeGmTicketListMineResponse:
+			{
+				auto parsed = ParseGmTicketListMineResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GMTICKET_LIST_MINE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gmTicketUi.OnListMineResponse(*parsed);
+				return;
+			}
+			case kOpcodeGmTicketCancelResponse:
+			{
+				auto parsed = ParseGmTicketCancelResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GMTICKET_CANCEL_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gmTicketUi.OnCancelResponse(*parsed);
+				return;
+			}
+			case kOpcodeGmTicketResolvedNotification:
+			{
+				auto parsed = ParseGmTicketResolvedNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GMTICKET_RESOLVED_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gmTicketUi.OnResolvedNotification(*parsed);
 				return;
 			}
 			default:
@@ -3243,6 +3322,7 @@ namespace engine
 		m_authUi.Shutdown();
 		m_chatUi.Shutdown();
 		m_mailUi.Shutdown();
+		m_gmTicketUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3446,6 +3526,12 @@ namespace engine
 				// jour dans le boucle Render plus bas.
 				m_mailImGui = std::make_unique<engine::render::MailImGuiRenderer>();
 				m_mailImGui->SetPresenter(&m_mailUi);
+				// CMANGOS.32 (Phase 5.32 step 3+4) — Renderer ImGui du panneau
+				// Support GM. Partage le contexte ImGui avec auth/chat/mail. Visible
+				// uniquement quand m_gmTicketsVisible (toggle via /ticket). La
+				// taille viewport est mise a jour dans la boucle Render plus bas.
+				m_gmTicketImGui = std::make_unique<engine::render::GmTicketImGuiRenderer>();
+				m_gmTicketImGui->SetPresenter(&m_gmTicketUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -4467,6 +4553,14 @@ namespace engine
 				m_mailImGui->SetEnabled(true);
 				m_mailImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_mailImGui->Render();
+			}
+			// CMANGOS.32 (Phase 5.32 step 3+4) — Render du panneau Support GM si visible.
+			// Le panneau partage la frame ImGui en cours (cf. m_mailImGui ci-dessus).
+			if (m_gmTicketsVisible && m_gmTicketImGui && m_gmTicketUi.IsInitialized())
+			{
+				m_gmTicketImGui->SetEnabled(true);
+				m_gmTicketImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_gmTicketImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -10,6 +10,7 @@
 #include "src/client/mail/MailUi.h"
 #include "src/client/quest/QuestUi.h"
 #include "src/client/social/IgnoreListUi.h"
+#include "src/client/gmtickets/GmTicketUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
@@ -66,6 +67,7 @@ namespace engine::render
 	class AuthImGuiRenderer;
 	class ChatImGuiRenderer;
 	class MailImGuiRenderer;
+	class GmTicketImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -322,6 +324,10 @@ namespace engine
 		/// Partage le contexte ImGui avec m_authImGui / m_chatImGui. Visibilite
 		/// pilotee par \c m_mailVisible (toggle via slash command /mail).
 		std::unique_ptr<engine::render::MailImGuiRenderer> m_mailImGui;
+		/// CMANGOS.32 (Phase 5.32 step 3+4) — Panneau "Support GM" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec m_authImGui / m_chatImGui / m_mailImGui.
+		/// Visibilite pilotee par \c m_gmTicketsVisible (toggle via slash command /ticket).
+		std::unique_ptr<engine::render::GmTicketImGuiRenderer> m_gmTicketImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -401,6 +407,14 @@ namespace engine
 		/// fire-and-forget des requetes 68/70/72 via
 		/// \c m_authUi.SendGenericRequestAsync.
 		engine::client::IgnoreListUiPresenter m_ignoreListUi;
+		/// CMANGOS.32 (Phase 5.32 step 3+4) — Presenter boite a tickets support GM.
+		/// Recoit les reponses opcodes 77/79/81/82 via le push handler du master ;
+		/// fire-and-forget des requetes 76/78/80 via
+		/// \c m_authUi.SendGenericRequestAsync.
+		engine::client::GmTicketUiPresenter m_gmTicketUi;
+		/// CMANGOS.32 (Phase 5.32 step 3+4) — Visibilite du panneau Support GM
+		/// (toggle via slash command \c /ticket ou \c /gmticket). Faux par defaut.
+		bool                                m_gmTicketsVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/gmtickets/GmTicketUi.cpp
+++ b/src/client/gmtickets/GmTicketUi.cpp
@@ -1,0 +1,249 @@
+// CMANGOS.32 (Phase 5.32 step 3+4) — Implementation GmTicketUiPresenter.
+
+#include "src/client/gmtickets/GmTicketUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	GmTicketUiPresenter::~GmTicketUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool GmTicketUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[GmTicketUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_state.layoutValid = true;
+		LOG_INFO(Core, "[GmTicketUiPresenter] Init OK");
+		return true;
+	}
+
+	void GmTicketUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		// Ne pas reset m_send : il est cable une fois au boot et on garde la
+		// reference (Engine::Shutdown sera responsable du teardown ordonne).
+		LOG_INFO(Core, "[GmTicketUiPresenter] Destroyed");
+	}
+
+	void GmTicketUiPresenter::RequestMyTickets()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GmTicketUiPresenter] RequestMyTickets: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGmTicketListMineRequestPayload();
+		m_state.isListLoading = true;
+		if (!m_send(engine::network::kOpcodeGmTicketListMineRequest, payload))
+		{
+			m_state.isListLoading = false;
+			m_state.lastErrorText = "Echec envoi (liste tickets).";
+			LOG_WARN(Net, "[GmTicketUiPresenter] RequestMyTickets: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[GmTicketUiPresenter] GmTicketListMineRequest queued");
+	}
+
+	void GmTicketUiPresenter::OpenTicket(std::string_view body)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GmTicketUiPresenter] OpenTicket: no send callback");
+			return;
+		}
+		// Le renderer doit en principe avoir bloque le bouton si le body est
+		// vide, mais on protege ici aussi : evite un round-trip pour un
+		// BodyEmpty cote serveur.
+		bool hasContent = false;
+		for (char c : body)
+		{
+			const unsigned char uc = static_cast<unsigned char>(c);
+			if (uc > 0x20u) { hasContent = true; break; }
+		}
+		if (!hasContent)
+		{
+			m_state.lastErrorText = "Le texte du ticket est vide.";
+			LOG_WARN(Net, "[GmTicketUiPresenter] OpenTicket: empty body");
+			return;
+		}
+		if (body.size() > engine::network::kMaxGmTicketBodyBytes)
+		{
+			m_state.lastErrorText = "Le texte du ticket est trop long (>4096 octets).";
+			body = body.substr(0, engine::network::kMaxGmTicketBodyBytes);
+		}
+		const auto payload = engine::network::BuildGmTicketOpenRequestPayload(body);
+		if (!m_send(engine::network::kOpcodeGmTicketOpenRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (ouverture ticket).";
+			LOG_WARN(Net, "[GmTicketUiPresenter] OpenTicket: send failed");
+			return;
+		}
+		// On ferme le compose au moment du submit : le serveur repondra plus
+		// tard avec un OpenResponse qui declenchera le refresh de la liste.
+		m_state.isComposeOpen = false;
+		m_state.composeBody.clear();
+		LOG_INFO(Net, "[GmTicketUiPresenter] GmTicketOpenRequest queued (size={})", body.size());
+	}
+
+	void GmTicketUiPresenter::CancelTicket(uint64_t ticketId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GmTicketUiPresenter] CancelTicket: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGmTicketCancelRequestPayload(ticketId);
+		if (!m_send(engine::network::kOpcodeGmTicketCancelRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (annulation).";
+			LOG_WARN(Net, "[GmTicketUiPresenter] CancelTicket: send failed (ticket={})", ticketId);
+			return;
+		}
+		LOG_INFO(Net, "[GmTicketUiPresenter] GmTicketCancelRequest queued (ticket={})", ticketId);
+	}
+
+	void GmTicketUiPresenter::OpenCompose()
+	{
+		if (!m_state.isComposeOpen)
+		{
+			m_state.composeBody.clear();
+		}
+		m_state.isComposeOpen = true;
+		m_state.lastErrorText.clear();
+		LOG_DEBUG(Core, "[GmTicketUiPresenter] OpenCompose");
+	}
+
+	void GmTicketUiPresenter::CloseCompose()
+	{
+		m_state.isComposeOpen = false;
+		// On garde le composeBody : si le joueur reouvre il retrouve sa saisie.
+		LOG_DEBUG(Core, "[GmTicketUiPresenter] CloseCompose");
+	}
+
+	void GmTicketUiPresenter::SetComposeBody(std::string_view body)
+	{
+		m_state.composeBody.assign(body.data(), body.size());
+	}
+
+	// -------------------------------------------------------------------------
+
+	void GmTicketUiPresenter::RebuildMineFromResponse(const engine::network::GmTicketListMineResponsePayload& resp)
+	{
+		m_state.mine.clear();
+		m_state.mine.reserve(resp.tickets.size());
+		for (const auto& t : resp.tickets)
+		{
+			GmTicketEntryView v;
+			v.id           = t.id;
+			v.createdTsMs  = t.createdTsMs;
+			v.resolvedTsMs = t.resolvedTsMs;
+			v.state        = t.state;
+			m_state.mine.push_back(v);
+		}
+	}
+
+	void GmTicketUiPresenter::OnOpenResponse(const engine::network::GmTicketOpenResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			using engine::network::GmTicketErrorCode;
+			switch (static_cast<GmTicketErrorCode>(resp.error))
+			{
+			case GmTicketErrorCode::BodyEmpty:
+				m_state.lastErrorText = "Le texte du ticket est vide.";
+				break;
+			case GmTicketErrorCode::BodyTooLong:
+				m_state.lastErrorText = "Le texte du ticket est trop long (>4096 octets).";
+				break;
+			case GmTicketErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur a l'ouverture du ticket.";
+				break;
+			}
+			LOG_WARN(Net, "[GmTicketUiPresenter] OnOpenResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		// OK : on rafraichit la liste pour faire apparaitre le nouveau ticket.
+		m_state.lastErrorText.clear();
+		LOG_INFO(Net, "[GmTicketUiPresenter] OnOpenResponse: ticketId={}", resp.ticketId);
+		RequestMyTickets();
+	}
+
+	void GmTicketUiPresenter::OnListMineResponse(const engine::network::GmTicketListMineResponsePayload& resp)
+	{
+		m_state.isListLoading = false;
+		if (resp.error != 0u)
+		{
+			using engine::network::GmTicketErrorCode;
+			if (static_cast<GmTicketErrorCode>(resp.error) == GmTicketErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur lors du chargement de la liste.";
+			LOG_WARN(Net, "[GmTicketUiPresenter] OnListMineResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		RebuildMineFromResponse(resp);
+		LOG_INFO(Net, "[GmTicketUiPresenter] OnListMineResponse: {} tickets",
+			m_state.mine.size());
+	}
+
+	void GmTicketUiPresenter::OnCancelResponse(const engine::network::GmTicketCancelResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			using engine::network::GmTicketErrorCode;
+			switch (static_cast<GmTicketErrorCode>(resp.error))
+			{
+			case GmTicketErrorCode::NotFound:
+				m_state.lastErrorText = "Ticket introuvable.";
+				break;
+			case GmTicketErrorCode::NotOwner:
+				m_state.lastErrorText = "Ce ticket ne vous appartient pas.";
+				break;
+			case GmTicketErrorCode::AlreadyResolved:
+				m_state.lastErrorText = "Ticket deja resolu, annulation impossible.";
+				break;
+			case GmTicketErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur a l'annulation.";
+				break;
+			}
+			LOG_WARN(Net, "[GmTicketUiPresenter] OnCancelResponse: server error code={} ticket={}",
+				static_cast<unsigned>(resp.error), resp.ticketId);
+			return;
+		}
+		m_state.lastErrorText.clear();
+		LOG_INFO(Net, "[GmTicketUiPresenter] OnCancelResponse: ticketId={} cancelled", resp.ticketId);
+		// Refresh la liste pour refleter le state Cancelled (ou disparition de
+		// la liste, selon la politique cote serveur).
+		RequestMyTickets();
+	}
+
+	void GmTicketUiPresenter::OnResolvedNotification(const engine::network::GmTicketResolvedNotificationPayload& note)
+	{
+		m_state.lastResolvedNotificationTicketId = note.ticketId;
+		LOG_INFO(Net, "[GmTicketUiPresenter] OnResolvedNotification: ticketId={} resolvedTsMs={}",
+			note.ticketId, note.resolvedTsMs);
+		// Refresh la liste pour mettre a jour l'etat affiche.
+		RequestMyTickets();
+	}
+}

--- a/src/client/gmtickets/GmTicketUi.h
+++ b/src/client/gmtickets/GmTicketUi.h
@@ -1,0 +1,136 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32 step 3+4) — Presenter client de la boite a tickets
+// support GM. Maintient un cache local des tickets ouverts par ce joueur,
+// la composition d'un nouveau ticket, et expose un compose dialog modal.
+//
+// Pas de rendu ImGui : le panneau est drawe par GmTicketImGuiRenderer qui
+// lit l'etat via GetState() et propage les inputs UI via setters/methodes.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans QuestUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes 77/79/81/82 vers
+// les OnXxx du presenter.
+
+#include "src/shared/network/GmTicketPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::client
+{
+	/// Une entree de la liste « mes tickets » exposable au layer UI.
+	/// Mirror direct de GmTicketEntry sur le wire mais avec des champs nommes
+	/// pour le renderer (et eventuellement enrichis a futur, e.g. label
+	/// localise pour state).
+	struct GmTicketEntryView
+	{
+		uint64_t id           = 0;
+		uint64_t createdTsMs  = 0;
+		uint64_t resolvedTsMs = 0;
+		uint8_t  state        = 0; ///< 0=Open, 1=Assigned, 2=Resolved, 3=Cancelled.
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct GmTicketUiState
+	{
+		std::vector<GmTicketEntryView>  mine;
+		std::string                     composeBody;
+		bool                            isComposeOpen   = false;
+		bool                            isListLoading   = false;
+		std::string                     lastErrorText;  ///< Vide si pas d'erreur transitoire.
+		std::optional<uint64_t>         lastResolvedNotificationTicketId; ///< Pour faire clignoter / toast.
+		bool                            layoutValid     = false;
+	};
+
+	/// Presenter pour la boite a tickets cote client. Doit etre Init() avant
+	/// tout usage du callback. Thread : main (comme les autres presenters UI).
+	class GmTicketUiPresenter final
+	{
+	public:
+		GmTicketUiPresenter() = default;
+
+		GmTicketUiPresenter(const GmTicketUiPresenter&)            = delete;
+		GmTicketUiPresenter& operator=(const GmTicketUiPresenter&) = delete;
+
+		~GmTicketUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.32 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback. Mirror du pattern QuestUi/MailUi.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestMyTickets / OpenTicket / CancelTicket.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie GMTICKET_LIST_MINE_REQUEST. Reponse via OnListMineResponse.
+		/// Met aussi m_state.isListLoading = true le temps de la reponse.
+		void RequestMyTickets();
+
+		/// Submit le compose en cours : envoie GMTICKET_OPEN_REQUEST avec
+		/// \p body, ferme le compose dialog. Si m_send est null ou body vide,
+		/// remplit lastErrorText et n'envoie rien.
+		void OpenTicket(std::string_view body);
+
+		/// Envoie GMTICKET_CANCEL_REQUEST pour \p ticketId.
+		void CancelTicket(uint64_t ticketId);
+
+		// ---------------------------------------------------------------------
+		// Compose dialog
+		// ---------------------------------------------------------------------
+
+		/// Ouvre le compose dialog (le renderer lira isComposeOpen). Reset le
+		/// composeBody si le dialog n'etait pas deja ouvert.
+		void OpenCompose();
+
+		/// Ferme le compose dialog (annule la saisie en cours).
+		void CloseCompose();
+
+		/// Met a jour le buffer de saisie depuis l'UI (InputTextMultiline).
+		void SetComposeBody(std::string_view body);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit GMTICKET_OPEN_RESPONSE. Si OK, refresh la liste (RequestMyTickets).
+		void OnOpenResponse(const engine::network::GmTicketOpenResponsePayload& resp);
+
+		/// Recoit GMTICKET_LIST_MINE_RESPONSE. Remplace la cache locale.
+		void OnListMineResponse(const engine::network::GmTicketListMineResponsePayload& resp);
+
+		/// Recoit GMTICKET_CANCEL_RESPONSE. Si OK, refresh la liste.
+		void OnCancelResponse(const engine::network::GmTicketCancelResponsePayload& resp);
+
+		/// Recoit GMTICKET_RESOLVED_NOTIFICATION push : note l'evenement dans
+		/// le state pour faire clignoter / afficher un toast cote renderer, et
+		/// refresh la liste pour mettre a jour l'etat affiche.
+		void OnResolvedNotification(const engine::network::GmTicketResolvedNotificationPayload& note);
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const GmTicketUiState& GetState() const { return m_state; }
+
+	private:
+		/// Met a jour m_state.mine depuis une reponse server.
+		void RebuildMineFromResponse(const engine::network::GmTicketListMineResponsePayload& resp);
+
+		bool                      m_initialized = false;
+		GmTicketUiState           m_state{};
+		SendCallback              m_send;
+	};
+}

--- a/src/client/render/GmTicketImGuiRenderer.cpp
+++ b/src/client/render/GmTicketImGuiRenderer.cpp
@@ -1,0 +1,285 @@
+#include "src/client/render/GmTicketImGuiRenderer.h"
+
+#include "src/client/gmtickets/GmTicketUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Rend une chaine "il y a X minutes/heures/jours" a partir d'un timestamp UTC ms.
+		/// Pour V1 on reste simple : pas d'i18n, hardcode FR. Si timestamp vide ou futur,
+		/// retourne "—".
+		std::string FormatRelativeTime(uint64_t ts)
+		{
+			if (ts == 0)
+				return "-";
+			using namespace std::chrono;
+			const uint64_t nowMs = static_cast<uint64_t>(
+				duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+			if (ts > nowMs)
+				return "a l'instant";
+			const uint64_t deltaMs = nowMs - ts;
+			const uint64_t deltaSec = deltaMs / 1000ull;
+			char buf[64]{};
+			if (deltaSec < 60ull)
+				std::snprintf(buf, sizeof(buf), "il y a %us", static_cast<unsigned>(deltaSec));
+			else if (deltaSec < 3600ull)
+				std::snprintf(buf, sizeof(buf), "il y a %u min", static_cast<unsigned>(deltaSec / 60ull));
+			else if (deltaSec < 86400ull)
+				std::snprintf(buf, sizeof(buf), "il y a %uh", static_cast<unsigned>(deltaSec / 3600ull));
+			else
+				std::snprintf(buf, sizeof(buf), "il y a %uj", static_cast<unsigned>(deltaSec / 86400ull));
+			return buf;
+		}
+
+		/// Convertit l'etat numerique (cf. TicketState) en libelle FR. Le client ne
+		/// connait pas l'enum cote serveur, on duplique ici les 4 valeurs canoniques.
+		const char* StateLabel(uint8_t state)
+		{
+			switch (state)
+			{
+			case 0u: return "Ouvert";
+			case 1u: return "Assigne GM";
+			case 2u: return "Resolu";
+			case 3u: return "Annule";
+			default: return "?";
+			}
+		}
+
+		/// Charge proprement un std::string dans un buffer C-string fixe (avec NUL).
+		void LoadStringIntoBuffer(const std::string& src, char* dst, size_t dstSize)
+		{
+			if (dstSize == 0)
+				return;
+			const size_t n = (src.size() < dstSize - 1) ? src.size() : (dstSize - 1);
+			if (n > 0)
+				std::memcpy(dst, src.data(), n);
+			dst[n] = '\0';
+		}
+	}
+
+	void GmTicketImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderListPanel();
+		RenderComposeDialog();
+	}
+
+	void GmTicketImGuiRenderer::RenderListPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre bottom-right, 500x300.
+		const float panelW = 500.f;
+		const float panelH = 300.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, vpH - panelH - margin);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Support GM##ln_gmtickets_panel", nullptr, flags))
+		{
+			// Banner notification : un GM vient de resoudre un ticket.
+			if (state.lastResolvedNotificationTicketId.has_value())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.9f, 0.4f, 1.f));
+				ImGui::TextWrapped("Un GM a resolu votre ticket #%" PRIu64 ".",
+					*state.lastResolvedNotificationTicketId);
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Erreur transitoire (rouge) — non bloquante.
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Toolbar : Nouveau ticket + Refresh.
+			if (ImGui::Button("Nouveau ticket"))
+			{
+				m_presenter->OpenCompose();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Rafraichir"))
+			{
+				m_presenter->RequestMyTickets();
+			}
+			ImGui::SameLine();
+			ImGui::TextDisabled("(%zu ticket%s)",
+				state.mine.size(), state.mine.size() > 1 ? "s" : "");
+
+			ImGui::Separator();
+
+			if (state.isListLoading)
+			{
+				ImGui::TextUnformatted("Chargement...");
+			}
+			else if (state.mine.empty())
+			{
+				ImGui::TextDisabled("Aucun ticket actif.");
+			}
+			else
+			{
+				const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+					| ImGuiTableFlags_RowBg
+					| ImGuiTableFlags_ScrollY
+					| ImGuiTableFlags_Resizable;
+				const float tableH = 200.f;
+				if (ImGui::BeginTable("##ln_gmtickets_list", 5, tableFlags, ImVec2(0.f, tableH)))
+				{
+					ImGui::TableSetupColumn("ID",     ImGuiTableColumnFlags_WidthFixed,   60.f);
+					ImGui::TableSetupColumn("Cree",   ImGuiTableColumnFlags_WidthFixed,   90.f);
+					ImGui::TableSetupColumn("Etat",   ImGuiTableColumnFlags_WidthFixed,   90.f);
+					ImGui::TableSetupColumn("Resolu", ImGuiTableColumnFlags_WidthFixed,   90.f);
+					ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableHeadersRow();
+
+					for (const auto& t : state.mine)
+					{
+						ImGui::TableNextRow();
+						ImGui::PushID(static_cast<int>(t.id));
+
+						ImGui::TableSetColumnIndex(0);
+						ImGui::Text("#%" PRIu64, t.id);
+
+						ImGui::TableSetColumnIndex(1);
+						ImGui::TextUnformatted(FormatRelativeTime(t.createdTsMs).c_str());
+
+						ImGui::TableSetColumnIndex(2);
+						ImGui::TextUnformatted(StateLabel(t.state));
+
+						ImGui::TableSetColumnIndex(3);
+						if (t.state == 2u && t.resolvedTsMs > 0u)
+							ImGui::TextUnformatted(FormatRelativeTime(t.resolvedTsMs).c_str());
+						else
+							ImGui::TextDisabled("-");
+
+						ImGui::TableSetColumnIndex(4);
+						// Le bouton "Annuler" est dispo seulement quand l'etat
+						// est Ouvert (state == 0). Sur les autres etats, on
+						// laisse vide pour eviter l'attente d'un AlreadyResolved
+						// / NotOwner cote serveur.
+						if (t.state == 0u)
+						{
+							if (ImGui::SmallButton("Annuler"))
+							{
+								m_presenter->CancelTicket(t.id);
+							}
+						}
+						else
+						{
+							ImGui::TextDisabled("-");
+						}
+
+						ImGui::PopID();
+					}
+					ImGui::EndTable();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void GmTicketImGuiRenderer::RenderComposeDialog()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Synchro buffer ImGui <- presenter quand la dialog s'ouvre. Une fois
+		// ouverte on laisse ImGui controller le buffer (push -> presenter via
+		// SetComposeBody chaque frame) sans re-charger l'etat depuis le
+		// presenter sinon on ecraserait la saisie.
+		static bool s_wasOpen = false;
+		if (state.isComposeOpen && !s_wasOpen)
+		{
+			LoadStringIntoBuffer(state.composeBody, m_bodyBuf, sizeof(m_bodyBuf));
+			ImGui::OpenPopup("Nouveau ticket support##ln_gmtickets_compose");
+		}
+		s_wasOpen = state.isComposeOpen;
+
+		// Centre la fenetre modale.
+		ImVec2 center;
+		center.x = (m_viewportW > 0) ? static_cast<float>(m_viewportW) * 0.5f : 640.f;
+		center.y = (m_viewportH > 0) ? static_cast<float>(m_viewportH) * 0.5f : 360.f;
+		ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(520.f, 360.f), ImGuiCond_Appearing);
+
+		if (ImGui::BeginPopupModal("Nouveau ticket support##ln_gmtickets_compose", nullptr,
+			ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::TextWrapped("Decrivez votre probleme avec autant de details que possible "
+				"(personnage, zone, ce qui s'est passe). Un GM le traitera des que possible.");
+			ImGui::Spacing();
+
+			if (ImGui::InputTextMultiline("##ln_gmtickets_body", m_bodyBuf, sizeof(m_bodyBuf),
+				ImVec2(-FLT_MIN, 200.f)))
+			{
+				m_presenter->SetComposeBody(m_bodyBuf);
+			}
+
+			// Compteur d'octets (pas de chars unicode-aware, cote serveur on
+			// limite par octets aussi : <= kMaxGmTicketBodyBytes = 4096).
+			const size_t curBytes = std::strlen(m_bodyBuf);
+			ImGui::TextDisabled("%zu / 4096 octets", curBytes);
+
+			ImGui::Separator();
+			const bool canSend = (curBytes > 0u);
+			if (!canSend) ImGui::BeginDisabled();
+			if (ImGui::Button("Envoyer", ImVec2(120.f, 0.f)))
+			{
+				m_presenter->OpenTicket(m_bodyBuf);
+				m_bodyBuf[0] = '\0';
+				ImGui::CloseCurrentPopup();
+			}
+			if (!canSend) ImGui::EndDisabled();
+			ImGui::SameLine();
+			if (ImGui::Button("Annuler", ImVec2(120.f, 0.f)))
+			{
+				m_presenter->CloseCompose();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void GmTicketImGuiRenderer::Render()             {}
+	void GmTicketImGuiRenderer::RenderListPanel()    {}
+	void GmTicketImGuiRenderer::RenderComposeDialog(){}
+}
+
+#endif

--- a/src/client/render/GmTicketImGuiRenderer.h
+++ b/src/client/render/GmTicketImGuiRenderer.h
@@ -1,0 +1,48 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32 step 3+4) — GmTicketImGuiRenderer : panel ImGui pour
+// la boite a tickets support GM cote joueur. Lit l'etat d'un GmTicketUiPresenter,
+// dispatch les inputs UI vers le presenter via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class GmTicketUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui de la boite a tickets joueur. Pas de logique de fetch /
+	/// parse : celle-ci est dans \ref engine::client::GmTicketUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs UI
+	/// vers le presenter.
+	class GmTicketImGuiRenderer
+	{
+	public:
+		GmTicketImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::GmTicketUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Support GM" + compose dialog (si \c isComposeOpen).
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), apres
+		/// NewFrame, si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		void RenderListPanel();
+		void RenderComposeDialog();
+
+		engine::client::GmTicketUiPresenter* m_presenter = nullptr;
+		bool                                  m_enabled  = false;
+		uint32_t                              m_viewportW = 0;
+		uint32_t                              m_viewportH = 0;
+
+		/// Buffer C-string pour le compose. Synchronise depuis le presenter
+		/// quand le compose s'ouvre, puis push -> presenter via SetComposeBody.
+		char m_bodyBuf[4200]{}; ///< 4096 max + marge NUL/UI.
+	};
+}

--- a/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
+++ b/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
@@ -1,0 +1,295 @@
+// CMANGOS.32 (Phase 5.32 step 3+4) — Implementation GmTicketHandler.
+
+#include "src/masterd/handlers/gmtickets/GmTicketHandler.h"
+
+#include "src/masterd/gmtickets/GmTicketSystem.h"
+#include "src/masterd/gmtickets/MysqlGmTicketStore.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/GmTicketPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Retourne le timestamp UTC en ms (epoch). Sert au createdTsMs du ticket.
+		uint64_t NowMs()
+		{
+			using namespace std::chrono;
+			return static_cast<uint64_t>(
+				duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+		}
+
+		/// Verifie qu'un body de ticket n'est pas vide / blanc. Pas de full
+		/// trim pour autoriser \n et tabulations utiles dans la mise en forme,
+		/// mais on exige au moins un caractere visible.
+		bool BodyHasContent(const std::string& body)
+		{
+			for (char c : body)
+			{
+				const unsigned char uc = static_cast<unsigned char>(c);
+				if (uc > 0x20u) return true;
+			}
+			return false;
+		}
+	}
+
+	void GmTicketHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sys || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[GmTicketHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account. Si l'un manque, on retourne une reponse
+		// type-specific avec error=Unauthorized.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(GmTicketErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeGmTicketOpenRequest:
+				pkt = BuildGmTicketOpenResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGmTicketListMineRequest:
+				pkt = BuildGmTicketListMineResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGmTicketCancelRequest:
+				pkt = BuildGmTicketCancelResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeGmTicketOpenRequest:
+			HandleOpen(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGmTicketListMineRequest:
+			HandleListMine(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGmTicketCancelRequest:
+			HandleCancel(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void GmTicketHandler::HandleOpen(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseGmTicketOpenRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildGmTicketOpenResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::BodyEmpty), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Validation longueur & contenu : BodyTooLong (>4096) > BodyEmpty (vide).
+		if (parsed->body.size() > kMaxGmTicketBodyBytes)
+		{
+			auto pkt = BuildGmTicketOpenResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::BodyTooLong), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[GmTicketHandler] Open BodyTooLong account={} size={}",
+				accountId, parsed->body.size());
+			return;
+		}
+		if (!BodyHasContent(parsed->body))
+		{
+			auto pkt = BuildGmTicketOpenResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::BodyEmpty), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[GmTicketHandler] Open BodyEmpty account={}", accountId);
+			return;
+		}
+
+		const uint64_t nowMs = NowMs();
+		const uint64_t newId = m_sys->Open(accountId, parsed->body, nowMs);
+
+		// Persistance best-effort : si dispo, on insere une copie dans la table.
+		// Le system in-memory reste l'autorite runtime ; la perte au reboot est
+		// rattrapee lors d'un futur reload (PR ulterieure).
+		if (m_store)
+		{
+			engine::server::gmtickets::GmTicket toInsert;
+			toInsert.id           = newId;
+			toInsert.reporter     = accountId;
+			toInsert.body         = parsed->body;
+			toInsert.createdTsMs  = nowMs;
+			toInsert.state        = engine::server::gmtickets::TicketState::Open;
+			const uint64_t persistedId = m_store->Insert(toInsert);
+			if (persistedId == 0u)
+			{
+				LOG_WARN(Net, "[GmTicketHandler] Open Insert failed (account={}, ticketMem={})",
+					accountId, newId);
+			}
+		}
+
+		LOG_INFO(Net, "[GmTicketHandler] Open account={} newId={} bodySize={}",
+			accountId, newId, parsed->body.size());
+
+		auto pkt = BuildGmTicketOpenResponsePacket(0u, newId, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void GmTicketHandler::HandleListMine(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		// V1 : le system n'expose pas de ListByReporter dedie ; on reutilise
+		// OpenQueue() (queue support runtime) et on filtre cote handler. Suffisant
+		// pour M tickets ouverts << N joueurs ; si volumetrie augmente on ajoutera
+		// un index inverse reporter -> tickets dans GmTicketSystem.
+		const auto openTickets = m_sys->OpenQueue();
+		std::vector<GmTicketEntry> entries;
+		entries.reserve(openTickets.size());
+		for (const auto& t : openTickets)
+		{
+			if (t.reporter != accountId)
+				continue;
+			GmTicketEntry e;
+			e.id           = t.id;
+			e.createdTsMs  = t.createdTsMs;
+			e.resolvedTsMs = t.resolvedTsMs;
+			e.state        = static_cast<uint8_t>(t.state);
+			entries.push_back(e);
+		}
+
+		LOG_INFO(Net, "[GmTicketHandler] ListMine account={} count={}",
+			accountId, entries.size());
+
+		auto pkt = BuildGmTicketListMineResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void GmTicketHandler::HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseGmTicketCancelRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildGmTicketCancelResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::NotFound), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint64_t ticketId = parsed->ticketId;
+		auto found = m_sys->Find(ticketId);
+		if (!found)
+		{
+			auto pkt = BuildGmTicketCancelResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::NotFound), ticketId,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[GmTicketHandler] Cancel NotFound account={} ticket={}",
+				accountId, ticketId);
+			return;
+		}
+
+		// Ownership : seul le reporter peut cancel son ticket cote joueur.
+		if (found->reporter != accountId)
+		{
+			auto pkt = BuildGmTicketCancelResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::NotOwner), ticketId,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[GmTicketHandler] Cancel NotOwner account={} ticket={} reporter={}",
+				accountId, ticketId, found->reporter);
+			return;
+		}
+
+		// On refuse de cancel un ticket deja Resolved (l'admin l'a clos cote GM).
+		if (found->state == engine::server::gmtickets::TicketState::Resolved)
+		{
+			auto pkt = BuildGmTicketCancelResponsePacket(
+				static_cast<uint8_t>(GmTicketErrorCode::AlreadyResolved), ticketId,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[GmTicketHandler] Cancel AlreadyResolved account={} ticket={}",
+				accountId, ticketId);
+			return;
+		}
+
+		// Tolere le double-cancel : Cancel sur un ticket Cancelled retourne Ok
+		// (idempotent cote client). Le system::Cancel reset l'etat, le store
+		// le reflete avec Update best-effort.
+		const bool changed = m_sys->Cancel(ticketId);
+		(void)changed;
+
+		if (m_store)
+		{
+			// Recharge la copie a jour depuis le system (state == Cancelled apres
+			// Cancel) et persist. Si l'Update echoue, on logue mais on ne rollback
+			// pas : la queue runtime est l'autorite.
+			auto updated = m_sys->Find(ticketId);
+			if (updated)
+			{
+				if (!m_store->Update(*updated))
+				{
+					LOG_WARN(Net, "[GmTicketHandler] Cancel Update failed (account={}, ticket={})",
+						accountId, ticketId);
+				}
+			}
+		}
+
+		LOG_INFO(Net, "[GmTicketHandler] Cancel account={} ticket={} ok",
+			accountId, ticketId);
+
+		auto pkt = BuildGmTicketCancelResponsePacket(0u, ticketId, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+}

--- a/src/masterd/handlers/gmtickets/GmTicketHandler.h
+++ b/src/masterd/handlers/gmtickets/GmTicketHandler.h
@@ -1,0 +1,89 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32 step 3+4) — GmTicketHandler : dispatch des opcodes
+// GmTickets cote joueur (76/78/80) et appel des methodes correspondantes du
+// GmTicketSystem (autorite runtime in-memory) + persistance via
+// MysqlGmTicketStore (best-effort).
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 76/78/80 (les requests). Les responses sont emises avec le meme
+// requestId / sessionId que la request recue.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 6 dans la reponse type-specific, plus exploitable
+// cote UI support qu'un BAD_REQUEST generique).
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::gmtickets
+{
+	class GmTicketSystem;
+	class MysqlGmTicketStore;
+}
+
+namespace engine::server
+{
+	/// Dispatcher GmTickets cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class GmTicketHandler
+	{
+	public:
+		/// Branche le system in-memory (autorite runtime des tickets).
+		void SetSystem(engine::server::gmtickets::GmTicketSystem* sys) { m_sys = sys; }
+		/// Branche le store MySQL (persistance audit). Optionnel : si nullptr,
+		/// le handler reste fonctionnel mais ne persiste pas en DB (mode no-DB).
+		void SetStore(engine::server::gmtickets::MysqlGmTicketStore* store) { m_store = store; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes GmTickets. Dispatch
+		/// vers HandleOpen/HandleListMine/HandleCancel selon l'opcode. Si l'opcode
+		/// n'est pas un opcode GmTickets, ignore silencieusement (filtrage deja
+		/// fait cote main_linux).
+		///
+		/// \param connId         identifiant de connexion TCP (pour Send response).
+		/// \param opcode         opcode du paquet entrant (76/78/80).
+		/// \param requestId      request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload        pointeur sur le payload (sans header).
+		/// \param payloadSize    taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// Traite GMTICKET_OPEN_REQUEST : valide body, system->Open + store->Insert.
+		void HandleOpen(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GMTICKET_LIST_MINE_REQUEST : itere la queue ouverte du system
+		/// et filtre par reporter == accountId.
+		void HandleListMine(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GMTICKET_CANCEL_REQUEST : verifie ownership + state, appelle
+		/// system->Cancel + store->Update best-effort.
+		void HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		engine::server::gmtickets::GmTicketSystem*       m_sys        = nullptr;
+		engine::server::gmtickets::MysqlGmTicketStore*   m_store      = nullptr;
+		NetServer*                                        m_server     = nullptr;
+		SessionManager*                                   m_sessionMgr = nullptr;
+		ConnectionSessionMap*                             m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -43,6 +43,9 @@
 #include "src/masterd/handlers/social/IgnoreListHandler.h"
 #include "src/masterd/social/IgnoreList.h"
 #include "src/masterd/social/MysqlIgnoreStore.h"
+#include "src/masterd/handlers/gmtickets/GmTicketHandler.h"
+#include "src/masterd/gmtickets/GmTicketSystem.h"
+#include "src/masterd/gmtickets/MysqlGmTicketStore.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
 #include "src/shared/core/Config.h"
@@ -408,6 +411,28 @@ int main(int argc, char** argv)
 		LOG_WARN(Net, "[ServerMain] IgnoreListHandler skipped (DB pool unavailable)");
 	}
 
+	// CMANGOS.32 (Phase 5.32 step 3+4) — GmTickets wire server.
+	// Le system in-memory est l'autorite runtime des tickets ouverts. Le store
+	// MySQL sert de persistance audit (et future reload au login). En mode
+	// no-DB on garde le system mais on saute le store : la perte au reboot
+	// est acceptable pour cette MVP (le client redemandera la liste).
+	engine::server::gmtickets::GmTicketSystem gmTicketSystem;
+	engine::server::gmtickets::MysqlGmTicketStore gmTicketStore(&dbPool);
+	engine::server::GmTicketHandler gmTicketHandler;
+	gmTicketHandler.SetSystem(&gmTicketSystem);
+	gmTicketHandler.SetServer(&server);
+	gmTicketHandler.SetSessionManager(&sessionManager);
+	gmTicketHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		gmTicketHandler.SetStore(&gmTicketStore);
+		LOG_INFO(Net, "[ServerMain] GmTicketHandler configured with DB store (CMANGOS.32 step 3+4)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] GmTicketHandler running in no-DB mode (no persistence)");
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -447,7 +472,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -489,6 +514,10 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeIgnoreRemoveRequest
 		      || opcode == kOpcodeIgnoreListRequest)
 			ignoreListHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeGmTicketOpenRequest
+		      || opcode == kOpcodeGmTicketListMineRequest
+		      || opcode == kOpcodeGmTicketCancelRequest)
+			gmTicketHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/GmTicketPayloads.cpp
+++ b/src/shared/network/GmTicketPayloads.cpp
@@ -1,0 +1,303 @@
+// CMANGOS.32 (Phase 5.32 step 3+4) — Implementation Parse/Build des payloads GmTickets.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     cote client pour les requests (envoye via SendGenericRequestAsync qui
+//     ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send. Le requestId
+//     vient du paquet d'origine (cf. RequestResponseDispatcher).
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/GmTicketPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Helper : construit un payload dans un buffer scratch dimensionne a la
+		/// limite protocole, puis le tronque a l'offset reel. Evite de penser a
+		/// la taille exacte d'avance pour les payloads contenant des strings/vector.
+		std::vector<uint8_t> MakeScratchBuffer()
+		{
+			return std::vector<uint8_t>(kProtocolV1MaxPacketSize, 0u);
+		}
+
+		/// Ecrit (uint8 error, uint64 ticketId). Mutualise pour les responses
+		/// Open (77) et Cancel (81) qui partagent le meme format.
+		bool WriteSimpleErrorAndTicket(ByteWriter& w, uint8_t error, uint64_t ticketId)
+		{
+			if (!w.WriteBytes(&error, 1u)) return false;
+			if (!w.WriteU64(ticketId))     return false;
+			return true;
+		}
+
+		/// Lit (uint8 error, uint64 ticketId). Symetrique de WriteSimpleErrorAndTicket.
+		bool ReadSimpleErrorAndTicket(ByteReader& r, uint8_t& error, uint64_t& ticketId)
+		{
+			if (!r.ReadBytes(&error, 1u)) return false;
+			if (!r.ReadU64(ticketId))     return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// GMTICKET_OPEN
+	// -------------------------------------------------------------------------
+
+	std::optional<GmTicketOpenRequestPayload> ParseGmTicketOpenRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint16 body_len (2). Body peut etre vide cote wire (le serveur
+		// retournera BodyEmpty), c'est mieux qu'un parse failure pour avoir un
+		// retour codifie.
+		if (!payload || payloadSize < 2u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketOpenRequestPayload out;
+		if (!r.ReadString(out.body))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketOpenRequestPayload(std::string_view body)
+	{
+		// Tronque defensivement avant l'appel ByteWriter pour eviter qu'une string
+		// > kProtocolV1MaxStringLength fasse echouer WriteString.
+		if (body.size() > kMaxGmTicketBodyBytes)
+			body = body.substr(0, kMaxGmTicketBodyBytes);
+
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteString(body))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<GmTicketOpenResponsePayload> ParseGmTicketOpenResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 ticketId (8) = 9 octets.
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketOpenResponsePayload out;
+		if (!ReadSimpleErrorAndTicket(r, out.error, out.ticketId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketOpenResponsePayload(uint8_t error, uint64_t ticketId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSimpleErrorAndTicket(w, error, ticketId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGmTicketOpenResponsePacket(uint8_t error, uint64_t ticketId,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSimpleErrorAndTicket(w, error, ticketId))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGmTicketOpenResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GMTICKET_LIST_MINE
+	// -------------------------------------------------------------------------
+
+	std::optional<GmTicketListMineRequestPayload> ParseGmTicketListMineRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte (0 octet ou plus, ignore le reste).
+		return GmTicketListMineRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildGmTicketListMineRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	namespace
+	{
+		/// Serialise la partie « apres error » de GMTICKET_LIST_MINE_RESPONSE.
+		bool WriteListMineBody(ByteWriter& w, uint8_t error, const std::vector<GmTicketEntry>& tickets)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(tickets.size())))
+				return false;
+			for (const auto& t : tickets)
+			{
+				if (!w.WriteU64(t.id))             return false;
+				if (!w.WriteU64(t.createdTsMs))    return false;
+				if (!w.WriteU64(t.resolvedTsMs))   return false;
+				if (!w.WriteBytes(&t.state, 1u))   return false;
+			}
+			return true;
+		}
+	}
+
+	std::optional<GmTicketListMineResponsePayload> ParseGmTicketListMineResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketListMineResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.tickets.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GmTicketEntry t;
+			if (!r.ReadU64(t.id))             return std::nullopt;
+			if (!r.ReadU64(t.createdTsMs))    return std::nullopt;
+			if (!r.ReadU64(t.resolvedTsMs))   return std::nullopt;
+			if (!r.ReadBytes(&t.state, 1u))   return std::nullopt;
+			out.tickets.push_back(t);
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketListMineResponsePayload(uint8_t error, const std::vector<GmTicketEntry>& tickets)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListMineBody(w, error, tickets))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGmTicketListMineResponsePacket(uint8_t error, const std::vector<GmTicketEntry>& tickets,
+	                                                         uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListMineBody(w, error, tickets))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGmTicketListMineResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GMTICKET_CANCEL
+	// -------------------------------------------------------------------------
+
+	std::optional<GmTicketCancelRequestPayload> ParseGmTicketCancelRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketCancelRequestPayload out;
+		if (!r.ReadU64(out.ticketId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketCancelRequestPayload(uint64_t ticketId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(ticketId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<GmTicketCancelResponsePayload> ParseGmTicketCancelResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 9u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketCancelResponsePayload out;
+		if (!ReadSimpleErrorAndTicket(r, out.error, out.ticketId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketCancelResponsePayload(uint8_t error, uint64_t ticketId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSimpleErrorAndTicket(w, error, ticketId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGmTicketCancelResponsePacket(uint8_t error, uint64_t ticketId,
+	                                                       uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSimpleErrorAndTicket(w, error, ticketId))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGmTicketCancelResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GMTICKET_RESOLVED_NOTIFICATION (push, request_id=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<GmTicketResolvedNotificationPayload> ParseGmTicketResolvedNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint64 ticketId (8) + uint64 resolvedTsMs (8) = 16 octets.
+		if (!payload || payloadSize < 16u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GmTicketResolvedNotificationPayload out;
+		if (!r.ReadU64(out.ticketId))     return std::nullopt;
+		if (!r.ReadU64(out.resolvedTsMs)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGmTicketResolvedNotificationPayload(uint64_t ticketId, uint64_t resolvedTsMs)
+	{
+		std::vector<uint8_t> buf(16u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(ticketId))     return {};
+		if (!w.WriteU64(resolvedTsMs)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGmTicketResolvedNotificationPacket(uint64_t ticketId, uint64_t resolvedTsMs,
+	                                                              uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(ticketId))     return {};
+		if (!w.WriteU64(resolvedTsMs)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0 (pas de request en correspondance cote client).
+		if (!builder.Finalize(kOpcodeGmTicketResolvedNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/GmTicketPayloads.h
+++ b/src/shared/network/GmTicketPayloads.h
@@ -1,0 +1,171 @@
+#pragma once
+// CMANGOS.32 (Phase 5.32 step 3+4) — Wire payloads pour les opcodes GmTickets (76-82).
+//
+// Trois paires Request/Response + 1 push :
+//   - Open      (76/77)
+//   - ListMine  (78/79)
+//   - Cancel    (80/81)
+//   - ResolvedNotification (82) — Master->Client push asynchrone (request_id=0)
+//     pour annoncer qu'un GM a resolu un ticket de ce joueur.
+//
+// Format wire : ByteReader/ByteWriter little-endian, strings length-prefixed
+// UTF-8 (uint16 length puis octets bruts), vectors prefixes par un uint16 count
+// via WriteArrayCount/ReadArrayCount (cf. ProtocolV1).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level. Mapping cote serveur depuis l'API
+	// GmTicketSystem (Open / Cancel) + checks a l'arrivee.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes GmTickets.
+	/// 0 = OK ; sinon ticketId == 0 ou tableau vide selon la nature de l'erreur.
+	enum class GmTicketErrorCode : uint8_t
+	{
+		Ok               = 0,
+		BodyEmpty        = 1,  ///< body est vide ou ne contient que du whitespace.
+		BodyTooLong      = 2,  ///< body > kMaxGmTicketBodyBytes.
+		NotFound         = 3,  ///< ticketId inconnu cote serveur.
+		NotOwner         = 4,  ///< le joueur tente de cancel un ticket pas le sien.
+		AlreadyResolved  = 5,  ///< tentative de cancel sur un ticket Resolved (pas annulable).
+		Unauthorized     = 6,  ///< pas de session valide cote master.
+	};
+
+	/// Plafond canonique du body d'un ticket. Au-dela, le serveur retourne
+	/// BodyTooLong et le client doit tronquer ou refuser cote UI.
+	inline constexpr size_t kMaxGmTicketBodyBytes = 4096u;
+
+	// =========================================================================
+	// GMTICKET_OPEN — Client -> Master : ouvre un nouveau ticket support.
+	// =========================================================================
+
+	/// Wire format : string body.
+	struct GmTicketOpenRequestPayload
+	{
+		std::string body;
+	};
+
+	/// Wire format :
+	///   uint8  error      (cf. GmTicketErrorCode)
+	///   uint64 ticketId   (0 si error != Ok)
+	struct GmTicketOpenResponsePayload
+	{
+		uint8_t  error    = 0;
+		uint64_t ticketId = 0;
+	};
+
+	// =========================================================================
+	// GMTICKET_LIST_MINE — Client -> Master : liste les tickets de ce joueur.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct GmTicketListMineRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entree resumee de la liste de tickets ouverts par le joueur.
+	/// Le body n'est pas renvoye (economise la bande passante) — V1 affiche
+	/// uniquement etat + horodatage cote UI joueur. Si besoin futur d'afficher
+	/// le body relu, ajouter une opcode GmTicketReadRequest dediee.
+	struct GmTicketEntry
+	{
+		uint64_t id            = 0;
+		uint64_t createdTsMs   = 0;
+		uint64_t resolvedTsMs  = 0;
+		uint8_t  state         = 0; ///< 0=Open, 1=Assigned, 2=Resolved, 3=Cancelled.
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 count          (si error == 0)
+	///   <count> entries       (8 + 8 + 8 + 1 = 25 octets chacune)
+	struct GmTicketListMineResponsePayload
+	{
+		uint8_t                     error = 0;
+		std::vector<GmTicketEntry>  tickets;
+	};
+
+	// =========================================================================
+	// GMTICKET_CANCEL — Client -> Master : annule son propre ticket.
+	// =========================================================================
+
+	/// Wire format : uint64 ticketId.
+	struct GmTicketCancelRequestPayload
+	{
+		uint64_t ticketId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 ticketId  (echo de la request)
+	struct GmTicketCancelResponsePayload
+	{
+		uint8_t  error    = 0;
+		uint64_t ticketId = 0;
+	};
+
+	// =========================================================================
+	// GMTICKET_RESOLVED_NOTIFICATION — Master -> Client (push, request_id=0).
+	// Annonce qu'un GM a resolu un ticket de ce joueur (api admin server-side).
+	// =========================================================================
+
+	/// Wire format : uint64 ticketId + uint64 resolvedTsMs (16 octets).
+	struct GmTicketResolvedNotificationPayload
+	{
+		uint64_t ticketId     = 0;
+		uint64_t resolvedTsMs = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un GMTICKET_OPEN_REQUEST.
+	/// \return nullopt si le payload est tronque ou malforme.
+	std::optional<GmTicketOpenRequestPayload>     ParseGmTicketOpenRequestPayload    (const uint8_t* payload, size_t payloadSize);
+	/// Parse le payload d'un GMTICKET_LIST_MINE_REQUEST. Toujours OK (payload vide accepte).
+	std::optional<GmTicketListMineRequestPayload> ParseGmTicketListMineRequestPayload(const uint8_t* payload, size_t payloadSize);
+	/// Parse le payload d'un GMTICKET_CANCEL_REQUEST. \return nullopt si payloadSize < 8.
+	std::optional<GmTicketCancelRequestPayload>   ParseGmTicketCancelRequestPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGmTicketOpenRequestPayload    (std::string_view body);
+	std::vector<uint8_t> BuildGmTicketListMineRequestPayload();
+	std::vector<uint8_t> BuildGmTicketCancelRequestPayload  (uint64_t ticketId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<GmTicketOpenResponsePayload>          ParseGmTicketOpenResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<GmTicketListMineResponsePayload>      ParseGmTicketListMineResponsePayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<GmTicketCancelResponsePayload>        ParseGmTicketCancelResponsePayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<GmTicketResolvedNotificationPayload>  ParseGmTicketResolvedNotificationPayload (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGmTicketOpenResponsePayload         (uint8_t error, uint64_t ticketId);
+	std::vector<uint8_t> BuildGmTicketListMineResponsePayload     (uint8_t error, const std::vector<GmTicketEntry>& tickets);
+	std::vector<uint8_t> BuildGmTicketCancelResponsePayload       (uint8_t error, uint64_t ticketId);
+	std::vector<uint8_t> BuildGmTicketResolvedNotificationPayload (uint64_t ticketId, uint64_t resolvedTsMs);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildGmTicketOpenResponsePacket     (uint8_t error, uint64_t ticketId,
+	                                                          uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGmTicketListMineResponsePacket (uint8_t error, const std::vector<GmTicketEntry>& tickets,
+	                                                          uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGmTicketCancelResponsePacket   (uint8_t error, uint64_t ticketId,
+	                                                          uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildGmTicketResolvedNotificationPacket(uint64_t ticketId, uint64_t resolvedTsMs,
+	                                                             uint64_t sessionIdHeader);
+}

--- a/src/shared/network/GmTicketPayloadsTests.cpp
+++ b/src/shared/network/GmTicketPayloadsTests.cpp
@@ -1,0 +1,289 @@
+/**
+ * CMANGOS.32 (Phase 5.32 step 3+4) — Round-trip tests for GMTICKET_*_REQUEST /
+ * GMTICKET_*_RESPONSE / GMTICKET_RESOLVED_NOTIFICATION payloads. Pure encoding
+ * tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ *
+ * Test policy : symetrique aux QuestPayloadsTests.cpp — pas de framework de
+ * test externe, juste un Assert local + main() qui appelle chaque suite.
+ */
+
+#include "src/shared/network/GmTicketPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// GMTICKET_OPEN
+// -----------------------------------------------------------------------------
+
+static void TestOpenRequestRoundTrip()
+{
+	const std::string body = "Bonjour GM, mon perso est bloque sous la map au respawn de Goblin Cave.";
+	auto buf = BuildGmTicketOpenRequestPayload(body);
+	Assert(!buf.empty(), "Open request payload not empty");
+	auto parsed = ParseGmTicketOpenRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Open request parses OK");
+	if (parsed)
+		Assert(parsed->body == body, "Open request body round-trips");
+}
+
+static void TestOpenRequestEmptyBody()
+{
+	auto buf = BuildGmTicketOpenRequestPayload("");
+	Assert(buf.size() == 2u, "Empty body == 2 bytes (uint16 length=0)");
+	auto parsed = ParseGmTicketOpenRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->body.empty(), "Empty body round-trips");
+}
+
+static void TestOpenRequestRejectsShort()
+{
+	auto parsed = ParseGmTicketOpenRequestPayload(nullptr, 2u);
+	Assert(!parsed.has_value(), "Open request rejects nullptr");
+	uint8_t one[1]{0};
+	auto parsed2 = ParseGmTicketOpenRequestPayload(one, 1u);
+	Assert(!parsed2.has_value(), "Open request rejects 1 byte");
+}
+
+static void TestOpenRequestTruncatesAtMax()
+{
+	std::string huge(kMaxGmTicketBodyBytes + 100u, 'X');
+	auto buf = BuildGmTicketOpenRequestPayload(huge);
+	auto parsed = ParseGmTicketOpenRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Build accepts oversize body (truncates)");
+	if (parsed)
+		Assert(parsed->body.size() == kMaxGmTicketBodyBytes, "Body truncated at kMaxGmTicketBodyBytes");
+}
+
+static void TestOpenResponseRoundTrip()
+{
+	auto buf = BuildGmTicketOpenResponsePayload(0u, 12345ull);
+	Assert(buf.size() == 9u, "Open response is 9 bytes (1 + 8)");
+	auto parsed = ParseGmTicketOpenResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Open response parses OK");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Open response error 0");
+		Assert(parsed->ticketId == 12345ull, "Open response ticketId");
+	}
+}
+
+static void TestOpenResponseError()
+{
+	auto buf = BuildGmTicketOpenResponsePayload(
+		static_cast<uint8_t>(GmTicketErrorCode::BodyTooLong), 0u);
+	auto parsed = ParseGmTicketOpenResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Open BodyTooLong decodes");
+}
+
+static void TestOpenResponsePacket()
+{
+	auto pkt = BuildGmTicketOpenResponsePacket(0u, 999ull, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Open response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGmTicketOpenResponse, "Packet opcode is GmTicketOpenResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseGmTicketOpenResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->ticketId == 999ull, "Open response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GMTICKET_LIST_MINE
+// -----------------------------------------------------------------------------
+
+static void TestListMineRequestRoundTrip()
+{
+	auto buf = BuildGmTicketListMineRequestPayload();
+	Assert(buf.empty(), "ListMine request payload empty");
+	auto parsed = ParseGmTicketListMineRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "ListMine request accepts empty payload");
+}
+
+static void TestListMineResponseEmpty()
+{
+	auto buf = BuildGmTicketListMineResponsePayload(0u, {});
+	auto parsed = ParseGmTicketListMineResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ListMine response empty parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "ListMine response empty error 0");
+		Assert(parsed->tickets.empty(), "ListMine response empty has 0 tickets");
+	}
+}
+
+static void TestListMineResponseUnauthorized()
+{
+	auto buf = BuildGmTicketListMineResponsePayload(
+		static_cast<uint8_t>(GmTicketErrorCode::Unauthorized), {});
+	auto parsed = ParseGmTicketListMineResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "ListMine response Unauthorized");
+}
+
+static void TestListMineResponseMultiple()
+{
+	std::vector<GmTicketEntry> entries;
+	entries.push_back({1ull, 1000ull, 0ull, 0u}); // Open
+	entries.push_back({2ull, 2000ull, 0ull, 1u}); // Assigned
+	entries.push_back({100ull, 3000ull, 4000ull, 2u}); // Resolved
+	auto buf = BuildGmTicketListMineResponsePayload(0u, entries);
+	auto parsed = ParseGmTicketListMineResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ListMine response multiple parses");
+	if (parsed && parsed->tickets.size() == 3u)
+	{
+		Assert(parsed->tickets[0].id == 1ull && parsed->tickets[0].state == 0u, "entry[0]");
+		Assert(parsed->tickets[1].id == 2ull && parsed->tickets[1].state == 1u, "entry[1]");
+		Assert(parsed->tickets[2].id == 100ull && parsed->tickets[2].resolvedTsMs == 4000ull, "entry[2]");
+	}
+	else
+	{
+		Assert(false, "ListMine response should have 3 entries");
+	}
+}
+
+static void TestListMineResponsePacket()
+{
+	std::vector<GmTicketEntry> entries;
+	entries.push_back({42ull, 1234ull, 0ull, 0u});
+	auto pkt = BuildGmTicketListMineResponsePacket(0u, entries, 7u, 0xDEADull);
+	Assert(!pkt.empty(), "ListMine response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "ListMine PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGmTicketListMineResponse, "Packet opcode is GmTicketListMineResponse");
+	Assert(view.RequestId() == 7u, "RequestId preserved");
+	auto parsed = ParseGmTicketListMineResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->tickets.size() == 1u, "ListMine response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GMTICKET_CANCEL
+// -----------------------------------------------------------------------------
+
+static void TestCancelRequestRoundTrip()
+{
+	auto buf = BuildGmTicketCancelRequestPayload(42ull);
+	Assert(buf.size() == 8u, "Cancel request is 8 bytes");
+	auto parsed = ParseGmTicketCancelRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->ticketId == 42ull, "Cancel request round-trips");
+}
+
+static void TestCancelRequestRejectsShort()
+{
+	auto parsed = ParseGmTicketCancelRequestPayload(nullptr, 8u);
+	Assert(!parsed.has_value(), "Cancel request rejects nullptr");
+	uint8_t shortBuf[7]{};
+	auto parsed2 = ParseGmTicketCancelRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Cancel request rejects 7 bytes");
+}
+
+static void TestCancelResponseRoundTrip()
+{
+	auto buf = BuildGmTicketCancelResponsePayload(0u, 42ull);
+	auto parsed = ParseGmTicketCancelResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->ticketId == 42ull, "Cancel response round-trips");
+}
+
+static void TestCancelResponseAlreadyResolved()
+{
+	auto buf = BuildGmTicketCancelResponsePayload(
+		static_cast<uint8_t>(GmTicketErrorCode::AlreadyResolved), 42ull);
+	auto parsed = ParseGmTicketCancelResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 5u, "Cancel AlreadyResolved decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GMTICKET_RESOLVED_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestResolvedNotificationRoundTrip()
+{
+	auto buf = BuildGmTicketResolvedNotificationPayload(99ull, 12345678ull);
+	Assert(buf.size() == 16u, "ResolvedNotification is 16 bytes");
+	auto parsed = ParseGmTicketResolvedNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ResolvedNotification parses");
+	if (parsed)
+	{
+		Assert(parsed->ticketId == 99ull, "ResolvedNotification ticketId");
+		Assert(parsed->resolvedTsMs == 12345678ull, "ResolvedNotification resolvedTsMs");
+	}
+}
+
+static void TestResolvedNotificationPacket()
+{
+	auto pkt = BuildGmTicketResolvedNotificationPacket(99ull, 555ull, 0xCAFEull);
+	Assert(!pkt.empty(), "ResolvedNotification packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "ResolvedNotification PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGmTicketResolvedNotification, "Opcode is GmTicketResolvedNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseGmTicketResolvedNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->ticketId == 99ull, "ResolvedNotification payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// Boundary
+// -----------------------------------------------------------------------------
+
+static void TestBoundaryTicketId()
+{
+	auto buf = BuildGmTicketCancelRequestPayload(0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseGmTicketCancelRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->ticketId == 0xFFFFFFFFFFFFFFFFull, "ticketId max round-trips");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestOpenRequestRoundTrip();
+	TestOpenRequestEmptyBody();
+	TestOpenRequestRejectsShort();
+	TestOpenRequestTruncatesAtMax();
+	TestOpenResponseRoundTrip();
+	TestOpenResponseError();
+	TestOpenResponsePacket();
+
+	TestListMineRequestRoundTrip();
+	TestListMineResponseEmpty();
+	TestListMineResponseUnauthorized();
+	TestListMineResponseMultiple();
+	TestListMineResponsePacket();
+
+	TestCancelRequestRoundTrip();
+	TestCancelRequestRejectsShort();
+	TestCancelResponseRoundTrip();
+	TestCancelResponseAlreadyResolved();
+
+	TestResolvedNotificationRoundTrip();
+	TestResolvedNotificationPacket();
+
+	TestBoundaryTicketId();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all gm ticket payload tests passed\n" : "[FAIL] some gm ticket tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -252,4 +252,27 @@ namespace engine::network
 	constexpr uint16_t kOpcodeIgnoreRemoveResponse = 71u; ///< Master→Client : OK ou NotIgnored.
 	constexpr uint16_t kOpcodeIgnoreListRequest    = 72u; ///< Client→Master : demande la liste complète des account_id ignorés (vide).
 	constexpr uint16_t kOpcodeIgnoreListResponse   = 73u; ///< Master→Client : tableau d'account_id ignorés ou Unauthorized.
+
+		// -------------------------------------------------------------------------
+		// Opcodes GmTickets (valeurs 76-82)
+		// Reference : Phase 5 CMANGOS.32 step 3+4. Wire client->master pour le
+		// support GM. Le step 1 (GmTicketSystem header-only) et le step 2
+		// (MysqlGmTicketStore + migration 0046) sont deja merges. Cette serie
+		// expose les operations cote joueur au client via 3 paires request/response
+		// + 1 push notification :
+		//   - Open   (76/77)               : le joueur ouvre un nouveau ticket support.
+		//   - ListMine (78/79)             : le joueur liste ses propres tickets ouverts.
+		//   - Cancel (80/81)               : le joueur annule son propre ticket.
+		//   - ResolvedNotification (82, push) : le master notifie le joueur quand
+		//     un GM a resolu son ticket.
+		// La V1 ne couvre pas l'UI GM cote support (admin tools, viendra plus tard).
+		// -------------------------------------------------------------------------
+
+		constexpr uint16_t kOpcodeGmTicketOpenRequest          = 76u; ///< Client to Master : ouvre un nouveau ticket (body texte).
+		constexpr uint16_t kOpcodeGmTicketOpenResponse         = 77u; ///< Master to Client : OK + ticketId, ou BodyEmpty / BodyTooLong.
+		constexpr uint16_t kOpcodeGmTicketListMineRequest      = 78u; ///< Client to Master : liste les tickets ouverts par ce joueur (vide).
+		constexpr uint16_t kOpcodeGmTicketListMineResponse     = 79u; ///< Master to Client : tableau {id, createdTsMs, state, resolvedTsMs} ou Unauthorized.
+		constexpr uint16_t kOpcodeGmTicketCancelRequest        = 80u; ///< Client to Master : annule son propre ticket.
+		constexpr uint16_t kOpcodeGmTicketCancelResponse       = 81u; ///< Master to Client : OK / NotFound / NotOwner / AlreadyResolved.
+		constexpr uint16_t kOpcodeGmTicketResolvedNotification = 82u; ///< Master to Client (push, request_id=0) : un GM a resolu un ticket de ce joueur.
 }


### PR DESCRIPTION
## GMTickets wire — server + client

Branche \`GmTicketSystem\` (step 1 mergé) + \`MysqlGmTicketStore\` (step 2 mergé) sur le wire et l'UI client. UI joueur : ouvrir un ticket support, lister, annuler. Notification push quand un GM résoud.

### Server wire
- \`ProtocolV1Constants.h\` : opcodes 76-82 (3 paires Request/Response + 1 push)
- \`src/shared/network/GmTicketPayloads.{h,cpp,Tests.cpp}\`
- \`src/masterd/handlers/gmtickets/GmTicketHandler.{h,cpp}\`
- \`src/masterd/main_linux.cpp\` : instancie + dispatch

### Client integration
- \`src/client/gmtickets/GmTicketUi.{h,cpp}\` : presenter + compose + cache
- \`src/client/render/GmTicketImGuiRenderer.{h,cpp}\` : panel ancré + dialog
- \`src/client/app/Engine\` : dispatch + slash command \`/ticket\` (alias \`/gmticket\`)

### V1 limitations
- Pas de UI GM côté support (admin tools, viendra plus tard)
- Pas de chargement initial depuis store au login (RequestMyTickets sur première ouverture)
- Push \`GmTicketResolvedNotification\` wiré mais pas encore émis (api admin Resolve à câbler)

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 76-82 + handler. Pas d'impact ancien client.

Generated with Claude Code