### PR TITLE
feat(trade): wire server FSM + UI client (Phase 4 CMANGOS.27 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,7 @@ add_library(engine_core
   src/shared/network/MailPayloads.cpp
   src/shared/network/QuestPayloads.cpp
   src/shared/network/GmTicketPayloads.cpp
+  src/shared/network/TradePayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
 )
@@ -652,6 +653,11 @@ add_test(NAME ignore_list_payloads_tests COMMAND ignore_list_payloads_tests)
 add_executable(gm_ticket_payloads_tests src/shared/network/GmTicketPayloadsTests.cpp)
 target_link_libraries(gm_ticket_payloads_tests PRIVATE engine_core)
 add_test(NAME gm_ticket_payloads_tests COMMAND gm_ticket_payloads_tests)
+
+# CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
+add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)
+target_link_libraries(trade_payloads_tests PRIVATE engine_core)
+add_test(NAME trade_payloads_tests COMMAND trade_payloads_tests)
 
 # M23.4: Log rotation smoke test (runtime logger)
 add_executable(log_rotation_smoke_tests src/shared/core/LogRotationSmokeTest.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,10 +116,13 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/quest/QuestHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/social/IgnoreListHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/trade/TradeHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/QuestPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GmTicketPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/TradePayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12,6 +12,7 @@
 #include "src/shared/network/MailPayloads.h"
 #include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/GmTicketPayloads.h"
+#include "src/shared/network/TradePayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/client/render/AuthImGuiRenderer.h"
@@ -854,6 +855,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
+		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
+		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
+		// Le presenter Init() existant a la signature (config) ; on lui passe m_cfg.
+		if (!m_tradeWindowUi.Init(m_cfg))
+		{
+			LOG_WARN(Core, "[Boot] TradeWindowUiPresenter init FAILED — trade desactive");
+		}
+		else
+		{
+			m_tradeWindowUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// Chat MVP — câblage bidirectionnel ChatUi <-> AuthUi (master TCP).
 		// Send : ChatUi::SubmitInputLine appelle AuthUi::SendChatAsync sur la connexion master vivante.
 		// Receive : AuthUi::PumpPostAuthEvents dispatche les paquets push (CHAT_RELAY notamment)
@@ -889,6 +905,52 @@ namespace engine
 					m_questUi.RequestQuestList();
 				}
 				LOG_INFO(Core, "[Engine] /quest toggle (visible={})", m_questVisible);
+				return true;
+			}
+			// CMANGOS.27 (Phase 4.27 step 3+4) — Slash command /trade <accountId>
+			// pour initier un echange avec le joueur cible. V1 : resolution par
+			// account_id direct (la resolution par character_name viendra avec
+			// PartySystem display ulterieurement). "/trade cancel" annule la
+			// trade en cours.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/trade" || text.starts_with("/trade ") || text.starts_with("/trade\t")))
+			{
+				const auto spaceIdx = text.find_first_of(" \t");
+				if (spaceIdx == std::string_view::npos)
+				{
+					LOG_INFO(Core, "[Engine] /trade : usage /trade <account_id> ou /trade cancel");
+					return true;
+				}
+				std::string_view arg = text.substr(spaceIdx + 1);
+				while (!arg.empty() && (arg.front() == ' ' || arg.front() == '\t'))
+					arg.remove_prefix(1u);
+				if (arg == "cancel")
+				{
+					m_tradeWindowUi.Cancel();
+					LOG_INFO(Core, "[Engine] /trade cancel");
+					return true;
+				}
+				uint64_t targetAccountId = 0u;
+				bool parsed = false;
+				try
+				{
+					size_t pos = 0;
+					const std::string argStr(arg);
+					targetAccountId = std::stoull(argStr, &pos, 10);
+					parsed = (pos > 0u && targetAccountId != 0u);
+				}
+				catch (...)
+				{
+					parsed = false;
+				}
+				if (!parsed)
+				{
+					LOG_WARN(Core, "[Engine] /trade : argument '{}' n'est pas un account_id valide",
+						std::string(arg));
+					return true;
+				}
+				m_tradeWindowUi.RequestBeginTrade(targetAccountId);
+				LOG_INFO(Core, "[Engine] /trade {}", targetAccountId);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1187,6 +1249,85 @@ namespace engine
 					return;
 				}
 				m_gmTicketUi.OnResolvedNotification(*parsed);
+				return;
+			}
+			// CMANGOS.27 (Phase 4.27 step 3+4) — Dispatch des reponses Trade
+			// (84/87/89/92) + push notifications (85/90/94).
+			case kOpcodeTradeBeginResponse:
+			{
+				auto parsed = ParseTradeBeginResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_BEGIN_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeBeginResponse(*parsed);
+				return;
+			}
+			case kOpcodeTradeBeginNotification:
+			{
+				auto parsed = ParseTradeBeginNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_BEGIN_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeBeginNotification(*parsed);
+				return;
+			}
+			case kOpcodeTradeSetOfferResponse:
+			{
+				auto parsed = ParseTradeSetOfferResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_SET_OFFER_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeSetOfferResponse(*parsed);
+				return;
+			}
+			case kOpcodeTradeLockResponse:
+			{
+				auto parsed = ParseTradeLockResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_LOCK_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeLockResponse(*parsed);
+				return;
+			}
+			case kOpcodeTradeStateUpdateNotification:
+			{
+				auto parsed = ParseTradeStateUpdateNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_STATE_UPDATE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeStateUpdate(*parsed);
+				return;
+			}
+			case kOpcodeTradeCommitResponse:
+			{
+				auto parsed = ParseTradeCommitResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_COMMIT_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeCommitResponse(*parsed);
+				return;
+			}
+			case kOpcodeTradeCancelNotification:
+			{
+				auto parsed = ParseTradeCancelNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] TRADE_CANCEL_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_tradeWindowUi.OnTradeCancelNotification(*parsed);
 				return;
 			}
 			default:

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -11,6 +11,7 @@
 #include "src/client/quest/QuestUi.h"
 #include "src/client/social/IgnoreListUi.h"
 #include "src/client/gmtickets/GmTicketUi.h"
+#include "src/client/trade/TradeWindowUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
@@ -415,6 +416,12 @@ namespace engine
 		/// CMANGOS.32 (Phase 5.32 step 3+4) — Visibilite du panneau Support GM
 		/// (toggle via slash command \c /ticket ou \c /gmticket). Faux par defaut.
 		bool                                m_gmTicketsVisible = false;
+		/// CMANGOS.27 (Phase 4.27 step 3+4) — Presenter de la fenetre d'echange
+		/// direct entre 2 joueurs. Recoit les responses opcodes 84/87/89/92 et
+		/// les push notifications 85/90/94 via le push handler du master ;
+		/// fire-and-forget des requetes 83/86/88/91/93 via
+		/// \c m_authUi.SendGenericRequestAsync.
+		engine::client::TradeWindowUiPresenter m_tradeWindowUi;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/trade/TradeWindowUi.cpp
+++ b/src/client/trade/TradeWindowUi.cpp
@@ -1,6 +1,7 @@
 #include "src/client/trade/TradeWindowUi.h"
 
 #include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
 
 #include <algorithm>
 
@@ -251,5 +252,265 @@ namespace engine::client
 			out.lockButtonEnabled    = false;
 			out.confirmButtonEnabled = false;
 		}
+	}
+
+	// =========================================================================
+	// CMANGOS.27 (Phase 4.27 step 3+4) -- Network actions (request senders)
+	// =========================================================================
+
+	void TradeWindowUiPresenter::RequestBeginTrade(uint64_t targetAccountId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] RequestBeginTrade: no send callback");
+			return;
+		}
+		if (m_currentSessionId != 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] RequestBeginTrade: already in trade (sid={})",
+				m_currentSessionId);
+			return;
+		}
+		const auto payload = engine::network::BuildTradeBeginRequestPayload(targetAccountId);
+		if (!m_send(engine::network::kOpcodeTradeBeginRequest, payload))
+		{
+			LOG_WARN(Net, "[TradeWindowUi] RequestBeginTrade: send failed (target={})", targetAccountId);
+			return;
+		}
+		LOG_INFO(Net, "[TradeWindowUi] TradeBeginRequest queued (target={})", targetAccountId);
+	}
+
+	void TradeWindowUiPresenter::SetMyOffer(uint64_t copperGold, const std::vector<uint64_t>& itemGuids)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] SetMyOffer: no send callback");
+			return;
+		}
+		if (m_currentSessionId == 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] SetMyOffer: no active trade session");
+			return;
+		}
+		const auto payload = engine::network::BuildTradeSetOfferRequestPayload(
+			m_currentSessionId, copperGold, itemGuids);
+		if (!m_send(engine::network::kOpcodeTradeSetOfferRequest, payload))
+		{
+			LOG_WARN(Net, "[TradeWindowUi] SetMyOffer: send failed (sid={})", m_currentSessionId);
+			return;
+		}
+		LOG_INFO(Net, "[TradeWindowUi] TradeSetOfferRequest queued (sid={} gold={} items={})",
+			m_currentSessionId, copperGold, itemGuids.size());
+	}
+
+	void TradeWindowUiPresenter::Lock()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Lock: no send callback");
+			return;
+		}
+		if (m_currentSessionId == 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Lock: no active trade session");
+			return;
+		}
+		const auto payload = engine::network::BuildTradeLockRequestPayload(m_currentSessionId);
+		if (!m_send(engine::network::kOpcodeTradeLockRequest, payload))
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Lock: send failed (sid={})", m_currentSessionId);
+			return;
+		}
+		LOG_INFO(Net, "[TradeWindowUi] TradeLockRequest queued (sid={})", m_currentSessionId);
+	}
+
+	void TradeWindowUiPresenter::Commit()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Commit: no send callback");
+			return;
+		}
+		if (m_currentSessionId == 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Commit: no active trade session");
+			return;
+		}
+		const auto payload = engine::network::BuildTradeCommitRequestPayload(m_currentSessionId);
+		if (!m_send(engine::network::kOpcodeTradeCommitRequest, payload))
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Commit: send failed (sid={})", m_currentSessionId);
+			return;
+		}
+		LOG_INFO(Net, "[TradeWindowUi] TradeCommitRequest queued (sid={})", m_currentSessionId);
+	}
+
+	void TradeWindowUiPresenter::Cancel()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Cancel: no send callback");
+			return;
+		}
+		if (m_currentSessionId == 0u)
+		{
+			// Pas d'erreur : on ne fait rien si pas de trade en cours.
+			return;
+		}
+		const auto payload = engine::network::BuildTradeCancelRequestPayload(m_currentSessionId);
+		if (!m_send(engine::network::kOpcodeTradeCancelRequest, payload))
+		{
+			LOG_WARN(Net, "[TradeWindowUi] Cancel: send failed (sid={})", m_currentSessionId);
+			return;
+		}
+		LOG_INFO(Net, "[TradeWindowUi] TradeCancelRequest queued (sid={})", m_currentSessionId);
+	}
+
+	// =========================================================================
+	// CMANGOS.27 (Phase 4.27 step 3+4) -- Master responses / push handlers
+	// =========================================================================
+
+	void TradeWindowUiPresenter::OnTradeBeginResponse(const engine::network::TradeBeginResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			using engine::network::TradeErrorCode;
+			std::string err;
+			switch (static_cast<TradeErrorCode>(resp.error))
+			{
+			case TradeErrorCode::PartnerOffline:  err = "Le partenaire n'est pas en ligne."; break;
+			case TradeErrorCode::PartnerInTrade:  err = "Le partenaire est deja dans un echange."; break;
+			case TradeErrorCode::SelfTrade:       err = "Impossible de commercer avec soi-meme."; break;
+			case TradeErrorCode::Unauthorized:    err = "Session invalide. Reconnectez-vous."; break;
+			default:                              err = "Erreur a l'ouverture de l'echange."; break;
+			}
+			m_state.resultText = "Trade refused: " + err;
+			LOG_WARN(Net, "[TradeWindowUi] OnTradeBeginResponse error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		// OK : on note la session active. L'UI reelle (ouverture du panneau)
+		// est gouvernee par le UIModel.tradeWindow.isOpen ; ici on enregistre
+		// juste le contexte reseau qui pilotera SetMyOffer/Lock/Commit/Cancel.
+		m_currentSessionId = resp.sessionId;
+		m_partnerAccountId = resp.partnerAccountId;
+		m_fsmState         = 0u; // Open
+		m_partnerCopperGold = 0;
+		m_partnerItemGuids.clear();
+		m_state.resultText.clear();
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeBeginResponse OK sid={} partner={}",
+			m_currentSessionId, m_partnerAccountId);
+	}
+
+	void TradeWindowUiPresenter::OnTradeBeginNotification(const engine::network::TradeBeginNotificationPayload& note)
+	{
+		// Quelqu'un nous a initie un trade. En V1 : auto-accept (UI s'ouvre,
+		// le joueur peut Cancel s'il ne veut pas). Si on a deja une session,
+		// on log et on ignore (le serveur a normalement deja rejete).
+		if (m_currentSessionId != 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] OnTradeBeginNotification ignored: already in trade sid={}",
+				m_currentSessionId);
+			return;
+		}
+		m_currentSessionId = note.sessionId;
+		m_partnerAccountId = note.partnerAccountId;
+		m_fsmState         = 0u;
+		m_partnerCopperGold = 0;
+		m_partnerItemGuids.clear();
+		m_state.resultText.clear();
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeBeginNotification incoming sid={} from={}",
+			m_currentSessionId, m_partnerAccountId);
+	}
+
+	void TradeWindowUiPresenter::OnTradeSetOfferResponse(const engine::network::TradeSetOfferResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] OnTradeSetOfferResponse error code={}",
+				static_cast<unsigned>(resp.error));
+			m_state.resultText = "Offer rejected by server.";
+			return;
+		}
+		LOG_DEBUG(Net, "[TradeWindowUi] OnTradeSetOfferResponse OK");
+	}
+
+	void TradeWindowUiPresenter::OnTradeLockResponse(const engine::network::TradeLockResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] OnTradeLockResponse error code={}",
+				static_cast<unsigned>(resp.error));
+			m_state.resultText = "Lock refused by server.";
+			return;
+		}
+		m_fsmState = resp.newState;
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeLockResponse newState={}", static_cast<unsigned>(resp.newState));
+	}
+
+	void TradeWindowUiPresenter::OnTradeStateUpdate(const engine::network::TradeStateUpdateNotificationPayload& note)
+	{
+		if (note.sessionId != m_currentSessionId)
+		{
+			// Push pour une autre session (race au reset, etc.) : on ignore.
+			LOG_DEBUG(Net, "[TradeWindowUi] OnTradeStateUpdate sid mismatch (got={} expected={})",
+				note.sessionId, m_currentSessionId);
+			return;
+		}
+		m_fsmState          = note.state;
+		m_partnerCopperGold = note.partnerCopperGold;
+		m_partnerItemGuids  = note.partnerItemGuids;
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeStateUpdate sid={} state={} partnerGold={} partnerItems={}",
+			note.sessionId, static_cast<unsigned>(note.state),
+			note.partnerCopperGold, note.partnerItemGuids.size());
+
+		// Etat terminal Committed : on libere le contexte cote client (le
+		// serveur a deja End()-e la session). L'UIModel propage isDone qui
+		// affichera resultText "Trade completed".
+		if (m_fsmState == 4u)
+		{
+			LOG_INFO(Net, "[TradeWindowUi] StateUpdate -> Committed, resetting session sid={}",
+				m_currentSessionId);
+			m_currentSessionId = 0;
+			m_partnerAccountId = 0;
+			m_partnerCopperGold = 0;
+			m_partnerItemGuids.clear();
+		}
+	}
+
+	void TradeWindowUiPresenter::OnTradeCommitResponse(const engine::network::TradeCommitResponsePayload& resp)
+	{
+		if (resp.error != 0u)
+		{
+			LOG_WARN(Net, "[TradeWindowUi] OnTradeCommitResponse error code={}",
+				static_cast<unsigned>(resp.error));
+			m_state.resultText = "Commit refused by server.";
+			return;
+		}
+		// Le state passera a Committed via le push StateUpdate (parallele a
+		// la response). Ici on log juste le succes ack par le master.
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeCommitResponse OK");
+	}
+
+	void TradeWindowUiPresenter::OnTradeCancelNotification(const engine::network::TradeCancelNotificationPayload& note)
+	{
+		if (note.sessionId != m_currentSessionId && m_currentSessionId != 0u)
+		{
+			LOG_DEBUG(Net, "[TradeWindowUi] OnTradeCancelNotification sid mismatch (got={} expected={})",
+				note.sessionId, m_currentSessionId);
+			return;
+		}
+		m_state.resultText = note.reason.empty()
+			? std::string("Trade cancelled.")
+			: ("Trade cancelled: " + note.reason);
+		m_state.isVisible = false;
+		LOG_INFO(Net, "[TradeWindowUi] OnTradeCancelNotification sid={} reason='{}'",
+			note.sessionId, note.reason);
+		// Reset le contexte : la session est terminale cote serveur.
+		m_currentSessionId = 0;
+		m_partnerAccountId = 0;
+		m_fsmState = 5u; // Cancelled
+		m_partnerCopperGold = 0;
+		m_partnerItemGuids.clear();
 	}
 }

--- a/src/client/trade/TradeWindowUi.h
+++ b/src/client/trade/TradeWindowUi.h
@@ -2,8 +2,10 @@
 
 #include "src/client/ui_common/UIModel.h"
 #include "src/shared/core/Config.h"
+#include "src/shared/network/TradePayloads.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -94,6 +96,74 @@ namespace engine::client
 		/// Return the immutable resolved panel state.
 		const TradeWindowPanelState& GetState() const { return m_state; }
 
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.27 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback. Mirror du pattern QuestUi/MailUi.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes Trade au master.
+		/// Doit etre appele avant tout RequestBeginTrade/SetMyOffer/Lock/Commit/Cancel.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie TRADE_BEGIN_REQUEST vers \p targetAccountId (account_id direct).
+		/// Reponse via OnTradeBeginResponse ; le partenaire recoit
+		/// OnTradeBeginNotification.
+		void RequestBeginTrade(uint64_t targetAccountId);
+
+		/// Envoie TRADE_SET_OFFER_REQUEST avec l'offer courant cote sender
+		/// (gold + items). Doit etre appele avec une session active
+		/// (RequestBeginTrade reussi ou OnTradeBeginNotification recu).
+		void SetMyOffer(uint64_t copperGold, const std::vector<uint64_t>& itemGuids);
+
+		/// Envoie TRADE_LOCK_REQUEST. Le serveur valide et eventuellement passe
+		/// en BothLocked si l'autre joueur a deja locke.
+		void Lock();
+
+		/// Envoie TRADE_COMMIT_REQUEST. N'est valide que si BothLocked cote
+		/// FSM. Sinon le serveur retourne WrongState.
+		void Commit();
+
+		/// Envoie TRADE_CANCEL_REQUEST. Possible depuis n'importe quel etat
+		/// non-terminal. Le serveur push CancelNotification aux 2 participants.
+		void Cancel();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit TRADE_BEGIN_RESPONSE. Si OK, met a jour la session active
+		/// cote presenter (sessionId + partner) et ouvre l'UI.
+		void OnTradeBeginResponse(const engine::network::TradeBeginResponsePayload& resp);
+
+		/// Recoit TRADE_BEGIN_NOTIFICATION (push) : un autre joueur initie un
+		/// trade vers nous. Met a jour la session active et ouvre l'UI.
+		void OnTradeBeginNotification(const engine::network::TradeBeginNotificationPayload& note);
+
+		/// Recoit TRADE_SET_OFFER_RESPONSE. ACK de notre propre SetMyOffer.
+		void OnTradeSetOfferResponse(const engine::network::TradeSetOfferResponsePayload& resp);
+
+		/// Recoit TRADE_LOCK_RESPONSE. ACK de notre Lock + nouveau state FSM.
+		void OnTradeLockResponse(const engine::network::TradeLockResponsePayload& resp);
+
+		/// Recoit TRADE_STATE_UPDATE_NOTIFICATION (push) : le partenaire a
+		/// modifie son offer ou son lock. Met a jour l'offer miroir cote UI.
+		void OnTradeStateUpdate(const engine::network::TradeStateUpdateNotificationPayload& note);
+
+		/// Recoit TRADE_COMMIT_RESPONSE. ACK du commit final.
+		void OnTradeCommitResponse(const engine::network::TradeCommitResponsePayload& resp);
+
+		/// Recoit TRADE_CANCEL_NOTIFICATION (push) : la trade a ete annulee
+		/// (par l'un des 2). Ferme l'UI cote presenter.
+		void OnTradeCancelNotification(const engine::network::TradeCancelNotificationPayload& note);
+
+		/// Accesseurs lecture seule pour tests/diagnostic.
+		uint64_t GetCurrentSessionId() const { return m_currentSessionId; }
+		uint64_t GetPartnerAccountId() const { return m_partnerAccountId; }
+		uint8_t  GetCurrentState()    const { return m_fsmState; }
+
 	private:
 		/// Recompute the full layout for a given viewport size.
 		void RebuildLayout();
@@ -114,5 +184,15 @@ namespace engine::client
 		uint32_t              m_viewportWidth  = 0;
 		uint32_t              m_viewportHeight = 0;
 		bool                  m_initialized    = false;
+
+		// CMANGOS.27 (Phase 4.27 step 3+4) -- network state cote presenter.
+		// La trade FSM cote master fait autorite ; on miroite simplement
+		// l'etat ici pour que l'UI affiche la bonne phase.
+		SendCallback          m_send;
+		uint64_t              m_currentSessionId = 0;   ///< 0 si pas de trade active.
+		uint64_t              m_partnerAccountId = 0;   ///< L'autre joueur (id account direct V1).
+		uint8_t               m_fsmState         = 0;   ///< 0=Open, 1=LockedA, 2=LockedB, 3=BothLocked, 4=Committed, 5=Cancelled.
+		uint64_t              m_partnerCopperGold = 0;  ///< Offer miroir cote partenaire (gold).
+		std::vector<uint64_t> m_partnerItemGuids;       ///< Offer miroir cote partenaire (items).
 	};
 }

--- a/src/masterd/handlers/trade/TradeHandler.cpp
+++ b/src/masterd/handlers/trade/TradeHandler.cpp
@@ -1,0 +1,608 @@
+// CMANGOS.27 (Phase 4.27 step 3+4) -- Implementation TradeHandler.
+
+#include "src/masterd/handlers/trade/TradeHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/masterd/trade/TradeSessionRegistry.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/TradePayloads.h"
+
+#include <utility>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Convertit une TradeState (enum class) en uint8_t pour le wire.
+		uint8_t StateToWire(engine::server::trade::TradeState s)
+		{
+			return static_cast<uint8_t>(s);
+		}
+
+		/// Renvoie l'offer du joueur sender dans la session (cote sender).
+		/// Utile pour pousser au partenaire l'etat *vu cote sender* en miroir.
+		const engine::server::trade::TradeOffer&
+		OfferOf(const engine::server::trade::TradeSession& sess, uint64_t accountId)
+		{
+			if (accountId == sess.PlayerA()) return sess.OfferA();
+			return sess.OfferB();
+		}
+	}
+
+	// =========================================================================
+	// HandlePacket : entry point dispatch + session/account resolution
+	// =========================================================================
+
+	void TradeHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_reg || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[TradeHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account. Si l'un manque, on retourne une reponse
+		// type-specific avec error=Unauthorized.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(TradeErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeTradeBeginRequest:
+				pkt = BuildTradeBeginResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeTradeSetOfferRequest:
+				pkt = BuildTradeSetOfferResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeTradeLockRequest:
+				pkt = BuildTradeLockResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeTradeCommitRequest:
+				pkt = BuildTradeCommitResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeTradeCancelRequest:
+				// Cancel n'a pas de response wire dediee : on reutilise la
+				// notification cote sender pour signaler l'echec d'auth.
+				pkt = BuildTradeCancelNotificationPacket(0u, "unauthorized", sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeTradeBeginRequest:
+			HandleBegin(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeTradeSetOfferRequest:
+			HandleSetOffer(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeTradeLockRequest:
+			HandleLock(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeTradeCommitRequest:
+			HandleCommit(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeTradeCancelRequest:
+			HandleCancel(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// =========================================================================
+	// FindConnIdForAccount / FindSessionIdForAccount
+	// =========================================================================
+
+	uint32_t TradeHandler::FindConnIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return connId;
+		}
+		return 0u;
+	}
+
+	uint64_t TradeHandler::FindSessionIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			(void)connId;
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return sessionId;
+		}
+		return 0u;
+	}
+
+	bool TradeHandler::SendPacketToAccount(uint64_t accountId, const std::vector<uint8_t>& packet)
+	{
+		if (packet.empty()) return false;
+		const uint32_t connId = FindConnIdForAccount(accountId);
+		if (connId == 0u) return false;
+		(void)m_server->Send(connId, packet);
+		return true;
+	}
+
+	// =========================================================================
+	// HandleBegin
+	// =========================================================================
+
+	void TradeHandler::HandleBegin(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseTradeBeginRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Begin parse failed account={} size={}", accountId, payloadSize);
+			return;
+		}
+
+		const uint64_t targetAcc = parsed->targetAccountId;
+
+		// Self-trade : explicitement rejete (le client peut tenter par bug
+		// d'UI, et la TradeSession::SetOffer ne distinguerait pas A == B).
+		if (targetAcc == 0u || targetAcc == accountId)
+		{
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::SelfTrade), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Begin SelfTrade account={}", accountId);
+			return;
+		}
+
+		// Verifie que ni A ni B ne sont deja dans une autre trade.
+		if (m_reg->IsInTrade(accountId) || m_reg->IsInTrade(targetAcc))
+		{
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::PartnerInTrade), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Begin PartnerInTrade sender={} target={}",
+				accountId, targetAcc);
+			return;
+		}
+
+		// Verifie que le target est online (a une connexion active sur le master).
+		const uint32_t targetConn = FindConnIdForAccount(targetAcc);
+		const uint64_t targetSessionIdHeader = FindSessionIdForAccount(targetAcc);
+		if (targetConn == 0u || targetSessionIdHeader == 0u)
+		{
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::PartnerOffline), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Begin PartnerOffline sender={} target={}",
+				accountId, targetAcc);
+			return;
+		}
+
+		// Cree la session.
+		const uint64_t sid = m_reg->Begin(accountId, targetAcc);
+		if (sid == 0u)
+		{
+			// Race : registry a refuse (l'un des 2 a entame une trade entre
+			// nos checks). On retourne PartnerInTrade.
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::PartnerInTrade), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Begin race PartnerInTrade sender={} target={}",
+				accountId, targetAcc);
+			return;
+		}
+
+		// Reponse au sender (initiateur).
+		{
+			auto pkt = BuildTradeBeginResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::Ok), sid, targetAcc,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+		}
+
+		// Push BeginNotification au target (avec son propre sessionIdHeader).
+		{
+			auto pkt = BuildTradeBeginNotificationPacket(sid, accountId, targetSessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(targetConn, pkt);
+		}
+
+		LOG_INFO(Net, "[TradeHandler] Begin OK sender={} target={} sid={}",
+			accountId, targetAcc, sid);
+	}
+
+	// =========================================================================
+	// HandleSetOffer
+	// =========================================================================
+
+	void TradeHandler::HandleSetOffer(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseTradeSetOfferRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		auto* sess = m_reg->GetById(parsed->sessionId);
+		if (!sess)
+		{
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] SetOffer InvalidSession account={} sid={}",
+				accountId, parsed->sessionId);
+			return;
+		}
+
+		if (sess->PlayerA() != accountId && sess->PlayerB() != accountId)
+		{
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::NotPartOfSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] SetOffer NotPartOfSession account={} sid={}",
+				accountId, parsed->sessionId);
+			return;
+		}
+
+		// Etats terminaux : refuse.
+		if (sess->State() == engine::server::trade::TradeState::Committed
+		 || sess->State() == engine::server::trade::TradeState::Cancelled)
+		{
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::SessionTerminal),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		engine::server::trade::TradeOffer offer;
+		offer.copper = parsed->copperGold;
+		offer.items  = parsed->itemGuids;
+
+		const bool ok = sess->SetOffer(accountId, std::move(offer));
+		if (!ok)
+		{
+			// Le seul cas de refus restant cote SetOffer (apres les checks
+			// ci-dessus) : tentative d'editer son offer alors qu'on est deja
+			// locke (LockedA/B/BothLocked cote sender).
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::WrongState),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] SetOffer WrongState account={} sid={} state={}",
+				accountId, parsed->sessionId, static_cast<unsigned>(sess->State()));
+			return;
+		}
+
+		// Reponse au sender.
+		{
+			auto pkt = BuildTradeSetOfferResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::Ok),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+		}
+
+		// Push StateUpdateNotification au partenaire avec l'offer mise a jour
+		// du sender (le partenaire voit "l'autre cote").
+		const uint64_t partnerAcc = (accountId == sess->PlayerA())
+			? sess->PlayerB() : sess->PlayerA();
+		const uint32_t partnerConn = FindConnIdForAccount(partnerAcc);
+		const uint64_t partnerSessionId = FindSessionIdForAccount(partnerAcc);
+		if (partnerConn != 0u && partnerSessionId != 0u)
+		{
+			const auto& senderOffer = OfferOf(*sess, accountId);
+			auto pkt = BuildTradeStateUpdateNotificationPacket(
+				parsed->sessionId, StateToWire(sess->State()),
+				senderOffer.copper, senderOffer.items, partnerSessionId);
+			if (!pkt.empty()) m_server->Send(partnerConn, pkt);
+		}
+
+		LOG_INFO(Net, "[TradeHandler] SetOffer OK account={} sid={} items={} gold={}",
+			accountId, parsed->sessionId, parsed->itemGuids.size(), parsed->copperGold);
+	}
+
+	// =========================================================================
+	// HandleLock
+	// =========================================================================
+
+	void TradeHandler::HandleLock(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseTradeLockRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildTradeLockResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		auto* sess = m_reg->GetById(parsed->sessionId);
+		if (!sess)
+		{
+			auto pkt = BuildTradeLockResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (sess->PlayerA() != accountId && sess->PlayerB() != accountId)
+		{
+			auto pkt = BuildTradeLockResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::NotPartOfSession), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		const bool ok = sess->Lock(accountId);
+		if (!ok)
+		{
+			auto pkt = BuildTradeLockResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::WrongState),
+				StateToWire(sess->State()),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Lock WrongState account={} sid={}",
+				accountId, parsed->sessionId);
+			return;
+		}
+
+		const uint8_t newState = StateToWire(sess->State());
+
+		// Reponse au sender.
+		{
+			auto pkt = BuildTradeLockResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::Ok), newState,
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+		}
+
+		// Push StateUpdateNotification au partenaire pour qu'il voie le nouveau
+		// state (ex : Open -> LockedA cote l'autre, ou LockedB -> BothLocked).
+		// On envoie l'offer du sender -- meme inchangee, c'est ce que le
+		// partenaire affiche dans son UI miroir.
+		const uint64_t partnerAcc = (accountId == sess->PlayerA())
+			? sess->PlayerB() : sess->PlayerA();
+		const uint32_t partnerConn = FindConnIdForAccount(partnerAcc);
+		const uint64_t partnerSessionId = FindSessionIdForAccount(partnerAcc);
+		if (partnerConn != 0u && partnerSessionId != 0u)
+		{
+			const auto& senderOffer = OfferOf(*sess, accountId);
+			auto pkt = BuildTradeStateUpdateNotificationPacket(
+				parsed->sessionId, newState,
+				senderOffer.copper, senderOffer.items, partnerSessionId);
+			if (!pkt.empty()) m_server->Send(partnerConn, pkt);
+		}
+
+		LOG_INFO(Net, "[TradeHandler] Lock OK account={} sid={} newState={}",
+			accountId, parsed->sessionId, static_cast<unsigned>(newState));
+	}
+
+	// =========================================================================
+	// HandleCommit
+	// =========================================================================
+
+	void TradeHandler::HandleCommit(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseTradeCommitRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildTradeCommitResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		auto* sess = m_reg->GetById(parsed->sessionId);
+		if (!sess)
+		{
+			auto pkt = BuildTradeCommitResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::InvalidSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (sess->PlayerA() != accountId && sess->PlayerB() != accountId)
+		{
+			auto pkt = BuildTradeCommitResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::NotPartOfSession),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		// V1 : on ne valide / n'applique PAS le delta inventory ici. On se
+		// contente d'avancer la FSM. La transaction reelle (lock items,
+		// transfert, application gold) viendra avec l'integration wallet.
+		const bool ok = sess->Commit();
+		if (!ok)
+		{
+			auto pkt = BuildTradeCommitResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::WrongState),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[TradeHandler] Commit WrongState account={} sid={} state={}",
+				accountId, parsed->sessionId, static_cast<unsigned>(sess->State()));
+			return;
+		}
+
+		// Reponse au sender.
+		{
+			auto pkt = BuildTradeCommitResponsePacket(
+				static_cast<uint8_t>(TradeErrorCode::Ok),
+				requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+		}
+
+		// Push StateUpdateNotification(Committed) aux 2 participants. Pour
+		// chacun, on envoie l'offer *de l'autre* avec state=Committed pour que
+		// l'UI puisse confirmer le contenu finalise.
+		const uint64_t accA = sess->PlayerA();
+		const uint64_t accB = sess->PlayerB();
+		const auto& offerA = sess->OfferA();
+		const auto& offerB = sess->OfferB();
+
+		const uint64_t sessA = FindSessionIdForAccount(accA);
+		const uint64_t sessB = FindSessionIdForAccount(accB);
+		const uint32_t connA = FindConnIdForAccount(accA);
+		const uint32_t connB = FindConnIdForAccount(accB);
+
+		// A voit l'offer de B avec state=Committed.
+		if (connA != 0u && sessA != 0u)
+		{
+			auto pkt = BuildTradeStateUpdateNotificationPacket(
+				parsed->sessionId, StateToWire(sess->State()),
+				offerB.copper, offerB.items, sessA);
+			if (!pkt.empty()) m_server->Send(connA, pkt);
+		}
+		// B voit l'offer de A avec state=Committed.
+		if (connB != 0u && sessB != 0u)
+		{
+			auto pkt = BuildTradeStateUpdateNotificationPacket(
+				parsed->sessionId, StateToWire(sess->State()),
+				offerA.copper, offerA.items, sessB);
+			if (!pkt.empty()) m_server->Send(connB, pkt);
+		}
+
+		LOG_INFO(Net, "[TradeHandler] Commit OK account={} sid={} (V1: no inventory delta applied)",
+			accountId, parsed->sessionId);
+
+		// Termine la session. Apres ce point, GetById(sid) retourne nullptr.
+		m_reg->End(parsed->sessionId);
+	}
+
+	// =========================================================================
+	// HandleCancel
+	// =========================================================================
+
+	void TradeHandler::HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		(void)connId;
+		(void)requestId;
+		(void)sessionIdHeader;
+
+		auto parsed = ParseTradeCancelRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[TradeHandler] Cancel parse failed account={} size={}", accountId, payloadSize);
+			return;
+		}
+
+		auto* sess = m_reg->GetById(parsed->sessionId);
+		if (!sess)
+		{
+			// Pas de session : silencieux. Le client peut avoir ferme l'UI
+			// apres un commit (session deja End()-ee) et envoye un Cancel
+			// tardif ; ce n'est pas une erreur fatale.
+			LOG_INFO(Net, "[TradeHandler] Cancel no-op (sid={} unknown) account={}",
+				parsed->sessionId, accountId);
+			return;
+		}
+
+		if (sess->PlayerA() != accountId && sess->PlayerB() != accountId)
+		{
+			LOG_WARN(Net, "[TradeHandler] Cancel NotPartOfSession account={} sid={}",
+				accountId, parsed->sessionId);
+			return;
+		}
+
+		const bool ok = sess->Cancel(accountId);
+		if (!ok)
+		{
+			// Session deja Committed/Cancelled ; on End() quand meme par
+			// idempotence (si c'etait un Cancel tardif apres Commit, la
+			// session a deja ete End() au Commit, le GetById serait null).
+			LOG_INFO(Net, "[TradeHandler] Cancel no-op (sid={} terminal) account={}",
+				parsed->sessionId, accountId);
+			return;
+		}
+
+		// Push CancelNotification aux 2 participants. La raison "partner cancelled"
+		// permet au client de l'afficher dans cancelReason cote UI.
+		const uint64_t accA = sess->PlayerA();
+		const uint64_t accB = sess->PlayerB();
+		const uint64_t sessA = FindSessionIdForAccount(accA);
+		const uint64_t sessB = FindSessionIdForAccount(accB);
+		const uint32_t connA = FindConnIdForAccount(accA);
+		const uint32_t connB = FindConnIdForAccount(accB);
+
+		if (connA != 0u && sessA != 0u)
+		{
+			const std::string_view reasonForA = (accountId == accA)
+				? std::string_view("you cancelled the trade")
+				: std::string_view("partner cancelled the trade");
+			auto pkt = BuildTradeCancelNotificationPacket(parsed->sessionId, reasonForA, sessA);
+			if (!pkt.empty()) m_server->Send(connA, pkt);
+		}
+		if (connB != 0u && sessB != 0u)
+		{
+			const std::string_view reasonForB = (accountId == accB)
+				? std::string_view("you cancelled the trade")
+				: std::string_view("partner cancelled the trade");
+			auto pkt = BuildTradeCancelNotificationPacket(parsed->sessionId, reasonForB, sessB);
+			if (!pkt.empty()) m_server->Send(connB, pkt);
+		}
+
+		LOG_INFO(Net, "[TradeHandler] Cancel OK account={} sid={}", accountId, parsed->sessionId);
+
+		// Termine la session.
+		m_reg->End(parsed->sessionId);
+	}
+}

--- a/src/masterd/handlers/trade/TradeHandler.h
+++ b/src/masterd/handlers/trade/TradeHandler.h
@@ -1,0 +1,112 @@
+#pragma once
+// CMANGOS.27 (Phase 4.27 step 3+4) -- TradeHandler : dispatch des opcodes
+// Trade cote master (83/86/88/91/93). Gere la creation des TradeSession via
+// TradeSessionRegistry et envoie les push notifications aux 2 participants
+// pour synchroniser leurs UI.
+//
+// Particularite Trade vs autres tickets : 2 clients connectes simultanement
+// participent a la meme session. Chaque transition d'etat (SetOffer / Lock /
+// Commit / Cancel) entraine un push au partenaire (et au sender pour la
+// reponse), pour qu'il rafraichisse son UI miroir.
+//
+// Le handler est instancie dans main_linux.cpp, cable via Set*() puis
+// enregistre dans le packetHandler du NetServer. Les responses sont emises
+// avec le meme requestId / sessionIdHeader que la request recue ; les push
+// notifications utilisent requestId=0.
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::trade
+{
+	class TradeSessionRegistry;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Trade cote master. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class TradeHandler
+	{
+	public:
+		/// Branche le registry des trades actives.
+		void SetRegistry(engine::server::trade::TradeSessionRegistry* r) { m_reg = r; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId. Utilisee pour resoudre
+		/// accountId -> connId via Snapshot() (V1 : O(n) au worst-case).
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Trade. Dispatch
+		/// vers HandleBegin/HandleSetOffer/HandleLock/HandleCommit/HandleCancel.
+		///
+		/// \param connId         identifiant de connexion TCP du sender.
+		/// \param opcode         opcode du paquet entrant (83/86/88/91/93).
+		/// \param requestId      request_id du paquet ; renvoye dans la reponse au sender.
+		/// \param sessionIdHeader session_id du paquet ; sert pour la reponse au sender.
+		/// \param payload        pointeur sur le payload (sans header).
+		/// \param payloadSize    taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// TRADE_BEGIN : valide self != target, target online, target ni A ni B
+		/// dans une autre trade ; cree la session via le registry et push une
+		/// BeginNotification au target.
+		void HandleBegin(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// TRADE_SET_OFFER : valide la session + l'appartenance, applique
+		/// session->SetOffer(...), et push une StateUpdateNotification au
+		/// partenaire.
+		void HandleSetOffer(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// TRADE_LOCK : valide la session, applique session->Lock(accountId).
+		/// Si le state passe a BothLocked, push StateUpdateNotification(BothLocked)
+		/// aux 2 (le sender voit aussi le state mis a jour via la response).
+		void HandleLock(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// TRADE_COMMIT : valide BothLocked, appelle session->Commit(), push
+		/// StateUpdateNotification(Committed) aux 2 et termine la session.
+		/// V1 : pas d'application reelle du delta inventory (TODO wallet).
+		void HandleCommit(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// TRADE_CANCEL : appelle session->Cancel(accountId), push
+		/// CancelNotification aux 2 et termine la session.
+		void HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Resout l'accountId -> connId (via Snapshot du connMap + reverse
+		/// lookup SessionManager). \return 0 si l'account n'a pas de session
+		/// active. Complexite O(n) ou n = nombre de connexions ; OK pour V1.
+		uint32_t FindConnIdForAccount(uint64_t accountId) const;
+
+		/// Resout l'accountId -> sessionIdHeader pour pouvoir adresser un push
+		/// au bon client. \return 0 si pas de session.
+		uint64_t FindSessionIdForAccount(uint64_t accountId) const;
+
+		/// Helper push : envoie un paquet pre-construit au compte si online.
+		/// \return true si l'envoi a ete tente (peut quand meme echouer cote
+		/// reseau), false si l'account n'est pas online.
+		bool SendPacketToAccount(uint64_t accountId, const std::vector<uint8_t>& packet);
+
+		engine::server::trade::TradeSessionRegistry* m_reg        = nullptr;
+		NetServer*                                    m_server     = nullptr;
+		SessionManager*                               m_sessionMgr = nullptr;
+		ConnectionSessionMap*                         m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -46,6 +46,8 @@
 #include "src/masterd/handlers/gmtickets/GmTicketHandler.h"
 #include "src/masterd/gmtickets/GmTicketSystem.h"
 #include "src/masterd/gmtickets/MysqlGmTicketStore.h"
+#include "src/masterd/handlers/trade/TradeHandler.h"
+#include "src/masterd/trade/TradeSessionRegistry.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
 #include "src/shared/core/Config.h"
@@ -433,6 +435,20 @@ int main(int argc, char** argv)
 		LOG_WARN(Net, "[ServerMain] GmTicketHandler running in no-DB mode (no persistence)");
 	}
 
+	// CMANGOS.27 (Phase 4.27 step 3+4) -- Trade wire server. Le registry est
+	// transient (pas persiste cote DB) : au reboot, toutes les trades en cours
+	// sont implicitement perdues, ce qui est acceptable pour le V1 (les
+	// clients re-affichent une UI vide au prochain login). Les opcodes 83/86/
+	// 88/91/93 sont dispatches au handler ; les responses 84/87/89/92 et les
+	// push notifications 85/90/94 sont emis par le handler aux participants.
+	engine::server::trade::TradeSessionRegistry tradeRegistry;
+	engine::server::TradeHandler tradeHandler;
+	tradeHandler.SetRegistry(&tradeRegistry);
+	tradeHandler.SetServer(&server);
+	tradeHandler.SetSessionManager(&sessionManager);
+	tradeHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] TradeHandler configured (CMANGOS.27 step 3+4, transient registry)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -472,7 +488,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -518,6 +534,12 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeGmTicketListMineRequest
 		      || opcode == kOpcodeGmTicketCancelRequest)
 			gmTicketHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeTradeBeginRequest
+		      || opcode == kOpcodeTradeSetOfferRequest
+		      || opcode == kOpcodeTradeLockRequest
+		      || opcode == kOpcodeTradeCommitRequest
+		      || opcode == kOpcodeTradeCancelRequest)
+			tradeHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/masterd/trade/TradeSessionRegistry.cpp
+++ b/src/masterd/trade/TradeSessionRegistry.cpp
@@ -1,0 +1,62 @@
+// CMANGOS.27 (Phase 4.27 step 3+4) -- Implementation TradeSessionRegistry.
+
+#include "src/masterd/trade/TradeSessionRegistry.h"
+
+namespace engine::server::trade
+{
+	SessionId TradeSessionRegistry::Begin(uint64_t accountA, uint64_t accountB)
+	{
+		// Refuse selfTrade : la verification est aussi cote handler (pour
+		// retourner SelfTrade comme code d'erreur), mais on protege ici aussi.
+		if (accountA == 0u || accountB == 0u || accountA == accountB)
+			return 0u;
+		// Refuse si l'un des 2 est deja dans une trade.
+		if (m_byAccount.count(accountA) != 0u || m_byAccount.count(accountB) != 0u)
+			return 0u;
+
+		const SessionId sid = m_next++;
+		m_sessions.emplace(sid,
+			std::make_unique<engine::server::trade::TradeSession>(accountA, accountB));
+		m_byAccount.emplace(accountA, sid);
+		m_byAccount.emplace(accountB, sid);
+		return sid;
+	}
+
+	engine::server::trade::TradeSession* TradeSessionRegistry::GetById(SessionId sid)
+	{
+		auto it = m_sessions.find(sid);
+		if (it == m_sessions.end()) return nullptr;
+		return it->second.get();
+	}
+
+	engine::server::trade::TradeSession* TradeSessionRegistry::GetByAccount(uint64_t accountId)
+	{
+		auto itAcc = m_byAccount.find(accountId);
+		if (itAcc == m_byAccount.end()) return nullptr;
+		return GetById(itAcc->second);
+	}
+
+	bool TradeSessionRegistry::IsInTrade(uint64_t accountId) const
+	{
+		return m_byAccount.count(accountId) != 0u;
+	}
+
+	SessionId TradeSessionRegistry::GetSessionByAccount(uint64_t accountId) const
+	{
+		auto it = m_byAccount.find(accountId);
+		if (it == m_byAccount.end()) return 0u;
+		return it->second;
+	}
+
+	void TradeSessionRegistry::End(SessionId sid)
+	{
+		auto itSess = m_sessions.find(sid);
+		if (itSess == m_sessions.end()) return;
+		// Retire les 2 entrees byAccount avant de detruire la session.
+		const uint64_t a = itSess->second->PlayerA();
+		const uint64_t b = itSess->second->PlayerB();
+		m_byAccount.erase(a);
+		m_byAccount.erase(b);
+		m_sessions.erase(itSess);
+	}
+}

--- a/src/masterd/trade/TradeSessionRegistry.h
+++ b/src/masterd/trade/TradeSessionRegistry.h
@@ -1,0 +1,67 @@
+#pragma once
+// CMANGOS.27 (Phase 4.27 step 3+4) -- TradeSessionRegistry : registry des
+// TradeSession actives cote master, indexees par sessionId + reverse map
+// account_id -> sessionId pour les checks d'unicite (un compte ne peut etre
+// que dans 1 trade a la fois).
+//
+// Thread-safety : non thread-safe (appel synchrone depuis le packet handler
+// thread principal du master, comme les autres handlers du repo). Si futur
+// passage multi-thread, ajouter un mutex au niveau de toutes les operations.
+//
+// V1 : sessions transitoires (pas persistees). Au reboot, toutes les trades
+// en cours sont implicitement Cancelled (les clients re-affichent une UI vide
+// au prochain login). Si besoin futur de persistence (anti-griefing), creer
+// une table trade_sessions avec un store associe.
+
+#include "src/shardd/trade/TradeSession.h"
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+
+namespace engine::server::trade
+{
+	using SessionId = uint64_t;
+
+	/// Registry des TradeSession actives. Une session lie 2 account_id et
+	/// possede son propre sessionId monotone.
+	class TradeSessionRegistry
+	{
+	public:
+		TradeSessionRegistry() = default;
+
+		/// Tente de creer une nouvelle session entre \p accountA et \p accountB.
+		/// \return un sessionId non-zero en cas de succes, 0 si l'un des 2 est
+		///         deja dans une trade (ou si accountA == accountB).
+		/// Effet de bord : ajoute la session aux 2 maps internes.
+		SessionId Begin(uint64_t accountA, uint64_t accountB);
+
+		/// \return le pointeur sur la TradeSession associee a \p sid, ou nullptr.
+		/// Ne transfere pas ownership ; le pointeur reste valide jusqu'a End(sid).
+		engine::server::trade::TradeSession* GetById(SessionId sid);
+
+		/// \return le pointeur sur la TradeSession ou \p accountId est partie A
+		///         ou partie B, ou nullptr s'il n'est dans aucune trade.
+		engine::server::trade::TradeSession* GetByAccount(uint64_t accountId);
+
+		/// True ssi \p accountId est partie d'une trade active.
+		bool IsInTrade(uint64_t accountId) const;
+
+		/// \return le sessionId de la trade ou \p accountId est partie, ou 0.
+		SessionId GetSessionByAccount(uint64_t accountId) const;
+
+		/// Termine la session \p sid : retire des 2 maps. Pas d'erreur si \p sid
+		/// est inconnu (idempotent). Apres End(), GetById(sid) retourne nullptr.
+		void End(SessionId sid);
+
+		/// Nombre de trades actives. Test/diagnostic.
+		size_t Count() const { return m_sessions.size(); }
+
+	private:
+		SessionId m_next = 1;
+		std::unordered_map<SessionId, std::unique_ptr<engine::server::trade::TradeSession>> m_sessions;
+		/// account_id -> sessionId. Maintenu en miroir de m_sessions pour les
+		/// 2 parties (A et B) de chaque trade.
+		std::unordered_map<uint64_t, SessionId> m_byAccount;
+	};
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -275,4 +275,45 @@ namespace engine::network
 		constexpr uint16_t kOpcodeGmTicketCancelRequest        = 80u; ///< Client to Master : annule son propre ticket.
 		constexpr uint16_t kOpcodeGmTicketCancelResponse       = 81u; ///< Master to Client : OK / NotFound / NotOwner / AlreadyResolved.
 		constexpr uint16_t kOpcodeGmTicketResolvedNotification = 82u; ///< Master to Client (push, request_id=0) : un GM a resolu un ticket de ce joueur.
+
+		// -------------------------------------------------------------------------
+		// Opcodes Trade (valeurs 83-94)
+		// Reference : Phase 4 CMANGOS.27 step 3+4. Wire client<->master pour le
+		// systeme d'echange direct entre 2 joueurs (TradeSession FSM :
+		// Open -> LockedA/B -> BothLocked -> Committed/Cancelled). Le step 1
+		// (TradeSession header-only) est deja merge ; pas de step 2 DB
+		// (sessions de trade transitoires, pas persistees).
+		//
+		// Architecture : le master gere un TradeSessionRegistry qui mappe
+		// account_id -> TradeSession active. Toute transition d'etat (SetOffer,
+		// Lock, Commit, Cancel) declenche une push notification a l'autre
+		// participant pour synchroniser son UI.
+		//
+		// V1 limitations :
+		//   - Resolution par account_id direct (pas encore par character_name).
+		//   - Pas d'application reelle du delta inventory au Commit (TODO wallet
+		//     integration). Le Commit valide juste la FSM.
+		//
+		// Decoupage opcode :
+		//   - Begin       (83/84) + push BeginNotification (85)
+		//   - SetOffer    (86/87)
+		//   - Lock        (88/89)
+		//   - StateUpdate push notification (90)  -> pousse aux 2 a chaque
+		//     changement d'offer/lock pour mise a jour reciproque de l'UI.
+		//   - Commit      (91/92)
+		//   - Cancel      (93) + push CancelNotification (94)
+		// -------------------------------------------------------------------------
+
+		constexpr uint16_t kOpcodeTradeBeginRequest             = 83u; ///< Client to Master : initie une demande de trade vers targetAccountId.
+		constexpr uint16_t kOpcodeTradeBeginResponse            = 84u; ///< Master to Client (initiateur) : ACK avec sessionId + partnerAccountId, ou erreur.
+		constexpr uint16_t kOpcodeTradeBeginNotification        = 85u; ///< Master to Client (push, request_id=0) : envoye au target pour annoncer la trade entrante.
+		constexpr uint16_t kOpcodeTradeSetOfferRequest          = 86u; ///< Client to Master : modifie l'offer (gold + items) cote sender. Refuse si la session est lockee cote sender.
+		constexpr uint16_t kOpcodeTradeSetOfferResponse         = 87u; ///< Master to Client : ACK ou erreur (WrongState, NotPartOfSession, ...).
+		constexpr uint16_t kOpcodeTradeLockRequest              = 88u; ///< Client to Master : verrouille l'offer cote sender.
+		constexpr uint16_t kOpcodeTradeLockResponse             = 89u; ///< Master to Client : ACK avec newState (0=Open, 1=LockedA, 2=LockedB, 3=BothLocked, ...).
+		constexpr uint16_t kOpcodeTradeStateUpdateNotification  = 90u; ///< Master to Client (push, request_id=0) : envoye au partenaire a chaque changement (offer/lock/commit/cancel).
+		constexpr uint16_t kOpcodeTradeCommitRequest            = 91u; ///< Client to Master : finalise l'echange (n'est valide qu'en BothLocked).
+		constexpr uint16_t kOpcodeTradeCommitResponse           = 92u; ///< Master to Client : ACK (OK) ou erreur (WrongState, ...).
+		constexpr uint16_t kOpcodeTradeCancelRequest            = 93u; ///< Client to Master : annule la trade (depuis n'importe quel etat non-terminal).
+		constexpr uint16_t kOpcodeTradeCancelNotification       = 94u; ///< Master to Client (push, request_id=0) : envoye aux 2 participants pour annoncer l'annulation.
 }

--- a/src/shared/network/TradePayloads.cpp
+++ b/src/shared/network/TradePayloads.cpp
@@ -1,0 +1,465 @@
+// CMANGOS.27 (Phase 4.27 step 3+4) -- Implementation Parse/Build des payloads Trade.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     cote client pour les requests (envoye via SendGenericRequestAsync qui
+//     ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send. Le requestId vient du paquet d'origine pour les
+//     responses ; les notifications utilisent requestId=0 (push asynchrone).
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/TradePayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Helper : construit un payload dans un buffer scratch dimensionne a la
+		/// limite protocole, puis le tronque a l'offset reel. Evite de calculer
+		/// la taille exacte d'avance pour les payloads de longueur variable
+		/// (offer items vector, cancel reason string, ...).
+		std::vector<uint8_t> MakeScratchBuffer()
+		{
+			return std::vector<uint8_t>(kProtocolV1MaxPacketSize, 0u);
+		}
+
+		/// Ecrit (uint64 sessionId, uint64 copperGold, uint16 itemCount + uint64 GUIDs).
+		/// Mutualise pour SetOfferRequest (86) et StateUpdateNotification (90),
+		/// qui partagent la meme sequence de champs (offer payload variable).
+		bool WriteOfferBody(ByteWriter& w, uint64_t copperGold, const std::vector<uint64_t>& itemGuids)
+		{
+			if (!w.WriteU64(copperGold))
+				return false;
+			// Tronque defensivement a kMaxTradeItemsPerOffer pour eviter un
+			// payload abusif. Le serveur fera aussi un check par securite.
+			const size_t count = (itemGuids.size() > kMaxTradeItemsPerOffer)
+				? kMaxTradeItemsPerOffer : itemGuids.size();
+			if (!w.WriteArrayCount(static_cast<uint16_t>(count)))
+				return false;
+			for (size_t i = 0; i < count; ++i)
+			{
+				if (!w.WriteU64(itemGuids[i]))
+					return false;
+			}
+			return true;
+		}
+
+		/// Lit (uint64 copperGold, uint16 itemCount + uint64 GUIDs). Symetrique
+		/// de WriteOfferBody.
+		bool ReadOfferBody(ByteReader& r, uint64_t& copperGold, std::vector<uint64_t>& itemGuids)
+		{
+			if (!r.ReadU64(copperGold))
+				return false;
+			uint16_t count = 0;
+			if (!r.ReadArrayCount(count))
+				return false;
+			if (count > kMaxTradeItemsPerOffer)
+				return false; // payload abusif rejete
+			itemGuids.clear();
+			itemGuids.reserve(count);
+			for (uint16_t i = 0; i < count; ++i)
+			{
+				uint64_t guid = 0;
+				if (!r.ReadU64(guid))
+					return false;
+				itemGuids.push_back(guid);
+			}
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_BEGIN
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeBeginRequestPayload> ParseTradeBeginRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeBeginRequestPayload out;
+		if (!r.ReadU64(out.targetAccountId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeBeginRequestPayload(uint64_t targetAccountId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(targetAccountId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<TradeBeginResponsePayload> ParseTradeBeginResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint64 sessionId (8) + uint64 partnerAccountId (8) = 17 octets.
+		if (!payload || payloadSize < 17u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeBeginResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))   return std::nullopt;
+		if (!r.ReadU64(out.sessionId))      return std::nullopt;
+		if (!r.ReadU64(out.partnerAccountId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeBeginResponsePayload(uint8_t error, uint64_t sessionId, uint64_t partnerAccountId)
+	{
+		std::vector<uint8_t> buf(17u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(sessionId))      return {};
+		if (!w.WriteU64(partnerAccountId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeBeginResponsePacket(uint8_t error, uint64_t sessionId, uint64_t partnerAccountId,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))   return {};
+		if (!w.WriteU64(sessionId))      return {};
+		if (!w.WriteU64(partnerAccountId)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeTradeBeginResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	std::optional<TradeBeginNotificationPayload> ParseTradeBeginNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint64 sessionId + uint64 partnerAccountId = 16 octets.
+		if (!payload || payloadSize < 16u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeBeginNotificationPayload out;
+		if (!r.ReadU64(out.sessionId))        return std::nullopt;
+		if (!r.ReadU64(out.partnerAccountId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeBeginNotificationPayload(uint64_t sessionId, uint64_t partnerAccountId)
+	{
+		std::vector<uint8_t> buf(16u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))        return {};
+		if (!w.WriteU64(partnerAccountId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeBeginNotificationPacket(uint64_t sessionId, uint64_t partnerAccountId,
+	                                                        uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(sessionId))        return {};
+		if (!w.WriteU64(partnerAccountId)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0 (pas de request en correspondance cote target).
+		if (!builder.Finalize(kOpcodeTradeBeginNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_SET_OFFER
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeSetOfferRequestPayload> ParseTradeSetOfferRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 sessionId (8) + uint64 copperGold (8) + uint16 count (2) = 18 octets.
+		if (!payload || payloadSize < 18u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeSetOfferRequestPayload out;
+		if (!r.ReadU64(out.sessionId)) return std::nullopt;
+		if (!ReadOfferBody(r, out.copperGold, out.itemGuids))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeSetOfferRequestPayload(uint64_t sessionId, uint64_t copperGold,
+	                                                       const std::vector<uint64_t>& itemGuids)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))     return {};
+		if (!WriteOfferBody(w, copperGold, itemGuids)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<TradeSetOfferResponsePayload> ParseTradeSetOfferResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeSetOfferResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeSetOfferResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeSetOfferResponsePacket(uint8_t error,
+	                                                       uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeTradeSetOfferResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_LOCK
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeLockRequestPayload> ParseTradeLockRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeLockRequestPayload out;
+		if (!r.ReadU64(out.sessionId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeLockRequestPayload(uint64_t sessionId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<TradeLockResponsePayload> ParseTradeLockResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error + uint8 newState = 2 octets.
+		if (!payload || payloadSize < 2u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeLockResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))    return std::nullopt;
+		if (!r.ReadBytes(&out.newState, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeLockResponsePayload(uint8_t error, uint8_t newState)
+	{
+		std::vector<uint8_t> buf(2u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u))    return {};
+		if (!w.WriteBytes(&newState, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeLockResponsePacket(uint8_t error, uint8_t newState,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u))    return {};
+		if (!w.WriteBytes(&newState, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeTradeLockResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_STATE_UPDATE_NOTIFICATION (push)
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeStateUpdateNotificationPayload> ParseTradeStateUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 sessionId (8) + uint8 state (1) + uint64 copperGold (8) + uint16 count (2) = 19 octets.
+		if (!payload || payloadSize < 19u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeStateUpdateNotificationPayload out;
+		if (!r.ReadU64(out.sessionId))     return std::nullopt;
+		if (!r.ReadBytes(&out.state, 1u))  return std::nullopt;
+		if (!ReadOfferBody(r, out.partnerCopperGold, out.partnerItemGuids))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeStateUpdateNotificationPayload(uint64_t sessionId, uint8_t state,
+	                                                                uint64_t partnerCopperGold,
+	                                                                const std::vector<uint64_t>& partnerItemGuids)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))     return {};
+		if (!w.WriteBytes(&state, 1u))  return {};
+		if (!WriteOfferBody(w, partnerCopperGold, partnerItemGuids))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeStateUpdateNotificationPacket(uint64_t sessionId, uint8_t state,
+	                                                               uint64_t partnerCopperGold,
+	                                                               const std::vector<uint64_t>& partnerItemGuids,
+	                                                               uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(sessionId))     return {};
+		if (!w.WriteBytes(&state, 1u))  return {};
+		if (!WriteOfferBody(w, partnerCopperGold, partnerItemGuids))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeTradeStateUpdateNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_COMMIT
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeCommitRequestPayload> ParseTradeCommitRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeCommitRequestPayload out;
+		if (!r.ReadU64(out.sessionId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeCommitRequestPayload(uint64_t sessionId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<TradeCommitResponsePayload> ParseTradeCommitResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeCommitResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeCommitResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeCommitResponsePacket(uint8_t error,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeTradeCommitResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// TRADE_CANCEL
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeCancelRequestPayload> ParseTradeCancelRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeCancelRequestPayload out;
+		if (!r.ReadU64(out.sessionId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeCancelRequestPayload(uint64_t sessionId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<TradeCancelNotificationPayload> ParseTradeCancelNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 sessionId (8) + uint16 reason_len (2) = 10 octets.
+		if (!payload || payloadSize < 10u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		TradeCancelNotificationPayload out;
+		if (!r.ReadU64(out.sessionId)) return std::nullopt;
+		if (!r.ReadString(out.reason)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildTradeCancelNotificationPayload(uint64_t sessionId, std::string_view reason)
+	{
+		auto buf = MakeScratchBuffer();
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(sessionId)) return {};
+		if (!w.WriteString(reason)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildTradeCancelNotificationPacket(uint64_t sessionId, std::string_view reason,
+	                                                          uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(sessionId)) return {};
+		if (!w.WriteString(reason)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeTradeCancelNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/TradePayloads.h
+++ b/src/shared/network/TradePayloads.h
@@ -1,0 +1,238 @@
+#pragma once
+// CMANGOS.27 (Phase 4.27 step 3+4) -- Wire payloads pour les opcodes Trade (83-94).
+//
+// 5 paires Request/Response + 3 push notifications :
+//   - Begin        (83/84)  + push BeginNotification (85)
+//   - SetOffer     (86/87)
+//   - Lock         (88/89)
+//   - StateUpdate  push (90)
+//   - Commit       (91/92)
+//   - Cancel       (93)     + push CancelNotification (94)
+//
+// Format wire : ByteReader/ByteWriter little-endian, vectors prefixes par
+// uint16 count via WriteArrayCount/ReadArrayCount, strings length-prefixed
+// (uint16 + UTF-8 bytes) via WriteString/ReadString.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur Trade -- wire-level. Mapping cote serveur depuis l'API
+	// TradeSession + checks de routing dans TradeHandler.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Trade.
+	/// 0 = OK ; sinon sessionId == 0 ou state non-significatif selon le cas.
+	enum class TradeErrorCode : uint8_t
+	{
+		Ok                = 0,
+		PartnerOffline    = 1,  ///< Le partenaire vise n'a pas de session active sur le master.
+		PartnerInTrade    = 2,  ///< Sender ou target est deja dans une autre TradeSession.
+		SelfTrade         = 3,  ///< Tentative de trade avec soi-meme.
+		InvalidSession    = 4,  ///< sessionId inconnu cote registry.
+		NotPartOfSession  = 5,  ///< L'expediteur n'est ni A ni B de la session ciblee.
+		WrongState        = 6,  ///< Action FSM invalide (ex: Commit avant BothLocked).
+		SessionTerminal   = 7,  ///< Session deja Committed ou Cancelled.
+		Unauthorized      = 8,  ///< Pas de session valide cote master.
+	};
+
+	/// Plafond du nombre d'items par offer cote wire. Au-dela, le serveur
+	/// retourne WrongState (ou tronque en silence) pour eviter un payload
+	/// gigantesque. Aligne avec la limite UI (8 slots de trade, mais on
+	/// laisse une marge pour stack splitting interne).
+	inline constexpr size_t kMaxTradeItemsPerOffer = 16u;
+
+	// =========================================================================
+	// TRADE_BEGIN -- Client -> Master : initie une demande de trade.
+	// =========================================================================
+
+	/// Wire format : uint64 targetAccountId.
+	struct TradeBeginRequestPayload
+	{
+		uint64_t targetAccountId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error            (cf. TradeErrorCode)
+	///   uint64 sessionId        (0 si error != Ok)
+	///   uint64 partnerAccountId (0 si error != Ok)
+	struct TradeBeginResponsePayload
+	{
+		uint8_t  error            = 0;
+		uint64_t sessionId        = 0;
+		uint64_t partnerAccountId = 0;
+	};
+
+	/// TRADE_BEGIN_NOTIFICATION (push, request_id=0). Envoye au target pour
+	/// l'informer qu'un trade entrant a ete cree. Wire format :
+	///   uint64 sessionId
+	///   uint64 partnerAccountId   (l'initiateur, du point de vue du target)
+	struct TradeBeginNotificationPayload
+	{
+		uint64_t sessionId        = 0;
+		uint64_t partnerAccountId = 0;
+	};
+
+	// =========================================================================
+	// TRADE_SET_OFFER -- Client -> Master : (re)definit l'offer cote sender.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 sessionId
+	///   uint64 copperGold
+	///   uint16 itemCount
+	///   <itemCount> uint64 itemGuid
+	struct TradeSetOfferRequestPayload
+	{
+		uint64_t              sessionId   = 0;
+		uint64_t              copperGold  = 0;
+		std::vector<uint64_t> itemGuids;
+	};
+
+	/// Wire format : uint8 error.
+	struct TradeSetOfferResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// TRADE_LOCK -- Client -> Master : verrouille l'offer cote sender.
+	// =========================================================================
+
+	/// Wire format : uint64 sessionId.
+	struct TradeLockRequestPayload
+	{
+		uint64_t sessionId = 0;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	///   uint8 newState   (0=Open, 1=LockedA, 2=LockedB, 3=BothLocked, 4=Committed, 5=Cancelled)
+	struct TradeLockResponsePayload
+	{
+		uint8_t error    = 0;
+		uint8_t newState = 0;
+	};
+
+	// =========================================================================
+	// TRADE_STATE_UPDATE_NOTIFICATION -- Master -> Client (push, request_id=0).
+	// Pousse au partenaire a chaque changement (SetOffer / Lock / Commit /
+	// Cancel cote autre joueur) pour rafraichir l'UI miroir.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 sessionId
+	///   uint8  state             (FSM courant)
+	///   uint64 partnerCopperGold (offer cote l'autre joueur)
+	///   uint16 itemCount
+	///   <itemCount> uint64 itemGuid
+	struct TradeStateUpdateNotificationPayload
+	{
+		uint64_t              sessionId         = 0;
+		uint8_t               state             = 0;
+		uint64_t              partnerCopperGold = 0;
+		std::vector<uint64_t> partnerItemGuids;
+	};
+
+	// =========================================================================
+	// TRADE_COMMIT -- Client -> Master : finalise l'echange.
+	// =========================================================================
+
+	/// Wire format : uint64 sessionId.
+	struct TradeCommitRequestPayload
+	{
+		uint64_t sessionId = 0;
+	};
+
+	/// Wire format : uint8 error.
+	struct TradeCommitResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// TRADE_CANCEL -- Client -> Master : annule la trade.
+	// =========================================================================
+
+	/// Wire format : uint64 sessionId.
+	struct TradeCancelRequestPayload
+	{
+		uint64_t sessionId = 0;
+	};
+
+	/// TRADE_CANCEL_NOTIFICATION (push, request_id=0). Envoye aux 2 participants
+	/// pour annoncer l'annulation et fermer l'UI cote chacun. Wire format :
+	///   uint64 sessionId
+	///   string reason   (peut etre vide ; ex : "partner cancelled", "timeout")
+	struct TradeCancelNotificationPayload
+	{
+		uint64_t    sessionId = 0;
+		std::string reason;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build -- Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeBeginRequestPayload>     ParseTradeBeginRequestPayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeSetOfferRequestPayload>  ParseTradeSetOfferRequestPayload (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeLockRequestPayload>      ParseTradeLockRequestPayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeCommitRequestPayload>    ParseTradeCommitRequestPayload   (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeCancelRequestPayload>    ParseTradeCancelRequestPayload   (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildTradeBeginRequestPayload     (uint64_t targetAccountId);
+	std::vector<uint8_t> BuildTradeSetOfferRequestPayload  (uint64_t sessionId, uint64_t copperGold,
+	                                                         const std::vector<uint64_t>& itemGuids);
+	std::vector<uint8_t> BuildTradeLockRequestPayload      (uint64_t sessionId);
+	std::vector<uint8_t> BuildTradeCommitRequestPayload    (uint64_t sessionId);
+	std::vector<uint8_t> BuildTradeCancelRequestPayload    (uint64_t sessionId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build -- Responses + push notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<TradeBeginResponsePayload>             ParseTradeBeginResponsePayload            (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeBeginNotificationPayload>         ParseTradeBeginNotificationPayload        (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeSetOfferResponsePayload>          ParseTradeSetOfferResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeLockResponsePayload>              ParseTradeLockResponsePayload             (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeStateUpdateNotificationPayload>   ParseTradeStateUpdateNotificationPayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeCommitResponsePayload>            ParseTradeCommitResponsePayload           (const uint8_t* payload, size_t payloadSize);
+	std::optional<TradeCancelNotificationPayload>        ParseTradeCancelNotificationPayload       (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildTradeBeginResponsePayload            (uint8_t error, uint64_t sessionId, uint64_t partnerAccountId);
+	std::vector<uint8_t> BuildTradeBeginNotificationPayload        (uint64_t sessionId, uint64_t partnerAccountId);
+	std::vector<uint8_t> BuildTradeSetOfferResponsePayload         (uint8_t error);
+	std::vector<uint8_t> BuildTradeLockResponsePayload             (uint8_t error, uint8_t newState);
+	std::vector<uint8_t> BuildTradeStateUpdateNotificationPayload  (uint64_t sessionId, uint8_t state,
+	                                                                 uint64_t partnerCopperGold,
+	                                                                 const std::vector<uint64_t>& partnerItemGuids);
+	std::vector<uint8_t> BuildTradeCommitResponsePayload           (uint8_t error);
+	std::vector<uint8_t> BuildTradeCancelNotificationPayload       (uint64_t sessionId, std::string_view reason);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildTradeBeginResponsePacket             (uint8_t error, uint64_t sessionId, uint64_t partnerAccountId,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeBeginNotificationPacket         (uint64_t sessionId, uint64_t partnerAccountId,
+	                                                                 uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeSetOfferResponsePacket          (uint8_t error,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeLockResponsePacket              (uint8_t error, uint8_t newState,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeStateUpdateNotificationPacket   (uint64_t sessionId, uint8_t state,
+	                                                                 uint64_t partnerCopperGold,
+	                                                                 const std::vector<uint64_t>& partnerItemGuids,
+	                                                                 uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeCommitResponsePacket            (uint8_t error,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildTradeCancelNotificationPacket        (uint64_t sessionId, std::string_view reason,
+	                                                                 uint64_t sessionIdHeader);
+}

--- a/src/shared/network/TradePayloadsTests.cpp
+++ b/src/shared/network/TradePayloadsTests.cpp
@@ -1,0 +1,358 @@
+/**
+ * CMANGOS.27 (Phase 4.27 step 3+4) -- Round-trip tests for TRADE_*_REQUEST /
+ * TRADE_*_RESPONSE / TRADE_*_NOTIFICATION payloads. Pure encoding tests
+ * (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ *
+ * Test policy : symetrique aux GmTicketPayloadsTests.cpp -- pas de framework
+ * de test externe, juste un Assert local + main() qui appelle chaque suite.
+ */
+
+#include "src/shared/network/TradePayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// TRADE_BEGIN
+// -----------------------------------------------------------------------------
+
+static void TestBeginRequestRoundTrip()
+{
+	auto buf = BuildTradeBeginRequestPayload(424242ull);
+	Assert(buf.size() == 8u, "Begin request is 8 bytes");
+	auto parsed = ParseTradeBeginRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->targetAccountId == 424242ull, "Begin request round-trips");
+}
+
+static void TestBeginRequestRejectsShort()
+{
+	uint8_t shortBuf[7]{};
+	auto parsed = ParseTradeBeginRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "Begin request rejects 7 bytes");
+	auto parsed2 = ParseTradeBeginRequestPayload(nullptr, 8u);
+	Assert(!parsed2.has_value(), "Begin request rejects nullptr");
+}
+
+static void TestBeginResponseRoundTrip()
+{
+	auto buf = BuildTradeBeginResponsePayload(0u, 17ull, 99ull);
+	Assert(buf.size() == 17u, "Begin response is 17 bytes (1 + 8 + 8)");
+	auto parsed = ParseTradeBeginResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Begin response parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Begin response error 0");
+		Assert(parsed->sessionId == 17ull, "Begin response sessionId");
+		Assert(parsed->partnerAccountId == 99ull, "Begin response partner");
+	}
+}
+
+static void TestBeginResponseError()
+{
+	auto buf = BuildTradeBeginResponsePayload(
+		static_cast<uint8_t>(TradeErrorCode::PartnerOffline), 0ull, 0ull);
+	auto parsed = ParseTradeBeginResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "PartnerOffline decodes");
+}
+
+static void TestBeginResponsePacket()
+{
+	auto pkt = BuildTradeBeginResponsePacket(0u, 17ull, 99ull, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Begin response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeTradeBeginResponse, "Opcode is TradeBeginResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseTradeBeginResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->sessionId == 17ull, "payload decodes");
+}
+
+static void TestBeginNotificationRoundTrip()
+{
+	auto buf = BuildTradeBeginNotificationPayload(17ull, 42ull);
+	Assert(buf.size() == 16u, "BeginNotification is 16 bytes");
+	auto parsed = ParseTradeBeginNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "BeginNotification parses");
+	if (parsed)
+	{
+		Assert(parsed->sessionId == 17ull, "BeginNotification sessionId");
+		Assert(parsed->partnerAccountId == 42ull, "BeginNotification partner");
+	}
+}
+
+static void TestBeginNotificationPacket()
+{
+	auto pkt = BuildTradeBeginNotificationPacket(17ull, 42ull, 0xDEADull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "BeginNotification packet parses");
+	Assert(view.Opcode() == kOpcodeTradeBeginNotification, "Opcode TradeBeginNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+}
+
+// -----------------------------------------------------------------------------
+// TRADE_SET_OFFER
+// -----------------------------------------------------------------------------
+
+static void TestSetOfferRequestRoundTrip()
+{
+	std::vector<uint64_t> guids = {1ull, 2ull, 3ull, 0xFFFFFFFFFFFFFFFFull};
+	auto buf = BuildTradeSetOfferRequestPayload(17ull, 100000ull, guids);
+	auto parsed = ParseTradeSetOfferRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "SetOffer request parses");
+	if (parsed)
+	{
+		Assert(parsed->sessionId == 17ull, "SetOffer sessionId");
+		Assert(parsed->copperGold == 100000ull, "SetOffer copperGold");
+		Assert(parsed->itemGuids.size() == 4u, "SetOffer 4 items");
+		Assert(parsed->itemGuids[3] == 0xFFFFFFFFFFFFFFFFull, "SetOffer max guid");
+	}
+}
+
+static void TestSetOfferRequestEmpty()
+{
+	auto buf = BuildTradeSetOfferRequestPayload(17ull, 0ull, {});
+	auto parsed = ParseTradeSetOfferRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->itemGuids.empty(), "SetOffer empty list round-trips");
+}
+
+static void TestSetOfferRequestTruncate()
+{
+	std::vector<uint64_t> too_many(kMaxTradeItemsPerOffer + 5u, 7ull);
+	auto buf = BuildTradeSetOfferRequestPayload(17ull, 0ull, too_many);
+	auto parsed = ParseTradeSetOfferRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "SetOffer truncates oversize list");
+	if (parsed)
+		Assert(parsed->itemGuids.size() == kMaxTradeItemsPerOffer, "SetOffer truncated to kMaxTradeItemsPerOffer");
+}
+
+static void TestSetOfferRequestRejectsShort()
+{
+	uint8_t shortBuf[10]{};
+	auto parsed = ParseTradeSetOfferRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "SetOffer rejects 10 bytes");
+}
+
+static void TestSetOfferResponseRoundTrip()
+{
+	auto buf = BuildTradeSetOfferResponsePayload(0u);
+	Assert(buf.size() == 1u, "SetOffer response is 1 byte");
+	auto parsed = ParseTradeSetOfferResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "SetOffer response 0");
+	auto buf2 = BuildTradeSetOfferResponsePayload(
+		static_cast<uint8_t>(TradeErrorCode::WrongState));
+	auto parsed2 = ParseTradeSetOfferResponsePayload(buf2.data(), buf2.size());
+	Assert(parsed2.has_value() && parsed2->error == 6u, "SetOffer WrongState");
+}
+
+// -----------------------------------------------------------------------------
+// TRADE_LOCK
+// -----------------------------------------------------------------------------
+
+static void TestLockRequestRoundTrip()
+{
+	auto buf = BuildTradeLockRequestPayload(99ull);
+	auto parsed = ParseTradeLockRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->sessionId == 99ull, "Lock round-trips");
+}
+
+static void TestLockResponseRoundTrip()
+{
+	auto buf = BuildTradeLockResponsePayload(0u, 3u);
+	Assert(buf.size() == 2u, "Lock response is 2 bytes");
+	auto parsed = ParseTradeLockResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Lock response parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Lock response error 0");
+		Assert(parsed->newState == 3u, "Lock response newState BothLocked");
+	}
+}
+
+static void TestLockResponsePacket()
+{
+	auto pkt = BuildTradeLockResponsePacket(0u, 1u, 7u, 0xBEEFull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Lock packet parses");
+	Assert(view.Opcode() == kOpcodeTradeLockResponse, "Opcode TradeLockResponse");
+	auto parsed = ParseTradeLockResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->newState == 1u, "Lock payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// TRADE_STATE_UPDATE_NOTIFICATION
+// -----------------------------------------------------------------------------
+
+static void TestStateUpdateRoundTrip()
+{
+	std::vector<uint64_t> guids = {10ull, 20ull, 30ull};
+	auto buf = BuildTradeStateUpdateNotificationPayload(17ull, 3u, 5000ull, guids);
+	auto parsed = ParseTradeStateUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "StateUpdate parses");
+	if (parsed)
+	{
+		Assert(parsed->sessionId == 17ull, "StateUpdate sessionId");
+		Assert(parsed->state == 3u, "StateUpdate state BothLocked");
+		Assert(parsed->partnerCopperGold == 5000ull, "StateUpdate gold");
+		Assert(parsed->partnerItemGuids.size() == 3u, "StateUpdate 3 items");
+		Assert(parsed->partnerItemGuids[2] == 30ull, "StateUpdate item[2]");
+	}
+}
+
+static void TestStateUpdateEmpty()
+{
+	auto buf = BuildTradeStateUpdateNotificationPayload(17ull, 0u, 0ull, {});
+	auto parsed = ParseTradeStateUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->partnerItemGuids.empty(), "StateUpdate empty parses");
+}
+
+static void TestStateUpdatePacket()
+{
+	auto pkt = BuildTradeStateUpdateNotificationPacket(17ull, 1u, 999ull, {1ull, 2ull}, 0xDEADull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "StateUpdate packet parses");
+	Assert(view.Opcode() == kOpcodeTradeStateUpdateNotification, "Opcode TradeStateUpdateNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	auto parsed = ParseTradeStateUpdateNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->partnerItemGuids.size() == 2u, "StateUpdate payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// TRADE_COMMIT
+// -----------------------------------------------------------------------------
+
+static void TestCommitRequestRoundTrip()
+{
+	auto buf = BuildTradeCommitRequestPayload(17ull);
+	Assert(buf.size() == 8u, "Commit request 8 bytes");
+	auto parsed = ParseTradeCommitRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->sessionId == 17ull, "Commit request round-trips");
+}
+
+static void TestCommitResponseRoundTrip()
+{
+	auto buf = BuildTradeCommitResponsePayload(0u);
+	auto parsed = ParseTradeCommitResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Commit response OK");
+	auto buf2 = BuildTradeCommitResponsePayload(
+		static_cast<uint8_t>(TradeErrorCode::WrongState));
+	auto parsed2 = ParseTradeCommitResponsePayload(buf2.data(), buf2.size());
+	Assert(parsed2.has_value() && parsed2->error == 6u, "Commit WrongState decodes");
+}
+
+// -----------------------------------------------------------------------------
+// TRADE_CANCEL
+// -----------------------------------------------------------------------------
+
+static void TestCancelRequestRoundTrip()
+{
+	auto buf = BuildTradeCancelRequestPayload(17ull);
+	auto parsed = ParseTradeCancelRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->sessionId == 17ull, "Cancel request round-trips");
+}
+
+static void TestCancelNotificationRoundTrip()
+{
+	const std::string reason = "partner cancelled the trade";
+	auto buf = BuildTradeCancelNotificationPayload(17ull, reason);
+	auto parsed = ParseTradeCancelNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "CancelNotification parses");
+	if (parsed)
+	{
+		Assert(parsed->sessionId == 17ull, "CancelNotification sessionId");
+		Assert(parsed->reason == reason, "CancelNotification reason round-trips");
+	}
+}
+
+static void TestCancelNotificationEmptyReason()
+{
+	auto buf = BuildTradeCancelNotificationPayload(17ull, "");
+	auto parsed = ParseTradeCancelNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->reason.empty(), "CancelNotification empty reason OK");
+}
+
+static void TestCancelNotificationPacket()
+{
+	auto pkt = BuildTradeCancelNotificationPacket(17ull, "timeout", 0xCAFEull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "CancelNotification packet parses");
+	Assert(view.Opcode() == kOpcodeTradeCancelNotification, "Opcode TradeCancelNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	auto parsed = ParseTradeCancelNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->reason == "timeout", "CancelNotification payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// Boundary
+// -----------------------------------------------------------------------------
+
+static void TestBoundaryMaxSession()
+{
+	auto buf = BuildTradeLockRequestPayload(0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseTradeLockRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->sessionId == 0xFFFFFFFFFFFFFFFFull, "Lock max sessionId round-trips");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestBeginRequestRoundTrip();
+	TestBeginRequestRejectsShort();
+	TestBeginResponseRoundTrip();
+	TestBeginResponseError();
+	TestBeginResponsePacket();
+	TestBeginNotificationRoundTrip();
+	TestBeginNotificationPacket();
+
+	TestSetOfferRequestRoundTrip();
+	TestSetOfferRequestEmpty();
+	TestSetOfferRequestTruncate();
+	TestSetOfferRequestRejectsShort();
+	TestSetOfferResponseRoundTrip();
+
+	TestLockRequestRoundTrip();
+	TestLockResponseRoundTrip();
+	TestLockResponsePacket();
+
+	TestStateUpdateRoundTrip();
+	TestStateUpdateEmpty();
+	TestStateUpdatePacket();
+
+	TestCommitRequestRoundTrip();
+	TestCommitResponseRoundTrip();
+
+	TestCancelRequestRoundTrip();
+	TestCancelNotificationRoundTrip();
+	TestCancelNotificationEmptyReason();
+	TestCancelNotificationPacket();
+
+	TestBoundaryMaxSession();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all trade payload tests passed\n" : "[FAIL] some trade tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Trade FSM wire — server + client

Branche \`TradeSession\` FSM (step 1 mergé) sur le wire et l'UI client. Master gère les sessions de trade entre 2 clients online.

### Server wire
- \`ProtocolV1Constants.h\` : opcodes 83-94 (5 paires Request/Response + 3 push)
- \`src/shared/network/TradePayloads.{h,cpp,Tests.cpp}\`
- \`src/masterd/trade/TradeSessionRegistry.{h,cpp}\` : registry sessions actives par accountId
- \`src/masterd/handlers/trade/TradeHandler.{h,cpp}\` : dispatch + push aux 2 clients
- \`src/masterd/main_linux.cpp\` : instancie + dispatch

### Client integration
- \`src/client/trade/TradeWindowUi\` étendu : SetSendCallback, actions RequestBegin/SetOffer/Lock/Commit/Cancel + handlers réception
- \`src/client/app/Engine\` : dispatch opcodes 84/85/87/89/90/92/94, slash \`/trade <id>\` et \`/trade cancel\`

### V1 limitations
- Résolution par account_id direct
- **Inventory non transactionnel** : Commit avance la FSM mais n'applique pas de delta inventory réel (TODO wallet integration + lock items pour éviter dupe)
- Pas de timer anti-scam (re-lock obligatoire si offer change après lock)
- Pas d'intégration UIModel.tradeWindow pour le renderer ImGui (pont à ajouter en sub-PR)

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 83-94 + handler. Pas d'impact ancien client.

Generated with Claude Code