### PR TITLE
feat(reputation): wire server + UI client (Phase 3 CMANGOS.24 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ add_library(engine_core
   src/client/social/FriendsUi.cpp
   src/client/social/IgnoreListUi.cpp
   src/client/gmtickets/GmTicketUi.cpp
+  src/client/reputation/ReputationUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
   src/shared/net/ChatSystem.cpp
@@ -334,6 +335,7 @@ add_library(engine_core
   src/client/render/ChatImGuiRenderer.cpp
   src/client/render/MailImGuiRenderer.cpp
   src/client/render/GmTicketImGuiRenderer.cpp
+  src/client/render/ReputationImGuiRenderer.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp
   src/client/render/DecalPass.cpp
@@ -426,6 +428,7 @@ add_library(engine_core
   src/shared/network/MailPayloads.cpp
   src/shared/network/QuestPayloads.cpp
   src/shared/network/GmTicketPayloads.cpp
+  src/shared/network/ReputationPayloads.cpp
   src/shared/network/TradePayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
@@ -653,6 +656,11 @@ add_test(NAME ignore_list_payloads_tests COMMAND ignore_list_payloads_tests)
 add_executable(gm_ticket_payloads_tests src/shared/network/GmTicketPayloadsTests.cpp)
 target_link_libraries(gm_ticket_payloads_tests PRIVATE engine_core)
 add_test(NAME gm_ticket_payloads_tests COMMAND gm_ticket_payloads_tests)
+
+# CMANGOS.24 (Phase 3.24 step 3+4): REPUTATION_*_REQUEST/RESPONSE payload round-trip tests
+add_executable(reputation_payloads_tests src/shared/network/ReputationPayloadsTests.cpp)
+target_link_libraries(reputation_payloads_tests PRIVATE engine_core)
+add_test(NAME reputation_payloads_tests COMMAND reputation_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,12 +117,14 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/social/IgnoreListHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/trade/TradeHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/reputation/ReputationHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/QuestPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GmTicketPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/TradePayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ReputationPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12,6 +12,7 @@
 #include "src/shared/network/MailPayloads.h"
 #include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/GmTicketPayloads.h"
+#include "src/shared/network/ReputationPayloads.h"
 #include "src/shared/network/TradePayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -19,6 +20,7 @@
 #include "src/client/render/ChatImGuiRenderer.h"
 #include "src/client/render/MailImGuiRenderer.h"
 #include "src/client/render/GmTicketImGuiRenderer.h"
+#include "src/client/render/ReputationImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -855,6 +857,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.24 (Phase 3.24 step 3+4) — Init du presenter Reputation +
+		// cable du send callback. Reception dispatchee dans le push handler
+		// ci-dessous (opcodes 96/97). Fire-and-forget de la requete 95 via
+		// SendGenericRequestAsync.
+		if (!m_reputationUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] ReputationUiPresenter init FAILED — panneau reputation desactive");
+		}
+		else
+		{
+			m_reputationUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -951,6 +968,22 @@ namespace engine
 				}
 				m_tradeWindowUi.RequestBeginTrade(targetAccountId);
 				LOG_INFO(Core, "[Engine] /trade {}", targetAccountId);
+				return true;
+			}
+			// CMANGOS.24 (Phase 3.24 step 3+4) — Slash command /rep et /reputation
+			// pour ouvrir/fermer le panneau Reputation et synchroniser la liste
+			// depuis le master au moment de l'ouverture.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/rep" || text == "/reputation"
+				    || text.starts_with("/rep ") || text.starts_with("/rep\t")
+				    || text.starts_with("/reputation ") || text.starts_with("/reputation\t")))
+			{
+				m_reputationVisible = !m_reputationVisible;
+				if (m_reputationVisible)
+				{
+					m_reputationUi.RequestReputationList();
+				}
+				LOG_INFO(Core, "[Engine] /rep toggle (visible={})", m_reputationVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1249,6 +1282,30 @@ namespace engine
 					return;
 				}
 				m_gmTicketUi.OnResolvedNotification(*parsed);
+				return;
+			}
+			// CMANGOS.24 (Phase 3.24 step 3+4) — Dispatch des reponses Reputation
+			// (96) + push UpdateNotification (97).
+			case kOpcodeReputationListResponse:
+			{
+				auto parsed = ParseReputationListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] REPUTATION_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_reputationUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeReputationUpdateNotification:
+			{
+				auto parsed = ParseReputationUpdateNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] REPUTATION_UPDATE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_reputationUi.OnUpdateNotification(*parsed);
 				return;
 			}
 			// CMANGOS.27 (Phase 4.27 step 3+4) — Dispatch des reponses Trade
@@ -3464,6 +3521,7 @@ namespace engine
 		m_chatUi.Shutdown();
 		m_mailUi.Shutdown();
 		m_gmTicketUi.Shutdown();
+		m_reputationUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3673,6 +3731,12 @@ namespace engine
 				// taille viewport est mise a jour dans la boucle Render plus bas.
 				m_gmTicketImGui = std::make_unique<engine::render::GmTicketImGuiRenderer>();
 				m_gmTicketImGui->SetPresenter(&m_gmTicketUi);
+				// CMANGOS.24 (Phase 3.24 step 3+4) — Renderer ImGui du panneau
+				// Reputation. Partage le contexte ImGui avec auth/chat/mail/gmtickets.
+				// Visible uniquement quand m_reputationVisible (toggle via /rep).
+				// La taille viewport est mise a jour dans la boucle Render plus bas.
+				m_reputationImGui = std::make_unique<engine::render::ReputationImGuiRenderer>();
+				m_reputationImGui->SetPresenter(&m_reputationUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -4702,6 +4766,16 @@ namespace engine
 				m_gmTicketImGui->SetEnabled(true);
 				m_gmTicketImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_gmTicketImGui->Render();
+			}
+			// CMANGOS.24 (Phase 3.24 step 3+4) — Tick le toast (expire ~3s) puis
+			// render le panneau Reputation si visible. Le toast push est rendu
+			// en plus de la liste si actif (overlay non bloquant).
+			m_reputationUi.TickToast(static_cast<float>(m_time.DeltaSeconds()));
+			if (m_reputationVisible && m_reputationImGui && m_reputationUi.IsInitialized())
+			{
+				m_reputationImGui->SetEnabled(true);
+				m_reputationImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_reputationImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -11,6 +11,7 @@
 #include "src/client/quest/QuestUi.h"
 #include "src/client/social/IgnoreListUi.h"
 #include "src/client/gmtickets/GmTicketUi.h"
+#include "src/client/reputation/ReputationUi.h"
 #include "src/client/trade/TradeWindowUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
@@ -69,6 +70,7 @@ namespace engine::render
 	class ChatImGuiRenderer;
 	class MailImGuiRenderer;
 	class GmTicketImGuiRenderer;
+	class ReputationImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -329,6 +331,10 @@ namespace engine
 		/// Partage le contexte ImGui avec m_authImGui / m_chatImGui / m_mailImGui.
 		/// Visibilite pilotee par \c m_gmTicketsVisible (toggle via slash command /ticket).
 		std::unique_ptr<engine::render::GmTicketImGuiRenderer> m_gmTicketImGui;
+		/// CMANGOS.24 (Phase 3.24 step 3+4) — Panneau "Reputation" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec auth/chat/mail/gmtickets. Visible uniquement
+		/// quand m_reputationVisible (toggle via slash command /rep ou /reputation).
+		std::unique_ptr<engine::render::ReputationImGuiRenderer> m_reputationImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -416,6 +422,13 @@ namespace engine
 		/// CMANGOS.32 (Phase 5.32 step 3+4) — Visibilite du panneau Support GM
 		/// (toggle via slash command \c /ticket ou \c /gmticket). Faux par defaut.
 		bool                                m_gmTicketsVisible = false;
+		/// CMANGOS.24 (Phase 3.24 step 3+4) — Presenter de la liste de reputations.
+		/// Recoit la reponse opcode 96 et le push 97 via le push handler du master ;
+		/// fire-and-forget de la requete 95 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::ReputationUiPresenter m_reputationUi;
+		/// CMANGOS.24 (Phase 3.24 step 3+4) — Visibilite du panneau Reputation
+		/// (toggle via slash command \c /rep ou \c /reputation). Faux par defaut.
+		bool                                  m_reputationVisible = false;
 		/// CMANGOS.27 (Phase 4.27 step 3+4) — Presenter de la fenetre d'echange
 		/// direct entre 2 joueurs. Recoit les responses opcodes 84/87/89/92 et
 		/// les push notifications 85/90/94 via le push handler du master ;

--- a/src/client/render/ReputationImGuiRenderer.cpp
+++ b/src/client/render/ReputationImGuiRenderer.cpp
@@ -1,0 +1,285 @@
+// CMANGOS.24 (Phase 3.24 step 3+4) — ReputationImGuiRenderer implementation.
+
+#include "src/client/render/ReputationImGuiRenderer.h"
+
+#include "src/client/reputation/ReputationUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Bornes par standing (synchronise avec ReputationManager::StandingFor).
+		/// Retourne la valeur min de l'intervalle pour le standing donne.
+		int32_t StandingMin(int8_t standing)
+		{
+			switch (standing)
+			{
+			case -6: return -42000;  // Hated
+			case -5: return -6000;   // Hostile
+			case -4: return -3000;   // Unfriendly
+			case -3: return -42000;  // Neutral (couvre tout l'intervalle <= 0 a partir de -3000)
+			case -2: return 0;       // Friendly
+			case -1: return 3000;    // Honored
+			case 0:  return 9000;    // Revered
+			case 1:  return 21000;   // Exalted
+			default: return -42000;
+			}
+		}
+
+		/// Bornes par standing : valeur max de l'intervalle.
+		int32_t StandingMax(int8_t standing)
+		{
+			switch (standing)
+			{
+			case -6: return -42001; // pas de progress dans Hated (clamp min)
+			case -5: return -3001;  // Hostile : -6000..-3001
+			case -4: return -1;     // Unfriendly : -3000..-1
+			case -3: return 0;      // Neutral : ..0
+			case -2: return 3000;   // Friendly : 0..3000
+			case -1: return 9000;   // Honored : 3000..9000
+			case 0:  return 21000;  // Revered : 9000..21000
+			case 1:  return 41999;  // Exalted : 21000..41999
+			default: return 41999;
+			}
+		}
+
+		/// Libelle FR pour un standing.
+		const char* StandingLabel(int8_t standing)
+		{
+			switch (standing)
+			{
+			case -6: return "Haine";
+			case -5: return "Hostile";
+			case -4: return "Inamical";
+			case -3: return "Neutre";
+			case -2: return "Amical";
+			case -1: return "Honore";
+			case 0:  return "Revere";
+			case 1:  return "Exalte";
+			default: return "?";
+			}
+		}
+
+		/// Couleur du texte / barre selon le standing.
+		ImVec4 StandingColor(int8_t standing)
+		{
+			switch (standing)
+			{
+			case -6: return ImVec4(0.85f, 0.18f, 0.18f, 1.0f); // Hated rouge fonce
+			case -5: return ImVec4(0.95f, 0.30f, 0.20f, 1.0f); // Hostile rouge
+			case -4: return ImVec4(0.95f, 0.55f, 0.20f, 1.0f); // Unfriendly orange
+			case -3: return ImVec4(0.70f, 0.70f, 0.70f, 1.0f); // Neutral gris
+			case -2: return ImVec4(0.40f, 0.85f, 0.40f, 1.0f); // Friendly vert clair
+			case -1: return ImVec4(0.30f, 0.90f, 0.30f, 1.0f); // Honored vert
+			case 0:  return ImVec4(0.95f, 0.78f, 0.30f, 1.0f); // Revered or
+			case 1:  return ImVec4(1.00f, 0.85f, 0.20f, 1.0f); // Exalted or vif
+			default: return ImVec4(0.70f, 0.70f, 0.70f, 1.0f);
+			}
+		}
+
+		/// Construit un nom de faction par defaut.
+		/// V1 : pas de map id->name client (ticket FactionTemplate fournira la
+		/// localisation ulterieurement). Hardcode "Faction #N".
+		std::string FactionDisplayName(uint32_t factionId)
+		{
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Faction #%u", static_cast<unsigned>(factionId));
+			return buf;
+		}
+
+		/// Calcule le ratio [0..1] du progress dans le standing courant.
+		float StandingProgressRatio(int32_t value, int8_t standing)
+		{
+			const int32_t lo = StandingMin(standing);
+			const int32_t hi = StandingMax(standing);
+			if (hi <= lo)
+				return 1.0f;
+			const float ratio = static_cast<float>(value - lo)
+				/ static_cast<float>(hi - lo);
+			return std::clamp(ratio, 0.0f, 1.0f);
+		}
+	}
+
+	void ReputationImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderListPanel();
+		RenderToast();
+	}
+
+	void ReputationImGuiRenderer::RenderListPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 350x500.
+		const float panelW = 350.f;
+		const float panelH = 500.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Reputation##ln_reputation_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge) — non bloquante.
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			if (ImGui::Button("Rafraichir"))
+			{
+				m_presenter->RequestReputationList();
+			}
+			ImGui::SameLine();
+			ImGui::TextDisabled("(%zu faction%s)",
+				state.entries.size(), state.entries.size() > 1 ? "s" : "");
+
+			ImGui::Separator();
+
+			if (state.isLoading)
+			{
+				ImGui::TextUnformatted("Chargement...");
+			}
+			else if (state.entries.empty())
+			{
+				ImGui::TextDisabled("Aucune reputation enregistree.");
+			}
+			else
+			{
+				const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+					| ImGuiTableFlags_RowBg
+					| ImGuiTableFlags_ScrollY
+					| ImGuiTableFlags_Resizable;
+				if (ImGui::BeginTable("##ln_reputation_list", 4, tableFlags, ImVec2(0.f, 0.f)))
+				{
+					ImGui::TableSetupColumn("Faction",  ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableSetupColumn("Standing", ImGuiTableColumnFlags_WidthFixed,  85.f);
+					ImGui::TableSetupColumn("Valeur",   ImGuiTableColumnFlags_WidthFixed,  60.f);
+					ImGui::TableSetupColumn("Progres",  ImGuiTableColumnFlags_WidthFixed,  80.f);
+					ImGui::TableHeadersRow();
+
+					for (const auto& e : state.entries)
+					{
+						ImGui::TableNextRow();
+						ImGui::PushID(static_cast<int>(e.factionId));
+
+						ImGui::TableSetColumnIndex(0);
+						const std::string name = FactionDisplayName(e.factionId);
+						ImGui::TextUnformatted(name.c_str());
+
+						ImGui::TableSetColumnIndex(1);
+						const ImVec4 col = StandingColor(e.standing);
+						ImGui::PushStyleColor(ImGuiCol_Text, col);
+						ImGui::TextUnformatted(StandingLabel(e.standing));
+						ImGui::PopStyleColor();
+
+						ImGui::TableSetColumnIndex(2);
+						ImGui::Text("%d", e.value);
+
+						ImGui::TableSetColumnIndex(3);
+						const float ratio = StandingProgressRatio(e.value, e.standing);
+						ImGui::PushStyleColor(ImGuiCol_PlotHistogram, col);
+						ImGui::ProgressBar(ratio, ImVec2(-FLT_MIN, 0.f), "");
+						ImGui::PopStyleColor();
+
+						ImGui::PopID();
+					}
+					ImGui::EndTable();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void ReputationImGuiRenderer::RenderToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastUpdateToast.has_value())
+			return;
+
+		const auto& upd = *state.lastUpdateToast;
+		const std::string name = FactionDisplayName(upd.factionId);
+		const char*       lab  = StandingLabel(upd.standing);
+		const ImVec4      col  = StandingColor(upd.standing);
+
+		// Toast en haut centre-droit.
+		const float toastW = 320.f;
+		const float toastH = 70.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = margin;
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.85f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.85f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoNav
+			| ImGuiWindowFlags_NoInputs;
+		if (ImGui::Begin("##ln_reputation_toast", nullptr, flags))
+		{
+			const int32_t delta = state.lastUpdateToastDelta;
+			char buf[160]{};
+			if (delta >= 0)
+				std::snprintf(buf, sizeof(buf), "+%d %s", delta, name.c_str());
+			else
+				std::snprintf(buf, sizeof(buf), "%d %s", delta, name.c_str());
+			ImGui::PushStyleColor(ImGuiCol_Text, col);
+			ImGui::TextUnformatted(buf);
+			ImGui::PopStyleColor();
+
+			std::snprintf(buf, sizeof(buf), "-> %s (%d)", lab, upd.value);
+			ImGui::TextUnformatted(buf);
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void ReputationImGuiRenderer::Render()           {}
+	void ReputationImGuiRenderer::RenderListPanel()  {}
+	void ReputationImGuiRenderer::RenderToast()      {}
+}
+
+#endif

--- a/src/client/render/ReputationImGuiRenderer.h
+++ b/src/client/render/ReputationImGuiRenderer.h
@@ -1,0 +1,45 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24 step 3+4) — ReputationImGuiRenderer : panneau ImGui
+// pour la liste de reputations cote joueur. Lit l'etat d'un
+// ReputationUiPresenter, dispatch les inputs UI vers le presenter via
+// accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class ReputationUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau Reputation. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::ReputationUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs UI
+	/// vers le presenter.
+	class ReputationImGuiRenderer
+	{
+	public:
+		ReputationImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::ReputationUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Reputation" + toast push s'il est actif.
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), apres
+		/// NewFrame, si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		void RenderListPanel();
+		void RenderToast();
+
+		engine::client::ReputationUiPresenter* m_presenter = nullptr;
+		bool                                    m_enabled  = false;
+		uint32_t                                m_viewportW = 0;
+		uint32_t                                m_viewportH = 0;
+	};
+}

--- a/src/client/reputation/ReputationUi.cpp
+++ b/src/client/reputation/ReputationUi.cpp
@@ -1,0 +1,151 @@
+// CMANGOS.24 (Phase 3.24 step 3+4) — Implementation ReputationUiPresenter.
+
+#include "src/client/reputation/ReputationUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Duree d'affichage du toast push en secondes.
+		constexpr float kToastDurationSeconds = 3.0f;
+	}
+
+	ReputationUiPresenter::~ReputationUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool ReputationUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[ReputationUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_state.layoutValid = true;
+		m_clockSeconds = 0.0f;
+		LOG_INFO(Core, "[ReputationUiPresenter] Init OK");
+		return true;
+	}
+
+	void ReputationUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		// Ne pas reset m_send : il est cable une fois au boot et on garde la
+		// reference (Engine::Shutdown sera responsable du teardown ordonne).
+		LOG_INFO(Core, "[ReputationUiPresenter] Destroyed");
+	}
+
+	void ReputationUiPresenter::RequestReputationList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ReputationUiPresenter] RequestReputationList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildReputationListRequestPayload();
+		m_state.isLoading = true;
+		if (!m_send(engine::network::kOpcodeReputationListRequest, payload))
+		{
+			m_state.isLoading = false;
+			m_state.lastErrorText = "Echec envoi (liste reputations).";
+			LOG_WARN(Net, "[ReputationUiPresenter] RequestReputationList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[ReputationUiPresenter] ReputationListRequest queued");
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ReputationUiPresenter::RebuildEntriesFromResponse(const engine::network::ReputationListResponsePayload& resp)
+	{
+		m_state.entries.clear();
+		m_state.entries.reserve(resp.entries.size());
+		for (const auto& e : resp.entries)
+		{
+			ReputationEntryView v;
+			v.factionId = e.factionId;
+			v.value     = e.value;
+			v.standing  = e.standing;
+			m_state.entries.push_back(v);
+		}
+	}
+
+	void ReputationUiPresenter::OnListResponse(const engine::network::ReputationListResponsePayload& resp)
+	{
+		m_state.isLoading = false;
+		if (resp.error != 0u)
+		{
+			using engine::network::ReputationErrorCode;
+			if (static_cast<ReputationErrorCode>(resp.error) == ReputationErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur lors du chargement des reputations.";
+			LOG_WARN(Net, "[ReputationUiPresenter] OnListResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		RebuildEntriesFromResponse(resp);
+		LOG_INFO(Net, "[ReputationUiPresenter] OnListResponse: {} entries",
+			m_state.entries.size());
+	}
+
+	void ReputationUiPresenter::UpdateOrInsertEntry(uint32_t factionId, int32_t newValue, int8_t newStanding)
+	{
+		for (auto& e : m_state.entries)
+		{
+			if (e.factionId == factionId)
+			{
+				e.value    = newValue;
+				e.standing = newStanding;
+				return;
+			}
+		}
+		// Insert : la faction n'etait pas dans la liste (rep gagnee pour la
+		// premiere fois). Ajout en queue ; le renderer triera.
+		ReputationEntryView v;
+		v.factionId = factionId;
+		v.value     = newValue;
+		v.standing  = newStanding;
+		m_state.entries.push_back(v);
+	}
+
+	void ReputationUiPresenter::OnUpdateNotification(const engine::network::ReputationUpdateNotificationPayload& note)
+	{
+		UpdateOrInsertEntry(note.factionId, note.newValue, note.newStanding);
+
+		// Arme le toast pour ~3s.
+		ReputationEntryView v;
+		v.factionId = note.factionId;
+		v.value     = note.newValue;
+		v.standing  = note.newStanding;
+		m_state.lastUpdateToast        = v;
+		m_state.lastUpdateToastDelta   = note.delta;
+		m_state.lastUpdateToastExpireAt = m_clockSeconds + kToastDurationSeconds;
+
+		LOG_INFO(Net, "[ReputationUiPresenter] OnUpdateNotification: faction={} newValue={} standing={} delta={}",
+			note.factionId, note.newValue, static_cast<int>(note.newStanding), note.delta);
+	}
+
+	void ReputationUiPresenter::TickToast(float deltaSeconds)
+	{
+		if (deltaSeconds <= 0.0f) return;
+		m_clockSeconds += deltaSeconds;
+		if (m_state.lastUpdateToast.has_value()
+			&& m_clockSeconds >= m_state.lastUpdateToastExpireAt)
+		{
+			m_state.lastUpdateToast.reset();
+			m_state.lastUpdateToastDelta    = 0;
+			m_state.lastUpdateToastExpireAt = 0.0f;
+		}
+	}
+}

--- a/src/client/reputation/ReputationUi.h
+++ b/src/client/reputation/ReputationUi.h
@@ -1,0 +1,119 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24 step 3+4) — Presenter client de la liste de
+// reputations. Maintient un cache local des reputations par faction +
+// affiche un toast non-bloquant sur la derniere mise a jour push.
+//
+// Pas de rendu ImGui : le panneau est drawe par ReputationImGuiRenderer qui
+// lit l'etat via GetState() et propage les inputs UI via les methodes du
+// presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans QuestUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes 96/97 vers
+// les OnXxx du presenter.
+
+#include "src/shared/network/ReputationPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::client
+{
+	/// Une entree de la liste de reputations exposable au layer UI.
+	/// Mirror direct de ReputationEntry sur le wire mais avec des champs
+	/// nommes pour le renderer.
+	struct ReputationEntryView
+	{
+		uint32_t factionId = 0;
+		int32_t  value     = 0; ///< [-42000 ; +41999] cmangos.
+		int8_t   standing  = 0; ///< -6 Hated ... +1 Exalted (cf. ReputationStanding).
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct ReputationUiState
+	{
+		std::vector<ReputationEntryView> entries;
+		bool                             isLoading = false;
+		std::string                      lastErrorText;       ///< Vide si pas d'erreur transitoire.
+		/// Toast non-bloquant : derniere mise a jour push (factionId, newValue, standing, delta).
+		/// Le renderer affiche un toast en haut du panneau pendant ~3s.
+		std::optional<ReputationEntryView> lastUpdateToast;
+		int32_t                          lastUpdateToastDelta = 0; ///< delta de la derniere notification (signed).
+		float                            lastUpdateToastExpireAt = 0.0f; ///< game seconds (cf. TickToast).
+		bool                             layoutValid = false;
+	};
+
+	/// Presenter pour le panneau Reputation cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main.
+	class ReputationUiPresenter final
+	{
+	public:
+		ReputationUiPresenter() = default;
+
+		ReputationUiPresenter(const ReputationUiPresenter&)            = delete;
+		ReputationUiPresenter& operator=(const ReputationUiPresenter&) = delete;
+
+		~ReputationUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.24 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestReputationList.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie REPUTATION_LIST_REQUEST. Reponse via OnListResponse.
+		/// Met aussi m_state.isLoading = true le temps de la reponse.
+		void RequestReputationList();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit REPUTATION_LIST_RESPONSE. Remplace la cache locale.
+		void OnListResponse(const engine::network::ReputationListResponsePayload& resp);
+
+		/// Recoit un push REPUTATION_UPDATE_NOTIFICATION : update entry locale +
+		/// arme le toast pour ~3s.
+		void OnUpdateNotification(const engine::network::ReputationUpdateNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// Tick / state access
+		// ---------------------------------------------------------------------
+
+		/// Avance le compteur de toast et clear l'overlay si expire. \p deltaSeconds
+		/// est le dt frame (en secondes). A appeler chaque frame depuis Engine.
+		void TickToast(float deltaSeconds);
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const ReputationUiState& GetState() const { return m_state; }
+
+	private:
+		/// Met a jour m_state.entries depuis une reponse server.
+		void RebuildEntriesFromResponse(const engine::network::ReputationListResponsePayload& resp);
+
+		/// Met a jour ou insere une entree apres push notification.
+		void UpdateOrInsertEntry(uint32_t factionId, int32_t newValue, int8_t newStanding);
+
+		bool                  m_initialized       = false;
+		ReputationUiState     m_state{};
+		SendCallback          m_send;
+		float                 m_clockSeconds      = 0.0f; ///< Cumul depuis Init() (non monotonic, juste utilise pour comparer expiry).
+	};
+}

--- a/src/masterd/handlers/reputation/ReputationHandler.cpp
+++ b/src/masterd/handlers/reputation/ReputationHandler.cpp
@@ -1,0 +1,182 @@
+// CMANGOS.24 (Phase 3.24 step 3+4) — Implementation ReputationHandler.
+
+#include "src/masterd/handlers/reputation/ReputationHandler.h"
+
+#include "src/masterd/reputation/MysqlReputationStore.h"
+#include "src/masterd/reputation/ReputationManager.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/ReputationPayloads.h"
+
+namespace engine::server
+{
+	void ReputationHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_mgr || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[ReputationHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(ReputationErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeReputationListRequest:
+				pkt = BuildReputationListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeReputationListRequest:
+			HandleListRequest(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ReputationHandler::HandleListRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+		using engine::server::reputation::ReputationManager;
+		using engine::server::reputation::ReputationStanding;
+
+		// Le manager n'expose pas d'iteration directe sur les factions d'un account ;
+		// on utilise donc le store comme source de verite a la List : si le store
+		// est present, on Load depuis la DB (qui contient toutes les factions
+		// connues du compte) puis on hydrate le manager (best-effort) pour les
+		// futures requetes. Si pas de store, on retourne une liste vide
+		// (V1 acceptable — le manager sera populate au fur et a mesure des gains).
+		std::vector<ReputationEntry> entries;
+		if (m_store)
+		{
+			const auto rows = m_store->Load(accountId);
+			entries.reserve(rows.size());
+			for (const auto& row : rows)
+			{
+				ReputationEntry e;
+				e.factionId = row.factionId;
+				e.value     = row.value;
+				e.standing  = static_cast<int8_t>(ReputationManager::StandingFor(row.value));
+				entries.push_back(e);
+			}
+		}
+
+		LOG_INFO(Net, "[ReputationHandler] List account={} count={}", accountId, entries.size());
+
+		auto pkt = BuildReputationListResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	bool ReputationHandler::ApplyReputationDelta(uint64_t accountId, uint32_t factionId, int32_t delta)
+	{
+		using namespace engine::network;
+		using engine::server::reputation::ReputationManager;
+
+		if (!m_mgr)
+		{
+			LOG_WARN(Net, "[ReputationHandler] ApplyReputationDelta : no manager (account={}, faction={})",
+				accountId, factionId);
+			return false;
+		}
+
+		// Applique au manager (le manager applique aussi le spillover automatiquement).
+		m_mgr->GainReputation(accountId, factionId, delta);
+		const int32_t newValue = m_mgr->GetReputation(accountId, factionId);
+		const auto    standing = ReputationManager::StandingFor(newValue);
+		const int8_t  standingByte = static_cast<int8_t>(standing);
+
+		// Persistance best-effort.
+		if (m_store)
+		{
+			if (!m_store->Upsert(accountId, factionId, newValue))
+			{
+				LOG_WARN(Net, "[ReputationHandler] Upsert failed (account={}, faction={}, value={})",
+					accountId, factionId, newValue);
+			}
+		}
+
+		LOG_INFO(Net, "[ReputationHandler] ApplyDelta account={} faction={} delta={} newValue={} standing={}",
+			accountId, factionId, delta, newValue, static_cast<int>(standingByte));
+
+		// Push notification au client si online (seulement la faction primaire en V1).
+		const uint32_t targetConn = FindConnIdForAccount(accountId);
+		const uint64_t targetSessionIdHeader = FindSessionIdForAccount(accountId);
+		if (targetConn != 0u && targetSessionIdHeader != 0u && m_server)
+		{
+			auto pkt = BuildReputationUpdateNotificationPacket(
+				factionId, newValue, standingByte, delta, targetSessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(targetConn, pkt);
+		}
+
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+
+	uint32_t ReputationHandler::FindConnIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return connId;
+		}
+		return 0u;
+	}
+
+	uint64_t ReputationHandler::FindSessionIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			(void)connId;
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return sessionId;
+		}
+		return 0u;
+	}
+}

--- a/src/masterd/handlers/reputation/ReputationHandler.h
+++ b/src/masterd/handlers/reputation/ReputationHandler.h
@@ -1,0 +1,101 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24 step 3+4) — ReputationHandler : dispatch des opcodes
+// Reputation (95-97) et appel des methodes correspondantes du
+// ReputationManager + persistance via MysqlReputationStore.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour
+// l'opcode 95 (REPUTATION_LIST_REQUEST).
+//
+// Le handler expose aussi une API publique ApplyReputationDelta() qu'un autre
+// handler (QuestHandler, futurs LootHandler / KillHandler / etc.) peut
+// appeler pour declencher un changement de reputation cote serveur. Le
+// changement est applique au manager (avec spillover), persiste en DB, et
+// pousse au client via REPUTATION_UPDATE_NOTIFICATION (opcode 97) si le
+// joueur est connecte. V1 limitations : seule la faction primaire est push,
+// les valeurs spillover restent silencieuses (sub-PR future).
+//
+// Validation session : REPUTATION_LIST_REQUEST exige une session authentifiee.
+// Si pas de session, on repond avec error=Unauthorized (code 6).
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::reputation
+{
+	class ReputationManager;
+	class MysqlReputationStore;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Reputation. Doit etre configure via Set*() avant tout HandlePacket.
+	class ReputationHandler
+	{
+	public:
+		/// Branche le manager in-memory (autorite runtime des valeurs de rep + spillover).
+		void SetManager(engine::server::reputation::ReputationManager* mgr) { m_mgr = mgr; }
+		/// Branche le store MySQL (persistance + reload au login). Optionnel : si
+		/// nullptr, le handler reste fonctionnel mais ne persiste pas en DB.
+		void SetStore(engine::server::reputation::MysqlReputationStore* store) { m_store = store; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* server) { m_server = server; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Reputation.
+		/// Dispatch vers HandleListRequest selon l'opcode. Si l'opcode n'est pas
+		/// un opcode Reputation, ignore silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (95).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : applique un delta de reputation a un account/faction.
+		/// Le manager applique le spillover automatiquement. Le store persiste
+		/// best-effort la nouvelle valeur. Si le client est en ligne, un push
+		/// REPUTATION_UPDATE_NOTIFICATION est envoye (factionId direct
+		/// uniquement — V1 ne push pas le spillover).
+		///
+		/// \param accountId  compte cible.
+		/// \param factionId  faction cible (la rule de spillover, si presente, propage).
+		/// \param delta      variation a appliquer (clamp [-42000, +41999] cote manager).
+		/// \return true si le manager + store ont applique le changement, false en cas d'erreur cote handler (manager nul, etc.). Le push notification est best-effort (false n'indique pas un echec push).
+		bool ApplyReputationDelta(uint64_t accountId, uint32_t factionId, int32_t delta);
+
+	private:
+		/// Traite REPUTATION_LIST_REQUEST : enumere les reputations de l'account
+		/// depuis le manager (charge depuis le store si l'account n'a aucune
+		/// rep en cache et qu'un store est branche).
+		void HandleListRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le connId actif d'un account_id (snapshot ConnectionSessionMap +
+		/// resolution session->account). Retourne 0 si offline.
+		uint32_t FindConnIdForAccount(uint64_t accountId) const;
+		/// Recherche le sessionIdHeader actif d'un account_id. Retourne 0 si offline.
+		uint64_t FindSessionIdForAccount(uint64_t accountId) const;
+
+		engine::server::reputation::ReputationManager*    m_mgr        = nullptr;
+		engine::server::reputation::MysqlReputationStore* m_store      = nullptr;
+		NetServer*                                         m_server     = nullptr;
+		SessionManager*                                    m_sessionMgr = nullptr;
+		ConnectionSessionMap*                              m_connMap    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -38,7 +38,10 @@
 #include "src/masterd/mail/MailManager.h"
 #include "src/masterd/mail/MysqlMailStore.h"
 #include "src/masterd/handlers/quest/QuestHandler.h"
+#include "src/masterd/handlers/reputation/ReputationHandler.h"
 #include "src/masterd/quests/MysqlQuestStateStore.h"
+#include "src/masterd/reputation/MysqlReputationStore.h"
+#include "src/masterd/reputation/ReputationManager.h"
 #include "src/masterd/quests/QuestState.h"
 #include "src/masterd/handlers/social/IgnoreListHandler.h"
 #include "src/masterd/social/IgnoreList.h"
@@ -449,6 +452,29 @@ int main(int argc, char** argv)
 	tradeHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] TradeHandler configured (CMANGOS.27 step 3+4, transient registry)");
 
+	// CMANGOS.24 (Phase 3.24 step 3+4) — Reputation wire server.
+	// Le manager in-memory est l'autorite runtime des reputations + spillover.
+	// Le store MySQL sert de persistance (et de source de verite pour la
+	// REPUTATION_LIST_REQUEST en V1, cf. ReputationHandler::HandleListRequest).
+	// En mode no-DB, la liste retournee au client est vide (le manager n'expose
+	// pas d'iteration directe sur les factions d'un account en V1).
+	engine::server::reputation::ReputationManager reputationManager;
+	engine::server::reputation::MysqlReputationStore reputationStore(&dbPool);
+	engine::server::ReputationHandler reputationHandler;
+	reputationHandler.SetManager(&reputationManager);
+	reputationHandler.SetServer(&server);
+	reputationHandler.SetSessionManager(&sessionManager);
+	reputationHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		reputationHandler.SetStore(&reputationStore);
+		LOG_INFO(Net, "[ServerMain] ReputationHandler configured with DB store (CMANGOS.24 step 3+4)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] ReputationHandler running in no-DB mode (List will return empty)");
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -488,7 +514,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -540,6 +566,8 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeTradeCommitRequest
 		      || opcode == kOpcodeTradeCancelRequest)
 			tradeHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeReputationListRequest)
+			reputationHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -316,4 +316,30 @@ namespace engine::network
 		constexpr uint16_t kOpcodeTradeCommitResponse           = 92u; ///< Master to Client : ACK (OK) ou erreur (WrongState, ...).
 		constexpr uint16_t kOpcodeTradeCancelRequest            = 93u; ///< Client to Master : annule la trade (depuis n'importe quel etat non-terminal).
 		constexpr uint16_t kOpcodeTradeCancelNotification       = 94u; ///< Master to Client (push, request_id=0) : envoye aux 2 participants pour annoncer l'annulation.
+
+	// -------------------------------------------------------------------------
+	// Opcodes Reputation (valeurs 95-97)
+	// Reference : Phase 3 CMANGOS.24 step 3+4. Wire client<->master pour la
+	// reputation par account/faction. Le step 1 (ReputationManager header-only,
+	// avec spillover bitmask) et le step 2 (MysqlReputationStore + migration
+	// 0047) sont deja merges. La reputation est read-only cote client : le
+	// serveur seul decide quand l'incrementer (quete reward, kill, etc.).
+	//
+	// Decoupage opcode :
+	//   - List   (95/96)               : le client demande la liste de ses
+	//     reputations (faction, value, standing).
+	//   - UpdateNotification (97, push) : le serveur notifie le client d'un
+	//     changement (suite a un game event). V1 ne pousse que la faction
+	//     primaire — les valeurs spillover sont persistees mais pas push.
+	//
+	// V1 limitations :
+	//   - Faction names hardcodes "Faction #N" cote client (FactionTemplate
+	//     ticket viendra fournir le map id->name).
+	//   - Pas de rate limiting sur les push (un par GainReputation direct).
+	//   - 98 et 99 reserves pour usage futur.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeReputationListRequest        = 95u; ///< Client to Master : liste les reputations de l'account courant (vide).
+	constexpr uint16_t kOpcodeReputationListResponse       = 96u; ///< Master to Client : tableau {factionId, value, standing} ou Unauthorized.
+	constexpr uint16_t kOpcodeReputationUpdateNotification = 97u; ///< Master to Client (push, request_id=0) : changement d'une reputation (factionId, newValue, newStanding, delta).
 }

--- a/src/shared/network/ReputationPayloads.cpp
+++ b/src/shared/network/ReputationPayloads.cpp
@@ -1,0 +1,193 @@
+// CMANGOS.24 (Phase 3.24 step 3+4) — Implementation Parse/Build des payloads Reputation.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+//
+// Note : ByteWriter/ByteReader n'ont pas WriteI32/ReadI32. On serialise les
+// int32 via static_cast<uint32_t>(value) et on lit via static_cast<int32_t>.
+// Le pattern bit-pour-bit est conserve (two's complement).
+
+#include "src/shared/network/ReputationPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit une entree (uint32 factionId, int32 value, int8 standing).
+		bool WriteEntry(ByteWriter& w, const ReputationEntry& e)
+		{
+			if (!w.WriteU32(e.factionId))                          return false;
+			if (!w.WriteU32(static_cast<uint32_t>(e.value)))       return false;
+			const uint8_t standingByte = static_cast<uint8_t>(e.standing);
+			if (!w.WriteBytes(&standingByte, 1u))                  return false;
+			return true;
+		}
+
+		/// Lit une entree (uint32 factionId, int32 value, int8 standing).
+		bool ReadEntry(ByteReader& r, ReputationEntry& e)
+		{
+			if (!r.ReadU32(e.factionId))                           return false;
+			uint32_t valueRaw = 0;
+			if (!r.ReadU32(valueRaw))                              return false;
+			e.value = static_cast<int32_t>(valueRaw);
+			uint8_t standingByte = 0;
+			if (!r.ReadBytes(&standingByte, 1u))                   return false;
+			e.standing = static_cast<int8_t>(standingByte);
+			return true;
+		}
+
+		/// Serialise la partie « apres error » de REPUTATION_LIST_RESPONSE.
+		bool WriteListBody(ByteWriter& w, uint8_t error, const std::vector<ReputationEntry>& entries)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(entries.size())))
+				return false;
+			for (const auto& e : entries)
+			{
+				if (!WriteEntry(w, e))
+					return false;
+			}
+			return true;
+		}
+
+		/// Serialise un push UPDATE_NOTIFICATION.
+		bool WriteUpdateBody(ByteWriter& w, uint32_t factionId, int32_t newValue, int8_t newStanding, int32_t delta)
+		{
+			if (!w.WriteU32(factionId))                                   return false;
+			if (!w.WriteU32(static_cast<uint32_t>(newValue)))             return false;
+			const uint8_t standingByte = static_cast<uint8_t>(newStanding);
+			if (!w.WriteBytes(&standingByte, 1u))                         return false;
+			if (!w.WriteU32(static_cast<uint32_t>(delta)))                return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// REPUTATION_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<ReputationListRequestPayload> ParseReputationListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return ReputationListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildReputationListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// REPUTATION_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<ReputationListResponsePayload> ParseReputationListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ReputationListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.entries.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			ReputationEntry e;
+			if (!ReadEntry(r, e))
+				return std::nullopt;
+			out.entries.push_back(e);
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildReputationListResponsePayload(uint8_t error, const std::vector<ReputationEntry>& entries)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListBody(w, error, entries))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildReputationListResponsePacket(uint8_t error, const std::vector<ReputationEntry>& entries,
+	                                                       uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListBody(w, error, entries))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeReputationListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// REPUTATION_UPDATE_NOTIFICATION (push, request_id=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<ReputationUpdateNotificationPayload> ParseReputationUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint32 factionId (4) + int32 newValue (4) + int8 newStanding (1) + int32 delta (4) = 13.
+		if (!payload || payloadSize < 13u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ReputationUpdateNotificationPayload out;
+		if (!r.ReadU32(out.factionId))            return std::nullopt;
+		uint32_t valueRaw = 0;
+		if (!r.ReadU32(valueRaw))                 return std::nullopt;
+		out.newValue = static_cast<int32_t>(valueRaw);
+		uint8_t standingByte = 0;
+		if (!r.ReadBytes(&standingByte, 1u))      return std::nullopt;
+		out.newStanding = static_cast<int8_t>(standingByte);
+		uint32_t deltaRaw = 0;
+		if (!r.ReadU32(deltaRaw))                 return std::nullopt;
+		out.delta = static_cast<int32_t>(deltaRaw);
+		return out;
+	}
+
+	std::vector<uint8_t> BuildReputationUpdateNotificationPayload(uint32_t factionId, int32_t newValue, int8_t newStanding, int32_t delta)
+	{
+		std::vector<uint8_t> buf(13u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteUpdateBody(w, factionId, newValue, newStanding, delta))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildReputationUpdateNotificationPacket(uint32_t factionId, int32_t newValue, int8_t newStanding, int32_t delta,
+	                                                              uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteUpdateBody(w, factionId, newValue, newStanding, delta))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeReputationUpdateNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/ReputationPayloads.h
+++ b/src/shared/network/ReputationPayloads.h
@@ -1,0 +1,111 @@
+#pragma once
+// CMANGOS.24 (Phase 3.24 step 3+4) — Wire payloads pour les opcodes Reputation (95-97).
+//
+// Une paire Request/Response + 1 push :
+//   - List               (95/96)
+//   - UpdateNotification (97 push) — Master to Client pour annoncer un changement
+//     de reputation declenche par un game event (quest reward, kill, etc.).
+//
+// La reputation est read-only cote client : le serveur seul decide de modifier.
+// Pas d'opcode "set reputation" — le client ne peut que lire (List) et reagir
+// a la notification push (UpdateNotification).
+//
+// Format wire : ByteReader/ByteWriter little-endian. Les valeurs int32 sont
+// passees via static_cast vers/depuis uint32_t (pas de WriteI32 disponible
+// dans ByteWriter — voir WriteEntry/ReadEntry dans le .cpp). Les valeurs
+// int8 (standing) passent via WriteBytes/ReadBytes 1 octet.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Reputation.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Reputation.
+	/// 0 = OK ; sinon le tableau des entries est vide.
+	enum class ReputationErrorCode : uint8_t
+	{
+		Ok           = 0,
+		Unauthorized = 6, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// REPUTATION_LIST — Client to Master : liste les reputations du compte.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct ReputationListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entree de la table de reputation (account, faction).
+	struct ReputationEntry
+	{
+		uint32_t factionId = 0;
+		int32_t  value     = 0; ///< [-42000 ; +41999] cmangos.
+		int8_t   standing  = 0; ///< cf. ReputationStanding (-6 Hated ... +1 Exalted).
+	};
+
+	/// Wire format :
+	///   uint8  error            (cf. ReputationErrorCode)
+	///   uint16 count             (si error == 0)
+	///   <count> entries          (4 + 4 + 1 octets chacune)
+	struct ReputationListResponsePayload
+	{
+		uint8_t                       error = 0;
+		std::vector<ReputationEntry>  entries;
+	};
+
+	// =========================================================================
+	// REPUTATION_UPDATE_NOTIFICATION — Master to Client (push, request_id=0).
+	// Annonce qu'un changement de reputation a eu lieu cote serveur.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 factionId   (4)
+	///   int32  newValue    (4, cast via uint32)
+	///   int8   newStanding (1)
+	///   int32  delta       (4, cast via uint32 ; positif = gain, negatif = perte)
+	struct ReputationUpdateNotificationPayload
+	{
+		uint32_t factionId   = 0;
+		int32_t  newValue    = 0;
+		int8_t   newStanding = 0;
+		int32_t  delta       = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un REPUTATION_LIST_REQUEST. Toujours OK (payload vide accepte).
+	std::optional<ReputationListRequestPayload> ParseReputationListRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildReputationListRequestPayload();
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<ReputationListResponsePayload>       ParseReputationListResponsePayload      (const uint8_t* payload, size_t payloadSize);
+	std::optional<ReputationUpdateNotificationPayload> ParseReputationUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildReputationListResponsePayload      (uint8_t error, const std::vector<ReputationEntry>& entries);
+	std::vector<uint8_t> BuildReputationUpdateNotificationPayload(uint32_t factionId, int32_t newValue, int8_t newStanding, int32_t delta);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildReputationListResponsePacket(uint8_t error, const std::vector<ReputationEntry>& entries,
+	                                                       uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildReputationUpdateNotificationPacket(uint32_t factionId, int32_t newValue, int8_t newStanding, int32_t delta,
+	                                                              uint64_t sessionIdHeader);
+}

--- a/src/shared/network/ReputationPayloadsTests.cpp
+++ b/src/shared/network/ReputationPayloadsTests.cpp
@@ -1,0 +1,211 @@
+/**
+ * CMANGOS.24 (Phase 3.24 step 3+4) — Round-trip tests for REPUTATION_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/ReputationPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// REPUTATION_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildReputationListRequestPayload();
+	Assert(buf.empty(), "List request payload empty");
+	auto parsed = ParseReputationListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildReputationListResponsePayload(0u, {});
+	auto parsed = ParseReputationListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response empty parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "List response empty error 0");
+		Assert(parsed->entries.empty(), "List response empty has 0 entries");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	auto buf = BuildReputationListResponsePayload(
+		static_cast<uint8_t>(ReputationErrorCode::Unauthorized), {});
+	auto parsed = ParseReputationListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "List response Unauthorized");
+}
+
+static void TestListResponseMultiple()
+{
+	std::vector<ReputationEntry> entries;
+	entries.push_back({1u, 0, -3});         // Neutral
+	entries.push_back({2u, 6000, -1});      // Honored
+	entries.push_back({100u, 21000, 0});    // Revered (border)
+	entries.push_back({200u, -42000, -6});  // Hated (min)
+	entries.push_back({300u, 41999, 1});    // Exalted (max)
+	auto buf = BuildReputationListResponsePayload(0u, entries);
+	auto parsed = ParseReputationListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response multiple parses");
+	if (parsed && parsed->entries.size() == 5u)
+	{
+		Assert(parsed->entries[0].factionId == 1u && parsed->entries[0].value == 0
+			&& parsed->entries[0].standing == -3, "entry[0] Neutral");
+		Assert(parsed->entries[1].factionId == 2u && parsed->entries[1].value == 6000
+			&& parsed->entries[1].standing == -1, "entry[1] Honored");
+		Assert(parsed->entries[2].factionId == 100u && parsed->entries[2].value == 21000
+			&& parsed->entries[2].standing == 0, "entry[2] Revered");
+		Assert(parsed->entries[3].factionId == 200u && parsed->entries[3].value == -42000
+			&& parsed->entries[3].standing == -6, "entry[3] Hated");
+		Assert(parsed->entries[4].factionId == 300u && parsed->entries[4].value == 41999
+			&& parsed->entries[4].standing == 1, "entry[4] Exalted");
+	}
+	else
+	{
+		Assert(false, "List response should have 5 entries");
+	}
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseReputationListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List response rejects nullptr");
+	uint8_t one[1]{0};
+	auto parsed2 = ParseReputationListResponsePayload(one, 0u);
+	Assert(!parsed2.has_value(), "List response rejects size 0");
+}
+
+static void TestListResponsePacket()
+{
+	std::vector<ReputationEntry> entries;
+	entries.push_back({42u, 1500, -2}); // Friendly
+	auto pkt = BuildReputationListResponsePacket(0u, entries, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "List response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeReputationListResponse, "Packet opcode is ReputationListResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseReputationListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->entries.size() == 1u
+		&& parsed->entries[0].factionId == 42u, "List response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// REPUTATION_UPDATE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestUpdateNotificationRoundTrip()
+{
+	auto buf = BuildReputationUpdateNotificationPayload(42u, 1500, -2, 250);
+	Assert(buf.size() == 13u, "Update notification is 13 bytes");
+	auto parsed = ParseReputationUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Update notification parses");
+	if (parsed)
+	{
+		Assert(parsed->factionId == 42u, "Update factionId");
+		Assert(parsed->newValue == 1500, "Update newValue");
+		Assert(parsed->newStanding == -2, "Update newStanding Friendly");
+		Assert(parsed->delta == 250, "Update delta");
+	}
+}
+
+static void TestUpdateNotificationNegativeDelta()
+{
+	auto buf = BuildReputationUpdateNotificationPayload(99u, -5000, -4, -1500);
+	auto parsed = ParseReputationUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Update with negative delta parses");
+	if (parsed)
+	{
+		Assert(parsed->newValue == -5000, "Negative newValue");
+		Assert(parsed->newStanding == -4, "Unfriendly standing");
+		Assert(parsed->delta == -1500, "Negative delta");
+	}
+}
+
+static void TestUpdateNotificationBoundary()
+{
+	// Values at protocol boundaries.
+	auto buf = BuildReputationUpdateNotificationPayload(0xFFFFFFFFu, -42000, -6, 41999);
+	auto parsed = ParseReputationUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Update boundary parses");
+	if (parsed)
+	{
+		Assert(parsed->factionId == 0xFFFFFFFFu, "factionId max");
+		Assert(parsed->newValue == -42000, "newValue min");
+		Assert(parsed->newStanding == -6, "Hated standing");
+		Assert(parsed->delta == 41999, "delta high");
+	}
+}
+
+static void TestUpdateNotificationRejectsShort()
+{
+	auto parsed = ParseReputationUpdateNotificationPayload(nullptr, 13u);
+	Assert(!parsed.has_value(), "Update rejects nullptr");
+	uint8_t shortBuf[12]{};
+	auto parsed2 = ParseReputationUpdateNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Update rejects 12 bytes");
+}
+
+static void TestUpdateNotificationPacket()
+{
+	auto pkt = BuildReputationUpdateNotificationPacket(42u, 1500, -2, 250, 0xBEEFull);
+	Assert(!pkt.empty(), "Update notification packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Update PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeReputationUpdateNotification, "Opcode is ReputationUpdateNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xBEEFull, "SessionId preserved");
+	auto parsed = ParseReputationUpdateNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->factionId == 42u && parsed->delta == 250,
+		"Update payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseUnauthorized();
+	TestListResponseMultiple();
+	TestListResponseRejectsShort();
+	TestListResponsePacket();
+
+	TestUpdateNotificationRoundTrip();
+	TestUpdateNotificationNegativeDelta();
+	TestUpdateNotificationBoundary();
+	TestUpdateNotificationRejectsShort();
+	TestUpdateNotificationPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all reputation payload tests passed\n"
+	                                : "[FAIL] some reputation tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Reputation wire — server + UI client

Branche \`ReputationManager\` (step 1 mergé) + \`MysqlReputationStore\` (step 2 mergé) sur le wire. UI client lit la liste et réagit au push update.

### Server wire
- \`ProtocolV1Constants.h\` : opcodes 95-97 (1 paire Request/Response + 1 push)
- \`src/shared/network/ReputationPayloads.{h,cpp,Tests.cpp}\`
- \`src/masterd/handlers/reputation/ReputationHandler.{h,cpp}\`
- \`src/masterd/main_linux.cpp\` : instancie + dispatch

### ApplyReputationDelta (helper public)
API interne sur le handler pour que QuestHandler / Loot / Kill puissent déclencher un gain de rep. Push auto au client si online + persist DB.

### Client integration
- \`src/client/reputation/ReputationUi.{h,cpp}\` : presenter + cache + toast
- \`src/client/render/ReputationImGuiRenderer.{h,cpp}\` : panel ancré droite, couleurs par standing, toast 3s
- \`src/client/app/Engine\` : dispatch 96/97 + slash \`/rep\`

### V1 limitations
- Faction names hardcodés "Faction #N" (FactionTemplate ticket à venir)
- Spillover : seule la faction primaire est push (manager calcule le spillover mais ne pousse que la faction directe)
- Aucun trigger \`ApplyReputationDelta\` câblé encore (sera fait par les futurs tickets quest reward / loot / kill)

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 95-97 + handler. Pas d'impact ancien client.

Generated with Claude Code