### PR TITLE
feat(lfg): wire server + UI client (Phase 5 CMANGOS.33 step 3+4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(engine_core
   src/client/social/IgnoreListUi.cpp
   src/client/gmtickets/GmTicketUi.cpp
   src/client/reputation/ReputationUi.cpp
+  src/client/lfg/LfgUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
   src/shared/net/ChatSystem.cpp
@@ -336,6 +337,7 @@ add_library(engine_core
   src/client/render/MailImGuiRenderer.cpp
   src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/ReputationImGuiRenderer.cpp
+  src/client/render/LfgImGuiRenderer.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp
   src/client/render/DecalPass.cpp
@@ -429,6 +431,7 @@ add_library(engine_core
   src/shared/network/QuestPayloads.cpp
   src/shared/network/GmTicketPayloads.cpp
   src/shared/network/ReputationPayloads.cpp
+  src/shared/network/LfgPayloads.cpp
   src/shared/network/TradePayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
@@ -661,6 +664,11 @@ add_test(NAME gm_ticket_payloads_tests COMMAND gm_ticket_payloads_tests)
 add_executable(reputation_payloads_tests src/shared/network/ReputationPayloadsTests.cpp)
 target_link_libraries(reputation_payloads_tests PRIVATE engine_core)
 add_test(NAME reputation_payloads_tests COMMAND reputation_payloads_tests)
+
+# CMANGOS.33 (Phase 5.33 step 3+4) — Lfg payloads round-trip tests (no DB / no network).
+add_executable(lfg_payloads_tests src/shared/network/LfgPayloadsTests.cpp)
+target_link_libraries(lfg_payloads_tests PRIVATE engine_core)
+add_test(NAME lfg_payloads_tests COMMAND lfg_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/gmtickets/GmTicketHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/trade/TradeHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/reputation/ReputationHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lfg/LfgHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -125,6 +126,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/GmTicketPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/TradePayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ReputationPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/LfgPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -13,6 +13,7 @@
 #include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/GmTicketPayloads.h"
 #include "src/shared/network/ReputationPayloads.h"
+#include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/TradePayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -21,6 +22,7 @@
 #include "src/client/render/MailImGuiRenderer.h"
 #include "src/client/render/GmTicketImGuiRenderer.h"
 #include "src/client/render/ReputationImGuiRenderer.h"
+#include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -872,6 +874,20 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.33 (Phase 5.33 step 3+4) — Init du presenter LFG + cable du
+		// send callback pour les requetes 100/102/104/107. Reception dispatchee
+		// dans le push handler ci-dessous (responses 101/103/105 + push 106).
+		if (!m_lfgUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] LfgUiPresenter init FAILED — panneau LFG desactive");
+		}
+		else
+		{
+			m_lfgUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -984,6 +1000,20 @@ namespace engine
 					m_reputationUi.RequestReputationList();
 				}
 				LOG_INFO(Core, "[Engine] /rep toggle (visible={})", m_reputationVisible);
+				return true;
+			}
+			// CMANGOS.33 (Phase 5.33 step 3+4) — Slash command /lfg pour
+			// ouvrir/fermer la fenetre LFG et synchroniser le status depuis le
+			// master au moment de l'ouverture.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/lfg" || text.starts_with("/lfg ") || text.starts_with("/lfg\t")))
+			{
+				m_lfgVisible = !m_lfgVisible;
+				if (m_lfgVisible)
+				{
+					m_lfgUi.RequestStatus();
+				}
+				LOG_INFO(Core, "[Engine] /lfg toggle (visible={})", m_lfgVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1306,6 +1336,52 @@ namespace engine
 					return;
 				}
 				m_reputationUi.OnUpdateNotification(*parsed);
+				return;
+			}
+			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
+			// (101/103/105) + push MatchProposalNotification (106).
+			case kOpcodeLfgQueueResponse:
+			{
+				auto parsed = ParseLfgQueueResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LFG_QUEUE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lfgUi.OnQueueResponse(*parsed);
+				return;
+			}
+			case kOpcodeLfgLeaveResponse:
+			{
+				auto parsed = ParseLfgLeaveResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LFG_LEAVE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lfgUi.OnLeaveResponse(*parsed);
+				return;
+			}
+			case kOpcodeLfgStatusResponse:
+			{
+				auto parsed = ParseLfgStatusResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LFG_STATUS_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lfgUi.OnStatusResponse(*parsed);
+				return;
+			}
+			case kOpcodeLfgMatchProposalNotification:
+			{
+				auto parsed = ParseLfgMatchProposalNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LFG_MATCH_PROPOSAL_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lfgUi.OnMatchProposal(*parsed);
 				return;
 			}
 			// CMANGOS.27 (Phase 4.27 step 3+4) — Dispatch des reponses Trade
@@ -3522,6 +3598,7 @@ namespace engine
 		m_mailUi.Shutdown();
 		m_gmTicketUi.Shutdown();
 		m_reputationUi.Shutdown();
+		m_lfgUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3737,6 +3814,11 @@ namespace engine
 				// La taille viewport est mise a jour dans la boucle Render plus bas.
 				m_reputationImGui = std::make_unique<engine::render::ReputationImGuiRenderer>();
 				m_reputationImGui->SetPresenter(&m_reputationUi);
+				// CMANGOS.33 (Phase 5.33 step 3+4) — Renderer ImGui du panneau LFG.
+				// Partage le contexte ImGui avec auth/chat/mail/gmtickets/reputation.
+				// Visible uniquement quand m_lfgVisible (toggle via /lfg).
+				m_lfgImGui = std::make_unique<engine::render::LfgImGuiRenderer>();
+				m_lfgImGui->SetPresenter(&m_lfgUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -4776,6 +4858,17 @@ namespace engine
 				m_reputationImGui->SetEnabled(true);
 				m_reputationImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_reputationImGui->Render();
+			}
+			// CMANGOS.33 (Phase 5.33 step 3+4) — Render du panneau LFG si visible.
+			// Le modal proposal s'affiche aussi quand hasProposal == true (meme si
+			// le panneau principal est masque), pour que le joueur ne rate pas
+			// la formation de groupe.
+			if (m_lfgImGui && m_lfgUi.IsInitialized()
+				&& (m_lfgVisible || m_lfgUi.GetState().hasProposal))
+			{
+				m_lfgImGui->SetEnabled(true);
+				m_lfgImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_lfgImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -12,6 +12,7 @@
 #include "src/client/social/IgnoreListUi.h"
 #include "src/client/gmtickets/GmTicketUi.h"
 #include "src/client/reputation/ReputationUi.h"
+#include "src/client/lfg/LfgUi.h"
 #include "src/client/trade/TradeWindowUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
@@ -71,6 +72,7 @@ namespace engine::render
 	class MailImGuiRenderer;
 	class GmTicketImGuiRenderer;
 	class ReputationImGuiRenderer;
+	class LfgImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -335,6 +337,10 @@ namespace engine
 		/// Partage le contexte ImGui avec auth/chat/mail/gmtickets. Visible uniquement
 		/// quand m_reputationVisible (toggle via slash command /rep ou /reputation).
 		std::unique_ptr<engine::render::ReputationImGuiRenderer> m_reputationImGui;
+		/// CMANGOS.33 (Phase 5.33 step 3+4) — Panneau "LFG" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec auth/chat/mail/gmtickets/reputation.
+		/// Visible uniquement quand m_lfgVisible (toggle via slash command /lfg).
+		std::unique_ptr<engine::render::LfgImGuiRenderer> m_lfgImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -429,6 +435,14 @@ namespace engine
 		/// CMANGOS.24 (Phase 3.24 step 3+4) — Visibilite du panneau Reputation
 		/// (toggle via slash command \c /rep ou \c /reputation). Faux par defaut.
 		bool                                  m_reputationVisible = false;
+		/// CMANGOS.33 (Phase 5.33 step 3+4) — Presenter de la fenetre LFG
+		/// (LookForGroup). Recoit les responses opcodes 101/103/105 et la push
+		/// notification 106 via le push handler du master ; fire-and-forget des
+		/// requetes 100/102/104/107 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::LfgUiPresenter        m_lfgUi;
+		/// CMANGOS.33 (Phase 5.33 step 3+4) — Visibilite du panneau LFG (toggle
+		/// via slash command \c /lfg). Faux par defaut.
+		bool                                  m_lfgVisible = false;
 		/// CMANGOS.27 (Phase 4.27 step 3+4) — Presenter de la fenetre d'echange
 		/// direct entre 2 joueurs. Recoit les responses opcodes 84/87/89/92 et
 		/// les push notifications 85/90/94 via le push handler du master ;

--- a/src/client/lfg/LfgUi.cpp
+++ b/src/client/lfg/LfgUi.cpp
@@ -1,0 +1,281 @@
+// CMANGOS.33 (Phase 5.33 step 3+4) — Implementation LfgUiPresenter.
+
+#include "src/client/lfg/LfgUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	LfgUiPresenter::~LfgUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool LfgUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[LfgUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_pendingRole = 0;
+		m_pendingDungeonId = 0;
+		LOG_INFO(Core, "[LfgUiPresenter] Init OK");
+		return true;
+	}
+
+	void LfgUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		// Ne pas reset m_send : il est cable une fois au boot et on garde la
+		// reference (Engine::Shutdown sera responsable du teardown ordonne).
+		LOG_INFO(Core, "[LfgUiPresenter] Destroyed");
+	}
+
+	void LfgUiPresenter::ClearQueueState()
+	{
+		m_state.inQueue           = false;
+		m_state.myRole            = 0;
+		m_state.myDungeonId       = 0;
+		m_state.elapsedSec        = 0;
+		m_state.estimatedWaitSec  = 0;
+	}
+
+	void LfgUiPresenter::ClearProposalState()
+	{
+		m_state.hasProposal       = false;
+		m_state.proposalId        = 0;
+		m_state.proposalDungeonId = 0;
+		m_state.proposalMembers.clear();
+	}
+
+	// -------------------------------------------------------------------------
+
+	void LfgUiPresenter::RequestQueue(uint8_t role, uint32_t dungeonId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LfgUiPresenter] RequestQueue: no send callback");
+			return;
+		}
+		// Validation cote client : role 0..2, dungeonId > 0. Le master
+		// validera quand meme, mais on evite un round-trip pour des inputs
+		// evidemment invalides.
+		if (role > 2u)
+		{
+			m_state.lastErrorText = "Role invalide.";
+			LOG_WARN(Net, "[LfgUiPresenter] RequestQueue: invalid role={}", static_cast<unsigned>(role));
+			return;
+		}
+		if (dungeonId == 0u)
+		{
+			m_state.lastErrorText = "Donjon non selectionne.";
+			LOG_WARN(Net, "[LfgUiPresenter] RequestQueue: invalid dungeonId");
+			return;
+		}
+
+		const auto payload = engine::network::BuildLfgQueueRequestPayload(role, dungeonId);
+		// Memorise le choix en attente de la reponse Ok.
+		m_pendingRole      = role;
+		m_pendingDungeonId = dungeonId;
+		if (!m_send(engine::network::kOpcodeLfgQueueRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (queue LFG).";
+			LOG_WARN(Net, "[LfgUiPresenter] RequestQueue: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[LfgUiPresenter] LfgQueueRequest queued (role={}, dungeon={})",
+			static_cast<unsigned>(role), dungeonId);
+	}
+
+	void LfgUiPresenter::RequestLeave()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LfgUiPresenter] RequestLeave: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildLfgLeaveRequestPayload();
+		if (!m_send(engine::network::kOpcodeLfgLeaveRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (leave LFG).";
+			LOG_WARN(Net, "[LfgUiPresenter] RequestLeave: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[LfgUiPresenter] LfgLeaveRequest queued");
+	}
+
+	void LfgUiPresenter::RequestStatus()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LfgUiPresenter] RequestStatus: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildLfgStatusRequestPayload();
+		if (!m_send(engine::network::kOpcodeLfgStatusRequest, payload))
+		{
+			LOG_WARN(Net, "[LfgUiPresenter] RequestStatus: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[LfgUiPresenter] LfgStatusRequest queued");
+	}
+
+	void LfgUiPresenter::AcceptMatch(uint64_t proposalId, bool accept)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LfgUiPresenter] AcceptMatch: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildLfgMatchAcceptRequestPayload(proposalId, accept);
+		if (!m_send(engine::network::kOpcodeLfgMatchAcceptRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (accept match).";
+			LOG_WARN(Net, "[LfgUiPresenter] AcceptMatch: send failed");
+			return;
+		}
+		LOG_INFO(Net, "[LfgUiPresenter] AcceptMatch sent (proposalId={}, accept={})",
+			proposalId, accept ? 1 : 0);
+
+		// V1 : on clear le proposal state immediatement pour fermer le modal,
+		// independamment de la reponse master (qui sera juste un LfgQueueResponse Ok).
+		// Si accept == false, on clear aussi l'etat queue local par coherence
+		// (le master ne re-queue pas le joueur en V1).
+		ClearProposalState();
+		if (!accept)
+		{
+			ClearQueueState();
+			m_state.lastInfoText = "Match refuse, vous etes hors queue.";
+		}
+		else
+		{
+			m_state.lastInfoText = "Match accepte. En attente du donjon...";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void LfgUiPresenter::OnQueueResponse(const engine::network::LfgQueueResponsePayload& resp)
+	{
+		using engine::network::LfgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<LfgErrorCode>(resp.error);
+			switch (err)
+			{
+			case LfgErrorCode::AlreadyQueued:
+				m_state.lastErrorText = "Vous etes deja en queue.";
+				break;
+			case LfgErrorCode::InvalidRole:
+				m_state.lastErrorText = "Role invalide.";
+				break;
+			case LfgErrorCode::InvalidDungeon:
+				m_state.lastErrorText = "Donjon invalide.";
+				break;
+			case LfgErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case LfgErrorCode::MatchExpired:
+				m_state.lastErrorText = "Match expire ou inconnu.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur LFG inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[LfgUiPresenter] OnQueueResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.inQueue          = true;
+		m_state.myRole           = m_pendingRole;
+		m_state.myDungeonId      = m_pendingDungeonId;
+		m_state.elapsedSec       = 0;
+		m_state.estimatedWaitSec = resp.estimatedWaitSec;
+		m_state.lastInfoText     = "Inscrit dans la queue.";
+		LOG_INFO(Net, "[LfgUiPresenter] OnQueueResponse OK estimated={}s",
+			resp.estimatedWaitSec);
+	}
+
+	void LfgUiPresenter::OnLeaveResponse(const engine::network::LfgLeaveResponsePayload& resp)
+	{
+		using engine::network::LfgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<LfgErrorCode>(resp.error);
+			if (err == LfgErrorCode::NotInQueue)
+				m_state.lastErrorText = "Vous n'etes pas en queue.";
+			else if (err == LfgErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur LFG inconnue.";
+			LOG_WARN(Net, "[LfgUiPresenter] OnLeaveResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		ClearQueueState();
+		m_state.lastInfoText = "Vous avez quitte la queue.";
+		LOG_INFO(Net, "[LfgUiPresenter] OnLeaveResponse OK");
+	}
+
+	void LfgUiPresenter::OnStatusResponse(const engine::network::LfgStatusResponsePayload& resp)
+	{
+		using engine::network::LfgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<LfgErrorCode>(resp.error);
+			if (err == LfgErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur LFG inconnue.";
+			LOG_WARN(Net, "[LfgUiPresenter] OnStatusResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		if (!resp.inQueue)
+		{
+			ClearQueueState();
+			LOG_DEBUG(Net, "[LfgUiPresenter] OnStatusResponse: not in queue");
+			return;
+		}
+		m_state.inQueue     = true;
+		m_state.myRole      = resp.role;
+		m_state.myDungeonId = resp.dungeonId;
+		m_state.elapsedSec  = resp.elapsedSec;
+		LOG_DEBUG(Net, "[LfgUiPresenter] OnStatusResponse: inQueue dungeon={} elapsed={}s",
+			resp.dungeonId, resp.elapsedSec);
+	}
+
+	void LfgUiPresenter::OnMatchProposal(const engine::network::LfgMatchProposalNotificationPayload& note)
+	{
+		m_state.hasProposal       = true;
+		m_state.proposalId        = note.proposalId;
+		m_state.proposalDungeonId = note.dungeonId;
+		m_state.proposalMembers.clear();
+		m_state.proposalMembers.reserve(note.members.size());
+		for (const auto& m : note.members)
+		{
+			m_state.proposalMembers.emplace_back(m.accountId, m.role);
+		}
+		// Quand un match est forme, le master a retire le joueur de la queue
+		// runtime. On clear notre etat queue local pour rester en sync :
+		// si l'utilisateur reject le match, V1 ne le re-queue pas (sub-PR
+		// future le fera si besoin).
+		ClearQueueState();
+		m_state.lastInfoText = "Donjon trouve !";
+		LOG_INFO(Net, "[LfgUiPresenter] OnMatchProposal proposalId={} dungeon={} members={}",
+			note.proposalId, note.dungeonId, note.members.size());
+	}
+}

--- a/src/client/lfg/LfgUi.h
+++ b/src/client/lfg/LfgUi.h
@@ -1,0 +1,141 @@
+#pragma once
+// CMANGOS.33 (Phase 5.33 step 3+4) — Presenter client de la fenetre LFG
+// (LookForGroup). Maintient un cache local de l'etat de queue +
+// affiche un modal popup quand un match proposal est recu (push opcode 106).
+//
+// Pas de rendu ImGui : le panneau est drawe par LfgImGuiRenderer qui lit
+// l'etat via GetState() et propage les inputs UI (Queue / Leave /
+// AcceptMatch / RejectMatch) via les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans QuestUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes 101/103/105/106
+// vers les OnXxx du presenter.
+
+#include "src/shared/network/LfgPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct LfgUiState
+	{
+		/// True si le joueur est inscrit dans la queue cote master.
+		bool     inQueue           = false;
+		/// Role choisi par le joueur (significatif si inQueue == true).
+		uint8_t  myRole            = 0;
+		/// Dungeon choisi (significatif si inQueue == true).
+		uint32_t myDungeonId       = 0;
+		/// Temps ecoule depuis Join (en secondes), mis a jour a chaque Status.
+		uint32_t elapsedSec        = 0;
+		/// Estimation initiale renvoyee par le master au Queue (V1 : 60s).
+		uint32_t estimatedWaitSec  = 0;
+
+		// Match proposal en cours (push opcode 106).
+		bool     hasProposal       = false;
+		uint64_t proposalId        = 0;
+		uint32_t proposalDungeonId = 0;
+		/// Liste des membres du groupe propose (accountId + role).
+		std::vector<std::pair<uint64_t, uint8_t>> proposalMembers;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire (e.g. "Vous etes en queue"). Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Presenter pour la fenetre LFG cote client. Doit etre Init() avant tout
+	/// usage du callback. Thread : main (comme les autres presenters UI).
+	class LfgUiPresenter final
+	{
+	public:
+		LfgUiPresenter() = default;
+
+		LfgUiPresenter(const LfgUiPresenter&)            = delete;
+		LfgUiPresenter& operator=(const LfgUiPresenter&) = delete;
+
+		~LfgUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.33 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestQueue / RequestLeave / etc.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie LFG_QUEUE_REQUEST avec \p role et \p dungeonId.
+		/// Reponse via \ref OnQueueResponse.
+		void RequestQueue(uint8_t role, uint32_t dungeonId);
+
+		/// Envoie LFG_LEAVE_REQUEST. Reponse via \ref OnLeaveResponse.
+		void RequestLeave();
+
+		/// Envoie LFG_STATUS_REQUEST. Reponse via \ref OnStatusResponse.
+		void RequestStatus();
+
+		/// Envoie LFG_MATCH_ACCEPT_REQUEST avec \p proposalId et \p accept.
+		/// Pas de OnXxx dedie en V1 : le master renvoie un LFG_QUEUE_RESPONSE
+		/// minimal (Ok). Le presenter clear son state proposal localement.
+		void AcceptMatch(uint64_t proposalId, bool accept);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit LFG_QUEUE_RESPONSE. Si OK, marque inQueue = true et stocke
+		/// estimatedWaitSec. Sinon, ecrit dans lastErrorText.
+		void OnQueueResponse(const engine::network::LfgQueueResponsePayload& resp);
+
+		/// Recoit LFG_LEAVE_RESPONSE. Si OK, clear l'etat de queue local.
+		void OnLeaveResponse(const engine::network::LfgLeaveResponsePayload& resp);
+
+		/// Recoit LFG_STATUS_RESPONSE. Met a jour inQueue / role / dungeon /
+		/// elapsed selon le payload.
+		void OnStatusResponse(const engine::network::LfgStatusResponsePayload& resp);
+
+		/// Recoit un push LFG_MATCH_PROPOSAL_NOTIFICATION : arme le modal
+		/// proposal avec proposalId + members + dungeonId.
+		void OnMatchProposal(const engine::network::LfgMatchProposalNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const LfgUiState& GetState() const { return m_state; }
+
+	private:
+		/// Clear l'etat de queue local (appelee a OnLeaveResponse Ok ou
+		/// a la formation d'un groupe). Ne touche pas le proposal en cours.
+		void ClearQueueState();
+
+		/// Clear l'etat proposal local (appelee apres AcceptMatch).
+		void ClearProposalState();
+
+		/// Memorise le role et dungeon choisi en attente de la reponse Ok.
+		uint8_t  m_pendingRole      = 0;
+		uint32_t m_pendingDungeonId = 0;
+
+		bool        m_initialized = false;
+		LfgUiState  m_state{};
+		SendCallback m_send;
+	};
+}

--- a/src/client/render/LfgImGuiRenderer.cpp
+++ b/src/client/render/LfgImGuiRenderer.cpp
@@ -1,0 +1,249 @@
+// CMANGOS.33 (Phase 5.33 step 3+4) — LfgImGuiRenderer implementation.
+
+#include "src/client/render/LfgImGuiRenderer.h"
+
+#include "src/client/lfg/LfgUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// V1 : catalogue dungeon hardcode cote client. Le master n'a pas de
+		/// catalogue centralise (tout dungeonId > 0 est accepte). Le ticket
+		/// futur DungeonCatalog cote shared/ permettra d'unifier.
+		struct DungeonInfo
+		{
+			uint32_t    id;
+			const char* label;
+		};
+		constexpr DungeonInfo kV1Dungeons[] = {
+			{1u, "Cave"},
+			{2u, "Tower"},
+			{3u, "Crypte"},
+		};
+
+		/// Libelle FR pour un role.
+		const char* RoleLabel(uint8_t role)
+		{
+			switch (role)
+			{
+			case 0: return "Tank";
+			case 1: return "Soigneur";
+			case 2: return "Dommages";
+			default: return "?";
+			}
+		}
+
+		/// Libelle FR pour un dungeon (lookup dans le catalogue ; sinon "Donjon #N").
+		std::string DungeonLabel(uint32_t dungeonId)
+		{
+			for (const auto& d : kV1Dungeons)
+			{
+				if (d.id == dungeonId) return std::string(d.label);
+			}
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Donjon #%u", static_cast<unsigned>(dungeonId));
+			return buf;
+		}
+	}
+
+	void LfgImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderMainPanel();
+		RenderProposalModal();
+	}
+
+	void LfgImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 320x420.
+		const float panelW = 320.f;
+		const float panelH = 420.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("LFG##ln_lfg_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			if (state.inQueue)
+			{
+				// Affichage etat de queue.
+				ImGui::TextUnformatted("En queue :");
+				ImGui::Separator();
+				ImGui::Text("Role     : %s", RoleLabel(state.myRole));
+				ImGui::Text("Donjon   : %s", DungeonLabel(state.myDungeonId).c_str());
+				ImGui::Text("Ecoule   : %u s", static_cast<unsigned>(state.elapsedSec));
+				if (state.estimatedWaitSec > 0u)
+					ImGui::Text("Estime   : %u s", static_cast<unsigned>(state.estimatedWaitSec));
+				ImGui::Spacing();
+
+				if (ImGui::Button("Rafraichir", ImVec2(140.f, 28.f)))
+					m_presenter->RequestStatus();
+				ImGui::SameLine();
+				if (ImGui::Button("Quitter la queue", ImVec2(140.f, 28.f)))
+					m_presenter->RequestLeave();
+			}
+			else
+			{
+				// Selecteur de role + dungeon + bouton Queue.
+				ImGui::TextUnformatted("Role :");
+				ImGui::RadioButton("Tank",     &m_uiSelectedRoleIdx, 0);
+				ImGui::SameLine();
+				ImGui::RadioButton("Soigneur", &m_uiSelectedRoleIdx, 1);
+				ImGui::SameLine();
+				ImGui::RadioButton("Dommages", &m_uiSelectedRoleIdx, 2);
+				ImGui::Separator();
+
+				ImGui::TextUnformatted("Donjon :");
+				const std::string previewLabel = DungeonLabel(m_uiSelectedDungeonId);
+				if (ImGui::BeginCombo("##ln_lfg_dungeon_combo", previewLabel.c_str()))
+				{
+					for (const auto& d : kV1Dungeons)
+					{
+						const bool selected = (d.id == m_uiSelectedDungeonId);
+						if (ImGui::Selectable(d.label, selected))
+						{
+							m_uiSelectedDungeonId = d.id;
+						}
+						if (selected) ImGui::SetItemDefaultFocus();
+					}
+					ImGui::EndCombo();
+				}
+				ImGui::Separator();
+
+				if (ImGui::Button("S'inscrire dans la queue", ImVec2(-FLT_MIN, 32.f)))
+				{
+					const uint8_t role = static_cast<uint8_t>(m_uiSelectedRoleIdx);
+					m_presenter->RequestQueue(role, m_uiSelectedDungeonId);
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void LfgImGuiRenderer::RenderProposalModal()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.hasProposal)
+			return;
+
+		// Modal centre, taille fixe 480x320.
+		const float modalW = 480.f;
+		const float modalH = 320.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, (vpW - modalW) * 0.5f);
+		const float posY = std::max(0.f, (vpH - modalH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(modalW, modalH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.97f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.97f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings;
+		if (ImGui::Begin("Donjon trouve !##ln_lfg_proposal", nullptr, flags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.85f, 0.20f, 1.f));
+			ImGui::TextUnformatted(DungeonLabel(state.proposalDungeonId).c_str());
+			ImGui::PopStyleColor();
+			ImGui::Separator();
+
+			ImGui::TextUnformatted("Membres du groupe :");
+			const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+				| ImGuiTableFlags_RowBg
+				| ImGuiTableFlags_ScrollY;
+			if (ImGui::BeginTable("##ln_lfg_proposal_members", 2, tableFlags, ImVec2(0.f, 180.f)))
+			{
+				ImGui::TableSetupColumn("Account", ImGuiTableColumnFlags_WidthStretch);
+				ImGui::TableSetupColumn("Role",    ImGuiTableColumnFlags_WidthFixed, 100.f);
+				ImGui::TableHeadersRow();
+				for (const auto& [accId, role] : state.proposalMembers)
+				{
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::Text("#%llu", static_cast<unsigned long long>(accId));
+					ImGui::TableSetColumnIndex(1);
+					ImGui::TextUnformatted(RoleLabel(role));
+				}
+				ImGui::EndTable();
+			}
+			ImGui::Spacing();
+
+			const float btnW = (modalW - 60.f) * 0.5f;
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.55f, 0.20f, 1.f));
+			if (ImGui::Button("Accepter", ImVec2(btnW, 32.f)))
+			{
+				m_presenter->AcceptMatch(state.proposalId, true);
+			}
+			ImGui::PopStyleColor();
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.55f, 0.20f, 0.20f, 1.f));
+			if (ImGui::Button("Refuser", ImVec2(btnW, 32.f)))
+			{
+				m_presenter->AcceptMatch(state.proposalId, false);
+			}
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void LfgImGuiRenderer::Render()             {}
+	void LfgImGuiRenderer::RenderMainPanel()    {}
+	void LfgImGuiRenderer::RenderProposalModal(){}
+}
+
+#endif

--- a/src/client/render/LfgImGuiRenderer.h
+++ b/src/client/render/LfgImGuiRenderer.h
@@ -1,0 +1,54 @@
+#pragma once
+// CMANGOS.33 (Phase 5.33 step 3+4) — LfgImGuiRenderer : panneau ImGui pour
+// la fenetre LookForGroup cote joueur. Lit l'etat d'un LfgUiPresenter,
+// dispatch les inputs UI (Queue / Leave / Status / Accept / Reject) via
+// accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class LfgUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau LFG. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::LfgUiPresenter. Le renderer ne
+	/// fait que dessiner l'etat courant et propager les inputs UI vers le
+	/// presenter.
+	class LfgImGuiRenderer
+	{
+	public:
+		LfgImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::LfgUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "LFG" + modal proposal s'il est actif. A appeler
+		/// entre \c ImGui::NewFrame() et \c ImGui::Render(), apres NewFrame,
+		/// si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (Queue / Leave + status courant).
+		void RenderMainPanel();
+
+		/// Dessine le modal popup quand un proposal est en attente.
+		void RenderProposalModal();
+
+		engine::client::LfgUiPresenter* m_presenter = nullptr;
+		bool                            m_enabled   = false;
+		uint32_t                        m_viewportW = 0;
+		uint32_t                        m_viewportH = 0;
+
+		/// Etat de l'UI : choix utilisateur courant (avant click "Queue").
+		/// Persistant entre frames pour que les radio/combo gardent leur
+		/// valeur tant que le user n'a pas valide.
+		int      m_uiSelectedRoleIdx    = 0; ///< 0=Tank, 1=Healer, 2=Damage.
+		uint32_t m_uiSelectedDungeonId  = 1; ///< id selectionne dans le combo.
+	};
+}

--- a/src/masterd/handlers/lfg/LfgHandler.cpp
+++ b/src/masterd/handlers/lfg/LfgHandler.cpp
@@ -1,0 +1,370 @@
+// CMANGOS.33 (Phase 5.33 step 3+4) — Implementation LfgHandler.
+
+#include "src/masterd/handlers/lfg/LfgHandler.h"
+
+#include "src/masterd/lfg/LfgQueue.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/LfgPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Retourne le timestamp UTC en ms (epoch). Sert au joinedTsMs et a
+		/// l'horodatage du tick matchmaking.
+		uint64_t NowMs()
+		{
+			using namespace std::chrono;
+			return static_cast<uint64_t>(
+				duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+		}
+
+		/// Estimee de temps d'attente en V1. Hardcode 60s — sera calcule
+		/// statistiquement plus tard (cf. CLAUDE.md / spec).
+		constexpr uint32_t kV1EstimatedWaitSec = 60u;
+	}
+
+	void LfgHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_queue || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[LfgHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(LfgErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeLfgQueueRequest:
+				pkt = BuildLfgQueueResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeLfgLeaveRequest:
+				pkt = BuildLfgLeaveResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeLfgStatusRequest:
+				pkt = BuildLfgStatusResponsePacket(kUnauth, false, 0u, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeLfgMatchAcceptRequest:
+				// V1 simplifie : reuse QueueResponse pour signaler Unauthorized
+				// sur un MatchAccept (cote client, OnMatchAcceptResponse n'existe
+				// pas — le client lit lastErrorText via OnQueueResponse).
+				pkt = BuildLfgQueueResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeLfgQueueRequest:
+			HandleQueue(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeLfgLeaveRequest:
+			HandleLeave(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeLfgStatusRequest:
+			HandleStatus(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeLfgMatchAcceptRequest:
+			HandleMatchAccept(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void LfgHandler::HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseLfgQueueRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildLfgQueueResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::InvalidDungeon), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[LfgHandler] Queue parse failed account={}", accountId);
+			return;
+		}
+
+		// Validation role : 0..2 (Tank / Healer / Damage).
+		if (parsed->role > 2u)
+		{
+			auto pkt = BuildLfgQueueResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::InvalidRole), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[LfgHandler] Queue InvalidRole account={} role={}",
+				accountId, static_cast<unsigned>(parsed->role));
+			return;
+		}
+
+		// Validation dungeon : 0 = invalide en V1 (pas de catalogue cote master).
+		if (parsed->dungeonId == 0u)
+		{
+			auto pkt = BuildLfgQueueResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::InvalidDungeon), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[LfgHandler] Queue InvalidDungeon account={}", accountId);
+			return;
+		}
+
+		// Already-queued : si l'account a deja une entree active, on refuse.
+		auto it = m_active.find(accountId);
+		if (it != m_active.end())
+		{
+			auto pkt = BuildLfgQueueResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::AlreadyQueued), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_INFO(Net, "[LfgHandler] Queue AlreadyQueued account={} dungeon={}",
+				accountId, it->second.dungeonId);
+			return;
+		}
+
+		const uint64_t nowMs = NowMs();
+		const auto role = static_cast<engine::server::lfg::LfgRole>(parsed->role);
+		m_queue->Join(parsed->dungeonId, accountId, role, nowMs);
+
+		ActiveEntry entry;
+		entry.dungeonId  = parsed->dungeonId;
+		entry.role       = parsed->role;
+		entry.joinedTsMs = nowMs;
+		m_active[accountId] = entry;
+
+		LOG_INFO(Net, "[LfgHandler] Queue account={} dungeon={} role={}",
+			accountId, parsed->dungeonId, static_cast<unsigned>(parsed->role));
+
+		auto pkt = BuildLfgQueueResponsePacket(0u, kV1EstimatedWaitSec,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void LfgHandler::HandleLeave(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		auto it = m_active.find(accountId);
+		if (it == m_active.end())
+		{
+			auto pkt = BuildLfgLeaveResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::NotInQueue),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_INFO(Net, "[LfgHandler] Leave NotInQueue account={}", accountId);
+			return;
+		}
+
+		const uint32_t dungeonId = it->second.dungeonId;
+		const bool removed = m_queue->Leave(dungeonId, accountId);
+		(void)removed;
+		m_active.erase(it);
+
+		LOG_INFO(Net, "[LfgHandler] Leave account={} dungeon={}", accountId, dungeonId);
+
+		auto pkt = BuildLfgLeaveResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	void LfgHandler::HandleStatus(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		auto it = m_active.find(accountId);
+		if (it == m_active.end())
+		{
+			auto pkt = BuildLfgStatusResponsePacket(0u, false, 0u, 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_DEBUG(Net, "[LfgHandler] Status notInQueue account={}", accountId);
+			return;
+		}
+
+		const uint64_t nowMs = NowMs();
+		const uint64_t elapsedMs = (nowMs > it->second.joinedTsMs) ? (nowMs - it->second.joinedTsMs) : 0u;
+		const uint32_t elapsedSec = static_cast<uint32_t>(elapsedMs / 1000u);
+
+		auto pkt = BuildLfgStatusResponsePacket(0u, true, it->second.role,
+			it->second.dungeonId, elapsedSec, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+		LOG_DEBUG(Net, "[LfgHandler] Status inQueue account={} dungeon={} elapsed={}",
+			accountId, it->second.dungeonId, elapsedSec);
+	}
+
+	void LfgHandler::HandleMatchAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseLfgMatchAcceptRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			auto pkt = BuildLfgQueueResponsePacket(
+				static_cast<uint8_t>(LfgErrorCode::MatchExpired), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			LOG_WARN(Net, "[LfgHandler] MatchAccept parse failed account={}", accountId);
+			return;
+		}
+
+		// V1 simplifie : pas d'etat proposal cote master. On logue, on considere
+		// le match comme "consume" (le compte n'est plus en queue cote handler
+		// car il a ete retire au TickMatchmaking precedent), et on retourne
+		// LfgQueueResponse Ok pour que le client puisse fermer son modal.
+		// Si accept == false, on logue mais on ne re-queue pas le joueur (V1).
+		LOG_INFO(Net, "[LfgHandler] MatchAccept account={} proposalId={} accept={}",
+			accountId, parsed->proposalId, parsed->accept ? 1 : 0);
+
+		auto pkt = BuildLfgQueueResponsePacket(0u, 0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void LfgHandler::TickMatchmaking(uint64_t nowMs)
+	{
+		using namespace engine::network;
+		(void)nowMs;
+		if (!m_queue || !m_server) return;
+
+		// Collecte des dungeons « connus » via l'index local m_active. On itere
+		// les entries actives, on note les dungeons distincts, puis on tente
+		// TryMatch sur chacun. Si un groupe est forme, on retire les membres
+		// de m_active et on push une notification a chaque membre online.
+		std::unordered_set<uint32_t> dungeons;
+		for (const auto& [accId, entry] : m_active)
+		{
+			(void)accId;
+			dungeons.insert(entry.dungeonId);
+		}
+
+		for (uint32_t dungeon : dungeons)
+		{
+			while (true)
+			{
+				auto group = m_queue->TryMatch(dungeon);
+				if (!group) break;
+
+				const uint64_t proposalId = m_nextProposalId++;
+				std::vector<LfgMatchMember> members;
+				members.reserve(group->members.size());
+				for (uint64_t memberId : group->members)
+				{
+					LfgMatchMember m;
+					m.accountId = memberId;
+					// Recuperer le role depuis m_active avant de le clear.
+					auto memberIt = m_active.find(memberId);
+					m.role = (memberIt != m_active.end()) ? memberIt->second.role : 0u;
+					members.push_back(m);
+				}
+
+				// Retire les membres de m_active.
+				for (uint64_t memberId : group->members)
+				{
+					m_active.erase(memberId);
+				}
+
+				LOG_INFO(Net, "[LfgHandler] TickMatchmaking proposal={} dungeon={} members={}",
+					proposalId, dungeon, group->members.size());
+
+				// Push notification a chaque membre online.
+				for (const auto& m : members)
+				{
+					const uint32_t targetConn = FindConnIdForAccount(m.accountId);
+					const uint64_t targetSessionIdHeader = FindSessionIdForAccount(m.accountId);
+					if (targetConn == 0u || targetSessionIdHeader == 0u)
+					{
+						LOG_WARN(Net, "[LfgHandler] Match member offline account={} (skip push)",
+							m.accountId);
+						continue;
+					}
+					auto pkt = BuildLfgMatchProposalNotificationPacket(
+						proposalId, dungeon, members, targetSessionIdHeader);
+					if (!pkt.empty())
+						m_server->Send(targetConn, pkt);
+				}
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	uint32_t LfgHandler::FindConnIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return connId;
+		}
+		return 0u;
+	}
+
+	uint64_t LfgHandler::FindSessionIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			(void)connId;
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return sessionId;
+		}
+		return 0u;
+	}
+}

--- a/src/masterd/handlers/lfg/LfgHandler.h
+++ b/src/masterd/handlers/lfg/LfgHandler.h
@@ -1,0 +1,130 @@
+#pragma once
+// CMANGOS.33 (Phase 5.33 step 3+4) — LfgHandler : dispatch des opcodes Lfg
+// (100/102/104/107) et appel des methodes correspondantes du LfgQueue.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 100/102/104/107.
+//
+// V1 limitations :
+//  - Pas d'etat « proposal » cote master (MatchAccept est juste loggee + Ok).
+//  - Pas de timer auto pour TickMatchmaking : doit etre appele manuellement
+//    (e.g. depuis un slash command admin ou un scheduler externe). Sub-PR
+//    future cablera un timer 5s.
+//  - estimatedWaitSec hardcode 60s.
+//  - Tracking « ou est inscrit le joueur » fait via une map locale au handler
+//    (LfgQueue::Join n'expose pas FindEntry), pour repondre a Leave/Status
+//    sans scanner toutes les queues.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized.
+
+#include <cstdint>
+#include <cstddef>
+#include <unordered_map>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server::lfg
+{
+	class LfgQueue;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Lfg. Doit etre configure via Set*() avant tout HandlePacket.
+	class LfgHandler
+	{
+	public:
+		/// Branche la queue in-memory (autorite runtime de l'inscription LFG).
+		void SetQueue(engine::server::lfg::LfgQueue* q) { m_queue = q; }
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* server) { m_server = server; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Lfg. Dispatch
+		/// vers HandleQueue/HandleLeave/etc. selon l'opcode. Si l'opcode n'est
+		/// pas un opcode Lfg, ignore silencieusement (filtrage deja fait
+		/// cote main_linux).
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (100/102/104/107).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// Tick periodique pour faire avancer le matchmaking. A appeler
+		/// manuellement en V1 (e.g. depuis un slash command admin ou un
+		/// scheduler externe). Sub-PR future cablera un timer 5s.
+		///
+		/// \param nowMs Timestamp courant en ms (pour l'horodatage des entries
+		///              futures ; non utilise en V1).
+		///
+		/// Effet de bord : pour chaque dungeon avec assez d'entries, forme un
+		/// groupe via LfgQueue::TryMatch (qui retire les entries de la queue),
+		/// puis envoie un push LFG_MATCH_PROPOSAL_NOTIFICATION a chaque membre
+		/// online. Le proposalId est genere via un compteur interne croissant.
+		void TickMatchmaking(uint64_t nowMs);
+
+	private:
+		/// Traite LFG_QUEUE_REQUEST.
+		void HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite LFG_LEAVE_REQUEST.
+		void HandleLeave(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite LFG_STATUS_REQUEST.
+		void HandleStatus(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite LFG_MATCH_ACCEPT_REQUEST. V1 simplifie : log + reponse Ok via
+		/// LfgQueueResponse (le proposal lifecycle est sub-PR future).
+		void HandleMatchAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le connId actif d'un account_id (snapshot ConnectionSessionMap +
+		/// resolution session->account). Retourne 0 si offline.
+		uint32_t FindConnIdForAccount(uint64_t accountId) const;
+		/// Recherche le sessionIdHeader actif d'un account_id. Retourne 0 si offline.
+		uint64_t FindSessionIdForAccount(uint64_t accountId) const;
+
+		/// Etat interne d'inscription d'un account a la queue. Mirror partiel
+		/// de LfgEntry (qui n'expose pas de FindEntry par accountId cote queue).
+		struct ActiveEntry
+		{
+			uint32_t dungeonId  = 0;
+			uint8_t  role       = 0;
+			uint64_t joinedTsMs = 0;
+		};
+
+		engine::server::lfg::LfgQueue*  m_queue       = nullptr;
+		NetServer*                       m_server      = nullptr;
+		SessionManager*                  m_sessionMgr  = nullptr;
+		ConnectionSessionMap*            m_connMap     = nullptr;
+
+		/// Index inverse account -> entry, pour repondre Leave/Status sans
+		/// scanner toutes les queues. Cleare a Leave et a TickMatchmaking
+		/// quand le membre est forme dans un groupe.
+		std::unordered_map<uint64_t, ActiveEntry> m_active;
+
+		/// Compteur monotone pour generer des proposalId. V1 : transient (reset
+		/// au reboot). Pas de collision tant qu'un seul master.
+		uint64_t m_nextProposalId = 1u;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -39,6 +39,8 @@
 #include "src/masterd/mail/MysqlMailStore.h"
 #include "src/masterd/handlers/quest/QuestHandler.h"
 #include "src/masterd/handlers/reputation/ReputationHandler.h"
+#include "src/masterd/handlers/lfg/LfgHandler.h"
+#include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/quests/MysqlQuestStateStore.h"
 #include "src/masterd/reputation/MysqlReputationStore.h"
 #include "src/masterd/reputation/ReputationManager.h"
@@ -475,6 +477,22 @@ int main(int argc, char** argv)
 		LOG_WARN(Net, "[ServerMain] ReputationHandler running in no-DB mode (List will return empty)");
 	}
 
+	// CMANGOS.33 (Phase 5.33 step 3+4) — LookForGroup wire server.
+	// La queue est transient (pas de persistance DB) : au reboot, toutes
+	// les inscriptions LFG sont perdues, ce qui est acceptable pour le V1
+	// (les clients re-affichent une UI vide au prochain login). Les opcodes
+	// 100/102/104/107 sont dispatches au handler ; les responses 101/103/105
+	// et la push notification 106 sont emis par le handler aux participants.
+	// Note V1 : TickMatchmaking n'est pas appele en boucle automatique ; un
+	// timer 5s sera cable dans une sub-PR future.
+	engine::server::lfg::LfgQueue lfgQueue;
+	engine::server::LfgHandler lfgHandler;
+	lfgHandler.SetQueue(&lfgQueue);
+	lfgHandler.SetServer(&server);
+	lfgHandler.SetSessionManager(&sessionManager);
+	lfgHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] LfgHandler configured (CMANGOS.33 step 3+4, transient queue)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -514,7 +532,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -568,6 +586,11 @@ int main(int argc, char** argv)
 			tradeHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeReputationListRequest)
 			reputationHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeLfgQueueRequest
+		      || opcode == kOpcodeLfgLeaveRequest
+		      || opcode == kOpcodeLfgStatusRequest
+		      || opcode == kOpcodeLfgMatchAcceptRequest)
+			lfgHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/LfgPayloads.cpp
+++ b/src/shared/network/LfgPayloads.cpp
@@ -1,0 +1,321 @@
+// CMANGOS.33 (Phase 5.33 step 3+4) — Implementation Parse/Build des payloads Lfg.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+//
+// Note : ByteWriter/ByteReader serialise les bool sur 1 octet via
+// WriteBytes / ReadBytes pour preserver la portabilite (pas de
+// WriteBool/ReadBool dispo).
+
+#include "src/shared/network/LfgPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un membre (uint64 accountId, uint8 role).
+		bool WriteMember(ByteWriter& w, const LfgMatchMember& m)
+		{
+			if (!w.WriteU64(m.accountId)) return false;
+			if (!w.WriteBytes(&m.role, 1u)) return false;
+			return true;
+		}
+
+		/// Lit un membre (uint64 accountId, uint8 role).
+		bool ReadMember(ByteReader& r, LfgMatchMember& out)
+		{
+			if (!r.ReadU64(out.accountId)) return false;
+			uint8_t role = 0;
+			if (!r.ReadBytes(&role, 1u)) return false;
+			out.role = role;
+			return true;
+		}
+
+		/// Serialise le body d'un MATCH_PROPOSAL_NOTIFICATION.
+		bool WriteMatchProposalBody(ByteWriter& w, uint64_t proposalId, uint32_t dungeonId,
+			const std::vector<LfgMatchMember>& members)
+		{
+			if (!w.WriteU64(proposalId))                                    return false;
+			if (!w.WriteU32(dungeonId))                                     return false;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(members.size())))  return false;
+			for (const auto& m : members)
+			{
+				if (!WriteMember(w, m)) return false;
+			}
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_QUEUE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgQueueRequestPayload> ParseLfgQueueRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 role (1) + uint32 dungeonId (4) = 5.
+		if (!payload || payloadSize < 5u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgQueueRequestPayload out;
+		uint8_t role = 0;
+		if (!r.ReadBytes(&role, 1u)) return std::nullopt;
+		out.role = role;
+		if (!r.ReadU32(out.dungeonId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgQueueRequestPayload(uint8_t role, uint32_t dungeonId)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&role, 1u)) return {};
+		if (!w.WriteU32(dungeonId))   return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_QUEUE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgQueueResponsePayload> ParseLfgQueueResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgQueueResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		// Si error == 0, lire estimatedWaitSec.
+		if (!r.ReadU32(out.estimatedWaitSec)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgQueueResponsePayload(uint8_t error, uint32_t estimatedWaitSec)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLfgQueueResponsePacket(uint8_t error, uint32_t estimatedWaitSec,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLfgQueueResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_LEAVE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgLeaveRequestPayload> ParseLfgLeaveRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return LfgLeaveRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildLfgLeaveRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_LEAVE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgLeaveResponsePayload> ParseLfgLeaveResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgLeaveResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgLeaveResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLfgLeaveResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLfgLeaveResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_STATUS — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgStatusRequestPayload> ParseLfgStatusRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		return LfgStatusRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildLfgStatusRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_STATUS — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgStatusResponsePayload> ParseLfgStatusResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1) + uint8 inQueue (1) + uint8 role (1) + uint32 dungeonId (4) + uint32 elapsedSec (4) = 11.
+		if (!payload || payloadSize < 11u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgStatusResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		uint8_t inQueueByte = 0;
+		if (!r.ReadBytes(&inQueueByte, 1u)) return std::nullopt;
+		out.inQueue = (inQueueByte != 0u);
+		uint8_t roleByte = 0;
+		if (!r.ReadBytes(&roleByte, 1u)) return std::nullopt;
+		out.role = roleByte;
+		if (!r.ReadU32(out.dungeonId))  return std::nullopt;
+		if (!r.ReadU32(out.elapsedSec)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgStatusResponsePayload(uint8_t error, bool inQueue, uint8_t role, uint32_t dungeonId, uint32_t elapsedSec)
+	{
+		std::vector<uint8_t> buf(11u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const uint8_t inQueueByte = inQueue ? 1u : 0u;
+		if (!w.WriteBytes(&inQueueByte, 1u)) return {};
+		if (!w.WriteBytes(&role, 1u))        return {};
+		if (!w.WriteU32(dungeonId))          return {};
+		if (!w.WriteU32(elapsedSec))         return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLfgStatusResponsePacket(uint8_t error, bool inQueue, uint8_t role, uint32_t dungeonId, uint32_t elapsedSec,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const uint8_t inQueueByte = inQueue ? 1u : 0u;
+		if (!w.WriteBytes(&inQueueByte, 1u)) return {};
+		if (!w.WriteBytes(&role, 1u))        return {};
+		if (!w.WriteU32(dungeonId))          return {};
+		if (!w.WriteU32(elapsedSec))         return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLfgStatusResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_MATCH_PROPOSAL_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgMatchProposalNotificationPayload> ParseLfgMatchProposalNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 proposalId (8) + uint32 dungeonId (4) + uint16 count (2) = 14.
+		if (!payload || payloadSize < 14u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgMatchProposalNotificationPayload out;
+		if (!r.ReadU64(out.proposalId)) return std::nullopt;
+		if (!r.ReadU32(out.dungeonId))  return std::nullopt;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))   return std::nullopt;
+		out.members.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			LfgMatchMember m;
+			if (!ReadMember(r, m)) return std::nullopt;
+			out.members.push_back(m);
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgMatchProposalNotificationPayload(uint64_t proposalId, uint32_t dungeonId,
+		const std::vector<LfgMatchMember>& members)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteMatchProposalBody(w, proposalId, dungeonId, members)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLfgMatchProposalNotificationPacket(uint64_t proposalId, uint32_t dungeonId,
+		const std::vector<LfgMatchMember>& members, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteMatchProposalBody(w, proposalId, dungeonId, members)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeLfgMatchProposalNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LFG_MATCH_ACCEPT — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgMatchAcceptRequestPayload> ParseLfgMatchAcceptRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 proposalId (8) + uint8 accept (1) = 9.
+		if (!payload || payloadSize < 9u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LfgMatchAcceptRequestPayload out;
+		if (!r.ReadU64(out.proposalId)) return std::nullopt;
+		uint8_t acceptByte = 0;
+		if (!r.ReadBytes(&acceptByte, 1u)) return std::nullopt;
+		out.accept = (acceptByte != 0u);
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLfgMatchAcceptRequestPayload(uint64_t proposalId, bool accept)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(proposalId)) return {};
+		const uint8_t acceptByte = accept ? 1u : 0u;
+		if (!w.WriteBytes(&acceptByte, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+}

--- a/src/shared/network/LfgPayloads.h
+++ b/src/shared/network/LfgPayloads.h
@@ -1,0 +1,188 @@
+#pragma once
+// CMANGOS.33 (Phase 5.33 step 3+4) — Wire payloads pour les opcodes Lfg
+// (100-107). 4 paires Request/Response + 1 push :
+//   - Queue                  (100/101)
+//   - Leave                  (102/103)
+//   - Status                 (104/105)
+//   - MatchProposalNotification (106 push) : push Master to Client annonce
+//     un groupe forme.
+//   - MatchAccept            (107) : pas de response payload separee en V1
+//     (le master se contente de logger et send Ok via une reponse minimale).
+//
+// La file LookForGroup est gardee cote master uniquement (pas de DB) : au
+// reboot, toutes les inscriptions sont perdues. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Toutes les strings
+// passent par WriteString/ReadString (uint16 length + UTF-8 bytes), et
+// toutes les arrays par WriteArrayCount/ReadArrayCount (uint16 count).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Lfg.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Lfg. 0 = OK.
+	enum class LfgErrorCode : uint8_t
+	{
+		Ok             = 0,
+		AlreadyQueued  = 1, ///< Le joueur est deja dans une queue (Queue request seulement).
+		NotInQueue     = 2, ///< Pas inscrit dans une queue (Leave / Status request).
+		InvalidRole    = 3, ///< role > 2 (Damage = 2 max).
+		InvalidDungeon = 4, ///< dungeonId == 0 (V1 : pas de catalogue cote master).
+		MatchExpired   = 5, ///< proposalId inconnu / expire (MatchAccept).
+		Unauthorized   = 6, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// LFG_QUEUE — Client to Master : inscription a la queue.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint8  role        (0=Tank, 1=Healer, 2=Damage ; cf. LfgRole)
+	///   uint32 dungeonId   (id opaque cote V1)
+	struct LfgQueueRequestPayload
+	{
+		uint8_t  role      = 0;
+		uint32_t dungeonId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error              (cf. LfgErrorCode)
+	///   uint32 estimatedWaitSec   (si error == 0)
+	struct LfgQueueResponsePayload
+	{
+		uint8_t  error             = 0;
+		uint32_t estimatedWaitSec  = 0;
+	};
+
+	// =========================================================================
+	// LFG_LEAVE — Client to Master : quitter la queue.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account et le dungeonId courant sont derives
+	/// cote master (V1 : un seul player => un seul dungeon en queue).
+	struct LfgLeaveRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct LfgLeaveResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// LFG_STATUS — Client to Master : interroge l'etat de queue du joueur.
+	// =========================================================================
+
+	/// Wire format : (vide).
+	struct LfgStatusRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint8  inQueue       (0=non, 1=oui ; bool serialise sur 1 octet)
+	///   uint8  role          (significatif si inQueue == 1)
+	///   uint32 dungeonId     (significatif si inQueue == 1)
+	///   uint32 elapsedSec    (depuis joinedTsMs ; 0 si pas en queue)
+	struct LfgStatusResponsePayload
+	{
+		uint8_t  error      = 0;
+		bool     inQueue    = false;
+		uint8_t  role       = 0;
+		uint32_t dungeonId  = 0;
+		uint32_t elapsedSec = 0;
+	};
+
+	// =========================================================================
+	// LFG_MATCH_PROPOSAL_NOTIFICATION — Master to Client (push, requestId=0).
+	// Annonce qu'un groupe a ete forme et qu'une proposition est en attente
+	// de confirmation.
+	// =========================================================================
+
+	/// Une entree de la liste de membres d'une match proposal.
+	struct LfgMatchMember
+	{
+		uint64_t accountId = 0;
+		uint8_t  role      = 0;
+	};
+
+	/// Wire format :
+	///   uint64 proposalId       (id opaque V1, 0 accepte)
+	///   uint32 dungeonId
+	///   uint16 memberCount
+	///   <count> members         (8 + 1 octets chacune)
+	struct LfgMatchProposalNotificationPayload
+	{
+		uint64_t                   proposalId = 0;
+		uint32_t                   dungeonId  = 0;
+		std::vector<LfgMatchMember> members;
+	};
+
+	// =========================================================================
+	// LFG_MATCH_ACCEPT — Client to Master : accepte ou rejette une proposal.
+	// V1 simplifie : pas de payload de reponse separee, le master logue et
+	// envoie LfgQueueResponse (Ok) en echo.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 proposalId
+	///   uint8  accept         (0 = reject, 1 = accept ; serialise via uint8)
+	struct LfgMatchAcceptRequestPayload
+	{
+		uint64_t proposalId = 0;
+		bool     accept     = false;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgQueueRequestPayload>        ParseLfgQueueRequestPayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgLeaveRequestPayload>        ParseLfgLeaveRequestPayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgStatusRequestPayload>       ParseLfgStatusRequestPayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgMatchAcceptRequestPayload>  ParseLfgMatchAcceptRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildLfgQueueRequestPayload(uint8_t role, uint32_t dungeonId);
+	std::vector<uint8_t> BuildLfgLeaveRequestPayload();
+	std::vector<uint8_t> BuildLfgStatusRequestPayload();
+	std::vector<uint8_t> BuildLfgMatchAcceptRequestPayload(uint64_t proposalId, bool accept);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<LfgQueueResponsePayload>                ParseLfgQueueResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgLeaveResponsePayload>                ParseLfgLeaveResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgStatusResponsePayload>               ParseLfgStatusResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<LfgMatchProposalNotificationPayload>    ParseLfgMatchProposalNotificationPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildLfgQueueResponsePayload(uint8_t error, uint32_t estimatedWaitSec);
+	std::vector<uint8_t> BuildLfgLeaveResponsePayload(uint8_t error);
+	std::vector<uint8_t> BuildLfgStatusResponsePayload(uint8_t error, bool inQueue, uint8_t role, uint32_t dungeonId, uint32_t elapsedSec);
+	std::vector<uint8_t> BuildLfgMatchProposalNotificationPayload(uint64_t proposalId, uint32_t dungeonId, const std::vector<LfgMatchMember>& members);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildLfgQueueResponsePacket(uint8_t error, uint32_t estimatedWaitSec,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildLfgLeaveResponsePacket(uint8_t error,
+	                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildLfgStatusResponsePacket(uint8_t error, bool inQueue, uint8_t role, uint32_t dungeonId, uint32_t elapsedSec,
+	                                                  uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildLfgMatchProposalNotificationPacket(uint64_t proposalId, uint32_t dungeonId, const std::vector<LfgMatchMember>& members,
+	                                                              uint64_t sessionIdHeader);
+}

--- a/src/shared/network/LfgPayloadsTests.cpp
+++ b/src/shared/network/LfgPayloadsTests.cpp
@@ -1,0 +1,343 @@
+/**
+ * CMANGOS.33 (Phase 5.33 step 3+4) — Round-trip tests for LFG_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/LfgPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// LFG_QUEUE
+// -----------------------------------------------------------------------------
+
+static void TestQueueRequestRoundTrip()
+{
+	auto buf = BuildLfgQueueRequestPayload(1u, 42u);
+	Assert(buf.size() == 5u, "Queue request payload size 5");
+	auto parsed = ParseLfgQueueRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Queue request parses");
+	if (parsed)
+	{
+		Assert(parsed->role == 1u, "Queue role 1");
+		Assert(parsed->dungeonId == 42u, "Queue dungeonId 42");
+	}
+}
+
+static void TestQueueRequestBoundary()
+{
+	auto buf = BuildLfgQueueRequestPayload(2u, 0xFFFFFFFFu);
+	auto parsed = ParseLfgQueueRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->role == 2u && parsed->dungeonId == 0xFFFFFFFFu,
+		"Queue boundary: role 2 + dungeonId max");
+}
+
+static void TestQueueRequestRejectsShort()
+{
+	auto parsed = ParseLfgQueueRequestPayload(nullptr, 5u);
+	Assert(!parsed.has_value(), "Queue request rejects nullptr");
+	uint8_t shortBuf[4]{};
+	auto parsed2 = ParseLfgQueueRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Queue request rejects 4 bytes");
+}
+
+static void TestQueueResponseOk()
+{
+	auto buf = BuildLfgQueueResponsePayload(0u, 60u);
+	Assert(buf.size() == 5u, "Queue response Ok size 5");
+	auto parsed = ParseLfgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->estimatedWaitSec == 60u,
+		"Queue response Ok parses");
+}
+
+static void TestQueueResponseError()
+{
+	auto buf = BuildLfgQueueResponsePayload(
+		static_cast<uint8_t>(LfgErrorCode::AlreadyQueued), 0u);
+	Assert(buf.size() == 1u, "Queue response error has only 1 byte");
+	auto parsed = ParseLfgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Queue response AlreadyQueued");
+}
+
+static void TestQueueResponsePacket()
+{
+	auto pkt = BuildLfgQueueResponsePacket(0u, 120u, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "Queue response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Queue PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLfgQueueResponse, "Opcode is LfgQueueResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseLfgQueueResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->estimatedWaitSec == 120u,
+		"Queue response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LFG_LEAVE
+// -----------------------------------------------------------------------------
+
+static void TestLeaveRequestRoundTrip()
+{
+	auto buf = BuildLfgLeaveRequestPayload();
+	Assert(buf.empty(), "Leave request payload empty");
+	auto parsed = ParseLfgLeaveRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Leave request accepts empty payload");
+}
+
+static void TestLeaveResponseOk()
+{
+	auto buf = BuildLfgLeaveResponsePayload(0u);
+	Assert(buf.size() == 1u, "Leave response Ok size 1");
+	auto parsed = ParseLfgLeaveResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Leave response Ok parses");
+}
+
+static void TestLeaveResponseNotInQueue()
+{
+	auto buf = BuildLfgLeaveResponsePayload(
+		static_cast<uint8_t>(LfgErrorCode::NotInQueue));
+	auto parsed = ParseLfgLeaveResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Leave response NotInQueue");
+}
+
+static void TestLeaveResponsePacket()
+{
+	auto pkt = BuildLfgLeaveResponsePacket(0u, 99u, 0xBEEFull);
+	Assert(!pkt.empty(), "Leave response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Leave PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLfgLeaveResponse, "Opcode is LfgLeaveResponse");
+	Assert(view.RequestId() == 99u, "Leave RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// LFG_STATUS
+// -----------------------------------------------------------------------------
+
+static void TestStatusRequestRoundTrip()
+{
+	auto buf = BuildLfgStatusRequestPayload();
+	Assert(buf.empty(), "Status request payload empty");
+	auto parsed = ParseLfgStatusRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Status request accepts empty payload");
+}
+
+static void TestStatusResponseInQueue()
+{
+	auto buf = BuildLfgStatusResponsePayload(0u, true, 1u, 42u, 30u);
+	Assert(buf.size() == 11u, "Status response size 11");
+	auto parsed = ParseLfgStatusResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Status response in-queue parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Status error 0");
+		Assert(parsed->inQueue == true, "Status inQueue true");
+		Assert(parsed->role == 1u, "Status role 1");
+		Assert(parsed->dungeonId == 42u, "Status dungeonId 42");
+		Assert(parsed->elapsedSec == 30u, "Status elapsedSec 30");
+	}
+}
+
+static void TestStatusResponseNotInQueue()
+{
+	auto buf = BuildLfgStatusResponsePayload(0u, false, 0u, 0u, 0u);
+	auto parsed = ParseLfgStatusResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->inQueue == false, "Status not in queue");
+}
+
+static void TestStatusResponseUnauthorized()
+{
+	auto buf = BuildLfgStatusResponsePayload(
+		static_cast<uint8_t>(LfgErrorCode::Unauthorized), false, 0u, 0u, 0u);
+	auto parsed = ParseLfgStatusResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "Status Unauthorized");
+}
+
+static void TestStatusResponseRejectsShort()
+{
+	auto parsed = ParseLfgStatusResponsePayload(nullptr, 11u);
+	Assert(!parsed.has_value(), "Status response rejects nullptr");
+	uint8_t shortBuf[10]{};
+	auto parsed2 = ParseLfgStatusResponsePayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Status response rejects 10 bytes");
+}
+
+static void TestStatusResponsePacket()
+{
+	auto pkt = BuildLfgStatusResponsePacket(0u, true, 2u, 7u, 15u, 100u, 0xFEEDull);
+	Assert(!pkt.empty(), "Status response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Status PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLfgStatusResponse, "Opcode is LfgStatusResponse");
+	auto parsed = ParseLfgStatusResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->role == 2u && parsed->dungeonId == 7u,
+		"Status payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LFG_MATCH_PROPOSAL_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMatchProposalEmpty()
+{
+	auto buf = BuildLfgMatchProposalNotificationPayload(123ull, 42u, {});
+	auto parsed = ParseLfgMatchProposalNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Match proposal empty parses");
+	if (parsed)
+	{
+		Assert(parsed->proposalId == 123ull, "Proposal id 123");
+		Assert(parsed->dungeonId == 42u, "Proposal dungeonId 42");
+		Assert(parsed->members.empty(), "Proposal members empty");
+	}
+}
+
+static void TestMatchProposalFullGroup()
+{
+	std::vector<LfgMatchMember> members;
+	members.push_back({1001ull, 0u}); // Tank
+	members.push_back({1002ull, 1u}); // Healer
+	members.push_back({1003ull, 2u}); // Damage
+	members.push_back({1004ull, 2u}); // Damage
+	members.push_back({1005ull, 2u}); // Damage
+	auto buf = BuildLfgMatchProposalNotificationPayload(0xDEADBEEFull, 99u, members);
+	auto parsed = ParseLfgMatchProposalNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Match proposal full group parses");
+	if (parsed && parsed->members.size() == 5u)
+	{
+		Assert(parsed->proposalId == 0xDEADBEEFull, "Proposal id big");
+		Assert(parsed->dungeonId == 99u, "Proposal dungeon 99");
+		Assert(parsed->members[0].accountId == 1001ull && parsed->members[0].role == 0u,
+			"Tank ok");
+		Assert(parsed->members[1].accountId == 1002ull && parsed->members[1].role == 1u,
+			"Healer ok");
+		Assert(parsed->members[2].role == 2u, "Damage 1 ok");
+		Assert(parsed->members[3].role == 2u, "Damage 2 ok");
+		Assert(parsed->members[4].role == 2u, "Damage 3 ok");
+	}
+	else
+	{
+		Assert(false, "Match proposal should have 5 members");
+	}
+}
+
+static void TestMatchProposalRejectsShort()
+{
+	auto parsed = ParseLfgMatchProposalNotificationPayload(nullptr, 14u);
+	Assert(!parsed.has_value(), "Match proposal rejects nullptr");
+	uint8_t shortBuf[13]{};
+	auto parsed2 = ParseLfgMatchProposalNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Match proposal rejects 13 bytes");
+}
+
+static void TestMatchProposalPacket()
+{
+	std::vector<LfgMatchMember> members;
+	members.push_back({42ull, 0u});
+	auto pkt = BuildLfgMatchProposalNotificationPacket(7ull, 1u, members, 0xC0DEull);
+	Assert(!pkt.empty(), "Match proposal packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Match proposal PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLfgMatchProposalNotification, "Opcode is LfgMatchProposalNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xC0DEull, "SessionId preserved");
+	auto parsed = ParseLfgMatchProposalNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->proposalId == 7ull
+		&& parsed->members.size() == 1u && parsed->members[0].accountId == 42ull,
+		"Match proposal payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LFG_MATCH_ACCEPT request (request only — no dedicated response opcode in V1)
+// -----------------------------------------------------------------------------
+
+static void TestMatchAcceptRequestRoundTrip()
+{
+	auto buf = BuildLfgMatchAcceptRequestPayload(0xCAFEull, true);
+	Assert(buf.size() == 9u, "MatchAccept request size 9");
+	auto parsed = ParseLfgMatchAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MatchAccept request parses");
+	if (parsed)
+	{
+		Assert(parsed->proposalId == 0xCAFEull, "Proposal id preserved");
+		Assert(parsed->accept == true, "accept true");
+	}
+}
+
+static void TestMatchAcceptRequestReject()
+{
+	auto buf = BuildLfgMatchAcceptRequestPayload(0xBEEFull, false);
+	auto parsed = ParseLfgMatchAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->accept == false, "MatchAccept reject");
+}
+
+static void TestMatchAcceptRequestRejectsShort()
+{
+	auto parsed = ParseLfgMatchAcceptRequestPayload(nullptr, 9u);
+	Assert(!parsed.has_value(), "MatchAccept rejects nullptr");
+	uint8_t shortBuf[8]{};
+	auto parsed2 = ParseLfgMatchAcceptRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchAccept rejects 8 bytes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestQueueRequestRoundTrip();
+	TestQueueRequestBoundary();
+	TestQueueRequestRejectsShort();
+	TestQueueResponseOk();
+	TestQueueResponseError();
+	TestQueueResponsePacket();
+
+	TestLeaveRequestRoundTrip();
+	TestLeaveResponseOk();
+	TestLeaveResponseNotInQueue();
+	TestLeaveResponsePacket();
+
+	TestStatusRequestRoundTrip();
+	TestStatusResponseInQueue();
+	TestStatusResponseNotInQueue();
+	TestStatusResponseUnauthorized();
+	TestStatusResponseRejectsShort();
+	TestStatusResponsePacket();
+
+	TestMatchProposalEmpty();
+	TestMatchProposalFullGroup();
+	TestMatchProposalRejectsShort();
+	TestMatchProposalPacket();
+
+	TestMatchAcceptRequestRoundTrip();
+	TestMatchAcceptRequestReject();
+	TestMatchAcceptRequestRejectsShort();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all lfg payload tests passed\n"
+	                                : "[FAIL] some lfg tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -342,4 +342,44 @@ namespace engine::network
 	constexpr uint16_t kOpcodeReputationListRequest        = 95u; ///< Client to Master : liste les reputations de l'account courant (vide).
 	constexpr uint16_t kOpcodeReputationListResponse       = 96u; ///< Master to Client : tableau {factionId, value, standing} ou Unauthorized.
 	constexpr uint16_t kOpcodeReputationUpdateNotification = 97u; ///< Master to Client (push, request_id=0) : changement d'une reputation (factionId, newValue, newStanding, delta).
+
+	// -------------------------------------------------------------------------
+	// Opcodes Lfg / LookForGroup (valeurs 100-107)
+	// Reference : Phase 5 CMANGOS.33 step 3+4. Wire client<->master pour le
+	// matchmaking dungeon (LookForGroup queue + match proposal). Le step 1
+	// (LfgQueue header-only, queue par dungeon avec roles Tank/Healer/Damage)
+	// est deja merge ; pas de step 2 DB (queue transient, perdue au reboot).
+	//
+	// Architecture : le master gere une LfgQueue transient. TickMatchmaking
+	// (declenche manuellement en V1, periodique sub-PR future) appelle
+	// TryMatch() sur chaque dungeon connu et envoie une push proposal a
+	// chaque membre du groupe forme.
+	//
+	// V1 limitations :
+	//   - Pas d'etat « proposal » cote master : MatchAccept est juste loggee
+	//     et retourne Ok (le proposal lifecycle viendra dans une sub-PR).
+	//   - estimatedWaitSec hardcode 60s (sera calcule statistiquement plus tard).
+	//   - Tick matchmaking pas appele en boucle automatique : sera cable a
+	//     un timer dans une sub-PR future (e.g. toutes les 5s).
+	//
+	// Decoupage opcode :
+	//   - Queue       (100/101)               : le joueur s'inscrit dans la queue.
+	//   - Leave       (102/103)               : le joueur quitte la queue.
+	//   - Status      (104/105)               : interroge l'etat de la queue
+	//     (en queue ? role/dungeon ? duree ecoulee ?).
+	//   - MatchProposalNotification (106, push) : un groupe a ete forme ;
+	//     liste des membres. Envoye a chaque membre.
+	//   - MatchAccept (107)                   : le client accepte ou rejette
+	//     le match propose. V1 : pas de response payload separee, juste
+	//     log cote master.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeLfgQueueRequest               = 100u; ///< Client to Master : s'inscrit dans la queue dungeon (role + dungeonId).
+	constexpr uint16_t kOpcodeLfgQueueResponse              = 101u; ///< Master to Client : OK + estimatedWaitSec, ou AlreadyQueued / InvalidRole / InvalidDungeon / Unauthorized.
+	constexpr uint16_t kOpcodeLfgLeaveRequest               = 102u; ///< Client to Master : quitte la queue (vide ; account derive de la session).
+	constexpr uint16_t kOpcodeLfgLeaveResponse              = 103u; ///< Master to Client : OK ou NotInQueue / Unauthorized.
+	constexpr uint16_t kOpcodeLfgStatusRequest              = 104u; ///< Client to Master : interroge l'etat de queue (vide).
+	constexpr uint16_t kOpcodeLfgStatusResponse             = 105u; ///< Master to Client : inQueue + role + dungeonId + elapsedSec, ou Unauthorized.
+	constexpr uint16_t kOpcodeLfgMatchProposalNotification  = 106u; ///< Master to Client (push, request_id=0) : un groupe a ete forme (proposalId, dungeonId, members).
+	constexpr uint16_t kOpcodeLfgMatchAcceptRequest         = 107u; ///< Client to Master : accepte ou rejette un match propose (proposalId + accept bool). V1 : log + ack.
 }


### PR DESCRIPTION
## LFG wire — server + UI client

Branche \`LfgQueue\` (step 1 mergé) sur le wire et UI client. Master gère la queue, matchmaking déféré (sub-PR). Client peut queue/leave/status/accept proposals.

### Server wire
- \`ProtocolV1Constants.h\` : opcodes 100-107 (4 paires Request/Response + 1 push)
- \`src/shared/network/LfgPayloads.{h,cpp,Tests.cpp}\`
- \`src/masterd/handlers/lfg/LfgHandler.{h,cpp}\` : dispatch + TickMatchmaking
- \`src/masterd/main_linux.cpp\` : instancie + dispatch

### Client integration
- \`src/client/lfg/LfgUi.{h,cpp}\` + \`render/LfgImGuiRenderer.{h,cpp}\`
- \`src/client/app/Engine\` : dispatch 101/103/105/106 + slash \`/lfg\`

### V1 limitations
- TickMatchmaking pas appelé auto (sera câblé avec un timer)
- Dungeon catalog hardcodé côté client (3 entrées)
- estimatedWaitSec hardcodé 60s
- MatchAccept simplifié (pas de proposal lifecycle dédié)

### Déploiement
⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — opcodes 100-107 + handler.

Generated with Claude Code