### PR TITLE
feat(skills): wire server snapshot + UI client (Phase 4 CMANGOS.39)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ add_library(engine_core
   src/client/reputation/ReputationUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
+  src/client/skills/SkillBookUi.cpp
   src/client/social/PartyHud.cpp
   src/client/world/ZonePreloadHook.cpp
   src/shared/net/ChatSystem.cpp
@@ -340,6 +341,7 @@ add_library(engine_core
   src/client/render/ReputationImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
+  src/client/render/SkillBookImGuiRenderer.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp
   src/client/render/DecalPass.cpp
@@ -435,6 +437,7 @@ add_library(engine_core
   src/shared/network/ReputationPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
+  src/shared/network/SkillPayloads.cpp
   src/shared/network/TradePayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
@@ -677,6 +680,11 @@ add_test(NAME lfg_payloads_tests COMMAND lfg_payloads_tests)
 add_executable(cinematic_payloads_tests src/shared/network/CinematicPayloadsTests.cpp)
 target_link_libraries(cinematic_payloads_tests PRIVATE engine_core)
 add_test(NAME cinematic_payloads_tests COMMAND cinematic_payloads_tests)
+
+# CMANGOS.39 (Phase 4.39 step 3+4) — Skill payloads round-trip tests (no DB / no network).
+add_executable(skill_payloads_tests src/shared/network/SkillPayloadsTests.cpp)
+target_link_libraries(skill_payloads_tests PRIVATE engine_core)
+add_test(NAME skill_payloads_tests COMMAND skill_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/reputation/ReputationHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lfg/LfgHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/cinematics/CinematicHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/skills/SkillHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -129,6 +130,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ReputationPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LfgPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/CinematicPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/SkillPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -15,6 +15,7 @@
 #include "src/shared/network/ReputationPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
+#include "src/shared/network/SkillPayloads.h"
 #include "src/shared/network/TradePayloads.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -25,6 +26,7 @@
 #include "src/client/render/ReputationImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
+#include "src/client/render/SkillBookImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -906,6 +908,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.39 (Phase 4.39 step 3+4) — Init du presenter Skill Book +
+		// cable du send callback. Reception dispatchee dans le push handler
+		// ci-dessous (opcodes 114/116/118 responses + 119 push). Fire-and-forget
+		// des requetes 113/115/117 via SendGenericRequestAsync.
+		if (!m_skillBookUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] SkillBookUiPresenter init FAILED — panneau skill book desactive");
+		}
+		else
+		{
+			m_skillBookUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1018,6 +1035,23 @@ namespace engine
 					m_reputationUi.RequestReputationList();
 				}
 				LOG_INFO(Core, "[Engine] /rep toggle (visible={})", m_reputationVisible);
+				return true;
+			}
+			// CMANGOS.39 (Phase 4.39 step 3+4) — Slash command /skills pour
+			// ouvrir/fermer le panneau Skill Book et synchroniser la liste
+			// depuis le master au moment de l'ouverture. La touche B fait
+			// la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/skills" || text == "/skill"
+				    || text.starts_with("/skills ") || text.starts_with("/skills\t")
+				    || text.starts_with("/skill ") || text.starts_with("/skill\t")))
+			{
+				m_skillBookVisible = !m_skillBookVisible;
+				if (m_skillBookVisible)
+				{
+					m_skillBookUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] /skills toggle (visible={})", m_skillBookVisible);
 				return true;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Slash command /lfg pour
@@ -1354,6 +1388,52 @@ namespace engine
 					return;
 				}
 				m_reputationUi.OnUpdateNotification(*parsed);
+				return;
+			}
+			// CMANGOS.39 (Phase 4.39 step 3+4) — Dispatch des reponses Skills
+			// (114/116/118) + push UpgradeNotification (119).
+			case kOpcodeSkillsListResponse:
+			{
+				auto parsed = ParseSkillsListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] SKILLS_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_skillBookUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeSkillLearnResponse:
+			{
+				auto parsed = ParseSkillLearnResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] SKILL_LEARN_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_skillBookUi.OnLearnResponse(*parsed);
+				return;
+			}
+			case kOpcodeSkillUseResponse:
+			{
+				auto parsed = ParseSkillUseResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] SKILL_USE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_skillBookUi.OnUseResponse(*parsed);
+				return;
+			}
+			case kOpcodeSkillUpgradeNotification:
+			{
+				auto parsed = ParseSkillUpgradeNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] SKILL_UPGRADE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_skillBookUi.OnUpgradeNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -3654,6 +3734,7 @@ namespace engine
 		m_reputationUi.Shutdown();
 		m_lfgUi.Shutdown();
 		m_cinematicUi.Shutdown();
+		m_skillBookUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3719,6 +3800,29 @@ namespace engine
 
 		if (m_input.WasPressed(engine::platform::Key::F_11))
     		m_window.ToggleFullscreen();
+
+		// CMANGOS.39 (Phase 4.39 step 3+4) — Touche B post-auth toggle le
+		// panneau Skill Book (equivalent a la slash command /skills). Bloquee
+		// si le chat a le focus (l'utilisateur tape) ou si le menu pause /
+		// editor est ouvert pour eviter les toggles accidentels.
+		{
+			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
+			const bool inGameNoMenu = !m_inGamePauseMenuVisible
+				&& !m_inGameOptionsPanelVisible
+				&& !m_editorEnabled
+				&& m_authUi.IsInitialized()
+				&& m_authUi.IsFlowComplete();
+			if (inGameNoMenu && !chatBlocks
+				&& m_input.WasPressed(engine::platform::Key::B))
+			{
+				m_skillBookVisible = !m_skillBookVisible;
+				if (m_skillBookVisible)
+				{
+					m_skillBookUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] B toggle skillbook (visible={})", m_skillBookVisible);
+			}
+		}
 
 		// M100.2 — Dispatch des raccourcis éditeur monde vers le shell. Ctrl+Z
 		// / Ctrl+Shift+Z / Ctrl+Y branchent la pile undo/redo ; F1..F12
@@ -3902,6 +4006,12 @@ namespace engine
 				// le declenchement est server-pushed.
 				m_cinematicImGui = std::make_unique<engine::render::CinematicImGuiRenderer>();
 				m_cinematicImGui->SetPresenter(&m_cinematicUi);
+				// CMANGOS.39 (Phase 4.39 step 3+4) — Renderer ImGui du panneau
+				// Skill Book. Partage le contexte ImGui avec auth/chat/mail/gmtickets/
+				// reputation/lfg. Visible uniquement quand m_skillBookVisible
+				// (toggle via /skills ou touche B).
+				m_skillBookImGui = std::make_unique<engine::render::SkillBookImGuiRenderer>();
+				m_skillBookImGui->SetPresenter(&m_skillBookUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -4961,6 +5071,16 @@ namespace engine
 			{
 				m_cinematicImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_cinematicImGui->Render();
+			}
+			// CMANGOS.39 (Phase 4.39 step 3+4) — Tick l'indicateur Use puis
+			// render le panneau Skill Book si visible. L'indicateur Use est rendu
+			// en plus de la liste si actif (overlay non bloquant).
+			m_skillBookUi.TickIndicator(static_cast<float>(m_time.DeltaSeconds()));
+			if (m_skillBookVisible && m_skillBookImGui && m_skillBookUi.IsInitialized())
+			{
+				m_skillBookImGui->SetEnabled(true);
+				m_skillBookImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_skillBookImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -14,6 +14,7 @@
 #include "src/client/reputation/ReputationUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
+#include "src/client/skills/SkillBookUi.h"
 #include "src/client/trade/TradeWindowUi.h"
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
@@ -75,6 +76,7 @@ namespace engine::render
 	class ReputationImGuiRenderer;
 	class LfgImGuiRenderer;
 	class CinematicImGuiRenderer;
+	class SkillBookImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -348,6 +350,11 @@ namespace engine
 		/// de lecture (m_cinematicUi.GetState().isPlaying). Toggle pilote par
 		/// les push 108 du master.
 		std::unique_ptr<engine::render::CinematicImGuiRenderer> m_cinematicImGui;
+		/// CMANGOS.39 (Phase 4.39 step 3+4) — Panneau "Skill Book" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec auth/chat/mail/gmtickets/reputation/lfg.
+		/// Visible uniquement quand m_skillBookVisible (toggle via slash command
+		/// /skills ou touche B).
+		std::unique_ptr<engine::render::SkillBookImGuiRenderer> m_skillBookImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -462,6 +469,14 @@ namespace engine
 		/// fire-and-forget des requetes 83/86/88/91/93 via
 		/// \c m_authUi.SendGenericRequestAsync.
 		engine::client::TradeWindowUiPresenter m_tradeWindowUi;
+		/// CMANGOS.39 (Phase 4.39 step 3+4) — Presenter de la skill book cote
+		/// client. Recoit les responses opcodes 114/116/118 et la push 119
+		/// via le push handler du master ; fire-and-forget des requetes
+		/// 113/115/117 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::SkillBookUiPresenter m_skillBookUi;
+		/// CMANGOS.39 (Phase 4.39 step 3+4) — Visibilite du panneau Skill Book
+		/// (toggle via slash command \c /skills ou touche B). Faux par defaut.
+		bool                                  m_skillBookVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/render/SkillBookImGuiRenderer.cpp
+++ b/src/client/render/SkillBookImGuiRenderer.cpp
@@ -1,0 +1,263 @@
+// CMANGOS.39 (Phase 4.39 step 3+4) — SkillBookImGuiRenderer implementation.
+
+#include "src/client/render/SkillBookImGuiRenderer.h"
+
+#include "src/client/render/LnTheme.h"
+#include "src/client/skills/SkillBookUi.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Couleur du texte / barre selon le ratio value/cap.
+		ImVec4 SkillProgressColor(uint16_t value, uint16_t cap)
+		{
+			if (cap == 0u) return ImVec4(0.70f, 0.70f, 0.70f, 1.f);
+			const float ratio = static_cast<float>(value) / static_cast<float>(cap);
+			if (ratio >= 1.0f) return ImVec4(1.00f, 0.85f, 0.20f, 1.f); // or = capped
+			if (ratio >= 0.75f) return ImVec4(0.40f, 0.85f, 0.40f, 1.f); // vert
+			if (ratio >= 0.40f) return ImVec4(0.95f, 0.85f, 0.30f, 1.f); // jaune
+			return ImVec4(0.95f, 0.55f, 0.20f, 1.f); // orange (debutant)
+		}
+
+		/// Libelle FR pour un SkillUseResult (0=Success, 1=Fail, 2=Crit).
+		const char* UseResultLabel(uint8_t result)
+		{
+			switch (result)
+			{
+			case 0u: return "Succes";
+			case 1u: return "Echec";
+			case 2u: return "Critique";
+			default: return "?";
+			}
+		}
+
+		/// Couleur du libelle indicateur Use.
+		ImVec4 UseResultColor(uint8_t result)
+		{
+			switch (result)
+			{
+			case 0u: return ImVec4(0.40f, 0.85f, 0.40f, 1.0f); // Success vert
+			case 1u: return ImVec4(0.85f, 0.40f, 0.40f, 1.0f); // Fail rouge
+			case 2u: return ImVec4(1.00f, 0.85f, 0.20f, 1.0f); // Crit or
+			default: return ImVec4(0.70f, 0.70f, 0.70f, 1.0f);
+			}
+		}
+	}
+
+	void SkillBookImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderListPanel();
+		RenderUseIndicator();
+	}
+
+	void SkillBookImGuiRenderer::RenderListPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 380x520. Decale legerement vs
+		// reputation pour eviter le chevauchement direct si les deux sont
+		// ouverts en meme temps.
+		const float panelW = 380.f;
+		const float panelH = 520.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Skill Book (B)##ln_skillbook_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge) — non bloquante.
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			if (ImGui::Button("Rafraichir"))
+			{
+				m_presenter->RequestList();
+			}
+			ImGui::SameLine();
+			ImGui::TextDisabled("(%zu skill%s)",
+				state.skills.size(), state.skills.size() > 1 ? "s" : "");
+
+			ImGui::Separator();
+
+			if (state.isLoading)
+			{
+				ImGui::TextUnformatted("Chargement...");
+			}
+			else if (state.skills.empty())
+			{
+				ImGui::TextDisabled("Aucune competence apprise.");
+			}
+			else
+			{
+				const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+					| ImGuiTableFlags_RowBg
+					| ImGuiTableFlags_ScrollY
+					| ImGuiTableFlags_Resizable;
+				if (ImGui::BeginTable("##ln_skillbook_list", 4, tableFlags, ImVec2(0.f, 0.f)))
+				{
+					ImGui::TableSetupColumn("Competence", ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableSetupColumn("Valeur",     ImGuiTableColumnFlags_WidthFixed,  90.f);
+					ImGui::TableSetupColumn("Progres",    ImGuiTableColumnFlags_WidthFixed,  90.f);
+					ImGui::TableSetupColumn("",           ImGuiTableColumnFlags_WidthFixed,  60.f);
+					ImGui::TableHeadersRow();
+
+					for (const auto& e : state.skills)
+					{
+						ImGui::TableNextRow();
+						ImGui::PushID(static_cast<int>(e.skillId));
+
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextUnformatted(e.name.c_str());
+						if (e.bonus > 0u)
+						{
+							ImGui::SameLine();
+							ImGui::TextDisabled("(+%u)", static_cast<unsigned>(e.bonus));
+						}
+
+						ImGui::TableSetColumnIndex(1);
+						ImGui::Text("%u / %u", static_cast<unsigned>(e.value),
+							static_cast<unsigned>(e.cap));
+
+						ImGui::TableSetColumnIndex(2);
+						const float ratio = (e.cap > 0u)
+							? std::clamp(static_cast<float>(e.value) / static_cast<float>(e.cap), 0.f, 1.f)
+							: 0.f;
+						const ImVec4 col = SkillProgressColor(e.value, e.cap);
+						ImGui::PushStyleColor(ImGuiCol_PlotHistogram, col);
+						ImGui::ProgressBar(ratio, ImVec2(-FLT_MIN, 0.f), "");
+						ImGui::PopStyleColor();
+
+						ImGui::TableSetColumnIndex(3);
+						// Bouton Use desactive si value == cap (pas de progression
+						// possible) ou si value == 0 (skill non encore appris reel ;
+						// V1 : Lockpicking commence a 0).
+						const bool capped = (e.cap > 0u && e.value >= e.cap);
+						if (capped)
+						{
+							ImGui::BeginDisabled();
+							ImGui::Button("Cap");
+							ImGui::EndDisabled();
+						}
+						else
+						{
+							if (ImGui::Button("Utiliser"))
+							{
+								m_presenter->RequestUse(e.skillId, 0u);
+							}
+						}
+
+						ImGui::PopID();
+					}
+					ImGui::EndTable();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void SkillBookImGuiRenderer::RenderUseIndicator()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastUseResult.has_value())
+			return;
+
+		const uint8_t result = *state.lastUseResult;
+		const ImVec4 col = UseResultColor(result);
+		const char*  lab = UseResultLabel(result);
+
+		// Indicateur en haut centre de l'ecran, fade-out implicite (la fenetre
+		// disparait quand TickIndicator clear lastUseResult). Pas de NoInputs
+		// puisqu'on veut juste un overlay.
+		const float toastW = 280.f;
+		const float toastH = 70.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float posX = std::max(0.f, (vpW - toastW) * 0.5f);
+		const float posY = margin;
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.85f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.85f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoNav
+			| ImGuiWindowFlags_NoInputs;
+		if (ImGui::Begin("##ln_skillbook_use_indicator", nullptr, flags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, col);
+			ImGui::TextUnformatted(lab);
+			ImGui::PopStyleColor();
+
+			char buf[160]{};
+			if (state.lastUseSkillId != 0u)
+			{
+				const std::string name = engine::client::GetSkillName(state.lastUseSkillId);
+				if (state.lastUseDelta > 0u)
+					std::snprintf(buf, sizeof(buf), "+%u %s",
+						static_cast<unsigned>(state.lastUseDelta), name.c_str());
+				else
+					std::snprintf(buf, sizeof(buf), "%s", name.c_str());
+			}
+			else if (state.lastUseDelta > 0u)
+			{
+				std::snprintf(buf, sizeof(buf), "+%u", static_cast<unsigned>(state.lastUseDelta));
+			}
+			else
+			{
+				std::snprintf(buf, sizeof(buf), "(pas de gain)");
+			}
+			ImGui::TextUnformatted(buf);
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void SkillBookImGuiRenderer::Render()             {}
+	void SkillBookImGuiRenderer::RenderListPanel()    {}
+	void SkillBookImGuiRenderer::RenderUseIndicator() {}
+}
+
+#endif

--- a/src/client/render/SkillBookImGuiRenderer.h
+++ b/src/client/render/SkillBookImGuiRenderer.h
@@ -1,0 +1,44 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39 step 3+4) — SkillBookImGuiRenderer : panneau ImGui
+// pour la skill book cote joueur. Lit l'etat d'un SkillBookUiPresenter,
+// dispatch les inputs UI vers le presenter via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class SkillBookUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau Skill Book. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::SkillBookUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs
+	/// UI vers le presenter.
+	class SkillBookImGuiRenderer
+	{
+	public:
+		SkillBookImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::SkillBookUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Skill Book" + indicateur Use s'il est actif.
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), apres
+		/// NewFrame, si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		void RenderListPanel();
+		void RenderUseIndicator();
+
+		engine::client::SkillBookUiPresenter* m_presenter = nullptr;
+		bool                                  m_enabled   = false;
+		uint32_t                              m_viewportW = 0;
+		uint32_t                              m_viewportH = 0;
+	};
+}

--- a/src/client/skills/SkillBookUi.cpp
+++ b/src/client/skills/SkillBookUi.cpp
@@ -1,0 +1,279 @@
+// CMANGOS.39 (Phase 4.39 step 3+4) — Implementation SkillBookUiPresenter.
+
+#include "src/client/skills/SkillBookUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdio>
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Duree d'affichage de l'indicateur Use (Success/Fail/Crit) en secondes.
+		constexpr float kIndicatorDurationSeconds = 2.0f;
+	}
+
+	std::string GetSkillName(uint16_t skillId)
+	{
+		// V1 : table hardcode des skills du starter set. La table de skills
+		// reelle viendra avec CMANGOS.41 (Trainers) ou CMANGOS.40 (Crafting
+		// catalog) qui exposera un map id -> name localise.
+		switch (skillId)
+		{
+		case 1u: return "Cuisine";
+		case 2u: return "Herboristerie";
+		case 3u: return "Mineur";
+		case 4u: return "Premiers soins";
+		case 5u: return "Crochetage";
+		default: break;
+		}
+		char buf[32]{};
+		std::snprintf(buf, sizeof(buf), "Skill #%u", static_cast<unsigned>(skillId));
+		return buf;
+	}
+
+	SkillBookUiPresenter::~SkillBookUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool SkillBookUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[SkillBookUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_state.layoutValid = true;
+		m_clockSeconds = 0.0f;
+		LOG_INFO(Core, "[SkillBookUiPresenter] Init OK");
+		return true;
+	}
+
+	void SkillBookUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[SkillBookUiPresenter] Destroyed");
+	}
+
+	void SkillBookUiPresenter::RequestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildSkillsListRequestPayload();
+		m_state.isLoading = true;
+		if (!m_send(engine::network::kOpcodeSkillsListRequest, payload))
+		{
+			m_state.isLoading = false;
+			m_state.lastErrorText = "Echec envoi (liste skills).";
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[SkillBookUiPresenter] SkillsListRequest queued");
+	}
+
+	void SkillBookUiPresenter::RequestLearn(uint16_t skillId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestLearn: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildSkillLearnRequestPayload(skillId);
+		if (!m_send(engine::network::kOpcodeSkillLearnRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (apprendre skill).";
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestLearn: send failed (skillId={})", skillId);
+			return;
+		}
+		LOG_DEBUG(Net, "[SkillBookUiPresenter] SkillLearnRequest queued skillId={}", skillId);
+	}
+
+	void SkillBookUiPresenter::RequestUse(uint16_t skillId, uint64_t targetEntityId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestUse: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildSkillUseRequestPayload(skillId, targetEntityId);
+		if (!m_send(engine::network::kOpcodeSkillUseRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (utiliser skill).";
+			LOG_WARN(Net, "[SkillBookUiPresenter] RequestUse: send failed (skillId={})", skillId);
+			return;
+		}
+		LOG_DEBUG(Net, "[SkillBookUiPresenter] SkillUseRequest queued skillId={} target={}",
+			skillId, targetEntityId);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void SkillBookUiPresenter::RebuildSkillsFromResponse(const engine::network::SkillsListResponsePayload& resp)
+	{
+		m_state.skills.clear();
+		m_state.skills.reserve(resp.skills.size());
+		for (const auto& e : resp.skills)
+		{
+			SkillBookEntryView v;
+			v.skillId = e.skillId;
+			v.value   = e.value;
+			v.cap     = e.cap;
+			v.bonus   = e.bonus;
+			v.name    = GetSkillName(e.skillId);
+			m_state.skills.push_back(std::move(v));
+		}
+	}
+
+	void SkillBookUiPresenter::OnListResponse(const engine::network::SkillsListResponsePayload& resp)
+	{
+		m_state.isLoading = false;
+		if (resp.error != 0u)
+		{
+			using engine::network::SkillErrorCode;
+			if (static_cast<SkillErrorCode>(resp.error) == SkillErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur lors du chargement des skills.";
+			LOG_WARN(Net, "[SkillBookUiPresenter] OnListResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		RebuildSkillsFromResponse(resp);
+		LOG_INFO(Net, "[SkillBookUiPresenter] OnListResponse: {} skills",
+			m_state.skills.size());
+	}
+
+	void SkillBookUiPresenter::UpdateOrInsertEntry(uint16_t skillId, uint16_t newValue, uint16_t newCap, uint16_t bonus)
+	{
+		for (auto& e : m_state.skills)
+		{
+			if (e.skillId == skillId)
+			{
+				e.value = newValue;
+				e.cap   = newCap;
+				if (bonus != 0u)
+					e.bonus = bonus;
+				return;
+			}
+		}
+		// Insert : le skill n'etait pas dans la liste (Learn d'un nouveau).
+		SkillBookEntryView v;
+		v.skillId = skillId;
+		v.value   = newValue;
+		v.cap     = newCap;
+		v.bonus   = bonus;
+		v.name    = GetSkillName(skillId);
+		m_state.skills.push_back(std::move(v));
+	}
+
+	void SkillBookUiPresenter::OnLearnResponse(const engine::network::SkillLearnResponsePayload& resp)
+	{
+		using engine::network::SkillErrorCode;
+		if (resp.error != 0u)
+		{
+			switch (static_cast<SkillErrorCode>(resp.error))
+			{
+			case SkillErrorCode::AlreadyLearned:
+				m_state.lastErrorText = "Vous connaissez deja cette competence.";
+				break;
+			case SkillErrorCode::UnknownSkill:
+				m_state.lastErrorText = "Competence inconnue.";
+				break;
+			case SkillErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur lors de l'apprentissage.";
+				break;
+			}
+			LOG_WARN(Net, "[SkillBookUiPresenter] OnLearnResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		LOG_INFO(Net, "[SkillBookUiPresenter] OnLearnResponse OK initialCap={}", resp.initialCap);
+		// L'insertion / update viendra avec la push UpgradeNotification (delta=0)
+		// emise par le serveur juste apres la response. On laisse donc OnUpgradeNotification
+		// mettre a jour la liste.
+	}
+
+	void SkillBookUiPresenter::ArmUseIndicator(uint16_t skillId, uint8_t result, uint16_t delta)
+	{
+		m_state.lastUseResult     = result;
+		m_state.lastUseSkillId    = skillId;
+		m_state.lastUseDelta      = delta;
+		m_state.lastUseExpireAt   = m_clockSeconds + kIndicatorDurationSeconds;
+	}
+
+	void SkillBookUiPresenter::OnUseResponse(const engine::network::SkillUseResponsePayload& resp)
+	{
+		using engine::network::SkillErrorCode;
+		if (resp.error != 0u)
+		{
+			switch (static_cast<SkillErrorCode>(resp.error))
+			{
+			case SkillErrorCode::SkillNotLearned:
+				m_state.lastErrorText = "Vous ne connaissez pas cette competence.";
+				break;
+			case SkillErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur lors de l'utilisation.";
+				break;
+			}
+			LOG_WARN(Net, "[SkillBookUiPresenter] OnUseResponse: server error code={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		LOG_INFO(Net, "[SkillBookUiPresenter] OnUseResponse: result={} delta={}",
+			static_cast<unsigned>(resp.result), resp.deltaValue);
+		// L'indicateur prend le skillId du dernier Use ; on ne le sait pas
+		// directement depuis la response (V1 : pas d'echo). On met skillId=0
+		// qui signifie "indicateur sans highlight specifique" cote renderer.
+		// Si gain effectif, la push UpgradeNotification fera le highlight propre.
+		ArmUseIndicator(0u, resp.result, resp.deltaValue);
+	}
+
+	void SkillBookUiPresenter::OnUpgradeNotification(const engine::network::SkillUpgradeNotificationPayload& note)
+	{
+		UpdateOrInsertEntry(note.skillId, note.newValue, note.newCap);
+
+		// Si delta > 0, on rearme l'indicateur avec le skillId precis (highlight).
+		// Si delta == 0 (cas du Learn), pas d'indicateur visuel additionnel.
+		if (note.delta > 0)
+		{
+			ArmUseIndicator(note.skillId, 0u /*Success*/, static_cast<uint16_t>(note.delta));
+		}
+
+		LOG_INFO(Net, "[SkillBookUiPresenter] OnUpgradeNotification: skill={} newValue={} newCap={} delta={}",
+			note.skillId, note.newValue, note.newCap, static_cast<int>(note.delta));
+	}
+
+	void SkillBookUiPresenter::TickIndicator(float deltaSeconds)
+	{
+		if (deltaSeconds <= 0.0f) return;
+		m_clockSeconds += deltaSeconds;
+		if (m_state.lastUseResult.has_value()
+			&& m_clockSeconds >= m_state.lastUseExpireAt)
+		{
+			m_state.lastUseResult.reset();
+			m_state.lastUseDelta    = 0;
+			m_state.lastUseSkillId  = 0;
+			m_state.lastUseExpireAt = 0.0f;
+		}
+	}
+}

--- a/src/client/skills/SkillBookUi.h
+++ b/src/client/skills/SkillBookUi.h
@@ -1,0 +1,146 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39 step 3+4) — Presenter client de la skill book.
+// Maintient un cache local des skills (value/cap/bonus) et expose les
+// reponses serveur (List/Learn/Use) ainsi qu'un indicateur transitoire
+// du dernier resultat de Use (Success/Fail/Crit).
+//
+// Pas de rendu ImGui : le panneau est drawe par SkillBookImGuiRenderer qui
+// lit l'etat via GetState() et propage les inputs UI via les methodes du
+// presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans QuestUiPresenter
+// et ReputationUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes 114/116/118/119
+// vers les OnXxx du presenter.
+
+#include "src/shared/network/SkillPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::client
+{
+	/// Une entree de la skill book exposable au layer UI.
+	/// Mirror direct de SkillBookEntry sur le wire avec un nom resolu cote
+	/// client (table statique GetSkillName(skillId)).
+	struct SkillBookEntryView
+	{
+		uint16_t    skillId = 0;
+		uint16_t    value   = 0; ///< niveau actuel.
+		uint16_t    cap     = 0; ///< cap dur (max attribuable a ce moment).
+		uint16_t    bonus   = 0; ///< bonus temporaire (potion, equipement).
+		std::string name;        ///< nom localise (FR) ou "Skill #N".
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct SkillBookState
+	{
+		std::vector<SkillBookEntryView> skills;
+		bool                            isLoading = false;
+		std::string                     lastErrorText;            ///< Vide si pas d'erreur transitoire.
+		/// Indicateur du dernier Use : 0=Success, 1=Fail, 2=Crit. nullopt = pas d'indicateur actif.
+		std::optional<uint8_t>          lastUseResult;
+		uint16_t                        lastUseDelta       = 0;   ///< delta du dernier Use (0 si pas de gain).
+		uint16_t                        lastUseSkillId     = 0;   ///< skillId du dernier Use (pour highlight).
+		float                           lastUseExpireAt    = 0.0f;///< game seconds (cf. TickIndicator).
+		bool                            layoutValid        = false;
+	};
+
+	/// Resout le nom localise d'un skill par son id. V1 : table hardcode des
+	/// 5 skills du starter set ; les ids inconnus retournent "Skill #N".
+	std::string GetSkillName(uint16_t skillId);
+
+	/// Presenter pour le panneau Skill Book cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main.
+	class SkillBookUiPresenter final
+	{
+	public:
+		SkillBookUiPresenter() = default;
+
+		SkillBookUiPresenter(const SkillBookUiPresenter&)            = delete;
+		SkillBookUiPresenter& operator=(const SkillBookUiPresenter&) = delete;
+
+		~SkillBookUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.39 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / RequestLearn / RequestUse.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie SKILLS_LIST_REQUEST. Reponse via OnListResponse.
+		/// Met aussi m_state.isLoading = true le temps de la reponse.
+		void RequestList();
+
+		/// Envoie SKILL_LEARN_REQUEST pour \p skillId. Reponse via OnLearnResponse.
+		void RequestLearn(uint16_t skillId);
+
+		/// Envoie SKILL_USE_REQUEST pour \p skillId avec target opaque \p targetEntityId.
+		/// V1 : target est log seulement cote serveur, pas de check.
+		/// Reponse via OnUseResponse (et eventuellement push UpgradeNotification).
+		void RequestUse(uint16_t skillId, uint64_t targetEntityId = 0u);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit SKILLS_LIST_RESPONSE. Remplace la cache locale.
+		void OnListResponse(const engine::network::SkillsListResponsePayload& resp);
+
+		/// Recoit SKILL_LEARN_RESPONSE. Met a jour ou insere un skill avec value=0
+		/// si error == Ok ; affiche un message transitoire sinon.
+		void OnLearnResponse(const engine::network::SkillLearnResponsePayload& resp);
+
+		/// Recoit SKILL_USE_RESPONSE. Arme l'indicateur transitoire (Success/Fail/Crit).
+		void OnUseResponse(const engine::network::SkillUseResponsePayload& resp);
+
+		/// Recoit un push SKILL_UPGRADE_NOTIFICATION : update entry locale +
+		/// arme l'indicateur si delta > 0 (gain visible cote UI).
+		void OnUpgradeNotification(const engine::network::SkillUpgradeNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// Tick / state access
+		// ---------------------------------------------------------------------
+
+		/// Avance le compteur de l'indicateur Use et clear l'overlay si expire.
+		/// \p deltaSeconds est le dt frame (en secondes). A appeler chaque frame
+		/// depuis Engine.
+		void TickIndicator(float deltaSeconds);
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const SkillBookState& GetState() const { return m_state; }
+
+	private:
+		/// Reconstruit m_state.skills depuis une SkillsListResponsePayload.
+		void RebuildSkillsFromResponse(const engine::network::SkillsListResponsePayload& resp);
+
+		/// Met a jour ou insere une entree apres push notification ou Learn ack.
+		void UpdateOrInsertEntry(uint16_t skillId, uint16_t newValue, uint16_t newCap, uint16_t bonus = 0u);
+
+		/// Arme l'indicateur Use pour ~2s.
+		void ArmUseIndicator(uint16_t skillId, uint8_t result, uint16_t delta);
+
+		bool                  m_initialized       = false;
+		SkillBookState        m_state{};
+		SendCallback          m_send;
+		float                 m_clockSeconds      = 0.0f; ///< Cumul depuis Init() (utilise pour comparer expiry).
+	};
+}

--- a/src/masterd/handlers/skills/SkillHandler.cpp
+++ b/src/masterd/handlers/skills/SkillHandler.cpp
@@ -1,0 +1,369 @@
+// CMANGOS.39 (Phase 4.39 step 3+4) — Implementation SkillHandler.
+
+#include "src/masterd/handlers/skills/SkillHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/SkillPayloads.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Seuil RNG pour SKILL_USE V1 : 70% Success, 30% Fail. Pas de Crit V1
+		/// (le presenter affiche tout de meme l'enum, et on pourra introduire
+		/// 5% Crit dans une calibration future). Distribution uniforme [0..99].
+		constexpr uint32_t kUseSuccessThresholdPct = 70u;
+
+		/// Cap initial pour un skill juste appris (V1). Aligne avec le starter set.
+		constexpr uint16_t kInitialCap = 75u;
+	}
+
+	void SkillHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[SkillHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(SkillErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeSkillsListRequest:
+				pkt = BuildSkillsListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeSkillLearnRequest:
+				pkt = BuildSkillLearnResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeSkillUseRequest:
+				pkt = BuildSkillUseResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeSkillsListRequest:
+			HandleListRequest(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeSkillLearnRequest:
+			HandleLearnRequest(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeSkillUseRequest:
+			HandleUseRequest(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void SkillHandler::SeedStarterSetIfNeeded(uint64_t accountId)
+	{
+		using namespace engine::network;
+
+		auto& entry = m_skillsByAccount[accountId];
+		if (!entry.empty())
+			return;
+
+		// Starter set V1 : Cooking, Herbalism, Mining, FirstAid (tous value=1
+		// pour signaler un debut concret au joueur), Lockpicking (value=0,
+		// debutant seulement si trainer apprend).
+		entry[1u] = SkillBookEntry{1u, 1u, kInitialCap, 0u}; // Cooking
+		entry[2u] = SkillBookEntry{2u, 1u, kInitialCap, 0u}; // Herbalism
+		entry[3u] = SkillBookEntry{3u, 1u, kInitialCap, 0u}; // Mining
+		entry[4u] = SkillBookEntry{4u, 1u, kInitialCap, 0u}; // FirstAid
+		entry[5u] = SkillBookEntry{5u, 0u, kInitialCap, 0u}; // Lockpicking
+
+		LOG_INFO(Net, "[SkillHandler] Seeded starter set for account={} ({} skills)",
+			accountId, entry.size());
+	}
+
+	// -------------------------------------------------------------------------
+
+	void SkillHandler::HandleListRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		std::vector<SkillBookEntry> entries;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			SeedStarterSetIfNeeded(accountId);
+			const auto& map = m_skillsByAccount[accountId];
+			entries.reserve(map.size());
+			for (const auto& [skillId, e] : map)
+			{
+				(void)skillId;
+				entries.push_back(e);
+			}
+		}
+
+		LOG_INFO(Net, "[SkillHandler] List account={} count={}", accountId, entries.size());
+
+		auto pkt = BuildSkillsListResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void SkillHandler::HandleLearnRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseSkillLearnRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[SkillHandler] Learn parse failed account={}", accountId);
+			auto pkt = BuildSkillLearnResponsePacket(
+				static_cast<uint8_t>(SkillErrorCode::UnknownSkill), 0u, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint16_t skillId = parsed->skillId;
+		if (skillId == 0u || skillId > kMaxValidSkillId)
+		{
+			LOG_INFO(Net, "[SkillHandler] Learn UnknownSkill account={} skillId={}",
+				accountId, skillId);
+			auto pkt = BuildSkillLearnResponsePacket(
+				static_cast<uint8_t>(SkillErrorCode::UnknownSkill), 0u, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		bool alreadyLearned = false;
+		uint16_t newValue = 0;
+		uint16_t newCap = kInitialCap;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			SeedStarterSetIfNeeded(accountId);
+			auto& map = m_skillsByAccount[accountId];
+			auto it = map.find(skillId);
+			if (it != map.end())
+			{
+				alreadyLearned = true;
+			}
+			else
+			{
+				// Ajout au store V1 avec value=0, cap=75.
+				SkillBookEntry e;
+				e.skillId = skillId;
+				e.value   = 0u;
+				e.cap     = kInitialCap;
+				e.bonus   = 0u;
+				map.emplace(skillId, e);
+				newValue = e.value;
+				newCap   = e.cap;
+			}
+		}
+
+		if (alreadyLearned)
+		{
+			LOG_INFO(Net, "[SkillHandler] Learn AlreadyLearned account={} skillId={}",
+				accountId, skillId);
+			auto pkt = BuildSkillLearnResponsePacket(
+				static_cast<uint8_t>(SkillErrorCode::AlreadyLearned), 0u, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[SkillHandler] Learn OK account={} skillId={} cap={}",
+			accountId, skillId, kInitialCap);
+
+		auto pkt = BuildSkillLearnResponsePacket(0u, kInitialCap, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// Push UpgradeNotification (delta=0) pour synchroniser le client.
+		PushSkillUpgrade(connId, skillId, newValue, newCap, 0);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void SkillHandler::HandleUseRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseSkillUseRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[SkillHandler] Use parse failed account={}", accountId);
+			auto pkt = BuildSkillUseResponsePacket(
+				static_cast<uint8_t>(SkillErrorCode::SkillNotLearned), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint16_t skillId = parsed->skillId;
+		const uint64_t targetEntityId = parsed->targetEntityId;
+
+		bool learned = false;
+		bool gained  = false;
+		uint16_t newValue = 0;
+		uint16_t newCap   = 0;
+		uint16_t delta    = 0;
+		uint8_t  result   = static_cast<uint8_t>(SkillUseResult::Fail);
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			SeedStarterSetIfNeeded(accountId);
+			auto& map = m_skillsByAccount[accountId];
+			auto it = map.find(skillId);
+			if (it == map.end())
+			{
+				learned = false;
+			}
+			else
+			{
+				learned = true;
+				auto& e = it->second;
+				newCap = e.cap;
+
+				// RNG seed lazy au premier usage.
+				if (!m_rngSeeded)
+				{
+					const auto seed = static_cast<std::mt19937::result_type>(
+						std::chrono::steady_clock::now().time_since_epoch().count());
+					m_rng.seed(seed);
+					m_rngSeeded = true;
+				}
+
+				// 70% success. V1 : pas de Crit (toujours Fail / Success).
+				std::uniform_int_distribution<uint32_t> dist(0u, 99u);
+				const uint32_t roll = dist(m_rng);
+				if (roll < kUseSuccessThresholdPct)
+				{
+					result = static_cast<uint8_t>(SkillUseResult::Success);
+					// Si already at cap, pas de gain (juste Success).
+					if (e.value < e.cap)
+					{
+						const uint16_t before = e.value;
+						const uint32_t after = static_cast<uint32_t>(e.value) + 1u;
+						e.value = static_cast<uint16_t>(after > e.cap ? e.cap : after);
+						delta = static_cast<uint16_t>(e.value - before);
+						gained = (delta > 0u);
+					}
+					newValue = e.value;
+				}
+				else
+				{
+					result = static_cast<uint8_t>(SkillUseResult::Fail);
+					newValue = e.value;
+				}
+			}
+		}
+
+		if (!learned)
+		{
+			LOG_INFO(Net, "[SkillHandler] Use SkillNotLearned account={} skillId={}",
+				accountId, skillId);
+			auto pkt = BuildSkillUseResponsePacket(
+				static_cast<uint8_t>(SkillErrorCode::SkillNotLearned), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[SkillHandler] Use account={} skillId={} target={} result={} delta={}",
+			accountId, skillId, targetEntityId, static_cast<unsigned>(result), delta);
+
+		auto pkt = BuildSkillUseResponsePacket(0u, result, delta, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// Push UpgradeNotification si gain effectif > 0.
+		if (gained)
+		{
+			PushSkillUpgrade(connId, skillId, newValue, newCap, static_cast<int16_t>(delta));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	bool SkillHandler::PushSkillUpgrade(uint32_t connId, uint16_t skillId,
+		uint16_t newValue, uint16_t newCap, int16_t delta)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[SkillHandler] PushSkillUpgrade dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			// V1 : on tolere session=0 dans le header push (le client s'est
+			// peut-etre deconnecte). On log et on skip.
+			LOG_WARN(Net, "[SkillHandler] PushSkillUpgrade: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildSkillUpgradeNotificationPacket(skillId, newValue, newCap, delta, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[SkillHandler] PushSkillUpgrade: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[SkillHandler] PushSkillUpgrade connId={} skillId={} newValue={} newCap={} delta={}",
+			connId, skillId, newValue, newCap, static_cast<int>(delta));
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+
+	uint64_t SkillHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/skills/SkillHandler.h
+++ b/src/masterd/handlers/skills/SkillHandler.h
@@ -1,0 +1,131 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39 step 3+4) — SkillHandler : dispatch des opcodes
+// Skills cote joueur (113/115/117) et appel des methodes correspondantes
+// d'un store in-memory de SkillBook par account.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 113/115/117 (les requests). Les responses 114/116/118 sont emises
+// avec le meme requestId / sessionId que la request recue. La push
+// notification 119 (SkillUpgradeNotification) est emise par PushSkillUpgrade,
+// API publique pour le futur CraftingSystem ou autres handlers (Quest reward,
+// etc.).
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 6) dans la reponse type-specific.
+//
+// Store in-memory V1 : map account_id -> map skillId -> SkillBookEntry. Au
+// premier acces (List ou Learn ou Use), un starter set hardcode est seede
+// (Cooking=1, Herbalism=2, Mining=3, FirstAid=4, Lockpicking=5, tous
+// value=1 ou 0, cap=75). Pas de persistance DB en V1 — toutes les progressions
+// sont perdues au reboot, ce qui est acceptable pour un V1 (sub-PR future
+// pour la persistance avec migration MysqlSkillStore).
+
+#include "src/shared/network/SkillPayloads.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <unordered_map>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Skills cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class SkillHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Skills.
+		/// Dispatch vers HandleListRequest / HandleLearnRequest / HandleUseRequest
+		/// selon l'opcode. Si l'opcode n'est pas un opcode Skills, ignore
+		/// silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (113/115/117).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push SkillUpgradeNotification (opcode 119)
+		/// au client identifie par \p connId. Utilise par les autres handlers
+		/// (CraftingSystem futur, QuestHandler reward, etc.) pour signaler un
+		/// gain de skill ou un changement de cap.
+		///
+		/// \param connId    identifiant de connexion TCP cible (0 = no-op).
+		/// \param skillId   skill modifie.
+		/// \param newValue  nouvelle valeur courante du skill.
+		/// \param newCap    nouveau cap (peut etre identique a l'ancien).
+		/// \param delta     variation appliquee (signed ; positif = gain).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushSkillUpgrade(uint32_t connId, uint16_t skillId,
+		                       uint16_t newValue, uint16_t newCap, int16_t delta);
+
+	private:
+		/// Traite SKILLS_LIST_REQUEST : enumere la skill book de l'account
+		/// (seede au premier acces avec un starter set hardcode V1).
+		void HandleListRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite SKILL_LEARN_REQUEST : verifie skillId valide (1..5 V1) et pas
+		/// deja appris. Si OK, ajoute au store avec value=0, cap=75 et push
+		/// une UpgradeNotification (delta=0) au meme client.
+		void HandleLearnRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite SKILL_USE_REQUEST : verifie skill appris. V1 : RNG 70% success,
+		/// si Success applique +1 (clamp cap). Si gain effectif > 0, push une
+		/// UpgradeNotification au meme client.
+		void HandleUseRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		/// Utilise par PushSkillUpgrade pour fabriquer le sessionId du header.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Seede le starter set V1 pour un account si l'entree n'existe pas.
+		/// Pas de mutex ici : appele uniquement sous m_mutex deja verrouille.
+		void SeedStarterSetIfNeeded(uint64_t accountId);
+
+		/// V1 : Cooking, Herbalism, Mining, FirstAid, Lockpicking.
+		static constexpr uint16_t kStarterSkillCount = 5u;
+		/// V1 : skillId max valide pour Learn (1..kStarterSkillCount).
+		static constexpr uint16_t kMaxValidSkillId = 5u;
+
+		NetServer*                                                                          m_server     = nullptr;
+		SessionManager*                                                                     m_sessionMgr = nullptr;
+		ConnectionSessionMap*                                                               m_connMap    = nullptr;
+
+		/// Store in-memory : account_id -> (skillId -> SkillBookEntry).
+		/// Protege par m_mutex (HandlePacket peut etre appele depuis le thread
+		/// reseau, PushSkillUpgrade peut etre appele depuis n'importe ou).
+		std::mutex                                                                          m_mutex;
+		std::unordered_map<uint64_t,
+			std::unordered_map<uint16_t, engine::network::SkillBookEntry>>                  m_skillsByAccount;
+
+		/// RNG pour Use 70% success. Seede au premier usage (lazy).
+		std::mt19937                                                                        m_rng;
+		bool                                                                                m_rngSeeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -42,6 +42,7 @@
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
+#include "src/masterd/handlers/skills/SkillHandler.h"
 #include "src/masterd/quests/MysqlQuestStateStore.h"
 #include "src/masterd/reputation/MysqlReputationStore.h"
 #include "src/masterd/reputation/ReputationManager.h"
@@ -506,6 +507,20 @@ int main(int argc, char** argv)
 	cinematicHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] CinematicHandler configured (CMANGOS.30 step 3+4, push-only)");
 
+	// CMANGOS.39 (Phase 4.39 step 3+4) — Skills wire server.
+	// Le master tient en memoire la skill book par account (V1, starter set
+	// hardcode : Cooking, Herbalism, Mining, FirstAid, Lockpicking). Les
+	// opcodes 113/115/117 sont dispatches au handler ; les responses
+	// 114/116/118 et la push notification 119 sont emis par le handler aux
+	// clients. Pas de persistance DB en V1 (sub-PR future avec migration
+	// MysqlSkillStore). PushSkillUpgrade est expose pour usage futur par
+	// le CraftingSystem ou autres handlers.
+	engine::server::SkillHandler skillHandler;
+	skillHandler.SetServer(&server);
+	skillHandler.SetSessionManager(&sessionManager);
+	skillHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] SkillHandler configured (CMANGOS.39 step 3+4, in-memory store)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -545,7 +560,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -607,6 +622,10 @@ int main(int argc, char** argv)
 		else if (opcode == kOpcodeCinematicAckRequest
 		      || opcode == kOpcodeCinematicSkipRequest)
 			cinematicHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeSkillsListRequest
+		      || opcode == kOpcodeSkillLearnRequest
+		      || opcode == kOpcodeSkillUseRequest)
+			skillHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -419,4 +419,42 @@ namespace engine::network
 	constexpr uint16_t kOpcodeCinematicAckResponse      = 110u; ///< Master to Client : ACK Ok ou erreur (UnknownSequence, NoActiveCinematic, ...).
 	constexpr uint16_t kOpcodeCinematicSkipRequest      = 111u; ///< Client to Master : le user a appuye sur Esc et demande a skip la cinematique en cours.
 	constexpr uint16_t kOpcodeCinematicSkipResponse     = 112u; ///< Master to Client : OK + allowed (true V1) ou SkipNotAllowed (cinematique obligatoire).
+
+	// -------------------------------------------------------------------------
+	// Opcodes Skills (valeurs 113-119)
+	// Reference : Phase 4 CMANGOS.39 step 3+4. Wire client<->master pour le
+	// SkillBook (cooking, herbalism, mining, lockpicking, weapon skills).
+	// Le step 1 (SkillBook header-only avec Get/Set/Gain/Effective) et le
+	// step 2 (tests) sont deja merges. Cette serie expose les operations
+	// au client via 3 paires request/response + 1 push notification.
+	//
+	// Architecture : le master tient en memoire la skill book par account
+	// (V1, starter set hardcode). Toute mutation (Learn / Use gain) declenche
+	// une push SkillUpgradeNotification au client pour synchroniser son UI.
+	//
+	// V1 limitations :
+	//   - Starter set hardcode cote master (Cooking=1, Herbalism=2, Mining=3,
+	//     FirstAid=4, Lockpicking=5). Trainer real venant en CMANGOS.41.
+	//   - Use random 70% success (V1) ; calibration economie a venir.
+	//   - Pas encore de SyncSkill RPC entre master et shardd (master autoritaire V1).
+	//   - Pas de Crafting hook -> SkillUpgrade (future PR avec CraftingSystem).
+	//
+	// Decoupage opcode :
+	//   - List   (113/114)               : le client demande la liste de ses
+	//     skills (value, cap, bonus).
+	//   - Learn  (115/116)               : le client demande apprendre un skill
+	//     (typiquement depuis un trainer).
+	//   - Use    (117/118)               : le client utilise un skill
+	//     non-combat (lockpicking, fishing).
+	//   - UpgradeNotification (119, push) : le master notifie le client d'un
+	//     gain (value+1) ou d'un changement de cap.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeSkillsListRequest        = 113u; ///< Client to Master : demande la liste des skills (vide).
+	constexpr uint16_t kOpcodeSkillsListResponse       = 114u; ///< Master to Client : liste {skillId, value, cap, bonus} ou Unauthorized.
+	constexpr uint16_t kOpcodeSkillLearnRequest        = 115u; ///< Client to Master : demande apprendre un skill (skillId, par ex. cooking depuis trainer).
+	constexpr uint16_t kOpcodeSkillLearnResponse       = 116u; ///< Master to Client : OK + cap initial, ou AlreadyLearned / UnknownSkill / Unauthorized.
+	constexpr uint16_t kOpcodeSkillUseRequest          = 117u; ///< Client to Master : utilise un skill non-combat (lockpicking, fishing).
+	constexpr uint16_t kOpcodeSkillUseResponse         = 118u; ///< Master to Client : OK + result + delta value, ou SkillNotLearned / SkillFailed / Unauthorized.
+	constexpr uint16_t kOpcodeSkillUpgradeNotification = 119u; ///< Master to Client (push, request_id=0) : skill upgrade (skillId, newValue, newCap, delta).
 }

--- a/src/shared/network/SkillPayloads.cpp
+++ b/src/shared/network/SkillPayloads.cpp
@@ -1,0 +1,328 @@
+// CMANGOS.39 (Phase 4.39 step 3+4) — Implementation Parse/Build des payloads Skills.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+//
+// Note : ByteWriter expose WriteU16, on l'utilise donc pour les champs uint16
+// (skillId, value, cap, bonus, delta cast). Le delta du push UpgradeNotification
+// est int16 ; on le serialise via static_cast<uint16_t> et on re-cast en int16
+// au Parse (pattern bit-pour-bit two's complement).
+
+#include "src/shared/network/SkillPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit une entree (uint16 skillId, uint16 value, uint16 cap, uint16 bonus).
+		bool WriteEntry(ByteWriter& w, const SkillBookEntry& e)
+		{
+			if (!w.WriteU16(e.skillId)) return false;
+			if (!w.WriteU16(e.value))   return false;
+			if (!w.WriteU16(e.cap))     return false;
+			if (!w.WriteU16(e.bonus))   return false;
+			return true;
+		}
+
+		/// Lit une entree (uint16 skillId, uint16 value, uint16 cap, uint16 bonus).
+		bool ReadEntry(ByteReader& r, SkillBookEntry& e)
+		{
+			if (!r.ReadU16(e.skillId)) return false;
+			if (!r.ReadU16(e.value))   return false;
+			if (!r.ReadU16(e.cap))     return false;
+			if (!r.ReadU16(e.bonus))   return false;
+			return true;
+		}
+
+		/// Serialise la partie « apres error » de SKILLS_LIST_RESPONSE.
+		bool WriteListBody(ByteWriter& w, uint8_t error, const std::vector<SkillBookEntry>& skills)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(skills.size())))
+				return false;
+			for (const auto& e : skills)
+			{
+				if (!WriteEntry(w, e))
+					return false;
+			}
+			return true;
+		}
+
+		/// Serialise un SKILL_LEARN_RESPONSE body (uint8 error + uint16 initialCap).
+		bool WriteLearnBody(ByteWriter& w, uint8_t error, uint16_t initialCap)
+		{
+			if (!w.WriteBytes(&error, 1u))      return false;
+			if (!w.WriteU16(initialCap))        return false;
+			return true;
+		}
+
+		/// Serialise un SKILL_USE_RESPONSE body (uint8 error + uint8 result + uint16 delta).
+		bool WriteUseBody(ByteWriter& w, uint8_t error, uint8_t result, uint16_t deltaValue)
+		{
+			if (!w.WriteBytes(&error, 1u))    return false;
+			if (!w.WriteBytes(&result, 1u))   return false;
+			if (!w.WriteU16(deltaValue))      return false;
+			return true;
+		}
+
+		/// Serialise un push UPGRADE_NOTIFICATION (skillId + newValue + newCap + delta).
+		bool WriteUpgradeBody(ByteWriter& w, uint16_t skillId, uint16_t newValue, uint16_t newCap, int16_t delta)
+		{
+			if (!w.WriteU16(skillId))                              return false;
+			if (!w.WriteU16(newValue))                             return false;
+			if (!w.WriteU16(newCap))                               return false;
+			if (!w.WriteU16(static_cast<uint16_t>(delta)))         return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// SKILLS_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillsListRequestPayload> ParseSkillsListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return SkillsListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildSkillsListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// SKILLS_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillsListResponsePayload> ParseSkillsListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillsListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.skills.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			SkillBookEntry e;
+			if (!ReadEntry(r, e))
+				return std::nullopt;
+			out.skills.push_back(e);
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillsListResponsePayload(uint8_t error, const std::vector<SkillBookEntry>& skills)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListBody(w, error, skills))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildSkillsListResponsePacket(uint8_t error, const std::vector<SkillBookEntry>& skills,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListBody(w, error, skills))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeSkillsListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// SKILL_LEARN — Request / Response
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillLearnRequestPayload> ParseSkillLearnRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint16 skillId (2).
+		if (!payload || payloadSize < 2u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillLearnRequestPayload out;
+		if (!r.ReadU16(out.skillId))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillLearnRequestPayload(uint16_t skillId)
+	{
+		std::vector<uint8_t> buf(2u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU16(skillId))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<SkillLearnResponsePayload> ParseSkillLearnResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint16 initialCap (2) = 3 octets.
+		if (!payload || payloadSize < 3u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillLearnResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (!r.ReadU16(out.initialCap))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillLearnResponsePayload(uint8_t error, uint16_t initialCap)
+	{
+		std::vector<uint8_t> buf(3u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteLearnBody(w, error, initialCap))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildSkillLearnResponsePacket(uint8_t error, uint16_t initialCap,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteLearnBody(w, error, initialCap))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeSkillLearnResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// SKILL_USE — Request / Response
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillUseRequestPayload> ParseSkillUseRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint16 skillId (2) + uint64 targetEntityId (8) = 10 octets.
+		if (!payload || payloadSize < 10u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillUseRequestPayload out;
+		if (!r.ReadU16(out.skillId))           return std::nullopt;
+		if (!r.ReadU64(out.targetEntityId))    return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillUseRequestPayload(uint16_t skillId, uint64_t targetEntityId)
+	{
+		std::vector<uint8_t> buf(10u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU16(skillId))           return {};
+		if (!w.WriteU64(targetEntityId))    return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::optional<SkillUseResponsePayload> ParseSkillUseResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint8 error (1) + uint8 result (1) + uint16 deltaValue (2) = 4 octets.
+		if (!payload || payloadSize < 4u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillUseResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))    return std::nullopt;
+		if (!r.ReadBytes(&out.result, 1u))   return std::nullopt;
+		if (!r.ReadU16(out.deltaValue))      return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillUseResponsePayload(uint8_t error, uint8_t result, uint16_t deltaValue)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteUseBody(w, error, result, deltaValue))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildSkillUseResponsePacket(uint8_t error, uint8_t result, uint16_t deltaValue,
+	                                                  uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteUseBody(w, error, result, deltaValue))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeSkillUseResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// SKILL_UPGRADE_NOTIFICATION (push, request_id=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillUpgradeNotificationPayload> ParseSkillUpgradeNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint16 skillId (2) + uint16 newValue (2) + uint16 newCap (2) + int16 delta (2) = 8 octets.
+		if (!payload || payloadSize < 8u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		SkillUpgradeNotificationPayload out;
+		if (!r.ReadU16(out.skillId))    return std::nullopt;
+		if (!r.ReadU16(out.newValue))   return std::nullopt;
+		if (!r.ReadU16(out.newCap))     return std::nullopt;
+		uint16_t deltaRaw = 0;
+		if (!r.ReadU16(deltaRaw))       return std::nullopt;
+		out.delta = static_cast<int16_t>(deltaRaw);
+		return out;
+	}
+
+	std::vector<uint8_t> BuildSkillUpgradeNotificationPayload(uint16_t skillId, uint16_t newValue, uint16_t newCap, int16_t delta)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteUpgradeBody(w, skillId, newValue, newCap, delta))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildSkillUpgradeNotificationPacket(uint16_t skillId, uint16_t newValue, uint16_t newCap, int16_t delta,
+	                                                          uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteUpgradeBody(w, skillId, newValue, newCap, delta))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeSkillUpgradeNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/SkillPayloads.h
+++ b/src/shared/network/SkillPayloads.h
@@ -1,0 +1,190 @@
+#pragma once
+// CMANGOS.39 (Phase 4.39 step 3+4) — Wire payloads pour les opcodes Skills
+// (113-119).
+//
+// Trois paires Request/Response + 1 push :
+//   - List              (113/114)
+//   - Learn             (115/116)
+//   - Use               (117/118)
+//   - UpgradeNotification (119 push) — Master to Client pour annoncer un gain
+//     de skill (suite a un Use ou a un crafting hook futur).
+//
+// Le SkillBook est read-only cote client cible : le serveur seul decide quand
+// gain ; les requests Learn/Use sont des intentions, le serveur valide.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Les valeurs uint16
+// (skillId, value, cap, bonus) sont serialisees via WriteU32 (le ByteWriter
+// n'expose pas WriteU16 generique mais WriteU32 ; on caste donc et on
+// re-tronque au Parse). Note : ByteWriter EXPOSE bien WriteU16 — on l'utilise
+// systematiquement pour les champs uint16 afin de garder le wire compact.
+// Le delta du push UpgradeNotification est int16 ; on serialise comme uint16
+// (cast bitwise two's complement) puis on re-cast en int16 au Parse.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Skills.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Skills.
+	/// 0 = OK ; sinon le payload secondaire est zero (entries vide / value=0).
+	enum class SkillErrorCode : uint8_t
+	{
+		Ok               = 0,
+		Unauthorized     = 6,  ///< Pas de session valide cote master.
+		UnknownSkill     = 7,  ///< skillId hors du catalog V1 (1..5).
+		AlreadyLearned   = 8,  ///< Learn d'un skill deja appris.
+		SkillNotLearned  = 9,  ///< Use sur un skill jamais appris.
+		SkillFailed      = 10, ///< Use sans gain (RNG failed) — soft failure.
+	};
+
+	/// Result code retourne par SkillUseResponse.
+	/// Different de l'error code : Use peut reussir sans erreur mais sans gain.
+	enum class SkillUseResult : uint8_t
+	{
+		Success         = 0,
+		Fail            = 1,
+		CriticalSuccess = 2,
+	};
+
+	// =========================================================================
+	// SKILLS_LIST — Client to Master : liste les skills de l'account.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct SkillsListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entree du SkillBook (skillId, value, cap, bonus).
+	/// Mirror direct de skills::SkillEntry du shardd avec skillId additionnel.
+	struct SkillBookEntry
+	{
+		uint16_t skillId = 0;
+		uint16_t value   = 0; ///< niveau actuel.
+		uint16_t cap     = 0; ///< cap dur (max attribuable a ce moment).
+		uint16_t bonus   = 0; ///< bonus temporaire (potion, equipement).
+	};
+
+	/// Wire format :
+	///   uint8  error            (cf. SkillErrorCode)
+	///   uint16 count             (si error == 0)
+	///   <count> entries          (2 + 2 + 2 + 2 = 8 octets chacune)
+	struct SkillsListResponsePayload
+	{
+		uint8_t                       error = 0;
+		std::vector<SkillBookEntry>   skills;
+	};
+
+	// =========================================================================
+	// SKILL_LEARN — Client to Master : demande apprendre un skill.
+	// =========================================================================
+
+	/// Wire format : uint16 skillId.
+	struct SkillLearnRequestPayload
+	{
+		uint16_t skillId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 initialCap   (cap initial du skill, 0 si error != Ok)
+	struct SkillLearnResponsePayload
+	{
+		uint8_t  error      = 0;
+		uint16_t initialCap = 0;
+	};
+
+	// =========================================================================
+	// SKILL_USE — Client to Master : utilise un skill non-combat.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint16 skillId
+	///   uint64 targetEntityId (V1 : opaque, log seulement)
+	struct SkillUseRequestPayload
+	{
+		uint16_t skillId        = 0;
+		uint64_t targetEntityId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint8  result        (cf. SkillUseResult ; 0=Success, 1=Fail, 2=Crit)
+	///   uint16 deltaValue    (gain effectif applique au skill)
+	struct SkillUseResponsePayload
+	{
+		uint8_t  error      = 0;
+		uint8_t  result     = 0;
+		uint16_t deltaValue = 0;
+	};
+
+	// =========================================================================
+	// SKILL_UPGRADE_NOTIFICATION — Master to Client (push, request_id=0).
+	// Annonce qu'un gain de skill a eu lieu cote serveur.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint16 skillId      (2)
+	///   uint16 newValue     (2)
+	///   uint16 newCap       (2)
+	///   int16  delta        (2, cast via uint16 ; positif = gain, 0 = bonus/cap update)
+	struct SkillUpgradeNotificationPayload
+	{
+		uint16_t skillId  = 0;
+		uint16_t newValue = 0;
+		uint16_t newCap   = 0;
+		int16_t  delta    = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	/// Parse le payload d'un SKILLS_LIST_REQUEST. Toujours OK (payload vide accepte).
+	std::optional<SkillsListRequestPayload> ParseSkillsListRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un SKILL_LEARN_REQUEST. \return nullopt si payloadSize < 2.
+	std::optional<SkillLearnRequestPayload> ParseSkillLearnRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Parse le payload d'un SKILL_USE_REQUEST. \return nullopt si payloadSize < 10.
+	std::optional<SkillUseRequestPayload>   ParseSkillUseRequestPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildSkillsListRequestPayload();
+	std::vector<uint8_t> BuildSkillLearnRequestPayload(uint16_t skillId);
+	std::vector<uint8_t> BuildSkillUseRequestPayload  (uint16_t skillId, uint64_t targetEntityId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<SkillsListResponsePayload>          ParseSkillsListResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<SkillLearnResponsePayload>          ParseSkillLearnResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<SkillUseResponsePayload>            ParseSkillUseResponsePayload           (const uint8_t* payload, size_t payloadSize);
+	std::optional<SkillUpgradeNotificationPayload>    ParseSkillUpgradeNotificationPayload   (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildSkillsListResponsePayload         (uint8_t error, const std::vector<SkillBookEntry>& skills);
+	std::vector<uint8_t> BuildSkillLearnResponsePayload         (uint8_t error, uint16_t initialCap);
+	std::vector<uint8_t> BuildSkillUseResponsePayload           (uint8_t error, uint8_t result, uint16_t deltaValue);
+	std::vector<uint8_t> BuildSkillUpgradeNotificationPayload   (uint16_t skillId, uint16_t newValue, uint16_t newCap, int16_t delta);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildSkillsListResponsePacket  (uint8_t error, const std::vector<SkillBookEntry>& skills,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildSkillLearnResponsePacket  (uint8_t error, uint16_t initialCap,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildSkillUseResponsePacket    (uint8_t error, uint8_t result, uint16_t deltaValue,
+	                                                     uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildSkillUpgradeNotificationPacket(uint16_t skillId, uint16_t newValue, uint16_t newCap, int16_t delta,
+	                                                          uint64_t sessionIdHeader);
+}

--- a/src/shared/network/SkillPayloadsTests.cpp
+++ b/src/shared/network/SkillPayloadsTests.cpp
@@ -1,0 +1,456 @@
+/**
+ * CMANGOS.39 (Phase 4.39 step 3+4) — Round-trip tests for SKILL_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/SkillPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// SKILLS_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildSkillsListRequestPayload();
+	Assert(buf.empty(), "List request payload empty");
+	auto parsed = ParseSkillsListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildSkillsListResponsePayload(0u, {});
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response empty parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "List response empty error 0");
+		Assert(parsed->skills.empty(), "List response empty has 0 entries");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	auto buf = BuildSkillsListResponsePayload(
+		static_cast<uint8_t>(SkillErrorCode::Unauthorized), {});
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "List response Unauthorized");
+}
+
+static void TestListResponseSingle()
+{
+	std::vector<SkillBookEntry> entries;
+	entries.push_back({1u, 25u, 75u, 0u}); // Cooking partial
+	auto buf = BuildSkillsListResponsePayload(0u, entries);
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response single parses");
+	if (parsed && parsed->skills.size() == 1u)
+	{
+		Assert(parsed->skills[0].skillId == 1u, "single skillId");
+		Assert(parsed->skills[0].value == 25u,  "single value");
+		Assert(parsed->skills[0].cap == 75u,    "single cap");
+		Assert(parsed->skills[0].bonus == 0u,   "single bonus");
+	}
+	else
+	{
+		Assert(false, "List response should have 1 entry");
+	}
+}
+
+static void TestListResponseMultiple()
+{
+	std::vector<SkillBookEntry> entries;
+	entries.push_back({1u, 1u,   75u,  0u});   // Cooking starter
+	entries.push_back({2u, 50u,  75u, 10u});   // Herbalism with bonus
+	entries.push_back({3u, 75u,  75u,  0u});   // Mining at cap
+	entries.push_back({4u, 0u,   75u,  0u});   // FirstAid not yet started
+	entries.push_back({5u, 30u,  75u,  5u});   // Lockpicking
+	auto buf = BuildSkillsListResponsePayload(0u, entries);
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response multiple parses");
+	if (parsed && parsed->skills.size() == 5u)
+	{
+		Assert(parsed->skills[0].skillId == 1u && parsed->skills[0].value == 1u
+			&& parsed->skills[0].cap == 75u && parsed->skills[0].bonus == 0u,
+			"entry[0] Cooking starter");
+		Assert(parsed->skills[1].skillId == 2u && parsed->skills[1].value == 50u
+			&& parsed->skills[1].cap == 75u && parsed->skills[1].bonus == 10u,
+			"entry[1] Herbalism with bonus");
+		Assert(parsed->skills[2].skillId == 3u && parsed->skills[2].value == 75u
+			&& parsed->skills[2].cap == 75u, "entry[2] Mining at cap");
+		Assert(parsed->skills[3].skillId == 4u && parsed->skills[3].value == 0u,
+			"entry[3] FirstAid not started");
+		Assert(parsed->skills[4].skillId == 5u && parsed->skills[4].bonus == 5u,
+			"entry[4] Lockpicking with bonus");
+	}
+	else
+	{
+		Assert(false, "List response should have 5 entries");
+	}
+}
+
+static void TestListResponseSkillIdZero()
+{
+	// Edge case : skillId = 0 (interpretable cote serveur comme UnknownSkill,
+	// mais le wire doit le serialiser fidelement).
+	std::vector<SkillBookEntry> entries;
+	entries.push_back({0u, 0u, 0u, 0u});
+	auto buf = BuildSkillsListResponsePayload(0u, entries);
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List with skillId=0 parses");
+	if (parsed && parsed->skills.size() == 1u)
+	{
+		Assert(parsed->skills[0].skillId == 0u, "skillId=0 preserved on wire");
+	}
+}
+
+static void TestListResponseValueGtCapBitwise()
+{
+	// Le serveur clamp normalement value <= cap, mais si pour une raison
+	// quelconque la valeur arrive > cap (corruption ou bug futur), le wire
+	// doit la transmettre fidelement (le clamp sera applique cote presenter ou UI).
+	std::vector<SkillBookEntry> entries;
+	entries.push_back({10u, 100u, 75u, 0u}); // value > cap (anormal)
+	auto buf = BuildSkillsListResponsePayload(0u, entries);
+	auto parsed = ParseSkillsListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List value > cap still parses");
+	if (parsed && parsed->skills.size() == 1u)
+	{
+		Assert(parsed->skills[0].value == 100u, "value=100 preserved bitwise");
+		Assert(parsed->skills[0].cap == 75u,    "cap=75 preserved bitwise");
+	}
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseSkillsListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List response rejects nullptr");
+	uint8_t one[1]{0};
+	auto parsed2 = ParseSkillsListResponsePayload(one, 0u);
+	Assert(!parsed2.has_value(), "List response rejects size 0");
+}
+
+static void TestListResponsePacket()
+{
+	std::vector<SkillBookEntry> entries;
+	entries.push_back({1u, 25u, 75u, 0u});
+	auto pkt = BuildSkillsListResponsePacket(0u, entries, 12345u, 0xCAFEull);
+	Assert(!pkt.empty(), "List response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeSkillsListResponse, "Packet opcode is SkillsListResponse");
+	Assert(view.RequestId() == 12345u, "RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "SessionId preserved");
+	auto parsed = ParseSkillsListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->skills.size() == 1u
+		&& parsed->skills[0].skillId == 1u, "List response payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// SKILL_LEARN
+// -----------------------------------------------------------------------------
+
+static void TestLearnRequestRoundTrip()
+{
+	auto buf = BuildSkillLearnRequestPayload(3u);
+	Assert(buf.size() == 2u, "Learn request payload is 2 bytes");
+	auto parsed = ParseSkillLearnRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Learn request parses");
+	if (parsed)
+	{
+		Assert(parsed->skillId == 3u, "Learn skillId preserved");
+	}
+}
+
+static void TestLearnRequestRejectsShort()
+{
+	auto parsed = ParseSkillLearnRequestPayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "Learn request rejects nullptr");
+	uint8_t shortBuf[1]{0};
+	auto parsed2 = ParseSkillLearnRequestPayload(shortBuf, 1u);
+	Assert(!parsed2.has_value(), "Learn request rejects 1 byte");
+}
+
+static void TestLearnResponseRoundTrip()
+{
+	auto buf = BuildSkillLearnResponsePayload(0u, 75u);
+	Assert(buf.size() == 3u, "Learn response payload is 3 bytes");
+	auto parsed = ParseSkillLearnResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Learn response parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Learn response error 0");
+		Assert(parsed->initialCap == 75u, "Learn initialCap preserved");
+	}
+}
+
+static void TestLearnResponseAlreadyLearned()
+{
+	auto buf = BuildSkillLearnResponsePayload(
+		static_cast<uint8_t>(SkillErrorCode::AlreadyLearned), 0u);
+	auto parsed = ParseSkillLearnResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 8u, "Learn AlreadyLearned");
+}
+
+static void TestLearnResponsePacket()
+{
+	auto pkt = BuildSkillLearnResponsePacket(0u, 75u, 999u, 0xBEEFull);
+	Assert(!pkt.empty(), "Learn response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Learn PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeSkillLearnResponse, "Opcode is SkillLearnResponse");
+	Assert(view.RequestId() == 999u, "Learn RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// SKILL_USE
+// -----------------------------------------------------------------------------
+
+static void TestUseRequestRoundTrip()
+{
+	auto buf = BuildSkillUseRequestPayload(5u, 0xABCDEFu);
+	Assert(buf.size() == 10u, "Use request payload is 10 bytes");
+	auto parsed = ParseSkillUseRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Use request parses");
+	if (parsed)
+	{
+		Assert(parsed->skillId == 5u, "Use skillId preserved");
+		Assert(parsed->targetEntityId == 0xABCDEFull, "Use targetEntityId preserved");
+	}
+}
+
+static void TestUseRequestNoTarget()
+{
+	auto buf = BuildSkillUseRequestPayload(2u, 0u);
+	auto parsed = ParseSkillUseRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->targetEntityId == 0ull,
+		"Use request targetEntityId=0 (no target)");
+}
+
+static void TestUseRequestRejectsShort()
+{
+	auto parsed = ParseSkillUseRequestPayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "Use request rejects nullptr");
+	uint8_t shortBuf[9]{};
+	auto parsed2 = ParseSkillUseRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Use request rejects 9 bytes");
+}
+
+static void TestUseResponseRoundTrip()
+{
+	auto buf = BuildSkillUseResponsePayload(0u,
+		static_cast<uint8_t>(SkillUseResult::Success), 1u);
+	Assert(buf.size() == 4u, "Use response payload is 4 bytes");
+	auto parsed = ParseSkillUseResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Use response parses");
+	if (parsed)
+	{
+		Assert(parsed->error == 0u, "Use response error 0");
+		Assert(parsed->result == 0u, "Use response Success");
+		Assert(parsed->deltaValue == 1u, "Use deltaValue preserved");
+	}
+}
+
+static void TestUseResponseCriticalSuccess()
+{
+	auto buf = BuildSkillUseResponsePayload(0u,
+		static_cast<uint8_t>(SkillUseResult::CriticalSuccess), 5u);
+	auto parsed = ParseSkillUseResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Use Crit parses");
+	if (parsed)
+	{
+		Assert(parsed->result == 2u, "Use result CriticalSuccess");
+		Assert(parsed->deltaValue == 5u, "Use Crit gain 5");
+	}
+}
+
+static void TestUseResponseFailNoGain()
+{
+	auto buf = BuildSkillUseResponsePayload(0u,
+		static_cast<uint8_t>(SkillUseResult::Fail), 0u);
+	auto parsed = ParseSkillUseResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Use Fail parses");
+	if (parsed)
+	{
+		Assert(parsed->result == 1u, "Use result Fail");
+		Assert(parsed->deltaValue == 0u, "Use Fail no gain");
+	}
+}
+
+static void TestUseResponseSkillNotLearned()
+{
+	auto buf = BuildSkillUseResponsePayload(
+		static_cast<uint8_t>(SkillErrorCode::SkillNotLearned), 0u, 0u);
+	auto parsed = ParseSkillUseResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 9u, "Use SkillNotLearned");
+}
+
+static void TestUseResponsePacket()
+{
+	auto pkt = BuildSkillUseResponsePacket(0u, 0u, 1u, 777u, 0xDEADBEEFull);
+	Assert(!pkt.empty(), "Use response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Use PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeSkillUseResponse, "Opcode is SkillUseResponse");
+	Assert(view.RequestId() == 777u, "Use RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// SKILL_UPGRADE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestUpgradeNotificationRoundTrip()
+{
+	auto buf = BuildSkillUpgradeNotificationPayload(1u, 26u, 75u, 1);
+	Assert(buf.size() == 8u, "Upgrade notification is 8 bytes");
+	auto parsed = ParseSkillUpgradeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Upgrade notification parses");
+	if (parsed)
+	{
+		Assert(parsed->skillId == 1u, "Upgrade skillId");
+		Assert(parsed->newValue == 26u, "Upgrade newValue");
+		Assert(parsed->newCap == 75u, "Upgrade newCap");
+		Assert(parsed->delta == 1, "Upgrade delta");
+	}
+}
+
+static void TestUpgradeNotificationZeroDelta()
+{
+	// Use case : Learn (cap initial pousse via upgrade notif avec delta=0).
+	auto buf = BuildSkillUpgradeNotificationPayload(5u, 0u, 75u, 0);
+	auto parsed = ParseSkillUpgradeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Upgrade with zero delta parses");
+	if (parsed)
+	{
+		Assert(parsed->skillId == 5u, "Upgrade skillId on Learn");
+		Assert(parsed->delta == 0, "Upgrade zero delta on Learn");
+		Assert(parsed->newCap == 75u, "Upgrade newCap on Learn");
+	}
+}
+
+static void TestUpgradeNotificationNegativeDelta()
+{
+	// Edge : delta peut etre negatif (cas futur : decay, debuff equipement
+	// retire). Verifie que int16 round-trip preserve le signe.
+	auto buf = BuildSkillUpgradeNotificationPayload(2u, 40u, 75u, -10);
+	auto parsed = ParseSkillUpgradeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Upgrade with negative delta parses");
+	if (parsed)
+	{
+		Assert(parsed->newValue == 40u, "Negative delta newValue");
+		Assert(parsed->delta == -10, "Negative delta preserved");
+	}
+}
+
+static void TestUpgradeNotificationBoundary()
+{
+	// Boundaries : skillId max 0xFFFF, value max 0xFFFF, delta max +/- 32767.
+	auto buf = BuildSkillUpgradeNotificationPayload(0xFFFFu, 0xFFFFu, 0xFFFFu, 32767);
+	auto parsed = ParseSkillUpgradeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Upgrade boundary parses");
+	if (parsed)
+	{
+		Assert(parsed->skillId == 0xFFFFu, "skillId max");
+		Assert(parsed->newValue == 0xFFFFu, "newValue max");
+		Assert(parsed->newCap == 0xFFFFu, "newCap max");
+		Assert(parsed->delta == 32767, "delta max positive");
+	}
+
+	auto buf2 = BuildSkillUpgradeNotificationPayload(1u, 0u, 1u, -32768);
+	auto parsed2 = ParseSkillUpgradeNotificationPayload(buf2.data(), buf2.size());
+	Assert(parsed2.has_value(), "Upgrade min delta parses");
+	if (parsed2)
+	{
+		Assert(parsed2->delta == -32768, "delta min negative");
+	}
+}
+
+static void TestUpgradeNotificationRejectsShort()
+{
+	auto parsed = ParseSkillUpgradeNotificationPayload(nullptr, 8u);
+	Assert(!parsed.has_value(), "Upgrade rejects nullptr");
+	uint8_t shortBuf[7]{};
+	auto parsed2 = ParseSkillUpgradeNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Upgrade rejects 7 bytes");
+}
+
+static void TestUpgradeNotificationPacket()
+{
+	auto pkt = BuildSkillUpgradeNotificationPacket(1u, 26u, 75u, 1, 0xBEEFull);
+	Assert(!pkt.empty(), "Upgrade notification packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok, "Upgrade PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeSkillUpgradeNotification, "Opcode is SkillUpgradeNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xBEEFull, "SessionId preserved");
+	auto parsed = ParseSkillUpgradeNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->skillId == 1u && parsed->delta == 1,
+		"Upgrade payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseUnauthorized();
+	TestListResponseSingle();
+	TestListResponseMultiple();
+	TestListResponseSkillIdZero();
+	TestListResponseValueGtCapBitwise();
+	TestListResponseRejectsShort();
+	TestListResponsePacket();
+
+	TestLearnRequestRoundTrip();
+	TestLearnRequestRejectsShort();
+	TestLearnResponseRoundTrip();
+	TestLearnResponseAlreadyLearned();
+	TestLearnResponsePacket();
+
+	TestUseRequestRoundTrip();
+	TestUseRequestNoTarget();
+	TestUseRequestRejectsShort();
+	TestUseResponseRoundTrip();
+	TestUseResponseCriticalSuccess();
+	TestUseResponseFailNoGain();
+	TestUseResponseSkillNotLearned();
+	TestUseResponsePacket();
+
+	TestUpgradeNotificationRoundTrip();
+	TestUpgradeNotificationZeroDelta();
+	TestUpgradeNotificationNegativeDelta();
+	TestUpgradeNotificationBoundary();
+	TestUpgradeNotificationRejectsShort();
+	TestUpgradeNotificationPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all skill payload tests passed\n"
+	                                : "[FAIL] some skill tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Phase 4 — CMANGOS.39 step 3+4 : Skills wire (snapshot + push + UI client)

Branche `SkillBook` (step 1+2 merge) sur le wire snapshot/push + UI panel client.
Master tient en mémoire la skill book par session (V1, starter set hardcodé) et
pousse les upgrades au client. Le client affiche un panel Skill Book (touche `B`
ou `/skills`) avec `value/cap/bonus` pour chaque skill.

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 7 opcodes (113-119)
  - `113/114` SkillsList Request/Response
  - `115/116` SkillLearn Request/Response
  - `117/118` SkillUse Request/Response
  - `119` SkillUpgradeNotification (push master → client)
- `src/shared/network/SkillPayloads.{h,cpp,Tests.cpp}` : 28 tests round-trip + edge cases
- `src/masterd/handlers/skills/SkillHandler.{h,cpp}` :
  - In-memory store `accountId → {skillId → {value, cap, bonus}}` (mutex protégé)
  - Starter set seedé au 1er accès : Cooking / Herbalism / Mining / FirstAid / Lockpicking (1/75 sauf Lockpicking 0/75)
  - **PushSkillUpgrade(connectionId, skillId, newValue, newCap, delta)** helper public (pour `CraftingSystem` hooks dans une future PR)
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 113/115/117

### Client integration
- `src/client/skills/SkillBookUi.{h,cpp}` : presenter + state, `RequestList/Learn/Use`, handlers `OnXxxResponse` + `OnUpgradeNotification`
- `src/client/render/SkillBookImGuiRenderer.{h,cpp}` : panel ImGui — liste skills, progress bar value/cap, bouton Use, indicator Success/Fail/Crit avec fade-out
- `src/client/app/Engine` : dispatch + slash `/skills` + touche `B` toggle (gardé par chat blocks + pause menu + editor + auth flow)
- `CMakeLists.txt` : sources engine_core + master_app + `skill_payloads_tests` target

### V1 limitations (consignées)
- Starter set hardcodé. Trainer réel viendra en CMANGOS.41 (Trainers).
- Use random 70% success (V1) ; calibration économie à venir.
- Pas encore de Sync RPC entre master et shardd (master autoritaire V1).
- Pas de hook CraftingSystem → SkillUpgrade (future PR : helper `PushSkillUpgrade` est déjà prêt).

### Tests
- `skill_payloads_tests` (28 tests : round-trip, headers, boundaries, error codes) — voir `src/shared/network/SkillPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 113-119 + handler SkillHandler. Sans redéploiement, les requests Skills d'un client neuf tomberaient sur fallback authHandler et retourneraient BAD_REQUEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)