### PR TITLE
feat(arena): wire queue + match proposal + result + UI client (Phase 5 CMANGOS.21)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(engine_core
   src/client/social/IgnoreListUi.cpp
   src/client/gmtickets/GmTicketUi.cpp
   src/client/reputation/ReputationUi.cpp
+  src/client/arena/ArenaUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -339,6 +340,7 @@ add_library(engine_core
   src/client/render/MailImGuiRenderer.cpp
   src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/ReputationImGuiRenderer.cpp
+  src/client/render/ArenaImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -435,6 +437,7 @@ add_library(engine_core
   src/shared/network/QuestPayloads.cpp
   src/shared/network/GmTicketPayloads.cpp
   src/shared/network/ReputationPayloads.cpp
+  src/shared/network/ArenaPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -685,6 +688,11 @@ add_test(NAME cinematic_payloads_tests COMMAND cinematic_payloads_tests)
 add_executable(skill_payloads_tests src/shared/network/SkillPayloadsTests.cpp)
 target_link_libraries(skill_payloads_tests PRIVATE engine_core)
 add_test(NAME skill_payloads_tests COMMAND skill_payloads_tests)
+
+# CMANGOS.21 (Phase 5.21 step 3+4) — Arena payloads round-trip tests (no DB / no network).
+add_executable(arena_payloads_tests src/shared/network/ArenaPayloadsTests.cpp)
+target_link_libraries(arena_payloads_tests PRIVATE engine_core)
+add_test(NAME arena_payloads_tests COMMAND arena_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lfg/LfgHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/cinematics/CinematicHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/skills/SkillHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/arena/ArenaHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -131,6 +132,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/LfgPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/CinematicPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/SkillPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ArenaPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -13,6 +13,7 @@
 #include "src/shared/network/QuestPayloads.h"
 #include "src/shared/network/GmTicketPayloads.h"
 #include "src/shared/network/ReputationPayloads.h"
+#include "src/shared/network/ArenaPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -24,6 +25,7 @@
 #include "src/client/render/MailImGuiRenderer.h"
 #include "src/client/render/GmTicketImGuiRenderer.h"
 #include "src/client/render/ReputationImGuiRenderer.h"
+#include "src/client/render/ArenaImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -923,6 +925,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.21 (Phase 5.21 step 3+4) — Init du presenter Arena + cable
+		// du send callback pour les requetes 120/122/124/127. Reception
+		// dispatchee dans le push handler ci-dessous (responses 121/123/125/128
+		// + push 126/129).
+		if (!m_arenaUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] ArenaUiPresenter init FAILED — panneau arena desactive");
+		}
+		else
+		{
+			m_arenaUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1066,6 +1083,21 @@ namespace engine
 					m_lfgUi.RequestStatus();
 				}
 				LOG_INFO(Core, "[Engine] /lfg toggle (visible={})", m_lfgVisible);
+				return true;
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4) — Slash command /arena pour
+			// ouvrir/fermer la fenetre Arena et synchroniser la liste des
+			// teams depuis le master au moment de l'ouverture. La touche A
+			// fait la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/arena" || text.starts_with("/arena ") || text.starts_with("/arena\t")))
+			{
+				m_arenaVisible = !m_arenaVisible;
+				if (m_arenaVisible)
+				{
+					m_arenaUi.RequestTeams();
+				}
+				LOG_INFO(Core, "[Engine] /arena toggle (visible={})", m_arenaVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1434,6 +1466,74 @@ namespace engine
 					return;
 				}
 				m_skillBookUi.OnUpgradeNotification(*parsed);
+				return;
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4) — Dispatch des reponses Arena
+			// (121/123/125/128) + push notifications (126/129).
+			case kOpcodeArenaTeamListResponse:
+			{
+				auto parsed = ParseArenaTeamListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_TEAM_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnTeamListResponse(*parsed);
+				return;
+			}
+			case kOpcodeArenaQueueResponse:
+			{
+				auto parsed = ParseArenaQueueResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_QUEUE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnQueueResponse(*parsed);
+				return;
+			}
+			case kOpcodeArenaLeaveQueueResponse:
+			{
+				auto parsed = ParseArenaLeaveQueueResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_LEAVE_QUEUE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnLeaveQueueResponse(*parsed);
+				return;
+			}
+			case kOpcodeArenaMatchProposalNotification:
+			{
+				auto parsed = ParseArenaMatchProposalNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_MATCH_PROPOSAL_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnMatchProposalNotification(*parsed);
+				return;
+			}
+			case kOpcodeArenaMatchAcceptResponse:
+			{
+				auto parsed = ParseArenaMatchAcceptResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_MATCH_ACCEPT_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnMatchAcceptResponse(*parsed);
+				return;
+			}
+			case kOpcodeArenaMatchResultNotification:
+			{
+				auto parsed = ParseArenaMatchResultNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] ARENA_MATCH_RESULT_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_arenaUi.OnMatchResultNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -3735,6 +3835,7 @@ namespace engine
 		m_lfgUi.Shutdown();
 		m_cinematicUi.Shutdown();
 		m_skillBookUi.Shutdown();
+		m_arenaUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3821,6 +3922,28 @@ namespace engine
 					m_skillBookUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] B toggle skillbook (visible={})", m_skillBookVisible);
+			}
+		}
+
+		// CMANGOS.21 (Phase 5.21 step 3+4) — Touche A post-auth toggle le
+		// panneau Arena (equivalent a la slash command /arena). Memes guards
+		// que la touche B (chat focus + pause + editor + auth flow).
+		{
+			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
+			const bool inGameNoMenu = !m_inGamePauseMenuVisible
+				&& !m_inGameOptionsPanelVisible
+				&& !m_editorEnabled
+				&& m_authUi.IsInitialized()
+				&& m_authUi.IsFlowComplete();
+			if (inGameNoMenu && !chatBlocks
+				&& m_input.WasPressed(engine::platform::Key::A))
+			{
+				m_arenaVisible = !m_arenaVisible;
+				if (m_arenaVisible)
+				{
+					m_arenaUi.RequestTeams();
+				}
+				LOG_INFO(Core, "[Engine] A toggle arena (visible={})", m_arenaVisible);
 			}
 		}
 
@@ -4012,6 +4135,14 @@ namespace engine
 				// (toggle via /skills ou touche B).
 				m_skillBookImGui = std::make_unique<engine::render::SkillBookImGuiRenderer>();
 				m_skillBookImGui->SetPresenter(&m_skillBookUi);
+				// CMANGOS.21 (Phase 5.21 step 3+4) — Renderer ImGui du panneau
+				// Arena. Visible uniquement quand m_arenaVisible (toggle via
+				// /arena ou touche A). Le popup proposal s'affiche aussi quand
+				// pendingProposalId.has_value() == true (meme si le panneau
+				// principal est masque), pour que le joueur ne rate pas la
+				// formation de match.
+				m_arenaImGui = std::make_unique<engine::render::ArenaImGuiRenderer>();
+				m_arenaImGui->SetPresenter(&m_arenaUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5081,6 +5212,17 @@ namespace engine
 				m_skillBookImGui->SetEnabled(true);
 				m_skillBookImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_skillBookImGui->Render();
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4) — Render du panneau Arena si
+			// visible. Le popup proposal s'affiche aussi quand pendingProposalId
+			// est set (meme si le panneau principal est masque), pour que le
+			// joueur ne rate pas la formation de match.
+			if (m_arenaImGui && m_arenaUi.IsInitialized()
+				&& (m_arenaVisible || m_arenaUi.GetState().pendingProposalId.has_value()))
+			{
+				m_arenaImGui->SetEnabled(true);
+				m_arenaImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_arenaImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -12,6 +12,7 @@
 #include "src/client/social/IgnoreListUi.h"
 #include "src/client/gmtickets/GmTicketUi.h"
 #include "src/client/reputation/ReputationUi.h"
+#include "src/client/arena/ArenaUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -77,6 +78,7 @@ namespace engine::render
 	class LfgImGuiRenderer;
 	class CinematicImGuiRenderer;
 	class SkillBookImGuiRenderer;
+	class ArenaImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -355,6 +357,11 @@ namespace engine
 		/// Visible uniquement quand m_skillBookVisible (toggle via slash command
 		/// /skills ou touche B).
 		std::unique_ptr<engine::render::SkillBookImGuiRenderer> m_skillBookImGui;
+		/// CMANGOS.21 (Phase 5.21 step 3+4) — Panneau "Arena" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec les autres panneaux post-auth.
+		/// Visible uniquement quand m_arenaVisible (toggle via slash command
+		/// /arena ou touche A).
+		std::unique_ptr<engine::render::ArenaImGuiRenderer> m_arenaImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -477,6 +484,14 @@ namespace engine
 		/// CMANGOS.39 (Phase 4.39 step 3+4) — Visibilite du panneau Skill Book
 		/// (toggle via slash command \c /skills ou touche B). Faux par defaut.
 		bool                                  m_skillBookVisible = false;
+		/// CMANGOS.21 (Phase 5.21 step 3+4) — Presenter de la fenetre Arena.
+		/// Recoit les responses opcodes 121/123/125/128 et les push notifications
+		/// 126/129 via le push handler du master ; fire-and-forget des requetes
+		/// 120/122/124/127 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::ArenaUiPresenter      m_arenaUi;
+		/// CMANGOS.21 (Phase 5.21 step 3+4) — Visibilite du panneau Arena
+		/// (toggle via slash command \c /arena ou touche A). Faux par defaut.
+		bool                                  m_arenaVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/arena/ArenaUi.cpp
+++ b/src/client/arena/ArenaUi.cpp
@@ -1,0 +1,320 @@
+// CMANGOS.21 (Phase 5.21 step 3+4) — Implementation ArenaUiPresenter.
+
+#include "src/client/arena/ArenaUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	ArenaUiPresenter::~ArenaUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool ArenaUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[ArenaUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_pendingTeamId = 0;
+		m_pendingSize   = 0;
+		LOG_INFO(Core, "[ArenaUiPresenter] Init OK");
+		return true;
+	}
+
+	void ArenaUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[ArenaUiPresenter] Destroyed");
+	}
+
+	void ArenaUiPresenter::ClearQueueState()
+	{
+		m_state.inQueue          = false;
+		m_state.queuedTeamId     = 0;
+		m_state.queuedSize       = 0;
+		m_state.estimatedWaitSec = 0;
+	}
+
+	void ArenaUiPresenter::ClearProposalState()
+	{
+		m_state.pendingProposalId.reset();
+		m_state.pendingOpponentName.clear();
+		m_state.pendingOpponentRating = 0;
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void ArenaUiPresenter::RequestTeams()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ArenaUiPresenter] RequestTeams: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildArenaTeamListRequestPayload();
+		if (!m_send(engine::network::kOpcodeArenaTeamListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste arena teams).";
+			LOG_WARN(Net, "[ArenaUiPresenter] RequestTeams: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[ArenaUiPresenter] ArenaTeamListRequest queued");
+	}
+
+	void ArenaUiPresenter::Queue(uint32_t teamId, uint8_t size)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ArenaUiPresenter] Queue: no send callback");
+			return;
+		}
+		// Validation cote client : size 2/3/5, teamId > 0. Le master validera
+		// quand meme, mais on evite un round-trip pour des inputs invalides.
+		if (size != 2u && size != 3u && size != 5u)
+		{
+			m_state.lastErrorText = "Taille arene invalide (2/3/5 attendus).";
+			LOG_WARN(Net, "[ArenaUiPresenter] Queue: invalid size={}",
+				static_cast<unsigned>(size));
+			return;
+		}
+		if (teamId == 0u)
+		{
+			m_state.lastErrorText = "Equipe invalide.";
+			LOG_WARN(Net, "[ArenaUiPresenter] Queue: invalid teamId");
+			return;
+		}
+
+		const auto payload = engine::network::BuildArenaQueueRequestPayload(teamId, size);
+		m_pendingTeamId = teamId;
+		m_pendingSize   = size;
+		if (!m_send(engine::network::kOpcodeArenaQueueRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (queue arena).";
+			LOG_WARN(Net, "[ArenaUiPresenter] Queue: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[ArenaUiPresenter] ArenaQueueRequest queued (teamId={}, size={})",
+			teamId, static_cast<unsigned>(size));
+	}
+
+	void ArenaUiPresenter::LeaveQueue()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ArenaUiPresenter] LeaveQueue: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildArenaLeaveQueueRequestPayload();
+		if (!m_send(engine::network::kOpcodeArenaLeaveQueueRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (leave queue arena).";
+			LOG_WARN(Net, "[ArenaUiPresenter] LeaveQueue: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[ArenaUiPresenter] ArenaLeaveQueueRequest queued");
+	}
+
+	void ArenaUiPresenter::AcceptProposal(uint32_t proposalId, bool accept)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ArenaUiPresenter] AcceptProposal: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildArenaMatchAcceptRequestPayload(proposalId, accept);
+		if (!m_send(engine::network::kOpcodeArenaMatchAcceptRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (accept match).";
+			LOG_WARN(Net, "[ArenaUiPresenter] AcceptProposal: send failed");
+			return;
+		}
+		LOG_INFO(Net, "[ArenaUiPresenter] AcceptProposal sent (proposalId={}, accept={})",
+			proposalId, accept ? 1 : 0);
+
+		// Clear le proposal state immediatement pour fermer le popup,
+		// independamment de la reponse master.
+		ClearProposalState();
+		if (!accept)
+		{
+			ClearQueueState();
+			m_state.lastInfoText = "Match refuse, vous etes hors queue.";
+		}
+		else
+		{
+			m_state.lastInfoText = "Match accepte. Combat en cours...";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void ArenaUiPresenter::OnTeamListResponse(const engine::network::ArenaTeamListResponsePayload& resp)
+	{
+		using engine::network::ArenaErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<ArenaErrorCode>(resp.error);
+			if (err == ArenaErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur arena inconnue.";
+			LOG_WARN(Net, "[ArenaUiPresenter] OnTeamListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.teams.clear();
+		m_state.teams.reserve(resp.teams.size());
+		for (const auto& t : resp.teams)
+		{
+			ArenaTeamSummary s;
+			s.teamId      = t.teamId;
+			s.size        = t.size;
+			s.name        = t.name;
+			s.rating      = t.rating;
+			s.weeklyGames = t.weeklyGames;
+			s.weeklyWins  = t.weeklyWins;
+			m_state.teams.push_back(std::move(s));
+		}
+		m_state.teamsLoaded = true;
+		LOG_INFO(Net, "[ArenaUiPresenter] OnTeamListResponse OK count={}",
+			m_state.teams.size());
+	}
+
+	void ArenaUiPresenter::OnQueueResponse(const engine::network::ArenaQueueResponsePayload& resp)
+	{
+		using engine::network::ArenaErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<ArenaErrorCode>(resp.error);
+			switch (err)
+			{
+			case ArenaErrorCode::AlreadyQueued:
+				m_state.lastErrorText = "Vous etes deja en queue.";
+				break;
+			case ArenaErrorCode::TeamNotFound:
+				m_state.lastErrorText = "Equipe introuvable.";
+				break;
+			case ArenaErrorCode::InvalidSize:
+				m_state.lastErrorText = "Taille arene invalide.";
+				break;
+			case ArenaErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur arena inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[ArenaUiPresenter] OnQueueResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.inQueue          = true;
+		m_state.queuedTeamId     = m_pendingTeamId;
+		m_state.queuedSize       = m_pendingSize;
+		m_state.estimatedWaitSec = resp.estimatedWaitSec;
+		m_state.lastInfoText     = "Inscrit en queue arene.";
+		LOG_INFO(Net, "[ArenaUiPresenter] OnQueueResponse OK estimated={}s",
+			resp.estimatedWaitSec);
+	}
+
+	void ArenaUiPresenter::OnLeaveQueueResponse(const engine::network::ArenaLeaveQueueResponsePayload& resp)
+	{
+		using engine::network::ArenaErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<ArenaErrorCode>(resp.error);
+			if (err == ArenaErrorCode::NotInQueue)
+				m_state.lastErrorText = "Vous n'etes pas en queue.";
+			else if (err == ArenaErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur arena inconnue.";
+			LOG_WARN(Net, "[ArenaUiPresenter] OnLeaveQueueResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		ClearQueueState();
+		ClearProposalState();
+		m_state.lastInfoText = "Vous avez quitte la queue.";
+		LOG_INFO(Net, "[ArenaUiPresenter] OnLeaveQueueResponse OK");
+	}
+
+	void ArenaUiPresenter::OnMatchProposalNotification(const engine::network::ArenaMatchProposalNotificationPayload& note)
+	{
+		m_state.pendingProposalId     = note.proposalId;
+		m_state.pendingOpponentName   = note.opponentTeamName;
+		m_state.pendingOpponentRating = note.opponentRating;
+		// Le master a retire le joueur de la queue runtime quand le match est
+		// forme. On clear notre etat queue local pour rester en sync.
+		ClearQueueState();
+		m_state.lastInfoText = "Match trouve !";
+		LOG_INFO(Net, "[ArenaUiPresenter] OnMatchProposalNotification proposalId={} opp={} rating={}",
+			note.proposalId, note.opponentTeamName, note.opponentRating);
+	}
+
+	void ArenaUiPresenter::OnMatchAcceptResponse(const engine::network::ArenaMatchAcceptResponsePayload& resp)
+	{
+		using engine::network::ArenaErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<ArenaErrorCode>(resp.error);
+			switch (err)
+			{
+			case ArenaErrorCode::ProposalExpired:
+				m_state.lastErrorText = "Le match propose a expire.";
+				break;
+			case ArenaErrorCode::UnknownProposal:
+				m_state.lastErrorText = "Match inconnu.";
+				break;
+			case ArenaErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur arena inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[ArenaUiPresenter] OnMatchAcceptResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+		m_state.lastErrorText.clear();
+		LOG_INFO(Net, "[ArenaUiPresenter] OnMatchAcceptResponse OK");
+	}
+
+	void ArenaUiPresenter::OnMatchResultNotification(const engine::network::ArenaMatchResultNotificationPayload& note)
+	{
+		m_state.lastMatchWin           = note.win;
+		m_state.lastMatchOpponent      = note.opponentName;
+		// Calcule delta signe (peut etre negatif).
+		m_state.lastMatchRatingDelta   = static_cast<int32_t>(note.newRating)
+		                                - static_cast<int32_t>(note.oldRating);
+
+		// Update la team locale dont le rating a change. V1 : on cherche par
+		// ownership cote presenter (le master n'envoie pas teamId dans le push,
+		// mais on a le queuedTeamId memorise — sauf que ClearQueueState a ete
+		// appele sur le proposal). Approche pragmatique : refresh la liste a
+		// la prochaine ouverture du panel, pour le moment on note juste le delta.
+		ClearProposalState();
+		m_state.lastInfoText.clear();
+		LOG_INFO(Net, "[ArenaUiPresenter] OnMatchResultNotification win={} old={} new={} opp={}",
+			note.win ? 1 : 0, note.oldRating, note.newRating, note.opponentName);
+	}
+}

--- a/src/client/arena/ArenaUi.h
+++ b/src/client/arena/ArenaUi.h
@@ -1,0 +1,163 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4) — Presenter client de la fenetre Arena.
+// Maintient un cache local des arena teams + etat de queue + popup proposal
+// + indicateur transitoire du dernier resultat de match (win/loss + delta ELO).
+//
+// Pas de rendu ImGui : le panneau est drawe par ArenaImGuiRenderer qui lit
+// l'etat via GetState() et propage les inputs UI (RequestTeams / Queue /
+// LeaveQueue / AcceptProposal) via les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans LfgUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes 121/123/125/126/128/129
+// vers les OnXxx du presenter.
+
+#include "src/shared/network/ArenaPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'une arena team exposable au layer UI. Mirror direct de
+	/// engine::network::ArenaTeamSummary.
+	struct ArenaTeamSummary
+	{
+		uint32_t    teamId       = 0;
+		uint8_t     size         = 0; ///< 2 / 3 / 5.
+		std::string name;
+		uint32_t    rating       = 0;
+		uint32_t    weeklyGames  = 0;
+		uint32_t    weeklyWins   = 0;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct ArenaUiState
+	{
+		std::vector<ArenaTeamSummary> teams;
+		bool                          teamsLoaded = false;
+
+		/// True si l'account est inscrit dans une queue arena.
+		bool     inQueue           = false;
+		uint32_t queuedTeamId      = 0;
+		uint8_t  queuedSize        = 0;
+		uint32_t estimatedWaitSec  = 0;
+
+		/// Match proposal en cours (push opcode 126).
+		std::optional<uint32_t> pendingProposalId;
+		std::string             pendingOpponentName;
+		uint32_t                pendingOpponentRating = 0;
+
+		/// Resultat du dernier match (push opcode 129). Affiche transitoirement
+		/// par le renderer ; lastMatchExpireAt sert au fade-out cote UI.
+		std::optional<bool>     lastMatchWin;
+		int32_t                 lastMatchRatingDelta = 0;
+		std::string             lastMatchOpponent;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire (e.g. "Inscrit en queue."). Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Presenter pour la fenetre Arena cote client. Doit etre Init() avant tout
+	/// usage du callback. Thread : main (comme les autres presenters UI).
+	class ArenaUiPresenter final
+	{
+	public:
+		ArenaUiPresenter() = default;
+
+		ArenaUiPresenter(const ArenaUiPresenter&)            = delete;
+		ArenaUiPresenter& operator=(const ArenaUiPresenter&) = delete;
+
+		~ArenaUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.21 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestTeams / Queue / LeaveQueue /
+		/// AcceptProposal.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie ARENA_TEAM_LIST_REQUEST. Reponse via OnTeamListResponse.
+		void RequestTeams();
+
+		/// Envoie ARENA_QUEUE_REQUEST avec \p teamId et \p size (2/3/5).
+		/// Reponse via OnQueueResponse.
+		void Queue(uint32_t teamId, uint8_t size);
+
+		/// Envoie ARENA_LEAVE_QUEUE_REQUEST. Reponse via OnLeaveQueueResponse.
+		void LeaveQueue();
+
+		/// Envoie ARENA_MATCH_ACCEPT_REQUEST avec \p proposalId et \p accept.
+		/// Reponse via OnMatchAcceptResponse + push MatchResult si accept=true.
+		void AcceptProposal(uint32_t proposalId, bool accept);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit ARENA_TEAM_LIST_RESPONSE. Remplace la cache locale.
+		void OnTeamListResponse(const engine::network::ArenaTeamListResponsePayload& resp);
+
+		/// Recoit ARENA_QUEUE_RESPONSE. Si OK, marque inQueue = true et stocke
+		/// estimatedWaitSec. Sinon, ecrit dans lastErrorText.
+		void OnQueueResponse(const engine::network::ArenaQueueResponsePayload& resp);
+
+		/// Recoit ARENA_LEAVE_QUEUE_RESPONSE. Si OK, clear l'etat de queue local.
+		void OnLeaveQueueResponse(const engine::network::ArenaLeaveQueueResponsePayload& resp);
+
+		/// Recoit un push ARENA_MATCH_PROPOSAL_NOTIFICATION : arme le popup
+		/// proposal avec proposalId + opponent.
+		void OnMatchProposalNotification(const engine::network::ArenaMatchProposalNotificationPayload& note);
+
+		/// Recoit ARENA_MATCH_ACCEPT_RESPONSE. Si OK et accept=true, on attend
+		/// le push MatchResult. Si erreur, ecrit dans lastErrorText.
+		void OnMatchAcceptResponse(const engine::network::ArenaMatchAcceptResponsePayload& resp);
+
+		/// Recoit un push ARENA_MATCH_RESULT_NOTIFICATION : update la team
+		/// localement (rating) + arme le toast result (win/loss + delta).
+		void OnMatchResultNotification(const engine::network::ArenaMatchResultNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const ArenaUiState& GetState() const { return m_state; }
+
+	private:
+		/// Clear l'etat de queue local (appele a OnLeaveQueueResponse Ok ou a
+		/// la reception d'un proposal ; ne touche pas le pending proposal).
+		void ClearQueueState();
+
+		/// Clear l'etat proposal local (appele apres AcceptProposal).
+		void ClearProposalState();
+
+		/// Memorise le teamId et size choisis en attente de la reponse Ok.
+		uint32_t m_pendingTeamId = 0;
+		uint8_t  m_pendingSize   = 0;
+
+		bool         m_initialized = false;
+		ArenaUiState m_state{};
+		SendCallback m_send;
+	};
+}

--- a/src/client/render/ArenaImGuiRenderer.cpp
+++ b/src/client/render/ArenaImGuiRenderer.cpp
@@ -1,0 +1,241 @@
+// CMANGOS.21 (Phase 5.21 step 3+4) — ArenaImGuiRenderer implementation.
+
+#include "src/client/render/ArenaImGuiRenderer.h"
+
+#include "src/client/arena/ArenaUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Libelle FR pour une taille d'arene.
+		const char* SizeLabel(uint8_t size)
+		{
+			switch (size)
+			{
+			case 2: return "2v2";
+			case 3: return "3v3";
+			case 5: return "5v5";
+			default: return "?";
+			}
+		}
+	}
+
+	void ArenaImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		RenderMainPanel();
+		RenderProposalPopup();
+	}
+
+	void ArenaImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 380x460.
+		const float panelW = 380.f;
+		const float panelH = 460.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Arena##ln_arena_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Resultat du dernier match (toast persistant tant que pas d'autre
+			// info ; le state n'a pas de fade-out auto cote presenter — V1).
+			if (state.lastMatchWin.has_value())
+			{
+				const bool win = *state.lastMatchWin;
+				ImGui::PushStyleColor(ImGuiCol_Text,
+					win ? ImVec4(0.4f, 1.f, 0.4f, 1.f)
+					    : ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				char buf[160]{};
+				std::snprintf(buf, sizeof(buf), "%s %+d rating contre %s",
+					win ? "Victoire" : "Defaite",
+					state.lastMatchRatingDelta,
+					state.lastMatchOpponent.c_str());
+				ImGui::TextWrapped("%s", buf);
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			if (state.inQueue)
+			{
+				ImGui::TextUnformatted("En queue arene :");
+				ImGui::Separator();
+				ImGui::Text("Equipe : #%u", static_cast<unsigned>(state.queuedTeamId));
+				ImGui::Text("Mode   : %s", SizeLabel(state.queuedSize));
+				if (state.estimatedWaitSec > 0u)
+					ImGui::Text("Estime : %u s", static_cast<unsigned>(state.estimatedWaitSec));
+				ImGui::Spacing();
+				if (ImGui::Button("Quitter la queue", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->LeaveQueue();
+			}
+			else
+			{
+				// Liste des teams + bouton Queue par team.
+				if (!state.teamsLoaded || state.teams.empty())
+				{
+					if (ImGui::Button("Charger mes equipes", ImVec2(-FLT_MIN, 28.f)))
+						m_presenter->RequestTeams();
+					if (state.teamsLoaded && state.teams.empty())
+					{
+						ImGui::TextWrapped("Aucune equipe arena.");
+					}
+				}
+				else
+				{
+					ImGui::TextUnformatted("Mes equipes :");
+					ImGui::Separator();
+					const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+						| ImGuiTableFlags_RowBg
+						| ImGuiTableFlags_ScrollY;
+					if (ImGui::BeginTable("##ln_arena_teams", 5, tableFlags, ImVec2(0.f, 220.f)))
+					{
+						ImGui::TableSetupColumn("Nom",    ImGuiTableColumnFlags_WidthStretch);
+						ImGui::TableSetupColumn("Mode",   ImGuiTableColumnFlags_WidthFixed, 50.f);
+						ImGui::TableSetupColumn("Rating", ImGuiTableColumnFlags_WidthFixed, 60.f);
+						ImGui::TableSetupColumn("W-L",    ImGuiTableColumnFlags_WidthFixed, 60.f);
+						ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 80.f);
+						ImGui::TableHeadersRow();
+						for (const auto& t : state.teams)
+						{
+							ImGui::TableNextRow();
+							ImGui::TableSetColumnIndex(0);
+							ImGui::TextUnformatted(t.name.c_str());
+							ImGui::TableSetColumnIndex(1);
+							ImGui::TextUnformatted(SizeLabel(t.size));
+							ImGui::TableSetColumnIndex(2);
+							ImGui::Text("%u", static_cast<unsigned>(t.rating));
+							ImGui::TableSetColumnIndex(3);
+							ImGui::Text("%u-%u",
+								static_cast<unsigned>(t.weeklyWins),
+								static_cast<unsigned>(
+									t.weeklyGames > t.weeklyWins
+										? (t.weeklyGames - t.weeklyWins) : 0u));
+							ImGui::TableSetColumnIndex(4);
+							ImGui::PushID(static_cast<int>(t.teamId));
+							if (ImGui::Button("Queue", ImVec2(70.f, 22.f)))
+								m_presenter->Queue(t.teamId, t.size);
+							ImGui::PopID();
+						}
+						ImGui::EndTable();
+					}
+					ImGui::Spacing();
+					if (ImGui::Button("Rafraichir la liste", ImVec2(-FLT_MIN, 28.f)))
+						m_presenter->RequestTeams();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void ArenaImGuiRenderer::RenderProposalPopup()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.pendingProposalId.has_value())
+			return;
+
+		// Modal centre, taille fixe 480x240.
+		const float modalW = 480.f;
+		const float modalH = 240.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, (vpW - modalW) * 0.5f);
+		const float posY = std::max(0.f, (vpH - modalH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(modalW, modalH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.97f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.97f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings;
+		if (ImGui::Begin("Match arene trouve !##ln_arena_proposal", nullptr, flags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.85f, 0.20f, 1.f));
+			ImGui::TextWrapped("Adversaire : %s", state.pendingOpponentName.c_str());
+			ImGui::PopStyleColor();
+			ImGui::Text("Rating : %u", static_cast<unsigned>(state.pendingOpponentRating));
+			ImGui::Separator();
+
+			ImGui::TextWrapped(
+				"Vous allez affronter cette equipe en arene. "
+				"Acceptez pour lancer le combat ou refusez pour annuler.");
+			ImGui::Spacing();
+
+			const float btnW = (modalW - 60.f) * 0.5f;
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.55f, 0.20f, 1.f));
+			if (ImGui::Button("Accepter", ImVec2(btnW, 32.f)))
+			{
+				m_presenter->AcceptProposal(*state.pendingProposalId, true);
+			}
+			ImGui::PopStyleColor();
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.55f, 0.20f, 0.20f, 1.f));
+			if (ImGui::Button("Refuser", ImVec2(btnW, 32.f)))
+			{
+				m_presenter->AcceptProposal(*state.pendingProposalId, false);
+			}
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void ArenaImGuiRenderer::Render()             {}
+	void ArenaImGuiRenderer::RenderMainPanel()    {}
+	void ArenaImGuiRenderer::RenderProposalPopup(){}
+}
+
+#endif

--- a/src/client/render/ArenaImGuiRenderer.h
+++ b/src/client/render/ArenaImGuiRenderer.h
@@ -1,0 +1,48 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4) — ArenaImGuiRenderer : panneau ImGui pour
+// la fenetre Arena cote joueur. Lit l'etat d'un ArenaUiPresenter, dispatch
+// les inputs UI (RequestTeams / Queue / LeaveQueue / Accept / Decline) via
+// accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class ArenaUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau Arena. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::ArenaUiPresenter. Le renderer ne
+	/// fait que dessiner l'etat courant et propager les inputs UI vers le
+	/// presenter.
+	class ArenaImGuiRenderer
+	{
+	public:
+		ArenaImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::ArenaUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Arena" + popup proposal s'il est actif. A appeler
+		/// entre \c ImGui::NewFrame() et \c ImGui::Render(), apres NewFrame,
+		/// si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (liste teams + queue/leave + last result).
+		void RenderMainPanel();
+
+		/// Dessine le popup quand un proposal est en attente.
+		void RenderProposalPopup();
+
+		engine::client::ArenaUiPresenter* m_presenter = nullptr;
+		bool                              m_enabled   = false;
+		uint32_t                          m_viewportW = 0;
+		uint32_t                          m_viewportH = 0;
+	};
+}

--- a/src/masterd/handlers/arena/ArenaHandler.cpp
+++ b/src/masterd/handlers/arena/ArenaHandler.cpp
@@ -1,0 +1,576 @@
+// CMANGOS.21 (Phase 5.21 step 3+4) — Implementation ArenaHandler.
+
+#include "src/masterd/handlers/arena/ArenaHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ArenaPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <algorithm>
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Convertit un uint8 size (2/3/5) en arena::TeamSize enum.
+		/// Retourne TeamSize::v2 par defaut sur valeur invalide.
+		engine::server::arena::TeamSize ToTeamSize(uint8_t s)
+		{
+			switch (s)
+			{
+			case 2: return engine::server::arena::TeamSize::v2;
+			case 3: return engine::server::arena::TeamSize::v3;
+			case 5: return engine::server::arena::TeamSize::v5;
+			default: return engine::server::arena::TeamSize::v2;
+			}
+		}
+
+		/// Verifie que size est un mode arena valide (2v2 / 3v3 / 5v5).
+		bool IsValidArenaSize(uint8_t s)
+		{
+			return s == 2u || s == 3u || s == 5u;
+		}
+	}
+
+	void ArenaHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[ArenaHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(ArenaErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeArenaTeamListRequest:
+				pkt = BuildArenaTeamListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeArenaQueueRequest:
+				pkt = BuildArenaQueueResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeArenaLeaveQueueRequest:
+				pkt = BuildArenaLeaveQueueResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeArenaMatchAcceptRequest:
+				pkt = BuildArenaMatchAcceptResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeArenaTeamListRequest:
+			HandleTeamList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeArenaQueueRequest:
+			HandleQueue(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeArenaLeaveQueueRequest:
+			HandleLeaveQueue(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeArenaMatchAcceptRequest:
+			HandleMatchAccept(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ArenaHandler::SeedStarterTeamsIfNeeded(uint64_t accountId)
+	{
+		using engine::server::arena::ArenaTeam;
+		using engine::server::arena::TeamSize;
+
+		auto it = m_accountSeeded.find(accountId);
+		if (it != m_accountSeeded.end())
+			return;
+
+		// V1 : 3 teams hardcode par account. Note : le registry n'est pas
+		// segmente par account, donc les teamIds sont partages — un teamId
+		// 1 vu en TeamList par account A est le meme objet que pour account B.
+		// Acceptable V1 (sub-PR future avec persistance DB et teamId
+		// globalement unique).
+		ArenaTeam t1;
+		t1.id = kSeedTeam1Id;
+		t1.size = TeamSize::v2;
+		t1.name = "LCDLLN A";
+		t1.rating = kSeedInitialRating;
+		m_registry.AddTeam(t1);
+
+		ArenaTeam t2;
+		t2.id = kSeedTeam2Id;
+		t2.size = TeamSize::v3;
+		t2.name = "LCDLLN B";
+		t2.rating = kSeedInitialRating;
+		m_registry.AddTeam(t2);
+
+		ArenaTeam t3;
+		t3.id = kSeedTeam3Id;
+		t3.size = TeamSize::v5;
+		t3.name = "LCDLLN C";
+		t3.rating = kSeedInitialRating;
+		m_registry.AddTeam(t3);
+
+		m_accountSeeded[accountId] = true;
+
+		LOG_INFO(Net, "[ArenaHandler] Seeded 3 starter teams for account={}", accountId);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ArenaHandler::HandleTeamList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		std::vector<ArenaTeamSummary> summaries;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			SeedStarterTeamsIfNeeded(accountId);
+
+			// Enumere les 3 teams seedees pour cet account.
+			const uint32_t ids[] = {kSeedTeam1Id, kSeedTeam2Id, kSeedTeam3Id};
+			for (uint32_t teamId : ids)
+			{
+				auto* t = m_registry.Get(teamId);
+				if (!t) continue;
+				ArenaTeamSummary s;
+				s.teamId       = t->id;
+				s.size         = static_cast<uint8_t>(t->size);
+				s.name         = t->name;
+				s.rating       = t->rating;
+				s.weeklyGames  = t->weeklyGames;
+				s.weeklyWins   = t->weeklyWins;
+				summaries.push_back(std::move(s));
+			}
+		}
+
+		LOG_INFO(Net, "[ArenaHandler] TeamList account={} count={}",
+			accountId, summaries.size());
+
+		auto pkt = BuildArenaTeamListResponsePacket(0u, summaries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ArenaHandler::HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseArenaQueueRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[ArenaHandler] Queue parse failed account={}", accountId);
+			auto pkt = BuildArenaQueueResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::InvalidSize), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Validation size : 2 / 3 / 5.
+		if (!IsValidArenaSize(parsed->size))
+		{
+			LOG_INFO(Net, "[ArenaHandler] Queue InvalidSize account={} size={}",
+				accountId, static_cast<unsigned>(parsed->size));
+			auto pkt = BuildArenaQueueResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::InvalidSize), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		uint32_t newProposalId = 0;
+		bool teamFound = false;
+		bool alreadyQueued = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			SeedStarterTeamsIfNeeded(accountId);
+
+			// Verifie team existe.
+			auto* t = m_registry.Get(parsed->teamId);
+			teamFound = (t != nullptr) && (static_cast<uint8_t>(t->size) == parsed->size);
+
+			if (teamFound)
+			{
+				// Verifie pas deja en queue.
+				if (m_queue.find(accountId) != m_queue.end())
+				{
+					alreadyQueued = true;
+				}
+				else
+				{
+					// Ajoute en queue.
+					QueueEntry e;
+					e.teamId   = parsed->teamId;
+					e.size     = parsed->size;
+					e.queuedAt = std::chrono::steady_clock::now();
+					m_queue[accountId] = e;
+
+					// V1 : cree immediatement un proposal contre AI fictive.
+					newProposalId = m_nextProposalId++;
+					Proposal p;
+					p.accountId      = accountId;
+					p.teamId         = parsed->teamId;
+					p.opponentTeamId = 0u; // AI fictive.
+					p.opponentName   = kAiOpponentName;
+					p.opponentRating = kAiOpponentRating;
+					p.createdAt      = std::chrono::steady_clock::now();
+					m_proposals[newProposalId] = p;
+				}
+			}
+		}
+
+		if (!teamFound)
+		{
+			LOG_INFO(Net, "[ArenaHandler] Queue TeamNotFound account={} teamId={} size={}",
+				accountId, parsed->teamId, static_cast<unsigned>(parsed->size));
+			auto pkt = BuildArenaQueueResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::TeamNotFound), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (alreadyQueued)
+		{
+			LOG_INFO(Net, "[ArenaHandler] Queue AlreadyQueued account={}", accountId);
+			auto pkt = BuildArenaQueueResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::AlreadyQueued), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[ArenaHandler] Queue OK account={} teamId={} size={} proposalId={}",
+			accountId, parsed->teamId, static_cast<unsigned>(parsed->size), newProposalId);
+
+		// Envoie le QueueResponse OK.
+		auto pkt = BuildArenaQueueResponsePacket(0u, kV1EstimatedWaitSec,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// V1 : push immediatement le MatchProposal contre AI fictive.
+		PushMatchProposal(connId, newProposalId, kAiOpponentName, kAiOpponentRating);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ArenaHandler::HandleLeaveQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		bool wasQueued = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto it = m_queue.find(accountId);
+			if (it != m_queue.end())
+			{
+				wasQueued = true;
+				m_queue.erase(it);
+				// Supprime les proposals associes a cet account.
+				for (auto pit = m_proposals.begin(); pit != m_proposals.end(); )
+				{
+					if (pit->second.accountId == accountId)
+						pit = m_proposals.erase(pit);
+					else
+						++pit;
+				}
+			}
+		}
+
+		if (!wasQueued)
+		{
+			LOG_INFO(Net, "[ArenaHandler] LeaveQueue NotInQueue account={}", accountId);
+			auto pkt = BuildArenaLeaveQueueResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::NotInQueue),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[ArenaHandler] LeaveQueue OK account={}", accountId);
+		auto pkt = BuildArenaLeaveQueueResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	void ArenaHandler::HandleMatchAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		using engine::server::arena::ApplyEloUpdate;
+
+		auto parsed = ParseArenaMatchAcceptRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[ArenaHandler] MatchAccept parse failed account={}", accountId);
+			auto pkt = BuildArenaMatchAcceptResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::UnknownProposal),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		bool win = false;
+		uint32_t oldRating = 0;
+		uint32_t newRating = 0;
+		std::string opponentName;
+		bool acceptOk = false;
+		bool proposalExpired = false;
+		bool unknownProposal = false;
+		bool acceptValueWasTrue = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto it = m_proposals.find(parsed->proposalId);
+			if (it == m_proposals.end())
+			{
+				unknownProposal = true;
+			}
+			else if (it->second.accountId != accountId)
+			{
+				// Proposal n'appartient pas a cet account.
+				unknownProposal = true;
+			}
+			else
+			{
+				// Check expiration.
+				const auto now = std::chrono::steady_clock::now();
+				const auto age = std::chrono::duration_cast<std::chrono::seconds>(
+					now - it->second.createdAt).count();
+				if (age >= static_cast<long long>(kProposalLifetimeSec))
+				{
+					proposalExpired = true;
+					m_proposals.erase(it);
+				}
+				else
+				{
+					// Proposal valide. Recupere l'etat avant de pop.
+					const Proposal p = it->second;
+					m_proposals.erase(it);
+					// Retire l'account de la queue (le match est en cours).
+					m_queue.erase(accountId);
+
+					acceptValueWasTrue = parsed->accept;
+
+					if (parsed->accept)
+					{
+						// V1 : RNG win/loss 50%. Apply ELO update.
+						if (!m_rngSeeded)
+						{
+							const auto seed = static_cast<std::mt19937::result_type>(
+								std::chrono::steady_clock::now().time_since_epoch().count());
+							m_rng.seed(seed);
+							m_rngSeeded = true;
+						}
+						std::uniform_int_distribution<uint32_t> dist(0u, 1u);
+						win = (dist(m_rng) == 1u);
+
+						// Recupere la team du joueur pour l'oldRating.
+						auto* myTeam = m_registry.Get(p.teamId);
+						oldRating = myTeam ? myTeam->rating : kSeedInitialRating;
+
+						uint32_t winnerNew = 0;
+						uint32_t loserNew  = 0;
+						if (win)
+						{
+							ApplyEloUpdate(oldRating, p.opponentRating, 32u, winnerNew, loserNew);
+							newRating = winnerNew;
+						}
+						else
+						{
+							ApplyEloUpdate(p.opponentRating, oldRating, 32u, winnerNew, loserNew);
+							newRating = loserNew;
+						}
+
+						// Update la team du joueur.
+						if (myTeam)
+						{
+							myTeam->rating = newRating;
+							myTeam->weeklyGames++;
+							myTeam->seasonGames++;
+							if (win)
+							{
+								myTeam->weeklyWins++;
+								myTeam->seasonWins++;
+							}
+						}
+						opponentName = p.opponentName;
+					}
+					acceptOk = true;
+				}
+			}
+		}
+
+		if (unknownProposal)
+		{
+			LOG_INFO(Net, "[ArenaHandler] MatchAccept UnknownProposal account={} proposalId={}",
+				accountId, parsed->proposalId);
+			auto pkt = BuildArenaMatchAcceptResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::UnknownProposal),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (proposalExpired)
+		{
+			LOG_INFO(Net, "[ArenaHandler] MatchAccept ProposalExpired account={} proposalId={}",
+				accountId, parsed->proposalId);
+			auto pkt = BuildArenaMatchAcceptResponsePacket(
+				static_cast<uint8_t>(ArenaErrorCode::ProposalExpired),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (!acceptOk)
+		{
+			LOG_WARN(Net, "[ArenaHandler] MatchAccept unexpected state account={}", accountId);
+			return;
+		}
+
+		LOG_INFO(Net, "[ArenaHandler] MatchAccept OK account={} proposalId={} accept={} win={} old={} new={}",
+			accountId, parsed->proposalId,
+			acceptValueWasTrue ? 1 : 0,
+			win ? 1 : 0,
+			oldRating, newRating);
+
+		// ACK Ok.
+		auto ack = BuildArenaMatchAcceptResponsePacket(0u, requestId, sessionIdHeader);
+		if (!ack.empty())
+			m_server->Send(connId, ack);
+
+		// Si accept=true, push le result. Sinon (reject), pas de result push.
+		if (acceptValueWasTrue)
+		{
+			PushMatchResult(connId, win, oldRating, newRating, opponentName);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	bool ArenaHandler::PushMatchProposal(uint32_t connId, uint32_t proposalId,
+		const std::string& opponentTeamName, uint32_t opponentRating)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchProposal dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchProposal: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildArenaMatchProposalNotificationPacket(
+			proposalId, opponentTeamName, opponentRating, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchProposal: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[ArenaHandler] PushMatchProposal connId={} proposalId={} opp={} rating={}",
+			connId, proposalId, opponentTeamName, opponentRating);
+		return true;
+	}
+
+	bool ArenaHandler::PushMatchResult(uint32_t connId, bool win, uint32_t oldRating,
+		uint32_t newRating, const std::string& opponentName)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchResult dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchResult: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildArenaMatchResultNotificationPacket(
+			win, oldRating, newRating, opponentName, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[ArenaHandler] PushMatchResult: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[ArenaHandler] PushMatchResult connId={} win={} old={} new={} opp={}",
+			connId, win ? 1 : 0, oldRating, newRating, opponentName);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+
+	uint64_t ArenaHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/arena/ArenaHandler.h
+++ b/src/masterd/handlers/arena/ArenaHandler.h
@@ -1,0 +1,198 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4) — ArenaHandler : dispatch des opcodes
+// Arena cote joueur (120/122/124/127) et appel des methodes correspondantes
+// d'un store in-memory de teams + queue + proposals.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 120/122/124/127 (les requests). Les responses 121/123/125/128 sont
+// emises avec le meme requestId / sessionId que la request recue. Les push
+// notifications 126 (MatchProposal) et 129 (MatchResult) sont emises par le
+// handler lui-meme apres traitement (V1 : push proposal immediatement apres
+// QueueResponse OK, push result immediatement apres MatchAccept OK).
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 7) dans la reponse type-specific.
+//
+// Store in-memory V1 : ArenaTeamRegistry seede au premier acces par account
+// (3 teams : id=1 size=2 name="LCDLLN A", id=2 size=3 name="LCDLLN B",
+// id=3 size=5 name="LCDLLN C", tous a rating=1500). Pas de persistance DB
+// en V1 — toutes les progressions sont perdues au reboot, ce qui est acceptable
+// pour un V1 (sub-PR future pour la persistance avec migration MysqlArenaStore).
+//
+// V1 limitations :
+//   - Match contre AI Team Alpha fictif (rating 1500). Pairing 2 accounts a venir.
+//   - Result win/loss random 50% (V1) ; vraie simulation match a venir.
+//   - estimatedWaitSec hardcode 5s (V1).
+//   - proposal expiration 30s (V1).
+
+#include "src/shardd/arena/ArenaTeam.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Arena cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class ArenaHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Arena.
+		/// Dispatch vers HandleTeamList / HandleQueue / HandleLeaveQueue /
+		/// HandleMatchAccept selon l'opcode. Si l'opcode n'est pas un opcode
+		/// Arena, ignore silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (120/122/124/127).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push MatchProposalNotification (opcode 126)
+		/// au client identifie par \p connId. Utilise par HandleQueue (V1 : push
+		/// immediatement apres QueueResponse OK avec opponent fictif AI).
+		///
+		/// \param connId            identifiant de connexion TCP cible (0 = no-op).
+		/// \param proposalId        id du proposal genere par le master.
+		/// \param opponentTeamName  nom de l'equipe adverse (V1 : "AI Team Alpha").
+		/// \param opponentRating    rating ELO de l'adversaire (V1 : 1500).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushMatchProposal(uint32_t connId, uint32_t proposalId,
+		                        const std::string& opponentTeamName, uint32_t opponentRating);
+
+		/// API publique : pousse une push MatchResultNotification (opcode 129)
+		/// au client identifie par \p connId. Utilise par HandleMatchAccept
+		/// (V1 : push immediatement apres MatchAccept OK avec result random).
+		///
+		/// \param connId        identifiant de connexion TCP cible (0 = no-op).
+		/// \param win           true si victoire, false si defaite.
+		/// \param oldRating     rating avant le match.
+		/// \param newRating     rating apres ELO update.
+		/// \param opponentName  nom de l'equipe adverse (pour affichage UI).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushMatchResult(uint32_t connId, bool win, uint32_t oldRating,
+		                      uint32_t newRating, const std::string& opponentName);
+
+	private:
+		/// Traite ARENA_TEAM_LIST_REQUEST : enumere les teams de l'account
+		/// (seed au premier acces avec un starter set hardcode V1).
+		void HandleTeamList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite ARENA_QUEUE_REQUEST : verifie size valide (2/3/5) et team
+		/// existe pour cet account. Si OK, ajoute a la queue puis push
+		/// immediatement un proposal contre AI fictive (V1).
+		void HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite ARENA_LEAVE_QUEUE_REQUEST : retire de la queue + supprime
+		/// les proposals associes. OK si etait en queue, NotInQueue sinon.
+		void HandleLeaveQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite ARENA_MATCH_ACCEPT_REQUEST : valide proposalId existe et
+		/// appartient a cet account. Si accept=true, push MatchResult avec
+		/// ELO update (V1 : 50% random). Si accept=false, supprime proposal
+		/// sans push result. ACK Ok dans tous les cas.
+		void HandleMatchAccept(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Seede les 3 teams V1 pour un account si l'entree n'existe pas.
+		/// Pas de mutex ici : appele uniquement sous m_mutex deja verrouille.
+		void SeedStarterTeamsIfNeeded(uint64_t accountId);
+
+		/// V1 : 3 teams seedees par account (id=1 size=2, id=2 size=3, id=3 size=5).
+		static constexpr uint32_t kSeedTeam1Id      = 1u;
+		static constexpr uint32_t kSeedTeam2Id      = 2u;
+		static constexpr uint32_t kSeedTeam3Id      = 3u;
+		static constexpr uint32_t kSeedInitialRating = 1500u;
+		/// V1 : estimatedWaitSec retourne dans QueueResponse.
+		static constexpr uint32_t kV1EstimatedWaitSec = 5u;
+		/// V1 : duree de vie d'un proposal en secondes.
+		static constexpr uint32_t kProposalLifetimeSec = 30u;
+		/// V1 : opponent fictif pour le pairing AI.
+		static constexpr const char* kAiOpponentName = "AI Team Alpha";
+		static constexpr uint32_t kAiOpponentRating = 1500u;
+
+		/// Etat d'inscription en queue : un account est dans la queue avec
+		/// un teamId + size. queuedAt sert a l'estimation d'attente future.
+		struct QueueEntry
+		{
+			uint32_t                              teamId   = 0;
+			uint8_t                               size     = 0;
+			std::chrono::steady_clock::time_point queuedAt;
+		};
+
+		/// Etat d'un proposal en attente d'accept/reject. accountId pour
+		/// verifier l'ownership a MatchAccept. opponentTeamId est 0 en V1
+		/// (AI fictive). createdAt sert au check d'expiration (30s V1).
+		struct Proposal
+		{
+			uint64_t                              accountId         = 0;
+			uint32_t                              teamId            = 0;
+			uint32_t                              opponentTeamId    = 0; ///< 0 = AI fictive (V1).
+			std::string                           opponentName;
+			uint32_t                              opponentRating    = 0;
+			std::chrono::steady_clock::time_point createdAt;
+		};
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Registry in-memory : seedage par account au premier acces. Le registry
+		/// expose Get / AddTeam / RecordMatch / ResetWeekly. V1 : pas d'isolation
+		/// par account — toutes les teams partagent le meme namespace numerique
+		/// (collision potentielle inter-account ; sub-PR future avec MysqlArenaStore
+		/// donnera un teamId globalement unique par auto-increment).
+		std::mutex                                       m_mutex;
+		engine::server::arena::ArenaTeamRegistry         m_registry;
+		/// Track des accounts deja seedes pour eviter de re-seed a chaque acces.
+		std::unordered_map<uint64_t, bool>               m_accountSeeded;
+
+		/// Queue active : account_id -> entry. Un seul account ne peut etre que
+		/// dans une seule queue (V1 ; pas de queue parallele 2v2/3v3 simultanees).
+		std::unordered_map<uint64_t, QueueEntry>         m_queue;
+
+		/// Proposals actifs : proposalId -> Proposal.
+		std::unordered_map<uint32_t, Proposal>           m_proposals;
+
+		/// Compteur monotone pour generer des proposalId. V1 : transient (reset
+		/// au reboot). Pas de collision tant qu'un seul master.
+		uint32_t                                         m_nextProposalId = 1u;
+
+		/// RNG pour le result win/loss V1 (50%). Seede au premier usage (lazy).
+		std::mt19937                                     m_rng;
+		bool                                             m_rngSeeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -39,6 +39,7 @@
 #include "src/masterd/mail/MysqlMailStore.h"
 #include "src/masterd/handlers/quest/QuestHandler.h"
 #include "src/masterd/handlers/reputation/ReputationHandler.h"
+#include "src/masterd/handlers/arena/ArenaHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -521,6 +522,22 @@ int main(int argc, char** argv)
 	skillHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] SkillHandler configured (CMANGOS.39 step 3+4, in-memory store)");
 
+	// CMANGOS.21 (Phase 5.21 step 3+4) — Arena wire server.
+	// Le master tient en memoire un ArenaTeamRegistry (V1, seed hardcode
+	// par account au premier acces : 3 teams 2v2/3v3/5v5 a rating 1500)
+	// + une queue par account + un map de proposals actifs. Les opcodes
+	// 120/122/124/127 sont dispatches au handler ; les responses
+	// 121/123/125/128 et les push notifications 126 (MatchProposal) +
+	// 129 (MatchResult) sont emises par le handler.
+	// V1 limitations : match contre AI Team Alpha fictif, result win/loss
+	// random 50%, pas de SyncArena RPC entre master et shardd. Pas de
+	// persistance DB (sub-PR future avec MysqlArenaStore).
+	engine::server::ArenaHandler arenaHandler;
+	arenaHandler.SetServer(&server);
+	arenaHandler.SetSessionManager(&sessionManager);
+	arenaHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] ArenaHandler configured (CMANGOS.21 step 3+4, in-memory registry)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -560,7 +577,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -626,6 +643,11 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeSkillLearnRequest
 		      || opcode == kOpcodeSkillUseRequest)
 			skillHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeArenaTeamListRequest
+		      || opcode == kOpcodeArenaQueueRequest
+		      || opcode == kOpcodeArenaLeaveQueueRequest
+		      || opcode == kOpcodeArenaMatchAcceptRequest)
+			arenaHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/ArenaPayloads.cpp
+++ b/src/shared/network/ArenaPayloads.cpp
@@ -1,0 +1,409 @@
+// CMANGOS.21 (Phase 5.21 step 3+4) — Implementation Parse/Build des payloads Arena.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket utilise PacketBuilder pour assembler le paquet
+//     complet header + payload, pret a passer a NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/ArenaPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un ArenaTeamSummary (uint32 teamId, uint8 size, string name,
+		/// uint32 rating, uint32 weeklyGames, uint32 weeklyWins).
+		bool WriteTeamSummary(ByteWriter& w, const ArenaTeamSummary& t)
+		{
+			if (!w.WriteU32(t.teamId))                  return false;
+			if (!w.WriteBytes(&t.size, 1u))             return false;
+			if (!w.WriteString(t.name))                 return false;
+			if (!w.WriteU32(t.rating))                  return false;
+			if (!w.WriteU32(t.weeklyGames))             return false;
+			if (!w.WriteU32(t.weeklyWins))              return false;
+			return true;
+		}
+
+		/// Lit un ArenaTeamSummary.
+		bool ReadTeamSummary(ByteReader& r, ArenaTeamSummary& out)
+		{
+			if (!r.ReadU32(out.teamId))                 return false;
+			uint8_t sizeByte = 0;
+			if (!r.ReadBytes(&sizeByte, 1u))            return false;
+			out.size = sizeByte;
+			if (!r.ReadString(out.name))                return false;
+			if (!r.ReadU32(out.rating))                 return false;
+			if (!r.ReadU32(out.weeklyGames))            return false;
+			if (!r.ReadU32(out.weeklyWins))             return false;
+			return true;
+		}
+
+		/// Serialise le body d'un MATCH_PROPOSAL_NOTIFICATION (proposalId,
+		/// opponentTeamName, opponentRating).
+		bool WriteMatchProposalBody(ByteWriter& w, uint32_t proposalId,
+			const std::string& opponentTeamName, uint32_t opponentRating)
+		{
+			if (!w.WriteU32(proposalId))                return false;
+			if (!w.WriteString(opponentTeamName))       return false;
+			if (!w.WriteU32(opponentRating))            return false;
+			return true;
+		}
+
+		/// Serialise le body d'un MATCH_RESULT_NOTIFICATION (win, oldRating,
+		/// newRating, opponentName).
+		bool WriteMatchResultBody(ByteWriter& w, bool win, uint32_t oldRating,
+			uint32_t newRating, const std::string& opponentName)
+		{
+			const uint8_t winByte = win ? 1u : 0u;
+			if (!w.WriteBytes(&winByte, 1u))            return false;
+			if (!w.WriteU32(oldRating))                 return false;
+			if (!w.WriteU32(newRating))                 return false;
+			if (!w.WriteString(opponentName))           return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_TEAM_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaTeamListRequestPayload> ParseArenaTeamListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return ArenaTeamListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildArenaTeamListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_TEAM_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaTeamListResponsePayload> ParseArenaTeamListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaTeamListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		// Si error == 0, lire count + entries.
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.teams.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			ArenaTeamSummary t;
+			if (!ReadTeamSummary(r, t)) return std::nullopt;
+			out.teams.push_back(std::move(t));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaTeamListResponsePayload(uint8_t error, const std::vector<ArenaTeamSummary>& teams)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(teams.size()))) return {};
+			for (const auto& t : teams)
+			{
+				if (!WriteTeamSummary(w, t)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaTeamListResponsePacket(uint8_t error, const std::vector<ArenaTeamSummary>& teams,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(teams.size()))) return {};
+			for (const auto& t : teams)
+			{
+				if (!WriteTeamSummary(w, t)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeArenaTeamListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_QUEUE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaQueueRequestPayload> ParseArenaQueueRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 teamId (4) + uint8 size (1) = 5.
+		if (!payload || payloadSize < 5u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaQueueRequestPayload out;
+		if (!r.ReadU32(out.teamId)) return std::nullopt;
+		uint8_t sizeByte = 0;
+		if (!r.ReadBytes(&sizeByte, 1u)) return std::nullopt;
+		out.size = sizeByte;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaQueueRequestPayload(uint32_t teamId, uint8_t size)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(teamId))         return {};
+		if (!w.WriteBytes(&size, 1u))    return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_QUEUE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaQueueResponsePayload> ParseArenaQueueResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaQueueResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		if (!r.ReadU32(out.estimatedWaitSec)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaQueueResponsePayload(uint8_t error, uint32_t estimatedWaitSec)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaQueueResponsePacket(uint8_t error, uint32_t estimatedWaitSec,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeArenaQueueResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_LEAVE_QUEUE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaLeaveQueueRequestPayload> ParseArenaLeaveQueueRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		return ArenaLeaveQueueRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildArenaLeaveQueueRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_LEAVE_QUEUE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaLeaveQueueResponsePayload> ParseArenaLeaveQueueResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaLeaveQueueResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaLeaveQueueResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaLeaveQueueResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeArenaLeaveQueueResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_MATCH_PROPOSAL_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaMatchProposalNotificationPayload> ParseArenaMatchProposalNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 proposalId (4) + uint16 strLen (2) + uint32 rating (4) = 10.
+		if (!payload || payloadSize < 10u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaMatchProposalNotificationPayload out;
+		if (!r.ReadU32(out.proposalId))           return std::nullopt;
+		if (!r.ReadString(out.opponentTeamName))  return std::nullopt;
+		if (!r.ReadU32(out.opponentRating))       return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchProposalNotificationPayload(uint32_t proposalId,
+		const std::string& opponentTeamName, uint32_t opponentRating)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteMatchProposalBody(w, proposalId, opponentTeamName, opponentRating)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchProposalNotificationPacket(uint32_t proposalId,
+		const std::string& opponentTeamName, uint32_t opponentRating, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteMatchProposalBody(w, proposalId, opponentTeamName, opponentRating)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeArenaMatchProposalNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_MATCH_ACCEPT — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaMatchAcceptRequestPayload> ParseArenaMatchAcceptRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 proposalId (4) + uint8 accept (1) = 5.
+		if (!payload || payloadSize < 5u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaMatchAcceptRequestPayload out;
+		if (!r.ReadU32(out.proposalId)) return std::nullopt;
+		uint8_t acceptByte = 0;
+		if (!r.ReadBytes(&acceptByte, 1u)) return std::nullopt;
+		out.accept = (acceptByte != 0u);
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchAcceptRequestPayload(uint32_t proposalId, bool accept)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(proposalId))         return {};
+		const uint8_t acceptByte = accept ? 1u : 0u;
+		if (!w.WriteBytes(&acceptByte, 1u))  return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_MATCH_ACCEPT — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaMatchAcceptResponsePayload> ParseArenaMatchAcceptResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaMatchAcceptResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchAcceptResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchAcceptResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeArenaMatchAcceptResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// ARENA_MATCH_RESULT_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaMatchResultNotificationPayload> ParseArenaMatchResultNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 win (1) + uint32 oldRating (4) + uint32 newRating (4) + uint16 strLen (2) = 11.
+		if (!payload || payloadSize < 11u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ArenaMatchResultNotificationPayload out;
+		uint8_t winByte = 0;
+		if (!r.ReadBytes(&winByte, 1u))      return std::nullopt;
+		out.win = (winByte != 0u);
+		if (!r.ReadU32(out.oldRating))       return std::nullopt;
+		if (!r.ReadU32(out.newRating))       return std::nullopt;
+		if (!r.ReadString(out.opponentName)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchResultNotificationPayload(bool win, uint32_t oldRating,
+		uint32_t newRating, const std::string& opponentName)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteMatchResultBody(w, win, oldRating, newRating, opponentName)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildArenaMatchResultNotificationPacket(bool win, uint32_t oldRating,
+		uint32_t newRating, const std::string& opponentName, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteMatchResultBody(w, win, oldRating, newRating, opponentName)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeArenaMatchResultNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/ArenaPayloads.h
+++ b/src/shared/network/ArenaPayloads.h
@@ -1,0 +1,227 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4) — Wire payloads pour les opcodes Arena
+// (120-129). 4 paires Request/Response + 2 push :
+//   - TeamList                        (120/121)
+//   - Queue                           (122/123)
+//   - LeaveQueue                      (124/125)
+//   - MatchProposalNotification       (126 push) : push Master to Client
+//     annonce qu'un match a ete forme.
+//   - MatchAccept                     (127/128)  : ACK accept/reject.
+//   - MatchResultNotification         (129 push) : push Master to Client
+//     annonce le resultat d'un match (win/loss + ELO update).
+//
+// Le ArenaTeamRegistry est garde cote master uniquement en V1 (pas de DB) :
+// au reboot, les teams seedees + queue + proposals sont perdus. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Toutes les strings
+// passent par WriteString/ReadString (uint16 length + UTF-8 bytes), et
+// toutes les arrays par WriteArrayCount/ReadArrayCount (uint16 count).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Arena.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Arena. 0 = OK.
+	enum class ArenaErrorCode : uint8_t
+	{
+		Ok               = 0,
+		AlreadyQueued    = 1, ///< Le compte est deja inscrit dans une queue arena.
+		TeamNotFound     = 2, ///< teamId inconnu pour ce compte.
+		InvalidSize      = 3, ///< size hors {2, 3, 5}.
+		NotInQueue       = 4, ///< Pas inscrit dans une queue arena (LeaveQueue).
+		ProposalExpired  = 5, ///< Le proposal a expire (timeout 30s) — MatchAccept.
+		UnknownProposal  = 6, ///< proposalId inconnu cote master — MatchAccept.
+		Unauthorized     = 7, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// ARENA_TEAM_LIST — Client to Master : liste des arena teams du compte.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct ArenaTeamListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Resume d'une arena team pour le wire (mirror partiel d'arena::ArenaTeam).
+	/// Wire format :
+	///   uint32 teamId
+	///   uint8  size           (2, 3 ou 5)
+	///   string name           (uint16 length + UTF-8)
+	///   uint32 rating
+	///   uint32 weeklyGames
+	///   uint32 weeklyWins
+	struct ArenaTeamSummary
+	{
+		uint32_t    teamId       = 0;
+		uint8_t     size         = 2; ///< 2 / 3 / 5.
+		std::string name;
+		uint32_t    rating       = 1500;
+		uint32_t    weeklyGames  = 0;
+		uint32_t    weeklyWins   = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error           (cf. ArenaErrorCode)
+	///   uint16 count            (si error == 0)
+	///   <count> ArenaTeamSummary
+	struct ArenaTeamListResponsePayload
+	{
+		uint8_t                       error = 0;
+		std::vector<ArenaTeamSummary> teams;
+	};
+
+	// =========================================================================
+	// ARENA_QUEUE — Client to Master : inscription a la queue arena.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 teamId
+	///   uint8  size            (2, 3 ou 5)
+	struct ArenaQueueRequestPayload
+	{
+		uint32_t teamId = 0;
+		uint8_t  size   = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error             (cf. ArenaErrorCode)
+	///   uint32 estimatedWaitSec  (si error == 0)
+	struct ArenaQueueResponsePayload
+	{
+		uint8_t  error            = 0;
+		uint32_t estimatedWaitSec = 0;
+	};
+
+	// =========================================================================
+	// ARENA_LEAVE_QUEUE — Client to Master : quitte la queue arena.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account derive de la session cote master.
+	struct ArenaLeaveQueueRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct ArenaLeaveQueueResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// ARENA_MATCH_PROPOSAL_NOTIFICATION — Master to Client (push, requestId=0).
+	// Annonce qu'un match a ete forme : opponent (V1 : AI fictive) et rating
+	// adverse. Le client doit confirmer via MatchAccept (accept=true|false).
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 proposalId
+	///   string opponentTeamName  (uint16 length + UTF-8)
+	///   uint32 opponentRating
+	struct ArenaMatchProposalNotificationPayload
+	{
+		uint32_t    proposalId       = 0;
+		std::string opponentTeamName;
+		uint32_t    opponentRating   = 0;
+	};
+
+	// =========================================================================
+	// ARENA_MATCH_ACCEPT — Client to Master : accepte ou rejette une proposal.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 proposalId
+	///   uint8  accept            (0 = reject, 1 = accept ; serialise via uint8)
+	struct ArenaMatchAcceptRequestPayload
+	{
+		uint32_t proposalId = 0;
+		bool     accept     = false;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct ArenaMatchAcceptResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// ARENA_MATCH_RESULT_NOTIFICATION — Master to Client (push, requestId=0).
+	// Annonce le resultat du match avec le nouveau rating ELO.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint8  win                (0 = loss, 1 = win)
+	///   uint32 oldRating
+	///   uint32 newRating
+	///   string opponentName       (uint16 length + UTF-8)
+	struct ArenaMatchResultNotificationPayload
+	{
+		bool        win        = false;
+		uint32_t    oldRating  = 0;
+		uint32_t    newRating  = 0;
+		std::string opponentName;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaTeamListRequestPayload>      ParseArenaTeamListRequestPayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaQueueRequestPayload>         ParseArenaQueueRequestPayload        (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaLeaveQueueRequestPayload>    ParseArenaLeaveQueueRequestPayload   (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaMatchAcceptRequestPayload>   ParseArenaMatchAcceptRequestPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildArenaTeamListRequestPayload();
+	std::vector<uint8_t> BuildArenaQueueRequestPayload(uint32_t teamId, uint8_t size);
+	std::vector<uint8_t> BuildArenaLeaveQueueRequestPayload();
+	std::vector<uint8_t> BuildArenaMatchAcceptRequestPayload(uint32_t proposalId, bool accept);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<ArenaTeamListResponsePayload>             ParseArenaTeamListResponsePayload          (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaQueueResponsePayload>                ParseArenaQueueResponsePayload             (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaLeaveQueueResponsePayload>           ParseArenaLeaveQueueResponsePayload        (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaMatchProposalNotificationPayload>    ParseArenaMatchProposalNotificationPayload (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaMatchAcceptResponsePayload>          ParseArenaMatchAcceptResponsePayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<ArenaMatchResultNotificationPayload>      ParseArenaMatchResultNotificationPayload   (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildArenaTeamListResponsePayload          (uint8_t error, const std::vector<ArenaTeamSummary>& teams);
+	std::vector<uint8_t> BuildArenaQueueResponsePayload             (uint8_t error, uint32_t estimatedWaitSec);
+	std::vector<uint8_t> BuildArenaLeaveQueueResponsePayload        (uint8_t error);
+	std::vector<uint8_t> BuildArenaMatchProposalNotificationPayload (uint32_t proposalId, const std::string& opponentTeamName, uint32_t opponentRating);
+	std::vector<uint8_t> BuildArenaMatchAcceptResponsePayload       (uint8_t error);
+	std::vector<uint8_t> BuildArenaMatchResultNotificationPayload   (bool win, uint32_t oldRating, uint32_t newRating, const std::string& opponentName);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildArenaTeamListResponsePacket          (uint8_t error, const std::vector<ArenaTeamSummary>& teams,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildArenaQueueResponsePacket             (uint8_t error, uint32_t estimatedWaitSec,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildArenaLeaveQueueResponsePacket        (uint8_t error,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildArenaMatchAcceptResponsePacket       (uint8_t error,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildArenaMatchProposalNotificationPacket (uint32_t proposalId, const std::string& opponentTeamName, uint32_t opponentRating,
+	                                                                 uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildArenaMatchResultNotificationPacket   (bool win, uint32_t oldRating, uint32_t newRating, const std::string& opponentName,
+	                                                                 uint64_t sessionIdHeader);
+}

--- a/src/shared/network/ArenaPayloadsTests.cpp
+++ b/src/shared/network/ArenaPayloadsTests.cpp
@@ -1,0 +1,438 @@
+/**
+ * CMANGOS.21 (Phase 5.21 step 3+4) — Round-trip tests for ARENA_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/ArenaPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// ARENA_TEAM_LIST
+// -----------------------------------------------------------------------------
+
+static void TestTeamListRequestRoundTrip()
+{
+	auto buf = BuildArenaTeamListRequestPayload();
+	Assert(buf.empty(), "TeamList request payload empty");
+	auto parsed = ParseArenaTeamListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "TeamList request accepts empty payload");
+}
+
+static void TestTeamListResponseEmpty()
+{
+	auto buf = BuildArenaTeamListResponsePayload(0u, {});
+	auto parsed = ParseArenaTeamListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->teams.empty(),
+		"TeamList response empty parses");
+}
+
+static void TestTeamListResponseFull()
+{
+	std::vector<ArenaTeamSummary> teams;
+	teams.push_back({1u, 2u, "LCDLLN A", 1500u, 0u, 0u});
+	teams.push_back({2u, 3u, "LCDLLN B", 1700u, 5u, 3u});
+	teams.push_back({3u, 5u, "LCDLLN C", 1500u, 0u, 0u});
+	auto buf = BuildArenaTeamListResponsePayload(0u, teams);
+	auto parsed = ParseArenaTeamListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "TeamList response full parses");
+	if (parsed && parsed->teams.size() == 3u)
+	{
+		Assert(parsed->teams[0].teamId == 1u, "Team 1 id");
+		Assert(parsed->teams[0].size == 2u, "Team 1 size 2");
+		Assert(parsed->teams[0].name == "LCDLLN A", "Team 1 name");
+		Assert(parsed->teams[0].rating == 1500u, "Team 1 rating");
+		Assert(parsed->teams[1].size == 3u, "Team 2 size 3");
+		Assert(parsed->teams[1].rating == 1700u, "Team 2 rating");
+		Assert(parsed->teams[1].weeklyGames == 5u, "Team 2 weeklyGames");
+		Assert(parsed->teams[1].weeklyWins == 3u, "Team 2 weeklyWins");
+		Assert(parsed->teams[2].size == 5u, "Team 3 size 5");
+	}
+	else
+	{
+		Assert(false, "TeamList should have 3 teams");
+	}
+}
+
+static void TestTeamListResponseError()
+{
+	auto buf = BuildArenaTeamListResponsePayload(
+		static_cast<uint8_t>(ArenaErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "TeamList error has only 1 byte");
+	auto parsed = ParseArenaTeamListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 7u, "TeamList Unauthorized");
+}
+
+static void TestTeamListResponseRejectsShort()
+{
+	auto parsed = ParseArenaTeamListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "TeamList rejects nullptr");
+}
+
+static void TestTeamListResponsePacket()
+{
+	std::vector<ArenaTeamSummary> teams;
+	teams.push_back({42u, 3u, "Test", 2000u, 10u, 7u});
+	auto pkt = BuildArenaTeamListResponsePacket(0u, teams, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "TeamList packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"TeamList PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaTeamListResponse, "Opcode is ArenaTeamListResponse");
+	Assert(view.RequestId() == 999u, "TeamList RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "TeamList SessionId preserved");
+	auto parsed = ParseArenaTeamListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->teams.size() == 1u
+		&& parsed->teams[0].teamId == 42u && parsed->teams[0].name == "Test",
+		"TeamList payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// ARENA_QUEUE
+// -----------------------------------------------------------------------------
+
+static void TestQueueRequestRoundTrip()
+{
+	auto buf = BuildArenaQueueRequestPayload(7u, 3u);
+	Assert(buf.size() == 5u, "Queue request payload size 5");
+	auto parsed = ParseArenaQueueRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Queue request parses");
+	if (parsed)
+	{
+		Assert(parsed->teamId == 7u, "Queue teamId 7");
+		Assert(parsed->size == 3u, "Queue size 3");
+	}
+}
+
+static void TestQueueRequestBoundary()
+{
+	// size=2 valide.
+	auto buf2 = BuildArenaQueueRequestPayload(0xFFFFFFFFu, 2u);
+	auto parsed2 = ParseArenaQueueRequestPayload(buf2.data(), buf2.size());
+	Assert(parsed2.has_value() && parsed2->teamId == 0xFFFFFFFFu && parsed2->size == 2u,
+		"Queue boundary: teamId max + size 2");
+	// size=5 valide.
+	auto buf5 = BuildArenaQueueRequestPayload(1u, 5u);
+	auto parsed5 = ParseArenaQueueRequestPayload(buf5.data(), buf5.size());
+	Assert(parsed5.has_value() && parsed5->size == 5u, "Queue boundary: size 5");
+	// size=0 (invalide cote handler mais wire l'accepte).
+	auto buf0 = BuildArenaQueueRequestPayload(1u, 0u);
+	auto parsed0 = ParseArenaQueueRequestPayload(buf0.data(), buf0.size());
+	Assert(parsed0.has_value() && parsed0->size == 0u, "Queue wire accepts size 0");
+}
+
+static void TestQueueRequestRejectsShort()
+{
+	auto parsed = ParseArenaQueueRequestPayload(nullptr, 5u);
+	Assert(!parsed.has_value(), "Queue request rejects nullptr");
+	uint8_t shortBuf[4]{};
+	auto parsed2 = ParseArenaQueueRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Queue request rejects 4 bytes");
+}
+
+static void TestQueueResponseOk()
+{
+	auto buf = BuildArenaQueueResponsePayload(0u, 30u);
+	Assert(buf.size() == 5u, "Queue response Ok size 5");
+	auto parsed = ParseArenaQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->estimatedWaitSec == 30u,
+		"Queue response Ok parses");
+}
+
+static void TestQueueResponseError()
+{
+	auto buf = BuildArenaQueueResponsePayload(
+		static_cast<uint8_t>(ArenaErrorCode::AlreadyQueued), 0u);
+	Assert(buf.size() == 1u, "Queue response error has only 1 byte");
+	auto parsed = ParseArenaQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Queue response AlreadyQueued");
+}
+
+static void TestQueueResponsePacket()
+{
+	auto pkt = BuildArenaQueueResponsePacket(0u, 60u, 12345u, 0xBEEFull);
+	Assert(!pkt.empty(), "Queue packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Queue PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaQueueResponse, "Opcode is ArenaQueueResponse");
+	Assert(view.RequestId() == 12345u, "Queue RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// ARENA_LEAVE_QUEUE
+// -----------------------------------------------------------------------------
+
+static void TestLeaveQueueRequestRoundTrip()
+{
+	auto buf = BuildArenaLeaveQueueRequestPayload();
+	Assert(buf.empty(), "LeaveQueue request payload empty");
+	auto parsed = ParseArenaLeaveQueueRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "LeaveQueue accepts empty payload");
+}
+
+static void TestLeaveQueueResponseOk()
+{
+	auto buf = BuildArenaLeaveQueueResponsePayload(0u);
+	Assert(buf.size() == 1u, "LeaveQueue response Ok size 1");
+	auto parsed = ParseArenaLeaveQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "LeaveQueue Ok parses");
+}
+
+static void TestLeaveQueueResponseNotInQueue()
+{
+	auto buf = BuildArenaLeaveQueueResponsePayload(
+		static_cast<uint8_t>(ArenaErrorCode::NotInQueue));
+	auto parsed = ParseArenaLeaveQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 4u, "LeaveQueue NotInQueue");
+}
+
+static void TestLeaveQueueResponsePacket()
+{
+	auto pkt = BuildArenaLeaveQueueResponsePacket(0u, 99u, 0xFEEDull);
+	Assert(!pkt.empty(), "LeaveQueue packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"LeaveQueue PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaLeaveQueueResponse, "Opcode is ArenaLeaveQueueResponse");
+	Assert(view.RequestId() == 99u, "LeaveQueue RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// ARENA_MATCH_PROPOSAL_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMatchProposalRoundTrip()
+{
+	auto buf = BuildArenaMatchProposalNotificationPayload(123u, "AI Team Alpha", 1500u);
+	auto parsed = ParseArenaMatchProposalNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MatchProposal parses");
+	if (parsed)
+	{
+		Assert(parsed->proposalId == 123u, "Proposal id 123");
+		Assert(parsed->opponentTeamName == "AI Team Alpha", "Opponent name");
+		Assert(parsed->opponentRating == 1500u, "Opponent rating");
+	}
+}
+
+static void TestMatchProposalEmptyName()
+{
+	auto buf = BuildArenaMatchProposalNotificationPayload(7u, "", 0u);
+	auto parsed = ParseArenaMatchProposalNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->opponentTeamName.empty()
+		&& parsed->proposalId == 7u, "MatchProposal empty name");
+}
+
+static void TestMatchProposalLargeRating()
+{
+	auto buf = BuildArenaMatchProposalNotificationPayload(0xDEADBEEFu, "X", 3000u);
+	auto parsed = ParseArenaMatchProposalNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->proposalId == 0xDEADBEEFu
+		&& parsed->opponentRating == 3000u, "MatchProposal large rating");
+}
+
+static void TestMatchProposalRejectsShort()
+{
+	auto parsed = ParseArenaMatchProposalNotificationPayload(nullptr, 10u);
+	Assert(!parsed.has_value(), "MatchProposal rejects nullptr");
+	uint8_t shortBuf[9]{};
+	auto parsed2 = ParseArenaMatchProposalNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchProposal rejects 9 bytes");
+}
+
+static void TestMatchProposalPacket()
+{
+	auto pkt = BuildArenaMatchProposalNotificationPacket(42u, "Beta", 1800u, 0xC0DEull);
+	Assert(!pkt.empty(), "MatchProposal packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MatchProposal PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaMatchProposalNotification, "Opcode is MatchProposal");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xC0DEull, "MatchProposal SessionId preserved");
+	auto parsed = ParseArenaMatchProposalNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->proposalId == 42u
+		&& parsed->opponentTeamName == "Beta" && parsed->opponentRating == 1800u,
+		"MatchProposal payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// ARENA_MATCH_ACCEPT
+// -----------------------------------------------------------------------------
+
+static void TestMatchAcceptRequestRoundTrip()
+{
+	auto buf = BuildArenaMatchAcceptRequestPayload(99u, true);
+	Assert(buf.size() == 5u, "MatchAccept request size 5");
+	auto parsed = ParseArenaMatchAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MatchAccept request parses");
+	if (parsed)
+	{
+		Assert(parsed->proposalId == 99u, "MatchAccept proposalId");
+		Assert(parsed->accept == true, "MatchAccept accept true");
+	}
+}
+
+static void TestMatchAcceptRequestReject()
+{
+	auto buf = BuildArenaMatchAcceptRequestPayload(0xDEADu, false);
+	auto parsed = ParseArenaMatchAcceptRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->accept == false, "MatchAccept reject");
+}
+
+static void TestMatchAcceptRequestRejectsShort()
+{
+	auto parsed = ParseArenaMatchAcceptRequestPayload(nullptr, 5u);
+	Assert(!parsed.has_value(), "MatchAccept rejects nullptr");
+	uint8_t shortBuf[4]{};
+	auto parsed2 = ParseArenaMatchAcceptRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchAccept rejects 4 bytes");
+}
+
+static void TestMatchAcceptResponseOk()
+{
+	auto buf = BuildArenaMatchAcceptResponsePayload(0u);
+	Assert(buf.size() == 1u, "MatchAccept response Ok size 1");
+	auto parsed = ParseArenaMatchAcceptResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "MatchAccept response Ok");
+}
+
+static void TestMatchAcceptResponseExpired()
+{
+	auto buf = BuildArenaMatchAcceptResponsePayload(
+		static_cast<uint8_t>(ArenaErrorCode::ProposalExpired));
+	auto parsed = ParseArenaMatchAcceptResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 5u, "MatchAccept ProposalExpired");
+}
+
+static void TestMatchAcceptResponsePacket()
+{
+	auto pkt = BuildArenaMatchAcceptResponsePacket(0u, 7u, 0xABCDull);
+	Assert(!pkt.empty(), "MatchAccept response packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MatchAccept PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaMatchAcceptResponse, "Opcode is MatchAcceptResponse");
+}
+
+// -----------------------------------------------------------------------------
+// ARENA_MATCH_RESULT_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMatchResultWin()
+{
+	auto buf = BuildArenaMatchResultNotificationPayload(true, 1500u, 1512u, "AI Team Alpha");
+	auto parsed = ParseArenaMatchResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MatchResult win parses");
+	if (parsed)
+	{
+		Assert(parsed->win == true, "MatchResult win true");
+		Assert(parsed->oldRating == 1500u, "MatchResult oldRating");
+		Assert(parsed->newRating == 1512u, "MatchResult newRating");
+		Assert(parsed->opponentName == "AI Team Alpha", "MatchResult opponent name");
+	}
+}
+
+static void TestMatchResultLoss()
+{
+	auto buf = BuildArenaMatchResultNotificationPayload(false, 1500u, 1488u, "AI Team Beta");
+	auto parsed = ParseArenaMatchResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->win == false
+		&& parsed->newRating == 1488u && parsed->oldRating == 1500u,
+		"MatchResult loss");
+}
+
+static void TestMatchResultRejectsShort()
+{
+	auto parsed = ParseArenaMatchResultNotificationPayload(nullptr, 11u);
+	Assert(!parsed.has_value(), "MatchResult rejects nullptr");
+	uint8_t shortBuf[10]{};
+	auto parsed2 = ParseArenaMatchResultNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchResult rejects 10 bytes");
+}
+
+static void TestMatchResultPacket()
+{
+	auto pkt = BuildArenaMatchResultNotificationPacket(true, 1500u, 1532u, "Gamma", 0xFADEull);
+	Assert(!pkt.empty(), "MatchResult packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MatchResult PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeArenaMatchResultNotification, "Opcode is MatchResultNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xFADEull, "MatchResult SessionId preserved");
+	auto parsed = ParseArenaMatchResultNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->win == true && parsed->newRating == 1532u
+		&& parsed->opponentName == "Gamma", "MatchResult payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestTeamListRequestRoundTrip();
+	TestTeamListResponseEmpty();
+	TestTeamListResponseFull();
+	TestTeamListResponseError();
+	TestTeamListResponseRejectsShort();
+	TestTeamListResponsePacket();
+
+	TestQueueRequestRoundTrip();
+	TestQueueRequestBoundary();
+	TestQueueRequestRejectsShort();
+	TestQueueResponseOk();
+	TestQueueResponseError();
+	TestQueueResponsePacket();
+
+	TestLeaveQueueRequestRoundTrip();
+	TestLeaveQueueResponseOk();
+	TestLeaveQueueResponseNotInQueue();
+	TestLeaveQueueResponsePacket();
+
+	TestMatchProposalRoundTrip();
+	TestMatchProposalEmptyName();
+	TestMatchProposalLargeRating();
+	TestMatchProposalRejectsShort();
+	TestMatchProposalPacket();
+
+	TestMatchAcceptRequestRoundTrip();
+	TestMatchAcceptRequestReject();
+	TestMatchAcceptRequestRejectsShort();
+	TestMatchAcceptResponseOk();
+	TestMatchAcceptResponseExpired();
+	TestMatchAcceptResponsePacket();
+
+	TestMatchResultWin();
+	TestMatchResultLoss();
+	TestMatchResultRejectsShort();
+	TestMatchResultPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all arena payload tests passed\n"
+	                                : "[FAIL] some arena tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -457,4 +457,46 @@ namespace engine::network
 	constexpr uint16_t kOpcodeSkillUseRequest          = 117u; ///< Client to Master : utilise un skill non-combat (lockpicking, fishing).
 	constexpr uint16_t kOpcodeSkillUseResponse         = 118u; ///< Master to Client : OK + result + delta value, ou SkillNotLearned / SkillFailed / Unauthorized.
 	constexpr uint16_t kOpcodeSkillUpgradeNotification = 119u; ///< Master to Client (push, request_id=0) : skill upgrade (skillId, newValue, newCap, delta).
+
+	// -------------------------------------------------------------------------
+	// Opcodes Arena (valeurs 120-129)
+	// Reference : Phase 5 CMANGOS.21 step 3+4. Wire client<->master pour le
+	// systeme d'arenes (queue 2v2/3v3/5v5, match proposal, result push avec
+	// rating ELO). Le step 1+2 (ArenaTeam + ArenaTeamRegistry header-only avec
+	// ApplyEloUpdate / RecordMatch / ResetWeekly) est deja merge.
+	//
+	// Architecture : le master tient en memoire un ArenaTeamRegistry (V1, seed
+	// hardcode par account au premier acces : 3 teams 2v2/3v3/5v5 a rating 1500)
+	// + une queue par account + un map de proposals actifs. Quand un account
+	// rejoint la queue, le master cree immediatement un proposal contre une AI
+	// fictive ("AI Team Alpha" rating 1500) et push une notification (V1).
+	//
+	// V1 limitations :
+	//   - Seed teams hardcode par account (3 teams 2v2/3v3/5v5). Vraie creation
+	//     via CMANGOS.41 (Trainers + ArenaTeam create UI).
+	//   - Match contre AI Team Alpha fictif ; vrai pairing 2 accounts a venir.
+	//   - Result win/loss random 50% (V1) ; vraie simulation match a venir.
+	//   - Pas de SyncArena RPC entre master et shardd (master autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - TeamList   (120/121)  : le client demande la liste de ses arena teams.
+	//   - Queue      (122/123)  : inscription en queue (teamId + size 2/3/5).
+	//   - LeaveQueue (124/125)  : quitte la queue.
+	//   - MatchProposalNotification (126, push) : un match a ete forme
+	//     (proposalId, opponentTeamName, opponentRating).
+	//   - MatchAccept (127/128) : accepte ou rejette un match propose.
+	//   - MatchResultNotification (129, push) : fin de match (win, oldRating,
+	//     newRating, opponentName).
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeArenaTeamListRequest           = 120u; ///< Client to Master : liste des arena teams (vide).
+	constexpr uint16_t kOpcodeArenaTeamListResponse          = 121u; ///< Master to Client : liste {teamId, size, name, rating, weeklyGames, weeklyWins} ou Unauthorized.
+	constexpr uint16_t kOpcodeArenaQueueRequest              = 122u; ///< Client to Master : s'inscrit en queue arena (teamId + size 2/3/5).
+	constexpr uint16_t kOpcodeArenaQueueResponse             = 123u; ///< Master to Client : OK + estimatedWaitSec, ou AlreadyQueued / TeamNotFound / InvalidSize / Unauthorized.
+	constexpr uint16_t kOpcodeArenaLeaveQueueRequest         = 124u; ///< Client to Master : quitte la queue arena.
+	constexpr uint16_t kOpcodeArenaLeaveQueueResponse        = 125u; ///< Master to Client : OK ou NotInQueue / Unauthorized.
+	constexpr uint16_t kOpcodeArenaMatchProposalNotification = 126u; ///< Master to Client (push, request_id=0) : un match a ete forme (proposalId, opponentTeamName, opponentRating).
+	constexpr uint16_t kOpcodeArenaMatchAcceptRequest        = 127u; ///< Client to Master : accepte (true) ou rejette (false) le match propose (proposalId + accept bool).
+	constexpr uint16_t kOpcodeArenaMatchAcceptResponse       = 128u; ///< Master to Client : ACK Ok ou ProposalExpired / UnknownProposal / Unauthorized.
+	constexpr uint16_t kOpcodeArenaMatchResultNotification   = 129u; ///< Master to Client (push, request_id=0) : fin de match (win bool, oldRating, newRating, opponentName).
 }


### PR DESCRIPTION
## Phase 5 — CMANGOS.21 step 3+4 : Arena wire (queue + match proposal + result push + UI)

Branche `ArenaTeam` (step 1+2 merge — ELO + Match history + Weekly stats) sur le wire queue/proposal/result + UI client.
Master tient en mémoire `ArenaTeamRegistry` (seed V1 hardcodé) + queue + proposals,
pousse une match proposal après queue puis un result avec ELO update.

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 10 opcodes (120-129)
  - `120/121` ArenaTeamList Request/Response
  - `122/123` ArenaQueue Request/Response
  - `124/125` ArenaLeaveQueue Request/Response
  - `126` ArenaMatchProposalNotification (push)
  - `127/128` ArenaMatchAccept Request/Response
  - `129` ArenaMatchResultNotification (push)
- `src/shared/network/ArenaPayloads.{h,cpp,Tests.cpp}` : 30 round-trip + edge cases
- `src/masterd/handlers/arena/ArenaHandler.{h,cpp}` :
  - `ArenaTeamRegistry` seedé par-account (3 teams 2v2/3v3/5v5)
  - Queue map + Proposal map (mutex protégé)
  - `PushMatchProposal` + `PushMatchResult` helpers publics
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 120/122/124/127

### Client integration
- `src/client/arena/ArenaUi.{h,cpp}` : presenter + state (teams, queue, pending proposal, last result)
- `src/client/render/ArenaImGuiRenderer.{h,cpp}` : panel ImGui (table teams + Queue/Leave) + popup proposal (Accept/Refuse) + toast result
- `src/client/app/Engine` : dispatch + slash `/arena` + touche `A` toggle (gardé par chat blocks + pause + editor + auth flow)
- `CMakeLists.txt` : sources + `arena_payloads_tests` target

### V1 limitations (consignées)
- Seed teams hardcodé par account (3 teams 2v2/3v3/5v5). Vraie création via CMANGOS.41 (Trainers + ArenaTeam create UI).
- Match contre AI Team Alpha fictif (V1) ; vrai pairing 2-accounts à venir.
- Result win/loss random 50% (V1) ; vraie simulation match à venir.
- Pas de SyncArena RPC entre master et shardd (master autoritaire V1).
- TeamIds 1/2/3 collisionnent entre accounts (acceptable V1 ; futur `MysqlArenaStore` avec IDs globalement uniques).

### Tests
- `arena_payloads_tests` (30 tests : round-trip, headers, boundaries, error codes, win/loss results) — voir `src/shared/network/ArenaPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 120-129 + handler ArenaHandler + queue/proposal/result logic. Sans redéploiement, les requests Arena d'un client neuf retourneraient BAD_REQUEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)