### PR TITLE
feat(battleground): wire queue + match flow + UI client (Phase 5 CMANGOS.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ add_library(engine_core
   src/client/gmtickets/GmTicketUi.cpp
   src/client/reputation/ReputationUi.cpp
   src/client/arena/ArenaUi.cpp
+  src/client/battleground/BattleGroundUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -341,6 +342,7 @@ add_library(engine_core
   src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/ReputationImGuiRenderer.cpp
   src/client/render/ArenaImGuiRenderer.cpp
+  src/client/render/BattleGroundImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -438,6 +440,7 @@ add_library(engine_core
   src/shared/network/GmTicketPayloads.cpp
   src/shared/network/ReputationPayloads.cpp
   src/shared/network/ArenaPayloads.cpp
+  src/shared/network/BattleGroundPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -693,6 +696,11 @@ add_test(NAME skill_payloads_tests COMMAND skill_payloads_tests)
 add_executable(arena_payloads_tests src/shared/network/ArenaPayloadsTests.cpp)
 target_link_libraries(arena_payloads_tests PRIVATE engine_core)
 add_test(NAME arena_payloads_tests COMMAND arena_payloads_tests)
+
+# CMANGOS.10 (Phase 5 step 3+4) — BattleGround payloads round-trip tests (no DB / no network).
+add_executable(battleground_payloads_tests src/shared/network/BattleGroundPayloadsTests.cpp)
+target_link_libraries(battleground_payloads_tests PRIVATE engine_core)
+add_test(NAME battleground_payloads_tests COMMAND battleground_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/cinematics/CinematicHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/skills/SkillHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/arena/ArenaHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/battleground/BattleGroundHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -133,6 +134,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/CinematicPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/SkillPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ArenaPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/BattleGroundPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -14,6 +14,7 @@
 #include "src/shared/network/GmTicketPayloads.h"
 #include "src/shared/network/ReputationPayloads.h"
 #include "src/shared/network/ArenaPayloads.h"
+#include "src/shared/network/BattleGroundPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -26,6 +27,7 @@
 #include "src/client/render/GmTicketImGuiRenderer.h"
 #include "src/client/render/ReputationImGuiRenderer.h"
 #include "src/client/render/ArenaImGuiRenderer.h"
+#include "src/client/render/BattleGroundImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -940,6 +942,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.10 (Phase 5 step 3+4) — Init du presenter BattleGround + cable
+		// du send callback pour les requetes 130/132/134/139. Reception
+		// dispatchee dans le push handler ci-dessous (responses 131/133/135
+		// + push 136/137/138).
+		if (!m_battleGroundUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] BattleGroundUiPresenter init FAILED — panneau BG desactive");
+		}
+		else
+		{
+			m_battleGroundUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1098,6 +1115,21 @@ namespace engine
 					m_arenaUi.RequestTeams();
 				}
 				LOG_INFO(Core, "[Engine] /arena toggle (visible={})", m_arenaVisible);
+				return true;
+			}
+			// CMANGOS.10 (Phase 5 step 3+4) — Slash command /bg pour ouvrir/
+			// fermer la fenetre BattleGround et synchroniser la liste depuis
+			// le master au moment de l'ouverture. La touche G fait la meme
+			// chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/bg" || text.starts_with("/bg ") || text.starts_with("/bg\t")))
+			{
+				m_battleGroundVisible = !m_battleGroundVisible;
+				if (m_battleGroundVisible)
+				{
+					m_battleGroundUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] /bg toggle (visible={})", m_battleGroundVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1534,6 +1566,74 @@ namespace engine
 					return;
 				}
 				m_arenaUi.OnMatchResultNotification(*parsed);
+				return;
+			}
+			// CMANGOS.10 (Phase 5 step 3+4) — Dispatch des reponses BattleGround
+			// (131/133/135) + push notifications (136/137/138).
+			case kOpcodeBgListResponse:
+			{
+				auto parsed = ParseBgListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeBgQueueResponse:
+			{
+				auto parsed = ParseBgQueueResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_QUEUE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnQueueResponse(*parsed);
+				return;
+			}
+			case kOpcodeBgLeaveQueueResponse:
+			{
+				auto parsed = ParseBgLeaveQueueResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_LEAVE_QUEUE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnLeaveQueueResponse(*parsed);
+				return;
+			}
+			case kOpcodeBgMatchStartNotification:
+			{
+				auto parsed = ParseBgMatchStartNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_MATCH_START_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnMatchStartNotification(*parsed);
+				return;
+			}
+			case kOpcodeBgScoreUpdateNotification:
+			{
+				auto parsed = ParseBgScoreUpdateNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_SCORE_UPDATE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnScoreUpdateNotification(*parsed);
+				return;
+			}
+			case kOpcodeBgMatchEndNotification:
+			{
+				auto parsed = ParseBgMatchEndNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] BG_MATCH_END_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_battleGroundUi.OnMatchEndNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -3836,6 +3936,7 @@ namespace engine
 		m_cinematicUi.Shutdown();
 		m_skillBookUi.Shutdown();
 		m_arenaUi.Shutdown();
+		m_battleGroundUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -3944,6 +4045,28 @@ namespace engine
 					m_arenaUi.RequestTeams();
 				}
 				LOG_INFO(Core, "[Engine] A toggle arena (visible={})", m_arenaVisible);
+			}
+		}
+
+		// CMANGOS.10 (Phase 5 step 3+4) — Touche G post-auth toggle le panneau
+		// BattleGround (equivalent a la slash command /bg). Memes guards que
+		// la touche A (chat focus + pause + editor + auth flow).
+		{
+			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
+			const bool inGameNoMenu = !m_inGamePauseMenuVisible
+				&& !m_inGameOptionsPanelVisible
+				&& !m_editorEnabled
+				&& m_authUi.IsInitialized()
+				&& m_authUi.IsFlowComplete();
+			if (inGameNoMenu && !chatBlocks
+				&& m_input.WasPressed(engine::platform::Key::G))
+			{
+				m_battleGroundVisible = !m_battleGroundVisible;
+				if (m_battleGroundVisible)
+				{
+					m_battleGroundUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] G toggle battleground (visible={})", m_battleGroundVisible);
 			}
 		}
 
@@ -4143,6 +4266,12 @@ namespace engine
 				// formation de match.
 				m_arenaImGui = std::make_unique<engine::render::ArenaImGuiRenderer>();
 				m_arenaImGui->SetPresenter(&m_arenaUi);
+				// CMANGOS.10 (Phase 5 step 3+4) — Renderer ImGui du panneau
+				// BattleGround. Visible quand m_battleGroundVisible (toggle
+				// /bg ou touche G), ou quand un match BG est actif (le
+				// scoreboard s'auto-affiche apres le push 136 MatchStart).
+				m_battleGroundImGui = std::make_unique<engine::render::BattleGroundImGuiRenderer>();
+				m_battleGroundImGui->SetPresenter(&m_battleGroundUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5223,6 +5352,17 @@ namespace engine
 				m_arenaImGui->SetEnabled(true);
 				m_arenaImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_arenaImGui->Render();
+			}
+			// CMANGOS.10 (Phase 5 step 3+4) — Render du panneau BattleGround si
+			// visible OU si un match est actif (le scoreboard s'affiche tout
+			// seul tant que activeMatchId est set, meme si le panneau principal
+			// est masque, pour que le joueur ne rate pas le match push-pousse).
+			if (m_battleGroundImGui && m_battleGroundUi.IsInitialized()
+				&& (m_battleGroundVisible || m_battleGroundUi.GetState().activeMatchId.has_value()))
+			{
+				m_battleGroundImGui->SetEnabled(true);
+				m_battleGroundImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_battleGroundImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -13,6 +13,7 @@
 #include "src/client/gmtickets/GmTicketUi.h"
 #include "src/client/reputation/ReputationUi.h"
 #include "src/client/arena/ArenaUi.h"
+#include "src/client/battleground/BattleGroundUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -79,6 +80,7 @@ namespace engine::render
 	class CinematicImGuiRenderer;
 	class SkillBookImGuiRenderer;
 	class ArenaImGuiRenderer;
+	class BattleGroundImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -362,6 +364,12 @@ namespace engine
 		/// Visible uniquement quand m_arenaVisible (toggle via slash command
 		/// /arena ou touche A).
 		std::unique_ptr<engine::render::ArenaImGuiRenderer> m_arenaImGui;
+		/// CMANGOS.10 (Phase 5 step 3+4) — Panneau "BattleGround" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec les autres panneaux post-auth.
+		/// Visible uniquement quand m_battleGroundVisible (toggle via slash
+		/// command /bg ou touche G) ou quand un match BG est actif (le
+		/// scoreboard s'affiche tout seul, push 136).
+		std::unique_ptr<engine::render::BattleGroundImGuiRenderer> m_battleGroundImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -492,6 +500,14 @@ namespace engine
 		/// CMANGOS.21 (Phase 5.21 step 3+4) — Visibilite du panneau Arena
 		/// (toggle via slash command \c /arena ou touche A). Faux par defaut.
 		bool                                  m_arenaVisible = false;
+		/// CMANGOS.10 (Phase 5 step 3+4) — Presenter de la fenetre BattleGround.
+		/// Recoit les responses opcodes 131/133/135 et les push notifications
+		/// 136/137/138 via le push handler du master ; fire-and-forget des
+		/// requetes 130/132/134/139 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::BattleGroundUiPresenter m_battleGroundUi;
+		/// CMANGOS.10 (Phase 5 step 3+4) — Visibilite du panneau BattleGround
+		/// (toggle via slash command \c /bg ou touche G). Faux par defaut.
+		bool                                  m_battleGroundVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/battleground/BattleGroundUi.cpp
+++ b/src/client/battleground/BattleGroundUi.cpp
@@ -1,0 +1,304 @@
+// CMANGOS.10 (Phase 5 step 3+4) — Implementation BattleGroundUiPresenter.
+
+#include "src/client/battleground/BattleGroundUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	BattleGroundUiPresenter::~BattleGroundUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool BattleGroundUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[BattleGroundUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_pendingBgType  = 0;
+		m_pendingFaction = 0;
+		LOG_INFO(Core, "[BattleGroundUiPresenter] Init OK");
+		return true;
+	}
+
+	void BattleGroundUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[BattleGroundUiPresenter] Destroyed");
+	}
+
+	void BattleGroundUiPresenter::ClearQueueState()
+	{
+		m_state.inQueue          = false;
+		m_state.queuedBgType     = 0;
+		m_state.queuedFaction    = 0;
+		m_state.estimatedWaitSec = 0;
+		m_state.queuePosition    = 0;
+	}
+
+	void BattleGroundUiPresenter::ClearActiveMatch()
+	{
+		m_state.activeMatchId.reset();
+		m_state.activeMatchBgType    = 0;
+		m_state.activeMatchMap.clear();
+		m_state.activeAllianceCount  = 0;
+		m_state.activeHordeCount     = 0;
+		m_state.allianceScore        = 0;
+		m_state.hordeScore           = 0;
+		m_state.matchElapsedSec      = 0;
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void BattleGroundUiPresenter::RequestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[BattleGroundUiPresenter] RequestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildBgListRequestPayload();
+		if (!m_send(engine::network::kOpcodeBgListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste BG).";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] RequestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[BattleGroundUiPresenter] BgListRequest queued");
+	}
+
+	void BattleGroundUiPresenter::Queue(uint16_t bgType, uint8_t faction)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[BattleGroundUiPresenter] Queue: no send callback");
+			return;
+		}
+		// Validation cote client : bgType > 0, faction 0/1.
+		if (bgType == 0u)
+		{
+			m_state.lastErrorText = "BG invalide.";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] Queue: invalid bgType=0");
+			return;
+		}
+		if (faction != 0u && faction != 1u)
+		{
+			m_state.lastErrorText = "Faction invalide (Alliance/Horde attendus).";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] Queue: invalid faction={}",
+				static_cast<unsigned>(faction));
+			return;
+		}
+
+		const auto payload = engine::network::BuildBgQueueRequestPayload(bgType, faction);
+		m_pendingBgType  = bgType;
+		m_pendingFaction = faction;
+		if (!m_send(engine::network::kOpcodeBgQueueRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (queue BG).";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] Queue: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[BattleGroundUiPresenter] BgQueueRequest queued (bgType={}, faction={})",
+			static_cast<unsigned>(bgType), static_cast<unsigned>(faction));
+	}
+
+	void BattleGroundUiPresenter::LeaveQueue()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[BattleGroundUiPresenter] LeaveQueue: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildBgLeaveQueueRequestPayload();
+		if (!m_send(engine::network::kOpcodeBgLeaveQueueRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (leave queue BG).";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] LeaveQueue: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[BattleGroundUiPresenter] BgLeaveQueueRequest queued");
+	}
+
+	void BattleGroundUiPresenter::LeaveMatch()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[BattleGroundUiPresenter] LeaveMatch: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildBgLeaveMatchRequestPayload();
+		if (!m_send(engine::network::kOpcodeBgLeaveMatchRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (forfait BG).";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] LeaveMatch: send failed");
+			return;
+		}
+		// Pas de Response paire : on attend le push MatchEndNotification du
+		// master pour clear l'etat. On affiche un info transitoire en attendant.
+		m_state.lastInfoText = "Forfait demande...";
+		LOG_INFO(Net, "[BattleGroundUiPresenter] LeaveMatch sent (forfeit)");
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void BattleGroundUiPresenter::OnListResponse(const engine::network::BgListResponsePayload& resp)
+	{
+		using engine::network::BgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<BgErrorCode>(resp.error);
+			if (err == BgErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur BG inconnue.";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] OnListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.battlegrounds.clear();
+		m_state.battlegrounds.reserve(resp.battlegrounds.size());
+		for (const auto& bg : resp.battlegrounds)
+		{
+			BattleGroundInfo info;
+			info.bgType   = bg.bgType;
+			info.name     = bg.name;
+			info.teamSize = bg.teamSize;
+			info.mapName  = bg.mapName;
+			m_state.battlegrounds.push_back(std::move(info));
+		}
+		m_state.listLoaded = true;
+		LOG_INFO(Net, "[BattleGroundUiPresenter] OnListResponse OK count={}",
+			m_state.battlegrounds.size());
+	}
+
+	void BattleGroundUiPresenter::OnQueueResponse(const engine::network::BgQueueResponsePayload& resp)
+	{
+		using engine::network::BgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<BgErrorCode>(resp.error);
+			switch (err)
+			{
+			case BgErrorCode::AlreadyQueued:
+				m_state.lastErrorText = "Vous etes deja en queue ou en match.";
+				break;
+			case BgErrorCode::UnknownBg:
+				m_state.lastErrorText = "BG inconnu.";
+				break;
+			case BgErrorCode::InvalidFaction:
+				m_state.lastErrorText = "Faction invalide.";
+				break;
+			case BgErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur BG inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[BattleGroundUiPresenter] OnQueueResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.inQueue          = true;
+		m_state.queuedBgType     = m_pendingBgType;
+		m_state.queuedFaction    = m_pendingFaction;
+		m_state.estimatedWaitSec = resp.estimatedWaitSec;
+		m_state.queuePosition    = resp.queuePosition;
+		m_state.lastInfoText     = "Inscrit en queue BG.";
+		LOG_INFO(Net, "[BattleGroundUiPresenter] OnQueueResponse OK estimated={}s pos={}",
+			resp.estimatedWaitSec, resp.queuePosition);
+	}
+
+	void BattleGroundUiPresenter::OnLeaveQueueResponse(const engine::network::BgLeaveQueueResponsePayload& resp)
+	{
+		using engine::network::BgErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<BgErrorCode>(resp.error);
+			if (err == BgErrorCode::NotInQueue)
+				m_state.lastErrorText = "Vous n'etes pas en queue.";
+			else if (err == BgErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur BG inconnue.";
+			LOG_WARN(Net, "[BattleGroundUiPresenter] OnLeaveQueueResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		ClearQueueState();
+		m_state.lastInfoText = "Vous avez quitte la queue BG.";
+		LOG_INFO(Net, "[BattleGroundUiPresenter] OnLeaveQueueResponse OK");
+	}
+
+	void BattleGroundUiPresenter::OnMatchStartNotification(const engine::network::BgMatchStartNotificationPayload& note)
+	{
+		// Le master a forme le match runtime. On clear l'etat queue local
+		// pour rester en sync et on arme l'etat match actif.
+		ClearQueueState();
+		m_state.activeMatchId         = note.matchId;
+		m_state.activeMatchBgType     = note.bgType;
+		m_state.activeMatchMap        = note.mapName;
+		m_state.activeAllianceCount   = note.allianceCount;
+		m_state.activeHordeCount      = note.hordeCount;
+		m_state.allianceScore         = 0u;
+		m_state.hordeScore            = 0u;
+		m_state.matchElapsedSec       = 0u;
+		// Reset le toast result du match precedent.
+		m_state.lastMatchWinner.reset();
+		m_state.lastInfoText = "Match BG demarre !";
+		LOG_INFO(Net, "[BattleGroundUiPresenter] OnMatchStartNotification matchId={} bgType={} a={} h={}",
+			note.matchId, static_cast<unsigned>(note.bgType),
+			static_cast<unsigned>(note.allianceCount), static_cast<unsigned>(note.hordeCount));
+	}
+
+	void BattleGroundUiPresenter::OnScoreUpdateNotification(const engine::network::BgScoreUpdateNotificationPayload& note)
+	{
+		// Filtre par matchId actif (en cas de race avec un MatchEnd recu juste avant).
+		if (m_state.activeMatchId.has_value() && *m_state.activeMatchId != note.matchId)
+		{
+			LOG_DEBUG(Net, "[BattleGroundUiPresenter] OnScoreUpdate skip stale matchId={} (active={})",
+				note.matchId, *m_state.activeMatchId);
+			return;
+		}
+		m_state.allianceScore   = note.allianceScore;
+		m_state.hordeScore      = note.hordeScore;
+		m_state.matchElapsedSec = note.elapsedSec;
+		LOG_DEBUG(Net, "[BattleGroundUiPresenter] OnScoreUpdate matchId={} a={} h={} t={}s",
+			note.matchId, note.allianceScore, note.hordeScore, note.elapsedSec);
+	}
+
+	void BattleGroundUiPresenter::OnMatchEndNotification(const engine::network::BgMatchEndNotificationPayload& note)
+	{
+		// Arme le toast result transitoire avec le winner + scores + duration.
+		m_state.lastMatchWinner        = note.winnerFaction;
+		m_state.lastMatchAllianceScore = note.allianceScore;
+		m_state.lastMatchHordeScore    = note.hordeScore;
+		m_state.lastMatchDurationSec   = note.durationSec;
+		// Clear l'etat match actif : le match est termine, on retourne sur la
+		// liste BG.
+		ClearActiveMatch();
+		m_state.lastInfoText.clear();
+		LOG_INFO(Net, "[BattleGroundUiPresenter] OnMatchEndNotification matchId={} winner={} a={} h={} dur={}s",
+			note.matchId, static_cast<unsigned>(note.winnerFaction),
+			note.allianceScore, note.hordeScore, note.durationSec);
+	}
+}

--- a/src/client/battleground/BattleGroundUi.h
+++ b/src/client/battleground/BattleGroundUi.h
@@ -1,0 +1,169 @@
+#pragma once
+// CMANGOS.10 (Phase 5 step 3+4) — Presenter client de la fenetre BattleGround.
+// Maintient un cache local des battlegrounds disponibles + etat de queue +
+// scoreboard du match actif + indicateur transitoire du dernier resultat.
+//
+// Pas de rendu ImGui : le panneau est drawe par BattleGroundImGuiRenderer
+// qui lit l'etat via GetState() et propage les inputs UI (RequestList /
+// Queue / LeaveQueue / LeaveMatch) via les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans LfgUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 131/133/135/136/137/138 vers les OnXxx du presenter.
+
+#include "src/shared/network/BattleGroundPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'un battleground exposable au layer UI. Mirror direct de
+	/// engine::network::BgInfo.
+	struct BattleGroundInfo
+	{
+		uint16_t    bgType   = 0;
+		std::string name;
+		uint8_t     teamSize = 0;
+		std::string mapName;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct BattleGroundUiState
+	{
+		std::vector<BattleGroundInfo> battlegrounds;
+		bool                          listLoaded = false;
+
+		/// True si l'account est inscrit dans une queue BG (ou en match).
+		bool     inQueue           = false;
+		uint16_t queuedBgType      = 0;
+		uint8_t  queuedFaction     = 0; ///< 0=Alliance, 1=Horde
+		uint32_t estimatedWaitSec  = 0;
+		uint32_t queuePosition     = 0;
+
+		/// Match actif (push opcode 136 a la reception). Reinitialise au
+		/// MatchEndNotification.
+		std::optional<uint64_t> activeMatchId;
+		uint16_t                activeMatchBgType = 0;
+		std::string             activeMatchMap;
+		uint8_t                 activeAllianceCount = 0;
+		uint8_t                 activeHordeCount    = 0;
+		uint32_t                allianceScore       = 0;
+		uint32_t                hordeScore          = 0;
+		uint32_t                matchElapsedSec     = 0;
+
+		/// Resultat du dernier match (push opcode 138). Affiche transitoirement
+		/// par le renderer.
+		std::optional<uint8_t>  lastMatchWinner; ///< 0=Alliance, 1=Horde, 2=Draw
+		uint32_t                lastMatchAllianceScore = 0;
+		uint32_t                lastMatchHordeScore    = 0;
+		uint32_t                lastMatchDurationSec   = 0;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire (e.g. "Inscrit en queue."). Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Presenter pour la fenetre BattleGround cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main (comme les autres presenters UI).
+	class BattleGroundUiPresenter final
+	{
+	public:
+		BattleGroundUiPresenter() = default;
+
+		BattleGroundUiPresenter(const BattleGroundUiPresenter&)            = delete;
+		BattleGroundUiPresenter& operator=(const BattleGroundUiPresenter&) = delete;
+
+		~BattleGroundUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.10 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / Queue / LeaveQueue / LeaveMatch.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie BG_LIST_REQUEST. Reponse via OnListResponse.
+		void RequestList();
+
+		/// Envoie BG_QUEUE_REQUEST avec \p bgType (1/2/3 V1) et \p faction
+		/// (0=Alliance, 1=Horde). Reponse via OnQueueResponse.
+		void Queue(uint16_t bgType, uint8_t faction);
+
+		/// Envoie BG_LEAVE_QUEUE_REQUEST. Reponse via OnLeaveQueueResponse.
+		void LeaveQueue();
+
+		/// Envoie BG_LEAVE_MATCH_REQUEST (forfait V1, fire-and-forget).
+		/// Pas de Response paire ; le master pousse a la place un
+		/// MatchEndNotification avec winnerFaction = opposite.
+		void LeaveMatch();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit BG_LIST_RESPONSE. Remplace la cache locale.
+		void OnListResponse(const engine::network::BgListResponsePayload& resp);
+
+		/// Recoit BG_QUEUE_RESPONSE. Si OK, marque inQueue = true et stocke
+		/// estimatedWaitSec + queuePosition. Sinon, ecrit dans lastErrorText.
+		void OnQueueResponse(const engine::network::BgQueueResponsePayload& resp);
+
+		/// Recoit BG_LEAVE_QUEUE_RESPONSE. Si OK, clear l'etat de queue local.
+		void OnLeaveQueueResponse(const engine::network::BgLeaveQueueResponsePayload& resp);
+
+		/// Recoit un push BG_MATCH_START_NOTIFICATION : arme l'etat match
+		/// actif (matchId + bgType + map + counts).
+		void OnMatchStartNotification(const engine::network::BgMatchStartNotificationPayload& note);
+
+		/// Recoit un push BG_SCORE_UPDATE_NOTIFICATION : update les scores
+		/// + elapsed du match actif.
+		void OnScoreUpdateNotification(const engine::network::BgScoreUpdateNotificationPayload& note);
+
+		/// Recoit un push BG_MATCH_END_NOTIFICATION : arme le toast result
+		/// (winner + scores + duration) puis clear l'etat match actif.
+		void OnMatchEndNotification(const engine::network::BgMatchEndNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const BattleGroundUiState& GetState() const { return m_state; }
+
+	private:
+		/// Clear l'etat de queue local (appele a OnLeaveQueueResponse Ok ou a
+		/// la reception d'un MatchStartNotification).
+		void ClearQueueState();
+
+		/// Clear l'etat match actif local (appele a OnMatchEndNotification).
+		void ClearActiveMatch();
+
+		/// Memorise le bgType et faction choisis en attente de la reponse Ok.
+		uint16_t m_pendingBgType  = 0;
+		uint8_t  m_pendingFaction = 0;
+
+		bool                m_initialized = false;
+		BattleGroundUiState m_state{};
+		SendCallback        m_send;
+	};
+}

--- a/src/client/render/BattleGroundImGuiRenderer.cpp
+++ b/src/client/render/BattleGroundImGuiRenderer.cpp
@@ -1,0 +1,278 @@
+// CMANGOS.10 (Phase 5 step 3+4) — BattleGroundImGuiRenderer implementation.
+
+#include "src/client/render/BattleGroundImGuiRenderer.h"
+
+#include "src/client/battleground/BattleGroundUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Libelle FR pour une faction.
+		const char* FactionLabel(uint8_t fac)
+		{
+			switch (fac)
+			{
+			case 0: return "Alliance";
+			case 1: return "Horde";
+			case 2: return "Egalite";
+			default: return "?";
+			}
+		}
+
+		/// Format MM:SS pour un nombre de secondes.
+		void FormatMmSs(uint32_t sec, char* out, size_t outSize)
+		{
+			const uint32_t m = sec / 60u;
+			const uint32_t s = sec % 60u;
+			std::snprintf(out, outSize, "%02u:%02u",
+				static_cast<unsigned>(m), static_cast<unsigned>(s));
+		}
+	}
+
+	void BattleGroundImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr || !m_enabled)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+		const auto& state = m_presenter->GetState();
+		if (state.activeMatchId.has_value())
+			RenderActiveMatchPanel();
+		else
+			RenderMainPanel();
+	}
+
+	void BattleGroundImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 420x500.
+		const float panelW = 420.f;
+		const float panelH = 500.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("BattleGround##ln_bg_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Resultat du dernier match (toast persistant tant que pas
+			// d'autre info ; le state n'a pas de fade-out auto cote presenter — V1).
+			if (state.lastMatchWinner.has_value())
+			{
+				const uint8_t winner = *state.lastMatchWinner;
+				ImVec4 col;
+				if (winner == 0u) col = ImVec4(0.4f, 0.7f, 1.f, 1.f);   // Alliance bleu
+				else if (winner == 1u) col = ImVec4(1.f, 0.4f, 0.4f, 1.f); // Horde rouge
+				else col = ImVec4(0.85f, 0.85f, 0.85f, 1.f);              // Draw
+				ImGui::PushStyleColor(ImGuiCol_Text, col);
+				char durBuf[16]{};
+				FormatMmSs(state.lastMatchDurationSec, durBuf, sizeof(durBuf));
+				char buf[200]{};
+				if (winner == 2u)
+				{
+					std::snprintf(buf, sizeof(buf), "Egalite ! %u-%u (%s)",
+						static_cast<unsigned>(state.lastMatchAllianceScore),
+						static_cast<unsigned>(state.lastMatchHordeScore),
+						durBuf);
+				}
+				else
+				{
+					std::snprintf(buf, sizeof(buf), "Victoire %s ! %u-%u (%s)",
+						FactionLabel(winner),
+						static_cast<unsigned>(state.lastMatchAllianceScore),
+						static_cast<unsigned>(state.lastMatchHordeScore),
+						durBuf);
+				}
+				ImGui::TextWrapped("%s", buf);
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			if (state.inQueue)
+			{
+				ImGui::TextUnformatted("En queue BG :");
+				ImGui::Separator();
+				ImGui::Text("BG       : #%u", static_cast<unsigned>(state.queuedBgType));
+				ImGui::Text("Faction  : %s", FactionLabel(state.queuedFaction));
+				if (state.queuePosition > 0u)
+					ImGui::Text("Position : %u", static_cast<unsigned>(state.queuePosition));
+				if (state.estimatedWaitSec > 0u)
+					ImGui::Text("Estime   : %u s", static_cast<unsigned>(state.estimatedWaitSec));
+				ImGui::Spacing();
+				if (ImGui::Button("Quitter la queue", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->LeaveQueue();
+			}
+			else
+			{
+				// Liste des BG + boutons Queue Alliance / Queue Horde par BG.
+				if (!state.listLoaded || state.battlegrounds.empty())
+				{
+					if (ImGui::Button("Charger les BG", ImVec2(-FLT_MIN, 28.f)))
+						m_presenter->RequestList();
+					if (state.listLoaded && state.battlegrounds.empty())
+					{
+						ImGui::TextWrapped("Aucun battleground disponible.");
+					}
+				}
+				else
+				{
+					ImGui::TextUnformatted("Battlegrounds :");
+					ImGui::Separator();
+					const ImGuiTableFlags tableFlags = ImGuiTableFlags_Borders
+						| ImGuiTableFlags_RowBg
+						| ImGuiTableFlags_ScrollY;
+					if (ImGui::BeginTable("##ln_bg_list", 4, tableFlags, ImVec2(0.f, 280.f)))
+					{
+						ImGui::TableSetupColumn("Nom",       ImGuiTableColumnFlags_WidthStretch);
+						ImGui::TableSetupColumn("Map",       ImGuiTableColumnFlags_WidthFixed, 80.f);
+						ImGui::TableSetupColumn("Taille",    ImGuiTableColumnFlags_WidthFixed, 50.f);
+						ImGui::TableSetupColumn("Faction",   ImGuiTableColumnFlags_WidthFixed, 160.f);
+						ImGui::TableHeadersRow();
+						for (const auto& bg : state.battlegrounds)
+						{
+							ImGui::TableNextRow();
+							ImGui::TableSetColumnIndex(0);
+							ImGui::TextUnformatted(bg.name.c_str());
+							ImGui::TableSetColumnIndex(1);
+							ImGui::TextUnformatted(bg.mapName.c_str());
+							ImGui::TableSetColumnIndex(2);
+							ImGui::Text("%uv%u",
+								static_cast<unsigned>(bg.teamSize),
+								static_cast<unsigned>(bg.teamSize));
+							ImGui::TableSetColumnIndex(3);
+							ImGui::PushID(static_cast<int>(bg.bgType));
+							ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.40f, 0.70f, 1.f));
+							if (ImGui::Button("Alliance", ImVec2(70.f, 22.f)))
+								m_presenter->Queue(bg.bgType, 0u);
+							ImGui::PopStyleColor();
+							ImGui::SameLine();
+							ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.70f, 0.20f, 0.20f, 1.f));
+							if (ImGui::Button("Horde", ImVec2(70.f, 22.f)))
+								m_presenter->Queue(bg.bgType, 1u);
+							ImGui::PopStyleColor();
+							ImGui::PopID();
+						}
+						ImGui::EndTable();
+					}
+					ImGui::Spacing();
+					if (ImGui::Button("Rafraichir la liste", ImVec2(-FLT_MIN, 28.f)))
+						m_presenter->RequestList();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void BattleGroundImGuiRenderer::RenderActiveMatchPanel()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.activeMatchId.has_value())
+			return;
+
+		// Geometrie : scoreboard centre haut, 520x180.
+		const float panelW = 520.f;
+		const float panelH = 180.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, (vpW - panelW) * 0.5f);
+		const float posY = 24.f;
+		(void)vpH;
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings;
+		if (ImGui::Begin("Match BG en cours##ln_bg_active", nullptr, flags))
+		{
+			char durBuf[16]{};
+			FormatMmSs(state.matchElapsedSec, durBuf, sizeof(durBuf));
+
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.85f, 0.20f, 1.f));
+			ImGui::Text("%s (BG #%u) - %s",
+				state.activeMatchMap.c_str(),
+				static_cast<unsigned>(state.activeMatchBgType),
+				durBuf);
+			ImGui::PopStyleColor();
+			ImGui::Separator();
+
+			// Scoreboard "Alliance X vs Horde Y" avec couleurs.
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.7f, 1.f, 1.f));
+			ImGui::Text("Alliance : %u (%u joueurs)",
+				static_cast<unsigned>(state.allianceScore),
+				static_cast<unsigned>(state.activeAllianceCount));
+			ImGui::PopStyleColor();
+
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+			ImGui::Text("Horde    : %u (%u joueurs)",
+				static_cast<unsigned>(state.hordeScore),
+				static_cast<unsigned>(state.activeHordeCount));
+			ImGui::PopStyleColor();
+
+			ImGui::Spacing();
+
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.55f, 0.20f, 0.20f, 1.f));
+			if (ImGui::Button("Forfait", ImVec2(-FLT_MIN, 28.f)))
+				m_presenter->LeaveMatch();
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void BattleGroundImGuiRenderer::Render()                  {}
+	void BattleGroundImGuiRenderer::RenderMainPanel()         {}
+	void BattleGroundImGuiRenderer::RenderActiveMatchPanel()  {}
+}
+
+#endif

--- a/src/client/render/BattleGroundImGuiRenderer.h
+++ b/src/client/render/BattleGroundImGuiRenderer.h
@@ -1,0 +1,48 @@
+#pragma once
+// CMANGOS.10 (Phase 5 step 3+4) — BattleGroundImGuiRenderer : panneau ImGui
+// pour la fenetre BattleGround cote joueur. Lit l'etat d'un
+// BattleGroundUiPresenter, dispatch les inputs UI (RequestList / Queue
+// Alliance / Queue Horde / LeaveQueue / LeaveMatch) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class BattleGroundUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau BattleGround. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::BattleGroundUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs UI
+	/// vers le presenter.
+	class BattleGroundImGuiRenderer
+	{
+	public:
+		BattleGroundImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::BattleGroundUiPresenter* presenter) { m_presenter = presenter; }
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "BattleGround" + scoreboard si match actif. A
+		/// appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), apres
+		/// NewFrame, si le presenter est valide et IsEnabled().
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (liste BG + queue/leave + last result).
+		void RenderMainPanel();
+
+		/// Dessine le scoreboard quand un match est actif.
+		void RenderActiveMatchPanel();
+
+		engine::client::BattleGroundUiPresenter* m_presenter = nullptr;
+		bool                                     m_enabled   = false;
+		uint32_t                                 m_viewportW = 0;
+		uint32_t                                 m_viewportH = 0;
+	};
+}

--- a/src/masterd/handlers/battleground/BattleGroundHandler.cpp
+++ b/src/masterd/handlers/battleground/BattleGroundHandler.cpp
@@ -1,0 +1,571 @@
+// CMANGOS.10 (Phase 5 step 3+4) — Implementation BattleGroundHandler.
+
+#include "src/masterd/handlers/battleground/BattleGroundHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/BattleGroundPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	// -------------------------------------------------------------------------
+	// Helpers static
+	// -------------------------------------------------------------------------
+
+	BattleGroundHandler::BgInfoEntry BattleGroundHandler::GetBgInfoStatic(uint16_t bgType)
+	{
+		BgInfoEntry e;
+		switch (bgType)
+		{
+		case kBgWarsong:
+			e.bgType   = kBgWarsong;
+			e.name     = "Warsong Gulch";
+			e.teamSize = 10u;
+			e.mapName  = "warsong";
+			break;
+		case kBgArathi:
+			e.bgType   = kBgArathi;
+			e.name     = "Arathi Basin";
+			e.teamSize = 15u;
+			e.mapName  = "arathi";
+			break;
+		case kBgAlterac:
+			e.bgType   = kBgAlterac;
+			e.name     = "Alterac Valley";
+			e.teamSize = 40u;
+			e.mapName  = "alterac";
+			break;
+		default:
+			break;
+		}
+		return e;
+	}
+
+	bool BattleGroundHandler::IsValidBgType(uint16_t bgType)
+	{
+		return bgType == kBgWarsong || bgType == kBgArathi || bgType == kBgAlterac;
+	}
+
+	bool BattleGroundHandler::IsValidFaction(uint8_t faction)
+	{
+		return faction == 0u || faction == 1u;
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket — dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void BattleGroundHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(BgErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeBgListRequest:
+				pkt = BuildBgListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeBgQueueRequest:
+				pkt = BuildBgQueueResponsePacket(kUnauth, 0u, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeBgLeaveQueueRequest:
+				pkt = BuildBgLeaveQueueResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeBgLeaveMatchRequest:
+				// Pas de Response paire (fire-and-forget V1) — drop silencieux.
+				LOG_INFO(Net, "[BattleGroundHandler] LeaveMatch dropped : Unauthorized");
+				return;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeBgListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeBgQueueRequest:
+			HandleQueue(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeBgLeaveQueueRequest:
+			HandleLeaveQueue(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeBgLeaveMatchRequest:
+			HandleLeaveMatch(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleList
+	// -------------------------------------------------------------------------
+
+	void BattleGroundHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		std::vector<BgInfo> bgs;
+		bgs.reserve(3u);
+		const uint16_t types[] = {kBgWarsong, kBgArathi, kBgAlterac};
+		for (uint16_t t : types)
+		{
+			auto e = GetBgInfoStatic(t);
+			BgInfo bg;
+			bg.bgType   = e.bgType;
+			bg.name     = e.name;
+			bg.teamSize = e.teamSize;
+			bg.mapName  = e.mapName;
+			bgs.push_back(std::move(bg));
+		}
+
+		LOG_INFO(Net, "[BattleGroundHandler] List account={} count={}",
+			accountId, bgs.size());
+
+		auto pkt = BuildBgListResponsePacket(0u, bgs, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleQueue — V1 : queue ack + match V1 vs AI bot immediatement.
+	// -------------------------------------------------------------------------
+
+	void BattleGroundHandler::HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseBgQueueRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] Queue parse failed account={}", accountId);
+			auto pkt = BuildBgQueueResponsePacket(
+				static_cast<uint8_t>(BgErrorCode::UnknownBg), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Validation bgType.
+		if (!IsValidBgType(parsed->bgType))
+		{
+			LOG_INFO(Net, "[BattleGroundHandler] Queue UnknownBg account={} bgType={}",
+				accountId, static_cast<unsigned>(parsed->bgType));
+			auto pkt = BuildBgQueueResponsePacket(
+				static_cast<uint8_t>(BgErrorCode::UnknownBg), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Validation faction.
+		if (!IsValidFaction(parsed->faction))
+		{
+			LOG_INFO(Net, "[BattleGroundHandler] Queue InvalidFaction account={} faction={}",
+				accountId, static_cast<unsigned>(parsed->faction));
+			auto pkt = BuildBgQueueResponsePacket(
+				static_cast<uint8_t>(BgErrorCode::InvalidFaction), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Decide ce qui se passe sous mutex : already queued ? deja en match ? sinon
+		// inscrire en queue ET creer match V1 ET pop la queue.
+		uint64_t newMatchId = 0;
+		bool alreadyQueued = false;
+		bool alreadyInMatch = false;
+		uint8_t allianceCount = 0;
+		uint8_t hordeCount = 0;
+		uint8_t winnerFaction = 0;
+		BgInfoEntry bgInfo;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+
+			if (m_queue.find(accountId) != m_queue.end())
+			{
+				alreadyQueued = true;
+			}
+			else if (m_accountMatch.find(accountId) != m_accountMatch.end())
+			{
+				// Considere comme "deja en queue" cote wire : V1 simplifie. On
+				// remappe sur AlreadyQueued pour ne pas inventer un nouveau code.
+				alreadyInMatch = true;
+			}
+			else
+			{
+				bgInfo = GetBgInfoStatic(parsed->bgType);
+
+				// Inscrit en queue (pour traceabilite log/metrics ; V1 retire
+				// immediatement apres puisque le match part de suite).
+				QueueState qs;
+				qs.bgType   = parsed->bgType;
+				qs.faction  = parsed->faction;
+				qs.queuedAt = std::chrono::steady_clock::now();
+				m_queue[accountId] = qs;
+
+				// Cree le match V1 immediatement.
+				newMatchId = m_nextMatchId.fetch_add(1ull);
+				ActiveMatch m;
+				m.bgType     = parsed->bgType;
+				m.mapName    = bgInfo.mapName;
+				m.startedAt  = std::chrono::steady_clock::now();
+				m.allianceScore = 0u;
+				m.hordeScore    = 0u;
+				if (parsed->faction == 0u)
+				{
+					m.alliance.push_back(accountId);
+					m.horde.push_back(kAiBotAccountId);
+				}
+				else
+				{
+					m.alliance.push_back(kAiBotAccountId);
+					m.horde.push_back(accountId);
+				}
+				allianceCount = static_cast<uint8_t>(m.alliance.size());
+				hordeCount    = static_cast<uint8_t>(m.horde.size());
+
+				m_matches[newMatchId] = m;
+				m_accountMatch[accountId] = newMatchId;
+
+				// Pop la queue (V1 : queue est juste un ack, le match part de suite).
+				m_queue.erase(accountId);
+
+				// V1 : winnerFaction tirage 50/50 entre joueur et opposite.
+				if (!m_rngSeeded)
+				{
+					const auto seed = static_cast<std::mt19937::result_type>(
+						std::chrono::steady_clock::now().time_since_epoch().count());
+					m_rng.seed(seed);
+					m_rngSeeded = true;
+				}
+				std::uniform_int_distribution<uint32_t> dist(0u, 1u);
+				const uint32_t coin = dist(m_rng);
+				// coin == 0 : le joueur gagne, coin == 1 : le opposite gagne.
+				if (coin == 0u)
+					winnerFaction = parsed->faction; // 0=Alliance, 1=Horde
+				else
+					winnerFaction = (parsed->faction == 0u) ? 1u : 0u;
+			}
+		}
+
+		if (alreadyQueued || alreadyInMatch)
+		{
+			LOG_INFO(Net, "[BattleGroundHandler] Queue AlreadyQueued account={} (inMatch={})",
+				accountId, alreadyInMatch ? 1 : 0);
+			auto pkt = BuildBgQueueResponsePacket(
+				static_cast<uint8_t>(BgErrorCode::AlreadyQueued), 0u, 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[BattleGroundHandler] Queue OK account={} bgType={} faction={} matchId={}",
+			accountId, static_cast<unsigned>(parsed->bgType),
+			static_cast<unsigned>(parsed->faction), newMatchId);
+
+		// Envoie le QueueResponse OK.
+		auto qPkt = BuildBgQueueResponsePacket(0u, kV1EstimatedWaitSec, kV1QueuePosition,
+			requestId, sessionIdHeader);
+		if (!qPkt.empty())
+			m_server->Send(connId, qPkt);
+
+		// V1 : pousse immediatement la sequence Start -> Score(s) -> End.
+		PushMatchStart(connId, newMatchId, parsed->bgType, bgInfo.mapName,
+			allianceCount, hordeCount);
+
+		// 3 score updates simules (5 / 10 / 15 sec). Faux scores qui montent
+		// progressivement vers le total final.
+		PushScoreUpdate(connId, newMatchId, 200u, 100u, kV1ScoreElapsed1);
+		PushScoreUpdate(connId, newMatchId, 500u, 350u, kV1ScoreElapsed2);
+		PushScoreUpdate(connId, newMatchId, 900u, 800u, kV1ScoreElapsed3);
+
+		// Final scores : 1500 vs 1200 si gagnant Alliance ; sinon 1200 vs 1500.
+		uint32_t finalAlliance = 0u;
+		uint32_t finalHorde = 0u;
+		if (winnerFaction == 0u)
+		{
+			finalAlliance = 1500u;
+			finalHorde    = 1200u;
+		}
+		else if (winnerFaction == 1u)
+		{
+			finalAlliance = 1200u;
+			finalHorde    = 1500u;
+		}
+		else
+		{
+			finalAlliance = 1300u;
+			finalHorde    = 1300u;
+		}
+
+		PushMatchEnd(connId, newMatchId, winnerFaction, finalAlliance, finalHorde, kV1MatchDuration);
+
+		// Cleanup : retire le match cote master apres push de End. Le client
+		// gere la disparition cote UI quand il recoit le End.
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto it = m_matches.find(newMatchId);
+			if (it != m_matches.end())
+			{
+				it->second.allianceScore = finalAlliance;
+				it->second.hordeScore    = finalHorde;
+				m_matches.erase(it);
+			}
+			m_accountMatch.erase(accountId);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleLeaveQueue
+	// -------------------------------------------------------------------------
+
+	void BattleGroundHandler::HandleLeaveQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		bool wasQueued = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto it = m_queue.find(accountId);
+			if (it != m_queue.end())
+			{
+				wasQueued = true;
+				m_queue.erase(it);
+			}
+		}
+
+		if (!wasQueued)
+		{
+			LOG_INFO(Net, "[BattleGroundHandler] LeaveQueue NotInQueue account={}", accountId);
+			auto pkt = BuildBgLeaveQueueResponsePacket(
+				static_cast<uint8_t>(BgErrorCode::NotInQueue),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[BattleGroundHandler] LeaveQueue OK account={}", accountId);
+		auto pkt = BuildBgLeaveQueueResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleLeaveMatch — fire-and-forget : push MatchEnd (forfait), pas de
+	// Response paire.
+	// -------------------------------------------------------------------------
+
+	void BattleGroundHandler::HandleLeaveMatch(uint32_t connId, uint32_t /*requestId*/, uint64_t /*sessionIdHeader*/,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		uint64_t matchId = 0;
+		uint16_t bgType = 0;
+		bool found = false;
+		uint8_t opposite = 2u; // par defaut Draw si on ne sait pas
+		uint32_t allianceScore = 0u;
+		uint32_t hordeScore    = 0u;
+		uint32_t durationSec   = 0u;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto idxIt = m_accountMatch.find(accountId);
+			if (idxIt != m_accountMatch.end())
+			{
+				matchId = idxIt->second;
+				auto mIt = m_matches.find(matchId);
+				if (mIt != m_matches.end())
+				{
+					found = true;
+					bgType = mIt->second.bgType;
+					// Determine la faction du joueur (Alliance ou Horde) pour
+					// donner la victoire a l'opposite.
+					bool isAlliance = false;
+					for (uint64_t a : mIt->second.alliance)
+					{
+						if (a == accountId) { isAlliance = true; break; }
+					}
+					opposite = isAlliance ? 1u /*Horde win*/ : 0u /*Alliance win*/;
+					allianceScore = mIt->second.allianceScore;
+					hordeScore    = mIt->second.hordeScore;
+					const auto now = std::chrono::steady_clock::now();
+					durationSec = static_cast<uint32_t>(
+						std::chrono::duration_cast<std::chrono::seconds>(
+							now - mIt->second.startedAt).count());
+					m_matches.erase(mIt);
+				}
+				m_accountMatch.erase(idxIt);
+			}
+		}
+
+		if (!found)
+		{
+			LOG_INFO(Net, "[BattleGroundHandler] LeaveMatch no active match account={} (drop)",
+				accountId);
+			return;
+		}
+
+		LOG_INFO(Net, "[BattleGroundHandler] LeaveMatch forfeit account={} matchId={} bgType={} winner={}",
+			accountId, matchId, static_cast<unsigned>(bgType), static_cast<unsigned>(opposite));
+
+		// V1 : push MatchEnd avec winnerFaction = opposite. Pas de Response
+		// paire (fire-and-forget).
+		PushMatchEnd(connId, matchId, opposite, allianceScore, hordeScore, durationSec);
+	}
+
+	// -------------------------------------------------------------------------
+	// Push helpers
+	// -------------------------------------------------------------------------
+
+	bool BattleGroundHandler::PushMatchStart(uint32_t connId, uint64_t matchId, uint16_t bgType,
+		const std::string& mapName, uint8_t allianceCount, uint8_t hordeCount)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchStart dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchStart: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildBgMatchStartNotificationPacket(
+			matchId, bgType, mapName, allianceCount, hordeCount, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchStart: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[BattleGroundHandler] PushMatchStart connId={} matchId={} bgType={} a={} h={}",
+			connId, matchId, static_cast<unsigned>(bgType),
+			static_cast<unsigned>(allianceCount), static_cast<unsigned>(hordeCount));
+		return true;
+	}
+
+	bool BattleGroundHandler::PushScoreUpdate(uint32_t connId, uint64_t matchId,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushScoreUpdate dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushScoreUpdate: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildBgScoreUpdateNotificationPacket(
+			matchId, allianceScore, hordeScore, elapsedSec, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushScoreUpdate: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[BattleGroundHandler] PushScoreUpdate connId={} matchId={} a={} h={} t={}s",
+			connId, matchId, allianceScore, hordeScore, elapsedSec);
+		return true;
+	}
+
+	bool BattleGroundHandler::PushMatchEnd(uint32_t connId, uint64_t matchId, uint8_t winnerFaction,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchEnd dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchEnd: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildBgMatchEndNotificationPacket(
+			matchId, winnerFaction, allianceScore, hordeScore, durationSec, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[BattleGroundHandler] PushMatchEnd: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[BattleGroundHandler] PushMatchEnd connId={} matchId={} winner={} a={} h={} dur={}s",
+			connId, matchId, static_cast<unsigned>(winnerFaction),
+			allianceScore, hordeScore, durationSec);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+
+	uint64_t BattleGroundHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/battleground/BattleGroundHandler.h
+++ b/src/masterd/handlers/battleground/BattleGroundHandler.h
@@ -1,0 +1,236 @@
+#pragma once
+// CMANGOS.10 (Phase 5 step 3+4) — BattleGroundHandler : dispatch des opcodes
+// BG cote joueur (130/132/134/139) et appel des methodes correspondantes
+// d'un store in-memory de queue + matches actifs.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 130/132/134/139 (les requests). Les responses 131/133/135 sont
+// emises avec le meme requestId / sessionId que la request recue. Les push
+// notifications 136 (MatchStart) / 137 (ScoreUpdate) / 138 (MatchEnd) sont
+// emises par le handler lui-meme apres traitement.
+//
+// V1 simplifie : a la queue request, master cree tout de suite un match
+// fictif vs AI bot (faction opposee) et envoie immediatement la sequence
+// Start -> Score(s) -> End. Pas besoin de Tick(). 139 (LeaveMatch) est
+// fire-and-forget : push BgMatchEndNotification (forfait) sans Response paire.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 5) dans la reponse type-specific.
+//
+// Store in-memory V1 :
+//   - 3 BG hardcodes au boot :
+//       bgType=1 "Warsong Gulch"  teamSize=10 mapName="warsong"
+//       bgType=2 "Arathi Basin"   teamSize=15 mapName="arathi"
+//       bgType=3 "Alterac Valley" teamSize=40 mapName="alterac"
+//   - Queue : map account_id -> QueueState. Un seul account ne peut etre
+//     que dans une seule queue (V1).
+//   - Matches actifs : map matchId -> ActiveMatch.
+//   - Member-to-match : map account_id -> matchId (index inverse pour
+//     LeaveMatch et eviter les doubles).
+//
+// V1 limitations :
+//   - 3 BG hardcodes (Warsong/Arathi/Alterac). Vrais BG via M40+ futur.
+//   - Match vs AI bot fictif (account 9999). Vrai matchmaking 2 factions
+//     a venir.
+//   - Score evolution simulee instantanee (V1) ; vrai gameplay BG via shardd futur.
+//   - estimatedWaitSec hardcode 10s (V1).
+//   - winnerFaction tirage 50/50 entre joueur et opposite (V1).
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher BattleGround cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class BattleGroundHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes BG.
+		/// Dispatch vers HandleList / HandleQueue / HandleLeaveQueue /
+		/// HandleLeaveMatch selon l'opcode. Si l'opcode n'est pas un opcode
+		/// BG, ignore silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (130/132/134/139).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push BgMatchStartNotification (opcode 136)
+		/// au client identifie par \p connId.
+		///
+		/// \param connId        identifiant de connexion TCP cible (0 = no-op).
+		/// \param matchId       identifiant unique du match.
+		/// \param bgType        type de BG (1/2/3 V1).
+		/// \param mapName       nom de la map (V1 : "warsong"/"arathi"/"alterac").
+		/// \param allianceCount nombre de joueurs cote Alliance.
+		/// \param hordeCount    nombre de joueurs cote Horde.
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushMatchStart(uint32_t connId, uint64_t matchId, uint16_t bgType,
+		                     const std::string& mapName, uint8_t allianceCount, uint8_t hordeCount);
+
+		/// API publique : pousse une push BgScoreUpdateNotification (opcode 137)
+		/// au client identifie par \p connId.
+		///
+		/// \param connId        identifiant de connexion TCP cible (0 = no-op).
+		/// \param matchId       identifiant du match.
+		/// \param allianceScore score cumule cote Alliance.
+		/// \param hordeScore    score cumule cote Horde.
+		/// \param elapsedSec    duree ecoulee depuis le start (secondes).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushScoreUpdate(uint32_t connId, uint64_t matchId,
+		                      uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec);
+
+		/// API publique : pousse une push BgMatchEndNotification (opcode 138)
+		/// au client identifie par \p connId.
+		///
+		/// \param connId         identifiant de connexion TCP cible (0 = no-op).
+		/// \param matchId        identifiant du match.
+		/// \param winnerFaction  0=Alliance, 1=Horde, 2=Draw.
+		/// \param allianceScore  score final cote Alliance.
+		/// \param hordeScore     score final cote Horde.
+		/// \param durationSec    duree totale du match (secondes).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushMatchEnd(uint32_t connId, uint64_t matchId, uint8_t winnerFaction,
+		                   uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec);
+
+	private:
+		/// Traite BG_LIST_REQUEST : retourne les 3 BG hardcodes V1.
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite BG_QUEUE_REQUEST : verifie bgType valide (1/2/3) + faction
+		/// valide (0/1) + pas deja queued. Si OK, ajoute a la queue, repond
+		/// QueueResponse Ok, puis cree immediatement un match V1 (vs AI bot)
+		/// et push la sequence Start -> Score(s) -> End.
+		void HandleQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite BG_LEAVE_QUEUE_REQUEST : retire de la queue. OK si etait
+		/// en queue, NotInQueue sinon.
+		void HandleLeaveQueue(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite BG_LEAVE_MATCH_REQUEST : si l'account est en match, push
+		/// MatchEndNotification (winnerFaction = opposite, forfait) puis
+		/// retire l'index. Pas de Response paire (fire-and-forget V1).
+		void HandleLeaveMatch(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// V1 : 3 BG hardcodes au boot. teamSize indicatif (V1 : 1 vrai joueur
+		/// + AI bots simules cote opposite).
+		static constexpr uint16_t kBgWarsong = 1u;
+		static constexpr uint16_t kBgArathi  = 2u;
+		static constexpr uint16_t kBgAlterac = 3u;
+		/// V1 : estimatedWaitSec hardcode dans QueueResponse.
+		static constexpr uint32_t kV1EstimatedWaitSec = 10u;
+		/// V1 : queuePosition hardcode dans QueueResponse (1 = match immediat).
+		static constexpr uint32_t kV1QueuePosition = 1u;
+		/// V1 : account_id fictif de l'AI bot cote opposite.
+		static constexpr uint64_t kAiBotAccountId = 9999ull;
+		/// V1 : durations simulees pour la sequence Score/End instantanee.
+		static constexpr uint32_t kV1ScoreElapsed1 = 5u;
+		static constexpr uint32_t kV1ScoreElapsed2 = 10u;
+		static constexpr uint32_t kV1ScoreElapsed3 = 15u;
+		static constexpr uint32_t kV1MatchDuration = 20u;
+
+		/// Renvoie le BgInfo {bgType, name, teamSize, mapName} pour un
+		/// bgType connu. Retourne {0, "", 0, ""} si bgType invalide.
+		struct BgInfoEntry
+		{
+			uint16_t    bgType   = 0;
+			std::string name;
+			uint8_t     teamSize = 0;
+			std::string mapName;
+		};
+		static BgInfoEntry GetBgInfoStatic(uint16_t bgType);
+
+		/// Verifie que bgType est l'un des BG hardcodes V1 (1/2/3).
+		static bool IsValidBgType(uint16_t bgType);
+
+		/// Verifie que faction est dans {0=Alliance, 1=Horde}.
+		static bool IsValidFaction(uint8_t faction);
+
+		/// Etat d'inscription en queue : un account est dans la queue avec
+		/// un bgType + faction. queuedAt sert a l'estimation d'attente future.
+		struct QueueState
+		{
+			uint16_t                              bgType   = 0;
+			uint8_t                               faction  = 0;
+			std::chrono::steady_clock::time_point queuedAt;
+		};
+
+		/// Etat d'un match actif. allianceScore/hordeScore mis a jour quand
+		/// le master push des updates ; durationSec calcule au MatchEnd.
+		struct ActiveMatch
+		{
+			uint16_t                              bgType         = 0;
+			std::string                           mapName;
+			std::vector<uint64_t>                 alliance;
+			std::vector<uint64_t>                 horde;
+			uint32_t                              allianceScore  = 0;
+			uint32_t                              hordeScore     = 0;
+			std::chrono::steady_clock::time_point startedAt;
+		};
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant queue + matches + accountMatch + nextMatchId + RNG.
+		std::mutex                                       m_mutex;
+
+		/// Queue active : account_id -> QueueState. Un seul account ne peut
+		/// etre que dans une seule queue (V1).
+		std::unordered_map<uint64_t, QueueState>         m_queue;
+
+		/// Matches actifs : matchId -> ActiveMatch.
+		std::unordered_map<uint64_t, ActiveMatch>        m_matches;
+
+		/// Index inverse : account_id -> matchId. Permet de trouver le match
+		/// d'un account au LeaveMatch ou de bloquer une nouvelle queue tant
+		/// que le match precedent n'a pas ete cloture.
+		std::unordered_map<uint64_t, uint64_t>           m_accountMatch;
+
+		/// Compteur monotone pour generer des matchId. V1 : transient (reset
+		/// au reboot). Pas de collision tant qu'un seul master.
+		std::atomic<uint64_t>                            m_nextMatchId{1ull};
+
+		/// RNG pour le winnerFaction V1 (50%). Seede au premier usage (lazy).
+		std::mt19937                                     m_rng;
+		bool                                             m_rngSeeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -40,6 +40,7 @@
 #include "src/masterd/handlers/quest/QuestHandler.h"
 #include "src/masterd/handlers/reputation/ReputationHandler.h"
 #include "src/masterd/handlers/arena/ArenaHandler.h"
+#include "src/masterd/handlers/battleground/BattleGroundHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -538,6 +539,22 @@ int main(int argc, char** argv)
 	arenaHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] ArenaHandler configured (CMANGOS.21 step 3+4, in-memory registry)");
 
+	// CMANGOS.10 (Phase 5 step 3+4) — BattleGround wire server.
+	// Le master tient en memoire un store de queue + matches actifs
+	// (V1 : 3 BG hardcodes Warsong/Arathi/Alterac, queue par account,
+	// match V1 vs AI bot fictif a la queue). Les opcodes 130/132/134/139
+	// sont dispatches au handler ; les responses 131/133/135 et les push
+	// notifications 136 (MatchStart) / 137 (ScoreUpdate) / 138 (MatchEnd)
+	// sont emises par le handler.
+	// V1 limitations : match vs AI bot, score evolution simulee
+	// instantanee, winnerFaction tirage 50/50, pas de SyncBg RPC entre
+	// master et shardd. Pas de persistance DB.
+	engine::server::BattleGroundHandler bgHandler;
+	bgHandler.SetServer(&server);
+	bgHandler.SetSessionManager(&sessionManager);
+	bgHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] BattleGroundHandler configured (CMANGOS.10 step 3+4, in-memory)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -577,7 +594,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -648,6 +665,11 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeArenaLeaveQueueRequest
 		      || opcode == kOpcodeArenaMatchAcceptRequest)
 			arenaHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeBgListRequest
+		      || opcode == kOpcodeBgQueueRequest
+		      || opcode == kOpcodeBgLeaveQueueRequest
+		      || opcode == kOpcodeBgLeaveMatchRequest)
+			bgHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/BattleGroundPayloads.cpp
+++ b/src/shared/network/BattleGroundPayloads.cpp
@@ -1,0 +1,423 @@
+// CMANGOS.10 (Phase 5 step 3+4) — Implementation Parse/Build des payloads BG.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/BattleGroundPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un BgInfo (uint16 bgType, string name, uint8 teamSize, string mapName).
+		bool WriteBgInfo(ByteWriter& w, const BgInfo& bg)
+		{
+			if (!w.WriteU16(bg.bgType))                   return false;
+			if (!w.WriteString(bg.name))                  return false;
+			if (!w.WriteBytes(&bg.teamSize, 1u))          return false;
+			if (!w.WriteString(bg.mapName))               return false;
+			return true;
+		}
+
+		/// Lit un BgInfo.
+		bool ReadBgInfo(ByteReader& r, BgInfo& out)
+		{
+			if (!r.ReadU16(out.bgType))                   return false;
+			if (!r.ReadString(out.name))                  return false;
+			uint8_t teamSizeByte = 0;
+			if (!r.ReadBytes(&teamSizeByte, 1u))          return false;
+			out.teamSize = teamSizeByte;
+			if (!r.ReadString(out.mapName))               return false;
+			return true;
+		}
+
+		/// Serialise le body d'un MATCH_START_NOTIFICATION (matchId, bgType,
+		/// mapName, allianceCount, hordeCount).
+		bool WriteMatchStartBody(ByteWriter& w, uint64_t matchId, uint16_t bgType,
+			const std::string& mapName, uint8_t allianceCount, uint8_t hordeCount)
+		{
+			if (!w.WriteU64(matchId))                     return false;
+			if (!w.WriteU16(bgType))                      return false;
+			if (!w.WriteString(mapName))                  return false;
+			if (!w.WriteBytes(&allianceCount, 1u))        return false;
+			if (!w.WriteBytes(&hordeCount, 1u))           return false;
+			return true;
+		}
+
+		/// Serialise le body d'un SCORE_UPDATE_NOTIFICATION (matchId, scores, elapsed).
+		bool WriteScoreUpdateBody(ByteWriter& w, uint64_t matchId,
+			uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec)
+		{
+			if (!w.WriteU64(matchId))                     return false;
+			if (!w.WriteU32(allianceScore))               return false;
+			if (!w.WriteU32(hordeScore))                  return false;
+			if (!w.WriteU32(elapsedSec))                  return false;
+			return true;
+		}
+
+		/// Serialise le body d'un MATCH_END_NOTIFICATION (matchId, winnerFaction,
+		/// scores, durationSec).
+		bool WriteMatchEndBody(ByteWriter& w, uint64_t matchId, uint8_t winnerFaction,
+			uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec)
+		{
+			if (!w.WriteU64(matchId))                     return false;
+			if (!w.WriteBytes(&winnerFaction, 1u))        return false;
+			if (!w.WriteU32(allianceScore))               return false;
+			if (!w.WriteU32(hordeScore))                  return false;
+			if (!w.WriteU32(durationSec))                 return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<BgListRequestPayload> ParseBgListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return BgListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildBgListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<BgListResponsePayload> ParseBgListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		// Si error == 0, lire count + entries.
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.battlegrounds.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			BgInfo bg;
+			if (!ReadBgInfo(r, bg)) return std::nullopt;
+			out.battlegrounds.push_back(std::move(bg));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgListResponsePayload(uint8_t error, const std::vector<BgInfo>& battlegrounds)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(battlegrounds.size()))) return {};
+			for (const auto& bg : battlegrounds)
+			{
+				if (!WriteBgInfo(w, bg)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgListResponsePacket(uint8_t error, const std::vector<BgInfo>& battlegrounds,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(battlegrounds.size()))) return {};
+			for (const auto& bg : battlegrounds)
+			{
+				if (!WriteBgInfo(w, bg)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeBgListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_QUEUE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<BgQueueRequestPayload> ParseBgQueueRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint16 bgType (2) + uint8 faction (1) = 3.
+		if (!payload || payloadSize < 3u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgQueueRequestPayload out;
+		if (!r.ReadU16(out.bgType)) return std::nullopt;
+		uint8_t factionByte = 0;
+		if (!r.ReadBytes(&factionByte, 1u)) return std::nullopt;
+		out.faction = factionByte;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgQueueRequestPayload(uint16_t bgType, uint8_t faction)
+	{
+		std::vector<uint8_t> buf(3u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU16(bgType))           return {};
+		if (!w.WriteBytes(&faction, 1u))   return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_QUEUE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<BgQueueResponsePayload> ParseBgQueueResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgQueueResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		if (!r.ReadU32(out.estimatedWaitSec)) return std::nullopt;
+		if (!r.ReadU32(out.queuePosition))    return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgQueueResponsePayload(uint8_t error, uint32_t estimatedWaitSec, uint32_t queuePosition)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+			if (!w.WriteU32(queuePosition))    return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgQueueResponsePacket(uint8_t error, uint32_t estimatedWaitSec, uint32_t queuePosition,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU32(estimatedWaitSec)) return {};
+			if (!w.WriteU32(queuePosition))    return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeBgQueueResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_LEAVE_QUEUE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<BgLeaveQueueRequestPayload> ParseBgLeaveQueueRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		return BgLeaveQueueRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildBgLeaveQueueRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_LEAVE_QUEUE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<BgLeaveQueueResponsePayload> ParseBgLeaveQueueResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgLeaveQueueResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgLeaveQueueResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgLeaveQueueResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeBgLeaveQueueResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_MATCH_START_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<BgMatchStartNotificationPayload> ParseBgMatchStartNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 matchId (8) + uint16 bgType (2) + uint16 strLen (2)
+		// + uint8 allianceCount (1) + uint8 hordeCount (1) = 14.
+		if (!payload || payloadSize < 14u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgMatchStartNotificationPayload out;
+		if (!r.ReadU64(out.matchId))             return std::nullopt;
+		if (!r.ReadU16(out.bgType))              return std::nullopt;
+		if (!r.ReadString(out.mapName))          return std::nullopt;
+		uint8_t allianceByte = 0;
+		if (!r.ReadBytes(&allianceByte, 1u))     return std::nullopt;
+		out.allianceCount = allianceByte;
+		uint8_t hordeByte = 0;
+		if (!r.ReadBytes(&hordeByte, 1u))        return std::nullopt;
+		out.hordeCount = hordeByte;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgMatchStartNotificationPayload(uint64_t matchId, uint16_t bgType,
+		const std::string& mapName, uint8_t allianceCount, uint8_t hordeCount)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteMatchStartBody(w, matchId, bgType, mapName, allianceCount, hordeCount)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgMatchStartNotificationPacket(uint64_t matchId, uint16_t bgType,
+		const std::string& mapName, uint8_t allianceCount, uint8_t hordeCount, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteMatchStartBody(w, matchId, bgType, mapName, allianceCount, hordeCount)) return {};
+		const size_t payloadBytes = w.Offset();
+		// Push : requestId=0.
+		if (!builder.Finalize(kOpcodeBgMatchStartNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_SCORE_UPDATE_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<BgScoreUpdateNotificationPayload> ParseBgScoreUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 matchId (8) + uint32 allianceScore (4) + uint32 hordeScore (4)
+		// + uint32 elapsedSec (4) = 20.
+		if (!payload || payloadSize < 20u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgScoreUpdateNotificationPayload out;
+		if (!r.ReadU64(out.matchId))         return std::nullopt;
+		if (!r.ReadU32(out.allianceScore))   return std::nullopt;
+		if (!r.ReadU32(out.hordeScore))      return std::nullopt;
+		if (!r.ReadU32(out.elapsedSec))      return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgScoreUpdateNotificationPayload(uint64_t matchId,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec)
+	{
+		std::vector<uint8_t> buf(20u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteScoreUpdateBody(w, matchId, allianceScore, hordeScore, elapsedSec)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgScoreUpdateNotificationPacket(uint64_t matchId,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteScoreUpdateBody(w, matchId, allianceScore, hordeScore, elapsedSec)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeBgScoreUpdateNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_MATCH_END_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<BgMatchEndNotificationPayload> ParseBgMatchEndNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 matchId (8) + uint8 winnerFaction (1) + uint32 alliance (4)
+		// + uint32 horde (4) + uint32 duration (4) = 21.
+		if (!payload || payloadSize < 21u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		BgMatchEndNotificationPayload out;
+		if (!r.ReadU64(out.matchId))        return std::nullopt;
+		uint8_t winnerByte = 0;
+		if (!r.ReadBytes(&winnerByte, 1u))  return std::nullopt;
+		out.winnerFaction = winnerByte;
+		if (!r.ReadU32(out.allianceScore))  return std::nullopt;
+		if (!r.ReadU32(out.hordeScore))     return std::nullopt;
+		if (!r.ReadU32(out.durationSec))    return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildBgMatchEndNotificationPayload(uint64_t matchId, uint8_t winnerFaction,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec)
+	{
+		std::vector<uint8_t> buf(21u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteMatchEndBody(w, matchId, winnerFaction, allianceScore, hordeScore, durationSec)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildBgMatchEndNotificationPacket(uint64_t matchId, uint8_t winnerFaction,
+		uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteMatchEndBody(w, matchId, winnerFaction, allianceScore, hordeScore, durationSec)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeBgMatchEndNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// BG_LEAVE_MATCH — Request (fire-and-forget V1)
+	// -------------------------------------------------------------------------
+
+	std::optional<BgLeaveMatchRequestPayload> ParseBgLeaveMatchRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		return BgLeaveMatchRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildBgLeaveMatchRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+}

--- a/src/shared/network/BattleGroundPayloads.h
+++ b/src/shared/network/BattleGroundPayloads.h
@@ -1,0 +1,248 @@
+#pragma once
+// CMANGOS.10 (Phase 5 step 3+4) — Wire payloads pour les opcodes BattleGround
+// (130-139). 3 paires Request/Response + 3 push notifications + 1 Request push :
+//   - List                            (130/131)
+//   - Queue                           (132/133)
+//   - LeaveQueue                      (134/135)
+//   - MatchStartNotification          (136 push) : push Master to Client
+//     annonce qu'un match BG a demarre.
+//   - ScoreUpdateNotification         (137 push) : push Master to Client
+//     update les scores Alliance/Horde + elapsed.
+//   - MatchEndNotification            (138 push) : push Master to Client
+//     annonce fin de match (winnerFaction + final scores + duration).
+//   - LeaveMatch                      (139 push) : Client to Master,
+//     forfait V1 (fire-and-forget, pas de Response paire).
+//
+// Le BattleGroundQueue est garde cote master uniquement en V1 (pas de DB) :
+// au reboot, queue + matches actifs sont perdus. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Toutes les strings
+// passent par WriteString/ReadString (uint16 length + UTF-8 bytes), et
+// toutes les arrays par WriteArrayCount/ReadArrayCount (uint16 count).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour BattleGround.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes BattleGround. 0 = OK.
+	enum class BgErrorCode : uint8_t
+	{
+		Ok               = 0,
+		AlreadyQueued    = 1, ///< Le compte est deja inscrit dans une queue BG.
+		UnknownBg        = 2, ///< bgType inconnu (1=Warsong, 2=Arathi, 3=Alterac V1).
+		InvalidFaction   = 3, ///< faction hors {0=Alliance, 1=Horde}.
+		NotInQueue       = 4, ///< Pas inscrit dans une queue BG (LeaveQueue).
+		Unauthorized     = 5, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// BG_LIST — Client to Master : liste des battlegrounds disponibles.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct BgListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Resume d'un battleground pour le wire.
+	/// Wire format :
+	///   uint16 bgType
+	///   string name           (uint16 length + UTF-8)
+	///   uint8  teamSize       (10, 15 ou 40 V1)
+	///   string mapName        (uint16 length + UTF-8)
+	struct BgInfo
+	{
+		uint16_t    bgType   = 0;
+		std::string name;
+		uint8_t     teamSize = 0;
+		std::string mapName;
+	};
+
+	/// Wire format :
+	///   uint8  error           (cf. BgErrorCode)
+	///   uint16 count            (si error == 0)
+	///   <count> BgInfo
+	struct BgListResponsePayload
+	{
+		uint8_t              error = 0;
+		std::vector<BgInfo>  battlegrounds;
+	};
+
+	// =========================================================================
+	// BG_QUEUE — Client to Master : inscription a la queue BG.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint16 bgType
+	///   uint8  faction         (0=Alliance, 1=Horde)
+	struct BgQueueRequestPayload
+	{
+		uint16_t bgType  = 0;
+		uint8_t  faction = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error             (cf. BgErrorCode)
+	///   uint32 estimatedWaitSec  (si error == 0)
+	///   uint32 queuePosition     (si error == 0)
+	struct BgQueueResponsePayload
+	{
+		uint8_t  error            = 0;
+		uint32_t estimatedWaitSec = 0;
+		uint32_t queuePosition    = 0;
+	};
+
+	// =========================================================================
+	// BG_LEAVE_QUEUE — Client to Master : quitte la queue BG.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account derive de la session cote master.
+	struct BgLeaveQueueRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct BgLeaveQueueResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// BG_MATCH_START_NOTIFICATION — Master to Client (push, requestId=0).
+	// Annonce qu'un match BG a demarre. Le client met a jour son scoreboard.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 matchId
+	///   uint16 bgType
+	///   string mapName        (uint16 length + UTF-8)
+	///   uint8  allianceCount
+	///   uint8  hordeCount
+	struct BgMatchStartNotificationPayload
+	{
+		uint64_t    matchId        = 0;
+		uint16_t    bgType         = 0;
+		std::string mapName;
+		uint8_t     allianceCount  = 0;
+		uint8_t     hordeCount     = 0;
+	};
+
+	// =========================================================================
+	// BG_SCORE_UPDATE_NOTIFICATION — Master to Client (push, requestId=0).
+	// Update transitoire des scores pendant le match.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 matchId
+	///   uint32 allianceScore
+	///   uint32 hordeScore
+	///   uint32 elapsedSec
+	struct BgScoreUpdateNotificationPayload
+	{
+		uint64_t matchId       = 0;
+		uint32_t allianceScore = 0;
+		uint32_t hordeScore    = 0;
+		uint32_t elapsedSec    = 0;
+	};
+
+	// =========================================================================
+	// BG_MATCH_END_NOTIFICATION — Master to Client (push, requestId=0).
+	// Annonce fin de match avec gagnant et scores finaux.
+	// winnerFaction : 0=Alliance, 1=Horde, 2=Draw.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 matchId
+	///   uint8  winnerFaction   (0/1/2)
+	///   uint32 allianceScore
+	///   uint32 hordeScore
+	///   uint32 durationSec
+	struct BgMatchEndNotificationPayload
+	{
+		uint64_t matchId        = 0;
+		uint8_t  winnerFaction  = 0;
+		uint32_t allianceScore  = 0;
+		uint32_t hordeScore     = 0;
+		uint32_t durationSec    = 0;
+	};
+
+	// =========================================================================
+	// BG_LEAVE_MATCH — Client to Master : forfait du match en cours.
+	// Pas de Response paire (fire-and-forget V1) ; le master pousse a la
+	// place un BgMatchEndNotification avec winnerFaction = opposite.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account derive de la session cote master.
+	struct BgLeaveMatchRequestPayload
+	{
+		// (vide)
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<BgListRequestPayload>        ParseBgListRequestPayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgQueueRequestPayload>       ParseBgQueueRequestPayload      (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgLeaveQueueRequestPayload>  ParseBgLeaveQueueRequestPayload (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgLeaveMatchRequestPayload>  ParseBgLeaveMatchRequestPayload (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildBgListRequestPayload();
+	std::vector<uint8_t> BuildBgQueueRequestPayload(uint16_t bgType, uint8_t faction);
+	std::vector<uint8_t> BuildBgLeaveQueueRequestPayload();
+	std::vector<uint8_t> BuildBgLeaveMatchRequestPayload();
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses & Notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<BgListResponsePayload>                ParseBgListResponsePayload               (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgQueueResponsePayload>               ParseBgQueueResponsePayload              (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgLeaveQueueResponsePayload>          ParseBgLeaveQueueResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgMatchStartNotificationPayload>      ParseBgMatchStartNotificationPayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgScoreUpdateNotificationPayload>     ParseBgScoreUpdateNotificationPayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<BgMatchEndNotificationPayload>        ParseBgMatchEndNotificationPayload       (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildBgListResponsePayload                (uint8_t error, const std::vector<BgInfo>& battlegrounds);
+	std::vector<uint8_t> BuildBgQueueResponsePayload               (uint8_t error, uint32_t estimatedWaitSec, uint32_t queuePosition);
+	std::vector<uint8_t> BuildBgLeaveQueueResponsePayload          (uint8_t error);
+	std::vector<uint8_t> BuildBgMatchStartNotificationPayload      (uint64_t matchId, uint16_t bgType, const std::string& mapName,
+	                                                                 uint8_t allianceCount, uint8_t hordeCount);
+	std::vector<uint8_t> BuildBgScoreUpdateNotificationPayload     (uint64_t matchId, uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec);
+	std::vector<uint8_t> BuildBgMatchEndNotificationPayload        (uint64_t matchId, uint8_t winnerFaction,
+	                                                                 uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildBgListResponsePacket                 (uint8_t error, const std::vector<BgInfo>& battlegrounds,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildBgQueueResponsePacket                (uint8_t error, uint32_t estimatedWaitSec, uint32_t queuePosition,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildBgLeaveQueueResponsePacket           (uint8_t error,
+	                                                                 uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildBgMatchStartNotificationPacket       (uint64_t matchId, uint16_t bgType, const std::string& mapName,
+	                                                                 uint8_t allianceCount, uint8_t hordeCount,
+	                                                                 uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildBgScoreUpdateNotificationPacket      (uint64_t matchId, uint32_t allianceScore, uint32_t hordeScore, uint32_t elapsedSec,
+	                                                                 uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildBgMatchEndNotificationPacket         (uint64_t matchId, uint8_t winnerFaction,
+	                                                                 uint32_t allianceScore, uint32_t hordeScore, uint32_t durationSec,
+	                                                                 uint64_t sessionIdHeader);
+}

--- a/src/shared/network/BattleGroundPayloadsTests.cpp
+++ b/src/shared/network/BattleGroundPayloadsTests.cpp
@@ -1,0 +1,474 @@
+/**
+ * CMANGOS.10 (Phase 5 step 3+4) — Round-trip tests for BG_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/BattleGroundPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// BG_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildBgListRequestPayload();
+	Assert(buf.empty(), "BgList request payload empty");
+	auto parsed = ParseBgListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "BgList request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildBgListResponsePayload(0u, {});
+	auto parsed = ParseBgListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->battlegrounds.empty(),
+		"BgList response empty parses");
+}
+
+static void TestListResponseFull()
+{
+	std::vector<BgInfo> bgs;
+	bgs.push_back({1u, "Warsong Gulch", 10u, "warsong"});
+	bgs.push_back({2u, "Arathi Basin",  15u, "arathi"});
+	bgs.push_back({3u, "Alterac Valley", 40u, "alterac"});
+	auto buf = BuildBgListResponsePayload(0u, bgs);
+	auto parsed = ParseBgListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "BgList response full parses");
+	if (parsed && parsed->battlegrounds.size() == 3u)
+	{
+		Assert(parsed->battlegrounds[0].bgType == 1u, "BG 1 bgType");
+		Assert(parsed->battlegrounds[0].name == "Warsong Gulch", "BG 1 name");
+		Assert(parsed->battlegrounds[0].teamSize == 10u, "BG 1 teamSize");
+		Assert(parsed->battlegrounds[0].mapName == "warsong", "BG 1 map");
+		Assert(parsed->battlegrounds[1].bgType == 2u, "BG 2 bgType");
+		Assert(parsed->battlegrounds[1].teamSize == 15u, "BG 2 teamSize");
+		Assert(parsed->battlegrounds[2].teamSize == 40u, "BG 3 teamSize");
+		Assert(parsed->battlegrounds[2].mapName == "alterac", "BG 3 map");
+	}
+	else
+	{
+		Assert(false, "BgList should have 3 battlegrounds");
+	}
+}
+
+static void TestListResponseError()
+{
+	auto buf = BuildBgListResponsePayload(
+		static_cast<uint8_t>(BgErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "BgList error has only 1 byte");
+	auto parsed = ParseBgListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 5u, "BgList Unauthorized");
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseBgListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "BgList rejects nullptr");
+}
+
+static void TestListResponsePacket()
+{
+	std::vector<BgInfo> bgs;
+	bgs.push_back({42u, "Test BG", 20u, "testmap"});
+	auto pkt = BuildBgListResponsePacket(0u, bgs, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "BgList packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"BgList PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgListResponse, "Opcode is BgListResponse");
+	Assert(view.RequestId() == 999u, "BgList RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "BgList SessionId preserved");
+	auto parsed = ParseBgListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->battlegrounds.size() == 1u
+		&& parsed->battlegrounds[0].bgType == 42u && parsed->battlegrounds[0].name == "Test BG",
+		"BgList payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// BG_QUEUE
+// -----------------------------------------------------------------------------
+
+static void TestQueueRequestRoundTrip()
+{
+	auto buf = BuildBgQueueRequestPayload(2u, 1u);
+	Assert(buf.size() == 3u, "BgQueue request payload size 3");
+	auto parsed = ParseBgQueueRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "BgQueue request parses");
+	if (parsed)
+	{
+		Assert(parsed->bgType == 2u, "BgQueue bgType 2");
+		Assert(parsed->faction == 1u, "BgQueue faction Horde");
+	}
+}
+
+static void TestQueueRequestBoundary()
+{
+	// Alliance bgType=1.
+	auto bufA = BuildBgQueueRequestPayload(1u, 0u);
+	auto parsedA = ParseBgQueueRequestPayload(bufA.data(), bufA.size());
+	Assert(parsedA.has_value() && parsedA->bgType == 1u && parsedA->faction == 0u,
+		"BgQueue boundary: Warsong Alliance");
+	// Max bgType.
+	auto bufMax = BuildBgQueueRequestPayload(0xFFFFu, 1u);
+	auto parsedMax = ParseBgQueueRequestPayload(bufMax.data(), bufMax.size());
+	Assert(parsedMax.has_value() && parsedMax->bgType == 0xFFFFu,
+		"BgQueue boundary: bgType max");
+}
+
+static void TestQueueRequestRejectsShort()
+{
+	auto parsed = ParseBgQueueRequestPayload(nullptr, 3u);
+	Assert(!parsed.has_value(), "BgQueue request rejects nullptr");
+	uint8_t shortBuf[2]{};
+	auto parsed2 = ParseBgQueueRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "BgQueue request rejects 2 bytes");
+}
+
+static void TestQueueResponseOk()
+{
+	auto buf = BuildBgQueueResponsePayload(0u, 30u, 5u);
+	Assert(buf.size() == 9u, "BgQueue response Ok size 9");
+	auto parsed = ParseBgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u
+		&& parsed->estimatedWaitSec == 30u && parsed->queuePosition == 5u,
+		"BgQueue response Ok parses");
+}
+
+static void TestQueueResponseError()
+{
+	auto buf = BuildBgQueueResponsePayload(
+		static_cast<uint8_t>(BgErrorCode::AlreadyQueued), 0u, 0u);
+	Assert(buf.size() == 1u, "BgQueue response error has only 1 byte");
+	auto parsed = ParseBgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "BgQueue response AlreadyQueued");
+}
+
+static void TestQueueResponseUnknownBg()
+{
+	auto buf = BuildBgQueueResponsePayload(
+		static_cast<uint8_t>(BgErrorCode::UnknownBg), 0u, 0u);
+	auto parsed = ParseBgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "BgQueue response UnknownBg");
+}
+
+static void TestQueueResponseInvalidFaction()
+{
+	auto buf = BuildBgQueueResponsePayload(
+		static_cast<uint8_t>(BgErrorCode::InvalidFaction), 0u, 0u);
+	auto parsed = ParseBgQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "BgQueue response InvalidFaction");
+}
+
+static void TestQueueResponsePacket()
+{
+	auto pkt = BuildBgQueueResponsePacket(0u, 60u, 1u, 12345u, 0xBEEFull);
+	Assert(!pkt.empty(), "BgQueue packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"BgQueue PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgQueueResponse, "Opcode is BgQueueResponse");
+	Assert(view.RequestId() == 12345u, "BgQueue RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// BG_LEAVE_QUEUE
+// -----------------------------------------------------------------------------
+
+static void TestLeaveQueueRequestRoundTrip()
+{
+	auto buf = BuildBgLeaveQueueRequestPayload();
+	Assert(buf.empty(), "BgLeaveQueue request payload empty");
+	auto parsed = ParseBgLeaveQueueRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "BgLeaveQueue accepts empty payload");
+}
+
+static void TestLeaveQueueResponseOk()
+{
+	auto buf = BuildBgLeaveQueueResponsePayload(0u);
+	Assert(buf.size() == 1u, "BgLeaveQueue response Ok size 1");
+	auto parsed = ParseBgLeaveQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "BgLeaveQueue Ok parses");
+}
+
+static void TestLeaveQueueResponseNotInQueue()
+{
+	auto buf = BuildBgLeaveQueueResponsePayload(
+		static_cast<uint8_t>(BgErrorCode::NotInQueue));
+	auto parsed = ParseBgLeaveQueueResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 4u, "BgLeaveQueue NotInQueue");
+}
+
+static void TestLeaveQueueResponsePacket()
+{
+	auto pkt = BuildBgLeaveQueueResponsePacket(0u, 99u, 0xFEEDull);
+	Assert(!pkt.empty(), "BgLeaveQueue packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"BgLeaveQueue PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgLeaveQueueResponse, "Opcode is BgLeaveQueueResponse");
+	Assert(view.RequestId() == 99u, "BgLeaveQueue RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// BG_MATCH_START_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMatchStartRoundTrip()
+{
+	auto buf = BuildBgMatchStartNotificationPayload(123ull, 1u, "warsong", 10u, 10u);
+	auto parsed = ParseBgMatchStartNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "BgMatchStart parses");
+	if (parsed)
+	{
+		Assert(parsed->matchId == 123ull, "MatchStart matchId");
+		Assert(parsed->bgType == 1u, "MatchStart bgType");
+		Assert(parsed->mapName == "warsong", "MatchStart map");
+		Assert(parsed->allianceCount == 10u, "MatchStart alliance count");
+		Assert(parsed->hordeCount == 10u, "MatchStart horde count");
+	}
+}
+
+static void TestMatchStartEmptyMap()
+{
+	auto buf = BuildBgMatchStartNotificationPayload(7ull, 0u, "", 0u, 0u);
+	auto parsed = ParseBgMatchStartNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->mapName.empty()
+		&& parsed->matchId == 7ull && parsed->allianceCount == 0u && parsed->hordeCount == 0u,
+		"MatchStart empty map + counts 0");
+}
+
+static void TestMatchStartLargeCounts()
+{
+	auto buf = BuildBgMatchStartNotificationPayload(0xDEADBEEFCAFEull, 3u, "alterac", 40u, 40u);
+	auto parsed = ParseBgMatchStartNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->matchId == 0xDEADBEEFCAFEull
+		&& parsed->allianceCount == 40u && parsed->hordeCount == 40u, "MatchStart large counts");
+}
+
+static void TestMatchStartRejectsShort()
+{
+	auto parsed = ParseBgMatchStartNotificationPayload(nullptr, 14u);
+	Assert(!parsed.has_value(), "MatchStart rejects nullptr");
+	uint8_t shortBuf[13]{};
+	auto parsed2 = ParseBgMatchStartNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchStart rejects 13 bytes");
+}
+
+static void TestMatchStartPacket()
+{
+	auto pkt = BuildBgMatchStartNotificationPacket(42ull, 2u, "arathi", 15u, 15u, 0xC0DEull);
+	Assert(!pkt.empty(), "MatchStart packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MatchStart PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgMatchStartNotification, "Opcode is MatchStart");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xC0DEull, "MatchStart SessionId preserved");
+	auto parsed = ParseBgMatchStartNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->matchId == 42ull
+		&& parsed->bgType == 2u && parsed->mapName == "arathi",
+		"MatchStart payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// BG_SCORE_UPDATE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestScoreUpdateRoundTrip()
+{
+	auto buf = BuildBgScoreUpdateNotificationPayload(123ull, 500u, 250u, 60u);
+	Assert(buf.size() == 20u, "ScoreUpdate payload size 20");
+	auto parsed = ParseBgScoreUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ScoreUpdate parses");
+	if (parsed)
+	{
+		Assert(parsed->matchId == 123ull, "ScoreUpdate matchId");
+		Assert(parsed->allianceScore == 500u, "ScoreUpdate alliance");
+		Assert(parsed->hordeScore == 250u, "ScoreUpdate horde");
+		Assert(parsed->elapsedSec == 60u, "ScoreUpdate elapsed");
+	}
+}
+
+static void TestScoreUpdateZero()
+{
+	auto buf = BuildBgScoreUpdateNotificationPayload(1ull, 0u, 0u, 0u);
+	auto parsed = ParseBgScoreUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->allianceScore == 0u && parsed->hordeScore == 0u
+		&& parsed->elapsedSec == 0u, "ScoreUpdate zero");
+}
+
+static void TestScoreUpdateMax()
+{
+	auto buf = BuildBgScoreUpdateNotificationPayload(0xFFFFFFFFFFFFFFFFull,
+		0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu);
+	auto parsed = ParseBgScoreUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->matchId == 0xFFFFFFFFFFFFFFFFull
+		&& parsed->allianceScore == 0xFFFFFFFFu, "ScoreUpdate max");
+}
+
+static void TestScoreUpdateRejectsShort()
+{
+	auto parsed = ParseBgScoreUpdateNotificationPayload(nullptr, 20u);
+	Assert(!parsed.has_value(), "ScoreUpdate rejects nullptr");
+	uint8_t shortBuf[19]{};
+	auto parsed2 = ParseBgScoreUpdateNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "ScoreUpdate rejects 19 bytes");
+}
+
+static void TestScoreUpdatePacket()
+{
+	auto pkt = BuildBgScoreUpdateNotificationPacket(7ull, 100u, 200u, 30u, 0xFADEull);
+	Assert(!pkt.empty(), "ScoreUpdate packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"ScoreUpdate PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgScoreUpdateNotification, "Opcode is ScoreUpdate");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+}
+
+// -----------------------------------------------------------------------------
+// BG_MATCH_END_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMatchEndAlliance()
+{
+	auto buf = BuildBgMatchEndNotificationPayload(123ull, 0u, 1500u, 0u, 225u);
+	Assert(buf.size() == 21u, "MatchEnd payload size 21");
+	auto parsed = ParseBgMatchEndNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MatchEnd alliance parses");
+	if (parsed)
+	{
+		Assert(parsed->matchId == 123ull, "MatchEnd matchId");
+		Assert(parsed->winnerFaction == 0u, "MatchEnd Alliance wins");
+		Assert(parsed->allianceScore == 1500u, "MatchEnd alliance score");
+		Assert(parsed->hordeScore == 0u, "MatchEnd horde score");
+		Assert(parsed->durationSec == 225u, "MatchEnd duration");
+	}
+}
+
+static void TestMatchEndHorde()
+{
+	auto buf = BuildBgMatchEndNotificationPayload(456ull, 1u, 200u, 1500u, 600u);
+	auto parsed = ParseBgMatchEndNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerFaction == 1u
+		&& parsed->hordeScore == 1500u, "MatchEnd Horde wins");
+}
+
+static void TestMatchEndDraw()
+{
+	auto buf = BuildBgMatchEndNotificationPayload(789ull, 2u, 750u, 750u, 1200u);
+	auto parsed = ParseBgMatchEndNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerFaction == 2u, "MatchEnd Draw");
+}
+
+static void TestMatchEndRejectsShort()
+{
+	auto parsed = ParseBgMatchEndNotificationPayload(nullptr, 21u);
+	Assert(!parsed.has_value(), "MatchEnd rejects nullptr");
+	uint8_t shortBuf[20]{};
+	auto parsed2 = ParseBgMatchEndNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MatchEnd rejects 20 bytes");
+}
+
+static void TestMatchEndPacket()
+{
+	auto pkt = BuildBgMatchEndNotificationPacket(99ull, 0u, 800u, 600u, 540u, 0xABCDull);
+	Assert(!pkt.empty(), "MatchEnd packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MatchEnd PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeBgMatchEndNotification, "Opcode is MatchEnd");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	auto parsed = ParseBgMatchEndNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->matchId == 99ull && parsed->winnerFaction == 0u,
+		"MatchEnd payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// BG_LEAVE_MATCH (fire-and-forget)
+// -----------------------------------------------------------------------------
+
+static void TestLeaveMatchRequestRoundTrip()
+{
+	auto buf = BuildBgLeaveMatchRequestPayload();
+	Assert(buf.empty(), "BgLeaveMatch request payload empty");
+	auto parsed = ParseBgLeaveMatchRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "BgLeaveMatch accepts empty payload");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseFull();
+	TestListResponseError();
+	TestListResponseRejectsShort();
+	TestListResponsePacket();
+
+	TestQueueRequestRoundTrip();
+	TestQueueRequestBoundary();
+	TestQueueRequestRejectsShort();
+	TestQueueResponseOk();
+	TestQueueResponseError();
+	TestQueueResponseUnknownBg();
+	TestQueueResponseInvalidFaction();
+	TestQueueResponsePacket();
+
+	TestLeaveQueueRequestRoundTrip();
+	TestLeaveQueueResponseOk();
+	TestLeaveQueueResponseNotInQueue();
+	TestLeaveQueueResponsePacket();
+
+	TestMatchStartRoundTrip();
+	TestMatchStartEmptyMap();
+	TestMatchStartLargeCounts();
+	TestMatchStartRejectsShort();
+	TestMatchStartPacket();
+
+	TestScoreUpdateRoundTrip();
+	TestScoreUpdateZero();
+	TestScoreUpdateMax();
+	TestScoreUpdateRejectsShort();
+	TestScoreUpdatePacket();
+
+	TestMatchEndAlliance();
+	TestMatchEndHorde();
+	TestMatchEndDraw();
+	TestMatchEndRejectsShort();
+	TestMatchEndPacket();
+
+	TestLeaveMatchRequestRoundTrip();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all battleground payload tests passed\n"
+	                                : "[FAIL] some battleground tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -499,4 +499,41 @@ namespace engine::network
 	constexpr uint16_t kOpcodeArenaMatchAcceptRequest        = 127u; ///< Client to Master : accepte (true) ou rejette (false) le match propose (proposalId + accept bool).
 	constexpr uint16_t kOpcodeArenaMatchAcceptResponse       = 128u; ///< Master to Client : ACK Ok ou ProposalExpired / UnknownProposal / Unauthorized.
 	constexpr uint16_t kOpcodeArenaMatchResultNotification   = 129u; ///< Master to Client (push, request_id=0) : fin de match (win bool, oldRating, newRating, opponentName).
+
+	// =====================================================================
+	// CMANGOS.10 step 3+4 — BattleGround wire (BG list, queue par faction
+	// Alliance/Horde, match start, score updates, match end). Master tient
+	// en memoire un BattleGroundQueue + matches actifs (V1).
+	//
+	// Architecture : 3 BG hardcodes au boot (Warsong Gulch, Arathi Basin,
+	// Alterac Valley). Le master tient en memoire la queue par account et
+	// les matches actifs. V1 simplifie : a la queue, master cree
+	// immediatement un match contre AI bot (faction opposee) et push la
+	// sequence Start -> Score(s) -> End. Pas besoin de Tick().
+	//
+	// V1 limitations :
+	//   - 3 BG hardcodes (Warsong/Arathi/Alterac). Vrais BG via M40+ futur.
+	//   - Match vs AI bot fictif (V1) ; vrai matchmaking 2 factions a venir.
+	//   - Score evolution simulee instantanee (V1) ; vrai gameplay BG via shardd futur.
+	//   - Pas de SyncBg RPC entre master et shardd (master autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - List       (130/131)               : liste des BG disponibles.
+	//   - Queue      (132/133)               : inscription en queue (bgType + faction 0/1).
+	//   - LeaveQueue (134/135)               : quitte la queue.
+	//   - MatchStartNotification (136, push) : match commence (matchId, mapName, counts).
+	//   - ScoreUpdateNotification (137, push): scores changes (matchId, scores, elapsed).
+	//   - MatchEndNotification (138, push)   : fin de match (winnerFaction, scores, duration).
+	//   - LeaveMatch (139)                   : forfait V1 (push fire-and-forget, pas de Response paire).
+	// =====================================================================
+	constexpr uint16_t kOpcodeBgListRequest                = 130u; ///< Client to Master : liste des BG disponibles (vide).
+	constexpr uint16_t kOpcodeBgListResponse               = 131u; ///< Master to Client : liste {bgType, name, teamSize, mapName} ou Unauthorized.
+	constexpr uint16_t kOpcodeBgQueueRequest               = 132u; ///< Client to Master : s'inscrit en queue BG (bgType + faction Alliance=0/Horde=1).
+	constexpr uint16_t kOpcodeBgQueueResponse              = 133u; ///< Master to Client : OK + estimatedWaitSec + queuePosition, ou AlreadyQueued / UnknownBg / InvalidFaction / Unauthorized.
+	constexpr uint16_t kOpcodeBgLeaveQueueRequest          = 134u; ///< Client to Master : quitte la queue BG (vide).
+	constexpr uint16_t kOpcodeBgLeaveQueueResponse         = 135u; ///< Master to Client : OK ou NotInQueue / Unauthorized.
+	constexpr uint16_t kOpcodeBgMatchStartNotification     = 136u; ///< Master to Client (push, request_id=0) : match commence (bgType, mapName, allianceCount, hordeCount, matchId).
+	constexpr uint16_t kOpcodeBgScoreUpdateNotification    = 137u; ///< Master to Client (push, request_id=0) : score changes (matchId, allianceScore, hordeScore, elapsedSec).
+	constexpr uint16_t kOpcodeBgMatchEndNotification       = 138u; ///< Master to Client (push, request_id=0) : fin de match (matchId, winnerFaction 0/1/2 = Alliance/Horde/Draw, allianceScore, hordeScore, durationSec).
+	constexpr uint16_t kOpcodeBgLeaveMatchRequest          = 139u; ///< Client to Master : quitte le match en cours (forfait V1) ou vide.
 }


### PR DESCRIPTION
## Phase 5 — CMANGOS.10 step 3+4 : BattleGround wire (queue + match flow + UI)

Branche `BattleGroundQueue` (step 1+2 merge — FIFO faction-balanced matchmaking) sur le wire queue/start/score/end + UI client.
Master tient en mémoire 3 BG hardcodés (Warsong, Arathi, Alterac) + queue + matches
actifs, pousse la séquence `MatchStart → 3× ScoreUpdate → MatchEnd` après queue (V1 vs AI bot).

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 10 opcodes (130-139)
  - `130/131` BgList Request/Response
  - `132/133` BgQueue Request/Response
  - `134/135` BgLeaveQueue Request/Response
  - `136` BgMatchStartNotification (push)
  - `137` BgScoreUpdateNotification (push)
  - `138` BgMatchEndNotification (push)
  - `139` BgLeaveMatchRequest (fire-and-forget — push EndNotification en réponse)
- `src/shared/network/BattleGroundPayloads.{h,cpp,Tests.cpp}` : 33 tests round-trip + edge cases
- `src/masterd/handlers/battleground/BattleGroundHandler.{h,cpp}` :
  - 3 BG hardcodés : Warsong Gulch (10v10), Arathi Basin (15v15), Alterac Valley (40v40)
  - In-memory queue + active matches map (mutex protégé)
  - `PushMatchStart` / `PushScoreUpdate` / `PushMatchEnd` helpers publics
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 130/132/134/139

### Client integration
- `src/client/battleground/BattleGroundUi.{h,cpp}` : presenter + state (BG list, queue, active match scoreboard, last result)
- `src/client/render/BattleGroundImGuiRenderer.{h,cpp}` : panel ImGui (BG list + Queue Alliance/Horde, queue status, scoreboard live, toast result)
- `src/client/app/Engine` : dispatch + slash `/bg` + touche `G` toggle (mêmes guards que Skills/Arena)
- `CMakeLists.txt` : sources + `battleground_payloads_tests` target

### V1 limitations (consignées)
- 3 BG hardcodés (Warsong/Arathi/Alterac). Vrais BG via M40+ futur.
- Match vs AI bot fictif (V1) ; vrai matchmaking 2 factions à venir.
- Score evolution simulée instantanée (5/10/15s « fake elapsed ») ; vrai gameplay BG via shardd futur.
- Pas de SyncBg RPC entre master et shardd (master autoritaire V1).

### Tests
- `battleground_payloads_tests` (33 tests : round-trip, headers, boundaries, error codes, score updates) — voir `src/shared/network/BattleGroundPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 130-139 + handler BattleGroundHandler. Sans redéploiement, les requests BG d'un client neuf retourneraient BAD_REQUEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)