### PR TITLE
feat(weather): wire zone subscribe + push updates + HUD client (CMANGOS.42)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ add_library(engine_core
   src/client/arena/ArenaUi.cpp
   src/client/battleground/BattleGroundUi.cpp
   src/client/outdoorpvp/OutdoorPvpUi.cpp
+  src/client/weather/WeatherUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -345,6 +346,7 @@ add_library(engine_core
   src/client/render/ArenaImGuiRenderer.cpp
   src/client/render/BattleGroundImGuiRenderer.cpp
   src/client/render/OutdoorPvpImGuiRenderer.cpp
+  src/client/render/WeatherImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -444,6 +446,7 @@ add_library(engine_core
   src/shared/network/ArenaPayloads.cpp
   src/shared/network/BattleGroundPayloads.cpp
   src/shared/network/OutdoorPvpPayloads.cpp
+  src/shared/network/WeatherPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -709,6 +712,11 @@ add_test(NAME battleground_payloads_tests COMMAND battleground_payloads_tests)
 add_executable(outdoorpvp_payloads_tests src/shared/network/OutdoorPvpPayloadsTests.cpp)
 target_link_libraries(outdoorpvp_payloads_tests PRIVATE engine_core)
 add_test(NAME outdoorpvp_payloads_tests COMMAND outdoorpvp_payloads_tests)
+
+# CMANGOS.42 (Phase 4.42 step 3+4) — Weather payloads round-trip tests (no DB / no network).
+add_executable(weather_payloads_tests src/shared/network/WeatherPayloadsTests.cpp)
+target_link_libraries(weather_payloads_tests PRIVATE engine_core)
+add_test(NAME weather_payloads_tests COMMAND weather_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/arena/ArenaHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/battleground/BattleGroundHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/weather/WeatherHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -137,6 +138,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ArenaPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/BattleGroundPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/OutdoorPvpPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/WeatherPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -16,6 +16,7 @@
 #include "src/shared/network/ArenaPayloads.h"
 #include "src/shared/network/BattleGroundPayloads.h"
 #include "src/shared/network/OutdoorPvpPayloads.h"
+#include "src/shared/network/WeatherPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -30,6 +31,7 @@
 #include "src/client/render/ArenaImGuiRenderer.h"
 #include "src/client/render/BattleGroundImGuiRenderer.h"
 #include "src/client/render/OutdoorPvpImGuiRenderer.h"
+#include "src/client/render/WeatherImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -974,6 +976,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.42 (Phase 4.42 step 3+4) — Init du presenter Weather + cable
+		// du send callback pour les requetes 150/152/154. Reception
+		// dispatchee dans le push handler ci-dessous (responses 151/153/155
+		// + push 156).
+		if (!m_weatherUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] WeatherUiPresenter init FAILED — panneau Weather desactive");
+		}
+		else
+		{
+			m_weatherUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1162,6 +1179,21 @@ namespace engine
 					m_outdoorPvpUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] /pvp toggle (visible={})", m_outdoorPvpVisible);
+				return true;
+			}
+			// CMANGOS.42 (Phase 4.42 step 3+4) — Slash command /weather pour
+			// ouvrir/fermer le panneau Weather et synchroniser la liste des
+			// zones meteo depuis le master au moment de l'ouverture. La
+			// touche Y fait la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/weather" || text.starts_with("/weather ") || text.starts_with("/weather\t")))
+			{
+				m_weatherVisible = !m_weatherVisible;
+				if (m_weatherVisible)
+				{
+					m_weatherUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] /weather toggle (visible={})", m_weatherVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1734,6 +1766,52 @@ namespace engine
 					return;
 				}
 				m_outdoorPvpUi.OnCaptureCompletedNotification(*parsed);
+				return;
+			}
+			// CMANGOS.42 (Phase 4.42 step 3+4) — Dispatch des reponses Weather
+			// (151/153/155) + push notification (156).
+			case kOpcodeWeatherListResponse:
+			{
+				auto parsed = ParseWeatherListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] WEATHER_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_weatherUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeWeatherSubscribeResponse:
+			{
+				auto parsed = ParseWeatherSubscribeResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] WEATHER_SUBSCRIBE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_weatherUi.OnSubscribeResponse(*parsed);
+				return;
+			}
+			case kOpcodeWeatherUnsubscribeResponse:
+			{
+				auto parsed = ParseWeatherUnsubscribeResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] WEATHER_UNSUBSCRIBE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_weatherUi.OnUnsubscribeResponse(*parsed);
+				return;
+			}
+			case kOpcodeWeatherUpdateNotification:
+			{
+				auto parsed = ParseWeatherUpdateNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] WEATHER_UPDATE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_weatherUi.OnUpdateNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -4038,6 +4116,7 @@ namespace engine
 		m_arenaUi.Shutdown();
 		m_battleGroundUi.Shutdown();
 		m_outdoorPvpUi.Shutdown();
+		m_weatherUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -4180,6 +4259,23 @@ namespace engine
 					m_outdoorPvpUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] P toggle outdoorpvp (visible={})", m_outdoorPvpVisible);
+			}
+			// CMANGOS.42 (Phase 4.42 step 3+4) — Touche Y : toggle panneau
+			// Weather + RequestList si on l'ouvre. Memes guards que A/G/P.
+			// Note : la touche Y est aussi utilisee comme Ctrl+Y pour le
+			// redo dans WorldEditorShell, mais le guard inGameNoMenu inclut
+			// !m_editorEnabled donc pas de conflit. WorldEditorShell traite
+			// Ctrl+Y / Ctrl+Shift+Y dans son propre bloc en aval.
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::Y))
+			{
+				m_weatherVisible = !m_weatherVisible;
+				if (m_weatherVisible)
+				{
+					m_weatherUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] Y toggle weather (visible={})", m_weatherVisible);
 			}
 		}
 
@@ -4390,6 +4486,13 @@ namespace engine
 				// (toggle via /pvp ou touche P).
 				m_outdoorPvpImGui = std::make_unique<engine::render::OutdoorPvpImGuiRenderer>();
 				m_outdoorPvpImGui->SetPresenter(&m_outdoorPvpUi);
+				// CMANGOS.42 (Phase 4.42 step 3+4) — Renderer ImGui Weather.
+				// Le panel principal n'est visible que quand m_weatherVisible
+				// (toggle via /weather ou touche Y). Le HUD top-right est
+				// rendu independamment des que activeZoneId est set sur le
+				// presenter (selectionne via le bouton "Set Active" du panel).
+				m_weatherImGui = std::make_unique<engine::render::WeatherImGuiRenderer>();
+				m_weatherImGui->SetPresenter(&m_weatherUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5491,6 +5594,17 @@ namespace engine
 				m_outdoorPvpImGui->SetEnabled(true);
 				m_outdoorPvpImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_outdoorPvpImGui->Render();
+			}
+			// CMANGOS.42 (Phase 4.42 step 3+4) — Render du panel Weather si
+			// m_weatherVisible (toggle via /weather ou touche Y), ET du HUD
+			// top-right si activeZoneId set. Render() lui-meme gere ces
+			// 2 cas independamment : on lui passe juste l'enabled flag pour
+			// le panel ; le HUD est conditionne par le presenter state.
+			if (m_weatherImGui && m_weatherUi.IsInitialized())
+			{
+				m_weatherImGui->SetEnabled(m_weatherVisible);
+				m_weatherImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_weatherImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -15,6 +15,7 @@
 #include "src/client/arena/ArenaUi.h"
 #include "src/client/battleground/BattleGroundUi.h"
 #include "src/client/outdoorpvp/OutdoorPvpUi.h"
+#include "src/client/weather/WeatherUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -83,6 +84,7 @@ namespace engine::render
 	class ArenaImGuiRenderer;
 	class BattleGroundImGuiRenderer;
 	class OutdoorPvpImGuiRenderer;
+	class WeatherImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -377,6 +379,12 @@ namespace engine
 		/// Visible uniquement quand m_outdoorPvpVisible (toggle via slash
 		/// command /pvp ou touche P).
 		std::unique_ptr<engine::render::OutdoorPvpImGuiRenderer> m_outdoorPvpImGui;
+		/// CMANGOS.42 (Phase 4.42 step 3+4) — Panneau "Weather" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec les autres panneaux post-auth.
+		/// Le panel principal est visible uniquement quand m_weatherVisible
+		/// (toggle via slash command /weather ou touche Y). Le HUD top-right
+		/// est rendu independamment du flag des que activeZoneId est set.
+		std::unique_ptr<engine::render::WeatherImGuiRenderer> m_weatherImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -523,6 +531,15 @@ namespace engine
 		/// CMANGOS.36 (Phase 5.36 step 3+4) — Visibilite du panneau OutdoorPvp
 		/// (toggle via slash command \c /pvp ou touche P). Faux par defaut.
 		bool                                  m_outdoorPvpVisible = false;
+		/// CMANGOS.42 (Phase 4.42 step 3+4) — Presenter de la fenetre Weather.
+		/// Recoit les responses opcodes 151/153/155 et la push notification
+		/// 156 via le push handler du master ; fire-and-forget des requetes
+		/// 150/152/154 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::WeatherUiPresenter   m_weatherUi;
+		/// CMANGOS.42 (Phase 4.42 step 3+4) — Visibilite du panneau Weather
+		/// (toggle via slash command \c /weather ou touche Y). Faux par defaut.
+		/// Le HUD top-right est rendu independamment quand activeZoneId set.
+		bool                                  m_weatherVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/render/WeatherImGuiRenderer.cpp
+++ b/src/client/render/WeatherImGuiRenderer.cpp
@@ -1,0 +1,276 @@
+// CMANGOS.42 (Phase 4.42 step 3+4) — WeatherImGuiRenderer implementation.
+
+#include "src/client/render/WeatherImGuiRenderer.h"
+
+#include "src/client/weather/WeatherUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Couleur ImGui par WeatherKind pour le texte (intensifie le visuel
+		/// de la liste / HUD). Inputs invalides -> gris.
+		ImVec4 KindColor(uint8_t kind)
+		{
+			switch (kind)
+			{
+			case 0: return ImVec4(1.0f, 0.95f, 0.40f, 1.f); // Clear -> jaune.
+			case 1: return ImVec4(0.40f, 0.65f, 1.00f, 1.f); // Rain -> bleu.
+			case 2: return ImVec4(0.92f, 0.95f, 1.00f, 1.f); // Snow -> blanc.
+			case 3: return ImVec4(0.75f, 0.40f, 0.95f, 1.f); // Storm -> violet.
+			case 4: return ImVec4(0.95f, 0.65f, 0.30f, 1.f); // Sandstorm -> orange.
+			case 5: return ImVec4(0.60f, 0.60f, 0.65f, 1.f); // Fog -> gris.
+			default: return ImVec4(0.7f, 0.7f, 0.7f, 1.f);
+			}
+		}
+
+		/// Petit "icone" textuel ASCII pour le HUD (pas d'emoji, MSVC
+		/// strict + Arial dans editor monde sans certains glyphs).
+		const char* KindIcon(uint8_t kind)
+		{
+			switch (kind)
+			{
+			case 0: return "[*]";  // Clear (etoile / soleil).
+			case 1: return "[/]";  // Rain (gouttes obliques).
+			case 2: return "[#]";  // Snow (flocon).
+			case 3: return "[!]";  // Storm.
+			case 4: return "[~]";  // Sandstorm.
+			case 5: return "[=]";  // Fog (brume).
+			default: return "[?]";
+			}
+		}
+	}
+
+	void WeatherImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		// Le panel n'est rendu que si IsEnabled().
+		if (m_enabled)
+			RenderMainPanel();
+
+		// Le HUD est rendu independamment, si activeZoneId set.
+		RenderHud();
+	}
+
+	void WeatherImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 460x500.
+		const float panelW = 460.f;
+		const float panelH = 500.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		// Decale un peu plus bas pour ne pas chevaucher avec le HUD top-right.
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Weather##ln_weather_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Liste des zones.
+			if (!state.zonesLoaded || state.zones.empty())
+			{
+				if (ImGui::Button("Charger les zones meteo", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->RequestList();
+				if (state.zonesLoaded && state.zones.empty())
+				{
+					ImGui::TextWrapped("Aucune zone meteo.");
+				}
+			}
+			else
+			{
+				ImGui::TextUnformatted("Zones meteo :");
+				ImGui::Separator();
+
+				for (const auto& z : state.zones)
+				{
+					ImGui::PushID(static_cast<int>(z.zoneId));
+
+					// Header de zone : icone + nom + (zone N).
+					ImGui::PushStyleColor(ImGuiCol_Text, KindColor(z.kind));
+					ImGui::Text("%s %s", KindIcon(z.kind), z.name.c_str());
+					ImGui::PopStyleColor();
+
+					// Sous-ligne : kind name + intensity %.
+					ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.85f, 0.85f, 0.85f, 1.f));
+					ImGui::Text("Etat : %s  -  Intensite : %.0f%%",
+						engine::client::WeatherKindName(z.kind),
+						static_cast<double>(z.intensity * 100.0f));
+					ImGui::PopStyleColor();
+
+					// Intensity bar.
+					const float pct = std::min(1.f, std::max(0.f, z.intensity));
+					ImGui::ProgressBar(pct, ImVec2(-FLT_MIN, 14.f));
+
+					// Boutons : Set Active / Subscribe / Unsubscribe.
+					const bool isActive = state.activeZoneId.has_value()
+						&& *state.activeZoneId == z.zoneId;
+					if (isActive)
+					{
+						ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.30f, 0.55f, 0.30f, 1.f));
+						if (ImGui::Button("Active (HUD)##active", ImVec2(140.f, 24.f)))
+							m_presenter->ClearActiveZone();
+						ImGui::PopStyleColor();
+					}
+					else
+					{
+						if (ImGui::Button("Set Active##active", ImVec2(140.f, 24.f)))
+							m_presenter->SetActiveZone(z.zoneId);
+					}
+
+					ImGui::SameLine();
+					const bool isSubscribed = state.subscribedZones.count(z.zoneId) > 0u;
+					if (isSubscribed)
+					{
+						ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.55f, 0.20f, 0.20f, 1.f));
+						if (ImGui::Button("Se desabonner##sub", ImVec2(160.f, 24.f)))
+							m_presenter->Unsubscribe(z.zoneId);
+						ImGui::PopStyleColor();
+					}
+					else
+					{
+						ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.45f, 0.30f, 1.f));
+						if (ImGui::Button("S'abonner##sub", ImVec2(160.f, 24.f)))
+							m_presenter->Subscribe(z.zoneId);
+						ImGui::PopStyleColor();
+					}
+
+					ImGui::Separator();
+					ImGui::PopID();
+				}
+
+				ImGui::Spacing();
+				if (ImGui::Button("Rafraichir la liste", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->RequestList();
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void WeatherImGuiRenderer::RenderHud()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		const auto& state = m_presenter->GetState();
+		if (!state.activeZoneId.has_value())
+			return;
+
+		const uint32_t zid = *state.activeZoneId;
+
+		// Cherche le nom de la zone dans le cache. Si absent, "Zone <id>".
+		std::string zoneName;
+		for (const auto& z : state.zones)
+		{
+			if (z.zoneId == zid)
+			{
+				zoneName = z.name;
+				break;
+			}
+		}
+		if (zoneName.empty())
+		{
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Zone %u", static_cast<unsigned>(zid));
+			zoneName = buf;
+		}
+
+		// Geometrie HUD : top-right, 240x70, hors viewport border de 16px.
+		const float hudW = 240.f;
+		const float hudH = 70.f;
+		const float margin = 16.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float posX = std::max(0.f, vpW - hudW - margin);
+		const float posY = margin;
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(hudW, hudH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.45f);
+
+		const ImGuiWindowFlags hudFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing;
+
+		if (ImGui::Begin("##ln_weather_hud", nullptr, hudFlags))
+		{
+			// Ligne 1 : icone (colore) + nom de zone.
+			ImGui::PushStyleColor(ImGuiCol_Text, KindColor(state.activeKind));
+			ImGui::Text("%s", KindIcon(state.activeKind));
+			ImGui::PopStyleColor();
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 1.f, 1.f, 1.f));
+			ImGui::TextUnformatted(zoneName.c_str());
+			ImGui::PopStyleColor();
+
+			// Ligne 2 : kind name + intensity %.
+			ImGui::PushStyleColor(ImGuiCol_Text, KindColor(state.activeKind));
+			ImGui::Text("%s  %.0f%%",
+				engine::client::WeatherKindName(state.activeKind),
+				static_cast<double>(state.activeIntensity * 100.0f));
+			ImGui::PopStyleColor();
+
+			// Ligne 3 : intensity bar.
+			const float pct = std::min(1.f, std::max(0.f, state.activeIntensity));
+			ImGui::ProgressBar(pct, ImVec2(-FLT_MIN, 8.f));
+		}
+		ImGui::End();
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void WeatherImGuiRenderer::Render()           {}
+	void WeatherImGuiRenderer::RenderMainPanel()  {}
+	void WeatherImGuiRenderer::RenderHud()        {}
+}
+
+#endif

--- a/src/client/render/WeatherImGuiRenderer.h
+++ b/src/client/render/WeatherImGuiRenderer.h
@@ -1,0 +1,58 @@
+#pragma once
+// CMANGOS.42 (Phase 4.42 step 3+4) — WeatherImGuiRenderer : 2 modes de
+// rendering pour la meteo cote client :
+//   1. Window panel "Weather" (toggleable via touche Y / slash /weather) :
+//      liste des zones avec kind + intensity bar, boutons Subscribe/Unsubscribe
+//      et Set Active (selectionne la zone HUD).
+//   2. HUD top-right overlay (toujours rendu si activeZoneId set) : icone
+//      + nom de la zone + kind + intensity bar. Pas de titre, non-deplaçable.
+//
+// Lit l'etat d'un WeatherUiPresenter, dispatch les inputs UI (RequestList /
+// Subscribe / Unsubscribe / SetActiveZone) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class WeatherUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui des composants Weather. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::WeatherUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs UI
+	/// vers le presenter.
+	class WeatherImGuiRenderer
+	{
+	public:
+		WeatherImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::WeatherUiPresenter* presenter) { m_presenter = presenter; }
+
+		/// Active/desactive le rendu du panel principal. Le HUD top-right est
+		/// independant de ce flag (toujours rendu si activeZoneId set).
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau et du HUD.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Weather" (si IsEnabled()) et le HUD top-right
+		/// (si activeZoneId set, independamment de IsEnabled()). A appeler
+		/// entre \c ImGui::NewFrame() et \c ImGui::Render(), apres NewFrame,
+		/// si le presenter est valide.
+		void Render();
+
+		/// Render uniquement le HUD top-right (utilise si on veut le HUD
+		/// sans le panel ; appelable independamment de Render() si besoin).
+		void RenderHud();
+
+	private:
+		/// Dessine le panneau principal (liste zones + boutons + intensity bars).
+		void RenderMainPanel();
+
+		engine::client::WeatherUiPresenter* m_presenter = nullptr;
+		bool                                m_enabled   = false;
+		uint32_t                            m_viewportW = 0;
+		uint32_t                            m_viewportH = 0;
+	};
+}

--- a/src/client/weather/WeatherUi.cpp
+++ b/src/client/weather/WeatherUi.cpp
@@ -1,0 +1,321 @@
+// CMANGOS.42 (Phase 4.42 step 3+4) — Implementation WeatherUiPresenter.
+
+#include "src/client/weather/WeatherUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::client
+{
+	// -------------------------------------------------------------------------
+	// WeatherKindName — static helper.
+	// -------------------------------------------------------------------------
+
+	const char* WeatherKindName(uint8_t kind)
+	{
+		switch (kind)
+		{
+		case 0: return "Clear";
+		case 1: return "Rain";
+		case 2: return "Snow";
+		case 3: return "Storm";
+		case 4: return "Sandstorm";
+		case 5: return "Fog";
+		default: return "?";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Presenter lifecycle
+	// -------------------------------------------------------------------------
+
+	WeatherUiPresenter::~WeatherUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool WeatherUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[WeatherUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_pendingSubscribeZoneId   = 0;
+		m_pendingUnsubscribeZoneId = 0;
+		LOG_INFO(Core, "[WeatherUiPresenter] Init OK");
+		return true;
+	}
+
+	void WeatherUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[WeatherUiPresenter] Destroyed");
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void WeatherUiPresenter::RequestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[WeatherUiPresenter] RequestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildWeatherListRequestPayload();
+		if (!m_send(engine::network::kOpcodeWeatherListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste meteo).";
+			LOG_WARN(Net, "[WeatherUiPresenter] RequestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[WeatherUiPresenter] Weather ListRequest queued");
+	}
+
+	void WeatherUiPresenter::Subscribe(uint32_t zoneId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[WeatherUiPresenter] Subscribe: no send callback");
+			return;
+		}
+		if (zoneId == 0u)
+		{
+			m_state.lastErrorText = "Zone invalide.";
+			LOG_WARN(Net, "[WeatherUiPresenter] Subscribe: invalid zoneId=0");
+			return;
+		}
+		const auto payload = engine::network::BuildWeatherSubscribeRequestPayload(zoneId);
+		m_pendingSubscribeZoneId = zoneId;
+		if (!m_send(engine::network::kOpcodeWeatherSubscribeRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (subscribe meteo).";
+			LOG_WARN(Net, "[WeatherUiPresenter] Subscribe: send failed zoneId={}", zoneId);
+			return;
+		}
+		LOG_DEBUG(Net, "[WeatherUiPresenter] SubscribeRequest queued (zoneId={})", zoneId);
+	}
+
+	void WeatherUiPresenter::Unsubscribe(uint32_t zoneId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[WeatherUiPresenter] Unsubscribe: no send callback");
+			return;
+		}
+		if (zoneId == 0u)
+		{
+			m_state.lastErrorText = "Zone invalide.";
+			LOG_WARN(Net, "[WeatherUiPresenter] Unsubscribe: invalid zoneId=0");
+			return;
+		}
+		const auto payload = engine::network::BuildWeatherUnsubscribeRequestPayload(zoneId);
+		m_pendingUnsubscribeZoneId = zoneId;
+		if (!m_send(engine::network::kOpcodeWeatherUnsubscribeRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (unsubscribe meteo).";
+			LOG_WARN(Net, "[WeatherUiPresenter] Unsubscribe: send failed zoneId={}", zoneId);
+			return;
+		}
+		LOG_DEBUG(Net, "[WeatherUiPresenter] UnsubscribeRequest queued (zoneId={})", zoneId);
+	}
+
+	void WeatherUiPresenter::SetActiveZone(uint32_t zoneId)
+	{
+		if (zoneId == 0u)
+		{
+			ClearActiveZone();
+			return;
+		}
+		m_state.activeZoneId = zoneId;
+		// Initialise activeKind / activeIntensity depuis le cache si dispo.
+		for (const auto& z : m_state.zones)
+		{
+			if (z.zoneId == zoneId)
+			{
+				m_state.activeKind      = z.kind;
+				m_state.activeIntensity = z.intensity;
+				break;
+			}
+		}
+		LOG_INFO(Core, "[WeatherUiPresenter] SetActiveZone zoneId={} kind={} intensity={:.3f}",
+			zoneId, static_cast<unsigned>(m_state.activeKind),
+			static_cast<double>(m_state.activeIntensity));
+	}
+
+	void WeatherUiPresenter::ClearActiveZone()
+	{
+		m_state.activeZoneId.reset();
+		m_state.activeKind      = 0;
+		m_state.activeIntensity = 0.0f;
+		LOG_INFO(Core, "[WeatherUiPresenter] ClearActiveZone");
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void WeatherUiPresenter::OnListResponse(const engine::network::WeatherListResponsePayload& resp)
+	{
+		using engine::network::WeatherErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<WeatherErrorCode>(resp.error);
+			if (err == WeatherErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur Weather inconnue.";
+			LOG_WARN(Net, "[WeatherUiPresenter] OnListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.zones.clear();
+		m_state.zones.reserve(resp.zones.size());
+		for (const auto& z : resp.zones)
+		{
+			WeatherZoneSummary local;
+			local.zoneId    = z.zoneId;
+			local.name      = z.name;
+			local.kind      = z.kind;
+			local.intensity = z.intensity;
+			m_state.zones.push_back(std::move(local));
+		}
+		m_state.zonesLoaded = true;
+
+		// Si la zone active est dans le cache, met a jour activeKind/intensity.
+		if (m_state.activeZoneId.has_value())
+		{
+			for (const auto& z : m_state.zones)
+			{
+				if (z.zoneId == *m_state.activeZoneId)
+				{
+					m_state.activeKind      = z.kind;
+					m_state.activeIntensity = z.intensity;
+					break;
+				}
+			}
+		}
+
+		LOG_INFO(Net, "[WeatherUiPresenter] OnListResponse OK count={}",
+			m_state.zones.size());
+	}
+
+	void WeatherUiPresenter::OnSubscribeResponse(const engine::network::WeatherSubscribeResponsePayload& resp)
+	{
+		using engine::network::WeatherErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<WeatherErrorCode>(resp.error);
+			switch (err)
+			{
+			case WeatherErrorCode::UnknownZone:
+				m_state.lastErrorText = "Zone meteo inconnue.";
+				break;
+			case WeatherErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Weather inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[WeatherUiPresenter] OnSubscribeResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		if (m_pendingSubscribeZoneId != 0u)
+		{
+			const uint32_t zid = m_pendingSubscribeZoneId;
+			m_state.subscribedZones.insert(zid);
+			m_state.lastInfoText = "Abonne aux push de la zone meteo.";
+			// Mise a jour locale du cache pour la zone subscribed avec
+			// kind + intensity initiales retournes par le master.
+			for (auto& z : m_state.zones)
+			{
+				if (z.zoneId == zid)
+				{
+					z.kind      = resp.currentKind;
+					z.intensity = resp.currentIntensity;
+					break;
+				}
+			}
+			// Si la zone subscribed est l'activeZone, met a jour le HUD.
+			if (m_state.activeZoneId.has_value() && *m_state.activeZoneId == zid)
+			{
+				m_state.activeKind      = resp.currentKind;
+				m_state.activeIntensity = resp.currentIntensity;
+			}
+			LOG_INFO(Net, "[WeatherUiPresenter] OnSubscribeResponse OK zoneId={} kind={} intensity={:.3f}",
+				zid, static_cast<unsigned>(resp.currentKind),
+				static_cast<double>(resp.currentIntensity));
+			m_pendingSubscribeZoneId = 0u;
+		}
+	}
+
+	void WeatherUiPresenter::OnUnsubscribeResponse(const engine::network::WeatherUnsubscribeResponsePayload& resp)
+	{
+		using engine::network::WeatherErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<WeatherErrorCode>(resp.error);
+			switch (err)
+			{
+			case WeatherErrorCode::NotSubscribed:
+				m_state.lastErrorText = "Pas abonne a cette zone meteo.";
+				break;
+			case WeatherErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Weather inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[WeatherUiPresenter] OnUnsubscribeResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		if (m_pendingUnsubscribeZoneId != 0u)
+		{
+			m_state.subscribedZones.erase(m_pendingUnsubscribeZoneId);
+			m_state.lastInfoText = "Desabonne de la zone meteo.";
+			LOG_INFO(Net, "[WeatherUiPresenter] OnUnsubscribeResponse OK zoneId={}",
+				m_pendingUnsubscribeZoneId);
+			m_pendingUnsubscribeZoneId = 0u;
+		}
+	}
+
+	void WeatherUiPresenter::OnUpdateNotification(const engine::network::WeatherUpdateNotificationPayload& note)
+	{
+		// Mise a jour locale du cache zones.
+		for (auto& z : m_state.zones)
+		{
+			if (z.zoneId == note.zoneId)
+			{
+				z.kind      = note.kind;
+				z.intensity = note.intensity;
+				break;
+			}
+		}
+		// Si zone active, met a jour le HUD aussi.
+		if (m_state.activeZoneId.has_value() && *m_state.activeZoneId == note.zoneId)
+		{
+			m_state.activeKind      = note.kind;
+			m_state.activeIntensity = note.intensity;
+		}
+		LOG_DEBUG(Net, "[WeatherUiPresenter] OnUpdateNotification zid={} kind={} intensity={:.3f}",
+			note.zoneId, static_cast<unsigned>(note.kind),
+			static_cast<double>(note.intensity));
+	}
+}

--- a/src/client/weather/WeatherUi.h
+++ b/src/client/weather/WeatherUi.h
@@ -1,0 +1,158 @@
+#pragma once
+// CMANGOS.42 (Phase 4.42 step 3+4) — Presenter client de la fenetre Weather.
+// Maintient un cache local des zones meteo + subscriptions actives + zone
+// active (pour le HUD top-right) + dernier state recu (kind + intensity).
+//
+// Pas de rendu ImGui : le panneau et le HUD sont drawes par
+// WeatherImGuiRenderer qui lit l'etat via GetState() et propage les inputs
+// UI (RequestList / Subscribe / Unsubscribe / SetActiveZone) via les
+// methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans OutdoorPvpUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 151/153/155/156 vers les OnXxx du presenter.
+
+#include "src/shared/network/WeatherPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'une zone meteo exposable au layer UI. Mirror direct
+	/// de engine::network::WeatherZoneSummary.
+	struct WeatherZoneSummary
+	{
+		uint32_t    zoneId    = 0;
+		std::string name;
+		uint8_t     kind      = 0;     ///< 0=Clear, 1=Rain, 2=Snow, 3=Storm, 4=Sandstorm, 5=Fog.
+		float       intensity = 0.0f;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct WeatherUiState
+	{
+		std::vector<WeatherZoneSummary>   zones;
+		bool                              zonesLoaded = false;
+
+		/// Subscriptions actives cote client (pour synchroniser les boutons
+		/// Subscribe/Unsubscribe). Mis a jour aux OnSubscribeResponse Ok /
+		/// OnUnsubscribeResponse Ok.
+		std::unordered_set<uint32_t>      subscribedZones;
+
+		/// Zone actuellement affichee dans le HUD top-right. Si non-set,
+		/// le HUD n'est pas rendu (panneau peut rester ouvert sans HUD).
+		std::optional<uint32_t>           activeZoneId;
+		uint8_t                           activeKind      = 0;     ///< Clear par defaut.
+		float                             activeIntensity = 0.0f;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire (e.g. "Abonne a Stormwind."). Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Static helper : retourne le libelle ASCII en anglais pour un kind donne.
+	/// Inputs invalides (kind > 5) renvoient "?".
+	const char* WeatherKindName(uint8_t kind);
+
+	/// Presenter pour la fenetre Weather cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main (comme les autres presenters UI).
+	class WeatherUiPresenter final
+	{
+	public:
+		WeatherUiPresenter() = default;
+
+		WeatherUiPresenter(const WeatherUiPresenter&)            = delete;
+		WeatherUiPresenter& operator=(const WeatherUiPresenter&) = delete;
+
+		~WeatherUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.42 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / Subscribe / Unsubscribe.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie WEATHER_LIST_REQUEST. Reponse via OnListResponse.
+		void RequestList();
+
+		/// Envoie WEATHER_SUBSCRIBE_REQUEST avec \p zoneId. Reponse via
+		/// OnSubscribeResponse. Le state est mis a jour cote client a
+		/// reception de la reponse Ok.
+		void Subscribe(uint32_t zoneId);
+
+		/// Envoie WEATHER_UNSUBSCRIBE_REQUEST avec \p zoneId. Reponse via
+		/// OnUnsubscribeResponse.
+		void Unsubscribe(uint32_t zoneId);
+
+		/// Selectionne la zone active pour le HUD. Pas d'envoi reseau (purement
+		/// cote client). Le HUD lit activeZoneId + activeKind + activeIntensity ;
+		/// les valeurs activeKind/activeIntensity sont initialisees depuis
+		/// le cache zones[zoneId] et mises a jour a chaque OnUpdateNotification
+		/// pour cette zone. Si la zone n'est pas dans le cache, activeZoneId
+		/// est quand meme set ; le HUD affichera "?".
+		void SetActiveZone(uint32_t zoneId);
+
+		/// Reset l'activeZoneId. Le HUD ne sera plus rendu.
+		void ClearActiveZone();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit WEATHER_LIST_RESPONSE. Remplace le cache local.
+		void OnListResponse(const engine::network::WeatherListResponsePayload& resp);
+
+		/// Recoit WEATHER_SUBSCRIBE_RESPONSE. Si Ok, ajoute zoneId a la
+		/// liste des subscriptions locale et met a jour le cache zones (kind
+		/// + intensity du state retourne par le master).
+		void OnSubscribeResponse(const engine::network::WeatherSubscribeResponsePayload& resp);
+
+		/// Recoit WEATHER_UNSUBSCRIBE_RESPONSE. Si Ok, retire zoneId.
+		void OnUnsubscribeResponse(const engine::network::WeatherUnsubscribeResponsePayload& resp);
+
+		/// Recoit un push WEATHER_UPDATE_NOTIFICATION : update kind +
+		/// intensity de la zone dans le cache local. Si activeZoneId == zoneId,
+		/// met aussi a jour le HUD (activeKind + activeIntensity).
+		void OnUpdateNotification(const engine::network::WeatherUpdateNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const WeatherUiState& GetState() const { return m_state; }
+
+	private:
+		/// Memorise le zoneId du Subscribe/Unsubscribe pendant pour pouvoir
+		/// updater le state (subscribedZones + cache kind/intensity) au
+		/// retour Ok.
+		uint32_t m_pendingSubscribeZoneId   = 0;
+		uint32_t m_pendingUnsubscribeZoneId = 0;
+
+		bool             m_initialized = false;
+		WeatherUiState   m_state{};
+		SendCallback     m_send;
+	};
+}

--- a/src/masterd/handlers/weather/WeatherHandler.cpp
+++ b/src/masterd/handlers/weather/WeatherHandler.cpp
@@ -1,0 +1,427 @@
+// CMANGOS.42 (Phase 4.42 step 3+4) — Implementation WeatherHandler.
+
+#include "src/masterd/handlers/weather/WeatherHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/WeatherPayloads.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::server::weather::WeatherKind;
+	using engine::server::weather::WeatherManager;
+	using engine::server::weather::ZoneWeatherProfile;
+	using engine::server::weather::ZoneWeatherState;
+
+	namespace
+	{
+		/// Retourne le steady_clock now en ms depuis epoch (resolution OK pour
+		/// le Tick de la WeatherManager qui n'a pas besoin d'horloge wallclock).
+		uint64_t NowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// SeedV1Zones — register the 3 hardcoded zones at boot.
+	// -------------------------------------------------------------------------
+
+	void WeatherHandler::SeedV1Zones()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_seeded)
+		{
+			LOG_DEBUG(Net, "[WeatherHandler] SeedV1Zones already seeded (idempotent skip)");
+			return;
+		}
+
+		// Init RNG depuis steady_clock (deterministic-ish per-boot, suffisant V1).
+		m_rng.seed(static_cast<std::mt19937::result_type>(NowMs()));
+
+		// Zone 1 : Stormwind Plains — climat tempere (Clear/Rain/Storm).
+		{
+			ZoneWeatherProfile p;
+			p.zoneId           = kZoneStormwindPlains;
+			p.changeIntervalMs = 60u * 60u * 1000u; // 1h, mais ForceReroll a chaque subscribe.
+			p.pClear     = 0.6f;
+			p.pRain      = 0.3f;
+			p.pSnow      = 0.0f;
+			p.pStorm     = 0.1f;
+			p.pSandstorm = 0.0f;
+			p.pFog       = 0.0f;
+			m_manager.RegisterZone(p);
+			m_zoneNames[kZoneStormwindPlains] = "Stormwind Plains";
+		}
+
+		// Zone 2 : Frozen Tundra — climat polaire (Clear/Snow/Fog).
+		{
+			ZoneWeatherProfile p;
+			p.zoneId           = kZoneFrozenTundra;
+			p.changeIntervalMs = 60u * 60u * 1000u;
+			p.pClear     = 0.4f;
+			p.pRain      = 0.0f;
+			p.pSnow      = 0.5f;
+			p.pStorm     = 0.0f;
+			p.pSandstorm = 0.0f;
+			p.pFog       = 0.1f;
+			m_manager.RegisterZone(p);
+			m_zoneNames[kZoneFrozenTundra] = "Frozen Tundra";
+		}
+
+		// Zone 3 : Tanaris Desert — climat aride (Clear/Sandstorm/Fog).
+		{
+			ZoneWeatherProfile p;
+			p.zoneId           = kZoneTanarisDesert;
+			p.changeIntervalMs = 60u * 60u * 1000u;
+			p.pClear     = 0.5f;
+			p.pRain      = 0.0f;
+			p.pSnow      = 0.0f;
+			p.pStorm     = 0.0f;
+			p.pSandstorm = 0.4f;
+			p.pFog       = 0.1f;
+			m_manager.RegisterZone(p);
+			m_zoneNames[kZoneTanarisDesert] = "Tanaris Desert";
+		}
+
+		// Premier Tick pour donner des states initiales aux 3 zones.
+		m_manager.Tick(NowMs(), m_rng);
+
+		m_seeded = true;
+		LOG_INFO(Net, "[WeatherHandler] V1 zones seeded : Stormwind Plains, Frozen Tundra, Tanaris Desert");
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket — dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void WeatherHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[WeatherHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(WeatherErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeWeatherListRequest:
+				pkt = BuildWeatherListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeWeatherSubscribeRequest:
+				pkt = BuildWeatherSubscribeResponsePacket(kUnauth, 0u, 0.0f, requestId, sessionIdHeader);
+				break;
+			case kOpcodeWeatherUnsubscribeRequest:
+				pkt = BuildWeatherUnsubscribeResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeWeatherListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeWeatherSubscribeRequest:
+			HandleSubscribe(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeWeatherUnsubscribeRequest:
+			HandleUnsubscribe(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleList
+	// -------------------------------------------------------------------------
+
+	void WeatherHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		std::vector<WeatherZoneSummary> zones;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const uint32_t zoneIds[] = {
+				kZoneStormwindPlains, kZoneFrozenTundra, kZoneTanarisDesert
+			};
+			for (uint32_t zid : zoneIds)
+			{
+				const ZoneWeatherState st = m_manager.GetState(zid);
+				WeatherZoneSummary summary;
+				summary.zoneId    = zid;
+				auto nameIt = m_zoneNames.find(zid);
+				if (nameIt != m_zoneNames.end())
+					summary.name = nameIt->second;
+				summary.kind      = static_cast<uint8_t>(st.kind);
+				summary.intensity = st.intensity;
+				zones.push_back(std::move(summary));
+			}
+		}
+
+		LOG_INFO(Net, "[WeatherHandler] List account={} count={}",
+			accountId, zones.size());
+
+		auto pkt = BuildWeatherListResponsePacket(0u, zones, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleSubscribe
+	// -------------------------------------------------------------------------
+
+	void WeatherHandler::HandleSubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseWeatherSubscribeRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[WeatherHandler] Subscribe parse failed account={}", accountId);
+			auto pkt = BuildWeatherSubscribeResponsePacket(
+				static_cast<uint8_t>(WeatherErrorCode::UnknownZone), 0u, 0.0f,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t zoneId = parsed->zoneId;
+		bool zoneKnown = false;
+		ZoneWeatherState beforeState{};
+		ZoneWeatherState afterState{};
+		std::vector<uint64_t> subscribersToBroadcast;
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			zoneKnown = (m_zoneNames.find(zoneId) != m_zoneNames.end());
+			if (zoneKnown)
+			{
+				m_subscriptions[accountId].insert(zoneId);
+				m_zoneSubscribers[zoneId].insert(accountId);
+
+				// Snapshot avant Tick pour detecter le changement.
+				beforeState = m_manager.GetState(zoneId);
+
+				// V1 : force reroll de cette zone et tick. Toutes les autres
+				// zones avec nextChangeTsMs encore future seront ignorees.
+				m_manager.ForceReroll(zoneId);
+				m_manager.Tick(NowMs(), m_rng);
+
+				afterState = m_manager.GetState(zoneId);
+
+				// Si etat change, prepare la liste des subscribers pour
+				// broadcast. On copie sous mutex pour pouvoir relacher avant
+				// d'envoyer (Send peut prendre un mutex aussi, eviter deadlock).
+				const bool kindChanged      = (afterState.kind != beforeState.kind);
+				const bool intensityChanged = (afterState.intensity != beforeState.intensity);
+				if (kindChanged || intensityChanged)
+				{
+					auto it = m_zoneSubscribers.find(zoneId);
+					if (it != m_zoneSubscribers.end())
+					{
+						subscribersToBroadcast.reserve(it->second.size());
+						for (uint64_t accId : it->second)
+							subscribersToBroadcast.push_back(accId);
+					}
+				}
+			}
+		}
+
+		if (!zoneKnown)
+		{
+			LOG_INFO(Net, "[WeatherHandler] Subscribe UnknownZone account={} zoneId={}",
+				accountId, zoneId);
+			auto pkt = BuildWeatherSubscribeResponsePacket(
+				static_cast<uint8_t>(WeatherErrorCode::UnknownZone), 0u, 0.0f,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[WeatherHandler] Subscribe OK account={} zoneId={} kind={} intensity={:.3f}",
+			accountId, zoneId, static_cast<unsigned>(afterState.kind),
+			static_cast<double>(afterState.intensity));
+
+		// Reponse Ok avec le state courant (apres potentiel reroll).
+		auto pkt = BuildWeatherSubscribeResponsePacket(0u,
+			static_cast<uint8_t>(afterState.kind), afterState.intensity,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// Broadcast WeatherUpdateNotification a tous les subscribers de la
+		// zone si l'etat a change suite a notre reroll. Le subscriber qui
+		// vient de s'abonner verra le push en plus de la response (idempotent).
+		for (uint64_t accId : subscribersToBroadcast)
+		{
+			const uint32_t targetConn = FindConnIdForAccount(accId);
+			if (targetConn == 0u) continue;
+			PushWeatherUpdate(targetConn, zoneId,
+				static_cast<uint8_t>(afterState.kind), afterState.intensity);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleUnsubscribe
+	// -------------------------------------------------------------------------
+
+	void WeatherHandler::HandleUnsubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseWeatherUnsubscribeRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[WeatherHandler] Unsubscribe parse failed account={}", accountId);
+			auto pkt = BuildWeatherUnsubscribeResponsePacket(
+				static_cast<uint8_t>(WeatherErrorCode::NotSubscribed),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t zoneId = parsed->zoneId;
+		bool wasSubscribed = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto it = m_subscriptions.find(accountId);
+			if (it != m_subscriptions.end())
+			{
+				auto erased = it->second.erase(zoneId);
+				if (erased > 0)
+					wasSubscribed = true;
+				if (it->second.empty())
+					m_subscriptions.erase(it);
+			}
+			auto rit = m_zoneSubscribers.find(zoneId);
+			if (rit != m_zoneSubscribers.end())
+			{
+				rit->second.erase(accountId);
+				if (rit->second.empty())
+					m_zoneSubscribers.erase(rit);
+			}
+		}
+
+		if (!wasSubscribed)
+		{
+			LOG_INFO(Net, "[WeatherHandler] Unsubscribe NotSubscribed account={} zoneId={}",
+				accountId, zoneId);
+			auto pkt = BuildWeatherUnsubscribeResponsePacket(
+				static_cast<uint8_t>(WeatherErrorCode::NotSubscribed),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[WeatherHandler] Unsubscribe OK account={} zoneId={}",
+			accountId, zoneId);
+		auto pkt = BuildWeatherUnsubscribeResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// PushWeatherUpdate
+	// -------------------------------------------------------------------------
+
+	bool WeatherHandler::PushWeatherUpdate(uint32_t connId, uint32_t zoneId, uint8_t kind, float intensity)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[WeatherHandler] PushWeatherUpdate dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[WeatherHandler] PushWeatherUpdate: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildWeatherUpdateNotificationPacket(zoneId, kind, intensity, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[WeatherHandler] PushWeatherUpdate: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[WeatherHandler] PushWeatherUpdate connId={} zid={} kind={} intensity={:.3f}",
+			connId, zoneId, static_cast<unsigned>(kind), static_cast<double>(intensity));
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	uint64_t WeatherHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+
+	uint32_t WeatherHandler::FindConnIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return connId;
+		}
+		return 0u;
+	}
+}

--- a/src/masterd/handlers/weather/WeatherHandler.h
+++ b/src/masterd/handlers/weather/WeatherHandler.h
@@ -1,0 +1,166 @@
+#pragma once
+// CMANGOS.42 (Phase 4.42 step 3+4) — WeatherHandler : dispatch des opcodes
+// Weather cote joueur (150/152/154) et appel des methodes correspondantes
+// d'un WeatherManager + tracking des subscriptions par account et par zone.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 150/152/154 (les requests). Les responses 151/153/155 sont
+// emises avec le meme requestId / sessionId que la request recue. La push
+// notification 156 (WeatherUpdate) est emise par le handler lui-meme apres
+// detection d'un changement d'etat dans une zone.
+//
+// V1 simplifie : a chaque SubscribeRequest, master appelle ForceReroll sur
+// la zone subscribed puis Tick(nowMs, rng). Si l'etat de la zone a change
+// (kind ou intensity != snapshot avant Tick), broadcast WeatherUpdateNotification
+// a tous les subscribers de cette zone (y compris le nouvel abonne, qui
+// verra ainsi un push immediat). Pas de thread Tick periodique en V1.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 3) dans la reponse type-specific.
+//
+// Store in-memory V1 :
+//   - 3 zones meteo seedees au boot :
+//       zoneId=1 "Stormwind Plains" pClear=0.6, pRain=0.3, pStorm=0.1
+//       zoneId=2 "Frozen Tundra"    pClear=0.4, pSnow=0.5, pFog=0.1
+//       zoneId=3 "Tanaris Desert"   pClear=0.5, pSandstorm=0.4, pFog=0.1
+//   - Subscriptions : map account_id -> set<zoneId>.
+//   - Reverse index : map zoneId -> set<account_id> (pour broadcast aux
+//     subscribers d'une zone).
+//   - Connection mapping : la resolution accountId -> connId est faite via
+//     SessionManager + ConnectionSessionMap au moment du push.
+//
+// V1 limitations :
+//   - 3 zones hardcodees. Vraies zones via M40+ futur.
+//   - Tick simule a chaque SubscribeRequest (force reroll). Vrai tick
+//     periodique via shardd futur.
+//   - Subscriptions in-memory (perdues au reboot).
+//   - Pas de SyncWeather RPC entre master et shardd (master autoritaire V1).
+
+#include "src/shardd/weather/WeatherManager.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Weather cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class WeatherHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId et
+		/// accountId -> sessionId au push.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Initialise le store V1 : enregistre les 3 zones meteo hardcodees
+		/// (Stormwind Plains, Frozen Tundra, Tanaris Desert) avec leurs
+		/// profiles probabilistes respectifs. Idempotent : appelable a
+		/// chaque boot.
+		void SeedV1Zones();
+
+		/// Point d'entree appele par NetServer pour les opcodes Weather.
+		/// Dispatch vers HandleList / HandleSubscribe / HandleUnsubscribe
+		/// selon l'opcode. Si l'opcode n'est pas un opcode Weather, ignore
+		/// silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (150/152/154).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push WeatherUpdateNotification (opcode 156)
+		/// au client identifie par \p connId. Utilise par le handler en
+		/// interne mais accessible egalement depuis l'exterieur (tests, hooks).
+		///
+		/// \param connId    identifiant de connexion TCP cible (0 = no-op).
+		/// \param zoneId    identifiant de la zone qui change.
+		/// \param kind      nouveau WeatherKind (uint8 0..5).
+		/// \param intensity nouvelle intensite [0..1].
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushWeatherUpdate(uint32_t connId, uint32_t zoneId, uint8_t kind, float intensity);
+
+	private:
+		/// Traite WEATHER_LIST_REQUEST : retourne les 3 zones hardcodees V1
+		/// + state courant (kind + intensity).
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite WEATHER_SUBSCRIBE_REQUEST : valide zoneId connue, ajoute
+		/// aux 2 indices subscriptions (account->zones et zone->accounts).
+		/// Force un reroll de la zone et Tick : si state change, broadcast
+		/// WeatherUpdateNotification a tous les subscribers de la zone.
+		/// Repond avec le state courant apres potentiel changement.
+		void HandleSubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite WEATHER_UNSUBSCRIBE_REQUEST : retire des 2 indices.
+		/// OK si l'etait, NotSubscribed sinon.
+		void HandleUnsubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Resoudre connId pour un accountId. V1 : iteration sur la map
+		/// connId->sessionId puis SessionManager pour matcher l'accountId.
+		/// Retourne 0 si non trouve.
+		uint32_t FindConnIdForAccount(uint64_t accountId) const;
+
+		/// V1 : 3 zones hardcodees au boot.
+		static constexpr uint32_t kZoneStormwindPlains = 1u;
+		static constexpr uint32_t kZoneFrozenTundra    = 2u;
+		static constexpr uint32_t kZoneTanarisDesert   = 3u;
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant m_manager + m_subscriptions + m_zoneNames + m_rng + m_seeded.
+		std::mutex                                       m_mutex;
+
+		/// Manager Weather partage : zones + states + profiles. Modifie
+		/// uniquement sous m_mutex.
+		engine::server::weather::WeatherManager          m_manager;
+
+		/// Noms runtime des zones (WeatherManager n'en stocke pas).
+		/// Cle = zoneId.
+		std::unordered_map<uint32_t, std::string>        m_zoneNames;
+
+		/// Subscriptions actives : account_id -> set<zoneId>.
+		std::unordered_map<uint64_t, std::unordered_set<uint32_t>> m_subscriptions;
+
+		/// Reverse index : zone_id -> set<account_id> pour broadcast.
+		std::unordered_map<uint32_t, std::unordered_set<uint64_t>> m_zoneSubscribers;
+
+		/// RNG seedee a steady_clock pour les Tick. Sous m_mutex.
+		std::mt19937                                     m_rng;
+
+		/// True une fois SeedV1Zones() appele avec succes.
+		bool                                             m_seeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -42,6 +42,7 @@
 #include "src/masterd/handlers/arena/ArenaHandler.h"
 #include "src/masterd/handlers/battleground/BattleGroundHandler.h"
 #include "src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h"
+#include "src/masterd/handlers/weather/WeatherHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -571,6 +572,21 @@ int main(int argc, char** argv)
 	outdoorPvpHandler.SeedV1Zones();
 	LOG_INFO(Net, "[ServerMain] OutdoorPvpHandler configured (CMANGOS.36 step 3+4, in-memory, 2 zones seed)");
 
+	// CMANGOS.42 (Phase 4.42 step 3+4) — Weather wire server.
+	// Le master tient en memoire un WeatherManager seede au boot avec 3 zones
+	// meteo (Stormwind Plains tempere, Frozen Tundra polaire, Tanaris Desert
+	// aride). Les opcodes 150/152/154 sont dispatches au handler ; les
+	// responses 151/153/155 et la push notification 156 (WeatherUpdate)
+	// sont emises par le handler. V1 limitations : tick simule a chaque
+	// SubscribeRequest (force reroll), pas de SyncWeather RPC entre master
+	// et shardd. Pas de persistance DB.
+	engine::server::WeatherHandler weatherHandler;
+	weatherHandler.SetServer(&server);
+	weatherHandler.SetSessionManager(&sessionManager);
+	weatherHandler.SetConnectionSessionMap(&connSessionMap);
+	weatherHandler.SeedV1Zones();
+	LOG_INFO(Net, "[ServerMain] WeatherHandler configured (CMANGOS.42 step 3+4, in-memory, 3 zones seed)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -610,7 +626,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -691,6 +707,10 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeOutdoorPvpUnsubscribeRequest
 		      || opcode == kOpcodeOutdoorPvpCaptureStartRequest)
 			outdoorPvpHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeWeatherListRequest
+		      || opcode == kOpcodeWeatherSubscribeRequest
+		      || opcode == kOpcodeWeatherUnsubscribeRequest)
+			weatherHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shardd/weather/WeatherManager.h
+++ b/src/shardd/weather/WeatherManager.h
@@ -74,6 +74,20 @@ namespace engine::server::weather
 			}
 		}
 
+		/// Force le prochain Tick a rerouler la zone donnee, peu importe le
+		/// nowMs. Utilise par le wire (CMANGOS.42 step 3+4) pour declencher un
+		/// changement immediat de meteo dans une zone (e.g. au moment d'une
+		/// SubscribeRequest pour la V1, qui veut faire bouger la meteo aussi
+		/// souvent que possible). No-op si la zone n'est pas enregistree.
+		///
+		/// \param zoneId identifiant de la zone a rerouler.
+		void ForceReroll(ZoneId zoneId)
+		{
+			auto it = m_state.find(zoneId);
+			if (it == m_state.end()) return;
+			it->second.nextChangeTsMs = 0;
+		}
+
 		size_t ZoneCount() const noexcept { return m_state.size(); }
 
 	private:

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -577,4 +577,43 @@ namespace engine::network
 	constexpr uint16_t kOpcodeOutdoorPvpCaptureStartResponse         = 147u; ///< Master to Client : OK ou UnknownObjective / InvalidFaction / Unauthorized.
 	constexpr uint16_t kOpcodeOutdoorPvpCaptureProgressNotification  = 148u; ///< Master to Client (push, request_id=0) : progression capture (zoneId, objectiveId, capturePct, capturingBy).
 	constexpr uint16_t kOpcodeOutdoorPvpCaptureCompletedNotification = 149u; ///< Master to Client (push, request_id=0) : capture finie (zoneId, objectiveId, newOwner, allianceScore, hordeScore).
+
+	// =====================================================================
+	// CMANGOS.42 step 3+4 — Weather wire (zone subscribe, push current state
+	// + push state change). Master tient en memoire un WeatherManager (V1
+	// seed hardcode, tick simule a la demande).
+	//
+	// Architecture : 3 zones meteo seedees au boot (Stormwind Plains avec
+	// pClear=0.6/pRain=0.3/pStorm=0.1, Frozen Tundra avec
+	// pClear=0.4/pSnow=0.5/pFog=0.1, Tanaris Desert avec
+	// pClear=0.5/pSandstorm=0.4/pFog=0.1). Le master tient en memoire la
+	// liste des subscribers par zone et l'etat courant. V1 simplifie : a
+	// chaque SubscribeRequest, master force un reroll (Tick) ; si le state
+	// d'une zone change, broadcast WeatherUpdateNotification a tous les
+	// subscribers de la zone.
+	//
+	// V1 limitations :
+	//   - 3 zones meteo hardcodees (Stormwind Plains, Frozen Tundra,
+	//     Tanaris Desert). Vraies zones via M40+ futur.
+	//   - Tick simule a chaque SubscribeRequest (force reroll). Vrai tick
+	//     periodique via shardd futur.
+	//   - Subscriptions in-memory (pas de persistance V1).
+	//   - Pas de SyncWeather RPC entre master et shardd (master autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - List       (150/151)               : liste des zones meteo + state.
+	//   - Subscribe  (152/153)               : s'abonne aux push d'une zone.
+	//   - Unsubscribe (154/155)              : se desabonne.
+	//   - UpdateNotification (156, push)     : changement meteo (zoneId, kind, intensity).
+	//
+	// Wire format kind : uint8 (Clear=0, Rain=1, Snow=2, Storm=3,
+	// Sandstorm=4, Fog=5). Wire format intensity : float32 LE (0..1).
+	// =====================================================================
+	constexpr uint16_t kOpcodeWeatherListRequest         = 150u; ///< Client to Master : liste des zones meteo (vide).
+	constexpr uint16_t kOpcodeWeatherListResponse        = 151u; ///< Master to Client : liste {zoneId, name, kind, intensity} ou Unauthorized.
+	constexpr uint16_t kOpcodeWeatherSubscribeRequest    = 152u; ///< Client to Master : s'abonne au push d'une zone (zoneId).
+	constexpr uint16_t kOpcodeWeatherSubscribeResponse   = 153u; ///< Master to Client : OK + current {kind, intensity}, ou UnknownZone / Unauthorized.
+	constexpr uint16_t kOpcodeWeatherUnsubscribeRequest  = 154u; ///< Client to Master : se desabonne (zoneId).
+	constexpr uint16_t kOpcodeWeatherUnsubscribeResponse = 155u; ///< Master to Client : OK ou NotSubscribed / Unauthorized.
+	constexpr uint16_t kOpcodeWeatherUpdateNotification  = 156u; ///< Master to Client (push, request_id=0) : changement meteo (zoneId, kind, intensity).
 }

--- a/src/shared/network/WeatherPayloads.cpp
+++ b/src/shared/network/WeatherPayloads.cpp
@@ -1,0 +1,319 @@
+// CMANGOS.42 (Phase 4.42 step 3+4) — Implementation Parse/Build des payloads Weather.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+//
+// Sequencage des float32 (intensity 0..1) : on utilise WriteBytes /
+// ReadBytes sur 4 octets bruts. Le float est suppose IEEE-754 32-bit en
+// little-endian (cas Windows MSVC + Linux GCC sur x86_64 et arm64).
+// Pattern identique a CharacterPayloads.cpp pour les coordonnees de spawn.
+
+#include "src/shared/network/WeatherPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un float32 little-endian sur 4 octets bruts. Renvoie false
+		/// s'il n'y a pas la place dans le buffer.
+		bool WriteFloatLE(ByteWriter& w, float value)
+		{
+			return w.WriteBytes(reinterpret_cast<const uint8_t*>(&value), sizeof(float));
+		}
+
+		/// Lit un float32 little-endian sur 4 octets bruts. Renvoie false
+		/// s'il n'y a pas assez d'octets disponibles.
+		bool ReadFloatLE(ByteReader& r, float& out)
+		{
+			return r.ReadBytes(reinterpret_cast<uint8_t*>(&out), sizeof(float));
+		}
+
+		/// Ecrit un WeatherZoneSummary (zoneId, name, kind, intensity).
+		bool WriteZoneSummary(ByteWriter& w, const WeatherZoneSummary& zone)
+		{
+			if (!w.WriteU32(zone.zoneId))                 return false;
+			if (!w.WriteString(zone.name))                return false;
+			if (!w.WriteBytes(&zone.kind, 1u))            return false;
+			if (!WriteFloatLE(w, zone.intensity))         return false;
+			return true;
+		}
+
+		/// Lit un WeatherZoneSummary.
+		bool ReadZoneSummary(ByteReader& r, WeatherZoneSummary& out)
+		{
+			if (!r.ReadU32(out.zoneId))                   return false;
+			if (!r.ReadString(out.name))                  return false;
+			uint8_t kindByte = 0;
+			if (!r.ReadBytes(&kindByte, 1u))              return false;
+			out.kind = kindByte;
+			if (!ReadFloatLE(r, out.intensity))           return false;
+			return true;
+		}
+
+		/// Serialise le body d'un WEATHER_UPDATE_NOTIFICATION (zoneId, kind,
+		/// intensity).
+		bool WriteUpdateNotificationBody(ByteWriter& w, uint32_t zoneId, uint8_t kind, float intensity)
+		{
+			if (!w.WriteU32(zoneId))                      return false;
+			if (!w.WriteBytes(&kind, 1u))                 return false;
+			if (!WriteFloatLE(w, intensity))              return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherListRequestPayload> ParseWeatherListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return WeatherListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildWeatherListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherListResponsePayload> ParseWeatherListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.zones.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			WeatherZoneSummary z;
+			if (!ReadZoneSummary(r, z)) return std::nullopt;
+			out.zones.push_back(std::move(z));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherListResponsePayload(uint8_t error, const std::vector<WeatherZoneSummary>& zones)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(zones.size()))) return {};
+			for (const auto& z : zones)
+			{
+				if (!WriteZoneSummary(w, z)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildWeatherListResponsePacket(uint8_t error, const std::vector<WeatherZoneSummary>& zones,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(zones.size()))) return {};
+			for (const auto& z : zones)
+			{
+				if (!WriteZoneSummary(w, z)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeWeatherListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_SUBSCRIBE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherSubscribeRequestPayload> ParseWeatherSubscribeRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherSubscribeRequestPayload out;
+		if (!r.ReadU32(out.zoneId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherSubscribeRequestPayload(uint32_t zoneId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(zoneId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_SUBSCRIBE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherSubscribeResponsePayload> ParseWeatherSubscribeResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherSubscribeResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		// Si Ok, body suit avec uint8 currentKind + float intensity.
+		if (payloadSize < 1u + 1u + 4u) return std::nullopt;
+		uint8_t kindByte = 0;
+		if (!r.ReadBytes(&kindByte, 1u)) return std::nullopt;
+		out.currentKind = kindByte;
+		if (!ReadFloatLE(r, out.currentIntensity)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherSubscribeResponsePayload(uint8_t error, uint8_t currentKind, float currentIntensity)
+	{
+		// 1 octet error (+ 1 + 4 = 5 si Ok). Buffer max 6.
+		std::vector<uint8_t> buf(6u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteBytes(&currentKind, 1u)) return {};
+			if (!WriteFloatLE(w, currentIntensity)) return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildWeatherSubscribeResponsePacket(uint8_t error, uint8_t currentKind, float currentIntensity,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteBytes(&currentKind, 1u)) return {};
+			if (!WriteFloatLE(w, currentIntensity)) return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeWeatherSubscribeResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_UNSUBSCRIBE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherUnsubscribeRequestPayload> ParseWeatherUnsubscribeRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherUnsubscribeRequestPayload out;
+		if (!r.ReadU32(out.zoneId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherUnsubscribeRequestPayload(uint32_t zoneId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(zoneId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_UNSUBSCRIBE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherUnsubscribeResponsePayload> ParseWeatherUnsubscribeResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherUnsubscribeResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherUnsubscribeResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildWeatherUnsubscribeResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeWeatherUnsubscribeResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// WEATHER_UPDATE_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherUpdateNotificationPayload> ParseWeatherUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 zoneId (4) + uint8 kind (1) + float intensity (4) = 9.
+		if (!payload || payloadSize < 9u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		WeatherUpdateNotificationPayload out;
+		if (!r.ReadU32(out.zoneId))      return std::nullopt;
+		uint8_t kindByte = 0;
+		if (!r.ReadBytes(&kindByte, 1u)) return std::nullopt;
+		out.kind = kindByte;
+		if (!ReadFloatLE(r, out.intensity)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildWeatherUpdateNotificationPayload(uint32_t zoneId, uint8_t kind, float intensity)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteUpdateNotificationBody(w, zoneId, kind, intensity)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildWeatherUpdateNotificationPacket(uint32_t zoneId, uint8_t kind, float intensity,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteUpdateNotificationBody(w, zoneId, kind, intensity)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeWeatherUpdateNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/WeatherPayloads.h
+++ b/src/shared/network/WeatherPayloads.h
@@ -1,0 +1,174 @@
+#pragma once
+// CMANGOS.42 (Phase 4.42 step 3+4) — Wire payloads pour les opcodes Weather
+// (150-156). 3 paires Request/Response + 1 push notification :
+//   - List                              (150/151)
+//   - Subscribe                         (152/153)
+//   - Unsubscribe                       (154/155)
+//   - UpdateNotification                (156 push) : push Master to Client
+//     changement meteo (zoneId, kind, intensity).
+//
+// Le master tient en memoire un WeatherManager (V1 : 3 zones hardcodees).
+// Au reboot, subscriptions et states sont reinitialises. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Toutes les strings
+// passent par WriteString/ReadString (uint16 length + UTF-8 bytes), et
+// toutes les arrays par WriteArrayCount/ReadArrayCount (uint16 count).
+// Les float32 (intensity 0..1) sont serialises bit-a-bit en little-endian
+// via WriteBytes / ReadBytes sur 4 octets (cf. CharacterPayloads.cpp pour
+// le pattern existant ; pas de helper WriteFloat dans ByteWriter).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Weather.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Weather. 0 = OK.
+	enum class WeatherErrorCode : uint8_t
+	{
+		Ok            = 0,
+		UnknownZone   = 1, ///< zoneId pas dans la liste hardcodee V1.
+		NotSubscribed = 2, ///< Tentative d'unsubscribe sans subscription prealable.
+		Unauthorized  = 3, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// Sous-struct partage — Zone summary.
+	// =========================================================================
+
+	/// Resume d'une zone meteo pour le wire.
+	/// Wire format :
+	///   uint32 zoneId
+	///   string name           (uint16 length + UTF-8)
+	///   uint8  kind           (Clear=0, Rain=1, Snow=2, Storm=3, Sandstorm=4, Fog=5)
+	///   float  intensity      (32 bits LE, 0..1)
+	struct WeatherZoneSummary
+	{
+		uint32_t    zoneId    = 0;
+		std::string name;
+		uint8_t     kind      = 0;     ///< WeatherKind enum value (0..5).
+		float       intensity = 0.0f;  ///< [0..1].
+	};
+
+	// =========================================================================
+	// WEATHER_LIST — Client to Master : liste des zones meteo.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct WeatherListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  error                     (cf. WeatherErrorCode)
+	///   uint16 zoneCount                 (si error == 0)
+	///   <count> WeatherZoneSummary
+	struct WeatherListResponsePayload
+	{
+		uint8_t                          error = 0;
+		std::vector<WeatherZoneSummary>  zones;
+	};
+
+	// =========================================================================
+	// WEATHER_SUBSCRIBE — Client to Master : s'abonne aux push d'une zone.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 zoneId
+	struct WeatherSubscribeRequestPayload
+	{
+		uint32_t zoneId = 0;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	///   uint8 currentKind        (si error == 0 ; sinon non lu)
+	///   float currentIntensity   (si error == 0 ; sinon non lu)
+	struct WeatherSubscribeResponsePayload
+	{
+		uint8_t error            = 0;
+		uint8_t currentKind      = 0;
+		float   currentIntensity = 0.0f;
+	};
+
+	// =========================================================================
+	// WEATHER_UNSUBSCRIBE — Client to Master : se desabonne.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 zoneId
+	struct WeatherUnsubscribeRequestPayload
+	{
+		uint32_t zoneId = 0;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct WeatherUnsubscribeResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// WEATHER_UPDATE_NOTIFICATION — Master to Client (push, request_id=0).
+	// Changement de meteo dans une zone.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 zoneId
+	///   uint8  kind
+	///   float  intensity      (32 bits LE, 0..1)
+	struct WeatherUpdateNotificationPayload
+	{
+		uint32_t zoneId    = 0;
+		uint8_t  kind      = 0;
+		float    intensity = 0.0f;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherListRequestPayload>        ParseWeatherListRequestPayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<WeatherSubscribeRequestPayload>   ParseWeatherSubscribeRequestPayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<WeatherUnsubscribeRequestPayload> ParseWeatherUnsubscribeRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildWeatherListRequestPayload();
+	std::vector<uint8_t> BuildWeatherSubscribeRequestPayload   (uint32_t zoneId);
+	std::vector<uint8_t> BuildWeatherUnsubscribeRequestPayload (uint32_t zoneId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses & Notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<WeatherListResponsePayload>        ParseWeatherListResponsePayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<WeatherSubscribeResponsePayload>   ParseWeatherSubscribeResponsePayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<WeatherUnsubscribeResponsePayload> ParseWeatherUnsubscribeResponsePayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<WeatherUpdateNotificationPayload>  ParseWeatherUpdateNotificationPayload (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildWeatherListResponsePayload       (uint8_t error, const std::vector<WeatherZoneSummary>& zones);
+	std::vector<uint8_t> BuildWeatherSubscribeResponsePayload  (uint8_t error, uint8_t currentKind, float currentIntensity);
+	std::vector<uint8_t> BuildWeatherUnsubscribeResponsePayload(uint8_t error);
+	std::vector<uint8_t> BuildWeatherUpdateNotificationPayload (uint32_t zoneId, uint8_t kind, float intensity);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildWeatherListResponsePacket        (uint8_t error, const std::vector<WeatherZoneSummary>& zones,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildWeatherSubscribeResponsePacket   (uint8_t error, uint8_t currentKind, float currentIntensity,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildWeatherUnsubscribeResponsePacket (uint8_t error, uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildWeatherUpdateNotificationPacket  (uint32_t zoneId, uint8_t kind, float intensity,
+	                                                            uint64_t sessionIdHeader);
+}

--- a/src/shared/network/WeatherPayloadsTests.cpp
+++ b/src/shared/network/WeatherPayloadsTests.cpp
@@ -1,0 +1,423 @@
+/**
+ * CMANGOS.42 (Phase 4.42 step 3+4) — Round-trip tests for WEATHER_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/WeatherPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+
+	bool FloatNear(float a, float b, float eps = 1e-5f)
+	{
+		const float d = a - b;
+		return (d < eps) && (d > -eps);
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// WEATHER_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildWeatherListRequestPayload();
+	Assert(buf.empty(), "Weather List request payload empty");
+	auto parsed = ParseWeatherListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Weather List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildWeatherListResponsePayload(0u, {});
+	auto parsed = ParseWeatherListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->zones.empty(),
+		"Weather List response empty parses");
+}
+
+static void TestListResponseSingleZone()
+{
+	WeatherZoneSummary z;
+	z.zoneId    = 1u;
+	z.name      = "Stormwind Plains";
+	z.kind      = 1u; // Rain
+	z.intensity = 0.5f;
+	auto buf = BuildWeatherListResponsePayload(0u, {z});
+	auto parsed = ParseWeatherListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Weather List single zone parses");
+	if (parsed && parsed->zones.size() == 1u)
+	{
+		Assert(parsed->zones[0].zoneId == 1u, "Zone 1 id");
+		Assert(parsed->zones[0].name == "Stormwind Plains", "Zone 1 name");
+		Assert(parsed->zones[0].kind == 1u, "Zone 1 kind Rain");
+		Assert(FloatNear(parsed->zones[0].intensity, 0.5f), "Zone 1 intensity 0.5");
+	}
+	else
+	{
+		Assert(false, "List should have 1 zone");
+	}
+}
+
+static void TestListResponseFullThreeZones()
+{
+	std::vector<WeatherZoneSummary> zones;
+
+	WeatherZoneSummary z1;
+	z1.zoneId    = 1u;
+	z1.name      = "Stormwind Plains";
+	z1.kind      = 0u; // Clear
+	z1.intensity = 0.0f;
+	zones.push_back(z1);
+
+	WeatherZoneSummary z2;
+	z2.zoneId    = 2u;
+	z2.name      = "Frozen Tundra";
+	z2.kind      = 2u; // Snow
+	z2.intensity = 0.75f;
+	zones.push_back(z2);
+
+	WeatherZoneSummary z3;
+	z3.zoneId    = 3u;
+	z3.name      = "Tanaris Desert";
+	z3.kind      = 4u; // Sandstorm
+	z3.intensity = 1.0f;
+	zones.push_back(z3);
+
+	auto buf = BuildWeatherListResponsePayload(0u, zones);
+	auto parsed = ParseWeatherListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Weather List 3 zones parses");
+	if (parsed && parsed->zones.size() == 3u)
+	{
+		Assert(parsed->zones[0].name == "Stormwind Plains", "Z[0] name");
+		Assert(parsed->zones[0].kind == 0u, "Z[0] Clear");
+		Assert(FloatNear(parsed->zones[0].intensity, 0.0f), "Z[0] intensity 0");
+		Assert(parsed->zones[1].name == "Frozen Tundra", "Z[1] name");
+		Assert(parsed->zones[1].kind == 2u, "Z[1] Snow");
+		Assert(FloatNear(parsed->zones[1].intensity, 0.75f), "Z[1] intensity 0.75");
+		Assert(parsed->zones[2].name == "Tanaris Desert", "Z[2] name");
+		Assert(parsed->zones[2].kind == 4u, "Z[2] Sandstorm");
+		Assert(FloatNear(parsed->zones[2].intensity, 1.0f), "Z[2] intensity 1.0");
+	}
+	else
+	{
+		Assert(false, "List should have 3 zones");
+	}
+}
+
+static void TestListResponseError()
+{
+	auto buf = BuildWeatherListResponsePayload(
+		static_cast<uint8_t>(WeatherErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "Weather List error has only 1 byte");
+	auto parsed = ParseWeatherListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "List Unauthorized");
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseWeatherListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List rejects nullptr");
+}
+
+static void TestListResponsePacket()
+{
+	WeatherZoneSummary z;
+	z.zoneId    = 42u;
+	z.name      = "Test Zone";
+	z.kind      = 3u;  // Storm
+	z.intensity = 0.8f;
+	auto pkt = BuildWeatherListResponsePacket(0u, {z}, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "List packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"List PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeWeatherListResponse, "Opcode is ListResponse");
+	Assert(view.RequestId() == 999u, "List RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "List SessionId preserved");
+	auto parsed = ParseWeatherListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->zones.size() == 1u
+		&& parsed->zones[0].zoneId == 42u && parsed->zones[0].name == "Test Zone"
+		&& parsed->zones[0].kind == 3u && FloatNear(parsed->zones[0].intensity, 0.8f),
+		"List payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// WEATHER_SUBSCRIBE
+// -----------------------------------------------------------------------------
+
+static void TestSubscribeRequestRoundTrip()
+{
+	auto buf = BuildWeatherSubscribeRequestPayload(1u);
+	Assert(buf.size() == 4u, "Subscribe request payload size 4");
+	auto parsed = ParseWeatherSubscribeRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->zoneId == 1u, "Subscribe request parses zoneId 1");
+}
+
+static void TestSubscribeRequestBoundary()
+{
+	auto bufMax = BuildWeatherSubscribeRequestPayload(0xFFFFFFFFu);
+	auto parsedMax = ParseWeatherSubscribeRequestPayload(bufMax.data(), bufMax.size());
+	Assert(parsedMax.has_value() && parsedMax->zoneId == 0xFFFFFFFFu,
+		"Subscribe boundary zoneId max");
+}
+
+static void TestSubscribeRequestRejectsShort()
+{
+	auto parsed = ParseWeatherSubscribeRequestPayload(nullptr, 4u);
+	Assert(!parsed.has_value(), "Subscribe request rejects nullptr");
+	uint8_t shortBuf[3]{};
+	auto parsed2 = ParseWeatherSubscribeRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Subscribe request rejects 3 bytes");
+}
+
+static void TestSubscribeResponseOk()
+{
+	auto buf = BuildWeatherSubscribeResponsePayload(0u, 1u, 0.5f);
+	Assert(buf.size() == 6u, "Subscribe response Ok size 6 (1+1+4)");
+	auto parsed = ParseWeatherSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Subscribe Ok parses error");
+	if (parsed)
+	{
+		Assert(parsed->currentKind == 1u, "Subscribe Ok currentKind");
+		Assert(FloatNear(parsed->currentIntensity, 0.5f), "Subscribe Ok currentIntensity");
+	}
+}
+
+static void TestSubscribeResponseOkAllKinds()
+{
+	for (uint8_t k = 0; k <= 5; ++k)
+	{
+		auto buf = BuildWeatherSubscribeResponsePayload(0u, k, static_cast<float>(k) * 0.2f);
+		auto parsed = ParseWeatherSubscribeResponsePayload(buf.data(), buf.size());
+		Assert(parsed.has_value() && parsed->error == 0u && parsed->currentKind == k,
+			"Subscribe Ok kind 0..5");
+		if (parsed)
+		{
+			Assert(FloatNear(parsed->currentIntensity, static_cast<float>(k) * 0.2f),
+				"Subscribe Ok intensity matches");
+		}
+	}
+}
+
+static void TestSubscribeResponseUnknownZone()
+{
+	auto buf = BuildWeatherSubscribeResponsePayload(
+		static_cast<uint8_t>(WeatherErrorCode::UnknownZone), 0u, 0.0f);
+	Assert(buf.size() == 1u, "Subscribe response error UnknownZone size 1 (no body)");
+	auto parsed = ParseWeatherSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Subscribe UnknownZone");
+}
+
+static void TestSubscribeResponseUnauthorized()
+{
+	auto buf = BuildWeatherSubscribeResponsePayload(
+		static_cast<uint8_t>(WeatherErrorCode::Unauthorized), 0u, 0.0f);
+	auto parsed = ParseWeatherSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "Subscribe Unauthorized");
+}
+
+static void TestSubscribeResponsePacket()
+{
+	auto pkt = BuildWeatherSubscribeResponsePacket(0u, 5u, 0.3f, 12345u, 0xBEEFull);
+	Assert(!pkt.empty(), "Subscribe packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Subscribe PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeWeatherSubscribeResponse, "Opcode is SubscribeResponse");
+	Assert(view.RequestId() == 12345u, "Subscribe RequestId preserved");
+	auto parsed = ParseWeatherSubscribeResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->currentKind == 5u
+		&& FloatNear(parsed->currentIntensity, 0.3f),
+		"Subscribe Ok packet body decodes");
+}
+
+// -----------------------------------------------------------------------------
+// WEATHER_UNSUBSCRIBE
+// -----------------------------------------------------------------------------
+
+static void TestUnsubscribeRequestRoundTrip()
+{
+	auto buf = BuildWeatherUnsubscribeRequestPayload(2u);
+	Assert(buf.size() == 4u, "Unsubscribe request payload size 4");
+	auto parsed = ParseWeatherUnsubscribeRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->zoneId == 2u, "Unsubscribe request parses zoneId 2");
+}
+
+static void TestUnsubscribeRequestRejectsShort()
+{
+	uint8_t shortBuf[3]{};
+	auto parsed = ParseWeatherUnsubscribeRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed.has_value(), "Unsubscribe request rejects 3 bytes");
+}
+
+static void TestUnsubscribeResponseOk()
+{
+	auto buf = BuildWeatherUnsubscribeResponsePayload(0u);
+	Assert(buf.size() == 1u, "Unsubscribe response Ok size 1");
+	auto parsed = ParseWeatherUnsubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Unsubscribe Ok parses");
+}
+
+static void TestUnsubscribeResponseNotSubscribed()
+{
+	auto buf = BuildWeatherUnsubscribeResponsePayload(
+		static_cast<uint8_t>(WeatherErrorCode::NotSubscribed));
+	auto parsed = ParseWeatherUnsubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Unsubscribe NotSubscribed");
+}
+
+static void TestUnsubscribeResponsePacket()
+{
+	auto pkt = BuildWeatherUnsubscribeResponsePacket(0u, 99u, 0xFEEDull);
+	Assert(!pkt.empty(), "Unsubscribe packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Unsubscribe PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeWeatherUnsubscribeResponse, "Opcode is UnsubscribeResponse");
+	Assert(view.RequestId() == 99u, "Unsubscribe RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// WEATHER_UPDATE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestUpdateNotificationRoundTrip()
+{
+	auto buf = BuildWeatherUpdateNotificationPayload(1u, 1u, 0.5f);
+	Assert(buf.size() == 9u, "Update payload size 9");
+	auto parsed = ParseWeatherUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Update parses");
+	if (parsed)
+	{
+		Assert(parsed->zoneId == 1u, "Update zoneId");
+		Assert(parsed->kind == 1u, "Update kind Rain");
+		Assert(FloatNear(parsed->intensity, 0.5f), "Update intensity 0.5");
+	}
+}
+
+static void TestUpdateNotificationZeroIntensity()
+{
+	auto buf = BuildWeatherUpdateNotificationPayload(2u, 0u, 0.0f);
+	auto parsed = ParseWeatherUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && FloatNear(parsed->intensity, 0.0f) && parsed->kind == 0u,
+		"Update Clear intensity 0");
+}
+
+static void TestUpdateNotificationFullIntensity()
+{
+	auto buf = BuildWeatherUpdateNotificationPayload(3u, 5u, 1.0f);
+	auto parsed = ParseWeatherUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && FloatNear(parsed->intensity, 1.0f) && parsed->kind == 5u,
+		"Update Fog intensity 1.0");
+}
+
+static void TestUpdateNotificationAllKinds()
+{
+	// Clear=0, Rain=1, Snow=2, Storm=3, Sandstorm=4, Fog=5
+	for (uint8_t k = 0; k <= 5; ++k)
+	{
+		auto buf = BuildWeatherUpdateNotificationPayload(10u + k, k, 0.42f);
+		auto parsed = ParseWeatherUpdateNotificationPayload(buf.data(), buf.size());
+		Assert(parsed.has_value() && parsed->kind == k && parsed->zoneId == 10u + k,
+			"Update kind round-trip 0..5");
+	}
+}
+
+static void TestUpdateNotificationKindByteIsRaw()
+{
+	// Le wire ne valide pas la valeur de kind ; le parser doit accepter
+	// une valeur "invalide" (e.g. 99u) — la validation est cote presenter.
+	auto buf = BuildWeatherUpdateNotificationPayload(1u, 99u, 0.1f);
+	auto parsed = ParseWeatherUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->kind == 99u,
+		"Update accepts raw uint8 kind 99 (validation is presenter-side)");
+}
+
+static void TestUpdateNotificationRejectsShort()
+{
+	auto parsed = ParseWeatherUpdateNotificationPayload(nullptr, 9u);
+	Assert(!parsed.has_value(), "Update rejects nullptr");
+	uint8_t shortBuf[8]{};
+	auto parsed2 = ParseWeatherUpdateNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Update rejects 8 bytes");
+}
+
+static void TestUpdateNotificationPacket()
+{
+	auto pkt = BuildWeatherUpdateNotificationPacket(1u, 3u, 0.6f, 0xFADEull);
+	Assert(!pkt.empty(), "Update packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Update PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeWeatherUpdateNotification, "Opcode is UpdateNotification");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xFADEull, "Update SessionId preserved");
+	auto parsed = ParseWeatherUpdateNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->zoneId == 1u && parsed->kind == 3u
+		&& FloatNear(parsed->intensity, 0.6f),
+		"Update payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseSingleZone();
+	TestListResponseFullThreeZones();
+	TestListResponseError();
+	TestListResponseRejectsShort();
+	TestListResponsePacket();
+
+	TestSubscribeRequestRoundTrip();
+	TestSubscribeRequestBoundary();
+	TestSubscribeRequestRejectsShort();
+	TestSubscribeResponseOk();
+	TestSubscribeResponseOkAllKinds();
+	TestSubscribeResponseUnknownZone();
+	TestSubscribeResponseUnauthorized();
+	TestSubscribeResponsePacket();
+
+	TestUnsubscribeRequestRoundTrip();
+	TestUnsubscribeRequestRejectsShort();
+	TestUnsubscribeResponseOk();
+	TestUnsubscribeResponseNotSubscribed();
+	TestUnsubscribeResponsePacket();
+
+	TestUpdateNotificationRoundTrip();
+	TestUpdateNotificationZeroIntensity();
+	TestUpdateNotificationFullIntensity();
+	TestUpdateNotificationAllKinds();
+	TestUpdateNotificationKindByteIsRaw();
+	TestUpdateNotificationRejectsShort();
+	TestUpdateNotificationPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all weather payload tests passed\n"
+	                                : "[FAIL] some weather tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## CMANGOS.42 step 3+4 : Weather wire (zone subscribe + push updates + HUD client)

Branche `WeatherManager` (step 1+2 merge — Markov-like par zone avec profile probabiliste) sur le wire zone-list/subscribe + push WeatherUpdate + UI HUD weather indicator.
Master tient en mémoire `WeatherManager` (V1 seed 3 zones), force reroll à chaque subscribe, broadcast les changements à tous les subscribers de la zone.

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 7 opcodes (150-156)
  - `150/151` WeatherList Request/Response
  - `152/153` Subscribe Request/Response (response inclut le current state immédiat)
  - `154/155` Unsubscribe Request/Response
  - `156` WeatherUpdateNotification (push)
- `src/shared/network/WeatherPayloads.{h,cpp,Tests.cpp}` : 27 tests round-trip + edge cases (intensity 0..1, kinds 0-5 + invalid)
- `src/masterd/handlers/weather/WeatherHandler.{h,cpp}` :
  - 3 zones seed : Stormwind Plains (pluie + storm), Frozen Tundra (neige + fog), Tanaris Desert (sandstorm + fog)
  - Subscriptions in-memory + reverse index pour broadcast
  - `PushWeatherUpdate` helper public
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 150/152/154
- `src/shardd/weather/WeatherManager.h` : ajout additif `ForceReroll(ZoneId)`

### Client integration
- `src/client/weather/WeatherUi.{h,cpp}` : presenter + state (zones, subscriptions, active zone HUD)
- `src/client/render/WeatherImGuiRenderer.{h,cpp}` :
  - **Panel** `/weather` ou `Y` : liste zones colorées par kind + intensity bar + Set Active + Subscribe/Unsubscribe
  - **HUD overlay** top-right 240×70, transparent (alpha 0.45), toujours rendu si une zone active est sélectionnée — affiche icône + nom zone + kind + intensity
- `src/client/app/Engine` : dispatch + slash `/weather` + touche `Y` toggle
- `CMakeLists.txt` : sources + `weather_payloads_tests` target

### V1 limitations (consignées)
- 3 zones hardcodées. Vraies zones via M40+ futur.
- Tick simulé à chaque SubscribeRequest (force reroll). Vrai tick périodique via shardd futur.
- Subscriptions in-memory.
- Pas de SyncWeather RPC entre master et shardd (master autoritaire V1).

### Tests
- `weather_payloads_tests` (27 tests) — voir `src/shared/network/WeatherPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 150-156 + handler WeatherHandler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)