### PR TITLE
feat(gameevents): wire list + subscribe + push + UI client (CMANGOS.31)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ add_library(engine_core
   src/client/battleground/BattleGroundUi.cpp
   src/client/outdoorpvp/OutdoorPvpUi.cpp
   src/client/weather/WeatherUi.cpp
+  src/client/events/GameEventUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -347,6 +348,7 @@ add_library(engine_core
   src/client/render/BattleGroundImGuiRenderer.cpp
   src/client/render/OutdoorPvpImGuiRenderer.cpp
   src/client/render/WeatherImGuiRenderer.cpp
+  src/client/render/GameEventImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -447,6 +449,7 @@ add_library(engine_core
   src/shared/network/BattleGroundPayloads.cpp
   src/shared/network/OutdoorPvpPayloads.cpp
   src/shared/network/WeatherPayloads.cpp
+  src/shared/network/GameEventPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -717,6 +720,11 @@ add_test(NAME outdoorpvp_payloads_tests COMMAND outdoorpvp_payloads_tests)
 add_executable(weather_payloads_tests src/shared/network/WeatherPayloadsTests.cpp)
 target_link_libraries(weather_payloads_tests PRIVATE engine_core)
 add_test(NAME weather_payloads_tests COMMAND weather_payloads_tests)
+
+# CMANGOS.31 (Phase 5.31 step 3+4) — GameEvent payloads round-trip tests (no DB / no network).
+add_executable(gameevent_payloads_tests src/shared/network/GameEventPayloadsTests.cpp)
+target_link_libraries(gameevent_payloads_tests PRIVATE engine_core)
+add_test(NAME gameevent_payloads_tests COMMAND gameevent_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/battleground/BattleGroundHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/weather/WeatherHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/events/GameEventHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -139,6 +140,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/BattleGroundPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/OutdoorPvpPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/WeatherPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/GameEventPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -17,6 +17,7 @@
 #include "src/shared/network/BattleGroundPayloads.h"
 #include "src/shared/network/OutdoorPvpPayloads.h"
 #include "src/shared/network/WeatherPayloads.h"
+#include "src/shared/network/GameEventPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -32,6 +33,7 @@
 #include "src/client/render/BattleGroundImGuiRenderer.h"
 #include "src/client/render/OutdoorPvpImGuiRenderer.h"
 #include "src/client/render/WeatherImGuiRenderer.h"
+#include "src/client/render/GameEventImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -991,6 +993,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.31 (Phase 5.31 step 3+4) — Init du presenter GameEvents +
+		// cable du send callback pour les requetes 157/159/161. Reception
+		// dispatchee dans le push handler ci-dessous (responses 158/160/162
+		// + push 163 StateChange).
+		if (!m_gameEventUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] GameEventUiPresenter init FAILED — panneau GameEvents desactive");
+		}
+		else
+		{
+			m_gameEventUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1194,6 +1211,21 @@ namespace engine
 					m_weatherUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] /weather toggle (visible={})", m_weatherVisible);
+				return true;
+			}
+			// CMANGOS.31 (Phase 5.31 step 3+4) — Slash command /events pour
+			// ouvrir/fermer le panneau GameEvents et synchroniser la liste
+			// depuis le master au moment de l'ouverture. La touche E fait
+			// la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/events" || text.starts_with("/events ") || text.starts_with("/events\t")))
+			{
+				m_gameEventVisible = !m_gameEventVisible;
+				if (m_gameEventVisible)
+				{
+					m_gameEventUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] /events toggle (visible={})", m_gameEventVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1812,6 +1844,52 @@ namespace engine
 					return;
 				}
 				m_weatherUi.OnUpdateNotification(*parsed);
+				return;
+			}
+			// CMANGOS.31 (Phase 5.31 step 3+4) — Dispatch des reponses
+			// GameEvents (158/160/162) + push notification (163).
+			case kOpcodeGameEventListResponse:
+			{
+				auto parsed = ParseGameEventListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GAME_EVENT_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gameEventUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeGameEventSubscribeResponse:
+			{
+				auto parsed = ParseGameEventSubscribeResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GAME_EVENT_SUBSCRIBE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gameEventUi.OnSubscribeResponse(*parsed);
+				return;
+			}
+			case kOpcodeGameEventUnsubscribeResponse:
+			{
+				auto parsed = ParseGameEventUnsubscribeResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GAME_EVENT_UNSUBSCRIBE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gameEventUi.OnUnsubscribeResponse(*parsed);
+				return;
+			}
+			case kOpcodeGameEventStateChangeNotification:
+			{
+				auto parsed = ParseGameEventStateChangeNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GAME_EVENT_STATE_CHANGE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_gameEventUi.OnStateChangeNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -4117,6 +4195,7 @@ namespace engine
 		m_battleGroundUi.Shutdown();
 		m_outdoorPvpUi.Shutdown();
 		m_weatherUi.Shutdown();
+		m_gameEventUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -4276,6 +4355,20 @@ namespace engine
 					m_weatherUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] Y toggle weather (visible={})", m_weatherVisible);
+			}
+			// CMANGOS.31 (Phase 5.31 step 3+4) — Touche E : toggle panneau
+			// GameEvents + RequestList si on l'ouvre. Memes guards que Y.
+			// Pas de conflit Ctrl+E (non utilise par WorldEditorShell).
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::E))
+			{
+				m_gameEventVisible = !m_gameEventVisible;
+				if (m_gameEventVisible)
+				{
+					m_gameEventUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] E toggle gameevents (visible={})", m_gameEventVisible);
 			}
 		}
 
@@ -4493,6 +4586,13 @@ namespace engine
 				// presenter (selectionne via le bouton "Set Active" du panel).
 				m_weatherImGui = std::make_unique<engine::render::WeatherImGuiRenderer>();
 				m_weatherImGui->SetPresenter(&m_weatherUi);
+				// CMANGOS.31 (Phase 5.31 step 3+4) — Renderer ImGui GameEvents.
+				// Le panel principal n'est visible que quand m_gameEventVisible
+				// (toggle via /events ou touche E). Le toast 5s sur dernier
+				// StateChange reçu est rendu independamment du flag (peut
+				// arriver panneau ferme).
+				m_gameEventImGui = std::make_unique<engine::render::GameEventImGuiRenderer>();
+				m_gameEventImGui->SetPresenter(&m_gameEventUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5605,6 +5705,16 @@ namespace engine
 				m_weatherImGui->SetEnabled(m_weatherVisible);
 				m_weatherImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_weatherImGui->Render();
+			}
+			// CMANGOS.31 (Phase 5.31 step 3+4) — Render du panel GameEvents
+			// si m_gameEventVisible (toggle via /events ou touche E), ET du
+			// toast 5s sur dernier StateChange reçu (rendu independamment
+			// par Render() si lastChangeTimeMs est recent).
+			if (m_gameEventImGui && m_gameEventUi.IsInitialized())
+			{
+				m_gameEventImGui->SetEnabled(m_gameEventVisible);
+				m_gameEventImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_gameEventImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -16,6 +16,7 @@
 #include "src/client/battleground/BattleGroundUi.h"
 #include "src/client/outdoorpvp/OutdoorPvpUi.h"
 #include "src/client/weather/WeatherUi.h"
+#include "src/client/events/GameEventUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -85,6 +86,7 @@ namespace engine::render
 	class BattleGroundImGuiRenderer;
 	class OutdoorPvpImGuiRenderer;
 	class WeatherImGuiRenderer;
+	class GameEventImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -385,6 +387,12 @@ namespace engine
 		/// (toggle via slash command /weather ou touche Y). Le HUD top-right
 		/// est rendu independamment du flag des que activeZoneId est set.
 		std::unique_ptr<engine::render::WeatherImGuiRenderer> m_weatherImGui;
+		/// CMANGOS.31 (Phase 5.31 step 3+4) — Panneau "Game Events" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec les autres panneaux post-auth.
+		/// Le panel principal est visible uniquement quand m_gameEventVisible
+		/// (toggle via slash command /events ou touche E). Le toast 5s sur
+		/// dernier StateChange reçu est rendu independamment du flag.
+		std::unique_ptr<engine::render::GameEventImGuiRenderer> m_gameEventImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -540,6 +548,15 @@ namespace engine
 		/// (toggle via slash command \c /weather ou touche Y). Faux par defaut.
 		/// Le HUD top-right est rendu independamment quand activeZoneId set.
 		bool                                  m_weatherVisible = false;
+		/// CMANGOS.31 (Phase 5.31 step 3+4) — Presenter de la fenetre GameEvents.
+		/// Recoit les responses opcodes 158/160/162 et la push notification
+		/// 163 (StateChange) via le push handler du master ; fire-and-forget
+		/// des requetes 157/159/161 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::GameEventUiPresenter  m_gameEventUi;
+		/// CMANGOS.31 (Phase 5.31 step 3+4) — Visibilite du panneau GameEvents
+		/// (toggle via slash command \c /events ou touche E). Faux par defaut.
+		/// Le toast 5s sur dernier StateChange reçu est rendu independamment.
+		bool                                  m_gameEventVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/events/GameEventUi.cpp
+++ b/src/client/events/GameEventUi.cpp
@@ -1,0 +1,288 @@
+// CMANGOS.31 (Phase 5.31 step 3+4) — Implementation GameEventUiPresenter.
+
+#include "src/client/events/GameEventUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <cstdio>
+
+namespace engine::client
+{
+	// -------------------------------------------------------------------------
+	// GameEventStateName — static helper.
+	// -------------------------------------------------------------------------
+
+	const char* GameEventStateName(uint8_t state)
+	{
+		switch (state)
+		{
+		case 0: return "Inactive";
+		case 1: return "Active";
+		default: return "?";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// FormatRelativeTime — static helper.
+	// -------------------------------------------------------------------------
+
+	std::string FormatRelativeTime(int64_t deltaMs)
+	{
+		if (deltaMs <= 0)
+			return std::string("-");
+
+		const int64_t seconds = deltaMs / 1000;
+		const int64_t days    = seconds / 86400;
+		const int64_t hours   = (seconds % 86400) / 3600;
+		const int64_t minutes = (seconds % 3600) / 60;
+		const int64_t secs    = seconds % 60;
+
+		char buf[64]{};
+		if (days > 0)
+		{
+			std::snprintf(buf, sizeof(buf), "%lldd %lldh",
+				static_cast<long long>(days),
+				static_cast<long long>(hours));
+		}
+		else if (hours > 0)
+		{
+			std::snprintf(buf, sizeof(buf), "%lldh %lldm",
+				static_cast<long long>(hours),
+				static_cast<long long>(minutes));
+		}
+		else if (minutes > 0)
+		{
+			std::snprintf(buf, sizeof(buf), "%lldm %llds",
+				static_cast<long long>(minutes),
+				static_cast<long long>(secs));
+		}
+		else
+		{
+			std::snprintf(buf, sizeof(buf), "%llds",
+				static_cast<long long>(secs));
+		}
+		return std::string(buf);
+	}
+
+	namespace
+	{
+		/// Retourne le steady_clock now en ms depuis le boot pour
+		/// l'horodatage local des toasts (5s d'affichage).
+		uint64_t SteadyMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Presenter lifecycle
+	// -------------------------------------------------------------------------
+
+	GameEventUiPresenter::~GameEventUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool GameEventUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[GameEventUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		LOG_INFO(Core, "[GameEventUiPresenter] Init OK");
+		return true;
+	}
+
+	void GameEventUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[GameEventUiPresenter] Destroyed");
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void GameEventUiPresenter::RequestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GameEventUiPresenter] RequestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGameEventListRequestPayload();
+		if (!m_send(engine::network::kOpcodeGameEventListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste events).";
+			LOG_WARN(Net, "[GameEventUiPresenter] RequestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[GameEventUiPresenter] GameEvent ListRequest queued");
+	}
+
+	void GameEventUiPresenter::Subscribe()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GameEventUiPresenter] Subscribe: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGameEventSubscribeRequestPayload();
+		if (!m_send(engine::network::kOpcodeGameEventSubscribeRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (subscribe events).";
+			LOG_WARN(Net, "[GameEventUiPresenter] Subscribe: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[GameEventUiPresenter] SubscribeRequest queued");
+	}
+
+	void GameEventUiPresenter::Unsubscribe()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GameEventUiPresenter] Unsubscribe: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGameEventUnsubscribeRequestPayload();
+		if (!m_send(engine::network::kOpcodeGameEventUnsubscribeRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (unsubscribe events).";
+			LOG_WARN(Net, "[GameEventUiPresenter] Unsubscribe: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[GameEventUiPresenter] UnsubscribeRequest queued");
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void GameEventUiPresenter::OnListResponse(const engine::network::GameEventListResponsePayload& resp)
+	{
+		using engine::network::GameEventErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GameEventErrorCode>(resp.error);
+			if (err == GameEventErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur GameEvent inconnue.";
+			LOG_WARN(Net, "[GameEventUiPresenter] OnListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.events.clear();
+		m_state.events.reserve(resp.events.size());
+		for (const auto& ev : resp.events)
+		{
+			GameEventSummary local;
+			local.eventId    = ev.eventId;
+			local.name       = ev.name;
+			local.state      = ev.state;
+			local.startTsMs  = ev.startTsMs;
+			local.durationMs = ev.durationMs;
+			local.recurMs    = ev.recurMs;
+			local.untilTsMs  = 0u; // sera renseigne par le prochain StateChange.
+			m_state.events.push_back(std::move(local));
+		}
+		m_state.eventsLoaded = true;
+
+		LOG_INFO(Net, "[GameEventUiPresenter] OnListResponse OK count={}",
+			m_state.events.size());
+	}
+
+	void GameEventUiPresenter::OnSubscribeResponse(const engine::network::GameEventSubscribeResponsePayload& resp)
+	{
+		using engine::network::GameEventErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GameEventErrorCode>(resp.error);
+			switch (err)
+			{
+			case GameEventErrorCode::AlreadySubscribed:
+				m_state.lastErrorText = "Deja abonne aux events.";
+				// Reflete l'etat reel cote serveur (si on s'est abonne dans
+				// une autre session par exemple).
+				m_state.subscribed = true;
+				break;
+			case GameEventErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur GameEvent inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[GameEventUiPresenter] OnSubscribeResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.subscribed = true;
+		m_state.lastInfoText = "Abonne aux push d'events.";
+		LOG_INFO(Net, "[GameEventUiPresenter] OnSubscribeResponse OK");
+	}
+
+	void GameEventUiPresenter::OnUnsubscribeResponse(const engine::network::GameEventUnsubscribeResponsePayload& resp)
+	{
+		using engine::network::GameEventErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GameEventErrorCode>(resp.error);
+			switch (err)
+			{
+			case GameEventErrorCode::NotSubscribed:
+				m_state.lastErrorText = "Pas abonne aux events.";
+				m_state.subscribed = false;
+				break;
+			case GameEventErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur GameEvent inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[GameEventUiPresenter] OnUnsubscribeResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.subscribed = false;
+		m_state.lastInfoText = "Desabonne des push d'events.";
+		LOG_INFO(Net, "[GameEventUiPresenter] OnUnsubscribeResponse OK");
+	}
+
+	void GameEventUiPresenter::OnStateChangeNotification(const engine::network::GameEventStateChangeNotificationPayload& note)
+	{
+		// Mise a jour locale du cache events.
+		for (auto& ev : m_state.events)
+		{
+			if (ev.eventId == note.eventId)
+			{
+				ev.state     = note.newState;
+				ev.untilTsMs = note.untilTsMs;
+				break;
+			}
+		}
+		// Met a jour le toast (lastChange*).
+		m_state.lastChangeEventId  = note.eventId;
+		m_state.lastChangeNewState = note.newState;
+		m_state.lastChangeTimeMs   = SteadyMs();
+		LOG_DEBUG(Net, "[GameEventUiPresenter] OnStateChangeNotification eid={} state={} untilTsMs={}",
+			note.eventId, static_cast<unsigned>(note.newState), note.untilTsMs);
+	}
+}

--- a/src/client/events/GameEventUi.h
+++ b/src/client/events/GameEventUi.h
@@ -1,0 +1,143 @@
+#pragma once
+// CMANGOS.31 (Phase 5.31 step 3+4) — Presenter client de la fenetre
+// GameEvents. Maintient un cache local des events saisonniers + flag
+// d'abonnement global + dernier changement reçu (pour toast UI).
+//
+// Pas de rendu ImGui : le panneau est drawe par GameEventImGuiRenderer qui
+// lit l'etat via GetState() et propage les inputs UI (RequestList /
+// Subscribe / Unsubscribe) via les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans WeatherUi).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 158/160/162/163 vers les OnXxx du presenter.
+
+#include "src/shared/network/GameEventPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'un event expose au layer UI. Mirror direct de
+	/// engine::network::GameEventSummary + un champ `untilTsMs` qui
+	/// reflete le dernier StateChange reçu (ou 0 si jamais reçu).
+	struct GameEventSummary
+	{
+		uint32_t    eventId    = 0;
+		std::string name;
+		uint8_t     state      = 0;     ///< 0=Inactive, 1=Active.
+		uint64_t    startTsMs  = 0;
+		uint64_t    durationMs = 0;
+		uint64_t    recurMs    = 0;
+		uint64_t    untilTsMs  = 0;     ///< Active: when ends ; Inactive: when starts. 0 = inconnu.
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct GameEventState
+	{
+		std::vector<GameEventSummary>     events;
+		bool                              eventsLoaded = false;
+
+		/// Abonnement global : true si l'utilisateur est abonne aux push.
+		bool                              subscribed   = false;
+
+		/// Dernier StateChange reçu : eventId + nouvel etat + instant
+		/// d'arrivee (ms steady_clock cote client). Utilise par le renderer
+		/// pour afficher un toast 5s apres reception. 0 = jamais reçu.
+		std::optional<uint64_t>           lastChangeTimeMs;
+		uint32_t                          lastChangeEventId  = 0;
+		uint8_t                           lastChangeNewState = 0;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire (e.g. "Abonne aux events."). Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Static helper : retourne le libelle ASCII en anglais pour un state.
+	/// Inputs invalides (state > 1) renvoient "?".
+	const char* GameEventStateName(uint8_t state);
+
+	/// Static helper : formate un delta en ms en chaine "in Xd Yh" ou
+	/// "Xh Ym" ou "Xm Ys". \p deltaMs peut etre negatif (renvoie "-").
+	/// \param deltaMs delta a formater.
+	std::string FormatRelativeTime(int64_t deltaMs);
+
+	/// Presenter pour la fenetre GameEvents cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main (comme les autres
+	/// presenters UI).
+	class GameEventUiPresenter final
+	{
+	public:
+		GameEventUiPresenter() = default;
+
+		GameEventUiPresenter(const GameEventUiPresenter&)            = delete;
+		GameEventUiPresenter& operator=(const GameEventUiPresenter&) = delete;
+
+		~GameEventUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.31 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / Subscribe / Unsubscribe.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie GAME_EVENT_LIST_REQUEST. Reponse via OnListResponse.
+		void RequestList();
+
+		/// Envoie GAME_EVENT_SUBSCRIBE_REQUEST. Reponse via OnSubscribeResponse.
+		void Subscribe();
+
+		/// Envoie GAME_EVENT_UNSUBSCRIBE_REQUEST. Reponse via OnUnsubscribeResponse.
+		void Unsubscribe();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit GAME_EVENT_LIST_RESPONSE. Remplace le cache local.
+		void OnListResponse(const engine::network::GameEventListResponsePayload& resp);
+
+		/// Recoit GAME_EVENT_SUBSCRIBE_RESPONSE. Si Ok, met subscribed=true.
+		void OnSubscribeResponse(const engine::network::GameEventSubscribeResponsePayload& resp);
+
+		/// Recoit GAME_EVENT_UNSUBSCRIBE_RESPONSE. Si Ok, met subscribed=false.
+		void OnUnsubscribeResponse(const engine::network::GameEventUnsubscribeResponsePayload& resp);
+
+		/// Recoit un push GAME_EVENT_STATE_CHANGE_NOTIFICATION : update
+		/// state + untilTsMs de l'event dans le cache local. Met aussi a jour
+		/// lastChangeEventId/lastChangeNewState/lastChangeTimeMs pour le toast UI.
+		void OnStateChangeNotification(const engine::network::GameEventStateChangeNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const GameEventState& GetState() const { return m_state; }
+
+	private:
+		bool             m_initialized = false;
+		GameEventState   m_state{};
+		SendCallback     m_send;
+	};
+}

--- a/src/client/render/GameEventImGuiRenderer.cpp
+++ b/src/client/render/GameEventImGuiRenderer.cpp
@@ -1,0 +1,323 @@
+// CMANGOS.31 (Phase 5.31 step 3+4) — GameEventImGuiRenderer implementation.
+
+#include "src/client/render/GameEventImGuiRenderer.h"
+
+#include "src/client/events/GameEventUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Couleur ImGui par etat (Active=vert, Inactive=gris). Inputs
+		/// invalides -> gris fonce.
+		ImVec4 StateColor(uint8_t state)
+		{
+			switch (state)
+			{
+			case 0: return ImVec4(0.60f, 0.60f, 0.65f, 1.f); // Inactive -> gris.
+			case 1: return ImVec4(0.40f, 0.95f, 0.40f, 1.f); // Active -> vert.
+			default: return ImVec4(0.50f, 0.40f, 0.40f, 1.f);
+			}
+		}
+
+		/// Petit "icone" textuel ASCII pour la liste (pas d'emoji, MSVC
+		/// strict + Arial dans editor monde sans certains glyphs).
+		const char* StateIcon(uint8_t state)
+		{
+			switch (state)
+			{
+			case 0: return "[ ]";  // Inactive.
+			case 1: return "[*]";  // Active.
+			default: return "[?]";
+			}
+		}
+
+		/// Retourne le system_clock now en ms epoch (pour calculer les
+		/// countdowns vis-a-vis des untilTsMs / startTsMs).
+		uint64_t WallNowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+
+		/// Retourne le steady_clock now en ms (pour les toasts 5s).
+		uint64_t SteadyNowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	void GameEventImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		// Le panel n'est rendu que si IsEnabled().
+		if (m_enabled)
+			RenderMainPanel();
+
+		// Le toast est rendu independamment, si un StateChange recent existe.
+		RenderToast();
+	}
+
+	void GameEventImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 480x520.
+		const float panelW = 480.f;
+		const float panelH = 520.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Game Events##ln_gameevents_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Bouton Subscribe / Unsubscribe global au top.
+			if (state.subscribed)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.55f, 0.20f, 0.20f, 1.f));
+				if (ImGui::Button("Se desabonner des events", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->Unsubscribe();
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.45f, 0.30f, 1.f));
+				if (ImGui::Button("S'abonner aux push d'events", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->Subscribe();
+				ImGui::PopStyleColor();
+			}
+			ImGui::Separator();
+
+			// Liste des events.
+			if (!state.eventsLoaded || state.events.empty())
+			{
+				if (ImGui::Button("Charger les events", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->RequestList();
+				if (state.eventsLoaded && state.events.empty())
+				{
+					ImGui::TextWrapped("Aucun event saisonnier.");
+				}
+			}
+			else
+			{
+				ImGui::TextUnformatted("Events saisonniers :");
+				ImGui::Separator();
+
+				const uint64_t nowMs = WallNowMs();
+
+				for (const auto& ev : state.events)
+				{
+					ImGui::PushID(static_cast<int>(ev.eventId));
+
+					// Header : icone d'etat + nom + (id).
+					ImGui::PushStyleColor(ImGuiCol_Text, StateColor(ev.state));
+					ImGui::Text("%s %s", StateIcon(ev.state), ev.name.c_str());
+					ImGui::PopStyleColor();
+
+					// Sous-ligne : etat textuel + countdown (ends in / starts in).
+					ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.85f, 0.85f, 0.85f, 1.f));
+					ImGui::Text("Etat : %s", engine::client::GameEventStateName(ev.state));
+					ImGui::PopStyleColor();
+
+					// Countdown : si untilTsMs reçu via push, calcule
+					// untilTsMs - nowMs ; sinon, fallback sur startTsMs/durationMs.
+					uint64_t targetTsMs = ev.untilTsMs;
+					if (targetTsMs == 0u)
+					{
+						// Fallback : derive depuis state + startTsMs +
+						// durationMs + recurMs.
+						if (ev.state == 1u)
+						{
+							// Active : derive la fin de l'occurrence courante.
+							if (ev.recurMs == 0u)
+							{
+								targetTsMs = ev.startTsMs + ev.durationMs;
+							}
+							else if (nowMs >= ev.startTsMs)
+							{
+								const uint64_t offset       = (nowMs - ev.startTsMs) % ev.recurMs;
+								const uint64_t cycleStartMs = nowMs - offset;
+								targetTsMs = cycleStartMs + ev.durationMs;
+							}
+						}
+						else
+						{
+							// Inactive : derive le prochain debut.
+							if (nowMs < ev.startTsMs)
+							{
+								targetTsMs = ev.startTsMs;
+							}
+							else if (ev.recurMs != 0u)
+							{
+								const uint64_t offset       = (nowMs - ev.startTsMs) % ev.recurMs;
+								const uint64_t cycleStartMs = nowMs - offset;
+								targetTsMs = cycleStartMs + ev.recurMs;
+							}
+						}
+					}
+
+					if (targetTsMs > 0u && targetTsMs > nowMs)
+					{
+						const int64_t deltaMs = static_cast<int64_t>(targetTsMs - nowMs);
+						const std::string rel = engine::client::FormatRelativeTime(deltaMs);
+						const char* prefix = (ev.state == 1u) ? "Termine dans" : "Demarre dans";
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.75f, 0.85f, 1.0f, 1.f));
+						ImGui::Text("%s : %s", prefix, rel.c_str());
+						ImGui::PopStyleColor();
+					}
+					else if (targetTsMs == 0u && ev.state == 0u && ev.recurMs == 0u)
+					{
+						// One-shot termine.
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.f));
+						ImGui::TextUnformatted("Termine.");
+						ImGui::PopStyleColor();
+					}
+
+					ImGui::Separator();
+					ImGui::PopID();
+				}
+
+				ImGui::Spacing();
+				if (ImGui::Button("Rafraichir la liste", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->RequestList();
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void GameEventImGuiRenderer::RenderToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastChangeTimeMs.has_value())
+			return;
+
+		// Toast actif 5s apres reception.
+		constexpr uint64_t kToastDurationMs = 5000ull;
+		const uint64_t nowSteady = SteadyNowMs();
+		if (nowSteady < *state.lastChangeTimeMs)
+			return;
+		const uint64_t age = nowSteady - *state.lastChangeTimeMs;
+		if (age > kToastDurationMs)
+			return;
+
+		// Cherche le nom de l'event dans le cache. Fallback "Event N".
+		std::string eventName;
+		for (const auto& ev : state.events)
+		{
+			if (ev.eventId == state.lastChangeEventId)
+			{
+				eventName = ev.name;
+				break;
+			}
+		}
+		if (eventName.empty())
+		{
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Event %u",
+				static_cast<unsigned>(state.lastChangeEventId));
+			eventName = buf;
+		}
+
+		// Texte + couleur selon nouvel etat.
+		const bool becameActive = (state.lastChangeNewState == 1u);
+		std::string text = eventName + (becameActive ? " a commence !" : " est termine.");
+		ImVec4 textColor = becameActive
+			? ImVec4(0.40f, 0.95f, 0.40f, 1.f) // vert
+			: ImVec4(0.95f, 0.65f, 0.30f, 1.f); // orange
+
+		// Geometrie toast : bottom-right, 320x60, marge 16.
+		const float toastW = 320.f;
+		const float toastH = 60.f;
+		const float margin = 16.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = std::max(0.f, vpH - toastH - margin);
+
+		// Fade out sur les 1000 dernieres ms.
+		float alpha = 0.95f;
+		if (age > kToastDurationMs - 1000ull)
+		{
+			const float remain = static_cast<float>(kToastDurationMs - age) / 1000.0f;
+			alpha = std::max(0.0f, std::min(0.95f, remain * 0.95f));
+		}
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(alpha);
+
+		const ImGuiWindowFlags toastFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoInputs;
+
+		if (ImGui::Begin("##ln_gameevents_toast", nullptr, toastFlags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, textColor);
+			ImGui::TextWrapped("%s", text.c_str());
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void GameEventImGuiRenderer::Render()           {}
+	void GameEventImGuiRenderer::RenderMainPanel()  {}
+	void GameEventImGuiRenderer::RenderToast()      {}
+}
+
+#endif

--- a/src/client/render/GameEventImGuiRenderer.h
+++ b/src/client/render/GameEventImGuiRenderer.h
@@ -1,0 +1,57 @@
+#pragma once
+// CMANGOS.31 (Phase 5.31 step 3+4) — GameEventImGuiRenderer : panneau ImGui
+// pour la fenetre GameEvents (events saisonniers). Liste les events avec
+// leur etat courant (Active/Inactive) + countdown via untilTsMs ;
+// boutons Subscribe / Unsubscribe globaux ; toast 5s sur dernier
+// changement reçu (push 163).
+//
+// Pas de HUD overlay : seulement le panel principal.
+//
+// Lit l'etat d'un GameEventUiPresenter, dispatch les inputs UI
+// (RequestList / Subscribe / Unsubscribe) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class GameEventUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau GameEvents. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::GameEventUiPresenter. Le
+	/// renderer ne fait que dessiner l'etat courant et propager les inputs UI
+	/// vers le presenter.
+	class GameEventImGuiRenderer
+	{
+	public:
+		GameEventImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::GameEventUiPresenter* presenter) { m_presenter = presenter; }
+
+		/// Active/desactive le rendu du panel principal.
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Game Events" (si IsEnabled()) et le toast 5s
+		/// pour le dernier StateChange reçu (rendu independamment du flag
+		/// IsEnabled() puisque les push peuvent arriver panneau ferme).
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(),
+		/// apres NewFrame, si le presenter est valide.
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (liste events + boutons + countdowns).
+		void RenderMainPanel();
+
+		/// Dessine le toast 5s en bas-droite si lastChange* est recent.
+		void RenderToast();
+
+		engine::client::GameEventUiPresenter* m_presenter = nullptr;
+		bool                                  m_enabled   = false;
+		uint32_t                              m_viewportW = 0;
+		uint32_t                              m_viewportH = 0;
+	};
+}

--- a/src/masterd/events/GameEventManager.h
+++ b/src/masterd/events/GameEventManager.h
@@ -57,6 +57,12 @@ namespace engine::server::events
 
 		size_t Size() const noexcept { return m_events.size(); }
 
+		/// CMANGOS.31 step 3+4 — Acces lecture seule a la map d'events pour
+		/// les iterations cote handler (List response, snapshot subscribe).
+		/// Modification additive : permet au GameEventHandler de construire
+		/// les summaries sans dupliquer la liste des ids.
+		const std::unordered_map<EventId, GameEventDef>& Events() const noexcept { return m_events; }
+
 	private:
 		std::unordered_map<EventId, GameEventDef> m_events;
 	};

--- a/src/masterd/handlers/events/GameEventHandler.cpp
+++ b/src/masterd/handlers/events/GameEventHandler.cpp
@@ -1,0 +1,418 @@
+// CMANGOS.31 (Phase 5.31 step 3+4) — Implementation GameEventHandler.
+
+#include "src/masterd/handlers/events/GameEventHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/GameEventPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::server::events::EventId;
+	using engine::server::events::EventState;
+	using engine::server::events::GameEventDef;
+	using engine::server::events::GameEventManager;
+
+	namespace
+	{
+		/// Retourne le system_clock now en ms depuis epoch (resolution ms,
+		/// wallclock pour comparer aux timestamps absolus des events).
+		uint64_t NowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+
+		/// Calcule untilTsMs : timestamp de la prochaine bascule pour un
+		/// event (def + nowMs + state actuel).
+		///
+		/// \param def           definition de l'event (timestamps + recur).
+		/// \param nowMs         instant courant (system_clock ms epoch).
+		/// \param currentState  state courant calcule par GameEventManager.
+		/// \return Si Active : timestamp ms de la fin de l'occurrence courante.
+		///         Si Inactive : timestamp ms du prochain debut. 0 si aucune
+		///         prochaine bascule (one-shot termine).
+		uint64_t ComputeUntilTs(const GameEventDef& def, uint64_t nowMs, EventState currentState)
+		{
+			if (def.recurMs == 0u)
+			{
+				// One-shot.
+				if (currentState == EventState::Active)
+				{
+					// Event en cours : se termine a startTsMs + durationMs.
+					return def.startTsMs + def.durationMs;
+				}
+				else
+				{
+					// Inactive : soit pas commence (renvoie startTsMs), soit
+					// termine definitivement (renvoie 0).
+					if (nowMs < def.startTsMs) return def.startTsMs;
+					return 0u;
+				}
+			}
+			// Recurrent.
+			if (nowMs < def.startTsMs)
+			{
+				// Avant la 1ere occurrence.
+				return def.startTsMs;
+			}
+			const uint64_t offset       = (nowMs - def.startTsMs) % def.recurMs;
+			const uint64_t cycleStartMs = nowMs - offset;
+			if (currentState == EventState::Active)
+			{
+				// Active : fin de l'occurrence courante.
+				return cycleStartMs + def.durationMs;
+			}
+			else
+			{
+				// Inactive : prochain debut = debut du cycle suivant.
+				return cycleStartMs + def.recurMs;
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// SeedV1Events — register the 4 hardcoded events at boot.
+	// -------------------------------------------------------------------------
+
+	void GameEventHandler::SeedV1Events()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_seeded)
+		{
+			LOG_DEBUG(Net, "[GameEventHandler] SeedV1Events already seeded (idempotent skip)");
+			return;
+		}
+
+		// Constantes V1 : durations + recur en ms.
+		constexpr uint64_t kDuration14d = 14ull * 24ull * 3600ull * 1000ull;  // 1209600000
+		constexpr uint64_t kDuration21d = 21ull * 24ull * 3600ull * 1000ull;  // 1814400000
+		constexpr uint64_t kRecur1y     = 365ull * 24ull * 3600ull * 1000ull; // 31536000000
+
+		// Event 1 : Halloween — 2026-10-15 (20741 jours epoch * 86400 * 1000).
+		{
+			GameEventDef d;
+			d.id         = kEventHalloween;
+			d.name       = "Halloween";
+			d.startTsMs  = 1791849600000ull;
+			d.durationMs = kDuration14d;
+			d.recurMs    = kRecur1y;
+			m_manager.Register(d);
+			m_eventNames[kEventHalloween] = "Halloween";
+		}
+
+		// Event 2 : Winter Veil — 2026-12-15 (20802 jours epoch * 86400 * 1000).
+		{
+			GameEventDef d;
+			d.id         = kEventWinterVeil;
+			d.name       = "Winter Veil";
+			d.startTsMs  = 1797206400000ull;
+			d.durationMs = kDuration21d;
+			d.recurMs    = kRecur1y;
+			m_manager.Register(d);
+			m_eventNames[kEventWinterVeil] = "Winter Veil";
+		}
+
+		// Event 3 : Lunar Festival — 2026-02-01 (20485 jours epoch * 86400 * 1000).
+		{
+			GameEventDef d;
+			d.id         = kEventLunarFestival;
+			d.name       = "Lunar Festival";
+			d.startTsMs  = 1769817600000ull;
+			d.durationMs = kDuration14d;
+			d.recurMs    = kRecur1y;
+			m_manager.Register(d);
+			m_eventNames[kEventLunarFestival] = "Lunar Festival";
+		}
+
+		// Event 4 : Midsummer Fire Festival — 2026-06-21 (20625 jours epoch * 86400 * 1000).
+		{
+			GameEventDef d;
+			d.id         = kEventMidsummerFire;
+			d.name       = "Midsummer Fire Festival";
+			d.startTsMs  = 1781913600000ull;
+			d.durationMs = kDuration14d;
+			d.recurMs    = kRecur1y;
+			m_manager.Register(d);
+			m_eventNames[kEventMidsummerFire] = "Midsummer Fire Festival";
+		}
+
+		m_seeded = true;
+		LOG_INFO(Net, "[GameEventHandler] V1 events seeded : Halloween, Winter Veil, Lunar Festival, Midsummer Fire Festival");
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket — dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void GameEventHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[GameEventHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(GameEventErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeGameEventListRequest:
+				pkt = BuildGameEventListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGameEventSubscribeRequest:
+				pkt = BuildGameEventSubscribeResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGameEventUnsubscribeRequest:
+				pkt = BuildGameEventUnsubscribeResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeGameEventListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGameEventSubscribeRequest:
+			HandleSubscribe(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGameEventUnsubscribeRequest:
+			HandleUnsubscribe(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleList
+	// -------------------------------------------------------------------------
+
+	void GameEventHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		const uint64_t nowMs = NowMs();
+		std::vector<GameEventSummary> events;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const auto& evs = m_manager.Events();
+			events.reserve(evs.size());
+			for (const auto& [eid, def] : evs)
+			{
+				const EventState st = m_manager.GetState(eid, nowMs);
+				GameEventSummary summary;
+				summary.eventId    = eid;
+				summary.name       = def.name;
+				summary.state      = static_cast<uint8_t>(st);
+				summary.startTsMs  = def.startTsMs;
+				summary.durationMs = def.durationMs;
+				summary.recurMs    = def.recurMs;
+				events.push_back(std::move(summary));
+			}
+		}
+
+		LOG_INFO(Net, "[GameEventHandler] List account={} count={}",
+			accountId, events.size());
+
+		auto pkt = BuildGameEventListResponsePacket(0u, events, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleSubscribe
+	// -------------------------------------------------------------------------
+
+	void GameEventHandler::HandleSubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		// Le payload est vide ; ParseGameEventSubscribeRequestPayload accepte
+		// tout buffer (y compris nullptr/0). On ne valide pas le contenu V1.
+		(void)ParseGameEventSubscribeRequestPayload(payload, payloadSize);
+
+		const uint64_t nowMs = NowMs();
+		bool alreadySubscribed = false;
+
+		// Snapshot a pousser au nouvel abonne : eventId -> (newState, untilTsMs).
+		struct PushItem { uint32_t eventId; uint8_t state; uint64_t untilTsMs; };
+		std::vector<PushItem> snapshot;
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto inserted = m_subscribers.insert(accountId);
+			if (!inserted.second)
+			{
+				alreadySubscribed = true;
+			}
+			else
+			{
+				// Premier subscribe pour cet accountId : compare l'etat
+				// actuel des events au dernier broadcast pour ne push que
+				// sur changement. Met a jour m_lastBroadcastState.
+				const auto& evs = m_manager.Events();
+				snapshot.reserve(evs.size());
+				for (const auto& [eid, def] : evs)
+				{
+					const EventState curSt = m_manager.GetState(eid, nowMs);
+					const uint8_t curStByte = static_cast<uint8_t>(curSt);
+					auto it = m_lastBroadcastState.find(eid);
+					const bool changed = (it == m_lastBroadcastState.end())
+						|| (it->second != curStByte);
+					if (changed)
+					{
+						const uint64_t untilTs = ComputeUntilTs(def, nowMs, curSt);
+						snapshot.push_back(PushItem{ eid, curStByte, untilTs });
+						m_lastBroadcastState[eid] = curStByte;
+					}
+				}
+			}
+		}
+
+		if (alreadySubscribed)
+		{
+			LOG_INFO(Net, "[GameEventHandler] Subscribe AlreadySubscribed account={}", accountId);
+			auto pkt = BuildGameEventSubscribeResponsePacket(
+				static_cast<uint8_t>(GameEventErrorCode::AlreadySubscribed),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[GameEventHandler] Subscribe OK account={} pushCount={}",
+			accountId, snapshot.size());
+
+		// Reponse OK.
+		auto pkt = BuildGameEventSubscribeResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// Push StateChangeNotification au nouvel abonne pour chaque event
+		// dont l'etat differe du dernier broadcast. V1 : pas de broadcast
+		// cross-subscribers (tick periodique a venir).
+		for (const auto& item : snapshot)
+		{
+			PushStateChange(connId, item.eventId, item.state, item.untilTsMs);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleUnsubscribe
+	// -------------------------------------------------------------------------
+
+	void GameEventHandler::HandleUnsubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		(void)ParseGameEventUnsubscribeRequestPayload(payload, payloadSize);
+
+		bool wasSubscribed = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto erased = m_subscribers.erase(accountId);
+			if (erased > 0)
+				wasSubscribed = true;
+		}
+
+		if (!wasSubscribed)
+		{
+			LOG_INFO(Net, "[GameEventHandler] Unsubscribe NotSubscribed account={}", accountId);
+			auto pkt = BuildGameEventUnsubscribeResponsePacket(
+				static_cast<uint8_t>(GameEventErrorCode::NotSubscribed),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[GameEventHandler] Unsubscribe OK account={}", accountId);
+		auto pkt = BuildGameEventUnsubscribeResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// PushStateChange
+	// -------------------------------------------------------------------------
+
+	bool GameEventHandler::PushStateChange(uint32_t connId, uint32_t eventId, uint8_t newState, uint64_t untilTsMs)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[GameEventHandler] PushStateChange dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[GameEventHandler] PushStateChange: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildGameEventStateChangeNotificationPacket(eventId, newState, untilTsMs, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[GameEventHandler] PushStateChange: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[GameEventHandler] PushStateChange connId={} eid={} state={} untilTsMs={}",
+			connId, eventId, static_cast<unsigned>(newState), untilTsMs);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	uint64_t GameEventHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/events/GameEventHandler.h
+++ b/src/masterd/handlers/events/GameEventHandler.h
@@ -1,0 +1,162 @@
+#pragma once
+// CMANGOS.31 (Phase 5.31 step 3+4) — GameEventHandler : dispatch des opcodes
+// GameEvent cote joueur (157/159/161) et appel des methodes correspondantes
+// d'un GameEventManager + tracking des subscriptions globales par account.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// opcodes 157/159/161 (les requests). Les responses 158/160/162 sont
+// emises avec le meme requestId / sessionId que la request recue. La push
+// notification 163 (StateChange) est emise par le handler pour signaler les
+// changements d'etat.
+//
+// V1 simplifie : l'abonnement est global (pas par event). A chaque
+// SubscribeRequest, master compare l'etat actuel des events au dernier
+// snapshot diffuse (m_lastBroadcastState) ; pour chaque event dont l'etat
+// differe, push StateChangeNotification au nouvel abonne uniquement (pas
+// de broadcast cross-subscribers V1) puis met a jour m_lastBroadcastState.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 3) dans la reponse type-specific.
+//
+// Store in-memory V1 :
+//   - 4 events seedees au boot :
+//       id=1 "Halloween"               startTsMs=2026-10-15  duration=14d  recur=365d
+//       id=2 "Winter Veil"             startTsMs=2026-12-15  duration=21d  recur=365d
+//       id=3 "Lunar Festival"          startTsMs=2026-02-01  duration=14d  recur=365d
+//       id=4 "Midsummer Fire Festival" startTsMs=2026-06-21  duration=14d  recur=365d
+//   - Subscribers : set<account_id> (abonnement global).
+//   - lastBroadcastState : map eventId -> dernier state (uint8) push.
+//
+// V1 limitations :
+//   - 4 events hardcodes. Future PR : DB seed via MysqlGameEventStore.
+//   - Subscribe = snapshot one-shot pour le nouvel abonne (pas de
+//     broadcast cross-subscribers V1).
+//   - Subscriptions in-memory (perdues au reboot).
+//   - Pas de SyncGameEvents RPC entre master et shardd (master autoritaire V1).
+
+#include "src/masterd/events/GameEventManager.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher GameEvent cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class GameEventHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId et
+		/// accountId -> sessionId au push.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Initialise le store V1 : enregistre les 4 events hardcodes
+		/// (Halloween, Winter Veil, Lunar Festival, Midsummer Fire Festival)
+		/// avec leurs timestamps absolus + duration + recur period.
+		/// Idempotent : appelable a chaque boot.
+		void SeedV1Events();
+
+		/// Point d'entree appele par NetServer pour les opcodes GameEvent.
+		/// Dispatch vers HandleList / HandleSubscribe / HandleUnsubscribe
+		/// selon l'opcode. Si l'opcode n'est pas un opcode GameEvent, ignore
+		/// silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (157/159/161).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push GameEventStateChangeNotification
+		/// (opcode 163) au client identifie par \p connId. Utilise par le
+		/// handler en interne mais accessible egalement depuis l'exterieur
+		/// (tests, hooks, future tick periodique).
+		///
+		/// \param connId     identifiant de connexion TCP cible (0 = no-op).
+		/// \param eventId    identifiant de l'event qui change.
+		/// \param newState   nouvel etat (0=Inactive, 1=Active).
+		/// \param untilTsMs  timestamp absolu de la prochaine bascule
+		///                   (Active: when ends ; Inactive: when starts ;
+		///                   0 = pas de prochaine bascule connue).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushStateChange(uint32_t connId, uint32_t eventId, uint8_t newState, uint64_t untilTsMs);
+
+	private:
+		/// Traite GAME_EVENT_LIST_REQUEST : retourne les 4 events hardcodes V1
+		/// + state courant + timestamps complets.
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GAME_EVENT_SUBSCRIBE_REQUEST : ajoute accountId aux
+		/// subscribers globaux. AlreadySubscribed si deja present, sinon OK.
+		/// Apres OK, push un snapshot des events dont l'etat actuel differe
+		/// du m_lastBroadcastState : un StateChangeNotification par event
+		/// au nouvel abonne, puis met a jour m_lastBroadcastState.
+		void HandleSubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GAME_EVENT_UNSUBSCRIBE_REQUEST : retire accountId. OK si
+		/// l'etait, NotSubscribed sinon.
+		void HandleUnsubscribe(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// V1 : 4 events hardcodes au boot.
+		static constexpr uint32_t kEventHalloween       = 1u;
+		static constexpr uint32_t kEventWinterVeil      = 2u;
+		static constexpr uint32_t kEventLunarFestival   = 3u;
+		static constexpr uint32_t kEventMidsummerFire   = 4u;
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant m_manager + m_eventNames + m_subscribers
+		/// + m_lastBroadcastState + m_seeded.
+		mutable std::mutex                               m_mutex;
+
+		/// Manager GameEvent partage : events + states. Modifie uniquement
+		/// sous m_mutex.
+		engine::server::events::GameEventManager         m_manager;
+
+		/// Noms runtime des events (GameEventManager les stocke deja, mais on
+		/// duplique pour un acces rapide cote logging et eviter de relire
+		/// la map a chaque appel).
+		std::unordered_map<uint32_t, std::string>        m_eventNames;
+
+		/// Abonnement global : set des accountId abonnes aux push.
+		std::unordered_set<uint64_t>                     m_subscribers;
+
+		/// Dernier state broadcast par event (pour ne push que sur changement).
+		/// Cle = eventId, valeur = uint8 state (0=Inactive, 1=Active).
+		std::unordered_map<uint32_t, uint8_t>            m_lastBroadcastState;
+
+		/// True une fois SeedV1Events() appele avec succes.
+		bool                                             m_seeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -642,7 +642,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -43,6 +43,7 @@
 #include "src/masterd/handlers/battleground/BattleGroundHandler.h"
 #include "src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h"
 #include "src/masterd/handlers/weather/WeatherHandler.h"
+#include "src/masterd/handlers/events/GameEventHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -587,6 +588,21 @@ int main(int argc, char** argv)
 	weatherHandler.SeedV1Zones();
 	LOG_INFO(Net, "[ServerMain] WeatherHandler configured (CMANGOS.42 step 3+4, in-memory, 3 zones seed)");
 
+	// CMANGOS.31 (Phase 5.31 step 3+4) — GameEventHandler : list/subscribe
+	// global + push StateChange. V1 : 4 events seedees au boot (Halloween,
+	// Winter Veil, Lunar Festival, Midsummer Fire). Les opcodes 157/159/161
+	// sont dispatches au handler ; les responses 158/160/162 et la push
+	// notification 163 (StateChange) sont emises par le handler. V1
+	// limitations : subscribe = snapshot one-shot (pas de broadcast
+	// cross-subscribers, pas de tick periodique). Pas de SyncGameEvents RPC
+	// entre master et shardd.
+	engine::server::GameEventHandler gameEventHandler;
+	gameEventHandler.SetServer(&server);
+	gameEventHandler.SetSessionManager(&sessionManager);
+	gameEventHandler.SetConnectionSessionMap(&connSessionMap);
+	gameEventHandler.SeedV1Events();
+	LOG_INFO(Net, "[ServerMain] GameEventHandler configured (CMANGOS.31 step 3+4, in-memory, 4 events seed)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -711,6 +727,10 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeWeatherSubscribeRequest
 		      || opcode == kOpcodeWeatherUnsubscribeRequest)
 			weatherHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeGameEventListRequest
+		      || opcode == kOpcodeGameEventSubscribeRequest
+		      || opcode == kOpcodeGameEventUnsubscribeRequest)
+			gameEventHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/GameEventPayloads.cpp
+++ b/src/shared/network/GameEventPayloads.cpp
@@ -1,0 +1,275 @@
+// CMANGOS.31 (Phase 5.31 step 3+4) — Implementation Parse/Build des payloads
+// GameEvent.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+//
+// Sequencage des uint64 (timestamps ms epoch, durations) : ByteWriter::WriteU64
+// / ByteReader::ReadU64 deja existants (8 octets little-endian).
+
+#include "src/shared/network/GameEventPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un GameEventSummary (eventId, name, state, startTsMs,
+		/// durationMs, recurMs).
+		bool WriteEventSummary(ByteWriter& w, const GameEventSummary& ev)
+		{
+			if (!w.WriteU32(ev.eventId))                  return false;
+			if (!w.WriteString(ev.name))                  return false;
+			if (!w.WriteBytes(&ev.state, 1u))             return false;
+			if (!w.WriteU64(ev.startTsMs))                return false;
+			if (!w.WriteU64(ev.durationMs))               return false;
+			if (!w.WriteU64(ev.recurMs))                  return false;
+			return true;
+		}
+
+		/// Lit un GameEventSummary.
+		bool ReadEventSummary(ByteReader& r, GameEventSummary& out)
+		{
+			if (!r.ReadU32(out.eventId))                  return false;
+			if (!r.ReadString(out.name))                  return false;
+			uint8_t stateByte = 0;
+			if (!r.ReadBytes(&stateByte, 1u))             return false;
+			out.state = stateByte;
+			if (!r.ReadU64(out.startTsMs))                return false;
+			if (!r.ReadU64(out.durationMs))               return false;
+			if (!r.ReadU64(out.recurMs))                  return false;
+			return true;
+		}
+
+		/// Serialise le body d'un GAME_EVENT_STATE_CHANGE_NOTIFICATION
+		/// (eventId, newState, untilTsMs).
+		bool WriteStateChangeBody(ByteWriter& w, uint32_t eventId, uint8_t newState, uint64_t untilTsMs)
+		{
+			if (!w.WriteU32(eventId))                     return false;
+			if (!w.WriteBytes(&newState, 1u))             return false;
+			if (!w.WriteU64(untilTsMs))                   return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventListRequestPayload> ParseGameEventListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return GameEventListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildGameEventListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventListResponsePayload> ParseGameEventListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GameEventListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.events.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GameEventSummary ev;
+			if (!ReadEventSummary(r, ev)) return std::nullopt;
+			out.events.push_back(std::move(ev));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGameEventListResponsePayload(uint8_t error, const std::vector<GameEventSummary>& events)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(events.size()))) return {};
+			for (const auto& ev : events)
+			{
+				if (!WriteEventSummary(w, ev)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGameEventListResponsePacket(uint8_t error, const std::vector<GameEventSummary>& events,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(events.size()))) return {};
+			for (const auto& ev : events)
+			{
+				if (!WriteEventSummary(w, ev)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGameEventListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_SUBSCRIBE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventSubscribeRequestPayload> ParseGameEventSubscribeRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte (abonnement global).
+		return GameEventSubscribeRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildGameEventSubscribeRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_SUBSCRIBE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventSubscribeResponsePayload> ParseGameEventSubscribeResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GameEventSubscribeResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGameEventSubscribeResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGameEventSubscribeResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGameEventSubscribeResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_UNSUBSCRIBE — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventUnsubscribeRequestPayload> ParseGameEventUnsubscribeRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return GameEventUnsubscribeRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildGameEventUnsubscribeRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_UNSUBSCRIBE — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventUnsubscribeResponsePayload> ParseGameEventUnsubscribeResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GameEventUnsubscribeResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGameEventUnsubscribeResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		buf[0] = error;
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGameEventUnsubscribeResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGameEventUnsubscribeResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GAME_EVENT_STATE_CHANGE_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventStateChangeNotificationPayload> ParseGameEventStateChangeNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 eventId (4) + uint8 newState (1) + uint64 untilTsMs (8) = 13.
+		if (!payload || payloadSize < 13u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GameEventStateChangeNotificationPayload out;
+		if (!r.ReadU32(out.eventId))      return std::nullopt;
+		uint8_t stateByte = 0;
+		if (!r.ReadBytes(&stateByte, 1u)) return std::nullopt;
+		out.newState = stateByte;
+		if (!r.ReadU64(out.untilTsMs))    return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGameEventStateChangeNotificationPayload(uint32_t eventId, uint8_t newState, uint64_t untilTsMs)
+	{
+		std::vector<uint8_t> buf(13u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteStateChangeBody(w, eventId, newState, untilTsMs)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGameEventStateChangeNotificationPacket(uint32_t eventId, uint8_t newState, uint64_t untilTsMs,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteStateChangeBody(w, eventId, newState, untilTsMs)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGameEventStateChangeNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/GameEventPayloads.h
+++ b/src/shared/network/GameEventPayloads.h
@@ -1,0 +1,172 @@
+#pragma once
+// CMANGOS.31 (Phase 5.31 step 3+4) — Wire payloads pour les opcodes GameEvent
+// (157-163). 3 paires Request/Response + 1 push notification :
+//   - List                              (157/158)
+//   - Subscribe                         (159/160)
+//   - Unsubscribe                       (161/162)
+//   - StateChangeNotification           (163 push) : push Master to Client
+//     changement d'etat event (eventId, newState, untilTsMs).
+//
+// Le master tient en memoire un GameEventManager (V1 : 4 events hardcodes
+// Halloween, Winter Veil, Lunar Festival, Midsummer Fire). Au reboot,
+// subscriptions et lastBroadcastState sont reinitialises. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Strings via
+// WriteString/ReadString (uint16 length + UTF-8 bytes), arrays via
+// WriteArrayCount/ReadArrayCount (uint16 count). Les uint64 (timestamps
+// ms depuis epoch, durations ms) passent par WriteU64/ReadU64.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour GameEvent.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes GameEvent. 0 = OK.
+	enum class GameEventErrorCode : uint8_t
+	{
+		Ok                = 0,
+		AlreadySubscribed = 1, ///< Tentative de subscribe quand deja abonne.
+		NotSubscribed     = 2, ///< Tentative d'unsubscribe sans subscription prealable.
+		Unauthorized      = 3, ///< Pas de session valide cote master.
+	};
+
+	// =========================================================================
+	// Sous-struct partage — Event summary.
+	// =========================================================================
+
+	/// Resume d'un event saisonnier pour le wire.
+	/// Wire format :
+	///   uint32 eventId
+	///   string name           (uint16 length + UTF-8)
+	///   uint8  state          (Inactive=0, Active=1)
+	///   uint64 startTsMs      (ms depuis epoch, debut absolu/recurrent)
+	///   uint64 durationMs     (duree de chaque occurrence)
+	///   uint64 recurMs        (0 = one-shot ; >0 = periode de recurrence)
+	struct GameEventSummary
+	{
+		uint32_t    eventId    = 0;
+		std::string name;
+		uint8_t     state      = 0;     ///< 0=Inactive, 1=Active.
+		uint64_t    startTsMs  = 0;
+		uint64_t    durationMs = 0;
+		uint64_t    recurMs    = 0;
+	};
+
+	// =========================================================================
+	// GAME_EVENT_LIST — Client to Master : liste des events.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct GameEventListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  error                     (cf. GameEventErrorCode)
+	///   uint16 eventCount                (si error == 0)
+	///   <count> GameEventSummary
+	struct GameEventListResponsePayload
+	{
+		uint8_t                         error = 0;
+		std::vector<GameEventSummary>   events;
+	};
+
+	// =========================================================================
+	// GAME_EVENT_SUBSCRIBE — Client to Master : s'abonne aux push.
+	// =========================================================================
+
+	/// Wire format : (vide). Abonnement global, pas par event.
+	struct GameEventSubscribeRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct GameEventSubscribeResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// GAME_EVENT_UNSUBSCRIBE — Client to Master : se desabonne.
+	// =========================================================================
+
+	/// Wire format : (vide).
+	struct GameEventUnsubscribeRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct GameEventUnsubscribeResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// GAME_EVENT_STATE_CHANGE_NOTIFICATION — Master to Client (push, requestId=0).
+	// Changement d'etat d'un event (devient Active ou Inactive).
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 eventId
+	///   uint8  newState        (0=Inactive, 1=Active)
+	///   uint64 untilTsMs       (timestamp absolu ms : si Active = quand finira ;
+	///                           si Inactive = quand recommencera ;
+	///                           0 = pas de prochaine bascule connue)
+	struct GameEventStateChangeNotificationPayload
+	{
+		uint32_t eventId    = 0;
+		uint8_t  newState   = 0;
+		uint64_t untilTsMs  = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventListRequestPayload>        ParseGameEventListRequestPayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<GameEventSubscribeRequestPayload>   ParseGameEventSubscribeRequestPayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<GameEventUnsubscribeRequestPayload> ParseGameEventUnsubscribeRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGameEventListRequestPayload();
+	std::vector<uint8_t> BuildGameEventSubscribeRequestPayload();
+	std::vector<uint8_t> BuildGameEventUnsubscribeRequestPayload();
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses & Notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<GameEventListResponsePayload>             ParseGameEventListResponsePayload             (const uint8_t* payload, size_t payloadSize);
+	std::optional<GameEventSubscribeResponsePayload>        ParseGameEventSubscribeResponsePayload        (const uint8_t* payload, size_t payloadSize);
+	std::optional<GameEventUnsubscribeResponsePayload>      ParseGameEventUnsubscribeResponsePayload      (const uint8_t* payload, size_t payloadSize);
+	std::optional<GameEventStateChangeNotificationPayload>  ParseGameEventStateChangeNotificationPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGameEventListResponsePayload            (uint8_t error, const std::vector<GameEventSummary>& events);
+	std::vector<uint8_t> BuildGameEventSubscribeResponsePayload       (uint8_t error);
+	std::vector<uint8_t> BuildGameEventUnsubscribeResponsePayload     (uint8_t error);
+	std::vector<uint8_t> BuildGameEventStateChangeNotificationPayload (uint32_t eventId, uint8_t newState, uint64_t untilTsMs);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildGameEventListResponsePacket            (uint8_t error, const std::vector<GameEventSummary>& events,
+	                                                                  uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGameEventSubscribeResponsePacket       (uint8_t error, uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGameEventUnsubscribeResponsePacket     (uint8_t error, uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildGameEventStateChangeNotificationPacket (uint32_t eventId, uint8_t newState, uint64_t untilTsMs,
+	                                                                  uint64_t sessionIdHeader);
+}

--- a/src/shared/network/GameEventPayloadsTests.cpp
+++ b/src/shared/network/GameEventPayloadsTests.cpp
@@ -1,0 +1,460 @@
+/**
+ * CMANGOS.31 (Phase 5.31 step 3+4) — Round-trip tests for GAME_EVENT_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/GameEventPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// GAME_EVENT_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildGameEventListRequestPayload();
+	Assert(buf.empty(), "GameEvent List request payload empty");
+	auto parsed = ParseGameEventListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "GameEvent List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildGameEventListResponsePayload(0u, {});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->events.empty(),
+		"GameEvent List response empty parses");
+}
+
+static void TestListResponseSingleEvent()
+{
+	GameEventSummary ev;
+	ev.eventId    = 1u;
+	ev.name       = "Halloween";
+	ev.state      = 1u; // Active
+	ev.startTsMs  = 1791849600000ull; // 2026-10-15
+	ev.durationMs = 1209600000ull;    // 14d
+	ev.recurMs    = 31536000000ull;   // 365d
+	auto buf = BuildGameEventListResponsePayload(0u, {ev});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "GameEvent List single event parses");
+	if (parsed && parsed->events.size() == 1u)
+	{
+		Assert(parsed->events[0].eventId == 1u, "Event 1 id");
+		Assert(parsed->events[0].name == "Halloween", "Event 1 name");
+		Assert(parsed->events[0].state == 1u, "Event 1 state Active");
+		Assert(parsed->events[0].startTsMs == 1791849600000ull, "Event 1 startTsMs");
+		Assert(parsed->events[0].durationMs == 1209600000ull, "Event 1 durationMs");
+		Assert(parsed->events[0].recurMs == 31536000000ull, "Event 1 recurMs");
+	}
+	else
+	{
+		Assert(false, "List should have 1 event");
+	}
+}
+
+static void TestListResponseFullFourEvents()
+{
+	std::vector<GameEventSummary> events;
+
+	GameEventSummary e1;
+	e1.eventId    = 1u;
+	e1.name       = "Halloween";
+	e1.state      = 0u;
+	e1.startTsMs  = 1791849600000ull;
+	e1.durationMs = 1209600000ull;
+	e1.recurMs    = 31536000000ull;
+	events.push_back(e1);
+
+	GameEventSummary e2;
+	e2.eventId    = 2u;
+	e2.name       = "Winter Veil";
+	e2.state      = 1u;
+	e2.startTsMs  = 1797206400000ull;
+	e2.durationMs = 1814400000ull; // 21d
+	e2.recurMs    = 31536000000ull;
+	events.push_back(e2);
+
+	GameEventSummary e3;
+	e3.eventId    = 3u;
+	e3.name       = "Lunar Festival";
+	e3.state      = 0u;
+	e3.startTsMs  = 1769817600000ull;
+	e3.durationMs = 1209600000ull;
+	e3.recurMs    = 31536000000ull;
+	events.push_back(e3);
+
+	GameEventSummary e4;
+	e4.eventId    = 4u;
+	e4.name       = "Midsummer Fire Festival";
+	e4.state      = 1u;
+	e4.startTsMs  = 1781913600000ull;
+	e4.durationMs = 1209600000ull;
+	e4.recurMs    = 31536000000ull;
+	events.push_back(e4);
+
+	auto buf = BuildGameEventListResponsePayload(0u, events);
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "GameEvent List 4 events parses");
+	if (parsed && parsed->events.size() == 4u)
+	{
+		Assert(parsed->events[0].name == "Halloween", "E[0] name");
+		Assert(parsed->events[0].state == 0u, "E[0] Inactive");
+		Assert(parsed->events[1].name == "Winter Veil", "E[1] name");
+		Assert(parsed->events[1].state == 1u, "E[1] Active");
+		Assert(parsed->events[1].durationMs == 1814400000ull, "E[1] duration 21d");
+		Assert(parsed->events[2].name == "Lunar Festival", "E[2] name");
+		Assert(parsed->events[3].name == "Midsummer Fire Festival", "E[3] name");
+		Assert(parsed->events[3].state == 1u, "E[3] Active");
+	}
+	else
+	{
+		Assert(false, "List should have 4 events");
+	}
+}
+
+static void TestListResponseError()
+{
+	auto buf = BuildGameEventListResponsePayload(
+		static_cast<uint8_t>(GameEventErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "GameEvent List error has only 1 byte");
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "List Unauthorized");
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseGameEventListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List rejects nullptr");
+}
+
+static void TestListResponseEmptyName()
+{
+	GameEventSummary ev;
+	ev.eventId    = 99u;
+	ev.name       = "";
+	ev.state      = 0u;
+	ev.startTsMs  = 0u;
+	ev.durationMs = 0u;
+	ev.recurMs    = 0u;
+	auto buf = BuildGameEventListResponsePayload(0u, {ev});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->events.size() == 1u
+		&& parsed->events[0].name.empty() && parsed->events[0].eventId == 99u,
+		"List accepts empty name");
+}
+
+static void TestListResponseLongName()
+{
+	GameEventSummary ev;
+	ev.eventId    = 7u;
+	ev.name       = std::string(200u, 'A');
+	ev.state      = 1u;
+	ev.startTsMs  = 12345u;
+	ev.durationMs = 67890u;
+	ev.recurMs    = 0u;
+	auto buf = BuildGameEventListResponsePayload(0u, {ev});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->events.size() == 1u
+		&& parsed->events[0].name.size() == 200u,
+		"List accepts long name (200 chars)");
+}
+
+static void TestListResponseRecurZero()
+{
+	GameEventSummary ev;
+	ev.eventId    = 11u;
+	ev.name       = "OneShot";
+	ev.state      = 0u;
+	ev.startTsMs  = 1000u;
+	ev.durationMs = 500u;
+	ev.recurMs    = 0u;
+	auto buf = BuildGameEventListResponsePayload(0u, {ev});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->events.size() == 1u
+		&& parsed->events[0].recurMs == 0u,
+		"List accepts recurMs=0 (one-shot)");
+}
+
+static void TestListResponseRecurMaxUint64()
+{
+	GameEventSummary ev;
+	ev.eventId    = 12u;
+	ev.name       = "Forever";
+	ev.state      = 1u;
+	ev.startTsMs  = 0xFFFFFFFFFFFFFFFFull;
+	ev.durationMs = 0xFFFFFFFFFFFFFFFFull;
+	ev.recurMs    = 0xFFFFFFFFFFFFFFFFull;
+	auto buf = BuildGameEventListResponsePayload(0u, {ev});
+	auto parsed = ParseGameEventListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->events.size() == 1u
+		&& parsed->events[0].startTsMs == 0xFFFFFFFFFFFFFFFFull
+		&& parsed->events[0].recurMs == 0xFFFFFFFFFFFFFFFFull,
+		"List accepts uint64 max boundary");
+}
+
+static void TestListResponsePacket()
+{
+	GameEventSummary ev;
+	ev.eventId    = 42u;
+	ev.name       = "Test Event";
+	ev.state      = 1u;
+	ev.startTsMs  = 12345u;
+	ev.durationMs = 67890u;
+	ev.recurMs    = 99999u;
+	auto pkt = BuildGameEventListResponsePacket(0u, {ev}, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "List packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"List PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGameEventListResponse, "Opcode is ListResponse");
+	Assert(view.RequestId() == 999u, "List RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "List SessionId preserved");
+	auto parsed = ParseGameEventListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->events.size() == 1u
+		&& parsed->events[0].eventId == 42u && parsed->events[0].name == "Test Event"
+		&& parsed->events[0].state == 1u && parsed->events[0].startTsMs == 12345u
+		&& parsed->events[0].durationMs == 67890u && parsed->events[0].recurMs == 99999u,
+		"List payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GAME_EVENT_SUBSCRIBE
+// -----------------------------------------------------------------------------
+
+static void TestSubscribeRequestRoundTrip()
+{
+	auto buf = BuildGameEventSubscribeRequestPayload();
+	Assert(buf.empty(), "Subscribe request payload empty");
+	auto parsed = ParseGameEventSubscribeRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Subscribe request accepts empty payload");
+}
+
+static void TestSubscribeResponseOk()
+{
+	auto buf = BuildGameEventSubscribeResponsePayload(0u);
+	Assert(buf.size() == 1u, "Subscribe response Ok size 1");
+	auto parsed = ParseGameEventSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Subscribe Ok parses");
+}
+
+static void TestSubscribeResponseAlreadySubscribed()
+{
+	auto buf = BuildGameEventSubscribeResponsePayload(
+		static_cast<uint8_t>(GameEventErrorCode::AlreadySubscribed));
+	auto parsed = ParseGameEventSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "Subscribe AlreadySubscribed");
+}
+
+static void TestSubscribeResponseUnauthorized()
+{
+	auto buf = BuildGameEventSubscribeResponsePayload(
+		static_cast<uint8_t>(GameEventErrorCode::Unauthorized));
+	auto parsed = ParseGameEventSubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "Subscribe Unauthorized");
+}
+
+static void TestSubscribeResponseRejectsShort()
+{
+	auto parsed = ParseGameEventSubscribeResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "Subscribe response rejects nullptr");
+}
+
+static void TestSubscribeResponsePacket()
+{
+	auto pkt = BuildGameEventSubscribeResponsePacket(0u, 12345u, 0xBEEFull);
+	Assert(!pkt.empty(), "Subscribe packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Subscribe PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGameEventSubscribeResponse, "Opcode is SubscribeResponse");
+	Assert(view.RequestId() == 12345u, "Subscribe RequestId preserved");
+	auto parsed = ParseGameEventSubscribeResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->error == 0u,
+		"Subscribe Ok packet body decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GAME_EVENT_UNSUBSCRIBE
+// -----------------------------------------------------------------------------
+
+static void TestUnsubscribeRequestRoundTrip()
+{
+	auto buf = BuildGameEventUnsubscribeRequestPayload();
+	Assert(buf.empty(), "Unsubscribe request payload empty");
+	auto parsed = ParseGameEventUnsubscribeRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Unsubscribe request accepts empty payload");
+}
+
+static void TestUnsubscribeResponseOk()
+{
+	auto buf = BuildGameEventUnsubscribeResponsePayload(0u);
+	Assert(buf.size() == 1u, "Unsubscribe response Ok size 1");
+	auto parsed = ParseGameEventUnsubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Unsubscribe Ok parses");
+}
+
+static void TestUnsubscribeResponseNotSubscribed()
+{
+	auto buf = BuildGameEventUnsubscribeResponsePayload(
+		static_cast<uint8_t>(GameEventErrorCode::NotSubscribed));
+	auto parsed = ParseGameEventUnsubscribeResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Unsubscribe NotSubscribed");
+}
+
+static void TestUnsubscribeResponsePacket()
+{
+	auto pkt = BuildGameEventUnsubscribeResponsePacket(0u, 99u, 0xFEEDull);
+	Assert(!pkt.empty(), "Unsubscribe packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Unsubscribe PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGameEventUnsubscribeResponse, "Opcode is UnsubscribeResponse");
+	Assert(view.RequestId() == 99u, "Unsubscribe RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// GAME_EVENT_STATE_CHANGE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestStateChangeRoundTrip()
+{
+	auto buf = BuildGameEventStateChangeNotificationPayload(1u, 1u, 1791849600000ull);
+	Assert(buf.size() == 13u, "StateChange payload size 13");
+	auto parsed = ParseGameEventStateChangeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "StateChange parses");
+	if (parsed)
+	{
+		Assert(parsed->eventId == 1u, "StateChange eventId");
+		Assert(parsed->newState == 1u, "StateChange newState Active");
+		Assert(parsed->untilTsMs == 1791849600000ull, "StateChange untilTsMs");
+	}
+}
+
+static void TestStateChangeInactiveZeroUntil()
+{
+	// State Inactive + untilTsMs=0 : event termine, pas de prochaine bascule.
+	auto buf = BuildGameEventStateChangeNotificationPayload(99u, 0u, 0u);
+	auto parsed = ParseGameEventStateChangeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->eventId == 99u
+		&& parsed->newState == 0u && parsed->untilTsMs == 0u,
+		"StateChange Inactive untilTsMs=0");
+}
+
+static void TestStateChangeUntilMaxUint64()
+{
+	auto buf = BuildGameEventStateChangeNotificationPayload(123u, 1u, 0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseGameEventStateChangeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->untilTsMs == 0xFFFFFFFFFFFFFFFFull,
+		"StateChange untilTsMs UINT64_MAX");
+}
+
+static void TestStateChangeStateByteIsRaw()
+{
+	// Le wire ne valide pas la valeur de state ; le parser doit accepter
+	// une valeur "invalide" (e.g. 99u) — la validation est cote presenter.
+	auto buf = BuildGameEventStateChangeNotificationPayload(1u, 99u, 0u);
+	auto parsed = ParseGameEventStateChangeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->newState == 99u,
+		"StateChange accepts raw uint8 newState 99 (validation presenter-side)");
+}
+
+static void TestStateChangeEventIdMax()
+{
+	auto buf = BuildGameEventStateChangeNotificationPayload(0xFFFFFFFFu, 1u, 12345u);
+	auto parsed = ParseGameEventStateChangeNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->eventId == 0xFFFFFFFFu,
+		"StateChange eventId UINT32_MAX");
+}
+
+static void TestStateChangeRejectsShort()
+{
+	auto parsed = ParseGameEventStateChangeNotificationPayload(nullptr, 13u);
+	Assert(!parsed.has_value(), "StateChange rejects nullptr");
+	uint8_t shortBuf[12]{};
+	auto parsed2 = ParseGameEventStateChangeNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "StateChange rejects 12 bytes");
+}
+
+static void TestStateChangePacket()
+{
+	auto pkt = BuildGameEventStateChangeNotificationPacket(1u, 1u, 1791849600000ull, 0xFADEull);
+	Assert(!pkt.empty(), "StateChange packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"StateChange PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGameEventStateChangeNotification, "Opcode is StateChange");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xFADEull, "StateChange SessionId preserved");
+	auto parsed = ParseGameEventStateChangeNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->eventId == 1u && parsed->newState == 1u
+		&& parsed->untilTsMs == 1791849600000ull,
+		"StateChange payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseSingleEvent();
+	TestListResponseFullFourEvents();
+	TestListResponseError();
+	TestListResponseRejectsShort();
+	TestListResponseEmptyName();
+	TestListResponseLongName();
+	TestListResponseRecurZero();
+	TestListResponseRecurMaxUint64();
+	TestListResponsePacket();
+
+	TestSubscribeRequestRoundTrip();
+	TestSubscribeResponseOk();
+	TestSubscribeResponseAlreadySubscribed();
+	TestSubscribeResponseUnauthorized();
+	TestSubscribeResponseRejectsShort();
+	TestSubscribeResponsePacket();
+
+	TestUnsubscribeRequestRoundTrip();
+	TestUnsubscribeResponseOk();
+	TestUnsubscribeResponseNotSubscribed();
+	TestUnsubscribeResponsePacket();
+
+	TestStateChangeRoundTrip();
+	TestStateChangeInactiveZeroUntil();
+	TestStateChangeUntilMaxUint64();
+	TestStateChangeStateByteIsRaw();
+	TestStateChangeEventIdMax();
+	TestStateChangeRejectsShort();
+	TestStateChangePacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all gameevent payload tests passed\n"
+	                                : "[FAIL] some gameevent tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -616,4 +616,48 @@ namespace engine::network
 	constexpr uint16_t kOpcodeWeatherUnsubscribeRequest  = 154u; ///< Client to Master : se desabonne (zoneId).
 	constexpr uint16_t kOpcodeWeatherUnsubscribeResponse = 155u; ///< Master to Client : OK ou NotSubscribed / Unauthorized.
 	constexpr uint16_t kOpcodeWeatherUpdateNotification  = 156u; ///< Master to Client (push, request_id=0) : changement meteo (zoneId, kind, intensity).
+
+	// =====================================================================
+	// CMANGOS.31 step 3+4 — GameEvents wire (events saisonniers, list,
+	// subscribe global, push state change). Master tient en memoire un
+	// GameEventManager (V1 seed 4 events : Halloween, Winter Veil, Lunar
+	// Festival, Midsummer Fire Festival).
+	//
+	// Architecture : 4 events seedees au boot avec timestamps absolus
+	// (ms depuis epoch) + duration + recur period. Le master tient en
+	// memoire la liste des subscribers globaux (abonnement non par event
+	// mais general aux changements). V1 simplifie : a chaque
+	// SubscribeRequest, master envoie un snapshot complet des events au
+	// nouvel abonne via une serie de StateChangeNotification (un par event
+	// dont l'etat differe du dernier broadcast). Pas de tick periodique
+	// V1.
+	//
+	// V1 limitations :
+	//   - 4 events hardcodes (Halloween, Winter Veil, Lunar Festival,
+	//     Midsummer Fire). Future PR : DB seed via MysqlGameEventStore.
+	//   - Subscribe = snapshot one-shot pour le nouvel abonne (pas de
+	//     broadcast cross-subscribers V1). Vrai broadcast quand tick
+	//     periodique sera branche.
+	//   - Subscriptions in-memory (perdues au reboot).
+	//   - Pas de SyncGameEvents RPC entre master et shardd (master
+	//     autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - List       (157/158)               : liste des events + state.
+	//   - Subscribe  (159/160)               : abonnement global aux push.
+	//   - Unsubscribe (161/162)              : retire l'abonnement global.
+	//   - StateChangeNotification (163, push) : changement etat event
+	//                                           (eventId, newState, untilTsMs).
+	//
+	// Wire format state : uint8 (Inactive=0, Active=1). untilTsMs : uint64
+	// LE (timestamp absolu ms epoch, prochaine bascule ; 0 = pas de
+	// recurrence et event termine definitivement).
+	// =====================================================================
+	constexpr uint16_t kOpcodeGameEventListRequest             = 157u; ///< Client to Master : liste des events saisonniers (vide).
+	constexpr uint16_t kOpcodeGameEventListResponse            = 158u; ///< Master to Client : liste {eventId, name, state, startTsMs, durationMs, recurMs} ou Unauthorized.
+	constexpr uint16_t kOpcodeGameEventSubscribeRequest        = 159u; ///< Client to Master : s'abonne aux push (vide, abonnement global).
+	constexpr uint16_t kOpcodeGameEventSubscribeResponse       = 160u; ///< Master to Client : OK ou AlreadySubscribed / Unauthorized.
+	constexpr uint16_t kOpcodeGameEventUnsubscribeRequest      = 161u; ///< Client to Master : se desabonne (vide).
+	constexpr uint16_t kOpcodeGameEventUnsubscribeResponse     = 162u; ///< Master to Client : OK ou NotSubscribed / Unauthorized.
+	constexpr uint16_t kOpcodeGameEventStateChangeNotification = 163u; ///< Master to Client (push, request_id=0) : changement etat event (eventId, newState, untilTsMs).
 }


### PR DESCRIPTION
## CMANGOS.31 step 3+4 : GameEvents wire (list + subscribe + state push + UI panel)

Branche `GameEventManager` (step 1+2 merge — events saisonniers récurrents) sur le wire list/subscribe/state-push + UI panel client.
Master tient en mémoire un `GameEventManager` (V1 seed 4 events saisonniers : Halloween, Winter Veil, Lunar Festival, Midsummer Fire), push les changements d'état aux subscribers sur leur subscribe.

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 7 opcodes (157-163)
  - `157/158` GameEventList Request/Response
  - `159/160` Subscribe Request/Response (abonnement global, vide)
  - `161/162` Unsubscribe Request/Response
  - `163` GameEventStateChangeNotification (push)
- `src/shared/network/GameEventPayloads.{h,cpp,Tests.cpp}` : 28 tests round-trip + edge cases
- `src/masterd/handlers/events/GameEventHandler.{h,cpp}` :
  - 4 events seedés : Halloween (oct), Winter Veil (déc), Lunar Festival (fév), Midsummer Fire (juin) — récurrence 365j
  - In-memory subscribers + `m_lastBroadcastState` (push uniquement sur changement)
  - Helper `ComputeUntilTs` pour countdown (Active → fin du cycle, Inactive → prochain départ)
  - `PushStateChange` helper public
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 157/159/161
- `src/masterd/events/GameEventManager.h` : ajout additif `Events() const` getter

### Client integration
- `src/client/events/GameEventUi.{h,cpp}` : presenter + state, helpers `GameEventStateName` + `FormatRelativeTime` (ex: "ends in 5d 12h", "starts in 23d")
- `src/client/render/GameEventImGuiRenderer.{h,cpp}` : panel ImGui (events colorés Active=vert / Inactive=gris, countdown, Subscribe toggle) + toast 5s sur changement
- `src/client/app/Engine` : dispatch + slash `/events` + touche `E` toggle
- `CMakeLists.txt` : sources + `gameevent_payloads_tests` target

### V1 limitations (consignées)
- 4 events hardcodés. Future PR : DB seed via MysqlGameEventStore.
- Subscribe = snapshot one-shot (pas de broadcast cross-subscribers V1). Vrai broadcast quand tick périodique sera branché.
- recurMs=365j (pas de gestion bissextile, dérive lente acceptable V1).
- Pas de SyncGameEvents RPC entre master et shardd (master autoritaire V1).

### Tests
- `gameevent_payloads_tests` (28 tests) — voir `src/shared/network/GameEventPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 157-163 + handler GameEventHandler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
