### PR TITLE
feat(guilds): wire list + members + perms + bank + UI panel client (CMANGOS.21)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ add_library(engine_core
   src/client/outdoorpvp/OutdoorPvpUi.cpp
   src/client/weather/WeatherUi.cpp
   src/client/events/GameEventUi.cpp
+  src/client/guild/GuildUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -349,6 +350,7 @@ add_library(engine_core
   src/client/render/OutdoorPvpImGuiRenderer.cpp
   src/client/render/WeatherImGuiRenderer.cpp
   src/client/render/GameEventImGuiRenderer.cpp
+  src/client/render/GuildImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -450,6 +452,7 @@ add_library(engine_core
   src/shared/network/OutdoorPvpPayloads.cpp
   src/shared/network/WeatherPayloads.cpp
   src/shared/network/GameEventPayloads.cpp
+  src/shared/network/GuildPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -725,6 +728,11 @@ add_test(NAME weather_payloads_tests COMMAND weather_payloads_tests)
 add_executable(gameevent_payloads_tests src/shared/network/GameEventPayloadsTests.cpp)
 target_link_libraries(gameevent_payloads_tests PRIVATE engine_core)
 add_test(NAME gameevent_payloads_tests COMMAND gameevent_payloads_tests)
+
+# CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Guild payloads round-trip tests (no DB / no network).
+add_executable(guild_payloads_tests src/shared/network/GuildPayloadsTests.cpp)
+target_link_libraries(guild_payloads_tests PRIVATE engine_core)
+add_test(NAME guild_payloads_tests COMMAND guild_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/weather/WeatherHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/events/GameEventHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/guild/GuildHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -141,6 +142,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/OutdoorPvpPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/WeatherPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GameEventPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/GuildPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -18,6 +18,7 @@
 #include "src/shared/network/OutdoorPvpPayloads.h"
 #include "src/shared/network/WeatherPayloads.h"
 #include "src/shared/network/GameEventPayloads.h"
+#include "src/shared/network/GuildPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -34,6 +35,7 @@
 #include "src/client/render/OutdoorPvpImGuiRenderer.h"
 #include "src/client/render/WeatherImGuiRenderer.h"
 #include "src/client/render/GameEventImGuiRenderer.h"
+#include "src/client/render/GuildImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -1008,6 +1010,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Init du presenter Guildes +
+		// cable du send callback pour les requetes 164/166/168/170. Reception
+		// dispatchee dans le push handler ci-dessous (responses 165/167/169/171
+		// + push 172 MotdUpdate).
+		if (!m_guildUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] GuildUiPresenter init FAILED — panneau Guildes desactive");
+		}
+		else
+		{
+			m_guildUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1226,6 +1243,23 @@ namespace engine
 					m_gameEventUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] /events toggle (visible={})", m_gameEventVisible);
+				return true;
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Slash command /guild
+			// pour ouvrir/fermer le panneau Guildes et synchroniser la liste
+			// depuis le master au moment de l'ouverture. La touche U fait
+			// la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/guild" || text == "/guilds"
+				    || text.starts_with("/guild ") || text.starts_with("/guild\t")
+				    || text.starts_with("/guilds ") || text.starts_with("/guilds\t")))
+			{
+				m_guildVisible = !m_guildVisible;
+				if (m_guildVisible)
+				{
+					m_guildUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] /guild toggle (visible={})", m_guildVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1890,6 +1924,63 @@ namespace engine
 					return;
 				}
 				m_gameEventUi.OnStateChangeNotification(*parsed);
+				return;
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Dispatch des reponses
+			// Guild (165/167/169/171) + push notification (172 MotdUpdate).
+			case kOpcodeGuildListResponse:
+			{
+				auto parsed = ParseGuildListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GUILD_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_guildUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeGuildMembersResponse:
+			{
+				auto parsed = ParseGuildMembersResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GUILD_MEMBERS_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_guildUi.OnMembersResponse(*parsed);
+				return;
+			}
+			case kOpcodeGuildPermissionsResponse:
+			{
+				auto parsed = ParseGuildPermissionsResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GUILD_PERMISSIONS_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_guildUi.OnPermissionsResponse(*parsed);
+				return;
+			}
+			case kOpcodeGuildBankResponse:
+			{
+				auto parsed = ParseGuildBankResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GUILD_BANK_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_guildUi.OnBankResponse(*parsed);
+				return;
+			}
+			case kOpcodeGuildMotdUpdateNotification:
+			{
+				auto parsed = ParseGuildMotdUpdateNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] GUILD_MOTD_UPDATE_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_guildUi.OnMotdUpdateNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -4196,6 +4287,7 @@ namespace engine
 		m_outdoorPvpUi.Shutdown();
 		m_weatherUi.Shutdown();
 		m_gameEventUi.Shutdown();
+		m_guildUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -4369,6 +4461,20 @@ namespace engine
 					m_gameEventUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] E toggle gameevents (visible={})", m_gameEventVisible);
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Touche U : toggle
+			// panneau Guildes + RequestList si on l'ouvre. Memes guards que
+			// E (chat focus, pause, editor). Pas de conflit Ctrl+U.
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::U))
+			{
+				m_guildVisible = !m_guildVisible;
+				if (m_guildVisible)
+				{
+					m_guildUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] U toggle guilds (visible={})", m_guildVisible);
 			}
 		}
 
@@ -4593,6 +4699,12 @@ namespace engine
 				// arriver panneau ferme).
 				m_gameEventImGui = std::make_unique<engine::render::GameEventImGuiRenderer>();
 				m_gameEventImGui->SetPresenter(&m_gameEventUi);
+				// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Renderer ImGui
+				// Guildes. Le panel principal n'est visible que quand
+				// m_guildVisible (toggle via /guild ou touche U). Le toast 5s
+				// sur dernier MotdUpdate reçu est rendu independamment du flag.
+				m_guildImGui = std::make_unique<engine::render::GuildImGuiRenderer>();
+				m_guildImGui->SetPresenter(&m_guildUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5715,6 +5827,16 @@ namespace engine
 				m_gameEventImGui->SetEnabled(m_gameEventVisible);
 				m_gameEventImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_gameEventImGui->Render();
+			}
+			// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Render du panel Guildes
+			// si m_guildVisible (toggle via /guild ou touche U), ET du toast 5s
+			// sur dernier MotdUpdate reçu (rendu independamment par Render()
+			// si lastMotdChangeTimeMs est recent).
+			if (m_guildImGui && m_guildUi.IsInitialized())
+			{
+				m_guildImGui->SetEnabled(m_guildVisible);
+				m_guildImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_guildImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -17,6 +17,7 @@
 #include "src/client/outdoorpvp/OutdoorPvpUi.h"
 #include "src/client/weather/WeatherUi.h"
 #include "src/client/events/GameEventUi.h"
+#include "src/client/guild/GuildUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -87,6 +88,7 @@ namespace engine::render
 	class OutdoorPvpImGuiRenderer;
 	class WeatherImGuiRenderer;
 	class GameEventImGuiRenderer;
+	class GuildImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -393,6 +395,12 @@ namespace engine
 		/// (toggle via slash command /events ou touche E). Le toast 5s sur
 		/// dernier StateChange reçu est rendu independamment du flag.
 		std::unique_ptr<engine::render::GameEventImGuiRenderer> m_gameEventImGui;
+		/// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Panneau "Guilds" (post-auth, ImGui).
+		/// Partage le contexte ImGui avec les autres panneaux post-auth.
+		/// Le panel principal est visible uniquement quand m_guildVisible
+		/// (toggle via slash command /guild ou touche U). Le toast 5s sur
+		/// dernier MotdUpdate reçu est rendu independamment du flag.
+		std::unique_ptr<engine::render::GuildImGuiRenderer> m_guildImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -557,6 +565,15 @@ namespace engine
 		/// (toggle via slash command \c /events ou touche E). Faux par defaut.
 		/// Le toast 5s sur dernier StateChange reçu est rendu independamment.
 		bool                                  m_gameEventVisible = false;
+		/// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Presenter de la fenetre Guildes.
+		/// Recoit les responses opcodes 165/167/169/171 et la push notification
+		/// 172 (MotdUpdate) via le push handler du master ; fire-and-forget des
+		/// requetes 164/166/168/170 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::GuildUiPresenter      m_guildUi;
+		/// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Visibilite du panneau Guildes
+		/// (toggle via slash command \c /guild ou touche U). Faux par defaut.
+		/// Le toast 5s sur dernier MotdUpdate reçu est rendu independamment.
+		bool                                  m_guildVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/guild/GuildUi.cpp
+++ b/src/client/guild/GuildUi.cpp
@@ -1,0 +1,363 @@
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Implementation GuildUiPresenter.
+
+#include "src/client/guild/GuildUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+
+namespace engine::client
+{
+	// -------------------------------------------------------------------------
+	// ExpandPermissionMask — static helper.
+	// -------------------------------------------------------------------------
+
+	namespace
+	{
+		// Bits matching server-side (cf. Permission enum dans GuildPermissionMatrix.h).
+		// On les duplique ici en client pour eviter le coupling au header server.
+		constexpr uint32_t kPermInvite       = 0x001u;
+		constexpr uint32_t kPermRemove       = 0x002u;
+		constexpr uint32_t kPermPromote      = 0x004u;
+		constexpr uint32_t kPermDemote       = 0x008u;
+		constexpr uint32_t kPermEditMotd     = 0x010u;
+		constexpr uint32_t kPermEditTabard   = 0x020u;
+		constexpr uint32_t kPermWithdrawGold = 0x040u;
+		constexpr uint32_t kPermBankView     = 0x080u;
+		constexpr uint32_t kPermBankDeposit  = 0x100u;
+		constexpr uint32_t kPermBankWithdraw = 0x200u;
+		constexpr uint32_t kPermDisband      = 0x400u;
+
+		/// Retourne le steady_clock now en ms depuis le boot pour l'horodatage
+		/// local des toasts (5s d'affichage).
+		uint64_t SteadyMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	std::vector<std::string> ExpandPermissionMask(uint32_t mask)
+	{
+		std::vector<std::string> out;
+		if (mask & kPermInvite)       out.push_back("Invite");
+		if (mask & kPermRemove)       out.push_back("Remove");
+		if (mask & kPermPromote)      out.push_back("Promote");
+		if (mask & kPermDemote)       out.push_back("Demote");
+		if (mask & kPermEditMotd)     out.push_back("EditMotd");
+		if (mask & kPermEditTabard)   out.push_back("EditTabard");
+		if (mask & kPermWithdrawGold) out.push_back("WithdrawGold");
+		if (mask & kPermBankView)     out.push_back("BankView");
+		if (mask & kPermBankDeposit)  out.push_back("BankDeposit");
+		if (mask & kPermBankWithdraw) out.push_back("BankWithdraw");
+		if (mask & kPermDisband)      out.push_back("Disband");
+		return out;
+	}
+
+	// -------------------------------------------------------------------------
+	// Presenter lifecycle
+	// -------------------------------------------------------------------------
+
+	GuildUiPresenter::~GuildUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool GuildUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[GuildUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		LOG_INFO(Core, "[GuildUiPresenter] Init OK");
+		return true;
+	}
+
+	void GuildUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[GuildUiPresenter] Destroyed");
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void GuildUiPresenter::RequestList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GuildUiPresenter] RequestList: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGuildListRequestPayload();
+		if (!m_send(engine::network::kOpcodeGuildListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste guildes).";
+			LOG_WARN(Net, "[GuildUiPresenter] RequestList: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[GuildUiPresenter] Guild ListRequest queued");
+	}
+
+	void GuildUiPresenter::SelectGuild(uint32_t guildId)
+	{
+		// Reset les sub-states avant de declencher 3 requetes paralleles.
+		m_state.selectedGuildId      = guildId;
+		m_state.selectedMembers.clear();
+		m_state.membersLoaded        = false;
+		m_state.selectedRanks.clear();
+		m_state.ranksLoaded          = false;
+		m_state.selectedBank.clear();
+		m_state.bankLoaded           = false;
+		m_state.lastErrorText.clear();
+
+		RequestMembers(guildId);
+		RequestPermissions(guildId);
+		RequestBank(guildId, 0u);
+		LOG_INFO(Core, "[GuildUiPresenter] SelectGuild guildId={} (members + perms + bank0 queued)",
+			guildId);
+	}
+
+	void GuildUiPresenter::RequestMembers(uint32_t guildId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GuildUiPresenter] RequestMembers: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGuildMembersRequestPayload(guildId);
+		if (!m_send(engine::network::kOpcodeGuildMembersRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (membres guilde).";
+			LOG_WARN(Net, "[GuildUiPresenter] RequestMembers: send failed guildId={}", guildId);
+			return;
+		}
+		LOG_DEBUG(Net, "[GuildUiPresenter] Guild MembersRequest queued guildId={}", guildId);
+	}
+
+	void GuildUiPresenter::RequestPermissions(uint32_t guildId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GuildUiPresenter] RequestPermissions: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGuildPermissionsRequestPayload(guildId);
+		if (!m_send(engine::network::kOpcodeGuildPermissionsRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (permissions guilde).";
+			LOG_WARN(Net, "[GuildUiPresenter] RequestPermissions: send failed guildId={}", guildId);
+			return;
+		}
+		LOG_DEBUG(Net, "[GuildUiPresenter] Guild PermissionsRequest queued guildId={}", guildId);
+	}
+
+	void GuildUiPresenter::RequestBank(uint32_t guildId, uint8_t tabIndex)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[GuildUiPresenter] RequestBank: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildGuildBankRequestPayload(guildId, tabIndex);
+		if (!m_send(engine::network::kOpcodeGuildBankRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (bank guilde).";
+			LOG_WARN(Net, "[GuildUiPresenter] RequestBank: send failed guildId={} tab={}",
+				guildId, static_cast<unsigned>(tabIndex));
+			return;
+		}
+		LOG_DEBUG(Net, "[GuildUiPresenter] Guild BankRequest queued guildId={} tab={}",
+			guildId, static_cast<unsigned>(tabIndex));
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void GuildUiPresenter::OnListResponse(const engine::network::GuildListResponsePayload& resp)
+	{
+		using engine::network::GuildErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GuildErrorCode>(resp.error);
+			if (err == GuildErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur Guild inconnue.";
+			LOG_WARN(Net, "[GuildUiPresenter] OnListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.guilds.clear();
+		m_state.guilds.reserve(resp.guilds.size());
+		for (const auto& g : resp.guilds)
+		{
+			GuildSummary local;
+			local.guildId     = g.guildId;
+			local.name        = g.name;
+			local.motd        = g.motd;
+			local.memberCount = g.memberCount;
+			local.leaderName  = g.leaderName;
+			m_state.guilds.push_back(std::move(local));
+		}
+		m_state.guildsLoaded = true;
+
+		LOG_INFO(Net, "[GuildUiPresenter] OnListResponse OK count={}",
+			m_state.guilds.size());
+	}
+
+	void GuildUiPresenter::OnMembersResponse(const engine::network::GuildMembersResponsePayload& resp)
+	{
+		using engine::network::GuildErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GuildErrorCode>(resp.error);
+			switch (err)
+			{
+			case GuildErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case GuildErrorCode::UnknownGuild:
+				m_state.lastErrorText = "Guilde introuvable.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Guild inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[GuildUiPresenter] OnMembersResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.selectedMembers.clear();
+		m_state.selectedMembers.reserve(resp.members.size());
+		for (const auto& m : resp.members)
+		{
+			GuildMember local;
+			local.accountName = m.accountName;
+			local.rankId      = m.rankId;
+			local.rankName    = m.rankName;
+			local.online      = m.online;
+			m_state.selectedMembers.push_back(std::move(local));
+		}
+		m_state.membersLoaded = true;
+
+		LOG_INFO(Net, "[GuildUiPresenter] OnMembersResponse OK count={}",
+			m_state.selectedMembers.size());
+	}
+
+	void GuildUiPresenter::OnPermissionsResponse(const engine::network::GuildPermissionsResponsePayload& resp)
+	{
+		using engine::network::GuildErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GuildErrorCode>(resp.error);
+			switch (err)
+			{
+			case GuildErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case GuildErrorCode::UnknownGuild:
+				m_state.lastErrorText = "Guilde introuvable.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Guild inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[GuildUiPresenter] OnPermissionsResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.selectedRanks.clear();
+		m_state.selectedRanks.reserve(resp.ranks.size());
+		for (const auto& p : resp.ranks)
+		{
+			GuildRankPerms local;
+			local.rankId   = p.rankId;
+			local.rankName = p.rankName;
+			local.mask     = p.mask;
+			m_state.selectedRanks.push_back(std::move(local));
+		}
+		m_state.ranksLoaded = true;
+
+		LOG_INFO(Net, "[GuildUiPresenter] OnPermissionsResponse OK ranks={}",
+			m_state.selectedRanks.size());
+	}
+
+	void GuildUiPresenter::OnBankResponse(const engine::network::GuildBankResponsePayload& resp)
+	{
+		using engine::network::GuildErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<GuildErrorCode>(resp.error);
+			switch (err)
+			{
+			case GuildErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case GuildErrorCode::UnknownGuild:
+				m_state.lastErrorText = "Guilde introuvable.";
+				break;
+			case GuildErrorCode::NoPermission:
+				m_state.lastErrorText = "Acces refuse a la banque.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Guild inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[GuildUiPresenter] OnBankResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.selectedBank.clear();
+		m_state.selectedBank.reserve(resp.items.size());
+		for (const auto& it : resp.items)
+		{
+			GuildBankItem local;
+			local.slotIndex = it.slotIndex;
+			local.itemName  = it.itemName;
+			local.count     = it.count;
+			m_state.selectedBank.push_back(std::move(local));
+		}
+		m_state.bankLoaded = true;
+
+		LOG_INFO(Net, "[GuildUiPresenter] OnBankResponse OK items={}",
+			m_state.selectedBank.size());
+	}
+
+	void GuildUiPresenter::OnMotdUpdateNotification(const engine::network::GuildMotdUpdateNotificationPayload& note)
+	{
+		// Mise a jour locale du cache guildes : remplace motd si trouve.
+		for (auto& g : m_state.guilds)
+		{
+			if (g.guildId == note.guildId)
+			{
+				g.motd = note.newMotd;
+				break;
+			}
+		}
+		// Met a jour le toast (lastMotd*).
+		m_state.lastMotdGuildId      = note.guildId;
+		m_state.lastMotdNewValue     = note.newMotd;
+		m_state.lastMotdChangeTimeMs = SteadyMs();
+		LOG_DEBUG(Net, "[GuildUiPresenter] OnMotdUpdateNotification gid={} motdLen={}",
+			note.guildId, note.newMotd.size());
+	}
+}

--- a/src/client/guild/GuildUi.h
+++ b/src/client/guild/GuildUi.h
@@ -1,0 +1,186 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Presenter client de la fenetre
+// Guildes. Maintient un cache local de la liste des guildes + selection
+// active (membres / permissions / bank tab 0) + dernier MOTD update reçu
+// (pour toast UI).
+//
+// Pas de rendu ImGui : le panneau est drawe par GuildImGuiRenderer qui lit
+// l'etat via GetState() et propage les inputs UI (RequestList /
+// SelectGuild / RequestMembers / RequestPermissions / RequestBank) via les
+// methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans GameEventUi).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 165/167/169/171/172 vers les OnXxx du presenter.
+
+#include "src/shared/network/GuildPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'une guilde expose au layer UI. Mirror direct de
+	/// engine::network::GuildSummary.
+	struct GuildSummary
+	{
+		uint32_t    guildId     = 0;
+		std::string name;
+		std::string motd;
+		uint32_t    memberCount = 0;
+		std::string leaderName;
+	};
+
+	/// Membre d'une guilde expose au layer UI. Mirror direct de
+	/// engine::network::GuildMember.
+	struct GuildMember
+	{
+		std::string accountName;
+		uint8_t     rankId   = 0;
+		std::string rankName;
+		bool        online   = false;
+	};
+
+	/// Permissions d'un rang expose au layer UI. Mirror direct de
+	/// engine::network::GuildRankPerms.
+	struct GuildRankPerms
+	{
+		uint8_t     rankId = 0;
+		std::string rankName;
+		uint32_t    mask   = 0;
+	};
+
+	/// Item de bank expose au layer UI. Mirror direct de
+	/// engine::network::GuildBankItem.
+	struct GuildBankItem
+	{
+		uint32_t    slotIndex = 0;
+		std::string itemName;
+		uint32_t    count     = 0;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct GuildState
+	{
+		std::vector<GuildSummary>         guilds;
+		bool                              guildsLoaded = false;
+
+		/// Guilde selectionnee : si set, on a demande (ou recu) members /
+		/// permissions / bank pour cette guilde.
+		std::optional<uint32_t>           selectedGuildId;
+		std::vector<GuildMember>          selectedMembers;
+		bool                              membersLoaded = false;
+		std::vector<GuildRankPerms>       selectedRanks;
+		bool                              ranksLoaded   = false;
+		std::vector<GuildBankItem>        selectedBank;
+		bool                              bankLoaded    = false;
+
+		/// Dernier MotdUpdate reçu : guildId + nouvelle valeur + instant
+		/// d'arrivee (ms steady_clock cote client). Utilise par le renderer
+		/// pour afficher un toast 5s apres reception.
+		std::optional<uint64_t>           lastMotdChangeTimeMs;
+		uint32_t                          lastMotdGuildId = 0;
+		std::string                       lastMotdNewValue;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire. Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Static helper : explose un mask de permissions WoW en libelles ASCII
+	/// (e.g. ["Invite", "Remove", ...]). Bits matching les constantes
+	/// serveur :
+	///   0x001 Invite, 0x002 Remove, 0x004 Promote, 0x008 Demote,
+	///   0x010 EditMotd, 0x020 EditTabard, 0x040 WithdrawGold, 0x080 BankView,
+	///   0x100 BankDeposit, 0x200 BankWithdraw, 0x400 Disband.
+	std::vector<std::string> ExpandPermissionMask(uint32_t mask);
+
+	/// Presenter pour la fenetre Guildes cote client. Doit etre Init() avant
+	/// tout usage du callback. Thread : main (comme les autres presenters UI).
+	class GuildUiPresenter final
+	{
+	public:
+		GuildUiPresenter() = default;
+
+		GuildUiPresenter(const GuildUiPresenter&)            = delete;
+		GuildUiPresenter& operator=(const GuildUiPresenter&) = delete;
+
+		~GuildUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.21 step 3+4 Guilds)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / SelectGuild.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie GUILD_LIST_REQUEST. Reponse via OnListResponse.
+		void RequestList();
+
+		/// Selectionne une guilde et declenche RequestMembers + RequestPermissions
+		/// + RequestBank tab 0 sur cette guilde. Le rendu ImGui basculera vers
+		/// l'onglet detail apres reception.
+		void SelectGuild(uint32_t guildId);
+
+		/// Envoie GUILD_MEMBERS_REQUEST. Reponse via OnMembersResponse.
+		void RequestMembers(uint32_t guildId);
+
+		/// Envoie GUILD_PERMISSIONS_REQUEST. Reponse via OnPermissionsResponse.
+		void RequestPermissions(uint32_t guildId);
+
+		/// Envoie GUILD_BANK_REQUEST. Reponse via OnBankResponse.
+		void RequestBank(uint32_t guildId, uint8_t tabIndex = 0u);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit GUILD_LIST_RESPONSE. Remplace le cache local des guildes.
+		void OnListResponse(const engine::network::GuildListResponsePayload& resp);
+
+		/// Recoit GUILD_MEMBERS_RESPONSE. Met a jour selectedMembers si la
+		/// guilde correspond a selectedGuildId, sinon cache l'erreur.
+		void OnMembersResponse(const engine::network::GuildMembersResponsePayload& resp);
+
+		/// Recoit GUILD_PERMISSIONS_RESPONSE. Met a jour selectedRanks.
+		void OnPermissionsResponse(const engine::network::GuildPermissionsResponsePayload& resp);
+
+		/// Recoit GUILD_BANK_RESPONSE. Met a jour selectedBank.
+		void OnBankResponse(const engine::network::GuildBankResponsePayload& resp);
+
+		/// Recoit un push GUILD_MOTD_UPDATE_NOTIFICATION : update motd dans
+		/// le cache des guildes + met a jour lastMotd* pour le toast UI.
+		void OnMotdUpdateNotification(const engine::network::GuildMotdUpdateNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const GuildState& GetState() const { return m_state; }
+
+	private:
+		bool             m_initialized = false;
+		GuildState       m_state{};
+		SendCallback     m_send;
+	};
+}

--- a/src/client/render/GuildImGuiRenderer.cpp
+++ b/src/client/render/GuildImGuiRenderer.cpp
@@ -1,0 +1,412 @@
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — GuildImGuiRenderer implementation.
+
+#include "src/client/render/GuildImGuiRenderer.h"
+
+#include "src/client/guild/GuildUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Couleur de l'indicateur online (vert) / offline (gris).
+		ImVec4 OnlineColor(bool online)
+		{
+			return online ? ImVec4(0.40f, 0.95f, 0.40f, 1.f)
+			              : ImVec4(0.55f, 0.55f, 0.60f, 1.f);
+		}
+
+		/// Retourne le steady_clock now en ms (pour les toasts 5s).
+		uint64_t SteadyNowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	void GuildImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		// Le panel n'est rendu que si IsEnabled().
+		if (m_enabled)
+			RenderMainPanel();
+
+		// Le toast est rendu independamment, si un MotdUpdate recent existe.
+		RenderToast();
+	}
+
+	void GuildImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 560x600.
+		const float panelW = 560.f;
+		const float panelH = 600.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Guilds (U)##ln_guilds_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Top : liste des guildes.
+			ImGui::TextUnformatted("Guildes :");
+			ImGui::Separator();
+
+			if (!state.guildsLoaded || state.guilds.empty())
+			{
+				if (ImGui::Button("Charger les guildes", ImVec2(-FLT_MIN, 28.f)))
+					m_presenter->RequestList();
+				if (state.guildsLoaded && state.guilds.empty())
+				{
+					ImGui::TextWrapped("Aucune guilde.");
+				}
+			}
+			else
+			{
+				const float topHeight = 200.f;
+				if (ImGui::BeginChild("##guilds_list_child", ImVec2(0.f, topHeight), true,
+					ImGuiWindowFlags_HorizontalScrollbar))
+				{
+					if (ImGui::BeginTable("##guilds_table", 4,
+						ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders
+						| ImGuiTableFlags_SizingStretchProp))
+					{
+						ImGui::TableSetupColumn("Nom");
+						ImGui::TableSetupColumn("Leader");
+						ImGui::TableSetupColumn("Membres");
+						ImGui::TableSetupColumn("Action");
+						ImGui::TableHeadersRow();
+
+						for (const auto& g : state.guilds)
+						{
+							ImGui::TableNextRow();
+							ImGui::PushID(static_cast<int>(g.guildId));
+							ImGui::TableNextColumn();
+							ImGui::TextUnformatted(g.name.c_str());
+							ImGui::TableNextColumn();
+							ImGui::TextUnformatted(g.leaderName.c_str());
+							ImGui::TableNextColumn();
+							ImGui::Text("%u", static_cast<unsigned>(g.memberCount));
+							ImGui::TableNextColumn();
+							const bool isSelected = state.selectedGuildId.has_value()
+								&& *state.selectedGuildId == g.guildId;
+							const char* btnLbl = isSelected ? "Selectionnee" : "Selectionner";
+							if (ImGui::SmallButton(btnLbl) && !isSelected)
+							{
+								m_presenter->SelectGuild(g.guildId);
+							}
+							ImGui::PopID();
+						}
+						ImGui::EndTable();
+					}
+				}
+				ImGui::EndChild();
+
+				ImGui::Spacing();
+				if (ImGui::Button("Rafraichir", ImVec2(-FLT_MIN, 24.f)))
+					m_presenter->RequestList();
+			}
+
+			ImGui::Separator();
+
+			// Bottom : 4 tabs detail si une guilde est selectionnee.
+			if (!state.selectedGuildId.has_value())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.7f, 0.7f, 1.f));
+				ImGui::TextWrapped("Selectionnez une guilde pour voir ses membres, ses permissions, sa banque et son MOTD.");
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				const uint32_t selId = *state.selectedGuildId;
+
+				// Resolve nom de la guilde selectionnee.
+				const char* selName = "?";
+				const char* selMotd = "";
+				for (const auto& g : state.guilds)
+				{
+					if (g.guildId == selId)
+					{
+						selName = g.name.c_str();
+						selMotd = g.motd.c_str();
+						break;
+					}
+				}
+
+				ImGui::Text("Guilde selectionnee : %s (id=%u)", selName, static_cast<unsigned>(selId));
+				ImGui::Spacing();
+
+				if (ImGui::BeginTabBar("##guild_detail_tabs", ImGuiTabBarFlags_None))
+				{
+					// Tab Members.
+					if (ImGui::BeginTabItem("Membres"))
+					{
+						if (!state.membersLoaded)
+						{
+							ImGui::TextUnformatted("Chargement...");
+						}
+						else if (state.selectedMembers.empty())
+						{
+							ImGui::TextUnformatted("Aucun membre.");
+						}
+						else
+						{
+							if (ImGui::BeginTable("##members_table", 3,
+								ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders
+								| ImGuiTableFlags_SizingStretchProp))
+							{
+								ImGui::TableSetupColumn("Nom");
+								ImGui::TableSetupColumn("Rang");
+								ImGui::TableSetupColumn("Statut");
+								ImGui::TableHeadersRow();
+								for (const auto& m : state.selectedMembers)
+								{
+									ImGui::TableNextRow();
+									ImGui::TableNextColumn();
+									ImGui::TextUnformatted(m.accountName.c_str());
+									ImGui::TableNextColumn();
+									ImGui::Text("%u %s", static_cast<unsigned>(m.rankId), m.rankName.c_str());
+									ImGui::TableNextColumn();
+									ImGui::PushStyleColor(ImGuiCol_Text, OnlineColor(m.online));
+									ImGui::TextUnformatted(m.online ? "En ligne" : "Hors ligne");
+									ImGui::PopStyleColor();
+								}
+								ImGui::EndTable();
+							}
+						}
+						ImGui::EndTabItem();
+					}
+
+					// Tab Permissions.
+					if (ImGui::BeginTabItem("Permissions"))
+					{
+						if (!state.ranksLoaded)
+						{
+							ImGui::TextUnformatted("Chargement...");
+						}
+						else if (state.selectedRanks.empty())
+						{
+							ImGui::TextUnformatted("Aucun rang.");
+						}
+						else
+						{
+							for (const auto& p : state.selectedRanks)
+							{
+								ImGui::PushID(static_cast<int>(p.rankId));
+								ImGui::Text("Rang %u : %s", static_cast<unsigned>(p.rankId), p.rankName.c_str());
+								// Chip-list : permissions actives.
+								auto perms = engine::client::ExpandPermissionMask(p.mask);
+								if (perms.empty())
+								{
+									ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.f));
+									ImGui::SameLine();
+									ImGui::TextUnformatted(" -- aucune --");
+									ImGui::PopStyleColor();
+								}
+								else
+								{
+									ImGui::Indent();
+									for (const auto& s : perms)
+									{
+										ImGui::SameLine();
+										ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.75f, 0.85f, 1.0f, 1.f));
+										ImGui::Text("[%s]", s.c_str());
+										ImGui::PopStyleColor();
+									}
+									ImGui::Unindent();
+									ImGui::NewLine();
+								}
+								ImGui::Separator();
+								ImGui::PopID();
+							}
+						}
+						ImGui::EndTabItem();
+					}
+
+					// Tab Bank (V1 : tab 0 only).
+					if (ImGui::BeginTabItem("Banque"))
+					{
+						ImGui::TextUnformatted("Onglet 0 (V1)");
+						ImGui::Separator();
+						if (!state.bankLoaded)
+						{
+							ImGui::TextUnformatted("Chargement...");
+						}
+						else if (state.selectedBank.empty())
+						{
+							ImGui::TextUnformatted("Banque vide.");
+						}
+						else
+						{
+							if (ImGui::BeginTable("##bank_table", 3,
+								ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders
+								| ImGuiTableFlags_SizingStretchProp))
+							{
+								ImGui::TableSetupColumn("Slot");
+								ImGui::TableSetupColumn("Item");
+								ImGui::TableSetupColumn("Quantite");
+								ImGui::TableHeadersRow();
+								for (const auto& it : state.selectedBank)
+								{
+									ImGui::TableNextRow();
+									ImGui::TableNextColumn();
+									ImGui::Text("%u", static_cast<unsigned>(it.slotIndex));
+									ImGui::TableNextColumn();
+									ImGui::TextUnformatted(it.itemName.c_str());
+									ImGui::TableNextColumn();
+									ImGui::Text("%u", static_cast<unsigned>(it.count));
+								}
+								ImGui::EndTable();
+							}
+						}
+						ImGui::EndTabItem();
+					}
+
+					// Tab MOTD.
+					if (ImGui::BeginTabItem("MOTD"))
+					{
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.85f, 0.85f, 0.85f, 1.f));
+						ImGui::TextWrapped("Message du jour :");
+						ImGui::PopStyleColor();
+						ImGui::Spacing();
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.95f, 0.7f, 1.f));
+						ImGui::TextWrapped("%s", *selMotd ? selMotd : "(vide)");
+						ImGui::PopStyleColor();
+						ImGui::EndTabItem();
+					}
+
+					ImGui::EndTabBar();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void GuildImGuiRenderer::RenderToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastMotdChangeTimeMs.has_value())
+			return;
+
+		// Toast actif 5s apres reception.
+		constexpr uint64_t kToastDurationMs = 5000ull;
+		const uint64_t nowSteady = SteadyNowMs();
+		if (nowSteady < *state.lastMotdChangeTimeMs)
+			return;
+		const uint64_t age = nowSteady - *state.lastMotdChangeTimeMs;
+		if (age > kToastDurationMs)
+			return;
+
+		// Cherche le nom de la guilde dans le cache. Fallback "Guilde N".
+		std::string guildName;
+		for (const auto& g : state.guilds)
+		{
+			if (g.guildId == state.lastMotdGuildId)
+			{
+				guildName = g.name;
+				break;
+			}
+		}
+		if (guildName.empty())
+		{
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Guilde %u",
+				static_cast<unsigned>(state.lastMotdGuildId));
+			guildName = buf;
+		}
+
+		std::string text = guildName + " : nouveau MOTD";
+
+		// Geometrie toast : bottom-right, 320x60, marge 16.
+		const float toastW = 320.f;
+		const float toastH = 60.f;
+		const float margin = 16.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = std::max(0.f, vpH - toastH - margin);
+
+		// Fade out sur les 1000 dernieres ms.
+		float alpha = 0.95f;
+		if (age > kToastDurationMs - 1000ull)
+		{
+			const float remain = static_cast<float>(kToastDurationMs - age) / 1000.0f;
+			alpha = std::max(0.0f, std::min(0.95f, remain * 0.95f));
+		}
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(alpha);
+
+		const ImGuiWindowFlags toastFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoInputs;
+
+		if (ImGui::Begin("##ln_guilds_toast", nullptr, toastFlags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.95f, 0.85f, 0.45f, 1.f));
+			ImGui::TextWrapped("%s", text.c_str());
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void GuildImGuiRenderer::Render()           {}
+	void GuildImGuiRenderer::RenderMainPanel()  {}
+	void GuildImGuiRenderer::RenderToast()      {}
+}
+
+#endif

--- a/src/client/render/GuildImGuiRenderer.h
+++ b/src/client/render/GuildImGuiRenderer.h
@@ -1,0 +1,58 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — GuildImGuiRenderer : panneau ImGui
+// pour la fenetre Guildes. Top section : table des guildes (Name / Leader /
+// Members) avec un bouton Select par ligne. Bottom section (visible si
+// selectedGuildId set) : 4 tabs (Members, Permissions, Bank, MOTD).
+//
+// Le toast 5s sur dernier MotdUpdate reçu est rendu independamment du flag
+// IsEnabled() (les push peuvent arriver panneau ferme).
+//
+// Lit l'etat d'un GuildUiPresenter, dispatch les inputs UI (RequestList /
+// SelectGuild) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class GuildUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau Guildes. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::GuildUiPresenter. Le renderer
+	/// ne fait que dessiner l'etat courant et propager les inputs UI vers
+	/// le presenter.
+	class GuildImGuiRenderer
+	{
+	public:
+		GuildImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::GuildUiPresenter* presenter) { m_presenter = presenter; }
+
+		/// Active/desactive le rendu du panel principal.
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Guilds" (si IsEnabled()) et le toast 5s pour le
+		/// dernier MotdUpdate reçu (rendu independamment du flag IsEnabled()
+		/// puisque les push peuvent arriver panneau ferme). A appeler entre
+		/// \c ImGui::NewFrame() et \c ImGui::Render(), apres NewFrame, si le
+		/// presenter est valide.
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (top : liste guildes ; bottom :
+		/// 4 tabs detail).
+		void RenderMainPanel();
+
+		/// Dessine le toast 5s en bas-droite si lastMotd* est recent.
+		void RenderToast();
+
+		engine::client::GuildUiPresenter* m_presenter = nullptr;
+		bool                              m_enabled   = false;
+		uint32_t                          m_viewportW = 0;
+		uint32_t                          m_viewportH = 0;
+	};
+}

--- a/src/masterd/handlers/guild/GuildHandler.cpp
+++ b/src/masterd/handlers/guild/GuildHandler.cpp
@@ -1,0 +1,488 @@
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Implementation GuildHandler.
+
+#include "src/masterd/handlers/guild/GuildHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/GuildPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Noms des rangs WoW par defaut (0=Guild Master ... 9=Initiate).
+		/// Static array : adresses stables pour const char* pour le wire.
+		const char* const kDefaultRankNames[10] = {
+			"Guild Master",
+			"Officer",
+			"Veteran",
+			"Senior",
+			"Trusted",
+			"Member",
+			"Apprentice",
+			"Recruit",
+			"Probationary",
+			"Initiate"
+		};
+	}
+
+	// -------------------------------------------------------------------------
+	// RankName — static helper public.
+	// -------------------------------------------------------------------------
+
+	const char* GuildHandler::RankName(uint8_t rankId)
+	{
+		if (rankId < 10u)
+			return kDefaultRankNames[rankId];
+		return "?";
+	}
+
+	// -------------------------------------------------------------------------
+	// SeedV1Guilds — register the 2 hardcoded guilds at boot.
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::SeedV1Guilds()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_seeded)
+		{
+			LOG_DEBUG(Net, "[GuildHandler] SeedV1Guilds already seeded (idempotent skip)");
+			return;
+		}
+
+		// Guilde 1 : Les Gardiens.
+		{
+			InMemoryGuild g;
+			g.guildId    = 1u;
+			g.name       = "Les Gardiens";
+			g.motd       = "Soyez courageux";
+			g.leaderName = "Aragorn";
+
+			InMemoryGuildMember m1; m1.accountName = "Aragorn"; m1.rankId = 0u; m1.online = true;
+			InMemoryGuildMember m2; m2.accountName = "Legolas"; m2.rankId = 1u; m2.online = true;
+			InMemoryGuildMember m3; m3.accountName = "Gimli";   m3.rankId = 5u; m3.online = false;
+			InMemoryGuildMember m4; m4.accountName = "Frodo";   m4.rankId = 9u; m4.online = false;
+			g.members.push_back(m1);
+			g.members.push_back(m2);
+			g.members.push_back(m3);
+			g.members.push_back(m4);
+
+			InMemoryGuildBankItem b1; b1.slotIndex = 0u; b1.itemName = "Iron Ore";       b1.count = 100u;
+			InMemoryGuildBankItem b2; b2.slotIndex = 1u; b2.itemName = "Linen Cloth";    b2.count = 250u;
+			InMemoryGuildBankItem b3; b3.slotIndex = 2u; b3.itemName = "Mageweave";      b3.count = 80u;
+			InMemoryGuildBankItem b4; b4.slotIndex = 3u; b4.itemName = "Health Potion";  b4.count = 30u;
+			InMemoryGuildBankItem b5; b5.slotIndex = 4u; b5.itemName = "Mana Potion";    b5.count = 20u;
+			g.bank0.push_back(b1);
+			g.bank0.push_back(b2);
+			g.bank0.push_back(b3);
+			g.bank0.push_back(b4);
+			g.bank0.push_back(b5);
+
+			m_guilds.push_back(std::move(g));
+			m_perms.SetupWowDefaults(1u);
+		}
+
+		// Guilde 2 : L'Ombre.
+		{
+			InMemoryGuild g;
+			g.guildId    = 2u;
+			g.name       = "L'Ombre";
+			g.motd       = "Le pouvoir est tout";
+			g.leaderName = "Saruman";
+
+			InMemoryGuildMember m1; m1.accountName = "Saruman";    m1.rankId = 0u; m1.online = true;
+			InMemoryGuildMember m2; m2.accountName = "Wormtongue"; m2.rankId = 5u; m2.online = false;
+			g.members.push_back(m1);
+			g.members.push_back(m2);
+
+			InMemoryGuildBankItem b1; b1.slotIndex = 0u; b1.itemName = "Black Cloth"; b1.count = 50u;
+			InMemoryGuildBankItem b2; b2.slotIndex = 1u; b2.itemName = "Soul Shard";  b2.count = 10u;
+			g.bank0.push_back(b1);
+			g.bank0.push_back(b2);
+
+			m_guilds.push_back(std::move(g));
+			m_perms.SetupWowDefaults(2u);
+		}
+
+		m_seeded = true;
+		LOG_INFO(Net, "[GuildHandler] V1 guilds seeded : Les Gardiens (id=1, 4 members), L'Ombre (id=2, 2 members)");
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket — dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[GuildHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(GuildErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeGuildListRequest:
+				pkt = BuildGuildListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGuildMembersRequest:
+				pkt = BuildGuildMembersResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGuildPermissionsRequest:
+				pkt = BuildGuildPermissionsResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeGuildBankRequest:
+				pkt = BuildGuildBankResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeGuildListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGuildMembersRequest:
+			HandleMembers(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGuildPermissionsRequest:
+			HandlePermissions(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeGuildBankRequest:
+			HandleBank(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// FindGuildLocked — m_mutex held by caller.
+	// -------------------------------------------------------------------------
+
+	const InMemoryGuild* GuildHandler::FindGuildLocked(uint32_t guildId) const
+	{
+		for (const auto& g : m_guilds)
+		{
+			if (g.guildId == guildId) return &g;
+		}
+		return nullptr;
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleList
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+
+		std::vector<GuildSummary> summaries;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			summaries.reserve(m_guilds.size());
+			for (const auto& g : m_guilds)
+			{
+				GuildSummary s;
+				s.guildId     = g.guildId;
+				s.name        = g.name;
+				s.motd        = g.motd;
+				s.memberCount = static_cast<uint32_t>(g.members.size());
+				s.leaderName  = g.leaderName;
+				summaries.push_back(std::move(s));
+			}
+		}
+
+		LOG_INFO(Net, "[GuildHandler] List account={} count={}",
+			accountId, summaries.size());
+
+		auto pkt = BuildGuildListResponsePacket(0u, summaries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleMembers
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::HandleMembers(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseGuildMembersRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[GuildHandler] Members parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildGuildMembersResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t guildId = parsed->guildId;
+		std::vector<GuildMember> members;
+		bool found = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const InMemoryGuild* g = FindGuildLocked(guildId);
+			if (g)
+			{
+				found = true;
+				members.reserve(g->members.size());
+				for (const auto& mem : g->members)
+				{
+					GuildMember wm;
+					wm.accountName = mem.accountName;
+					wm.rankId      = mem.rankId;
+					wm.rankName    = RankName(mem.rankId);
+					wm.online      = mem.online;
+					members.push_back(std::move(wm));
+				}
+			}
+		}
+
+		if (!found)
+		{
+			LOG_INFO(Net, "[GuildHandler] Members UnknownGuild account={} guildId={}",
+				accountId, guildId);
+			auto pkt = BuildGuildMembersResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[GuildHandler] Members account={} guildId={} count={}",
+			accountId, guildId, members.size());
+
+		auto pkt = BuildGuildMembersResponsePacket(0u, members, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePermissions
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::HandlePermissions(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseGuildPermissionsRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[GuildHandler] Permissions parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildGuildPermissionsResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t guildId = parsed->guildId;
+		std::vector<GuildRankPerms> ranks;
+		bool found = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const InMemoryGuild* g = FindGuildLocked(guildId);
+			if (g)
+			{
+				found = true;
+				// Itere les rangs 0..9 V1 (rank fixed).
+				ranks.reserve(10u);
+				for (uint8_t r = 0u; r < 10u; ++r)
+				{
+					GuildRankPerms p;
+					p.rankId   = r;
+					p.rankName = RankName(r);
+					p.mask     = m_perms.GetMask(guildId, r);
+					ranks.push_back(std::move(p));
+				}
+			}
+		}
+
+		if (!found)
+		{
+			LOG_INFO(Net, "[GuildHandler] Permissions UnknownGuild account={} guildId={}",
+				accountId, guildId);
+			auto pkt = BuildGuildPermissionsResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[GuildHandler] Permissions account={} guildId={} ranks=10", accountId, guildId);
+
+		auto pkt = BuildGuildPermissionsResponsePacket(0u, ranks, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleBank
+	// -------------------------------------------------------------------------
+
+	void GuildHandler::HandleBank(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseGuildBankRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[GuildHandler] Bank parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildGuildBankResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t guildId  = parsed->guildId;
+		const uint8_t  tabIndex = parsed->tabIndex;
+
+		// V1 : seul le tab 0 est supporte. Tab > 0 => NoPermission.
+		if (tabIndex != 0u)
+		{
+			LOG_INFO(Net, "[GuildHandler] Bank NoPermission account={} guildId={} tab={}",
+				accountId, guildId, static_cast<unsigned>(tabIndex));
+			auto pkt = BuildGuildBankResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::NoPermission), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		std::vector<GuildBankItem> items;
+		bool found = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const InMemoryGuild* g = FindGuildLocked(guildId);
+			if (g)
+			{
+				found = true;
+				items.reserve(g->bank0.size());
+				for (const auto& b : g->bank0)
+				{
+					GuildBankItem wi;
+					wi.slotIndex = b.slotIndex;
+					wi.itemName  = b.itemName;
+					wi.count     = b.count;
+					items.push_back(std::move(wi));
+				}
+			}
+		}
+
+		if (!found)
+		{
+			LOG_INFO(Net, "[GuildHandler] Bank UnknownGuild account={} guildId={}",
+				accountId, guildId);
+			auto pkt = BuildGuildBankResponsePacket(
+				static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {},
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[GuildHandler] Bank account={} guildId={} tab=0 count={}",
+			accountId, guildId, items.size());
+
+		auto pkt = BuildGuildBankResponsePacket(0u, items, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// PushMotdUpdate
+	// -------------------------------------------------------------------------
+
+	bool GuildHandler::PushMotdUpdate(uint32_t connId, uint32_t guildId, const std::string& newMotd)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[GuildHandler] PushMotdUpdate dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[GuildHandler] PushMotdUpdate: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildGuildMotdUpdateNotificationPacket(guildId, newMotd, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[GuildHandler] PushMotdUpdate: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[GuildHandler] PushMotdUpdate connId={} guildId={} motdLen={}",
+			connId, guildId, newMotd.size());
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	uint64_t GuildHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/guild/GuildHandler.h
+++ b/src/masterd/handlers/guild/GuildHandler.h
@@ -1,0 +1,176 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — GuildHandler : dispatch des
+// opcodes Guild cote joueur (164/166/168/170) et registry in-memory V1
+// de 2 guildes hardcodees ("Les Gardiens" + "L'Ombre") avec leurs membres,
+// bank tab 0 et permissions WoW defaults par rang.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// 4 requests opcodes. Les responses 165/167/169/171 sont emises avec le
+// meme requestId / sessionId que la request recue. La push notification 172
+// (MotdUpdate) est emise par le handler (helper public PushMotdUpdate)
+// pour signaler les changements de MOTD a un client donne.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 1) dans la reponse type-specific.
+//
+// Store in-memory V1 (mutex protege) :
+//   - Guild 1 "Les Gardiens" leader=Aragorn motd="Soyez courageux"
+//       members : Aragorn(0/GM, online), Legolas(1/Officer, online),
+//                 Gimli(5/Member, offline), Frodo(9/Initiate, offline)
+//       bank0 : Iron Ore x100, Linen Cloth x250, Mageweave x80,
+//               Health Potion x30, Mana Potion x20
+//   - Guild 2 "L'Ombre" leader=Saruman motd="Le pouvoir est tout"
+//       members : Saruman(0/GM, online), Wormtongue(5/Member, offline)
+//       bank0 : Black Cloth x50, Soul Shard x10
+//   - GuildPermissionMatrix : SetupWowDefaults(1) + SetupWowDefaults(2).
+//   - Rank names array : 10 ranks (0=Guild Master ... 9=Initiate).
+//
+// V1 limitations :
+//   - 2 guildes hardcodees. Future PR : DB seed via MysqlGuildStore.
+//   - Pas de filtrage par account membership : n'importe quel client peut
+//     consulter n'importe quelle guilde V1 (lecture seule globale). Vraie
+//     ACL via la matrice GuildPermissionMatrix viendra plus tard.
+//   - Bank tab 0 only.
+//   - Pas de modification client (Invite/Remove/Promote/Demote V1 read-only).
+//   - Pas de SyncGuilds RPC entre master et shardd (master autoritaire V1).
+
+#include "src/shardd/guild/GuildPermissionMatrix.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Membre in-memory d'une guilde V1.
+	struct InMemoryGuildMember
+	{
+		std::string accountName;
+		uint8_t     rankId = 0;
+		bool        online = false;
+	};
+
+	/// Item in-memory de la bank tab 0 V1.
+	struct InMemoryGuildBankItem
+	{
+		uint32_t    slotIndex = 0;
+		std::string itemName;
+		uint32_t    count     = 0;
+	};
+
+	/// Guilde in-memory V1.
+	struct InMemoryGuild
+	{
+		uint32_t                            guildId = 0;
+		std::string                         name;
+		std::string                         motd;
+		std::string                         leaderName;
+		std::vector<InMemoryGuildMember>    members;
+		std::vector<InMemoryGuildBankItem>  bank0;
+	};
+
+	/// Dispatcher Guild cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class GuildHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Initialise le store V1 : enregistre les 2 guildes hardcodees
+		/// ("Les Gardiens", "L'Ombre") avec leurs membres + bank + perms WoW.
+		/// Idempotent : appelable a chaque boot.
+		void SeedV1Guilds();
+
+		/// Point d'entree appele par NetServer pour les opcodes Guild.
+		/// Dispatch vers HandleList / HandleMembers / HandlePermissions /
+		/// HandleBank selon l'opcode. Si l'opcode n'est pas un opcode Guild,
+		/// ignore silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (164/166/168/170).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push GuildMotdUpdateNotification (opcode 172)
+		/// au client identifie par \p connId. Utilise par le handler en interne
+		/// mais accessible egalement depuis l'exterieur (tests, hooks, future
+		/// PR /guild motd <text>).
+		///
+		/// \param connId    identifiant de connexion TCP cible (0 = no-op).
+		/// \param guildId   identifiant de la guilde dont le MOTD change.
+		/// \param newMotd   nouveau MOTD (UTF-8).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushMotdUpdate(uint32_t connId, uint32_t guildId, const std::string& newMotd);
+
+		/// Helper static : retourne le nom du rang WoW par defaut pour un rankId
+		/// (0=Guild Master ... 9=Initiate). \p rankId hors plage retourne "?".
+		static const char* RankName(uint8_t rankId);
+
+	private:
+		/// Traite GUILD_LIST_REQUEST : retourne les 2 guildes seedees V1 + summary.
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GUILD_MEMBERS_REQUEST : valide guildId puis renvoie la liste
+		/// des membres avec rankName resolu.
+		void HandleMembers(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GUILD_PERMISSIONS_REQUEST : valide guildId puis itere les rangs
+		/// 0-9 et renvoie les masks via GuildPermissionMatrix::GetMask.
+		void HandlePermissions(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite GUILD_BANK_REQUEST : valide guildId + tabIndex (0 V1) puis
+		/// renvoie la liste des items du tab 0.
+		void HandleBank(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Recherche dans m_guilds la guilde guildId (sans verrouiller m_mutex —
+		/// l'appelant doit deja le tenir).
+		const InMemoryGuild* FindGuildLocked(uint32_t guildId) const;
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant m_guilds + m_perms + m_seeded.
+		mutable std::mutex                               m_mutex;
+
+		/// Registry guildes in-memory (V1, 2 guildes seedees).
+		std::vector<InMemoryGuild>                       m_guilds;
+
+		/// Matrice de permissions par rang. Defaults WoW seedes au boot pour
+		/// les 2 guildes V1.
+		engine::server::guild::GuildPermissionMatrix     m_perms;
+
+		/// True une fois SeedV1Guilds() appele avec succes.
+		bool                                             m_seeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -44,6 +44,7 @@
 #include "src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h"
 #include "src/masterd/handlers/weather/WeatherHandler.h"
 #include "src/masterd/handlers/events/GameEventHandler.h"
+#include "src/masterd/handlers/guild/GuildHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -603,6 +604,22 @@ int main(int argc, char** argv)
 	gameEventHandler.SeedV1Events();
 	LOG_INFO(Net, "[ServerMain] GameEventHandler configured (CMANGOS.31 step 3+4, in-memory, 4 events seed)");
 
+	// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — GuildHandler : list /
+	// members / permissions / bank + push MotdUpdate. V1 : 2 guildes
+	// seedees au boot ("Les Gardiens", "L'Ombre") avec membres + bank
+	// + WoW perms defaults par rang. Les opcodes 164/166/168/170 sont
+	// dispatches au handler ; les responses 165/167/169/171 et la push
+	// notification 172 (MotdUpdate) sont emises par le handler. V1
+	// limitations : pas de filtrage par account membership, bank tab 0
+	// only, lecture seule (pas de modification client). Pas de SyncGuilds
+	// RPC entre master et shardd.
+	engine::server::GuildHandler guildHandler;
+	guildHandler.SetServer(&server);
+	guildHandler.SetSessionManager(&sessionManager);
+	guildHandler.SetConnectionSessionMap(&connSessionMap);
+	guildHandler.SeedV1Guilds();
+	LOG_INFO(Net, "[ServerMain] GuildHandler configured (CMANGOS.21 step 3+4 Guilds, in-memory, 2 guilds seed)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -642,7 +659,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -731,6 +748,11 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeGameEventSubscribeRequest
 		      || opcode == kOpcodeGameEventUnsubscribeRequest)
 			gameEventHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeGuildListRequest
+		      || opcode == kOpcodeGuildMembersRequest
+		      || opcode == kOpcodeGuildPermissionsRequest
+		      || opcode == kOpcodeGuildBankRequest)
+			guildHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shardd/guild/GuildPermissionMatrix.h
+++ b/src/shardd/guild/GuildPermissionMatrix.h
@@ -49,6 +49,26 @@ namespace engine::server::guild
 			return (rit->second.mask & Bit(p)) != 0;
 		}
 
+		/// Renvoie le mask brut d'un rang (0 si guilde ou rang inconnu).
+		/// Utilise par GuildHandler pour serialiser la matrice complete sur
+		/// le wire (rang -> mask).
+		uint32_t GetMask(GuildId g, RankId r) const
+		{
+			auto git = m_perms.find(g);
+			if (git == m_perms.end()) return 0u;
+			auto rit = git->second.find(r);
+			if (rit == git->second.end()) return 0u;
+			return rit->second.mask;
+		}
+
+		/// Indique si une guilde a au moins un rang configure dans la matrice.
+		/// Utilise par GuildHandler pour valider qu'un guildId existe avant de
+		/// servir une requete permissions/members/bank.
+		bool HasGuild(GuildId g) const
+		{
+			return m_perms.find(g) != m_perms.end();
+		}
+
 		/// Configure le defaut WoW-like : GM=tout, Officer=invite/remove/promote +
 		/// bank, Member=bank view/deposit, Initiate=rien.
 		void SetupWowDefaults(GuildId g)

--- a/src/shared/network/GuildPayloads.cpp
+++ b/src/shared/network/GuildPayloads.cpp
@@ -1,0 +1,476 @@
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Implementation Parse/Build des
+// payloads Guild.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/GuildPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un GuildSummary (guildId, name, motd, memberCount, leaderName).
+		bool WriteGuildSummary(ByteWriter& w, const GuildSummary& g)
+		{
+			if (!w.WriteU32(g.guildId))     return false;
+			if (!w.WriteString(g.name))     return false;
+			if (!w.WriteString(g.motd))     return false;
+			if (!w.WriteU32(g.memberCount)) return false;
+			if (!w.WriteString(g.leaderName)) return false;
+			return true;
+		}
+
+		/// Lit un GuildSummary.
+		bool ReadGuildSummary(ByteReader& r, GuildSummary& out)
+		{
+			if (!r.ReadU32(out.guildId))     return false;
+			if (!r.ReadString(out.name))     return false;
+			if (!r.ReadString(out.motd))     return false;
+			if (!r.ReadU32(out.memberCount)) return false;
+			if (!r.ReadString(out.leaderName)) return false;
+			return true;
+		}
+
+		/// Ecrit un GuildMember (accountName, rankId, rankName, online).
+		bool WriteGuildMember(ByteWriter& w, const GuildMember& m)
+		{
+			if (!w.WriteString(m.accountName)) return false;
+			if (!w.WriteBytes(&m.rankId, 1u))  return false;
+			if (!w.WriteString(m.rankName))    return false;
+			const uint8_t onlineByte = m.online ? 1u : 0u;
+			if (!w.WriteBytes(&onlineByte, 1u)) return false;
+			return true;
+		}
+
+		/// Lit un GuildMember.
+		bool ReadGuildMember(ByteReader& r, GuildMember& out)
+		{
+			if (!r.ReadString(out.accountName)) return false;
+			uint8_t rankByte = 0;
+			if (!r.ReadBytes(&rankByte, 1u))    return false;
+			out.rankId = rankByte;
+			if (!r.ReadString(out.rankName))    return false;
+			uint8_t onlineByte = 0;
+			if (!r.ReadBytes(&onlineByte, 1u))  return false;
+			out.online = (onlineByte != 0u);
+			return true;
+		}
+
+		/// Ecrit un GuildRankPerms (rankId, rankName, mask).
+		bool WriteGuildRankPerms(ByteWriter& w, const GuildRankPerms& p)
+		{
+			if (!w.WriteBytes(&p.rankId, 1u)) return false;
+			if (!w.WriteString(p.rankName))   return false;
+			if (!w.WriteU32(p.mask))          return false;
+			return true;
+		}
+
+		/// Lit un GuildRankPerms.
+		bool ReadGuildRankPerms(ByteReader& r, GuildRankPerms& out)
+		{
+			uint8_t rankByte = 0;
+			if (!r.ReadBytes(&rankByte, 1u)) return false;
+			out.rankId = rankByte;
+			if (!r.ReadString(out.rankName)) return false;
+			if (!r.ReadU32(out.mask))        return false;
+			return true;
+		}
+
+		/// Ecrit un GuildBankItem (slotIndex, itemName, count).
+		bool WriteGuildBankItem(ByteWriter& w, const GuildBankItem& it)
+		{
+			if (!w.WriteU32(it.slotIndex)) return false;
+			if (!w.WriteString(it.itemName)) return false;
+			if (!w.WriteU32(it.count))     return false;
+			return true;
+		}
+
+		/// Lit un GuildBankItem.
+		bool ReadGuildBankItem(ByteReader& r, GuildBankItem& out)
+		{
+			if (!r.ReadU32(out.slotIndex)) return false;
+			if (!r.ReadString(out.itemName)) return false;
+			if (!r.ReadU32(out.count))     return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildListRequestPayload> ParseGuildListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return GuildListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildGuildListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildListResponsePayload> ParseGuildListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.guilds.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GuildSummary g;
+			if (!ReadGuildSummary(r, g)) return std::nullopt;
+			out.guilds.push_back(std::move(g));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildListResponsePayload(uint8_t error, const std::vector<GuildSummary>& guilds)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(guilds.size()))) return {};
+			for (const auto& g : guilds)
+			{
+				if (!WriteGuildSummary(w, g)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGuildListResponsePacket(uint8_t error, const std::vector<GuildSummary>& guilds,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(guilds.size()))) return {};
+			for (const auto& g : guilds)
+			{
+				if (!WriteGuildSummary(w, g)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGuildListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_MEMBERS — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildMembersRequestPayload> ParseGuildMembersRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildMembersRequestPayload out;
+		if (!r.ReadU32(out.guildId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildMembersRequestPayload(uint32_t guildId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(guildId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_MEMBERS — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildMembersResponsePayload> ParseGuildMembersResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildMembersResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.members.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GuildMember m;
+			if (!ReadGuildMember(r, m)) return std::nullopt;
+			out.members.push_back(std::move(m));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildMembersResponsePayload(uint8_t error, const std::vector<GuildMember>& members)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(members.size()))) return {};
+			for (const auto& m : members)
+			{
+				if (!WriteGuildMember(w, m)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGuildMembersResponsePacket(uint8_t error, const std::vector<GuildMember>& members,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(members.size()))) return {};
+			for (const auto& m : members)
+			{
+				if (!WriteGuildMember(w, m)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGuildMembersResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_PERMISSIONS — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildPermissionsRequestPayload> ParseGuildPermissionsRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildPermissionsRequestPayload out;
+		if (!r.ReadU32(out.guildId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildPermissionsRequestPayload(uint32_t guildId)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(guildId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_PERMISSIONS — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildPermissionsResponsePayload> ParseGuildPermissionsResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildPermissionsResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.ranks.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GuildRankPerms p;
+			if (!ReadGuildRankPerms(r, p)) return std::nullopt;
+			out.ranks.push_back(std::move(p));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildPermissionsResponsePayload(uint8_t error, const std::vector<GuildRankPerms>& ranks)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(ranks.size()))) return {};
+			for (const auto& p : ranks)
+			{
+				if (!WriteGuildRankPerms(w, p)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGuildPermissionsResponsePacket(uint8_t error, const std::vector<GuildRankPerms>& ranks,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(ranks.size()))) return {};
+			for (const auto& p : ranks)
+			{
+				if (!WriteGuildRankPerms(w, p)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGuildPermissionsResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_BANK — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildBankRequestPayload> ParseGuildBankRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 guildId (4) + uint8 tabIndex (1) = 5.
+		if (!payload || payloadSize < 5u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildBankRequestPayload out;
+		if (!r.ReadU32(out.guildId)) return std::nullopt;
+		uint8_t tabByte = 0;
+		if (!r.ReadBytes(&tabByte, 1u)) return std::nullopt;
+		out.tabIndex = tabByte;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildBankRequestPayload(uint32_t guildId, uint8_t tabIndex)
+	{
+		std::vector<uint8_t> buf(5u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(guildId)) return {};
+		if (!w.WriteBytes(&tabIndex, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_BANK — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildBankResponsePayload> ParseGuildBankResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildBankResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.items.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			GuildBankItem it;
+			if (!ReadGuildBankItem(r, it)) return std::nullopt;
+			out.items.push_back(std::move(it));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildBankResponsePayload(uint8_t error, const std::vector<GuildBankItem>& items)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(items.size()))) return {};
+			for (const auto& it : items)
+			{
+				if (!WriteGuildBankItem(w, it)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGuildBankResponsePacket(uint8_t error, const std::vector<GuildBankItem>& items,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(items.size()))) return {};
+			for (const auto& it : items)
+			{
+				if (!WriteGuildBankItem(w, it)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGuildBankResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// GUILD_MOTD_UPDATE_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildMotdUpdateNotificationPayload> ParseGuildMotdUpdateNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 guildId (4) + uint16 string length (2) = 6 (string vide possible).
+		if (!payload || payloadSize < 6u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		GuildMotdUpdateNotificationPayload out;
+		if (!r.ReadU32(out.guildId))      return std::nullopt;
+		if (!r.ReadString(out.newMotd))   return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildGuildMotdUpdateNotificationPayload(uint32_t guildId, const std::string& newMotd)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(guildId))   return {};
+		if (!w.WriteString(newMotd)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildGuildMotdUpdateNotificationPacket(uint32_t guildId, const std::string& newMotd,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU32(guildId))   return {};
+		if (!w.WriteString(newMotd)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeGuildMotdUpdateNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/GuildPayloads.h
+++ b/src/shared/network/GuildPayloads.h
@@ -1,0 +1,242 @@
+#pragma once
+// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Wire payloads pour les opcodes
+// Guild (164-172). 4 paires Request/Response + 1 push notification :
+//   - List         (164/165) : liste des guildes (summary).
+//   - Members      (166/167) : liste des membres d'une guilde.
+//   - Permissions  (168/169) : matrice mask par rang.
+//   - Bank         (170/171) : contenu bank tab 0.
+//   - MotdUpdateNotification (172 push) : changement MOTD.
+//
+// Le master tient en memoire un registry de guildes (V1 : 2 guildes hardcodees
+// "Les Gardiens" et "L'Ombre" avec membres + bank + permissions WoW defaults).
+// Subscriptions et registry sont reinitialises au reboot. Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Strings via
+// WriteString/ReadString (uint16 length + UTF-8 bytes), arrays via
+// WriteArrayCount/ReadArrayCount (uint16 count). Bool serialise en uint8 (0/1).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Guild.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Guild. 0 = OK.
+	enum class GuildErrorCode : uint8_t
+	{
+		Ok            = 0,
+		Unauthorized  = 1, ///< Pas de session valide cote master.
+		UnknownGuild  = 2, ///< guildId inconnu du registry master.
+		NoPermission  = 3, ///< Le rang du joueur ne couvre pas l'op (e.g. BankView).
+	};
+
+	// =========================================================================
+	// Sous-structs partages.
+	// =========================================================================
+
+	/// Resume d'une guilde pour le wire (List response).
+	/// Wire format :
+	///   uint32 guildId
+	///   string name
+	///   string motd
+	///   uint32 memberCount
+	///   string leaderName
+	struct GuildSummary
+	{
+		uint32_t    guildId     = 0;
+		std::string name;
+		std::string motd;
+		uint32_t    memberCount = 0;
+		std::string leaderName;
+	};
+
+	/// Membre d'une guilde pour le wire (Members response).
+	/// Wire format :
+	///   string accountName
+	///   uint8  rankId
+	///   string rankName
+	///   uint8  online (0 ou 1)
+	struct GuildMember
+	{
+		std::string accountName;
+		uint8_t     rankId   = 0;
+		std::string rankName;
+		bool        online   = false;
+	};
+
+	/// Permissions d'un rang pour le wire (Permissions response).
+	/// Wire format :
+	///   uint8  rankId
+	///   string rankName
+	///   uint32 mask
+	struct GuildRankPerms
+	{
+		uint8_t     rankId = 0;
+		std::string rankName;
+		uint32_t    mask   = 0;
+	};
+
+	/// Item de la bank d'une guilde (V1 : tab 0 only).
+	/// Wire format :
+	///   uint32 slotIndex
+	///   string itemName
+	///   uint32 count
+	struct GuildBankItem
+	{
+		uint32_t    slotIndex = 0;
+		std::string itemName;
+		uint32_t    count     = 0;
+	};
+
+	// =========================================================================
+	// GUILD_LIST — Client to Master : liste des guildes.
+	// =========================================================================
+
+	/// Wire format : (vide). L'account est derive de la session cote master.
+	struct GuildListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  error                     (cf. GuildErrorCode)
+	///   uint16 guildCount                (si error == 0)
+	///   <count> GuildSummary
+	struct GuildListResponsePayload
+	{
+		uint8_t                   error = 0;
+		std::vector<GuildSummary> guilds;
+	};
+
+	// =========================================================================
+	// GUILD_MEMBERS — Client to Master : liste des membres d'une guilde.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 guildId
+	struct GuildMembersRequestPayload
+	{
+		uint32_t guildId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 memberCount               (si error == 0)
+	///   <count> GuildMember
+	struct GuildMembersResponsePayload
+	{
+		uint8_t                  error = 0;
+		std::vector<GuildMember> members;
+	};
+
+	// =========================================================================
+	// GUILD_PERMISSIONS — Client to Master : matrice par rang.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 guildId
+	struct GuildPermissionsRequestPayload
+	{
+		uint32_t guildId = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 rankCount                 (si error == 0)
+	///   <count> GuildRankPerms
+	struct GuildPermissionsResponsePayload
+	{
+		uint8_t                     error = 0;
+		std::vector<GuildRankPerms> ranks;
+	};
+
+	// =========================================================================
+	// GUILD_BANK — Client to Master : contenu bank tab 0.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 guildId
+	///   uint8  tabIndex (V1 = 0)
+	struct GuildBankRequestPayload
+	{
+		uint32_t guildId  = 0;
+		uint8_t  tabIndex = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint16 itemCount                 (si error == 0)
+	///   <count> GuildBankItem
+	struct GuildBankResponsePayload
+	{
+		uint8_t                    error = 0;
+		std::vector<GuildBankItem> items;
+	};
+
+	// =========================================================================
+	// GUILD_MOTD_UPDATE_NOTIFICATION — Master to Client (push, requestId=0).
+	// Changement de MOTD pour une guilde donnee.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 guildId
+	///   string newMotd
+	struct GuildMotdUpdateNotificationPayload
+	{
+		uint32_t    guildId = 0;
+		std::string newMotd;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildListRequestPayload>          ParseGuildListRequestPayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildMembersRequestPayload>       ParseGuildMembersRequestPayload      (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildPermissionsRequestPayload>   ParseGuildPermissionsRequestPayload  (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildBankRequestPayload>          ParseGuildBankRequestPayload         (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGuildListRequestPayload         ();
+	std::vector<uint8_t> BuildGuildMembersRequestPayload      (uint32_t guildId);
+	std::vector<uint8_t> BuildGuildPermissionsRequestPayload  (uint32_t guildId);
+	std::vector<uint8_t> BuildGuildBankRequestPayload         (uint32_t guildId, uint8_t tabIndex);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses & Notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<GuildListResponsePayload>                 ParseGuildListResponsePayload               (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildMembersResponsePayload>              ParseGuildMembersResponsePayload            (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildPermissionsResponsePayload>          ParseGuildPermissionsResponsePayload        (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildBankResponsePayload>                 ParseGuildBankResponsePayload               (const uint8_t* payload, size_t payloadSize);
+	std::optional<GuildMotdUpdateNotificationPayload>       ParseGuildMotdUpdateNotificationPayload     (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildGuildListResponsePayload              (uint8_t error, const std::vector<GuildSummary>& guilds);
+	std::vector<uint8_t> BuildGuildMembersResponsePayload           (uint8_t error, const std::vector<GuildMember>& members);
+	std::vector<uint8_t> BuildGuildPermissionsResponsePayload       (uint8_t error, const std::vector<GuildRankPerms>& ranks);
+	std::vector<uint8_t> BuildGuildBankResponsePayload              (uint8_t error, const std::vector<GuildBankItem>& items);
+	std::vector<uint8_t> BuildGuildMotdUpdateNotificationPayload    (uint32_t guildId, const std::string& newMotd);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildGuildListResponsePacket              (uint8_t error, const std::vector<GuildSummary>& guilds,
+	                                                                uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGuildMembersResponsePacket           (uint8_t error, const std::vector<GuildMember>& members,
+	                                                                uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGuildPermissionsResponsePacket       (uint8_t error, const std::vector<GuildRankPerms>& ranks,
+	                                                                uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildGuildBankResponsePacket              (uint8_t error, const std::vector<GuildBankItem>& items,
+	                                                                uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildGuildMotdUpdateNotificationPacket    (uint32_t guildId, const std::string& newMotd,
+	                                                                uint64_t sessionIdHeader);
+}

--- a/src/shared/network/GuildPayloadsTests.cpp
+++ b/src/shared/network/GuildPayloadsTests.cpp
@@ -1,0 +1,486 @@
+/**
+ * CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Round-trip tests for GUILD_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/GuildPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// GUILD_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestRoundTrip()
+{
+	auto buf = BuildGuildListRequestPayload();
+	Assert(buf.empty(), "Guild List request payload empty");
+	auto parsed = ParseGuildListRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Guild List request accepts empty payload");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildGuildListResponsePayload(0u, {});
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->guilds.empty(),
+		"Guild List response empty parses");
+}
+
+static void TestListResponseSingleGuild()
+{
+	GuildSummary g;
+	g.guildId     = 1u;
+	g.name        = "Les Gardiens";
+	g.motd        = "Soyez courageux";
+	g.memberCount = 4u;
+	g.leaderName  = "Aragorn";
+	auto buf = BuildGuildListResponsePayload(0u, {g});
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Guild List single guild parses");
+	if (parsed && parsed->guilds.size() == 1u)
+	{
+		Assert(parsed->guilds[0].guildId == 1u, "Guild 1 id");
+		Assert(parsed->guilds[0].name == "Les Gardiens", "Guild 1 name");
+		Assert(parsed->guilds[0].motd == "Soyez courageux", "Guild 1 motd");
+		Assert(parsed->guilds[0].memberCount == 4u, "Guild 1 memberCount");
+		Assert(parsed->guilds[0].leaderName == "Aragorn", "Guild 1 leader");
+	}
+	else
+	{
+		Assert(false, "List should have 1 guild");
+	}
+}
+
+static void TestListResponseTwoGuilds()
+{
+	std::vector<GuildSummary> guilds;
+	GuildSummary g1;
+	g1.guildId     = 1u;
+	g1.name        = "Les Gardiens";
+	g1.motd        = "Soyez courageux";
+	g1.memberCount = 4u;
+	g1.leaderName  = "Aragorn";
+	guilds.push_back(g1);
+
+	GuildSummary g2;
+	g2.guildId     = 2u;
+	g2.name        = "L'Ombre";
+	g2.motd        = "Le pouvoir est tout";
+	g2.memberCount = 2u;
+	g2.leaderName  = "Saruman";
+	guilds.push_back(g2);
+
+	auto buf = BuildGuildListResponsePayload(0u, guilds);
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guilds.size() == 2u, "List 2 guilds parses");
+	if (parsed && parsed->guilds.size() == 2u)
+	{
+		Assert(parsed->guilds[0].name == "Les Gardiens", "G[0] name");
+		Assert(parsed->guilds[1].name == "L'Ombre", "G[1] name");
+		Assert(parsed->guilds[1].leaderName == "Saruman", "G[1] leader");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	auto buf = BuildGuildListResponsePayload(
+		static_cast<uint8_t>(GuildErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "Guild List error has only 1 byte");
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "List Unauthorized");
+}
+
+static void TestListResponseRejectsShort()
+{
+	auto parsed = ParseGuildListResponsePayload(nullptr, 1u);
+	Assert(!parsed.has_value(), "List rejects nullptr");
+}
+
+static void TestListResponseEmptyMotd()
+{
+	GuildSummary g;
+	g.guildId     = 99u;
+	g.name        = "NoMotd";
+	g.motd        = "";
+	g.memberCount = 0u;
+	g.leaderName  = "";
+	auto buf = BuildGuildListResponsePayload(0u, {g});
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guilds.size() == 1u
+		&& parsed->guilds[0].motd.empty()
+		&& parsed->guilds[0].leaderName.empty(),
+		"List accepts empty motd / leader");
+}
+
+static void TestListResponseLongName()
+{
+	GuildSummary g;
+	g.guildId     = 7u;
+	g.name        = std::string(200u, 'A');
+	g.motd        = std::string(500u, 'B');
+	g.memberCount = 0xFFFFFFFFu;
+	g.leaderName  = "X";
+	auto buf = BuildGuildListResponsePayload(0u, {g});
+	auto parsed = ParseGuildListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guilds.size() == 1u
+		&& parsed->guilds[0].name.size() == 200u
+		&& parsed->guilds[0].motd.size() == 500u
+		&& parsed->guilds[0].memberCount == 0xFFFFFFFFu,
+		"List accepts long name + uint32 max memberCount");
+}
+
+static void TestListResponsePacket()
+{
+	GuildSummary g;
+	g.guildId     = 42u;
+	g.name        = "Test";
+	g.motd        = "Hello";
+	g.memberCount = 3u;
+	g.leaderName  = "Boss";
+	auto pkt = BuildGuildListResponsePacket(0u, {g}, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "List packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"List PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGuildListResponse, "Opcode is ListResponse");
+	Assert(view.RequestId() == 999u, "List RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "List SessionId preserved");
+	auto parsed = ParseGuildListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->guilds.size() == 1u
+		&& parsed->guilds[0].guildId == 42u && parsed->guilds[0].leaderName == "Boss",
+		"List payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GUILD_MEMBERS
+// -----------------------------------------------------------------------------
+
+static void TestMembersRequestRoundTrip()
+{
+	auto buf = BuildGuildMembersRequestPayload(7u);
+	auto parsed = ParseGuildMembersRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guildId == 7u,
+		"Members request round-trip guildId=7");
+}
+
+static void TestMembersRequestRejectsShort()
+{
+	auto parsed = ParseGuildMembersRequestPayload(nullptr, 4u);
+	Assert(!parsed.has_value(), "Members request rejects nullptr");
+	uint8_t shortBuf[3]{};
+	auto parsed2 = ParseGuildMembersRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Members request rejects 3 bytes");
+}
+
+static void TestMembersResponseEmpty()
+{
+	auto buf = BuildGuildMembersResponsePayload(0u, {});
+	auto parsed = ParseGuildMembersResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->members.empty(),
+		"Members empty parses");
+}
+
+static void TestMembersResponseFour()
+{
+	std::vector<GuildMember> members;
+	GuildMember m1; m1.accountName = "Aragorn";  m1.rankId = 0u; m1.rankName = "Guild Master"; m1.online = true;  members.push_back(m1);
+	GuildMember m2; m2.accountName = "Legolas";  m2.rankId = 1u; m2.rankName = "Officer";       m2.online = true;  members.push_back(m2);
+	GuildMember m3; m3.accountName = "Gimli";    m3.rankId = 5u; m3.rankName = "Member";        m3.online = false; members.push_back(m3);
+	GuildMember m4; m4.accountName = "Frodo";    m4.rankId = 9u; m4.rankName = "Initiate";      m4.online = false; members.push_back(m4);
+	auto buf = BuildGuildMembersResponsePayload(0u, members);
+	auto parsed = ParseGuildMembersResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->members.size() == 4u, "Members 4 parses");
+	if (parsed && parsed->members.size() == 4u)
+	{
+		Assert(parsed->members[0].rankId == 0u && parsed->members[0].online == true,
+			"M[0] GM online");
+		Assert(parsed->members[2].rankId == 5u && parsed->members[2].online == false,
+			"M[2] Member offline");
+		Assert(parsed->members[3].accountName == "Frodo", "M[3] name");
+	}
+}
+
+static void TestMembersResponseUnknownGuild()
+{
+	auto buf = BuildGuildMembersResponsePayload(
+		static_cast<uint8_t>(GuildErrorCode::UnknownGuild), {});
+	auto parsed = ParseGuildMembersResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Members UnknownGuild");
+}
+
+static void TestMembersResponsePacket()
+{
+	std::vector<GuildMember> members;
+	GuildMember m; m.accountName = "Boss"; m.rankId = 0u; m.rankName = "GM"; m.online = true;
+	members.push_back(m);
+	auto pkt = BuildGuildMembersResponsePacket(0u, members, 1234u, 0xBEEFull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Members PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGuildMembersResponse, "Opcode is MembersResponse");
+	Assert(view.RequestId() == 1234u, "Members RequestId preserved");
+	auto parsed = ParseGuildMembersResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->members.size() == 1u
+		&& parsed->members[0].accountName == "Boss" && parsed->members[0].online == true,
+		"Members payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// GUILD_PERMISSIONS
+// -----------------------------------------------------------------------------
+
+static void TestPermissionsRequestRoundTrip()
+{
+	auto buf = BuildGuildPermissionsRequestPayload(2u);
+	auto parsed = ParseGuildPermissionsRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guildId == 2u,
+		"Permissions request round-trip guildId=2");
+}
+
+static void TestPermissionsResponseEmpty()
+{
+	auto buf = BuildGuildPermissionsResponsePayload(0u, {});
+	auto parsed = ParseGuildPermissionsResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->ranks.empty(),
+		"Permissions empty parses");
+}
+
+static void TestPermissionsResponseTenRanks()
+{
+	std::vector<GuildRankPerms> ranks;
+	for (uint8_t i = 0; i < 10u; ++i)
+	{
+		GuildRankPerms p;
+		p.rankId   = i;
+		p.rankName = "Rank";
+		p.mask     = (i == 0u) ? 0xFFFFFFFFu : (i == 9u) ? 0u : (1u << i);
+		ranks.push_back(p);
+	}
+	auto buf = BuildGuildPermissionsResponsePayload(0u, ranks);
+	auto parsed = ParseGuildPermissionsResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->ranks.size() == 10u, "Perms 10 ranks parses");
+	if (parsed && parsed->ranks.size() == 10u)
+	{
+		Assert(parsed->ranks[0].mask == 0xFFFFFFFFu, "Rank 0 mask all");
+		Assert(parsed->ranks[9].mask == 0u, "Rank 9 mask none");
+		Assert(parsed->ranks[5].mask == (1u << 5), "Rank 5 mask shift");
+	}
+}
+
+static void TestPermissionsResponseMaskMaxAndZero()
+{
+	GuildRankPerms p1; p1.rankId = 0u; p1.rankName = "All";  p1.mask = 0xFFFFFFFFu;
+	GuildRankPerms p2; p2.rankId = 9u; p2.rankName = "Zero"; p2.mask = 0u;
+	auto buf = BuildGuildPermissionsResponsePayload(0u, {p1, p2});
+	auto parsed = ParseGuildPermissionsResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->ranks.size() == 2u
+		&& parsed->ranks[0].mask == 0xFFFFFFFFu && parsed->ranks[1].mask == 0u,
+		"Perms accept mask 0 and 0xFFFFFFFF");
+}
+
+static void TestPermissionsResponsePacket()
+{
+	GuildRankPerms p; p.rankId = 0u; p.rankName = "GM"; p.mask = 0xFFFFFFFFu;
+	auto pkt = BuildGuildPermissionsResponsePacket(0u, {p}, 555u, 0xFEEDull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Perms PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGuildPermissionsResponse, "Opcode is PermsResponse");
+	Assert(view.RequestId() == 555u, "Perms RequestId preserved");
+}
+
+// -----------------------------------------------------------------------------
+// GUILD_BANK
+// -----------------------------------------------------------------------------
+
+static void TestBankRequestRoundTrip()
+{
+	auto buf = BuildGuildBankRequestPayload(3u, 0u);
+	auto parsed = ParseGuildBankRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guildId == 3u && parsed->tabIndex == 0u,
+		"Bank request round-trip guildId=3 tab=0");
+}
+
+static void TestBankRequestRejectsShort()
+{
+	auto parsed = ParseGuildBankRequestPayload(nullptr, 5u);
+	Assert(!parsed.has_value(), "Bank request rejects nullptr");
+	uint8_t shortBuf[4]{};
+	auto parsed2 = ParseGuildBankRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Bank request rejects 4 bytes");
+}
+
+static void TestBankResponseEmpty()
+{
+	auto buf = BuildGuildBankResponsePayload(0u, {});
+	auto parsed = ParseGuildBankResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->items.empty(),
+		"Bank empty parses");
+}
+
+static void TestBankResponseFiveItems()
+{
+	std::vector<GuildBankItem> items;
+	GuildBankItem it1; it1.slotIndex = 0u; it1.itemName = "Iron Ore";       it1.count = 100u; items.push_back(it1);
+	GuildBankItem it2; it2.slotIndex = 1u; it2.itemName = "Linen Cloth";    it2.count = 250u; items.push_back(it2);
+	GuildBankItem it3; it3.slotIndex = 2u; it3.itemName = "Mageweave";      it3.count = 80u;  items.push_back(it3);
+	GuildBankItem it4; it4.slotIndex = 3u; it4.itemName = "Health Potion";  it4.count = 30u;  items.push_back(it4);
+	GuildBankItem it5; it5.slotIndex = 4u; it5.itemName = "Mana Potion";    it5.count = 20u;  items.push_back(it5);
+	auto buf = BuildGuildBankResponsePayload(0u, items);
+	auto parsed = ParseGuildBankResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->items.size() == 5u, "Bank 5 items parses");
+	if (parsed && parsed->items.size() == 5u)
+	{
+		Assert(parsed->items[0].itemName == "Iron Ore" && parsed->items[0].count == 100u,
+			"Bank[0] Iron Ore x100");
+		Assert(parsed->items[4].itemName == "Mana Potion" && parsed->items[4].count == 20u,
+			"Bank[4] Mana Potion x20");
+	}
+}
+
+static void TestBankResponseNoPermission()
+{
+	auto buf = BuildGuildBankResponsePayload(
+		static_cast<uint8_t>(GuildErrorCode::NoPermission), {});
+	auto parsed = ParseGuildBankResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "Bank NoPermission");
+}
+
+static void TestBankResponsePacket()
+{
+	GuildBankItem it; it.slotIndex = 9u; it.itemName = "Foo"; it.count = 7u;
+	auto pkt = BuildGuildBankResponsePacket(0u, {it}, 42u, 0x12345ull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Bank PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGuildBankResponse, "Opcode is BankResponse");
+}
+
+// -----------------------------------------------------------------------------
+// GUILD_MOTD_UPDATE_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestMotdNotifRoundTrip()
+{
+	auto buf = BuildGuildMotdUpdateNotificationPayload(1u, "Nouveau MOTD");
+	auto parsed = ParseGuildMotdUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "MotdUpdate parses");
+	if (parsed)
+	{
+		Assert(parsed->guildId == 1u, "MotdUpdate guildId");
+		Assert(parsed->newMotd == "Nouveau MOTD", "MotdUpdate text");
+	}
+}
+
+static void TestMotdNotifEmptyMotd()
+{
+	auto buf = BuildGuildMotdUpdateNotificationPayload(99u, "");
+	auto parsed = ParseGuildMotdUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->guildId == 99u && parsed->newMotd.empty(),
+		"MotdUpdate accepts empty motd");
+}
+
+static void TestMotdNotifLongMotd()
+{
+	const std::string longMotd(1000u, 'M');
+	auto buf = BuildGuildMotdUpdateNotificationPayload(7u, longMotd);
+	auto parsed = ParseGuildMotdUpdateNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->newMotd.size() == 1000u,
+		"MotdUpdate accepts long motd 1000 chars");
+}
+
+static void TestMotdNotifRejectsShort()
+{
+	auto parsed = ParseGuildMotdUpdateNotificationPayload(nullptr, 6u);
+	Assert(!parsed.has_value(), "MotdUpdate rejects nullptr");
+	uint8_t shortBuf[5]{};
+	auto parsed2 = ParseGuildMotdUpdateNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "MotdUpdate rejects 5 bytes");
+}
+
+static void TestMotdNotifPacket()
+{
+	auto pkt = BuildGuildMotdUpdateNotificationPacket(2u, "L'Ombre Update", 0xFADEull);
+	Assert(!pkt.empty(), "MotdUpdate packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"MotdUpdate PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeGuildMotdUpdateNotification, "Opcode is MotdUpdate");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xFADEull, "MotdUpdate SessionId preserved");
+	auto parsed = ParseGuildMotdUpdateNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->guildId == 2u
+		&& parsed->newMotd == "L'Ombre Update",
+		"MotdUpdate payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestRoundTrip();
+	TestListResponseEmpty();
+	TestListResponseSingleGuild();
+	TestListResponseTwoGuilds();
+	TestListResponseUnauthorized();
+	TestListResponseRejectsShort();
+	TestListResponseEmptyMotd();
+	TestListResponseLongName();
+	TestListResponsePacket();
+
+	TestMembersRequestRoundTrip();
+	TestMembersRequestRejectsShort();
+	TestMembersResponseEmpty();
+	TestMembersResponseFour();
+	TestMembersResponseUnknownGuild();
+	TestMembersResponsePacket();
+
+	TestPermissionsRequestRoundTrip();
+	TestPermissionsResponseEmpty();
+	TestPermissionsResponseTenRanks();
+	TestPermissionsResponseMaskMaxAndZero();
+	TestPermissionsResponsePacket();
+
+	TestBankRequestRoundTrip();
+	TestBankRequestRejectsShort();
+	TestBankResponseEmpty();
+	TestBankResponseFiveItems();
+	TestBankResponseNoPermission();
+	TestBankResponsePacket();
+
+	TestMotdNotifRoundTrip();
+	TestMotdNotifEmptyMotd();
+	TestMotdNotifLongMotd();
+	TestMotdNotifRejectsShort();
+	TestMotdNotifPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all guild payload tests passed\n"
+	                                : "[FAIL] some guild tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -660,4 +660,41 @@ namespace engine::network
 	constexpr uint16_t kOpcodeGameEventUnsubscribeRequest      = 161u; ///< Client to Master : se desabonne (vide).
 	constexpr uint16_t kOpcodeGameEventUnsubscribeResponse     = 162u; ///< Master to Client : OK ou NotSubscribed / Unauthorized.
 	constexpr uint16_t kOpcodeGameEventStateChangeNotification = 163u; ///< Master to Client (push, request_id=0) : changement etat event (eventId, newState, untilTsMs).
+
+	// =====================================================================
+	// CMANGOS.21 step 3+4 — Guilds wire (guild list, members, bank, permissions
+	// par rang). Master tient en memoire un registry guildes (V1 seed hardcode
+	// 2 guildes + GuildPermissionMatrix WoW defaults).
+	//
+	// Architecture : 2 guildes seedees au boot (Les Gardiens + L'Ombre) avec
+	// leurs membres, bank tab 0 et permissions par rang. Le master tient en
+	// memoire un std::vector<InMemoryGuild> et la matrice de permissions
+	// (cf. GuildPermissionMatrix). V1 simplifie : pas de filtrage par account
+	// membership (n'importe quel client logged-in peut consulter n'importe
+	// quelle guilde) ; vraie ACL via la matrice viendra plus tard.
+	//
+	// V1 limitations :
+	//   - 2 guildes hardcodees (Les Gardiens, L'Ombre). Future PR : DB seed
+	//     via MysqlGuildStore + creation in-game via /guild create.
+	//   - Pas de filtrage par account membership (lecture seule globale V1).
+	//   - Bank tab 0 only (V1). Future PR : multi-onglets.
+	//   - Pas de modification client (Invite/Remove/Promote/Demote V1 read-only).
+	//   - Pas de SyncGuilds RPC entre master et shardd (master autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - List         (164/165) : liste des guildes (summary).
+	//   - Members      (166/167) : liste des membres d'une guilde.
+	//   - Permissions  (168/169) : matrice mask par rang.
+	//   - Bank         (170/171) : contenu de la bank tab 0.
+	//   - MotdUpdate   (172, push, request_id=0) : changement de MOTD.
+	// =====================================================================
+	constexpr uint16_t kOpcodeGuildListRequest            = 164u; ///< Client to Master : liste des guildes (vide).
+	constexpr uint16_t kOpcodeGuildListResponse           = 165u; ///< Master to Client : liste {guildId, name, motd, memberCount, leaderName} ou Unauthorized.
+	constexpr uint16_t kOpcodeGuildMembersRequest         = 166u; ///< Client to Master : liste des membres d'une guilde (guildId).
+	constexpr uint16_t kOpcodeGuildMembersResponse        = 167u; ///< Master to Client : liste {accountName, rankId, rankName, online} ou UnknownGuild / Unauthorized.
+	constexpr uint16_t kOpcodeGuildPermissionsRequest     = 168u; ///< Client to Master : matrice permissions (guildId).
+	constexpr uint16_t kOpcodeGuildPermissionsResponse    = 169u; ///< Master to Client : liste {rankId, rankName, mask} ou UnknownGuild / Unauthorized.
+	constexpr uint16_t kOpcodeGuildBankRequest            = 170u; ///< Client to Master : contenu bank d'une guilde (guildId, tabIndex).
+	constexpr uint16_t kOpcodeGuildBankResponse           = 171u; ///< Master to Client : liste {slotIndex, itemName, count} ou UnknownGuild / NoPermission / Unauthorized.
+	constexpr uint16_t kOpcodeGuildMotdUpdateNotification = 172u; ///< Master to Client (push, request_id=0) : changement MOTD (guildId, newMotd).
 }

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -38,6 +38,7 @@ namespace engine::platform
 		S = 'S',
 		D = 'D',
 		E = 'E',
+		U = 'U',
 		X = 'X',
 		Y = 'Y',
 		Z = 'Z',


### PR DESCRIPTION
## CMANGOS.21 step 3+4 : Guilds wire (list / members / permissions / bank + UI panel)

Branche `GuildPermissionMatrix` (step 1+2 merge — bitmask Permission + RankPerms WoW defaults) sur le wire guild list/members/permissions/bank + UI panel multi-tab client.
Master tient en mémoire un registry de guildes (V1 seed 2 guildes hardcodées avec membres + bank + permissions WoW defaults).

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 9 opcodes (164-172)
  - `164/165` GuildList Request/Response
  - `166/167` GuildMembers Request/Response
  - `168/169` GuildPermissions Request/Response
  - `170/171` GuildBank Request/Response (tab 0 V1)
  - `172` GuildMotdUpdateNotification (push)
- `src/shared/network/GuildPayloads.{h,cpp,Tests.cpp}` : 31 tests round-trip + edge cases
- `src/masterd/handlers/guild/GuildHandler.{h,cpp}` :
  - 2 guildes seed : `Les Gardiens` (Aragorn/Legolas/Gimli/Frodo + bank 5 items) + `L'Ombre` (Saruman/Wormtongue + bank 2 items)
  - `RankName` helper (10 ranks 0-9 : Guild Master → Initiate)
  - `GuildPermissionMatrix::SetupWowDefaults` appliqué aux 2 guildes
  - `PushMotdUpdate` helper public
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 164/166/168/170 + ajout `&guildHandler` dans capture-list lambda
- `src/shardd/guild/GuildPermissionMatrix.h` : ajout additif `GetMask(g, r)` + `HasGuild(g)` getters

### Client integration
- `src/client/guild/GuildUi.{h,cpp}` : presenter + state, helper `ExpandPermissionMask` (mask → ["Invite", "Remove", ...])
- `src/client/render/GuildImGuiRenderer.{h,cpp}` : panel multi-tab Members / Permissions / Bank / MOTD + toast 5s sur changement MOTD
- `src/client/app/Engine` : dispatch + slash `/guild` (alias `/guilds`) + touche `U` toggle (`Key::U` ajouté à Input.h)
- `CMakeLists.txt` : sources + `guild_payloads_tests` target

### V1 limitations (consignées)
- 2 guildes hardcodées. Future PR : DB seed via MysqlGuildStore + création in-game `/guild create`.
- Pas de filtrage par account membership (n'importe quel client peut voir toute guilde V1). Vrai access control via permission gating futur.
- Bank tab 0 only. Future PR : multi-onglets.
- Lecture seule V1 (pas de Invite/Remove/Promote/Demote modifications côté client).
- Pas de SyncGuilds RPC entre master et shardd (master autoritaire V1).

### Tests
- `guild_payloads_tests` (31 tests : round-trip, headers, masks 0/0xFFFFFFFF, errors UnknownGuild/NoPermission/Unauthorized) — voir `src/shared/network/GuildPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 164-172 + handler GuildHandler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
