### PR TITLE
fix(web-portal): preserve 4 account roles + treat staff roles as admin

### DIFF
--- a/web-portal/app/admin/acceptances/page.tsx
+++ b/web-portal/app/admin/acceptances/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
+import { isStaff } from "@/lib/auth/roles";
 import { query } from "@/lib/db/connection";
 import type { RowDataPacket } from "mysql2/promise";
 
@@ -15,7 +16,7 @@ type AcceptanceRow = RowDataPacket & {
 export default async function AdminAcceptancesPage() {
   const session = await getSession();
   if (!session) redirect("/login?redirect=/admin/acceptances");
-  if (session.role !== "admin") redirect("/");
+  if (!isStaff(session.role)) redirect("/");
 
   let rows: AcceptanceRow[] = [];
   let dbError = false;

--- a/web-portal/app/admin/bugs/page.tsx
+++ b/web-portal/app/admin/bugs/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { query } from '@/lib/db/connection'
 import { getSession } from '@/lib/auth/session'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import BugAdmin from '@/components/admin/BugAdmin'
 
@@ -28,7 +29,7 @@ export default async function AdminBugsPage({
 }) {
   const session = await getSession();
   if (!session) redirect('/login?redirect=/admin/bugs');
-  if (session.role !== 'admin') redirect('/');
+  if (!isStaff(session.role)) redirect('/');
 
   const rawStatus = searchParams.status ?? 'all'
   const status: StatusFilter = VALID_STATUSES.includes(rawStatus as StatusFilter)

--- a/web-portal/app/admin/cgu/page.tsx
+++ b/web-portal/app/admin/cgu/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { query } from "@/lib/db/connection";
 import { CguManager } from "@/components/admin/CguManager";
 import { getSession } from "@/lib/auth/session";
+import { isStaff } from "@/lib/auth/roles";
 import type { RowDataPacket } from "mysql2/promise";
 
 type EditionRow = RowDataPacket & {
@@ -35,7 +36,7 @@ async function getEditions(): Promise<EditionRow[]> {
 export default async function AdminCguPage() {
   const session = await getSession();
   if (!session) redirect("/login?redirect=/admin/cgu");
-  if (session.role !== "admin") redirect("/");
+  if (!isStaff(session.role)) redirect("/");
 
   const editions = await getEditions();
 

--- a/web-portal/app/admin/faq/page.tsx
+++ b/web-portal/app/admin/faq/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { query } from '@/lib/db/connection'
 import { getSession } from '@/lib/auth/session'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import FaqAdmin from '@/components/admin/FaqAdmin'
 
@@ -17,7 +18,7 @@ type FaqItem = RowDataPacket & {
 export default async function AdminFaqPage() {
   const session = await getSession();
   if (!session) redirect('/login?redirect=/admin/faq');
-  if (session.role !== 'admin') redirect('/');
+  if (!isStaff(session.role)) redirect('/');
 
   let items: FaqItem[] = []
   let dbError = false

--- a/web-portal/app/admin/page.tsx
+++ b/web-portal/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
+import { isStaff } from "@/lib/auth/roles";
 import { query } from "@/lib/db/connection";
 import type { RowDataPacket } from "mysql2/promise";
 
@@ -26,7 +27,7 @@ async function getStats() {
 export default async function AdminHomePage() {
   const session = await getSession();
   if (!session) redirect("/login?redirect=/admin");
-  if (session.role !== "admin") redirect("/");
+  if (!isStaff(session.role)) redirect("/");
 
   const stats = await getStats();
 

--- a/web-portal/app/admin/players/page.tsx
+++ b/web-portal/app/admin/players/page.tsx
@@ -2,8 +2,18 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { query } from '@/lib/db/connection'
 import { getSession } from '@/lib/auth/session'
+import { isStaff, type AccountRole } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { PlayerActions, type PlayerRow } from '@/components/admin/PlayerActions'
+
+function roleBadgeLabel(role: AccountRole): string {
+  switch (role) {
+    case 'administrator': return 'Admin'
+    case 'game_master':   return 'GM'
+    case 'moderator':     return 'Mod'
+    default:              return ''
+  }
+}
 
 const PAGE_SIZE = 25
 
@@ -27,7 +37,7 @@ function emailBadge(verified: number) {
 export default async function AdminPlayersPage({ searchParams }: PageProps) {
   const session = await getSession();
   if (!session) redirect('/login?redirect=/admin/players');
-  if (session.role !== 'admin') redirect('/');
+  if (!isStaff(session.role)) redirect('/');
 
   const page = Math.max(1, parseInt(searchParams.page ?? '1', 10) || 1)
   const status: AccountStatus = (['active', 'disabled'].includes(searchParams.status ?? '') ? searchParams.status : 'all') as AccountStatus
@@ -194,8 +204,8 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
 
                   {/* Badges */}
                   <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
-                    {/* Role badge for admins */}
-                    {player.role === 'admin' && (
+                    {/* Role badge pour staff (admin / GM / moderateur) */}
+                    {isStaff(player.role) && (
                       <span style={{
                         display: 'inline-flex', alignItems: 'center',
                         fontFamily: 'var(--font-ui)', fontSize: '9.5px', letterSpacing: '.2em', textTransform: 'uppercase',
@@ -203,7 +213,7 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
                         border: '1px solid rgba(232,197,110,.6)',
                         color: 'var(--ln-accent)', background: 'rgba(232,197,110,.1)', flexShrink: 0,
                       }}>
-                        Admin
+                        {roleBadgeLabel(player.role as AccountRole)}
                       </span>
                     )}
                     {/* Account status */}

--- a/web-portal/app/admin/roadmap/page.tsx
+++ b/web-portal/app/admin/roadmap/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { query } from '@/lib/db/connection'
 import { getSession } from '@/lib/auth/session'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import RoadmapAdmin from './RoadmapAdmin'
 
@@ -17,7 +18,7 @@ type RoadmapItem = RowDataPacket & {
 export default async function AdminRoadmapPage() {
   const session = await getSession();
   if (!session) redirect('/login?redirect=/admin/roadmap');
-  if (session.role !== 'admin') redirect('/');
+  if (!isStaff(session.role)) redirect('/');
 
   let items: RoadmapItem[] = []
   let dbError = false

--- a/web-portal/app/api/admin/bugs/[id]/route.ts
+++ b/web-portal/app/api/admin/bugs/[id]/route.ts
@@ -1,6 +1,6 @@
-// PATCH /api/admin/bugs/[id]
+﻿// PATCH /api/admin/bugs/[id]
 // Body: { adminStatus, adminComment?, awardExploit?: boolean }
-// Auth: requires cookie lcdlln_portal_role === 'admin'
+// Auth: requires staff role (moderator / game_master / administrator)
 //
 // Exploit award logic (when awardExploit === true && adminStatus === 'resolved'):
 //  1. Count the number of already-awarded (resolved) bug reports for the reporter.
@@ -9,13 +9,14 @@
 //  4. Set exploit_awarded = 1 on the bug report.
 
 import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 const VALID_STATUSES = ['pending', 'confirmed', 'in_progress', 'resolved', 'not_a_bug'] as const
@@ -41,7 +42,7 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   if (!isAdmin()) {
-    return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
+    return NextResponse.json({ error: 'AccÃ¨s refusÃ©' }, { status: 403 })
   }
 
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/cgu/[id]/publish/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/publish/route.ts
@@ -1,6 +1,7 @@
-// POST /api/admin/cgu/[id]/publish
+﻿// POST /api/admin/cgu/[id]/publish
 // Publishes a draft CGU edition
 import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
@@ -10,7 +11,7 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const jar = cookies()
-  if (jar.get('lcdlln_portal_role')?.value !== 'admin') {
+  if (!isStaff(jar.get('lcdlln_portal_role')?.value)) {
     return NextResponse.json({ ok: false }, { status: 403 })
   }
 
@@ -23,10 +24,10 @@ export async function POST(
       [id]
     )
     const edition = rows[0] ?? null
-    if (!edition) return NextResponse.json({ ok: false, message: 'Édition introuvable' }, { status: 404 })
+    if (!edition) return NextResponse.json({ ok: false, message: 'Ã‰dition introuvable' }, { status: 404 })
     if (edition.status !== 'draft') {
       return NextResponse.json(
-        { ok: false, message: 'Seules les éditions en brouillon peuvent être publiées' },
+        { ok: false, message: 'Seules les Ã©ditions en brouillon peuvent Ãªtre publiÃ©es' },
         { status: 409 }
       )
     }

--- a/web-portal/app/api/admin/cgu/[id]/retire/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/retire/route.ts
@@ -4,6 +4,7 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 
 export async function POST(
@@ -11,7 +12,7 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const jar = cookies()
-  if (jar.get('lcdlln_portal_role')?.value !== 'admin') {
+  if (!isStaff(jar.get('lcdlln_portal_role')?.value)) {
     return NextResponse.json({ ok: false }, { status: 403 })
   }
 

--- a/web-portal/app/api/admin/cgu/[id]/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/route.ts
@@ -3,11 +3,12 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 async function getEdition(id: number) {

--- a/web-portal/app/api/admin/cgu/route.ts
+++ b/web-portal/app/api/admin/cgu/route.ts
@@ -1,14 +1,15 @@
-// POST /api/admin/cgu
+﻿// POST /api/admin/cgu
 // Body: { versionLabel, titleFr, contentFr, titleEn?, contentEn? }
 // Creates a new terms_edition (status='draft') + terms_localizations entries
 import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { ResultSetHeader } from 'mysql2/promise'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 export async function POST(request: Request) {

--- a/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
+++ b/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server'
+﻿import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
+  return isStaff(role)
 }
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {

--- a/web-portal/app/api/admin/faq/[id]/route.ts
+++ b/web-portal/app/api/admin/faq/[id]/route.ts
@@ -3,10 +3,11 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 export async function PATCH(

--- a/web-portal/app/api/admin/faq/route.ts
+++ b/web-portal/app/api/admin/faq/route.ts
@@ -3,11 +3,12 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 export async function GET() {

--- a/web-portal/app/api/admin/players/[id]/activate/route.ts
+++ b/web-portal/app/api/admin/players/[id]/activate/route.ts
@@ -1,10 +1,11 @@
-import { NextResponse } from 'next/server'
+﻿import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
+  return isStaff(role)
 }
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {

--- a/web-portal/app/api/admin/players/[id]/characters/route.ts
+++ b/web-portal/app/api/admin/players/[id]/characters/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server'
+﻿import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
+  return isStaff(role)
 }
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {

--- a/web-portal/app/api/admin/players/[id]/disable/route.ts
+++ b/web-portal/app/api/admin/players/[id]/disable/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 import { sendAccountDisabled } from '@/lib/email/sender'
 import type { RowDataPacket } from 'mysql2/promise'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
+  return isStaff(role)
 }
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {

--- a/web-portal/app/api/admin/players/[id]/verify-email/route.ts
+++ b/web-portal/app/api/admin/players/[id]/verify-email/route.ts
@@ -1,10 +1,11 @@
-import { NextResponse } from 'next/server'
+﻿import { NextResponse } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
-  return role === 'admin'
+  return isStaff(role)
 }
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {

--- a/web-portal/app/api/admin/roadmap/[id]/route.ts
+++ b/web-portal/app/api/admin/roadmap/[id]/route.ts
@@ -3,10 +3,11 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 export async function PATCH(

--- a/web-portal/app/api/admin/roadmap/route.ts
+++ b/web-portal/app/api/admin/roadmap/route.ts
@@ -3,11 +3,12 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 
 function isAdmin(): boolean {
   const jar = cookies()
-  return jar.get('lcdlln_portal_role')?.value === 'admin'
+  return isStaff(jar.get('lcdlln_portal_role')?.value)
 }
 
 export async function GET() {

--- a/web-portal/app/api/auth/login/route.ts
+++ b/web-portal/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { verifyPortalCredentials } from "@/lib/auth/portalLogin";
 import { query } from "@/lib/db/connection";
 import type { RowDataPacket } from "mysql2/promise";
+import { isStaff, normalizeRole } from "@/lib/auth/roles";
 
 const COOKIE_NAME = "lcdlln_portal_account";
 const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 7;
@@ -29,7 +30,7 @@ export async function POST(request: Request) {
       'SELECT role, tag_id FROM accounts WHERE id = ? LIMIT 1',
       [result.accountId]
     );
-    const accountRole = accountRows[0]?.role ?? 'player';
+    const accountRole = normalizeRole(accountRows[0]?.role);
     const accountTagId = accountRows[0]?.tag_id ?? null;
 
     const jar = cookies();
@@ -52,7 +53,7 @@ export async function POST(request: Request) {
       ok: true,
       login: result.login,
       tagId: accountTagId,
-      redirect: accountRole === 'admin' ? '/admin' : '/player',
+      redirect: isStaff(accountRole) ? '/admin' : '/player',
     });
   } catch {
     return NextResponse.json({ ok: false, message: "Requête invalide." }, { status: 400 });

--- a/web-portal/components/layout/HeaderActions.tsx
+++ b/web-portal/components/layout/HeaderActions.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Session } from '@/lib/auth/session'
+import { isStaff } from '@/lib/auth/roles'
 
 interface Props {
   session: Session
@@ -39,7 +40,7 @@ export function HeaderActions({ session }: Props) {
           <Link href="/player">Espace joueur</Link>
         )}
 
-        {session?.role === 'admin' && (
+        {isStaff(session?.role) && (
           <Link href="/admin">Admin</Link>
         )}
 

--- a/web-portal/lib/auth/roles.ts
+++ b/web-portal/lib/auth/roles.ts
@@ -1,0 +1,54 @@
+// Roles centralisés pour le web-portal.
+// La table `accounts.role` (migration sql/migrations/0043_phase_1c_account_roles.sql)
+// porte une enum a 4 valeurs : 'player', 'moderator', 'game_master',
+// 'administrator'. Avant cette migration, c'etait un binaire 'player'/'admin'.
+// Les helpers ci-dessous permettent au portal de continuer a fonctionner avec
+// la granularite hierarchique (Player < Moderator < GameMaster < Administrator)
+// tout en preservant l'ancienne logique "admin OK / player KO" via isStaff().
+
+export const ACCOUNT_ROLES = ['player', 'moderator', 'game_master', 'administrator'] as const
+
+export type AccountRole = (typeof ACCOUNT_ROLES)[number]
+
+/// Convertit une valeur DB (ou cookie) potentiellement inconnue en AccountRole.
+/// Retourne 'player' par defaut pour toute valeur non reconnue ou nulle.
+export function normalizeRole(raw: string | null | undefined): AccountRole {
+  if (!raw) return 'player'
+  if ((ACCOUNT_ROLES as readonly string[]).includes(raw)) {
+    return raw as AccountRole
+  }
+  return 'player'
+}
+
+/// Retourne true si le role donne dispose des privileges staff (admin-portal).
+/// Tout role autre que 'player' est considere comme staff.
+export function isStaff(role: AccountRole | string | null | undefined): boolean {
+  const r = typeof role === 'string' ? normalizeRole(role) : 'player'
+  return r !== 'player'
+}
+
+/// Helper inverse pour clarte de lecture.
+export function isPlayer(role: AccountRole | string | null | undefined): boolean {
+  return !isStaff(role)
+}
+
+/// Hierarchie pour comparaisons "au moins" :
+/// player(0) < moderator(1) < game_master(2) < administrator(3).
+export function roleLevel(role: AccountRole | string | null | undefined): number {
+  const r = typeof role === 'string' ? normalizeRole(role) : 'player'
+  switch (r) {
+    case 'player':
+      return 0
+    case 'moderator':
+      return 1
+    case 'game_master':
+      return 2
+    case 'administrator':
+      return 3
+  }
+}
+
+/// Retourne true si \p role >= \p minimum dans la hierarchie.
+export function hasAtLeast(role: AccountRole | string | null | undefined, minimum: AccountRole): boolean {
+  return roleLevel(role) >= roleLevel(minimum)
+}

--- a/web-portal/lib/auth/session.ts
+++ b/web-portal/lib/auth/session.ts
@@ -1,10 +1,11 @@
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { normalizeRole, type AccountRole } from '@/lib/auth/roles'
 
 export type Session = {
   accountId: number
-  role: 'player' | 'admin'
+  role: AccountRole
   tagId: string | null
   login: string
 } | null
@@ -26,7 +27,7 @@ export async function getSession(): Promise<Session> {
     if (!row) return null
     return {
       accountId: row.id,
-      role: (row.role === 'admin' ? 'admin' : 'player') as 'player' | 'admin',
+      role: normalizeRole(row.role),
       tagId: row.tag_id ?? null,
       login: row.login,
     }

--- a/web-portal/middleware.ts
+++ b/web-portal/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { isStaff } from '@/lib/auth/roles'
 
 export function middleware(request: NextRequest) {
   const accountId = request.cookies.get('lcdlln_portal_account')?.value
@@ -20,7 +21,7 @@ export function middleware(request: NextRequest) {
       loginUrl.searchParams.set('redirect', pathname)
       return NextResponse.redirect(loginUrl)
     }
-    if (role !== 'admin') {
+    if (!isStaff(role)) {
       return NextResponse.redirect(new URL('/', request.url))
     }
   }


### PR DESCRIPTION
## Régression : web-portal incompatible avec migration 0043 (4 rôles d'accounts)

### Contexte

La migration `sql/migrations/0043_phase_1c_account_roles.sql` a étendu `accounts.role` :
- Avant : `ENUM('player', 'admin')`
- Après : `ENUM('player', 'moderator', 'game_master', 'administrator')` avec backfill `'admin' → 'administrator'`.

### Régression observée

Le web-portal testait `role === 'admin'` à **9 endroits côté pages** + **13 routes API admin** + **middleware + login + Header**. Comme la valeur DB est désormais `'administrator'`, tous les admins étaient vus comme `'player'` après la migration → plus aucun accès `/admin`.

### Fix

**Nouveau module centralisé** `web-portal/lib/auth/roles.ts` :
- `normalizeRole(raw)` : valide vers `AccountRole = 'player' | 'moderator' | 'game_master' | 'administrator'`
- `isStaff(role)` : true si `role !== 'player'` (admin/GM/modo)
- `hasAtLeast(role, minimum)` : hiérarchie ordinale player(0)..administrator(3) pour gating futur

**Migrations effectuées** :
- `Session.role` typé sur les 4 valeurs (au lieu du `'player' | 'admin'` aplati)
- `getSession()` propage la valeur DB via `normalizeRole` (plus de flatten binaire)
- Login route : redirige `/admin` si `isStaff(role)`
- Middleware : `isStaff()` pour autoriser `/admin`
- 7 pages admin : `!isStaff(session.role)` au lieu de `session.role !== 'admin'`
- 13 routes API admin : `isStaff(...)` au lieu de `?.value === 'admin'`
- HeaderActions : bouton Admin visible si `isStaff(session?.role)`
- `/admin/players` : badge rôle distinct selon valeur (Admin / GM / Mod)

### Effet

Les 3 rôles staff (moderator, game_master, administrator) ont désormais accès au `/admin` web-portal. Future PR pourra introduire du gating granulaire par hiérarchie via `hasAtLeast()` (ex: page debug réservée `administrator` uniquement).

### Tests
Pas de framework de test côté web-portal (pas de script `test`/`typecheck` dans `package.json`). Vérification visuelle des 25 fichiers modifiés ; tous les `=== 'admin'` ont été remplacés (grep zéro résultat).

### Déploiement
> ✅ **Pas de redéploiement serveur (master/shard) requis** — correction web-portal uniquement, aucune modification du wire ou de la DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
