### PR TITLE
feat(auction): wire list + post + bid + expired + UI panel client (CMANGOS.09)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ add_library(engine_core
   src/client/weather/WeatherUi.cpp
   src/client/events/GameEventUi.cpp
   src/client/guild/GuildUi.cpp
+  src/client/auction/AuctionUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -351,6 +352,7 @@ add_library(engine_core
   src/client/render/WeatherImGuiRenderer.cpp
   src/client/render/GameEventImGuiRenderer.cpp
   src/client/render/GuildImGuiRenderer.cpp
+  src/client/render/AuctionImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -453,6 +455,7 @@ add_library(engine_core
   src/shared/network/WeatherPayloads.cpp
   src/shared/network/GameEventPayloads.cpp
   src/shared/network/GuildPayloads.cpp
+  src/shared/network/AuctionPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -733,6 +736,11 @@ add_test(NAME gameevent_payloads_tests COMMAND gameevent_payloads_tests)
 add_executable(guild_payloads_tests src/shared/network/GuildPayloadsTests.cpp)
 target_link_libraries(guild_payloads_tests PRIVATE engine_core)
 add_test(NAME guild_payloads_tests COMMAND guild_payloads_tests)
+
+# CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Auction payloads round-trip tests (no DB / no network).
+add_executable(auction_payloads_tests src/shared/network/AuctionPayloadsTests.cpp)
+target_link_libraries(auction_payloads_tests PRIVATE engine_core)
+add_test(NAME auction_payloads_tests COMMAND auction_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/weather/WeatherHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/events/GameEventHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/guild/GuildHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -143,6 +144,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/WeatherPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GameEventPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GuildPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -19,6 +19,7 @@
 #include "src/shared/network/WeatherPayloads.h"
 #include "src/shared/network/GameEventPayloads.h"
 #include "src/shared/network/GuildPayloads.h"
+#include "src/shared/network/AuctionPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -36,6 +37,7 @@
 #include "src/client/render/WeatherImGuiRenderer.h"
 #include "src/client/render/GameEventImGuiRenderer.h"
 #include "src/client/render/GuildImGuiRenderer.h"
+#include "src/client/render/AuctionImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -1025,6 +1027,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Init du presenter
+		// Hotel des Ventes + cable du send callback pour les requetes
+		// 173/175/177/179. Reception dispatchee dans le push handler ci-dessous
+		// (responses 174/176/178/180 + push 181 AuctionExpired).
+		if (!m_auctionHouseUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] AuctionHousePresenter init FAILED — panneau Hotel des Ventes desactive");
+		}
+		else
+		{
+			m_auctionHouseUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1260,6 +1277,23 @@ namespace engine
 					m_guildUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] /guild toggle (visible={})", m_guildVisible);
+				return true;
+			}
+			// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Slash command /ah
+			// pour ouvrir/fermer le panneau Hotel des Ventes et synchroniser
+			// la liste des encheres depuis le master au moment de l'ouverture.
+			// La touche H fait la meme chose (cf. boucle input dans BeginFrame).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/ah" || text == "/auction"
+				    || text.starts_with("/ah ") || text.starts_with("/ah\t")
+				    || text.starts_with("/auction ") || text.starts_with("/auction\t")))
+			{
+				m_auctionHouseVisible = !m_auctionHouseVisible;
+				if (m_auctionHouseVisible)
+				{
+					m_auctionHouseUi.RequestList(0u);
+				}
+				LOG_INFO(Core, "[Engine] /ah toggle (visible={})", m_auctionHouseVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -1981,6 +2015,64 @@ namespace engine
 					return;
 				}
 				m_guildUi.OnMotdUpdateNotification(*parsed);
+				return;
+			}
+			// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Dispatch des
+			// reponses Auction (174/176/178/180) + push notification 181
+			// (AuctionExpired).
+			case kOpcodeAuctionListResponse:
+			{
+				auto parsed = ParseAuctionListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] AUCTION_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_auctionHouseUi.OnListResponse(*parsed);
+				return;
+			}
+			case kOpcodeAuctionPostResponse:
+			{
+				auto parsed = ParseAuctionPostResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] AUCTION_POST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_auctionHouseUi.OnPostResponse(*parsed);
+				return;
+			}
+			case kOpcodeAuctionBidResponse:
+			{
+				auto parsed = ParseAuctionBidResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] AUCTION_BID_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_auctionHouseUi.OnBidResponse(*parsed);
+				return;
+			}
+			case kOpcodeAuctionCancelResponse:
+			{
+				auto parsed = ParseAuctionCancelResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] AUCTION_CANCEL_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_auctionHouseUi.OnCancelResponse(*parsed);
+				return;
+			}
+			case kOpcodeAuctionExpiredNotification:
+			{
+				auto parsed = ParseAuctionExpiredNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] AUCTION_EXPIRED_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_auctionHouseUi.OnExpiredNotification(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -4288,6 +4380,7 @@ namespace engine
 		m_weatherUi.Shutdown();
 		m_gameEventUi.Shutdown();
 		m_guildUi.Shutdown();
+		m_auctionHouseUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -4475,6 +4568,20 @@ namespace engine
 					m_guildUi.RequestList();
 				}
 				LOG_INFO(Core, "[Engine] U toggle guilds (visible={})", m_guildVisible);
+			}
+			// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Touche H : toggle
+			// panneau Hotel des Ventes + RequestList si on l'ouvre. Memes
+			// guards que U. Pas de conflit Ctrl+H.
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::H))
+			{
+				m_auctionHouseVisible = !m_auctionHouseVisible;
+				if (m_auctionHouseVisible)
+				{
+					m_auctionHouseUi.RequestList(0u);
+				}
+				LOG_INFO(Core, "[Engine] H toggle auction house (visible={})", m_auctionHouseVisible);
 			}
 		}
 
@@ -4705,6 +4812,13 @@ namespace engine
 				// sur dernier MotdUpdate reçu est rendu independamment du flag.
 				m_guildImGui = std::make_unique<engine::render::GuildImGuiRenderer>();
 				m_guildImGui->SetPresenter(&m_guildUi);
+				// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Renderer
+				// ImGui Hotel des Ventes. Le panel principal n'est visible
+				// que quand m_auctionHouseVisible (toggle via /ah ou touche
+				// H). Les toasts 5s sur derniere bid + dernier
+				// AuctionExpired sont rendus independamment du flag.
+				m_auctionHouseImGui = std::make_unique<engine::render::AuctionImGuiRenderer>();
+				m_auctionHouseImGui->SetPresenter(&m_auctionHouseUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5837,6 +5951,17 @@ namespace engine
 				m_guildImGui->SetEnabled(m_guildVisible);
 				m_guildImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_guildImGui->Render();
+			}
+			// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Render du panel
+			// Hotel des Ventes si m_auctionHouseVisible (toggle via /ah ou
+			// touche H), ET des toasts 5s sur derniere bid + dernier
+			// AuctionExpired (rendus independamment par Render() si
+			// lastBidTimeMs / lastExpirationTimeMs sont recents).
+			if (m_auctionHouseImGui && m_auctionHouseUi.IsInitialized())
+			{
+				m_auctionHouseImGui->SetEnabled(m_auctionHouseVisible);
+				m_auctionHouseImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_auctionHouseImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -18,6 +18,7 @@
 #include "src/client/weather/WeatherUi.h"
 #include "src/client/events/GameEventUi.h"
 #include "src/client/guild/GuildUi.h"
+#include "src/client/auction/AuctionUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -89,6 +90,7 @@ namespace engine::render
 	class WeatherImGuiRenderer;
 	class GameEventImGuiRenderer;
 	class GuildImGuiRenderer;
+	class AuctionImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -401,6 +403,13 @@ namespace engine
 		/// (toggle via slash command /guild ou touche U). Le toast 5s sur
 		/// dernier MotdUpdate reçu est rendu independamment du flag.
 		std::unique_ptr<engine::render::GuildImGuiRenderer> m_guildImGui;
+		/// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Panneau "Auction
+		/// House" (post-auth, ImGui). Partage le contexte ImGui avec les
+		/// autres panneaux post-auth. Le panel principal est visible
+		/// uniquement quand m_auctionHouseVisible (toggle via slash command
+		/// /ah ou touche H). Les toasts 5s sur derniere bid + dernier
+		/// AuctionExpired sont rendus independamment du flag.
+		std::unique_ptr<engine::render::AuctionImGuiRenderer> m_auctionHouseImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -574,6 +583,18 @@ namespace engine
 		/// (toggle via slash command \c /guild ou touche U). Faux par defaut.
 		/// Le toast 5s sur dernier MotdUpdate reçu est rendu independamment.
 		bool                                  m_guildVisible = false;
+		/// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Presenter de la
+		/// fenetre Hotel des Ventes. Recoit les responses opcodes
+		/// 174/176/178/180 et la push notification 181 (AuctionExpired) via
+		/// le push handler du master ; fire-and-forget des requetes
+		/// 173/175/177/179 via \c m_authUi.SendGenericRequestAsync.
+		engine::client::AuctionHousePresenter m_auctionHouseUi;
+		/// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Visibilite du
+		/// panneau Hotel des Ventes (toggle via slash command \c /ah ou
+		/// touche H). Faux par defaut. Le toast 5s sur derniere bid + le
+		/// toast 5s sur dernier AuctionExpired reçu sont rendus
+		/// independamment.
+		bool                                  m_auctionHouseVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/auction/AuctionUi.cpp
+++ b/src/client/auction/AuctionUi.cpp
@@ -1,0 +1,396 @@
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Implementation
+// AuctionHousePresenter.
+
+#include "src/client/auction/AuctionUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <cstdio>
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Retourne le steady_clock now en ms depuis le boot pour l'horodatage
+		/// local des toasts (5s d'affichage).
+		uint64_t SteadyMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// FormatCopper / FormatDuration — static helpers.
+	// -------------------------------------------------------------------------
+
+	std::string FormatCopper(uint64_t copper)
+	{
+		if (copper == 0ull)
+		{
+			return std::string("0c");
+		}
+		const uint64_t gold   = copper / 10000ull;
+		const uint64_t rest1  = copper % 10000ull;
+		const uint64_t silver = rest1 / 100ull;
+		const uint64_t cop    = rest1 % 100ull;
+		char buf[64]{};
+		// Composantes non-nulles uniquement.
+		if (gold > 0ull && silver > 0ull && cop > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llug %llus %lluc",
+				static_cast<unsigned long long>(gold),
+				static_cast<unsigned long long>(silver),
+				static_cast<unsigned long long>(cop));
+		}
+		else if (gold > 0ull && silver > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llug %llus",
+				static_cast<unsigned long long>(gold),
+				static_cast<unsigned long long>(silver));
+		}
+		else if (gold > 0ull && cop > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llug %lluc",
+				static_cast<unsigned long long>(gold),
+				static_cast<unsigned long long>(cop));
+		}
+		else if (gold > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llug",
+				static_cast<unsigned long long>(gold));
+		}
+		else if (silver > 0ull && cop > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llus %lluc",
+				static_cast<unsigned long long>(silver),
+				static_cast<unsigned long long>(cop));
+		}
+		else if (silver > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%llus",
+				static_cast<unsigned long long>(silver));
+		}
+		else
+		{
+			std::snprintf(buf, sizeof(buf), "%lluc",
+				static_cast<unsigned long long>(cop));
+		}
+		return std::string(buf);
+	}
+
+	std::string FormatDuration(uint64_t seconds)
+	{
+		if (seconds == 0ull)
+		{
+			return std::string("expired");
+		}
+		const uint64_t hours    = seconds / 3600ull;
+		const uint64_t restSec  = seconds % 3600ull;
+		const uint64_t minutes  = restSec / 60ull;
+		char buf[32]{};
+		if (hours > 0ull && minutes > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%lluh %llum",
+				static_cast<unsigned long long>(hours),
+				static_cast<unsigned long long>(minutes));
+		}
+		else if (hours > 0ull)
+		{
+			std::snprintf(buf, sizeof(buf), "%lluh",
+				static_cast<unsigned long long>(hours));
+		}
+		else
+		{
+			// minutes ou less than 1 minute : floor a 1m si > 0.
+			const uint64_t shownMinutes = (minutes == 0ull) ? 1ull : minutes;
+			std::snprintf(buf, sizeof(buf), "%llum",
+				static_cast<unsigned long long>(shownMinutes));
+		}
+		return std::string(buf);
+	}
+
+	// -------------------------------------------------------------------------
+	// Presenter lifecycle
+	// -------------------------------------------------------------------------
+
+	AuctionHousePresenter::~AuctionHousePresenter()
+	{
+		Shutdown();
+	}
+
+	bool AuctionHousePresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[AuctionHousePresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		m_pendingBidAuctionId = 0u;
+		LOG_INFO(Core, "[AuctionHousePresenter] Init OK");
+		return true;
+	}
+
+	void AuctionHousePresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		m_pendingBidAuctionId = 0u;
+		LOG_INFO(Core, "[AuctionHousePresenter] Destroyed");
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void AuctionHousePresenter::RequestList(uint32_t filter)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[AuctionHousePresenter] RequestList: no send callback");
+			return;
+		}
+		m_state.filterItemTemplateId = filter;
+		const auto payload = engine::network::BuildAuctionListRequestPayload(filter);
+		if (!m_send(engine::network::kOpcodeAuctionListRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (liste encheres).";
+			LOG_WARN(Net, "[AuctionHousePresenter] RequestList: send failed filter={}", filter);
+			return;
+		}
+		LOG_DEBUG(Net, "[AuctionHousePresenter] Auction ListRequest queued filter={}", filter);
+	}
+
+	void AuctionHousePresenter::Post(uint32_t itemTemplateId, uint32_t count,
+		uint64_t startBidCopper, uint64_t buyoutCopper, uint8_t durationHours)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[AuctionHousePresenter] Post: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildAuctionPostRequestPayload(
+			itemTemplateId, count, startBidCopper, buyoutCopper, durationHours);
+		if (!m_send(engine::network::kOpcodeAuctionPostRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (poste enchere).";
+			LOG_WARN(Net, "[AuctionHousePresenter] Post: send failed item={} count={}",
+				itemTemplateId, count);
+			return;
+		}
+		LOG_DEBUG(Net, "[AuctionHousePresenter] Auction PostRequest queued item={} count={} duration={}h",
+			itemTemplateId, count, static_cast<unsigned>(durationHours));
+	}
+
+	void AuctionHousePresenter::Bid(uint64_t auctionId, uint64_t bidAmountCopper)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[AuctionHousePresenter] Bid: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildAuctionBidRequestPayload(
+			auctionId, bidAmountCopper);
+		if (!m_send(engine::network::kOpcodeAuctionBidRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (mise enchere).";
+			LOG_WARN(Net, "[AuctionHousePresenter] Bid: send failed auctionId={} amount={}",
+				auctionId, bidAmountCopper);
+			return;
+		}
+		m_pendingBidAuctionId = auctionId;
+		LOG_DEBUG(Net, "[AuctionHousePresenter] Auction BidRequest queued auctionId={} amount={}",
+			auctionId, bidAmountCopper);
+	}
+
+	void AuctionHousePresenter::Cancel(uint64_t auctionId)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[AuctionHousePresenter] Cancel: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildAuctionCancelRequestPayload(auctionId);
+		if (!m_send(engine::network::kOpcodeAuctionCancelRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (annulation enchere).";
+			LOG_WARN(Net, "[AuctionHousePresenter] Cancel: send failed auctionId={}", auctionId);
+			return;
+		}
+		LOG_DEBUG(Net, "[AuctionHousePresenter] Auction CancelRequest queued auctionId={}", auctionId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void AuctionHousePresenter::OnListResponse(const engine::network::AuctionListResponsePayload& resp)
+	{
+		using engine::network::AuctionErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<AuctionErrorCode>(resp.error);
+			if (err == AuctionErrorCode::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur Auction inconnue.";
+			LOG_WARN(Net, "[AuctionHousePresenter] OnListResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.listings.clear();
+		m_state.listings.reserve(resp.listings.size());
+		for (const auto& s : resp.listings)
+		{
+			AuctionListingSummary local;
+			local.auctionId              = s.auctionId;
+			local.itemTemplateId         = s.itemTemplateId;
+			local.itemName               = s.itemName;
+			local.count                  = s.count;
+			local.currentBidCopper       = s.currentBidCopper;
+			local.buyoutCopper           = s.buyoutCopper;
+			local.ownerName              = s.ownerName;
+			local.secondsUntilExpiration = s.secondsUntilExpiration;
+			m_state.listings.push_back(std::move(local));
+		}
+		m_state.listingsLoaded = true;
+
+		LOG_INFO(Net, "[AuctionHousePresenter] OnListResponse OK count={}",
+			m_state.listings.size());
+	}
+
+	void AuctionHousePresenter::OnPostResponse(const engine::network::AuctionPostResponsePayload& resp)
+	{
+		using engine::network::AuctionErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<AuctionErrorCode>(resp.error);
+			switch (err)
+			{
+			case AuctionErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case AuctionErrorCode::InvalidParams:
+				m_state.lastErrorText = "Parametres invalides (count/prix/duree).";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Auction inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[AuctionHousePresenter] OnPostResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		char buf[64]{};
+		std::snprintf(buf, sizeof(buf), "Enchere postee #%llu",
+			static_cast<unsigned long long>(resp.auctionId));
+		m_state.lastInfoText = buf;
+		LOG_INFO(Net, "[AuctionHousePresenter] OnPostResponse OK auctionId={}", resp.auctionId);
+		// Refresh la liste suite a un Post reussi.
+		RequestList(m_state.filterItemTemplateId);
+	}
+
+	void AuctionHousePresenter::OnBidResponse(const engine::network::AuctionBidResponsePayload& resp)
+	{
+		using engine::network::AuctionErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<AuctionErrorCode>(resp.error);
+			switch (err)
+			{
+			case AuctionErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case AuctionErrorCode::BidTooLow:
+				m_state.lastErrorText = "Mise trop basse.";
+				break;
+			case AuctionErrorCode::AuctionExpired:
+				m_state.lastErrorText = "Enchere expiree.";
+				break;
+			case AuctionErrorCode::OwnAuction:
+				m_state.lastErrorText = "Vous ne pouvez pas miser sur votre propre enchere.";
+				break;
+			case AuctionErrorCode::AuctionNotFound:
+				m_state.lastErrorText = "Enchere introuvable.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Auction inconnue.";
+				break;
+			}
+			m_pendingBidAuctionId = 0u;
+			LOG_WARN(Net, "[AuctionHousePresenter] OnBidResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.lastBidWasBuyout = (resp.isBuyout != 0u);
+		m_state.lastBidAuctionId = m_pendingBidAuctionId;
+		m_state.lastBidTimeMs    = SteadyMs();
+		m_pendingBidAuctionId    = 0u;
+		LOG_INFO(Net, "[AuctionHousePresenter] OnBidResponse OK isBuyout={}",
+			static_cast<unsigned>(resp.isBuyout));
+
+		// Refresh la liste suite a une Bid reussie.
+		RequestList(m_state.filterItemTemplateId);
+	}
+
+	void AuctionHousePresenter::OnCancelResponse(const engine::network::AuctionCancelResponsePayload& resp)
+	{
+		using engine::network::AuctionErrorCode;
+		if (resp.error != 0u)
+		{
+			const auto err = static_cast<AuctionErrorCode>(resp.error);
+			switch (err)
+			{
+			case AuctionErrorCode::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case AuctionErrorCode::NotOwner:
+				m_state.lastErrorText = "Vous n'etes pas le proprietaire.";
+				break;
+			case AuctionErrorCode::AuctionNotFound:
+				m_state.lastErrorText = "Enchere introuvable.";
+				break;
+			case AuctionErrorCode::AuctionExpired:
+				m_state.lastErrorText = "Enchere deja terminee.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Auction inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[AuctionHousePresenter] OnCancelResponse error={}",
+				static_cast<unsigned>(resp.error));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.lastInfoText = "Enchere annulee.";
+		LOG_INFO(Net, "[AuctionHousePresenter] OnCancelResponse OK");
+
+		// Refresh la liste suite a un Cancel reussi.
+		RequestList(m_state.filterItemTemplateId);
+	}
+
+	void AuctionHousePresenter::OnExpiredNotification(const engine::network::AuctionExpiredNotificationPayload& note)
+	{
+		m_state.lastExpirationAuctionId   = note.auctionId;
+		m_state.lastExpirationWon         = (note.won != 0u);
+		m_state.lastExpirationFinalBid    = note.finalBidCopper;
+		m_state.lastExpirationWinnerName  = note.winnerName;
+		m_state.lastExpirationTimeMs      = SteadyMs();
+		LOG_DEBUG(Net, "[AuctionHousePresenter] OnExpiredNotification auctionId={} won={} finalBid={}",
+			note.auctionId, static_cast<unsigned>(note.won), note.finalBidCopper);
+	}
+}

--- a/src/client/auction/AuctionUi.h
+++ b/src/client/auction/AuctionUi.h
@@ -1,0 +1,170 @@
+#pragma once
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Presenter client de la
+// fenetre Hotel des Ventes. Maintient un cache local des listings + champ
+// filter actif + memoire des derniers evenements (bid OK, bid buyout, push
+// AuctionExpired) pour afficher des toasts.
+//
+// Pas de rendu ImGui : le panneau est drawe par AuctionImGuiRenderer qui
+// lit l'etat via GetState() et propage les inputs UI (RequestList / Post /
+// Bid / Cancel) via les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans GuildUiPresenter).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 174/176/178/180/181 vers les OnXxx du presenter.
+
+#include "src/shared/network/AuctionPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Resume d'une enchere expose au layer UI. Mirror direct de
+	/// engine::network::AuctionListingSummary.
+	struct AuctionListingSummary
+	{
+		uint64_t    auctionId               = 0;
+		uint32_t    itemTemplateId          = 0;
+		std::string itemName;
+		uint32_t    count                   = 0;
+		uint64_t    currentBidCopper        = 0;
+		uint64_t    buyoutCopper            = 0;
+		std::string ownerName;
+		uint64_t    secondsUntilExpiration  = 0;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct AuctionState
+	{
+		std::vector<AuctionListingSummary> listings;
+		bool                               listingsLoaded     = false;
+
+		/// Filter actif sur le itemTemplateId (0 = pas de filtre).
+		uint32_t                           filterItemTemplateId = 0;
+
+		/// Toast 5s sur derniere bid recue (succes ou buyout).
+		std::optional<uint64_t>            lastBidTimeMs;
+		bool                               lastBidWasBuyout    = false;
+		uint64_t                           lastBidAuctionId    = 0;
+
+		/// Toast 5s sur dernier AuctionExpired reçu (push asynchrone).
+		std::optional<uint64_t>            lastExpirationTimeMs;
+		uint64_t                           lastExpirationAuctionId = 0;
+		bool                               lastExpirationWon       = false;
+		uint64_t                           lastExpirationFinalBid  = 0;
+		std::string                        lastExpirationWinnerName;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire. Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Static helper : formate un montant en copper "12g 34s 56c" (1 gold =
+	/// 10000 copper, 1 silver = 100 copper). Ne rend que les composantes
+	/// non-nulles, sauf si copper == 0 auquel cas retourne "0c".
+	std::string FormatCopper(uint64_t copper);
+
+	/// Static helper : formate une duree en secondes "23h 12m" / "5h" /
+	/// "12m" / "expired". Si seconds == 0, retourne "expired".
+	std::string FormatDuration(uint64_t seconds);
+
+	/// Presenter pour la fenetre AuctionHouse cote client. Doit etre Init()
+	/// avant tout usage du callback. Thread : main (comme les autres
+	/// presenters UI).
+	class AuctionHousePresenter final
+	{
+	public:
+		AuctionHousePresenter() = default;
+
+		AuctionHousePresenter(const AuctionHousePresenter&)            = delete;
+		AuctionHousePresenter& operator=(const AuctionHousePresenter&) = delete;
+
+		~AuctionHousePresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.09 step 3+4)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		/// Cable via \ref SetSendCallback.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout RequestList / Post / Bid / Cancel.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie AUCTION_LIST_REQUEST. \p filter (0 = pas de filtre) memorise
+		/// dans m_state.filterItemTemplateId. Reponse via OnListResponse.
+		void RequestList(uint32_t filter = 0u);
+
+		/// Envoie AUCTION_POST_REQUEST. Validation cote serveur.
+		/// Reponse via OnPostResponse.
+		///
+		/// \param itemTemplateId  id de l'item a poster.
+		/// \param count           quantite > 0.
+		/// \param startBidCopper  bid initial > 0.
+		/// \param buyoutCopper    0 = pas de buyout, sinon >= startBidCopper.
+		/// \param durationHours   12, 24 ou 48.
+		void Post(uint32_t itemTemplateId, uint32_t count,
+			uint64_t startBidCopper, uint64_t buyoutCopper, uint8_t durationHours);
+
+		/// Envoie AUCTION_BID_REQUEST. Reponse via OnBidResponse.
+		void Bid(uint64_t auctionId, uint64_t bidAmountCopper);
+
+		/// Envoie AUCTION_CANCEL_REQUEST. Reponse via OnCancelResponse.
+		void Cancel(uint64_t auctionId);
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit AUCTION_LIST_RESPONSE. Remplace le cache local des listings.
+		void OnListResponse(const engine::network::AuctionListResponsePayload& resp);
+
+		/// Recoit AUCTION_POST_RESPONSE. Set lastInfoText sur succes, lastErrorText
+		/// sur erreur. Refresh la liste apres un Post reussi.
+		void OnPostResponse(const engine::network::AuctionPostResponsePayload& resp);
+
+		/// Recoit AUCTION_BID_RESPONSE. Met a jour lastBid* pour le toast UI.
+		void OnBidResponse(const engine::network::AuctionBidResponsePayload& resp);
+
+		/// Recoit AUCTION_CANCEL_RESPONSE. Set lastInfoText sur succes,
+		/// lastErrorText sur erreur. Refresh la liste apres un Cancel reussi.
+		void OnCancelResponse(const engine::network::AuctionCancelResponsePayload& resp);
+
+		/// Recoit un push AUCTION_EXPIRED_NOTIFICATION : met a jour lastExpiration*
+		/// pour le toast UI.
+		void OnExpiredNotification(const engine::network::AuctionExpiredNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const AuctionState& GetState() const { return m_state; }
+
+	private:
+		bool             m_initialized = false;
+		AuctionState     m_state{};
+		SendCallback     m_send;
+
+		/// Memoire de l'auctionId du dernier Bid envoye, pour pouvoir
+		/// renseigner lastBidAuctionId au moment de la reception de la
+		/// reponse (la response ne contient pas l'auctionId).
+		uint64_t         m_pendingBidAuctionId = 0u;
+	};
+}

--- a/src/client/render/AuctionImGuiRenderer.cpp
+++ b/src/client/render/AuctionImGuiRenderer.cpp
@@ -1,0 +1,401 @@
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — AuctionImGuiRenderer
+// implementation.
+
+#include "src/client/render/AuctionImGuiRenderer.h"
+
+#include "src/client/auction/AuctionUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Retourne le steady_clock now en ms (pour les toasts 5s).
+		uint64_t SteadyNowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	void AuctionImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		// Le panel n'est rendu que si IsEnabled().
+		if (m_enabled)
+			RenderMainPanel();
+
+		// Les toasts sont rendus independamment.
+		RenderBidToast();
+		RenderExpiredToast();
+	}
+
+	void AuctionImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre droite, 640x720.
+		const float panelW = 640.f;
+		const float panelH = 720.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - panelW - margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Auction House (H)##ln_auction_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Top : filter + Refresh.
+			ImGui::TextUnformatted("Filtre :");
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(120.f);
+			ImGui::InputInt("##filter_item", &m_inputFilter);
+			if (m_inputFilter < 0) m_inputFilter = 0;
+			ImGui::SameLine();
+			if (ImGui::Button("Rafraichir"))
+			{
+				m_presenter->RequestList(static_cast<uint32_t>(m_inputFilter));
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Toutes"))
+			{
+				m_inputFilter = 0;
+				m_presenter->RequestList(0u);
+			}
+			ImGui::Separator();
+
+			// Middle : table des listings.
+			ImGui::TextUnformatted("Encheres actives :");
+			if (!state.listingsLoaded)
+			{
+				ImGui::TextUnformatted("(non chargees)");
+			}
+			else if (state.listings.empty())
+			{
+				ImGui::TextWrapped("Aucune enchere correspondante.");
+			}
+			else
+			{
+				const float tableHeight = 360.f;
+				if (ImGui::BeginChild("##auction_list_child", ImVec2(0.f, tableHeight), true,
+					ImGuiWindowFlags_HorizontalScrollbar))
+				{
+					if (ImGui::BeginTable("##auction_table", 7,
+						ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders
+						| ImGuiTableFlags_SizingStretchProp))
+					{
+						ImGui::TableSetupColumn("Item");
+						ImGui::TableSetupColumn("Qte");
+						ImGui::TableSetupColumn("Owner");
+						ImGui::TableSetupColumn("Bid");
+						ImGui::TableSetupColumn("Buyout");
+						ImGui::TableSetupColumn("Reste");
+						ImGui::TableSetupColumn("Action");
+						ImGui::TableHeadersRow();
+
+						for (const auto& a : state.listings)
+						{
+							ImGui::TableNextRow();
+							ImGui::PushID(static_cast<int>(a.auctionId & 0x7FFFFFFFu));
+							ImGui::TableNextColumn();
+							ImGui::Text("%s", a.itemName.c_str());
+							ImGui::TableNextColumn();
+							ImGui::Text("%u", static_cast<unsigned>(a.count));
+							ImGui::TableNextColumn();
+							ImGui::TextUnformatted(a.ownerName.c_str());
+							ImGui::TableNextColumn();
+							const std::string cur = engine::client::FormatCopper(a.currentBidCopper);
+							ImGui::TextUnformatted(cur.c_str());
+							ImGui::TableNextColumn();
+							if (a.buyoutCopper == 0ull)
+							{
+								ImGui::TextUnformatted("-");
+							}
+							else
+							{
+								const std::string buy = engine::client::FormatCopper(a.buyoutCopper);
+								ImGui::TextUnformatted(buy.c_str());
+							}
+							ImGui::TableNextColumn();
+							const std::string dur = engine::client::FormatDuration(a.secondsUntilExpiration);
+							ImGui::TextUnformatted(dur.c_str());
+							ImGui::TableNextColumn();
+							if (ImGui::SmallButton("Miser"))
+							{
+								m_bidTargetAuctionId = a.auctionId;
+								m_inputBidAmount = static_cast<int>(std::min<uint64_t>(
+									a.currentBidCopper + 1ull, static_cast<uint64_t>(0x7FFFFFFF)));
+								m_bidPopupOpen = true;
+							}
+							ImGui::PopID();
+						}
+						ImGui::EndTable();
+					}
+				}
+				ImGui::EndChild();
+			}
+
+			ImGui::Separator();
+
+			// Bottom : formulaire Post.
+			ImGui::TextUnformatted("Poster une enchere :");
+			ImGui::SetNextItemWidth(120.f);
+			ImGui::InputInt("Item ID##post_item", &m_inputPostItem);
+			if (m_inputPostItem < 1) m_inputPostItem = 1;
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(80.f);
+			ImGui::InputInt("Qte##post_count", &m_inputPostCount);
+			if (m_inputPostCount < 1) m_inputPostCount = 1;
+
+			ImGui::SetNextItemWidth(140.f);
+			ImGui::InputInt("Bid initial (copper)##post_startbid", &m_inputPostStartBid);
+			if (m_inputPostStartBid < 1) m_inputPostStartBid = 1;
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(140.f);
+			ImGui::InputInt("Buyout (copper)##post_buyout", &m_inputPostBuyout);
+			if (m_inputPostBuyout < 0) m_inputPostBuyout = 0;
+
+			ImGui::TextUnformatted("Duree :");
+			ImGui::SameLine();
+			ImGui::RadioButton("12h##dur12", &m_inputPostDurationIdx, 0);
+			ImGui::SameLine();
+			ImGui::RadioButton("24h##dur24", &m_inputPostDurationIdx, 1);
+			ImGui::SameLine();
+			ImGui::RadioButton("48h##dur48", &m_inputPostDurationIdx, 2);
+
+			if (ImGui::Button("Poster", ImVec2(160.f, 28.f)))
+			{
+				const uint8_t durationHours = (m_inputPostDurationIdx == 0) ? 12u
+					: (m_inputPostDurationIdx == 2) ? 48u : 24u;
+				m_presenter->Post(
+					static_cast<uint32_t>(m_inputPostItem),
+					static_cast<uint32_t>(m_inputPostCount),
+					static_cast<uint64_t>(m_inputPostStartBid),
+					static_cast<uint64_t>(m_inputPostBuyout),
+					durationHours);
+			}
+
+			// Popup de confirmation Bid.
+			if (m_bidPopupOpen)
+			{
+				ImGui::OpenPopup("##bid_popup");
+				m_bidPopupOpen = false;
+			}
+			if (ImGui::BeginPopupModal("##bid_popup", nullptr,
+				ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
+			{
+				ImGui::Text("Miser sur enchere #%llu",
+					static_cast<unsigned long long>(m_bidTargetAuctionId));
+				ImGui::SetNextItemWidth(180.f);
+				ImGui::InputInt("Montant (copper)##bid_amount", &m_inputBidAmount);
+				if (m_inputBidAmount < 1) m_inputBidAmount = 1;
+				ImGui::Separator();
+				if (ImGui::Button("Valider", ImVec2(120.f, 0.f)))
+				{
+					m_presenter->Bid(m_bidTargetAuctionId,
+						static_cast<uint64_t>(m_inputBidAmount));
+					m_bidTargetAuctionId = 0u;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Annuler", ImVec2(120.f, 0.f)))
+				{
+					m_bidTargetAuctionId = 0u;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void AuctionImGuiRenderer::RenderBidToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastBidTimeMs.has_value())
+			return;
+
+		constexpr uint64_t kToastDurationMs = 5000ull;
+		const uint64_t nowSteady = SteadyNowMs();
+		if (nowSteady < *state.lastBidTimeMs)
+			return;
+		const uint64_t age = nowSteady - *state.lastBidTimeMs;
+		if (age > kToastDurationMs)
+			return;
+
+		char buf[80]{};
+		if (state.lastBidWasBuyout)
+		{
+			std::snprintf(buf, sizeof(buf), "Achat immediat #%llu",
+				static_cast<unsigned long long>(state.lastBidAuctionId));
+		}
+		else
+		{
+			std::snprintf(buf, sizeof(buf), "Mise placee sur #%llu",
+				static_cast<unsigned long long>(state.lastBidAuctionId));
+		}
+
+		// Geometrie toast : bottom-right, 320x60, marge 16.
+		const float toastW = 320.f;
+		const float toastH = 60.f;
+		const float margin = 16.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = std::max(0.f, vpH - toastH - margin);
+
+		float alpha = 0.95f;
+		if (age > kToastDurationMs - 1000ull)
+		{
+			const float remain = static_cast<float>(kToastDurationMs - age) / 1000.0f;
+			alpha = std::max(0.0f, std::min(0.95f, remain * 0.95f));
+		}
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(alpha);
+
+		const ImGuiWindowFlags toastFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoInputs;
+
+		if (ImGui::Begin("##ln_auction_bid_toast", nullptr, toastFlags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.95f, 0.85f, 0.45f, 1.f));
+			ImGui::TextWrapped("%s", buf);
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+	}
+
+	void AuctionImGuiRenderer::RenderExpiredToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastExpirationTimeMs.has_value())
+			return;
+
+		constexpr uint64_t kToastDurationMs = 5000ull;
+		const uint64_t nowSteady = SteadyNowMs();
+		if (nowSteady < *state.lastExpirationTimeMs)
+			return;
+		const uint64_t age = nowSteady - *state.lastExpirationTimeMs;
+		if (age > kToastDurationMs)
+			return;
+
+		std::string text;
+		char buf[160]{};
+		if (state.lastExpirationWon)
+		{
+			const std::string finalAmt = engine::client::FormatCopper(state.lastExpirationFinalBid);
+			std::snprintf(buf, sizeof(buf), "Auction #%llu expiree -- vendue a %s pour %s",
+				static_cast<unsigned long long>(state.lastExpirationAuctionId),
+				state.lastExpirationWinnerName.empty() ? "?" : state.lastExpirationWinnerName.c_str(),
+				finalAmt.c_str());
+		}
+		else
+		{
+			std::snprintf(buf, sizeof(buf), "Auction #%llu expiree sans acheteur",
+				static_cast<unsigned long long>(state.lastExpirationAuctionId));
+		}
+		text = buf;
+
+		// Geometrie toast : bottom-right, decale au-dessus du bid toast.
+		const float toastW = 360.f;
+		const float toastH = 64.f;
+		const float margin = 16.f;
+		const float spacing = 76.f;  // au-dessus du bid toast.
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = std::max(0.f, vpH - toastH - margin - spacing);
+
+		float alpha = 0.95f;
+		if (age > kToastDurationMs - 1000ull)
+		{
+			const float remain = static_cast<float>(kToastDurationMs - age) / 1000.0f;
+			alpha = std::max(0.0f, std::min(0.95f, remain * 0.95f));
+		}
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(alpha);
+
+		const ImGuiWindowFlags toastFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoInputs;
+
+		if (ImGui::Begin("##ln_auction_expired_toast", nullptr, toastFlags))
+		{
+			const ImVec4 color = state.lastExpirationWon
+				? ImVec4(0.55f, 0.95f, 0.55f, 1.f)
+				: ImVec4(0.85f, 0.6f, 0.45f, 1.f);
+			ImGui::PushStyleColor(ImGuiCol_Text, color);
+			ImGui::TextWrapped("%s", text.c_str());
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void AuctionImGuiRenderer::Render()             {}
+	void AuctionImGuiRenderer::RenderMainPanel()    {}
+	void AuctionImGuiRenderer::RenderBidToast()     {}
+	void AuctionImGuiRenderer::RenderExpiredToast() {}
+}
+
+#endif

--- a/src/client/render/AuctionImGuiRenderer.h
+++ b/src/client/render/AuctionImGuiRenderer.h
@@ -1,0 +1,76 @@
+#pragma once
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — AuctionImGuiRenderer :
+// panneau ImGui pour l'Hotel des Ventes. Top section : input filter
+// (itemTemplateId) + bouton Refresh. Middle section : table des listings
+// (Item / Count / Owner / Current Bid / Buyout / Time Left + bouton
+// Bid/Buyout par ligne). Bottom section : formulaire Post (item, count,
+// startBid copper, buyout copper, duration 12h/24h/48h).
+//
+// Le toast 5s sur derniere bid + le toast 5s sur dernier AuctionExpired sont
+// rendus independamment du flag IsEnabled() (les push peuvent arriver panneau
+// ferme).
+//
+// Lit l'etat d'un AuctionHousePresenter, dispatch les inputs UI (RequestList /
+// Post / Bid / Cancel) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class AuctionHousePresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau AuctionHouse. Pas de logique de fetch /
+	/// parse : celle-ci est dans \ref engine::client::AuctionHousePresenter.
+	/// Le renderer ne fait que dessiner l'etat courant et propager les inputs
+	/// UI vers le presenter.
+	class AuctionImGuiRenderer
+	{
+	public:
+		AuctionImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::AuctionHousePresenter* presenter) { m_presenter = presenter; }
+
+		/// Active/desactive le rendu du panel principal.
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Auction House" (si IsEnabled()) et les toasts 5s
+		/// pour la derniere Bid + le dernier AuctionExpired (rendus
+		/// independamment du flag IsEnabled() puisque les push peuvent
+		/// arriver panneau ferme). A appeler entre \c ImGui::NewFrame() et
+		/// \c ImGui::Render(), apres NewFrame, si le presenter est valide.
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (top : filter + listings + bid ;
+		/// bottom : post form).
+		void RenderMainPanel();
+
+		/// Dessine le toast 5s en bas-droite si lastBidTimeMs est recent.
+		void RenderBidToast();
+
+		/// Dessine le toast 5s (en dessous du bid toast) si
+		/// lastExpirationTimeMs est recent.
+		void RenderExpiredToast();
+
+		engine::client::AuctionHousePresenter* m_presenter = nullptr;
+		bool                                   m_enabled   = false;
+		uint32_t                               m_viewportW = 0;
+		uint32_t                               m_viewportH = 0;
+
+		// Buffers ImGui pour les inputs (persistants entre frames).
+		int      m_inputFilter         = 0;
+		int      m_inputPostItem       = 1;
+		int      m_inputPostCount      = 1;
+		int      m_inputPostStartBid   = 100;
+		int      m_inputPostBuyout     = 0;
+		int      m_inputPostDurationIdx= 1;  // 0=12h, 1=24h, 2=48h
+		uint64_t m_bidTargetAuctionId  = 0u;
+		int      m_inputBidAmount      = 0;
+		bool     m_bidPopupOpen        = false;
+	};
+}

--- a/src/masterd/handlers/auction/AuctionHandler.cpp
+++ b/src/masterd/handlers/auction/AuctionHandler.cpp
@@ -1,0 +1,627 @@
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Implementation AuctionHandler.
+
+#include "src/masterd/handlers/auction/AuctionHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/AuctionPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Constante : nombre maximum d'entrees dans la table de noms d'items V1.
+		constexpr uint32_t kItemNameTableMax = 10u;
+
+		/// Table d'items V1 (10 entries hardcode). Adresses stables pour const char*.
+		const char* const kItemNames[kItemNameTableMax + 1u] = {
+			"Item #0",        // 0 (placeholder, jamais retourne pour 0)
+			"Iron Ore",       // 1
+			"Linen Cloth",    // 2
+			"Mageweave",      // 3
+			"Health Potion",  // 4
+			"Mana Potion",    // 5
+			"Mithril Bar",    // 6
+			"Thorium Ore",    // 7
+			"Black Lotus",    // 8
+			"Arcanite Bar",   // 9
+			"Soul Shard"      // 10
+		};
+
+		/// Format un fallback "Item #<id>" pour les ids hors table.
+		std::string FormatUnknownItemName(uint32_t id)
+		{
+			char buf[32]{};
+			// std::snprintf est ASCII-safe sur MSVC.
+			std::snprintf(buf, sizeof(buf), "Item #%u", static_cast<unsigned>(id));
+			return std::string(buf);
+		}
+
+		/// Format "Account#<id>" pour les owners V1 postes par le client.
+		std::string FormatAccountOwnerName(uint64_t accountId)
+		{
+			char buf[40]{};
+			std::snprintf(buf, sizeof(buf), "Account#%llu",
+				static_cast<unsigned long long>(accountId));
+			return std::string(buf);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// ResolveItemName — static helper public.
+	// -------------------------------------------------------------------------
+
+	std::string AuctionHandler::ResolveItemName(uint32_t itemTemplateId)
+	{
+		if (itemTemplateId >= 1u && itemTemplateId <= kItemNameTableMax)
+		{
+			return std::string(kItemNames[itemTemplateId]);
+		}
+		return FormatUnknownItemName(itemTemplateId);
+	}
+
+	// -------------------------------------------------------------------------
+	// SeedV1Auctions — register the 8 hardcoded listings at boot.
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::SeedV1Auctions()
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_seeded)
+		{
+			LOG_DEBUG(Net, "[AuctionHandler] SeedV1Auctions already seeded (idempotent skip)");
+			return;
+		}
+
+		const auto now = std::chrono::steady_clock::now();
+		const auto hr  = std::chrono::hours(1);
+
+		// Helper local : alloue l'id, init owner V1 par chaine fournie (les
+		// owners seedees sont fictifs, sans accountId reel = 0).
+		auto add = [&](uint32_t itemTemplateId, uint32_t count,
+			uint64_t startBid, uint64_t buyout, uint64_t expiresInHours,
+			const char* ownerName)
+		{
+			InMemoryAuction a;
+			a.auctionId              = m_nextAuctionId.fetch_add(1u, std::memory_order_relaxed);
+			a.itemTemplateId         = itemTemplateId;
+			a.itemName               = ResolveItemName(itemTemplateId);
+			a.count                  = count;
+			a.startBidCopper         = startBid;
+			a.currentBidCopper       = startBid;
+			a.buyoutCopper           = buyout;
+			a.ownerName              = ownerName;
+			a.ownerAccountId         = 0u; // V1 : owners seed fictifs.
+			a.highestBidderName      = "";
+			a.highestBidderAccountId = 0u;
+			a.expiresAt              = now + (hr * static_cast<long long>(expiresInHours));
+			a.ended                  = false;
+			a.wonByBuyout            = false;
+			m_auctions.push_back(std::move(a));
+		};
+
+		// 8 auctions seedees (mix items / owners / durations / buyouts).
+		add(1u,  20u, 500ull,    1000ull,   1ull,  "Aragorn"); // Iron Ore
+		add(2u,  50u, 300ull,    0ull,      6ull,  "Legolas"); // Linen Cloth, no buyout
+		add(3u,  10u, 1500ull,   3000ull,   12ull, "Gimli");   // Mageweave
+		add(4u,  5u,  250ull,    500ull,    24ull, "Aragorn"); // Health Potion
+		add(5u,  5u,  250ull,    0ull,      24ull, "Saruman"); // Mana Potion, no buyout
+		add(6u,  3u,  10000ull,  25000ull,  36ull, "Saruman"); // Mithril Bar
+		add(7u,  15u, 8000ull,   0ull,      48ull, "Gimli");   // Thorium Ore, no buyout
+		add(8u,  1u,  50000ull,  150000ull, 48ull, "Legolas"); // Black Lotus
+
+		m_seeded = true;
+		LOG_INFO(Net, "[AuctionHandler] V1 auctions seeded : 8 listings ({} -> {})",
+			m_auctions.front().auctionId, m_auctions.back().auctionId);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket — dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[AuctionHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(AuctionErrorCode::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeAuctionListRequest:
+				pkt = BuildAuctionListResponsePacket(kUnauth, {}, requestId, sessionIdHeader);
+				break;
+			case kOpcodeAuctionPostRequest:
+				pkt = BuildAuctionPostResponsePacket(kUnauth, 0ull, requestId, sessionIdHeader);
+				break;
+			case kOpcodeAuctionBidRequest:
+				pkt = BuildAuctionBidResponsePacket(kUnauth, 0u, requestId, sessionIdHeader);
+				break;
+			case kOpcodeAuctionCancelRequest:
+				pkt = BuildAuctionCancelResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeAuctionListRequest:
+			HandleList(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeAuctionPostRequest:
+			HandlePost(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeAuctionBidRequest:
+			HandleBid(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeAuctionCancelRequest:
+			HandleCancel(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// ScanExpiredLocked — collect newly expired auctions, mutex held.
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::ScanExpiredLocked(std::chrono::steady_clock::time_point now,
+		std::vector<ExpiredPushItem>& expiredOwners)
+	{
+		for (auto& a : m_auctions)
+		{
+			if (a.ended) continue;
+			if (a.expiresAt <= now)
+			{
+				a.ended = true;
+				ExpiredPushItem item;
+				item.ownerAccountId = a.ownerAccountId;
+				item.auctionId      = a.auctionId;
+				const bool wonByBid = (a.highestBidderAccountId != 0u);
+				item.won            = wonByBid ? 1u : 0u;
+				item.finalBidCopper = wonByBid ? a.currentBidCopper : 0ull;
+				item.winnerName     = wonByBid ? a.highestBidderName : std::string();
+				expiredOwners.push_back(std::move(item));
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleList
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseAuctionListRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[AuctionHandler] List parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildAuctionListResponsePacket(0u, {}, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint32_t filter = parsed->itemTemplateIdFilter;
+		const auto now = std::chrono::steady_clock::now();
+
+		std::vector<AuctionListingSummary> summaries;
+		std::vector<ExpiredPushItem> expiredOwners;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+
+			// 1) Marque les auctions expirees + collecte les owners a notifier.
+			ScanExpiredLocked(now, expiredOwners);
+
+			// 2) Construit la liste des actives (non ended) avec filter.
+			summaries.reserve(m_auctions.size());
+			for (const auto& a : m_auctions)
+			{
+				if (a.ended) continue;
+				if (filter != 0u && a.itemTemplateId != filter) continue;
+				const auto remaining = a.expiresAt - now;
+				const auto remainingSec = std::chrono::duration_cast<std::chrono::seconds>(remaining).count();
+				AuctionListingSummary s;
+				s.auctionId              = a.auctionId;
+				s.itemTemplateId         = a.itemTemplateId;
+				s.itemName               = a.itemName;
+				s.count                  = a.count;
+				s.currentBidCopper       = a.currentBidCopper;
+				s.buyoutCopper           = a.buyoutCopper;
+				s.ownerName              = a.ownerName;
+				s.secondsUntilExpiration = (remainingSec > 0) ? static_cast<uint64_t>(remainingSec) : 0ull;
+				summaries.push_back(std::move(s));
+			}
+		}
+
+		// Push notifications hors mutex (ne devrait pas reentrer dans le handler).
+		for (const auto& item : expiredOwners)
+		{
+			if (item.ownerAccountId == 0u) continue;
+			const uint32_t ownerConn = FindConnIdForAccount(item.ownerAccountId);
+			if (ownerConn == 0u) continue;
+			(void)PushAuctionExpired(ownerConn, item.auctionId, item.won,
+				item.finalBidCopper, item.winnerName);
+		}
+
+		LOG_INFO(Net, "[AuctionHandler] List account={} filter={} count={} expired={}",
+			accountId, filter, summaries.size(), expiredOwners.size());
+
+		auto pkt = BuildAuctionListResponsePacket(0u, summaries, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePost
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::HandlePost(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseAuctionPostRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[AuctionHandler] Post parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildAuctionPostResponsePacket(
+				static_cast<uint8_t>(AuctionErrorCode::InvalidParams), 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		// Validation params.
+		const uint32_t itemTemplateId = parsed->itemTemplateId;
+		const uint32_t count          = parsed->count;
+		const uint64_t startBid       = parsed->startBidCopper;
+		const uint64_t buyout         = parsed->buyoutCopper;
+		const uint8_t  durationHours  = parsed->durationHours;
+
+		const bool durationOk = (durationHours == 12u || durationHours == 24u || durationHours == 48u);
+		const bool buyoutOk   = (buyout == 0ull) || (buyout >= startBid);
+		const bool valid      = (count > 0u) && (startBid > 0ull) && buyoutOk && durationOk;
+
+		if (!valid)
+		{
+			LOG_INFO(Net, "[AuctionHandler] Post InvalidParams account={} item={} count={} startBid={} buyout={} durationHours={}",
+				accountId, itemTemplateId, count, startBid, buyout,
+				static_cast<unsigned>(durationHours));
+			auto pkt = BuildAuctionPostResponsePacket(
+				static_cast<uint8_t>(AuctionErrorCode::InvalidParams), 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint64_t newId = m_nextAuctionId.fetch_add(1u, std::memory_order_relaxed);
+		const auto now = std::chrono::steady_clock::now();
+		const auto expiresAt = now + std::chrono::hours(static_cast<long long>(durationHours));
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			InMemoryAuction a;
+			a.auctionId              = newId;
+			a.itemTemplateId         = itemTemplateId;
+			a.itemName               = ResolveItemName(itemTemplateId);
+			a.count                  = count;
+			a.startBidCopper         = startBid;
+			a.currentBidCopper       = startBid;
+			a.buyoutCopper           = buyout;
+			a.ownerName              = FormatAccountOwnerName(accountId);
+			a.ownerAccountId         = accountId;
+			a.highestBidderName      = "";
+			a.highestBidderAccountId = 0u;
+			a.expiresAt              = expiresAt;
+			a.ended                  = false;
+			a.wonByBuyout            = false;
+			m_auctions.push_back(std::move(a));
+		}
+
+		LOG_INFO(Net, "[AuctionHandler] Post Ok account={} item={} count={} auctionId={} durationHours={}",
+			accountId, itemTemplateId, count, newId,
+			static_cast<unsigned>(durationHours));
+
+		auto pkt = BuildAuctionPostResponsePacket(0u, newId, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleBid
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::HandleBid(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseAuctionBidRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[AuctionHandler] Bid parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildAuctionBidResponsePacket(
+				static_cast<uint8_t>(AuctionErrorCode::AuctionNotFound), 0u,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint64_t auctionId = parsed->auctionId;
+		const uint64_t bidAmount = parsed->bidAmountCopper;
+
+		uint8_t  errorCode    = 0u;
+		uint8_t  isBuyout     = 0u;
+		uint64_t sellerAccountId = 0u;
+		uint64_t buyoutAuctionId = 0ull;
+		uint64_t buyoutFinalBid  = 0ull;
+		std::string buyoutWinnerName;
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			InMemoryAuction* found = nullptr;
+			for (auto& a : m_auctions)
+			{
+				if (a.auctionId == auctionId)
+				{
+					found = &a;
+					break;
+				}
+			}
+			if (!found)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::AuctionNotFound);
+			}
+			else if (found->ended || found->expiresAt <= std::chrono::steady_clock::now())
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::AuctionExpired);
+			}
+			else if (found->ownerAccountId != 0u && found->ownerAccountId == accountId)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::OwnAuction);
+			}
+			else if (bidAmount <= found->currentBidCopper)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::BidTooLow);
+			}
+			else
+			{
+				// Bid acceptee. Verifie buyout.
+				const std::string bidderName = FormatAccountOwnerName(accountId);
+				if (found->buyoutCopper > 0ull && bidAmount >= found->buyoutCopper)
+				{
+					// Buyout immediat.
+					found->currentBidCopper       = bidAmount;
+					found->highestBidderName      = bidderName;
+					found->highestBidderAccountId = accountId;
+					found->ended                  = true;
+					found->wonByBuyout            = true;
+					isBuyout = 1u;
+					sellerAccountId  = found->ownerAccountId;
+					buyoutAuctionId  = found->auctionId;
+					buyoutFinalBid   = bidAmount;
+					buyoutWinnerName = bidderName;
+				}
+				else
+				{
+					// Bid normale.
+					found->currentBidCopper       = bidAmount;
+					found->highestBidderName      = bidderName;
+					found->highestBidderAccountId = accountId;
+				}
+			}
+		}
+
+		if (errorCode != 0u)
+		{
+			LOG_INFO(Net, "[AuctionHandler] Bid error account={} auctionId={} bid={} error={}",
+				accountId, auctionId, bidAmount, static_cast<unsigned>(errorCode));
+			auto pkt = BuildAuctionBidResponsePacket(errorCode, 0u, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[AuctionHandler] Bid Ok account={} auctionId={} bid={} buyout={}",
+			accountId, auctionId, bidAmount, static_cast<unsigned>(isBuyout));
+
+		auto pkt = BuildAuctionBidResponsePacket(0u, isBuyout, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		// Push expired notification au seller en cas de buyout immediat.
+		if (isBuyout == 1u && sellerAccountId != 0u)
+		{
+			const uint32_t sellerConn = FindConnIdForAccount(sellerAccountId);
+			if (sellerConn != 0u)
+			{
+				(void)PushAuctionExpired(sellerConn, buyoutAuctionId, 1u,
+					buyoutFinalBid, buyoutWinnerName);
+			}
+			else
+			{
+				LOG_DEBUG(Net, "[AuctionHandler] Bid buyout : seller account={} not connected (skip push)",
+					sellerAccountId);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleCancel
+	// -------------------------------------------------------------------------
+
+	void AuctionHandler::HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseAuctionCancelRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[AuctionHandler] Cancel parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildAuctionCancelResponsePacket(
+				static_cast<uint8_t>(AuctionErrorCode::AuctionNotFound),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint64_t auctionId = parsed->auctionId;
+
+		uint8_t errorCode = 0u;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			InMemoryAuction* found = nullptr;
+			for (auto& a : m_auctions)
+			{
+				if (a.auctionId == auctionId)
+				{
+					found = &a;
+					break;
+				}
+			}
+			if (!found)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::AuctionNotFound);
+			}
+			else if (found->ended)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::AuctionExpired);
+			}
+			else if (found->ownerAccountId == 0u || found->ownerAccountId != accountId)
+			{
+				errorCode = static_cast<uint8_t>(AuctionErrorCode::NotOwner);
+			}
+			else
+			{
+				found->ended = true;
+			}
+		}
+
+		if (errorCode != 0u)
+		{
+			LOG_INFO(Net, "[AuctionHandler] Cancel error account={} auctionId={} error={}",
+				accountId, auctionId, static_cast<unsigned>(errorCode));
+			auto pkt = BuildAuctionCancelResponsePacket(errorCode, requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		LOG_INFO(Net, "[AuctionHandler] Cancel Ok account={} auctionId={}",
+			accountId, auctionId);
+
+		auto pkt = BuildAuctionCancelResponsePacket(0u, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+	// PushAuctionExpired
+	// -------------------------------------------------------------------------
+
+	bool AuctionHandler::PushAuctionExpired(uint32_t connId, uint64_t auctionId, uint8_t won,
+		uint64_t finalBidCopper, const std::string& winnerName)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[AuctionHandler] PushAuctionExpired dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[AuctionHandler] PushAuctionExpired: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildAuctionExpiredNotificationPacket(auctionId, won, finalBidCopper,
+			winnerName, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[AuctionHandler] PushAuctionExpired: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[AuctionHandler] PushAuctionExpired connId={} auctionId={} won={} finalBid={}",
+			connId, auctionId, static_cast<unsigned>(won), finalBidCopper);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	uint64_t AuctionHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+
+	uint32_t AuctionHandler::FindConnIdForAccount(uint64_t accountId) const
+	{
+		if (!m_connMap || !m_sessionMgr) return 0u;
+		const auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessionId] : snapshot)
+		{
+			auto acc = m_sessionMgr->GetAccountId(sessionId);
+			if (acc && *acc == accountId)
+				return connId;
+		}
+		return 0u;
+	}
+}

--- a/src/masterd/handlers/auction/AuctionHandler.h
+++ b/src/masterd/handlers/auction/AuctionHandler.h
@@ -1,0 +1,189 @@
+#pragma once
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — AuctionHandler : dispatch
+// des opcodes Auction (173/175/177/179) cote joueur et registry in-memory V1
+// de 8 listings hardcodees au boot. Le master gere les bids et marque les
+// auctions ended a chaque scan AuctionListRequest, en pushant
+// AuctionExpiredNotification a leurs owners si la connexion existe.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// 4 requests opcodes. Les responses 174/176/178/180 sont emises avec le
+// meme requestId / sessionId que la request recue. La push notification 181
+// (AuctionExpired) est emise par le handler (helper public PushAuctionExpired)
+// pour signaler les fins d'auctions.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// error=Unauthorized (code 1) dans la reponse type-specific.
+//
+// Store in-memory V1 (mutex protege) :
+//   - 8 auctions hardcodees au boot avec differents owners (Aragorn, Legolas,
+//     Gimli, Saruman) et expirations echelonnees (1h-48h).
+//   - Map item template id -> name (10 entries) pour les listings V1.
+//   - m_nextAuctionId (atomic) : incremente a chaque AuctionPostRequest.
+//
+// V1 limitations :
+//   - 8 listings hardcodes au boot. Future PR : DB seed via MysqlAuctionStore.
+//   - Item name table 10 entries hardcode. Future PR : ItemTemplate join.
+//   - Owner name = "Account#<id>" pour les listings postes par le client V1.
+//   - Pas d'expiration tick periodique : scan a chaque AuctionListRequest.
+//   - Pas de SyncAuction RPC entre master et shardd.
+//   - Pas de paiement reel : economie cosmetique V1.
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Auction in-memory V1.
+	struct InMemoryAuction
+	{
+		uint64_t                              auctionId               = 0;
+		uint32_t                              itemTemplateId          = 0;
+		std::string                           itemName;
+		uint32_t                              count                   = 0;
+		uint64_t                              startBidCopper          = 0;
+		uint64_t                              currentBidCopper        = 0;
+		uint64_t                              buyoutCopper            = 0;
+		std::string                           ownerName;
+		uint64_t                              ownerAccountId          = 0;
+		std::string                           highestBidderName;
+		uint64_t                              highestBidderAccountId  = 0;
+		std::chrono::steady_clock::time_point expiresAt{};
+		bool                                  ended                   = false;
+		bool                                  wonByBuyout             = false;
+	};
+
+	/// Dispatcher Auction cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class AuctionHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Initialise le store V1 : enregistre 8 auctions hardcodees avec
+		/// differents owners (Aragorn, Legolas, Gimli, Saruman) et expirations
+		/// echelonnees (1h-48h). Idempotent : appelable a chaque boot.
+		void SeedV1Auctions();
+
+		/// Point d'entree appele par NetServer pour les opcodes Auction.
+		/// Dispatch vers HandleList / HandlePost / HandleBid / HandleCancel
+		/// selon l'opcode. Si l'opcode n'est pas un opcode Auction, ignore
+		/// silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (173/175/177/179).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push AuctionExpiredNotification (opcode 181)
+		/// au client identifie par \p connId. Utilise par le handler en interne
+		/// (a chaque AuctionListRequest pour les auctions expirees) mais
+		/// accessible egalement depuis l'exterieur (tests, hooks futurs).
+		///
+		/// \param connId          identifiant de connexion TCP cible (0 = no-op).
+		/// \param auctionId       identifiant de l'auction expiree.
+		/// \param won             1 si vendue, 0 si terminee sans bid.
+		/// \param finalBidCopper  montant final (0 si won=0).
+		/// \param winnerName      nom du gagnant (vide si won=0).
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushAuctionExpired(uint32_t connId, uint64_t auctionId, uint8_t won,
+		                        uint64_t finalBidCopper, const std::string& winnerName);
+
+		/// Helper static : retourne le nom hardcode d'un item template V1.
+		/// Pour les ids inconnus retourne "Item #<id>".
+		static std::string ResolveItemName(uint32_t itemTemplateId);
+
+	private:
+		/// Traite AUCTION_LIST_REQUEST : scan + push expired si necessaires +
+		/// retourne les listings actifs (filtre eventuel sur itemTemplateId).
+		void HandleList(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite AUCTION_POST_REQUEST : valide params (count > 0, startBid > 0,
+		/// buyout 0 ou >= startBid, durationHours in {12, 24, 48}) puis cree
+		/// une nouvelle auction.
+		void HandlePost(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite AUCTION_BID_REQUEST : verifie auction active + bidAmount >
+		/// currentBid + bidder != owner. Si bidAmount >= buyoutCopper et buyout
+		/// > 0 -> buyout immediat (push expired au seller).
+		void HandleBid(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite AUCTION_CANCEL_REQUEST : verifie ownership puis marque
+		/// ended=true.
+		void HandleCancel(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Resout un accountId vers un connId via Snapshot() + GetAccountId().
+		/// Retourne 0 si aucune connexion ne correspond.
+		uint32_t FindConnIdForAccount(uint64_t accountId) const;
+
+		/// Scanne m_auctions et marque ended=true pour celles dont
+		/// expiresAt <= now. Pour chaque auction nouvellement marquee ended,
+		/// pousse AuctionExpiredNotification au owner si sa connexion est
+		/// resolvable. Doit etre appele AVEC m_mutex tenu par l'appelant.
+		///
+		/// \param now    instant de reference (steady_clock).
+		/// \param[out] expiredOwners  collecte des paires (ownerAccountId,
+		///                            auctionId, won, finalBid, winnerName)
+		///                            a pousser apres relachement du mutex.
+		struct ExpiredPushItem
+		{
+			uint64_t    ownerAccountId  = 0;
+			uint64_t    auctionId       = 0;
+			uint8_t     won             = 0;
+			uint64_t    finalBidCopper  = 0;
+			std::string winnerName;
+		};
+		void ScanExpiredLocked(std::chrono::steady_clock::time_point now,
+			std::vector<ExpiredPushItem>& expiredOwners);
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant m_auctions + m_seeded.
+		mutable std::mutex                               m_mutex;
+
+		/// Registry auctions in-memory (V1, 8 listings seedees au boot +
+		/// listings postes par les clients).
+		std::vector<InMemoryAuction>                     m_auctions;
+
+		/// Generateur d'auctionId monotone. Atomic pour autoriser un futur
+		/// usage hors mutex si necessaire.
+		std::atomic<uint64_t>                            m_nextAuctionId{1ull};
+
+		/// True une fois SeedV1Auctions() appele avec succes.
+		bool                                             m_seeded     = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -45,6 +45,7 @@
 #include "src/masterd/handlers/weather/WeatherHandler.h"
 #include "src/masterd/handlers/events/GameEventHandler.h"
 #include "src/masterd/handlers/guild/GuildHandler.h"
+#include "src/masterd/handlers/auction/AuctionHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -620,6 +621,22 @@ int main(int argc, char** argv)
 	guildHandler.SeedV1Guilds();
 	LOG_INFO(Net, "[ServerMain] GuildHandler configured (CMANGOS.21 step 3+4 Guilds, in-memory, 2 guilds seed)");
 
+	// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — AuctionHandler : list /
+	// post / bid / cancel + push AuctionExpired. V1 : 8 listings hardcodes
+	// au boot avec differents owners (Aragorn, Legolas, Gimli, Saruman) et
+	// expirations echelonnees (1h-48h). Les opcodes 173/175/177/179 sont
+	// dispatches au handler ; les responses 174/176/178/180 et la push
+	// notification 181 (AuctionExpired) sont emises par le handler. V1
+	// limitations : item name table 10 entries hardcode, owner name =
+	// "Account#<id>", pas de paiement reel (economie cosmetique), pas de
+	// SyncAuction RPC entre master et shardd.
+	engine::server::AuctionHandler auctionHandler;
+	auctionHandler.SetServer(&server);
+	auctionHandler.SetSessionManager(&sessionManager);
+	auctionHandler.SetConnectionSessionMap(&connSessionMap);
+	auctionHandler.SeedV1Auctions();
+	LOG_INFO(Net, "[ServerMain] AuctionHandler configured (CMANGOS.09 step 3+4 AuctionHouse, in-memory, 8 listings seed)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -659,7 +676,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -753,6 +770,11 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeGuildPermissionsRequest
 		      || opcode == kOpcodeGuildBankRequest)
 			guildHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeAuctionListRequest
+		      || opcode == kOpcodeAuctionPostRequest
+		      || opcode == kOpcodeAuctionBidRequest
+		      || opcode == kOpcodeAuctionCancelRequest)
+			auctionHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/AuctionPayloads.cpp
+++ b/src/shared/network/AuctionPayloads.cpp
@@ -1,0 +1,385 @@
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Implementation Parse/Build
+// des payloads Auction.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/AuctionPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Ecrit un AuctionListingSummary complet sur le wire.
+		bool WriteAuctionListingSummary(ByteWriter& w, const AuctionListingSummary& s)
+		{
+			if (!w.WriteU64(s.auctionId))              return false;
+			if (!w.WriteU32(s.itemTemplateId))         return false;
+			if (!w.WriteString(s.itemName))            return false;
+			if (!w.WriteU32(s.count))                  return false;
+			if (!w.WriteU64(s.currentBidCopper))       return false;
+			if (!w.WriteU64(s.buyoutCopper))           return false;
+			if (!w.WriteString(s.ownerName))           return false;
+			if (!w.WriteU64(s.secondsUntilExpiration)) return false;
+			return true;
+		}
+
+		/// Lit un AuctionListingSummary depuis le wire.
+		bool ReadAuctionListingSummary(ByteReader& r, AuctionListingSummary& out)
+		{
+			if (!r.ReadU64(out.auctionId))              return false;
+			if (!r.ReadU32(out.itemTemplateId))         return false;
+			if (!r.ReadString(out.itemName))            return false;
+			if (!r.ReadU32(out.count))                  return false;
+			if (!r.ReadU64(out.currentBidCopper))       return false;
+			if (!r.ReadU64(out.buyoutCopper))           return false;
+			if (!r.ReadString(out.ownerName))           return false;
+			if (!r.ReadU64(out.secondsUntilExpiration)) return false;
+			return true;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_LIST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionListRequestPayload> ParseAuctionListRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 4u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionListRequestPayload out;
+		if (!r.ReadU32(out.itemTemplateIdFilter)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionListRequestPayload(uint32_t itemTemplateIdFilter)
+	{
+		std::vector<uint8_t> buf(4u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(itemTemplateIdFilter)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_LIST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionListResponsePayload> ParseAuctionListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.listings.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			AuctionListingSummary s;
+			if (!ReadAuctionListingSummary(r, s)) return std::nullopt;
+			out.listings.push_back(std::move(s));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionListResponsePayload(uint8_t error, const std::vector<AuctionListingSummary>& listings)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(listings.size()))) return {};
+			for (const auto& s : listings)
+			{
+				if (!WriteAuctionListingSummary(w, s)) return {};
+			}
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildAuctionListResponsePacket(uint8_t error, const std::vector<AuctionListingSummary>& listings,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(listings.size()))) return {};
+			for (const auto& s : listings)
+			{
+				if (!WriteAuctionListingSummary(w, s)) return {};
+			}
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeAuctionListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_POST — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionPostRequestPayload> ParseAuctionPostRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint32 itemTemplateId (4) + uint32 count (4) + uint64 startBid (8)
+		//     + uint64 buyout (8) + uint8 durationHours (1) = 25.
+		if (!payload || payloadSize < 25u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionPostRequestPayload out;
+		if (!r.ReadU32(out.itemTemplateId))   return std::nullopt;
+		if (!r.ReadU32(out.count))            return std::nullopt;
+		if (!r.ReadU64(out.startBidCopper))   return std::nullopt;
+		if (!r.ReadU64(out.buyoutCopper))     return std::nullopt;
+		if (!r.ReadBytes(&out.durationHours, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionPostRequestPayload(uint32_t itemTemplateId, uint32_t count,
+		uint64_t startBidCopper, uint64_t buyoutCopper, uint8_t durationHours)
+	{
+		std::vector<uint8_t> buf(25u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU32(itemTemplateId))   return {};
+		if (!w.WriteU32(count))            return {};
+		if (!w.WriteU64(startBidCopper))   return {};
+		if (!w.WriteU64(buyoutCopper))     return {};
+		if (!w.WriteBytes(&durationHours, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_POST — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionPostResponsePayload> ParseAuctionPostResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionPostResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		if (!r.ReadU64(out.auctionId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionPostResponsePayload(uint8_t error, uint64_t auctionId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU64(auctionId)) return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildAuctionPostResponsePacket(uint8_t error, uint64_t auctionId,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteU64(auctionId)) return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeAuctionPostResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_BID — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionBidRequestPayload> ParseAuctionBidRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 auctionId (8) + uint64 bidAmount (8) = 16.
+		if (!payload || payloadSize < 16u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionBidRequestPayload out;
+		if (!r.ReadU64(out.auctionId))       return std::nullopt;
+		if (!r.ReadU64(out.bidAmountCopper)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionBidRequestPayload(uint64_t auctionId, uint64_t bidAmountCopper)
+	{
+		std::vector<uint8_t> buf(16u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(auctionId))       return {};
+		if (!w.WriteU64(bidAmountCopper)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_BID — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionBidResponsePayload> ParseAuctionBidResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionBidResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		if (out.error != 0u) return out;
+		if (!r.ReadBytes(&out.isBuyout, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionBidResponsePayload(uint8_t error, uint8_t isBuyout)
+	{
+		std::vector<uint8_t> buf(2u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteBytes(&isBuyout, 1u)) return {};
+		}
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildAuctionBidResponsePacket(uint8_t error, uint8_t isBuyout,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		if (error == 0u)
+		{
+			if (!w.WriteBytes(&isBuyout, 1u)) return {};
+		}
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeAuctionBidResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_CANCEL — Request
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionCancelRequestPayload> ParseAuctionCancelRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 8u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionCancelRequestPayload out;
+		if (!r.ReadU64(out.auctionId)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionCancelRequestPayload(uint64_t auctionId)
+	{
+		std::vector<uint8_t> buf(8u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(auctionId)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_CANCEL — Response
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionCancelResponsePayload> ParseAuctionCancelResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionCancelResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionCancelResponsePayload(uint8_t error)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&error, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildAuctionCancelResponsePacket(uint8_t error,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&error, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeAuctionCancelResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// AUCTION_EXPIRED_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionExpiredNotificationPayload> ParseAuctionExpiredNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 auctionId (8) + uint8 won (1) + uint64 finalBid (8)
+		//     + uint16 string length (2) = 19 (winnerName vide possible).
+		if (!payload || payloadSize < 19u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AuctionExpiredNotificationPayload out;
+		if (!r.ReadU64(out.auctionId))     return std::nullopt;
+		if (!r.ReadBytes(&out.won, 1u))    return std::nullopt;
+		if (!r.ReadU64(out.finalBidCopper)) return std::nullopt;
+		if (!r.ReadString(out.winnerName)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAuctionExpiredNotificationPayload(uint64_t auctionId, uint8_t won,
+		uint64_t finalBidCopper, const std::string& winnerName)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(auctionId))     return {};
+		if (!w.WriteBytes(&won, 1u))    return {};
+		if (!w.WriteU64(finalBidCopper)) return {};
+		if (!w.WriteString(winnerName)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildAuctionExpiredNotificationPacket(uint64_t auctionId, uint8_t won,
+		uint64_t finalBidCopper, const std::string& winnerName, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(auctionId))     return {};
+		if (!w.WriteBytes(&won, 1u))    return {};
+		if (!w.WriteU64(finalBidCopper)) return {};
+		if (!w.WriteString(winnerName)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeAuctionExpiredNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/AuctionPayloads.h
+++ b/src/shared/network/AuctionPayloads.h
@@ -1,0 +1,229 @@
+#pragma once
+// CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Wire payloads pour les
+// opcodes Auction (173-181). 4 paires Request/Response + 1 push notification :
+//   - List   (173/174)               : liste des listings (filter optionnel itemTemplateId).
+//   - Post   (175/176)               : poste une nouvelle enchere.
+//   - Bid    (177/178)               : place une bid (ou buyout immediat).
+//   - Cancel (179/180)               : annule une enchere du sender.
+//   - ExpiredNotification (181 push) : enchere expiree (vendue ou non).
+//
+// Le master tient en memoire un registry d'auctions (V1 : 8 listings seedees
+// au boot avec differents owners). Les bids sont gerees inline. Pas de Tick
+// periodique pour expirations : scan a chaque AuctionListRequest.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Strings via
+// WriteString/ReadString (uint16 length + UTF-8 bytes), arrays via
+// WriteArrayCount/ReadArrayCount (uint16 count). Bool serialise en uint8 (0/1).
+// Quantites monetaires en uint64 (copper).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur — wire-level pour Auction.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Auction. 0 = OK.
+	enum class AuctionErrorCode : uint8_t
+	{
+		Ok               = 0,
+		Unauthorized     = 1, ///< Pas de session valide cote master.
+		InvalidParams    = 2, ///< Post : count=0, startBid=0, duration invalide, ou buyout < startBid.
+		BidTooLow        = 3, ///< Bid : montant <= currentBid.
+		AuctionExpired   = 4, ///< Bid/Cancel : auction terminee ou expiree.
+		OwnAuction       = 5, ///< Bid : le bidder est le owner de l'auction.
+		NotOwner         = 6, ///< Cancel : le sender n'est pas le owner.
+		AuctionNotFound  = 7, ///< Cancel/Bid : auctionId inconnu du registry.
+	};
+
+	// =========================================================================
+	// Sous-structs partages.
+	// =========================================================================
+
+	/// Resume d'une enchere active pour le wire (List response).
+	/// Wire format :
+	///   uint64 auctionId
+	///   uint32 itemTemplateId
+	///   string itemName
+	///   uint32 count
+	///   uint64 currentBidCopper
+	///   uint64 buyoutCopper                 (0 = pas de buyout)
+	///   string ownerName
+	///   uint64 secondsUntilExpiration
+	struct AuctionListingSummary
+	{
+		uint64_t    auctionId               = 0;
+		uint32_t    itemTemplateId          = 0;
+		std::string itemName;
+		uint32_t    count                   = 0;
+		uint64_t    currentBidCopper        = 0;
+		uint64_t    buyoutCopper            = 0;
+		std::string ownerName;
+		uint64_t    secondsUntilExpiration  = 0;
+	};
+
+	// =========================================================================
+	// AUCTION_LIST — Client to Master : liste les enchetes actives.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 itemTemplateIdFilter (0 = pas de filtre)
+	struct AuctionListRequestPayload
+	{
+		uint32_t itemTemplateIdFilter = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error                       (cf. AuctionErrorCode)
+	///   uint16 listingCount                (si error == 0)
+	///   <count> AuctionListingSummary
+	struct AuctionListResponsePayload
+	{
+		uint8_t                            error = 0;
+		std::vector<AuctionListingSummary> listings;
+	};
+
+	// =========================================================================
+	// AUCTION_POST — Client to Master : poste une nouvelle enchere.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint32 itemTemplateId
+	///   uint32 count
+	///   uint64 startBidCopper
+	///   uint64 buyoutCopper       (0 = pas de buyout)
+	///   uint8  durationHours      (12, 24 ou 48 V1)
+	struct AuctionPostRequestPayload
+	{
+		uint32_t itemTemplateId  = 0;
+		uint32_t count           = 0;
+		uint64_t startBidCopper  = 0;
+		uint64_t buyoutCopper    = 0;
+		uint8_t  durationHours   = 0;
+	};
+
+	/// Wire format :
+	///   uint8  error
+	///   uint64 auctionId          (si error == 0)
+	struct AuctionPostResponsePayload
+	{
+		uint8_t  error     = 0;
+		uint64_t auctionId = 0;
+	};
+
+	// =========================================================================
+	// AUCTION_BID — Client to Master : place une bid (ou buyout).
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 auctionId
+	///   uint64 bidAmountCopper
+	struct AuctionBidRequestPayload
+	{
+		uint64_t auctionId       = 0;
+		uint64_t bidAmountCopper = 0;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	///   uint8 isBuyout         (0 = bid normale, 1 = buyout immediat)
+	struct AuctionBidResponsePayload
+	{
+		uint8_t error    = 0;
+		uint8_t isBuyout = 0;
+	};
+
+	// =========================================================================
+	// AUCTION_CANCEL — Client to Master : annule sa propre enchere.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 auctionId
+	struct AuctionCancelRequestPayload
+	{
+		uint64_t auctionId = 0;
+	};
+
+	/// Wire format :
+	///   uint8 error
+	struct AuctionCancelResponsePayload
+	{
+		uint8_t error = 0;
+	};
+
+	// =========================================================================
+	// AUCTION_EXPIRED_NOTIFICATION — Master to Client (push, requestId=0).
+	// Enchere expiree : soit vendue (won=1), soit terminee sans bid (won=0).
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 auctionId
+	///   uint8  won                   (0 = pas de bid / 1 = vendue)
+	///   uint64 finalBidCopper        (0 si won=0)
+	///   string winnerName            (vide si won=0)
+	struct AuctionExpiredNotificationPayload
+	{
+		uint64_t    auctionId       = 0;
+		uint8_t     won             = 0;
+		uint64_t    finalBidCopper  = 0;
+		std::string winnerName;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Requests (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionListRequestPayload>    ParseAuctionListRequestPayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionPostRequestPayload>    ParseAuctionPostRequestPayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionBidRequestPayload>     ParseAuctionBidRequestPayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionCancelRequestPayload>  ParseAuctionCancelRequestPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildAuctionListRequestPayload    (uint32_t itemTemplateIdFilter);
+	std::vector<uint8_t> BuildAuctionPostRequestPayload    (uint32_t itemTemplateId, uint32_t count,
+	                                                        uint64_t startBidCopper, uint64_t buyoutCopper,
+	                                                        uint8_t durationHours);
+	std::vector<uint8_t> BuildAuctionBidRequestPayload     (uint64_t auctionId, uint64_t bidAmountCopper);
+	std::vector<uint8_t> BuildAuctionCancelRequestPayload  (uint64_t auctionId);
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — Responses & Notifications (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<AuctionListResponsePayload>          ParseAuctionListResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionPostResponsePayload>          ParseAuctionPostResponsePayload         (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionBidResponsePayload>           ParseAuctionBidResponsePayload          (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionCancelResponsePayload>        ParseAuctionCancelResponsePayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<AuctionExpiredNotificationPayload>   ParseAuctionExpiredNotificationPayload  (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildAuctionListResponsePayload          (uint8_t error, const std::vector<AuctionListingSummary>& listings);
+	std::vector<uint8_t> BuildAuctionPostResponsePayload          (uint8_t error, uint64_t auctionId);
+	std::vector<uint8_t> BuildAuctionBidResponsePayload           (uint8_t error, uint8_t isBuyout);
+	std::vector<uint8_t> BuildAuctionCancelResponsePayload        (uint8_t error);
+	std::vector<uint8_t> BuildAuctionExpiredNotificationPayload   (uint64_t auctionId, uint8_t won,
+	                                                               uint64_t finalBidCopper,
+	                                                               const std::string& winnerName);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	std::vector<uint8_t> BuildAuctionListResponsePacket        (uint8_t error, const std::vector<AuctionListingSummary>& listings,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildAuctionPostResponsePacket        (uint8_t error, uint64_t auctionId,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildAuctionBidResponsePacket         (uint8_t error, uint8_t isBuyout,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildAuctionCancelResponsePacket      (uint8_t error,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildAuctionExpiredNotificationPacket (uint64_t auctionId, uint8_t won,
+	                                                            uint64_t finalBidCopper,
+	                                                            const std::string& winnerName,
+	                                                            uint64_t sessionIdHeader);
+}

--- a/src/shared/network/AuctionPayloadsTests.cpp
+++ b/src/shared/network/AuctionPayloadsTests.cpp
@@ -1,0 +1,476 @@
+/**
+ * CMANGOS.09 (Phase 5.09 step 3+4 AuctionHouse) — Round-trip tests pour les
+ * payloads AUCTION_*. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/AuctionPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// AUCTION_LIST
+// -----------------------------------------------------------------------------
+
+static void TestListRequestNoFilter()
+{
+	auto buf = BuildAuctionListRequestPayload(0u);
+	auto parsed = ParseAuctionListRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->itemTemplateIdFilter == 0u,
+		"List request round-trip filter=0");
+}
+
+static void TestListRequestWithFilter()
+{
+	auto buf = BuildAuctionListRequestPayload(42u);
+	auto parsed = ParseAuctionListRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->itemTemplateIdFilter == 42u,
+		"List request round-trip filter=42");
+}
+
+static void TestListRequestRejectsShort()
+{
+	auto parsed = ParseAuctionListRequestPayload(nullptr, 4u);
+	Assert(!parsed.has_value(), "List request rejects nullptr");
+	uint8_t shortBuf[3]{};
+	auto parsed2 = ParseAuctionListRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "List request rejects 3 bytes");
+}
+
+static void TestListResponseEmpty()
+{
+	auto buf = BuildAuctionListResponsePayload(0u, {});
+	auto parsed = ParseAuctionListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->listings.empty(),
+		"List response empty parses");
+}
+
+static void TestListResponseSingle()
+{
+	AuctionListingSummary s;
+	s.auctionId              = 7ull;
+	s.itemTemplateId         = 1u;
+	s.itemName               = "Iron Ore";
+	s.count                  = 20u;
+	s.currentBidCopper       = 500ull;
+	s.buyoutCopper           = 1000ull;
+	s.ownerName              = "Aragorn";
+	s.secondsUntilExpiration = 3600ull;
+	auto buf = BuildAuctionListResponsePayload(0u, {s});
+	auto parsed = ParseAuctionListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "List response single parses");
+	if (parsed && parsed->listings.size() == 1u)
+	{
+		Assert(parsed->listings[0].auctionId == 7ull,           "List[0] auctionId");
+		Assert(parsed->listings[0].itemTemplateId == 1u,        "List[0] itemTemplateId");
+		Assert(parsed->listings[0].itemName == "Iron Ore",      "List[0] itemName");
+		Assert(parsed->listings[0].count == 20u,                "List[0] count");
+		Assert(parsed->listings[0].currentBidCopper == 500ull,  "List[0] currentBid");
+		Assert(parsed->listings[0].buyoutCopper == 1000ull,     "List[0] buyout");
+		Assert(parsed->listings[0].ownerName == "Aragorn",      "List[0] ownerName");
+		Assert(parsed->listings[0].secondsUntilExpiration == 3600ull, "List[0] secondsUntil");
+	}
+	else
+	{
+		Assert(false, "List should have 1 listing");
+	}
+}
+
+static void TestListResponseMultiple()
+{
+	std::vector<AuctionListingSummary> listings;
+	for (uint64_t i = 0; i < 8u; ++i)
+	{
+		AuctionListingSummary s;
+		s.auctionId              = i + 1u;
+		s.itemTemplateId         = static_cast<uint32_t>(i + 1u);
+		s.itemName               = "Item";
+		s.count                  = static_cast<uint32_t>(i + 1u);
+		s.currentBidCopper       = (i + 1u) * 100ull;
+		s.buyoutCopper           = (i + 1u) * 200ull;
+		s.ownerName              = "Owner";
+		s.secondsUntilExpiration = (i + 1u) * 3600ull;
+		listings.push_back(s);
+	}
+	auto buf = BuildAuctionListResponsePayload(0u, listings);
+	auto parsed = ParseAuctionListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->listings.size() == 8u, "List 8 listings parses");
+	if (parsed && parsed->listings.size() == 8u)
+	{
+		Assert(parsed->listings[0].auctionId == 1ull, "L[0] id 1");
+		Assert(parsed->listings[7].auctionId == 8ull, "L[7] id 8");
+		Assert(parsed->listings[7].secondsUntilExpiration == 8ull * 3600ull, "L[7] expiration");
+	}
+}
+
+static void TestListResponseUnauthorized()
+{
+	auto buf = BuildAuctionListResponsePayload(
+		static_cast<uint8_t>(AuctionErrorCode::Unauthorized), {});
+	Assert(buf.size() == 1u, "List error has only 1 byte");
+	auto parsed = ParseAuctionListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 1u, "List Unauthorized");
+}
+
+static void TestListResponsePriceMaxAndZero()
+{
+	AuctionListingSummary s1;
+	s1.auctionId = 1ull;
+	s1.itemTemplateId = 1u;
+	s1.itemName = "Cheap";
+	s1.count = 1u;
+	s1.currentBidCopper = 0ull;
+	s1.buyoutCopper = 0ull;
+	s1.ownerName = "X";
+	s1.secondsUntilExpiration = 0ull;
+	AuctionListingSummary s2;
+	s2.auctionId = 2ull;
+	s2.itemTemplateId = 2u;
+	s2.itemName = "Max";
+	s2.count = 0xFFFFFFFFu;
+	s2.currentBidCopper = 0xFFFFFFFFFFFFFFFFull;
+	s2.buyoutCopper = 0xFFFFFFFFFFFFFFFFull;
+	s2.ownerName = "Y";
+	s2.secondsUntilExpiration = 0xFFFFFFFFFFFFFFFFull;
+	auto buf = BuildAuctionListResponsePayload(0u, {s1, s2});
+	auto parsed = ParseAuctionListResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->listings.size() == 2u
+		&& parsed->listings[0].currentBidCopper == 0ull
+		&& parsed->listings[1].currentBidCopper == 0xFFFFFFFFFFFFFFFFull
+		&& parsed->listings[1].buyoutCopper == 0xFFFFFFFFFFFFFFFFull,
+		"List accepts 0 and uint64 max copper");
+}
+
+static void TestListResponsePacket()
+{
+	AuctionListingSummary s;
+	s.auctionId = 42ull;
+	s.itemTemplateId = 5u;
+	s.itemName = "Mana Potion";
+	s.count = 5u;
+	s.currentBidCopper = 250ull;
+	s.buyoutCopper = 500ull;
+	s.ownerName = "Boss";
+	s.secondsUntilExpiration = 7200ull;
+	auto pkt = BuildAuctionListResponsePacket(0u, {s}, 999u, 0xCAFEull);
+	Assert(!pkt.empty(), "List packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"List PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeAuctionListResponse, "Opcode is ListResponse");
+	Assert(view.RequestId() == 999u, "List RequestId preserved");
+	Assert(view.SessionId() == 0xCAFEull, "List SessionId preserved");
+	auto parsed = ParseAuctionListResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->listings.size() == 1u
+		&& parsed->listings[0].auctionId == 42ull
+		&& parsed->listings[0].ownerName == "Boss",
+		"List payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// AUCTION_POST
+// -----------------------------------------------------------------------------
+
+static void TestPostRequestRoundTrip()
+{
+	auto buf = BuildAuctionPostRequestPayload(7u, 10u, 100ull, 500ull, 24u);
+	auto parsed = ParseAuctionPostRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "Post request parses");
+	if (parsed)
+	{
+		Assert(parsed->itemTemplateId == 7u, "Post itemTemplateId");
+		Assert(parsed->count == 10u, "Post count");
+		Assert(parsed->startBidCopper == 100ull, "Post startBid");
+		Assert(parsed->buyoutCopper == 500ull, "Post buyout");
+		Assert(parsed->durationHours == 24u, "Post durationHours");
+	}
+}
+
+static void TestPostRequestNoBuyout()
+{
+	auto buf = BuildAuctionPostRequestPayload(1u, 1u, 50ull, 0ull, 12u);
+	auto parsed = ParseAuctionPostRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->buyoutCopper == 0ull
+		&& parsed->durationHours == 12u,
+		"Post accepts buyout=0 + duration=12h");
+}
+
+static void TestPostRequestDuration48h()
+{
+	auto buf = BuildAuctionPostRequestPayload(99u, 100u, 1000ull, 5000ull, 48u);
+	auto parsed = ParseAuctionPostRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->durationHours == 48u,
+		"Post accepts duration=48h");
+}
+
+static void TestPostRequestRejectsShort()
+{
+	auto parsed = ParseAuctionPostRequestPayload(nullptr, 25u);
+	Assert(!parsed.has_value(), "Post request rejects nullptr");
+	uint8_t shortBuf[24]{};
+	auto parsed2 = ParseAuctionPostRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Post request rejects 24 bytes");
+}
+
+static void TestPostResponseOk()
+{
+	auto buf = BuildAuctionPostResponsePayload(0u, 12345ull);
+	auto parsed = ParseAuctionPostResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->auctionId == 12345ull,
+		"Post response Ok with auctionId");
+}
+
+static void TestPostResponseInvalidParams()
+{
+	auto buf = BuildAuctionPostResponsePayload(
+		static_cast<uint8_t>(AuctionErrorCode::InvalidParams), 0ull);
+	Assert(buf.size() == 1u, "Post error has only 1 byte");
+	auto parsed = ParseAuctionPostResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 2u, "Post InvalidParams");
+}
+
+static void TestPostResponsePacket()
+{
+	auto pkt = BuildAuctionPostResponsePacket(0u, 777ull, 1234u, 0xBEEFull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Post PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeAuctionPostResponse, "Opcode is PostResponse");
+	Assert(view.RequestId() == 1234u, "Post RequestId preserved");
+	auto parsed = ParseAuctionPostResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->auctionId == 777ull, "Post payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// AUCTION_BID
+// -----------------------------------------------------------------------------
+
+static void TestBidRequestRoundTrip()
+{
+	auto buf = BuildAuctionBidRequestPayload(7ull, 1500ull);
+	auto parsed = ParseAuctionBidRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->auctionId == 7ull
+		&& parsed->bidAmountCopper == 1500ull,
+		"Bid request round-trip");
+}
+
+static void TestBidRequestRejectsShort()
+{
+	auto parsed = ParseAuctionBidRequestPayload(nullptr, 16u);
+	Assert(!parsed.has_value(), "Bid request rejects nullptr");
+	uint8_t shortBuf[15]{};
+	auto parsed2 = ParseAuctionBidRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Bid request rejects 15 bytes");
+}
+
+static void TestBidResponseNormal()
+{
+	auto buf = BuildAuctionBidResponsePayload(0u, 0u);
+	auto parsed = ParseAuctionBidResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->isBuyout == 0u,
+		"Bid response Ok normal");
+}
+
+static void TestBidResponseBuyout()
+{
+	auto buf = BuildAuctionBidResponsePayload(0u, 1u);
+	auto parsed = ParseAuctionBidResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u && parsed->isBuyout == 1u,
+		"Bid response Ok buyout");
+}
+
+static void TestBidResponseTooLow()
+{
+	auto buf = BuildAuctionBidResponsePayload(
+		static_cast<uint8_t>(AuctionErrorCode::BidTooLow), 0u);
+	Assert(buf.size() == 1u, "Bid error has only 1 byte");
+	auto parsed = ParseAuctionBidResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 3u, "Bid BidTooLow");
+}
+
+static void TestBidResponseOwnAuction()
+{
+	auto buf = BuildAuctionBidResponsePayload(
+		static_cast<uint8_t>(AuctionErrorCode::OwnAuction), 0u);
+	auto parsed = ParseAuctionBidResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 5u, "Bid OwnAuction");
+}
+
+static void TestBidResponsePacket()
+{
+	auto pkt = BuildAuctionBidResponsePacket(0u, 1u, 555u, 0xFEEDull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Bid PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeAuctionBidResponse, "Opcode is BidResponse");
+	auto parsed = ParseAuctionBidResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->isBuyout == 1u, "Bid payload decodes buyout=1");
+}
+
+// -----------------------------------------------------------------------------
+// AUCTION_CANCEL
+// -----------------------------------------------------------------------------
+
+static void TestCancelRequestRoundTrip()
+{
+	auto buf = BuildAuctionCancelRequestPayload(99ull);
+	auto parsed = ParseAuctionCancelRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->auctionId == 99ull,
+		"Cancel request round-trip");
+}
+
+static void TestCancelRequestRejectsShort()
+{
+	auto parsed = ParseAuctionCancelRequestPayload(nullptr, 8u);
+	Assert(!parsed.has_value(), "Cancel request rejects nullptr");
+	uint8_t shortBuf[7]{};
+	auto parsed2 = ParseAuctionCancelRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Cancel request rejects 7 bytes");
+}
+
+static void TestCancelResponseOk()
+{
+	auto buf = BuildAuctionCancelResponsePayload(0u);
+	auto parsed = ParseAuctionCancelResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 0u, "Cancel response Ok");
+}
+
+static void TestCancelResponseNotOwner()
+{
+	auto buf = BuildAuctionCancelResponsePayload(
+		static_cast<uint8_t>(AuctionErrorCode::NotOwner));
+	auto parsed = ParseAuctionCancelResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->error == 6u, "Cancel NotOwner");
+}
+
+static void TestCancelResponsePacket()
+{
+	auto pkt = BuildAuctionCancelResponsePacket(0u, 42u, 0x12345ull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Cancel PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeAuctionCancelResponse, "Opcode is CancelResponse");
+}
+
+// -----------------------------------------------------------------------------
+// AUCTION_EXPIRED_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestExpiredNotifWonRoundTrip()
+{
+	auto buf = BuildAuctionExpiredNotificationPayload(7ull, 1u, 1500ull, "Aragorn");
+	auto parsed = ParseAuctionExpiredNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "ExpiredNotif won parses");
+	if (parsed)
+	{
+		Assert(parsed->auctionId == 7ull, "ExpiredNotif auctionId");
+		Assert(parsed->won == 1u, "ExpiredNotif won=1");
+		Assert(parsed->finalBidCopper == 1500ull, "ExpiredNotif finalBid");
+		Assert(parsed->winnerName == "Aragorn", "ExpiredNotif winnerName");
+	}
+}
+
+static void TestExpiredNotifLostRoundTrip()
+{
+	auto buf = BuildAuctionExpiredNotificationPayload(99ull, 0u, 0ull, "");
+	auto parsed = ParseAuctionExpiredNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->won == 0u
+		&& parsed->finalBidCopper == 0ull
+		&& parsed->winnerName.empty(),
+		"ExpiredNotif lost (won=0, no winner) round-trip");
+}
+
+static void TestExpiredNotifRejectsShort()
+{
+	auto parsed = ParseAuctionExpiredNotificationPayload(nullptr, 19u);
+	Assert(!parsed.has_value(), "ExpiredNotif rejects nullptr");
+	uint8_t shortBuf[18]{};
+	auto parsed2 = ParseAuctionExpiredNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "ExpiredNotif rejects 18 bytes");
+}
+
+static void TestExpiredNotifPacket()
+{
+	auto pkt = BuildAuctionExpiredNotificationPacket(123ull, 1u, 9999ull, "Saruman", 0xFADEull);
+	Assert(!pkt.empty(), "ExpiredNotif packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"ExpiredNotif PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeAuctionExpiredNotification, "Opcode is ExpiredNotif");
+	Assert(view.RequestId() == 0u, "Push requestId=0");
+	Assert(view.SessionId() == 0xFADEull, "ExpiredNotif SessionId preserved");
+	auto parsed = ParseAuctionExpiredNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->auctionId == 123ull
+		&& parsed->winnerName == "Saruman",
+		"ExpiredNotif payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// main
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestListRequestNoFilter();
+	TestListRequestWithFilter();
+	TestListRequestRejectsShort();
+	TestListResponseEmpty();
+	TestListResponseSingle();
+	TestListResponseMultiple();
+	TestListResponseUnauthorized();
+	TestListResponsePriceMaxAndZero();
+	TestListResponsePacket();
+
+	TestPostRequestRoundTrip();
+	TestPostRequestNoBuyout();
+	TestPostRequestDuration48h();
+	TestPostRequestRejectsShort();
+	TestPostResponseOk();
+	TestPostResponseInvalidParams();
+	TestPostResponsePacket();
+
+	TestBidRequestRoundTrip();
+	TestBidRequestRejectsShort();
+	TestBidResponseNormal();
+	TestBidResponseBuyout();
+	TestBidResponseTooLow();
+	TestBidResponseOwnAuction();
+	TestBidResponsePacket();
+
+	TestCancelRequestRoundTrip();
+	TestCancelRequestRejectsShort();
+	TestCancelResponseOk();
+	TestCancelResponseNotOwner();
+	TestCancelResponsePacket();
+
+	TestExpiredNotifWonRoundTrip();
+	TestExpiredNotifLostRoundTrip();
+	TestExpiredNotifRejectsShort();
+	TestExpiredNotifPacket();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all auction payload tests passed\n"
+	                                : "[FAIL] some auction tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -697,4 +697,45 @@ namespace engine::network
 	constexpr uint16_t kOpcodeGuildBankRequest            = 170u; ///< Client to Master : contenu bank d'une guilde (guildId, tabIndex).
 	constexpr uint16_t kOpcodeGuildBankResponse           = 171u; ///< Master to Client : liste {slotIndex, itemName, count} ou UnknownGuild / NoPermission / Unauthorized.
 	constexpr uint16_t kOpcodeGuildMotdUpdateNotification = 172u; ///< Master to Client (push, request_id=0) : changement MOTD (guildId, newMotd).
+
+	// =====================================================================
+	// CMANGOS.09 step 3+4 — AuctionHouse wire (list, post, bid, cancel, expired
+	// push). Master tient en memoire un registry de listings (V1 seed via
+	// 8 listings hardcodes au boot) + handle bids + simule les expirations
+	// au scan a chaque AuctionListRequest.
+	//
+	// Architecture : 8 auctions seedees au boot avec differents owners
+	// (Aragorn, Legolas, Gimli, Saruman) et expirations echelonnees
+	// (1h-48h), avec ou sans buyout. Le master tient en memoire un
+	// std::vector<InMemoryAuction> protege par mutex. V1 simplifie : pas
+	// de Tick periodique pour expirations -- le scan est fait a chaque
+	// AuctionListRequest (les auctions expirees sont marquees ended et
+	// poussent une AuctionExpiredNotification a leur owner via connId
+	// resolu si possible).
+	//
+	// V1 limitations :
+	//   - 8 listings hardcodes au boot. Future PR : DB seed via
+	//     MysqlAuctionStore + AuctionHouseBot integration pour low-pop.
+	//   - Item name table 10 entries hardcode. Future PR : ItemTemplate join.
+	//   - Owner name = "Account#<id>" V1. Future PR : lookup CharacterName.
+	//   - Pas d'expiration tick periodique : scan a chaque AuctionListRequest.
+	//   - Pas de SyncAuction RPC entre master et shardd (master autoritaire V1).
+	//   - Pas de paiement reel : economie cosmetique V1 (pas de gold debit/credit).
+	//
+	// Decoupage opcode :
+	//   - List   (173/174)               : liste les listings actifs (filter optionnel).
+	//   - Post   (175/176)               : poste une nouvelle enchere.
+	//   - Bid    (177/178)               : place une bid (ou achete via buyout).
+	//   - Cancel (179/180)               : annule sa propre enchere.
+	//   - ExpiredNotification (181, push) : enchere expiree (vendue ou non).
+	// =====================================================================
+	constexpr uint16_t kOpcodeAuctionListRequest          = 173u; ///< Client to Master : liste listings (filter optionnel : itemTemplateId).
+	constexpr uint16_t kOpcodeAuctionListResponse         = 174u; ///< Master to Client : liste {auctionId, itemTemplateId, itemName, count, currentBidCopper, buyoutCopper, ownerName, secondsUntilExpiration} ou Unauthorized.
+	constexpr uint16_t kOpcodeAuctionPostRequest          = 175u; ///< Client to Master : post nouvelle enchere (itemTemplateId, count, startBidCopper, buyoutCopper, durationHours).
+	constexpr uint16_t kOpcodeAuctionPostResponse         = 176u; ///< Master to Client : OK + auctionId, ou InvalidParams / Unauthorized.
+	constexpr uint16_t kOpcodeAuctionBidRequest           = 177u; ///< Client to Master : place une bid (auctionId, bidAmountCopper).
+	constexpr uint16_t kOpcodeAuctionBidResponse          = 178u; ///< Master to Client : OK + isBuyout bool, ou BidTooLow / AuctionExpired / OwnAuction / Unauthorized.
+	constexpr uint16_t kOpcodeAuctionCancelRequest        = 179u; ///< Client to Master : annule sa propre enchere (auctionId).
+	constexpr uint16_t kOpcodeAuctionCancelResponse       = 180u; ///< Master to Client : OK ou NotOwner / AuctionNotFound / Unauthorized.
+	constexpr uint16_t kOpcodeAuctionExpiredNotification  = 181u; ///< Master to Client (push, request_id=0) : enchere expiree (auctionId, won bool, finalBidCopper, winnerName).
 }


### PR DESCRIPTION
## CMANGOS.09 step 3+4 : AuctionHouse wire (list / post / bid / expired + UI panel)

Wire de l'Auction House master-side avec un registry in-memory (V1 seed 8 listings hardcodés) + UI panel client multi-section (filter, listings table, post form).

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 9 opcodes (173-181)
  - `173/174` AuctionList Request/Response
  - `175/176` AuctionPost Request/Response
  - `177/178` AuctionBid Request/Response (avec flag `isBuyout`)
  - `179/180` AuctionCancel Request/Response
  - `181` AuctionExpiredNotification (push)
- `src/shared/network/AuctionPayloads.{h,cpp,Tests.cpp}` : 32 tests round-trip + edge cases
- `src/masterd/handlers/auction/AuctionHandler.{h,cpp}` :
  - 8 listings seed avec items hardcodés (Iron Ore, Linen Cloth, Mageweave, Health Potion, etc.)
  - `ResolveItemName(itemTemplateId)` (10 entries hardcodées + fallback `Item #<id>`)
  - Buyout logic : si `bidAmount >= buyoutCopper`, auction ended immédiatement + push expiration au seller
  - Scan-on-list expiration : `ScanExpiredLocked` marque les auctions expirées à chaque `AuctionListRequest`
  - `PushAuctionExpired` helper public
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 173/175/177/179 + `&auctionHandler` ajouté à la capture-list lambda (vérifié : `weatherHandler`, `gameEventHandler`, `guildHandler` également présents)

### Client integration
- `src/client/auction/AuctionUi.{h,cpp}` : `AuctionHousePresenter` (nommage différencié pour ne pas collisionner avec `AuctionUiPresenter` M35.4 debug HUD existant) + helpers `FormatCopper` ("12g 34s 56c") et `FormatDuration` ("23h 12m" / "expired")
- `src/client/render/AuctionImGuiRenderer.{h,cpp}` : panel ImGui filter + table listings (Item / Count / Owner / Bid / Buyout / Time Left + bouton Bid/Buyout par ligne) + post form (itemTemplateId, count, startBid, buyout, durée 12h/24h/48h) + 2 toasts (bid placée, auction expirée)
- `src/client/app/Engine` : dispatch + slash `/ah` (alias `/auction`) + touche `H` toggle

### V1 limitations (consignées)
- 8 listings hardcodés au boot. Future PR : DB seed via `MysqlAuctionStore` + intégration `AuctionHouseBot` pour low-pop.
- Item name table 10 entries hardcodées. Future PR : `ItemTemplate` join.
- Owner name = "Account#<id>" V1. Future PR : lookup CharacterName.
- Pas d'expiration tick périodique : scan à chaque `AuctionListRequest`.
- Pas de SyncAuction RPC entre master et shardd (master autoritaire V1).
- Pas de paiement réel : économie cosmétique V1 (pas de gold debit/credit).

### Tests
- `auction_payloads_tests` (32 tests) — voir `src/shared/network/AuctionPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 173-181 + handler AuctionHandler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
