### PR TITLE
feat(loot): wire group roll Need/Greed/Pass + UI roll window client (CMANGOS.17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ add_library(engine_core
   src/client/events/GameEventUi.cpp
   src/client/guild/GuildUi.cpp
   src/client/auction/AuctionUi.cpp
+  src/client/loot/LootRollUi.cpp
   src/client/lfg/LfgUi.cpp
   src/client/cinematics/CinematicUi.cpp
   src/client/skills/SkillBookUi.cpp
@@ -353,6 +354,7 @@ add_library(engine_core
   src/client/render/GameEventImGuiRenderer.cpp
   src/client/render/GuildImGuiRenderer.cpp
   src/client/render/AuctionImGuiRenderer.cpp
+  src/client/render/LootRollImGuiRenderer.cpp
   src/client/render/LfgImGuiRenderer.cpp
   src/client/render/CinematicImGuiRenderer.cpp
   src/client/render/SkillBookImGuiRenderer.cpp
@@ -456,6 +458,7 @@ add_library(engine_core
   src/shared/network/GameEventPayloads.cpp
   src/shared/network/GuildPayloads.cpp
   src/shared/network/AuctionPayloads.cpp
+  src/shared/network/LootPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -741,6 +744,11 @@ add_test(NAME guild_payloads_tests COMMAND guild_payloads_tests)
 add_executable(auction_payloads_tests src/shared/network/AuctionPayloadsTests.cpp)
 target_link_libraries(auction_payloads_tests PRIVATE engine_core)
 add_test(NAME auction_payloads_tests COMMAND auction_payloads_tests)
+
+# CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Loot payloads round-trip tests (no DB / no network).
+add_executable(loot_payloads_tests src/shared/network/LootPayloadsTests.cpp)
+target_link_libraries(loot_payloads_tests PRIVATE engine_core)
+add_test(NAME loot_payloads_tests COMMAND loot_payloads_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/events/GameEventHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/guild/GuildHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/loot/LootHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -145,6 +146,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/GameEventPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GuildPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/LootPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -20,6 +20,7 @@
 #include "src/shared/network/GameEventPayloads.h"
 #include "src/shared/network/GuildPayloads.h"
 #include "src/shared/network/AuctionPayloads.h"
+#include "src/shared/network/LootPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -38,6 +39,7 @@
 #include "src/client/render/GameEventImGuiRenderer.h"
 #include "src/client/render/GuildImGuiRenderer.h"
 #include "src/client/render/AuctionImGuiRenderer.h"
+#include "src/client/render/LootRollImGuiRenderer.h"
 #include "src/client/render/LfgImGuiRenderer.h"
 #include "src/client/render/CinematicImGuiRenderer.h"
 #include "src/client/render/SkillBookImGuiRenderer.h"
@@ -1042,6 +1044,21 @@ namespace engine
 			});
 		}
 
+		// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Init du presenter Loot Roll
+		// + cable du send callback pour les requetes 183/186. Reception
+		// dispatchee dans le push handler ci-dessous (responses 184/187 + push
+		// 182 RollNotification + push 185 RollResultNotification).
+		if (!m_lootRollUi.Init())
+		{
+			LOG_WARN(Core, "[Boot] LootRollUiPresenter init FAILED — fenetre Loot Roll desactivee");
+		}
+		else
+		{
+			m_lootRollUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+				return m_authUi.SendGenericRequestAsync(opcode, payload);
+			});
+		}
+
 		// CMANGOS.27 (Phase 4.27 step 3+4) — Init du presenter TradeWindow + cable
 		// du send callback pour les requetes 83/86/88/91/93. Reception dispatchee
 		// dans le push handler ci-dessous (responses 84/87/89/92 + push 85/90/94).
@@ -1294,6 +1311,19 @@ namespace engine
 					m_auctionHouseUi.RequestList(0u);
 				}
 				LOG_INFO(Core, "[Engine] /ah toggle (visible={})", m_auctionHouseVisible);
+				return true;
+			}
+			// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Slash command /loot
+			// pour ouvrir/fermer la fenetre Loot Roll. La touche L fait la
+			// meme chose (cf. boucle input dans BeginFrame). Pas de fetch
+			// immediat : la fenetre montre les pending rolls reçus via push
+			// + le bouton Simulate Loot Roll (debug V1).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/loot"
+				    || text.starts_with("/loot ") || text.starts_with("/loot\t")))
+			{
+				m_lootRollVisible = !m_lootRollVisible;
+				LOG_INFO(Core, "[Engine] /loot toggle (visible={})", m_lootRollVisible);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -2073,6 +2103,53 @@ namespace engine
 					return;
 				}
 				m_auctionHouseUi.OnExpiredNotification(*parsed);
+				return;
+			}
+			// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Dispatch des push Loot
+			// (182 RollNotification + 185 RollResultNotification) + responses
+			// (184 ChoiceResponse + 187 SimulateRollResponse).
+			case kOpcodeLootRollNotification:
+			{
+				auto parsed = ParseLootRollNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LOOT_ROLL_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lootRollUi.OnRollNotification(*parsed);
+				return;
+			}
+			case kOpcodeLootRollChoiceResponse:
+			{
+				auto parsed = ParseLootRollChoiceResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LOOT_ROLL_CHOICE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lootRollUi.OnChoiceResponse(*parsed);
+				return;
+			}
+			case kOpcodeLootRollResultNotification:
+			{
+				auto parsed = ParseLootRollResultNotificationPayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LOOT_ROLL_RESULT_NOTIFICATION parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lootRollUi.OnRollResultNotification(*parsed);
+				return;
+			}
+			case kOpcodeLootSimulateRollResponse:
+			{
+				auto parsed = ParseLootSimulateRollResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] LOOT_SIMULATE_ROLL_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_lootRollUi.OnSimulateRollResponse(*parsed);
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
@@ -4381,6 +4458,7 @@ namespace engine
 		m_gameEventUi.Shutdown();
 		m_guildUi.Shutdown();
 		m_auctionHouseUi.Shutdown();
+		m_lootRollUi.Shutdown();
 		m_window.Destroy();
 		LOG_INFO(Core, "[Engine] Shutdown complete");
 		return 0;
@@ -4582,6 +4660,17 @@ namespace engine
 					m_auctionHouseUi.RequestList(0u);
 				}
 				LOG_INFO(Core, "[Engine] H toggle auction house (visible={})", m_auctionHouseVisible);
+			}
+			// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Touche L : toggle
+			// fenetre Loot Roll. Memes guards que U. Pas de conflit Ctrl+L.
+			// Pas de fetch a l'ouverture : les pending rolls arrivent via
+			// push, le bouton Simulate sert pour la demo V1.
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::L))
+			{
+				m_lootRollVisible = !m_lootRollVisible;
+				LOG_INFO(Core, "[Engine] L toggle loot roll (visible={})", m_lootRollVisible);
 			}
 		}
 
@@ -4819,6 +4908,13 @@ namespace engine
 				// AuctionExpired sont rendus independamment du flag.
 				m_auctionHouseImGui = std::make_unique<engine::render::AuctionImGuiRenderer>();
 				m_auctionHouseImGui->SetPresenter(&m_auctionHouseUi);
+
+				// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Renderer ImGui Loot
+				// Roll. Le panel principal n'est visible que quand
+				// m_lootRollVisible (toggle via /loot ou touche L). Le toast
+				// 5s sur dernier RollResult reçu est rendu independamment.
+				m_lootRollImGui = std::make_unique<engine::render::LootRollImGuiRenderer>();
+				m_lootRollImGui->SetPresenter(&m_lootRollUi);
 				// M43.4 — Editor Hub overlay : créé inconditionnellement, ne s'affiche que
 				// si --editor est actif (cf. condition Render branch plus bas).
 				m_editorHubImGui = std::make_unique<engine::render::EditorHubImGuiRenderer>();
@@ -5962,6 +6058,16 @@ namespace engine
 				m_auctionHouseImGui->SetEnabled(m_auctionHouseVisible);
 				m_auctionHouseImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_auctionHouseImGui->Render();
+			}
+			// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Render du panneau Loot
+			// Roll si m_lootRollVisible (toggle via /loot ou touche L), ET du
+			// toast 5s sur dernier RollResult reçu (rendu independamment par
+			// Render() si lastResultTimeMs est recent).
+			if (m_lootRollImGui && m_lootRollUi.IsInitialized())
+			{
+				m_lootRollImGui->SetEnabled(m_lootRollVisible);
+				m_lootRollImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_lootRollImGui->Render();
 			}
 			// DIAG chat-only branch (in-game).
 			if ((m_currentFrame % 60u) == 0u)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -19,6 +19,7 @@
 #include "src/client/events/GameEventUi.h"
 #include "src/client/guild/GuildUi.h"
 #include "src/client/auction/AuctionUi.h"
+#include "src/client/loot/LootRollUi.h"
 #include "src/client/lfg/LfgUi.h"
 #include "src/client/cinematics/CinematicUi.h"
 #include "src/client/skills/SkillBookUi.h"
@@ -91,6 +92,7 @@ namespace engine::render
 	class GameEventImGuiRenderer;
 	class GuildImGuiRenderer;
 	class AuctionImGuiRenderer;
+	class LootRollImGuiRenderer;
 	class EditorHubImGuiRenderer;
 	class DeferredPipeline;
 }
@@ -410,6 +412,11 @@ namespace engine
 		/// /ah ou touche H). Les toasts 5s sur derniere bid + dernier
 		/// AuctionExpired sont rendus independamment du flag.
 		std::unique_ptr<engine::render::AuctionImGuiRenderer> m_auctionHouseImGui;
+		/// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Panneau "Loot Roll" (post-auth, ImGui).
+		/// Le panel principal est visible uniquement quand m_lootRollVisible
+		/// (toggle via slash command \c /loot ou touche L). Le toast 5s sur
+		/// dernier RollResult reçu est rendu independamment du flag.
+		std::unique_ptr<engine::render::LootRollImGuiRenderer> m_lootRollImGui;
 		/// M43.4 — Panneau "Editor Hub" overlay quand `--editor` actif.
 		std::unique_ptr<engine::render::EditorHubImGuiRenderer> m_editorHubImGui;
 		/// Données carte / import (uniquement si \c m_worldEditorExe).
@@ -595,6 +602,15 @@ namespace engine
 		/// toast 5s sur dernier AuctionExpired reçu sont rendus
 		/// independamment.
 		bool                                  m_auctionHouseVisible = false;
+		/// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Presenter de la fenetre Loot
+		/// Roll. Recoit les push opcodes 182/185 et la response 184/187 via le
+		/// push handler du master ; fire-and-forget des requetes 183/186 via
+		/// \c m_authUi.SendGenericRequestAsync.
+		engine::client::LootRollUiPresenter   m_lootRollUi;
+		/// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — Visibilite du panneau Loot Roll
+		/// (toggle via slash command \c /loot ou touche L). Faux par defaut.
+		/// Le toast 5s sur dernier RollResult reçu est rendu independamment.
+		bool                                  m_lootRollVisible = false;
 		/// Phase 3.5 — Bannière "Bienvenue, X" affichée transitoirement après EnterWorld.
 		/// Vide quand inactive. Comparée à \c steady_clock::now() chaque frame.
 		std::string                                  m_enterWorldBannerText;

--- a/src/client/loot/LootRollUi.cpp
+++ b/src/client/loot/LootRollUi.cpp
@@ -1,0 +1,229 @@
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Implementation LootRollUiPresenter.
+
+#include "src/client/loot/LootRollUi.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+
+namespace engine::client
+{
+	namespace
+	{
+		/// Retourne le steady_clock now en ms depuis le boot pour l'horodatage
+		/// local des toasts (5s d'affichage) et du countdown des rolls
+		/// pending.
+		uint64_t SteadyMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// LootChoiceName - static helper.
+	// -------------------------------------------------------------------------
+
+	const char* LootChoiceName(uint8_t choice)
+	{
+		switch (choice)
+		{
+		case 0u: return "Pass";
+		case 1u: return "Greed";
+		case 2u: return "Need";
+		default: return "?";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Presenter lifecycle
+	// -------------------------------------------------------------------------
+
+	LootRollUiPresenter::~LootRollUiPresenter()
+	{
+		Shutdown();
+	}
+
+	bool LootRollUiPresenter::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Core, "[LootRollUiPresenter] Init ignored: already initialized");
+			return true;
+		}
+		m_initialized = true;
+		m_state = {};
+		LOG_INFO(Core, "[LootRollUiPresenter] Init OK");
+		return true;
+	}
+
+	void LootRollUiPresenter::Shutdown()
+	{
+		if (!m_initialized)
+			return;
+		m_initialized = false;
+		m_state = {};
+		LOG_INFO(Core, "[LootRollUiPresenter] Destroyed");
+	}
+
+	// -------------------------------------------------------------------------
+	// Outgoing requests
+	// -------------------------------------------------------------------------
+
+	void LootRollUiPresenter::Choose(uint64_t rollId, uint8_t choice)
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LootRollUiPresenter] Choose: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildLootRollChoiceRequestPayload(rollId, choice);
+		if (!m_send(engine::network::kOpcodeLootRollChoiceRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (loot choice).";
+			LOG_WARN(Net, "[LootRollUiPresenter] Choose: send failed rollId={}", rollId);
+			return;
+		}
+
+		// Marque myChoice dans le pending pour griser les boutons.
+		for (auto& p : m_state.pendingRolls)
+		{
+			if (p.rollId == rollId)
+			{
+				p.myChoice = choice;
+				break;
+			}
+		}
+		LOG_DEBUG(Net, "[LootRollUiPresenter] Choice queued rollId={} choice={}",
+			rollId, static_cast<unsigned>(choice));
+	}
+
+	void LootRollUiPresenter::SimulateRoll()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[LootRollUiPresenter] SimulateRoll: no send callback");
+			return;
+		}
+		const auto payload = engine::network::BuildLootSimulateRollRequestPayload();
+		if (!m_send(engine::network::kOpcodeLootSimulateRollRequest, payload))
+		{
+			m_state.lastErrorText = "Echec envoi (simulate roll).";
+			LOG_WARN(Net, "[LootRollUiPresenter] SimulateRoll: send failed");
+			return;
+		}
+		LOG_DEBUG(Net, "[LootRollUiPresenter] SimulateRoll queued");
+	}
+
+	// -------------------------------------------------------------------------
+	// Incoming responses / push
+	// -------------------------------------------------------------------------
+
+	void LootRollUiPresenter::OnChoiceResponse(const engine::network::LootRollChoiceResponsePayload& resp)
+	{
+		using engine::network::LootResponseStatus;
+		if (resp.status != 0u)
+		{
+			const auto err = static_cast<LootResponseStatus>(resp.status);
+			switch (err)
+			{
+			case LootResponseStatus::Unauthorized:
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+				break;
+			case LootResponseStatus::InvalidChoice:
+				m_state.lastErrorText = "Choix invalide.";
+				break;
+			case LootResponseStatus::RollNotFound:
+				m_state.lastErrorText = "Roll inconnue (deja terminee ?).";
+				break;
+			case LootResponseStatus::RollEnded:
+				m_state.lastErrorText = "Roll deja terminee.";
+				break;
+			default:
+				m_state.lastErrorText = "Erreur Loot inconnue.";
+				break;
+			}
+			LOG_WARN(Net, "[LootRollUiPresenter] OnChoiceResponse error={}",
+				static_cast<unsigned>(resp.status));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		LOG_DEBUG(Net, "[LootRollUiPresenter] OnChoiceResponse OK");
+	}
+
+	void LootRollUiPresenter::OnSimulateRollResponse(const engine::network::LootSimulateRollResponsePayload& resp)
+	{
+		using engine::network::LootResponseStatus;
+		if (resp.status != 0u)
+		{
+			const auto err = static_cast<LootResponseStatus>(resp.status);
+			if (err == LootResponseStatus::Unauthorized)
+				m_state.lastErrorText = "Session invalide. Reconnectez-vous.";
+			else
+				m_state.lastErrorText = "Erreur Loot inconnue.";
+			LOG_WARN(Net, "[LootRollUiPresenter] OnSimulateRollResponse error={}",
+				static_cast<unsigned>(resp.status));
+			return;
+		}
+
+		m_state.lastErrorText.clear();
+		m_state.lastInfoText = "Roll simulee.";
+		LOG_INFO(Net, "[LootRollUiPresenter] OnSimulateRollResponse OK rollId={}", resp.rollId);
+	}
+
+	void LootRollUiPresenter::OnRollNotification(const engine::network::LootRollNotificationPayload& note)
+	{
+		// Si une PendingRoll avec le meme rollId existe deja, on l'ignore
+		// (cas pathologique : double push).
+		for (const auto& p : m_state.pendingRolls)
+		{
+			if (p.rollId == note.rollId)
+			{
+				LOG_WARN(Net, "[LootRollUiPresenter] OnRollNotification: duplicate rollId={} ignored",
+					note.rollId);
+				return;
+			}
+		}
+
+		PendingRoll p;
+		p.rollId         = note.rollId;
+		p.itemTemplateId = note.itemTemplateId;
+		p.itemName       = note.itemName;
+		p.count          = note.count;
+		p.expiresAtMs    = SteadyMs() + static_cast<uint64_t>(note.durationSec) * 1000ull;
+		// myChoice reste std::nullopt jusqu'au click.
+		m_state.pendingRolls.push_back(std::move(p));
+
+		LOG_INFO(Net, "[LootRollUiPresenter] OnRollNotification rollId={} item='{}' count={} duration={}s",
+			note.rollId, note.itemName, note.count, note.durationSec);
+	}
+
+	void LootRollUiPresenter::OnRollResultNotification(const engine::network::LootRollResultNotificationPayload& note)
+	{
+		// Retire la pending roll du cache (par rollId).
+		for (auto it = m_state.pendingRolls.begin(); it != m_state.pendingRolls.end(); ++it)
+		{
+			if (it->rollId == note.rollId)
+			{
+				m_state.pendingRolls.erase(it);
+				break;
+			}
+		}
+
+		// Met a jour lastResult* pour le toast.
+		m_state.lastResultTimeMs       = SteadyMs();
+		m_state.lastResultRollId       = note.rollId;
+		m_state.lastResultWinnerName   = note.winnerName;
+		m_state.lastResultWinnerChoice = note.winnerChoice;
+		m_state.lastResultWinnerRoll   = note.winnerRoll;
+		m_state.lastResultItemName     = note.itemName;
+		m_state.lastResultCount        = note.count;
+
+		LOG_INFO(Net, "[LootRollUiPresenter] OnRollResultNotification rollId={} winner='{}' choice={} roll={}",
+			note.rollId, note.winnerName, static_cast<unsigned>(note.winnerChoice),
+			static_cast<unsigned>(note.winnerRoll));
+	}
+}

--- a/src/client/loot/LootRollUi.h
+++ b/src/client/loot/LootRollUi.h
@@ -1,0 +1,150 @@
+#pragma once
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Presenter client de la fenetre Loot
+// Roll. Maintient la liste des rolls actives en attente de choix joueur +
+// dernier resultat recu (pour toast 5s).
+//
+// Pas de rendu ImGui : le panneau est drawe par LootRollImGuiRenderer qui lit
+// l'etat via GetState() et propage les inputs UI (Choose / SimulateRoll) via
+// les methodes du presenter.
+//
+// Send : fire-and-forget via un callback (cf. m_send dans GuildUi).
+// Receive : Engine::SetMasterPushHandler dispatche les opcodes
+// 182/184/185/187 vers les OnXxx du presenter.
+
+#include "src/shared/network/LootPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	/// Roll en attente de choix joueur expose au layer UI.
+	/// Mirror direct de engine::network::LootRollNotificationPayload + un
+	/// horodatage local d'expiration et le choix utilisateur s'il a deja
+	/// clique.
+	struct PendingRoll
+	{
+		uint64_t              rollId         = 0;
+		uint32_t              itemTemplateId = 0;
+		std::string           itemName;
+		uint32_t              count          = 0;
+		/// Steady_clock now en ms a la reception + durationSec*1000.
+		/// Permet d'afficher "Time left: 12s" en decomptant.
+		uint64_t              expiresAtMs    = 0;
+		/// Set apres un click utilisateur (Need/Greed/Pass). Le presenter
+		/// laisse la pending visible jusqu'au resultat (lastResult*).
+		std::optional<uint8_t> myChoice;
+	};
+
+	/// Etat snapshot expose au renderer ImGui. Le panneau lit ces champs en
+	/// lecture seule et appelle les methodes du presenter pour les muter.
+	struct LootRollState
+	{
+		/// Liste des rolls en attente de choix. Trie par ordre d'arrivee.
+		std::vector<PendingRoll> pendingRolls;
+
+		/// Toast sur le dernier resultat recu : steady_clock now en ms a la
+		/// reception. Le toast est rendu pendant 5s puis disparait. Un seul
+		/// toast (le dernier ecrase le precedent V1).
+		std::optional<uint64_t> lastResultTimeMs;
+		uint64_t                lastResultRollId       = 0;
+		std::string             lastResultWinnerName;
+		uint8_t                 lastResultWinnerChoice = 0;
+		uint8_t                 lastResultWinnerRoll   = 0;
+		std::string             lastResultItemName;
+		uint32_t                lastResultCount        = 0;
+
+		/// Vide si pas d'erreur transitoire. Sinon affiche en rouge.
+		std::string lastErrorText;
+		/// Texte d'info transitoire. Vide par defaut.
+		std::string lastInfoText;
+	};
+
+	/// Static helper : retourne le libelle ASCII pour un choice (0=Pass,
+	/// 1=Greed, 2=Need). Pour un choice hors plage, retourne "?".
+	const char* LootChoiceName(uint8_t choice);
+
+	/// Presenter pour la fenetre Loot Roll cote client. Doit etre Init() avant
+	/// tout usage du callback. Thread : main (comme les autres presenters UI).
+	class LootRollUiPresenter final
+	{
+	public:
+		LootRollUiPresenter() = default;
+
+		LootRollUiPresenter(const LootRollUiPresenter&)            = delete;
+		LootRollUiPresenter& operator=(const LootRollUiPresenter&) = delete;
+
+		~LootRollUiPresenter();
+
+		/// Initialise le presenter. Idempotent (LOG_WARN si appele 2x).
+		bool Init();
+
+		/// Libere le state. Apres Shutdown, IsInitialized() == false.
+		void Shutdown();
+
+		bool IsInitialized() const { return m_initialized; }
+
+		// ---------------------------------------------------------------------
+		// Network wiring (CMANGOS.17 step 3+4 Loot)
+		// ---------------------------------------------------------------------
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Cable le callback pour fire-and-forget des requetes au master.
+		/// Doit etre appele avant tout Choose / SimulateRoll.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie LOOT_ROLL_CHOICE_REQUEST (opcode 183). Marque la pending
+		/// roll \p rollId comme "myChoice set" pour griser les boutons cote
+		/// renderer. Reponse via OnChoiceResponse.
+		///
+		/// \param rollId  identifiant de la roll cible.
+		/// \param choice  0=Pass, 1=Greed, 2=Need.
+		void Choose(uint64_t rollId, uint8_t choice);
+
+		/// Envoie LOOT_SIMULATE_ROLL_REQUEST (opcode 186). Outil dev V1 : le
+		/// master cree une nouvelle roll avec le creator comme seul eligible.
+		/// Reponse via OnSimulateRollResponse, et push RollNotification recue
+		/// via OnRollNotification.
+		void SimulateRoll();
+
+		// ---------------------------------------------------------------------
+		// Master responses / push
+		// ---------------------------------------------------------------------
+
+		/// Recoit LOOT_ROLL_CHOICE_RESPONSE (opcode 184). Met a jour
+		/// lastErrorText si !=Ok. Sinon ne fait rien (la roll sera retiree
+		/// du cache au moment du RollResultNotification).
+		void OnChoiceResponse(const engine::network::LootRollChoiceResponsePayload& resp);
+
+		/// Recoit LOOT_SIMULATE_ROLL_RESPONSE (opcode 187). Met a jour
+		/// lastErrorText si !=Ok, ou lastInfoText "Roll simulated" si Ok.
+		void OnSimulateRollResponse(const engine::network::LootSimulateRollResponsePayload& resp);
+
+		/// Recoit un push LOOT_ROLL_NOTIFICATION (opcode 182). Ajoute une
+		/// nouvelle PendingRoll au cache (calcule expiresAtMs = now + duration).
+		void OnRollNotification(const engine::network::LootRollNotificationPayload& note);
+
+		/// Recoit un push LOOT_ROLL_RESULT_NOTIFICATION (opcode 185). Retire
+		/// la PendingRoll du cache (par rollId) + met a jour lastResult* pour
+		/// le toast UI.
+		void OnRollResultNotification(const engine::network::LootRollResultNotificationPayload& note);
+
+		// ---------------------------------------------------------------------
+		// State access
+		// ---------------------------------------------------------------------
+
+		/// Snapshot lecture seule de l'etat courant pour le renderer.
+		const LootRollState& GetState() const { return m_state; }
+
+	private:
+		bool             m_initialized = false;
+		LootRollState    m_state{};
+		SendCallback     m_send;
+	};
+}

--- a/src/client/render/LootRollImGuiRenderer.cpp
+++ b/src/client/render/LootRollImGuiRenderer.cpp
@@ -1,0 +1,267 @@
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - LootRollImGuiRenderer implementation.
+
+#include "src/client/render/LootRollImGuiRenderer.h"
+
+#include "src/client/loot/LootRollUi.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Couleur pour un choice (0=Pass=gris, 1=Greed=vert, 2=Need=violet).
+		ImVec4 ChoiceColor(uint8_t choice)
+		{
+			switch (choice)
+			{
+			case 0u: return ImVec4(0.55f, 0.55f, 0.60f, 1.f); // Pass : gris
+			case 1u: return ImVec4(0.40f, 0.95f, 0.40f, 1.f); // Greed : vert
+			case 2u: return ImVec4(0.80f, 0.45f, 0.95f, 1.f); // Need : violet
+			default: return ImVec4(0.95f, 0.85f, 0.45f, 1.f);
+			}
+		}
+
+		/// Retourne le steady_clock now en ms (pour les toasts 5s + countdown).
+		uint64_t SteadyNowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	void LootRollImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr)
+			return;
+		if (!m_presenter->IsInitialized())
+			return;
+
+		// Le panel n'est rendu que si IsEnabled().
+		if (m_enabled)
+			RenderMainPanel();
+
+		// Le toast est rendu independamment, si un RollResult recent existe.
+		RenderToast();
+	}
+
+	void LootRollImGuiRenderer::RenderMainPanel()
+	{
+		const auto& state = m_presenter->GetState();
+
+		// Geometrie : panneau ancre a gauche-centre, 460x520.
+		const float panelW = 460.f;
+		const float panelH = 520.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, margin);
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Loot Roll (L)##ln_loot_panel", nullptr, flags))
+		{
+			// Erreur transitoire (rouge).
+			if (!state.lastErrorText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastErrorText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+			// Info transitoire (vert leger).
+			if (!state.lastInfoText.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.f, 0.4f, 1.f));
+				ImGui::TextWrapped("%s", state.lastInfoText.c_str());
+				ImGui::PopStyleColor();
+				ImGui::Separator();
+			}
+
+			// Top : bouton Simulate (V1 debug).
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.95f, 0.85f, 0.45f, 1.f));
+			ImGui::TextUnformatted("DEBUG (V1) :");
+			ImGui::PopStyleColor();
+			if (ImGui::Button("Simulate Loot Roll", ImVec2(-FLT_MIN, 28.f)))
+			{
+				m_presenter->SimulateRoll();
+			}
+
+			ImGui::Separator();
+
+			// Liste des pending rolls.
+			if (state.pendingRolls.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.7f, 0.7f, 1.f));
+				ImGui::TextWrapped("Aucune roll en attente.");
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				const uint64_t now = SteadyNowMs();
+				for (const auto& p : state.pendingRolls)
+				{
+					ImGui::PushID(static_cast<int>(p.rollId & 0x7FFFFFFFull));
+
+					ImGui::Spacing();
+					if (ImGui::BeginChild("##roll_card", ImVec2(0.f, 110.f), true,
+						ImGuiWindowFlags_NoScrollbar))
+					{
+						// Item name + count.
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.95f, 0.7f, 1.f));
+						ImGui::Text("%s x%u", p.itemName.c_str(),
+							static_cast<unsigned>(p.count));
+						ImGui::PopStyleColor();
+
+						// Countdown : "Time left: Xs".
+						uint64_t remainMs = 0;
+						if (p.expiresAtMs > now)
+							remainMs = p.expiresAtMs - now;
+						const uint64_t remainSec = remainMs / 1000ull;
+						ImGui::Text("Time left: %us", static_cast<unsigned>(remainSec));
+
+						// Boutons Need/Greed/Pass (grises si myChoice set).
+						const bool clicked = p.myChoice.has_value();
+						if (clicked)
+						{
+							ImGui::PushStyleColor(ImGuiCol_Text, ChoiceColor(*p.myChoice));
+							ImGui::Text("Vous avez choisi : %s",
+								engine::client::LootChoiceName(*p.myChoice));
+							ImGui::PopStyleColor();
+						}
+						else
+						{
+							// Need (violet).
+							ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.45f, 0.20f, 0.55f, 1.f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.55f, 0.30f, 0.65f, 1.f));
+							if (ImGui::Button("Need", ImVec2(120.f, 26.f)))
+								m_presenter->Choose(p.rollId, 2u);
+							ImGui::PopStyleColor(2);
+							ImGui::SameLine();
+							// Greed (vert).
+							ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.55f, 0.20f, 1.f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.30f, 0.65f, 0.30f, 1.f));
+							if (ImGui::Button("Greed", ImVec2(120.f, 26.f)))
+								m_presenter->Choose(p.rollId, 1u);
+							ImGui::PopStyleColor(2);
+							ImGui::SameLine();
+							// Pass (gris).
+							ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.40f, 0.40f, 0.45f, 1.f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.50f, 0.50f, 0.55f, 1.f));
+							if (ImGui::Button("Pass", ImVec2(120.f, 26.f)))
+								m_presenter->Choose(p.rollId, 0u);
+							ImGui::PopStyleColor(2);
+						}
+					}
+					ImGui::EndChild();
+
+					ImGui::PopID();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+
+	void LootRollImGuiRenderer::RenderToast()
+	{
+		const auto& state = m_presenter->GetState();
+		if (!state.lastResultTimeMs.has_value())
+			return;
+
+		// Toast actif 5s apres reception.
+		constexpr uint64_t kToastDurationMs = 5000ull;
+		const uint64_t nowSteady = SteadyNowMs();
+		if (nowSteady < *state.lastResultTimeMs)
+			return;
+		const uint64_t age = nowSteady - *state.lastResultTimeMs;
+		if (age > kToastDurationMs)
+			return;
+
+		// Compose le texte du toast. Si winnerName vide => "Personne (tous Pass)".
+		char buf[256]{};
+		if (state.lastResultWinnerName.empty())
+		{
+			std::snprintf(buf, sizeof(buf),
+				"Personne n'a remporte %s x%u (tous Pass)",
+				state.lastResultItemName.c_str(),
+				static_cast<unsigned>(state.lastResultCount));
+		}
+		else
+		{
+			std::snprintf(buf, sizeof(buf),
+				"%s a gagne %s x%u (%s avec roll %u)",
+				state.lastResultWinnerName.c_str(),
+				state.lastResultItemName.c_str(),
+				static_cast<unsigned>(state.lastResultCount),
+				engine::client::LootChoiceName(state.lastResultWinnerChoice),
+				static_cast<unsigned>(state.lastResultWinnerRoll));
+		}
+
+		// Geometrie toast : bottom-right, 380x60, marge 16.
+		const float toastW = 380.f;
+		const float toastH = 60.f;
+		const float margin = 16.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = std::max(0.f, vpW - toastW - margin);
+		const float posY = std::max(0.f, vpH - toastH - margin);
+
+		// Fade out sur les 1000 dernieres ms.
+		float alpha = 0.95f;
+		if (age > kToastDurationMs - 1000ull)
+		{
+			const float remain = static_cast<float>(kToastDurationMs - age) / 1000.0f;
+			alpha = std::max(0.0f, std::min(0.95f, remain * 0.95f));
+		}
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(alpha);
+
+		const ImGuiWindowFlags toastFlags = ImGuiWindowFlags_NoTitleBar
+			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoScrollbar
+			| ImGuiWindowFlags_NoSavedSettings
+			| ImGuiWindowFlags_NoFocusOnAppearing
+			| ImGuiWindowFlags_NoInputs;
+
+		if (ImGui::Begin("##ln_loot_toast", nullptr, toastFlags))
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ChoiceColor(state.lastResultWinnerChoice));
+			ImGui::TextWrapped("%s", buf);
+			ImGui::PopStyleColor();
+		}
+		ImGui::End();
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void LootRollImGuiRenderer::Render()           {}
+	void LootRollImGuiRenderer::RenderMainPanel()  {}
+	void LootRollImGuiRenderer::RenderToast()      {}
+}
+
+#endif

--- a/src/client/render/LootRollImGuiRenderer.h
+++ b/src/client/render/LootRollImGuiRenderer.h
@@ -1,0 +1,59 @@
+#pragma once
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - LootRollImGuiRenderer : panneau ImGui
+// pour la fenetre Loot Roll. Top section : bouton "Simulate Loot Roll" (debug
+// V1). Pour chaque pendingRoll : bloc avec item name + count + countdown
+// "Time left: 12s" + 3 boutons Need / Greed / Pass (grises si myChoice deja
+// set).
+//
+// Le toast 5s sur dernier RollResult est rendu independamment du flag
+// IsEnabled() (les push peuvent arriver panneau ferme), avec couleur selon
+// choice : Need=violet, Greed=vert, Pass=gris.
+//
+// Lit l'etat d'un LootRollUiPresenter, dispatch les inputs UI (Choose /
+// SimulateRoll) via accesseurs / methodes.
+
+#include <cstdint>
+
+namespace engine::client { class LootRollUiPresenter; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau Loot Roll. Pas de logique de fetch / parse :
+	/// celle-ci est dans \ref engine::client::LootRollUiPresenter. Le renderer
+	/// ne fait que dessiner l'etat courant et propager les inputs UI vers le
+	/// presenter.
+	class LootRollImGuiRenderer
+	{
+	public:
+		LootRollImGuiRenderer() = default;
+
+		/// Cable le presenter (pointeur non possede). \pre presenter init avant Render.
+		void SetPresenter(engine::client::LootRollUiPresenter* presenter) { m_presenter = presenter; }
+
+		/// Active/desactive le rendu du panel principal.
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau et du toast.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Loot Roll" (si IsEnabled()) et le toast 5s sur
+		/// le dernier RollResult recu (rendu independamment du flag
+		/// IsEnabled() puisque les push peuvent arriver panneau ferme).
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), apres
+		/// NewFrame, si le presenter est valide.
+		void Render();
+
+	private:
+		/// Dessine le panneau principal (bouton Simulate + cards par roll).
+		void RenderMainPanel();
+
+		/// Dessine le toast 5s en bas-droite si lastResultTimeMs est recent.
+		void RenderToast();
+
+		engine::client::LootRollUiPresenter* m_presenter = nullptr;
+		bool                                 m_enabled   = false;
+		uint32_t                             m_viewportW = 0;
+		uint32_t                             m_viewportH = 0;
+	};
+}

--- a/src/masterd/handlers/loot/LootHandler.cpp
+++ b/src/masterd/handlers/loot/LootHandler.cpp
@@ -1,0 +1,480 @@
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Implementation LootHandler.
+
+#include "src/masterd/handlers/loot/LootHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/LootPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Items hardcodes V1 (id 1..5). Adresses stables pour le wire.
+		struct ItemEntry { uint32_t id; const char* name; };
+		const ItemEntry kV1Items[] = {
+			{1u, "Iron Ore"},
+			{2u, "Linen Cloth"},
+			{3u, "Mageweave"},
+			{4u, "Health Potion"},
+			{5u, "Mana Potion"},
+		};
+		constexpr size_t kV1ItemCount = sizeof(kV1Items) / sizeof(kV1Items[0]);
+	}
+
+	// -------------------------------------------------------------------------
+	// ResolveItemName - static helper public.
+	// -------------------------------------------------------------------------
+
+	std::string LootHandler::ResolveItemName(uint32_t itemTemplateId)
+	{
+		for (size_t i = 0; i < kV1ItemCount; ++i)
+		{
+			if (kV1Items[i].id == itemTemplateId)
+				return std::string(kV1Items[i].name);
+		}
+		// Fallback ASCII-safe pour les ids hors plage (V1 ne devrait pas arriver).
+		char buf[32]{};
+		std::snprintf(buf, sizeof(buf), "Item #%u", static_cast<unsigned>(itemTemplateId));
+		return std::string(buf);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandlePacket - dispatch + session validation
+	// -------------------------------------------------------------------------
+
+	void LootHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[LootHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Resolution session/account.
+		uint64_t accountId = 0;
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+			{
+				accountId = *acc;
+				sessionOk = true;
+			}
+		}
+
+		if (!sessionOk)
+		{
+			std::vector<uint8_t> pkt;
+			const uint8_t kUnauth = static_cast<uint8_t>(LootResponseStatus::Unauthorized);
+			switch (opcode)
+			{
+			case kOpcodeLootRollChoiceRequest:
+				pkt = BuildLootRollChoiceResponsePacket(kUnauth, requestId, sessionIdHeader);
+				break;
+			case kOpcodeLootSimulateRollRequest:
+				pkt = BuildLootSimulateRollResponsePacket(kUnauth, 0ull, requestId, sessionIdHeader);
+				break;
+			default:
+				return;
+			}
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		switch (opcode)
+		{
+		case kOpcodeLootRollChoiceRequest:
+			HandleChoice(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		case kOpcodeLootSimulateRollRequest:
+			HandleSimulateRoll(connId, requestId, sessionIdHeader, accountId, payload, payloadSize);
+			break;
+		default:
+			break;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// RollDie0to100Locked / PickRandomItemIdLocked
+	// -------------------------------------------------------------------------
+
+	uint8_t LootHandler::RollDie0to100Locked()
+	{
+		if (!m_rngSeeded)
+		{
+			const auto seed = static_cast<uint32_t>(
+				std::chrono::steady_clock::now().time_since_epoch().count());
+			m_rng.seed(seed);
+			m_rngSeeded = true;
+		}
+		std::uniform_int_distribution<int> dist(0, 100);
+		return static_cast<uint8_t>(dist(m_rng));
+	}
+
+	uint32_t LootHandler::PickRandomItemIdLocked()
+	{
+		if (!m_rngSeeded)
+		{
+			const auto seed = static_cast<uint32_t>(
+				std::chrono::steady_clock::now().time_since_epoch().count());
+			m_rng.seed(seed);
+			m_rngSeeded = true;
+		}
+		std::uniform_int_distribution<int> dist(1, static_cast<int>(kV1ItemCount));
+		return static_cast<uint32_t>(dist(m_rng));
+	}
+
+	// -------------------------------------------------------------------------
+	// ResolveRollLocked - pick winner, push result, mark resolved.
+	// -------------------------------------------------------------------------
+
+	void LootHandler::ResolveRollLocked(ActiveRoll& r)
+	{
+		if (r.resolved) return;
+
+		// Pour chaque eligible, on lit son choice. Si pas de choice, on
+		// considere Pass (timeout). On pioche un roll 0..100 pour les
+		// non-Pass. Need > Greed > Pass + plus haut roll dans la meme categorie.
+		std::string winnerName;
+		uint8_t     winnerChoice = static_cast<uint8_t>(LootChoice::Pass);
+		uint8_t     winnerRoll   = 0u;
+		LootChoice  winnerCat    = LootChoice::Pass;
+
+		for (size_t i = 0; i < r.eligibleAccountIds.size(); ++i)
+		{
+			const uint64_t accId = r.eligibleAccountIds[i];
+			LootChoice ch = LootChoice::Pass;
+			auto it = r.choices.find(accId);
+			if (it != r.choices.end())
+				ch = it->second;
+
+			if (ch == LootChoice::Pass)
+				continue;
+
+			// Pioche le roll 0..100 pour ce participant non-Pass.
+			const uint8_t rollVal = RollDie0to100Locked();
+
+			// Compare au winner courant. Need bat Greed bat Pass. Egale categorie =>
+			// plus haut roll gagne.
+			bool replace = false;
+			if (winnerCat == LootChoice::Pass)
+			{
+				replace = true;
+			}
+			else if (ch == LootChoice::Need && winnerCat == LootChoice::Greed)
+			{
+				replace = true;
+			}
+			else if (ch == LootChoice::Greed && winnerCat == LootChoice::Need)
+			{
+				replace = false;
+			}
+			else
+			{
+				// Meme categorie : compare rolls.
+				if (rollVal > winnerRoll)
+					replace = true;
+			}
+
+			if (replace)
+			{
+				// Resoudre le nom : V1 simple, on utilise "Account #<id>" comme
+				// fallback. Future PR : SessionManager exposera le character
+				// name via OnCharacterEnterWorld.
+				char nameBuf[32]{};
+				std::snprintf(nameBuf, sizeof(nameBuf), "Account #%llu",
+					static_cast<unsigned long long>(accId));
+				winnerName   = nameBuf;
+				winnerChoice = static_cast<uint8_t>(ch);
+				winnerRoll   = rollVal;
+				winnerCat    = ch;
+			}
+		}
+
+		// Push RollResultNotification a chaque eligible (V1 : un seul, le creator).
+		for (size_t i = 0; i < r.eligibleConnIds.size(); ++i)
+		{
+			const uint32_t cid = r.eligibleConnIds[i];
+			PushRollResult(cid, r.rollId, winnerName, winnerChoice, winnerRoll,
+				r.itemTemplateId, r.itemName, r.count);
+		}
+
+		r.resolved = true;
+		LOG_INFO(Net, "[LootHandler] ResolveRoll rollId={} winner='{}' choice={} roll={}",
+			r.rollId, winnerName, static_cast<unsigned>(winnerChoice),
+			static_cast<unsigned>(winnerRoll));
+	}
+
+	// -------------------------------------------------------------------------
+	// ScanExpiredRollsLocked - resolve les rolls dont endsAt est depasse.
+	// -------------------------------------------------------------------------
+
+	void LootHandler::ScanExpiredRollsLocked()
+	{
+		const auto now = std::chrono::steady_clock::now();
+		for (auto& kv : m_rolls)
+		{
+			ActiveRoll& r = kv.second;
+			if (r.resolved) continue;
+			if (now >= r.endsAt)
+			{
+				ResolveRollLocked(r);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleSimulateRoll - V1 outil dev : creator-only eligible.
+	// -------------------------------------------------------------------------
+
+	void LootHandler::HandleSimulateRoll(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseLootSimulateRollRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[LootHandler] SimulateRoll parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildLootSimulateRollResponsePacket(
+				static_cast<uint8_t>(LootResponseStatus::Unauthorized), 0ull,
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		uint64_t newRollId = 0;
+		uint32_t itemTemplateId = 0;
+		std::string itemName;
+		uint32_t count = 1u;
+		constexpr uint32_t kV1DurationSec = 30u;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			newRollId      = m_nextRollId.fetch_add(1u);
+			itemTemplateId = PickRandomItemIdLocked();
+			itemName       = ResolveItemName(itemTemplateId);
+
+			ActiveRoll r;
+			r.rollId         = newRollId;
+			r.itemTemplateId = itemTemplateId;
+			r.itemName       = itemName;
+			r.count          = count;
+			r.endsAt         = std::chrono::steady_clock::now()
+				+ std::chrono::seconds(kV1DurationSec);
+			r.eligibleAccountIds.push_back(accountId);
+			r.eligibleConnIds.push_back(connId);
+			r.resolved = false;
+
+			m_rolls[newRollId] = std::move(r);
+		}
+
+		// Push RollNotification au creator (V1 = seul eligible).
+		PushRollNotification(connId, newRollId, itemTemplateId, itemName, count, kV1DurationSec);
+
+		// Reponse Ok + rollId.
+		auto pkt = BuildLootSimulateRollResponsePacket(
+			static_cast<uint8_t>(LootResponseStatus::Ok), newRollId,
+			requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		LOG_INFO(Net, "[LootHandler] SimulateRoll account={} rollId={} item={} count={}",
+			accountId, newRollId, itemName, count);
+	}
+
+	// -------------------------------------------------------------------------
+	// HandleChoice
+	// -------------------------------------------------------------------------
+
+	void LootHandler::HandleChoice(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		uint64_t accountId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		auto parsed = ParseLootRollChoiceRequestPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[LootHandler] Choice parse failed account={} size={}",
+				accountId, payloadSize);
+			auto pkt = BuildLootRollChoiceResponsePacket(
+				static_cast<uint8_t>(LootResponseStatus::InvalidChoice),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		const uint64_t rollId = parsed->rollId;
+		const uint8_t  choice = parsed->choice;
+
+		// Wire-level rejette les choices > 2.
+		if (choice > 2u)
+		{
+			LOG_INFO(Net, "[LootHandler] Choice InvalidChoice account={} rollId={} choice={}",
+				accountId, rollId, static_cast<unsigned>(choice));
+			auto pkt = BuildLootRollChoiceResponsePacket(
+				static_cast<uint8_t>(LootResponseStatus::InvalidChoice),
+				requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+
+		uint8_t status = static_cast<uint8_t>(LootResponseStatus::Ok);
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+
+			// Avant de traiter, scan les rolls expirees.
+			ScanExpiredRollsLocked();
+
+			auto it = m_rolls.find(rollId);
+			if (it == m_rolls.end())
+			{
+				status = static_cast<uint8_t>(LootResponseStatus::RollNotFound);
+			}
+			else
+			{
+				ActiveRoll& r = it->second;
+				if (r.resolved)
+				{
+					status = static_cast<uint8_t>(LootResponseStatus::RollEnded);
+				}
+				else
+				{
+					// Verifie que accountId est eligible.
+					bool eligible = false;
+					for (uint64_t accId : r.eligibleAccountIds)
+					{
+						if (accId == accountId) { eligible = true; break; }
+					}
+					if (!eligible)
+					{
+						status = static_cast<uint8_t>(LootResponseStatus::Unauthorized);
+					}
+					else
+					{
+						r.choices[accountId] = static_cast<LootChoice>(choice);
+
+						// V1 simple : un seul eligible, donc des qu'il choose, on resout.
+						// Plus general : verifier si toutes les choices sont recues.
+						if (r.choices.size() >= r.eligibleAccountIds.size())
+						{
+							ResolveRollLocked(r);
+						}
+					}
+				}
+			}
+		}
+
+		auto pkt = BuildLootRollChoiceResponsePacket(status, requestId, sessionIdHeader);
+		if (!pkt.empty())
+			m_server->Send(connId, pkt);
+
+		LOG_INFO(Net, "[LootHandler] Choice account={} rollId={} choice={} status={}",
+			accountId, rollId, static_cast<unsigned>(choice),
+			static_cast<unsigned>(status));
+	}
+
+	// -------------------------------------------------------------------------
+	// PushRollNotification
+	// -------------------------------------------------------------------------
+
+	bool LootHandler::PushRollNotification(uint32_t connId, uint64_t rollId, uint32_t itemTemplateId,
+		const std::string& itemName, uint32_t count, uint32_t durationSec)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollNotification dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollNotification: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildLootRollNotificationPacket(rollId, itemTemplateId, itemName, count,
+			durationSec, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollNotification: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[LootHandler] PushRollNotification connId={} rollId={} item='{}' count={} duration={}s",
+			connId, rollId, itemName, count, durationSec);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// PushRollResult
+	// -------------------------------------------------------------------------
+
+	bool LootHandler::PushRollResult(uint32_t connId, uint64_t rollId, const std::string& winnerName,
+		uint8_t winnerChoice, uint8_t winnerRoll, uint32_t itemTemplateId,
+		const std::string& itemName, uint32_t count)
+	{
+		using namespace engine::network;
+
+		if (!m_server || connId == 0u)
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollResult dropped : server null or connId=0");
+			return false;
+		}
+
+		const uint64_t sessionIdHeader = FindSessionIdForConn(connId);
+		if (sessionIdHeader == 0u)
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollResult: connId={} no session (skip)", connId);
+			return false;
+		}
+
+		auto pkt = BuildLootRollResultNotificationPacket(rollId, winnerName, winnerChoice,
+			winnerRoll, itemTemplateId, itemName, count, sessionIdHeader);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[LootHandler] PushRollResult: build packet failed connId={}", connId);
+			return false;
+		}
+
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[LootHandler] PushRollResult connId={} rollId={} winner='{}' choice={} roll={}",
+			connId, rollId, winnerName, static_cast<unsigned>(winnerChoice),
+			static_cast<unsigned>(winnerRoll));
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	uint64_t LootHandler::FindSessionIdForConn(uint32_t connId) const
+	{
+		if (!m_connMap) return 0u;
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid) return 0u;
+		return *sid;
+	}
+}

--- a/src/masterd/handlers/loot/LootHandler.h
+++ b/src/masterd/handlers/loot/LootHandler.h
@@ -1,0 +1,210 @@
+#pragma once
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - LootHandler : dispatch des opcodes
+// Loot cote joueur (183 Choice, 186 SimulateRoll) et registry in-memory V1
+// des rolls actives.
+//
+// Le handler est instancie dans main_linux.cpp au boot du master, cable via
+// SetXxx(...), puis enregistre dans le packetHandler du NetServer pour les
+// 2 requests opcodes. Les responses 184/187 sont emises avec le meme
+// requestId / sessionId que la request recue. Les push notifications 182
+// (RollNotification) et 185 (RollResultNotification) sont emises par le
+// handler aux clients eligibles.
+//
+// V1 simulation simple :
+//   - SimulateRollRequest cree une nouvelle ActiveRoll avec creator comme
+//     SEUL eligible (pas de groupe). itemTemplateId aleatoire dans 1..5,
+//     count=1, durationSec=30. Push immediatement RollNotification au creator.
+//     Reponse Ok + rollId.
+//   - ChoiceRequest : verifie roll existe + non resolved + creator eligible.
+//     Set choice. Comme un seul eligible, resout immediatement : random
+//     uint8 0..100, regle Need > Greed > Pass + plus haut roll dans la meme
+//     categorie. Tous Pass => personne ne gagne (winnerName="" + roll=0).
+//     Push RollResultNotification au creator. Marque resolved=true.
+//   - Pas de Tick periodique pour timeout : a chaque HandleChoice on scan
+//     les rolls expirees pour les resolve.
+//
+// Validation session : chaque opcode exige une session authentifiee. Le
+// handler resout connId -> sessionId via ConnectionSessionMap, puis sessionId
+// -> accountId via SessionManager. Si l'un echoue, on repond avec
+// status=Unauthorized (code 1) dans la reponse type-specific.
+//
+// Items hardcode V1 :
+//   1 = Iron Ore
+//   2 = Linen Cloth
+//   3 = Mageweave
+//   4 = Health Potion
+//   5 = Mana Potion
+//
+// V1 limitations :
+//   - SimulateRoll = creator-only eligible (pas de groupe). Future PR :
+//     integration avec Group/Party (CMANGOS.15).
+//   - Items hardcode (5 entries V1). Future PR : integration LootTable +
+//     ItemTemplate (engine::server::loot::LootTable).
+//   - Pas de timeout tick periodique : scan a chaque HandleChoice.
+//   - Pas de SyncLoot RPC entre master et shardd (master autoritaire V1).
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Choix d'un joueur pour une roll de loot. Wire format uint8.
+	enum class LootChoice : uint8_t
+	{
+		Pass  = 0,
+		Greed = 1,
+		Need  = 2,
+	};
+
+	/// Roll active in-memory V1.
+	/// resolved=false tant que toutes les choices ne sont pas recues
+	/// OU que endsAt n'est pas atteint. Une fois resolved=true, plus aucune
+	/// nouvelle choice n'est acceptee (RollEnded).
+	struct ActiveRoll
+	{
+		uint64_t                                       rollId         = 0;
+		uint32_t                                       itemTemplateId = 0;
+		std::string                                    itemName;
+		uint32_t                                       count          = 0;
+		std::chrono::steady_clock::time_point          endsAt;
+		std::vector<uint64_t>                          eligibleAccountIds;
+		std::unordered_map<uint64_t /*accountId*/, LootChoice> choices;
+		/// Pour pouvoir push le resultat aux eligibles, on memorise leur
+		/// connId associe au moment de la creation. Parallele a
+		/// eligibleAccountIds (meme indexation).
+		std::vector<uint32_t>                          eligibleConnIds;
+		bool                                           resolved       = false;
+	};
+
+	/// Dispatcher Loot cote joueur. Doit etre configure via Set*() avant
+	/// tout HandlePacket.
+	class LootHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId -> sessionId.
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Point d'entree appele par NetServer pour les opcodes Loot.
+		/// Dispatch vers HandleChoice / HandleSimulateRoll selon l'opcode.
+		/// Si l'opcode n'est pas un opcode Loot, ignore silencieusement.
+		///
+		/// \param connId          identifiant de connexion TCP (pour Send response).
+		/// \param opcode          opcode du paquet entrant (183/186).
+		/// \param requestId       request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload         pointeur sur le payload (sans header).
+		/// \param payloadSize     taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// API publique : pousse une push LootRollNotification (opcode 182)
+		/// au client identifie par \p connId. Utilise par le handler en interne
+		/// mais accessible egalement depuis l'exterieur (tests, hooks, future
+		/// integration shardd quand un mob drop un item group-roll).
+		///
+		/// \param connId          identifiant de connexion TCP cible (0 = no-op).
+		/// \param rollId          identifiant unique de la roll.
+		/// \param itemTemplateId  identifiant template de l'item.
+		/// \param itemName        nom resolu de l'item.
+		/// \param count           nombre d'items dropes.
+		/// \param durationSec     duree en secondes avant timeout.
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushRollNotification(uint32_t connId, uint64_t rollId, uint32_t itemTemplateId,
+			const std::string& itemName, uint32_t count, uint32_t durationSec);
+
+		/// API publique : pousse une push LootRollResultNotification (opcode 185)
+		/// au client identifie par \p connId.
+		///
+		/// \param connId          identifiant de connexion TCP cible (0 = no-op).
+		/// \param rollId          identifiant unique de la roll.
+		/// \param winnerName      nom du gagnant (vide si tous Pass).
+		/// \param winnerChoice    choix du gagnant (0=Pass / 1=Greed / 2=Need).
+		/// \param winnerRoll      roll du gagnant (0..100, 0 si tous Pass).
+		/// \param itemTemplateId  identifiant template de l'item.
+		/// \param itemName        nom resolu de l'item.
+		/// \param count           nombre d'items dropes.
+		/// \return true si le packet a ete envoye, false si connId invalide ou server null.
+		bool PushRollResult(uint32_t connId, uint64_t rollId, const std::string& winnerName,
+			uint8_t winnerChoice, uint8_t winnerRoll, uint32_t itemTemplateId,
+			const std::string& itemName, uint32_t count);
+
+		/// Helper static : retourne le nom de l'item hardcode V1 pour un
+		/// itemTemplateId donne (1..5). Pour un id hors plage, retourne
+		/// un fallback "Item #<id>" (ASCII safe pour MSVC).
+		static std::string ResolveItemName(uint32_t itemTemplateId);
+
+	private:
+		/// Traite LOOT_ROLL_CHOICE_REQUEST : valide rollId + non-resolved
+		/// + creator eligible, set choice, et resout la roll si toutes
+		/// les choices recues OU endsAt depasse.
+		void HandleChoice(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Traite LOOT_SIMULATE_ROLL_REQUEST : cree une nouvelle ActiveRoll
+		/// avec le creator comme seul eligible, push RollNotification, et
+		/// retourne Ok + rollId.
+		void HandleSimulateRoll(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+			uint64_t accountId, const uint8_t* payload, size_t payloadSize);
+
+		/// Recherche le sessionIdHeader actif pour un connId donne. Retourne 0
+		/// si la connexion n'a pas de session ou si la map n'est pas branchee.
+		uint64_t FindSessionIdForConn(uint32_t connId) const;
+
+		/// Pioche un random uint8 dans [0, 100]. Utilise mt19937 + uniform.
+		/// Doit etre appele sous m_mutex (m_rng accede partage).
+		uint8_t RollDie0to100Locked();
+
+		/// Pioche un itemTemplateId dans [1, 5] (V1 hardcode 5 entries).
+		/// Doit etre appele sous m_mutex.
+		uint32_t PickRandomItemIdLocked();
+
+		/// Resout la roll \p r : pour chaque non-Pass choice, pioche un random
+		/// 0..100. Need > Greed > Pass. Tie sur meme categorie : plus haut
+		/// roll gagne. Tous Pass => winnerName="" + winnerRoll=0.
+		/// Push RollResultNotification a chaque eligible, set resolved=true.
+		/// Doit etre appele sous m_mutex.
+		void ResolveRollLocked(ActiveRoll& r);
+
+		/// Scan toutes les rolls non-resolved pour resolve celles dont
+		/// endsAt est depassee. Appele en debut de HandleChoice.
+		/// Doit etre appele sous m_mutex.
+		void ScanExpiredRollsLocked();
+
+		NetServer*                                       m_server     = nullptr;
+		SessionManager*                                  m_sessionMgr = nullptr;
+		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Mutex protegeant m_rolls + m_nextRollId + m_rng.
+		mutable std::mutex                               m_mutex;
+
+		/// Registry des rolls actives. Cle = rollId.
+		std::unordered_map<uint64_t, ActiveRoll>         m_rolls;
+
+		/// Compteur monotone pour generer les rollId. Incremente atomicly.
+		std::atomic<uint64_t>                            m_nextRollId{1};
+
+		/// PRNG mt19937 seede sur steady_clock::now() au premier usage.
+		/// Protege par m_mutex.
+		std::mt19937                                     m_rng;
+		bool                                             m_rngSeeded = false;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -46,6 +46,7 @@
 #include "src/masterd/handlers/events/GameEventHandler.h"
 #include "src/masterd/handlers/guild/GuildHandler.h"
 #include "src/masterd/handlers/auction/AuctionHandler.h"
+#include "src/masterd/handlers/loot/LootHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -637,6 +638,22 @@ int main(int argc, char** argv)
 	auctionHandler.SeedV1Auctions();
 	LOG_INFO(Net, "[ServerMain] AuctionHandler configured (CMANGOS.09 step 3+4 AuctionHouse, in-memory, 8 listings seed)");
 
+	// CMANGOS.17 (Phase 3.17 step 3+4 Loot) — LootHandler : Choice
+	// (Need/Greed/Pass) + SimulateRoll DEBUG + push RollNotification + push
+	// RollResultNotification. V1 simulation simple : un seul eligible par roll
+	// (le creator), items hardcodes (5 entries), random roll 0..100, regle
+	// Need > Greed > Pass + plus haut roll dans la meme categorie. Les
+	// opcodes 183/186 sont dispatches au handler ; les responses 184/187 et
+	// les push notifications 182/185 sont emises par le handler. V1
+	// limitations : pas de groupe (CMANGOS.15), items hardcodes, pas de
+	// timeout tick periodique (scan a chaque HandleChoice), pas de SyncLoot
+	// RPC entre master et shardd.
+	engine::server::LootHandler lootHandler;
+	lootHandler.SetServer(&server);
+	lootHandler.SetSessionManager(&sessionManager);
+	lootHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] LootHandler configured (CMANGOS.17 step 3+4 Loot, in-memory, simulation V1)");
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -676,7 +693,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -775,6 +792,9 @@ int main(int argc, char** argv)
 		      || opcode == kOpcodeAuctionBidRequest
 		      || opcode == kOpcodeAuctionCancelRequest)
 			auctionHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeLootRollChoiceRequest
+		      || opcode == kOpcodeLootSimulateRollRequest)
+			lootHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/LootPayloads.cpp
+++ b/src/shared/network/LootPayloads.cpp
@@ -1,0 +1,247 @@
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Implementation Parse/Build des
+// payloads Loot.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> contenant uniquement le
+//     payload (sans header protocol_v1). Utilise pour tests round-trip et
+//     pour les requests cote client (envoyees via SendGenericRequestAsync
+//     qui ajoute le header).
+//   - Build*ResponsePacket / Build*NotificationPacket utilise PacketBuilder
+//     pour assembler le paquet complet header + payload, pret a passer a
+//     NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/LootPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	// -------------------------------------------------------------------------
+	// LOOT_ROLL_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<LootRollNotificationPayload> ParseLootRollNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 rollId (8) + uint32 itemTemplateId (4) + uint16 strLen (2)
+		//     + uint32 count (4) + uint32 durationSec (4) = 22 (string vide possible).
+		if (!payload || payloadSize < 22u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LootRollNotificationPayload out;
+		if (!r.ReadU64(out.rollId))         return std::nullopt;
+		if (!r.ReadU32(out.itemTemplateId)) return std::nullopt;
+		if (!r.ReadString(out.itemName))    return std::nullopt;
+		if (!r.ReadU32(out.count))          return std::nullopt;
+		if (!r.ReadU32(out.durationSec))    return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLootRollNotificationPayload(uint64_t rollId, uint32_t itemTemplateId, const std::string& itemName,
+		uint32_t count, uint32_t durationSec)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(rollId))         return {};
+		if (!w.WriteU32(itemTemplateId)) return {};
+		if (!w.WriteString(itemName))    return {};
+		if (!w.WriteU32(count))          return {};
+		if (!w.WriteU32(durationSec))    return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLootRollNotificationPacket(uint64_t rollId, uint32_t itemTemplateId, const std::string& itemName,
+		uint32_t count, uint32_t durationSec, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(rollId))         return {};
+		if (!w.WriteU32(itemTemplateId)) return {};
+		if (!w.WriteString(itemName))    return {};
+		if (!w.WriteU32(count))          return {};
+		if (!w.WriteU32(durationSec))    return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLootRollNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LOOT_ROLL_CHOICE - Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LootRollChoiceRequestPayload> ParseLootRollChoiceRequestPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 rollId (8) + uint8 choice (1) = 9.
+		if (!payload || payloadSize < 9u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LootRollChoiceRequestPayload out;
+		if (!r.ReadU64(out.rollId)) return std::nullopt;
+		uint8_t choiceByte = 0;
+		if (!r.ReadBytes(&choiceByte, 1u)) return std::nullopt;
+		out.choice = choiceByte;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLootRollChoiceRequestPayload(uint64_t rollId, uint8_t choice)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(rollId))         return {};
+		if (!w.WriteBytes(&choice, 1u))  return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	// -------------------------------------------------------------------------
+	// LOOT_ROLL_CHOICE - Response
+	// -------------------------------------------------------------------------
+
+	std::optional<LootRollChoiceResponsePayload> ParseLootRollChoiceResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 1u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LootRollChoiceResponsePayload out;
+		if (!r.ReadBytes(&out.status, 1u)) return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLootRollChoiceResponsePayload(uint8_t status)
+	{
+		std::vector<uint8_t> buf(1u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&status, 1u)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLootRollChoiceResponsePacket(uint8_t status, uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&status, 1u)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLootRollChoiceResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LOOT_ROLL_RESULT_NOTIFICATION (push, requestId=0)
+	// -------------------------------------------------------------------------
+
+	std::optional<LootRollResultNotificationPayload> ParseLootRollResultNotificationPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint64 rollId (8) + uint16 winnerNameLen (2) + uint8 choice (1)
+		//     + uint8 roll (1) + uint32 itemTemplateId (4) + uint16 itemNameLen (2)
+		//     + uint32 count (4) = 22 (strings vides possibles).
+		if (!payload || payloadSize < 22u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LootRollResultNotificationPayload out;
+		if (!r.ReadU64(out.rollId))         return std::nullopt;
+		if (!r.ReadString(out.winnerName))  return std::nullopt;
+		uint8_t choiceByte = 0;
+		if (!r.ReadBytes(&choiceByte, 1u))  return std::nullopt;
+		out.winnerChoice = choiceByte;
+		uint8_t rollByte = 0;
+		if (!r.ReadBytes(&rollByte, 1u))    return std::nullopt;
+		out.winnerRoll = rollByte;
+		if (!r.ReadU32(out.itemTemplateId)) return std::nullopt;
+		if (!r.ReadString(out.itemName))    return std::nullopt;
+		if (!r.ReadU32(out.count))          return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLootRollResultNotificationPayload(uint64_t rollId, const std::string& winnerName,
+		uint8_t winnerChoice, uint8_t winnerRoll, uint32_t itemTemplateId, const std::string& itemName, uint32_t count)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(rollId))             return {};
+		if (!w.WriteString(winnerName))      return {};
+		if (!w.WriteBytes(&winnerChoice, 1u)) return {};
+		if (!w.WriteBytes(&winnerRoll, 1u))  return {};
+		if (!w.WriteU32(itemTemplateId))     return {};
+		if (!w.WriteString(itemName))        return {};
+		if (!w.WriteU32(count))              return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLootRollResultNotificationPacket(uint64_t rollId, const std::string& winnerName,
+		uint8_t winnerChoice, uint8_t winnerRoll, uint32_t itemTemplateId, const std::string& itemName, uint32_t count,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(rollId))             return {};
+		if (!w.WriteString(winnerName))      return {};
+		if (!w.WriteBytes(&winnerChoice, 1u)) return {};
+		if (!w.WriteBytes(&winnerRoll, 1u))  return {};
+		if (!w.WriteU32(itemTemplateId))     return {};
+		if (!w.WriteString(itemName))        return {};
+		if (!w.WriteU32(count))              return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLootRollResultNotification, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// LOOT_SIMULATE_ROLL - Request
+	// -------------------------------------------------------------------------
+
+	std::optional<LootSimulateRollRequestPayload> ParseLootSimulateRollRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepte.
+		return LootSimulateRollRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildLootSimulateRollRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	// -------------------------------------------------------------------------
+	// LOOT_SIMULATE_ROLL - Response
+	// -------------------------------------------------------------------------
+
+	std::optional<LootSimulateRollResponsePayload> ParseLootSimulateRollResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 status (1) + uint64 rollId (8) = 9.
+		if (!payload || payloadSize < 9u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		LootSimulateRollResponsePayload out;
+		if (!r.ReadBytes(&out.status, 1u)) return std::nullopt;
+		if (!r.ReadU64(out.rollId))        return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildLootSimulateRollResponsePayload(uint8_t status, uint64_t rollId)
+	{
+		std::vector<uint8_t> buf(9u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteBytes(&status, 1u)) return {};
+		if (!w.WriteU64(rollId))        return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildLootSimulateRollResponsePacket(uint8_t status, uint64_t rollId,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteBytes(&status, 1u)) return {};
+		if (!w.WriteU64(rollId))        return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeLootSimulateRollResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/LootPayloads.h
+++ b/src/shared/network/LootPayloads.h
@@ -1,0 +1,158 @@
+#pragma once
+// CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Wire payloads pour les opcodes
+// Loot (182-187). 2 paires Request/Response + 2 push notifications :
+//   - RollNotification        (182, push, request_id=0) : nouvelle roll proposee.
+//   - Choice                  (183/184)                 : Need/Greed/Pass.
+//   - RollResultNotification  (185, push, request_id=0) : roll terminee.
+//   - SimulateRoll            (186/187)                 : DEBUG simule une roll.
+//
+// Le master tient en memoire un registry de rolls actifs (V1 : un seul
+// eligible par roll, le creator) + items hardcodes (5 entries). Acceptable V1.
+//
+// Format wire : ByteReader/ByteWriter little-endian. Strings via
+// WriteString/ReadString (uint16 length + UTF-8 bytes), uint8 ecrits via
+// WriteBytes(&val, 1u).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// Codes d'erreur - wire-level pour Loot.
+	// =========================================================================
+
+	/// Code d'erreur generique pour les opcodes Loot. 0 = OK.
+	enum class LootResponseStatus : uint8_t
+	{
+		Ok            = 0,
+		Unauthorized  = 1, ///< Pas de session valide cote master.
+		InvalidChoice = 2, ///< choice n'est pas 0/1/2.
+		RollNotFound  = 3, ///< rollId inconnu du registry master.
+		RollEnded     = 4, ///< Roll deja resolved (timeout ou tous les choix recus).
+	};
+
+	// =========================================================================
+	// LOOT_ROLL_NOTIFICATION - Master to Client (push, requestId=0).
+	// Nouvelle roll proposee : eligible doit choisir Need/Greed/Pass.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 rollId
+	///   uint32 itemTemplateId
+	///   string itemName
+	///   uint32 count
+	///   uint32 durationSec
+	struct LootRollNotificationPayload
+	{
+		uint64_t    rollId         = 0;
+		uint32_t    itemTemplateId = 0;
+		std::string itemName;
+		uint32_t    count          = 0;
+		uint32_t    durationSec    = 0;
+	};
+
+	// =========================================================================
+	// LOOT_ROLL_CHOICE - Client to Master : choix Need/Greed/Pass.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 rollId
+	///   uint8  choice (0=Pass, 1=Greed, 2=Need)
+	struct LootRollChoiceRequestPayload
+	{
+		uint64_t rollId = 0;
+		uint8_t  choice = 0;
+	};
+
+	/// Wire format :
+	///   uint8 status (cf. LootResponseStatus)
+	struct LootRollChoiceResponsePayload
+	{
+		uint8_t status = 0;
+	};
+
+	// =========================================================================
+	// LOOT_ROLL_RESULT_NOTIFICATION - Master to Client (push, requestId=0).
+	// Roll terminee : winner connu (ou personne si tous Pass).
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 rollId
+	///   string winnerName        (vide si personne, tous Pass)
+	///   uint8  winnerChoice      (0=Pass/1=Greed/2=Need)
+	///   uint8  winnerRoll        (0..100, 0 si tous Pass)
+	///   uint32 itemTemplateId
+	///   string itemName
+	///   uint32 count
+	struct LootRollResultNotificationPayload
+	{
+		uint64_t    rollId         = 0;
+		std::string winnerName;
+		uint8_t     winnerChoice   = 0;
+		uint8_t     winnerRoll     = 0;
+		uint32_t    itemTemplateId = 0;
+		std::string itemName;
+		uint32_t    count          = 0;
+	};
+
+	// =========================================================================
+	// LOOT_SIMULATE_ROLL - Client to Master : DEBUG simule une roll.
+	// =========================================================================
+
+	/// Wire format : (vide). V1 outil dev, le creator devient seul eligible.
+	struct LootSimulateRollRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Wire format :
+	///   uint8  status (cf. LootResponseStatus)
+	///   uint64 rollId   (si status == 0, sinon 0)
+	struct LootSimulateRollResponsePayload
+	{
+		uint8_t  status = 0;
+		uint64_t rollId = 0;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build - Notifications & Requests (payload-only)
+	// -------------------------------------------------------------------------
+
+	std::optional<LootRollNotificationPayload>        ParseLootRollNotificationPayload       (const uint8_t* payload, size_t payloadSize);
+	std::optional<LootRollChoiceRequestPayload>       ParseLootRollChoiceRequestPayload      (const uint8_t* payload, size_t payloadSize);
+	std::optional<LootRollChoiceResponsePayload>      ParseLootRollChoiceResponsePayload     (const uint8_t* payload, size_t payloadSize);
+	std::optional<LootRollResultNotificationPayload>  ParseLootRollResultNotificationPayload (const uint8_t* payload, size_t payloadSize);
+	std::optional<LootSimulateRollRequestPayload>     ParseLootSimulateRollRequestPayload    (const uint8_t* payload, size_t payloadSize);
+	std::optional<LootSimulateRollResponsePayload>    ParseLootSimulateRollResponsePayload   (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildLootRollNotificationPayload      (uint64_t rollId, uint32_t itemTemplateId, const std::string& itemName,
+	                                                            uint32_t count, uint32_t durationSec);
+	std::vector<uint8_t> BuildLootRollChoiceRequestPayload     (uint64_t rollId, uint8_t choice);
+	std::vector<uint8_t> BuildLootRollChoiceResponsePayload    (uint8_t status);
+	std::vector<uint8_t> BuildLootRollResultNotificationPayload(uint64_t rollId, const std::string& winnerName,
+	                                                            uint8_t winnerChoice, uint8_t winnerRoll,
+	                                                            uint32_t itemTemplateId, const std::string& itemName,
+	                                                            uint32_t count);
+	std::vector<uint8_t> BuildLootSimulateRollRequestPayload   ();
+	std::vector<uint8_t> BuildLootSimulateRollResponsePayload  (uint8_t status, uint64_t rollId);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilise cote handler serveur.
+	// -------------------------------------------------------------------------
+
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildLootRollNotificationPacket       (uint64_t rollId, uint32_t itemTemplateId, const std::string& itemName,
+	                                                            uint32_t count, uint32_t durationSec, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildLootRollChoiceResponsePacket     (uint8_t status, uint32_t requestId, uint64_t sessionIdHeader);
+	/// Push asynchrone (request_id=0). Aucun client request en correspondance.
+	std::vector<uint8_t> BuildLootRollResultNotificationPacket (uint64_t rollId, const std::string& winnerName,
+	                                                            uint8_t winnerChoice, uint8_t winnerRoll,
+	                                                            uint32_t itemTemplateId, const std::string& itemName,
+	                                                            uint32_t count, uint64_t sessionIdHeader);
+	std::vector<uint8_t> BuildLootSimulateRollResponsePacket   (uint8_t status, uint64_t rollId,
+	                                                            uint32_t requestId, uint64_t sessionIdHeader);
+}

--- a/src/shared/network/LootPayloadsTests.cpp
+++ b/src/shared/network/LootPayloadsTests.cpp
@@ -1,0 +1,431 @@
+/**
+ * CMANGOS.17 (Phase 3.17 step 3+4 Loot) - Round-trip tests for LOOT_*
+ * payloads. Pure encoding tests (no DB / no network).
+ *
+ * Returns 0 on success, 1 on first failure.
+ */
+
+#include "src/shared/network/LootPayloads.h"
+#include "src/shared/network/PacketView.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::network;
+
+// -----------------------------------------------------------------------------
+// LOOT_ROLL_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestRollNotificationRoundTrip()
+{
+	auto buf = BuildLootRollNotificationPayload(42ull, 1u, "Iron Ore", 5u, 30u);
+	auto parsed = ParseLootRollNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "RollNotification round-trip parses");
+	if (parsed)
+	{
+		Assert(parsed->rollId == 42ull, "RollNotification rollId=42");
+		Assert(parsed->itemTemplateId == 1u, "RollNotification itemTemplateId=1");
+		Assert(parsed->itemName == "Iron Ore", "RollNotification itemName");
+		Assert(parsed->count == 5u, "RollNotification count=5");
+		Assert(parsed->durationSec == 30u, "RollNotification durationSec=30");
+	}
+}
+
+static void TestRollNotificationEmptyName()
+{
+	auto buf = BuildLootRollNotificationPayload(1ull, 0u, "", 0u, 0u);
+	auto parsed = ParseLootRollNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "RollNotification empty name parses");
+	if (parsed)
+	{
+		Assert(parsed->itemName.empty(), "RollNotification empty itemName");
+		Assert(parsed->count == 0u, "RollNotification count=0");
+	}
+}
+
+static void TestRollNotificationLongName()
+{
+	std::string longName(500u, 'X');
+	auto buf = BuildLootRollNotificationPayload(0xCAFEBABEull, 0xFFFFFFFFu, longName, 0xFFFFFFFFu, 0xFFFFFFFFu);
+	auto parsed = ParseLootRollNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "RollNotification long name parses");
+	if (parsed)
+	{
+		Assert(parsed->rollId == 0xCAFEBABEull, "RollNotification rollId max");
+		Assert(parsed->itemName.size() == 500u, "RollNotification long itemName");
+		Assert(parsed->count == 0xFFFFFFFFu, "RollNotification count u32 max");
+		Assert(parsed->durationSec == 0xFFFFFFFFu, "RollNotification duration u32 max");
+	}
+}
+
+static void TestRollNotificationRejectsShort()
+{
+	auto parsed = ParseLootRollNotificationPayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "RollNotification rejects nullptr");
+	uint8_t shortBuf[10]{};
+	auto parsed2 = ParseLootRollNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "RollNotification rejects 10 bytes");
+}
+
+static void TestRollNotificationPacket()
+{
+	auto pkt = BuildLootRollNotificationPacket(7ull, 3u, "Mageweave", 1u, 30u, 0xDEADBEEFull);
+	Assert(!pkt.empty(), "RollNotification packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"RollNotification PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLootRollNotification, "Opcode is RollNotification");
+	Assert(view.RequestId() == 0u, "RollNotification RequestId is 0 (push)");
+	Assert(view.SessionId() == 0xDEADBEEFull, "RollNotification SessionId preserved");
+	auto parsed = ParseLootRollNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->rollId == 7ull && parsed->itemName == "Mageweave",
+		"RollNotification packet payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LOOT_ROLL_CHOICE - Request
+// -----------------------------------------------------------------------------
+
+static void TestChoiceRequestPass()
+{
+	auto buf = BuildLootRollChoiceRequestPayload(42ull, 0u);
+	auto parsed = ParseLootRollChoiceRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->rollId == 42ull && parsed->choice == 0u,
+		"ChoiceRequest Pass round-trip");
+}
+
+static void TestChoiceRequestGreed()
+{
+	auto buf = BuildLootRollChoiceRequestPayload(7ull, 1u);
+	auto parsed = ParseLootRollChoiceRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->choice == 1u, "ChoiceRequest Greed round-trip");
+}
+
+static void TestChoiceRequestNeed()
+{
+	auto buf = BuildLootRollChoiceRequestPayload(99ull, 2u);
+	auto parsed = ParseLootRollChoiceRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->choice == 2u, "ChoiceRequest Need round-trip");
+}
+
+static void TestChoiceRequestInvalid255()
+{
+	// Le wire accepte 255, c'est le handler serveur qui rejettera (InvalidChoice).
+	auto buf = BuildLootRollChoiceRequestPayload(1ull, 255u);
+	auto parsed = ParseLootRollChoiceRequestPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->choice == 255u,
+		"ChoiceRequest accepts choice=255 at wire level");
+}
+
+static void TestChoiceRequestRejectsShort()
+{
+	auto parsed = ParseLootRollChoiceRequestPayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "ChoiceRequest rejects nullptr");
+	uint8_t shortBuf[8]{};
+	auto parsed2 = ParseLootRollChoiceRequestPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "ChoiceRequest rejects 8 bytes");
+}
+
+// -----------------------------------------------------------------------------
+// LOOT_ROLL_CHOICE - Response
+// -----------------------------------------------------------------------------
+
+static void TestChoiceResponseOk()
+{
+	auto buf = BuildLootRollChoiceResponsePayload(0u);
+	Assert(buf.size() == 1u, "ChoiceResponse Ok 1 byte");
+	auto parsed = ParseLootRollChoiceResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 0u, "ChoiceResponse Ok parses");
+}
+
+static void TestChoiceResponseInvalidChoice()
+{
+	auto buf = BuildLootRollChoiceResponsePayload(
+		static_cast<uint8_t>(LootResponseStatus::InvalidChoice));
+	auto parsed = ParseLootRollChoiceResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 2u, "ChoiceResponse InvalidChoice");
+}
+
+static void TestChoiceResponseRollNotFound()
+{
+	auto buf = BuildLootRollChoiceResponsePayload(
+		static_cast<uint8_t>(LootResponseStatus::RollNotFound));
+	auto parsed = ParseLootRollChoiceResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 3u, "ChoiceResponse RollNotFound");
+}
+
+static void TestChoiceResponseRollEnded()
+{
+	auto buf = BuildLootRollChoiceResponsePayload(
+		static_cast<uint8_t>(LootResponseStatus::RollEnded));
+	auto parsed = ParseLootRollChoiceResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 4u, "ChoiceResponse RollEnded");
+}
+
+static void TestChoiceResponseUnauthorized()
+{
+	auto buf = BuildLootRollChoiceResponsePayload(
+		static_cast<uint8_t>(LootResponseStatus::Unauthorized));
+	auto parsed = ParseLootRollChoiceResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 1u, "ChoiceResponse Unauthorized");
+}
+
+static void TestChoiceResponsePacket()
+{
+	auto pkt = BuildLootRollChoiceResponsePacket(0u, 1234u, 0xCAFEull);
+	Assert(!pkt.empty(), "ChoiceResponse packet built");
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"ChoiceResponse PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLootRollChoiceResponse, "Opcode is ChoiceResponse");
+	Assert(view.RequestId() == 1234u, "ChoiceResponse RequestId preserved");
+	auto parsed = ParseLootRollChoiceResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->status == 0u, "ChoiceResponse packet payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LOOT_ROLL_RESULT_NOTIFICATION (push)
+// -----------------------------------------------------------------------------
+
+static void TestRollResultNeedWinner()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		42ull, "Aragorn", 2u /*Need*/, 87u, 1u, "Iron Ore", 5u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "RollResult Need winner parses");
+	if (parsed)
+	{
+		Assert(parsed->rollId == 42ull, "RollResult rollId=42");
+		Assert(parsed->winnerName == "Aragorn", "RollResult winnerName");
+		Assert(parsed->winnerChoice == 2u, "RollResult winnerChoice=Need");
+		Assert(parsed->winnerRoll == 87u, "RollResult winnerRoll=87");
+		Assert(parsed->itemTemplateId == 1u, "RollResult itemTemplateId=1");
+		Assert(parsed->itemName == "Iron Ore", "RollResult itemName");
+		Assert(parsed->count == 5u, "RollResult count=5");
+	}
+}
+
+static void TestRollResultGreedWinner()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		7ull, "Legolas", 1u /*Greed*/, 50u, 4u, "Health Potion", 1u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerChoice == 1u && parsed->winnerRoll == 50u,
+		"RollResult Greed winner parses");
+}
+
+static void TestRollResultAllPass()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		99ull, "" /*personne*/, 0u /*Pass*/, 0u, 5u, "Mana Potion", 2u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "RollResult all Pass parses");
+	if (parsed)
+	{
+		Assert(parsed->winnerName.empty(), "RollResult empty winnerName when all Pass");
+		Assert(parsed->winnerChoice == 0u, "RollResult winnerChoice=Pass");
+		Assert(parsed->winnerRoll == 0u, "RollResult winnerRoll=0");
+	}
+}
+
+static void TestRollResultRollMin()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		1ull, "X", 2u, 0u /*roll min*/, 1u, "Iron", 1u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerRoll == 0u, "RollResult roll=0 parses");
+}
+
+static void TestRollResultRollMax()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		2ull, "Y", 2u, 100u /*roll max*/, 1u, "Iron", 1u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerRoll == 100u, "RollResult roll=100 parses");
+}
+
+static void TestRollResultLongName()
+{
+	std::string longName(300u, 'A');
+	auto buf = BuildLootRollResultNotificationPayload(
+		1ull, longName, 2u, 50u, 1u, "Item", 1u);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->winnerName.size() == 300u,
+		"RollResult long winnerName parses");
+}
+
+static void TestRollResultCountMax()
+{
+	auto buf = BuildLootRollResultNotificationPayload(
+		1ull, "X", 1u, 50u, 0xFFFFFFFFu, "Y", 0xFFFFFFFFu);
+	auto parsed = ParseLootRollResultNotificationPayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->count == 0xFFFFFFFFu
+		&& parsed->itemTemplateId == 0xFFFFFFFFu,
+		"RollResult u32 max count + itemTemplateId");
+}
+
+static void TestRollResultRejectsShort()
+{
+	auto parsed = ParseLootRollResultNotificationPayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "RollResult rejects nullptr");
+	uint8_t shortBuf[15]{};
+	auto parsed2 = ParseLootRollResultNotificationPayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "RollResult rejects 15 bytes");
+}
+
+static void TestRollResultPacket()
+{
+	auto pkt = BuildLootRollResultNotificationPacket(
+		42ull, "Boss", 2u, 75u, 1u, "Mageweave", 3u, 0xBEEFull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"RollResult PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLootRollResultNotification,
+		"Opcode is RollResultNotification");
+	Assert(view.RequestId() == 0u, "RollResult RequestId is 0 (push)");
+	auto parsed = ParseLootRollResultNotificationPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->winnerName == "Boss" && parsed->winnerRoll == 75u,
+		"RollResult packet payload decodes");
+}
+
+// -----------------------------------------------------------------------------
+// LOOT_SIMULATE_ROLL - Request
+// -----------------------------------------------------------------------------
+
+static void TestSimulateRequestEmpty()
+{
+	auto buf = BuildLootSimulateRollRequestPayload();
+	Assert(buf.empty(), "Simulate request payload empty");
+	auto parsed = ParseLootSimulateRollRequestPayload(nullptr, 0u);
+	Assert(parsed.has_value(), "Simulate request accepts empty payload");
+}
+
+// -----------------------------------------------------------------------------
+// LOOT_SIMULATE_ROLL - Response
+// -----------------------------------------------------------------------------
+
+static void TestSimulateResponseOk()
+{
+	auto buf = BuildLootSimulateRollResponsePayload(0u, 42ull);
+	auto parsed = ParseLootSimulateRollResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 0u && parsed->rollId == 42ull,
+		"Simulate response Ok round-trip");
+}
+
+static void TestSimulateResponseUnauthorized()
+{
+	auto buf = BuildLootSimulateRollResponsePayload(
+		static_cast<uint8_t>(LootResponseStatus::Unauthorized), 0ull);
+	auto parsed = ParseLootSimulateRollResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->status == 1u && parsed->rollId == 0ull,
+		"Simulate response Unauthorized");
+}
+
+static void TestSimulateResponseRollIdMax()
+{
+	auto buf = BuildLootSimulateRollResponsePayload(0u, 0xFFFFFFFFFFFFFFFFull);
+	auto parsed = ParseLootSimulateRollResponsePayload(buf.data(), buf.size());
+	Assert(parsed.has_value() && parsed->rollId == 0xFFFFFFFFFFFFFFFFull,
+		"Simulate response rollId u64 max");
+}
+
+static void TestSimulateResponseRejectsShort()
+{
+	auto parsed = ParseLootSimulateRollResponsePayload(nullptr, 0u);
+	Assert(!parsed.has_value(), "Simulate response rejects nullptr");
+	uint8_t shortBuf[8]{};
+	auto parsed2 = ParseLootSimulateRollResponsePayload(shortBuf, sizeof(shortBuf));
+	Assert(!parsed2.has_value(), "Simulate response rejects 8 bytes");
+}
+
+static void TestSimulateResponsePacket()
+{
+	auto pkt = BuildLootSimulateRollResponsePacket(0u, 99ull, 555u, 0xCAFEull);
+	PacketView view;
+	Assert(PacketView::Parse(pkt.data(), pkt.size(), view) == PacketParseResult::Ok,
+		"Simulate response PacketView parse OK");
+	Assert(view.Opcode() == kOpcodeLootSimulateRollResponse,
+		"Opcode is SimulateRollResponse");
+	Assert(view.RequestId() == 555u, "Simulate response RequestId preserved");
+	auto parsed = ParseLootSimulateRollResponsePayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value() && parsed->rollId == 99ull, "Simulate response packet decodes");
+}
+
+// -----------------------------------------------------------------------------
+// Status enum exhaustif
+// -----------------------------------------------------------------------------
+
+static void TestStatusEnumValues()
+{
+	Assert(static_cast<uint8_t>(LootResponseStatus::Ok) == 0u, "Status Ok=0");
+	Assert(static_cast<uint8_t>(LootResponseStatus::Unauthorized) == 1u, "Status Unauthorized=1");
+	Assert(static_cast<uint8_t>(LootResponseStatus::InvalidChoice) == 2u, "Status InvalidChoice=2");
+	Assert(static_cast<uint8_t>(LootResponseStatus::RollNotFound) == 3u, "Status RollNotFound=3");
+	Assert(static_cast<uint8_t>(LootResponseStatus::RollEnded) == 4u, "Status RollEnded=4");
+}
+
+// -----------------------------------------------------------------------------
+
+int main()
+{
+	TestRollNotificationRoundTrip();
+	TestRollNotificationEmptyName();
+	TestRollNotificationLongName();
+	TestRollNotificationRejectsShort();
+	TestRollNotificationPacket();
+
+	TestChoiceRequestPass();
+	TestChoiceRequestGreed();
+	TestChoiceRequestNeed();
+	TestChoiceRequestInvalid255();
+	TestChoiceRequestRejectsShort();
+
+	TestChoiceResponseOk();
+	TestChoiceResponseInvalidChoice();
+	TestChoiceResponseRollNotFound();
+	TestChoiceResponseRollEnded();
+	TestChoiceResponseUnauthorized();
+	TestChoiceResponsePacket();
+
+	TestRollResultNeedWinner();
+	TestRollResultGreedWinner();
+	TestRollResultAllPass();
+	TestRollResultRollMin();
+	TestRollResultRollMax();
+	TestRollResultLongName();
+	TestRollResultCountMax();
+	TestRollResultRejectsShort();
+	TestRollResultPacket();
+
+	TestSimulateRequestEmpty();
+
+	TestSimulateResponseOk();
+	TestSimulateResponseUnauthorized();
+	TestSimulateResponseRollIdMax();
+	TestSimulateResponseRejectsShort();
+	TestSimulateResponsePacket();
+
+	TestStatusEnumValues();
+
+	std::cerr << (s_failCount == 0 ? "[OK] all loot payload tests passed\n"
+	                                : "[FAIL] some loot tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -738,4 +738,43 @@ namespace engine::network
 	constexpr uint16_t kOpcodeAuctionCancelRequest        = 179u; ///< Client to Master : annule sa propre enchere (auctionId).
 	constexpr uint16_t kOpcodeAuctionCancelResponse       = 180u; ///< Master to Client : OK ou NotOwner / AuctionNotFound / Unauthorized.
 	constexpr uint16_t kOpcodeAuctionExpiredNotification  = 181u; ///< Master to Client (push, request_id=0) : enchere expiree (auctionId, won bool, finalBidCopper, winnerName).
+
+	// =====================================================================
+	// CMANGOS.17 step 3+4 — Loot wire (group roll Need/Greed/Pass + result
+	// push). Master tient en memoire les rolls actifs (V1 simulation simple :
+	// un seul eligible par roll, le creator). 6 opcodes : 2 paires Request/
+	// Response (Choice + SimulateRoll) + 2 push notifications (RollNotification
+	// + RollResultNotification).
+	//
+	// Architecture : a chaque SimulateRollRequest (V1 outil dev), master cree
+	// une nouvelle ActiveRoll avec creator comme seul eligible, item aleatoire
+	// dans 1..5, count=1, durationSec=30. Push immediatement RollNotification
+	// au creator. Quand creator envoie ChoiceRequest (Need/Greed/Pass), master
+	// resout immediatement la roll (un seul eligible) : random uint8 0..100,
+	// regle Need > Greed > Pass + plus haut roll dans la meme categorie. Push
+	// RollResultNotification au creator.
+	//
+	// V1 limitations :
+	//   - SimulateRoll = creator-only eligible (pas de groupe). Future PR :
+	//     integration avec Group/Party (CMANGOS.15).
+	//   - Items hardcode (5 entries V1). Future PR : integration LootTable +
+	//     ItemTemplate (engine::server::loot::LootTable).
+	//   - Pas de timeout tick periodique : scan a chaque HandleChoice.
+	//   - Pas de SyncLoot RPC entre master et shardd (master autoritaire V1).
+	//
+	// Decoupage opcode :
+	//   - RollNotification        (182, push, request_id=0) : nouvelle roll proposee.
+	//   - Choice                  (183/184)                 : Need/Greed/Pass.
+	//   - RollResultNotification  (185, push, request_id=0) : roll terminee.
+	//   - SimulateRoll            (186/187)                 : DEBUG simule une roll.
+	//
+	// Wire format choice : uint8 (Pass=0, Greed=1, Need=2). Wire format
+	// winnerRoll : uint8 0..100.
+	// =====================================================================
+	constexpr uint16_t kOpcodeLootRollNotification        = 182u; ///< Master to Client (push, request_id=0) : nouvelle roll proposee (rollId, itemTemplateId, itemName, count, durationSec).
+	constexpr uint16_t kOpcodeLootRollChoiceRequest       = 183u; ///< Client to Master : choix du joueur (rollId, choice 0=Pass/1=Greed/2=Need).
+	constexpr uint16_t kOpcodeLootRollChoiceResponse      = 184u; ///< Master to Client : OK ou InvalidChoice / RollNotFound / RollEnded / Unauthorized.
+	constexpr uint16_t kOpcodeLootRollResultNotification  = 185u; ///< Master to Client (push, request_id=0) : roll terminee (rollId, winnerName, winnerChoice, winnerRoll uint8 0-100, itemTemplateId, itemName, count).
+	constexpr uint16_t kOpcodeLootSimulateRollRequest     = 186u; ///< Client to Master : DEBUG simule une roll (creator devient eligible) — V1 outil dev.
+	constexpr uint16_t kOpcodeLootSimulateRollResponse    = 187u; ///< Master to Client : OK + rollId, ou Unauthorized.
 }


### PR DESCRIPTION
## CMANGOS.17 step 3+4 : Loot wire (group roll Need/Greed/Pass + UI roll window)

Wire le mécanisme de loot group roll (Need/Greed/Pass + result) avec UI client.
Master tient en mémoire les rolls actifs (V1 simulation simple : un seul éligible par roll, le creator) + push notifications aux participants.

### Server wire (master)
- `src/shared/network/ProtocolV1Constants.h` : 6 opcodes (182-187)
  - `182` LootRollNotification (push)
  - `183/184` LootRollChoice Request/Response
  - `185` LootRollResultNotification (push)
  - `186/187` LootSimulateRoll Request/Response (debug V1)
- `src/shared/network/LootPayloads.{h,cpp,Tests.cpp}` : 33 tests round-trip + edge cases
- `src/masterd/handlers/loot/LootHandler.{h,cpp}` :
  - `ActiveRoll` registry mutex-protégé
  - Resolution Need > Greed > Pass + highest roll 0..100 within same category
  - All-Pass case : winnerName vide
  - Scan timeout à chaque HandleChoice
  - `PushRollNotification` + `PushRollResult` helpers publics
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcodes 183/186 + `&lootHandler` ajouté à la capture-list lambda

### Client integration
- `src/client/loot/LootRollUi.{h,cpp}` : presenter + state (pendingRolls, lastResult toast)
- `src/client/render/LootRollImGuiRenderer.{h,cpp}` :
  - Bouton « Simulate Loot Roll » au top (debug V1)
  - Card par pendingRoll : item name + count + countdown + 3 boutons Need(violet) / Greed(vert) / Pass(gris)
  - Toast 5s sur lastResult avec choice color-coded
- `src/client/app/Engine` : dispatch + slash `/loot` + touche `L` toggle (déjà dans Input.h)
- `CMakeLists.txt` : sources + `loot_payloads_tests` target

### V1 limitations (consignées)
- Simulate Roll = creator-only eligible (pas de groupe). Future PR : intégration avec Group/Party (CMANGOS.15) pour résoudre les éligibles depuis le party qui a tué le mob.
- Items hardcodés (5 entries V1). Future PR : intégration LootTable + ItemTemplate.
- Pas de timeout tick périodique : scan à chaque HandleChoice.
- Winner name V1 : `Account #<id>`. Future hookup avec OnCharacterEnterWorld.
- Pas de SyncLoot RPC entre master et shardd (master autoritaire V1).

### Tests
- `loot_payloads_tests` (33 tests) — voir `src/shared/network/LootPayloadsTests.cpp`
- CI Linux + Windows lance les tests automatiquement

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 182-187 + handler LootHandler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
