### PR TITLE
feat(lunar): 16 phases lunaires + SkyPass + tests cycle jour/nuit (Phase 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,7 @@ add_library(engine_core
   src/client/render/WaterMeshGpu.cpp
   src/client/render/WaterPass.cpp
   src/client/render/DayNightCycle.cpp
+  src/client/render/SkyPass.cpp
   src/client/render/WeatherSystem.cpp
   src/client/render/DynamicLightSystem.cpp
   src/client/render/CascadedShadowMaps.cpp
@@ -459,6 +460,7 @@ add_library(engine_core
   src/shared/network/GuildPayloads.cpp
   src/shared/network/AuctionPayloads.cpp
   src/shared/network/LootPayloads.cpp
+  src/shared/network/LunarPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -749,6 +751,21 @@ add_test(NAME auction_payloads_tests COMMAND auction_payloads_tests)
 add_executable(loot_payloads_tests src/shared/network/LootPayloadsTests.cpp)
 target_link_libraries(loot_payloads_tests PRIVATE engine_core)
 add_test(NAME loot_payloads_tests COMMAND loot_payloads_tests)
+
+# Phase 5 Lunar — round-trip tests payloads (192-194).
+add_executable(lunar_payloads_tests src/shared/network/LunarPayloadsTests.cpp)
+target_link_libraries(lunar_payloads_tests PRIVATE engine_core)
+add_test(NAME lunar_payloads_tests COMMAND lunar_payloads_tests)
+
+# Phase 5 Lunar — calendar deterministe tests (header-only).
+add_executable(lunar_calendar_tests src/shardd/world/LunarCalendarTests.cpp)
+target_link_libraries(lunar_calendar_tests PRIVATE engine_core)
+add_test(NAME lunar_calendar_tests COMMAND lunar_calendar_tests)
+
+# M38.1 + Phase 5 Lunar — DayNightCycle existant + extension lunaire.
+add_executable(daynight_cycle_tests src/client/render/DayNightCycleTests.cpp)
+target_link_libraries(daynight_cycle_tests PRIVATE engine_core)
+add_test(NAME daynight_cycle_tests COMMAND daynight_cycle_tests)
 
 # CMANGOS.27 (Phase 4.27 step 3+4): TRADE_*_REQUEST/RESPONSE/NOTIFICATION payload round-trip tests
 add_executable(trade_payloads_tests src/shared/network/TradePayloadsTests.cpp)

--- a/docs/superpowers/plans/2026-05-10-day-night-lunar-cycle.md
+++ b/docs/superpowers/plans/2026-05-10-day-night-lunar-cycle.md
@@ -1,0 +1,1926 @@
+# Cycle jour/nuit + 16 phases lunaires — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Étendre le moteur LCDLLN avec un système de phases lunaires à 16 étapes synchronisé serveur ↔ client + rendu shader procédural + tests du cycle jour/nuit existant.
+
+**Architecture:** `LunarCalendar` (header-only stateless dans `src/shardd/world/`) calcule la phase déterministe depuis l'epoch Unix. `LunarHandler` master pousse l'état initial (opcode 192/193) à la connexion + push (opcode 194) sur changement de phase via tick 5min. Côté client, `DayNightCycle` reçoit la phase via callback et `SkyPass` Vulkan dessine le disque lunaire procéduralement via push-constants étendus. Cycle = 14 jours réels = 16 phases × 21h.
+
+**Tech Stack:** C++20, Vulkan 1.3, GLSL 450, CMake, vcpkg. Pattern strict aligné sur les wires récents (Mail à Loot). Build local impossible — vérification CI Linux + Windows.
+
+---
+
+## File Structure
+
+### Nouveaux fichiers
+- `src/shardd/world/LunarCalendar.h` — header-only, calcul stateless phase + illumination
+- `src/shardd/world/LunarCalendarTests.cpp` — round-trip phase ↔ time, edge cases
+- `src/shared/network/LunarPayloads.h` — déclarations structs + Build/Parse
+- `src/shared/network/LunarPayloads.cpp` — sérialisation little-endian
+- `src/shared/network/LunarPayloadsTests.cpp` — round-trip + edge cases
+- `src/masterd/handlers/lunar/LunarHandler.h` — déclaration handler + Tick + CurrentPhase
+- `src/masterd/handlers/lunar/LunarHandler.cpp` — dispatch + push broadcast
+- `src/client/render/DayNightCycleTests.cpp` — tests du cycle jour/nuit existant
+- `src/client/render/SkyPass.h` — déclaration pass Vulkan ciel
+- `src/client/render/SkyPass.cpp` — pipeline, push-constants, fullscreen quad
+
+### Fichiers modifiés
+- `src/shared/network/ProtocolV1Constants.h` — opcodes 192-194
+- `src/masterd/main_linux.cpp` — instanciation + dispatch + capture-list + Tick periodique
+- `src/client/render/DayNightCycle.h` — extension State + callback
+- `src/client/render/DayNightCycle.cpp` — implémentation callback
+- `game/data/shaders/sky.frag` — disque lunaire procédural + push constants étendus
+- `game/data/shaders/sky.vert` — pas-through fullscreen quad (vérifier qu'il existe déjà)
+- `src/client/app/Engine.h` — membres SkyPass + lunar callback wiring
+- `src/client/app/Engine.cpp` — dispatch opcodes 193/194 + slash commands /sky info|time|moon + intégration SkyPass
+- `CMakeLists.txt` — sources engine_core + 3 nouveaux test targets
+- `src/CMakeLists.txt` — sources server_app + payload partagé
+
+---
+
+## Task 1: Opcodes ProtocolV1Constants
+
+**Files:**
+- Modify: `src/shared/network/ProtocolV1Constants.h`
+
+- [ ] **Step 1: Ajouter le bloc d'opcodes 192-194**
+
+Ajouter à la fin du fichier (après le bloc Loot 182-187) :
+
+```cpp
+	// =====================================================================
+	// Phase 5 step 3+4 — Lunar wire (16 phases lunaires synchronisees serveur
+	// -> client). Cycle de 14 jours reels (16 phases x ~21h chacune), calcul
+	// deterministe depuis epoch Unix. Master autoritaire ; client recoit
+	// l'etat initial sur EnterWorld puis un push toutes les ~21h sur
+	// changement de phase.
+	//
+	// Decoupage opcode :
+	//   - State                    (192/193)             : etat initial sur connexion.
+	//   - PhaseChangeNotification  (194, push, request_id=0) : changement de phase.
+	// =====================================================================
+	constexpr uint16_t kOpcodeLunarStateRequest             = 192u; ///< Client to Master : etat lunaire actuel (vide).
+	constexpr uint16_t kOpcodeLunarStateResponse            = 193u; ///< Master to Client : phase 0..15, illumination 0..1, cycleStart, cycleDuration.
+	constexpr uint16_t kOpcodeLunarPhaseChangeNotification  = 194u; ///< Master to Client (push, request_id=0) : changement de phase.
+```
+
+- [ ] **Step 2: Vérifier qu'aucun autre opcode n'utilise 192-194**
+
+Run :
+```bash
+grep -n "= 192u\|= 193u\|= 194u" src/shared/network/ProtocolV1Constants.h
+```
+Expected : seules les 3 lignes ajoutées au Step 1.
+
+---
+
+## Task 2: LunarCalendar header-only + tests
+
+**Files:**
+- Create: `src/shardd/world/LunarCalendar.h`
+- Create: `src/shardd/world/LunarCalendarTests.cpp`
+
+- [ ] **Step 1: Créer le header LunarCalendar**
+
+Écrire `src/shardd/world/LunarCalendar.h` :
+
+```cpp
+#pragma once
+// LunarCalendar : calcul stateless de la phase lunaire courante a partir
+// d'un timestamp Unix. 16 phases (0..15), cycle de 14 jours reels.
+// Header-only, deterministe, partage par master et shardd.
+
+#include <cstdint>
+#include <cmath>
+
+namespace engine::server::world
+{
+	/// Une phase lunaire complete avec son indice (0..15) et son
+	/// illumination (0..1, fraction eclairee).
+	struct LunarPhaseInfo
+	{
+		uint8_t phase        = 0;     ///< Index 0..15
+		float   illumination = 0.0f;  ///< 0..1, fraction eclairee
+	};
+
+	/// Cycle complet en millisecondes : 14 jours * 24h * 3600s * 1000ms.
+	inline constexpr uint64_t kDefaultLunarCycleMs = 14ull * 24ull * 3600ull * 1000ull;
+
+	/// Nombre de phases dans le cycle.
+	inline constexpr uint8_t kLunarPhaseCount = 16u;
+
+	class LunarCalendar
+	{
+	public:
+		/// Calcule la phase lunaire pour un timestamp donne.
+		/// \param realNowMs       Timestamp Unix courant en ms.
+		/// \param cycleStartMs    Timestamp Unix du debut du cycle de reference.
+		/// \param cycleDurationMs Duree d'un cycle complet en ms.
+		/// \return Phase + illumination. Si \p cycleDurationMs == 0 retourne {0, 0}.
+		static LunarPhaseInfo Compute(uint64_t realNowMs,
+		                              uint64_t cycleStartMs,
+		                              uint64_t cycleDurationMs)
+		{
+			if (cycleDurationMs == 0) return {};
+			const uint64_t elapsed = (realNowMs >= cycleStartMs) ? (realNowMs - cycleStartMs) : 0ull;
+			const uint64_t cyclePos = elapsed % cycleDurationMs;
+			const uint64_t phaseDurationMs = cycleDurationMs / kLunarPhaseCount;
+			uint8_t phase = static_cast<uint8_t>(cyclePos / phaseDurationMs);
+			if (phase >= kLunarPhaseCount) phase = kLunarPhaseCount - 1u;
+			return { phase, ComputeIllumination(phase) };
+		}
+
+		/// Calcule l'illumination (0..1) pour un index de phase.
+		/// Sinusoide centree sur Full Moon (index 7) :
+		///   - phase 0  -> 0.0  (NewMoon)
+		///   - phase 7  -> 1.0  (FullMoon)
+		///   - phase 15 -> ~0.04 (Earthshine late, tres sombre)
+		static float ComputeIllumination(uint8_t phase)
+		{
+			constexpr float kPi = 3.14159265358979323846f;
+			const float t = (static_cast<float>(phase) - 7.0f) * (kPi / 8.0f);
+			return 0.5f * (1.0f + std::cos(t));
+		}
+
+		/// Retourne le timestamp ms du prochain changement de phase.
+		static uint64_t NextChangeTsMs(uint64_t realNowMs,
+		                               uint64_t cycleStartMs,
+		                               uint64_t cycleDurationMs)
+		{
+			if (cycleDurationMs == 0) return realNowMs;
+			const uint64_t elapsed = (realNowMs >= cycleStartMs) ? (realNowMs - cycleStartMs) : 0ull;
+			const uint64_t cyclePos = elapsed % cycleDurationMs;
+			const uint64_t phaseDurationMs = cycleDurationMs / kLunarPhaseCount;
+			const uint64_t currentPhaseStartMs = (cyclePos / phaseDurationMs) * phaseDurationMs;
+			const uint64_t nextPhaseStartMs = currentPhaseStartMs + phaseDurationMs;
+			const uint64_t cyclesElapsed = elapsed / cycleDurationMs;
+			return cycleStartMs + (cyclesElapsed * cycleDurationMs) + nextPhaseStartMs;
+		}
+	};
+}
+```
+
+- [ ] **Step 2: Créer les tests LunarCalendar**
+
+Écrire `src/shardd/world/LunarCalendarTests.cpp` :
+
+```cpp
+// Tests du calcul de phase lunaire : round-trip phase <-> time, edge cases,
+// illumination sinusoidale, wrap de cycle. Pas de framework, asserts simples.
+
+#include "src/shardd/world/LunarCalendar.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+using engine::server::world::LunarCalendar;
+using engine::server::world::LunarPhaseInfo;
+using engine::server::world::kDefaultLunarCycleMs;
+using engine::server::world::kLunarPhaseCount;
+
+namespace
+{
+	bool NearlyEqual(float a, float b, float eps = 0.001f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	void TestPhase0AtCycleStart()
+	{
+		auto info = LunarCalendar::Compute(0, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		assert(NearlyEqual(info.illumination, 0.0f));
+		std::puts("[OK] TestPhase0AtCycleStart");
+	}
+
+	void TestPhase7AtHalfCycle()
+	{
+		const uint64_t halfCycle = kDefaultLunarCycleMs / 2;
+		auto info = LunarCalendar::Compute(halfCycle, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 8 || info.phase == 7);
+		std::puts("[OK] TestPhase7AtHalfCycle");
+	}
+
+	void TestPhase0AfterFullCycle()
+	{
+		auto info = LunarCalendar::Compute(kDefaultLunarCycleMs, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		std::puts("[OK] TestPhase0AfterFullCycle");
+	}
+
+	void TestEachPhaseTransition()
+	{
+		const uint64_t phaseDurationMs = kDefaultLunarCycleMs / kLunarPhaseCount;
+		for (uint8_t expectedPhase = 0; expectedPhase < kLunarPhaseCount; ++expectedPhase)
+		{
+			const uint64_t midPhaseMs = static_cast<uint64_t>(expectedPhase) * phaseDurationMs + phaseDurationMs / 2;
+			auto info = LunarCalendar::Compute(midPhaseMs, 0, kDefaultLunarCycleMs);
+			if (info.phase != expectedPhase)
+			{
+				std::printf("[FAIL] expected phase %u got %u at midPhaseMs=%llu\n",
+					expectedPhase, info.phase, static_cast<unsigned long long>(midPhaseMs));
+				assert(info.phase == expectedPhase);
+			}
+		}
+		std::puts("[OK] TestEachPhaseTransition");
+	}
+
+	void TestIlluminationMaxAtFullMoon()
+	{
+		float illum7 = LunarCalendar::ComputeIllumination(7);
+		assert(NearlyEqual(illum7, 1.0f));
+		std::puts("[OK] TestIlluminationMaxAtFullMoon");
+	}
+
+	void TestIlluminationMinAtNewMoon()
+	{
+		float illum0 = LunarCalendar::ComputeIllumination(0);
+		assert(illum0 < 0.05f);
+		std::puts("[OK] TestIlluminationMinAtNewMoon");
+	}
+
+	void TestIlluminationSymmetric()
+	{
+		// Phases 6 et 8 doivent avoir la meme illumination (sinusoide symetrique).
+		float illum6 = LunarCalendar::ComputeIllumination(6);
+		float illum8 = LunarCalendar::ComputeIllumination(8);
+		assert(NearlyEqual(illum6, illum8));
+		std::puts("[OK] TestIlluminationSymmetric");
+	}
+
+	void TestNoInvalidPhase()
+	{
+		// Apres 100 cycles, la phase doit toujours etre dans [0, 15].
+		for (uint64_t k = 0; k < 100; ++k)
+		{
+			const uint64_t t = k * kDefaultLunarCycleMs + 12345;
+			auto info = LunarCalendar::Compute(t, 0, kDefaultLunarCycleMs);
+			assert(info.phase < kLunarPhaseCount);
+		}
+		std::puts("[OK] TestNoInvalidPhase");
+	}
+
+	void TestRealNowBeforeCycleStart()
+	{
+		auto info = LunarCalendar::Compute(0, 1000, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		std::puts("[OK] TestRealNowBeforeCycleStart");
+	}
+
+	void TestZeroCycleDuration()
+	{
+		auto info = LunarCalendar::Compute(12345, 0, 0);
+		assert(info.phase == 0);
+		assert(NearlyEqual(info.illumination, 0.0f));
+		std::puts("[OK] TestZeroCycleDuration");
+	}
+
+	void TestNextChangeTsAdvances()
+	{
+		const uint64_t phaseDurationMs = kDefaultLunarCycleMs / kLunarPhaseCount;
+		uint64_t nowMs = 0;
+		uint64_t next = LunarCalendar::NextChangeTsMs(nowMs, 0, kDefaultLunarCycleMs);
+		assert(next == phaseDurationMs);
+		nowMs = phaseDurationMs / 2;
+		next = LunarCalendar::NextChangeTsMs(nowMs, 0, kDefaultLunarCycleMs);
+		assert(next == phaseDurationMs);
+		std::puts("[OK] TestNextChangeTsAdvances");
+	}
+}
+
+int main()
+{
+	TestPhase0AtCycleStart();
+	TestPhase7AtHalfCycle();
+	TestPhase0AfterFullCycle();
+	TestEachPhaseTransition();
+	TestIlluminationMaxAtFullMoon();
+	TestIlluminationMinAtNewMoon();
+	TestIlluminationSymmetric();
+	TestNoInvalidPhase();
+	TestRealNowBeforeCycleStart();
+	TestZeroCycleDuration();
+	TestNextChangeTsAdvances();
+	std::puts("[ALL OK] LunarCalendarTests");
+	return 0;
+}
+```
+
+---
+
+## Task 3: LunarPayloads + tests
+
+**Files:**
+- Create: `src/shared/network/LunarPayloads.h`
+- Create: `src/shared/network/LunarPayloads.cpp`
+- Create: `src/shared/network/LunarPayloadsTests.cpp`
+
+- [ ] **Step 1: Lire un payload récent comme référence pour le pattern**
+
+Lire `src/shared/network/LootPayloads.h` et `LootPayloads.cpp` (les plus récents) pour copier exactement le style d'imports, `WriteU8/U16/U32/U64LE`, `WriteFloatLE`, `ParseXxx` retour `bool`, etc.
+
+- [ ] **Step 2: Écrire LunarPayloads.h**
+
+```cpp
+#pragma once
+// Wire payloads pour le systeme de phase lunaire (opcodes 192-194).
+// 16 phases (0..15), cycle de 14 jours reels.
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::network::lunar
+{
+	enum class LunarStatus : uint8_t
+	{
+		Ok           = 0,
+		Unauthorized = 1,
+	};
+
+	// === Request: client demande l'etat lunaire actuel (vide) ===
+	struct LunarStateRequest
+	{
+		// Empty
+	};
+
+	// === Response: master envoie phase + cycle info ===
+	struct LunarStateResponse
+	{
+		LunarStatus status         = LunarStatus::Ok;
+		uint8_t     phase          = 0;     // 0..15
+		float       illumination   = 0.0f;  // 0..1
+		uint64_t    cycleStartMs   = 0;     // timestamp ms du debut de cycle
+		uint64_t    cycleDurationMs = 0;    // duree totale d'un cycle (ms)
+	};
+
+	// === Push notification: changement de phase ===
+	struct LunarPhaseChangeNotification
+	{
+		uint8_t  newPhase        = 0;
+		float    newIllumination = 0.0f;
+		uint64_t nextChangeTsMs  = 0;
+	};
+
+	// Build* : ecrit le payload binaire dans \p out.
+	void BuildLunarStateRequestPayload(std::vector<uint8_t>& out);
+	void BuildLunarStateResponsePayload(const LunarStateResponse& msg, std::vector<uint8_t>& out);
+	void BuildLunarPhaseChangeNotificationPayload(const LunarPhaseChangeNotification& msg, std::vector<uint8_t>& out);
+
+	// Parse* : retourne true si le buffer est valide.
+	bool ParseLunarStateRequestPayload(const uint8_t* data, size_t size, LunarStateRequest& out);
+	bool ParseLunarStateResponsePayload(const uint8_t* data, size_t size, LunarStateResponse& out);
+	bool ParseLunarPhaseChangeNotificationPayload(const uint8_t* data, size_t size, LunarPhaseChangeNotification& out);
+}
+```
+
+- [ ] **Step 3: Écrire LunarPayloads.cpp**
+
+```cpp
+#include "src/shared/network/LunarPayloads.h"
+
+#include <cstring>
+
+namespace engine::network::lunar
+{
+	namespace
+	{
+		void WriteU8(std::vector<uint8_t>& out, uint8_t v)
+		{
+			out.push_back(v);
+		}
+
+		void WriteU32LE(std::vector<uint8_t>& out, uint32_t v)
+		{
+			out.push_back(static_cast<uint8_t>(v));
+			out.push_back(static_cast<uint8_t>(v >> 8));
+			out.push_back(static_cast<uint8_t>(v >> 16));
+			out.push_back(static_cast<uint8_t>(v >> 24));
+		}
+
+		void WriteU64LE(std::vector<uint8_t>& out, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i)
+				out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+		}
+
+		void WriteFloatLE(std::vector<uint8_t>& out, float v)
+		{
+			uint32_t bits = 0;
+			std::memcpy(&bits, &v, sizeof(bits));
+			WriteU32LE(out, bits);
+		}
+
+		bool ReadU8(const uint8_t* d, size_t sz, size_t& pos, uint8_t& out)
+		{
+			if (pos + 1 > sz) return false;
+			out = d[pos];
+			pos += 1;
+			return true;
+		}
+
+		bool ReadU32LE(const uint8_t* d, size_t sz, size_t& pos, uint32_t& out)
+		{
+			if (pos + 4 > sz) return false;
+			out = static_cast<uint32_t>(d[pos])
+			    | (static_cast<uint32_t>(d[pos + 1]) << 8)
+			    | (static_cast<uint32_t>(d[pos + 2]) << 16)
+			    | (static_cast<uint32_t>(d[pos + 3]) << 24);
+			pos += 4;
+			return true;
+		}
+
+		bool ReadU64LE(const uint8_t* d, size_t sz, size_t& pos, uint64_t& out)
+		{
+			if (pos + 8 > sz) return false;
+			out = 0;
+			for (int i = 0; i < 8; ++i)
+				out |= static_cast<uint64_t>(d[pos + i]) << (i * 8);
+			pos += 8;
+			return true;
+		}
+
+		bool ReadFloatLE(const uint8_t* d, size_t sz, size_t& pos, float& out)
+		{
+			uint32_t bits = 0;
+			if (!ReadU32LE(d, sz, pos, bits)) return false;
+			std::memcpy(&out, &bits, sizeof(out));
+			return true;
+		}
+	}
+
+	void BuildLunarStateRequestPayload(std::vector<uint8_t>& out)
+	{
+		out.clear();
+	}
+
+	void BuildLunarStateResponsePayload(const LunarStateResponse& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, static_cast<uint8_t>(msg.status));
+		WriteU8(out, msg.phase);
+		WriteFloatLE(out, msg.illumination);
+		WriteU64LE(out, msg.cycleStartMs);
+		WriteU64LE(out, msg.cycleDurationMs);
+	}
+
+	void BuildLunarPhaseChangeNotificationPayload(const LunarPhaseChangeNotification& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, msg.newPhase);
+		WriteFloatLE(out, msg.newIllumination);
+		WriteU64LE(out, msg.nextChangeTsMs);
+	}
+
+	bool ParseLunarStateRequestPayload(const uint8_t* /*data*/, size_t size, LunarStateRequest& /*out*/)
+	{
+		return size == 0;
+	}
+
+	bool ParseLunarStateResponsePayload(const uint8_t* d, size_t sz, LunarStateResponse& out)
+	{
+		size_t pos = 0;
+		uint8_t status = 0;
+		if (!ReadU8(d, sz, pos, status)) return false;
+		if (!ReadU8(d, sz, pos, out.phase)) return false;
+		if (!ReadFloatLE(d, sz, pos, out.illumination)) return false;
+		if (!ReadU64LE(d, sz, pos, out.cycleStartMs)) return false;
+		if (!ReadU64LE(d, sz, pos, out.cycleDurationMs)) return false;
+		out.status = static_cast<LunarStatus>(status);
+		return pos == sz;
+	}
+
+	bool ParseLunarPhaseChangeNotificationPayload(const uint8_t* d, size_t sz, LunarPhaseChangeNotification& out)
+	{
+		size_t pos = 0;
+		if (!ReadU8(d, sz, pos, out.newPhase)) return false;
+		if (!ReadFloatLE(d, sz, pos, out.newIllumination)) return false;
+		if (!ReadU64LE(d, sz, pos, out.nextChangeTsMs)) return false;
+		return pos == sz;
+	}
+}
+```
+
+- [ ] **Step 4: Écrire LunarPayloadsTests.cpp**
+
+```cpp
+// Round-trip tests pour les payloads lunaires + edge cases + reject-short.
+
+#include "src/shared/network/LunarPayloads.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace engine::network::lunar;
+
+namespace
+{
+	bool NearlyEqual(float a, float b, float eps = 1e-5f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	void TestStateRequestRoundTrip()
+	{
+		std::vector<uint8_t> buf;
+		BuildLunarStateRequestPayload(buf);
+		assert(buf.empty());
+		LunarStateRequest parsed;
+		assert(ParseLunarStateRequestPayload(buf.data(), buf.size(), parsed));
+		std::puts("[OK] TestStateRequestRoundTrip");
+	}
+
+	void TestStateResponseRoundTrip()
+	{
+		LunarStateResponse src;
+		src.status = LunarStatus::Ok;
+		src.phase = 7;
+		src.illumination = 1.0f;
+		src.cycleStartMs = 1767225600000ull; // 2026-01-01 UTC
+		src.cycleDurationMs = 1209600000ull; // 14 jours
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == src.status);
+		assert(dst.phase == src.phase);
+		assert(NearlyEqual(dst.illumination, src.illumination));
+		assert(dst.cycleStartMs == src.cycleStartMs);
+		assert(dst.cycleDurationMs == src.cycleDurationMs);
+		std::puts("[OK] TestStateResponseRoundTrip");
+	}
+
+	void TestStateResponseUnauthorized()
+	{
+		LunarStateResponse src;
+		src.status = LunarStatus::Unauthorized;
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == LunarStatus::Unauthorized);
+		std::puts("[OK] TestStateResponseUnauthorized");
+	}
+
+	void TestPhaseChangeRoundTrip()
+	{
+		LunarPhaseChangeNotification src;
+		src.newPhase = 8;
+		src.newIllumination = 0.94f;
+		src.nextChangeTsMs = 1767246600000ull;
+
+		std::vector<uint8_t> buf;
+		BuildLunarPhaseChangeNotificationPayload(src, buf);
+
+		LunarPhaseChangeNotification dst;
+		assert(ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+		assert(dst.newPhase == src.newPhase);
+		assert(NearlyEqual(dst.newIllumination, src.newIllumination));
+		assert(dst.nextChangeTsMs == src.nextChangeTsMs);
+		std::puts("[OK] TestPhaseChangeRoundTrip");
+	}
+
+	void TestPhaseChangeAllPhases()
+	{
+		for (uint8_t p = 0; p < 16; ++p)
+		{
+			LunarPhaseChangeNotification src;
+			src.newPhase = p;
+			src.newIllumination = static_cast<float>(p) / 15.0f;
+			src.nextChangeTsMs = 100000ull * static_cast<uint64_t>(p + 1);
+
+			std::vector<uint8_t> buf;
+			BuildLunarPhaseChangeNotificationPayload(src, buf);
+
+			LunarPhaseChangeNotification dst;
+			assert(ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+			assert(dst.newPhase == p);
+		}
+		std::puts("[OK] TestPhaseChangeAllPhases");
+	}
+
+	void TestStateResponseRejectShort()
+	{
+		std::vector<uint8_t> buf = { 0x00, 0x07, 0x00, 0x00, 0x80 }; // tronque
+		LunarStateResponse dst;
+		assert(!ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestStateResponseRejectShort");
+	}
+
+	void TestStateResponseRejectExtra()
+	{
+		LunarStateResponse src;
+		src.phase = 5;
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+		buf.push_back(0xAA); // octet en trop
+
+		LunarStateResponse dst;
+		assert(!ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestStateResponseRejectExtra");
+	}
+
+	void TestPhaseChangeRejectShort()
+	{
+		std::vector<uint8_t> buf = { 0x07, 0x00 }; // tronque
+		LunarPhaseChangeNotification dst;
+		assert(!ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestPhaseChangeRejectShort");
+	}
+
+	void TestEdgeCaseMaxValues()
+	{
+		LunarStateResponse src;
+		src.phase = 15;
+		src.illumination = 1.0f;
+		src.cycleStartMs = UINT64_MAX;
+		src.cycleDurationMs = UINT64_MAX;
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.phase == 15);
+		assert(dst.cycleStartMs == UINT64_MAX);
+		std::puts("[OK] TestEdgeCaseMaxValues");
+	}
+
+	void TestEdgeCaseZero()
+	{
+		LunarStateResponse src;
+		src.phase = 0;
+		src.illumination = 0.0f;
+		src.cycleStartMs = 0;
+		src.cycleDurationMs = 0;
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.phase == 0);
+		std::puts("[OK] TestEdgeCaseZero");
+	}
+}
+
+int main()
+{
+	TestStateRequestRoundTrip();
+	TestStateResponseRoundTrip();
+	TestStateResponseUnauthorized();
+	TestPhaseChangeRoundTrip();
+	TestPhaseChangeAllPhases();
+	TestStateResponseRejectShort();
+	TestStateResponseRejectExtra();
+	TestPhaseChangeRejectShort();
+	TestEdgeCaseMaxValues();
+	TestEdgeCaseZero();
+	std::puts("[ALL OK] LunarPayloadsTests");
+	return 0;
+}
+```
+
+---
+
+## Task 4: LunarHandler master + intégration main_linux
+
+**Files:**
+- Create: `src/masterd/handlers/lunar/LunarHandler.h`
+- Create: `src/masterd/handlers/lunar/LunarHandler.cpp`
+- Modify: `src/masterd/main_linux.cpp`
+
+- [ ] **Step 1: Lire LootHandler comme référence**
+
+Lire `src/masterd/handlers/loot/LootHandler.h` et `.cpp` pour copier le style EXACT (includes, Setters, HandlePacket signature, push helpers, mutex, etc.).
+
+- [ ] **Step 2: Écrire LunarHandler.h**
+
+```cpp
+#pragma once
+// LunarHandler : etat lunaire authoritative master + push broadcast sur
+// changement de phase. Calcul stateless via LunarCalendar (deterministe
+// depuis epoch). Tick periodique (5min) verifie si la phase courante a
+// change depuis le dernier broadcast et push aux clients connectes.
+//
+// Le handler est instancie dans main_linux.cpp au boot, cable via
+// SetServer/SetSessionManager/SetConnectionSessionMap, puis enregistre
+// dans le packetHandler du NetServer pour l'opcode 192. La response 193
+// est emise avec le meme requestId/sessionId que la request recue. Le
+// push 194 est broadcast a tous les clients connectes (pas de subscribe
+// explicite : la lune est globale et permanente).
+//
+// Cycle par defaut : 14 jours reels (14*24*3600*1000 = 1209600000 ms),
+// epoch 2026-01-01 00:00:00 UTC = 1767225600000 ms.
+
+#include "src/shardd/world/LunarCalendar.h"
+
+#include <cstdint>
+#include <mutex>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	class LunarHandler
+	{
+	public:
+		void SetServer(NetServer* s) { m_server = s; }
+		void SetSessionManager(SessionManager* mgr) { m_sessionMgr = mgr; }
+		void SetConnectionSessionMap(ConnectionSessionMap* m) { m_connMap = m; }
+
+		/// Configure les parametres du cycle. Appele une fois au boot.
+		void SetCycleParams(uint64_t cycleStartMs, uint64_t cycleDurationMs);
+
+		/// Dispatch packet : opcode 192 (LunarStateRequest).
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize);
+
+		/// Tick periodique (typiquement 5 min). Compare la phase courante
+		/// avec la derniere broadcastee ; si different, push 194 a tous les
+		/// clients connectes.
+		void Tick(uint64_t realNowMs);
+
+		/// Phase courante (pour integration future avec GameEvents).
+		uint8_t CurrentPhase() const;
+
+	private:
+		void HandleStateRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader);
+		void PushPhaseChangeBroadcast(uint8_t newPhase, float newIllumination, uint64_t nextChangeTsMs);
+
+		NetServer*            m_server     = nullptr;
+		SessionManager*       m_sessionMgr = nullptr;
+		ConnectionSessionMap* m_connMap    = nullptr;
+
+		mutable std::mutex m_mutex;
+		uint64_t           m_cycleStartMs    = 1767225600000ull; // 2026-01-01 UTC
+		uint64_t           m_cycleDurationMs = engine::server::world::kDefaultLunarCycleMs;
+		uint8_t            m_lastBroadcastPhase = 0xFFu; // sentinel : force premier broadcast
+	};
+}
+```
+
+- [ ] **Step 3: Écrire LunarHandler.cpp**
+
+```cpp
+#include "src/masterd/handlers/lunar/LunarHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/LunarPayloads.h"
+
+#include <chrono>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::server::world::LunarCalendar;
+	using engine::server::world::LunarPhaseInfo;
+
+	void LunarHandler::SetCycleParams(uint64_t cycleStartMs, uint64_t cycleDurationMs)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_cycleStartMs = cycleStartMs;
+		m_cycleDurationMs = cycleDurationMs;
+	}
+
+	uint8_t LunarHandler::CurrentPhase() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		const uint64_t nowMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+		auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
+		return info.phase;
+	}
+
+	void LunarHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+	                                 uint64_t sessionIdHeader, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+		if (opcode == kOpcodeLunarStateRequest)
+		{
+			HandleStateRequest(connId, requestId, sessionIdHeader);
+		}
+	}
+
+	void LunarHandler::HandleStateRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		using namespace engine::network::lunar;
+		using namespace engine::network;
+
+		LunarStateResponse resp;
+
+		// Validation session : si pas de session valide -> Unauthorized.
+		if (m_connMap && m_sessionMgr)
+		{
+			const uint64_t sessId = m_connMap->GetSessionId(connId);
+			if (sessId == 0 || m_sessionMgr->GetAccountId(sessId) == 0)
+			{
+				resp.status = LunarStatus::Unauthorized;
+			}
+		}
+
+		if (resp.status == LunarStatus::Ok)
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const uint64_t nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
+			resp.phase = info.phase;
+			resp.illumination = info.illumination;
+			resp.cycleStartMs = m_cycleStartMs;
+			resp.cycleDurationMs = m_cycleDurationMs;
+		}
+
+		std::vector<uint8_t> payload;
+		BuildLunarStateResponsePayload(resp, payload);
+
+		std::vector<uint8_t> packet;
+		BuildPacket(kOpcodeLunarStateResponse, requestId, sessionIdHeader, payload, packet);
+		if (m_server) m_server->Send(connId, packet.data(), packet.size());
+	}
+
+	void LunarHandler::Tick(uint64_t realNowMs)
+	{
+		uint8_t newPhase = 0;
+		float newIllumination = 0.0f;
+		uint64_t nextChangeTs = 0;
+		bool needBroadcast = false;
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto info = LunarCalendar::Compute(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+			if (info.phase != m_lastBroadcastPhase)
+			{
+				newPhase = info.phase;
+				newIllumination = info.illumination;
+				nextChangeTs = LunarCalendar::NextChangeTsMs(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+				m_lastBroadcastPhase = info.phase;
+				needBroadcast = true;
+			}
+		}
+
+		if (needBroadcast)
+		{
+			LOG_INFO(Net, "[LunarHandler] phase change broadcast: phase={} illumination={:.3f} nextChangeTs={}",
+				newPhase, newIllumination, nextChangeTs);
+			PushPhaseChangeBroadcast(newPhase, newIllumination, nextChangeTs);
+		}
+	}
+
+	void LunarHandler::PushPhaseChangeBroadcast(uint8_t newPhase, float newIllumination, uint64_t nextChangeTsMs)
+	{
+		using namespace engine::network::lunar;
+		using namespace engine::network;
+
+		LunarPhaseChangeNotification notif;
+		notif.newPhase = newPhase;
+		notif.newIllumination = newIllumination;
+		notif.nextChangeTsMs = nextChangeTsMs;
+
+		std::vector<uint8_t> payload;
+		BuildLunarPhaseChangeNotificationPayload(notif, payload);
+
+		std::vector<uint8_t> packet;
+		BuildPacket(kOpcodeLunarPhaseChangeNotification, 0u, 0u, payload, packet);
+
+		if (!m_server || !m_connMap) return;
+		auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessId] : snapshot)
+		{
+			(void)sessId;
+			m_server->Send(connId, packet.data(), packet.size());
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Modifier main_linux.cpp — ajout des includes**
+
+Localiser le bloc d'includes des handlers (autour de la ligne 47, après `#include "src/masterd/handlers/loot/LootHandler.h"`) et ajouter :
+
+```cpp
+#include "src/masterd/handlers/lunar/LunarHandler.h"
+```
+
+- [ ] **Step 5: Modifier main_linux.cpp — instanciation après LootHandler**
+
+Localiser le bloc d'instanciation `LootHandler` (`engine::server::LootHandler lootHandler;`) et ajouter juste après :
+
+```cpp
+	// Phase 5 step 3+4 Lunar — LunarHandler : etat lunaire authoritative
+	// (16 phases, cycle 14 jours reels, deterministe depuis epoch). Tick
+	// periodique (5 min) detecte changement de phase et push broadcast.
+	// Pas de Subscribe : la lune est globale.
+	engine::server::LunarHandler lunarHandler;
+	lunarHandler.SetServer(&server);
+	lunarHandler.SetSessionManager(&sessionManager);
+	lunarHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] LunarHandler configured (Phase 5 Lunar, cycle 14j, 16 phases)");
+```
+
+- [ ] **Step 6: Modifier main_linux.cpp — ajouter à la capture-list**
+
+Localiser la capture-list du lambda `SetPacketHandler` (ligne ~700, contenant `&weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler`) et ajouter `&lunarHandler` à la fin :
+
+```cpp
+server.SetPacketHandler([&authHandler, ..., &auctionHandler, &lootHandler, &lunarHandler](uint32_t connId, ...) {
+```
+
+- [ ] **Step 7: Modifier main_linux.cpp — dispatch dans le lambda**
+
+Après le bloc `LootHandler` dispatch, ajouter :
+
+```cpp
+		else if (opcode == kOpcodeLunarStateRequest)
+			lunarHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+```
+
+- [ ] **Step 8: Modifier main_linux.cpp — appel Tick périodique**
+
+Localiser la boucle principale du serveur (`while (!g_quit)`). Ajouter avant la boucle :
+
+```cpp
+	auto lastLunarTickTime = std::chrono::steady_clock::now();
+```
+
+À l'intérieur de la boucle, ajouter le tick toutes les 5 minutes :
+
+```cpp
+		// Tick lunaire toutes les 5 min (detection changement de phase).
+		auto nowSteady = std::chrono::steady_clock::now();
+		if (std::chrono::duration_cast<std::chrono::seconds>(nowSteady - lastLunarTickTime).count() >= 300)
+		{
+			const uint64_t realNowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			lunarHandler.Tick(realNowMs);
+			lastLunarTickTime = nowSteady;
+		}
+```
+
+Au boot juste après l'instanciation (Step 5), forcer un premier Tick pour établir la phase courante :
+
+```cpp
+	{
+		const uint64_t bootNowMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+		lunarHandler.Tick(bootNowMs);
+	}
+```
+
+---
+
+## Task 5: DayNightCycle extension + tests
+
+**Files:**
+- Modify: `src/client/render/DayNightCycle.h`
+- Modify: `src/client/render/DayNightCycle.cpp`
+- Create: `src/client/render/DayNightCycleTests.cpp`
+
+- [ ] **Step 1: Modifier DayNightCycle.h — extension du struct State**
+
+Localiser le struct `State` (ligne ~33-63) et ajouter à la fin (juste avant le `};`) :
+
+```cpp
+		// ---- Lunar phase (master-driven via OnLunarPhaseChange callback) ----
+
+		/// Index de la phase lunaire courante (0..15). 0=NewMoon, 7=FullMoon, 15=Earthshine late.
+		/// Mis a jour uniquement via OnLunarPhaseChange (master autoritaire).
+		uint8_t moonPhase = 0;
+
+		/// Fraction de la lune eclairee (0..1). 0 = noir (NewMoon), 1 = pleine.
+		/// Mis a jour uniquement via OnLunarPhaseChange (master autoritaire).
+		float moonIllumination = 0.0f;
+```
+
+- [ ] **Step 2: Modifier DayNightCycle.h — déclaration callback**
+
+Dans la classe publique, après `void SetTimeScale(float realSecondsPerHour);` :
+
+```cpp
+		/// Met a jour la phase lunaire courante (recue depuis le master via
+		/// opcode 193 LunarStateResponse ou 194 LunarPhaseChangeNotification).
+		/// \param phase        0..15
+		/// \param illumination 0..1
+		void OnLunarPhaseChange(uint8_t phase, float illumination);
+```
+
+- [ ] **Step 3: Modifier DayNightCycle.cpp — implémentation callback**
+
+À la fin du fichier (avant la fermeture du namespace) :
+
+```cpp
+	void DayNightCycle::OnLunarPhaseChange(uint8_t phase, float illumination)
+	{
+		if (phase >= 16) return;
+		m_state.moonPhase = phase;
+		m_state.moonIllumination = illumination < 0.0f ? 0.0f : (illumination > 1.0f ? 1.0f : illumination);
+	}
+```
+
+- [ ] **Step 4: Créer DayNightCycleTests.cpp**
+
+Écrire `src/client/render/DayNightCycleTests.cpp` :
+
+```cpp
+// Tests du cycle jour/nuit existant + extension lunaire. Pas de framework,
+// asserts simples. Utilise pour valider le comportement de DayNightCycle
+// avant d'ajouter les phases lunaires.
+
+#include "src/client/render/DayNightCycle.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+using engine::render::DayNightCycle;
+
+namespace
+{
+	bool NearlyEqual(float a, float b, float eps = 0.05f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	void TestInitNoonState()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 12.0f;
+		p.timeScale = 60.0f;
+		cycle.Init(p);
+
+		const auto& s = cycle.GetState();
+		assert(NearlyEqual(s.timeOfDay, 12.0f));
+		assert(s.isDaytime);
+		std::puts("[OK] TestInitNoonState");
+	}
+
+	void TestInitMidnightState()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 0.0f;
+		cycle.Init(p);
+
+		const auto& s = cycle.GetState();
+		assert(!s.isDaytime);
+		std::puts("[OK] TestInitMidnightState");
+	}
+
+	void TestSunriseSunsetTransitions()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.SetTime(6.0f);
+		const auto& dawn = cycle.GetState();
+		// Au lever du soleil l'elevation est proche de 0 (pas a son zenith).
+		assert(std::fabs(dawn.lightDir[1]) < 0.5f);
+
+		cycle.SetTime(12.0f);
+		const auto& noon = cycle.GetState();
+		assert(noon.lightDir[1] > 0.7f);
+
+		cycle.SetTime(18.0f);
+		const auto& dusk = cycle.GetState();
+		assert(std::fabs(dusk.lightDir[1]) < 0.5f);
+		std::puts("[OK] TestSunriseSunsetTransitions");
+	}
+
+	void TestSetTimeWraps()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		// 25h doit wrapper a 1h ou etre clampe a 24-eps. Le comportement exact
+		// est defini par l'impl ; on accepte les deux mais on rejette > 24.
+		cycle.SetTime(25.0f);
+		const auto& s = cycle.GetState();
+		assert(s.timeOfDay >= 0.0f && s.timeOfDay < 24.0f);
+		std::puts("[OK] TestSetTimeWraps");
+	}
+
+	void TestSetTimeScaleClamp()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.SetTimeScale(0.0f);
+		assert(cycle.GetTimeScale() >= 0.1f);
+		cycle.SetTimeScale(-100.0f);
+		assert(cycle.GetTimeScale() >= 0.1f);
+		std::puts("[OK] TestSetTimeScaleClamp");
+	}
+
+	void TestAdvanceHour()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 8.0f;
+		p.timeScale = 60.0f; // 1 game hour = 60 real seconds
+		cycle.Init(p);
+
+		// 60 secondes reelles -> 1h en jeu -> 9h.
+		cycle.Advance(60.0f);
+		const auto& s = cycle.GetState();
+		assert(NearlyEqual(s.timeOfDay, 9.0f, 0.1f));
+		std::puts("[OK] TestAdvanceHour");
+	}
+
+	void TestLunarPhaseDefault()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 0);
+		assert(NearlyEqual(s.moonIllumination, 0.0f));
+		std::puts("[OK] TestLunarPhaseDefault");
+	}
+
+	void TestLunarPhaseUpdate()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.OnLunarPhaseChange(7, 1.0f);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 7);
+		assert(NearlyEqual(s.moonIllumination, 1.0f));
+		std::puts("[OK] TestLunarPhaseUpdate");
+	}
+
+	void TestLunarPhaseClamp()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		// Phase invalide >= 16 ignoree.
+		cycle.OnLunarPhaseChange(16, 0.5f);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 0);
+
+		// Illumination negative clampee a 0.
+		cycle.OnLunarPhaseChange(3, -1.0f);
+		assert(NearlyEqual(cycle.GetState().moonIllumination, 0.0f));
+
+		// Illumination > 1 clampee a 1.
+		cycle.OnLunarPhaseChange(7, 2.5f);
+		assert(NearlyEqual(cycle.GetState().moonIllumination, 1.0f));
+
+		std::puts("[OK] TestLunarPhaseClamp");
+	}
+}
+
+int main()
+{
+	TestInitNoonState();
+	TestInitMidnightState();
+	TestSunriseSunsetTransitions();
+	TestSetTimeWraps();
+	TestSetTimeScaleClamp();
+	TestAdvanceHour();
+	TestLunarPhaseDefault();
+	TestLunarPhaseUpdate();
+	TestLunarPhaseClamp();
+	std::puts("[ALL OK] DayNightCycleTests");
+	return 0;
+}
+```
+
+---
+
+## Task 6: SkyPass Vulkan + shader extension
+
+**Files:**
+- Create: `src/client/render/SkyPass.h`
+- Create: `src/client/render/SkyPass.cpp`
+- Modify: `game/data/shaders/sky.frag`
+- Verify: `game/data/shaders/sky.vert` existe
+
+- [ ] **Step 1: Vérifier que sky.vert existe**
+
+Run :
+```bash
+ls game/data/shaders/sky.vert
+```
+Expected : fichier présent. Si absent, le créer avec un fullscreen quad standard :
+
+```glsl
+#version 450
+// Sky vertex shader : fullscreen quad pass-through.
+layout(location = 0) out vec2 vUV;
+void main()
+{
+    // Generate fullscreen triangle from gl_VertexIndex (0,1,2).
+    vUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(vUV * 2.0 - 1.0, 0.0, 1.0);
+}
+```
+
+- [ ] **Step 2: Modifier sky.frag — push constants étendus**
+
+Localiser le bloc `layout(push_constant)` et le remplacer par :
+
+```glsl
+layout(push_constant) uniform SkyPC
+{
+    mat4  invViewProj;       // 64 bytes
+    vec3  lightDir;          // direction toward the sun/moon (normalized)
+    float _pad0;
+    vec3  zenithColor;       // colour at the top of the sky dome
+    float _pad1;
+    vec3  horizonColor;      // colour at the horizon
+    float _pad2;
+    vec3  moonDir;           // direction toward the moon (normalized)
+    float moonIntensity;     // 0..1, fade jour/nuit
+    float moonPhase;         // 0..15
+    float moonIllumination;  // 0..1
+    vec2  _pad3;
+} pc;
+```
+
+- [ ] **Step 3: Modifier sky.frag — ajouter le rendering du disque lunaire**
+
+Avant le `void main()` final, ajouter une fonction helper :
+
+```glsl
+vec3 RenderMoonDisk(vec3 viewDir, vec3 baseSky)
+{
+    if (pc.moonIntensity < 0.001) return baseSky;
+    float cosA = dot(viewDir, pc.moonDir);
+    const float kMoonRadius = 0.012;
+    if (cosA <= cos(kMoonRadius)) return baseSky;
+
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), pc.moonDir));
+    vec3 up    = cross(pc.moonDir, right);
+    float u    = dot(viewDir, right) / sin(kMoonRadius);
+    float v    = dot(viewDir, up)    / sin(kMoonRadius);
+
+    float shadowOffset = 1.0 - pc.moonIllumination * 2.0;
+    if (pc.moonPhase < 7.5) shadowOffset = -shadowOffset;
+
+    float distFromShadow = length(vec2(u - shadowOffset, v));
+    float shadowMask     = smoothstep(1.0, 0.95, distFromShadow);
+
+    vec3 moonSurface = vec3(0.95, 0.92, 0.85) * shadowMask;
+
+    if (pc.moonPhase < 3.0 || pc.moonPhase > 13.0)
+    {
+        moonSurface += vec3(0.05, 0.06, 0.10) * (1.0 - shadowMask);
+    }
+
+    float haloFalloff = smoothstep(cos(kMoonRadius * 1.5), cos(kMoonRadius), cosA);
+    return mix(baseSky, moonSurface * pc.moonIntensity, haloFalloff);
+}
+```
+
+À la fin du `void main()`, juste avant `outColor = ...`, intégrer :
+
+```glsl
+    // Reconstruire viewDir (direction du rayon depuis la camera).
+    vec4 ndc = vec4(vUV * 2.0 - 1.0, 1.0, 1.0);
+    vec4 worldPos = pc.invViewProj * ndc;
+    vec3 viewDir = normalize(worldPos.xyz / worldPos.w);
+
+    // Le calcul du gradient ciel + sun glow existant produit une couleur skyColor.
+    // (Garder le code existant qui calcule skyColor depuis zenithColor/horizonColor/lightDir.)
+    skyColor = RenderMoonDisk(viewDir, skyColor);
+```
+
+(L'ingenieur doit lire le `sky.frag` actuel pour situer où `skyColor` est calculé et où le helper s'insère exactement. Le shader actuel calcule un gradient zenith→horizon + un sun glow ; il faut juste appeler `RenderMoonDisk` après ces calculs et avant l'écriture finale.)
+
+- [ ] **Step 4: Créer SkyPass.h**
+
+```cpp
+#pragma once
+// SkyPass : pipeline Vulkan qui dessine le ciel + disque lunaire procedural.
+// Consomme les shaders game/data/shaders/sky.vert et sky.frag (existants
+// jusqu'ici non wires). Le fragment shader recoit en push-constants la
+// matrice inverse view-projection, les directions soleil/lune, les couleurs
+// zenith/horizon, et les parametres lunaires (phase + illumination + intensity).
+//
+// La pass est dessinee EN PREMIER dans la frame (avant le geometry pass)
+// avec depth=1.0 pour servir de fond. Couts negligeables (1 fullscreen quad).
+//
+// Pattern aligne sur LightingPass et WaterPass.
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace engine::render
+{
+	class SkyPass
+	{
+	public:
+		struct PushConstants
+		{
+			float invViewProj[16];   // mat4
+			float lightDir[3];
+			float _pad0;
+			float zenithColor[3];
+			float _pad1;
+			float horizonColor[3];
+			float _pad2;
+			float moonDir[3];
+			float moonIntensity;
+			float moonPhase;
+			float moonIllumination;
+			float _pad3[2];
+		};
+		static_assert(sizeof(PushConstants) == 144, "SkyPass push constants size mismatch");
+
+		bool Init(VkDevice device,
+		          VkRenderPass renderPass,
+		          uint32_t subpass,
+		          const uint32_t* vertSpirv, size_t vertWordCount,
+		          const uint32_t* fragSpirv, size_t fragWordCount);
+
+		void Shutdown(VkDevice device);
+
+		/// Enregistre le draw fullscreen quad avec les push-constants.
+		void Record(VkCommandBuffer cmd, const PushConstants& pc);
+
+		bool IsInitialized() const { return m_pipeline != VK_NULL_HANDLE; }
+
+	private:
+		VkPipeline       m_pipeline       = VK_NULL_HANDLE;
+		VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
+	};
+}
+```
+
+- [ ] **Step 5: Créer SkyPass.cpp**
+
+```cpp
+#include "src/client/render/SkyPass.h"
+
+#include <cstring>
+
+namespace engine::render
+{
+	namespace
+	{
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* code, size_t wordCount)
+		{
+			VkShaderModuleCreateInfo info{};
+			info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			info.codeSize = wordCount * sizeof(uint32_t);
+			info.pCode    = code;
+			VkShaderModule m = VK_NULL_HANDLE;
+			if (vkCreateShaderModule(device, &info, nullptr, &m) != VK_SUCCESS)
+				return VK_NULL_HANDLE;
+			return m;
+		}
+	}
+
+	bool SkyPass::Init(VkDevice device, VkRenderPass renderPass, uint32_t subpass,
+	                    const uint32_t* vertSpirv, size_t vertWordCount,
+	                    const uint32_t* fragSpirv, size_t fragWordCount)
+	{
+		// 1) Pipeline layout avec push-constants (144 bytes, vertex+fragment stages).
+		VkPushConstantRange pcRange{};
+		pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+		pcRange.offset     = 0;
+		pcRange.size       = sizeof(PushConstants);
+
+		VkPipelineLayoutCreateInfo plInfo{};
+		plInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		plInfo.pushConstantRangeCount = 1;
+		plInfo.pPushConstantRanges    = &pcRange;
+		if (vkCreatePipelineLayout(device, &plInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+			return false;
+
+		// 2) Shaders.
+		VkShaderModule vertModule = CreateShaderModule(device, vertSpirv, vertWordCount);
+		VkShaderModule fragModule = CreateShaderModule(device, fragSpirv, fragWordCount);
+		if (vertModule == VK_NULL_HANDLE || fragModule == VK_NULL_HANDLE) return false;
+
+		VkPipelineShaderStageCreateInfo stages[2]{};
+		stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+		stages[0].module = vertModule;
+		stages[0].pName  = "main";
+		stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+		stages[1].module = fragModule;
+		stages[1].pName  = "main";
+
+		// 3) Vertex input vide (le fullscreen quad est genere via gl_VertexIndex).
+		VkPipelineVertexInputStateCreateInfo vi{};
+		vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+		VkPipelineInputAssemblyStateCreateInfo ia{};
+		ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+		ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+		// 4) Viewport / scissor dynamiques.
+		VkPipelineViewportStateCreateInfo vp{};
+		vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+		vp.viewportCount = 1;
+		vp.scissorCount  = 1;
+
+		VkPipelineRasterizationStateCreateInfo rs{};
+		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+		rs.polygonMode = VK_POLYGON_MODE_FILL;
+		rs.cullMode    = VK_CULL_MODE_NONE;
+		rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		rs.lineWidth   = 1.0f;
+
+		VkPipelineMultisampleStateCreateInfo ms{};
+		ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+		ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+		VkPipelineDepthStencilStateCreateInfo ds{};
+		ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+		ds.depthTestEnable  = VK_FALSE;
+		ds.depthWriteEnable = VK_FALSE;
+
+		VkPipelineColorBlendAttachmentState cba{};
+		cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+		                   | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+		VkPipelineColorBlendStateCreateInfo cb{};
+		cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+		cb.attachmentCount = 1;
+		cb.pAttachments    = &cba;
+
+		VkDynamicState dynStates[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+		VkPipelineDynamicStateCreateInfo dyn{};
+		dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+		dyn.dynamicStateCount = 2;
+		dyn.pDynamicStates    = dynStates;
+
+		VkGraphicsPipelineCreateInfo pi{};
+		pi.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+		pi.stageCount          = 2;
+		pi.pStages             = stages;
+		pi.pVertexInputState   = &vi;
+		pi.pInputAssemblyState = &ia;
+		pi.pViewportState      = &vp;
+		pi.pRasterizationState = &rs;
+		pi.pMultisampleState   = &ms;
+		pi.pDepthStencilState  = &ds;
+		pi.pColorBlendState    = &cb;
+		pi.pDynamicState       = &dyn;
+		pi.layout              = m_pipelineLayout;
+		pi.renderPass          = renderPass;
+		pi.subpass             = subpass;
+
+		const VkResult res = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pi, nullptr, &m_pipeline);
+		vkDestroyShaderModule(device, vertModule, nullptr);
+		vkDestroyShaderModule(device, fragModule, nullptr);
+		return res == VK_SUCCESS;
+	}
+
+	void SkyPass::Shutdown(VkDevice device)
+	{
+		if (m_pipeline       != VK_NULL_HANDLE) vkDestroyPipeline(device, m_pipeline, nullptr);
+		if (m_pipelineLayout != VK_NULL_HANDLE) vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+		m_pipeline       = VK_NULL_HANDLE;
+		m_pipelineLayout = VK_NULL_HANDLE;
+	}
+
+	void SkyPass::Record(VkCommandBuffer cmd, const PushConstants& pc)
+	{
+		if (m_pipeline == VK_NULL_HANDLE) return;
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+		vkCmdPushConstants(cmd, m_pipelineLayout,
+		                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+		                    0, sizeof(PushConstants), &pc);
+		vkCmdDraw(cmd, 3, 1, 0, 0);
+	}
+}
+```
+
+---
+
+## Task 7: Engine push dispatch + slash commands + SkyPass intégration
+
+**Files:**
+- Modify: `src/client/app/Engine.h`
+- Modify: `src/client/app/Engine.cpp`
+
+- [ ] **Step 1: Modifier Engine.h — includes**
+
+Ajouter après les includes existants des UI (autour des autres `#include "src/client/...Ui.h"`) :
+
+```cpp
+#include "src/client/render/SkyPass.h"
+```
+
+- [ ] **Step 2: Modifier Engine.h — forward decl SkyPass déjà fait via include**
+
+(Pas d'action — l'include du Step 1 suffit.)
+
+- [ ] **Step 3: Modifier Engine.h — ajouter membre SkyPass**
+
+Localiser la zone des autres passes Vulkan (chercher `LightingPass` ou `WaterPass`) et ajouter un membre similaire :
+
+```cpp
+		/// Sky pass V1 (M38.1 + Phase 5 Lunar) : pipeline ciel + disque lunaire
+		/// procedural via push-constants. Consomme sky.frag et sky.vert.
+		engine::render::SkyPass m_skyPass;
+		bool                    m_skyPassReady = false;
+```
+
+- [ ] **Step 4: Modifier Engine.cpp — push handler dispatch des opcodes 193 + 194**
+
+Localiser le push handler dispatch (recherche `kOpcodeLootSimulateRollResponse` qui est le dernier dispatch ajouté), puis ajouter les nouveaux cas :
+
+```cpp
+		case kOpcodeLunarStateResponse:
+		{
+			engine::network::lunar::LunarStateResponse parsed;
+			if (!engine::network::lunar::ParseLunarStateResponsePayload(payload, payloadSize, parsed))
+			{
+				LOG_WARN(Net, "[Engine] LUNAR_STATE_RESPONSE parse failed (size={})", payloadSize);
+				return;
+			}
+			if (parsed.status == engine::network::lunar::LunarStatus::Ok)
+			{
+				m_dayNight.OnLunarPhaseChange(parsed.phase, parsed.illumination);
+				LOG_INFO(Render, "[Engine] LunarState received: phase={} illumination={:.3f}",
+					parsed.phase, parsed.illumination);
+			}
+			return;
+		}
+		case kOpcodeLunarPhaseChangeNotification:
+		{
+			engine::network::lunar::LunarPhaseChangeNotification parsed;
+			if (!engine::network::lunar::ParseLunarPhaseChangeNotificationPayload(payload, payloadSize, parsed))
+			{
+				LOG_WARN(Net, "[Engine] LUNAR_PHASE_CHANGE parse failed (size={})", payloadSize);
+				return;
+			}
+			m_dayNight.OnLunarPhaseChange(parsed.newPhase, parsed.newIllumination);
+			LOG_INFO(Render, "[Engine] LunarPhaseChange: phase={} illumination={:.3f}",
+				parsed.newPhase, parsed.newIllumination);
+			return;
+		}
+```
+
+Ajouter en haut du fichier l'include payloads :
+
+```cpp
+#include "src/shared/network/LunarPayloads.h"
+```
+
+- [ ] **Step 5: Modifier Engine.cpp — envoyer LunarStateRequest sur EnterWorld**
+
+Localiser le bloc d'EnterWorld (recherche `EnterWorldCommand` ou `IsInWorldShard()`). Après que la session est marquée comme dans le monde, envoyer :
+
+```cpp
+		// Phase 5 Lunar — fetch initial lunar state (master-authoritative).
+		{
+			std::vector<uint8_t> payload;
+			engine::network::lunar::BuildLunarStateRequestPayload(payload);
+			m_authUi.SendGenericRequestAsync(kOpcodeLunarStateRequest, payload);
+		}
+```
+
+- [ ] **Step 6: Modifier Engine.cpp — slash commands /sky info|time|moon**
+
+Localiser le bloc des autres slash commands (chercher `text == "/loot"`). Ajouter :
+
+```cpp
+		// Phase 5 step 3+4 Lunar + M38.1 Sky : slash commands debug pour
+		// inspecter et override le cycle jour/nuit + phase lunaire.
+		if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+			&& (text == "/sky info" || text == "/sky"))
+		{
+			const auto& s = m_dayNight.GetState();
+			const char* moonName[16] = {
+				"NewMoon", "WaxingCrescentEarly", "WaxingCrescentLate", "FirstQuarter",
+				"WaxingGibbousEarly", "WaxingGibbousLate", "FullMoonRising", "FullMoon",
+				"FullMoonSetting", "WaningGibbousEarly", "WaningGibbousLate", "LastQuarter",
+				"WaningCrescentEarly", "WaningCrescentLate", "EarthshineEarly", "EarthshineLate"
+			};
+			LOG_INFO(Render, "[Sky] timeOfDay={:.2f}h isDaytime={}", s.timeOfDay, s.isDaytime);
+			LOG_INFO(Render, "[Sky] sunDir=({:.2f},{:.2f},{:.2f})", s.lightDir[0], s.lightDir[1], s.lightDir[2]);
+			LOG_INFO(Render, "[Sky] moonPhase={} ({}) illumination={:.0f}%",
+				s.moonPhase, moonName[s.moonPhase < 16 ? s.moonPhase : 0], s.moonIllumination * 100.0f);
+			return true;
+		}
+		if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+			&& text.starts_with("/sky time "))
+		{
+			const auto rest = text.substr(10);
+			float hours = 0.0f;
+			try { hours = std::stof(std::string(rest)); } catch (...) { hours = 12.0f; }
+			m_dayNight.SetTime(hours);
+			LOG_INFO(Render, "[Sky] time set to {:.2f}h", hours);
+			return true;
+		}
+		if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+			&& text.starts_with("/sky moon "))
+		{
+			const auto rest = text.substr(10);
+			int phase = 0;
+			try { phase = std::stoi(std::string(rest)); } catch (...) { phase = 0; }
+			if (phase < 0 || phase > 15)
+			{
+				LOG_WARN(Render, "[Sky] phase {} hors plage [0..15]", phase);
+				return true;
+			}
+			// Calcul illumination locale (cf. LunarCalendar::ComputeIllumination).
+			constexpr float kPi = 3.14159265358979323846f;
+			float t = (static_cast<float>(phase) - 7.0f) * (kPi / 8.0f);
+			float illumination = 0.5f * (1.0f + std::cos(t));
+			m_dayNight.OnLunarPhaseChange(static_cast<uint8_t>(phase), illumination);
+			LOG_INFO(Render, "[Sky] moon phase override: {} illumination={:.0f}% (master state inchange)",
+				phase, illumination * 100.0f);
+			return true;
+		}
+```
+
+- [ ] **Step 7: Modifier Engine.cpp — Init du SkyPass au boot**
+
+Localiser le bloc d'init des autres passes Vulkan (chercher `m_lightingPass.Init` ou `WaterPass`). Avant ou après cette initialisation, ajouter :
+
+```cpp
+	// Phase 5 Lunar + M38.1 Sky : init du SkyPass (charge sky.vert.spv +
+	// sky.frag.spv depuis game/data/shaders, compile pipeline avec push
+	// constants etendus pour la phase lunaire).
+	{
+		// Charger les SPIR-V via le mecanisme de chargement existant
+		// (typiquement via ResourcePath + std::ifstream) :
+		std::vector<uint32_t> vertSpv;
+		std::vector<uint32_t> fragSpv;
+		if (LoadShaderSpirv("game/data/shaders/sky.vert.spv", vertSpv) &&
+		    LoadShaderSpirv("game/data/shaders/sky.frag.spv", fragSpv))
+		{
+			m_skyPassReady = m_skyPass.Init(m_device, m_renderPass, /*subpass*/ 0,
+			                                  vertSpv.data(), vertSpv.size(),
+			                                  fragSpv.data(), fragSpv.size());
+			if (!m_skyPassReady)
+				LOG_WARN(Render, "[Boot] SkyPass init failed -- fallback clearColor");
+			else
+				LOG_INFO(Render, "[Boot] SkyPass ready");
+		}
+	}
+```
+
+(L'engineer doit identifier l'helper `LoadShaderSpirv` ou équivalent dans le codebase existant — chercher `vkCreateShaderModule` pour trouver le pattern de loading utilisé.)
+
+- [ ] **Step 8: Modifier Engine.cpp — Record SkyPass dans la frame**
+
+Avant le geometry pass (chercher `vkCmdBeginRenderPass` ou le premier `Record` d'une pass), enregistrer le SkyPass :
+
+```cpp
+		if (m_skyPassReady)
+		{
+			engine::render::SkyPass::PushConstants pc{};
+
+			// invViewProj : matrice inverse view-projection courante.
+			std::memcpy(pc.invViewProj, m_camera.GetInvViewProj().m, sizeof(pc.invViewProj));
+
+			const auto& dn = m_dayNight.GetState();
+			pc.lightDir[0] = dn.lightDir[0]; pc.lightDir[1] = dn.lightDir[1]; pc.lightDir[2] = dn.lightDir[2];
+			pc.zenithColor[0] = dn.skyZenith[0]; pc.zenithColor[1] = dn.skyZenith[1]; pc.zenithColor[2] = dn.skyZenith[2];
+			pc.horizonColor[0] = dn.skyHorizon[0]; pc.horizonColor[1] = dn.skyHorizon[1]; pc.horizonColor[2] = dn.skyHorizon[2];
+
+			// MoonDir : oppose au soleil (cf. DayNightCycle).
+			pc.moonDir[0] = -dn.lightDir[0];
+			pc.moonDir[1] = -dn.lightDir[1];
+			pc.moonDir[2] = -dn.lightDir[2];
+			pc.moonIntensity = dn.isDaytime ? 0.0f : 1.0f;
+			pc.moonPhase = static_cast<float>(dn.moonPhase);
+			pc.moonIllumination = dn.moonIllumination;
+
+			m_skyPass.Record(commandBuffer, pc);
+		}
+```
+
+(L'engineer doit adapter le nom des variables `commandBuffer` et `m_camera.GetInvViewProj()` selon le code existant.)
+
+- [ ] **Step 9: Modifier Engine.cpp — Shutdown du SkyPass**
+
+Dans `Shutdown()`, avant `m_window.Destroy()` :
+
+```cpp
+	if (m_skyPassReady) m_skyPass.Shutdown(m_device);
+```
+
+---
+
+## Task 8: CMake registration
+
+**Files:**
+- Modify: `CMakeLists.txt`
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1: Ajouter sources engine_core dans CMakeLists.txt racine**
+
+Localiser le bloc des sources `engine_core` (chercher `LootRollUi.cpp`) et ajouter :
+
+```cmake
+  src/client/render/SkyPass.cpp
+  src/shared/network/LunarPayloads.cpp
+```
+
+- [ ] **Step 2: Ajouter test targets dans CMakeLists.txt racine**
+
+Localiser le bloc des `lcdlln_add_simple_test` (chercher `loot_payloads_tests`) et ajouter :
+
+```cmake
+# Phase 5 Lunar — round-trip tests.
+add_executable(lunar_payloads_tests src/shared/network/LunarPayloadsTests.cpp)
+target_link_libraries(lunar_payloads_tests PRIVATE engine_core)
+add_test(NAME lunar_payloads_tests COMMAND lunar_payloads_tests)
+
+# Phase 5 Lunar — calendar deterministe tests (header-only).
+add_executable(lunar_calendar_tests src/shardd/world/LunarCalendarTests.cpp)
+target_link_libraries(lunar_calendar_tests PRIVATE engine_core)
+add_test(NAME lunar_calendar_tests COMMAND lunar_calendar_tests)
+
+# M38.1 + Phase 5 Lunar — DayNightCycle existant + extension lunaire.
+add_executable(daynight_cycle_tests src/client/render/DayNightCycleTests.cpp)
+target_link_libraries(daynight_cycle_tests PRIVATE engine_core)
+add_test(NAME daynight_cycle_tests COMMAND daynight_cycle_tests)
+```
+
+- [ ] **Step 3: Ajouter sources server_app dans src/CMakeLists.txt**
+
+Localiser le bloc des sources serveur (chercher `LootHandler.cpp` et `LootPayloads.cpp`) et ajouter :
+
+```cmake
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lunar/LunarHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/LunarPayloads.cpp
+```
+
+---
+
+## Task 9: Compilation des shaders SPIR-V
+
+**Files:**
+- Build script (CMake / glslc / glslangValidator) qui produit `sky.vert.spv` et `sky.frag.spv` à partir des sources
+
+- [ ] **Step 1: Vérifier que la chaine de compilation shader existe**
+
+Run :
+```bash
+find . -name "*.frag.spv" 2>/dev/null | head -3
+find . -name "*compileShaders*" -o -name "compile_shaders*" 2>/dev/null | head -3
+```
+
+Si des `.spv` existent déjà pour d'autres shaders (water, lighting, etc.), la chaîne fonctionne — `sky.vert/frag` seront compilés automatiquement par le même mécanisme. Sinon, l'engineer doit identifier l'outil utilisé (probablement `glslangValidator` ou `glslc` dans CMake).
+
+- [ ] **Step 2: Si nécessaire, ajouter les shaders sky à la liste compile**
+
+Chercher `add_custom_command.*\.spv` ou `compile_shader\(` dans `CMakeLists.txt`. Ajouter l'entrée pour `sky.vert` / `sky.frag` si elle manque. Si la compilation se fait via glob, vérifier que les fichiers sont bien inclus.
+
+---
+
+## Task 10: Commit + push + PR
+
+**Files:**
+- Branch: `claude/day-night-lunar-design` (déjà créée)
+
+- [ ] **Step 1: Vérifier que tous les fichiers sont créés / modifiés**
+
+Run :
+```bash
+git status --short
+```
+Expected : nouveaux fichiers Lunar* + modifications dans `ProtocolV1Constants.h`, `main_linux.cpp`, `DayNightCycle.{h,cpp}`, `Engine.{h,cpp}`, `sky.frag`, CMakeLists.
+
+- [ ] **Step 2: Stager + committer**
+
+Run :
+```bash
+git add src/shardd/world/LunarCalendar.h \
+        src/shardd/world/LunarCalendarTests.cpp \
+        src/shared/network/LunarPayloads.h \
+        src/shared/network/LunarPayloads.cpp \
+        src/shared/network/LunarPayloadsTests.cpp \
+        src/shared/network/ProtocolV1Constants.h \
+        src/masterd/handlers/lunar/LunarHandler.h \
+        src/masterd/handlers/lunar/LunarHandler.cpp \
+        src/masterd/main_linux.cpp \
+        src/client/render/DayNightCycle.h \
+        src/client/render/DayNightCycle.cpp \
+        src/client/render/DayNightCycleTests.cpp \
+        src/client/render/SkyPass.h \
+        src/client/render/SkyPass.cpp \
+        src/client/app/Engine.h \
+        src/client/app/Engine.cpp \
+        game/data/shaders/sky.frag \
+        game/data/shaders/sky.vert \
+        CMakeLists.txt \
+        src/CMakeLists.txt
+
+git commit -m "$(cat <<'EOF'
+feat(lunar): wire 16 phases lunaires + SkyPass + tests cycle jour/nuit
+
+Implementation Phase 5 step 3+4 Lunar :
+- LunarCalendar header-only (calcul deterministe phase 0..15 +
+  illumination sinusoidale depuis epoch Unix)
+- LunarPayloads (opcodes 192-194) : State Request/Response + Push
+  PhaseChangeNotification
+- LunarHandler master : etat authoritative + tick 5min + push broadcast
+- DayNightCycle etendu : moonPhase/moonIllumination + callback
+  OnLunarPhaseChange. Tests unitaires du cycle existant ajoutes.
+- SkyPass Vulkan NOUVEAU : sky.frag/sky.vert existent depuis M38.1
+  mais n'etaient pas wires dans le pipeline ; le ciel etait juste un
+  clearColor. SkyPass charge les shaders et dessine le ciel + disque
+  lunaire procedural via push-constants etendus.
+- sky.frag etendu : disque lunaire procedural (intersection 2 cercles)
+  + earthshine sur les phases sombres + halo doux.
+- Engine : dispatch opcodes 193/194, fetch initial sur EnterWorld,
+  slash commands debug /sky info|time|moon.
+- 3 cibles CTest : lunar_calendar_tests, lunar_payloads_tests,
+  daynight_cycle_tests.
+
+Cycle = 14 jours reels (16 phases x ~21h). Phase deterministe depuis
+epoch 2026-01-01 UTC. La Lune Noire (phases 0/14/15, ~21% du temps)
+servira a declencher des events thematiques (fil rouge LCDLLN).
+
+V1 limitations consignees :
+- Pas de hook event lune <-> GameEvents (CurrentPhase expose, future PR)
+- Pas de modulation lightColor nocturne par moonIllumination
+- Pas de texture surface lunaire
+- Master autoritaire ; pas de SyncLunar RPC entre master et shardd
+
+Deploiement : REDEPLOIEMENT MASTER LINUX REQUIS - opcodes 192-194 +
+LunarHandler. Pas de migration DB.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Push**
+
+Run :
+```bash
+git push -u origin claude/day-night-lunar-design
+```
+
+- [ ] **Step 4: Créer la PR**
+
+Run :
+```bash
+gh pr create --base main --head claude/day-night-lunar-design \
+  --title "feat(lunar): 16 phases lunaires + SkyPass + tests cycle jour/nuit (Phase 5)" \
+  --body-file docs/superpowers/specs/2026-05-10-day-night-lunar-cycle-design.md
+```
+
+(L'engineer doit ensuite enrichir le body avec un récap des changements ; le contenu du spec est un bon point de départ.)
+
+---
+
+## Self-Review
+
+### Spec coverage
+- ✅ LunarCalendar header-only (Section Architecture #1) → Task 2
+- ✅ LunarHandler master + tick 5min (Architecture #2) → Tasks 3-4
+- ✅ DayNightCycle extension (Architecture #3) → Task 5
+- ✅ SkyPass C++ Vulkan (Architecture #4) → Task 6
+- ✅ sky.frag procedural moon disk (Section Rendering) → Task 6 Step 3
+- ✅ Opcodes 192-194 (Section Wire) → Task 1
+- ✅ Payloads structs (Section Wire) → Task 3
+- ✅ Tick + broadcast + EnterWorld fetch (Section Flow) → Tasks 4 + 7
+- ✅ 16 phases avec illumination sinusoïdale (Section 2) → Task 2
+- ✅ 3 cibles CTest (Section Tests A/B/C) → Tasks 2, 3, 5 + Task 8
+- ✅ Slash commands /sky info|time|moon (Section Tests E) → Task 7 Step 6
+- ✅ CMake registration (Section Fichiers) → Task 8
+- ✅ Capture-list lambda (note CRITIQUE in spec) → Task 4 Step 6
+
+### Placeholder scan
+Aucun "TBD", "TODO", "implement later", "fill in details". Tous les steps contiennent du code complet ou des commandes exactes. Quelques steps mentionnent que l'engineer doit "identifier l'helper LoadShaderSpirv ou équivalent" / "adapter le nom des variables" — ces points sont marqués explicitement comme nécessitant une lecture du code existant et ne sont pas des placeholders cachés.
+
+### Type consistency
+- `LunarPhaseInfo { uint8_t phase; float illumination; }` — utilisé cohéremment dans Tasks 2, 3, 4
+- `LunarStateResponse` champs : `status`, `phase`, `illumination`, `cycleStartMs`, `cycleDurationMs` — cohérent partout
+- `LunarPhaseChangeNotification` champs : `newPhase`, `newIllumination`, `nextChangeTsMs` — cohérent partout
+- `OnLunarPhaseChange(uint8_t phase, float illumination)` — signature cohérente entre déclaration (Task 5 Step 2) et utilisation (Task 7 Step 4)
+- `kOpcodeLunarStateRequest = 192u` etc. — cohérent
+
+### Note opérationnelle
+Le pattern projet est **single squash-merge commit par PR**. Toutes les modifications de ce plan rentrent dans un unique commit final (Task 10), pas un commit par task. Les "tasks" sont des unités logiques pour faciliter la review et l'exécution par subagent.

--- a/docs/superpowers/specs/2026-05-10-day-night-lunar-cycle-design.md
+++ b/docs/superpowers/specs/2026-05-10-day-night-lunar-cycle-design.md
@@ -1,0 +1,442 @@
+# Cycle jour/nuit + 16 phases lunaires — Design
+
+**Date** : 2026-05-10
+**Auteur** : Claude (brainstorming avec hcornet)
+**Statut** : Spec validée, prête pour writing-plans
+
+---
+
+## Résumé exécutif
+
+Étendre le moteur LCDLLN avec un système de phases lunaires à 16 étapes
+distinctes, synchronisé serveur ↔ client, avec rendu visuel procédural dans
+le sky shader existant. Vérifier en parallèle que le cycle jour/nuit déjà
+en place (`DayNightCycle`, `WorldClock`) est fonctionnel via tests
+unitaires + commandes debug.
+
+Le cycle lunaire dure **2 semaines réelles** (16 phases × ~21h chacune),
+indépendant du cycle jour/nuit en jeu (qui tourne à 24min réelles par jour
+en jeu par défaut). La phase est calculée de manière déterministe à partir
+de l'epoch Unix, donc identique pour tous les joueurs sans synchronisation
+explicite, et trivialement reproductible pour les tests.
+
+La "Lune Noire" du titre LCDLLN correspond aux phases 0/14/15
+(illumination ≤ 1%) qui couvrent ~3 nuits par cycle de 14 jours, soit
+~21% du temps. Cette phase pourra servir de condition de déclenchement
+pour de futurs game events.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────┐    ┌─────────────────────────┐
+│  Master (authoritative) │    │  Client (visualization) │
+│                         │    │                         │
+│  WorldClock (existant)  │    │  DayNightCycle          │
+│  LunarCalendar (header) │    │   (existant + extension)│
+│  LunarHandler           │    │   + moon phase mirror   │
+│   + tick périodique     │    │   + sky shader uniform  │
+│   + push on phase change│    │                         │
+└──────────┬──────────────┘    └────────▲────────────────┘
+           │                            │
+           │  opcodes 192-194 :         │
+           │   State / Push             │
+           └────────────────────────────┘
+```
+
+### Composants
+
+1. **`engine::server::world::LunarCalendar`** — header-only à
+   `src/shardd/world/LunarCalendar.h`, namespace existant. Calcule la
+   phase courante (0..15) depuis `realNowMs`, `cycleStartTsMs`, et
+   `cycleDurationMs` (= 14j × 24h × 3600s × 1000ms = 1 209 600 000 ms).
+   Pure stateless, méthode statique `Compute(realNowMs, cycleStartTsMs,
+   cycleDurationMs)` → struct `{ uint8_t phase; float illumination; }`.
+   Partagé par master et shardd (déterministe).
+
+2. **`engine::server::LunarHandler`** — master-side, à
+   `src/masterd/handlers/lunar/LunarHandler.{h,cpp}`. Setters
+   `SetServer`/`SetSessionManager`/`SetConnectionSessionMap`. Dispatch
+   opcode 192 (`LunarStateRequest`). Méthode publique `Tick(nowMs)`
+   appelée toutes les 5 minutes depuis la boucle main du master :
+   compare `LunarCalendar::Compute()` avec `m_lastBroadcastPhase` ;
+   si différent, push `LunarPhaseChangeNotification` (opcode 194) à
+   tous les clients connectés via `ConnectionSessionMap::Snapshot()`.
+   Méthode publique `CurrentPhase() const` pour intégration future
+   avec le système d'events.
+
+3. **`engine::render::DayNightCycle`** étendu — ajouts au struct
+   `State` : `uint8_t moonPhase`, `float moonIllumination`. Nouveau
+   callback `OnLunarPhaseChange(uint8_t, float)` settable depuis
+   l'Engine. Pas de calcul local de la phase (master autoritaire).
+
+4. **Sky pass C++** — découverte pendant la conception : les fichiers
+   `game/data/shaders/sky.frag` et `sky.vert` existent (M38.1) mais ne
+   sont actuellement **pas wirés** dans le pipeline Vulkan client. Le
+   ciel est aujourd'hui une simple `clearColor` issue de
+   `DayNightCycle.skyHorizon`. Cette spec inclut donc la création de
+   `src/client/render/SkyPass.{h,cpp}` (pattern aligné sur les autres
+   passes — `AuthLogoPass`, `LightingPass`, `WaterPass`) qui charge
+   `sky.vert.spv` + `sky.frag.spv` et fait un draw fullscreen quad avec
+   les push-constants `SkyPC` étendus :
+
+   ```glsl
+   layout(push_constant) uniform SkyPC {
+       mat4  invViewProj;       // existant
+       vec3  lightDir;          // existant (sun ou moon selon nuit/jour)
+       float _pad0;
+       vec3  zenithColor;       // existant
+       float _pad1;
+       vec3  horizonColor;      // existant
+       float _pad2;
+       vec3  moonDir;           // NOUVEAU (12h offset du soleil)
+       float moonIntensity;     // NOUVEAU (fade jour/nuit)
+       float moonPhase;         // NOUVEAU (0..15)
+       float moonIllumination;  // NOUVEAU (0..1)
+       vec2  _pad3;
+   } pc;
+   ```
+
+   Le `sky.frag` actuel est étendu avec ~30 lignes pour le disque
+   lunaire (cf. section Rendering). Le `clearColor` actuel est
+   conservé en fallback si SkyPass échoue à initialiser.
+
+5. **Engine client (`src/client/app/Engine.{h,cpp}`)** — push handler
+   dispatch sur opcodes 193/194. Sur EnterWorld (post-auth), envoi de
+   `LunarStateRequest` pour récupérer l'état initial. Slash commands
+   debug `/sky info`, `/sky time <hours>`, `/sky moon <phase 0..15>`.
+
+---
+
+## Les 16 phases lunaires
+
+Subdivision des 8 phases astronomiques classiques en `Early` / `Late`,
+plus une phase `Earthshine` symétrique pour boucler le cycle.
+
+| Index | Nom (FR) | Nom (EN) | Illumination | Type |
+|---|---|---|---|---|
+| 0 | Nouvelle Lune | NewMoon | 0% | Lune Noire |
+| 1 | Premier Croissant tôt | WaxingCrescentEarly | 6% | Croissant croissant |
+| 2 | Premier Croissant tard | WaxingCrescentLate | 19% | Croissant croissant |
+| 3 | Premier Quartier | FirstQuarter | 25% | Quartier |
+| 4 | Gibbeuse Croissante tôt | WaxingGibbousEarly | 44% | Gibbeuse croissante |
+| 5 | Gibbeuse Croissante tard | WaxingGibbousLate | 69% | Gibbeuse croissante |
+| 6 | Pleine Lune ascendante | FullMoonRising | 94% | Pleine |
+| 7 | Pleine Lune | FullMoon | 100% | Pleine |
+| 8 | Pleine Lune descendante | FullMoonSetting | 94% | Pleine |
+| 9 | Gibbeuse Décroissante tôt | WaningGibbousEarly | 69% | Gibbeuse décroissante |
+| 10 | Gibbeuse Décroissante tard | WaningGibbousLate | 44% | Gibbeuse décroissante |
+| 11 | Dernier Quartier | LastQuarter | 25% | Quartier |
+| 12 | Dernier Croissant tôt | WaningCrescentEarly | 19% | Croissant décroissant |
+| 13 | Dernier Croissant tard | WaningCrescentLate | 6% | Croissant décroissant |
+| 14 | Lune Cendrée tôt | EarthshineEarly | 1% | Quasi-noire |
+| 15 | Lune Cendrée tard | EarthshineLate | 1% | Quasi-noire |
+
+### Calcul de l'illumination
+
+Sinusoïde centrée sur Full Moon (index 7) :
+
+```cpp
+float Illumination(uint8_t phase) {
+    float t = (static_cast<int>(phase) - 7) * (3.14159265f / 8.0f);
+    return 0.5f * (1.0f + std::cos(t));
+}
+```
+
+Cette formule donne `1.0` pour phase=7 et `~0` pour phases 0 et 15 (les
+extrêmes). Les phases 0/14/15 ont illumination ≤ 1% (lune noire effective).
+
+### Lien avec le lore LCDLLN
+
+Les 3 phases "Lune Noire" (0, 14, 15) couvrent ~3 jours réels par cycle
+de 14 jours, soit ~21% du temps. C'est ni trop rare ni trop fréquent
+pour servir de condition de déclenchement à de futurs events serveur
+("Les Chroniques De La Lune Noire" — fil rouge thématique).
+
+---
+
+## Wire & data flow
+
+### Opcodes (192-194)
+
+```cpp
+// =====================================================================
+// Lunar wire — phase courante + push sur changement.
+// 16 phases (0..15), cycle de 14 jours reels, calcul deterministe depuis
+// epoch. Master autoritaire ; client recoit l'etat initial sur connexion
+// puis un push toutes les ~21h sur changement de phase.
+// =====================================================================
+constexpr uint16_t kOpcodeLunarStateRequest             = 192u;
+constexpr uint16_t kOpcodeLunarStateResponse            = 193u;
+constexpr uint16_t kOpcodeLunarPhaseChangeNotification  = 194u;
+```
+
+### Payloads
+
+```cpp
+struct LunarStateRequest {
+    // (vide)
+};
+
+struct LunarStateResponse {
+    uint8_t  phase;             // 0..15
+    float    illumination;      // 0..1
+    uint64_t cycleStartTsMs;    // timestamp ms du début du cycle courant
+    uint64_t cycleDurationMs;   // 14j × 24h × 3600s × 1000ms
+};
+
+struct LunarPhaseChangeNotification {
+    uint8_t  newPhase;          // 0..15
+    float    newIllumination;   // 0..1
+    uint64_t nextChangeTsMs;    // timestamp ms du prochain changement
+};
+```
+
+Sérialisation little-endian, helpers `WriteUInt8/16/32/64LE` et
+`WriteFloatLE` existants. Pattern strict aligné avec les payloads
+récents (Loot, Auction, Weather…).
+
+### Flow
+
+1. **Boot master** : `LunarHandler` initialise `m_cycleStartTsMs` (epoch
+   Unix arbitraire, par exemple 2026-01-01 00:00:00 UTC = 1767225600000),
+   `m_cycleDurationMs = 1209600000`, et calcule la phase courante.
+2. **Connexion client** : sur EnterWorld, le client envoie opcode 192.
+   Master répond opcode 193 avec l'état complet.
+3. **Tick master (5 min)** : si la phase courante diffère de
+   `m_lastBroadcastPhase`, master push opcode 194 à tous les clients
+   connectés.
+4. **Réception client** : `Engine::DispatchPushHandler` route opcodes
+   193/194 vers `m_dayNightCycle.OnLunarPhaseChange(...)`.
+5. **Sky shader** : à chaque frame, push-constants `moonPhase` et
+   `moonIllumination` sont lus depuis `m_dayNightCycle.GetState()`.
+
+### Pas de Subscribe/Unsubscribe
+
+Différent de Weather/GameEvents : la lune est globale et permanente, le
+push est broadcast à tous les clients connectés sans opt-in. Charge
+négligeable (1 push par client toutes les ~21h).
+
+---
+
+## Rendering shader procédural
+
+### Push-constants `sky.frag`
+
+```glsl
+layout(push_constant) uniform SkyParams {
+    vec3 zenithColor;
+    vec3 horizonColor;
+    vec3 sunDir;
+    vec3 moonDir;
+    float sunIntensity;
+    float moonIntensity;
+    float moonPhase;        // 0..15, encode en float
+    float moonIllumination; // 0..1
+} sky;
+```
+
+### Algorithme
+
+```glsl
+// Distance angulaire au centre du disque lunaire
+float cosA = dot(viewDir, sky.moonDir);
+float moonRadius = 0.012; // ~0.7 degre, taille apparente reelle
+
+if (cosA > cos(moonRadius)) {
+    // Repere local 2D du disque
+    vec3 right = normalize(cross(vec3(0,1,0), sky.moonDir));
+    vec3 up    = cross(sky.moonDir, right);
+    float u    = dot(viewDir, right) / sin(moonRadius);
+    float v    = dot(viewDir, up)    / sin(moonRadius);
+
+    // Masque d'ombre via 2 disques superposes
+    float shadowOffset = 1.0 - sky.moonIllumination * 2.0;
+    bool  shadowOnLeft = sky.moonPhase < 7.5;
+    if (shadowOnLeft) shadowOffset = -shadowOffset;
+
+    float distFromShadow = length(vec2(u - shadowOffset, v));
+    float shadowMask     = smoothstep(1.0, 0.95, distFromShadow);
+
+    vec3 moonSurface = vec3(0.95, 0.92, 0.85) * shadowMask;
+
+    // Earthshine sur les phases proches de NewMoon
+    if (sky.moonPhase < 3.0 || sky.moonPhase > 13.0) {
+        moonSurface += vec3(0.05, 0.06, 0.10) * (1.0 - shadowMask);
+    }
+
+    // Halo doux
+    float haloFalloff = smoothstep(cos(moonRadius * 1.5),
+                                    cos(moonRadius), cosA);
+
+    finalColor = mix(skyColor, moonSurface * sky.moonIntensity,
+                     haloFalloff);
+}
+```
+
+### Caractéristiques
+
+- **Pas de texture** — entièrement procédural, ~30 lignes GLSL
+- **Earthshine subtil** sur les phases proches de NewMoon (visible
+  même à phase 0 si on regarde attentivement)
+- **Halo doux** pour effet "MMO moderne"
+- `moonIntensity` masque la lune le jour (fadé par `DayNightCycle`
+  selon l'élévation du soleil)
+- **Coût GPU négligeable** : un seul `if` par fragment, calculs simples
+
+### Couleur surface lunaire
+
+Constante `vec3(0.95, 0.92, 0.85)` (gris légèrement chaud). Pourra être
+exposée en push-constant dans une future itération pour ajustement
+artistique sans recompilation du shader.
+
+---
+
+## Tests & vérification
+
+### A. `lunar_calendar_tests` — `src/shardd/world/LunarCalendarTests.cpp`
+
+- `Compute(0, 0, 1209600000)` → phase 0
+- `Compute(0, 0, 1209600000)` à `now=cycleDuration/2` → phase 7 ou 8
+- `Compute(0, 0, 1209600000)` à `now=cycleDuration` → phase 0 (wrap)
+- Boucle paramétrée 0..15 : phase varie correctement à chaque
+  1/16 du cycle
+- Illumination est sinusoïdale (max à phase 7, min aux phases 0 et 15)
+- Toutes les valeurs ∈ [0, 15], jamais 16+
+
+15+ assertions. Pas de framework, pattern existant (assert simples).
+
+### B. `lunar_payloads_tests` — `src/shared/network/LunarPayloadsTests.cpp`
+
+- Round-trip `LunarStateRequest` / `LunarStateResponse` /
+  `LunarPhaseChangeNotification`
+- Edge cases : phase=0/15, illumination=0.0/1.0, timestamps
+  0/UINT64_MAX
+- Reject buffer trop court
+- 15+ tests
+
+### C. `daynight_cycle_tests` — `src/client/render/DayNightCycleTests.cpp` (NOUVEAU)
+
+Vérification du cycle jour/nuit existant qui n'a actuellement aucun
+test unitaire :
+
+- `Init(initialTimeOfDay=8)` → state.timeOfDay = 8, isDaytime = true
+- `Advance(deltaSeconds=3600 * timeScale)` → timeOfDay avance d'1h
+- À 6h : `lightDir.y ≈ 0` (lever soleil)
+- À 12h : `lightDir.y ≈ 1` (zénith)
+- À 18h : `lightDir.y ≈ 0` (coucher)
+- À 0h : moon prend le relais comme directional light, isDaytime=false
+- Couleurs lerpent monotonement entre keyframes
+  dawn/noon/dusk/night
+- `SetTime(25)` clamp ou wrap à 1.0
+- `SetTimeScale(0)` clamp à 0.1 (no divide-by-zero)
+- Nouvel état `moonPhase` = 0 par défaut, `moonIllumination` = 0
+- Après `OnLunarPhaseChange(7, 1.0)` : state reflète
+
+### D. CMake
+
+3 nouveaux targets via `lcdlln_add_simple_test()` :
+- `lunar_calendar_tests`
+- `lunar_payloads_tests`
+- `daynight_cycle_tests`
+
+### E. Tests visuels in-game (manuels mais documentés)
+
+#### Commande `/sky info`
+
+Imprime dans la console et le log :
+
+```
+[Sky] timeOfDay=14:32  isDaytime=true
+[Sky] sunDir=(+0.34, +0.91, +0.21)  intensity=0.95
+[Sky] moonPhase=7 (FullMoon, illumination=100%)
+[Sky] nextPhaseChange=in 18h 24m (real time)
+```
+
+#### Commande `/sky time <hours>`
+
+Force `m_dayNightCycle.SetTime(hours)`. Permet de prévisualiser tout
+le cycle 24h en quelques secondes.
+
+#### Commande `/sky moon <phase 0..15>`
+
+**Dev only**, override local de `m_dayNightCycle.m_state.moonPhase` et
+`moonIllumination`. Master conserve la phase réelle. Permet de
+prévisualiser tous les visuels en quelques secondes plutôt qu'attendre
+14 jours réels.
+
+### F. Checklist visuelle
+
+À valider en lançant le client + master :
+
+- [ ] Lune visible la nuit, invisible/atténuée le jour
+- [ ] Position lune cohérente avec position soleil (opposée, 12h offset)
+- [ ] Phase 0 (NewMoon) : lune quasi noire, légère lueur cendrée
+- [ ] Phase 3 (FirstQuarter) : moitié droite éclairée
+- [ ] Phase 7 (FullMoon) : disque entièrement éclairé, halo subtil
+- [ ] Phase 11 (LastQuarter) : moitié gauche éclairée
+- [ ] Transition entre phases (`/sky moon` rapide) douce, pas de saut
+- [ ] Couleurs ciel cohérentes aux 4 transitions (dawn/noon/dusk/midnight)
+
+---
+
+## Limitations V1 (consignées)
+
+- Lune sans texture surface (gris uniforme + masque). Future PR :
+  texture cratère + normal map.
+- Pas de gestion des éclipses solaires/lunaires.
+- Pas de hook event lune ↔ GameEvents — `LunarHandler::CurrentPhase()`
+  est exposé mais non consommé. Future PR : extension de
+  `GameEventManager` avec condition `requires_lunar_phase`.
+- Pas de persistance DB — `cycleStartTsMs` est hardcodé au boot
+  master (epoch fixe 2026-01-01). Suffisant car le calcul est
+  déterministe ; future PR pourra exposer `world.lunar.cycle_start`
+  dans `config.json`.
+- Pas de variation de luminosité ambiante selon la phase (full moon
+  ne donne pas plus de lumière qu'une nouvelle lune). Future PR :
+  modulation du `lightColor` nocturne par `moonIllumination`.
+- Master autoritaire ; pas de SyncLunar RPC entre master et shardd
+  (shardd recompute localement via `LunarCalendar` si besoin).
+
+---
+
+## Déploiement
+
+⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 192-194 +
+nouveau `LunarHandler` enregistré dans le dispatch lambda.
+
+✅ Pas de migration DB.
+
+Le client neuf parlera dans le vide à un master ancien (BAD_REQUEST sur
+opcode 192) ; déploiement lock-step requis.
+
+---
+
+## Fichiers impactés (récapitulatif)
+
+### Nouveaux
+
+- `src/shared/network/LunarPayloads.{h,cpp}` (+ Tests.cpp)
+- `src/shardd/world/LunarCalendar.h` (+ Tests.cpp)
+- `src/masterd/handlers/lunar/LunarHandler.{h,cpp}`
+- `src/client/render/DayNightCycleTests.cpp` (NOUVEAU)
+
+### Modifiés
+
+- `src/shared/network/ProtocolV1Constants.h` — opcodes 192-194
+- `src/masterd/main_linux.cpp` — instanciation + dispatch
+  + `&lunarHandler` dans capture-list lambda
+- `src/client/render/DayNightCycle.{h,cpp}` — extension state +
+  callback `OnLunarPhaseChange`
+- `game/data/shaders/sky.frag` — disque lunaire procédural + push
+  constants étendus
+- `src/client/app/Engine.{h,cpp}` — dispatch + slash commands debug
+  + intégration de `SkyPass` dans le pipeline de rendu
+- `CMakeLists.txt` + `src/CMakeLists.txt` — nouveaux sources + tests
+
+### Nouveaux (suite)
+
+- `src/client/render/SkyPass.{h,cpp}` — pass Vulkan qui consomme les
+  shaders `sky.frag` / `sky.vert` existants (jusqu'ici non wirés). Pattern
+  aligné sur `LightingPass` / `WaterPass` / `AuthLogoPass`.

--- a/game/data/shaders/sky.frag
+++ b/game/data/shaders/sky.frag
@@ -1,33 +1,97 @@
 #version 450
-// M38.1 — Sky gradient fragment shader.
+// M38.1 + Phase 5 Lunar — Sky gradient fragment shader avec disque lunaire procedural.
 //
 // Implements a Rayleigh-scattering approximation for the sky dome:
 //   - Vertical gradient from zenith colour to horizon colour.
 //   - Mie-scatter-like glow around the sun disk.
 //   - Colours driven by the DayNightCycle CPU system via push constants.
+//   - Procedural moon disk with phase-driven shadow (Phase 5 Lunar).
 //
-// Push constants (80 bytes):
-//   invViewProj  (64 bytes, mat4) — inverse view-projection for view direction recovery
-//   lightDir     (12 bytes, vec3) — normalised direction toward the sun/moon
-//   _pad0        ( 4 bytes)
-//   zenithColor  (12 bytes, vec3) — sky colour at the zenith
-//   _pad1        ( 4 bytes)
-//   horizonColor (12 bytes, vec3) — sky colour at the horizon
-//   _pad2        ( 4 bytes)
+// Push constants (144 bytes total):
+//   invViewProj      ( 64 bytes, mat4) — inverse view-projection for view direction recovery
+//   lightDir         ( 12 bytes, vec3) — normalised direction toward the sun
+//   _pad0            (  4 bytes)
+//   zenithColor      ( 12 bytes, vec3) — sky colour at the zenith
+//   _pad1            (  4 bytes)
+//   horizonColor     ( 12 bytes, vec3) — sky colour at the horizon
+//   _pad2            (  4 bytes)
+//   moonDir          ( 12 bytes, vec3) — direction toward the moon (normalized)
+//   moonIntensity    (  4 bytes, float) — 0..1, fade jour/nuit
+//   moonPhase        (  4 bytes, float) — 0..15
+//   moonIllumination (  4 bytes, float) — 0..1
+//   _pad3            (  8 bytes)
 
 layout(location = 0) in  vec2 vUV;
 layout(location = 0) out vec4 outColor;
 
 layout(push_constant) uniform SkyPC
 {
-    mat4  invViewProj;    // 64 bytes
-    vec3  lightDir;       // direction toward the sun/moon (normalized)
+    mat4  invViewProj;       // 64 bytes
+    vec3  lightDir;          // direction toward the sun/moon (normalized)
     float _pad0;
-    vec3  zenithColor;    // colour at the top of the sky dome
+    vec3  zenithColor;       // colour at the top of the sky dome
     float _pad1;
-    vec3  horizonColor;   // colour at the horizon
+    vec3  horizonColor;      // colour at the horizon
     float _pad2;
+    vec3  moonDir;           // direction toward the moon (normalized)
+    float moonIntensity;     // 0..1, fade jour/nuit
+    float moonPhase;         // 0..15
+    float moonIllumination;  // 0..1
+    vec2  _pad3;
 } pc;
+
+// -------------------------------------------------------------------------
+// RenderMoonDisk : composite procedurale d'un disque lunaire avec ombre
+// dependant de la phase. Renvoie la couleur ciel modifiee (mix entre baseSky
+// et la surface lunaire ponderee par halo + intensity).
+//
+// Algorithme :
+//   1. Si moonIntensity ~= 0 (jour), retourne baseSky inchange.
+//   2. Calcule cosA = dot(viewDir, moonDir). Si en dehors du cone de la lune
+//      (cosA <= cos(kMoonRadius)), retourne baseSky.
+//   3. Construit un repere local (right, up) sur le disque, projete viewDir
+//      pour obtenir (u, v) dans le disque.
+//   4. Calcule un masque d'ombre via la distance a un cercle decalle
+//      d'apres l'illumination (intersection 2 cercles, classique pour
+//      simuler les phases).
+//   5. Pour les phases tres sombres (0..2 et 13..15), ajoute un peu
+//      d'earthshine bleute sur la partie ombragee.
+//   6. Mix avec un halo doux (smoothstep) entre baseSky et moonSurface.
+// -------------------------------------------------------------------------
+vec3 RenderMoonDisk(vec3 viewDir, vec3 baseSky)
+{
+    if (pc.moonIntensity < 0.001) return baseSky;
+    float cosA = dot(viewDir, pc.moonDir);
+    const float kMoonRadius = 0.012;
+    if (cosA <= cos(kMoonRadius * 1.5)) return baseSky;
+
+    vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), pc.moonDir));
+    vec3 up    = cross(pc.moonDir, right);
+    float u    = dot(viewDir, right) / sin(kMoonRadius);
+    float v    = dot(viewDir, up)    / sin(kMoonRadius);
+
+    // Decalage du cercle d'ombre selon l'illumination. Le signe depend de la
+    // phase : avant FullMoon (phase < 7.5) la lune croit a droite, apres elle
+    // decroit a gauche.
+    float shadowOffset = 1.0 - pc.moonIllumination * 2.0;
+    if (pc.moonPhase < 7.5) shadowOffset = -shadowOffset;
+
+    float distFromShadow = length(vec2(u - shadowOffset, v));
+    float shadowMask     = smoothstep(1.0, 0.95, distFromShadow);
+
+    vec3 moonSurface = vec3(0.95, 0.92, 0.85) * shadowMask;
+
+    // Earthshine sur les phases tres sombres (0..2 et 13..15) : bleute discret
+    // sur la partie ombragee.
+    if (pc.moonPhase < 3.0 || pc.moonPhase > 13.0)
+    {
+        moonSurface += vec3(0.05, 0.06, 0.10) * (1.0 - shadowMask);
+    }
+
+    // Halo doux : transition smoothstep entre baseSky et moonSurface.
+    float haloFalloff = smoothstep(cos(kMoonRadius * 1.5), cos(kMoonRadius), cosA);
+    return mix(baseSky, moonSurface * pc.moonIntensity, haloFalloff);
+}
 
 void main()
 {
@@ -75,6 +139,11 @@ void main()
         float belowT  = clamp(-viewDir.y / 0.1, 0.0, 1.0);
         skyColor = mix(skyColor, pc.horizonColor * 0.3, belowT);
     }
+
+    // ---- Phase 5 Lunar — disque lunaire procedural ---------------------------
+    // Compose le disque lunaire (avec ombre dependant de la phase) sur la
+    // couleur ciel courante. Si moonIntensity == 0 (jour), no-op.
+    skyColor = RenderMoonDisk(viewDir, skyColor);
 
     // ---- Final colour --------------------------------------------------------
     outColor = vec4(skyColor + sunContrib, 1.0);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/guild/GuildHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/loot/LootHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lunar/LunarHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -147,6 +148,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/GuildPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LootPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/LunarPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3378,6 +3378,93 @@ namespace engine
 															});
 													}
 												}
+
+												// Phase 5 Lunar + M38.1 Sky : enregistre le draw fullscreen-quad
+												// du SkyPass (ciel + disque lunaire procedural) dans le render
+												// pass loadOp=LOAD du GeometryPass. SkyPass a ete Init contre
+												// `GetRenderPassLoad()` au boot, donc on doit etre dans ce
+												// render pass actif pour que vkCmdDraw soit valide. On reuse
+												// `RecordTerrainChunkBatch` (qui ouvre exactement ce render
+												// pass + framebuffer GBuffer + viewport/scissor) comme
+												// wrapper. La pass est emise en fin de lambda Geometry pour
+												// que le clear initial du GeometryPass ne l'ecrase pas. Avec
+												// le pipeline SkyPass (depthTest=FALSE, depthWrite=FALSE), le
+												// fullscreen-quad couvre tout le champ de vision ; les pixels
+												// reels de geometrie ont deja ete ecrits dans GBuffer
+												// avant. La consommation finale par LightingPass se fait via
+												// les autres attachments (depth, normal, ORM) — Sky ne
+												// renseigne que GBuffer A (albedo).
+												if (m_skyPassReady)
+												{
+													engine::render::SkyPass::PushConstants skyPc{};
+
+													// Calcul invViewProj inline (meme pattern que Decals/Lighting plus bas
+													// dans le fichier — pas de helper Mat4::Inverse global pour l'instant).
+													const float* vp = rs.viewProjMatrix.m;
+													const float a00=vp[0], a10=vp[1], a20=vp[2],  a30=vp[3];
+													const float a01=vp[4], a11=vp[5], a21=vp[6],  a31=vp[7];
+													const float a02=vp[8], a12=vp[9], a22=vp[10], a32=vp[11];
+													const float a03=vp[12],a13=vp[13],a23=vp[14], a33=vp[15];
+													const float b00=a00*a11-a10*a01, b01=a00*a21-a20*a01, b02=a00*a31-a30*a01;
+													const float b03=a10*a21-a20*a11, b04=a10*a31-a30*a11, b05=a20*a31-a30*a21;
+													const float b06=a02*a13-a12*a03, b07=a02*a23-a22*a03, b08=a02*a33-a32*a03;
+													const float b09=a12*a23-a22*a13, b10=a12*a33-a32*a13, b11=a22*a33-a32*a23;
+													const float det = b00*b11-b01*b10+b02*b09+b03*b08-b04*b07+b05*b06;
+													if (det > 1e-7f || det < -1e-7f)
+													{
+														const float invDet = 1.0f / det;
+														skyPc.invViewProj[0]  = ( a11*b11-a21*b10+a31*b09)*invDet;
+														skyPc.invViewProj[1]  = (-a10*b11+a20*b10-a30*b09)*invDet;
+														skyPc.invViewProj[2]  = ( a13*b05-a23*b04+a33*b03)*invDet;
+														skyPc.invViewProj[3]  = (-a12*b05+a22*b04-a32*b03)*invDet;
+														skyPc.invViewProj[4]  = (-a01*b11+a21*b08-a31*b07)*invDet;
+														skyPc.invViewProj[5]  = ( a00*b11-a20*b08+a30*b07)*invDet;
+														skyPc.invViewProj[6]  = (-a03*b05+a23*b02-a33*b01)*invDet;
+														skyPc.invViewProj[7]  = ( a02*b05-a22*b02+a32*b01)*invDet;
+														skyPc.invViewProj[8]  = ( a01*b10-a11*b08+a31*b06)*invDet;
+														skyPc.invViewProj[9]  = (-a00*b10+a10*b08-a30*b06)*invDet;
+														skyPc.invViewProj[10] = ( a03*b04-a13*b02+a33*b00)*invDet;
+														skyPc.invViewProj[11] = (-a02*b04+a12*b02-a32*b00)*invDet;
+														skyPc.invViewProj[12] = (-a01*b09+a11*b07-a21*b06)*invDet;
+														skyPc.invViewProj[13] = ( a00*b09-a10*b07+a20*b06)*invDet;
+														skyPc.invViewProj[14] = (-a03*b03+a13*b01-a23*b00)*invDet;
+														skyPc.invViewProj[15] = ( a02*b03-a12*b01+a22*b00)*invDet;
+													}
+													else
+													{
+														// Identity fallback — l'invViewProj sera approximatif mais le
+														// shader continuera a tourner sans NaN.
+														skyPc.invViewProj[0] = skyPc.invViewProj[5] =
+															skyPc.invViewProj[10] = skyPc.invViewProj[15] = 1.0f;
+													}
+
+													const auto& dn = m_dayNight.GetState();
+													skyPc.lightDir[0]      = dn.lightDir[0];
+													skyPc.lightDir[1]      = dn.lightDir[1];
+													skyPc.lightDir[2]      = dn.lightDir[2];
+													skyPc.zenithColor[0]   = dn.skyZenith[0];
+													skyPc.zenithColor[1]   = dn.skyZenith[1];
+													skyPc.zenithColor[2]   = dn.skyZenith[2];
+													skyPc.horizonColor[0]  = dn.skyHorizon[0];
+													skyPc.horizonColor[1]  = dn.skyHorizon[1];
+													skyPc.horizonColor[2]  = dn.skyHorizon[2];
+													// Lune = direction opposee au soleil (convention LCDLLN).
+													skyPc.moonDir[0]       = -dn.lightDir[0];
+													skyPc.moonDir[1]       = -dn.lightDir[1];
+													skyPc.moonDir[2]       = -dn.lightDir[2];
+													skyPc.moonIntensity    = dn.isDaytime ? 0.0f : 1.0f;
+													skyPc.moonPhase        = static_cast<float>(dn.moonPhase);
+													skyPc.moonIllumination = dn.moonIllumination;
+
+													m_pipeline->GetGeometryPass().RecordTerrainChunkBatch(
+														m_vkDeviceContext.GetDevice(), cmd, reg,
+														m_vkSwapchain.GetExtent(),
+														m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId,
+														m_fgGBufferVelocityId, m_fgDepthId,
+														[this, &skyPc](VkCommandBuffer innerCmd) {
+															m_skyPass.Record(innerCmd, skyPc);
+														});
+												}
 											});
 
 										m_frameGraph.addPass("HiZ_Build",

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -21,6 +21,7 @@
 #include "src/shared/network/GuildPayloads.h"
 #include "src/shared/network/AuctionPayloads.h"
 #include "src/shared/network/LootPayloads.h"
+#include "src/shared/network/LunarPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -1326,6 +1327,59 @@ namespace engine
 				LOG_INFO(Core, "[Engine] /loot toggle (visible={})", m_lootRollVisible);
 				return true;
 			}
+			// Phase 5 step 3+4 Lunar + M38.1 Sky : slash commands debug pour
+			// inspecter et override le cycle jour/nuit + phase lunaire.
+			//   /sky info        : log timeOfDay + sun dir + moon phase + illumination.
+			//   /sky time <h>    : SetTime(h), ex. "/sky time 22.5".
+			//   /sky moon <i>    : OnLunarPhaseChange(i, calc(i)), ex. "/sky moon 7".
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/sky info" || text == "/sky"))
+			{
+				const auto& s = m_dayNight.GetState();
+				const char* moonName[16] = {
+					"NewMoon", "WaxingCrescentEarly", "WaxingCrescentLate", "FirstQuarter",
+					"WaxingGibbousEarly", "WaxingGibbousLate", "FullMoonRising", "FullMoon",
+					"FullMoonSetting", "WaningGibbousEarly", "WaningGibbousLate", "LastQuarter",
+					"WaningCrescentEarly", "WaningCrescentLate", "EarthshineEarly", "EarthshineLate"
+				};
+				LOG_INFO(Render, "[Sky] timeOfDay={:.2f}h isDaytime={}", s.timeOfDay, s.isDaytime);
+				LOG_INFO(Render, "[Sky] sunDir=({:.2f},{:.2f},{:.2f})", s.lightDir[0], s.lightDir[1], s.lightDir[2]);
+				LOG_INFO(Render, "[Sky] moonPhase={} ({}) illumination={:.0f}%",
+					static_cast<unsigned>(s.moonPhase),
+					moonName[s.moonPhase < 16 ? s.moonPhase : 0],
+					s.moonIllumination * 100.0f);
+				return true;
+			}
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/sky time "))
+			{
+				const auto rest = text.substr(10);
+				float hours = 0.0f;
+				try { hours = std::stof(std::string(rest)); } catch (...) { hours = 12.0f; }
+				m_dayNight.SetTime(hours);
+				LOG_INFO(Render, "[Sky] time set to {:.2f}h", hours);
+				return true;
+			}
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/sky moon "))
+			{
+				const auto rest = text.substr(10);
+				int phase = 0;
+				try { phase = std::stoi(std::string(rest)); } catch (...) { phase = 0; }
+				if (phase < 0 || phase > 15)
+				{
+					LOG_WARN(Render, "[Sky] phase {} hors plage [0..15]", phase);
+					return true;
+				}
+				// Calcul illumination locale (cf. LunarCalendar::ComputeIllumination).
+				constexpr float kPi = 3.14159265358979323846f;
+				float t = (static_cast<float>(phase) - 7.0f) * (kPi / 8.0f);
+				float illumination = 0.5f * (1.0f + std::cos(t));
+				m_dayNight.OnLunarPhaseChange(static_cast<uint8_t>(phase), illumination);
+				LOG_INFO(Render, "[Sky] moon phase override: {} illumination={:.0f}% (master state inchange)",
+					phase, illumination * 100.0f);
+				return true;
+			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
 			// pour ouvrir/fermer le panneau Support GM et synchroniser la liste
 			// depuis le master au moment de l'ouverture.
@@ -2152,6 +2206,39 @@ namespace engine
 				m_lootRollUi.OnSimulateRollResponse(*parsed);
 				return;
 			}
+			// Phase 5 step 3+4 Lunar — Dispatch des opcodes 193 (StateResponse)
+			// et 194 (PhaseChangeNotification, push). Master autoritaire ; le
+			// client recoit l'etat initial sur EnterWorld puis un push toutes
+			// les ~21h sur changement de phase.
+			case kOpcodeLunarStateResponse:
+			{
+				engine::network::lunar::LunarStateResponse parsed;
+				if (!engine::network::lunar::ParseLunarStateResponsePayload(payload, payloadSize, parsed))
+				{
+					LOG_WARN(Net, "[Engine] LUNAR_STATE_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				if (parsed.status == engine::network::lunar::LunarStatus::Ok)
+				{
+					m_dayNight.OnLunarPhaseChange(parsed.phase, parsed.illumination);
+					LOG_INFO(Render, "[Engine] LunarState received: phase={} illumination={:.3f}",
+						static_cast<unsigned>(parsed.phase), parsed.illumination);
+				}
+				return;
+			}
+			case kOpcodeLunarPhaseChangeNotification:
+			{
+				engine::network::lunar::LunarPhaseChangeNotification parsed;
+				if (!engine::network::lunar::ParseLunarPhaseChangeNotificationPayload(payload, payloadSize, parsed))
+				{
+					LOG_WARN(Net, "[Engine] LUNAR_PHASE_CHANGE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_dayNight.OnLunarPhaseChange(parsed.newPhase, parsed.newIllumination);
+				LOG_INFO(Render, "[Engine] LunarPhaseChange: phase={} illumination={:.3f}",
+					static_cast<unsigned>(parsed.newPhase), parsed.newIllumination);
+				return;
+			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG
 			// (101/103/105) + push MatchProposalNotification (106).
 			case kOpcodeLfgQueueResponse:
@@ -2888,6 +2975,34 @@ namespace engine
 												!waterFrag.empty(),
 												normalView != VK_NULL_HANDLE,
 												skyView != VK_NULL_HANDLE);
+										}
+									}
+
+									// Phase 5 Lunar + M38.1 Sky : init du SkyPass (charge sky.vert.spv +
+									// sky.frag.spv depuis game/data/shaders, compile pipeline avec push
+									// constants etendus pour la phase lunaire). Si l'init echoue
+									// (shaders absents, push constants size mismatch, etc.), m_skyPassReady
+									// reste false et le rendu fallback sur le clearColor existant.
+									if (pipelineOk)
+									{
+										std::vector<uint32_t> skyVert = loadSpirv("shaders/sky.vert.spv");
+										std::vector<uint32_t> skyFrag = loadSpirv("shaders/sky.frag.spv");
+										if (!skyVert.empty() && !skyFrag.empty())
+										{
+											m_skyPassReady = m_skyPass.Init(
+												m_vkDeviceContext.GetDevice(),
+												m_pipeline->GetGeometryPass().GetRenderPassLoad(),
+												/*subpass*/ 0u,
+												skyVert.data(), skyVert.size(),
+												skyFrag.data(), skyFrag.size());
+											if (!m_skyPassReady)
+												LOG_WARN(Render, "[Boot] SkyPass init failed -- fallback clearColor");
+											else
+												LOG_INFO(Render, "[Boot] SkyPass ready (Phase 5 Lunar + M38.1 Sky)");
+										}
+										else
+										{
+											LOG_WARN(Render, "[Boot] SkyPass : sky.vert.spv or sky.frag.spv missing -- fallback clearColor");
 										}
 									}
 
@@ -4378,6 +4493,14 @@ namespace engine
 			// (les ressources sont indépendantes mais l'ordre symétrique d'Init est plus
 			// lisible côté boot ↔ shutdown).
 			m_waterPass.Destroy(m_vkDeviceContext.GetDevice());
+			// Phase 5 Lunar + M38.1 Sky : detruit le SkyPass (pipeline + layout)
+			// avant le DeferredPipeline (m_skyPass depend du renderPass de
+			// GeometryPass, donc on libere le pipeline d'abord).
+			if (m_skyPassReady)
+			{
+				m_skyPass.Shutdown(m_vkDeviceContext.GetDevice());
+				m_skyPassReady = false;
+			}
 			m_waterMeshGpu.Destroy();
 			if (m_waterTransferPool != VK_NULL_HANDLE)
 			{
@@ -5238,6 +5361,18 @@ namespace engine
 					// Phase 5 reconnect — mémorise l'identité pour pouvoir ré-envoyer
 					// CHARACTER_ENTER_WORLD à la reconnexion sans repasser par tout le flow.
 					m_authUi.RememberPostEnterWorldCharacter(m_currentCharacterId, enterCmd.characterName);
+				}
+
+				// Phase 5 Lunar — fetch initial lunar state (master-authoritative).
+				// Le master repondra via opcode 193 (LunarStateResponse) qui est
+				// dispatche dans le push handler ci-dessus pour appeler
+				// m_dayNight.OnLunarPhaseChange. Le push 194 arrive ensuite a
+				// chaque changement de phase (~21h).
+				{
+					std::vector<uint8_t> lunarPayload;
+					engine::network::lunar::BuildLunarStateRequestPayload(lunarPayload);
+					(void)m_authUi.SendGenericRequestAsync(
+						engine::network::kOpcodeLunarStateRequest, lunarPayload);
 				}
 
 				// Override runtime du host:port gameplay UDP par l'endpoint du shard accepté.

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -51,6 +51,7 @@
 #include "src/client/render/WaterMeshGpu.h"
 #include "src/client/render/WaterPass.h"
 #include "src/client/render/DayNightCycle.h"
+#include "src/client/render/SkyPass.h"
 #include "src/client/render/WeatherSystem.h"
 #include "src/client/render/DynamicLightSystem.h"
 #include "src/client/world/water/WaterSurfaces.h"
@@ -331,6 +332,14 @@ namespace engine
 
 		/// M38.1: day/night cycle (time-of-day, sun direction, sky gradient colours).
 		engine::render::DayNightCycle m_dayNight;
+
+		/// Sky pass V1 (M38.1 + Phase 5 Lunar) : pipeline ciel + disque lunaire
+		/// procedural via push-constants. Consomme sky.frag et sky.vert. Le
+		/// pipeline est cree au boot dans InitVulkan ; m_skyPassReady passe a
+		/// true uniquement si la creation reussit (sinon fallback : le ciel
+		/// reste un clearColor simple, sans rendering du disque lunaire).
+		engine::render::SkyPass m_skyPass;
+		bool                    m_skyPassReady = false;
 
 		/// M38.2: weather system (state machine, rain/snow particles, fog density, audio volume).
 		engine::render::WeatherSystem m_weatherSystem;

--- a/src/client/render/DayNightCycle.cpp
+++ b/src/client/render/DayNightCycle.cpp
@@ -266,4 +266,21 @@ namespace engine::render
 		}
 	}
 
+	// -------------------------------------------------------------------------
+	// OnLunarPhaseChange — callback master-driven (Phase 5 Lunar)
+	// -------------------------------------------------------------------------
+
+	/// Setter idempotent : valide la phase (rejet si >= 16) et clampe
+	/// l'illumination dans [0..1]. Ne touche pas a m_timeOfDay ni au reste
+	/// du State (le ciel jour/nuit reste calcule par ComputeState() depuis
+	/// le clock interne ; seuls moonPhase et moonIllumination sont mis a jour
+	/// ici, pour servir au SkyPass via push-constants).
+	void DayNightCycle::OnLunarPhaseChange(uint8_t phase, float illumination)
+	{
+		if (phase >= 16) return;
+		m_state.moonPhase = phase;
+		m_state.moonIllumination = illumination < 0.0f ? 0.0f
+		                          : (illumination > 1.0f ? 1.0f : illumination);
+	}
+
 } // namespace engine::render

--- a/src/client/render/DayNightCycle.h
+++ b/src/client/render/DayNightCycle.h
@@ -60,6 +60,16 @@ namespace engine::render
 
 			/// True when the sun is above the horizon (elevation > 0).
 			bool isDaytime = true;
+
+			// ---- Lunar phase (master-driven via OnLunarPhaseChange callback) ----
+
+			/// Index de la phase lunaire courante (0..15). 0=NewMoon, 7=FullMoon, 15=Earthshine late.
+			/// Mis a jour uniquement via OnLunarPhaseChange (master autoritaire).
+			uint8_t moonPhase = 0;
+
+			/// Fraction de la lune eclairee (0..1). 0 = noir (NewMoon), 1 = pleine.
+			/// Mis a jour uniquement via OnLunarPhaseChange (master autoritaire).
+			float moonIllumination = 0.0f;
 		};
 
 		DayNightCycle() = default;
@@ -82,6 +92,17 @@ namespace engine::render
 		/// Used by the editor's "Atmosphere" panel slider. Clamps to [0.1, 1000.0]
 		/// to avoid divide-by-zero or wraparound issues.
 		void SetTimeScale(float realSecondsPerHour);
+
+		/// Met a jour la phase lunaire courante (recue depuis le master via
+		/// opcode 193 LunarStateResponse ou 194 LunarPhaseChangeNotification).
+		/// L'appel est idempotent et thread-safe au sens "appel main thread"
+		/// (pas de mutex : le main thread reception du Engine appelle ce
+		/// setter, le main thread render lit moonPhase/moonIllumination via
+		/// GetState()). Si \p phase >= 16, l'appel est ignore (defense V1).
+		/// Si \p illumination est hors [0..1], il est clampe.
+		/// \param phase        0..15
+		/// \param illumination 0..1 (clamp si hors plage)
+		void OnLunarPhaseChange(uint8_t phase, float illumination);
 
 		/// Return the current time scale (real seconds per in-game hour).
 		float GetTimeScale() const { return m_timeScale; }

--- a/src/client/render/DayNightCycleTests.cpp
+++ b/src/client/render/DayNightCycleTests.cpp
@@ -1,0 +1,180 @@
+// Tests du cycle jour/nuit existant + extension lunaire. Pas de framework,
+// asserts simples. Utilise pour valider le comportement de DayNightCycle
+// avant et apres l'ajout des phases lunaires (Phase 5 Lunar). Le binaire
+// est enregistre dans CMakeLists.txt comme cible CTest `daynight_cycle_tests`.
+
+#include "src/client/render/DayNightCycle.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+using engine::render::DayNightCycle;
+
+namespace
+{
+	/// Compare deux floats avec une tolerance \p eps (defaut 0.05f, le cycle
+	/// utilise des keyframes lerpees donc les comparaisons restent floues).
+	bool NearlyEqual(float a, float b, float eps = 0.05f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	/// A midi (12h), le cycle doit etre en jour avec timeOfDay ~ 12.
+	void TestInitNoonState()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 12.0f;
+		p.timeScale = 60.0f;
+		cycle.Init(p);
+
+		const auto& s = cycle.GetState();
+		assert(NearlyEqual(s.timeOfDay, 12.0f));
+		assert(s.isDaytime);
+		std::puts("[OK] TestInitNoonState");
+	}
+
+	/// A minuit (0h), le cycle doit etre en nuit (isDaytime=false).
+	void TestInitMidnightState()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 0.0f;
+		cycle.Init(p);
+
+		const auto& s = cycle.GetState();
+		assert(!s.isDaytime);
+		std::puts("[OK] TestInitMidnightState");
+	}
+
+	/// Au lever (6h) le soleil est proche de l'horizon, a midi (12h) il est
+	/// haut, au coucher (18h) il est proche de l'horizon.
+	void TestSunriseSunsetTransitions()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.SetTime(6.0f);
+		const auto& dawn = cycle.GetState();
+		// Au lever du soleil l'elevation est proche de 0 (pas a son zenith).
+		assert(std::fabs(dawn.lightDir[1]) < 0.5f);
+
+		cycle.SetTime(12.0f);
+		const auto& noon = cycle.GetState();
+		assert(noon.lightDir[1] > 0.7f);
+
+		cycle.SetTime(18.0f);
+		const auto& dusk = cycle.GetState();
+		assert(std::fabs(dusk.lightDir[1]) < 0.5f);
+		std::puts("[OK] TestSunriseSunsetTransitions");
+	}
+
+	/// SetTime(25h) doit produire un timeOfDay valide dans [0..24).
+	void TestSetTimeWraps()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.SetTime(25.0f);
+		const auto& s = cycle.GetState();
+		assert(s.timeOfDay >= 0.0f && s.timeOfDay < 24.0f);
+		std::puts("[OK] TestSetTimeWraps");
+	}
+
+	/// SetTimeScale clampe le timeScale a une valeur min positive.
+	void TestSetTimeScaleClamp()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.SetTimeScale(0.0f);
+		assert(cycle.GetTimeScale() >= 0.1f);
+		cycle.SetTimeScale(-100.0f);
+		assert(cycle.GetTimeScale() >= 0.1f);
+		std::puts("[OK] TestSetTimeScaleClamp");
+	}
+
+	/// 60 secondes reelles avec timeScale=60 doit avancer de 1h en jeu.
+	void TestAdvanceHour()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		p.initialTimeOfDay = 8.0f;
+		p.timeScale = 60.0f; // 1 game hour = 60 real seconds
+		cycle.Init(p);
+
+		// 60 secondes reelles -> 1h en jeu -> 9h.
+		cycle.Advance(60.0f);
+		const auto& s = cycle.GetState();
+		assert(NearlyEqual(s.timeOfDay, 9.0f, 0.1f));
+		std::puts("[OK] TestAdvanceHour");
+	}
+
+	/// Apres Init, moonPhase=0 et moonIllumination=0 (defaut).
+	void TestLunarPhaseDefault()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 0);
+		assert(NearlyEqual(s.moonIllumination, 0.0f));
+		std::puts("[OK] TestLunarPhaseDefault");
+	}
+
+	/// OnLunarPhaseChange(7, 1.0) doit bien set les valeurs.
+	void TestLunarPhaseUpdate()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		cycle.OnLunarPhaseChange(7, 1.0f);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 7);
+		assert(NearlyEqual(s.moonIllumination, 1.0f));
+		std::puts("[OK] TestLunarPhaseUpdate");
+	}
+
+	/// OnLunarPhaseChange clampe l'illumination et ignore les phases >= 16.
+	void TestLunarPhaseClamp()
+	{
+		DayNightCycle cycle;
+		DayNightCycle::Params p;
+		cycle.Init(p);
+
+		// Phase invalide >= 16 ignoree.
+		cycle.OnLunarPhaseChange(16, 0.5f);
+		const auto& s = cycle.GetState();
+		assert(s.moonPhase == 0);
+
+		// Illumination negative clampee a 0.
+		cycle.OnLunarPhaseChange(3, -1.0f);
+		assert(NearlyEqual(cycle.GetState().moonIllumination, 0.0f));
+
+		// Illumination > 1 clampee a 1.
+		cycle.OnLunarPhaseChange(7, 2.5f);
+		assert(NearlyEqual(cycle.GetState().moonIllumination, 1.0f));
+
+		std::puts("[OK] TestLunarPhaseClamp");
+	}
+}
+
+int main()
+{
+	TestInitNoonState();
+	TestInitMidnightState();
+	TestSunriseSunsetTransitions();
+	TestSetTimeWraps();
+	TestSetTimeScaleClamp();
+	TestAdvanceHour();
+	TestLunarPhaseDefault();
+	TestLunarPhaseUpdate();
+	TestLunarPhaseClamp();
+	std::puts("[ALL OK] DayNightCycleTests");
+	return 0;
+}

--- a/src/client/render/SkyPass.cpp
+++ b/src/client/render/SkyPass.cpp
@@ -1,0 +1,151 @@
+// Implementation SkyPass (Phase 5 Lunar + M38.1 Sky) — pipeline Vulkan
+// fullscreen-quad pour le ciel + disque lunaire procedural.
+
+#include "src/client/render/SkyPass.h"
+
+#include <cstring>
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Cree un VkShaderModule a partir d'un SPIR-V deja charge en memoire.
+		/// Renvoie VK_NULL_HANDLE en cas d'echec.
+		/// \param device    Device Vulkan logique.
+		/// \param code      Pointeur sur le SPIR-V (uint32 words).
+		/// \param wordCount Nombre de uint32 dans \p code.
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* code, size_t wordCount)
+		{
+			VkShaderModuleCreateInfo info{};
+			info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			info.codeSize = wordCount * sizeof(uint32_t);
+			info.pCode    = code;
+			VkShaderModule m = VK_NULL_HANDLE;
+			if (vkCreateShaderModule(device, &info, nullptr, &m) != VK_SUCCESS)
+				return VK_NULL_HANDLE;
+			return m;
+		}
+	}
+
+	bool SkyPass::Init(VkDevice device, VkRenderPass renderPass, uint32_t subpass,
+	                    const uint32_t* vertSpirv, size_t vertWordCount,
+	                    const uint32_t* fragSpirv, size_t fragWordCount)
+	{
+		// 1) Pipeline layout avec push-constants (144 bytes, vertex+fragment stages).
+		VkPushConstantRange pcRange{};
+		pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+		pcRange.offset     = 0;
+		pcRange.size       = sizeof(PushConstants);
+
+		VkPipelineLayoutCreateInfo plInfo{};
+		plInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		plInfo.pushConstantRangeCount = 1;
+		plInfo.pPushConstantRanges    = &pcRange;
+		if (vkCreatePipelineLayout(device, &plInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+			return false;
+
+		// 2) Shaders.
+		VkShaderModule vertModule = CreateShaderModule(device, vertSpirv, vertWordCount);
+		VkShaderModule fragModule = CreateShaderModule(device, fragSpirv, fragWordCount);
+		if (vertModule == VK_NULL_HANDLE || fragModule == VK_NULL_HANDLE)
+		{
+			if (vertModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, vertModule, nullptr);
+			if (fragModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, fragModule, nullptr);
+			return false;
+		}
+
+		VkPipelineShaderStageCreateInfo stages[2]{};
+		stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+		stages[0].module = vertModule;
+		stages[0].pName  = "main";
+		stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+		stages[1].module = fragModule;
+		stages[1].pName  = "main";
+
+		// 3) Vertex input vide (le fullscreen quad est genere via gl_VertexIndex).
+		VkPipelineVertexInputStateCreateInfo vi{};
+		vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+		VkPipelineInputAssemblyStateCreateInfo ia{};
+		ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+		ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+		// 4) Viewport / scissor dynamiques.
+		VkPipelineViewportStateCreateInfo vp{};
+		vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+		vp.viewportCount = 1;
+		vp.scissorCount  = 1;
+
+		VkPipelineRasterizationStateCreateInfo rs{};
+		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+		rs.polygonMode = VK_POLYGON_MODE_FILL;
+		rs.cullMode    = VK_CULL_MODE_NONE;
+		rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		rs.lineWidth   = 1.0f;
+
+		VkPipelineMultisampleStateCreateInfo ms{};
+		ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+		ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+		VkPipelineDepthStencilStateCreateInfo ds{};
+		ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+		ds.depthTestEnable  = VK_FALSE;
+		ds.depthWriteEnable = VK_FALSE;
+
+		VkPipelineColorBlendAttachmentState cba{};
+		cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+		                   | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+		VkPipelineColorBlendStateCreateInfo cb{};
+		cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+		cb.attachmentCount = 1;
+		cb.pAttachments    = &cba;
+
+		VkDynamicState dynStates[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+		VkPipelineDynamicStateCreateInfo dyn{};
+		dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+		dyn.dynamicStateCount = 2;
+		dyn.pDynamicStates    = dynStates;
+
+		VkGraphicsPipelineCreateInfo pi{};
+		pi.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+		pi.stageCount          = 2;
+		pi.pStages             = stages;
+		pi.pVertexInputState   = &vi;
+		pi.pInputAssemblyState = &ia;
+		pi.pViewportState      = &vp;
+		pi.pRasterizationState = &rs;
+		pi.pMultisampleState   = &ms;
+		pi.pDepthStencilState  = &ds;
+		pi.pColorBlendState    = &cb;
+		pi.pDynamicState       = &dyn;
+		pi.layout              = m_pipelineLayout;
+		pi.renderPass          = renderPass;
+		pi.subpass             = subpass;
+
+		const VkResult res = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pi, nullptr, &m_pipeline);
+		vkDestroyShaderModule(device, vertModule, nullptr);
+		vkDestroyShaderModule(device, fragModule, nullptr);
+		return res == VK_SUCCESS;
+	}
+
+	void SkyPass::Shutdown(VkDevice device)
+	{
+		if (m_pipeline       != VK_NULL_HANDLE) vkDestroyPipeline(device, m_pipeline, nullptr);
+		if (m_pipelineLayout != VK_NULL_HANDLE) vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+		m_pipeline       = VK_NULL_HANDLE;
+		m_pipelineLayout = VK_NULL_HANDLE;
+	}
+
+	void SkyPass::Record(VkCommandBuffer cmd, const PushConstants& pc)
+	{
+		if (m_pipeline == VK_NULL_HANDLE) return;
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+		vkCmdPushConstants(cmd, m_pipelineLayout,
+		                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+		                    0, sizeof(PushConstants), &pc);
+		vkCmdDraw(cmd, 3, 1, 0, 0);
+	}
+}

--- a/src/client/render/SkyPass.h
+++ b/src/client/render/SkyPass.h
@@ -1,0 +1,83 @@
+#pragma once
+// SkyPass : pipeline Vulkan qui dessine le ciel + disque lunaire procedural.
+// Consomme les shaders game/data/shaders/sky.vert et sky.frag (existants
+// jusqu'ici non wires). Le fragment shader recoit en push-constants la
+// matrice inverse view-projection, les directions soleil/lune, les couleurs
+// zenith/horizon, et les parametres lunaires (phase + illumination + intensity).
+//
+// La pass est dessinee EN PREMIER dans la frame (avant le geometry pass)
+// avec depthTest = false / depthWrite = false pour servir de fond.
+// Couts negligeables (1 fullscreen quad genere via gl_VertexIndex).
+//
+// Pattern aligne sur LightingPass et autres passes Vulkan du repo :
+//   - Init  : cree pipeline layout + pipeline + shader modules.
+//   - Record: bind pipeline + push constants + draw 3 vertices (fullscreen tri).
+//   - Shutdown : destroy pipeline + layout.
+//
+// Thread-safety : les methodes Init/Shutdown doivent etre appelees sur le
+// thread main (le device Vulkan n'est pas thread-safe par defaut). Record
+// peut etre appelee depuis un thread render dedie tant qu'on respecte
+// l'ordre dans le command buffer.
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <cstddef>
+
+namespace engine::render
+{
+	/// Pipeline Vulkan dedie a la pass ciel + disque lunaire (Phase 5 Lunar).
+	class SkyPass
+	{
+	public:
+		/// Push-constants (144 bytes total). Doit matcher exactement le bloc
+		/// `SkyPC` dans sky.frag (alignement std140 vec3 = 16 bytes via _padN).
+		struct PushConstants
+		{
+			float invViewProj[16];   ///< mat4
+			float lightDir[3];
+			float _pad0;
+			float zenithColor[3];
+			float _pad1;
+			float horizonColor[3];
+			float _pad2;
+			float moonDir[3];
+			float moonIntensity;
+			float moonPhase;
+			float moonIllumination;
+			float _pad3[2];
+		};
+		static_assert(sizeof(PushConstants) == 144, "SkyPass push constants size mismatch");
+
+		/// Cree le pipeline layout + pipeline + shader modules.
+		/// \param device         Device Vulkan logique.
+		/// \param renderPass     RenderPass parent (typiquement le main scene pass).
+		/// \param subpass        Indice du subpass (typiquement 0).
+		/// \param vertSpirv      Pointeur sur le SPIR-V vertex (sky.vert.spv).
+		/// \param vertWordCount  Nombre de uint32 dans le SPIR-V vertex.
+		/// \param fragSpirv      Pointeur sur le SPIR-V fragment (sky.frag.spv).
+		/// \param fragWordCount  Nombre de uint32 dans le SPIR-V fragment.
+		/// \return true si le pipeline est cree avec succes.
+		bool Init(VkDevice device,
+		          VkRenderPass renderPass,
+		          uint32_t subpass,
+		          const uint32_t* vertSpirv, size_t vertWordCount,
+		          const uint32_t* fragSpirv, size_t fragWordCount);
+
+		/// Destroy pipeline + layout. Appelable plusieurs fois (idempotent).
+		void Shutdown(VkDevice device);
+
+		/// Enregistre le draw fullscreen quad avec les push-constants.
+		/// Doit etre appelee dans un command buffer ouvert avec le bon
+		/// renderPass actif. No-op si Init a echoue.
+		/// \param cmd Command buffer Vulkan en cours d'enregistrement.
+		/// \param pc  Push constants a binder pour ce draw.
+		void Record(VkCommandBuffer cmd, const PushConstants& pc);
+
+		/// True si le pipeline est cree et utilisable.
+		bool IsInitialized() const { return m_pipeline != VK_NULL_HANDLE; }
+
+	private:
+		VkPipeline       m_pipeline       = VK_NULL_HANDLE;
+		VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
+	};
+}

--- a/src/masterd/handlers/lunar/LunarHandler.cpp
+++ b/src/masterd/handlers/lunar/LunarHandler.cpp
@@ -1,0 +1,161 @@
+// Implementation LunarHandler : dispatch + push broadcast (Phase 5 Lunar).
+
+#include "src/masterd/handlers/lunar/LunarHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/LunarPayloads.h"
+
+#include <chrono>
+#include <span>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::server::world::LunarCalendar;
+	using engine::server::world::LunarPhaseInfo;
+
+	void LunarHandler::SetCycleParams(uint64_t cycleStartMs, uint64_t cycleDurationMs)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_cycleStartMs = cycleStartMs;
+		m_cycleDurationMs = cycleDurationMs;
+	}
+
+	uint8_t LunarHandler::CurrentPhase() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		const uint64_t nowMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+		auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
+		return info.phase;
+	}
+
+	void LunarHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+	                                 uint64_t sessionIdHeader, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+		if (opcode == kOpcodeLunarStateRequest)
+		{
+			HandleStateRequest(connId, requestId, sessionIdHeader);
+		}
+	}
+
+	void LunarHandler::HandleStateRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		using namespace engine::network::lunar;
+		using namespace engine::network;
+
+		LunarStateResponse resp;
+
+		// Validation session : si pas de session valide -> Unauthorized.
+		if (m_connMap && m_sessionMgr)
+		{
+			auto sessIdOpt = m_connMap->GetSessionId(connId);
+			if (!sessIdOpt || *sessIdOpt == 0u || sessionIdHeader == 0u
+				|| *sessIdOpt != sessionIdHeader)
+			{
+				resp.status = LunarStatus::Unauthorized;
+			}
+			else
+			{
+				auto accIdOpt = m_sessionMgr->GetAccountId(*sessIdOpt);
+				if (!accIdOpt || *accIdOpt == 0u)
+				{
+					resp.status = LunarStatus::Unauthorized;
+				}
+			}
+		}
+		else
+		{
+			// Handler pas cable -> repond Unauthorized par defaut (defensive).
+			resp.status = LunarStatus::Unauthorized;
+		}
+
+		if (resp.status == LunarStatus::Ok)
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const uint64_t nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
+			resp.phase = info.phase;
+			resp.illumination = info.illumination;
+			resp.cycleStartMs = m_cycleStartMs;
+			resp.cycleDurationMs = m_cycleDurationMs;
+		}
+
+		std::vector<uint8_t> payload;
+		BuildLunarStateResponsePayload(resp, payload);
+
+		// Construction du packet complet via PacketBuilder (header + payload).
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (w.Remaining() < payload.size()) return;
+		if (!w.WriteBytes(payload.data(), payload.size())) return;
+		if (!builder.Finalize(kOpcodeLunarStateResponse, 0u, requestId, sessionIdHeader, payload.size())) return;
+		if (m_server)
+			m_server->Send(connId, builder.Data());
+	}
+
+	void LunarHandler::Tick(uint64_t realNowMs)
+	{
+		uint8_t newPhase = 0;
+		float newIllumination = 0.0f;
+		uint64_t nextChangeTs = 0;
+		bool needBroadcast = false;
+
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto info = LunarCalendar::Compute(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+			if (info.phase != m_lastBroadcastPhase)
+			{
+				newPhase = info.phase;
+				newIllumination = info.illumination;
+				nextChangeTs = LunarCalendar::NextChangeTsMs(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+				m_lastBroadcastPhase = info.phase;
+				needBroadcast = true;
+			}
+		}
+
+		if (needBroadcast)
+		{
+			LOG_INFO(Net, "[LunarHandler] phase change broadcast: phase={} illumination={:.3f} nextChangeTs={}",
+				static_cast<unsigned>(newPhase), newIllumination,
+				static_cast<unsigned long long>(nextChangeTs));
+			PushPhaseChangeBroadcast(newPhase, newIllumination, nextChangeTs);
+		}
+	}
+
+	void LunarHandler::PushPhaseChangeBroadcast(uint8_t newPhase, float newIllumination, uint64_t nextChangeTsMs)
+	{
+		using namespace engine::network::lunar;
+		using namespace engine::network;
+
+		LunarPhaseChangeNotification notif;
+		notif.newPhase = newPhase;
+		notif.newIllumination = newIllumination;
+		notif.nextChangeTsMs = nextChangeTsMs;
+
+		std::vector<uint8_t> payload;
+		BuildLunarPhaseChangeNotificationPayload(notif, payload);
+
+		// Push asynchrone : requestId=0, sessionId=0 dans le header.
+		auto packet = BuildPushPacket(kOpcodeLunarPhaseChangeNotification,
+			std::span<const uint8_t>(payload.data(), payload.size()));
+		if (packet.empty()) return;
+
+		if (!m_server || !m_connMap) return;
+		auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessId] : snapshot)
+		{
+			(void)sessId;
+			m_server->Send(connId, packet);
+		}
+	}
+}

--- a/src/masterd/handlers/lunar/LunarHandler.h
+++ b/src/masterd/handlers/lunar/LunarHandler.h
@@ -1,0 +1,102 @@
+#pragma once
+// LunarHandler : etat lunaire authoritative master + push broadcast sur
+// changement de phase. Calcul stateless via LunarCalendar (deterministe
+// depuis epoch). Tick periodique (5min) verifie si la phase courante a
+// change depuis le dernier broadcast et push aux clients connectes.
+//
+// Le handler est instancie dans main_linux.cpp au boot, cable via
+// SetServer/SetSessionManager/SetConnectionSessionMap, puis enregistre
+// dans le packetHandler du NetServer pour l'opcode 192. La response 193
+// est emise avec le meme requestId/sessionId que la request recue. Le
+// push 194 est broadcast a tous les clients connectes (pas de subscribe
+// explicite : la lune est globale et permanente).
+//
+// Cycle par defaut : 14 jours reels (14*24*3600*1000 = 1209600000 ms),
+// epoch 2026-01-01 00:00:00 UTC = 1767225600000 ms.
+//
+// V1 limitations :
+//   - Pas de hook event lune <-> GameEvents (CurrentPhase expose pour future PR).
+//   - Pas de SyncLunar RPC entre master et shardd : master autoritaire,
+//     le shardd peut recalculer la phase via LunarCalendar (header-only).
+//   - Pas de override admin (parametre fixe au boot via SetCycleParams).
+
+#include "src/shardd/world/LunarCalendar.h"
+
+#include <cstdint>
+#include <mutex>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Lunar cote master + tick periodique 5 min.
+	/// Doit etre configure via Set*() avant tout HandlePacket / Tick.
+	class LunarHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId (validation auth).
+		void SetSessionManager(SessionManager* mgr) { m_sessionMgr = mgr; }
+		/// Branche la map connId -> sessionId pour valider les requests + iterer pour le push.
+		void SetConnectionSessionMap(ConnectionSessionMap* m) { m_connMap = m; }
+
+		/// Configure les parametres du cycle. Appele une fois au boot avant le
+		/// premier Tick. Modifie uniquement les parametres ; ne reset pas
+		/// m_lastBroadcastPhase (le prochain Tick fera le diff comme d'habitude).
+		/// \param cycleStartMs    Timestamp Unix ms du debut de cycle de reference.
+		/// \param cycleDurationMs Duree d'un cycle complet en ms.
+		void SetCycleParams(uint64_t cycleStartMs, uint64_t cycleDurationMs);
+
+		/// Dispatch packet : opcode 192 (LunarStateRequest) -> response 193.
+		/// Si l'opcode n'est pas Lunar, ignore silencieusement.
+		///
+		/// \param connId           identifiant de connexion TCP (pour Send response).
+		/// \param opcode           opcode du paquet entrant (192).
+		/// \param requestId        request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader  session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload          pointeur sur le payload (sans header).
+		/// \param payloadSize      taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize);
+
+		/// Tick periodique (typiquement appele toutes les 5 min). Compare la
+		/// phase courante avec la derniere broadcastee ; si different, push
+		/// 194 a tous les clients connectes (Snapshot ConnectionSessionMap).
+		///
+		/// \param realNowMs Timestamp Unix courant en ms.
+		void Tick(uint64_t realNowMs);
+
+		/// Phase courante (pour integration future avec GameEvents).
+		/// Lecture sous mutex pour coherence avec SetCycleParams.
+		uint8_t CurrentPhase() const;
+
+	private:
+		/// Traite LUNAR_STATE_REQUEST : valide session, calcule phase courante,
+		/// envoie une reponse 193 avec la phase + cycle params.
+		void HandleStateRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader);
+
+		/// Push une LUNAR_PHASE_CHANGE_NOTIFICATION (opcode 194, push) a tous les
+		/// clients connectes (snapshot de ConnectionSessionMap).
+		void PushPhaseChangeBroadcast(uint8_t newPhase, float newIllumination, uint64_t nextChangeTsMs);
+
+		NetServer*            m_server     = nullptr;
+		SessionManager*       m_sessionMgr = nullptr;
+		ConnectionSessionMap* m_connMap    = nullptr;
+
+		/// Mutex protegeant m_cycleStartMs / m_cycleDurationMs / m_lastBroadcastPhase.
+		mutable std::mutex m_mutex;
+		/// Epoch 2026-01-01 00:00:00 UTC = 1767225600000 ms (cycle de reference).
+		uint64_t           m_cycleStartMs    = 1767225600000ull;
+		/// Duree par defaut : 14 jours reels (cf. kDefaultLunarCycleMs).
+		uint64_t           m_cycleDurationMs = engine::server::world::kDefaultLunarCycleMs;
+		/// Sentinel 0xFFu : force le premier broadcast au premier Tick (la phase
+		/// courante sera != 0xFFu, donc differente de m_lastBroadcastPhase).
+		uint8_t            m_lastBroadcastPhase = 0xFFu;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -47,6 +47,7 @@
 #include "src/masterd/handlers/guild/GuildHandler.h"
 #include "src/masterd/handlers/auction/AuctionHandler.h"
 #include "src/masterd/handlers/loot/LootHandler.h"
+#include "src/masterd/handlers/lunar/LunarHandler.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -654,6 +655,27 @@ int main(int argc, char** argv)
 	lootHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] LootHandler configured (CMANGOS.17 step 3+4 Loot, in-memory, simulation V1)");
 
+	// Phase 5 step 3+4 Lunar — LunarHandler : etat lunaire authoritative
+	// (16 phases, cycle 14 jours reels, deterministe depuis epoch). Tick
+	// periodique (5 min) detecte changement de phase et push broadcast.
+	// Pas de Subscribe : la lune est globale.
+	engine::server::LunarHandler lunarHandler;
+	lunarHandler.SetServer(&server);
+	lunarHandler.SetSessionManager(&sessionManager);
+	lunarHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] LunarHandler configured (Phase 5 Lunar, cycle 14j, 16 phases)");
+
+	// Premier Tick au boot : etablit la phase courante (m_lastBroadcastPhase
+	// passe de 0xFF a la valeur reelle, broadcast initial aux clients
+	// connectes — V1 il n'y en a pas encore puisque le serveur vient de
+	// demarrer, mais c'est defensif et coherent).
+	{
+		const uint64_t bootNowMs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+		lunarHandler.Tick(bootNowMs);
+	}
+
 	// Wire PasswordResetHandler dependencies.
 	passwordResetHandler.SetServer(&server);
 	passwordResetHandler.SetAccountStore(accountStore);
@@ -693,7 +715,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -795,6 +817,8 @@ int main(int argc, char** argv)
 		else if (opcode == kOpcodeLootRollChoiceRequest
 		      || opcode == kOpcodeLootSimulateRollRequest)
 			lootHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeLunarStateRequest)
+			lunarHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});
@@ -1029,6 +1053,15 @@ int main(int argc, char** argv)
 	auto lastSummaryLog = std::chrono::steady_clock::now();
 	constexpr auto kSummaryInterval = std::chrono::seconds(60);
 
+	// Phase 5 Lunar — Tick periodique (5 min) pour detecter changement de phase
+	// et push broadcast aux clients connectes. Le calcul est deterministe via
+	// LunarCalendar : la phase courante est purement fonction du timestamp
+	// realNowMs + cycleStart + cycleDuration. Le Tick compare avec la derniere
+	// phase broadcastee (m_lastBroadcastPhase) et n'emet un push que si
+	// different.
+	auto lastLunarTickTime = std::chrono::steady_clock::now();
+	constexpr auto kLunarTickInterval = std::chrono::seconds(300);
+
 	while (server.IsRunning() && g_quit == 0)
 	{
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -1084,6 +1117,17 @@ int main(int argc, char** argv)
 				LogNetworkStats(stats);
 				lastStatsDump = now;
 			}
+		}
+
+		// Phase 5 Lunar — Tick periodique (5 min) detection changement de phase.
+		// Le Tick compare avec la derniere phase broadcastee et push 194 si different.
+		if (now - lastLunarTickTime >= kLunarTickInterval)
+		{
+			const uint64_t realNowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			lunarHandler.Tick(realNowMs);
+			lastLunarTickTime = now;
 		}
 	}
 

--- a/src/shardd/world/LunarCalendar.h
+++ b/src/shardd/world/LunarCalendar.h
@@ -1,0 +1,93 @@
+#pragma once
+// LunarCalendar : calcul stateless de la phase lunaire courante a partir
+// d'un timestamp Unix. 16 phases (0..15), cycle de 14 jours reels.
+// Header-only, deterministe, partage par master et shardd.
+//
+// Conventions :
+//   - phase 0  : NewMoon (illumination ~0)
+//   - phase 7  : FullMoon (illumination 1.0)
+//   - phase 15 : Earthshine late (~0.04, juste avant un nouveau cycle)
+//
+// Le calcul est purement deterministe : aucune dependance a un etat
+// mutable. La meme entree (realNowMs, cycleStartMs, cycleDurationMs)
+// produira toujours la meme phase et illumination, ce qui permet au
+// master et au shardd de calculer la phase localement sans
+// synchronisation.
+
+#include <cstdint>
+#include <cmath>
+
+namespace engine::server::world
+{
+	/// Une phase lunaire complete avec son indice (0..15) et son
+	/// illumination (0..1, fraction eclairee).
+	struct LunarPhaseInfo
+	{
+		uint8_t phase        = 0;     ///< Index 0..15
+		float   illumination = 0.0f;  ///< 0..1, fraction eclairee
+	};
+
+	/// Cycle complet en millisecondes : 14 jours * 24h * 3600s * 1000ms.
+	inline constexpr uint64_t kDefaultLunarCycleMs = 14ull * 24ull * 3600ull * 1000ull;
+
+	/// Nombre de phases dans le cycle.
+	inline constexpr uint8_t kLunarPhaseCount = 16u;
+
+	class LunarCalendar
+	{
+	public:
+		/// Calcule la phase lunaire pour un timestamp donne.
+		/// \param realNowMs       Timestamp Unix courant en ms.
+		/// \param cycleStartMs    Timestamp Unix du debut du cycle de reference.
+		/// \param cycleDurationMs Duree d'un cycle complet en ms.
+		/// \return Phase + illumination. Si \p cycleDurationMs == 0 retourne {0, 0}.
+		///         Si \p realNowMs < \p cycleStartMs, retourne phase 0 (clamp anti-underflow).
+		static LunarPhaseInfo Compute(uint64_t realNowMs,
+		                              uint64_t cycleStartMs,
+		                              uint64_t cycleDurationMs)
+		{
+			if (cycleDurationMs == 0) return {};
+			const uint64_t elapsed = (realNowMs >= cycleStartMs) ? (realNowMs - cycleStartMs) : 0ull;
+			const uint64_t cyclePos = elapsed % cycleDurationMs;
+			const uint64_t phaseDurationMs = cycleDurationMs / kLunarPhaseCount;
+			uint8_t phase = static_cast<uint8_t>(cyclePos / phaseDurationMs);
+			if (phase >= kLunarPhaseCount) phase = kLunarPhaseCount - 1u;
+			return { phase, ComputeIllumination(phase) };
+		}
+
+		/// Calcule l'illumination (0..1) pour un index de phase.
+		/// Sinusoide centree sur Full Moon (index 7) :
+		///   - phase 0  -> 0.0  (NewMoon)
+		///   - phase 7  -> 1.0  (FullMoon)
+		///   - phase 15 -> ~0.04 (Earthshine late, tres sombre)
+		/// \param phase Index 0..15. Au-dela, le resultat est wrap par la sinusoide.
+		static float ComputeIllumination(uint8_t phase)
+		{
+			constexpr float kPi = 3.14159265358979323846f;
+			const float t = (static_cast<float>(phase) - 7.0f) * (kPi / 8.0f);
+			return 0.5f * (1.0f + std::cos(t));
+		}
+
+		/// Retourne le timestamp ms du prochain changement de phase.
+		/// Utile pour l'UI ("prochaine phase dans XXh") et pour le tick
+		/// du LunarHandler qui peut comparer realNowMs >= NextChangeTsMs.
+		/// \param realNowMs       Timestamp Unix courant en ms.
+		/// \param cycleStartMs    Timestamp Unix du debut du cycle de reference.
+		/// \param cycleDurationMs Duree d'un cycle complet en ms.
+		/// \return Timestamp ms absolu du debut de la phase suivante. Si
+		///         \p cycleDurationMs == 0 retourne \p realNowMs (no-op).
+		static uint64_t NextChangeTsMs(uint64_t realNowMs,
+		                               uint64_t cycleStartMs,
+		                               uint64_t cycleDurationMs)
+		{
+			if (cycleDurationMs == 0) return realNowMs;
+			const uint64_t elapsed = (realNowMs >= cycleStartMs) ? (realNowMs - cycleStartMs) : 0ull;
+			const uint64_t cyclePos = elapsed % cycleDurationMs;
+			const uint64_t phaseDurationMs = cycleDurationMs / kLunarPhaseCount;
+			const uint64_t currentPhaseStartMs = (cyclePos / phaseDurationMs) * phaseDurationMs;
+			const uint64_t nextPhaseStartMs = currentPhaseStartMs + phaseDurationMs;
+			const uint64_t cyclesElapsed = elapsed / cycleDurationMs;
+			return cycleStartMs + (cyclesElapsed * cycleDurationMs) + nextPhaseStartMs;
+		}
+	};
+}

--- a/src/shardd/world/LunarCalendarTests.cpp
+++ b/src/shardd/world/LunarCalendarTests.cpp
@@ -1,0 +1,154 @@
+// Tests du calcul de phase lunaire : round-trip phase <-> time, edge cases,
+// illumination sinusoidale, wrap de cycle. Pas de framework, asserts simples.
+// Le binaire est enregistre dans CMakeLists.txt comme cible CTest
+// `lunar_calendar_tests`.
+
+#include "src/shardd/world/LunarCalendar.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+using engine::server::world::LunarCalendar;
+using engine::server::world::LunarPhaseInfo;
+using engine::server::world::kDefaultLunarCycleMs;
+using engine::server::world::kLunarPhaseCount;
+
+namespace
+{
+	/// Compare deux floats avec une tolerance \p eps.
+	bool NearlyEqual(float a, float b, float eps = 0.001f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	/// A t=0 (debut de cycle), phase doit etre 0 (NewMoon) avec illumination ~0.
+	void TestPhase0AtCycleStart()
+	{
+		auto info = LunarCalendar::Compute(0, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		assert(NearlyEqual(info.illumination, 0.0f));
+		std::puts("[OK] TestPhase0AtCycleStart");
+	}
+
+	/// A la moitie du cycle, on doit etre a la phase 7 ou 8 (FullMoon ou
+	/// FullMoonSetting selon arrondi). On accepte les deux.
+	void TestPhase7AtHalfCycle()
+	{
+		const uint64_t halfCycle = kDefaultLunarCycleMs / 2;
+		auto info = LunarCalendar::Compute(halfCycle, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 8 || info.phase == 7);
+		std::puts("[OK] TestPhase7AtHalfCycle");
+	}
+
+	/// Apres un cycle complet, on doit retomber sur la phase 0.
+	void TestPhase0AfterFullCycle()
+	{
+		auto info = LunarCalendar::Compute(kDefaultLunarCycleMs, 0, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		std::puts("[OK] TestPhase0AfterFullCycle");
+	}
+
+	/// Pour chaque phase 0..15, le calcul a midPhaseMs doit retourner
+	/// exactement cette phase.
+	void TestEachPhaseTransition()
+	{
+		const uint64_t phaseDurationMs = kDefaultLunarCycleMs / kLunarPhaseCount;
+		for (uint8_t expectedPhase = 0; expectedPhase < kLunarPhaseCount; ++expectedPhase)
+		{
+			const uint64_t midPhaseMs = static_cast<uint64_t>(expectedPhase) * phaseDurationMs + phaseDurationMs / 2;
+			auto info = LunarCalendar::Compute(midPhaseMs, 0, kDefaultLunarCycleMs);
+			if (info.phase != expectedPhase)
+			{
+				std::printf("[FAIL] expected phase %u got %u at midPhaseMs=%llu\n",
+					expectedPhase, info.phase, static_cast<unsigned long long>(midPhaseMs));
+				assert(info.phase == expectedPhase);
+			}
+		}
+		std::puts("[OK] TestEachPhaseTransition");
+	}
+
+	/// L'illumination est maximale (1.0) a la phase 7 (FullMoon).
+	void TestIlluminationMaxAtFullMoon()
+	{
+		float illum7 = LunarCalendar::ComputeIllumination(7);
+		assert(NearlyEqual(illum7, 1.0f));
+		std::puts("[OK] TestIlluminationMaxAtFullMoon");
+	}
+
+	/// L'illumination est minimale (proche de 0) a la phase 0 (NewMoon).
+	void TestIlluminationMinAtNewMoon()
+	{
+		float illum0 = LunarCalendar::ComputeIllumination(0);
+		assert(illum0 < 0.05f);
+		std::puts("[OK] TestIlluminationMinAtNewMoon");
+	}
+
+	/// L'illumination est symetrique autour de la phase 7 : 6 == 8.
+	void TestIlluminationSymmetric()
+	{
+		float illum6 = LunarCalendar::ComputeIllumination(6);
+		float illum8 = LunarCalendar::ComputeIllumination(8);
+		assert(NearlyEqual(illum6, illum8));
+		std::puts("[OK] TestIlluminationSymmetric");
+	}
+
+	/// Apres 100 cycles, la phase doit toujours etre dans [0, 15].
+	void TestNoInvalidPhase()
+	{
+		for (uint64_t k = 0; k < 100; ++k)
+		{
+			const uint64_t t = k * kDefaultLunarCycleMs + 12345;
+			auto info = LunarCalendar::Compute(t, 0, kDefaultLunarCycleMs);
+			assert(info.phase < kLunarPhaseCount);
+		}
+		std::puts("[OK] TestNoInvalidPhase");
+	}
+
+	/// Si realNow < cycleStart (clamp anti-underflow), phase = 0.
+	void TestRealNowBeforeCycleStart()
+	{
+		auto info = LunarCalendar::Compute(0, 1000, kDefaultLunarCycleMs);
+		assert(info.phase == 0);
+		std::puts("[OK] TestRealNowBeforeCycleStart");
+	}
+
+	/// cycleDurationMs == 0 retourne {0, 0} (no-op).
+	void TestZeroCycleDuration()
+	{
+		auto info = LunarCalendar::Compute(12345, 0, 0);
+		assert(info.phase == 0);
+		assert(NearlyEqual(info.illumination, 0.0f));
+		std::puts("[OK] TestZeroCycleDuration");
+	}
+
+	/// NextChangeTsMs avance correctement entre phases.
+	void TestNextChangeTsAdvances()
+	{
+		const uint64_t phaseDurationMs = kDefaultLunarCycleMs / kLunarPhaseCount;
+		uint64_t nowMs = 0;
+		uint64_t next = LunarCalendar::NextChangeTsMs(nowMs, 0, kDefaultLunarCycleMs);
+		assert(next == phaseDurationMs);
+		nowMs = phaseDurationMs / 2;
+		next = LunarCalendar::NextChangeTsMs(nowMs, 0, kDefaultLunarCycleMs);
+		assert(next == phaseDurationMs);
+		std::puts("[OK] TestNextChangeTsAdvances");
+	}
+}
+
+int main()
+{
+	TestPhase0AtCycleStart();
+	TestPhase7AtHalfCycle();
+	TestPhase0AfterFullCycle();
+	TestEachPhaseTransition();
+	TestIlluminationMaxAtFullMoon();
+	TestIlluminationMinAtNewMoon();
+	TestIlluminationSymmetric();
+	TestNoInvalidPhase();
+	TestRealNowBeforeCycleStart();
+	TestZeroCycleDuration();
+	TestNextChangeTsAdvances();
+	std::puts("[ALL OK] LunarCalendarTests");
+	return 0;
+}

--- a/src/shared/network/LunarPayloads.cpp
+++ b/src/shared/network/LunarPayloads.cpp
@@ -1,0 +1,135 @@
+// Implementation Build/Parse des payloads Lunar (opcodes 192-194).
+// Format little-endian, sans PacketBuilder : ce module produit uniquement
+// le payload nu. Le LunarHandler appelle BuildPushPacket (pour le 194) ou
+// PacketBuilder::Finalize (pour le 193) pour ajouter le header protocol_v1.
+
+#include "src/shared/network/LunarPayloads.h"
+
+#include <cstring>
+
+namespace engine::network::lunar
+{
+	namespace
+	{
+		/// Ecrit un uint8 a la fin de \p out.
+		void WriteU8(std::vector<uint8_t>& out, uint8_t v)
+		{
+			out.push_back(v);
+		}
+
+		/// Ecrit un uint32 little-endian a la fin de \p out.
+		void WriteU32LE(std::vector<uint8_t>& out, uint32_t v)
+		{
+			out.push_back(static_cast<uint8_t>(v));
+			out.push_back(static_cast<uint8_t>(v >> 8));
+			out.push_back(static_cast<uint8_t>(v >> 16));
+			out.push_back(static_cast<uint8_t>(v >> 24));
+		}
+
+		/// Ecrit un uint64 little-endian a la fin de \p out.
+		void WriteU64LE(std::vector<uint8_t>& out, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i)
+				out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+		}
+
+		/// Ecrit un float little-endian (bit-cast vers uint32) a la fin de \p out.
+		void WriteFloatLE(std::vector<uint8_t>& out, float v)
+		{
+			uint32_t bits = 0;
+			std::memcpy(&bits, &v, sizeof(bits));
+			WriteU32LE(out, bits);
+		}
+
+		/// Lit un uint8 et avance \p pos. Retourne false si insuffisant.
+		bool ReadU8(const uint8_t* d, size_t sz, size_t& pos, uint8_t& out)
+		{
+			if (pos + 1 > sz) return false;
+			out = d[pos];
+			pos += 1;
+			return true;
+		}
+
+		/// Lit un uint32 little-endian et avance \p pos. Retourne false si insuffisant.
+		bool ReadU32LE(const uint8_t* d, size_t sz, size_t& pos, uint32_t& out)
+		{
+			if (pos + 4 > sz) return false;
+			out = static_cast<uint32_t>(d[pos])
+			    | (static_cast<uint32_t>(d[pos + 1]) << 8)
+			    | (static_cast<uint32_t>(d[pos + 2]) << 16)
+			    | (static_cast<uint32_t>(d[pos + 3]) << 24);
+			pos += 4;
+			return true;
+		}
+
+		/// Lit un uint64 little-endian et avance \p pos. Retourne false si insuffisant.
+		bool ReadU64LE(const uint8_t* d, size_t sz, size_t& pos, uint64_t& out)
+		{
+			if (pos + 8 > sz) return false;
+			out = 0;
+			for (int i = 0; i < 8; ++i)
+				out |= static_cast<uint64_t>(d[pos + i]) << (i * 8);
+			pos += 8;
+			return true;
+		}
+
+		/// Lit un float little-endian (bit-cast depuis uint32) et avance \p pos.
+		bool ReadFloatLE(const uint8_t* d, size_t sz, size_t& pos, float& out)
+		{
+			uint32_t bits = 0;
+			if (!ReadU32LE(d, sz, pos, bits)) return false;
+			std::memcpy(&out, &bits, sizeof(out));
+			return true;
+		}
+	}
+
+	void BuildLunarStateRequestPayload(std::vector<uint8_t>& out)
+	{
+		out.clear();
+	}
+
+	void BuildLunarStateResponsePayload(const LunarStateResponse& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, static_cast<uint8_t>(msg.status));
+		WriteU8(out, msg.phase);
+		WriteFloatLE(out, msg.illumination);
+		WriteU64LE(out, msg.cycleStartMs);
+		WriteU64LE(out, msg.cycleDurationMs);
+	}
+
+	void BuildLunarPhaseChangeNotificationPayload(const LunarPhaseChangeNotification& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, msg.newPhase);
+		WriteFloatLE(out, msg.newIllumination);
+		WriteU64LE(out, msg.nextChangeTsMs);
+	}
+
+	bool ParseLunarStateRequestPayload(const uint8_t* /*data*/, size_t size, LunarStateRequest& /*out*/)
+	{
+		return size == 0;
+	}
+
+	bool ParseLunarStateResponsePayload(const uint8_t* d, size_t sz, LunarStateResponse& out)
+	{
+		size_t pos = 0;
+		uint8_t status = 0;
+		if (!ReadU8(d, sz, pos, status)) return false;
+		if (!ReadU8(d, sz, pos, out.phase)) return false;
+		if (!ReadFloatLE(d, sz, pos, out.illumination)) return false;
+		if (!ReadU64LE(d, sz, pos, out.cycleStartMs)) return false;
+		if (!ReadU64LE(d, sz, pos, out.cycleDurationMs)) return false;
+		out.status = static_cast<LunarStatus>(status);
+		return pos == sz;
+	}
+
+	bool ParseLunarPhaseChangeNotificationPayload(const uint8_t* d, size_t sz, LunarPhaseChangeNotification& out)
+	{
+		size_t pos = 0;
+		if (!ReadU8(d, sz, pos, out.newPhase)) return false;
+		if (!ReadFloatLE(d, sz, pos, out.newIllumination)) return false;
+		if (!ReadU64LE(d, sz, pos, out.nextChangeTsMs)) return false;
+		return pos == sz;
+	}
+}

--- a/src/shared/network/LunarPayloads.h
+++ b/src/shared/network/LunarPayloads.h
@@ -1,0 +1,65 @@
+#pragma once
+// Wire payloads pour le systeme de phase lunaire (opcodes 192-194).
+// 16 phases (0..15), cycle de 14 jours reels.
+//
+// Format wire little-endian (cf. autres *Payloads du repo). Aucun champ
+// string dans cette serie : tous les champs sont uint8 / uint64 / float
+// (uint32 bits memcpy). Pas de PacketBuilder helpers — le LunarHandler
+// construit le packet final via BuildPushPacket (pour 194) ou un
+// PacketBuilder (pour 193).
+//
+// V1 : pas de hook event lune <-> GameEvents (CurrentPhase est expose
+// par LunarHandler). La pousse vers GameEventManager viendra via une
+// PR future quand le seed des events thematiques (Lune Noire) sera
+// branche.
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine::network::lunar
+{
+	/// Status response Lunar : OK ou Unauthorized (pas de session valide).
+	enum class LunarStatus : uint8_t
+	{
+		Ok           = 0,
+		Unauthorized = 1,
+	};
+
+	// === Request: client demande l'etat lunaire actuel (vide) ===
+	struct LunarStateRequest
+	{
+		// Empty — payload vide (size == 0).
+	};
+
+	// === Response: master envoie phase + cycle info ===
+	struct LunarStateResponse
+	{
+		LunarStatus status         = LunarStatus::Ok;
+		uint8_t     phase          = 0;     ///< 0..15
+		float       illumination   = 0.0f;  ///< 0..1
+		uint64_t    cycleStartMs   = 0;     ///< timestamp ms du debut de cycle
+		uint64_t    cycleDurationMs = 0;    ///< duree totale d'un cycle (ms)
+	};
+
+	// === Push notification: changement de phase ===
+	struct LunarPhaseChangeNotification
+	{
+		uint8_t  newPhase        = 0;
+		float    newIllumination = 0.0f;
+		uint64_t nextChangeTsMs  = 0;
+	};
+
+	/// Build* : ecrit le payload binaire dans \p out (clear puis push_back).
+	void BuildLunarStateRequestPayload(std::vector<uint8_t>& out);
+	void BuildLunarStateResponsePayload(const LunarStateResponse& msg, std::vector<uint8_t>& out);
+	void BuildLunarPhaseChangeNotificationPayload(const LunarPhaseChangeNotification& msg, std::vector<uint8_t>& out);
+
+	/// Parse* : retourne true si le buffer est valide (taille exacte attendue).
+	/// Reject-short et reject-extra : la taille du payload doit egaler exactement
+	/// la somme des champs encodes (1 + 1 + 4 + 8 + 8 = 22 pour StateResponse,
+	/// 1 + 4 + 8 = 13 pour PhaseChangeNotification, 0 pour StateRequest).
+	bool ParseLunarStateRequestPayload(const uint8_t* data, size_t size, LunarStateRequest& out);
+	bool ParseLunarStateResponsePayload(const uint8_t* data, size_t size, LunarStateResponse& out);
+	bool ParseLunarPhaseChangeNotificationPayload(const uint8_t* data, size_t size, LunarPhaseChangeNotification& out);
+}

--- a/src/shared/network/LunarPayloadsTests.cpp
+++ b/src/shared/network/LunarPayloadsTests.cpp
@@ -1,0 +1,194 @@
+// Round-trip tests pour les payloads lunaires + edge cases + reject-short.
+// Pas de framework, asserts simples. Le binaire est enregistre dans
+// CMakeLists.txt comme cible CTest `lunar_payloads_tests`.
+
+#include "src/shared/network/LunarPayloads.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace engine::network::lunar;
+
+namespace
+{
+	/// Compare deux floats avec une tolerance \p eps (defaut 1e-5f).
+	bool NearlyEqual(float a, float b, float eps = 1e-5f)
+	{
+		return std::fabs(a - b) < eps;
+	}
+
+	/// Round-trip d'un payload vide (StateRequest).
+	void TestStateRequestRoundTrip()
+	{
+		std::vector<uint8_t> buf;
+		BuildLunarStateRequestPayload(buf);
+		assert(buf.empty());
+		LunarStateRequest parsed;
+		assert(ParseLunarStateRequestPayload(buf.data(), buf.size(), parsed));
+		std::puts("[OK] TestStateRequestRoundTrip");
+	}
+
+	/// Round-trip standard d'une StateResponse Ok avec valeurs realistes.
+	void TestStateResponseRoundTrip()
+	{
+		LunarStateResponse src;
+		src.status = LunarStatus::Ok;
+		src.phase = 7;
+		src.illumination = 1.0f;
+		src.cycleStartMs = 1767225600000ull; // 2026-01-01 UTC
+		src.cycleDurationMs = 1209600000ull; // 14 jours
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == src.status);
+		assert(dst.phase == src.phase);
+		assert(NearlyEqual(dst.illumination, src.illumination));
+		assert(dst.cycleStartMs == src.cycleStartMs);
+		assert(dst.cycleDurationMs == src.cycleDurationMs);
+		std::puts("[OK] TestStateResponseRoundTrip");
+	}
+
+	/// Round-trip d'une StateResponse Unauthorized (status != Ok).
+	void TestStateResponseUnauthorized()
+	{
+		LunarStateResponse src;
+		src.status = LunarStatus::Unauthorized;
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == LunarStatus::Unauthorized);
+		std::puts("[OK] TestStateResponseUnauthorized");
+	}
+
+	/// Round-trip standard d'une PhaseChangeNotification avec valeurs realistes.
+	void TestPhaseChangeRoundTrip()
+	{
+		LunarPhaseChangeNotification src;
+		src.newPhase = 8;
+		src.newIllumination = 0.94f;
+		src.nextChangeTsMs = 1767246600000ull;
+
+		std::vector<uint8_t> buf;
+		BuildLunarPhaseChangeNotificationPayload(src, buf);
+
+		LunarPhaseChangeNotification dst;
+		assert(ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+		assert(dst.newPhase == src.newPhase);
+		assert(NearlyEqual(dst.newIllumination, src.newIllumination));
+		assert(dst.nextChangeTsMs == src.nextChangeTsMs);
+		std::puts("[OK] TestPhaseChangeRoundTrip");
+	}
+
+	/// Round-trip pour chacune des 16 phases (couverture exhaustive).
+	void TestPhaseChangeAllPhases()
+	{
+		for (uint8_t p = 0; p < 16; ++p)
+		{
+			LunarPhaseChangeNotification src;
+			src.newPhase = p;
+			src.newIllumination = static_cast<float>(p) / 15.0f;
+			src.nextChangeTsMs = 100000ull * static_cast<uint64_t>(p + 1);
+
+			std::vector<uint8_t> buf;
+			BuildLunarPhaseChangeNotificationPayload(src, buf);
+
+			LunarPhaseChangeNotification dst;
+			assert(ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+			assert(dst.newPhase == p);
+		}
+		std::puts("[OK] TestPhaseChangeAllPhases");
+	}
+
+	/// Reject-short : payload tronque avant la fin doit etre rejete.
+	void TestStateResponseRejectShort()
+	{
+		std::vector<uint8_t> buf = { 0x00, 0x07, 0x00, 0x00, 0x80 }; // tronque
+		LunarStateResponse dst;
+		assert(!ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestStateResponseRejectShort");
+	}
+
+	/// Reject-extra : un octet en trop a la fin du payload doit etre rejete.
+	void TestStateResponseRejectExtra()
+	{
+		LunarStateResponse src;
+		src.phase = 5;
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+		buf.push_back(0xAA); // octet en trop
+
+		LunarStateResponse dst;
+		assert(!ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestStateResponseRejectExtra");
+	}
+
+	/// Reject-short pour PhaseChangeNotification.
+	void TestPhaseChangeRejectShort()
+	{
+		std::vector<uint8_t> buf = { 0x07, 0x00 }; // tronque
+		LunarPhaseChangeNotification dst;
+		assert(!ParseLunarPhaseChangeNotificationPayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestPhaseChangeRejectShort");
+	}
+
+	/// Edge case : valeurs maximales (UINT64_MAX, illumination 1.0, phase 15).
+	void TestEdgeCaseMaxValues()
+	{
+		LunarStateResponse src;
+		src.phase = 15;
+		src.illumination = 1.0f;
+		src.cycleStartMs = UINT64_MAX;
+		src.cycleDurationMs = UINT64_MAX;
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.phase == 15);
+		assert(dst.cycleStartMs == UINT64_MAX);
+		std::puts("[OK] TestEdgeCaseMaxValues");
+	}
+
+	/// Edge case : tous les champs a 0.
+	void TestEdgeCaseZero()
+	{
+		LunarStateResponse src;
+		src.phase = 0;
+		src.illumination = 0.0f;
+		src.cycleStartMs = 0;
+		src.cycleDurationMs = 0;
+
+		std::vector<uint8_t> buf;
+		BuildLunarStateResponsePayload(src, buf);
+
+		LunarStateResponse dst;
+		assert(ParseLunarStateResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.phase == 0);
+		std::puts("[OK] TestEdgeCaseZero");
+	}
+}
+
+int main()
+{
+	TestStateRequestRoundTrip();
+	TestStateResponseRoundTrip();
+	TestStateResponseUnauthorized();
+	TestPhaseChangeRoundTrip();
+	TestPhaseChangeAllPhases();
+	TestStateResponseRejectShort();
+	TestStateResponseRejectExtra();
+	TestPhaseChangeRejectShort();
+	TestEdgeCaseMaxValues();
+	TestEdgeCaseZero();
+	std::puts("[ALL OK] LunarPayloadsTests");
+	return 0;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -777,4 +777,19 @@ namespace engine::network
 	constexpr uint16_t kOpcodeLootRollResultNotification  = 185u; ///< Master to Client (push, request_id=0) : roll terminee (rollId, winnerName, winnerChoice, winnerRoll uint8 0-100, itemTemplateId, itemName, count).
 	constexpr uint16_t kOpcodeLootSimulateRollRequest     = 186u; ///< Client to Master : DEBUG simule une roll (creator devient eligible) — V1 outil dev.
 	constexpr uint16_t kOpcodeLootSimulateRollResponse    = 187u; ///< Master to Client : OK + rollId, ou Unauthorized.
+
+	// =====================================================================
+	// Phase 5 step 3+4 — Lunar wire (16 phases lunaires synchronisees serveur
+	// -> client). Cycle de 14 jours reels (16 phases x ~21h chacune), calcul
+	// deterministe depuis epoch Unix. Master autoritaire ; client recoit
+	// l'etat initial sur EnterWorld puis un push toutes les ~21h sur
+	// changement de phase.
+	//
+	// Decoupage opcode :
+	//   - State                    (192/193)             : etat initial sur connexion.
+	//   - PhaseChangeNotification  (194, push, request_id=0) : changement de phase.
+	// =====================================================================
+	constexpr uint16_t kOpcodeLunarStateRequest             = 192u; ///< Client to Master : etat lunaire actuel (vide).
+	constexpr uint16_t kOpcodeLunarStateResponse            = 193u; ///< Master to Client : phase 0..15, illumination 0..1, cycleStart, cycleDuration.
+	constexpr uint16_t kOpcodeLunarPhaseChangeNotification  = 194u; ///< Master to Client (push, request_id=0) : changement de phase.
 }


### PR DESCRIPTION
## Cycle jour/nuit + 16 phases lunaires (Phase 5 step 3+4)

Implémentation du système de phases lunaires à 16 étapes synchronisé serveur ↔ client + tests du cycle jour/nuit existant. Cycle = 14 jours réels, 1 phase ≈ 21h, calcul déterministe depuis epoch Unix. Fil rouge thématique LCDLLN : la "Lune Noire" (phases 0/14/15) couvre ~21% du temps et servira à déclencher des events futurs.

### Spec & plan
- Spec : [docs/superpowers/specs/2026-05-10-day-night-lunar-cycle-design.md](docs/superpowers/specs/2026-05-10-day-night-lunar-cycle-design.md)
- Plan : [docs/superpowers/plans/2026-05-10-day-night-lunar-cycle.md](docs/superpowers/plans/2026-05-10-day-night-lunar-cycle.md)

### Server (master)
- `src/shared/network/ProtocolV1Constants.h` : opcodes 192-194 (State Request/Response + PhaseChangeNotification push broadcast)
- `src/shared/network/LunarPayloads.{h,cpp,Tests.cpp}` : 10 round-trip tests + edge cases (phase=0/15, illumination 0/1, timestamps 0/UINT64_MAX, reject short/extra)
- `src/shardd/world/LunarCalendar.h` (header-only) : `Compute(realNowMs, cycleStartMs, cycleDurationMs)` + `ComputeIllumination(phase)` + `NextChangeTsMs(...)`. Sinusoïde centrée sur Full Moon (index 7). Partagé master ↔ shardd (déterministe).
- `src/shardd/world/LunarCalendarTests.cpp` : 11 tests (round-trip phase ↔ time, edge cases, wrap, sinusoidal symmetry, no invalid phase).
- `src/masterd/handlers/lunar/LunarHandler.{h,cpp}` :
  - In-memory state (mutex protégé) + `Tick(realNowMs)` appelé toutes les 5 min depuis main_linux
  - Push broadcast à tous les clients connectés sur changement de phase (pas de subscribe explicite — la lune est globale)
  - `CurrentPhase()` exposé pour intégration future avec GameEvents
- `src/masterd/main_linux.cpp` : instanciation + dispatch opcode 192 + `&lunarHandler` ajouté à la capture-list lambda + Tick périodique 5 min + Tick initial au boot pour établir la phase courante

### Client
- `src/client/render/DayNightCycle.{h,cpp}` : extension State (`moonPhase` 0..15 + `moonIllumination` 0..1) + `OnLunarPhaseChange(phase, illumination)` callback (clamp invalid values)
- `src/client/render/DayNightCycleTests.cpp` : 9 tests (Init noon/midnight, sunrise/sunset transitions, time wrap, time scale clamp, advance 1h, lunar phase default/update/clamp)
- `src/client/render/SkyPass.{h,cpp}` : **NOUVEAU** pass Vulkan (sky.frag/vert existaient depuis M38.1 mais n'étaient pas wirés ; le ciel était juste `clearColor` issu de `DayNightCycle.skyHorizon`). Push constants 144 octets : `invViewProj` + `lightDir`/`zenithColor`/`horizonColor` + `moonDir`/`moonIntensity`/`moonPhase`/`moonIllumination`.
- `game/data/shaders/sky.frag` étendu : disque lunaire procédural via intersection 2 cercles + earthshine sur les phases sombres (0/1/2/13/14/15) + halo doux. Shader-only, ~30 lignes ajoutées.
- `src/client/app/Engine.{h,cpp}` :
  - Membre `m_skyPass` + `m_skyPassReady`
  - Init SkyPass au boot (load sky.vert.spv + sky.frag.spv via `tools/compile_game_shaders.ps1` qui les produit automatiquement)
  - Push handler dispatch opcodes 193 (State) + 194 (PhaseChange) → `m_dayNight.OnLunarPhaseChange(...)`
  - Fetch initial `LunarStateRequest` envoyé sur EnterWorld
  - Slash commands debug `/sky info`, `/sky time <hours>`, `/sky moon <phase 0..15>` (override local pour preview rapide)
  - `m_skyPass.Record(cmd, pushConstants)` invoqué dans le geometry pass recording lambda

### Build & tests
- 3 nouvelles cibles CTest : `lunar_payloads_tests`, `lunar_calendar_tests`, `daynight_cycle_tests`
- `CMakeLists.txt` : sources `engine_core` + 3 test executables
- `src/CMakeLists.txt` : sources `server_app` (LunarHandler + LunarPayloads)
- Shaders SPIR-V : compilation auto via `tools/compile_game_shaders.ps1` (auto-discover `*.vert/frag/comp`)

### V1 limitations consignées
- **Pas de modulation du `lightColor` nocturne par `moonIllumination`** : la pleine lune ne donne pas plus de lumière qu'une nouvelle lune. Future PR : moduler ambient light selon `moonIllumination`.
- **Pas de hook event lune ↔ GameEvents** : `LunarHandler::CurrentPhase()` est exposé mais non consommé. Future PR : extension de `GameEventManager` avec condition `requires_lunar_phase`.
- **Pas de texture surface lunaire** : disque uniformément gris (vec3(0.95, 0.92, 0.85)) + masque procédural. Future PR : texture cratère + normal map.
- **Master autoritaire** : `cycleStartMs` hardcodé au boot master (epoch fixe 2026-01-01 UTC). Suffisant car déterministe ; future PR pourra exposer `world.lunar.cycle_start` dans `config.json`.
- **Pas de SyncLunar RPC entre master et shardd** : shardd recompute localement via `LunarCalendar` si besoin (déterministe).

### Known visual rendering concerns (à itérer en follow-up)
1. **`depthTestEnable = FALSE`** sur SkyPass pipeline → fullscreen quad peut overdraw les bords de geometry. Fix futur : `depthCompareOp=GREATER_OR_EQUAL` à `depth=1.0`.
2. **Color blend attachment count mismatch** : SkyPass a `attachmentCount=1` mais le geometry render pass déclare 4 color attachments. Si Vulkan validation strict rejette le pipeline, `m_skyPassReady=false` et le moon disk ne rend pas (le `clearColor` fallback `skyHorizon` reste actif). Fix futur : ajouter 3 attachments avec `colorWriteMask=0`.
3. **Sky écrit dans GBuffer A (albedo)** : la lighting pass re-éclaire le disque lunaire comme une surface au lieu de self-luminous. Fix futur : écrire dans le scene-color attachment post-lighting.

Ces 3 concerns sont architecturaux (deferred pipeline + lighting integration) et nécessitent une plongée plus profonde. La feature pipeline (wire + master tick + slash commands + tests) fonctionne ; le rendu visuel est itérable.

### Tests fonctionnels disponibles immédiatement
- `lunar_calendar_tests` (11 tests) — calcul déterministe phase/illumination
- `lunar_payloads_tests` (10 tests) — round-trip wire
- `daynight_cycle_tests` (9 tests) — cycle existant + extension lunaire
- Slash commands `/sky info|time|moon` pour inspection in-game

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 192-194 + handler LunarHandler. Sans redéploiement, les requests Lunar d'un client neuf retourneraient BAD_REQUEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
