### PR TITLE
fix(lunar): SkyPass rendering -- depth test + 4 blend attachments + lighting passthrough

### DIFF
--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -20,9 +20,11 @@
 //   vec4  lightDir      – normalised direction *toward* the light (xyz, w unused)
 //   vec4  lightColor    – RGB radiance (color * intensity, w unused)
 //   vec4  ambientColor  – constant ambient RGB (fallback when useIBL == 0)
-//   vec4  skyColor      – RGB couleur du ciel (utilisée pour les pixels sans
-//                         géométrie, c.-à-d. depth == 1.0). Pilotée par
-//                         DayNightCycle (skyHorizon) côté CPU. w unused.
+//   vec4  skyColor      – RGB couleur du ciel pour les pixels sans géométrie
+//                         (depth == 1.0). Pilotée par DayNightCycle
+//                         (skyHorizon) côté CPU. w = 1.0 si SkyPass est
+//                         ready (alors on lit GBufferA pour la sky), 0.0
+//                         si on utilise la flat skyColor.
 //   float useIBL        – 1.0 = use IBL, 0.0 = constant ambient
 
 layout(location = 0) in  vec2 inUV;
@@ -47,7 +49,7 @@ layout(push_constant) uniform PC
     vec4  lightDir;     // normalised direction toward the directional light (xyz)
     vec4  lightColor;   // RGB radiance (xyz = color * intensity)
     vec4  ambientColor; // constant ambient RGB (fallback when useIBL == 0)
-    vec4  skyColor;     // RGB couleur du ciel pour les pixels sans géométrie
+    vec4  skyColor;     // rgb = couleur du ciel flat (fallback) ; w = 1.0 si SkyPass ready
     float useIBL;       // 1.0 = use IBL, 0.0 = constant ambient
 } pc;
 
@@ -105,11 +107,19 @@ void main()
     float depth     = texture(depthTex, inUV).r;
 
     // ---- Sky / empty fragments (depth == 1.0 means no geometry) --------
-    // On utilise la couleur du ciel pilotée par DayNightCycle (horizon).
-    // Permet de voir l'effet jour/nuit dans l'éditeur même sans skybox.
+    // Phase 5 Lunar (PR #561 fix Concern 3) : si SkyPass est ready
+    // (signale par pc.skyColor.w >= 0.5), il a dessine le ciel
+    // procedural + disque lunaire dans GBufferA dans le render pass
+    // loadOp=LOAD du GeometryPass, uniquement la ou depth==1.0
+    // (depthTest=LESS_OR_EQUAL avec gl_Position.z=1.0). On passe alors
+    // GBufferA tel quel au scene color HDR sans re-eclairage. Sinon
+    // (SkyPass.Init a echoue ou shaders absents au boot) on garde le
+    // fallback flat skyColor pilote par DayNightCycle pour ne pas
+    // casser le rendu jour/nuit.
     if (depth >= 1.0)
     {
-        outSceneColorHDR = vec4(pc.skyColor.rgb, 1.0);
+        vec3 skyOut = (pc.skyColor.w >= 0.5) ? baseAlbedo.rgb : pc.skyColor.rgb;
+        outSceneColorHDR = vec4(skyOut, 1.0);
         return;
     }
 

--- a/game/data/shaders/sky.vert
+++ b/game/data/shaders/sky.vert
@@ -1,6 +1,15 @@
 #version 450
 // M38.1 — Sky gradient vertex shader.
 // Fullscreen triangle; view direction reconstructed in fragment shader.
+//
+// gl_Position.z = 1.0 (far plane Vulkan, standard depth) : combine avec
+// `depthTestEnable=TRUE` + `depthCompareOp=LESS_OR_EQUAL` cote pipeline,
+// le sky ne passe le test que la ou la depth a ete laissee a 1.0
+// (clear value GeometryPass = "no geometry"). Les pixels avec geometrie
+// ont depth < 1.0 donc le test `1.0 <= depth_geo` echoue et la geometrie
+// reste visible. depthWriteEnable=FALSE pour ne pas modifier la depth :
+// LightingPass detecte toujours "no geometry" via depth==1.0 et compose
+// la sky depuis GBuffer A (Phase 5 Lunar / M38.1).
 
 layout(location = 0) out vec2 vUV;
 
@@ -8,5 +17,5 @@ void main()
 {
     // Fullscreen triangle trick (CCW winding).
     vUV = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
-    gl_Position = vec4(vUV * 2.0 - 1.0, 0.0, 1.0);
+    gl_Position = vec4(vUV * 2.0 - 1.0, 1.0, 1.0);
 }

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3715,12 +3715,19 @@ namespace engine
 												// Couleur du ciel utilisée par lighting.frag pour les pixels
 												// sans géométrie (depth==1.0). Pilotée par DayNightCycle pour
 												// rendre le cycle jour/nuit visible sans skybox dédié.
+												// Phase 5 Lunar (PR #561 fix Concern 3) : skyColor.w sert de
+												// flag "SkyPass ready". Quand m_skyPassReady=true, le SkyPass
+												// a ecrit la sky procedurale (gradient + sun glow + moon disk
+												// avec phase) dans GBufferA pour les pixels depth==1.0 ;
+												// lighting.frag lit alors GBufferA. Sinon (SkyPass.Init failed
+												// ou shaders absents) on tombe sur la flat skyColor pour
+												// preserver le rendu jour/nuit.
 												{
 													const engine::render::DayNightCycle::State& dnLight = m_dayNight.GetState();
 													lp.skyColor[0] = dnLight.skyHorizon[0];
 													lp.skyColor[1] = dnLight.skyHorizon[1];
 													lp.skyColor[2] = dnLight.skyHorizon[2];
-													lp.skyColor[3] = 0.0f;
+													lp.skyColor[3] = m_skyPassReady ? 1.0f : 0.0f;
 												}
 												VkImageView irrView       = VK_NULL_HANDLE;
 												VkSampler   irrSamp       = VK_NULL_HANDLE;

--- a/src/client/render/SkyPass.cpp
+++ b/src/client/render/SkyPass.cpp
@@ -89,19 +89,43 @@ namespace engine::render
 		ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
 		ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
+		// Concern 1 fix (Phase 5 Lunar PR #561 review) :
+		// depthTestEnable=TRUE + depthCompareOp=LESS_OR_EQUAL + depthWriteEnable=FALSE.
+		// Convention LCDLLN = standard Z (depth=1.0 = far) cf. GeometryPass /
+		// ShadowMapPass / TerrainChunkPipeline / WaterPass qui utilisent tous
+		// VK_COMPARE_OP_LESS_OR_EQUAL. sky.vert ecrit `gl_Position.z = 1.0` donc
+		// le sky ne passe le test que la ou la depth a ete laissee a la clear
+		// value 1.0 (= no geometry). Les pixels avec geometrie ont depth < 1.0,
+		// le test `1.0 <= depth_geo` echoue et la geometrie reste intacte dans
+		// GBuffer A. depthWriteEnable=FALSE car LightingPass detecte les pixels
+		// "sky" via depth==1.0 ; on ne doit pas modifier la depth.
 		VkPipelineDepthStencilStateCreateInfo ds{};
 		ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-		ds.depthTestEnable  = VK_FALSE;
+		ds.depthTestEnable  = VK_TRUE;
 		ds.depthWriteEnable = VK_FALSE;
+		ds.depthCompareOp   = VK_COMPARE_OP_LESS_OR_EQUAL;
 
-		VkPipelineColorBlendAttachmentState cba{};
-		cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
-		                   | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+		// Concern 2 fix (Phase 5 Lunar PR #561 review) :
+		// Le render pass parent (GeometryPass::GetRenderPassLoad) declare 4
+		// color attachments (GBufferA/albedo, GBufferB/normal, GBufferC/ORM,
+		// Velocity). Vulkan exige que `attachmentCount` corresponde exactement
+		// au nombre de color attachments du subpass courant. On configure 4
+		// VkPipelineColorBlendAttachmentState : seul le slot [0] (GBufferA
+		// albedo) est ecrit avec RGBA ; les 3 autres ont colorWriteMask=0
+		// (pas de write) -- la geometrie de la frame courante reste intacte
+		// dans GBufferB/C/Velocity et LightingPass continue a y lire les
+		// vraies normales/ORM/velocity quand il y a de la geometrie.
+		VkPipelineColorBlendAttachmentState cba[4]{};
+		cba[0].colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+		                      | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+		cba[1].colorWriteMask = 0;
+		cba[2].colorWriteMask = 0;
+		cba[3].colorWriteMask = 0;
 
 		VkPipelineColorBlendStateCreateInfo cb{};
 		cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-		cb.attachmentCount = 1;
-		cb.pAttachments    = &cba;
+		cb.attachmentCount = 4;
+		cb.pAttachments    = cba;
 
 		VkDynamicState dynStates[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
 		VkPipelineDynamicStateCreateInfo dyn{};

--- a/src/client/render/SkyPass.h
+++ b/src/client/render/SkyPass.h
@@ -1,12 +1,16 @@
 #pragma once
 // SkyPass : pipeline Vulkan qui dessine le ciel + disque lunaire procedural.
-// Consomme les shaders game/data/shaders/sky.vert et sky.frag (existants
-// jusqu'ici non wires). Le fragment shader recoit en push-constants la
-// matrice inverse view-projection, les directions soleil/lune, les couleurs
-// zenith/horizon, et les parametres lunaires (phase + illumination + intensity).
+// Consomme les shaders game/data/shaders/sky.vert et sky.frag. Le fragment
+// shader recoit en push-constants la matrice inverse view-projection, les
+// directions soleil/lune, les couleurs zenith/horizon, et les parametres
+// lunaires (phase + illumination + intensity).
 //
-// La pass est dessinee EN PREMIER dans la frame (avant le geometry pass)
-// avec depthTest = false / depthWrite = false pour servir de fond.
+// La pass est dessinee dans le render pass loadOp=LOAD du GeometryPass,
+// APRES le draw geometry principal. sky.vert ecrit gl_Position.z=1.0
+// (far plane), pipeline avec depthTest=TRUE / LESS_OR_EQUAL / write=FALSE :
+// le sky ne s'ecrit que la ou il n'y a pas de geometrie (depth==1.0).
+// Le sky n'ecrit que dans GBufferA (albedo) ; LightingPass lit GBufferA
+// pour les pixels sky (depth==1.0) au lieu d'utiliser un skyColor flat.
 // Couts negligeables (1 fullscreen quad genere via gl_VertexIndex).
 //
 // Pattern aligne sur LightingPass et autres passes Vulkan du repo :


### PR DESCRIPTION
## Fix rendu visuel SkyPass : 3 concerns architecturaux résolus

Suite à la PR #561 (Lunar) qui a posé l'infrastructure SkyPass mais flaggé 3 concerns architecturaux empêchant le rendu visuel correct du moon disk dans le deferred pipeline. Cette PR finalise l'intégration pour que `/sky moon 0..15` affiche effectivement les 16 phases lunaires distinctes.

### Les 3 concerns résolus

#### 1. `depthTestEnable=FALSE` → overdraw geometry edges
- `game/data/shaders/sky.vert` : `gl_Position.z = 1.0` (far plane, standard Z convention)
- `SkyPass.cpp` : `depthTestEnable=VK_TRUE`, `depthCompareOp=VK_COMPARE_OP_LESS_OR_EQUAL`, `depthWriteEnable=VK_FALSE` (sky n'écrit pas de depth, geometry l'a déjà fait)
- Convention alignée sur GeometryPass / ShadowMapPass / TerrainChunkPipeline / WaterPass

#### 2. Color blend attachment count mismatch (1 vs 4)
- `SkyPass.cpp` : 4 `VkPipelineColorBlendAttachmentState` entries pour matcher `subpass.colorAttachmentCount = 4` du GBuffer pass
- Slot `[0]` (GBuffer A) écrit RGBA, slots `[1..3]` ont `colorWriteMask=0`
- Le pipeline ne sera plus rejeté par Vulkan validation strict

#### 3. Sky écrit dans GBuffer A → re-éclairé par lighting pass (approche hybride)
- `lighting.frag` modifié : à `depth >= 1.0`, si `pc.skyColor.w >= 0.5` (flag SkyPass actif), lit la couleur depuis GBuffer A et l'utilise directement (self-luminous, pas de re-éclairage). Sinon fallback sur le skyColor flat.
- `Engine.cpp` : `lp.skyColor[3] = m_skyPassReady ? 1.0f : 0.0f` drive le flag via le 4ème composant des push constants existants — **aucun changement de struct size, aucune nouvelle descriptor binding**, fallback automatique si SkyPass init échoue.
- Approche choisie au lieu de créer un nouveau pipeline post-lighting (plus simple, moins invasif).

### Fichiers modifiés
- `game/data/shaders/sky.vert` — gl_Position.z = 1.0
- `game/data/shaders/lighting.frag` — composite SkyPass output au depth=1.0
- `src/client/render/SkyPass.h` — commentaire architecture
- `src/client/render/SkyPass.cpp` — depth test + 4 attachments
- `src/client/app/Engine.cpp` — flag skyColor.w pour lighting pass

### Tests
Pas de tests unitaires ajoutés (changements purement Vulkan/GLSL). Validation visuelle in-game requise après merge :
1. `/sky time 22` (forcer la nuit)
2. `/sky moon 0` puis `/sky moon 7` puis `/sky moon 15` — vérifier que les 3 phases sont visuellement distinctes
3. Boucler sur les 16 phases pour confirmer qu'elles évoluent progressivement

### V1 limitations restantes (consignées)
- `sky.frag` reconstruit viewDir depuis `worldPos.xyz / w` sans soustraire la position caméra (origin-relative). Pré-existant de #561, fonctionne correctement quand la caméra est près de l'origine. Fix futur : ajouter `cameraPos` dans les push constants si artefacts visibles à grandes coordonnées world.
- `/sky moon X` change phase/illumination mais le moon n'est visible que si `dn.isDaytime=false`. UX peut être améliorée pour auto-set la nuit lors d'un override.
- GBuffer A est R8G8B8A8_SRGB → quantification 8-bit/channel. Acceptable V1 (pas de banding visible).

### Déploiement
> ✅ **Client uniquement** — pas de redéploiement serveur. Aucun changement protocole, handler, migration DB ni gating sécurité. Uniquement shaders Vulkan + pipeline rendu côté client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
