### PR TITLE
diag(lunar): logs verbeux dans LunarHandler pour diagnostiquer prod silencieux

### DIFF
--- a/src/masterd/handlers/lunar/LunarHandler.cpp
+++ b/src/masterd/handlers/lunar/LunarHandler.cpp
@@ -53,14 +53,22 @@ namespace engine::server
 
 		LunarStateResponse resp;
 
+		LOG_INFO(Net, "[LunarHandler] HandleStateRequest received (connId={} requestId={} sessionIdHeader={})",
+			connId, requestId, static_cast<unsigned long long>(sessionIdHeader));
+
 		// Validation session : si pas de session valide -> Unauthorized.
 		if (m_connMap && m_sessionMgr)
 		{
 			auto sessIdOpt = m_connMap->GetSessionId(connId);
+			const uint64_t sessIdResolved = sessIdOpt.has_value() ? *sessIdOpt : 0u;
 			if (!sessIdOpt || *sessIdOpt == 0u || sessionIdHeader == 0u
 				|| *sessIdOpt != sessionIdHeader)
 			{
 				resp.status = LunarStatus::Unauthorized;
+				LOG_WARN(Net, "[LunarHandler] auth REJECTED (connId={} sessIdResolved={} sessionIdHeader={} match={})",
+					connId, static_cast<unsigned long long>(sessIdResolved),
+					static_cast<unsigned long long>(sessionIdHeader),
+					(sessIdOpt.has_value() && *sessIdOpt == sessionIdHeader) ? 1 : 0);
 			}
 			else
 			{
@@ -68,6 +76,14 @@ namespace engine::server
 				if (!accIdOpt || *accIdOpt == 0u)
 				{
 					resp.status = LunarStatus::Unauthorized;
+					LOG_WARN(Net, "[LunarHandler] auth REJECTED account_id missing (connId={} sessId={})",
+						connId, static_cast<unsigned long long>(sessIdResolved));
+				}
+				else
+				{
+					LOG_INFO(Net, "[LunarHandler] auth OK (connId={} sessId={} accountId={})",
+						connId, static_cast<unsigned long long>(sessIdResolved),
+						static_cast<unsigned long long>(*accIdOpt));
 				}
 			}
 		}
@@ -75,6 +91,8 @@ namespace engine::server
 		{
 			// Handler pas cable -> repond Unauthorized par defaut (defensive).
 			resp.status = LunarStatus::Unauthorized;
+			LOG_WARN(Net, "[LunarHandler] handler not wired (connMap={} sessionMgr={})",
+				m_connMap ? 1 : 0, m_sessionMgr ? 1 : 0);
 		}
 
 		if (resp.status == LunarStatus::Ok)
@@ -88,6 +106,10 @@ namespace engine::server
 			resp.illumination = info.illumination;
 			resp.cycleStartMs = m_cycleStartMs;
 			resp.cycleDurationMs = m_cycleDurationMs;
+			LOG_INFO(Net, "[LunarHandler] sending LunarStateResponse (connId={} phase={} illumination={:.3f} cycleStartMs={} cycleDurationMs={})",
+				connId, static_cast<unsigned>(resp.phase), resp.illumination,
+				static_cast<unsigned long long>(resp.cycleStartMs),
+				static_cast<unsigned long long>(resp.cycleDurationMs));
 		}
 
 		std::vector<uint8_t> payload;


### PR DESCRIPTION
## Logs diagnostic LunarHandler

Suite au déploiement de PR #561+#562+#563 sur le master de prod (build #1185), aucun log `[LunarHandler]` n'apparaît côté serveur même quand le client envoie l'opcode 192 sur EnterWorld. Cette PR ajoute des logs verbeux dans `HandleStateRequest` pour diagnostiquer la source du problème.

### Logs ajoutés

**À la réception du packet** :
```
[LunarHandler] HandleStateRequest received (connId=X requestId=Y sessionIdHeader=Z)
```

**Si auth rejected** (3 cas distincts visibles dans le log) :
```
[LunarHandler] auth REJECTED (connId=X sessIdResolved=Y sessionIdHeader=Z match=0|1)
```
- `sessIdResolved=0` → la session n'est pas dans `m_connMap` pour ce connId
- `sessionIdHeader=0` → le client a envoyé un packet sans session ID
- `match=0` → mismatch entre la session connue et celle dans le packet

**Si auth OK** :
```
[LunarHandler] auth OK (connId=X sessId=Y accountId=Z)
[LunarHandler] sending LunarStateResponse (connId=X phase=N illumination=0.NNN cycleStartMs=... cycleDurationMs=...)
```

**Si handler pas câblé** :
```
[LunarHandler] handler not wired (connMap=0|1 sessionMgr=0|1)
```

### Ce que ça permettra de voir

Après merge + redéploiement master, à chaque login + EnterWorld le client envoie opcode 192 — on verra :
1. Si le handler est bien invoqué
2. Si l'auth check passe ou rejette
3. La phase courante calculée depuis l'epoch (devrait être ~3 aujourd'hui pour cycleStart=2026-01-01)

Si on ne voit AUCUN `[LunarHandler] HandleStateRequest received` → le dispatch dans `main_linux.cpp` ne route pas l'opcode 192 (à investigate).

### Pas de changement de comportement

Logs uniquement. Pas de modification de la logique d'auth ni du payload.

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** pour activer les nouveaux logs (sinon on continue de diagnostiquer en aveugle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
