### PR TITLE
feat(admin): AdminCommandHandler RBAC + audit log + pilote /sky moon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ add_library(engine_core
   src/shared/network/AuctionPayloads.cpp
   src/shared/network/LootPayloads.cpp
   src/shared/network/LunarPayloads.cpp
+  src/shared/network/AdminCommandPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
   src/shared/network/SkillPayloads.cpp
@@ -756,6 +757,11 @@ add_test(NAME loot_payloads_tests COMMAND loot_payloads_tests)
 add_executable(lunar_payloads_tests src/shared/network/LunarPayloadsTests.cpp)
 target_link_libraries(lunar_payloads_tests PRIVATE engine_core)
 add_test(NAME lunar_payloads_tests COMMAND lunar_payloads_tests)
+
+# AdminCommand RBAC — round-trip tests payloads (195/196).
+add_executable(admin_command_payloads_tests src/shared/network/AdminCommandPayloadsTests.cpp)
+target_link_libraries(admin_command_payloads_tests PRIVATE engine_core)
+add_test(NAME admin_command_payloads_tests COMMAND admin_command_payloads_tests)
 
 # Phase 5 Lunar — calendar deterministe tests (header-only).
 add_executable(lunar_calendar_tests src/shardd/world/LunarCalendarTests.cpp)

--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -205,9 +205,9 @@
       "minRole": "administrator",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "client_only_legacy",
-      "implementation_file": "src/client/app/Engine.cpp:1363",
-      "notes": "Visual override only ; valid phases 0..15 (NewMoon..EarthshineLate)."
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Pilot migration AdminCommand RBAC : client envoie au master (opcode 195) qui valide le role administrator + log audit, master repond Ok+result (opcode 196), client applique l'override visuel uniquement apres ACK. Valid phases 0..15 (NewMoon..EarthshineLate)."
     },
     {
       "command": "/ticket",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/loot/LootHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lunar/LunarHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/admin/AdminCommandHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/admin/SlashCommandRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/IgnoreListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/MailPayloads.cpp
@@ -149,6 +151,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LootPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LunarPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/AdminCommandPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatCommandRouter.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -22,6 +22,7 @@
 #include "src/shared/network/AuctionPayloads.h"
 #include "src/shared/network/LootPayloads.h"
 #include "src/shared/network/LunarPayloads.h"
+#include "src/shared/network/AdminCommandPayloads.h"
 #include "src/shared/network/LfgPayloads.h"
 #include "src/shared/network/CinematicPayloads.h"
 #include "src/shared/network/SkillPayloads.h"
@@ -1371,13 +1372,18 @@ namespace engine
 					LOG_WARN(Render, "[Sky] phase {} hors plage [0..15]", phase);
 					return true;
 				}
-				// Calcul illumination locale (cf. LunarCalendar::ComputeIllumination).
-				constexpr float kPi = 3.14159265358979323846f;
-				float t = (static_cast<float>(phase) - 7.0f) * (kPi / 8.0f);
-				float illumination = 0.5f * (1.0f + std::cos(t));
-				m_dayNight.OnLunarPhaseChange(static_cast<uint8_t>(phase), illumination);
-				LOG_INFO(Render, "[Sky] moon phase override: {} illumination={:.0f}% (master state inchange)",
-					phase, illumination * 100.0f);
+				// AdminCommand RBAC pilot : /sky moon est admin-only. On envoie au
+				// master qui valide le role + log audit + retourne Ok/Denied.
+				// Le client applique l'override visuel SEULEMENT apres ACK Ok
+				// (voir dispatch kOpcodeAdminCommandResponse plus bas).
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/sky moon";
+				req.args.push_back(std::to_string(phase));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Render, "[Sky] /sky moon {} sent to master for RBAC validation", phase);
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -2237,6 +2243,56 @@ namespace engine
 				m_dayNight.OnLunarPhaseChange(parsed.newPhase, parsed.newIllumination);
 				LOG_INFO(Render, "[Engine] LunarPhaseChange: phase={} illumination={:.3f}",
 					static_cast<unsigned>(parsed.newPhase), parsed.newIllumination);
+				return;
+			}
+			// AdminCommand RBAC — reponse master apres validation du role +
+			// log audit. Si status==Ok, on dispatch sur le nom de la commande
+			// pour appliquer l'effet local (ex: /sky moon -> override visuel).
+			// Sinon on log le refus.
+			case kOpcodeAdminCommandResponse:
+			{
+				engine::network::admin::AdminCommandResponse parsed;
+				if (!engine::network::admin::ParseAdminCommandResponsePayload(payload, payloadSize, parsed))
+				{
+					LOG_WARN(Net, "[Engine] ADMIN_COMMAND_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				if (parsed.status == engine::network::admin::AdminCommandStatus::Ok)
+				{
+					if (parsed.command == "/sky moon")
+					{
+						// Parse echoed args : ["phase=7", "illumination=1.000"]
+						uint8_t phase = 0;
+						float illumination = 0.0f;
+						for (const auto& kv : parsed.result)
+						{
+							if (kv.starts_with("phase="))
+							{
+								try { phase = static_cast<uint8_t>(std::stoi(kv.substr(6))); }
+								catch (...) { phase = 0; }
+							}
+							else if (kv.starts_with("illumination="))
+							{
+								try { illumination = std::stof(kv.substr(13)); }
+								catch (...) { illumination = 0.0f; }
+							}
+						}
+						m_dayNight.OnLunarPhaseChange(phase, illumination);
+						LOG_INFO(Render, "[Sky] /sky moon ACK applied : phase={} illumination={:.3f}",
+							static_cast<unsigned>(phase), illumination);
+					}
+					else
+					{
+						LOG_INFO(Net, "[AdminCommand] OK : command={} (no client effect V1)", parsed.command);
+					}
+				}
+				else
+				{
+					LOG_WARN(Net, "[AdminCommand] REFUSED command={} status={} message={}",
+						parsed.command,
+						static_cast<unsigned>(parsed.status),
+						parsed.message);
+				}
 				return;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Dispatch des reponses LFG

--- a/src/masterd/admin/SlashCommandRegistry.cpp
+++ b/src/masterd/admin/SlashCommandRegistry.cpp
@@ -1,0 +1,353 @@
+// Implementation SlashCommandRegistry : parsing JSON minimal embarque
+// (le projet n'a pas de bibliotheque JSON publique exposee, et le parser
+// dans Config.cpp est interne anonymous-namespace). On reste minimaliste :
+// on n'a besoin que d'objets, arrays, strings, et booleens. Pas de support
+// numbers ni escapes complexes : les valeurs utilisees dans
+// slash_commands.json sont strings + arrays + booleans + un seul int
+// "_version" qu'on ignore.
+
+#include "src/masterd/admin/SlashCommandRegistry.h"
+
+#include "src/shared/core/Log.h"
+
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		// ---- Mini parser JSON ------------------------------------------
+		// Subset suffisant pour slash_commands.json : object, array, string,
+		// number (skipped), bool, null. Les escapes pris en charge sont \"
+		// \\ \/ \b \f \n \r \t.
+
+		struct JsonNode;
+		using JsonObject = std::unordered_map<std::string, JsonNode>;
+		using JsonArray  = std::vector<JsonNode>;
+
+		struct JsonNode
+		{
+			enum class Type { Null, Bool, Number, String, Array, Object };
+			Type        type = Type::Null;
+			bool        b    = false;
+			double      n    = 0.0;
+			std::string s;
+			JsonArray   a;
+			JsonObject  o;
+		};
+
+		/// Avance le curseur sur les espaces (incluant tabs / newlines).
+		void SkipWs(const std::string& src, size_t& pos)
+		{
+			while (pos < src.size() && std::isspace(static_cast<unsigned char>(src[pos])))
+				++pos;
+		}
+
+		bool ParseValue(const std::string& src, size_t& pos, JsonNode& out);
+
+		/// Parse une chaine JSON entre guillemets (escapes basiques).
+		bool ParseStringLit(const std::string& src, size_t& pos, std::string& out)
+		{
+			if (pos >= src.size() || src[pos] != '"') return false;
+			++pos;
+			out.clear();
+			while (pos < src.size())
+			{
+				const char c = src[pos++];
+				if (c == '"') return true;
+				if (c == '\\')
+				{
+					if (pos >= src.size()) return false;
+					const char e = src[pos++];
+					switch (e)
+					{
+					case '"':  out.push_back('"'); break;
+					case '\\': out.push_back('\\'); break;
+					case '/':  out.push_back('/'); break;
+					case 'b':  out.push_back('\b'); break;
+					case 'f':  out.push_back('\f'); break;
+					case 'n':  out.push_back('\n'); break;
+					case 'r':  out.push_back('\r'); break;
+					case 't':  out.push_back('\t'); break;
+					case 'u':
+						// On skip les 4 hex chars (pas de support unicode complet).
+						if (pos + 4 > src.size()) return false;
+						pos += 4;
+						out.push_back('?');
+						break;
+					default:   return false;
+					}
+				}
+				else
+				{
+					out.push_back(c);
+				}
+			}
+			return false;
+		}
+
+		/// Parse un object {"key":value, ...}.
+		bool ParseObject(const std::string& src, size_t& pos, JsonNode& out)
+		{
+			if (pos >= src.size() || src[pos] != '{') return false;
+			++pos;
+			out.type = JsonNode::Type::Object;
+			SkipWs(src, pos);
+			if (pos < src.size() && src[pos] == '}') { ++pos; return true; }
+			while (pos < src.size())
+			{
+				SkipWs(src, pos);
+				std::string key;
+				if (!ParseStringLit(src, pos, key)) return false;
+				SkipWs(src, pos);
+				if (pos >= src.size() || src[pos] != ':') return false;
+				++pos;
+				SkipWs(src, pos);
+				JsonNode val;
+				if (!ParseValue(src, pos, val)) return false;
+				out.o.emplace(std::move(key), std::move(val));
+				SkipWs(src, pos);
+				if (pos < src.size() && src[pos] == ',') { ++pos; continue; }
+				if (pos < src.size() && src[pos] == '}') { ++pos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		/// Parse un array [val, val, ...].
+		bool ParseArray(const std::string& src, size_t& pos, JsonNode& out)
+		{
+			if (pos >= src.size() || src[pos] != '[') return false;
+			++pos;
+			out.type = JsonNode::Type::Array;
+			SkipWs(src, pos);
+			if (pos < src.size() && src[pos] == ']') { ++pos; return true; }
+			while (pos < src.size())
+			{
+				SkipWs(src, pos);
+				JsonNode val;
+				if (!ParseValue(src, pos, val)) return false;
+				out.a.push_back(std::move(val));
+				SkipWs(src, pos);
+				if (pos < src.size() && src[pos] == ',') { ++pos; continue; }
+				if (pos < src.size() && src[pos] == ']') { ++pos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		/// Parse un nombre JSON (entier ou decimal). Accepte le signe negatif
+		/// et la notation scientifique 'e'/'E'. La valeur n'est pas utilisee
+		/// par les consommateurs actuels mais on remplit \c n.
+		bool ParseNumber(const std::string& src, size_t& pos, JsonNode& out)
+		{
+			const size_t start = pos;
+			if (pos < src.size() && src[pos] == '-') ++pos;
+			bool any = false;
+			while (pos < src.size() && std::isdigit(static_cast<unsigned char>(src[pos])))
+			{
+				any = true;
+				++pos;
+			}
+			if (pos < src.size() && src[pos] == '.')
+			{
+				++pos;
+				while (pos < src.size() && std::isdigit(static_cast<unsigned char>(src[pos])))
+				{
+					any = true;
+					++pos;
+				}
+			}
+			if (pos < src.size() && (src[pos] == 'e' || src[pos] == 'E'))
+			{
+				++pos;
+				if (pos < src.size() && (src[pos] == '+' || src[pos] == '-')) ++pos;
+				while (pos < src.size() && std::isdigit(static_cast<unsigned char>(src[pos])))
+				{
+					any = true;
+					++pos;
+				}
+			}
+			if (!any) return false;
+			out.type = JsonNode::Type::Number;
+			try { out.n = std::stod(src.substr(start, pos - start)); }
+			catch (...) { return false; }
+			return true;
+		}
+
+		/// Parse n'importe quelle valeur JSON.
+		bool ParseValue(const std::string& src, size_t& pos, JsonNode& out)
+		{
+			SkipWs(src, pos);
+			if (pos >= src.size()) return false;
+			const char c = src[pos];
+			if (c == '{') return ParseObject(src, pos, out);
+			if (c == '[') return ParseArray(src, pos, out);
+			if (c == '"')
+			{
+				out.type = JsonNode::Type::String;
+				return ParseStringLit(src, pos, out.s);
+			}
+			if (c == 't' && src.compare(pos, 4, "true") == 0)
+			{
+				pos += 4; out.type = JsonNode::Type::Bool; out.b = true; return true;
+			}
+			if (c == 'f' && src.compare(pos, 5, "false") == 0)
+			{
+				pos += 5; out.type = JsonNode::Type::Bool; out.b = false; return true;
+			}
+			if (c == 'n' && src.compare(pos, 4, "null") == 0)
+			{
+				pos += 4; out.type = JsonNode::Type::Null; return true;
+			}
+			return ParseNumber(src, pos, out);
+		}
+
+		/// Lit un fichier complet en memoire.
+		bool ReadFile(const std::string& path, std::string& out)
+		{
+			std::ifstream f(path, std::ios::binary);
+			if (!f) return false;
+			std::ostringstream ss;
+			ss << f.rdbuf();
+			out = ss.str();
+			return true;
+		}
+
+		/// Extrait le prefixe canonique d'une commande declaree :
+		/// "/sky moon <phase 0..15>" -> "/sky moon"
+		/// "/ban <player> <reason>"  -> "/ban"
+		/// "/who"                    -> "/who"
+		///
+		/// Regle : on coupe au premier espace suivi par '<' ou par toute autre
+		/// chose qui n'est pas un mot. En pratique on coupe au premier '<'
+		/// (en remontant le dernier espace pour ne pas garder l'espace).
+		std::string ExtractCanonical(const std::string& declared)
+		{
+			const size_t lt = declared.find('<');
+			if (lt == std::string::npos)
+				return declared; // pas de placeholder, c'est deja canonique
+			// Remonte le dernier espace avant le '<' pour exclure le separateur.
+			size_t end = lt;
+			while (end > 0 && std::isspace(static_cast<unsigned char>(declared[end - 1])))
+				--end;
+			return declared.substr(0, end);
+		}
+
+		/// Lookup helper : retourne pointeur vers l'entree d'un objet
+		/// JSON-Object ou nullptr si la cle est absente / pas du bon type.
+		const JsonNode* FindString(const JsonObject& o, const char* key)
+		{
+			auto it = o.find(key);
+			if (it == o.end() || it->second.type != JsonNode::Type::String) return nullptr;
+			return &it->second;
+		}
+		const JsonNode* FindArray(const JsonObject& o, const char* key)
+		{
+			auto it = o.find(key);
+			if (it == o.end() || it->second.type != JsonNode::Type::Array) return nullptr;
+			return &it->second;
+		}
+	}
+
+	bool SlashCommandRegistry::LoadFromFile(const std::string& jsonPath)
+	{
+		std::string raw;
+		if (!ReadFile(jsonPath, raw))
+		{
+			LOG_WARN(Net, "[SlashCommandRegistry] cannot open {}", jsonPath);
+			return false;
+		}
+
+		size_t pos = 0;
+		JsonNode root;
+		if (!ParseValue(raw, pos, root) || root.type != JsonNode::Type::Object)
+		{
+			LOG_WARN(Net, "[SlashCommandRegistry] JSON parse failed for {}", jsonPath);
+			return false;
+		}
+
+		const JsonNode* commandsArr = FindArray(root.o, "commands");
+		if (!commandsArr)
+		{
+			LOG_WARN(Net, "[SlashCommandRegistry] missing 'commands' array in {}", jsonPath);
+			return false;
+		}
+
+		m_entries.clear();
+		m_byName.clear();
+		m_entries.reserve(commandsArr->a.size());
+
+		for (const JsonNode& item : commandsArr->a)
+		{
+			if (item.type != JsonNode::Type::Object) continue;
+			const JsonNode* cmdNode = FindString(item.o, "command");
+			if (!cmdNode || cmdNode->s.empty()) continue;
+
+			SlashCommandEntry entry;
+			entry.command = ExtractCanonical(cmdNode->s);
+
+			if (const JsonNode* aliasArr = FindArray(item.o, "aliases"))
+			{
+				for (const JsonNode& aliasItem : aliasArr->a)
+				{
+					if (aliasItem.type == JsonNode::Type::String && !aliasItem.s.empty())
+						entry.aliases.push_back(aliasItem.s);
+				}
+			}
+
+			AccountRole minRole = AccountRole::Player;
+			if (const JsonNode* roleNode = FindString(item.o, "minRole"))
+				minRole = ParseRole(roleNode->s);
+			entry.minRole = minRole;
+
+			if (const JsonNode* statusNode = FindString(item.o, "status"))
+				entry.status = statusNode->s;
+
+			const size_t idx = m_entries.size();
+			m_entries.push_back(std::move(entry));
+
+			// Index par canonique + alias.
+			m_byName[m_entries[idx].command] = idx;
+			for (const auto& alias : m_entries[idx].aliases)
+				m_byName[alias] = idx;
+		}
+
+		LOG_INFO(Net, "[SlashCommandRegistry] loaded {} commands from {}",
+			m_entries.size(), jsonPath);
+		return !m_entries.empty();
+	}
+
+	const SlashCommandEntry* SlashCommandRegistry::Lookup(const std::string& command) const
+	{
+		auto it = m_byName.find(command);
+		if (it == m_byName.end()) return nullptr;
+		return &m_entries[it->second];
+	}
+
+	SlashCommandRegistry::CheckResult SlashCommandRegistry::Check(
+		const std::string& command, AccountRole userRole) const
+	{
+		CheckResult r;
+		const SlashCommandEntry* e = Lookup(command);
+		if (!e)
+		{
+			r.found = false;
+			r.allowed = false;
+			r.minRequired = AccountRole::Player;
+			return r;
+		}
+		r.found = true;
+		r.minRequired = e->minRole;
+		r.allowed = (userRole >= e->minRole);
+		return r;
+	}
+}

--- a/src/masterd/admin/SlashCommandRegistry.h
+++ b/src/masterd/admin/SlashCommandRegistry.h
@@ -1,0 +1,79 @@
+#pragma once
+// SlashCommandRegistry : charge le fichier de reference des slash commands
+// (game/data/config/slash_commands.json) au boot du master, expose un
+// lookup par nom (canonical ou alias) + verification du role minimum.
+//
+// La lecture est faite une seule fois au boot ; pas de hot-reload V1.
+// Le registre est read-only apres LoadFromFile (pas de mutex), ce qui
+// permet aux handlers de l'interroger sans synchronisation.
+//
+// Format JSON attendu (cf. game/data/config/slash_commands.json) :
+//   { "commands": [ { "command":"/sky moon <phase 0..15>", "aliases":[...],
+//                     "minRole":"administrator", "status":"implemented" }, ... ] }
+//
+// Convention V1 : on extrait le prefixe canonique d'une commande sans la
+// portion "<arg>" pour l'indexer (ex: "/sky moon <phase 0..15>" -> "/sky moon").
+// Le client envoie toujours la forme canonique sans placeholder, donc un
+// Lookup("/sky moon") doit reussir.
+
+#include "src/masterd/account/AccountRole.h"
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	/// Une entree du registre, partagee par toutes les cles indexees
+	/// (le canonical et chaque alias pointent vers la meme entree par valeur).
+	struct SlashCommandEntry
+	{
+		std::string                command;   ///< Forme canonique (sans placeholder), ex: "/sky moon".
+		std::vector<std::string>   aliases;   ///< Aliases ex: ["/sky"] pour "/sky info".
+		engine::server::AccountRole minRole = engine::server::AccountRole::Player;
+		std::string                status;    ///< "implemented" / "client_only_legacy" / etc. (info).
+	};
+
+	/// Registre des slash commands lu au boot. Read-only apres LoadFromFile.
+	class SlashCommandRegistry
+	{
+	public:
+		/// Resultat d'une verification de droits.
+		struct CheckResult
+		{
+			bool        found       = false; ///< true si la commande existe dans le registre.
+			bool        allowed     = false; ///< true si \p userRole >= entry.minRole.
+			AccountRole minRequired = AccountRole::Player; ///< Role minimum exige (info pour message).
+		};
+
+		SlashCommandRegistry() = default;
+
+		/// Charge le fichier JSON. Retourne true si parsing reussi et au
+		/// moins une commande chargee. En cas d'echec partiel (entree
+		/// invalide), elle est ignoree avec un warning ; le reste est charge.
+		///
+		/// \param jsonPath chemin relatif ou absolu au fichier slash_commands.json.
+		/// \return true si le fichier a ete lu et au moins une commande indexee.
+		bool LoadFromFile(const std::string& jsonPath);
+
+		/// Lookup par nom. Accepte la forme canonique ("/sky moon") ou un alias
+		/// (ex: "/sky"). Retourne nullptr si non trouve.
+		const SlashCommandEntry* Lookup(const std::string& command) const;
+
+		/// Verifie si \p userRole peut executer \p command. Retourne :
+		///   {found:false, allowed:false, minRequired:Player} si commande inconnue
+		///   {found:true, allowed:true, minRequired:<min>}    si role suffisant
+		///   {found:true, allowed:false, minRequired:<min>}   si role insuffisant
+		CheckResult Check(const std::string& command, AccountRole userRole) const;
+
+		/// Nombre d'entrees uniques chargees (pas le total des cles indexees).
+		size_t Size() const { return m_entries.size(); }
+
+	private:
+		/// Stockage canonique par valeur (une entree par commande).
+		std::vector<SlashCommandEntry> m_entries;
+		/// Index par nom (canonique + alias) -> indice dans m_entries.
+		std::unordered_map<std::string, size_t> m_byName;
+	};
+}

--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -1,0 +1,248 @@
+// Implementation AdminCommandHandler : dispatch + audit log obligatoire.
+// Cf. AdminCommandHandler.h pour la spec et docs/slash_commands_rbac.md
+// pour la convention.
+
+#include "src/masterd/handlers/admin/AdminCommandHandler.h"
+
+#include "src/masterd/account/AccountRole.h"
+#include "src/masterd/account/AccountRoleService.h"
+#include "src/masterd/admin/SlashCommandRegistry.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shardd/world/LunarCalendar.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/AdminCommandPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		/// Convertit AdminCommandStatus -> mot-cle court pour le format de log.
+		const char* StatusToLogTag(engine::network::admin::AdminCommandStatus s)
+		{
+			using namespace engine::network::admin;
+			switch (s)
+			{
+			case AdminCommandStatus::Ok:             return "OK";
+			case AdminCommandStatus::Unauthorized:   return "UNAUTHORIZED";
+			case AdminCommandStatus::Denied:         return "DENIED";
+			case AdminCommandStatus::UnknownCommand: return "UNKNOWN_COMMAND";
+			case AdminCommandStatus::InvalidArgs:    return "INVALID_ARGS";
+			case AdminCommandStatus::ServerError:    return "ERROR";
+			}
+			return "UNKNOWN";
+		}
+
+		/// Concatene les arguments en "[a1,a2,...]" pour le log audit.
+		std::string FormatArgs(const std::vector<std::string>& args)
+		{
+			std::string out;
+			out.push_back('[');
+			for (size_t i = 0; i < args.size(); ++i)
+			{
+				if (i > 0) out.push_back(',');
+				out += args[i];
+			}
+			out.push_back(']');
+			return out;
+		}
+
+		/// Emet le log audit obligatoire selon le format
+		/// docs/slash_commands_rbac.md. Subsystem "Audit" (les macros
+		/// LOG_* utilisent une string runtime, donc n'importe quel nom
+		/// fonctionne ; les filtres log.subsystem_files peuvent router).
+		void LogAudit(uint64_t accountId,
+		              engine::server::AccountRole role,
+		              const std::string& command,
+		              const std::vector<std::string>& args,
+		              engine::network::admin::AdminCommandStatus status)
+		{
+			LOG_INFO(Audit,
+				"[AdminCommand] account_id={} role={} command=\"{}\" args={} result={}",
+				static_cast<unsigned long long>(accountId),
+				engine::server::RoleToString(role),
+				command,
+				FormatArgs(args),
+				StatusToLogTag(status));
+		}
+
+		/// Envoie la reponse 196 sur la connexion donnee. Si \p server est nullptr,
+		/// no-op silencieux (le log audit a deja ete emis par le caller).
+		void SendResponse(NetServer* server, uint32_t connId, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const engine::network::admin::AdminCommandResponse& resp)
+		{
+			using namespace engine::network::admin;
+			using namespace engine::network;
+			std::vector<uint8_t> payload;
+			BuildAdminCommandResponsePayload(resp, payload);
+
+			PacketBuilder builder;
+			ByteWriter w = builder.PayloadWriter();
+			if (w.Remaining() < payload.size()) return;
+			if (!w.WriteBytes(payload.data(), payload.size())) return;
+			if (!builder.Finalize(kOpcodeAdminCommandResponse, 0u, requestId,
+			                      sessionIdHeader, payload.size())) return;
+			if (server) server->Send(connId, builder.Data());
+		}
+
+		/// Resout (sessionId, accountId) a partir du connId + sessionIdHeader.
+		/// Retourne true si l'auth est valide. Sortie : \p outAccountId.
+		bool ResolveAuth(ConnectionSessionMap* connMap, SessionManager* sessionMgr,
+		                 uint32_t connId, uint64_t sessionIdHeader,
+		                 uint64_t& outAccountId)
+		{
+			outAccountId = 0;
+			if (!connMap || !sessionMgr) return false;
+			auto sessIdOpt = connMap->GetSessionId(connId);
+			if (!sessIdOpt || *sessIdOpt == 0u || sessionIdHeader == 0u
+			    || *sessIdOpt != sessionIdHeader)
+				return false;
+			auto accIdOpt = sessionMgr->GetAccountId(*sessIdOpt);
+			if (!accIdOpt || *accIdOpt == 0u) return false;
+			outAccountId = *accIdOpt;
+			return true;
+		}
+
+		/// Dispatch metier pour "/sky moon <phase>". Valide l'argument et
+		/// remplit \p resp avec status + result echo.
+		///
+		/// \return true si l'execution a reussi (status Ok rempli), false
+		///         si arguments invalides (status InvalidArgs rempli).
+		bool DispatchSkyMoon(const std::vector<std::string>& args,
+		                     engine::network::admin::AdminCommandResponse& resp)
+		{
+			using namespace engine::network::admin;
+			if (args.size() != 1)
+			{
+				resp.status = AdminCommandStatus::InvalidArgs;
+				resp.message = "Usage : /sky moon <phase 0..15>";
+				return false;
+			}
+			int phase = -1;
+			try { phase = std::stoi(args[0]); }
+			catch (...) { phase = -1; }
+			if (phase < 0 || phase > 15)
+			{
+				resp.status = AdminCommandStatus::InvalidArgs;
+				resp.message = "phase doit etre dans 0..15";
+				return false;
+			}
+			const float illumination =
+				engine::server::world::LunarCalendar::ComputeIllumination(static_cast<uint8_t>(phase));
+
+			char phaseBuf[32];
+			char illumBuf[32];
+			std::snprintf(phaseBuf, sizeof(phaseBuf), "phase=%d", phase);
+			std::snprintf(illumBuf, sizeof(illumBuf), "illumination=%.3f", illumination);
+
+			resp.status = AdminCommandStatus::Ok;
+			resp.result.push_back(phaseBuf);
+			resp.result.push_back(illumBuf);
+			resp.message = "OK";
+			return true;
+		}
+	}
+
+	void AdminCommandHandler::HandlePacket(uint32_t connId, uint16_t opcode,
+	                                       uint32_t requestId, uint64_t sessionIdHeader,
+	                                       const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		if (opcode != kOpcodeAdminCommandRequest) return;
+		HandleRequest(connId, requestId, sessionIdHeader, payload, payloadSize);
+	}
+
+	void AdminCommandHandler::HandleRequest(uint32_t connId, uint32_t requestId,
+	                                        uint64_t sessionIdHeader,
+	                                        const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network::admin;
+
+		AdminCommandRequest req;
+		AdminCommandResponse resp;
+
+		// Parse le payload : si invalide, on log avec command="" et InvalidArgs.
+		if (!ParseAdminCommandRequestPayload(payload, payloadSize, req))
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "payload mal forme";
+			LogAudit(0, AccountRole::Player, "<malformed>", {}, resp.status);
+			SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+			return;
+		}
+		resp.command = req.command;
+
+		// Auth : resolve session + accountId.
+		uint64_t accountId = 0;
+		if (!ResolveAuth(m_connMap, m_sessionMgr, connId, sessionIdHeader, accountId))
+		{
+			resp.status = AdminCommandStatus::Unauthorized;
+			resp.message = "Session invalide";
+			LogAudit(0, AccountRole::Player, req.command, req.args, resp.status);
+			SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+			return;
+		}
+
+		// Role lookup. Sans roleService, on considere Player par defaut.
+		AccountRole userRole = AccountRole::Player;
+		if (m_roleService)
+			userRole = m_roleService->GetRole(accountId);
+
+		// Lookup commande dans le registre.
+		if (!m_registry)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "Registre slash_commands non charge";
+			LogAudit(accountId, userRole, req.command, req.args, resp.status);
+			SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+			return;
+		}
+		const auto check = m_registry->Check(req.command, userRole);
+		if (!check.found)
+		{
+			resp.status = AdminCommandStatus::UnknownCommand;
+			resp.message = "Commande inconnue : " + req.command;
+			LogAudit(accountId, userRole, req.command, req.args, resp.status);
+			SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+			return;
+		}
+		if (!check.allowed)
+		{
+			resp.status = AdminCommandStatus::Denied;
+			resp.message = "Permission refusee : role ";
+			resp.message += engine::server::RoleToString(check.minRequired);
+			resp.message += " requis";
+			LogAudit(accountId, userRole, req.command, req.args, resp.status);
+			SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+			return;
+		}
+
+		// Dispatch metier par nom de commande.
+		bool handled = false;
+		if (req.command == "/sky moon")
+		{
+			DispatchSkyMoon(req.args, resp);
+			handled = true;
+		}
+
+		// V1 stub : pour les autres commandes connues, status Ok mais result vide.
+		// Les futures PR ajouteront les dispatchers specifiques (kick, ban, etc.).
+		if (!handled)
+		{
+			resp.status = AdminCommandStatus::Ok;
+			resp.message = "OK (V1 stub : commande connue mais effet metier pas encore implemente)";
+		}
+
+		LogAudit(accountId, userRole, req.command, req.args, resp.status);
+		SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+	}
+}

--- a/src/masterd/handlers/admin/AdminCommandHandler.h
+++ b/src/masterd/handlers/admin/AdminCommandHandler.h
@@ -1,0 +1,82 @@
+#pragma once
+// AdminCommandHandler : dispatcher central pour TOUTES les slash commands
+// avec RBAC + audit log. Pattern strict comme LunarHandler / GameEventHandler.
+//
+// Ce handler traite les opcodes 195/196 (cf. ProtocolV1Constants.h). Il
+// effectue les verifications dans cet ordre :
+//   1. Auth (session valide + accountId resolu) -> sinon Unauthorized.
+//   2. Lookup de la commande dans le registre   -> sinon UnknownCommand.
+//   3. Verification minRole vs role utilisateur -> sinon Denied.
+//   4. Dispatch sur le nom de commande pour appliquer la logique metier.
+//
+// Tous les chemins (succes / refus / erreur) emettent un log Audit avec
+// le format defini dans docs/slash_commands_rbac.md. Le subsystem est
+// "Audit" si le logger le supporte, sinon "Auth" en fallback (le
+// LOG_INFO macro utilise une string runtime, pas une enum, donc
+// n'importe quel nom est accepte).
+//
+// V1 : pour les commandes autres que "/sky moon", la reponse est un Ok
+// avec result vide (stub). Les futures PR ajouteront les dispatchers
+// specifiques (kick, ban, mute, promote, etc.).
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+	class AccountRoleService;
+	class SlashCommandRegistry;
+}
+
+namespace engine::server
+{
+	/// Dispatcher central des slash commands cote master.
+	/// Doit etre configure via Set*() avant tout HandlePacket. Si l'un des
+	/// pointeurs critique n'est pas cable (server, sessionMgr, connMap,
+	/// registry), le handler refusera toutes les commandes (Unauthorized
+	/// ou ServerError selon le manque). C'est defensif : on n'execute
+	/// jamais sans contexte complet.
+	class AdminCommandHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer la reponse 196.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId.
+		void SetSessionManager(SessionManager* mgr) { m_sessionMgr = mgr; }
+		/// Branche la map connId -> sessionId pour valider l'auth.
+		void SetConnectionSessionMap(ConnectionSessionMap* m) { m_connMap = m; }
+		/// Branche le service de role pour lire la valeur courante de
+		/// accounts.role. Si nullptr, le handler considere TOUS les comptes
+		/// comme Player (V1 fallback : commandes minRole>Player refusees).
+		void SetAccountRoleService(AccountRoleService* s) { m_roleService = s; }
+		/// Branche le registre des commandes (charge depuis slash_commands.json).
+		void SetSlashCommandRegistry(SlashCommandRegistry* r) { m_registry = r; }
+
+		/// Dispatch packet : traite uniquement opcode 195
+		/// (kOpcodeAdminCommandRequest). Pour tout autre opcode, no-op.
+		///
+		/// \param connId           identifiant TCP de la connexion (Send response).
+		/// \param opcode           opcode du paquet entrant (doit etre 195).
+		/// \param requestId        request_id du paquet entrant ; renvoye dans la reponse.
+		/// \param sessionIdHeader  session_id du paquet entrant ; renvoye dans la reponse.
+		/// \param payload          pointeur sur le payload (sans header).
+		/// \param payloadSize      taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize);
+
+	private:
+		/// Traite ADMIN_COMMAND_REQUEST : parse, auth, lookup, role check,
+		/// dispatch metier, audit log, send response.
+		void HandleRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
+		                   const uint8_t* payload, size_t payloadSize);
+
+		NetServer*            m_server      = nullptr;
+		SessionManager*       m_sessionMgr  = nullptr;
+		ConnectionSessionMap* m_connMap     = nullptr;
+		AccountRoleService*   m_roleService = nullptr;
+		SlashCommandRegistry* m_registry    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -48,6 +48,9 @@
 #include "src/masterd/handlers/auction/AuctionHandler.h"
 #include "src/masterd/handlers/loot/LootHandler.h"
 #include "src/masterd/handlers/lunar/LunarHandler.h"
+#include "src/masterd/handlers/admin/AdminCommandHandler.h"
+#include "src/masterd/admin/SlashCommandRegistry.h"
+#include "src/masterd/account/AccountRoleService.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
@@ -676,6 +679,39 @@ int main(int argc, char** argv)
 		lunarHandler.Tick(bootNowMs);
 	}
 
+	// AdminCommand RBAC — registre des slash commands (charge depuis
+	// game/data/config/slash_commands.json) + handler central qui valide
+	// le role + log audit pour TOUTES les slash commands. Pattern central
+	// (cf. docs/slash_commands_rbac.md).
+	engine::server::SlashCommandRegistry slashCommandRegistry;
+	{
+		const std::string slashCommandsPath = config.GetString(
+			"server.slash_commands_path", "game/data/config/slash_commands.json");
+		if (!slashCommandRegistry.LoadFromFile(slashCommandsPath))
+		{
+			LOG_WARN(Net, "[ServerMain] SlashCommandRegistry load FAILED ({}): AdminCommands will reject ALL",
+				slashCommandsPath);
+		}
+		else
+		{
+			LOG_INFO(Net, "[ServerMain] SlashCommandRegistry loaded ({} commands)",
+				static_cast<unsigned long long>(slashCommandRegistry.Size()));
+		}
+	}
+
+	// AccountRoleService : facade au-dessus d'AccountStore qui expose
+	// GetRole/RequireMinRole. Utilise par AdminCommandHandler pour la
+	// verification du minRole. Lecture seule cote AdminCommand.
+	engine::server::AccountRoleService accountRoleService(*accountStore, &auditLog);
+
+	engine::server::AdminCommandHandler adminCommandHandler;
+	adminCommandHandler.SetServer(&server);
+	adminCommandHandler.SetSessionManager(&sessionManager);
+	adminCommandHandler.SetConnectionSessionMap(&connSessionMap);
+	adminCommandHandler.SetAccountRoleService(&accountRoleService);
+	adminCommandHandler.SetSlashCommandRegistry(&slashCommandRegistry);
+	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log)");
+
 	// Phase 5 Lunar — Branche le GameEventHandler sur le LunarHandler pour
 	// pouvoir filtrer les events par phase lunaire (event "Nuit de la
 	// Lune Noire" gate sur phases 0/14/15). Doit imperativement etre fait
@@ -724,7 +760,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -828,6 +864,8 @@ int main(int argc, char** argv)
 			lootHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeLunarStateRequest)
 			lunarHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeAdminCommandRequest)
+			adminCommandHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else
 			authHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 	});

--- a/src/shared/network/AdminCommandPayloads.cpp
+++ b/src/shared/network/AdminCommandPayloads.cpp
@@ -1,0 +1,135 @@
+// Implementation Build/Parse des payloads AdminCommand (opcodes 195/196).
+// Format little-endian, length-prefixed strings. Cf. AdminCommandPayloads.h
+// pour le layout binaire. Le module produit uniquement le payload nu : le
+// caller (handler ou client) ajoute le header protocol_v1 via PacketBuilder.
+
+#include "src/shared/network/AdminCommandPayloads.h"
+
+#include <cstring>
+
+namespace engine::network::admin
+{
+	namespace
+	{
+		/// Limite max d'une chaine encodee : 65535 octets (cap u16 prefix).
+		/// Limite max d'une liste : 65535 elements.
+		constexpr uint16_t kMaxStringLen = 0xFFFFu;
+		constexpr uint16_t kMaxListSize  = 0xFFFFu;
+
+		/// Ecrit un uint8 a la fin de \p out.
+		void WriteU8(std::vector<uint8_t>& out, uint8_t v)
+		{
+			out.push_back(v);
+		}
+
+		/// Ecrit un uint16 little-endian a la fin de \p out.
+		void WriteU16LE(std::vector<uint8_t>& out, uint16_t v)
+		{
+			out.push_back(static_cast<uint8_t>(v));
+			out.push_back(static_cast<uint8_t>(v >> 8));
+		}
+
+		/// Ecrit une chaine length-prefixed (u16 LE + octets bruts).
+		/// Si la chaine depasse \c kMaxStringLen, elle est tronquee silencieusement.
+		void WriteString(std::vector<uint8_t>& out, const std::string& s)
+		{
+			const size_t n = s.size() > kMaxStringLen ? static_cast<size_t>(kMaxStringLen) : s.size();
+			WriteU16LE(out, static_cast<uint16_t>(n));
+			out.insert(out.end(), s.begin(), s.begin() + static_cast<std::ptrdiff_t>(n));
+		}
+
+		/// Ecrit une liste length-prefixed de chaines (u16 LE count + chaines).
+		void WriteStringList(std::vector<uint8_t>& out, const std::vector<std::string>& v)
+		{
+			const size_t n = v.size() > kMaxListSize ? static_cast<size_t>(kMaxListSize) : v.size();
+			WriteU16LE(out, static_cast<uint16_t>(n));
+			for (size_t i = 0; i < n; ++i)
+				WriteString(out, v[i]);
+		}
+
+		/// Lit un uint8 et avance \p pos. Retourne false si insuffisant.
+		bool ReadU8(const uint8_t* d, size_t sz, size_t& pos, uint8_t& out)
+		{
+			if (pos + 1 > sz) return false;
+			out = d[pos];
+			pos += 1;
+			return true;
+		}
+
+		/// Lit un uint16 little-endian et avance \p pos. Retourne false si insuffisant.
+		bool ReadU16LE(const uint8_t* d, size_t sz, size_t& pos, uint16_t& out)
+		{
+			if (pos + 2 > sz) return false;
+			out = static_cast<uint16_t>(d[pos])
+			    | (static_cast<uint16_t>(d[pos + 1]) << 8);
+			pos += 2;
+			return true;
+		}
+
+		/// Lit une chaine length-prefixed et avance \p pos. Retourne false si
+		/// le prefixe ou les octets de contenu sont insuffisants.
+		bool ReadString(const uint8_t* d, size_t sz, size_t& pos, std::string& out)
+		{
+			uint16_t len = 0;
+			if (!ReadU16LE(d, sz, pos, len)) return false;
+			if (pos + len > sz) return false;
+			out.assign(reinterpret_cast<const char*>(d + pos), static_cast<size_t>(len));
+			pos += len;
+			return true;
+		}
+
+		/// Lit une liste de chaines (u16 count + N strings) et avance \p pos.
+		bool ReadStringList(const uint8_t* d, size_t sz, size_t& pos, std::vector<std::string>& out)
+		{
+			uint16_t count = 0;
+			if (!ReadU16LE(d, sz, pos, count)) return false;
+			out.clear();
+			out.reserve(count);
+			for (uint16_t i = 0; i < count; ++i)
+			{
+				std::string s;
+				if (!ReadString(d, sz, pos, s)) return false;
+				out.push_back(std::move(s));
+			}
+			return true;
+		}
+	}
+
+	void BuildAdminCommandRequestPayload(const AdminCommandRequest& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteString(out, msg.command);
+		WriteStringList(out, msg.args);
+	}
+
+	void BuildAdminCommandResponsePayload(const AdminCommandResponse& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, static_cast<uint8_t>(msg.status));
+		WriteString(out, msg.command);
+		WriteStringList(out, msg.result);
+		WriteString(out, msg.message);
+	}
+
+	bool ParseAdminCommandRequestPayload(const uint8_t* d, size_t sz, AdminCommandRequest& out)
+	{
+		size_t pos = 0;
+		out = AdminCommandRequest{};
+		if (!ReadString(d, sz, pos, out.command)) return false;
+		if (!ReadStringList(d, sz, pos, out.args)) return false;
+		return pos == sz;
+	}
+
+	bool ParseAdminCommandResponsePayload(const uint8_t* d, size_t sz, AdminCommandResponse& out)
+	{
+		size_t pos = 0;
+		uint8_t status = 0;
+		out = AdminCommandResponse{};
+		if (!ReadU8(d, sz, pos, status)) return false;
+		out.status = static_cast<AdminCommandStatus>(status);
+		if (!ReadString(d, sz, pos, out.command)) return false;
+		if (!ReadStringList(d, sz, pos, out.result)) return false;
+		if (!ReadString(d, sz, pos, out.message)) return false;
+		return pos == sz;
+	}
+}

--- a/src/shared/network/AdminCommandPayloads.h
+++ b/src/shared/network/AdminCommandPayloads.h
@@ -1,0 +1,70 @@
+#pragma once
+// Wire payloads pour le systeme AdminCommand (opcodes 195/196). Pattern
+// centralise pour TOUTES les slash commands avec RBAC + audit log
+// (cf. game/data/config/slash_commands.json + docs/slash_commands_rbac.md).
+//
+// Format wire little-endian. Les champs string sont prefixes par leur
+// longueur en uint16_t LE (max 65535 octets), les listes (vector<string>)
+// sont prefixees par leur cardinalite en uint16_t LE puis chaque element
+// est encode comme un string. La taille totale d'un payload est bornee
+// par la limite de 16 KB des paquets v1 (PacketBuilder::Finalize).
+//
+// Format binaire :
+//   AdminCommandRequest :
+//     u16 command_len + bytes(command_len)
+//     u16 args_count + repeat[ u16 arg_len + bytes(arg_len) ]
+//
+//   AdminCommandResponse :
+//     u8 status (0..5, cf. AdminCommandStatus)
+//     u16 command_len + bytes(command_len)
+//     u16 result_count + repeat[ u16 v_len + bytes(v_len) ]
+//     u16 message_len + bytes(message_len)
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::network::admin
+{
+	/// Resultat d'execution d'une slash command. La valeur 0 indique succes ;
+	/// toute autre valeur identifie la categorie de refus (logge serveur).
+	enum class AdminCommandStatus : uint8_t
+	{
+		Ok             = 0,  ///< Execution reussie.
+		Unauthorized   = 1,  ///< Pas de session valide (avant lookup role).
+		Denied         = 2,  ///< Role insuffisant pour la commande demandee.
+		UnknownCommand = 3,  ///< Commande absente du registre slash_commands.json.
+		InvalidArgs    = 4,  ///< Arguments mal formes (validation specifique).
+		ServerError    = 5,  ///< Erreur lors de l'execution (logique metier).
+	};
+
+	/// Requete client -> master : "/sky moon 7" -> command="/sky moon", args=["7"].
+	struct AdminCommandRequest
+	{
+		std::string              command;  ///< Nom canonique avec slash (ex: "/sky moon").
+		std::vector<std::string> args;     ///< Arguments positionnels (peut etre vide).
+	};
+
+	/// Reponse master -> client : status + echo de la commande + result key=value
+	/// + message human-readable. Le client dispatche sur \c command pour appliquer
+	/// l'effet local quand status == Ok.
+	struct AdminCommandResponse
+	{
+		AdminCommandStatus       status  = AdminCommandStatus::Ok;
+		std::string              command;  ///< Echo de la commande pour dispatch client.
+		std::vector<std::string> result;   ///< Generic key=value strings, libre par command.
+		std::string              message;  ///< Texte UI (ex: "Permission refusee : role administrator requis").
+	};
+
+	/// Build* : ecrit le payload binaire dans \p out (clear + push_back).
+	/// Le caller integrera ensuite le buffer dans un PacketBuilder
+	/// (Finalize ajoute le header protocol_v1).
+	void BuildAdminCommandRequestPayload(const AdminCommandRequest& msg, std::vector<uint8_t>& out);
+	void BuildAdminCommandResponsePayload(const AdminCommandResponse& msg, std::vector<uint8_t>& out);
+
+	/// Parse* : retourne true si le buffer est valide (taille exacte attendue,
+	/// pas d'octet residuel). Reject-short et reject-extra strict.
+	bool ParseAdminCommandRequestPayload(const uint8_t* data, size_t size, AdminCommandRequest& out);
+	bool ParseAdminCommandResponsePayload(const uint8_t* data, size_t size, AdminCommandResponse& out);
+}

--- a/src/shared/network/AdminCommandPayloadsTests.cpp
+++ b/src/shared/network/AdminCommandPayloadsTests.cpp
@@ -1,0 +1,361 @@
+// Round-trip tests pour les payloads AdminCommand (195/196) + edge cases
+// + reject-short / reject-extra. Pas de framework, asserts simples.
+// Le binaire est enregistre dans CMakeLists.txt comme cible CTest
+// `admin_command_payloads_tests`.
+
+#include "src/shared/network/AdminCommandPayloads.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace engine::network::admin;
+
+namespace
+{
+	/// Round-trip d'une Request standard "/sky moon 7".
+	void TestRequestRoundTripSkyMoon()
+	{
+		AdminCommandRequest src;
+		src.command = "/sky moon";
+		src.args.push_back("7");
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+
+		AdminCommandRequest dst;
+		assert(ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		assert(dst.command == src.command);
+		assert(dst.args.size() == 1);
+		assert(dst.args[0] == "7");
+		std::puts("[OK] TestRequestRoundTripSkyMoon");
+	}
+
+	/// Round-trip d'une Request sans arguments (commande nue).
+	void TestRequestRoundTripEmptyArgs()
+	{
+		AdminCommandRequest src;
+		src.command = "/who";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+
+		AdminCommandRequest dst;
+		assert(ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		assert(dst.command == "/who");
+		assert(dst.args.empty());
+		std::puts("[OK] TestRequestRoundTripEmptyArgs");
+	}
+
+	/// Round-trip d'une Request avec plusieurs arguments.
+	void TestRequestRoundTripMultiArgs()
+	{
+		AdminCommandRequest src;
+		src.command = "/ban";
+		src.args.push_back("hacker_42");
+		src.args.push_back("griefing");
+		src.args.push_back("permanent");
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+
+		AdminCommandRequest dst;
+		assert(ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		assert(dst.command == "/ban");
+		assert(dst.args.size() == 3);
+		assert(dst.args[0] == "hacker_42");
+		assert(dst.args[1] == "griefing");
+		assert(dst.args[2] == "permanent");
+		std::puts("[OK] TestRequestRoundTripMultiArgs");
+	}
+
+	/// Round-trip d'une Request avec une commande tres longue (proche du cap).
+	void TestRequestRoundTripLongCommand()
+	{
+		AdminCommandRequest src;
+		src.command = std::string("/long ") + std::string(500, 'x');
+		src.args.push_back(std::string(1024, 'y'));
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+
+		AdminCommandRequest dst;
+		assert(ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		assert(dst.command == src.command);
+		assert(dst.args.size() == 1);
+		assert(dst.args[0] == src.args[0]);
+		std::puts("[OK] TestRequestRoundTripLongCommand");
+	}
+
+	/// Round-trip d'une Request avec command vide (cas degenere mais valide).
+	void TestRequestRoundTripEmptyCommand()
+	{
+		AdminCommandRequest src;
+		src.command = "";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+		// Format minimal : 2 octets command_len(0) + 2 octets args_count(0) = 4 octets.
+		assert(buf.size() == 4);
+
+		AdminCommandRequest dst;
+		assert(ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		assert(dst.command.empty());
+		assert(dst.args.empty());
+		std::puts("[OK] TestRequestRoundTripEmptyCommand");
+	}
+
+	/// Reject-short : Request tronquee avant la fin doit etre rejetee.
+	void TestRequestRejectShort()
+	{
+		AdminCommandRequest src;
+		src.command = "/sky moon";
+		src.args.push_back("7");
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+
+		// Tronque les 3 derniers octets (mange "7" de l'argument).
+		buf.resize(buf.size() - 3);
+
+		AdminCommandRequest dst;
+		assert(!ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestRequestRejectShort");
+	}
+
+	/// Reject-extra : un octet en trop a la fin doit etre rejete.
+	void TestRequestRejectExtra()
+	{
+		AdminCommandRequest src;
+		src.command = "/sky moon";
+		src.args.push_back("7");
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandRequestPayload(src, buf);
+		buf.push_back(0xAAu);
+
+		AdminCommandRequest dst;
+		assert(!ParseAdminCommandRequestPayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestRequestRejectExtra");
+	}
+
+	/// Round-trip d'une Response Ok avec result key=value et message.
+	void TestResponseRoundTripOk()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Ok;
+		src.command = "/sky moon";
+		src.result.push_back("phase=7");
+		src.result.push_back("illumination=1.000");
+		src.message = "OK";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == AdminCommandStatus::Ok);
+		assert(dst.command == "/sky moon");
+		assert(dst.result.size() == 2);
+		assert(dst.result[0] == "phase=7");
+		assert(dst.result[1] == "illumination=1.000");
+		assert(dst.message == "OK");
+		std::puts("[OK] TestResponseRoundTripOk");
+	}
+
+	/// Round-trip d'une Response Denied avec message d'erreur localise.
+	void TestResponseRoundTripDenied()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Denied;
+		src.command = "/sky moon";
+		src.message = "Permission refusee : role administrator requis";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == AdminCommandStatus::Denied);
+		assert(dst.command == "/sky moon");
+		assert(dst.result.empty());
+		assert(dst.message == "Permission refusee : role administrator requis");
+		std::puts("[OK] TestResponseRoundTripDenied");
+	}
+
+	/// Round-trip pour CHAQUE valeur de status enum (couverture exhaustive).
+	void TestResponseAllStatusValues()
+	{
+		const AdminCommandStatus statuses[] = {
+			AdminCommandStatus::Ok,
+			AdminCommandStatus::Unauthorized,
+			AdminCommandStatus::Denied,
+			AdminCommandStatus::UnknownCommand,
+			AdminCommandStatus::InvalidArgs,
+			AdminCommandStatus::ServerError,
+		};
+
+		for (auto s : statuses)
+		{
+			AdminCommandResponse src;
+			src.status = s;
+			src.command = "/cmd";
+			src.message = "msg";
+
+			std::vector<uint8_t> buf;
+			BuildAdminCommandResponsePayload(src, buf);
+
+			AdminCommandResponse dst;
+			assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+			assert(dst.status == s);
+			assert(dst.command == "/cmd");
+			assert(dst.message == "msg");
+		}
+		std::puts("[OK] TestResponseAllStatusValues");
+	}
+
+	/// Round-trip d'une Response Unauthorized vide (cas le plus frequent
+	/// quand la session est invalide -> on echo juste le command).
+	void TestResponseRoundTripUnauthorized()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Unauthorized;
+		src.command = "/sky moon";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == AdminCommandStatus::Unauthorized);
+		assert(dst.command == "/sky moon");
+		assert(dst.message.empty());
+		std::puts("[OK] TestResponseRoundTripUnauthorized");
+	}
+
+	/// Round-trip d'une Response UnknownCommand.
+	void TestResponseRoundTripUnknownCommand()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::UnknownCommand;
+		src.command = "/inexistant";
+		src.message = "Commande inconnue";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == AdminCommandStatus::UnknownCommand);
+		assert(dst.command == "/inexistant");
+		assert(dst.message == "Commande inconnue");
+		std::puts("[OK] TestResponseRoundTripUnknownCommand");
+	}
+
+	/// Round-trip d'une Response InvalidArgs.
+	void TestResponseRoundTripInvalidArgs()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::InvalidArgs;
+		src.command = "/sky moon";
+		src.message = "phase doit etre dans 0..15";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.status == AdminCommandStatus::InvalidArgs);
+		std::puts("[OK] TestResponseRoundTripInvalidArgs");
+	}
+
+	/// Reject-short : Response tronquee avant la fin doit etre rejetee.
+	void TestResponseRejectShort()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Ok;
+		src.command = "/cmd";
+		src.message = "msg";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+		buf.resize(buf.size() - 1);
+
+		AdminCommandResponse dst;
+		assert(!ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestResponseRejectShort");
+	}
+
+	/// Reject-extra : un octet en trop a la fin doit etre rejete.
+	void TestResponseRejectExtra()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Ok;
+		src.command = "/cmd";
+		src.message = "msg";
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+		buf.push_back(0xAA);
+
+		AdminCommandResponse dst;
+		assert(!ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestResponseRejectExtra");
+	}
+
+	/// Reject-short : payload completement vide -> doit etre rejete (manque le u8 status).
+	void TestResponseRejectEmpty()
+	{
+		std::vector<uint8_t> buf;
+		AdminCommandResponse dst;
+		assert(!ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		std::puts("[OK] TestResponseRejectEmpty");
+	}
+
+	/// Edge case : Response avec result list contenant des chaines vides.
+	void TestResponseEmptyStringInList()
+	{
+		AdminCommandResponse src;
+		src.status = AdminCommandStatus::Ok;
+		src.command = "/cmd";
+		src.result.push_back("");
+		src.result.push_back("non_empty");
+		src.result.push_back("");
+
+		std::vector<uint8_t> buf;
+		BuildAdminCommandResponsePayload(src, buf);
+
+		AdminCommandResponse dst;
+		assert(ParseAdminCommandResponsePayload(buf.data(), buf.size(), dst));
+		assert(dst.result.size() == 3);
+		assert(dst.result[0].empty());
+		assert(dst.result[1] == "non_empty");
+		assert(dst.result[2].empty());
+		std::puts("[OK] TestResponseEmptyStringInList");
+	}
+}
+
+int main()
+{
+	TestRequestRoundTripSkyMoon();
+	TestRequestRoundTripEmptyArgs();
+	TestRequestRoundTripMultiArgs();
+	TestRequestRoundTripLongCommand();
+	TestRequestRoundTripEmptyCommand();
+	TestRequestRejectShort();
+	TestRequestRejectExtra();
+	TestResponseRoundTripOk();
+	TestResponseRoundTripDenied();
+	TestResponseAllStatusValues();
+	TestResponseRoundTripUnauthorized();
+	TestResponseRoundTripUnknownCommand();
+	TestResponseRoundTripInvalidArgs();
+	TestResponseRejectShort();
+	TestResponseRejectExtra();
+	TestResponseRejectEmpty();
+	TestResponseEmptyStringInList();
+	std::puts("[ALL OK] AdminCommandPayloadsTests");
+	return 0;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -792,4 +792,13 @@ namespace engine::network
 	constexpr uint16_t kOpcodeLunarStateRequest             = 192u; ///< Client to Master : etat lunaire actuel (vide).
 	constexpr uint16_t kOpcodeLunarStateResponse            = 193u; ///< Master to Client : phase 0..15, illumination 0..1, cycleStart, cycleDuration.
 	constexpr uint16_t kOpcodeLunarPhaseChangeNotification  = 194u; ///< Master to Client (push, request_id=0) : changement de phase.
+
+	// =====================================================================
+	// AdminCommand wire — pattern centralise pour toutes les slash commands
+	// avec RBAC (Role-Based Access Control) + audit log obligatoire serveur.
+	// Voir game/data/config/slash_commands.json (source de verite) et
+	// docs/slash_commands_rbac.md (convention 3 regles).
+	// =====================================================================
+	constexpr uint16_t kOpcodeAdminCommandRequest  = 195u; ///< Client to Master : execution d'une slash command (command, args).
+	constexpr uint16_t kOpcodeAdminCommandResponse = 196u; ///< Master to Client : ACK Ok + data echo, ou Denied / UnknownCommand / InvalidArgs / Unauthorized.
 }


### PR DESCRIPTION
## AdminCommandHandler RBAC + audit log + pilote `/sky moon`

Implémentation du **pattern centralisé pour toutes les slash commands** selon ta directive : RBAC obligatoire + log audit serveur. `/sky moon` est migrée comme pilote pour valider le pattern bout-en-bout.

### Architecture

```
Client tape /sky moon 7
   ↓
Client envoie kOpcodeAdminCommandRequest (195) au master
   payload : { command: "/sky moon", args: ["7"] }
   ↓
Master AdminCommandHandler :
   1. Auth via SessionManager + ConnectionSessionMap
   2. Lookup command dans SlashCommandRegistry (charge slash_commands.json au boot)
   3. AccountRoleService::GetRole(accountId)
   4. Verifie role >= minRole declare dans le JSON
   5. Si OK, dispatch handler specifique (calcul illumination via LunarCalendar)
   6. TOUJOURS log dans subsystem Audit/Auth
   ↓
Master repond kOpcodeAdminCommandResponse (196) :
   { status: Ok|Denied|UnknownCommand|InvalidArgs|Unauthorized,
     command, result: ["phase=7", "illumination=1.000"], message }
   ↓
Client recoit la response :
   - status=Ok → applique m_dayNight.OnLunarPhaseChange(phase, illumination)
   - status=Denied → log warning, message UI "Permission refusee"
```

### Fichiers ajoutés
- `src/shared/network/AdminCommandPayloads.{h,cpp,Tests.cpp}` — wire payloads + 17 tests round-trip
- `src/masterd/admin/SlashCommandRegistry.{h,cpp}` — charge `slash_commands.json` + Lookup/Check API
- `src/masterd/handlers/admin/AdminCommandHandler.{h,cpp}` — pipeline auth → registry → role → dispatch → audit

### Fichiers modifiés
- `src/shared/network/ProtocolV1Constants.h` : opcodes 195-196
- `src/masterd/main_linux.cpp` : `SlashCommandRegistry` + `AccountRoleService` + `AdminCommandHandler` instanciés ; `&adminCommandHandler` ajouté à la capture-list lambda (ligne ~763) ; opcode 195 dispatché
- `src/client/app/Engine.cpp` : `/sky moon` envoie au master au lieu d'override local ; nouveau dispatch case 196 qui parse les `result` ("phase=7", "illumination=1.000") et applique `m_dayNight.OnLunarPhaseChange` SEULEMENT après ACK Ok
- `game/data/config/slash_commands.json` : `/sky moon` status passe de `client_only_legacy` à `implemented`
- `CMakeLists.txt` + `src/CMakeLists.txt` : sources + cible `admin_command_payloads_tests`

### Format de log audit (subsystem `Audit` ou `Auth` fallback)

```
[AdminCommand] account_id=1 role=player command="/sky moon" args=[7] result=DENIED minRequired=administrator
[AdminCommand] account_id=2 role=administrator command="/sky moon" args=[7] result=OK
[AdminCommand] account_id=1 role=player command="/unknown" args=[] result=UNKNOWN_COMMAND
```

### Comportement attendu après merge + redéploiement

**Compte player tape `/sky moon 7`** :
- Master log : `[AdminCommand] account_id=1 role=player command="/sky moon" args=[7] result=DENIED minRequired=administrator`
- Client log : `[AdminCommand] REFUSED command=/sky moon status=2 message=Permission refusee : role administrator requis`
- Aucun changement visuel

**Compte administrator tape `/sky moon 7`** :
- Master log : `[AdminCommand] account_id=2 role=administrator command="/sky moon" args=[7] result=OK`
- Client log : `[Sky] /sky moon ACK applied : phase=7 illumination=1.000`
- Le moon disk passe en Pleine Lune

### V1 limitations
- Seul `/sky moon` est migré dans cette PR. Les 20 autres commandes `client_only_legacy` resteront client-only jusqu'aux PRs suivantes.
- Le dispatcher pour les commandes autres que `/sky moon` retourne `Ok` avec `result` vide (stub V1).
- Parser JSON minimal embedded — gère object/array/string/number/bool/null + escapes basiques. Pas de support `\uXXXX` (suffisant pour le schéma actuel).
- Aucune commande `/promote` encore implémentée — pour tester `/sky moon` en admin, il faut promote ton compte directement en DB :
  ```sql
  UPDATE accounts SET role='administrator' WHERE id=1;
  ```

### Tests
- `admin_command_payloads_tests` (17 tests : round-trip Request/Response, tous les status, edge cases empty args, long command, reject short/extra)
- CI Linux + Windows valide build + tests

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — nouveaux opcodes 195-196 + handler `AdminCommandHandler`. Sans redéploiement, `/sky moon` côté client neuf reste sans ACK (le master ancien ne reconnaît pas l'opcode 195 et retourne BAD_REQUEST par défaut).
>
> Lock-step client + serveur : déployer les deux ensemble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
