### PR TITLE
feat(admin): Wave 2 -- moderation commands /who /report /kick /mute /ban /announce

### DIFF
--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -263,8 +263,9 @@
       "minRole": "player",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:53"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : client envoie au master (opcode 195), master enumere les sessions actives via SessionManager.ListActiveAccountIds + resout login via AccountStore.FindByAccountId, response affichee dans le chat."
     },
     {
       "command": "/report <player>",
@@ -274,8 +275,9 @@
       "minRole": "player",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:59"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : cree un ticket GM via GmTicketSystem.Open avec actor = reporter, target lookup via AccountStore.FindByLogin. Response contient ticket_id."
     },
     {
       "command": "/friend <player>",
@@ -330,8 +332,9 @@
       "minRole": "moderator",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:61"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : verifie role inferieur strict via AccountRoleService.HasLowerSecurity, trouve la connexion via ConnectionSessionMap.Snapshot, ferme via NetServer.CloseConnection."
     },
     {
       "command": "/ban <player> <reason>",
@@ -341,8 +344,9 @@
       "minRole": "game_master",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:63"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : UPDATE accounts.account_status=Locked via AccountStore.SetAccountStatus, deconnecte le compte si online. Verifie role inferieur strict."
     },
     {
       "command": "/mute <player> <duration>",
@@ -352,8 +356,9 @@
       "minRole": "moderator",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:65"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : REPLACE INTO chat_mutes (migration 0044) avec until_ts = now + duration_minutes. ChatGate filtre les messages a l'envoi. Verifie role inferieur strict."
     },
     {
       "command": "/announce <message>",
@@ -363,8 +368,9 @@
       "minRole": "game_master",
       "serverInteraction": true,
       "serverLogged": true,
-      "status": "shardd_routed",
-      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp:67"
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 2 RBAC migration : broadcast un ChatRelay channel=Server, sender=[Announce] login a toutes les sessions actives via ConnectionSessionMap.Snapshot. Pas de filtre IgnoreList."
     },
     {
       "command": "/promote <account_id> <role>",

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1484,9 +1484,6 @@ namespace engine
 				}
 				std::string accIdStr(rest.substr(0, spacePos));
 				std::string roleStr(rest.substr(spacePos + 1));
-				// On ne valide pas plus avant cote client : le master fait
-				// la validation autoritative (account_id non nul, role connu)
-				// et repond InvalidArgs si besoin.
 				engine::network::admin::AdminCommandRequest req;
 				req.command = "/promote";
 				req.args.push_back(accIdStr);
@@ -1497,6 +1494,164 @@ namespace engine
 					engine::network::kOpcodeAdminCommandRequest, payload);
 				LOG_INFO(Core, "[Admin] /promote {} -> {} envoye au master (RBAC + audit)",
 					accIdStr, roleStr);
+				return true;
+			}
+			// Wave 2 RBAC migration : /who (player) -> AdminCommand.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& (text == "/who" || text.starts_with("/who ") || text.starts_with("/who\t")))
+			{
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/who";
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /who sent to master");
+				return true;
+			}
+			// Wave 2 RBAC migration : /report <player> (player) -> AdminCommand.
+			// Cree un ticket GM cote master ; la reponse affiche le ticket_id.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/report "))
+			{
+				std::string_view rest = text.substr(8);
+				while (!rest.empty() && (rest.front() == ' ' || rest.front() == '\t'))
+					rest.remove_prefix(1u);
+				if (rest.empty())
+				{
+					LOG_WARN(Core, "[Engine] /report sans argument joueur");
+					return true;
+				}
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/report";
+				req.args.push_back(std::string(rest));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /report {} sent to master", std::string(rest));
+				return true;
+			}
+			// Wave 2 RBAC migration : /kick <player> (moderator) -> AdminCommand.
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/kick "))
+			{
+				std::string_view rest = text.substr(6);
+				while (!rest.empty() && (rest.front() == ' ' || rest.front() == '\t'))
+					rest.remove_prefix(1u);
+				if (rest.empty())
+				{
+					LOG_WARN(Core, "[Engine] /kick sans argument joueur");
+					return true;
+				}
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/kick";
+				req.args.push_back(std::string(rest));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /kick {} sent to master", std::string(rest));
+				return true;
+			}
+			// Wave 2 RBAC migration : /mute <player> <duration_min> (moderator).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/mute "))
+			{
+				std::string_view rest = text.substr(6);
+				while (!rest.empty() && (rest.front() == ' ' || rest.front() == '\t'))
+					rest.remove_prefix(1u);
+				if (rest.empty())
+				{
+					LOG_WARN(Core, "[Engine] /mute sans arguments");
+					return true;
+				}
+				// Split : premier mot = player, reste = duration (ou plus).
+				auto firstSpace = rest.find_first_of(" \t");
+				if (firstSpace == std::string_view::npos)
+				{
+					LOG_WARN(Core, "[Engine] /mute necessite <player> <duration_minutes>");
+					return true;
+				}
+				std::string player(rest.substr(0, firstSpace));
+				std::string_view durView = rest.substr(firstSpace + 1u);
+				while (!durView.empty() && (durView.front() == ' ' || durView.front() == '\t'))
+					durView.remove_prefix(1u);
+				if (durView.empty())
+				{
+					LOG_WARN(Core, "[Engine] /mute : duree manquante");
+					return true;
+				}
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/mute";
+				req.args.push_back(std::move(player));
+				req.args.push_back(std::string(durView));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /mute sent to master");
+				return true;
+			}
+			// Wave 2 RBAC migration : /ban <player> <reason...> (game_master).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/ban "))
+			{
+				std::string_view rest = text.substr(5);
+				while (!rest.empty() && (rest.front() == ' ' || rest.front() == '\t'))
+					rest.remove_prefix(1u);
+				if (rest.empty())
+				{
+					LOG_WARN(Core, "[Engine] /ban sans argument joueur");
+					return true;
+				}
+				auto firstSpace = rest.find_first_of(" \t");
+				std::string player;
+				std::string reason;
+				if (firstSpace == std::string_view::npos)
+				{
+					player = std::string(rest);
+				}
+				else
+				{
+					player = std::string(rest.substr(0, firstSpace));
+					std::string_view reasonView = rest.substr(firstSpace + 1u);
+					while (!reasonView.empty() && (reasonView.front() == ' ' || reasonView.front() == '\t'))
+						reasonView.remove_prefix(1u);
+					reason = std::string(reasonView);
+				}
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/ban";
+				req.args.push_back(std::move(player));
+				if (!reason.empty())
+					req.args.push_back(std::move(reason));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /ban sent to master");
+				return true;
+			}
+			// Wave 2 RBAC migration : /announce <message> (game_master).
+			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
+				&& text.starts_with("/announce "))
+			{
+				std::string_view rest = text.substr(10);
+				while (!rest.empty() && (rest.front() == ' ' || rest.front() == '\t'))
+					rest.remove_prefix(1u);
+				if (rest.empty())
+				{
+					LOG_WARN(Core, "[Engine] /announce : message vide");
+					return true;
+				}
+				engine::network::admin::AdminCommandRequest req;
+				req.command = "/announce";
+				req.args.push_back(std::string(rest));
+				std::vector<uint8_t> payload;
+				engine::network::admin::BuildAdminCommandRequestPayload(req, payload);
+				(void)m_authUi.SendGenericRequestAsync(
+					engine::network::kOpcodeAdminCommandRequest, payload);
+				LOG_INFO(Core, "[Engine] /announce sent to master");
 				return true;
 			}
 			// CMANGOS.32 (Phase 5.32 step 3+4) — Slash command /ticket et /gmticket
@@ -2415,8 +2570,6 @@ namespace engine
 					}
 					else if (parsed.command == "/sky time")
 					{
-						// Parse echoed arg : ["hours=22.500"]. Le master a deja
-						// valide la plage [0..24) — on applique sans recheck.
 						float hours = 12.0f;
 						for (const auto& kv : parsed.result)
 						{
@@ -2432,10 +2585,6 @@ namespace engine
 					}
 					else if (parsed.command == "/sky info")
 					{
-						// Read-only : le master ne renvoie pas d'etat metier
-						// (le client a deja le state local DayNight). On
-						// dump l'etat local cote log Render maintenant qu'on
-						// a l'autorisation serveur (audit cote master deja emis).
 						const auto& s = m_dayNight.GetState();
 						static const char* kMoonName[16] = {
 							"NewMoon", "WaxingCrescentEarly", "WaxingCrescentLate", "FirstQuarter",
@@ -2454,15 +2603,69 @@ namespace engine
 					}
 					else if (parsed.command == "/loot")
 					{
-						// Toggle deja applique localement a la frappe (le panneau
-						// UI ne dependant pas du master). On log juste l'ACK audit.
 						LOG_INFO(Core, "[Admin] /loot ACK : {}", parsed.message);
 					}
 					else if (parsed.command == "/promote")
 					{
-						// Echo : ["account_id=123", "new_role=moderator"]. On log
-						// pour feedback admin (la persistance est cote master).
 						LOG_INFO(Core, "[Admin] /promote ACK : {}", parsed.message);
+					}
+					else if (parsed.command == "/who"
+					      || parsed.command == "/report"
+					      || parsed.command == "/kick"
+					      || parsed.command == "/mute"
+					      || parsed.command == "/ban"
+					      || parsed.command == "/announce")
+					{
+						// Wave 2 : reponses moderation. Affiche le resultat
+						// dans le chat (canal Server) pour feedback joueur.
+						std::string body;
+						if (parsed.command == "/who")
+						{
+							std::string countStr;
+							std::string loginsStr;
+							for (const auto& kv : parsed.result)
+							{
+								if (kv.starts_with("count="))
+									countStr = kv.substr(6);
+								else if (kv.starts_with("logins="))
+									loginsStr = kv.substr(7);
+							}
+							body = "[Who] " + countStr + " joueurs connectes";
+							if (!loginsStr.empty())
+								body += " : " + loginsStr;
+						}
+						else if (parsed.command == "/report")
+						{
+							body = "[Report] " + parsed.message;
+						}
+						else if (parsed.command == "/kick")
+						{
+							body = "[Kick] " + parsed.message;
+						}
+						else if (parsed.command == "/mute")
+						{
+							body = "[Mute] " + parsed.message;
+						}
+						else if (parsed.command == "/ban")
+						{
+							body = "[Ban] " + parsed.message;
+						}
+						else if (parsed.command == "/announce")
+						{
+							body = "[Announce] " + parsed.message;
+						}
+
+						if (!body.empty() && m_chatUi.IsInitialized())
+						{
+							engine::net::ChatMessage line;
+							line.timestampUnixMs = 0;
+							line.channel = engine::net::ChatChannel::Server;
+							line.sender = "system";
+							line.text = std::move(body);
+							m_chatUi.PushNetworkLine(line);
+						}
+						LOG_INFO(Net, "[AdminCommand] OK command={} message={}",
+							parsed.command, parsed.message);
 					}
 					else
 					{

--- a/src/masterd/account/AccountStore.h
+++ b/src/masterd/account/AccountStore.h
@@ -110,5 +110,14 @@ namespace engine::server
 		/// \return true si la mise à jour a réussi, false si compte inexistant
 		///         ou si role == Console.
 		virtual bool SetRole(uint64_t account_id, AccountRole role) = 0;
+
+		/// Met a jour le statut d'un compte (Active / Locked). Utilise par
+		/// AdminCommandHandler::DispatchBan pour bannir un compte. N'ecrit
+		/// PAS de log audit (responsabilite du caller). Persiste en RAM ou
+		/// en DB selon l'implementation.
+		/// \param account_id Compte cible.
+		/// \param status     Nouveau statut.
+		/// \return true si la mise a jour a reussi, false si compte inexistant.
+		virtual bool SetAccountStatus(uint64_t account_id, AccountStatus status) = 0;
 	};
 }

--- a/src/masterd/account/InMemoryAccountStore.cpp
+++ b/src/masterd/account/InMemoryAccountStore.cpp
@@ -201,4 +201,23 @@ namespace engine::server
 		}
 		return false;
 	}
+
+	/// Met a jour le statut d'un compte en RAM. Iteration lineaire sur les
+	/// comptes via m_by_login (cout O(N) acceptable pour tests / fallback).
+	bool InMemoryAccountStore::SetAccountStatus(uint64_t account_id, AccountStatus status)
+	{
+		std::lock_guard<std::recursive_mutex> lock(m_mutex);
+		for (auto& [login, rec] : m_by_login)
+		{
+			if (rec.account_id == account_id)
+			{
+				rec.status = status;
+				LOG_INFO(Auth, "[InMemoryAccountStore] SetAccountStatus OK account_id={} status={}",
+					account_id, static_cast<int>(status));
+				return true;
+			}
+		}
+		LOG_WARN(Auth, "[InMemoryAccountStore] SetAccountStatus: account_id={} not found", account_id);
+		return false;
+	}
 }

--- a/src/masterd/account/InMemoryAccountStore.h
+++ b/src/masterd/account/InMemoryAccountStore.h
@@ -34,6 +34,7 @@ namespace engine::server
 		void PersistEmailVerificationCode(uint64_t account_id, const std::string& code) override;
 		AccountRole GetRole(uint64_t account_id) override;
 		bool SetRole(uint64_t account_id, AccountRole role) override;
+		bool SetAccountStatus(uint64_t account_id, AccountStatus status) override;
 
 	private:
 		mutable std::recursive_mutex m_mutex;

--- a/src/masterd/account/MysqlAccountStore.cpp
+++ b/src/masterd/account/MysqlAccountStore.cpp
@@ -511,4 +511,30 @@ namespace engine::server
 			account_id, roleStr);
 		return true;
 	}
+
+	/// Met a jour account_status (Active=0, Locked=2) via UPDATE direct.
+	/// Utilise par AdminCommandHandler::DispatchBan.
+	bool MysqlAccountStore::SetAccountStatus(uint64_t account_id, AccountStatus status)
+	{
+		if (!m_pool)
+			return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql)
+			return false;
+
+		const int statusInt = static_cast<int>(status);
+		const std::string sql = "UPDATE accounts SET account_status=" + std::to_string(statusInt)
+			+ " WHERE id=" + std::to_string(account_id) + " LIMIT 1";
+		if (!engine::server::db::DbExecute(mysql, sql))
+			return false;
+		if (mysql_affected_rows(mysql) == 0)
+		{
+			LOG_WARN(Auth, "[MysqlAccountStore] SetAccountStatus: account_id={} not found", account_id);
+			return false;
+		}
+		LOG_INFO(Auth, "[MysqlAccountStore] SetAccountStatus account_id={} status={}",
+			account_id, statusInt);
+		return true;
+	}
 }

--- a/src/masterd/account/MysqlAccountStore.h
+++ b/src/masterd/account/MysqlAccountStore.h
@@ -135,6 +135,12 @@ namespace engine::server
 		/// Refuse role=Console (runtime-only). CMANGOS.06 (Phase 1c).
 		bool SetRole(uint64_t account_id, AccountRole role) override;
 
+		/// Met a jour le statut d'un compte via UPDATE accounts SET
+		/// account_status=? WHERE id=?. Utilise par AdminCommandHandler
+		/// pour /ban (status=Locked). Aucun audit ecrit ici : la
+		/// responsabilite est du caller.
+		bool SetAccountStatus(uint64_t account_id, AccountStatus status) override;
+
 	private:
 		/// Pointeur non-owning vers le ConnectionPool MySQL master.
 		/// Null uniquement si le constructeur a reçu nullptr — comportement indéfini si accédé après.

--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -4,18 +4,29 @@
 
 #include "src/masterd/handlers/admin/AdminCommandHandler.h"
 
+#include "src/masterd/account/AccountRecord.h"
 #include "src/masterd/account/AccountRole.h"
 #include "src/masterd/account/AccountRoleService.h"
+#include "src/masterd/account/AccountStore.h"
+#include "src/masterd/account/AccountValidation.h"
 #include "src/masterd/admin/SlashCommandRegistry.h"
+#include "src/masterd/gmtickets/GmTicketSystem.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shardd/world/LunarCalendar.h"
 #include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+#include "src/shared/net/ChatSystem.h"
 #include "src/shared/network/AdminCommandPayloads.h"
+#include "src/shared/network/ChatPayloads.h"
 #include "src/shared/network/NetServer.h"
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 
+#include <mysql.h>
+
+#include <chrono>
 #include <cstdio>
 #include <sstream>
 #include <string>
@@ -141,6 +152,27 @@ namespace engine::server
 				"/ticket", "/gmticket",
 			};
 			return kSet;
+		}
+
+		/// Timestamp Unix en millisecondes (UTC), aligne sur ChatRelayHandler.
+		uint64_t NowUnixMsUtc()
+		{
+			using namespace std::chrono;
+			return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+		}
+
+		/// Echappe une chaine pour SQL (utilise par /mute : INSERT). Aligne
+		/// sur le helper DbHelpers (mais defini ici car on n'a pas
+		/// EscapeMysql exporte publiquement).
+		std::string EscapeForSql(MYSQL* mysql, std::string_view input)
+		{
+			if (!mysql)
+				return std::string(input);
+			std::string out(input.size() * 2u + 1u, '\0');
+			const unsigned long len = mysql_real_escape_string(mysql,
+				out.data(), input.data(), static_cast<unsigned long>(input.size()));
+			out.resize(len);
+			return out;
 		}
 
 		/// Dispatch metier pour "/sky moon <phase>". Valide l'argument et
@@ -420,6 +452,36 @@ namespace engine::server
 			DispatchPromote(req.args, accountId, m_roleService, resp);
 			handled = true;
 		}
+		else if (req.command == "/who")
+		{
+			DispatchWho(resp);
+			handled = true;
+		}
+		else if (req.command == "/report")
+		{
+			DispatchReport(accountId, req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/kick")
+		{
+			DispatchKick(accountId, req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/mute")
+		{
+			DispatchMute(accountId, req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/ban")
+		{
+			DispatchBan(accountId, req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/announce")
+		{
+			DispatchAnnounce(accountId, req.args, resp);
+			handled = true;
+		}
 		else if (UiPanelCommandSet().count(req.command) > 0)
 		{
 			// Wave 3 RBAC migration : les UI panel commands sont log-only.
@@ -441,5 +503,391 @@ namespace engine::server
 
 		LogAudit(accountId, userRole, req.command, req.args, resp.status);
 		SendResponse(m_server, connId, requestId, sessionIdHeader, resp);
+	}
+
+	// ============================================================
+	// Wave 2 dispatchers : moderation tools.
+	// ============================================================
+
+	/// Liste tous les joueurs connectes (etat Authenticated / Active).
+	/// Renvoie result = ["count=N", "logins=alice,bob,charlie"]. Visible
+	/// par minRole player (registry decide) ; resout login via store.
+	void AdminCommandHandler::DispatchWho(engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (!m_sessionMgr || !m_accountStore)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/who : sessionMgr ou accountStore non cable";
+			return;
+		}
+		const auto accountIds = m_sessionMgr->ListActiveAccountIds();
+		std::string logins;
+		size_t resolved = 0u;
+		for (size_t i = 0; i < accountIds.size(); ++i)
+		{
+			auto rec = m_accountStore->FindByAccountId(accountIds[i]);
+			if (!rec) continue;
+			if (resolved > 0u) logins.push_back(',');
+			logins += rec->login;
+			++resolved;
+		}
+
+		char countBuf[32];
+		std::snprintf(countBuf, sizeof(countBuf), "count=%zu", resolved);
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(countBuf);
+		resp.result.push_back(std::string("logins=") + logins);
+		resp.message = "OK";
+	}
+
+	/// Cree un ticket GM cote master. Le body du ticket est un message
+	/// generique mentionnant le report ; le GM consultera la liste pour
+	/// suivre. Pas d'effet client direct hormis l'ACK avec ticket_id.
+	void AdminCommandHandler::DispatchReport(uint64_t actorAccountId,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (args.size() < 1u)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /report <player>";
+			return;
+		}
+		if (!m_accountStore || !m_gmTicketSys)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/report : accountStore ou gmTicketSystem non cable";
+			return;
+		}
+		const std::string& targetLogin = args[0];
+		const auto normLogin = engine::server::NormaliseLoginView(targetLogin);
+		auto target = m_accountStore->FindByLogin(normLogin);
+		if (!target)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Joueur introuvable : " + targetLogin;
+			return;
+		}
+
+		// Body du ticket : reference le compte cible + le timestamp.
+		const uint64_t nowMs = NowUnixMsUtc();
+		std::string body = "Report contre '";
+		body += target->login;
+		body += "' (account_id=";
+		body += std::to_string(target->account_id);
+		body += ").";
+
+		const auto ticketId = m_gmTicketSys->Open(actorAccountId, body, nowMs);
+
+		char idBuf[48];
+		std::snprintf(idBuf, sizeof(idBuf), "ticket_id=%llu",
+			static_cast<unsigned long long>(ticketId));
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(idBuf);
+		resp.message = "Ticket cree (id=" + std::to_string(ticketId) + ")";
+	}
+
+	/// Kick : ferme la connexion TCP du joueur cible. Verifie role
+	/// inferieur strict (un mod ne peut pas kick un autre mod). Trouve
+	/// la connection via Snapshot + GetAccountId.
+	void AdminCommandHandler::DispatchKick(uint64_t actorAccountId,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (args.size() < 1u)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /kick <player>";
+			return;
+		}
+		if (!m_accountStore || !m_sessionMgr || !m_connMap || !m_server)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/kick : dependences non cablees";
+			return;
+		}
+		const auto normLogin = engine::server::NormaliseLoginView(args[0]);
+		auto target = m_accountStore->FindByLogin(normLogin);
+		if (!target)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Joueur introuvable : " + args[0];
+			return;
+		}
+
+		// Check : role cible strictement inferieur a celui de l'acteur.
+		// Un moderator ne peut pas kick un autre moderator (regle ticket).
+		if (m_roleService && !m_roleService->HasLowerSecurity(target->account_id, actorAccountId))
+		{
+			resp.status = AdminCommandStatus::Denied;
+			resp.message = "Impossible de kicker un compte de rang egal ou superieur";
+			return;
+		}
+
+		// Trouve la connId du target via la snapshot connMap.
+		const auto snapshot = m_connMap->Snapshot();
+		uint32_t targetConnId = 0u;
+		bool found = false;
+		for (const auto& [connId, sessId] : snapshot)
+		{
+			auto accIdOpt = m_sessionMgr->GetAccountId(sessId);
+			if (accIdOpt && *accIdOpt == target->account_id)
+			{
+				targetConnId = connId;
+				found = true;
+				break;
+			}
+		}
+
+		if (!found)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Joueur '" + args[0] + "' n'est pas connecte";
+			return;
+		}
+
+		m_server->CloseConnection(targetConnId, DisconnectReason::PeerClosed);
+		LOG_INFO(Audit, "[AdminCommand] Kick actor={} target_account={} target_login={} conn={}",
+			static_cast<unsigned long long>(actorAccountId),
+			static_cast<unsigned long long>(target->account_id),
+			target->login,
+			static_cast<unsigned>(targetConnId));
+
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(std::string("kicked=") + target->login);
+		resp.message = "Joueur kicke : " + target->login;
+	}
+
+	/// Mute : INSERT/REPLACE dans chat_mutes avec until_ts dans le futur.
+	/// Necessite un pool MySQL cable. Verifie role inferieur strict.
+	void AdminCommandHandler::DispatchMute(uint64_t actorAccountId,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (args.size() < 2u)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /mute <player> <duration_minutes>";
+			return;
+		}
+		if (!m_accountStore || !m_dbPool)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/mute : accountStore ou dbPool non cable";
+			return;
+		}
+
+		int durationMin = -1;
+		try { durationMin = std::stoi(args[1]); }
+		catch (...) { durationMin = -1; }
+		if (durationMin <= 0 || durationMin > 60 * 24 * 365)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "duree invalide (minutes, 1..525600)";
+			return;
+		}
+
+		const auto normLogin = engine::server::NormaliseLoginView(args[0]);
+		auto target = m_accountStore->FindByLogin(normLogin);
+		if (!target)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Joueur introuvable : " + args[0];
+			return;
+		}
+		if (m_roleService && !m_roleService->HasLowerSecurity(target->account_id, actorAccountId))
+		{
+			resp.status = AdminCommandStatus::Denied;
+			resp.message = "Impossible de mute un compte de rang egal ou superieur";
+			return;
+		}
+
+		const uint64_t nowMs = NowUnixMsUtc();
+		const uint64_t untilTsMs = nowMs + static_cast<uint64_t>(durationMin) * 60ull * 1000ull;
+		const std::string reason = std::string("muted by account_id=")
+			+ std::to_string(actorAccountId);
+
+		auto guard = m_dbPool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "DB indisponible";
+			return;
+		}
+		const std::string escReason = EscapeForSql(mysql, reason);
+		char sqlBuf[512];
+		std::snprintf(sqlBuf, sizeof(sqlBuf),
+			"REPLACE INTO chat_mutes (account_id, until_ts, reason) "
+			"VALUES (%llu, %llu, '%s')",
+			static_cast<unsigned long long>(target->account_id),
+			static_cast<unsigned long long>(untilTsMs),
+			escReason.c_str());
+		if (!engine::server::db::DbExecute(mysql, sqlBuf))
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "DB write failed";
+			return;
+		}
+
+		char untilBuf[64];
+		std::snprintf(untilBuf, sizeof(untilBuf), "until_ts_ms=%llu",
+			static_cast<unsigned long long>(untilTsMs));
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(std::string("muted=") + target->login);
+		resp.result.push_back(untilBuf);
+		resp.message = "Joueur mute : " + target->login;
+	}
+
+	/// Ban : UPDATE accounts.status=Locked. Si online, kick aussi pour
+	/// effet immediat. Verifie role inferieur strict.
+	void AdminCommandHandler::DispatchBan(uint64_t actorAccountId,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (args.size() < 1u)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /ban <player> [reason]";
+			return;
+		}
+		if (!m_accountStore)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/ban : accountStore non cable";
+			return;
+		}
+
+		const auto normLogin = engine::server::NormaliseLoginView(args[0]);
+		auto target = m_accountStore->FindByLogin(normLogin);
+		if (!target)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Joueur introuvable : " + args[0];
+			return;
+		}
+		if (m_roleService && !m_roleService->HasLowerSecurity(target->account_id, actorAccountId))
+		{
+			resp.status = AdminCommandStatus::Denied;
+			resp.message = "Impossible de ban un compte de rang egal ou superieur";
+			return;
+		}
+
+		std::string reason;
+		for (size_t i = 1; i < args.size(); ++i)
+		{
+			if (i > 1u) reason.push_back(' ');
+			reason += args[i];
+		}
+
+		if (!m_accountStore->SetAccountStatus(target->account_id, AccountStatus::Locked))
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "Echec mise a jour status compte";
+			return;
+		}
+
+		// Si online, deconnecte aussi (ban prend effet immediat).
+		if (m_sessionMgr && m_connMap && m_server)
+		{
+			const auto snapshot = m_connMap->Snapshot();
+			for (const auto& [connId, sessId] : snapshot)
+			{
+				auto accIdOpt = m_sessionMgr->GetAccountId(sessId);
+				if (accIdOpt && *accIdOpt == target->account_id)
+				{
+					m_server->CloseConnection(connId, DisconnectReason::PeerClosed);
+					break;
+				}
+			}
+		}
+
+		LOG_INFO(Audit, "[AdminCommand] Ban actor={} target_account={} target_login={} reason='{}'",
+			static_cast<unsigned long long>(actorAccountId),
+			static_cast<unsigned long long>(target->account_id),
+			target->login,
+			reason);
+
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(std::string("banned=") + target->login);
+		if (!reason.empty())
+			resp.result.push_back(std::string("reason=") + reason);
+		resp.message = "Joueur banni : " + target->login;
+	}
+
+	/// Announce : broadcast un ChatRelay channel=Server a toutes les
+	/// sessions actives. Pas de filtre IgnoreList (un announce admin
+	/// doit toucher tout le monde).
+	void AdminCommandHandler::DispatchAnnounce(uint64_t actorAccountId,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (args.empty())
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /announce <message>";
+			return;
+		}
+		if (!m_server || !m_connMap || !m_sessionMgr)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/announce : dependences non cablees";
+			return;
+		}
+
+		// Reconstruit le message a partir des args.
+		std::string message;
+		for (size_t i = 0; i < args.size(); ++i)
+		{
+			if (i > 0u) message.push_back(' ');
+			message += args[i];
+		}
+		if (message.empty())
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Message vide";
+			return;
+		}
+
+		// Sender : tag generique + login si dispo.
+		std::string sender = "[Announce]";
+		if (m_accountStore)
+		{
+			auto rec = m_accountStore->FindByAccountId(actorAccountId);
+			if (rec)
+			{
+				sender = "[Announce] ";
+				sender += rec->login;
+			}
+		}
+
+		const uint64_t ts = NowUnixMsUtc();
+		const uint8_t channel = static_cast<uint8_t>(engine::net::ChatChannel::Server);
+		const auto snapshot = m_connMap->Snapshot();
+		size_t delivered = 0u;
+		for (const auto& [connId, sessId] : snapshot)
+		{
+			auto pkt = engine::network::BuildChatRelayPacket(ts, channel, sender, message, sessId);
+			if (pkt.empty()) continue;
+			if (m_server->Send(connId, pkt))
+				++delivered;
+		}
+
+		LOG_INFO(Audit, "[AdminCommand] Announce actor={} delivered={}/{} text='{}'",
+			static_cast<unsigned long long>(actorAccountId),
+			delivered, snapshot.size(),
+			message.size() > 200u ? message.substr(0, 200u) + "...[truncated]" : message);
+
+		char deliveredBuf[48];
+		std::snprintf(deliveredBuf, sizeof(deliveredBuf), "delivered=%zu", delivered);
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(deliveredBuf);
+		resp.message = "Announce diffuse";
 	}
 }

--- a/src/masterd/handlers/admin/AdminCommandHandler.h
+++ b/src/masterd/handlers/admin/AdminCommandHandler.h
@@ -15,15 +15,27 @@
 // LOG_INFO macro utilise une string runtime, pas une enum, donc
 // n'importe quel nom est accepte).
 //
-// Commandes dispatchees V1 (Wave 1) :
-//   - "/sky moon <phase>"   admin   (pilot)
-//   - "/sky time <hours>"   admin
-//   - "/sky info"           player  (audit-only)
-//   - "/loot"               admin   (UI toggle + audit)
-//   - "/promote <id> <role>" admin   (mise a jour role via AccountRoleService)
+// Commandes dispatchees (Wave 1 + Wave 2) :
+//   Wave 1 (debug + admin tool) :
+//     - "/sky moon <phase>"      admin        (pilot)
+//     - "/sky time <hours>"      admin
+//     - "/sky info"              player       (audit-only)
+//     - "/loot"                  admin        (UI toggle + audit)
+//     - "/promote <id> <role>"   admin        (AccountRoleService::SetRole)
+//   Wave 2 (moderation) :
+//     - "/who"                   player       (liste joueurs connectes)
+//     - "/report <player>"       player       (cree un ticket GM)
+//     - "/kick <player>"         moderator    (deconnecte un joueur)
+//     - "/mute <player> <min>"   moderator    (chat_mutes via DB)
+//     - "/ban <player> <reason>" game_master  (account_status=Locked + kick)
+//     - "/announce <message>"    game_master  (broadcast canal Server)
+//   Wave 3 (UI panels log-only) : /mail, /quest, /guild, /ah, /skills, /lfg,
+//     /arena, /bg, /pvp, /weather, /events, /rep, /ticket
+//
 // Pour toute autre commande connue du registre, la reponse est un Ok stub
-// avec result vide. Les futures PR ajouteront les dispatchers specifiques
-// (kick, ban, mute, etc.).
+// avec result vide. Les futures PR ajouteront les dispatchers specifiques.
+
+#include "src/shared/network/AdminCommandPayloads.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -34,7 +46,18 @@ namespace engine::server
 	class SessionManager;
 	class ConnectionSessionMap;
 	class AccountRoleService;
+	class AccountStore;
 	class SlashCommandRegistry;
+}
+
+namespace engine::server::db
+{
+	class ConnectionPool;
+}
+
+namespace engine::server::gmtickets
+{
+	class GmTicketSystem;
 }
 
 namespace engine::server
@@ -61,6 +84,19 @@ namespace engine::server
 		/// Branche le registre des commandes (charge depuis slash_commands.json).
 		void SetSlashCommandRegistry(SlashCommandRegistry* r) { m_registry = r; }
 
+		/// Branche l'AccountStore pour resoudre login -> account_id
+		/// (utilise par /kick, /mute, /ban, /report). Si nullptr, ces
+		/// commandes repondront ServerError.
+		void SetAccountStore(AccountStore* store) { m_accountStore = store; }
+
+		/// Branche le GmTicketSystem pour creer des tickets via /report.
+		/// Si nullptr, /report repondra ServerError.
+		void SetGmTicketSystem(engine::server::gmtickets::GmTicketSystem* sys) { m_gmTicketSys = sys; }
+
+		/// Branche le pool MySQL pour /mute (INSERT chat_mutes). Si nullptr,
+		/// /mute repondra ServerError.
+		void SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_dbPool = pool; }
+
 		/// Dispatch packet : traite uniquement opcode 195
 		/// (kOpcodeAdminCommandRequest). Pour tout autre opcode, no-op.
 		///
@@ -79,10 +115,69 @@ namespace engine::server
 		void HandleRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,
 		                   const uint8_t* payload, size_t payloadSize);
 
+		/// Dispatch "/who" : enumere les sessions actives, resout
+		/// account_id -> login via AccountStore, et remplit \p resp avec
+		/// "count=N" + "logins=alice,bob,..." en compact CSV.
+		/// \param resp Reponse a remplir (status sera Ok meme si liste vide).
+		void DispatchWho(engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/report <player>" : valide args, resout target par
+		/// login, et cree un ticket GM via GmTicketSystem avec
+		/// actorAccountId comme reporter.
+		/// \param actorAccountId  Compte qui execute la commande.
+		/// \param args            args[0] = nom du joueur cible.
+		/// \param resp            Reponse a remplir (status Ok / InvalidArgs / ServerError).
+		void DispatchReport(uint64_t actorAccountId,
+		                    const std::vector<std::string>& args,
+		                    engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/kick <player>" : verifie role inferieur strict
+		/// (un mod ne kick pas un mod), trouve la connexion via la
+		/// snapshot connMap, puis CloseConnection.
+		/// \param actorAccountId  Compte qui execute la commande.
+		/// \param args            args[0] = nom du joueur cible.
+		/// \param resp            Reponse a remplir.
+		void DispatchKick(uint64_t actorAccountId,
+		                  const std::vector<std::string>& args,
+		                  engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/mute <player> <duration_minutes>" : verifie role
+		/// inferieur strict, INSERT/REPLACE dans la table chat_mutes avec
+		/// until_ts = NowUnixMsUtc() + duration_minutes * 60_000.
+		/// \param actorAccountId  Compte qui execute la commande.
+		/// \param args            args[0] = nom joueur, args[1] = duree en minutes (>0).
+		/// \param resp            Reponse a remplir.
+		void DispatchMute(uint64_t actorAccountId,
+		                  const std::vector<std::string>& args,
+		                  engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/ban <player> <reason>" : verifie role inferieur,
+		/// UPDATE accounts.status=Locked via AccountStore::SetAccountStatus,
+		/// puis deconnecte le compte si online.
+		/// \param actorAccountId  Compte qui execute la commande.
+		/// \param args            args[0] = nom joueur, args[1..] = raison libre.
+		/// \param resp            Reponse a remplir.
+		void DispatchBan(uint64_t actorAccountId,
+		                 const std::vector<std::string>& args,
+		                 engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/announce <message>" : broadcast un ChatRelay
+		/// (channel=Server, sender="[Announce] <actorLogin>") a toutes
+		/// les sessions actives via la snapshot connMap.
+		/// \param actorAccountId  Compte qui execute la commande (pour login dans sender).
+		/// \param args            args[0..] = message complet (concatene si plusieurs).
+		/// \param resp            Reponse a remplir.
+		void DispatchAnnounce(uint64_t actorAccountId,
+		                      const std::vector<std::string>& args,
+		                      engine::network::admin::AdminCommandResponse& resp);
+
 		NetServer*            m_server      = nullptr;
 		SessionManager*       m_sessionMgr  = nullptr;
 		ConnectionSessionMap* m_connMap     = nullptr;
 		AccountRoleService*   m_roleService = nullptr;
 		SlashCommandRegistry* m_registry    = nullptr;
+		AccountStore*         m_accountStore = nullptr;
+		engine::server::gmtickets::GmTicketSystem* m_gmTicketSys = nullptr;
+		engine::server::db::ConnectionPool*        m_dbPool      = nullptr;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -840,7 +840,14 @@ int main(int argc, char** argv)
 	adminCommandHandler.SetConnectionSessionMap(&connSessionMap);
 	adminCommandHandler.SetAccountRoleService(&accountRoleService);
 	adminCommandHandler.SetSlashCommandRegistry(&slashCommandRegistry);
-	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log)");
+	// Wave 2 moderation tools : /who, /report, /kick, /mute, /ban, /announce
+	// necessitent l'AccountStore (lookup login -> account_id), le
+	// GmTicketSystem (creation ticket via /report), et le pool MySQL
+	// (INSERT chat_mutes via /mute).
+	adminCommandHandler.SetAccountStore(accountStore);
+	adminCommandHandler.SetGmTicketSystem(&gmTicketSystem);
+	adminCommandHandler.SetConnectionPool(&dbPool);
+	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log + Wave 2 moderation wiring)");
 
 	// Phase 5 Lunar — Branche le GameEventHandler sur le LunarHandler pour
 	// pouvoir filtrer les events par phase lunaire (event "Nuit de la

--- a/src/masterd/session/SessionManager.cpp
+++ b/src/masterd/session/SessionManager.cpp
@@ -172,6 +172,24 @@ namespace engine::server
 		return it->second.account_id;
 	}
 
+	/// Enumere tous les accountId associes a une session en etat
+	/// Authenticated ou Active. Utilise par AdminCommandHandler::DispatchWho
+	/// pour construire la liste des joueurs connectes. Pas de garantie
+	/// d'ordre (unordered_map). Pas de filtrage role : tous les comptes
+	/// connectes remontent.
+	std::vector<uint64_t> SessionManager::ListActiveAccountIds() const
+	{
+		std::vector<uint64_t> out;
+		out.reserve(m_by_session_id.size());
+		for (const auto& [id, s] : m_by_session_id)
+		{
+			(void)id;
+			if (s.state == SessionState::Authenticated || s.state == SessionState::Active)
+				out.push_back(s.account_id);
+		}
+		return out;
+	}
+
 	void SessionManager::EvictExpired()
 	{
 		auto now = Clock::now();

--- a/src/masterd/session/SessionManager.h
+++ b/src/masterd/session/SessionManager.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace engine::server
 {
@@ -100,6 +101,13 @@ namespace engine::server
 
 		/// Returns account_id for \a session_id if session exists. For M22.4 (shard ticket request).
 		std::optional<uint64_t> GetAccountId(uint64_t session_id) const;
+
+		/// Liste les accountId des sessions actuellement en etat Authenticated
+		/// ou Active. Utilise par AdminCommandHandler (/who) pour enumerer
+		/// les joueurs connectes. L'ordre n'est pas garanti (depend de
+		/// l'iteration unordered_map). Pas de filtrage : tous les comptes
+		/// authentifies remontent, y compris les staff / admins.
+		std::vector<uint64_t> ListActiveAccountIds() const;
 
 	private:
 		using Clock = std::chrono::steady_clock;


### PR DESCRIPTION
## Wave 2 — Moderation commands via AdminCommandHandler

Migration et implémentation des 6 commandes de modération dans `AdminCommandHandler`. Toutes auditées + role-gated.

### Commandes ajoutées

| Commande | minRole | Effet |
|---|---|---|
| `/who` | player | Liste les comptes connectés via `SessionManager::ListActiveAccountIds` |
| `/report <player>` | player | Crée un GM ticket via `GmTicketSystem` |
| `/kick <player>` | moderator | Disconnect via `ConnMap`+`Server::Disconnect`. Check `HasLowerSecurity` |
| `/mute <player> <duration>` | moderator | INSERT chat_mutes avec `muted_until`. Check role |
| `/ban <player> <reason>` | game_master | `AccountStore::SetAccountStatus(banned)` + disconnect |
| `/announce <message>` | game_master | Broadcast `ChatChannel::Server` à toutes les sessions |

### Audit log : 100% couverture

Chaque dispatch passe par `HandleRequest` qui appelle systématiquement :
```
LogAudit(accountId, userRole, req.command, req.args, resp.status)
```
Plus des `LOG_INFO(Audit, ...)` additionnels pour `/kick`, `/ban`, `/announce` (traçabilité action-specific).

Aucun chemin client→server sans audit, conforme à l'exigence sécurité.

### Nouveaux helpers
- `SessionManager::ListActiveAccountIds() -> std::vector<uint64_t>` (pour `/who`)
- `AccountStore::SetAccountStatus(account_id, status)` (InMemory + Mysql)
- `AdminCommandHandler` : 3 nouveaux setters (`SetAccountStore`, `SetGmTicketSystem`, `SetConnectionPool`)
- 6 dispatchers privés (`DispatchWho`, `DispatchReport`, etc.)

### Pattern strict aligné sur Wave 1

Client → opcode 195 → master → audit + role check + dispatch métier → opcode 196 → client affiche dans le chat.

### V1 limitations
- `DisconnectReason::Admin` n'existe pas (utilisé `PeerClosed` pour /kick + /ban). Future PR : ajouter le code.
- `/ban` n'écrit pas `disabled_reason` (colonne pas présente). Reason loggé seulement via audit. Future migration possible.
- `/mute` bypasse `ChatGate` pour l'INSERT — `MakeSqlMuteLookup` le verra au prochain message.
- Pas de tests unitaires (suite à venir).

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — 6 nouveaux dispatchers + 3 setters câblés dans main_linux.cpp. Sans redéploiement, les commandes tomberaient dans le stub Ok générique sans effet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
