### PR TITLE
feat(lunar): Wave 4 -- lighting modulation + craters + config externalization

### DIFF
--- a/config.json
+++ b/config.json
@@ -127,6 +127,11 @@
             "z": 0.0,
             "yaw_deg": 0.0,
             "pitch_deg": -10.0
+        },
+        "lunar": {
+            "_comment": "Phase 5 Lunar (Wave 4) — parametres du cycle lunaire authoritative cote master. cycle_start_unix_ms : timestamp Unix (ms) du debut du cycle de reference (defaut 1767225600000 = 2026-01-01 00:00:00 UTC). cycle_duration_ms : duree d'un cycle complet (defaut 1209600000 = 14 jours reels = 16 phases x ~21h). LunarHandler relit ces deux cles au boot via SetCycleParams() ; un changement requiert un redemarrage du master. Le shardd recalcule la phase via LunarCalendar (header-only), pas besoin de relire ces cles cote shard.",
+            "cycle_start_unix_ms": 1767225600000,
+            "cycle_duration_ms": 1209600000
         }
     },
     "paths": {

--- a/deploy/docker/config/master.config.json
+++ b/deploy/docker/config/master.config.json
@@ -25,5 +25,12 @@
     }
   },
   "paths": { "content": "game/data" },
-  "terms": { "enforce": true }
+  "terms": { "enforce": true },
+  "world": {
+    "lunar": {
+      "_comment": "Phase 5 Lunar (Wave 4) -- parametres du cycle authoritative cote master. Defaults : cycle_start = 1767225600000 ms (2026-01-01 UTC), duration = 1209600000 ms (14 jours reels).",
+      "cycle_start_unix_ms": 1767225600000,
+      "cycle_duration_ms": 1209600000
+    }
+  }
 }

--- a/game/data/shaders/sky.frag
+++ b/game/data/shaders/sky.frag
@@ -81,6 +81,28 @@ vec3 RenderMoonDisk(vec3 viewDir, vec3 baseSky)
 
     vec3 moonSurface = vec3(0.95, 0.92, 0.85) * shadowMask;
 
+    // Wave 4 polish — texture surface lunaire procedurale (no asset needed).
+    // V1 simple : value-noise sparse pour simuler des cratere-spots, plus une
+    // tache plus large simulant un Mare (ex. Mare Tranquillitatis). La
+    // multiplication garde la tonalite generale et assombrit ponctuellement
+    // pour donner du relief visuel. Une PR future pourra remplacer par une
+    // vraie texture lunaire (cube ou sphere mapping). On applique uniquement
+    // si on est dans la zone illuminee (shadowMask > epsilon) pour ne pas
+    // crepiter la zone sombre.
+    if (shadowMask > 0.01)
+    {
+        // Value-noise simple a partir des coords (u, v) du disque.
+        float craterNoise = fract(sin(dot(vec2(u, v), vec2(12.9898, 78.233))) * 43758.5453);
+        // smoothstep(0.85, 0.95) -> ~10% des points donnent un cratere visible.
+        craterNoise = smoothstep(0.85, 0.95, craterNoise);
+        moonSurface *= 1.0 - craterNoise * 0.25;  // assombrissement 25% ponctuel.
+
+        // Cratere "Mare" plus grand a (u=0.2, v=0.1) — ombre douce ~15%.
+        float distFromMare = length(vec2(u - 0.2, v - 0.1));
+        float mareMask     = smoothstep(0.4, 0.3, distFromMare);
+        moonSurface *= 1.0 - mareMask * 0.15;
+    }
+
     // Earthshine sur les phases tres sombres (0..2 et 13..15) : bleute discret
     // sur la partie ombragee.
     if (pc.moonPhase < 3.0 || pc.moonPhase > 13.0)

--- a/src/client/render/DayNightCycle.cpp
+++ b/src/client/render/DayNightCycle.cpp
@@ -234,9 +234,18 @@ namespace engine::render
 		else
 		{
 			// Nighttime: moonlight (dim, cold).
-			m_state.lightColor[0] = kLightColorMoon[0] * kIntensityNight;
-			m_state.lightColor[1] = kLightColorMoon[1] * kIntensityNight;
-			m_state.lightColor[2] = kLightColorMoon[2] * kIntensityNight;
+			//
+			// Wave 4 polish (Phase 5 Lunar) : modulation par moonIllumination
+			// pour qu'une pleine lune (illumination=1) eclaire ~2x plus qu'une
+			// nouvelle lune (illumination=0). Coherent avec la realite physique
+			// (la pleine lune apporte ~0.25 lux, la nouvelle lune ~0). On garde
+			// un plancher 0.5 pour eviter une nuit completement noire en
+			// nouvelle lune (l'ambient minimum + lumiere stellaire compensent).
+			// Formule : moonBoost = 0.5 + illumination * 0.5 -> [0.5..1.0].
+			const float moonBoost = 0.5f + m_state.moonIllumination * 0.5f;
+			m_state.lightColor[0] = kLightColorMoon[0] * kIntensityNight * moonBoost;
+			m_state.lightColor[1] = kLightColorMoon[1] * kIntensityNight * moonBoost;
+			m_state.lightColor[2] = kLightColorMoon[2] * kIntensityNight * moonBoost;
 		}
 
 		// ---- Ambient colour --------------------------------------------------
@@ -245,6 +254,20 @@ namespace engine::render
 		m_state.ambientColor[0] = 0.04f * ambientScale + 0.02f * dayT;
 		m_state.ambientColor[1] = 0.04f * ambientScale + 0.04f * dayT;
 		m_state.ambientColor[2] = 0.08f * ambientScale + 0.06f * dayT;
+
+		// Wave 4 polish (Phase 5 Lunar) : la nuit, on module aussi l'ambient
+		// par moonIllumination. La pleine lune eclaire l'environnement de
+		// maniere diffuse (ciel un peu plus clair, ombres moins noires), la
+		// nouvelle lune au contraire laisse l'ambient minimum (kAmbientNightMin
+		// scaled). On applique le moonBoost UNIQUEMENT si !isSunUp pour ne pas
+		// affecter le rendu jour. Meme formule que pour lightColor (cf. supra).
+		if (!isSunUp)
+		{
+			const float moonBoost = 0.5f + m_state.moonIllumination * 0.5f;
+			m_state.ambientColor[0] *= moonBoost;
+			m_state.ambientColor[1] *= moonBoost;
+			m_state.ambientColor[2] *= moonBoost;
+		}
 
 		// ---- Sky gradient colours -------------------------------------------
 		// Blend between night → dawn/dusk → noon based on sun elevation.

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -666,6 +666,33 @@ int main(int argc, char** argv)
 	lunarHandler.SetServer(&server);
 	lunarHandler.SetSessionManager(&sessionManager);
 	lunarHandler.SetConnectionSessionMap(&connSessionMap);
+
+	// Wave 4 polish (Phase 5 Lunar) -- externalisation des parametres du
+	// cycle dans config.json (cles world.lunar.*). Defaults identiques
+	// aux constantes hardcodees existantes (cycle_start = 2026-01-01 UTC,
+	// duration = 14 jours reels). Lecture en int64_t depuis Config (cf.
+	// src/shared/core/Config.h) puis cast en uint64_t (les valeurs sont
+	// toujours positives). Doit etre appele AVANT le boot Tick pour que
+	// le premier broadcast utilise les bons parametres.
+	{
+		const int64_t kDefaultCycleStartMs = 1767225600000ll;
+		const int64_t kDefaultCycleDurMs   = 1209600000ll;
+		const int64_t cfgStartMs = config.GetInt(
+			"world.lunar.cycle_start_unix_ms", kDefaultCycleStartMs);
+		const int64_t cfgDurMs   = config.GetInt(
+			"world.lunar.cycle_duration_ms", kDefaultCycleDurMs);
+		const uint64_t cycleStartMs = (cfgStartMs > 0)
+			? static_cast<uint64_t>(cfgStartMs)
+			: static_cast<uint64_t>(kDefaultCycleStartMs);
+		const uint64_t cycleDurMs   = (cfgDurMs   > 0)
+			? static_cast<uint64_t>(cfgDurMs)
+			: static_cast<uint64_t>(kDefaultCycleDurMs);
+		lunarHandler.SetCycleParams(cycleStartMs, cycleDurMs);
+		LOG_INFO(Net, "[ServerMain] Lunar cycle config : start={}ms duration={}ms",
+			static_cast<unsigned long long>(cycleStartMs),
+			static_cast<unsigned long long>(cycleDurMs));
+	}
+
 	LOG_INFO(Net, "[ServerMain] LunarHandler configured (Phase 5 Lunar, cycle 14j, 16 phases)");
 
 	// Premier Tick au boot : etablit la phase courante (m_lastBroadcastPhase


### PR DESCRIPTION
## Wave 4 — Lunar visual polish

Affinage visuel du système Lunar : modulation lighting nocturne par phase, externalization config, cratères procéduraux. Vérification des 3 concerns architecturaux PR #562.

### Modulation `lightColor` + `ambientColor` par `moonIllumination`

```cpp
const float moonBoost = 0.5f + (m_state.moonIllumination * 0.5f);  // [0.5..1.0]
m_state.lightColor[0..2] *= moonBoost;
m_state.ambientColor[0..2] *= moonBoost;
```

Effet :
- Nouvelle lune (illumination 0.0) → `moonBoost = 0.5` → nuit la plus sombre
- Pleine lune (illumination 1.0) → `moonBoost = 1.0` → nuit ~2× plus claire

Plancher 0.5 pour éviter pitch-black même en NewMoon.

### Cratères procéduraux dans `sky.frag`

Pas de texture, value-noise pur :
- Bruit ponctuel `fract(sin(dot(...)))` avec `smoothstep(0.85, 0.95)` → 25% darker spots aléatoires
- Patch « Mare » à `(u=0.2, v=0.1)` avec `smoothstep(0.4, 0.3)` → 15% darker (simule un grand bassin)

Encadré par `if (shadowMask > 0.01)` pour ne pas crépiter la zone sombre.

### Configuration externe `world.lunar.*`

`config.json` + `deploy/docker/config/master.config.json` :
```json
"world": {
  "lunar": {
    "cycle_start_unix_ms": 1767225600000,
    "cycle_duration_ms": 1209600000,
    "_comment": "Cycle 14 jours reels (16 phases x ~21h). Default 2026-01-01 UTC."
  }
}
```

`main_linux.cpp` lit ces clés au boot via `Config::GetInt(...)` puis appelle `lunarHandler.SetCycleParams(...)` AVANT le tick initial. Defaults préservés si clés absentes (rétrocompatible).

### 3 concerns architecturaux PR #562 vérifiés (no-op)

| Concern | Localisation | État |
|---|---|---|
| `depthTestEnable=TRUE` + `LESS_OR_EQUAL` + `depthWriteEnable=FALSE` | `SkyPass.cpp:103-106` | ✅ OK |
| 4 color blend attachments (slot[0] RGBA, slots[1..3] mask=0) | `SkyPass.cpp:118-128` | ✅ OK |
| Routing post-lighting via `skyColor.w` flag | `lighting.frag:119-124` | ✅ OK |

Aucune modification nécessaire — tous les 3 fixes étaient déjà en place via PR #562.

### V1 limitations
- Pas de hot-reload des clés `world.lunar.*` (restart master requis pour changement)
- shardd ne reçoit pas les overrides — assume default `kDefaultLunarCycleMs`. Future PR : config sync.
- Pas de tests unitaires sur la modulation lightColor (à ajouter)

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX + CLIENT REQUIS** — master lit nouvelle clé config au boot, client recompile shader sky.frag. Lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
