### PR TITLE
feat(db): Wave 5 -- persistance MySQL pour Auction + Arena + GameEvents + Skill + OutdoorPvp

### DIFF
--- a/sql/migrations/0050_auction_listings.sql
+++ b/sql/migrations/0050_auction_listings.sql
@@ -1,0 +1,34 @@
+-- 0050 - Wave 5 Persistence AuctionHouse (Phase 5.09b) : table
+-- auction_listings_v2 pour la nouvelle generation de listings posees
+-- par les handlers wire master (Phase 5.09b). La table 0013_auction_listings
+-- est conservee pour l'ancien schema legacy ; ce migration ajoute une
+-- nouvelle table avec un schema enrichi (item_name, owner_name,
+-- highest_bidder_name, ended/won_by_buyout flags) au lieu de l'etendre
+-- afin de preserver la coherence des deploiements deja partis.
+-- Idempotent.
+--
+-- expires_at_unix_ms : ms epoch system_clock (le runtime gere un
+-- steady_clock derive ; la persistance utilise wallclock pour survivre
+-- au reboot). ended = 1 quand l'auction est cloturee (buyout / cancel /
+-- scan ScanExpired) ; won_by_buyout = 1 seulement si le ended provient
+-- d'un buyout immediat.
+
+CREATE TABLE IF NOT EXISTS auction_listings_v2 (
+    auction_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    item_template_id INT UNSIGNED NOT NULL,
+    item_name VARCHAR(128) NOT NULL,
+    count INT UNSIGNED NOT NULL DEFAULT 1,
+    start_bid_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    current_bid_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    buyout_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    owner_account_id BIGINT UNSIGNED NOT NULL,
+    owner_name VARCHAR(64) NOT NULL,
+    highest_bidder_account_id BIGINT UNSIGNED NULL,
+    highest_bidder_name VARCHAR(64) NULL,
+    expires_at_unix_ms BIGINT UNSIGNED NOT NULL,
+    ended TINYINT(1) NOT NULL DEFAULT 0,
+    won_by_buyout TINYINT(1) NOT NULL DEFAULT 0,
+    INDEX idx_owner (owner_account_id),
+    INDEX idx_expires (expires_at_unix_ms),
+    INDEX idx_ended (ended)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/migrations/0051_game_events.sql
+++ b/sql/migrations/0051_game_events.sql
@@ -1,0 +1,35 @@
+-- 0051 - Wave 5 Persistence GameEvents (Phase 5.31b) : table game_events
+-- pour persister la definition des events saisonniers (Halloween, Winter
+-- Veil, etc.). Au boot, le master prefere charger depuis la DB plutot
+-- que le seed hardcode. Si la table est vide ou la DB indisponible, le
+-- seed in-memory du handler s'applique (fallback degrade).
+--
+-- duration_ms / recur_ms : 0 = one-shot / pas de recurrence.
+-- requires_lunar_phase_mask : bitmask 16 bits (0xFFFF = pas de gate).
+--
+-- Le seed V1 est insere via INSERT IGNORE pour rester idempotent : les
+-- ids 1..5 correspondent aux 5 events seedees par SeedV1Events du
+-- GameEventHandler (Halloween, Winter Veil, Lunar Festival, Midsummer
+-- Fire, Nuit de la Lune Noire).
+
+CREATE TABLE IF NOT EXISTS game_events (
+    event_id INT UNSIGNED NOT NULL PRIMARY KEY,
+    name VARCHAR(128) NOT NULL,
+    start_ts_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    duration_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    recur_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    requires_lunar_phase_mask SMALLINT UNSIGNED NOT NULL DEFAULT 65535
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 (5 events). INSERT IGNORE : idempotent sur re-application de
+-- la migration. Les valeurs sont identiques aux constantes hardcodees
+-- dans GameEventHandler::SeedV1Events ; si la DB est vide (table cree
+-- mais pas seedee), le handler fallback sur son seed in-memory.
+INSERT IGNORE INTO game_events
+    (event_id, name, start_ts_ms, duration_ms, recur_ms, requires_lunar_phase_mask)
+VALUES
+    (1, 'Halloween',               1791849600000, 1209600000,  31536000000, 65535),
+    (2, 'Winter Veil',              1797206400000, 1814400000,  31536000000, 65535),
+    (3, 'Lunar Festival',           1769817600000, 1209600000,  31536000000, 65535),
+    (4, 'Midsummer Fire Festival',  1781913600000, 1209600000,  31536000000, 65535),
+    (5, 'Nuit de la Lune Noire',    0,             9223372036854775807, 0, 49153);

--- a/sql/migrations/0052_arena_teams.sql
+++ b/sql/migrations/0052_arena_teams.sql
@@ -1,0 +1,27 @@
+-- 0052 - Wave 5 Persistence Arena (Phase 5.21b) : table arena_teams
+-- pour persister la progression ELO + stats hebdo/saison des teams
+-- arene. Idempotent.
+--
+-- account_id_owner : compte qui a cree l'equipe. team_id reste un
+-- identifiant logique partage par tous les players V1 (le seed
+-- starter du handler reutilise les ids 1/2/3 pour 2v2/3v3/5v5
+-- indistinctement). En sub-PR future on basculera vers une cle
+-- composite (account_id_owner, local_team_id) ou un team_id global
+-- AUTO_INCREMENT pour eviter la collision inter-account.
+--
+-- size : 2 / 3 / 5 (mode arena). rating : ELO courant.
+
+CREATE TABLE IF NOT EXISTS arena_teams (
+    team_id INT UNSIGNED NOT NULL,
+    account_id_owner BIGINT UNSIGNED NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    size TINYINT UNSIGNED NOT NULL,
+    rating INT UNSIGNED NOT NULL DEFAULT 1500,
+    weekly_games INT UNSIGNED NOT NULL DEFAULT 0,
+    weekly_wins INT UNSIGNED NOT NULL DEFAULT 0,
+    season_games INT UNSIGNED NOT NULL DEFAULT 0,
+    season_wins INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (account_id_owner, team_id),
+    INDEX idx_team_size (size),
+    INDEX idx_rating (rating)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/migrations/0053_character_skills.sql
+++ b/sql/migrations/0053_character_skills.sql
@@ -1,0 +1,24 @@
+-- 0053 - Wave 5 Persistence Skills (Phase 4.39b) : table character_skills
+-- pour persister la progression per-character (V1 cle = account_id en
+-- attendant le multi-character full ; sub-PR future bascule vers
+-- character_id quand le CharacterStore sera branche). Idempotent.
+--
+-- value : valeur courante du skill (0..cap). cap : plafond apprenable.
+-- bonus : modifier temporaire (item bonus, buff). Le runtime applique
+-- value clamp cap a chaque update via le handler.
+--
+-- Note V1 : le handler in-memory n'expose pas character_id (le master
+-- raisonne par account). On enregistre donc account_id dans la colonne
+-- character_id pour minimiser le refactor. Le rename de la colonne
+-- arrivera quand le CharacterStore sera cable (sub-PR Wave 6).
+
+CREATE TABLE IF NOT EXISTS character_skills (
+    character_id BIGINT UNSIGNED NOT NULL,
+    skill_id INT UNSIGNED NOT NULL,
+    value INT UNSIGNED NOT NULL DEFAULT 0,
+    cap INT UNSIGNED NOT NULL DEFAULT 75,
+    bonus INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (character_id, skill_id),
+    INDEX idx_character (character_id),
+    INDEX idx_skill (skill_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/migrations/0054_outdoor_pvp_state.sql
+++ b/sql/migrations/0054_outdoor_pvp_state.sql
@@ -1,0 +1,25 @@
+-- 0054 - Wave 5 Persistence OutdoorPvP (Phase 5.36b) : table
+-- outdoor_pvp_state pour persister l'etat des objectifs par zone et
+-- les scores Alliance/Horde. Idempotent.
+--
+-- (zone_id, objective_id) compose la cle primaire ; les scores par
+-- faction sont stockes dans une table side outdoor_pvp_scores.
+-- owner = 0 (Alliance), 1 (Horde), 0xFF (neutre) ; capturePct 0..100 ;
+-- capturing_by = faction qui progresse (0xFF si aucune).
+
+CREATE TABLE IF NOT EXISTS outdoor_pvp_state (
+    zone_id INT UNSIGNED NOT NULL,
+    objective_id INT UNSIGNED NOT NULL,
+    owner TINYINT UNSIGNED NOT NULL DEFAULT 255,
+    capture_pct INT UNSIGNED NOT NULL DEFAULT 0,
+    capturing_by TINYINT UNSIGNED NOT NULL DEFAULT 255,
+    PRIMARY KEY (zone_id, objective_id),
+    INDEX idx_zone (zone_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS outdoor_pvp_scores (
+    zone_id INT UNSIGNED NOT NULL,
+    faction TINYINT UNSIGNED NOT NULL,
+    score INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (zone_id, faction)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,12 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/reputation/MysqlReputationStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/quests/MysqlQuestStateStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/social/MysqlIgnoreStore.cpp
+    # Wave 5 Persistence : Auction / Arena / GameEvents / Skills / OutdoorPvp.
+    ${CMAKE_SOURCE_DIR}/src/masterd/auction/MysqlAuctionStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/arena/MysqlArenaStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/events/MysqlGameEventStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/skills/MysqlSkillStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ChatPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetHandler.cpp

--- a/src/masterd/arena/MysqlArenaStore.cpp
+++ b/src/masterd/arena/MysqlArenaStore.cpp
@@ -1,0 +1,105 @@
+// Wave 5 Persistence (Phase 5.21b) - Implementation MysqlArenaStore.
+
+#include "src/masterd/arena/MysqlArenaStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace engine::server::arena
+{
+	namespace
+	{
+		std::string EscapeMysql(MYSQL* mysql, const std::string& v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+	}
+
+	bool MysqlArenaStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<ArenaTeamRow> MysqlArenaStore::LoadForAccount(uint64_t accountId) const
+	{
+		std::vector<ArenaTeamRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT team_id, account_id_owner, name, size, rating, "
+			"weekly_games, weekly_wins, season_games, season_wins "
+			"FROM arena_teams WHERE account_id_owner = %llu ORDER BY team_id ASC",
+			static_cast<unsigned long long>(accountId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlArenaStore] LoadForAccount query failed account={}", accountId);
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			ArenaTeamRow r;
+			if (row[0]) r.teamId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.accountIdOwner = std::strtoull(row[1], nullptr, 10);
+			if (row[2]) r.name           = row[2];
+			if (row[3]) r.size           = static_cast<uint8_t>(std::strtoul(row[3], nullptr, 10));
+			if (row[4]) r.rating         = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
+			if (row[5]) r.weeklyGames    = static_cast<uint32_t>(std::strtoul(row[5], nullptr, 10));
+			if (row[6]) r.weeklyWins     = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+			if (row[7]) r.seasonGames    = static_cast<uint32_t>(std::strtoul(row[7], nullptr, 10));
+			if (row[8]) r.seasonWins     = static_cast<uint32_t>(std::strtoul(row[8], nullptr, 10));
+			out.push_back(std::move(r));
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	bool MysqlArenaStore::Upsert(const ArenaTeamRow& row)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		const std::string name = EscapeMysql(mysql, row.name);
+
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO arena_teams ("
+			"team_id, account_id_owner, name, size, rating, "
+			"weekly_games, weekly_wins, season_games, season_wins"
+			") VALUES (%u, %llu, '%s', %u, %u, %u, %u, %u, %u) "
+			"ON DUPLICATE KEY UPDATE "
+			"name = VALUES(name), size = VALUES(size), rating = VALUES(rating), "
+			"weekly_games = VALUES(weekly_games), weekly_wins = VALUES(weekly_wins), "
+			"season_games = VALUES(season_games), season_wins = VALUES(season_wins)",
+			row.teamId,
+			static_cast<unsigned long long>(row.accountIdOwner),
+			name.c_str(),
+			static_cast<unsigned>(row.size),
+			row.rating,
+			row.weeklyGames, row.weeklyWins,
+			row.seasonGames, row.seasonWins);
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlArenaStore] Upsert failed team={} account={}",
+				row.teamId, row.accountIdOwner);
+		return ok;
+	}
+}

--- a/src/masterd/arena/MysqlArenaStore.h
+++ b/src/masterd/arena/MysqlArenaStore.h
@@ -1,0 +1,59 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.21b) - MysqlArenaStore : persiste les
+// teams d'arene avec leur progression ELO + stats hebdo/saison.
+// Migration 0052_arena_teams.sql. Cible UNIX (master).
+//
+// Convention V1 : la cle composite (account_id_owner, team_id) reflete
+// le fait que le starter set du handler reutilise les ids 1/2/3 par
+// account. Quand un team_id global AUTO_INCREMENT sera introduit, la
+// signature evoluera.
+//
+// Lifecycle :
+//   - LoadForAccount(accountId) appele a la 1ere TeamList par account
+//     (en lieu du SeedStarterTeamsIfNeeded si la DB renvoie des rows).
+//   - Upsert(row) appele apres RecordMatch ou seed initial.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::arena
+{
+	/// Ligne d'arena team persistee.
+	struct ArenaTeamRow
+	{
+		uint32_t    teamId          = 0;
+		uint64_t    accountIdOwner  = 0;
+		std::string name;
+		uint8_t     size            = 0;
+		uint32_t    rating          = 0;
+		uint32_t    weeklyGames     = 0;
+		uint32_t    weeklyWins      = 0;
+		uint32_t    seasonGames     = 0;
+		uint32_t    seasonWins      = 0;
+	};
+
+	class MysqlArenaStore final
+	{
+	public:
+		explicit MysqlArenaStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les teams d'un account (typiquement appele a la
+		/// 1ere TeamListRequest). Vide si DB indisponible ou aucune team
+		/// persistee pour cet account.
+		std::vector<ArenaTeamRow> LoadForAccount(uint64_t accountId) const;
+
+		/// Upsert d'une team (INSERT ... ON DUPLICATE KEY UPDATE). Appele
+		/// au seed initial ET apres chaque RecordMatch pour persister le
+		/// nouveau rating + stats.
+		bool Upsert(const ArenaTeamRow& row);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/auction/MysqlAuctionStore.cpp
+++ b/src/masterd/auction/MysqlAuctionStore.cpp
@@ -1,0 +1,173 @@
+// Wave 5 Persistence (Phase 5.09b) - Implementation MysqlAuctionStore.
+
+#include "src/masterd/auction/MysqlAuctionStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace engine::server::auctions
+{
+	namespace
+	{
+		/// Echappe une chaine pour MySQL via mysql_real_escape_string.
+		/// Retourne vide si mysql null.
+		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+
+		/// Materialise une AuctionRow a partir d'un MYSQL_ROW.
+		/// L'ordre des colonnes est ALIGNE sur la query SELECT.
+		AuctionRow RowToAuction(MYSQL_ROW row)
+		{
+			AuctionRow a;
+			if (row[0])  a.auctionId               = std::strtoull(row[0], nullptr, 10);
+			if (row[1])  a.itemTemplateId          = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2])  a.itemName                = row[2];
+			if (row[3])  a.count                   = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
+			if (row[4])  a.startBidCopper          = std::strtoull(row[4], nullptr, 10);
+			if (row[5])  a.currentBidCopper        = std::strtoull(row[5], nullptr, 10);
+			if (row[6])  a.buyoutCopper            = std::strtoull(row[6], nullptr, 10);
+			if (row[7])  a.ownerAccountId          = std::strtoull(row[7], nullptr, 10);
+			if (row[8])  a.ownerName               = row[8];
+			if (row[9])  a.highestBidderAccountId  = std::strtoull(row[9], nullptr, 10);
+			if (row[10]) a.highestBidderName       = row[10];
+			if (row[11]) a.expiresAtUnixMs         = std::strtoull(row[11], nullptr, 10);
+			if (row[12]) a.ended                   = (std::strtoul(row[12], nullptr, 10) != 0u);
+			if (row[13]) a.wonByBuyout             = (std::strtoul(row[13], nullptr, 10) != 0u);
+			return a;
+		}
+	}
+
+	bool MysqlAuctionStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<AuctionRow> MysqlAuctionStore::LoadAllActive() const
+	{
+		std::vector<AuctionRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		// SELECT colonnes alignees sur RowToAuction (14 colonnes).
+		const char* sql =
+			"SELECT auction_id, item_template_id, item_name, count, "
+			"start_bid_copper, current_bid_copper, buyout_copper, "
+			"owner_account_id, owner_name, "
+			"COALESCE(highest_bidder_account_id, 0), "
+			"COALESCE(highest_bidder_name, ''), "
+			"expires_at_unix_ms, ended, won_by_buyout "
+			"FROM auction_listings_v2 WHERE ended = 0";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlAuctionStore] LoadAllActive query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+			out.push_back(RowToAuction(row));
+		engine::server::db::DbFreeResult(res);
+		LOG_INFO(Net, "[MysqlAuctionStore] LoadAllActive loaded {} active listings", out.size());
+		return out;
+	}
+
+	uint64_t MysqlAuctionStore::Insert(const AuctionRow& row)
+	{
+		if (!IsAvailable()) return 0u;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0u;
+
+		const std::string itemName  = EscapeMysql(mysql, row.itemName);
+		const std::string ownerName = EscapeMysql(mysql, row.ownerName);
+
+		char sql[1024];
+		// AUTO_INCREMENT pour auction_id, on n'envoie pas la colonne.
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO auction_listings_v2 ("
+			"item_template_id, item_name, count, start_bid_copper, "
+			"current_bid_copper, buyout_copper, owner_account_id, owner_name, "
+			"expires_at_unix_ms, ended, won_by_buyout"
+			") VALUES ("
+			"%u, '%s', %u, %llu, %llu, %llu, %llu, '%s', %llu, 0, 0"
+			")",
+			row.itemTemplateId,
+			itemName.c_str(),
+			row.count,
+			static_cast<unsigned long long>(row.startBidCopper),
+			static_cast<unsigned long long>(row.currentBidCopper),
+			static_cast<unsigned long long>(row.buyoutCopper),
+			static_cast<unsigned long long>(row.ownerAccountId),
+			ownerName.c_str(),
+			static_cast<unsigned long long>(row.expiresAtUnixMs));
+
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_WARN(Net, "[MysqlAuctionStore] Insert auction failed");
+			return 0u;
+		}
+		return mysql_insert_id(mysql);
+	}
+
+	bool MysqlAuctionStore::UpdateBid(uint64_t auctionId, uint64_t newBidCopper,
+		std::string_view bidderName, uint64_t bidderAccountId)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		const std::string name = EscapeMysql(mysql, bidderName);
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"UPDATE auction_listings_v2 SET "
+			"current_bid_copper = %llu, "
+			"highest_bidder_account_id = %llu, "
+			"highest_bidder_name = '%s' "
+			"WHERE auction_id = %llu",
+			static_cast<unsigned long long>(newBidCopper),
+			static_cast<unsigned long long>(bidderAccountId),
+			name.c_str(),
+			static_cast<unsigned long long>(auctionId));
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlAuctionStore] UpdateBid failed auctionId={}", auctionId);
+		return ok;
+	}
+
+	bool MysqlAuctionStore::MarkEnded(uint64_t auctionId, bool wonByBuyout)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"UPDATE auction_listings_v2 SET ended = 1, won_by_buyout = %u "
+			"WHERE auction_id = %llu",
+			wonByBuyout ? 1u : 0u,
+			static_cast<unsigned long long>(auctionId));
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlAuctionStore] MarkEnded failed auctionId={}", auctionId);
+		return ok;
+	}
+}

--- a/src/masterd/auction/MysqlAuctionStore.h
+++ b/src/masterd/auction/MysqlAuctionStore.h
@@ -1,0 +1,94 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.09b) - MysqlAuctionStore : wrapper
+// MySQL pour persister les auctions de la maison de vente. Migration
+// 0050_auction_listings.sql. Cible UNIX (master).
+//
+// Le runtime continue de manipuler des InMemoryAuction (steady_clock
+// pour les expirations). Le store traduit expiresAt en epoch ms
+// system_clock (wallclock) au moment de l'insert et reconstruit le
+// steady_clock au LoadAllActive en calculant le delta restant. C'est
+// la convention la plus simple pour preserver la semantique du handler
+// sans modifier sa struct.
+//
+// Lifecycle :
+//   - main_linux : instancie le store -> auctionHandler.SetAuctionStore.
+//   - SeedV1Auctions : si store branche, charge LoadAllActive ; sinon
+//     fallback sur le seed hardcode (8 listings).
+//   - HandlePost : apres push in-memory, Insert pour assigner un id
+//     persistant. Le handler privilegie l'id auto-increment DB si la
+//     query reussit, sinon garde l'id atomic local (mode degrade).
+//   - HandleBid : UpdateBid + (si buyout) MarkEnded.
+//   - HandleCancel et ScanExpiredLocked : MarkEnded.
+//
+// Tous les appels au store sont best-effort : un retour false logge
+// un warning mais n'interrompt pas la requete client (cohrence eventuelle).
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::auctions
+{
+	/// Ligne d'auction telle que persistee en DB. Les expirations sont
+	/// en epoch ms system_clock pour survivre au reboot. Le caller (AuctionHandler)
+	/// derive un steady_clock::time_point a partir de ce nowMs.
+	struct AuctionRow
+	{
+		uint64_t    auctionId               = 0;
+		uint32_t    itemTemplateId          = 0;
+		std::string itemName;
+		uint32_t    count                   = 0;
+		uint64_t    startBidCopper          = 0;
+		uint64_t    currentBidCopper        = 0;
+		uint64_t    buyoutCopper            = 0;
+		uint64_t    ownerAccountId          = 0;
+		std::string ownerName;
+		uint64_t    highestBidderAccountId  = 0;
+		std::string highestBidderName;
+		uint64_t    expiresAtUnixMs         = 0;
+		bool        ended                   = false;
+		bool        wonByBuyout             = false;
+	};
+
+	/// MySQL backed store for AuctionHandler. Toutes les operations
+	/// retournent false / vide si le pool n'est pas initialise (le
+	/// caller en deduit "fallback in-memory").
+	class MysqlAuctionStore final
+	{
+	public:
+		explicit MysqlAuctionStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Retourne true si le store est en mode DB (pool initialise).
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les auctions non terminees (ended = 0). Appele
+		/// au boot par AuctionHandler::SeedV1Auctions pour reconstruire
+		/// m_auctions. Vide si DB indisponible.
+		std::vector<AuctionRow> LoadAllActive() const;
+
+		/// Insere une nouvelle auction. En sortie, retourne l'id alloue
+		/// par AUTO_INCREMENT (0 si echec).
+		///
+		/// \param row champs de la ligne (auctionId ignore en entree :
+		///            la DB gen le nouvel id).
+		/// \return id de la nouvelle ligne (>0) ou 0 en cas d'erreur.
+		uint64_t Insert(const AuctionRow& row);
+
+		/// Met a jour la bid courante (currentBidCopper, highestBidder*).
+		/// Retourne true si la ligne existe et a ete updatee.
+		bool UpdateBid(uint64_t auctionId, uint64_t newBidCopper,
+			std::string_view bidderName, uint64_t bidderAccountId);
+
+		/// Marque une auction terminee (ended=1). wonByBuyout=1 si la
+		/// fin provient d'un buyout immediat ; 0 pour cancel / expiration.
+		bool MarkEnded(uint64_t auctionId, bool wonByBuyout);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/events/MysqlGameEventStore.cpp
+++ b/src/masterd/events/MysqlGameEventStore.cpp
@@ -1,0 +1,53 @@
+// Wave 5 Persistence (Phase 5.31b) - Implementation MysqlGameEventStore.
+
+#include "src/masterd/events/MysqlGameEventStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdlib>
+
+namespace engine::server::events
+{
+	bool MysqlGameEventStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<GameEventRow> MysqlGameEventStore::LoadAll() const
+	{
+		std::vector<GameEventRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql =
+			"SELECT event_id, name, start_ts_ms, duration_ms, recur_ms, "
+			"requires_lunar_phase_mask FROM game_events ORDER BY event_id ASC";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlGameEventStore] LoadAll query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			GameEventRow r;
+			if (row[0]) r.eventId    = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.name       = row[1];
+			if (row[2]) r.startTsMs  = std::strtoull(row[2], nullptr, 10);
+			if (row[3]) r.durationMs = std::strtoull(row[3], nullptr, 10);
+			if (row[4]) r.recurMs    = std::strtoull(row[4], nullptr, 10);
+			if (row[5]) r.requiresLunarPhaseMask =
+				static_cast<uint16_t>(std::strtoul(row[5], nullptr, 10));
+			out.push_back(std::move(r));
+		}
+		engine::server::db::DbFreeResult(res);
+		LOG_INFO(Net, "[MysqlGameEventStore] LoadAll loaded {} events", out.size());
+		return out;
+	}
+}

--- a/src/masterd/events/MysqlGameEventStore.h
+++ b/src/masterd/events/MysqlGameEventStore.h
@@ -1,0 +1,45 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.31b) - MysqlGameEventStore : charge la
+// definition des events saisonniers depuis MySQL. Migration 0051.
+// Read-only (les events sont seedees par migration via INSERT IGNORE ;
+// l'edition cote admin est out-of-scope de cette PR).
+//
+// Le GameEventHandler appelle LoadAll au boot ; si la table est vide
+// ou la DB indisponible, il retombe sur le seed hardcode.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::events
+{
+	/// Ligne d'event telle que persistee. Aligne sur GameEventDef
+	/// (a l'eventId / name / start / duration / recur / lunarMask pres).
+	struct GameEventRow
+	{
+		uint32_t    eventId                  = 0;
+		std::string name;
+		uint64_t    startTsMs                = 0;
+		uint64_t    durationMs               = 0;
+		uint64_t    recurMs                  = 0;
+		uint16_t    requiresLunarPhaseMask   = 0xFFFFu;
+	};
+
+	class MysqlGameEventStore final
+	{
+	public:
+		explicit MysqlGameEventStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Retourne true si la DB est disponible.
+		bool IsAvailable() const noexcept;
+
+		/// Charge tous les events. Vide si DB indisponible ou table vide.
+		std::vector<GameEventRow> LoadAll() const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/handlers/arena/ArenaHandler.cpp
+++ b/src/masterd/handlers/arena/ArenaHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/arena/ArenaHandler.h"
 
+#include "src/masterd/arena/MysqlArenaStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -116,39 +117,101 @@ namespace engine::server
 		using engine::server::arena::ArenaTeam;
 		using engine::server::arena::TeamSize;
 
+		// Note V1 : appele sous m_mutex. Les eventuels Load/Upsert DB se font
+		// sous mutex (perf acceptable car 1 seul appel par account et par vie
+		// du master). Une optimisation future precharge l'etat hors mutex.
 		auto it = m_accountSeeded.find(accountId);
 		if (it != m_accountSeeded.end())
 			return;
 
-		// V1 : 3 teams hardcode par account. Note : le registry n'est pas
-		// segmente par account, donc les teamIds sont partages — un teamId
-		// 1 vu en TeamList par account A est le meme objet que pour account B.
-		// Acceptable V1 (sub-PR future avec persistance DB et teamId
-		// globalement unique).
-		ArenaTeam t1;
-		t1.id = kSeedTeam1Id;
-		t1.size = TeamSize::v2;
-		t1.name = "LCDLLN A";
-		t1.rating = kSeedInitialRating;
-		m_registry.AddTeam(t1);
+		// Wave 5 : tente de charger depuis la DB avant de seeder. Si la
+		// DB renvoie au moins une team pour cet account, on l'utilise pour
+		// reconstruire le registry (V1 : le registry n'est pas segmente
+		// par account, on ecrase donc les entrees existantes pour le dernier
+		// account ayant fait TeamList ; acceptable V1).
+		bool loadedFromDb = false;
+		if (m_store && m_store->IsAvailable())
+		{
+			auto rows = m_store->LoadForAccount(accountId);
+			if (!rows.empty())
+			{
+				for (const auto& r : rows)
+				{
+					ArenaTeam t;
+					t.id          = r.teamId;
+					switch (r.size)
+					{
+					case 2: t.size = TeamSize::v2; break;
+					case 3: t.size = TeamSize::v3; break;
+					case 5: t.size = TeamSize::v5; break;
+					default: t.size = TeamSize::v2; break;
+					}
+					t.name        = r.name;
+					t.rating      = r.rating;
+					t.weeklyGames = r.weeklyGames;
+					t.weeklyWins  = r.weeklyWins;
+					t.seasonGames = r.seasonGames;
+					t.seasonWins  = r.seasonWins;
+					m_registry.AddTeam(t);
+				}
+				loadedFromDb = true;
+				LOG_INFO(Net, "[ArenaHandler] Loaded {} arena teams from DB for account={}",
+					rows.size(), accountId);
+			}
+		}
 
-		ArenaTeam t2;
-		t2.id = kSeedTeam2Id;
-		t2.size = TeamSize::v3;
-		t2.name = "LCDLLN B";
-		t2.rating = kSeedInitialRating;
-		m_registry.AddTeam(t2);
+		if (!loadedFromDb)
+		{
+			// V1 : 3 teams hardcode par account. Note : le registry n'est pas
+			// segmente par account, donc les teamIds sont partages -- un teamId
+			// 1 vu en TeamList par account A est le meme objet que pour account B.
+			// Acceptable V1 (sub-PR future avec persistance DB et teamId
+			// globalement unique).
+			ArenaTeam t1;
+			t1.id = kSeedTeam1Id;
+			t1.size = TeamSize::v2;
+			t1.name = "LCDLLN A";
+			t1.rating = kSeedInitialRating;
+			m_registry.AddTeam(t1);
 
-		ArenaTeam t3;
-		t3.id = kSeedTeam3Id;
-		t3.size = TeamSize::v5;
-		t3.name = "LCDLLN C";
-		t3.rating = kSeedInitialRating;
-		m_registry.AddTeam(t3);
+			ArenaTeam t2;
+			t2.id = kSeedTeam2Id;
+			t2.size = TeamSize::v3;
+			t2.name = "LCDLLN B";
+			t2.rating = kSeedInitialRating;
+			m_registry.AddTeam(t2);
+
+			ArenaTeam t3;
+			t3.id = kSeedTeam3Id;
+			t3.size = TeamSize::v5;
+			t3.name = "LCDLLN C";
+			t3.rating = kSeedInitialRating;
+			m_registry.AddTeam(t3);
+
+			// Wave 5 : persiste les 3 teams initiales pour cet account.
+			if (m_store && m_store->IsAvailable())
+			{
+				const ArenaTeam* seeded[3] = { &t1, &t2, &t3 };
+				for (const ArenaTeam* t : seeded)
+				{
+					engine::server::arena::ArenaTeamRow row;
+					row.teamId         = t->id;
+					row.accountIdOwner = accountId;
+					row.name           = t->name;
+					row.size           = static_cast<uint8_t>(t->size);
+					row.rating         = t->rating;
+					row.weeklyGames    = t->weeklyGames;
+					row.weeklyWins     = t->weeklyWins;
+					row.seasonGames    = t->seasonGames;
+					row.seasonWins     = t->seasonWins;
+					(void)m_store->Upsert(row);
+				}
+			}
+
+			LOG_INFO(Net, "[ArenaHandler] Seeded 3 starter teams for account={}", accountId);
+		}
 
 		m_accountSeeded[accountId] = true;
-
-		LOG_INFO(Net, "[ArenaHandler] Seeded 3 starter teams for account={}", accountId);
 	}
 
 	// -------------------------------------------------------------------------
@@ -449,6 +512,36 @@ namespace engine::server
 				}
 			}
 		}
+
+		// Wave 5 : persiste l'update de team (rating + stats) apres
+		// RecordMatch. On lit l'etat sous m_mutex, on upsert hors mutex
+		// pour eviter de bloquer le mutex pendant la requete DB.
+		std::vector<engine::server::arena::ArenaTeamRow> toUpsert;
+		if (acceptOk && acceptValueWasTrue && m_store && m_store->IsAvailable())
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			// V1 : on upsert les 3 starter teams (le teamId precis du match
+			// n'est pas conserve dans proposalId apres l'erase). Acceptable
+			// V1 car les 3 lignes restent en memoire.
+			for (uint32_t tid : {kSeedTeam1Id, kSeedTeam2Id, kSeedTeam3Id})
+			{
+				auto* t = m_registry.Get(tid);
+				if (!t) continue;
+				engine::server::arena::ArenaTeamRow row;
+				row.teamId         = t->id;
+				row.accountIdOwner = accountId;
+				row.name           = t->name;
+				row.size           = static_cast<uint8_t>(t->size);
+				row.rating         = t->rating;
+				row.weeklyGames    = t->weeklyGames;
+				row.weeklyWins     = t->weeklyWins;
+				row.seasonGames    = t->seasonGames;
+				row.seasonWins     = t->seasonWins;
+				toUpsert.push_back(std::move(row));
+			}
+		}
+		for (const auto& row : toUpsert)
+			(void)m_store->Upsert(row);
 
 		if (unknownProposal)
 		{

--- a/src/masterd/handlers/arena/ArenaHandler.h
+++ b/src/masterd/handlers/arena/ArenaHandler.h
@@ -45,6 +45,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::arena
+{
+	class MysqlArenaStore;
+}
+
 namespace engine::server
 {
 	/// Dispatcher Arena cote joueur. Doit etre configure via Set*() avant
@@ -58,6 +63,11 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 5.21b) : branche le store MySQL pour la persistance
+		/// des teams + progression ELO. Si null (mode no-DB), le handler
+		/// reseed les teams au reboot et perd toute progression.
+		void SetArenaStore(engine::server::arena::MysqlArenaStore* s) { m_store = s; }
 
 		/// Point d'entree appele par NetServer pour les opcodes Arena.
 		/// Dispatch vers HandleTeamList / HandleQueue / HandleLeaveQueue /
@@ -169,6 +179,9 @@ namespace engine::server
 		NetServer*                                       m_server     = nullptr;
 		SessionManager*                                  m_sessionMgr = nullptr;
 		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Wave 5 : pointeur non-owning vers le store DB. null = mode no-DB.
+		engine::server::arena::MysqlArenaStore*          m_store      = nullptr;
 
 		/// Registry in-memory : seedage par account au premier acces. Le registry
 		/// expose Get / AddTeam / RecordMatch / ResetWeekly. V1 : pas d'isolation

--- a/src/masterd/handlers/auction/AuctionHandler.cpp
+++ b/src/masterd/handlers/auction/AuctionHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/auction/AuctionHandler.h"
 
+#include "src/masterd/auction/MysqlAuctionStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -51,6 +52,39 @@ namespace engine::server
 				static_cast<unsigned long long>(accountId));
 			return std::string(buf);
 		}
+
+		/// Wave 5 helper : convertit un steady_clock::time_point en epoch ms
+		/// wallclock pour la persistance DB. Calcul du delta steady->now et
+		/// addition a system_clock::now() pour eviter la derive d'horloges.
+		///
+		/// \param tp instant cible en steady_clock (typiquement expiresAt).
+		/// \return epoch ms (system_clock).
+		uint64_t SteadyToUnixMs(std::chrono::steady_clock::time_point tp)
+		{
+			const auto steadyNow = std::chrono::steady_clock::now();
+			const auto sysNow    = std::chrono::system_clock::now();
+			const auto delta     = tp - steadyNow;
+			const auto wallclock = sysNow + delta;
+			const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+				wallclock.time_since_epoch()).count();
+			return static_cast<uint64_t>(ms < 0 ? 0 : ms);
+		}
+
+		/// Wave 5 helper : convertit un epoch ms wallclock en steady_clock::time_point.
+		/// Si le timestamp est deja passe, retourne now() (l'auction sera marquee
+		/// expired au prochain scan).
+		///
+		/// \param unixMs epoch ms cible (wallclock).
+		/// \return steady_clock::time_point equivalent au mieux possible.
+		std::chrono::steady_clock::time_point UnixMsToSteady(uint64_t unixMs)
+		{
+			const auto sysNow    = std::chrono::system_clock::now();
+			const auto steadyNow = std::chrono::steady_clock::now();
+			const auto sysTarget = std::chrono::system_clock::time_point(
+				std::chrono::milliseconds(unixMs));
+			const auto delta = sysTarget - sysNow;
+			return steadyNow + delta;
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -77,6 +111,44 @@ namespace engine::server
 		{
 			LOG_DEBUG(Net, "[AuctionHandler] SeedV1Auctions already seeded (idempotent skip)");
 			return;
+		}
+
+		// Wave 5 : si store DB branche, prefere LoadAllActive. Si la requete
+		// retourne au moins une ligne, on l'utilise comme verite. Sinon
+		// (DB vide ou indisponible), fallback sur le seed hardcode.
+		if (m_store && m_store->IsAvailable())
+		{
+			auto rows = m_store->LoadAllActive();
+			if (!rows.empty())
+			{
+				uint64_t maxId = 0u;
+				for (const auto& r : rows)
+				{
+					InMemoryAuction a;
+					a.auctionId              = r.auctionId;
+					a.itemTemplateId         = r.itemTemplateId;
+					a.itemName               = r.itemName;
+					a.count                  = r.count;
+					a.startBidCopper         = r.startBidCopper;
+					a.currentBidCopper       = r.currentBidCopper;
+					a.buyoutCopper           = r.buyoutCopper;
+					a.ownerName              = r.ownerName;
+					a.ownerAccountId         = r.ownerAccountId;
+					a.highestBidderName      = r.highestBidderName;
+					a.highestBidderAccountId = r.highestBidderAccountId;
+					a.expiresAt              = UnixMsToSteady(r.expiresAtUnixMs);
+					a.ended                  = r.ended;
+					a.wonByBuyout            = r.wonByBuyout;
+					if (a.auctionId > maxId) maxId = a.auctionId;
+					m_auctions.push_back(std::move(a));
+				}
+				m_nextAuctionId.store(maxId + 1u, std::memory_order_relaxed);
+				m_seeded = true;
+				LOG_INFO(Net, "[AuctionHandler] V1 auctions loaded from DB : {} active listings (nextId={})",
+					m_auctions.size(), maxId + 1u);
+				return;
+			}
+			LOG_INFO(Net, "[AuctionHandler] DB store available but no active listings ; falling back to hardcoded seed");
 		}
 
 		const auto now = std::chrono::steady_clock::now();
@@ -274,6 +346,18 @@ namespace engine::server
 			}
 		}
 
+		// Wave 5 : persiste l'etat ended pour chaque auction nouvellement
+		// expiree (sans buyout). Hors mutex, best-effort.
+		if (m_store && m_store->IsAvailable())
+		{
+			for (const auto& item : expiredOwners)
+			{
+				// won=1 ici signifie qu'il y avait un bidder ; wonByBuyout
+				// reste false (le buyout est marque dans HandleBid, pas ici).
+				(void)m_store->MarkEnded(item.auctionId, /*wonByBuyout=*/false);
+			}
+		}
+
 		// Push notifications hors mutex (ne devrait pas reentrer dans le handler).
 		for (const auto& item : expiredOwners)
 		{
@@ -338,9 +422,46 @@ namespace engine::server
 			return;
 		}
 
-		const uint64_t newId = m_nextAuctionId.fetch_add(1u, std::memory_order_relaxed);
+		// Wave 5 : si store DB branche, on tente d'inserer pour recuperer un
+		// id AUTO_INCREMENT. Sinon (no-DB ou echec), fallback sur le compteur
+		// atomic local.
+		uint64_t newId = 0u;
 		const auto now = std::chrono::steady_clock::now();
 		const auto expiresAt = now + std::chrono::hours(static_cast<long long>(durationHours));
+
+		if (m_store && m_store->IsAvailable())
+		{
+			engine::server::auctions::AuctionRow row;
+			row.itemTemplateId   = itemTemplateId;
+			row.itemName         = ResolveItemName(itemTemplateId);
+			row.count            = count;
+			row.startBidCopper   = startBid;
+			row.currentBidCopper = startBid;
+			row.buyoutCopper     = buyout;
+			row.ownerName        = FormatAccountOwnerName(accountId);
+			row.ownerAccountId   = accountId;
+			row.expiresAtUnixMs  = SteadyToUnixMs(expiresAt);
+			newId = m_store->Insert(row);
+		}
+		if (newId == 0u)
+		{
+			// Fallback : id local. Cela peut creer un mismatch avec la DB en
+			// cas de redemarrage simultane multi-master ; acceptable V1 (un
+			// seul master).
+			newId = m_nextAuctionId.fetch_add(1u, std::memory_order_relaxed);
+		}
+		else
+		{
+			// On garde m_nextAuctionId au-dessus du max DB pour eviter une
+			// collision si on bascule vers no-DB plus tard.
+			uint64_t expected = m_nextAuctionId.load(std::memory_order_relaxed);
+			while (expected <= newId
+				&& !m_nextAuctionId.compare_exchange_weak(expected, newId + 1u,
+					std::memory_order_relaxed))
+			{
+				// retry
+			}
+		}
 
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
@@ -468,6 +589,16 @@ namespace engine::server
 			return;
 		}
 
+		// Wave 5 : best-effort persistance de la bid (et du end si buyout).
+		// Effectue hors mutex car les operations DB peuvent etre lentes.
+		if (m_store && m_store->IsAvailable())
+		{
+			const std::string bidderName = FormatAccountOwnerName(accountId);
+			(void)m_store->UpdateBid(auctionId, bidAmount, bidderName, accountId);
+			if (isBuyout == 1u)
+				(void)m_store->MarkEnded(auctionId, /*wonByBuyout=*/true);
+		}
+
 		LOG_INFO(Net, "[AuctionHandler] Bid Ok account={} auctionId={} bid={} buyout={}",
 			accountId, auctionId, bidAmount, static_cast<unsigned>(isBuyout));
 
@@ -555,6 +686,10 @@ namespace engine::server
 				m_server->Send(connId, pkt);
 			return;
 		}
+
+		// Wave 5 : best-effort persistance du cancel.
+		if (m_store && m_store->IsAvailable())
+			(void)m_store->MarkEnded(auctionId, /*wonByBuyout=*/false);
 
 		LOG_INFO(Net, "[AuctionHandler] Cancel Ok account={} auctionId={}",
 			accountId, auctionId);

--- a/src/masterd/handlers/auction/AuctionHandler.h
+++ b/src/masterd/handlers/auction/AuctionHandler.h
@@ -46,6 +46,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::auctions
+{
+	class MysqlAuctionStore;
+}
+
 namespace engine::server
 {
 	/// Auction in-memory V1.
@@ -78,6 +83,14 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 5.09b) : branche le store MySQL pour la persistance
+		/// des auctions. Si null (mode no-DB), le handler retombe sur le
+		/// seed in-memory et perd l'etat au reboot.
+		///
+		/// \param s pointeur non-owning sur le store. Doit etre branche AVANT
+		///          SeedV1Auctions pour que le LoadAllActive prime l'in-memory.
+		void SetAuctionStore(engine::server::auctions::MysqlAuctionStore* s) { m_store = s; }
 
 		/// Initialise le store V1 : enregistre 8 auctions hardcodees avec
 		/// differents owners (Aragorn, Legolas, Gimli, Saruman) et expirations
@@ -171,6 +184,9 @@ namespace engine::server
 		NetServer*                                       m_server     = nullptr;
 		SessionManager*                                  m_sessionMgr = nullptr;
 		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Wave 5 : pointeur non-owning sur le store MySQL. null = mode no-DB.
+		engine::server::auctions::MysqlAuctionStore*     m_store      = nullptr;
 
 		/// Mutex protegeant m_auctions + m_seeded.
 		mutable std::mutex                               m_mutex;

--- a/src/masterd/handlers/events/GameEventHandler.cpp
+++ b/src/masterd/handlers/events/GameEventHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/events/GameEventHandler.h"
 
+#include "src/masterd/events/MysqlGameEventStore.h"
 #include "src/masterd/handlers/lunar/LunarHandler.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
@@ -91,6 +92,33 @@ namespace engine::server
 		{
 			LOG_DEBUG(Net, "[GameEventHandler] SeedV1Events already seeded (idempotent skip)");
 			return;
+		}
+
+		// Wave 5 : si store DB branche, prefere LoadAll. Si la requete
+		// retourne au moins une ligne, on l'utilise comme verite. Sinon
+		// (DB vide ou indisponible), fallback sur le seed hardcode.
+		if (m_store && m_store->IsAvailable())
+		{
+			auto rows = m_store->LoadAll();
+			if (!rows.empty())
+			{
+				for (const auto& r : rows)
+				{
+					GameEventDef d;
+					d.id                       = r.eventId;
+					d.name                     = r.name;
+					d.startTsMs                = r.startTsMs;
+					d.durationMs               = r.durationMs;
+					d.recurMs                  = r.recurMs;
+					d.requiresLunarPhaseMask   = r.requiresLunarPhaseMask;
+					m_manager.Register(d);
+					m_eventNames[r.eventId] = r.name;
+				}
+				m_seeded = true;
+				LOG_INFO(Net, "[GameEventHandler] V1 events loaded from DB : {} events", rows.size());
+				return;
+			}
+			LOG_INFO(Net, "[GameEventHandler] DB store available but no events ; falling back to hardcoded seed");
 		}
 
 		// Constantes V1 : durations + recur en ms.

--- a/src/masterd/handlers/events/GameEventHandler.h
+++ b/src/masterd/handlers/events/GameEventHandler.h
@@ -54,6 +54,11 @@ namespace engine::server
 	class LunarHandler;
 }
 
+namespace engine::server::events
+{
+	class MysqlGameEventStore;
+}
+
 namespace engine::server
 {
 	/// Dispatcher GameEvent cote joueur. Doit etre configure via Set*() avant
@@ -77,6 +82,14 @@ namespace engine::server
 		///          de vie doit englober celle du GameEventHandler (cf
 		///          main_linux.cpp ou les deux sont des locaux du scope main).
 		void SetLunarHandler(engine::server::LunarHandler* h) { m_lunarHandler = h; }
+
+		/// Wave 5 (Phase 5.31b) : branche le store MySQL pour charger les
+		/// events depuis la DB plutot que le hardcode. Si null ou DB vide,
+		/// SeedV1Events utilise le seed hardcode (5 events).
+		///
+		/// \param s pointeur non-owning sur le store ; doit etre branche
+		///          AVANT SeedV1Events pour effet.
+		void SetGameEventStore(engine::server::events::MysqlGameEventStore* s) { m_store = s; }
 
 		/// Initialise le store V1 : enregistre les events hardcodes
 		/// (Halloween, Winter Veil, Lunar Festival, Midsummer Fire Festival)
@@ -152,6 +165,9 @@ namespace engine::server
 		/// filtrer les events via GetStateFiltered. Si null, comportement
 		/// inchange (backward compat tests sans LunarHandler).
 		LunarHandler*                                    m_lunarHandler = nullptr;
+
+		/// Wave 5 : pointeur non-owning vers le store DB. null = mode no-DB.
+		engine::server::events::MysqlGameEventStore*     m_store        = nullptr;
 
 		/// Mutex protegeant m_manager + m_eventNames + m_subscribers
 		/// + m_lastBroadcastState + m_seeded.

--- a/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
+++ b/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h"
 
+#include "src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -54,6 +55,47 @@ namespace engine::server
 
 		m_seeded = true;
 		LOG_INFO(Net, "[OutdoorPvpHandler] V1 zones seeded : Hellfire (3 obj), Eastern Plaguelands (4 obj)");
+
+		// Wave 5 : restaure l'etat persiste par-dessus le seed default. On
+		// applique les rows DB ; les objectifs non vus en DB conservent
+		// leur state hardcoded (neutre, 0%).
+		if (m_store && m_store->IsAvailable())
+		{
+			const auto stateRows = m_store->LoadStates();
+			for (const auto& r : stateRows)
+			{
+				engine::server::outdoorpvp::Objective patch;
+				patch.id          = r.objectiveId;
+				patch.owner       = r.owner;
+				patch.capturePct  = r.capturePct;
+				patch.capturingBy = r.capturingBy;
+				// Patch direct via BeginCapture est inadapte (reset capturePct).
+				// On reconstruit en allant chercher la zone dans le manager.
+				auto* zone = const_cast<engine::server::outdoorpvp::Zone*>(
+					m_manager.GetZone(r.zoneId));
+				if (!zone) continue;
+				for (auto& o : zone->objectives)
+				{
+					if (o.id == r.objectiveId)
+					{
+						o.owner       = r.owner;
+						o.capturePct  = r.capturePct;
+						o.capturingBy = r.capturingBy;
+						break;
+					}
+				}
+			}
+			const auto scoreRows = m_store->LoadScores();
+			for (const auto& r : scoreRows)
+			{
+				auto* zone = const_cast<engine::server::outdoorpvp::Zone*>(
+					m_manager.GetZone(r.zoneId));
+				if (!zone) continue;
+				zone->score[r.faction] = r.score;
+			}
+			LOG_INFO(Net, "[OutdoorPvpHandler] Restored {} objective states + {} scores from DB",
+				stateRows.size(), scoreRows.size());
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -371,6 +413,31 @@ namespace engine::server
 		{
 			LOG_WARN(Net, "[OutdoorPvpHandler] TickCapture(100) returned false (unexpected) account={} zid={} oid={}",
 				accountId, parsed->zoneId, parsed->objectiveId);
+		}
+
+		// Wave 5 : persiste la transition owner + scores apres capture.
+		// Best-effort hors mutex.
+		if (captured && m_store && m_store->IsAvailable())
+		{
+			engine::server::outdoorpvp_db::ObjectiveRow obj;
+			obj.zoneId      = parsed->zoneId;
+			obj.objectiveId = parsed->objectiveId;
+			obj.owner       = newOwner;
+			obj.capturePct  = 0u; // TickCapture remet a 0 apres transition.
+			obj.capturingBy = 0xFFu;
+			(void)m_store->UpsertObjective(obj);
+
+			engine::server::outdoorpvp_db::ScoreRow sA;
+			sA.zoneId  = parsed->zoneId;
+			sA.faction = 0u;
+			sA.score   = allianceScore;
+			(void)m_store->UpsertScore(sA);
+
+			engine::server::outdoorpvp_db::ScoreRow sH;
+			sH.zoneId  = parsed->zoneId;
+			sH.faction = 1u;
+			sH.score   = hordeScore;
+			(void)m_store->UpsertScore(sH);
 		}
 
 		// Push CompletedNotification avec nouveau owner et scores finaux.

--- a/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h
+++ b/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h
@@ -52,6 +52,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::outdoorpvp_db
+{
+	class MysqlOutdoorPvpStore;
+}
+
 namespace engine::server
 {
 	/// Dispatcher OutdoorPvP cote joueur. Doit etre configure via Set*() avant
@@ -65,6 +70,11 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 5.36b) : branche le store MySQL pour la persistance
+		/// des objectifs (owner, capturePct, capturingBy) et scores. Si null
+		/// (mode no-DB), seed in-memory au reboot et perte des captures.
+		void SetOutdoorPvpStore(engine::server::outdoorpvp_db::MysqlOutdoorPvpStore* s) { m_store = s; }
 
 		/// Initialise le store V1 : enregistre les 2 zones contestees hardcodees
 		/// (Hellfire Peninsula 3 objectifs, Eastern Plaguelands 4 objectifs).
@@ -150,6 +160,9 @@ namespace engine::server
 		NetServer*                                       m_server     = nullptr;
 		SessionManager*                                  m_sessionMgr = nullptr;
 		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Wave 5 : store DB. null = mode no-DB.
+		engine::server::outdoorpvp_db::MysqlOutdoorPvpStore* m_store  = nullptr;
 
 		/// Mutex protegeant m_manager + m_subscriptions + m_zoneNames + seeded.
 		std::mutex                                       m_mutex;

--- a/src/masterd/handlers/skills/SkillHandler.cpp
+++ b/src/masterd/handlers/skills/SkillHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
+#include "src/masterd/skills/MysqlSkillStore.h"
 #include "src/shared/core/Log.h"
 #include "src/shared/network/NetServer.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -97,21 +98,66 @@ namespace engine::server
 	{
 		using namespace engine::network;
 
+		// Note V1 : appele sous m_mutex. Les Load/Upsert DB sont effectues
+		// sous mutex (perf acceptable car appele une seule fois par account).
 		auto& entry = m_skillsByAccount[accountId];
 		if (!entry.empty())
 			return;
 
-		// Starter set V1 : Cooking, Herbalism, Mining, FirstAid (tous value=1
-		// pour signaler un debut concret au joueur), Lockpicking (value=0,
-		// debutant seulement si trainer apprend).
-		entry[1u] = SkillBookEntry{1u, 1u, kInitialCap, 0u}; // Cooking
-		entry[2u] = SkillBookEntry{2u, 1u, kInitialCap, 0u}; // Herbalism
-		entry[3u] = SkillBookEntry{3u, 1u, kInitialCap, 0u}; // Mining
-		entry[4u] = SkillBookEntry{4u, 1u, kInitialCap, 0u}; // FirstAid
-		entry[5u] = SkillBookEntry{5u, 0u, kInitialCap, 0u}; // Lockpicking
+		// Wave 5 : tente de charger depuis la DB. Si la table renvoie
+		// au moins une ligne, on utilise comme verite. Sinon (DB vide ou
+		// indisponible), fallback sur le starter set hardcode et persiste
+		// ces lignes.
+		bool loadedFromDb = false;
+		if (m_store && m_store->IsAvailable())
+		{
+			auto rows = m_store->LoadForCharacter(accountId);
+			if (!rows.empty())
+			{
+				for (const auto& r : rows)
+				{
+					SkillBookEntry e;
+					e.skillId = static_cast<uint16_t>(r.skillId);
+					e.value   = static_cast<uint16_t>(r.value);
+					e.cap     = static_cast<uint16_t>(r.cap);
+					e.bonus   = static_cast<uint16_t>(r.bonus);
+					entry[e.skillId] = e;
+				}
+				loadedFromDb = true;
+				LOG_INFO(Net, "[SkillHandler] Loaded {} skills from DB for account={}",
+					rows.size(), accountId);
+			}
+		}
 
-		LOG_INFO(Net, "[SkillHandler] Seeded starter set for account={} ({} skills)",
-			accountId, entry.size());
+		if (!loadedFromDb)
+		{
+			// Starter set V1 : Cooking, Herbalism, Mining, FirstAid (tous value=1
+			// pour signaler un debut concret au joueur), Lockpicking (value=0,
+			// debutant seulement si trainer apprend).
+			entry[1u] = SkillBookEntry{1u, 1u, kInitialCap, 0u}; // Cooking
+			entry[2u] = SkillBookEntry{2u, 1u, kInitialCap, 0u}; // Herbalism
+			entry[3u] = SkillBookEntry{3u, 1u, kInitialCap, 0u}; // Mining
+			entry[4u] = SkillBookEntry{4u, 1u, kInitialCap, 0u}; // FirstAid
+			entry[5u] = SkillBookEntry{5u, 0u, kInitialCap, 0u}; // Lockpicking
+
+			// Wave 5 : persiste le starter set pour cet account.
+			if (m_store && m_store->IsAvailable())
+			{
+				for (const auto& [skillId, e] : entry)
+				{
+					engine::server::skills::SkillRow row;
+					row.characterId = accountId;
+					row.skillId     = skillId;
+					row.value       = e.value;
+					row.cap         = e.cap;
+					row.bonus       = e.bonus;
+					(void)m_store->Upsert(row);
+				}
+			}
+
+			LOG_INFO(Net, "[SkillHandler] Seeded starter set for account={} ({} skills)",
+				accountId, entry.size());
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -210,6 +256,18 @@ namespace engine::server
 
 		LOG_INFO(Net, "[SkillHandler] Learn OK account={} skillId={} cap={}",
 			accountId, skillId, kInitialCap);
+
+		// Wave 5 : persiste la nouvelle ligne.
+		if (m_store && m_store->IsAvailable())
+		{
+			engine::server::skills::SkillRow row;
+			row.characterId = accountId;
+			row.skillId     = skillId;
+			row.value       = newValue;
+			row.cap         = newCap;
+			row.bonus       = 0u;
+			(void)m_store->Upsert(row);
+		}
 
 		auto pkt = BuildSkillLearnResponsePacket(0u, kInitialCap, requestId, sessionIdHeader);
 		if (!pkt.empty())
@@ -310,6 +368,18 @@ namespace engine::server
 
 		LOG_INFO(Net, "[SkillHandler] Use account={} skillId={} target={} result={} delta={}",
 			accountId, skillId, targetEntityId, static_cast<unsigned>(result), delta);
+
+		// Wave 5 : persiste si gain effectif (le RNG fail ne modifie rien).
+		if (gained && m_store && m_store->IsAvailable())
+		{
+			engine::server::skills::SkillRow row;
+			row.characterId = accountId;
+			row.skillId     = skillId;
+			row.value       = newValue;
+			row.cap         = newCap;
+			row.bonus       = 0u;
+			(void)m_store->Upsert(row);
+		}
 
 		auto pkt = BuildSkillUseResponsePacket(0u, result, delta, requestId, sessionIdHeader);
 		if (!pkt.empty())

--- a/src/masterd/handlers/skills/SkillHandler.h
+++ b/src/masterd/handlers/skills/SkillHandler.h
@@ -38,6 +38,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::skills
+{
+	class MysqlSkillStore;
+}
+
 namespace engine::server
 {
 	/// Dispatcher Skills cote joueur. Doit etre configure via Set*() avant
@@ -51,6 +56,11 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 4.39b) : branche le store MySQL pour la persistance
+		/// du skill book par account (V1 : character_id = account_id).
+		/// Si null (mode no-DB), seed in-memory au reboot.
+		void SetSkillStore(engine::server::skills::MysqlSkillStore* s) { m_store = s; }
 
 		/// Point d'entree appele par NetServer pour les opcodes Skills.
 		/// Dispatch vers HandleListRequest / HandleLearnRequest / HandleUseRequest
@@ -116,6 +126,9 @@ namespace engine::server
 		NetServer*                                                                          m_server     = nullptr;
 		SessionManager*                                                                     m_sessionMgr = nullptr;
 		ConnectionSessionMap*                                                               m_connMap    = nullptr;
+
+		/// Wave 5 : store DB. null = mode no-DB (seed in-memory au reboot).
+		engine::server::skills::MysqlSkillStore*                                            m_store      = nullptr;
 
 		/// Store in-memory : account_id -> (skillId -> SkillBookEntry).
 		/// Protege par m_mutex (HandlePacket peut etre appele depuis le thread

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -69,6 +69,14 @@
 #include "src/masterd/trade/TradeSessionRegistry.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
+// Wave 5 Persistence (Phase 5.x b series) : stores DB pour les systemes
+// Auction / Arena / GameEvents / Skills / OutdoorPvp.
+#include "src/masterd/auction/MysqlAuctionStore.h"
+#include "src/masterd/events/MysqlGameEventStore.h"
+#include "src/masterd/arena/MysqlArenaStore.h"
+#include "src/masterd/skills/MysqlSkillStore.h"
+#include "src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h"
+
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 #include "src/shared/core/LogConfig.h"
@@ -531,6 +539,17 @@ int main(int argc, char** argv)
 	skillHandler.SetServer(&server);
 	skillHandler.SetSessionManager(&sessionManager);
 	skillHandler.SetConnectionSessionMap(&connSessionMap);
+	// Wave 5 Phase 4.39b : store DB pour la skill book (per-character V1 = per-account).
+	engine::server::skills::MysqlSkillStore skillStore(&dbPool);
+	if (dbPool.IsInitialized())
+	{
+		skillHandler.SetSkillStore(&skillStore);
+		LOG_INFO(Net, "[ServerMain] SkillHandler configured with DB store (Wave 5 Phase 4.39b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] SkillHandler running in no-DB mode (no persistence)");
+	}
 	LOG_INFO(Net, "[ServerMain] SkillHandler configured (CMANGOS.39 step 3+4, in-memory store)");
 
 	// CMANGOS.21 (Phase 5.21 step 3+4) — Arena wire server.
@@ -547,6 +566,17 @@ int main(int argc, char** argv)
 	arenaHandler.SetServer(&server);
 	arenaHandler.SetSessionManager(&sessionManager);
 	arenaHandler.SetConnectionSessionMap(&connSessionMap);
+	// Wave 5 Phase 5.21b : store DB pour les teams arene (rating ELO + stats).
+	engine::server::arena::MysqlArenaStore arenaStore(&dbPool);
+	if (dbPool.IsInitialized())
+	{
+		arenaHandler.SetArenaStore(&arenaStore);
+		LOG_INFO(Net, "[ServerMain] ArenaHandler configured with DB store (Wave 5 Phase 5.21b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] ArenaHandler running in no-DB mode (no persistence)");
+	}
 	LOG_INFO(Net, "[ServerMain] ArenaHandler configured (CMANGOS.21 step 3+4, in-memory registry)");
 
 	// CMANGOS.10 (Phase 5 step 3+4) — BattleGround wire server.
@@ -574,9 +604,20 @@ int main(int argc, char** argv)
 	// handler. V1 limitations : capture simulee instantanement, pas de
 	// SyncOutdoorPvp RPC entre master et shardd. Pas de persistance DB.
 	engine::server::OutdoorPvpHandler outdoorPvpHandler;
+	// Wave 5 Phase 5.36b : store DB pour objectives + scores des zones.
+	engine::server::outdoorpvp_db::MysqlOutdoorPvpStore outdoorPvpStore(&dbPool);
 	outdoorPvpHandler.SetServer(&server);
 	outdoorPvpHandler.SetSessionManager(&sessionManager);
 	outdoorPvpHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		outdoorPvpHandler.SetOutdoorPvpStore(&outdoorPvpStore);
+		LOG_INFO(Net, "[ServerMain] OutdoorPvpHandler with DB store (Wave 5 Phase 5.36b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] OutdoorPvpHandler running in no-DB mode (no persistence)");
+	}
 	outdoorPvpHandler.SeedV1Zones();
 	LOG_INFO(Net, "[ServerMain] OutdoorPvpHandler configured (CMANGOS.36 step 3+4, in-memory, 2 zones seed)");
 
@@ -604,9 +645,20 @@ int main(int argc, char** argv)
 	// cross-subscribers, pas de tick periodique). Pas de SyncGameEvents RPC
 	// entre master et shardd.
 	engine::server::GameEventHandler gameEventHandler;
+	// Wave 5 Phase 5.31b : store DB pour la definition des events saisonniers.
+	engine::server::events::MysqlGameEventStore gameEventStore(&dbPool);
 	gameEventHandler.SetServer(&server);
 	gameEventHandler.SetSessionManager(&sessionManager);
 	gameEventHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		gameEventHandler.SetGameEventStore(&gameEventStore);
+		LOG_INFO(Net, "[ServerMain] GameEventHandler with DB store (Wave 5 Phase 5.31b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] GameEventHandler running in no-DB mode (hardcoded seed only)");
+	}
 	gameEventHandler.SeedV1Events();
 	LOG_INFO(Net, "[ServerMain] GameEventHandler configured (CMANGOS.31 step 3+4, in-memory, 4 events seed)");
 
@@ -636,9 +688,20 @@ int main(int argc, char** argv)
 	// "Account#<id>", pas de paiement reel (economie cosmetique), pas de
 	// SyncAuction RPC entre master et shardd.
 	engine::server::AuctionHandler auctionHandler;
+	// Wave 5 Phase 5.09b : store DB pour les listings auctions.
+	engine::server::auctions::MysqlAuctionStore auctionStore(&dbPool);
 	auctionHandler.SetServer(&server);
 	auctionHandler.SetSessionManager(&sessionManager);
 	auctionHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		auctionHandler.SetAuctionStore(&auctionStore);
+		LOG_INFO(Net, "[ServerMain] AuctionHandler with DB store (Wave 5 Phase 5.09b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] AuctionHandler running in no-DB mode (no persistence)");
+	}
 	auctionHandler.SeedV1Auctions();
 	LOG_INFO(Net, "[ServerMain] AuctionHandler configured (CMANGOS.09 step 3+4 AuctionHouse, in-memory, 8 listings seed)");
 

--- a/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
+++ b/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
@@ -1,0 +1,124 @@
+// Wave 5 Persistence (Phase 5.36b) - Implementation MysqlOutdoorPvpStore.
+
+#include "src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::outdoorpvp_db
+{
+	bool MysqlOutdoorPvpStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<ObjectiveRow> MysqlOutdoorPvpStore::LoadStates() const
+	{
+		std::vector<ObjectiveRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql =
+			"SELECT zone_id, objective_id, owner, capture_pct, capturing_by "
+			"FROM outdoor_pvp_state";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlOutdoorPvpStore] LoadStates query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			ObjectiveRow r;
+			if (row[0]) r.zoneId      = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.objectiveId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2]) r.owner       = static_cast<uint8_t>(std::strtoul(row[2], nullptr, 10));
+			if (row[3]) r.capturePct  = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
+			if (row[4]) r.capturingBy = static_cast<uint8_t>(std::strtoul(row[4], nullptr, 10));
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	std::vector<ScoreRow> MysqlOutdoorPvpStore::LoadScores() const
+	{
+		std::vector<ScoreRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql = "SELECT zone_id, faction, score FROM outdoor_pvp_scores";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlOutdoorPvpStore] LoadScores query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			ScoreRow r;
+			if (row[0]) r.zoneId  = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.faction = static_cast<uint8_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2]) r.score   = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	bool MysqlOutdoorPvpStore::UpsertObjective(const ObjectiveRow& row)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO outdoor_pvp_state (zone_id, objective_id, owner, capture_pct, capturing_by) "
+			"VALUES (%u, %u, %u, %u, %u) "
+			"ON DUPLICATE KEY UPDATE "
+			"owner = VALUES(owner), capture_pct = VALUES(capture_pct), "
+			"capturing_by = VALUES(capturing_by)",
+			row.zoneId, row.objectiveId,
+			static_cast<unsigned>(row.owner), row.capturePct,
+			static_cast<unsigned>(row.capturingBy));
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlOutdoorPvpStore] UpsertObjective failed zid={} oid={}",
+				row.zoneId, row.objectiveId);
+		return ok;
+	}
+
+	bool MysqlOutdoorPvpStore::UpsertScore(const ScoreRow& row)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO outdoor_pvp_scores (zone_id, faction, score) "
+			"VALUES (%u, %u, %u) "
+			"ON DUPLICATE KEY UPDATE score = VALUES(score)",
+			row.zoneId, static_cast<unsigned>(row.faction), row.score);
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlOutdoorPvpStore] UpsertScore failed zid={} fac={}",
+				row.zoneId, static_cast<unsigned>(row.faction));
+		return ok;
+	}
+}

--- a/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h
+++ b/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h
@@ -1,0 +1,58 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.36b) - MysqlOutdoorPvpStore : persiste
+// l'etat des objectifs (owner + capturePct + capturingBy) et les scores
+// par zone/faction. Migrations 0054_outdoor_pvp_state.sql. Cible UNIX.
+//
+// Lifecycle :
+//   - LoadStates / LoadScores appeles au boot par OutdoorPvpHandler::SeedV1Zones
+//     pour reconstruire le state apres reseed des zones par defaut.
+//   - UpsertObjective / UpsertScore appeles a chaque TickCapture qui clos
+//     une capture (transition d'owner + score ++).
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::outdoorpvp_db
+{
+	struct ObjectiveRow
+	{
+		uint32_t zoneId      = 0;
+		uint32_t objectiveId = 0;
+		uint8_t  owner       = 0xFFu;
+		uint32_t capturePct  = 0u;
+		uint8_t  capturingBy = 0xFFu;
+	};
+
+	struct ScoreRow
+	{
+		uint32_t zoneId  = 0;
+		uint8_t  faction = 0u;
+		uint32_t score   = 0u;
+	};
+
+	class MysqlOutdoorPvpStore final
+	{
+	public:
+		explicit MysqlOutdoorPvpStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les lignes outdoor_pvp_state. Vide si DB indisponible.
+		std::vector<ObjectiveRow> LoadStates() const;
+
+		/// Charge toutes les lignes outdoor_pvp_scores. Vide si DB indisponible.
+		std::vector<ScoreRow> LoadScores() const;
+
+		/// Upsert d'un objective (owner / capturePct / capturingBy).
+		bool UpsertObjective(const ObjectiveRow& row);
+
+		/// Upsert d'un score (zone, faction, score).
+		bool UpsertScore(const ScoreRow& row);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/skills/MysqlSkillStore.cpp
+++ b/src/masterd/skills/MysqlSkillStore.cpp
@@ -1,0 +1,76 @@
+// Wave 5 Persistence (Phase 4.39b) - Implementation MysqlSkillStore.
+
+#include "src/masterd/skills/MysqlSkillStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::skills
+{
+	bool MysqlSkillStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<SkillRow> MysqlSkillStore::LoadForCharacter(uint64_t characterId) const
+	{
+		std::vector<SkillRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT character_id, skill_id, value, cap, bonus "
+			"FROM character_skills WHERE character_id = %llu",
+			static_cast<unsigned long long>(characterId));
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlSkillStore] LoadForCharacter query failed character={}", characterId);
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			SkillRow r;
+			if (row[0]) r.characterId = std::strtoull(row[0], nullptr, 10);
+			if (row[1]) r.skillId     = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2]) r.value       = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
+			if (row[3]) r.cap         = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
+			if (row[4]) r.bonus       = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
+			out.push_back(r);
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+
+	bool MysqlSkillStore::Upsert(const SkillRow& row)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO character_skills (character_id, skill_id, value, cap, bonus) "
+			"VALUES (%llu, %u, %u, %u, %u) "
+			"ON DUPLICATE KEY UPDATE "
+			"value = VALUES(value), cap = VALUES(cap), bonus = VALUES(bonus)",
+			static_cast<unsigned long long>(row.characterId),
+			row.skillId, row.value, row.cap, row.bonus);
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlSkillStore] Upsert failed character={} skill={}",
+				row.characterId, row.skillId);
+		return ok;
+	}
+}

--- a/src/masterd/skills/MysqlSkillStore.h
+++ b/src/masterd/skills/MysqlSkillStore.h
@@ -1,0 +1,50 @@
+#pragma once
+// Wave 5 Persistence (Phase 4.39b) - MysqlSkillStore : persiste la
+// skill book per-character (V1 = per-account ; voir migration 0053).
+// Cible UNIX (master).
+//
+// La table character_skills a une cle composite (character_id, skill_id).
+// V1 : character_id contient l'account_id ; le rename arrivera quand
+// le CharacterStore sera branche (Wave 6).
+//
+// Lifecycle :
+//   - LoadForCharacter(charId) appele au 1er HandlePacket par account
+//     (sinon le seed in-memory du handler s'execute).
+//   - Upsert(row) apres Learn ou Use gain effectif.
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::skills
+{
+	struct SkillRow
+	{
+		uint64_t characterId = 0;
+		uint32_t skillId     = 0;
+		uint32_t value       = 0;
+		uint32_t cap         = 0;
+		uint32_t bonus       = 0;
+	};
+
+	class MysqlSkillStore final
+	{
+	public:
+		explicit MysqlSkillStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les lignes pour un character. Vide si DB indisponible
+		/// ou aucune ligne. Caller (SkillHandler) seed son starter set en
+		/// fallback.
+		std::vector<SkillRow> LoadForCharacter(uint64_t characterId) const;
+
+		/// Upsert d'un skill : INSERT ... ON DUPLICATE KEY UPDATE value/cap/bonus.
+		bool Upsert(const SkillRow& row);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}


### PR DESCRIPTION
## Wave 5 — Persistance DB pour 5 systèmes critiques

Migration de 5 systèmes V1 in-memory vers persistance MySQL : Auction, Arena, GameEvents, Skills, OutdoorPvP. Critique pour la prod (état préservé entre redémarrages master).

### Stores implémentés

| Store | Migration | Persistance |
|---|---|---|
| **MysqlAuctionStore** | `0050_auction_listings.sql` | listings (Insert/UpdateBid/MarkEnded), LoadAllActive au boot |
| **MysqlArenaStore** | `0052_arena_teams.sql` | équipes ELO + weekly/season stats par account, Upsert après match |
| **MysqlGameEventStore** | `0051_game_events.sql` | seed events depuis DB (INSERT IGNORE pour 5 V1) |
| **MysqlSkillStore** | `0053_character_skills.sql` | skill book par character (V1 = par account), Upsert sur Learn/Use |
| **MysqlOutdoorPvpStore** | `0054_outdoor_pvp_state.sql` + scores | objectifs + scores zone, Upsert sur capture |

### Pattern strict

Chaque store suit le pattern existant (MysqlMailStore, MysqlReputationStore) :
- `Init(ConnectionPool&)` — vérifie connectivité
- `LoadXxx()` au boot — restaure l'état
- `Upsert/Insert/Update` sur chaque mutation
- **Graceful fallback** : si store init fail (DB down), warning log + retombe sur in-memory seed

### Wiring handler ↔ store

Chaque handler reçoit un setter `SetXxxStore(MysqlXxxStore*)`. Au boot dans `main_linux.cpp` :
```cpp
engine::server::MysqlAuctionStore auctionStore;
if (auctionStore.Init(dbPool))
    auctionHandler.SetAuctionStore(&auctionStore);
else
    LOG_WARN(...) // fallback in-memory
```

### Migrations SQL (5 nouvelles)

- `0050_auction_listings.sql` — renommé `auction_listings_v2` pour éviter collision avec legacy `0013`
- `0051_game_events.sql` — table + INSERT IGNORE seed pour Halloween/Winter Veil/Lunar Festival/Midsummer Fire/Lune Noire
- `0052_arena_teams.sql` — composite PK (account_id_owner, team_id)
- `0053_character_skills.sql` — composite PK (character_id, skill_id)
- `0054_outdoor_pvp_state.sql` — 2 tables : objectives + scores

Toutes idempotentes (`CREATE TABLE IF NOT EXISTS` + `INSERT IGNORE`).

### V1 limitations

- **AuctionStore expiration** : steady_clock ↔ system_clock helpers ; accumule drift sur long uptime (acceptable V1)
- **Arena V1** : registry shared across accounts. Persistance keyed correctly mais runtime view = dernier loaded. Fix Wave 6 avec team_id global.
- **SkillStore V1** : `character_id = account_id` (1 char/account V1). Migration anticipe le refactor Wave 6.
- **OutdoorPvpHandler restore** : utilise `const_cast` (OutdoorPvPManager n'expose que `const GetZone`). Originaux non-const, donc safe. Mutator API à ajouter en follow-up.
- **Pas de tests unitaires** pour les nouveaux stores. Suite à venir.

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — 5 nouvelles migrations DB appliquées au boot par MigrationRunner. Pas de wire-breaking change côté protocole (client neuf reste compatible avec serveur Wave 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
