### PR TITLE
feat(shardd): Wave 6 -- wire AI EventAI + PoolManager runtimes au boot

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -604,6 +604,7 @@ elseif(UNIX)
   add_test(NAME server_list_policy_tests COMMAND server_list_policy_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M22.6: Shard server (ticket handshake + enregistrement TLS/TCP vers le Master via ShardToMasterClient)
+  # Wave 6: + EventAIRuntime + PoolManagerRuntime (tickes + seedes au boot).
   add_executable(shard_app
     ${CMAKE_SOURCE_DIR}/src/shardd/main_linux.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/NetServer.cpp
@@ -617,6 +618,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAI.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAIRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolManagerRuntime.cpp
   )
   target_include_directories(shard_app PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(shard_app PRIVATE engine_core OpenSSL::SSL pthread)

--- a/src/shardd/ai/EventAIRuntime.cpp
+++ b/src/shardd/ai/EventAIRuntime.cpp
@@ -1,0 +1,59 @@
+#include "src/shardd/ai/EventAIRuntime.h"
+
+namespace engine::server::ai
+{
+	/// Charge deux scripts V1 hardcodes :
+	///   - eventId 1 : OnSpawn one-shot (fire au premier Tick), action Say
+	///   - eventId 2 : Timer 30s..30s (fire periodiquement), action Say
+	/// Pas de loader DB pour cette PR : on prouve juste que le path tick
+	/// EventAI -> EvaluateEvents -> mise a jour d'etat est exerce en prod.
+	void EventAIRuntime::SeedV1Events()
+	{
+		m_rows.clear();
+		m_state = EventAIState{};
+		m_totalFires = 0;
+		m_firstTick = true;
+
+		EventAIRow onSpawn;
+		onSpawn.eventId      = 1;
+		onSpawn.trigger      = EventTrigger::OnSpawn;
+		onSpawn.action       = EventAction::Say;
+		onSpawn.actionString = "Greetings, traveler.";
+		onSpawn.oneShot      = true;
+		m_rows.push_back(onSpawn);
+
+		EventAIRow periodicSay;
+		periodicSay.eventId      = 2;
+		periodicSay.trigger      = EventTrigger::Timer;
+		periodicSay.param1       = 30000;   // 30s min
+		periodicSay.param2       = 30000;   // 30s max
+		periodicSay.action       = EventAction::Say;
+		periodicSay.actionString = "I keep an eye on these woods.";
+		periodicSay.oneShot      = false;
+		m_rows.push_back(periodicSay);
+	}
+
+	/// Construit un EventAIContext minimal (HP=100, hors combat) et delegue
+	/// a EvaluateEvents(). Le flag justSpawned n'est vrai qu'au premier
+	/// tick, pour declencher l'event OnSpawn one-shot.
+	std::size_t EventAIRuntime::Tick(uint64_t nowMs)
+	{
+		if (m_rows.empty())
+			return 0;
+
+		EventAIContext ctx;
+		ctx.hpPct             = 100;
+		ctx.targetHpPct       = 100;
+		ctx.justEnteredCombat = false;
+		ctx.justSpawned       = m_firstTick;
+		ctx.justDied          = false;
+		ctx.nowMs             = nowMs;
+
+		std::vector<std::uint32_t> firedIds;
+		EvaluateEvents(m_rows, ctx, m_state, firedIds);
+
+		m_firstTick = false;
+		m_totalFires += firedIds.size();
+		return firedIds.size();
+	}
+}

--- a/src/shardd/ai/EventAIRuntime.h
+++ b/src/shardd/ai/EventAIRuntime.h
@@ -1,0 +1,59 @@
+#pragma once
+// Wave 6 — Wrapper runtime EventAI : agrege l'evaluateur header-only
+// (EventAI.h / EvaluateEvents) avec un etat de creature seede au boot
+// du shardd. V1 minimaliste : 1 a 2 EventAIRow hardcodes (creature qui
+// dit une ligne toutes les N secondes) pour prouver que le systeme
+// tourne en production. Les futurs PR brancheront un loader DB-driven
+// (table event_ai_scripts) qui remplira m_rows par creature.
+//
+// L'objectif principal de cette PR : instanciation + tick periodique
+// dans la boucle main_linux.cpp pour que le path "EventAI evaluator"
+// soit reellement exerce a chaque seconde, plutot que de rester un
+// header-only orphelin.
+
+#include "src/shardd/ai/EventAI.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::ai
+{
+	/// Wrapper minimaliste autour de EvaluateEvents() : detient les rows
+	/// seedes au boot + l'etat (timers + flags one-shot) pour une creature
+	/// fictive V1. Future iteration : map<CreatureGuid, EventAIState> +
+	/// rows charges depuis la DB.
+	class EventAIRuntime
+	{
+	public:
+		EventAIRuntime() = default;
+
+		/// Charge 1-2 scripts EventAI hardcodes (V1) : verifie que le wiring
+		/// est fonctionnel cote shardd. Doit etre appele avant le premier
+		/// Tick(). Idempotent : peut etre rappele pour reset l'etat (utile
+		/// en tests, jamais en prod).
+		void SeedV1Events();
+
+		/// Evalue les rows seedes contre un contexte minimal (creature
+		/// fictive, HP=100, hors combat). Retourne le nombre d'events firees
+		/// ce tick. Effet de bord : met a jour m_state (timers + flags
+		/// one-shot) et incremente m_totalFires.
+		///
+		/// \param nowMs Horloge wall-clock en millisecondes (system_clock
+		///   typiquement). Utilisee pour evaluer EventTrigger::Timer.
+		std::size_t Tick(uint64_t nowMs);
+
+		/// Nombre total d'events firees depuis le boot (cumul sur toute la
+		/// duree de vie du runtime). Util pour le log periodique
+		/// "[EventAI] tick : N events fired".
+		std::uint64_t TotalFires() const noexcept { return m_totalFires; }
+
+		/// Nombre de rows seedes (V1 : 1 ou 2).
+		std::size_t RowCount() const noexcept { return m_rows.size(); }
+
+	private:
+		std::vector<EventAIRow> m_rows;
+		EventAIState            m_state;
+		std::uint64_t           m_totalFires   = 0;
+		bool                    m_firstTick    = true;   ///< Pour declencher OnSpawn une fois.
+	};
+}

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -10,6 +10,9 @@
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 #include "src/shared/core/LogConfig.h"
+// Wave 6 — Wiring runtime des modules internes (EventAI + PoolManager).
+#include "src/shardd/ai/EventAIRuntime.h"
+#include "src/shardd/pools/PoolManagerRuntime.h"
 
 #include <csignal>
 #include <chrono>
@@ -126,6 +129,30 @@ int main(int argc, char** argv)
 	toMaster.SetHeartbeatIntervalSec(static_cast<int>(config.GetInt("shard.heartbeat_interval_sec", 10)));
 	toMaster.Start();
 
+	// Wave 6 — Instanciation + seed des modules internes (EventAI + Pools).
+	// V1 : scripts/pools hardcodes. Future iteration : SeedFromDb() qui
+	// remplace SeedV1Events/SeedV1Pools. Le but ici est de prouver que les
+	// path tick EventAI / Roll PoolManager sont reellement exerces au
+	// runtime, pas seulement testes en unit.
+	engine::server::ai::EventAIRuntime eventAi;
+	eventAi.SeedV1Events();
+	LOG_INFO(AI, "[EventAI] seeded {} V1 events at boot", eventAi.RowCount());
+
+	engine::server::pools::PoolManagerRuntime pools;
+	pools.SeedV1Pools();
+	LOG_INFO(Pools, "[PoolManager] {} pools registered at boot", pools.PoolCount());
+
+	// Tick periodique EventAI : intervalle 1s. La boucle principale tourne
+	// a 100ms (sleep_for(100ms) ci-dessous) donc on filtre via
+	// lastEventAiTickMs. Idem pour le log periodique 60s qui dump le
+	// cumul "N events fired".
+	using clock = std::chrono::steady_clock;
+	auto lastEventAiTickTime = clock::now();
+	auto lastEventAiLogTime  = clock::now();
+	const auto kEventAiTickInterval = std::chrono::milliseconds(1000);
+	const auto kEventAiLogInterval  = std::chrono::seconds(60);
+	std::uint64_t firesSinceLastLog = 0;
+
 	LOG_INFO(Net, "[ShardMain] Shard server running (Ctrl+C to stop); master {}:{} register endpoint='{}'",
 		masterHost, masterPort, regEndpoint);
 
@@ -138,6 +165,27 @@ int main(int argc, char** argv)
 		// a 0 car SetCurrentLoad n'etait jamais appele.
 		toMaster.SetCurrentLoad(server.GetConnectionCount());
 		toMaster.Pump();
+
+		// Wave 6 — Tick EventAI (1Hz). Convertit steady_clock en wall-clock
+		// (system_clock) car les triggers Timer comparent ctx.nowMs avec un
+		// timer interne aussi en ms wall-clock.
+		const auto nowSteady = clock::now();
+		if (nowSteady - lastEventAiTickTime >= kEventAiTickInterval)
+		{
+			const std::uint64_t realNowMs = static_cast<std::uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			firesSinceLastLog += eventAi.Tick(realNowMs);
+			lastEventAiTickTime = nowSteady;
+		}
+		if (nowSteady - lastEventAiLogTime >= kEventAiLogInterval)
+		{
+			LOG_INFO(AI, "[EventAI] tick : {} events fired (last 60s), total since boot {}",
+				firesSinceLastLog, eventAi.TotalFires());
+			firesSinceLastLog = 0;
+			lastEventAiLogTime = nowSteady;
+		}
+
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
 

--- a/src/shardd/pools/PoolManagerRuntime.cpp
+++ b/src/shardd/pools/PoolManagerRuntime.cpp
@@ -1,0 +1,42 @@
+#include "src/shardd/pools/PoolManagerRuntime.h"
+
+namespace engine::server::pools
+{
+	/// Enregistre deux pools V1 :
+	///   - poolId 1 ("wolves") : 3 candidats (spawnIds 1001/1002/1003)
+	///     avec poids 2.0 / 1.0 / 1.0, maxActive=1
+	///   - poolId 2 ("rabbits") : 2 candidats (spawnIds 2001/2002)
+	///     avec poids 1.0 / 1.0, maxActive=2 (les deux peuvent etre actifs)
+	/// Les SpawnIds sont arbitraires : ils referencent une futur table
+	/// creature_spawn dont les binding seront ajoutes en meme temps que
+	/// le loader DB des pools.
+	void PoolManagerRuntime::SeedV1Pools()
+	{
+		Pool wolves;
+		wolves.poolId    = 1;
+		wolves.maxActive = 1;
+		wolves.entries   = {
+			{ 1001, 2.0f },   // dire wolf : poids double
+			{ 1002, 1.0f },   // grey wolf
+			{ 1003, 1.0f }    // shadow wolf
+		};
+		m_mgr.Register(std::move(wolves));
+
+		Pool rabbits;
+		rabbits.poolId    = 2;
+		rabbits.maxActive = 2;
+		rabbits.entries   = {
+			{ 2001, 1.0f },   // brown rabbit
+			{ 2002, 1.0f }    // grey rabbit
+		};
+		m_mgr.Register(std::move(rabbits));
+	}
+
+	/// Delegue a PoolManager::Roll en passant m_rng par reference. Le RNG
+	/// interne est seede une fois via random_device au constructeur ; ne
+	/// pas le re-seeder en cours d'execution (briserait la sequence).
+	std::vector<SpawnId> PoolManagerRuntime::Roll(PoolId poolId)
+	{
+		return m_mgr.Roll(poolId, m_rng);
+	}
+}

--- a/src/shardd/pools/PoolManagerRuntime.h
+++ b/src/shardd/pools/PoolManagerRuntime.h
@@ -1,0 +1,51 @@
+#pragma once
+// Wave 6 — Wrapper runtime PoolManager : detient un PoolManager seede
+// au boot du shardd avec 1-2 pools de demonstration (wolves, rabbits).
+// V1 : pools hardcodes pour prouver que le wiring est correct ; les
+// futurs PR brancheront un loader DB (table pool_template / pool_member)
+// qui remplira m_mgr depuis MySQL.
+//
+// L'objectif principal de cette PR : instanciation au boot + accesseur
+// Roll(PoolId) reutilisable par le code de spawner. Le tirage weighted
+// random (sans replacement) est entierement delegue au header-only
+// PoolManager.h, on n'ajoute pas de logique ici, juste du cablage.
+
+#include "src/shardd/pools/PoolManager.h"
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace engine::server::pools
+{
+	/// Wrapper minimaliste autour de PoolManager : detient le manager,
+	/// un RNG mt19937 (seede via random_device au boot) et expose
+	/// Roll(PoolId) pour le code spawner. Future iteration : SeedFromDb()
+	/// qui replace SeedV1Pools().
+	class PoolManagerRuntime
+	{
+	public:
+		PoolManagerRuntime() : m_rng(std::random_device{}()) {}
+
+		/// Enregistre 1-2 pools V1 hardcodes (wolves, rabbits) pour valider
+		/// le wiring. Idempotent : peut etre rappele pour reset (jamais en
+		/// prod). Voir .cpp pour les valeurs.
+		void SeedV1Pools();
+
+		/// Tire \p count spawns depuis la pool \p poolId. Wrapper direct
+		/// sur PoolManager::Roll qui passe le RNG interne. Retourne vide
+		/// si pool inconnue.
+		///
+		/// \param poolId Identifiant de pool seede via SeedV1Pools() ou un
+		///   futur loader DB.
+		std::vector<SpawnId> Roll(PoolId poolId);
+
+		/// Nombre de pools enregistrees (sert pour le log boot
+		/// "[PoolManager] N pools registered at boot").
+		std::size_t PoolCount() const noexcept { return m_mgr.PoolCount(); }
+
+	private:
+		PoolManager   m_mgr;
+		std::mt19937  m_rng;
+	};
+}


### PR DESCRIPTION
## Wave 6 — Wire AI EventAI + PoolManager dans shardd runtime

Activation au boot du shardd de 2 systèmes serveur dont l'algorithme + tests étaient déjà mergés mais qui n'étaient pas instanciés en runtime.

### Wiring

| Système | Wrapper créé | Tick |
|---|---|---|
| **EventAI** | `EventAIRuntime` (état + 2 events seedés V1) | 1 Hz dans la main loop shardd |
| **PoolManager** | `PoolManagerRuntime` (mt19937 seeded + 2 pools) | Pas de tick (`Roll()` à la demande) |

### Fichiers ajoutés
- `src/shardd/ai/EventAIRuntime.{h,cpp}` — wrapper sur les `EventAIRow` + `EventAIState`
- `src/shardd/pools/PoolManagerRuntime.{h,cpp}` — wrapper sur `PoolManager` + `std::mt19937`

### Fichiers modifiés
- `src/shardd/main_linux.cpp` — instanciation au boot, seed `[EventAI] X events seeded` + `[PoolManager] N pools seeded`, tick 1 Hz EventAI
- `src/CMakeLists.txt` — sources UNIX `shard_app`

### V1 contenu hardcodé
- **EventAI** : 2 events scripts (timed say) — pour démontrer que l'évaluateur tourne
- **PoolManager** : 2 pools (wolves, rabbits)

Future PR : DB-driven via tables `event_ai_scripts`, `pool_template`, `pool_member`.

### V1 limitations
- 1 état EventAI partagé (1 créature fictive). Production : `unordered_map<CreatureGuid, EventAIState>`.
- `EventAction::Say` fires ne push pas encore de chat packet — wiring prouve l'évaluation.
- `PoolManagerRuntime::Roll()` exposé mais aucun spawner ne l'appelle encore.
- Wiring UNIX shardd uniquement (Windows sandbox `server_app` inchangé).

### Déploiement
> ⚠️ **REDÉPLOIEMENT SHARD LINUX REQUIS** — nouveaux runtimes au boot. Pas de wire-breaking côté protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
