### PR TITLE
feat(db): Wave 5 phase 2 -- persistance Guild + BattleGround + Loot stores

### DIFF
--- a/sql/migrations/0055_guilds_master.sql
+++ b/sql/migrations/0055_guilds_master.sql
@@ -1,0 +1,101 @@
+-- 0055 - Wave 5 Persistence Guilds (Phase 5.21b) : tables guilds_master,
+-- guild_members et guild_bank pour persister la definition des guildes
+-- V1 (2 guildes hardcodees + leurs membres + bank tab 0). Au boot, le
+-- master prefere charger depuis la DB plutot que le seed hardcode dans
+-- GuildHandler::SeedV1Guilds. Si la table est vide ou la DB indisponible,
+-- le seed in-memory s'applique (fallback degrade).
+--
+-- guilds_master :
+--   - guild_id : auto-increment PK. V1 ids 1..2 reserves au seed.
+--   - leader_account_id : pointe sur accounts.account_id (mais pas de
+--     FK ici, on garde la table autonome pour permettre des seeds
+--     decorelles des accounts reels).
+--   - created_at_unix_ms : timestamp creation pour l'audit.
+--
+-- guild_members :
+--   - cle composite (guild_id, account_id) : un account ne peut etre
+--     que dans une seule guilde a la fois (regle V1).
+--   - rank_id : 0=Guild Master .. 9=Initiate, defaut 5=Member.
+--
+-- guild_bank :
+--   - bank tab 0 only en V1 (tab_index hardcode a 0 dans le seed mais
+--     la colonne est presente pour preparer V2).
+--   - cle composite (guild_id, tab_index, slot_index) : un slot ne peut
+--     contenir qu'un item type a la fois (stack au niveau du count).
+--
+-- Le seed V1 est insere via INSERT IGNORE pour rester idempotent.
+-- Les 2 guildes "Les Gardiens" (id=1) et "L Ombre" (id=2, sans
+-- apostrophe car ASCII safe MSVC) correspondent au seed hardcode de
+-- GuildHandler::SeedV1Guilds. Les noms de membres sont stockes via
+-- account_id (1=Aragorn, 2=Legolas, 3=Gimli, 4=Frodo, 5=Saruman,
+-- 6=Wormtongue) -- la resolution accountId -> name reste cote handler
+-- (V1 lookup en memoire jusqu'a integration AccountStore).
+
+CREATE TABLE IF NOT EXISTS guilds_master (
+    guild_id            INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name                VARCHAR(64) NOT NULL,
+    motd                VARCHAR(256) NOT NULL DEFAULT '',
+    leader_account_id   BIGINT UNSIGNED NOT NULL,
+    created_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (guild_id),
+    UNIQUE KEY uk_guild_name (name),
+    KEY idx_leader (leader_account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS guild_members (
+    guild_id           INT UNSIGNED NOT NULL,
+    account_id         BIGINT UNSIGNED NOT NULL,
+    rank_id            TINYINT UNSIGNED NOT NULL DEFAULT 5,
+    joined_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (guild_id, account_id),
+    KEY idx_account (account_id),
+    CONSTRAINT fk_guild_members_guild FOREIGN KEY (guild_id)
+        REFERENCES guilds_master(guild_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS guild_bank (
+    guild_id           INT UNSIGNED NOT NULL,
+    tab_index          TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    slot_index         INT UNSIGNED NOT NULL,
+    item_template_id   INT UNSIGNED NOT NULL,
+    item_name          VARCHAR(128) NOT NULL,
+    count              INT UNSIGNED NOT NULL DEFAULT 1,
+    PRIMARY KEY (guild_id, tab_index, slot_index),
+    CONSTRAINT fk_guild_bank_guild FOREIGN KEY (guild_id)
+        REFERENCES guilds_master(guild_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 : 2 guildes + 6 membres + 7 items bank. INSERT IGNORE rend
+-- la migration idempotente (re-application = no-op si dej seedee).
+-- Les timestamps created_at_unix_ms / joined_at_unix_ms sont fixes a
+-- 1767225600000 (2025-12-31 19:00:00 UTC) pour donner un repere
+-- stable a travers les redeploys (corresponds approximativement a
+-- la mise en service V1 alpha).
+
+INSERT IGNORE INTO guilds_master (guild_id, name, motd, leader_account_id, created_at_unix_ms) VALUES
+    (1, 'Les Gardiens', 'Soyez courageux',     1, 1767225600000),
+    (2, 'L Ombre',      'Le pouvoir est tout', 5, 1767225600000);
+
+-- account_id mapping V1 (resolu cote handler via lookup local) :
+--   1=Aragorn (GM), 2=Legolas (Officer), 3=Gimli (Member), 4=Frodo (Initiate)
+--   5=Saruman (GM), 6=Wormtongue (Member)
+INSERT IGNORE INTO guild_members (guild_id, account_id, rank_id, joined_at_unix_ms) VALUES
+    (1, 1, 0, 1767225600000),
+    (1, 2, 1, 1767225600000),
+    (1, 3, 5, 1767225600000),
+    (1, 4, 9, 1767225600000),
+    (2, 5, 0, 1767225600000),
+    (2, 6, 5, 1767225600000);
+
+-- Bank tab 0 : 5 items pour Les Gardiens, 2 items pour L Ombre.
+-- itemTemplateId V1 : 1=Iron Ore, 2=Linen Cloth, 3=Mageweave,
+-- 4=Health Potion, 5=Mana Potion, 6=Black Cloth, 7=Soul Shard.
+-- (Aligne sur le seed in-memory hardcode de SeedV1Guilds.)
+INSERT IGNORE INTO guild_bank (guild_id, tab_index, slot_index, item_template_id, item_name, count) VALUES
+    (1, 0, 0, 1, 'Iron Ore',       100),
+    (1, 0, 1, 2, 'Linen Cloth',    250),
+    (1, 0, 2, 3, 'Mageweave',      80),
+    (1, 0, 3, 4, 'Health Potion',  30),
+    (1, 0, 4, 5, 'Mana Potion',    20),
+    (2, 0, 0, 6, 'Black Cloth',    50),
+    (2, 0, 1, 7, 'Soul Shard',     10);

--- a/sql/migrations/0056_bg_history.sql
+++ b/sql/migrations/0056_bg_history.sql
@@ -1,0 +1,30 @@
+-- 0056 - Wave 5 Persistence BattleGround (Phase 5.10b) : table
+-- bg_match_history pour persister les resultats de matchs joues. Le
+-- BattleGroundHandler insere une ligne via MysqlBattleGroundStore::InsertMatch
+-- a chaque MatchEnd push. Read API LoadRecent(limit) est expose pour
+-- de futures UI leaderboard / stats (out-of-scope de cette PR cote
+-- wire / opcode).
+--
+-- match_id : auto-increment, sert d'identifiant unique persistant
+-- (distinct du matchId in-memory atomic compteur qui reset au reboot).
+-- bg_type : 1=Warsong, 2=Arathi, 3=Alterac V1.
+-- winner_faction : 0=Alliance, 1=Horde, 2=Draw.
+-- started_at_unix_ms : timestamp de creation du match (avant Push Start).
+-- duration_sec : duree totale entre Start et End push.
+--
+-- Pas de seed : la table reste vide jusqu'au premier MatchEnd execute
+-- par le handler. Une DB vide est un etat valide (premier boot).
+
+CREATE TABLE IF NOT EXISTS bg_match_history (
+    match_id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    bg_type             SMALLINT UNSIGNED NOT NULL,
+    map_name            VARCHAR(64) NOT NULL,
+    alliance_score      INT UNSIGNED NOT NULL DEFAULT 0,
+    horde_score         INT UNSIGNED NOT NULL DEFAULT 0,
+    winner_faction      TINYINT UNSIGNED NOT NULL DEFAULT 2,
+    duration_sec        INT UNSIGNED NOT NULL DEFAULT 0,
+    started_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (match_id),
+    KEY idx_started (started_at_unix_ms),
+    KEY idx_bg_type (bg_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/sql/migrations/0057_loot_tables.sql
+++ b/sql/migrations/0057_loot_tables.sql
@@ -1,0 +1,57 @@
+-- 0057 - Wave 5 Persistence Loot (Phase 3.17b) : tables loot_tables +
+-- loot_table_entries pour persister la definition des tables de loot
+-- V1 (wolf_basic, rabbit_basic). Pattern similaire a game_events :
+-- seed via INSERT IGNORE, lecture read-only au boot par le
+-- LootHandler (qui utilise actuellement un tableau hardcode 5 items).
+--
+-- loot_tables :
+--   - table_id : auto-increment PK. V1 ids 1..2 reserves au seed.
+--   - name : identifiant logique unique (wolf_basic, rabbit_basic, ...).
+--
+-- loot_table_entries :
+--   - drop_chance_pct : 0..100, probabilite que l'item drop (V1 simple).
+--   - min_count / max_count : range de quantites possibles. min<=max.
+--   - cle composite (entry_id) auto-increment pour pouvoir insere
+--     plusieurs items du meme template_id dans une meme table.
+--
+-- Pas de UNIQUE sur (table_id, item_template_id) volontairement : il
+-- est legitime d'avoir 2 entrees pour le meme item avec des drop_chance
+-- distinctes (ex. drop pity vs drop bonus).
+
+CREATE TABLE IF NOT EXISTS loot_tables (
+    table_id     INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name         VARCHAR(64) NOT NULL,
+    description  VARCHAR(256) NOT NULL DEFAULT '',
+    PRIMARY KEY (table_id),
+    UNIQUE KEY uk_loot_table_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS loot_table_entries (
+    entry_id           INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    table_id           INT UNSIGNED NOT NULL,
+    item_template_id   INT UNSIGNED NOT NULL,
+    item_name          VARCHAR(128) NOT NULL,
+    drop_chance_pct    INT UNSIGNED NOT NULL DEFAULT 100,
+    min_count          INT UNSIGNED NOT NULL DEFAULT 1,
+    max_count          INT UNSIGNED NOT NULL DEFAULT 1,
+    PRIMARY KEY (entry_id),
+    KEY idx_table (table_id),
+    CONSTRAINT fk_loot_entries_table FOREIGN KEY (table_id)
+        REFERENCES loot_tables(table_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 : 2 tables de base (wolf_basic + rabbit_basic) avec 3 entries
+-- au total. INSERT IGNORE rend la migration idempotente.
+INSERT IGNORE INTO loot_tables (table_id, name, description) VALUES
+    (1, 'wolf_basic',    'Standard wolf drops'),
+    (2, 'rabbit_basic',  'Standard rabbit drops');
+
+-- entry_id explicite pour le seed (sinon AUTO_INCREMENT mais on prefere
+-- des ids stables a travers les re-applications).
+-- Note : item_template_id 1 = Wolf Pelt (pas Iron Ore : on suppose
+-- qu'a partir de la table loot_tables le master peut potentiellement
+-- avoir des noms d'items disjoints du LootHandler hardcode 1..5 actuel).
+INSERT IGNORE INTO loot_table_entries (entry_id, table_id, item_template_id, item_name, drop_chance_pct, min_count, max_count) VALUES
+    (1, 1, 1,   'Wolf Pelt',      80, 1, 2),
+    (2, 1, 100, 'Health Potion',  10, 1, 1),
+    (3, 2, 2,   'Rabbit Foot',    95, 1, 1);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,12 +162,16 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/reputation/MysqlReputationStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/quests/MysqlQuestStateStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/social/MysqlIgnoreStore.cpp
-    # Wave 5 Persistence : Auction / Arena / GameEvents / Skills / OutdoorPvp.
+    # Wave 5 Persistence phase 1 : Auction / Arena / GameEvents / Skills / OutdoorPvp.
     ${CMAKE_SOURCE_DIR}/src/masterd/auction/MysqlAuctionStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/arena/MysqlArenaStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/events/MysqlGameEventStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/skills/MysqlSkillStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
+    # Wave 5 Persistence phase 2 : Guild / BattleGround / Loot stores.
+    ${CMAKE_SOURCE_DIR}/src/masterd/guild/MysqlGuildStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/battleground/MysqlBattleGroundStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/loot/MysqlLootStore.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ChatPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetHandler.cpp

--- a/src/masterd/battleground/MysqlBattleGroundStore.cpp
+++ b/src/masterd/battleground/MysqlBattleGroundStore.cpp
@@ -1,0 +1,114 @@
+// Wave 5 Persistence (Phase 5.10b) - Implementation MysqlBattleGroundStore.
+
+#include "src/masterd/battleground/MysqlBattleGroundStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace engine::server::bg_db
+{
+	namespace
+	{
+		/// Echappe une chaine pour MySQL. Retourne vide si mysql null.
+		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+	}
+
+	bool MysqlBattleGroundStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	uint64_t MysqlBattleGroundStore::InsertMatch(uint16_t bgType, std::string_view mapName,
+		uint32_t allianceScore, uint32_t hordeScore,
+		uint8_t winnerFaction, uint32_t durationSec,
+		uint64_t startedAtUnixMs)
+	{
+		if (!IsAvailable()) return 0u;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0u;
+
+		const std::string mapEsc = EscapeMysql(mysql, mapName);
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO bg_match_history ("
+			"bg_type, map_name, alliance_score, horde_score, "
+			"winner_faction, duration_sec, started_at_unix_ms"
+			") VALUES (%u, '%s', %u, %u, %u, %u, %llu)",
+			static_cast<unsigned>(bgType),
+			mapEsc.c_str(),
+			allianceScore,
+			hordeScore,
+			static_cast<unsigned>(winnerFaction),
+			durationSec,
+			static_cast<unsigned long long>(startedAtUnixMs));
+
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_WARN(Net, "[MysqlBattleGroundStore] InsertMatch failed bgType={} winner={}",
+				static_cast<unsigned>(bgType), static_cast<unsigned>(winnerFaction));
+			return 0u;
+		}
+		const uint64_t newId = mysql_insert_id(mysql);
+		LOG_DEBUG(Net, "[MysqlBattleGroundStore] InsertMatch ok match_id={} bgType={} dur={}s",
+			newId, static_cast<unsigned>(bgType), durationSec);
+		return newId;
+	}
+
+	std::vector<MatchHistoryRow> MysqlBattleGroundStore::LoadRecent(size_t limit) const
+	{
+		std::vector<MatchHistoryRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		// Clamp limit pour eviter une requete monstre par accident.
+		if (limit == 0u) limit = 1u;
+		if (limit > 1000u) limit = 1000u;
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT match_id, bg_type, map_name, alliance_score, "
+			"horde_score, winner_faction, duration_sec, started_at_unix_ms "
+			"FROM bg_match_history ORDER BY started_at_unix_ms DESC LIMIT %zu",
+			limit);
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlBattleGroundStore] LoadRecent query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			MatchHistoryRow r;
+			if (row[0]) r.matchId          = std::strtoull(row[0], nullptr, 10);
+			if (row[1]) r.bgType           = static_cast<uint16_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2]) r.mapName          = row[2];
+			if (row[3]) r.allianceScore    = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
+			if (row[4]) r.hordeScore       = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
+			if (row[5]) r.winnerFaction    = static_cast<uint8_t>(std::strtoul(row[5], nullptr, 10));
+			if (row[6]) r.durationSec      = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+			if (row[7]) r.startedAtUnixMs  = std::strtoull(row[7], nullptr, 10);
+			out.push_back(std::move(r));
+		}
+		engine::server::db::DbFreeResult(res);
+		LOG_INFO(Net, "[MysqlBattleGroundStore] LoadRecent loaded {} rows (limit={})", out.size(), limit);
+		return out;
+	}
+}

--- a/src/masterd/battleground/MysqlBattleGroundStore.h
+++ b/src/masterd/battleground/MysqlBattleGroundStore.h
@@ -1,0 +1,81 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.10b) - MysqlBattleGroundStore : wrapper
+// MySQL pour persister l'historique des matchs BG joues. Migration
+// 0056_bg_history.sql. Cible UNIX (master).
+//
+// Le runtime continue de manipuler des ActiveMatch in-memory (steady_clock
+// pour le startedAt). A chaque MatchEnd push, le BattleGroundHandler appelle
+// InsertMatch pour archiver le resultat. Le matchId in-memory (compteur
+// atomic transient) est distinct du match_id DB (auto-increment).
+//
+// Lifecycle :
+//   - main_linux : instancie le store -> bgHandler.SetMatchHistoryStore.
+//   - Pas de seed / LoadAll au boot : la table est en write-only V1
+//     (l'API LoadRecent est expose pour de futures UI / leaderboard
+//     mais pas branchee en lecture par le handler V1).
+//   - HandleQueue (post-MatchEnd) : InsertMatch best-effort, echec
+//     logge mais n'interrompt pas la sequence wire.
+//
+// Tous les appels au store sont best-effort : un retour false / 0
+// logge un warning mais n'interrompt pas le push MatchEnd au client.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::bg_db
+{
+	/// Ligne d'historique de match BG.
+	struct MatchHistoryRow
+	{
+		uint64_t    matchId            = 0;
+		uint16_t    bgType             = 0;
+		std::string mapName;
+		uint32_t    allianceScore      = 0;
+		uint32_t    hordeScore         = 0;
+		uint8_t     winnerFaction      = 2u;  // 0=Alliance, 1=Horde, 2=Draw.
+		uint32_t    durationSec        = 0;
+		uint64_t    startedAtUnixMs    = 0;
+	};
+
+	/// MySQL backed store pour BattleGroundHandler. Toutes les operations
+	/// retournent false / vide si le pool n'est pas initialise.
+	class MysqlBattleGroundStore final
+	{
+	public:
+		explicit MysqlBattleGroundStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Retourne true si le store est en mode DB (pool initialise).
+		bool IsAvailable() const noexcept;
+
+		/// Insere une ligne d'historique de match. Le match_id DB est
+		/// auto-genere (AUTO_INCREMENT) -- distinct du matchId in-memory
+		/// passe en parametre.
+		///
+		/// \param bgType            type de BG (1=Warsong, 2=Arathi, 3=Alterac).
+		/// \param mapName           nom de la map (UTF-8, <= 64).
+		/// \param allianceScore     score final cote Alliance.
+		/// \param hordeScore        score final cote Horde.
+		/// \param winnerFaction     0=Alliance, 1=Horde, 2=Draw.
+		/// \param durationSec       duree totale du match en secondes.
+		/// \param startedAtUnixMs   timestamp de creation du match (system_clock ms).
+		/// \return match_id DB auto-genere (>0) ou 0 en cas d'echec.
+		uint64_t InsertMatch(uint16_t bgType, std::string_view mapName,
+			uint32_t allianceScore, uint32_t hordeScore,
+			uint8_t winnerFaction, uint32_t durationSec,
+			uint64_t startedAtUnixMs);
+
+		/// Charge les N derniers matchs (par started_at desc) pour une
+		/// future UI leaderboard. Vide si DB indisponible ou table vide.
+		///
+		/// \param limit nombre max de lignes a retourner (defaut 50).
+		std::vector<MatchHistoryRow> LoadRecent(size_t limit = 50u) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/guild/MysqlGuildStore.cpp
+++ b/src/masterd/guild/MysqlGuildStore.cpp
@@ -1,0 +1,209 @@
+// Wave 5 Persistence (Phase 5.21b) - Implementation MysqlGuildStore.
+
+#include "src/masterd/guild/MysqlGuildStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::guilds_db
+{
+	namespace
+	{
+		/// Echappe une chaine pour MySQL via mysql_real_escape_string.
+		/// Retourne vide si mysql null. Wrapper minimal aligne sur le
+		/// pattern utilise dans Wave 5 phase 1 (MysqlAuctionStore).
+		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
+		{
+			if (!mysql) return {};
+			std::vector<char> buf(v.size() * 2 + 1);
+			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
+				static_cast<unsigned long>(v.size()));
+			return std::string(buf.data(), w);
+		}
+	}
+
+	bool MysqlGuildStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<GuildMasterRow> MysqlGuildStore::LoadAll() const
+	{
+		std::vector<GuildMasterRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		// Etape 1 : SELECT guildes. Index dans out / guildIndex pour
+		// pouvoir attacher rapidement les membres + bank lors des queries
+		// suivantes sans repasser par une boucle lineaire.
+		std::unordered_map<uint32_t, size_t> guildIndex;
+		{
+			const char* sql =
+				"SELECT guild_id, name, motd, leader_account_id, "
+				"created_at_unix_ms FROM guilds_master ORDER BY guild_id ASC";
+			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+			if (!res)
+			{
+				LOG_WARN(Net, "[MysqlGuildStore] LoadAll guilds_master query failed");
+				return out;
+			}
+			while (MYSQL_ROW row = mysql_fetch_row(res))
+			{
+				GuildMasterRow g;
+				if (row[0]) g.guildId          = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+				if (row[1]) g.name             = row[1];
+				if (row[2]) g.motd             = row[2];
+				if (row[3]) g.leaderAccountId  = std::strtoull(row[3], nullptr, 10);
+				if (row[4]) g.createdAtUnixMs  = std::strtoull(row[4], nullptr, 10);
+				guildIndex[g.guildId] = out.size();
+				out.push_back(std::move(g));
+			}
+			engine::server::db::DbFreeResult(res);
+		}
+
+		if (out.empty())
+		{
+			LOG_INFO(Net, "[MysqlGuildStore] LoadAll : 0 guilds (DB empty, caller will fallback)");
+			return out;
+		}
+
+		// Etape 2 : SELECT membres. Une seule query pour toutes les
+		// guildes (V1 N reste petit).
+		{
+			const char* sql =
+				"SELECT guild_id, account_id, rank_id, joined_at_unix_ms "
+				"FROM guild_members ORDER BY guild_id ASC, rank_id ASC, account_id ASC";
+			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+			if (!res)
+			{
+				LOG_WARN(Net, "[MysqlGuildStore] LoadAll guild_members query failed");
+				// On retourne quand meme les guildes meme sans membres.
+				return out;
+			}
+			while (MYSQL_ROW row = mysql_fetch_row(res))
+			{
+				GuildMemberRow m;
+				if (row[0]) m.guildId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+				if (row[1]) m.accountId       = std::strtoull(row[1], nullptr, 10);
+				if (row[2]) m.rankId          = static_cast<uint8_t>(std::strtoul(row[2], nullptr, 10));
+				if (row[3]) m.joinedAtUnixMs  = std::strtoull(row[3], nullptr, 10);
+				auto it = guildIndex.find(m.guildId);
+				if (it != guildIndex.end())
+					out[it->second].members.push_back(std::move(m));
+			}
+			engine::server::db::DbFreeResult(res);
+		}
+
+		// Etape 3 : SELECT bank tab 0.
+		{
+			const char* sql =
+				"SELECT guild_id, tab_index, slot_index, item_template_id, "
+				"item_name, count FROM guild_bank WHERE tab_index = 0 "
+				"ORDER BY guild_id ASC, slot_index ASC";
+			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+			if (!res)
+			{
+				LOG_WARN(Net, "[MysqlGuildStore] LoadAll guild_bank query failed");
+				return out;
+			}
+			while (MYSQL_ROW row = mysql_fetch_row(res))
+			{
+				GuildBankItemRow b;
+				if (row[0]) b.guildId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+				if (row[1]) b.tabIndex        = static_cast<uint8_t>(std::strtoul(row[1], nullptr, 10));
+				if (row[2]) b.slotIndex       = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
+				if (row[3]) b.itemTemplateId  = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
+				if (row[4]) b.itemName        = row[4];
+				if (row[5]) b.count           = static_cast<uint32_t>(std::strtoul(row[5], nullptr, 10));
+				auto it = guildIndex.find(b.guildId);
+				if (it != guildIndex.end())
+					out[it->second].bank0.push_back(std::move(b));
+			}
+			engine::server::db::DbFreeResult(res);
+		}
+
+		LOG_INFO(Net, "[MysqlGuildStore] LoadAll loaded {} guilds from DB", out.size());
+		return out;
+	}
+
+	uint32_t MysqlGuildStore::InsertGuild(std::string_view name, std::string_view motd,
+		uint64_t leaderAccountId, uint64_t createdAtUnixMs)
+	{
+		if (!IsAvailable()) return 0u;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return 0u;
+
+		const std::string nameEsc = EscapeMysql(mysql, name);
+		const std::string motdEsc = EscapeMysql(mysql, motd);
+
+		char sql[1024];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO guilds_master (name, motd, leader_account_id, created_at_unix_ms) "
+			"VALUES ('%s', '%s', %llu, %llu)",
+			nameEsc.c_str(),
+			motdEsc.c_str(),
+			static_cast<unsigned long long>(leaderAccountId),
+			static_cast<unsigned long long>(createdAtUnixMs));
+
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_WARN(Net, "[MysqlGuildStore] InsertGuild failed name=<{}>", name);
+			return 0u;
+		}
+		return static_cast<uint32_t>(mysql_insert_id(mysql));
+	}
+
+	bool MysqlGuildStore::InsertMember(uint32_t guildId, uint64_t accountId,
+		uint8_t rankId, uint64_t joinedAtUnixMs)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT INTO guild_members (guild_id, account_id, rank_id, joined_at_unix_ms) "
+			"VALUES (%u, %llu, %u, %llu)",
+			guildId,
+			static_cast<unsigned long long>(accountId),
+			static_cast<unsigned>(rankId),
+			static_cast<unsigned long long>(joinedAtUnixMs));
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlGuildStore] InsertMember failed guildId={} accountId={}", guildId, accountId);
+		return ok;
+	}
+
+	bool MysqlGuildStore::UpdateMotd(uint32_t guildId, std::string_view newMotd)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		const std::string motdEsc = EscapeMysql(mysql, newMotd);
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"UPDATE guilds_master SET motd = '%s' WHERE guild_id = %u",
+			motdEsc.c_str(), guildId);
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+			LOG_WARN(Net, "[MysqlGuildStore] UpdateMotd failed guildId={}", guildId);
+		return ok;
+	}
+}

--- a/src/masterd/guild/MysqlGuildStore.h
+++ b/src/masterd/guild/MysqlGuildStore.h
@@ -1,0 +1,120 @@
+#pragma once
+// Wave 5 Persistence (Phase 5.21b) - MysqlGuildStore : wrapper MySQL
+// pour persister les guildes (definition + membres + bank tab 0).
+// Migration 0055_guilds_master.sql. Cible UNIX (master).
+//
+// Le runtime continue de manipuler des InMemoryGuild (defini dans
+// GuildHandler.h). Le store traduit ces structs vers les 3 tables
+// guilds_master / guild_members / guild_bank (cf. migration 0055).
+//
+// Lifecycle :
+//   - main_linux : instancie le store -> guildHandler.SetGuildStore.
+//   - SeedV1Guilds : si store branche, charge LoadAll ; sinon fallback
+//     sur le seed hardcode (2 guildes).
+//   - V1 read-only cote client : InsertGuild / InsertMember / UpdateMotd
+//     sont exposes pour de futurs handlers (Create / Promote / SetMotd)
+//     mais ne sont pas appeles par les opcodes V1 actuels.
+//
+// Tous les appels au store sont best-effort : un retour false logge
+// un warning mais n'interrompt pas la requete client (coherence eventuelle).
+// L'AccountId pour les membres est utilise tel quel ; la resolution
+// accountId -> accountName reste a la charge du caller (V1 : table
+// hardcoded dans GuildHandler).
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server { struct InMemoryGuild; }
+
+namespace engine::server::guilds_db
+{
+	/// Ligne membre brute telle que persistee. Le rankId 0..9 correspond
+	/// aux noms de rangs WoW (cf. GuildHandler::RankName).
+	struct GuildMemberRow
+	{
+		uint32_t guildId          = 0;
+		uint64_t accountId        = 0;
+		uint8_t  rankId           = 5u;
+		uint64_t joinedAtUnixMs   = 0u;
+	};
+
+	/// Ligne bank tab 0 brute telle que persistee.
+	struct GuildBankItemRow
+	{
+		uint32_t    guildId         = 0;
+		uint8_t     tabIndex        = 0u;
+		uint32_t    slotIndex       = 0u;
+		uint32_t    itemTemplateId  = 0u;
+		std::string itemName;
+		uint32_t    count           = 0u;
+	};
+
+	/// Ligne guilde brute telle que persistee.
+	struct GuildMasterRow
+	{
+		uint32_t                       guildId           = 0;
+		std::string                    name;
+		std::string                    motd;
+		uint64_t                       leaderAccountId   = 0;
+		uint64_t                       createdAtUnixMs   = 0;
+		std::vector<GuildMemberRow>    members;
+		std::vector<GuildBankItemRow>  bank0;
+	};
+
+	/// MySQL backed store pour GuildHandler. Toutes les operations
+	/// retournent false / vide si le pool n'est pas initialise (le
+	/// caller en deduit "fallback in-memory").
+	class MysqlGuildStore final
+	{
+	public:
+		explicit MysqlGuildStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Retourne true si le store est en mode DB (pool initialise).
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les guildes + leurs membres + leur bank tab 0.
+		/// Appele au boot par GuildHandler::SeedV1Guilds pour reconstruire
+		/// m_guilds. Vide si DB indisponible.
+		///
+		/// Note : la resolution accountId -> accountName n'est PAS faite
+		/// ici (le store ne joint pas la table accounts). Le caller
+		/// (GuildHandler) doit completer accountName apres LoadAll en
+		/// utilisant sa table de lookup interne ou un AccountStore.
+		std::vector<GuildMasterRow> LoadAll() const;
+
+		/// Insere une nouvelle guilde. La cle guildId peut etre 0 (la DB
+		/// genere l'id via AUTO_INCREMENT) ou une valeur explicite. Le
+		/// caller recupere l'id alloue via la valeur de retour.
+		///
+		/// \param name              nom unique de la guilde (UTF-8, <= 64).
+		/// \param motd              MOTD initial (UTF-8, <= 256).
+		/// \param leaderAccountId   account_id du leader.
+		/// \param createdAtUnixMs   timestamp creation (system_clock ms).
+		/// \return guildId nouvellement insere (>0) ou 0 en cas d'echec.
+		uint32_t InsertGuild(std::string_view name, std::string_view motd,
+			uint64_t leaderAccountId, uint64_t createdAtUnixMs);
+
+		/// Insere un membre dans une guilde existante. Echoue si le tuple
+		/// (guildId, accountId) existe deja (PRIMARY KEY).
+		///
+		/// \param guildId          id guilde cible.
+		/// \param accountId        account a ajouter.
+		/// \param rankId           rang 0..9 (defaut 5=Member).
+		/// \param joinedAtUnixMs   timestamp d'adhesion.
+		/// \return true en succes, false sinon.
+		bool InsertMember(uint32_t guildId, uint64_t accountId,
+			uint8_t rankId, uint64_t joinedAtUnixMs);
+
+		/// Met a jour le MOTD d'une guilde. Retourne true si la ligne
+		/// existe et a ete updatee.
+		bool UpdateMotd(uint32_t guildId, std::string_view newMotd);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/handlers/battleground/BattleGroundHandler.cpp
+++ b/src/masterd/handlers/battleground/BattleGroundHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/battleground/BattleGroundHandler.h"
 
+#include "src/masterd/battleground/MysqlBattleGroundStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -343,6 +344,22 @@ namespace engine::server
 		}
 
 		PushMatchEnd(connId, newMatchId, winnerFaction, finalAlliance, finalHorde, kV1MatchDuration);
+
+		// Wave 5 (Phase 5.10b) : archive le match en DB (best-effort).
+		// Le startedAtUnixMs est recalcule a partir du chrono in-memory :
+		// system_clock::now() - kV1MatchDuration secondes, approximation
+		// suffisante V1 (le match est joue en quasi-instantane cote master).
+		if (m_historyStore && m_historyStore->IsAvailable())
+		{
+			const auto nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			const uint64_t startedAtMs = (nowMs > kV1MatchDuration * 1000ull)
+				? (nowMs - kV1MatchDuration * 1000ull) : 0ull;
+			m_historyStore->InsertMatch(parsed->bgType, bgInfo.mapName,
+				finalAlliance, finalHorde, winnerFaction,
+				kV1MatchDuration, startedAtMs);
+		}
 
 		// Cleanup : retire le match cote master apres push de End. Le client
 		// gere la disparition cote UI quand il recoit le End.

--- a/src/masterd/handlers/battleground/BattleGroundHandler.h
+++ b/src/masterd/handlers/battleground/BattleGroundHandler.h
@@ -56,6 +56,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::bg_db
+{
+	class MysqlBattleGroundStore;
+}
+
 namespace engine::server
 {
 	/// Dispatcher BattleGround cote joueur. Doit etre configure via Set*() avant
@@ -69,6 +74,15 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 5.10b) : branche le store MySQL pour archiver
+		/// les matchs joues (table bg_match_history). Optionnel ; si
+		/// null ou DB indisponible, les matchs ne sont pas persistes
+		/// (les push wire continuent normalement, mode degrade).
+		///
+		/// \param s pointeur non-owning sur le store. La duree de vie
+		///          doit englober celle du handler (cf main_linux).
+		void SetMatchHistoryStore(engine::server::bg_db::MysqlBattleGroundStore* s) { m_historyStore = s; }
 
 		/// Point d'entree appele par NetServer pour les opcodes BG.
 		/// Dispatch vers HandleList / HandleQueue / HandleLeaveQueue /
@@ -209,6 +223,10 @@ namespace engine::server
 		NetServer*                                       m_server     = nullptr;
 		SessionManager*                                  m_sessionMgr = nullptr;
 		ConnectionSessionMap*                            m_connMap    = nullptr;
+
+		/// Wave 5 (Phase 5.10b) : store DB optionnel pour archiver les
+		/// matchs joues. Non-owning ; lifetime gere par main_linux.
+		engine::server::bg_db::MysqlBattleGroundStore*   m_historyStore = nullptr;
 
 		/// Mutex protegeant queue + matches + accountMatch + nextMatchId + RNG.
 		std::mutex                                       m_mutex;

--- a/src/masterd/handlers/guild/GuildHandler.cpp
+++ b/src/masterd/handlers/guild/GuildHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/guild/GuildHandler.h"
 
+#include "src/masterd/guild/MysqlGuildStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -9,12 +10,41 @@
 #include "src/shared/network/NetServer.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 
+#include <cstdio>
 #include <vector>
 
 namespace engine::server
 {
 	namespace
 	{
+		/// Mapping account_id -> nom de personnage V1. Utilise pour
+		/// reconstituer le member.accountName / guild.leaderName lors
+		/// du LoadAll DB (les tables guild_members / guilds_master
+		/// referencent account_id, pas un display name). V1 hardcode
+		/// 6 entries -- aligne sur le seed de la migration 0055 et le
+		/// seed in-memory hardcode plus bas. Pour un id inconnu on
+		/// fallback sur "Account#<id>" (ASCII safe MSVC).
+		///
+		/// Une PR ulterieure pourra basculer la resolution sur
+		/// AccountStore (lookup live sur la table accounts).
+		std::string ResolveV1AccountName(uint64_t accountId)
+		{
+			switch (accountId)
+			{
+			case 1ull: return std::string("Aragorn");
+			case 2ull: return std::string("Legolas");
+			case 3ull: return std::string("Gimli");
+			case 4ull: return std::string("Frodo");
+			case 5ull: return std::string("Saruman");
+			case 6ull: return std::string("Wormtongue");
+			default:   break;
+			}
+			char buf[32]{};
+			std::snprintf(buf, sizeof(buf), "Account#%llu",
+				static_cast<unsigned long long>(accountId));
+			return std::string(buf);
+		}
+
 		/// Noms des rangs WoW par defaut (0=Guild Master ... 9=Initiate).
 		/// Static array : adresses stables pour const char* pour le wire.
 		const char* const kDefaultRankNames[10] = {
@@ -53,6 +83,52 @@ namespace engine::server
 		{
 			LOG_DEBUG(Net, "[GuildHandler] SeedV1Guilds already seeded (idempotent skip)");
 			return;
+		}
+
+		// Wave 5 phase 2 : si store DB branche, prefere LoadAll. Si la requete
+		// retourne au moins une guilde, on l'utilise comme verite. Sinon
+		// (DB vide ou indisponible), fallback sur le seed hardcode.
+		if (m_store && m_store->IsAvailable())
+		{
+			auto rows = m_store->LoadAll();
+			if (!rows.empty())
+			{
+				for (const auto& r : rows)
+				{
+					InMemoryGuild g;
+					g.guildId    = r.guildId;
+					g.name       = r.name;
+					g.motd       = r.motd;
+					g.leaderName = ResolveV1AccountName(r.leaderAccountId);
+
+					for (const auto& mr : r.members)
+					{
+						InMemoryGuildMember m;
+						m.accountName = ResolveV1AccountName(mr.accountId);
+						m.rankId      = mr.rankId;
+						// online inconnu cote DB V1 (snapshot statique).
+						// Le handler ne push pas d'event presence V1 :
+						// online reste false par defaut sauf pour le leader
+						// (heuristique simple V1 : leader = online).
+						m.online      = (mr.accountId == r.leaderAccountId);
+						g.members.push_back(std::move(m));
+					}
+					for (const auto& bi : r.bank0)
+					{
+						InMemoryGuildBankItem b;
+						b.slotIndex = bi.slotIndex;
+						b.itemName  = bi.itemName;
+						b.count     = bi.count;
+						g.bank0.push_back(std::move(b));
+					}
+					m_perms.SetupWowDefaults(g.guildId);
+					m_guilds.push_back(std::move(g));
+				}
+				m_seeded = true;
+				LOG_INFO(Net, "[GuildHandler] V1 guilds loaded from DB : {} guilds", rows.size());
+				return;
+			}
+			LOG_INFO(Net, "[GuildHandler] DB store available but empty, falling back to hardcoded seed");
 		}
 
 		// Guilde 1 : Les Gardiens.

--- a/src/masterd/handlers/guild/GuildHandler.h
+++ b/src/masterd/handlers/guild/GuildHandler.h
@@ -52,6 +52,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::guilds_db
+{
+	class MysqlGuildStore;
+}
+
 namespace engine::server
 {
 	/// Membre in-memory d'une guilde V1.
@@ -93,9 +98,20 @@ namespace engine::server
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
 
+		/// Wave 5 (Phase 5.21b) : branche le store MySQL pour charger les
+		/// guildes + membres + bank depuis la DB plutot que le hardcode.
+		/// Si null ou DB vide, SeedV1Guilds utilise le seed hardcode
+		/// (2 guildes).
+		///
+		/// \param s pointeur non-owning sur le store ; doit etre branche
+		///          AVANT SeedV1Guilds pour effet.
+		void SetGuildStore(engine::server::guilds_db::MysqlGuildStore* s) { m_store = s; }
+
 		/// Initialise le store V1 : enregistre les 2 guildes hardcodees
 		/// ("Les Gardiens", "L'Ombre") avec leurs membres + bank + perms WoW.
-		/// Idempotent : appelable a chaque boot.
+		/// Idempotent : appelable a chaque boot. Si m_store est branche
+		/// et que la DB contient des guildes, prefere LoadAll au seed
+		/// hardcode (cf. Wave 5 phase 2).
 		void SeedV1Guilds();
 
 		/// Point d'entree appele par NetServer pour les opcodes Guild.
@@ -172,5 +188,10 @@ namespace engine::server
 
 		/// True une fois SeedV1Guilds() appele avec succes.
 		bool                                             m_seeded = false;
+
+		/// Wave 5 (Phase 5.21b) : store DB optionnel. Si non-null et la DB
+		/// renvoie au moins une guilde au boot, prefere LoadAll au seed
+		/// hardcode. Non-owning ; lifetime gere par main_linux.
+		engine::server::guilds_db::MysqlGuildStore*      m_store      = nullptr;
 	};
 }

--- a/src/masterd/handlers/loot/LootHandler.cpp
+++ b/src/masterd/handlers/loot/LootHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/loot/LootHandler.h"
 
+#include "src/masterd/loot/MysqlLootStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -43,6 +44,39 @@ namespace engine::server
 		char buf[32]{};
 		std::snprintf(buf, sizeof(buf), "Item #%u", static_cast<unsigned>(itemTemplateId));
 		return std::string(buf);
+	}
+
+	// -------------------------------------------------------------------------
+	// LoadLootTablesFromDb - Wave 5 phase 2 (Phase 3.17b) : warm-load
+	// des loot tables depuis le store DB pour log diagnostique. V1 :
+	// les entries chargees ne sont pas encore branchees sur SimulateRoll
+	// (qui garde son tableau hardcode 5 items). Une PR ulterieure pourra
+	// remplacer PickRandomItemIdLocked par un tirage sur les entries DB.
+	// -------------------------------------------------------------------------
+
+	void LootHandler::LoadLootTablesFromDb()
+	{
+		m_loadedLootEntries = 0;
+		if (!m_lootStore || !m_lootStore->IsAvailable())
+		{
+			LOG_INFO(Net, "[LootHandler] LoadLootTablesFromDb : no store / DB unavailable, keeping hardcoded V1 items");
+			return;
+		}
+		auto tables = m_lootStore->LoadAllTables();
+		if (tables.empty())
+		{
+			LOG_INFO(Net, "[LootHandler] LoadLootTablesFromDb : 0 tables in DB (fallback hardcoded V1 items)");
+			return;
+		}
+		for (const auto& t : tables)
+		{
+			auto entries = m_lootStore->LoadEntriesForTable(t.tableId);
+			m_loadedLootEntries += entries.size();
+			LOG_INFO(Net, "[LootHandler] LoadLootTablesFromDb : table id={} name={} entries={}",
+				t.tableId, t.name, entries.size());
+		}
+		LOG_INFO(Net, "[LootHandler] LoadLootTablesFromDb : total {} entries across {} tables",
+			m_loadedLootEntries, tables.size());
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/masterd/handlers/loot/LootHandler.h
+++ b/src/masterd/handlers/loot/LootHandler.h
@@ -60,6 +60,11 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::loot_db
+{
+	class MysqlLootStore;
+}
+
 namespace engine::server
 {
 	/// Choix d'un joueur pour une roll de loot. Wire format uint8.
@@ -101,6 +106,26 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Wave 5 (Phase 3.17b) : branche le store MySQL pour charger
+		/// les loot tables depuis la DB. Optionnel ; si null ou DB vide,
+		/// le handler continue d'utiliser son tableau hardcode 5 items
+		/// pour SimulateRoll (le DB store reste expose pour future
+		/// integration drop-by-creature, hors scope V1).
+		///
+		/// \param s pointeur non-owning sur le store. La duree de vie
+		///          doit englober celle du handler (cf main_linux).
+		void SetLootStore(engine::server::loot_db::MysqlLootStore* s) { m_lootStore = s; }
+
+		/// Wave 5 (Phase 3.17b) : charge les loot tables depuis le store
+		/// DB (si branche et disponible). V1 : le resultat est logge pour
+		/// traceabilite mais le handler ne l'utilise pas encore au runtime
+		/// (SimulateRoll garde son tableau hardcode 5 items). Une PR
+		/// ulterieure remplacera kV1Items par les entries DB.
+		///
+		/// Idempotent : appelable a chaque boot. Effet de bord : ecrit
+		/// dans m_loadedLootEntries (utilise pour log diagnostique uniquement V1).
+		void LoadLootTablesFromDb();
 
 		/// Point d'entree appele par NetServer pour les opcodes Loot.
 		/// Dispatch vers HandleChoice / HandleSimulateRoll selon l'opcode.
@@ -206,5 +231,14 @@ namespace engine::server
 		/// Protege par m_mutex.
 		std::mt19937                                     m_rng;
 		bool                                             m_rngSeeded = false;
+
+		/// Wave 5 (Phase 3.17b) : store DB optionnel pour les loot tables.
+		/// Non-owning ; lifetime gere par main_linux.
+		engine::server::loot_db::MysqlLootStore*         m_lootStore = nullptr;
+
+		/// Wave 5 (Phase 3.17b) : nombre d'entrees loot tables chargees
+		/// au boot (somme sur toutes les tables). 0 si pas de store ou
+		/// DB vide. Utilise pour log diagnostique uniquement V1.
+		size_t                                           m_loadedLootEntries = 0;
 	};
 }

--- a/src/masterd/loot/MysqlLootStore.cpp
+++ b/src/masterd/loot/MysqlLootStore.cpp
@@ -1,0 +1,87 @@
+// Wave 5 Persistence (Phase 3.17b) - Implementation MysqlLootStore.
+
+#include "src/masterd/loot/MysqlLootStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::loot_db
+{
+	bool MysqlLootStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	std::vector<LootTableRow> MysqlLootStore::LoadAllTables() const
+	{
+		std::vector<LootTableRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		const char* sql =
+			"SELECT table_id, name, description FROM loot_tables "
+			"ORDER BY table_id ASC";
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlLootStore] LoadAllTables query failed");
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			LootTableRow r;
+			if (row[0]) r.tableId     = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.name        = row[1];
+			if (row[2]) r.description = row[2];
+			out.push_back(std::move(r));
+		}
+		engine::server::db::DbFreeResult(res);
+		LOG_INFO(Net, "[MysqlLootStore] LoadAllTables loaded {} tables", out.size());
+		return out;
+	}
+
+	std::vector<LootEntryRow> MysqlLootStore::LoadEntriesForTable(uint32_t tableId) const
+	{
+		std::vector<LootEntryRow> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[512];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT entry_id, table_id, item_template_id, item_name, "
+			"drop_chance_pct, min_count, max_count "
+			"FROM loot_table_entries WHERE table_id = %u ORDER BY entry_id ASC",
+			tableId);
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlLootStore] LoadEntriesForTable query failed tableId={}", tableId);
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			LootEntryRow r;
+			if (row[0]) r.entryId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+			if (row[1]) r.tableId          = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
+			if (row[2]) r.itemTemplateId   = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
+			if (row[3]) r.itemName         = row[3];
+			if (row[4]) r.dropChancePct    = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
+			if (row[5]) r.minCount          = static_cast<uint32_t>(std::strtoul(row[5], nullptr, 10));
+			if (row[6]) r.maxCount          = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+			out.push_back(std::move(r));
+		}
+		engine::server::db::DbFreeResult(res);
+		LOG_INFO(Net, "[MysqlLootStore] LoadEntriesForTable tableId={} loaded {} entries", tableId, out.size());
+		return out;
+	}
+}

--- a/src/masterd/loot/MysqlLootStore.h
+++ b/src/masterd/loot/MysqlLootStore.h
@@ -1,0 +1,73 @@
+#pragma once
+// Wave 5 Persistence (Phase 3.17b) - MysqlLootStore : wrapper MySQL
+// pour persister les tables de loot (definition + entries). Migration
+// 0057_loot_tables.sql. Cible UNIX (master).
+//
+// Read-only V1 : les tables sont seedees via INSERT IGNORE dans la
+// migration (wolf_basic + rabbit_basic). Le LootHandler appelle
+// LoadAllTables au boot pour preparer une future integration avec un
+// systeme de drop par creature (out-of-scope de cette PR cote wire).
+//
+// Lifecycle :
+//   - main_linux : instancie le store -> lootHandler.SetLootStore.
+//   - Pas d'appel obligatoire au boot V1 (le LootHandler garde son
+//     tableau hardcode 5 items pour SimulateRoll). Une PR ulterieure
+//     basculera le LootHandler sur les tables DB pour les vrais drops.
+//   - Pas de mutation V1 : la table est read-only cote master, edition
+//     reservee aux migrations / outils d'admin externes.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::loot_db
+{
+	/// Ligne table de loot (definition).
+	struct LootTableRow
+	{
+		uint32_t    tableId      = 0;
+		std::string name;
+		std::string description;
+	};
+
+	/// Ligne entree de table de loot (item drop possible).
+	struct LootEntryRow
+	{
+		uint32_t    entryId          = 0;
+		uint32_t    tableId          = 0;
+		uint32_t    itemTemplateId   = 0;
+		std::string itemName;
+		uint32_t    dropChancePct    = 0;
+		uint32_t    minCount         = 1;
+		uint32_t    maxCount         = 1;
+	};
+
+	/// MySQL backed store pour LootHandler. Toutes les operations
+	/// retournent une collection vide si le pool n'est pas initialise
+	/// (le caller en deduit "fallback in-memory tableau hardcode").
+	class MysqlLootStore final
+	{
+	public:
+		explicit MysqlLootStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// Retourne true si le store est en mode DB (pool initialise).
+		bool IsAvailable() const noexcept;
+
+		/// Charge toutes les tables de loot (sans leurs entries). Pour
+		/// recuperer les entries d'une table, appeler LoadEntriesForTable.
+		/// Vide si DB indisponible ou table vide.
+		std::vector<LootTableRow> LoadAllTables() const;
+
+		/// Charge les entries (items dropables) d'une table donnee.
+		/// Vide si DB indisponible, table inexistante, ou aucune entry.
+		///
+		/// \param tableId id de la loot_tables ligne.
+		std::vector<LootEntryRow> LoadEntriesForTable(uint32_t tableId) const;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -69,13 +69,17 @@
 #include "src/masterd/trade/TradeSessionRegistry.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 
-// Wave 5 Persistence (Phase 5.x b series) : stores DB pour les systemes
-// Auction / Arena / GameEvents / Skills / OutdoorPvp.
+// Wave 5 Persistence phase 1 : stores DB pour Auction / Arena / GameEvents /
+// Skills / OutdoorPvp.
 #include "src/masterd/auction/MysqlAuctionStore.h"
 #include "src/masterd/events/MysqlGameEventStore.h"
 #include "src/masterd/arena/MysqlArenaStore.h"
 #include "src/masterd/skills/MysqlSkillStore.h"
 #include "src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h"
+// Wave 5 Persistence phase 2 : stores DB pour Guild / BattleGround / Loot.
+#include "src/masterd/guild/MysqlGuildStore.h"
+#include "src/masterd/battleground/MysqlBattleGroundStore.h"
+#include "src/masterd/loot/MysqlLootStore.h"
 
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
@@ -593,6 +597,17 @@ int main(int argc, char** argv)
 	bgHandler.SetServer(&server);
 	bgHandler.SetSessionManager(&sessionManager);
 	bgHandler.SetConnectionSessionMap(&connSessionMap);
+	// Wave 5 Phase 5.10b : store DB pour archiver l'historique des matchs (write-only V1).
+	engine::server::bg_db::MysqlBattleGroundStore bgHistoryStore(&dbPool);
+	if (dbPool.IsInitialized())
+	{
+		bgHandler.SetMatchHistoryStore(&bgHistoryStore);
+		LOG_INFO(Net, "[ServerMain] BattleGroundHandler with DB history store (Wave 5 Phase 5.10b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] BattleGroundHandler running in no-DB mode (matches not archived)");
+	}
 	LOG_INFO(Net, "[ServerMain] BattleGroundHandler configured (CMANGOS.10 step 3+4, in-memory)");
 
 	// CMANGOS.36 (Phase 5.36 step 3+4) — OutdoorPvp wire server.
@@ -672,9 +687,22 @@ int main(int argc, char** argv)
 	// only, lecture seule (pas de modification client). Pas de SyncGuilds
 	// RPC entre master et shardd.
 	engine::server::GuildHandler guildHandler;
+	// Wave 5 Phase 5.21b : store DB pour la persistence des guildes
+	// (definition + membres + bank tab 0). Branche AVANT SeedV1Guilds
+	// pour qu'il puisse LoadAll plutot que le seed hardcode.
+	engine::server::guilds_db::MysqlGuildStore guildStore(&dbPool);
 	guildHandler.SetServer(&server);
 	guildHandler.SetSessionManager(&sessionManager);
 	guildHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		guildHandler.SetGuildStore(&guildStore);
+		LOG_INFO(Net, "[ServerMain] GuildHandler with DB store (Wave 5 Phase 5.21b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] GuildHandler running in no-DB mode (hardcoded seed only)");
+	}
 	guildHandler.SeedV1Guilds();
 	LOG_INFO(Net, "[ServerMain] GuildHandler configured (CMANGOS.21 step 3+4 Guilds, in-memory, 2 guilds seed)");
 
@@ -716,9 +744,21 @@ int main(int argc, char** argv)
 	// timeout tick periodique (scan a chaque HandleChoice), pas de SyncLoot
 	// RPC entre master et shardd.
 	engine::server::LootHandler lootHandler;
+	// Wave 5 Phase 3.17b : store DB pour les loot tables (read-only V1).
+	engine::server::loot_db::MysqlLootStore lootStore(&dbPool);
 	lootHandler.SetServer(&server);
 	lootHandler.SetSessionManager(&sessionManager);
 	lootHandler.SetConnectionSessionMap(&connSessionMap);
+	if (dbPool.IsInitialized())
+	{
+		lootHandler.SetLootStore(&lootStore);
+		lootHandler.LoadLootTablesFromDb();
+		LOG_INFO(Net, "[ServerMain] LootHandler with DB store (Wave 5 Phase 3.17b)");
+	}
+	else
+	{
+		LOG_WARN(Net, "[ServerMain] LootHandler running in no-DB mode (hardcoded 5 items only)");
+	}
 	LOG_INFO(Net, "[ServerMain] LootHandler configured (CMANGOS.17 step 3+4 Loot, in-memory, simulation V1)");
 
 	// Phase 5 step 3+4 Lunar — LunarHandler : etat lunaire authoritative


### PR DESCRIPTION
## Wave 5 phase 2 — Persistance DB pour Guild + BattleGround + Loot

Suite à Wave 5 phase 1 (PR #572 : Auction + Arena + GameEvents + Skill + OutdoorPvp), cette phase 2 ajoute 3 stores supplémentaires.

### Nouveaux stores

| Store | Migration | Persiste |
|---|---|---|
| **MysqlGuildStore** | `0055_guilds_master.sql` (3 tables) | Guildes + membres + bank, seed 2 guildes V1 |
| **MysqlBattleGroundStore** | `0056_bg_history.sql` | Historique des matchs terminés (write-only V1) |
| **MysqlLootStore** | `0057_loot_tables.sql` (2 tables) | Loot tables + entries, seed wolf_basic / rabbit_basic |

### Wiring handlers

- `GuildHandler::SetGuildStore(...)` → `LoadAll()` au seed initial
- `BattleGroundHandler::SetMatchHistoryStore(...)` → `InsertMatch()` post-MatchEnd
- `LootHandler::SetLootStore(...)` → `LoadLootTablesFromDb()` au boot

### Pattern strict aligné Wave 5 phase 1

- Init via `ConnectionPool`
- Graceful fallback in-memory si DB down
- Migrations idempotentes (`CREATE TABLE IF NOT EXISTS` + `INSERT IGNORE`)

### V1 limitations
- **Loot DB partielle** : `LoadLootTablesFromDb` charge + logge mais `SimulateRoll` garde son table hardcode V1. Bascule complète drop-by-creature pour future PR.
- **Guild online status** : non persisté (snapshot statique). Au LoadAll, seul leader marqué online par heuristique. Future PR : intégration SessionManager presence.
- **AccountName lookup V1** : `ResolveV1AccountName` hardcode 6 mappings, fallback `Account#<id>`. Dynamic via AccountStore en future PR.
- **BG startedAt approximé** (`now - duration_sec`) car seul steady_clock en RAM.

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX REQUIS** — 3 nouvelles migrations + nouvelles routes persistance Guild/BG/Loot. Aucun changement client (pas d'opcode/payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
