### PR TITLE
feat(entities): Wave 7 foundation -- ObjectGuid + UpdateMask + Object base class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ServerListHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/metrics/HealthEndpoint.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/metrics/PrometheusMetrics.cpp
+    # Wave 7 Entities foundation : Object base (header-only en pratique, .cpp
+    # garde un translation unit nomme pour futures methodes out-of-line).
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp
   )
   target_include_directories(server_app PRIVATE ${MYSQL_INCLUDE_DIR} ${CMAKE_SOURCE_DIR})
   # M32.1: MySQL available on UNIX — FriendSystem compiles with full DB support.
@@ -360,6 +363,14 @@ elseif(UNIX)
   target_link_libraries(object_guid_tests PRIVATE engine_core spdlog::spdlog pthread)
   target_compile_options(object_guid_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME object_guid_tests COMMAND object_guid_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Wave 7 Entities foundation : ObjectGuid + UpdateMask + UpdateField + Object base.
+  # Note : namespace engine::server::entities, distinct du ObjectGuid existant
+  # dans engine::server::shard. Les deux cohabitent ; la migration progressive
+  # vers la version "entities" sera faite par PRs futures.
+  lcdlln_add_simple_test(entities_foundation_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/ObjectGuidTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp)
 
   # CMANGOS.18 (Phase 3.18a) : MailManager core (workflow Send/Take/COD/expire).
   lcdlln_add_simple_test(mail_manager_tests

--- a/src/shardd/entities/Object.cpp
+++ b/src/shardd/entities/Object.cpp
@@ -1,0 +1,11 @@
+// Object.cpp — Wave 7 foundation : implementation vide.
+//
+// La classe Object est entierement inline (constructeur trivial, accesseurs
+// noexcept), donc ce .cpp ne contient pour l'instant que l'include du header.
+// Il est cependant present pour :
+//   1. Avoir une translation unit nommee si on doit ajouter des methodes
+//      out-of-line ou des constantes statiques later.
+//   2. Servir de link target pour la cible CMake `engine_core` /
+//      `server_app` qui veut un .cpp pour generer une .o.
+
+#include "src/shardd/entities/Object.h"

--- a/src/shardd/entities/Object.h
+++ b/src/shardd/entities/Object.h
@@ -1,0 +1,58 @@
+#pragma once
+// Object : classe de base pour toutes les entites MMO (Player, Creature,
+// GameObject, etc.). Detient :
+//   - un ObjectGuid identifiant (immuable apres construction)
+//   - une UpdateMask dimensionnee pour les fields delta replication.
+//
+// Future : sera derivee par Unit -> Player / Creature, puis specialisee
+// pour exposer ses propres UpdateField<T> (cf. ticket Entities hierarchy
+// pour la specification de la hierarchie complete).
+//
+// Wave 7 foundation : interface minimale pour permettre la suite des PRs
+// (chaque sous-type ajoutera ses propres champs et tests).
+
+#include "src/shardd/entities/ObjectGuid.h"
+#include "src/shardd/entities/UpdateMask.h"
+
+#include <cstdint>
+#include <cstddef>
+
+namespace engine::server::entities
+{
+	/// Base class polymorphe pour toutes les entites MMO.
+	class Object
+	{
+	public:
+		/// Constructeur : initialise le guid + alloue le mask pour \p fieldCount champs.
+		/// \param guid identifiant immuable de l'objet (logique : c'est sa cle).
+		/// \param fieldCount nombre de UpdateField<T> que la classe derivee va exposer.
+		///        Determine la taille du bitmask (ceil(fieldCount/32) chunks).
+		Object(ObjectGuid guid, size_t fieldCount)
+			: m_guid(guid), m_mask(fieldCount) {}
+
+		/// Destructeur virtuel : Object est polymorphe (derive par Unit, Player, etc.).
+		virtual ~Object() = default;
+
+		/// Lecture du guid (immutable).
+		ObjectGuid Guid() const noexcept { return m_guid; }
+
+		/// Lecture du type discriminant (shortcut sur Guid().Type()).
+		ObjectType Type() const noexcept { return m_guid.Type(); }
+
+		/// Mask de mise a jour mutable (utilise par les UpdateField<T> derives).
+		UpdateMask& Mask() noexcept { return m_mask; }
+		const UpdateMask& Mask() const noexcept { return m_mask; }
+
+		/// Reset le mask apres replication reussie au client. A appeler par
+		/// la couche de replication apres avoir construit + envoye un delta.
+		void OnReplicationSent() noexcept { m_mask.Clear(); }
+
+		/// True si l'objet a au moins un champ modifie depuis le dernier
+		/// OnReplicationSent() (ou depuis la construction si jamais reset).
+		bool IsDirty() const noexcept { return !m_mask.Empty(); }
+
+	protected:
+		ObjectGuid  m_guid;
+		UpdateMask  m_mask;
+	};
+}

--- a/src/shardd/entities/ObjectGuid.h
+++ b/src/shardd/entities/ObjectGuid.h
@@ -1,0 +1,118 @@
+#pragma once
+// ObjectGuid : identifiant 64-bit pour tous les objets MMO (player, creature,
+// gameobject, item, etc.). Encodage : [type 8 bits | id 56 bits].
+// Header-only, deterministe, partage par master/shardd/client (wire format).
+//
+// Wave 7 foundation : type minimal independant de l'ObjectGuid existant
+// dans engine::server::shard (qui a un layout 3 champs type/entry/counter
+// incompatible avec l'API delta replication WoW-like ciblee ici). Les deux
+// vivent en parallele : la migration progressive sera faite par PRs futures.
+//
+// Pas d'integration dans les payloads existants, par design : Wave 7 ne livre
+// QUE les briques de base + leurs tests, l'integration viendra plus tard.
+
+#include <cstdint>
+#include <string>
+
+namespace engine::server::entities
+{
+	/// Type d'objet encode dans les 8 bits de poids fort de ObjectGuid.
+	/// Valeurs stables : ne JAMAIS reassigner (le wire en depend).
+	enum class ObjectType : uint8_t
+	{
+		None        = 0,
+		Player      = 1,
+		Creature    = 2,
+		GameObject  = 3,
+		Item        = 4,
+		Container   = 5,
+		Corpse      = 6,
+		DynamicObject = 7,
+		Pet         = 8,
+		Vehicle     = 9,
+		// Reserve : 10..255 pour futurs types.
+	};
+
+	/// Identifiant 64-bit type-safe. Encode :
+	///   - bits [56..63] : ObjectType (8 bits)
+	///   - bits [0..55]  : id local au type (56 bits, soit ~7.2e16 valeurs)
+	class ObjectGuid
+	{
+	public:
+		/// Construit un guid invalide (raw=0, Type=None, Id=0).
+		constexpr ObjectGuid() noexcept = default;
+
+		/// Construit depuis la representation brute (sortie d'un Raw() precedent).
+		/// Pas de validation : caller garantit la valeur.
+		constexpr explicit ObjectGuid(uint64_t raw) noexcept : m_raw(raw) {}
+
+		/// Construit depuis un type + un id 56-bit. Si \p id depasse 56 bits,
+		/// les bits hauts sont silencieusement tronques (clipping kIdMask).
+		constexpr ObjectGuid(ObjectType type, uint64_t id) noexcept
+			: m_raw((static_cast<uint64_t>(type) << 56) | (id & kIdMask)) {}
+
+		/// Representation brute, utilisable pour serialisation reseau / DB.
+		constexpr uint64_t Raw() const noexcept { return m_raw; }
+
+		/// Extrait le type depuis les 8 bits de poids fort.
+		constexpr ObjectType Type() const noexcept { return static_cast<ObjectType>(m_raw >> 56); }
+
+		/// Extrait l'id (56 bits) depuis les bits de poids faible.
+		constexpr uint64_t Id() const noexcept { return m_raw & kIdMask; }
+
+		/// True si raw=0 (guid construit par defaut ou explicitement invalide).
+		constexpr bool IsEmpty() const noexcept { return m_raw == 0; }
+
+		constexpr bool operator==(const ObjectGuid& o) const noexcept { return m_raw == o.m_raw; }
+		constexpr bool operator!=(const ObjectGuid& o) const noexcept { return m_raw != o.m_raw; }
+		constexpr bool operator<(const ObjectGuid& o)  const noexcept { return m_raw < o.m_raw; }
+
+		/// Masque des 56 bits d'id. Expose en public pour les tests / serialisation.
+		static constexpr uint64_t kIdMask = 0x00FFFFFFFFFFFFFFull;
+
+	private:
+		uint64_t m_raw = 0;
+	};
+
+	/// Helper : convertit ObjectType vers string (logging/debug). Jamais nullptr.
+	/// Retourne "Unknown" pour les valeurs non listees.
+	inline const char* ObjectTypeToString(ObjectType t) noexcept
+	{
+		switch (t)
+		{
+			case ObjectType::None:          return "None";
+			case ObjectType::Player:        return "Player";
+			case ObjectType::Creature:      return "Creature";
+			case ObjectType::GameObject:    return "GameObject";
+			case ObjectType::Item:          return "Item";
+			case ObjectType::Container:     return "Container";
+			case ObjectType::Corpse:        return "Corpse";
+			case ObjectType::DynamicObject: return "DynamicObject";
+			case ObjectType::Pet:           return "Pet";
+			case ObjectType::Vehicle:       return "Vehicle";
+		}
+		return "Unknown";
+	}
+
+	/// Format lisible : "Player#1234" / "Creature#56" / "Empty" si raw=0.
+	inline std::string FormatGuid(ObjectGuid g)
+	{
+		if (g.IsEmpty()) return "Empty";
+		std::string out = ObjectTypeToString(g.Type());
+		out.push_back('#');
+		out += std::to_string(g.Id());
+		return out;
+	}
+}
+
+namespace std
+{
+	template<>
+	struct hash<engine::server::entities::ObjectGuid>
+	{
+		size_t operator()(const engine::server::entities::ObjectGuid& g) const noexcept
+		{
+			return std::hash<uint64_t>{}(g.Raw());
+		}
+	};
+}

--- a/src/shardd/entities/ObjectGuidTests.cpp
+++ b/src/shardd/entities/ObjectGuidTests.cpp
@@ -1,0 +1,256 @@
+// Wave 7 foundation tests : ObjectGuid encoding + UpdateMask bit ops +
+// UpdateField auto-flag + Object base class dirty tracking.
+//
+// Pattern aligne sur LunarCalendarTests.cpp : pas de framework, asserts +
+// printf simples. Le binaire est enregistre dans CMakeLists.txt comme
+// cible CTest `entities_foundation_tests`.
+
+#include "src/shardd/entities/ObjectGuid.h"
+#include "src/shardd/entities/UpdateMask.h"
+#include "src/shardd/entities/UpdateField.h"
+#include "src/shardd/entities/Object.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdint>
+#include <functional>
+#include <string>
+
+using namespace engine::server::entities;
+
+namespace
+{
+	/// Round-trip basique : type + id sortent identiques apres construction.
+	void TestObjectGuidEncoding()
+	{
+		ObjectGuid g(ObjectType::Player, 1234);
+		assert(g.Type() == ObjectType::Player);
+		assert(g.Id() == 1234);
+		assert(g.Raw() != 0);
+		std::puts("[OK] TestObjectGuidEncoding");
+	}
+
+	/// Construction par defaut : guid vide, type None, id 0.
+	void TestObjectGuidEmpty()
+	{
+		ObjectGuid g;
+		assert(g.IsEmpty());
+		assert(g.Type() == ObjectType::None);
+		assert(g.Id() == 0);
+		std::puts("[OK] TestObjectGuidEmpty");
+	}
+
+	/// Id maximal (56 bits tous a 1) : doit etre preserve sans clipping.
+	void TestObjectGuidMaxId()
+	{
+		ObjectGuid g(ObjectType::Creature, ObjectGuid::kIdMask);
+		assert(g.Type() == ObjectType::Creature);
+		assert(g.Id() == ObjectGuid::kIdMask);
+		std::puts("[OK] TestObjectGuidMaxId");
+	}
+
+	/// Id > 56 bits : doit etre tronque proprement sans contaminer le type.
+	void TestObjectGuidIdMaskClipping()
+	{
+		uint64_t bigId = 0xFFFFFFFFFFFFFFFFull;
+		ObjectGuid g(ObjectType::Player, bigId);
+		assert(g.Id() == ObjectGuid::kIdMask);
+		assert(g.Type() == ObjectType::Player);
+		std::puts("[OK] TestObjectGuidIdMaskClipping");
+	}
+
+	/// Egalite : memes type+id sont egaux, type different inverse.
+	void TestObjectGuidEquality()
+	{
+		ObjectGuid a(ObjectType::Player, 100);
+		ObjectGuid b(ObjectType::Player, 100);
+		ObjectGuid c(ObjectType::Creature, 100);
+		assert(a == b);
+		assert(a != c);
+		std::puts("[OK] TestObjectGuidEquality");
+	}
+
+	/// Helper FormatGuid : libelle + id pour log/debug.
+	void TestFormatGuid()
+	{
+		ObjectGuid g(ObjectType::Player, 42);
+		assert(FormatGuid(g) == "Player#42");
+		ObjectGuid empty;
+		assert(FormatGuid(empty) == "Empty");
+		std::puts("[OK] TestFormatGuid");
+	}
+
+	/// Helper ObjectTypeToString : couvre toutes les valeurs nommees + Unknown
+	/// pour une valeur non listee.
+	void TestObjectTypeToString()
+	{
+		assert(std::string(ObjectTypeToString(ObjectType::None)) == "None");
+		assert(std::string(ObjectTypeToString(ObjectType::Player)) == "Player");
+		assert(std::string(ObjectTypeToString(ObjectType::Creature)) == "Creature");
+		assert(std::string(ObjectTypeToString(ObjectType::GameObject)) == "GameObject");
+		assert(std::string(ObjectTypeToString(ObjectType::Item)) == "Item");
+		assert(std::string(ObjectTypeToString(ObjectType::Container)) == "Container");
+		assert(std::string(ObjectTypeToString(ObjectType::Corpse)) == "Corpse");
+		assert(std::string(ObjectTypeToString(ObjectType::DynamicObject)) == "DynamicObject");
+		assert(std::string(ObjectTypeToString(ObjectType::Pet)) == "Pet");
+		assert(std::string(ObjectTypeToString(ObjectType::Vehicle)) == "Vehicle");
+		// Valeur reservee non utilisee : retourne "Unknown".
+		assert(std::string(ObjectTypeToString(static_cast<ObjectType>(200))) == "Unknown");
+		std::puts("[OK] TestObjectTypeToString");
+	}
+
+	/// Operations de base : Set / Clear / Test / Empty / PopCount.
+	void TestUpdateMaskBasic()
+	{
+		UpdateMask m(64);
+		assert(m.FieldCount() == 64);
+		assert(m.Empty());
+		assert(m.PopCount() == 0);
+
+		m.SetBit(5);
+		m.SetBit(31);
+		m.SetBit(63);
+		assert(!m.Empty());
+		assert(m.PopCount() == 3);
+		assert(m.TestBit(5));
+		assert(m.TestBit(31));
+		assert(m.TestBit(63));
+		assert(!m.TestBit(0));
+		assert(!m.TestBit(32));
+
+		m.ClearBit(5);
+		assert(m.PopCount() == 2);
+		assert(!m.TestBit(5));
+
+		m.Clear();
+		assert(m.Empty());
+		std::puts("[OK] TestUpdateMaskBasic");
+	}
+
+	/// SetBit / TestBit hors plage : no-op silencieux.
+	void TestUpdateMaskOutOfRange()
+	{
+		UpdateMask m(8);
+		m.SetBit(8);   // hors plage (FieldCount=8, valides=0..7)
+		m.SetBit(100);
+		assert(m.Empty());
+		assert(!m.TestBit(8));
+		assert(!m.TestBit(100));
+		std::puts("[OK] TestUpdateMaskOutOfRange");
+	}
+
+	/// Resize remet tout a 0, meme les indices precedemment valides.
+	void TestUpdateMaskResize()
+	{
+		UpdateMask m(4);
+		m.SetBit(0);
+		m.SetBit(3);
+		assert(m.PopCount() == 2);
+
+		m.Resize(64);
+		assert(m.FieldCount() == 64);
+		assert(m.Empty());
+		assert(m.PopCount() == 0);
+		std::puts("[OK] TestUpdateMaskResize");
+	}
+
+	/// UpdateField : Set modifie + flag, Set meme valeur ne flag pas,
+	/// MarkDirty force le flag.
+	void TestUpdateField()
+	{
+		UpdateMask mask(4);
+		UpdateField<int> field(2, &mask, 0);
+		assert(field.Get() == 0);
+		assert(mask.Empty());
+
+		field.Set(42);
+		assert(field.Get() == 42);
+		assert(mask.TestBit(2));
+		assert(mask.PopCount() == 1);
+
+		// Set meme valeur : pas de re-flag.
+		mask.Clear();
+		field.Set(42);
+		assert(mask.Empty());
+
+		// MarkDirty force.
+		field.MarkDirty();
+		assert(mask.TestBit(2));
+		std::puts("[OK] TestUpdateField");
+	}
+
+	/// UpdateField detache (mask=nullptr) : Set / MarkDirty ne crashent pas.
+	void TestUpdateFieldDetached()
+	{
+		UpdateField<int> field(0, nullptr, 10);
+		assert(field.Get() == 10);
+		field.Set(20);
+		assert(field.Get() == 20);
+		field.MarkDirty(); // no-op silencieux, pas de crash
+		std::puts("[OK] TestUpdateFieldDetached");
+	}
+
+	/// Object : guid immuable, Mask() mutable, IsDirty reflete le mask,
+	/// OnReplicationSent reset.
+	void TestObjectBase()
+	{
+		ObjectGuid guid(ObjectType::Player, 12345);
+		Object obj(guid, 16);
+		assert(obj.Guid() == guid);
+		assert(obj.Type() == ObjectType::Player);
+		assert(!obj.IsDirty());
+
+		obj.Mask().SetBit(3);
+		assert(obj.IsDirty());
+
+		obj.OnReplicationSent();
+		assert(!obj.IsDirty());
+		std::puts("[OK] TestObjectBase");
+	}
+
+	/// Le hash std::hash<ObjectGuid> est deterministe sur Raw().
+	void TestObjectGuidHashable()
+	{
+		std::hash<ObjectGuid> hasher;
+		ObjectGuid a(ObjectType::Player, 1);
+		ObjectGuid b(ObjectType::Player, 1);
+		assert(hasher(a) == hasher(b));
+		// hash(a) != hash(c) avec haute probabilite (pas un test strict).
+		std::puts("[OK] TestObjectGuidHashable");
+	}
+
+	/// Round-trip Raw -> ObjectGuid -> Raw conserve la valeur exacte.
+	void TestObjectGuidRawRoundTrip()
+	{
+		uint64_t expected = (static_cast<uint64_t>(ObjectType::Creature) << 56) | 0x123456789ABCull;
+		ObjectGuid g(expected);
+		assert(g.Raw() == expected);
+		assert(g.Type() == ObjectType::Creature);
+		assert(g.Id() == 0x123456789ABCull);
+
+		ObjectGuid g2(g.Type(), g.Id());
+		assert(g2.Raw() == g.Raw());
+		std::puts("[OK] TestObjectGuidRawRoundTrip");
+	}
+}
+
+int main()
+{
+	TestObjectGuidEncoding();
+	TestObjectGuidEmpty();
+	TestObjectGuidMaxId();
+	TestObjectGuidIdMaskClipping();
+	TestObjectGuidEquality();
+	TestFormatGuid();
+	TestObjectTypeToString();
+	TestUpdateMaskBasic();
+	TestUpdateMaskOutOfRange();
+	TestUpdateMaskResize();
+	TestUpdateField();
+	TestUpdateFieldDetached();
+	TestObjectBase();
+	TestObjectGuidHashable();
+	TestObjectGuidRawRoundTrip();
+	std::puts("[ALL OK] EntitiesFoundationTests");
+	return 0;
+}

--- a/src/shardd/entities/UpdateField.h
+++ b/src/shardd/entities/UpdateField.h
@@ -1,0 +1,69 @@
+#pragma once
+// UpdateField<T> : wrapper d'un champ stockant valeur courante + index dans
+// l'UpdateMask du parent. Set() met le bit a 1 si la valeur change ;
+// MarkDirty() force le flag dirty meme si la valeur est inchangee (utile
+// pour la replication initiale).
+// Header-only.
+//
+// Pattern WoW-like : un objet expose N UpdateField<T>, chaque setter passe
+// par Set() qui marque automatiquement le champ comme modifie. Le code de
+// replication consulte ensuite l'UpdateMask pour serialiser uniquement les
+// champs flagges.
+
+#include "src/shardd/entities/UpdateMask.h"
+
+#include <cstddef>
+#include <utility>
+
+namespace engine::server::entities
+{
+	/// Wrapper de champ avec auto-flag de modification. T doit etre
+	/// comparable via operator!= et move-constructible.
+	template<typename T>
+	class UpdateField
+	{
+	public:
+		/// Construit un field non-attache (mask=nullptr, Set() ne flag rien).
+		/// Utile pour les conteneurs temporaires.
+		UpdateField() = default;
+
+		/// Construit un field attache a un mask externe. Le mask doit survivre
+		/// a l'UpdateField (typiquement detenu par l'Object parent).
+		/// \param fieldIdx index du bit dans \p mask (< mask->FieldCount()).
+		/// \param mask pointeur vers le mask parent (peut etre nullptr pour
+		///        un field detache).
+		/// \param initial valeur initiale (le mask N'EST PAS flagge a la construction).
+		UpdateField(size_t fieldIdx, UpdateMask* mask, T initial = T{})
+			: m_value(std::move(initial))
+			, m_fieldIdx(fieldIdx)
+			, m_mask(mask)
+		{}
+
+		/// Lecture de la valeur courante.
+		const T& Get() const noexcept { return m_value; }
+
+		/// Set la nouvelle valeur. Si elle differe de la valeur courante,
+		/// le bit fieldIdx du mask parent est mis a 1.
+		void Set(T newValue)
+		{
+			if (m_value != newValue)
+			{
+				m_value = std::move(newValue);
+				if (m_mask) m_mask->SetBit(m_fieldIdx);
+			}
+		}
+
+		/// Force flag dirty meme si la valeur est inchangee. Sert pour l'init
+		/// initiale (premier envoi a un client qui n'a pas encore l'objet) ou
+		/// pour une replication forcee.
+		void MarkDirty() noexcept
+		{
+			if (m_mask) m_mask->SetBit(m_fieldIdx);
+		}
+
+	private:
+		T            m_value{};
+		size_t       m_fieldIdx = 0;
+		UpdateMask*  m_mask     = nullptr;
+	};
+}

--- a/src/shardd/entities/UpdateMask.h
+++ b/src/shardd/entities/UpdateMask.h
@@ -1,0 +1,101 @@
+#pragma once
+// UpdateMask : bit-mask sur N champs (un bit par UpdateField). Permet le
+// delta replication : ne serialiser / envoyer QUE les champs modifies depuis
+// la derniere snapshot. Pattern WoW-like.
+// Header-only.
+//
+// Stockage en chunks de uint32_t : pour N champs, on alloue ceil(N/32) chunks.
+// SetBit / ClearBit / TestBit sont O(1). PopCount parcourt tous les chunks
+// (O(N/32)) avec Brian Kernighan's bit count.
+//
+// Hors plage : SetBit/ClearBit/TestBit hors [0, FieldCount) sont des no-ops
+// (defensif, plutot que asserts qui crashent en prod). Les tests verifient ce
+// comportement.
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace engine::server::entities
+{
+	/// Mask de bits sur N champs. \p fieldCount est defini soit au constructeur,
+	/// soit a posteriori via Resize().
+	class UpdateMask
+	{
+	public:
+		/// Construit un mask vide (0 champs). Appeler Resize() avant utilisation.
+		UpdateMask() = default;
+
+		/// Construit un mask dimensionne pour \p fieldCount champs, tous a 0.
+		explicit UpdateMask(size_t fieldCount) { Resize(fieldCount); }
+
+		/// Redimensionne le mask. Tous les bits sont remis a 0 apres l'appel,
+		/// y compris pour les indices < fieldCount precedent.
+		void Resize(size_t fieldCount)
+		{
+			m_fieldCount = fieldCount;
+			const size_t chunks = (fieldCount + 31u) / 32u;
+			m_chunks.assign(chunks, 0u);
+		}
+
+		/// Remet tous les bits a 0. La taille (FieldCount) est conservee.
+		void Clear() noexcept
+		{
+			for (auto& c : m_chunks) c = 0u;
+		}
+
+		/// Met le bit \p fieldIdx a 1. No-op si fieldIdx >= FieldCount.
+		void SetBit(size_t fieldIdx) noexcept
+		{
+			if (fieldIdx >= m_fieldCount) return;
+			m_chunks[fieldIdx / 32u] |= (1u << (fieldIdx % 32u));
+		}
+
+		/// Met le bit \p fieldIdx a 0. No-op si fieldIdx >= FieldCount.
+		void ClearBit(size_t fieldIdx) noexcept
+		{
+			if (fieldIdx >= m_fieldCount) return;
+			m_chunks[fieldIdx / 32u] &= ~(1u << (fieldIdx % 32u));
+		}
+
+		/// Retourne true si le bit \p fieldIdx est a 1. False si hors plage.
+		bool TestBit(size_t fieldIdx) const noexcept
+		{
+			if (fieldIdx >= m_fieldCount) return false;
+			return (m_chunks[fieldIdx / 32u] & (1u << (fieldIdx % 32u))) != 0u;
+		}
+
+		/// Nombre total de champs declares.
+		size_t FieldCount() const noexcept { return m_fieldCount; }
+
+		/// Acces direct aux chunks (utile pour serialisation reseau).
+		const std::vector<uint32_t>& Chunks() const noexcept { return m_chunks; }
+
+		/// True si aucun bit n'est a 1.
+		bool Empty() const noexcept
+		{
+			for (auto c : m_chunks)
+				if (c != 0u) return false;
+			return true;
+		}
+
+		/// Compte le nombre de bits a 1 (Brian Kernighan, O(set bits)).
+		size_t PopCount() const noexcept
+		{
+			size_t count = 0u;
+			for (auto c : m_chunks)
+			{
+				while (c)
+				{
+					c &= (c - 1u); // efface le bit a 1 le plus bas
+					++count;
+				}
+			}
+			return count;
+		}
+
+	private:
+		size_t                  m_fieldCount = 0;
+		std::vector<uint32_t>   m_chunks;
+	};
+}


### PR DESCRIPTION
## Wave 7 — Entities foundation : ObjectGuid + UpdateMask + Object

Briques de base pour le futur système Object hierarchy + delta replication. Cette PR livre la **fondation seule** — pas de refactoring des wire payloads existants (multi-jours).

### Fichiers ajoutés

| Fichier | Rôle |
|---|---|
| `src/shardd/entities/ObjectGuid.h` | ID 64-bit (8 bits type + 56 bits id), hashable + ordonnable + helpers |
| `src/shardd/entities/UpdateMask.h` | Bit-mask N champs en chunks uint32, Set/Clear/Test/PopCount |
| `src/shardd/entities/UpdateField.h` | Wrapper auto-flag dirty (Set ne flag que si valeur change) |
| `src/shardd/entities/Object.h` | Base class : guid + mask, `IsDirty()` / `OnReplicationSent()` |
| `src/shardd/entities/Object.cpp` | Translation unit minimal (linkable) |
| `src/shardd/entities/ObjectGuidTests.cpp` | 15 tests : encoding, max id, mask, fields, dirty tracking, hash |

### Design

- **Namespace `engine::server::entities`** distinct du `engine::server::shard::ObjectGuid` existant (layout 3 champs incompatible avec pattern delta replication). Les deux cohabitent ; migration progressive par futures PRs.
- **Aucune touche** aux payloads, handlers ou wire existants — Wave 7 livre UNIQUEMENT les briques foundation.
- Pas de wire-breaking, aucun changement protocole.

### Tests CTest

`entities_foundation_tests` via `lcdlln_add_simple_test()` :
- ObjectGuid encoding/decoding
- UpdateMask bit ops + out-of-range
- UpdateField change detection
- Object base dirty tracking
- Hash determinism

### V1 limitations

- Pas d'intégration aux wire payloads existants (futures PRs : refactor wire delta replication)
- Pas d'instances Player/Creature dérivées (futures PRs : Unit hierarchy)
- 256 types possibles dans `ObjectType` enum (V1 : 9 utilisés, 247 réservés)

### Déploiement

> ✅ **Pas de redéploiement** — code header-only + .cpp vide, non utilisé runtime, aucun wire change. Cette PR pose juste la fondation pour les futures intégrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
