### PR TITLE
feat(shardd): Wave 8 -- wire Combat ThreatList + DBScripts runtimes au boot

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -626,6 +626,7 @@ elseif(UNIX)
 
   # M22.6: Shard server (ticket handshake + enregistrement TLS/TCP vers le Master via ShardToMasterClient)
   # Wave 6: + EventAIRuntime + PoolManagerRuntime (tickes + seedes au boot).
+  # Wave 8: + ThreatListRuntime + DBScriptRuntime (idem).
   add_executable(shard_app
     ${CMAKE_SOURCE_DIR}/src/shardd/main_linux.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/NetServer.cpp
@@ -642,6 +643,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAI.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAIRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolManagerRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/combat/ThreatListRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScript.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScriptRuntime.cpp
   )
   target_include_directories(shard_app PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(shard_app PRIVATE engine_core OpenSSL::SSL pthread)

--- a/src/shardd/combat/ThreatListRuntime.cpp
+++ b/src/shardd/combat/ThreatListRuntime.cpp
@@ -1,0 +1,81 @@
+#include "src/shardd/combat/ThreatListRuntime.h"
+
+#include <vector>
+
+namespace engine::server::combat
+{
+	/// Seed V1 hardcode : un seul couple "creature attaquee + deux
+	/// attaquants". Volontairement minimaliste : la valeur de la PR est
+	/// d'avoir un Tick reellement appele en boucle main, pas d'avoir
+	/// un scenario realiste. Le scenario realiste viendra avec les
+	/// handlers Damage cote shardd qui appelleront AddThreat depuis
+	/// les paquets gameplay.
+	void ThreatListRuntime::SeedV1Aggro()
+	{
+		m_lists.clear();
+		m_totalDecayed = 0;
+
+		ThreatList& tl = m_lists[1];   // creature fictive #1
+		tl.AddThreat(1001, 50.0f);     // player #1001
+		tl.AddThreat(1002, 30.0f);     // player #1002
+	}
+
+	/// Decay uniforme par tick. Pour chaque ThreatList, on collecte les
+	/// attaquants a soustraire (on ne peut pas iterer + supprimer en
+	/// meme temps sur une unordered_map sans utiliser erase(it)). Puis
+	/// on applique : si nouvelle valeur <= 0, DropAttacker ; sinon
+	/// SetThreat.
+	///
+	/// Note : (void)nowMs car V1 n'utilise pas le temps wall-clock — le
+	/// decay est purement "par tick". Conservation du parametre pour
+	/// future iteration scoring d'inactivite.
+	std::size_t ThreatListRuntime::Tick(uint64_t /*nowMs*/, float decayAmount)
+	{
+		if (decayAmount <= 0.0f)
+			return 0;
+
+		std::size_t decayedThisTick = 0;
+		for (auto& [creatureId, list] : m_lists)
+		{
+			// Snapshot des attaquants courants pour eviter mutation
+			// pendant iteration. TopN(SIZE_MAX) renvoie tout, trie
+			// par threat decroissant — l'ordre n'a pas d'importance
+			// pour le decay, on prend l'API publique qui existe deja.
+			std::vector<EntityId> attackers = list.TopN(static_cast<std::size_t>(-1));
+			for (EntityId atk : attackers)
+			{
+				const float cur = list.GetThreat(atk);
+				const float next = cur - decayAmount;
+				if (next <= 0.0f)
+				{
+					list.DropAttacker(atk);
+					++decayedThisTick;
+				}
+				else
+				{
+					list.SetThreat(atk, next);
+				}
+			}
+		}
+		m_totalDecayed += decayedThisTick;
+		return decayedThisTick;
+	}
+
+	/// Somme des Size() de chaque ThreatList. Lineaire en nombre de
+	/// creatures suivies (V1 : 1).
+	std::size_t ThreatListRuntime::TotalEntries() const
+	{
+		std::size_t n = 0;
+		for (const auto& [creatureId, list] : m_lists)
+			n += list.Size();
+		return n;
+	}
+
+	/// Acces direct pour futurs handlers ; nullptr si creatureId pas
+	/// suivi. V1 : seule creatureId=1 retourne un pointeur valide.
+	ThreatList* ThreatListRuntime::Get(EntityId creatureId)
+	{
+		auto it = m_lists.find(creatureId);
+		return (it == m_lists.end()) ? nullptr : &it->second;
+	}
+}

--- a/src/shardd/combat/ThreatListRuntime.h
+++ b/src/shardd/combat/ThreatListRuntime.h
@@ -1,0 +1,76 @@
+#pragma once
+// Wave 8 — Wrapper runtime ThreatList : detient une (ou plusieurs)
+// ThreatList header-only seedees au boot du shardd avec un cas d'aggro
+// V1 minimaliste (1 creature, 2 attaquants). Le but est de prouver que
+// le path "tick combat + decay" est reellement exerce a chaque tick
+// du runtime (ici, 5s), plutot que rester un header-only oriente tests.
+//
+// Cette PR : 1 creature fictive (creatureId=1) avec 2 attaquants
+// (playerId=1001 threat=50, playerId=1002 threat=30). Tick(nowMs)
+// applique un decay leger sur l'ensemble (le combat se calme quand
+// personne ne tape) et purge les entrees a 0 (DropAttacker). Le
+// nombre d'entrees purgees est renvoye pour le log periodique.
+//
+// Future iteration : map<CreatureGuid, ThreatList> alimentee par les
+// handlers Damage / Heal / Taunt cote shardd ; SeedFromDb() pour les
+// scenarios scriptes (raid encounters).
+
+#include "src/shardd/combat/ThreatList.h"
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace engine::server::combat
+{
+	/// Wrapper minimaliste autour de ThreatList. V1 : detient une seule
+	/// liste de threat seedee au boot pour creatureId=1, avec deux
+	/// attaquants fictifs. Future iteration : map<EntityId, ThreatList>
+	/// alimentee par les handlers de combat.
+	class ThreatListRuntime
+	{
+	public:
+		ThreatListRuntime() = default;
+
+		/// Charge un scenario V1 hardcode : creature #1 avec deux
+		/// attaquants (player #1001 = 50 threat, player #1002 = 30).
+		/// Idempotent : peut etre rappele pour reset (jamais en prod).
+		/// Effet de bord : reset m_lists et m_totalDecayed.
+		void SeedV1Aggro();
+
+		/// Applique un decay periodique a toutes les listes detenues.
+		/// Pour chaque attaquant, retire \p decayAmount au threat ; si
+		/// le threat tombe a 0 (ou en-dessous), l'attaquant est purge
+		/// de la liste. Retourne le nombre total d'attaquants purges
+		/// ce tick (pour log "[ThreatList] N entries decayed").
+		///
+		/// \param nowMs Horloge wall-clock en millisecondes (system_clock).
+		///   Non utilise par V1 mais conserve pour parite avec EventAI
+		///   et pour les futurs scenarios "decay base sur la duree
+		///   d'inactivite par attaquant".
+		/// \param decayAmount Quantite de threat a retirer par tick par
+		///   attaquant. Defaut 5.0f -> a 5s d'intervalle, un attaquant a
+		///   50 threat met 50s a etre purge sans nouvelle action de sa
+		///   part. Volontairement conservateur pour V1.
+		std::size_t Tick(uint64_t nowMs, float decayAmount = 5.0f);
+
+		/// Nombre total d'attaquants purges depuis le boot. Sert pour le
+		/// log periodique cumule.
+		std::uint64_t TotalDecayed() const noexcept { return m_totalDecayed; }
+
+		/// Nombre de creatures (ThreatList) suivies. V1 : 1.
+		std::size_t CreatureCount() const noexcept { return m_lists.size(); }
+
+		/// Nombre total d'attaquants suivis sur l'ensemble des listes.
+		/// Util pour log boot "N entries seeded" (vs creatures).
+		std::size_t TotalEntries() const;
+
+		/// Acces lecture/ecriture pour les futurs handlers de combat
+		/// (Damage/Heal/Taunt). Retourne nullptr si la creature n'est
+		/// pas suivie. V1 : seul creatureId=1 existe apres SeedV1Aggro().
+		ThreatList* Get(EntityId creatureId);
+
+	private:
+		std::unordered_map<EntityId, ThreatList> m_lists;
+		std::uint64_t                            m_totalDecayed = 0;
+	};
+}

--- a/src/shardd/dbscripts/DBScriptRuntime.cpp
+++ b/src/shardd/dbscripts/DBScriptRuntime.cpp
@@ -1,0 +1,112 @@
+#include "src/shardd/dbscripts/DBScriptRuntime.h"
+
+#include "src/shared/core/Log.h"
+
+namespace engine::server::dbscripts
+{
+	/// Helper interne : fabrique une ScriptCommand atomique (kind +
+	/// delay + dataString optionnelle). Garde les sites d'appel de
+	/// SeedV1Scripts lisibles.
+	static ScriptCommand MakeCmd(CommandKind k, uint32_t delayMs,
+		uint32_t p1 = 0, const char* text = nullptr)
+	{
+		ScriptCommand c;
+		c.kind   = k;
+		c.delayMs = delayMs;
+		c.param1 = p1;
+		if (text) c.dataString = text;
+		return c;
+	}
+
+	/// Seed V1 hardcode : deux scripts de demonstration. Les valeurs
+	/// (param1, dataString) sont arbitraires — futures iterations les
+	/// chargeront depuis la DB (table dbscripts).
+	void DBScriptRuntime::SeedV1Scripts()
+	{
+		m_scripts.clear();
+		m_active.clear();
+		m_totalFires = 0;
+
+		// Script 1 : "greet" - NPC qui dit bonjour, attend 2s, puis
+		// dit une seconde ligne. Demontre Say + Wait via delayMs.
+		Script greet;
+		greet.scriptId = 1;
+		greet.commands.push_back(MakeCmd(CommandKind::Say, 0,    0, "Greetings, traveler."));
+		greet.commands.push_back(MakeCmd(CommandKind::Wait, 2000));
+		greet.commands.push_back(MakeCmd(CommandKind::Say, 0,    0, "Safe travels."));
+		m_scripts.emplace(greet.scriptId, std::move(greet));
+
+		// Script 2 : "patrol" - NPC qui salue (emote), se deplace
+		// 1s plus tard, puis re-emote. param1=1 emoteId, param1=42
+		// waypointId : arbitraires V1.
+		Script patrol;
+		patrol.scriptId = 2;
+		patrol.commands.push_back(MakeCmd(CommandKind::Emote,  0, 1));
+		patrol.commands.push_back(MakeCmd(CommandKind::MoveTo, 1000, 42));
+		patrol.commands.push_back(MakeCmd(CommandKind::Emote,  0, 1));
+		m_scripts.emplace(patrol.scriptId, std::move(patrol));
+	}
+
+	/// Verifie l'existence puis demarre une execution. La file
+	/// d'executions n'est pas bornee V1 — en prod, ajouter un cap
+	/// (max scripts actifs simultanes) pour eviter une fuite si un
+	/// declencheur s'emballe.
+	bool DBScriptRuntime::RunScript(uint32_t scriptId, uint64_t nowMs)
+	{
+		auto it = m_scripts.find(scriptId);
+		if (it == m_scripts.end())
+			return false;
+		ScriptVMState state;
+		m_vm.Start(state, it->second, nowMs);
+		m_active.push_back(state);
+		return true;
+	}
+
+	/// Avance toutes les executions actives. Les commandes firees sont
+	/// loggees ici pour V1 ; les PRs futures brancheront un dispatch
+	/// reel (Say -> ChatRelayHandler, MoveTo -> MotionGenerator, etc.).
+	///
+	/// Pour purger les executions terminees, on parcourt en place et
+	/// on retire via swap-and-pop : ordre non preserve mais ok V1.
+	std::size_t DBScriptRuntime::Tick(uint64_t nowMs)
+	{
+		std::size_t firedThisTick = 0;
+		std::vector<std::size_t> firedIdx;
+		for (std::size_t i = 0; i < m_active.size(); /*increment conditionnel*/)
+		{
+			ScriptVMState& st = m_active[i];
+			auto it = m_scripts.find(st.scriptId);
+			if (it == m_scripts.end())
+			{
+				// Script disparu du catalogue (theoriquement impossible
+				// V1) : on retire l'execution.
+				m_active[i] = m_active.back();
+				m_active.pop_back();
+				continue;
+			}
+
+			firedIdx.clear();
+			const bool stillRunning = m_vm.Step(st, it->second, nowMs, firedIdx);
+			for (std::size_t cmdIdx : firedIdx)
+			{
+				LOG_DEBUG(DBScripts,
+					"[DBScripts] script {} fired cmd idx {} kind {}",
+					st.scriptId, cmdIdx,
+					static_cast<int>(it->second.commands[cmdIdx].kind));
+			}
+			firedThisTick += firedIdx.size();
+
+			if (!stillRunning)
+			{
+				m_active[i] = m_active.back();
+				m_active.pop_back();
+			}
+			else
+			{
+				++i;
+			}
+		}
+		m_totalFires += firedThisTick;
+		return firedThisTick;
+	}
+}

--- a/src/shardd/dbscripts/DBScriptRuntime.h
+++ b/src/shardd/dbscripts/DBScriptRuntime.h
@@ -1,0 +1,78 @@
+#pragma once
+// Wave 8 — Wrapper runtime DBScripts : detient un catalogue de scripts
+// (Script) charges au boot et une liste d'executions actives
+// (ScriptVMState). V1 minimaliste : 1-2 scripts hardcodes pour prouver
+// que le path "tick + Step VM + dispatch fired commands" est exerce
+// en boucle main (1Hz), plutot que rester un module orphelin.
+//
+// Cette PR : 1 script "greet" (Say + Wait + Say) + 1 script "patrol"
+// (Emote + MoveTo + Emote). Tick(nowMs) execute Step sur chaque
+// ScriptVMState actif et dispatche les fired commands via un sink
+// minimal (log "[DBScripts] script N fired cmd idx K"). Le vrai
+// dispatcher (vers ChatRelay pour Say, vers MovementGenerator pour
+// MoveTo, etc.) sera branche par les PRs futures.
+//
+// Future iteration : SeedFromDb() qui remplace SeedV1Scripts() ; et
+// integration QuestRuntime / talk handler pour RunScript(scriptId)
+// declenche par un evenement de jeu (creature interaction, etc.).
+
+#include "src/shardd/dbscripts/DBScript.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::dbscripts
+{
+	/// Wrapper minimaliste autour de Script + ScriptVM. Detient le
+	/// catalogue (m_scripts) et la liste des executions actives
+	/// (m_active). Une execution = un ScriptVMState lie a un scriptId.
+	class DBScriptRuntime
+	{
+	public:
+		DBScriptRuntime() = default;
+
+		/// Charge 1-2 scripts V1 hardcodes :
+		///   - scriptId 1 ("greet")  : Say 0ms + Wait 2000ms + Say 0ms
+		///   - scriptId 2 ("patrol") : Emote 0ms + MoveTo 1000ms + Emote 0ms
+		/// Effet de bord : reset m_scripts, m_active, m_totalFires.
+		/// Idempotent : peut etre rappele pour reset (jamais en prod).
+		void SeedV1Scripts();
+
+		/// Demarre l'execution du script \p scriptId. Si le script
+		/// n'existe pas, retourne false sans rien faire. Sinon ajoute
+		/// un ScriptVMState a m_active et appelle Start() dessus.
+		///
+		/// \param nowMs Horloge wall-clock en millisecondes. Le premier
+		///   command (idx 0) fire quand nowMs >= now + commands[0].delayMs.
+		bool RunScript(uint32_t scriptId, uint64_t nowMs);
+
+		/// Avance toutes les executions actives. Pour chaque
+		/// ScriptVMState, appelle ScriptVM::Step ; les indices de
+		/// commandes firees sont logs pour l'instant (futur : dispatch
+		/// vers les sous-systemes concernes). Les executions terminees
+		/// sont retirees de m_active.
+		///
+		/// Retourne le nombre total de commandes firees ce tick (pour
+		/// log periodique).
+		///
+		/// \param nowMs Horloge wall-clock en millisecondes (system_clock).
+		std::size_t Tick(uint64_t nowMs);
+
+		/// Nombre de scripts dans le catalogue. Sert pour log boot
+		/// "[DBScripts] N scripts loaded at boot".
+		std::size_t ScriptCount() const noexcept { return m_scripts.size(); }
+
+		/// Nombre d'executions actives a l'instant t.
+		std::size_t ActiveCount() const noexcept { return m_active.size(); }
+
+		/// Cumul total de commandes firees depuis le boot.
+		std::uint64_t TotalFires() const noexcept { return m_totalFires; }
+
+	private:
+		std::unordered_map<uint32_t, Script> m_scripts;
+		std::vector<ScriptVMState>           m_active;
+		ScriptVM                             m_vm;
+		std::uint64_t                        m_totalFires = 0;
+	};
+}

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -13,6 +13,9 @@
 // Wave 6 — Wiring runtime des modules internes (EventAI + PoolManager).
 #include "src/shardd/ai/EventAIRuntime.h"
 #include "src/shardd/pools/PoolManagerRuntime.h"
+// Wave 8 — Wiring runtime des modules internes (ThreatList + DBScripts).
+#include "src/shardd/combat/ThreatListRuntime.h"
+#include "src/shardd/dbscripts/DBScriptRuntime.h"
 
 #include <csignal>
 #include <chrono>
@@ -142,6 +145,24 @@ int main(int argc, char** argv)
 	pools.SeedV1Pools();
 	LOG_INFO(Pools, "[PoolManager] {} pools registered at boot", pools.PoolCount());
 
+	// Wave 8 — Instanciation + seed ThreatList + DBScripts. Meme pattern
+	// que Wave 6 : on prouve que les path tick (decay ThreatList + Step
+	// VM DBScripts) sont reellement exerces au runtime, pas seulement en
+	// unit tests. Pas de loader DB pour cette PR ; future iteration
+	// branche les vraies sources de donnees + dispatch reel des fired
+	// commands DBScripts.
+	engine::server::combat::ThreatListRuntime threats;
+	threats.SeedV1Aggro();
+	LOG_INFO(Combat,
+		"[ThreatList] {} creature(s) seeded with {} aggro entries at boot",
+		threats.CreatureCount(), threats.TotalEntries());
+
+	engine::server::dbscripts::DBScriptRuntime dbScripts;
+	dbScripts.SeedV1Scripts();
+	LOG_INFO(DBScripts,
+		"[DBScripts] {} scripts loaded at boot",
+		dbScripts.ScriptCount());
+
 	// Tick periodique EventAI : intervalle 1s. La boucle principale tourne
 	// a 100ms (sleep_for(100ms) ci-dessous) donc on filtre via
 	// lastEventAiTickMs. Idem pour le log periodique 60s qui dump le
@@ -152,6 +173,40 @@ int main(int argc, char** argv)
 	const auto kEventAiTickInterval = std::chrono::milliseconds(1000);
 	const auto kEventAiLogInterval  = std::chrono::seconds(60);
 	std::uint64_t firesSinceLastLog = 0;
+
+	// Wave 8 — Cadences propres aux deux nouveaux modules :
+	//   - ThreatList : decay periodique tous les 5s (combat plus lent
+	//     a tick que l'AI). Log periodique 60s dump du cumul purges.
+	//   - DBScripts  : Step VM tous les 1s. Log periodique 60s dump du
+	//     cumul commandes firees. RunScript(1) une seule fois apres le
+	//     seed pour que l'execution V1 fire reellement au runtime, ce
+	//     qui valide la chaine complete Start -> Step -> teardown.
+	auto lastThreatTickTime  = clock::now();
+	auto lastThreatLogTime   = clock::now();
+	auto lastDbScriptTickTime = clock::now();
+	auto lastDbScriptLogTime  = clock::now();
+	const auto kThreatTickInterval   = std::chrono::seconds(5);
+	const auto kThreatLogInterval    = std::chrono::seconds(60);
+	const auto kDbScriptTickInterval = std::chrono::seconds(1);
+	const auto kDbScriptLogInterval  = std::chrono::seconds(60);
+	std::uint64_t decaysSinceLastLog       = 0;
+	std::uint64_t dbScriptFiresSinceLastLog = 0;
+
+	// Demarre une execution V1 de scriptId=1 ("greet") pour que la
+	// boucle Step en ait au moins une a faire avancer. En prod ce
+	// RunScript sera declenche par un evenement gameplay (interaction
+	// NPC, etc.) plutot que cable inconditionnellement au boot.
+	{
+		const std::uint64_t bootNowMs = static_cast<std::uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+		if (dbScripts.RunScript(1, bootNowMs))
+		{
+			LOG_INFO(DBScripts,
+				"[DBScripts] V1 script 1 ('greet') started at boot ({} active)",
+				dbScripts.ActiveCount());
+		}
+	}
 
 	LOG_INFO(Net, "[ShardMain] Shard server running (Ctrl+C to stop); master {}:{} register endpoint='{}'",
 		masterHost, masterPort, regEndpoint);
@@ -184,6 +239,47 @@ int main(int argc, char** argv)
 				firesSinceLastLog, eventAi.TotalFires());
 			firesSinceLastLog = 0;
 			lastEventAiLogTime = nowSteady;
+		}
+
+		// Wave 8 — Tick ThreatList (5s). Wall-clock pas indispensable V1
+		// (decay par tick), mais on passe nowMs pour parite API et pour
+		// futurs scenarios de decay base sur l'inactivite.
+		if (nowSteady - lastThreatTickTime >= kThreatTickInterval)
+		{
+			const std::uint64_t realNowMs = static_cast<std::uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			decaysSinceLastLog += threats.Tick(realNowMs);
+			lastThreatTickTime = nowSteady;
+		}
+		if (nowSteady - lastThreatLogTime >= kThreatLogInterval)
+		{
+			LOG_INFO(Combat,
+				"[ThreatList] tick : {} entries decayed (last 60s), total since boot {}, currently {} entries across {} creatures",
+				decaysSinceLastLog, threats.TotalDecayed(),
+				threats.TotalEntries(), threats.CreatureCount());
+			decaysSinceLastLog = 0;
+			lastThreatLogTime = nowSteady;
+		}
+
+		// Wave 8 — Tick DBScripts (1s). nowMs en wall-clock car la VM
+		// compare nextRunTickMs (initialise depuis Start) a nowMs.
+		if (nowSteady - lastDbScriptTickTime >= kDbScriptTickInterval)
+		{
+			const std::uint64_t realNowMs = static_cast<std::uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			dbScriptFiresSinceLastLog += dbScripts.Tick(realNowMs);
+			lastDbScriptTickTime = nowSteady;
+		}
+		if (nowSteady - lastDbScriptLogTime >= kDbScriptLogInterval)
+		{
+			LOG_INFO(DBScripts,
+				"[DBScripts] tick : {} commands fired (last 60s), total since boot {}, {} active",
+				dbScriptFiresSinceLastLog, dbScripts.TotalFires(),
+				dbScripts.ActiveCount());
+			dbScriptFiresSinceLastLog = 0;
+			lastDbScriptLogTime = nowSteady;
 		}
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));


### PR DESCRIPTION
## Wave 8 — Wire Combat ThreatList + DBScripts runtimes shardd

Activation au boot du shardd de 2 systèmes serveur internes dont l'algorithme + tests étaient déjà mergés mais qui n'étaient pas instanciés en runtime. Pattern strict aligné sur Wave 6 (EventAI + PoolManager).

### Wiring

| Système | Wrapper créé | Tick | Logique V1 |
|---|---|---|---|
| **ThreatList** | `ThreatListRuntime` | 5s | Decay 5 threat / 5s, purge attackers à 0 |
| **DBScripts** | `DBScriptRuntime` | 1s | ScriptVM step-by-step (Say + Wait + Emote + MoveTo) |

### Fichiers ajoutés
- `src/shardd/combat/ThreatListRuntime.{h,cpp}`
- `src/shardd/dbscripts/DBScriptRuntime.{h,cpp}`

### Fichiers modifiés
- `src/shardd/main_linux.cpp` — instanciation + seed boot + Tick périodiques + logs cumulés (60s)
- `src/CMakeLists.txt` — 3 nouvelles sources `shard_app` UNIX

### V1 contenu hardcodé

**ThreatList** : 1 créature (id=1) avec 2 attackers (player#100=50threat, player#101=30threat).
**DBScripts** :
- scriptId=1 "greet" : Say + Wait 2000ms + Say
- scriptId=2 "patrol" : Emote + MoveTo 1000ms + Emote
- `RunScript(1)` au boot pour exercer le path Tick

### V1 limitations
- DBScript fired commands logged seulement (pas de dispatch ChatRelayHandler/MotionGenerator) — futures PRs
- ThreatList decay uniforme V1 ; futur : decay par inactivité par-attacker
- Wiring UNIX shardd uniquement (`shard_app` WIN32 sandbox inchangé)

### Déploiement
> ⚠️ **REDÉPLOIEMENT SHARD LINUX REQUIS** — nouveaux runtimes au boot. Pas de wire-breaking côté protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
