### PR TITLE
feat(shardd): Wave 9 -- wire AntiCheat + SpellFamily + InstanceManager runtimes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -627,6 +627,7 @@ elseif(UNIX)
   # M22.6: Shard server (ticket handshake + enregistrement TLS/TCP vers le Master via ShardToMasterClient)
   # Wave 6: + EventAIRuntime + PoolManagerRuntime (tickes + seedes au boot).
   # Wave 8: + ThreatListRuntime + DBScriptRuntime (idem).
+  # Wave 9: + AntiCheatGameplayRuntime + SpellFamilyRuntime + InstanceManagerRuntime.
   add_executable(shard_app
     ${CMAKE_SOURCE_DIR}/src/shardd/main_linux.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/NetServer.cpp
@@ -646,6 +647,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/combat/ThreatListRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScript.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScriptRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/spell/SpellFamilyRuntime.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/maps/InstanceManagerRuntime.cpp
   )
   target_include_directories(shard_app PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(shard_app PRIVATE engine_core OpenSSL::SSL pthread)

--- a/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
+++ b/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
@@ -1,0 +1,51 @@
+#include "src/shardd/anticheat/AntiCheatGameplayRuntime.h"
+
+namespace engine::server::anticheat
+{
+	namespace
+	{
+		/// PlayerIds fictifs scannes a chaque Tick. V1 : 3 entrees pour
+		/// avoir un fan-out non trivial sans alourdir le path CPU. Future
+		/// iteration : remplace par un fan-out reel via PlayerManager.
+		constexpr PlayerId kFakePlayers[] = { 1001ULL, 1002ULL, 1003ULL };
+	}
+
+	/// Reconstruit le detecteur interne avec la config V1 hardcodee
+	/// (cf. AntiCheatGameplayRuntime.h pour les valeurs detaillees). Reset
+	/// aussi les compteurs cumulatifs et le tick counter, donc l'effet
+	/// est equivalent a une nouvelle instance.
+	void AntiCheatGameplayRuntime::SeedV1Config()
+	{
+		AntiCheatConfig cfg;
+		cfg.maxSpeedMps    = 7.5f;
+		cfg.speedTolerance = 1.5f;
+		cfg.maxSingleStepM = 50.0f;
+		m_detector = AntiCheatGameplay(cfg);
+		m_totalViolations = 0;
+		m_tickCounter     = 0;
+	}
+
+	/// Avance chaque PlayerId fictif d'un petit pas plausible (1m sur l'axe
+	/// X par tick) puis interroge le detecteur. Le delta-temps theorique
+	/// entre deux ticks est de 1000 ms (cadence du wiring main_linux.cpp),
+	/// donc la vitesse calculee restera proche de 1 m/s, bien sous le
+	/// seuil maxAllowed = 7.5 * 1.5 = 11.25 m/s. En regime nominal, le
+	/// retour est donc 0.
+	std::size_t AntiCheatGameplayRuntime::Tick(std::uint64_t nowMs)
+	{
+		++m_tickCounter;
+		const float x = static_cast<float>(m_tickCounter) * 1.0f;
+		const float y = 0.0f;
+		const float z = 0.0f;
+
+		std::size_t violations = 0;
+		for (PlayerId pid : kFakePlayers)
+		{
+			const CheatVerdict v = m_detector.CheckMovement(pid, x, y, z, nowMs);
+			if (v != CheatVerdict::OK)
+				++violations;
+		}
+		m_totalViolations += violations;
+		return violations;
+	}
+}

--- a/src/shardd/anticheat/AntiCheatGameplayRuntime.h
+++ b/src/shardd/anticheat/AntiCheatGameplayRuntime.h
@@ -1,0 +1,66 @@
+#pragma once
+// Wave 9 — Wrapper runtime AntiCheatGameplay : detient un detecteur
+// AntiCheatGameplay seede au boot du shardd avec une config V1 hardcodee
+// (max speed 7.5 m/s * tolerance 1.5 = 11.25 m/s effectif, max single
+// step 50m -> teleport hack au-dela). Tick periodique (1s) qui scan une
+// poignee de "fake players" pour exercer le path CheckMovement -> verdict
+// au runtime. Future iteration : SeedFromConfig() qui lit les seuils
+// depuis config.json, et un fan-out reel via PlayerManager au lieu de
+// players fictifs.
+//
+// Le but de cette PR : prouver que le path tick AntiCheat est reellement
+// exerce a chaque seconde, pas seulement teste en unit. Les "violations"
+// detectees sont cumulees et loggees toutes les 60s ; un cumul a 0 ne
+// logge rien (pas de bruit en prod si tout va bien).
+
+#include "src/shardd/anticheat/AntiCheatGameplay.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::server::anticheat
+{
+	/// Wrapper minimaliste autour de AntiCheatGameplay : detient le
+	/// detecteur configure V1 (maxSpeedMps=7.5, tolerance=1.5,
+	/// maxSingleStepM=50.0) et expose un Tick() qui scan une petite
+	/// liste de PlayerIds fictifs. Future iteration : etat partage avec
+	/// PlayerManager + EventBus pour le fan-out reel des MOVE_REPORT.
+	class AntiCheatGameplayRuntime
+	{
+	public:
+		AntiCheatGameplayRuntime() = default;
+
+		/// Charge la config V1 hardcodee dans le detecteur interne :
+		///   - maxSpeedMps    = 7.5  (walk + run + mount typique)
+		///   - speedTolerance = 1.5  (50% lag headroom)
+		///   - maxSingleStepM = 50.0 (teleport hack au-dela)
+		/// Idempotent : peut etre rappele pour reset l'etat interne du
+		/// detecteur (utile en tests, jamais en prod).
+		void SeedV1Config();
+
+		/// Scan une liste fixe de PlayerIds fictifs (1001..1003) et fait
+		/// avancer la position de chacun d'une petite quantite plausible
+		/// depuis le dernier Tick. Retourne le nombre de verdicts != OK
+		/// detectes ce tick (typiquement 0 en regime nominal).
+		///
+		/// V1 : positions deterministes proches de la realite (deplacement
+		/// "lent" 1m/s). En pratique, le detecteur n'a rien a flag tant que
+		/// SeedV1Config() est applique tel quel ; ce Tick() prouve juste
+		/// que le path CheckMovement est exerce a chaque seconde au runtime.
+		///
+		/// \param nowMs Horloge wall-clock en millisecondes (system_clock
+		///   typiquement). Doit etre monotone d'un tick a l'autre, sinon
+		///   le calcul de delta-temps interne donnera des speeds aberrants.
+		std::size_t Tick(std::uint64_t nowMs);
+
+		/// Nombre total de violations detectees depuis le boot (cumul
+		/// sur toute la duree de vie du runtime). Sert pour le log
+		/// periodique 60s "[AntiCheat] N violations in last 60s".
+		std::uint64_t TotalViolations() const noexcept { return m_totalViolations; }
+
+	private:
+		AntiCheatGameplay m_detector;
+		std::uint64_t     m_totalViolations = 0;
+		std::uint64_t     m_tickCounter     = 0;   ///< Pour generer un mouvement deterministe.
+	};
+}

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -16,6 +16,10 @@
 // Wave 8 — Wiring runtime des modules internes (ThreatList + DBScripts).
 #include "src/shardd/combat/ThreatListRuntime.h"
 #include "src/shardd/dbscripts/DBScriptRuntime.h"
+// Wave 9 — Wiring runtime AntiCheat + SpellFamily + InstanceManager.
+#include "src/shardd/anticheat/AntiCheatGameplayRuntime.h"
+#include "src/shardd/spell/SpellFamilyRuntime.h"
+#include "src/shardd/maps/InstanceManagerRuntime.h"
 
 #include <csignal>
 #include <chrono>
@@ -163,6 +167,21 @@ int main(int argc, char** argv)
 		"[DBScripts] {} scripts loaded at boot",
 		dbScripts.ScriptCount());
 
+	// Wave 9 — AntiCheat + SpellFamily + InstanceManager. Meme pattern : on
+	// seede au boot pour qu'au moins UN cycle V1 soit exerce en prod (et
+	// pour qu'un futur SeedFromDb() ait son point d'accroche evident).
+	engine::server::anticheat::AntiCheatGameplayRuntime antiCheat;
+	antiCheat.SeedV1Config();
+	LOG_INFO(AntiCheat, "[AntiCheat] runtime configured (V1 thresholds : maxSpeed=7.5 m/s, tolerance=1.5, maxStep=50 m)");
+
+	engine::server::spell::SpellFamilyRuntime spellFamily;
+	spellFamily.SeedV1Families();
+	LOG_INFO(Spell, "[SpellFamily] {} spells registered at boot", spellFamily.SpellCount());
+
+	engine::server::maps::InstanceManagerRuntime instanceMgr;
+	instanceMgr.SeedV1Maps();
+	LOG_INFO(Maps, "[InstanceManager] {} maps registered at boot", instanceMgr.MapCount());
+
 	// Tick periodique EventAI : intervalle 1s. La boucle principale tourne
 	// a 100ms (sleep_for(100ms) ci-dessous) donc on filtre via
 	// lastEventAiTickMs. Idem pour le log periodique 60s qui dump le
@@ -207,6 +226,17 @@ int main(int argc, char** argv)
 				dbScripts.ActiveCount());
 		}
 	}
+
+	// Wave 9 — Cadence AntiCheat : 1Hz (granularite mouvement client). Le
+	// log periodique 60s ne dump que si le cumul est > 0 (pas de bruit en
+	// regime nominal). cumulativeAntiCheatViolations est volontairement
+	// distinct de TotalViolations() pour pouvoir reset par tranche de 60s
+	// sans toucher au cumul "depuis boot" expose par le runtime.
+	auto lastAntiCheatTickTime = clock::now();
+	auto lastAntiCheatLogTime  = clock::now();
+	const auto kAntiCheatTickInterval = std::chrono::milliseconds(1000);
+	const auto kAntiCheatLogInterval  = std::chrono::seconds(60);
+	std::uint64_t cumulativeAntiCheatViolations = 0;
 
 	LOG_INFO(Net, "[ShardMain] Shard server running (Ctrl+C to stop); master {}:{} register endpoint='{}'",
 		masterHost, masterPort, regEndpoint);
@@ -280,6 +310,29 @@ int main(int argc, char** argv)
 				dbScripts.ActiveCount());
 			dbScriptFiresSinceLastLog = 0;
 			lastDbScriptLogTime = nowSteady;
+		}
+
+		// Wave 9 — Tick AntiCheat (1Hz). Meme conversion steady -> wall-clock
+		// que pour EventAI : le detecteur calcule un dt en millisecondes
+		// wall-clock, donc passer realNowMs est obligatoire.
+		if (nowSteady - lastAntiCheatTickTime >= kAntiCheatTickInterval)
+		{
+			const std::uint64_t realNowMs = static_cast<std::uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			cumulativeAntiCheatViolations += antiCheat.Tick(realNowMs);
+			lastAntiCheatTickTime = nowSteady;
+		}
+		if (nowSteady - lastAntiCheatLogTime >= kAntiCheatLogInterval)
+		{
+			if (cumulativeAntiCheatViolations > 0)
+			{
+				LOG_INFO(AntiCheat,
+					"[AntiCheat] {} violations in last 60s (total since boot {})",
+					cumulativeAntiCheatViolations, antiCheat.TotalViolations());
+				cumulativeAntiCheatViolations = 0;
+			}
+			lastAntiCheatLogTime = nowSteady;
 		}
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/shardd/maps/InstanceManagerRuntime.cpp
+++ b/src/shardd/maps/InstanceManagerRuntime.cpp
@@ -1,0 +1,38 @@
+#include "src/shardd/maps/InstanceManagerRuntime.h"
+
+namespace engine::server::maps
+{
+	/// Enregistre trois MapIds V1 hardcodees comme instanciables :
+	///   - 100 : "Donjon des Marais"   (donjon 5-man)
+	///   - 101 : "Crypte du Vieux Roi" (donjon 5-man)
+	///   - 200 : "Vallee des Cendres"  (battleground PvP)
+	/// Ces ids ne pretendent pas matcher un DBC reel ; le loader DB
+	/// fournira l'ensemble canonique (probablement aligne sur la
+	/// numerotation existante des assets monde).
+	void InstanceManagerRuntime::SeedV1Maps()
+	{
+		m_maps.clear();
+		m_maps.insert(MapId{100});
+		m_maps.insert(MapId{101});
+		m_maps.insert(MapId{200});
+	}
+
+	/// Cree une instance pour \p mapId si elle est enregistree. La
+	/// validation se fait sur le set m_maps : si le loader DB n'a pas
+	/// pousse la map, on refuse silencieusement (retour 0) plutot que
+	/// de spawner une instance fantome. \p partyGuid est ignore en V1
+	/// mais le parametre est present pour stabiliser la signature
+	/// (l'appelant final passera deja la party).
+	InstanceId InstanceManagerRuntime::CreateInstance(MapId mapId,
+		std::uint64_t /*partyGuid*/, std::uint64_t nowMs)
+	{
+		if (!IsMapRegistered(mapId))
+			return InstanceId{0};
+		return m_mgr.Create(mapId, nowMs);
+	}
+
+	bool InstanceManagerRuntime::IsMapRegistered(MapId mapId) const noexcept
+	{
+		return m_maps.find(mapId) != m_maps.end();
+	}
+}

--- a/src/shardd/maps/InstanceManagerRuntime.h
+++ b/src/shardd/maps/InstanceManagerRuntime.h
@@ -1,0 +1,71 @@
+#pragma once
+// Wave 9 — Wrapper runtime InstanceManager : detient un registre de
+// MapIds "instanciables" seede au boot du shardd avec 2-3 maps hardcodees
+// (deux donjons et un BG) + un InstanceManager pour le lifecycle reel
+// (Create / Touch / MarkIdle / Despawn / GarbageCollect). V1 : map
+// registry in-memory, pas de validation cross-DBC. Future iteration :
+// SeedFromDb() qui charge depuis la table map_template avec capacite,
+// idle_unload_ms, party_size_max, etc.
+//
+// Pas de Tick() pour cette PR : la creation d'instance se fait a la
+// demande (event d'entree de donjon ou ouverture de BG). Un futur tick
+// sera ajoute pour GarbageCollect() periodique des instances Idle, mais
+// pour V1 on prouve juste que le path "registre + Create" est cable.
+
+#include "src/shardd/maps/InstanceManager.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_set>
+
+namespace engine::server::maps
+{
+	/// Wrapper minimaliste autour d'InstanceManager + un set de MapIds
+	/// "instanciables". Le set sert de garde-fou : on refuse de creer
+	/// une instance pour une map non enregistree (loader DB fournira
+	/// l'ensemble canonique). InstanceManager reste expose pour les
+	/// operations avancees (TouchActivity, MarkIdle, GarbageCollect).
+	class InstanceManagerRuntime
+	{
+	public:
+		InstanceManagerRuntime() = default;
+
+		/// Enregistre 2-3 MapIds V1 hardcodees comme instanciables. Voir
+		/// .cpp pour les valeurs. Idempotent : peut etre rappele pour
+		/// reset le registre (utile en tests, jamais en prod ; reset le
+		/// registre n'affecte pas les instances deja creees).
+		void SeedV1Maps();
+
+		/// Cree une nouvelle instance pour \p mapId si \p mapId est
+		/// enregistre. Retourne l'InstanceId alloue, ou 0 si la map est
+		/// inconnue (0 n'est jamais un ID valide vu que m_mgr.m_nextId
+		/// demarre a 1).
+		///
+		/// \param partyGuid Identifiant de party demandeuse, conserve
+		///   pour traces futures. V1 : non stocke, le binding party ->
+		///   instance sera ajoute en meme temps que le PartyManager.
+		InstanceId CreateInstance(MapId mapId, std::uint64_t partyGuid, std::uint64_t nowMs);
+
+		/// True si \p mapId est dans le registre des maps instanciables.
+		bool IsMapRegistered(MapId mapId) const noexcept;
+
+		/// Nombre de MapIds enregistres (sert pour le log boot
+		/// "[InstanceManager] N maps registered at boot").
+		std::size_t MapCount() const noexcept { return m_maps.size(); }
+
+		/// Nombre d'instances actuellement vivantes (Created/Active/Idle).
+		/// Les instances Despawned restent comptees jusqu'a un GC.
+		std::size_t LiveInstanceCount() const noexcept { return m_mgr.Size(); }
+
+		/// Accesseur sur le manager interne pour les operations avancees
+		/// (TouchActivity, MarkIdle, Despawn, GarbageCollect, Find). A
+		/// utiliser parcimonieusement : preferable d'enrichir l'API du
+		/// runtime quand un cas d'usage stable emerge.
+		InstanceManager&       Manager() noexcept       { return m_mgr; }
+		const InstanceManager& Manager() const noexcept { return m_mgr; }
+
+	private:
+		std::unordered_set<MapId> m_maps;
+		InstanceManager           m_mgr;
+	};
+}

--- a/src/shardd/spell/SpellFamilyRuntime.cpp
+++ b/src/shardd/spell/SpellFamilyRuntime.cpp
@@ -1,0 +1,61 @@
+#include "src/shardd/spell/SpellFamilyRuntime.h"
+
+namespace engine::server::spell
+{
+	/// Enregistre trois SpellInfo V1 hardcodees. Les spellIds sont choisis
+	/// pour evoquer les sorts canoniques sans pretendre matcher un DBC
+	/// reel (ce sera le boulot du loader DB) :
+	///   - 133  "Fireball"      : Mage, mask bit 0 set sur parts[0]
+	///   - 116  "Frostbolt"     : Mage, mask bit 1 set sur parts[0]
+	///   - 12294 "Mortal Strike" : Warrior, mask bit 0 set sur parts[0]
+	/// Le decoupage des bits dans parts[] est arbitraire pour V1 ; le
+	/// loader DB definira la convention canonique (a aligner sur les
+	/// scripts existants au moment du portage).
+	void SpellFamilyRuntime::SeedV1Families()
+	{
+		m_spells.clear();
+
+		{
+			SpellInfo si;
+			si.spellId    = 133;
+			si.family     = SpellFamily::Mage;
+			si.familyMask = SpellFamilyMask(0x00000001u);
+			m_spells.emplace(si.spellId, si);
+		}
+		{
+			SpellInfo si;
+			si.spellId    = 116;
+			si.family     = SpellFamily::Mage;
+			si.familyMask = SpellFamilyMask(0x00000002u);
+			m_spells.emplace(si.spellId, si);
+		}
+		{
+			SpellInfo si;
+			si.spellId    = 12294;
+			si.family     = SpellFamily::Warrior;
+			si.familyMask = SpellFamilyMask(0x00000001u);
+			m_spells.emplace(si.spellId, si);
+		}
+	}
+
+	const SpellInfo* SpellFamilyRuntime::Find(std::uint32_t spellId) const noexcept
+	{
+		auto it = m_spells.find(spellId);
+		return (it == m_spells.end()) ? nullptr : &it->second;
+	}
+
+	bool SpellFamilyRuntime::HasFamily(std::uint32_t spellId,
+		SpellFamily mustHaveFamily) const noexcept
+	{
+		const SpellInfo* si = Find(spellId);
+		return si != nullptr && si->family == mustHaveFamily;
+	}
+
+	bool SpellFamilyRuntime::MatchesProc(std::uint32_t spellId,
+		SpellFamily mustHaveFamily, const SpellFamilyMask& anyOfMask) const noexcept
+	{
+		const SpellInfo* si = Find(spellId);
+		if (si == nullptr) return false;
+		return SpellMatchesProcCriteria(*si, mustHaveFamily, anyOfMask);
+	}
+}

--- a/src/shardd/spell/SpellFamilyRuntime.h
+++ b/src/shardd/spell/SpellFamilyRuntime.h
@@ -1,0 +1,60 @@
+#pragma once
+// Wave 9 — Wrapper runtime SpellFamily : detient un registre statique de
+// SpellInfo (spellId -> family + familyMask) seede au boot du shardd avec
+// 2-3 sample spells hardcodees (Fireball, Frostbolt, Mortal Strike). V1
+// : registre in-memory, lookup O(1). Future iteration : SeedFromDb() qui
+// remplace SeedV1Families() en chargeant depuis MySQL (table spell_info
+// avec famille + mask128).
+//
+// Pas de Tick() : SpellFamilyMask est une primitive de classification
+// utilisee a la demande par les futures couches ProcEvent / SpellCast
+// / AuraTrigger. Le runtime expose juste un Find(spellId) + HasFamily()
+// + MatchesProc() pour que le code appelant ne touche pas directement
+// au unordered_map.
+
+#include "src/shardd/spell/SpellFamilyMask.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+
+namespace engine::server::spell
+{
+	/// Wrapper minimaliste autour d'un registre spellId -> SpellInfo.
+	/// Future iteration : ce registre sera charge depuis la DB et le
+	/// runtime exposera Refresh() + un cache invalidation hook.
+	class SpellFamilyRuntime
+	{
+	public:
+		SpellFamilyRuntime() = default;
+
+		/// Charge 2-3 SpellInfo V1 hardcodees pour exercer le wiring.
+		/// Voir .cpp pour les valeurs (Fireball/Frostbolt en famille Mage,
+		/// Mortal Strike en famille Warrior). Idempotent : peut etre
+		/// rappele pour reset le registre (utile en tests, jamais en prod).
+		void SeedV1Families();
+
+		/// Cherche un spell par id. Retourne nullptr si inconnu. Pointeur
+		/// non-owning : la lifetime suit celle du registre interne, ne pas
+		/// le stocker au-dela d'un appel a Refresh()/SeedV1Families().
+		const SpellInfo* Find(std::uint32_t spellId) const noexcept;
+
+		/// True si \p spellId existe ET sa famille == \p mustHaveFamily.
+		/// Convenance pour les codes appelants qui ne se soucient pas du
+		/// mask 128.
+		bool HasFamily(std::uint32_t spellId, SpellFamily mustHaveFamily) const noexcept;
+
+		/// Wrapper sur SpellMatchesProcCriteria : true si \p spellId est
+		/// connu ET match le critere ProcEvent (\p mustHaveFamily +
+		/// \p anyOfMask).
+		bool MatchesProc(std::uint32_t spellId, SpellFamily mustHaveFamily,
+			const SpellFamilyMask& anyOfMask) const noexcept;
+
+		/// Nombre de spells enregistres (sert pour le log boot
+		/// "[SpellFamily] N spells registered at boot").
+		std::size_t SpellCount() const noexcept { return m_spells.size(); }
+
+	private:
+		std::unordered_map<std::uint32_t, SpellInfo> m_spells;
+	};
+}


### PR DESCRIPTION
## Wave 9 — Wire AntiCheat + SpellFamily + InstanceManager runtimes shardd

Suite à Wave 6 (#573 EventAI+PoolManager) et Wave 8 (#576 ThreatList+DBScripts), Wave 9 active 3 systèmes serveur internes supplémentaires au boot du shardd.

### Wiring

| Système | Wrapper | Tick | V1 contenu |
|---|---|---|---|
| **AntiCheatGameplay** | `AntiCheatGameplayRuntime` | 1s | Config V1 hardcodée + scan 3 players factices, flag SpeedHack/TeleportHack |
| **SpellFamilyMask** | `SpellFamilyRuntime` | (à la demande) | 3 spell families seedées (sample masks) |
| **InstanceManager** | `InstanceManagerRuntime` | (à la demande) | 2-3 maps instances registered |

### Fichiers ajoutés
- `src/shardd/anticheat/AntiCheatGameplayRuntime.{h,cpp}`
- `src/shardd/spell/SpellFamilyRuntime.{h,cpp}`
- `src/shardd/maps/InstanceManagerRuntime.{h,cpp}`

### Fichiers modifiés
- `src/shardd/main_linux.cpp` — seeds boot + tick AntiCheat 1Hz + log cumulé 60s
- `src/CMakeLists.txt` — 3 nouvelles sources UNIX `shard_app`

### V1 limitations
- AntiCheat scan 3 PlayerIds factices (1001..1003) qui bougent 1m/tick — pas de fan-out via PlayerManager (V1 out-of-scope)
- SpellFamily seed values arbitraires (DB loader future PR définira la convention)
- InstanceManager pas de GarbageCollect tick V1 (seed + on-demand `CreateInstance` seulement)
- Wave 9 base = `origin/main` (sans Wave 8) — diff stacks cleanly. Si Wave 8 land en premier, trivial merge dans `main_linux.cpp`.

### Déploiement
> ⚠️ **REDÉPLOIEMENT SHARD LINUX REQUIS** — nouveaux runtimes + tick AntiCheat au boot. Pas de wire-breaking côté protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
