### PR TITLE
fix(db): URGENT -- rename guild_members -> guild_members_v2 (migration 0055 crash)

### DIFF
--- a/sql/migrations/0055_guilds_master.sql
+++ b/sql/migrations/0055_guilds_master.sql
@@ -1,5 +1,5 @@
 -- 0055 - Wave 5 Persistence Guilds (Phase 5.21b) : tables guilds_master,
--- guild_members et guild_bank pour persister la definition des guildes
+-- guild_members_v2 et guild_bank pour persister la definition des guildes
 -- V1 (2 guildes hardcodees + leurs membres + bank tab 0). Au boot, le
 -- master prefere charger depuis la DB plutot que le seed hardcode dans
 -- GuildHandler::SeedV1Guilds. Si la table est vide ou la DB indisponible,
@@ -12,7 +12,7 @@
 --     decorelles des accounts reels).
 --   - created_at_unix_ms : timestamp creation pour l'audit.
 --
--- guild_members :
+-- guild_members_v2 :
 --   - cle composite (guild_id, account_id) : un account ne peut etre
 --     que dans une seule guilde a la fois (regle V1).
 --   - rank_id : 0=Guild Master .. 9=Initiate, defaut 5=Member.
@@ -42,14 +42,14 @@ CREATE TABLE IF NOT EXISTS guilds_master (
     KEY idx_leader (leader_account_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS guild_members (
+CREATE TABLE IF NOT EXISTS guild_members_v2 (
     guild_id           INT UNSIGNED NOT NULL,
     account_id         BIGINT UNSIGNED NOT NULL,
     rank_id            TINYINT UNSIGNED NOT NULL DEFAULT 5,
     joined_at_unix_ms  BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (guild_id, account_id),
     KEY idx_account (account_id),
-    CONSTRAINT fk_guild_members_guild FOREIGN KEY (guild_id)
+    CONSTRAINT fk_guild_members_v2_guild FOREIGN KEY (guild_id)
         REFERENCES guilds_master(guild_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -79,7 +79,7 @@ INSERT IGNORE INTO guilds_master (guild_id, name, motd, leader_account_id, creat
 -- account_id mapping V1 (resolu cote handler via lookup local) :
 --   1=Aragorn (GM), 2=Legolas (Officer), 3=Gimli (Member), 4=Frodo (Initiate)
 --   5=Saruman (GM), 6=Wormtongue (Member)
-INSERT IGNORE INTO guild_members (guild_id, account_id, rank_id, joined_at_unix_ms) VALUES
+INSERT IGNORE INTO guild_members_v2 (guild_id, account_id, rank_id, joined_at_unix_ms) VALUES
     (1, 1, 0, 1767225600000),
     (1, 2, 1, 1767225600000),
     (1, 3, 5, 1767225600000),

--- a/src/masterd/guild/MysqlGuildStore.cpp
+++ b/src/masterd/guild/MysqlGuildStore.cpp
@@ -82,11 +82,11 @@ namespace engine::server::guilds_db
 		{
 			const char* sql =
 				"SELECT guild_id, account_id, rank_id, joined_at_unix_ms "
-				"FROM guild_members ORDER BY guild_id ASC, rank_id ASC, account_id ASC";
+				"FROM guild_members_v2 ORDER BY guild_id ASC, rank_id ASC, account_id ASC";
 			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
 			if (!res)
 			{
-				LOG_WARN(Net, "[MysqlGuildStore] LoadAll guild_members query failed");
+				LOG_WARN(Net, "[MysqlGuildStore] LoadAll guild_members_v2 query failed");
 				// On retourne quand meme les guildes meme sans membres.
 				return out;
 			}
@@ -174,7 +174,7 @@ namespace engine::server::guilds_db
 
 		char sql[256];
 		std::snprintf(sql, sizeof(sql),
-			"INSERT INTO guild_members (guild_id, account_id, rank_id, joined_at_unix_ms) "
+			"INSERT INTO guild_members_v2 (guild_id, account_id, rank_id, joined_at_unix_ms) "
 			"VALUES (%u, %llu, %u, %llu)",
 			guildId,
 			static_cast<unsigned long long>(accountId),


### PR DESCRIPTION
## Fix critique : migration 0055 crashe le master au boot

Le master de prod ne démarre plus depuis le déploiement de Wave 5 phase 2 (PR #574 mergée hier soir) :

```
[MigrationRunner] Applied migration 54 (0054_outdoor_pvp_state.sql)
[MigrationRunner] Drain results after migration 55 failed: Unknown column 'account_id' in 'field list'
[ServerMain] Migrations failed, exiting
```

Loop infini de redémarrage Docker.

### Cause

La migration `0003_guilds.sql` (M32.3, depuis longtemps en prod) a créé une table `guild_members` avec colonne **`player_id`**. Ma migration `0055_guilds_master.sql` (PR #574) faisait :

```sql
CREATE TABLE IF NOT EXISTS guild_members (
    guild_id INT UNSIGNED, account_id BIGINT UNSIGNED, ...  -- nouveau schema
);
INSERT IGNORE INTO guild_members (guild_id, account_id, ...) VALUES ...;
```

Le `CREATE TABLE IF NOT EXISTS` était **no-op** (table 0003 existait déjà). Puis l'INSERT échoue car la table existante a `player_id`, pas `account_id`.

### Fix

Renommer toutes les références `guild_members` → `guild_members_v2` dans :
- `sql/migrations/0055_guilds_master.sql` (8 occurrences : CREATE, FK constraint, INSERT, commentaires)
- `src/masterd/guild/MysqlGuildStore.cpp` (3 occurrences : SELECT LoadAll, log message, INSERT)

La table legacy `guild_members` (0003) reste intacte (le code legacy peut continuer à la lire via `player_id`). Les guildes V2 (Wave 5p2) utilisent maintenant `guild_members_v2` (avec `account_id`).

### Comportement attendu après redéploiement

```
[MigrationRunner] Applied migration 55 (0055_guilds_master.sql)
[MigrationRunner] Applied migration 56 (0056_bg_history.sql)
[MigrationRunner] Applied migration 57 (0057_loot_tables.sql)
[MigrationRunner] Migrations complete, lock released
[ServerMain] Serveur ready
```

Pas de migration de données nécessaire : `guild_members_v2` est créée vide puis seedée via `INSERT IGNORE` V1 ("Les Gardiens" + "L Ombre" avec leurs membres).

### Tests
Pas de tests unitaires modifiés. Le fix est validé par la CI (compile) + redéploiement prod (run).

### Déploiement
> ⚠️ **REDÉPLOIEMENT MASTER LINUX URGENT** — sans ce fix, le master crashe en loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
