### PR TITLE
feat(persistence): Wave 10 -- MysqlMailStore IsAvailable + InMemoryMailStore fallback

### DIFF
--- a/src/masterd/mail/MysqlMailStore.cpp
+++ b/src/masterd/mail/MysqlMailStore.cpp
@@ -14,6 +14,8 @@ namespace engine::server::mail
 {
 	namespace
 	{
+		/// Echappe une chaine pour MySQL via mysql_real_escape_string.
+		/// Retourne vide si mysql null. Aligne sur le pattern MysqlGuildStore.
 		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
 		{
 			if (!mysql) return {};
@@ -23,6 +25,10 @@ namespace engine::server::mail
 			return std::string(buf.data(), w);
 		}
 
+		/// Mappe une ligne SELECT mail (10 colonnes dans l'ordre canonique
+		/// mail_id, sender, receiver, subject, body, copper_gold, copper_cod,
+		/// sent_ts_ms, expires_ts_ms, state) vers la struct Mail.
+		/// N'attache PAS les items — c'est LoadItemsForMail qui s'en charge.
 		Mail RowToMail(MYSQL_ROW row)
 		{
 			Mail m;
@@ -43,6 +49,9 @@ namespace engine::server::mail
 			return m;
 		}
 
+		/// Charge les attachments d'un mail depuis mail_items dans \p m.
+		/// Effet de bord : append-only sur m.items (le caller doit l'initialiser
+		/// vide). Log warning sur erreur DB ; ne throw jamais.
 		void LoadItemsForMail(MYSQL* mysql, Mail& m)
 		{
 			char sql[256];
@@ -51,7 +60,11 @@ namespace engine::server::mail
 				"WHERE mail_id = %llu ORDER BY slot ASC",
 				static_cast<unsigned long long>(m.mailId));
 			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-			if (!res) return;
+			if (!res)
+			{
+				LOG_WARN(Net, "[MysqlMailStore] LoadItemsForMail query failed mailId={}", m.mailId);
+				return;
+			}
 			while (MYSQL_ROW row = mysql_fetch_row(res))
 			{
 				MailItemAttachment a;
@@ -63,9 +76,14 @@ namespace engine::server::mail
 		}
 	}
 
+	bool MysqlMailStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
 	uint64_t MysqlMailStore::Insert(Mail& out)
 	{
-		if (!m_pool || !m_pool->IsInitialized()) return 0;
+		if (!IsAvailable()) return 0;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return 0;
@@ -92,7 +110,8 @@ namespace engine::server::mail
 
 		if (!engine::server::db::DbExecute(mysql, sql))
 		{
-			LOG_ERROR(Core, "[MysqlMailStore] Insert mail failed");
+			LOG_WARN(Net, "[MysqlMailStore] Insert mail failed sender={} receiver={}",
+				out.senderAccountId, out.receiverAccountId);
 			return 0;
 		}
 		out.mailId = mysql_insert_id(mysql);
@@ -108,7 +127,8 @@ namespace engine::server::mail
 				i, it.itemTemplateId, it.count);
 			if (!engine::server::db::DbExecute(mysql, sqli))
 			{
-				LOG_ERROR(Core, "[MysqlMailStore] Insert mail_item slot={} failed", i);
+				LOG_WARN(Net, "[MysqlMailStore] Insert mail_item slot={} failed mailId={}",
+					i, out.mailId);
 				return 0;
 			}
 		}
@@ -119,7 +139,7 @@ namespace engine::server::mail
 
 	std::optional<Mail> MysqlMailStore::Find(uint64_t mailId) const
 	{
-		if (!m_pool || !m_pool->IsInitialized()) return std::nullopt;
+		if (!IsAvailable()) return std::nullopt;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return std::nullopt;
@@ -147,7 +167,7 @@ namespace engine::server::mail
 	std::vector<Mail> MysqlMailStore::ListInbox(uint64_t receiverAccountId) const
 	{
 		std::vector<Mail> out;
-		if (!m_pool || !m_pool->IsInitialized()) return out;
+		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return out;
@@ -156,7 +176,8 @@ namespace engine::server::mail
 		std::snprintf(sql, sizeof(sql),
 			"SELECT mail_id, sender_account_id, receiver_account_id, subject, body, "
 			"copper_gold, copper_cod, sent_ts_ms, expires_ts_ms, state "
-			"FROM mail WHERE receiver_account_id = %llu",
+			"FROM mail WHERE receiver_account_id = %llu "
+			"ORDER BY sent_ts_ms DESC",
 			static_cast<unsigned long long>(receiverAccountId));
 		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
 		if (!res) return out;
@@ -171,7 +192,7 @@ namespace engine::server::mail
 
 	bool MysqlMailStore::Update(const Mail& mail)
 	{
-		if (!m_pool || !m_pool->IsInitialized()) return false;
+		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return false;
@@ -188,7 +209,11 @@ namespace engine::server::mail
 			static_cast<unsigned>(mail.state),
 			static_cast<unsigned long long>(mail.expiresTsMs),
 			static_cast<unsigned long long>(mail.mailId));
-		if (!engine::server::db::DbExecute(mysql, sql)) return false;
+		if (!engine::server::db::DbExecute(mysql, sql))
+		{
+			LOG_WARN(Net, "[MysqlMailStore] Update mail row failed mailId={}", mail.mailId);
+			return false;
+		}
 
 		// Items : delete + reinsert (simple). Une optimisation possible
 		// est diff, mais le caller appelle Update apres TakeItems donc
@@ -206,7 +231,12 @@ namespace engine::server::mail
 				"VALUES (%llu, %zu, %u, %u)",
 				static_cast<unsigned long long>(mail.mailId),
 				i, it.itemTemplateId, it.count);
-			if (!engine::server::db::DbExecute(mysql, sql)) return false;
+			if (!engine::server::db::DbExecute(mysql, sql))
+			{
+				LOG_WARN(Net, "[MysqlMailStore] Update mail_item slot={} failed mailId={}",
+					i, mail.mailId);
+				return false;
+			}
 		}
 		tx.Commit();
 		return true;
@@ -214,7 +244,7 @@ namespace engine::server::mail
 
 	bool MysqlMailStore::Delete(uint64_t mailId)
 	{
-		if (!m_pool || !m_pool->IsInitialized()) return false;
+		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return false;
@@ -230,14 +260,17 @@ namespace engine::server::mail
 			"DELETE FROM mail WHERE mail_id = %llu",
 			static_cast<unsigned long long>(mailId));
 		const bool ok = engine::server::db::DbExecute(mysql, sql);
-		if (ok) tx.Commit();
+		if (!ok)
+			LOG_WARN(Net, "[MysqlMailStore] Delete mail failed mailId={}", mailId);
+		else
+			tx.Commit();
 		return ok;
 	}
 
 	std::vector<uint64_t> MysqlMailStore::FindExpired(uint64_t nowMs) const
 	{
 		std::vector<uint64_t> out;
-		if (!m_pool || !m_pool->IsInitialized()) return out;
+		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
 		if (!mysql) return out;

--- a/src/masterd/mail/MysqlMailStore.h
+++ b/src/masterd/mail/MysqlMailStore.h
@@ -15,6 +15,11 @@ namespace engine::server::mail
 		explicit MysqlMailStore(engine::server::db::ConnectionPool* pool)
 			: m_pool(pool) {}
 
+		/// Retourne true si le store est en mode DB (pool initialise).
+		/// Le caller s'en sert pour decider d'instancier le MailManager
+		/// avec ce store ou avec un InMemoryMailStore (mode no-DB / tests).
+		bool IsAvailable() const noexcept;
+
 		uint64_t Insert(Mail& out) override;
 		std::optional<Mail> Find(uint64_t mailId) const override;
 		std::vector<Mail> ListInbox(uint64_t receiverAccountId) const override;

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -35,6 +35,7 @@
 #include "src/masterd/handlers/character/CharacterEnterWorldHandler.h"
 #include "src/masterd/handlers/chat/ChatRelayHandler.h"
 #include "src/masterd/handlers/mail/MailHandler.h"
+#include "src/masterd/mail/InMemoryMailStore.h"
 #include "src/masterd/mail/MailManager.h"
 #include "src/masterd/mail/MysqlMailStore.h"
 #include "src/masterd/handlers/quest/QuestHandler.h"
@@ -377,27 +378,32 @@ int main(int argc, char** argv)
 	}
 
 	// CMANGOS.18 (Phase 3.18 step 3) — Mail wire server.
-	// Le store DB est instancié seulement si dbPool est dispo (sinon le master
-	// tourne en mode "no-DB" — accountStoreMem — et on ne peut pas persister
-	// de mails). Dans ce mode dégradé, on laisse m_mgr=nullptr côté handler →
-	// HandlePacket logge un warning et drop. C'est cohérent avec le fait qu'en
-	// mode no-DB, l'auth n'est pas non plus persistée et la mailbox n'a pas
-	// de raison d'être réellement utilisable.
-	engine::server::mail::MysqlMailStore mailStore(&dbPool);
-	engine::server::mail::MailManager mailManager(&mailStore);
-	engine::server::MailHandler mailHandler;
-	if (dbPool.IsInitialized())
+	// Wave 10 : on instancie les deux stores (Mysql + InMemory) et on
+	// branche le MailManager sur celui qui est disponible. En production
+	// (DB pool initialise) c'est MysqlMailStore et les mails persistent ;
+	// en mode no-DB (dev local, tests integration sans MySQL) on retombe
+	// sur InMemoryMailStore — la mailbox reste fonctionnelle pour la
+	// session courante mais ne survit pas a un reboot.
+	engine::server::mail::MysqlMailStore mailStoreDb(&dbPool);
+	engine::server::mail::InMemoryMailStore mailStoreMem;
+	engine::server::mail::IMailStore* mailStoreActive = nullptr;
+	if (mailStoreDb.IsAvailable())
 	{
-		mailHandler.SetMailManager(&mailManager);
-		mailHandler.SetServer(&server);
-		mailHandler.SetSessionManager(&sessionManager);
-		mailHandler.SetConnectionSessionMap(&connSessionMap);
-		LOG_INFO(Net, "[ServerMain] MailHandler configured (CMANGOS.18 step 3)");
+		mailStoreActive = &mailStoreDb;
+		LOG_INFO(Net, "[ServerMain] MailStore : MySQL-backed (Wave 10)");
 	}
 	else
 	{
-		LOG_WARN(Net, "[ServerMain] MailHandler skipped (DB pool unavailable)");
+		mailStoreActive = &mailStoreMem;
+		LOG_WARN(Net, "[ServerMain] MailStore : in-memory fallback (DB unavailable, mails will not persist)");
 	}
+	engine::server::mail::MailManager mailManager(mailStoreActive);
+	engine::server::MailHandler mailHandler;
+	mailHandler.SetMailManager(&mailManager);
+	mailHandler.SetServer(&server);
+	mailHandler.SetSessionManager(&sessionManager);
+	mailHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] MailHandler configured (CMANGOS.18 step 3)");
 
 	// CMANGOS.23 (Phase 5.23 step 3+4) — Quest wire server.
 	// Le tracker in-memory est l'autorite runtime des etats Quest. Le store


### PR DESCRIPTION
## Summary

Polish pass sur le MysqlMailStore deja en place (PR #508). Aligne sur le pattern Wave 5 (MysqlGuildStore) :

- Ajoute `IsAvailable() const noexcept` (alignement Wave 5p2).
- LOG_ERROR(Core,...) -> LOG_WARN(Net,...) sur les erreurs DB transitoires.
- ORDER BY sent_ts_ms DESC sur ListInbox (canonical newest-first).
- main_linux : fallback InMemoryMailStore au lieu de skip MailHandler quand le pool DB n'est pas dispo. La mailbox reste utilisable en dev/no-DB ; les mails ne survivent simplement pas a un redemarrage.

## Test plan

- [ ] Build Linux CI green.
- [ ] Boot masterd avec DB -> log MailStore : MySQL-backed (Wave 10).
- [ ] Boot masterd sans DB -> log MailStore : in-memory fallback + MailHandler toujours wire.
- [ ] Send/Take/Delete via opcodes 49/51/53/55/57 OK dans les deux modes.

**Deploiement** : redeploiement serveur master requis -- le wiring du MailHandler change (plus de skip en mode no-DB).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>