### PR TITLE
feat(masterd): Wave 11 -- CinematicStore (persist seen cinematics)

### DIFF
--- a/sql/migrations/0058_cinematic_seen.sql
+++ b/sql/migrations/0058_cinematic_seen.sql
@@ -1,0 +1,11 @@
+-- 0058 - Wave 11 Persistence Cinematics : table cinematic_seen pour tracker
+-- les cutscenes deja vues par un account (evite de rejouer l'intro a chaque
+-- login). Cle composite (account_id, sequence_id).
+
+CREATE TABLE IF NOT EXISTS cinematic_seen (
+    account_id         BIGINT UNSIGNED NOT NULL,
+    sequence_id        INT UNSIGNED    NOT NULL,
+    first_seen_ts_ms   BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (account_id, sequence_id),
+    KEY idx_account (account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/guild/MysqlGuildStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/battleground/MysqlBattleGroundStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/loot/MysqlLootStore.cpp
+    # Wave 11 Persistence : Cinematic seen store (table cinematic_seen, 0058).
+    ${CMAKE_SOURCE_DIR}/src/masterd/cinematics/InMemoryCinematicStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/cinematics/MysqlCinematicStore.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ChatPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetHandler.cpp

--- a/src/masterd/cinematics/CinematicStore.h
+++ b/src/masterd/cinematics/CinematicStore.h
@@ -1,0 +1,45 @@
+#pragma once
+// Wave 11 Persistence Cinematics — ICinematicStore : interface abstraite pour
+// persister les cinematiques deja vues par un account. Deux impls :
+//   - InMemoryCinematicStore : map en RAM, utilise quand le pool MySQL n'est
+//     pas dispo (mode dev / no-DB). L'etat est perdu au reboot du master.
+//   - MysqlCinematicStore    : backed par la table cinematic_seen (migration
+//     0058). Idempotence via INSERT IGNORE.
+//
+// L'API est minimale : marquer une sequence vue, lire si vue, lister les
+// sequences vues par un account (pour de futurs hooks Quest / Loot qui
+// voudraient gater les replays cote serveur).
+//
+// Aucune impl ne leve d'exception : tout retour booleen indique succes / no-op
+// (MarkSeen sur une ligne deja presente retourne true silencieusement).
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::server::cinematics
+{
+	/// Interface store cinematic_seen. Pattern Wave 5 (cf. MysqlGuildStore,
+	/// MysqlMailStore) : la classe concrete decide si elle persiste vraiment
+	/// (MySQL) ou seulement en RAM. Pas d'exception, best-effort.
+	class ICinematicStore
+	{
+	public:
+		virtual ~ICinematicStore() = default;
+
+		/// Marque la sequence comme vue par l'account. Idempotent (INSERT
+		/// IGNORE / no-op si deja vue). Retourne true si la persistance n'a
+		/// pas echoue (l'idempotence est consideree comme succes).
+		///
+		/// \param accountId  account propriétaire de la "vue".
+		/// \param sequenceId id de la cinematic (cf. seq<id>.json client).
+		/// \param nowMs      timestamp first-seen en ms wall-clock (utilise
+		///                   uniquement si l'insertion cree une nouvelle ligne).
+		virtual bool MarkSeen(uint64_t accountId, uint32_t sequenceId, uint64_t nowMs) = 0;
+
+		/// True si l'account a deja vu la sequence.
+		virtual bool HasSeen(uint64_t accountId, uint32_t sequenceId) const = 0;
+
+		/// Liste des sequences vues par un account. Tri non garanti.
+		virtual std::vector<uint32_t> ListSeen(uint64_t accountId) const = 0;
+	};
+}

--- a/src/masterd/cinematics/InMemoryCinematicStore.cpp
+++ b/src/masterd/cinematics/InMemoryCinematicStore.cpp
@@ -1,0 +1,37 @@
+// Wave 11 Persistence Cinematics — Implementation InMemoryCinematicStore.
+
+#include "src/masterd/cinematics/InMemoryCinematicStore.h"
+
+namespace engine::server::cinematics
+{
+	bool InMemoryCinematicStore::MarkSeen(uint64_t accountId, uint32_t sequenceId, uint64_t nowMs)
+	{
+		// nowMs n'est pas conserve en RAM : on n'expose pas de "first_seen_ts_ms"
+		// dans cette impl ; le MysqlCinematicStore en fait usage. On accepte le
+		// parametre par symetrie d'interface.
+		(void)nowMs;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_seen[accountId].insert(sequenceId);
+		return true;
+	}
+
+	bool InMemoryCinematicStore::HasSeen(uint64_t accountId, uint32_t sequenceId) const
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_seen.find(accountId);
+		if (it == m_seen.end()) return false;
+		return it->second.count(sequenceId) > 0;
+	}
+
+	std::vector<uint32_t> InMemoryCinematicStore::ListSeen(uint64_t accountId) const
+	{
+		std::vector<uint32_t> out;
+		std::lock_guard<std::mutex> lk(m_mutex);
+		auto it = m_seen.find(accountId);
+		if (it == m_seen.end()) return out;
+		out.reserve(it->second.size());
+		for (uint32_t seq : it->second)
+			out.push_back(seq);
+		return out;
+	}
+}

--- a/src/masterd/cinematics/InMemoryCinematicStore.h
+++ b/src/masterd/cinematics/InMemoryCinematicStore.h
@@ -1,0 +1,30 @@
+#pragma once
+// Wave 11 Persistence Cinematics — InMemoryCinematicStore : impl RAM
+// d'ICinematicStore pour dev / tests / fallback no-DB. L'etat est perdu au
+// reboot du master ; le client reverra l'intro a chaque relance dans ce mode.
+
+#include "src/masterd/cinematics/CinematicStore.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace engine::server::cinematics
+{
+	/// Map accountId -> set<sequenceId>. N reste petit en V1 (qq accounts,
+	/// qq dizaines de cinematics) donc on garde la struct lisible plutot que
+	/// d'optimiser via un pack 64 bits (accountId<<32)|sequenceId.
+	/// Thread-safe via un mutex unique : volumes V1 negligeables, on
+	/// privilegie la simplicite.
+	class InMemoryCinematicStore final : public ICinematicStore
+	{
+	public:
+		bool MarkSeen(uint64_t accountId, uint32_t sequenceId, uint64_t nowMs) override;
+		bool HasSeen(uint64_t accountId, uint32_t sequenceId) const override;
+		std::vector<uint32_t> ListSeen(uint64_t accountId) const override;
+
+	private:
+		mutable std::mutex                                          m_mutex;
+		std::unordered_map<uint64_t, std::unordered_set<uint32_t>>  m_seen;
+	};
+}

--- a/src/masterd/cinematics/MysqlCinematicStore.cpp
+++ b/src/masterd/cinematics/MysqlCinematicStore.cpp
@@ -1,0 +1,107 @@
+// Wave 11 Persistence Cinematics — Implementation MysqlCinematicStore.
+
+#include "src/masterd/cinematics/MysqlCinematicStore.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/DbHelpers.h"
+
+#include <mysql.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::server::cinematics
+{
+	namespace
+	{
+		// Pas de chaine a echapper pour cette table (cles numeriques uniquement),
+		// donc on omet EscapeMysql ici. Pattern Wave 5 garde la helper en
+		// anonymous namespace quand elle est utile ; on respecte la convention
+		// par absence quand on n'en a pas besoin.
+	}
+
+	bool MysqlCinematicStore::IsAvailable() const noexcept
+	{
+		return m_pool && m_pool->IsInitialized();
+	}
+
+	bool MysqlCinematicStore::MarkSeen(uint64_t accountId, uint32_t sequenceId, uint64_t nowMs)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		// INSERT IGNORE : idempotent vis-a-vis de la PK (account_id, sequence_id).
+		// Si la ligne existe deja, on garde le first_seen_ts_ms d'origine.
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"INSERT IGNORE INTO cinematic_seen (account_id, sequence_id, first_seen_ts_ms) "
+			"VALUES (%llu, %u, %llu)",
+			static_cast<unsigned long long>(accountId),
+			sequenceId,
+			static_cast<unsigned long long>(nowMs));
+
+		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		if (!ok)
+		{
+			LOG_WARN(Net, "[MysqlCinematicStore] MarkSeen failed account={} sequenceId={}",
+				accountId, sequenceId);
+		}
+		return ok;
+	}
+
+	bool MysqlCinematicStore::HasSeen(uint64_t accountId, uint32_t sequenceId) const
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return false;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT 1 FROM cinematic_seen WHERE account_id = %llu AND sequence_id = %u LIMIT 1",
+			static_cast<unsigned long long>(accountId),
+			sequenceId);
+
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlCinematicStore] HasSeen query failed account={} sequenceId={}",
+				accountId, sequenceId);
+			return false;
+		}
+		const bool found = (mysql_fetch_row(res) != nullptr);
+		engine::server::db::DbFreeResult(res);
+		return found;
+	}
+
+	std::vector<uint32_t> MysqlCinematicStore::ListSeen(uint64_t accountId) const
+	{
+		std::vector<uint32_t> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		if (!mysql) return out;
+
+		char sql[256];
+		std::snprintf(sql, sizeof(sql),
+			"SELECT sequence_id FROM cinematic_seen WHERE account_id = %llu",
+			static_cast<unsigned long long>(accountId));
+
+		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
+		if (!res)
+		{
+			LOG_WARN(Net, "[MysqlCinematicStore] ListSeen query failed account={}", accountId);
+			return out;
+		}
+		while (MYSQL_ROW row = mysql_fetch_row(res))
+		{
+			if (row[0])
+				out.push_back(static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10)));
+		}
+		engine::server::db::DbFreeResult(res);
+		return out;
+	}
+}

--- a/src/masterd/cinematics/MysqlCinematicStore.h
+++ b/src/masterd/cinematics/MysqlCinematicStore.h
@@ -1,0 +1,30 @@
+#pragma once
+// Wave 11 Persistence Cinematics — MysqlCinematicStore : impl MySQL
+// d'ICinematicStore (table cinematic_seen, migration 0058). Cible UNIX
+// (master Linux). Best-effort : tout echec query logge un warning mais ne
+// leve pas d'exception. MarkSeen est idempotent via INSERT IGNORE.
+
+#include "src/masterd/cinematics/CinematicStore.h"
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server::cinematics
+{
+	class MysqlCinematicStore final : public ICinematicStore
+	{
+	public:
+		explicit MysqlCinematicStore(engine::server::db::ConnectionPool* pool)
+			: m_pool(pool) {}
+
+		/// True si le pool est initialise (mode DB actif). Aligne sur le
+		/// pattern Wave 5 (MysqlGuildStore::IsAvailable).
+		bool IsAvailable() const noexcept;
+
+		bool MarkSeen(uint64_t accountId, uint32_t sequenceId, uint64_t nowMs) override;
+		bool HasSeen(uint64_t accountId, uint32_t sequenceId) const override;
+		std::vector<uint32_t> ListSeen(uint64_t accountId) const override;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/handlers/cinematics/CinematicHandler.cpp
+++ b/src/masterd/handlers/cinematics/CinematicHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
 
+#include "src/masterd/cinematics/CinematicStore.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -9,6 +10,7 @@
 #include "src/shared/network/NetServer.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 
+#include <chrono>
 #include <vector>
 
 namespace engine::server
@@ -97,9 +99,29 @@ namespace engine::server
 		LOG_INFO(Net, "[CinematicHandler] Ack account={} sequenceId={} completionState={}",
 			accountId, parsed->sequenceId, static_cast<unsigned>(parsed->completionState));
 
+		// Wave 11 : persistance "seen" via le store branche (si dispo).
+		// Le timestamp first-seen est un wall-clock ms (system_clock) :
+		// on s'aligne sur le format ms unix UTC utilise par les autres
+		// migrations (mail.sent_ts_ms, guilds.created_at_unix_ms).
+		if (m_store)
+		{
+			const uint64_t nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			m_store->MarkSeen(accountId, parsed->sequenceId, nowMs);
+		}
+
 		auto pkt = BuildCinematicAckResponsePacket(0u, requestId, sessionIdHeader);
 		if (!pkt.empty())
 			m_server->Send(connId, pkt);
+	}
+
+	// -------------------------------------------------------------------------
+
+	bool CinematicHandler::HasSeen(uint64_t accountId, uint32_t sequenceId) const
+	{
+		if (!m_store) return false;
+		return m_store->HasSeen(accountId, sequenceId);
 	}
 
 	void CinematicHandler::HandleSkipRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader,

--- a/src/masterd/handlers/cinematics/CinematicHandler.h
+++ b/src/masterd/handlers/cinematics/CinematicHandler.h
@@ -31,6 +31,8 @@ namespace engine::server
 	class ConnectionSessionMap;
 }
 
+namespace engine::server::cinematics { class ICinematicStore; }
+
 namespace engine::server
 {
 	/// Dispatcher Cinematics. Doit etre configure via Set*() avant tout
@@ -44,6 +46,19 @@ namespace engine::server
 		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
 		/// Branche la map connId -> sessionId.
 		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+		/// Branche le store cinematic_seen (Wave 11). Si null, le handler
+		/// ne persiste pas le "seen" mais reste fonctionnel (V1 fallback).
+		/// Le store doit survivre au handler.
+		void SetCinematicStore(engine::server::cinematics::ICinematicStore* s) { m_store = s; }
+
+		/// True si l'account a deja vu la sequence selon le store branche.
+		/// Retourne false si le store est null (mode no-store = jamais vue).
+		/// Pratique pour les callers PushCinematic qui veulent gater les
+		/// replays (ex: skip intro a la 2e session).
+		///
+		/// \param accountId  account interroge.
+		/// \param sequenceId id de la cinematic.
+		bool HasSeen(uint64_t accountId, uint32_t sequenceId) const;
 
 		/// Point d'entree appele par NetServer pour les opcodes Cinematics
 		/// entrants (109 Ack, 111 Skip). Si l'opcode n'est pas un opcode
@@ -101,5 +116,6 @@ namespace engine::server
 		NetServer*            m_server     = nullptr;
 		SessionManager*       m_sessionMgr = nullptr;
 		ConnectionSessionMap* m_connMap    = nullptr;
+		engine::server::cinematics::ICinematicStore* m_store = nullptr;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -54,6 +54,8 @@
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
 #include "src/masterd/handlers/cinematics/CinematicHandler.h"
+#include "src/masterd/cinematics/InMemoryCinematicStore.h"
+#include "src/masterd/cinematics/MysqlCinematicStore.h"
 #include "src/masterd/handlers/skills/SkillHandler.h"
 #include "src/masterd/quests/MysqlQuestStateStore.h"
 #include "src/masterd/reputation/MysqlReputationStore.h"
@@ -530,6 +532,25 @@ int main(int argc, char** argv)
 	cinematicHandler.SetSessionManager(&sessionManager);
 	cinematicHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] CinematicHandler configured (CMANGOS.30 step 3+4, push-only)");
+
+	// Wave 11 — CinematicStore : DB-backed si pool dispo, fallback in-memory sinon.
+	// Permet de tracker quelles cutscenes un account a deja vues (futur :
+	// skip intro a la 2e session). Le store survit au handler car les deux
+	// objets sont locaux a main et detruits dans le meme scope.
+	engine::server::cinematics::MysqlCinematicStore cinematicStoreDb(&dbPool);
+	engine::server::cinematics::InMemoryCinematicStore cinematicStoreInMem;
+	engine::server::cinematics::ICinematicStore* cinematicStore = nullptr;
+	if (cinematicStoreDb.IsAvailable())
+	{
+		cinematicStore = &cinematicStoreDb;
+		LOG_INFO(Net, "[CinematicStore] MySQL-backed (Wave 11)");
+	}
+	else
+	{
+		cinematicStore = &cinematicStoreInMem;
+		LOG_WARN(Net, "[CinematicStore] in-memory fallback - cinematic 'seen' state will not persist this session");
+	}
+	cinematicHandler.SetCinematicStore(cinematicStore);
 
 	// CMANGOS.39 (Phase 4.39 step 3+4) — Skills wire server.
 	// Le master tient en memoire la skill book par account (V1, starter set


### PR DESCRIPTION
## Summary

- Migration 0058 ajoute la table `cinematic_seen` (PK composite account_id+sequence_id + first_seen_ts_ms pour audit).
- Introduit `ICinematicStore` avec deux impls : `InMemoryCinematicStore` (RAM fallback, mutex-protected) et `MysqlCinematicStore` (pattern Wave 5 : `IsAvailable`, `INSERT IGNORE`, pas d'exceptions, `LOG_WARN` sur erreurs DB).
- Wire le store dans `CinematicHandler` via `SetCinematicStore` ; `HandleAckRequest` appelle `MarkSeen(accountId, sequenceId, nowMs)` apres un parse reussi. Expose `HasSeen()` public pour futur gating (gating non implemente ici -- hors scope).
- `main_linux.cpp` choisit MySQL ou in-memory selon `dbPool` availability, log le choix au boot.

Debloque les futures PRs (ex: skip intro au 2e login) sans changement wire format. Opcodes 108/109/110/111/112 inchanges.

## Test plan

- [ ] Build Linux green avec `-Wall -Wextra -Wpedantic`.
- [ ] Boot master avec DB -> log `[CinematicStore] MySQL-backed (Wave 11)`.
- [ ] Boot master sans DB -> log `[CinematicStore] in-memory fallback`.
- [ ] Client ack cinematic -> row visible dans `SELECT * FROM cinematic_seen`.
- [ ] Re-ack meme sequence -> pas de duplicate (INSERT IGNORE idempotent), first_seen_ts_ms inchange.

**Deploiement** : redeploiement serveur (master) requis -- nouvelle migration 0058 + nouveau code de persistance. Pas de changement client.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>