### PR TITLE
feat(shared/network): Wave 12 -- PacketLog ring buffer (debug RX/TX trace)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ErrorPacket.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuthRegisterPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/CharacterPayloads.cpp
@@ -604,6 +605,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
   )
   target_include_directories(shard_ticket_tests PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(shard_ticket_tests PRIVATE engine_core OpenSSL::SSL)
@@ -618,11 +620,27 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
   )
   target_include_directories(server_list_policy_tests PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(server_list_policy_tests PRIVATE engine_core)
   target_compile_options(server_list_policy_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME server_list_policy_tests COMMAND server_list_policy_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Wave 12: PacketLog ring buffer (debug RX/TX trace, opt-in) — pure unit tests.
+  # Aucun lien sur engine_core ni OpenSSL : PacketLog est autonome (std + threads).
+  # NB : ce module vit dans engine::server::netdebug (src/shared/network/),
+  # distinct de l'ancien engine::server::packetlog (src/shared/packetlog/,
+  # header-only, test cible `packet_log_tests`). Cible CTest dediee :
+  # `packet_log_netdebug_tests`.
+  add_executable(packet_log_netdebug_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLogTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
+  )
+  target_include_directories(packet_log_netdebug_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(packet_log_netdebug_tests PRIVATE pthread)
+  target_compile_options(packet_log_netdebug_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME packet_log_netdebug_tests COMMAND packet_log_netdebug_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M22.6: Shard server (ticket handshake + enregistrement TLS/TCP vers le Master via ShardToMasterClient)
   # Wave 6: + EventAIRuntime + PoolManagerRuntime (tickes + seedes au boot).
@@ -641,6 +659,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAI.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAIRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolManagerRuntime.cpp

--- a/src/shared/network/PacketLog.cpp
+++ b/src/shared/network/PacketLog.cpp
@@ -1,0 +1,188 @@
+// Wave 12 — PacketLog : implementation du ring buffer de paquets recents.
+// Voir PacketLog.h pour la conception. Aucun appel a un service externe :
+// le caller fournit le timestamp courant pour decoupler des syscalls.
+
+#include "src/shared/network/PacketLog.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <sstream>
+
+namespace engine::server::netdebug
+{
+	namespace
+	{
+		/// Formatte un timestamp Unix (millisecondes UTC) en
+		/// "YYYY-MM-DD HH:MM:SS.mmm". gmtime_s sous MSVC, gmtime_r ailleurs.
+		/// Effet de bord : aucun (pure conversion).
+		std::string FormatTimestampUtc(uint64_t timestampUnixMs)
+		{
+			const time_t secs = static_cast<time_t>(timestampUnixMs / 1000ULL);
+			const unsigned int millis =
+				static_cast<unsigned int>(timestampUnixMs % 1000ULL);
+
+			std::tm tmUtc{};
+#if defined(_WIN32)
+			gmtime_s(&tmUtc, &secs);
+#else
+			gmtime_r(&secs, &tmUtc);
+#endif
+
+			char buf[32] = {0};
+			// "YYYY-MM-DD HH:MM:SS" tient sur 19 octets + NUL.
+			std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tmUtc);
+
+			char out[40] = {0};
+			std::snprintf(out, sizeof(out), "%s.%03u", buf, millis);
+			return std::string(out);
+		}
+
+		/// Formatte les premiers \p len octets de \p preview en hex
+		/// majuscule, separes par des espaces (ex: "AA BB CC"). Borne par
+		/// kPreviewBytes pour ne pas deborder.
+		std::string FormatPreviewHex(const std::array<uint8_t, kPreviewBytes>& preview,
+		                             size_t len)
+		{
+			const size_t n = std::min(len, kPreviewBytes);
+			if (n == 0)
+				return std::string();
+
+			std::string out;
+			out.reserve(n * 3);
+			char tmp[4];
+			for (size_t i = 0; i < n; ++i)
+			{
+				std::snprintf(tmp, sizeof(tmp), "%02X", preview[i]);
+				if (i > 0)
+					out.push_back(' ');
+				out.append(tmp);
+			}
+			return out;
+		}
+
+		/// Convertit l'enum PacketDirection en libelle court "RX"/"TX".
+		const char* DirectionLabel(PacketDirection dir) noexcept
+		{
+			return (dir == PacketDirection::TX) ? "TX" : "RX";
+		}
+	}
+
+	PacketLog::PacketLog(size_t capacity)
+		: m_capacity(capacity)
+	{
+		// Pre-allocation : on dimensionne le vector a la capacite max
+		// pour que Append soit O(1) sans realloc. Si capacity == 0, le
+		// log est inerte (Append/Drain no-op).
+		if (m_capacity > 0)
+			m_ring.resize(m_capacity);
+	}
+
+	void PacketLog::Append(PacketDirection dir,
+	                       uint32_t connId,
+	                       uint16_t opcode,
+	                       uint32_t requestId,
+	                       uint64_t sessionId,
+	                       const uint8_t* payload,
+	                       size_t payloadSize,
+	                       uint64_t nowUnixMs)
+	{
+		if (m_capacity == 0)
+			return; // Log inerte.
+
+		PacketLogEntry entry;
+		entry.timestampUnixMs = nowUnixMs;
+		entry.connId          = connId;
+		entry.opcode          = opcode;
+		entry.requestId       = requestId;
+		entry.sessionId       = sessionId;
+		entry.direction       = dir;
+		entry.payloadSize     = payloadSize;
+
+		// Copie tronquee du payload (zero-fill restant via array{} init).
+		const size_t toCopy = (payload != nullptr)
+			? std::min(payloadSize, kPreviewBytes)
+			: 0;
+		if (toCopy > 0)
+			std::memcpy(entry.payloadPreview.data(), payload, toCopy);
+
+		std::lock_guard<std::mutex> lock(m_mu);
+		m_ring[m_writeIdx] = entry;
+		m_writeIdx = (m_writeIdx + 1) % m_capacity;
+		if (m_writeIdx == 0)
+			m_wrapped = true;
+	}
+
+	std::vector<PacketLogEntry> PacketLog::Drain() const
+	{
+		std::lock_guard<std::mutex> lock(m_mu);
+		if (m_capacity == 0)
+			return {};
+
+		std::vector<PacketLogEntry> out;
+		if (!m_wrapped)
+		{
+			// Pas encore wrappe : ordre chronologique = [0..m_writeIdx).
+			out.reserve(m_writeIdx);
+			for (size_t i = 0; i < m_writeIdx; ++i)
+				out.push_back(m_ring[i]);
+		}
+		else
+		{
+			// Wrappe : plus vieux en [m_writeIdx..capacity), puis [0..m_writeIdx).
+			out.reserve(m_capacity);
+			for (size_t i = m_writeIdx; i < m_capacity; ++i)
+				out.push_back(m_ring[i]);
+			for (size_t i = 0; i < m_writeIdx; ++i)
+				out.push_back(m_ring[i]);
+		}
+		return out;
+	}
+
+	std::vector<PacketLogEntry> PacketLog::DrainForConn(uint32_t connId) const
+	{
+		auto all = Drain();
+		std::vector<PacketLogEntry> filtered;
+		filtered.reserve(all.size());
+		for (const auto& e : all)
+		{
+			if (e.connId == connId)
+				filtered.push_back(e);
+		}
+		return filtered;
+	}
+
+	size_t PacketLog::Size() const
+	{
+		std::lock_guard<std::mutex> lock(m_mu);
+		if (m_capacity == 0)
+			return 0;
+		return m_wrapped ? m_capacity : m_writeIdx;
+	}
+
+	std::string FormatEntries(const std::vector<PacketLogEntry>& entries)
+	{
+		if (entries.empty())
+			return std::string();
+
+		std::ostringstream oss;
+		for (const auto& e : entries)
+		{
+			oss << '[' << FormatTimestampUtc(e.timestampUnixMs) << "] "
+			    << DirectionLabel(e.direction) << ' '
+			    << "connId=" << e.connId << ' '
+			    << "opcode=" << e.opcode << ' '
+			    << "reqId="  << e.requestId << ' '
+			    << "sessId=" << e.sessionId << ' '
+			    << "size="   << e.payloadSize;
+
+			const std::string hex = FormatPreviewHex(e.payloadPreview, e.payloadSize);
+			if (!hex.empty())
+				oss << " preview=" << hex;
+			oss << '\n';
+		}
+		return oss.str();
+	}
+}

--- a/src/shared/network/PacketLog.h
+++ b/src/shared/network/PacketLog.h
@@ -1,0 +1,140 @@
+// Wave 12 — PacketLog : ring buffer thread-safe de paquets recents (RX/TX)
+// pour analyse post-mortem cote serveur. Capture un snapshot leger (header
+// + premiers octets du payload) pour pouvoir dumper le contexte lorsqu'un
+// handler journalise une erreur. Opt-in : pas wire dans NetServer dans cette
+// PR (foundation only). Une PR ulterieure branchera Append() dans les chemins
+// RX/TX et DumpRecent() dans les handlers d'erreur.
+//
+// Conception :
+//   - capacite fixee a la construction (typiquement 256..1024)
+//   - Append : O(1), overwrite quand plein, thread-safe (mutex court)
+//   - Drain  : copie complete du buffer en ordre chronologique
+//   - payload preview tronque a kPreviewBytes (64) pour ne pas exploser la
+//     RAM en cas de stream lourd
+//   - aucune persistance disque, aucun throw explicite
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace engine::server::netdebug
+{
+	/// Direction du paquet : RX (recu du client) ou TX (envoye au client).
+	enum class PacketDirection : uint8_t
+	{
+		RX = 0,
+		TX = 1,
+	};
+
+	/// Nombre d'octets de payload conserves en preview dans chaque entry du
+	/// ring buffer. On NE STOCKE PAS le payload complet pour eviter une
+	/// explosion memoire (cas streams gros). 64 octets suffisent pour les
+	/// debug habituels (header opcode + premiers champs).
+	inline constexpr size_t kPreviewBytes = 64;
+
+	/// Snapshot d'un paquet capture en RAM dans le ring buffer.
+	/// Contient : metadata (timestamp, conn, opcode, sessionId, direction)
+	/// + un preview tronque du payload pour hex-dump.
+	struct PacketLogEntry
+	{
+		/// Timestamp Unix en millisecondes (UTC) au moment du capture.
+		uint64_t        timestampUnixMs = 0;
+		/// Identifiant de la connexion source/destination (slot NetServer).
+		uint32_t        connId          = 0;
+		/// Opcode applicatif (header v1).
+		uint16_t        opcode          = 0;
+		/// requestId du header (corrélation request/response).
+		uint32_t        requestId       = 0;
+		/// sessionId du header (lien session post-AUTH ; 0 si pre-auth).
+		uint64_t        sessionId       = 0;
+		/// Sens du paquet (depuis le point de vue du serveur).
+		PacketDirection direction       = PacketDirection::RX;
+		/// Taille reelle du payload (non tronquee).
+		size_t          payloadSize     = 0;
+		/// Premiers kPreviewBytes octets du payload (hex-dump friendly).
+		/// Les octets non remplis (si payloadSize < kPreviewBytes) sont
+		/// zero-fill.
+		std::array<uint8_t, kPreviewBytes> payloadPreview{};
+	};
+
+	/// Ring buffer thread-safe (un seul mutex couvre Append + Drain) de
+	/// paquets recents. Capacite immuable apres construction. Append est
+	/// toujours O(1) (overwrite quand plein). Drain renvoie une copie
+	/// complete du buffer en ordre chronologique (plus vieux en [0]).
+	///
+	/// Performance : acceptable car PacketLog est opt-in (active uniquement
+	/// en build dev/debug via flag config dans une PR ulterieure).
+	///
+	/// Thread safety : toutes les methodes publiques sont thread-safe.
+	class PacketLog final
+	{
+	public:
+		/// Cree un ring buffer de capacite \p capacity. Si capacity == 0,
+		/// le log est inerte (Append no-op, Drain renvoie {}).
+		explicit PacketLog(size_t capacity);
+
+		/// Capture un paquet dans le ring buffer. Best-effort : ne throw
+		/// jamais (en dehors d'une allocation OS catastrophique du vector
+		/// initial, mais le buffer est dimensionne a la construction).
+		/// Copie au max kPreviewBytes du payload, zero-fill le reste.
+		/// Thread-safe (verrou court).
+		///
+		/// \param dir          Sens du paquet (RX ou TX).
+		/// \param connId       Slot de connexion NetServer.
+		/// \param opcode       Opcode applicatif (header v1).
+		/// \param requestId    requestId du header.
+		/// \param sessionId    sessionId du header (0 si pre-auth).
+		/// \param payload      Pointeur sur le payload (peut etre nullptr
+		///                     si payloadSize == 0).
+		/// \param payloadSize  Taille reelle du payload (octets).
+		/// \param nowUnixMs    Timestamp Unix en ms (UTC). Le caller le
+		///                     fournit pour decoupler des appels systeme.
+		void Append(PacketDirection dir,
+		            uint32_t connId,
+		            uint16_t opcode,
+		            uint32_t requestId,
+		            uint64_t sessionId,
+		            const uint8_t* payload,
+		            size_t payloadSize,
+		            uint64_t nowUnixMs);
+
+		/// Snapshot complet du buffer en ordre chronologique (entry la plus
+		/// ancienne en [0], la plus recente en [size-1]). Renvoie un vector
+		/// vide si jamais Append n'a ete appele. Thread-safe (verrou court,
+		/// copie sous mutex).
+		std::vector<PacketLogEntry> Drain() const;
+
+		/// Identique a Drain mais filtre pour ne garder que les entries
+		/// dont connId == \p connId. Utile pour dumper le contexte d'une
+		/// connexion specifique en cas d'erreur.
+		std::vector<PacketLogEntry> DrainForConn(uint32_t connId) const;
+
+		/// Capacite maximale (immuable apres construction).
+		size_t Capacity() const noexcept { return m_capacity; }
+
+		/// Nombre courant d'entries dans le buffer (<= Capacity()).
+		size_t Size() const;
+
+	private:
+		const size_t                 m_capacity;
+		mutable std::mutex           m_mu;
+		std::vector<PacketLogEntry>  m_ring;
+		size_t                       m_writeIdx = 0;
+		bool                         m_wrapped  = false;
+	};
+
+	/// Formatte une liste d'entries en texte multilignes pour log/dump.
+	/// Chaque entry occupe une ligne au format :
+	///
+	///   [YYYY-MM-DD HH:MM:SS.mmm] DIR connId=X opcode=Y reqId=Z sessId=W
+	///   size=N preview=AA BB CC ...
+	///
+	/// La conversion du timestamp utilise gmtime (UTC). Pas de localisation.
+	/// Si \p entries est vide, retourne une chaine vide.
+	std::string FormatEntries(const std::vector<PacketLogEntry>& entries);
+}

--- a/src/shared/network/PacketLogTests.cpp
+++ b/src/shared/network/PacketLogTests.cpp
@@ -1,0 +1,213 @@
+// Wave 12 — PacketLog tests : couvre Append, Drain, capacity wraparound,
+// DrainForConn et le format de FormatEntries. Pas de framework de test,
+// juste main() avec asserts et return EXIT_FAILURE en cas d'echec.
+// Le binaire est enregistre dans src/CMakeLists.txt comme cible CTest
+// `packet_log_tests`.
+
+#include "src/shared/network/PacketLog.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using engine::server::netdebug::FormatEntries;
+using engine::server::netdebug::kPreviewBytes;
+using engine::server::netdebug::PacketDirection;
+using engine::server::netdebug::PacketLog;
+using engine::server::netdebug::PacketLogEntry;
+
+namespace
+{
+	/// Helper : Append une entry minimaliste (pas de payload) en RX.
+	void AppendSimple(PacketLog& pl, uint32_t connId, uint16_t opcode,
+	                  uint64_t nowMs)
+	{
+		pl.Append(PacketDirection::RX, connId, opcode,
+		          /*requestId=*/0, /*sessionId=*/0,
+		          /*payload=*/nullptr, /*payloadSize=*/0, nowMs);
+	}
+
+	/// Test 1 : Drain sur log vide -> vector vide.
+	void TestEmpty()
+	{
+		PacketLog pl(4);
+		auto v = pl.Drain();
+		assert(v.empty());
+		assert(pl.Size() == 0);
+		assert(pl.Capacity() == 4);
+		std::puts("[OK] TestEmpty");
+	}
+
+	/// Test 2 : Append 3 entries dans capacite 4 -> Drain renvoie 3 en
+	/// ordre chronologique (opcode = 10, 11, 12).
+	void TestBelowCapacity()
+	{
+		PacketLog pl(4);
+		AppendSimple(pl, /*connId=*/1, /*opcode=*/10, /*nowMs=*/1000);
+		AppendSimple(pl, /*connId=*/1, /*opcode=*/11, /*nowMs=*/1001);
+		AppendSimple(pl, /*connId=*/1, /*opcode=*/12, /*nowMs=*/1002);
+
+		auto v = pl.Drain();
+		assert(v.size() == 3);
+		assert(v[0].opcode == 10);
+		assert(v[1].opcode == 11);
+		assert(v[2].opcode == 12);
+		assert(pl.Size() == 3);
+		std::puts("[OK] TestBelowCapacity");
+	}
+
+	/// Test 3 : Append 4 entries (= capacite) -> Drain renvoie 4 en ordre.
+	void TestExactCapacity()
+	{
+		PacketLog pl(4);
+		for (uint16_t i = 0; i < 4; ++i)
+			AppendSimple(pl, /*connId=*/2, /*opcode=*/i, /*nowMs=*/2000 + i);
+
+		auto v = pl.Drain();
+		assert(v.size() == 4);
+		for (size_t i = 0; i < 4; ++i)
+			assert(v[i].opcode == static_cast<uint16_t>(i));
+		assert(pl.Size() == 4);
+		std::puts("[OK] TestExactCapacity");
+	}
+
+	/// Test 4 : Append 6 entries dans capacite 4 -> Drain renvoie les 4
+	/// dernieres (opcodes 2, 3, 4, 5) en ordre chronologique. Verifie le
+	/// comportement de wraparound.
+	void TestWraparound()
+	{
+		PacketLog pl(4);
+		for (uint16_t i = 0; i < 6; ++i)
+			AppendSimple(pl, /*connId=*/3, /*opcode=*/i, /*nowMs=*/3000 + i);
+
+		auto v = pl.Drain();
+		assert(v.size() == 4);
+		assert(v[0].opcode == 2);
+		assert(v[1].opcode == 3);
+		assert(v[2].opcode == 4);
+		assert(v[3].opcode == 5);
+		assert(pl.Size() == 4);
+		std::puts("[OK] TestWraparound");
+	}
+
+	/// Test 5 : Append entries avec connIds mixtes -> DrainForConn filtre
+	/// correctement.
+	void TestDrainForConn()
+	{
+		PacketLog pl(8);
+		// Intercalle connId=10 et connId=20.
+		AppendSimple(pl, 10, /*opcode=*/100, 5000);
+		AppendSimple(pl, 20, /*opcode=*/200, 5001);
+		AppendSimple(pl, 10, /*opcode=*/101, 5002);
+		AppendSimple(pl, 20, /*opcode=*/201, 5003);
+		AppendSimple(pl, 10, /*opcode=*/102, 5004);
+
+		auto all = pl.Drain();
+		assert(all.size() == 5);
+
+		auto conn10 = pl.DrainForConn(10);
+		assert(conn10.size() == 3);
+		assert(conn10[0].opcode == 100);
+		assert(conn10[1].opcode == 101);
+		assert(conn10[2].opcode == 102);
+
+		auto conn20 = pl.DrainForConn(20);
+		assert(conn20.size() == 2);
+		assert(conn20[0].opcode == 200);
+		assert(conn20[1].opcode == 201);
+
+		auto connEmpty = pl.DrainForConn(99);
+		assert(connEmpty.empty());
+
+		std::puts("[OK] TestDrainForConn");
+	}
+
+	/// Test 6 : Append un payload de 100 octets -> entry.payloadSize == 100,
+	/// payloadPreview rempli avec les 64 premiers octets.
+	void TestPayloadPreview()
+	{
+		PacketLog pl(2);
+
+		std::vector<uint8_t> payload(100);
+		for (size_t i = 0; i < payload.size(); ++i)
+			payload[i] = static_cast<uint8_t>(i & 0xFF);
+
+		pl.Append(PacketDirection::TX, /*connId=*/42, /*opcode=*/0xBEEF,
+		          /*requestId=*/7, /*sessionId=*/0xDEADBEEFCAFEull,
+		          payload.data(), payload.size(), /*nowMs=*/6000);
+
+		auto v = pl.Drain();
+		assert(v.size() == 1);
+		assert(v[0].payloadSize == 100);
+		assert(v[0].connId == 42);
+		assert(v[0].opcode == 0xBEEF);
+		assert(v[0].requestId == 7);
+		assert(v[0].sessionId == 0xDEADBEEFCAFEull);
+		assert(v[0].direction == PacketDirection::TX);
+
+		// Les 64 premiers octets doivent correspondre.
+		for (size_t i = 0; i < kPreviewBytes; ++i)
+			assert(v[0].payloadPreview[i] == static_cast<uint8_t>(i & 0xFF));
+
+		std::puts("[OK] TestPayloadPreview");
+	}
+
+	/// Test 7 : FormatEntries renvoie un texte non vide contenant les
+	/// champs attendus (RX/TX, opcode=, connId=).
+	void TestFormatEntriesNonEmpty()
+	{
+		PacketLog pl(4);
+		uint8_t payload[3] = { 0xAA, 0xBB, 0xCC };
+		pl.Append(PacketDirection::RX, /*connId=*/7, /*opcode=*/123,
+		          /*requestId=*/0, /*sessionId=*/0,
+		          payload, sizeof(payload), /*nowMs=*/1700000000000ULL);
+
+		auto entries = pl.Drain();
+		assert(entries.size() == 1);
+		std::string s = FormatEntries(entries);
+		assert(!s.empty());
+
+		// Doit contenir le libelle de direction.
+		assert(s.find("RX") != std::string::npos);
+		// Doit contenir l'opcode formatte.
+		assert(s.find("opcode=123") != std::string::npos);
+		// Doit contenir le connId.
+		assert(s.find("connId=7") != std::string::npos);
+		// Doit contenir un preview hex (au moins les premiers octets).
+		assert(s.find("AA BB CC") != std::string::npos);
+
+		// FormatEntries sur un vector vide -> string vide.
+		std::vector<PacketLogEntry> empty;
+		assert(FormatEntries(empty).empty());
+
+		std::puts("[OK] TestFormatEntriesNonEmpty");
+	}
+
+	/// Test bonus : capacity == 0 -> log inerte, Append no-op, Drain vide.
+	void TestZeroCapacity()
+	{
+		PacketLog pl(0);
+		AppendSimple(pl, 1, 99, 100);
+		assert(pl.Drain().empty());
+		assert(pl.Size() == 0);
+		assert(pl.Capacity() == 0);
+		std::puts("[OK] TestZeroCapacity");
+	}
+}
+
+int main()
+{
+	TestEmpty();
+	TestBelowCapacity();
+	TestExactCapacity();
+	TestWraparound();
+	TestDrainForConn();
+	TestPayloadPreview();
+	TestFormatEntriesNonEmpty();
+	TestZeroCapacity();
+	std::puts("[ALL OK] PacketLogTests");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Foundation PR : ring buffer thread-safe (mutex) de paquets recents (RX/TX) pour analyse post-mortem serveur. Opt-in, aucun handler ni NetServer modifie dans cette PR -- le wire viendra plus tard.

- `engine::server::netdebug::PacketLog(capacity)` : Append O(1) (overwrite quand plein), Drain ordre chronologique, DrainForConn filtre par connexion.
- `PacketLogEntry` : timestamp UTC ms, connId, opcode, requestId, sessionId, direction RX/TX, payloadSize, preview tronque a 64 octets (zero-fill).
- `FormatEntries(entries)` : dump multiligne human-readable au format `[YYYY-MM-DD HH:MM:SS.mmm] DIR connId=X opcode=Y reqId=Z sessId=W size=N preview=AA BB CC ...`.
- Module distinct de l'ancien `engine::server::packetlog` (header-only stub non utilise). CTest dediee `packet_log_netdebug_tests`.

## Test plan

- [x] `packet_log_netdebug_tests` : Empty / BelowCapacity / ExactCapacity / Wraparound / DrainForConn / PayloadPreview (100B truncated to 64B) / FormatEntries non-empty / ZeroCapacity (inert).
- [ ] CI Linux build vert (server_app, shard_app, shard_ticket_tests, server_list_policy_tests, packet_log_netdebug_tests).

## Follow-up (PRs ulterieures)

1. Wire `PacketLog::Append()` dans NetServer RX/TX (avec config flag opt-in).
2. Wire `PacketLog::DumpRecent()` dans les error handlers (e.g. BadOpcode, AuthFail).
3. Cleanup : supprimer le stub `src/shared/packetlog/PacketLog.h` non utilise (dead code).

**Deploiement** : client uniquement, pas de redeploiement serveur -- code serveur ajoute mais non wire (foundation). Le wire dans NetServer + handlers d'erreur ulterieurement necessitera **REDEPLOIEMENT SERVEUR REQUIS** (master + shard).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>