### PR TITLE
fix(masterd/serverlist): players=sessionCharMap.Count() quand single-shard

### DIFF
--- a/src/masterd/handlers/shard/ServerListHandler.cpp
+++ b/src/masterd/handlers/shard/ServerListHandler.cpp
@@ -13,6 +13,7 @@ namespace engine::server
 	void ServerListHandler::SetServer(NetServer* server) { m_server = server; }
 	void ServerListHandler::SetShardRegistry(ShardRegistry* registry) { m_registry = registry; }
 	void ServerListHandler::SetCharacterCountHook(std::function<uint32_t(uint32_t)> hook) { m_characterCountHook = std::move(hook); }
+	void ServerListHandler::SetMasterSessionCountHook(std::function<uint32_t()> hook) { m_masterSessionCountHook = std::move(hook); }
 
 	void ServerListHandler::SetServerRegistry(ServerRegistry* selfRegistry)
 	{
@@ -33,13 +34,31 @@ namespace engine::server
 		std::vector<engine::network::ServerListEntry> entries;
 		{
 			auto list = m_registry->ListShards();
+			// Compteur shards online/degraded : si UN SEUL est actif, on lui assigne
+			// le total master-side (sessionCharMap.Count()) au lieu de s.current_load.
+			// Meme logique que statusProvider dans main_linux.cpp pour /status JSON.
+			// Sans ce fallback, current_load reste a 0 (heartbeat shard ne voit que
+			// les TCP transitoires) -> client affiche 0/500 alors que API montre 1.
+			uint32_t shardsOnline = 0;
+			for (const auto& s : list)
+			{
+				if (s.state == engine::server::ShardState::Online
+					|| s.state == engine::server::ShardState::Degraded)
+					++shardsOnline;
+			}
+			const bool singleShardOnline = (shardsOnline == 1u);
+			const uint32_t masterSessions = m_masterSessionCountHook ? m_masterSessionCountHook() : 0u;
 			entries.reserve(list.size());
 			for (const auto& s : list)
 			{
+				const bool isOnline = (s.state == engine::server::ShardState::Online
+					|| s.state == engine::server::ShardState::Degraded);
 				engine::network::ServerListEntry e;
 				e.shard_id = s.shard_id;
 				e.status = static_cast<uint8_t>(s.state);
-				e.current_load = s.current_load;
+				e.current_load = (singleShardOnline && isOnline)
+					? masterSessions
+					: s.current_load;
 				e.max_capacity = s.max_capacity;
 				e.character_count = m_characterCountHook ? m_characterCountHook(s.shard_id) : 0u;
 				e.endpoint = s.endpoint;

--- a/src/masterd/handlers/shard/ServerListHandler.h
+++ b/src/masterd/handlers/shard/ServerListHandler.h
@@ -25,6 +25,15 @@ namespace engine::server
 		void SetCharacterCountHook(std::function<uint32_t(uint32_t shard_id)> hook);
 		void SetServerRegistry(ServerRegistry* selfRegistry);
 
+		/// Optional: nombre total de sessions actives cote master (sessionCharMap.Count()).
+		/// Quand UN SEUL shard est online (cas dev/single-shard), on utilise cette valeur a
+		/// la place de `current_load` (issu du heartbeat shard). Le shard binaire ne voit que
+		/// les TCP transitoires (handshake ticket → close), donc son current_load reste a 0
+		/// en pratique pendant que des joueurs sont en monde. Sans ce hook, le client affiche
+		/// 0/500 alors que l'API HTTP `/status` (qui applique la meme logique) montre players=1.
+		/// Si non cable, on retombe sur s.current_load pour toutes les entrees.
+		void SetMasterSessionCountHook(std::function<uint32_t()> hook);
+
 		/// Handles SERVER_LIST_REQUEST only. Ignores other opcodes.
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
@@ -34,5 +43,6 @@ namespace engine::server
 		ShardRegistry* m_registry = nullptr;
 		ServerRegistry* m_serverRegistry = nullptr;
 		std::function<uint32_t(uint32_t)> m_characterCountHook;
+		std::function<uint32_t()> m_masterSessionCountHook;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -906,6 +906,12 @@ int main(int argc, char** argv)
 	engine::server::ServerListHandler serverListHandler;
 	serverListHandler.SetServer(&server);
 	serverListHandler.SetShardRegistry(&shardRegistry);
+	// Single-shard online → on assigne le total master-side au shard unique. Sinon le
+	// wire SERVER_LIST renvoie current_load (heartbeat) qui reste a 0 (le shard binaire
+	// ne voit que les TCP transitoires post-handshake) et le client affiche 0/500 alors
+	// que /status JSON montre players=1. Meme logique que statusProvider plus bas.
+	serverListHandler.SetMasterSessionCountHook(
+		[&sessionCharMap]() { return static_cast<uint32_t>(sessionCharMap.Count()); });
 
 	engine::server::ServerRegistry serverRegistry;
 	// Le master ne s'auto-enregistre dans game_servers que si server.self_register=true.


### PR DESCRIPTION
## Bug

- API HTTP `/status` renvoie `players: 1` pour le shard unique.
- Client en panneau Server Select affiche `0 / 500`.

## Cause

`ServerListHandler::HandlePacket` utilisait `s.current_load` directement (issu du heartbeat shard), alors que le shard binaire ne voit que les TCP transitoires (handshake ticket -> close) et reste a 0. Le HTTP statusProvider applique deja la logique "single shard online -> assigne le total master au shard unique" (cf. `main_linux.cpp:1099-1135`), mais cette logique n'etait pas appliquee au wire SERVER_LIST_RESPONSE.

## Fix

- `ServerListHandler.h` : nouveau setter `SetMasterSessionCountHook(std::function<uint32_t()>)` + membre.
- `ServerListHandler.cpp` : compte les shards Online/Degraded, et si **un seul** est actif, assigne `masterSessions` (lambda hook) a son `current_load`. Sinon fallback sur `s.current_load`.
- `main_linux.cpp` : cable le hook avec `[&sessionCharMap]() { return static_cast<uint32_t>(sessionCharMap.Count()); }`.

Resultat : meme valeur visible cote API HTTP et cote client. Generalisation multi-shard (mapping char->shard) reste pour futur.

## Test plan

- [ ] Build Linux CI green.
- [ ] Avant fix : client affiche 0/500 + API montre players=1.
- [ ] Apres fix : client affiche 1/500 (meme valeur que API).
- [ ] Connecter 2 comptes -> les 2 voient 2/500.
- [ ] Verifier qu'avec aucun joueur en monde le client affiche 0/500 (pas de regression).

**Deploiement** : redeploiement serveur master requis (la logique de SERVER_LIST_RESPONSE change). Pas de changement client.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>