### PR TITLE
fix(security): KickedByDuplicateLogin ferme aussi la TCP du client kicke

### DIFF
--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -342,6 +342,30 @@ int main(int argc, char** argv)
 	// Phase 4 chat — mapping connId → (character_id, character_name) pour sender display + whisper target.
 	engine::server::SessionCharacterMap sessionCharMap;
 
+	// Fix duplicate-login : quand SessionManager::Close fire (notamment via la policy
+	// KickExisting), on cascade la fermeture : trouver le connId du client kicke,
+	// fermer sa TCP master + nettoyer ConnectionSessionMap + SessionCharacterMap.
+	// Sans ce hook, le client garde sa connexion master + shard alive et peut jouer
+	// le meme personnage en parallele du nouveau client (cf. bug observe avec deux
+	// IP differentes sur account_id=1).
+	sessionManager.SetOnSessionClosed(
+		[&server, &connSessionMap, &sessionCharMap](uint64_t sessionId, uint64_t accountId,
+			engine::server::SessionCloseReason reason)
+		{
+			(void)accountId;
+			(void)reason;
+			auto oldConn = connSessionMap.FindConnIdForSession(sessionId);
+			if (!oldConn)
+				return;
+			LOG_INFO(Net,
+				"[SessionManager] cascading close : connId={} sessionId={} reason={}",
+				*oldConn, sessionId, engine::server::SessionCloseReasonToString(reason));
+			server.CloseConnection(*oldConn,
+				engine::server::DisconnectReason::KickedByDuplicateLogin);
+			connSessionMap.Remove(*oldConn);
+			sessionCharMap.Remove(*oldConn);
+		});
+
 	engine::server::CharacterEnterWorldHandler characterEnterWorldHandler;
 	characterEnterWorldHandler.SetServer(&server);
 	characterEnterWorldHandler.SetSessionManager(&sessionManager);

--- a/src/masterd/session/ConnectionSessionMap.cpp
+++ b/src/masterd/session/ConnectionSessionMap.cpp
@@ -23,6 +23,17 @@ namespace engine::server
 		return it->second;
 	}
 
+	std::optional<uint32_t> ConnectionSessionMap::FindConnIdForSession(uint64_t sessionId) const
+	{
+		std::lock_guard lock(m_mutex);
+		for (const auto& [conn, sess] : m_connToSession)
+		{
+			if (sess == sessionId)
+				return conn;
+		}
+		return std::nullopt;
+	}
+
 	std::vector<std::pair<uint32_t, uint64_t>> ConnectionSessionMap::Snapshot() const
 	{
 		std::vector<std::pair<uint32_t, uint64_t>> out;

--- a/src/masterd/session/ConnectionSessionMap.h
+++ b/src/masterd/session/ConnectionSessionMap.h
@@ -26,6 +26,12 @@ namespace engine::server
 		/// Returns session_id for \a connId if registered. For M22.4 (shard ticket: connId → account_id).
 		std::optional<uint64_t> GetSessionId(uint32_t connId) const;
 
+		/// Reverse lookup : connId associe a \a sessionId si enregistre. Utilise par le
+		/// hook OnSessionClosed (cf. SessionManager) pour fermer la TCP de la session
+		/// duplicate-login. Walk O(N) sous mutex ; N petit (connexions actives) donc
+		/// pas de besoin de map inverse maintenue en permanence.
+		std::optional<uint32_t> FindConnIdForSession(uint64_t sessionId) const;
+
 		/// Chat MVP — Snapshot des paires (connId, sessionId) actuellement enregistrées.
 		/// Utilisé par les handlers broadcast (chat) qui doivent envoyer un même paquet à
 		/// toutes les sessions actives. Verrouille brièvement le mutex pour copier la map ;

--- a/src/masterd/session/SessionManager.cpp
+++ b/src/masterd/session/SessionManager.cpp
@@ -11,6 +11,11 @@ namespace engine::server
 		constexpr uint64_t kInvalidSessionId = 0;
 	}
 
+	void SessionManager::SetOnSessionClosed(std::function<void(uint64_t, uint64_t, SessionCloseReason)> hook)
+	{
+		m_onSessionClosed = std::move(hook);
+	}
+
 	void SessionManager::SetConfig(const SessionManagerConfig& config)
 	{
 		m_config = config;
@@ -134,6 +139,12 @@ namespace engine::server
 		it->second.state = SessionState::Closed;
 		m_by_account_id.erase(account_id);
 		LOG_INFO(Net, "[SessionManager] Close: session_id={} account_id={} reason={}", session_id, account_id, SessionCloseReasonToString(reason));
+		// Fire le hook APRES log + cleanup interne : le subscriber peut, ex. fermer
+		// la TCP du connId associe et nettoyer SessionCharacterMap. La copie locale
+		// du hook evite un crash si le subscriber le reset au milieu de l'appel.
+		auto hook = m_onSessionClosed;
+		if (hook)
+			hook(session_id, account_id, reason);
 	}
 
 	void SessionManager::SetState(uint64_t session_id, SessionState state)

--- a/src/masterd/session/SessionManager.h
+++ b/src/masterd/session/SessionManager.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -109,12 +110,23 @@ namespace engine::server
 		/// authentifies remontent, y compris les staff / admins.
 		std::vector<uint64_t> ListActiveAccountIds() const;
 
+		/// Callback fire des qu'une session est fermee via Close() (y compris
+		/// la fermeture interne lors de duplicate-login policy KickExisting).
+		/// Le hook recoit (session_id, account_id, reason). Utilise par
+		/// main_linux.cpp pour cascader la fermeture : trouver la TCP du
+		/// connId associe (via ConnectionSessionMap::FindConnIdForSession),
+		/// la fermer, et nettoyer SessionCharacterMap. Sans ce hook le client
+		/// duplicate-login restait connecte au master TCP + au shard, et
+        /// pouvait jouer le meme personnage en parallele du nouveau client.
+		void SetOnSessionClosed(std::function<void(uint64_t sessionId, uint64_t accountId, SessionCloseReason)> hook);
+
 	private:
 		using Clock = std::chrono::steady_clock;
 
 		SessionManagerConfig m_config;
 		std::unordered_map<uint64_t, Session> m_by_session_id;
 		std::unordered_map<uint64_t, uint64_t> m_by_account_id;
+		std::function<void(uint64_t, uint64_t, SessionCloseReason)> m_onSessionClosed;
 
 		bool isValid(const Session& s, Clock::time_point now) const;
 		uint64_t generateSessionId();

--- a/src/shared/network/NetServer.cpp
+++ b/src/shared/network/NetServer.cpp
@@ -202,6 +202,7 @@ namespace engine::server
 		case DisconnectReason::SendError: return "send_error";
 		case DisconnectReason::TxQueueCap: return "tx_queue_cap";
 		case DisconnectReason::HeartbeatTimeout: return "heartbeat_timeout";
+		case DisconnectReason::KickedByDuplicateLogin: return "kicked_by_duplicate_login";
 		default: return "unknown";
 	}
 }

--- a/src/shared/network/NetServer.h
+++ b/src/shared/network/NetServer.h
@@ -32,6 +32,11 @@ namespace engine::server
 		SendError,
 		TxQueueCap,
 		HeartbeatTimeout,
+		/// Connexion fermee a la demande de l'application (ex: SessionManager
+		/// cascade kick suite a un duplicate-login). N'est jamais positionnee
+		/// par le NetServer lui-meme : seulement par les handlers qui
+		/// appellent CloseConnection() depuis le hook OnSessionClosed.
+		KickedByDuplicateLogin,
 		Count
 	};
 


### PR DESCRIPTION
## Bug observe

- `account_id=1` connecte depuis IP1 (10.0.4.62) sur connId=29, en monde sur character_id=1.
- Meme `account_id=1` se reconnecte depuis IP2 (10.0.4.167) sur connId=32.
- `SessionManager.Close` fire `reason=KickedByDuplicateLogin` pour la session IP1.
- **MAIS la TCP master de IP1 (connId=29) reste vivante** + `SessionCharacterMap` entry intact.
- **Les deux clients peuvent jouer le meme personnage simultanement**.

Cf. logs serveur :
```
08:39:22 [CharacterEnterWorldHandler] registered (account_id=1, character_id=1) [IP1 connId=29]
08:39:50 [SessionManager] Close session_id=X reason=KickedByDuplicateLogin  [IP1 kicked]
08:39:55 [CharacterEnterWorldHandler] registered (account_id=1, character_id=1) [IP2 connId=32]
08:40:04 [NetServer] Connection closed (connId=29, peer=10.0.4.62, reason=peer_closed)  [IP1 ferme PAR LUI-MEME, pas par le master]
```

Le master n'avait jamais ferme la TCP de IP1 -- seul le client a fini par se deconnecter naturellement.

## Cause

`SessionManager::Close` marque la session `Closed` dans `m_by_session_id` et purge `m_by_account_id`, mais ne touche pas a la TCP (`NetServer`) ni a `SessionCharacterMap`.

## Fix master-side

- **`ConnectionSessionMap`** : nouveau `FindConnIdForSession(sessionId)` (walk O(N) sous mutex, suffisant pour N petits).
- **`SessionManager`** : nouveau `SetOnSessionClosed` callback fire dans `Close()` (apres log + cleanup interne). Pas de couplage direct avec NetServer.
- **`NetServer::DisconnectReason`** : nouvelle entree `KickedByDuplicateLogin` + string `"kicked_by_duplicate_login"`.
- **`main_linux.cpp`** : cable `sessionManager.SetOnSessionClosed` -> lookup `oldConn` via `connSessionMap`, `server.CloseConnection(oldConn, KickedByDuplicateLogin)`, cleanup `connSessionMap` + `sessionCharMap`.

## Resultat

La TCP master de IP1 est fermee immediatement quand IP2 declenche le kick. SessionCharacterMap est purge.

## Limitation (a fixer en suivi PR)

La TCP **shard** de IP1 reste alive jusqu'a son propre HeartbeatTimeout (~60s). Pour eliminer la fenetre de duplicate-play sur le shard, un suivi cablera `ShardTicketHandshakeHandler` pour evicter toute connexion shard existante d'un meme `account_id` lors d'un nouveau ticket. Le master-side suffit deja pour empecher la majorite des scenarios (le client kicke ne peut plus faire d'action master-routed : chat, mail, slash commands, etc.).

## Test plan

- [ ] Build Linux CI green.
- [ ] Avant fix : 2 clients sur le meme account peuvent jouer le meme personnage.
- [ ] Apres fix : le 1er client est immediatement deconnecte du master (logs `[NETSRV] CloseConnection ... reason=kicked_by_duplicate_login`), son SessionCharacterMap purge.
- [ ] Verifier qu'un seul utilisateur connecte n'est pas affecte (pas de regression).

**Deploiement** : redeploiement serveur master requis. Pas de changement client.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>