### PR TITLE
fix(shardd): evict prior shard TCP on duplicate-account ticket

### DIFF
--- a/src/masterd/handlers/shard/ShardTicketHandshakeHandler.cpp
+++ b/src/masterd/handlers/shard/ShardTicketHandshakeHandler.cpp
@@ -15,6 +15,20 @@ namespace engine::server
 	void ShardTicketHandshakeHandler::OnConnectionClosed(uint32_t connId)
 	{
 		m_handshakeDone.erase(connId);
+		// Nettoie aussi les maps account<->conn pour eviter de laisser un
+		// account orphelin (si reconnexion plus tard, on n'evicterait pas
+		// la "fausse" conn deja fermee). Si l'account avait une autre
+		// connexion entre temps, m_accountToConn[account] != connId donc
+		// on ne purge pas par erreur.
+		auto it = m_connToAccount.find(connId);
+		if (it != m_connToAccount.end())
+		{
+			const uint64_t accountId = it->second;
+			auto acctIt = m_accountToConn.find(accountId);
+			if (acctIt != m_accountToConn.end() && acctIt->second == connId)
+				m_accountToConn.erase(acctIt);
+			m_connToAccount.erase(it);
+		}
 	}
 
 	void ShardTicketHandshakeHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t /*sessionIdHeader*/,
@@ -49,6 +63,27 @@ namespace engine::server
 			m_server->CloseConnection(connId, DisconnectReason::InvalidPacket);
 			return;
 		}
+		// Eviction du duplicate-ticket : si cet account a deja une connexion shard active,
+		// on la ferme avant d'accepter la nouvelle. Suivi du fix #584 cote master.
+		// Sans cette eviction, la fenetre HeartbeatTimeout (~60s) permettait au precedent
+		// client de jouer le meme personnage en parallele du nouveau.
+		{
+			auto prev = m_accountToConn.find(accept->account_id);
+			if (prev != m_accountToConn.end() && prev->second != connId)
+			{
+				const uint32_t oldConnId = prev->second;
+				LOG_INFO(Core,
+					"[ShardTicketHandshakeHandler] evicting prior connection (account_id={} oldConnId={} newConnId={})",
+					accept->account_id, oldConnId, connId);
+				m_server->CloseConnection(oldConnId, DisconnectReason::KickedByDuplicateLogin);
+				// On nettoie nos maps en avance (sans attendre OnConnectionClosed du NetServer
+				// qui peut etre asynchrone) : la nouvelle conn va inserer juste apres.
+				m_handshakeDone.erase(oldConnId);
+				m_connToAccount.erase(oldConnId);
+				m_accountToConn.erase(prev);
+			}
+		}
+
 		auto pkt = BuildShardTicketAcceptedPacket(requestId);
 		if (pkt.empty() || !m_server->Send(connId, pkt))
 		{
@@ -57,6 +92,8 @@ namespace engine::server
 			return;
 		}
 		m_handshakeDone.insert(connId);
+		m_accountToConn[accept->account_id] = connId;
+		m_connToAccount[connId] = accept->account_id;
 		LOG_INFO(Core, "[ShardTicketHandshakeHandler] Ticket accepted (connId={} account_id={} target_shard_id={})", connId, accept->account_id, accept->target_shard_id);
 	}
 }

--- a/src/masterd/handlers/shard/ShardTicketHandshakeHandler.h
+++ b/src/masterd/handlers/shard/ShardTicketHandshakeHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace engine::server
@@ -12,6 +13,13 @@ namespace engine::server
 namespace engine::server
 {
 	/// Shard-side handler: first packet from each connection must be PRESENT_SHARD_TICKET; validates and responds TICKET_ACCEPTED or TICKET_REJECTED (M22.6).
+	///
+	/// Suivi de #584 (master-side kick) : quand un nouveau ticket arrive pour un account_id
+	/// deja en monde sur ce shard, on evicte la connexion precedente (close TCP + cleanup).
+	/// Sans cette eviction, le shard accepte les 2 tickets et garde les 2 TCP alive jusqu'au
+	/// HeartbeatTimeout (~60s), permettant un duplicate-play pendant cette fenetre. Le map
+	/// account_id -> connId est tenue ici (handler du shard) car le shard n'a pas de
+	/// SessionManager equivalent au master.
 	class ShardTicketHandshakeHandler
 	{
 	public:
@@ -31,5 +39,11 @@ namespace engine::server
 		NetServer* m_server = nullptr;
 		ShardTicketValidator* m_validator = nullptr;
 		std::unordered_set<uint32_t> m_handshakeDone;
+		/// account_id -> connId pour eviction sur duplicate-ticket. Le shard
+		/// ne maintient pas de SessionManager : on s'appuie sur cette map locale
+		/// pour ne garder qu'une connexion par account a la fois.
+		std::unordered_map<uint64_t, uint32_t> m_accountToConn;
+		/// connId -> account_id pour reverse lookup au cleanup (OnConnectionClosed).
+		std::unordered_map<uint32_t, uint64_t> m_connToAccount;
 	};
 }


### PR DESCRIPTION
## Suivi de #584

[#584](https://github.com/tips-of-mine/LCDLLN-test/pull/584) (master-side) ferme la TCP master du client kicke mais **la TCP shard restait alive** jusqu'au HeartbeatTimeout (~60s). Pendant cette fenetre, le 1er client pouvait continuer a jouer le meme personnage que le nouveau client connecte depuis une autre IP.

## Fix shard-side

`ShardTicketHandshakeHandler` tient maintenant une map `account_id -> connId`. Quand un nouveau ticket est valide pour un account deja en monde, la connexion precedente est immediatement fermee avec `DisconnectReason::KickedByDuplicateLogin` avant l'envoi du `TICKET_ACCEPTED` au nouveau client.

Conjugue avec #584 : un duplicate-login depuis 2 IPs ferme maintenant **les 2 TCP (master + shard) du 1er client en <1s** -- plus aucune fenetre de duplicate-play possible.

## Implementation

- `ShardTicketHandshakeHandler.h` : nouvelles maps `m_accountToConn` + `m_connToAccount`.
- `ShardTicketHandshakeHandler.cpp` : avant `Send(TICKET_ACCEPTED)`, check `m_accountToConn[account_id]` ; si conn precedente differente, `CloseConnection(old, KickedByDuplicateLogin)` + purge maps. Insert apres send reussi.
- `OnConnectionClosed` nettoie aussi les nouvelles maps (idempotent en cas de race entre eviction inline et close NetServer).

## Limitation (suivi pre-existant)

`OnConnectionClosed` n'est pas wire dans `shardd/main_linux.cpp` (deja le cas pour `m_handshakeDone`). Suivi : cabler un NetServer disconnect callback. Pour ce fix le memory leak reste borne (2 entries par nouvelle conn) et la correctness est preservee.

## Test plan

- [ ] Build Linux CI green.
- [ ] Avant fix : connecter account=1 depuis IP1, puis depuis IP2 -> les 2 TCP shard restent alive ~60s, 2 clients peuvent jouer en parallele.
- [ ] Apres fix : la TCP shard de IP1 est fermee en <1s avec log `[NETSRV] CloseConnection ... reason=kicked_by_duplicate_login` + `[ShardTicketHandshakeHandler] evicting prior connection (account_id=1 oldConnId=X newConnId=Y)`.

**Deploiement** : redeploiement **shard** requis. Pas de redeploiement master. Pas de changement client.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>