### PR TITLE
feat(net/server): Wave 15 -- PacketLog dump on close (anomalies protocole)

### DIFF
--- a/src/shared/network/NetServer.cpp
+++ b/src/shared/network/NetServer.cpp
@@ -250,6 +250,37 @@ namespace engine::server
 			}
 		}
 
+		// Wave 15 — Dump des paquets recents pour cette conn si PacketLog opt-in
+		// est active ET reason indique une anomalie protocole / reseau. On exclut
+		// les fermetures "normales" (PeerClosed, HeartbeatTimeout, KickedByDuplicateLogin)
+		// pour ne dumper que les vrais bugs (decode, send, ssl, queue cap, handshake).
+		// Le dump sort en LOG_WARN avec le FormatEntries de PacketLog -- ne s'imprime
+		// que si packetLog != nullptr (cf. server.debug.packetlog.enabled).
+		if (hadConn && packetLog != nullptr)
+		{
+			const bool isProtocolError =
+				reason == DisconnectReason::InvalidPacket
+				|| reason == DisconnectReason::DecodeFailures
+				|| reason == DisconnectReason::HandshakeTimeout
+				|| reason == DisconnectReason::TlsHandshakeFailed
+				|| reason == DisconnectReason::SslReadError
+				|| reason == DisconnectReason::SslWriteError
+				|| reason == DisconnectReason::RecvError
+				|| reason == DisconnectReason::SendError
+				|| reason == DisconnectReason::TxQueueCap;
+			if (isProtocolError)
+			{
+				auto recent = packetLog->DrainForConn(connId);
+				if (!recent.empty())
+				{
+					LOG_WARN(Net,
+						"[PacketLog] dump on close connId={} reason={} entries={} :\n{}",
+						connId, DisconnectReasonString(reason), recent.size(),
+						engine::server::netdebug::FormatEntries(recent));
+				}
+			}
+		}
+
 		// M25.4: update DDoS tracking regardless of other close causes.
 		if (ipHostOrder != 0u)
 			ddosProtector.OnConnectionClosed(ipHostOrder, reason, std::chrono::steady_clock::now());


### PR DESCRIPTION
## Summary

Suite de Wave 12 ([#581](https://github.com/tips-of-mine/LCDLLN-test/pull/581) foundation) et Wave 14 ([#587](https://github.com/tips-of-mine/LCDLLN-test/pull/587) wire RX/TX) : quand une connexion ferme avec une reason protocol-error (decode failures, send error, TLS handshake, queue cap, etc.), on dump les paquets recents du connId via `PacketLog.FormatEntries`.

## Comportement

Le dump n'est emis que si :
1. `packetLog != nullptr` (opt-in via `server.debug.packetlog.enabled`)
2. `reason` indique un bug technique (PAS `PeerClosed` / `HeartbeatTimeout` / `KickedByDuplicateLogin` -- ces fermetures sont normales).

Reasons declencheurs : `InvalidPacket`, `DecodeFailures`, `HandshakeTimeout`, `TlsHandshakeFailed`, `SslReadError`, `SslWriteError`, `RecvError`, `SendError`, `TxQueueCap`.

Sortie : `LOG_WARN(Net, ...)` avec le rendu multiligne human-readable de `FormatEntries`. Le ring buffer est tenu en RAM par PacketLog ; `DrainForConn` copie les entries matching le connId sans les detruire.

## Exemple de log

```
[Net] [PacketLog] dump on close connId=29 reason=decode_failures entries=4 :
[2026-05-11 10:30:12.345] RX connId=29 opcode=23 reqId=1 sessId=8697... size=12 preview=...
[2026-05-11 10:30:12.456] TX connId=29 opcode=24 reqId=1 sessId=8697... size=8  preview=...
[2026-05-11 10:30:13.567] RX connId=29 opcode=46 reqId=2 sessId=8697... size=99 preview=...
```

## Cas d'usage

Un opcode arrive mal forme et plante `DecodeFailures` -> le log montre les N derniers paquets RX/TX sur cette conn, ce qui aide a diagnostiquer le client (mauvaise version client, attaque, race condition, etc.).

## Test plan

- [ ] Build Linux CI green.
- [ ] Activer `server.debug.packetlog.enabled = true` + simuler une `DecodeFailures` (envoyer du bruit sur le port) -> verifier le log `[PacketLog] dump on close ...` avec entries non vide.
- [ ] Default OFF : aucune sortie supplementaire, behaviour inchange.

**Deploiement** : redeploiement serveur (master + shard) requis si on veut activer le flag. Default OFF -> aucun impact behaviour, pas de redeploy strict necessaire.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>