### PR TITLE
feat(masterd/admin): Wave 16 -- /packetlog admin command (on-demand RBAC dump)

### DIFF
--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -383,6 +383,42 @@
       "status": "implemented",
       "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
       "notes": "Wave 1 RBAC : applique via AccountRoleService::SetRole (DB + audit role_change). Role attendu : player/moderator/game_master/administrator. Required for testing admin-only commands without manual DB access."
+    },
+    {
+      "command": "/packetlog status",
+      "aliases": [],
+      "description": "Affiche l'etat du PacketLog (active/desactive, capacite, taille courante).",
+      "category": "debug",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 16 RBAC : reporte enabled=true/false + capacity + size courante du ring buffer. Si server.debug.packetlog.enabled=false, retourne Ok avec message 'PacketLog disabled'."
+    },
+    {
+      "command": "/packetlog dump <connId> <n>",
+      "aliases": [],
+      "description": "Dump on-demand des n derniers paquets RX/TX d'une connexion donnee (defaut 20).",
+      "category": "debug",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 16 RBAC : utilise PacketLog::DrainForConn(connId) puis FormatEntries. n optionnel (defaut 20). Resultat tronque a ~4 KB pour tenir dans un seul paquet wire."
+    },
+    {
+      "command": "/packetlog dump_all <n>",
+      "aliases": [],
+      "description": "Dump on-demand des n derniers paquets RX/TX toutes connexions confondues (defaut 20).",
+      "category": "debug",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Wave 16 RBAC : utilise PacketLog::Drain() puis FormatEntries. n optionnel (defaut 20). Resultat tronque a ~4 KB pour tenir dans un seul paquet wire."
     }
   ]
 }

--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -22,6 +22,7 @@
 #include "src/shared/network/ChatPayloads.h"
 #include "src/shared/network/NetServer.h"
 #include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/PacketLog.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 
 #include <mysql.h>
@@ -482,6 +483,21 @@ namespace engine::server
 			DispatchAnnounce(accountId, req.args, resp);
 			handled = true;
 		}
+		else if (req.command == "/packetlog status")
+		{
+			DispatchPacketLog("status", req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/packetlog dump")
+		{
+			DispatchPacketLog("dump", req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/packetlog dump_all")
+		{
+			DispatchPacketLog("dump_all", req.args, resp);
+			handled = true;
+		}
 		else if (UiPanelCommandSet().count(req.command) > 0)
 		{
 			// Wave 3 RBAC migration : les UI panel commands sont log-only.
@@ -889,5 +905,153 @@ namespace engine::server
 		resp.status = AdminCommandStatus::Ok;
 		resp.result.push_back(deliveredBuf);
 		resp.message = "Announce diffuse";
+	}
+
+	// ============================================================
+	// Wave 16 : /packetlog (debug ring buffer on-demand dump).
+	// ============================================================
+
+	/// Implementation des 3 sous-commandes /packetlog. Garde-fou commun :
+	/// si m_packetLog == nullptr (server.debug.packetlog.enabled=false),
+	/// repond Ok avec un message indiquant que la fonctionnalite est
+	/// desactivee — pas d'erreur (rationale : c'est une commande de
+	/// diagnostic, on veut un feedback explicite plutot qu'un refus).
+	///
+	/// Truncation : le payload AdminCommandResponse total doit tenir dans
+	/// un paquet wire de 16 KB max ; on borne le dump a ~4 KB pour laisser
+	/// de la marge aux autres champs (command echo, message, header).
+	void AdminCommandHandler::DispatchPacketLog(const std::string& subCommand,
+		const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+
+		// Cas PacketLog desactive : on retourne Ok avec un message clair
+		// (le client peut ainsi distinguer "feature off" de "ServerError").
+		if (m_packetLog == nullptr)
+		{
+			resp.status = AdminCommandStatus::Ok;
+			resp.message = "PacketLog disabled (server.debug.packetlog.enabled=false)";
+			resp.result.push_back("enabled=false");
+			return;
+		}
+
+		// Borne de truncation pour tenir dans un seul paquet wire.
+		// kProtocolV1MaxPacketSize == 16384, on garde ~4 KB pour le dump.
+		constexpr size_t kMaxDumpBytes = 4096u;
+		// Defaut "n" si non fourni : 20 entries.
+		constexpr size_t kDefaultN = 20u;
+
+		// Helper : tronque chronologiquement aux N entries les plus
+		// recentes (l'ordre de FormatEntries est plus vieux -> plus
+		// recent ; on garde donc le suffixe).
+		auto KeepLastN = [](std::vector<engine::server::netdebug::PacketLogEntry>& v, size_t n)
+		{
+			if (v.size() > n)
+				v.erase(v.begin(), v.begin() + (v.size() - n));
+		};
+
+		// Helper : tronque la chaine \p text a \p maxBytes et ajoute un
+		// suffixe explicite si truncation a eu lieu.
+		auto TruncateToMax = [](std::string& text, size_t maxBytes)
+		{
+			constexpr const char kSuffix[] = "... (truncated)";
+			const size_t suffixLen = sizeof(kSuffix) - 1u;
+			if (text.size() <= maxBytes) return;
+			if (maxBytes <= suffixLen)
+			{
+				text.assign(kSuffix, suffixLen);
+				return;
+			}
+			text.resize(maxBytes - suffixLen);
+			text.append(kSuffix, suffixLen);
+		};
+
+		if (subCommand == "status")
+		{
+			const size_t cap = m_packetLog->Capacity();
+			const size_t sz  = m_packetLog->Size();
+			char buf[96];
+			std::snprintf(buf, sizeof(buf),
+				"enabled, capacity=%zu, size=%zu", cap, sz);
+			resp.status = AdminCommandStatus::Ok;
+			resp.result.push_back("enabled=true");
+			char capBuf[48];
+			std::snprintf(capBuf, sizeof(capBuf), "capacity=%zu", cap);
+			resp.result.push_back(capBuf);
+			char sizeBuf[48];
+			std::snprintf(sizeBuf, sizeof(sizeBuf), "size=%zu", sz);
+			resp.result.push_back(sizeBuf);
+			resp.message = buf;
+			return;
+		}
+
+		if (subCommand == "dump")
+		{
+			if (args.empty())
+			{
+				resp.status = AdminCommandStatus::InvalidArgs;
+				resp.message = "Usage : /packetlog dump <connId> [n]";
+				return;
+			}
+			uint32_t connId = 0u;
+			try { connId = static_cast<uint32_t>(std::stoul(args[0])); }
+			catch (...) { connId = 0u; }
+			// Note : connId == 0 est une valeur valide (slot NetServer
+			// commence a 0 ou 1 selon allocations). On ne rejette pas.
+
+			size_t n = kDefaultN;
+			if (args.size() >= 2u)
+			{
+				try { n = static_cast<size_t>(std::stoul(args[1])); }
+				catch (...) { n = kDefaultN; }
+				if (n == 0u) n = kDefaultN;
+			}
+
+			auto entries = m_packetLog->DrainForConn(connId);
+			KeepLastN(entries, n);
+
+			std::string dump = engine::server::netdebug::FormatEntries(entries);
+			TruncateToMax(dump, kMaxDumpBytes);
+
+			char hdrBuf[96];
+			std::snprintf(hdrBuf, sizeof(hdrBuf),
+				"connId=%u count=%zu", static_cast<unsigned>(connId), entries.size());
+			resp.status = AdminCommandStatus::Ok;
+			resp.result.push_back(hdrBuf);
+			resp.result.push_back(std::string("dump=\n") + dump);
+			resp.message = "OK";
+			return;
+		}
+
+		if (subCommand == "dump_all")
+		{
+			size_t n = kDefaultN;
+			if (!args.empty())
+			{
+				try { n = static_cast<size_t>(std::stoul(args[0])); }
+				catch (...) { n = kDefaultN; }
+				if (n == 0u) n = kDefaultN;
+			}
+
+			auto entries = m_packetLog->Drain();
+			KeepLastN(entries, n);
+
+			std::string dump = engine::server::netdebug::FormatEntries(entries);
+			TruncateToMax(dump, kMaxDumpBytes);
+
+			char hdrBuf[64];
+			std::snprintf(hdrBuf, sizeof(hdrBuf), "count=%zu", entries.size());
+			resp.status = AdminCommandStatus::Ok;
+			resp.result.push_back(hdrBuf);
+			resp.result.push_back(std::string("dump=\n") + dump);
+			resp.message = "OK";
+			return;
+		}
+
+		// Defensif : sous-commande inconnue (ne devrait pas arriver car le
+		// dispatcher en amont matche par nom canonique).
+		resp.status = AdminCommandStatus::InvalidArgs;
+		resp.message = "Sous-commande /packetlog inconnue : " + subCommand;
 	}
 }

--- a/src/masterd/handlers/admin/AdminCommandHandler.h
+++ b/src/masterd/handlers/admin/AdminCommandHandler.h
@@ -31,6 +31,10 @@
 //     - "/announce <message>"    game_master  (broadcast canal Server)
 //   Wave 3 (UI panels log-only) : /mail, /quest, /guild, /ah, /skills, /lfg,
 //     /arena, /bg, /pvp, /weather, /events, /rep, /ticket
+//   Wave 16 (debug PacketLog on-demand) :
+//     - "/packetlog status"             admin   (etat ring buffer)
+//     - "/packetlog dump <connId> [n]"  admin   (dump entries d'une conn)
+//     - "/packetlog dump_all [n]"       admin   (dump global)
 //
 // Pour toute autre commande connue du registre, la reponse est un Ok stub
 // avec result vide. Les futures PR ajouteront les dispatchers specifiques.
@@ -58,6 +62,11 @@ namespace engine::server::db
 namespace engine::server::gmtickets
 {
 	class GmTicketSystem;
+}
+
+namespace engine::server::netdebug
+{
+	class PacketLog;
 }
 
 namespace engine::server
@@ -96,6 +105,12 @@ namespace engine::server
 		/// Branche le pool MySQL pour /mute (INSERT chat_mutes). Si nullptr,
 		/// /mute repondra ServerError.
 		void SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_dbPool = pool; }
+
+		/// Branche le ring buffer PacketLog (Wave 12) pour les commandes
+		/// /packetlog status, /packetlog dump, /packetlog dump_all. Si
+		/// nullptr (cas server.debug.packetlog.enabled=false), les
+		/// commandes repondront Ok avec un message "PacketLog disabled".
+		void SetPacketLog(engine::server::netdebug::PacketLog* log) { m_packetLog = log; }
 
 		/// Dispatch packet : traite uniquement opcode 195
 		/// (kOpcodeAdminCommandRequest). Pour tout autre opcode, no-op.
@@ -171,6 +186,21 @@ namespace engine::server
 		                      const std::vector<std::string>& args,
 		                      engine::network::admin::AdminCommandResponse& resp);
 
+		/// Dispatch des trois sous-commandes "/packetlog status",
+		/// "/packetlog dump <connId> [n]" et "/packetlog dump_all [n]".
+		/// Wave 16 : si m_packetLog == nullptr, retourne Ok avec un message
+		/// "PacketLog disabled". Sinon, formate les entries demandees et
+		/// les inscrit dans resp.result (tronquees a ~4 KB).
+		/// \param subCommand  Identifiant de la sous-commande : "status",
+		///                    "dump" ou "dump_all" (extrait du nom canonique
+		///                    "/packetlog <sub>").
+		/// \param args        Arguments positionnels apres la sous-commande
+		///                    (connId pour dump, n optionnel partout).
+		/// \param resp        Reponse a remplir.
+		void DispatchPacketLog(const std::string& subCommand,
+		                       const std::vector<std::string>& args,
+		                       engine::network::admin::AdminCommandResponse& resp);
+
 		NetServer*            m_server      = nullptr;
 		SessionManager*       m_sessionMgr  = nullptr;
 		ConnectionSessionMap* m_connMap     = nullptr;
@@ -179,5 +209,6 @@ namespace engine::server
 		AccountStore*         m_accountStore = nullptr;
 		engine::server::gmtickets::GmTicketSystem* m_gmTicketSys = nullptr;
 		engine::server::db::ConnectionPool*        m_dbPool      = nullptr;
+		engine::server::netdebug::PacketLog*       m_packetLog   = nullptr;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -917,7 +917,11 @@ int main(int argc, char** argv)
 	adminCommandHandler.SetAccountStore(accountStore);
 	adminCommandHandler.SetGmTicketSystem(&gmTicketSystem);
 	adminCommandHandler.SetConnectionPool(&dbPool);
-	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log + Wave 2 moderation wiring)");
+	// Wave 16 : branche le PacketLog pour /packetlog status/dump/dump_all.
+	// Si packetLogOpt est nullptr (server.debug.packetlog.enabled=false),
+	// le handler bascule naturellement sur le chemin "PacketLog disabled".
+	adminCommandHandler.SetPacketLog(packetLogOpt.get());
+	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log + Wave 2 moderation + Wave 16 packetlog wiring)");
 
 	// Phase 5 Lunar — Branche le GameEventHandler sur le LunarHandler pour
 	// pouvoir filtrer les events par phase lunaire (event "Nuit de la


### PR DESCRIPTION
## Resume

Ajoute la commande administrateur `/packetlog` (3 sous-commandes) pour dumper a la demande le ring buffer PacketLog (Wave 12) sans casser la connexion -- contrairement au dump automatique de Wave 15 declenche uniquement sur erreur protocole.

## Sous-commandes

- `/packetlog status` -- etat (enabled, capacity, size courante)
- `/packetlog dump <connId> [n]` -- n dernieres entries pour une connexion (defaut 20)
- `/packetlog dump_all [n]` -- n dernieres entries toutes connexions (defaut 20)

Toutes `minRole=administrator`, auditees via le standard `[AdminCommand]` log + RBAC `SlashCommandRegistry`.

## Comportement quand PacketLog desactive

Si `server.debug.packetlog.enabled=false` (`packetLogOpt` est nullptr), le handler retourne `Ok` avec le message `"PacketLog disabled (server.debug.packetlog.enabled=false)"` -- pas d'erreur, juste un feedback explicite.

## Modifs

- `game/data/config/slash_commands.json` : 3 entrees `category="debug"`, `minRole="administrator"`.
- `AdminCommandHandler.h` : forward-decl `engine::server::netdebug::PacketLog`, setter `SetPacketLog`, membre prive, signature `DispatchPacketLog`.
- `AdminCommandHandler.cpp` : 3 cases dans le dispatcher, implementation avec truncation ~4 KB (sous `kProtocolV1MaxPacketSize=16384`) pour tenir dans un seul paquet wire.
- `main_linux.cpp` : `adminCommandHandler.SetPacketLog(packetLogOpt.get())` (nullptr-safe).

## Note opcode

Reutilise `kOpcodeAdminCommandRequest` (195) -- aucun wire-breaking change. Client inchange.

## Test plan

- [ ] CI Linux + Windows build vert.
- [ ] Avec `server.debug.packetlog.enabled=true`, verifier `/packetlog status` retourne `enabled, capacity=N, size=M`.
- [ ] `/packetlog dump <connId> 5` retourne au plus 5 entries pour cette conn.
- [ ] `/packetlog dump_all 100` tronque a ~4 KB avec suffix `... (truncated)` si necessaire.
- [ ] PacketLog desactive : les 3 commandes retournent `Ok` + message "PacketLog disabled".
- [ ] Un compte `player` recoit `DENIED` ; admin peut executer ; le log `[AdminCommand]` apparait cote master.

**Deploiement** : redeploiement serveur (master) requis -- nouveau handler pour 3 sous-commandes du registre, sinon le client recevra `UnknownCommand`. Pas de wire-breaking, pas de migration DB, client inchange.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>