### PR TITLE
fix(db): CLIENT_FOUND_ROWS -- supprime faux positif 'no row updated' sur position save

### DIFF
--- a/src/shared/db/ConnectionPool.cpp
+++ b/src/shared/db/ConnectionPool.cpp
@@ -49,8 +49,15 @@ namespace engine::server::db
 
 	bool ConnectionPool::ConnectOne(MYSQL* mysql) const
 	{
+		// CLIENT_FOUND_ROWS : mysql_affected_rows() retourne le nombre de rangs MATCHES
+		// (et non changes) sur les UPDATE. Sans ce flag, un UPDATE avec valeurs
+		// identiques (ex: joueur immobile -> spawn_x/y/z inchanges) renvoie 0 et
+		// les handlers logguent un faux warning "no row updated". Avec ce flag,
+		// la semantique "0 -> row absente" devient fiable. Aucun callsite n'a
+		// besoin de la semantique "changed only" : tous attendent matched.
 		return mysql_real_connect(mysql, m_host.c_str(), m_user.c_str(),
-			m_password.empty() ? nullptr : m_password.c_str(), m_database.c_str(), m_port, nullptr, 0) != nullptr;
+			m_password.empty() ? nullptr : m_password.c_str(), m_database.c_str(),
+			m_port, nullptr, CLIENT_FOUND_ROWS) != nullptr;
 	}
 
 	bool ConnectionPool::Init(const engine::core::Config& config)


### PR DESCRIPTION
## Bug observe

Logs prod (apres EnterWorld success) :
```
[CharacterSavePositionHandler] Position saved (account_id=1, character_id=1, pos=(0.00, 101.70, 0.00))
[CharacterSavePositionHandler] no row updated (account_id=1, character_id=1) -- not owned, missing or deleted
```

Le 1er save reussit, les suivants logguent un faux warning "not owned". Le BAD_REQUEST renvoye au client peut induire une logique erronee cote client.

## Cause

Par defaut, MySQL renvoie `mysql_affected_rows` = nb de rangs **CHANGES** (pas matched). Quand le joueur reste immobile, `UPDATE characters SET spawn_x=..., spawn_y=..., spawn_z=... WHERE id=X AND account_id=Y` produit matched=1 mais changed=0 -> le handler interprete a tort "row not found".

## Fix

Passe `CLIENT_FOUND_ROWS` au `mysql_real_connect` dans [ConnectionPool::ConnectOne](src/shared/db/ConnectionPool.cpp:50). Avec ce flag, `affected_rows` retourne **matched**. La semantique "0 -> row absente" redevient fiable.

Le reconnect path (line 167) appelle aussi `ConnectOne` -> couvert.

## Audit des 6 callsites `mysql_affected_rows`

| Callsite | Operation | Impact du flag |
|---|---|---|
| MysqlAccountStore email_verified | UPDATE | Pas de regression -- "deja verifie + reapplique" est un succes |
| MysqlAccountStore password_hash | UPDATE | Idem |
| MysqlAccountStore role | UPDATE | Idem (re-promote meme role -> success) |
| MysqlAccountStore status | UPDATE | Idem |
| CharacterDeleteHandler | DELETE | Inchange (flag affecte que UPDATE) |
| CharacterSavePositionHandler | UPDATE | **Fix : plus de faux warnings sur joueur immobile** |

Aucun callsite n'attend "changed only" -- tous veulent matched-rows.

## Test plan

- [ ] CI Linux build green.
- [ ] Avant fix : se connecter, attendre 2-3 ticks immobiles -> log `no row updated`.
- [ ] Apres fix : meme scenario -> log `Position saved` a chaque save, plus de warning.

**Deploiement** : redeploiement serveur master requis (semantique DB change au boot via la flag de connexion). Pas d'impact client, pas de migration.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>