### PR TITLE
feat(world): Wave 18 -- GridVisitor + GridNotifier (AoI 7x7 broadcast)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,9 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shardd/world/TickScheduler.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/SpatialPartition.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/GridState.cpp
+    # Wave 18 : GridNotifier (foncteur Visitor + filter predicate).
+    # GridVisitor.h est header-only template, pas de .cpp.
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/GridNotifier.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/ZoneTransitions.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/Config.cpp
@@ -572,6 +575,29 @@ elseif(UNIX)
   target_link_libraries(grid_state_tests PRIVATE engine_core spdlog::spdlog pthread)
   target_compile_options(grid_state_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME grid_state_tests COMMAND grid_state_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Wave 18 (CMANGOS.03 step 2) : GridVisitor pattern (template free function)
+  # parcourt l'AoI 7x7 cells autour d'une position.
+  add_executable(grid_visitor_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/GridVisitorTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/SpatialPartition.cpp
+  )
+  target_include_directories(grid_visitor_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(grid_visitor_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(grid_visitor_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME grid_visitor_tests COMMAND grid_visitor_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Wave 18 (CMANGOS.03 step 2) : GridNotifier foncteur Visitor avec filter
+  # predicate (utilise pour broadcasts localises -- collecte recipients).
+  add_executable(grid_notifier_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/GridNotifierTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/GridNotifier.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/SpatialPartition.cpp
+  )
+  target_include_directories(grid_notifier_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(grid_notifier_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(grid_notifier_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME grid_notifier_tests COMMAND grid_notifier_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # CMANGOS.05 (Phase 2.05b) : VMapFormat encode/decode tests (no DB, no I/O)
   add_executable(vmap_format_tests

--- a/src/shardd/world/GridNotifier.cpp
+++ b/src/shardd/world/GridNotifier.cpp
@@ -1,0 +1,9 @@
+// GridNotifier : translation unit. Toutes les methodes sont inline dans
+// le header (header-only design). Ce .cpp existe pour CMake (cible
+// nommee + symbole faible si methodes deplacees out-of-line dans le futur).
+#include "src/shardd/world/GridNotifier.h"
+
+namespace engine::server
+{
+	// Methodes out-of-line a ajouter au besoin.
+}

--- a/src/shardd/world/GridNotifier.h
+++ b/src/shardd/world/GridNotifier.h
@@ -1,0 +1,66 @@
+#pragma once
+// GridNotifier : foncteur Visitor specialise pour collecter les
+// destinataires d'un broadcast localise (typiquement les Player dans
+// l'AoI). Se branche sur GridVisit via GridVisitWithVisitor.
+//
+// Conception : GridNotifier ne SAIT PAS comment determiner si un
+// EntityId est un Player. Il delegue a un PlayerFilter (predicate)
+// fourni par le caller — typiquement une lambda qui interroge
+// ObjectAccessor (Wave 19) : `[&](EntityId id) { return
+// accessor.GetSnapshot(id) && accessor.GetSnapshot(id)->isPlayer; }`.
+//
+// Apres GridVisitWithVisitor, le caller utilise Recipients() pour
+// envoyer le packet sur les sessions correspondantes (resolution
+// EntityId -> SessionId via la session map, Wave 12+).
+
+#include "src/shared/network/ReplicationTypes.h"
+
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace engine::server
+{
+	/// Foncteur Visitor : collecte les EntityId qui satisfont un predicate
+	/// (typiquement "est un Player"). Stateful : conserve la liste pour
+	/// reuse par le caller post-visite.
+	class GridNotifier
+	{
+	public:
+		/// Predicate : retourne true si l'EntityId doit etre inclus dans
+		/// Recipients(). Caller fournit la logique (ex: lookup
+		/// ObjectAccessor).
+		using PlayerFilter = std::function<bool(EntityId)>;
+
+		/// \param isPlayer predicate. Si null, AUCUN id n'est collecte
+		///        (defensif : pas de broadcast accidentel a toutes les
+		///        entites du voisinage).
+		explicit GridNotifier(PlayerFilter isPlayer)
+			: m_isPlayer(std::move(isPlayer))
+		{}
+
+		/// Appelee par GridVisitWithVisitor pour chaque EntityId visite.
+		/// Filtre via le predicate et accumule si match.
+		void Visit(EntityId id)
+		{
+			if (m_isPlayer && m_isPlayer(id))
+				m_recipients.push_back(id);
+		}
+
+		/// Liste des EntityId collectes par filtre. Order : ordre de
+		/// visite (depend de GridVisit, non garanti stable).
+		const std::vector<EntityId>& Recipients() const noexcept { return m_recipients; }
+
+		/// Nombre de destinataires collectes (alias de Recipients().size()).
+		size_t Count() const noexcept { return m_recipients.size(); }
+
+		/// Reset interne — utile pour reutiliser un GridNotifier sur
+		/// plusieurs broadcasts successifs sans realloc.
+		void Reset() noexcept { m_recipients.clear(); }
+
+	private:
+		PlayerFilter          m_isPlayer;
+		std::vector<EntityId> m_recipients;
+	};
+}

--- a/src/shardd/world/GridNotifierTests.cpp
+++ b/src/shardd/world/GridNotifierTests.cpp
@@ -1,0 +1,130 @@
+// Wave 18 — GridNotifier tests : foncteur Visitor avec predicate filter
+// (typiquement "est un Player"). Branche sur GridVisitor.
+//
+// Pattern aligne sur les autres tests entities Wave 17 : asserts +
+// printf, pas de framework. Cible CTest : grid_notifier_tests.
+
+#include "src/shardd/world/GridNotifier.h"
+#include "src/shardd/world/GridVisitor.h"
+#include "src/shardd/world/SpatialPartition.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <unordered_set>
+
+using namespace engine::server;
+
+namespace
+{
+	/// Notifier avec predicate null : aucune collecte (defensif).
+	void TestGridNotifierNullPredicate()
+	{
+		GridNotifier notifier(/*isPlayer*/nullptr);
+		notifier.Visit(1);
+		notifier.Visit(2);
+		assert(notifier.Count() == 0);
+		assert(notifier.Recipients().empty());
+		std::puts("[OK] TestGridNotifierNullPredicate");
+	}
+
+	/// Predicate "tous players" : tous les ids visites sont collectes.
+	void TestGridNotifierAllPlayers()
+	{
+		GridNotifier notifier([](EntityId) { return true; });
+		notifier.Visit(10);
+		notifier.Visit(20);
+		notifier.Visit(30);
+		assert(notifier.Count() == 3);
+		assert(notifier.Recipients()[0] == 10);
+		assert(notifier.Recipients()[1] == 20);
+		assert(notifier.Recipients()[2] == 30);
+		std::puts("[OK] TestGridNotifierAllPlayers");
+	}
+
+	/// Predicate selectif : seules certaines ids sont des players.
+	void TestGridNotifierSelectiveFilter()
+	{
+		std::unordered_set<EntityId> players = {100, 300};
+		GridNotifier notifier([&players](EntityId id) {
+			return players.count(id) > 0;
+		});
+
+		// Visite 100, 200, 300, 400 : seuls 100 et 300 doivent etre collectes.
+		notifier.Visit(100);
+		notifier.Visit(200);
+		notifier.Visit(300);
+		notifier.Visit(400);
+		assert(notifier.Count() == 2);
+		auto has100 = std::find(notifier.Recipients().begin(),
+			notifier.Recipients().end(), 100) != notifier.Recipients().end();
+		auto has300 = std::find(notifier.Recipients().begin(),
+			notifier.Recipients().end(), 300) != notifier.Recipients().end();
+		auto has200 = std::find(notifier.Recipients().begin(),
+			notifier.Recipients().end(), 200) != notifier.Recipients().end();
+		assert(has100);
+		assert(has300);
+		assert(!has200);
+		std::puts("[OK] TestGridNotifierSelectiveFilter");
+	}
+
+	/// Reset clear les recipients sans toucher au predicate.
+	void TestGridNotifierReset()
+	{
+		GridNotifier notifier([](EntityId) { return true; });
+		notifier.Visit(1);
+		notifier.Visit(2);
+		assert(notifier.Count() == 2);
+		notifier.Reset();
+		assert(notifier.Count() == 0);
+		// Le predicate fonctionne toujours apres reset.
+		notifier.Visit(3);
+		assert(notifier.Count() == 1);
+		assert(notifier.Recipients()[0] == 3);
+		std::puts("[OK] TestGridNotifierReset");
+	}
+
+	/// Integration end-to-end : place 4 entites dans une CellGrid, dont 2
+	/// "players" (par filter). GridVisitWithVisitor parcourt l'AoI, le
+	/// notifier filtre via le predicate.
+	void TestGridNotifierIntegrationWithCellGrid()
+	{
+		CellGrid grid;
+		grid.Init();
+
+		// 4 entites au meme endroit (5000,5000) — tous dans le 7x7 center.
+		CellCoord cell{};
+		assert(grid.UpsertEntity(101, 5000.0f, 5000.0f, cell));
+		assert(grid.UpsertEntity(102, 5050.0f, 5050.0f, cell));
+		assert(grid.UpsertEntity(201, 5010.0f, 5010.0f, cell));
+		assert(grid.UpsertEntity(202, 5020.0f, 5020.0f, cell));
+
+		// "Players" = ids commencant par 1, "Creatures" = ids commencant par 2.
+		std::unordered_set<EntityId> playerIds = {101, 102};
+		GridNotifier notifier([&playerIds](EntityId id) {
+			return playerIds.count(id) > 0;
+		});
+
+		GridVisitWithVisitor(grid, 5000.0f, 5000.0f, notifier);
+
+		assert(notifier.Count() == 2);
+		auto has101 = std::find(notifier.Recipients().begin(),
+			notifier.Recipients().end(), 101) != notifier.Recipients().end();
+		auto has102 = std::find(notifier.Recipients().begin(),
+			notifier.Recipients().end(), 102) != notifier.Recipients().end();
+		assert(has101);
+		assert(has102);
+		std::puts("[OK] TestGridNotifierIntegrationWithCellGrid");
+	}
+}
+
+int main()
+{
+	TestGridNotifierNullPredicate();
+	TestGridNotifierAllPlayers();
+	TestGridNotifierSelectiveFilter();
+	TestGridNotifierReset();
+	TestGridNotifierIntegrationWithCellGrid();
+	std::puts("All GridNotifier tests passed");
+	return 0;
+}

--- a/src/shardd/world/GridVisitor.h
+++ b/src/shardd/world/GridVisitor.h
@@ -1,0 +1,65 @@
+#pragma once
+// GridVisitor : pattern Visitor pour parcourir les entites dans un AoI
+// autour d'une position. Compose CellGrid::BuildInterestSet (7x7 cells)
+// + CellGrid::GatherEntityIds. Header-only template.
+//
+// Pattern WoW-like adapte LCDLLN : le visiteur est un foncteur ou une
+// lambda invoque pour chaque EntityId dans le voisinage. Le caller
+// resout l'objet derriere l'id via ObjectAccessor (Wave 19).
+//
+// Limite Wave 18 : utilise le radius par defaut kBaseInterestRadiusCells
+// (3 cells = 7x7 = 700m d'AoI avec kSpatialCellSizeMeters=100m). Pour un
+// AoI plus fin (ex: /say a 30m), il faudra une grille a cellule plus
+// petite ou un filtrage radial par distance euclidienne du caller.
+
+#include "src/shardd/world/SpatialPartition.h"
+#include "src/shared/network/ReplicationTypes.h"
+
+#include <utility>
+#include <vector>
+
+namespace engine::server
+{
+	/// Visite toutes les entites dans le voisinage 7x7 cells autour de
+	/// (centerX, centerZ). \p fn est invoque une fois par EntityId trouve.
+	///
+	/// \param grid CellGrid initialisee. Si non initialisee, no-op.
+	/// \param centerX position X world-space en metres.
+	/// \param centerZ position Z world-space en metres.
+	/// \param fn foncteur invocable avec (EntityId). Peut etre lambda.
+	///
+	/// \remark Order de visite non garanti (depend de l'ordre des cells
+	///         dans BuildInterestSet + l'ordre interne de chaque cell).
+	/// \remark Si (centerX, centerZ) tombe hors de la zone, no-op silent.
+	template<typename Fn>
+	void GridVisit(const CellGrid& grid, float centerX, float centerZ, Fn&& fn)
+	{
+		CellCoord center{};
+		if (!grid.TryWorldToCellCoord(centerX, centerZ, center))
+			return;
+
+		std::vector<CellCoord> cells;
+		grid.BuildInterestSet(center, cells);
+
+		std::vector<EntityId> ids;
+		grid.GatherEntityIds(cells, ids);
+
+		for (auto id : ids)
+			fn(id);
+	}
+
+	/// Variante non-template (type-erased via std::function-like) — utile
+	/// pour les call-sites qui n'ont pas de raison d'inline. Implementee
+	/// inline en termes de GridVisit<Fn>. Conserve l'API symmetrique
+	/// avec un foncteur stateful (GridNotifier).
+	///
+	/// \remark Si tu peux utiliser le template, prefer GridVisit<Fn> qui
+	///         n'a aucun cout d'indirection.
+	template<typename Visitor>
+	void GridVisitWithVisitor(const CellGrid& grid, float centerX, float centerZ, Visitor& visitor)
+	{
+		GridVisit(grid, centerX, centerZ, [&visitor](EntityId id) {
+			visitor.Visit(id);
+		});
+	}
+}

--- a/src/shardd/world/GridVisitorTests.cpp
+++ b/src/shardd/world/GridVisitorTests.cpp
@@ -1,0 +1,194 @@
+// Wave 18 — GridVisitor tests : pattern Visitor sur CellGrid (AoI 7x7).
+// Tests deterministes (pas de random stat) : place les entites a des
+// positions connues + verifie le set d'IDs visites.
+//
+// Pattern aligne sur ObjectGuidTests.cpp / WorldObjectTests.cpp :
+// asserts + printf, pas de framework. Cible CTest : grid_visitor_tests.
+
+#include "src/shardd/world/GridVisitor.h"
+#include "src/shardd/world/SpatialPartition.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::server;
+
+namespace
+{
+	/// Visite vide : aucune entite -> fn jamais appelee.
+	void TestGridVisitEmpty()
+	{
+		CellGrid grid;
+		grid.Init();
+		int count = 0;
+		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		assert(count == 0);
+		std::puts("[OK] TestGridVisitEmpty");
+	}
+
+	/// Une entite a la position center : fn appelee 1x avec son ID.
+	void TestGridVisitSingleEntity()
+	{
+		CellGrid grid;
+		grid.Init();
+		CellCoord cell{};
+		assert(grid.UpsertEntity(/*id*/42, /*x*/5000.0f, /*z*/5000.0f, cell));
+
+		std::vector<EntityId> visited;
+		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+			visited.push_back(id);
+		});
+		assert(visited.size() == 1);
+		assert(visited[0] == 42);
+		std::puts("[OK] TestGridVisitSingleEntity");
+	}
+
+	/// Entite a +50m (meme cell que center avec kSpatialCellSizeMeters=100) :
+	/// visite OK.
+	void TestGridVisitSameCell()
+	{
+		CellGrid grid;
+		grid.Init();
+		CellCoord cell{};
+		assert(grid.UpsertEntity(1, 5000.0f, 5000.0f, cell));
+		assert(grid.UpsertEntity(2, 5050.0f, 5050.0f, cell)); // meme cell
+
+		std::vector<EntityId> visited;
+		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+			visited.push_back(id);
+		});
+		assert(visited.size() == 2);
+		std::puts("[OK] TestGridVisitSameCell");
+	}
+
+	/// Entite a +200m (cell+2, dans le 7x7 centre sur (5000,5000)) : visite OK.
+	/// Entite a +500m (cell+5, hors 7x7) : non visitee.
+	void TestGridVisitNeighborhoodBoundary()
+	{
+		CellGrid grid;
+		grid.Init();
+		CellCoord cell{};
+		assert(grid.UpsertEntity(10, 5000.0f, 5000.0f, cell));  // center
+		assert(grid.UpsertEntity(20, 5200.0f, 5000.0f, cell));  // +2 cells (inside 7x7)
+		assert(grid.UpsertEntity(30, 5500.0f, 5000.0f, cell));  // +5 cells (outside 7x7)
+
+		std::vector<EntityId> visited;
+		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+			visited.push_back(id);
+		});
+		assert(visited.size() == 2);
+		// 10 et 20 sont dans le 7x7, 30 est dehors.
+		auto has10 = std::find(visited.begin(), visited.end(), 10) != visited.end();
+		auto has20 = std::find(visited.begin(), visited.end(), 20) != visited.end();
+		auto has30 = std::find(visited.begin(), visited.end(), 30) != visited.end();
+		assert(has10 && has20 && !has30);
+		std::puts("[OK] TestGridVisitNeighborhoodBoundary");
+	}
+
+	/// Center hors de la zone : no-op silent (pas de crash, pas de visite).
+	void TestGridVisitOutsideZone()
+	{
+		CellGrid grid;
+		grid.Init();
+		CellCoord cell{};
+		assert(grid.UpsertEntity(1, 5000.0f, 5000.0f, cell));
+
+		// Position negative ou > kZoneSizeMeters -> hors zone.
+		int count = 0;
+		GridVisit(grid, -100.0f, 5000.0f, [&count](EntityId) { ++count; });
+		assert(count == 0);
+		GridVisit(grid, 50000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		assert(count == 0);
+		std::puts("[OK] TestGridVisitOutsideZone");
+	}
+
+	/// Grille non initialisee : GridVisit retourne sans erreur (TryWorldToCellCoord
+	/// retourne false).
+	void TestGridVisitUninitialized()
+	{
+		CellGrid grid;
+		// pas d'Init()
+		int count = 0;
+		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		assert(count == 0);
+		std::puts("[OK] TestGridVisitUninitialized");
+	}
+
+	/// Visitor stateful (pattern GridVisitWithVisitor) : la struct
+	/// accumule les ids, on verifie l'integrite.
+	void TestGridVisitWithVisitor()
+	{
+		struct CollectorVisitor
+		{
+			std::vector<EntityId> ids;
+			void Visit(EntityId id) { ids.push_back(id); }
+		};
+
+		CellGrid grid;
+		grid.Init();
+		CellCoord cell{};
+		assert(grid.UpsertEntity(7, 5000.0f, 5000.0f, cell));
+		assert(grid.UpsertEntity(8, 5050.0f, 5050.0f, cell));
+
+		CollectorVisitor v;
+		GridVisitWithVisitor(grid, 5000.0f, 5000.0f, v);
+		assert(v.ids.size() == 2);
+		std::puts("[OK] TestGridVisitWithVisitor");
+	}
+
+	/// Stress test : 1000 entites reparties uniformement sur la zone.
+	/// Avec AoI 7x7 cells = 700m sur une zone 10000m, on attend en
+	/// moyenne (700/10000)^2 * 1000 = 4.9 entites visibles. Test
+	/// deterministe : on place les entites sur une grille regulière et
+	/// on calcule exactement combien tombent dans le 7x7 centre.
+	void TestGridVisitStress1000Entities()
+	{
+		CellGrid grid;
+		grid.Init();
+
+		// Place 1000 entites sur grille 32x32 (1024 cells, gardons 1000)
+		// pas = 312.5m, mais on arrondit a 310m pour rester dans zone.
+		// Cells 100m -> les entites tombent dans des cells distinctes.
+		const int stepMeters = 310;
+		int placed = 0;
+		for (int gx = 0; gx < 32 && placed < 1000; ++gx)
+		{
+			for (int gz = 0; gz < 32 && placed < 1000; ++gz)
+			{
+				const float x = static_cast<float>(gx * stepMeters + 50);
+				const float z = static_cast<float>(gz * stepMeters + 50);
+				CellCoord cell{};
+				if (grid.UpsertEntity(static_cast<EntityId>(placed + 1), x, z, cell))
+					++placed;
+			}
+		}
+		assert(placed == 1000);
+
+		// Visite autour de (5000, 5000) : 7x7 cells centrees sur (50, 50)
+		// in cell-coords (5000m / 100m = 50). Range cells [47..53] sur x et z.
+		// Cells touchées : trouver les entites avec gx*310+50 dans [4700..5350]
+		// (cells 47..53 = 4700..5400 m), idem pour z. gx*310+50 in [4700..5350]
+		// -> gx in [15..17] (since 15*310+50=4700, 17*310+50=5320, 18*310+50=5630>5400).
+		// 3 valeurs de gx * 3 valeurs de gz = 9 entites attendues.
+		int count = 0;
+		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		assert(count == 9);
+		std::puts("[OK] TestGridVisitStress1000Entities");
+	}
+}
+
+int main()
+{
+	TestGridVisitEmpty();
+	TestGridVisitSingleEntity();
+	TestGridVisitSameCell();
+	TestGridVisitNeighborhoodBoundary();
+	TestGridVisitOutsideZone();
+	TestGridVisitUninitialized();
+	TestGridVisitWithVisitor();
+	TestGridVisitStress1000Entities();
+	std::puts("All GridVisitor tests passed");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Wave 18 livre le **pattern Visitor sur la grille spatiale** (CellGrid) — base pour tout broadcast localisé. Construit sur la fondation `SpatialPartition` + `CellGrid::BuildInterestSet/GatherEntityIds` existante (déjà au boot shard).

C'est le **Wave 18 de la roadmap server-first** ([spec](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md)). Suit la Wave 17 ([PR #591](https://github.com/tips-of-mine/LCDLLN-test/pull/591)).

## Commits (3)

1. **`feat(world): Wave 18a`** — `GridVisitor.h` template free function (`GridVisit(grid, x, z, fn)` + `GridVisitWithVisitor`)
2. **`feat(world): Wave 18b`** — `GridNotifier.h/.cpp` foncteur Visitor avec `PlayerFilter` (predicate)
3. **`build(wave-18)`** — wire CMakeLists.txt (2 cibles CTest)

## Audit anti-doublon (règle 2026-05-11)

`grep "GridVisitor\|GridNotifier" src/` → 0 hit avant cette PR. Vrai gap. Compose des fonctions existantes (`BuildInterestSet`, `GatherEntityIds`) sans toucher à CellGrid.

## API

```cpp
// Template visit pour code inline (zero indirection)
engine::server::GridVisit(grid, posX, posZ, [&](EntityId id) {
    // do something per entity in AoI
});

// Foncteur Visitor pour code stateful
engine::server::GridNotifier notifier([&](EntityId id) {
    // predicate: typiquement isPlayer via ObjectAccessor
    auto snap = accessor.GetSnapshot(id);
    return snap && snap->isPlayer;
});
engine::server::GridVisitWithVisitor(grid, posX, posZ, notifier);

for (EntityId recipient : notifier.Recipients()) {
    // envoyer packet sur la session correspondante
}
```

## AoI Wave 18

- `kSpatialCellSizeMeters = 100m` (constante existante, non touchée)
- `kBaseInterestRadiusCells = 3` → voisinage **7x7 cells = 700m × 700m**
- Approprié pour : `/yell`, `/zone`, combat log spatial, particles spawn
- **Pas approprié pour** : `/say` (~30m) — nécessitera grille à cellule plus petite ou filtrage radial euclidien dans une Wave future

## Limitations volontaires

- **Pas de Map class** — Wave 21 livrera `WorldMap`/`DungeonMap`/`BattlegroundMap`. Wave 18 expose des fonctions libres dans `engine::server` namespace.
- **Pas d'intégration ObjectAccessor automatique** — le `PlayerFilter` est injecté par le caller. Garde GridNotifier découplé d'ObjectAccessor (testable sans dépendance).
- **Pas de broadcast packet effectif** — GridNotifier *collecte* les recipients, le caller fait l'envoi via ses propres canaux session. C'est volontaire (séparation des responsabilités).

## Test plan

| Cible CTest | Cas |
|-------------|-----|
| `grid_visitor_tests` | 8 cas : empty, single, same cell, neighborhood boundary (+200m visible/+500m hors), outside zone, uninitialized, visitor pattern, stress 1000 entités (vérif count exact = 9 entités dans 7x7) |
| `grid_notifier_tests` | 5 cas : null predicate, all-true, selective filter, Reset, intégration end-to-end avec CellGrid |

CI sur cette PR :
- [ ] Linux build (`build-linux`) compile les 2 nouveaux test binaires
- [ ] Si PR #592 (ctest gate) déjà mergée : les 13 cas tournent réellement en CI

## Doc

CODEBASE_MAP.md **non touché** dans cette PR pour éviter conflit de merge avec PR #591 (qui ajoute déjà la section §18 sur `src/shardd/world/`). Un commit doc dédié suivra après merge de #591 + #594 pour mettre à jour la mention "Manque (Wave 18 roadmap)" → "Livré Wave 18".

## Déploiement

⚠️ **REDÉPLOIEMENT SHARD REQUIS** — nouvelles classes côté shard (intégrées au target Linux `server_app`). Pas de wire-breaking, pas de migration DB, pas d'impact client.

## Suivant : Wave 19 (HostileRefManager bidir)

Une fois cette PR mergée, prochaine étape : ajouter `HostileRefManager` bidirectionnel sur `ThreatList` existant (Wave 8 #576). Voir [spec §4 Wave 19](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)