### PR TITLE
feat(combat): Wave 19 -- HostileRefManager bidirectionnel + cleanup symetrique

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,6 +540,11 @@ elseif(UNIX)
   # CMANGOS.11 (Phase 3.11a) : ThreatList AI target selector (header-only).
   lcdlln_add_simple_test(threat_list_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/combat/ThreatListTests.cpp)
+  # Wave 19 (CMANGOS.11 step 2) : HostileRefManager bidirectionnel (cibles +
+  # attaquants) avec helpers EngageHostile / DisengageHostile / CleanupOnDeath.
+  lcdlln_add_simple_test(hostile_ref_manager_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/combat/HostileRefManagerTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/combat/HostileRefManager.cpp)
   # CMANGOS.24 (Phase 3.24a) : ReputationManager + spillover (header-only).
   lcdlln_add_simple_test(reputation_manager_tests
     ${CMAKE_SOURCE_DIR}/src/masterd/reputation/ReputationManagerTests.cpp)
@@ -736,6 +741,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/ai/EventAIRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolManagerRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/combat/ThreatListRuntime.cpp
+    # Wave 19 : HostileRefManager bidirectionnel (cibles + attaquants).
+    ${CMAKE_SOURCE_DIR}/src/shardd/combat/HostileRefManager.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScript.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScriptRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp

--- a/src/shardd/combat/HostileRefManager.cpp
+++ b/src/shardd/combat/HostileRefManager.cpp
@@ -1,0 +1,23 @@
+// HostileRefManager : translation unit pour CleanupOnDeath (la seule
+// fonction non-inline). Le reste est header-only inline pour permettre
+// au compilateur d'optimiser les push/erase dans les call-sites typiques
+// (Update tick chaque frame).
+#include "src/shardd/combat/HostileRefManager.h"
+
+namespace engine::server::combat
+{
+	void CleanupOnDeath(EntityId deadId,
+		const std::vector<HostileRefManager*>& affectedManagers)
+	{
+		// Iteration unique : pour chaque manager, retirer deadId des 2 listes
+		// (targets ET haters). erase() est no-op si absent, donc safe meme si
+		// le manager n'avait pas de relation avec deadId.
+		for (auto* mgr : affectedManagers)
+		{
+			if (mgr == nullptr)
+				continue;
+			mgr->RemoveTarget(deadId);
+			mgr->RemoveHater(deadId);
+		}
+	}
+}

--- a/src/shardd/combat/HostileRefManager.h
+++ b/src/shardd/combat/HostileRefManager.h
@@ -1,0 +1,115 @@
+#pragma once
+// HostileRefManager : pattern bidirectionnel pour les relations hostiles
+// entre Unit. Complete ThreatList (Wave 8 #576) qui ne gere QUE la
+// direction "qui me hait".
+//
+// Pour une paire hostile A -> B :
+//   - A.m_targets contient B (les Unit que A hait, ses cibles offensives)
+//   - B.m_haters  contient A (les Unit qui haïssent B, ses attaquants)
+//
+// Les 2 listes doivent rester coherentes : si A meurt, A doit etre retire
+// de tous les m_targets de ses haters ET de tous les m_haters de ses
+// targets. Sans ce cleanup, des "ghost references" subsistent et causent
+// des bugs aggro persistant apres mort.
+//
+// Conception : HostileRefManager est une COMPOSANTE d'Unit, pas un
+// singleton global. Chaque Unit en possede un. La synchronisation
+// bidirectionnelle est faite via le helper EngageHostile(actor, target)
+// ci-dessous, ou explicitement par le caller.
+//
+// Cleanup symetrique : CleanupOnDeath(deadId, managers) — le caller
+// passe la liste des managers a nettoyer (typiquement tous les Unit du
+// shard, recuperes via ObjectAccessor Wave 19 livre).
+
+#include "src/shared/network/ReplicationTypes.h"
+
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+namespace engine::server::combat
+{
+	/// Composante "relations hostiles" d'une Unit. Detient les 2 cotes
+	/// de la relation : ses cibles (m_targets) et ses attaquants (m_haters).
+	class HostileRefManager
+	{
+	public:
+		HostileRefManager() = default;
+
+		/// Ajoute \p targetId aux cibles de cette Unit. No-op si deja present.
+		/// Side note : pour synchroniser, le caller doit aussi appeler
+		/// AddHater(thisOwnerId) sur target.HostileRefManager.
+		void AddTarget(EntityId targetId) { m_targets.insert(targetId); }
+
+		/// Ajoute \p haterId aux attaquants de cette Unit. No-op si deja present.
+		void AddHater(EntityId haterId) { m_haters.insert(haterId); }
+
+		/// Retire \p targetId. No-op si absent.
+		void RemoveTarget(EntityId targetId) { m_targets.erase(targetId); }
+
+		/// Retire \p haterId. No-op si absent.
+		void RemoveHater(EntityId haterId) { m_haters.erase(haterId); }
+
+		/// True si \p id est une cible offensive (cette Unit la hait).
+		bool HasTarget(EntityId id) const noexcept { return m_targets.count(id) > 0; }
+
+		/// True si \p id est un attaquant (cette Unit est haie par lui).
+		bool HasHater(EntityId id) const noexcept { return m_haters.count(id) > 0; }
+
+		const std::unordered_set<EntityId>& Targets() const noexcept { return m_targets; }
+		const std::unordered_set<EntityId>& Haters() const noexcept { return m_haters; }
+
+		size_t TargetCount() const noexcept { return m_targets.size(); }
+		size_t HaterCount() const noexcept { return m_haters.size(); }
+
+		/// True si la Unit est engagee dans une relation hostile (cible ou attaquant).
+		bool IsEngaged() const noexcept { return !m_targets.empty() || !m_haters.empty(); }
+
+		/// Reset complet (typiquement appele par Unit::OnDespawn / OnReset
+		/// avant un cleanup symetrique global).
+		void Clear() noexcept
+		{
+			m_targets.clear();
+			m_haters.clear();
+		}
+
+	private:
+		std::unordered_set<EntityId> m_targets;
+		std::unordered_set<EntityId> m_haters;
+	};
+
+	/// Helper : etablit une relation hostile A -> B avec synchronisation
+	/// automatique des 2 cotes (idempotent).
+	///
+	/// \param actor   manager de l'agresseur
+	/// \param actorId EntityId de l'agresseur (pour s'inscrire dans target.haters)
+	/// \param target  manager de la cible
+	/// \param targetId EntityId de la cible (pour s'inscrire dans actor.targets)
+	inline void EngageHostile(HostileRefManager& actor, EntityId actorId,
+		HostileRefManager& target, EntityId targetId)
+	{
+		actor.AddTarget(targetId);
+		target.AddHater(actorId);
+	}
+
+	/// Helper : retire la relation A -> B symetriquement (idempotent).
+	inline void DisengageHostile(HostileRefManager& actor, EntityId actorId,
+		HostileRefManager& target, EntityId targetId)
+	{
+		actor.RemoveTarget(targetId);
+		target.RemoveHater(actorId);
+	}
+
+	/// Cleanup symetrique : retire \p deadId de tous les managers fournis
+	/// (a la fois cote m_targets et m_haters). Idempotent et sur si \p deadId
+	/// n'est present dans aucun manager.
+	///
+	/// Usage typique : `Unit::Die()` collecte les manager pointers depuis
+	/// les EntityId de m_haters U m_targets (via ObjectAccessor), puis appelle
+	/// ce helper.
+	///
+	/// \param deadId EntityId de l'unit qui meurt / despawn
+	/// \param affectedManagers managers qui peuvent contenir une reference a deadId
+	void CleanupOnDeath(EntityId deadId,
+		const std::vector<HostileRefManager*>& affectedManagers);
+}

--- a/src/shardd/combat/HostileRefManagerTests.cpp
+++ b/src/shardd/combat/HostileRefManagerTests.cpp
@@ -1,0 +1,230 @@
+// Wave 19 — HostileRefManager tests : pattern bidirectionnel cibles
+// (m_targets) + attaquants (m_haters), avec helpers EngageHostile /
+// DisengageHostile / CleanupOnDeath pour la synchronisation symetrique.
+//
+// Pattern aligne sur les autres tests entities/combat : asserts +
+// printf, pas de framework. Cible CTest : hostile_ref_manager_tests.
+
+#include "src/shardd/combat/HostileRefManager.h"
+
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::server::combat;
+using engine::server::EntityId;
+
+namespace
+{
+	/// Construction : 2 sets vides, IsEngaged false.
+	void TestHostileRefManagerEmpty()
+	{
+		HostileRefManager mgr;
+		assert(mgr.TargetCount() == 0);
+		assert(mgr.HaterCount() == 0);
+		assert(!mgr.IsEngaged());
+		assert(!mgr.HasTarget(42));
+		assert(!mgr.HasHater(42));
+		std::puts("[OK] TestHostileRefManagerEmpty");
+	}
+
+	/// AddTarget : 1 cible dans m_targets, m_haters vide, IsEngaged true.
+	void TestAddTarget()
+	{
+		HostileRefManager mgr;
+		mgr.AddTarget(100);
+		assert(mgr.TargetCount() == 1);
+		assert(mgr.HasTarget(100));
+		assert(mgr.HaterCount() == 0);
+		assert(mgr.IsEngaged());
+		std::puts("[OK] TestAddTarget");
+	}
+
+	/// AddHater : 1 attaquant dans m_haters, m_targets vide, IsEngaged true.
+	void TestAddHater()
+	{
+		HostileRefManager mgr;
+		mgr.AddHater(200);
+		assert(mgr.HaterCount() == 1);
+		assert(mgr.HasHater(200));
+		assert(mgr.TargetCount() == 0);
+		assert(mgr.IsEngaged());
+		std::puts("[OK] TestAddHater");
+	}
+
+	/// AddTarget idempotent : ajouter 2 fois le meme id -> 1 entry.
+	void TestAddTargetIdempotent()
+	{
+		HostileRefManager mgr;
+		mgr.AddTarget(50);
+		mgr.AddTarget(50);
+		mgr.AddTarget(50);
+		assert(mgr.TargetCount() == 1);
+		std::puts("[OK] TestAddTargetIdempotent");
+	}
+
+	/// RemoveTarget : retire bien la cible. No-op sur id inconnu.
+	void TestRemoveTarget()
+	{
+		HostileRefManager mgr;
+		mgr.AddTarget(100);
+		mgr.AddTarget(200);
+		mgr.RemoveTarget(100);
+		assert(mgr.TargetCount() == 1);
+		assert(!mgr.HasTarget(100));
+		assert(mgr.HasTarget(200));
+		// No-op sur id inconnu.
+		mgr.RemoveTarget(999);
+		assert(mgr.TargetCount() == 1);
+		std::puts("[OK] TestRemoveTarget");
+	}
+
+	/// Clear : vide les 2 listes, IsEngaged false.
+	void TestClear()
+	{
+		HostileRefManager mgr;
+		mgr.AddTarget(1);
+		mgr.AddTarget(2);
+		mgr.AddHater(10);
+		mgr.AddHater(20);
+		assert(mgr.IsEngaged());
+		mgr.Clear();
+		assert(mgr.TargetCount() == 0);
+		assert(mgr.HaterCount() == 0);
+		assert(!mgr.IsEngaged());
+		std::puts("[OK] TestClear");
+	}
+
+	/// EngageHostile : synchronisation automatique des 2 cotes A -> B.
+	/// A.targets contient B, B.haters contient A.
+	void TestEngageHostileSynchronization()
+	{
+		HostileRefManager a;
+		HostileRefManager b;
+		const EntityId idA = 1;
+		const EntityId idB = 2;
+
+		EngageHostile(a, idA, b, idB);
+
+		assert(a.HasTarget(idB));
+		assert(!a.HasHater(idB));
+		assert(b.HasHater(idA));
+		assert(!b.HasTarget(idA));
+		std::puts("[OK] TestEngageHostileSynchronization");
+	}
+
+	/// DisengageHostile : retire la paire des 2 cotes (inverse exact d'Engage).
+	void TestDisengageHostileSynchronization()
+	{
+		HostileRefManager a;
+		HostileRefManager b;
+		const EntityId idA = 1;
+		const EntityId idB = 2;
+
+		EngageHostile(a, idA, b, idB);
+		assert(a.HasTarget(idB) && b.HasHater(idA));
+
+		DisengageHostile(a, idA, b, idB);
+		assert(!a.HasTarget(idB));
+		assert(!b.HasHater(idA));
+		assert(a.TargetCount() == 0);
+		assert(b.HaterCount() == 0);
+		std::puts("[OK] TestDisengageHostileSynchronization");
+	}
+
+	/// CleanupOnDeath : retire deadId de tous les managers fournis,
+	/// cote targets ET cote haters. Idempotent et sur sur nullptr.
+	void TestCleanupOnDeathRemovesFromAllManagers()
+	{
+		HostileRefManager mgrA;  // hait deadId
+		HostileRefManager mgrB;  // est hai par deadId
+		HostileRefManager mgrC;  // pas de relation avec deadId
+		const EntityId deadId = 666;
+
+		// A hait deadId
+		mgrA.AddTarget(deadId);
+		mgrA.AddTarget(100);  // autre cible, ne doit pas etre touchee
+		// B est hai par deadId
+		mgrB.AddHater(deadId);
+		mgrB.AddHater(200);  // autre hater, ne doit pas etre touche
+		// C n'a aucune relation avec deadId, mais a d'autres relations
+		mgrC.AddTarget(300);
+		mgrC.AddHater(400);
+
+		std::vector<HostileRefManager*> managers = {&mgrA, &mgrB, &mgrC, nullptr};
+		CleanupOnDeath(deadId, managers);
+
+		// deadId est retire partout
+		assert(!mgrA.HasTarget(deadId));
+		assert(!mgrB.HasHater(deadId));
+
+		// Les autres relations sont preservees
+		assert(mgrA.HasTarget(100));
+		assert(mgrB.HasHater(200));
+		assert(mgrC.HasTarget(300));
+		assert(mgrC.HasHater(400));
+
+		// Idempotent : second appel ne casse rien
+		CleanupOnDeath(deadId, managers);
+		assert(mgrA.TargetCount() == 1);
+		assert(mgrB.HaterCount() == 1);
+		std::puts("[OK] TestCleanupOnDeathRemovesFromAllManagers");
+	}
+
+	/// Scenario realiste : 1 player vs 3 mobs. Le player tue mob1. Verifier
+	/// que mob1 n'est plus dans les m_haters du player, et que le player
+	/// n'est plus dans les m_targets de mob1 (mais mob2/mob3 conservent
+	/// le player en target).
+	void TestRealisticCombatScenario()
+	{
+		HostileRefManager player;
+		HostileRefManager mob1, mob2, mob3;
+		const EntityId pId = 1;
+		const EntityId m1 = 101, m2 = 102, m3 = 103;
+
+		// Les 3 mobs aggro le player
+		EngageHostile(mob1, m1, player, pId);
+		EngageHostile(mob2, m2, player, pId);
+		EngageHostile(mob3, m3, player, pId);
+
+		assert(player.HaterCount() == 3);
+		assert(player.HasHater(m1) && player.HasHater(m2) && player.HasHater(m3));
+		assert(mob1.HasTarget(pId));
+		assert(mob2.HasTarget(pId));
+		assert(mob3.HasTarget(pId));
+
+		// Player retourne le combat sur mob1 (cible offensive principale)
+		EngageHostile(player, pId, mob1, m1);
+		assert(player.HasTarget(m1));
+		assert(mob1.HasHater(pId));
+
+		// Player tue mob1 -> cleanup global
+		std::vector<HostileRefManager*> all = {&player, &mob1, &mob2, &mob3};
+		CleanupOnDeath(m1, all);
+
+		// mob1 disparait des relations
+		assert(!player.HasTarget(m1));  // plus de cible sur lui
+		assert(!player.HasHater(m1));   // plus d'attaquant
+		// mais mob2, mob3 toujours en aggro sur le player
+		assert(player.HasHater(m2));
+		assert(player.HasHater(m3));
+		assert(player.HaterCount() == 2);
+		std::puts("[OK] TestRealisticCombatScenario");
+	}
+}
+
+int main()
+{
+	TestHostileRefManagerEmpty();
+	TestAddTarget();
+	TestAddHater();
+	TestAddTargetIdempotent();
+	TestRemoveTarget();
+	TestClear();
+	TestEngageHostileSynchronization();
+	TestDisengageHostileSynchronization();
+	TestCleanupOnDeathRemovesFromAllManagers();
+	TestRealisticCombatScenario();
+	std::puts("All HostileRefManager tests passed");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Wave 19 complete `ThreatList` (Wave 8 [#576](https://github.com/tips-of-mine/LCDLLN-test/pull/576)) qui ne gere QUE la direction "qui me hait" (m_haters implicite). HostileRefManager ajoute le côté offensif (m_targets) et fournit les helpers de synchronisation symétrique entre les 2 listes.

C'est le **Wave 19 de la roadmap server-first** ([spec §4 Wave 19](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md)). Suit Wave 17 [#591](https://github.com/tips-of-mine/LCDLLN-test/pull/591) (mergée) et Wave 18 [#593](https://github.com/tips-of-mine/LCDLLN-test/pull/593) (en attente).

## Audit anti-doublon (règle 2026-05-11)

`grep "HostileRef\|HostileReference" src/` → 0 hit avant cette PR. Vrai gap. ThreatList existant (`src/shardd/combat/ThreatList.h`) reste inchangé.

## Conception

- **Composante d'Unit, pas singleton** : chaque Unit possède son propre `HostileRefManager`. Tests sans dépendance externe.
- **API duale** :
  - `AddTarget(id)` / `AddHater(id)` — manuel, pour les cas non-symétriques
  - `EngageHostile(actor, actorId, target, targetId)` — helper synchronisé
  - `DisengageHostile(...)` — retire symétriquement
  - `CleanupOnDeath(deadId, managers)` — retire deadId de tous les m_targets ET m_haters des managers fournis
- **Cleanup global** : le caller (typiquement `Unit::Die()`) collecte les managers affectés via `ObjectAccessor` (Wave 19 livré) et passe le vector.

## API exemple

\`\`\`cpp
HostileRefManager player;
HostileRefManager mob1, mob2;
// Mob1 et Mob2 aggro le player
EngageHostile(mob1, m1Id, player, pId);
EngageHostile(mob2, m2Id, player, pId);
// Player.HaterCount() == 2
// mob1.HasTarget(pId) == true

// Player tue Mob1
CleanupOnDeath(m1Id, {&player, &mob1, &mob2});
// player.HasHater(m1Id) == false, player.HasHater(m2Id) == true
\`\`\`

## Test plan

| Cible CTest | Cas |
|-------------|-----|
| `hostile_ref_manager_tests` | 10 cas : empty, AddTarget, AddHater, idempotence, Remove, Clear, EngageHostile sync, DisengageHostile sync, CleanupOnDeath (incl. nullptr safe + idempotent), scenario realiste 1 player vs 3 mobs kill flow |

CI sur cette PR :
- [ ] Linux build + ctest (gate actif depuis [#592](https://github.com/tips-of-mine/LCDLLN-test/pull/592))
- [ ] Windows build

## Limites volontaires Wave 19

- **Pas d'integration dans Unit (Wave 17)** — `Unit::Die()` ne câble pas encore `HostileRefManager::CleanupOnDeath()`. Ce wiring sera un Wave 19b dedie (ou plus tard quand l'ObjectAccessor sera étendu pour exposer un iter sur les managers).
- **Pas d'integration avec ThreatList** — les 2 systèmes vivent côte à côte. Le coupling viendra naturellement quand l'API combat sera unifiée.
- **Pas de notification réseau** — c'est server-side pur, pas wire-affected.

## Doc

CODEBASE_MAP.md non touché dans cette PR (la section §18 sur `src/shardd/combat/` n'existe pas explicitement — section globale §18 sur `src/shardd/` mentionne combat).

## Déploiement

⚠️ **REDÉPLOIEMENT SHARD REQUIS** — nouveau code combat côté shard. Pas de wire-breaking, pas de migration DB, pas d'impact client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)