### PR TITLE
feat(pools): Wave 20 -- nested pools + runtime state persistence

### DIFF
--- a/sql/migrations/0059_pool_extensions.sql
+++ b/sql/migrations/0059_pool_extensions.sql
@@ -1,0 +1,37 @@
+-- 0059 — Wave 20 Pool extensions : nested pools (table pool_pool) +
+-- runtime state persistence (table pool_member_state).
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+
+-- Table pool_pool : permet a un pool d'avoir des sous-pools comme entries.
+-- Quand RollImpl tire un entry "nested", il recurse dans le child_pool_id.
+-- Cycle detection cote moteur (PoolManager.h), pas au niveau DB.
+CREATE TABLE IF NOT EXISTS pool_pool
+(
+	parent_pool_id  INT UNSIGNED NOT NULL,
+	child_pool_id   INT UNSIGNED NOT NULL,
+	weight          FLOAT NOT NULL DEFAULT 1.0,
+	PRIMARY KEY (parent_pool_id, child_pool_id),
+	-- Index inverse pour query "quels parents pointent vers ce pool ?"
+	-- (utile lors d'un cleanup/refactor de la hierarchie).
+	KEY idx_pool_pool_child (child_pool_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table pool_member_state : etat runtime persiste des membres d'une pool.
+-- Permet de survivre a un reboot shard sans tout re-roller (les rare
+-- spawns deja kill restent dead jusqu'a leur respawn_at).
+CREATE TABLE IF NOT EXISTS pool_member_state
+(
+	pool_id        INT UNSIGNED NOT NULL,
+	spawn_id       INT UNSIGNED NOT NULL,
+	status         TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Alive, 1=Dead, 2=Respawning
+	respawn_at_sec BIGINT NOT NULL DEFAULT 0,             -- Unix timestamp seconds, 0 = aucun
+	updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	               ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (pool_id, spawn_id),
+	-- Index pour query par status (ex : "trouve tous les spawns Respawning
+	-- a re-creer au prochain tick").
+	KEY idx_pool_member_state_status (status),
+	-- Index par respawn timer (purge cleanup ou tick respawn scheduler).
+	KEY idx_pool_member_state_respawn (respawn_at_sec)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -476,6 +476,16 @@ elseif(UNIX)
   lcdlln_add_simple_test(pool_manager_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolManagerTests.cpp)
 
+  # Wave 20 (CMANGOS.22 step 2) : Pool nested + persistence.
+  # PoolManager.h gagne le support nested + cycle detection (backward compat
+  # avec les pools simples : si Pool.nested est vide, comportement identique
+  # a la Phase 4.22a). PoolStatePersistence.h est header-only (interface +
+  # InMemoryPoolStateStore pour tests).
+  lcdlln_add_simple_test(pool_nested_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolNestedTests.cpp)
+  lcdlln_add_simple_test(pool_persistence_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/pools/PoolPersistenceTests.cpp)
+
   # CMANGOS.08 (Phase 5.08a) : ArenaTeam + ELO (header-only).
   lcdlln_add_simple_test(arena_team_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/arena/ArenaTeamTests.cpp)

--- a/src/shardd/pools/PoolManager.h
+++ b/src/shardd/pools/PoolManager.h
@@ -1,13 +1,18 @@
 #pragma once
-// CMANGOS.22 (Phase 4.22a) — PoolManager : weighted random spawn pour
-// rare spawns. Une pool a N candidats avec poids et un slot maxActive.
-// L'algorithm choisit weighted-random sans replacement parmi les
-// candidats.
+// CMANGOS.22 — PoolManager : weighted random spawn pour rare spawns.
+// Une pool a N candidats avec poids et un slot maxActive. L'algorithme
+// choisit weighted-random sans replacement parmi les candidats.
+//
+// Phase 4.22a (mergee) : pools simples (entries = SpawnId).
+// Wave 20 : nested pools — une entry peut etre un SpawnId OU une
+// reference vers un autre PoolId (table pool_pool). Roll() recurse
+// avec cycle detection (visited set + profondeur max).
 
 #include <algorithm>
 #include <cstdint>
 #include <random>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace engine::server::pools
@@ -21,12 +26,26 @@ namespace engine::server::pools
 		float   weight  = 1.0f;  ///< plus eleve = plus probable
 	};
 
+	/// Wave 20 : entry "nested" — pointe vers un autre pool. Quand pickee,
+	/// Roll() recurse dans le pool enfant et flatten le resultat.
+	struct NestedPoolEntry
+	{
+		PoolId childPoolId = 0;
+		float  weight      = 1.0f;
+	};
+
 	struct Pool
 	{
-		PoolId                 poolId     = 0;
-		uint32_t               maxActive  = 1;
-		std::vector<PoolEntry> entries;
+		PoolId                       poolId    = 0;
+		uint32_t                     maxActive = 1;
+		std::vector<PoolEntry>       entries;  ///< spawns directs
+		std::vector<NestedPoolEntry> nested;   ///< sous-pools (Wave 20)
 	};
+
+	/// Profondeur maximale de recursion pour les nested pools. Si depassee,
+	/// la branche nestee est skip silent (defense contre cycles non
+	/// detectables ou pyramides excessives).
+	inline constexpr uint32_t kMaxNestedPoolDepth = 8;
 
 	class PoolManager
 	{
@@ -36,45 +55,79 @@ namespace engine::server::pools
 		void Register(Pool pool) { m_pools[pool.poolId] = std::move(pool); }
 
 		/// Roll \p count spawns parmi la pool \p poolId. Retourne les
-		/// SpawnIds choisis (sans replacement). Si count > entries.size(),
-		/// retourne tous les entries. Si pool inconnue ou maxActive=0,
-		/// retourne vide.
+		/// SpawnIds choisis (sans replacement pour entries directs ; les
+		/// nested pools sont independants au sein de leur propre Roll).
+		///
+		/// Si une nested entry est pickee, recurse dans le pool enfant.
+		/// Cycle detection via visited set + depth limit (kMaxNestedPoolDepth).
+		///
+		/// Compatible avec les pools "simples" (nested vide) : comportement
+		/// identique a la Phase 4.22a — backward compat strict.
 		std::vector<SpawnId> Roll(PoolId poolId, std::mt19937& rng) const
 		{
-			auto it = m_pools.find(poolId);
-			if (it == m_pools.end()) return {};
-			const Pool& p = it->second;
-			if (p.maxActive == 0 || p.entries.empty()) return {};
-
-			// Copy + weighted shuffle.
-			std::vector<PoolEntry> copy = p.entries;
+			std::unordered_set<PoolId> visited;
 			std::vector<SpawnId> out;
-			out.reserve(std::min<size_t>(p.maxActive, copy.size()));
-
-			for (uint32_t i = 0; i < p.maxActive && !copy.empty(); ++i)
-			{
-				float total = 0.0f;
-				for (const auto& e : copy) total += std::max(0.0f, e.weight);
-				if (total <= 0.0f) break;
-
-				std::uniform_real_distribution<float> d(0.0f, total);
-				const float pick = d(rng);
-				float acc = 0.0f;
-				size_t pickedIdx = 0;
-				for (size_t k = 0; k < copy.size(); ++k)
-				{
-					acc += std::max(0.0f, copy[k].weight);
-					if (pick <= acc) { pickedIdx = k; break; }
-				}
-				out.push_back(copy[pickedIdx].spawnId);
-				copy.erase(copy.begin() + pickedIdx);  // sans replacement
-			}
+			RollImpl(poolId, rng, /*depth*/0, visited, out);
 			return out;
 		}
 
 		size_t PoolCount() const noexcept { return m_pools.size(); }
 
 	private:
+		/// Recursion interne avec cycle detection.
+		void RollImpl(PoolId poolId, std::mt19937& rng, uint32_t depth,
+			std::unordered_set<PoolId>& visited, std::vector<SpawnId>& out) const
+		{
+			// Cycle ou profondeur excessive : skip silent.
+			if (depth >= kMaxNestedPoolDepth) return;
+			if (!visited.insert(poolId).second) return; // deja visite -> cycle
+
+			auto it = m_pools.find(poolId);
+			if (it == m_pools.end()) return;
+			const Pool& p = it->second;
+			if (p.maxActive == 0) return;
+			if (p.entries.empty() && p.nested.empty()) return;
+
+			// Combiner entries + nested dans une liste de "candidats" tiree
+			// sans replacement. Tag : Spawn ou Nested.
+			enum class Kind { Spawn, Nested };
+			struct Candidate { Kind kind; SpawnId spawnId; PoolId childPoolId; float weight; };
+			std::vector<Candidate> candidates;
+			candidates.reserve(p.entries.size() + p.nested.size());
+			for (const auto& e : p.entries)
+				candidates.push_back({Kind::Spawn, e.spawnId, 0, std::max(0.0f, e.weight)});
+			for (const auto& n : p.nested)
+				candidates.push_back({Kind::Nested, 0, n.childPoolId, std::max(0.0f, n.weight)});
+
+			for (uint32_t i = 0; i < p.maxActive && !candidates.empty(); ++i)
+			{
+				float total = 0.0f;
+				for (const auto& c : candidates) total += c.weight;
+				if (total <= 0.0f) break;
+
+				std::uniform_real_distribution<float> d(0.0f, total);
+				const float pick = d(rng);
+				float acc = 0.0f;
+				size_t pickedIdx = 0;
+				for (size_t k = 0; k < candidates.size(); ++k)
+				{
+					acc += candidates[k].weight;
+					if (pick <= acc) { pickedIdx = k; break; }
+				}
+
+				const Candidate& chosen = candidates[pickedIdx];
+				if (chosen.kind == Kind::Spawn)
+				{
+					out.push_back(chosen.spawnId);
+				}
+				else // Nested
+				{
+					RollImpl(chosen.childPoolId, rng, depth + 1, visited, out);
+				}
+				candidates.erase(candidates.begin() + pickedIdx);  // sans replacement
+			}
+		}
+
 		std::unordered_map<PoolId, Pool> m_pools;
 	};
 }

--- a/src/shardd/pools/PoolNestedTests.cpp
+++ b/src/shardd/pools/PoolNestedTests.cpp
@@ -1,0 +1,205 @@
+// Wave 20 — Pool nested tests : pools imbriques (pool_pool) + cycle
+// detection. Le PoolManager existant reste backward compatible : si
+// `nested` est vide, comportement identique a la Phase 4.22a.
+
+#include "src/shardd/pools/PoolManager.h"
+#include "src/shared/core/Log.h"
+
+#include <algorithm>
+#include <random>
+#include <unordered_set>
+
+namespace
+{
+	using engine::server::pools::NestedPoolEntry;
+	using engine::server::pools::Pool;
+	using engine::server::pools::PoolEntry;
+	using engine::server::pools::PoolManager;
+	using engine::server::pools::SpawnId;
+
+	/// Backward compat : pool sans nested -> comportement Phase 4.22a.
+	bool TestBackwardCompatNoNested()
+	{
+		PoolManager mgr;
+		Pool p;
+		p.poolId = 1;
+		p.maxActive = 1;
+		p.entries = {{100, 1.0f}, {200, 1.0f}, {300, 1.0f}};
+		// p.nested est vide par defaut.
+		mgr.Register(p);
+		std::mt19937 rng(42);
+		auto out = mgr.Roll(1, rng);
+		if (out.size() != 1) return false;
+		if (out[0] != 100 && out[0] != 200 && out[0] != 300) return false;
+		LOG_INFO(Core, "[PoolNestedTests] backward compat no-nested OK");
+		return true;
+	}
+
+	/// Pool parent avec uniquement une nested entry -> recurse dans le
+	/// child et retourne ses spawns. Aucun spawn direct dans le parent.
+	bool TestSingleNestedRecurse()
+	{
+		PoolManager mgr;
+		Pool child;
+		child.poolId = 10;
+		child.maxActive = 2;
+		child.entries = {{500, 1.0f}, {501, 1.0f}};
+		mgr.Register(child);
+
+		Pool parent;
+		parent.poolId = 1;
+		parent.maxActive = 1;  // 1 entry pickee dans le parent (qui est la nested)
+		parent.nested = {{10, 1.0f}};
+		mgr.Register(parent);
+
+		std::mt19937 rng(42);
+		auto out = mgr.Roll(1, rng);
+		// Le parent pick l'entry nested -> recurse child (maxActive=2) -> 2 spawns.
+		if (out.size() != 2) return false;
+		// Les spawns doivent etre 500 et 501.
+		std::sort(out.begin(), out.end());
+		if (out[0] != 500 || out[1] != 501) return false;
+		LOG_INFO(Core, "[PoolNestedTests] single nested recurse OK");
+		return true;
+	}
+
+	/// Mix entries directs + nested. Avec maxActive=1, on pick UN seul
+	/// candidat (spawn direct OU nested) -> output 1 ou plusieurs spawns
+	/// selon le tirage.
+	bool TestMixDirectAndNested()
+	{
+		PoolManager mgr;
+		Pool child;
+		child.poolId = 10;
+		child.maxActive = 3;  // si nested pickee, recurse fournit 3 spawns
+		child.entries = {{500, 1.0f}, {501, 1.0f}, {502, 1.0f}};
+		mgr.Register(child);
+
+		Pool parent;
+		parent.poolId = 1;
+		parent.maxActive = 1;
+		parent.entries = {{100, 1.0f}};
+		parent.nested = {{10, 1.0f}};
+		mgr.Register(parent);
+
+		std::mt19937 rng(7);
+		auto out = mgr.Roll(1, rng);
+		// Soit 1 spawn (100 si direct pickee) soit 3 spawns (500/501/502
+		// si nested pickee).
+		if (out.size() != 1 && out.size() != 3) return false;
+		LOG_INFO(Core, "[PoolNestedTests] mix direct/nested OK");
+		return true;
+	}
+
+	/// Cycle simple A -> B -> A : detection via visited set, skip silent.
+	/// Le parent retourne juste ses spawns directs s'il en a, ou vide.
+	bool TestCycleDetection2Pools()
+	{
+		PoolManager mgr;
+		Pool a;
+		a.poolId = 1;
+		a.maxActive = 1;
+		a.entries = {{100, 1.0f}};
+		a.nested = {{2, 1.0f}};
+		mgr.Register(a);
+
+		Pool b;
+		b.poolId = 2;
+		b.maxActive = 1;
+		b.entries = {{200, 1.0f}};
+		b.nested = {{1, 1.0f}};  // cycle vers A
+		mgr.Register(b);
+
+		// Avec ce setup et n'importe quel rng, on ne doit JAMAIS crasher
+		// ni boucler infiniment. Le resultat doit etre un sous-ensemble
+		// de {100, 200}.
+		std::mt19937 rng(99);
+		auto out = mgr.Roll(1, rng);
+		// Verification : pas de crash, et tous les spawns retournes sont
+		// dans {100, 200}.
+		for (auto s : out)
+		{
+			if (s != 100 && s != 200) return false;
+		}
+		LOG_INFO(Core, "[PoolNestedTests] cycle 2 pools OK (size={})", out.size());
+		return true;
+	}
+
+	/// Cycle 3 pools : A -> B -> C -> A. Meme garantie : pas de crash,
+	/// resultat dans {100, 200, 300}.
+	bool TestCycleDetection3Pools()
+	{
+		PoolManager mgr;
+		Pool a; a.poolId = 1; a.maxActive = 1; a.entries = {{100, 1.0f}}; a.nested = {{2, 1.0f}}; mgr.Register(a);
+		Pool b; b.poolId = 2; b.maxActive = 1; b.entries = {{200, 1.0f}}; b.nested = {{3, 1.0f}}; mgr.Register(b);
+		Pool c; c.poolId = 3; c.maxActive = 1; c.entries = {{300, 1.0f}}; c.nested = {{1, 1.0f}}; mgr.Register(c);
+
+		std::mt19937 rng(123);
+		auto out = mgr.Roll(1, rng);
+		for (auto s : out)
+		{
+			if (s != 100 && s != 200 && s != 300) return false;
+		}
+		LOG_INFO(Core, "[PoolNestedTests] cycle 3 pools OK (size={})", out.size());
+		return true;
+	}
+
+	/// Nested pointe vers un pool inexistant -> skip silent, parent
+	/// retourne juste ses spawns directs.
+	bool TestNestedUnknownPool()
+	{
+		PoolManager mgr;
+		Pool a;
+		a.poolId = 1;
+		a.maxActive = 2;  // pick 2 candidats sur 2 disponibles
+		a.entries = {{100, 1.0f}};
+		a.nested = {{999, 1.0f}};  // pool 999 n'existe pas
+		mgr.Register(a);
+
+		std::mt19937 rng(42);
+		auto out = mgr.Roll(1, rng);
+		// Spawn 100 obligatoirement dans le resultat (l'autre candidat
+		// est nested vers 999 qui est skip silent).
+		// Resultat : soit [100] (si nested pickee 1er + 100 pickee 2e) soit [100]
+		// (si 100 pickee 1er, nested pickee 2e mais 999 inexistant).
+		bool has100 = std::find(out.begin(), out.end(), 100) != out.end();
+		if (!has100) return false;
+		LOG_INFO(Core, "[PoolNestedTests] nested unknown pool OK");
+		return true;
+	}
+
+	/// Pool a sans entries ni nested -> retourne vide.
+	bool TestEmptyPoolBothFields()
+	{
+		PoolManager mgr;
+		Pool a;
+		a.poolId = 1;
+		a.maxActive = 5;
+		// entries et nested vides
+		mgr.Register(a);
+
+		std::mt19937 rng(1);
+		auto out = mgr.Roll(1, rng);
+		if (!out.empty()) return false;
+		LOG_INFO(Core, "[PoolNestedTests] empty both fields OK");
+		return true;
+	}
+}
+
+int main()
+{
+	bool ok = true;
+	ok &= TestBackwardCompatNoNested();
+	ok &= TestSingleNestedRecurse();
+	ok &= TestMixDirectAndNested();
+	ok &= TestCycleDetection2Pools();
+	ok &= TestCycleDetection3Pools();
+	ok &= TestNestedUnknownPool();
+	ok &= TestEmptyPoolBothFields();
+
+	if (ok)
+		LOG_INFO(Core, "[PoolNestedTests] All tests passed");
+	else
+		LOG_ERROR(Core, "[PoolNestedTests] FAIL");
+	return ok ? 0 : 1;
+}

--- a/src/shardd/pools/PoolPersistenceTests.cpp
+++ b/src/shardd/pools/PoolPersistenceTests.cpp
@@ -1,0 +1,146 @@
+// Wave 20 — Pool persistence tests : InMemoryPoolStateStore round-trip
+// + LoadByPool filtering. L'impl MySQL sera testee via integration
+// tests separes (exclus de la CI Linux par exemple, ou couverts par
+// db_layer_tests).
+
+#include "src/shardd/pools/PoolStatePersistence.h"
+#include "src/shared/core/Log.h"
+
+#include <algorithm>
+
+namespace
+{
+	using engine::server::pools::InMemoryPoolStateStore;
+	using engine::server::pools::PoolMemberState;
+	using engine::server::pools::PoolSpawnStatus;
+
+	/// Empty store : LoadAll vide, LoadByPool vide.
+	bool TestEmptyStore()
+	{
+		InMemoryPoolStateStore store;
+		if (!store.LoadAll().empty()) return false;
+		if (!store.LoadByPool(42).empty()) return false;
+		if (store.Size() != 0) return false;
+		LOG_INFO(Core, "[PoolPersistenceTests] empty store OK");
+		return true;
+	}
+
+	/// Save 3 entries -> LoadAll retourne 3 entries identiques (champs preserves).
+	bool TestSaveLoadRoundtrip()
+	{
+		InMemoryPoolStateStore store;
+		std::vector<PoolMemberState> in = {
+			{1, 100, PoolSpawnStatus::Alive,      0},
+			{1, 101, PoolSpawnStatus::Dead,       1000000},
+			{2, 200, PoolSpawnStatus::Respawning, 2000000},
+		};
+		if (!store.SaveAll(in)) return false;
+		if (store.Size() != 3) return false;
+
+		auto out = store.LoadAll();
+		if (out.size() != 3) return false;
+
+		// Tri pour comparaison deterministe.
+		std::sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
+			if (a.poolId != b.poolId) return a.poolId < b.poolId;
+			return a.spawnId < b.spawnId;
+		});
+
+		if (out[0].poolId != 1 || out[0].spawnId != 100
+			|| out[0].status != PoolSpawnStatus::Alive
+			|| out[0].respawnAtSec != 0) return false;
+		if (out[1].poolId != 1 || out[1].spawnId != 101
+			|| out[1].status != PoolSpawnStatus::Dead
+			|| out[1].respawnAtSec != 1000000) return false;
+		if (out[2].poolId != 2 || out[2].spawnId != 200
+			|| out[2].status != PoolSpawnStatus::Respawning
+			|| out[2].respawnAtSec != 2000000) return false;
+		LOG_INFO(Core, "[PoolPersistenceTests] save/load roundtrip OK");
+		return true;
+	}
+
+	/// Upsert : sauver 2x le meme (poolId, spawnId) -> 1 entry, derniere
+	/// valeur preservee.
+	bool TestUpsertOverwrite()
+	{
+		InMemoryPoolStateStore store;
+		std::vector<PoolMemberState> first = {
+			{1, 100, PoolSpawnStatus::Alive, 0},
+		};
+		std::vector<PoolMemberState> second = {
+			{1, 100, PoolSpawnStatus::Dead, 9999},
+		};
+		store.SaveAll(first);
+		store.SaveAll(second);
+
+		if (store.Size() != 1) return false;
+		auto out = store.LoadAll();
+		if (out.size() != 1) return false;
+		if (out[0].status != PoolSpawnStatus::Dead) return false;
+		if (out[0].respawnAtSec != 9999) return false;
+		LOG_INFO(Core, "[PoolPersistenceTests] upsert overwrite OK");
+		return true;
+	}
+
+	/// LoadByPool filtre par pool_id : seuls les entries de ce pool sont retournes.
+	bool TestLoadByPool()
+	{
+		InMemoryPoolStateStore store;
+		store.SaveAll({
+			{1, 100, PoolSpawnStatus::Alive, 0},
+			{1, 101, PoolSpawnStatus::Dead, 100},
+			{2, 200, PoolSpawnStatus::Alive, 0},
+			{2, 201, PoolSpawnStatus::Dead, 200},
+			{3, 300, PoolSpawnStatus::Respawning, 300},
+		});
+
+		auto pool1 = store.LoadByPool(1);
+		if (pool1.size() != 2) return false;
+		for (const auto& s : pool1)
+			if (s.poolId != 1) return false;
+
+		auto pool2 = store.LoadByPool(2);
+		if (pool2.size() != 2) return false;
+
+		auto pool3 = store.LoadByPool(3);
+		if (pool3.size() != 1) return false;
+		if (pool3[0].status != PoolSpawnStatus::Respawning) return false;
+
+		auto pool42 = store.LoadByPool(42);
+		if (!pool42.empty()) return false;
+		LOG_INFO(Core, "[PoolPersistenceTests] LoadByPool filter OK");
+		return true;
+	}
+
+	/// Clear : vide tout, Size() retombe a 0.
+	bool TestClear()
+	{
+		InMemoryPoolStateStore store;
+		store.SaveAll({
+			{1, 100, PoolSpawnStatus::Alive, 0},
+			{1, 101, PoolSpawnStatus::Dead, 0},
+		});
+		if (store.Size() != 2) return false;
+		store.Clear();
+		if (store.Size() != 0) return false;
+		if (!store.LoadAll().empty()) return false;
+		LOG_INFO(Core, "[PoolPersistenceTests] clear OK");
+		return true;
+	}
+}
+
+int main()
+{
+	bool ok = true;
+	ok &= TestEmptyStore();
+	ok &= TestSaveLoadRoundtrip();
+	ok &= TestUpsertOverwrite();
+	ok &= TestLoadByPool();
+	ok &= TestClear();
+
+	if (ok)
+		LOG_INFO(Core, "[PoolPersistenceTests] All tests passed");
+	else
+		LOG_ERROR(Core, "[PoolPersistenceTests] FAIL");
+	return ok ? 0 : 1;
+}

--- a/src/shardd/pools/PoolStatePersistence.h
+++ b/src/shardd/pools/PoolStatePersistence.h
@@ -1,0 +1,99 @@
+#pragma once
+// Wave 20 — Pool runtime state persistence : permet de sauvegarder
+// l'etat des spawns (alive/dead/respawning) et de le recharger au
+// reboot du shard, evitant un re-roll global qui briserait l'experience
+// de joueurs ayant deja kill un rare spawn.
+//
+// Conception : 2 couches.
+// - IPoolStateStore : interface abstraite (Save/Load).
+// - InMemoryPoolStateStore : impl pour tests (pas de DB).
+//
+// L'impl Mysql sera dans src/masterd/pools/MysqlPoolStateStore.h/.cpp
+// (a venir Wave 20b ou plus tard, hors scope strict de cette PR).
+
+#include "src/shardd/pools/PoolManager.h"
+
+#include <chrono>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::pools
+{
+	/// Statut runtime d'un spawn dans une pool.
+	enum class PoolSpawnStatus : uint8_t
+	{
+		Alive      = 0,  ///< spawn actif dans le monde
+		Dead       = 1,  ///< tue ou despawn, attend respawn timer
+		Respawning = 2,  ///< timer ecoule, spawn en cours de re-creation
+	};
+
+	/// Etat persistant d'un membre d'une pool. Cle unique : (poolId, spawnId).
+	struct PoolMemberState
+	{
+		PoolId          poolId      = 0;
+		SpawnId         spawnId     = 0;
+		PoolSpawnStatus status      = PoolSpawnStatus::Dead;
+		/// Timestamp Unix (secondes) auquel le respawn doit avoir lieu.
+		/// 0 = pas de respawn programme (ex : status Alive).
+		int64_t         respawnAtSec = 0;
+	};
+
+	/// Interface : impl MySQL ou InMemory selon le contexte.
+	class IPoolStateStore
+	{
+	public:
+		virtual ~IPoolStateStore() = default;
+
+		/// Sauve l'etat de tous les membres fournis (upsert par cle (poolId, spawnId)).
+		/// Retourne true si OK, false si erreur (logged par l'impl).
+		virtual bool SaveAll(const std::vector<PoolMemberState>& states) = 0;
+
+		/// Charge tous les etats persistes. Vide si store vide.
+		virtual std::vector<PoolMemberState> LoadAll() = 0;
+
+		/// Charge l'etat d'un membre specifique. Vide si absent.
+		virtual std::vector<PoolMemberState> LoadByPool(PoolId poolId) = 0;
+	};
+
+	/// Impl in-memory pour tests. Clef de stockage : 64 bits (poolId << 32) | spawnId.
+	class InMemoryPoolStateStore final : public IPoolStateStore
+	{
+	public:
+		bool SaveAll(const std::vector<PoolMemberState>& states) override
+		{
+			for (const auto& s : states)
+				m_store[Key(s.poolId, s.spawnId)] = s;
+			return true;
+		}
+
+		std::vector<PoolMemberState> LoadAll() override
+		{
+			std::vector<PoolMemberState> out;
+			out.reserve(m_store.size());
+			for (const auto& kv : m_store)
+				out.push_back(kv.second);
+			return out;
+		}
+
+		std::vector<PoolMemberState> LoadByPool(PoolId poolId) override
+		{
+			std::vector<PoolMemberState> out;
+			for (const auto& kv : m_store)
+				if (kv.second.poolId == poolId)
+					out.push_back(kv.second);
+			return out;
+		}
+
+		size_t Size() const noexcept { return m_store.size(); }
+		void Clear() noexcept { m_store.clear(); }
+
+	private:
+		static uint64_t Key(PoolId p, SpawnId s) noexcept
+		{
+			return (static_cast<uint64_t>(p) << 32) | static_cast<uint64_t>(s);
+		}
+
+		std::unordered_map<uint64_t, PoolMemberState> m_store;
+	};
+}


### PR DESCRIPTION
## Summary

Wave 20 étend `PoolManager` (Phase 4.22a, header-only) avec **nested pools** + **runtime state persistence** :

- **Nesting** : un pool peut contenir des références vers d'autres pools. Quand `Roll()` pick une `NestedPoolEntry`, il recurse dans le child pool et flatten le résultat.
- **Cycle detection** : visited set + `kMaxNestedPoolDepth=8` — les cycles A→B→A ou pyramides excessives sont skip silent (jamais de crash ni boucle infinie).
- **Persistence scaffolding** : `IPoolStateStore` interface + `InMemoryPoolStateStore` impl (pour tests). L'impl MySQL suivra dans une Wave 20b dédiée (ou intégrée plus tard via `src/masterd/pools/MysqlPoolStateStore`).

C'est le **Wave 20 de la roadmap server-first** ([spec §4 Wave 20](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md)).

## Audit anti-doublon (règle 2026-05-11)

\`grep "pool_pool\|pool_member_state\|nested\|NestedPool" src/ sql/migrations/\` → 0 hit avant cette PR. PoolManager Phase 4.22a reste **strict backward compat** : si `Pool.nested` est vide, comportement identique. Tests existants `pool_manager_tests` non touchés.

## Migration DB

\`sql/migrations/0059_pool_extensions.sql\` :
- \`pool_pool(parent_pool_id, child_pool_id, weight)\` — relation parent-enfant
- \`pool_member_state(pool_id, spawn_id, status, respawn_at_sec, updated_at)\` — état runtime persisté
- Idempotente (\`CREATE TABLE IF NOT EXISTS\`), rejouable sans erreur

## Fichiers

| Fichier | Rôle |
|---------|------|
| `src/shardd/pools/PoolManager.h` (modifié) | Ajoute `NestedPoolEntry`, `kMaxNestedPoolDepth`, étend `Roll()` avec recursion + cycle detection |
| `src/shardd/pools/PoolStatePersistence.h` (nouveau) | `PoolSpawnStatus`, `PoolMemberState`, `IPoolStateStore`, `InMemoryPoolStateStore` |
| `src/shardd/pools/PoolNestedTests.cpp` (nouveau) | 7 cas dont cycle 2 pools, cycle 3 pools, unknown nested |
| `src/shardd/pools/PoolPersistenceTests.cpp` (nouveau) | 5 cas dont upsert overwrite, LoadByPool filter |
| `sql/migrations/0059_pool_extensions.sql` (nouveau) | 2 tables idempotentes |

## Test plan

- [ ] CI Linux build + ctest (gate actif depuis #592)
- [ ] `pool_manager_tests` (existant) toujours vert (non-régression backward compat)
- [ ] `pool_nested_tests` (nouveau) vert
- [ ] `pool_persistence_tests` (nouveau) vert
- [ ] CI Windows compile

## Limites volontaires Wave 20

- **Pas d'impl MySQL** — `MysqlPoolStateStore` viendra plus tard via `src/masterd/pools/` (suit le pattern Wave 5/10 stores).
- **Pas de wiring runtime** — `PoolManagerRuntime.cpp` n'utilise pas encore PoolStatePersistence ; le caller doit appeler SaveAll/LoadAll manuellement. L'intégration tick respawn scheduler sera une Wave dédiée.
- **Pas de migration des seeds** — `pool_template` et `pool_creature` existaient déjà (Wave 6 #573) ; cette PR n'altère pas leurs données, ajoute juste les 2 nouvelles tables.

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR (master + shard) REQUIS** — migration `0059_pool_extensions.sql` + binaire shard étendu. Pas de wire-breaking, pas d'impact client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)