### PR TITLE
feat(groups): Wave 22 -- Groups master-side + LootRule 4 impls

### DIFF
--- a/sql/migrations/0060_groups.sql
+++ b/sql/migrations/0060_groups.sql
@@ -1,0 +1,53 @@
+-- 0060 — Wave 22 Groups master-side : groupes (party/raid) + members + audit
+-- des loot rolls. Master-side car les groupes peuvent etre cross-shard
+-- (raid future).
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+
+-- Table groups : 1 ligne par groupe actif (party ou raid). Disband =
+-- DELETE (cascade member rows via FK ON DELETE CASCADE).
+CREATE TABLE IF NOT EXISTS groups
+(
+	group_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	group_type   TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Party, 1=Raid
+	leader_id    BIGINT UNSIGNED NOT NULL,
+	loot_method  TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=FFA, 1=RR, 2=ML, 3=NBG
+	created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (group_id),
+	KEY idx_groups_leader (leader_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table group_members : (group_id, player_id) avec role optionnel.
+-- ON DELETE CASCADE assure le cleanup quand un groupe est dissolved.
+CREATE TABLE IF NOT EXISTS group_members
+(
+	group_id    BIGINT UNSIGNED NOT NULL,
+	player_id   BIGINT UNSIGNED NOT NULL,
+	role        TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Unknown, 1=Tank, 2=Heal, 3=Dps
+	joined_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (group_id, player_id),
+	-- Un player ne peut etre que dans 1 groupe a la fois : index unique
+	-- sur player_id pour enforce cette contrainte au niveau DB aussi.
+	UNIQUE KEY uniq_group_members_player (player_id),
+	KEY idx_group_members_group (group_id),
+	CONSTRAINT fk_group_members_group
+		FOREIGN KEY (group_id) REFERENCES groups (group_id)
+		ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table group_loot_rolls : audit des decisions roll (Need/Greed/Pass) pour
+-- le LootMethod NeedBeforeGreed. Permet de revisiter une dispute ulterieure.
+-- Pas de FK vers groups (un loot roll peut survivre au disband group pour
+-- conserver l'historique audit).
+CREATE TABLE IF NOT EXISTS group_loot_rolls
+(
+	roll_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	group_id    BIGINT UNSIGNED NOT NULL,
+	item_id     BIGINT UNSIGNED NOT NULL,
+	player_id   BIGINT UNSIGNED NOT NULL,
+	choice      TINYINT UNSIGNED NOT NULL,  -- 0=Pass, 1=Greed, 2=Need
+	rolled_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (roll_id),
+	KEY idx_group_loot_rolls_group (group_id),
+	KEY idx_group_loot_rolls_item (item_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -552,6 +552,14 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/loot/LootTableTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/loot/LootTable.cpp)
 
+  # Wave 22 (CMANGOS.15 + CMANGOS.17 step 2) : Groups master-side +
+  # LootRule 4 impls (FFA, RoundRobin, MasterLooter, NeedBeforeGreed).
+  # Header-only (Group + GroupManager + ILootRule + concrete impls).
+  lcdlln_add_simple_test(group_manager_tests
+    ${CMAKE_SOURCE_DIR}/src/masterd/Groups/GroupManagerTests.cpp)
+  lcdlln_add_simple_test(loot_rule_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/loot/LootRuleTests.cpp)
+
   # CMANGOS.11 (Phase 3.11a) : ThreatList AI target selector (header-only).
   lcdlln_add_simple_test(threat_list_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/combat/ThreatListTests.cpp)

--- a/src/masterd/Groups/Group.h
+++ b/src/masterd/Groups/Group.h
@@ -1,0 +1,120 @@
+#pragma once
+// Wave 22 — Group : un groupe de joueurs (party 5p ou raid 10/25/40). Master-side
+// car les groupes peuvent etre cross-shard (raid future). Detient :
+// - id immuable (GroupId, alloue par GroupManager)
+// - type (Party / Raid) immuable apres creation
+// - leader (PlayerId) — peut etre change via Promote
+// - lootMethod — peut etre change par le leader
+// - membres (set de PlayerId + role par membre)
+//
+// Pattern WoW-like adapte LCDLLN : pas de membre intrusive list (cmangos
+// utilise un GroupReference doubly-linked, on simplifie en set hash-based
+// car nos lookups sont domines par "is X in group ?" et "list members").
+
+#include "src/masterd/Groups/GroupTypes.h"
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace engine::server::groups
+{
+	/// Donnees par membre. Role optionnel pour LFG / matchmaking.
+	struct GroupMember
+	{
+		PlayerId  playerId = 0;
+		GroupRole role     = GroupRole::Unknown;
+	};
+
+	class Group
+	{
+	public:
+		/// \param id      identifiant alloue par GroupManager
+		/// \param type    Party ou Raid (immuable apres creation)
+		/// \param leader  player initial creant le groupe (auto-ajoute)
+		Group(GroupId id, GroupType type, PlayerId leader)
+			: m_id(id), m_type(type), m_leader(leader), m_lootMethod(LootMethod::FreeForAll)
+		{
+			// Le leader est auto-ajoute comme membre.
+			m_members[leader] = GroupMember{leader, GroupRole::Unknown};
+		}
+
+		GroupId   Id() const noexcept { return m_id; }
+		GroupType Type() const noexcept { return m_type; }
+		PlayerId  Leader() const noexcept { return m_leader; }
+		LootMethod CurrentLootMethod() const noexcept { return m_lootMethod; }
+
+		/// Ajoute \p playerId au groupe avec role optionnel. Retourne false si :
+		/// - le player est deja dans le groupe (idempotent : pas de re-add)
+		/// - la capacite max est atteinte (5 party / 40 raid)
+		bool AddMember(PlayerId playerId, GroupRole role = GroupRole::Unknown)
+		{
+			if (m_members.count(playerId) > 0)
+				return false;  // deja present
+			const uint32_t maxCap = (m_type == GroupType::Party) ? kPartyMaxMembers : kRaidMaxMembers;
+			if (m_members.size() >= maxCap)
+				return false;
+			m_members[playerId] = GroupMember{playerId, role};
+			return true;
+		}
+
+		/// Retire \p playerId du groupe. Retourne true si retire, false si absent.
+		/// Si le leader part, transfere le leadership au premier membre restant
+		/// (ou groupe vide si etait seul).
+		bool RemoveMember(PlayerId playerId)
+		{
+			auto it = m_members.find(playerId);
+			if (it == m_members.end()) return false;
+			m_members.erase(it);
+			if (m_leader == playerId && !m_members.empty())
+			{
+				// Transfert auto au premier restant (ordre non-deterministe :
+				// le caller peut promouvoir explicitement avant un Remove si
+				// la regle metier l'exige).
+				m_leader = m_members.begin()->first;
+			}
+			return true;
+		}
+
+		bool HasMember(PlayerId playerId) const noexcept
+		{
+			return m_members.count(playerId) > 0;
+		}
+
+		size_t MemberCount() const noexcept { return m_members.size(); }
+
+		const std::unordered_map<PlayerId, GroupMember>& Members() const noexcept
+		{
+			return m_members;
+		}
+
+		/// Promote \p playerId leader. Retourne false si non-membre.
+		bool Promote(PlayerId playerId)
+		{
+			if (m_members.count(playerId) == 0) return false;
+			m_leader = playerId;
+			return true;
+		}
+
+		/// Set role pour un membre. Retourne false si non-membre.
+		bool SetRole(PlayerId playerId, GroupRole role)
+		{
+			auto it = m_members.find(playerId);
+			if (it == m_members.end()) return false;
+			it->second.role = role;
+			return true;
+		}
+
+		/// Change le LootMethod du groupe. Pas de gating leader-only ici (a
+		/// faire dans le handler, qui valide que l'appelant == leader).
+		void SetLootMethod(LootMethod m) noexcept { m_lootMethod = m; }
+
+		bool IsEmpty() const noexcept { return m_members.empty(); }
+
+	private:
+		GroupId    m_id;
+		GroupType  m_type;
+		PlayerId   m_leader;
+		LootMethod m_lootMethod;
+		std::unordered_map<PlayerId, GroupMember> m_members;
+	};
+}

--- a/src/masterd/Groups/GroupManager.h
+++ b/src/masterd/Groups/GroupManager.h
@@ -1,0 +1,132 @@
+#pragma once
+// Wave 22 — GroupManager : registre central des groupes actifs sur le master.
+// Alloue les GroupId monotoniques croissants, indexe les groupes par id ET
+// par playerId pour des lookups O(1) "quel groupe contient ce player ?".
+//
+// Pas thread-safe : a appeler depuis le thread de tick master. Si un futur
+// scenario reclame thread-safety (callback async chat handler par ex), on
+// ajoutera un mutex sur les 2 maps.
+
+#include "src/masterd/Groups/Group.h"
+#include "src/masterd/Groups/GroupTypes.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+namespace engine::server::groups
+{
+	class GroupManager
+	{
+	public:
+		GroupManager() = default;
+
+		/// Cree un nouveau groupe avec \p leader comme premier membre.
+		/// \return GroupId alloue (monotone croissant a partir de 1).
+		/// Si le leader est deja dans un autre groupe, retire-le de l'ancien
+		/// d'abord (un player ne peut etre que dans 1 groupe a la fois).
+		GroupId CreateGroup(PlayerId leader, GroupType type)
+		{
+			// Si leader deja dans un groupe, le retirer d'abord.
+			RemovePlayerFromCurrentGroup(leader);
+
+			const GroupId id = m_nextId++;
+			auto group = std::make_unique<Group>(id, type, leader);
+			m_byPlayer[leader] = id;
+			m_groups[id] = std::move(group);
+			return id;
+		}
+
+		/// Ajoute \p playerId au groupe \p groupId. Retourne true si succes.
+		/// Echoue si :
+		/// - groupId inconnu
+		/// - player deja dans le meme groupe (idempotent)
+		/// - groupe a capacite max
+		bool AddMember(GroupId groupId, PlayerId playerId, GroupRole role = GroupRole::Unknown)
+		{
+			auto it = m_groups.find(groupId);
+			if (it == m_groups.end()) return false;
+			// Si player dans un autre groupe, retirer d'abord (transferer).
+			RemovePlayerFromCurrentGroup(playerId);
+			if (!it->second->AddMember(playerId, role))
+				return false;
+			m_byPlayer[playerId] = groupId;
+			return true;
+		}
+
+		/// Retire \p playerId de son groupe courant (no-op si pas dans un groupe).
+		/// Si le groupe devient vide apres le retrait, le supprime.
+		void RemoveMember(PlayerId playerId)
+		{
+			auto byIt = m_byPlayer.find(playerId);
+			if (byIt == m_byPlayer.end()) return;
+			const GroupId gid = byIt->second;
+			m_byPlayer.erase(byIt);
+
+			auto gIt = m_groups.find(gid);
+			if (gIt == m_groups.end()) return;
+			gIt->second->RemoveMember(playerId);
+			if (gIt->second->IsEmpty())
+				m_groups.erase(gIt);
+		}
+
+		/// Dissolve un groupe : retire tous les membres + delete. Idempotent.
+		void Disband(GroupId groupId)
+		{
+			auto it = m_groups.find(groupId);
+			if (it == m_groups.end()) return;
+			// Recopie pour iterer sans modifier la map sous-jacente.
+			const auto memberCopy = it->second->Members();
+			for (const auto& kv : memberCopy)
+				m_byPlayer.erase(kv.first);
+			m_groups.erase(it);
+		}
+
+		/// Lookup groupe par id. Retourne nullptr si inconnu.
+		Group* Find(GroupId groupId)
+		{
+			auto it = m_groups.find(groupId);
+			return (it != m_groups.end()) ? it->second.get() : nullptr;
+		}
+
+		const Group* Find(GroupId groupId) const
+		{
+			auto it = m_groups.find(groupId);
+			return (it != m_groups.end()) ? it->second.get() : nullptr;
+		}
+
+		/// Lookup groupe d'un player. Retourne nullopt si pas dans un groupe.
+		std::optional<GroupId> GroupOfPlayer(PlayerId playerId) const
+		{
+			auto it = m_byPlayer.find(playerId);
+			if (it == m_byPlayer.end()) return std::nullopt;
+			return it->second;
+		}
+
+		size_t GroupCount() const noexcept { return m_groups.size(); }
+
+	private:
+		/// Helper interne : si \p playerId est dans un groupe, l'en retirer.
+		/// No-op sinon. Utilise par CreateGroup + AddMember pour gerer le
+		/// transfert d'un groupe a un autre.
+		void RemovePlayerFromCurrentGroup(PlayerId playerId)
+		{
+			auto it = m_byPlayer.find(playerId);
+			if (it == m_byPlayer.end()) return;
+			const GroupId oldId = it->second;
+			m_byPlayer.erase(it);
+			auto gIt = m_groups.find(oldId);
+			if (gIt != m_groups.end())
+			{
+				gIt->second->RemoveMember(playerId);
+				if (gIt->second->IsEmpty())
+					m_groups.erase(gIt);
+			}
+		}
+
+		GroupId m_nextId = 1;
+		std::unordered_map<GroupId, std::unique_ptr<Group>> m_groups;
+		std::unordered_map<PlayerId, GroupId>                m_byPlayer;
+	};
+}

--- a/src/masterd/Groups/GroupManagerTests.cpp
+++ b/src/masterd/Groups/GroupManagerTests.cpp
@@ -1,0 +1,275 @@
+// Wave 22 — GroupManager tests : create/add/remove/disband + transfer
+// player entre groupes + leader promotion / transferring + capacity caps.
+//
+// Pattern aligne sur les autres tests : asserts + printf, pas de framework.
+// Cible CTest : group_manager_tests.
+
+#include "src/masterd/Groups/GroupManager.h"
+
+#include <cassert>
+#include <cstdio>
+
+using namespace engine::server::groups;
+
+namespace
+{
+	// ========================================================================
+	// CreateGroup
+	// ========================================================================
+
+	void TestCreateGroupBasic()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(/*leader*/1, GroupType::Party);
+		assert(id == 1);
+		assert(mgr.GroupCount() == 1);
+		// Le leader est dans le groupe.
+		auto opt = mgr.GroupOfPlayer(1);
+		assert(opt.has_value() && opt.value() == id);
+		// Le groupe est de type Party, leader=1.
+		const Group* g = mgr.Find(id);
+		assert(g != nullptr);
+		assert(g->Type() == GroupType::Party);
+		assert(g->Leader() == 1);
+		assert(g->MemberCount() == 1);
+		std::puts("[OK] TestCreateGroupBasic");
+	}
+
+	void TestCreateGroupIdMonotonic()
+	{
+		GroupManager mgr;
+		const GroupId a = mgr.CreateGroup(1, GroupType::Party);
+		const GroupId b = mgr.CreateGroup(2, GroupType::Party);
+		const GroupId c = mgr.CreateGroup(3, GroupType::Raid);
+		assert(a < b && b < c);
+		std::puts("[OK] TestCreateGroupIdMonotonic");
+	}
+
+	void TestCreateGroupTransferLeader()
+	{
+		// Si le leader est deja dans un autre groupe, il est retire de
+		// l'ancien et place dans le nouveau.
+		GroupManager mgr;
+		const GroupId g1 = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(g1, 2);
+		const GroupId g2 = mgr.CreateGroup(1, GroupType::Raid);
+		// 1 est dans g2, pas dans g1.
+		auto p1 = mgr.GroupOfPlayer(1);
+		assert(p1.has_value() && p1.value() == g2);
+		const Group* g1Ptr = mgr.Find(g1);
+		assert(g1Ptr != nullptr);
+		assert(!g1Ptr->HasMember(1));
+		assert(g1Ptr->HasMember(2));  // 2 toujours dans g1
+		std::puts("[OK] TestCreateGroupTransferLeader");
+	}
+
+	// ========================================================================
+	// AddMember
+	// ========================================================================
+
+	void TestAddMember()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		assert(mgr.AddMember(id, 2));
+		assert(mgr.AddMember(id, 3));
+		const Group* g = mgr.Find(id);
+		assert(g->MemberCount() == 3);
+		assert(g->HasMember(1) && g->HasMember(2) && g->HasMember(3));
+		// Idempotent : re-add d'un member retourne false.
+		assert(!mgr.AddMember(id, 2));
+		assert(g->MemberCount() == 3);
+		std::puts("[OK] TestAddMember");
+	}
+
+	void TestAddMemberCapacityParty()
+	{
+		// Party cap = 5. Le leader compte comme 1 membre.
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		assert(mgr.AddMember(id, 2));
+		assert(mgr.AddMember(id, 3));
+		assert(mgr.AddMember(id, 4));
+		assert(mgr.AddMember(id, 5));
+		// 5 members, cap atteinte.
+		assert(!mgr.AddMember(id, 6));
+		assert(mgr.Find(id)->MemberCount() == 5);
+		std::puts("[OK] TestAddMemberCapacityParty");
+	}
+
+	void TestAddMemberUnknownGroup()
+	{
+		GroupManager mgr;
+		assert(!mgr.AddMember(/*inconnu*/999, 1));
+		std::puts("[OK] TestAddMemberUnknownGroup");
+	}
+
+	void TestAddMemberTransferBetweenGroups()
+	{
+		// Si on ajoute un player deja dans un autre groupe, il est transfere.
+		GroupManager mgr;
+		const GroupId g1 = mgr.CreateGroup(1, GroupType::Party);
+		const GroupId g2 = mgr.CreateGroup(10, GroupType::Party);
+		mgr.AddMember(g1, 2);
+		// Transfer 2 de g1 vers g2.
+		assert(mgr.AddMember(g2, 2));
+		assert(!mgr.Find(g1)->HasMember(2));
+		assert(mgr.Find(g2)->HasMember(2));
+		auto opt = mgr.GroupOfPlayer(2);
+		assert(opt.has_value() && opt.value() == g2);
+		std::puts("[OK] TestAddMemberTransferBetweenGroups");
+	}
+
+	// ========================================================================
+	// RemoveMember + disband auto
+	// ========================================================================
+
+	void TestRemoveMember()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(id, 2);
+		mgr.AddMember(id, 3);
+		mgr.RemoveMember(2);
+		assert(!mgr.Find(id)->HasMember(2));
+		assert(!mgr.GroupOfPlayer(2).has_value());
+		// 1 et 3 toujours dans le groupe.
+		assert(mgr.Find(id)->MemberCount() == 2);
+		std::puts("[OK] TestRemoveMember");
+	}
+
+	void TestRemoveMemberDisbandWhenEmpty()
+	{
+		// Si on retire le dernier membre, le groupe est auto-supprime.
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.RemoveMember(1);
+		assert(mgr.GroupCount() == 0);
+		assert(mgr.Find(id) == nullptr);
+		std::puts("[OK] TestRemoveMemberDisbandWhenEmpty");
+	}
+
+	void TestRemoveMemberLeaderTransfer()
+	{
+		// Si on retire le leader, le leadership passe a un autre membre.
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(id, 2);
+		mgr.AddMember(id, 3);
+		mgr.RemoveMember(1);
+		const Group* g = mgr.Find(id);
+		assert(g != nullptr);
+		assert(g->Leader() == 2 || g->Leader() == 3);  // ordre non-deterministe
+		assert(g->MemberCount() == 2);
+		std::puts("[OK] TestRemoveMemberLeaderTransfer");
+	}
+
+	// ========================================================================
+	// Disband explicite
+	// ========================================================================
+
+	void TestDisband()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(id, 2);
+		mgr.AddMember(id, 3);
+		mgr.Disband(id);
+		assert(mgr.GroupCount() == 0);
+		assert(!mgr.GroupOfPlayer(1).has_value());
+		assert(!mgr.GroupOfPlayer(2).has_value());
+		assert(!mgr.GroupOfPlayer(3).has_value());
+		std::puts("[OK] TestDisband");
+	}
+
+	void TestDisbandUnknown()
+	{
+		GroupManager mgr;
+		mgr.Disband(999);  // no-op
+		assert(mgr.GroupCount() == 0);
+		std::puts("[OK] TestDisbandUnknown");
+	}
+
+	// ========================================================================
+	// Group methods directs (via Find)
+	// ========================================================================
+
+	void TestPromote()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(id, 2);
+		Group* g = mgr.Find(id);
+		assert(g->Leader() == 1);
+		assert(g->Promote(2));
+		assert(g->Leader() == 2);
+		// Promote sur non-membre : false.
+		assert(!g->Promote(999));
+		assert(g->Leader() == 2);
+		std::puts("[OK] TestPromote");
+	}
+
+	void TestSetRole()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		mgr.AddMember(id, 2);
+		Group* g = mgr.Find(id);
+		assert(g->SetRole(2, GroupRole::Tank));
+		// SetRole sur non-membre : false.
+		assert(!g->SetRole(999, GroupRole::Heal));
+		const auto& members = g->Members();
+		auto it = members.find(2);
+		assert(it != members.end() && it->second.role == GroupRole::Tank);
+		std::puts("[OK] TestSetRole");
+	}
+
+	void TestSetLootMethod()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Party);
+		Group* g = mgr.Find(id);
+		assert(g->CurrentLootMethod() == LootMethod::FreeForAll);
+		g->SetLootMethod(LootMethod::NeedBeforeGreed);
+		assert(g->CurrentLootMethod() == LootMethod::NeedBeforeGreed);
+		std::puts("[OK] TestSetLootMethod");
+	}
+
+	void TestRaidCapacity()
+	{
+		GroupManager mgr;
+		const GroupId id = mgr.CreateGroup(1, GroupType::Raid);
+		// Ajoute jusqu'a 40 (Raid cap). Leader compte = 1, donc 39 add.
+		for (PlayerId p = 2; p <= 40; ++p)
+		{
+			bool ok = mgr.AddMember(id, p);
+			assert(ok);
+		}
+		assert(mgr.Find(id)->MemberCount() == 40);
+		// 41e : refuse.
+		assert(!mgr.AddMember(id, 41));
+		std::puts("[OK] TestRaidCapacity");
+	}
+}
+
+int main()
+{
+	TestCreateGroupBasic();
+	TestCreateGroupIdMonotonic();
+	TestCreateGroupTransferLeader();
+	TestAddMember();
+	TestAddMemberCapacityParty();
+	TestAddMemberUnknownGroup();
+	TestAddMemberTransferBetweenGroups();
+	TestRemoveMember();
+	TestRemoveMemberDisbandWhenEmpty();
+	TestRemoveMemberLeaderTransfer();
+	TestDisband();
+	TestDisbandUnknown();
+	TestPromote();
+	TestSetRole();
+	TestSetLootMethod();
+	TestRaidCapacity();
+	std::puts("All GroupManager tests passed");
+	return 0;
+}

--- a/src/masterd/Groups/GroupTypes.h
+++ b/src/masterd/Groups/GroupTypes.h
@@ -1,0 +1,56 @@
+#pragma once
+// Wave 22 — GroupTypes : enums communes pour Group (party / raid),
+// LootMethod (FFA / round-robin / master-looter / need-before-greed),
+// GroupRole (tank / heal / DPS).
+//
+// Header-only, valeurs stables (wire format + DB en dependent).
+
+#include <cstdint>
+
+namespace engine::server::groups
+{
+	using GroupId  = uint64_t;
+	using PlayerId = uint64_t;
+
+	/// Type de groupe. Party = max 5, Raid = max 10/25/40.
+	enum class GroupType : uint8_t
+	{
+		Party = 0,
+		Raid  = 1,
+	};
+
+	/// Methode de loot configuree pour le groupe. Determine quelle LootRule
+	/// est appliquee aux drops collectes ensemble.
+	enum class LootMethod : uint8_t
+	{
+		FreeForAll      = 0,  ///< Premier arrive premier servi (loot independant)
+		RoundRobin      = 1,  ///< Rotation au prochain drop
+		MasterLooter    = 2,  ///< Un membre (leader) attribue manuellement
+		NeedBeforeGreed = 3,  ///< Roll Need (priorite) > Greed > Pass
+	};
+
+	/// Role optionnel (utilise par LFG / matchmaker). Conserve par membre.
+	enum class GroupRole : uint8_t
+	{
+		Unknown = 0,
+		Tank    = 1,
+		Heal    = 2,
+		Dps     = 3,
+	};
+
+	inline const char* LootMethodToString(LootMethod m) noexcept
+	{
+		switch (m)
+		{
+			case LootMethod::FreeForAll:      return "FreeForAll";
+			case LootMethod::RoundRobin:      return "RoundRobin";
+			case LootMethod::MasterLooter:    return "MasterLooter";
+			case LootMethod::NeedBeforeGreed: return "NeedBeforeGreed";
+		}
+		return "Unknown";
+	}
+
+	/// Capacite max selon le type (utilise par Group::AddMember pour rejeter).
+	inline constexpr uint32_t kPartyMaxMembers = 5;
+	inline constexpr uint32_t kRaidMaxMembers  = 40;
+}

--- a/src/shardd/loot/LootRule.h
+++ b/src/shardd/loot/LootRule.h
@@ -1,0 +1,151 @@
+#pragma once
+// Wave 22 — LootRule : interface + 4 implementations basiques pour
+// distribuer un drop a un groupe selon le LootMethod configure.
+//
+// Pattern interface + impls header-only : pas de virtual call cost si le
+// caller utilise directement les impls concretes (FreeForAllLootRule,
+// RoundRobinLootRule, etc.). Le caller choisit l'impl selon le LootMethod
+// du Group (cf. dispatch dans Group::CurrentLootMethod).
+//
+// Conception : LootRule ne SAIT PAS comment lire l'inventaire ou la DB.
+// Il prend une liste d'EligibleEntity (player IDs presents au kill) et
+// retourne le PlayerId gagnant pour CE drop. Le caller (LootHandler ou
+// equivalent) execute ensuite la mutation persistente (insert mail / item).
+
+#include "src/masterd/Groups/GroupTypes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::loot
+{
+	using engine::server::groups::PlayerId;
+
+	/// Roll Need (priorite haute) > Greed > Pass. Utilise par
+	/// NeedBeforeGreedLootRule.
+	enum class RollChoice : uint8_t
+	{
+		Pass  = 0,
+		Greed = 1,
+		Need  = 2,
+	};
+
+	/// Interface abstraite : 1 methode pure virtuelle Pick(). Pas de state
+	/// shared entre LootRule et le caller — le caller passe tout le contexte
+	/// au moment du call.
+	class ILootRule
+	{
+	public:
+		virtual ~ILootRule() = default;
+
+		/// \param eligible player IDs presents au kill (membres du groupe
+		///                 + qualifies par la regle metier, ex : range/loot,
+		///                 done par le caller avant l'appel)
+		/// \param rolls    optionnel : map des choix roll par player (utilise
+		///                 par NeedBeforeGreed seulement, ignore par les autres)
+		/// \return PlayerId gagnant, ou nullopt si pas de gagnant determine
+		///         (ex : tous Pass sur NeedBeforeGreed).
+		virtual std::optional<PlayerId> Pick(
+			const std::vector<PlayerId>& eligible,
+			const std::unordered_map<PlayerId, RollChoice>& rolls) const = 0;
+	};
+
+	// ========================================================================
+	// FreeForAll : premier dans la liste eligible. Simple et deterministe.
+	// ========================================================================
+	class FreeForAllLootRule final : public ILootRule
+	{
+	public:
+		std::optional<PlayerId> Pick(
+			const std::vector<PlayerId>& eligible,
+			const std::unordered_map<PlayerId, RollChoice>& /*rolls*/) const override
+		{
+			if (eligible.empty()) return std::nullopt;
+			return eligible.front();
+		}
+	};
+
+	// ========================================================================
+	// RoundRobin : rotation. Le compteur interne est conserve par le caller
+	// (typiquement membre du Group) via SetCursor / GetCursor.
+	// ========================================================================
+	class RoundRobinLootRule final : public ILootRule
+	{
+	public:
+		std::optional<PlayerId> Pick(
+			const std::vector<PlayerId>& eligible,
+			const std::unordered_map<PlayerId, RollChoice>& /*rolls*/) const override
+		{
+			if (eligible.empty()) return std::nullopt;
+			const size_t idx = m_cursor % eligible.size();
+			m_cursor++;
+			return eligible[idx];
+		}
+
+		void SetCursor(size_t c) noexcept { m_cursor = c; }
+		size_t GetCursor() const noexcept { return m_cursor; }
+
+	private:
+		mutable size_t m_cursor = 0;
+	};
+
+	// ========================================================================
+	// MasterLooter : retourne toujours le leader (= masterLooter). Le caller
+	// fournit le leader via le constructeur.
+	// ========================================================================
+	class MasterLooterLootRule final : public ILootRule
+	{
+	public:
+		explicit MasterLooterLootRule(PlayerId masterLooter)
+			: m_masterLooter(masterLooter) {}
+
+		std::optional<PlayerId> Pick(
+			const std::vector<PlayerId>& eligible,
+			const std::unordered_map<PlayerId, RollChoice>& /*rolls*/) const override
+		{
+			if (eligible.empty()) return std::nullopt;
+			// Verifier que masterLooter est dans eligible — sinon fallback au
+			// premier (cas defensif : masterLooter offline, kick, etc.).
+			for (auto p : eligible)
+				if (p == m_masterLooter) return m_masterLooter;
+			return eligible.front();
+		}
+
+	private:
+		PlayerId m_masterLooter;
+	};
+
+	// ========================================================================
+	// NeedBeforeGreed : si au moins 1 Need -> tiebreaker premier-arrive.
+	// Sinon, si au moins 1 Greed -> idem. Sinon, nullopt (tous Pass).
+	// ========================================================================
+	class NeedBeforeGreedLootRule final : public ILootRule
+	{
+	public:
+		std::optional<PlayerId> Pick(
+			const std::vector<PlayerId>& eligible,
+			const std::unordered_map<PlayerId, RollChoice>& rolls) const override
+		{
+			if (eligible.empty()) return std::nullopt;
+			// Cherche un Need d'abord, dans l'ordre de eligible.
+			for (auto p : eligible)
+			{
+				auto it = rolls.find(p);
+				if (it != rolls.end() && it->second == RollChoice::Need)
+					return p;
+			}
+			// Sinon cherche un Greed.
+			for (auto p : eligible)
+			{
+				auto it = rolls.find(p);
+				if (it != rolls.end() && it->second == RollChoice::Greed)
+					return p;
+			}
+			// Tous Pass -> pas de gagnant.
+			return std::nullopt;
+		}
+	};
+}

--- a/src/shardd/loot/LootRuleTests.cpp
+++ b/src/shardd/loot/LootRuleTests.cpp
@@ -1,0 +1,206 @@
+// Wave 22 — LootRule tests : 4 implementations (FFA, RoundRobin,
+// MasterLooter, NeedBeforeGreed).
+//
+// Pattern aligne sur les autres tests : asserts + printf, pas de framework.
+// Cible CTest : loot_rule_tests.
+
+#include "src/shardd/loot/LootRule.h"
+
+#include <cassert>
+#include <cstdio>
+
+using namespace engine::server::loot;
+using engine::server::groups::PlayerId;
+
+namespace
+{
+	// ========================================================================
+	// FreeForAll
+	// ========================================================================
+
+	void TestFFAFirstEligible()
+	{
+		FreeForAllLootRule rule;
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		auto winner = rule.Pick(eligible, {});
+		assert(winner.has_value() && winner.value() == 1);
+		std::puts("[OK] TestFFAFirstEligible");
+	}
+
+	void TestFFAEmpty()
+	{
+		FreeForAllLootRule rule;
+		auto winner = rule.Pick({}, {});
+		assert(!winner.has_value());
+		std::puts("[OK] TestFFAEmpty");
+	}
+
+	// ========================================================================
+	// RoundRobin
+	// ========================================================================
+
+	void TestRRRotation()
+	{
+		RoundRobinLootRule rule;
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		// 1er pick : index 0 = player 1
+		auto w1 = rule.Pick(eligible, {});
+		assert(w1.has_value() && w1.value() == 1);
+		// 2e : index 1 = player 2
+		auto w2 = rule.Pick(eligible, {});
+		assert(w2.has_value() && w2.value() == 2);
+		// 3e : index 2 = player 3
+		auto w3 = rule.Pick(eligible, {});
+		assert(w3.has_value() && w3.value() == 3);
+		// 4e : retour a index 0 = player 1
+		auto w4 = rule.Pick(eligible, {});
+		assert(w4.has_value() && w4.value() == 1);
+		std::puts("[OK] TestRRRotation");
+	}
+
+	void TestRRCursorState()
+	{
+		RoundRobinLootRule rule;
+		std::vector<PlayerId> eligible = {10, 20, 30};
+		rule.SetCursor(2);
+		auto w = rule.Pick(eligible, {});
+		// cursor=2 % 3 = 2 -> player 30
+		assert(w.has_value() && w.value() == 30);
+		assert(rule.GetCursor() == 3);
+		std::puts("[OK] TestRRCursorState");
+	}
+
+	void TestRREmpty()
+	{
+		RoundRobinLootRule rule;
+		auto w = rule.Pick({}, {});
+		assert(!w.has_value());
+		std::puts("[OK] TestRREmpty");
+	}
+
+	// ========================================================================
+	// MasterLooter
+	// ========================================================================
+
+	void TestMLLeaderWins()
+	{
+		MasterLooterLootRule rule(/*masterLooter*/5);
+		std::vector<PlayerId> eligible = {1, 2, 5, 7};
+		auto w = rule.Pick(eligible, {});
+		assert(w.has_value() && w.value() == 5);
+		std::puts("[OK] TestMLLeaderWins");
+	}
+
+	void TestMLFallbackWhenOffline()
+	{
+		// Si masterLooter n'est pas dans eligible (offline / kick), fallback
+		// au premier (defense).
+		MasterLooterLootRule rule(/*masterLooter*/99);
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		auto w = rule.Pick(eligible, {});
+		assert(w.has_value() && w.value() == 1);
+		std::puts("[OK] TestMLFallbackWhenOffline");
+	}
+
+	void TestMLEmpty()
+	{
+		MasterLooterLootRule rule(5);
+		auto w = rule.Pick({}, {});
+		assert(!w.has_value());
+		std::puts("[OK] TestMLEmpty");
+	}
+
+	// ========================================================================
+	// NeedBeforeGreed
+	// ========================================================================
+
+	void TestNBGNeedWins()
+	{
+		NeedBeforeGreedLootRule rule;
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		std::unordered_map<PlayerId, RollChoice> rolls = {
+			{1, RollChoice::Greed},
+			{2, RollChoice::Need},  // priorite haute
+			{3, RollChoice::Greed},
+		};
+		auto w = rule.Pick(eligible, rolls);
+		assert(w.has_value() && w.value() == 2);
+		std::puts("[OK] TestNBGNeedWins");
+	}
+
+	void TestNBGGreedFallback()
+	{
+		NeedBeforeGreedLootRule rule;
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		std::unordered_map<PlayerId, RollChoice> rolls = {
+			{1, RollChoice::Pass},
+			{2, RollChoice::Greed},
+			{3, RollChoice::Pass},
+		};
+		auto w = rule.Pick(eligible, rolls);
+		assert(w.has_value() && w.value() == 2);
+		std::puts("[OK] TestNBGGreedFallback");
+	}
+
+	void TestNBGAllPass()
+	{
+		NeedBeforeGreedLootRule rule;
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		std::unordered_map<PlayerId, RollChoice> rolls = {
+			{1, RollChoice::Pass},
+			{2, RollChoice::Pass},
+			{3, RollChoice::Pass},
+		};
+		auto w = rule.Pick(eligible, rolls);
+		assert(!w.has_value());
+		std::puts("[OK] TestNBGAllPass");
+	}
+
+	void TestNBGNeedTiebreakerFirstInList()
+	{
+		NeedBeforeGreedLootRule rule;
+		// 2 players Need -> celui qui apparait premier dans eligible gagne.
+		std::vector<PlayerId> eligible = {1, 2, 3};
+		std::unordered_map<PlayerId, RollChoice> rolls = {
+			{1, RollChoice::Need},
+			{2, RollChoice::Need},
+			{3, RollChoice::Greed},
+		};
+		auto w = rule.Pick(eligible, rolls);
+		assert(w.has_value() && w.value() == 1);
+		std::puts("[OK] TestNBGNeedTiebreakerFirstInList");
+	}
+
+	void TestNBGMissingRollsCountAsPass()
+	{
+		NeedBeforeGreedLootRule rule;
+		// Si un player n'a pas roll, il est traite comme Pass (pas dans la map).
+		std::vector<PlayerId> eligible = {1, 2};
+		std::unordered_map<PlayerId, RollChoice> rolls = {
+			{1, RollChoice::Greed},
+			// player 2 absent
+		};
+		auto w = rule.Pick(eligible, rolls);
+		assert(w.has_value() && w.value() == 1);  // 1 Greed gagne
+		std::puts("[OK] TestNBGMissingRollsCountAsPass");
+	}
+}
+
+int main()
+{
+	TestFFAFirstEligible();
+	TestFFAEmpty();
+	TestRRRotation();
+	TestRRCursorState();
+	TestRREmpty();
+	TestMLLeaderWins();
+	TestMLFallbackWhenOffline();
+	TestMLEmpty();
+	TestNBGNeedWins();
+	TestNBGGreedFallback();
+	TestNBGAllPass();
+	TestNBGNeedTiebreakerFirstInList();
+	TestNBGMissingRollsCountAsPass();
+	std::puts("All LootRule tests passed");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Wave 22 livre le système de **groupes master-side** (party 5p / raid 40p) + 4 impls **LootRule** côté shard. C'est le **Wave 22 de la roadmap server-first** ([spec §4 Wave 22](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md)).

## Fichiers

| Fichier | Rôle |
|---------|------|
| `src/masterd/Groups/GroupTypes.h` | Enums : GroupType, LootMethod, GroupRole + capacités max party/raid |
| `src/masterd/Groups/Group.h` | Classe Group : leader, members[role], lootMethod. AddMember/RemoveMember/Promote/SetRole |
| `src/masterd/Groups/GroupManager.h` | Registry : GroupId monotone, index par playerId (O(1) "quel groupe ?"), transfer auto entre groupes, disband auto si vide |
| `src/shardd/loot/LootRule.h` | Interface ILootRule + 4 impls header-only (FFA, RR, ML, NBG) |
| `src/masterd/Groups/GroupManagerTests.cpp` | 16 cas |
| `src/shardd/loot/LootRuleTests.cpp` | 13 cas |
| `sql/migrations/0060_groups.sql` | Tables `groups` + `group_members` (UNIQUE player_id) + `group_loot_rolls` |

## Audit anti-doublon (règle 2026-05-11)

`grep "class GroupManager\|class Group[^A-Za-z]\|GroupReference\|class LootRule" src/` → 0 hit avant cette PR.

Note : `src/client/loot/LootRollUi.h` existe pour l'UI roll Need/Greed (PR #560) — mais c'est côté CLIENT, et `LootRollUi`/`LootRollState` sont des structs UI distinctes de `ILootRule` côté serveur. Pas de conflit.

## Convention PascalCase

- **Nouveau dossier `src/masterd/Groups/`** : PascalCase (règle 2026-05-11)
- Dossiers existants restent lowercase (`src/shardd/loot/`) → ajout de fichiers PascalCase (`LootRule.h`, `LootRuleTests.cpp`)

## API exemple

```cpp
// Master-side : create group
engine::server::groups::GroupManager mgr;
const auto gid = mgr.CreateGroup(/*leader*/playerA, GroupType::Party);
mgr.AddMember(gid, playerB, GroupRole::Tank);
mgr.AddMember(gid, playerC, GroupRole::Heal);

// Shard-side : when loot drops, dispatch via configured LootRule
const auto* group = mgr.Find(gid);
engine::server::loot::FreeForAllLootRule rule;  // ou switch sur group->CurrentLootMethod()
const auto winner = rule.Pick({playerA, playerB, playerC}, {});
// winner.value() = playerA (premier dans eligible pour FFA)
```

## Test plan

- [ ] Linux build + ctest (gate actif depuis #592)
- [ ] `group_manager_tests` — 16 cas (cap party/raid, transfer, disband, leader transfer)
- [ ] `loot_rule_tests` — 13 cas (FFA, RR rotation+cursor, ML fallback offline, NBG matrix complet)
- [ ] Windows build

## Limites volontaires Wave 22

- **Pas de persistance MySQL** — `GroupManager` est in-memory uniquement. Une impl `MysqlGroupStore` viendra plus tard (suit pattern Wave 5/10 stores).
- **Pas de handler opcodes** — `GroupHandler.h/cpp` (opcodes GROUP_INVITE/ACCEPT/LEAVE/LOOT_DECISION) non livrés ici. Le client UI roll (#560) existe déjà mais ne se câble pas encore au backend — wiring viendra dans une Wave dédiée.
- **Pas de GroupReference intrusive (cmangos-style)** — simplifié en `unordered_set<PlayerId>` membre de Group. Les lookups dominants sont "is X in group ?" et "list members" — hash-based suffit.
- **NeedBeforeGreed tiebreaker** : premier-dans-eligible (pas de RNG roll number). Acceptable pour la base ; une Wave RNG pourra ajouter le score 1-100 plus tard.

## Déploiement

⚠️ **REDÉPLOIEMENT MASTER REQUIS** — migration `0060_groups.sql` + binaire étendu. Pas de wire-breaking, pas d'impact client (UI existante non affectée jusqu'au wiring handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)