### PR TITLE
feat(spell): Wave 23 -- SpellMgr + Spell state machine + Aura + ProcMgr

### DIFF
--- a/sql/migrations/0061_spell_aura.sql
+++ b/sql/migrations/0061_spell_aura.sql
@@ -1,0 +1,34 @@
+-- 0061 — Wave 23 Spell/Aura/Proc : persistance des auras au logout +
+-- table proc templates data-driven.
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+
+-- Persistance des auras actifs sur un character au logout. Au login, le
+-- shard re-applique chaque ligne (avec verification expiresAtMs > now pour
+-- skip les auras expires entre temps).
+CREATE TABLE IF NOT EXISTS character_auras
+(
+	character_id     BIGINT UNSIGNED NOT NULL,
+	spell_id         INT UNSIGNED NOT NULL,
+	caster_id        BIGINT UNSIGNED NOT NULL,
+	applied_at_ms    BIGINT UNSIGNED NOT NULL,
+	expires_at_ms    BIGINT UNSIGNED NOT NULL,
+	stack_count      INT UNSIGNED NOT NULL DEFAULT 1,
+	PRIMARY KEY (character_id, spell_id, caster_id),
+	KEY idx_character_auras_character (character_id),
+	KEY idx_character_auras_expires (expires_at_ms)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Templates des procs data-driven. Charges au boot, immutable runtime.
+-- Hot-reload via /reload procs (admin GM+, audit).
+CREATE TABLE IF NOT EXISTS spell_proc_template
+(
+	proc_id              INT UNSIGNED NOT NULL,
+	event_type           TINYINT UNSIGNED NOT NULL,  -- ProcEvent enum
+	trigger_spell_id     INT UNSIGNED NOT NULL,
+	proc_chance          TINYINT UNSIGNED NOT NULL DEFAULT 100,  -- 0-100
+	internal_cooldown_ms INT UNSIGNED NOT NULL DEFAULT 0,
+	PRIMARY KEY (proc_id),
+	KEY idx_spell_proc_template_event (event_type),
+	KEY idx_spell_proc_template_trigger (trigger_spell_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -578,6 +578,10 @@ elseif(UNIX)
   # CMANGOS.26 (Phase 3.26a) : SpellFamilyMask 128-bit + ProcEvent matching.
   lcdlln_add_simple_test(spell_family_mask_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/spell/SpellFamilyMaskTests.cpp)
+  # Wave 23 (CMANGOS.26 step 2) : SpellMgr + Spell state machine + Aura
+  # tick/stack + ProcMgr event dispatch (header-only, etend SpellFamily).
+  lcdlln_add_simple_test(spell_mgr_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/spell/SpellMgrTests.cpp)
   # CMANGOS.14 (Phase 3.14a) : DBScripts VM step-by-step.
   lcdlln_add_simple_test(dbscript_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/dbscripts/DBScriptTests.cpp

--- a/src/shardd/spell/Aura.h
+++ b/src/shardd/spell/Aura.h
@@ -1,0 +1,90 @@
+#pragma once
+// Wave 23 — Aura : effet persistant sur Unit (buff ou debuff). Cree au
+// moment du Spell::Apply() quand durationMs > 0.
+//
+// Cycle de vie :
+//   Cree (caster, target, expiresAtMs) ──Tick──> Tick periodic ──Expire──> dead
+//                                             └─Stack──> stackCount incremente
+//
+// Stack rules : pour l'instant, simple — meme spellId du meme caster = stack.
+// Le moteur appelle TryStack(other) avant d'ajouter un Aura, et si OK,
+// l'Aura existant absorbe (refresh + incremente stackCount).
+
+#include "src/shardd/spell/SpellTemplate.h"
+
+#include <cstdint>
+
+namespace engine::server::spell
+{
+	using CasterEntityId = uint64_t;
+
+	class Aura
+	{
+	public:
+		/// \param tpl         template du sort source (lifetime caller)
+		/// \param caster      caster (utile pour replication / dispel rules)
+		/// \param target      target ou l'Aura est applique
+		/// \param appliedAtMs timestamp de creation (epoch ms ou ms relatif)
+		Aura(const SpellTemplate& tpl, CasterEntityId caster, TargetEntityId target,
+			uint64_t appliedAtMs)
+			: m_tpl(&tpl), m_caster(caster), m_target(target)
+			, m_appliedAtMs(appliedAtMs)
+			, m_expiresAtMs(appliedAtMs + tpl.durationMs)
+			, m_nextTickAtMs(tpl.tickPeriodMs > 0 ? appliedAtMs + tpl.tickPeriodMs : 0)
+		{}
+
+		const SpellTemplate& Template() const noexcept { return *m_tpl; }
+		CasterEntityId       Caster() const noexcept { return m_caster; }
+		TargetEntityId       Target() const noexcept { return m_target; }
+		uint64_t             AppliedAtMs() const noexcept { return m_appliedAtMs; }
+		uint64_t             ExpiresAtMs() const noexcept { return m_expiresAtMs; }
+		uint32_t             StackCount() const noexcept { return m_stackCount; }
+
+		/// True si \p nowMs >= expiresAtMs. L'Aura doit etre retire.
+		bool IsExpired(uint64_t nowMs) const noexcept { return nowMs >= m_expiresAtMs; }
+
+		/// Avance les ticks. Retourne le nombre de ticks consommes durant
+		/// cette frame (0 si pas encore atteint). Le caller applique l'effet
+		/// du sort (basePoints) une fois par tick.
+		uint32_t AdvanceTick(uint64_t nowMs)
+		{
+			if (m_tpl->tickPeriodMs == 0) return 0;
+			uint32_t ticks = 0;
+			while (m_nextTickAtMs > 0 && nowMs >= m_nextTickAtMs && m_nextTickAtMs < m_expiresAtMs)
+			{
+				++ticks;
+				m_nextTickAtMs += m_tpl->tickPeriodMs;
+			}
+			return ticks;
+		}
+
+		/// True si \p other peut s'empiler sur cette Aura. Rule simple Wave
+		/// 23 : meme spellId ET meme caster. Si oui, le caller appelle Stack()
+		/// pour incrementer + refresh expiresAtMs.
+		bool CanStackWith(const Aura& other) const noexcept
+		{
+			return m_tpl->spellId == other.m_tpl->spellId
+				&& m_caster == other.m_caster;
+		}
+
+		/// Empile : incremente stackCount + refresh expiresAtMs. \p nowMs
+		/// est le timestamp de la nouvelle application.
+		void Stack(uint64_t nowMs)
+		{
+			++m_stackCount;
+			m_expiresAtMs = nowMs + m_tpl->durationMs;
+			// Repositionner les ticks restants depuis nowMs si periodique.
+			if (m_tpl->tickPeriodMs > 0)
+				m_nextTickAtMs = nowMs + m_tpl->tickPeriodMs;
+		}
+
+	private:
+		const SpellTemplate* m_tpl;
+		CasterEntityId       m_caster;
+		TargetEntityId       m_target;
+		uint64_t             m_appliedAtMs;
+		uint64_t             m_expiresAtMs;
+		uint64_t             m_nextTickAtMs;   ///< 0 = pas de tick (Aura non periodique)
+		uint32_t             m_stackCount = 1;
+	};
+}

--- a/src/shardd/spell/ProcMgr.h
+++ b/src/shardd/spell/ProcMgr.h
@@ -1,0 +1,99 @@
+#pragma once
+// Wave 23 — ProcMgr : declencheurs conditionnels d'effets sur events
+// gameplay (OnMeleeHit, OnSpellCrit, OnHpBelow30, etc.).
+//
+// Pattern : un proc est defini par un ProcTemplate qui specifie sur quel
+// event il declenche, avec quelle chance (procChance 0-100), et quel
+// spell il declenche. Au runtime, le caller appelle ProcMgr::OnEvent()
+// avec le type d'event, et ProcMgr retourne la liste des spellIds a
+// declencher (apres roll de chance).
+
+#include "src/shardd/spell/SpellTemplate.h"
+
+#include <cstdint>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server::spell
+{
+	/// Types d'events qui peuvent declencher un proc. Stable (wire / DB).
+	enum class ProcEvent : uint8_t
+	{
+		OnMeleeHit       = 0,
+		OnMeleeCrit      = 1,
+		OnSpellHit       = 2,
+		OnSpellCrit      = 3,
+		OnHpBelowPercent = 4,   ///< trigger sous N% HP (param)
+		OnKill           = 5,
+		OnDeath          = 6,
+	};
+
+	struct ProcTemplate
+	{
+		uint32_t   procId      = 0;   ///< id unique
+		ProcEvent  event       = ProcEvent::OnMeleeHit;
+		SpellId    triggerSpell = 0;  ///< sort a declencher
+		uint8_t    procChance  = 100; ///< 0-100 (%)
+		uint32_t   internalCooldownMs = 0; ///< 0 = pas de ICD
+	};
+
+	class ProcMgr
+	{
+	public:
+		ProcMgr() = default;
+
+		/// Enregistre un proc template. Indexe par event pour lookup O(1)
+		/// au moment d'OnEvent.
+		void Register(ProcTemplate proc)
+		{
+			m_byEvent[proc.event].push_back(proc);
+		}
+
+		/// Declenche les procs eligibles pour \p event. Retourne les
+		/// spellIds a caster (apres roll chance).
+		///
+		/// \param event       type d'event qui s'est produit
+		/// \param rng         random generator (caller fournit pour reproductibilite)
+		/// \param nowMs       timestamp actuel (pour ICD check)
+		/// \param ownerProcCooldowns map procId → nextReadyAtMs par owner (modifiee in-place)
+		/// \return liste de spellIds a caster
+		std::vector<SpellId> OnEvent(
+			ProcEvent event,
+			std::mt19937& rng,
+			uint64_t nowMs,
+			std::unordered_map<uint32_t, uint64_t>& ownerProcCooldowns) const
+		{
+			std::vector<SpellId> out;
+			auto it = m_byEvent.find(event);
+			if (it == m_byEvent.end()) return out;
+
+			std::uniform_int_distribution<uint32_t> d(0, 99);
+			for (const auto& p : it->second)
+			{
+				// ICD check.
+				auto cdIt = ownerProcCooldowns.find(p.procId);
+				if (cdIt != ownerProcCooldowns.end() && nowMs < cdIt->second)
+					continue;
+				// Roll chance.
+				if (p.procChance >= 100 || d(rng) < p.procChance)
+				{
+					out.push_back(p.triggerSpell);
+					if (p.internalCooldownMs > 0)
+						ownerProcCooldowns[p.procId] = nowMs + p.internalCooldownMs;
+				}
+			}
+			return out;
+		}
+
+		size_t ProcCount() const noexcept
+		{
+			size_t total = 0;
+			for (const auto& kv : m_byEvent) total += kv.second.size();
+			return total;
+		}
+
+	private:
+		std::unordered_map<ProcEvent, std::vector<ProcTemplate>> m_byEvent;
+	};
+}

--- a/src/shardd/spell/Spell.h
+++ b/src/shardd/spell/Spell.h
@@ -1,0 +1,108 @@
+#pragma once
+// Wave 23 — Spell : INSTANCE de cast en cours. State machine :
+//
+//   Idle ──Begin──> Casting ──TickReady──> Casted ──Apply──> Resolved
+//                      │
+//                      └──Interrupt──> Interrupted (terminal)
+//
+// Le caller (combat handler / event tick) appelle Tick(deltaMs) chaque
+// frame. Quand l'etat passe a Casted, le caller doit appeler Apply()
+// (effet sur target) avant que Resolved soit atteint.
+//
+// Stateless cote SpellTemplate : Spell detient juste l'avancement du cast.
+
+#include "src/shardd/spell/SpellTemplate.h"
+
+#include <cstdint>
+
+namespace engine::server::spell
+{
+	using TargetEntityId = uint64_t;
+
+	enum class SpellState : uint8_t
+	{
+		Idle        = 0,
+		Casting     = 1,
+		Casted      = 2,   ///< cast time complete, en attente Apply()
+		Resolved    = 3,   ///< Apply() appele, effet propage
+		Interrupted = 4,   ///< terminal, kick durant Casting
+	};
+
+	inline const char* SpellStateToString(SpellState s) noexcept
+	{
+		switch (s)
+		{
+			case SpellState::Idle:        return "Idle";
+			case SpellState::Casting:     return "Casting";
+			case SpellState::Casted:      return "Casted";
+			case SpellState::Resolved:    return "Resolved";
+			case SpellState::Interrupted: return "Interrupted";
+		}
+		return "Unknown";
+	}
+
+	class Spell
+	{
+	public:
+		/// \param tpl template du sort (lifetime garanti par caller)
+		/// \param target entityId du target principal (peut etre 0 pour Self)
+		Spell(const SpellTemplate& tpl, TargetEntityId target)
+			: m_tpl(&tpl), m_target(target)
+		{}
+
+		const SpellTemplate& Template() const noexcept { return *m_tpl; }
+		TargetEntityId       Target() const noexcept { return m_target; }
+		SpellState           State() const noexcept { return m_state; }
+		uint32_t             ElapsedMs() const noexcept { return m_elapsedMs; }
+
+		/// Demarre le cast : transition Idle → Casting. No-op si pas Idle.
+		bool Begin()
+		{
+			if (m_state != SpellState::Idle) return false;
+			m_state = SpellState::Casting;
+			m_elapsedMs = 0;
+			return true;
+		}
+
+		/// Avance le timer. Si elapsedMs >= castTimeMs, transition vers
+		/// Casted (cast complete, en attente d'Apply). No-op si pas Casting.
+		void Tick(uint32_t deltaMs)
+		{
+			if (m_state != SpellState::Casting) return;
+			m_elapsedMs += deltaMs;
+			if (m_elapsedMs >= m_tpl->castTimeMs)
+				m_state = SpellState::Casted;
+		}
+
+		/// Marque le sort comme resolu (effet propage via Aura ou damage).
+		/// No-op si pas Casted.
+		bool Apply()
+		{
+			if (m_state != SpellState::Casted) return false;
+			m_state = SpellState::Resolved;
+			return true;
+		}
+
+		/// Interrompt le cast (kick, mort, mouvement). Transition possible
+		/// uniquement depuis Casting. No-op sinon.
+		bool Interrupt()
+		{
+			if (m_state != SpellState::Casting) return false;
+			m_state = SpellState::Interrupted;
+			return true;
+		}
+
+		/// True si le sort est terminal (Resolved ou Interrupted) — peut etre
+		/// retire de la liste active.
+		bool IsTerminal() const noexcept
+		{
+			return m_state == SpellState::Resolved || m_state == SpellState::Interrupted;
+		}
+
+	private:
+		const SpellTemplate* m_tpl;
+		TargetEntityId       m_target;
+		SpellState           m_state    = SpellState::Idle;
+		uint32_t             m_elapsedMs = 0;
+	};
+}

--- a/src/shardd/spell/SpellMgr.h
+++ b/src/shardd/spell/SpellMgr.h
@@ -1,0 +1,45 @@
+#pragma once
+// Wave 23 — SpellMgr : catalogue des SpellTemplate. Indexe par spellId,
+// lookup O(1). Immutable au runtime apres chargement initial (les
+// templates sont des donnees DB read-only via SqlStorage Wave 18).
+//
+// Pas thread-safe en mutation : Register() doit etre appele uniquement
+// pendant le boot ou un /reload manuel ; les lookups Find() sont
+// concurrents safe (lecture seule).
+
+#include "src/shardd/spell/SpellTemplate.h"
+
+#include <cstddef>
+#include <unordered_map>
+
+namespace engine::server::spell
+{
+	class SpellMgr
+	{
+	public:
+		SpellMgr() = default;
+
+		/// Enregistre un template. Si un template avec le meme spellId existe
+		/// deja, il est REMPLACE (hot-reload friendly).
+		void Register(SpellTemplate tpl)
+		{
+			const SpellId id = tpl.spellId;
+			m_templates[id] = std::move(tpl);
+		}
+
+		/// Cherche un template par id. Retourne nullptr si inconnu.
+		const SpellTemplate* Find(SpellId id) const
+		{
+			auto it = m_templates.find(id);
+			return (it != m_templates.end()) ? &it->second : nullptr;
+		}
+
+		/// Reset le catalogue. Utile pour les tests et le /reload spells.
+		void Clear() noexcept { m_templates.clear(); }
+
+		size_t TemplateCount() const noexcept { return m_templates.size(); }
+
+	private:
+		std::unordered_map<SpellId, SpellTemplate> m_templates;
+	};
+}

--- a/src/shardd/spell/SpellMgrTests.cpp
+++ b/src/shardd/spell/SpellMgrTests.cpp
@@ -1,0 +1,290 @@
+// Wave 23 — SpellMgr + Spell state machine + Aura tick + ProcMgr tests.
+// Pattern aligne sur les autres tests Wave : asserts + printf.
+// Cible CTest : spell_mgr_tests (consolide les 4 sous-domaines en 1 binaire).
+
+#include "src/shardd/spell/SpellMgr.h"
+#include "src/shardd/spell/Spell.h"
+#include "src/shardd/spell/Aura.h"
+#include "src/shardd/spell/ProcMgr.h"
+
+#include <cassert>
+#include <cstdio>
+#include <random>
+#include <string>
+
+using namespace engine::server::spell;
+
+namespace
+{
+	SpellTemplate MakeBasicSpell(SpellId id, uint32_t castMs, uint32_t durMs = 0,
+		uint32_t tickMs = 0, int32_t basePts = 100)
+	{
+		SpellTemplate t;
+		t.spellId      = id;
+		t.name         = "TestSpell" + std::to_string(id);
+		t.targetType   = SpellTargetType::SingleEnemy;
+		t.castTimeMs   = castMs;
+		t.durationMs   = durMs;
+		t.tickPeriodMs = tickMs;
+		t.basePoints   = basePts;
+		return t;
+	}
+
+	// ========================================================================
+	// SpellMgr
+	// ========================================================================
+
+	void TestSpellMgrRegisterFind()
+	{
+		SpellMgr mgr;
+		mgr.Register(MakeBasicSpell(100, 1500));
+		mgr.Register(MakeBasicSpell(200, 0));
+		assert(mgr.TemplateCount() == 2);
+		const auto* t = mgr.Find(100);
+		assert(t != nullptr && t->castTimeMs == 1500);
+		assert(mgr.Find(999) == nullptr);
+		std::puts("[OK] TestSpellMgrRegisterFind");
+	}
+
+	void TestSpellMgrReregisterOverwrites()
+	{
+		SpellMgr mgr;
+		mgr.Register(MakeBasicSpell(100, 1500));
+		mgr.Register(MakeBasicSpell(100, 3000));  // overwrite
+		assert(mgr.TemplateCount() == 1);
+		assert(mgr.Find(100)->castTimeMs == 3000);
+		std::puts("[OK] TestSpellMgrReregisterOverwrites");
+	}
+
+	// ========================================================================
+	// Spell state machine
+	// ========================================================================
+
+	void TestSpellStateInstant()
+	{
+		auto tpl = MakeBasicSpell(1, 0);  // cast instant
+		Spell s(tpl, /*target*/42);
+		assert(s.State() == SpellState::Idle);
+		assert(s.Begin());
+		// castTimeMs = 0 -> Tick(0) doit faire passer Casting -> Casted
+		s.Tick(0);
+		assert(s.State() == SpellState::Casted);
+		assert(s.Apply());
+		assert(s.State() == SpellState::Resolved);
+		assert(s.IsTerminal());
+		std::puts("[OK] TestSpellStateInstant");
+	}
+
+	void TestSpellStateCastTime()
+	{
+		auto tpl = MakeBasicSpell(1, 1500);
+		Spell s(tpl, 42);
+		assert(s.Begin());
+		s.Tick(500);
+		assert(s.State() == SpellState::Casting);
+		s.Tick(500);
+		assert(s.State() == SpellState::Casting);
+		s.Tick(500);
+		assert(s.State() == SpellState::Casted);  // 1500ms elapsed
+		assert(s.Apply());
+		assert(s.State() == SpellState::Resolved);
+		std::puts("[OK] TestSpellStateCastTime");
+	}
+
+	void TestSpellInterrupt()
+	{
+		auto tpl = MakeBasicSpell(1, 2000);
+		Spell s(tpl, 42);
+		assert(s.Begin());
+		s.Tick(500);
+		assert(s.Interrupt());
+		assert(s.State() == SpellState::Interrupted);
+		assert(s.IsTerminal());
+		// Tick post-interrupt = no-op.
+		s.Tick(1000);
+		assert(s.State() == SpellState::Interrupted);
+		// Apply post-interrupt = false.
+		assert(!s.Apply());
+		std::puts("[OK] TestSpellInterrupt");
+	}
+
+	void TestSpellInvalidTransitions()
+	{
+		auto tpl = MakeBasicSpell(1, 1000);
+		Spell s(tpl, 42);
+		// Apply avant Begin : false.
+		assert(!s.Apply());
+		// Interrupt avant Begin : false (pas Casting).
+		assert(!s.Interrupt());
+		// Begin 2x : 2e false.
+		assert(s.Begin());
+		assert(!s.Begin());
+		std::puts("[OK] TestSpellInvalidTransitions");
+	}
+
+	// ========================================================================
+	// Aura tick + stack
+	// ========================================================================
+
+	void TestAuraExpiration()
+	{
+		auto tpl = MakeBasicSpell(1, /*cast*/0, /*duration*/5000);
+		Aura a(tpl, /*caster*/10, /*target*/20, /*nowMs*/1000);
+		assert(!a.IsExpired(1000));
+		assert(!a.IsExpired(5000));
+		assert(!a.IsExpired(5999));
+		assert(a.IsExpired(6000));   // applied=1000 + duration=5000 = 6000
+		assert(a.IsExpired(10000));
+		std::puts("[OK] TestAuraExpiration");
+	}
+
+	void TestAuraTickPeriodic()
+	{
+		// Duration 10s, tick toutes les 2s -> 4 ticks attendus (a 2,4,6,8s).
+		// Le tick a 10s tombe pile sur expiresAtMs, donc le check < expires
+		// l'exclut.
+		auto tpl = MakeBasicSpell(1, 0, /*duration*/10000, /*tick*/2000);
+		Aura a(tpl, 10, 20, /*applied*/0);
+		// Avance jusqu'a 9000 ms -> ticks consommes a 2k,4k,6k,8k = 4 ticks.
+		uint32_t total = a.AdvanceTick(9000);
+		assert(total == 4);
+		// Re-advance to 9500 : no new tick (next serait a 10000 = expires).
+		total = a.AdvanceTick(9500);
+		assert(total == 0);
+		std::puts("[OK] TestAuraTickPeriodic");
+	}
+
+	void TestAuraStack()
+	{
+		auto tpl = MakeBasicSpell(1, 0, /*duration*/5000);
+		Aura a1(tpl, /*caster*/10, /*target*/20, /*applied*/1000);
+		Aura a2(tpl, /*caster*/10, /*target*/20, /*applied*/2000);
+		assert(a1.CanStackWith(a2));
+		// Stack : refresh + increment count.
+		a1.Stack(2000);
+		assert(a1.StackCount() == 2);
+		assert(a1.ExpiresAtMs() == 7000);  // 2000 + 5000
+		std::puts("[OK] TestAuraStack");
+	}
+
+	void TestAuraNoStackDifferentCaster()
+	{
+		auto tpl = MakeBasicSpell(1, 0, 5000);
+		Aura a1(tpl, /*caster*/10, 20, 0);
+		Aura a2(tpl, /*caster*/11, 20, 0);  // caster different
+		assert(!a1.CanStackWith(a2));
+		std::puts("[OK] TestAuraNoStackDifferentCaster");
+	}
+
+	void TestAuraNoTickIfPassive()
+	{
+		// Duration > 0 mais tickPeriodMs = 0 -> aura passive, pas de tick.
+		auto tpl = MakeBasicSpell(1, 0, 5000, /*tick*/0);
+		Aura a(tpl, 10, 20, 0);
+		uint32_t ticks = a.AdvanceTick(10000);
+		assert(ticks == 0);
+		std::puts("[OK] TestAuraNoTickIfPassive");
+	}
+
+	// ========================================================================
+	// ProcMgr
+	// ========================================================================
+
+	void TestProcMgrChanceFull()
+	{
+		ProcMgr proc;
+		ProcTemplate t;
+		t.procId = 1;
+		t.event = ProcEvent::OnMeleeHit;
+		t.triggerSpell = 999;
+		t.procChance = 100;  // always
+		proc.Register(t);
+
+		std::mt19937 rng(42);
+		std::unordered_map<uint32_t, uint64_t> cd;
+		auto out = proc.OnEvent(ProcEvent::OnMeleeHit, rng, 1000, cd);
+		assert(out.size() == 1 && out[0] == 999);
+		std::puts("[OK] TestProcMgrChanceFull");
+	}
+
+	void TestProcMgrChanceZero()
+	{
+		ProcMgr proc;
+		ProcTemplate t;
+		t.procId = 2;
+		t.event = ProcEvent::OnSpellCrit;
+		t.triggerSpell = 555;
+		t.procChance = 0;  // never
+		proc.Register(t);
+
+		std::mt19937 rng(42);
+		std::unordered_map<uint32_t, uint64_t> cd;
+		auto out = proc.OnEvent(ProcEvent::OnSpellCrit, rng, 1000, cd);
+		assert(out.empty());
+		std::puts("[OK] TestProcMgrChanceZero");
+	}
+
+	void TestProcMgrInternalCooldown()
+	{
+		ProcMgr proc;
+		ProcTemplate t;
+		t.procId = 3;
+		t.event = ProcEvent::OnMeleeCrit;
+		t.triggerSpell = 777;
+		t.procChance = 100;  // always
+		t.internalCooldownMs = 5000;
+		proc.Register(t);
+
+		std::mt19937 rng(42);
+		std::unordered_map<uint32_t, uint64_t> cd;
+		// Premier proc : OK.
+		auto out1 = proc.OnEvent(ProcEvent::OnMeleeCrit, rng, 1000, cd);
+		assert(out1.size() == 1);
+		// 2e proc 2s plus tard : ICD bloque.
+		auto out2 = proc.OnEvent(ProcEvent::OnMeleeCrit, rng, 3000, cd);
+		assert(out2.empty());
+		// 5.5s apres premier proc : OK.
+		auto out3 = proc.OnEvent(ProcEvent::OnMeleeCrit, rng, 6500, cd);
+		assert(out3.size() == 1);
+		std::puts("[OK] TestProcMgrInternalCooldown");
+	}
+
+	void TestProcMgrEventMismatch()
+	{
+		ProcMgr proc;
+		ProcTemplate t;
+		t.procId = 4;
+		t.event = ProcEvent::OnDeath;
+		t.triggerSpell = 111;
+		t.procChance = 100;
+		proc.Register(t);
+
+		std::mt19937 rng(42);
+		std::unordered_map<uint32_t, uint64_t> cd;
+		// Event different : aucun proc.
+		auto out = proc.OnEvent(ProcEvent::OnMeleeHit, rng, 1000, cd);
+		assert(out.empty());
+		std::puts("[OK] TestProcMgrEventMismatch");
+	}
+}
+
+int main()
+{
+	TestSpellMgrRegisterFind();
+	TestSpellMgrReregisterOverwrites();
+	TestSpellStateInstant();
+	TestSpellStateCastTime();
+	TestSpellInterrupt();
+	TestSpellInvalidTransitions();
+	TestAuraExpiration();
+	TestAuraTickPeriodic();
+	TestAuraStack();
+	TestAuraNoStackDifferentCaster();
+	TestAuraNoTickIfPassive();
+	TestProcMgrChanceFull();
+	TestProcMgrChanceZero();
+	TestProcMgrInternalCooldown();
+	TestProcMgrEventMismatch();
+	std::puts("All SpellMgr/Spell/Aura/ProcMgr tests passed");
+	return 0;
+}

--- a/src/shardd/spell/SpellTemplate.h
+++ b/src/shardd/spell/SpellTemplate.h
@@ -1,0 +1,45 @@
+#pragma once
+// Wave 23 — SpellTemplate : donnees statiques d'un sort (immuable apres
+// load). Compose avec SpellFamilyMask (Wave 9 existant) pour le matching
+// proc/aura cross-spell.
+//
+// Le runtime cree un Spell (instance de cast) qui pointe vers ce template
+// via spellId. Les valeurs (basePoints, durationMs, cooldownMs) restent
+// lisibles via le template ; chaque cast applique d'eventuels modifiers.
+
+#include "src/shardd/spell/SpellFamilyMask.h"
+
+#include <cstdint>
+#include <string>
+
+namespace engine::server::spell
+{
+	using SpellId = uint32_t;
+
+	/// Type de target sur le sort. Determine comment les engagements
+	/// d'eligibilite (range, LOS, faction) sont evalues par le caster.
+	enum class SpellTargetType : uint8_t
+	{
+		Self          = 0,
+		SingleEnemy   = 1,
+		SingleAlly    = 2,
+		AreaAroundSelf = 3,   ///< AOE rayon autour du caster
+		AreaAtTarget  = 4,    ///< AOE rayon autour du target
+		Cone          = 5,    ///< Cone devant le caster
+	};
+
+	/// Donnees statiques d'un sort. Chargees une fois au boot, immuables.
+	struct SpellTemplate
+	{
+		SpellId         spellId        = 0;
+		std::string     name;          ///< affichage UI/log uniquement
+		SpellTargetType targetType     = SpellTargetType::SingleEnemy;
+		uint32_t        castTimeMs     = 1500;  ///< 0 = instant
+		uint32_t        cooldownMs     = 0;     ///< 0 = pas de cooldown
+		int32_t         basePoints     = 0;     ///< dommages / soins / mod stat (positif/negatif)
+		uint32_t        durationMs     = 0;     ///< 0 = instant ; > 0 = applique un Aura
+		uint32_t        tickPeriodMs   = 0;     ///< 0 = pas de tick (Aura passive)
+		float           rangeMeters    = 30.0f;
+		SpellFamilyMask familyMask;             ///< grouping pour proc/dispel
+	};
+}


### PR DESCRIPTION
## Summary

Wave 23 livre le **catalogue de sorts + instance de cast + effets persistants + déclencheurs conditionnels** (header-only). Étend `src/shardd/spell/` existant (Wave 9 #577 SpellFamilyMask + Runtime).

C'est le **Wave 23 de la roadmap server-first** ([spec §4 Wave 23](docs/superpowers/specs/2026-05-11-waves-17-38-server-foundations-design.md)).

## Fichiers

| Fichier | Rôle |
|---------|------|
| `SpellTemplate.h` | Données statiques (spellId, targetType, castTimeMs, cooldownMs, basePoints, durationMs, tickPeriodMs, rangeMeters, familyMask) |
| `Spell.h` | INSTANCE de cast — state machine Idle→Casting→Casted→Resolved (ou Interrupted) |
| `Aura.h` | Effet persistant — tick periodic, expire, CanStackWith + Stack |
| `ProcMgr.h` | Registry proc templates, OnEvent(event, rng, nowMs, cd) retourne spellIds |
| `SpellMgr.h` | Catalogue Register/Find/Clear |
| `SpellMgrTests.cpp` | 15 cas |
| `sql/migrations/0061_spell_aura.sql` | 2 tables (`character_auras` persist, `spell_proc_template` data-driven) |

## Audit anti-doublon

`grep "class SpellMgr\|class Aura\b\|class ProcMgr" src/` → 0 hit avant cette PR. SpellFamilyMask (Wave 9) intact.

## Convention PascalCase

Fichiers + classes + méthodes en PascalCase. Dossier `src/shardd/spell/` existant lowercase conservé (ajout de fichiers PascalCase dedans).

## State machine Spell

```
Idle ─Begin()─> Casting ─Tick(deltaMs)─> Casted ─Apply()─> Resolved
                   │
                   └─Interrupt()─> Interrupted
```

Tous les transitions invalides retournent `false` (defensif). `IsTerminal()` true pour `Resolved` ou `Interrupted`.

## API exemple

```cpp
// Catalogue boot
engine::server::spell::SpellMgr mgr;
mgr.Register({.spellId = 100, .castTimeMs = 1500, .durationMs = 8000, .tickPeriodMs = 2000, .basePoints = 25});

// Cast un sort
const auto* tpl = mgr.Find(100);
engine::server::spell::Spell s(*tpl, /*target*/playerId);
s.Begin();
// Tick chaque frame
s.Tick(33);  // 33ms = ~30 FPS
if (s.State() == SpellState::Casted) {
    s.Apply();
    // Si durationMs > 0, le caller cree un Aura sur le target
    engine::server::spell::Aura a(*tpl, casterId, targetId, nowMs);
    // Tick l'Aura chaque frame
    uint32_t ticks = a.AdvanceTick(nowMs);
    // ticks * basePoints = damage/heal applique cette frame
}
```

## Test plan

- [ ] Linux build + ctest (gate actif depuis #592)
- [ ] `spell_mgr_tests` — 15 cas couvrant les 4 sous-domaines
- [ ] Windows build

## Limites volontaires Wave 23

- **Pas d'intégration Unit (Wave 17)** — Aura n'est pas encore "attaché" à Unit côté code ; c'est le travail d'un wiring ultérieur.
- **Pas de wiring runtime** — SpellMgr/ProcMgr ne sont pas câblés au boot. Un `SpellMgrRuntime.cpp` viendra plus tard.
- **Stack rules simples** — meme spellId + meme caster = stack. Les règles WoW complètes (school-based, partial stack, etc.) viendront plus tard.
- **NeedBeforeGreed tiebreaker** : premier-dans-eligible (cf. note Wave 22 PR #597).

## Déploiement

⚠️ **REDÉPLOIEMENT SHARD REQUIS** — migration 0061 + binaire. Pas de wire-breaking, pas d'impact client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)