### PR TITLE
fix(client/sky): /sky info reponse master affichee dans le chat in-game

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -2600,6 +2600,21 @@ namespace engine
 							static_cast<unsigned>(s.moonPhase),
 							kMoonName[s.moonPhase < 16 ? s.moonPhase : 0],
 							s.moonIllumination * 100.0f);
+
+						// Affichage chat in-game : sans ce push, l'utilisateur ne voit
+						// l'info que dans les logs. Cf. pattern identique pour /sky moon
+						// (pushAdminChatLine plus haut) et /who/report/kick/ban/announce.
+						pushAdminChatLine("[Sky]", "timeOfDay=%.2fh isDaytime=%d",
+							static_cast<double>(s.timeOfDay),
+							static_cast<int>(s.isDaytime));
+						pushAdminChatLine("[Sky]", "sunDir=(%.2f,%.2f,%.2f)",
+							static_cast<double>(s.lightDir[0]),
+							static_cast<double>(s.lightDir[1]),
+							static_cast<double>(s.lightDir[2]));
+						pushAdminChatLine("[Sky]", "moonPhase=%u (%s) illumination=%.0f%%",
+							static_cast<unsigned>(s.moonPhase),
+							kMoonName[s.moonPhase < 16 ? s.moonPhase : 0],
+							static_cast<double>(s.moonIllumination * 100.0f));
 					}
 					else if (parsed.command == "/loot")
 					{


### PR DESCRIPTION
## Bug observé

L'utilisateur tape \`/sky info\` dans le chat in-game. Côté master :
\`\`\`
[Audit] [AdminCommand] account_id=1 role=administrator command="/sky info" args=[] result=OK
\`\`\`
→ **Master OK** : commande reçue, RBAC passé, audit log écrit, AdminCommandResponse envoyée au client.

Côté client : la ligne d'écho local \`05:28 SRV [SKY] /SKY INFO ENVOYE AU MASTER (AUDIT + RBAC)\` apparaît bien (envoi confirmé), **mais aucune ligne de réponse ne s'affiche** dans le chat panel — alors que le master a bien répondu.

## Cause racine

Dans \`src/client/app/Engine.cpp:2586-2603\`, le handler \`/sky info\` côté client :
- ✅ Reçoit la \`AdminCommandResponse\`
- ✅ Lit l'état local DayNight (\`m_dayNight.GetState()\`)
- ✅ Logue 3 lignes via \`LOG_INFO(Render, ...)\` (visible dans console/log files)
- ❌ **N'appelle PAS \`pushAdminChatLine\`** → rien n'est poussé dans le chat panel UI

Comparaison avec \`/sky moon\` (ligne 2566) qui fait bien \`pushAdminChatLine\` après son ACK : c'est juste un oubli sur \`/sky info\`.

## Fix

Ajout de 3 \`pushAdminChatLine("[Sky]", ...)\` après les 3 \`LOG_INFO\` existants (mêmes données, format adapté à printf-style requis par le helper). Pattern identique à \`/sky moon\` et aux commandes Wave 2 (/who, /report, /kick, /ban, /announce).

Lignes désormais affichées dans le chat panel après \`/sky info\` :
\`\`\`
[Sky] timeOfDay=X.XXh isDaytime=0/1
[Sky] sunDir=(X.XX, Y.YY, Z.ZZ)
[Sky] moonPhase=N (NomPhase) illumination=N%
\`\`\`

## Note conceptuelle

\`/sky info\` est volontairement **lecture seule côté gameplay** (cf. \`DispatchSkyInfo\` dans \`AdminCommandHandler.cpp:252-270\`) : le master n'envoie pas les valeurs dans \`resp.result\`, il acquitte juste avec \`status=Ok\`. C'est l'état local \`m_dayNight\` côté client qui est lu pour afficher l'info. L'ACK master sert uniquement de gate RBAC + audit log.

## Test plan

- [ ] CI Linux build + ctest
- [ ] CI Windows build (le code touche \`src/client/app/Engine.cpp\` qui est compilé Windows)
- [ ] Test manuel : se connecter en compte administrator, taper \`/sky info\` dans le chat, vérifier que 3 lignes \`[Sky] ...\` apparaissent dans le panel.

## Déploiement

✅ **Pas de redéploiement serveur** — fix client pur. Le master fait déjà sa part correctement (envoie l'ACK depuis le début). L'utilisateur peut continuer à utiliser l'ancien client tant qu'il accepte de ne pas voir le retour visuel ; le nouveau client affichera bien les 3 lignes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)