### PR TITLE
fix(client/auth): débloquer l'UI quand le master est injoignable

### DIFF
--- a/game/data/localization/en/en.json
+++ b/game/data/localization/en/en.json
@@ -233,6 +233,7 @@
   "auth.info.character_cancelled": "Character creation cancelled. Back to login.",
   "auth.info.reconnect_in_progress": "Connection lost. Reconnecting...",
   "auth.info.reconnect_success": "Connection restored.",
+  "auth.info.server_unavailable": "Server unavailable. Please try again in a moment.",
   "auth.error.reconnect_failed_back_to_login": "Reconnection failed. Back to login.",
   "auth.hint.login.submit": "Enter to log in",
   "auth.hint.login.register": "Ctrl+R create an account",

--- a/game/data/localization/fr/fr.json
+++ b/game/data/localization/fr/fr.json
@@ -233,6 +233,7 @@
   "auth.info.character_cancelled": "Creation du personnage annulee. Retour a la connexion.",
   "auth.info.reconnect_in_progress": "Connexion perdue. Reconnexion en cours...",
   "auth.info.reconnect_success": "Connexion retablie.",
+  "auth.info.server_unavailable": "Serveur indisponible. Reessayez dans quelques instants.",
   "auth.error.reconnect_failed_back_to_login": "Reconnexion impossible. Retour a la connexion.",
   "auth.hint.login.submit": "Entree pour se connecter",
   "auth.hint.login.register": "Ctrl+R creer un compte",

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4743,9 +4743,11 @@ namespace engine
 														}
 														LOG_DEBUG(Render, "[CopyPresent] UI layers cleared; recording glyphs (if valid)");
 														// Dessiner le logo AVANT le texte pour éviter qu’un PNG opaque ne recouvre les glyphes.
-														// Logo statut : uniquement pendant la requête HTTP (pas quand le cache est à jour).
+														// Logo statut : affiche pendant la requete HTTP (spin) ET ensuite, des qu'un
+														// resultat de sonde est connu, pour montrer success/error. Sans cette seconde
+														// condition, l'utilisateur perd tout retour visuel quand le master est down.
 														const bool showAuthStatusLogo = authVisualState.login
-															&& authVisualState.authLogoSpin;
+															&& (authVisualState.authLogoSpin || authVisualState.authStatusKnown);
 														if (m_authLogoPass.IsValid() && showAuthStatusLogo)
 														{
 															engine::render::TextureAsset* logoTex = nullptr;
@@ -4753,11 +4755,13 @@ namespace engine
 															{
 																logoTex = m_authLogoTexture.Get();
 															}
-															else if (authVisualState.authStatusOk && m_authLogoSuccessTexture.IsValid())
+															else if (authVisualState.authStatusKnown && authVisualState.authStatusOk
+																&& m_authLogoSuccessTexture.IsValid())
 															{
 																logoTex = m_authLogoSuccessTexture.Get();
 															}
-															else if (!authVisualState.authStatusOk && m_authLogoErrorTexture.IsValid())
+															else if (authVisualState.authStatusKnown && !authVisualState.authStatusOk
+																&& m_authLogoErrorTexture.IsValid())
 															{
 																logoTex = m_authLogoErrorTexture.Get();
 															}

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -635,7 +635,11 @@ namespace engine::client
 				return resp;
 			}
 
-			WinHttpSetTimeouts(hRequest, 10000u, 10000u, timeoutMs, timeoutMs);
+			// Propager le timeout configure aux 4 phases (resolve, connect, send, receive) :
+			// sans cela, resolve/connect restent a 10 s chacun et WinHTTP retente plusieurs
+			// fois => le worker bloque ~30 s quand le master est down, alors qu'on attend
+			// un echec rapide pour basculer l'UI sur "serveur indisponible".
+			WinHttpSetTimeouts(hRequest, timeoutMs, timeoutMs, timeoutMs, timeoutMs);
 			LOG_INFO(Core, "[StatusProbe] WinHTTP: envoi de la requête…");
 
 			if (!WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0))
@@ -1616,6 +1620,26 @@ namespace engine::client
 			m_authAvailabilityChecking = false;
 			m_authAvailabilityPollTimer = 0.f;
 			m_authLogoRotationRad = 0.f;
+			// Le master peut etre injoignable (transport HTTP en echec) ou repondre que le service
+			// est indisponible (authOk/masterOk faux). Dans ces deux cas, exposer un message clair
+			// dans m_infoBanner pour que l'utilisateur sache pourquoi la connexion ne progresse pas.
+			// Quand la sonde redevient OK, on retire un eventuel ancien message server_unavailable
+			// pour ne pas le laisser trainer.
+			{
+				const bool probeOk = copy.success && m_statusCache.authOk && m_statusCache.masterOk;
+				const std::string unavailableMsg = Tr("auth.info.server_unavailable");
+				if (!probeOk)
+				{
+					if (m_infoBanner.empty() || m_infoBanner == unavailableMsg)
+					{
+						m_infoBanner = m_statusCache.infoMessage.empty() ? unavailableMsg : m_statusCache.infoMessage;
+					}
+				}
+				else if (m_infoBanner == unavailableMsg)
+				{
+					m_infoBanner.clear();
+				}
+			}
 			LOG_INFO(Core,
 				"[StatusProbe] thread principal: résultat consommé — httpLayerOk={} authOk={} masterOk={} shards={} totalJoueurs={} "
 				"infoMessage='{}' workerMsg='{}' → UI: maintenance seulement si httpLayerOk et JSON indique indisponibilité",


### PR DESCRIPTION
## Contexte

Diagnostic à partir d'un log client de ~51 000 lignes (~26 s de session sur l'écran d'authentification, avec le master volontairement down pour maintenance). Trois bugs cumulés donnent au joueur l'illusion d'un client figé alors que le binaire tourne normalement.

## Bugs corrigés

### 1. `WinHttpSetTimeouts` ne propage pas le timeout configuré
`src/client/auth/AuthUiPresenterCore.cpp:638` — le timeout `1500 ms` n'était appliqué qu'aux phases `send`/`receive`. `resolve` et `connect` restaient hardcodés à `10 000 ms`. WinHTTP retentant la connexion 3× sur erreur réseau, le worker thread bloquait ~30 s avant de remonter l'échec, au lieu des 1.5 s attendus. Fix : propager `timeoutMs` aux 4 phases.

### 2. Logo statut jamais affiché après la sonde
`src/client/app/Engine.cpp:4747` — la garde extérieure `showAuthStatusLogo` exigeait `authLogoSpin == true`. Conséquence : les branches `m_authLogoSuccessTexture` / `m_authLogoErrorTexture` à l'intérieur du `if` étaient **inaccessibles**. Quand la sonde se terminait (succès ou échec), `authLogoSpin` repassait à `false` et plus aucun logo n'était dessiné. Fix : autoriser l'affichage si `authLogoSpin || authStatusKnown`, et conditionner les branches success/error sur `authStatusKnown`.

### 3. Aucun message texte quand la sonde échoue
`AuthUiPresenterCore.cpp` — `PollAsyncResult` consommait le résultat de la sonde mais ne remplissait pas `m_infoBanner`. Aucun feedback texte pour l'utilisateur. Fix : en cas d'échec (`!copy.success || !authOk || !masterOk`), poser `m_infoBanner` avec la clé localisée `auth.info.server_unavailable` (fallback) ou `m_statusCache.infoMessage` si renseigné. Le banner se vide automatiquement quand la sonde redevient OK. Nouvelles clés ajoutées dans `fr.json` et `en.json`.

## Ce qui n'est pas dans cette PR

- ❌ Désactivation du bouton SE CONNECTER pendant la sonde (changement de comportement, à discuter séparément)
- ❌ Auto-retry plus agressif que l'intervalle 120 s existant
- ❌ Aucune modification serveur

## Test plan

- [ ] Build Windows + lancer le client avec un master volontairement down
- [ ] Vérifier dans le log : `WinHttpSendRequest a échoué — 12002` doit apparaître ~1.5 s après le démarrage (et plus ~30 s)
- [ ] Vérifier visuellement : logo "erreur" affiché en coin (au lieu de rien) après l'échec de la sonde
- [ ] Vérifier visuellement : bannière « Serveur indisponible. Réessayez dans quelques instants. » visible sur l'écran d'auth
- [ ] Relancer le master, attendre la prochaine sonde (~120 s), vérifier que le logo bascule en "success" et que la bannière disparaît
- [ ] Tester en `locale=en` pour valider la traduction anglaise

## Déploiement

✅ **Client uniquement, pas de redéploiement serveur.** Aucun changement de protocole, aucun nouveau handler master/shard, aucune migration DB.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8KW9akjsHfts372ii2tb5)_