### PR TITLE
fix(client/world): déduppe les WARN "terrain.bin absent" dans StreamCache

### DIFF
--- a/src/client/world/StreamCache.cpp
+++ b/src/client/world/StreamCache.cpp
@@ -106,6 +106,10 @@ namespace engine::world
 		const size_t entryCount = m_map.size();
 		m_map.clear();
 		m_lruOrder.clear();
+		// Le set de cles "deja warnees" suit le meme cycle de vie : changer de zone
+		// reset le contexte et on veut a nouveau diagnostiquer un eventuel chunk
+		// manquant dans la nouvelle zone.
+		m_terrainChunkMissWarned.clear();
 		m_currentSizeBytes = 0;
 		m_hitCount = 0;
 		m_missCount = 0;
@@ -129,7 +133,11 @@ namespace engine::world
 		std::ifstream f(fullPath, std::ios::binary);
 		if (!f.good())
 		{
-			LOG_WARN(World, "[StreamCache] terrain.bin absent: {}", fullPath);
+			// Le scheduler peut interroger ce chunk a chaque frame. On garde le WARN
+			// pour signaler une fois l'absence (utile en diag), mais on dedup par cle
+			// pour ne pas inonder le log (cf. m_terrainChunkMissWarned).
+			if (m_terrainChunkMissWarned.insert(cacheKey).second)
+				LOG_WARN(World, "[StreamCache] terrain.bin absent: {} (warn unique par cle, voir Clear())", fullPath);
 			return nullptr;
 		}
 		f.seekg(0, std::ios::end);
@@ -137,7 +145,8 @@ namespace engine::world
 		f.seekg(0, std::ios::beg);
 		if (fileSize <= 0)
 		{
-			LOG_WARN(World, "[StreamCache] terrain.bin vide: {}", fullPath);
+			if (m_terrainChunkMissWarned.insert(cacheKey).second)
+				LOG_WARN(World, "[StreamCache] terrain.bin vide: {} (warn unique par cle)", fullPath);
 			return nullptr;
 		}
 		std::vector<uint8_t> blob(static_cast<size_t>(fileSize));
@@ -156,6 +165,9 @@ namespace engine::world
 			LOG_WARN(World, "[StreamCache] LoadTerrainBin fail ({}): {}", fullPath, err);
 			return nullptr;
 		}
+		// Chargement OK : retirer la cle du set de warns deduppe pour qu'un eventuel
+		// futur passage absent->present->absent puisse a nouveau emettre un warn.
+		m_terrainChunkMissWarned.erase(cacheKey);
 		Insert(cacheKey, blob);
 		return chunk;
 	}

--- a/src/client/world/StreamCache.h
+++ b/src/client/world/StreamCache.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace engine::core { class Config; }
@@ -87,6 +88,10 @@ namespace engine::world
 		};
 		std::unordered_map<std::string, Entry> m_map;
 		std::vector<std::string> m_lruOrder;
+		/// Cles deja signalees comme absentes/vides par LoadTerrainChunk : evite de re-spammer
+		/// le meme WARN a chaque frame quand le scheduler interroge un chunk inexistant
+		/// (49 chunks * ~60 fps = ~3000 WARN/s sinon). Vide par Clear().
+		std::unordered_set<std::string> m_terrainChunkMissWarned;
 		size_t m_maxSizeBytes = 1024 * 1024 * 1024; // 1 GB default
 		size_t m_currentSizeBytes = 0;
 		uint64_t m_hitCount = 0;


### PR DESCRIPTION
## Contexte

Suite à l'analyse du log client (51 000 lignes, ~26 s de session), **~99 % du volume du log** provenait du même WARN répété :

```
[StreamCache] terrain.bin absent: game/data/chunks/chunk_-3_-3/terrain.bin
[StreamCache] terrain.bin absent: game/data/chunks/chunk_-2_-3/terrain.bin
... 47 autres chunks ...
```
À ~60 fps × 49 chunks (-3..3)² × ~10 s d'attente, cela donne **~30 000 WARN identiques**.

## Cause

`StreamCache::LoadTerrainChunk` (`src/client/world/StreamCache.cpp:132`) émet un WARN à chaque appel quand le fichier est absent. Le scheduler de streaming interroge ces chunks chaque frame → spam infini. Les autres méthodes (`LoadTerrainLods`, `LoadSplatMap`, `LoadWater`) sont déjà silencieuses sur absence, mais celle-ci avait choisi de loguer pour le diagnostic.

## Fix

Mémoriser dans un `std::unordered_set<std::string> m_terrainChunkMissWarned` les clés déjà signalées :
- Le WARN reste émis la **première fois** (utile en diagnostic)
- Devient silencieux ensuite tant que la clé est dans le set
- Le set est vidé par `Clear()` (changement de zone)
- La clé est retirée du set quand un chargement réussit (permet un futur re-warn si le fichier disparaît à chaud)

## Ce qui ne change pas

- `LoadTerrainChunk` continue de retourner `nullptr` quand le fichier est absent
- Le scheduler retente toujours à la prochaine frame (la dedup ne concerne que le **log**, pas la logique de chargement)
- L'I/O `std::ifstream` est toujours fait (très peu coûteux sur Windows pour un fichier inexistant)

## Test plan

- [ ] Build local + tests
- [ ] Lancer le client avec une zone sans `chunks/chunk_X_Y/terrain.bin` (ex: l'écran d'auth actuel)
- [ ] Vérifier qu'on voit **49 WARN** au boot (un par chunk attendu) puis plus rien
- [ ] Vérifier qu'un `Clear()` (changement de zone) réémet les WARN si les nouveaux chunks sont aussi absents
- [ ] Vérifier qu'une zone complète (tous chunks présents) n'émet **aucun** WARN

## Déploiement

✅ **Client uniquement, pas de redéploiement serveur.** Aucune modification de protocole, handler, DB ou comportement fonctionnel — uniquement le volume des logs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8KW9akjsHfts372ii2tb5)_