### PR TITLE
fix(client/audio): déclarer le bus "Weather" et dédupliquer les MAJ identiques

### DIFF
--- a/game/data/audio/zone_audio.json
+++ b/game/data/audio/zone_audio.json
@@ -11,6 +11,10 @@
     {
       "id": "UI",
       "volume": 0.9
+    },
+    {
+      "id": "Weather",
+      "volume": 1.0
     }
   ],
   "sounds": [

--- a/src/client/audio/AudioEngine.cpp
+++ b/src/client/audio/AudioEngine.cpp
@@ -6,6 +6,7 @@
 #include "src/shared/platform/FileSystem.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <filesystem>
 #include <memory>
@@ -263,7 +264,14 @@ namespace engine::audio
 			return false;
 		}
 
-		it->second.volume = std::clamp(volume, 0.0f, 1.0f);
+		// Cette methode est aussi appelee a chaque frame depuis Engine pour piloter le
+		// bus "Weather" depuis l'intensite de pluie. On dedup avec un epsilon pour eviter
+		// d'inonder le log INFO quand la valeur n'a pas change reellement (rain stable).
+		const float clamped = std::clamp(volume, 0.0f, 1.0f);
+		constexpr float kVolumeEpsilon = 1.0f / 256.0f; // ~0.004, sous le seuil audible
+		if (std::abs(clamped - it->second.volume) < kVolumeEpsilon)
+			return true;
+		it->second.volume = clamped;
 		LOG_INFO(Core, "[AudioEngine] Bus volume updated (bus={}, volume={:.2f})", busId, it->second.volume);
 		return true;
 	}


### PR DESCRIPTION
## Contexte

Suite à l'analyse du log client, on voyait à chaque frame :

```
[10:30:26][WARN ][Core] [AudioEngine] SetBusVolume failed: unknown bus 'Weather'
```

Soit ~1 700 WARN identiques sur 26 s de session.

## Cause

`Engine.cpp:5670` pilote le volume du bus `Weather` depuis l'intensité de pluie à chaque frame :

```cpp
// Drive the "Weather" audio bus volume from rain intensity (spec step 6).
// Graceful no-op if the bus is not defined in the zone audio JSON.
m_audioEngine.SetBusVolume("Weather", m_weatherSystem.GetAudioVolume());
```

Le commentaire indique que l'appel devait être un **no-op silencieux** si le bus n'était pas défini. Mais :
1. `zone_audio.json` ne déclarait que `SFX`, `Music`, `UI` — pas de `Weather`
2. `AudioEngine::SetBusVolume` émet un `LOG_WARN` quand le bus est inconnu (intention diagnostique pour les typos)

→ WARN spammé à chaque frame.

## Fix (2 changements complémentaires)

### 1. Déclarer le bus `Weather` dans `zone_audio.json`
Le code l'attendait déjà. C'est cohérent avec le commentaire d'intention.

### 2. Dans `AudioEngine::SetBusVolume`, dédup les MAJ inutiles
Sans cette seconde modif, déclarer le bus transformerait le WARN spam en `LOG_INFO` spam (`Bus volume updated`) puisque cette fonction loggue aussi à chaque appel. Avec un epsilon de `1/256` (sous le seuil audible), le log INFO n'est plus émis que sur **changement réel** de volume.

## Ce qui ne change pas

- Le `LOG_WARN` pour bus vraiment inconnu reste en place — utile pour détecter les typos
- Le `LOG_WARN` "engine not initialized" reste en place
- Le clamp `[0, 1]` reste en place
- Le retour `bool` reste vrai si le bus existe (même si dédup → no-op)

## Test plan

- [ ] Build local + tests
- [ ] Lancer le client → vérifier qu'on ne voit plus le WARN `unknown bus 'Weather'`
- [ ] Vérifier qu'à chaque changement réel de volume (ex: ajustement Master dans Options) on voit un `Bus volume updated` (et un seul)
- [ ] Vérifier que pendant le rendu météo stable, aucun `Bus volume updated` n'apparaît
- [ ] Forcer un appel avec un bus inexistant (`SetBusVolume("Fake", …)`) → vérifier qu'on voit toujours le WARN
- [ ] WorldEditor : ouvrir `EditorAudioPanel`, vérifier que le bus `Weather` apparaît dans la liste

## Déploiement

✅ **Client uniquement, pas de redéploiement serveur.** Données : modification de `zone_audio.json` (contenu du jeu, distribué avec le client).


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8KW9akjsHfts372ii2tb5)_