### PR TITLE
fix(log): corriger les format strings %.*s sur fmt/std::format

### DIFF
--- a/src/client/render/AssetRegistry.cpp
+++ b/src/client/render/AssetRegistry.cpp
@@ -318,7 +318,7 @@ namespace engine::render
 
 	AssetId AssetRegistry::loadMeshInternal(std::string_view relativePath)
 	{
-		LOG_WARN(Render, "[ASSET] loadMesh '%.*s'", static_cast<int>(relativePath.size()), relativePath.data());
+		LOG_WARN(Render, "[ASSET] loadMesh '{}'", relativePath);
 		if (!m_config || m_device == VK_NULL_HANDLE) return kInvalidAssetId;
 		std::vector<uint8_t> data = engine::platform::FileSystem::ReadAllBytesContent(*m_config, relativePath);
 		if (data.size() < 16) { LOG_ERROR(Render, "AssetRegistry: mesh file too small: {}", relativePath); return kInvalidAssetId; }
@@ -461,7 +461,7 @@ namespace engine::render
 
 	AssetId AssetRegistry::loadTextureInternal(std::string_view relativePath, bool useSrgb, VkFormat presentBlitDstFormat)
 	{
-		LOG_WARN(Render, "[ASSET] loadTexture '%.*s'", static_cast<int>(relativePath.size()), relativePath.data());
+		LOG_WARN(Render, "[ASSET] loadTexture '{}'", relativePath);
 		if (!m_config || m_device == VK_NULL_HANDLE)
 			return kInvalidAssetId;
 		std::vector<uint8_t> data = engine::platform::FileSystem::ReadAllBytesContent(*m_config, relativePath);

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -164,7 +164,7 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' endpoint='{}' cap={}", m_name.c_st
 
 	void ShardToMasterClient::OnDisconnected(std::string_view reason)
 	{
-LOG_INFO(Net, "[STMC] OnDisconnected reason='%.*s' next_backoff={}s", static_cast<int>(reason.size()), reason.data(), m_reconnect_backoff_sec);
+		LOG_INFO(Net, "[STMC] OnDisconnected reason='{}' next_backoff={}s", reason, m_reconnect_backoff_sec);
 		m_state = State::Disconnected;
 		m_shard_id = 0;
 		ScheduleReconnect();


### PR DESCRIPTION
## Contexte

Repéré dans le log client analysé :
```
[10:30:25][WARN ][Render] [ASSET] loadTexture '%.*s'
[10:30:26][WARN ][Render] [ASSET] loadMesh '%.*s'
```

Le placeholder `%.*s` est affiché littéralement au lieu du nom de l'asset.

## Cause

3 appels `LOG_*` utilisent la syntaxe `printf` (`%.*s` + `(int len, ptr)`) alors que les macros de log du projet sont basées sur `fmt`/`std::format` qui utilisent `{}` comme placeholder. Le formateur ne reconnaît pas `%.*s`, donc il est passé tel quel et les arguments restants sont ignorés (ou pire, mismatch sur le nombre d'args attendus selon la version de fmt).

## Fix

Remplacer `"%.*s"` + `static_cast<int>(sv.size())` + `sv.data()` par `"{}"` + `sv` (les `string_view` sont supportés nativement par fmt et `std::format`).

Trois sites :

| Fichier | Méthode | Côté |
|---|---|---|
| `src/client/render/AssetRegistry.cpp:321` | `loadMeshInternal` | client |
| `src/client/render/AssetRegistry.cpp:464` | `loadTextureInternal` | client |
| `src/shared/network/ShardToMasterClient.cpp:167` | `OnDisconnected` | partagé (master/shard) |

Au passage, l'indentation aberrante de la ligne dans `ShardToMasterClient.cpp` (collée à la marge de gauche) est réalignée sur le bloc englobant.

## Test plan

- [ ] Build local + tests
- [ ] Lancer le client → vérifier que les lignes `[ASSET] loadMesh '...'` et `[ASSET] loadTexture '...'` affichent désormais le chemin réel
- [ ] Côté shard, si on peut provoquer un disconnect du master, vérifier que `[STMC] OnDisconnected reason='...'` affiche bien la raison

## Déploiement

⚠️ **Redéploiement serveur (master + shard) requis pour `ShardToMasterClient.cpp`** — fichier partagé compilé dans le binaire serveur. Pas de changement protocole, juste un message de log corrigé : le redéploiement peut être groupé avec un prochain cycle si l'équipe le souhaite.

✅ Côté client (`AssetRegistry`) : pas de redéploiement client urgent, prochain build standard suffira.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8KW9akjsHfts372ii2tb5)_