### PR TITLE
fix(platform/fs): normaliser les séparateurs dans FileSystem::Join (forward slashes)

### DIFF
--- a/src/shared/platform/FileSystem.cpp
+++ b/src/shared/platform/FileSystem.cpp
@@ -7,7 +7,23 @@ namespace engine::platform
 {
 	std::filesystem::path FileSystem::Join(std::string_view a, std::string_view b)
 	{
-		return std::filesystem::path(a) / std::filesystem::path(b);
+		// On evite std::filesystem::path::operator/ qui inserait le separateur prefere
+		// du systeme : sous Windows, joindre "game/data" et "audio/foo.mp3" produisait
+		// "game/data\\audio/foo.mp3" (slashes mixes), ce qui pollue les logs et complique
+		// la diff de chemins. On construit ici une representation a slashes uniformes
+		// (forward), compatible avec les APIs filesystem Windows comme POSIX.
+		std::string out(a);
+		if (!out.empty())
+		{
+			const char last = out.back();
+			if (last != '/' && last != '\\')
+				out += '/';
+		}
+		out.append(b.data(), b.size());
+		// Normalise un eventuel '\\' deja present dans la base ou la sous-cle.
+		for (char& c : out)
+			if (c == '\\') c = '/';
+		return std::filesystem::path(out);
 	}
 
 	std::filesystem::path FileSystem::ResolveContentPath(const engine::core::Config& cfg, std::string_view relativeContentPath)


### PR DESCRIPTION
## Contexte

Repéré dans le log client : les chemins affichés mélangent `/` et `\` :

```
[10:30:24][INFO][Core] [ZoneVersion] Loading header game/data\zone.meta
[10:30:25][INFO][Core] [Boot] Menu music (miniaudio): game/data\audio/Horns_of_the_Fallen_Bastion.mp3
```

C'est purement cosmétique (les APIs Windows tolèrent les forward slashes) mais ça pollue les logs, complique la lecture et casse toute comparaison textuelle de chemins.

## Cause

`std::filesystem::path::operator/` insère le **séparateur préféré** du système. Sous Windows c'est `\`, même quand la base utilise déjà des `/`. Concrètement :

```cpp
// FileSystem.cpp (avant)
std::filesystem::path Join(std::string_view a, std::string_view b)
{
    return std::filesystem::path(a) / std::filesystem::path(b);
    //                              ^ insère '\\' sous Windows
}
```

Avec `a = "game/data"` et `b = "audio/foo.mp3"` → `"game/data\audio/foo.mp3"`.

## Fix

Reconstruire la chaîne manuellement dans `Join` :
- Concaténer `a + '/' + b` (en ajoutant le `/` seulement si nécessaire)
- Normaliser tout `\` résiduel en `/` (au cas où la base ou la sous-clé en contient)
- Construire le `std::filesystem::path` à partir de la chaîne uniforme

Le `path` retourné reste pleinement valide pour toutes les APIs filesystem ; seul son rendu textuel (`.string()`) change.

## Impact

- `ResolveContentPath`, `ResolveExternalPath`, et tous leurs appelants (~50+ logs) affichent désormais des chemins en `/` uniforme
- Aucun changement de sémantique pour `Exists`, `ReadAllBytes`, `WriteAllText`, etc.
- Pas de migration nécessaire

## Test plan

- [ ] Build local + tests Windows + Linux
- [ ] Vérifier dans le log :
  - `[ZoneVersion] Loading header game/data/zone.meta` (au lieu de `\`)
  - `[Boot] Menu music (miniaudio): game/data/audio/Horns_...mp3`
- [ ] Vérifier qu'un fichier `game/data\foo.txt` (avec `\` réel) est toujours lisible si jamais ce cas existe (peu probable)
- [ ] Vérifier que `EditorMode.cpp:963` (`FileSystem::Join(m_contentRoot, m_volumeLayoutPath)`) continue de fonctionner

## Déploiement

⚠️ **Redéploiement client ET serveur** : le fichier `src/shared/platform/FileSystem.cpp` est partagé et utilisé par `masterd`. Aucun changement fonctionnel (juste de présentation des logs), peut être groupé avec un cycle de déploiement standard.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8KW9akjsHfts372ii2tb5)_