### PR TITLE
fix(sql): backtick la table `groups` dans 0060 — mot réservé MySQL 8.0 (master crash-loop)

### DIFF
--- a/sql/migrations/0060_groups.sql
+++ b/sql/migrations/0060_groups.sql
@@ -3,10 +3,15 @@
 -- (raid future).
 --
 -- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+--
+-- Note : la table `groups` est backtick-quotee partout — `GROUPS` est un
+-- mot reserve depuis MySQL 8.0.2 (window functions). Sans les backticks,
+-- `CREATE TABLE groups` et `REFERENCES groups` sont des syntax errors sur
+-- MySQL 8.x (OK sur 5.7, d'ou le passage CI initial).
 
 -- Table groups : 1 ligne par groupe actif (party ou raid). Disband =
 -- DELETE (cascade member rows via FK ON DELETE CASCADE).
-CREATE TABLE IF NOT EXISTS groups
+CREATE TABLE IF NOT EXISTS `groups`
 (
 	group_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 	group_type   TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Party, 1=Raid
@@ -31,7 +36,7 @@ CREATE TABLE IF NOT EXISTS group_members
 	UNIQUE KEY uniq_group_members_player (player_id),
 	KEY idx_group_members_group (group_id),
 	CONSTRAINT fk_group_members_group
-		FOREIGN KEY (group_id) REFERENCES groups (group_id)
+		FOREIGN KEY (group_id) REFERENCES `groups` (group_id)
 		ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
## Problème

Le master crash-loop au déploiement. La migration 60 échoue :

```
[MigrationRunner] Execute migration 60 failed: You have an error in your SQL syntax;
... near 'groups
(
        group_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, ...
```

`GROUPS` est un **mot réservé MySQL depuis 8.0.2** (window functions). `CREATE TABLE groups` et `REFERENCES groups` sans backticks sont des **syntax errors sur MySQL 8.x**. La CI / l'environnement de dev tournaient vraisemblablement sur MySQL 5.7 (où `GROUPS` n'est pas réservé), d'où le passage initial en CI lors du merge de la PR #597 (Wave 22 Groups).

Conséquence : `MigrationRunner` reste bloqué à `schema version: 59`, le boot échoue, le conteneur redémarre en boucle.

## Fix

Backtick `` `groups` `` sur les 2 occurrences SQL de `0060_groups.sql` :
- `CREATE TABLE IF NOT EXISTS ` + `` `groups` ``
- `FOREIGN KEY (group_id) REFERENCES ` + `` `groups` (group_id)``

+ une note explicative en tête de fichier.

## Sécurité du changement

- **Migration 60 jamais appliquée** en prod (`schema version` bloquée à 59) → éditer le fichier de migration est sûr, il n'a tourné nulle part.
- **Blast radius minimal** : le `GroupManager` de Wave 22 (`src/masterd/Groups/`) est **header-only / in-memory** — aucun code runtime ne requête la table `groups`. `grep` confirme : seule la migration référence ce nom.
- Migrations 61-63 vérifiées : `character_auras`, `spell_proc_template`, `group_members`, `group_loot_rolls`, `creature_movement`, `dungeon_instances` — aucun autre mot réservé.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Redéploiement master : `MigrationRunner` applique 60 → 63 et le serveur boote
- [ ] (si possible) faire tourner les migrations contre une instance MySQL 8.x en CI pour attraper ce type de régression à l'avenir

> **Déploiement** : ⚠️ ce fix débloque le redéploiement master en cours. À merger et redéployer en priorité — le master est actuellement down (crash-loop).

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_