### PR TITLE
fix: compteur joueurs fiable + ventilation par rôle (/status) + écran « Choisir un serveur »

### DIFF
--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -350,6 +350,10 @@ namespace engine::client
 			std::string name;
 			bool ok = false;
 			uint32_t players = 0;
+			/// "host:port" du shard, tel que renvoyé par /status. Sert de clé de
+			/// correspondance avec \ref engine::network::ServerListEntry::endpoint
+			/// pour rafraîchir le compteur de joueurs de l'écran de choix de serveur.
+			std::string endpoint;
 		};
 
 		struct StatusCache
@@ -682,6 +686,12 @@ namespace engine::client
 		/// dans \ref m_pendingDeleteCharacterId par \ref ImGuiRequestDeleteCharacter).
 		void StartCharacterDeleteWorker(const engine::core::Config& cfg);
 		void StartStatusProbeWorker(const engine::core::Config& cfg);
+		/// Réinjecte le compteur de joueurs frais de \ref m_statusCache (sonde /status,
+		/// rafraîchie périodiquement) dans le \c current_load de \ref m_shardPickEntries.
+		/// Sans cela, l'écran « Choisir un serveur » reste figé sur l'instantané pris au
+		/// moment de la connexion (typiquement 0 joueur). Correspondance par endpoint ;
+		/// les entrées sans correspondance gardent leur valeur d'origine.
+		void RefreshShardPickEntriesFromStatusCache();
 		void ResetMasterSession();
 		void StartMasterFlowWorker(const engine::core::Config& cfg);
 		void PollAsyncResult(const engine::core::Config& cfg);

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -492,8 +492,9 @@ namespace engine::client
 						s.name = statusCfg.GetString(keyName, std::string("server") + std::to_string(i));
 						s.ok = statusCfg.GetBool(keyOk, true);
 						s.players = static_cast<uint32_t>(std::max<int64_t>(0, statusCfg.GetInt(keyPlayers, 0)));
-						LOG_INFO(Core, "[StatusProbe] parse: shard [{}] name='{}' ok={} players={}", i, s.name, s.ok ? "true" : "false",
-							s.players);
+						s.endpoint = statusCfg.GetString(base + "endpoint", "");
+						LOG_INFO(Core, "[StatusProbe] parse: shard [{}] name='{}' ok={} players={} endpoint='{}'", i, s.name,
+							s.ok ? "true" : "false", s.players, s.endpoint);
 						cache.servers.push_back(std::move(s));
 					}
 				}
@@ -1067,6 +1068,7 @@ namespace engine::client
 	void AuthUiPresenter::StartTermsAcceptWorker(const engine::core::Config&) {}
 	void AuthUiPresenter::StartCharacterCreateWorker(const engine::core::Config&) {}
 	void AuthUiPresenter::StartStatusProbeWorker(const engine::core::Config&) {}
+	void AuthUiPresenter::RefreshShardPickEntriesFromStatusCache() {}
 	void AuthUiPresenter::ResetMasterSession() {}
 	void AuthUiPresenter::StartMasterFlowWorker(const engine::core::Config&) {}
 	void AuthUiPresenter::PollAsyncResult(const engine::core::Config&) {}
@@ -1544,6 +1546,37 @@ namespace engine::client
 		return Tr(std::string("language.name.") + std::string(localeTag));
 	}
 
+	void AuthUiPresenter::RefreshShardPickEntriesFromStatusCache()
+	{
+		// m_shardPickEntries vient d'un unique SERVER_LIST pris pendant le flux de connexion,
+		// puis la connexion master est fermee : son current_load reste donc fige (souvent 0)
+		// meme si des joueurs entrent/sortent. La sonde /status, elle, est rafraichie toutes
+		// les 2 min et porte le compte a jour (sessionCharMap cote master). On reinjecte donc
+		// players -> current_load par correspondance d'endpoint.
+		if (m_shardPickEntries.empty() || m_statusCache.servers.empty())
+			return;
+		size_t patched = 0;
+		for (auto& entry : m_shardPickEntries)
+		{
+			if (entry.endpoint.empty())
+				continue;
+			for (const auto& srv : m_statusCache.servers)
+			{
+				if (srv.endpoint == entry.endpoint)
+				{
+					if (entry.current_load != srv.players)
+					{
+						entry.current_load = srv.players;
+						++patched;
+					}
+					break;
+				}
+			}
+		}
+		if (patched > 0)
+			LOG_INFO(Core, "[AuthUiPresenter] Shard pick: {} entree(s) de charge rafraichie(s) depuis la sonde /status", patched);
+	}
+
 	void AuthUiPresenter::PollAsyncResult(const engine::core::Config& cfg)
 	{
 		auto pendingKindTag = [](AsyncKind k) -> const char*
@@ -1613,6 +1646,9 @@ namespace engine::client
 		if (kind == AsyncKind::StatusProbe)
 		{
 			m_statusCache = copy.statusCache;
+			// La sonde /status porte le compte de joueurs a jour : on le repercute sur
+			// l'ecran de choix de serveur, sinon il reste fige sur l'instantanee de connexion.
+			RefreshShardPickEntriesFromStatusCache();
 			m_statusProbeCompletedOnce = true;
 			m_lastStatusProbeHttpSuccess = copy.success;
 			// Si on a fini la première vérification, on autorise les refresh périodiques.
@@ -1938,6 +1974,10 @@ namespace engine::client
 		if (kind == AsyncKind::Login && copy.shardChoiceRequired)
 		{
 			m_shardPickEntries = std::move(copy.serverListForPick);
+			// Applique tout de suite le dernier compte connu de la sonde /status (la
+			// connexion master est fermee apres SERVER_LIST : pas d'autre rafraichissement
+			// avant la prochaine sonde periodique).
+			RefreshShardPickEntriesFromStatusCache();
 			m_shardPickChoiceShardId = 0;
 			for (const auto& e : m_shardPickEntries)
 			{


### PR DESCRIPTION
## Contexte

Le compteur de joueurs était faux à plusieurs niveaux. Trois itérations dans cette PR :

1. **Écran « Choisir un serveur » figé** — il affichait un instantané `SERVER_LIST` pris à la connexion, jamais rafraîchi.
2. **Compteur `/status` lui-même faux** — il retombait à 0 alors que des joueurs étaient en jeu.
3. **Demande d'enrichissement** — ajouter une ventilation par rôle de compte dans l'API.

## Origine du compteur faux

`sessionCharMap` (source du compteur `/status`) est indexé sur la **connexion TCP master**. Le client n'émettait plus rien sur cette connexion après l'entrée en jeu → la connexion tombait ~50 s plus tard (`Connection closed connId=18 … alive_s=51.616`), l'entrée disparaissait, le compteur retombait à 0. La connexion shard, elle, est transitoire **par conception** (ticket validé puis fermée) — la vraie session vit sur la connexion master.

## Correctif — Option 1 : fiabiliser le suivi côté master

- **Client** (`AuthUiPresenterSettings.cpp`) : `PumpPostAuthEvents` émet un `kOpcodeHeartbeat` périodique (30 s) sur la connexion master tant que le joueur est en jeu. Le master `Touch()` la session (plus de `HeartbeatTimeout`) et le trafic garde la TCP vivante → `sessionCharMap` reste peuplé.
- **Master** (`SessionCharacterMap`) : porte désormais le `role` du compte (lu depuis `accounts.role` par `CharacterEnterWorldHandler`) + expose `CountByRole()`.
- **API `/status`** : chaque `game_servers[]` gagne un sous-objet `players_by_role` `{player, moderator, game_master, administrator}`, et la racine un `totalPlayersByRole`. La somme des 4 sous-compteurs vaut `players`.
- **Écran « Choisir un serveur »** (commits précédents) : se rafraîchit depuis la sonde `/status` (`GameServerStatus` gagne `endpoint` comme clé de correspondance).

Aucun changement de protocole wire, aucun nouvel opcode, aucun nouveau handler serveur : `kOpcodeHeartbeat` existait déjà et était déjà routé/géré côté master (`AuthRegisterHandler` → `SessionManager::Touch`).

## Hors périmètre (suivi séparé)

Le **double-login** (même compte/personnage jouable simultanément par 2 clients) : l'éviction `KickedByDuplicateLogin` ne ferme que des TCP transitoires, pas une session de jeu account-keyed. À traiter dans une PR dédiée (changement de gating sécurité).

## Test plan

- [ ] Build Windows + Linux (CI).
- [ ] `ctest` : `SessionCharacterMapTests` (signature `Set` + nouveau test `CountByRole`) — vérifié en local, passe.
- [ ] Joueur en jeu → `/status` montre `players: 1` **et** le bon `players_by_role` ; reste stable au-delà de ~1 min (heartbeat).
- [ ] Compte `game_master` / `administrator` en jeu → apparaît dans le bon sous-compteur.
- [ ] Joueur quitte → compteur + ventilation retombent.
- [ ] Écran « Choisir un serveur » affiche le total à jour.

---

**Déploiement** : ⚠️ **redéploiement serveur master requis** — `CharacterEnterWorldHandler`, `SessionCharacterMap` et le provider `/status` changent. Côté client, build Windows à redéployer aussi (heartbeat master). Les deux côtés doivent être déployés en lock-step. Pas de changement shard, pas de migration DB.
