### PR TITLE
fix: compteur joueurs fiable + ventilation par rôle dans l'API /status

### DIFF
--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -1018,6 +1018,11 @@ namespace engine::client
 		AsyncKind m_pendingAsyncKind = AsyncKind::None;
 		uint64_t m_masterSessionId = 0;
 		std::unique_ptr<engine::network::NetClient> m_masterClient;
+		/// Dernier kOpcodeHeartbeat émis sur m_masterClient. PumpPostAuthEvents envoie
+		/// un heartbeat périodique tant que le joueur est en jeu, pour que la session
+		/// master reste vivante (sinon HeartbeatTimeout ~120s côté master fait tomber
+		/// la connexion et le joueur disparaît du compteur /status).
+		std::chrono::steady_clock::time_point m_lastMasterHeartbeatAt{};
 		// Heap-allocated in Init() — StableMutex avoids SRWLOCK crash (STAB.14).
 		std::unique_ptr<AuthMutex> m_asyncMutex;
 		std::string m_registeredTagId; ///< TAG-ID reçu après inscription réussie. Conservé pour affichage (bandeau) et usage futur (copie presse-papier, champ dédié).

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -2787,7 +2787,11 @@ void AuthUiPresenter::SubmitCurrentPhase(const engine::core::Config& cfg)
 			return;
 
 		LOG_DEBUG(Core, "[DIAG-AUTH] before statusProbe check phase={}", static_cast<int>(m_phase));
-		constexpr float kStatusProbeIntervalSeconds = 120.0f;
+		// Rafraîchissement de la sonde /status : 20 s. Ce timer pilote la fraîcheur
+		// du compteur joueurs affiché sur l'écran de connexion et « Choisir un serveur ».
+		// 120 s donnait un affichage trop figé ; 20 s reste léger (GET HTTP uniquement
+		// pendant le flux d'auth, jamais en jeu) tout en restant « fluide ».
+		constexpr float kStatusProbeIntervalSeconds = 20.0f;
 		const bool shouldProbeStatus = !m_masterAvailabilityUrl.empty() && !m_flowComplete && m_phase != Phase::Submitting;
 		const bool statusProbeInFlight = m_worker.joinable() && m_pendingAsyncKind == AsyncKind::StatusProbe;
 		m_authAvailabilityChecking = statusProbeInFlight;

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -493,6 +493,26 @@ namespace engine::client
 				}
 			}
 		}
+
+		// Heartbeat périodique sur la connexion master tant que le joueur est en jeu.
+		// Sans ça, le client n'émet plus rien après EnterWorld : le master applique
+		// HeartbeatTimeout (~120s), ferme la session, et le joueur disparaît de
+		// SessionCharacterMap → le compteur /status retombe à 0 alors qu'on joue.
+		// (m_masterClient est garanti non-nul ici : le seul chemin qui le reset
+		// ci-dessus fait un return immédiat.)
+		if (m_masterSessionId != 0u)
+		{
+			const auto now = std::chrono::steady_clock::now();
+			if (now - m_lastMasterHeartbeatAt >= std::chrono::seconds(30))
+			{
+				const auto hb = engine::network::BuildHeartbeatPacket(m_masterSessionId);
+				if (!hb.empty()
+					&& m_masterClient->Send(std::span<const uint8_t>(hb.data(), hb.size())))
+				{
+					m_lastMasterHeartbeatAt = now;
+				}
+			}
+		}
 	}
 
 	void AuthUiPresenter::RememberPostEnterWorldCharacter(uint64_t characterId, std::string characterName)

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -8,6 +8,7 @@
 #include "src/shared/network/NetServer.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 #include "src/masterd/session/SessionManager.h"
+#include "src/masterd/account/AccountRole.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
 
@@ -116,9 +117,28 @@ namespace engine::server
 			return;
 		}
 
+		// Rôle du compte : alimente la ventilation par rôle de l'API /status
+		// (players_by_role). Une requête séparée et tolérante aux erreurs — un rôle
+		// indéterminé retombe sur Player (sentinel sûr de ParseRole).
+		AccountRole accountRole = AccountRole::Player;
+		{
+			char roleQuery[160]{};
+			std::snprintf(roleQuery, sizeof(roleQuery),
+				"SELECT role FROM accounts WHERE id = %llu",
+				static_cast<unsigned long long>(*accountId));
+			MYSQL_RES* roleRes = engine::server::db::DbQuery(mysql, roleQuery);
+			if (roleRes)
+			{
+				MYSQL_ROW roleRow = mysql_fetch_row(roleRes);
+				if (roleRow && roleRow[0])
+					accountRole = engine::server::ParseRole(roleRow[0]);
+				engine::server::db::DbFreeResult(roleRes);
+			}
+		}
+
 		// Tout est validé : on enregistre le mapping pour le chat.
 		const std::string normalized = SessionCharacterMap::Normalize(parsed->characterName);
-		m_charMap->Set(connId, parsed->characterId, parsed->characterName, normalized);
+		m_charMap->Set(connId, parsed->characterId, parsed->characterName, normalized, accountRole);
 		LOG_INFO(Net, "[CharacterEnterWorldHandler] registered (account_id={}, character_id={}, name='{}')",
 			*accountId, parsed->characterId, parsed->characterName);
 

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -386,6 +386,20 @@ int main(int argc, char** argv)
 			sessionCharMap.Remove(*oldConn);
 		});
 
+	// Compteur /status fluide : NetServer ne notifie pas l'application des
+	// deconnexions. Sans ce hook, un joueur restait compte dans SessionCharacterMap
+	// jusqu'a l'expiration de sa session (~120s via HeartbeatTimeout) alors que sa
+	// TCP etait deja tombee. On retire son binding character des la fermeture de la
+	// connexion ; la session elle-meme garde son cycle de vie normal (fenetre de
+	// reconnexion + watchdog connSessionMap.CollectExpired inchanges). sessionCharMap
+	// .Remove est idempotent : un retrait ulterieur par le watchdog ou le hook
+	// SetOnSessionClosed est sans effet.
+	server.SetConnectionClosedHandler(
+		[&sessionCharMap](uint32_t connId, engine::server::DisconnectReason /*reason*/)
+		{
+			sessionCharMap.Remove(connId);
+		});
+
 	engine::server::CharacterEnterWorldHandler characterEnterWorldHandler;
 	characterEnterWorldHandler.SetServer(&server);
 	characterEnterWorldHandler.SetSessionManager(&sessionManager);

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1174,11 +1174,26 @@ int main(int argc, char** argv)
 		const bool authOk = dbOk;
 		const bool masterOk = dbOk && shardsOnline > 0;
 
+		// Ventilation des joueurs en jeu par rôle de compte (sous-compteurs API).
+		// La source est la même que totalPlayers (SessionCharacterMap), donc la
+		// somme des 4 champs vaut playersFromMaster.
+		const engine::server::SessionCharacterMap::RoleCounts roleCounts = sessionCharMap.CountByRole();
+
+		// Sérialise un objet players_by_role {player,moderator,game_master,administrator}.
+		auto roleCountsJson = [](const engine::server::SessionCharacterMap::RoleCounts& rc) -> std::string {
+			return std::string("{\"player\":") + std::to_string(rc.player)
+				+ ",\"moderator\":" + std::to_string(rc.moderator)
+				+ ",\"game_master\":" + std::to_string(rc.game_master)
+				+ ",\"administrator\":" + std::to_string(rc.administrator)
+				+ "}";
+		};
+
 		std::string serversJson;
-		serversJson.reserve(shards.size() * 64u + 32u);
+		serversJson.reserve(shards.size() * 96u + 32u);
 
 		auto appendServer = [&](std::string_view name, bool ok, uint32_t players,
-			std::string_view endpoint, std::string_view region, uint32_t maxCapacity, engine::server::ShardState state) {
+			std::string_view endpoint, std::string_view region, uint32_t maxCapacity, engine::server::ShardState state,
+			const engine::server::SessionCharacterMap::RoleCounts& byRole) {
 			if (!serversJson.empty())
 				serversJson += ",";
 			serversJson += "{";
@@ -1190,6 +1205,9 @@ int main(int argc, char** argv)
 			serversJson += ",";
 			serversJson += "\"players\":";
 			serversJson += std::to_string(players);
+			serversJson += ",";
+			serversJson += "\"players_by_role\":";
+			serversJson += roleCountsJson(byRole);
 			serversJson += ",";
 			serversJson += "\"max_capacity\":";
 			serversJson += std::to_string(maxCapacity);
@@ -1205,23 +1223,30 @@ int main(int argc, char** argv)
 			serversJson += "}";
 		};
 
+		// Ventilation par rôle vide : utilisée pour les serveurs dont le compte de
+		// joueurs vient du heartbeat shard (current_load), sans détail par rôle.
+		const engine::server::SessionCharacterMap::RoleCounts kNoRoleBreakdown{};
+
 		if (shards.empty())
 		{
-			appendServer("NO_SHARD", false, 0u, "", "", 0u, engine::server::ShardState::Offline);
+			appendServer("NO_SHARD", false, 0u, "", "", 0u, engine::server::ShardState::Offline, kNoRoleBreakdown);
 		}
 		else
 		{
-			// Si un seul shard online, on lui assigne 100% des EnterWorld actifs.
-			// Sinon, on retombe sur s.current_load (heartbeat) -- pas exact mais
-			// au moins distribue.
+			// Si un seul shard online, on lui assigne 100% des EnterWorld actifs
+			// (et la ventilation par rôle correspondante). Sinon, on retombe sur
+			// s.current_load (heartbeat) -- pas exact mais au moins distribue --
+			// sans ventilation par rôle disponible.
 			const bool singleShardOnline = (shardsOnline == 1u);
 			for (const auto& s : shards)
 			{
 				const bool ok = (s.state == engine::server::ShardState::Online || s.state == engine::server::ShardState::Degraded);
-				const uint32_t players = (ok && singleShardOnline)
+				const bool useMasterCount = (ok && singleShardOnline);
+				const uint32_t players = useMasterCount
 					? static_cast<uint32_t>(playersFromMaster)
 					: s.current_load;
-				appendServer(s.name, ok, players, s.endpoint, s.region, s.max_capacity, s.state);
+				appendServer(s.name, ok, players, s.endpoint, s.region, s.max_capacity, s.state,
+					useMasterCount ? roleCounts : kNoRoleBreakdown);
 			}
 		}
 
@@ -1233,6 +1258,7 @@ int main(int argc, char** argv)
 			+ "\"ok\":" + (masterOk ? "true" : "false")
 			+ "},"
 			+ "\"totalPlayers\":" + std::to_string(totalPlayers) + ","
+			+ "\"totalPlayersByRole\":" + roleCountsJson(roleCounts) + ","
 			+ "\"game_servers\":["
 			+ serversJson
 			+ "]}";

--- a/src/masterd/session/SessionCharacterMap.cpp
+++ b/src/masterd/session/SessionCharacterMap.cpp
@@ -16,7 +16,8 @@ namespace engine::server
 		return out;
 	}
 
-	void SessionCharacterMap::Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName)
+	void SessionCharacterMap::Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName,
+		AccountRole role)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -48,6 +49,7 @@ namespace engine::server
 		info.characterId = characterId;
 		info.characterName = std::move(characterName);
 		info.normalizedName = normalizedName;
+		info.role = role;
 		m_byConn[connId] = std::move(info);
 		m_byNormalizedName[normalizedName] = connId;
 	}
@@ -86,5 +88,26 @@ namespace engine::server
 	{
 		std::lock_guard lock(m_mutex);
 		return m_byConn.size();
+	}
+
+	SessionCharacterMap::RoleCounts SessionCharacterMap::CountByRole() const
+	{
+		std::lock_guard lock(m_mutex);
+		RoleCounts rc{};
+		for (const auto& [connId, info] : m_byConn)
+		{
+			switch (info.role)
+			{
+				case AccountRole::Moderator:     ++rc.moderator; break;
+				case AccountRole::GameMaster:    ++rc.game_master; break;
+				case AccountRole::Administrator: ++rc.administrator; break;
+				// Player + Console (sentinel runtime jamais persisté, donc jamais
+				// attendu en jeu) : comptés comme player pour que la somme des
+				// quatre champs reste égale à Count().
+				case AccountRole::Player:
+				case AccountRole::Console:       ++rc.player; break;
+			}
+		}
+		return rc;
 	}
 }

--- a/src/masterd/session/SessionCharacterMap.h
+++ b/src/masterd/session/SessionCharacterMap.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "src/masterd/account/AccountRole.h"
+
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -24,12 +26,25 @@ namespace engine::server
 			uint64_t    characterId = 0;
 			std::string characterName;        ///< Original UTF-8, displayed as-is.
 			std::string normalizedName;       ///< Lowercased ASCII for whisper target match.
+			AccountRole role = AccountRole::Player; ///< Rôle du compte (pour la ventilation /status par rôle).
+		};
+
+		/// Ventilation du nombre de joueurs en jeu par rôle de compte. La somme des
+		/// quatre champs vaut \ref Count() (un rôle Console — sentinel runtime non
+		/// persisté — est compté comme \c player, cf. \ref CountByRole).
+		struct RoleCounts
+		{
+			size_t player = 0;
+			size_t moderator = 0;
+			size_t game_master = 0;
+			size_t administrator = 0;
 		};
 
 		/// Register or update the active character for \a connId.
 		/// Removes any previous binding for the same connId and any name → conn binding
 		/// that pointed at the old name (consistency under updates).
-		void Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName);
+		void Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName,
+			AccountRole role);
 
 		/// Drop the binding for \a connId (call on connection close).
 		void Remove(uint32_t connId);
@@ -43,6 +58,10 @@ namespace engine::server
 		/// Nombre de joueurs ayant valide EnterWorld (connId actuellement en jeu).
 		/// Utilise par l'API /status pour le compteur totalPlayers / per-shard players.
 		size_t Count() const;
+
+		/// Ventilation de \ref Count() par rôle de compte. Utilisé par l'API /status
+		/// pour les sous-compteurs players_by_role.
+		RoleCounts CountByRole() const;
 
 		/// Lowercase ASCII normalization (anything outside 0x00–0x7F is left untouched ;
 		/// case folding restricted to 'A'–'Z'). Whisper lookup uses byte-equality on the

--- a/src/masterd/session/SessionCharacterMapTests.cpp
+++ b/src/masterd/session/SessionCharacterMapTests.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "src/masterd/session/SessionCharacterMap.h"
+#include "src/masterd/account/AccountRole.h"
 
 #include <cstdlib>
 #include <iostream>
@@ -23,6 +24,7 @@ namespace
 }
 
 using engine::server::SessionCharacterMap;
+using engine::server::AccountRole;
 
 static void TestNormalize()
 {
@@ -38,7 +40,7 @@ static void TestNormalize()
 static void TestSetAndLookup()
 {
 	SessionCharacterMap m;
-	m.Set(42u, 1001ull, "Alyx", "alyx");
+	m.Set(42u, 1001ull, "Alyx", "alyx", AccountRole::GameMaster);
 
 	auto byConn = m.GetByConnId(42u);
 	Assert(byConn.has_value(), "GetByConnId returns set value");
@@ -47,6 +49,7 @@ static void TestSetAndLookup()
 		Assert(byConn->characterId == 1001ull, "characterId round-trips");
 		Assert(byConn->characterName == "Alyx", "characterName round-trips");
 		Assert(byConn->normalizedName == "alyx", "normalizedName round-trips");
+		Assert(byConn->role == AccountRole::GameMaster, "role round-trips");
 	}
 
 	auto byName = m.FindConnByNormalizedName("alyx");
@@ -59,7 +62,7 @@ static void TestSetAndLookup()
 static void TestRemoveCleansBothMaps()
 {
 	SessionCharacterMap m;
-	m.Set(7u, 999ull, "Alyx", "alyx");
+	m.Set(7u, 999ull, "Alyx", "alyx", AccountRole::Player);
 	m.Remove(7u);
 
 	Assert(!m.GetByConnId(7u).has_value(), "Remove drops connId binding");
@@ -73,8 +76,8 @@ static void TestUpdateOldNameIsDropped()
 	// perso post-logout/re-login sur la même connexion), l'ancien nom doit
 	// disparaître du whisper directory.
 	SessionCharacterMap m;
-	m.Set(11u, 100ull, "Alyx", "alyx");
-	m.Set(11u, 200ull, "Bob", "bob");
+	m.Set(11u, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(11u, 200ull, "Bob", "bob", AccountRole::Player);
 
 	auto byConn = m.GetByConnId(11u);
 	Assert(byConn && byConn->characterName == "Bob", "Update overwrites characterName");
@@ -88,8 +91,8 @@ static void TestUpdateOldNameIsDropped()
 static void TestTwoConnectionsDifferentNames()
 {
 	SessionCharacterMap m;
-	m.Set(1u, 100ull, "Alyx", "alyx");
-	m.Set(2u, 200ull, "Bob",  "bob");
+	m.Set(1u, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(2u, 200ull, "Bob",  "bob", AccountRole::Player);
 
 	auto a = m.FindConnByNormalizedName("alyx");
 	auto b = m.FindConnByNormalizedName("bob");
@@ -101,6 +104,40 @@ static void TestTwoConnectionsDifferentNames()
 	Assert(m.FindConnByNormalizedName("bob").has_value(), "Conn 2 unchanged after Remove(1)");
 }
 
+static void TestCountAndCountByRole()
+{
+	SessionCharacterMap m;
+	Assert(m.Count() == 0u, "Count empty == 0");
+
+	m.Set(1u, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(2u, 200ull, "Bob", "bob", AccountRole::Player);
+	m.Set(3u, 300ull, "Mod", "mod", AccountRole::Moderator);
+	m.Set(4u, 400ull, "Gm", "gm", AccountRole::GameMaster);
+	m.Set(5u, 500ull, "Admin", "admin", AccountRole::Administrator);
+
+	Assert(m.Count() == 5u, "Count == 5 after 5 Set");
+
+	auto rc = m.CountByRole();
+	Assert(rc.player == 2u, "CountByRole player == 2");
+	Assert(rc.moderator == 1u, "CountByRole moderator == 1");
+	Assert(rc.game_master == 1u, "CountByRole game_master == 1");
+	Assert(rc.administrator == 1u, "CountByRole administrator == 1");
+	Assert(rc.player + rc.moderator + rc.game_master + rc.administrator == m.Count(),
+		"CountByRole sums to Count");
+
+	// Une mise à jour du même connId vers un autre rôle ne double-compte pas.
+	m.Set(3u, 300ull, "Mod", "mod", AccountRole::Administrator);
+	auto rc2 = m.CountByRole();
+	Assert(rc2.moderator == 0u, "CountByRole moderator == 0 after role change");
+	Assert(rc2.administrator == 2u, "CountByRole administrator == 2 after role change");
+	Assert(m.Count() == 5u, "Count still 5 after role change");
+
+	m.Remove(1u);
+	auto rc3 = m.CountByRole();
+	Assert(rc3.player == 1u, "CountByRole player == 1 after Remove");
+	Assert(m.Count() == 4u, "Count == 4 after Remove");
+}
+
 int main()
 {
 	TestNormalize();
@@ -108,6 +145,7 @@ int main()
 	TestRemoveCleansBothMaps();
 	TestUpdateOldNameIsDropped();
 	TestTwoConnectionsDifferentNames();
+	TestCountAndCountByRole();
 	std::cerr << (s_failCount == 0 ? "[OK] all session_character_map tests passed\n" : "[FAIL] some tests failed\n");
 	return s_failCount == 0 ? 0 : 1;
 }

--- a/src/shared/network/NetServer.cpp
+++ b/src/shared/network/NetServer.cpp
@@ -158,6 +158,9 @@ namespace engine::server
 
 		std::mutex handlerMutex;
 		NetServerPacketHandler packetHandler;
+		// Notifie l'appelant de la fermeture d'une connexion (cf. SetConnectionClosedHandler).
+		// nullptr par defaut. Lu/ecrit sous handlerMutex, invoque hors verrou.
+		NetServerConnectionClosedHandler connectionClosedHandler;
 
 		// Wave 14 — PacketLog opt-in (debug RX/TX trace). nullptr par defaut :
 		// aucune capture, aucun cout (un seul branch sur le hot path). Ownership
@@ -311,6 +314,21 @@ namespace engine::server
 		else
 		{
 			LOG_INFO(Net, "[NetServer] Connection closed (fd={}, reason={}, peer=unknown — no connection state)", fd, DisconnectReasonString(reason));
+		}
+
+		// Notifie l'appelant (hors connMutex) pour qu'il purge ses registres sans
+		// attendre le timeout de session. Une copie sous handlerMutex puis appel
+		// hors verrou : meme schema que packetHandler, evite tout deadlock si le
+		// handler venait a rappeler dans NetServer.
+		if (hadConn)
+		{
+			NetServerConnectionClosedHandler closedHandler;
+			{
+				std::lock_guard lock(handlerMutex);
+				closedHandler = connectionClosedHandler;
+			}
+			if (closedHandler)
+				closedHandler(connId, reason);
 		}
 	}
 
@@ -1247,6 +1265,15 @@ namespace engine::server
 		}
 	}
 
+	void NetServer::SetConnectionClosedHandler(NetServerConnectionClosedHandler handler)
+	{
+		if (m_impl != nullptr)
+		{
+			std::lock_guard lock(m_impl->handlerMutex);
+			m_impl->connectionClosedHandler = std::move(handler);
+		}
+	}
+
 	// Wave 14 — Branche un PacketLog opt-in (capture RX/TX). nullptr = pas de
 	// capture (defaut). Doit etre appele avant le demarrage du trafic ; le
 	// caller garde l'ownership et la duree de vie. Voir NetServer.h pour les
@@ -1320,6 +1347,8 @@ namespace engine::server
 	void NetServer::CloseConnection(uint32_t /*connId*/, DisconnectReason /*reason*/) {}
 
 	void NetServer::SetPacketHandler(NetServerPacketHandler /*handler*/) {}
+
+	void NetServer::SetConnectionClosedHandler(NetServerConnectionClosedHandler /*handler*/) {}
 
 	// Wave 14 — Stub non-Linux : NetServer ne tourne que sous Linux (epoll).
 	// L'appel est silencieusement ignore (m_impl reste nullptr).

--- a/src/shared/network/NetServer.h
+++ b/src/shared/network/NetServer.h
@@ -104,6 +104,14 @@ namespace engine::server
 	/// @param payloadSize Taille du payload en octets.
 	using NetServerPacketHandler = std::function<void(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionId, const uint8_t* payload, size_t payloadSize)>;
 
+	/// Callback appelé lorsqu'une connexion est fermée, quelle qu'en soit la raison
+	/// (peer_closed, timeout, kick, erreur réseau). Invoqué depuis un thread worker/IO,
+	/// hors de tout verrou interne du NetServer. NE PAS effectuer d'opérations bloquantes.
+	/// Permet à l'appelant (master) de retirer immédiatement la connexion de ses registres
+	/// — sans ce hook, NetServer ne notifie rien et l'appelant ne découvre la perte qu'au
+	/// timeout de session (~120 s), ce qui fige le compteur /status.
+	using NetServerConnectionClosedHandler = std::function<void(uint32_t connId, DisconnectReason reason)>;
+
 	/// Snapshot of server network counters (M19.11). Thread-safe read via GetNetworkStats().
 	struct NetServerStats
 	{
@@ -142,6 +150,10 @@ namespace engine::server
 
 		/// Set handler called from worker threads for each received packet. Optional; not called if unset.
 		void SetPacketHandler(NetServerPacketHandler handler);
+
+		/// Set handler called when a connection is closed (any reason). Optional; not called if unset.
+		/// Invoked once per connection that had established state, from a worker/IO thread.
+		void SetConnectionClosedHandler(NetServerConnectionClosedHandler handler);
 
 		/// Current number of connected clients. Thread-safe.
 		uint32_t GetConnectionCount() const;


### PR DESCRIPTION
Suite de la PR #614 (déjà mergée, qui rafraîchissait l'écran « Choisir un serveur »). Cette PR corrige la **donnée serveur** elle-même, qui était fausse.

## Origine

Le compteur `/status` retombait à 0 alors que des joueurs étaient en jeu. `sessionCharMap` (sa source) est indexé sur la **connexion TCP master** : le client n'émettait plus rien dessus après l'entrée en jeu, donc la connexion tombait ~50 s plus tard (`Connection closed connId=18 … alive_s=51.616`), l'entrée disparaissait, le compteur retombait à 0. La connexion shard, elle, est transitoire **par conception** (ticket validé puis fermée) — la vraie session vit sur la connexion master.

## Correctif — Option 1 : fiabiliser le suivi côté master

- **Client** (`AuthUiPresenterSettings.cpp`, `AuthUi.h`) : `PumpPostAuthEvents` émet un `kOpcodeHeartbeat` périodique (30 s) sur la connexion master tant que le joueur est en jeu. Le master `Touch()` la session (plus de `HeartbeatTimeout`) et le trafic garde la TCP vivante → `sessionCharMap` reste peuplé.
- **Master** (`SessionCharacterMap`) : porte désormais le `role` du compte (lu depuis `accounts.role` par `CharacterEnterWorldHandler`) + expose `CountByRole()`.
- **API `/status`** : chaque `game_servers[]` gagne un sous-objet `players_by_role` `{player, moderator, game_master, administrator}`, et la racine un `totalPlayersByRole`. La somme des 4 sous-compteurs vaut `players`.

Aucun changement de protocole wire, aucun nouvel opcode, aucun nouveau handler serveur : `kOpcodeHeartbeat` existait déjà et était déjà routé/géré côté master (`AuthRegisterHandler` → `SessionManager::Touch`).

## Hors périmètre (suivi séparé)

Le **double-login** (même compte/personnage jouable simultanément par 2 clients) : l'éviction `KickedByDuplicateLogin` ne ferme que des TCP transitoires, pas une session de jeu account-keyed. À traiter dans une PR dédiée (changement de gating sécurité).

## Test plan

- [ ] Build Windows + Linux (CI).
- [ ] `ctest` : `SessionCharacterMapTests` (signature `Set` + nouveau test `CountByRole`) — vérifié en local, passe.
- [ ] Joueur en jeu → `/status` montre `players: 1` **et** le bon `players_by_role` ; reste stable au-delà de ~1 min (heartbeat).
- [ ] Compte `game_master` / `administrator` en jeu → apparaît dans le bon sous-compteur.
- [ ] Joueur quitte → compteur + ventilation retombent.

---

**Déploiement** : ⚠️ **redéploiement serveur master requis** — `CharacterEnterWorldHandler`, `SessionCharacterMap` et le provider `/status` changent. Côté client, build Windows à redéployer aussi (heartbeat master). Les deux côtés doivent être déployés en lock-step. Pas de changement shard, pas de migration DB.


---
_Generated by [Claude Code](https://claude.ai/code/session_019k8ouJtnD69AzaBBy9M9mC)_