### PR TITLE
fix: refuser la 2e connexion d'un compte déjà en jeu (double-login)

### DIFF
--- a/docs/double_login_protection.md
+++ b/docs/double_login_protection.md
@@ -1,0 +1,157 @@
+# Protection double-login — design
+
+**Statut** : ✅ Livré dans la PR #616.
+**PRs liées** : #615 (compteur joueurs fiable + heartbeat client master — prérequis pour la fiabilité de la détection « en jeu »).
+
+---
+
+## 1. Symptôme observé
+
+Un même compte pouvait être « connecté » deux fois en parallèle : deux clients
+ouvraient le même personnage et jouaient simultanément. La barre de joueurs
+oscillait, et l'éviction `KickedByDuplicateLogin` semblait sans effet.
+
+## 2. Cause racine — le ping-pong de reconnexion
+
+Le master appliquait déjà la policy `KickExisting` : sur une nouvelle auth pour
+un compte déjà en session, l'ancienne session était fermée. Mais :
+
+1. La fermeture côté master = simple `close()` TCP du connId visé. Aucune
+   notification protocole envoyée.
+2. Côté client kické, `NetClient` ne voit qu'un `peer closed`
+   (`NetClient.cpp:611`) — indistinguable d'une coupure réseau.
+3. `PumpPostAuthEvents`, en post-EnterWorld, déclenche la reconnexion auto
+   (`m_reconnectInProgress = true`).
+4. La reconnexion ré-authentifie → kicke le client B → B reconnecte → kicke A →
+   **boucle infinie**.
+
+Résultat : les deux clients flappaient sans cesse, donnant l'illusion d'une
+double connexion simultanée.
+
+## 3. Décision de design
+
+Trois options envisagées :
+
+| | Avantage | Inconvénient | Verdict |
+|---|---|---|---|
+| (a) Notifier le client kické pour qu'il ne reconnecte pas | Conserve `KickExisting` | Nécessite flush TX fiable côté NetServer ; le 2ᵉ joueur prend la place du 1ᵉʳ | écarté |
+| (b) Policy globale `RefuseNew` | Le joueur en place est protégé | Casse le flux de connexion normal du client (auth#1 puis re-auth dans `MasterShardClientFlow` — la 2ᵉ serait refusée par la 1ʳᵉ) | écarté |
+| **(c) Refuser la 2ᵉ auth uniquement si la session existante est en jeu** | Le joueur en place est protégé ; le flux client double-auth reste compatible (la session pré-monde transitoire est toujours kickée) | Un hook supplémentaire à câbler | **retenu** |
+
+## 4. Architecture retenue
+
+### 4.1 Hook `SessionManager::SetSessionInWorldHook`
+
+`SessionManager.h` / `.cpp` exposent un hook optionnel :
+
+```cpp
+void SetSessionInWorldHook(std::function<bool(uint64_t existingSessionId)> hook);
+```
+
+`CreateSession`, sur détection de doublon pour un compte :
+
+1. Si `hook && hook(existing)` → **retourne `kInvalidSessionId` (refus)**, quelle
+   que soit la `DuplicateLoginPolicy`.
+2. Sinon → policy configurée (par défaut `KickExisting`, qui kicke la session
+   pré-monde transitoire — typiquement le double-auth du flux client).
+
+### 4.2 Câblage `main_linux.cpp`
+
+```cpp
+sessionManager.SetSessionInWorldHook(
+    [&connSessionMap, &sessionCharMap](uint64_t existingSessionId) -> bool
+    {
+        auto connId = connSessionMap.FindConnIdForSession(existingSessionId);
+        if (!connId) return false;
+        return sessionCharMap.GetByConnId(*connId).has_value();
+    });
+```
+
+Chaîne de résolution : `existingSessionId → connId (ConnectionSessionMap)
+→ SessionCharacterMap` — la présence d'un binding character signe l'`EnterWorld`
+validé.
+
+### 4.3 Renvoi au handler — aucun changement
+
+`AuthRegisterHandler::HandleAuth` traitait **déjà** `CreateSession() == 0` en
+renvoyant `BuildAuthResponseErrorPacket(NetErrorCode::ALREADY_LOGGED_IN, ...)`
+au client. Rien à modifier.
+
+### 4.4 Propagation côté client
+
+- `MasterShardClientFlow` : capte `p->error_code` (jusque-là ignoré) et le
+  propage via le nouveau champ `MasterShardFlowResult::authErrorCode`.
+- `AsyncResult::flowAuthAlreadyLoggedIn` : flag passé du worker au main thread
+  (la localisation `Tr(...)` n'est appelée que côté main).
+- **Deux workers concernés** : `StartLoginWorker` (auth initiale, c'est ELLE qui
+  reçoit le refus pour un 2ᵉ joueur en pratique) et `StartMasterFlowWorker`
+  (re-auth du flux complet). Les deux lèvent le flag sur `ALREADY_LOGGED_IN`.
+- `PollAsyncResult` (deux branches : `AsyncKind::AuthOnly` et la fin du flux
+  Master/Shard) : si le flag est levé, affiche `Tr("auth.error.already_logged_in")`
+  au lieu du label réseau brut `NetErrorLabel(...)` (qui renverrait « Already
+  logged in » en anglais quelle que soit la locale).
+
+### 4.5 Localisation
+
+Clé `auth.error.already_logged_in` ajoutée dans `fr.json` et `en.json`. Le
+message mentionne explicitement la session active et invite à contacter le
+support et changer son mot de passe si ce n'est pas l'utilisateur.
+
+## 5. Compatibilité avec le flux de connexion client
+
+Le client s'authentifie **deux fois** dans son cycle de connexion normal :
+
+1. `StartLoginWorker` — auth initiale (validation credentials, terms, etc.).
+2. `StartMasterFlowWorker` → `MasterShardClientFlow::Run` — re-auth complet
+   du flux master/shard sur une nouvelle connexion.
+
+Au moment de la re-auth (étape 2), la session de l'étape 1 existe encore mais
+**n'est pas en jeu** (`sessionCharMap` n'a pas encore reçu d'`EnterWorld`).
+Le hook renvoie `false` → policy `KickExisting` s'applique → la session
+transitoire est kickée → l'auth #2 passe. Le flux client n'est **pas cassé**.
+
+## 6. Cas couverts et edge cases
+
+| Scénario | Résultat |
+|---|---|
+| Joueur A en jeu, joueur B s'authentifie avec le compte de A | **Refus** côté master ; B voit le message localisé ; A continue à jouer |
+| A se déconnecte proprement (TCP master close) → relogue rapidement | `KickExisting` (1ʳᵉ session pas en jeu pendant la fenêtre de reconnexion ? voir ci-dessous) |
+| Flux normal client : auth#1 + auth#2 dans `MasterShardClientFlow` | `KickExisting` (auth#1 pas en jeu) → flux complet OK |
+| A en jeu, sa TCP master tombe vraiment (rare grâce au heartbeat #615) | Pendant la reconnexion : `sessionCharMap.Remove(connId)` est appelé par le hook `SetConnectionClosedHandler` (cf. #615), donc A n'est plus « en jeu » côté hook → un 2ᵉ login dans cette fenêtre pourrait le kicker. **Acceptable** : la fenêtre est très courte avec le heartbeat actif. |
+
+## 7. Hors scope
+
+- **Éviction de la session de jeu UDP côté shard** — le shard Linux déployé ne
+  fait pas (encore) tourner de session de jeu UDP réelle (`m_clients` de
+  `ServerApp` n'est utilisé que sur le binaire Windows). Quand le gameplay UDP
+  sera câblé sur le shard Linux, une éviction account-keyed côté
+  `ServerApp::HandleHello` deviendra nécessaire (refus de l'arrivée d'un 2ᵉ
+  endpoint UDP pour un compte déjà présent). À traiter dans un suivi dédié.
+- **Authentification UDP** — `HandleHello` fait confiance au `helloNonce`
+  (`character_id`) du client sans signature. À renforcer en même temps que
+  l'éviction UDP.
+
+## 8. Fichiers touchés (PR #616)
+
+| Fichier | Changement |
+|---|---|
+| `src/masterd/session/SessionManager.h/.cpp` | Hook `SetSessionInWorldHook` + appel dans `CreateSession` |
+| `src/masterd/main_linux.cpp` | Câblage du hook (sessionId → connId → sessionCharMap) |
+| `src/shared/network/MasterShardClientFlow.h/.cpp` | Champ `authErrorCode` propagé depuis `ParseAuthResponsePayload` |
+| `src/client/auth/AuthUi.h` | `AsyncResult::flowAuthAlreadyLoggedIn` |
+| `src/client/auth/AuthUiPresenterCore.cpp` | Flag levé dans `StartLoginWorker` + `StartMasterFlowWorker` ; lecture localisée dans les deux branches de `PollAsyncResult` |
+| `game/data/localization/{fr,en}/{fr,en}.json` | Clé `auth.error.already_logged_in` |
+
+## 9. Test plan
+
+- [x] Compte A en jeu, B tente de s'y connecter → refus, message dédié.
+- [x] A continue à jouer sans interruption.
+- [x] Flux de connexion normal d'un compte (auth#1 + re-auth flow) → non cassé.
+- [x] Locale FR : le message FR s'affiche (pas le label anglais brut).
+- [ ] Reconnexion auto après vraie coupure (rare avec le heartbeat) : pas
+      de régression du comportement existant.
+
+## 10. Déploiement
+
+⚠️ Redéploiement **master** (binaire) + rebuild **client Windows** en lock-step.
+Pas de migration DB, pas de nouvel opcode, pas de changement de protocole.

--- a/game/data/localization/en/en.json
+++ b/game/data/localization/en/en.json
@@ -213,6 +213,7 @@
   "auth.error.terms_session_inactive": "Terms session is not active.",
   "auth.error.character_session_inactive": "Character creation session is not active.",
   "auth.error.invalid_credentials": "Username or password incorrect.",
+  "auth.error.already_logged_in": "This account is already logged in. If this is not you, contact support and change your password immediately.",
   "auth.info.register_ok": "Registration OK. Enter the verification code sent by email.",
   "auth.info.tag_id": "Your TAG-ID:",
   "auth.email_confirmation.title": "Registration successful",

--- a/game/data/localization/en/en.json
+++ b/game/data/localization/en/en.json
@@ -213,7 +213,7 @@
   "auth.error.terms_session_inactive": "Terms session is not active.",
   "auth.error.character_session_inactive": "Character creation session is not active.",
   "auth.error.invalid_credentials": "Username or password incorrect.",
-  "auth.error.already_logged_in": "This account is already logged in. If this is not you, contact support and change your password immediately.",
+  "auth.error.already_logged_in": "An active session already exists with this login. If this is not you, contact support and change your password immediately.",
   "auth.info.register_ok": "Registration OK. Enter the verification code sent by email.",
   "auth.info.tag_id": "Your TAG-ID:",
   "auth.email_confirmation.title": "Registration successful",

--- a/game/data/localization/fr/fr.json
+++ b/game/data/localization/fr/fr.json
@@ -213,6 +213,7 @@
   "auth.error.terms_session_inactive": "La session des conditions n'est pas active.",
   "auth.error.character_session_inactive": "La session de creation du personnage n'est pas active.",
   "auth.error.invalid_credentials": "Identifiant ou mot de passe incorrect.",
+  "auth.error.already_logged_in": "Ce compte est deja connecte en jeu. Si ce n'est pas vous, contactez le support et changez votre mot de passe immediatement.",
   "auth.info.register_ok": "Inscription OK. Saisissez le code de verification envoye par email.",
   "auth.info.tag_id": "Votre TAG-ID :",
   "auth.email_confirmation.title": "Inscription reussie",

--- a/game/data/localization/fr/fr.json
+++ b/game/data/localization/fr/fr.json
@@ -213,7 +213,7 @@
   "auth.error.terms_session_inactive": "La session des conditions n'est pas active.",
   "auth.error.character_session_inactive": "La session de creation du personnage n'est pas active.",
   "auth.error.invalid_credentials": "Identifiant ou mot de passe incorrect.",
-  "auth.error.already_logged_in": "Ce compte est deja connecte en jeu. Si ce n'est pas vous, contactez le support et changez votre mot de passe immediatement.",
+  "auth.error.already_logged_in": "Une session est deja active avec cet identifiant. Si ce n'est pas vous, contactez le support et changez votre mot de passe immediatement.",
   "auth.info.register_ok": "Inscription OK. Saisissez le code de verification envoye par email.",
   "auth.info.tag_id": "Votre TAG-ID :",
   "auth.email_confirmation.title": "Inscription reussie",

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -987,6 +987,9 @@ namespace engine::client
 
 			/// AsyncKind::Login : plusieurs shards en ligne, choix utilisateur requis.
 			bool shardChoiceRequired = false;
+			/// AsyncKind::Login : l'AUTH a échoué avec ALREADY_LOGGED_IN (compte déjà en jeu).
+			/// Le main thread affiche alors un message dédié au lieu du message générique.
+			bool flowAuthAlreadyLoggedIn = false;
 			std::vector<engine::network::ServerListEntry> serverListForPick;
 			/// Phase 2 — Personnages reçus via CHARACTER_LIST après TICKET_ACCEPTED. Vide si aucun
 			/// (route vers CharacterCreate) ou si la requête optionnelle a échoué (même routage).

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -2052,8 +2052,16 @@ namespace engine::client
 			SetPhase(Phase::CharacterSelect);
 			return;
 		}
-		EnterAuthErrorPhase(Phase::Login, copy.message);
-		LOG_WARN(Core, "[AuthUiPresenter] Master/shard flow FAILED: {}", copy.message);
+		// Compte déjà connecté en jeu : le master a refusé cette 2ᵉ authentification
+		// (ALREADY_LOGGED_IN). On affiche un message dédié — l'utilisateur doit savoir
+		// que son compte est déjà en ligne, et contacter le support + changer son mot
+		// de passe si ce n'est pas lui.
+		const std::string flowErrorMsg = copy.flowAuthAlreadyLoggedIn
+			? Tr("auth.error.already_logged_in")
+			: copy.message;
+		EnterAuthErrorPhase(Phase::Login, flowErrorMsg);
+		LOG_WARN(Core, "[AuthUiPresenter] Master/shard flow FAILED: {} (alreadyLoggedIn={})",
+			copy.message, copy.flowAuthAlreadyLoggedIn ? 1 : 0);
 	}
 
 	void AuthUiPresenter::StartLoginWorker(const engine::core::Config& cfg)
@@ -2333,6 +2341,8 @@ namespace engine::client
 			{
 				local.success = r.success;
 				local.message = r.success ? (std::string("Shard ready (shard_id=") + std::to_string(r.shard_id) + ").") : r.errorMessage;
+				local.flowAuthAlreadyLoggedIn =
+					!r.success && r.authErrorCode == engine::network::NetErrorCode::ALREADY_LOGGED_IN;
 				if (r.success)
 				{
 					// Phase 2 — la liste optionnelle est récupérée par le flow sur la connexion master ;

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1748,9 +1748,16 @@ namespace engine::client
 			}
 			else
 			{
+				// Compte déjà connecté en jeu : message dédié (priorité sur le filtre
+				// generique invalid_credentials/account_not_found, qui masque la
+				// distinction identifiant/mot de passe).
+				if (copy.flowAuthAlreadyLoggedIn)
+				{
+					EnterAuthErrorPhase(Phase::Login, Tr("auth.error.already_logged_in"));
+				}
 				// Masquer la distinction identifiant/mot de passe pour ne pas révéler
 				// si c'est le login ou le mot de passe qui est incorrect.
-				if (copy.message == "Invalid credentials" || copy.message == "Account not found")
+				else if (copy.message == "Invalid credentials" || copy.message == "Account not found")
 				{
 					EnterAuthErrorPhase(Phase::Login, Tr("auth.error.invalid_credentials"));
 				}
@@ -2135,6 +2142,11 @@ namespace engine::client
 						if (auth && auth->success == 0)
 						{
 							errMsg = std::string(NetErrorLabel(auth->error_code));
+							// Compte déjà connecté en jeu : on lève le flag pour que le
+							// consumer PollAsyncResult affiche le message localisé dédié
+							// au lieu du label réseau brut « Already logged in ».
+							if (auth->error_code == engine::network::NetErrorCode::ALREADY_LOGGED_IN)
+								local.flowAuthAlreadyLoggedIn = true;
 							return;
 						}
 						auto er = engine::network::ParseErrorPayload(pl.data(), pl.size());

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -400,6 +400,24 @@ int main(int argc, char** argv)
 			sessionCharMap.Remove(connId);
 		});
 
+	// Protection in-world contre le double-login : si un compte est deja en jeu
+	// (EnterWorld valide), une seconde authentification du meme compte est refusee
+	// au lieu de kicker le joueur en place. CreateSession interroge ce hook sur
+	// detection de duplicate-login. Chaine de resolution :
+	//   existingSessionId -> connId (ConnectionSessionMap::FindConnIdForSession)
+	//                     -> SessionCharacterMap::GetByConnId : present == en jeu.
+	// Si la session existante n'est PAS en jeu (auth pre-monde transitoire, ex. le
+	// double-auth du flux de connexion client), le hook renvoie false et la policy
+	// KickExisting habituelle s'applique : le flux client n'est pas casse.
+	sessionManager.SetSessionInWorldHook(
+		[&connSessionMap, &sessionCharMap](uint64_t existingSessionId) -> bool
+		{
+			auto connId = connSessionMap.FindConnIdForSession(existingSessionId);
+			if (!connId)
+				return false;
+			return sessionCharMap.GetByConnId(*connId).has_value();
+		});
+
 	engine::server::CharacterEnterWorldHandler characterEnterWorldHandler;
 	characterEnterWorldHandler.SetServer(&server);
 	characterEnterWorldHandler.SetSessionManager(&sessionManager);

--- a/src/masterd/session/SessionManager.cpp
+++ b/src/masterd/session/SessionManager.cpp
@@ -16,6 +16,11 @@ namespace engine::server
 		m_onSessionClosed = std::move(hook);
 	}
 
+	void SessionManager::SetSessionInWorldHook(std::function<bool(uint64_t)> hook)
+	{
+		m_sessionInWorldHook = std::move(hook);
+	}
+
 	void SessionManager::SetConfig(const SessionManagerConfig& config)
 	{
 		m_config = config;
@@ -69,6 +74,16 @@ namespace engine::server
 			auto sit = m_by_session_id.find(existing_id);
 			if (sit != m_by_session_id.end() && isValid(sit->second, now))
 			{
+				// Protection prioritaire : si la session existante correspond à un joueur
+				// réellement en jeu (EnterWorld validé), on refuse la nouvelle auth quelle
+				// que soit la policy — le joueur en place n'est jamais kické. KickExisting
+				// ne s'applique donc qu'aux sessions pré-monde transitoires (typiquement le
+				// double-auth du flux de connexion client : auth initiale + re-auth du flow).
+				if (m_sessionInWorldHook && m_sessionInWorldHook(existing_id))
+				{
+					LOG_INFO(Net, "[SessionManager] CreateSession refused: account_id={} already in-world (session_id={})", account_id, existing_id);
+					return kInvalidSessionId;
+				}
 				if (m_config.duplicate_login_policy == DuplicateLoginPolicy::RefuseNew)
 				{
 					LOG_INFO(Net, "[SessionManager] CreateSession refused: account_id={} already has active session", account_id);

--- a/src/masterd/session/SessionManager.h
+++ b/src/masterd/session/SessionManager.h
@@ -120,6 +120,16 @@ namespace engine::server
         /// pouvait jouer le meme personnage en parallele du nouveau client.
 		void SetOnSessionClosed(std::function<void(uint64_t sessionId, uint64_t accountId, SessionCloseReason)> hook);
 
+		/// Hook optionnel interrogé par \ref CreateSession sur détection de duplicate-login.
+		/// Reçoit la \a existingSessionId (la session déjà en place pour le compte) et doit
+		/// renvoyer true si elle correspond à un joueur réellement en jeu (EnterWorld validé).
+		/// Si true, la nouvelle authentification est **refusée** quelle que soit la policy —
+		/// le joueur en jeu est protégé. Si false (ou hook non câblé), la policy configurée
+		/// s'applique : \c KickExisting kicke alors la session existante, ce qui reste correct
+		/// pour une session pré-monde transitoire (ex. le double-auth du flux de connexion
+		/// client : auth initiale puis re-auth dans MasterShardClientFlow).
+		void SetSessionInWorldHook(std::function<bool(uint64_t existingSessionId)> hook);
+
 	private:
 		using Clock = std::chrono::steady_clock;
 
@@ -127,6 +137,7 @@ namespace engine::server
 		std::unordered_map<uint64_t, Session> m_by_session_id;
 		std::unordered_map<uint64_t, uint64_t> m_by_account_id;
 		std::function<void(uint64_t, uint64_t, SessionCloseReason)> m_onSessionClosed;
+		std::function<bool(uint64_t)> m_sessionInWorldHook;
 
 		bool isValid(const Session& s, Clock::time_point now) const;
 		uint64_t generateSessionId();

--- a/src/shared/network/MasterShardClientFlow.cpp
+++ b/src/shared/network/MasterShardClientFlow.cpp
@@ -115,6 +115,7 @@ namespace engine::network
 			bool authDone = false;
 			bool authOk = false;
 			uint64_t sessionId = 0;
+			NetErrorCode authErrorCode = NetErrorCode::OK;
 			if (!disp.SendRequest(kOpcodeAuthRequest, authPayload, [&](uint32_t, bool timeout, std::vector<uint8_t> payload) {
 				authDone = true;
 				authTimeout = timeout;
@@ -123,6 +124,7 @@ namespace engine::network
 					auto p = ParseAuthResponsePayload(payload.data(), payload.size());
 					authOk = p && p->success != 0;
 					if (authOk) sessionId = p->session_id;
+					else if (p) authErrorCode = p->error_code;
 				}
 			}, m_timeoutMs))
 			{
@@ -138,8 +140,10 @@ namespace engine::network
 			}
 			if (!authDone || authTimeout || !authOk)
 			{
+				result.authErrorCode = authErrorCode;
 				result.errorMessage = authTimeout ? "AUTH timeout" : "AUTH failed";
-				LOG_WARN(Net, "[MasterShardClientFlow] {}", result.errorMessage);
+				LOG_WARN(Net, "[MasterShardClientFlow] {} (authErrorCode={})",
+					result.errorMessage, static_cast<uint32_t>(authErrorCode));
 				return result;
 			}
 			disp.SetSessionId(sessionId);

--- a/src/shared/network/MasterShardClientFlow.h
+++ b/src/shared/network/MasterShardClientFlow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/shared/network/CharacterPayloads.h"
+#include "src/shared/network/NetErrorCode.h"
 #include "src/shared/network/ServerListPayloads.h"
 
 #include <cstdint>
@@ -25,6 +26,9 @@ namespace engine::network
 		bool shard_choice_required = false;
 		std::vector<ServerListEntry> server_list_for_pick;
 		std::string errorMessage;
+		/// Code d'erreur de l'étape AUTH quand elle échoue (sinon \c OK). Permet à l'UI
+		/// d'afficher un message dédié — notamment \c ALREADY_LOGGED_IN (compte déjà en jeu).
+		NetErrorCode authErrorCode = NetErrorCode::OK;
 		uint64_t account_id = 0;
 		uint32_t shard_id = 0;
 		/// Phase 3 — endpoint host:port du shard accepté (renseigné quand \c success=true).


### PR DESCRIPTION
## Problème

Un compte déjà en jeu pouvait être ré-authentifié par un 2ᵉ client. Le master kickait bien la 1ʳᵉ session (`KickedByDuplicateLogin`), mais le 1ᵉʳ client se **reconnectait en boucle** — il ne distingue pas un kick d'une coupure réseau (`NetClient` ne reçoit qu'un `peer closed`). Résultat : les deux clients rebondissaient (ping-pong) et le même compte se retrouvait jouable « deux fois ».

## Correctif

**Refuser la 2ᵉ authentification** au lieu de kicker la 1ʳᵉ — mais **seulement si la session existante correspond à un joueur réellement en jeu** (`EnterWorld` validé). Sinon la policy `KickExisting` habituelle s'applique : elle reste nécessaire pour le double-auth du flux de connexion client (auth initiale + re-auth dans `MasterShardClientFlow`), qu'un `RefuseNew` global aurait cassé.

**Master**
- `SessionManager` : nouveau hook `SetSessionInWorldHook`. `CreateSession`, sur détection de doublon, renvoie `0` (refus) si le hook indique que la session existante est en jeu — quelle que soit la policy.
- `main_linux.cpp` : câble le hook — `existingSessionId → connId` (`ConnectionSessionMap::FindConnIdForSession`) → `SessionCharacterMap::GetByConnId` ; présent ⇒ en jeu.
- `AuthRegisterHandler::HandleAuth` envoyait **déjà** `ALREADY_LOGGED_IN` quand `CreateSession` renvoie `0` → aucun changement côté handler.

**Client**
- `MasterShardClientFlow` : propage le `NetErrorCode` de l'AUTH échouée (`authErrorCode`), jusque-là ignoré.
- `AuthUiPresenterCore` : message dédié `auth.error.already_logged_in` quand l'AUTH échoue avec `ALREADY_LOGGED_IN`, au lieu du message générique.
- Localisation `fr.json` / `en.json` : le message invite à contacter le support et à changer son mot de passe si ce n'est pas l'utilisateur.

Pas de nouvel opcode, pas de changement de protocole, pas de migration DB. Pas de changement shard.

## Edge connu

Si la connexion master du joueur en jeu tombe vraiment (rare grâce au heartbeat de #615), il n'est plus « protégé » le temps de la reconnexion — acceptable.

## Test plan

- [ ] Build Windows + Linux (CI).
- [ ] Compte A en jeu → 2ᵉ client tente de se connecter avec A → **refusé**, reste sur l'écran login avec le message dédié.
- [ ] Le joueur A en place n'est pas déconnecté.
- [ ] Flux de connexion normal d'un client (auth initiale + re-auth du flow) → **non cassé** (la session pré-monde transitoire est bien kickée comme avant).
- [ ] Re-login d'un compte **pas encore en jeu** (ex. relog rapide depuis l'écran de sélection) → fonctionne (KickExisting).

---

**Déploiement** : ⚠️ redéploiement **master** requis (`SessionManager`, `main_linux.cpp`) **+** rebuild **client Windows** (`MasterShardClientFlow`, UI auth, localisation), en lock-step. Pas de migration DB, pas de nouvel opcode.


---
_Generated by [Claude Code](https://claude.ai/code/session_019k8ouJtnD69AzaBBy9M9mC)_