### PR TITLE
feat(world): M100.46 incréments 2b+2d+3 + convention grille monde

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,12 +398,18 @@ add_library(engine_core
   src/world_editor/zone_presets/OperationParams.cpp
   src/world_editor/zone_presets/CustomizationApplier.cpp
   # Incrément 2b : Reset des documents + dispatcher + exécuteur.
-  # Le dispatcher câble end-to-end les types place_cave / place_overhang
-  # / place_dungeon ; les 11 autres types sont gracieusement skipped
-  # (log info, aligné sur le skip silencieux des entrées `decoration`).
+  # Incrément 2c : place_arch câblé. Incrément 2d : mountain_macro /
+  # valley_macro / lake_polygon / river_manual câblés. Au total 8/14
+  # types câblés ; les 4 restants (coastline, river_network,
+  # hydraulic_erosion, thermal_wind_erosion) demandent d'extraire la
+  # simulation des Tools UI (incrément 2e+).
   src/world_editor/zone_presets/WorldMapEditDocumentReset.cpp
   src/world_editor/zone_presets/OperationDispatcher.cpp
   src/world_editor/zone_presets/ZonePresetExecutor.cpp
+  # Incrément 3 : dialog modal ImGui pour appliquer un preset à la
+  # carte courante (entrée menu Fichier > "Appliquer un preset de
+  # zone..."). Single-thread : bloque le main thread pendant Execute.
+  src/world_editor/zone_presets/ZonePresetDialog.cpp
   # M100.45 Phase B — migration des outils vers Simple/Advanced + presets.
   # ToolPresetApply : mapping pur preset -> struct d'outil (testable).
   # PresetDropdownWidget : widget ImGui A.6 réutilisable par les panels.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,13 @@ add_library(engine_core
   src/world_editor/zone_presets/ZonePresetRegistry.cpp
   src/world_editor/zone_presets/OperationParams.cpp
   src/world_editor/zone_presets/CustomizationApplier.cpp
+  # Incrément 2b : Reset des documents + dispatcher + exécuteur.
+  # Le dispatcher câble end-to-end les types place_cave / place_overhang
+  # / place_dungeon ; les 11 autres types sont gracieusement skipped
+  # (log info, aligné sur le skip silencieux des entrées `decoration`).
+  src/world_editor/zone_presets/WorldMapEditDocumentReset.cpp
+  src/world_editor/zone_presets/OperationDispatcher.cpp
+  src/world_editor/zone_presets/ZonePresetExecutor.cpp
   # M100.45 Phase B — migration des outils vers Simple/Advanced + presets.
   # ToolPresetApply : mapping pur preset -> struct d'outil (testable).
   # PresetDropdownWidget : widget ImGui A.6 réutilisable par les panels.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,10 @@ add_library(engine_core
   src/world_editor/water/RiverTool.cpp
   # M100.36 — River Network Generator (watershed D8 + OceanSettings)
   src/world_editor/water/ConsolidatedHeightGrid.cpp
+  # M100.46 — helper partagé qui assemble un grid 2x2 chunks depuis le
+  # TerrainDocument (anciennement dupliqué dans CoastlineEditorTool,
+  # ThermalWindErosionTool et OperationDispatcher).
+  src/world_editor/water/HeightGridAssembly.cpp
   src/world_editor/water/D8FlowDirection.cpp
   src/world_editor/water/FlowAccumulation.cpp
   src/world_editor/water/PathSimplifyDouglasPeucker.cpp

--- a/docs/world_cell_grid_convention.md
+++ b/docs/world_cell_grid_convention.md
@@ -1,0 +1,185 @@
+# Convention de nommage des cellules monde
+
+Document de référence pour le découpage de la carte LCDLLN en cellules de
+zone. Cette convention fige l'identifiant de chaque cellule sur disque et
+dans le code, indépendamment de l'**implémentation interne** (chunks moteur,
+spatial grid serveur, etc., qui ont leurs propres unités).
+
+---
+
+## 1. Grille monde
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Nombre de lignes (Nord/Sud) | **33** (14 N → 18 S) |
+| Nombre de colonnes (Est/Ouest) | **40** (19 W → 20 E) |
+| Total de cellules | **1320** (33 × 40) |
+| Taille d'une cellule | **10 km × 10 km** (= `engine::world::kZoneSize` en mètres) |
+| Carte totale | **330 km × 400 km** (132 000 km²) |
+
+Une cellule = une **zone** au sens moteur (1 `runtime_manifest.json`, 1
+heightmap, 20×20 chunks de 500 m).
+
+---
+
+## 2. Origine et orientation
+
+L'**Oracle** est le centre logique de l'empire. Sa cellule est
+**`cell_n000_e000`**. Toutes les autres cellules sont nommées par rapport à
+elle :
+
+- Axe **Nord/Sud** : `N` croît vers le nord depuis Oracle, `S` croît vers le
+  sud.
+- Axe **Est/Ouest** : `E` croît vers l'est depuis Oracle, `W` croît vers
+  l'ouest.
+
+L'origine `(N000, E000)` est volontairement **décentrée** dans la grille
+33×40 (Oracle a 14 lignes au nord et 18 au sud ; 19 colonnes à l'ouest et
+20 à l'est) pour refléter la géographie narrative de l'empire.
+
+---
+
+## 3. Format de l'identifiant
+
+```text
+cell_<lat><DDD>_<lon><DDD>
+```
+
+- Préfixe littéral `cell_`.
+- `lat` ∈ {`n`, `s`}, `lon` ∈ {`e`, `w`}.
+- `DDD` : trois chiffres décimaux **zéro-paddés** (000 .. 999). 3 chiffres
+  laissent de la marge si la carte s'agrandit (1 000 cellules par côté).
+- Tout en **minuscules** : impératif imposé par
+  `SanitizeZoneId` (`src/world_editor/ui/WorldMapIo.cpp:1235`), qui force
+  alphanum + `_` + lowercase sur tout `zone_id` côté éditeur. Toute saisie
+  utilisateur `cell_N000_E000` sera normalisée en `cell_n000_e000` au Save.
+
+### Exemples
+
+| Cellule | Sens |
+|---------|------|
+| `cell_n000_e000` | Oracle (centre) |
+| `cell_n014_w019` | Coin nord-ouest |
+| `cell_n014_e020` | Coin nord-est |
+| `cell_s018_w019` | Coin sud-ouest |
+| `cell_s018_e020` | Coin sud-est |
+| `cell_n011_e002` | Exemple d'île à 2 cellules au NE d'Oracle |
+
+### Conversion ↔ ancienne convention `R###C###`
+
+Sous l'ancienne grille `R050C010` → `R370C400` (32 lignes × 391 colonnes,
+origine NO), la cellule située à `(row=R, col=C)` correspondait à un point
+de la carte. La nouvelle convention utilise Oracle comme origine ; les
+valeurs `R`/`C` qui plaçaient Oracle dans l'ancienne grille sont :
+
+```
+oracle_row = 50 + 14 = 64    (offset N: 14 lignes au nord)
+oracle_col = 10 + 19 = 29    (offset W: 19 colonnes à l'ouest)
+```
+
+Donc :
+
+```
+N = oracle_row - R          (négatif → S = R - oracle_row)
+E = C - oracle_col          (négatif → W = oracle_col - C)
+```
+
+Validation sur les coins (issus de la discussion produit) :
+
+| Ancienne | Nouvelle |
+|----------|----------|
+| `R050C010` | `cell_n014_w019` |
+| `R050C400` | `cell_n014_e020` |
+| `R370C010` | `cell_s018_w019` |
+| `R370C400` | `cell_s018_e020` |
+| `R080C220` | `cell_n011_e002` |
+
+---
+
+## 4. Structure d'un dossier de cellule
+
+Chaque cellule habitée a son dossier sous `game/data/zones/<cell_id>/` avec,
+**au minimum** :
+
+```
+cell_n000_e000/
+├── runtime_manifest.json   # version 3, zone_id = "cell_n000_e000"
+└── .gitkeep                # pour garder le dossier en git tant que vide
+```
+
+Quand l'éditeur monde sauvegarde la zone, il ajoute selon le contenu :
+
+```
+├── terrain_height.r16h     # heightmap (généré par éditeur)
+├── terrain_splat.slap      # splat layers (généré par éditeur)
+├── terrain_grass.grms      # masque herbe (généré par éditeur)
+├── atmosphere.json         # ambiance / éclairage (généré par zone_builder)
+├── probes.bin              # sondes globales (généré par zone_builder)
+├── zone.meta               # header binaire versionné
+├── chunks/                 # 20×20 chunks (généré par zone_builder)
+├── layout_from_editor.json # instances depuis l'éditeur
+├── spawners.json           # peuplement runtime (édité à la main / outil)
+├── events.json             # events runtime (édité à la main / outil)
+└── gathering_nodes.json    # nodes de collecte (édité à la main / outil)
+```
+
+Voir `docs/world_editor_zone_pipeline.md` pour le pipeline complet
+édition → export runtime → `zone_builder`.
+
+---
+
+## 5. Politique de création des cellules
+
+**Pas de pré-création massive** des 1320 cellules. Chaque cellule est créée
+**à la main au fur et à mesure** que le mapping avance. Raisons :
+
+1. Une cellule pleinement éditée pèse plusieurs centaines de KB de binaires
+   (heightmap + splat + grass + chunks) → 1320 × ~300 KB ≈ 400 MB de
+   binaires dans git, inutiles tant que la cellule n'est pas mappée.
+2. Le système Zone Presets (M100.46) est l'outil prévu pour bootstrapper
+   rapidement une cellule depuis un template (`temperate_forest`,
+   `rocky_coast`, …). Pré-créer des stubs vides court-circuite ce flux.
+3. La grille évoluera : un découpage en îles ou en sous-régions narratives
+   peut rendre certaines cellules absentes/inutiles.
+
+**Workflow attendu** pour une nouvelle cellule :
+
+1. Créer le dossier `game/data/zones/cell_<lat><DDD>_<lon><DDD>/`.
+2. Y placer un `runtime_manifest.json` stub minimal (heightmap/splat/grass
+   = `null`, `terrain_world_size_m` = 10000, `zone_id` = nom du dossier) +
+   un `.gitkeep`.
+3. Ouvrir la cellule dans `lcdlln_world_editor`.
+4. Appliquer un Zone Preset adapté (Fichier > Appliquer un preset, M100.46
+   incrément 3) **OU** sculpter à la main.
+5. Sauvegarder → l'éditeur écrit les binaires (terrain_height,
+   terrain_splat, terrain_grass) + met à jour le manifest.
+6. Optionnel : `zone_builder --layout zones/<cell>/layout_from_editor.json
+   --output zones/<cell> --zone-id <cell>` pour packager les chunks.
+
+---
+
+## 6. État actuel
+
+| Cellule | Statut | Notes |
+|---------|--------|-------|
+| `cell_n000_e000` | Stub (manifest vide) | Oracle, créée pour valider la convention. |
+| `demo_plains` | Zone démo legacy | Conservée pour les tests et la checklist ; pas renommée. |
+| `zone_0`, `zone_1`, `zone_2` | Zones de test legacy | Conservées pour les exemples de layout. |
+
+Les zones legacy (`demo_plains`, `zone_*`) ne sont **pas** renommées : elles
+servent de référence pour les tests et la documentation existante. La
+nouvelle convention s'applique aux cellules **du monde de jeu** uniquement.
+
+---
+
+## 7. Évolutions
+
+Si la grille change (taille de cellule, dimensions, origine), mettre à jour
+ce document **et** :
+
+- `engine::world::kZoneSize` dans `src/client/world/WorldModel.h` si la
+  taille de cellule bouge (impact streaming et chunk size).
+- Le tableau de mapping `R###C###` ↔ `cell_*` ci-dessus.
+- Toute documentation aval (`world_editor_zone_pipeline.md`,
+  `world_zone_demo_checklist.md`) qui pourrait référencer un id de zone
+  ancien.

--- a/game/data/zones/cell_n000_e000/runtime_manifest.json
+++ b/game/data/zones/cell_n000_e000/runtime_manifest.json
@@ -1,0 +1,14 @@
+{
+  "lcdlln_runtime_manifest_version": 3,
+  "zone_id": "cell_n000_e000",
+  "terrain_heightmap": null,
+  "terrain_splatmap": null,
+  "terrain_grass_mask": null,
+  "source_edit_format_version": 1,
+  "terrain_world_size_m": 10000,
+  "texture_assets": [],
+  "exported_textures": [],
+  "texture_assets_source_missing": [],
+  "object_prefab_ids": [],
+  "note": "Prototype cellule monde — Oracle / centre de l'empire. Convention cell_<N|S>DDD_<E|W>DDD (voir docs/world_cell_grid_convention.md). Stub minimal : aucun terrain ni splat ; l'éditeur générera les binaires (terrain_height.r16h, terrain_splat.slap, …) au premier Save après application d'un Zone Preset (M100.46)."
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5497,6 +5497,10 @@ namespace engine
 				if (m_worldEditorExe)
 				{
 					m_worldEditorImGui->SetEditorContext(m_worldEditorSession.get(), &m_cfg);
+					// M100.46 incrément 3 — branche le Shell pour que le
+					// dialog Zone Presets puisse résoudre documents et
+					// catalogs au moment de l'exécution.
+					m_worldEditorImGui->SetWorldEditorShell(m_worldEditorShell.get());
 
 					// Cache de vignettes pour les textures de splatting.
 					m_texturePreviewCache = std::make_unique<engine::editor::TexturePreviewCache>();

--- a/src/world_editor/terrain/TerrainDocument.h
+++ b/src/world_editor/terrain/TerrainDocument.h
@@ -59,6 +59,16 @@ namespace engine::editor::world
 		/// Nombre de chunks actuellement résidents en RAM.
 		size_t LoadedChunkCount() const { return m_chunks.size(); }
 
+		/// M100.46 — Vide intégralement le cache RAM (chunks + splats).
+		/// Les prochains `EnsureLoaded` / `EnsureSplatLoaded` reconstruiront
+		/// des chunks plats à 0 m. Utilisé par `WorldMapEditDocumentReset`
+		/// avant l'exécution d'un zone preset sur une zone non vide.
+		void Reset() noexcept
+		{
+			m_chunks.clear();
+			m_splats.clear();
+		}
+
 		/// Attache un `TerrainLodWorker` pour la régénération asynchrone des
 		/// LODs (M100.8). Le caller possède le worker (ne le détruit pas pendant
 		/// la durée de vie du document). `contentRoot` est mémorisé pour que le

--- a/src/world_editor/terrain/erosion/ThermalWindErosionTool.cpp
+++ b/src/world_editor/terrain/erosion/ThermalWindErosionTool.cpp
@@ -1,8 +1,8 @@
 #include "src/world_editor/terrain/erosion/ThermalWindErosionTool.h"
 
-#include "src/client/world/terrain/TerrainChunk.h"
 #include "src/world_editor/terrain/TerrainDocument.h"
 #include "src/world_editor/terrain/erosion/ThermalWindErosionCommand.h"
+#include "src/world_editor/water/HeightGridAssembly.h"
 #include "src/world_editor/water/WaterDocument.h"
 
 #include <memory>
@@ -10,51 +10,9 @@
 
 namespace engine::editor::world::erosion
 {
-	namespace
-	{
-		constexpr int kRes =
-			static_cast<int>(engine::world::terrain::kTerrainResolution);
-
-		/// Assemble un grid 2×2 chunks autour de l'origine (même périmètre
-		/// MVP que les autres outils Phase 2.5).
-		engine::editor::world::ConsolidatedHeightGrid BuildGrid(
-			engine::editor::world::TerrainDocument& terrain,
-			const engine::core::Config& cfg)
-		{
-			constexpr int kChunksDim = 2;
-			engine::editor::world::ConsolidatedHeightGrid grid;
-			grid.cellSizeMeters = engine::world::terrain::kTerrainCellSizeMeters;
-			grid.originCellX = 0;
-			grid.originCellZ = 0;
-			const int W = kChunksDim * (kRes - 1) + 1;
-			const int H = kChunksDim * (kRes - 1) + 1;
-			grid.width = W;
-			grid.height = H;
-			grid.heights.assign(static_cast<size_t>(W) * H, 0.0f);
-			for (int cz = 0; cz < kChunksDim; ++cz)
-			{
-				for (int cx = 0; cx < kChunksDim; ++cx)
-				{
-					auto chunk = terrain.EnsureLoaded(cfg, cx, cz);
-					if (!chunk) continue;
-					const int baseX = cx * (kRes - 1);
-					const int baseZ = cz * (kRes - 1);
-					for (int iz = 0; iz < kRes; ++iz)
-					{
-						for (int ix = 0; ix < kRes; ++ix)
-						{
-							const int gx = baseX + ix;
-							const int gz = baseZ + iz;
-							if (gx >= W || gz >= H) continue;
-							grid.heights[static_cast<size_t>(gz) * W + gx] =
-								chunk->heights[static_cast<size_t>(iz) * kRes + ix];
-						}
-					}
-				}
-			}
-			return grid;
-		}
-	}
+	// `BuildGridFromLoadedChunks` vit maintenant dans
+	// `water/HeightGridAssembly.{h,cpp}` (partagé avec CoastlineEditorTool
+	// et OperationDispatcher). Voir l'include ci-dessus.
 
 	bool ThermalWindErosionTool::Init(engine::editor::world::CommandStack& stack,
 		engine::editor::world::TerrainDocument& terrain,
@@ -83,7 +41,7 @@ namespace engine::editor::world::erosion
 	{
 		if (m_terrain == nullptr || m_water == nullptr || m_cfg == nullptr) return false;
 
-		auto grid = BuildGrid(*m_terrain, *m_cfg);
+		auto grid = engine::editor::world::BuildGridFromLoadedChunks(*m_terrain, *m_cfg);
 		const float seaLevel = m_water->GetOcean().seaLevelMeters;
 
 		m_thermalDeltas.clear();

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -6,6 +6,8 @@
 /// valley_macro / lake_polygon / river_manual). L'UI (incrément 3)
 /// vient avec ses propres tests.
 
+#include "src/client/world/terrain/TerrainChunk.h"
+#include "src/shared/core/Config.h"
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/terrain/TerrainDocument.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
@@ -14,6 +16,7 @@
 #include "src/world_editor/volumes/dungeons/DungeonCatalog.h"
 #include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
 #include "src/world_editor/volumes/overhangs/OverhangCatalog.h"
+#include "src/world_editor/water/HeightGridAssembly.h"
 #include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/zone_presets/CustomizationApplier.h"
 #include "src/world_editor/zone_presets/OperationDispatcher.h"
@@ -830,6 +833,60 @@ namespace
 		REQUIRE(cmd == nullptr);
 	}
 
+	// --- Helper partagé : BuildGridFromLoadedChunks --------------------
+
+	/// `BuildGridFromLoadedChunks` doit produire une grille bien
+	/// dimensionnée (2×(kRes-1)+1 par axe) avec heights initiales à 0
+	/// quand aucun chunk n'existe sur disque (EnsureLoaded crée des
+	/// chunks plats par défaut).
+	void Test_HeightGridAssembly_BuildsFlat()
+	{
+		engine::core::Config cfg;
+		ew::TerrainDocument terrain;
+
+		const auto grid = ew::BuildGridFromLoadedChunks(terrain, cfg);
+
+		const int kRes = static_cast<int>(engine::world::terrain::kTerrainResolution);
+		const int expectedDim = 2 * (kRes - 1) + 1;
+		REQUIRE(grid.width  == expectedDim);
+		REQUIRE(grid.height == expectedDim);
+		REQUIRE(grid.heights.size() ==
+			static_cast<size_t>(expectedDim) * expectedDim);
+		REQUIRE(NearEq(grid.cellSizeMeters,
+			engine::world::terrain::kTerrainCellSizeMeters));
+		REQUIRE(grid.originCellX == 0);
+		REQUIRE(grid.originCellZ == 0);
+
+		// Toutes les heights sont à 0 : EnsureLoaded crée des chunks plats
+		// quand aucun terrain.bin n'existe sur disque.
+		for (float h : grid.heights)
+		{
+			REQUIRE(NearEq(h, 0.0));
+		}
+
+		// EnsureLoaded a chargé 2x2 chunks = 4.
+		REQUIRE(terrain.LoadedChunkCount() == 4u);
+	}
+
+	/// Hauteurs non nulles : on injecte une valeur dans un chunk déjà chargé
+	/// avant l'appel et on vérifie qu'elle se retrouve dans la grille.
+	void Test_HeightGridAssembly_PreservesNonZeroHeights()
+	{
+		engine::core::Config cfg;
+		ew::TerrainDocument terrain;
+		// Pré-charge le chunk (0,0) et injecte une hauteur connue.
+		auto chunk = terrain.EnsureLoaded(cfg, 0, 0);
+		REQUIRE(chunk);
+		const int kRes = static_cast<int>(engine::world::terrain::kTerrainResolution);
+		// Cellule (10, 20) du chunk → height 42.0.
+		chunk->heights[static_cast<size_t>(20) * kRes + 10] = 42.0f;
+
+		const auto grid = ew::BuildGridFromLoadedChunks(terrain, cfg);
+		// Mapping : cellule (10, 20) du chunk (0,0) → cellule (10, 20)
+		// de la grille (chunks (0,0) occupent baseX=0, baseZ=0).
+		REQUIRE(NearEq(grid.Get(10, 20), 42.0));
+	}
+
 	// --- Incrément 2e : hydraulic_erosion / thermal_wind_erosion /
 	//                    river_network / coastline (config-required)
 
@@ -1076,6 +1133,8 @@ int main()
 	Test_Dispatcher_LakePolygon_RejectsDegenerate();
 	Test_Dispatcher_RiverManual_BuildsCommand();
 	Test_Dispatcher_UnsupportedType_GracefulSkip();
+	Test_HeightGridAssembly_BuildsFlat();
+	Test_HeightGridAssembly_PreservesNonZeroHeights();
 	Test_Dispatcher_HydraulicErosion_RequiresConfig();
 	Test_Dispatcher_ThermalWindErosion_RejectsAllDisabled();
 	Test_Dispatcher_RiverNetwork_RejectsEmptySources();

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -8,6 +8,7 @@
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/terrain/TerrainDocument.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
+#include "src/world_editor/volumes/arches/ArchCatalog.h"
 #include "src/world_editor/volumes/caves/CaveCatalog.h"
 #include "src/world_editor/volumes/dungeons/DungeonCatalog.h"
 #include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
@@ -449,9 +450,10 @@ namespace
 		ew::TerrainDocument& t, vol::MeshInsertDocument& m,
 		vol::dungeons::DungeonPortalDocument& d,
 		vol::caves::CaveCatalog& cv, vol::overhangs::OverhangCatalog& oh,
+		vol::arches::ArchCatalog& ar,
 		vol::dungeons::DungeonCatalog& dc)
 	{
-		return zp::DispatchContext{ t, m, d, cv, oh, dc };
+		return zp::DispatchContext{ t, m, d, cv, oh, ar, dc };
 	}
 
 	/// place_cave : trouve l'entrée catalogue, construit une commande
@@ -465,6 +467,7 @@ namespace
 				"aabbMin":[-2,0,-2],"aabbMax":[2,3,2],"entrancePoint":[0,0,-2]}]
 		})", err));
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 
 		ew::TerrainDocument terrain;
@@ -482,7 +485,7 @@ namespace
 			"autoSnapToGround":true
 		})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Ok);
@@ -504,6 +507,7 @@ namespace
 		std::string err;
 		(void)caveCat.ParseJson(R"({"caves":[]})", err);
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		ew::TerrainDocument terrain;
 		vol::MeshInsertDocument meshDoc;
@@ -513,7 +517,7 @@ namespace
 		op.type    = "place_cave";
 		op.rawJson = R"({"type":"place_cave","catalogId":"ghost","worldPosition":[0,0,0]})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Failed);
@@ -525,6 +529,7 @@ namespace
 	{
 		vol::caves::CaveCatalog caveCat;
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		std::string err;
 		REQUIRE(dgCat.ParseJson(R"({
@@ -545,7 +550,7 @@ namespace
 			"triggerRadius":4
 		})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Ok);
@@ -556,11 +561,57 @@ namespace
 		REQUIRE(portalDoc.All()[0].requiredLevel == 15u); // depuis le catalog
 	}
 
+	/// place_arch : géométrie dérivée (midpoint, yaw, scale) à partir
+	/// des deux piliers + résolution du catalog. Mirror de ArchTool::Place.
+	void Test_Dispatcher_PlaceArch_DerivesGeometry()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		std::string err;
+		// Arche native : pillarA=[-2,0,0], pillarB=[2,0,0] → span natif = 4 m.
+		REQUIRE(arCat.ParseJson(R"({
+			"arches":[{"id":"a1","gltf":"arches/a1.gltf","displayName":"Arche test",
+				"archAnchorA":[-2.0,0.0,0.0],"archAnchorB":[2.0,0.0,0.0],
+				"archHeight":3.0,"aabbMin":[-3,0,-1],"aabbMax":[3,4,1]}]
+		})", err));
+
+		ew::TerrainDocument terrain;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "place_arch";
+		// Monde : A=(0,10,0), B=(8,10,0) → span = 8 m, scale = 8/4 = 2,
+		// midpoint = (4,10,0), yaw = atan2(0,8) = 0 deg.
+		op.rawJson = R"({
+			"type":"place_arch","catalogId":"a1",
+			"pillarA":[0,10,0],"pillarB":[8,10,0]
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		stack.Push(std::move(cmd));
+		REQUIRE(meshDoc.Size() == 1u);
+		const auto& inst = meshDoc.All()[0];
+		REQUIRE(inst.insertCategory == "arch");
+		REQUIRE(NearEq(inst.worldPosition.x, 4.0));    // midpoint
+		REQUIRE(NearEq(inst.worldPosition.y, 10.0));
+		REQUIRE(NearEq(inst.worldPosition.z, 0.0));
+		REQUIRE(NearEq(inst.uniformScale, 2.0));        // 8 / 4
+		REQUIRE(std::fabs(inst.eulerRotationDeg.y) < 0.1f); // yaw ≈ 0 deg
+	}
+
 	/// Type non câblé en MVP → Unsupported, pas de crash.
 	void Test_Dispatcher_UnsupportedType_GracefulSkip()
 	{
 		vol::caves::CaveCatalog caveCat;
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		ew::TerrainDocument terrain;
 		vol::MeshInsertDocument meshDoc;
@@ -570,7 +621,7 @@ namespace
 		op.type    = "hydraulic_erosion";  // connu mais non câblé
 		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":1000})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Unsupported);
@@ -589,6 +640,7 @@ namespace
 				"entrancePoint":[0,0,0]}]
 		})", err));
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		REQUIRE(dgCat.ParseJson(R"({"dungeons":[{"id":"dt","minDifficulty":1,"maxDifficulty":1}]})", err));
 
@@ -627,7 +679,7 @@ namespace
 		preset.operations.push_back(op4);
 
 		zp::ZonePresetExecutor executor;
-		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat };
+		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
 		int callbackCount = 0;
 		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
 			stack, ctx, water,
@@ -654,6 +706,7 @@ namespace
 			"caves":[{"id":"c1","gltf":"x.gltf","aabbMin":[-1,0,-1],"aabbMax":[1,2,1]}]
 		})", err));
 		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 
 		ew::TerrainDocument terrain;
@@ -673,7 +726,7 @@ namespace
 		}
 
 		zp::ZonePresetExecutor executor;
-		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat };
+		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
 		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
 			stack, ctx, water,
 			[](const zp::ExecutionProgress& p) {
@@ -714,6 +767,7 @@ int main()
 	Test_Dispatcher_PlaceCave_BuildsCommand();
 	Test_Dispatcher_PlaceCave_UnknownCatalog();
 	Test_Dispatcher_PlaceDungeon_BuildsCommand();
+	Test_Dispatcher_PlaceArch_DerivesGeometry();
 	Test_Dispatcher_UnsupportedType_GracefulSkip();
 	Test_Executor_RunsAndSummarizes();
 	Test_Executor_CancelViaCallback();

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -984,6 +984,143 @@ namespace
 		REQUIRE(rc == zp::DispatchResult::Failed);
 	}
 
+	// --- Happy path : ops sim avec Config + chunks préchargés -------------
+	//
+	// Ces tests valident le wiring complet :
+	//   BuildGridFromLoadedChunks → Run*Simulation → command builder.
+	// Petits paramètres (50 gouttes, lifetime 10) pour rester < 100 ms.
+
+	/// Helper : remplit les 4 chunks (0,0)..(1,1) d'une pente diagonale
+	/// pour que les sims aient quelque chose à éroder / suivre.
+	void InjectSlopedHeights(ew::TerrainDocument& terrain,
+		const engine::core::Config& cfg, float maxHeight)
+	{
+		const int kRes = static_cast<int>(engine::world::terrain::kTerrainResolution);
+		for (int cz = 0; cz < 2; ++cz)
+		{
+			for (int cx = 0; cx < 2; ++cx)
+			{
+				auto chunk = terrain.EnsureLoaded(cfg, cx, cz);
+				REQUIRE(chunk);
+				for (int iz = 0; iz < kRes; ++iz)
+				{
+					for (int ix = 0; ix < kRes; ++ix)
+					{
+						const float gx = static_cast<float>(cx * (kRes - 1) + ix);
+						const float gz = static_cast<float>(cz * (kRes - 1) + iz);
+						const float totalDim = static_cast<float>(2 * (kRes - 1));
+						// Pente diagonale 0..maxHeight.
+						chunk->heights[static_cast<size_t>(iz) * kRes + ix] =
+							maxHeight * (gx + gz) / (2.0f * totalDim);
+					}
+				}
+			}
+		}
+	}
+
+	/// hydraulic_erosion happy path : Config + chunks pentus → dispatcher
+	/// renvoie Ok et la commande "Hydraulic Erosion" est construite.
+	void Test_Dispatcher_HydraulicErosion_OkWithConfig()
+	{
+		engine::core::Config cfg;
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		InjectSlopedHeights(terrain, cfg, 100.0f);
+
+		zp::ZonePresetOperation op;
+		op.type    = "hydraulic_erosion";
+		// Petits params pour test rapide. rngSeed fixe pour déterminisme.
+		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":50,"maxLifetimeSteps":10,"rngSeed":7})";
+
+		const zp::DispatchContext ctx{
+			terrain, water, meshDoc, portalDoc,
+			caveCat, ohCat, arCat, dgCat, &cfg };
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		REQUIRE(std::string(cmd->GetLabel()) == "Hydraulic Erosion");
+	}
+
+	/// thermal_wind_erosion happy path : valide le wiring du wrapper
+	/// `ThermalWindErosionParams` (incrément 2e+ : preset overlay) sans
+	/// preset, défauts struct + JSON.
+	void Test_Dispatcher_ThermalWindErosion_OkWithConfig()
+	{
+		engine::core::Config cfg;
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		InjectSlopedHeights(terrain, cfg, 80.0f);
+
+		zp::ZonePresetOperation op;
+		op.type    = "thermal_wind_erosion";
+		// Thermal seulement (rapide). 3 passes pour test minimal.
+		op.rawJson = R"({"type":"thermal_wind_erosion","thermalEnabled":true,"windEnabled":false,"numPasses":3})";
+
+		const zp::DispatchContext ctx{
+			terrain, water, meshDoc, portalDoc,
+			caveCat, ohCat, arCat, dgCat, &cfg };
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		REQUIRE(std::string(cmd->GetLabel()) == "Thermal/Wind Erosion");
+	}
+
+	/// coastline happy path : sea level réglé + smoothing seul (cliffs
+	/// désactivés pour rapidité). Vérifie l'insertion du LakeInstance
+	/// océan + construction de la commande.
+	void Test_Dispatcher_Coastline_OkWithConfig()
+	{
+		engine::core::Config cfg;
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		InjectSlopedHeights(terrain, cfg, 80.0f);
+
+		zp::ZonePresetOperation op;
+		op.type    = "coastline";
+		op.rawJson = R"({"type":"coastline","seaLevelMeters":40,"beachEnabled":true,"cliffsEnabled":false})";
+
+		const zp::DispatchContext ctx{
+			terrain, water, meshDoc, portalDoc,
+			caveCat, ohCat, arCat, dgCat, &cfg };
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		REQUIRE(std::string(cmd->GetLabel()) == "Coastline");
+
+		// Push pour valider que Execute() ne crash pas (côté coastline
+		// le LakeInstance océan est inséré ET le sea level écrit dans
+		// WaterDocument).
+		stack.Push(std::move(cmd));
+		REQUIRE(NearEq(water.GetOcean().seaLevelMeters, 40.0));
+		REQUIRE(water.Get().lakes.size() == 1u);
+		REQUIRE(water.Get().lakes[0].isOcean);
+	}
+
 	// --- ZonePresetExecutor (incrément 2b) ---------------------------------
 
 	/// Exécution complète : reset + boucle ops. Vérifie le résumé.
@@ -1139,6 +1276,9 @@ int main()
 	Test_Dispatcher_ThermalWindErosion_RejectsAllDisabled();
 	Test_Dispatcher_RiverNetwork_RejectsEmptySources();
 	Test_Dispatcher_Coastline_RequiresConfig();
+	Test_Dispatcher_HydraulicErosion_OkWithConfig();
+	Test_Dispatcher_ThermalWindErosion_OkWithConfig();
+	Test_Dispatcher_Coastline_OkWithConfig();
 	Test_Executor_RunsAndSummarizes();
 	Test_Executor_CancelViaCallback();
 

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -1121,6 +1121,109 @@ namespace
 		REQUIRE(water.Get().lakes[0].isOcean);
 	}
 
+	/// river_network happy path : 2 sources sur terrain pentu → commande
+	/// construite. Petit minFlowThresholdCells pour que les rivières
+	/// ne soient pas rejetées sur ce mini terrain.
+	void Test_Dispatcher_RiverNetwork_OkWithConfig()
+	{
+		engine::core::Config cfg;
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		InjectSlopedHeights(terrain, cfg, 200.0f);
+
+		zp::ZonePresetOperation op;
+		op.type    = "river_network";
+		// Deux sources, threshold bas pour ne pas rejeter, pas de carving
+		// (sinon la commande applique des deltas qui demandent un chunk
+		// dirty path).
+		op.rawJson = R"({"type":"river_network","sources":[[50,50],[100,100]],"minFlowThresholdCells":10,"carvingEnabled":false})";
+
+		const zp::DispatchContext ctx{
+			terrain, water, meshDoc, portalDoc,
+			caveCat, ohCat, arCat, dgCat, &cfg };
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		REQUIRE(std::string(cmd->GetLabel()) == "River Network");
+	}
+
+	// --- Executor end-to-end : mini-preset mixte (macro + place + sim) ---
+
+	/// Test d'intégration : un mini ZonePreset construit en mémoire avec
+	/// 3 ops de natures différentes (mountain_macro = macro polyline,
+	/// place_cave = mesh insert, hydraulic_erosion = sim) exécuté
+	/// complètement via le ZonePresetExecutor → CommandStack peuplé +
+	/// documents mutés. Couvre le chemin happy path complet.
+	void Test_Executor_MixedPresetEndToEnd()
+	{
+		engine::core::Config cfg;
+		vol::caves::CaveCatalog caveCat;
+		std::string err;
+		REQUIRE(caveCat.ParseJson(R"({
+			"caves":[{"id":"c1","gltf":"caves/c1.gltf","displayName":"Petite grotte",
+				"aabbMin":[-2,0,-2],"aabbMax":[2,3,2],"entrancePoint":[0,0,-2]}]
+		})", err));
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		// Pré-remplis le terrain pour que hydraulic_erosion ait quelque
+		// chose à éroder.
+		InjectSlopedHeights(terrain, cfg, 100.0f);
+
+		zp::ZonePreset preset;
+		preset.id = "e2e_mixed";
+		preset.operations.push_back({
+			"mountain_macro", "", {},
+			R"({"type":"mountain_macro","polyline":[[100,100],[400,150],[700,100]],"widthMeters":200,"heightMeters":50})"
+		});
+		preset.operations.push_back({
+			"place_cave", "", {},
+			R"({"type":"place_cave","catalogId":"c1","worldPosition":[300,20,400]})"
+		});
+		preset.operations.push_back({
+			"hydraulic_erosion", "", {},
+			R"({"type":"hydraulic_erosion","numDroplets":30,"maxLifetimeSteps":8,"rngSeed":3})"
+		});
+
+		zp::ZonePresetExecutor executor;
+		const zp::DispatchContext ctx{
+			terrain, water, meshDoc, portalDoc,
+			caveCat, ohCat, arCat, dgCat, &cfg };
+
+		int callbackCount = 0;
+		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
+			stack, ctx,
+			[&](const zp::ExecutionProgress&) { ++callbackCount; return true; });
+
+		REQUIRE(summary.totalSteps == 3u);
+		REQUIRE(summary.commandsPushed == 3u);
+		REQUIRE(summary.unsupportedSkipped == 0u);
+		REQUIRE(summary.failed == 0u);
+		REQUIRE(!summary.wasCancelled);
+		REQUIRE(callbackCount == 3);
+
+		// La cave a effectivement été poussée dans MeshInsertDocument.
+		REQUIRE(meshDoc.Size() == 1u);
+		REQUIRE(meshDoc.All()[0].insertCategory == "cave");
+		// Le CommandStack a 3 commandes (= rien skip).
+		REQUIRE(stack.UndoSize() == 3u);
+	}
+
 	// --- ZonePresetExecutor (incrément 2b) ---------------------------------
 
 	/// Exécution complète : reset + boucle ops. Vérifie le résumé.
@@ -1279,6 +1382,8 @@ int main()
 	Test_Dispatcher_HydraulicErosion_OkWithConfig();
 	Test_Dispatcher_ThermalWindErosion_OkWithConfig();
 	Test_Dispatcher_Coastline_OkWithConfig();
+	Test_Dispatcher_RiverNetwork_OkWithConfig();
+	Test_Executor_MixedPresetEndToEnd();
 	Test_Executor_RunsAndSummarizes();
 	Test_Executor_CancelViaCallback();
 

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -5,9 +5,20 @@
 /// CustomizationApplier) et l'UI sont des incréments suivants — leurs
 /// tests (déterminisme, customisation, annulation) viendront avec.
 
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/terrain/TerrainDocument.h"
+#include "src/world_editor/volumes/MeshInsertDocument.h"
+#include "src/world_editor/volumes/caves/CaveCatalog.h"
+#include "src/world_editor/volumes/dungeons/DungeonCatalog.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
+#include "src/world_editor/volumes/overhangs/OverhangCatalog.h"
+#include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/zone_presets/CustomizationApplier.h"
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
 #include "src/world_editor/zone_presets/OperationParams.h"
+#include "src/world_editor/zone_presets/WorldMapEditDocumentReset.h"
 #include "src/world_editor/zone_presets/ZonePreset.h"
+#include "src/world_editor/zone_presets/ZonePresetExecutor.h"
 #include "src/world_editor/zone_presets/ZonePresetIo.h"
 #include "src/world_editor/zone_presets/ZonePresetRegistry.h"
 
@@ -402,6 +413,276 @@ namespace
 		REQUIRE(p.GetNumber("heightMeters", h) && NearEq(h, 600.0));
 		REQUIRE(p.GetNumber("numDroplets", n) && NearEq(n, 80000.0));
 	}
+
+	// --- WorldMapEditDocumentReset (incrément 2b) --------------------------
+
+	namespace ew = engine::editor::world;
+	namespace vol = engine::editor::world::volumes;
+
+	/// Reset vide les 4 documents en mémoire.
+	void Test_WorldMapEditDocumentReset_ClearsAllDocs()
+	{
+		ew::TerrainDocument terrain;
+		ew::WaterDocument   water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		// Pré-remplissage minimal.
+		vol::MeshInsertInstance mi;
+		mi.gltfRelativePath = "x"; mi.insertCategory = "cave";
+		meshDoc.Add(mi);
+		vol::dungeons::DungeonPortalInstance dp;
+		dp.dungeonTemplateId = "y";
+		portalDoc.Add(dp);
+		REQUIRE(meshDoc.Size() == 1u);
+		REQUIRE(portalDoc.Size() == 1u);
+
+		zp::ResetEditedZoneDocuments(terrain, water, meshDoc, portalDoc);
+		REQUIRE(meshDoc.Size() == 0u);
+		REQUIRE(portalDoc.Size() == 0u);
+		// terrain/water n'ont pas de Size() public mais leur Reset est appelé.
+	}
+
+	// --- OperationDispatcher (incrément 2b) --------------------------------
+
+	zp::DispatchContext MakeMinimalCtx(
+		ew::TerrainDocument& t, vol::MeshInsertDocument& m,
+		vol::dungeons::DungeonPortalDocument& d,
+		vol::caves::CaveCatalog& cv, vol::overhangs::OverhangCatalog& oh,
+		vol::dungeons::DungeonCatalog& dc)
+	{
+		return zp::DispatchContext{ t, m, d, cv, oh, dc };
+	}
+
+	/// place_cave : trouve l'entrée catalogue, construit une commande
+	/// PlaceCaveCommand qui exécutée pousse l'instance dans le doc.
+	void Test_Dispatcher_PlaceCave_BuildsCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		std::string err;
+		REQUIRE(caveCat.ParseJson(R"({
+			"caves":[{"id":"c1","gltf":"caves/c1.gltf","displayName":"Petite grotte",
+				"aabbMin":[-2,0,-2],"aabbMax":[2,3,2],"entrancePoint":[0,0,-2]}]
+		})", err));
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "place_cave";
+		op.rawJson = R"({
+			"type":"place_cave",
+			"catalogId":"c1",
+			"worldPosition":[100,50,200],
+			"rotationY":45,
+			"autoSnapToGround":true
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+
+		stack.Push(std::move(cmd));
+		REQUIRE(meshDoc.Size() == 1u);
+		REQUIRE(meshDoc.All()[0].insertCategory == "cave");
+		REQUIRE(meshDoc.All()[0].gltfRelativePath == "caves/c1.gltf");
+		// Snap au sol : y = 50 - entrancePoint.y(=0) = 50 (entrancePoint.y
+		// est 0 dans le catalogue ci-dessus).
+		REQUIRE(NearEq(meshDoc.All()[0].worldPosition.y, 50.0));
+	}
+
+	/// place_cave avec catalogId introuvable → Failed.
+	void Test_Dispatcher_PlaceCave_UnknownCatalog()
+	{
+		vol::caves::CaveCatalog caveCat;
+		std::string err;
+		(void)caveCat.ParseJson(R"({"caves":[]})", err);
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "place_cave";
+		op.rawJson = R"({"type":"place_cave","catalogId":"ghost","worldPosition":[0,0,0]})";
+
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+		REQUIRE(cmd == nullptr);
+	}
+
+	/// place_dungeon : catalogId du dungeon catalog, instance créée.
+	void Test_Dispatcher_PlaceDungeon_BuildsCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		std::string err;
+		REQUIRE(dgCat.ParseJson(R"({
+			"dungeons":[{"id":"dt","displayName":"Donjon test","requiredLevel":15,
+				"minDifficulty":1,"maxDifficulty":2}]
+		})", err));
+
+		ew::TerrainDocument terrain;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "place_dungeon";
+		op.rawJson = R"({
+			"type":"place_dungeon","catalogId":"dt",
+			"worldPosition":[800,0,800],"rotationY":90,
+			"triggerRadius":4
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		stack.Push(std::move(cmd));
+		REQUIRE(portalDoc.Size() == 1u);
+		REQUIRE(portalDoc.All()[0].dungeonTemplateId == "dt");
+		REQUIRE(NearEq(portalDoc.All()[0].triggerRadius, 4.0));
+		REQUIRE(portalDoc.All()[0].requiredLevel == 15u); // depuis le catalog
+	}
+
+	/// Type non câblé en MVP → Unsupported, pas de crash.
+	void Test_Dispatcher_UnsupportedType_GracefulSkip()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "hydraulic_erosion";  // connu mais non câblé
+		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":1000})";
+
+		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Unsupported);
+		REQUIRE(cmd == nullptr);
+	}
+
+	// --- ZonePresetExecutor (incrément 2b) ---------------------------------
+
+	/// Exécution complète : reset + boucle ops. Vérifie le résumé.
+	void Test_Executor_RunsAndSummarizes()
+	{
+		vol::caves::CaveCatalog caveCat;
+		std::string err;
+		REQUIRE(caveCat.ParseJson(R"({
+			"caves":[{"id":"c1","gltf":"x.gltf","aabbMin":[-1,0,-1],"aabbMax":[1,2,1],
+				"entrancePoint":[0,0,0]}]
+		})", err));
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		REQUIRE(dgCat.ParseJson(R"({"dungeons":[{"id":"dt","minDifficulty":1,"maxDifficulty":1}]})", err));
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		// Pré-remplissage : reset doit nettoyer.
+		vol::MeshInsertInstance pre;
+		pre.gltfRelativePath = "pre"; pre.insertCategory = "cave";
+		meshDoc.Add(pre);
+
+		zp::ZonePreset preset;
+		preset.id = "mixed";
+		// 1) hydraulic = non supporté → skipped
+		zp::ZonePresetOperation op1;
+		op1.type    = "hydraulic_erosion";
+		op1.rawJson = R"({"type":"hydraulic_erosion"})";
+		preset.operations.push_back(op1);
+		// 2) place_cave OK
+		zp::ZonePresetOperation op2;
+		op2.type    = "place_cave";
+		op2.rawJson = R"({"type":"place_cave","catalogId":"c1","worldPosition":[0,10,0]})";
+		preset.operations.push_back(op2);
+		// 3) place_cave catalogId ghost → failed
+		zp::ZonePresetOperation op3;
+		op3.type    = "place_cave";
+		op3.rawJson = R"({"type":"place_cave","catalogId":"ghost","worldPosition":[0,0,0]})";
+		preset.operations.push_back(op3);
+		// 4) place_dungeon OK
+		zp::ZonePresetOperation op4;
+		op4.type    = "place_dungeon";
+		op4.rawJson = R"({"type":"place_dungeon","catalogId":"dt","worldPosition":[5,0,5]})";
+		preset.operations.push_back(op4);
+
+		zp::ZonePresetExecutor executor;
+		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat };
+		int callbackCount = 0;
+		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
+			stack, ctx, water,
+			[&](const zp::ExecutionProgress&) { ++callbackCount; return true; });
+
+		REQUIRE(summary.totalSteps == 4u);
+		REQUIRE(summary.commandsPushed == 2u);     // cave + dungeon
+		REQUIRE(summary.unsupportedSkipped == 1u);  // hydraulic
+		REQUIRE(summary.failed == 1u);              // cave ghost
+		REQUIRE(!summary.wasCancelled);
+		REQUIRE(callbackCount == 4);
+		// Le pré-remplissage a été nettoyé par le reset, puis le cave OK
+		// a poussé 1 instance.
+		REQUIRE(meshDoc.Size() == 1u);
+		REQUIRE(portalDoc.Size() == 1u);
+	}
+
+	/// Callback retournant false → cancel après l'op courante.
+	void Test_Executor_CancelViaCallback()
+	{
+		vol::caves::CaveCatalog caveCat;
+		std::string err;
+		REQUIRE(caveCat.ParseJson(R"({
+			"caves":[{"id":"c1","gltf":"x.gltf","aabbMin":[-1,0,-1],"aabbMax":[1,2,1]}]
+		})", err));
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePreset preset;
+		preset.id = "cancel_test";
+		for (int i = 0; i < 3; ++i)
+		{
+			zp::ZonePresetOperation op;
+			op.type    = "place_cave";
+			op.rawJson = R"({"type":"place_cave","catalogId":"c1","worldPosition":[0,0,0]})";
+			preset.operations.push_back(op);
+		}
+
+		zp::ZonePresetExecutor executor;
+		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, dgCat };
+		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
+			stack, ctx, water,
+			[](const zp::ExecutionProgress& p) {
+				// Stoppe après l'étape 1.
+				return p.currentStep < 2u;
+			});
+		REQUIRE(summary.wasCancelled);
+		REQUIRE(summary.commandsPushed == 1u); // seule la 1ère op est passée
+	}
 }
 
 int main()
@@ -429,6 +710,13 @@ int main()
 	Test_Customization_UnaffectedOpUnchanged();
 	Test_Customization_WaterAndDryness();
 	Test_Customization_NeutralLeavesParamsIdentical();
+	Test_WorldMapEditDocumentReset_ClearsAllDocs();
+	Test_Dispatcher_PlaceCave_BuildsCommand();
+	Test_Dispatcher_PlaceCave_UnknownCatalog();
+	Test_Dispatcher_PlaceDungeon_BuildsCommand();
+	Test_Dispatcher_UnsupportedType_GracefulSkip();
+	Test_Executor_RunsAndSummarizes();
+	Test_Executor_CancelViaCallback();
 
 	if (g_failed > 0)
 	{

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -1,9 +1,10 @@
-/// Tests unitaires CPU pour M100.46 incrément 1 — Zone Presets Library
-/// (socle data : format JSON + parsing + validation + registry).
+/// Tests unitaires CPU pour M100.46 — Zone Presets Library.
 ///
-/// Le moteur d'exécution (ZonePresetExecutor / OperationDispatcher /
-/// CustomizationApplier) et l'UI sont des incréments suivants — leurs
-/// tests (déterminisme, customisation, annulation) viendront avec.
+/// Couvre les incréments 1 (data : JSON / validation / registry), 2a
+/// (OperationParams + CustomizationApplier), 2b (Reset + dispatcher
+/// `place_*` + executor), 2c (place_arch), 2d (mountain_macro /
+/// valley_macro / lake_polygon / river_manual). L'UI (incrément 3)
+/// vient avec ses propres tests.
 
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/terrain/TerrainDocument.h"
@@ -447,13 +448,14 @@ namespace
 	// --- OperationDispatcher (incrément 2b) --------------------------------
 
 	zp::DispatchContext MakeMinimalCtx(
-		ew::TerrainDocument& t, vol::MeshInsertDocument& m,
+		ew::TerrainDocument& t, ew::WaterDocument& w,
+		vol::MeshInsertDocument& m,
 		vol::dungeons::DungeonPortalDocument& d,
 		vol::caves::CaveCatalog& cv, vol::overhangs::OverhangCatalog& oh,
 		vol::arches::ArchCatalog& ar,
 		vol::dungeons::DungeonCatalog& dc)
 	{
-		return zp::DispatchContext{ t, m, d, cv, oh, ar, dc };
+		return zp::DispatchContext{ t, w, m, d, cv, oh, ar, dc };
 	}
 
 	/// place_cave : trouve l'entrée catalogue, construit une commande
@@ -471,6 +473,7 @@ namespace
 		vol::dungeons::DungeonCatalog dgCat;
 
 		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
 		vol::MeshInsertDocument meshDoc;
 		vol::dungeons::DungeonPortalDocument portalDoc;
 		ew::CommandStack stack;
@@ -485,7 +488,7 @@ namespace
 			"autoSnapToGround":true
 		})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Ok);
@@ -510,6 +513,7 @@ namespace
 		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
 		vol::MeshInsertDocument meshDoc;
 		vol::dungeons::DungeonPortalDocument portalDoc;
 
@@ -517,7 +521,7 @@ namespace
 		op.type    = "place_cave";
 		op.rawJson = R"({"type":"place_cave","catalogId":"ghost","worldPosition":[0,0,0]})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Failed);
@@ -538,6 +542,7 @@ namespace
 		})", err));
 
 		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
 		vol::MeshInsertDocument meshDoc;
 		vol::dungeons::DungeonPortalDocument portalDoc;
 		ew::CommandStack stack;
@@ -550,7 +555,7 @@ namespace
 			"triggerRadius":4
 		})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Ok);
@@ -578,6 +583,7 @@ namespace
 		})", err));
 
 		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
 		vol::MeshInsertDocument meshDoc;
 		vol::dungeons::DungeonPortalDocument portalDoc;
 		ew::CommandStack stack;
@@ -591,7 +597,7 @@ namespace
 			"pillarA":[0,10,0],"pillarB":[8,10,0]
 		})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Ok);
@@ -606,7 +612,201 @@ namespace
 		REQUIRE(std::fabs(inst.eulerRotationDeg.y) < 0.1f); // yaw ≈ 0 deg
 	}
 
-	/// Type non câblé en MVP → Unsupported, pas de crash.
+	// --- Incrément 2d : mountain_macro / valley_macro / lake_polygon /
+	//                    river_manual
+
+	/// mountain_macro : polyline → rasterisation → MountainRangeCommand
+	/// avec deltas non vides (au moins un chunk touché).
+	void Test_Dispatcher_MountainMacro_RasterizesAndBuildsCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "mountain_macro";
+		// Polyline traversant 2-3 chunks (kChunkSize = 500 m). Hauteur 100 m,
+		// largeur 400 m → assure une rasterisation non vide.
+		op.rawJson = R"({
+			"type":"mountain_macro",
+			"polyline":[[200,200],[700,200],[1200,200]],
+			"widthMeters":400,
+			"heightMeters":100
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		// On ne pousse pas la commande (Execute toucherait des chunks que le
+		// TerrainDocument doit charger via Config — non disponible en test).
+		// L'objectif est de valider le wiring dispatcher → rasterizer →
+		// constructeur de commande.
+	}
+
+	/// mountain_macro avec polyline trop courte → Failed.
+	void Test_Dispatcher_MountainMacro_RejectsBadPolyline()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "mountain_macro";
+		op.rawJson = R"({"type":"mountain_macro","polyline":[[100,100]],"widthMeters":200,"heightMeters":50})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+		REQUIRE(cmd == nullptr);
+	}
+
+	/// valley_macro : même polyline que mountain_macro, mais le rasterizer
+	/// est invoqué avec `invert=true`. On vérifie que la commande retournée
+	/// est bien un ValleyChainCommand (label "Valley Chain").
+	void Test_Dispatcher_ValleyMacro_BuildsValleyCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "valley_macro";
+		op.rawJson = R"({
+			"type":"valley_macro",
+			"polyline":[[300,300],[800,400],[1300,500]],
+			"widthMeters":300,
+			"heightMeters":80
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+		REQUIRE(std::string(cmd->GetLabel()) == "Valley Chain");
+	}
+
+	/// lake_polygon : polygone fermé → LakeInstance avec polygon Y=waterLevel,
+	/// AddLakeCommand exécutée → lac présent dans WaterDocument.
+	void Test_Dispatcher_LakePolygon_BuildsCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "lake_polygon";
+		op.rawJson = R"({
+			"type":"lake_polygon",
+			"polygon":[[100,100],[200,100],[200,200],[100,200]],
+			"waterLevel":12.5
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+		REQUIRE(cmd != nullptr);
+
+		stack.Push(std::move(cmd));
+		REQUIRE(water.Get().lakes.size() == 1u);
+		const auto& lake = water.Get().lakes[0];
+		REQUIRE(lake.polygon.size() == 4u);
+		REQUIRE(NearEq(lake.waterLevelY, 12.5));
+		REQUIRE(NearEq(lake.polygon[0].y, 12.5)); // Y rempli depuis waterLevel
+	}
+
+	/// lake_polygon avec polygon de 2 points → Failed (besoin ≥ 3 points).
+	void Test_Dispatcher_LakePolygon_RejectsDegenerate()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "lake_polygon";
+		op.rawJson = R"({"type":"lake_polygon","polygon":[[0,0],[100,0]],"waterLevel":5})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+	}
+
+	/// river_manual : polyline → RiverInstance avec nodes width/depth par
+	/// défaut, Y = 0 (MVP).
+	void Test_Dispatcher_RiverManual_BuildsCommand()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+		ew::CommandStack stack;
+
+		zp::ZonePresetOperation op;
+		op.type    = "river_manual";
+		op.rawJson = R"({
+			"type":"river_manual",
+			"polyline":[[100,200],[500,250],[900,200]],
+			"widthMeters":6,
+			"depthMeters":2
+		})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Ok);
+
+		stack.Push(std::move(cmd));
+		REQUIRE(water.Get().rivers.size() == 1u);
+		const auto& river = water.Get().rivers[0];
+		REQUIRE(river.nodes.size() == 3u);
+		REQUIRE(NearEq(river.nodes[1].widthMeters, 6.0));
+		REQUIRE(NearEq(river.nodes[1].depthMeters, 2.0));
+		REQUIRE(NearEq(river.nodes[1].position.y, 0.0)); // Y = 0 en MVP
+	}
+
+	/// Type encore non câblé (coastline en 2d) → Unsupported, pas de crash.
 	void Test_Dispatcher_UnsupportedType_GracefulSkip()
 	{
 		vol::caves::CaveCatalog caveCat;
@@ -614,6 +814,7 @@ namespace
 		vol::arches::ArchCatalog arCat;
 		vol::dungeons::DungeonCatalog dgCat;
 		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
 		vol::MeshInsertDocument meshDoc;
 		vol::dungeons::DungeonPortalDocument portalDoc;
 
@@ -621,7 +822,7 @@ namespace
 		op.type    = "hydraulic_erosion";  // connu mais non câblé
 		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":1000})";
 
-		const auto ctx = MakeMinimalCtx(terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Unsupported);
@@ -679,10 +880,10 @@ namespace
 		preset.operations.push_back(op4);
 
 		zp::ZonePresetExecutor executor;
-		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
+		const zp::DispatchContext ctx{ terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
 		int callbackCount = 0;
 		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
-			stack, ctx, water,
+			stack, ctx,
 			[&](const zp::ExecutionProgress&) { ++callbackCount; return true; });
 
 		REQUIRE(summary.totalSteps == 4u);
@@ -726,9 +927,9 @@ namespace
 		}
 
 		zp::ZonePresetExecutor executor;
-		const zp::DispatchContext ctx{ terrain, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
+		const zp::DispatchContext ctx{ terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat };
 		const auto summary = executor.Execute(preset, zp::CustomizationParams{},
-			stack, ctx, water,
+			stack, ctx,
 			[](const zp::ExecutionProgress& p) {
 				// Stoppe après l'étape 1.
 				return p.currentStep < 2u;
@@ -768,6 +969,12 @@ int main()
 	Test_Dispatcher_PlaceCave_UnknownCatalog();
 	Test_Dispatcher_PlaceDungeon_BuildsCommand();
 	Test_Dispatcher_PlaceArch_DerivesGeometry();
+	Test_Dispatcher_MountainMacro_RasterizesAndBuildsCommand();
+	Test_Dispatcher_MountainMacro_RejectsBadPolyline();
+	Test_Dispatcher_ValleyMacro_BuildsValleyCommand();
+	Test_Dispatcher_LakePolygon_BuildsCommand();
+	Test_Dispatcher_LakePolygon_RejectsDegenerate();
+	Test_Dispatcher_RiverManual_BuildsCommand();
 	Test_Dispatcher_UnsupportedType_GracefulSkip();
 	Test_Executor_RunsAndSummarizes();
 	Test_Executor_CancelViaCallback();

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -806,7 +806,8 @@ namespace
 		REQUIRE(NearEq(river.nodes[1].position.y, 0.0)); // Y = 0 en MVP
 	}
 
-	/// Type encore non câblé (coastline en 2d) → Unsupported, pas de crash.
+	/// `splat_paint` reste Unsupported après l'incrément 2e (action ponctuelle,
+	/// pas une op batch déterministe). Ne crash pas, ne lève rien.
 	void Test_Dispatcher_UnsupportedType_GracefulSkip()
 	{
 		vol::caves::CaveCatalog caveCat;
@@ -819,14 +820,111 @@ namespace
 		vol::dungeons::DungeonPortalDocument portalDoc;
 
 		zp::ZonePresetOperation op;
-		op.type    = "hydraulic_erosion";  // connu mais non câblé
-		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":1000})";
+		op.type    = "splat_paint";
+		op.rawJson = R"({"type":"splat_paint","layerIndex":2,"strength":0.5})";
 
 		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
 		std::unique_ptr<ew::ICommand> cmd;
 		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
 		REQUIRE(rc == zp::DispatchResult::Unsupported);
 		REQUIRE(cmd == nullptr);
+	}
+
+	// --- Incrément 2e : hydraulic_erosion / thermal_wind_erosion /
+	//                    river_network / coastline (config-required)
+
+	/// Les 4 ops simulation refusent gracieusement quand `Config` est absent
+	/// du DispatchContext (impossible de charger les chunks). Pas de crash,
+	/// renvoie Failed + log warning.
+	void Test_Dispatcher_HydraulicErosion_RequiresConfig()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "hydraulic_erosion";
+		op.rawJson = R"({"type":"hydraulic_erosion","numDroplets":5000,"rngSeed":"global"})";
+
+		// MakeMinimalCtx ne renseigne pas Config (defaults nullptr).
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+		REQUIRE(cmd == nullptr);
+	}
+
+	/// `thermal_wind_erosion` avec aucune passe activée → Failed (avant même
+	/// le check Config — gating au plus tôt).
+	void Test_Dispatcher_ThermalWindErosion_RejectsAllDisabled()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "thermal_wind_erosion";
+		op.rawJson = R"({"type":"thermal_wind_erosion","thermalEnabled":false,"windEnabled":false})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+	}
+
+	/// `river_network` sans sources → Failed (validation paramètres avant
+	/// même de toucher Config).
+	void Test_Dispatcher_RiverNetwork_RejectsEmptySources()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "river_network";
+		op.rawJson = R"({"type":"river_network","sources":[],"carvingEnabled":true})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
+	}
+
+	/// `coastline` sans Config → Failed.
+	void Test_Dispatcher_Coastline_RequiresConfig()
+	{
+		vol::caves::CaveCatalog caveCat;
+		vol::overhangs::OverhangCatalog ohCat;
+		vol::arches::ArchCatalog arCat;
+		vol::dungeons::DungeonCatalog dgCat;
+		ew::TerrainDocument terrain;
+		ew::WaterDocument water;
+		vol::MeshInsertDocument meshDoc;
+		vol::dungeons::DungeonPortalDocument portalDoc;
+
+		zp::ZonePresetOperation op;
+		op.type    = "coastline";
+		op.rawJson = R"({"type":"coastline","seaLevelMeters":30,"beachEnabled":true,"cliffsEnabled":true})";
+
+		const auto ctx = MakeMinimalCtx(terrain, water, meshDoc, portalDoc, caveCat, ohCat, arCat, dgCat);
+		std::unique_ptr<ew::ICommand> cmd;
+		const auto rc = zp::DispatchOperation(op, zp::CustomizationParams{}, ctx, cmd);
+		REQUIRE(rc == zp::DispatchResult::Failed);
 	}
 
 	// --- ZonePresetExecutor (incrément 2b) ---------------------------------
@@ -858,10 +956,12 @@ namespace
 
 		zp::ZonePreset preset;
 		preset.id = "mixed";
-		// 1) hydraulic = non supporté → skipped
+		// 1) splat_paint = connu mais pas câblé → skipped (incrément 2e
+		//    a câblé hydraulic_erosion ; il ne reste que sculpt_brush /
+		//    splat_paint comme types non câblés).
 		zp::ZonePresetOperation op1;
-		op1.type    = "hydraulic_erosion";
-		op1.rawJson = R"({"type":"hydraulic_erosion"})";
+		op1.type    = "splat_paint";
+		op1.rawJson = R"({"type":"splat_paint","layerIndex":2})";
 		preset.operations.push_back(op1);
 		// 2) place_cave OK
 		zp::ZonePresetOperation op2;
@@ -888,7 +988,7 @@ namespace
 
 		REQUIRE(summary.totalSteps == 4u);
 		REQUIRE(summary.commandsPushed == 2u);     // cave + dungeon
-		REQUIRE(summary.unsupportedSkipped == 1u);  // hydraulic
+		REQUIRE(summary.unsupportedSkipped == 1u);  // splat_paint
 		REQUIRE(summary.failed == 1u);              // cave ghost
 		REQUIRE(!summary.wasCancelled);
 		REQUIRE(callbackCount == 4);
@@ -976,6 +1076,10 @@ int main()
 	Test_Dispatcher_LakePolygon_RejectsDegenerate();
 	Test_Dispatcher_RiverManual_BuildsCommand();
 	Test_Dispatcher_UnsupportedType_GracefulSkip();
+	Test_Dispatcher_HydraulicErosion_RequiresConfig();
+	Test_Dispatcher_ThermalWindErosion_RejectsAllDisabled();
+	Test_Dispatcher_RiverNetwork_RejectsEmptySources();
+	Test_Dispatcher_Coastline_RequiresConfig();
 	Test_Executor_RunsAndSummarizes();
 	Test_Executor_CancelViaCallback();
 

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -7,6 +7,7 @@
 #include "src/world_editor/ui/TreeSpeciesCatalog.h"
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/modes/EditorModeRegistry.h"
+#include "src/world_editor/zone_presets/ZonePresetDialog.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -50,6 +51,15 @@ namespace engine::editor
 	{
 		m_session = session;
 		m_cfg = cfg;
+		// Instancie le dialog Zone Presets (M100.46 incrément 3) à la
+		// première mise en place du contexte éditeur. Toujours créé pour
+		// que l'entrée menu Fichier soit cliquable dès que le Shell est
+		// branché en plus.
+		if (!m_zonePresetDialog)
+		{
+			m_zonePresetDialog =
+				std::make_unique<engine::editor::world::zone_presets::ZonePresetDialog>();
+		}
 	}
 
 #if defined(_WIN32)
@@ -740,6 +750,16 @@ namespace engine::editor
 					(void)m_session->ActionExportRuntime(*m_cfg);
 				}
 				ImGui::Separator();
+				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
+				// Preset. Désactivée si le Shell n'est pas branché (le
+				// dialog a besoin des 4 documents + catalogs).
+				if (ImGui::MenuItem("Appliquer un preset de zone...", nullptr, false,
+					m_shell != nullptr && m_zonePresetDialog != nullptr)
+					&& m_shell && m_zonePresetDialog)
+				{
+					m_zonePresetDialog->Open();
+				}
+				ImGui::Separator();
 				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
 					&& m_session && m_cfg)
 				{
@@ -875,6 +895,13 @@ namespace engine::editor
 				}
 			}
 			ImGui::EndMainMenuBar();
+		}
+
+		// M100.46 incrément 3 — dessine la popup modale Zone Presets
+		// (no-op si non ouverte ou Shell non branché).
+		if (m_zonePresetDialog && m_shell)
+		{
+			m_zonePresetDialog->Draw(*m_shell);
 		}
 
 		ImGuiViewport* vp = ImGui::GetMainViewport();

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -376,6 +376,12 @@ namespace engine::editor
 	} // namespace
 #endif
 
+	// Ctor + dtor out-of-line : la définition de `ZonePresetDialog` doit
+	// être visible ici pour que `std::unique_ptr<ZonePresetDialog>` puisse
+	// générer son cleanup d'exception. L'`#include` au top du fichier
+	// fournit le type complet.
+	WorldEditorImGui::WorldEditorImGui() = default;
+
 	WorldEditorImGui::~WorldEditorImGui()
 	{
 #if defined(_WIN32)

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -904,10 +904,12 @@ namespace engine::editor
 		}
 
 		// M100.46 incrément 3 — dessine la popup modale Zone Presets
-		// (no-op si non ouverte ou Shell non branché).
+		// (no-op si non ouverte ou Shell non branché). m_cfg passé pour
+		// les ops simulation (incrément 2e) : si null, les 4 ops sim
+		// renverront Failed.
 		if (m_zonePresetDialog && m_shell)
 		{
-			m_zonePresetDialog->Draw(*m_shell);
+			m_zonePresetDialog->Draw(*m_shell, m_cfg);
 		}
 
 		ImGuiViewport* vp = ImGui::GetMainViewport();

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -73,7 +73,11 @@ namespace engine::editor
 	class WorldEditorImGui final
 	{
 	public:
-		WorldEditorImGui() = default;
+		/// Constructeur out-of-line : la définition vit dans le `.cpp` où
+		/// `ZonePresetDialog.h` est inclus en entier. Sans cela, le
+		/// unique_ptr<ZonePresetDialog> ne peut pas instancier son cleanup
+		/// d'exception (type incomplet vu depuis Engine.cpp).
+		WorldEditorImGui();
 		WorldEditorImGui(const WorldEditorImGui&) = delete;
 		WorldEditorImGui& operator=(const WorldEditorImGui&) = delete;
 		WorldEditorImGui(WorldEditorImGui&&) = delete;

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
 #include <vector>
 
@@ -24,6 +25,14 @@ namespace engine::render
 namespace engine::render::terrain
 {
 	struct HeightmapData;
+}
+namespace engine::editor::world
+{
+	class WorldEditorShell;
+}
+namespace engine::editor::world::zone_presets
+{
+	class ZonePresetDialog;
 }
 
 namespace engine::editor
@@ -70,6 +79,17 @@ namespace engine::editor
 		WorldEditorImGui(WorldEditorImGui&&) = delete;
 		WorldEditorImGui& operator=(WorldEditorImGui&&) = delete;
 		~WorldEditorImGui();
+
+		/// Branche le `WorldEditorShell` propriétaire des 4 documents
+		/// (terrain / water / mesh inserts / dungeon portals), du
+		/// `CommandStack` et des 4 catalogs (caves, overhangs, arches,
+		/// dungeons) — requis pour l'entrée menu Fichier > « Appliquer un
+		/// preset de zone » (M100.46 incrément 3). Pointeur non possédé.
+		/// Si nul, l'entrée menu est désactivée.
+		void SetWorldEditorShell(engine::editor::world::WorldEditorShell* shell)
+		{
+			m_shell = shell;
+		}
 
 		/// \param hwndNative \c HWND sous Windows, sinon ignoré.
 		/// \param cfg utilisé pour charger les polices TTF de l'UI auth (Windlass / Morpheus) dans
@@ -130,6 +150,11 @@ namespace engine::editor
 		engine::core::Config* m_cfg = nullptr;
 		engine::render::DayNightCycle* m_dayNight = nullptr;
 		engine::editor::TexturePreviewCache* m_texturePreviewCache = nullptr;
+		engine::editor::world::WorldEditorShell* m_shell = nullptr;
+		/// Dialog modal Zone Presets (M100.46 incrément 3). PIMPL via
+		/// unique_ptr pour éviter d'exposer le header dans l'API publique
+		/// du WorldEditorImGui (cycle Shell ↔ dialog).
+		std::unique_ptr<engine::editor::world::zone_presets::ZonePresetDialog> m_zonePresetDialog;
 		bool m_showTextureLibrary = false;  // pilote par le menu Affichage (Task 14)
 		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,

--- a/src/world_editor/volumes/MeshInsertDocument.h
+++ b/src/world_editor/volumes/MeshInsertDocument.h
@@ -51,6 +51,16 @@ namespace engine::editor::world::volumes
 		void MarkDirty() noexcept     { m_dirty = true; }
 		void ClearDirty() noexcept    { m_dirty = false; }
 
+		/// M100.46 — Vide intégralement le document (instances + compteur
+		/// de guid). Marque `m_dirty`. Utilisé par `WorldMapEditDocumentReset`
+		/// avant l'exécution d'un zone preset sur une zone non vide.
+		void Reset() noexcept
+		{
+			m_instances.clear();
+			m_nextGuid = 0u;
+			m_dirty    = true;
+		}
+
 		/// Sauvegarde dans `<paths.content>/instances/mesh_inserts.bin`. Reset
 		/// `m_dirty`.
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);

--- a/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
+++ b/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
@@ -34,6 +34,15 @@ namespace engine::editor::world::volumes::dungeons
 		bool IsDirty() const noexcept { return m_dirty; }
 		void ClearDirty() noexcept    { m_dirty = false; }
 
+		/// M100.46 — Vide intégralement le document. Marque `m_dirty`.
+		/// Utilisé par `WorldMapEditDocumentReset` avant un zone preset.
+		void Reset() noexcept
+		{
+			m_instances.clear();
+			m_nextGuid = 0u;
+			m_dirty    = true;
+		}
+
 		/// Sauve dans `<paths.content>/instances/dungeon_portals.bin`.
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);
 		/// Charge depuis `<paths.content>/instances/dungeon_portals.bin`.

--- a/src/world_editor/water/CoastlineEditorTool.cpp
+++ b/src/world_editor/water/CoastlineEditorTool.cpp
@@ -5,6 +5,7 @@
 #include "src/world_editor/water/CoastlineCliffs.h"
 #include "src/world_editor/water/CoastlineCommand.h"
 #include "src/world_editor/water/CoastlineSmoothing.h"
+#include "src/world_editor/water/HeightGridAssembly.h"
 #include "src/world_editor/water/WaterDocument.h"
 
 #include <algorithm>
@@ -16,58 +17,14 @@ namespace engine::editor::world
 {
 	namespace
 	{
-		constexpr int kRes =
-			static_cast<int>(engine::world::terrain::kTerrainResolution);
-
 		/// Marge externe du polygone océan en mètres (cf. spec §"Génération
 		/// du polygone océan").
 		constexpr float kOceanMarginMeters = 1000.0f;
 
-		/// Construit un `ConsolidatedHeightGrid` à partir des chunks
-		/// actuellement chargés dans `terrain`, sur une plage donnée
-		/// (déterminée par les coords des chunks chargés). Pour M100.37
-		/// MVP : on construit autour du chunk (0, 0) si chargé ; sinon
-		/// retourne un grid vide. Le ticket d'optimisation pourra étendre
-		/// pour zone-complète.
-		ConsolidatedHeightGrid BuildGridFromLoadedChunks(
-			TerrainDocument& terrain, const engine::core::Config& cfg)
-		{
-			ConsolidatedHeightGrid grid;
-			grid.cellSizeMeters = engine::world::terrain::kTerrainCellSizeMeters;
-			// MVP : on assemble juste 2×2 chunks autour de l'origine.
-			constexpr int kChunksDim = 2;
-			constexpr int kBaseX = 0;
-			constexpr int kBaseZ = 0;
-			grid.originCellX = kBaseX * (kRes - 1);
-			grid.originCellZ = kBaseZ * (kRes - 1);
-			const int W = kChunksDim * (kRes - 1) + 1;
-			const int H = kChunksDim * (kRes - 1) + 1;
-			grid.width = W;
-			grid.height = H;
-			grid.heights.assign(static_cast<size_t>(W) * H, 0.0f);
-			for (int cz = 0; cz < kChunksDim; ++cz)
-			{
-				for (int cx = 0; cx < kChunksDim; ++cx)
-				{
-					auto chunk = terrain.EnsureLoaded(cfg, kBaseX + cx, kBaseZ + cz);
-					if (!chunk) continue;
-					const int baseX = cx * (kRes - 1);
-					const int baseZ = cz * (kRes - 1);
-					for (int iz = 0; iz < kRes; ++iz)
-					{
-						for (int ix = 0; ix < kRes; ++ix)
-						{
-							const int gx = baseX + ix;
-							const int gz = baseZ + iz;
-							if (gx >= W || gz >= H) continue;
-							grid.heights[static_cast<size_t>(gz) * W + gx] =
-								chunk->heights[static_cast<size_t>(iz) * kRes + ix];
-						}
-					}
-				}
-			}
-			return grid;
-		}
+		// `BuildGridFromLoadedChunks` vit maintenant dans
+		// `water/HeightGridAssembly.{h,cpp}` (partagé avec
+		// ThermalWindErosionTool et OperationDispatcher). Voir l'include
+		// ci-dessus.
 	}
 
 	bool CoastlineEditorTool::Init(CommandStack& stack, TerrainDocument& terrain,

--- a/src/world_editor/water/HeightGridAssembly.cpp
+++ b/src/world_editor/water/HeightGridAssembly.cpp
@@ -1,0 +1,48 @@
+#include "src/world_editor/water/HeightGridAssembly.h"
+
+#include "src/client/world/terrain/TerrainChunk.h"
+#include "src/world_editor/terrain/TerrainDocument.h"
+
+namespace engine::editor::world
+{
+	ConsolidatedHeightGrid BuildGridFromLoadedChunks(TerrainDocument& terrain,
+		const engine::core::Config& cfg)
+	{
+		constexpr int kRes =
+			static_cast<int>(engine::world::terrain::kTerrainResolution);
+		constexpr int kChunksDim = 2;
+
+		ConsolidatedHeightGrid grid;
+		grid.cellSizeMeters = engine::world::terrain::kTerrainCellSizeMeters;
+		grid.originCellX    = 0;
+		grid.originCellZ    = 0;
+		const int W = kChunksDim * (kRes - 1) + 1;
+		const int H = kChunksDim * (kRes - 1) + 1;
+		grid.width  = W;
+		grid.height = H;
+		grid.heights.assign(static_cast<size_t>(W) * H, 0.0f);
+
+		for (int cz = 0; cz < kChunksDim; ++cz)
+		{
+			for (int cx = 0; cx < kChunksDim; ++cx)
+			{
+				auto chunk = terrain.EnsureLoaded(cfg, cx, cz);
+				if (!chunk) continue;
+				const int baseX = cx * (kRes - 1);
+				const int baseZ = cz * (kRes - 1);
+				for (int iz = 0; iz < kRes; ++iz)
+				{
+					for (int ix = 0; ix < kRes; ++ix)
+					{
+						const int gx = baseX + ix;
+						const int gz = baseZ + iz;
+						if (gx >= W || gz >= H) continue;
+						grid.heights[static_cast<size_t>(gz) * W + gx] =
+							chunk->heights[static_cast<size_t>(iz) * kRes + ix];
+					}
+				}
+			}
+		}
+		return grid;
+	}
+}

--- a/src/world_editor/water/HeightGridAssembly.h
+++ b/src/world_editor/water/HeightGridAssembly.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "src/world_editor/water/ConsolidatedHeightGrid.h"
+
+namespace engine::core { class Config; }
+
+namespace engine::editor::world
+{
+	class TerrainDocument;
+
+	/// Assemble un `ConsolidatedHeightGrid` à partir des chunks chargés du
+	/// `TerrainDocument`. MVP M100.36/.37/.38/.39/.46 : 2×2 chunks autour de
+	/// l'origine (`chunk_(0,0)`..`chunk_(1,1)`), via `EnsureLoaded` qui charge
+	/// depuis disque ou crée un chunk plat 0 m si absent.
+	///
+	/// Résolution résultante : `2 × (kTerrainResolution - 1) + 1` cellules
+	/// par axe (typiquement 1025×1025 pour kTerrainResolution=513), pas
+	/// `kTerrainCellSizeMeters`.
+	///
+	/// Cette fonction remplace 3 copies historiques identiques (M100.37
+	/// `CoastlineEditorTool`, M100.39 `ThermalWindErosionTool`, M100.46
+	/// `OperationDispatcher`) — toute évolution vers une zone-complète ou un
+	/// streaming différent ne touche désormais qu'un seul endroit.
+	///
+	/// \param terrain  Document terrain. Mute via `EnsureLoaded` (caches).
+	/// \param cfg      Source de `paths.content` pour la lecture disque.
+	/// \return         Grid prêt pour `RunHydraulicOnGrid`, `RunWatershedOnGrid`,
+	///                 `ExtractCoastlineSegments`, etc.
+	///
+	/// Effet de bord : bloque le main thread le temps du chargement
+	/// disque/CPU des 4 chunks. Pas thread-safe (le document non plus).
+	ConsolidatedHeightGrid BuildGridFromLoadedChunks(TerrainDocument& terrain,
+		const engine::core::Config& cfg);
+}

--- a/src/world_editor/water/WaterDocument.h
+++ b/src/world_editor/water/WaterDocument.h
@@ -50,6 +50,16 @@ namespace engine::editor::world
 		/// Engine::Render apres avoir reconstruit les buffers GPU water depuis la scene).
 		void ClearDirty() noexcept    { m_dirty = false; }
 
+		/// M100.46 — Vide intégralement la scène (lakes, rivers, océan
+		/// par défaut). Marque `m_dirty`. Utilisé par `WorldMapEditDocumentReset`
+		/// avant l'exécution d'un zone preset sur une zone non vide.
+		void Reset() noexcept
+		{
+			m_scene = engine::world::water::WaterScene{};
+			m_ocean = OceanSettings{};
+			m_dirty = true;
+		}
+
 		/// Sauvegarde dans `<paths.content>/instances/water.bin`. Reset m_dirty.
 		/// Écrit toujours en format v2 (avec `m_ocean.seaLevelMeters`).
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -4,6 +4,8 @@
 #include "src/client/world/terrain/TerrainChunk.h"
 #include "src/client/world/water/WaterSurfaces.h"
 #include "src/shared/core/Log.h"
+#include "src/world_editor/presets/ToolPresetApply.h"
+#include "src/world_editor/presets/ToolPresetRegistry.h"
 #include "src/world_editor/terrain/MountainRangeCommand.h"
 #include "src/world_editor/terrain/PolylineMacroCore.h"
 #include "src/world_editor/terrain/TerrainDocument.h"
@@ -14,6 +16,7 @@
 #include "src/world_editor/terrain/erosion/ThermalSimulation.h"
 #include "src/world_editor/terrain/erosion/ThermalSimulationParams.h"
 #include "src/world_editor/terrain/erosion/ThermalWindErosionCommand.h"
+#include "src/world_editor/terrain/erosion/ThermalWindErosionParams.h"
 #include "src/world_editor/terrain/erosion/WindSimulation.h"
 #include "src/world_editor/terrain/erosion/WindSimulationParams.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
@@ -477,6 +480,41 @@ namespace engine::editor::world::zone_presets
 			return fallback;
 		}
 
+		/// Lit la clé `"preset"` du JSON op et applique l'overlay de preset
+		/// si trouvée dans le `ToolPresetRegistry`. M100.46 incrément 2e+ :
+		/// connecte les `tool_presets/<toolId>.json` (chargés au boot) aux
+		/// dispatchers, pour que `"preset":"subtle"` (hydraulic) ou
+		/// `"preset":"sand_and_talus"` (thermal_wind) charge réellement les
+		/// physics params, pas seulement les scalaires explicites du JSON.
+		///
+		/// Ordre du remplissage des params : defaults struct → preset
+		/// overlay (ici) → JSON scalar overrides (après l'appel).
+		/// JSON gagne toujours sur preset.
+		///
+		/// \param toolId       id du tool dans le registry (ex. "hydraulic_erosion")
+		/// \param jsonParams   params de l'op (lit la clé "preset")
+		/// \param applyFn      fonctor `void(const ToolPreset&)` qui appelle
+		///                     l'ApplyXxxPreset typé sur le struct cible.
+		/// Effet de bord : log warn si `presetId` non vide mais introuvable.
+		template <typename ApplyFn>
+		void MaybeApplyToolPreset(const std::string& toolId,
+			const OperationParams& jsonParams, ApplyFn&& applyFn)
+		{
+			std::string presetId;
+			if (!jsonParams.GetString("preset", presetId) || presetId.empty())
+				return;
+			const auto* tp = engine::editor::world::presets::ToolPresetRegistry::Instance()
+				.FindPreset(toolId, presetId);
+			if (tp == nullptr)
+			{
+				LOG_WARN(EditorWorld,
+					"[OperationDispatcher] preset '{}' introuvable pour tool '{}'",
+					presetId, toolId);
+				return;
+			}
+			applyFn(*tp);
+		}
+
 		// --- hydraulic_erosion --------------------------------------------
 
 		DispatchResult DispatchHydraulicErosion(const OperationParams& params,
@@ -492,6 +530,13 @@ namespace engine::editor::world::zone_presets
 
 			using namespace engine::editor::world::erosion;
 			HydraulicSimulationParams sim;
+
+			// Preset overlay (defaults → preset → JSON scalars).
+			MaybeApplyToolPreset("hydraulic_erosion", params,
+				[&](const engine::editor::world::presets::ToolPreset& tp) {
+					engine::editor::world::presets::ApplyHydraulicErosionPreset(sim, tp);
+				});
+
 			sim.numDroplets = static_cast<uint32_t>(
 				ReadFloat(params, "numDroplets", static_cast<float>(sim.numDroplets)));
 			sim.maxLifetimeSteps = static_cast<uint32_t>(
@@ -535,13 +580,21 @@ namespace engine::editor::world::zone_presets
 				return DispatchResult::Failed;
 			}
 
-			ThermalSimulationParams thermalP;
+			// Wrapper attendu par ApplyThermalWindErosionPreset. Les
+			// scalaires JSON viendront overrider après l'overlay preset.
+			ThermalWindErosionParams combined;
+			MaybeApplyToolPreset("thermal_wind_erosion", params,
+				[&](const engine::editor::world::presets::ToolPreset& tp) {
+					engine::editor::world::presets::ApplyThermalWindErosionPreset(combined, tp);
+				});
+			ThermalSimulationParams& thermalP = combined.thermal;
+			WindSimulationParams&    windP    = combined.wind;
+
 			thermalP.talusAngleDeg  = ReadFloat(params, "talusAngleDeg",  thermalP.talusAngleDeg);
 			thermalP.forcePerPass   = ReadFloat(params, "forcePerPass",   thermalP.forcePerPass);
 			thermalP.numPasses      = static_cast<uint32_t>(
 				ReadFloat(params, "numPasses", static_cast<float>(thermalP.numPasses)));
 
-			WindSimulationParams windP;
 			windP.windAngleDeg   = ReadFloat(params, "windAngleDeg",   windP.windAngleDeg);
 			windP.windStrength   = ReadFloat(params, "windStrength",   windP.windStrength);
 			windP.numParticles   = static_cast<uint32_t>(
@@ -593,6 +646,14 @@ namespace engine::editor::world::zone_presets
 			}
 
 			engine::editor::world::WatershedSimulationParams sim;
+
+			// Preset overlay (laisse `springs` intacts, conforme au
+			// docstring d'ApplyRiverNetworkPreset).
+			MaybeApplyToolPreset("river_network", params,
+				[&](const engine::editor::world::presets::ToolPreset& tp) {
+					engine::editor::world::presets::ApplyRiverNetworkPreset(sim, tp);
+				});
+
 			sim.springs.reserve(sources.size() / 2);
 			for (size_t i = 0; i + 1 < sources.size(); i += 2)
 			{

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -1,6 +1,10 @@
 #include "src/world_editor/zone_presets/OperationDispatcher.h"
 
+#include "src/client/world/water/WaterSurfaces.h"
 #include "src/shared/core/Log.h"
+#include "src/world_editor/terrain/MountainRangeCommand.h"
+#include "src/world_editor/terrain/PolylineMacroCore.h"
+#include "src/world_editor/terrain/ValleyChainCommand.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
 #include "src/world_editor/volumes/MeshInsertInstance.h"
 #include "src/world_editor/volumes/arches/ArchCatalog.h"
@@ -13,6 +17,8 @@
 #include "src/world_editor/volumes/dungeons/PlaceDungeonPortalCommand.h"
 #include "src/world_editor/volumes/overhangs/OverhangCatalog.h"
 #include "src/world_editor/volumes/overhangs/PlaceOverhangCommand.h"
+#include "src/world_editor/water/AddLakeCommand.h"
+#include "src/world_editor/water/AddRiverCommand.h"
 #include "src/world_editor/zone_presets/OperationParams.h"
 
 #include <cmath>
@@ -221,6 +227,161 @@ namespace engine::editor::world::zone_presets
 			return DispatchResult::Ok;
 		}
 
+		// --- macros polyline (mountain_macro / valley_macro) ---------------
+
+		/// Construit `MacroPolylineParams` à partir d'un polyline aplati
+		/// `[x0, z0, x1, z1, …]` et de scalaires globaux width/height/noise.
+		/// Les vertices héritent tous des mêmes valeurs (les presets n'ont
+		/// pas de granularité per-vertex dans le format JSON M100.46 §A.2).
+		/// Renvoie false si le polyline est invalide (< 2 vertices).
+		bool BuildMacroParamsFromJson(const OperationParams& params,
+			MacroPolylineParams& outParams)
+		{
+			std::vector<double> flat;
+			if (!params.GetNumberList("polyline", flat) || flat.size() < 4
+				|| (flat.size() % 2) != 0)
+				return false;
+
+			const float widthMeters    = ReadFloat(params, "widthMeters",    250.0f);
+			const float heightMeters   = ReadFloat(params, "heightMeters",   400.0f);
+			const float noiseAmplitude = ReadFloat(params, "noiseAmplitude",  30.0f);
+			const float asymmetry      = ReadFloat(params, "asymmetry",        0.0f);
+
+			outParams.vertices.clear();
+			outParams.vertices.reserve(flat.size() / 2);
+			for (size_t i = 0; i + 1 < flat.size(); i += 2)
+			{
+				PolylineVertex v;
+				v.worldX         = static_cast<float>(flat[i]);
+				v.worldZ         = static_cast<float>(flat[i + 1]);
+				v.widthMeters    = widthMeters;
+				v.heightMeters   = heightMeters;
+				v.noiseAmplitude = noiseAmplitude;
+				v.asymmetry      = asymmetry;
+				outParams.vertices.push_back(v);
+			}
+			outParams.mode           = PolylineMode::Open;
+			outParams.profile        = FlankProfile::Smoothstep;
+			outParams.noiseSeed      = static_cast<uint32_t>(
+				ReadFloat(params, "noiseSeed", 0.0f));
+			outParams.noiseFrequency = ReadFloat(params, "noiseFrequency", 0.005f);
+			return true;
+		}
+
+		DispatchResult DispatchMountainMacro(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			MacroPolylineParams macroParams;
+			if (!BuildMacroParamsFromJson(params, macroParams))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] mountain_macro : polyline invalide");
+				return DispatchResult::Failed;
+			}
+			auto deltas = RasterizeMacroPolyline(macroParams, /*invert*/ false);
+			if (deltas.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] mountain_macro : rasterisation vide");
+				return DispatchResult::Failed;
+			}
+			outCmd = std::make_unique<MountainRangeCommand>(ctx.terrain, std::move(deltas));
+			return DispatchResult::Ok;
+		}
+
+		DispatchResult DispatchValleyMacro(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			MacroPolylineParams macroParams;
+			if (!BuildMacroParamsFromJson(params, macroParams))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] valley_macro : polyline invalide");
+				return DispatchResult::Failed;
+			}
+			auto deltas = RasterizeMacroPolyline(macroParams, /*invert*/ true);
+			if (deltas.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] valley_macro : rasterisation vide");
+				return DispatchResult::Failed;
+			}
+			outCmd = std::make_unique<ValleyChainCommand>(ctx.terrain, std::move(deltas));
+			return DispatchResult::Ok;
+		}
+
+		// --- lake_polygon --------------------------------------------------
+
+		DispatchResult DispatchLakePolygon(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::vector<double> flat;
+			if (!params.GetNumberList("polygon", flat) || flat.size() < 6
+				|| (flat.size() % 2) != 0)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] lake_polygon : polygon invalide (besoin ≥ 3 points)");
+				return DispatchResult::Failed;
+			}
+			const float waterLevel = ReadFloat(params, "waterLevel", 0.0f);
+
+			engine::world::water::LakeInstance lake;
+			std::string name;
+			if (params.GetString("name", name)) lake.name = std::move(name);
+			lake.waterLevelY = waterLevel;
+			lake.polygon.reserve(flat.size() / 2);
+			for (size_t i = 0; i + 1 < flat.size(); i += 2)
+			{
+				lake.polygon.push_back(engine::math::Vec3{
+					static_cast<float>(flat[i]),
+					waterLevel,
+					static_cast<float>(flat[i + 1])
+				});
+			}
+			// turbidity / bottomColor / isOcean → défauts struct.
+
+			outCmd = std::make_unique<AddLakeCommand>(ctx.water, std::move(lake));
+			return DispatchResult::Ok;
+		}
+
+		// --- river_manual --------------------------------------------------
+
+		DispatchResult DispatchRiverManual(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::vector<double> flat;
+			if (!params.GetNumberList("polyline", flat) || flat.size() < 4
+				|| (flat.size() % 2) != 0)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] river_manual : polyline invalide (besoin ≥ 2 points)");
+				return DispatchResult::Failed;
+			}
+			const float widthMeters = ReadFloat(params, "widthMeters", 4.0f);
+			const float depthMeters = ReadFloat(params, "depthMeters", 1.0f);
+			// Y = 0 par convention MVP : le runtime client recalcule l'élévation
+			// depuis la heightmap au load (TODO : lookup TerrainDocument quand
+			// l'éditeur expose une API headless TerrainDocument::SampleHeight).
+
+			engine::world::water::RiverInstance river;
+			std::string name;
+			if (params.GetString("name", name)) river.name = std::move(name);
+			river.nodes.reserve(flat.size() / 2);
+			for (size_t i = 0; i + 1 < flat.size(); i += 2)
+			{
+				engine::world::water::RiverNode node;
+				node.position = engine::math::Vec3{
+					static_cast<float>(flat[i]),
+					0.0f,
+					static_cast<float>(flat[i + 1])
+				};
+				node.widthMeters = widthMeters;
+				node.depthMeters = depthMeters;
+				river.nodes.push_back(node);
+			}
+
+			outCmd = std::make_unique<AddRiverCommand>(ctx.water, std::move(river));
+			return DispatchResult::Ok;
+		}
+
 		// --- place_dungeon --------------------------------------------------
 
 		DispatchResult DispatchPlaceDungeon(const OperationParams& params,
@@ -290,11 +451,19 @@ namespace engine::editor::world::zone_presets
 		if (op.type == "place_arch")     return DispatchPlaceArch(params, ctx, outCmd);
 		if (op.type == "place_dungeon")  return DispatchPlaceDungeon(params, ctx, outCmd);
 
-		// Types connus mais non câblés en MVP incrément 2b — l'executor
-		// logge et continue (comportement aligné sur le skip silencieux
-		// de la section `decoration` §A.4).
+		// Incrément 2d — types câblés via wrappers ou commandes plain-data.
+		if (op.type == "mountain_macro") return DispatchMountainMacro(params, ctx, outCmd);
+		if (op.type == "valley_macro")   return DispatchValleyMacro(params, ctx, outCmd);
+		if (op.type == "lake_polygon")   return DispatchLakePolygon(params, ctx, outCmd);
+		if (op.type == "river_manual")   return DispatchRiverManual(params, ctx, outCmd);
+
+		// Types connus mais non câblés (besoin d'extraire la simulation des
+		// Tools UI ou de capturer un snapshot d'état pré-action) :
+		// `coastline`, `river_network`, `hydraulic_erosion`,
+		// `thermal_wind_erosion`. Comportement aligné sur le skip silencieux
+		// de la section `decoration` §A.4.
 		LOG_INFO(EditorWorld,
-			"[OperationDispatcher] type '{}' connu mais non câblé en M100.46 incrément 2b (op ignorée)",
+			"[OperationDispatcher] type '{}' connu mais non câblé en M100.46 incrément 2d (op ignorée)",
 			op.type);
 		return DispatchResult::Unsupported;
 	}

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -1,10 +1,21 @@
 #include "src/world_editor/zone_presets/OperationDispatcher.h"
 
+#include "src/client/world/WorldModel.h"
+#include "src/client/world/terrain/TerrainChunk.h"
 #include "src/client/world/water/WaterSurfaces.h"
 #include "src/shared/core/Log.h"
 #include "src/world_editor/terrain/MountainRangeCommand.h"
 #include "src/world_editor/terrain/PolylineMacroCore.h"
+#include "src/world_editor/terrain/TerrainDocument.h"
 #include "src/world_editor/terrain/ValleyChainCommand.h"
+#include "src/world_editor/terrain/erosion/HydraulicErosionCommand.h"
+#include "src/world_editor/terrain/erosion/HydraulicSimulation.h"
+#include "src/world_editor/terrain/erosion/HydraulicSimulationParams.h"
+#include "src/world_editor/terrain/erosion/ThermalSimulation.h"
+#include "src/world_editor/terrain/erosion/ThermalSimulationParams.h"
+#include "src/world_editor/terrain/erosion/ThermalWindErosionCommand.h"
+#include "src/world_editor/terrain/erosion/WindSimulation.h"
+#include "src/world_editor/terrain/erosion/WindSimulationParams.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
 #include "src/world_editor/volumes/MeshInsertInstance.h"
 #include "src/world_editor/volumes/arches/ArchCatalog.h"
@@ -19,9 +30,20 @@
 #include "src/world_editor/volumes/overhangs/PlaceOverhangCommand.h"
 #include "src/world_editor/water/AddLakeCommand.h"
 #include "src/world_editor/water/AddRiverCommand.h"
+#include "src/world_editor/water/CoastlineCliffs.h"
+#include "src/world_editor/water/CoastlineCommand.h"
+#include "src/world_editor/water/CoastlineSmoothing.h"
+#include "src/world_editor/water/ConsolidatedHeightGrid.h"
+#include "src/world_editor/water/OceanSettings.h"
+#include "src/world_editor/water/RiverNetworkCommand.h"
+#include "src/world_editor/water/SpringSource.h"
+#include "src/world_editor/water/WaterDocument.h"
+#include "src/world_editor/water/WatershedSimulation.h"
+#include "src/world_editor/water/WatershedSimulationParams.h"
 #include "src/world_editor/zone_presets/OperationParams.h"
 
 #include <cmath>
+#include <optional>
 #include <utility>
 
 namespace engine::editor::world::zone_presets
@@ -382,6 +404,323 @@ namespace engine::editor::world::zone_presets
 			return DispatchResult::Ok;
 		}
 
+		// --- Sim helpers ---------------------------------------------------
+
+		/// Assemble un `ConsolidatedHeightGrid` 2×2 chunks (~1025×1025 cellules)
+		/// à partir des chunks chargés du `TerrainDocument`. Réplique le pattern
+		/// `BuildGrid` dupliqué dans `ThermalWindErosionTool` / `CoastlineEditorTool`.
+		///
+		/// Effet de bord : appelle `TerrainDocument::EnsureLoaded` (bloque le
+		/// main thread le temps du chargement disque/CPU).
+		engine::editor::world::ConsolidatedHeightGrid
+		BuildGridFromLoadedChunks(engine::editor::world::TerrainDocument& terrain,
+			const engine::core::Config& cfg)
+		{
+			constexpr int kRes      = static_cast<int>(engine::world::terrain::kTerrainResolution);
+			constexpr int kChunksDim = 2;
+			engine::editor::world::ConsolidatedHeightGrid grid;
+			grid.cellSizeMeters = engine::world::terrain::kTerrainCellSizeMeters;
+			grid.originCellX = 0;
+			grid.originCellZ = 0;
+			const int W = kChunksDim * (kRes - 1) + 1;
+			const int H = kChunksDim * (kRes - 1) + 1;
+			grid.width = W;
+			grid.height = H;
+			grid.heights.assign(static_cast<size_t>(W) * H, 0.0f);
+			for (int cz = 0; cz < kChunksDim; ++cz)
+			{
+				for (int cx = 0; cx < kChunksDim; ++cx)
+				{
+					auto chunk = terrain.EnsureLoaded(cfg, cx, cz);
+					if (!chunk) continue;
+					const int baseX = cx * (kRes - 1);
+					const int baseZ = cz * (kRes - 1);
+					for (int iz = 0; iz < kRes; ++iz)
+					{
+						for (int ix = 0; ix < kRes; ++ix)
+						{
+							const int gx = baseX + ix;
+							const int gz = baseZ + iz;
+							if (gx >= W || gz >= H) continue;
+							grid.heights[static_cast<size_t>(gz) * W + gx] =
+								chunk->heights[static_cast<size_t>(iz) * kRes + ix];
+						}
+					}
+				}
+			}
+			return grid;
+		}
+
+		/// Fusionne `src` dans `dst` cellule par cellule (les valeurs s'additionnent).
+		void MergeDeltas(engine::editor::world::SparseChunkDeltas& dst,
+			const engine::editor::world::SparseChunkDeltas& src)
+		{
+			for (const auto& kv : src)
+			{
+				auto& chunkMap = dst[kv.first];
+				for (const auto& cell : kv.second)
+					chunkMap[cell.first] += cell.second;
+			}
+		}
+
+		/// Si la clé `rngSeed` est une chaîne "global", utilise `custom.seed`.
+		/// Sinon, lit la valeur numérique. Défaut : `fallback`.
+		uint32_t ReadRngSeed(const OperationParams& params,
+			const CustomizationParams& custom, uint32_t fallback)
+		{
+			std::string s;
+			if (params.GetString("rngSeed", s) && s == "global")
+				return custom.seed;
+			double v = 0.0;
+			if (params.GetNumber("rngSeed", v))
+				return static_cast<uint32_t>(v < 0.0 ? 0.0 : v);
+			return fallback;
+		}
+
+		// --- hydraulic_erosion --------------------------------------------
+
+		DispatchResult DispatchHydraulicErosion(const OperationParams& params,
+			const CustomizationParams& custom,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			if (ctx.config == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] hydraulic_erosion : Config absent du DispatchContext");
+				return DispatchResult::Failed;
+			}
+
+			using namespace engine::editor::world::erosion;
+			HydraulicSimulationParams sim;
+			sim.numDroplets = static_cast<uint32_t>(
+				ReadFloat(params, "numDroplets", static_cast<float>(sim.numDroplets)));
+			sim.maxLifetimeSteps = static_cast<uint32_t>(
+				ReadFloat(params, "maxLifetimeSteps", static_cast<float>(sim.maxLifetimeSteps)));
+			sim.sedimentCapacity = ReadFloat(params, "sedimentCapacity", sim.sedimentCapacity);
+			sim.erosionRate      = ReadFloat(params, "erosionRate",      sim.erosionRate);
+			sim.depositionRate   = ReadFloat(params, "depositionRate",   sim.depositionRate);
+			sim.evaporationRate  = ReadFloat(params, "evaporationRate",  sim.evaporationRate);
+			sim.gravity          = ReadFloat(params, "gravity",          sim.gravity);
+			sim.inertia          = ReadFloat(params, "inertia",          sim.inertia);
+			sim.rngSeed          = ReadRngSeed(params, custom, sim.rngSeed);
+
+			auto grid = BuildGridFromLoadedChunks(ctx.terrain, *ctx.config);
+			const float seaLevel = ctx.water.GetOcean().seaLevelMeters;
+
+			auto result = RunHydraulicOnGrid(grid, seaLevel, sim);
+			outCmd = std::make_unique<HydraulicErosionCommand>(ctx.terrain,
+				std::move(result), sim);
+			return DispatchResult::Ok;
+		}
+
+		// --- thermal_wind_erosion ------------------------------------------
+
+		DispatchResult DispatchThermalWindErosion(const OperationParams& params,
+			const CustomizationParams& custom,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			if (ctx.config == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] thermal_wind_erosion : Config absent");
+				return DispatchResult::Failed;
+			}
+
+			using namespace engine::editor::world::erosion;
+			const bool thermalEnabled = ReadBool(params, "thermalEnabled", true);
+			const bool windEnabled    = ReadBool(params, "windEnabled",    true);
+			if (!thermalEnabled && !windEnabled)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] thermal_wind_erosion : aucune passe activée");
+				return DispatchResult::Failed;
+			}
+
+			ThermalSimulationParams thermalP;
+			thermalP.talusAngleDeg  = ReadFloat(params, "talusAngleDeg",  thermalP.talusAngleDeg);
+			thermalP.forcePerPass   = ReadFloat(params, "forcePerPass",   thermalP.forcePerPass);
+			thermalP.numPasses      = static_cast<uint32_t>(
+				ReadFloat(params, "numPasses", static_cast<float>(thermalP.numPasses)));
+
+			WindSimulationParams windP;
+			windP.windAngleDeg   = ReadFloat(params, "windAngleDeg",   windP.windAngleDeg);
+			windP.windStrength   = ReadFloat(params, "windStrength",   windP.windStrength);
+			windP.numParticles   = static_cast<uint32_t>(
+				ReadFloat(params, "numParticles", static_cast<float>(windP.numParticles)));
+			windP.rngSeed        = ReadRngSeed(params, custom, windP.rngSeed);
+
+			auto grid = BuildGridFromLoadedChunks(ctx.terrain, *ctx.config);
+			const float seaLevel = ctx.water.GetOcean().seaLevelMeters;
+
+			ThermalWindErosionCommand::Data data;
+			if (thermalEnabled)
+			{
+				auto r = RunThermalSimulation(grid, seaLevel, thermalP);
+				data.thermalDeltas = r.deltas;
+				data.thermalStats  = r;
+			}
+			if (windEnabled)
+			{
+				// `grid` muté par thermal sert d'input à wind (ordre respecté).
+				auto r = RunWindSimulation(grid, seaLevel, windP);
+				data.windDeltas = r.deltas;
+				data.windStats  = r;
+			}
+
+			outCmd = std::make_unique<ThermalWindErosionCommand>(ctx.terrain, std::move(data));
+			return DispatchResult::Ok;
+		}
+
+		// --- river_network -------------------------------------------------
+
+		DispatchResult DispatchRiverNetwork(const OperationParams& params,
+			const CustomizationParams& custom,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			(void)custom; // pas de customisation directe ici (water_density déjà appliqué upstream)
+			if (ctx.config == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] river_network : Config absent");
+				return DispatchResult::Failed;
+			}
+
+			std::vector<double> sources;
+			if (!params.GetNumberList("sources", sources) || sources.size() < 2
+				|| (sources.size() % 2) != 0)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] river_network : sources invalides (besoin ≥ 1 paire [x,z])");
+				return DispatchResult::Failed;
+			}
+
+			engine::editor::world::WatershedSimulationParams sim;
+			sim.springs.reserve(sources.size() / 2);
+			for (size_t i = 0; i + 1 < sources.size(); i += 2)
+			{
+				engine::editor::world::SpringSource s;
+				s.worldX = static_cast<float>(sources[i]);
+				s.worldZ = static_cast<float>(sources[i + 1]);
+				s.worldY = 0.0f; // résolu par re-sampling dans le simulateur
+				sim.springs.push_back(s);
+			}
+			sim.carveHeightmap = ReadBool(params, "carvingEnabled", sim.carveHeightmap);
+			sim.minFlowThresholdCells = static_cast<uint32_t>(
+				ReadFloat(params, "minFlowThresholdCells",
+					static_cast<float>(sim.minFlowThresholdCells)));
+
+			auto grid = BuildGridFromLoadedChunks(ctx.terrain, *ctx.config);
+			const float seaLevel = ctx.water.GetOcean().seaLevelMeters;
+
+			auto result = engine::editor::world::RunWatershedOnGrid(grid, seaLevel, sim);
+			const auto& currentOcean = ctx.water.GetOcean();
+			outCmd = std::make_unique<engine::editor::world::RiverNetworkCommand>(
+				ctx.terrain, ctx.water, std::move(result),
+				currentOcean, currentOcean);
+			return DispatchResult::Ok;
+		}
+
+		// --- coastline -----------------------------------------------------
+
+		DispatchResult DispatchCoastline(const OperationParams& params,
+			const CustomizationParams& custom,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			(void)custom;
+			if (ctx.config == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] coastline : Config absent");
+				return DispatchResult::Failed;
+			}
+
+			// Construit OceanSettings depuis le JSON, défauts depuis la valeur
+			// courante (cohérent avec l'usage du tool — l'utilisateur ne
+			// renseigne souvent que seaLevelMeters).
+			engine::editor::world::OceanSettings newOcean = ctx.water.GetOcean();
+			newOcean.seaLevelMeters = ReadFloat(params, "seaLevelMeters",
+				newOcean.seaLevelMeters);
+			newOcean.turbidity      = ReadFloat(params, "turbidity",      newOcean.turbidity);
+			newOcean.windInfluence  = ReadFloat(params, "windInfluence",  newOcean.windInfluence);
+			newOcean.enabled        = ReadBool(params, "oceanEnabled",    newOcean.enabled);
+
+			const bool smoothingEnabled = ReadBool(params, "beachEnabled", true);
+			const bool cliffsEnabled    = ReadBool(params, "cliffsEnabled", false);
+
+			engine::editor::world::CoastlineCommand::ApplyData data;
+			data.previousOcean = ctx.water.GetOcean();
+			data.newOcean      = newOcean;
+
+			// Recherche / insertion de la LakeInstance océan (mêmes
+			// défauts visuels que CoastlineEditorTool : marge 1000 m,
+			// rectangle englobant + 1 pt de fermeture).
+			const auto& scene = ctx.water.Get();
+			int existingIndex = -1;
+			for (size_t i = 0; i < scene.lakes.size(); ++i)
+			{
+				if (scene.lakes[i].isOcean)
+				{
+					existingIndex = static_cast<int>(i);
+					break;
+				}
+			}
+			data.existingOceanIndex = existingIndex;
+			if (existingIndex >= 0)
+			{
+				data.previousOceanLake = scene.lakes[static_cast<size_t>(existingIndex)];
+			}
+			else
+			{
+				constexpr float kOceanMarginMeters = 1000.0f;
+				constexpr float kZoneSizeMeters =
+					static_cast<float>(engine::world::kZoneSize);
+				engine::world::water::LakeInstance lake;
+				lake.name = "ocean";
+				lake.polygon = {
+					{ -kOceanMarginMeters, newOcean.seaLevelMeters, -kOceanMarginMeters },
+					{ kZoneSizeMeters + kOceanMarginMeters, newOcean.seaLevelMeters, -kOceanMarginMeters },
+					{ kZoneSizeMeters + kOceanMarginMeters, newOcean.seaLevelMeters,  kZoneSizeMeters + kOceanMarginMeters },
+					{ -kOceanMarginMeters, newOcean.seaLevelMeters,  kZoneSizeMeters + kOceanMarginMeters },
+					{ -kOceanMarginMeters, newOcean.seaLevelMeters, -kOceanMarginMeters },
+				};
+				lake.waterLevelY = newOcean.seaLevelMeters;
+				lake.bottomColor = engine::math::Vec3{
+					newOcean.bottomColor[0],
+					newOcean.bottomColor[1],
+					newOcean.bottomColor[2]
+				};
+				lake.turbidity = newOcean.turbidity;
+				lake.isOcean   = true;
+				data.oceanToInsert = std::move(lake);
+			}
+
+			if (smoothingEnabled || cliffsEnabled)
+			{
+				auto grid = BuildGridFromLoadedChunks(ctx.terrain, *ctx.config);
+				if (smoothingEnabled)
+				{
+					const float bandM  = ReadFloat(params, "smoothingBandMeters", 5.0f);
+					const float forceF = ReadFloat(params, "smoothingForce",      0.3f);
+					auto deltas = engine::editor::world::ComputeCoastlineSmoothingDeltas(
+						grid, newOcean.seaLevelMeters, bandM, forceF);
+					MergeDeltas(data.heightmapDeltas, deltas);
+				}
+				if (cliffsEnabled)
+				{
+					const float thresholdM  = ReadFloat(params, "cliffsThresholdMeters",   8.0f);
+					const float slopeDeg    = ReadFloat(params, "cliffsSlopeThresholdDeg", 45.0f);
+					const float landSideM   = ReadFloat(params, "cliffsLandSideMeters",    6.0f);
+					const float seaSideM    = ReadFloat(params, "cliffsSeaSideMeters",     3.0f);
+					auto deltas = engine::editor::world::ComputeCoastlineCliffsDeltas(
+						grid, newOcean.seaLevelMeters,
+						thresholdM, slopeDeg, landSideM, seaSideM);
+					MergeDeltas(data.heightmapDeltas, deltas);
+				}
+			}
+
+			outCmd = std::make_unique<engine::editor::world::CoastlineCommand>(
+				ctx.terrain, ctx.water, std::move(data));
+			return DispatchResult::Ok;
+		}
+
 		// --- place_dungeon --------------------------------------------------
 
 		DispatchResult DispatchPlaceDungeon(const OperationParams& params,
@@ -457,13 +796,20 @@ namespace engine::editor::world::zone_presets
 		if (op.type == "lake_polygon")   return DispatchLakePolygon(params, ctx, outCmd);
 		if (op.type == "river_manual")   return DispatchRiverManual(params, ctx, outCmd);
 
-		// Types connus mais non câblés (besoin d'extraire la simulation des
-		// Tools UI ou de capturer un snapshot d'état pré-action) :
-		// `coastline`, `river_network`, `hydraulic_erosion`,
-		// `thermal_wind_erosion`. Comportement aligné sur le skip silencieux
-		// de la section `decoration` §A.4.
+		// Incrément 2e — câblage des 4 ops simulation via les variantes
+		// pures `Run*OnGrid` / `RunThermalSimulation` / `RunWindSimulation`
+		// + le helper local `BuildGridFromLoadedChunks`. 14/14 types câblés.
+		if (op.type == "hydraulic_erosion")     return DispatchHydraulicErosion(params, custom, ctx, outCmd);
+		if (op.type == "thermal_wind_erosion")  return DispatchThermalWindErosion(params, custom, ctx, outCmd);
+		if (op.type == "river_network")         return DispatchRiverNetwork(params, custom, ctx, outCmd);
+		if (op.type == "coastline")             return DispatchCoastline(params, custom, ctx, outCmd);
+
+		// `sculpt_brush` et `splat_paint` connus mais pas câblés (les 8
+		// presets livrés ne les utilisent pas et leurs ICommand sont des
+		// actions ponctuelles, pas du batch déterministe). Skip silencieux
+		// aligné sur le comportement §A.4 pour `decoration`.
 		LOG_INFO(EditorWorld,
-			"[OperationDispatcher] type '{}' connu mais non câblé en M100.46 incrément 2d (op ignorée)",
+			"[OperationDispatcher] type '{}' connu mais pas câblé en M100.46 (sculpt_brush/splat_paint = ponctuel, pas batch)",
 			op.type);
 		return DispatchResult::Unsupported;
 	}

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -1,0 +1,227 @@
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
+
+#include "src/shared/core/Log.h"
+#include "src/world_editor/volumes/MeshInsertDocument.h"
+#include "src/world_editor/volumes/MeshInsertInstance.h"
+#include "src/world_editor/volumes/arches/PlaceArchCommand.h"
+#include "src/world_editor/volumes/caves/CaveCatalog.h"
+#include "src/world_editor/volumes/caves/PlaceCaveCommand.h"
+#include "src/world_editor/volumes/dungeons/DungeonCatalog.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalInstance.h"
+#include "src/world_editor/volumes/dungeons/PlaceDungeonPortalCommand.h"
+#include "src/world_editor/volumes/overhangs/OverhangCatalog.h"
+#include "src/world_editor/volumes/overhangs/PlaceOverhangCommand.h"
+#include "src/world_editor/zone_presets/OperationParams.h"
+
+#include <utility>
+
+namespace engine::editor::world::zone_presets
+{
+	namespace
+	{
+		using engine::math::Vec3;
+
+		/// Lit `worldPosition` (3 floats aplatis) depuis `params`.
+		/// Fallback : (0,0,0). Retourne false si la clé est absente.
+		bool ReadWorldPos(const OperationParams& params, Vec3& out)
+		{
+			std::vector<double> v;
+			if (!params.GetNumberList("worldPosition", v) || v.size() < 3u)
+				return false;
+			out.x = static_cast<float>(v[0]);
+			out.y = static_cast<float>(v[1]);
+			out.z = static_cast<float>(v[2]);
+			return true;
+		}
+
+		float ReadFloat(const OperationParams& params, const char* key, float fallback)
+		{
+			double v = 0.0;
+			return params.GetNumber(key, v) ? static_cast<float>(v) : fallback;
+		}
+
+		bool ReadBool(const OperationParams& params, const char* key, bool fallback)
+		{
+			bool v = false;
+			return params.GetBool(key, v) ? v : fallback;
+		}
+
+		// --- place_cave ----------------------------------------------------
+
+		DispatchResult DispatchPlaceCave(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::string catalogId;
+			if (!params.GetString("catalogId", catalogId) || catalogId.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_cave : catalogId manquant");
+				return DispatchResult::Failed;
+			}
+			const auto* entry = ctx.caveCatalog.FindById(catalogId);
+			if (entry == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_cave : catalogId '{}' introuvable",
+					catalogId);
+				return DispatchResult::Failed;
+			}
+			Vec3 worldPos{};
+			if (!ReadWorldPos(params, worldPos))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_cave : worldPosition manquant");
+				return DispatchResult::Failed;
+			}
+			const float rotationY = ReadFloat(params, "rotationY", 0.0f);
+			const bool  snapToGround = ReadBool(params, "autoSnapToGround", true);
+
+			using engine::editor::world::volumes::MeshInsertInstance;
+			using engine::editor::world::volumes::caves::PlaceCaveCommand;
+
+			MeshInsertInstance inst;
+			inst.guid                = 0u;
+			inst.gltfRelativePath    = entry->gltfRelativePath;
+			inst.worldPosition       = worldPos;
+			if (snapToGround) inst.worldPosition.y -= entry->entrancePoint.y;
+			inst.eulerRotationDeg    = { 0.0f, rotationY, 0.0f };
+			inst.uniformScale        = ReadFloat(params, "uniformScale", 1.0f);
+			inst.insertCategory      = "cave";
+			inst.displayName         = entry->displayName.empty() ? entry->id : entry->displayName;
+			inst.hasInteriorVolume   = true;
+			inst.receivesAudioReverb = true;
+			inst.allowsWaterIngress  = false;
+
+			PlaceCaveCommand::Data data;
+			data.instance = std::move(inst);
+			// Pas de splatPatch côté zone preset (camouflage = follow-up).
+
+			outCmd = std::make_unique<PlaceCaveCommand>(
+				ctx.meshInserts, ctx.terrain, std::move(data));
+			return DispatchResult::Ok;
+		}
+
+		// --- place_overhang -------------------------------------------------
+
+		DispatchResult DispatchPlaceOverhang(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::string catalogId;
+			if (!params.GetString("catalogId", catalogId) || catalogId.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_overhang : catalogId manquant");
+				return DispatchResult::Failed;
+			}
+			const auto* entry = ctx.overhangCatalog.FindById(catalogId);
+			if (entry == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_overhang : catalogId '{}' introuvable",
+					catalogId);
+				return DispatchResult::Failed;
+			}
+			Vec3 worldPos{};
+			if (!ReadWorldPos(params, worldPos))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_overhang : worldPosition manquant");
+				return DispatchResult::Failed;
+			}
+			const float yawDeg  = ReadFloat(params, "wallNormalYawDeg",
+				ReadFloat(params, "rotationY", 0.0f));
+			const float tiltDeg = ReadFloat(params, "tiltDeg", 0.0f);
+			const float scale   = ReadFloat(params, "uniformScale", 1.0f);
+
+			using engine::editor::world::volumes::MeshInsertInstance;
+			using engine::editor::world::volumes::overhangs::PlaceOverhangCommand;
+
+			MeshInsertInstance inst;
+			inst.guid                = 0u;
+			inst.gltfRelativePath    = entry->gltfRelativePath;
+			inst.worldPosition       = worldPos;
+			inst.eulerRotationDeg    = { 0.0f, yawDeg, tiltDeg };
+			inst.uniformScale        = scale;
+			inst.insertCategory      = "overhang";
+			inst.displayName         = entry->displayName.empty() ? entry->id : entry->displayName;
+			inst.hasInteriorVolume   = false;
+			inst.allowsWaterIngress  = false;
+
+			outCmd = std::make_unique<PlaceOverhangCommand>(ctx.meshInserts, std::move(inst));
+			return DispatchResult::Ok;
+		}
+
+		// --- place_dungeon --------------------------------------------------
+
+		DispatchResult DispatchPlaceDungeon(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::string catalogId;
+			if (!params.GetString("catalogId", catalogId) || catalogId.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_dungeon : catalogId manquant");
+				return DispatchResult::Failed;
+			}
+			const auto* entry = ctx.dungeonCatalog.FindById(catalogId);
+			if (entry == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_dungeon : catalogId '{}' introuvable",
+					catalogId);
+				return DispatchResult::Failed;
+			}
+			Vec3 worldPos{};
+			if (!ReadWorldPos(params, worldPos))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_dungeon : worldPosition manquant");
+				return DispatchResult::Failed;
+			}
+			std::string dungeonTemplateId;
+			if (!params.GetString("dungeonId", dungeonTemplateId) || dungeonTemplateId.empty())
+			{
+				dungeonTemplateId = entry->id; // défaut : id du catalog
+			}
+
+			using engine::editor::world::volumes::dungeons::DungeonPortalInstance;
+			using engine::editor::world::volumes::dungeons::PlaceDungeonPortalCommand;
+
+			DungeonPortalInstance inst;
+			inst.guid              = 0u;
+			inst.dungeonTemplateId = dungeonTemplateId;
+			inst.displayName       = entry->displayName.empty() ? entry->id : entry->displayName;
+			inst.decorativeMeshPath = entry->decorativeMeshPath;
+			inst.worldPosition     = worldPos;
+			inst.eulerRotationDeg  = { 0.0f, ReadFloat(params, "rotationY", 0.0f), 0.0f };
+			inst.triggerRadius     = ReadFloat(params, "triggerRadius", 3.0f);
+			inst.requiredLevel     = static_cast<uint16_t>(
+				ReadFloat(params, "requiredLevel", static_cast<float>(entry->requiredLevel)));
+			inst.minDifficulty     = entry->minDifficulty;
+			inst.maxDifficulty     = entry->maxDifficulty;
+
+			outCmd = std::make_unique<PlaceDungeonPortalCommand>(ctx.dungeonPortals, std::move(inst));
+			return DispatchResult::Ok;
+		}
+	}
+
+	DispatchResult DispatchOperation(const ZonePresetOperation& op,
+		const CustomizationParams& custom,
+		const DispatchContext& ctx,
+		std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+	{
+		outCmd.reset();
+
+		// Parse les params + applique la customisation (multiplicateurs
+		// sur les champs scalaires selon op.affectedBy).
+		OperationParams params = OperationParams::Parse(op.rawJson);
+		ApplyCustomization(params, op.affectedBy, custom);
+
+		if (op.type == "place_cave")    return DispatchPlaceCave(params, ctx, outCmd);
+		if (op.type == "place_overhang") return DispatchPlaceOverhang(params, ctx, outCmd);
+		if (op.type == "place_dungeon") return DispatchPlaceDungeon(params, ctx, outCmd);
+
+		// Types connus mais non câblés en MVP incrément 2b — l'executor
+		// logge et continue (comportement aligné sur le skip silencieux
+		// de la section `decoration` §A.4).
+		LOG_INFO(EditorWorld,
+			"[OperationDispatcher] type '{}' connu mais non câblé en M100.46 incrément 2b (op ignorée)",
+			op.type);
+		return DispatchResult::Unsupported;
+	}
+}

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -3,6 +3,7 @@
 #include "src/shared/core/Log.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
 #include "src/world_editor/volumes/MeshInsertInstance.h"
+#include "src/world_editor/volumes/arches/ArchCatalog.h"
 #include "src/world_editor/volumes/arches/PlaceArchCommand.h"
 #include "src/world_editor/volumes/caves/CaveCatalog.h"
 #include "src/world_editor/volumes/caves/PlaceCaveCommand.h"
@@ -14,6 +15,7 @@
 #include "src/world_editor/volumes/overhangs/PlaceOverhangCommand.h"
 #include "src/world_editor/zone_presets/OperationParams.h"
 
+#include <cmath>
 #include <utility>
 
 namespace engine::editor::world::zone_presets
@@ -148,6 +150,77 @@ namespace engine::editor::world::zone_presets
 			return DispatchResult::Ok;
 		}
 
+		// --- place_arch -----------------------------------------------------
+
+		/// Lit un Vec3 (3 floats aplatis) depuis `params` sous la clé `key`.
+		bool ReadVec3Key(const OperationParams& params, const char* key, Vec3& out)
+		{
+			std::vector<double> v;
+			if (!params.GetNumberList(key, v) || v.size() < 3u) return false;
+			out.x = static_cast<float>(v[0]);
+			out.y = static_cast<float>(v[1]);
+			out.z = static_cast<float>(v[2]);
+			return true;
+		}
+
+		DispatchResult DispatchPlaceArch(const OperationParams& params,
+			const DispatchContext& ctx,
+			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
+		{
+			std::string catalogId;
+			if (!params.GetString("catalogId", catalogId) || catalogId.empty())
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_arch : catalogId manquant");
+				return DispatchResult::Failed;
+			}
+			const auto* entry = ctx.archCatalog.FindById(catalogId);
+			if (entry == nullptr)
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_arch : catalogId '{}' introuvable",
+					catalogId);
+				return DispatchResult::Failed;
+			}
+			Vec3 pillarA{}, pillarB{};
+			if (!ReadVec3Key(params, "pillarA", pillarA)
+				|| !ReadVec3Key(params, "pillarB", pillarB))
+			{
+				LOG_WARN(EditorWorld, "[OperationDispatcher] place_arch : pillarA/B manquants");
+				return DispatchResult::Failed;
+			}
+
+			// Géométrie dérivée (mirror de ArchTool::Place) :
+			//   worldPosition = midpoint(A, B),
+			//   eulerRotationDeg.y = atan2(Bz-Az, Bx-Ax) en degrés,
+			//   uniformScale = span_world / span_natif (clampé > 0).
+			constexpr float kRadToDeg = 57.29577951308232f;
+			const float dx = pillarB.x - pillarA.x;
+			const float dz = pillarB.z - pillarA.z;
+			const float spanWorld  = std::sqrt(dx * dx + dz * dz);
+			const float spanNative = entry->NativeSpanMeters();
+			const float scale = (spanNative > 0.001f && spanWorld > 0.001f)
+				? (spanWorld / spanNative) : 1.0f;
+
+			using engine::editor::world::volumes::MeshInsertInstance;
+			using engine::editor::world::volumes::arches::PlaceArchCommand;
+
+			MeshInsertInstance inst;
+			inst.guid              = 0u;
+			inst.gltfRelativePath  = entry->gltfRelativePath;
+			inst.worldPosition.x   = 0.5f * (pillarA.x + pillarB.x);
+			inst.worldPosition.y   = 0.5f * (pillarA.y + pillarB.y);
+			inst.worldPosition.z   = 0.5f * (pillarA.z + pillarB.z);
+			inst.eulerRotationDeg  = { 0.0f, std::atan2(dz, dx) * kRadToDeg, 0.0f };
+			inst.uniformScale      = scale;
+			inst.insertCategory    = "arch";
+			inst.displayName       = entry->displayName.empty() ? entry->id : entry->displayName;
+			inst.hasInteriorVolume   = false;
+			inst.receivesAudioReverb = false;
+			inst.allowsWaterIngress  = false;
+
+			outCmd = std::make_unique<PlaceArchCommand>(ctx.meshInserts, std::move(inst));
+			return DispatchResult::Ok;
+		}
+
 		// --- place_dungeon --------------------------------------------------
 
 		DispatchResult DispatchPlaceDungeon(const OperationParams& params,
@@ -212,9 +285,10 @@ namespace engine::editor::world::zone_presets
 		OperationParams params = OperationParams::Parse(op.rawJson);
 		ApplyCustomization(params, op.affectedBy, custom);
 
-		if (op.type == "place_cave")    return DispatchPlaceCave(params, ctx, outCmd);
+		if (op.type == "place_cave")     return DispatchPlaceCave(params, ctx, outCmd);
 		if (op.type == "place_overhang") return DispatchPlaceOverhang(params, ctx, outCmd);
-		if (op.type == "place_dungeon") return DispatchPlaceDungeon(params, ctx, outCmd);
+		if (op.type == "place_arch")     return DispatchPlaceArch(params, ctx, outCmd);
+		if (op.type == "place_dungeon")  return DispatchPlaceDungeon(params, ctx, outCmd);
 
 		// Types connus mais non câblés en MVP incrément 2b — l'executor
 		// logge et continue (comportement aligné sur le skip silencieux

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -37,6 +37,7 @@
 #include "src/world_editor/water/CoastlineCommand.h"
 #include "src/world_editor/water/CoastlineSmoothing.h"
 #include "src/world_editor/water/ConsolidatedHeightGrid.h"
+#include "src/world_editor/water/HeightGridAssembly.h"
 #include "src/world_editor/water/OceanSettings.h"
 #include "src/world_editor/water/RiverNetworkCommand.h"
 #include "src/world_editor/water/SpringSource.h"
@@ -409,50 +410,10 @@ namespace engine::editor::world::zone_presets
 
 		// --- Sim helpers ---------------------------------------------------
 
-		/// Assemble un `ConsolidatedHeightGrid` 2×2 chunks (~1025×1025 cellules)
-		/// à partir des chunks chargés du `TerrainDocument`. Réplique le pattern
-		/// `BuildGrid` dupliqué dans `ThermalWindErosionTool` / `CoastlineEditorTool`.
-		///
-		/// Effet de bord : appelle `TerrainDocument::EnsureLoaded` (bloque le
-		/// main thread le temps du chargement disque/CPU).
-		engine::editor::world::ConsolidatedHeightGrid
-		BuildGridFromLoadedChunks(engine::editor::world::TerrainDocument& terrain,
-			const engine::core::Config& cfg)
-		{
-			constexpr int kRes      = static_cast<int>(engine::world::terrain::kTerrainResolution);
-			constexpr int kChunksDim = 2;
-			engine::editor::world::ConsolidatedHeightGrid grid;
-			grid.cellSizeMeters = engine::world::terrain::kTerrainCellSizeMeters;
-			grid.originCellX = 0;
-			grid.originCellZ = 0;
-			const int W = kChunksDim * (kRes - 1) + 1;
-			const int H = kChunksDim * (kRes - 1) + 1;
-			grid.width = W;
-			grid.height = H;
-			grid.heights.assign(static_cast<size_t>(W) * H, 0.0f);
-			for (int cz = 0; cz < kChunksDim; ++cz)
-			{
-				for (int cx = 0; cx < kChunksDim; ++cx)
-				{
-					auto chunk = terrain.EnsureLoaded(cfg, cx, cz);
-					if (!chunk) continue;
-					const int baseX = cx * (kRes - 1);
-					const int baseZ = cz * (kRes - 1);
-					for (int iz = 0; iz < kRes; ++iz)
-					{
-						for (int ix = 0; ix < kRes; ++ix)
-						{
-							const int gx = baseX + ix;
-							const int gz = baseZ + iz;
-							if (gx >= W || gz >= H) continue;
-							grid.heights[static_cast<size_t>(gz) * W + gx] =
-								chunk->heights[static_cast<size_t>(iz) * kRes + ix];
-						}
-					}
-				}
-			}
-			return grid;
-		}
+		// L'assemblage du `ConsolidatedHeightGrid` 2×2 chunks vit maintenant
+		// dans `water/HeightGridAssembly.{h,cpp}` (partagé avec
+		// CoastlineEditorTool et ThermalWindErosionTool). On le réutilise tel
+		// quel via `engine::editor::world::BuildGridFromLoadedChunks(...)`.
 
 		/// Fusionne `src` dans `dst` cellule par cellule (les valeurs s'additionnent).
 		void MergeDeltas(engine::editor::world::SparseChunkDeltas& dst,

--- a/src/world_editor/zone_presets/OperationDispatcher.h
+++ b/src/world_editor/zone_presets/OperationDispatcher.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/zone_presets/CustomizationApplier.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+
+#include <memory>
+
+namespace engine::editor::world
+{
+	class TerrainDocument;
+}
+
+namespace engine::editor::world::volumes
+{
+	class MeshInsertDocument;
+	namespace caves    { class CaveCatalog; }
+	namespace overhangs { class OverhangCatalog; }
+	namespace dungeons
+	{
+		class DungeonPortalDocument;
+		class DungeonCatalog;
+	}
+}
+
+namespace engine::editor::world::zone_presets
+{
+	/// Contexte fourni au dispatcher : refs sur les documents et catalogs
+	/// nécessaires pour construire les commandes des opérations
+	/// supportées (M100.46 incrément 2b).
+	///
+	/// Pour cet incrément, les types câblés end-to-end sont les
+	/// **place_*** (cave, overhang, dungeon) dont les chemins de commande
+	/// existent déjà (M100.40-43). Les 11 autres types (mountain_macro,
+	/// valley_macro, sculpt_brush, splat_paint, lake_polygon, river_manual,
+	/// coastline, river_network, hydraulic_erosion, thermal_wind_erosion,
+	/// place_arch) demandent d'ajouter des chemins « headless » aux outils
+	/// concernés — itérations suivantes (2c, 2d…).
+	struct DispatchContext
+	{
+		engine::editor::world::TerrainDocument&                        terrain;
+		engine::editor::world::volumes::MeshInsertDocument&            meshInserts;
+		engine::editor::world::volumes::dungeons::DungeonPortalDocument& dungeonPortals;
+
+		const engine::editor::world::volumes::caves::CaveCatalog&      caveCatalog;
+		const engine::editor::world::volumes::overhangs::OverhangCatalog& overhangCatalog;
+		const engine::editor::world::volumes::dungeons::DungeonCatalog& dungeonCatalog;
+	};
+
+	/// Résultat d'un dispatch.
+	enum class DispatchResult : uint8_t
+	{
+		Ok        = 0,  ///< commande créée
+		Unsupported = 1, ///< type connu mais pas encore câblé en MVP
+		Failed    = 2,  ///< params manquants / catalog entry introuvable
+	};
+
+	/// Construit la commande correspondant à `op`, paramètres typés
+	/// extraits de `op.rawJson` + customisation appliquée. La commande
+	/// n'est PAS poussée sur le stack — c'est le rôle du `ZonePresetExecutor`.
+	///
+	/// \param op       opération source (`type`, `rawJson`, `toolPresetId`,
+	///                 `affectedBy`).
+	/// \param custom   curseurs globaux relief/eau/sécheresse + seed.
+	/// \param ctx      références documents + catalogs.
+	/// \param outCmd   reçoit la commande (vide si non-OK).
+	/// \return         statut détaillé pour le logging côté executor.
+	DispatchResult DispatchOperation(const ZonePresetOperation& op,
+		const CustomizationParams& custom,
+		const DispatchContext& ctx,
+		std::unique_ptr<engine::editor::world::ICommand>& outCmd);
+}

--- a/src/world_editor/zone_presets/OperationDispatcher.h
+++ b/src/world_editor/zone_presets/OperationDispatcher.h
@@ -16,6 +16,7 @@ namespace engine::editor::world::volumes
 	class MeshInsertDocument;
 	namespace caves    { class CaveCatalog; }
 	namespace overhangs { class OverhangCatalog; }
+	namespace arches   { class ArchCatalog; }
 	namespace dungeons
 	{
 		class DungeonPortalDocument;
@@ -44,6 +45,7 @@ namespace engine::editor::world::zone_presets
 
 		const engine::editor::world::volumes::caves::CaveCatalog&      caveCatalog;
 		const engine::editor::world::volumes::overhangs::OverhangCatalog& overhangCatalog;
+		const engine::editor::world::volumes::arches::ArchCatalog&     archCatalog;
 		const engine::editor::world::volumes::dungeons::DungeonCatalog& dungeonCatalog;
 	};
 

--- a/src/world_editor/zone_presets/OperationDispatcher.h
+++ b/src/world_editor/zone_presets/OperationDispatcher.h
@@ -9,6 +9,7 @@
 namespace engine::editor::world
 {
 	class TerrainDocument;
+	class WaterDocument;
 }
 
 namespace engine::editor::world::volumes
@@ -28,18 +29,24 @@ namespace engine::editor::world::zone_presets
 {
 	/// Contexte fourni au dispatcher : refs sur les documents et catalogs
 	/// nécessaires pour construire les commandes des opérations
-	/// supportées (M100.46 incrément 2b).
+	/// supportées (M100.46 incréments 2b + 2d).
 	///
-	/// Pour cet incrément, les types câblés end-to-end sont les
-	/// **place_*** (cave, overhang, dungeon) dont les chemins de commande
-	/// existent déjà (M100.40-43). Les 11 autres types (mountain_macro,
-	/// valley_macro, sculpt_brush, splat_paint, lake_polygon, river_manual,
-	/// coastline, river_network, hydraulic_erosion, thermal_wind_erosion,
-	/// place_arch) demandent d'ajouter des chemins « headless » aux outils
-	/// concernés — itérations suivantes (2c, 2d…).
+	/// Types câblés end-to-end :
+	///   - **place_*** (cave, overhang, arch, dungeon) — incrément 2b/2c.
+	///   - **mountain_macro / valley_macro** — incrément 2d via
+	///     `RasterizeMacroPolyline` + `MountainRangeCommand / ValleyChainCommand`.
+	///   - **lake_polygon / river_manual** — incrément 2d via
+	///     `AddLakeCommand / AddRiverCommand` (path direct, structs plain data).
+	///
+	/// Types encore non câblés (incréments 2e+, demandent d'extraire la
+	/// simulation des Tools UI ou de capturer un snapshot d'état pré-action) :
+	/// `coastline`, `river_network`, `hydraulic_erosion`,
+	/// `thermal_wind_erosion`. Ces 4 types restent gracieusement
+	/// **Unsupported** + LOG_INFO.
 	struct DispatchContext
 	{
 		engine::editor::world::TerrainDocument&                        terrain;
+		engine::editor::world::WaterDocument&                          water;
 		engine::editor::world::volumes::MeshInsertDocument&            meshInserts;
 		engine::editor::world::volumes::dungeons::DungeonPortalDocument& dungeonPortals;
 

--- a/src/world_editor/zone_presets/OperationDispatcher.h
+++ b/src/world_editor/zone_presets/OperationDispatcher.h
@@ -6,6 +6,11 @@
 
 #include <memory>
 
+namespace engine::core
+{
+	class Config;
+}
+
 namespace engine::editor::world
 {
 	class TerrainDocument;
@@ -27,22 +32,29 @@ namespace engine::editor::world::volumes
 
 namespace engine::editor::world::zone_presets
 {
-	/// Contexte fourni au dispatcher : refs sur les documents et catalogs
-	/// nécessaires pour construire les commandes des opérations
-	/// supportées (M100.46 incréments 2b + 2d).
+	/// Contexte fourni au dispatcher : refs sur les documents, catalogs et
+	/// `Config` nécessaires pour construire les commandes (M100.46 incréments
+	/// 2b + 2c + 2d + 2e).
 	///
-	/// Types câblés end-to-end :
-	///   - **place_*** (cave, overhang, arch, dungeon) — incrément 2b/2c.
-	///   - **mountain_macro / valley_macro** — incrément 2d via
-	///     `RasterizeMacroPolyline` + `MountainRangeCommand / ValleyChainCommand`.
-	///   - **lake_polygon / river_manual** — incrément 2d via
-	///     `AddLakeCommand / AddRiverCommand` (path direct, structs plain data).
+	/// Types câblés end-to-end (12/14 après incrément 2e) :
+	///   - **place_*** (cave, overhang, arch, dungeon) — 2b/2c.
+	///   - **mountain_macro / valley_macro** — 2d via `RasterizeMacroPolyline`.
+	///   - **lake_polygon / river_manual** — 2d via Add*Command plain data.
+	///   - **hydraulic_erosion / thermal_wind_erosion / river_network /
+	///     coastline** — 2e via assemblage `ConsolidatedHeightGrid` +
+	///     simulations pures (`RunHydraulicOnGrid`, `RunThermalSimulation`,
+	///     `RunWindSimulation`, `RunWatershedOnGrid`,
+	///     `ComputeCoastlineSmoothing/CliffsDeltas`).
 	///
-	/// Types encore non câblés (incréments 2e+, demandent d'extraire la
-	/// simulation des Tools UI ou de capturer un snapshot d'état pré-action) :
-	/// `coastline`, `river_network`, `hydraulic_erosion`,
-	/// `thermal_wind_erosion`. Ces 4 types restent gracieusement
-	/// **Unsupported** + LOG_INFO.
+	/// Restent **`sculpt_brush`** et **`splat_paint`** comme `Unsupported` :
+	/// les 8 presets livrés ne les utilisent pas, et leurs ICommand sont
+	/// des actions ponctuelles non destinées à du batch déterministe.
+	/// Câblage repoussé jusqu'à ce qu'un preset les exige.
+	///
+	/// Le `config` est requis par les 4 ops simulation (lecture des chunks
+	/// via `TerrainDocument::EnsureLoaded`). Si `config == nullptr` ces 4
+	/// ops renvoient `Failed` avec un LOG_WARN ; les 10 autres ops ne le
+	/// consultent pas.
 	struct DispatchContext
 	{
 		engine::editor::world::TerrainDocument&                        terrain;
@@ -54,6 +66,11 @@ namespace engine::editor::world::zone_presets
 		const engine::editor::world::volumes::overhangs::OverhangCatalog& overhangCatalog;
 		const engine::editor::world::volumes::arches::ArchCatalog&     archCatalog;
 		const engine::editor::world::volumes::dungeons::DungeonCatalog& dungeonCatalog;
+
+		/// Pointeur nullable. Requis pour les 4 ops sim (hydraulic /
+		/// thermal_wind / river_network / coastline) qui chargent des chunks
+		/// terrain via `EnsureLoaded(*config, ...)`. Null → ces ops failed.
+		const engine::core::Config*                                    config = nullptr;
 	};
 
 	/// Résultat d'un dispatch.

--- a/src/world_editor/zone_presets/WorldMapEditDocumentReset.cpp
+++ b/src/world_editor/zone_presets/WorldMapEditDocumentReset.cpp
@@ -1,0 +1,21 @@
+#include "src/world_editor/zone_presets/WorldMapEditDocumentReset.h"
+
+#include "src/world_editor/terrain/TerrainDocument.h"
+#include "src/world_editor/volumes/MeshInsertDocument.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
+#include "src/world_editor/water/WaterDocument.h"
+
+namespace engine::editor::world::zone_presets
+{
+	void ResetEditedZoneDocuments(
+		engine::editor::world::TerrainDocument& terrain,
+		engine::editor::world::WaterDocument& water,
+		engine::editor::world::volumes::MeshInsertDocument& meshInserts,
+		engine::editor::world::volumes::dungeons::DungeonPortalDocument& dungeonPortals)
+	{
+		terrain.Reset();
+		water.Reset();
+		meshInserts.Reset();
+		dungeonPortals.Reset();
+	}
+}

--- a/src/world_editor/zone_presets/WorldMapEditDocumentReset.h
+++ b/src/world_editor/zone_presets/WorldMapEditDocumentReset.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace engine::editor::world
+{
+	class TerrainDocument;
+	class WaterDocument;
+	namespace volumes
+	{
+		class MeshInsertDocument;
+		namespace dungeons { class DungeonPortalDocument; }
+	}
+}
+
+namespace engine::editor::world::zone_presets
+{
+	/// Vide intégralement les 4 documents éditeur d'une zone (M100.46
+	/// §D.3). Utilisé par `ZonePresetExecutor` avant l'exécution d'un
+	/// preset sur une zone non vide.
+	///
+	/// Effet : `Reset()` est appelé sur chacun des documents. Les chunks
+	/// terrain reviennent à plat à 0 m via lazy load, la scène water est
+	/// vidée (lakes/rivers/ocean défaut), les mesh inserts et portails
+	/// sont supprimés.
+	///
+	/// Note MVP : ce helper ne pousse PAS de `ResetZoneCommand` sur le
+	/// CommandStack (spec §D.3 le prévoit pour Ctrl+Z après preset).
+	/// L'annulation est laissée à un follow-up : pour cet incrément, le
+	/// reset est destructif (irréversible). L'utilisateur en est prévenu
+	/// par le dialog de confirmation côté UI (incrément 3).
+	void ResetEditedZoneDocuments(
+		engine::editor::world::TerrainDocument& terrain,
+		engine::editor::world::WaterDocument& water,
+		engine::editor::world::volumes::MeshInsertDocument& meshInserts,
+		engine::editor::world::volumes::dungeons::DungeonPortalDocument& dungeonPortals);
+}

--- a/src/world_editor/zone_presets/ZonePresetDialog.cpp
+++ b/src/world_editor/zone_presets/ZonePresetDialog.cpp
@@ -33,7 +33,8 @@ namespace engine::editor::world::zone_presets
 	/// durée — convention single-thread acceptée (cf. ZonePresetExecutor.h).
 	/// Renseigne `m_lastSummary`, `m_lastPresetId`, `m_lastDurationMs`
 	/// puis bascule à l'écran résultat.
-	void ZonePresetDialog::RunSelectedPreset(engine::editor::world::WorldEditorShell& shell)
+	void ZonePresetDialog::RunSelectedPreset(engine::editor::world::WorldEditorShell& shell,
+		const engine::core::Config* cfg)
 	{
 		const auto& presets = ZonePresetRegistry::Instance().Presets();
 		if (m_selectedIndex >= presets.size())
@@ -55,6 +56,7 @@ namespace engine::editor::world::zone_presets
 			shell.GetOverhangTool().Catalog(),
 			shell.GetArchTool().Catalog(),
 			shell.GetDungeonPortalTool().Catalog(),
+			cfg,  // M100.46 incrément 2e — requis par les 4 ops simulation.
 		};
 
 		LOG_INFO(EditorWorld,
@@ -89,7 +91,8 @@ namespace engine::editor::world::zone_presets
 	/// Doit être appelée chaque frame depuis WorldEditorImGui::BuildUi.
 	/// Effet de bord : pose un popup ImGui actif sur le premier frame
 	/// après `Open()`.
-	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell& shell)
+	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell& shell,
+		const engine::core::Config* cfg)
 	{
 		if (m_openRequested)
 		{
@@ -111,7 +114,7 @@ namespace engine::editor::world::zone_presets
 		}
 
 		if (m_screen == Screen::Select)
-			DrawSelectScreen(shell);
+			DrawSelectScreen(shell, cfg);
 		else
 			DrawResultScreen();
 
@@ -122,7 +125,8 @@ namespace engine::editor::world::zone_presets
 	}
 
 	/// Écran de sélection : liste à gauche, détails + sliders à droite.
-	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell& shell)
+	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell& shell,
+		const engine::core::Config* cfg)
 	{
 		ImGui::TextUnformatted("Applique un template de zone à la carte courante.");
 		ImGui::TextWrapped("ATTENTION : terrain, water, mesh inserts et portails de donjon "
@@ -188,7 +192,7 @@ namespace engine::editor::world::zone_presets
 		const bool canApply = (m_selectedIndex < presets.size());
 		if (!canApply) ImGui::BeginDisabled();
 		if (ImGui::Button("Appliquer", ImVec2(140.0f, 0.0f)) && canApply)
-			RunSelectedPreset(shell);
+			RunSelectedPreset(shell, cfg);
 		if (!canApply) ImGui::EndDisabled();
 
 		ImGui::SameLine();
@@ -243,8 +247,10 @@ namespace engine::editor::world::zone_presets
 	// Pas d'ImGui hors Windows : le world editor est Windows-only. On garde
 	// les symboles linkés pour que l'unité de compilation soit utilisable
 	// dans engine_core sans condition. Les méthodes sont no-op.
-	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell&)        { }
-	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell&) { }
+	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell&,
+		const engine::core::Config*) { }
+	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell&,
+		const engine::core::Config*) { }
 	void ZonePresetDialog::DrawResultScreen()                                    { }
 #endif
 }

--- a/src/world_editor/zone_presets/ZonePresetDialog.cpp
+++ b/src/world_editor/zone_presets/ZonePresetDialog.cpp
@@ -1,0 +1,250 @@
+#include "src/world_editor/zone_presets/ZonePresetDialog.h"
+
+#include "src/shared/core/Log.h"
+#include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/volumes/arches/ArchTool.h"
+#include "src/world_editor/volumes/caves/CaveTool.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
+#include "src/world_editor/volumes/overhangs/OverhangTool.h"
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+#include "src/world_editor/zone_presets/ZonePresetRegistry.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+#include <chrono>
+#include <cstdint>
+
+namespace engine::editor::world::zone_presets
+{
+	ZonePresetDialog::ZonePresetDialog()  = default;
+	ZonePresetDialog::~ZonePresetDialog() = default;
+
+	void ZonePresetDialog::Open()
+	{
+		m_openRequested = true;
+		m_screen        = Screen::Select;
+	}
+
+	/// Construit le `DispatchContext` à partir des refs Shell et lance
+	/// l'exécution synchrone. Le main thread ImGui est bloqué pendant la
+	/// durée — convention single-thread acceptée (cf. ZonePresetExecutor.h).
+	/// Renseigne `m_lastSummary`, `m_lastPresetId`, `m_lastDurationMs`
+	/// puis bascule à l'écran résultat.
+	void ZonePresetDialog::RunSelectedPreset(engine::editor::world::WorldEditorShell& shell)
+	{
+		const auto& presets = ZonePresetRegistry::Instance().Presets();
+		if (m_selectedIndex >= presets.size())
+			return;
+		const ZonePreset& preset = presets[m_selectedIndex];
+
+		CustomizationParams custom;
+		custom.reliefMultiplier       = m_relief;
+		custom.waterDensityMultiplier = m_waterDensity;
+		custom.drynessMultiplier      = m_dryness;
+		custom.seed                   = m_seed;
+
+		const DispatchContext ctx{
+			shell.MutableTerrainDocument(),
+			shell.MutableWaterDocument(),
+			shell.MutableMeshInsertDocument(),
+			shell.MutableDungeonPortalDocument(),
+			shell.GetCaveTool().Catalog(),
+			shell.GetOverhangTool().Catalog(),
+			shell.GetArchTool().Catalog(),
+			shell.GetDungeonPortalTool().Catalog(),
+		};
+
+		LOG_INFO(EditorWorld,
+			"[ZonePresetDialog] Application '{}' (relief=x{:.2f} water=x{:.2f} dryness=x{:.2f} seed={})",
+			preset.id, custom.reliefMultiplier, custom.waterDensityMultiplier,
+			custom.drynessMultiplier, custom.seed);
+
+		using clock = std::chrono::steady_clock;
+		const auto t0 = clock::now();
+
+		ZonePresetExecutor executor;
+		// Callback inerte : on ne peut pas pumper ImGui pendant Execute()
+		// (single-thread). La progression part au log via les LOG_INFO du
+		// ZonePresetExecutor.
+		m_lastSummary = executor.Execute(preset, custom,
+			shell.MutableCommandStack(), ctx,
+			[](const ExecutionProgress&) { return true; });
+
+		const auto t1     = clock::now();
+		m_lastDurationMs  = std::chrono::duration<double, std::milli>(t1 - t0).count();
+		m_lastPresetId    = preset.id;
+		m_screen          = Screen::Result;
+
+		LOG_INFO(EditorWorld,
+			"[ZonePresetDialog] '{}' terminé en {:.0f} ms (pushed={}, skipped={}, failed={})",
+			preset.id, m_lastDurationMs, m_lastSummary.commandsPushed,
+			m_lastSummary.unsupportedSkipped, m_lastSummary.failed);
+	}
+
+#if defined(_WIN32)
+	/// Dessine la popup modale en deux écrans (sélection / résultat).
+	/// Doit être appelée chaque frame depuis WorldEditorImGui::BuildUi.
+	/// Effet de bord : pose un popup ImGui actif sur le premier frame
+	/// après `Open()`.
+	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell& shell)
+	{
+		if (m_openRequested)
+		{
+			ImGui::OpenPopup("Zone Presets##zp_modal");
+			m_openRequested = false;
+			m_isOpen        = true;
+		}
+		if (!m_isOpen)
+			return;
+
+		ImGui::SetNextWindowSize(ImVec2(720.0f, 520.0f), ImGuiCond_FirstUseEver);
+
+		bool open = true;
+		if (!ImGui::BeginPopupModal("Zone Presets##zp_modal", &open,
+			ImGuiWindowFlags_NoSavedSettings))
+		{
+			m_isOpen = false;
+			return;
+		}
+
+		if (m_screen == Screen::Select)
+			DrawSelectScreen(shell);
+		else
+			DrawResultScreen();
+
+		ImGui::EndPopup();
+
+		if (!open)
+			m_isOpen = false;
+	}
+
+	/// Écran de sélection : liste à gauche, détails + sliders à droite.
+	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell& shell)
+	{
+		ImGui::TextUnformatted("Applique un template de zone à la carte courante.");
+		ImGui::TextWrapped("ATTENTION : terrain, water, mesh inserts et portails de donjon "
+			"de la zone seront vidés avant exécution. Sauvegardez d'abord si nécessaire.");
+		ImGui::Separator();
+
+		const auto& presets = ZonePresetRegistry::Instance().Presets();
+
+		ImGui::BeginChild("##zp_list", ImVec2(220.0f, 320.0f), true);
+		if (presets.empty())
+		{
+			ImGui::TextDisabled("Aucun preset chargé.");
+			ImGui::TextWrapped("Vérifie game/data/editor/zone_presets/*.json + paths.content.");
+		}
+		else
+		{
+			for (size_t i = 0; i < presets.size(); ++i)
+			{
+				const auto& p     = presets[i];
+				const std::string label = !p.displayName.fr.empty()
+					? p.displayName.fr : p.id;
+				const bool selected = (i == m_selectedIndex);
+				ImGui::PushID(static_cast<int>(i));
+				if (ImGui::Selectable(label.c_str(), selected))
+					m_selectedIndex = i;
+				ImGui::PopID();
+			}
+		}
+		ImGui::EndChild();
+
+		ImGui::SameLine();
+
+		ImGui::BeginChild("##zp_details", ImVec2(0.0f, 320.0f), false);
+		if (m_selectedIndex >= presets.size())
+		{
+			ImGui::TextDisabled("Sélectionne un preset à gauche.");
+		}
+		else
+		{
+			const auto& p = presets[m_selectedIndex];
+			ImGui::Text("Preset : %s", !p.displayName.fr.empty()
+				? p.displayName.fr.c_str() : p.id.c_str());
+			ImGui::Text("Id : %s", p.id.c_str());
+			ImGui::Text("Opérations : %zu  -  Durée estimée : ~%.0f s",
+				p.operations.size(),
+				static_cast<double>(p.estimatedExecutionSeconds));
+			ImGui::Separator();
+			ImGui::TextWrapped("%s", p.description.fr.c_str());
+			ImGui::Separator();
+			ImGui::TextUnformatted("Customisation :");
+			ImGui::SliderFloat("Relief",         &m_relief,       0.25f, 2.0f, "x%.2f");
+			ImGui::SliderFloat("Densite d'eau",  &m_waterDensity, 0.25f, 2.0f, "x%.2f");
+			ImGui::SliderFloat("Secheresse",     &m_dryness,      0.25f, 2.0f, "x%.2f");
+
+			int seed = static_cast<int>(m_seed);
+			if (ImGui::InputInt("Seed RNG", &seed, 1, 100))
+				m_seed = static_cast<uint32_t>(seed < 0 ? 0 : seed);
+		}
+		ImGui::EndChild();
+
+		ImGui::Separator();
+
+		const bool canApply = (m_selectedIndex < presets.size());
+		if (!canApply) ImGui::BeginDisabled();
+		if (ImGui::Button("Appliquer", ImVec2(140.0f, 0.0f)) && canApply)
+			RunSelectedPreset(shell);
+		if (!canApply) ImGui::EndDisabled();
+
+		ImGui::SameLine();
+		if (ImGui::Button("Annuler", ImVec2(140.0f, 0.0f)))
+		{
+			m_isOpen = false;
+			ImGui::CloseCurrentPopup();
+		}
+	}
+
+	/// Écran de résultat post-exécution.
+	void ZonePresetDialog::DrawResultScreen()
+	{
+		ImGui::TextUnformatted("Résumé de l'application");
+		ImGui::Separator();
+		ImGui::Text("Preset                 : %s", m_lastPresetId.c_str());
+		ImGui::Spacing();
+		ImGui::Text("Opérations totales     : %u", m_lastSummary.totalSteps);
+		ImGui::Text("Commandes poussées     : %u", m_lastSummary.commandsPushed);
+		ImGui::Text("Ignorées (non câblées) : %u", m_lastSummary.unsupportedSkipped);
+		ImGui::Text("Échecs                 : %u", m_lastSummary.failed);
+		ImGui::Text("Annulé                 : %s",
+			m_lastSummary.wasCancelled ? "oui" : "non");
+		ImGui::Text("Durée                  : %.0f ms", m_lastDurationMs);
+		ImGui::Separator();
+		if (m_lastSummary.unsupportedSkipped > 0u)
+		{
+			ImGui::TextWrapped("Note : certaines opérations (érosions, river_network, "
+				"coastline) n'ont pas encore de chemin d'exécution sans UI et sont "
+				"ignorées (M100.46 incrément 2e à venir).");
+			ImGui::Separator();
+		}
+		if (m_lastSummary.failed > 0u)
+		{
+			ImGui::TextWrapped("Certaines opérations ont échoué (catalogId introuvable, "
+				"paramètres invalides...). Voir les logs EditorWorld pour le détail.");
+			ImGui::Separator();
+		}
+		if (ImGui::Button("Retour à la sélection", ImVec2(180.0f, 0.0f)))
+		{
+			m_screen = Screen::Select;
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Fermer", ImVec2(140.0f, 0.0f)))
+		{
+			m_isOpen = false;
+			ImGui::CloseCurrentPopup();
+		}
+	}
+
+#else
+	// Pas d'ImGui hors Windows : le world editor est Windows-only. On garde
+	// les symboles linkés pour que l'unité de compilation soit utilisable
+	// dans engine_core sans condition. Les méthodes sont no-op.
+	void ZonePresetDialog::Draw(engine::editor::world::WorldEditorShell&)        { }
+	void ZonePresetDialog::DrawSelectScreen(engine::editor::world::WorldEditorShell&) { }
+	void ZonePresetDialog::DrawResultScreen()                                    { }
+#endif
+}

--- a/src/world_editor/zone_presets/ZonePresetDialog.h
+++ b/src/world_editor/zone_presets/ZonePresetDialog.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "src/world_editor/zone_presets/CustomizationApplier.h"
+#include "src/world_editor/zone_presets/ZonePresetExecutor.h"
+
+#include <cstdint>
+#include <string>
+
+namespace engine::editor::world
+{
+	class WorldEditorShell;
+}
+
+namespace engine::editor::world::zone_presets
+{
+	/// Dialog modal pour appliquer un Zone Preset à la carte courante
+	/// (M100.46 incrément 3). Encapsule :
+	///   - sélection d'un preset dans `ZonePresetRegistry`,
+	///   - sliders de customisation (relief / water_density / dryness)
+	///     + champ seed,
+	///   - bouton « Appliquer » qui exécute synchronone (le main thread
+	///     ImGui est bloqué pendant la durée d'exécution — convention
+	///     éditeur single-thread, cf. ZonePresetExecutor.h),
+	///   - écran de résumé post-exécution (commandes poussées / skipped /
+	///     failed / annulé).
+	///
+	/// Cycle de vie :
+	///   1. `Open()` ouvre la popup au prochain frame.
+	///   2. `Draw(shell)` est appelée chaque frame depuis WorldEditorImGui ;
+	///      no-op si la popup est fermée.
+	///   3. Au clic « Appliquer », `Draw` exécute le preset et passe en
+	///      écran « Résultat » sans fermer la popup (l'utilisateur ferme
+	///      via « OK » ou la croix).
+	///
+	/// Contraintes thread/timing : doit être appelée depuis le main thread
+	/// (rendu ImGui). Les accès aux 4 documents du Shell ne sont pas
+	/// thread-safe.
+	class ZonePresetDialog
+	{
+	public:
+		ZonePresetDialog();
+		~ZonePresetDialog();
+
+		ZonePresetDialog(const ZonePresetDialog&)            = delete;
+		ZonePresetDialog& operator=(const ZonePresetDialog&) = delete;
+
+		/// Demande l'ouverture de la popup au prochain `Draw()`. No-op si
+		/// déjà ouverte.
+		void Open();
+
+		/// Dessine la popup si elle est ouverte. Reçoit le Shell pour
+		/// résoudre les documents (terrain / water / mesh / dungeon) et
+		/// les 4 catalogs (caves / overhangs / arches / dungeons) au
+		/// moment de l'exécution.
+		void Draw(engine::editor::world::WorldEditorShell& shell);
+
+	private:
+		/// État interne de la popup. Pas exposé en public pour garder le
+		/// header léger.
+		enum class Screen : uint8_t
+		{
+			Select  = 0,  ///< choix du preset + sliders
+			Result  = 1,  ///< résumé post-exécution
+		};
+
+		void DrawSelectScreen(engine::editor::world::WorldEditorShell& shell);
+		void DrawResultScreen();
+
+		/// Exécute le preset sélectionné. Renseigne `m_lastSummary` et
+		/// bascule l'écran à `Result`. Le main thread ImGui est bloqué
+		/// pendant la durée — comportement attendu.
+		void RunSelectedPreset(engine::editor::world::WorldEditorShell& shell);
+
+		/// `true` au prochain frame quand `Open()` a été appelé — pousse
+		/// `ImGui::OpenPopup` une seule fois puis remet à `false`.
+		bool m_openRequested = false;
+		bool m_isOpen        = false;
+		Screen m_screen      = Screen::Select;
+
+		/// Index du preset sélectionné dans `ZonePresetRegistry::Presets()`
+		/// (size_t MAX = aucune sélection au premier ouvert).
+		size_t m_selectedIndex = static_cast<size_t>(-1);
+
+		/// Curseurs customisation MVP (UI). Convertis en `CustomizationParams`
+		/// au moment de l'exécution.
+		float m_relief       = 1.0f;
+		float m_waterDensity = 1.0f;
+		float m_dryness      = 1.0f;
+		uint32_t m_seed      = 12345u;
+
+		/// Renseigné après une exécution. `commandsPushed` = 0 et
+		/// `totalSteps` = 0 → pas d'exécution encore lancée.
+		ExecutionSummary m_lastSummary{};
+		/// Id du preset effectivement exécuté (pour l'écran résultat).
+		std::string m_lastPresetId;
+		/// Durée wall-clock observée côté UI (millisecondes).
+		double m_lastDurationMs = 0.0;
+	};
+}

--- a/src/world_editor/zone_presets/ZonePresetDialog.h
+++ b/src/world_editor/zone_presets/ZonePresetDialog.h
@@ -6,6 +6,11 @@
 #include <cstdint>
 #include <string>
 
+namespace engine::core
+{
+	class Config;
+}
+
 namespace engine::editor::world
 {
 	class WorldEditorShell;
@@ -50,9 +55,13 @@ namespace engine::editor::world::zone_presets
 
 		/// Dessine la popup si elle est ouverte. Reçoit le Shell pour
 		/// résoudre les documents (terrain / water / mesh / dungeon) et
-		/// les 4 catalogs (caves / overhangs / arches / dungeons) au
-		/// moment de l'exécution.
-		void Draw(engine::editor::world::WorldEditorShell& shell);
+		/// les 4 catalogs (caves / overhangs / arches / dungeons), plus
+		/// la `Config` requise par les 4 ops simulation (incrément 2e).
+		/// `cfg` peut être null mais les ops `hydraulic_erosion`,
+		/// `thermal_wind_erosion`, `river_network`, `coastline` renverront
+		/// alors `Failed`.
+		void Draw(engine::editor::world::WorldEditorShell& shell,
+			const engine::core::Config* cfg);
 
 	private:
 		/// État interne de la popup. Pas exposé en public pour garder le
@@ -63,13 +72,15 @@ namespace engine::editor::world::zone_presets
 			Result  = 1,  ///< résumé post-exécution
 		};
 
-		void DrawSelectScreen(engine::editor::world::WorldEditorShell& shell);
+		void DrawSelectScreen(engine::editor::world::WorldEditorShell& shell,
+			const engine::core::Config* cfg);
 		void DrawResultScreen();
 
 		/// Exécute le preset sélectionné. Renseigne `m_lastSummary` et
 		/// bascule l'écran à `Result`. Le main thread ImGui est bloqué
 		/// pendant la durée — comportement attendu.
-		void RunSelectedPreset(engine::editor::world::WorldEditorShell& shell);
+		void RunSelectedPreset(engine::editor::world::WorldEditorShell& shell,
+			const engine::core::Config* cfg);
 
 		/// `true` au prochain frame quand `Open()` a été appelé — pousse
 		/// `ImGui::OpenPopup` une seule fois puis remet à `false`.

--- a/src/world_editor/zone_presets/ZonePresetExecutor.cpp
+++ b/src/world_editor/zone_presets/ZonePresetExecutor.cpp
@@ -13,7 +13,6 @@ namespace engine::editor::world::zone_presets
 		const CustomizationParams& custom,
 		engine::editor::world::CommandStack& commandStack,
 		const DispatchContext& dispatchCtx,
-		engine::editor::world::WaterDocument& water,
 		const ProgressCallback& progressCallback)
 	{
 		m_cancelRequested.store(false, std::memory_order_release);
@@ -22,7 +21,7 @@ namespace engine::editor::world::zone_presets
 		summary.totalSteps = static_cast<uint32_t>(preset.operations.size());
 
 		// 1) Reset destructif de la zone (M100.46 §D.3).
-		ResetEditedZoneDocuments(dispatchCtx.terrain, water,
+		ResetEditedZoneDocuments(dispatchCtx.terrain, dispatchCtx.water,
 			dispatchCtx.meshInserts, dispatchCtx.dungeonPortals);
 		LOG_INFO(EditorWorld, "[ZonePresetExecutor] Zone reset pour '{}' ({} ops)",
 			preset.id, summary.totalSteps);

--- a/src/world_editor/zone_presets/ZonePresetExecutor.cpp
+++ b/src/world_editor/zone_presets/ZonePresetExecutor.cpp
@@ -1,0 +1,79 @@
+#include "src/world_editor/zone_presets/ZonePresetExecutor.h"
+
+#include "src/shared/core/Log.h"
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/zone_presets/WorldMapEditDocumentReset.h"
+
+#include <memory>
+#include <utility>
+
+namespace engine::editor::world::zone_presets
+{
+	ExecutionSummary ZonePresetExecutor::Execute(const ZonePreset& preset,
+		const CustomizationParams& custom,
+		engine::editor::world::CommandStack& commandStack,
+		const DispatchContext& dispatchCtx,
+		engine::editor::world::WaterDocument& water,
+		const ProgressCallback& progressCallback)
+	{
+		m_cancelRequested.store(false, std::memory_order_release);
+
+		ExecutionSummary summary;
+		summary.totalSteps = static_cast<uint32_t>(preset.operations.size());
+
+		// 1) Reset destructif de la zone (M100.46 §D.3).
+		ResetEditedZoneDocuments(dispatchCtx.terrain, water,
+			dispatchCtx.meshInserts, dispatchCtx.dungeonPortals);
+		LOG_INFO(EditorWorld, "[ZonePresetExecutor] Zone reset pour '{}' ({} ops)",
+			preset.id, summary.totalSteps);
+
+		// 2) Boucle d'exécution séquentielle.
+		for (uint32_t i = 0; i < summary.totalSteps; ++i)
+		{
+			if (IsCancelRequested())
+			{
+				summary.wasCancelled = true;
+				LOG_INFO(EditorWorld, "[ZonePresetExecutor] Annulé après {} ops", i);
+				break;
+			}
+
+			const ZonePresetOperation& op = preset.operations[i];
+			std::unique_ptr<engine::editor::world::ICommand> cmd;
+			const DispatchResult result = DispatchOperation(op, custom, dispatchCtx, cmd);
+
+			switch (result)
+			{
+				case DispatchResult::Ok:
+					commandStack.Push(std::move(cmd));
+					++summary.commandsPushed;
+					break;
+				case DispatchResult::Unsupported:
+					++summary.unsupportedSkipped;
+					break;
+				case DispatchResult::Failed:
+					++summary.failed;
+					break;
+			}
+
+			if (progressCallback)
+			{
+				ExecutionProgress prog;
+				prog.currentStep      = i + 1u;
+				prog.totalSteps       = summary.totalSteps;
+				prog.currentStepLabel = "Étape " + std::to_string(i + 1u)
+					+ "/" + std::to_string(summary.totalSteps) + " : " + op.type;
+				prog.fractionComplete = static_cast<float>(i + 1u)
+					/ static_cast<float>(summary.totalSteps);
+				prog.isCancelled      = IsCancelRequested();
+				const bool keepGoing = progressCallback(prog);
+				if (!keepGoing) RequestCancel();
+			}
+		}
+
+		LOG_INFO(EditorWorld,
+			"[ZonePresetExecutor] '{}' terminé : {} commandes / {} skipped (non câblés) / {} failed{}",
+			preset.id, summary.commandsPushed, summary.unsupportedSkipped, summary.failed,
+			summary.wasCancelled ? " (annulé)" : "");
+		return summary;
+	}
+}

--- a/src/world_editor/zone_presets/ZonePresetExecutor.h
+++ b/src/world_editor/zone_presets/ZonePresetExecutor.h
@@ -12,7 +12,6 @@
 namespace engine::editor::world
 {
 	class CommandStack;
-	class WaterDocument;
 }
 
 namespace engine::editor::world::zone_presets
@@ -33,12 +32,12 @@ namespace engine::editor::world::zone_presets
 	{
 		uint32_t totalSteps         = 0u;
 		uint32_t commandsPushed     = 0u; ///< nombre d'ICommand vraiment exécutées
-		uint32_t unsupportedSkipped = 0u; ///< type connu mais pas câblé (incrément 2b)
+		uint32_t unsupportedSkipped = 0u; ///< type connu mais pas câblé (incrément 2d)
 		uint32_t failed             = 0u; ///< dispatch failed (catalog introuvable, etc.)
 		bool     wasCancelled       = false;
 	};
 
-	/// Moteur d'exécution d'un zone preset (M100.46 incrément 2b).
+	/// Moteur d'exécution d'un zone preset (M100.46 incréments 2b + 2d).
 	///
 	/// Workflow (cf. spec §D) :
 	///   1. Vide la zone (`ResetEditedZoneDocuments`) — destructif en MVP.
@@ -50,11 +49,14 @@ namespace engine::editor::world::zone_presets
 	///      d. arrêt si `progressCallback` retourne false OU si
 	///         `RequestCancel()` a été appelé entretemps.
 	///
-	/// Une opération non supportée par le dispatcher (11 des 14 types en
-	/// MVP incrément 2b) est ignorée silencieusement avec un log info,
-	/// conformément au comportement du spec pour la section `decoration`
-	/// avec types inconnus. Le compteur `unsupportedSkipped` du résumé
-	/// permet à l'UI d'informer l'utilisateur.
+	/// Types câblés (incréments 2b + 2c + 2d) : `place_cave`, `place_overhang`,
+	/// `place_arch`, `place_dungeon`, `mountain_macro`, `valley_macro`,
+	/// `lake_polygon`, `river_manual` (8 sur 14). Les 4 restants
+	/// (`coastline`, `river_network`, `hydraulic_erosion`,
+	/// `thermal_wind_erosion`) sont ignorés silencieusement avec un log info
+	/// (besoin d'extraire la simulation des Tools UI — itération 2e+). Le
+	/// compteur `unsupportedSkipped` du résumé permet à l'UI d'informer
+	/// l'utilisateur.
 	class ZonePresetExecutor
 	{
 	public:
@@ -64,12 +66,13 @@ namespace engine::editor::world::zone_presets
 
 		/// Exécute `preset`. `commandStack` reçoit les commandes (une par
 		/// opération supportée). `progressCallback` peut être nul. Renvoie
-		/// un résumé d'exécution.
+		/// un résumé d'exécution. Les 4 documents (terrain, water,
+		/// meshInserts, dungeonPortals) sont accédés via `dispatchCtx` —
+		/// utilisés à la fois pour le reset initial et par les dispatchers.
 		ExecutionSummary Execute(const ZonePreset& preset,
 			const CustomizationParams& custom,
 			engine::editor::world::CommandStack& commandStack,
 			const DispatchContext& dispatchCtx,
-			engine::editor::world::WaterDocument& water,
 			const ProgressCallback& progressCallback);
 
 		/// Demande l'arrêt de l'exécution en cours. Appelable depuis le

--- a/src/world_editor/zone_presets/ZonePresetExecutor.h
+++ b/src/world_editor/zone_presets/ZonePresetExecutor.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "src/world_editor/zone_presets/CustomizationApplier.h"
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace engine::editor::world
+{
+	class CommandStack;
+	class WaterDocument;
+}
+
+namespace engine::editor::world::zone_presets
+{
+	/// État d'avancement transmis au progressCallback de l'exécuteur
+	/// (M100.46 §D.1).
+	struct ExecutionProgress
+	{
+		uint32_t    currentStep      = 0u;
+		uint32_t    totalSteps       = 0u;
+		std::string currentStepLabel; ///< « Étape 3/8 : place_cave »
+		float       fractionComplete = 0.0f;
+		bool        isCancelled      = false;
+	};
+
+	/// Résumé d'exécution renvoyé par `Execute`.
+	struct ExecutionSummary
+	{
+		uint32_t totalSteps         = 0u;
+		uint32_t commandsPushed     = 0u; ///< nombre d'ICommand vraiment exécutées
+		uint32_t unsupportedSkipped = 0u; ///< type connu mais pas câblé (incrément 2b)
+		uint32_t failed             = 0u; ///< dispatch failed (catalog introuvable, etc.)
+		bool     wasCancelled       = false;
+	};
+
+	/// Moteur d'exécution d'un zone preset (M100.46 incrément 2b).
+	///
+	/// Workflow (cf. spec §D) :
+	///   1. Vide la zone (`ResetEditedZoneDocuments`) — destructif en MVP.
+	///   2. Boucle sur `preset.operations` :
+	///      a. dispatch → `ICommand` (ou skip si non supporté/failed).
+	///      b. push sur le `CommandStack` (= Execute + permet Ctrl+Z par
+	///         étape).
+	///      c. progressCallback invoqué synchrone après chaque étape.
+	///      d. arrêt si `progressCallback` retourne false OU si
+	///         `RequestCancel()` a été appelé entretemps.
+	///
+	/// Une opération non supportée par le dispatcher (11 des 14 types en
+	/// MVP incrément 2b) est ignorée silencieusement avec un log info,
+	/// conformément au comportement du spec pour la section `decoration`
+	/// avec types inconnus. Le compteur `unsupportedSkipped` du résumé
+	/// permet à l'UI d'informer l'utilisateur.
+	class ZonePresetExecutor
+	{
+	public:
+		using ProgressCallback = std::function<bool(const ExecutionProgress&)>;
+
+		ZonePresetExecutor() = default;
+
+		/// Exécute `preset`. `commandStack` reçoit les commandes (une par
+		/// opération supportée). `progressCallback` peut être nul. Renvoie
+		/// un résumé d'exécution.
+		ExecutionSummary Execute(const ZonePreset& preset,
+			const CustomizationParams& custom,
+			engine::editor::world::CommandStack& commandStack,
+			const DispatchContext& dispatchCtx,
+			engine::editor::world::WaterDocument& water,
+			const ProgressCallback& progressCallback);
+
+		/// Demande l'arrêt de l'exécution en cours. Appelable depuis le
+		/// thread UI. L'arrêt prend effet **après** la commande courante
+		/// (pas en plein milieu d'une simulation). Les commandes déjà
+		/// poussées restent sur le stack — annulables individuellement.
+		void RequestCancel() { m_cancelRequested.store(true, std::memory_order_release); }
+
+		bool IsCancelRequested() const noexcept
+		{
+			return m_cancelRequested.load(std::memory_order_acquire);
+		}
+
+	private:
+		std::atomic<bool> m_cancelRequested{ false };
+	};
+}


### PR DESCRIPTION
## Résumé

PR qui regroupe :
- **M100.46 incrément 2b** — moteur d'exécution (Reset + dispatcher + executor).
- **M100.46 incrément 2d** — câblage de 4 ops supplémentaires (8/14 maintenant).
- **M100.46 incrément 3** — UI : popup modale ZonePresetDialog + entrée menu Fichier.
- **Convention de découpage monde** — figée à `cell_<N|S>DDD_<E|W>DDD` avec Oracle = `cell_n000_e000`.

---

## 1. M100.46 incrément 2b — moteur d'exécution

### `Reset()` sur les 4 documents (header-only, inline)
- `TerrainDocument::Reset()` : vide `m_chunks` + `m_splats` (lazy reload).
- `WaterDocument::Reset()` : `m_scene` + `m_ocean` au défaut, `m_dirty`.
- `MeshInsertDocument::Reset()` : instances cleared, guid 0, dirty.
- `DungeonPortalDocument::Reset()` : idem.

### `zone_presets/WorldMapEditDocumentReset.{h,cpp}`
Helper qui appelle `Reset()` sur les 4 docs.

### `zone_presets/OperationDispatcher.{h,cpp}`
- `DispatchContext` : refs docs + 4 catalogs (cave, overhang, arch, dungeon).
- `DispatchOperation(op, custom, ctx, &outCmd) → Ok / Unsupported / Failed`.
- Câblé end-to-end : `place_cave`, `place_overhang`, `place_arch`, `place_dungeon`.

### `zone_presets/ZonePresetExecutor.{h,cpp}`
- Orchestre : Reset → boucle ops → dispatch → push `CommandStack` → progressCallback → cancel après op courante.
- `RequestCancel()` thread-safe (atomic).
- `ExecutionSummary` : `totalSteps`, `commandsPushed`, `unsupportedSkipped`, `failed`, `wasCancelled`.

---

## 2. M100.46 incrément 2d — 4 ops de plus câblés

Audit des 8 commandes de tools terrain/water existants : seules `AddLakeCommand` et `AddRiverCommand` sont 100% headless. `MountainRangeCommand` et `ValleyChainCommand` prennent des `SparseChunkDeltas` pré-rasterisés → wrappers via `RasterizeMacroPolyline`. Les 4 autres (`coastline`, `river_network`, `hydraulic_erosion`, `thermal_wind_erosion`) prennent en entrée des **résultats** de simulation — il faut extraire les simulations des Tools UI pour les câbler, ce qui est repoussé à un incrément 2e+.

Câblés en 2d :
- **`mountain_macro`** : wrapper polyline (flat `[x0,z0,x1,z1,…]`) + scalaires `widthMeters`/`heightMeters` → `MacroPolylineParams` → `RasterizeMacroPolyline(..., invert=false)` → `MountainRangeCommand`.
- **`valley_macro`** : idem avec `invert=true` → `ValleyChainCommand`.
- **`lake_polygon`** : `polygon` flat → `LakeInstance` avec `polygon[i].y = waterLevel` → `AddLakeCommand`.
- **`river_manual`** : `polyline` flat → `RiverInstance` avec defaults `widthMeters=4`/`depthMeters=1`, `Y=0` MVP (TODO : lookup `TerrainDocument::SampleHeight` quand l'API headless existe) → `AddRiverCommand`.

`WaterDocument` déplacé dans `DispatchContext`. `Execute()` perd son paramètre `water` séparé.

**État du dispatcher : 8/14 types câblés.** Les 4 restants restent `Unsupported` + LOG_INFO.

---

## 3. M100.46 incrément 3 — UI dialog modal

### `zone_presets/ZonePresetDialog.{h,cpp}`
Popup modale ImGui qui rend les Zone Presets utilisables depuis l'éditeur monde.

**Architecture** : PIMPL via `std::unique_ptr<ZonePresetDialog>` dans `WorldEditorImGui` pour éviter d'exposer `imgui.h` dans l'API publique du wrapper. Header avec forward decl uniquement.

**Deux écrans** :
- **Sélection** : liste à gauche (8 presets chargés depuis `editor/zone_presets/*.json`), détails à droite (nom, id, nb d'ops, durée estimée, description FR), 3 sliders `0.25x..2.0x` (relief / densité d'eau / sécheresse) + `InputInt` pour le seed (défaut 12345). Boutons `Appliquer` / `Annuler`.
- **Résultat** : résumé `totalSteps / commandsPushed / unsupportedSkipped / failed / durée ms` + note explicite quand des ops ont été skipped (explique que les 4 manquantes arrivent en 2e+). Boutons `Retour à la sélection` / `Fermer`.

### Câblage
- `WorldEditorImGui::SetWorldEditorShell(WorldEditorShell*)` : nouveau setter, miroir du pattern `SetDayNightCycle` / `SetTexturePreviewCache`. Le dialog est instancié dans `SetEditorContext`.
- `BuildUi` dessine la popup juste après `EndMainMenuBar`.
- Entrée menu `Fichier > "Appliquer un preset de zone..."` désactivée tant que le Shell n'est pas branché.
- `Engine.cpp` : appelle `SetWorldEditorShell(m_worldEditorShell.get())` au boot `--editor-world`.

### Single-thread (assumé)
`ZonePresetExecutor::Execute()` est synchrone et bloque le main thread ImGui pendant la durée (architecture éditeur single-thread, cf. ZonePresetExecutor.h). Le callback de progression renseigne le log mais ne peut pas redessiner ImGui pendant l'appel. Comportement attendu — si une frame Linux freeze de 200ms gène pendant un preset 60-ops, on bascule sur un worker thread + queue main thread dans un incrément futur.

### Avertissement utilisateur
Banner explicite avant Apply : « terrain / water / mesh inserts / portails de donjon **seront vidés** avant exécution. Sauvegardez d'abord. »

---

## 4. Convention de découpage monde

- **`docs/world_cell_grid_convention.md`** : convention figée pour les 1320 cellules (33 × 40), origine Oracle au centre logique de l'empire, taille de cellule = 10 km × 10 km (= `kZoneSize`). Format `cell_<N|S>DDD_<E|W>DDD` tout en minuscules (imposé par `SanitizeZoneId`). Mapping ↔ ancienne grille `R###C###` + politique « pas de pré-création massive ».
- **`game/data/zones/cell_n000_e000/`** : prototype Oracle avec `runtime_manifest.json` v3 minimal + `.gitkeep`. Sert de modèle pour les futures cellules.

---

## Tests

`zone_presets_tests` — total **36 tests** :
- Existant (30) : parse / validate / registry / OperationParams / CustomizationApplier / Reset / Dispatcher place_* / Executor.
- Nouveau 2d (6) : mountain_macro rasterize + bad polyline / valley_macro label / lake_polygon build + degenerate / river_manual build.

Pas de tests automatisés pour le dialog UI (couplage ImGui lourd ; setup Shell complet trop coûteux pour le gain). La logique d'exécution sous-jacente est déjà couverte par les tests Executor.

Validation syntaxique passée localement sur les fichiers modifiés ; CI Linux + Windows feront le test complet (CI précédente verte sur 2b+2d).

---

## Reste M100.46

| Incrément | Contenu |
|---|---|
| 2e+ | Wiring `coastline`, `river_network`, `hydraulic_erosion`, `thermal_wind_erosion`. Demande d'extraire les simulations (`HydraulicSimulation::Run`, `RiverNetworkGenerator::Run`, etc.) des Tools UI pour qu'elles s'invoquent sans UI. |
| 4 | Progress bar live pendant Execute (impose un worker thread). |
| (art) | 8 thumbnails PNG. |

---

## Déploiement

> **Déploiement** : ✅ client/éditeur + content uniquement. Aucun changement serveur, aucun format binaire.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] `ctest -R zone_presets_tests` passe (36 tests)
- [ ] Manuel Windows : lancer `lcdlln_world_editor.exe` → menu Fichier > « Appliquer un preset de zone... » → choisir `temperate_forest` → cliquer Appliquer → vérifier que :
  - le terrain devient non-vide (mountain_macro a sculpté des collines au sud),
  - un lac apparaît (lake_polygon),
  - les logs `[ZonePresetExecutor]` montrent `pushed >= 3, skipped >= 2` (l'hydraulic_erosion est encore skipped).
- [ ] Manuel : tester avec `cell_n000_e000` (Oracle) après l'avoir ouvert dans l'éditeur.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_