### PR TITLE
fix(client/boot): retirer le decal de test visible au premier écran

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3078,15 +3078,6 @@ namespace engine
 											}
 										}
 										m_decalSystem.Init(m_cfg, m_assetRegistry);
-										{
-											engine::render::DecalComponent decal{};
-											decal.center = { 0.0f, 0.05f, 0.0f };
-											decal.halfExtents = { 2.0f, 1.0f, 2.0f };
-											decal.albedoTexturePath = "textures/test.texr";
-											decal.lifetimeSeconds = 30.0f;
-											decal.fadeDurationSeconds = 5.0f;
-											m_decalSystem.Spawn(decal);
-										}
 
 										{
 											std::string lutPath = m_cfg.GetString("color_grading.lut_path", "");


### PR DESCRIPTION
## Symptôme

Au tout premier écran du client (avant l'apparition de l'UI auth), un rectangle blanc apparaissait brièvement sur l'écran noir.

## Cause

Un decal de test était spawné **inconditionnellement** au boot à l'origine du monde (`Engine.cpp:3081-3089`) :
- Position : `(0, 0.05, 0)`, demi-extents `(2, 1, 2)` → boîte 4×2×4 m projetée sur le sol
- Texture : `textures/test.texr` (1×1 blanc — texture de test générique)
- Durée : 30 s avec fondu 5 s

Visible le temps que l'UI auth (background + logo) finisse d'être uploadée sur le GPU.

## Fix

Retrait des 9 lignes de spawn. Le `DecalSystem::Init` au-dessus reste en place pour les decals « vrais » (AoE preview, decals d'éditeur monde, etc.).

## Pour aller plus loin (hors scope de cette PR)

Si tu veux remplacer le bref écran noir par un splash logo, c'est un chantier UX plus large : afficher un overlay logo plein écran tant que `m_authUiBackgroundTexture` / les assets auth ne sont pas prêts à être présentés. À traiter dans un ticket dédié si souhaité.

## Test plan

- [ ] Build Windows.
- [ ] Lancer le client : pas de rectangle blanc au boot ; transition directe écran noir → écran d'auth.
- [ ] Aucune régression sur le `DecalSystem` (AoE preview, decals d'éditeur monde restent fonctionnels).

---

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur. Pas de migration DB, pas de changement de protocole.


---
_Generated by [Claude Code](https://claude.ai/code/session_019k8ouJtnD69AzaBBy9M9mC)_