### PR TITLE
fix(client/app): auto-activate WorldEditorShell when --world-editor (unblocks Zone Presets menu)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -668,8 +668,18 @@ namespace engine
 		// --world-editor qui active le shell M43.x). Activée par le flag CLI
 		// --editor-world ou par editor.world.enabled = true dans config.json.
 		// Les deux shells peuvent cohabiter pendant la transition.
+		//
+		// **Auto-activation pour `lcdlln_world_editor.exe`** : depuis M100.46
+		// incrément 3 (dialog Zone Presets), l'éditeur monde a besoin du
+		// `WorldEditorShell` pour résoudre les 4 documents + 4 catalogs. Sans
+		// le Shell, l'entrée menu « Appliquer un preset de zone… » est grisée
+		// (m_shell nul). Le binaire `--world-editor` implique donc
+		// `--editor-world` par défaut. La warning « deux shells coexistent »
+		// reste loguée plus bas en info — c'est attendu.
 		const bool worldEditorWorldFlag =
-			HasCliFlag(argc, argv, "--editor-world") || m_cfg.GetBool("editor.world.enabled", false);
+			HasCliFlag(argc, argv, "--editor-world")
+			|| m_cfg.GetBool("editor.world.enabled", false)
+			|| m_worldEditorExe;
 
 		if (m_worldEditorExe)
 		{
@@ -751,10 +761,19 @@ namespace engine
 		// public si un sous-système a besoin de le savoir.
 		if (worldEditorWorldFlag)
 		{
-			if (m_worldEditorExe)
+			// `--world-editor` implique désormais `--editor-world` (M100.46
+			// incrément 3 — la dialog Zone Presets exige le Shell). On
+			// log seulement si l'utilisateur a explicitement combiné les
+			// deux flags ou réglé `editor.world.enabled = true` ET lancé
+			// l'exe éditeur — pour signaler la coexistence des deux shells
+			// (M43.x toolbar + M100.1 WorldEditorShell).
+			const bool worldEditorWorldExplicit =
+				HasCliFlag(argc, argv, "--editor-world")
+				|| m_cfg.GetBool("editor.world.enabled", false);
+			if (m_worldEditorExe && worldEditorWorldExplicit)
 			{
-				LOG_WARN(Core,
-					"[Boot] --world-editor ET --editor-world activés — cas non-supporté ; les deux shells vont coexister");
+				LOG_INFO(Core,
+					"[Boot] --world-editor + --editor-world (ou editor.world.enabled) — les deux shells coexistent");
 			}
 			if (m_editorMode)
 			{


### PR DESCRIPTION
## Bug observé

Depuis M100.46 incrément 3, l'entrée menu `Fichier > Appliquer un preset de zone...` reste **grisée** dans `lcdlln_world_editor.exe` parce que le `WorldEditorShell` n'est pas instancié.

Capture du symptôme :

> Menu Fichier ouvert, l'entrée "Appliquer un preset de zone..." est inactive (texte grisé).

## Cause racine

Deux flags distincts cohabitent depuis M43.x :

| Flag | Variable | Rôle |
|------|----------|------|
| `--world-editor` | `m_worldEditorExe` | binaire éditeur monde (UI ImGui, Vulkan, pas d'auth client) |
| `--editor-world` | `worldEditorWorldFlag` | couche additionnelle `WorldEditorShell` (4 documents + 4 catalogs + CommandStack) |

Pré-M100.46, ils étaient mutuellement exclusifs : binaire éditeur OU shell, pas les deux. Depuis **M100.46 incrément 3**, la dialog Zone Presets a besoin du Shell pour résoudre les documents et catalogs au moment de l'exécution du preset (cf. `WorldEditorImGui::SetWorldEditorShell` câblé dans `Engine.cpp:5494`).

Quand l'utilisateur lance `lcdlln_world_editor.exe` **sans** `--editor-world` ni `editor.world.enabled: true` :

1. `m_worldEditorExe = true` → `WorldEditorImGui::Init` + `SetEditorContext`.
2. `worldEditorWorldFlag = false` → `m_worldEditorShell` jamais instancié.
3. `SetWorldEditorShell(m_worldEditorShell.get())` reçoit `nullptr`.
4. `m_shell == nullptr` → `ImGui::MenuItem(... enabled=false)` → grisé.

## Fix

`--world-editor` **implique désormais `--editor-world`** :

```cpp
const bool worldEditorWorldFlag =
    HasCliFlag(argc, argv, "--editor-world")
    || m_cfg.GetBool("editor.world.enabled", false)
    || m_worldEditorExe;  // M100.46 incr 3 : Shell requis par Zone Presets.
```

La warning `--world-editor ET --editor-world activés — cas non-supporté` est dégradée en `LOG_INFO` et déclenchée seulement quand l'utilisateur a **explicitement** combiné les deux flags (ou activé `editor.world.enabled = true`) en plus du binaire éditeur. Le cas "binaire éditeur seul" ne logue plus rien — il instancie juste le Shell silencieusement.

## Impact

- `lcdlln_world_editor.exe` boote désormais avec le Shell activé → menu Zone Presets **actif** → dialog ouvrable → terraformation par preset fonctionnelle end-to-end.
- Aucune régression : les autres modes (`--editor-world` côté serveur, client jeu sans flag) ne sont pas touchés.
- Aucun changement de format binaire, aucun opcode, aucun handler.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] **Manuel critique** : `lcdlln_world_editor.exe` (sans flag, sans modif config.json) → menu `Fichier` contient `Appliquer un preset de zone...` **actif** (non grisé) → clic ouvre la modale → choisir `temperate_forest` → Appliquer → terraformation appliquée.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_