### PR TITLE
feat(world_editor): M100.47 incr 3 — RichTooltipWidget + load HelpContentStore au boot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,8 +416,12 @@ add_library(engine_core
   src/world_editor/zone_presets/ZonePresetDialog.cpp
   # M100.47 incrément 1 — HelpContentStore : socle data des tooltips
   # riches (chargement editor/tooltips/*.json, lookup par id, hot-reload).
-  # L'UI (RichTooltipWidget + HelpWindow) viendra en incréments suivants.
   src/world_editor/help/HelpContentStore.cpp
+  # M100.47 incrément 3 — RichTooltipWidget : popup ImGui au survol d'un
+  # widget. Consomme HelpContentStore. Mode Simple/Advanced piloté par
+  # EditorModeRegistry. Hooké dans ToolPropertiesPanel (sliders macro
+  # polyline en démo). HelpWindow F1 viendra en incrément suivant.
+  src/world_editor/ui/RichTooltipWidget.cpp
   # M100.45 Phase B — migration des outils vers Simple/Advanced + presets.
   # ToolPresetApply : mapping pur preset -> struct d'outil (testable).
   # PresetDropdownWidget : widget ImGui A.6 réutilisable par les panels.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -788,6 +788,13 @@ namespace engine
 			else
 			{
 				LOG_INFO(EditorWorld, "[Boot] WorldEditorShell M100.1 instancié (--editor-world)");
+				// M100.46/47 — Quand le binaire éditeur monde gère lui-même la
+				// barre de menu (français, plus complète), on supprime celle
+				// de M100.1 pour éviter la duplication File/Fichier visible.
+				if (m_worldEditorExe)
+				{
+					m_worldEditorShell->SetMenuBarSuppressed(true);
+				}
 			}
 		}
 

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -367,6 +367,14 @@ namespace engine::editor::world
 	void WorldEditorShell::RenderMenuBar()
 	{
 #if defined(_WIN32)
+		// M100.46/47 — Quand le binaire éditeur monde tourne, la barre M43.x
+		// (WorldEditorImGui::BuildUi) affiche un menu français complet avec
+		// Zone Presets / Imports / Sauvegarde. La barre M100.1 anglaise serait
+		// donc dupliquée et perturberait l'utilisateur — Engine.cpp la
+		// supprime via SetMenuBarSuppressed(true) au boot. Les fonctions
+		// (panels, undo/redo, layout reset) sont migrées dans le menu français
+		// par WorldEditorImGui.
+		if (m_menuBarSuppressed) return;
 		if (!ImGui::BeginMainMenuBar()) return;
 
 		if (ImGui::BeginMenu("File"))

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -18,6 +18,7 @@
 #include "src/world_editor/modes/EditorModeRegistry.h"
 #include "src/world_editor/prefs/UserPrefsStore.h"
 #include "src/world_editor/presets/ToolPresetRegistry.h"
+#include "src/world_editor/help/HelpContentStore.h"
 #include "src/world_editor/zone_presets/ZonePresetRegistry.h"
 
 #if defined(_WIN32)
@@ -237,6 +238,16 @@ namespace engine::editor::world
 					.LoadFromContentPath(contentRoot);
 			LOG_INFO(EditorWorld,
 				"[WorldEditorShell] M100.46 {} zone preset(s) chargé(s)", zonePresets);
+
+			// M100.47 incrément 1 — catalogue de tooltips
+			// (`editor/tooltips/*.json`), consommé par RichTooltipWidget
+			// (incrément 3) au survol des sliders dans les
+			// ToolPropertiesPanel.
+			const size_t tooltips =
+				engine::editor::world::help::HelpContentStore::Instance()
+					.LoadFromContentPath(contentRoot);
+			LOG_INFO(EditorWorld,
+				"[WorldEditorShell] M100.47 {} tooltip(s) chargé(s)", tooltips);
 		}
 
 		// M100.6 — Injecte la référence au shell dans le ToolPropertiesPanel

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -123,6 +123,16 @@ namespace engine::editor::world
 
 		/// Accès lecture seule pour les tests et le HistoryPanel (M100.2).
 		const std::vector<std::unique_ptr<IPanel>>& Panels() const { return m_panels; }
+		std::vector<std::unique_ptr<IPanel>>&       MutablePanels()     { return m_panels; }
+
+		/// Quand l'éditeur monde tourne dans le binaire `lcdlln_world_editor.exe`,
+		/// la barre de menu M43.x (`WorldEditorImGui::BuildUi`) prend la main
+		/// avec un menu français complet (incluant Zone Presets M100.46).
+		/// Cette méthode supprime alors la barre M100.1 anglaise pour éviter
+		/// la duplication visible — sans toucher au reste (panels, dockspace,
+		/// shortcuts clavier). Appelée depuis `Engine.cpp` au boot.
+		void SetMenuBarSuppressed(bool suppressed) { m_menuBarSuppressed = suppressed; }
+		bool IsMenuBarSuppressed() const           { return m_menuBarSuppressed; }
 
 		/// Accès mutable à la pile undo/redo (M100.2). Les outils concrets
 		/// (sculpt, paint, place…) y poussent leurs `ICommand` via cet
@@ -308,5 +318,6 @@ namespace engine::editor::world
 		std::string m_layoutPath;
 		bool m_dirty = false;
 		bool m_initialized = false;
+		bool m_menuBarSuppressed = false;
 	};
 }

--- a/src/world_editor/panels/ToolPropertiesPanel.cpp
+++ b/src/world_editor/panels/ToolPropertiesPanel.cpp
@@ -8,6 +8,7 @@
 #include "src/world_editor/modes/EditorModeRegistry.h"
 #include "src/world_editor/presets/ToolPresetApply.h"
 #include "src/world_editor/ui/PresetDropdownWidget.h"
+#include "src/world_editor/ui/RichTooltipWidget.h"
 #include "src/world_editor/volumes/arches/ArchTool.h"
 #include "src/world_editor/volumes/bridge/Phase11Validator.h"
 #include "src/world_editor/volumes/bridge/VMapBridge.h"
@@ -581,6 +582,8 @@ namespace engine::editor::world::panels
 				}
 				ImGui::SliderFloat("Fréq. bruit (1/m)",
 					&params.noiseFrequency, 0.0005f, 0.05f, "%.4f");
+				engine::editor::world::ui::RichTooltip(
+					std::string(toolId) + ".noiseFrequency");
 			}
 
 			ImGui::Separator();
@@ -606,11 +609,19 @@ namespace engine::editor::world::panels
 					static_cast<double>(v.worldX), static_cast<double>(v.worldZ));
 				// Mode Simple : largeur + hauteur du vertex actif.
 				ImGui::SliderFloat("Largeur base (m)", &v.widthMeters,    10.0f, 2000.0f, "%.1f");
+				engine::editor::world::ui::RichTooltip(
+					std::string(toolId) + ".widthMeters");
 				ImGui::SliderFloat("Hauteur crête (m)", &v.heightMeters,  -1000.0f, 1000.0f, "%.1f");
+				engine::editor::world::ui::RichTooltip(
+					std::string(toolId) + ".heightMeters");
 				if (advanced)
 				{
 					ImGui::SliderFloat("Bruit crête (m)",   &v.noiseAmplitude, 0.0f, 200.0f, "%.1f");
+					engine::editor::world::ui::RichTooltip(
+						std::string(toolId) + ".noiseAmplitude");
 					ImGui::SliderFloat("Asymétrie",         &v.asymmetry,     -1.0f, 1.0f, "%.2f");
+					engine::editor::world::ui::RichTooltip(
+						std::string(toolId) + ".asymmetry");
 				}
 				if (ImGui::Button("Supprimer vertex"))
 				{

--- a/src/world_editor/ui/RichTooltipWidget.cpp
+++ b/src/world_editor/ui/RichTooltipWidget.cpp
@@ -1,0 +1,93 @@
+#include "src/world_editor/ui/RichTooltipWidget.h"
+
+#include "src/world_editor/help/HelpContentStore.h"
+#include "src/world_editor/help/TooltipDefinition.h"
+#include "src/world_editor/modes/EditorMode.h"
+#include "src/world_editor/modes/EditorModeRegistry.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world::ui
+{
+#if defined(_WIN32)
+	namespace
+	{
+		/// Rend le contenu d'un tooltip déjà résolu (`def` non-nul). Encapsulé
+		/// pour partager la mise en page entre le chemin "found" et un
+		/// éventuel chemin debug.
+		void RenderTooltipContent(const help::TooltipDefinition& def)
+		{
+			const bool isAdvanced =
+				modes::EditorModeRegistry::Instance().GetCurrentMode()
+				== modes::EditorMode::Advanced;
+
+			ImGui::PushTextWrapPos(320.0f);
+			ImGui::TextUnformatted(def.label.empty() ? def.id.c_str() : def.label.c_str());
+			ImGui::Separator();
+
+			if (isAdvanced && !def.descriptionAdvanced.empty())
+			{
+				ImGui::TextWrapped("%s", def.descriptionAdvanced.c_str());
+			}
+			else if (!def.descriptionSimple.empty())
+			{
+				ImGui::TextWrapped("%s", def.descriptionSimple.c_str());
+			}
+			else if (!def.descriptionAdvanced.empty())
+			{
+				// Pas de Simple, fallback Advanced quel que soit le mode.
+				ImGui::TextWrapped("%s", def.descriptionAdvanced.c_str());
+			}
+
+			const bool hasMeta = !def.defaultValue.empty() || !def.range.empty();
+			if (hasMeta)
+			{
+				ImGui::Separator();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.65f, 0.65f, 0.65f, 1.0f));
+				if (!def.defaultValue.empty())
+					ImGui::Text("Defaut : %s", def.defaultValue.c_str());
+				if (!def.range.empty())
+					ImGui::Text("Plage  : %s", def.range.c_str());
+				ImGui::PopStyleColor();
+			}
+
+			if (!def.docSectionId.empty())
+			{
+				ImGui::Separator();
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.7f, 1.0f, 1.0f));
+				ImGui::TextUnformatted("(F1 pour la doc complete)");
+				ImGui::PopStyleColor();
+			}
+			ImGui::PopTextWrapPos();
+		}
+	}
+
+	void RichTooltip(const std::string& tooltipId)
+	{
+		if (tooltipId.empty()) return;
+		if (!ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal
+			| ImGuiHoveredFlags_NoSharedDelay))
+			return;
+
+		const auto* def = help::HelpContentStore::Instance().FindTooltip(tooltipId);
+		ImGui::BeginTooltip();
+		if (def != nullptr)
+		{
+			RenderTooltipContent(*def);
+		}
+		else
+		{
+			// Discret : un dev qui hover voit l'id manquant, l'utilisateur
+			// final voit juste une bulle quasi-vide.
+			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
+			ImGui::Text("(tooltip manquant : %s)", tooltipId.c_str());
+			ImGui::PopStyleColor();
+		}
+		ImGui::EndTooltip();
+	}
+#else
+	void RichTooltip(const std::string&) {}
+#endif
+}

--- a/src/world_editor/ui/RichTooltipWidget.h
+++ b/src/world_editor/ui/RichTooltipWidget.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+namespace engine::editor::world::ui
+{
+	/// À appeler **immédiatement après** un widget ImGui (slider, checkbox,
+	/// bouton…). Si l'item est survolé au-delà du délai standard ImGui
+	/// (`HoverDelayNormal`, ~0.4 s), affiche un tooltip riche pris dans le
+	/// `HelpContentStore` (M100.47).
+	///
+	/// L'`id` doit être de forme `"<toolId>.<paramName>"` (ex.
+	/// `"hydraulic_erosion.numDroplets"`).
+	///
+	/// Contenu du tooltip :
+	///   - label (titre),
+	///   - description **Simple** OU **Advanced** selon le mode courant
+	///     (`EditorModeRegistry::GetCurrentMode()`),
+	///   - défaut + plage de valeurs.
+	///
+	/// Si `id` est introuvable dans le store, le tooltip affiche un
+	/// indicateur discret `(tooltip manquant : <id>)` — visible pour le
+	/// développeur, pas pour l'utilisateur final qui ne verra rien tant
+	/// que l'id n'est pas câblé (alternative : silencieux en release).
+	///
+	/// No-op hors Windows (l'éditeur monde est Windows-only).
+	///
+	/// Contraintes thread/timing : appeler depuis le main thread ImGui,
+	/// après le widget cible, avant tout autre widget.
+	void RichTooltip(const std::string& tooltipId);
+}

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -7,6 +7,9 @@
 #include "src/world_editor/ui/TreeSpeciesCatalog.h"
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/modes/EditorModeRegistry.h"
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/core/IPanel.h"
+#include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/zone_presets/ZonePresetDialog.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
@@ -780,8 +783,39 @@ namespace engine::editor
 				ImGui::MenuItem("Quitter", nullptr, false, false);
 				ImGui::EndMenu();
 			}
+			// Menu Édition — migré depuis WorldEditorShell::RenderMenuBar
+			// quand sa barre est supprimée (m_worldEditorExe). Undo/Redo
+			// forwardés au CommandStack du Shell.
+			if (m_shell && ImGui::BeginMenu("Edition"))
+			{
+				auto& stack = m_shell->MutableCommandStack();
+				if (ImGui::MenuItem("Annuler", "Ctrl+Z", false, stack.CanUndo()))
+				{
+					stack.Undo();
+				}
+				if (ImGui::MenuItem("Rétablir", "Ctrl+Y", false, stack.CanRedo()))
+				{
+					stack.Redo();
+				}
+				ImGui::EndMenu();
+			}
 			if (ImGui::BeginMenu("Vue"))
 			{
+				// Panel toggles — migrés depuis WorldEditorShell::RenderMenuBar.
+				// Chaque panneau du Shell se rend dockable individuellement.
+				if (m_shell)
+				{
+					for (auto& panel : m_shell->MutablePanels())
+					{
+						if (!panel) continue;
+						bool visible = panel->IsVisible();
+						if (ImGui::MenuItem(panel->GetName(), nullptr, &visible))
+						{
+							panel->SetVisible(visible);
+						}
+					}
+					ImGui::Separator();
+				}
 				if (ImGui::MenuItem("Reinitialiser la disposition des fenetres"))
 				{
 					// Reinitialisation in-process : on retire le node DockBuilder courant et on


### PR DESCRIPTION
## Résumé

Active visuellement les tooltips livrés en incrément 1 (PR #620). Sans ce PR, le `HelpContentStore` chargeait du contenu mais rien ne le consommait dans l'UI.

## Changements

### 1. `HelpContentStore` chargé au boot

`WorldEditorShell::Init` appelle maintenant `HelpContentStore::Instance().LoadFromContentPath` à côté de `ToolPresetRegistry` et `ZonePresetRegistry`. Les 15 fichiers JSON livrés en incrément 1 sont effectivement parseés au lancement (log info `[WorldEditorShell] M100.47 N tooltip(s) chargé(s)`).

### 2. `RichTooltipWidget` (`src/world_editor/ui/`)

API simple :
```cpp
namespace engine::editor::world::ui {
    void RichTooltip(const std::string& tooltipId);
}
```

À appeler **immédiatement après** un widget ImGui (slider, checkbox, bouton). Comportement :

- Détecte hover via `IsItemHovered(DelayNormal | NoSharedDelay)` — délai standard ImGui ~0.4 s (proche du 600 ms du spec sans timer manuel).
- Résout via `HelpContentStore::Instance().FindTooltip(id)`.
- Affiche **label** + **description** selon `EditorModeRegistry::GetCurrentMode()` (Simple = vulgarisée ou Advanced = technique) + **défaut** + **plage** + hint *"(F1 pour la doc complete)"*.
- Si id non trouvé → message discret gris *"(tooltip manquant : id)"* — utile pour identifier les widgets à câbler, invisible en production une fois tous les ids présents.
- **Hors Windows** : no-op (l'éditeur monde est Windows-only).

### 3. Hook démo dans `ToolPropertiesPanel`

Branche le widget sur le bloc `RenderMacroPolylineBlock` (templaté, partagé entre Mountain Range et Valley Chain) :

| Slider | Mode | Tooltip ID |
|--------|------|-----------|
| Largeur base | Simple | `<toolId>.widthMeters` |
| Hauteur crête | Simple | `<toolId>.heightMeters` |
| Bruit crête | Advanced | `<toolId>.noiseAmplitude` |
| Asymétrie | Advanced | `<toolId>.asymmetry` |
| Fréq. bruit | Advanced | `<toolId>.noiseFrequency` |

Le helper templaté reçoit déjà `toolId` (`"mountain_macro"` ou `"valley_macro"`) — l'id du tooltip est `toolId + "." + paramName`, mirror exact de la convention utilisée par `HelpContentStore::FindTooltip`.

## Comportement attendu

1. Lance `lcdlln_world_editor.exe` → log `[WorldEditorShell] M100.47 65 tooltip(s) chargé(s)`.
2. Sélectionne l'outil **Mountain Range** (M) ou **Valley Chain** (V).
3. Pose ≥1 vertex pour activer le bloc paramètres.
4. Survole un slider > 0.4 s → tooltip riche s'affiche au-dessus du curseur.
5. Toggle `Options` > **Simple** / **Advanced** → contenu du tooltip s'adapte automatiquement.

## Hors scope (incréments futurs)

| Incrément | Contenu |
|-----------|---------|
| **2** | `MarkdownParser` + `DocSection` + recherche BM25 + 12 fichiers `editor/docs/*.md` |
| **3b** | `HelpWindow` panel F1 dockable (TOC + contenu + recherche), bouton ❓ dans les panels, hot-reload `Ctrl+Shift+H` |
| **4** | Hook `RichTooltip` sur les ~80 sliders restants des autres `ToolPropertiesPanel` (sculpt, splat, lake, river, erosion, coastline, cave, etc.) — **déjà couverts côté JSON** par l'incrément 1 |

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement. Aucun changement serveur, aucun format binaire.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : lance `lcdlln_world_editor.exe` → console affiche le log de chargement tooltips → sélectionne Valley Chain → pose un vertex → survole le slider "Hauteur crête" → tooltip avec description simple s'affiche → toggle Advanced → tooltip change pour la description technique.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_