### PR TITLE
fix(world_editor): bridge TerrainDocument mutations to GPU heightmap (visible commands)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8039,19 +8039,21 @@ namespace engine
 		constexpr float kCell =
 			engine::world::terrain::kTerrainCellSizeMeters;
 
-		// Itère les chunks chargés du document. Chaque cellule (ix, iz) du
-		// chunk a une position monde ; on la convertit en pixel heightmap.
-		// La conversion float (m) → uint16 normalise par heightScale.
+		// Itère **tous les chunks chargés** du document (pas seulement 2×2),
+		// car les zone presets s'appliquent sur 10 km (toute la zone) et
+		// peuvent charger n'importe quelle paire (cx, cz). Pour chaque
+		// cellule (ix, iz), on calcule sa position monde → pixel heightmap.
+		// Conversion float (m) → uint16 normalise par heightScale.
 		uint32_t touchedChunks = 0u;
-		for (int cz = 0; cz < 2; ++cz)
-		{
-			for (int cx = 0; cx < 2; ++cx)
+		uint64_t modifiedCells = 0u;
+		terrainDoc.ForEachLoadedChunk(
+			[&](engine::world::GlobalChunkCoord coord,
+			    const std::shared_ptr<engine::world::terrain::TerrainChunk>& chunk)
 			{
-				auto chunk = terrainDoc.Find({ cx, cz });
-				if (!chunk) continue;
+				if (!chunk) return;
 				++touchedChunks;
-				const float chunkOriginX = static_cast<float>(cx) * (kChunkRes - 1u) * kCell;
-				const float chunkOriginZ = static_cast<float>(cz) * (kChunkRes - 1u) * kCell;
+				const float chunkOriginX = static_cast<float>(coord.x) * (kChunkRes - 1u) * kCell;
+				const float chunkOriginZ = static_cast<float>(coord.z) * (kChunkRes - 1u) * kCell;
 				for (uint32_t iz = 0; iz < kChunkRes; ++iz)
 				{
 					for (uint32_t ix = 0; ix < kChunkRes; ++ix)
@@ -8068,10 +8070,13 @@ namespace engine
 						const float norm = std::clamp(heightMeters / heightScale, 0.0f, 1.0f);
 						const uint16_t u16 = static_cast<uint16_t>(norm * 65535.0f + 0.5f);
 						hm.heights[pz * hmW + px] = u16;
+						++modifiedCells;
 					}
 				}
-			}
-		}
+			});
+		LOG_INFO(EditorWorld,
+			"[Engine] SyncHeightmapFromDocument: {} chunks visited, {} cells written, hm={}x{}, heightScale={:.1f}m",
+			touchedChunks, modifiedCells, hmW, hmH, heightScale);
 		if (touchedChunks == 0u) return;
 
 		// Pousse au GPU. FlushHeightmap re-upload la heightmap CPU complète

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5649,6 +5649,15 @@ namespace engine
 		{
 			RebuildWorldEditorTerrainGpu();
 		}
+		// M100.46+ — Pont TerrainDocument → HeightmapData GPU. Consomme le
+		// flag set par le callback OnChunkChanged et déclenche la copie
+		// chunks → heightmap CPU + FlushHeightmap GPU. Coût ~10-30 ms par
+		// tick concerné (acceptable pour des ops one-shot ; pas atteint par
+		// les brushstrokes interactifs qui ont leur propre path direct).
+		if (m_worldEditorTerrainNeedsSync.exchange(false, std::memory_order_acq_rel))
+		{
+			SyncWorldEditorHeightmapFromDocument();
+		}
 		if (m_worldEditorExe && m_worldEditorSession && m_texturePreviewCache)
 		{
 			for (const std::string& rel : m_worldEditorSession->RecentlyImportedTextures())
@@ -7906,6 +7915,20 @@ namespace engine
 		}
 		m_terrain.InvalidateFramebufferCache(device);
 
+		// M100.46+ — Pont TerrainDocument → HeightmapData GPU. Le callback
+		// est appelé synchrone par OnCommit (thread main) — il ne fait que
+		// set un flag atomique pour différer la sync au prochain tick (où
+		// l'on a accès à VkDeviceContext sans race). Re-set à chaque
+		// Rebuild pour ne pas perdre l'observer si Shell ou Tools sont
+		// reset.
+		if (m_worldEditorShell && m_worldEditorShell->IsInitialized())
+		{
+			m_worldEditorShell->MutableTerrainDocument().SetOnChunkChanged(
+				[this](engine::world::GlobalChunkCoord) {
+					m_worldEditorTerrainNeedsSync.store(true, std::memory_order_release);
+				});
+		}
+
 		// Detection "aucune texture utilisateur assignee" -> pousse le flag fallback
 		// orange au TerrainRenderer (via push-constant). Des qu'au moins une couche
 		// splat recoit un mapping texture (refs[i] non vide), le flag retombe a
@@ -7980,6 +8003,88 @@ namespace engine
 				reset.position.x, reset.position.y, reset.position.z, reset.farZ,
 				actualExtX, actualExtZ, ox, oz);
 		}
+	}
+
+	void Engine::SyncWorldEditorHeightmapFromDocument()
+	{
+#if defined(_WIN32)
+		// Garde stricte : seul l'éditeur monde a un TerrainDocument actif
+		// (le Shell). Le client jeu ne passe jamais ici.
+		if (!m_worldEditorExe || !m_worldEditorShell || !m_worldEditorShell->IsInitialized())
+			return;
+		if (!m_worldEditorTerrainTools.IsValid()) return;
+		if (!m_terrain.IsValid()) return;
+
+		auto& terrainDoc = m_worldEditorShell->MutableTerrainDocument();
+		auto& hm         = m_terrain.GetMutableHeightmapData();
+		if (hm.width == 0 || hm.height == 0 || hm.heights.empty()) return;
+
+		const float heightScale = m_terrain.GetHeightScale();
+		if (heightScale <= 0.0f) return;
+
+		// Map terrain world coords → heightmap pixel coords.
+		// La heightmap couvre `terrainWorldSize` mètres avec `width-1` mailles
+		// horizontales. Origine en (terrainOriginX, terrainOriginZ).
+		const float originX     = m_terrain.GetTerrainOriginX();
+		const float originZ     = m_terrain.GetTerrainOriginZ();
+		const float worldSize   = m_terrain.GetTerrainWorldSize();
+		if (worldSize <= 0.0f) return;
+		const uint32_t hmW      = hm.width;
+		const uint32_t hmH      = hm.height;
+		const float pixelsPerMX = static_cast<float>(hmW - 1u) / worldSize;
+		const float pixelsPerMZ = static_cast<float>(hmH - 1u) / worldSize;
+
+		constexpr uint32_t kChunkRes =
+			static_cast<uint32_t>(engine::world::terrain::kTerrainResolution);
+		constexpr float kCell =
+			engine::world::terrain::kTerrainCellSizeMeters;
+
+		// Itère les chunks chargés du document. Chaque cellule (ix, iz) du
+		// chunk a une position monde ; on la convertit en pixel heightmap.
+		// La conversion float (m) → uint16 normalise par heightScale.
+		uint32_t touchedChunks = 0u;
+		for (int cz = 0; cz < 2; ++cz)
+		{
+			for (int cx = 0; cx < 2; ++cx)
+			{
+				auto chunk = terrainDoc.Find({ cx, cz });
+				if (!chunk) continue;
+				++touchedChunks;
+				const float chunkOriginX = static_cast<float>(cx) * (kChunkRes - 1u) * kCell;
+				const float chunkOriginZ = static_cast<float>(cz) * (kChunkRes - 1u) * kCell;
+				for (uint32_t iz = 0; iz < kChunkRes; ++iz)
+				{
+					for (uint32_t ix = 0; ix < kChunkRes; ++ix)
+					{
+						const float worldX = originX + chunkOriginX + static_cast<float>(ix) * kCell;
+						const float worldZ = originZ + chunkOriginZ + static_cast<float>(iz) * kCell;
+						const float fx = (worldX - originX) * pixelsPerMX;
+						const float fz = (worldZ - originZ) * pixelsPerMZ;
+						if (fx < 0.0f || fz < 0.0f) continue;
+						const uint32_t px = static_cast<uint32_t>(fx + 0.5f);
+						const uint32_t pz = static_cast<uint32_t>(fz + 0.5f);
+						if (px >= hmW || pz >= hmH) continue;
+						const float heightMeters = chunk->heights[iz * kChunkRes + ix];
+						const float norm = std::clamp(heightMeters / heightScale, 0.0f, 1.0f);
+						const uint16_t u16 = static_cast<uint16_t>(norm * 65535.0f + 0.5f);
+						hm.heights[pz * hmW + px] = u16;
+					}
+				}
+			}
+		}
+		if (touchedChunks == 0u) return;
+
+		// Pousse au GPU. FlushHeightmap re-upload la heightmap CPU complète
+		// vers l'image GPU R16 (single staging buffer + one-time command
+		// buffer). Coût ~10-30 ms sur 1025² uint16 (~2 MB).
+		const auto& hmGpu = m_terrain.GetHeightmapGpu();
+		(void)m_worldEditorTerrainTools.FlushHeightmap(
+			m_vkDeviceContext.GetDevice(),
+			m_vkDeviceContext.GetPhysicalDevice(),
+			m_vkDeviceContext.GetGraphicsQueue(),
+			m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
+			hmGpu.image);
+#endif
 	}
 
 	void Engine::ProcessSplatRefsDirty()

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -228,6 +228,18 @@ namespace engine
 		/// World editor: (re)charge heightmap + outils sculpt depuis le document.
 		void RebuildWorldEditorTerrainGpu();
 
+		/// M100.46+ — Pont CPU TerrainDocument → GPU HeightmapData.
+		/// Itère les chunks chargés du TerrainDocument du Shell, copie leurs
+		/// heights float (mètres) vers la HeightmapData CPU uint16 du
+		/// TerrainRenderer (conversion par `terrain.height_scale`), puis
+		/// pousse au GPU via `m_worldEditorTerrainTools.FlushHeightmap`.
+		///
+		/// Appelée chaque frame uniquement si `m_worldEditorTerrainNeedsSync`
+		/// est vrai (flag set par le callback `OnChunkChanged` du document).
+		/// No-op si l'éditeur monde n'est pas actif ou si les structures
+		/// ne sont pas valides.
+		void SyncWorldEditorHeightmapFromDocument();
+
 		/// Si WorldEditorSession::ConsumeSplatRefsDirty() == true, repack les
 		/// 4 layers (procedural fallback + textures importees via le cache)
 		/// dans m_terrain.GetSplatting() et reuploade le GPU array.
@@ -461,6 +473,13 @@ namespace engine
 #if defined(_WIN32)
 		engine::render::terrain::TerrainEditingTools m_worldEditorTerrainTools;
 #endif
+		/// M100.46+ — Pont TerrainDocument → HeightmapData GPU. Mis à true
+		/// quand `TerrainDocument::OnCommit` est appelé (callback enregistré
+		/// au boot éditeur monde) ; consommé au tick suivant par
+		/// `SyncWorldEditorHeightmapFromDocument` qui copie les chunks du
+		/// document dans la heightmap CPU (uint16) puis appelle
+		/// `FlushHeightmap` pour pousser au GPU.
+		std::atomic<bool> m_worldEditorTerrainNeedsSync{ false };
 		/// M08.4: Optional color grading LUT (strip 256x16 .texr). Loaded from config color_grading.lut_path.
 		engine::render::TextureHandle m_colorGradingLutHandle;
 		/// Fond plein écran pour l’écran auth (PNG sous paths.content, ex. ui/login/background.png).

--- a/src/world_editor/terrain/TerrainDocument.cpp
+++ b/src/world_editor/terrain/TerrainDocument.cpp
@@ -155,6 +155,16 @@ namespace engine::editor::world
 
 	void TerrainDocument::OnCommit(engine::world::GlobalChunkCoord coord)
 	{
+		// M100.46+ — pont CPU → GPU (rendu éditeur). Notifie l'observer
+		// avant tout autre traitement pour que la heightmap GPU soit
+		// re-synchronisée au prochain tick Engine, même si aucun worker
+		// LOD n'est attaché (cas typique : tests + binaire éditeur en mode
+		// préview rapide).
+		if (m_onChunkChanged)
+		{
+			m_onChunkChanged(coord);
+		}
+
 		if (m_lodWorker == nullptr) return;
 		auto chunk = Find(coord);
 		if (!chunk) return; // sécurité : commit sur un chunk non chargé n'a pas de sens

--- a/src/world_editor/terrain/TerrainDocument.cpp
+++ b/src/world_editor/terrain/TerrainDocument.cpp
@@ -18,6 +18,20 @@ namespace engine::editor::world
 			 | static_cast<uint64_t>(static_cast<uint32_t>(c.z));
 	}
 
+	void TerrainDocument::ForEachLoadedChunk(const ChunkVisitor& visitor) const
+	{
+		if (!visitor) return;
+		for (const auto& kv : m_chunks)
+		{
+			if (!kv.second.chunk) continue;
+			engine::world::GlobalChunkCoord coord{
+				static_cast<int32_t>(static_cast<uint32_t>(kv.first >> 32)),
+				static_cast<int32_t>(static_cast<uint32_t>(kv.first & 0xFFFFFFFFull))
+			};
+			visitor(coord, kv.second.chunk);
+		}
+	}
+
 	std::shared_ptr<engine::world::terrain::TerrainChunk>
 	TerrainDocument::EnsureLoaded(const engine::core::Config& config, int chunkX, int chunkZ)
 	{

--- a/src/world_editor/terrain/TerrainDocument.h
+++ b/src/world_editor/terrain/TerrainDocument.h
@@ -113,6 +113,14 @@ namespace engine::editor::world
 		using OnChunkChangedCallback = std::function<void(engine::world::GlobalChunkCoord)>;
 		void SetOnChunkChanged(OnChunkChangedCallback cb) { m_onChunkChanged = std::move(cb); }
 
+		/// Itère **tous les chunks actuellement chargés** en RAM, appelant
+		/// `visitor(coord, chunk_ptr)` pour chaque. Utilisé par
+		/// `Engine::SyncWorldEditorHeightmapFromDocument` pour pousser tous
+		/// les chunks au GPU (et pas seulement les 2×2 du coin SW).
+		using ChunkVisitor = std::function<void(engine::world::GlobalChunkCoord,
+			const std::shared_ptr<engine::world::terrain::TerrainChunk>&)>;
+		void ForEachLoadedChunk(const ChunkVisitor& visitor) const;
+
 	private:
 		struct ChunkSlot
 		{

--- a/src/world_editor/terrain/TerrainDocument.h
+++ b/src/world_editor/terrain/TerrainDocument.h
@@ -5,6 +5,7 @@
 #include "src/client/world/terrain/TerrainChunk.h"
 #include "src/client/world/terrain/TerrainLodWorker.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -101,6 +102,17 @@ namespace engine::editor::world
 		std::shared_ptr<engine::world::terrain::SplatMap> FindSplat(
 			engine::world::GlobalChunkCoord coord) const;
 
+		/// Callback invoqué par `OnCommit(coord)` à chaque mutation
+		/// committée d'un chunk (M100.46+ pont CPU → GPU). Permet à un
+		/// observer (Engine) de marquer la heightmap GPU à re-synchroniser.
+		///
+		/// Effet de bord : le callback est invoqué **synchrone** depuis le
+		/// thread qui appelle `OnCommit`. Doit donc être très court (set un
+		/// flag, ne pas faire d'IO ni de Vulkan call) — la synchro lourde
+		/// est repoussée au prochain tick Engine.
+		using OnChunkChangedCallback = std::function<void(engine::world::GlobalChunkCoord)>;
+		void SetOnChunkChanged(OnChunkChangedCallback cb) { m_onChunkChanged = std::move(cb); }
+
 	private:
 		struct ChunkSlot
 		{
@@ -114,6 +126,7 @@ namespace engine::editor::world
 		std::unordered_map<uint64_t, ChunkSlot> m_chunks;
 		engine::world::terrain::TerrainLodWorker* m_lodWorker = nullptr;
 		std::string m_contentRootForLods;
+		OnChunkChangedCallback m_onChunkChanged;
 
 		/// Slot splat-map (M100.9) parallèle à `ChunkSlot` mais sur un map
 		/// distinct pour éviter de réécrire EnsureLoaded/MarkDirty/Save.

--- a/src/world_editor/zone_presets/OperationDispatcher.cpp
+++ b/src/world_editor/zone_presets/OperationDispatcher.cpp
@@ -294,6 +294,53 @@ namespace engine::editor::world::zone_presets
 			return true;
 		}
 
+		/// Pré-charge tous les chunks couverts par le bounding box d'un
+		/// polyline macro (largeur max × 1.5 de padding). Sans ce
+		/// pré-chargement, `MacroPolylineCommandBase::ApplyDeltas` fait
+		/// `Find(coord)` → nullptr → skip silencieux pour les chunks non
+		/// chargés. Avec les zone presets qui dessinent sur 10 km (zone
+		/// complète), il faut charger plusieurs chunks au-delà du 2×2 du
+		/// coin SW initial.
+		///
+		/// Requiert `ctx.config != nullptr`. No-op sinon (les ops macro
+		/// sans Config dégradent silencieusement).
+		void PreloadChunksForMacroPolyline(const MacroPolylineParams& macroParams,
+			const DispatchContext& ctx)
+		{
+			if (ctx.config == nullptr) return;
+			if (macroParams.vertices.empty()) return;
+
+			constexpr float kChunkSpanMeters =
+				(engine::world::terrain::kTerrainResolution - 1u) *
+				 engine::world::terrain::kTerrainCellSizeMeters;
+
+			float maxWidth = 0.0f;
+			float bbMinX = +1e30f, bbMaxX = -1e30f;
+			float bbMinZ = +1e30f, bbMaxZ = -1e30f;
+			for (const auto& v : macroParams.vertices)
+			{
+				maxWidth = std::max(maxWidth, v.widthMeters);
+				bbMinX = std::min(bbMinX, v.worldX);
+				bbMaxX = std::max(bbMaxX, v.worldX);
+				bbMinZ = std::min(bbMinZ, v.worldZ);
+				bbMaxZ = std::max(bbMaxZ, v.worldZ);
+			}
+			const float pad = maxWidth * 1.5f;
+			bbMinX -= pad; bbMaxX += pad;
+			bbMinZ -= pad; bbMaxZ += pad;
+			const int cxMin = static_cast<int>(std::floor(bbMinX / kChunkSpanMeters));
+			const int cxMax = static_cast<int>(std::floor(bbMaxX / kChunkSpanMeters));
+			const int czMin = static_cast<int>(std::floor(bbMinZ / kChunkSpanMeters));
+			const int czMax = static_cast<int>(std::floor(bbMaxZ / kChunkSpanMeters));
+			for (int cz = czMin; cz <= czMax; ++cz)
+			{
+				for (int cx = cxMin; cx <= cxMax; ++cx)
+				{
+					(void)ctx.terrain.EnsureLoaded(*ctx.config, cx, cz);
+				}
+			}
+		}
+
 		DispatchResult DispatchMountainMacro(const OperationParams& params,
 			const DispatchContext& ctx,
 			std::unique_ptr<engine::editor::world::ICommand>& outCmd)
@@ -304,6 +351,8 @@ namespace engine::editor::world::zone_presets
 				LOG_WARN(EditorWorld, "[OperationDispatcher] mountain_macro : polyline invalide");
 				return DispatchResult::Failed;
 			}
+			// Pré-charge les chunks couverts (zone preset sur 10 km).
+			PreloadChunksForMacroPolyline(macroParams, ctx);
 			auto deltas = RasterizeMacroPolyline(macroParams, /*invert*/ false);
 			if (deltas.empty())
 			{
@@ -324,6 +373,7 @@ namespace engine::editor::world::zone_presets
 				LOG_WARN(EditorWorld, "[OperationDispatcher] valley_macro : polyline invalide");
 				return DispatchResult::Failed;
 			}
+			PreloadChunksForMacroPolyline(macroParams, ctx);
 			auto deltas = RasterizeMacroPolyline(macroParams, /*invert*/ true);
 			if (deltas.empty())
 			{


### PR DESCRIPTION
## Bug observé

Aucune commande éditeur terrain (Mountain Range, Valley Chain, Hydraulic Erosion, Zone Preset, etc.) n'apparaît à l'écran. Seul le pinceau interactif (Sculpt drag) est visible. Confirmé par l'utilisateur sur la **remarque #1** :

> *« lorsque j'essaye de créer un creuse sur la carte, je ne le voix pas »*

## Cause racine

Les `ICommand` mutent le `TerrainDocument::m_chunks` (modèle chunk-orienté pour l'export streaming), mais le rendu GPU lit la `HeightmapData` (uint16, 2D) du `TerrainRenderer`. **Aucun pont entre les deux** :

- `TerrainDocument::OnCommit` enqueue uniquement vers le `TerrainLodWorker` (régen LOD + écriture disque async).
- `TerrainEditingTools::ApplyBrush` mute directement `HeightmapData` puis `FlushHeightmap` GPU — mais ce chemin n'est pris **que** par le pinceau interactif (clic + drag), pas par les commandes undo/redo.

Conséquence : le `TerrainDocument` accumule des deltas que le GPU ne voit jamais. L'utilisateur applique un Zone Preset → terrain reste figé.

## Fix (Option A' — la plus sûre)

Bridge minimal entre TerrainDocument et le rendu GPU, sans toucher au pinceau interactif (qui marche déjà).

### 1. `TerrainDocument::SetOnChunkChanged(callback)`
Nouveau `std::function<void(GlobalChunkCoord)>` field. Appelé **synchrone** depuis `OnCommit(coord)` avant l'enqueue LOD worker. Le callback doit être très court (set un flag), pas d'IO ni Vulkan call.

### 2. `Engine::m_worldEditorTerrainNeedsSync` (atomic<bool>)
Flag levé par le callback à chaque commit. Consommé chaque frame après ImGui via `exchange(false)` (one-shot, lock-free).

### 3. `Engine::SyncWorldEditorHeightmapFromDocument()`
Nouvelle méthode appelée quand le flag est levé :
- Itère les 4 chunks (0,0)..(1,1) chargés du Document.
- Pour chaque cellule du chunk, calcule sa position monde → position pixel dans la `HeightmapData` (via `terrain.origin` + `terrain.world_size` du renderer).
- Convertit la hauteur `float` (mètres) en `uint16` normalisé par `terrain.height_scale` (même convention que `ApplyBrush`).
- Écrit `m_terrain.GetMutableHeightmapData().heights[pz*W+px]`.
- Appelle `m_worldEditorTerrainTools.FlushHeightmap` sur l'image GPU R16 (`HeightmapGpu.image`) — staging + one-time command buffer + vkQueueSubmit synchrone.

### 4. Câblage callback
Fait juste après `TerrainEditingTools::Init` dans `RebuildWorldEditorTerrainGpu`. Re-set à chaque rebuild pour ne pas perdre l'observer si Shell/Tools sont reset.

## Comportement attendu

- ✅ Valley Chain : pose ≥2 vertices, clique **Apply** → terrain se creuse visiblement.
- ✅ Mountain Range, Lake, River, Zone Preset (incluant Hydraulic Erosion, Coastline, etc. via le dispatcher M100.46) : modifs visibles.
- ✅ **Ctrl+Z** inverse la commande → terrain revient à l'état précédent visible.
- ✅ Pinceau interactif (Sculpt drag) **reste inchangé** : son chemin direct `ApplyBrush → FlushHeightmap` est séparé, pas affecté.

## Latence

Per-Apply : **~10-30 ms** (FlushHeightmap upload total 1025² uint16 ≈ 2 MB staging + submit). Acceptable pour les ops one-shot. Le pinceau interactif 60 Hz reste sur son chemin direct (pas atteint).

## Hors scope

- **Sync inverse `HeightmapData → TerrainDocument`** (le pinceau interactif ne pousse pas sa modif dans le document) : déjà géré séparément par `OnMouseUp` du SculptTool qui push une `TerrainSculptCommand`.
- **Optimisation : sync partielle par région** (option B). Follow-up si la latence A' gêne en pratique.
- **Tests automatisés** : nécessitent un harnais Vulkan headless. Hors scope.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement. Aucun changement serveur, aucun format binaire.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] **Manuel critique** : `lcdlln_world_editor.exe` → menu Fichier > « Appliquer un preset de zone… » → choisir `temperate_forest` → Appliquer → **le terrain doit se sculpter visiblement** (collines + creux + lac).
- [ ] Manuel : sélectionner Valley Chain (V) → poser 2 vertices → Apply → vallée visible.
- [ ] Manuel : Ctrl+Z → terrain revient à l'état d'avant.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_