### PR TITLE
fix(world_editor): toggle grille dans menu Vue + corrige son débordement sur les fenêtres

### DIFF
--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -280,7 +280,15 @@ namespace engine::editor
 			{
 				return;
 			}
-			ImDrawList* dl = ImGui::GetForegroundDrawList();
+			// Background draw list (et non Foreground) pour que la grille et
+			// les marqueurs d'overlay viewport 3D soient **dessinés sous les
+			// fenêtres ImGui dockées** (panneaux Outils, Inspector, Tool
+			// Properties, etc.). En Foreground la grille débordait sur toutes
+			// les fenêtres et rendait l'UI illisible. L'ordre Z final est :
+			//   Vulkan terrain (fond) → BackgroundDrawList (grille, brush
+			//   preview, marqueurs) → fenêtres ImGui (recouvrent) →
+			//   ForegroundDrawList (reservé aux popups critiques).
+			ImDrawList* dl = ImGui::GetBackgroundDrawList();
 			const float* vp = d.viewProjColMajor;
 			const int vw = d.viewportWidth;
 			const int vh = d.viewportHeight;
@@ -801,6 +809,18 @@ namespace engine::editor
 			}
 			if (ImGui::BeginMenu("Vue"))
 			{
+				// Toggle grille — placé en tête du menu Vue pour être trouvable
+				// immédiatement sans ré-ouvrir le panneau "Affichage & grille"
+				// (qui peut être fermé par l'utilisateur sans moyen évident
+				// de le rouvrir). Le checkmark reflète l'état courant de
+				// `WorldEditorSession::ShowGrid()`. Pas de raccourci clavier
+				// par choix utilisateur.
+				if (m_session)
+				{
+					ImGui::MenuItem("Grille (afficher/masquer)", nullptr,
+						&m_session->ShowGrid());
+				}
+				ImGui::Separator();
 				// Panel toggles — migrés depuis WorldEditorShell::RenderMenuBar.
 				// Chaque panneau du Shell se rend dockable individuellement.
 				if (m_shell)


### PR DESCRIPTION
## Deux fix UX liés à la grille de référence du viewport 3D

### 1. Toggle accessible depuis le menu Vue

L'utilisateur peut fermer le panneau dockable **« Affichage & grille »** (qui contient la checkbox `Grille (apercu ecran)` et le slider de maille) — mais **aucun moyen évident de le rouvrir** une fois fermé (le panneau n'est pas un Shell panel listé dans le menu Vue, il est créé directement via `ImGui::Begin / End` dans `WorldEditorImGui::BuildUi`).

→ Nouvelle entrée en tête du menu **Vue** :
**`Grille (afficher/masquer)`** avec checkmark sur l'état courant. Pilote `WorldEditorSession::ShowGrid()` directement. **Pas de raccourci clavier** (choix utilisateur explicite).

### 2. Grille ne déborde plus sur les autres fenêtres

La grille (et les marqueurs d'overlay viewport — preview brosse, gizmos d'instances) était dessinée sur `ImGui::GetForegroundDrawList()`, qui est rendu **par-dessus toutes les fenêtres ImGui** y compris les panneaux dockés (Tool Properties, Inspector, etc.) — résultat : lignes de grille visibles à travers les panneaux, lisibilité dégradée.

→ Passage à **`ImGui::GetBackgroundDrawList()`**. Nouvel ordre Z :

```
  Vulkan terrain (fond)
  → BackgroundDrawList (grille, brush preview, marqueurs instances)
  → fenêtres ImGui dockées (recouvrent la grille — fix attendu)
  → ForegroundDrawList (réservé aux popups critiques uniquement)
```

Aucun changement de comportement sur le terrain 3D lui-même.

## Impact

- **Client jeu** : ✅ aucun (toutes les modifs sont dans `WorldEditorImGui::BuildUi`, exécuté uniquement par `lcdlln_world_editor.exe`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé, aucun nouvel opcode.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → menu Vue → première entrée = « Grille (afficher/masquer) » avec checkmark → toggle marche.
- [ ] Manuel : avec la grille active, ouvrir le panneau Tool Properties → les lignes de grille ne sont plus visibles à travers le panneau.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_