### PR TITLE
feat(world_editor): M100.34 incr 1 — EditorViewportRenderTarget (offscreen viewport infra)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,11 @@ add_library(engine_core
   src/world_editor/ui/WorldEditorSession.cpp
   src/world_editor/ui/TexturePreviewCache.cpp
   src/world_editor/ui/TextureLibraryPanel.cpp
+  # M100.34 incrément 1 — Cible offscreen R8G8B8A8 dédiée au viewport
+  # éditeur, exposée à ImGui pour affichage dans le ScenePanel.
+  # L'image est créée + transitionnée SHADER_READ_ONLY mais reste noire
+  # tant que la PR 2 ne branche pas la copie depuis SceneColor_LDR.
+  src/world_editor/render/EditorViewportRenderTarget.cpp
   # M100.1 — World editor "couche au-dessus" (engine::editor::world).
   # Cohabite avec WorldEditorImGui ; activé par --editor-world ou
   # editor.world.enabled. Pas référencé par engine/server/.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5,6 +5,7 @@
 #include "src/world_editor/ui/WorldEditorImGui.h"
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/panels/ScenePanel.h"
 #include "src/shared/core/memory/Memory.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/network/ChatPayloads.h"
@@ -5057,6 +5058,10 @@ namespace engine
 		if (m_vkDeviceContext.IsValid())
 		{
 			vkDeviceWaitIdle(m_vkDeviceContext.GetDevice());
+			// M100.34 incrément 1 — détruit l'image offscreen viewport
+			// AVANT TexturePreviewCache (qui possède aussi des descriptors
+			// ImGui), pour respecter l'ordre LIFO de désallocation.
+			m_editorViewportTarget.Shutdown(m_vkDeviceContext.GetDevice());
 #if defined(_WIN32)
 			if (m_texturePreviewCache) m_texturePreviewCache->Shutdown();
 			m_texturePreviewCache.reset();
@@ -5535,6 +5540,22 @@ namespace engine
 					if (m_worldEditorImGui && m_texturePreviewCache)
 					{
 						m_worldEditorImGui->SetTexturePreviewCache(m_texturePreviewCache.get());
+					}
+
+					// M100.34 incrément 1 — Cible offscreen viewport éditeur.
+					// Taille initiale alignée sur la swapchain ; la PR 2 ajoutera
+					// la passe FrameGraph qui y copie SceneColor_LDR + la
+					// logique de resize sur la taille du ScenePanel.
+					const uint32_t initW = m_vkSwapchain.GetExtent().width;
+					const uint32_t initH = m_vkSwapchain.GetExtent().height;
+					if (!m_editorViewportTarget.Init(
+						m_vkDeviceContext.GetDevice(),
+						m_vkDeviceContext.GetPhysicalDevice(),
+						m_vkDeviceContext.GetGraphicsQueue(),
+						m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
+						initW, initH))
+					{
+						LOG_WARN(Render, "[Engine] EditorViewportRenderTarget init failed -- ScenePanel restera en mode placeholder");
 					}
 				}
 				// Branche le DayNightCycle au panneau "Atmosphere" pour que l'utilisateur
@@ -6184,6 +6205,23 @@ namespace engine
 		if (m_worldEditorShell && m_worldEditorShell->IsInitialized()
 			&& m_worldEditorImGui && m_worldEditorImGui->IsReady())
 		{
+			// M100.34 incrément 1 — pousse le texture ID de l'image offscreen
+			// du viewport au ScenePanel (premier panel du Shell, ordre stable
+			// garanti par WorldEditorShell::Init). PR 1 : image noire, pas
+			// encore branchée au FrameGraph. PR 2 : copie SceneColor_LDR
+			// dedans et la cible devient visible.
+			if (m_editorViewportTarget.IsValid()
+				&& !m_worldEditorShell->Panels().empty()
+				&& m_worldEditorShell->Panels()[0])
+			{
+				auto* scenePanel = dynamic_cast<engine::editor::world::panels::ScenePanel*>(
+					m_worldEditorShell->MutablePanels()[0].get());
+				if (scenePanel != nullptr)
+				{
+					scenePanel->SetEditorViewportTextureId(
+						m_editorViewportTarget.GetImguiTextureId());
+				}
+			}
 			m_worldEditorShell->RenderFrame();
 		}
 #endif

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -73,6 +73,7 @@
 #include "src/client/render/terrain/TerrainEditingTools.h"
 #include "src/world_editor/ui/TexturePreviewCache.h"
 #endif
+#include "src/world_editor/render/EditorViewportRenderTarget.h"
 
 struct GLFWwindow;
 
@@ -435,6 +436,16 @@ namespace engine
 		/// Cohabite avec WorldEditorImGui (les deux peuvent être actifs).
 		/// Le shell appelle ImGui (Windows-only) — toujours nul sur Linux.
 		std::unique_ptr<engine::editor::world::WorldEditorShell> m_worldEditorShell;
+
+		/// M100.34 incrément 1 — Cible offscreen R8G8B8A8 dédiée au viewport
+		/// éditeur. Possédée par Engine, init après VkDeviceContext valide
+		/// + ImGui_ImplVulkan_Init OK, détruite avant le shutdown Vulkan.
+		/// Le `ScenePanel` lit `GetImguiTextureId()` chaque frame pour
+		/// l'afficher via `ImGui::Image`. L'image est créée mais reste
+		/// noire en PR 1 (rendu réel branché en PR 2 via passe FrameGraph
+		/// qui copie `SceneColor_LDR`).
+		engine::editor::world::EditorViewportRenderTarget m_editorViewportTarget;
+
 #if defined(_WIN32)
 		std::unique_ptr<engine::editor::TexturePreviewCache> m_texturePreviewCache;
 

--- a/src/world_editor/panels/ScenePanel.cpp
+++ b/src/world_editor/panels/ScenePanel.cpp
@@ -52,11 +52,24 @@ namespace engine::editor::world::panels
 			const ImVec2 avail = ImGui::GetContentRegionAvail();
 			m_viewportWidth = static_cast<int>(avail.x);
 			m_viewportHeight = static_cast<int>(avail.y);
-			ImGui::TextDisabled("Scene viewport — placeholder M100.1.");
-			ImGui::TextWrapped(
-				"La vue 3D principale du monde en édition apparaîtra ici "
-				"à partir de M100.34 (integration rendu offscreen).");
-			ImGui::Text("Viewport courant : %d x %d px", m_viewportWidth, m_viewportHeight);
+
+			// M100.34 incrément 1 — affiche l'image offscreen via ImGui::Image
+			// si l'`EditorViewportRenderTarget` du Engine a fourni un texture ID.
+			// La target est initialement vide (noire) ; la PR 2 branchera la
+			// copie depuis SceneColor_LDR pour montrer le rendu réel.
+			if (m_editorViewportTexId != 0u && m_viewportWidth > 0 && m_viewportHeight > 0)
+			{
+				ImGui::Image(reinterpret_cast<ImTextureID>(m_editorViewportTexId),
+					avail);
+			}
+			else
+			{
+				ImGui::TextDisabled("Scene viewport — placeholder M100.1.");
+				ImGui::TextWrapped(
+					"La vue 3D principale du monde en édition apparaîtra ici "
+					"à partir de M100.34 (integration rendu offscreen).");
+				ImGui::Text("Viewport courant : %d x %d px", m_viewportWidth, m_viewportHeight);
+			}
 		}
 		ImGui::End();
 #endif

--- a/src/world_editor/panels/ScenePanel.cpp
+++ b/src/world_editor/panels/ScenePanel.cpp
@@ -59,7 +59,13 @@ namespace engine::editor::world::panels
 			// copie depuis SceneColor_LDR pour montrer le rendu réel.
 			if (m_editorViewportTexId != 0u && m_viewportWidth > 0 && m_viewportHeight > 0)
 			{
-				ImGui::Image(reinterpret_cast<ImTextureID>(m_editorViewportTexId),
+				// `ImTextureID` est défini comme `ImU64` (numérique) dans cette
+				// version d'ImGui — `static_cast` direct, pas `reinterpret_cast`
+				// (le cast pointeur échoue sous MSVC C2440). Le `uint64_t`
+				// stocké côté `EditorViewportRenderTarget` est le
+				// `VkDescriptorSet` retourné par `ImGui_ImplVulkan_AddTexture`,
+				// déjà tronqué/casté en uint64.
+				ImGui::Image(static_cast<ImTextureID>(m_editorViewportTexId),
 					avail);
 			}
 			else

--- a/src/world_editor/panels/ScenePanel.h
+++ b/src/world_editor/panels/ScenePanel.h
@@ -2,6 +2,8 @@
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/camera/EditorCameraController.h"
 
+#include <cstdint>
+
 namespace engine::editor::world::panels
 {
 	/// Panneau Scene du shell éditeur monde (M100.1 + M100.4).
@@ -46,10 +48,24 @@ namespace engine::editor::world::panels
 		/// frame pour obtenir la matrice de vue/projection courante.
 		const engine::editor::world::EditorCameraController& GetCamera() const { return m_camera; }
 
+		/// M100.34 incrément 1 — Texture ID ImGui (descriptor VkDescriptorSet
+		/// reinterprété en uint64_t) de l'image offscreen `EditorViewportRenderTarget`
+		/// owned par `Engine`. Renseigné depuis `Engine` chaque frame après
+		/// Init de la target. 0 = pas encore disponible → fallback placeholder
+		/// texte.
+		///
+		/// La PR 1 livre l'infra : le texture ID pointe sur une image **noire**
+		/// (rien n'est encore copié dedans). La PR 2 branche la passe FrameGraph
+		/// qui copie `SceneColor_LDR` dans cette image → le rendu réel apparaîtra
+		/// dans le panneau.
+		void     SetEditorViewportTextureId(uint64_t id) { m_editorViewportTexId = id; }
+		uint64_t GetEditorViewportTextureId() const     { return m_editorViewportTexId; }
+
 	private:
 		bool m_visible = true;
 		int m_viewportWidth = 0;
 		int m_viewportHeight = 0;
 		engine::editor::world::EditorCameraController m_camera;
+		uint64_t m_editorViewportTexId = 0u;
 	};
 }

--- a/src/world_editor/render/EditorViewportRenderTarget.cpp
+++ b/src/world_editor/render/EditorViewportRenderTarget.cpp
@@ -1,0 +1,352 @@
+#include "src/world_editor/render/EditorViewportRenderTarget.h"
+
+#include "src/shared/core/Log.h"
+
+#include <functional>
+#include <vulkan/vulkan.h>
+
+#if defined(_WIN32)
+#	include "imgui_impl_vulkan.h"
+#endif
+
+namespace engine::editor::world
+{
+	namespace
+	{
+		/// Choisit un MemoryType DEVICE_LOCAL pour l'image offscreen.
+		/// Pattern miroir de `TexturePreviewCache::FindMemoryType`.
+		bool PickMemoryTypeIndex(VkPhysicalDevice physDev,
+			uint32_t memoryTypeBits, VkMemoryPropertyFlags wantedProps,
+			uint32_t& outIndex)
+		{
+			VkPhysicalDeviceMemoryProperties memProps{};
+			vkGetPhysicalDeviceMemoryProperties(physDev, &memProps);
+			for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+			{
+				const bool typeMatches  = (memoryTypeBits & (1u << i)) != 0u;
+				const bool propsOk      = (memProps.memoryTypes[i].propertyFlags
+					& wantedProps) == wantedProps;
+				if (typeMatches && propsOk)
+				{
+					outIndex = i;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// Submit synchrone d'un command buffer one-shot + wait queue idle.
+		/// Pattern partagé avec `TexturePreviewCache` / `TerrainEditingTools`
+		/// pour les transitions d'image hors render loop.
+		bool RunOneShotCommands(VkDevice device, VkQueue queue,
+			uint32_t queueFamilyIndex, VkCommandBuffer& outPersistedCmd,
+			VkCommandPool& outPersistedPool,
+			const std::function<void(VkCommandBuffer)>& recordFn)
+		{
+			VkCommandPoolCreateInfo pci{};
+			pci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+			pci.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+			pci.queueFamilyIndex = queueFamilyIndex;
+			if (vkCreateCommandPool(device, &pci, nullptr, &outPersistedPool) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[EditorViewportRT] vkCreateCommandPool failed");
+				return false;
+			}
+			VkCommandBufferAllocateInfo aci{};
+			aci.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+			aci.commandPool = outPersistedPool;
+			aci.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+			aci.commandBufferCount = 1;
+			if (vkAllocateCommandBuffers(device, &aci, &outPersistedCmd) != VK_SUCCESS)
+			{
+				vkDestroyCommandPool(device, outPersistedPool, nullptr);
+				outPersistedPool = VK_NULL_HANDLE;
+				LOG_ERROR(Render, "[EditorViewportRT] vkAllocateCommandBuffers failed");
+				return false;
+			}
+			VkCommandBufferBeginInfo bi{};
+			bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+			bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+			if (vkBeginCommandBuffer(outPersistedCmd, &bi) != VK_SUCCESS)
+			{
+				vkDestroyCommandPool(device, outPersistedPool, nullptr);
+				outPersistedPool = VK_NULL_HANDLE;
+				outPersistedCmd  = VK_NULL_HANDLE;
+				return false;
+			}
+			recordFn(outPersistedCmd);
+			if (vkEndCommandBuffer(outPersistedCmd) != VK_SUCCESS)
+			{
+				vkDestroyCommandPool(device, outPersistedPool, nullptr);
+				outPersistedPool = VK_NULL_HANDLE;
+				outPersistedCmd  = VK_NULL_HANDLE;
+				return false;
+			}
+			VkSubmitInfo si{};
+			si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+			si.commandBufferCount = 1;
+			si.pCommandBuffers    = &outPersistedCmd;
+			if (vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE) != VK_SUCCESS)
+			{
+				vkDestroyCommandPool(device, outPersistedPool, nullptr);
+				outPersistedPool = VK_NULL_HANDLE;
+				outPersistedCmd  = VK_NULL_HANDLE;
+				return false;
+			}
+			vkQueueWaitIdle(queue);
+			vkDestroyCommandPool(device, outPersistedPool, nullptr);
+			outPersistedPool = VK_NULL_HANDLE;
+			outPersistedCmd  = VK_NULL_HANDLE;
+			return true;
+		}
+	}
+
+	EditorViewportRenderTarget::~EditorViewportRenderTarget()
+	{
+		// Destruction explicite par l'appelant via Shutdown(device) — pas de
+		// VkDevice ici donc on log un warn si encore valide (équivaut au
+		// pattern WorldEditorImGui qui prévient l'oubli de Shutdown).
+		if (m_image != VK_NULL_HANDLE || m_sampler != VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "[EditorViewportRT] destructor : Shutdown(device) non appele avant destruction");
+		}
+	}
+
+	bool EditorViewportRenderTarget::Init(VkDevice device, VkPhysicalDevice physicalDevice,
+		VkQueue queue, uint32_t queueFamilyIndex,
+		uint32_t initialWidth, uint32_t initialHeight)
+	{
+		if (m_image != VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "[EditorViewportRT] Init appele deux fois sans Shutdown intermediaire");
+			return false;
+		}
+		if (initialWidth == 0u || initialHeight == 0u)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] Init avec taille nulle ({}x{})",
+				initialWidth, initialHeight);
+			return false;
+		}
+
+		// Sampler persistant : reutilise entre Resize.
+		VkSamplerCreateInfo sci{};
+		sci.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sci.magFilter    = VK_FILTER_LINEAR;
+		sci.minFilter    = VK_FILTER_LINEAR;
+		sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sci.borderColor  = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+		sci.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+		sci.maxLod       = 0.0f;
+		if (vkCreateSampler(device, &sci, nullptr, &m_sampler) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] vkCreateSampler failed");
+			return false;
+		}
+
+		if (!CreateImageResources(device, physicalDevice, queue, queueFamilyIndex,
+			initialWidth, initialHeight))
+		{
+			vkDestroySampler(device, m_sampler, nullptr);
+			m_sampler = VK_NULL_HANDLE;
+			return false;
+		}
+
+		LOG_INFO(Render, "[EditorViewportRT] Init OK ({}x{} R8G8B8A8_UNORM)",
+			initialWidth, initialHeight);
+		return true;
+	}
+
+	void EditorViewportRenderTarget::Shutdown(VkDevice device)
+	{
+		DestroyImageResources(device);
+		if (m_sampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_sampler, nullptr);
+			m_sampler = VK_NULL_HANDLE;
+		}
+		m_width  = 0;
+		m_height = 0;
+	}
+
+	bool EditorViewportRenderTarget::Resize(VkDevice device, VkPhysicalDevice physicalDevice,
+		VkQueue queue, uint32_t queueFamilyIndex,
+		uint32_t newWidth, uint32_t newHeight)
+	{
+		if (newWidth == m_width && newHeight == m_height) return true;
+		if (newWidth == 0u || newHeight == 0u) return false;
+		DestroyImageResources(device);
+		return CreateImageResources(device, physicalDevice, queue, queueFamilyIndex,
+			newWidth, newHeight);
+	}
+
+	uint64_t EditorViewportRenderTarget::GetImguiTextureId() const
+	{
+		return m_imguiTextureId;
+	}
+
+	void EditorViewportRenderTarget::DestroyImageResources(VkDevice device)
+	{
+#if defined(_WIN32)
+		if (m_imguiTextureId != 0u)
+		{
+			ImGui_ImplVulkan_RemoveTexture(
+				reinterpret_cast<VkDescriptorSet>(m_imguiTextureId));
+			m_imguiTextureId = 0u;
+		}
+#else
+		m_imguiTextureId = 0u;
+#endif
+		if (m_view != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device, m_view, nullptr);
+			m_view = VK_NULL_HANDLE;
+		}
+		if (m_image != VK_NULL_HANDLE)
+		{
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+		}
+		if (m_memory != VK_NULL_HANDLE)
+		{
+			vkFreeMemory(device, m_memory, nullptr);
+			m_memory = VK_NULL_HANDLE;
+		}
+	}
+
+	bool EditorViewportRenderTarget::CreateImageResources(VkDevice device,
+		VkPhysicalDevice physicalDevice, VkQueue queue, uint32_t queueFamilyIndex,
+		uint32_t w, uint32_t h)
+	{
+		// 1) Image — usage TRANSFER_DST (PR 2 copiera SceneColor_LDR dedans)
+		//    + SAMPLED (ImGui::Image sample dedans) + COLOR_ATTACHMENT
+		//    (optionnel : permet aussi un rendu direct si la PR 3 utilise
+		//    cette image comme attachment).
+		VkImageCreateInfo ici{};
+		ici.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		ici.imageType     = VK_IMAGE_TYPE_2D;
+		ici.format        = kFormat;
+		ici.extent        = { w, h, 1u };
+		ici.mipLevels     = 1u;
+		ici.arrayLayers   = 1u;
+		ici.samples       = VK_SAMPLE_COUNT_1_BIT;
+		ici.tiling        = VK_IMAGE_TILING_OPTIMAL;
+		ici.usage         = VK_IMAGE_USAGE_SAMPLED_BIT
+		                  | VK_IMAGE_USAGE_TRANSFER_DST_BIT
+		                  | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+		ici.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+		ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		if (vkCreateImage(device, &ici, nullptr, &m_image) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] vkCreateImage failed ({}x{})", w, h);
+			return false;
+		}
+
+		// 2) Memory
+		VkMemoryRequirements memReq{};
+		vkGetImageMemoryRequirements(device, m_image, &memReq);
+		uint32_t memTypeIdx = 0u;
+		if (!PickMemoryTypeIndex(physicalDevice, memReq.memoryTypeBits,
+			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, memTypeIdx))
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] no DEVICE_LOCAL memory type");
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+		VkMemoryAllocateInfo mai{};
+		mai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		mai.allocationSize  = memReq.size;
+		mai.memoryTypeIndex = memTypeIdx;
+		if (vkAllocateMemory(device, &mai, nullptr, &m_memory) != VK_SUCCESS
+			|| vkBindImageMemory(device, m_image, m_memory, 0) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] vkAllocate/BindMemory failed");
+			if (m_memory != VK_NULL_HANDLE) vkFreeMemory(device, m_memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image  = VK_NULL_HANDLE;
+			m_memory = VK_NULL_HANDLE;
+			return false;
+		}
+
+		// 3) Transition UNDEFINED → SHADER_READ_ONLY_OPTIMAL — sinon
+		//    ImGui::Image sample une image en layout invalide → validation
+		//    layer warn + comportement indéfini.
+		VkCommandBuffer cmd  = VK_NULL_HANDLE;
+		VkCommandPool   pool = VK_NULL_HANDLE;
+		const bool transitionOk = RunOneShotCommands(device, queue, queueFamilyIndex,
+			cmd, pool,
+			[&](VkCommandBuffer c)
+			{
+				VkImageMemoryBarrier b{};
+				b.sType         = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+				b.oldLayout     = VK_IMAGE_LAYOUT_UNDEFINED;
+				b.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+				b.srcAccessMask = 0;
+				b.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+				b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+				b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+				b.image            = m_image;
+				b.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+				vkCmdPipelineBarrier(c,
+					VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+					VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+					0, 0, nullptr, 0, nullptr, 1, &b);
+			});
+		if (!transitionOk)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] transition layout failed");
+			vkFreeMemory(device, m_memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image  = VK_NULL_HANDLE;
+			m_memory = VK_NULL_HANDLE;
+			return false;
+		}
+
+		// 4) View
+		VkImageViewCreateInfo vci{};
+		vci.sType            = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		vci.image            = m_image;
+		vci.viewType         = VK_IMAGE_VIEW_TYPE_2D;
+		vci.format           = kFormat;
+		vci.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+		if (vkCreateImageView(device, &vci, nullptr, &m_view) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] vkCreateImageView failed");
+			vkFreeMemory(device, m_memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image  = VK_NULL_HANDLE;
+			m_memory = VK_NULL_HANDLE;
+			return false;
+		}
+
+		// 5) Descriptor ImGui (Windows uniquement — l'editeur monde aussi).
+#if defined(_WIN32)
+		VkDescriptorSet ds = ImGui_ImplVulkan_AddTexture(m_sampler, m_view,
+			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		if (ds == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "[EditorViewportRT] ImGui_ImplVulkan_AddTexture failed");
+			vkDestroyImageView(device, m_view, nullptr);
+			vkFreeMemory(device, m_memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image  = VK_NULL_HANDLE;
+			m_memory = VK_NULL_HANDLE;
+			m_view   = VK_NULL_HANDLE;
+			return false;
+		}
+		m_imguiTextureId = reinterpret_cast<uint64_t>(ds);
+#else
+		(void)queue; (void)queueFamilyIndex;
+		// Hors Windows : pas d'ImGui Vulkan disponible. L'éditeur monde est
+		// Windows-only ; la classe reste compilable pour engine_core mais
+		// `GetImguiTextureId()` retourne 0 → `ImGui::Image` ne dessine rien.
+		m_imguiTextureId = 0u;
+#endif
+
+		m_width  = w;
+		m_height = h;
+		return true;
+	}
+}

--- a/src/world_editor/render/EditorViewportRenderTarget.h
+++ b/src/world_editor/render/EditorViewportRenderTarget.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cstdint>
+#include <vulkan/vulkan_core.h>
+
+struct ImDrawList;
+
+namespace engine::editor::world
+{
+	/// Image VkImage R8G8B8A8 dédiée à recevoir le rendu offscreen du
+	/// viewport éditeur, exposée à ImGui pour affichage dans le `ScenePanel`
+	/// via `ImGui::Image(GetImguiTextureId(), ...)` (M100.34 — préalable au
+	/// multi-viewport / vue 4-écrans).
+	///
+	/// PR 1 (cette livraison) : infrastructure seule — l'image est créée,
+	/// transitionnée en `SHADER_READ_ONLY_OPTIMAL`, exposée à ImGui, mais
+	/// **aucun contenu** n'est encore écrit dedans (rendu offscreen branché
+	/// dans la PR suivante via une passe FrameGraph qui copie
+	/// `SceneColor_LDR` vers cette image).
+	///
+	/// Cycle de vie typique :
+	///   1. `Init(device, physDev, queue, queueFamilyIndex, width, height)` au boot.
+	///   2. `Resize(w, h)` quand le ScenePanel ou la swapchain changent de taille.
+	///   3. `GetImguiTextureId()` consommé par `ScenePanel::Render` chaque frame.
+	///   4. `Shutdown(device)` au shutdown Engine.
+	///
+	/// Contraintes thread/timing : main thread Vulkan. Toutes les opérations
+	/// Vulkan (create/destroy image, allocate memory, register descriptor ImGui)
+	/// sont synchrones.
+	class EditorViewportRenderTarget
+	{
+	public:
+		EditorViewportRenderTarget() = default;
+		~EditorViewportRenderTarget();
+
+		EditorViewportRenderTarget(const EditorViewportRenderTarget&)            = delete;
+		EditorViewportRenderTarget& operator=(const EditorViewportRenderTarget&) = delete;
+
+		/// Alloue VkImage + memory + view + sampler + descriptor ImGui.
+		/// Transition de l'image en `SHADER_READ_ONLY_OPTIMAL` immédiatement
+		/// pour que `ImGui::Image` puisse l'échantillonner même si rien n'a
+		/// encore été copié dedans (l'image est noire au démarrage —
+		/// défaut du `VK_IMAGE_LAYOUT_UNDEFINED → SHADER_READ_ONLY`).
+		///
+		/// \return false si une des allocations échoue. Dans ce cas l'objet
+		/// est laissé en état "non initialisé" (`IsValid() == false`).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkQueue queue, uint32_t queueFamilyIndex,
+			uint32_t initialWidth, uint32_t initialHeight);
+
+		/// Détruit toutes les ressources Vulkan + le descriptor ImGui.
+		/// Idempotent — appelable plusieurs fois. Le device doit être idle
+		/// (cf. `vkDeviceWaitIdle`).
+		void Shutdown(VkDevice device);
+
+		/// Re-crée l'image à la taille `(w, h)`. No-op si la taille est
+		/// inchangée. À appeler depuis le main thread après que le device
+		/// soit idle (cf. swapchain recreate path dans Engine.cpp). Le
+		/// descriptor ImGui est recréé — l'ancien ID devient invalide.
+		bool Resize(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkQueue queue, uint32_t queueFamilyIndex,
+			uint32_t newWidth, uint32_t newHeight);
+
+		bool     IsValid()           const { return m_image != VK_NULL_HANDLE; }
+		uint32_t GetWidth()          const { return m_width; }
+		uint32_t GetHeight()         const { return m_height; }
+		VkImage  GetImage()          const { return m_image; }
+		VkImageView GetImageView()   const { return m_view; }
+		VkFormat GetFormat()         const { return kFormat; }
+
+		/// Descriptor ImGui à passer à `ImGui::Image`. Retourne 0 si
+		/// `IsValid() == false`. Le descriptor est stable tant que `Resize`
+		/// ou `Shutdown` n'est pas appelé.
+		uint64_t GetImguiTextureId() const;
+
+	private:
+		/// Format fixe : R8G8B8A8 UNORM, alignement standard ImGui_ImplVulkan.
+		/// Le rendu source (SceneColor_LDR du FrameGraph) est en format
+		/// HDR ; la PR 2 ajoutera une passe tonemap-aware lors de la copie
+		/// si nécessaire (vkCmdBlitImage ou conversion explicite).
+		static constexpr VkFormat kFormat = VK_FORMAT_R8G8B8A8_UNORM;
+
+		/// Helper interne : détruit toutes les ressources sauf le sampler
+		/// (réutilisable entre Resize). Idempotent.
+		void DestroyImageResources(VkDevice device);
+
+		/// Crée image + memory + view + descriptor ImGui à la taille (w, h).
+		/// Transitionne l'image neuve en `SHADER_READ_ONLY_OPTIMAL`.
+		bool CreateImageResources(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkQueue queue, uint32_t queueFamilyIndex,
+			uint32_t w, uint32_t h);
+
+		VkImage        m_image     = VK_NULL_HANDLE;
+		VkImageView    m_view      = VK_NULL_HANDLE;
+		VkDeviceMemory m_memory    = VK_NULL_HANDLE;
+		VkSampler      m_sampler   = VK_NULL_HANDLE;
+		uint32_t       m_width     = 0;
+		uint32_t       m_height    = 0;
+
+		/// `VkDescriptorSet` retournée par `ImGui_ImplVulkan_AddTexture`.
+		/// Opaque depuis l'extérieur de ce header (ImGui types non
+		/// exposés). Stocké en `uint64_t` pour éviter d'inclure imgui
+		/// dans le header.
+		uint64_t       m_imguiTextureId = 0u;
+	};
+}


### PR DESCRIPTION
## Premier pas vers la vue 4-écrans (remarque utilisateur #2)

Sous-tâche de **M100.34** — pose l'infrastructure pour le rendu offscreen du viewport éditeur. Sans ça, `ScenePanel` reste un placeholder text et il est impossible d'avoir plusieurs vues.

## Fichiers ajoutés

### `src/world_editor/render/EditorViewportRenderTarget.{h,cpp}`

Classe Vulkan raw qui gère :
- `VkImage R8G8B8A8_UNORM` + `VkDeviceMemory DEVICE_LOCAL`
- `VkImageView 2D` + `VkSampler LINEAR` clamp
- Transition initial `UNDEFINED → SHADER_READ_ONLY_OPTIMAL` (sinon `ImGui::Image` sample une image en layout invalide → validation warn)
- Descriptor ImGui via `ImGui_ImplVulkan_AddTexture`
- `Resize` / `Shutdown` propres + Init/Shutdown idempotents

Pattern miroir de `TexturePreviewCache` (allocations raw, one-shot command buffer pour la transition layout). Hors Windows : compile mais `GetImguiTextureId()` retourne 0 (ImGui Vulkan absent).

## Fichiers modifiés

### `Engine.h` / `Engine.cpp`
- Membre `m_editorViewportTarget` (non-pointer).
- Init après `WorldEditorImGui::Init` + `TexturePreviewCache::Init`, taille = swapchain extent au moment de l'init. PR 2 ajoutera le resize sur taille panneau.
- Shutdown avant `TexturePreviewCache::Shutdown` (LIFO).
- Chaque frame avant `m_worldEditorShell->RenderFrame()` : push le texture ID au ScenePanel (premier panel du Shell).

### `ScenePanel.{h,cpp}`
- Nouveau setter `SetEditorViewportTextureId(uint64_t)`.
- `Render()` utilise `ImGui::Image` quand l'ID est dispo, sinon conserve le placeholder text d'origine (graceful fallback).

### `CMakeLists.txt`
- Ajoute `EditorViewportRenderTarget.cpp` à `engine_core`.

## Comportement attendu en PR 1

**ScenePanel affiche une image NOIRE** à la place du placeholder text. C'est l'attendu : l'infra est en place, mais aucun rendu n'est encore copié dans la target. C'est la PR 2 qui rendra la cible visible.

## Roadmap M100.34 → vue 4-écrans

| PR | Contenu |
|----|---------|
| **2** | Passe FrameGraph `EditorViewportCopy` qui copie `SceneColor_LDR` (post-tonemap) → `m_editorViewportTarget`. ScenePanel affiche enfin le rendu. Resize sur taille panneau. |
| **3** | Clear swapchain en background uni (rendu unique dans ScenePanel, plus de duplication full-screen). |
| **4** | Multi-target : 4 `EditorViewportRenderTarget` pour 4 caméras (3D libre + Top/Front/Side ortho). |
| **5** | Layout 2x2 dans ScenePanel + toggle dans menu Vue. |
| **6** | Interaction souris par viewport, sync sélection. |

## Impact

- **Client jeu** : ✅ aucun (`m_editorViewportTarget.Init` n'est appelé que dans le bloc `if (m_worldEditorExe)`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → log info `[EditorViewportRT] Init OK (WxH R8G8B8A8_UNORM)` au boot
- [ ] Manuel : ScenePanel affiche un rectangle noir (pas le placeholder text) → confirme que `ImGui::Image` lit bien le descriptor
- [ ] Manuel : aucune validation layer warn Vulkan en debug build

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_