### PR TITLE
fix(world_editor): re-expose panneau Atmosphere via menu Vue (régression #622)

### DIFF
--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -854,6 +854,12 @@ namespace engine::editor
 					}
 				}
 				ImGui::MenuItem("Bibliotheque de textures", nullptr, &m_showTextureLibrary);
+				// Panneau « Atmosphere » (cycle jour/nuit). Le panneau est
+				// dessine inline par `BuildUi` (pas un Shell panel), donc
+				// pas liste dans la boucle Panels() ci-dessus. Toggle direct
+				// via ce flag — corrige la regression apres #622 (suppression
+				// barre M100.1 qui exposait tous les panels).
+				ImGui::MenuItem("Atmosphere (jour/nuit)", nullptr, &m_showAtmospherePanel);
 				ImGui::Separator();
 				if (m_cfg)
 				{
@@ -1217,7 +1223,12 @@ namespace engine::editor
 			// time-of-day (0-24h), timeScale (vitesse du temps), et lecture des
 			// valeurs derivees (direction soleil, couleurs ciel zenith/horizon,
 			// ambient, isDaytime).
-			ImGui::Begin("Atmosphere");
+			// Panneau pilote par `m_showAtmospherePanel` (menu `Vue >
+			// Atmosphere`). Sans ce p_open, l'utilisateur ne pouvait pas
+			// rouvrir le panneau apres l'avoir ferme via la croix du dock.
+			if (m_showAtmospherePanel)
+			{
+			ImGui::Begin("Atmosphere", &m_showAtmospherePanel);
 			if (m_dayNight == nullptr)
 			{
 				ImGui::TextDisabled("DayNightCycle non branche.");
@@ -1302,6 +1313,7 @@ namespace engine::editor
 				}
 			}
 			ImGui::End();
+			} // if (m_showAtmospherePanel)
 
 			ImGui::Begin("Outils");
 			// Etat du terrain - visible en permanence, pour expliquer pourquoi le clic peut etre inactif.

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -160,6 +160,14 @@ namespace engine::editor
 		/// du WorldEditorImGui (cycle Shell ↔ dialog).
 		std::unique_ptr<engine::editor::world::zone_presets::ZonePresetDialog> m_zonePresetDialog;
 		bool m_showTextureLibrary = false;  // pilote par le menu Affichage (Task 14)
+		/// Flag de visibilité du panneau « Atmosphere » (cycle jour/nuit
+		/// + couleurs ciel + ambient). Par défaut visible. Pilote par
+		/// l'entrée menu `Vue > Atmosphere`. Sans ce toggle, le panneau
+		/// ne peut pas être ré-ouvert une fois fermé via la croix du
+		/// dock — d'où la régression signalée utilisateur après les fix
+		/// dual-menu (#622) qui ont supprimé l'ancienne barre M100.1
+		/// listant tous les panels.
+		bool m_showAtmospherePanel = true;
 		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
 		/// repassé à true après la pose.


### PR DESCRIPTION
## Bug signalé utilisateur

Le panneau **« Atmosphere »** (cycle jour/nuit, couleurs ciel, ambient) a disparu et il est impossible de le rouvrir.

## Cause racine

`WorldEditorImGui::BuildUi` dessine le panneau via `ImGui::Begin("Atmosphere")` **sans `p_open`** et le panneau n'est **pas listé dans le menu Vue** (parce qu'il n'est pas un Shell panel — juste un `Begin/End` inline).

Avant **#622** (fix dual-menu), l'ancienne barre M100.1 anglaise exposait quand même tous les panels via son menu `View`. Depuis #622 qui a supprimé cette barre, plus aucun toggle. Si l'utilisateur ferme la fenêtre (croix du dock), elle reste fermée sans recours.

## Fix

1. **Flag de visibilité** `m_showAtmospherePanel = true` (par défaut visible) dans `WorldEditorImGui.h`.
2. **`Begin("Atmosphere", &m_showAtmospherePanel)`** : la croix du dock met le flag à `false` → frame suivante skip le contenu.
3. **MenuItem « Atmosphere (jour/nuit) »** dans le menu Vue, après « Bibliotheque de textures » → toggle direct le flag.

Pattern identique à `m_showTextureLibrary` existant.

## Hors scope (autre note utilisateur)

L'utilisateur signale aussi que **le rendu visuel jour/nuit n'est pas très bien fait**. C'est un sujet de qualité visuelle du `DayNightCycle` / `SkyPass` / `lighting ambient` — hors scope de ce fix de visibilité.

À traiter dans un ticket dédié — **M100.24 Sun, Sky & Probes Editor** (statut `Ready` dans l'INDEX) couvre justement le polishing du rendu atmosphérique : sun direction precise, sky color zenith/horizon LUT, IBL probes éditables. C'est le bon endroit pour ce travail visuel.

## Reste à faire (suivi)

Les autres panneaux inline non listés dans le menu Vue ont le même risque de régression :
- « Carte » (chargement carte, taille, seed)
- « Affichage & grille » (slider maille — déjà partiellement adressé par #624 qui a ajouté le toggle grille direct)
- « Outils » (placeholder)
- « Import assets »
- « Objets sur la carte »
- « Statut » + « Proprietes »

Si tu en signales d'autres disparus, je les ajouterai chacun en fix minimal (1 flag + 1 MenuItem par panel).

## Impact

- **Client jeu** : ✅ aucun (code dans `WorldEditorImGui` exécuté uniquement par `lcdlln_world_editor.exe`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → panneau « Atmosphere » visible au boot.
- [ ] Manuel : ferme le panneau (croix dans le dock) → disparaît.
- [ ] Manuel : menu Vue → « Atmosphere (jour/nuit) » avec checkmark à off → toggle → panneau réapparaît.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_