### PR TITLE
fix(world_editor): slider Heure du panneau Atmosphere — drag-stable pattern

### DIFF
--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -1226,10 +1226,29 @@ namespace engine::editor
 			else
 			{
 				const engine::render::DayNightCycle::State& dn = m_dayNight->GetState();
-				float tod = dn.timeOfDay;
+				// Petit padding pour que le slider ne soit pas collé contre la
+				// barre d'onglets du dock (la zone de clic du tab interceptait
+				// les events au-dessus du slider, le rendant difficile à drag).
+				ImGui::Dummy(ImVec2(0.0f, 2.0f));
+
+				// Pattern drag-stable : tant que l'utilisateur tient le slider,
+				// on lit la valeur locale snapshotée pour éviter qu'ImGui ne
+				// reset son drag state à cause de `dn.timeOfDay` mis à jour
+				// chaque frame par le cycle (timeScale = 60 ⇒ +0.000278h/frame).
+				float tod = m_atmosphereHourEditing
+					? m_atmosphereHourLocal
+					: dn.timeOfDay;
 				if (ImGui::SliderFloat("Heure (0-24)", &tod, 0.0f, 24.0f, "%.2f h"))
 				{
+					m_atmosphereHourLocal   = tod;
+					m_atmosphereHourEditing = true;
 					m_dayNight->SetTime(tod);
+				}
+				// Detection release : si plus actif, on relâche le snapshot
+				// et le slider re-suit la valeur live du cycle.
+				if (m_atmosphereHourEditing && !ImGui::IsItemActive())
+				{
+					m_atmosphereHourEditing = false;
 				}
 				float ts = m_dayNight->GetTimeScale();
 				if (ImGui::SliderFloat("Vitesse temps (s/heure)", &ts, 0.1f, 600.0f, "%.1f"))

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -160,6 +160,18 @@ namespace engine::editor
 		/// du WorldEditorImGui (cycle Shell ↔ dialog).
 		std::unique_ptr<engine::editor::world::zone_presets::ZonePresetDialog> m_zonePresetDialog;
 		bool m_showTextureLibrary = false;  // pilote par le menu Affichage (Task 14)
+		/// Pattern drag-stable pour le slider "Heure" du panneau Atmosphere.
+		/// Sans ça, le slider est inutilisable parce que `dn.timeOfDay` est
+		/// re-écrit chaque frame par le cycle jour/nuit (timeScale != 0) et
+		/// ImGui interprète la valeur changeante externellement comme un
+		/// "reset" du drag state.
+		///
+		/// Tant que `m_atmosphereHourEditing` est vrai (l'utilisateur tient
+		/// le slider via `IsItemActive`), le slider lit `m_atmosphereHourLocal`
+		/// au lieu de la valeur live du cycle. Le SetTime du DayNightCycle
+		/// est appelé à chaque tick. Au release : retour à la valeur live.
+		bool  m_atmosphereHourEditing = false;
+		float m_atmosphereHourLocal   = 0.0f;
 		/// Flag traçant si une tentative de pose de la disposition par défaut (DockBuilder) a déjà
 		/// été faite. Reset à false au démarrage et lors d'un « Réinitialiser la disposition »,
 		/// repassé à true après la pose.


### PR DESCRIPTION
## Bug signalé utilisateur (capture)

Le slider **« Heure (0-24) »** du panneau Atmosphere est **visible mais impossible à modifier**. La valeur affichée (`8.14h`) bouge correctement parce que le cycle jour/nuit avance le temps automatiquement, mais le clic+drag sur le slider ne fait rien.

L'autre slider du panneau (« Vitesse temps ») marche normalement → dissymétrie visible dans la capture.

## Cause racine

Le code lisait `dn.timeOfDay` chaque frame dans une variable locale `tod` passée par pointeur à `ImGui::SliderFloat`. Avec `timeScale = 60` (défaut), `dn.timeOfDay` est **ré-écrit chaque frame** (+0.000278h/frame à 60fps).

ImGui voit la valeur changer externellement entre deux drag events → reset implicite de son état interne de drag → l'utilisateur ne peut jamais "saisir" le slider.

En plus, le slider était **collé contre la barre d'onglets du dock** (0 pixel de padding) — la hit zone du tab pouvait intercepter les clics sur la première ligne du slider.

Le slider « Vitesse temps » n'a pas ce problème parce que `dn.timeScale` n'est PAS mis à jour automatiquement — il vient d'être set par l'utilisateur et reste stable.

## Fix

### 1. `ImGui::Dummy(0, 2)` avant le slider
2 pixels de padding pour éloigner la zone de clic du tab bar.

### 2. Pattern drag-stable (pattern standard ImGui pour valeurs animées)

Deux nouveaux membres dans `WorldEditorImGui` :
- `bool m_atmosphereHourEditing = false`
- `float m_atmosphereHourLocal = 0.0f` (snapshot)

Logique :
```cpp
float tod = m_atmosphereHourEditing ? m_atmosphereHourLocal : dn.timeOfDay;
if (ImGui::SliderFloat("Heure (0-24)", &tod, 0.0f, 24.0f, "%.2f h")) {
    m_atmosphereHourLocal   = tod;
    m_atmosphereHourEditing = true;
    m_dayNight->SetTime(tod);
}
if (m_atmosphereHourEditing && !ImGui::IsItemActive()) {
    m_atmosphereHourEditing = false;
}
```

Comportement :
- **Avant drag** : `tod = dn.timeOfDay` (live, le slider suit l'heure qui avance).
- **Pendant drag** : `tod = m_atmosphereHourLocal` (snapshot figé, ImGui ne voit plus la valeur bouger entre deux frames → drag stable). Chaque mouvement du slider met à jour `m_atmosphereHourLocal` ET appelle `SetTime` sur le cycle.
- **Au release** : `IsItemActive()` retourne false → reset du flag → `tod` re-suit `dn.timeOfDay` qui continue d'avancer.

## Impact

- **Client jeu** : ✅ aucun (code dans `WorldEditorImGui`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → panneau Atmosphere → drag le slider « Heure » → la valeur suit le curseur correctement → release → l'heure reprend son avance automatique selon le timeScale.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_