### PR TITLE
fix(world_editor): surface_table.json path doublé (game/data/game/data/...)

### DIFF
--- a/src/world_editor/panels/SurfaceTablePanel.cpp
+++ b/src/world_editor/panels/SurfaceTablePanel.cpp
@@ -8,14 +8,17 @@
 
 namespace engine::editor::world::panels
 {
-	/// Charge `surface_table.json` depuis `<contentRoot>/game/data/gameplay/`.
+	/// Charge `surface_table.json` depuis `<contentRoot>/gameplay/`.
+	/// Le caller passe déjà `paths.content` (typiquement `game/data`) — on
+	/// ne re-préfixe donc PAS avec `game/data` (bug doublait le chemin :
+	/// `game/data/game/data/gameplay/surface_table.json` → parse error).
 	/// Effets de bord : remplit `m_table` (succès) et `m_status` (succès ou
 	/// erreur). Appelée une fois par `WorldEditorShell::Init` (main thread).
 	/// Le bouton Reload du panel rappelle `m_table.LoadFromJson(m_jsonPath, err)`
 	/// avec le même path.
 	void SurfaceTablePanel::LoadFromContentRoot(const std::filesystem::path& contentRoot)
 	{
-		m_jsonPath = contentRoot / "game" / "data" / "gameplay" / "surface_table.json";
+		m_jsonPath = contentRoot / "gameplay" / "surface_table.json";
 		std::string err;
 		if (m_table.LoadFromJson(m_jsonPath, err))
 		{

--- a/src/world_editor/panels/SurfaceTablePanel.h
+++ b/src/world_editor/panels/SurfaceTablePanel.h
@@ -20,8 +20,9 @@ namespace engine::editor::world::panels
 		bool IsVisible() const override { return m_visible; }
 		void SetVisible(bool v) override { m_visible = v; }
 
-		/// Charge le JSON depuis `<contentRoot>/game/data/gameplay/surface_table.json`.
-		/// `contentRoot` typique : "game/data". Appelé une fois par WorldEditorShell::Init.
+		/// Charge le JSON depuis `<contentRoot>/gameplay/surface_table.json`.
+		/// `contentRoot` typique : "game/data" (lu depuis `paths.content`).
+		/// Appelé une fois par WorldEditorShell::Init.
 		/// Effet de bord : remplit `m_table` et `m_status`.
 		void LoadFromContentRoot(const std::filesystem::path& contentRoot);
 


### PR DESCRIPTION
## Bug repéré dans une capture précédente

Status du panneau Surface Table au boot :
> `Parse error: SurfaceTable: cannot open game/data/game/data/gameplay/surface_table.json`

Le chemin contient **« game/data » deux fois** → le panneau Surface Table affiche toujours « parse error » et la table de surfaces (13 entrées : grass, dirt, rock, sand, snow, wood, stone, metal, water, lava, ice, mud, gravel) reste vide.

## Cause racine

`SurfaceTablePanel::LoadFromContentRoot(contentRoot)` construit :
```cpp
m_jsonPath = contentRoot / "game" / "data" / "gameplay" / "surface_table.json";
```

Mais le caller (`WorldEditorShell::Init`) passe **déjà** :
```cpp
cfg.GetString("paths.content", "game/data")  // → "game/data"
```

Résultat : `game/data` + `game/data/gameplay/surface_table.json` = `game/data/game/data/gameplay/surface_table.json` → fichier inexistant → parse error.

## Fix

```diff
- m_jsonPath = contentRoot / "game" / "data" / "gameplay" / "surface_table.json";
+ m_jsonPath = contentRoot / "gameplay" / "surface_table.json";
```

Doc + commentaire header mis à jour pour clarifier que `contentRoot` n'a PAS besoin de re-préfixe.

Fichier cible vérifié présent à `game/data/gameplay/surface_table.json`.

## Comportement attendu

- Boot `lcdlln_world_editor.exe` → menu Vue > « Surface Table » → panneau affiche `Loaded ✓ (13 entries)` au lieu du parse error.

## Impact

- **Client jeu** : ✅ aucun (SurfaceTablePanel = code éditeur, exécuté uniquement dans `lcdlln_world_editor.exe`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → menu Vue > Surface Table → status affiche `Loaded ✓ (13 entries)` au lieu du parse error précédent.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_