### PR TITLE
feat(world_editor): M100.34 incr 3 — resize viewport target sur taille ScenePanel

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -6206,6 +6206,50 @@ namespace engine
 			m_worldEditorImGui->NewFrame(static_cast<float>(dt), imguiDw, imguiDh);
 		}
 
+		// M100.34 incrément 3 — Resize de la cible offscreen viewport sur la
+		// taille réelle du ScenePanel. Sans ça, la target reste fixée à la
+		// taille de la swapchain au boot et l'image est étirée par
+		// `ImGui::Image` dans le panneau (aspect ratio cassé). La mesure
+		// `ScenePanel::GetViewportWidth/Height` vient du frame précédent
+		// (set dans `ScenePanel::Render` post-`ImGui::GetContentRegionAvail`).
+		// Si elle diffère de la target actuelle, on attend que le device
+		// soit idle (sinon destroy d'une image en cours d'utilisation) puis
+		// on recrée à la nouvelle taille. Pattern rare (resize panel = action
+		// utilisateur sporadique), donc waitIdle acceptable côté perf.
+		if (m_worldEditorExe && m_worldEditorShell
+			&& m_worldEditorShell->IsInitialized()
+			&& m_editorViewportTarget.IsValid()
+			&& !m_worldEditorShell->Panels().empty()
+			&& m_worldEditorShell->Panels()[0])
+		{
+			auto* scenePanel = dynamic_cast<engine::editor::world::panels::ScenePanel*>(
+				m_worldEditorShell->MutablePanels()[0].get());
+			if (scenePanel != nullptr)
+			{
+				const int wRaw = scenePanel->GetViewportWidth();
+				const int hRaw = scenePanel->GetViewportHeight();
+				const uint32_t w = (wRaw > 0) ? static_cast<uint32_t>(wRaw) : 0u;
+				const uint32_t h = (hRaw > 0) ? static_cast<uint32_t>(hRaw) : 0u;
+				if (w > 0u && h > 0u
+					&& (w != m_editorViewportTarget.GetWidth()
+					 || h != m_editorViewportTarget.GetHeight()))
+				{
+					vkDeviceWaitIdle(m_vkDeviceContext.GetDevice());
+					if (!m_editorViewportTarget.Resize(
+						m_vkDeviceContext.GetDevice(),
+						m_vkDeviceContext.GetPhysicalDevice(),
+						m_vkDeviceContext.GetGraphicsQueue(),
+						m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
+						w, h))
+					{
+						LOG_WARN(Render,
+							"[Engine] EditorViewportRenderTarget::Resize({}x{}) failed",
+							w, h);
+					}
+				}
+			}
+		}
+
 		// M100.1 — Rendu de la coquille du nouvel éditeur monde. Doit être
 		// appelée après ImGui::NewFrame (fait par WorldEditorImGui::NewFrame
 		// ci-dessus, qui partage le même contexte ImGui) et avant


### PR DESCRIPTION
## Suite de M100.34 incr 2 (#626) — corrige l'aspect ratio étiré

La target offscreen était créée à la taille de la swapchain au boot et restait fixée. Donc quand le `ScenePanel` est plus petit, `ImGui::Image` étire l'image (aspect ratio cassé). Plus grand → image compressée et floue.

## Fix

Chaque frame, **avant** `m_worldEditorImGui->NewFrame`, vérification que `ScenePanel::GetViewportWidth/Height` correspond à la taille de `m_editorViewportTarget`. Si différent :

```cpp
vkDeviceWaitIdle(device);
m_editorViewportTarget.Resize(device, physDev, queue, qfi, w, h);
```

### Choix techniques

- **vkDeviceWaitIdle obligatoire** : sans ça, `Resize` destroy l'image alors qu'elle peut être en cours d'utilisation par un command buffer en vol → crash garanti.
- **Sporadique** : l'utilisateur redimensionne le panneau peu souvent (drag de bord), donc le coût `waitIdle` est acceptable. Si la taille ne change pas, no-op.
- **Lag d'1 frame** : la taille est mesurée à la frame N (`ImGui::GetContentRegionAvail` dans `Render`) et utilisée à la frame N+1 (resize avant NewFrame). Invisible pour l'utilisateur.

## Comportement attendu

- Le rendu 3D dans le ScenePanel a maintenant l'**aspect ratio correct** quel que soit la taille du panneau.
- Drag de bord du ScenePanel → resize instantané sans étirement.
- Si on réduit à 100×100 px : la target est recréée à 100×100 (économie GPU memory).
- Si on agrandit à 1920×1080 : la target s'agrandit, le blit upscale correctement.

## Roadmap M100.34 (reste après cette PR)

| PR | Contenu |
|----|---------|
| **4** | Clear swapchain en arrière-plan uni (rendu unique dans ScenePanel, plus de duplication full-screen) |
| **5** | 4 targets pour 4 caméras (3D libre + Top/Front/Side ortho) |
| **6** | Caméras ortho — paramétrage des matrices de projection |
| **7** | Layout 2x2 + toggle menu Vue « Vue 4-écrans » |

## Impact

- **Client jeu** : ✅ aucun (`if (m_worldEditorExe && ...)`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → panneau Scene affiche le terrain 3D **sans étirement** (drag le bord du panneau pour modifier sa taille → l'image reste proportionnelle).
- [ ] Manuel : aucune validation layer warning Vulkan au resize.
- [ ] Manuel : pas de crash au resize de la fenêtre principale (qui resize aussi la swapchain).

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_