### PR TITLE
refactor(world_editor): M100.34 incr 5 — std::array&lt;EditorViewportRenderTarget, 4&gt; (infra multi-viewport)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5083,7 +5083,11 @@ namespace engine
 			// M100.34 incrément 1 — détruit l'image offscreen viewport
 			// AVANT TexturePreviewCache (qui possède aussi des descriptors
 			// ImGui), pour respecter l'ordre LIFO de désallocation.
-			m_editorViewportTarget.Shutdown(m_vkDeviceContext.GetDevice());
+			// M100.34 incr 5 — shutdown les 4 targets (index 1-3 sont no-op s'ils n'ont jamais été init).
+		for (auto& target : m_editorViewportTargets)
+		{
+			target.Shutdown(m_vkDeviceContext.GetDevice());
+		}
 #if defined(_WIN32)
 			if (m_texturePreviewCache) m_texturePreviewCache->Shutdown();
 			m_texturePreviewCache.reset();
@@ -5570,14 +5574,17 @@ namespace engine
 					// logique de resize sur la taille du ScenePanel.
 					const uint32_t initW = m_vkSwapchain.GetExtent().width;
 					const uint32_t initH = m_vkSwapchain.GetExtent().height;
-					if (!m_editorViewportTarget.Init(
+					// M100.34 incr 5 — Init seulement l'index 0 (vue 3D libre).
+					// Les targets 1-3 (ortho Top/Front/Side) seront init en incr 6
+					// quand on aura les caméras correspondantes.
+					if (!m_editorViewportTargets[0].Init(
 						m_vkDeviceContext.GetDevice(),
 						m_vkDeviceContext.GetPhysicalDevice(),
 						m_vkDeviceContext.GetGraphicsQueue(),
 						m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
 						initW, initH))
 					{
-						LOG_WARN(Render, "[Engine] EditorViewportRenderTarget init failed -- ScenePanel restera en mode placeholder");
+						LOG_WARN(Render, "[Engine] EditorViewportRenderTarget[0] init failed -- ScenePanel restera en mode placeholder");
 					}
 				}
 				// Branche le DayNightCycle au panneau "Atmosphere" pour que l'utilisateur
@@ -6240,7 +6247,7 @@ namespace engine
 		// utilisateur sporadique), donc waitIdle acceptable côté perf.
 		if (m_worldEditorExe && m_worldEditorShell
 			&& m_worldEditorShell->IsInitialized()
-			&& m_editorViewportTarget.IsValid()
+			&& m_editorViewportTargets[0].IsValid()
 			&& !m_worldEditorShell->Panels().empty()
 			&& m_worldEditorShell->Panels()[0])
 		{
@@ -6253,11 +6260,11 @@ namespace engine
 				const uint32_t w = (wRaw > 0) ? static_cast<uint32_t>(wRaw) : 0u;
 				const uint32_t h = (hRaw > 0) ? static_cast<uint32_t>(hRaw) : 0u;
 				if (w > 0u && h > 0u
-					&& (w != m_editorViewportTarget.GetWidth()
-					 || h != m_editorViewportTarget.GetHeight()))
+					&& (w != m_editorViewportTargets[0].GetWidth()
+					 || h != m_editorViewportTargets[0].GetHeight()))
 				{
 					vkDeviceWaitIdle(m_vkDeviceContext.GetDevice());
-					if (!m_editorViewportTarget.Resize(
+					if (!m_editorViewportTargets[0].Resize(
 						m_vkDeviceContext.GetDevice(),
 						m_vkDeviceContext.GetPhysicalDevice(),
 						m_vkDeviceContext.GetGraphicsQueue(),
@@ -6285,7 +6292,7 @@ namespace engine
 			// garanti par WorldEditorShell::Init). PR 1 : image noire, pas
 			// encore branchée au FrameGraph. PR 2 : copie SceneColor_LDR
 			// dedans et la cible devient visible.
-			if (m_editorViewportTarget.IsValid()
+			if (m_editorViewportTargets[0].IsValid()
 				&& !m_worldEditorShell->Panels().empty()
 				&& m_worldEditorShell->Panels()[0])
 			{
@@ -6294,7 +6301,7 @@ namespace engine
 				if (scenePanel != nullptr)
 				{
 					scenePanel->SetEditorViewportTextureId(
-						m_editorViewportTarget.GetImguiTextureId());
+						m_editorViewportTargets[0].GetImguiTextureId());
 				}
 			}
 			m_worldEditorShell->RenderFrame();
@@ -7288,11 +7295,11 @@ namespace engine
 	        // ScenePanel n'affiche pas son propre overlay = pas de récursion) vers
 	        // l'image offscreen. Barriers à la main parce qu'on est hors FrameGraph
 	        // ici (juste après son execute()).
-	        if (m_worldEditorExe && m_editorViewportTarget.IsValid()
+	        if (m_worldEditorExe && m_editorViewportTargets[0].IsValid()
 	            && m_fgSceneColorLDRId != engine::render::kInvalidResourceId)
 	        {
 	            VkImage sceneLdr = m_fgRegistry.getImage(m_fgSceneColorLDRId);
-	            VkImage dst      = m_editorViewportTarget.GetImage();
+	            VkImage dst      = m_editorViewportTargets[0].GetImage();
 	            if (sceneLdr != VK_NULL_HANDLE && dst != VK_NULL_HANDLE)
 	            {
 	                // Step 1: transitions de layout.
@@ -7330,8 +7337,8 @@ namespace engine
 	                region.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
 	                region.dstOffsets[0]  = { 0, 0, 0 };
 	                region.dstOffsets[1]  = {
-	                    static_cast<int32_t>(m_editorViewportTarget.GetWidth()),
-	                    static_cast<int32_t>(m_editorViewportTarget.GetHeight()),
+	                    static_cast<int32_t>(m_editorViewportTargets[0].GetWidth()),
+	                    static_cast<int32_t>(m_editorViewportTargets[0].GetHeight()),
 	                    1
 	                };
 	                vkCmdBlitImage(fr.cmdBuffer,

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4544,6 +4544,28 @@ namespace engine
 												VkImage dstImg = reg.getImage(m_fgBackbufferId);
 												if (srcImg == VK_NULL_HANDLE || dstImg == VK_NULL_HANDLE) return;
 												VkExtent2D ext = m_vkSwapchain.GetExtent();
+
+												// M100.34 incrément 4 — En mode éditeur monde, on ne copie PAS
+												// `SceneColor_LDR` vers le backbuffer (sinon le rendu 3D apparaît
+												// dupliqué : une fois en plein écran + une fois dans le ScenePanel).
+												// Le backbuffer est clearé à un gris neutre. ImGui rendra ses panels
+												// par-dessus (incluant le ScenePanel qui affiche le rendu via la
+												// target offscreen — incr 2).
+												if (m_worldEditorExe)
+												{
+													const VkClearColorValue editorBgColor = { { 0.10f, 0.11f, 0.13f, 1.0f } };
+													VkImageSubresourceRange clearRange{};
+													clearRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+													clearRange.baseMipLevel   = 0;
+													clearRange.levelCount     = 1;
+													clearRange.baseArrayLayer = 0;
+													clearRange.layerCount     = 1;
+													vkCmdClearColorImage(cmd, dstImg,
+														VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+														&editorBgColor, 1, &clearRange);
+													return; // skip copy + auth UI blit (pas pertinent en éditeur)
+												}
+
 												bool authPhotoBackdrop = false;
 												const bool presentSolidColorDebug = m_cfg.GetBool("render.debug_present_solid_color.enabled", false);
 												if (presentSolidColorDebug)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -449,14 +449,18 @@ namespace engine
 		/// Le shell appelle ImGui (Windows-only) — toujours nul sur Linux.
 		std::unique_ptr<engine::editor::world::WorldEditorShell> m_worldEditorShell;
 
-		/// M100.34 incrément 1 — Cible offscreen R8G8B8A8 dédiée au viewport
-		/// éditeur. Possédée par Engine, init après VkDeviceContext valide
-		/// + ImGui_ImplVulkan_Init OK, détruite avant le shutdown Vulkan.
-		/// Le `ScenePanel` lit `GetImguiTextureId()` chaque frame pour
-		/// l'afficher via `ImGui::Image`. L'image est créée mais reste
-		/// noire en PR 1 (rendu réel branché en PR 2 via passe FrameGraph
-		/// qui copie `SceneColor_LDR`).
-		engine::editor::world::EditorViewportRenderTarget m_editorViewportTarget;
+		/// M100.34 incrément 1-5 — Cibles offscreen R8G8B8A8 pour le multi-viewport.
+		/// 4 cibles, une par caméra dans le futur layout 2x2 (incr 7) :
+		///   - `[0]` : caméra 3D libre (Orbital / FPS) — utilisée par le ScenePanel
+		///             actuel. Init dès le boot de l'éditeur.
+		///   - `[1]` : caméra Top ortho — init en incr 6.
+		///   - `[2]` : caméra Front ortho — init en incr 6.
+		///   - `[3]` : caméra Side ortho — init en incr 6.
+		///
+		/// Incréments 1-4 (livrés) : seul l'index 0 est utilisé.
+		/// Incrément 5 (cette livraison) : refactor en `std::array` pour préparer
+		/// l'usage des index 1-3 sans toucher au code Engine en aval.
+		std::array<engine::editor::world::EditorViewportRenderTarget, 4> m_editorViewportTargets;
 
 #if defined(_WIN32)
 		std::unique_ptr<engine::editor::TexturePreviewCache> m_texturePreviewCache;


### PR DESCRIPTION
## Refactor préparatoire — vue 4-écrans (remarque utilisateur #2)

Convertit la cible offscreen unique en **array de 4** pour préparer le futur layout 2x2 (3D libre + Top/Front/Side ortho).

⚠️ **Dépendance** : cette PR est branchée sur **#632 (incr 4)**. Mergez #632 d'abord, sinon les commits seront empilés.

## Mapping cible → caméra

| Index | Caméra | Statut |
|-------|--------|--------|
| `[0]` | 3D libre (Orbital / FPS) | ✅ utilisé par le ScenePanel actuel |
| `[1]` | Top ortho (vue de dessus) | ⏸️ init en incr 6 |
| `[2]` | Front ortho (face XY) | ⏸️ init en incr 6 |
| `[3]` | Side ortho (côté YZ) | ⏸️ init en incr 6 |

## Changements

### `Engine.h`
```diff
- EditorViewportRenderTarget m_editorViewportTarget;
+ std::array<EditorViewportRenderTarget, 4> m_editorViewportTargets;
```

`<array>` déjà inclus, pas de nouvelle dépendance.

### `Engine.cpp`
- **Init** (boot éditeur) : seul `m_editorViewportTargets[0]` est initialisé. Les index 1-3 restent en état non-init (`IsValid() == false`).
- **Resize** (chaque frame) : ne touche que `[0]`.
- **Blit `SceneColor_LDR` → target** (après FrameGraph) : copie dans `[0]`. Les 3 autres targets seront alimentées par leurs propres render passes en incr 6.
- **Push texture ID au ScenePanel** : utilise `[0].GetImguiTextureId()`.
- **Shutdown** : boucle sur les 4 targets et appelle `Shutdown` sur chacune. Les index non-init sont no-op.

## Zéro changement de comportement

L'utilisateur ne verra strictement rien de différent. Le ScenePanel continue d'afficher la vue 3D libre via `m_editorViewportTargets[0]`, exactement comme avant.

## Roadmap M100.34 (reste)

| PR | Contenu |
|----|---------|
| **6** | Caméras ortho Top/Front/Side : ajoute 3 caméras + 3 render passes qui écrivent dans `[1..3]` |
| **7** | Layout 2x2 : nouveaux ScenePanels (`TopOrtho/FrontOrtho/SideOrtho`) qui affichent les targets via `ImGui::Image`. Toggle menu Vue « Vue 4-écrans » |

## Impact

- **Client jeu** : ✅ aucun (l'array vit dans Engine mais n'est utilisé que dans les blocs guard par `m_worldEditorExe`).
- **Serveur** : ✅ aucun.
- **Format binaire** : aucun bumpé.
- **Coût RAM** : un `EditorViewportRenderTarget` non-init ≈ 0 octet utilisé (juste des membres `VkImage = VK_NULL_HANDLE`). Pas de coût avant qu'on les init en incr 6.

## Déploiement

> **Déploiement** : ✅ client/éditeur uniquement.

## Test plan

- [ ] CI `build-linux` + `build-windows` vertes
- [ ] Manuel : `lcdlln_world_editor.exe` → aucun changement visuel détectable. Le ScenePanel affiche le rendu 3D comme avant.
- [ ] **Non-régression** : `lcdlln.exe` (client jeu) → fonctionne identiquement.

https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_