### PR TITLE
fix(world_editor): M100.34 incr 4.1 — rebase coords souris pick éditeur sur ScenePanel

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -6615,7 +6615,56 @@ namespace engine
 					overlay.gridCellMeters = m_worldEditorSession->GridCellMeters();
 					overlay.brushRadiusMeters = m_worldEditorSession->BrushRadius();
 					const bool capBeforeUi = m_worldEditorImGui->WantsCaptureMouse();
-					terrainPick = RaycastTerrainFromCamera(out.camera, vw, vh, m_input.MouseX(), m_input.MouseY(), hm,
+
+					// M100.34 incr 4.1 — rebase des coords souris pour le pick éditeur.
+					// La scène est rendue en taille backbuffer (vw x vh) puis cette
+					// image est étirée par `ImGui::Image` dans le sous-rectangle du
+					// ScenePanel. Pour que cliquer SUR le terrain visible donne un
+					// hit cohérent, on traduit la position souris en fraction du
+					// rect du panel, puis on remappe cette fraction sur les pixels
+					// backbuffer (qui sont les coords attendues par la projection
+					// camera courante). Hors panel → pas de pick (et donc pas
+					// d'overlay brush ni d'édition déclenchée plus bas).
+					int pickMouseX = m_input.MouseX();
+					int pickMouseY = m_input.MouseY();
+					bool pickAllowed = true;
+					if (m_worldEditorExe && m_worldEditorShell
+						&& m_worldEditorShell->IsInitialized()
+						&& !m_worldEditorShell->Panels().empty()
+						&& m_worldEditorShell->Panels()[0])
+					{
+						auto* scenePanel = dynamic_cast<engine::editor::world::panels::ScenePanel*>(
+							m_worldEditorShell->MutablePanels()[0].get());
+						int rxMin = 0, ryMin = 0, rxMax = 0, ryMax = 0;
+						if (scenePanel && scenePanel->GetViewportScreenRect(rxMin, ryMin, rxMax, ryMax))
+						{
+							const int rw = rxMax - rxMin;
+							const int rh = ryMax - ryMin;
+							if (rw > 0 && rh > 0
+								&& pickMouseX >= rxMin && pickMouseX < rxMax
+								&& pickMouseY >= ryMin && pickMouseY < ryMax)
+							{
+								const float u = static_cast<float>(pickMouseX - rxMin)
+								              / static_cast<float>(rw);
+								const float v = static_cast<float>(pickMouseY - ryMin)
+								              / static_cast<float>(rh);
+								pickMouseX = static_cast<int>(u * static_cast<float>(vw));
+								pickMouseY = static_cast<int>(v * static_cast<float>(vh));
+							}
+							else
+							{
+								pickAllowed = false;
+							}
+						}
+						else
+						{
+							// ScenePanel pas encore prêt (placeholder texte ou masqué) :
+							// on bloque les outils pour éviter d'éditer dans le vide.
+							pickAllowed = false;
+						}
+					}
+
+					terrainPick = pickAllowed && RaycastTerrainFromCamera(out.camera, vw, vh, pickMouseX, pickMouseY, hm,
 						overlay.terrainOriginX, overlay.terrainOriginZ, overlay.terrainWorldSize, overlay.heightScale,
 						pickX, pickZ);
 					overlay.showBrushPreview =

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4544,6 +4544,28 @@ namespace engine
 												VkImage dstImg = reg.getImage(m_fgBackbufferId);
 												if (srcImg == VK_NULL_HANDLE || dstImg == VK_NULL_HANDLE) return;
 												VkExtent2D ext = m_vkSwapchain.GetExtent();
+
+												// M100.34 incrément 4 — En mode éditeur monde, on ne copie PAS
+												// `SceneColor_LDR` vers le backbuffer (sinon le rendu 3D apparaît
+												// dupliqué : une fois en plein écran + une fois dans le ScenePanel).
+												// Le backbuffer est clearé à un gris neutre. ImGui rendra ses panels
+												// par-dessus (incluant le ScenePanel qui affiche le rendu via la
+												// target offscreen — incr 2).
+												if (m_worldEditorExe)
+												{
+													const VkClearColorValue editorBgColor = { { 0.10f, 0.11f, 0.13f, 1.0f } };
+													VkImageSubresourceRange clearRange{};
+													clearRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+													clearRange.baseMipLevel   = 0;
+													clearRange.levelCount     = 1;
+													clearRange.baseArrayLayer = 0;
+													clearRange.layerCount     = 1;
+													vkCmdClearColorImage(cmd, dstImg,
+														VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+														&editorBgColor, 1, &clearRange);
+													return; // skip copy + auth UI blit (pas pertinent en éditeur)
+												}
+
 												bool authPhotoBackdrop = false;
 												const bool presentSolidColorDebug = m_cfg.GetBool("render.debug_present_solid_color.enabled", false);
 												if (presentSolidColorDebug)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4548,9 +4548,14 @@ namespace engine
 												// M100.34 incrément 4 — En mode éditeur monde, on ne copie PAS
 												// `SceneColor_LDR` vers le backbuffer (sinon le rendu 3D apparaît
 												// dupliqué : une fois en plein écran + une fois dans le ScenePanel).
-												// Le backbuffer est clearé à un gris neutre. ImGui rendra ses panels
-												// par-dessus (incluant le ScenePanel qui affiche le rendu via la
-												// target offscreen — incr 2).
+												// Le backbuffer reçoit un clear gris neutre. ImGui rendra ses
+												// panels par-dessus via `RecordToBackbuffer` plus bas dans cette
+												// même lambda.
+												//
+												// **Critique** : ne PAS faire `return` ici, sinon on skip aussi
+												// l'appel `m_worldEditorImGui->RecordToBackbuffer(...)` plus bas
+												// → écran complètement vide (régression observée — fix en 2 commit).
+												bool skipSceneCopyForEditor = false;
 												if (m_worldEditorExe)
 												{
 													const VkClearColorValue editorBgColor = { { 0.10f, 0.11f, 0.13f, 1.0f } };
@@ -4563,7 +4568,7 @@ namespace engine
 													vkCmdClearColorImage(cmd, dstImg,
 														VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
 														&editorBgColor, 1, &clearRange);
-													return; // skip copy + auth UI blit (pas pertinent en éditeur)
+													skipSceneCopyForEditor = true;
 												}
 
 												bool authPhotoBackdrop = false;
@@ -4581,7 +4586,7 @@ namespace engine
 													vkCmdClearColorImage(cmd, dstImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &debugColor, 1, &clearRange);
 													LOG_DEBUG(Render, "[CopyPresent] debug clear color applied");
 												}
-												else
+												else if (!skipSceneCopyForEditor)
 												{
 													LOG_DEBUG(Render, "[CopyPresent] vkCmdCopyImage begin");
 													// Use a direct copy for presentation. Some Intel/swapchain combinations are fragile
@@ -4595,6 +4600,9 @@ namespace engine
 													vkCmdCopyImage(cmd, srcImg, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 													LOG_DEBUG(Render, "[CopyPresent] vkCmdCopyImage done");
 												}
+												// `else` implicite : `skipSceneCopyForEditor` est vrai → le backbuffer
+												// est déjà clearé en gris, on saute le copy. Le code continue pour
+												// laisser passer `RecordToBackbuffer` (ImGui) ci-dessous.
 												const engine::client::AuthUiPresenter::VisualState authVisualState = m_authUi.GetVisualState();
 												const bool authBgBlitWanted = authVisualState.active && m_authUiBackgroundTexture.IsValid()
 													&& m_cfg.GetBool("render.auth_ui.background_blit.enabled", true) && !presentSolidColorDebug;

--- a/src/world_editor/panels/ScenePanel.cpp
+++ b/src/world_editor/panels/ScenePanel.cpp
@@ -27,6 +27,9 @@ namespace engine::editor::world::panels
 	void ScenePanel::Render()
 	{
 #if defined(_WIN32)
+		// Reset chaque frame : si le panel est masqué ou affiche le placeholder
+		// texte, `GetViewportScreenRect` doit renvoyer false (cf. M100.34 incr 4.1).
+		m_hasViewportRect = false;
 		if (!m_visible) return;
 		if (ImGui::Begin("Scene", &m_visible))
 		{
@@ -67,6 +70,20 @@ namespace engine::editor::world::panels
 				// déjà tronqué/casté en uint64.
 				ImGui::Image(static_cast<ImTextureID>(m_editorViewportTexId),
 					avail);
+
+				// M100.34 incr 4.1 — capture du rect écran de l'image juste
+				// après son draw. `GetItemRectMin/Max` renvoie des coords en
+				// pixels client de la fenêtre OS (même repère que `m_input.MouseX/Y`
+				// côté Engine), ce qui permet à `Engine.cpp` de rebaser les
+				// coords souris du raycast terrain sur ce sous-rectangle.
+				const ImVec2 rmin = ImGui::GetItemRectMin();
+				const ImVec2 rmax = ImGui::GetItemRectMax();
+				m_contentMinX = static_cast<int>(rmin.x);
+				m_contentMinY = static_cast<int>(rmin.y);
+				m_contentMaxX = static_cast<int>(rmax.x);
+				m_contentMaxY = static_cast<int>(rmax.y);
+				m_hasViewportRect = (m_contentMaxX > m_contentMinX)
+				                 && (m_contentMaxY > m_contentMinY);
 			}
 			else
 			{

--- a/src/world_editor/panels/ScenePanel.h
+++ b/src/world_editor/panels/ScenePanel.h
@@ -61,11 +61,44 @@ namespace engine::editor::world::panels
 		void     SetEditorViewportTextureId(uint64_t id) { m_editorViewportTexId = id; }
 		uint64_t GetEditorViewportTextureId() const     { return m_editorViewportTexId; }
 
+		/// M100.34 incr 4.1 — Rect écran (pixels client de la fenêtre OS) occupé
+		/// par l'`ImGui::Image` du viewport offscreen lors de la dernière frame.
+		/// Renseigné chaque frame dans `Render()` juste après `ImGui::Image`.
+		/// Retourne `false` tant que le placeholder texte est affiché (texture
+		/// non encore disponible) ou si le panel est replié/masqué — dans ce
+		/// cas, le caller doit ignorer l'input éditeur (pas de pick, pas de
+		/// brush preview).
+		///
+		/// Utilisé par `Engine.cpp` pour rebaser les coords souris du raycast
+		/// terrain : sans ça les outils sculpt/splat/place tirent contre les
+		/// dimensions du backbuffer plein écran alors que le rendu réel est
+		/// confiné dans ce sous-rectangle (régression cassante depuis M100.34
+		/// incrément 4 qui clear le swapchain en gris).
+		bool GetViewportScreenRect(int& outMinX, int& outMinY,
+			int& outMaxX, int& outMaxY) const
+		{
+			if (!m_hasViewportRect) return false;
+			outMinX = m_contentMinX;
+			outMinY = m_contentMinY;
+			outMaxX = m_contentMaxX;
+			outMaxY = m_contentMaxY;
+			return true;
+		}
+
 	private:
 		bool m_visible = true;
 		int m_viewportWidth = 0;
 		int m_viewportHeight = 0;
 		engine::editor::world::EditorCameraController m_camera;
 		uint64_t m_editorViewportTexId = 0u;
+
+		// M100.34 incr 4.1 — capture du rect écran de l'`ImGui::Image` (rebase
+		// des coords d'input par `Engine.cpp`). Reste à `false` tant qu'aucune
+		// frame n'a affiché l'image (placeholder texte → input éditeur ignoré).
+		bool m_hasViewportRect = false;
+		int  m_contentMinX = 0;
+		int  m_contentMinY = 0;
+		int  m_contentMaxX = 0;
+		int  m_contentMaxY = 0;
 	};
 }


### PR DESCRIPTION
## Contexte

Depuis l'incrément 4 de M100.34 (#632, clear swapchain en gris en mode éditeur), le rendu 3D est confiné dans le sous-rectangle de `ScenePanel` (via `ImGui::Image`) — ce qui est l'objectif (cf. captures Godot fournies par l'utilisateur). Mais les outils d'édition (sculpt, splat, place, route) sont devenus inutilisables : le pick continuait à utiliser `m_input.MouseX/Y` plein-écran + dimensions backbuffer → ray totalement hors-cible, clics sans effet visible.

> *"Mais comment je vais faire pour réaliser les modification sur la carte ?"* — utilisateur

## Fix

1. **`ScenePanel`** capture chaque frame le rect écran de son `ImGui::Image` (`GetItemRectMin/Max`) et l'expose via `GetViewportScreenRect(outMinX, outMinY, outMaxX, outMaxY)`. Retourne `false` tant que la texture n'est pas prête (placeholder texte affiché) ou que le panel est masqué.

2. **`Engine.cpp`** (bloc raycast terrain ~ligne 6601) : si rect dispo, traduit la souris en fraction du rect du panel puis remappe sur les coords backbuffer (qui sont les coords attendues par la projection caméra courante, inchangée). Si souris hors panel ou panel pas prêt → `pickAllowed=false` → pas de pick → pas de brush preview ni d'édition (évite aussi d'éditer quand on clique sur Inspector, Files, menus, etc.).

## Limite connue / suite

La projection caméra reste calée sur l'aspect backbuffer plein-écran ; l'aspect-stretch dans le panel introduit une déformation visuelle (terrain légèrement étiré horizontalement si le panel est plus carré que la fenêtre OS). Le mapping click-where-you-see reste cohérent avec ce qui est affiché. Une fixation propre de l'aspect viendra avec l'incrément 6 (rendu direct dans la target panel, à sa propre résolution + son propre aspect ratio).

## Test plan

- [ ] Lancer `lcdlln_world_editor.exe`
- [ ] Charger / créer une carte
- [ ] Outil sculpt : clic-glisser dans le ScenePanel → le terrain monte / descend / lisse là où on clique
- [ ] Outil splat : clic-glisser → la texture change sur la zone cliquée
- [ ] Outil place : clic → instance posée sous le curseur
- [ ] Clic sur Inspector ou FileSystem → aucune édition déclenchée
- [ ] Brush preview (disque rouge sur le sol) suit le curseur uniquement quand il est dans le ScenePanel
- [ ] Resize du ScenePanel (drag du splitter) : pick reste cohérent après resize

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1jcZ1iSuPzLu6CJtkZGXg)_