### PR TITLE
chore(client/render): GeometryPass cullMode=NONE — diagnostic avatar …

### DIFF
--- a/src/client/render/GeometryPass.cpp
+++ b/src/client/render/GeometryPass.cpp
@@ -372,17 +372,19 @@ namespace engine::render
 		VkPipelineRasterizationStateCreateInfo rs = {};
 		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 		rs.polygonMode = VK_POLYGON_MODE_FILL;
-		rs.cullMode    = VK_CULL_MODE_BACK_BIT;
-		// PR25 (M??.?) : meme correction que TerrainRenderer.cpp:528 (PR24).
-		// Le commit ee181da (Reapply view matrix transposee) a change la
-		// convention de Camera::ComputeViewMatrix vers Vulkan LH +Z forward.
-		// Avec cette nouvelle matrice, les meshes generes en CCW world-space
-		// apparaissent en CW dans le clip space. Avec frontFace=CCW +
-		// cullMode=BACK_BIT, le pipeline rejetait silencieusement TOUS les
-		// triangles -> avatar humanoide invisible en mode editeur (item 2 de
-		// la finalisation editeur 2026-05-06) ET dans le client de jeu post-
-		// EnterWorld (regression notee 2026-05-05). Fix : frontFace=CW.
-		rs.frontFace   = VK_FRONT_FACE_CLOCKWISE;
+		// =====================================================================
+		// DIAGNOSTIC TEMPORAIRE — audit 2026-05-18 : avatar invisible client
+		// PR25 (3009263) avait fixe l'editeur en passant CCW->CW. L'utilisateur
+		// rapporte que l'avatar reste invisible dans le client de jeu apres
+		// EnterWorld malgre PR25. Hypotheses : (a) winding mesh different entre
+		// editeur et client (b) autre cause (descriptor, depth, position).
+		// On force `cullMode=NONE` pour eliminer/confirmer la cause winding.
+		//   - Si avatar visible en client => probleme de winding, basculer CCW.
+		//   - Si avatar toujours invisible => bug ailleurs.
+		// A REVERTIR EN BACK_BIT (+ winding decide selon resultat) avant merge.
+		// =====================================================================
+		rs.cullMode    = VK_CULL_MODE_NONE;
+		rs.frontFace   = VK_FRONT_FACE_CLOCKWISE; // sans effet tant que cullMode=NONE
 		rs.lineWidth   = 1.0f;
 
 		VkPipelineMultisampleStateCreateInfo ms = {};


### PR DESCRIPTION
…invisible client

Audit complet du repo 2026-05-18 a identifié `GeometryPass.cpp:385` (frontFace=CW appliqué par PR25 3009263, 2026-05-06) comme cause probable du bug "avatar humanoïde invisible dans le client de jeu" noté 2026-05-05 (memory projet).

Conflit empirique vs théorique :
- PR25 (empirique) : passer `CCW -> CW` a rendu l'avatar visible en mode éditeur, et la PR affirmait "BONUS : corrige aussi le client".
- Audit (théorique) : analyse arithmétique de la view matrix (ee181da) + symétrie avec `ShadowMapPass.cpp:200` (CCW+BACK) et `TerrainRenderer.cpp:542` (CCW+BACK, fix PR #613) sur les mêmes meshes -> CW est probablement faux, l'avatar devrait être rendu avec CCW+BACK.

L'utilisateur confirme (2026-05-18) que l'avatar reste invisible dans le client de jeu malgré PR25 -> PR25 a fix l'éditeur mais pas le client.

Plutôt que de basculer aveuglément en CCW (risque de recasser l'éditeur), on pose un patch DIAGNOSTIC TEMPORAIRE : `cullMode = VK_CULL_MODE_NONE`.

Résultats possibles au test :
1. Avatar visible en client -> c'est bien le winding, on bascule CCW (cohérent avec ShadowMap + TerrainRenderer legacy + règle CLAUDE.md). Si CCW casse l'éditeur, c'est que client et éditeur consomment des meshes à conventions différentes -> plan dédié pour aligner.
2. Avatar toujours invisible avec NONE -> ce n'est PAS le winding, on enquête ailleurs (descriptor set, depth state, blend, texture transparente, position out of frustum).

À reverter (back en BACK_BIT + frontFace déterminé) avant merge final. Cette PR sert uniquement à produire un binaire client de diagnostic via CI.

Audit complet à venir en lots suivants : sécurité master (Mersenne session_id, absence de mutex, énumération comptes, CAPTCHA TLS sans validation cert), validation gameplay shardd vide, migrations 0023 dupliquée, sauvegardes éditeur non-atomiques, etc.

Déploiement : ✅ client uniquement, pas de redéploiement serveur.