### PR TITLE
fix(master/security): RAND_bytes + mutex partout + audit log thread-s…

### DIFF
--- a/src/masterd/session/SessionManager.cpp
+++ b/src/masterd/session/SessionManager.cpp
@@ -1,8 +1,12 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
+
 #include <algorithm>
 #include <chrono>
-#include <random>
+#include <cstring>
+#include <mutex>
+
+#include <openssl/rand.h>
 
 namespace engine::server
 {
@@ -13,16 +17,19 @@ namespace engine::server
 
 	void SessionManager::SetOnSessionClosed(std::function<void(uint64_t, uint64_t, SessionCloseReason)> hook)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_onSessionClosed = std::move(hook);
 	}
 
 	void SessionManager::SetSessionInWorldHook(std::function<bool(uint64_t)> hook)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_sessionInWorldHook = std::move(hook);
 	}
 
 	void SessionManager::SetConfig(const SessionManagerConfig& config)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_config = config;
 		LOG_DEBUG(Net, "[SessionManager] Config set: max_age_sec={} heartbeat_timeout_sec={} reconnection_window_sec={}",
 			m_config.max_session_age_sec, m_config.heartbeat_timeout_sec, m_config.reconnection_window_sec);
@@ -44,6 +51,7 @@ namespace engine::server
 
 	bool SessionManager::isValid(const Session& s, Clock::time_point now) const
 	{
+		// Caller doit detenir m_mutex.
 		if (s.state != SessionState::Authenticated && s.state != SessionState::Active)
 			return false;
 		if (now > s.expires_at)
@@ -56,14 +64,56 @@ namespace engine::server
 
 	uint64_t SessionManager::generateSessionId()
 	{
-		std::random_device rd;
-		std::mt19937_64 gen(rd());
-		std::uniform_int_distribution<uint64_t> dist(1, UINT64_MAX);
-		return dist(gen);
+		// Audit 2026-05-18 : avant ce fix, on utilisait std::mt19937_64 (non-CSPRNG)
+		// seede par std::random_device. Mersenne Twister n'est PAS un CSPRNG : apres
+		// ~624 sorties consecutives observees, l'etat interne est recuperable et
+		// tous les session_id futurs deviennent predictibles. On bascule sur
+		// OpenSSL RAND_bytes (meme pattern que ShardTicketHandler.cpp:108).
+		unsigned char buf[sizeof(uint64_t)];
+		if (RAND_bytes(buf, static_cast<int>(sizeof(buf))) != 1)
+		{
+			LOG_ERROR(Net, "[SessionManager] RAND_bytes failed during generateSessionId");
+			return kInvalidSessionId;
+		}
+		uint64_t id = 0;
+		std::memcpy(&id, buf, sizeof(uint64_t));
+		// Eviter la sentinelle kInvalidSessionId (0). Probabilite 1/2^64 -> negligeable
+		// mais on garde le check pour eliminer le doute.
+		if (id == kInvalidSessionId)
+			id = 1;
+		return id;
+	}
+
+	void SessionManager::closeInternal_NoLock(uint64_t session_id, SessionCloseReason reason)
+	{
+		// Caller doit detenir m_mutex.
+		auto it = m_by_session_id.find(session_id);
+		if (it == m_by_session_id.end())
+			return;
+		uint64_t account_id = it->second.account_id;
+		it->second.state = SessionState::Closed;
+		m_by_account_id.erase(account_id);
+		LOG_INFO(Net, "[SessionManager] Close: session_id={} account_id={} reason={}", session_id, account_id, SessionCloseReasonToString(reason));
+		// Fire le hook APRES log + cleanup interne. La copie locale du hook evite
+		// un crash si le subscriber le reset au milieu de l'appel.
+		// IMPORTANT : on appelle le hook SANS detenir m_mutex pour eviter une
+		// reentrance vers SessionManager via le subscriber (ex. fermeture TCP
+		// qui pourrait redeclencher une logique session).
+		auto hook = m_onSessionClosed;
+		if (hook)
+		{
+			// Le caller doit avoir un std::unique_lock plutot qu'un lock_guard si
+			// le hook a besoin d'etre appele sans le verrou. Convention ici : on
+			// fire le hook SOUS verrou (simpler) ; les subscribers doivent eviter
+			// de re-entrer dans SessionManager. Si necessite future de fire hors
+			// verrou, refactor caller en unique_lock + unlock avant hook.
+			hook(session_id, account_id, reason);
+		}
 	}
 
 	uint64_t SessionManager::CreateSession(uint64_t account_id)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = Clock::now();
 		auto expires_at = now + std::chrono::seconds(m_config.max_session_age_sec);
 
@@ -89,7 +139,9 @@ namespace engine::server
 					LOG_INFO(Net, "[SessionManager] CreateSession refused: account_id={} already has active session", account_id);
 					return kInvalidSessionId;
 				}
-				Close(existing_id, SessionCloseReason::KickedByDuplicateLogin);
+				// IMPORTANT : on detient deja m_mutex, donc on doit appeler la variante
+				// sans verrou pour eviter un deadlock.
+				closeInternal_NoLock(existing_id, SessionCloseReason::KickedByDuplicateLogin);
 			}
 		}
 
@@ -123,6 +175,7 @@ namespace engine::server
 	{
 		if (session_id == kInvalidSessionId)
 			return false;
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_by_session_id.find(session_id);
 		if (it == m_by_session_id.end())
 			return false;
@@ -134,6 +187,7 @@ namespace engine::server
 	{
 		if (session_id == kInvalidSessionId)
 			return false;
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_by_session_id.find(session_id);
 		if (it == m_by_session_id.end())
 			return false;
@@ -147,23 +201,13 @@ namespace engine::server
 
 	void SessionManager::Close(uint64_t session_id, SessionCloseReason reason)
 	{
-		auto it = m_by_session_id.find(session_id);
-		if (it == m_by_session_id.end())
-			return;
-		uint64_t account_id = it->second.account_id;
-		it->second.state = SessionState::Closed;
-		m_by_account_id.erase(account_id);
-		LOG_INFO(Net, "[SessionManager] Close: session_id={} account_id={} reason={}", session_id, account_id, SessionCloseReasonToString(reason));
-		// Fire le hook APRES log + cleanup interne : le subscriber peut, ex. fermer
-		// la TCP du connId associe et nettoyer SessionCharacterMap. La copie locale
-		// du hook evite un crash si le subscriber le reset au milieu de l'appel.
-		auto hook = m_onSessionClosed;
-		if (hook)
-			hook(session_id, account_id, reason);
+		std::lock_guard<std::mutex> lock(m_mutex);
+		closeInternal_NoLock(session_id, reason);
 	}
 
 	void SessionManager::SetState(uint64_t session_id, SessionState state)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_by_session_id.find(session_id);
 		if (it == m_by_session_id.end())
 			return;
@@ -178,6 +222,7 @@ namespace engine::server
 
 	size_t SessionManager::GetActiveCount() const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		size_t n = 0;
 		for (const auto& [id, s] : m_by_session_id)
 		{
@@ -192,6 +237,7 @@ namespace engine::server
 	{
 		if (session_id == kInvalidSessionId)
 			return std::nullopt;
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_by_session_id.find(session_id);
 		if (it == m_by_session_id.end())
 			return std::nullopt;
@@ -205,6 +251,7 @@ namespace engine::server
 	/// connectes remontent.
 	std::vector<uint64_t> SessionManager::ListActiveAccountIds() const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::vector<uint64_t> out;
 		out.reserve(m_by_session_id.size());
 		for (const auto& [id, s] : m_by_session_id)
@@ -218,6 +265,7 @@ namespace engine::server
 
 	void SessionManager::EvictExpired()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = Clock::now();
 		for (auto it = m_by_session_id.begin(); it != m_by_session_id.end(); )
 		{

--- a/src/masterd/session/SessionManager.h
+++ b/src/masterd/session/SessionManager.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -66,7 +67,13 @@ namespace engine::server
 	};
 
 	/// Global session manager: one active session per account, 64-bit session_id, 24h expiry, reconnection window.
-	/// Lookup by session_id and by account_id. Uses monotonic clock for timeouts. Thread-safe if external mutex is used (v1 single-threaded server).
+	/// Lookup by session_id and by account_id. Uses monotonic clock for timeouts.
+	/// Thread-safe : un `std::mutex` interne (m_mutex) protege m_by_session_id /
+	/// m_by_account_id. Toutes les methodes publiques (mutables et const) le
+	/// prennent. NetServer dispatche les paquets via un pool de worker threads
+	/// donc plusieurs handlers peuvent appeler SessionManager en parallele.
+	/// Audit 2026-05-18 : avant ce fix, le commentaire disait "v1 single-threaded
+	/// server" et il n'y avait AUCUNE protection -> data race UB sur les maps.
 	class SessionManager
 	{
 	public:
@@ -133,6 +140,13 @@ namespace engine::server
 	private:
 		using Clock = std::chrono::steady_clock;
 
+		/// Mutex interne protegeant toutes les structures partagees. Mutable
+		/// pour permettre aux methodes const (Validate, GetAccountId, etc.) de
+		/// le prendre. Verrou non-recursif : les helpers privees ne le prennent
+		/// PAS (a appeler uniquement depuis une methode publique qui a deja
+		/// pris le verrou ; cf. closeInternal_NoLock).
+		mutable std::mutex m_mutex;
+
 		SessionManagerConfig m_config;
 		std::unordered_map<uint64_t, Session> m_by_session_id;
 		std::unordered_map<uint64_t, uint64_t> m_by_account_id;
@@ -141,6 +155,11 @@ namespace engine::server
 
 		bool isValid(const Session& s, Clock::time_point now) const;
 		uint64_t generateSessionId();
+
+		/// Variante non-locking de Close, a appeler uniquement quand le caller
+		/// detient deja m_mutex. Evite la deadlock dans CreateSession qui doit
+		/// fermer une session existante (KickExisting) tout en tenant le verrou.
+		void closeInternal_NoLock(uint64_t session_id, SessionCloseReason reason);
 	};
 
 	/// Returns a human-readable string for SessionCloseReason (logging).

--- a/src/shared/db/ConnectionPool.cpp
+++ b/src/shared/db/ConnectionPool.cpp
@@ -144,50 +144,104 @@ namespace engine::server::db
 
 	ConnectionPool::Guard ConnectionPool::Acquire()
 	{
+		// Audit 2026-05-18 : avant ce fix, `mysql_ping` (round-trip reseau,
+		// plusieurs ms a plusieurs secondes en cas de timeout) etait appele SOUS
+		// m_mutex. Tous les autres workers DB etaient bloques pendant le ping
+		// d'une seule connexion -> sous charge avec un slot mort, tout le pool
+		// se serialisait sur la latence MySQL. Fix : extraire le slot sous
+		// verrou, faire le ping + reconnect HORS verrou, puis re-prendre le
+		// verrou seulement pour publier le resultat (mysql handle remplace).
 		auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kAcquireTimeoutMs);
 		for (;;)
 		{
+			// Phase 1 (verrou) : reserver un slot libre.
+			size_t slot_index = static_cast<size_t>(-1);
+			MYSQL* mysql_handle = nullptr;
 			{
 				std::lock_guard<std::mutex> lock(m_mutex);
 				if (!m_initialized)
 					return Guard();
-
-				for (auto& e : m_connections)
+				for (size_t i = 0; i < m_connections.size(); ++i)
 				{
+					auto& e = m_connections[i];
 					if (!e.in_use && e.mysql)
 					{
-						if (mysql_ping(e.mysql) != 0)
-						{
-							mysql_close(e.mysql);
-							e.mysql = mysql_init(nullptr);
-							if (e.mysql)
-							{
-								bool reconnect = false;
-								mysql_options(e.mysql, MYSQL_OPT_RECONNECT, &reconnect);
-								if (!ConnectOne(e.mysql))
-								{
-									LOG_WARN(Core, "[ConnectionPool] Reconnect failed: {}", mysql_error(e.mysql));
-									mysql_close(e.mysql);
-									e.mysql = nullptr;
-									continue;
-								}
-								LOG_INFO(Core, "[ConnectionPool] Reconnected after ping failure");
-							}
-						}
-						if (e.mysql)
-						{
-							e.in_use = true;
-							return Guard(this, e.mysql);
-						}
+						e.in_use = true; // reservation immediate, meme si le ping va echouer
+						mysql_handle = e.mysql;
+						slot_index = i;
+						break;
 					}
 				}
 			}
+
+			if (mysql_handle == nullptr)
+			{
+				// Pas de slot libre : sleep court puis retry.
+				if (std::chrono::steady_clock::now() >= deadline)
+				{
+					LOG_ERROR(Core, "[ConnectionPool] Acquire timeout");
+					return Guard();
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(kAcquireRetryMs));
+				continue;
+			}
+
+			// Phase 2 (HORS verrou) : ping. Si succes, on rend immediatement.
+			if (mysql_ping(mysql_handle) == 0)
+			{
+				return Guard(this, mysql_handle);
+			}
+
+			// Phase 3 (HORS verrou) : ping a echoue. Close + reconnect.
+			mysql_close(mysql_handle);
+			MYSQL* new_handle = mysql_init(nullptr);
+			bool reconnect_ok = false;
+			if (new_handle)
+			{
+				bool reconnect_flag = false;
+				mysql_options(new_handle, MYSQL_OPT_RECONNECT, &reconnect_flag);
+				reconnect_ok = ConnectOne(new_handle);
+				if (!reconnect_ok)
+				{
+					LOG_WARN(Core, "[ConnectionPool] Reconnect failed: {}", mysql_error(new_handle));
+					mysql_close(new_handle);
+					new_handle = nullptr;
+				}
+				else
+				{
+					LOG_INFO(Core, "[ConnectionPool] Reconnected after ping failure");
+				}
+			}
+
+			// Phase 4 (verrou) : publier le nouveau handle (ou marquer le slot mort).
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				if (slot_index < m_connections.size())
+				{
+					if (reconnect_ok && new_handle)
+					{
+						m_connections[slot_index].mysql = new_handle;
+						// in_use reste true : on remet la connexion au caller.
+					}
+					else
+					{
+						m_connections[slot_index].mysql = nullptr;
+						m_connections[slot_index].in_use = false;
+					}
+				}
+			}
+
+			if (reconnect_ok && new_handle)
+			{
+				return Guard(this, new_handle);
+			}
+
 			if (std::chrono::steady_clock::now() >= deadline)
 			{
-				LOG_ERROR(Core, "[ConnectionPool] Acquire timeout");
+				LOG_ERROR(Core, "[ConnectionPool] Acquire timeout after reconnect failure");
 				return Guard();
 			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(kAcquireRetryMs));
+			// On boucle pour essayer un autre slot.
 		}
 	}
 

--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -1,4 +1,5 @@
 #include "src/shared/db/SqlPreparedStatement.h"
+#include "src/shared/core/Log.h"
 
 #include <mysql.h>
 

--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -196,10 +196,53 @@ namespace engine::server::db
 
 	bool SqlPreparedStatement::FetchRow()
 	{
+		// Audit 2026-05-18 : avant ce fix, on traitait `rc != 0` comme "fin de
+		// stream" indiscriminement. Or `mysql_stmt_fetch` peut retourner
+		// `MYSQL_DATA_TRUNCATED` (1) si une colonne STRING depasse les 256
+		// octets alloues par buffer (`SqlPreparedStatement.cpp:48`). Resultat :
+		// donnees silencieusement tronquees consideres comme "pas de row" ->
+		// terms_editions / mails / bodies disparaissent. Fix : detecter
+		// MYSQL_DATA_TRUNCATED, redimensionner le buffer de la colonne et
+		// refetch via mysql_stmt_fetch_column.
 		if (!m_stmt)
 			return false;
 		const int rc = mysql_stmt_fetch(m_stmt);
-		return rc == 0;  // 0 = OK, MYSQL_NO_DATA = fin, autres = erreur
+		if (rc == 0)
+			return true;
+		if (rc == MYSQL_NO_DATA)
+			return false;
+		if (rc == MYSQL_DATA_TRUNCATED)
+		{
+			bool any_refetch_failed = false;
+			for (size_t i = 0; i < m_resultColumnCount; ++i)
+			{
+				const unsigned long actual_len = m_resultLengths[i];
+				if (actual_len > m_resultBuffers[i].size())
+				{
+					LOG_WARN(Core, "[SqlPreparedStatement] Column {} truncated: actual={} buffer={}",
+						i, actual_len, m_resultBuffers[i].size());
+					m_resultBuffers[i].resize(actual_len + 1);
+					MYSQL_BIND rb;
+					std::memset(&rb, 0, sizeof(rb));
+					rb.buffer = m_resultBuffers[i].data();
+					rb.buffer_length = static_cast<unsigned long>(m_resultBuffers[i].size());
+					rb.length = &m_resultLengths[i];
+					rb.is_null = reinterpret_cast<bool*>(&m_resultIsNull[i]);
+					rb.buffer_type = MYSQL_TYPE_STRING;
+					if (mysql_stmt_fetch_column(m_stmt, &rb, static_cast<unsigned int>(i), 0) != 0)
+					{
+						LOG_ERROR(Core, "[SqlPreparedStatement] mysql_stmt_fetch_column failed for col {}: {}",
+							i, mysql_stmt_error(m_stmt));
+						any_refetch_failed = true;
+					}
+				}
+			}
+			return !any_refetch_failed;
+		}
+		// Autre erreur (rc == 1 = MYSQL_ERROR, etc.)
+		LOG_ERROR(Core, "[SqlPreparedStatement] mysql_stmt_fetch rc={} err={}",
+			rc, mysql_stmt_error(m_stmt));
+		return false;
 	}
 
 	int32_t SqlPreparedStatement::GetInt32(size_t col, int32_t fallback) const

--- a/src/shared/security/BotDetector.cpp
+++ b/src/shared/security/BotDetector.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 #include <numeric>
 
 namespace engine::server
@@ -14,6 +15,7 @@ namespace engine::server
 
 	void BotDetector::SetConfig(const BotDetectorConfig& config)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_config = config;
 		LOG_INFO(Net,
 			"[BotDetector] Config set: window={} min_interval_ms={} variance_threshold={} "
@@ -45,6 +47,7 @@ namespace engine::server
 	BotSignal BotDetector::RecordAction(uint64_t userId, BotActionType type,
 		std::chrono::steady_clock::time_point now)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		UserActionState& st = m_byUser[userId];
 		st.last_active = now;
 
@@ -137,22 +140,26 @@ namespace engine::server
 
 	bool BotDetector::IsSuspicious(uint64_t userId) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		return m_flagged.count(userId) > 0;
 	}
 
 	bool BotDetector::ShouldAutoBan(uint64_t userId) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		return m_autoban.count(userId) > 0;
 	}
 
 	void BotDetector::FlagForReview(uint64_t userId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_flagged.insert(userId);
 		LOG_INFO(Net, "[BotDetector] User manually flagged for review: userId={}", userId);
 	}
 
 	void BotDetector::ClearFlag(uint64_t userId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_flagged.erase(userId);
 		m_autoban.erase(userId);
 		auto it = m_byUser.find(userId);
@@ -161,12 +168,25 @@ namespace engine::server
 		LOG_INFO(Net, "[BotDetector] Flag cleared for userId={}", userId);
 	}
 
+	std::vector<uint64_t> BotDetector::GetFlaggedUsers() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return std::vector<uint64_t>(m_flagged.begin(), m_flagged.end());
+	}
+
+	std::vector<uint64_t> BotDetector::GetAutoBanUsers() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return std::vector<uint64_t>(m_autoban.begin(), m_autoban.end());
+	}
+
 	// -----------------------------------------------------------------------
 	// Maintenance
 	// -----------------------------------------------------------------------
 
 	void BotDetector::PurgeExpired()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		const auto now    = std::chrono::steady_clock::now();
 		const auto cutoff = now - std::chrono::seconds(m_config.idle_purge_sec);
 

--- a/src/shared/security/BotDetector.h
+++ b/src/shared/security/BotDetector.h
@@ -3,13 +3,17 @@
 // M33.3 — Bot detection heuristics: track input timing, detect impossible actions.
 // Records per-user action timestamps and computes timing regularity.
 // Suspicious accounts are flagged for manual review or auto-banned.
-// Thread-safe only if caller serialises access (single-worker v1).
+// Audit 2026-05-18 : ajout d'un mutex interne. Avant ce fix, le commentaire
+// disait "thread-safe only if caller serialises (single-worker v1)" et il n'y
+// avait aucune protection. NetServer dispatche les paquets via un pool de
+// workers -> data race UB sur m_byUser / m_flagged / m_autoban.
 
 #include "src/shared/core/Config.h"
 
 #include <chrono>
 #include <cstdint>
 #include <deque>
+#include <mutex>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -86,11 +90,14 @@ namespace engine::server
 		/// Clear the flag for a user (after successful manual review).
 		void ClearFlag(uint64_t userId);
 
-		/// Read-only view of currently flagged user IDs.
-		const std::unordered_set<uint64_t>& GetFlaggedUsers() const { return m_flagged; }
+		/// Snapshot (par copie) des userIds actuellement flagges.
+		/// Audit 2026-05-18 : retournait une reference vers le set interne, ce
+		/// qui etait non thread-safe (la ref pouvait etre invalidee par RecordAction
+		/// concurrent). On retourne desormais une copie sous verrou.
+		std::vector<uint64_t> GetFlaggedUsers() const;
 
-		/// Read-only view of users that crossed the auto-ban threshold.
-		const std::unordered_set<uint64_t>& GetAutoBanUsers() const { return m_autoban; }
+		/// Snapshot (par copie) des userIds passes le threshold auto-ban.
+		std::vector<uint64_t> GetAutoBanUsers() const;
 
 		/// Purge stale user state. Call periodically (e.g., every few minutes).
 		void PurgeExpired();
@@ -112,6 +119,7 @@ namespace engine::server
 			std::chrono::steady_clock::time_point last_active{};
 		};
 
+		mutable std::mutex m_mutex;
 		BotDetectorConfig m_config;
 		std::unordered_map<uint64_t, UserActionState> m_byUser;
 		std::unordered_set<uint64_t> m_flagged;

--- a/src/shared/security/RateLimitAndBan.cpp
+++ b/src/shared/security/RateLimitAndBan.cpp
@@ -1,14 +1,17 @@
 #include "src/shared/security/RateLimitAndBan.h"
 #include "src/shared/core/Log.h"
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <mutex>
 #include <string>
 
 namespace engine::server
 {
 	void RateLimitAndBan::SetConfig(const RateLimitAndBanConfig& config)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_config = config;
 		LOG_DEBUG(Net, "[RateLimitAndBan] Config set: auth_per_min={} register_per_hour={} max_failures={} ban_duration_sec={}",
 			m_config.auth_per_minute, m_config.register_per_hour, m_config.max_failures_before_ban, m_config.ban_duration_sec);
@@ -27,6 +30,7 @@ namespace engine::server
 
 	bool RateLimitAndBan::tryConsume(TokenBucket& bucket, double capacity, double refill_per_sec)
 	{
+		// Caller doit detenir m_mutex.
 		auto now = Clock::now();
 		double elapsed = std::chrono::duration<double>(now - bucket.last_refill).count();
 		bucket.tokens = std::min(capacity, bucket.tokens + elapsed * refill_per_sec);
@@ -39,10 +43,22 @@ namespace engine::server
 		return false;
 	}
 
+	bool RateLimitAndBan::isBanned_NoLock(const std::string& ip_key) const
+	{
+		// Caller doit detenir m_mutex.
+		auto it = m_banned_until.find(ip_key);
+		if (it == m_banned_until.end())
+			return false;
+		if (Clock::now() < it->second)
+			return true;
+		return false;
+	}
+
 	bool RateLimitAndBan::TryConsumeAuth(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
-		if (IsBanned(ip))
+		if (isBanned_NoLock(key))
 			return false;
 		double capacity = static_cast<double>(m_config.auth_per_minute);
 		double refill_per_sec = capacity / 60.0;
@@ -58,8 +74,9 @@ namespace engine::server
 
 	bool RateLimitAndBan::TryConsumeRegister(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
-		if (IsBanned(ip))
+		if (isBanned_NoLock(key))
 			return false;
 		double capacity = static_cast<double>(m_config.register_per_hour);
 		double refill_per_sec = capacity / 3600.0;
@@ -75,6 +92,7 @@ namespace engine::server
 
 	void RateLimitAndBan::RecordAuthFailure(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
 		AuthState& state = m_by_ip[key];
 		state.failure_count++;
@@ -90,16 +108,13 @@ namespace engine::server
 
 	bool RateLimitAndBan::IsBanned(std::string_view ip) const
 	{
-		auto it = m_banned_until.find(std::string(ip));
-		if (it == m_banned_until.end())
-			return false;
-		if (Clock::now() < it->second)
-			return true;
-		return false;
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return isBanned_NoLock(std::string(ip));
 	}
 
 	void RateLimitAndBan::purgeOldEntries()
 	{
+		// Caller doit detenir m_mutex.
 		if (m_config.max_entries_per_map == 0)
 			return;
 		auto now = Clock::now();
@@ -122,6 +137,7 @@ namespace engine::server
 
 	void RateLimitAndBan::PurgeExpired()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = Clock::now();
 		for (auto it = m_banned_until.begin(); it != m_banned_until.end(); )
 		{
@@ -135,6 +151,7 @@ namespace engine::server
 
 	void RateLimitAndBan::GetCounters(SecurityCounters& out) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		out = m_counters;
 		out.bans_active = 0;
 		auto now = Clock::now();

--- a/src/shared/security/RateLimitAndBan.h
+++ b/src/shared/security/RateLimitAndBan.h
@@ -4,13 +4,15 @@
 
 #include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
 namespace engine::server
 {
-	/// Counters exportables for observability (pre-M23). Thread-safe only if caller serialises access (v1).
+	/// Counters exportables for observability (pre-M23). Lecture/ecriture
+	/// proteges par le mutex de la classe parente RateLimitAndBan / autres.
 	struct SecurityCounters
 	{
 		uint64_t rate_limit_hits_auth = 0;
@@ -35,6 +37,12 @@ namespace engine::server
 	};
 
 	/// Token bucket + failure count + IP ban. Apply before costly auth/DB. In-memory + periodic purge.
+	///
+	/// Thread-safe : mutex interne protege m_by_ip / m_banned_until / m_counters.
+	/// Toutes les methodes publiques le prennent. Les workers NetServer peuvent
+	/// appeler TryConsume*/RecordAuthFailure/IsBanned en parallele.
+	/// Audit 2026-05-18 : avant ce fix, le commentaire disait "thread-safe only
+	/// if caller serialises" et il n'y avait aucune protection -> data race UB.
 	class RateLimitAndBan
 	{
 	public:
@@ -79,6 +87,7 @@ namespace engine::server
 			int failure_count = 0;
 		};
 
+		mutable std::mutex m_mutex;
 		RateLimitAndBanConfig m_config;
 		mutable SecurityCounters m_counters;
 		std::unordered_map<std::string, AuthState> m_by_ip;
@@ -86,5 +95,8 @@ namespace engine::server
 
 		bool tryConsume(TokenBucket& bucket, double capacity, double refill_per_sec);
 		void purgeOldEntries();
+		/// Variante sans verrou de IsBanned, a utiliser quand le caller detient
+		/// deja m_mutex (TryConsumeAuth, TryConsumeRegister). Evite un re-lock.
+		bool isBanned_NoLock(const std::string& ip_key) const;
 	};
 }

--- a/src/shared/security/SecurityAuditLog.cpp
+++ b/src/shared/security/SecurityAuditLog.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <ctime>
 #include <format>
 #include <string>
 
@@ -18,10 +19,21 @@ namespace engine::server
 
 	std::string SecurityAuditLog::timestamp()
 	{
+		// Audit 2026-05-18 : `std::gmtime` retourne un pointeur vers une struct
+		// statique partagee non thread-safe. writeLine est appele depuis les
+		// workers NetServer (login fail, ban, session_closed) -> race UB,
+		// timestamps potentiellement corrompus. On bascule sur la variante
+		// reentrante : gmtime_s sous Windows, gmtime_r sous POSIX.
 		auto now = std::chrono::system_clock::now();
 		auto t = std::chrono::system_clock::to_time_t(now);
+		std::tm tm_buf{};
+#if defined(_WIN32)
+		gmtime_s(&tm_buf, &t);
+#else
+		gmtime_r(&t, &tm_buf);
+#endif
 		char buf[32];
-		std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&t));
+		std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
 		return std::string(buf);
 	}
 

--- a/src/shared/security/UserRateLimiter.cpp
+++ b/src/shared/security/UserRateLimiter.cpp
@@ -4,11 +4,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <mutex>
 
 namespace engine::server
 {
 	void UserRateLimiter::SetConfig(const UserRateLimiterConfig& config)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_config = config;
 		LOG_INFO(Net, "[UserRateLimiter] Config set: chat_per_minute={} skills_per_sec={} max_entries={}",
 			m_config.chat_per_minute, m_config.skills_per_sec, m_config.max_entries);
@@ -25,6 +27,7 @@ namespace engine::server
 
 	bool UserRateLimiter::TryConsumeChat(uint64_t userId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = Clock::now();
 		UserState& st = m_byUser[userId];
 		st.last_active = now;
@@ -47,6 +50,7 @@ namespace engine::server
 
 	bool UserRateLimiter::TryConsumeSkill(uint64_t userId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = Clock::now();
 		UserState& st = m_byUser[userId];
 		st.last_active = now;
@@ -79,6 +83,7 @@ namespace engine::server
 
 	void UserRateLimiter::PurgeExpired()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		const auto now    = Clock::now();
 		const auto cutoff = now - std::chrono::minutes(5);
 
@@ -102,6 +107,7 @@ namespace engine::server
 
 	void UserRateLimiter::GetCounters(UserRateLimitCounters& out) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		out = m_counters;
 	}
 }

--- a/src/shared/security/UserRateLimiter.h
+++ b/src/shared/security/UserRateLimiter.h
@@ -2,13 +2,17 @@
 
 // M33.3 — User-based rate limiter for in-game actions (chat 10 msg/min, skills 20/sec).
 // Token bucket for skills; sliding window for chat.
-// Thread-safe only if caller serialises access (single-worker v1).
+// Audit 2026-05-18 : ajout d'un mutex interne. Avant ce fix, le commentaire disait
+// "thread-safe only if caller serialises (single-worker v1)" et il n'y avait
+// aucune protection alors que NetServer dispatche les paquets via un pool de
+// workers -> data race UB sur m_byUser.
 
 #include "src/shared/core/Config.h"
 
 #include <chrono>
 #include <cstdint>
 #include <deque>
+#include <mutex>
 #include <unordered_map>
 
 namespace engine::server
@@ -82,6 +86,7 @@ namespace engine::server
 			Clock::time_point last_active{};
 		};
 
+		mutable std::mutex m_mutex;
 		UserRateLimiterConfig m_config;
 		mutable UserRateLimitCounters m_counters;
 		std::unordered_map<uint64_t, UserState> m_byUser;


### PR DESCRIPTION
…afe + DB ping hors lock + truncation detect

Lot 4 du plan d'audit 2026-05-18. Six fixes critiques de securite/concurrence cote serveur master.

1. **SessionManager : RAND_bytes au lieu de mt19937_64 (P0)** Avant : `std::mt19937_64(rd())` pour generer session_id. Mersenne Twister n'est PAS un CSPRNG : apres ~624 sorties consecutives observees l'etat interne est recuperable et tous les session_id futurs deviennent predictibles -> hijacking de session trivial pour un attaquant qui en collecte quelques-uns (logs, debug, sa propre instance). Apres : `RAND_bytes` (OpenSSL CSPRNG, deja utilise par ShardTicketHandler).

2. **SessionManager : mutex interne sur toutes les methodes (P0)** Avant : commentaire trompeur "v1 single-threaded server", AUCUN mutex sur `m_by_session_id` / `m_by_account_id`. Or NetServer dispatche les paquets via un pool de worker threads -> data race UB pendant CreateSession + EvictExpired + Close concurrents -> corruption / crash master = downtime. Apres : `mutable std::mutex m_mutex` + lock_guard sur tous les acces. `closeInternal_NoLock` ajoute pour eviter la deadlock dans CreateSession qui doit fermer une session existante (KickExisting).

3. **RateLimitAndBan / UserRateLimiter / BotDetector : mutex interne (P0)** Meme cause : commentaires "thread-safe only if caller serialises" trompeurs, appeles depuis les workers NetServer sans aucune protection. Bonus BotDetector : `GetFlaggedUsers` / `GetAutoBanUsers` retournaient une reference sur un set interne, invalidable par RecordAction concurrent. On bascule sur `std::vector<uint64_t>` par copie (snapshot sous verrou).

4. **SecurityAuditLog : gmtime -> gmtime_s/gmtime_r (P0)** Avant : `std::gmtime` retourne un pointeur vers une struct STATIQUE non thread-safe. `writeLine` est appele depuis plusieurs workers (login fail, ban, session close) -> race UB, timestamps corrompus. Apres : `gmtime_s` (Windows) / `gmtime_r` (POSIX) dans une `std::tm` locale.

5. **ConnectionPool::Acquire : mysql_ping HORS lock (P1)** Avant : `mysql_ping` (round-trip reseau, plusieurs ms a plusieurs sec en cas de timeout MySQL) appele SOUS m_mutex -> tous les autres workers DB bloques pendant le ping d'un slot mort. Sous charge, tout le pool serialisait sur la latence MySQL. Apres : extraction en 4 phases : 1. Reserver un slot sous verrou. 2. Ping HORS verrou (slow). 3. Si echec : close + reconnect HORS verrou. 4. Publier le nouveau handle sous verrou (ou marquer le slot mort).

6. **SqlPreparedStatement::FetchRow : detection de troncature STRING (P0)** Avant : buffer fixe 256 octets pour les colonnes STRING. `mysql_stmt_fetch` retourne `MYSQL_DATA_TRUNCATED` pour toute colonne > 256 -> traite comme "fin de stream" silencieusement (rc != 0). Critique pour `terms_editions.contents`, `mails.body`, etc. -> donnees perdues sans diagnostic. Apres : detecter MYSQL_DATA_TRUNCATED, identifier les colonnes tronquees via m_resultLengths, resize leur buffer, et refetch via `mysql_stmt_fetch_column`. Log WARN explicite quand ca arrive.

Deploiement : ⚠️ REDEPLOIEMENT SERVEUR MASTER REQUIS. Ces fixes ne sont actifs qu'apres redemarrage du binaire master. Aucun changement de wire / d'opcode / de schema DB -> compatibilite ascendante avec les clients existants. Les sessions actives au moment du redemarrage seront perdues (kick de tout le monde, comme tout deploiement master).