### PR TITLE
fix(masterd): route opcode 37 (ResendVerificationRequest) vers Passwo…

### DIFF
--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1030,7 +1030,13 @@ int main(int argc, char** argv)
 			serverListHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeForgotPasswordRequest
 		      || opcode == kOpcodeResetPasswordRequest
-		      || opcode == kOpcodeVerifyEmailRequest)
+		      || opcode == kOpcodeVerifyEmailRequest
+		      // Audit 2026-05-18 : opcode 37 (kOpcodeResendVerificationRequest)
+		      // etait orphelin — PasswordResetHandler::HandlePacket l.49 le gere
+		      // (HandleResendVerification l.296) mais le routing principal ne le
+		      // dispatchait pas, le client envoyait dans le vide et tombait dans
+		      // le default branch -> authHandler -> BAD_REQUEST silencieux.
+		      || opcode == kOpcodeResendVerificationRequest)
 			passwordResetHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeTermsStatusRequest || opcode == kOpcodeTermsContentRequest || opcode == kOpcodeTermsAcceptRequest)
 			termsHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);


### PR DESCRIPTION
…rdResetHandler

Audit 2026-05-18 : opcode 37 (`kOpcodeResendVerificationRequest`) etait orphelin cote serveur :
- `PasswordResetHandler::HandlePacket` (l.49-53) gere bien l'opcode et appelle `HandleResendVerification` (l.296).
- Mais `main_linux.cpp:1031-1033` ne routait que les opcodes 35/36/38 (Forgot/ Reset/Verify) vers le handler ; le 37 tombait dans le default branch (authHandler) qui ne le connaissait pas et renvoyait BAD_REQUEST silencieux.

Consequence : le client appuyant sur "Renvoyer le code de verification" envoyait le paquet dans le vide. Le compte restait bloque sans verification email.

Fix : ajouter `kOpcodeResendVerificationRequest` a la liste des opcodes routes vers `passwordResetHandler` dans `main_linux.cpp`.

Deploiement : ⚠️ redeploiement serveur master REQUIS — le handler existait deja mais le routing manquait ; sans redeploiement le bug reste actif.