### PR TITLE
fix(shared/security): CaptchaVerifier HTTPS hardening (cert validatio…

### DIFF
--- a/src/shared/security/CaptchaVerifier.cpp
+++ b/src/shared/security/CaptchaVerifier.cpp
@@ -1,22 +1,38 @@
 // M33.3 — CAPTCHA token verifier implementation.
-// UNIX: uses blocking POSIX socket + OpenSSL to POST to the provider verify endpoint.
-// Windows: HTTP layer not implemented — logs warning, returns true (bypass for local/dev builds).
+// UNIX: POSIX socket + OpenSSL HTTPS POST avec validation cert + timeouts + URL-encoding.
+// Windows: HTTPS layer non implementee — retourne false (refus) au lieu de bypass.
+//          Le master prod tourne sur Linux ; Windows uniquement pour dev/tests (utiliser
+//          captcha.trusted_ips pour les IPs locales).
+//
+// Audit 2026-05-18 : VerifyHttp cumulait 5 problemes critiques (P0) avant ce fix :
+//   1. Aucune validation cert (pas de SSL_CTX_set_verify, pas de load_verify_paths)
+//      -> MITM trivial pour exfiltrer le secret_key hCaptcha/reCaptcha.
+//   2. Token concatene au body sans URL-encoding -> injection theorique de
+//      parametres / CRLF si le fournisseur change le format de token un jour.
+//   3. Aucun timeout socket -> attaquant peut faire pendre indefiniment le master
+//      sur le verify (DoS register).
+//   4. Un seul SSL_read 4 Ko -> reponses fragmentees produisent des faux negatifs.
+//   5. Sur Windows, VerifyHttp retournait true sans verifier RIEN (bypass total).
+//      Si quelqu'un lancait le master sur Windows, register sans CAPTCHA.
 #include "src/shared/security/CaptchaVerifier.h"
 #include "src/shared/core/Log.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <string>
 #include <string_view>
 
-// OpenSSL-based HTTP POST is only compiled on UNIX where OpenSSL is available.
+// OpenSSL-based HTTP POST is only compiled on UNIX where the socket layer is POSIX.
 #if defined(__unix__) || defined(__linux__) || defined(__APPLE__)
 #  define CAPTCHA_HAS_HTTP 1
 #  include <arpa/inet.h>
 #  include <netdb.h>
 #  include <sys/socket.h>
+#  include <sys/time.h>
 #  include <unistd.h>
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
+#  include <openssl/x509v3.h>
 #  include <cstring>
 #  include <sstream>
 #else
@@ -25,6 +41,40 @@
 
 namespace engine::server
 {
+	namespace
+	{
+		/// Timeout TCP connect / TLS handshake / SSL_read / SSL_write.
+		/// Le verify CAPTCHA est synchrone dans le flux register : trop court bloque
+		/// les utilisateurs legitimes sur reseau lent ; trop long ouvre un DoS.
+		/// 5s de marge pour le DNS + handshake + round-trip, 3s par operation socket.
+		constexpr int kCaptchaConnectTimeoutSec = 5;
+		constexpr int kCaptchaIoTimeoutSec      = 3;
+
+		/// URL-encode application/x-www-form-urlencoded : conserve [a-zA-Z0-9-_.~]
+		/// tel quel, encode tout le reste en %XX. RFC 3986 section 2.3.
+		std::string UrlEncode(std::string_view s)
+		{
+			std::string out;
+			out.reserve(s.size() * 3u / 2u);
+			for (unsigned char c : s)
+			{
+				if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+				    (c >= '0' && c <= '9') ||
+				    c == '-' || c == '_' || c == '.' || c == '~')
+				{
+					out.push_back(static_cast<char>(c));
+				}
+				else
+				{
+					char hex[4];
+					std::snprintf(hex, sizeof(hex), "%%%02X", c);
+					out.append(hex);
+				}
+			}
+			return out;
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// Configuration
 	// -----------------------------------------------------------------------
@@ -140,13 +190,13 @@ namespace engine::server
 
 #if CAPTCHA_HAS_HTTP
 
-	/// Minimal HTTPS POST to the CAPTCHA verify endpoint.
+	/// Minimal HTTPS POST to the CAPTCHA verify endpoint avec validation cert,
+	/// URL-encoding du body, timeouts socket, lecture bouclee.
 	/// Parses the JSON response for {"success":true}.
 	bool CaptchaVerifier::VerifyHttp(std::string_view token, std::string_view remoteIp) const
 	{
 		// Parse host/path from verify URL.
 		const std::string url = ResolveVerifyUrl();
-		// Expected format: https://<host>/<path>
 		if (url.rfind("https://", 0) != 0)
 		{
 			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: unsupported URL scheme: {}", url);
@@ -161,21 +211,21 @@ namespace engine::server
 			? "/"
 			: hostAndPath.substr(slashPos);
 
-		// Build POST body.
+		// Build POST body avec URL-encoding (audit fix #2).
 		std::string body = "secret=";
-		body += m_config.secret_key;
+		body += UrlEncode(m_config.secret_key);
 		body += "&response=";
-		body += std::string(token);
+		body += UrlEncode(token);
 		if (!remoteIp.empty())
 		{
 			body += "&remoteip=";
-			body += std::string(remoteIp);
+			body += UrlEncode(remoteIp);
 		}
 
-		// Build HTTP request.
 		std::ostringstream req;
 		req << "POST " << path << " HTTP/1.1\r\n"
 		    << "Host: " << host << "\r\n"
+		    << "User-Agent: lcdlln-master/captcha\r\n"
 		    << "Content-Type: application/x-www-form-urlencoded\r\n"
 		    << "Content-Length: " << body.size() << "\r\n"
 		    << "Connection: close\r\n"
@@ -202,16 +252,28 @@ namespace engine::server
 			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: socket() failed");
 			return false;
 		}
+
+		// Timeouts socket (audit fix #3) : SO_RCVTIMEO + SO_SNDTIMEO bornent
+		// connect/read/write a kCaptchaIoTimeoutSec chacun. Sans cela, un
+		// fournisseur qui pend faisait pendre le master indefiniment -> DoS.
+		struct timeval tv{};
+		tv.tv_sec  = kCaptchaIoTimeoutSec;
+		tv.tv_usec = 0;
+		setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+		setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+		// connect avec son propre timeout via SO_SNDTIMEO + alarme manuelle :
+		// on garde la connexion bloquante (avec SO_SNDTIMEO ca borne la duree).
 		if (::connect(fd, res->ai_addr, res->ai_addrlen) != 0)
 		{
 			freeaddrinfo(res);
 			::close(fd);
-			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: connect() failed to host={}", host);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: connect() failed/timeout to host={}", host);
 			return false;
 		}
 		freeaddrinfo(res);
 
-		// TLS handshake.
+		// TLS handshake AVEC validation cert (audit fix #1).
 		SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
 		if (!ctx)
 		{
@@ -219,25 +281,114 @@ namespace engine::server
 			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_CTX_new failed");
 			return false;
 		}
-		SSL* ssl = SSL_new(ctx);
-		SSL_set_fd(ssl, fd);
-		SSL_set_tlsext_host_name(ssl, host.c_str());
-		if (SSL_connect(ssl) != 1)
+		// Charge les root CAs du systeme (Debian/Ubuntu: /etc/ssl/certs).
+		if (SSL_CTX_set_default_verify_paths(ctx) != 1)
 		{
-			SSL_free(ssl);
 			SSL_CTX_free(ctx);
 			::close(fd);
-			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: TLS handshake failed to host={}", host);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_CTX_set_default_verify_paths failed — no root CAs available");
+			return false;
+		}
+		// Demande la validation du peer ; si la chaine est invalide, SSL_connect echoue.
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
+		// Verifie aussi que le hostname du cert matche celui qu'on veut joindre
+		// (protection contre cert valide pour un autre domaine).
+		SSL_CTX_set_verify_depth(ctx, 8);
+
+		SSL* ssl = SSL_new(ctx);
+		if (!ssl)
+		{
+			SSL_CTX_free(ctx);
+			::close(fd);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_new failed");
 			return false;
 		}
 
-		// Send request.
-		SSL_write(ssl, reqStr.data(), static_cast<int>(reqStr.size()));
+		// SNI + hostname check via X509_VERIFY_PARAM.
+		SSL_set_tlsext_host_name(ssl, host.c_str());
+		X509_VERIFY_PARAM* vparam = SSL_get0_param(ssl);
+		if (vparam)
+		{
+			// X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS : refuse *.foo.bar pour foo.bar
+			X509_VERIFY_PARAM_set_hostflags(vparam, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+			if (X509_VERIFY_PARAM_set1_host(vparam, host.c_str(), host.size()) != 1)
+			{
+				SSL_free(ssl);
+				SSL_CTX_free(ctx);
+				::close(fd);
+				LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: X509_VERIFY_PARAM_set1_host failed");
+				return false;
+			}
+		}
 
-		// Read response (up to 4 KB).
-		char buf[4096]{};
-		int  read_len = SSL_read(ssl, buf, sizeof(buf) - 1);
-		buf[read_len > 0 ? read_len : 0] = '\0';
+		SSL_set_fd(ssl, fd);
+		if (SSL_connect(ssl) != 1)
+		{
+			// SSL_connect echec : log les erreurs OpenSSL pour aider le diag
+			// (typiquement cert invalide, hostname mismatch, ou expiration).
+			const unsigned long err = ERR_get_error();
+			char errbuf[256];
+			ERR_error_string_n(err, errbuf, sizeof(errbuf));
+			SSL_free(ssl);
+			SSL_CTX_free(ctx);
+			::close(fd);
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: TLS handshake failed to host={} err={}", host, errbuf);
+			return false;
+		}
+
+		// Verification explicite du resultat de verify (defense en profondeur ;
+		// SSL_connect echoue deja sur cert invalide, mais on double-check).
+		const long verify_result = SSL_get_verify_result(ssl);
+		if (verify_result != X509_V_OK)
+		{
+			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: cert verify failed code={} ({})",
+				verify_result, X509_verify_cert_error_string(verify_result));
+			SSL_shutdown(ssl);
+			SSL_free(ssl);
+			SSL_CTX_free(ctx);
+			::close(fd);
+			return false;
+		}
+
+		// Send request avec un loop d'ecriture (SSL_write peut retourner partiel
+		// sur SSL_MODE_ENABLE_PARTIAL_WRITE ou WANT_READ/WANT_WRITE).
+		size_t total_written = 0;
+		while (total_written < reqStr.size())
+		{
+			const int chunk = SSL_write(ssl,
+				reqStr.data() + total_written,
+				static_cast<int>(reqStr.size() - total_written));
+			if (chunk <= 0)
+			{
+				LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_write failed/timeout (host={} sent={}/{})",
+					host, total_written, reqStr.size());
+				SSL_shutdown(ssl);
+				SSL_free(ssl);
+				SSL_CTX_free(ctx);
+				::close(fd);
+				return false;
+			}
+			total_written += static_cast<size_t>(chunk);
+		}
+
+		// Read response en boucle (audit fix #4) jusqu'a EOF ou erreur, max 64 KB.
+		std::string response;
+		response.reserve(4096);
+		constexpr size_t kMaxResponseBytes = 64u * 1024u;
+		char buf[4096];
+		while (response.size() < kMaxResponseBytes)
+		{
+			const int n = SSL_read(ssl, buf, sizeof(buf));
+			if (n > 0)
+			{
+				response.append(buf, static_cast<size_t>(n));
+			}
+			else
+			{
+				// 0 = clean shutdown ; <0 = erreur ou timeout. Dans les deux cas on s'arrete.
+				break;
+			}
+		}
 
 		SSL_shutdown(ssl);
 		SSL_free(ssl);
@@ -245,7 +396,6 @@ namespace engine::server
 		::close(fd);
 
 		// Look for "success":true in the JSON body (simple substring match).
-		const std::string response(buf, read_len > 0 ? static_cast<size_t>(read_len) : 0u);
 		const bool success = response.find("\"success\":true") != std::string::npos
 		                  || response.find("\"success\": true") != std::string::npos;
 
@@ -255,7 +405,8 @@ namespace engine::server
 		}
 		else
 		{
-			LOG_WARN(Net, "[CaptchaVerifier] Token verification FAILED (host={})", host);
+			LOG_WARN(Net, "[CaptchaVerifier] Token verification FAILED (host={} response_size={})",
+				host, response.size());
 		}
 		return success;
 	}
@@ -264,10 +415,16 @@ namespace engine::server
 
 	bool CaptchaVerifier::VerifyHttp(std::string_view /*token*/, std::string_view /*remoteIp*/) const
 	{
-		LOG_WARN(Net,
+		// Audit 2026-05-18 fix #5 : avant on retournait true (bypass total). Si
+		// quelqu'un lancait le master sur Windows, register sans CAPTCHA. On
+		// refuse desormais. Windows est usage dev/tests uniquement ; pour les
+		// IPs locales, utiliser `captcha.trusted_ips` qui sont autorisees
+		// avant le VerifyHttp (cf. Verify() public).
+		LOG_ERROR(Net,
 			"[CaptchaVerifier] VerifyHttp: HTTP layer not implemented on this platform — "
-			"token accepted (bypass). Configure an external CAPTCHA proxy for production.");
-		return true;
+			"verification REFUSED. Configure captcha.trusted_ips pour les hotes dev/tests, "
+			"ou utiliser le master Linux pour la prod.");
+		return false;
 	}
 
 #endif // CAPTCHA_HAS_HTTP


### PR DESCRIPTION
…n + URL-encode + timeouts + looped read + Windows refus)

Lot 6 du plan d'audit 2026-05-18. Cinq P0 cumules sur la verification CAPTCHA.

1. **Validation cert TLS (P0)** Avant : `SSL_CTX_new(TLS_client_method())` sans `set_verify` ni `load_verify_paths` -> aucune verification de la chaine cert du fournisseur hCaptcha/reCaptcha. MITM trivial pour exfiltrer le `secret_key`. Apres : - `SSL_CTX_set_default_verify_paths(ctx)` charge les root CAs systeme. - `SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr)`. - `X509_VERIFY_PARAM_set1_host(vparam, host, len)` valide le hostname du cert (defense contre cert valide pour un autre domaine). - `X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS` refuse `*.foo.bar` pour `foo.bar`. - Double-check `SSL_get_verify_result(ssl) == X509_V_OK` apres handshake. - Si SSL_CTX_set_default_verify_paths echoue (no root CAs), on refuse (au lieu de continuer en non-verifie comme avant).

2. **URL-encoding du body POST (P0)** Avant : `body += std::string(token)` sans escape. Un token contenant `&secret=xxx` ou `\r\n` pouvait injecter des parametres / fragmenter la requete HTTP. Mitigation actuelle : les tokens hCaptcha/reCaptcha sont alphanum, mais on depend du fournisseur. Apres : helper `UrlEncode` (RFC 3986 section 2.3 : conserve [a-zA-Z0-9-_.~], encode tout le reste en %XX). Applique a `secret`, `response`, `remoteip`.

3. **Timeouts socket (P0)** Avant : aucun timeout sur connect/SSL_read/SSL_write -> attaquant peut faire pendre hCaptcha (ou faire pendre une replication du DNS) et bloquer le master sur le verify -> DoS register trivial. Apres : `SO_RCVTIMEO` + `SO_SNDTIMEO` configures a 3s. Connect via socket bloquante respecte SO_SNDTIMEO (timeout 3s effectif).

4. **Lecture bouclee (P0)** Avant : un seul `SSL_read(buf, 4096)`. Si la reponse arrive fragmentee (cas frequent TLS), le substring "success":true rate -> faux negatifs -> users bloques au CAPTCHA. Apres : boucle `while (response.size() < kMaxResponseBytes) SSL_read(...)` jusqu'a EOF/erreur (max 64 KB). Plus de loop d'ecriture pour SSL_write partiel.

5. **Windows : refus au lieu de bypass (P0)** Avant : `bool VerifyHttp(...) const { LOG_WARN(...); return true; }` -> si le master tournait sur Windows (test/dev) ou si la macro `__linux__` ne tombait pas, register acceptait n'importe quel token CAPTCHA. Apres : retourne `false` + LOG_ERROR explicite. Pour le dev local on passe par `captcha.trusted_ips` (deja en place avant le VerifyHttp).

Includes ajoutes : `<openssl/x509v3.h>` (X509_VERIFY_PARAM, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS), `<sys/time.h>` (struct timeval).

Deploiement : ⚠️ REDEPLOIEMENT SERVEUR MASTER REQUIS. Aucun wire change, mais les utilisateurs dev/Windows qui passaient par le bypass devront ajouter leur IP a `captcha.trusted_ips`. Le secret_key prod ne fuit plus via MITM.