### PR TITLE
fix(client/render): TerrainRenderer depthCompareOp LESS -> LESS_OR_EQUAL

### DIFF
--- a/src/client/render/terrain/TerrainRenderer.cpp
+++ b/src/client/render/terrain/TerrainRenderer.cpp
@@ -550,7 +550,11 @@ namespace engine::render::terrain
             dsCI.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
             dsCI.depthTestEnable  = VK_TRUE;
             dsCI.depthWriteEnable = VK_TRUE;
-            dsCI.depthCompareOp   = VK_COMPARE_OP_LESS;
+            // Audit 2026-05-18 : aligne avec GeometryPass.cpp, ShadowMapPass.cpp,
+            // SkyPass.cpp, TerrainChunkPipeline.cpp qui utilisent tous LESS_OR_EQUAL.
+            // LESS rejetait les triangles strictement coplanaires (z-fight sol au
+            // demarrage d'une frame ou le sol et un decal sont au meme Y).
+            dsCI.depthCompareOp   = VK_COMPARE_OP_LESS_OR_EQUAL;
 
             // 4 color attachments (A, B, C, Velocity) — no blending
             VkPipelineColorBlendAttachmentState blendAtts[4]{};


### PR DESCRIPTION
Audit 2026-05-18 : `TerrainRenderer.cpp:553` (pipeline terrain patches legacy) utilisait `VK_COMPARE_OP_LESS` alors que tous les autres pipelines de la chaine geometry-stage utilisent `VK_COMPARE_OP_LESS_OR_EQUAL` :
  - `GeometryPass.cpp:396`
  - `ShadowMapPass.cpp:213`
  - `SkyPass.cpp:106`
  - `TerrainChunkPipeline.cpp:296`

Consequence du LESS strict : tout triangle strictement coplanaire avec un fragment deja ecrit etait rejete. Cas concret en editeur monde : terrain Pre-Pass clear (LOAD_OP_CLEAR, depth=1.0) avant la geometry ; un avatar coplanaire au sol etait rejete par le terrain en LESS la ou LESS_OR_EQUAL accepte. Risque z-fight reproductible difficilement mais reel sur splats decales tres pres du sol.

Aucun impact connu en visuel actuel ; correction de coherence pour eviter une regression future quand on ajoutera des decals plaques au sol.

Deploiement : ✅ client uniquement, pas de redeploiement serveur.