### PR TITLE
fix(client/security): allow_insecure_dev fallback true -> false (audi…

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -290,7 +290,7 @@ namespace engine
 			if (persisted.Has("client.gameplay_udp.enabled"))
 				cfg.SetValue("client.gameplay_udp.enabled", persisted.GetBool("client.gameplay_udp.enabled", cfg.GetBool("client.gameplay_udp.enabled", false)));
 			if (persisted.Has("client.allow_insecure_dev"))
-				cfg.SetValue("client.allow_insecure_dev", persisted.GetBool("client.allow_insecure_dev", cfg.GetBool("client.allow_insecure_dev", true)));
+				cfg.SetValue("client.allow_insecure_dev", persisted.GetBool("client.allow_insecure_dev", cfg.GetBool("client.allow_insecure_dev", false)));
 			if (persisted.Has("client.auth_ui.timeout_ms"))
 				cfg.SetValue("client.auth_ui.timeout_ms", persisted.GetInt("client.auth_ui.timeout_ms", cfg.GetInt("client.auth_ui.timeout_ms", 5000)));
 			if (persisted.Has("render.auth_ui.background_blit.enabled"))
@@ -315,7 +315,7 @@ namespace engine
 				cfg.GetBool("controls.invert_y", false),
 				cfg.GetString("controls.movement_layout", "wasd"),
 				cfg.GetBool("client.gameplay_udp.enabled", false),
-				cfg.GetBool("client.allow_insecure_dev", true),
+				cfg.GetBool("client.allow_insecure_dev", false),
 				cfg.GetInt("client.auth_ui.timeout_ms", 5000),
 				cfg.GetBool("render.auth_ui.background_blit.enabled", true),
 				cfg.GetString("render.auth_ui.background_blit.fit", "cover_height"));

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -128,7 +128,12 @@ namespace engine::client
 				+ EscapeJsonString(locale)
 				+ "\",\n    \"auth_ui\": {\n      \"remember_login\": "
 				+ JsonBool(rememberLogin)
-				+ ",\n      \"timeout_ms\": 5000\n    },\n    \"allow_insecure_dev\": true,\n    \"gameplay_udp\": {\n      \"enabled\": false\n    }\n  },\n  \"render\": {\n    \"fullscreen\": "
+				// Audit 2026-05-18 : fallback `allow_insecure_dev` passe a `false`
+				// par defaut. Un client neuf valide la chaine de cert master TLS sauf
+				// si l'utilisateur opt-in explicitement (option dev). Avant : `true`
+				// = accept self-signed silencieusement = MITM trivial pour qui peut
+				// intercepter le trafic master du joueur.
+				+ ",\n      \"timeout_ms\": 5000\n    },\n    \"allow_insecure_dev\": false,\n    \"gameplay_udp\": {\n      \"enabled\": false\n    }\n  },\n  \"render\": {\n    \"fullscreen\": "
 				+ JsonBool(fullscreen)
 				+ ",\n    \"vsync\": "
 				+ JsonBool(vsync)
@@ -1211,7 +1216,7 @@ namespace engine::client
 		m_pendingControlSettings = {};
 		m_gameplayUdpEnabled = cfg.GetBool("client.gameplay_udp.enabled", false);
 		m_gameplayUdpEnabledPending = m_gameplayUdpEnabled;
-		m_allowInsecureDev = cfg.GetBool("client.allow_insecure_dev", true);
+		m_allowInsecureDev = cfg.GetBool("client.allow_insecure_dev", false);
 		m_allowInsecureDevPending = m_allowInsecureDev;
 		m_authTimeoutMs = static_cast<uint32_t>(std::clamp<int64_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000), 1000, 15000));
 		m_authTimeoutMsPending = m_authTimeoutMs;
@@ -2087,7 +2092,7 @@ namespace engine::client
 		const std::string host = cfg.GetEffectiveMasterHost("localhost");
 		const uint16_t port = static_cast<uint16_t>(cfg.GetInt("client.master_port", 3840));
 		const uint32_t timeoutMs = static_cast<uint32_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000));
-		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", true);
+		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", false);
 		const std::string serverFingerprint = cfg.GetString("client.server_fingerprint", "");
 		const std::string login = m_login;
 		const std::string locale = CurrentLocale();
@@ -2301,7 +2306,7 @@ namespace engine::client
 		const std::string host = cfg.GetEffectiveMasterHost("localhost");
 		const uint16_t port = static_cast<uint16_t>(cfg.GetInt("client.master_port", 3840));
 		const uint32_t timeoutMs = static_cast<uint32_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000));
-		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", true);
+		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", false);
 		const std::string serverFingerprint = cfg.GetString("client.server_fingerprint", "");
 		const std::string login = m_login;
 		const bool shardPickWhenMultiple = cfg.GetBool("client.auth_ui.shard_pick_when_multiple", true);
@@ -2381,7 +2386,7 @@ namespace engine::client
 		const std::string host = cfg.GetEffectiveMasterHost("localhost");
 		const uint16_t port = static_cast<uint16_t>(cfg.GetInt("client.master_port", 3840));
 		const uint32_t timeoutMs = static_cast<uint32_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000));
-		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", true);
+		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", false);
 		const std::string serverFingerprint = cfg.GetString("client.server_fingerprint", "");
 		const uint64_t accountId = m_pendingVerifyAccountId;
 		const std::string code = m_verifyCode;
@@ -2454,7 +2459,7 @@ namespace engine::client
 		const std::string host = cfg.GetEffectiveMasterHost("localhost");
 		const uint16_t port = static_cast<uint16_t>(cfg.GetInt("client.master_port", 3840));
 		const uint32_t timeoutMs = static_cast<uint32_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000));
-		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", true);
+		const bool allowInsecure = cfg.GetBool("client.allow_insecure_dev", false);
 		const std::string serverFingerprint = cfg.GetString("client.server_fingerprint", "");
 		const uint64_t accountId = m_pendingVerifyAccountId;
 


### PR DESCRIPTION
…t 2026-05-18)

Audit 2026-05-18 : `client.allow_insecure_dev` avait un fallback `true` dans 8 sites cote client. Si un build release sortait sans `config.json` patche, le client acceptait n'importe quel certificat TLS du master sans validation -> MITM trivial sur le trafic master du joueur (auth, session, password).

Sites modifies (tous `cfg.GetBool("client.allow_insecure_dev", true)` -> `false`) :
- `src/client/app/Engine.cpp:293` (override depuis user_settings.json)
- `src/client/app/Engine.cpp:318` (log boot)
- `src/client/auth/AuthUiPresenterCore.cpp:131` (template JSON `user_settings.json` initial : `"allow_insecure_dev": true` -> `false`)
- `src/client/auth/AuthUiPresenterCore.cpp:1214` (init membre)
- `src/client/auth/AuthUiPresenterCore.cpp:2090,2304,2384,2457` (lookups divers du flag dans le flow auth)

Le comportement utilisateur :
- Sur un fresh install sans config local : TLS validation activee par defaut, refuse les certs auto-signes / non valides.
- Sur un dev local sans cert master valide : ajouter explicitement `client.allow_insecure_dev: true` dans `config.json` ou `user_settings.json`.
- Builds QA/dev existants avec config patche : pas d'impact, leur valeur persistee gagne sur le fallback.

Aucun changement de logique : seule la valeur par defaut bascule.

Deploiement : ✅ client uniquement. Pas de redeploiement serveur.