### PR TITLE
docs(audits): update B.1 + C MVP avec bugs decouverts au smoke test f…

### DIFF
--- a/docs/superpowers/audits/2026-05-20-B1-status-known-bugs.md
+++ b/docs/superpowers/audits/2026-05-20-B1-status-known-bugs.md
@@ -64,16 +64,37 @@ Locomotion state machine production-ready en local, qui transforme la state mach
 
 **Symptôme à valider** : que se passe-t-il quand l'utilisateur appuie en même temps S+Q, S+D, ou S+Q+D ? La logique actuelle (`IsPureBackInput` = S seul) bascule en free-mover dès qu'une autre touche est ajoutée — donc S+Q se comporte comme Q seul (pivot mesh vers gauche+arrière). À tester pour valider qu'il n'y a pas de glitch d'animation.
 
-### 3. Smoke test §11 du spec non complètement validé
+### 2bis. Direction backward incorrecte après strafe latéral
+
+**Symptôme rapporté lors du smoke test C MVP final (2026-05-20)** :
+- L'utilisateur appuie sur D (strafe droite) → le perso se déplace bien à droite ✅
+- Puis il relâche D et appuie sur S (recule) → le perso recule **mais à destination de la gauche** au lieu de reculer dans la direction logique (vers la caméra) ❌
+- Symétrique avec A puis S : le perso recule à destination de la droite.
+
+**Reproduction** : appuyer brièvement sur D, relâcher, puis appuyer sur S seul. Observer la direction de recul du personnage.
+
+**Hypothèse** : le `m_avatarYaw` (ou le vecteur forward) n'est pas correctement reset entre la sortie du free-mover (Q/D) et l'entrée dans WalkBack (S seul). Le back-step utilise probablement un yaw qui a dérivé pendant le strafe.
+
+**Fichiers à inspecter** :
+- `src/client/app/Engine.cpp` : grep `m_avatarYaw`, `WalkBack`, `movingBack`, `IsPureBackInput` (zone ~6846-6926).
+- Comprendre comment le yaw est calculé pendant strafe vs backward, et pourquoi la transition strafe→backward garde une orientation résiduelle.
+
+**Premier réflexe debug** : tracer `m_avatarYaw` chaque frame et vérifier sa valeur quand on relâche Q/D et quand on enfonce S.
+
+### 3. Caméra tracking (cf. §1 — confirmé à nouveau lors du smoke test C MVP final)
+
+Le bug §1 ci-dessus a été confirmé une seconde fois lors du smoke test C MVP : la caméra ne suit pas le perso en temps réel. À traiter en priorité dans la session debug B.1 dédiée.
+
+### 4. Smoke test §11 du spec non complètement validé
 
 Les 7 critères de validation visuelle (§11) doivent être re-déroulés sur le dernier commit (`91d7279`) une fois les bugs ci-dessus résolus :
 1. ☑ Spawn sur sol, pose Idle stable (sans oscillation)
 2. ☑ Z + relâche → StartWalking → Walk → relâche → Idle
 3. ☑ Shift+Z → Run, Shift relâché → Walk
-4. ☑ Espace en mouvement → Jump → Fall → Land → Walk
+4. ☑ Espace en mouvement → Jump → Fall → Land → Walk (mais asset Jump à remplacer, cf. C MVP audit §6)
 5. ☐ S seul → WalkBack avec mesh dos cam (animation Walking Backwards visible)
 6. ☐ Q et D → mesh pivote vers la direction et avance (free-mover, plus de strafe invisible)
-7. ☐ Aucun tremblement de mesh ; caméra collée au perso sans saccade
+7. ☐ Aucun tremblement de mesh ; caméra collée au perso sans saccade (cf. §2bis + §3)
 
 ## Limitations connues (hors-scope B.1, à traiter dans B.2 / B.3 / autres)
 

--- a/docs/superpowers/audits/2026-05-20-C-MVP-status-known-bugs.md
+++ b/docs/superpowers/audits/2026-05-20-C-MVP-status-known-bugs.md
@@ -1,6 +1,6 @@
 # C MVP (Races multi-mesh) — Statut & bugs connus
 
-**Branche** : `claude/races-c-mvp` (commit de tête : `1bf83fc` au 2026-05-20)
+**Branche** : `claude/races-c-mvp` (mergée dans main via PR #648 / squash `166d484` au 2026-05-20)
 **Spec** : [docs/superpowers/specs/2026-05-20-races-mvp-design.md](../specs/2026-05-20-races-mvp-design.md)
 **Plan** : [docs/superpowers/plans/2026-05-20-races-mvp.md](../plans/2026-05-20-races-mvp.md)
 
@@ -28,20 +28,24 @@ Charger un mesh skinned différent selon la race du personnage (humain / nain / 
 ### Bugs corrigés post-test
 
 - Merge conflict après squash de B.1 sur main — commit `b1883f2` (résolution mécanique : on garde HEAD partout).
-- **Bug critique** : `kMvpRaces[]` itérait sur `"orc"` (singulier) alors que `races.json` a `"orcs"` (pluriel). Race jamais chargée, fallback humains pour tout perso orc. Fix `1bf83fc` : `{ "humains", "nains", "orcs" }`.
+- **Bug critique race id** : `kMvpRaces[]` itérait sur `"orc"` (singulier) alors que `races.json` a `"orcs"` (pluriel). Race jamais chargée, fallback humains pour tout perso orc. Fix `1bf83fc` : `{ "humains", "nains", "orcs" }`.
+- **Bug viewport invisible** : `RacePreviewViewport::Init` faisait `UNDEFINED → SHADER_READ_ONLY` sans clear color → image undefined invisible. Fix `5348ebd` : ajout `vkCmdClearColorImage` bleu sombre.
+- **Bug soft-delete slot** : `FindNextSlot` filtrait `deleted_at IS NULL` mais la unique key SQL `uq_characters_account_server_slot` était globale → collision après suppression. Fix migration `0064` (`5348ebd`) : generated VIRTUAL column `slot_active` + partial unique.
+- **Bug soft-delete name (check programmatique)** : `CharacterNameExistsOnServer` ne filtrait pas `deleted_at IS NULL` → nom de perso supprimé restait réservé à vie. Fix `913acaa`.
+- **Bug soft-delete name (unique SQL)** : seconde unique key `uq_characters_name_server` bloquait la réutilisation du nom au niveau DB. Fix migration `0065` (`ba767bc`) : generated VIRTUAL column `name_active` + partial unique.
 
-## Smoke test partiel (Task 14)
+## Smoke test final (Task 14, build post-`ba767bc`)
 
-Test effectué par l'utilisateur sur le build `cbbf955` (avant le fix `1bf83fc`). Résultats :
+Test effectué par l'utilisateur après tous les fixes (viewport + soft-delete). Résultats :
 
 | Critère §7 | Statut | Note |
 |------------|--------|------|
-| 1. Boot logs : 3 meshes chargés | ⚠️ Partiel | Humains OK (65 bones, 9 clips). Orcs n'était PAS chargé à cause du bug `orc` vs `orcs` (fix `1bf83fc`). Nains absent (fichier manquant, fallback humains attendu). |
+| 1. Boot logs : 3 meshes chargés | ⚠️ Partiel | Humains OK (65 bones, 9 clips). Orcs OK (65 bones, 9 clips). Nains absent (FBX non uploadé, fallback humains attendu). |
 | 2. Combo race affiche les 8 races | ✅ OK | Le refactor `AuthImGuiCharacterCreate` itère sur `CharacterCreationPresenter::GetRaces()`. |
-| 3. Création perso orc → mesh orc | ❌ Non testé | L'utilisateur n'a pas créé de perso orc lors de ce smoke. À re-tester sur build `1bf83fc`. |
-| 4. Login perso existant → mesh OK | ✅ OK | Le perso `fds` (race=humains) affiche correctement le mesh humain. `[EnterWorld] Avatar mesh selected for race 'humains' (65 bones, 9 clips)`. |
-| 5. Anims B.1 sur mesh race | ⚠️ Non testé | L'utilisateur a quitté immédiatement après EnterWorld, sans bouger. |
-| 6. Fallback race inconnue | ⚠️ Non testé | Pas de modif `race_str` manuel pour ce test. |
+| 3. Création perso orc → mesh orc | ✅ OK | `[EnterWorld] Avatar mesh selected for race 'orcs' (65 bones, 9 clips)` confirmé sur `grokorc`. |
+| 4. Login perso existant → mesh OK | ✅ OK | Validé sur `fds` (humains) et `grokorc` (orcs). |
+| 5. Anims B.1 sur mesh race | ⚠️ Partiel | Idle/Walk/Run/Idle transitions OK. Bugs visuels résiduels (cf. §6 ci-dessous). |
+| 6. Fallback race inconnue | ⏸️ Non testé | Test optionnel, non bloquant pour MVP. |
 
 ## Bugs en suspens (renvoyés à C.2 ou session debug ultérieure)
 
@@ -88,6 +92,48 @@ Test effectué par l'utilisateur sur le build `cbbf955` (avant le fix `1bf83fc`)
 
 **Fix possible (C.2)** : Engine pourrait demander la liste des races à AuthUI via une méthode dédiée au lieu d'instancier son propre presenter local. Refactor architecture, pas critique.
 
+### 6. Vibration des jambes pendant Walk/Run sur mesh orc
+
+**Symptôme rapporté lors du smoke test final** : pendant les anims Walk et Run sur le perso `grokorc` (race=orcs, mesh `orc.glb`), vibration / tremblement visible au niveau des jambes du personnage. Pas explicitement reporté sur le mesh humain — peut-être présent mais moins visible vu les proportions.
+
+**Hypothèses** :
+1. **Retargeting Mixamo imparfait** : les clips d'animation (`y_bot_walk.glb`, `y_bot_run.glb`, etc.) sont chargées via `LoadClipsAnimOnly` qui retarget par nom de bone (`mixamorig:LeftLeg` etc.). Si le mesh orc a des proportions de jambes différentes du Y Bot, les keyframes mal interpolées peuvent produire des micro-translations parasites.
+2. **Bone weights** du mesh orc mal exportés (problème dans le FBX original ou la conversion FBX2glTF).
+3. **Bug de skinning shader** : interpolation linéaire entre matrices au lieu de quaternion, micro-flicker numérique.
+4. **`inverseBindMatrix`** du mesh orc mal calculé (cf. `SkinnedMeshLoader`).
+
+**Premier réflexe debug** : ouvrir `orc.glb` dans un viewer (gltf-viewer-app ou Blender) pour voir si la vibration est dans le mesh source ou si elle apparaît au runtime. Si runtime, dump les matrices de bones leg et voir si elles oscillent.
+
+**Sévérité** : bas (cosmétique, pas bloquant). Chip-task créée pendant la session — à traiter dans branche dédiée `claude/debug-skinning-leg-vibration` après les bugs B.1 plus prioritaires.
+
+### 7. Anims Jump incorrectes (asset issue, action user)
+
+**Symptôme rapporté lors du smoke test final** : "On voit bien les modèles de saut, mais je n'ai pas dû te donner les bons, les visuels ne sont pas bons" — les clips Mixamo utilisés pour Jump/Fall/Land donnent un visuel incorrect.
+
+**Action user** : re-uploader les bons FBX Mixamo Jump/Fall/Land dans `tools/asset_pipeline/inbox/` (variantes "No Skin"). Les FBX actuels sont `Jumping No Skin.fbx` etc. Choisir un set d'animations cohérent qui forme un cycle Jump→Fall→Land naturel.
+
+**Sévérité** : moyenne (visuel pendant le saut). Pas un bug code, juste un remplacement d'asset suivi d'une régénération des `.glb` via `convert_race_meshes.py` ou pipeline équivalent pour les clips standalone.
+
+### 8. Direction backward incorrecte après strafe latéral (B.1)
+
+**Symptôme rapporté lors du smoke test final** : touche D (strafe droite) puis S (recule) → le perso recule mais à destination de la gauche. Symétrique avec A puis S.
+
+**Statut** : bug B.1 (locomotion / state machine), pas C MVP. Documenté en détail dans [docs/superpowers/audits/2026-05-20-B1-status-known-bugs.md §2bis](2026-05-20-B1-status-known-bugs.md).
+
+### 9. Caméra ne suit pas le perso en temps réel (B.1)
+
+**Statut** : bug B.1 connu, confirmé une seconde fois lors du smoke test C MVP final. Documenté dans [docs/superpowers/audits/2026-05-20-B1-status-known-bugs.md §1 et §3](2026-05-20-B1-status-known-bugs.md).
+
+### 10. Layout clavier AZERTY non auto-détecté (UX)
+
+**Symptôme rapporté** : sur clavier AZERTY, les touches Z et Q ne déclenchent aucun mouvement. Seules W, A, S, D fonctionnent (mapping QWERTY hardcoded au défaut).
+
+**Workaround utilisateur** : aller dans Options → Layout → basculer en ZQSD. L'option `controls.movement_layout` existe et est persistée dans `user_settings.json` (cf. fix B.1 `91d7279`).
+
+**Bug réel** : pas de détection automatique du layout système au premier lancement. Le défaut WASD pénalise les utilisateurs AZERTY qui ne connaissent pas l'option.
+
+**Sévérité** : basse (workaround simple), pas bloquant. À polish ultérieurement (détection via Windows `GetKeyboardLayout()` ou prompt au premier lancement).
+
 ## Bugs résiduels B.1 préservés intacts
 
 Le wiring C MVP ne touche ni `CharacterController`, ni `TerrainCollider`, ni la state machine de locomotion (B.1). Tous les fixes B.1 restent en place :
@@ -97,7 +143,8 @@ Le wiring C MVP ne touche ni `CharacterController`, ni `TerrainCollider`, ni la 
 - `EngineNowSec()` normalisation float
 
 Bugs B.1 ouverts (cf. `docs/superpowers/audits/2026-05-20-B1-status-known-bugs.md`) :
-- Caméra tracking pas bien fixée au mouvement (à reprendre en session debug B.1 dédiée).
+- §1 + §3 : Caméra tracking pas bien fixée au mouvement (confirmé à nouveau lors du smoke test C MVP final).
+- §2bis : Direction backward incorrecte après strafe latéral (nouveau bug découvert lors du smoke test C MVP final).
 
 ## Plan pour C.2 (sous-projet futur)
 


### PR DESCRIPTION
…inal

Suite du smoke test C MVP post-merge dans main (PR #648 / `166d484`). L'utilisateur a deroule les criteres 3+5 et rapporte plusieurs bugs residuels qui n'etaient pas documentes. Mise a jour des 2 audits pour tracabilite (decisions / sessions futures sur d'autres PC).

### Audit B.1 (locomotion)
- Ajout §2bis : direction backward incorrecte apres strafe lateral (D puis S -> recule a gauche au lieu de vers la camera). Hypothese : m_avatarYaw mal reset entre sortie free-mover (Q/D) et entree WalkBack (S seul).
- Ajout §3 : cross-ref camera tracking confirme une seconde fois.
- §4 (smoke test §11) : update critere 4 avec note sur asset Jump.

### Audit C MVP (races multi-mesh)
- Update header : branche mergee dans main via PR #648.
- Section "Bugs corriges post-test" : ajout des 4 fixes soft-delete (5348ebd viewport, 5348ebd migration 0064 slot, 913acaa handler, ba767bc migration 0065 name) + bug viewport.
- "Smoke test partiel" -> "Smoke test final" : tableau §7 mis a jour avec criteres 3 et 4 valides (mesh orc OK pour grokorc).
- Ajout §6 : vibration des jambes pendant Walk/Run sur mesh orc. Hypotheses : retargeting Mixamo imparfait, bone weights mal exportes, ou inverseBindMatrix orc mal calcule. Chip-task creee.
- Ajout §7 : anims Jump incorrectes (asset issue, action user).
- Ajout §8 : cross-ref direction backward post-strafe (-> B.1 §2bis).
- Ajout §9 : cross-ref camera tracking (-> B.1 §1+§3).
- Ajout §10 : layout AZERTY non auto-detecte (workaround via Options).

Aucun changement de code, doc uniquement.

Deploiement : pas de redeploiement serveur ni client, doc uniquement.