### PR TITLE
feat(character): panneau UI « Apparence physique » + presets (CHAR-MODEL.25 Phase 3)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1490,6 +1490,10 @@ Le wiring C MVP ne touche ni `CharacterController` ni `TerrainCollider` (sticky 
 | `tools/asset_pipeline/{process_character_assets,validate_fbx}.py` | Pipeline inbox → `game/data/models/characters/<race>/...` + validation FBX (extension, taille, nommage). |
 | Tests : `character_customization_tests` (CTest) | Chargement des 8 races, validation, génération valide, résolution, ordre des tailles (nain<humain<orc), round-trip JSON. |
 
+### Intégration UI (Phase 3)
+
+`CharacterCreationPresenter` charge le système à l'`Init` (`<paths.content>/configuration`) et l'expose via `GetCustomizationSystem()`. L'écran `AuthImGuiRenderer::RenderCharCreateScreen` (`AuthImGuiCharacterCreate.cpp`, `#if _WIN32`) affiche le panneau **« Apparence physique »** : slider Taille + section « Proportions avancées » (jambes / épaules / corpulence) bornés aux limites de la race + boutons **Presets rapides** (data-driven depuis `body_proportions.json`, via `ApplyProportionPreset` clampé). État édité dans `AuthImGuiRenderer::m_charBodyMetrics`. Presets de proportions : `GetProportionPresets` / `DefaultMetricsForRace` / `ApplyProportionPreset` / `ClampMetricsToRace` (testés par `character_customization_tests`). **À brancher** : transmission serveur des métriques + application au mesh 3D.
+
 ### Limite d'intégration (stub assumé)
 
 `ApplyCustomization` est un **stub documenté** : le moteur n'a pas encore de scène `GameObject`/`Skeleton`/composants. La fonction résout les assets et trace le plan ; le câblage GPU réel (attachement aux sockets, scaling des os, upload textures) est renvoyé à un ticket ultérieur. La **résolution** (`ResolveCustomization`) est complète et testée.

--- a/docs/CHARACTER_CUSTOMIZATION.md
+++ b/docs/CHARACTER_CUSTOMIZATION.md
@@ -51,8 +51,35 @@ if (sys.ValidateCustomization(c)) {
   (attachement GPU, scaling des os, upload textures) est laissé à un futur
   ticket. La *résolution* (`ResolveCustomization`), elle, est complète et testée.
 
+Proportions (presets `body_proportions.json`) :
+- `GetProportionPresets()` : liste des presets chargés.
+- `DefaultMetricsForRace(raceId)` : métriques par défaut de la race.
+- `ApplyProportionPreset(raceId, presetId, metrics)` : applique un preset puis
+  **clampe aux limites de la race** (renvoie false si race/preset inconnu).
+- `ClampMetricsToRace(raceId, metrics)` : borne des métriques arbitraires.
+
 Sérialisation : `CharacterCustomization::ToJson()` / `FromJson()` (round-trip,
 versionné `"1.0.0"`).
+
+## Intégration UI (écran de création de personnage)
+
+Le presenter `engine::client::CharacterCreationPresenter` charge le système à
+l'`Init` (`<paths.content>/configuration`) et l'expose via
+`GetCustomizationSystem()`. L'écran ImGui
+`AuthImGuiRenderer::RenderCharCreateScreen`
+(`src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp`, `#if _WIN32`)
+affiche le panneau **« Apparence physique »** :
+- slider **Taille** (`heightScale`) borné à `[scaleMin, scaleMax]` de la race ;
+- section repliable **« Proportions avancées »** : Longueur des jambes, Largeur
+  des épaules, Corpulence — bornées aux plages de la race ;
+- **Presets rapides** : un bouton par preset de `body_proportions.json`
+  (`ApplyProportionPreset`, clampé à la race).
+
+Les valeurs éditées vivent dans l'état du renderer (`m_charBodyMetrics`) et sont
+réinitialisées aux défauts de la race quand la race change. **À brancher**
+(suivi) : transmission des métriques au serveur (le payload de création est
+encore `name + race` en MVP) et application au mesh 3D (cf. stub
+`ApplyCustomization`).
 
 Tests : `src/client/character_creation/tests/CharacterCustomizationTests.cpp`
 (cible CTest `character_customization_tests`).

--- a/src/client/character_creation/CharacterCreationUi.cpp
+++ b/src/client/character_creation/CharacterCreationUi.cpp
@@ -64,6 +64,18 @@ namespace engine::client
 			LOG_WARN(Core, "[CharacterCreation] Init: could not load classes from '{}' — using empty list", classesRel);
 		}
 
+		// Système de customisation (limites par race + presets de proportions),
+		// chargé depuis <paths.content>/configuration/. Non-fatal s'il échoue :
+		// l'écran reste utilisable, le panneau « Apparence physique » se masque.
+		{
+			const std::string contentRoot = config.GetString("paths.content", "game/data");
+			if (!m_customization.Initialize(contentRoot + "/configuration"))
+			{
+				LOG_WARN(Core, "[CharacterCreation] Init: customization configs not loaded "
+				               "(panneau proportions désactivé)");
+			}
+		}
+
 		// Reset creation state to sane defaults.
 		m_state = CharacterCreationState{};
 		m_selectedClassFiltered = 0;

--- a/src/client/character_creation/CharacterCreationUi.h
+++ b/src/client/character_creation/CharacterCreationUi.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/client/character_creation/CharacterCustomizationSystem.h"
 #include "src/shared/core/Config.h"
 #include "src/shared/network/CharacterPayloads.h"
 
@@ -143,6 +144,16 @@ namespace engine::client
 		/// Currently selected race, or nullptr.
 		const RaceDefinition* GetSelectedRace() const;
 
+		/// Système de customisation (limites physiques par race + presets de
+		/// proportions). Chargé depuis game/data/configuration/ à l'Init.
+		/// Utilisé par l'UI pour le panneau « Apparence physique » (sliders de
+		/// proportions bornés par race + presets rapides). Aligné sur les ids
+		/// de race de races.json.
+		const CharacterCustomizationSystem& GetCustomizationSystem() const
+		{
+			return m_customization;
+		}
+
 		// ---- Class selection ----
 
 		/// Select the class at \p index within GetFilteredClasses().
@@ -226,6 +237,7 @@ namespace engine::client
 
 		std::vector<RaceDefinition>  m_races;
 		std::vector<ClassDefinition> m_classes;
+		CharacterCustomizationSystem m_customization; ///< Limites + presets (configuration/).
 		uint32_t m_selectedClassFiltered = 0; ///< Index within filtered class list.
 		CharacterCreationState m_state{};
 		bool m_initialized = false;

--- a/src/client/character_creation/CharacterCustomizationSystem.cpp
+++ b/src/client/character_creation/CharacterCustomizationSystem.cpp
@@ -298,8 +298,91 @@ namespace engine::client
 			}
 		}
 
-		LOG_INFO(CharCustom, "[Customization] Initialized with {} race(s)", m_raceConfigs.size());
+		// Presets de proportions (optionnels).
+		m_proportionPresets.clear();
+		const std::string presetsPath =
+		    (fs::path(configBasePath) / "customization" / "body_proportions.json").string();
+		engine::core::Config presetCfg;
+		if (presetCfg.LoadFromFile(presetsPath))
+		{
+			size_t i = 0;
+			while (presetCfg.Has("presets[" + std::to_string(i) + "].id"))
+			{
+				const std::string p = "presets[" + std::to_string(i) + "]";
+				ProportionPreset preset;
+				preset.id                 = presetCfg.GetString(p + ".id", "");
+				preset.displayName        = presetCfg.GetString(p + ".displayName", preset.id);
+				preset.description        = presetCfg.GetString(p + ".description", "");
+				preset.heightScale        = static_cast<float>(presetCfg.GetDouble(p + ".heightScale", 1.0));
+				preset.legLengthRatio     = static_cast<float>(presetCfg.GetDouble(p + ".legLengthRatio", 1.0));
+				preset.shoulderWidthRatio = static_cast<float>(presetCfg.GetDouble(p + ".shoulderWidthRatio", 1.0));
+				preset.torsoWidthRatio    = static_cast<float>(presetCfg.GetDouble(p + ".torsoWidthRatio", 1.0));
+				m_proportionPresets.push_back(std::move(preset));
+				++i;
+			}
+		}
+
+		LOG_INFO(CharCustom, "[Customization] Initialized with {} race(s), {} proportion preset(s)",
+		         m_raceConfigs.size(), m_proportionPresets.size());
 		return !m_raceConfigs.empty();
+	}
+
+	CharacterBodyMetrics CharacterCustomizationSystem::DefaultMetricsForRace(
+	    const std::string& raceId) const
+	{
+		CharacterBodyMetrics m;
+		const RaceConfiguration* race = GetRaceConfig(raceId);
+		if (!race)
+			return m;
+		const auto& lim          = race->physicalLimits;
+		m.heightScale            = static_cast<float>(lim.height.scaleDefault);
+		m.legLengthRatio         = static_cast<float>(lim.proportions.legLength.defaultValue);
+		m.shoulderWidthRatio     = static_cast<float>(lim.proportions.shoulderWidth.defaultValue);
+		m.torsoWidthRatio        = static_cast<float>(lim.proportions.torsoWidth.defaultValue);
+		m.bodyMassIndex          = static_cast<float>(lim.bodyMass.defaultValue);
+		return m;
+	}
+
+	void CharacterCustomizationSystem::ClampMetricsToRace(const std::string& raceId,
+	                                                      CharacterBodyMetrics& metrics) const
+	{
+		const RaceConfiguration* race = GetRaceConfig(raceId);
+		if (!race)
+			return;
+		const auto& lim = race->physicalLimits;
+		auto clamp      = [](float v, double lo, double hi) {
+            return static_cast<float>(std::min(std::max(static_cast<double>(v), lo), hi));
+		};
+		metrics.heightScale        = clamp(metrics.heightScale, lim.height.scaleMin, lim.height.scaleMax);
+		metrics.legLengthRatio     = clamp(metrics.legLengthRatio, lim.proportions.legLength.min, lim.proportions.legLength.max);
+		metrics.shoulderWidthRatio = clamp(metrics.shoulderWidthRatio, lim.proportions.shoulderWidth.min, lim.proportions.shoulderWidth.max);
+		metrics.torsoWidthRatio    = clamp(metrics.torsoWidthRatio, lim.proportions.torsoWidth.min, lim.proportions.torsoWidth.max);
+		metrics.bodyMassIndex      = clamp(metrics.bodyMassIndex, lim.bodyMass.min, lim.bodyMass.max);
+	}
+
+	bool CharacterCustomizationSystem::ApplyProportionPreset(const std::string& raceId,
+	                                                         const std::string& presetId,
+	                                                         CharacterBodyMetrics& metrics) const
+	{
+		if (!GetRaceConfig(raceId))
+			return false;
+		const ProportionPreset* preset = nullptr;
+		for (const auto& p : m_proportionPresets)
+			if (p.id == presetId)
+			{
+				preset = &p;
+				break;
+			}
+		if (!preset)
+			return false;
+
+		metrics.heightScale        = preset->heightScale;
+		metrics.legLengthRatio     = preset->legLengthRatio;
+		metrics.shoulderWidthRatio = preset->shoulderWidthRatio;
+		metrics.torsoWidthRatio    = preset->torsoWidthRatio;
+		// La corpulence n'est pas définie par les presets : on la conserve.
+		ClampMetricsToRace(raceId, metrics);
+		return true;
 	}
 
 	bool CharacterCustomizationSystem::InRange(double v, const ValueRange& r)
@@ -571,12 +654,7 @@ namespace engine::client
 		if (!race->eyeColors.empty())
 			c.eyeColorId = race->eyeColors[0].id;
 
-		const auto& lim                = race->physicalLimits;
-		c.bodyMetrics.heightScale      = static_cast<float>(lim.height.scaleDefault);
-		c.bodyMetrics.legLengthRatio   = static_cast<float>(lim.proportions.legLength.defaultValue);
-		c.bodyMetrics.shoulderWidthRatio = static_cast<float>(lim.proportions.shoulderWidth.defaultValue);
-		c.bodyMetrics.torsoWidthRatio  = static_cast<float>(lim.proportions.torsoWidth.defaultValue);
-		c.bodyMetrics.bodyMassIndex    = static_cast<float>(lim.bodyMass.defaultValue);
+		c.bodyMetrics = DefaultMetricsForRace(raceId);
 
 		for (const auto& m : race->faceMorphs)
 			c.morphWeights[m.name] = static_cast<float>(m.defaultValue);

--- a/src/client/character_creation/CharacterCustomizationSystem.h
+++ b/src/client/character_creation/CharacterCustomizationSystem.h
@@ -204,6 +204,20 @@ namespace engine::client
 	// Système
 	// ------------------------------------------------------------------------
 
+	/// Preset de proportions corporelles (configuration/customization/body_proportions.json).
+	/// Les ratios s'appliquent aux `CharacterBodyMetrics` puis sont clampés aux
+	/// limites de la race sélectionnée.
+	struct ProportionPreset
+	{
+		std::string id;
+		std::string displayName;
+		std::string description;
+		float       heightScale        = 1.0f;
+		float       legLengthRatio     = 1.0f;
+		float       shoulderWidthRatio = 1.0f;
+		float       torsoWidthRatio    = 1.0f;
+	};
+
 	class CharacterCustomizationSystem
 	{
 	public:
@@ -237,6 +251,27 @@ namespace engine::client
 		std::vector<std::string> GetAvailableRaces() const;
 		size_t RaceCount() const { return m_raceConfigs.size(); }
 
+		// ---- Proportions (presets + bornes par race) ----
+
+		/// Presets de proportions chargés depuis body_proportions.json.
+		const std::vector<ProportionPreset>& GetProportionPresets() const
+		{
+			return m_proportionPresets;
+		}
+
+		/// Métriques par défaut de la race (valeurs `default` de physicalLimits).
+		/// Race inconnue -> métriques neutres.
+		CharacterBodyMetrics DefaultMetricsForRace(const std::string& raceId) const;
+
+		/// Clampe chaque métrique aux bornes de la race (no-op si race inconnue).
+		void ClampMetricsToRace(const std::string& raceId, CharacterBodyMetrics& metrics) const;
+
+		/// Applique un preset de proportions à `metrics` puis clampe aux limites
+		/// de la race. La corpulence (bodyMassIndex) n'est pas touchée par les
+		/// presets. Renvoie false si la race ou le preset est inconnu.
+		bool ApplyProportionPreset(const std::string& raceId, const std::string& presetId,
+		                           CharacterBodyMetrics& metrics) const;
+
 		// ---- Presets / génération ----
 
 		/// Customisation par défaut valide (premiers modules, métriques par
@@ -254,6 +289,7 @@ namespace engine::client
 		                                     const std::string& id);
 
 		std::unordered_map<std::string, std::shared_ptr<RaceConfiguration>> m_raceConfigs;
+		std::vector<ProportionPreset> m_proportionPresets;
 		std::mt19937 m_rng;
 	};
 

--- a/src/client/character_creation/tests/CharacterCustomizationTests.cpp
+++ b/src/client/character_creation/tests/CharacterCustomizationTests.cpp
@@ -184,6 +184,46 @@ namespace
 		REQUIRE(effective(humain) < effective(orc));
 	}
 
+	void Test_ProportionPresets()
+	{
+		CharacterCustomizationSystem sys;
+		InitSystem(sys);
+
+		// Les presets de body_proportions.json sont chargés.
+		const auto& presets = sys.GetProportionPresets();
+		REQUIRE(presets.size() >= 6);
+		bool hasAverage = false;
+		for (const auto& p : presets)
+			if (p.id == "average")
+				hasAverage = true;
+		REQUIRE(hasAverage);
+
+		// Application sur une race aux limites larges (humains) : 'average'
+		// donne des ratios neutres dans les bornes.
+		engine::client::CharacterBodyMetrics mh = sys.DefaultMetricsForRace("humains");
+		REQUIRE(sys.ApplyProportionPreset("humains", "average", mh));
+		REQUIRE(std::fabs(mh.heightScale - 1.0f) < 1e-3f);
+
+		// Application sur les nains (taille max 0.85) : un preset 'grand'
+		// (heightScale 1.08) doit être CLAMPÉ aux limites de la race.
+		engine::client::CharacterBodyMetrics mn = sys.DefaultMetricsForRace("nains");
+		REQUIRE(sys.ApplyProportionPreset("nains", "tall_slender", mn));
+		const auto* nains = sys.GetRaceConfig("nains");
+		REQUIRE(nains != nullptr);
+		REQUIRE(mn.heightScale <= static_cast<float>(nains->physicalLimits.height.scaleMax) + 1e-4f);
+		REQUIRE(mn.heightScale >= static_cast<float>(nains->physicalLimits.height.scaleMin) - 1e-4f);
+
+		// Après application d'un preset, les métriques restent valides.
+		CharacterCustomization c = sys.MakeDefaultCustomization("nains", "male");
+		c.bodyMetrics = mn;
+		REQUIRE(sys.ValidateCustomization(c));
+
+		// Race ou preset inconnu -> false.
+		engine::client::CharacterBodyMetrics tmp;
+		REQUIRE(!sys.ApplyProportionPreset("nope", "average", tmp));
+		REQUIRE(!sys.ApplyProportionPreset("humains", "nope", tmp));
+	}
+
 	void Test_JsonRoundTrip()
 	{
 		CharacterCustomizationSystem sys;
@@ -219,6 +259,7 @@ int main()
 	Test_Resolve();
 	Test_RacialFeatureResolves();
 	Test_HeightOrderingByRace();
+	Test_ProportionPresets();
 	Test_JsonRoundTrip();
 
 	if (g_failed == 0)

--- a/src/client/render/AuthImGuiRenderer.h
+++ b/src/client/render/AuthImGuiRenderer.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "src/client/auth/AuthUi.h"
+#include "src/client/character_creation/CharacterCustomization.h"
 
 namespace engine::core
 {
@@ -79,6 +80,13 @@ namespace engine::render
 		/// Index dans la liste des races jouables (cf. RenderCharCreateScreen).
 		/// 0 = humains, 1 = elfes, 2 = orcs, 3 = nains, 4 = demons, 5 = chevaliers_dragons.
 		int m_charRaceIdx = 0;
+
+		/// Métriques de proportions éditées par le panneau « Apparence physique »
+		/// (CHAR-MODEL.25). Bornées aux limites de la race sélectionnée. Réinitialisées
+		/// aux valeurs par défaut de la race quand \c m_charMetricsRaceIdx diffère de
+		/// \c m_charRaceIdx.
+		engine::client::CharacterBodyMetrics m_charBodyMetrics{};
+		int m_charMetricsRaceIdx = -1; ///< Race pour laquelle m_charBodyMetrics a été initialisé.
 
 		bool m_optDirty = false;
 		bool m_optFullscreen = true;

--- a/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
@@ -1,24 +1,19 @@
 // AUTH-UI.11 - rendu ImGui ecran de creation de personnage avec saisie du nom et confirmation (split depuis AuthImGuiRenderer.cpp).
-// Contient RenderCharCreateScreen : panneau avec champ de nom, lignes d'information issues du modele, et boutons Annuler / Creer.
+// Contient RenderCharCreateScreen : panneau 2 colonnes (gauche = apercu 3D,
+// droite = nom + race + apparence physique), puis boutons Annuler / Creer.
 //
 // Sous-projet C MVP (Task 12) — Refactor : la liste des races est
 // desormais lue depuis CharacterCreationPresenter::GetRaces() (parsing
 // races.json au boot via AuthUiPresenter::Init) au lieu d'etre hardcodee.
-// Coherence garantie : si on ajoute / retire une race en data, l'UI suit
-// sans changement de code.
 //
-// Un apercu 3D est affiche via ImGui::Image quand le RacePreviewViewport
-// (branche par Engine::Init) est valide. Pour MVP le rendu mesh 3D du
-// viewport n'est pas encore implemente (Task 11 = fallback clear color),
-// donc on superpose le nom de la race pour que l'utilisateur sache
-// laquelle est selectionnee.
+// CHAR-MODEL.25 — Panneau "Apparence physique" : sliders de proportions
+// bornes aux limites de la race + presets rapides (data-driven depuis
+// body_proportions.json via CharacterCustomizationSystem). Disposition 2
+// colonnes pour garder le panneau de hauteur moyenne et lisible.
 
 #include "src/client/render/AuthImGuiRenderer.h"
 #include "src/client/render/LnTheme.h"
 
-// Sous-projet C MVP (Task 12) — necessaire pour iterer sur
-// CharacterCreationPresenter::GetRaces() et appeler
-// RacePreviewViewport::SetMesh / GetImguiTextureId / IsValid.
 #include "src/client/auth/AuthUi.h"
 #include "src/client/character_creation/CharacterCreationUi.h"
 #include "src/client/render/race/RacePreviewViewport.h"
@@ -40,181 +35,207 @@ namespace engine::render
 		}
 	} // namespace
 
-	/// Affiche l'ecran de creation de personnage : champ de saisie du nom, lignes d'information issues du modele, puis boutons Annuler et Creer.
+	/// Affiche l'ecran de creation de personnage en 2 colonnes : apercu 3D a
+	/// gauche, options (nom, race, apparence physique) a droite, boutons dessous.
 	void AuthImGuiRenderer::RenderCharCreateScreen(const RenderModel& rm, float vpW, float vpH)
 	{
 		// Titre/sous-titre via helper unifie (reference visuelle).
 		DrawAuthBigTitle(rm, vpW, vpH, "charcreate");
 		const float titleZoneW = vpW * 0.96f;
 
-		const std::string panelTitle = rm.sectionTitle.empty() ? std::string("Creation de personnage") : rm.sectionTitle;
-		if (!BeginPanel(680.f, titleZoneW, vpH, panelTitle.c_str(), "", ""))
+		// Panneau elargi pour une disposition 2 colonnes. Hauteur en auto-resize :
+		// le contenu reparti sur 2 colonnes garde une hauteur moyenne.
+		float panelW = 900.f;
+		if (panelW > titleZoneW)
+			panelW = titleZoneW;
+
+		const std::string panelTitle =
+			rm.sectionTitle.empty() ? std::string("Creation de personnage") : rm.sectionTitle;
+		if (!BeginPanel(panelW, titleZoneW, vpH, panelTitle.c_str(), "", ""))
 		{
 			EndPanel();
 			ImGui::EndChild();
 			return;
 		}
-		const std::string& nameLabel = rm.fields.empty() ? std::string("Nom du personnage") : rm.fields[0].label;
-		DrawField(nameLabel.c_str(), m_charName, static_cast<int>(sizeof(m_charName)));
-		for (const auto& line : rm.bodyLines)
-		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
-			ImGui::TextWrapped("%s", line.text.c_str());
-			ImGui::PopStyleColor();
-		}
 
-		// Choix de la race : itere sur les races chargees par
-		// CharacterCreationPresenter (M39.1, etendu Task 1 avec meshPath).
-		// Plus de liste hardcodee : la coherence avec races.json est
-		// garantie cote data.
-		ImGui::Spacing();
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
-		ImGui::TextUnformatted("RACE");
-		ImGui::PopStyleColor();
-		const auto* ccPresenter = (m_authPresenter ? m_authPresenter->GetCharacterCreationPresenter() : nullptr);
+		// Presenter + liste des races (data-driven, cf. races.json) + systeme de
+		// customisation (limites par race + presets de proportions).
+		const auto* ccPresenter =
+			(m_authPresenter ? m_authPresenter->GetCharacterCreationPresenter() : nullptr);
 		const std::vector<engine::client::RaceDefinition>* races =
 			ccPresenter ? &ccPresenter->GetRaces() : nullptr;
-		if (races && !races->empty())
+		const engine::client::CharacterCustomizationSystem* custSys =
+			ccPresenter ? &ccPresenter->GetCustomizationSystem() : nullptr;
+		const bool hasRaces = (races && !races->empty());
+		if (hasRaces && (m_charRaceIdx < 0 || m_charRaceIdx >= static_cast<int>(races->size())))
+			m_charRaceIdx = 0;
+
+		// Disposition 2 colonnes : [apercu 3D (largeur fixe) | options (etire)].
+		if (ImGui::BeginTable("##cc_layout", 2, ImGuiTableFlags_BordersInnerV, ImVec2(0.f, 0.f)))
 		{
-			// Build le vector de libelles affichables (.c_str() refs sur
-			// la duree de l'appel Combo ; safe car races est stable).
-			std::vector<const char*> labels;
-			labels.reserve(races->size());
-			for (const auto& r : *races) labels.push_back(r.displayName.c_str());
-			if (m_charRaceIdx < 0 || m_charRaceIdx >= static_cast<int>(races->size())) m_charRaceIdx = 0;
-			const int prevRaceIdx = m_charRaceIdx;
-			ImGui::SetNextItemWidth(-FLT_MIN);
-			ImGui::Combo("##charcreate_race", &m_charRaceIdx, labels.data(), static_cast<int>(labels.size()));
-			// Si la selection a change OU si c'est la 1ere frame (le
-			// viewport n'a pas encore de mesh : detection via
-			// m_racePreviewInitialMeshSent) : notifier le preview
-			// viewport pour qu'il charge le mesh de la race (lookup
-			// via AuthUiPresenter::GetRaceMeshForId qui delegue a
-			// Engine::GetRaceMesh, avec fallback humains si la race
-			// n'est pas chargee dans m_raceMeshes).
-			const bool needFirstPush = !m_racePreviewInitialMeshSent;
-			if ((m_charRaceIdx != prevRaceIdx || needFirstPush) && m_racePreview && m_authPresenter)
-			{
-				m_racePreview->SetMesh(m_authPresenter->GetRaceMeshForId((*races)[m_charRaceIdx].id));
-				m_racePreviewInitialMeshSent = true;
-			}
-			// Preview 3D : ImGui::Image consomme la VkDescriptorSet
-			// enregistree par RacePreviewViewport::Init. Task 11 =
-			// fallback clear color noir pour MVP (rendu mesh 3D reel
-			// laisse a un sous-projet C.1.5 / C.2 qui refactorera
-			// SkinnedRenderer pour le rendre RT-agnostic).
+			ImGui::TableSetupColumn("##cc_preview", ImGuiTableColumnFlags_WidthFixed, 280.f);
+			ImGui::TableSetupColumn("##cc_options", ImGuiTableColumnFlags_WidthStretch);
+			ImGui::TableNextRow();
+
+			// ---------------- Colonne gauche : apercu visuel ----------------
+			ImGui::TableSetColumnIndex(0);
+			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::TextUnformatted("APERCU");
+			ImGui::PopStyleColor();
 			if (m_racePreview && m_racePreview->IsValid())
 			{
-				ImGui::Spacing();
-				// `ImTextureID` est defini comme `ImU64` (numerique) dans
-				// le fork ImGui utilise ici : `static_cast` direct, pas
-				// `reinterpret_cast` (le cast pointeur echoue sous MSVC
-				// C2440). Pattern miroir de ScenePanel.cpp / M100.34.
+				// `ImTextureID` est defini comme `ImU64` (numerique) dans le fork
+				// ImGui utilise ici : static_cast direct (cf. ScenePanel.cpp / M100.34).
 				ImGui::Image(static_cast<ImTextureID>(m_racePreview->GetImguiTextureId()),
 				             ImVec2(256.0f, 384.0f));
-				// Overlay : nom de la race par-dessus (compense le
-				// fallback viewport qui ne dessine pas encore le mesh
-				// 3D pour MVP -> l'utilisateur a quand meme un retour
-				// visuel de la race selectionnee).
-				ImGui::Text("Race : %s", (*races)[m_charRaceIdx].displayName.c_str());
+				if (hasRaces)
+					ImGui::Text("Race : %s", (*races)[m_charRaceIdx].displayName.c_str());
 			}
 			else
 			{
-				// Pas de preview disponible : fallback texte simple
-				// (cas typique : Engine n'a pas reussi a creer le
-				// viewport, ou test unitaire sans Engine).
-				ImGui::TextDisabled("(preview 3D indisponible)");
+				ImGui::TextDisabled("(apercu 3D indisponible)");
 			}
-		}
-		else
-		{
-			// Fallback "race par defaut" si le presenter n'est pas
-			// dispo (Init du presenter a rate, ou races.json absent).
-			// Le bouton Creer enverra "humains" par defaut.
-			ImGui::TextDisabled("(liste des races indisponible)");
-			if (m_charRaceIdx < 0) m_charRaceIdx = 0;
-		}
 
-		// CHAR-MODEL.25 — Panneau "Apparence physique" : sliders de proportions
-		// bornes aux limites de la race + presets rapides. Pilote par
-		// CharacterCustomizationSystem (charge depuis game/data/configuration/).
-		// Les valeurs editees vivent dans m_charBodyMetrics (etat renderer) ;
-		// l'envoi serveur n'est pas encore branche (payload name+race en MVP).
-		const engine::client::CharacterCustomizationSystem* custSys =
-			ccPresenter ? &ccPresenter->GetCustomizationSystem() : nullptr;
-		if (custSys && races && !races->empty() &&
-		    m_charRaceIdx >= 0 && m_charRaceIdx < static_cast<int>(races->size()))
-		{
-			const std::string& curRaceId = (*races)[m_charRaceIdx].id;
-			const engine::client::RaceConfiguration* raceCfg = custSys->GetRaceConfig(curRaceId);
-			if (raceCfg)
+			// ---------------- Colonne droite : options ----------------
+			ImGui::TableSetColumnIndex(1);
+
+			const std::string& nameLabel =
+				rm.fields.empty() ? std::string("Nom du personnage") : rm.fields[0].label;
+			DrawField(nameLabel.c_str(), m_charName, static_cast<int>(sizeof(m_charName)));
+			for (const auto& line : rm.bodyLines)
 			{
-				// Reset des metriques sur changement de race (defauts de la race).
-				if (m_charMetricsRaceIdx != m_charRaceIdx)
-				{
-					m_charBodyMetrics    = custSys->DefaultMetricsForRace(curRaceId);
-					m_charMetricsRaceIdx = m_charRaceIdx;
-				}
-
-				ImGui::Spacing();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
-				ImGui::TextUnformatted("APPARENCE PHYSIQUE");
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::TextWrapped("%s", line.text.c_str());
 				ImGui::PopStyleColor();
+			}
 
-				const auto& lim = raceCfg->physicalLimits;
+			// Race (combo data-driven). Le push du mesh d'apercu se fait ici
+			// (colonne droite) ; la colonne gauche affiche le rendu correspondant
+			// (1 frame de latence au changement, invisible en pratique).
+			ImGui::Spacing();
+			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::TextUnformatted("RACE");
+			ImGui::PopStyleColor();
+			if (hasRaces)
+			{
+				std::vector<const char*> labels;
+				labels.reserve(races->size());
+				for (const auto& r : *races)
+					labels.push_back(r.displayName.c_str());
+				const int prevRaceIdx = m_charRaceIdx;
 				ImGui::SetNextItemWidth(-FLT_MIN);
-				ImGui::SliderFloat("Taille", &m_charBodyMetrics.heightScale,
-				                   static_cast<float>(lim.height.scaleMin),
-				                   static_cast<float>(lim.height.scaleMax), "%.2f");
-
-				if (ImGui::CollapsingHeader("Proportions avancees"))
+				ImGui::Combo("##charcreate_race", &m_charRaceIdx, labels.data(),
+				             static_cast<int>(labels.size()));
+				const bool needFirstPush = !m_racePreviewInitialMeshSent;
+				if ((m_charRaceIdx != prevRaceIdx || needFirstPush) && m_racePreview && m_authPresenter)
 				{
-					ImGui::SetNextItemWidth(-FLT_MIN);
-					ImGui::SliderFloat("Longueur des jambes", &m_charBodyMetrics.legLengthRatio,
-					                   static_cast<float>(lim.proportions.legLength.min),
-					                   static_cast<float>(lim.proportions.legLength.max), "%.2f");
-					ImGui::SetNextItemWidth(-FLT_MIN);
-					ImGui::SliderFloat("Largeur des epaules", &m_charBodyMetrics.shoulderWidthRatio,
-					                   static_cast<float>(lim.proportions.shoulderWidth.min),
-					                   static_cast<float>(lim.proportions.shoulderWidth.max), "%.2f");
-					ImGui::SetNextItemWidth(-FLT_MIN);
-					ImGui::SliderFloat("Corpulence", &m_charBodyMetrics.bodyMassIndex,
-					                   static_cast<float>(lim.bodyMass.min),
-					                   static_cast<float>(lim.bodyMass.max), "%.2f");
+					m_racePreview->SetMesh(m_authPresenter->GetRaceMeshForId((*races)[m_charRaceIdx].id));
+					m_racePreviewInitialMeshSent = true;
 				}
+			}
+			else
+			{
+				ImGui::TextDisabled("(liste des races indisponible)");
+				if (m_charRaceIdx < 0)
+					m_charRaceIdx = 0;
+			}
 
-				// Presets rapides (data-driven depuis body_proportions.json).
-				const auto& presets = custSys->GetProportionPresets();
-				if (!presets.empty())
+			// Apparence physique (CHAR-MODEL.25) : sliders bornes a la race +
+			// presets. Labels au-dessus des sliders (sinon clippes par -FLT_MIN).
+			if (custSys && hasRaces)
+			{
+				const std::string& curRaceId = (*races)[m_charRaceIdx].id;
+				const engine::client::RaceConfiguration* raceCfg = custSys->GetRaceConfig(curRaceId);
+				if (raceCfg)
 				{
-					ImGui::Spacing();
-					ImGui::TextUnformatted("Presets rapides :");
-					for (size_t pi = 0; pi < presets.size(); ++pi)
+					if (m_charMetricsRaceIdx != m_charRaceIdx)
 					{
-						if (pi > 0) ImGui::SameLine();
-						// Label visible + id ImGui unique (##) pour eviter les collisions.
-						const std::string btnLabel =
-							presets[pi].displayName + "##preset_" + presets[pi].id;
-						if (ImGui::Button(btnLabel.c_str()))
+						m_charBodyMetrics    = custSys->DefaultMetricsForRace(curRaceId);
+						m_charMetricsRaceIdx = m_charRaceIdx;
+					}
+
+					ImGui::Spacing();
+					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::TextUnformatted("APPARENCE PHYSIQUE");
+					ImGui::PopStyleColor();
+
+					const auto& lim = raceCfg->physicalLimits;
+					ImGui::TextUnformatted("Taille");
+					ImGui::SetNextItemWidth(-FLT_MIN);
+					ImGui::SliderFloat("##cc_taille", &m_charBodyMetrics.heightScale,
+					                   static_cast<float>(lim.height.scaleMin),
+					                   static_cast<float>(lim.height.scaleMax), "%.2f");
+
+					if (ImGui::CollapsingHeader("Proportions avancees"))
+					{
+						ImGui::TextUnformatted("Longueur des jambes");
+						ImGui::SetNextItemWidth(-FLT_MIN);
+						ImGui::SliderFloat("##cc_legs", &m_charBodyMetrics.legLengthRatio,
+						                   static_cast<float>(lim.proportions.legLength.min),
+						                   static_cast<float>(lim.proportions.legLength.max), "%.2f");
+						ImGui::TextUnformatted("Largeur des epaules");
+						ImGui::SetNextItemWidth(-FLT_MIN);
+						ImGui::SliderFloat("##cc_shoulders", &m_charBodyMetrics.shoulderWidthRatio,
+						                   static_cast<float>(lim.proportions.shoulderWidth.min),
+						                   static_cast<float>(lim.proportions.shoulderWidth.max), "%.2f");
+						ImGui::TextUnformatted("Corpulence");
+						ImGui::SetNextItemWidth(-FLT_MIN);
+						ImGui::SliderFloat("##cc_mass", &m_charBodyMetrics.bodyMassIndex,
+						                   static_cast<float>(lim.bodyMass.min),
+						                   static_cast<float>(lim.bodyMass.max), "%.2f");
+					}
+
+					// Presets rapides (data-driven). Wrap manuel sur la largeur
+					// de colonne (ImGui ne wrappe pas les boutons en SameLine).
+					const auto& presets = custSys->GetProportionPresets();
+					if (!presets.empty())
+					{
+						ImGui::Spacing();
+						ImGui::TextUnformatted("Presets rapides :");
+						const float avail     = ImGui::GetContentRegionAvail().x;
+						const float spacing   = ImGui::GetStyle().ItemSpacing.x;
+						const float framePadX = ImGui::GetStyle().FramePadding.x * 2.f;
+						float lineUsed = 0.f;
+						for (size_t pi = 0; pi < presets.size(); ++pi)
 						{
-							custSys->ApplyProportionPreset(curRaceId, presets[pi].id, m_charBodyMetrics);
+							const float btnW =
+								ImGui::CalcTextSize(presets[pi].displayName.c_str()).x + framePadX;
+							if (pi > 0)
+							{
+								if (lineUsed + spacing + btnW <= avail)
+								{
+									ImGui::SameLine();
+									lineUsed += spacing;
+								}
+								else
+								{
+									lineUsed = 0.f; // passe a la ligne suivante
+								}
+							}
+							const std::string btnLabel =
+								presets[pi].displayName + "##preset_" + presets[pi].id;
+							if (ImGui::Button(btnLabel.c_str()))
+								custSys->ApplyProportionPreset(curRaceId, presets[pi].id, m_charBodyMetrics);
+							lineUsed += btnW;
 						}
 					}
 				}
 			}
+
+			ImGui::EndTable();
 		}
 
+		// Boutons (pleine largeur, sous les 2 colonnes). Largeurs finies pour
+		// eviter que Annuler ne capture les clics destines a Creer.
 		ImGui::Spacing();
-		// Largeurs finies pour eviter que Annuler (pleine largeur) ne capture les clics destines
-		// a Creer (cf. correctif AuthImGuiTerms.cpp pour la meme classe de bug).
-		const float ccGap = 8.f;
+		const float ccGap  = 8.f;
 		const float ccBtnW = (ImGui::GetContentRegionAvail().x - ccGap) * 0.5f;
 		if (DrawGhostButton("Annuler", false, ccBtnW) && m_authPresenter != nullptr)
 		{
 			m_authPresenter->ImGuiCancelCharacterCreateReturnToLogin();
 		}
 		ImGui::SameLine(0.f, ccGap);
-		std::string submitLabel = "Creer"; ///< Libelle du bouton de confirmation, surcharge par l'action primaire du modele si presente.
+		std::string submitLabel = "Creer"; ///< Surcharge par l'action primaire du modele si presente.
 		for (const auto& a : rm.actions)
 		{
 			if (a.primary)
@@ -223,21 +244,17 @@ namespace engine::render
 				break;
 			}
 		}
-		if (DrawPrimaryButton(submitLabel.c_str(), false, ccBtnW) && m_authPresenter != nullptr && m_authCfg != nullptr)
+		if (DrawPrimaryButton(submitLabel.c_str(), false, ccBtnW) && m_authPresenter != nullptr &&
+		    m_authCfg != nullptr)
 		{
-			// Sous-projet C MVP (Task 12) — Resout le raceId depuis le
-			// presenter (au lieu d'une liste hardcodee). Fallback
-			// "humains" si la liste est vide (alignement avec le
-			// fallback de Engine::GetRaceMesh).
+			// Resout le raceId depuis le presenter (fallback "humains").
 			std::string raceId = "humains";
 			const auto* presenterForSubmit = m_authPresenter->GetCharacterCreationPresenter();
 			if (presenterForSubmit)
 			{
 				const auto& submitRaces = presenterForSubmit->GetRaces();
 				if (m_charRaceIdx >= 0 && m_charRaceIdx < static_cast<int>(submitRaces.size()))
-				{
 					raceId = submitRaces[m_charRaceIdx].id;
-				}
 			}
 			m_authPresenter->ImGuiSubmitCharacterCreate(*m_authCfg, m_charName, raceId.c_str());
 		}

--- a/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
@@ -134,6 +134,76 @@ namespace engine::render
 			ImGui::TextDisabled("(liste des races indisponible)");
 			if (m_charRaceIdx < 0) m_charRaceIdx = 0;
 		}
+
+		// CHAR-MODEL.25 — Panneau "Apparence physique" : sliders de proportions
+		// bornes aux limites de la race + presets rapides. Pilote par
+		// CharacterCustomizationSystem (charge depuis game/data/configuration/).
+		// Les valeurs editees vivent dans m_charBodyMetrics (etat renderer) ;
+		// l'envoi serveur n'est pas encore branche (payload name+race en MVP).
+		const engine::client::CharacterCustomizationSystem* custSys =
+			ccPresenter ? &ccPresenter->GetCustomizationSystem() : nullptr;
+		if (custSys && races && !races->empty() &&
+		    m_charRaceIdx >= 0 && m_charRaceIdx < static_cast<int>(races->size()))
+		{
+			const std::string& curRaceId = (*races)[m_charRaceIdx].id;
+			const engine::client::RaceConfiguration* raceCfg = custSys->GetRaceConfig(curRaceId);
+			if (raceCfg)
+			{
+				// Reset des metriques sur changement de race (defauts de la race).
+				if (m_charMetricsRaceIdx != m_charRaceIdx)
+				{
+					m_charBodyMetrics    = custSys->DefaultMetricsForRace(curRaceId);
+					m_charMetricsRaceIdx = m_charRaceIdx;
+				}
+
+				ImGui::Spacing();
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::TextUnformatted("APPARENCE PHYSIQUE");
+				ImGui::PopStyleColor();
+
+				const auto& lim = raceCfg->physicalLimits;
+				ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::SliderFloat("Taille", &m_charBodyMetrics.heightScale,
+				                   static_cast<float>(lim.height.scaleMin),
+				                   static_cast<float>(lim.height.scaleMax), "%.2f");
+
+				if (ImGui::CollapsingHeader("Proportions avancees"))
+				{
+					ImGui::SetNextItemWidth(-FLT_MIN);
+					ImGui::SliderFloat("Longueur des jambes", &m_charBodyMetrics.legLengthRatio,
+					                   static_cast<float>(lim.proportions.legLength.min),
+					                   static_cast<float>(lim.proportions.legLength.max), "%.2f");
+					ImGui::SetNextItemWidth(-FLT_MIN);
+					ImGui::SliderFloat("Largeur des epaules", &m_charBodyMetrics.shoulderWidthRatio,
+					                   static_cast<float>(lim.proportions.shoulderWidth.min),
+					                   static_cast<float>(lim.proportions.shoulderWidth.max), "%.2f");
+					ImGui::SetNextItemWidth(-FLT_MIN);
+					ImGui::SliderFloat("Corpulence", &m_charBodyMetrics.bodyMassIndex,
+					                   static_cast<float>(lim.bodyMass.min),
+					                   static_cast<float>(lim.bodyMass.max), "%.2f");
+				}
+
+				// Presets rapides (data-driven depuis body_proportions.json).
+				const auto& presets = custSys->GetProportionPresets();
+				if (!presets.empty())
+				{
+					ImGui::Spacing();
+					ImGui::TextUnformatted("Presets rapides :");
+					for (size_t pi = 0; pi < presets.size(); ++pi)
+					{
+						if (pi > 0) ImGui::SameLine();
+						// Label visible + id ImGui unique (##) pour eviter les collisions.
+						const std::string btnLabel =
+							presets[pi].displayName + "##preset_" + presets[pi].id;
+						if (ImGui::Button(btnLabel.c_str()))
+						{
+							custSys->ApplyProportionPreset(curRaceId, presets[pi].id, m_charBodyMetrics);
+						}
+					}
+				}
+			}
+		}
+
 		ImGui::Spacing();
 		// Largeurs finies pour eviter que Annuler (pleine largeur) ne capture les clics destines
 		// a Creer (cf. correctif AuthImGuiTerms.cpp pour la meme classe de bug).


### PR DESCRIPTION
## Contexte

Suite de la PR #651 (mergée). #651 ne contenait que le **back-end** (data + système C++ + outils + docs). Ce commit, poussé **après** le merge de #651, ajoute l'**intégration UI** (Phase 3 du ticket) qui manquait.

## Contenu (commit `3c24f13`)

- **Système** : presets de proportions chargés depuis `body_proportions.json` + `DefaultMetricsForRace` / `ClampMetricsToRace` / `ApplyProportionPreset` (applique un preset puis **clampe aux limites de la race**) → ferme **DoD 5.8**.
- **Presenter** : `CharacterCreationPresenter` possède le système (init depuis `<paths.content>/configuration`) et l'expose via `GetCustomizationSystem()`.
- **Écran** (`AuthImGuiCharacterCreate.cpp`, `#if _WIN32`) : panneau **« APPARENCE PHYSIQUE »** — slider **Taille**, section repliable **« Proportions avancées »** (jambes / épaules / corpulence) bornées à la race, et **Presets rapides** (boutons générés depuis le JSON). État dans `AuthImGuiRenderer::m_charBodyMetrics`, réinitialisé au changement de race.
- **Test** : `Test_ProportionPresets` dans `character_customization_tests`.

## Vérifications
- ✅ Compilation C++20 `-Wall -Wextra -Wpedantic` sans warning (système, presenter, TU de contrôle des appels du panneau)
- ✅ Tests headless : `character_customization_tests` (dont presets) + `race_definition_tests` → pas de régression
- ⚠️ Bloc ImGui sous `#if _WIN32` non compilable localement (besoin d'`imgui.h`) → validé par la CI `build-windows`

## Reste à brancher (suivi)
- Transmission des métriques au serveur (payload de création encore `name + race`)
- Application réelle au mesh 3D (stub `ApplyCustomization`)

## Déploiement
✅ Client uniquement, **pas de redéploiement serveur**.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_