### PR TITLE
config: switch endpoints from local IP to public IP 82.66.77.254

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -27,8 +27,8 @@ LCDLLN_HMAC_SECRET=dev_secret_change_in_production_32chars
 # Client : aligner external/external_links.json (status HTTP, master_tcp_host) sur l’IP réelle du serveur.
 
 # --- Shard (adresse annoncée aux clients dans la liste des serveurs) -----------------
-# Doit être joignable depuis la machine qui lance le jeu (ex. IP LAN de l’hôte Docker + port publié shard).
-# SHARD_REGISTER_ENDPOINT=10.0.4.133:3843
+# Doit être joignable depuis la machine qui lance le jeu (IP publique ou LAN + port publié shard).
+# SHARD_REGISTER_ENDPOINT=82.66.77.254:3843
 # SHARD_PORT=3843
 
 # --- Traefik (web-portal, phpmyadmin ; master désactivé par défaut) ---

--- a/external/external_links.json
+++ b/external/external_links.json
@@ -1,9 +1,9 @@
 {
   "client": {
     "web_portal_reset_url": "https://lcdlln-portal.tips-of-mine.com/password-recovery",
-    "status_api_url": "http://82.66.77.254:3842/status",
-    "master_tcp_host": "82.66.77.254",
-    "master_https_host": "82.66.77.254",
-    "master_embedded_http_origin": "http://82.66.77.254:3842"
+    "status_api_url": "http://lcdlln-master.tips-of-mine.com:3842/status",
+    "master_tcp_host": "lcdlln-master.tips-of-mine.com",
+    "master_https_host": "lcdlln-master.tips-of-mine.com",
+    "master_embedded_http_origin": "http://lcdlln-master.tips-of-mine.com:3842"
   }
 }

--- a/external/external_links.json
+++ b/external/external_links.json
@@ -1,9 +1,9 @@
 {
   "client": {
     "web_portal_reset_url": "https://lcdlln-portal.tips-of-mine.com/password-recovery",
-    "status_api_url": "http://10.0.4.133:3842/status",
-    "master_tcp_host": "10.0.4.133",
-    "master_https_host": "10.0.4.133",
-    "master_embedded_http_origin": "http://10.0.4.133:3842"
+    "status_api_url": "http://82.66.77.254:3842/status",
+    "master_tcp_host": "82.66.77.254",
+    "master_https_host": "82.66.77.254",
+    "master_embedded_http_origin": "http://82.66.77.254:3842"
   }
 }

--- a/src/shared/core/DefaultClientEndpoints.h
+++ b/src/shared/core/DefaultClientEndpoints.h
@@ -5,5 +5,5 @@
 namespace engine::core::defaults
 {
 	/// URL de la sonde `/status` — à garder alignée avec `external/external_links.json` (`client.status_api_url`).
-	inline constexpr std::string_view kStatusApiUrl = "http://10.0.4.133:3842/status";
+	inline constexpr std::string_view kStatusApiUrl = "http://82.66.77.254:3842/status";
 }


### PR DESCRIPTION
## Résumé

- Remplace `10.0.4.133` par `82.66.77.254` dans `external/external_links.json` (4 clés)
- Aligne `DefaultClientEndpoints.h` (`kStatusApiUrl`) avec la même IP publique

## Vérifications préalables

Avant le changement, les deux services critiques ont été testés et confirmés accessibles sur l'IP publique :
- ✅ Port **3842** HTTP — `curl http://82.66.77.254:3842/status` → OK
- ✅ Port **3840** TCP — `Test-NetConnection -Port 3840` → `TcpTestSucceeded: True`

## Déploiement

✅ client uniquement, pas de redéploiement serveur — changement purement de configuration d'endpoint client, aucun opcode ni protocole modifié.

https://claude.ai/code/session_013tRDm5cjQF6K7GXpRxPH71

---
_Generated by [Claude Code](https://claude.ai/code/session_013tRDm5cjQF6K7GXpRxPH71)_