### PR TITLE
config: bascule l'hôte master vers 82.66.77.254

### DIFF
--- a/external/external_links.json
+++ b/external/external_links.json
@@ -1,9 +1,9 @@
 {
   "client": {
     "web_portal_reset_url": "https://lcdlln-portal.tips-of-mine.com/password-recovery",
-    "status_api_url": "http://10.0.4.133:3842/status",
-    "master_tcp_host": "10.0.4.133",
-    "master_https_host": "10.0.4.133",
-    "master_embedded_http_origin": "http://10.0.4.133:3842"
+    "status_api_url": "http://82.66.77.254:3842/status",
+    "master_tcp_host": "82.66.77.254",
+    "master_https_host": "82.66.77.254",
+    "master_embedded_http_origin": "http://82.66.77.254:3842"
   }
 }


### PR DESCRIPTION
## Changement

Bascule de l'hôte **master** vers la nouvelle IP publique dans `external/external_links.json` :

`10.0.4.133` → **`82.66.77.254`** sur les 4 clés :
- `status_api_url` (`http://82.66.77.254:3842/status`)
- `master_tcp_host`
- `master_https_host`
- `master_embedded_http_origin` (`http://82.66.77.254:3842`)

JSON validé. Changement isolé (rien d'autre touché), indépendant de la migration UE5 (PR #654).

## Déploiement
⚠️ **Config réseau client** : `external_links.json` est fusionné comme défauts par le client (`Config::MergeDefaultsFromJsonFile`). Les clients utiliseront cette IP pour joindre le master. Vérifier que le master écoute bien sur `82.66.77.254:3842` (status/HTTP) et le port TCP gameplay avant de diffuser. Pas de changement de protocole ni de code serveur → **pas de redéploiement serveur** induit par cette PR (juste s'assurer que l'IP cible est correcte/joignable).

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_