### PR TITLE
ci: package external_links.json (IP master = source unique, sans recompiler)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -200,6 +200,16 @@ jobs:
             Copy-Item $config -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
           }
 
+          # external/external_links.json : source runtime de l'IP master (status
+          # + host master derive). Charge a cote de l'exe par Config.cpp et ecrase
+          # le defaut compile (DefaultClientEndpoints). En le packageant ici, l'IP
+          # se change en editant ce seul fichier, sans recompiler.
+          $extLinks = "$env:GITHUB_WORKSPACE\external\external_links.json"
+          if (Test-Path $extLinks) {
+            New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\artifacts\external" | Out-Null
+            Copy-Item $extLinks -Destination "$env:GITHUB_WORKSPACE\artifacts\external" -Force
+          }
+
           # build_hlod.bat à la racine du package de livraison (si présent)
           $buildHlod = "$env:GITHUB_WORKSPACE\build_hlod.bat"
           if (Test-Path $buildHlod) {

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -93,6 +93,9 @@ Le **ZIP CI** inclut **`deploy/docker/web-portal/`**. En clone Git sans pack : `
 
 **Master — accès par IP (défaut actuel)** : le service `master` publie **3840** (jeu) et **3842** (HTTP embarqué : `/status`, etc.) sur **`MASTER_PUBLISH_ADDR`** (défaut `0.0.0.0`), joignable depuis le LAN (ex. `http://10.0.4.133:3842/status`). **`traefik.enable=false`** sur le master : pas de route Traefik tant que vous n’avez pas de DNS / reverse proxy devant. Côté client, adaptez **`external/external_links.json`** (copié à côté de l’exe) si l’IP du serveur change.
 
+> **IP master côté client — source unique** : l’IP/host effectif vient de `external/external_links.json` (`client.status_api_url`, `master_tcp_host`, …), chargé **à côté de l’exe** par `Config.cpp` et qui **écrase** le défaut compilé `engine::core::defaults::kStatusApiUrl` (`src/shared/core/DefaultClientEndpoints.h`). Depuis la CI, l’artefact Windows **package** ce fichier (étape « Collect artifacts » de `build-windows.yml`) → **pour changer l’IP, éditer `external/external_links.json` suffit** (le défaut compilé n’est qu’un repli si le fichier est absent ; le garder aligné).
+
+
 **Master derrière Traefik (plus tard)** : copier les labels depuis **`traefik-master.labels.reference.yml`** (HTTP vers 3842, TCP jeu vers 3840, TLS passthrough). Il faut alors des **entrypoints** Traefik adaptés et `traefik.enable=true` sur le master ; voir aussi [doc Traefik TCP](https://doc.traefik.io/traefik/routing/routers/#tcp).
 
 **Dépannage** : si le routeur ne répond pas, vérifiez que Traefik apparaît dans `docker network inspect traefik_front_network` et que le DNS pointe vers Traefik pour l’host des labels (`lcdlln-portal.tips-of-mine.com` par défaut).


### PR DESCRIPTION
## Point #1 — IP master : source unique = `external/external_links.json`

### Problème
L'artefact Windows ne contenait **pas** `external/external_links.json`. Le client retombait donc sur l'IP **compilée** (`engine::core::defaults::kStatusApiUrl`) → impossible de changer l'IP sans recompiler (cause des timeouts `12002` rencontrés).

### Fix
`build-windows.yml` (étape « Collect artifacts ») **package** désormais `external/external_links.json` dans l'artefact. Le client le charge **à côté de l'exe** (`Config.cpp`) et il **écrase** le défaut compilé.

➡️ Conséquence : **pour changer l'IP master, il suffit d'éditer `external/external_links.json`** (et de relivrer l'artefact) — plus besoin de recompiler. Le défaut compilé (`DefaultClientEndpoints.h`, déjà sur `82.66.77.254`) reste un **repli** si le fichier est absent.

### Doc
`deploy/docker/README.md` : note ajoutée sur la résolution de l'IP côté client (source unique + repli compilé).

> Reste hors-scope ici (commentaires/exemples) : `deploy/docker/.env.example` et commentaires `docker-compose.yml`/README mentionnent encore `10.0.4.133` à titre d'exemple — inertes (dis-moi si tu veux les aligner aussi).

## Déploiement
✅ Client/CI uniquement, pas de redéploiement serveur.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_