### PR TITLE
feat(input): défaut clavier OS au 1er lancement (AZERTY → zqsd)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1506,3 +1506,14 @@ Le wiring C MVP ne touche ni `CharacterController` ni `TerrainCollider` (sticky 
 ### Extensibilité
 
 Ajouter une race = entrée dans `races.json` + `RACE_SPECS` du générateur → `gen_race_configs.py` → `Initialize()` découvre le fichier automatiquement (aucune recompilation). Nouvelles features raciales : synchroniser `kKnownRacialFeatures` (`.cpp`) et le générateur. Conventions assets : `docs/CONVENTIONS_NAMING.md`, exigences FBX : `docs/FBX_REQUIREMENTS.md`.
+
+## 26. Disposition clavier par défaut au 1er lancement (2026-05-22)
+
+**Objectif** : au tout premier lancement (aucune préférence persistée), choisir automatiquement la disposition de déplacement selon le **clavier de l'OS** — clavier **français (AZERTY) → `zqsd`**, sinon `wasd`. Le joueur peut toujours changer dans les Options ; la valeur persistée (`user_settings.json`) **prime ensuite**.
+
+### Mécanique
+
+- Réglage : `controls.movement_layout` = `"wasd"` | `"zqsd"` (lu dans `m_useZqsd` côté `AuthUiPresenter`, et en `engine::render::MovementLayout` côté `Engine`).
+- Détection : `Engine.cpp` (namespace anonyme) `DetectDefaultMovementLayout()` — sur Windows `GetKeyboardLayout(0)` → `PRIMARYLANGID == LANG_FRENCH` ⇒ `zqsd` ; ailleurs (`#else`) ⇒ `wasd`.
+- Injection : juste après `ApplyUserSettingsOverrides(m_cfg)`, **si** `!m_cfg.Has("controls.movement_layout")` (ni `config.json` ni `user_settings.json` ne le fixent), on `SetValue` le défaut OS. Les lectures aval (`Engine` + `AuthUiPresenter`) héritent donc du bon défaut, et le 1er enregistrement de `user_settings.json` le persiste (template via `replaceString("movement_layout", …)`).
+- Priorité : `user_settings.json` > `config.json` > **défaut OS** > `"wasd"` (repli ultime). Aucune régression : si une source fixe déjà la disposition, le défaut OS est ignoré.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -405,6 +405,21 @@ namespace engine
 			return RaycastTerrainHeightmap(camera.position, dir, hm, ox, oz, ws, hScale, maxDist, outX, outZ);
 		}
 
+		// Détecte la disposition clavier par défaut au 1er lancement selon l'OS :
+		// clavier français (AZERTY) -> "zqsd", sinon "wasd". N'est appliquée que si
+		// ni config.json ni user_settings.json ne fixent controls.movement_layout ;
+		// le choix du joueur (persisté dans user_settings.json) prime ensuite.
+		std::string DetectDefaultMovementLayout()
+		{
+#if defined(_WIN32)
+			const HKL  hkl    = ::GetKeyboardLayout(0);
+			const WORD langId = LOWORD(reinterpret_cast<UINT_PTR>(hkl));
+			if (PRIMARYLANGID(langId) == LANG_FRENCH)
+				return "zqsd";
+#endif
+			return "wasd";
+		}
+
 		void ApplyUserSettingsOverrides(engine::core::Config& cfg)
 		{
 			engine::core::Config persisted;
@@ -814,6 +829,14 @@ namespace engine
 		// Config + subsystems
 		// ------------------------------------------------------------------
 		ApplyUserSettingsOverrides(m_cfg);
+		// 1er lancement : si aucune source (config.json / user_settings.json) ne
+		// fixe la disposition clavier, défaut basé sur le clavier OS (AZERTY -> zqsd).
+		if (!m_cfg.Has("controls.movement_layout"))
+		{
+			const std::string osLayout = DetectDefaultMovementLayout();
+			m_cfg.SetValue("controls.movement_layout", osLayout);
+			LOG_INFO(Core, "[Boot] controls.movement_layout défaut OS (clavier) = {}", osLayout);
+		}
 		m_vsync   = m_cfg.GetBool("render.vsync", true);
 		m_fixedDt = m_cfg.GetDouble("time.fixed_dt", 0.0);
 		m_worldEditorExe = HasCliFlag(argc, argv, "--world-editor");


### PR DESCRIPTION
## Point #4 — Disposition clavier par défaut au 1er lancement

Au tout premier lancement (aucune préférence persistée), la disposition de déplacement suit désormais le **clavier de l'OS** :
- clavier **français (AZERTY) → `zqsd`** ;
- sinon → `wasd`.

Le joueur peut toujours changer dans les **Options** ; la valeur persistée dans `user_settings.json` **prime ensuite** (aucune régression pour les configs existantes).

### Implémentation
- `Engine.cpp` : `DetectDefaultMovementLayout()` — Win32 `GetKeyboardLayout(0)` → `PRIMARYLANGID == LANG_FRENCH` ⇒ `zqsd` ; `#else` ⇒ `wasd`.
- Injection juste après `ApplyUserSettingsOverrides(m_cfg)` **uniquement si** `!m_cfg.Has("controls.movement_layout")` (ni `config.json` ni `user_settings.json` ne le fixent). Les lectures aval (`Engine` + `AuthUiPresenter`) héritent du défaut, et le 1er enregistrement de `user_settings.json` le persiste.
- Priorité : `user_settings.json` > `config.json` > **défaut OS** > `"wasd"` (repli).
- Doc : `CODEBASE_MAP.md` §26.

### Test (à valider sur Windows)
1. Supprimer `user_settings.json` (simuler 1er lancement) sur un poste **clavier FR** → au boot, log `[Boot] controls.movement_layout défaut OS (clavier) = zqsd` et déplacements en ZQSD.
2. Changer en WASD dans Options → relancer → reste WASD (persistance prime).
3. Poste clavier US → défaut `wasd`.

> Détection Windows uniquement (le client est Windows) ; ailleurs repli `wasd`.

## Déploiement
✅ Client uniquement, **pas de redéploiement serveur**.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_