### PR TITLE
feat(anim): exposer les clips UE5 à l'avatar (foundation #3, hors pistol/driving)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1517,3 +1517,16 @@ Ajouter une race = entrée dans `races.json` + `RACE_SPECS` du générateur → 
 - Détection : `Engine.cpp` (namespace anonyme) `DetectDefaultMovementLayout()` — sur Windows `GetKeyboardLayout(0)` → `PRIMARYLANGID == LANG_FRENCH` ⇒ `zqsd` ; ailleurs (`#else`) ⇒ `wasd`.
 - Injection : juste après `ApplyUserSettingsOverrides(m_cfg)`, **si** `!m_cfg.Has("controls.movement_layout")` (ni `config.json` ni `user_settings.json` ne le fixent), on `SetValue` le défaut OS. Les lectures aval (`Engine` + `AuthUiPresenter`) héritent donc du bon défaut, et le 1er enregistrement de `user_settings.json` le persiste (template via `replaceString("movement_layout", …)`).
 - Priorité : `user_settings.json` > `config.json` > **défaut OS** > `"wasd"` (repli ultime). Aucune régression : si une source fixe déjà la disposition, le défaut OS est ignoré.
+
+## 27. Animations UE5 — clips disponibles & mapping (2026-05-22)
+
+La library `models/animations/humanoid_base/Humanoid_Base_Standard/…glb` contient **45 clips** (rig UE5), chargés/retargetés par `SkinnedMeshLoader::LoadClipsAnimOnly` et rattachés à l'avatar dans `Engine.cpp` (branche `isUe5Rig` de `loadOneRace`).
+
+### Étape 1 (faite) — clips exposés
+- **Mappés aux états de locomotion** (joués par la state machine) : `Idle←Idle_Loop`, `Walk←Walk_Loop`, `StartWalking/WalkBack←Walk_Loop`, `Run←Jog_Fwd_Loop`, `Jump←Jump_Start`, `Fall←Jump_Loop`, `Land←Jump_Land`.
+- **Exposés par leur nom brut** (disponibles via `SkinnedMesh::FindClip("<nom>")`, **sans déclencheur** pour l'instant) : tous les autres clips retenus — `Sprint_Loop, Walk_Formal_Loop, Crouch_Idle_Loop, Crouch_Fwd_Loop, Roll, Roll_RM, Push_Loop, Idle_Talking_Loop, Idle_Torch_Loop, Sword_Idle, Sword_Attack, Sword_Attack_RM, Punch_Jab, Punch_Cross, Hit_Chest, Hit_Head, Death01, Spell_Simple_Enter/Idle_Loop/Shoot/Exit, Dance_Loop, Sitting_Enter/Idle_Loop/Talking_Loop/Exit, Interact, PickUp_Table, Fixing_Kneeling, Swim_Fwd_Loop, Swim_Idle_Loop`.
+- **Exclus** (non chargés) : `Pistol_*` (pas d'arme à feu), `Driving_Loop` (pas de véhicule), `A_TPose` (pose de référence).
+- Test : `skinned_mesh_loader_tests` vérifie la présence/retarget de plusieurs de ces clips.
+
+### Étape 2 (à venir, 1 PR par feature, testée en jeu) — déclencheurs
+La state machine n'a que `Idle/StartWalking/Walk/WalkBack/Run/Jump/Fall/Land` ; `Run` = touche **Shift**. Aucun système de **crouch / dodge / combat / emote** ; la **nage** existe dans `CharacterController` mais est forcée à `false` (B.1). « Câbler » chaque clip = créer l'input + l'état/le système gameplay. Ordre prévu : **Sprint → Crouch → Roll/esquive → emote `/dance`** → (combat & nage = plus gros, dépend possiblement des events serveur).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4023,6 +4023,38 @@ namespace engine
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
+
+															// Expose AUSSI tous les autres clips UE5 par leur nom brut (sans
+															// prefixe "Armature|"), disponibles pour les futurs systemes
+															// (sprint, crouch, roll, combat, emotes, nage...). Exclus : armes
+															// a feu (pas dans le jeu) + conduite (pas de vehicule) + A_TPose
+															// (pose de reference, pas une anim de jeu). Aucun declencheur ici :
+															// les clips sont seulement rendus accessibles via FindClip(<nom>).
+															auto isExcludedUe5Clip = [](const std::string& n) {
+																return n == "Pistol_Aim_Up" || n == "Pistol_Aim_Neutral"
+																	|| n == "Pistol_Aim_Down" || n == "Pistol_Idle_Loop"
+																	|| n == "Pistol_Reload" || n == "Pistol_Shoot"
+																	|| n == "Driving_Loop" || n == "A_TPose";
+															};
+															int ue5Exposed = 0;
+															for (const auto& c : ue5Clips) {
+																if (c.duration <= 0.0f) continue;
+																std::string name = c.name;
+																const auto bar = name.rfind('|');
+																if (bar != std::string::npos) name = name.substr(bar + 1);
+																if (isExcludedUe5Clip(name)) continue;
+																bool exists = false;
+																for (const auto& existing : loaded->clips) {
+																	if (existing.name == name) { exists = true; break; }
+																}
+																if (exists) continue;
+																engine::render::skinned::AnimationClip copy = c;
+																copy.name = name;
+																loaded->clips.push_back(std::move(copy));
+																++ue5Exposed;
+															}
+															LOG_INFO(Render, "[Engine] UE5 race '{}' : {} clips additionnels exposes (total {})",
+																raceId, ue5Exposed, loaded->clips.size());
 														}
 														else
 														{

--- a/src/client/render/skinned/tests/SkinnedMeshLoaderTests.cpp
+++ b/src/client/render/skinned/tests/SkinnedMeshLoaderTests.cpp
@@ -144,6 +144,20 @@ namespace
             const auto& trk = idle->tracks[pelvisIdx];
             REQUIRE(!trk.rotation.empty() || !trk.translation.empty());
         }
+
+        // Les clips additionnels exposés à l'avatar (sprint/crouch/combat/emotes)
+        // doivent être présents et retargetés dans la library (foundation #3).
+        auto hasClip = [&](const char* needle) {
+            for (const auto& c : clips)
+                if (c.name.find(needle) != std::string::npos && c.duration > 0.0f) return true;
+            return false;
+        };
+        REQUIRE(hasClip("Sprint_Loop"));
+        REQUIRE(hasClip("Crouch_Idle_Loop"));
+        REQUIRE(hasClip("Roll"));
+        REQUIRE(hasClip("Sword_Attack"));
+        REQUIRE(hasClip("Dance_Loop"));
+        REQUIRE(hasClip("Swim_Fwd_Loop"));
     }
 
     /// Vérifie qu'un chemin inexistant renvoie std::nullopt (pas un crash).


### PR DESCRIPTION
## Point #3 — Étape 1 : exposer les animations UE5 à l'avatar

Les 45 clips de la library UE5 (`Humanoid_Base_Standard`) sont désormais **rattachés à l'avatar par leur nom brut** (sans préfixe `Armature|`), en plus des 6 rôles de locomotion déjà mappés. Disponibles via `SkinnedMesh::FindClip("<nom>")` pour les futurs systèmes.

**Exclus** (sur ta demande) : `Pistol_*` (pas d'arme à feu), `Driving_Loop` (pas de véhicule), + `A_TPose` (pose de référence, pas une anim de jeu).

⚠️ **Aucun déclencheur ajouté ici** : les clips non-locomotion (sprint, crouch, combat, emotes, nage…) sont **chargés et accessibles** mais **pas encore joués** — il n'y a pas d'input/état/système gameplay pour les déclencher. C'est l'**étape 2** (1 PR par feature, testée en jeu).

## Détail
- `Engine.cpp` : boucle d'exposition dans la branche `isUe5Rig` de `loadOneRace`.
- `skinned_mesh_loader_tests` : vérifie présence + retarget de `Sprint_Loop, Crouch_Idle_Loop, Roll, Sword_Attack, Dance_Loop, Swim_Fwd_Loop` → **exécuté en local (headers Vulkan), OK**.
- Doc : `CODEBASE_MAP.md` §27 (liste complète + mapping + roadmap des triggers).

## Étape 2 — roadmap des déclencheurs (à venir, dans l'ordre)
La SM n'a que `Idle/StartWalking/Walk/WalkBack/Run/Jump/Fall/Land` (`Run` = Shift) ; pas de système crouch/dodge/combat/emote ; nage présente dans `CharacterController` mais forcée à `false` (B.1). Câbler = créer input + état/système. Ordre : **Sprint → Crouch → Roll/esquive → emote `/dance`** → (combat & nage = plus gros, possiblement events serveur).

## Déploiement
✅ Client uniquement, **pas de redéploiement serveur**.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_