### PR TITLE
feat(loco): sprint (Alt) — 3e palier de vitesse + état + anim UE5

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1530,3 +1530,15 @@ La library `models/animations/humanoid_base/Humanoid_Base_Standard/…glb` conti
 
 ### Étape 2 (à venir, 1 PR par feature, testée en jeu) — déclencheurs
 La state machine n'a que `Idle/StartWalking/Walk/WalkBack/Run/Jump/Fall/Land` ; `Run` = touche **Shift**. Aucun système de **crouch / dodge / combat / emote** ; la **nage** existe dans `CharacterController` mais est forcée à `false` (B.1). « Câbler » chaque clip = créer l'input + l'état/le système gameplay. Ordre prévu : **Sprint → Crouch → Roll/esquive → emote `/dance`** → (combat & nage = plus gros, dépend possiblement des events serveur).
+
+## 28. Sprint — palier de vitesse + état de locomotion (2026-05-22)
+
+**Objectif** : 3ᵉ palier de déplacement (premier déclencheur d'anim UE5 de l'étape 2 de §27). Touches : **marche** (défaut) → **course = Shift** (jog) → **sprint = Alt maintenu**.
+
+### Chaîne complète
+- **Input** : `engine::platform::Key::Alt = 0x12` (VK_MENU, capturé via `WM_SYSKEYDOWN` dans `Input::HandleMessage`). `BuildMoveInput` : `out.sprint = input.IsDown(Key::Alt)`.
+- **Vitesse** : `CharacterController::Config::sprintSpeed = 13` ; `targetSpeed = sprint ? sprintSpeed : (run ? runSpeed : walkSpeed)`.
+- **État** : `AvatarLocomotionState::Sprint` (après `Run`) ; transitions dans la SM (`Walk/Run/StartWalking/Land` → `Sprint` si `moveInput.sprint`, et `Sprint` → Run/Walk/Idle/WalkBack/Jump). `StateToClipName(Sprint) = "Sprint"`, `ClipLoops(Sprint) = true`.
+- **Anim** : `addRole("Sprint", "Sprint_Loop")` dans la branche UE5 de `loadOneRace` (clip de la library UE5). Pour une race Mixamo sans clip "Sprint", `FindClip` renvoie nullptr → l'anim précédente continue (repli gracieux).
+
+Priorité d'intention : **sprint > run > walk**. Reste de l'étape 2 (§27) : Crouch → Roll/esquive → emote `/dance`.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -183,6 +183,7 @@ namespace engine
 			}
 
 			out.run         = input.IsDown(engine::platform::Key::Shift);
+			out.sprint      = input.IsDown(engine::platform::Key::Alt);
 			out.jumpPressed = input.WasPressed(engine::platform::Key::Space);
 			// swim/fly hors-scope B.1 : restent false (consommes par les modes
 			// Water/Fly du CharacterController, inutiles tant que la query eau
@@ -223,6 +224,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Walk:         return "Walk";
 				case engine::Engine::AvatarLocomotionState::WalkBack:     return "WalkBack";
 				case engine::Engine::AvatarLocomotionState::Run:          return "Run";
+				case engine::Engine::AvatarLocomotionState::Sprint:       return "Sprint";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -244,6 +246,7 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::Walk
 				|| s == engine::Engine::AvatarLocomotionState::WalkBack
 				|| s == engine::Engine::AvatarLocomotionState::Run
+				|| s == engine::Engine::AvatarLocomotionState::Sprint
 				|| s == engine::Engine::AvatarLocomotionState::Fall;
 		}
 
@@ -4020,6 +4023,7 @@ namespace engine
 															addRole("StartWalking", "Walk_Loop");
 															addRole("WalkBack", "Walk_Loop");
 															addRole("Run", "Jog_Fwd_Loop");
+															addRole("Sprint", "Sprint_Loop");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7033,12 +7037,15 @@ namespace engine
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
 								else if (startWalkClip && stateElapsed >= startWalkClip->duration)
-									newState = (moveInput.run ? AvatarLocomotionState::Run : AvatarLocomotionState::Walk);
+									newState = (moveInput.sprint ? AvatarLocomotionState::Sprint
+									            : moveInput.run ? AvatarLocomotionState::Run
+									            : AvatarLocomotionState::Walk);
 								break;
 							case AvatarLocomotionState::Walk:
 								if (!moving)                      newState = AvatarLocomotionState::Idle;
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (moveInput.sprint)        newState = AvatarLocomotionState::Sprint;
 								else if (moveInput.run)           newState = AvatarLocomotionState::Run;
 								break;
 							case AvatarLocomotionState::WalkBack:
@@ -7050,7 +7057,15 @@ namespace engine
 								if (!moving)                      newState = AvatarLocomotionState::Idle;
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (moveInput.sprint)        newState = AvatarLocomotionState::Sprint;
 								else if (!moveInput.run)          newState = AvatarLocomotionState::Walk;
+								break;
+							case AvatarLocomotionState::Sprint:
+								if (!moving)                      newState = AvatarLocomotionState::Idle;
+								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
+								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (!moveInput.sprint)
+									newState = (moveInput.run ? AvatarLocomotionState::Run : AvatarLocomotionState::Walk);
 								break;
 							case AvatarLocomotionState::Jump:
 								// Takeoff = first 40% of Jump clip ; then Fall (until grounded).
@@ -7066,6 +7081,7 @@ namespace engine
 								{
 									if (!moving)                  newState = AvatarLocomotionState::Idle;
 									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
 									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
 									else                          newState = AvatarLocomotionState::Walk;
 								}

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -578,6 +578,7 @@ namespace engine
 			Walk,
 			WalkBack,
 			Run,
+			Sprint,
 			Jump,
 			Fall,
 			Land

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -124,7 +124,8 @@ namespace engine::gameplay
 		const float moveLen = LengthXZ(desiredMoveXZ);
 		const bool hasMove = moveLen > 1e-5f;
 
-		const float targetSpeed = input.run ? m_cfg.runSpeed : m_cfg.walkSpeed;
+		const float targetSpeed = input.sprint ? m_cfg.sprintSpeed
+		                        : (input.run  ? m_cfg.runSpeed : m_cfg.walkSpeed);
 		engine::math::Vec3 desiredVelXZ(0.0f, 0.0f, 0.0f);
 		if (hasMove)
 			desiredVelXZ = desiredMoveXZ * (targetSpeed / moveLen);

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -58,6 +58,8 @@ namespace engine::gameplay
 		/// Desired direction on XZ plane (y ignored). Length can be 0.
 		engine::math::Vec3 moveDirXZ{ 0.0f, 0.0f, 0.0f };
 		bool run = false;
+		/// Sprint (vitesse max). Prioritaire sur `run`. Mappé sur Alt côté caller.
+		bool sprint = false;
 		/// Jump edge trigger (true on the frame the player presses jump).
 		bool jumpPressed = false;
 
@@ -76,6 +78,7 @@ namespace engine::gameplay
 		{
 			float walkSpeed = 5.0f;  ///< range: 4-6 m/s
 			float runSpeed = 9.0f;   ///< range: 8-10 m/s
+			float sprintSpeed = 13.0f; ///< range: 12-14 m/s (Alt maintenu)
 			float acceleration = 25.0f; ///< m/s^2
 			float friction = 20.0f;     ///< m/s^2 (horizontal decel when no input)
 

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -45,6 +45,7 @@ namespace engine::platform
 		Escape = 0x1B,
 		Tab = 0x09,
 		Control = 0x11,
+		Alt = 0x12, ///< VK_MENU (gauche ou droite) — capturé via WM_SYSKEYDOWN. Sprint (CHAR-MODEL).
 		Space = 0x20,
 		Enter = 0x0D,
 		Backspace = 0x08,


### PR DESCRIPTION
## Point #3 — Étape 2, feature 1 : Sprint (Alt)

3ᵉ palier de déplacement, **premier déclencheur d'anim UE5** de l'étape 2 :
**marche** (défaut) → **course = Shift** (jog, inchangé) → **sprint = Alt maintenu**.

### Chaîne complète
- **Input** : ajout `engine::platform::Key::Alt = 0x12` (VK_MENU, capturé via `WM_SYSKEYDOWN` dans `Input::HandleMessage`). `BuildMoveInput` : `out.sprint = input.IsDown(Key::Alt)`.
- **Vitesse** : `CharacterController::Config::sprintSpeed = 13` ; `targetSpeed = sprint ? sprintSpeed : (run ? runSpeed : walkSpeed)`.
- **État** : nouvel `AvatarLocomotionState::Sprint` + transitions SM (`Walk/Run/StartWalking/Land → Sprint` si `sprint` ; `Sprint → Run/Walk/Idle/WalkBack/Jump`). `StateToClipName(Sprint)="Sprint"`, `ClipLoops(Sprint)=true`.
- **Anim** : `addRole("Sprint","Sprint_Loop")` (branche UE5). Race Mixamo sans clip "Sprint" → `FindClip` nullptr → anim précédente continue (repli gracieux, pas de régression).

Priorité : **sprint > run > walk**.

### Vérifs côté agent
- ✅ `CharacterController.cpp` : syntaxe OK (compile-check local).
- ✅ Couverture des `switch` sur l'enum (StateToClipName + SM) à jour → pas de `-Wswitch`.
- ⚠️ `Engine.cpp` non compilable en isolé ici → compilation validée par CI ; **rendu/feel à tester en jeu**.

### À tester (Windows)
Maintenir **Alt** en déplacement → vitesse accrue + anim `Sprint_Loop` ; relâcher → retour course/marche. (Note : Alt peut être capté par l'OS pour le menu fenêtre ; si gênant on rebindera.)

> Doc : `CODEBASE_MAP.md` §28. Dépend de la library UE5 (`Sprint_Loop`), déjà sur `main` via #654.

## Déploiement
✅ Client uniquement, **pas de redéploiement serveur**.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_