### PR TITLE
feat(loco): crouch (Ctrl) — accroupi (vitesse + états + anim UE5)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1506,3 +1506,15 @@ Le wiring C MVP ne touche ni `CharacterController` ni `TerrainCollider` (sticky 
 ### Extensibilité
 
 Ajouter une race = entrée dans `races.json` + `RACE_SPECS` du générateur → `gen_race_configs.py` → `Initialize()` découvre le fichier automatiquement (aucune recompilation). Nouvelles features raciales : synchroniser `kKnownRacialFeatures` (`.cpp`) et le générateur. Conventions assets : `docs/CONVENTIONS_NAMING.md`, exigences FBX : `docs/FBX_REQUIREMENTS.md`.
+
+## 28. Sprint — palier de vitesse + état de locomotion (2026-05-22)
+
+**Objectif** : 3ᵉ palier de déplacement (premier déclencheur d'anim UE5 de l'étape 2 de §27). Touches : **marche** (défaut) → **course = Shift** (jog) → **sprint = Alt maintenu**.
+
+### Chaîne complète
+- **Input** : `engine::platform::Key::Alt = 0x12` (VK_MENU, capturé via `WM_SYSKEYDOWN` dans `Input::HandleMessage`). `BuildMoveInput` : `out.sprint = input.IsDown(Key::Alt)`.
+- **Vitesse** : `CharacterController::Config::sprintSpeed = 13` ; `targetSpeed = sprint ? sprintSpeed : (run ? runSpeed : walkSpeed)`.
+- **État** : `AvatarLocomotionState::Sprint` (après `Run`) ; transitions dans la SM (`Walk/Run/StartWalking/Land` → `Sprint` si `moveInput.sprint`, et `Sprint` → Run/Walk/Idle/WalkBack/Jump). `StateToClipName(Sprint) = "Sprint"`, `ClipLoops(Sprint) = true`.
+- **Anim** : `addRole("Sprint", "Sprint_Loop")` dans la branche UE5 de `loadOneRace` (clip de la library UE5). Pour une race Mixamo sans clip "Sprint", `FindClip` renvoie nullptr → l'anim précédente continue (repli gracieux).
+
+Priorité d'intention : **sprint > run > walk**. Reste de l'étape 2 (§27) : Crouch → Roll/esquive → emote `/dance`.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1518,3 +1518,19 @@ Ajouter une race = entrée dans `races.json` + `RACE_SPECS` du générateur → 
 - **Anim** : `addRole("Sprint", "Sprint_Loop")` dans la branche UE5 de `loadOneRace` (clip de la library UE5). Pour une race Mixamo sans clip "Sprint", `FindClip` renvoie nullptr → l'anim précédente continue (repli gracieux).
 
 Priorité d'intention : **sprint > run > walk**. Reste de l'étape 2 (§27) : Crouch → Roll/esquive → emote `/dance`.
+
+## 29. Crouch (Ctrl) — accroupi (vitesse + états de locomotion) (2026-05-22)
+
+**Objectif** : 2ᵉ déclencheur de l'étape 2 (§27). Touche : **Ctrl maintenu** = accroupi (idle + déplacement). Priorité **crouch > sprint > run > walk**.
+
+### Chaîne
+- **Input** : `BuildMoveInput` → `out.crouch = input.IsDown(Key::Control)` (Ctrl existe déjà dans l'enum).
+- **Vitesse** : `CharacterController::Config::crouchSpeed = 2.5` ; `targetSpeed = crouch ? crouchSpeed : (sprint ? … : (run ? … : walk))`.
+- **États** : `AvatarLocomotionState::CrouchIdle` (immobile) et `CrouchWalk` (en mouvement). Implémentés par un **override après le switch** de la SM : si `moveInput.crouch` (et pas en amorce de saut) → `CrouchWalk`/`CrouchIdle` selon `moving`. Les `case CrouchIdle/CrouchWalk` du switch calculent la **sortie debout** (relâche Ctrl → Idle/Walk/Run/Sprint/WalkBack, ou Jump). `StateToClipName`/`ClipLoops` à jour (loop).
+- **Anim** : `addRole("CrouchIdle","Crouch_Idle_Loop")` + `addRole("CrouchWalk","Crouch_Fwd_Loop")` (branche UE5).
+
+### Limites connues (1ère itération)
+- **Pas de réduction de capsule** : l'anim est accroupie mais la collision (`r=0.3 h=1.8`) est inchangée → pas de passage sous obstacle bas pour l'instant (à ajouter avec un test "puis-je me relever ?").
+- **Ctrl** sert aussi de modificateur de raccourcis (ex. Ctrl+L loot) : tenir Ctrl pour s'accroupir peut interférer avec ces combos (rebindable si gênant).
+
+Reste de l'étape 2 : Roll/esquive → emote `/dance`.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -183,6 +183,7 @@ namespace engine
 			}
 
 			out.run         = input.IsDown(engine::platform::Key::Shift);
+			out.sprint      = input.IsDown(engine::platform::Key::Alt);
 			out.jumpPressed = input.WasPressed(engine::platform::Key::Space);
 			// swim/fly hors-scope B.1 : restent false (consommes par les modes
 			// Water/Fly du CharacterController, inutiles tant que la query eau
@@ -223,6 +224,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Walk:         return "Walk";
 				case engine::Engine::AvatarLocomotionState::WalkBack:     return "WalkBack";
 				case engine::Engine::AvatarLocomotionState::Run:          return "Run";
+				case engine::Engine::AvatarLocomotionState::Sprint:       return "Sprint";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -244,6 +246,7 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::Walk
 				|| s == engine::Engine::AvatarLocomotionState::WalkBack
 				|| s == engine::Engine::AvatarLocomotionState::Run
+				|| s == engine::Engine::AvatarLocomotionState::Sprint
 				|| s == engine::Engine::AvatarLocomotionState::Fall;
 		}
 
@@ -3997,6 +4000,7 @@ namespace engine
 															addRole("StartWalking", "Walk_Loop");
 															addRole("WalkBack", "Walk_Loop");
 															addRole("Run", "Jog_Fwd_Loop");
+															addRole("Sprint", "Sprint_Loop");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -6978,12 +6982,15 @@ namespace engine
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
 								else if (startWalkClip && stateElapsed >= startWalkClip->duration)
-									newState = (moveInput.run ? AvatarLocomotionState::Run : AvatarLocomotionState::Walk);
+									newState = (moveInput.sprint ? AvatarLocomotionState::Sprint
+									            : moveInput.run ? AvatarLocomotionState::Run
+									            : AvatarLocomotionState::Walk);
 								break;
 							case AvatarLocomotionState::Walk:
 								if (!moving)                      newState = AvatarLocomotionState::Idle;
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (moveInput.sprint)        newState = AvatarLocomotionState::Sprint;
 								else if (moveInput.run)           newState = AvatarLocomotionState::Run;
 								break;
 							case AvatarLocomotionState::WalkBack:
@@ -6995,7 +7002,15 @@ namespace engine
 								if (!moving)                      newState = AvatarLocomotionState::Idle;
 								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
 								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (moveInput.sprint)        newState = AvatarLocomotionState::Sprint;
 								else if (!moveInput.run)          newState = AvatarLocomotionState::Walk;
+								break;
+							case AvatarLocomotionState::Sprint:
+								if (!moving)                      newState = AvatarLocomotionState::Idle;
+								else if (moveInput.jumpPressed)   newState = AvatarLocomotionState::Jump;
+								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (!moveInput.sprint)
+									newState = (moveInput.run ? AvatarLocomotionState::Run : AvatarLocomotionState::Walk);
 								break;
 							case AvatarLocomotionState::Jump:
 								// Takeoff = first 40% of Jump clip ; then Fall (until grounded).
@@ -7011,6 +7026,7 @@ namespace engine
 								{
 									if (!moving)                  newState = AvatarLocomotionState::Idle;
 									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
 									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
 									else                          newState = AvatarLocomotionState::Walk;
 								}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -184,6 +184,7 @@ namespace engine
 
 			out.run         = input.IsDown(engine::platform::Key::Shift);
 			out.sprint      = input.IsDown(engine::platform::Key::Alt);
+			out.crouch      = input.IsDown(engine::platform::Key::Control);
 			out.jumpPressed = input.WasPressed(engine::platform::Key::Space);
 			// swim/fly hors-scope B.1 : restent false (consommes par les modes
 			// Water/Fly du CharacterController, inutiles tant que la query eau
@@ -225,6 +226,8 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::WalkBack:     return "WalkBack";
 				case engine::Engine::AvatarLocomotionState::Run:          return "Run";
 				case engine::Engine::AvatarLocomotionState::Sprint:       return "Sprint";
+				case engine::Engine::AvatarLocomotionState::CrouchIdle:   return "CrouchIdle";
+				case engine::Engine::AvatarLocomotionState::CrouchWalk:   return "CrouchWalk";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -247,6 +250,8 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::WalkBack
 				|| s == engine::Engine::AvatarLocomotionState::Run
 				|| s == engine::Engine::AvatarLocomotionState::Sprint
+				|| s == engine::Engine::AvatarLocomotionState::CrouchIdle
+				|| s == engine::Engine::AvatarLocomotionState::CrouchWalk
 				|| s == engine::Engine::AvatarLocomotionState::Fall;
 		}
 
@@ -4001,6 +4006,8 @@ namespace engine
 															addRole("WalkBack", "Walk_Loop");
 															addRole("Run", "Jog_Fwd_Loop");
 															addRole("Sprint", "Sprint_Loop");
+															addRole("CrouchIdle", "Crouch_Idle_Loop");
+															addRole("CrouchWalk", "Crouch_Fwd_Loop");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7031,7 +7038,23 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							case AvatarLocomotionState::CrouchIdle:
+							case AvatarLocomotionState::CrouchWalk:
+								// Base de sortie vers la station debout ; l'override crouch ci-dessous
+								// re-force le crouch tant que Ctrl est tenu.
+								if (moveInput.jumpPressed)        newState = AvatarLocomotionState::Jump;
+								else if (!moving)                 newState = AvatarLocomotionState::Idle;
+								else if (movingBack)              newState = AvatarLocomotionState::WalkBack;
+								else if (moveInput.sprint)        newState = AvatarLocomotionState::Sprint;
+								else if (moveInput.run)           newState = AvatarLocomotionState::Run;
+								else                              newState = AvatarLocomotionState::Walk;
+								break;
 						}
+
+						// Crouch (Ctrl) : etat accroupi prioritaire tant que la touche est tenue
+						// (sauf amorce de saut). CrouchWalk si deplacement, sinon CrouchIdle.
+						if (moveInput.crouch && newState != AvatarLocomotionState::Jump)
+							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 					}
 					else
 					{

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -579,6 +579,8 @@ namespace engine
 			WalkBack,
 			Run,
 			Sprint,
+			CrouchIdle,
+			CrouchWalk,
 			Jump,
 			Fall,
 			Land

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -578,6 +578,7 @@ namespace engine
 			Walk,
 			WalkBack,
 			Run,
+			Sprint,
 			Jump,
 			Fall,
 			Land

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -124,7 +124,8 @@ namespace engine::gameplay
 		const float moveLen = LengthXZ(desiredMoveXZ);
 		const bool hasMove = moveLen > 1e-5f;
 
-		const float targetSpeed = input.run ? m_cfg.runSpeed : m_cfg.walkSpeed;
+		const float targetSpeed = input.sprint ? m_cfg.sprintSpeed
+		                        : (input.run  ? m_cfg.runSpeed : m_cfg.walkSpeed);
 		engine::math::Vec3 desiredVelXZ(0.0f, 0.0f, 0.0f);
 		if (hasMove)
 			desiredVelXZ = desiredMoveXZ * (targetSpeed / moveLen);

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -124,8 +124,9 @@ namespace engine::gameplay
 		const float moveLen = LengthXZ(desiredMoveXZ);
 		const bool hasMove = moveLen > 1e-5f;
 
-		const float targetSpeed = input.sprint ? m_cfg.sprintSpeed
-		                        : (input.run  ? m_cfg.runSpeed : m_cfg.walkSpeed);
+		const float targetSpeed = input.crouch ? m_cfg.crouchSpeed
+		                        : (input.sprint ? m_cfg.sprintSpeed
+		                        : (input.run    ? m_cfg.runSpeed : m_cfg.walkSpeed));
 		engine::math::Vec3 desiredVelXZ(0.0f, 0.0f, 0.0f);
 		if (hasMove)
 			desiredVelXZ = desiredMoveXZ * (targetSpeed / moveLen);

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -60,6 +60,8 @@ namespace engine::gameplay
 		bool run = false;
 		/// Sprint (vitesse max). Prioritaire sur `run`. Mappé sur Alt côté caller.
 		bool sprint = false;
+		/// Accroupi (vitesse réduite). Prioritaire sur run/sprint. Mappé sur Ctrl.
+		bool crouch = false;
 		/// Jump edge trigger (true on the frame the player presses jump).
 		bool jumpPressed = false;
 
@@ -79,6 +81,7 @@ namespace engine::gameplay
 			float walkSpeed = 5.0f;  ///< range: 4-6 m/s
 			float runSpeed = 9.0f;   ///< range: 8-10 m/s
 			float sprintSpeed = 13.0f; ///< range: 12-14 m/s (Alt maintenu)
+			float crouchSpeed = 2.5f;  ///< range: 2-3 m/s (Ctrl maintenu)
 			float acceleration = 25.0f; ///< m/s^2
 			float friction = 20.0f;     ///< m/s^2 (horizontal decel when no input)
 

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -58,6 +58,8 @@ namespace engine::gameplay
 		/// Desired direction on XZ plane (y ignored). Length can be 0.
 		engine::math::Vec3 moveDirXZ{ 0.0f, 0.0f, 0.0f };
 		bool run = false;
+		/// Sprint (vitesse max). Prioritaire sur `run`. Mappé sur Alt côté caller.
+		bool sprint = false;
 		/// Jump edge trigger (true on the frame the player presses jump).
 		bool jumpPressed = false;
 
@@ -76,6 +78,7 @@ namespace engine::gameplay
 		{
 			float walkSpeed = 5.0f;  ///< range: 4-6 m/s
 			float runSpeed = 9.0f;   ///< range: 8-10 m/s
+			float sprintSpeed = 13.0f; ///< range: 12-14 m/s (Alt maintenu)
 			float acceleration = 25.0f; ///< m/s^2
 			float friction = 20.0f;     ///< m/s^2 (horizontal decel when no input)
 

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -45,6 +45,7 @@ namespace engine::platform
 		Escape = 0x1B,
 		Tab = 0x09,
 		Control = 0x11,
+		Alt = 0x12, ///< VK_MENU (gauche ou droite) — capturé via WM_SYSKEYDOWN. Sprint (CHAR-MODEL).
 		Space = 0x20,
 		Enter = 0x0D,
 		Backspace = 0x08,


### PR DESCRIPTION
## Point #3 — Étape 2, feature 2 : Crouch (Ctrl)

> **PR empilée sur #660 (Sprint)** : base = `claude/sprint-locomotion`. Merger **#660 d'abord** ; je retargeterai cette PR sur `main` ensuite. Le diff ici ne montre que le crouch.

Accroupi : **Ctrl maintenu** → `CrouchIdle` (immobile) / `CrouchWalk` (en mouvement). Priorité **crouch > sprint > run > walk**.

### Chaîne
- **Input** : `out.crouch = input.IsDown(Key::Control)` (Ctrl déjà dans l'enum).
- **Vitesse** : `Config::crouchSpeed = 2.5` ; `targetSpeed = crouch ? crouchSpeed : (sprint ? … : (run ? … : walk))`.
- **États** : `CrouchIdle` / `CrouchWalk` via **override après le switch** SM (entrée depuis n'importe quel état debout) ; `case`s d'exit dans le switch (relâche Ctrl → état debout adéquat, ou Jump). `StateToClipName`/`ClipLoops` à jour → **11 états couverts** (pas de `-Wswitch`).
- **Anim** : `addRole("CrouchIdle","Crouch_Idle_Loop")` + `addRole("CrouchWalk","Crouch_Fwd_Loop")`.

### Vérifs côté agent
- ✅ `CharacterController.cpp` syntaxe OK.
- ✅ Switch SM couvre les 11 états.
- ⚠️ `Engine.cpp` non compilable isolé ici → CI valide ; **à tester en jeu**.

### Limites (1ère itération)
- **Pas de réduction de capsule** (collision `r=0.3 h=1.8` inchangée) → pas de passage sous obstacle bas ; à ajouter avec un test « puis-je me relever ? ».
- **Ctrl** partagé avec des raccourcis (Ctrl+L loot…) → tenir Ctrl pour s'accroupir peut interférer (rebindable).

### À tester (Windows)
Maintenir **Ctrl** immobile → `Crouch_Idle_Loop` ; en déplacement → `Crouch_Fwd_Loop` (vitesse réduite) ; relâcher → retour debout.

Doc : `CODEBASE_MAP.md` §29.

## Déploiement
✅ Client uniquement, **pas de redéploiement serveur**.

https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_