### PR TITLE
feat(combat): attaque mêlée (clic gauche) — clip Sword_Attack one-shot

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1581,3 +1581,22 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - **Double-tap Ctrl** : la fenêtre 0.30 s peut occasionnellement déclencher un Roll lors d'un crouch « nerveux » (deux appuis rapprochés). Ajustable via le seuil.
 
 §27 étape 2 **terminée**.
+
+## 31. Attaque mêlée (clic gauche) — clip combat one-shot (2026-05-22)
+
+**Objectif** : 1er déclencheur de l'étape « combat » de §27 (après l'étape 2 locomotion). Câble un clip d'attaque mêlée déclenché par l'input, **purement client/cosmétique** pour l'instant (pas de dégâts ni d'aller-retour serveur).
+
+### Chaîne
+- **Input** : **clic gauche** (`m_input.WasMousePressed(MouseButton::Left)`), edge-triggered, lu dans la SM. Le bloc gameplay est déjà gardé contre le focus chat / l'auth (Engine.cpp ~6969) ; on exclut en plus le drag inventaire (`!m_invUi.IsDragging()`) pour ne pas frapper en relâchant un objet.
+- **État** : `AvatarLocomotionState::Attack` (**one-shot**, non bouclé — absent de `ClipLoops`). Override après le switch : `if (attackPressed && !jumpPressed && état ≠ Roll && état ≠ Attack) newState = Attack` — **prioritaire sur le crouch** (on peut frapper accroupi, retour debout l'attaque finie), mais ne coupe **pas** un Roll en cours et ne s'enclenche pas en plein saut. Le `case Attack` du switch sort vers la locomotion quand `stateElapsed ≥ attackClip->duration` (ou clip absent → sortie immédiate).
+- **Anim** : `addRole("Attack", "Sword_Attack")` (branche UE5 ; clip dont l'existence est vérifiée par `SkinnedMeshLoaderTests`). `StateToClipName(Attack) = "Attack"`.
+- **Déplacement** : non modifié pendant l'attaque (geste plein corps, pas de root motion) — le `CharacterController` continue de piloter la position selon l'input.
+
+### Priorité d'intention (au sol), mise à jour
+`Roll (double-tap Ctrl) > Attack (clic gauche) > Dance (/dance, à l'arrêt) > Crouch (Ctrl tenu) > Sprint (Alt) > Run (Shift) > Walk`.
+
+### Limites connues
+- **Cosmétique uniquement** : aucun dégât, aucune cible, aucun envoi serveur. Le HUD combat existant (`src/client/combat/`) reste piloté par les events serveur, indépendant de ce geste.
+- **Pas d'arme visible** : le clip `Sword_Attack` est joué sans système d'équipement (l'avatar « frappe » à mains nues visuellement). À relier au futur système d'équipement.
+- **Pas de combo** : un clic pendant l'attaque est ignoré (le clip doit finir). Combo `Sword_Attack` → enchaînement à ajouter plus tard.
+- **Clic sur UI ouverte** : un clic gauche sur une fenêtre de jeu (inventaire/boutique) peut aussi déclencher le geste (curseur libre en vue 3ᵉ personne) ; seuls le focus chat et le drag inventaire sont exclus pour l'instant.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -230,6 +230,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::CrouchWalk:   return "CrouchWalk";
 				case engine::Engine::AvatarLocomotionState::Roll:         return "Roll";
 				case engine::Engine::AvatarLocomotionState::Dance:        return "Dance";
+				case engine::Engine::AvatarLocomotionState::Attack:       return "Attack";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -4054,6 +4055,7 @@ namespace engine
 															addRole("CrouchWalk", "Crouch_Fwd_Loop");
 															addRole("Roll", "Roll");
 															addRole("Dance", "Dance_Loop");
+															addRole("Attack", "Sword_Attack");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7053,6 +7055,15 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("Land");
 					const engine::render::skinned::AnimationClip* rollClip =
 						m_currentSkinnedMesh->FindClip("Roll");
+					const engine::render::skinned::AnimationClip* attackClip =
+						m_currentSkinnedMesh->FindClip("Attack");
+
+					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
+					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
+					// le drag inventaire pour ne pas frapper en relachant un objet.
+					const bool attackPressed =
+						m_input.WasMousePressed(engine::platform::MouseButton::Left)
+						&& !m_invUi.IsDragging();
 
 					// Esquive/roulade : Ctrl double-tap (fenetre 0.30s). Ctrl maintenu
 					// = crouch ; deux appuis rapides = Roll (one-shot).
@@ -7164,13 +7175,27 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							case AvatarLocomotionState::Attack:
+								// One-shot : retour locomotion quand le clip d'attaque est fini.
+								// Le deplacement reste pilote par le CharacterController pendant
+								// l'attaque (geste plein corps, pas de root motion).
+								if (!attackClip || stateElapsed >= attackClip->duration)
+								{
+									if (!moving)                  newState = AvatarLocomotionState::Idle;
+									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
+									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
+									else                          newState = AvatarLocomotionState::Walk;
+								}
+								break;
 						}
 
 						// Crouch (Ctrl) : etat accroupi prioritaire tant que la touche est tenue
-						// (sauf amorce de saut, ou Roll/Dance en cours). CrouchWalk si deplacement.
+						// (sauf amorce de saut, ou Roll/Dance/Attack en cours). CrouchWalk si deplacement.
 						if (moveInput.crouch && newState != AvatarLocomotionState::Jump
 							&& newState != AvatarLocomotionState::Roll
-							&& newState != AvatarLocomotionState::Dance)
+							&& newState != AvatarLocomotionState::Dance
+							&& newState != AvatarLocomotionState::Attack)
 							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 
 						// Esquive/roulade (Ctrl double-tap) : Roll one-shot, prioritaire sur crouch.
@@ -7181,6 +7206,14 @@ namespace engine
 						if (danceRequested && !moving && !movingBack && !moveInput.jumpPressed
 							&& m_avatarLocoState != AvatarLocomotionState::Roll)
 							newState = AvatarLocomotionState::Dance;
+
+						// Attaque melee (clic gauche) : Sword_Attack one-shot. Ne s'enclenche
+						// pas pendant un saut/roll et ne coupe pas un Roll en cours. Prioritaire
+						// sur crouch (on peut frapper accroupi -> repasse debout l'attaque finie).
+						if (attackPressed && !moveInput.jumpPressed
+							&& m_avatarLocoState != AvatarLocomotionState::Roll
+							&& m_avatarLocoState != AvatarLocomotionState::Attack)
+							newState = AvatarLocomotionState::Attack;
 					}
 					else
 					{

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -583,6 +583,7 @@ namespace engine
 			CrouchWalk,
 			Roll,
 			Dance,
+			Attack,
 			Jump,
 			Fall,
 			Land


### PR DESCRIPTION
## Résumé

Premier déclencheur de l'étape **combat** de §27 (après l'étape 2 locomotion). Câble un clip d'attaque mêlée **piloté par l'input**, **purement client/cosmétique** (pas de dégâts ni d'aller-retour serveur).

- **Attaque = clic gauche** (`WasMousePressed(Left)`, edge-triggered) → état `AvatarLocomotionState::Attack` **one-shot** (clip `Sword_Attack`).
- Gardes : le bloc gameplay est déjà protégé contre le focus chat / l'auth (Engine.cpp ~6969) ; on exclut en plus le **drag inventaire** (`!m_invUi.IsDragging()`).
- **Priorité** : `Roll (double-tap Ctrl) > Attack (clic gauche) > Dance > Crouch > Sprint > Run > Walk`. L'attaque ne coupe pas un Roll en cours et ne s'enclenche pas en plein saut ; elle est prioritaire sur le crouch (frapper accroupi → retour debout l'attaque finie).
- `addRole("Attack", "Sword_Attack")` — clip dont l'existence est **vérifiée par `SkinnedMeshLoaderTests`**.
- Déplacement non modifié pendant l'attaque (geste plein corps, pas de root motion).
- Doc : **CODEBASE_MAP §31**.

## Note de stacking
Empilée sur **#663 (roll + emote)**, pas encore mergé. Le diff inclut donc temporairement les commits roll/emote. Après merge de #663, rebase (`git rebase --onto main`) pour nettoyer le diff.

## Décision en attente (touche « action » E)
Tu as demandé que la touche **« action/interagir » soit E** (en déplaçant ce qui est dessus). Aujourd'hui E fait deux choses : toggle du panneau **GameEvents** en jeu (Engine.cpp ~5965) et incrément du prix mini dans l'UI **hôtel des ventes** (~8728). Il n'existe pas encore de système « interagir » auquel relier E. Cette PR ne touche pas à E — à cadrer séparément (que doit faire « interagir » ? où déplacer GameEvents ?).

## Test plan
- [ ] Build Windows/Linux (CI) sans erreur.
- [ ] En jeu : clic gauche → animation d'attaque jouée une fois, puis retour locomotion.
- [ ] Clic gauche en marchant/courant → attaque jouée, déplacement conservé.
- [ ] Taper dans le chat / drag inventaire → pas d'attaque parasite.

## Limites connues
- Cosmétique uniquement (pas de dégâts/cible/serveur).
- Pas d'arme visible (clip joué sans système d'équipement).
- Pas de combo (clic ignoré pendant l'attaque).
- Un clic gauche sur une fenêtre de jeu ouverte peut aussi déclencher le geste (curseur libre en 3ᵉ personne).

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (anim + input local ; aucun opcode, handler ni migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_