### PR TITLE
feat(ui): menu de panneaux (barre ImGui) + libération de la touche E

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1600,3 +1600,17 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - **Pas d'arme visible** : le clip `Sword_Attack` est joué sans système d'équipement (l'avatar « frappe » à mains nues visuellement). À relier au futur système d'équipement.
 - **Pas de combo** : un clic pendant l'attaque est ignoré (le clip doit finir). Combo `Sword_Attack` → enchaînement à ajouter plus tard.
 - **Clic sur UI ouverte** : un clic gauche sur une fenêtre de jeu (inventaire/boutique) peut aussi déclencher le geste (curseur libre en vue 3ᵉ personne) ; seuls le focus chat et le drag inventaire sont exclus pour l'instant.
+## 32. Menu de panneaux (barre de menus ImGui) + libération de la touche E (2026-05-22)
+
+**Objectif** : offrir un accès **souris** à tous les panneaux togglables (sans raccourci clavier dédié) et **libérer la touche E** pour une future action « interagir » (hors combat). Premier menu ImGui du **client de jeu** (jusqu'ici, seul l'éditeur monde en avait).
+
+### Chaîne
+- **Barre de menus** : `ImGui::BeginMainMenuBar()` → menu `« Panneaux »` rendu dans la branche ImGui in-game de `Engine::Update` (`src/client/app/Engine.cpp`, juste après `m_chatImGui->Render(...)`, sous `#if defined(_WIN32)`). Toujours visible en jeu (tant que `render.chat_imgui.enabled` ou un menu pause/options est actif).
+- **Items** : un `MenuItem` par panneau (Carnet de sorts, Arènes, Champs de bataille, PvP extérieur, Météo, Événements, Guilde, Hôtel des ventes, Jets de butin). Chaque item reflète l'état `m_*Visible` (coche) et, à l'ouverture, reproduit le `RequestList()`/`RequestTeams()` du toggle clavier correspondant.
+- **Libellés ASCII** : la police ImGui par défaut (ProggyClean) n'a pas les glyphes accentués → libellés sans accents pour un rendu correct quelle que soit la police.
+- **Touche E libérée** : le bloc `if (... Key::E) { m_gameEventVisible = ... }` (toggle GameEvents au clavier) est **supprimé**. GameEvents s'ouvre désormais **uniquement via le menu**. Les autres panneaux **gardent leur touche** (B/A/G/P/Y/U/H/L) **en plus** de l'accès menu.
+
+### Limites connues
+- **Barre toujours visible** : occupe un bandeau haut en jeu (choix assumé pour l'accès sans touche) ; à terme on pourra la masquer/replier.
+- **E non rebranchée** : E ne fait plus rien tant que le système « interagir » (PNJ/objet/loot) n'existe pas — réservée volontairement, pas de bind mort.
+- **Rendu non vérifié visuellement** : code ImGui Windows-only, non testable en headless ; validation au build Windows.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1528,8 +1528,9 @@ namespace engine
 			}
 			// CMANGOS.31 (Phase 5.31 step 3+4) — Slash command /events pour
 			// ouvrir/fermer le panneau GameEvents et synchroniser la liste
-			// depuis le master au moment de l'ouverture. La touche E fait
-			// la meme chose (cf. boucle input dans BeginFrame).
+			// depuis le master au moment de l'ouverture. Le menu "Panneaux"
+			// (barre de menus ImGui in-game) fait la meme chose (la touche E,
+			// qui servait a cela, a ete liberee).
 			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
 				&& (text == "/events" || text.starts_with("/events ") || text.starts_with("/events\t")))
 			{
@@ -5961,20 +5962,9 @@ namespace engine
 				}
 				LOG_INFO(Core, "[Engine] Y toggle weather (visible={})", m_weatherVisible);
 			}
-			// CMANGOS.31 (Phase 5.31 step 3+4) — Touche E : toggle panneau
-			// GameEvents + RequestList si on l'ouvre. Memes guards que Y.
-			// Pas de conflit Ctrl+E (non utilise par WorldEditorShell).
-			if (inGameNoMenu && !chatBlocks
-				&& !m_input.IsDown(engine::platform::Key::Control)
-				&& m_input.WasPressed(engine::platform::Key::E))
-			{
-				m_gameEventVisible = !m_gameEventVisible;
-				if (m_gameEventVisible)
-				{
-					m_gameEventUi.RequestList();
-				}
-				LOG_INFO(Core, "[Engine] E toggle gameevents (visible={})", m_gameEventVisible);
-			}
+			// Touche E desormais LIBRE (reservee a une future action "interagir"
+			// hors combat). Le panneau GameEvents s'ouvre via la barre de menus
+			// "Panneaux" (rendu ImGui in-game), plus par une touche dediee.
 			// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — Touche U : toggle
 			// panneau Guildes + RequestList si on l'ouvre. Memes guards que
 			// E (chat focus, pause, editor). Pas de conflit Ctrl+U.
@@ -7680,6 +7670,64 @@ namespace engine
 			}
 			// `inWorldShard` = true uniquement post-EnterWorld : ajoute le canal Zone.
 			m_chatImGui->Render(dw, dh, m_authUi.IsInWorldShard());
+			// Menu de panneaux : barre de menus ImGui toujours visible en jeu,
+			// acces souris a tous les panneaux togglables sans raccourci clavier
+			// dedie. Les panneaux gardent par ailleurs leurs touches existantes ;
+			// GameEvents n'est plus accessible que par ce menu (touche E liberee).
+			// Chaque MenuItem reflete l'etat *Visible et reproduit le RequestList
+			// d'ouverture du toggle clavier correspondant.
+			if (ImGui::BeginMainMenuBar())
+			{
+				if (ImGui::BeginMenu("Panneaux"))
+				{
+					if (ImGui::MenuItem("Carnet de sorts", nullptr, m_skillBookVisible))
+					{
+						m_skillBookVisible = !m_skillBookVisible;
+						if (m_skillBookVisible) m_skillBookUi.RequestList();
+					}
+					if (ImGui::MenuItem("Arenes", nullptr, m_arenaVisible))
+					{
+						m_arenaVisible = !m_arenaVisible;
+						if (m_arenaVisible) m_arenaUi.RequestTeams();
+					}
+					if (ImGui::MenuItem("Champs de bataille", nullptr, m_battleGroundVisible))
+					{
+						m_battleGroundVisible = !m_battleGroundVisible;
+						if (m_battleGroundVisible) m_battleGroundUi.RequestList();
+					}
+					if (ImGui::MenuItem("PvP exterieur", nullptr, m_outdoorPvpVisible))
+					{
+						m_outdoorPvpVisible = !m_outdoorPvpVisible;
+						if (m_outdoorPvpVisible) m_outdoorPvpUi.RequestList();
+					}
+					if (ImGui::MenuItem("Meteo", nullptr, m_weatherVisible))
+					{
+						m_weatherVisible = !m_weatherVisible;
+						if (m_weatherVisible) m_weatherUi.RequestList();
+					}
+					if (ImGui::MenuItem("Evenements", nullptr, m_gameEventVisible))
+					{
+						m_gameEventVisible = !m_gameEventVisible;
+						if (m_gameEventVisible) m_gameEventUi.RequestList();
+					}
+					if (ImGui::MenuItem("Guilde", nullptr, m_guildVisible))
+					{
+						m_guildVisible = !m_guildVisible;
+						if (m_guildVisible) m_guildUi.RequestList();
+					}
+					if (ImGui::MenuItem("Hotel des ventes", nullptr, m_auctionHouseVisible))
+					{
+						m_auctionHouseVisible = !m_auctionHouseVisible;
+						if (m_auctionHouseVisible) m_auctionHouseUi.RequestList(0u);
+					}
+					if (ImGui::MenuItem("Jets de butin", nullptr, m_lootRollVisible))
+					{
+						m_lootRollVisible = !m_lootRollVisible;
+					}
+					ImGui::EndMenu();
+				}
+				ImGui::EndMainMenuBar();
+			}
 			// CMANGOS.18 (Phase 3.18 step 4) — Render du panneau Mail si visible.
 			// Le panneau partage la frame ImGui en cours (NewFrame deja appele
 			// par chatImguiOverlayNewFrame plus haut). Visible uniquement quand


### PR DESCRIPTION
## Résumé

Premier menu ImGui du **client de jeu** + **libération de la touche E**, suite à ta demande (E = future action « interagir », GameEvents sans touche dédiée).

- **Barre de menus ImGui « Panneaux »** (toujours visible en jeu) → accès **souris** à tous les panneaux togglables : Carnet de sorts, Arènes, Champs de bataille, PvP extérieur, Météo, Événements, Guilde, Hôtel des ventes, Jets de butin. Chaque item reflète l'état `m_*Visible` (coche) et reproduit le `RequestList()`/`RequestTeams()` d'ouverture.
- **Touche E libérée** : suppression du raccourci clavier GameEvents. GameEvents reste accessible via le **menu** (et la slash command `/events`). E ne fait plus rien — **réservée** pour une future action « interagir » (PNJ/objet/loot), **pas de bind mort**.
- Les **autres panneaux gardent leur touche** (B/A/G/P/Y/U/H/L) **en plus** du menu.
- Libellés **ASCII** (la police ImGui par défaut, ProggyClean, n'a pas les glyphes accentués).
- Doc : **CODEBASE_MAP §32**.

## Indépendance / numérotation
Branche partie de `main` (à jour, crouch #662 inclus). **Indépendante** de #663 (roll/emote) et #664 (attaque). La section doc prend **§32** (et non §30/§31, déjà pris par #663/#664 non mergés) pour éviter les collisions. Un conflit `CODEBASE_MAP.md` à la fin de fichier est possible au merge croisé → résolution = **garder toutes les sections** (comme les autres PR en vol).

## Test plan
- [ ] Build Windows (CI) sans erreur.
- [ ] En jeu : barre « Panneaux » visible en haut ; chaque entrée ouvre/ferme le bon panneau, coche à jour.
- [ ] E n'ouvre plus GameEvents ; `/events` et le menu l'ouvrent toujours.
- [ ] Les autres touches (B/A/G/P/Y/U/H/L) fonctionnent toujours.

## Limites connues
- **Barre toujours visible** : bandeau haut permanent en jeu (choix assumé pour l'accès sans touche) ; masquage/repli possible plus tard.
- **Rendu non vérifié visuellement** : ImGui Windows-only, non testable en headless → validation au build Windows par toi.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (UI + input local ; aucun opcode, handler ni migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_