### PR TITLE
feat(combat): sort (touche R) — clip Spell_Simple_Shoot one-shot

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1614,3 +1614,21 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - **Barre toujours visible** : occupe un bandeau haut en jeu (choix assumé pour l'accès sans touche) ; à terme on pourra la masquer/replier.
 - **E non rebranchée** : E ne fait plus rien tant que le système « interagir » (PNJ/objet/loot) n'existe pas — réservée volontairement, pas de bind mort.
 - **Rendu non vérifié visuellement** : code ImGui Windows-only, non testable en headless ; validation au build Windows.
+
+## 33. Sort — cast (touche R) — clip `Spell_Simple_Shoot` one-shot (2026-05-22)
+
+**Objectif** : 2ᵉ déclencheur de l'étape « combat » de §27 (pendant du clic gauche de l'attaque #31). Câble un clip de **sort** piloté par l'input, **purement client/cosmétique** (pas de cible, de dégâts ni d'aller-retour serveur).
+
+### Chaîne
+- **Input** : **touche `R`** (`m_input.WasPressed(Key::R)`), edge-triggered, lue dans la SM. Le **clic droit n'est PAS utilisé** (déjà pris par le RMB-look de la caméra orbitale, `ThirdPersonCamera`/Engine.cpp). La touche **E reste libre/réservée** (cf. §32, action « interagir » future). Le bloc gameplay est déjà gardé contre le focus chat / l'auth (Engine.cpp ~6961), donc `R` ne se déclenche pas en tapant dans le chat.
+- **État** : `AvatarLocomotionState::Cast` (**one-shot**, non bouclé — absent de `ClipLoops`). Override après le switch : `if (castPressed && !jumpPressed && état ∉ {Roll, Attack, Cast}) newState = Cast` — **prioritaire sur le crouch** (caster accroupi → retour debout le sort fini), mais ne coupe **pas** un Roll/Attack en cours et ne s'enclenche pas en plein saut. Le `case Cast` du switch sort vers la locomotion quand `stateElapsed ≥ castClip->duration` (ou clip absent → sortie immédiate).
+- **Anim** : `addRole("Cast", "Spell_Simple_Shoot")` (branche UE5). `StateToClipName(Cast) = "Cast"`. L'attaque exclut aussi `Cast` en cours (pas de clic gauche pendant un sort, et inversement).
+- **Déplacement** : non modifié pendant le sort (geste plein corps, pas de root motion).
+
+### Priorité d'intention (au sol), mise à jour
+`Roll (double-tap Ctrl) > Attack (clic gauche) > Cast (touche R) > Dance (/dance, à l'arrêt) > Crouch (Ctrl tenu) > Sprint (Alt) > Run (Shift) > Walk`.
+
+### Limites connues
+- **Cosmétique uniquement** : aucun projectile, aucune cible, aucun envoi serveur.
+- **Clip unique (pas de séquence)** : on joue `Spell_Simple_Shoot` seul, sans le wind-up/exit (`Spell_Simple_Enter`/`Idle_Loop`/`Exit`). Le crossfade lisse le retour à la locomotion ; une vraie séquence Enter→(channel)→Shoot→Exit est une amélioration future.
+- **Repli gracieux** : une race sans clip `Spell_Simple_Shoot` (`FindClip` nullptr) sort immédiatement de l'état (anim précédente conservée).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -231,6 +231,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Roll:         return "Roll";
 				case engine::Engine::AvatarLocomotionState::Dance:        return "Dance";
 				case engine::Engine::AvatarLocomotionState::Attack:       return "Attack";
+				case engine::Engine::AvatarLocomotionState::Cast:         return "Cast";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -4057,6 +4058,7 @@ namespace engine
 															addRole("Roll", "Roll");
 															addRole("Dance", "Dance_Loop");
 															addRole("Attack", "Sword_Attack");
+															addRole("Cast", "Spell_Simple_Shoot");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7047,6 +7049,8 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("Roll");
 					const engine::render::skinned::AnimationClip* attackClip =
 						m_currentSkinnedMesh->FindClip("Attack");
+					const engine::render::skinned::AnimationClip* castClip =
+						m_currentSkinnedMesh->FindClip("Cast");
 
 					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
 					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
@@ -7054,6 +7058,12 @@ namespace engine
 					const bool attackPressed =
 						m_input.WasMousePressed(engine::platform::MouseButton::Left)
 						&& !m_invUi.IsDragging();
+
+					// Sort : touche R (edge). Meme bloc gameplay garde contre le focus
+					// chat / l'auth (cf. ligne ~6961). Geste cosmetique one-shot (pas de
+					// cible ni d'aller-retour serveur), pendant clavier de l'attaque souris.
+					const bool castPressed =
+						m_input.WasPressed(engine::platform::Key::R);
 
 					// Esquive/roulade : Ctrl double-tap (fenetre 0.30s). Ctrl maintenu
 					// = crouch ; deux appuis rapides = Roll (one-shot).
@@ -7178,6 +7188,18 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							case AvatarLocomotionState::Cast:
+								// One-shot : retour locomotion quand le clip de sort est fini.
+								// Deplacement pilote par le CharacterController pendant le cast.
+								if (!castClip || stateElapsed >= castClip->duration)
+								{
+									if (!moving)                  newState = AvatarLocomotionState::Idle;
+									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
+									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
+									else                          newState = AvatarLocomotionState::Walk;
+								}
+								break;
 						}
 
 						// Crouch (Ctrl) : etat accroupi prioritaire tant que la touche est tenue
@@ -7185,7 +7207,8 @@ namespace engine
 						if (moveInput.crouch && newState != AvatarLocomotionState::Jump
 							&& newState != AvatarLocomotionState::Roll
 							&& newState != AvatarLocomotionState::Dance
-							&& newState != AvatarLocomotionState::Attack)
+							&& newState != AvatarLocomotionState::Attack
+							&& newState != AvatarLocomotionState::Cast)
 							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 
 						// Esquive/roulade (Ctrl double-tap) : Roll one-shot, prioritaire sur crouch.
@@ -7202,8 +7225,19 @@ namespace engine
 						// sur crouch (on peut frapper accroupi -> repasse debout l'attaque finie).
 						if (attackPressed && !moveInput.jumpPressed
 							&& m_avatarLocoState != AvatarLocomotionState::Roll
+							&& m_avatarLocoState != AvatarLocomotionState::Cast
 							&& m_avatarLocoState != AvatarLocomotionState::Attack)
 							newState = AvatarLocomotionState::Attack;
+
+						// Sort (touche R) : Spell_Simple_Shoot one-shot. Memes regles que
+						// l'attaque (pas pendant un saut/roll, ne coupe pas un Roll/Attack/
+						// Cast en cours). Prioritaire sur le crouch (caster accroupi ->
+						// repasse debout le sort fini).
+						if (castPressed && !moveInput.jumpPressed
+							&& m_avatarLocoState != AvatarLocomotionState::Roll
+							&& m_avatarLocoState != AvatarLocomotionState::Attack
+							&& m_avatarLocoState != AvatarLocomotionState::Cast)
+							newState = AvatarLocomotionState::Cast;
 					}
 					else
 					{

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -584,6 +584,7 @@ namespace engine
 			Roll,
 			Dance,
 			Attack,
+			Cast,
 			Jump,
 			Fall,
 			Land


### PR DESCRIPTION
## Résumé

**2ᵉ déclencheur de l'étape combat** du §27 (pendant clavier du clic gauche de l'attaque #664). Câble un clip de **sort** piloté par l'input, **purement client/cosmétique** (pas de cible, dégâts ni aller-retour serveur). Fait en autonomie, un seul PR, dans le même pattern one-shot que Roll/Attack.

- **Sort = touche `R`** (`WasPressed(Key::R)`, edge-triggered) → état `AvatarLocomotionState::Cast` **one-shot** (clip `Spell_Simple_Shoot`).
- **Choix de la touche** : le **clic droit est exclu** (déjà pris par le RMB-look de la caméra orbitale → l'utiliser ferait caster à chaque rotation caméra). **E reste réservée** (§32, future action « interagir »). `R` était libre et conventionnelle pour « sort/capacité ».
- **Gardes** : le bloc gameplay est déjà protégé contre le focus chat / l'auth (Engine.cpp ~6961) → `R` ne se déclenche pas en tapant dans le chat.
- **Priorité** : `Roll (double-tap Ctrl) > Attack (clic gauche) > Cast (R) > Dance > Crouch > Sprint > Run > Walk`. Le sort ne coupe pas un Roll/Attack en cours, ne s'enclenche pas en plein saut, prioritaire sur le crouch (caster accroupi → retour debout le sort fini). L'attaque exclut aussi `Cast` en cours (pas de clic gauche pendant un sort).
- Déplacement non modifié pendant le sort (geste plein corps, pas de root motion).
- Doc : **CODEBASE_MAP §33**.

## Test plan
- [ ] Build Windows/Linux (CI) sans erreur.
- [ ] En jeu : **R** → animation de sort jouée une fois, puis retour locomotion.
- [ ] **R** en marchant/courant → sort joué, déplacement conservé.
- [ ] Taper dans le chat → **R** ne lance pas de sort.
- [ ] Clic droit (caméra) → toujours rotation caméra, **aucun** sort déclenché.
- [ ] Priorités : pendant un Roll/Attack, **R** ne coupe pas ; en plein saut, pas de sort.

## Limites connues
- **Cosmétique uniquement** : aucun projectile, cible, ou envoi serveur.
- **Clip unique** : `Spell_Simple_Shoot` joué seul, sans wind-up/exit (`Spell_Simple_Enter`/`Idle_Loop`/`Exit`). Le crossfade lisse le retour ; une vraie séquence Enter→Shoot→Exit est une amélioration future.
- **Rendu non vérifié visuellement** (anim Windows-only, non testable en headless) → validation au build par toi. Si `Spell_Simple_Shoot` paraît abrupt seul, je peux passer à la séquence complète.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (anim + input local ; aucun opcode, handler ni migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_