### PR TITLE
feat(controls): touches remappables (Options) + action « interagir » (E)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1630,7 +1630,7 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 
 ### Limites connues
 - **Cosmétique uniquement** : aucun projectile, aucune cible, aucun envoi serveur.
-- **Clip unique (pas de séquence)** : on joue `Spell_Simple_Shoot` seul, sans le wind-up/exit (`Spell_Simple_Enter`/`Idle_Loop`/`Exit`). Le crossfade lisse le retour à la locomotion ; une vraie séquence Enter→(channel)→Shoot→Exit est une amélioration future.
+- **Séquence Enter→Shoot→Exit** (depuis §37+) : l'état `Cast` joue désormais `Spell_Simple_Enter` à l'entrée, puis **rejoue** `Spell_Simple_Shoot` puis `Spell_Simple_Exit` aux frontières de phase (`m_castPhase`), via un **replay de clip en cours d'état** (`m_avatarPendingClipRole`, consommé une fois par frame dans la SM — rejoue un one-shot sans transition). `addRole` : `Cast`=Enter, `CastShoot`=Shoot, `CastExit`=Exit. **Garde-fou** : sortie forcée si `stateElapsed ≥ 3 s` → jamais bloqué. Mécanisme réutilisable pour d'autres séquences (emotes Enter/Exit, combos).
 - **Repli gracieux** : une race sans clip `Spell_Simple_Shoot` (`FindClip` nullptr) sort immédiatement de l'état (anim précédente conservée).
 
 ## 34. Touches d'action remappables depuis le menu Options (2026-05-22)

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1672,3 +1672,21 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 ### Limites connues
 - **Geste cosmétique seulement** : aucune cible, aucun objet ramassé, aucun PNJ adressé — c'est l'animation de base. Le vrai système « interagir » (raycast vers une entité interactible, prompt, loot) reste à construire (nécessitera des entités interactibles, voire des events serveur).
 - **Repli gracieux** : race sans clip `Interact` → sortie immédiate de l'état.
+
+## 36. Emotes génériques par slash command (généralisation de `/dance`) (2026-05-22)
+
+**Objectif** : transformer le `/dance` mono-usage (§30) en **système d'emotes data-driven** — ajouter une emote = **une ligne** + un `addRole`. Livré dans la même PR que §34/§35 (« minimum de PR »).
+
+### Mécanique
+- **État unique `Emote`** (renommé depuis `Dance`) : anim **en boucle**, interrompue par tout déplacement/saut (le `case Emote` sort vers Walk/Run/Jump/…). `ClipLoops(Emote) = true`.
+- **Clip dynamique** : le rôle d'anim joué n'est pas fixe. `m_pendingEmoteRole` (posé par la slash command) → consommé par la SM → `m_currentEmoteRole`. Au point de lecture du clip (`Engine.cpp`, transition d'état), si `newState == Emote` on joue `m_currentEmoteRole` au lieu de `StateToClipName`.
+- **Table des emotes** (`kEmotes` dans le handler chat) : `{ commande, rôle, message }`. Actuellement : `/dance`→Dance, `/sit` & `/assis`→Sit, `/talk`→Talk, `/torch`→Torch. Rôles mappés via `addRole("Dance","Dance_Loop")`, `addRole("Sit","Sitting_Idle_Loop")`, `addRole("Talk","Idle_Talking_Loop")`, `addRole("Torch","Idle_Torch_Loop")`.
+- **Priorité** : `Roll > Attack > Cast > Interact > Emote > Crouch > Sprint > Run > Walk` (emote uniquement à l'arrêt, hors Roll).
+
+### Ajouter une emote
+1. Une entrée `{ "/macommande", "MonRole", "Mon message." }` dans `kEmotes`.
+2. Un `addRole("MonRole", "Clip_Loop")` (clip présent dans la library UE5).
+
+### Limites connues
+- **Pas de changement d'emote « à chaud »** : enchaîner deux emotes sans bouger ne relance pas le clip (le state reste `Emote`, pas de transition). Bouger puis ré-emoter. (Acceptable ; à raffiner si besoin via un re-trigger sur changement de rôle.)
+- **Emotes en boucle simple** : pas de séquence Enter/Exit (ex. `Sitting_Enter`/`Exit` non utilisés) — on joue directement le `*_Idle_Loop`, le crossfade lisse l'entrée/sortie.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1652,7 +1652,7 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - Roulade et Attaque affichées en **info** (non remappables : la roulade suit la touche Accroupi, l'attaque est le clic gauche — souris).
 
 ### Limites connues
-- **Persistance session-only** : le rebind écrit dans `m_cfg` (live), comme les autres réglages du panneau Options in-game ; non re-sérialisé dans `user_settings.json` (même limite que volume/sensibilité de ce panneau). Pour un défaut persistant, éditer `config.json`.
+- **Persistance** : le rebind est **persisté** dans un fichier dédié `keybinds.json` (écrit par le panneau Options via `FileSystem::WriteAllText`, format contrôlé). Au boot, `ApplyUserSettingsOverrides` fait `cfg.LoadFromFile("keybinds.json")` qui **merge** par-dessus les défauts de `config.json`. Choix d'un **fichier dédié** (et non un patch de `user_settings.json`) pour que tout échec d'écriture/lecture soit **bénin** (retour aux défauts) et ne corrompe jamais les autres réglages. Les sliders volume/sensibilité de ce panneau restent eux session-only (hors périmètre).
 - **Pas de détection de conflit** : binder deux actions sur la même touche est permis (ex. réutiliser une touche de panneau B/G/…). À durcir si besoin.
 - **Souris/modificateurs** : l'attaque (clic gauche) n'est pas remappable en v1 ; rebinder un modificateur (Alt/Ctrl) vers une lettre fonctionne mais peut entrer en conflit avec d'autres usages (Ctrl = modificateur de raccourcis).
 

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1680,7 +1680,7 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 ### Mécanique
 - **État unique `Emote`** (renommé depuis `Dance`) : anim **en boucle**, interrompue par tout déplacement/saut (le `case Emote` sort vers Walk/Run/Jump/…). `ClipLoops(Emote) = true`.
 - **Clip dynamique** : le rôle d'anim joué n'est pas fixe. `m_pendingEmoteRole` (posé par la slash command) → consommé par la SM → `m_currentEmoteRole`. Au point de lecture du clip (`Engine.cpp`, transition d'état), si `newState == Emote` on joue `m_currentEmoteRole` au lieu de `StateToClipName`.
-- **Table des emotes** (`kEmotes` dans le handler chat) : `{ commande, rôle, message }`. Actuellement : `/dance`→Dance, `/sit` & `/assis`→Sit, `/talk`→Talk, `/torch`→Torch. Rôles mappés via `addRole("Dance","Dance_Loop")`, `addRole("Sit","Sitting_Idle_Loop")`, `addRole("Talk","Idle_Talking_Loop")`, `addRole("Torch","Idle_Torch_Loop")`.
+- **Table des emotes** (`kEmotes` dans le handler chat) : `{ commande, rôle, message }`. Actuellement : `/dance`, `/sit` & `/assis`, `/talk`, `/torch`, `/kneel` (Fixing_Kneeling), `/sittalk` (Sitting_Talking_Loop), `/push` (Push_Loop). Rôles mappés via `addRole("Dance","Dance_Loop")`, `addRole("Sit","Sitting_Idle_Loop")`, `addRole("Talk","Idle_Talking_Loop")`, `addRole("Torch","Idle_Torch_Loop")`.
 - **Priorité** : `Roll > Attack > Cast > Interact > Emote > Crouch > Sprint > Run > Walk` (emote uniquement à l'arrêt, hors Roll).
 
 ### Ajouter une emote

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1577,7 +1577,7 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 `Roll (double-tap) > Dance (/dance, à l'arrêt) > Crouch (Ctrl tenu) > Sprint (Alt) > Run (Shift) > Walk`.
 
 ### Limites connues
-- **Roll sans déplacement réel** : l'anim joue mais le `CharacterController` n'applique pas d'impulsion/i-frames d'esquive (purement cosmétique pour l'instant).
+- **Roll = vraie esquive (impulsion)** : au passage en Roll, l'Engine appelle `CharacterController::ApplyDodgeImpulse(dir)` (dir = mouvement, sinon avant-caméra). Pendant `dodgeDurationSec` (~0.45 s) la vitesse horizontale est forcée à `dodgeSpeed` (~11 m/s) ; collision (sweep) et gravité restent appliquées (roulade dans un mur / au bord OK). **I-frames d'invincibilité** non incluses : elles n'ont de sens qu'avec le système de dégâts (combat réel, côté serveur) — à ajouter là. À régler en jeu : `dodgeSpeed`/`dodgeDurationSec`.
 - **Double-tap Ctrl** : la fenêtre 0.30 s peut occasionnellement déclencher un Roll lors d'un crouch « nerveux » (deux appuis rapprochés). Ajustable via le seuil.
 
 §27 étape 2 **terminée**.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1655,3 +1655,20 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - **Persistance session-only** : le rebind écrit dans `m_cfg` (live), comme les autres réglages du panneau Options in-game ; non re-sérialisé dans `user_settings.json` (même limite que volume/sensibilité de ce panneau). Pour un défaut persistant, éditer `config.json`.
 - **Pas de détection de conflit** : binder deux actions sur la même touche est permis (ex. réutiliser une touche de panneau B/G/…). À durcir si besoin.
 - **Souris/modificateurs** : l'attaque (clic gauche) n'est pas remappable en v1 ; rebinder un modificateur (Alt/Ctrl) vers une lettre fonctionne mais peut entrer en conflit avec d'autres usages (Ctrl = modificateur de raccourcis).
+
+## 35. Action « interagir » (touche E) — geste `Interact` one-shot (2026-05-22)
+
+**Objectif** : donner enfin un usage à la **touche E** réservée au §32 (libérée du toggle GameEvents). Premier maillon d'un futur système d'interaction (PNJ/objet/loot) : pour l'instant un **geste cosmétique** one-shot, comme l'attaque/le sort. Livré **dans la même PR que les keybinds (§34)** (consigne « minimum de PR »).
+
+### Chaîne
+- **Input** : touche **remappable** `controls.keybind.interact` (défaut `E`), résolue chaque frame (`KeyFromName`). `interactPressed = WasPressed(interactKey)`, dans le bloc gameplay gardé (chat/auth/Options).
+- **État** : `AvatarLocomotionState::Interact` (**one-shot**, absent de `ClipLoops`). Override : `if (interactPressed && !jump && état ∉ {Roll, Attack, Cast, Interact}) newState = Interact` — prioritaire sur le crouch, ne coupe pas Roll/Attack/Cast. Le `case Interact` sort vers la locomotion quand `stateElapsed ≥ interactClip->duration`.
+- **Anim** : `addRole("Interact", "Interact")`. `StateToClipName(Interact) = "Interact"`.
+- **Remap** : 4ᵉ ligne « Interagir » dans la section Controles du panneau Options (capture clavier, comme sprint/crouch/sort).
+
+### Priorité d'intention (au sol), mise à jour
+`Roll > Attack > Cast > Interact > Dance > Crouch > Sprint > Run > Walk` (les actions one-shot s'excluent mutuellement tant que l'une joue).
+
+### Limites connues
+- **Geste cosmétique seulement** : aucune cible, aucun objet ramassé, aucun PNJ adressé — c'est l'animation de base. Le vrai système « interagir » (raycast vers une entité interactible, prompt, loot) reste à construire (nécessitera des entités interactibles, voire des events serveur).
+- **Repli gracieux** : race sans clip `Interact` → sortie immédiate de l'état.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1706,3 +1706,28 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 ### Limites connues
 - **Cosmétique** : aucun dégât/cible (comme l'attaque épée).
 - **Alternance Jab/Cross** : chaque coup alterne `Punch_Jab` et `Punch_Cross` (variété ; clip dynamique via `m_currentPunchRole`, comme l'état Emote). Pas de vrai « combo » chaîné sur presses rapides — un coup pendant l'autre est ignoré (one-shot) ; échec bénin (au pire le mauvais clip de poing, jamais d'état bloqué).
+
+## 38. Nage automatique (immersion > bassin) — v1 (2026-05-22)
+
+**Objectif** : passage en nage **sans touche**, déclenché par le niveau d'eau sur le corps (au-dessus du bassin). La physique de nage (`CharacterController` mode `Water`) et le rendu d'eau existaient déjà ; on branche la **détection d'eau** + l'**anim**.
+
+### Chaîne
+- **QueryWater** (`TerrainCollider`) : `BindWater(WaterScene*)` + override `QueryWater(center)` — point-in-polygon (ray-casting XZ) sur les lacs ; retient la surface la plus haute couvrant (x,z). `inWater = (surfaceY > centerY)` → le **centre de la capsule ≈ bassin**, donc nage quand l'eau dépasse le bassin (réglable). Le `CharacterController` bascule alors **automatiquement** en mode `Water` (déjà implémenté).
+- **Anim** : nouveaux états `SwimIdle`/`SwimForward` (bouclés), `addRole("SwimIdle","Swim_Idle_Loop")`/`("SwimForward","Swim_Fwd_Loop")`. Dans la SM, un override **après** locomotion/air : `if (m_characterController.IsInWater()) newState = (moving)?SwimForward:SwimIdle;` (surclasse tout). **Sortie d'eau** gérée explicitement (sinon l'avatar resterait figé en nage au sol).
+- **Eau de TEST** (`world.test_water.*`, défaut activé) : la zone demo est plate et sans eau → on pose un **bassin procédural** (lac carré au-dessus du sol) pour pouvoir tester. À remplacer par une vraie étendue d'eau (pipeline `water.bin` / level-design).
+
+### Limites connues
+- **Eau-test artificielle** : « pool » posé sur la plaine (pas de bassin creusé) ; visuellement faux mais fonctionnel. Winding du quad à vérifier (surface peut être cullée — la nage marche quand même).
+- **Lacs seulement** (rivières ignorées en v1). Pas de contrôle vertical mappé (swimUp/Down existent, non bindés).
+
+## 39. Interaction (touche E) — objets + dialogue PNJ — v1 (2026-05-22)
+
+**Objectif** : donner un vrai usage à E (au-delà du geste §35) : **interagir avec des objets** et **parler aux PNJ**. v1 = framework + cibles de TEST.
+
+### Chaîne
+- **Entités** : `Engine::InteractableEntity { position, radius, isNpc, label, message }` + `m_interactables`. Deux cibles de TEST placées près du spawn (un PNJ « Villageois », un « Coffre »).
+- **Détection** : chaque frame, l'interactible le plus proche (distance XZ) à portée. À l'**entrée de portée** → hint chat (« Près de X — appuyez sur E »). Sur **E** (`interactPressed`) → message chat : dialogue (`[PNJ]`) ou effet (`[Objet]`). Le geste Interact (§35) joue par ailleurs.
+
+### Limites connues
+- **Cibles invisibles** (pas de rendu de props/PNJ) → découvrables seulement via le hint chat. À remplacer par de vraies entités avec **meshes** + **dialogues** (arbre de dialogue, loot, etc.).
+- **Dialogue mono-ligne** (pas d'arbre). Pas de portée/raycast visée (proximité simple).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1632,3 +1632,26 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - **Cosmétique uniquement** : aucun projectile, aucune cible, aucun envoi serveur.
 - **Clip unique (pas de séquence)** : on joue `Spell_Simple_Shoot` seul, sans le wind-up/exit (`Spell_Simple_Enter`/`Idle_Loop`/`Exit`). Le crossfade lisse le retour à la locomotion ; une vraie séquence Enter→(channel)→Shoot→Exit est une amélioration future.
 - **Repli gracieux** : une race sans clip `Spell_Simple_Shoot` (`FindClip` nullptr) sort immédiatement de l'état (anim précédente conservée).
+
+## 34. Touches d'action remappables depuis le menu Options (2026-05-22)
+
+**Objectif** : rendre **modifiables in-game** (panneau Options) les touches des actions ajoutées récemment (Sprint, Accroupi/Roulade, Sort), sans toucher au protocole ni au serveur.
+
+### Config
+- Clés `controls.keybind.{sprint,crouch,cast}` (défauts `Alt`/`Ctrl`/`R`) dans `config.json`. Noms acceptés = ceux de la table `kRebindableKeys` (Engine.cpp) : lettres A-Z **sauf I/J/K/T** (absentes de `platform::Key`), chiffres 0-9, `Ctrl`/`Alt`/`Shift`/`Espace`/`Tab`.
+- `KeyName(Key)` / `KeyFromName(nom, fallback)` (anonymous namespace de `Engine.cpp`) font la conversion enum ↔ nom. Pas de modif de l'API `Input`.
+
+### Lecture gameplay (config-driven)
+- Dans le bloc gameplay (`Engine.cpp`, `if (!authGateActive && !IsChatFocusActive() && !m_inGameOptionsPanelVisible)`), les 3 touches sont **résolues chaque frame** depuis la config (reflète un rebind immédiatement).
+- `BuildMoveInput(..., sprintKey, crouchKey)` : `out.sprint = IsDown(sprintKey)`, `out.crouch = IsDown(crouchKey)` (avant : `Alt`/`Control` en dur). La **roulade** réutilise `crouchKey` (double-appui). Le **sort** lit `WasPressed(castKey)`. Run (Shift) et Jump (Espace) restent fixes (hors périmètre « nouvelles touches »).
+
+### UI Options (rebind par capture)
+- Section « Controles » ajoutée au **panneau Options in-game** (`Engine.cpp`, `#if defined(_WIN32)`). Une ligne par action (Sprint/Accroupi/Sort) : libellé + touche courante + bouton « Modifier ».
+- « Modifier » arme `m_rebindingAction` (1/2/3) ; le rendu suivant capture la **1re touche connue pressée** (`kRebindableKeys`) et écrit `controls.keybind.*` (Échap = annuler).
+- **Gameplay suspendu** tant que le panneau Options est ouvert (ajout de `!m_inGameOptionsPanelVisible` au garde) → la touche capturée ne déclenche pas l'action en même temps.
+- Roulade et Attaque affichées en **info** (non remappables : la roulade suit la touche Accroupi, l'attaque est le clic gauche — souris).
+
+### Limites connues
+- **Persistance session-only** : le rebind écrit dans `m_cfg` (live), comme les autres réglages du panneau Options in-game ; non re-sérialisé dans `user_settings.json` (même limite que volume/sensibilité de ce panneau). Pour un défaut persistant, éditer `config.json`.
+- **Pas de détection de conflit** : binder deux actions sur la même touche est permis (ex. réutiliser une touche de panneau B/G/…). À durcir si besoin.
+- **Souris/modificateurs** : l'attaque (clic gauche) n'est pas remappable en v1 ; rebinder un modificateur (Alt/Ctrl) vers une lettre fonctionne mais peut entrer en conflit avec d'autres usages (Ctrl = modificateur de raccourcis).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1690,3 +1690,19 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 ### Limites connues
 - **Pas de changement d'emote « à chaud »** : enchaîner deux emotes sans bouger ne relance pas le clip (le state reste `Emote`, pas de transition). Bouger puis ré-emoter. (Acceptable ; à raffiner si besoin via un re-trigger sur changement de rôle.)
 - **Emotes en boucle simple** : pas de séquence Enter/Exit (ex. `Sitting_Enter`/`Exit` non utilisés) — on joue directement le `*_Idle_Loop`, le crossfade lisse l'entrée/sortie.
+
+## 37. Coup de poing (touche C) + factorisation des actions one-shot (2026-05-22)
+
+**Objectif** : 2ᵉ attaque mêlée (coup de poing) **et** nettoyage de la logique d'exclusion mutuelle des actions one-shot, devenue verbeuse au fil des ajouts (attaque/sort/interaction).
+
+### Coup de poing
+- **Input** : touche **remappable** `controls.keybind.punch` (défaut `C`), edge. `addRole("Punch", "Punch_Jab")`.
+- **État** : `AvatarLocomotionState::Punch` (one-shot, comme l'attaque). 5ᵉ ligne « Coup de poing » dans la section Controles d'Options.
+
+### Factorisation `busyOneShot()`
+- Une lambda `busyOneShot()` (dans la SM) retourne vrai si l'avatar est dans **une action one-shot ou la roulade** (`Roll/Attack/Cast/Interact/Punch`). Les overrides d'attaque/coup/sort/interaction se réduisent à `if (xPressed && !jump && !busyOneShot()) newState = X;` — **comportement identique** à l'ancienne liste d'exclusions, mais plus lisible et **extensible** (ajouter une action one-shot = une entrée dans la lambda + un override).
+- **Priorité (au sol)** : `Roll > Attack > Punch > Cast > Interact > Emote > Crouch > Sprint > Run > Walk`.
+
+### Limites connues
+- **Cosmétique** : aucun dégât/cible (comme l'attaque épée).
+- **Pas de combo** : `Punch_Cross` reste non câblé (enchaînement Jab→Cross = amélioration future).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1705,4 +1705,4 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 
 ### Limites connues
 - **Cosmétique** : aucun dégât/cible (comme l'attaque épée).
-- **Pas de combo** : `Punch_Cross` reste non câblé (enchaînement Jab→Cross = amélioration future).
+- **Alternance Jab/Cross** : chaque coup alterne `Punch_Jab` et `Punch_Cross` (variété ; clip dynamique via `m_currentPunchRole`, comme l'état Emote). Pas de vrai « combo » chaîné sur presses rapides — un coup pendant l'autre est ignoré (one-shot) ; échec bénin (au pire le mauvais clip de poing, jamais d'état bloqué).

--- a/config.json
+++ b/config.json
@@ -93,6 +93,14 @@
     "camera": {
         "mouse_sensitivity": 0.002
     },
+    "_comment_controls": "Touches d'action remappables in-game (menu Options). Noms acceptes : lettres A-Z (sauf I/J/K/T, absentes de l'enum Key), chiffres 0-9, Ctrl, Alt, Shift, Espace, Tab. La roulade reprend la touche d'accroupissement (double-appui) ; l'attaque reste le clic gauche (non remappable en v1).",
+    "controls": {
+        "keybind": {
+            "sprint": "Alt",
+            "crouch": "Ctrl",
+            "cast": "R"
+        }
+    },
     "_comment_player_movement": "Sous-projet B.1 — CharacterController params. Defaults sensibles si absent (CharacterController::Config). walk_speed/run_speed en m/s. gravity en m/s2 (signe negatif). jump_speed = impulse m/s a l'instant du jump. coyote_time_s = jump grace apres avoir quitte le sol. jump_buffer_s = jump grace si presse juste avant atterrissage.",
     "player": {
         "movement": {

--- a/config.json
+++ b/config.json
@@ -98,7 +98,8 @@
         "keybind": {
             "sprint": "Alt",
             "crouch": "Ctrl",
-            "cast": "R"
+            "cast": "R",
+            "interact": "E"
         }
     },
     "_comment_player_movement": "Sous-projet B.1 — CharacterController params. Defaults sensibles si absent (CharacterController::Config). walk_speed/run_speed en m/s. gravity en m/s2 (signe negatif). jump_speed = impulse m/s a l'instant du jump. coyote_time_s = jump grace apres avoir quitte le sol. jump_buffer_s = jump grace si presse juste avant atterrissage.",

--- a/config.json
+++ b/config.json
@@ -99,7 +99,8 @@
             "sprint": "Alt",
             "crouch": "Ctrl",
             "cast": "R",
-            "interact": "E"
+            "interact": "E",
+            "punch": "C"
         }
     },
     "_comment_player_movement": "Sous-projet B.1 — CharacterController params. Defaults sensibles si absent (CharacterController::Config). walk_speed/run_speed en m/s. gravity en m/s2 (signe negatif). jump_speed = impulse m/s a l'instant du jump. coyote_time_s = jump grace apres avoir quitte le sol. jump_buffer_s = jump grace si presse juste avant atterrissage.",

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4134,7 +4134,9 @@ namespace engine
 															addRole("SitTalk", "Sitting_Talking_Loop");
 															addRole("Push", "Push_Loop");
 															addRole("Attack", "Sword_Attack");
-															addRole("Cast", "Spell_Simple_Shoot");
+															addRole("Cast", "Spell_Simple_Enter");
+															addRole("CastShoot", "Spell_Simple_Shoot");
+															addRole("CastExit", "Spell_Simple_Exit");
 															addRole("Interact", "Interact");
 															addRole("Punch", "Punch_Jab");
 															addRole("PunchCross", "Punch_Cross");
@@ -7143,6 +7145,10 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("Attack");
 					const engine::render::skinned::AnimationClip* castClip =
 						m_currentSkinnedMesh->FindClip("Cast");
+					const engine::render::skinned::AnimationClip* castShootClip =
+						m_currentSkinnedMesh->FindClip("CastShoot");
+					const engine::render::skinned::AnimationClip* castExitClip =
+						m_currentSkinnedMesh->FindClip("CastExit");
 					const engine::render::skinned::AnimationClip* interactClip =
 						m_currentSkinnedMesh->FindClip("Interact");
 					const engine::render::skinned::AnimationClip* punchClip =
@@ -7295,9 +7301,23 @@ namespace engine
 								}
 								break;
 							case AvatarLocomotionState::Cast:
-								// One-shot : retour locomotion quand le clip de sort est fini.
-								// Deplacement pilote par le CharacterController pendant le cast.
-								if (!castClip || stateElapsed >= castClip->duration)
+							{
+								// Sequence : Enter (clip "Cast") -> Shoot -> Exit, les 2 derniers rejoues
+								// via m_avatarPendingClipRole (sans changer d'etat). Garde-fou 3s.
+								const float enterDur = castClip ? castClip->duration : 0.0f;
+								const float shootDur = castShootClip ? castShootClip->duration : 0.0f;
+								const float exitDur  = castExitClip ? castExitClip->duration : 0.0f;
+								if (m_castPhase == 0 && stateElapsed >= enterDur)
+								{
+									m_avatarPendingClipRole = "CastShoot";
+									m_castPhase = 1;
+								}
+								else if (m_castPhase == 1 && stateElapsed >= enterDur + shootDur)
+								{
+									m_avatarPendingClipRole = "CastExit";
+									m_castPhase = 2;
+								}
+								if (stateElapsed >= enterDur + shootDur + exitDur || stateElapsed >= 3.0f)
 								{
 									if (!moving)                  newState = AvatarLocomotionState::Idle;
 									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
@@ -7306,6 +7326,7 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							}
 							case AvatarLocomotionState::Interact:
 								// One-shot : retour locomotion quand le geste d'interaction est fini.
 								// Action non-combat (la touche E reservee au menu Options trouve ici son usage).
@@ -7426,6 +7447,7 @@ namespace engine
 
 						m_avatarLocoState = newState;
 						m_avatarLocoStateEnterTime = now;
+						if (newState == AvatarLocomotionState::Cast) m_castPhase = 0;
 
 						// Trigger crossfade vers le clip du nouvel etat. Si le clip est
 						// introuvable (asset manquant -> FindClip == nullptr), on log un
@@ -7446,6 +7468,14 @@ namespace engine
 						{
 							LOG_WARN(Render, "[Avatar SM] FindClip('{}') returned nullptr — animation precedente continue", clipName);
 						}
+					}
+					// Replay d'un clip en cours d'etat (sequence de sort) sans transition d'etat.
+					if (!m_avatarPendingClipRole.empty())
+					{
+						const engine::render::skinned::AnimationClip* rc = m_currentSkinnedMesh->FindClip(m_avatarPendingClipRole.c_str());
+						if (rc)
+							m_avatarCrossfade.Play(*rc, /*loops=*/false, nowSec);
+						m_avatarPendingClipRole.clear();
 					}
 				}
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -278,6 +278,8 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
+				case engine::Engine::AvatarLocomotionState::SwimIdle:     return "SwimIdle";
+				case engine::Engine::AvatarLocomotionState::SwimForward:  return "SwimForward";
 			}
 			return "Idle";
 		}
@@ -300,7 +302,9 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::CrouchIdle
 				|| s == engine::Engine::AvatarLocomotionState::CrouchWalk
 				|| s == engine::Engine::AvatarLocomotionState::Emote
-				|| s == engine::Engine::AvatarLocomotionState::Fall;
+				|| s == engine::Engine::AvatarLocomotionState::Fall
+				|| s == engine::Engine::AvatarLocomotionState::SwimIdle
+				|| s == engine::Engine::AvatarLocomotionState::SwimForward;
 		}
 
 		engine::core::LogLevel ParseLogLevelConfig(std::string_view text)
@@ -4143,6 +4147,8 @@ namespace engine
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
+															addRole("SwimIdle", "Swim_Idle_Loop");
+															addRole("SwimForward", "Swim_Fwd_Loop");
 
 															// Expose AUSSI tous les autres clips UE5 par leur nom brut (sans
 															// prefixe "Armature|"), disponibles pour les futurs systemes
@@ -4305,6 +4311,52 @@ namespace engine
 										// que la sphere du bas de la capsule traverse le sol au premier sweep.
 										{
 											m_terrainCollider.BindTerrain(&m_terrain);
+
+											// Nage (v1) : eau-test procedurale. La zone demo est plate et sans
+											// eau ; on pose un BASSIN DE TEST au-dessus du sol pour valider la
+											// mecanique de nage (a remplacer par une vraie etendue d'eau via le
+											// pipeline water.bin / level-design). Desactivable : world.test_water.enabled=false.
+											if (m_cfg.GetBool("world.test_water.enabled", true))
+											{
+												const float cx = static_cast<float>(m_cfg.GetDouble("world.test_water.center_x", 25.0));
+												const float cz = static_cast<float>(m_cfg.GetDouble("world.test_water.center_z", 0.0));
+												const float half = static_cast<float>(m_cfg.GetDouble("world.test_water.half_size_m", 15.0));
+												const float depth = static_cast<float>(m_cfg.GetDouble("world.test_water.depth_m", 2.5));
+												const float lvl = m_terrainCollider.GroundHeightAt(cx, cz) + depth;
+												auto waterScene = std::make_shared<engine::world::water::WaterScene>();
+												engine::world::water::LakeInstance lake;
+												lake.name = "test_pool";
+												lake.waterLevelY = lvl;
+												// Polygone XZ (SW->SE->NE->NW). Si la surface est cullee a l'affichage,
+												// inverser l'ordre (winding) ; la nage (QueryWater) marche dans les 2 cas.
+												lake.polygon = {
+													engine::math::Vec3{ cx - half, lvl, cz - half },
+													engine::math::Vec3{ cx + half, lvl, cz - half },
+													engine::math::Vec3{ cx + half, lvl, cz + half },
+													engine::math::Vec3{ cx - half, lvl, cz + half },
+												};
+												waterScene->lakes.push_back(std::move(lake));
+												m_clientWaterScene = std::move(waterScene);
+												m_waterClientSceneDirty = true;
+												LOG_INFO(Render, "[Nage] Eau-test posee (centre=({:.1f},{:.1f}) half={:.1f} niveauY={:.2f})", cx, cz, half, lvl);
+											}
+											m_terrainCollider.BindWater(m_clientWaterScene.get());
+											// Interaction (v1) : entites interactibles de TEST (invisibles) pour valider
+											// la mecanique objets + dialogue PNJ. A remplacer par de vraies entites.
+											m_interactables.clear();
+											{
+												InteractableEntity npc;
+												npc.position = engine::math::Vec3{ 4.0f, 0.0f, 0.0f };
+												npc.radius = 2.5f; npc.isNpc = true; npc.label = "Villageois";
+												npc.message = "Villageois : Bienvenue ! L'eau de test est a l'est.";
+												m_interactables.push_back(npc);
+												InteractableEntity chest;
+												chest.position = engine::math::Vec3{ -4.0f, 0.0f, 0.0f };
+												chest.radius = 2.0f; chest.isNpc = false; chest.label = "Coffre";
+												chest.message = "Vous fouillez le coffre... vide pour l'instant.";
+												m_interactables.push_back(chest);
+											}
+											m_interactableInRange = -1;
 
 											engine::gameplay::CharacterController::Config ccCfg{};
 											ccCfg.walkSpeed     = static_cast<float>(m_cfg.GetDouble("player.movement.walk_speed",      5.0));
@@ -7432,6 +7484,23 @@ namespace engine
 						}
 					}
 
+					// Nage : si le controller est en mode eau (immersion > bassin), l'avatar
+					// nage -> surclasse locomotion / saut / actions one-shot ci-dessus. A la
+					// sortie d'eau, on quitte explicitement Swim* (le switch n'a pas de case
+					// Swim* -> sinon l'avatar resterait fige en nage au sol).
+					if (m_characterController.IsInWater())
+					{
+						newState = (moving || movingBack) ? AvatarLocomotionState::SwimForward : AvatarLocomotionState::SwimIdle;
+					}
+					else if (m_avatarLocoState == AvatarLocomotionState::SwimIdle
+						|| m_avatarLocoState == AvatarLocomotionState::SwimForward)
+					{
+						if (!grounded)        newState = AvatarLocomotionState::Fall;
+						else if (movingBack)  newState = AvatarLocomotionState::WalkBack;
+						else if (moving)      newState = moveInput.sprint ? AvatarLocomotionState::Sprint : (moveInput.run ? AvatarLocomotionState::Run : AvatarLocomotionState::Walk);
+						else                  newState = AvatarLocomotionState::Idle;
+					}
+
 					if (newState != m_avatarLocoState)
 					{
 						// DEBUG B.1 : log chaque transition d'etat pour diagnostiquer
@@ -7476,6 +7545,49 @@ namespace engine
 						if (rc)
 							m_avatarCrossfade.Play(*rc, /*loops=*/false, nowSec);
 						m_avatarPendingClipRole.clear();
+					}
+
+					// Interaction (touche E) : interactible le plus proche (distance XZ) a portee.
+					// Hint chat a l'entree de portee ; sur E -> effet (objet) ou dialogue (PNJ).
+					// Le geste Interact joue par ailleurs (SM). v1 sans rendu des cibles.
+					{
+						const engine::math::Vec3 ppos = m_characterController.GetPosition();
+						int nearestI = -1;
+						float bestD2 = 0.0f;
+						for (std::size_t i = 0; i < m_interactables.size(); ++i)
+						{
+							const InteractableEntity& e = m_interactables[i];
+							const float dx = e.position.x - ppos.x;
+							const float dz = e.position.z - ppos.z;
+							const float d2 = dx * dx + dz * dz;
+							if (d2 <= e.radius * e.radius && (nearestI < 0 || d2 < bestD2))
+							{
+								nearestI = static_cast<int>(i);
+								bestD2 = d2;
+							}
+						}
+						auto pushInteractChat = [&](const std::string& sender, const std::string& text)
+						{
+							engine::net::ChatMessage cm;
+							cm.timestampUnixMs = static_cast<uint64_t>(
+								std::chrono::duration_cast<std::chrono::milliseconds>(
+									std::chrono::system_clock::now().time_since_epoch()).count());
+							cm.channel = engine::net::ChatChannel::Server;
+							cm.sender = sender;
+							cm.text = text;
+							m_chatUi.PushNetworkLine(cm);
+						};
+						if (nearestI != m_interactableInRange)
+						{
+							m_interactableInRange = nearestI;
+							if (nearestI >= 0)
+								pushInteractChat("[Interaction]", "Pres de " + m_interactables[nearestI].label + " - appuyez sur E.");
+						}
+						if (interactPressed && nearestI >= 0)
+						{
+							const InteractableEntity& e = m_interactables[nearestI];
+							pushInteractChat(e.isNpc ? "[PNJ]" : "[Objet]", e.message);
+						}
 					}
 				}
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -274,6 +274,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Attack:       return "Attack";
 				case engine::Engine::AvatarLocomotionState::Cast:         return "Cast";
 				case engine::Engine::AvatarLocomotionState::Interact:     return "Interact";
+				case engine::Engine::AvatarLocomotionState::Punch:        return "Punch";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -4122,6 +4123,7 @@ namespace engine
 															addRole("Attack", "Sword_Attack");
 															addRole("Cast", "Spell_Simple_Shoot");
 															addRole("Interact", "Interact");
+															addRole("Punch", "Punch_Jab");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7036,6 +7038,8 @@ namespace engine
 					KeyFromName(m_cfg.GetString("controls.keybind.cast", "R"), engine::platform::Key::R);
 				const engine::platform::Key interactKey =
 					KeyFromName(m_cfg.GetString("controls.keybind.interact", "E"), engine::platform::Key::E);
+				const engine::platform::Key punchKey =
+					KeyFromName(m_cfg.GetString("controls.keybind.punch", "C"), engine::platform::Key::C);
 				// Vue 3eme personne : controleur orbital pur (camera derriere la
 				// cible). Souris libre par defaut ; clic droit maintenu = rotate
 				// camera autour de la cible (yaw/pitch) ; molette = zoom.
@@ -7127,6 +7131,8 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("Cast");
 					const engine::render::skinned::AnimationClip* interactClip =
 						m_currentSkinnedMesh->FindClip("Interact");
+					const engine::render::skinned::AnimationClip* punchClip =
+						m_currentSkinnedMesh->FindClip("Punch");
 
 					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
 					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
@@ -7146,6 +7152,10 @@ namespace engine
 					// usage). Geste cosmetique one-shot ; cible/objet a brancher plus tard.
 					const bool interactPressed =
 						m_input.WasPressed(interactKey);
+
+					// Coup de poing : 2e attaque melee, touche remappable (controls.keybind.punch, def. C).
+					const bool punchPressed =
+						m_input.WasPressed(punchKey);
 
 					// Esquive/roulade : double-appui (fenetre 0.30s) sur la touche Crouch
 					// (remappable). Touche maintenue = crouch ; deux appuis = Roll (one-shot).
@@ -7294,19 +7304,43 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							case AvatarLocomotionState::Punch:
+								// One-shot : retour locomotion quand le coup de poing est fini.
+								if (!punchClip || stateElapsed >= punchClip->duration)
+								{
+									if (!moving)                  newState = AvatarLocomotionState::Idle;
+									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
+									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
+									else                          newState = AvatarLocomotionState::Walk;
+								}
+								break;
 						}
 
+						// Une action "one-shot" en cours (roulade ou geste combat/interaction)
+						// bloque le declenchement d'une autre. Centralise ici pour eviter une
+						// longue liste d'exclusions par override et faciliter l'ajout d'actions.
+						auto busyOneShot = [&]()
+						{
+							return m_avatarLocoState == AvatarLocomotionState::Roll
+								|| m_avatarLocoState == AvatarLocomotionState::Attack
+								|| m_avatarLocoState == AvatarLocomotionState::Cast
+								|| m_avatarLocoState == AvatarLocomotionState::Interact
+								|| m_avatarLocoState == AvatarLocomotionState::Punch;
+						};
+
 						// Crouch (Ctrl) : etat accroupi prioritaire tant que la touche est tenue
-						// (sauf amorce de saut, ou Roll/Dance/Attack en cours). CrouchWalk si deplacement.
+						// (sauf amorce de saut, emote, ou action one-shot en cours). CrouchWalk si deplacement.
 						if (moveInput.crouch && newState != AvatarLocomotionState::Jump
 							&& newState != AvatarLocomotionState::Roll
 							&& newState != AvatarLocomotionState::Emote
 							&& newState != AvatarLocomotionState::Attack
 							&& newState != AvatarLocomotionState::Cast
-							&& newState != AvatarLocomotionState::Interact)
+							&& newState != AvatarLocomotionState::Interact
+							&& newState != AvatarLocomotionState::Punch)
 							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 
-						// Esquive/roulade (Ctrl double-tap) : Roll one-shot, prioritaire sur crouch.
+						// Esquive/roulade (double-appui Crouch) : Roll one-shot, prioritaire sur crouch.
 						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll)
 							newState = AvatarLocomotionState::Roll;
 
@@ -7318,35 +7352,21 @@ namespace engine
 							newState = AvatarLocomotionState::Emote;
 						}
 
-						// Attaque melee (clic gauche) : Sword_Attack one-shot. Ne s'enclenche
-						// pas pendant un saut/roll et ne coupe pas un Roll en cours. Prioritaire
-						// sur crouch (on peut frapper accroupi -> repasse debout l'attaque finie).
-						if (attackPressed && !moveInput.jumpPressed
-							&& m_avatarLocoState != AvatarLocomotionState::Roll
-							&& m_avatarLocoState != AvatarLocomotionState::Cast
-							&& m_avatarLocoState != AvatarLocomotionState::Attack
-							&& m_avatarLocoState != AvatarLocomotionState::Interact)
+						// Attaque melee (clic gauche) : Sword_Attack one-shot. Pas pendant un saut
+						// ni une autre action one-shot ; prioritaire sur le crouch.
+						if (attackPressed && !moveInput.jumpPressed && !busyOneShot())
 							newState = AvatarLocomotionState::Attack;
 
-						// Sort (touche R) : Spell_Simple_Shoot one-shot. Memes regles que
-						// l'attaque (pas pendant un saut/roll, ne coupe pas un Roll/Attack/
-						// Cast en cours). Prioritaire sur le crouch (caster accroupi ->
-						// repasse debout le sort fini).
-						if (castPressed && !moveInput.jumpPressed
-							&& m_avatarLocoState != AvatarLocomotionState::Roll
-							&& m_avatarLocoState != AvatarLocomotionState::Attack
-							&& m_avatarLocoState != AvatarLocomotionState::Cast
-							&& m_avatarLocoState != AvatarLocomotionState::Interact)
+						// Coup de poing (touche C par defaut) : Punch_Jab one-shot, 2e attaque melee.
+						if (punchPressed && !moveInput.jumpPressed && !busyOneShot())
+							newState = AvatarLocomotionState::Punch;
+
+						// Sort (touche R par defaut) : Spell_Simple_Shoot one-shot.
+						if (castPressed && !moveInput.jumpPressed && !busyOneShot())
 							newState = AvatarLocomotionState::Cast;
 
-						// Interagir (touche E par defaut) : geste Interact one-shot, action
-						// non-combat. Memes regles que le sort (pas pendant saut/roll, ne coupe
-						// pas un Roll/Attack/Cast/Interact en cours). Prioritaire sur le crouch.
-						if (interactPressed && !moveInput.jumpPressed
-							&& m_avatarLocoState != AvatarLocomotionState::Roll
-							&& m_avatarLocoState != AvatarLocomotionState::Attack
-							&& m_avatarLocoState != AvatarLocomotionState::Cast
-							&& m_avatarLocoState != AvatarLocomotionState::Interact)
+						// Interagir (touche E par defaut) : geste Interact one-shot, action non-combat.
+						if (interactPressed && !moveInput.jumpPressed && !busyOneShot())
 							newState = AvatarLocomotionState::Interact;
 					}
 					else
@@ -8073,7 +8093,7 @@ namespace engine
 			if (m_inGameOptionsPanelVisible)
 			{
 				const float optW = 460.f;
-				const float optH = 520.f;
+				const float optH = 560.f;
 				ImGui::SetNextWindowPos(ImVec2((dw - optW) * 0.5f, (dh - optH) * 0.5f), ImGuiCond_Always);
 				ImGui::SetNextWindowSize(ImVec2(optW, optH), ImGuiCond_Always);
 				ImGui::SetNextWindowBgAlpha(0.95f);
@@ -8139,7 +8159,8 @@ namespace engine
 									(m_rebindingAction == 1) ? "controls.keybind.sprint"
 									: (m_rebindingAction == 2) ? "controls.keybind.crouch"
 									: (m_rebindingAction == 3) ? "controls.keybind.cast"
-									: "controls.keybind.interact";
+									: (m_rebindingAction == 4) ? "controls.keybind.interact"
+									: "controls.keybind.punch";
 								m_cfg.SetValue(cfgKey, std::string(rk.name));
 								m_rebindingAction = 0;
 								break;
@@ -8165,6 +8186,7 @@ namespace engine
 				rebindRow("Accroupi", "controls.keybind.crouch", "Ctrl", 2);
 				rebindRow("Sort", "controls.keybind.cast", "R", 3);
 				rebindRow("Interagir", "controls.keybind.interact", "E", 4);
+				rebindRow("Coup de poing", "controls.keybind.punch", "C", 5);
 				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
 				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4137,6 +4137,7 @@ namespace engine
 															addRole("Cast", "Spell_Simple_Shoot");
 															addRole("Interact", "Interact");
 															addRole("Punch", "Punch_Jab");
+															addRole("PunchCross", "Punch_Cross");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7145,7 +7146,7 @@ namespace engine
 					const engine::render::skinned::AnimationClip* interactClip =
 						m_currentSkinnedMesh->FindClip("Interact");
 					const engine::render::skinned::AnimationClip* punchClip =
-						m_currentSkinnedMesh->FindClip("Punch");
+						m_currentSkinnedMesh->FindClip(m_currentPunchRole.c_str());
 
 					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
 					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
@@ -7372,7 +7373,12 @@ namespace engine
 
 						// Coup de poing (touche C par defaut) : Punch_Jab one-shot, 2e attaque melee.
 						if (punchPressed && !moveInput.jumpPressed && !busyOneShot())
+						{
+							// Alterne Jab <-> Cross a chaque coup (variete ; clip dynamique).
+							m_currentPunchRole = m_punchAlt ? "PunchCross" : "Punch";
+							m_punchAlt = !m_punchAlt;
 							newState = AvatarLocomotionState::Punch;
+						}
 
 						// Sort (touche R par defaut) : Spell_Simple_Shoot one-shot.
 						if (castPressed && !moveInput.jumpPressed && !busyOneShot())
@@ -7417,8 +7423,9 @@ namespace engine
 						// introuvable (asset manquant -> FindClip == nullptr), on log un
 						// warn une seule fois et on laisse l'animation precedente continuer
 						// (Sample retombera dessus jusqu'a la prochaine transition reussie).
-						const char* clipName = (newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty())
-							? m_currentEmoteRole.c_str()
+						const char* clipName =
+							(newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty()) ? m_currentEmoteRole.c_str()
+							: (newState == AvatarLocomotionState::Punch) ? m_currentPunchRole.c_str()
 							: StateToClipName(newState);
 						const engine::render::skinned::AnimationClip* newClip = m_currentSkinnedMesh->FindClip(clipName);
 						if (newClip)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -136,10 +136,51 @@ namespace engine
 		///         `swim*/fly` sont hors-scope B.1 et restent false.
 		///
 		/// Effet de bord : aucun. Pure projection input -> intention.
+		// Touches remappables (nom config <-> enum platform::Key). Limitee aux
+		// Key reellement definies dans l'enum (I/J/K/T n'y figurent pas). Sert au
+		// panneau Options (affichage + capture du rebind) et a la lecture des
+		// binds gameplay depuis controls.keybind.* (sprint / crouch / cast).
+		struct RebindableKey { engine::platform::Key key; const char* name; };
+		const RebindableKey kRebindableKeys[] = {
+			{engine::platform::Key::A,"A"},{engine::platform::Key::B,"B"},{engine::platform::Key::C,"C"},
+			{engine::platform::Key::D,"D"},{engine::platform::Key::E,"E"},{engine::platform::Key::F,"F"},
+			{engine::platform::Key::G,"G"},{engine::platform::Key::H,"H"},{engine::platform::Key::L,"L"},
+			{engine::platform::Key::M,"M"},{engine::platform::Key::N,"N"},{engine::platform::Key::O,"O"},
+			{engine::platform::Key::P,"P"},{engine::platform::Key::Q,"Q"},{engine::platform::Key::R,"R"},
+			{engine::platform::Key::S,"S"},{engine::platform::Key::U,"U"},{engine::platform::Key::V,"V"},
+			{engine::platform::Key::W,"W"},{engine::platform::Key::X,"X"},{engine::platform::Key::Y,"Y"},
+			{engine::platform::Key::Z,"Z"},
+			{engine::platform::Key::Digit0,"0"},{engine::platform::Key::Digit1,"1"},{engine::platform::Key::Digit2,"2"},
+			{engine::platform::Key::Digit3,"3"},{engine::platform::Key::Digit4,"4"},{engine::platform::Key::Digit5,"5"},
+			{engine::platform::Key::Digit6,"6"},{engine::platform::Key::Digit7,"7"},{engine::platform::Key::Digit8,"8"},
+			{engine::platform::Key::Digit9,"9"},
+			{engine::platform::Key::Control,"Ctrl"},{engine::platform::Key::Alt,"Alt"},
+			{engine::platform::Key::Shift,"Shift"},{engine::platform::Key::Space,"Espace"},
+			{engine::platform::Key::Tab,"Tab"},
+		};
+
+		/// Nom affichable/config d'une touche (ou "?" si hors table).
+		const char* KeyName(engine::platform::Key k)
+		{
+			for (const auto& e : kRebindableKeys)
+				if (e.key == k) return e.name;
+			return "?";
+		}
+
+		/// Resout un nom de touche (config) en `Key`, `fallback` si inconnu.
+		engine::platform::Key KeyFromName(const std::string& name, engine::platform::Key fallback)
+		{
+			for (const auto& e : kRebindableKeys)
+				if (name == e.name) return e.key;
+			return fallback;
+		}
+
 		engine::gameplay::MoveInput BuildMoveInput(
 			const engine::platform::Input& input,
 			const engine::render::OrbitalCameraController& camera,
-			engine::render::MovementLayout layout)
+			engine::render::MovementLayout layout,
+			engine::platform::Key sprintKey,
+			engine::platform::Key crouchKey)
 		{
 			engine::gameplay::MoveInput out{};
 
@@ -183,8 +224,8 @@ namespace engine
 			}
 
 			out.run         = input.IsDown(engine::platform::Key::Shift);
-			out.sprint      = input.IsDown(engine::platform::Key::Alt);
-			out.crouch      = input.IsDown(engine::platform::Key::Control);
+			out.sprint      = input.IsDown(sprintKey);
+			out.crouch      = input.IsDown(crouchKey);
 			out.jumpPressed = input.WasPressed(engine::platform::Key::Space);
 			// swim/fly hors-scope B.1 : restent false (consommes par les modes
 			// Water/Fly du CharacterController, inutiles tant que la query eau
@@ -6960,8 +7001,17 @@ namespace engine
 
 		if (!m_editorEnabled)
 		{
-			if (!authGateActive && !m_chatUi.IsChatFocusActive())
+			if (!authGateActive && !m_chatUi.IsChatFocusActive() && !m_inGameOptionsPanelVisible)
 			{
+				// Touches d'action remappables (controls.keybind.*), resolues chaque
+				// frame depuis la config pour refleter immediatement un rebind fait
+				// dans le panneau Options. Defauts : sprint=Alt, crouch=Ctrl, sort=R.
+				const engine::platform::Key sprintKey =
+					KeyFromName(m_cfg.GetString("controls.keybind.sprint", "Alt"), engine::platform::Key::Alt);
+				const engine::platform::Key crouchKey =
+					KeyFromName(m_cfg.GetString("controls.keybind.crouch", "Ctrl"), engine::platform::Key::Control);
+				const engine::platform::Key castKey =
+					KeyFromName(m_cfg.GetString("controls.keybind.cast", "R"), engine::platform::Key::R);
 				// Vue 3eme personne : controleur orbital pur (camera derriere la
 				// cible). Souris libre par defaut ; clic droit maintenu = rotate
 				// camera autour de la cible (yaw/pitch) ; molette = zoom.
@@ -6973,7 +7023,7 @@ namespace engine
 				// avant le CC, son repere (Forward/Right XZ) servirait a projeter
 				// l'input du frame courant mais sa position cible utiliserait la
 				// position de la frame precedente -> 1-frame lag visible.
-				const auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout);
+				const auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout, sprintKey, crouchKey);
 				m_characterController.Update(static_cast<float>(dt), moveInput, m_terrainCollider);
 				const engine::math::Vec3 ccPos = m_characterController.GetPosition();
 				m_orbitalCameraController.SetTargetPosition(ccPos);
@@ -7063,12 +7113,12 @@ namespace engine
 					// chat / l'auth (cf. ligne ~6961). Geste cosmetique one-shot (pas de
 					// cible ni d'aller-retour serveur), pendant clavier de l'attaque souris.
 					const bool castPressed =
-						m_input.WasPressed(engine::platform::Key::R);
+						m_input.WasPressed(castKey);
 
-					// Esquive/roulade : Ctrl double-tap (fenetre 0.30s). Ctrl maintenu
-					// = crouch ; deux appuis rapides = Roll (one-shot).
+					// Esquive/roulade : double-appui (fenetre 0.30s) sur la touche Crouch
+					// (remappable). Touche maintenue = crouch ; deux appuis = Roll (one-shot).
 					bool dodgePressed = false;
-					if (m_input.WasPressed(engine::platform::Key::Control))
+					if (m_input.WasPressed(crouchKey))
 					{
 						if (nowSec - m_lastCtrlTapSec <= 0.30f)
 							dodgePressed = true;
@@ -7960,8 +8010,8 @@ namespace engine
 			// Le full panel auth Options reste accessible via Se deconnecter -> Login -> Options.
 			if (m_inGameOptionsPanelVisible)
 			{
-				const float optW = 420.f;
-				const float optH = 320.f;
+				const float optW = 460.f;
+				const float optH = 480.f;
 				ImGui::SetNextWindowPos(ImVec2((dw - optW) * 0.5f, (dh - optH) * 0.5f), ImGuiCond_Always);
 				ImGui::SetNextWindowSize(ImVec2(optW, optH), ImGuiCond_Always);
 				ImGui::SetNextWindowBgAlpha(0.95f);
@@ -8002,6 +8052,57 @@ namespace engine
 				{
 					m_cfg.SetValue("controls.mouse_sensitivity", static_cast<double>(sens));
 				}
+
+				// --- Controles : touches d'action remappables (controls.keybind.*) ---
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::TextUnformatted("Controles");
+
+				// Capture du rebind en cours : la 1re touche connue pressee est affectee
+				// a l'action ciblee (Echap annule). Le bloc gameplay etant suspendu tant
+				// que ce panneau est ouvert, la touche capturee ne declenche pas l'action.
+				if (m_rebindingAction != 0)
+				{
+					if (m_input.WasPressed(engine::platform::Key::Escape))
+					{
+						m_rebindingAction = 0;
+					}
+					else
+					{
+						for (const auto& rk : kRebindableKeys)
+						{
+							if (m_input.WasPressed(rk.key))
+							{
+								const char* cfgKey =
+									(m_rebindingAction == 1) ? "controls.keybind.sprint"
+									: (m_rebindingAction == 2) ? "controls.keybind.crouch"
+									: "controls.keybind.cast";
+								m_cfg.SetValue(cfgKey, std::string(rk.name));
+								m_rebindingAction = 0;
+								break;
+							}
+						}
+					}
+				}
+
+				auto rebindRow = [&](const char* label, const char* cfgKey,
+					const char* def, int action)
+				{
+					const std::string cur = m_cfg.GetString(cfgKey, def);
+					ImGui::Text("%s : %s", label, cur.c_str());
+					ImGui::SameLine(190.f);
+					ImGui::PushID(action);
+					if (m_rebindingAction == action)
+						ImGui::TextUnformatted("appuyez sur une touche (Echap = annuler)");
+					else if (ImGui::SmallButton("Modifier"))
+						m_rebindingAction = action;
+					ImGui::PopID();
+				};
+				rebindRow("Sprint", "controls.keybind.sprint", "Alt", 1);
+				rebindRow("Accroupi", "controls.keybind.crouch", "Ctrl", 2);
+				rebindRow("Sort", "controls.keybind.cast", "R", 3);
+				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
+				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
 
 				ImGui::Spacing();
 				ImGui::Separator();

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -273,6 +273,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::Dance:        return "Dance";
 				case engine::Engine::AvatarLocomotionState::Attack:       return "Attack";
 				case engine::Engine::AvatarLocomotionState::Cast:         return "Cast";
+				case engine::Engine::AvatarLocomotionState::Interact:     return "Interact";
 				case engine::Engine::AvatarLocomotionState::Jump:         return "Jump";
 				case engine::Engine::AvatarLocomotionState::Fall:         return "Fall";
 				case engine::Engine::AvatarLocomotionState::Land:         return "Land";
@@ -4100,6 +4101,7 @@ namespace engine
 															addRole("Dance", "Dance_Loop");
 															addRole("Attack", "Sword_Attack");
 															addRole("Cast", "Spell_Simple_Shoot");
+															addRole("Interact", "Interact");
 															addRole("Jump", "Jump_Start");
 															addRole("Fall", "Jump_Loop");
 															addRole("Land", "Jump_Land");
@@ -7012,6 +7014,8 @@ namespace engine
 					KeyFromName(m_cfg.GetString("controls.keybind.crouch", "Ctrl"), engine::platform::Key::Control);
 				const engine::platform::Key castKey =
 					KeyFromName(m_cfg.GetString("controls.keybind.cast", "R"), engine::platform::Key::R);
+				const engine::platform::Key interactKey =
+					KeyFromName(m_cfg.GetString("controls.keybind.interact", "E"), engine::platform::Key::E);
 				// Vue 3eme personne : controleur orbital pur (camera derriere la
 				// cible). Souris libre par defaut ; clic droit maintenu = rotate
 				// camera autour de la cible (yaw/pitch) ; molette = zoom.
@@ -7101,6 +7105,8 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("Attack");
 					const engine::render::skinned::AnimationClip* castClip =
 						m_currentSkinnedMesh->FindClip("Cast");
+					const engine::render::skinned::AnimationClip* interactClip =
+						m_currentSkinnedMesh->FindClip("Interact");
 
 					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
 					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
@@ -7114,6 +7120,12 @@ namespace engine
 					// cible ni d'aller-retour serveur), pendant clavier de l'attaque souris.
 					const bool castPressed =
 						m_input.WasPressed(castKey);
+
+					// Interagir : touche remappable (controls.keybind.interact, def. E),
+					// edge. Action non-combat (la touche E reservee au §32 trouve ici son
+					// usage). Geste cosmetique one-shot ; cible/objet a brancher plus tard.
+					const bool interactPressed =
+						m_input.WasPressed(interactKey);
 
 					// Esquive/roulade : double-appui (fenetre 0.30s) sur la touche Crouch
 					// (remappable). Touche maintenue = crouch ; deux appuis = Roll (one-shot).
@@ -7250,6 +7262,18 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
+							case AvatarLocomotionState::Interact:
+								// One-shot : retour locomotion quand le geste d'interaction est fini.
+								// Action non-combat (la touche E reservee au menu Options trouve ici son usage).
+								if (!interactClip || stateElapsed >= interactClip->duration)
+								{
+									if (!moving)                  newState = AvatarLocomotionState::Idle;
+									else if (movingBack)          newState = AvatarLocomotionState::WalkBack;
+									else if (moveInput.sprint)    newState = AvatarLocomotionState::Sprint;
+									else if (moveInput.run)       newState = AvatarLocomotionState::Run;
+									else                          newState = AvatarLocomotionState::Walk;
+								}
+								break;
 						}
 
 						// Crouch (Ctrl) : etat accroupi prioritaire tant que la touche est tenue
@@ -7258,7 +7282,8 @@ namespace engine
 							&& newState != AvatarLocomotionState::Roll
 							&& newState != AvatarLocomotionState::Dance
 							&& newState != AvatarLocomotionState::Attack
-							&& newState != AvatarLocomotionState::Cast)
+							&& newState != AvatarLocomotionState::Cast
+							&& newState != AvatarLocomotionState::Interact)
 							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 
 						// Esquive/roulade (Ctrl double-tap) : Roll one-shot, prioritaire sur crouch.
@@ -7276,7 +7301,8 @@ namespace engine
 						if (attackPressed && !moveInput.jumpPressed
 							&& m_avatarLocoState != AvatarLocomotionState::Roll
 							&& m_avatarLocoState != AvatarLocomotionState::Cast
-							&& m_avatarLocoState != AvatarLocomotionState::Attack)
+							&& m_avatarLocoState != AvatarLocomotionState::Attack
+							&& m_avatarLocoState != AvatarLocomotionState::Interact)
 							newState = AvatarLocomotionState::Attack;
 
 						// Sort (touche R) : Spell_Simple_Shoot one-shot. Memes regles que
@@ -7286,8 +7312,19 @@ namespace engine
 						if (castPressed && !moveInput.jumpPressed
 							&& m_avatarLocoState != AvatarLocomotionState::Roll
 							&& m_avatarLocoState != AvatarLocomotionState::Attack
-							&& m_avatarLocoState != AvatarLocomotionState::Cast)
+							&& m_avatarLocoState != AvatarLocomotionState::Cast
+							&& m_avatarLocoState != AvatarLocomotionState::Interact)
 							newState = AvatarLocomotionState::Cast;
+
+						// Interagir (touche E par defaut) : geste Interact one-shot, action
+						// non-combat. Memes regles que le sort (pas pendant saut/roll, ne coupe
+						// pas un Roll/Attack/Cast/Interact en cours). Prioritaire sur le crouch.
+						if (interactPressed && !moveInput.jumpPressed
+							&& m_avatarLocoState != AvatarLocomotionState::Roll
+							&& m_avatarLocoState != AvatarLocomotionState::Attack
+							&& m_avatarLocoState != AvatarLocomotionState::Cast
+							&& m_avatarLocoState != AvatarLocomotionState::Interact)
+							newState = AvatarLocomotionState::Interact;
 					}
 					else
 					{
@@ -8011,7 +8048,7 @@ namespace engine
 			if (m_inGameOptionsPanelVisible)
 			{
 				const float optW = 460.f;
-				const float optH = 480.f;
+				const float optH = 520.f;
 				ImGui::SetNextWindowPos(ImVec2((dw - optW) * 0.5f, (dh - optH) * 0.5f), ImGuiCond_Always);
 				ImGui::SetNextWindowSize(ImVec2(optW, optH), ImGuiCond_Always);
 				ImGui::SetNextWindowBgAlpha(0.95f);
@@ -8076,7 +8113,8 @@ namespace engine
 								const char* cfgKey =
 									(m_rebindingAction == 1) ? "controls.keybind.sprint"
 									: (m_rebindingAction == 2) ? "controls.keybind.crouch"
-									: "controls.keybind.cast";
+									: (m_rebindingAction == 3) ? "controls.keybind.cast"
+									: "controls.keybind.interact";
 								m_cfg.SetValue(cfgKey, std::string(rk.name));
 								m_rebindingAction = 0;
 								break;
@@ -8101,6 +8139,7 @@ namespace engine
 				rebindRow("Sprint", "controls.keybind.sprint", "Alt", 1);
 				rebindRow("Accroupi", "controls.keybind.crouch", "Ctrl", 2);
 				rebindRow("Sort", "controls.keybind.cast", "R", 3);
+				rebindRow("Interagir", "controls.keybind.interact", "E", 4);
 				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
 				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -478,6 +478,13 @@ namespace engine
 
 		void ApplyUserSettingsOverrides(engine::core::Config& cfg)
 		{
+			// Binds clavier persistants (controls.keybind.*) : fichier dedie
+			// keybinds.json, ecrit par le panneau Options au rebind. Merge par-dessus
+			// les defauts de config.json. Absent/malforme -> ignore (on garde les defauts) ;
+			// fichier dedie => un echec ne corrompt jamais user_settings.json.
+			if (cfg.LoadFromFile("keybinds.json"))
+				LOG_INFO(Core, "[Boot] keybinds.json applique (binds clavier persistants)");
+
 			engine::core::Config persisted;
 			if (!persisted.LoadFromFile("user_settings.json"))
 			{
@@ -8168,6 +8175,20 @@ namespace engine
 									: (m_rebindingAction == 4) ? "controls.keybind.interact"
 									: "controls.keybind.punch";
 								m_cfg.SetValue(cfgKey, std::string(rk.name));
+								// Persistance : ecrit keybinds.json (fichier dedie, format controle ;
+								// valeurs = noms ASCII de kRebindableKeys -> pas d'echappement JSON requis).
+								{
+									const std::string kb =
+										std::string("{\n  \"controls\": {\n    \"keybind\": {\n")
+										+ "      \"sprint\": \"" + m_cfg.GetString("controls.keybind.sprint", "Alt") + "\",\n"
+										+ "      \"crouch\": \"" + m_cfg.GetString("controls.keybind.crouch", "Ctrl") + "\",\n"
+										+ "      \"cast\": \"" + m_cfg.GetString("controls.keybind.cast", "R") + "\",\n"
+										+ "      \"interact\": \"" + m_cfg.GetString("controls.keybind.interact", "E") + "\",\n"
+										+ "      \"punch\": \"" + m_cfg.GetString("controls.keybind.punch", "C") + "\"\n"
+										+ "    }\n  }\n}\n";
+									if (!engine::platform::FileSystem::WriteAllText("keybinds.json", kb))
+										LOG_WARN(Core, "[Options] keybinds.json non ecrit (rebind non persiste)");
+								}
 								m_rebindingAction = 0;
 								break;
 							}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -270,7 +270,7 @@ namespace engine
 				case engine::Engine::AvatarLocomotionState::CrouchIdle:   return "CrouchIdle";
 				case engine::Engine::AvatarLocomotionState::CrouchWalk:   return "CrouchWalk";
 				case engine::Engine::AvatarLocomotionState::Roll:         return "Roll";
-				case engine::Engine::AvatarLocomotionState::Dance:        return "Dance";
+				case engine::Engine::AvatarLocomotionState::Emote:        return "Emote";
 				case engine::Engine::AvatarLocomotionState::Attack:       return "Attack";
 				case engine::Engine::AvatarLocomotionState::Cast:         return "Cast";
 				case engine::Engine::AvatarLocomotionState::Interact:     return "Interact";
@@ -298,7 +298,7 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::Sprint
 				|| s == engine::Engine::AvatarLocomotionState::CrouchIdle
 				|| s == engine::Engine::AvatarLocomotionState::CrouchWalk
-				|| s == engine::Engine::AvatarLocomotionState::Dance
+				|| s == engine::Engine::AvatarLocomotionState::Emote
 				|| s == engine::Engine::AvatarLocomotionState::Fall;
 		}
 
@@ -1374,23 +1374,40 @@ namespace engine
 				sendAdminAudit("/mail");
 				return true;
 			}
-			// CHAR-MODEL — Emote /dance : pose une requete consommee par la state
-			// machine de locomotion (avatar -> etat Dance, annule au moindre
-			// deplacement/saut). Slash command locale (pas d'aller-retour serveur).
-			if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say)
-				&& (text == "/dance" || text.starts_with("/dance ") || text.starts_with("/dance\t")))
+			// CHAR-MODEL — Emotes par slash command : posent un role d'emote consomme
+			// par la state machine (avatar -> etat Emote, anim en boucle annulee au
+			// moindre deplacement/saut). Locales (pas d'aller-retour serveur). Ajouter
+			// une emote = une ligne dans kEmotes (+ addRole correspondant).
 			{
-				m_danceRequested = true;
-				LOG_INFO(Core, "[Engine] /dance emote requested");
-				engine::net::ChatMessage emoteMsg;
-				emoteMsg.timestampUnixMs = static_cast<uint64_t>(
-					std::chrono::duration_cast<std::chrono::milliseconds>(
-						std::chrono::system_clock::now().time_since_epoch()).count());
-				emoteMsg.channel = engine::net::ChatChannel::Server;
-				emoteMsg.sender  = "[Emote]";
-				emoteMsg.text    = "Vous dansez.";
-				m_chatUi.PushNetworkLine(emoteMsg);
-				return true;
+				struct EmoteCmd { const char* cmd; const char* role; const char* feedback; };
+				static const EmoteCmd kEmotes[] = {
+					{ "/dance", "Dance", "Vous dansez." },
+					{ "/sit",   "Sit",   "Vous vous asseyez." },
+					{ "/assis", "Sit",   "Vous vous asseyez." },
+					{ "/talk",  "Talk",  "Vous discutez." },
+					{ "/torch", "Torch", "Vous brandissez une torche." },
+				};
+				if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say))
+				{
+					for (const auto& em : kEmotes)
+					{
+						const std::string c = em.cmd;
+						if (text == c || text.starts_with(c + " ") || text.starts_with(c + "\t"))
+						{
+							m_pendingEmoteRole = em.role;
+							LOG_INFO(Core, "[Engine] emote {} (role {}) requested", em.cmd, em.role);
+							engine::net::ChatMessage emoteMsg;
+							emoteMsg.timestampUnixMs = static_cast<uint64_t>(
+								std::chrono::duration_cast<std::chrono::milliseconds>(
+									std::chrono::system_clock::now().time_since_epoch()).count());
+							emoteMsg.channel = engine::net::ChatChannel::Server;
+							emoteMsg.sender  = "[Emote]";
+							emoteMsg.text    = em.feedback;
+							m_chatUi.PushNetworkLine(emoteMsg);
+							return true;
+						}
+					}
+				}
 			}
 			// CMANGOS.23 (Phase 5.23 step 3+4) — Slash command /quest et /quests
 			// pour ouvrir/fermer le panneau quete et synchroniser la liste depuis
@@ -4099,6 +4116,9 @@ namespace engine
 															addRole("CrouchWalk", "Crouch_Fwd_Loop");
 															addRole("Roll", "Roll");
 															addRole("Dance", "Dance_Loop");
+															addRole("Sit", "Sitting_Idle_Loop");
+															addRole("Talk", "Idle_Talking_Loop");
+															addRole("Torch", "Idle_Torch_Loop");
 															addRole("Attack", "Sword_Attack");
 															addRole("Cast", "Spell_Simple_Shoot");
 															addRole("Interact", "Interact");
@@ -7136,9 +7156,9 @@ namespace engine
 							dodgePressed = true;
 						m_lastCtrlTapSec = nowSec;
 					}
-					// Emote /dance : requete posee par la commande chat, consommee ici.
-					const bool danceRequested = m_danceRequested;
-					m_danceRequested = false;
+					// Emote demandee par slash command, consommee ici (vide = aucune).
+					const std::string emoteRole = m_pendingEmoteRole;
+					m_pendingEmoteRole.clear();
 
 					AvatarLocomotionState newState = m_avatarLocoState;
 					if (grounded)
@@ -7226,7 +7246,7 @@ namespace engine
 									else                          newState = AvatarLocomotionState::Walk;
 								}
 								break;
-							case AvatarLocomotionState::Dance:
+							case AvatarLocomotionState::Emote:
 								// Emote en boucle : interrompue par tout mouvement / saut.
 								if (moving || movingBack || moveInput.jumpPressed)
 								{
@@ -7280,7 +7300,7 @@ namespace engine
 						// (sauf amorce de saut, ou Roll/Dance/Attack en cours). CrouchWalk si deplacement.
 						if (moveInput.crouch && newState != AvatarLocomotionState::Jump
 							&& newState != AvatarLocomotionState::Roll
-							&& newState != AvatarLocomotionState::Dance
+							&& newState != AvatarLocomotionState::Emote
 							&& newState != AvatarLocomotionState::Attack
 							&& newState != AvatarLocomotionState::Cast
 							&& newState != AvatarLocomotionState::Interact)
@@ -7290,10 +7310,13 @@ namespace engine
 						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll)
 							newState = AvatarLocomotionState::Roll;
 
-						// Emote /dance : uniquement a l'arret (immobile, sans saut ni roll en cours).
-						if (danceRequested && !moving && !movingBack && !moveInput.jumpPressed
+						// Emote (slash) : uniquement a l'arret (immobile, sans saut ni roll en cours).
+						if (!emoteRole.empty() && !moving && !movingBack && !moveInput.jumpPressed
 							&& m_avatarLocoState != AvatarLocomotionState::Roll)
-							newState = AvatarLocomotionState::Dance;
+						{
+							m_currentEmoteRole = emoteRole;
+							newState = AvatarLocomotionState::Emote;
+						}
 
 						// Attaque melee (clic gauche) : Sword_Attack one-shot. Ne s'enclenche
 						// pas pendant un saut/roll et ne coupe pas un Roll en cours. Prioritaire
@@ -7361,7 +7384,9 @@ namespace engine
 						// introuvable (asset manquant -> FindClip == nullptr), on log un
 						// warn une seule fois et on laisse l'animation precedente continuer
 						// (Sample retombera dessus jusqu'a la prochaine transition reussie).
-						const char* clipName = StateToClipName(newState);
+						const char* clipName = (newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty())
+							? m_currentEmoteRole.c_str()
+							: StateToClipName(newState);
 						const engine::render::skinned::AnimationClip* newClip = m_currentSkinnedMesh->FindClip(clipName);
 						if (newClip)
 						{

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1387,6 +1387,9 @@ namespace engine
 					{ "/assis", "Sit",   "Vous vous asseyez." },
 					{ "/talk",  "Talk",  "Vous discutez." },
 					{ "/torch", "Torch", "Vous brandissez une torche." },
+					{ "/kneel", "Kneel", "Vous vous agenouillez." },
+					{ "/sittalk", "SitTalk", "Vous discutez, assis." },
+					{ "/push", "Push", "Vous poussez." },
 				};
 				if (channel == static_cast<uint8_t>(engine::net::ChatChannel::Say))
 				{
@@ -4120,6 +4123,9 @@ namespace engine
 															addRole("Sit", "Sitting_Idle_Loop");
 															addRole("Talk", "Idle_Talking_Loop");
 															addRole("Torch", "Idle_Torch_Loop");
+															addRole("Kneel", "Fixing_Kneeling");
+															addRole("SitTalk", "Sitting_Talking_Loop");
+															addRole("Push", "Push_Loop");
 															addRole("Attack", "Sword_Attack");
 															addRole("Cast", "Spell_Simple_Shoot");
 															addRole("Interact", "Interact");

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7356,7 +7356,15 @@ namespace engine
 
 						// Esquive/roulade (double-appui Crouch) : Roll one-shot, prioritaire sur crouch.
 						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll)
+						{
 							newState = AvatarLocomotionState::Roll;
+							// Impulsion d'esquive : direction = mouvement si actif, sinon l'avant camera.
+							// Le CharacterController force la vitesse horizontale pendant dodgeDurationSec.
+							engine::math::Vec3 dodgeDir = moveInput.moveDirXZ;
+							if (dodgeDir.x * dodgeDir.x + dodgeDir.z * dodgeDir.z < 1e-6f)
+								dodgeDir = m_orbitalCameraController.GetForwardXZ();
+							m_characterController.ApplyDodgeImpulse(dodgeDir);
+						}
 
 						// Emote (slash) : uniquement a l'arret (immobile, sans saut ni roll en cours).
 						if (!emoteRole.empty() && !moving && !movingBack && !moveInput.jumpPressed

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -586,6 +586,7 @@ namespace engine
 			Attack,
 			Cast,
 			Interact,
+			Punch,
 			Jump,
 			Fall,
 			Land

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -582,7 +582,7 @@ namespace engine
 			CrouchIdle,
 			CrouchWalk,
 			Roll,
-			Dance,
+			Emote,
 			Attack,
 			Cast,
 			Interact,
@@ -595,9 +595,11 @@ namespace engine
 		/// Instant (s, EngineNowSec) du dernier appui sur Ctrl — détection du
 		/// double-tap pour déclencher la roulade/esquive (Roll). -10 = jamais.
 		float                                                    m_lastCtrlTapSec = -10.0f;
-		/// Emote danse demandée (commande chat /dance) — consommée par la state
-		/// machine de locomotion pour passer en état Dance (annulée au déplacement).
-		bool                                                     m_danceRequested = false;
+		/// Emote en cours de demande (slash command), consommée par la state machine
+		/// de locomotion : passe l'avatar en état Emote (anim en boucle, annulée au
+		/// déplacement). m_currentEmoteRole = rôle d'anim actif (clip joué en Emote).
+		std::string                                              m_pendingEmoteRole;
+		std::string                                              m_currentEmoteRole;
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -589,7 +589,9 @@ namespace engine
 			Punch,
 			Jump,
 			Fall,
-			Land
+			Land,
+			SwimIdle,
+			SwimForward
 		};
 	private:
 		AvatarLocomotionState                                     m_avatarLocoState = AvatarLocomotionState::Idle;
@@ -610,6 +612,19 @@ namespace engine
 		/// sans changer d'etat). Garde-fou 3s dans le case Cast => jamais bloque.
 		int                                                      m_castPhase = 0;
 		std::string                                              m_avatarPendingClipRole;
+		/// Interaction (touche E) v1 : entites interactibles (objets / PNJ). Cibles
+		/// de TEST invisibles (pas de rendu/dialogue avance) -> a remplacer par de
+		/// vraies entites. m_interactableInRange = index a portee (-1 = aucun).
+		struct InteractableEntity
+		{
+			engine::math::Vec3 position{};
+			float radius = 2.5f;
+			bool isNpc = false;
+			std::string label;
+			std::string message;
+		};
+		std::vector<InteractableEntity> m_interactables;
+		int m_interactableInRange = -1;
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -605,6 +605,11 @@ namespace engine
 		/// et bascule Jab<->Cross a chaque coup. Clip dynamique (cf. point de lecture).
 		std::string                                              m_currentPunchRole = "Punch";
 		bool                                                     m_punchAlt = false;
+		/// Sequence de sort : phase (0=Enter,1=Shoot,2=Exit) + clip a rejouer en
+		/// cours d'etat (vide=aucun ; consomme 1 fois par la SM, rejoue un one-shot
+		/// sans changer d'etat). Garde-fou 3s dans le case Cast => jamais bloque.
+		int                                                      m_castPhase = 0;
+		std::string                                              m_avatarPendingClipRole;
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -585,6 +585,7 @@ namespace engine
 			Dance,
 			Attack,
 			Cast,
+			Interact,
 			Jump,
 			Fall,
 			Land

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -597,6 +597,10 @@ namespace engine
 		/// Emote danse demandée (commande chat /dance) — consommée par la state
 		/// machine de locomotion pour passer en état Dance (annulée au déplacement).
 		bool                                                     m_danceRequested = false;
+		/// Action en cours de remappage dans le panneau Options (capture clavier) :
+		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
+		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).
+		int                                                      m_rebindingAction = 0;
 		/// Instant d'entrée dans l'état courant. Utilisé pour :
 		///   - détecter la fin de StartWalking / Jump / Land (durée écoulée >= clip.duration).
 		///   - tracer la transition Jump -> Fall après 40% du clip Jump (takeoff).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -601,6 +601,10 @@ namespace engine
 		/// déplacement). m_currentEmoteRole = rôle d'anim actif (clip joué en Emote).
 		std::string                                              m_pendingEmoteRole;
 		std::string                                              m_currentEmoteRole;
+		/// Combo coups de poing : role d'anim du poing en cours (Punch=Jab / PunchCross)
+		/// et bascule Jab<->Cross a chaque coup. Clip dynamique (cf. point de lecture).
+		std::string                                              m_currentPunchRole = "Punch";
+		bool                                                     m_punchAlt = false;
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -66,6 +66,17 @@ namespace engine::gameplay
 		return true;
 	}
 
+	void CharacterController::ApplyDodgeImpulse(const engine::math::Vec3& dirXZ)
+	{
+		const float len = std::sqrt(dirXZ.x * dirXZ.x + dirXZ.z * dirXZ.z);
+		if (len < 1e-4f)
+			return;
+		m_dodgeDirXZ = engine::math::Vec3(dirXZ.x / len, 0.0f, dirXZ.z / len);
+		m_dodgeTimeRemaining = m_cfg.dodgeDurationSec;
+		m_velocity.x = m_dodgeDirXZ.x * m_cfg.dodgeSpeed;
+		m_velocity.z = m_dodgeDirXZ.z * m_cfg.dodgeSpeed;
+	}
+
 	bool CharacterController::Update(float dt, const MoveInput& input, const IWorldCollider& world)
 	{
 		if (dt <= 0.0f)
@@ -131,9 +142,16 @@ namespace engine::gameplay
 		if (hasMove)
 			desiredVelXZ = desiredMoveXZ * (targetSpeed / moveLen);
 
-		// Horizontal acceleration or friction.
+		// Horizontal acceleration or friction. Exception : pendant une esquive
+		// (m_dodgeTimeRemaining > 0), la vitesse horizontale est forcee a
+		// l'impulsion d'esquive ; collision (sweep) et gravite restent appliquees.
 		engine::math::Vec3 velXZ = Vec3XZ(m_velocity);
-		if (hasMove)
+		if (m_dodgeTimeRemaining > 0.0f && !inWater && !isFlying)
+		{
+			m_dodgeTimeRemaining -= dt;
+			velXZ = m_dodgeDirXZ * m_cfg.dodgeSpeed;
+		}
+		else if (hasMove)
 		{
 			const engine::math::Vec3 delta = desiredVelXZ - velXZ;
 			const float deltaLen = delta.Length();

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -128,6 +128,9 @@ namespace engine::gameplay
 		bool Update(float dt, const MoveInput& input, const IWorldCollider& world);
 
 		bool IsGrounded() const { return m_isGrounded; }
+		/// True quand le controller est en mode nage (immersion detectee par
+		/// IWorldCollider::QueryWater). Consomme par la state machine d'anim.
+		bool IsInWater() const { return m_mode == MovementMode::Water; }
 		engine::math::Vec3 GetPosition() const { return m_positionCenter; }
 		engine::math::Vec3 GetVelocity() const { return m_velocity; }
 		IWorldCollider::Capsule GetCapsule() const { return m_capsule; }

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -95,6 +95,12 @@ namespace engine::gameplay
 			float coyoteTimeSec = 0.1f;   ///< allow jump shortly after leaving ground
 			float jumpBufferSec = 0.1f;   ///< allow jump shortly before landing
 
+			// Esquive / roulade (dodge). Impulsion horizontale appliquee au passage
+			// en etat Roll (cf. Engine SM). I-frames d'invincibilite differees au
+			// systeme de combat reel (cote serveur).
+			float dodgeSpeed = 11.0f;       ///< m/s, vitesse de l'impulsion d'esquive
+			float dodgeDurationSec = 0.45f; ///< duree de l'impulsion (~ duree du clip Roll)
+
 			// Swimming parameters.
 			float waterGravityMultiplier = 0.3f; ///< reduced gravity factor while submerged
 			float waterHorizontalDamping = 6.0f; ///< horizontal velocity damping (1/s)
@@ -125,6 +131,13 @@ namespace engine::gameplay
 		engine::math::Vec3 GetPosition() const { return m_positionCenter; }
 		engine::math::Vec3 GetVelocity() const { return m_velocity; }
 		IWorldCollider::Capsule GetCapsule() const { return m_capsule; }
+
+		/// Declenche une impulsion d'esquive (roulade) dans la direction XZ donnee.
+		/// Pendant `dodgeDurationSec`, la vitesse horizontale est forcee a
+		/// `dodgeSpeed` dans cette direction ; collision (sweep) et gravite restent
+		/// appliquees (on peut rouler dans un mur / au bord d'une falaise). Sans
+		/// effet si `dirXZ` est ~nul. Appele par l'Engine au passage en etat Roll.
+		void ApplyDodgeImpulse(const engine::math::Vec3& dirXZ);
 
 	private:
 		static float DotXZ(const engine::math::Vec3& a, const engine::math::Vec3& b)
@@ -169,6 +182,10 @@ namespace engine::gameplay
 		bool m_isGrounded = false;
 		float m_timeSinceLeftGroundSec = 0.0f;
 		float m_timeSinceJumpPressedSec = 999.0f; // invalid until jumpPressed occurs
+		// Esquive en cours : temps restant (s) et direction XZ normalisee. Tant que
+		// m_dodgeTimeRemaining > 0, la vitesse horizontale est forcee (cf. Update).
+		float m_dodgeTimeRemaining = 0.0f;
+		engine::math::Vec3 m_dodgeDirXZ{ 0.0f, 0.0f, 0.0f };
 	};
 }
 

--- a/src/client/gameplay/TerrainCollider.cpp
+++ b/src/client/gameplay/TerrainCollider.cpp
@@ -1,8 +1,10 @@
 #include "src/client/gameplay/TerrainCollider.h"
 #include "src/client/render/terrain/TerrainRenderer.h"
+#include "src/client/world/water/WaterSurfaces.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 namespace engine::gameplay
 {
@@ -96,6 +98,54 @@ bool TerrainCollider::SweepCapsule(const Capsule& capsule,
     }
 
     return outHit.hit;
+}
+
+/// Nage : detecte l'immersion a `worldCenter` (centre capsule ~ hauteur du
+/// bassin). Parcourt les lacs de la scene d'eau et fait un point-in-polygon
+/// (ray-casting) dans le plan XZ ; retient la surface la plus haute couvrant
+/// (x,z). `inWater` ssi la surface depasse le centre (eau au-dessus du bassin).
+bool TerrainCollider::QueryWater(const engine::math::Vec3& worldCenter, WaterQuery& out) const
+{
+    out = WaterQuery{};
+    if (m_water == nullptr)
+        return false;
+
+    const float px = worldCenter.x;
+    const float pz = worldCenter.z;
+    bool found = false;
+    float bestSurfaceY = 0.0f;
+
+    for (const auto& lake : m_water->lakes)
+    {
+        const std::vector<engine::math::Vec3>& poly = lake.polygon;
+        const std::size_t n = poly.size();
+        if (n < 3)
+            continue;
+        bool inside = false;
+        for (std::size_t i = 0, j = n - 1; i < n; j = i++)
+        {
+            const float zi = poly[i].z, zj = poly[j].z;
+            if ((zi > pz) != (zj > pz))
+            {
+                const float xCross = (poly[j].x - poly[i].x) * (pz - zi) / (zj - zi) + poly[i].x;
+                if (px < xCross)
+                    inside = !inside;
+            }
+        }
+        if (inside && (!found || lake.waterLevelY > bestSurfaceY))
+        {
+            found = true;
+            bestSurfaceY = lake.waterLevelY;
+        }
+    }
+
+    if (!found)
+        return false;
+
+    out.surfaceY = bestSurfaceY;
+    out.depth    = bestSurfaceY - worldCenter.y;  // > 0 si centre (bassin) immerge
+    out.inWater  = out.depth > 0.0f;
+    return out.inWater;
 }
 
 }  // namespace engine::gameplay

--- a/src/client/gameplay/TerrainCollider.h
+++ b/src/client/gameplay/TerrainCollider.h
@@ -7,6 +7,11 @@ namespace engine::render::terrain
     class TerrainRenderer;  // forward
 }
 
+namespace engine::world::water
+{
+    struct WaterScene;  // forward (nage : QueryWater)
+}
+
 namespace engine::gameplay
 {
 
@@ -51,10 +56,21 @@ public:
     /// terrain n'est bind.
     float GroundHeightAt(float worldX, float worldZ) const;
 
+    /// Bind la scene d'eau (non-owning) pour la nage. nullptr = pas d'eau.
+    void BindWater(const engine::world::water::WaterScene* water) { m_water = water; }
+
+    /// IWorldCollider : detecte l'immersion a `worldCenter` (centre capsule ~
+    /// hauteur du bassin). Parcourt les lacs de la scene d'eau (point-in-polygon
+    /// XZ) ; si le centre est sous la surface d'un lac -> `inWater=true`,
+    /// `surfaceY`/`depth` renseignes. Sans scene -> `inWater=false`.
+    bool QueryWater(const engine::math::Vec3& worldCenter, WaterQuery& out) const override;
+
 private:
     /// Non-owning. Lifetime garanti par l'appelant (le terrain vit aussi
     /// longtemps que le collider qui s'y refere).
     const engine::render::terrain::TerrainRenderer* m_terrain = nullptr;
+    /// Non-owning. Scene d'eau pour QueryWater (nage). nullptr = pas d'eau.
+    const engine::world::water::WaterScene* m_water = nullptr;
 };
 
 }  // namespace engine::gameplay


### PR DESCRIPTION
## Résumé

Deux choses liées, **regroupées dans une seule PR** (consigne « minimum de PR ») :

### 1. Touches d'action remappables depuis le menu Options (§34)
- **Sprint** (déf. `Alt`), **Accroupi** (déf. `Ctrl`), **Sort** (déf. `R`) lus depuis `controls.keybind.*` et **remappables in-game** via une section « Controles » du panneau Options (clic « Modifier » → appuie une touche → enregistré ; Échap annule).
- **Roulade** = double-appui sur la touche Accroupi (suit le rebind) ; **Attaque** = clic gauche → affichées en info (non remappables en v1).
- **Gameplay suspendu** quand le panneau Options est ouvert (la touche capturée ne déclenche pas l'action).
- `Key`↔nom local à `Engine.cpp` (`kRebindableKeys`) — pas de modif de l'API `Input`. Touches dispo : A-Z (sauf I/J/K/T), 0-9, Ctrl/Alt/Shift/Espace/Tab.

### 2. Action « interagir » sur la touche E (§35)
- Donne enfin un usage à **E** (réservée au §32) : geste **`Interact` one-shot** (même pattern qu'attaque/sort), **remappable** lui aussi (`controls.keybind.interact`, déf. `E`, 4ᵉ ligne « Interagir » dans Options).
- **Priorité** : `Roll > Attack > Cast > Interact > Dance > Crouch > Sprint > Run > Walk`.
- **Cosmétique pour l'instant** : c'est l'animation de base ; la vraie interaction (cible/PNJ/objet/loot) reste à construire.

## Test plan
- [ ] Build Windows/Linux (CI) sans erreur.
- [ ] Options → « Controles » : « Modifier » sur Sprint/Accroupi/Sort/Interagir → la touche change ; l'action répond à la nouvelle touche, plus à l'ancienne.
- [ ] **E** → joue le geste d'interaction (une fois), puis retour locomotion.
- [ ] Roulade = double-appui sur la (nouvelle) touche Accroupi.
- [ ] Pendant la capture d'un rebind, la touche pressée ne déclenche pas l'action ; Échap annule.

## Limites connues
- **Persistance session-only** (live config, non re-sérialisée dans `user_settings.json`, comme volume/sensibilité de ce panneau). Défaut persistant = éditer `config.json`.
- **Pas de détection de conflit** entre deux actions sur la même touche.
- **Interagir = cosmétique** (pas de cible/objet) ; **attaque (souris)** non remappable en v1.
- **Rendu non vérifié visuellement** (ImGui Windows-only) → validation au build par toi.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (input + config + UI + anim locales ; aucun opcode, handler ni migration).