### PR TITLE
feat(content): interactibles pilotés par config + pipeline eau réel

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1747,3 +1747,12 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 - Un vrai `instances/water.bin` par zone (level-design) pour de l'eau realiste.
 - Des meshes/rendu pour les interactibles (PNJ/objets visibles) + arbres de dialogue.
 - Des meshes d'armes (`models/equipment/weapons/*` vides) pour l'equipement / arme visible.
+
+## 41. Dialogue PNJ + marqueurs ImGui des interactibles (2026-05-22)
+
+Complète §39/§40 (interaction E) côté **dialogue** et **visibilité**.
+
+- **Dialogue multi-lignes** : `InteractableEntity.dialogue` (vector) + `dialogueCursor`. En config : `world.interactables.i.dialogue.count` + `.dialogue.j`. Sur E, un PNJ avec dialogue affiche la **ligne suivante** (boucle) ; sinon `message`. (Objets : `message`.) Exemple livré pour le Villageois (config.json).
+- **Marqueurs ImGui** (`#if _WIN32`) : chaque interactible affiche un **label flottant projeté** à l'écran (`WorldToScreenPx`, formule alignée sur `WorldEditorImGui::WorldToScreen`, viewProj col-major). Surligné + « [E] » à portée. Donne la **visibilité** sans passe de rendu de mesh (les vrais props/PNJ visibles = backlog).
+
+Backlog complet des tâches restantes (polish, contenu, serveur) : **`docs/BACKLOG_gameplay.md`**.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1756,3 +1756,8 @@ Complète §39/§40 (interaction E) côté **dialogue** et **visibilité**.
 - **Marqueurs ImGui** (`#if _WIN32`) : chaque interactible affiche un **label flottant projeté** à l'écran (`WorldToScreenPx`, formule alignée sur `WorldEditorImGui::WorldToScreen`, viewProj col-major). Surligné + « [E] » à portée. Donne la **visibilité** sans passe de rendu de mesh (les vrais props/PNJ visibles = backlog).
 
 Backlog complet des tâches restantes (polish, contenu, serveur) : **`docs/BACKLOG_gameplay.md`**.
+
+## 42. Nage — complétion : contrôle vertical + rivières (2026-05-22)
+
+- **Contrôle vertical** : `BuildMoveInput` pose `swimUpPressed`=Espace, `swimDownPressed`=touche Crouch. Le `CharacterController` ne les consomme qu'en mode `Water` (monter/descendre en nage) ; hors eau, Espace=saut / Crouch=accroupi inchangés.
+- **Rivières dans `QueryWater`** : en plus des lacs (point-in-polygon), on teste chaque segment `[a,b]` des rivières (distance XZ au segment ≤ demi-largeur interpolée → immersion ; surface = Y interpolé le long du segment). Couvre lacs **et** rivières (océan = lac `isOcean`).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1761,3 +1761,15 @@ Backlog complet des tâches restantes (polish, contenu, serveur) : **`docs/BACKL
 
 - **Contrôle vertical** : `BuildMoveInput` pose `swimUpPressed`=Espace, `swimDownPressed`=touche Crouch. Le `CharacterController` ne les consomme qu'en mode `Water` (monter/descendre en nage) ; hors eau, Espace=saut / Crouch=accroupi inchangés.
 - **Rivières dans `QueryWater`** : en plus des lacs (point-in-polygon), on teste chaque segment `[a,b]` des rivières (distance XZ au segment ≤ demi-largeur interpolée → immersion ; surface = Y interpolé le long du segment). Couvre lacs **et** rivières (océan = lac `isOcean`).
+
+## 43. Modèle féminin — cosmétique client v1 (#2) (2026-05-22)
+
+**Objectif** : rendre le **modèle féminin** sélectionnable/affiché côté client, sans serveur (les meshes `Female_Ranger`/`Female_Peasant` existaient mais n'étaient pas câblés ; `races.json` ne pointe que `Male_Ranger`).
+
+- **Genre** : `client.character_creation.gender` = `"male"` (défaut) | `"female"`. Au chargement de l'avatar, si `female`, on **dérive** le chemin `Male_` → `Female_` (humains : `Male_Ranger/Male_Ranger.glb` → `Female_Ranger/Female_Ranger.glb`, présent). Races sans variante (`orcs`/`nains`, pas de `Male_` dans le chemin) → mesh par défaut inchangé.
+- **Cosmétique / client uniquement** : choix lu en config, **non persisté** (relog = retour au défaut) et **non envoyé au serveur**. Aucun redéploiement.
+
+### Reste (étape 2, cf. backlog #2)
+- **Sélecteur de genre dans l'UI** de création de perso (ImGui) — au lieu de la config.
+- **Persistance serveur** : genre stocké en DB (migration) + payload → redéploiement master/shard, visible des autres joueurs.
+- **Textures** (#5) : les modèles (M/F) rendent en matériau fallback tant que les textures ne sont pas placées/converties (assets).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1731,3 +1731,19 @@ Reste de l'étape 2 : Roll/esquive → emote `/dance`.
 ### Limites connues
 - **Cibles invisibles** (pas de rendu de props/PNJ) → découvrables seulement via le hint chat. À remplacer par de vraies entités avec **meshes** + **dialogues** (arbre de dialogue, loot, etc.).
 - **Dialogue mono-ligne** (pas d'arbre). Pas de portée/raycast visée (proximité simple).
+
+## 40. Outillage contenu : interactibles en config + pipeline eau reel (2026-05-22)
+
+**Objectif** : transformer les v1 « test » (§38 nage, §39 interagir) en systemes **pilotes par donnees**, prets pour du vrai contenu — sans rien casser (replis conserves).
+
+### Interactibles data-driven
+- Declares en config sous `world.interactables` : `count` + par index `i` les cles `world.interactables.i.{x,z,radius,npc,label,message}` (objet JSON a cles numerotees -> aplati par `Config`, pas de parseur de tableau). Lus au world-init dans `m_interactables`.
+- **Repli** : si `count<=0` (ou section absente), 2 cibles de TEST pres du spawn (Villageois + Coffre). `config.json` livre ces 2 par defaut (authorables / extensibles).
+
+### Pipeline eau reel
+- Au world-init, `m_streamCache.LoadWater(cfg, "")` tente de charger `instances/water.bin` (vrai contenu eau). Si present -> `m_clientWaterScene` = eau reelle. **Sinon** repli sur l'eau-test procedurale (§38). Dans les deux cas `BindWater` branche la scene sur le collider (nage).
+
+### Reste a fournir (contenu / assets, hors code)
+- Un vrai `instances/water.bin` par zone (level-design) pour de l'eau realiste.
+- Des meshes/rendu pour les interactibles (PNJ/objets visibles) + arbres de dialogue.
+- Des meshes d'armes (`models/equipment/weapons/*` vides) pour l'equipement / arme visible.

--- a/config.json
+++ b/config.json
@@ -141,6 +141,20 @@
     },
     "world": {
         "max_draw_distance_m": 0.0,
+        "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet). Cibles de TEST pres du spawn par defaut.",
+        "interactables": {
+            "count": 2,
+            "0": { "x": 4.0, "z": 0.0, "radius": 2.5, "npc": true, "label": "Villageois", "message": "Villageois : Bienvenue ! L'eau de test est a l'est." },
+            "1": { "x": -4.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Coffre", "message": "Vous fouillez le coffre... vide pour l'instant." }
+        },
+        "_comment_test_water": "Nage : bassin de TEST procedural (la zone demo n'a pas d'eau). enabled=false pour le retirer. Ignore si un instances/water.bin reel est charge.",
+        "test_water": {
+            "enabled": true,
+            "center_x": 25.0,
+            "center_z": 0.0,
+            "half_size_m": 15.0,
+            "depth_m": 2.5
+        },
         "default_spawn": {
             "_comment": "Position de la caméra (m) au moment du clic Jouer (Phase 3.5). Y > 0 = au-dessus du terrain. Sera surchargée par characters.spawn_x/y/z une fois la migration en place.",
             "x": 0.0,

--- a/config.json
+++ b/config.json
@@ -144,7 +144,7 @@
         "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet). Cibles de TEST pres du spawn par defaut.",
         "interactables": {
             "count": 2,
-            "0": { "x": 4.0, "z": 0.0, "radius": 2.5, "npc": true, "label": "Villageois", "message": "Villageois : Bienvenue ! L'eau de test est a l'est." },
+            "0": { "x": 4.0, "z": 0.0, "radius": 2.5, "npc": true, "label": "Villageois", "message": "Villageois : Bonjour !", "dialogue": { "count": 3, "0": "Bonjour, aventurier ! Bienvenue par ici.", "1": "Le bassin de test est a l'est, si tu veux nager.", "2": "Reviens me voir quand tu veux." } },
             "1": { "x": -4.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Coffre", "message": "Vous fouillez le coffre... vide pour l'instant." }
         },
         "_comment_test_water": "Nage : bassin de TEST procedural (la zone demo n'a pas d'eau). enabled=false pour le retirer. Ignore si un instances/water.bin reel est charge.",

--- a/config.json
+++ b/config.json
@@ -204,7 +204,9 @@
         "allow_insecure_dev": true,
         "locale": "",
         "character_creation": {
-            "default_server_id": 1
+            "default_server_id": 1,
+            "_comment_gender": "Modele feminin (cosmetique client v1) : 'male' ou 'female'. Si 'female', l'avatar derive le mesh Male_ -> Female_ (humains : Female_Ranger). Non persiste (relog = retour defaut) ; persistance serveur = etape 2.",
+            "gender": "male"
         },
         "auth_ui": {
             "enabled": true,

--- a/docs/BACKLOG_gameplay.md
+++ b/docs/BACKLOG_gameplay.md
@@ -1,0 +1,70 @@
+# Backlog gameplay (LCDLLN) — à réaliser plus tard
+
+> Récapitulatif des tâches identifiées au fil du développement (avatar / locomotion /
+> combat / nage / interaction / contenu). Mis à jour le 2026-05-23.
+> Les sections livrées sont dans `CODEBASE_MAP.md` §28→§40.
+
+## A. Polish marginale (code, faible valeur, à valider en jeu)
+
+- **Crouch — réduction de capsule** : aujourd'hui l'anim accroupie joue mais la capsule
+  de collision reste `r=0.3 h=1.8` (pas de passage sous obstacle bas). À ajouter :
+  réduire `m_capsule.height` quand `crouch`, + test « puis-je me relever ? » (sweep à
+  hauteur debout) avant de quitter l'accroupi. **Risque** : fall-through / rester coincé
+  accroupi / jitter du centre — non testable en headless, à faire avec validation en jeu.
+- **Emote `/sit` avec Enter/Idle/Exit** : actuellement les emotes jouent un simple loop.
+  Pour `/sit` (et clips `Sitting_Enter`/`Idle_Loop`/`Exit`), enchaîner s'asseoir → tenir →
+  se relever (au déplacement). Réutiliser le mécanisme de replay de clip en cours d'état
+  (`m_avatarPendingClipRole`, cf. §33), avec une phase « loop » intermédiaire et une
+  sortie déclenchée par le mouvement (pas par un timer).
+- **Combo épée** : enchaînement sur clics rapides (au lieu d'« ignoré pendant l'attaque »).
+  Nécessite un 2ᵉ clip de frappe franc (seul `Sword_Attack_RM`, à root-motion, dispo).
+
+## B. Refinements mouvement / anim
+
+- **Roll — i-frames** : la roulade a son impulsion (§30) mais pas d'invincibilité ;
+  n'a de sens qu'avec un système de dégâts (cf. section serveur).
+- **Nage — contrôle vertical** : `swimUpPressed`/`swimDownPressed` existent dans
+  `CharacterController` mais ne sont pas bindés (monter/descendre en nage).
+- **Nage — rivières** : `QueryWater` (§38) ne gère que les lacs (point-in-polygon).
+  Ajouter les rivières (`RiverInstance`, largeur/profondeur le long du tracé).
+- **Détection de conflit de touches** (Options) : binder 2 actions sur la même touche
+  est permis sans avertissement (§34).
+- **Attaque (souris) remappable** : le clic gauche d'attaque n'est pas remappable (§34).
+
+## C. Contenu / assets (hors code — création par level-design / artiste)
+
+- **Meshes d'armes** : `models/equipment/weapons/{magic,one_handed,ranged,two_handed}`
+  ne contiennent que des `.gitkeep`. Sans mesh d'arme → pas d'« arme visible » possible.
+  Bloque le **système d'équipement** (slots + attache aux os).
+- **Vraie étendue d'eau** par zone : un `instances/water.bin` réaliste (basin creusé)
+  au lieu de l'eau-test procédurale (cf. §38, §40). **L'éditeur monde produit déjà
+  des `water.bin`** (`WaterDocument`/`SaveWaterBin`) — un générateur CLI séparé serait
+  redondant (chaîne de link Log/FileSystem). Reste à AUTHORER une vraie étendue (level-design).
+- **Entités interactibles visibles** : meshes/props pour les PNJ et objets (le rendu
+  3D statique n'existe pas encore côté client — voir §F). Aujourd'hui : marqueurs
+  ImGui + hint chat seulement.
+- **Arbres de dialogue** : le format dialogue livré est mono-/multi-ligne simple ;
+  un vrai système de dialogue (branches, choix, conditions) reste à faire.
+
+## D. Systèmes plus gros (code, à cadrer)
+
+- **Système d'équipement** : slots, attache d'un mesh d'arme à un os (main) du squelette,
+  équiper/déséquiper. Dépend des meshes d'armes (section C).
+- **Système d'interaction complet** : raycast visée (au lieu de proximité simple),
+  prompt UI dédié, loot, déclencheurs d'objets typés, dialogue PNJ branché.
+- **Rendu de props / meshes statiques** : passe de rendu pour afficher des objets non-skinnés
+  (interactibles, décor) à une position monde — n'existe pas (seul l'avatar skinné est rendu).
+
+## E. Dépend du SERVEUR (redéploiement master/shard)
+
+- **Combat réel** : dégâts, cible/ciblage, application des effets ; réactions
+  `Hit_Chest`/`Hit_Head`, mort `Death01`. Nécessite des events serveur.
+- **Sync multijoueur** : que les autres joueurs voient nos états (nage, emotes, attaques,
+  roulade…) — réplication réseau des états d'animation/action.
+
+## F. Notes techniques
+
+- **Persistance Options** : volume / sensibilité du panneau Options in-game restent
+  *session-only* (non sérialisés). Seuls les binds sont persistés (`keybinds.json`, §34/§38… cf. §34).
+- **Validation runtime** : tout le gameplay/anim/physique ci-dessus n'est pas testable en
+  CI (compilation seulement). Chaque item « feel » nécessite un test en jeu (build Windows).

--- a/docs/BACKLOG_gameplay.md
+++ b/docs/BACKLOG_gameplay.md
@@ -23,10 +23,6 @@
 
 - **Roll — i-frames** : la roulade a son impulsion (§30) mais pas d'invincibilité ;
   n'a de sens qu'avec un système de dégâts (cf. section serveur).
-- **Nage — contrôle vertical** : `swimUpPressed`/`swimDownPressed` existent dans
-  `CharacterController` mais ne sont pas bindés (monter/descendre en nage).
-- **Nage — rivières** : `QueryWater` (§38) ne gère que les lacs (point-in-polygon).
-  Ajouter les rivières (`RiverInstance`, largeur/profondeur le long du tracé).
 - **Détection de conflit de touches** (Options) : binder 2 actions sur la même touche
   est permis sans avertissement (§34).
 - **Attaque (souris) remappable** : le clic gauche d'attaque n'est pas remappable (§34).

--- a/docs/BACKLOG_gameplay.md
+++ b/docs/BACKLOG_gameplay.md
@@ -64,3 +64,9 @@
   *session-only* (non sérialisés). Seuls les binds sont persistés (`keybinds.json`, §34/§38… cf. §34).
 - **Validation runtime** : tout le gameplay/anim/physique ci-dessus n'est pas testable en
   CI (compilation seulement). Chaque item « feel » nécessite un test en jeu (build Windows).
+
+## G. Character-customization (chantier d'origine)
+
+- **#2 Modèle féminin** : cosmétique client ✅ (§43, `client.character_creation.gender`). **Reste** : sélecteur UI de genre + **persistance serveur** (DB migration + payload = redéploiement).
+- **#5 Textures** : modèles M/F en matériau fallback (aucune texture sous `models/characters/`). Placer les textures + reconvertir (assets) ; côté code, vérifier les chemins référencés par les `.glb`.
+- **#3 Animations** : ✅ fait et dépassé (§27→§42).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -246,9 +246,11 @@ namespace engine
 			out.sprint      = input.IsDown(sprintKey);
 			out.crouch      = input.IsDown(crouchKey);
 			out.jumpPressed = input.WasPressed(engine::platform::Key::Space);
-			// swim/fly hors-scope B.1 : restent false (consommes par les modes
-			// Water/Fly du CharacterController, inutiles tant que la query eau
-			// n'est pas branchee — IWorldCollider::QueryWater renvoie false).
+			// Nage : contrôle vertical. Espace = remonter, touche Crouch = descendre.
+			// Le CharacterController ne les consomme qu'en mode Water (cf. QueryWater) ;
+			// hors eau, Espace reste le saut et Crouch l'accroupi.
+			out.swimUpPressed   = input.IsDown(engine::platform::Key::Space);
+			out.swimDownPressed = input.IsDown(crouchKey);
 			return out;
 		}
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -175,6 +175,25 @@ namespace engine
 			return fallback;
 		}
 
+		// Projette une position monde -> pixels ecran. Formule alignee sur
+		// WorldEditorImGui::WorldToScreen (viewProj col-major .m, convention Vulkan).
+		// false si derriere la camera ou hors near/far. Sert aux marqueurs interactibles.
+		[[maybe_unused]] bool WorldToScreenPx(const float vp[16], float wx, float wy, float wz,
+			int vw, int vh, float& sx, float& sy)
+		{
+			const float cx = vp[0]*wx + vp[4]*wy + vp[8]*wz + vp[12];
+			const float cy = vp[1]*wx + vp[5]*wy + vp[9]*wz + vp[13];
+			const float cz = vp[2]*wx + vp[6]*wy + vp[10]*wz + vp[14];
+			const float cw = vp[3]*wx + vp[7]*wy + vp[11]*wz + vp[15];
+			if (cw <= 1e-5f) return false;
+			const float invW = 1.0f / cw;
+			const float ndcX = cx * invW, ndcY = cy * invW, ndcZ = cz * invW;
+			if (ndcZ < 0.0f || ndcZ > 1.0f) return false;
+			sx = (ndcX * 0.5f + 0.5f) * static_cast<float>(vw);
+			sy = (ndcY * 0.5f + 0.5f) * static_cast<float>(vh);
+			return true;
+		}
+
 		engine::gameplay::MoveInput BuildMoveInput(
 			const engine::platform::Input& input,
 			const engine::render::OrbitalCameraController& camera,
@@ -4362,6 +4381,9 @@ namespace engine
 												e.isNpc = m_cfg.GetBool(base + "npc", false);
 												e.label = m_cfg.GetString(base + "label", "?");
 												e.message = m_cfg.GetString(base + "message", "");
+												const int dcount = static_cast<int>(m_cfg.GetInt(base + "dialogue.count", 0));
+												for (int dj = 0; dj < dcount; ++dj)
+													e.dialogue.push_back(m_cfg.GetString(base + "dialogue." + std::to_string(dj), ""));
 												m_interactables.push_back(e);
 											}
 											if (m_interactables.empty())
@@ -7606,8 +7628,16 @@ namespace engine
 						}
 						if (interactPressed && nearestI >= 0)
 						{
-							const InteractableEntity& e = m_interactables[nearestI];
-							pushInteractChat(e.isNpc ? "[PNJ]" : "[Objet]", e.message);
+							InteractableEntity& e = m_interactables[nearestI];
+							if (e.isNpc && !e.dialogue.empty())
+							{
+								pushInteractChat("[PNJ]", e.label + " : " + e.dialogue[e.dialogueCursor]);
+								e.dialogueCursor = (e.dialogueCursor + 1) % static_cast<int>(e.dialogue.size());
+							}
+							else
+							{
+								pushInteractChat(e.isNpc ? "[PNJ]" : "[Objet]", e.message);
+							}
 						}
 					}
 				}
@@ -8027,6 +8057,26 @@ namespace engine
 			}
 			// `inWorldShard` = true uniquement post-EnterWorld : ajoute le canal Zone.
 			m_chatImGui->Render(dw, dh, m_authUi.IsInWorldShard());
+			// Marqueurs ImGui des interactibles : label flottant projete (visibilite v1
+			// sans mesh). Surligne + " [E]" si a portee. Cf. m_interactables (#39/#40).
+			{
+				const int ivw = static_cast<int>(dw);
+				const int ivh = static_cast<int>(dh);
+				ImDrawList* fg = ImGui::GetForegroundDrawList();
+				for (std::size_t ii = 0; ii < m_interactables.size(); ++ii)
+				{
+					const InteractableEntity& e = m_interactables[ii];
+					const float my = m_terrainCollider.GroundHeightAt(e.position.x, e.position.z) + 1.9f;
+					float sx = 0.0f, sy = 0.0f;
+					if (!WorldToScreenPx(out.viewProjMatrix.m, e.position.x, my, e.position.z, ivw, ivh, sx, sy))
+						continue;
+					const bool inRange = (static_cast<int>(ii) == m_interactableInRange);
+					const ImU32 col = inRange ? IM_COL32(255, 220, 80, 255) : IM_COL32(210, 210, 210, 200);
+					const std::string txt = e.label + (inRange ? " [E]" : "");
+					const ImVec2 ts = ImGui::CalcTextSize(txt.c_str());
+					fg->AddText(ImVec2(sx - ts.x * 0.5f, sy - ts.y), col, txt.c_str());
+				}
+			}
 			// Menu de panneaux : barre de menus ImGui toujours visible en jeu,
 			// acces souris a tous les panneaux togglables sans raccourci clavier
 			// dedie. Les panneaux gardent par ailleurs leurs touches existantes ;

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4258,6 +4258,10 @@ namespace engine
 
 													// Charge les 3 races MVP. Lookup meshPath via
 													// CharacterCreationPresenter local (Init() vient d'etre appele).
+													// Modele feminin (cosmetique client v1, #2) : si genre feminin, derive le
+													// chemin Male_ -> Female_ (humains : Male_Ranger -> Female_Ranger present).
+													// Sans variante (pas de 'Male_') -> mesh par defaut. NON persiste (serveur=etape 2).
+													const std::string avatarGender = m_cfg.GetString("client.character_creation.gender", "male");
 													for (const char* raceId : kMvpRaces) {
 														const auto& races = racesPresenter.GetRaces();
 														const engine::client::RaceDefinition* def = nullptr;
@@ -4266,7 +4270,17 @@ namespace engine
 															LOG_WARN(Render, "[Engine] Race '{}' : RaceDefinition introuvable ou meshPath vide", raceId);
 															continue;
 														}
-														loadOneRace(raceId, def->meshPath, def->importScale, def->importRotXDeg);
+														std::string meshPath = def->meshPath;
+														if (avatarGender == "female") {
+															std::string fem = meshPath;
+															std::string::size_type gp = 0;
+															while ((gp = fem.find("Male_", gp)) != std::string::npos) { fem.replace(gp, 5, "Female_"); gp += 7; }
+															if (fem != meshPath) {
+																meshPath = fem;
+																LOG_INFO(Render, "[Engine] Race '{}' : variante feminine -> {}", raceId, meshPath);
+															}
+														}
+														loadOneRace(raceId, meshPath, def->importScale, def->importRotXDeg);
 													}
 
 													// Pointe m_currentSkinnedMesh vers le mesh humain par defaut (le

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4316,7 +4316,15 @@ namespace engine
 											// eau ; on pose un BASSIN DE TEST au-dessus du sol pour valider la
 											// mecanique de nage (a remplacer par une vraie etendue d'eau via le
 											// pipeline water.bin / level-design). Desactivable : world.test_water.enabled=false.
-											if (m_cfg.GetBool("world.test_water.enabled", true))
+											// Nage : tenter d'abord une VRAIE eau (instances/water.bin via StreamCache) ;
+											// repli sur l'eau-test procedurale si absente (zone demo plate, sans water.bin).
+											if (auto realWater = m_streamCache.LoadWater(m_cfg, ""))
+											{
+												m_clientWaterScene = realWater;
+												m_waterClientSceneDirty = true;
+												LOG_INFO(Render, "[Nage] water.bin charge ({} lac(s))", static_cast<int>(realWater->lakes.size()));
+											}
+											else if (m_cfg.GetBool("world.test_water.enabled", true))
 											{
 												const float cx = static_cast<float>(m_cfg.GetDouble("world.test_water.center_x", 25.0));
 												const float cz = static_cast<float>(m_cfg.GetDouble("world.test_water.center_z", 0.0));
@@ -4341,9 +4349,22 @@ namespace engine
 												LOG_INFO(Render, "[Nage] Eau-test posee (centre=({:.1f},{:.1f}) half={:.1f} niveauY={:.2f})", cx, cz, half, lvl);
 											}
 											m_terrainCollider.BindWater(m_clientWaterScene.get());
-											// Interaction (v1) : entites interactibles de TEST (invisibles) pour valider
-											// la mecanique objets + dialogue PNJ. A remplacer par de vraies entites.
+											// Interaction : interactibles declares en config (world.interactables.N.*).
+											// Repli sur 2 cibles de TEST pres du spawn si aucun n'est declare.
 											m_interactables.clear();
+											const int icount = static_cast<int>(m_cfg.GetInt("world.interactables.count", 0));
+											for (int ii = 0; ii < icount; ++ii)
+											{
+												const std::string base = "world.interactables." + std::to_string(ii) + ".";
+												InteractableEntity e;
+												e.position = engine::math::Vec3{ static_cast<float>(m_cfg.GetDouble(base + "x", 0.0)), 0.0f, static_cast<float>(m_cfg.GetDouble(base + "z", 0.0)) };
+												e.radius = static_cast<float>(m_cfg.GetDouble(base + "radius", 2.5));
+												e.isNpc = m_cfg.GetBool(base + "npc", false);
+												e.label = m_cfg.GetString(base + "label", "?");
+												e.message = m_cfg.GetString(base + "message", "");
+												m_interactables.push_back(e);
+											}
+											if (m_interactables.empty())
 											{
 												InteractableEntity npc;
 												npc.position = engine::math::Vec3{ 4.0f, 0.0f, 0.0f };

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -622,6 +622,10 @@ namespace engine
 			bool isNpc = false;
 			std::string label;
 			std::string message;
+			/// Dialogue PNJ multi-lignes (optionnel). Si non vide, chaque appui sur E
+			/// affiche la ligne suivante (boucle). Sinon on affiche `message`.
+			std::vector<std::string> dialogue;
+			int dialogueCursor = 0;
 		};
 		std::vector<InteractableEntity> m_interactables;
 		int m_interactableInRange = -1;

--- a/src/client/gameplay/TerrainCollider.cpp
+++ b/src/client/gameplay/TerrainCollider.cpp
@@ -139,6 +139,38 @@ bool TerrainCollider::QueryWater(const engine::math::Vec3& worldCenter, WaterQue
         }
     }
 
+    // Rivieres : pour chaque segment [a,b], distance XZ du point au segment ;
+    // si <= demi-largeur (interpolee), on est dans la riviere. Surface = Y
+    // interpole le long du segment (le node.position.y porte la surface).
+    for (const auto& river : m_water->rivers)
+    {
+        const std::vector<engine::world::water::RiverNode>& nodes = river.nodes;
+        for (std::size_t i = 0; i + 1 < nodes.size(); ++i)
+        {
+            const engine::math::Vec3& a = nodes[i].position;
+            const engine::math::Vec3& b = nodes[i + 1].position;
+            const float abx = b.x - a.x, abz = b.z - a.z;
+            const float abLen2 = abx * abx + abz * abz;
+            float t = 0.0f;
+            if (abLen2 > 1e-6f)
+                t = std::clamp(((px - a.x) * abx + (pz - a.z) * abz) / abLen2, 0.0f, 1.0f);
+            const float closeX = a.x + t * abx;
+            const float closeZ = a.z + t * abz;
+            const float dx = px - closeX, dz = pz - closeZ;
+            const float d2 = dx * dx + dz * dz;
+            const float halfW = (nodes[i].widthMeters + t * (nodes[i + 1].widthMeters - nodes[i].widthMeters)) * 0.5f;
+            if (d2 <= halfW * halfW)
+            {
+                const float surfaceY = a.y + t * (b.y - a.y);
+                if (!found || surfaceY > bestSurfaceY)
+                {
+                    found = true;
+                    bestSurfaceY = surfaceY;
+                }
+            }
+        }
+    }
+
     if (!found)
         return false;
 


### PR DESCRIPTION
## Résumé

Suite du travail post-merge #667 : transformer les v1 « test » (nage, interagir) en **systèmes pilotés par données**, prêts pour du vrai contenu — sans rien casser (replis conservés). **Validé en compilation locale** (`g++ -fsyntax-only`, 0 erreur).

### Interactibles pilotés par config (§40)
- Déclarés sous `world.interactables` : `count` + par index `world.interactables.i.{x,z,radius,npc,label,message}` (objet JSON à clés numérotées → aplati par `Config`, pas de parseur de tableau).
- **Repli** : 2 cibles de TEST près du spawn si rien n'est déclaré. `config.json` en livre 2 par défaut (authorables/extensibles).

### Pipeline eau réel (§40)
- Au world-init, `m_streamCache.LoadWater()` tente de charger un vrai `instances/water.bin` → eau réelle ; **sinon** repli sur l'eau-test procédurale (#667). `BindWater` branche la scène sur le collider dans les deux cas.

## Test plan
- [ ] Build Windows/Linux (CI) sans erreur.
- [ ] En jeu : interactibles toujours présents (config par défaut) — approche + E → dialogue/effet.
- [ ] Éditer `config.json` `world.interactables` → les cibles changent.
- [ ] Nage : sans `water.bin`, l'eau-test fonctionne comme avant.

## Reste (contenu/assets, hors code)
- Un vrai `water.bin` par zone (level-design).
- Meshes/rendu pour PNJ/objets + arbres de dialogue.
- Meshes d'armes (`models/equipment/weapons/*` vides) pour l'équipement.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (config + data + gameplay local ; aucun opcode/handler/migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_