### PR TITLE
feat(controls): avertissement de conflit de touches (Options)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1773,3 +1773,7 @@ Backlog complet des tâches restantes (polish, contenu, serveur) : **`docs/BACKL
 - **Sélecteur de genre dans l'UI** de création de perso (ImGui) — au lieu de la config.
 - **Persistance serveur** : genre stocké en DB (migration) + payload → redéploiement master/shard, visible des autres joueurs.
 - **Textures** (#5) : les modèles (M/F) rendent en matériau fallback tant que les textures ne sont pas placées/converties (assets).
+
+## 45. Détection de conflit de touches (Options) (2026-05-23)
+
+Petit garde-fou UX (§34) : au rebind d'une action dans le panneau Options, si la touche choisie est **déjà affectée à une autre action** (sprint/accroupi/sort/interagir/coup de poing), un **avertissement** s'affiche sous les lignes de rebind (`m_keybindWarning`, texte orange). Le bind reste **appliqué** (doublon autorisé, juste signalé). Effacé au prochain rebind sans conflit.

--- a/docs/BACKLOG_gameplay.md
+++ b/docs/BACKLOG_gameplay.md
@@ -23,8 +23,6 @@
 
 - **Roll — i-frames** : la roulade a son impulsion (§30) mais pas d'invincibilité ;
   n'a de sens qu'avec un système de dégâts (cf. section serveur).
-- **Détection de conflit de touches** (Options) : binder 2 actions sur la même touche
-  est permis sans avertissement (§34).
 - **Attaque (souris) remappable** : le clic gauche d'attaque n'est pas remappable (§34).
 
 ## C. Contenu / assets (hors code — création par level-design / artiste)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8418,6 +8418,23 @@ namespace engine
 									: (m_rebindingAction == 3) ? "controls.keybind.cast"
 									: (m_rebindingAction == 4) ? "controls.keybind.interact"
 									: "controls.keybind.punch";
+								// Detection de conflit : la touche choisie est-elle deja sur une autre
+								// action ? (doublon autorise, juste signale sous les lignes de rebind).
+								m_keybindWarning.clear();
+								{
+									struct Kb { int act; const char* key; const char* label; };
+									static const Kb kKb[] = {
+										{1,"controls.keybind.sprint","Sprint"}, {2,"controls.keybind.crouch","Accroupi"},
+										{3,"controls.keybind.cast","Sort"}, {4,"controls.keybind.interact","Interagir"},
+										{5,"controls.keybind.punch","Coup de poing"},
+									};
+									for (const auto& kb : kKb)
+										if (kb.act != m_rebindingAction && m_cfg.GetString(kb.key, "") == rk.name)
+										{
+											m_keybindWarning = std::string("Touche '") + rk.name + "' deja utilisee par " + kb.label + " (doublon).";
+											break;
+										}
+								}
 								m_cfg.SetValue(cfgKey, std::string(rk.name));
 								// Persistance : ecrit keybinds.json (fichier dedie, format controle ;
 								// valeurs = noms ASCII de kRebindableKeys -> pas d'echappement JSON requis).
@@ -8460,6 +8477,8 @@ namespace engine
 				rebindRow("Coup de poing", "controls.keybind.punch", "C", 5);
 				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
 				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
+				if (!m_keybindWarning.empty())
+					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "%s", m_keybindWarning.c_str());
 
 				ImGui::Spacing();
 				ImGui::Separator();

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -633,6 +633,10 @@ namespace engine
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).
 		int                                                      m_rebindingAction = 0;
+		/// Avertissement de conflit de touches affiché sous les lignes de rebind
+		/// (Options) : non vide si la dernière touche bindée était déjà sur une
+		/// autre action. Le bind reste appliqué (doublon autorisé, juste signalé).
+		std::string                                              m_keybindWarning;
 		/// Instant d'entrée dans l'état courant. Utilisé pour :
 		///   - détecter la fin de StartWalking / Jump / Land (durée écoulée >= clip.duration).
 		///   - tracer la transition Jump -> Fall après 40% du clip Jump (takeoff).


### PR DESCRIPTION
## Résumé

Garde-fou UX (backlog §34) : au rebind d'une action dans le panneau **Options**, si la touche choisie est **déjà affectée à une autre action** (Sprint / Accroupi / Sort / Interagir / Coup de poing), un **avertissement orange** s'affiche sous les lignes de rebind. Le bind reste **appliqué** (doublon autorisé, juste signalé). Effacé au prochain rebind sans conflit.

- `m_keybindWarning` (membre) renseigné à la capture si la touche est déjà sur une autre action ; affiché via `ImGui::TextColored`.
- Code dans le panneau Options (`#if defined(_WIN32)`) → validé par le **build-windows** CI (le reste compile 0 erreur en local).
- Doc : **CODEBASE_MAP §45** ; item retiré du backlog.

## Test plan
- [ ] Build Windows/Linux (CI).
- [ ] Options → « Modifier » sur une action → presser une touche **déjà utilisée** par une autre → l'avertissement orange apparaît ; le bind est quand même appliqué.

**Déploiement** : ✅ client uniquement (UI Options ; aucun changement serveur).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_