### PR TITLE
feat(combat): attaque remappable (touche alternative)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1777,3 +1777,7 @@ Backlog complet des tâches restantes (polish, contenu, serveur) : **`docs/BACKL
 ## 45. Détection de conflit de touches (Options) (2026-05-23)
 
 Petit garde-fou UX (§34) : au rebind d'une action dans le panneau Options, si la touche choisie est **déjà affectée à une autre action** (sprint/accroupi/sort/interagir/coup de poing), un **avertissement** s'affiche sous les lignes de rebind (`m_keybindWarning`, texte orange). Le bind reste **appliqué** (doublon autorisé, juste signalé). Effacé au prochain rebind sans conflit.
+
+## 46. Attaque remappable (touche alternative) (2026-05-23)
+
+L'attaque restait fixée au clic gauche (§31). Ajout d'une **touche alternative** : `controls.keybind.attack` (vide par défaut = clic gauche seul). Si renseignée avec une touche valide (table `kRebindableKeys`), l'attaque se déclenche au **clic gauche OU** sur cette touche. Validation par round-trip `KeyName(KeyFromName(...))` (ignore une valeur invalide → pas de déclenchement parasite). Volet **input** (cross-platform) ; la ligne UI dans Options reste un petit suivi (Windows-only).

--- a/config.json
+++ b/config.json
@@ -100,7 +100,8 @@
             "crouch": "Ctrl",
             "cast": "R",
             "interact": "E",
-            "punch": "C"
+            "punch": "C",
+            "attack": ""
         }
     },
     "_comment_player_movement": "Sous-projet B.1 — CharacterController params. Defaults sensibles si absent (CharacterController::Config). walk_speed/run_speed en m/s. gravity en m/s2 (signe negatif). jump_speed = impulse m/s a l'instant du jump. coyote_time_s = jump grace apres avoir quitte le sol. jump_buffer_s = jump grace si presse juste avant atterrissage.",

--- a/docs/BACKLOG_gameplay.md
+++ b/docs/BACKLOG_gameplay.md
@@ -23,7 +23,7 @@
 
 - **Roll — i-frames** : la roulade a son impulsion (§30) mais pas d'invincibilité ;
   n'a de sens qu'avec un système de dégâts (cf. section serveur).
-- **Attaque (souris) remappable** : le clic gauche d'attaque n'est pas remappable (§34).
+- **Attaque remappable — UI** : touche alternative livrée par config (§46) ; reste la ligne UI dans Options (Windows-only).
 
 ## C. Contenu / assets (hors code — création par level-design / artiste)
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7268,9 +7268,15 @@ namespace engine
 					// Attaque melee : clic gauche (edge). Le bloc gameplay est deja garde
 					// contre le focus chat / l'auth (cf. ligne ~6969) ; on exclut en plus
 					// le drag inventaire pour ne pas frapper en relachant un objet.
+					// Touche d'attaque ALTERNATIVE (controls.keybind.attack, vide = clic gauche
+					// seul). Permet de remapper l'attaque sur une touche, en plus du clic gauche.
+					// Round-trip KeyName(KeyFromName(...)) pour ignorer une valeur invalide.
+					const std::string attackKeyName = m_cfg.GetString("controls.keybind.attack", "");
+					const engine::platform::Key attackKey = KeyFromName(attackKeyName, engine::platform::Key::Escape);
+					const bool attackKeyBound = !attackKeyName.empty() && std::string(KeyName(attackKey)) == attackKeyName;
 					const bool attackPressed =
-						m_input.WasMousePressed(engine::platform::MouseButton::Left)
-						&& !m_invUi.IsDragging();
+						(m_input.WasMousePressed(engine::platform::MouseButton::Left) && !m_invUi.IsDragging())
+						|| (attackKeyBound && m_input.WasPressed(attackKey));
 
 					// Sort : touche R (edge). Meme bloc gameplay garde contre le focus
 					// chat / l'auth (cf. ligne ~6961). Geste cosmetique one-shot (pas de


### PR DESCRIPTION
## Résumé

L'attaque restait fixée au **clic gauche** (§31). Ajout d'une **touche alternative** : `controls.keybind.attack` (vide par défaut = clic gauche seul). Si renseignée avec une touche valide, l'attaque se déclenche au **clic gauche OU** sur cette touche.

- Validation **round-trip** `KeyName(KeyFromName(...))` → une valeur invalide est ignorée (pas de déclenchement parasite, ex. sur Échap).
- Volet **input** (cross-platform), validé en compilation locale (0 erreur).
- La **ligne UI** dans le panneau Options (pour rebinder à la souris/clavier) reste un petit suivi (Windows-only).
- Doc : **CODEBASE_MAP §46**.

## Test plan
- [ ] Build Windows/Linux (CI).
- [ ] `controls.keybind.attack` vide → attaque au clic gauche (inchangé).
- [ ] `controls.keybind.attack="F"` → attaque au clic gauche **ou** sur F.

**Déploiement** : ✅ client uniquement (input + config ; aucun changement serveur).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_