### PR TITLE
fix(avatar): tremblement / « parait double » du modèle (régression #672)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1816,3 +1816,15 @@ L'attaque restait fixée au clic gauche (§31). Ajout d'une **touche alternative
 ### Limites / reste
 - **ORM peau** non packée (Roughness source dispo dans l'inbox) → repli ORM par défaut (peau un peu trop lisse). Packer R=AO/G=Rough/B=Metal = polish ultérieur.
 - **Validation visuelle requise** (rendu non testable en CI) : à confirmer en jeu via screenshots.
+
+## 48. Avatar : depth bias peau (anti z-fighting peau/habit) (2026-05-23)
+
+**Problème** : après §47, l'avatar **clignotait / paraissait double** sur le corps (rapporté en jeu, « la surface clignote et parait double, seulement sur le modèle »). Cause : sur l'avatar modulaire, la **peau du corps** (`MI_Regular_Male`) est ~**coplanaire** avec l'**habit** (`MI_Ranger`) sur les bras (le corps complet est sous l'habit). Avant §47 les deux portaient la même texture → invisible ; avec deux textures distinctes, le **z-fighting** devient visible (amplifié par la TAA).
+
+### Fix
+- **Depth bias** sur les sous-maillages **peau** uniquement : le pipeline `SkinnedRenderer` passe `depthBiasEnable=TRUE` + `VK_DYNAMIC_STATE_DEPTH_BIAS` ; `Record` appelle `vkCmdSetDepthBias` par sous-maillage (biais config pour la peau, 0 pour l'habit). La peau est poussée **derrière** l'habit coplanaire → l'habit gagne le z-test (`LESS_OR_EQUAL`) là où ils se superposent ; la peau **exposée** (mains) rend normalement.
+- **Réglable à chaud** (pas de rebuild) : `client.character_creation.skin_depth_bias_constant` / `_slope` (défauts 4.0 / 4.0). Valeurs négatives possibles si le sens doit être inversé. 0 = désactivé.
+- **Pipeline / winding (CCW + BACK) inchangés** (seul `depthBiasEnable` + l'état dynamique sont ajoutés).
+
+### À valider
+- En jeu : plus de clignotement « double » sur le corps ; la peau des mains reste visible ; l'habit n'empiète pas trop sur la peau exposée (sinon **baisser** le biais dans config).

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1828,3 +1828,15 @@ L'attaque restait fixée au clic gauche (§31). Ajout d'une **touche alternative
 
 ### À valider
 - En jeu : plus de clignotement « double » sur le corps ; la peau des mains reste visible ; l'habit n'empiète pas trop sur la peau exposée (sinon **baisser** le biais dans config).
+
+## 49. Avatar : double-buffer des buffers skinning (anti tremblement / pose « double ») (2026-05-23)
+
+**Problème** : l'avatar **tremble** / **parait double** en jeu (régression vs `8b974e9`, apparue avec #672). **Cause racine** : `SkinnedRenderer` réécrivait chaque frame un **unique** bone SSBO (matrices de skinning) + un **unique** model instance buffer, tous deux host-coherent. Avec **2 frames en vol** (FIF=2, cf. `m_frameArena`), la frame N+1 réécrit ces buffers **pendant que le GPU lit encore** ceux de la frame N → deux poses se mélangent (tremblement). Le multi-draw de #672 (9 draws au lieu d'1) **allonge la fenêtre de lecture GPU** → la course, jusque-là peu visible, devient flagrante. Le caveat était déjà documenté dans `SkinnedRenderer.cpp` (« fix propre = duplication par frame, PR de suivi »).
+
+### Fix
+- **Duplication par slot** : `SkinnedRenderer` alloue `kFrameSlots = 3` copies (FIF=2 + 1 de marge) du bone SSBO, du model buffer, et du descriptor set bone (chaque set pointe sur SON SSBO). `Record` choisit le slot de la frame puis avance un **ring** (`m_frameSlot = (m_frameSlot+1) % kFrameSlots`) → on ne réécrit jamais un buffer encore lu.
+- **Auto-contenu** : ring interne au renderer, **aucun** changement côté `Engine` (pas de frame index à câbler). Init/Record/Destroy bouclent sur les slots.
+- **Pipeline / shaders / winding inchangés.**
+
+### À valider
+- En jeu : l'avatar ne tremble plus / ne paraît plus double, immobile **et** en mouvement.

--- a/config.json
+++ b/config.json
@@ -215,7 +215,10 @@
             "body_basecolor": "textures/characters/humains/T_Regular_Male_BaseColor.png",
             "body_normal": "textures/characters/humains/T_Regular_Male_Normal.png",
             "body_orm": "",
-            "body_material_names": "MI_Regular_Male"
+            "body_material_names": "MI_Regular_Male",
+            "_comment_skin_depth_bias": "Anti z-fighting : sur l'avatar modulaire, la peau du corps est ~coplanaire avec l'habit (bras) ; texturees differemment elles clignotent / paraissent doubles. On pousse la PEAU legerement en arriere (depth bias) pour que l'habit gagne la ou ils se superposent ; la peau exposee (mains) rend normalement. Reglable A CHAUD (relance du client, pas de rebuild) : augmenter si ca clignote encore, baisser si l'habit ronge la peau exposee. 0 = desactive. constant = decalage fixe, slope = decalage proportionnel a la pente (utile sur surfaces obliques).",
+            "skin_depth_bias_constant": 4.0,
+            "skin_depth_bias_slope": 4.0
         },
         "auth_ui": {
             "enabled": true,

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4075,6 +4075,12 @@ namespace engine
 										// tout autre nom recoit l'habit. Defaut : "MI_Regular_Male".
 										m_avatarBodyMaterialNames = SplitCsv(
 											m_cfg.GetString("client.character_creation.body_material_names", "MI_Regular_Male"));
+										// Depth bias peau (anti z-fight peau/habit, « parait double ») : reglable
+										// a chaud via config (pas de rebuild pour ajuster). 0 = desactive.
+										m_avatarSkinDepthBiasConstant = static_cast<float>(
+											m_cfg.GetDouble("client.character_creation.skin_depth_bias_constant", 4.0));
+										m_avatarSkinDepthBiasSlope = static_cast<float>(
+											m_cfg.GetDouble("client.character_creation.skin_depth_bias_slope", 4.0));
 
 										m_avatarSkinTextureHandle = m_assetRegistry.LoadTexture(outfitBc, /*useSrgb*/ true);
 										if (!m_avatarSkinTextureHandle.IsValid())
@@ -4735,7 +4741,10 @@ namespace engine
 																materialCache.GetDescriptorSet(),
 																finalModelMat.m,
 																skinnedMaterialIndex,
-																submeshMaterialIndices);
+																submeshMaterialIndices,
+																m_avatarBodyMaterialId,
+																m_avatarSkinDepthBiasConstant,
+																m_avatarSkinDepthBiasSlope);
 														});
 												}
 

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -345,6 +345,13 @@ namespace engine
 		/// recoivent m_avatarBodyMaterialId (la peau). Tout autre nom -> habit.
 		/// Renseigne depuis client.character_creation.body_material_names.
 		std::vector<std::string> m_avatarBodyMaterialNames;
+		/// Depth bias applique aux sous-maillages PEAU (corps) au draw pour les
+		/// pousser DERRIERE l'habit coplanaire et eviter le z-fighting/flicker
+		/// (« parait double ») sur l'avatar modulaire (peau sous l'habit, bras).
+		/// Reglable a chaud via client.character_creation.skin_depth_bias_* (pas
+		/// de rebuild necessaire pour ajuster). Defauts sensibles si absent.
+		float m_avatarSkinDepthBiasConstant = 4.0f;
+		float m_avatarSkinDepthBiasSlope    = 4.0f;
 		engine::render::DecalSystem m_decalSystem;
 		std::vector<engine::render::VisibleDecal> m_visibleDecals;
 

--- a/src/client/render/skinned/SkinnedRenderer.cpp
+++ b/src/client/render/skinned/SkinnedRenderer.cpp
@@ -454,42 +454,42 @@ bool SkinnedRenderer::Init(VkDevice device,
     }
 
     // -------------------------------------------------------------------------
-    // Bone SSBO (host-visible + coherent). Dimensionné pour maxBones mat4.
-    // Réécrit chaque Record (Task 14).
+    // Bone SSBO + model instance buffer : kFrameSlots copies (anti-course FIF).
+    // Chaque slot a son SSBO bones, son buffer model, et son descriptor set
+    // bone qui pointe sur SON SSBO. Record alterne de slot a chaque frame pour
+    // ne jamais reecrire un buffer encore lu par une frame en vol.
     // -------------------------------------------------------------------------
     const VkDeviceSize boneBufferSize =
         static_cast<VkDeviceSize>(maxBonesPerSkeleton) * sizeof(float) * 16;
-    if (!CreateEmptyHostVisibleBuffer(device, physicalDevice,
-                                      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-                                      boneBufferSize, &m_boneSsbo, &m_boneSsboMemory)) {
-        LOG_ERROR(Render, "[SkinnedRenderer] bone SSBO creation failed ({} bytes)",
-                      static_cast<size_t>(boneBufferSize));
-        Destroy(device);
-        return false;
+    for (uint32_t slot = 0; slot < kFrameSlots; ++slot) {
+        if (!CreateEmptyHostVisibleBuffer(device, physicalDevice,
+                                          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+                                          boneBufferSize, &m_boneSsbo[slot], &m_boneSsboMemory[slot])) {
+            LOG_ERROR(Render, "[SkinnedRenderer] bone SSBO creation failed slot {} ({} bytes)",
+                          slot, static_cast<size_t>(boneBufferSize));
+            Destroy(device);
+            return false;
+        }
+        if (!CreateEmptyHostVisibleBuffer(device, physicalDevice,
+                                          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                                          64u, &m_modelInstanceBuffer[slot], &m_modelInstanceMemory[slot])) {
+            LOG_ERROR(Render, "[SkinnedRenderer] model instance buffer creation failed slot {}", slot);
+            Destroy(device);
+            return false;
+        }
     }
 
     // -------------------------------------------------------------------------
-    // Model instance buffer (1 mat4 = 64 octets). Réécrit chaque Record.
-    // -------------------------------------------------------------------------
-    if (!CreateEmptyHostVisibleBuffer(device, physicalDevice,
-                                      VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-                                      64u, &m_modelInstanceBuffer, &m_modelInstanceMemory)) {
-        LOG_ERROR(Render, "[SkinnedRenderer] model instance buffer creation failed");
-        Destroy(device);
-        return false;
-    }
-
-    // -------------------------------------------------------------------------
-    // Descriptor pool (1 SSBO max) + allocation du bone descriptor set +
-    // binding du SSBO sur ce set.
+    // Descriptor pool (kFrameSlots SSBO) + 1 bone descriptor set par slot,
+    // chacun bindant le SSBO du meme slot.
     // -------------------------------------------------------------------------
     VkDescriptorPoolSize poolSize = {};
     poolSize.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    poolSize.descriptorCount = 1;
+    poolSize.descriptorCount = kFrameSlots;
 
     VkDescriptorPoolCreateInfo poolCi = {};
     poolCi.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolCi.maxSets       = 1;
+    poolCi.maxSets       = kFrameSlots;
     poolCi.poolSizeCount = 1;
     poolCi.pPoolSizes    = &poolSize;
 
@@ -499,35 +499,37 @@ bool SkinnedRenderer::Init(VkDevice device,
         return false;
     }
 
-    VkDescriptorSetAllocateInfo allocInfo = {};
-    allocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool     = m_descriptorPool;
-    allocInfo.descriptorSetCount = 1;
-    allocInfo.pSetLayouts        = &m_boneSetLayout;
+    for (uint32_t slot = 0; slot < kFrameSlots; ++slot) {
+        VkDescriptorSetAllocateInfo allocInfo = {};
+        allocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocInfo.descriptorPool     = m_descriptorPool;
+        allocInfo.descriptorSetCount = 1;
+        allocInfo.pSetLayouts        = &m_boneSetLayout;
 
-    if (vkAllocateDescriptorSets(device, &allocInfo, &m_boneDescriptorSet) != VK_SUCCESS) {
-        LOG_ERROR(Render, "[SkinnedRenderer] bone descriptor set allocation failed");
-        Destroy(device);
-        return false;
+        if (vkAllocateDescriptorSets(device, &allocInfo, &m_boneDescriptorSet[slot]) != VK_SUCCESS) {
+            LOG_ERROR(Render, "[SkinnedRenderer] bone descriptor set allocation failed slot {}", slot);
+            Destroy(device);
+            return false;
+        }
+
+        VkDescriptorBufferInfo boneBufInfo = {};
+        boneBufInfo.buffer = m_boneSsbo[slot];
+        boneBufInfo.offset = 0;
+        boneBufInfo.range  = VK_WHOLE_SIZE;
+
+        VkWriteDescriptorSet write = {};
+        write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write.dstSet          = m_boneDescriptorSet[slot];
+        write.dstBinding      = 0;
+        write.dstArrayElement = 0;
+        write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        write.descriptorCount = 1;
+        write.pBufferInfo     = &boneBufInfo;
+        vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
     }
 
-    VkDescriptorBufferInfo boneBufInfo = {};
-    boneBufInfo.buffer = m_boneSsbo;
-    boneBufInfo.offset = 0;
-    boneBufInfo.range  = VK_WHOLE_SIZE;
-
-    VkWriteDescriptorSet write = {};
-    write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet          = m_boneDescriptorSet;
-    write.dstBinding      = 0;
-    write.dstArrayElement = 0;
-    write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    write.descriptorCount = 1;
-    write.pBufferInfo     = &boneBufInfo;
-    vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
-
-    LOG_INFO(Render, "[SkinnedRenderer] Init OK (maxBones={}, SSBO={} bytes)",
-                 maxBonesPerSkeleton, static_cast<size_t>(boneBufferSize));
+    LOG_INFO(Render, "[SkinnedRenderer] Init OK (maxBones={}, SSBO={} bytes x{} slots)",
+                 maxBonesPerSkeleton, static_cast<size_t>(boneBufferSize), kFrameSlots);
     return true;
 }
 
@@ -539,10 +541,11 @@ bool SkinnedRenderer::Init(VkDevice device,
 // que `GeometryPass::Record`). Les paramètres `renderPass` / `framebuffer`
 // restent dans la signature pour symétrie et usage futur éventuel.
 //
-// Caveat known FIF (frame-in-flight) : si l'engine a FIF >= 2, les buffers
-// host-coherent réécrits chaque frame peuvent racer avec la draw précédente.
-// Pour l'unique avatar du scope A c'est peu visible, mais le fix propre
-// (duplication des buffers par frame) appartient à une PR de suivi.
+// FIF (frame-in-flight) : les buffers host-coherent réécrits chaque frame sont
+// désormais DUPLIQUÉS par slot (kFrameSlots, ring avancé à chaque Record) pour
+// ne jamais réécrire un buffer encore lu par une frame en vol. Sans ça, à FIF=2
+// (a fortiori avec le multi-draw qui allonge la fenêtre de lecture GPU), la
+// course faisait trembler l'avatar / le faisait « parait double ». Cf. §49.
 // -----------------------------------------------------------------------------
 
 void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
@@ -559,6 +562,12 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
                              float skinDepthBiasConstant,
                              float skinDepthBiasSlope)
 {
+    // 0. Sélectionne le slot de buffers de cette frame puis avance le ring.
+    //    Garantit qu'on ne réécrit jamais le bone SSBO / model buffer encore lu
+    //    par une frame en vol (FIF) → plus de tremblement / pose « double ».
+    const uint32_t slot = m_frameSlot;
+    m_frameSlot = (m_frameSlot + 1u) % kFrameSlots;
+
     // 1. Upload des matrices de bones dans le SSBO host-visible.
     //    Clamp au max alloué dans Init pour ne jamais déborder (256 bones par
     //    défaut). Si la liste est vide on saute l'upload (mesh sans skin
@@ -568,9 +577,9 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
         const size_t boneBytes = boneCountClamped * sizeof(engine::math::Mat4);
         if (boneBytes > 0) {
             void* mapped = nullptr;
-            if (vkMapMemory(device, m_boneSsboMemory, 0, boneBytes, 0, &mapped) == VK_SUCCESS) {
+            if (vkMapMemory(device, m_boneSsboMemory[slot], 0, boneBytes, 0, &mapped) == VK_SUCCESS) {
                 std::memcpy(mapped, finalBoneMatrices.data(), boneBytes);
-                vkUnmapMemory(device, m_boneSsboMemory);
+                vkUnmapMemory(device, m_boneSsboMemory[slot]);
             } else {
                 LOG_WARN(Render, "[SkinnedRenderer] vkMapMemory failed for bone SSBO; skipping draw");
                 return;
@@ -581,9 +590,9 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
     // 2. Upload de la matrice modèle (64 octets) dans le per-instance buffer.
     {
         void* mapped = nullptr;
-        if (vkMapMemory(device, m_modelInstanceMemory, 0, 64, 0, &mapped) == VK_SUCCESS) {
+        if (vkMapMemory(device, m_modelInstanceMemory[slot], 0, 64, 0, &mapped) == VK_SUCCESS) {
             std::memcpy(mapped, modelMatrixColumnMajor4x4, 64);
-            vkUnmapMemory(device, m_modelInstanceMemory);
+            vkUnmapMemory(device, m_modelInstanceMemory[slot]);
         } else {
             LOG_WARN(Render, "[SkinnedRenderer] vkMapMemory failed for model instance buffer; skipping draw");
             return;
@@ -611,7 +620,7 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
 
     // 5. Bind des descriptor sets : set 0 = matériau (fourni par l'appelant),
     //    set 1 = bone SSBO (interne, mis à jour à l'Init).
-    VkDescriptorSet sets[2] = { materialDescriptorSet, m_boneDescriptorSet };
+    VkDescriptorSet sets[2] = { materialDescriptorSet, m_boneDescriptorSet[slot] };
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout,
                              /*firstSet*/ 0, /*setCount*/ 2, sets, 0, nullptr);
 
@@ -636,7 +645,7 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
 
     // 7. Bind des vertex buffers : per-vertex @ binding 0 (mesh), per-instance
     //    @ binding 1 (matrice modèle). Cf. layout vertex input dans Init.
-    VkBuffer vbufs[2] = { mesh.vertexBuffer, m_modelInstanceBuffer };
+    VkBuffer vbufs[2] = { mesh.vertexBuffer, m_modelInstanceBuffer[slot] };
     VkDeviceSize offsets[2] = { 0, 0 };
     vkCmdBindVertexBuffers(cmd, 0, 2, vbufs, offsets);
 
@@ -700,39 +709,43 @@ void SkinnedRenderer::Destroy(VkDevice device)
         m_pipeline = VK_NULL_HANDLE;
         m_boneSetLayout = VK_NULL_HANDLE;
         m_descriptorPool = VK_NULL_HANDLE;
-        m_boneDescriptorSet = VK_NULL_HANDLE;
-        m_boneSsbo = VK_NULL_HANDLE;
-        m_boneSsboMemory = VK_NULL_HANDLE;
-        m_modelInstanceBuffer = VK_NULL_HANDLE;
-        m_modelInstanceMemory = VK_NULL_HANDLE;
+        for (uint32_t slot = 0; slot < kFrameSlots; ++slot) {
+            m_boneDescriptorSet[slot] = VK_NULL_HANDLE;
+            m_boneSsbo[slot] = VK_NULL_HANDLE;
+            m_boneSsboMemory[slot] = VK_NULL_HANDLE;
+            m_modelInstanceBuffer[slot] = VK_NULL_HANDLE;
+            m_modelInstanceMemory[slot] = VK_NULL_HANDLE;
+        }
+        m_frameSlot = 0;
         m_maxBones = 0;
         return;
     }
 
-    // Le descriptor set est libéré automatiquement par la destruction du pool.
+    // Les descriptor sets sont libérés automatiquement par la destruction du pool.
     if (m_descriptorPool != VK_NULL_HANDLE) {
         vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
         m_descriptorPool = VK_NULL_HANDLE;
-        m_boneDescriptorSet = VK_NULL_HANDLE;
     }
-
-    if (m_modelInstanceBuffer != VK_NULL_HANDLE) {
-        vkDestroyBuffer(device, m_modelInstanceBuffer, nullptr);
-        m_modelInstanceBuffer = VK_NULL_HANDLE;
+    for (uint32_t slot = 0; slot < kFrameSlots; ++slot) {
+        m_boneDescriptorSet[slot] = VK_NULL_HANDLE;
+        if (m_modelInstanceBuffer[slot] != VK_NULL_HANDLE) {
+            vkDestroyBuffer(device, m_modelInstanceBuffer[slot], nullptr);
+            m_modelInstanceBuffer[slot] = VK_NULL_HANDLE;
+        }
+        if (m_modelInstanceMemory[slot] != VK_NULL_HANDLE) {
+            vkFreeMemory(device, m_modelInstanceMemory[slot], nullptr);
+            m_modelInstanceMemory[slot] = VK_NULL_HANDLE;
+        }
+        if (m_boneSsbo[slot] != VK_NULL_HANDLE) {
+            vkDestroyBuffer(device, m_boneSsbo[slot], nullptr);
+            m_boneSsbo[slot] = VK_NULL_HANDLE;
+        }
+        if (m_boneSsboMemory[slot] != VK_NULL_HANDLE) {
+            vkFreeMemory(device, m_boneSsboMemory[slot], nullptr);
+            m_boneSsboMemory[slot] = VK_NULL_HANDLE;
+        }
     }
-    if (m_modelInstanceMemory != VK_NULL_HANDLE) {
-        vkFreeMemory(device, m_modelInstanceMemory, nullptr);
-        m_modelInstanceMemory = VK_NULL_HANDLE;
-    }
-
-    if (m_boneSsbo != VK_NULL_HANDLE) {
-        vkDestroyBuffer(device, m_boneSsbo, nullptr);
-        m_boneSsbo = VK_NULL_HANDLE;
-    }
-    if (m_boneSsboMemory != VK_NULL_HANDLE) {
-        vkFreeMemory(device, m_boneSsboMemory, nullptr);
-        m_boneSsboMemory = VK_NULL_HANDLE;
-    }
+    m_frameSlot = 0;
 
     if (m_pipeline != VK_NULL_HANDLE) {
         vkDestroyPipeline(device, m_pipeline, nullptr);

--- a/src/client/render/skinned/SkinnedRenderer.cpp
+++ b/src/client/render/skinned/SkinnedRenderer.cpp
@@ -383,6 +383,15 @@ bool SkinnedRenderer::Init(VkDevice device,
     rs.cullMode    = VK_CULL_MODE_BACK_BIT;
     rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
     rs.lineWidth   = 1.0f;
+    // Depth bias active (valeurs poussees dynamiquement par Record) : sert a
+    // departager les couches qui se chevauchent sur l'avatar modulaire (peau du
+    // corps SOUS l'habit, ~coplanaires sur les bras) -> sans biais elles
+    // z-fightent et clignotent ("parait double") une fois texturees differemment
+    // (peau vs habit). On pousse la PEAU legerement en arriere pour que l'habit
+    // gagne la ou ils se superposent ; la peau exposee (mains) rend normalement.
+    // depthBiasEnable seul ne biaise rien : tout vient des vkCmdSetDepthBias par
+    // sous-maillage (0 pour l'habit, valeur config pour la peau).
+    rs.depthBiasEnable = VK_TRUE;
 
     VkPipelineMultisampleStateCreateInfo ms = {};
     ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
@@ -405,10 +414,13 @@ bool SkinnedRenderer::Init(VkDevice device,
     cb.attachmentCount = 4;
     cb.pAttachments    = blendAtt;
 
-    VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    // DEPTH_BIAS dynamique : valeurs (re)poussees par Record selon que le
+    // sous-maillage est de la peau (biais config) ou de l'habit (0).
+    VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR,
+                                   VK_DYNAMIC_STATE_DEPTH_BIAS };
     VkPipelineDynamicStateCreateInfo dyn = {};
     dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    dyn.dynamicStateCount = 2;
+    dyn.dynamicStateCount = 3;
     dyn.pDynamicStates    = dynStates;
 
     VkGraphicsPipelineCreateInfo gpInfo = {};
@@ -542,7 +554,10 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
                              VkDescriptorSet materialDescriptorSet,
                              const float* modelMatrixColumnMajor4x4,
                              uint32_t materialIndex,
-                             const std::vector<uint32_t>& submeshMaterialIndices)
+                             const std::vector<uint32_t>& submeshMaterialIndices,
+                             uint32_t skinMaterialIndex,
+                             float skinDepthBiasConstant,
+                             float skinDepthBiasSlope)
 {
     // 1. Upload des matrices de bones dans le SSBO host-visible.
     //    Clamp au max alloué dans Init pour ne jamais déborder (256 bones par
@@ -634,13 +649,25 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
     //    materialIndex (habit vs peau). Le descriptor set (set 0) est bindless
     //    et déjà bindé : seul le push constant materialIndex change entre draws.
     //    Sinon, chemin mono-draw historique (mesh.indexCount d'un coup).
+    // Le pipeline a depthBiasEnable=TRUE + DEPTH_BIAS dynamique : il FAUT donc
+    // appeler vkCmdSetDepthBias avant chaque draw (sinon valeur indefinie). On
+    // pose 0 par defaut, et le biais peau (skinDepthBias*) pour les sous-maillages
+    // dont l'index materiau figure dans skinMaterialIndices.
+    auto isSkin = [&](uint32_t matIndex) -> bool {
+        return skinMaterialIndex != 0u && matIndex == skinMaterialIndex;
+    };
+
     const bool perSubmesh =
         !mesh.submeshes.empty() && submeshMaterialIndices.size() == mesh.submeshes.size();
     if (perSubmesh) {
         for (size_t s = 0; s < mesh.submeshes.size(); ++s) {
             const SkinnedSubMesh& sub = mesh.submeshes[s];
             if (sub.indexCount == 0) continue;
-            pc.materialIndex = submeshMaterialIndices[s];
+            const uint32_t matIdx = submeshMaterialIndices[s];
+            const bool skin = isSkin(matIdx);
+            vkCmdSetDepthBias(cmd, skin ? skinDepthBiasConstant : 0.0f, 0.0f,
+                              skin ? skinDepthBiasSlope : 0.0f);
+            pc.materialIndex = matIdx;
             vkCmdPushConstants(cmd, m_pipelineLayout,
                                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
                                0, sizeof(PushConstants), &pc);
@@ -648,6 +675,7 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
                              sub.firstIndex, 0, 0);
         }
     } else {
+        vkCmdSetDepthBias(cmd, 0.0f, 0.0f, 0.0f);
         pc.materialIndex = materialIndex;
         vkCmdPushConstants(cmd, m_pipelineLayout,
                            VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,

--- a/src/client/render/skinned/SkinnedRenderer.h
+++ b/src/client/render/skinned/SkinnedRenderer.h
@@ -120,6 +120,16 @@ public:
     ///                            propre draw call avec son index (rendu
     ///                            multi-matériaux : habit vs peau). Sinon on
     ///                            retombe sur un unique draw avec `materialIndex`.
+    /// \param skinMaterialIndex   Index matériau considéré « peau » (corps), ou
+    ///                            0 = aucun. Les sous-maillages dont l'index
+    ///                            matériau == celui-ci reçoivent un depth bias
+    ///                            (skinDepthBias*) pour passer DERRIÈRE l'habit
+    ///                            coplanaire et éviter le z-fighting/flicker
+    ///                            (« parait double »). 0 → aucun biais.
+    /// \param skinDepthBiasConstant Facteur constant passé à vkCmdSetDepthBias
+    ///                            pour les sous-maillages peau (0 = pas de biais).
+    /// \param skinDepthBiasSlope  Facteur de pente passé à vkCmdSetDepthBias
+    ///                            pour les sous-maillages peau.
     void Record(VkDevice device, VkCommandBuffer cmd,
                 VkExtent2D extent,
                 VkRenderPass renderPass, VkFramebuffer framebuffer,
@@ -129,7 +139,10 @@ public:
                 VkDescriptorSet materialDescriptorSet,
                 const float* modelMatrixColumnMajor4x4,
                 uint32_t materialIndex,
-                const std::vector<uint32_t>& submeshMaterialIndices = {});
+                const std::vector<uint32_t>& submeshMaterialIndices = {},
+                uint32_t skinMaterialIndex = 0u,
+                float skinDepthBiasConstant = 0.0f,
+                float skinDepthBiasSlope = 0.0f);
 
     /// Libère toutes les ressources Vulkan dans l'ordre inverse de leur
     /// création. Idempotent (safe à appeler plusieurs fois, ou après un Init

--- a/src/client/render/skinned/SkinnedRenderer.h
+++ b/src/client/render/skinned/SkinnedRenderer.h
@@ -157,6 +157,14 @@ public:
     ///         Utilisé par l'appelant pour créer un framebuffer compatible.
     VkRenderPass GetRenderPass() const { return m_renderPass; }
 
+    /// Nombre de copies des buffers réécrits chaque frame (bone SSBO + model
+    /// instance + descriptor set bone). Doit être >= au nombre de frames en vol
+    /// (FIF) de l'engine (2). Sans cette duplication, réécrire un buffer
+    /// host-coherent pendant que la frame précédente le lit encore provoque une
+    /// course → l'avatar tremble / « parait double » (deux poses se mélangent).
+    /// 3 = FIF(2) + 1 de marge. Cf. CODEBASE_MAP §49.
+    static constexpr uint32_t kFrameSlots = 3u;
+
 private:
     VkDevice m_device = VK_NULL_HANDLE;
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
@@ -167,14 +175,20 @@ private:
 
     VkDescriptorSetLayout m_boneSetLayout = VK_NULL_HANDLE;
     VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
-    VkDescriptorSet m_boneDescriptorSet = VK_NULL_HANDLE;
+    /// Un descriptor set bone par slot, pointant chacun sur son m_boneSsbo[slot].
+    VkDescriptorSet m_boneDescriptorSet[kFrameSlots] = {};
 
-    VkBuffer m_boneSsbo = VK_NULL_HANDLE;
-    VkDeviceMemory m_boneSsboMemory = VK_NULL_HANDLE;
+    /// Bone SSBO host-visible/coherent, un par slot (anti-course FIF).
+    VkBuffer m_boneSsbo[kFrameSlots] = {};
+    VkDeviceMemory m_boneSsboMemory[kFrameSlots] = {};
 
-    /// VkBuffer 64 octets : mat4 modèle de l'avatar, réécrit chaque Record.
-    VkBuffer m_modelInstanceBuffer = VK_NULL_HANDLE;
-    VkDeviceMemory m_modelInstanceMemory = VK_NULL_HANDLE;
+    /// VkBuffer 64 octets : mat4 modèle de l'avatar, réécrit chaque Record, un
+    /// par slot (anti-course FIF).
+    VkBuffer m_modelInstanceBuffer[kFrameSlots] = {};
+    VkDeviceMemory m_modelInstanceMemory[kFrameSlots] = {};
+
+    /// Slot courant, avancé d'un cran à chaque Record (ring sur kFrameSlots).
+    uint32_t m_frameSlot = 0u;
 
     uint32_t m_maxBones = 0;
 };


### PR DESCRIPTION
## Contexte

Régression rapportée en jeu : **« le personnage tremble / la surface clignote et paraît double, seulement sur le modèle »**, absente à `8b974e9` et apparue avec **#672** (multi-matériaux). Diff `8b974e9..HEAD` : #672 ne change **pas** la géométrie ni le skinning (le loader ne fait qu'enregistrer des plages d'indices) — les seules nouveautés runtime sont **les textures distinctes** et **le passage à 9 sous-draws**. Deux mécanismes en découlent, corrigés ici.

## Fix 1 — Double-buffer des buffers de skinning (cause principale du tremblement) — §49

`SkinnedRenderer` réécrivait chaque frame un **unique** bone SSBO + model instance buffer host-coherent. À **FIF=2**, la frame N+1 les réécrit pendant que le GPU lit encore ceux de la frame N → **deux poses se mélangent** (= tremble / « paraît double »). Le multi-draw de #672 **allonge la fenêtre de lecture GPU** et rend la course flagrante. Le caveat était déjà documenté dans le code (fix différé = « duplication par frame »).

→ `kFrameSlots = 3` copies (FIF + marge) du bone SSBO, du model buffer et du descriptor set bone ; `Record` alterne via un **ring interne**. Auto-contenu, **aucun changement côté Engine**.

## Fix 2 — Depth bias peau (z-fighting peau/habit) — §48

Sur l'avatar modulaire, la **peau** (`MI_Regular_Male`) est ~coplanaire avec l'**habit** (`MI_Ranger`) sur les bras. Avant #672 même texture → invisible ; depuis, textures différentes → z-fight visible. On pousse la peau **derrière** l'habit (`vkCmdSetDepthBias` par sous-maillage). **Réglable à chaud** dans `config.json` (`client.character_creation.skin_depth_bias_constant` / `_slope`, défaut 4.0) → **pas de rebuild** pour ajuster ; 0 = off.

## À valider (en jeu)

- [ ] L'avatar **ne tremble plus / ne paraît plus double**, immobile et en mouvement (Fix 1).
- [ ] Plus de clignotement de surface sur les bras ; peau des mains visible ; l'habit n'empiète pas trop (sinon ajuster le biais en config, sans rebuild) (Fix 2).

---

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (rendu/pipeline/config client ; aucun opcode, handler, migration DB ou clé serveur).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu8ypCuVoeaU9qcMiqf5F2)_