### PR TITLE
fix(migrations): resout le doublon 0023 (bloqueur boot master) + 0066

### DIFF
--- a/sql/migrations/0066_accounts_profile_complete.sql
+++ b/sql/migrations/0066_accounts_profile_complete.sql
@@ -1,0 +1,107 @@
+-- Migration 0066 — Complète les colonnes de profil sur `accounts` (résout le doublon 0023).
+--
+-- Contexte : deux migrations portaient le numéro 0023 (0023_accounts_profile.sql et
+-- 0023_accounts_profile_fields.sql). Le MigrationRunner n'appliquant qu'UN script par
+-- numéro, l'une des deux n'a jamais été appliquée → un sous-ensemble de colonnes manque
+-- selon la base. Cette migration ajoute, de façon IDEMPOTENTE, l'UNION de toutes les
+-- colonnes des deux fichiers 0023 : quelle que soit celle déjà appliquée, les colonnes
+-- manquantes sont comblées (les colonnes déjà présentes sont laissées telles quelles).
+--
+-- Idempotent : chaque colonne n'est ajoutée que si absente (information_schema + PREPARE).
+-- Pas de COMMENT (évite l'échappement d'apostrophes) ; les colonnes restent fonctionnelles.
+
+-- first_name (présent dans les deux 0023 ; ajouté seulement si totalement absent)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'first_name');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN first_name VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- last_name
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'last_name');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN last_name VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- birth_date (uniquement dans 0023_accounts_profile_fields.sql)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'birth_date');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN birth_date VARCHAR(10) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_street (uniquement dans 0023_accounts_profile.sql)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_street');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_street VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_city
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_city');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_city VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_zip
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_zip');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_zip VARCHAR(20) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_country
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_country');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_country VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending_token
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending_token');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending_token VARCHAR(128) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending_expires_at
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending_expires_at');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending_expires_at DATETIME NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- disabled_reason
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'disabled_reason');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN disabled_reason TEXT NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- role (ENUM player/admin ; NOT NULL DEFAULT remplit les lignes existantes)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'role');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN role ENUM(''player'',''admin'') NOT NULL DEFAULT ''player''', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_email
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_email');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_email VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_validated (TINYINT NOT NULL DEFAULT 0 remplit les lignes existantes)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_validated');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_validated TINYINT(1) NOT NULL DEFAULT 0', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_token
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_token');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_token VARCHAR(128) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_token_expires_at
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_token_expires_at');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_token_expires_at DATETIME NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;

--- a/sql/migrations/README.md
+++ b/sql/migrations/README.md
@@ -25,3 +25,21 @@
 ## Application dans une transaction
 
 Chaque migration doit être exécutée dans une transaction si le moteur le permet (MySQL : `START TRANSACTION;` … `COMMIT;`). En cas d’erreur : `ROLLBACK;`.
+
+## Cas particulier : doublon historique 0023 (NE PAS SUPPRIMER)
+
+Deux fichiers portent le numéro **0023** (`0023_accounts_profile.sql` et
+`0023_accounts_profile_fields.sql`). C’est un doublon **historique** : selon la base,
+**l’un OU l’autre** a été appliqué (et son checksum est en `schema_version`).
+
+- **Ne supprimez NI l’un NI l’autre.** Le `MigrationRunner` accepte qu’un numéro ait
+  plusieurs fichiers et valide le checksum en base s’il correspond à **n’importe lequel**
+  d’eux ; supprimer le fichier réellement appliqué provoquerait un *checksum mismatch*
+  → **arrêt du master au démarrage**.
+- À l’application (base fraîche), un **seul** script par numéro est exécuté (anti
+  double-`INSERT` sur la PK `version`).
+- Les colonnes du fichier 0023 **non** appliqué sont comblées de façon **idempotente**
+  par `0066_accounts_profile_complete.sql` (union de toutes les colonnes des deux 0023).
+
+**Convention pour l’avenir : un numéro = un fichier.** Ce doublon est une exception gérée,
+pas un modèle à suivre.

--- a/src/masterd/migrations/MigrationRunner.cpp
+++ b/src/masterd/migrations/MigrationRunner.cpp
@@ -204,33 +204,36 @@ namespace engine::server
 		}
 		std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
-		// Verify checksums for all applied versions
+		// Verify checksums for all applied versions.
+		// Tolérance doublon : plusieurs fichiers peuvent porter le même numéro (ex. 0023
+		// historique). La migration réellement appliquée correspond à l'UN d'eux ; on
+		// accepte si le checksum en base correspond à n'importe lequel des fichiers de ce
+		// numéro (sinon le boot avortait via un find_if non déterministe).
 		for (const auto& [version, expectedChecksum] : appliedVersions)
 		{
-			auto it = std::find_if(files.begin(), files.end(), [version](const auto& p) { return p.first == version; });
-			if (it == files.end())
+			fs::path firstFile;
+			bool anyMatch = false;
+			for (const auto& [v, p] : files)
+			{
+				if (v != version) continue;
+				if (firstFile.empty()) firstFile = p;
+				std::string computed = Sha256HexFromFile(p);
+				if (!computed.empty() && computed == expectedChecksum) { anyMatch = true; break; }
+			}
+			if (firstFile.empty())
 			{
 				LOG_ERROR(Core, "[MigrationRunner] Applied version {} has no matching file in {}", version, migrationsPath);
 				mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");
 				mysql_close(mysql);
 				return false;
 			}
-			std::string computed = Sha256HexFromFile(it->second);
-			if (computed.empty())
+			if (!anyMatch)
 			{
-				LOG_ERROR(Core, "[MigrationRunner] Failed to read migration file: {}", it->second.generic_string());
-				mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");
-				mysql_close(mysql);
-				return false;
-			}
-			if (computed != expectedChecksum)
-			{
-				// Anciens schema.sql Docker / init inséraient ce checksum factice pour la v1 ; le volume MySQL
-				// ne repasse pas par docker-entrypoint-initdb.d. On aligne une seule fois sur le fichier actuel.
 				static constexpr std::string_view kLegacyV1Placeholder =
 					"0000000000000000000000000000000000000000000000000000000000000001";
 				if (version == 1 && expectedChecksum == kLegacyV1Placeholder)
 				{
+					std::string computed = Sha256HexFromFile(firstFile);
 					char escaped[160];
 					mysql_real_escape_string(mysql, escaped, computed.c_str(), static_cast<unsigned long>(computed.size()));
 					std::string fixSql = "UPDATE schema_version SET checksum='";
@@ -238,30 +241,22 @@ namespace engine::server
 					fixSql += "' WHERE version=1";
 					if (mysql_real_query(mysql, fixSql.c_str(), static_cast<unsigned long>(fixSql.size())) != 0)
 					{
-						LOG_ERROR(Core, "[MigrationRunner] Échec réparation checksum v1 : {}", mysql_error(mysql));
+						LOG_ERROR(Core, "[MigrationRunner] Echec reparation checksum v1 : {}", mysql_error(mysql));
 						mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");
 						mysql_close(mysql);
 						return false;
 					}
 					if (!DrainResults(mysql))
 					{
-						LOG_ERROR(Core, "[MigrationRunner] Drain après réparation checksum v1 : {}", mysql_error(mysql));
+						LOG_ERROR(Core, "[MigrationRunner] Drain apres reparation checksum v1 : {}", mysql_error(mysql));
 						mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");
 						mysql_close(mysql);
 						return false;
 					}
-					LOG_WARN(Core,
-						"[MigrationRunner] Checksum v1 corrigé (placeholder historique → SHA-256 actuel de {})",
-						it->second.filename().string());
+					LOG_WARN(Core, "[MigrationRunner] Checksum v1 corrige (placeholder historique -> SHA-256 actuel de {})", firstFile.filename().string());
 					continue;
 				}
-				LOG_ERROR(Core,
-					"[MigrationRunner] Checksum mismatch for version {} (file {}): en base='{}', fichier='{}'. "
-					"(voir deploy/docker/repair-schema-checksum.sh ou README si migration légitime)",
-					version,
-					it->second.generic_string(),
-					expectedChecksum,
-					computed);
+				LOG_ERROR(Core, "[MigrationRunner] Checksum mismatch version {} : aucun fichier de ce numero ne correspond (ex. {}), en base='{}'", version, firstFile.generic_string(), expectedChecksum);
 				mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");
 				mysql_close(mysql);
 				return false;
@@ -269,11 +264,22 @@ namespace engine::server
 		}
 		int maxApplied = appliedVersions.empty() ? 0 : appliedVersions.back().first;
 
+		// Anti-doublon : si deux fichiers portent le même numéro (ex. 0023), on n'applique
+		// qu'UN script par numéro et on n'insère qu'UNE ligne schema_version (sinon INSERT
+		// en double sur la PK version -> boot avorté). Les colonnes manquantes du second
+		// fichier doivent être ajoutées par une migration idempotente ultérieure (cf. 0066).
+		std::vector<int> appliedThisRun;
+
 		// Apply pending migrations
 		for (const auto& [version, path] : files)
 		{
 			if (version <= maxApplied)
 				continue;
+			if (std::find(appliedThisRun.begin(), appliedThisRun.end(), version) != appliedThisRun.end())
+			{
+				LOG_WARN(Core, "[MigrationRunner] Numero {} en double -- fichier '{}' ignore (un seul script par numero applique)", version, path.filename().string());
+				continue;
+			}
 			std::string sql = engine::platform::FileSystem::ReadAllText(path);
 			if (sql.empty())
 			{
@@ -320,6 +326,7 @@ namespace engine::server
 			}
 			DrainResults(mysql);
 			LOG_INFO(Core, "[MigrationRunner] Applied migration {} ({})", version, path.filename().string());
+			appliedThisRun.push_back(version);
 		}
 
 		mysql_query(mysql, "SELECT RELEASE_LOCK('lcdlln_master_migrations')");


### PR DESCRIPTION
## Contexte
Audit des migrations avant déploiement serveur. **Bloqueur de démarrage trouvé** : deux fichiers portent le numéro **0023** (`0023_accounts_profile.sql` + `0023_accounts_profile_fields.sql`).

Le `MigrationRunner` ajoutait **les deux** à sa liste → selon l'état de la base :
- base fraîche : deux `INSERT schema_version(version=23)` → erreur clé primaire → **boot avorté** ;
- base déjà à jour : la vérif de checksum retrouvait **un** des deux fichiers (ordre `std::sort` non déterministe) → si ≠ checksum stocké → **mismatch → boot avorté**.

Dans les deux cas, `main_linux.cpp` fait `return 1` (le master quitte).

## Correctifs
- **`MigrationRunner.cpp`** — robustesse (changements *strictement plus permissifs* : ne peuvent qu'**éviter** un abort, jamais en créer) :
  - **Checksum tolérant** : un numéro peut avoir plusieurs fichiers ; on valide si l'empreinte en base correspond à **n'importe lequel** d'eux.
  - **Anti-doublon à l'application** : un seul script par numéro est exécuté, une seule ligne `schema_version` insérée.
- **`0066_accounts_profile_complete.sql`** (idempotent) : ajoute l'**union** des colonnes des deux `0023` → quel que soit le 0023 déjà appliqué, les colonnes manquantes (`role`/parental_*/adresse/email_pending **ou** `birth_date`) sont comblées.
- **README** : documente le doublon 0023 (⚠️ **ne pas supprimer** les fichiers : le runner s'appuie sur leur présence pour valider le checksum en base).

## Pourquoi pas de suppression de fichier
Supprimer le mauvais 0023 (celui réellement appliqué) casserait la vérif de checksum. Avec le runner tolérant + 0066, **les deux 0023 restent** et le résultat est correct quel que soit l'état de la base — sans avoir besoin de connaître quel 0023 a été appliqué.

## Validation (CI = compile ; runtime = toi)
- [ ] CI build-linux/windows verte (compile masterd).
- [ ] Au boot du master : plus d'abort, et au besoin migration 66 appliquée (`[MigrationRunner] Applied migration 66`).

## Déploiement
⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master)** — modifie le MigrationRunner + ajoute la migration 0066. À déployer avant/with le prochain boot. (Aucun changement client.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)