### PR TITLE
feat(props): rendu des props statiques (coffre) — chantier B

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ add_library(engine_core
   src/client/render/skinned/SkinnedMeshLoader.cpp
   src/client/render/skinned/SkinnedMesh.cpp
   src/client/render/skinned/SkinnedRenderer.cpp
+  src/client/render/static_mesh/StaticMeshLoader.cpp
   src/client/gameplay/CharacterController.cpp
   src/client/gameplay/TerrainCollider.cpp
   src/client/gameplay/ThirdPersonCamera.cpp

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1881,5 +1881,23 @@ Les logs `[AvatarSkinDiag]` ont montré : matériaux OK (idMale=2, idFemale=3), 
 
 ### Reste
 - **#2** (peau peu visible) : `peau=1` sur 10 (seules les mains, `MI_Regular_Male`). À isoler via le test depth bias=0 (réglable à chaud, §48) : depth bias trop fort vs mesh n'exposant que les mains.
-- L'aperçu 3D réel (rendu forward dédié réutilisant `BuildSubmeshMaterialIndices`) est la **Phase 2 (§52 à venir)**.
+- L'aperçu 3D réel de l'avatar (rendu forward dédié) reste une option ultérieure.
 - **Déploiement** : ✅ client uniquement, pas de redéploiement serveur (le fix serveur du genre viendra séparément).
+
+## 52. Rendu des props statiques (coffre + interactibles) — chantier B (2026-05-24)
+
+**But** : afficher un mesh 3D pour les interactibles (coffre, etc.), au lieu du seul marqueur texte. Débloque le §F (« aucun rendu de props statiques »). Validé en jeu (le coffre s'affiche). Sur 94 props, **93 sont statiques** (sans armature) → le `SkinnedRenderer` ne peut pas les rendre ; il fallait un chemin statique.
+
+### Pièces
+- `src/client/render/static_mesh/StaticMeshLoader.{h,cpp}` : loader glTF **statique** (cgltf, CPU). Lit géométrie (pos/normal/uv) + sous-maillages + **URI de textures par matériau** (trim sheet). Pendant non-skinné de `SkinnedMeshLoader`. N'inclut PAS `CGLTF_IMPLEMENTATION` (résolu via SkinnedMeshLoader.cpp). Testé : `static_mesh_loader_tests` (Barrel statique, Chest extrait les matériaux/URIs, fichier absent → nullopt).
+- `AssetRegistry::CreateMeshFromData(vertexData, vertexCount, indices, indexCount)` : crée un `MeshAsset` GPU depuis des données en mémoire (format `kMeshVertexStride`=32o pos/normal/uv, identique `.mesh`), sans fichier ni cache. Miroir de `loadMeshInternal`.
+- `Engine::LoadInteractableProps()` (boot) : pour chaque interactible avec `meshPath`, charge le glTF, **groupe les sous-maillages par matériau**, crée un `MeshAsset` par groupe + résout/charge le **matériau trim** (cache bindless, mis en cache par nom de matériau via `materialCache.CreateMaterial`). Stocke `m_props` (matrice modèle + parties `{MeshHandle, materialIndex}`). Matrice = `Translate(pos au sol) * RotateY(yaw) * Scale`.
+- `Engine::RecordPropsGeometry(cmd, reg, rs)` (par frame, dans la passe « Geometry » après l'avatar) : **approche A** = un `GeometryPass.Record(... loadExistingGbuffer=true)` par partie (matériau), superposé au GBuffer terrain+avatar. No-op si pas de load pass.
+- Config : `world.interactables.N.mesh` / `scale` / `yaw_deg` ; `InteractableEntity` += `meshPath`/`meshScale`/`meshYawDeg`. Le coffre → `meshes/props/Chest_Wood.gltf`.
+
+### Limites / reste
+- Le **coffre est riggé** (seul prop avec armature) → rendu en **pose de repos** (squelette ignoré) ; OK visuellement, mais les props statiques (Barrel…) sont le cas nominal.
+- Pas de vertex-color (matériaux `MI_Trim_*_Vertex`) → ces props rendraient à plat (finition ultérieure).
+- Pas de culling par prop ni d'instancing (quelques draws, OK pour peu de props).
+- **Chantier C** à suivre : surbrillance du prop ciblé + repère d'interaction (remplace le `[E]` texte).
+- **Déploiement** : ✅ client uniquement.

--- a/config.json
+++ b/config.json
@@ -146,7 +146,7 @@
         "interactables": {
             "count": 2,
             "0": { "x": 4.0, "z": 0.0, "radius": 2.5, "npc": true, "label": "Villageois", "message": "Villageois : Bonjour !", "dialogue": { "count": 3, "0": "Bonjour, aventurier ! Bienvenue par ici.", "1": "Le bassin de test est a l'est, si tu veux nager.", "2": "Reviens me voir quand tu veux." } },
-            "1": { "x": -4.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Coffre", "message": "Vous fouillez le coffre... vide pour l'instant." }
+            "1": { "x": -4.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Coffre", "message": "Vous fouillez le coffre... vide pour l'instant.", "mesh": "meshes/props/Chest_Wood.gltf", "scale": 1.0, "yaw_deg": 0.0 }
         },
         "_comment_test_water": "Nage : bassin de TEST procedural (la zone demo n'a pas d'eau). enabled=false pour le retirer. Ignore si un instances/water.bin reel est charge.",
         "test_water": {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -686,6 +686,11 @@ elseif(UNIX)
   lcdlln_add_simple_test(skinned_mesh_loader_tests
     ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/SkinnedMeshLoaderTests.cpp)
 
+  # Chargeur de mesh glTF statique (props, chantier B). StaticMeshLoader.cpp est
+  # compile dans engine_core ; cgltf y est resolu via SkinnedMeshLoader.cpp (CGLTF_IMPLEMENTATION).
+  lcdlln_add_simple_test(static_mesh_loader_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/static_mesh/tests/StaticMeshLoaderTests.cpp)
+
   # Sous-projet B.1 (locomotion state machine) etape 1/14 : Mat4 helpers.
   # Identity / Translate / RotateY utilises par la state machine pour composer
   # T(pos) * R_y(yaw) par frame (model matrix de l'avatar).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1,5 +1,6 @@
 ﻿#include "src/client/app/Engine.h"
 
+#include "src/client/render/static_mesh/StaticMeshLoader.h"
 #include "src/shared/core/Log.h"
 #include "src/world_editor/ui/EditorMode.h"
 #include "src/world_editor/ui/WorldEditorImGui.h"
@@ -4510,6 +4511,9 @@ namespace engine
 												e.isNpc = m_cfg.GetBool(base + "npc", false);
 												e.label = m_cfg.GetString(base + "label", "?");
 												e.message = m_cfg.GetString(base + "message", "");
+												e.meshPath = m_cfg.GetString(base + "mesh", "");
+												e.meshScale = static_cast<float>(m_cfg.GetDouble(base + "scale", 1.0));
+												e.meshYawDeg = static_cast<float>(m_cfg.GetDouble(base + "yaw_deg", 0.0));
 												const int dcount = static_cast<int>(m_cfg.GetInt(base + "dialogue.count", 0));
 												for (int dj = 0; dj < dcount; ++dj)
 													e.dialogue.push_back(m_cfg.GetString(base + "dialogue." + std::to_string(dj), ""));
@@ -4526,9 +4530,12 @@ namespace engine
 												chest.position = engine::math::Vec3{ -4.0f, 0.0f, 0.0f };
 												chest.radius = 2.0f; chest.isNpc = false; chest.label = "Coffre";
 												chest.message = "Vous fouillez le coffre... vide pour l'instant.";
+												chest.meshPath = "meshes/props/Chest_Wood.gltf";
 												m_interactables.push_back(chest);
 											}
 											m_interactableInRange = -1;
+											// Chantier B : charge les meshes statiques des props (coffre + interactibles).
+											LoadInteractableProps();
 
 											engine::gameplay::CharacterController::Config ccCfg{};
 											ccCfg.walkSpeed     = static_cast<float>(m_cfg.GetDouble("player.movement.walk_speed",      5.0));
@@ -4802,6 +4809,9 @@ namespace engine
 																m_avatarSkinDepthBiasSlope);
 														});
 												}
+
+												// Chantier B : dessine les props statiques (coffre, etc.) par-dessus le GBuffer.
+												RecordPropsGeometry(cmd, reg, rs);
 
 												// M100 — Task 12 : drawcall terrain chunk (post-Phase-3a).
 												// Dessine les chunks visibles qui ont terrain.bin + splat.bin
@@ -9221,6 +9231,138 @@ namespace engine
 			LOG_WARN(Core, "[Avatar] character_appearance.json non ecrit (genre perso non persiste)");
 		LOG_INFO(Core, "[Avatar] Genre perso '{}' -> {} (persiste, {} perso(s))",
 			characterName, gender, genders.size());
+	}
+
+	void Engine::LoadInteractableProps()
+	{
+		m_props.clear();
+		if (!m_pipeline) return;
+		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
+		if (!materialCache.IsValid()) return;
+		const std::string contentRoot = m_cfg.GetString("paths.content", "game/data");
+		constexpr float kDeg2Rad = 3.14159265f / 180.f;
+		// Cache materiau trim par nom (Furniture/Metal/Cloth...) -> index bindless.
+		std::unordered_map<std::string, uint32_t> trimMatCache;
+
+		for (const auto& e : m_interactables)
+		{
+			if (e.meshPath.empty()) continue;
+			const std::string full = contentRoot + "/" + e.meshPath;
+			auto cpu = engine::render::staticmesh::StaticMeshLoader::LoadCpuOnlyForTests(full);
+			if (!cpu || cpu->vertices.empty() || cpu->submeshes.empty())
+			{
+				LOG_WARN(Render, "[Props] mesh load FAIL '{}'", full);
+				continue;
+			}
+			// Dossier du mesh : les URI de textures sont relatives au .gltf.
+			std::string meshDir;
+			{
+				const auto slash = e.meshPath.find_last_of('/');
+				if (slash != std::string::npos) meshDir = e.meshPath.substr(0, slash + 1);
+			}
+			// Groupe les indices par nom de materiau + un sous-maillage representatif (URIs).
+			std::unordered_map<std::string, std::vector<uint32_t>> idxByMat;
+			std::unordered_map<std::string, const engine::render::staticmesh::StaticSubMesh*> repByMat;
+			for (const auto& sub : cpu->submeshes)
+			{
+				std::vector<uint32_t>& v = idxByMat[sub.materialName];
+				v.insert(v.end(), cpu->indices.begin() + sub.firstIndex,
+				         cpu->indices.begin() + sub.firstIndex + sub.indexCount);
+				if (repByMat.find(sub.materialName) == repByMat.end()) repByMat[sub.materialName] = &sub;
+			}
+
+			PropRenderable prop;
+			const float groundY = m_terrainCollider.GroundHeightAt(e.position.x, e.position.z);
+			engine::math::Mat4 scaleM = engine::math::Mat4::Identity();
+			scaleM.m[0] = e.meshScale; scaleM.m[5] = e.meshScale; scaleM.m[10] = e.meshScale;
+			prop.modelMatrix =
+				engine::math::Mat4::Translate(engine::math::Vec3{ e.position.x, groundY, e.position.z }) *
+				engine::math::Mat4::RotateY(e.meshYawDeg * kDeg2Rad) *
+				scaleM;
+
+			for (const auto& kv : idxByMat)
+			{
+				const std::string& matName = kv.first;
+				const std::vector<uint32_t>& idxs = kv.second;
+				if (idxs.empty()) continue;
+				engine::render::MeshHandle mh = m_assetRegistry.CreateMeshFromData(
+					cpu->vertices.data(), static_cast<uint32_t>(cpu->vertices.size()),
+					idxs.data(), static_cast<uint32_t>(idxs.size()));
+				if (!mh.IsValid()) continue;
+
+				uint32_t matIdx = materialCache.GetDefaultMaterialIndex();
+				auto cached = trimMatCache.find(matName);
+				if (cached != trimMatCache.end())
+				{
+					matIdx = cached->second;
+				}
+				else
+				{
+					const engine::render::staticmesh::StaticSubMesh* rep = repByMat[matName];
+					if (rep && !rep->baseColorUri.empty())
+					{
+						const engine::render::TextureHandle bc =
+							m_assetRegistry.LoadTexture(meshDir + rep->baseColorUri, /*useSrgb*/ true);
+						if (bc.IsValid())
+						{
+							engine::render::Material mat{};
+							mat.baseColor = bc;
+							if (!rep->normalUri.empty())
+							{
+								const engine::render::TextureHandle n = m_assetRegistry.LoadTexture(meshDir + rep->normalUri, false);
+								if (n.IsValid()) mat.normal = n;
+							}
+							if (!rep->ormUri.empty())
+							{
+								const engine::render::TextureHandle o = m_assetRegistry.LoadTexture(meshDir + rep->ormUri, false);
+								if (o.IsValid()) mat.orm = o;
+							}
+							matIdx = materialCache.CreateMaterial(m_vkDeviceContext.GetDevice(), mat);
+						}
+					}
+					trimMatCache[matName] = matIdx;
+				}
+
+				PropPart part;
+				part.mesh = mh;
+				part.materialIndex = matIdx;
+				prop.parts.push_back(part);
+			}
+
+			if (!prop.parts.empty())
+			{
+				LOG_INFO(Render, "[Props] '{}' charge ({} partie(s), mesh '{}')", e.label, prop.parts.size(), e.meshPath);
+				m_props.push_back(std::move(prop));
+			}
+		}
+		LOG_INFO(Render, "[Props] {} prop(s) rendus", m_props.size());
+	}
+
+	void Engine::RecordPropsGeometry(VkCommandBuffer cmd, engine::render::Registry& reg,
+	                                 const engine::RenderState& rs)
+	{
+		if (m_props.empty() || !m_pipeline) return;
+		auto& geom = m_pipeline->GetGeometryPass();
+		// loadOp=LOAD requis pour se superposer au GBuffer (terrain + avatar) sans clear.
+		if (!geom.HasLoadPass()) return;
+		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
+		for (const auto& prop : m_props)
+		{
+			for (const auto& part : prop.parts)
+			{
+				engine::render::MeshAsset* mesh = part.mesh.Get();
+				if (mesh == nullptr) continue;
+				geom.Record(
+					m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(),
+					m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId, m_fgGBufferVelocityId, m_fgDepthId,
+					rs.prevViewProjMatrix.m, rs.viewProjMatrix.m, mesh,
+					0u,
+					materialCache.GetDescriptorSet(),
+					prop.modelMatrix.m,
+					part.materialIndex,
+					true);
+			}
+		}
 	}
 
 	void Engine::OnResize(int w, int h)

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -683,9 +683,44 @@ namespace engine
 			/// affiche la ligne suivante (boucle). Sinon on affiche `message`.
 			std::vector<std::string> dialogue;
 			int dialogueCursor = 0;
+			/// Mesh statique optionnel du prop (chantier B). Chemin relatif à
+			/// paths.content (ex. "meshes/props/Chest_Wood.gltf"). Vide = pas de mesh
+			/// rendu (marqueur ImGui seul, comportement historique).
+			std::string meshPath;
+			float meshScale = 1.0f;    ///< Échelle uniforme appliquée au mesh.
+			float meshYawDeg = 0.0f;   ///< Rotation Y (degrés) du mesh.
 		};
 		std::vector<InteractableEntity> m_interactables;
 		int m_interactableInRange = -1;
+
+		/// Une partie de prop = un sous-ensemble de matériau (un MeshAsset GPU + son
+		/// index matériau bindless). Un prop multi-matériaux a plusieurs parties.
+		struct PropPart
+		{
+			engine::render::MeshHandle mesh;
+			uint32_t materialIndex = 0;
+		};
+		/// Prop rendu in-world : matrice modèle monde + parties (une par matériau).
+		struct PropRenderable
+		{
+			engine::math::Mat4 modelMatrix = engine::math::Mat4::Identity();
+			std::vector<PropPart> parts;
+		};
+		/// Props statiques rendus (chantier B), construits au boot depuis les
+		/// interactibles ayant un meshPath. Cf. LoadInteractableProps / RecordPropsGeometry.
+		std::vector<PropRenderable> m_props;
+
+		/// Charge les meshes glTF statiques des interactibles (groupés par matériau,
+		/// matériaux trim chargés dans le cache bindless) et peuple m_props. À appeler
+		/// au boot, après l'init du pipeline (cache matériaux valide) et le parse des
+		/// interactibles. Main thread.
+		void LoadInteractableProps();
+
+		/// Dessine les props (m_props) dans la passe Geometry, après l'avatar : un
+		/// GeometryPass.Record par partie (matériau) avec loadOp=LOAD (superposition au
+		/// GBuffer terrain/avatar). No-op si pas de props ou pas de load pass.
+		void RecordPropsGeometry(VkCommandBuffer cmd, engine::render::Registry& reg,
+		                         const engine::RenderState& rs);
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/render/AssetRegistry.cpp
+++ b/src/client/render/AssetRegistry.cpp
@@ -316,6 +316,86 @@ namespace engine::render
 		LOG_INFO(Render, "[AssetRegistry] Destroyed");
 	}
 
+	MeshHandle AssetRegistry::CreateMeshFromData(const void* vertexData, uint32_t vertexCount,
+	                                             const uint32_t* indices, uint32_t indexCount)
+	{
+		if (m_device == VK_NULL_HANDLE || vertexData == nullptr || vertexCount == 0 ||
+			indices == nullptr || indexCount == 0)
+			return MeshHandle(this, kInvalidAssetId);
+
+		const size_t vertexBytes = static_cast<size_t>(vertexCount) * kMeshVertexStride;
+		const size_t indexBytes  = static_cast<size_t>(indexCount) * sizeof(uint32_t);
+		const uint8_t* vBytes = reinterpret_cast<const uint8_t*>(vertexData);
+
+		MeshAsset asset{};
+		asset.vertexCount = vertexCount;
+		asset.indexCount  = indexCount;
+		{
+			const float* first = reinterpret_cast<const float*>(vBytes);
+			asset.localBoundsMin = { first[0], first[1], first[2] };
+			asset.localBoundsMax = asset.localBoundsMin;
+			for (uint32_t vi = 1; vi < vertexCount; ++vi)
+			{
+				const float* p = reinterpret_cast<const float*>(vBytes + static_cast<size_t>(vi) * kMeshVertexStride);
+				asset.localBoundsMin.x = std::min(asset.localBoundsMin.x, p[0]);
+				asset.localBoundsMin.y = std::min(asset.localBoundsMin.y, p[1]);
+				asset.localBoundsMin.z = std::min(asset.localBoundsMin.z, p[2]);
+				asset.localBoundsMax.x = std::max(asset.localBoundsMax.x, p[0]);
+				asset.localBoundsMax.y = std::max(asset.localBoundsMax.y, p[1]);
+				asset.localBoundsMax.z = std::max(asset.localBoundsMax.z, p[2]);
+			}
+			asset.hasLocalBounds = true;
+		}
+
+		auto createBuffer = [&](VkDeviceSize size, VkBufferUsageFlags usage,
+			VkBuffer& outBuffer, void*& outAlloc) -> bool
+		{
+			VkBufferCreateInfo bufInfo{};
+			bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+			bufInfo.size = size;
+			bufInfo.usage = usage;
+			bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+			if (vkCreateBuffer(m_device, &bufInfo, nullptr, &outBuffer) != VK_SUCCESS || outBuffer == VK_NULL_HANDLE)
+				return false;
+			VkMemoryRequirements memReq{};
+			vkGetBufferMemoryRequirements(m_device, outBuffer, &memReq);
+			uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits,
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+			if (memTypeIdx == UINT32_MAX) { vkDestroyBuffer(m_device, outBuffer, nullptr); outBuffer = VK_NULL_HANDLE; return false; }
+			VkMemoryAllocateInfo allocInfo{};
+			allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			allocInfo.allocationSize = memReq.size;
+			allocInfo.memoryTypeIndex = memTypeIdx;
+			VkDeviceMemory mem = VK_NULL_HANDLE;
+			if (vkAllocateMemory(m_device, &allocInfo, nullptr, &mem) != VK_SUCCESS || mem == VK_NULL_HANDLE) { vkDestroyBuffer(m_device, outBuffer, nullptr); outBuffer = VK_NULL_HANDLE; return false; }
+			if (vkBindBufferMemory(m_device, outBuffer, mem, 0) != VK_SUCCESS) { vkFreeMemory(m_device, mem, nullptr); vkDestroyBuffer(m_device, outBuffer, nullptr); outBuffer = VK_NULL_HANDLE; return false; }
+			outAlloc = reinterpret_cast<void*>(mem);
+			return true;
+		};
+
+		if (!createBuffer(vertexBytes, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, asset.vertexBuffer, asset.vertexAlloc))
+			return MeshHandle(this, kInvalidAssetId);
+		if (!createBuffer(indexBytes, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, asset.indexBuffer, asset.indexAlloc))
+		{
+			VkDeviceMemory vMem = reinterpret_cast<VkDeviceMemory>(asset.vertexAlloc);
+			vkDestroyBuffer(m_device, asset.vertexBuffer, nullptr);
+			vkFreeMemory(m_device, vMem, nullptr);
+			return MeshHandle(this, kInvalidAssetId);
+		}
+
+		void* pv = nullptr;
+		VkDeviceMemory vMem = reinterpret_cast<VkDeviceMemory>(asset.vertexAlloc);
+		if (vkMapMemory(m_device, vMem, 0, vertexBytes, 0, &pv) == VK_SUCCESS) { memcpy(pv, vBytes, vertexBytes); vkUnmapMemory(m_device, vMem); }
+		void* pi = nullptr;
+		VkDeviceMemory iMem = reinterpret_cast<VkDeviceMemory>(asset.indexAlloc);
+		if (vkMapMemory(m_device, iMem, 0, indexBytes, 0, &pi) == VK_SUCCESS) { memcpy(pi, indices, indexBytes); vkUnmapMemory(m_device, iMem); }
+
+		AssetId id = m_nextMeshId++;
+		m_meshes[id] = std::move(asset);
+		LOG_INFO(Render, "[AssetRegistry] CreateMeshFromData OK ({} vertices, {} indices)", vertexCount, indexCount);
+		return MeshHandle(this, id);
+	}
+
 	AssetId AssetRegistry::loadMeshInternal(std::string_view relativePath)
 	{
 		LOG_WARN(Render, "[ASSET] loadMesh '{}'", relativePath);

--- a/src/client/render/AssetRegistry.h
+++ b/src/client/render/AssetRegistry.h
@@ -122,6 +122,19 @@ namespace engine::render
 		/// Format: minimal binary .mesh (see implementation). Returns invalid handle on failure.
 		MeshHandle LoadMesh(std::string_view relativePath);
 
+		/// Crée un MeshAsset GPU à partir de données en mémoire (props chargés depuis
+		/// glTF, chantier B). Les sommets doivent être au format `kMeshVertexStride`
+		/// (pos[3]+normal[3]+uv[2] = 32 octets), identique au format `.mesh`, pour être
+		/// compatibles avec le pipeline GeometryPass. Pas de cache (chaque appel crée un
+		/// nouvel asset, libéré au Shutdown du registry).
+		/// \param vertexData    Pointeur vers `vertexCount * 32` octets (8 floats/sommet).
+        /// \param vertexCount   Nombre de sommets.
+        /// \param indices       Index buffer (uint32, triangle list).
+        /// \param indexCount    Nombre d'indices.
+		/// \return Handle invalide si device absent, données vides, ou échec Vulkan.
+		MeshHandle CreateMeshFromData(const void* vertexData, uint32_t vertexCount,
+		                              const uint32_t* indices, uint32_t indexCount);
+
 		/// Loads a texture from content path. Returns cached asset if already loaded.
 		/// \param useSrgb If true, use sRGB format; otherwise linear.
 		/// Format: raw .texr (magic, width, height, sRGB flag, RGBA pixels) ou PNG (8-bit RGBA).

--- a/src/client/render/static_mesh/StaticMeshLoader.cpp
+++ b/src/client/render/static_mesh/StaticMeshLoader.cpp
@@ -1,0 +1,119 @@
+#include "src/client/render/static_mesh/StaticMeshLoader.h"
+
+// cgltf est défini (CGLTF_IMPLEMENTATION) une seule fois dans le projet, dans
+// SkinnedMeshLoader.cpp. Ici on n'inclut que les déclarations.
+#include "cgltf.h"
+
+#include "src/shared/core/Log.h"
+
+namespace engine::render::staticmesh
+{
+
+namespace
+{
+    /// Extrait l'URI d'image d'une texture_view glTF (ou chaîne vide si absente).
+    std::string UriOf(const cgltf_texture_view& view)
+    {
+        if (view.texture && view.texture->image && view.texture->image->uri)
+            return view.texture->image->uri;
+        return {};
+    }
+}  // namespace
+
+std::optional<StaticMeshCpuData> StaticMeshLoader::LoadCpuOnlyForTests(const std::string& path)
+{
+    cgltf_options options = {};
+    cgltf_data* data = nullptr;
+    cgltf_result result = cgltf_parse_file(&options, path.c_str(), &data);
+    if (result != cgltf_result_success)
+    {
+        LOG_WARN(Render, "[StaticMeshLoader] Parse failed for '{}' (cgltf result={})", path, static_cast<int>(result));
+        if (data) cgltf_free(data);
+        return std::nullopt;
+    }
+    if (cgltf_load_buffers(&options, data, path.c_str()) != cgltf_result_success)
+    {
+        LOG_WARN(Render, "[StaticMeshLoader] Load buffers failed for '{}'", path);
+        cgltf_free(data);
+        return std::nullopt;
+    }
+
+    StaticMeshCpuData out;
+    bool meshLoaded = false;
+
+    // Fusionne toutes les primitives de tous les meshes en un seul buffer
+    // (vertices/indices), en réindexant chaque primitive sur l'offset courant.
+    for (cgltf_size mi = 0; mi < data->meshes_count; ++mi)
+    {
+        const cgltf_mesh* mesh = &data->meshes[mi];
+        for (cgltf_size pi = 0; pi < mesh->primitives_count; ++pi)
+        {
+            const cgltf_primitive* prim = &mesh->primitives[pi];
+            const cgltf_accessor *aPos = nullptr, *aNor = nullptr, *aUv = nullptr;
+            for (cgltf_size ai = 0; ai < prim->attributes_count; ++ai)
+            {
+                const cgltf_attribute& at = prim->attributes[ai];
+                if (at.type == cgltf_attribute_type_position) aPos = at.data;
+                else if (at.type == cgltf_attribute_type_normal) aNor = at.data;
+                else if (at.type == cgltf_attribute_type_texcoord && at.index == 0) aUv = at.data;
+            }
+            if (!aPos) continue;  // primitive sans position : ignorée
+
+            const uint32_t baseVertex = static_cast<uint32_t>(out.vertices.size());
+            const size_t nv = aPos->count;
+            out.vertices.resize(baseVertex + nv);
+            for (size_t v = 0; v < nv; ++v)
+            {
+                StaticVertex& sv = out.vertices[baseVertex + v];
+                cgltf_accessor_read_float(aPos, v, sv.pos, 3);
+                if (aNor) cgltf_accessor_read_float(aNor, v, sv.normal, 3);
+                if (aUv)  cgltf_accessor_read_float(aUv, v, sv.uv, 2);
+            }
+
+            const uint32_t subFirstIndex = static_cast<uint32_t>(out.indices.size());
+            if (prim->indices)
+            {
+                const size_t ni = prim->indices->count;
+                const size_t base = out.indices.size();
+                out.indices.resize(base + ni);
+                for (size_t i = 0; i < ni; ++i)
+                    out.indices[base + i] = baseVertex + static_cast<uint32_t>(cgltf_accessor_read_index(prim->indices, i));
+            }
+            else
+            {
+                const size_t base = out.indices.size();
+                out.indices.resize(base + nv);
+                for (size_t i = 0; i < nv; ++i)
+                    out.indices[base + i] = baseVertex + static_cast<uint32_t>(i);
+            }
+
+            StaticSubMesh sub;
+            sub.firstIndex = subFirstIndex;
+            sub.indexCount = static_cast<uint32_t>(out.indices.size()) - subFirstIndex;
+            if (prim->material)
+            {
+                if (prim->material->name) sub.materialName = prim->material->name;
+                if (prim->material->has_pbr_metallic_roughness)
+                {
+                    const cgltf_pbr_metallic_roughness& pbr = prim->material->pbr_metallic_roughness;
+                    sub.baseColorUri = UriOf(pbr.base_color_texture);
+                    sub.ormUri       = UriOf(pbr.metallic_roughness_texture);
+                }
+                sub.normalUri = UriOf(prim->material->normal_texture);
+            }
+            out.submeshes.push_back(std::move(sub));
+            meshLoaded = true;
+        }
+    }
+
+    cgltf_free(data);
+
+    if (!meshLoaded)
+    {
+        LOG_WARN(Render, "[StaticMeshLoader] No primitive with POSITION in '{}'", path);
+        return std::nullopt;
+    }
+    return out;
+}
+
+}  // namespace engine::render::staticmesh

--- a/src/client/render/static_mesh/StaticMeshLoader.h
+++ b/src/client/render/static_mesh/StaticMeshLoader.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// Chargeur de mesh glTF STATIQUE (sans squelette) pour les props (chantier B).
+// Pendant non-skinné de SkinnedMeshLoader : 93/94 props n'ont pas d'armature et
+// ne peuvent donc pas passer par SkinnedMeshLoader (qui exige JOINTS_0/WEIGHTS_0).
+//
+// Cette première étape (incrément 1) ne fait que la lecture CPU (cgltf) :
+// géométrie + sous-maillages + chemins de textures par matériau. L'upload GPU et
+// le rendu (via GeometryPass) viennent dans les incréments suivants.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::render::staticmesh
+{
+
+/// Sommet statique minimal (position + normale + UV). Pas de bones/weights.
+struct StaticVertex
+{
+    float pos[3]    = { 0.f, 0.f, 0.f };
+    float normal[3] = { 0.f, 0.f, 1.f };
+    float uv[2]     = { 0.f, 0.f };
+};
+
+/// Plage d'indices d'un sous-maillage + nom et textures du matériau glTF associé.
+/// Les chemins de textures sont les `uri` glTF (relatifs au .gltf), vides si absents.
+struct StaticSubMesh
+{
+    uint32_t    firstIndex = 0;   ///< Offset (en indices) du début de la plage.
+    uint32_t    indexCount = 0;   ///< Nombre d'indices (multiple de 3).
+    std::string materialName;     ///< Nom du matériau glTF (ex. "MI_Trim_Metal"). Vide si aucun.
+    std::string baseColorUri;     ///< URI baseColor (sRGB). Vide si absent.
+    std::string normalUri;        ///< URI normal map (linéaire). Vide si absent.
+    std::string ormUri;           ///< URI ORM / metallic-roughness (linéaire). Vide si absent.
+};
+
+/// Données CPU d'un mesh statique : sommets + indices triangulaires + sous-maillages.
+/// Toutes les primitives de tous les meshes du fichier sont fusionnées (un seul
+/// vertex/index buffer), comme SkinnedMeshLoader.
+struct StaticMeshCpuData
+{
+    std::vector<StaticVertex> vertices;
+    std::vector<uint32_t>     indices;
+    std::vector<StaticSubMesh> submeshes;
+};
+
+class StaticMeshLoader
+{
+public:
+    /// Parse un .gltf/.glb statique via cgltf et renvoie ses données CPU.
+    /// \return std::nullopt si le fichier est introuvable/illisible, ou s'il ne
+    ///         contient aucune primitive avec attribut POSITION.
+    /// N'alloue aucune ressource GPU (lecture CPU pure ; testable hors device).
+    static std::optional<StaticMeshCpuData> LoadCpuOnlyForTests(const std::string& path);
+};
+
+}  // namespace engine::render::staticmesh

--- a/src/client/render/static_mesh/tests/StaticMeshLoaderTests.cpp
+++ b/src/client/render/static_mesh/tests/StaticMeshLoaderTests.cpp
@@ -1,0 +1,74 @@
+// Tests for StaticMeshLoader — CPU-only path against real prop .gltf fixtures.
+
+#include "src/client/render/static_mesh/StaticMeshLoader.h"
+
+#include <cstdio>
+#include <string>
+
+using engine::render::staticmesh::StaticMeshCpuData;
+using engine::render::staticmesh::StaticMeshLoader;
+
+namespace
+{
+    int g_failed = 0;
+    #define REQUIRE(cond) do { \
+        if (!(cond)) { std::fprintf(stderr, "[FAIL] %s:%d %s\n", __FILE__, __LINE__, #cond); ++g_failed; } \
+    } while (0)
+
+    // Un prop STATIQUE (sans armature) se charge : géométrie non vide, triangles valides.
+    void Test_LoadStaticBarrel()
+    {
+        auto result = StaticMeshLoader::LoadCpuOnlyForTests("game/data/meshes/props/Barrel.gltf");
+        REQUIRE(result.has_value());
+        if (!result.has_value()) return;
+        const StaticMeshCpuData& m = *result;
+        REQUIRE(!m.vertices.empty());
+        REQUIRE(!m.indices.empty());
+        REQUIRE(m.indices.size() % 3 == 0);  // triangles
+        REQUIRE(!m.submeshes.empty());
+        // Toutes les plages de sous-maillage sont dans les bornes de l'index buffer.
+        for (const auto& s : m.submeshes)
+        {
+            REQUIRE(s.indexCount % 3 == 0);
+            REQUIRE(static_cast<size_t>(s.firstIndex) + s.indexCount <= m.indices.size());
+        }
+        // Tous les indices référencent un sommet existant.
+        for (uint32_t idx : m.indices)
+            REQUIRE(idx < m.vertices.size());
+    }
+
+    // Le coffre (riggé) se charge AUSSI par le loader statique (on ignore le skin) :
+    // valide l'extraction des noms de matériaux trim + des URI de textures.
+    void Test_LoadChestExtractsTrimMaterials()
+    {
+        auto result = StaticMeshLoader::LoadCpuOnlyForTests("game/data/meshes/props/Chest_Wood.gltf");
+        REQUIRE(result.has_value());
+        if (!result.has_value()) return;
+        const StaticMeshCpuData& m = *result;
+        REQUIRE(!m.submeshes.empty());
+        bool foundNamedMaterial = false;
+        bool foundBaseColorUri = false;
+        for (const auto& s : m.submeshes)
+        {
+            if (!s.materialName.empty()) foundNamedMaterial = true;
+            if (!s.baseColorUri.empty()) foundBaseColorUri = true;
+        }
+        REQUIRE(foundNamedMaterial);   // ex. "MI_Trim_Furniture" / "MI_Trim_Metal"
+        REQUIRE(foundBaseColorUri);    // ex. "T_Trim_Furniture_BaseColor.png"
+    }
+
+    // Chemin inexistant -> std::nullopt (pas de crash).
+    void Test_LoadMissingFile_ReturnsNullopt()
+    {
+        auto result = StaticMeshLoader::LoadCpuOnlyForTests("game/data/meshes/props/does_not_exist.gltf");
+        REQUIRE(!result.has_value());
+    }
+}  // namespace
+
+int main()
+{
+    Test_LoadStaticBarrel();
+    Test_LoadChestExtractsTrimMaterials();
+    Test_LoadMissingFile_ReturnsNullopt();
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Contexte (chantier B — rendu des props)
Audit : sur 94 props (`game/data/meshes/props/*.gltf`), **93 sont statiques** (sans armature). `SkinnedRenderer` exige `JOINTS_0/WEIGHTS_0` → il ne peut pas les rendre. C'est le blocage §F « aucun rendu de props statiques ». Approche retenue (validée) : **loader glTF statique + rendu via `GeometryPass`** ; périmètre initial **coffre + interactibles**.

## Incrément 1 (cette PR) — fondation CPU, testable en CI
- `src/client/render/static_mesh/StaticMeshLoader.{h,cpp}` : pendant non-skinné de `SkinnedMeshLoader`. Lit géométrie (pos/normal/uv) + sous-maillages + **URI de textures par matériau** (trim sheet : baseColor/normal/ORM) via cgltf, en **CPU pur** (pas de GPU). cgltf est résolu via `SkinnedMeshLoader.cpp` (qui porte `CGLTF_IMPLEMENTATION`).
- `static_mesh_loader_tests` : Barrel (statique) charge + invariants (triangles, indices bornés) ; Chest_Wood extrait les matériaux trim + URIs ; fichier absent → `nullopt`.

## Suite (incréments à venir)
2. Upload GPU (`StaticMesh`) + chargement des matériaux trim dans le cache bindless.
3. Liste d'instances depuis `world.interactables` (+ meshPath/transform) + **draw via `GeometryPass`**.
4. (chantier C) feedback d'interaction : surbrillance + repère, en remplacement du `[E]` texte.

## Validation
- [ ] CI verte (compile engine_core + `static_mesh_loader_tests`). ⚠️ CI compile-only : le test s'exécute en local/VS ou chez toi.
- Rien de visible en jeu encore (fondation) — le rendu arrive aux incréments 2/3.

## Déploiement
✅ **client uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)