### PR TITLE
feat(interaction): surbrillance 3D du prop + badge touche E (chantier C)

### DIFF
--- a/game/data/shaders/gbuffer_geometry.frag
+++ b/game/data/shaders/gbuffer_geometry.frag
@@ -53,6 +53,12 @@ void main()
     // pass will read it as linear (sRGB attachment auto-linearises on sample).
     outAlbedo = texture(uTextures[mat.baseColorIndex], tiledUv);
 
+    // Surbrillance d'interaction (chantier C) : si le bit Highlight (1) est posé dans
+    // mat.flags, on teinte l'albedo vers un or chaud + on l'éclaircit. Les matériaux
+    // normaux (flags=0) ne sont pas affectés.
+    if ((mat.flags & 1u) != 0u)
+        outAlbedo.rgb = mix(outAlbedo.rgb, vec3(1.0, 0.85, 0.30), 0.45) * 1.25;
+
     // ---- Normal -----------------------------------------------------------
     // Decode the tangent-space normal map from [0,1] → [-1,1].
     // Without per-vertex tangent data (MVP) we perturb the interpolated

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8286,9 +8286,23 @@ namespace engine
 						continue;
 					const bool inRange = (static_cast<int>(ii) == m_interactableInRange);
 					const ImU32 col = inRange ? IM_COL32(255, 220, 80, 255) : IM_COL32(210, 210, 210, 200);
-					const std::string txt = e.label + (inRange ? " [E]" : "");
-					const ImVec2 ts = ImGui::CalcTextSize(txt.c_str());
-					fg->AddText(ImVec2(sx - ts.x * 0.5f, sy - ts.y), col, txt.c_str());
+					// Label du nom seul ; le "[E]" texte est remplace par un badge touche
+					// (chantier C) + la surbrillance 3D du prop signale l'interactivite.
+					const ImVec2 ts = ImGui::CalcTextSize(e.label.c_str());
+					fg->AddText(ImVec2(sx - ts.x * 0.5f, sy - ts.y), col, e.label.c_str());
+					// Repere d'interaction : badge "touche E" sous le label quand a portee.
+					if (inRange)
+					{
+						const ImVec2 keySz = ImGui::CalcTextSize("E");
+						const float pad = 6.0f;
+						const float bw = keySz.x + pad * 2.0f;
+						const float bh = keySz.y + pad * 2.0f;
+						const float bx = sx - bw * 0.5f;
+						const float by = sy + 4.0f;
+						fg->AddRectFilled(ImVec2(bx, by), ImVec2(bx + bw, by + bh), IM_COL32(20, 20, 24, 220), 4.0f);
+						fg->AddRect(ImVec2(bx, by), ImVec2(bx + bw, by + bh), IM_COL32(255, 220, 80, 255), 4.0f, 0, 2.0f);
+						fg->AddText(ImVec2(bx + pad, by + pad), IM_COL32(255, 220, 80, 255), "E");
+					}
 				}
 			}
 			// Menu de panneaux : barre de menus ImGui toujours visible en jeu,
@@ -9241,11 +9255,12 @@ namespace engine
 		if (!materialCache.IsValid()) return;
 		const std::string contentRoot = m_cfg.GetString("paths.content", "game/data");
 		constexpr float kDeg2Rad = 3.14159265f / 180.f;
-		// Cache materiau trim par nom (Furniture/Metal/Cloth...) -> index bindless.
-		std::unordered_map<std::string, uint32_t> trimMatCache;
+		// Cache materiau trim par nom (Furniture/Metal/Cloth...) -> {index normal, index highlight}.
+		std::unordered_map<std::string, std::pair<uint32_t, uint32_t>> trimMatCache;
 
-		for (const auto& e : m_interactables)
+		for (std::size_t ii = 0; ii < m_interactables.size(); ++ii)
 		{
+			const InteractableEntity& e = m_interactables[ii];
 			if (e.meshPath.empty()) continue;
 			const std::string full = contentRoot + "/" + e.meshPath;
 			auto cpu = engine::render::staticmesh::StaticMeshLoader::LoadCpuOnlyForTests(full);
@@ -9291,10 +9306,12 @@ namespace engine
 				if (!mh.IsValid()) continue;
 
 				uint32_t matIdx = materialCache.GetDefaultMaterialIndex();
+				uint32_t hlIdx  = matIdx;
 				auto cached = trimMatCache.find(matName);
 				if (cached != trimMatCache.end())
 				{
-					matIdx = cached->second;
+					matIdx = cached->second.first;
+					hlIdx  = cached->second.second;
 				}
 				else
 				{
@@ -9318,17 +9335,22 @@ namespace engine
 								if (o.IsValid()) mat.orm = o;
 							}
 							matIdx = materialCache.CreateMaterial(m_vkDeviceContext.GetDevice(), mat);
+							// Variante surbrillance : memes textures + flag Highlight (teinte au draw).
+							mat.flags = engine::render::MaterialFlags::Highlight;
+							hlIdx = materialCache.CreateMaterial(m_vkDeviceContext.GetDevice(), mat);
 						}
 					}
-					trimMatCache[matName] = matIdx;
+					trimMatCache[matName] = { matIdx, hlIdx };
 				}
 
 				PropPart part;
 				part.mesh = mh;
 				part.materialIndex = matIdx;
+				part.highlightMaterialIndex = hlIdx;
 				prop.parts.push_back(part);
 			}
 
+			prop.interactableIndex = static_cast<int>(ii);
 			if (!prop.parts.empty())
 			{
 				LOG_INFO(Render, "[Props] '{}' charge ({} partie(s), mesh '{}')", e.label, prop.parts.size(), e.meshPath);
@@ -9348,6 +9370,10 @@ namespace engine
 		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
 		for (const auto& prop : m_props)
 		{
+			// Surbrillance (chantier C) : si ce prop est l'interactible a portee, on
+			// dessine ses parties avec la variante de materiau Highlight (teinte).
+			const bool highlight =
+				(prop.interactableIndex >= 0 && prop.interactableIndex == m_interactableInRange);
 			for (const auto& part : prop.parts)
 			{
 				engine::render::MeshAsset* mesh = part.mesh.Get();
@@ -9359,7 +9385,7 @@ namespace engine
 					0u,
 					materialCache.GetDescriptorSet(),
 					prop.modelMatrix.m,
-					part.materialIndex,
+					highlight ? part.highlightMaterialIndex : part.materialIndex,
 					true);
 			}
 		}

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -699,12 +699,18 @@ namespace engine
 		{
 			engine::render::MeshHandle mesh;
 			uint32_t materialIndex = 0;
+			/// Variante du matériau avec MaterialFlags::Highlight (teinte de surbrillance).
+			/// Utilisée au draw quand le prop est l'interactible ciblé (chantier C).
+			uint32_t highlightMaterialIndex = 0;
 		};
 		/// Prop rendu in-world : matrice modèle monde + parties (une par matériau).
 		struct PropRenderable
 		{
 			engine::math::Mat4 modelMatrix = engine::math::Mat4::Identity();
 			std::vector<PropPart> parts;
+			/// Index dans m_interactables (pour comparer à m_interactableInRange et
+			/// décider la surbrillance). -1 si non lié à un interactible.
+			int interactableIndex = -1;
 		};
 		/// Props statiques rendus (chantier B), construits au boot depuis les
 		/// interactibles ayant un meshPath. Cf. LoadInteractableProps / RecordPropsGeometry.

--- a/src/client/render/Material.h
+++ b/src/client/render/Material.h
@@ -10,10 +10,13 @@
 
 namespace engine::render
 {
-	/// Flags for material properties (reserved for future use).
+	/// Flags for material properties (bitmask, propagés vers MaterialGpuData.flags).
 	enum class MaterialFlags : uint32_t
 	{
 		None = 0,
+		/// Surbrillance : le fragment shader gbuffer_geometry.frag teinte l'albedo
+		/// quand ce bit est posé (feedback d'interaction sur le prop ciblé, chantier C).
+		Highlight = 1u << 0,
 	};
 
 	/// Per-material texture handles + tiling parameters.


### PR DESCRIPTION
## Chantier C — feedback d'interaction (empilé sur #678)
Remplace le `Coffre [E]` texte par : **surbrillance 3D du prop ciblé** (option choisie) + **badge touche « E »**.

> ⚠️ Empilée sur #678 (props) : tant que #678 n'est pas mergé, ce diff inclut aussi ses commits. Après merge de #678, il ne restera que le commit C.

## Contenu
- **`MaterialFlags::Highlight`** + teinte dans `gbuffer_geometry.frag` : si le bit est posé, l'albedo est teinté or chaud + éclairci. Les matériaux normaux (flags=0) **ne sont pas affectés** (avatar/terrain/props non ciblés inchangés).
- Par partie de prop : une **variante de matériau Highlight** (mêmes textures + flag).
- `RecordPropsGeometry` : dessine le prop **à portée** (`m_interactableInRange`) avec la variante Highlight.
- Marqueur : `"[E]"` texte → **badge touche « E »** (ImGui) sous le label.

## ⚠️ Étape build de ton côté
Régénère **`game/data/shaders/gbuffer_geometry.frag.spv`** via `tools/compile_game_shaders.ps1` (j'ai modifié le `.frag`). Sans régen : pas de teinte (mais aucune casse — dégradation propre) ; le badge « E » fonctionne quand même.

## Validation (en jeu)
- Près du coffre : le mesh **se teinte/éclaircit** quand tu es à portée, et un **badge « E »** s'affiche sous « Coffre ».

## Déploiement
✅ **client uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)