### PR TITLE
feat(gender): persistance serveur du genre (#1, wire-breaking)

### DIFF
--- a/sql/migrations/0067_characters_gender.sql
+++ b/sql/migrations/0067_characters_gender.sql
@@ -1,0 +1,24 @@
+-- Migration 0067 — Genre du personnage persisté en base.
+--
+-- Jusqu'ici le genre de l'avatar était un réglage client global (puis par
+-- personnage côté client uniquement, cf. character_appearance.json). On le
+-- persiste désormais côté serveur : le client l'envoie à la création
+-- (CharacterCreateRequestPayload.gender) et le master le renvoie dans
+-- CharacterListEntry.gender → l'avatar correct (mesh + peau) au relog, quelle
+-- que soit la machine.
+--
+-- Idempotent : colonne ajoutée uniquement si manquante. Défaut 'male' pour les
+-- personnages créés avant cette migration.
+
+SET NAMES utf8mb4;
+
+SET @m67_c := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'characters' AND column_name = 'gender'
+);
+SET @m67_s := IF(@m67_c = 0,
+  'ALTER TABLE characters ADD COLUMN gender VARCHAR(8) NOT NULL DEFAULT ''male''',
+  'SELECT 1');
+PREPARE m67_p FROM @m67_s;
+EXECUTE m67_p;
+DEALLOCATE PREPARE m67_p;

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -6962,22 +6962,31 @@ namespace engine
 							spawnX, ccY, spawnZ, groundY);
 					}
 
-					// Fix client interim #1 : applique le genre persiste pour CE perso (par nom)
-					// AVANT la selection du mesh/peau. Absent (perso cree cette session, ou
-					// perso d'avant ce fix) => on garde le genre courant. Le stockage serveur
-					// (DB) remplacera cette lecture client le moment venu.
+					// #1 — genre du perso applique AVANT la selection du mesh/peau.
+					// Source autoritative : enterCmd.gender (DB serveur via CHARACTER_LIST,
+					// migration 0067). Repli : characters.<nom>.gender (fix client interim)
+					// si le serveur ne fournit pas encore le genre (master pas redeploye).
 					{
-						const std::string storedGender =
-							m_cfg.GetString("characters." + enterCmd.characterName + ".gender", "");
-						if (storedGender == "male" || storedGender == "female") {
-							if (storedGender != m_avatarGender) {
-								m_avatarGender = storedGender;
+						std::string gender = enterCmd.gender;
+						const char* src = "serveur";
+						if (gender != "male" && gender != "female")
+						{
+							gender = m_cfg.GetString("characters." + enterCmd.characterName + ".gender", "");
+							src = "client (repli)";
+						}
+						if (gender == "male" || gender == "female")
+						{
+							if (gender != m_avatarGender)
+							{
+								m_avatarGender = gender;
 								m_avatarSkinDiagLoggedGender.clear();
 							}
-							LOG_INFO(Core, "[EnterWorld] genre perso '{}' = {} (persistance client)",
-								enterCmd.characterName, storedGender);
-						} else {
-							LOG_INFO(Core, "[EnterWorld] pas de genre persiste pour '{}' -> genre courant '{}'",
+							LOG_INFO(Core, "[EnterWorld] genre perso '{}' = {} ({})",
+								enterCmd.characterName, gender, src);
+						}
+						else
+						{
+							LOG_INFO(Core, "[EnterWorld] pas de genre (serveur/client) pour '{}' -> genre courant '{}'",
 								enterCmd.characterName, m_avatarGender);
 						}
 					}

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -113,6 +113,9 @@ namespace engine::client
 			/// `m_currentSkinnedMesh` via `Engine::GetRaceMesh(raceId)` (avec fallback
 			/// humains si la race n'est pas chargée dans `m_raceMeshes`).
 			std::string raceId;
+			/// #1 serveur — genre du personnage ("male"/"female"), reçu via CHARACTER_LIST
+			/// (migration 0067). Vide = legacy/pré-migration -> 'male' par défaut côté Engine.
+			std::string gender;
 		};
 
 		struct AudioSettingsCommand
@@ -888,6 +891,9 @@ namespace engine::client
 		/// Vide = race non sélectionnée (le serveur recevra une chaîne vide et
 		/// stockera race_str = ""). Aligné sur la table `races` (cf. migration 0036).
 		std::string m_characterRaceId;
+		/// #1 serveur — genre choisi sur l'écran CharacterCreate ("male"/"female"),
+		/// envoyé au master dans CharacterCreateRequestPayload.gender. Défaut "male".
+		std::string m_characterGender = "male";
 		uint32_t m_activeField = 0;
 		int32_t m_hoveredFieldIndex = -1;
 		int32_t m_hoveredFieldInfoIndex = -1;

--- a/src/client/auth/screens/AuthScreenCharacterCreate.cpp
+++ b/src/client/auth/screens/AuthScreenCharacterCreate.cpp
@@ -62,10 +62,12 @@ namespace engine::client
 		}
 		m_characterName = nameUtf8 ? std::string(nameUtf8) : std::string();
 		m_characterRaceId = raceIdUtf8 ? std::string(raceIdUtf8) : std::string();
-		// Applique le genre choisi au moteur AVANT la soumission : l'EnterWorld qui
-		// suit resout le mesh via Engine::GetRaceMesh(raceId) qui lit m_avatarGender.
-		// SetCharacterGender persiste le genre PAR PERSONNAGE (characters.<nom>.gender)
-		// pour que le relog d'un perso existant retrouve son genre (fix client interim #1).
+		// #1 serveur — genre envoye au master dans la requete de creation (persiste en DB).
+		m_characterGender = (genderUtf8 && std::string(genderUtf8) == "female") ? "female" : "male";
+		// Applique aussi le genre au moteur AVANT la soumission : l'EnterWorld qui suit
+		// resout le mesh via Engine::GetRaceMesh(raceId) qui lit m_avatarGender.
+		// SetCharacterGender garde le fix client interim #1 (repli si la DB serveur n'a
+		// pas encore le genre, ex. master pas redeploye).
 		if (m_engineForRaceLookup != nullptr && genderUtf8 != nullptr)
 			m_engineForRaceLookup->SetCharacterGender(m_characterName, genderUtf8);
 		SubmitCurrentPhase(cfg);
@@ -139,6 +141,7 @@ namespace engine::client
 		const uint32_t timeoutMs = static_cast<uint32_t>(cfg.GetInt("client.auth_ui.timeout_ms", 5000));
 		const std::string characterName = m_characterName;
 		const std::string characterRaceId = m_characterRaceId;
+		const std::string characterGender = m_characterGender;  // #1 serveur
 
 		m_pendingAsyncKind = AsyncKind::CharacterCreate;
 		{
@@ -148,7 +151,7 @@ namespace engine::client
 
 		engine::network::NetClient* const masterClient = m_masterClient.get();
 		const uint64_t sessionId = m_masterSessionId;
-		m_worker = std::thread([this, masterClient, sessionId, timeoutMs, characterName, characterRaceId]() {
+		m_worker = std::thread([this, masterClient, sessionId, timeoutMs, characterName, characterRaceId, characterGender]() {
 			AsyncResult local{};
 			if (masterClient == nullptr)
 			{
@@ -163,7 +166,7 @@ namespace engine::client
 			bool done = false;
 			std::string errMsg;
 			if (!disp.SendRequest(engine::network::kOpcodeCharacterCreateRequest,
-					engine::network::BuildCharacterCreateRequestPayload(characterName, characterRaceId),
+					engine::network::BuildCharacterCreateRequestPayload(characterName, characterRaceId, "", {}, characterGender),
 					[&](uint32_t, bool timeout, std::vector<uint8_t> pl) {
 						done = true;
 						if (timeout)

--- a/src/client/auth/screens/AuthScreenCharacterSelect.cpp
+++ b/src/client/auth/screens/AuthScreenCharacterSelect.cpp
@@ -67,6 +67,8 @@ namespace engine::client
 		// race via Engine::GetRaceMesh(). Vide pour les persos pre-migration
 		// (Engine retombera sur le fallback humains).
 		m_pendingEnterWorld.raceId        = chosen.race_str;
+			// #1 serveur — genre du perso (DB, migration 0067) via CHARACTER_LIST -> Engine.
+			m_pendingEnterWorld.gender        = chosen.gender;
 		const bool nonZero = (chosen.spawn_x != 0.0f) || (chosen.spawn_y != 0.0f)
 			|| (chosen.spawn_z != 0.0f) || (chosen.spawn_yaw_deg != 0.0f)
 			|| (chosen.spawn_pitch_deg != 0.0f);

--- a/src/masterd/handlers/character/CharacterCreateHandler.cpp
+++ b/src/masterd/handlers/character/CharacterCreateHandler.cpp
@@ -256,19 +256,24 @@ namespace engine::server
 			return "";
 		};
 		const std::string factionStr = factionFromRace(raceIdTruncated);
+		// #1 serveur — genre du personnage (validé male/female, défaut male).
+		const std::string genderStr = (parsed->gender == "female") ? "female" : "male";
 		char escapedRace[80]{};
 		char escapedClass[80]{};
 		char escapedFaction[80]{};
+		char escapedGender[24]{};
 		mysql_real_escape_string(mysql, escapedRace,
 			raceIdTruncated.c_str(), static_cast<unsigned long>(raceIdTruncated.size()));
 		mysql_real_escape_string(mysql, escapedClass,
 			classIdTruncated.c_str(), static_cast<unsigned long>(classIdTruncated.size()));
 		mysql_real_escape_string(mysql, escapedFaction,
 			factionStr.c_str(), static_cast<unsigned long>(factionStr.size()));
+		mysql_real_escape_string(mysql, escapedGender,
+			genderStr.c_str(), static_cast<unsigned long>(genderStr.size()));
 
 		std::string sql =
 			"INSERT INTO characters (account_id, slot, name, server_id, race_id, class_id, level, appearance_json,"
-			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str, faction_str) VALUES ("
+			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str, faction_str, gender) VALUES ("
 			+ std::to_string(*accountId) + ", "
 			+ std::to_string(slot) + ", '"
 			+ escapedName + "', "
@@ -276,7 +281,8 @@ namespace engine::server
 			+ spawnBuf + ", '"
 			+ escapedRace + "', '"
 			+ escapedClass + "', '"
-			+ escapedFaction + "')";
+			+ escapedFaction + "', '"
+			+ escapedGender + "')";
 		if (!engine::server::db::DbExecute(mysql, sql))
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::BAD_REQUEST, "character creation failed", requestId, sessionIdHeader);

--- a/src/masterd/handlers/character/CharacterListHandler.cpp
+++ b/src/masterd/handlers/character/CharacterListHandler.cpp
@@ -72,7 +72,7 @@ namespace engine::server
 			"COALESCE(UNIX_TIMESTAMP(s.last_seen), 0) AS last_seen_unix, "
 			"COALESCE(s.total_play_seconds, 0) AS total_play, "
 			"c.spawn_x, c.spawn_y, c.spawn_z, c.spawn_yaw_deg, c.spawn_pitch_deg, "
-			"c.race_str, c.class_str "
+			"c.race_str, c.class_str, c.gender "
 			"FROM characters c "
 			"LEFT JOIN character_stats s ON s.character_id = c.id AND s.server_id = c.server_id "
 			"WHERE c.account_id = " + std::to_string(*accountId)
@@ -112,6 +112,9 @@ namespace engine::server
 			// Phase 3.8 — race / class strings (migration 0033).
 			if (row[14]) e.race_str  = row[14];
 			if (row[15]) e.class_str = row[15];
+			// #1 serveur — genre (migration 0067). Defaut 'male' si vide/NULL.
+			if (row[16]) e.gender = row[16];
+			if (e.gender.empty()) e.gender = "male";
 			entries.push_back(std::move(e));
 		}
 		engine::server::db::DbFreeResult(res);

--- a/src/shared/network/CharacterListPayloadsTests.cpp
+++ b/src/shared/network/CharacterListPayloadsTests.cpp
@@ -96,6 +96,7 @@ static void TestPopulatedResponseRoundTrip()
 		a.spawn_pitch_deg  = -5.5f;
 		a.race_str         = "humains";
 		a.class_str        = "warrior";
+		a.gender           = "female";
 		entries.push_back(a);
 	}
 	{
@@ -146,6 +147,7 @@ static void TestPopulatedResponseRoundTrip()
 		Assert(a.spawn_pitch_deg == -5.5f, "entry0 spawn_pitch_deg");
 		Assert(a.race_str == "humains", "entry0 race_str");
 		Assert(a.class_str == "warrior", "entry0 class_str");
+		Assert(a.gender == "female", "entry0 gender");
 
 		const auto& b = parsed->entries[1];
 		Assert(b.character_id == 1002u, "entry1 id");

--- a/src/shared/network/CharacterPayloads.cpp
+++ b/src/shared/network/CharacterPayloads.cpp
@@ -62,6 +62,13 @@ namespace engine::network
 			if (r.ReadBytes(&b, 1u)) out.customization.eyeColorIdx = b;
 		}
 
+		// #1 serveur — genre (string), optionnel : absent sur ancien client (forward-compat).
+		if (r.Remaining() > 0)
+		{
+			if (!r.ReadString(out.gender))
+				return std::nullopt;
+		}
+
 		return out;
 	}
 
@@ -72,7 +79,8 @@ namespace engine::network
 	std::vector<uint8_t> BuildCharacterCreateRequestPayload(std::string_view name,
 	                                                        std::string_view raceId,
 	                                                        std::string_view classId,
-	                                                        const CharacterCustomization& customization)
+	                                                        const CharacterCustomization& customization,
+	                                                        std::string_view gender)
 	{
 		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
 		ByteWriter w(buf.data(), buf.size());
@@ -95,6 +103,10 @@ namespace engine::network
 			customization.eyeColorIdx
 		};
 		if (!w.WriteBytes(customBytes, 5u))
+			return {};
+
+		// #1 serveur — genre (string), appendu après la customization.
+		if (!w.WriteString(gender))
 			return {};
 
 		buf.resize(w.Offset());
@@ -211,6 +223,10 @@ namespace engine::network
 			// Phase 3.8 — race/class strings (length-prefixed UTF-8).
 			if (!r.ReadString(e.race_str) || !r.ReadString(e.class_str))
 				return std::nullopt;
+			// #1 serveur — genre (string), appendu après class_str (wire-breaking,
+			// client/master en lock-step). Vide => 'male' appliqué côté client.
+			if (!r.ReadString(e.gender))
+				return std::nullopt;
 			out.entries.push_back(std::move(e));
 		}
 		return out;
@@ -254,6 +270,9 @@ namespace engine::network
 				}
 				// Phase 3.8 — race / class strings.
 				if (!w.WriteString(e.race_str) || !w.WriteString(e.class_str))
+					return {};
+				// #1 serveur — genre (string), appendu après class_str.
+				if (!w.WriteString(e.gender))
 					return {};
 			}
 		}

--- a/src/shared/network/CharacterPayloads.h
+++ b/src/shared/network/CharacterPayloads.h
@@ -31,6 +31,7 @@ namespace engine::network
 		std::string           raceId;    ///< M39.1 — race identifier (e.g. "humains").
 		std::string           classId;   ///< M39.1 — class identifier (e.g. "warrior").
 		CharacterCustomization customization{}; ///< M39.1 — appearance options.
+		std::string           gender;    ///< "male"/"female" (#1 serveur). Vide => 'male' côté serveur.
 	};
 
 	struct CharacterCreateResponsePayload
@@ -43,7 +44,8 @@ namespace engine::network
 	std::vector<uint8_t> BuildCharacterCreateRequestPayload(std::string_view name,
 	                                                        std::string_view raceId  = {},
 	                                                        std::string_view classId = {},
-	                                                        const CharacterCustomization& customization = {});
+	                                                        const CharacterCustomization& customization = {},
+	                                                        std::string_view gender = {});
 
 	std::optional<CharacterCreateResponsePayload> ParseCharacterCreateResponsePayload(const uint8_t* payload, size_t payloadSize);
 	std::vector<uint8_t> BuildCharacterCreateResponsePacket(uint8_t success, uint64_t characterId, uint32_t requestId, uint64_t sessionIdHeader);
@@ -84,6 +86,9 @@ namespace engine::network
 		// Vides si character créé pré-migration 0033, ou si l'utilisateur n'a pas choisi.
 		std::string race_str;
 		std::string class_str;
+		// #1 serveur — genre ("male"/"female"). Appendu après class_str (wire-breaking,
+		// client + master déployés ensemble). Vide => 'male' côté client.
+		std::string gender;
 	};
 
 	struct CharacterListResponsePayload


### PR DESCRIPTION
## Objectif
Termine le **bug #1** côté serveur : le genre du personnage est persisté en **DB** et appliqué au relog (multi-machines), remplaçant le fix client interim (`character_appearance.json`).

## Contenu (couches)
- **DB** : `0067_characters_gender.sql` — colonne `gender VARCHAR(8) NOT NULL DEFAULT 'male'` (idempotent).
- **Payloads** :
  - `CharacterCreateRequestPayload += gender` (append après customization ; parse **tolérant** → forward-compat).
  - `CharacterListEntry += gender` (append après class_str ; parse **strict** → ⚠️ **wire-breaking, lock-step**).
- **Serveur** : `CharacterCreateHandler` stocke `gender` (INSERT) ; `CharacterListHandler` `SELECT c.gender` → entrée.
- **Client** : envoie le genre à la création ; propage `CharacterListEntry.gender` → `EnterWorldCommand.gender` → `Engine` applique `enterCmd.gender` (**autoritatif serveur**), avec **repli** sur le fix client interim si le serveur ne fournit pas (master pas redéployé).
- **Test** : round-trip `gender` dans `CharacterListPayloadsTests` (filet wire ; à exécuter — la CI est compile-only).

## ⚠️ Déploiement — IMPORTANT
- **REDÉPLOIEMENT SERVEUR REQUIS (master)** : migration 0067 + handlers + payload.
- **WIRE-BREAKING (CHARACTER_LIST)** : le client neuf et le master neuf doivent être déployés **ensemble** (lock-step). Un client neuf contre un master ancien → la liste de persos échoue (parse strict).
- Repli : un perso créé avant la migration a `gender='male'` par défaut ; le fix client interim reste actif si le master n'a pas encore le genre.

## Validation
- Lance les tests de payload (`character_list_payloads_tests`) — round-trip gender OK.
- En jeu (master redéployé) : crée un perso féminin → relog (même ou autre machine) → la peau/mesh féminin s'applique, **sans** dépendre du fichier client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)