### PR TITLE
fix(migrations): 0043 crée accounts.role si absente (boot master en crash-loop)

### DIFF
--- a/sql/migrations/0043_phase_1c_account_roles.sql
+++ b/sql/migrations/0043_phase_1c_account_roles.sql
@@ -5,6 +5,29 @@
 
 SET NAMES utf8mb4;
 
+-- 0) Garantir l'existence de la colonne `role`. Selon lequel des deux fichiers
+--    0023 a été appliqué (doublon de numéro, cf. MigrationRunner + 0066), la
+--    colonne peut ne PAS exister ici : 0023_accounts_profile.sql la crée, mais
+--    0023_accounts_profile_fields.sql non, et 0066 (qui comble le manque) tourne
+--    APRÈS 0043. Sans cette garde, l'UPDATE en (2) échoue avec
+--    « Unknown column 'role' » et le master boucle au boot. On la crée au format
+--    binaire historique ('player','admin') ; l'étape (1) l'étendra ensuite.
+SET @m43_c0 := (
+  SELECT COUNT(*)
+  FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name   = 'accounts'
+    AND column_name  = 'role'
+);
+SET @m43_s0 := IF(@m43_c0 = 0,
+  'ALTER TABLE accounts ADD COLUMN role '
+  'ENUM(''player'',''admin'') NOT NULL DEFAULT ''player'' '
+  'COMMENT ''Role du compte (sera etendu par 0043)''',
+  'SELECT 1');
+PREPARE m43_p0 FROM @m43_s0;
+EXECUTE m43_p0;
+DEALLOCATE PREPARE m43_p0;
+
 -- 1) Vérifier l'état actuel de la colonne `role` et étendre l'ENUM si
 --    elle est encore au format binaire ('player','admin').
 


### PR DESCRIPTION
## Symptôme

Le master boucle au boot (sortie immédiate, redémarrage en boucle) :

```
[MigrationRunner] Applied migration 42 (0042_phase_1b_globals.sql)
[MigrationRunner] Drain results after migration 43 failed: Unknown column 'role' in 'where clause'
[ServerMain] Migrations failed, exiting
```

## Cause racine (bug d'ordonnancement)

- Deux fichiers portent le numéro **0023** :
  - `0023_accounts_profile_fields.sql` → ajoute `first_name/last_name/birth_date`
  - `0023_accounts_profile.sql` → ajoute le profil complet **dont la colonne `role`**
- Le `MigrationRunner` n'applique **qu'un seul fichier par numéro** (et l'ordre entre deux fichiers de même numéro est **non déterministe**). Sur cette base, c'est `_fields` qui a été appliqué → la colonne **`role` n'a jamais été créée** (cf. log `Numero 23 en double ... ignore`).
- La migration de rattrapage **`0066`** recrée idempotemment `role`, **mais elle tourne après `0043`**. Or `0043` exécute déjà `UPDATE accounts SET role='administrator' WHERE role='admin'` → `Unknown column 'role'` → abort → crash-loop.

Les installs où le `0023` *avec* `role` avait été tiré au sort fonctionnaient ; d'où le caractère intermittent.

## Correctif

`0043` devient **auto-suffisante** : une étape (0) ajoute la colonne `role` au format binaire historique `ENUM('player','admin')` **si elle est absente**, avant l'extension de l'ENUM (4 niveaux), le backfill et l'index. Idempotent (`information_schema` + `PREPARE`), aucun effet sur les bases où `role` existe déjà. Corrige aussi les installs fraîches qui tirent au sort le `0023` sans `role`.

La base en panne est à `schema_version = 42` (43 jamais enregistrée) : rejouer le binaire applique la `0043` corrigée puis la suite (44→49). Pas de souci de checksum sur cette base (la vérification ne porte que sur les versions déjà appliquées, ≤ 42).

## Test plan

- [ ] Sur une base à v42 **sans** colonne `role` : le boot applique 0043→… sans erreur, `role` = `ENUM('player','moderator','game_master','administrator')`, index `ix_accounts_role` présent.
- [ ] Sur une base **avec** `role` déjà à 4 valeurs : 0043 ne touche rien (idempotent).
- [ ] Base fraîche complète (0001→0049) : boot OK quel que soit le `0023` sélectionné.

---

> **Déploiement** : ⚠️ **redéploiement serveur (master) requis** — migration DB (`0043` modifiée) ; il faut rejouer le binaire master pour appliquer la migration corrigée au boot. Pas de changement client, pas de changement wire.


---
_Generated by [Claude Code](https://claude.ai/code/session_018aLJqVdZPxozdT2QTXHcyY)_