### PR TITLE
feat(net): Phase B — annonce + résolution de l'endpoint UDP du shard

### DIFF
--- a/src/masterd/handlers/shard/ServerListHandler.cpp
+++ b/src/masterd/handlers/shard/ServerListHandler.cpp
@@ -62,6 +62,7 @@ namespace engine::server
 				e.max_capacity = s.max_capacity;
 				e.character_count = m_characterCountHook ? m_characterCountHook(s.shard_id) : 0u;
 				e.endpoint = s.endpoint;
+				e.udp_endpoint = s.udp_endpoint; // TB.1 : relais de l'endpoint UDP au client
 				e.display_name = s.display_name.empty() ? s.name : s.display_name;
 				e.game_mode = s.game_mode;
 				e.ruleset = s.ruleset;

--- a/src/masterd/handlers/shard/ServerListPolicyTests.cpp
+++ b/src/masterd/handlers/shard/ServerListPolicyTests.cpp
@@ -36,7 +36,7 @@ static void TestServerListReflectsRegistry()
 	engine::core::Log::Init(logSettings);
 
 	ShardRegistry reg;
-	auto id1 = reg.RegisterShard("s1", "ep1", 100, "eu", "Royaume Un",
+	auto id1 = reg.RegisterShard("s1", "ep1", "", 100, "eu", "Royaume Un",
 		engine::network::ShardGameMode::PvP, engine::network::ShardRuleset::Hardcore);
 	Assert(id1.has_value(), "Register s1");
 	reg.UpdateHeartbeat(*id1, 25);
@@ -85,8 +85,8 @@ static void TestPolicyChoosesLessLoadedShard()
 	engine::core::Log::Init(logSettings);
 
 	ShardRegistry reg;
-	auto id1 = reg.RegisterShard("s1", "ep1", 100, "eu");
-	auto id2 = reg.RegisterShard("s2", "ep2", 100, "eu");
+	auto id1 = reg.RegisterShard("s1", "ep1", "", 100, "eu");
+	auto id2 = reg.RegisterShard("s2", "ep2", "", 100, "eu");
 	Assert(id1.has_value() && id2.has_value(), "Register 2 shards");
 	reg.UpdateHeartbeat(*id1, 60);
 	reg.UpdateHeartbeat(*id2, 20);

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -70,7 +70,7 @@ namespace engine::server
 
 		// --- Étape 2 : enregistrement dans le registre ----------------------------
 		// RegisterShard retourne nullopt si le nom est déjà présent (cas de reconnexion).
-		auto id = m_registry->RegisterShard(std::move(parsed->name), std::move(parsed->endpoint), parsed->max_capacity,
+		auto id = m_registry->RegisterShard(std::move(parsed->name), std::move(parsed->endpoint), std::move(parsed->udp_endpoint), parsed->max_capacity,
 			std::move(parsed->region), std::move(parsed->display_name), parsed->game_mode, parsed->ruleset);
 		LOG_DEBUG(Server, "[SREG] RegisterShard id={} (0=duplicate)", id ? *id : 0u);
 

--- a/src/masterd/shards/ShardDownDetectionTests.cpp
+++ b/src/masterd/shards/ShardDownDetectionTests.cpp
@@ -37,7 +37,7 @@ static void TestEvictStaleHeartbeatsMarksOfflineAndInvokesCallback()
 
 	ShardRegistry reg;
 	auto t0 = std::chrono::steady_clock::now();
-	auto idOpt = reg.RegisterShard("s1", "ep1", 100, "eu");
+	auto idOpt = reg.RegisterShard("s1", "ep1", "", 100, "eu");
 	Assert(idOpt.has_value(), "RegisterShard returns id");
 	uint32_t shardId = *idOpt;
 
@@ -70,7 +70,7 @@ static void TestOnlineToDegradedWhenLoadAboveThreshold()
 
 	ShardRegistry reg;
 	reg.SetDegradedLoadThreshold(0.90);
-	auto idOpt = reg.RegisterShard("s1", "ep1", 100, "eu");
+	auto idOpt = reg.RegisterShard("s1", "ep1", "", 100, "eu");
 	Assert(idOpt.has_value(), "RegisterShard returns id");
 	uint32_t shardId = *idOpt;
 	// First heartbeat: Registering → Online
@@ -96,7 +96,7 @@ static void TestDegradedToOnlineWhenLoadBelowThreshold()
 
 	ShardRegistry reg;
 	reg.SetDegradedLoadThreshold(0.90);
-	auto idOpt = reg.RegisterShard("s1", "ep1", 100, "eu");
+	auto idOpt = reg.RegisterShard("s1", "ep1", "", 100, "eu");
 	Assert(idOpt.has_value(), "RegisterShard returns id");
 	uint32_t shardId = *idOpt;
 	reg.UpdateHeartbeat(shardId, 95);
@@ -121,7 +121,7 @@ static void TestDegradedToOfflineOnHeartbeatTimeout()
 	ShardRegistry reg;
 	reg.SetDegradedLoadThreshold(0.90);
 	auto t0 = std::chrono::steady_clock::now();
-	auto idOpt = reg.RegisterShard("s1", "ep1", 100, "eu");
+	auto idOpt = reg.RegisterShard("s1", "ep1", "", 100, "eu");
 	Assert(idOpt.has_value(), "RegisterShard returns id");
 	uint32_t shardId = *idOpt;
 	reg.UpdateHeartbeat(shardId, 95);
@@ -146,8 +146,8 @@ static void TestSelectShardExcludesDegraded()
 
 	ShardRegistry reg;
 	reg.SetDegradedLoadThreshold(0.90);
-	auto id1Opt = reg.RegisterShard("s1", "ep1", 100, "eu");
-	auto id2Opt = reg.RegisterShard("s2", "ep2", 100, "eu");
+	auto id1Opt = reg.RegisterShard("s1", "ep1", "", 100, "eu");
+	auto id2Opt = reg.RegisterShard("s2", "ep2", "", 100, "eu");
 	Assert(id1Opt.has_value() && id2Opt.has_value(), "Both shards registered");
 	uint32_t shard1 = *id1Opt;
 	uint32_t shard2 = *id2Opt;

--- a/src/masterd/shards/ShardRegistry.cpp
+++ b/src/masterd/shards/ShardRegistry.cpp
@@ -9,7 +9,7 @@
 
 namespace engine::server
 {
-	std::optional<uint32_t> ShardRegistry::RegisterShard(std::string name, std::string endpoint, uint32_t max_capacity,
+	std::optional<uint32_t> ShardRegistry::RegisterShard(std::string name, std::string endpoint, std::string udp_endpoint, uint32_t max_capacity,
 		std::string region, std::string display_name,
 		engine::network::ShardGameMode game_mode, engine::network::ShardRuleset ruleset)
 	{
@@ -26,6 +26,7 @@ LOG_DEBUG(Server, "[SREG_REG] RegisterShard name='{}' endpoint='{}' cap={}", nam
 		e.shard_id = id;
 		e.name = std::move(name);
 		e.endpoint = std::move(endpoint);
+		e.udp_endpoint = std::move(udp_endpoint);
 		e.region = std::move(region);
 		e.max_capacity = max_capacity;
 		e.current_load = 0;
@@ -179,6 +180,7 @@ LOG_DEBUG(Server, "[SREG_REG] EvictStaleHeartbeats timeout={}s marked={}", timeo
 		info.shard_id = e.shard_id;
 		info.name = e.name;
 		info.endpoint = e.endpoint;
+			info.udp_endpoint = e.udp_endpoint;
 		info.region = e.region;
 		info.max_capacity = e.max_capacity;
 		info.current_load = e.current_load;
@@ -201,6 +203,7 @@ LOG_DEBUG(Server, "[SREG_REG] EvictStaleHeartbeats timeout={}s marked={}", timeo
 			info.shard_id = e.shard_id;
 			info.name = e.name;
 			info.endpoint = e.endpoint;
+			info.udp_endpoint = e.udp_endpoint;
 			info.region = e.region;
 			info.max_capacity = e.max_capacity;
 			info.current_load = e.current_load;
@@ -237,6 +240,7 @@ LOG_DEBUG(Server, "[SREG_REG] EvictStaleHeartbeats timeout={}s marked={}", timeo
 		info.shard_id = best->shard_id;
 		info.name = best->name;
 		info.endpoint = best->endpoint;
+		info.udp_endpoint = best->udp_endpoint;
 		info.region = best->region;
 		info.max_capacity = best->max_capacity;
 		info.current_load = best->current_load;

--- a/src/masterd/shards/ShardRegistry.h
+++ b/src/masterd/shards/ShardRegistry.h
@@ -28,6 +28,7 @@ namespace engine::server
 		uint32_t shard_id = 0;
 		std::string name;          ///< Identifiant technique unique (clé interne).
 		std::string endpoint;
+		std::string udp_endpoint;  ///< TB.1: endpoint UDP gameplay annoncé (relayé au client via SERVER_LIST).
 		std::string region;
 		uint32_t max_capacity = 0;
 		uint32_t current_load = 0;
@@ -52,7 +53,7 @@ namespace engine::server
 		/// \param display_name nom public affiché ; si vide, on retombe sur \p name.
 		/// \param game_mode mode de jeu annoncé (PvE/PvP).
 		/// \param ruleset règle annoncée (liste fermée).
-		std::optional<uint32_t> RegisterShard(std::string name, std::string endpoint, uint32_t max_capacity,
+		std::optional<uint32_t> RegisterShard(std::string name, std::string endpoint, std::string udp_endpoint, uint32_t max_capacity,
 			std::string region = {}, std::string display_name = {},
 			engine::network::ShardGameMode game_mode = engine::network::ShardGameMode::PvE,
 			engine::network::ShardRuleset ruleset = engine::network::ShardRuleset::Cooperative);
@@ -93,6 +94,7 @@ namespace engine::server
 			uint32_t shard_id = 0;
 			std::string name;
 			std::string endpoint;
+			std::string udp_endpoint;
 			std::string region;
 			uint32_t max_capacity = 0;
 			uint32_t current_load = 0;

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -140,6 +140,8 @@ int main(int argc, char** argv)
 	const uint16_t masterPort = static_cast<uint16_t>(config.GetInt("shard.master.port", config.GetInt("shard.master_port", 3840)));
 	const std::string regName = config.GetString("shard.register.name", config.GetString("shard.register_name", "shard"));
 	const std::string regEndpoint = config.GetString("shard.register.endpoint", config.GetString("shard.register_endpoint", "127.0.0.1:3843"));
+	// TB.1 : endpoint UDP gameplay annoncé au master (relayé au client via SERVER_LIST). Vide = non annoncé.
+	const std::string regUdpEndpoint = config.GetString("shard.register.udp_endpoint", "");
 	const uint32_t regCap = static_cast<uint32_t>(config.GetInt("shard.register.max_capacity", config.GetInt("shard.register_max_capacity", 500)));
 	const std::string buildVer = config.GetString("shard.register.build_version", config.GetString("shard.build_version", "dev"));
 	// Présentation publique du serveur dans la liste client (M-server-meta).
@@ -161,7 +163,7 @@ int main(int argc, char** argv)
 	if (!masterTlsFp.empty())
 		toMaster.SetExpectedServerFingerprint(masterTlsFp);
 	toMaster.SetAllowInsecureDev(masterInsecure);
-	toMaster.SetShardIdentity(regName, regEndpoint, regCap, buildVer, regDisplayName, regGameMode, regRuleset, regRegion);
+	toMaster.SetShardIdentity(regName, regEndpoint, regUdpEndpoint, regCap, buildVer, regDisplayName, regGameMode, regRuleset, regRegion);
 	toMaster.SetHeartbeatIntervalSec(static_cast<int>(config.GetInt("shard.heartbeat_interval_sec", 10)));
 	toMaster.Start();
 

--- a/src/shared/network/MasterShardClientFlow.cpp
+++ b/src/shared/network/MasterShardClientFlow.cpp
@@ -407,7 +407,23 @@ namespace engine::network
 
 		result.success = true;
 		result.shard_id = targetShardId;
-		result.shard_endpoint = shardHost + ":" + std::to_string(static_cast<unsigned>(shardPort));
+		// TB.2 : l'endpoint renvoyé au client pour le gameplay UDP est l'udp_endpoint
+		// annoncé par le master (et NON le host:port TCP du ticket). Repli sur le TCP si
+		// le shard n'a pas annoncé d'endpoint UDP (compat). Même rewrite loopback→master
+		// (shard co-localisé) que pour la connexion TCP.
+		if (chosen != nullptr && !chosen->udp_endpoint.empty())
+		{
+			std::string udpHost;
+			uint16_t udpPort = 0;
+			ParseEndpoint(chosen->udp_endpoint, udpHost, udpPort);
+			if (IsLoopbackHost(udpHost) && !IsLoopbackHost(m_masterHost))
+				udpHost = m_masterHost;
+			result.shard_endpoint = udpHost + ":" + std::to_string(static_cast<unsigned>(udpPort));
+		}
+		else
+		{
+			result.shard_endpoint = shardHost + ":" + std::to_string(static_cast<unsigned>(shardPort));
+		}
 		LOG_INFO(Net, "[MasterShardClientFlow] Flow complete (shard_id={}, endpoint={}, characters={})",
 			result.shard_id, result.shard_endpoint, result.character_list.size());
 		return result;

--- a/src/shared/network/ServerListPayloads.cpp
+++ b/src/shared/network/ServerListPayloads.cpp
@@ -31,6 +31,8 @@ namespace engine::network
 				break;
 			if (!r.ReadString(e.endpoint))
 				break;
+			if (!r.ReadString(e.udp_endpoint)) // TB.1 (wire-breaking) : après endpoint TCP
+				break;
 			if (!r.ReadString(e.display_name))
 				break;
 			uint8_t modeByte = 0;
@@ -48,7 +50,7 @@ namespace engine::network
 	{
 		size_t total = 2u;
 		for (const auto& e : entries)
-			total += 4u + 1u + 4u + 4u + 4u + 2u + e.endpoint.size() + 2u + e.display_name.size() + 1u + 1u;
+			total += 4u + 1u + 4u + 4u + 4u + 2u + e.endpoint.size() + 2u + e.udp_endpoint.size() + 2u + e.display_name.size() + 1u + 1u;
 		if (total > kProtocolV1MaxPacketSize)
 			return {};
 		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
@@ -65,6 +67,8 @@ namespace engine::network
 			if (!w.WriteU32(e.current_load) || !w.WriteU32(e.max_capacity) || !w.WriteU32(e.character_count))
 				return {};
 			if (!w.WriteString(e.endpoint))
+				return {};
+			if (!w.WriteString(e.udp_endpoint)) // TB.1 (wire-breaking) : après endpoint TCP
 				return {};
 			const uint8_t modeByte = static_cast<uint8_t>(e.game_mode);
 			const uint8_t rulesetByte = static_cast<uint8_t>(e.ruleset);

--- a/src/shared/network/ServerListPayloads.h
+++ b/src/shared/network/ServerListPayloads.h
@@ -18,6 +18,7 @@ namespace engine::network
 		uint32_t max_capacity = 0;
 		uint32_t character_count = 0; ///< Optional, from hook (M20/M21); 0 if not provided.
 		std::string endpoint;          ///< M22.6: shard address (host:port) for CONNECT SHARD. Sert à se connecter, NE PAS afficher au joueur.
+		std::string udp_endpoint;      ///< TB.1: endpoint UDP gameplay du shard (host:port). Vide si non annoncé.
 		std::string display_name;      ///< Nom public du serveur (texte). Remplace l'IP dans la liste client.
 		ShardGameMode game_mode = ShardGameMode::PvE; ///< PvE / PvP (remplace « PvE » figé).
 		ShardRuleset ruleset = ShardRuleset::Cooperative; ///< Règle (remplace « COOPERATIVE » figé).

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -13,7 +13,7 @@ namespace engine::network
 			return std::nullopt;
 		ByteReader r(payload, payloadSize);
 		ShardRegisterPayload out;
-		if (!r.ReadString(out.name) || !r.ReadString(out.endpoint))
+		if (!r.ReadString(out.name) || !r.ReadString(out.endpoint) || !r.ReadString(out.udp_endpoint))
 			return std::nullopt;
 		if (!r.ReadU32(out.max_capacity) || !r.ReadU32(out.current_load))
 			return std::nullopt;
@@ -34,12 +34,12 @@ namespace engine::network
 	}
 
 	std::vector<uint8_t> BuildShardRegisterPayload(std::string_view name, std::string_view endpoint,
-		uint32_t max_capacity, uint32_t current_load, std::string_view build_version,
+		std::string_view udp_endpoint, uint32_t max_capacity, uint32_t current_load, std::string_view build_version,
 		std::string_view display_name, ShardGameMode game_mode, ShardRuleset ruleset, std::string_view region)
 	{
 		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
 		ByteWriter w(buf.data(), buf.size());
-		if (!w.WriteString(name) || !w.WriteString(endpoint) || !w.WriteU32(max_capacity) || !w.WriteU32(current_load) || !w.WriteString(build_version))
+		if (!w.WriteString(name) || !w.WriteString(endpoint) || !w.WriteString(udp_endpoint) || !w.WriteU32(max_capacity) || !w.WriteU32(current_load) || !w.WriteString(build_version))
 			return {};
 		const uint8_t modeByte = static_cast<uint8_t>(game_mode);
 		const uint8_t rulesetByte = static_cast<uint8_t>(ruleset);

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -17,6 +17,7 @@ namespace engine::network
 	{
 		std::string name;            ///< Identifiant technique unique (clé de dédup à la reconnexion).
 		std::string endpoint;
+		std::string udp_endpoint;    ///< TB.1: endpoint UDP gameplay du shard (host:port). Vide si non annoncé.
 		uint32_t max_capacity = 0;
 		uint32_t current_load = 0;
 		std::string build_version;
@@ -29,9 +30,10 @@ namespace engine::network
 	/// Parses SHARD_REGISTER payload. Returns nullopt if truncated or invalid.
 	std::optional<ShardRegisterPayload> ParseShardRegisterPayload(const uint8_t* payload, size_t payloadSize);
 
-	/// Builds SHARD_REGISTER payload (Shard→Master).
+	/// Builds SHARD_REGISTER payload (Shard→Master). TB.1: \a udp_endpoint annonce l'endpoint
+	/// UDP gameplay du shard (relayé au client via SERVER_LIST).
 	std::vector<uint8_t> BuildShardRegisterPayload(std::string_view name, std::string_view endpoint,
-		uint32_t max_capacity, uint32_t current_load, std::string_view build_version,
+		std::string_view udp_endpoint, uint32_t max_capacity, uint32_t current_load, std::string_view build_version,
 		std::string_view display_name = {}, ShardGameMode game_mode = ShardGameMode::PvE,
 		ShardRuleset ruleset = ShardRuleset::Cooperative, std::string_view region = {});
 

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -42,11 +42,12 @@ namespace engine::network
 		m_allow_insecure = allow;
 	}
 
-	void ShardToMasterClient::SetShardIdentity(std::string name, std::string endpoint, uint32_t max_capacity, std::string build_version,
+	void ShardToMasterClient::SetShardIdentity(std::string name, std::string endpoint, std::string udp_endpoint, uint32_t max_capacity, std::string build_version,
 		std::string display_name, ShardGameMode game_mode, ShardRuleset ruleset, std::string region)
 	{
 		m_name = std::move(name);
 		m_endpoint = std::move(endpoint);
+		m_udp_endpoint = std::move(udp_endpoint);
 		m_max_capacity = max_capacity;
 		m_build_version = std::move(build_version);
 		m_display_name = display_name.empty() ? m_name : std::move(display_name);
@@ -117,7 +118,7 @@ LOG_DEBUG(Net, "[STMC] Pump state={} reconnect_in={}s", (int)m_state, (long long
 	void ShardToMasterClient::SendRegister()
 	{
 LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} mode={} ruleset={}", m_name.c_str(), m_display_name.c_str(), m_endpoint.c_str(), m_max_capacity, GameModeToken(m_game_mode), RulesetToken(m_ruleset));
-		auto payload = BuildShardRegisterPayload(m_name, m_endpoint, m_max_capacity, m_current_load, m_build_version,
+		auto payload = BuildShardRegisterPayload(m_name, m_endpoint, m_udp_endpoint, m_max_capacity, m_current_load, m_build_version,
 			m_display_name, m_game_mode, m_ruleset, m_region);
 		if (payload.empty())
 		{

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -35,7 +35,7 @@ namespace engine::network
 		/// \param game_mode mode de jeu annoncé (PvE/PvP).
 		/// \param ruleset règle annoncée (liste fermée).
 		/// \param region région annoncée (texte libre), exposée par l'API /status.
-		void SetShardIdentity(std::string name, std::string endpoint, uint32_t max_capacity, std::string build_version,
+		void SetShardIdentity(std::string name, std::string endpoint, std::string udp_endpoint, uint32_t max_capacity, std::string build_version,
 			std::string display_name = {}, ShardGameMode game_mode = ShardGameMode::PvE,
 			ShardRuleset ruleset = ShardRuleset::Cooperative, std::string region = {});
 
@@ -76,6 +76,7 @@ namespace engine::network
 		bool m_allow_insecure = false;
 		std::string m_name;
 		std::string m_endpoint;
+		std::string m_udp_endpoint; ///< TB.1: endpoint UDP gameplay annoncé au master.
 		uint32_t m_max_capacity = 0;
 		std::string m_build_version;
 		std::string m_display_name;


### PR DESCRIPTION
## Résumé (Phase B — TB.1 + TB.2, indépendante, basée sur main)

Le client cesse de viser le défaut codé en dur `127.0.0.1:27015` pour le gameplay UDP : le **shard annonce son endpoint UDP**, le **master le relaie** au client via SERVER_LIST, et le **client s'y connecte**.

### TB.1 — Master annonce l'endpoint UDP
- `ShardRegisterPayload` + `udp_endpoint` (Build/Parse symétriques). `ShardToMasterClient::SetShardIdentity(+udp_endpoint)` ; `shardd/main_linux` lit `shard.register.udp_endpoint`.
- `ShardRegistry` (ShardInfo + Entry + RegisterShard) stocke + expose `udp_endpoint` ; `ShardRegisterHandler` le transmet.
- `ServerListEntry` + `udp_endpoint` (Build/Parse) ; `ServerListHandler` le relaie au client.
- Tests `RegisterShard` mis à jour (nouvel arg).

### TB.2 — Client résout l'UDP
- `MasterShardClientFlow` : `result.shard_endpoint` (déjà plumbé jusqu'à `Engine::InitGameplayNet` via `enterCmd.shardEndpoint`) vaut désormais l'`udp_endpoint` annoncé du shard choisi (repli TCP si vide ; rewrite loopback→master conservé).

## Test plan
- [ ] CI Linux : master/shard rebâtis (wire `udp_endpoint`) + `server_list_policy_tests` vert.
- [ ] CI Windows : client rebâti (parse + usage `udp_endpoint`).
- [ ] **Run (ta vérif)** : configurer `shard.register.udp_endpoint` côté shard → le client se connecte à l'IP/port UDP réels (logs `[GameplayNet] UDP connect <ip réelle>`).

## Déploiement
⚠️ **Wire-breaking master↔shard (SHARD_REGISTER) ET master↔client (SERVER_LIST)** → **lock-step master + shard + client**. Renseigner la clé `shard.register.udp_endpoint` côté shard. Nécessite TA.3 déployé (le shard écoute en UDP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)