### PR TITLE
feat(client): TD.1 — table des avatars distants (données réplication)

### DIFF
--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -653,21 +653,38 @@ namespace engine::client
 		stats.sentPackets = m_snapshotMessage.sentPackets;
 		stats.hasSnapshot = false;
 
+		// TD.1 — on n'extrait plus seulement le joueur local : on capture aussi les avatars
+		// distants (≠ joueur local) dans m_model.remoteEntities pour le rendu monde (TD.2).
+		// Reconstruction complète à chaque snapshot (le snapshot porte l'ensemble courant de
+		// l'AoI ; une entité absente du prochain snapshot disparaît donc naturellement).
+		m_model.remoteEntities.clear();
 		for (const engine::server::SnapshotEntity& entity : m_snapshotScratch)
 		{
-			if (entity.entityId != stats.playerEntityId)
+			if (entity.entityId == stats.playerEntityId)
 			{
+				stats.currentHealth = entity.state.currentHealth;
+				stats.maxHealth = entity.state.maxHealth;
+				stats.stateFlags = entity.state.stateFlags;
+				stats.positionX = entity.state.positionX;
+				stats.positionY = entity.state.positionY;
+				stats.positionZ = entity.state.positionZ;
+				stats.hasSnapshot = true;
 				continue;
 			}
 
-			stats.currentHealth = entity.state.currentHealth;
-			stats.maxHealth = entity.state.maxHealth;
-			stats.stateFlags = entity.state.stateFlags;
-			stats.positionX = entity.state.positionX;
-			stats.positionY = entity.state.positionY;
-			stats.positionZ = entity.state.positionZ;
-			stats.hasSnapshot = true;
-			break;
+			UIRemoteEntity remote;
+			remote.entityId = entity.entityId;
+			remote.positionX = entity.state.positionX;
+			remote.positionY = entity.state.positionY;
+			remote.positionZ = entity.state.positionZ;
+			remote.yawRadians = entity.state.yawRadians;
+			remote.velocityX = entity.state.velocityX;
+			remote.velocityY = entity.state.velocityY;
+			remote.velocityZ = entity.state.velocityZ;
+			remote.currentHealth = entity.state.currentHealth;
+			remote.maxHealth = entity.state.maxHealth;
+			remote.stateFlags = entity.state.stateFlags;
+			m_model.remoteEntities.push_back(remote);
 		}
 
 		if (m_model.targetStats.hasTarget)

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -285,6 +285,24 @@ namespace engine::client
 		std::vector<engine::server::ItemStack> rewardItems;
 	};
 
+	/// TD.1 — un avatar joueur/créature distant répliqué par l'AoI (≠ joueur local).
+	/// Rempli depuis les SnapshotEntity à chaque snapshot ; consommé par le rendu monde
+	/// (TD.2) et l'interpolation (TD.3).
+	struct UIRemoteEntity
+	{
+		engine::server::EntityId entityId = 0;
+		float positionX = 0.0f;
+		float positionY = 0.0f;
+		float positionZ = 0.0f;
+		float yawRadians = 0.0f;
+		float velocityX = 0.0f;
+		float velocityY = 0.0f;
+		float velocityZ = 0.0f;
+		uint32_t currentHealth = 0;
+		uint32_t maxHealth = 0;
+		uint32_t stateFlags = 0;
+	};
+
 	/// Pure data model consumed by UI views and debug panels.
 	struct UIModel
 	{
@@ -301,6 +319,9 @@ namespace engine::client
 		std::vector<UIActiveEmoteEntry> activeEmotes;
 		/// M32.2: Party member entries (up to 5), populated from PartyUpdate packets.
 		std::vector<UIPartyMemberEntry> partyMembers;
+		/// TD.1 : avatars distants (≠ joueur local) reçus dans le dernier snapshot AoI.
+		/// Reconstruit à chaque ApplySnapshot. Consommé par le rendu monde (TD.2).
+		std::vector<UIRemoteEntity> remoteEntities;
 		/// M32.2: True when the local player is currently in a party.
 		bool        inParty          = false;
 		/// M32.2: Human-readable loot mode label received in the last PartyUpdate (e.g. "FreeForAll").


### PR DESCRIPTION
## Résumé (Phase D — TD.1 fondation, basée sur main)

`UIModelBinding::ApplySnapshot` n'extrayait que le joueur local (entités distantes ignorées via `continue`). Désormais on construit à chaque snapshot **`m_model.remoteEntities`** : les `UIRemoteEntity` (id, pos X/Y/Z, yaw, vélocité, health, stateFlags) de toutes les entités ≠ joueur local.

C'est la **donnée** nécessaire pour afficher les autres joueurs. Reconstruction complète à chaque snapshot (l'instantané porte l'ensemble courant de l'AoI → despawn naturel).

## Reste (Phase D, suite — session fraîche + vérif au run)
- **TD.2** : rendu des avatars distants via `GeometryPass` aux positions de `remoteEntities`. ⚠️ **Ne pas toucher `frontFace`/`cullMode`** (cf. CLAUDE.md, convention winding — risque terrain invisible).
- **TD.3** : interpolation entre les 2 derniers snapshots (~100 ms de buffer) + extrapolation courte + snap si écart trop grand.
- **TD.4** (option) : nameplates.

## Test plan
- [ ] CI Linux/Windows : compile (client) avec `remoteEntities`.
- [ ] **Run (ta vérif)** : après TD.2, 2 comptes connectés se voient bouger.

## Déploiement
✅ Client uniquement (donnée), pas de changement wire. (Le « se voir bouger » complet nécessite A+B+C déployés + TD.2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)