### PR TITLE
feat(client): Phase D — rendu des avatars distants + interpolation + test protocole

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -440,6 +440,11 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransportTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransport.cpp)
 
+  # TE.1 (replication des joueurs) : round-trip EncodeInput/DecodeInput (Y+yaw, TC.1)
+  # + Hello. ServerProtocol.cpp est fourni par engine_core (lié par le helper).
+  lcdlln_add_simple_test(server_protocol_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ServerProtocolTests.cpp)
+
   # TA.3 (replication des joueurs) : registre des personnages admis (gate de la
   # session UDP, lié au character_id authentifié du ticket). Pure logique testable.
   lcdlln_add_simple_test(admitted_character_registry_tests

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4837,6 +4837,9 @@ namespace engine
 												// Chantier B : dessine les props statiques (coffre, etc.) par-dessus le GBuffer.
 												RecordPropsGeometry(cmd, reg, rs);
 
+												// TD.2 : dessine les avatars des joueurs distants (réplication AoI).
+												RecordRemoteAvatars(cmd, reg, rs);
+
 												// M100 — Task 12 : drawcall terrain chunk (post-Phase-3a).
 												// Dessine les chunks visibles qui ont terrain.bin + splat.bin
 												// dans une passe de chargement (loadOp=LOAD) après la geometry
@@ -9492,6 +9495,39 @@ namespace engine
 					highlight ? part.highlightMaterialIndex : part.materialIndex,
 					true);
 			}
+		}
+	}
+
+	void Engine::RecordRemoteAvatars(VkCommandBuffer cmd, engine::render::Registry& reg,
+	                                 const engine::RenderState& rs)
+	{
+		if (!m_pipeline) return;
+		const std::vector<engine::client::UIRemoteEntity>& remotes = m_uiModelBinding.GetModel().remoteEntities;
+		if (remotes.empty()) return;
+		engine::render::MeshAsset* mesh = m_geometryMeshHandle.Get();
+		if (mesh == nullptr || mesh->vertexBuffer == VK_NULL_HANDLE || mesh->indexBuffer == VK_NULL_HANDLE) return;
+		auto& geom = m_pipeline->GetGeometryPass();
+		// loadOp=LOAD requis pour se superposer au GBuffer (terrain + avatar + props) sans clear.
+		if (!geom.HasLoadPass()) return;
+		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
+		const uint32_t materialIndex = (m_avatarMaterialId != 0u)
+			? m_avatarMaterialId : materialCache.GetDefaultMaterialIndex();
+		for (const engine::client::UIRemoteEntity& re : remotes)
+		{
+			// Pieds au sol : le serveur réplique la position « centre capsule » comme pour
+			// l'avatar local (feetPos = ccPos.y - 0.9). Même offset ici pour la cohérence.
+			const engine::math::Mat4 model =
+				engine::math::Mat4::Translate(engine::math::Vec3{ re.positionX, re.positionY - 0.9f, re.positionZ }) *
+				engine::math::Mat4::RotateY(re.yawRadians);
+			geom.Record(
+				m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(),
+				m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId, m_fgGBufferVelocityId, m_fgDepthId,
+				rs.prevViewProjMatrix.m, rs.viewProjMatrix.m, mesh,
+				0u,
+				materialCache.GetDescriptorSet(),
+				model.m,
+				materialIndex,
+				true);
 		}
 	}
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9514,11 +9514,19 @@ namespace engine
 			? m_avatarMaterialId : materialCache.GetDefaultMaterialIndex();
 		for (const engine::client::UIRemoteEntity& re : remotes)
 		{
+			// TD.3 : position lissée (interpolation, cf. UpdateGameplayNet) ; repli sur la
+			// position snapshot brute si pas encore d'état lissé (graceful).
+			float px = re.positionX, py = re.positionY, pz = re.positionZ, yaw = re.yawRadians;
+			const auto sit = m_remoteSmoothed.find(re.entityId);
+			if (sit != m_remoteSmoothed.end() && sit->second.valid)
+			{
+				px = sit->second.x; py = sit->second.y; pz = sit->second.z; yaw = sit->second.yaw;
+			}
 			// Pieds au sol : le serveur réplique la position « centre capsule » comme pour
 			// l'avatar local (feetPos = ccPos.y - 0.9). Même offset ici pour la cohérence.
 			const engine::math::Mat4 model =
-				engine::math::Mat4::Translate(engine::math::Vec3{ re.positionX, re.positionY - 0.9f, re.positionZ }) *
-				engine::math::Mat4::RotateY(re.yawRadians);
+				engine::math::Mat4::Translate(engine::math::Vec3{ px, py - 0.9f, pz }) *
+				engine::math::Mat4::RotateY(yaw);
 			geom.Record(
 				m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(),
 				m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId, m_fgGBufferVelocityId, m_fgDepthId,
@@ -9783,6 +9791,37 @@ namespace engine
 				const engine::math::Vec3 avatarPos = m_characterController.GetPosition();
 				(void)m_gameplayUdp.SendInput(clientId, ++m_gameplayInputSeq,
 					avatarPos.x, avatarPos.y, avatarPos.z, m_avatarYaw);
+			}
+		}
+
+		// TD.3 — lissage exponentiel des positions des avatars distants vers la cible
+		// snapshot (~10 Hz) pour un rendu fluide entre snapshots. RecordRemoteAvatars lit
+		// ces valeurs (et retombe sur la position snapshot brute si une entité manque ici).
+		{
+			const std::vector<engine::client::UIRemoteEntity>& remotes = m_uiModelBinding.GetModel().remoteEntities;
+			const float k = std::clamp(deltaSeconds * 12.0f, 0.0f, 1.0f); // ~0.1-0.2 s pour converger
+			for (const engine::client::UIRemoteEntity& re : remotes)
+			{
+				RemoteAvatarSmoothed& s = m_remoteSmoothed[re.entityId];
+				if (!s.valid)
+				{
+					s.x = re.positionX; s.y = re.positionY; s.z = re.positionZ; s.yaw = re.yawRadians; s.valid = true;
+				}
+				else
+				{
+					s.x += (re.positionX - s.x) * k;
+					s.y += (re.positionY - s.y) * k;
+					s.z += (re.positionZ - s.z) * k;
+					s.yaw += (re.yawRadians - s.yaw) * k;
+				}
+			}
+			// Purge des entités sorties d'AoI (borne la map ; erase renvoie l'itérateur suivant).
+			for (auto it = m_remoteSmoothed.begin(); it != m_remoteSmoothed.end(); )
+			{
+				bool present = false;
+				for (const engine::client::UIRemoteEntity& re : remotes)
+					if (re.entityId == it->first) { present = true; break; }
+				if (present) ++it; else it = m_remoteSmoothed.erase(it);
 			}
 		}
 

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -740,6 +740,13 @@ namespace engine
 		/// GBuffer terrain/avatar). No-op si pas de props ou pas de load pass.
 		void RecordPropsGeometry(VkCommandBuffer cmd, engine::render::Registry& reg,
 		                         const engine::RenderState& rs);
+		/// TD.2 — dessine les avatars des joueurs distants (m_uiModelBinding remoteEntities)
+		/// dans la passe Geometry, un GeometryPass.Record par entité avec le mesh placeholder
+		/// (m_geometryMeshHandle), à leur position/orientation réseau. Path instancié éprouvé
+		/// (identique aux props) — évite le SkinnedRenderer (anneau 3 slots). No-op si aucune
+		/// entité distante / pas de mesh / pas de load pass.
+		void RecordRemoteAvatars(VkCommandBuffer cmd, engine::render::Registry& reg,
+		                         const engine::RenderState& rs);
 		/// Action en cours de remappage dans le panneau Options (capture clavier) :
 		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
 		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -797,6 +797,12 @@ namespace engine
 		float                                                     m_avatarYaw = 3.14159265f;
 		uint32_t m_gameplayInputSeq = 0;         ///< TC.2 : séquence monotone des Input UDP.
 		float    m_gameplayInputAccumSec = 0.0f; ///< TC.2 : accumulateur de cadence d'envoi.
+		/// TD.3 : position lissée d'un avatar distant (interpolation exponentielle vers la
+		/// cible snapshot, mise à jour par frame dans UpdateGameplayNet).
+		struct RemoteAvatarSmoothed { float x = 0.0f; float y = 0.0f; float z = 0.0f; float yaw = 0.0f; bool valid = false; };
+		/// TD.3 : positions lissées par EntityId. Si une entité n'y figure pas, le rendu
+		/// (RecordRemoteAvatars) retombe sur sa position snapshot brute (graceful).
+		std::unordered_map<engine::server::EntityId, RemoteAvatarSmoothed> m_remoteSmoothed;
 		engine::gameplay::MoveInput                               m_lastMoveInput{};
 
 		/// Terrain décalé (jeu + world editor exclusif : un seul actif selon le binaire / reload).

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -1,0 +1,94 @@
+// TE.1 — round-trip du protocole UDP gameplay : EncodeInput/DecodeInput (incl. Y + yaw,
+// ajoutés en TC.1) + EncodeHello/DecodeHello + rejet d'un paquet tronqué.
+// Pattern repo : int main() + assert + std::puts, sans framework. Cible CTest :
+// server_protocol_tests (branche UNIX de src/CMakeLists.txt).
+//
+// Le preset CI Linux est Release (-DNDEBUG) → on neutralise NDEBUG pour que les
+// assert mordent réellement.
+#ifdef NDEBUG
+#	undef NDEBUG
+#endif
+
+#include "src/shared/network/ServerProtocol.h"
+
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+using engine::server::DecodeHello;
+using engine::server::DecodeInput;
+using engine::server::EncodeHello;
+using engine::server::EncodeInput;
+using engine::server::HelloMessage;
+using engine::server::InputMessage;
+
+namespace
+{
+	/// TC.1 : un Input encodé puis décodé restitue exactement clientId, sequence et la
+	/// position 3D + yaw (encodage bit-exact via bit_cast → égalité flottante exacte).
+	void TestInputRoundTrip()
+	{
+		InputMessage in{};
+		in.clientId = 7u;
+		in.inputSequence = 12345u;
+		in.positionMetersX = 12.5f;
+		in.positionMetersY = 100.25f;
+		in.positionMetersZ = -8.75f;
+		in.yawRadians = 1.5708f;
+
+		const std::vector<std::byte> packet = EncodeInput(in);
+		assert(!packet.empty());
+
+		InputMessage out{};
+		assert(DecodeInput(packet, out));
+		assert(out.clientId == in.clientId);
+		assert(out.inputSequence == in.inputSequence);
+		assert(out.positionMetersX == in.positionMetersX);
+		assert(out.positionMetersY == in.positionMetersY);
+		assert(out.positionMetersZ == in.positionMetersZ);
+		assert(out.yawRadians == in.yawRadians);
+		std::puts("[OK] TestInputRoundTrip");
+	}
+
+	/// Un Input tronqué (payload < 24 octets) est rejeté par DecodeInput.
+	void TestInputRejectsTruncated()
+	{
+		InputMessage in{};
+		in.clientId = 1u;
+		std::vector<std::byte> packet = EncodeInput(in);
+		assert(packet.size() > 4u);
+		packet.resize(packet.size() - 1u); // ampute un octet du payload
+
+		InputMessage out{};
+		assert(!DecodeInput(packet, out));
+		std::puts("[OK] TestInputRejectsTruncated");
+	}
+
+	/// Round-trip Hello (clientNonce uint64 = character_id complet, cf. protocole v2+).
+	void TestHelloRoundTrip()
+	{
+		HelloMessage in{};
+		in.requestedTickHz = 20u;
+		in.requestedSnapshotHz = 10u;
+		in.clientNonce = 0x1122334455667788ull;
+
+		const std::vector<std::byte> packet = EncodeHello(in);
+		assert(!packet.empty());
+
+		HelloMessage out{};
+		assert(DecodeHello(packet, out));
+		assert(out.requestedTickHz == in.requestedTickHz);
+		assert(out.requestedSnapshotHz == in.requestedSnapshotHz);
+		assert(out.clientNonce == in.clientNonce);
+		std::puts("[OK] TestHelloRoundTrip");
+	}
+}
+
+int main()
+{
+	TestInputRoundTrip();
+	TestInputRejectsTruncated();
+	TestHelloRoundTrip();
+	std::puts("All ServerProtocol tests passed");
+	return 0;
+}


### PR DESCRIPTION
## Résumé (Phase D : TD.2 + TD.3 + TE.1, basée sur main)

Rend visibles les autres joueurs (réplication AoI déjà en place côté serveur/réseau via Phases A/B/C).

### TD.2 — rendu des avatars distants
`Engine::RecordRemoteAvatars` dessine chaque `remoteEntity` (TD.1) via `GeometryPass::Record` (path **instancié éprouvé**, identique aux props — N draws/frame OK) avec le mesh placeholder `avatar_placeholder.mesh`, à sa position/orientation réseau. **Évite le `SkinnedRenderer`** (anneau 3 slots, inadapté à N avatars/frame). Appelé après les props dans la passe Geometry (loadOp=LOAD).

### TD.3 — interpolation (lissage)
Lissage exponentiel côté `Engine` des positions distantes vers la cible snapshot (≈10 Hz) à chaque frame → mouvement fluide. **Graceful** : si non tické, retombe sur la position snapshot (= comportement TD.2). *(commit suivant)*

### TE.1 — test protocole
`server_protocol_tests` : round-trip `EncodeInput`/`DecodeInput` (Y+yaw, TC.1) + rejet tronqué + Hello.

## Test plan
- [ ] CI Linux/Windows : compile client + `server_protocol_tests` vert.
- [ ] **Run (ta vérif demain)** : 2 comptes connectés → chacun voit l'autre (mesh placeholder) bouger ; ajuster échelle/offset du placeholder si besoin.

## Déploiement
✅ Client uniquement (rendu + interpolation). Nécessite A+B+C déployés (serveur) pour des données réelles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)