### PR TITLE
fix(deploy): shard charge libmysqlclient depuis le bundle (régression TA.4)

### DIFF
--- a/deploy/docker/Dockerfile.shard
+++ b/deploy/docker/Dockerfile.shard
@@ -1,6 +1,11 @@
 # M24.4 — Shard server (image runtime, binaire pré-compilé)
 # Build : depuis deploy/docker avec bin/lcdlln_shard
 #   docker build -f Dockerfile.shard -t lcdlln-shard:ubuntu-24.04 .
+#
+# libmysqlclient : depuis TA.4 (pont position), le shard link MySQL pour lire
+# characters.spawn_x/y/z. Le runtime libmysqlclient.so.21 est fourni par le
+# bundle CI dans lib/ (pack-linux-docker-bundle.sh), pas via apt — même
+# mécanisme que le Dockerfile.master.
 
 # Même base que le master (binaires CI = ubuntu-latest / glibc récent).
 FROM ubuntu:24.04
@@ -12,6 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
+
+COPY lib/ /usr/local/lib/
+RUN ldconfig
 
 WORKDIR /app
 


### PR DESCRIPTION
## Symptôme

Le conteneur `lcdlln-shard` ne démarre plus en prod (boot loop) :

```
/app/lcdlln_shard: error while loading shared libraries:
libmysqlclient.so.21: cannot open shared object file: No such file or directory
```

## Cause

Depuis **TA.4 (#691 — pont position)**, `shard_app` link MySQL pour lire `characters.spawn_x/y/z` au `HandleHello`. Mais `Dockerfile.shard` n'avait jamais été mis à jour pour fournir le runtime `libmysqlclient.so.21` au chargement du binaire — le link satisfait l'éditeur de liens à la compilation, pas le loader au démarrage.

Le master a déjà résolu ce problème dans `Dockerfile.master` (`COPY lib/ /usr/local/lib/` + `ldconfig`), et le bundle CI (`scripts/pack-linux-docker-bundle.sh`) extrait déjà `libmysqlclient.so.21` du paquet hôte `libmysqlclient21` et le dépose dans `deploy/docker/lib/`. Le bundle est donc déjà disponible, il manque juste sa prise en compte côté shard.

## Correctif

Aligner `Dockerfile.shard` sur `Dockerfile.master` :

```dockerfile
COPY lib/ /usr/local/lib/
RUN ldconfig
```

Pas de C++ touché. Pas de wire-breaking. Pas de migration DB.

## Test plan

- [ ] CI `Build Linux` reste verte (pas de changement code)
- [ ] Reproduction manuelle : `cd deploy/docker && docker compose build shard && docker compose up -d shard` → conteneur reste UP, `docker logs lcdlln-shard` montre le banner habituel au lieu de l'erreur `libmysqlclient.so.21`

## Déploiement

⚠️ **Rebuild de l'image `lcdlln-shard` requis** (pas un simple `docker compose restart`). Côté ops :

```sh
cd /opt/lcdlln/deploy/docker
docker compose build shard
docker compose up -d shard
```

Master non touché. Client non concerné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDhyiFv4RvnBVe5DUSqiWt)_