### PR TITLE
fix(shard): admet le character_id pousse par le master a EnterWorld (TA.3)

### DIFF
--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -4,10 +4,12 @@
 #include "src/shared/network/CharacterPayloads.h"
 #include "src/shared/network/ErrorPacket.h"
 #include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/ShardPayloads.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/shared/network/NetServer.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 #include "src/masterd/session/SessionManager.h"
+#include "src/masterd/shards/ShardRegistry.h"
 #include "src/masterd/account/AccountRole.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
@@ -15,6 +17,7 @@
 #include <mysql.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 
 namespace engine::server
@@ -24,6 +27,7 @@ namespace engine::server
 	void CharacterEnterWorldHandler::SetConnectionSessionMap(ConnectionSessionMap* map) { m_connMap = map; }
 	void CharacterEnterWorldHandler::SetSessionCharacterMap(SessionCharacterMap* charMap) { m_charMap = charMap; }
 	void CharacterEnterWorldHandler::SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_pool = pool; }
+	void CharacterEnterWorldHandler::SetShardRegistry(ShardRegistry* registry) { m_shardRegistry = registry; }
 
 	void CharacterEnterWorldHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize)
@@ -74,17 +78,19 @@ namespace engine::server
 			return;
 		}
 
-		// Vérifie ownership : SELECT name FROM characters WHERE id=? AND account_id=? AND deleted_at IS NULL.
+		// Vérifie ownership : SELECT name, server_id FROM characters WHERE id=? AND account_id=? AND deleted_at IS NULL.
 		// On compare ensuite le name DB au name client byte-pour-byte (rejette toute imposture
-		// comme un sender qui claim un autre nom que celui en DB).
+		// comme un sender qui claim un autre nom que celui en DB). TA.3 : server_id sert au
+		// lookup du shard cible pour le push d'admission.
 		char queryBuf[256]{};
 		std::snprintf(queryBuf, sizeof(queryBuf),
-			"SELECT name FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
+			"SELECT name, server_id FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
 			static_cast<unsigned long long>(parsed->characterId),
 			static_cast<unsigned long long>(*accountId));
 
 		MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
 		std::string dbName;
+		uint32_t dbServerId = 0;
 		bool found = false;
 		if (res)
 		{
@@ -92,6 +98,8 @@ namespace engine::server
 			if (row && row[0])
 			{
 				dbName = row[0];
+				if (row[1])
+					dbServerId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
 				found = true;
 			}
 			engine::server::db::DbFreeResult(res);
@@ -141,6 +149,39 @@ namespace engine::server
 		m_charMap->Set(connId, parsed->characterId, parsed->characterName, normalized, accountRole);
 		LOG_INFO(Net, "[CharacterEnterWorldHandler] registered (account_id={}, character_id={}, name='{}')",
 			*accountId, parsed->characterId, parsed->characterName);
+
+		// TA.3 — push d'admission au shard. Sans ça, le client envoie son Hello UDP avec
+		// `clientNonce=character_id`, mais le shard l'a admis au handshake TCP avec
+		// `character_id=0` (le ticket avait été demandé AVANT le choix de perso), donc rejet.
+		// Le push réutilise la connexion TCP long-vivante établie par ShardToMasterClient.
+		if (m_shardRegistry != nullptr && dbServerId != 0u)
+		{
+			auto shardConnId = m_shardRegistry->GetShardConnection(dbServerId);
+			if (shardConnId)
+			{
+				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId);
+				if (!admitPkt.empty() && m_server->Send(*shardConnId, admitPkt))
+				{
+					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={})",
+						dbServerId, *shardConnId, *accountId, parsed->characterId);
+				}
+				else
+				{
+					LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push send FAILED (shard_id={}, shardConnId={}, account_id={}, character_id={})",
+						dbServerId, *shardConnId, *accountId, parsed->characterId);
+				}
+			}
+			else
+			{
+				LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push skipped: no shard connection (shard_id={}, account_id={}, character_id={})",
+					dbServerId, *accountId, parsed->characterId);
+			}
+		}
+		else if (m_shardRegistry == nullptr)
+		{
+			LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push skipped: ShardRegistry not configured (account_id={}, character_id={})",
+				*accountId, parsed->characterId);
+		}
 
 		auto pkt = BuildCharacterEnterWorldResponsePacket(1u, requestId, sessionIdHeader);
 		if (!pkt.empty())

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.h
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.h
@@ -14,6 +14,7 @@ namespace engine::server
 	class SessionManager;
 	class ConnectionSessionMap;
 	class SessionCharacterMap;
+	class ShardRegistry;
 
 	/// Phase 4 chat — Master-side handler for kOpcodeCharacterEnterWorldRequest.
 	///
@@ -22,6 +23,12 @@ namespace engine::server
 	/// binding in \ref SessionCharacterMap so subsequent CHAT_SEND_REQUEST can :
 	///   - use the character display name as sender (instead of the account login).
 	///   - resolve /whisper targets by character name → connId.
+	///
+	/// TA.3 — Émet aussi un push `kOpcodeMasterToShardAdmitCharacter` au shard sur lequel
+	/// vit le perso (résolu via `characters.server_id` + `ShardRegistry::GetShardConnection`)
+	/// pour qu'il admette `(account_id, character_id)` dans son `AdmittedCharacterRegistry`.
+	/// Sans ce push, le Hello UDP du client serait rejeté (ticket émis avant EnterWorld =
+	/// `character_id=0` côté shard).
 	///
 	/// Idempotent : the same client may resend if it changes character (logout to
 	/// CharacterSelect then re-EnterWorld).
@@ -33,6 +40,9 @@ namespace engine::server
 		void SetConnectionSessionMap(ConnectionSessionMap* map);
 		void SetSessionCharacterMap(SessionCharacterMap* charMap);
 		void SetConnectionPool(engine::server::db::ConnectionPool* pool);
+		/// TA.3 — facultatif. Si non configuré, le push d'admission est skip (log WARN unique
+		/// au premier EnterWorld). Permet de tourner sans cette fonctionnalité (tests / dev).
+		void SetShardRegistry(ShardRegistry* registry);
 
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
@@ -43,5 +53,6 @@ namespace engine::server
 		ConnectionSessionMap*               m_connMap  = nullptr;
 		SessionCharacterMap*                m_charMap  = nullptr;
 		engine::server::db::ConnectionPool* m_pool     = nullptr;
+		ShardRegistry*                      m_shardRegistry = nullptr; ///< TA.3 — lookup connId pour push d'admission.
 	};
 }

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -86,6 +86,9 @@ namespace engine::server
 				if (s.name == name)
 				{
 					m_registry->UpdateHeartbeat(s.shard_id, current_load);
+					// TA.3 : memorise la nouvelle connId du shard (re-register implique souvent
+					// une nouvelle connexion TCP) pour les push master->shard (AdmitCharacter).
+					m_registry->SetShardConnection(s.shard_id, connId);
 					auto pkt = BuildShardRegisterOkPacket(s.shard_id, requestId);
 					if (!pkt.empty() && m_server->Send(connId, pkt))
 					{
@@ -106,6 +109,8 @@ namespace engine::server
 		// --- Étape 3 : mise à jour du heartbeat et envoi de la réponse OK ----------
 		// Le premier UpdateHeartbeat fait passer l'état de Registering → Online.
 		m_registry->UpdateHeartbeat(*id, current_load);
+		// TA.3 : memorise la connId du shard pour les push master->shard (AdmitCharacter).
+		m_registry->SetShardConnection(*id, connId);
 		auto pkt = BuildShardRegisterOkPacket(*id, requestId);
 		if (!pkt.empty() && m_server->Send(connId, pkt))
 		{

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -424,6 +424,10 @@ int main(int argc, char** argv)
 	characterEnterWorldHandler.SetConnectionSessionMap(&connSessionMap);
 	characterEnterWorldHandler.SetSessionCharacterMap(&sessionCharMap);
 	characterEnterWorldHandler.SetConnectionPool(&dbPool);
+	// TA.3 — pousse l'admission (account_id, character_id) au shard a chaque EnterWorld
+	// reussi, via la connexion TCP long-vivante etablie par ShardToMasterClient et la
+	// connId memorisee par ShardRegisterHandler::SetShardConnection.
+	characterEnterWorldHandler.SetShardRegistry(&shardRegistry);
 
 	// M100.44 — handler des portails de donjon (Phase 11). Câble les
 	// opcodes 197/198 réservés par M100.43 : INSERT dans dungeon_instances

--- a/src/masterd/shards/ShardRegistry.cpp
+++ b/src/masterd/shards/ShardRegistry.cpp
@@ -251,4 +251,21 @@ LOG_DEBUG(Server, "[SREG_REG] EvictStaleHeartbeats timeout={}s marked={}", timeo
 		info.ruleset = best->ruleset;
 		return info;
 	}
+
+	void ShardRegistry::SetShardConnection(uint32_t shard_id, uint32_t connId)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_shards.find(shard_id) == m_shards.end())
+			return; // shard inconnu (race avec un evict ?). On ignore plutôt qu'insérer un fantôme.
+		m_shard_connections[shard_id] = connId;
+	}
+
+	std::optional<uint32_t> ShardRegistry::GetShardConnection(uint32_t shard_id) const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		auto it = m_shard_connections.find(shard_id);
+		if (it == m_shard_connections.end())
+			return std::nullopt;
+		return it->second;
+	}
 }

--- a/src/masterd/shards/ShardRegistry.h
+++ b/src/masterd/shards/ShardRegistry.h
@@ -88,6 +88,16 @@ namespace engine::server
 		/// M22.5: returns Online shard with lowest load ratio (current_load/max_capacity). Excludes Offline and Degraded.
 		std::optional<ShardInfo> SelectShard() const;
 
+		/// TA.3 — Mémorise (ou rafraîchit) la `connId` TCP sur laquelle le shard est connecté
+		/// au master. Permet au master d'émettre une commande push (ex.
+		/// `kOpcodeMasterToShardAdmitCharacter`) via `NetServer::Send(connId, ...)` en
+		/// réutilisant la connexion long-vivante initiée par `ShardToMasterClient`. Appelé
+		/// par `ShardRegisterHandler` à chaque (re-)register. No-op si shard_id inconnu.
+		void SetShardConnection(uint32_t shard_id, uint32_t connId);
+
+		/// TA.3 — Récupère la connId TCP du shard. `nullopt` si aucune connexion mémorisée.
+		std::optional<uint32_t> GetShardConnection(uint32_t shard_id) const;
+
 	private:
 		struct Entry
 		{
@@ -107,6 +117,10 @@ namespace engine::server
 		mutable std::mutex m_mutex;
 		std::unordered_map<uint32_t, Entry> m_shards;
 		std::unordered_map<std::string, uint32_t> m_name_to_id;
+		/// TA.3 — Mapping shard_id → connId TCP. Tenu synchronisé par `ShardRegisterHandler`
+		/// à chaque (re-)register du shard. Permet au master d'émettre des push vers le shard
+		/// via `NetServer::Send(connId, ...)`.
+		std::unordered_map<uint32_t, uint32_t> m_shard_connections;
 		uint32_t m_next_id = 1;
 		std::function<void(uint32_t)> m_shard_down_callback;
 		double m_degraded_load_threshold = 0.90;

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -172,6 +172,18 @@ int main(int argc, char** argv)
 	toMaster.SetAllowInsecureDev(masterInsecure);
 	toMaster.SetShardIdentity(regName, regEndpoint, regUdpEndpoint, regCap, buildVer, regDisplayName, regGameMode, regRuleset, regRegion);
 	toMaster.SetHeartbeatIntervalSec(static_cast<int>(config.GetInt("shard.heartbeat_interval_sec", 10)));
+	// TA.3 — admet (account_id, character_id) dans le registre dès que le master pousse
+	// kOpcodeMasterToShardAdmitCharacter (suite à un EnterWorld réussi côté master). Sans
+	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le
+	// ticket TCP avait été émis avant le choix de perso (character_id=0 → non admis).
+	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id) {
+		const std::uint64_t nowMs = static_cast<std::uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+		admittedRegistry.Admit(character_id, account_id, nowMs);
+		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, nowMs={})",
+			account_id, character_id, nowMs);
+	});
 	toMaster.Start();
 	// TA.3 : boucle gameplay UDP (ServerApp) sur un thread dedie, gated par admittedRegistry.
 	// Cohabite avec la stack TCP ticket + heartbeat + runtimes (ports/protocoles distincts).

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -816,4 +816,10 @@ namespace engine::network
 
 	constexpr uint16_t kOpcodeEnterDungeonRequest  = 197u; ///< Client to Master : déclenche un portail (dungeonTemplateId, difficulty). Reservé M100.43, non câblé jusqu'a M100.44.
 	constexpr uint16_t kOpcodeEnterDungeonResponse = 198u; ///< Master to Client : ACK avec instanceId + shardEndpoint, ou erreur (TemplateNotFound / InstanceFull / DifficultyLocked).
+
+	// -------------------------------------------------------------------------
+	// TA.3 — Admission de personnage (master → shard, push) — voir AdmitCharacterPayload.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeMasterToShardAdmitCharacter = 199u; ///< Master to Shard (push, request_id=0) : (account_id, character_id) à admettre dans AdmittedCharacterRegistry, suite à un EnterWorld réussi côté master.
 }

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -105,4 +105,28 @@ namespace engine::network
 			return {};
 		return buf;
 	}
+
+	std::optional<AdmitCharacterPayload> ParseAdmitCharacterPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (payload == nullptr || payloadSize < 16u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AdmitCharacterPayload out;
+		if (!r.ReadU64(out.account_id) || !r.ReadU64(out.character_id))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(account_id) || !w.WriteU64(character_id))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		// Push master→shard, pas de request_id ni session.
+		if (!builder.Finalize(kOpcodeMasterToShardAdmitCharacter, 0, 0, 0, payloadBytes))
+			return {};
+		return builder.Data();
+	}
 }

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -68,4 +68,21 @@ namespace engine::network
 
 	/// Builds SHARD_HEARTBEAT payload (Shard→Master). timestamp: e.g. seconds since epoch or monotonic.
 	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0);
+
+	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id).
+	/// Émis par le master (CharacterEnterWorldHandler) à destination du shard via la
+	/// connexion TCP persistante établie par ShardToMasterClient. Le shard l'utilise pour
+	/// admettre (account_id, character_id) dans son AdmittedCharacterRegistry → le Hello
+	/// UDP du client (clientNonce=character_id) sera ensuite accepté.
+	struct AdmitCharacterPayload
+	{
+		uint64_t account_id = 0;
+		uint64_t character_id = 0;
+	};
+
+	/// Parses MASTER_TO_SHARD_ADMIT_CHARACTER payload. Returns nullopt if truncated.
+	std::optional<AdmitCharacterPayload> ParseAdmitCharacterPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Builds MASTER_TO_SHARD_ADMIT_CHARACTER packet (Master→Shard, push, request_id=0).
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id);
 }

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -200,6 +200,28 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 			LOG_ERROR(Core, "[ShardToMasterClient] Register ERROR from Master");
 			m_client->Disconnect("register error");
 		}
+		else if (opcode == kOpcodeMasterToShardAdmitCharacter)
+		{
+			// TA.3 — push master->shard suite a un EnterWorld reussi cote master.
+			// Le master reutilise cette connexion long-vivante (initialement
+			// shard->master) pour pousser (account_id, character_id) au shard sans
+			// inventer un nouveau canal de transport.
+			auto parsed = ParseAdmitCharacterPayload(view.Payload(), view.PayloadSize());
+			if (!parsed)
+			{
+				LOG_WARN(Core, "[ShardToMasterClient] AdmitCharacter: parse FAILED (size={})", view.PayloadSize());
+				return;
+			}
+			if (!m_admit_callback)
+			{
+				LOG_WARN(Core, "[ShardToMasterClient] AdmitCharacter received but no callback registered (account_id={}, character_id={})",
+					parsed->account_id, parsed->character_id);
+				return;
+			}
+			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={})",
+				parsed->account_id, parsed->character_id);
+			m_admit_callback(parsed->account_id, parsed->character_id);
+		}
 	}
 
 	void ShardToMasterClient::ScheduleReconnect()

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -51,6 +52,13 @@ namespace engine::network
 		/// Heartbeat interval in seconds. Default 10. Call before Start() to take effect.
 		void SetHeartbeatIntervalSec(int sec) { m_heartbeat_interval_sec = (sec > 0) ? sec : 10; }
 
+		/// TA.3 — Callback invoqué quand le master pousse un `kOpcodeMasterToShardAdmitCharacter`
+		/// (suite à un EnterWorld réussi côté master). Le destinataire typique alimente
+		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, now)` côté shard.
+		/// `nullptr` (défaut) = drop silencieux.
+		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id)>;
+		void SetAdmitCharacterCallback(AdmitCharacterCallback cb) { m_admit_callback = std::move(cb); }
+
 		enum class State
 		{
 			Disconnected,
@@ -91,5 +99,7 @@ namespace engine::network
 		std::chrono::steady_clock::time_point m_reconnect_after{};
 		int m_reconnect_backoff_sec = 1;
 		int m_heartbeat_interval_sec = 10;
+		/// TA.3 — callback admission (master push). Voir SetAdmitCharacterCallback.
+		AdmitCharacterCallback m_admit_callback;
 	};
 }


### PR DESCRIPTION
## Symptôme (logs prod)

```
lcdlln-shard | [ServerApp] Hello rejected: character_key=1 not admitted (no valid ticket)
lcdlln-shard | [ServerApp] Hello rejected: character_key=2 not admitted (no valid ticket)
```

Les 2 clients se connectent au master, EnterWorld réussit côté master (`CharacterEnterWorldHandler registered`), mais le `Hello` UDP est rejeté côté shard → `clients=0`, `tx_packets=0` dans tous les `Tick stats` → **aucune session UDP gameplay**, donc aucun snapshot, aucun avatar distant, et les 2 joueurs ne se voient pas.

## Cause

Le ticket TCP du shard est demandé **AVANT** le choix de personnage. Flux client réel :

```
AUTH > SERVER_LIST > REQUEST_TICKET(shard_id) > PRESENT_SHARD_TICKET (shard)
     > CHARACTER_LIST > [user picks char] > EnterWorld > Hello UDP
```

`ShardTicketHandler.cpp:117-122` (master) :
```cpp
uint64_t character_id = 0;
if (m_charMap != nullptr)
    if (auto info = m_charMap->GetByConnId(connId))
        character_id = info->characterId;
```

`m_charMap` n'est peuplé qu'à l'EnterWorld → à l'instant du ticket, `character_id=0`. Le shard l'admet avec `0` (no-op : `AdmittedCharacterRegistry::Admit` ignore les `characterId == 0` — c'est la sentinelle « aucun personnage »).

Plus tard, le `Hello` UDP arrive avec `clientNonce=character_id=1`. `IsAdmitted(1)` échoue → rejet.

## Correctif — option B du plan : master push à EnterWorld

Réutilise la connexion TCP long-vivante établie par `ShardToMasterClient` (initialement shard→master) en mode **bidirectionnel** : le master pousse un nouveau opcode sur cette même socket, le shard l'intercepte dans `OnPacketReceived`. Aucun nouveau canal de transport, aucune wire-change client.

### Détails

- **Nouveau opcode** `kOpcodeMasterToShardAdmitCharacter = 199` (master→shard push, `request_id=0`).
- **Nouveau payload** `AdmitCharacterPayload { uint64 account_id; uint64 character_id; }` dans `ShardPayloads.{h,cpp}`.
- **`ShardRegistry`** gagne `SetShardConnection(shard_id, connId)` / `GetShardConnection(shard_id)` pour mémoriser la connId TCP du shard. Tenu synchronisé par `ShardRegisterHandler` à chaque (re-)register.
- **`CharacterEnterWorldHandler`** :
  - Étend la requête DB existante : `SELECT name, server_id FROM characters WHERE id=? AND account_id=?` (pas de round-trip supplémentaire).
  - Après validation, lookup `shardConnId` via `ShardRegistry::GetShardConnection(server_id)` et `m_server->Send(shardConnId, BuildAdmitCharacterPacket(account_id, character_id))`.
- **`ShardToMasterClient::OnPacketReceived`** dispatche le nouvel opcode vers un callback (`SetAdmitCharacterCallback`).
- **`shardd/main_linux.cpp`** branche ce callback sur `admittedRegistry.Admit(character_id, account_id, nowMs)`.

### Sécurité

- Le master reste l'autorité : vérifie l'ownership (`account_id` = compte de la session) **avant** de pousser, comme aujourd'hui.
- Le shard ne fait que persister l'admission signalée par le master (déjà autoritaire pour l'auth).
- Pas d'exposition réseau : la connexion master↔shard est interne au réseau Docker, déjà sécurisée par le ticket HMAC et la TLS optionnelle.

### Latence

- Push master→shard : immédiat sur la TCP long-vivante (sub-ms en docker, ~quelques ms cross-host).
- Le master envoie le push **avant** le `EnterWorldResponse` au client → quand le client envoie `Hello` UDP après réception de la réponse, l'admission est déjà appliquée côté shard (TCP master→shard plus court que master→client→shard via UDP).

## Pas dans cette PR

- Pas de bump `kProtocolVersion` (canal interne master-shard, pas du protocole UDP client).
- Pas de retry client-side du `Hello` (la latence du push est suffisamment basse).
- Pas de TTL/cleanup explicite des admissions (déjà géré par `AdmittedCharacterRegistry`, TTL 5 min).

## Test plan

- [ ] CI `Build Linux` + `Build Windows` verts.
- [ ] Reproduction manuelle 2 clients : chacun voit l'avatar de l'autre bouger.
- [ ] Logs serveur attendus :
  ```
  master | [CharacterEnterWorldHandler] admit push sent (shard_id=1, ..., character_id=1)
  shard  | [ShardToMasterClient] AdmitCharacter received (account_id=1, character_id=1)
  shard  | [ShardMain] Admit pushed by master (account_id=1, character_id=1, nowMs=...)
  shard  | [ServerApp] Tick stats (..., clients=1, ..., tx_packets=N>0)
  ```

## Déploiement

⚠️ **Redéploiement coordonné master + shard requis** (les binaires doivent connaître le nouvel opcode 199). Client non touché. Pas de migration DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDhyiFv4RvnBVe5DUSqiWt)_