### PR TITLE
fix(shard): buffer le Hello UDP en attente d'admission (race avec push master)

### DIFF
--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -4,10 +4,12 @@
 #include "src/shared/network/CharacterPayloads.h"
 #include "src/shared/network/ErrorPacket.h"
 #include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/ShardPayloads.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/shared/network/NetServer.h"
 #include "src/masterd/session/SessionCharacterMap.h"
 #include "src/masterd/session/SessionManager.h"
+#include "src/masterd/shards/ShardRegistry.h"
 #include "src/masterd/account/AccountRole.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
@@ -15,6 +17,7 @@
 #include <mysql.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 
 namespace engine::server
@@ -24,6 +27,7 @@ namespace engine::server
 	void CharacterEnterWorldHandler::SetConnectionSessionMap(ConnectionSessionMap* map) { m_connMap = map; }
 	void CharacterEnterWorldHandler::SetSessionCharacterMap(SessionCharacterMap* charMap) { m_charMap = charMap; }
 	void CharacterEnterWorldHandler::SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_pool = pool; }
+	void CharacterEnterWorldHandler::SetShardRegistry(ShardRegistry* registry) { m_shardRegistry = registry; }
 
 	void CharacterEnterWorldHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize)
@@ -74,17 +78,19 @@ namespace engine::server
 			return;
 		}
 
-		// Vérifie ownership : SELECT name FROM characters WHERE id=? AND account_id=? AND deleted_at IS NULL.
+		// Vérifie ownership : SELECT name, server_id FROM characters WHERE id=? AND account_id=? AND deleted_at IS NULL.
 		// On compare ensuite le name DB au name client byte-pour-byte (rejette toute imposture
-		// comme un sender qui claim un autre nom que celui en DB).
+		// comme un sender qui claim un autre nom que celui en DB). TA.3 : server_id sert au
+		// lookup du shard cible pour le push d'admission.
 		char queryBuf[256]{};
 		std::snprintf(queryBuf, sizeof(queryBuf),
-			"SELECT name FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
+			"SELECT name, server_id FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
 			static_cast<unsigned long long>(parsed->characterId),
 			static_cast<unsigned long long>(*accountId));
 
 		MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
 		std::string dbName;
+		uint32_t dbServerId = 0;
 		bool found = false;
 		if (res)
 		{
@@ -92,6 +98,8 @@ namespace engine::server
 			if (row && row[0])
 			{
 				dbName = row[0];
+				if (row[1])
+					dbServerId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
 				found = true;
 			}
 			engine::server::db::DbFreeResult(res);
@@ -141,6 +149,39 @@ namespace engine::server
 		m_charMap->Set(connId, parsed->characterId, parsed->characterName, normalized, accountRole);
 		LOG_INFO(Net, "[CharacterEnterWorldHandler] registered (account_id={}, character_id={}, name='{}')",
 			*accountId, parsed->characterId, parsed->characterName);
+
+		// TA.3 — push d'admission au shard. Sans ça, le client envoie son Hello UDP avec
+		// `clientNonce=character_id`, mais le shard l'a admis au handshake TCP avec
+		// `character_id=0` (le ticket avait été demandé AVANT le choix de perso), donc rejet.
+		// Le push réutilise la connexion TCP long-vivante établie par ShardToMasterClient.
+		if (m_shardRegistry != nullptr && dbServerId != 0u)
+		{
+			auto shardConnId = m_shardRegistry->GetShardConnection(dbServerId);
+			if (shardConnId)
+			{
+				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId);
+				if (!admitPkt.empty() && m_server->Send(*shardConnId, admitPkt))
+				{
+					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={})",
+						dbServerId, *shardConnId, *accountId, parsed->characterId);
+				}
+				else
+				{
+					LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push send FAILED (shard_id={}, shardConnId={}, account_id={}, character_id={})",
+						dbServerId, *shardConnId, *accountId, parsed->characterId);
+				}
+			}
+			else
+			{
+				LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push skipped: no shard connection (shard_id={}, account_id={}, character_id={})",
+					dbServerId, *accountId, parsed->characterId);
+			}
+		}
+		else if (m_shardRegistry == nullptr)
+		{
+			LOG_WARN(Net, "[CharacterEnterWorldHandler] admit push skipped: ShardRegistry not configured (account_id={}, character_id={})",
+				*accountId, parsed->characterId);
+		}
 
 		auto pkt = BuildCharacterEnterWorldResponsePacket(1u, requestId, sessionIdHeader);
 		if (!pkt.empty())

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.h
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.h
@@ -14,6 +14,7 @@ namespace engine::server
 	class SessionManager;
 	class ConnectionSessionMap;
 	class SessionCharacterMap;
+	class ShardRegistry;
 
 	/// Phase 4 chat — Master-side handler for kOpcodeCharacterEnterWorldRequest.
 	///
@@ -22,6 +23,12 @@ namespace engine::server
 	/// binding in \ref SessionCharacterMap so subsequent CHAT_SEND_REQUEST can :
 	///   - use the character display name as sender (instead of the account login).
 	///   - resolve /whisper targets by character name → connId.
+	///
+	/// TA.3 — Émet aussi un push `kOpcodeMasterToShardAdmitCharacter` au shard sur lequel
+	/// vit le perso (résolu via `characters.server_id` + `ShardRegistry::GetShardConnection`)
+	/// pour qu'il admette `(account_id, character_id)` dans son `AdmittedCharacterRegistry`.
+	/// Sans ce push, le Hello UDP du client serait rejeté (ticket émis avant EnterWorld =
+	/// `character_id=0` côté shard).
 	///
 	/// Idempotent : the same client may resend if it changes character (logout to
 	/// CharacterSelect then re-EnterWorld).
@@ -33,6 +40,9 @@ namespace engine::server
 		void SetConnectionSessionMap(ConnectionSessionMap* map);
 		void SetSessionCharacterMap(SessionCharacterMap* charMap);
 		void SetConnectionPool(engine::server::db::ConnectionPool* pool);
+		/// TA.3 — facultatif. Si non configuré, le push d'admission est skip (log WARN unique
+		/// au premier EnterWorld). Permet de tourner sans cette fonctionnalité (tests / dev).
+		void SetShardRegistry(ShardRegistry* registry);
 
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
@@ -43,5 +53,6 @@ namespace engine::server
 		ConnectionSessionMap*               m_connMap  = nullptr;
 		SessionCharacterMap*                m_charMap  = nullptr;
 		engine::server::db::ConnectionPool* m_pool     = nullptr;
+		ShardRegistry*                      m_shardRegistry = nullptr; ///< TA.3 — lookup connId pour push d'admission.
 	};
 }

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -86,6 +86,9 @@ namespace engine::server
 				if (s.name == name)
 				{
 					m_registry->UpdateHeartbeat(s.shard_id, current_load);
+					// TA.3 : memorise la nouvelle connId du shard (re-register implique souvent
+					// une nouvelle connexion TCP) pour les push master->shard (AdmitCharacter).
+					m_registry->SetShardConnection(s.shard_id, connId);
 					auto pkt = BuildShardRegisterOkPacket(s.shard_id, requestId);
 					if (!pkt.empty() && m_server->Send(connId, pkt))
 					{
@@ -106,6 +109,8 @@ namespace engine::server
 		// --- Étape 3 : mise à jour du heartbeat et envoi de la réponse OK ----------
 		// Le premier UpdateHeartbeat fait passer l'état de Registering → Online.
 		m_registry->UpdateHeartbeat(*id, current_load);
+		// TA.3 : memorise la connId du shard pour les push master->shard (AdmitCharacter).
+		m_registry->SetShardConnection(*id, connId);
 		auto pkt = BuildShardRegisterOkPacket(*id, requestId);
 		if (!pkt.empty() && m_server->Send(connId, pkt))
 		{

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -424,6 +424,10 @@ int main(int argc, char** argv)
 	characterEnterWorldHandler.SetConnectionSessionMap(&connSessionMap);
 	characterEnterWorldHandler.SetSessionCharacterMap(&sessionCharMap);
 	characterEnterWorldHandler.SetConnectionPool(&dbPool);
+	// TA.3 — pousse l'admission (account_id, character_id) au shard a chaque EnterWorld
+	// reussi, via la connexion TCP long-vivante etablie par ShardToMasterClient et la
+	// connId memorisee par ShardRegisterHandler::SetShardConnection.
+	characterEnterWorldHandler.SetShardRegistry(&shardRegistry);
 
 	// M100.44 — handler des portails de donjon (Phase 11). Câble les
 	// opcodes 197/198 réservés par M100.43 : INSERT dans dungeon_instances

--- a/src/masterd/shards/ShardRegistry.cpp
+++ b/src/masterd/shards/ShardRegistry.cpp
@@ -251,4 +251,21 @@ LOG_DEBUG(Server, "[SREG_REG] EvictStaleHeartbeats timeout={}s marked={}", timeo
 		info.ruleset = best->ruleset;
 		return info;
 	}
+
+	void ShardRegistry::SetShardConnection(uint32_t shard_id, uint32_t connId)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_shards.find(shard_id) == m_shards.end())
+			return; // shard inconnu (race avec un evict ?). On ignore plutôt qu'insérer un fantôme.
+		m_shard_connections[shard_id] = connId;
+	}
+
+	std::optional<uint32_t> ShardRegistry::GetShardConnection(uint32_t shard_id) const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		auto it = m_shard_connections.find(shard_id);
+		if (it == m_shard_connections.end())
+			return std::nullopt;
+		return it->second;
+	}
 }

--- a/src/masterd/shards/ShardRegistry.h
+++ b/src/masterd/shards/ShardRegistry.h
@@ -88,6 +88,16 @@ namespace engine::server
 		/// M22.5: returns Online shard with lowest load ratio (current_load/max_capacity). Excludes Offline and Degraded.
 		std::optional<ShardInfo> SelectShard() const;
 
+		/// TA.3 — Mémorise (ou rafraîchit) la `connId` TCP sur laquelle le shard est connecté
+		/// au master. Permet au master d'émettre une commande push (ex.
+		/// `kOpcodeMasterToShardAdmitCharacter`) via `NetServer::Send(connId, ...)` en
+		/// réutilisant la connexion long-vivante initiée par `ShardToMasterClient`. Appelé
+		/// par `ShardRegisterHandler` à chaque (re-)register. No-op si shard_id inconnu.
+		void SetShardConnection(uint32_t shard_id, uint32_t connId);
+
+		/// TA.3 — Récupère la connId TCP du shard. `nullopt` si aucune connexion mémorisée.
+		std::optional<uint32_t> GetShardConnection(uint32_t shard_id) const;
+
 	private:
 		struct Entry
 		{
@@ -107,6 +117,10 @@ namespace engine::server
 		mutable std::mutex m_mutex;
 		std::unordered_map<uint32_t, Entry> m_shards;
 		std::unordered_map<std::string, uint32_t> m_name_to_id;
+		/// TA.3 — Mapping shard_id → connId TCP. Tenu synchronisé par `ShardRegisterHandler`
+		/// à chaque (re-)register du shard. Permet au master d'émettre des push vers le shard
+		/// via `NetServer::Send(connId, ...)`.
+		std::unordered_map<uint32_t, uint32_t> m_shard_connections;
 		uint32_t m_next_id = 1;
 		std::function<void(uint32_t)> m_shard_down_callback;
 		double m_degraded_load_threshold = 0.90;

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -172,6 +172,18 @@ int main(int argc, char** argv)
 	toMaster.SetAllowInsecureDev(masterInsecure);
 	toMaster.SetShardIdentity(regName, regEndpoint, regUdpEndpoint, regCap, buildVer, regDisplayName, regGameMode, regRuleset, regRegion);
 	toMaster.SetHeartbeatIntervalSec(static_cast<int>(config.GetInt("shard.heartbeat_interval_sec", 10)));
+	// TA.3 — admet (account_id, character_id) dans le registre dès que le master pousse
+	// kOpcodeMasterToShardAdmitCharacter (suite à un EnterWorld réussi côté master). Sans
+	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le
+	// ticket TCP avait été émis avant le choix de perso (character_id=0 → non admis).
+	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id) {
+		const std::uint64_t nowMs = static_cast<std::uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+		admittedRegistry.Admit(character_id, account_id, nowMs);
+		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, nowMs={})",
+			account_id, character_id, nowMs);
+	});
 	toMaster.Start();
 	// TA.3 : boucle gameplay UDP (ServerApp) sur un thread dedie, gated par admittedRegistry.
 	// Cohabite avec la stack TCP ticket + heartbeat + runtimes (ports/protocoles distincts).

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -816,4 +816,10 @@ namespace engine::network
 
 	constexpr uint16_t kOpcodeEnterDungeonRequest  = 197u; ///< Client to Master : déclenche un portail (dungeonTemplateId, difficulty). Reservé M100.43, non câblé jusqu'a M100.44.
 	constexpr uint16_t kOpcodeEnterDungeonResponse = 198u; ///< Master to Client : ACK avec instanceId + shardEndpoint, ou erreur (TemplateNotFound / InstanceFull / DifficultyLocked).
+
+	// -------------------------------------------------------------------------
+	// TA.3 — Admission de personnage (master → shard, push) — voir AdmitCharacterPayload.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpcodeMasterToShardAdmitCharacter = 199u; ///< Master to Shard (push, request_id=0) : (account_id, character_id) à admettre dans AdmittedCharacterRegistry, suite à un EnterWorld réussi côté master.
 }

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -105,4 +105,28 @@ namespace engine::network
 			return {};
 		return buf;
 	}
+
+	std::optional<AdmitCharacterPayload> ParseAdmitCharacterPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (payload == nullptr || payloadSize < 16u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		AdmitCharacterPayload out;
+		if (!r.ReadU64(out.account_id) || !r.ReadU64(out.character_id))
+			return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(account_id) || !w.WriteU64(character_id))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		// Push master→shard, pas de request_id ni session.
+		if (!builder.Finalize(kOpcodeMasterToShardAdmitCharacter, 0, 0, 0, payloadBytes))
+			return {};
+		return builder.Data();
+	}
 }

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -68,4 +68,21 @@ namespace engine::network
 
 	/// Builds SHARD_HEARTBEAT payload (Shard→Master). timestamp: e.g. seconds since epoch or monotonic.
 	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0);
+
+	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id).
+	/// Émis par le master (CharacterEnterWorldHandler) à destination du shard via la
+	/// connexion TCP persistante établie par ShardToMasterClient. Le shard l'utilise pour
+	/// admettre (account_id, character_id) dans son AdmittedCharacterRegistry → le Hello
+	/// UDP du client (clientNonce=character_id) sera ensuite accepté.
+	struct AdmitCharacterPayload
+	{
+		uint64_t account_id = 0;
+		uint64_t character_id = 0;
+	};
+
+	/// Parses MASTER_TO_SHARD_ADMIT_CHARACTER payload. Returns nullopt if truncated.
+	std::optional<AdmitCharacterPayload> ParseAdmitCharacterPayload(const uint8_t* payload, size_t payloadSize);
+
+	/// Builds MASTER_TO_SHARD_ADMIT_CHARACTER packet (Master→Shard, push, request_id=0).
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id);
 }

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -200,6 +200,28 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 			LOG_ERROR(Core, "[ShardToMasterClient] Register ERROR from Master");
 			m_client->Disconnect("register error");
 		}
+		else if (opcode == kOpcodeMasterToShardAdmitCharacter)
+		{
+			// TA.3 — push master->shard suite a un EnterWorld reussi cote master.
+			// Le master reutilise cette connexion long-vivante (initialement
+			// shard->master) pour pousser (account_id, character_id) au shard sans
+			// inventer un nouveau canal de transport.
+			auto parsed = ParseAdmitCharacterPayload(view.Payload(), view.PayloadSize());
+			if (!parsed)
+			{
+				LOG_WARN(Core, "[ShardToMasterClient] AdmitCharacter: parse FAILED (size={})", view.PayloadSize());
+				return;
+			}
+			if (!m_admit_callback)
+			{
+				LOG_WARN(Core, "[ShardToMasterClient] AdmitCharacter received but no callback registered (account_id={}, character_id={})",
+					parsed->account_id, parsed->character_id);
+				return;
+			}
+			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={})",
+				parsed->account_id, parsed->character_id);
+			m_admit_callback(parsed->account_id, parsed->character_id);
+		}
 	}
 
 	void ShardToMasterClient::ScheduleReconnect()

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -51,6 +52,13 @@ namespace engine::network
 		/// Heartbeat interval in seconds. Default 10. Call before Start() to take effect.
 		void SetHeartbeatIntervalSec(int sec) { m_heartbeat_interval_sec = (sec > 0) ? sec : 10; }
 
+		/// TA.3 — Callback invoqué quand le master pousse un `kOpcodeMasterToShardAdmitCharacter`
+		/// (suite à un EnterWorld réussi côté master). Le destinataire typique alimente
+		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, now)` côté shard.
+		/// `nullptr` (défaut) = drop silencieux.
+		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id)>;
+		void SetAdmitCharacterCallback(AdmitCharacterCallback cb) { m_admit_callback = std::move(cb); }
+
 		enum class State
 		{
 			Disconnected,
@@ -91,5 +99,7 @@ namespace engine::network
 		std::chrono::steady_clock::time_point m_reconnect_after{};
 		int m_reconnect_backoff_sec = 1;
 		int m_heartbeat_interval_sec = 10;
+		/// TA.3 — callback admission (master push). Voir SetAdmitCharacterCallback.
+		AdmitCharacterCallback m_admit_callback;
 	};
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -296,6 +296,7 @@ namespace engine::server
 		m_dynamicEvents.clear();
 		m_spawners.clear();
 		m_pendingDatagrams.clear();
+		m_pendingHellos.clear(); // TA.3 — buffer Hello en attente d'admission, vide au boot.
 		m_zoneGrids.clear();
 		m_nextServerEntityId = 0x200000000ull;
 		if (!m_zoneTransitionMap.Init())
@@ -540,6 +541,7 @@ namespace engine::server
 		}
 		m_zoneGrids.clear();
 		m_pendingDatagrams.clear();
+		m_pendingHellos.clear(); // TA.3 — buffer Hello en attente d'admission.
 		m_tickScheduler.Shutdown();
 		m_transport.Shutdown();
 		m_zoneTransitionMap.Shutdown();
@@ -1037,10 +1039,33 @@ namespace engine::server
 				std::chrono::steady_clock::now().time_since_epoch()).count());
 			if (!m_admittedRegistry->IsAdmitted(tentativeCharacterKey, nowMs))
 			{
-				LOG_WARN(Net,
-					"[ServerApp] Hello rejected: character_key={} not admitted (no valid ticket) (endpoint={})",
+				// TA.3 — race condition Hello/Admit : l'admission est peut-être en route
+				// (master vient de pousser kOpcodeMasterToShardAdmitCharacter, mais le
+				// Hello UDP est arrivé avant). On met en attente plutôt que de drop, et
+				// DrainPendingHellos (appelé à chaque TickOnce) re-essaiera dès que
+				// l'admission sera vue.
+				// Dédup par character_key : un client qui spam Hello pour le même perso
+				// n'écrase que sa propre entrée (et le timestamp est rafraîchi).
+				bool found = false;
+				for (PendingHello& entry : m_pendingHellos)
+				{
+					if (entry.characterKey == tentativeCharacterKey)
+					{
+						entry.endpoint = endpoint;
+						entry.arrivedAtMs = nowMs;
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+				{
+					m_pendingHellos.push_back(PendingHello{ endpoint, tentativeCharacterKey, nowMs });
+				}
+				LOG_INFO(Net,
+					"[ServerApp] Hello mis en attente d'admission (character_key={}, endpoint={}, pending={})",
 					tentativeCharacterKey,
-					UdpTransport::EndpointToString(endpoint));
+					UdpTransport::EndpointToString(endpoint),
+					m_pendingHellos.size());
 				return;
 			}
 		}
@@ -1237,9 +1262,60 @@ namespace engine::server
 		UpdateClientInterest(*client);
 	}
 
+	void ServerApp::DrainPendingHellos()
+	{
+		if (m_pendingHellos.empty() || m_admittedRegistry == nullptr)
+			return;
+		const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		// On copie les entrées candidates (admises ou expirées) puis on rebuild la liste
+		// en gardant uniquement les non-admises non-expirées. Cas attendu : 0-2 entrées,
+		// donc le coût est négligeable.
+		std::vector<PendingHello> toReplay;
+		std::vector<PendingHello> stillPending;
+		toReplay.reserve(m_pendingHellos.size());
+		stillPending.reserve(m_pendingHellos.size());
+		for (const PendingHello& entry : m_pendingHellos)
+		{
+			if (nowMs - entry.arrivedAtMs > kPendingHelloTtlMs)
+			{
+				LOG_WARN(Net,
+					"[ServerApp] Hello en attente expire (character_key={}, endpoint={}, age_ms={})",
+					entry.characterKey,
+					UdpTransport::EndpointToString(entry.endpoint),
+					nowMs - entry.arrivedAtMs);
+				continue; // drop expired
+			}
+			if (m_admittedRegistry->IsAdmitted(entry.characterKey, nowMs))
+			{
+				toReplay.push_back(entry);
+			}
+			else
+			{
+				stillPending.push_back(entry);
+			}
+		}
+		m_pendingHellos = std::move(stillPending);
+		// Retraite hors-boucle pour eviter de re-entrer dans HandleHello qui pourrait
+		// re-buffer l'entree si on echoue une 2e fois (cas pathologique : admit revoque
+		// entre temps). Le rebuild de m_pendingHellos est deja figé avant les Replay.
+		for (const PendingHello& entry : toReplay)
+		{
+			LOG_INFO(Net,
+				"[ServerApp] Retraite Hello en attente (character_key={}, endpoint={}, age_ms={})",
+				entry.characterKey,
+				UdpTransport::EndpointToString(entry.endpoint),
+				nowMs - entry.arrivedAtMs);
+			HandleHello(entry.endpoint, entry.characterKey);
+		}
+	}
+
 	void ServerApp::TickOnce()
 	{
 		++m_currentTick;
+		// TA.3 — retraite avant Simulate : un Hello admis ce tick devient un client connecté
+		// dont la position sera diffusée par MaybeSendSnapshots du même tick.
+		DrainPendingHellos();
 		Simulate();
 		MaybeAutosaveCharacters();
 		RefreshReplication();

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -293,6 +293,13 @@ namespace engine::server
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).
 		void HandleHello(const Endpoint& endpoint, uint64_t helloNonce);
 
+		/// TA.3 — Retraite les Hellos en attente d'admission. Appelé au début de chaque
+		/// TickOnce : pour chaque entrée du buffer, si le registry indique maintenant
+		/// l'admission, on rappelle HandleHello (l'admission ayant été poussée entre temps
+		/// par le master via kOpcodeMasterToShardAdmitCharacter). Entrées expirées (TTL)
+		/// supprimées silencieusement.
+		void DrainPendingHellos();
+
 		/// Record the last input sequence for a connected client.
 		void HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians);
 
@@ -834,6 +841,25 @@ namespace engine::server
 		/// TA.3 : gate de session UDP (optionnel, possédé par l'appelant). Voir
 		/// SetAdmittedCharacterRegistry.
 		AdmittedCharacterRegistry* m_admittedRegistry = nullptr;
+
+		/// TA.3 — race condition Hello/Admit : le Hello UDP du client peut arriver au shard
+		/// AVANT que le push d'admission TCP du master n'ait été traité (master émet le push
+		/// puis répond au client ; UDP client→shard est souvent plus court que TCP master→shard
+		/// par bufferisation). Sans buffer, le Hello est rejeté et le client ne réessaie pas.
+		/// On garde donc en attente, pour un court TTL, les Hellos rejetés pour cause
+		/// « not admitted » ; à chaque tick on les retraite si l'admission est devenue valide.
+		/// Réécrit uniquement depuis le thread gameplay (HandleHello + DrainPendingHellos),
+		/// pas besoin de mutex (le registry sous-jacent est thread-safe).
+		struct PendingHello
+		{
+			Endpoint endpoint{};
+			uint64_t characterKey = 0;
+			uint64_t arrivedAtMs = 0;
+		};
+		std::vector<PendingHello> m_pendingHellos;
+		/// TTL ms d'un Hello en attente. Au-delà, on abandonne (l'admission n'est pas arrivée).
+		/// 5 s suffisent largement vs la latence master→shard (typiquement < 100 ms).
+		static constexpr uint64_t kPendingHelloTtlMs = 5000u;
 
 		/// TA.3c : anti-triche mouvement (speed/teleport) sur les positions reçues en
 		/// Input. Détecteur header-only seedé à la config V1 par défaut (7.5 m/s * 1.5,


### PR DESCRIPTION
## Symptôme (logs prod, après PR #704)

```
shard | [ServerApp] Hello rejected: character_key=1 not admitted (no valid ticket)
shard | [ShardToMasterClient] AdmitCharacter received (account_id=1, character_id=1)   ← APRÈS
shard | [ShardMain] Admit pushed by master (account_id=1, character_id=1)
```

PR #704 fait bien arriver le push d'admission au shard, **mais après** le `Hello` UDP du client. Le client ne réessaie pas → `clients=0`, `tx_packets=0` → joueurs invisibles.

## Cause

Race condition. Côté master, dans `CharacterEnterWorldHandler` :
1. Push admit master→shard via `NetServer::Send(shardConnId, packet)` (TCP, asynchrone / worker pool).
2. Réponse `EnterWorld` au client via le même `NetServer::Send`.

Le client reçoit la réponse, fait `InitGameplayNet` → `SendHello` UDP direct vers le shard. Le chemin master→client→shard via Internet+UDP est en pratique **plus court** que le chemin master→shard TCP bufferisé sur le worker `NetServer`. Résultat : le `Hello` overtake le push admit.

## Correctif — shard-only, sans wire-change

Au lieu de drop le Hello rejeté, on le **met en attente** côté shard et on le retraite quand l'admission arrive :

- `ServerApp` : nouveau buffer `std::vector<PendingHello> m_pendingHellos`, TTL 5 s.
- `HandleHello` : sur rejet « not admitted », on insère/rafraîchit l'entrée par `character_key` (dedup, le client qui spam Hello n'écrase que sa propre entrée).
- `DrainPendingHellos` (nouveau) appelé en début de chaque `TickOnce` (20 Hz, latence max **50 ms** après que l'admit arrive) :
  - Si l'admission est devenue valide → on rappelle `HandleHello` (qui passe cette fois le gate et crée le client).
  - Si TTL dépassé → drop silencieux.
- `Init`/`Shutdown` : clear du buffer comme `m_pendingDatagrams`.

## Pas dans cette PR

- Aucun changement protocole, aucun bump `kProtocolVersion`.
- Aucun changement client. Pas de retry Hello côté client (inutile maintenant que le shard tolère le retard).
- Aucun changement master. La race reste possible mais inoffensive.

## Logs attendus après merge (succès)

```
shard | [ServerApp] Hello mis en attente d'admission (character_key=1, ..., pending=1)
shard | [ShardToMasterClient] AdmitCharacter received (account_id=1, character_id=1)
shard | [ShardMain] Admit pushed by master (...)
shard | [ServerApp] Retraite Hello en attente (character_key=1, ..., age_ms=42)
shard | [ServerApp] Tick stats (..., clients=1, ..., tx_packets=N>0)
```

## Déploiement

⚠️ **Redéploiement serveur (shard Linux) requis**. Master non touché. Client non concerné. Pas de migration DB.

⚠️ **Cette PR est stackée sur PR #704** (qui n'est pas encore mergée). GitHub re-pointera automatiquement sur `main` après le merge de #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDhyiFv4RvnBVe5DUSqiWt)_