### PR TITLE
fix(replication): bugs A+B+C+D — origin grille, timeout UDP, despawn auto, diag rendu avatar (v2)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9537,11 +9537,44 @@ namespace engine
 		if (!m_pipeline) return;
 		const std::vector<engine::client::UIRemoteEntity>& remotes = m_uiModelBinding.GetModel().remoteEntities;
 		if (remotes.empty()) return;
+		// TD.2 diag : logs une-fois pour identifier les early-return silencieux qui empechent
+		// le rendu des avatars distants (nameplate visible mais skin invisible).
+		static bool diagLoggedReason = false;
 		engine::render::MeshAsset* mesh = m_geometryMeshHandle.Get();
-		if (mesh == nullptr || mesh->vertexBuffer == VK_NULL_HANDLE || mesh->indexBuffer == VK_NULL_HANDLE) return;
+		if (mesh == nullptr || mesh->vertexBuffer == VK_NULL_HANDLE || mesh->indexBuffer == VK_NULL_HANDLE)
+		{
+			if (!diagLoggedReason)
+			{
+				LOG_WARN(Render,
+					"[RecordRemoteAvatars] SKIP : mesh placeholder non pret (mesh={} vbuf={} ibuf={}, remotes={})",
+					mesh ? "ok" : "null",
+					(mesh && mesh->vertexBuffer != VK_NULL_HANDLE) ? "ok" : "null",
+					(mesh && mesh->indexBuffer != VK_NULL_HANDLE) ? "ok" : "null",
+					remotes.size());
+				diagLoggedReason = true;
+			}
+			return;
+		}
 		auto& geom = m_pipeline->GetGeometryPass();
 		// loadOp=LOAD requis pour se superposer au GBuffer (terrain + avatar + props) sans clear.
-		if (!geom.HasLoadPass()) return;
+		if (!geom.HasLoadPass())
+		{
+			if (!diagLoggedReason)
+			{
+				LOG_WARN(Render, "[RecordRemoteAvatars] SKIP : GeometryPass sans load pass (remotes={})", remotes.size());
+				diagLoggedReason = true;
+			}
+			return;
+		}
+		static bool diagLoggedSuccess = false;
+		if (!diagLoggedSuccess)
+		{
+			LOG_INFO(Render,
+				"[RecordRemoteAvatars] OK : rendu des avatars distants demarre (remotes={}, mesh.vcount={}, mesh.icount={}, material_id={})",
+				remotes.size(), mesh->vertexCount, mesh->indexCount,
+				(m_avatarMaterialId != 0u) ? m_avatarMaterialId : 0u);
+			diagLoggedSuccess = true;
+		}
 		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
 		const uint32_t materialIndex = (m_avatarMaterialId != 0u)
 			? m_avatarMaterialId : materialCache.GetDefaultMaterialIndex();

--- a/src/shardd/world/GridNotifierTests.cpp
+++ b/src/shardd/world/GridNotifierTests.cpp
@@ -92,12 +92,12 @@ namespace
 		CellGrid grid;
 		grid.Init();
 
-		// 4 entites au meme endroit (5000,5000) — tous dans le 7x7 center.
+		// 4 entites au meme endroit (0,0) — convention centree, tous dans le 7x7 center.
 		CellCoord cell{};
-		assert(grid.UpsertEntity(101, 5000.0f, 5000.0f, cell));
-		assert(grid.UpsertEntity(102, 5050.0f, 5050.0f, cell));
-		assert(grid.UpsertEntity(201, 5010.0f, 5010.0f, cell));
-		assert(grid.UpsertEntity(202, 5020.0f, 5020.0f, cell));
+		assert(grid.UpsertEntity(101, 0.0f, 0.0f, cell));
+		assert(grid.UpsertEntity(102, 50.0f, 50.0f, cell));
+		assert(grid.UpsertEntity(201, 10.0f, 10.0f, cell));
+		assert(grid.UpsertEntity(202, 20.0f, 20.0f, cell));
 
 		// "Players" = ids commencant par 1, "Creatures" = ids commencant par 2.
 		std::unordered_set<EntityId> playerIds = {101, 102};
@@ -105,7 +105,7 @@ namespace
 			return playerIds.count(id) > 0;
 		});
 
-		GridVisitWithVisitor(grid, 5000.0f, 5000.0f, notifier);
+		GridVisitWithVisitor(grid, 0.0f, 0.0f, notifier);
 
 		assert(notifier.Count() == 2);
 		auto has101 = std::find(notifier.Recipients().begin(),

--- a/src/shardd/world/GridVisitorTests.cpp
+++ b/src/shardd/world/GridVisitorTests.cpp
@@ -23,7 +23,7 @@ namespace
 		CellGrid grid;
 		grid.Init();
 		int count = 0;
-		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		GridVisit(grid, 0.0f, 0.0f, [&count](EntityId) { ++count; });
 		assert(count == 0);
 		std::puts("[OK] TestGridVisitEmpty");
 	}
@@ -37,7 +37,7 @@ namespace
 		assert(grid.UpsertEntity(/*id*/42, /*x*/5000.0f, /*z*/5000.0f, cell));
 
 		std::vector<EntityId> visited;
-		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+		GridVisit(grid, 0.0f, 0.0f, [&visited](EntityId id) {
 			visited.push_back(id);
 		});
 		assert(visited.size() == 1);
@@ -52,11 +52,11 @@ namespace
 		CellGrid grid;
 		grid.Init();
 		CellCoord cell{};
-		assert(grid.UpsertEntity(1, 5000.0f, 5000.0f, cell));
-		assert(grid.UpsertEntity(2, 5050.0f, 5050.0f, cell)); // meme cell
+		assert(grid.UpsertEntity(1, 0.0f, 0.0f, cell));
+		assert(grid.UpsertEntity(2, 50.0f, 50.0f, cell)); // meme cell
 
 		std::vector<EntityId> visited;
-		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+		GridVisit(grid, 0.0f, 0.0f, [&visited](EntityId id) {
 			visited.push_back(id);
 		});
 		assert(visited.size() == 2);
@@ -70,12 +70,12 @@ namespace
 		CellGrid grid;
 		grid.Init();
 		CellCoord cell{};
-		assert(grid.UpsertEntity(10, 5000.0f, 5000.0f, cell));  // center
-		assert(grid.UpsertEntity(20, 5200.0f, 5000.0f, cell));  // +2 cells (inside 7x7)
-		assert(grid.UpsertEntity(30, 5500.0f, 5000.0f, cell));  // +5 cells (outside 7x7)
+		assert(grid.UpsertEntity(10, 0.0f, 0.0f, cell));  // center
+		assert(grid.UpsertEntity(20, 200.0f, 0.0f, cell));  // +2 cells (inside 7x7)
+		assert(grid.UpsertEntity(30, 500.0f, 0.0f, cell));  // +5 cells (outside 7x7)
 
 		std::vector<EntityId> visited;
-		GridVisit(grid, 5000.0f, 5000.0f, [&visited](EntityId id) {
+		GridVisit(grid, 0.0f, 0.0f, [&visited](EntityId id) {
 			visited.push_back(id);
 		});
 		assert(visited.size() == 2);
@@ -93,13 +93,13 @@ namespace
 		CellGrid grid;
 		grid.Init();
 		CellCoord cell{};
-		assert(grid.UpsertEntity(1, 5000.0f, 5000.0f, cell));
+		assert(grid.UpsertEntity(1, 0.0f, 0.0f, cell));
 
-		// Position negative ou > kZoneSizeMeters -> hors zone.
+		// Convention centree : plage monde acceptee [-5000, +5000). Au-dela : hors-zone.
 		int count = 0;
-		GridVisit(grid, -100.0f, 5000.0f, [&count](EntityId) { ++count; });
+		GridVisit(grid, -50000.0f, 0.0f, [&count](EntityId) { ++count; });
 		assert(count == 0);
-		GridVisit(grid, 50000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		GridVisit(grid, 50000.0f, 0.0f, [&count](EntityId) { ++count; });
 		assert(count == 0);
 		std::puts("[OK] TestGridVisitOutsideZone");
 	}
@@ -111,7 +111,7 @@ namespace
 		CellGrid grid;
 		// pas d'Init()
 		int count = 0;
-		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		GridVisit(grid, 0.0f, 0.0f, [&count](EntityId) { ++count; });
 		assert(count == 0);
 		std::puts("[OK] TestGridVisitUninitialized");
 	}
@@ -129,11 +129,11 @@ namespace
 		CellGrid grid;
 		grid.Init();
 		CellCoord cell{};
-		assert(grid.UpsertEntity(7, 5000.0f, 5000.0f, cell));
-		assert(grid.UpsertEntity(8, 5050.0f, 5050.0f, cell));
+		assert(grid.UpsertEntity(7, 0.0f, 0.0f, cell));
+		assert(grid.UpsertEntity(8, 50.0f, 50.0f, cell));
 
 		CollectorVisitor v;
-		GridVisitWithVisitor(grid, 5000.0f, 5000.0f, v);
+		GridVisitWithVisitor(grid, 0.0f, 0.0f, v);
 		assert(v.ids.size() == 2);
 		std::puts("[OK] TestGridVisitWithVisitor");
 	}
@@ -148,17 +148,18 @@ namespace
 		CellGrid grid;
 		grid.Init();
 
-		// Place 1000 entites sur grille 32x32 (1024 cells, gardons 1000)
-		// pas = 312.5m, mais on arrondit a 310m pour rester dans zone.
-		// Cells 100m -> les entites tombent dans des cells distinctes.
+		// Convention centree (-5000..+5000) : place 1000 entites sur grille 32x32 dont
+		// l'origine grille est a (-5000+50, -5000+50). Pas = 310m. Cells 100m -> les
+		// entites tombent dans des cells distinctes.
 		const int stepMeters = 310;
+		const float originMeters = -5000.0f + 50.0f; // coin sud-ouest dans le repere centre
 		int placed = 0;
 		for (int gx = 0; gx < 32 && placed < 1000; ++gx)
 		{
 			for (int gz = 0; gz < 32 && placed < 1000; ++gz)
 			{
-				const float x = static_cast<float>(gx * stepMeters + 50);
-				const float z = static_cast<float>(gz * stepMeters + 50);
+				const float x = originMeters + static_cast<float>(gx * stepMeters);
+				const float z = originMeters + static_cast<float>(gz * stepMeters);
 				CellCoord cell{};
 				if (grid.UpsertEntity(static_cast<EntityId>(placed + 1), x, z, cell))
 					++placed;
@@ -166,14 +167,13 @@ namespace
 		}
 		assert(placed == 1000);
 
-		// Visite autour de (5000, 5000) : 7x7 cells centrees sur (50, 50)
-		// in cell-coords (5000m / 100m = 50). Range cells [47..53] sur x et z.
-		// Cells touchées : trouver les entites avec gx*310+50 dans [4700..5350]
-		// (cells 47..53 = 4700..5400 m), idem pour z. gx*310+50 in [4700..5350]
-		// -> gx in [15..17] (since 15*310+50=4700, 17*310+50=5320, 18*310+50=5630>5400).
-		// 3 valeurs de gx * 3 valeurs de gz = 9 entites attendues.
+		// Visite autour de (0, 0) world (= cell (50, 50) en repere grille apres offset).
+		// Plage cellules visitee : [47..53] sur x et z (7x7). Cellules touchees a partir
+		// de la grille reguliere : entites avec gx*310 + (-4950) dans world [-300..+350]
+		// (cells 47..53 = world [-300..+400] approx). gx in [15..17] (15*310-4950=-300,
+		// 17*310-4950=320). 3 valeurs de gx * 3 valeurs de gz = 9 entites attendues.
 		int count = 0;
-		GridVisit(grid, 5000.0f, 5000.0f, [&count](EntityId) { ++count; });
+		GridVisit(grid, 0.0f, 0.0f, [&count](EntityId) { ++count; });
 		assert(count == 9);
 		std::puts("[OK] TestGridVisitStress1000Entities");
 	}

--- a/src/shardd/world/SpatialPartition.cpp
+++ b/src/shardd/world/SpatialPartition.cpp
@@ -90,14 +90,22 @@ namespace engine::server
 			return false;
 		}
 
-		if (posX < 0.0f || posZ < 0.0f || posX >= static_cast<float>(kZoneSizeMeters) || posZ >= static_cast<float>(kZoneSizeMeters))
+		// Convention : le client centre le monde à (0,0) (cf. Engine.cpp B.1 spawn).
+		// La grille stocke des cellules indexées [0, kCellGridAxisCount). On translate
+		// donc les coords monde par +halfZone pour les mapper sur l'espace cellule.
+		// Plage monde acceptée : [-halfZone, +halfZone). Au-delà : hors-zone (rejet).
+		constexpr float halfZoneMeters = static_cast<float>(kZoneSizeMeters) * 0.5f;
+		const float gridX = posX + halfZoneMeters;
+		const float gridZ = posZ + halfZoneMeters;
+		if (gridX < 0.0f || gridZ < 0.0f || gridX >= static_cast<float>(kZoneSizeMeters) || gridZ >= static_cast<float>(kZoneSizeMeters))
 		{
-			LOG_WARN(Net, "[CellGrid] TryWorldToCellCoord FAILED: out of zone position ({:.2f}, {:.2f})", posX, posZ);
+			LOG_WARN(Net, "[CellGrid] TryWorldToCellCoord FAILED: out of zone position ({:.2f}, {:.2f}) (plage acceptee [-{:.0f}, +{:.0f}))",
+				posX, posZ, halfZoneMeters, halfZoneMeters);
 			return false;
 		}
 
-		outCell.x = static_cast<int16_t>(std::floor(posX / static_cast<float>(kCellSizeMeters)));
-		outCell.z = static_cast<int16_t>(std::floor(posZ / static_cast<float>(kCellSizeMeters)));
+		outCell.x = static_cast<int16_t>(std::floor(gridX / static_cast<float>(kCellSizeMeters)));
+		outCell.z = static_cast<int16_t>(std::floor(gridZ / static_cast<float>(kCellSizeMeters)));
 		return true;
 	}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1074,6 +1074,8 @@ namespace engine::server
 		if (existingClient != nullptr)
 		{
 			existingClient->helloNonce = helloNonce;
+			existingClient->lastUdpActivityAtMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
 			LOG_INFO(Net, "[ServerApp] Handshake refresh (client_id={}, endpoint={}, nonce={})",
 				existingClient->clientId,
 				UdpTransport::EndpointToString(endpoint),
@@ -1098,6 +1100,9 @@ namespace engine::server
 		client.stats.currentHealth = kDefaultPlayerHealth;
 		client.stats.maxHealth = kDefaultPlayerHealth;
 		client.combat = BuildDefaultCombatComponent(m_tickHz, kDefaultPlayerDamage);
+		// TA.3 — initialise le timestamp d'activite UDP au Hello (premier signe de vie).
+		client.lastUdpActivityAtMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
 		ConnectedClient& acceptedClient = m_clients.emplace_back(std::move(client));
 		// TG.2 — insertion incrémentale dans les 3 index O(1). push_back garantit que les
 		// indices existants restent valides (la nouvelle entrée est en queue).
@@ -1242,6 +1247,10 @@ namespace engine::server
 		const float previousPositionX = client->positionMetersX;
 		const float previousPositionZ = client->positionMetersZ;
 		client->lastInputSequence = inputSequence;
+		// TA.3 — rafraichit le timestamp UDP : ce client est vivant. EvictIdleClients
+		// le laissera tranquille tant qu'il continue d'envoyer des Input.
+		client->lastUdpActivityAtMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
 		client->positionMetersX = positionMetersX;
 		client->positionMetersY = positionMetersY; // TC.1 : altitude fournie par le client
 		client->positionMetersZ = positionMetersZ;
@@ -1310,12 +1319,49 @@ namespace engine::server
 		}
 	}
 
+	void ServerApp::EvictIdleUdpClients()
+	{
+		if (m_clients.empty())
+			return;
+		const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		// Recolte les candidats puis appelle DisconnectConnectedClient hors-boucle (qui
+		// modifie m_clients + reconstruit les index hash TG.2 ; iterer en mutation casserait).
+		std::vector<uint32_t> toDisconnect;
+		toDisconnect.reserve(m_clients.size());
+		for (const ConnectedClient& client : m_clients)
+		{
+			if (client.lastUdpActivityAtMs == 0)
+				continue; // jamais initialise (defensive)
+			if (nowMs - client.lastUdpActivityAtMs >= kUdpClientIdleTimeoutMs)
+			{
+				LOG_INFO(Net,
+					"[ServerApp] Evict idle UDP client (client_id={}, character_key={}, endpoint={}, idle_ms={})",
+					client.clientId, client.persistenceCharacterKey,
+					UdpTransport::EndpointToString(client.endpoint),
+					nowMs - client.lastUdpActivityAtMs);
+				toDisconnect.push_back(client.clientId);
+			}
+		}
+		for (uint32_t clientId : toDisconnect)
+		{
+			DisconnectConnectedClient(clientId, "udp_idle_timeout");
+		}
+	}
+
 	void ServerApp::TickOnce()
 	{
 		++m_currentTick;
 		// TA.3 — retraite avant Simulate : un Hello admis ce tick devient un client connecté
 		// dont la position sera diffusée par MaybeSendSnapshots du même tick.
 		DrainPendingHellos();
+		// TA.3 — eviction des clients UDP zombies (1 Hz pour limiter le cout, suffisant
+		// pour la propriete attendue : zombie disparait en max ~kUdpClientIdleTimeoutMs + 1 s).
+		if (m_currentTick - m_lastEvictIdleClientsTick >= m_tickHz)
+		{
+			EvictIdleUdpClients();
+			m_lastEvictIdleClientsTick = m_currentTick;
+		}
 		Simulate();
 		MaybeAutosaveCharacters();
 		RefreshReplication();

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -88,6 +88,11 @@ namespace engine::server
 		EntityId entityId = 0;
 		uint32_t archetypeId = 1;
 		uint32_t lastInputSequence = 0;
+		/// TA.3 — timeout zombie : rafraichi a chaque Hello/Input (UDP). Utilise par
+		/// EvictIdleClients pour evincer un client qui ne souffle plus depuis > N ticks
+		/// (le NetServer TCP a son propre timeout, mais l'UDP gameplay non — sans ca,
+		/// les avatars de joueurs deconnectes restent broadcastes indefiniment).
+		uint64_t lastUdpActivityAtMs = 0;
 		/// Phase 3.7.5 — élargi à uint64 pour porter le character_id complet.
 		uint64_t helloNonce = 0;
 		uint64_t persistenceCharacterKey = 0;
@@ -299,6 +304,13 @@ namespace engine::server
 		/// par le master via kOpcodeMasterToShardAdmitCharacter). Entrées expirées (TTL)
 		/// supprimées silencieusement.
 		void DrainPendingHellos();
+
+		/// TA.3 — Évince les clients dont la dernière activité UDP date de plus de
+		/// kUdpClientIdleTimeoutMs. Le UDP est sans connexion : un client qui ferme son
+		/// process ne génère aucun FIN, donc sans timeout actif son `ConnectedClient` resterait
+		/// dans `m_clients` et sa position continuerait d'être broadcastée aux autres
+		/// (avatars / nameplates fantômes). Appelé périodiquement dans TickOnce.
+		void EvictIdleUdpClients();
 
 		/// Record the last input sequence for a connected client.
 		void HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians);
@@ -860,6 +872,13 @@ namespace engine::server
 		/// TTL ms d'un Hello en attente. Au-delà, on abandonne (l'admission n'est pas arrivée).
 		/// 5 s suffisent largement vs la latence master→shard (typiquement < 100 ms).
 		static constexpr uint64_t kPendingHelloTtlMs = 5000u;
+
+		/// TA.3 — délai d'inactivité au-delà duquel un client UDP est considéré déconnecté.
+		/// Choisi a 30 s : largement plus que la cadence Input (50 ms a 20 Hz) tout en restant
+		/// court pour eviter des nameplates fantomes longtemps apres une deco brutale.
+		static constexpr uint64_t kUdpClientIdleTimeoutMs = 30000u;
+		/// Dernier tick ou EvictIdleUdpClients a tourne (throttling 1 Hz au lieu de 20 Hz).
+		uint32_t m_lastEvictIdleClientsTick = 0;
 
 		/// TA.3c : anti-triche mouvement (speed/teleport) sur les positions reçues en
 		/// Input. Détecteur header-only seedé à la config V1 par défaut (7.5 m/s * 1.5,


### PR DESCRIPTION
> ⚠️ **Remplace PR #706** (historique pollué après le squash-merge de #705 → 0 check_runs déclenchés). Cette PR a un seul commit propre directement sur `main`.

## Contexte

Après merge de PR #704 (libmysqlclient) + #705 (race admit Hello/Push), tests 2 joueurs confirment :
- ✅ Système accepte 2 clients UDP, snapshots circulent (`tx_packets > 0`).
- ❌ **Bug A** : seul le nameplate « P\<id\> » s'affiche, pas l'avatar 3D.
- ❌ **Bug B** : nameplates fantômes restent après déconnexion.
- ❌ **Bug C** : shard ne purge pas les clients UDP zombies (`total_clients=3` alors qu'il n'y a eu que 2 sessions).
- ❌ **Bug D** : `CellGrid` rejette `posX<0` ou `posZ<0`, donc dès qu'un joueur bouge, sa position dans la grille AoI est figée (`Interest update skipped`).

Capture d'écran confirmée : avatar local visible, mais 3 nameplates P1/P2/P3 flottants sans skin 3D.

Cette PR corrige les 4 dans un seul lot.

## Bug D — `CellGrid` origin centré

Convention divergente : client → centre (0,0), serveur → coin (0,0). Fix : `TryWorldToCellCoord` translate par `+halfZone` (5000 m) avant test de bornes. Plage acceptée maintenant `[-5000, +5000)`. Tests `GridVisitorTests` + `GridNotifierTests` adaptés à la nouvelle convention.

## Bug C — Eviction UDP idle

- `ConnectedClient` gagne `lastUdpActivityAtMs`, rafraîchi à chaque `HandleHello` et chaque `HandleInput`.
- Nouvelle méthode `EvictIdleUdpClients` : balaye `m_clients`, évince ceux idle ≥ 30 s.
- Appelée à 1 Hz dans `TickOnce`.
- `DisconnectConnectedClient` existant retire l'entité de la grille AoI ; `RefreshReplicationForClient` du tick suivant envoie un `Despawn` aux autres clients.

## Bug B — Auto-résolu par C

`UIModelBinding::ApplySnapshot` fait `clear()` + refill de `remoteEntities` à chaque snapshot, et `Engine::UpdateGameplayNet` purge `m_remoteSmoothed` pour les entités absentes. Donc dès que le serveur arrête de broadcaster le zombie (fix Bug C), le client le retire. **Aucun code client supplémentaire requis.**

## Bug A — Diagnostic ajouté

`RecordRemoteAvatars` utilise `m_geometryMeshHandle` (mesh placeholder `avatar_placeholder.mesh`) + `GeometryPass.Record`, **même pattern** que `RecordPropsGeometry` qui marche (le coffre est visible). Probable early-return silencieux (`mesh->vertexBuffer == VK_NULL_HANDLE` ou `geom.HasLoadPass() == false`).

Logs WARN/INFO une-fois ajoutés dans `RecordRemoteAvatars` pour identifier la condition exacte au runtime. Fix définitif quand la cause sera confirmée par les logs prod.

## Pas dans cette PR

- Pas de wire-change, pas de bump `kProtocolVersion`.
- Pas de migration DB.
- Pas de modif master.

## Test plan

- [ ] CI verte
- [ ] Runtime 2 clients :
  - Bug D : plus de `[CellGrid] UpsertEntity FAILED` quand un joueur marche.
  - Bug C : 30 s après une déco, `[ServerApp] Evict idle UDP client` dans les logs shard.
  - Bug B : la nameplate de l'autre joueur disparaît dans la foulée.
  - Bug A : logs client `[RecordRemoteAvatars] SKIP : ...` ou `OK : rendu démarre` — diagnostic pour le fix définitif.

## Déploiement

⚠️ **Redéploiement shard + nouveau binaire client** requis. Master non touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDhyiFv4RvnBVe5DUSqiWt)_