### PR TITLE
fix(client): bug A — avatar distant 3D invisible (matériau + filtre mobs)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9566,20 +9566,33 @@ namespace engine
 			}
 			return;
 		}
+		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
+		// Le placeholder mesh (avatar_placeholder.mesh) a ses propres UVs simples, qui ne
+		// sont pas alignées sur l'atlas T_Ranger du matériau habit (m_avatarMaterialId).
+		// Sampler avec ce matériau renvoie des zones arbitraires de la texture (souvent
+		// transparentes ou indistinguables du ciel) — l'avatar distant est dessiné mais
+		// invisible à l'écran (bug A historique). Tant qu'on n'a pas de matériau dédié
+		// placeholder, on utilise le matériau par défaut (texture fallback unie) : visible,
+		// sans dépendance à un atlas spécifique.
+		const uint32_t materialIndex = materialCache.GetDefaultMaterialIndex();
 		static bool diagLoggedSuccess = false;
 		if (!diagLoggedSuccess)
 		{
 			LOG_INFO(Render,
-				"[RecordRemoteAvatars] OK : rendu des avatars distants demarre (remotes={}, mesh.vcount={}, mesh.icount={}, material_id={})",
+				"[RecordRemoteAvatars] OK : rendu des avatars distants demarre (remotes={}, mesh.vcount={}, mesh.icount={}, material_id={} (default placeholder))",
 				remotes.size(), mesh->vertexCount, mesh->indexCount,
-				(m_avatarMaterialId != 0u) ? m_avatarMaterialId : 0u);
+				materialIndex);
 			diagLoggedSuccess = true;
 		}
-		auto& materialCache = m_pipeline->GetMaterialDescriptorCache();
-		const uint32_t materialIndex = (m_avatarMaterialId != 0u)
-			? m_avatarMaterialId : materialCache.GetDefaultMaterialIndex();
 		for (const engine::client::UIRemoteEntity& re : remotes)
 		{
+			// remoteEntities contient TOUTES les entités distantes (joueurs + mobs + lootbags).
+			// Les mobs ont leur propre pipeline de rendu (mesh dédié), donc ici on ne dessine
+			// le placeholder que pour les joueurs distants (playerClientId != 0). Sans ce filtre
+			// on superposerait un humanoïde placeholder par-dessus chaque mob — bug visuel.
+			// Même critère que la plaque de nom (cf. boucle TD.4 dans le HUD in-game).
+			if (re.playerClientId == 0u)
+				continue;
 			// TD.3 : position lissée (interpolation, cf. UpdateGameplayNet) ; repli sur la
 			// position snapshot brute si pas encore d'état lissé (graceful).
 			float px = re.positionX, py = re.positionY, pz = re.positionZ, yaw = re.yawRadians;


### PR DESCRIPTION
## Contexte

Suite à la diag PR #707 (logs `[RecordRemoteAvatars] OK/SKIP …`), les logs client en condition réelle (2 joueurs connectés) ont confirmé :

```
[Render] [RecordRemoteAvatars] OK : rendu des avatars distants demarre
         (remotes=5, mesh.vcount=144, mesh.icount=216, material_id=1)
```

→ Le `geom.Record` est bien appelé (pas un early-return silencieux). Bug A ailleurs.

## Cause 1 — Matériau habit utilisé sur mesh placeholder

`RecordRemoteAvatars` utilisait `m_avatarMaterialId` (id=1, matériau habit Ranger avec textures `T_Ranger` 4096²). Ce matériau est conçu pour le mesh skinné `Male_Ranger.glb` qui a un UV atlas spécifique aligné sur cette texture.

Le placeholder `avatar_placeholder.mesh` a ses propres UVs simples (humanoïde basique 144 verts, T-pose), qui samplent des zones arbitraires de `T_Ranger_BaseColor.png` — typiquement le fond de l'atlas, qui est soit transparent soit indistinguable de la couleur du ciel.

**Résultat** : draw call émis correctement (vu dans les logs), mais visuellement invisible à l'écran (plaque de nom seule visible).

**Fix 1** : utiliser `materialCache.GetDefaultMaterialIndex()` (texture fallback unie, slot 0). Visible sans dépendance à un atlas. Solution long terme (matériau dédié placeholder avec sa propre texture) = ticket art séparé.

## Cause 2 — Mobs dessinés comme placeholders humanoïdes

La boucle itérait sur `remoteEntities` sans filtre. Or `remoteEntities` contient **toutes** les entités distantes : joueurs **+ mobs + lootbags**. Logs prod : `remotes=5` (4 mobs spawner/event + 1 joueur).

Sans le matériau cassé qui masquait tout, on superposerait 4 humanoïdes placeholder par-dessus chaque mob. Bug visuel.

**Fix 2** : ajouter `if (re.playerClientId == 0u) continue;` en tête de boucle. Même critère que la plaque de nom (cf. ligne 8426, condition identique).

## Pas dans cette PR

- Pas de changement protocole, pas de bump `kProtocolVersion`.
- Pas de modif serveur.
- Pas de migration DB.
- Matériau dédié placeholder (art) → ticket séparé.
- Bug nameplate « P{n} » → nom personnage (wire-breaking) → PR séparée.
- Anti-cheat false positive → PR séparée.
- Persistence read-only FS → PR séparée (Docker).

## Test plan

- [ ] CI verte (build Linux + Windows)
- [ ] Runtime 2 clients : l'avatar 3D du joueur distant doit être visible (placeholder gris/blanc selon fallback) à côté de sa plaque de nom `P{n}`.
- [ ] Mobs : aucun humanoïde placeholder par-dessus eux (uniquement leur mesh dédié).
- [ ] Log client `[RecordRemoteAvatars] OK ... material_id=0 (default placeholder)` à la première snapshot avec un autre joueur.

## Déploiement

> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_