### PR TITLE
fix(shard): anti-cheat false positive — timing inputSequence au lieu de steady_clock

### DIFF
--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1229,17 +1229,27 @@ namespace engine::server
 		// TA.3c — anti-triche : rejette une position implausible (speed/teleport hack)
 		// AVANT de l'appliquer ; on conserve alors la dernière position valide. TC.1 : l'Input
 		// porte désormais Y → on l'utilise pour la distance 3D.
+		//
+		// On utilise inputSequence (et non steady_clock serveur) comme source de temps. Raison :
+		// quand plusieurs paquets UDP arrivent dans la même tick serveur (burst de réception
+		// — courant en UDP même en flux nominal, notamment sous mode TG.3 thread receive split),
+		// ils sont processés en séquence avec des steady_clock_now() quasi identiques.
+		// dt(steady_clock) ≈ 0 ms → vitesse calculée énorme → faux positif SpeedHack alors que
+		// le client a bien envoyé ses inputs à cadence normale. inputSequence est en revanche
+		// stable : 1 unité = 1 tick client = 1000/m_tickHz ms (m_tickHz partagé avec le client
+		// via le Welcome packet ; client et serveur tiquent au même rythme).
 		{
-			const uint64_t antiCheatNowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
-				std::chrono::steady_clock::now().time_since_epoch()).count());
+			const uint16_t tickHzSafe = (m_tickHz != 0u) ? m_tickHz : static_cast<uint16_t>(20);  // fallback defensif si Init n'a pas tourne
+			const uint64_t clientTickPeriodMs = 1000u / static_cast<uint64_t>(tickHzSafe);
+			const uint64_t antiCheatNowMs = static_cast<uint64_t>(inputSequence) * clientTickPeriodMs;
 			const anticheat::CheatVerdict verdict = m_antiCheat.CheckMovement(
 				client->persistenceCharacterKey, positionMetersX, positionMetersY, positionMetersZ, antiCheatNowMs);
 			if (verdict != anticheat::CheatVerdict::OK)
 			{
 				++m_antiCheatViolations;
 				LOG_WARN(AntiCheat,
-					"[ServerApp] Input rejete par anti-triche (verdict={}, client_id={}, character_key={}, pos=({:.2f},{:.2f}))",
-					static_cast<int>(verdict), client->clientId, client->persistenceCharacterKey, positionMetersX, positionMetersZ);
+					"[ServerApp] Input rejete par anti-triche (verdict={}, client_id={}, character_key={}, pos=({:.2f},{:.2f}), seq={})",
+					static_cast<int>(verdict), client->clientId, client->persistenceCharacterKey, positionMetersX, positionMetersZ, inputSequence);
 				return;
 			}
 		}
@@ -4426,6 +4436,12 @@ namespace engine::server
 				(void)zoneIt->second.RemoveEntity(clientIt->entityId);
 			}
 		}
+
+		// TA.3c — reset de l'état anti-cheat pour ce character_key. Sans ça, si le même
+		// personnage se reconnecte plus tard, son inputSequence redémarre à 1 alors que le
+		// state AntiCheat conserve l'ancien tsMs (très supérieur) → dt négatif clampé à 1 ms
+		// → faux positif SpeedHack sur le premier input post-reconnexion.
+		m_antiCheat.Reset(clientIt->persistenceCharacterKey);
 
 		OnClientLogout(*clientIt);
 		LOG_INFO(Net, "[ServerApp] Client disconnected (client_id={}, reason={})", clientId, persistenceReason);


### PR DESCRIPTION
## Symptôme

Logs serveur du test 2 joueurs (cf. logs prod précédents) :

```
[ServerApp] Input rejete par anti-triche (verdict=1, client_id=1, character_key=1, pos=(2.75,5.78))
[ServerApp] Input rejete par anti-triche (verdict=1, client_id=1, character_key=1, pos=(3.07,6.45))
... ~10 violations/sec
```

Joueur qui marche normalement (~0.3 m / 50 ms = 6 m/s, sous la limite 7.5 × 1.5 = 11.25 m/s). Pourtant verdict=1 (SpeedHack) tiré.

## Cause

`AntiCheatGameplay::CheckMovement` utilisait `std::chrono::steady_clock::now()` côté serveur comme source de temps pour calculer `dt` entre deux positions reportées.

Quand **plusieurs paquets UDP du même client arrivent dans la même tick serveur** (burst de réception réseau — courant en UDP même en flux nominal, accentué par le mode opt-in TG.3 « thread receive split »), ils sont traités en séquence avec des `steady_clock_now()` quasi identiques :

```
dt(steady_clock) ≈ 0 ms  →  speed = dist / dt  →  énorme  →  faux SpeedHack
```

alors que le client a bien envoyé ses inputs à cadence normale (50 ms à 20 Hz).

## Correctif (server-only)

Utiliser **`inputSequence`** comme source de temps. C'est le compteur incrémenté d'1 par tick client, déjà transmis dans chaque packet Input. Avec un tick à `1000/m_tickHz` ms (rythme partagé client/serveur via le Welcome packet), on dérive :

```cpp
antiCheatNowMs = inputSequence * (1000 / m_tickHz)
```

Cette valeur représente le **temps écoulé côté client**, robuste au burst de réception côté serveur.

### Reset sur déconnexion

Ajout aussi : `m_antiCheat.Reset(persistenceCharacterKey)` dans `DisconnectConnectedClient`. Sans ce reset, un personnage qui se reconnecte plus tard verrait son `inputSequence` redémarrer à 1 alors que l'AntiCheat conserve l'ancien `tsMs` (élevé) → `dt` négatif clampé à 1 ms → faux positif sur le premier input post-reconnexion.

## Pas dans cette PR

- Pas de wire-change, pas de bump `kProtocolVersion`.
- Pas de modif client (les binaires client déjà en place fonctionneront sans changement).
- Pas de modif master.
- Pas de migration DB.

## Test plan

- [ ] CI verte (build Linux + Windows + tests `AntiCheatGameplayTests`)
- [ ] Runtime test : joueur qui marche normalement à ~6 m/s → **aucune** violation `verdict=1`.
- [ ] Runtime test : un vrai speed-hack (téléporter le client manuellement à >11 m/s effectif) → toujours détecté.
- [ ] Runtime test : déco + reco d'un même personnage → pas de faux positif sur le premier input post-reco.

Les tests unitaires `AntiCheatGameplayTests` ne sont **pas** modifiés : ils passent un `nowMs` littéral (1000, 2000, …) ; la sémantique « valeur monotone en ms » reste valide, qu'elle vienne de `steady_clock` ou de `inputSequence × period`. Le delta est ce qui compte pour l'algo et reste cohérent.

## Déploiement

> **Déploiement** : ⚠️ redéploiement shard requis. Master non touché, client non concerné.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_