### PR TITLE
fix(deploy): persistence read-only FS — sous-mount rw pour autosave perso

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -128,6 +128,13 @@ services:
     volumes:
       - ./config/shard.config.json:/app/config.json:ro
       - ./game/data:/app/game/data:ro
+      # TA.4 — autosave perso : CharacterPersistenceStore écrit
+      # game/data/persistence/characters/character_<id>.ini à chaque autosave (30 s).
+      # Sans ce sous-mount, l'écriture échoue (Read-only file system) car le parent
+      # game/data est monté ro pour protéger les assets immuables. Docker permet
+      # de superposer un sous-chemin en rw sur un parent ro — c'est ce qu'on fait ici.
+      # Le dossier hôte ./data/persistence est créé automatiquement au premier `up`.
+      - ./data/persistence:/app/game/data/persistence:rw
       - ./data/logs/shard:/app/logs
     environment:
       SHARD_REGISTER_ENDPOINT: ${SHARD_REGISTER_ENDPOINT:-127.0.0.1:3843}


### PR DESCRIPTION
## Symptôme

Logs prod shard (toutes les 30 s tant qu'un joueur est en jeu) :

```
[FileSystem] WriteAllText FAILED: create_directories(game/data/persistence/characters, Read-only file system)
[CharacterPersistence] Save FAILED (character_key=1, path=persistence/characters/character_1.ini)
[ServerApp] Character save FAILED (client_id=1, character_key=1, reason=autosave)
```

## Cause

`docker-compose.yml` monte `./game/data` en **read-only** dans le container shard :

```yaml
- ./game/data:/app/game/data:ro
```

C'est volontaire — protège les assets immuables (meshes, textures, splatmaps, configs…). Mais le shard écrit aussi sous `game/data/persistence/characters/` (`CharacterPersistenceStore` construit le chemin `persistence/characters/character_<id>.ini` concaténé au content base `game/data`). L'écriture échoue.

## Correctif (deploy-only)

Ajouter un **sous-mount rw** qui superpose uniquement le chemin `persistence/`, en laissant le reste de `game/data` en `ro` :

```yaml
- ./game/data:/app/game/data:ro
- ./data/persistence:/app/game/data/persistence:rw   # ← nouveau
```

Docker permet cette superposition : le sous-mount prend précédence sur le parent pour ce chemin précis. L'écriture devient possible **sans casser la protection `ro`** sur les autres assets.

Le dossier hôte `./data/persistence/` est créé automatiquement au premier `docker compose up` (même convention que `./data/mysql`, `./data/logs/shard`, etc.).

## Pas dans cette PR

- Pas de changement code C++.
- Pas de wire-change.
- Pas de modif master / client.
- Pas de migration DB.

## Test plan

- [ ] CI verte (build du bundle Docker dans la pipeline)
- [ ] `docker compose up -d --force-recreate shard` sur l'hôte de prod
- [ ] Vérifier dans les logs shard : plus d'erreur `WriteAllText FAILED ... Read-only file system`
- [ ] Vérifier que `./data/persistence/characters/character_<id>.ini` apparaît sur l'hôte après une partie + déconnexion
- [ ] Restart shard → le `character_<id>.ini` est rechargé via `LoadCharacter` (plus de log `Load skipped: character file missing`)

## Déploiement

> **Déploiement** : ⚠️ redéploiement shard requis (`docker compose up -d --force-recreate shard`). Master non touché, client non concerné.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_