### PR TITLE
feat(replication): TD.5 — nom de personnage dans le SnapshotEntity (wire bump v5→v6)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8434,7 +8434,13 @@ namespace engine
 						float sxp = 0.0f, syp = 0.0f;
 						if (!WorldToScreenPx(out.viewProjMatrix.m, wx, wy + 1.2f, wz, ivw, ivh, sxp, syp))
 							continue;
-						const std::string label = "P" + std::to_string(re.playerClientId);
+						// TD.5 : on affiche le vrai nom du perso s'il est connu (chargé depuis
+						// la DB serveur et propagé via le SnapshotEntity). Sinon, fallback sur
+						// "P<clientId>" — utile quand la DB serveur ne sert pas (Windows / DB
+						// indisponible) ou pour identifier l'entité dans un log.
+						const std::string label = !re.displayName.empty()
+							? re.displayName
+							: ("P" + std::to_string(re.playerClientId));
 						const ImVec2 ts = ImGui::CalcTextSize(label.c_str());
 						// Halo noir derriere le texte pour la lisibilite sur fond clair (ciel).
 						fg->AddRectFilled(

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -725,6 +725,8 @@ namespace engine::client
 			remote.stateFlags = entity.state.stateFlags;
 			// TD.4 : propage le clientId reçu (0 = mob/lootbag, ≠ 0 = joueur distant).
 			remote.playerClientId = entity.playerClientId;
+			// TD.5 : nom du perso pour la plaque de nom (vide → fallback "P<clientId>").
+			remote.displayName = entity.characterName;
 			m_model.remoteEntities.push_back(remote);
 		}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -304,6 +304,10 @@ namespace engine::client
 		uint32_t stateFlags = 0;
 		/// TD.4 : id client (≠ entityId) reçu du serveur, sert à l'overlay nameplate.
 		uint32_t playerClientId = 0;
+		/// TD.5 : nom du personnage choisi par le joueur, propagé via le SnapshotEntity.
+		/// Vide pour les mobs / lootbags, ou pour les joueurs si la DB serveur n'a pas
+		/// pu servir le nom — le HUD retombe alors sur "P<playerClientId>".
+		std::string displayName;
 	};
 
 	/// Pure data model consumed by UI views and debug panels.

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace engine::server
 {
@@ -65,11 +66,15 @@ namespace engine::server
 	/// Snapshot payload for one already-spawned entity state update.
 	/// TD.4 — `playerClientId` ≠ 0 quand l'entité représente un **joueur connecté** ;
 	/// vaut 0 pour les mobs / loot bags. Sert au client à afficher une plaque de nom
-	/// "P<playerClientId>" au-dessus des avatars distants (cf. `Engine::Update.*Hud`).
+	/// au-dessus des avatars distants (cf. `Engine::Update.*Hud`).
+	/// TD.5 — `characterName` porte le nom de personnage choisi par le joueur ; non vide
+	/// uniquement pour les joueurs (mobs/lootbags ont la chaîne vide). Wire-bump v5→v6 :
+	/// chaque entité du Snapshot est suivie d'une chaîne préfixée u16 (taille variable).
 	struct SnapshotEntity
 	{
 		EntityId entityId = 0;
 		EntityState state{};
 		uint32_t playerClientId = 0;
+		std::string characterName;
 	};
 }

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -292,10 +292,12 @@ namespace engine::server
 		outMessage.chunkCount = ReadU16(payload, 22);
 
 		const size_t entityCount = static_cast<size_t>(outMessage.entityCount);
-		// TD.4 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId) = 52 octets.
-		// TG.1 — header passe a 24 octets.
-		const size_t expectedPayloadSize = 24 + (entityCount * 52);
-		if (payload.size() != expectedPayloadSize)
+		// TD.5 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name) octets. On vérifie un minimum (54 par entité, nom vide), puis
+		// on parse sequentiellement et on rejette si on dépasse la fin du payload en cours de route.
+		// TG.1 — header a 24 octets.
+		const size_t minimumPayloadSize = 24 + (entityCount * 54);
+		if (payload.size() < minimumPayloadSize)
 		{
 			return false;
 		}
@@ -316,6 +318,14 @@ namespace engine::server
 			// TD.4 : id client decode apres EntityState. ReadEntityState a deja avance offset de 40.
 			entity.playerClientId = ReadU32(payload, offset);
 			offset += 4;
+			// TD.5 : nom du personnage (chaîne préfixée u16). Borne dure : 64 octets (cf.
+			// kMaxChatLocalSenderNameBytes), au-delà on rejette le paquet pour défense en profondeur.
+			if (!ReadSizedString(payload, offset, entity.characterName)
+				|| entity.characterName.size() > 64u)
+			{
+				outEntities.clear();
+				return false;
+			}
 		}
 
 		return true;
@@ -400,9 +410,13 @@ namespace engine::server
 
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities)
 	{
-		// TD.4 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId) = 52 octets.
+		// TD.4 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId) + 2 (nameLen)
+		// + N (name bytes, variable) octets. TD.5 wire-bump v5→v6 : ajout du nom de personnage.
+		// Pour le sizing : on prend une estimation a 8 + 40 + 4 + 2 = 54 par entite (sans le nom)
+		// + buffer reserve via push_back si nom non vide. BeginPacket.reserve est juste un hint,
+		// pas une borne stricte (le vector grandit a l'append).
 		// TG.1 — header passe de 20 → 24 octets (ajout chunkIndex + chunkCount uint16 × 2).
-		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 52));
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 54));
 		WriteU32(packet, message.clientId);
 		WriteU32(packet, message.serverTick);
 		WriteU16(packet, message.connectedClients);
@@ -417,8 +431,10 @@ namespace engine::server
 		{
 			WriteU64(packet, entity.entityId);
 			WriteEntityState(packet, entity.state);
-			// TD.4 : id client (≠ entityId) pour qu'un client distant puisse afficher "P<clientId>".
+			// TD.4 : id client (≠ entityId) pour qu'un client distant puisse afficher la plaque.
 			WriteU32(packet, entity.playerClientId);
+			// TD.5 : nom du personnage (préfixé u16). Vide pour les mobs / lootbags.
+			WriteSizedString(packet, entity.characterName);
 		}
 		return packet;
 	}

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -23,7 +23,7 @@ namespace engine::server
 	/// `chunkCount = 1` (mono-paquet) reste le cas dominant ; `chunkCount > 1` exige une
 	/// réassemblage côté client (cf. UIModelBinding::ApplySnapshot).
 	/// Wire-breaking : client + shard doivent se déployer ensemble.
-	inline constexpr uint16_t kProtocolVersion = 5;
+	inline constexpr uint16_t kProtocolVersion = 6;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -100,7 +100,8 @@ namespace
 		inMsg.sentPackets = 77u;
 
 		std::vector<SnapshotEntity> in;
-		// 2 joueurs avec playerClientId ≠ 0, 1 mob avec playerClientId = 0.
+		// 2 joueurs avec playerClientId ≠ 0 et un characterName non vide,
+		// 1 mob avec playerClientId = 0 et characterName vide.
 		SnapshotEntity ePlayerA{};
 		ePlayerA.entityId = 0x200000001ull;
 		ePlayerA.state.positionX = 10.5f;
@@ -108,6 +109,7 @@ namespace
 		ePlayerA.state.positionZ = -3.75f;
 		ePlayerA.state.yawRadians = 0.42f;
 		ePlayerA.playerClientId = 7u;
+		ePlayerA.characterName = "homme"; // TD.5
 		in.push_back(ePlayerA);
 
 		SnapshotEntity ePlayerB{};
@@ -115,6 +117,7 @@ namespace
 		ePlayerB.state.positionX = 100.0f;
 		ePlayerB.state.positionZ = 50.0f;
 		ePlayerB.playerClientId = 12u;
+		ePlayerB.characterName = "femme"; // TD.5
 		in.push_back(ePlayerB);
 
 		SnapshotEntity eMob{};
@@ -122,6 +125,7 @@ namespace
 		eMob.state.currentHealth = 80u;
 		eMob.state.maxHealth = 100u;
 		eMob.playerClientId = 0u; // mob => pas de nameplate
+		// characterName reste vide pour les mobs / lootbags (TD.5).
 		in.push_back(eMob);
 
 		const std::vector<std::byte> packet = EncodeSnapshot(inMsg, in);
@@ -141,22 +145,28 @@ namespace
 		assert(out[0].state.positionZ == ePlayerA.state.positionZ);
 		assert(out[0].state.yawRadians == ePlayerA.state.yawRadians);
 		assert(out[0].playerClientId == 7u);
+		assert(out[0].characterName == "homme"); // TD.5
 
 		assert(out[1].entityId == ePlayerB.entityId);
 		assert(out[1].state.positionX == ePlayerB.state.positionX);
 		assert(out[1].playerClientId == 12u);
+		assert(out[1].characterName == "femme"); // TD.5
 
 		assert(out[2].entityId == eMob.entityId);
 		assert(out[2].state.currentHealth == 80u);
 		assert(out[2].state.maxHealth == 100u);
 		assert(out[2].playerClientId == 0u);
+		assert(out[2].characterName.empty()); // TD.5 : mob => pas de nom
 		std::puts("[OK] TestSnapshotRoundTripWithPlayerClientId");
 	}
 
-	/// TD.4 — un Snapshot dont la taille de payload ne suit pas la nouvelle convention
-	/// 52 octets/entité doit être rejeté (defense contre un client/serveur de version
-	/// antérieure parlant v3 = 48 octets/entité).
-	void TestSnapshotRejectsLegacyV3PayloadSize()
+	/// TD.5 — un Snapshot dont la taille de payload est inferieure au minimum attendu
+	/// (54 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0,
+	/// au-delà de l'entête 24 octets) doit être rejeté. Defense en profondeur contre un
+	/// pair (client ou serveur) qui parlerait une version antérieure du wire (v3 = 48,
+	/// v4 = 52, v5 = 52 sans nom). Le bump kProtocolVersion à v6 filtre déjà la plupart
+	/// des cas dans DecodeHeader, ce test couvre une corruption après header valide.
+	void TestSnapshotRejectsTruncatedPayload()
 	{
 		SnapshotMessage inMsg{};
 		inMsg.entityCount = 1u;
@@ -164,17 +174,19 @@ namespace
 		SnapshotEntity e{};
 		e.entityId = 0x200000001ull;
 		e.playerClientId = 5u;
+		// characterName vide → 2 octets de nameLen seulement.
 		in.push_back(e);
 
 		std::vector<std::byte> packet = EncodeSnapshot(inMsg, in);
-		// Ampute exactement 4 octets : simule l'absence du playerClientId (taille v3).
+		// Ampute 4 octets : simule un pair qui n'aurait pas écrit nameLen+name (4 < 2 mais on
+		// retire 4 pour passer aussi sous le playerClientId terminé, soit un pair pré-v6).
 		assert(packet.size() >= 4u);
 		packet.resize(packet.size() - 4u);
 
 		SnapshotMessage outMsg{};
 		std::vector<SnapshotEntity> out;
 		assert(!DecodeSnapshot(packet, outMsg, out));
-		std::puts("[OK] TestSnapshotRejectsLegacyV3PayloadSize");
+		std::puts("[OK] TestSnapshotRejectsTruncatedPayload");
 	}
 
 	/// TG.1 — round-trip Snapshot avec chunkIndex / chunkCount > 1 : le wire transporte
@@ -242,7 +254,7 @@ int main()
 	TestInputRejectsTruncated();
 	TestHelloRoundTrip();
 	TestSnapshotRoundTripWithPlayerClientId();
-	TestSnapshotRejectsLegacyV3PayloadSize();
+	TestSnapshotRejectsTruncatedPayload();
 	TestSnapshotRoundTripWithChunking();
 	TestSnapshotMonoChunkDefaultsRoundTrip();
 	std::puts("All ServerProtocol tests passed");

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -972,7 +972,7 @@ namespace engine::server
 		LOG_WARN(Net, "[ServerApp] Dropped invalid packet from {}", UdpTransport::EndpointToString(datagram.endpoint));
 	}
 
-	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg)
+	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg, std::string& outName)
 	{
 #if defined(SHARD_POSITION_DB)
 		if (m_characterDbPool == nullptr || characterId == 0u)
@@ -986,8 +986,9 @@ namespace engine::server
 			return false;
 		}
 		char sql[256];
+		// TD.5 — on fetch aussi `name` pour le SnapshotEntity (plaque de nom).
 		std::snprintf(sql, sizeof(sql),
-			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg FROM characters "
+			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name FROM characters "
 			"WHERE id = %llu AND deleted_at IS NULL",
 			static_cast<unsigned long long>(characterId));
 		MYSQL_RES* res = db::DbQuery(mysql, sql);
@@ -1002,12 +1003,13 @@ namespace engine::server
 			y = row[1] ? std::strtof(row[1], nullptr) : 0.0f;
 			z = row[2] ? std::strtof(row[2], nullptr) : 0.0f;
 			yawDeg = row[3] ? std::strtof(row[3], nullptr) : 0.0f;
+			outName = row[4] ? std::string(row[4]) : std::string{};
 			found = true;
 		}
 		db::DbFreeResult(res);
 		return found;
 #else
-		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg;
+		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName;
 		return false;
 #endif
 	}
@@ -1164,15 +1166,18 @@ namespace engine::server
 		// conserve la position fichier. Avant UpdateClientInterest (qui place l'AoI).
 		{
 			float dbX = 0.0f, dbY = 0.0f, dbZ = 0.0f, dbYawDeg = 0.0f;
-			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg))
+			std::string dbName;
+			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName))
 			{
 				acceptedClient.positionMetersX = dbX;
 				acceptedClient.positionMetersY = dbY;
 				acceptedClient.positionMetersZ = dbZ;
 				acceptedClient.yawRadians = dbYawDeg * 0.01745329252f; // deg -> rad
+				// TD.5 — nom du personnage destiné aux plaques de nom des avatars distants.
+				acceptedClient.characterName = std::move(dbName);
 				LOG_INFO(Net,
-					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, pos=({:.2f}, {:.2f}, {:.2f}))",
-					acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ);
+					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
+					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, dbX, dbY, dbZ);
 			}
 		}
 
@@ -3799,8 +3804,12 @@ namespace engine::server
 			outEntity.entityId = client->entityId;
 			outEntity.state = BuildEntityState(*client);
 			// TD.4 : expose le clientId au snapshot pour que les autres clients puissent
-			// afficher une plaque de nom "P<clientId>" au-dessus de cet avatar joueur.
+			// afficher une plaque de nom au-dessus de cet avatar joueur.
 			outEntity.playerClientId = client->clientId;
+			// TD.5 : nom du perso (chargé depuis la DB au moment de l'admission) → plaque
+			// avec le vrai nom au lieu du fallback "P<clientId>". Vide si la DB n'a pas pu
+			// servir (Windows / DB indisponible), le client retombe sur "P<clientId>".
+			outEntity.characterName = client->characterName;
 			return true;
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -96,6 +96,11 @@ namespace engine::server
 		/// Phase 3.7.5 — élargi à uint64 pour porter le character_id complet.
 		uint64_t helloNonce = 0;
 		uint64_t persistenceCharacterKey = 0;
+		/// TD.5 — nom du personnage choisi par le joueur (cf. table SQL characters.name).
+		/// Chargé depuis la DB au moment de l'admission (LoadCharacterIdentityFromDb) puis
+		/// recopié dans chaque SnapshotEntity pour ce client → les avatars distants peuvent
+		/// afficher le vrai nom dans leur plaque (au lieu du fallback "P<clientId>").
+		std::string characterName;
 		uint32_t experiencePoints = 0;
 		uint32_t gold = 0;
 		/// M35.1 — additional currencies (wallet); gold remains primary trade currency.
@@ -292,7 +297,11 @@ namespace engine::server
 		/// \a characterId via m_characterDbPool. Renvoie true + remplit x/y/z/yawDeg si trouvé.
 		/// Renvoie false si pas de pool, DB non configurée, ou personnage absent (le caller
 		/// garde alors la position fichier). Corps réel sous ENGINE_HAS_MYSQL (sinon no-op).
-		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg);
+		/// TA.4 — charge spawn (position + yaw) depuis `characters` ; TD.5 — récupère aussi
+		/// `name` pour le porter dans le SnapshotEntity (plaque de nom des avatars distants).
+		/// Renvoie false si pas de pool DB (Windows / DB non configurée) ou si character
+		/// introuvable ; dans ce cas les out-params ne sont pas modifiés.
+		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg, std::string& outName);
 
 		/// Accept a new client or refresh an existing handshake.
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).


### PR DESCRIPTION
## Symptôme

La plaque de nom au-dessus des avatars distants affiche `P<n>` (ex. `P10`), où `n` est le clientId interne du shard, au lieu du vrai nom du personnage (ex. `homme`, `femme`).

Cf. capture utilisateur (PR #708) : avatar visible avec nameplate « P10 ».

## Cause

Le `SnapshotEntity` (wire AoI) transporte `playerClientId` mais **pas le nom du personnage**. Le HUD client n'a aucun moyen de connaître les noms des autres joueurs — il ne dispose que d'un identifiant client opaque.

## Correctif (wire-breaking — kProtocolVersion v5→v6)

Ajout d'un champ `characterName` (chaîne préfixée `u16`, max 64 octets) à la fin de chaque `SnapshotEntity`. Bump `kProtocolVersion` v5 → v6.

### Plumbing serveur

- **Shard** : `LoadSpawnFromDb` fetch maintenant aussi `characters.name` (1 colonne ajoutée à la requête existante TA.4, **aucun round-trip supplémentaire**). Stocké dans `ConnectedClient.characterName`, recopié dans chaque `SnapshotEntity` via `TryBuildSnapshotEntity`.
- **Protocole** : `EncodeSnapshot` / `DecodeSnapshot` écrivent et parsent la chaîne après `playerClientId`. Décoder rejette si nom > 64 octets (défense en profondeur). Taille minimum 54 octets/entité (au lieu de 52 strict précédent), payload variable au-delà.

### Plumbing client

- **`UIRemoteEntity`** gagne `displayName`, peuplé depuis `SnapshotEntity` dans `UIModelBinding::ApplySnapshot`.
- **`Engine.cpp`** utilise `re.displayName` si non vide, sinon fallback `"P" + clientId` (utile en build Windows sans DB ou si la DB serveur ne sert pas le nom).

### Tests

`ServerProtocolTests.cpp` :
- Round-trip étendu avec `characterName` non vide (`"homme"` / `"femme"`) et mob avec nom vide.
- Test de troncation renommé `TestSnapshotRejectsTruncatedPayload` (logique inchangée, le minimum payload check rejette les pairs pré-v6).

## Pas dans cette PR

- **Pas de migration DB** : la colonne `characters.name` existe déjà (utilisée par `CharacterListHandler`, `CharacterCreateHandler`).
- **Pas de changement master** : le nom est lu directement par le shard depuis MySQL, sans avoir à étendre l'`AdmitCharacter` (opcode 199) qui reste à `(account_id, character_id)`.

### Fallback Windows / DB indisponible

`LoadSpawnFromDb` retourne `false` → `acceptedClient.characterName` reste vide → le client affiche `"P<n>"` comme avant. Aucune régression visuelle dans ce cas.

## Test plan

- [ ] CI verte (build Linux + Windows + `ServerProtocolTests`)
- [ ] Runtime 2 joueurs (`homme` + `femme`) : la plaque affiche le vrai nom au-dessus de l'autre joueur, pas `P<n>`.
- [ ] Toujours pas de plaque sur les mobs / lootbags (`playerClientId == 0` filter inchangé).
- [ ] Logs shard : `Spawn position chargee depuis la DB (character_key=N, name="homme", ...)` confirme la lecture du nom.
- [ ] Build Windows (sans `SHARD_POSITION_DB`) : le shard tourne sans crash, le client retombe sur `P<n>` (fallback testé).

## Déploiement

> **Déploiement** : ⚠️ redéploiement coordonné **shard + nouveau binaire client** en lock-step (wire-breaking v5→v6). Master non touché.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_