### PR TITLE
fix(deploy): restreindre overlay rw à persistence/characters/ (régression PR #710)

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -133,8 +133,13 @@ services:
       # Sans ce sous-mount, l'écriture échoue (Read-only file system) car le parent
       # game/data est monté ro pour protéger les assets immuables. Docker permet
       # de superposer un sous-chemin en rw sur un parent ro — c'est ce qu'on fait ici.
-      # Le dossier hôte ./data/persistence est créé automatiquement au premier `up`.
-      - ./data/persistence:/app/game/data/persistence:rw
+      # IMPORTANT : on monte SEULEMENT le sous-répertoire `characters/`, PAS tout
+      # `persistence/`. Sinon le sous-mount masque aussi `persistence/db/migrations/`
+      # qui contient le schéma SQL (0001_characters_inventory.sql) nécessaire à
+      # CharacterPersistenceStore.Init — sans schéma, Init échoue et ServerApp.Init
+      # plante → UDP désactivé → aucune réplication joueurs (régression PR #710).
+      # Le dossier hôte ./data/persistence/characters est créé automatiquement au premier `up`.
+      - ./data/persistence/characters:/app/game/data/persistence/characters:rw
       - ./data/logs/shard:/app/logs
     environment:
       SHARD_REGISTER_ENDPOINT: ${SHARD_REGISTER_ENDPOINT:-127.0.0.1:3843}

--- a/game/data/persistence/characters/.gitkeep
+++ b/game/data/persistence/characters/.gitkeep
@@ -1,0 +1,9 @@
+# TA.4 — répertoire de persistance des personnages (.ini écrits par
+# CharacterPersistenceStore.Save toutes les 30 s). Maintenu vide dans le
+# bundle pour servir uniquement de mountpoint au bind rw Docker :
+# `./data/persistence/characters:/app/game/data/persistence/characters:rw`
+# (cf. deploy/docker/docker-compose.yml service shard).
+#
+# Sans ce fichier-sentinelle, Git ignore le répertoire vide → il n'apparaît
+# pas dans le bundle → Docker ne peut pas créer le mountpoint sous le parent
+# /app/game/data monté en read-only, et le shard refuse de démarrer.


### PR DESCRIPTION
## 🚨 Régression critique de PR #710

Sans ce fix, **aucun joueur ne voit aucun autre joueur** (réplication UDP désactivée).

## Symptôme (logs prod shard après PR #710)

```
[CharacterPersistence] Init FAILED: schema file missing
  (persistence/db/migrations/0001_characters_inventory.sql)
[ServerApp] Init FAILED: character persistence startup failed
[ShardMain] ServerApp Init a echoue — replication UDP desactivee
```

Conséquence : la réplication UDP gameplay est complètement désactivée. Le shard accepte les connexions TCP (CharacterList, EnterWorld OK) mais ne lance pas son UDP server. Le client envoie `Hello` UDP → silence du serveur → pas de Welcome → reste en world sans recevoir de snapshots → ne voit personne.

C'est une **régression complète** des fonctionnalités multi-joueurs livrées dans #707, #708, #709, #711.

## Cause

PR #710 (commit `279bd7f`) montait :

```yaml
- ./data/persistence:/app/game/data/persistence:rw
```

Cet overlay masque **tout** le répertoire `persistence/` du conteneur, **y compris** `persistence/db/migrations/` qui contient le schéma SQL `0001_characters_inventory.sql` nécessaire à `CharacterPersistenceStore::Init`. Le dossier hôte `./data/persistence/` étant vide au démarrage, le schéma disparaît du point de vue du shard → `Init` échoue → `ServerApp::Init` plante → UDP désactivé.

C'est mon erreur dans la PR initiale : je n'avais pas anticipé que `persistence/` contenait aussi des assets read-only (le schéma SQL) en plus de `characters/`.

## Correctif

Restreindre le sous-mount au sous-répertoire effectivement écrit (`characters/`), pas au répertoire parent entier :

```yaml
- ./game/data:/app/game/data:ro
- ./data/persistence/characters:/app/game/data/persistence/characters:rw   # ← scope restreint
```

Ainsi :
- `persistence/db/migrations/0001_characters_inventory.sql` reste accessible via le bind ro parent.
- `persistence/characters/` est overlayé par le bind rw, l'autosave perso fonctionne.

## Pas dans cette PR

- Pas de changement code C++.
- Pas de wire-change.
- Pas de modif master / client.

## Test plan

- [ ] CI verte (build du bundle Docker)
- [ ] `docker compose up -d --force-recreate shard` sur l'hôte de prod
- [ ] Logs shard au démarrage : **plus** d'erreur `CharacterPersistence Init FAILED ... schema file missing` ; on doit voir `[CharacterPersistence] Init OK (schema_path=persistence/db/migrations/0001_characters_inventory.sql)`.
- [ ] Connexion 2 joueurs : ils se voient mutuellement (toutes les fonctionnalités de #707/#708/#709/#711 reviennent).
- [ ] Autosave 30s : `./data/persistence/characters/character_<id>.ini` apparaît sur l'hôte (la cible primaire de PR #710 reste atteinte).

## Déploiement

> **Déploiement** : ⚠️ **URGENT** — redéploiement shard requis (`docker compose up -d --force-recreate shard`). Master non touché, client non concerné. Sans ce fix, le multi-joueur reste cassé.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_