### PR TITLE
fix(shard): TD.5 — nom personnage propagé via AdmitCharacter (mode no-DB)

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -133,8 +133,13 @@ services:
       # Sans ce sous-mount, l'écriture échoue (Read-only file system) car le parent
       # game/data est monté ro pour protéger les assets immuables. Docker permet
       # de superposer un sous-chemin en rw sur un parent ro — c'est ce qu'on fait ici.
-      # Le dossier hôte ./data/persistence est créé automatiquement au premier `up`.
-      - ./data/persistence:/app/game/data/persistence:rw
+      # IMPORTANT : on monte SEULEMENT le sous-répertoire `characters/`, PAS tout
+      # `persistence/`. Sinon le sous-mount masque aussi `persistence/db/migrations/`
+      # qui contient le schéma SQL (0001_characters_inventory.sql) nécessaire à
+      # CharacterPersistenceStore.Init — sans schéma, Init échoue et ServerApp.Init
+      # plante → UDP désactivé → aucune réplication joueurs (régression PR #710).
+      # Le dossier hôte ./data/persistence/characters est créé automatiquement au premier `up`.
+      - ./data/persistence/characters:/app/game/data/persistence/characters:rw
       - ./data/logs/shard:/app/logs
     environment:
       SHARD_REGISTER_ENDPOINT: ${SHARD_REGISTER_ENDPOINT:-127.0.0.1:3843}

--- a/game/data/persistence/characters/.gitkeep
+++ b/game/data/persistence/characters/.gitkeep
@@ -1,0 +1,9 @@
+# TA.4 — répertoire de persistance des personnages (.ini écrits par
+# CharacterPersistenceStore.Save toutes les 30 s). Maintenu vide dans le
+# bundle pour servir uniquement de mountpoint au bind rw Docker :
+# `./data/persistence/characters:/app/game/data/persistence/characters:rw`
+# (cf. deploy/docker/docker-compose.yml service shard).
+#
+# Sans ce fichier-sentinelle, Git ignore le répertoire vide → il n'apparaît
+# pas dans le bundle → Docker ne peut pas créer le mountpoint sous le parent
+# /app/game/data monté en read-only, et le shard refuse de démarrer.

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -159,7 +159,11 @@ namespace engine::server
 			auto shardConnId = m_shardRegistry->GetShardConnection(dbServerId);
 			if (shardConnId)
 			{
-				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId);
+				// TD.5 — on embarque le nom du personnage dans le push d'admission pour
+				// permettre au shard (notamment en mode no-DB) de l'utiliser dans la
+				// SnapshotEntity (plaque de nom des avatars distants).
+				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId,
+					parsed->characterName);
 				if (!admitPkt.empty() && m_server->Send(*shardConnId, admitPkt))
 				{
 					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={})",

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -176,13 +176,14 @@ int main(int argc, char** argv)
 	// kOpcodeMasterToShardAdmitCharacter (suite à un EnterWorld réussi côté master). Sans
 	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le
 	// ticket TCP avait été émis avant le choix de perso (character_id=0 → non admis).
-	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id) {
+	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id,
+		std::string_view character_name) {
 		const std::uint64_t nowMs = static_cast<std::uint64_t>(
 			std::chrono::duration_cast<std::chrono::milliseconds>(
 				std::chrono::steady_clock::now().time_since_epoch()).count());
-		admittedRegistry.Admit(character_id, account_id, nowMs);
-		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, nowMs={})",
-			account_id, character_id, nowMs);
+		admittedRegistry.Admit(character_id, account_id, character_name, nowMs);
+		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, name='{}', nowMs={})",
+			account_id, character_id, character_name, nowMs);
 	});
 	toMaster.Start();
 	// TA.3 : boucle gameplay UDP (ServerApp) sur un thread dedie, gated par admittedRegistry.

--- a/src/shardd/world/AdmittedCharacterRegistry.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistry.cpp
@@ -2,14 +2,23 @@
 
 namespace engine::server
 {
-	void AdmittedCharacterRegistry::Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs)
+	void AdmittedCharacterRegistry::Admit(uint64_t characterId, uint64_t accountId,
+		std::string_view characterName, uint64_t nowMs)
 	{
 		if (characterId == 0u)
 		{
 			return; // sentinelle « aucun personnage » : jamais admis.
 		}
 		std::lock_guard<std::mutex> lock(m_mutex);
-		m_admitted[characterId] = Entry{accountId, nowMs};
+		// Préserve le nom déjà connu si la nouvelle admission est anonyme (rafraîchissement
+		// d'horodatage via un ticket sans nom après un EnterWorld qui l'avait fourni).
+		Entry& entry = m_admitted[characterId];
+		entry.accountId = accountId;
+		entry.admittedAtMs = nowMs;
+		if (!characterName.empty())
+		{
+			entry.characterName.assign(characterName);
+		}
 	}
 
 	void AdmittedCharacterRegistry::Revoke(uint64_t characterId)
@@ -46,6 +55,21 @@ namespace engine::server
 			return 0u;
 		}
 		return it->second.accountId;
+	}
+
+	std::string AdmittedCharacterRegistry::AdmittedCharacterName(uint64_t characterId, uint64_t nowMs) const
+	{
+		if (characterId == 0u)
+		{
+			return {};
+		}
+		std::lock_guard<std::mutex> lock(m_mutex);
+		const auto it = m_admitted.find(characterId);
+		if (it == m_admitted.end() || (nowMs - it->second.admittedAtMs) > m_ttlMs)
+		{
+			return {};
+		}
+		return it->second.characterName;
 	}
 
 	size_t AdmittedCharacterRegistry::Count() const

--- a/src/shardd/world/AdmittedCharacterRegistry.h
+++ b/src/shardd/world/AdmittedCharacterRegistry.h
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace engine::server
@@ -27,7 +29,17 @@ namespace engine::server
 		/// Admet (ou rafraîchit l'horodatage d')un personnage. `characterId == 0` est ignoré
 		/// (sentinelle « aucun personnage » : un ticket émis avant l'EnterWorld porte 0).
 		/// \param nowMs horloge monotone en millisecondes (point de départ du TTL).
-		void Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs);
+		/// \param characterName TD.5 — nom du personnage (table SQL characters.name) ; peut
+		///        être vide si l'origine de l'admission n'a pas le nom (ex. ticket TCP
+		///        antérieur à EnterWorld). Le shard utilise ce nom pour alimenter
+		///        ConnectedClient.characterName en mode no-DB.
+		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName, uint64_t nowMs);
+
+		/// Surcharge legacy (sans nom) — équivalente à Admit(..., "", nowMs).
+		void Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs)
+		{
+			Admit(characterId, accountId, std::string_view{}, nowMs);
+		}
 
 		/// Retire un personnage (ex. déconnexion). No-op si absent.
 		void Revoke(uint64_t characterId);
@@ -38,6 +50,11 @@ namespace engine::server
 
 		/// account_id associé à un personnage admis et non expiré, 0 sinon.
 		uint64_t AdmittedAccountId(uint64_t characterId, uint64_t nowMs) const;
+
+		/// TD.5 — nom du personnage admis et non expiré, chaîne vide sinon (ou si aucun
+		/// nom n'avait été fourni à `Admit`). Utilisé par `ServerApp::HandleHello` pour
+		/// remplir `ConnectedClient.characterName` quand la DB locale n'est pas configurée.
+		std::string AdmittedCharacterName(uint64_t characterId, uint64_t nowMs) const;
 
 		/// Nombre d'entrées (admises ou non, sans purge). Utile aux tests / diagnostics.
 		size_t Count() const;
@@ -51,6 +68,7 @@ namespace engine::server
 		{
 			uint64_t accountId = 0;
 			uint64_t admittedAtMs = 0;
+			std::string characterName; ///< TD.5 — peut être vide (admission sans nom).
 		};
 
 		mutable std::mutex m_mutex;

--- a/src/shardd/world/AdmittedCharacterRegistryTests.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistryTests.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <string_view>
 
 using engine::server::AdmittedCharacterRegistry;
 
@@ -75,6 +76,33 @@ namespace
 		assert(reg.IsAdmitted(5u, 2500u));     // de nouveau valide
 		std::puts("[OK] TestReAdmitRefreshesTimestamp");
 	}
+
+	/// TD.5 — Admit avec nom retourne ce nom ; Admit sans nom retourne chaîne vide.
+	void TestAdmitWithName()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.SetTtlMs(1000u);
+		reg.Admit(11u, 1u, std::string_view{"homme"}, 100u);
+		assert(reg.AdmittedCharacterName(11u, 100u) == "homme");
+		reg.Admit(12u, 1u, 100u); // surcharge legacy = nom vide
+		assert(reg.AdmittedCharacterName(12u, 100u).empty());
+		// character_id inconnu ou expiré => chaîne vide
+		assert(reg.AdmittedCharacterName(999u, 100u).empty());
+		assert(reg.AdmittedCharacterName(11u, 100u + 5000u).empty()); // TTL dépassé
+		std::puts("[OK] TestAdmitWithName");
+	}
+
+	/// TD.5 — un re-Admit anonyme après un Admit nommé préserve le nom (le ticket TCP
+	/// rafraîchit le timestamp mais ne porte pas le nom — ne doit pas l'effacer).
+	void TestReAdmitWithoutNamePreservesName()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.Admit(20u, 7u, std::string_view{"femme"}, 0u);
+		assert(reg.AdmittedCharacterName(20u, 0u) == "femme");
+		reg.Admit(20u, 7u, 1000u); // legacy : sans nom
+		assert(reg.AdmittedCharacterName(20u, 1000u) == "femme");
+		std::puts("[OK] TestReAdmitWithoutNamePreservesName");
+	}
 }
 
 int main()
@@ -84,6 +112,8 @@ int main()
 	TestAdmissionExpiresAfterTtl();
 	TestRevoke();
 	TestReAdmitRefreshesTimestamp();
+	TestAdmitWithName();
+	TestReAdmitWithoutNamePreservesName();
 	std::puts("All AdmittedCharacterRegistry tests passed");
 	return 0;
 }

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -114,14 +114,25 @@ namespace engine::network
 		AdmitCharacterPayload out;
 		if (!r.ReadU64(out.account_id) || !r.ReadU64(out.character_id))
 			return std::nullopt;
+		// TD.5 — character_name optionnel : un master ancien ne l'enverra pas et le payload
+		// s'arrête à 16 octets. Dans ce cas, on garde out.character_name vide et le shard
+		// retombera sur le fallback "P<clientId>" (comportement legacy).
+		if (r.Remaining() > 0u)
+		{
+			if (!r.ReadString(out.character_name))
+				return std::nullopt;
+		}
 		return out;
 	}
 
-	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id)
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
+		std::string_view character_name)
 	{
 		PacketBuilder builder;
 		ByteWriter w = builder.PayloadWriter();
 		if (!w.WriteU64(account_id) || !w.WriteU64(character_id))
+			return {};
+		if (!w.WriteString(character_name))
 			return {};
 		const size_t payloadBytes = w.Offset();
 		// Push master→shard, pas de request_id ni session.

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -69,20 +69,27 @@ namespace engine::network
 	/// Builds SHARD_HEARTBEAT payload (Shard→Master). timestamp: e.g. seconds since epoch or monotonic.
 	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0);
 
-	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id).
+	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id, character_name).
 	/// Émis par le master (CharacterEnterWorldHandler) à destination du shard via la
 	/// connexion TCP persistante établie par ShardToMasterClient. Le shard l'utilise pour
 	/// admettre (account_id, character_id) dans son AdmittedCharacterRegistry → le Hello
-	/// UDP du client (clientNonce=character_id) sera ensuite accepté.
+	/// UDP du client (clientNonce=character_id) sera ensuite accepté. TD.5 — `character_name`
+	/// vient de la table SQL `characters.name` et permet au shard (en mode no-DB en
+	/// particulier) de remplir `ConnectedClient.characterName`, donc la plaque de nom
+	/// des avatars distants côté client.
 	struct AdmitCharacterPayload
 	{
 		uint64_t account_id = 0;
 		uint64_t character_id = 0;
+		std::string character_name;
 	};
 
 	/// Parses MASTER_TO_SHARD_ADMIT_CHARACTER payload. Returns nullopt if truncated.
 	std::optional<AdmitCharacterPayload> ParseAdmitCharacterPayload(const uint8_t* payload, size_t payloadSize);
 
 	/// Builds MASTER_TO_SHARD_ADMIT_CHARACTER packet (Master→Shard, push, request_id=0).
-	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id);
+	/// \param character_name nom du personnage (table SQL characters.name) ; sera tronqué
+	///        à 32 caractères côté master avant l'appel (cohérent avec la contrainte SQL).
+	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
+		std::string_view character_name);
 }

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -218,9 +218,9 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 					parsed->account_id, parsed->character_id);
 				return;
 			}
-			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={})",
-				parsed->account_id, parsed->character_id);
-			m_admit_callback(parsed->account_id, parsed->character_id);
+			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={}, name='{}')",
+				parsed->account_id, parsed->character_id, parsed->character_name);
+			m_admit_callback(parsed->account_id, parsed->character_id, parsed->character_name);
 		}
 	}
 

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -54,9 +54,12 @@ namespace engine::network
 
 		/// TA.3 — Callback invoqué quand le master pousse un `kOpcodeMasterToShardAdmitCharacter`
 		/// (suite à un EnterWorld réussi côté master). Le destinataire typique alimente
-		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, now)` côté shard.
+		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, characterName, now)`
+		/// côté shard. TD.5 — `character_name` est fourni par le master (table characters.name)
+		/// pour alimenter les plaques de nom côté client ; peut être vide (master legacy).
 		/// `nullptr` (défaut) = drop silencieux.
-		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id)>;
+		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id,
+			std::string_view character_name)>;
 		void SetAdmitCharacterCallback(AdmitCharacterCallback cb) { m_admit_callback = std::move(cb); }
 
 		enum class State

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1179,6 +1179,25 @@ namespace engine::server
 					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
 					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, dbX, dbY, dbZ);
 			}
+			// TD.5 — fallback nom : en mode no-DB (deploiement sans MySQL cote shard),
+			// LoadSpawnFromDb renvoie false et characterName reste vide → la plaque
+			// retomberait sur le fallback "P<clientId>" cote client. Le master nous a
+			// pousse le nom via kOpcodeMasterToShardAdmitCharacter (TD.5), on le recupere
+			// du registre d'admission qui le stocke depuis cette PR.
+			if (acceptedClient.characterName.empty() && m_admittedRegistry != nullptr)
+			{
+				const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::steady_clock::now().time_since_epoch()).count());
+				std::string admittedName = m_admittedRegistry->AdmittedCharacterName(
+					acceptedClient.persistenceCharacterKey, nowMs);
+				if (!admittedName.empty())
+				{
+					acceptedClient.characterName = std::move(admittedName);
+					LOG_INFO(Net,
+						"[ServerApp] Nom personnage recupere du registre d'admission (character_key={}, name=\"{}\")",
+						acceptedClient.persistenceCharacterKey, acceptedClient.characterName);
+				}
+			}
 		}
 
 		std::vector<QuestProgressDelta> questSyncDeltas;

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -97,9 +97,11 @@ namespace engine::server
 		uint64_t helloNonce = 0;
 		uint64_t persistenceCharacterKey = 0;
 		/// TD.5 — nom du personnage choisi par le joueur (cf. table SQL characters.name).
-		/// Chargé depuis la DB au moment de l'admission (LoadCharacterIdentityFromDb) puis
-		/// recopié dans chaque SnapshotEntity pour ce client → les avatars distants peuvent
-		/// afficher le vrai nom dans leur plaque (au lieu du fallback "P<clientId>").
+		/// Chargé depuis la DB (LoadSpawnFromDb) si le shard a un pool MySQL configuré ;
+		/// sinon (mode no-DB) repris du push master AdmitCharacter via
+		/// AdmittedCharacterRegistry::AdmittedCharacterName. Recopié dans chaque
+		/// SnapshotEntity pour ce client → les avatars distants peuvent afficher le vrai
+		/// nom dans leur plaque (au lieu du fallback "P<clientId>").
 		std::string characterName;
 		uint32_t experiencePoints = 0;
 		uint32_t gold = 0;


### PR DESCRIPTION
## Contexte — pourquoi PR #711 ne suffisait pas

PR #711 a câblé le wire UDP (SnapshotEntity transporte `characterName`, kProtocolVersion v5→v6) **et** la lecture du nom depuis la table SQL `characters` côté shard via `LoadSpawnFromDb`. Test 2 joueurs réel après merge : nameplate reste `P1`.

**Cause** : dans le déploiement actuel, le shard tourne en **mode no-DB** :
```
[ShardMain] DB non configuree — spawn depuis fichier (pont position TA.4 inactif)
[FriendSystem] GetFriendList: no DB (no-DB mode)
```
→ `LoadSpawnFromDb` renvoie `false` → `ConnectedClient.characterName` reste vide → snapshot émis avec nom vide → client retombe sur `"P" + clientId`.

Le master, lui, **connaît le nom** (il vient juste de le valider contre la DB centrale) :
```
[CharacterEnterWorldHandler] registered (account_id=2, character_id=1, name='homme')
[CharacterEnterWorldHandler] admit push sent (shard_id=1, ...)   ← nom PAS dans le push
```
Mais le push `kOpcodeMasterToShardAdmitCharacter` (opcode 199) ne transportait que `(account_id, character_id)`.

## Fix — étendre AdmitCharacter master→shard

Wire payload (opcode 199, TCP master→shard, push) :
```
avant : u64 account_id | u64 character_id                                    (16 octets)
après : u64 account_id | u64 character_id | u16 nameLen | nameLen octets    (>= 16 octets)
```

**Backward compat** : `ParseAdmitCharacterPayload` lit le nom seulement si `Remaining() > 0`. Un shard neuf accepte donc un master ancien (nom = vide → fallback `P<clientId>`).

Côté shard, le nom remonte via :
1. `ShardToMasterClient::AdmitCharacterCallback` — signature passe à `(u64, u64, string_view)`.
2. `AdmittedCharacterRegistry::Admit(charId, accId, name, now)` stocke le nom dans `Entry::characterName`. Surcharge legacy `Admit(charId, accId, now)` conservée pour `ShardTicketHandshakeHandler` (ticket TCP émis avant `EnterWorld`, sans nom). Un re-Admit anonyme après un Admit nommé **préserve** le nom (timestamp refresh sans écraser).
3. `ServerApp::HandleHello` : après `LoadSpawnFromDb`, si `characterName` est vide et que le registre est branché, récupère le nom via `AdmittedCharacterName(charId, now)`.

## Inclus aussi PR #712 (regression deploy)

Origin/main contient encore l'overlay `./data/persistence:/app/game/data/persistence:rw` (PR #710 cassée) qui masque `persistence/db/migrations/0001_*.sql` du bundle ro. Les 2 commits cherry-pickés ici sont les correctifs PR #712 (sous-mount restreint à `characters/` + `.gitkeep` pour que le mountpoint existe).

## Tests

`AdmittedCharacterRegistryTests` (suite existante TA.3) gagne 2 cas :
- `TestAdmitWithName` — `AdmittedCharacterName` retourne le nom passé à `Admit`, chaîne vide pour la surcharge legacy, chaîne vide après TTL.
- `TestReAdmitWithoutNamePreservesName` — un re-Admit sans nom (ticket TCP) ne doit pas écraser un nom déjà stocké.

## Logs attendus après déploiement

```
[ShardToMasterClient] AdmitCharacter received (account_id=2, character_id=1, name='homme')
[ShardMain] Admit pushed by master (account_id=2, character_id=1, name='homme', nowMs=...)
[ServerApp] Nom personnage recupere du registre d'admission (character_key=1, name="homme")
```
Nameplate côté client : `"homme"` / `"femme"` au lieu de `"P1"` / `"P2"`.

## Hors scope

L'artefact visuel "bug entre skin joueur et skin coffre" rapporté dans le test précédent n'est pas adressé ici — manque de signal pour diagnostiquer (pas de log particulier). À reprendre sur un screenshot plus net une fois cette PR mergée.

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR REQUIS — master ET shard en lock-step.**

Wire master↔shard étendu (opcode 199). La backward compat protège un mismatch transitoire (un shard neuf face à un master ancien retombe sur le fallback "P{n}", aucun crash), mais pour activer la feature il faut les deux côtés à jour. Pas de bump de `kProtocolVersion` UDP (gameplay client↔shard inchangé, toujours v6 depuis #711).

Côté client : **rien à redéployer** (le wire UDP est inchangé, le client lit déjà `displayName` depuis SnapshotEntity depuis #711).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_