### PR TITLE
fix(shard): anti-cheat — seuil aligné sur sprintSpeed client (13 m/s)

### DIFF
--- a/src/shardd/anticheat/AntiCheatGameplay.h
+++ b/src/shardd/anticheat/AntiCheatGameplay.h
@@ -27,8 +27,11 @@ namespace engine::server::anticheat
 
 	struct AntiCheatConfig
 	{
-		float    maxSpeedMps      = 7.5f;     ///< walk + run + mount typical
-		float    speedTolerance   = 1.5f;     ///< 50%% lag headroom
+		/// Vitesse max légale du client (gameplay) : sprintSpeed (touche Alt) côté
+		/// CharacterController.h = 13.0 m/s. Walk = 5, Run = 9, Sprint = 13. On aligne
+		/// le seuil sur la vitesse la plus haute pour éviter les faux positifs en sprint.
+		float    maxSpeedMps      = 13.0f;
+		float    speedTolerance   = 1.5f;     ///< 50% de marge pour le lag/jitter UDP
 		float    maxSingleStepM   = 50.0f;    ///< gros hop = teleport hack
 	};
 

--- a/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
+++ b/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
@@ -17,7 +17,7 @@ namespace engine::server::anticheat
 	void AntiCheatGameplayRuntime::SeedV1Config()
 	{
 		AntiCheatConfig cfg;
-		cfg.maxSpeedMps    = 7.5f;
+		cfg.maxSpeedMps    = 13.0f;  // sprintSpeed client (cf. CharacterController.h)
 		cfg.speedTolerance = 1.5f;
 		cfg.maxSingleStepM = 50.0f;
 		m_detector = AntiCheatGameplay(cfg);
@@ -29,7 +29,7 @@ namespace engine::server::anticheat
 	/// X par tick) puis interroge le detecteur. Le delta-temps theorique
 	/// entre deux ticks est de 1000 ms (cadence du wiring main_linux.cpp),
 	/// donc la vitesse calculee restera proche de 1 m/s, bien sous le
-	/// seuil maxAllowed = 7.5 * 1.5 = 11.25 m/s. En regime nominal, le
+	/// seuil maxAllowed = 13.0 * 1.5 = 19.5 m/s. En regime nominal, le
 	/// retour est donc 0.
 	std::size_t AntiCheatGameplayRuntime::Tick(std::uint64_t nowMs)
 	{

--- a/src/shardd/anticheat/AntiCheatGameplayTests.cpp
+++ b/src/shardd/anticheat/AntiCheatGameplayTests.cpp
@@ -18,7 +18,7 @@ namespace
 	{
 		AntiCheatGameplay ac;
 		ac.CheckMovement(1, 0, 0, 0, 1000);
-		// 5m en 1s = 5 m/s, sous 7.5 m/s default → OK.
+		// 5m en 1s = 5 m/s, sous 13.0 m/s default → OK.
 		if (ac.CheckMovement(1, 5, 0, 0, 2000) != CheatVerdict::OK) return false;
 		LOG_INFO(Core, "[AntiCheatTests] normal speed OK");
 		return true;
@@ -28,7 +28,7 @@ namespace
 	{
 		AntiCheatGameplay ac;
 		ac.CheckMovement(1, 0, 0, 0, 1000);
-		// 30m en 1s = 30 m/s, > 11.25 m/s tolerance → SpeedHack.
+		// 30m en 1s = 30 m/s, > 19.5 m/s tolerance → SpeedHack.
 		if (ac.CheckMovement(1, 30, 0, 0, 2000) != CheatVerdict::SpeedHack) return false;
 		LOG_INFO(Core, "[AntiCheatTests] speed hack detected");
 		return true;
@@ -43,6 +43,27 @@ namespace
 		LOG_INFO(Core, "[AntiCheatTests] teleport hack detected");
 		return true;
 	}
+
+	/// Regression : un joueur en sprint (touche Alt, 13 m/s côté CharacterController)
+	/// envoyant ses inputs à 20 Hz (= 50 ms entre ticks, donc 0.65 m par tick) doit être
+	/// accepté. Le bug d'origine : maxSpeedMps=7.5 → seuil 11.25 m/s, donc 13 m/s rejeté
+	/// comme SpeedHack pendant les phases de sprint normales. Les logs de prod montraient
+	/// 18+ rejets par minute dont la majorité sur ces déplacements légitimes.
+	bool TestSprintAtTickRateNotRejected()
+	{
+		AntiCheatGameplay ac;
+		// Sprint = 13 m/s, tick = 50 ms (20 Hz) → 0.65 m par tick.
+		ac.CheckMovement(1, 0.0f, 0.0f, 0.0f, 0);
+		for (int i = 1; i <= 20; ++i)  // 20 ticks = 1 seconde de sprint
+		{
+			const float x = static_cast<float>(i) * 0.65f;
+			const uint64_t tsMs = static_cast<uint64_t>(i) * 50u;
+			if (ac.CheckMovement(1, x, 0.0f, 0.0f, tsMs) != CheatVerdict::OK)
+				return false;
+		}
+		LOG_INFO(Core, "[AntiCheatTests] sprint at tick rate accepted");
+		return true;
+	}
 }
 
 int main(int argc, char** argv)
@@ -54,7 +75,8 @@ int main(int argc, char** argv)
 	engine::core::Log::Init(logSettings);
 
 	const bool ok = TestFirstReportOK() && TestNormalSpeed()
-		&& TestSpeedHack() && TestTeleportHack();
+		&& TestSpeedHack() && TestTeleportHack()
+		&& TestSprintAtTickRateNotRejected();
 	if (ok) LOG_INFO(Core, "[AntiCheatTests] ALL OK");
 	else LOG_ERROR(Core, "[AntiCheatTests] FAIL");
 	engine::core::Log::Shutdown();

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
 	// pour qu'un futur SeedFromDb() ait son point d'accroche evident).
 	engine::server::anticheat::AntiCheatGameplayRuntime antiCheat;
 	antiCheat.SeedV1Config();
-	LOG_INFO(AntiCheat, "[AntiCheat] runtime configured (V1 thresholds : maxSpeed=7.5 m/s, tolerance=1.5, maxStep=50 m)");
+	LOG_INFO(AntiCheat, "[AntiCheat] runtime configured (V1 thresholds : maxSpeed=13.0 m/s, tolerance=1.5, maxStep=50 m)");
 
 	engine::server::spell::SpellFamilyRuntime spellFamily;
 	spellFamily.SeedV1Families();


### PR DESCRIPTION
## Cause racine

Mismatch entre la **vitesse de sprint client (13 m/s)** et le **seuil anti-cheat serveur (11.25 m/s)** :

```cpp
// client/gameplay/CharacterController.h
float walkSpeed   = 5.0f;
float runSpeed    = 9.0f;
float sprintSpeed = 13.0f;  // touche Alt maintenue

// shardd/anticheat/AntiCheatGameplay.h (avant fix)
float maxSpeedMps    = 7.5f;   // ← MÊME PAS runSpeed !
float speedTolerance = 1.5f;   // → seuil 11.25 m/s
```

## Symptôme observé (logs prod, test 2 joueurs)

Sur ~1 minute de gameplay, **18+ rejets** avec `verdict=1 (SpeedHack)` :

```
[07:46:35][WARN][AntiCheat] Input rejete (verdict=1, seq=549, pos=(-7.35,3.18))
[07:46:35]                                 (verdict=1, seq=550, pos=(-7.87,3.44))
[07:46:53]                                 (verdict=1, seq=851, ...)
[07:46:53]                                 (verdict=1, seq=852, ...)
[07:46:53]                                 ... 8 rejets consécutifs ...
```

Calcul des deltas observés :
- Position seq=549 → seq=550 : Δ = 0.58 m en 50 ms (1 tick à 20 Hz) = **11.6 m/s**
- Position seq=852 → seq=853 : Δ = 0.65 m en 50 ms = **13 m/s**

Donc le joueur sprintait légitimement (le log client confirme `[Avatar SM] Walk -> Sprint`). À 13 m/s × tick 50 ms = 0.65 m par paquet, la vitesse mesurée est ≈ 13 m/s, juste au-dessus du seuil 11.25.

Le joueur pouvait quand même se déplacer (le rejet sur un paquet n'empêche pas le suivant), mais les inputs intermédiaires étaient perdus → position serveur saccadée → desync visible côté autres joueurs.

## Fix

`maxSpeedMps : 7.5 → 13.0` (aligné sur `sprintSpeed` client). `tolerance` reste à 1.5, donc seuil effectif = **19.5 m/s** = 50% de marge au-dessus du sprint pour couvrir :
- Jitter UDP / lag réseau temporaire
- Root motion d'animation (un step de marche peut ponctuellement dépasser walkSpeed)
- Pentes descendantes qui accélèrent

## Défense en profondeur conservée

- `maxSingleStepM = 50 m` inchangé → vrais teleport hacks toujours bloqués via `TeleportHack`.
- `SpeedHack` toujours détecté au-delà de 19.5 m/s. Test existant (30 m/s rejeté) passe toujours.

## Tests

`AntiCheatGameplayTests` (suite TA.3c) gagne :
- `TestSprintAtTickRateNotRejected` — simule 1 seconde de sprint à 13 m/s (20 ticks de 0.65 m). Doit être intégralement accepté (0 rejet sur 20 inputs).

Tests existants (`TestNormalSpeed`, `TestSpeedHack`, `TestTeleportHack`) toujours verts, commentaires mis à jour pour refléter le nouveau seuil 19.5 m/s.

Compilé + run local :
```
[AntiCheatTests] first report OK
[AntiCheatTests] normal speed OK
[AntiCheatTests] speed hack detected
[AntiCheatTests] teleport hack detected
[AntiCheatTests] sprint at tick rate accepted
[AntiCheatTests] ALL OK
```

## Pas dans cette PR

- Pas de changement wire (le anti-cheat est entièrement serveur).
- Pas de modif master / client.

## Déploiement

> **Déploiement** : ⚠️ **redéploiement serveur shard requis** (`docker compose up -d --force-recreate shard`). Master non touché. Client non concerné (le sprintSpeed client était déjà à 13 m/s avant ce fix — c'est le serveur qui était mal configuré).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_