### PR TITLE
feat(replication): TD.6 — genre du personnage propagé end-to-end (wire v6→v7)

### DIFF
--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -727,6 +727,8 @@ namespace engine::client
 			remote.playerClientId = entity.playerClientId;
 			// TD.5 : nom du perso pour la plaque de nom (vide → fallback "P<clientId>").
 			remote.displayName = entity.characterName;
+			// TD.6 : genre du perso pour le rendu de l'avatar distant (vide → fallback "male").
+			remote.gender = entity.gender;
 			m_model.remoteEntities.push_back(remote);
 		}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -308,6 +308,10 @@ namespace engine::client
 		/// Vide pour les mobs / lootbags, ou pour les joueurs si la DB serveur n'a pas
 		/// pu servir le nom — le HUD retombe alors sur "P<playerClientId>".
 		std::string displayName;
+		/// TD.6 : genre du personnage ("male"/"female", cf. migration 0067), propagé via
+		/// le SnapshotEntity. Vide pour les mobs / lootbags, ou pour les joueurs si le
+		/// master n'a pas pu fournir le genre — le rendu retombe alors sur "male".
+		std::string gender;
 	};
 
 	/// Pure data model consumed by UI views and debug panels.

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -78,18 +78,20 @@ namespace engine::server
 			return;
 		}
 
-		// Vérifie ownership : SELECT name, server_id FROM characters WHERE id=? AND account_id=? AND deleted_at IS NULL.
-		// On compare ensuite le name DB au name client byte-pour-byte (rejette toute imposture
-		// comme un sender qui claim un autre nom que celui en DB). TA.3 : server_id sert au
-		// lookup du shard cible pour le push d'admission.
+		// Vérifie ownership : SELECT name, server_id, gender FROM characters WHERE id=? AND account_id=?
+		// AND deleted_at IS NULL. On compare ensuite le name DB au name client byte-pour-byte
+		// (rejette toute imposture comme un sender qui claim un autre nom que celui en DB).
+		// TA.3 : server_id sert au lookup du shard cible pour le push d'admission.
+		// TD.6 : gender (migration 0067, "male"/"female") propagé au shard via AdmitCharacter.
 		char queryBuf[256]{};
 		std::snprintf(queryBuf, sizeof(queryBuf),
-			"SELECT name, server_id FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
+			"SELECT name, server_id, gender FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
 			static_cast<unsigned long long>(parsed->characterId),
 			static_cast<unsigned long long>(*accountId));
 
 		MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
 		std::string dbName;
+		std::string dbGender;
 		uint32_t dbServerId = 0;
 		bool found = false;
 		if (res)
@@ -100,6 +102,8 @@ namespace engine::server
 				dbName = row[0];
 				if (row[1])
 					dbServerId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
+				if (row[2])
+					dbGender = row[2];
 				found = true;
 			}
 			engine::server::db::DbFreeResult(res);
@@ -162,8 +166,11 @@ namespace engine::server
 				// TD.5 — on embarque le nom du personnage dans le push d'admission pour
 				// permettre au shard (notamment en mode no-DB) de l'utiliser dans la
 				// SnapshotEntity (plaque de nom des avatars distants).
+				// TD.6 — on embarque aussi le genre (cf. migration 0067) pour permettre au
+				// client de sélectionner le bon mesh skinné (Male_Ranger vs Female_Ranger)
+				// pour les avatars distants.
 				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId,
-					parsed->characterName);
+					parsed->characterName, dbGender);
 				if (!admitPkt.empty() && m_server->Send(*shardConnId, admitPkt))
 				{
 					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={})",

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -177,13 +177,13 @@ int main(int argc, char** argv)
 	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le
 	// ticket TCP avait été émis avant le choix de perso (character_id=0 → non admis).
 	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id,
-		std::string_view character_name) {
+		std::string_view character_name, std::string_view gender) {
 		const std::uint64_t nowMs = static_cast<std::uint64_t>(
 			std::chrono::duration_cast<std::chrono::milliseconds>(
 				std::chrono::steady_clock::now().time_since_epoch()).count());
-		admittedRegistry.Admit(character_id, account_id, character_name, nowMs);
-		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, name='{}', nowMs={})",
-			account_id, character_id, character_name, nowMs);
+		admittedRegistry.Admit(character_id, account_id, character_name, gender, nowMs);
+		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, name='{}', gender='{}', nowMs={})",
+			account_id, character_id, character_name, gender, nowMs);
 	});
 	toMaster.Start();
 	// TA.3 : boucle gameplay UDP (ServerApp) sur un thread dedie, gated par admittedRegistry.

--- a/src/shardd/world/AdmittedCharacterRegistry.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistry.cpp
@@ -3,21 +3,25 @@
 namespace engine::server
 {
 	void AdmittedCharacterRegistry::Admit(uint64_t characterId, uint64_t accountId,
-		std::string_view characterName, uint64_t nowMs)
+		std::string_view characterName, std::string_view gender, uint64_t nowMs)
 	{
 		if (characterId == 0u)
 		{
 			return; // sentinelle « aucun personnage » : jamais admis.
 		}
 		std::lock_guard<std::mutex> lock(m_mutex);
-		// Préserve le nom déjà connu si la nouvelle admission est anonyme (rafraîchissement
-		// d'horodatage via un ticket sans nom après un EnterWorld qui l'avait fourni).
+		// Préserve le nom/genre déjà connus si la nouvelle admission est anonyme (rafraîchissement
+		// d'horodatage via un ticket sans nom après un EnterWorld qui les avait fournis).
 		Entry& entry = m_admitted[characterId];
 		entry.accountId = accountId;
 		entry.admittedAtMs = nowMs;
 		if (!characterName.empty())
 		{
 			entry.characterName.assign(characterName);
+		}
+		if (!gender.empty())
+		{
+			entry.gender.assign(gender);
 		}
 	}
 
@@ -70,6 +74,21 @@ namespace engine::server
 			return {};
 		}
 		return it->second.characterName;
+	}
+
+	std::string AdmittedCharacterRegistry::AdmittedGender(uint64_t characterId, uint64_t nowMs) const
+	{
+		if (characterId == 0u)
+		{
+			return {};
+		}
+		std::lock_guard<std::mutex> lock(m_mutex);
+		const auto it = m_admitted.find(characterId);
+		if (it == m_admitted.end() || (nowMs - it->second.admittedAtMs) > m_ttlMs)
+		{
+			return {};
+		}
+		return it->second.gender;
 	}
 
 	size_t AdmittedCharacterRegistry::Count() const

--- a/src/shardd/world/AdmittedCharacterRegistry.h
+++ b/src/shardd/world/AdmittedCharacterRegistry.h
@@ -33,12 +33,22 @@ namespace engine::server
 		///        être vide si l'origine de l'admission n'a pas le nom (ex. ticket TCP
 		///        antérieur à EnterWorld). Le shard utilise ce nom pour alimenter
 		///        ConnectedClient.characterName en mode no-DB.
-		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName, uint64_t nowMs);
+		/// \param gender TD.6 — genre du personnage ("male"/"female", cf. migration 0067) ;
+		///        peut être vide si master legacy. Propagé au client via SnapshotEntity pour
+		///        sélectionner le mesh skinné des avatars distants.
+		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName,
+			std::string_view gender, uint64_t nowMs);
 
-		/// Surcharge legacy (sans nom) — équivalente à Admit(..., "", nowMs).
+		/// Surcharge legacy (sans nom ni genre) — équivalente à Admit(..., "", "", nowMs).
 		void Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs)
 		{
-			Admit(characterId, accountId, std::string_view{}, nowMs);
+			Admit(characterId, accountId, std::string_view{}, std::string_view{}, nowMs);
+		}
+
+		/// Surcharge legacy (sans genre) — équivalente à Admit(..., name, "", nowMs).
+		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName, uint64_t nowMs)
+		{
+			Admit(characterId, accountId, characterName, std::string_view{}, nowMs);
 		}
 
 		/// Retire un personnage (ex. déconnexion). No-op si absent.
@@ -56,6 +66,11 @@ namespace engine::server
 		/// remplir `ConnectedClient.characterName` quand la DB locale n'est pas configurée.
 		std::string AdmittedCharacterName(uint64_t characterId, uint64_t nowMs) const;
 
+		/// TD.6 — genre du personnage admis et non expiré, chaîne vide sinon. Utilisé par
+		/// `ServerApp::HandleHello` pour remplir `ConnectedClient.gender` quand la DB
+		/// locale n'est pas configurée (et propagé au client via SnapshotEntity).
+		std::string AdmittedGender(uint64_t characterId, uint64_t nowMs) const;
+
 		/// Nombre d'entrées (admises ou non, sans purge). Utile aux tests / diagnostics.
 		size_t Count() const;
 
@@ -69,6 +84,7 @@ namespace engine::server
 			uint64_t accountId = 0;
 			uint64_t admittedAtMs = 0;
 			std::string characterName; ///< TD.5 — peut être vide (admission sans nom).
+			std::string gender;        ///< TD.6 — peut être vide (admission sans genre).
 		};
 
 		mutable std::mutex m_mutex;

--- a/src/shardd/world/AdmittedCharacterRegistryTests.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistryTests.cpp
@@ -103,6 +103,35 @@ namespace
 		assert(reg.AdmittedCharacterName(20u, 1000u) == "femme");
 		std::puts("[OK] TestReAdmitWithoutNamePreservesName");
 	}
+
+	/// TD.6 — Admit avec genre retourne ce genre ; surcharges sans genre retournent vide.
+	void TestAdmitWithGender()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.SetTtlMs(1000u);
+		reg.Admit(30u, 1u, std::string_view{"homme"}, std::string_view{"male"}, 100u);
+		assert(reg.AdmittedGender(30u, 100u) == "male");
+		reg.Admit(31u, 1u, std::string_view{"femme"}, std::string_view{"female"}, 100u);
+		assert(reg.AdmittedGender(31u, 100u) == "female");
+		// Surcharge legacy (nom mais sans genre) => genre vide.
+		reg.Admit(32u, 1u, std::string_view{"anon"}, 100u);
+		assert(reg.AdmittedGender(32u, 100u).empty());
+		// character_id inconnu ou expiré => chaîne vide.
+		assert(reg.AdmittedGender(999u, 100u).empty());
+		assert(reg.AdmittedGender(30u, 100u + 5000u).empty()); // TTL dépassé
+		std::puts("[OK] TestAdmitWithGender");
+	}
+
+	/// TD.6 — un re-Admit sans genre après un Admit avec genre préserve le genre.
+	void TestReAdmitWithoutGenderPreservesGender()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.Admit(40u, 7u, std::string_view{"femme"}, std::string_view{"female"}, 0u);
+		assert(reg.AdmittedGender(40u, 0u) == "female");
+		reg.Admit(40u, 7u, std::string_view{"femme"}, 1000u); // surcharge sans genre
+		assert(reg.AdmittedGender(40u, 1000u) == "female");
+		std::puts("[OK] TestReAdmitWithoutGenderPreservesGender");
+	}
 }
 
 int main()
@@ -114,6 +143,8 @@ int main()
 	TestReAdmitRefreshesTimestamp();
 	TestAdmitWithName();
 	TestReAdmitWithoutNamePreservesName();
+	TestAdmitWithGender();
+	TestReAdmitWithoutGenderPreservesGender();
 	std::puts("All AdmittedCharacterRegistry tests passed");
 	return 0;
 }

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -70,11 +70,16 @@ namespace engine::server
 	/// TD.5 — `characterName` porte le nom de personnage choisi par le joueur ; non vide
 	/// uniquement pour les joueurs (mobs/lootbags ont la chaîne vide). Wire-bump v5→v6 :
 	/// chaque entité du Snapshot est suivie d'une chaîne préfixée u16 (taille variable).
+	/// TD.6 — `gender` porte le genre du personnage ("male"/"female", cf. migration 0067).
+	/// Permet au client de sélectionner le bon mesh skinné (Male_Ranger vs Female_Ranger)
+	/// pour le rendu de l'avatar distant. Chaîne vide pour les mobs/lootbags. Wire-bump
+	/// v6→v7 : ajout d'une seconde chaîne préfixée u16 après `characterName`.
 	struct SnapshotEntity
 	{
 		EntityId entityId = 0;
 		EntityState state{};
 		uint32_t playerClientId = 0;
 		std::string characterName;
+		std::string gender;
 	};
 }

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -292,11 +292,11 @@ namespace engine::server
 		outMessage.chunkCount = ReadU16(payload, 22);
 
 		const size_t entityCount = static_cast<size_t>(outMessage.entityCount);
-		// TD.5 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
-		// + 2 (nameLen) + N (name) octets. On vérifie un minimum (54 par entité, nom vide), puis
-		// on parse sequentiellement et on rejette si on dépasse la fin du payload en cours de route.
-		// TG.1 — header a 24 octets.
-		const size_t minimumPayloadSize = 24 + (entityCount * 54);
+		// TD.6 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name) + 2 (genderLen) + M (gender) octets. On vérifie un minimum
+		// (56 par entité, nom et genre vides), puis on parse sequentiellement et on rejette si
+		// on dépasse la fin du payload en cours de route. TG.1 — header a 24 octets.
+		const size_t minimumPayloadSize = 24 + (entityCount * 56);
 		if (payload.size() < minimumPayloadSize)
 		{
 			return false;
@@ -322,6 +322,14 @@ namespace engine::server
 			// kMaxChatLocalSenderNameBytes), au-delà on rejette le paquet pour défense en profondeur.
 			if (!ReadSizedString(payload, offset, entity.characterName)
 				|| entity.characterName.size() > 64u)
+			{
+				outEntities.clear();
+				return false;
+			}
+			// TD.6 : genre du personnage (chaîne préfixée u16). Borne dure : 8 octets (cf.
+			// VARCHAR(8) en DB, cf. migration 0067). Vide pour les mobs/lootbags.
+			if (!ReadSizedString(payload, offset, entity.gender)
+				|| entity.gender.size() > 8u)
 			{
 				outEntities.clear();
 				return false;
@@ -410,13 +418,13 @@ namespace engine::server
 
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities)
 	{
-		// TD.4 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId) + 2 (nameLen)
-		// + N (name bytes, variable) octets. TD.5 wire-bump v5→v6 : ajout du nom de personnage.
-		// Pour le sizing : on prend une estimation a 8 + 40 + 4 + 2 = 54 par entite (sans le nom)
-		// + buffer reserve via push_back si nom non vide. BeginPacket.reserve est juste un hint,
-		// pas une borne stricte (le vector grandit a l'append).
+		// TD.6 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name bytes) + 2 (genderLen) + M (gender bytes, variable) octets.
+		// Wire-bump v6→v7 : ajout du genre du personnage après le nom. Pour le sizing :
+		// estimation à 8 + 40 + 4 + 2 + 2 = 56 par entité (nom et genre vides). BeginPacket.reserve
+		// est juste un hint, pas une borne stricte (le vector grandit à l'append).
 		// TG.1 — header passe de 20 → 24 octets (ajout chunkIndex + chunkCount uint16 × 2).
-		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 54));
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 56));
 		WriteU32(packet, message.clientId);
 		WriteU32(packet, message.serverTick);
 		WriteU16(packet, message.connectedClients);
@@ -435,6 +443,8 @@ namespace engine::server
 			WriteU32(packet, entity.playerClientId);
 			// TD.5 : nom du personnage (préfixé u16). Vide pour les mobs / lootbags.
 			WriteSizedString(packet, entity.characterName);
+			// TD.6 : genre du personnage (préfixé u16). Vide pour les mobs / lootbags.
+			WriteSizedString(packet, entity.gender);
 		}
 		return packet;
 	}

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -23,7 +23,7 @@ namespace engine::server
 	/// `chunkCount = 1` (mono-paquet) reste le cas dominant ; `chunkCount > 1` exige une
 	/// réassemblage côté client (cf. UIModelBinding::ApplySnapshot).
 	/// Wire-breaking : client + shard doivent se déployer ensemble.
-	inline constexpr uint16_t kProtocolVersion = 6;
+	inline constexpr uint16_t kProtocolVersion = 7;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -100,8 +100,8 @@ namespace
 		inMsg.sentPackets = 77u;
 
 		std::vector<SnapshotEntity> in;
-		// 2 joueurs avec playerClientId ≠ 0 et un characterName non vide,
-		// 1 mob avec playerClientId = 0 et characterName vide.
+		// 2 joueurs avec playerClientId ≠ 0, characterName et gender non vides ;
+		// 1 mob avec playerClientId = 0, characterName et gender vides.
 		SnapshotEntity ePlayerA{};
 		ePlayerA.entityId = 0x200000001ull;
 		ePlayerA.state.positionX = 10.5f;
@@ -110,6 +110,7 @@ namespace
 		ePlayerA.state.yawRadians = 0.42f;
 		ePlayerA.playerClientId = 7u;
 		ePlayerA.characterName = "homme"; // TD.5
+		ePlayerA.gender = "male";          // TD.6
 		in.push_back(ePlayerA);
 
 		SnapshotEntity ePlayerB{};
@@ -118,6 +119,7 @@ namespace
 		ePlayerB.state.positionZ = 50.0f;
 		ePlayerB.playerClientId = 12u;
 		ePlayerB.characterName = "femme"; // TD.5
+		ePlayerB.gender = "female";        // TD.6
 		in.push_back(ePlayerB);
 
 		SnapshotEntity eMob{};
@@ -125,7 +127,7 @@ namespace
 		eMob.state.currentHealth = 80u;
 		eMob.state.maxHealth = 100u;
 		eMob.playerClientId = 0u; // mob => pas de nameplate
-		// characterName reste vide pour les mobs / lootbags (TD.5).
+		// characterName et gender restent vides pour les mobs / lootbags (TD.5/TD.6).
 		in.push_back(eMob);
 
 		const std::vector<std::byte> packet = EncodeSnapshot(inMsg, in);
@@ -146,26 +148,29 @@ namespace
 		assert(out[0].state.yawRadians == ePlayerA.state.yawRadians);
 		assert(out[0].playerClientId == 7u);
 		assert(out[0].characterName == "homme"); // TD.5
+		assert(out[0].gender == "male");          // TD.6
 
 		assert(out[1].entityId == ePlayerB.entityId);
 		assert(out[1].state.positionX == ePlayerB.state.positionX);
 		assert(out[1].playerClientId == 12u);
 		assert(out[1].characterName == "femme"); // TD.5
+		assert(out[1].gender == "female");        // TD.6
 
 		assert(out[2].entityId == eMob.entityId);
 		assert(out[2].state.currentHealth == 80u);
 		assert(out[2].state.maxHealth == 100u);
 		assert(out[2].playerClientId == 0u);
 		assert(out[2].characterName.empty()); // TD.5 : mob => pas de nom
+		assert(out[2].gender.empty());        // TD.6 : mob => pas de genre
 		std::puts("[OK] TestSnapshotRoundTripWithPlayerClientId");
 	}
 
-	/// TD.5 — un Snapshot dont la taille de payload est inferieure au minimum attendu
-	/// (54 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0,
-	/// au-delà de l'entête 24 octets) doit être rejeté. Defense en profondeur contre un
-	/// pair (client ou serveur) qui parlerait une version antérieure du wire (v3 = 48,
-	/// v4 = 52, v5 = 52 sans nom). Le bump kProtocolVersion à v6 filtre déjà la plupart
-	/// des cas dans DecodeHeader, ce test couvre une corruption après header valide.
+	/// TD.6 — un Snapshot dont la taille de payload est inferieure au minimum attendu
+	/// (56 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0
+	/// + 2 genderLen=0, au-delà de l'entête 24 octets) doit être rejeté. Defense en
+	/// profondeur contre un pair qui parlerait une version antérieure du wire. Le bump
+	/// kProtocolVersion à v7 filtre déjà la plupart des cas dans DecodeHeader, ce test
+	/// couvre une corruption après header valide.
 	void TestSnapshotRejectsTruncatedPayload()
 	{
 		SnapshotMessage inMsg{};

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -122,17 +122,26 @@ namespace engine::network
 			if (!r.ReadString(out.character_name))
 				return std::nullopt;
 		}
+		// TD.6 — gender optionnel : un master sans la migration 0067 ne l'enverra pas. Dans
+		// ce cas, le client retombera sur "male" par défaut côté rendu.
+		if (r.Remaining() > 0u)
+		{
+			if (!r.ReadString(out.gender))
+				return std::nullopt;
+		}
 		return out;
 	}
 
 	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
-		std::string_view character_name)
+		std::string_view character_name, std::string_view gender)
 	{
 		PacketBuilder builder;
 		ByteWriter w = builder.PayloadWriter();
 		if (!w.WriteU64(account_id) || !w.WriteU64(character_id))
 			return {};
 		if (!w.WriteString(character_name))
+			return {};
+		if (!w.WriteString(gender))
 			return {};
 		const size_t payloadBytes = w.Offset();
 		// Push master→shard, pas de request_id ni session.

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -69,19 +69,22 @@ namespace engine::network
 	/// Builds SHARD_HEARTBEAT payload (Shard→Master). timestamp: e.g. seconds since epoch or monotonic.
 	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0);
 
-	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id, character_name).
+	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id, character_name, gender).
 	/// Émis par le master (CharacterEnterWorldHandler) à destination du shard via la
 	/// connexion TCP persistante établie par ShardToMasterClient. Le shard l'utilise pour
 	/// admettre (account_id, character_id) dans son AdmittedCharacterRegistry → le Hello
 	/// UDP du client (clientNonce=character_id) sera ensuite accepté. TD.5 — `character_name`
 	/// vient de la table SQL `characters.name` et permet au shard (en mode no-DB en
 	/// particulier) de remplir `ConnectedClient.characterName`, donc la plaque de nom
-	/// des avatars distants côté client.
+	/// des avatars distants côté client. TD.6 — `gender` vient de `characters.gender`
+	/// (migration 0067, "male"/"female") et permet au client de choisir le mesh skinné
+	/// correct pour les avatars distants.
 	struct AdmitCharacterPayload
 	{
 		uint64_t account_id = 0;
 		uint64_t character_id = 0;
 		std::string character_name;
+		std::string gender;
 	};
 
 	/// Parses MASTER_TO_SHARD_ADMIT_CHARACTER payload. Returns nullopt if truncated.
@@ -90,6 +93,7 @@ namespace engine::network
 	/// Builds MASTER_TO_SHARD_ADMIT_CHARACTER packet (Master→Shard, push, request_id=0).
 	/// \param character_name nom du personnage (table SQL characters.name) ; sera tronqué
 	///        à 32 caractères côté master avant l'appel (cohérent avec la contrainte SQL).
+	/// \param gender genre du personnage ("male"/"female", cf. migration 0067).
 	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
-		std::string_view character_name);
+		std::string_view character_name, std::string_view gender);
 }

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -218,9 +218,9 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 					parsed->account_id, parsed->character_id);
 				return;
 			}
-			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={}, name='{}')",
-				parsed->account_id, parsed->character_id, parsed->character_name);
-			m_admit_callback(parsed->account_id, parsed->character_id, parsed->character_name);
+			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={}, name='{}', gender='{}')",
+				parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender);
+			m_admit_callback(parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender);
 		}
 	}
 

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -54,12 +54,14 @@ namespace engine::network
 
 		/// TA.3 — Callback invoqué quand le master pousse un `kOpcodeMasterToShardAdmitCharacter`
 		/// (suite à un EnterWorld réussi côté master). Le destinataire typique alimente
-		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, characterName, now)`
+		/// `AdmittedCharacterRegistry::Admit(character_id, account_id, characterName, gender, now)`
 		/// côté shard. TD.5 — `character_name` est fourni par le master (table characters.name)
 		/// pour alimenter les plaques de nom côté client ; peut être vide (master legacy).
+		/// TD.6 — `gender` ("male"/"female", cf. migration 0067) permet au client de choisir
+		/// le mesh skinné des avatars distants ; peut être vide (master sans migration 0067).
 		/// `nullptr` (défaut) = drop silencieux.
 		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id,
-			std::string_view character_name)>;
+			std::string_view character_name, std::string_view gender)>;
 		void SetAdmitCharacterCallback(AdmitCharacterCallback cb) { m_admit_callback = std::move(cb); }
 
 		enum class State

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -972,7 +972,8 @@ namespace engine::server
 		LOG_WARN(Net, "[ServerApp] Dropped invalid packet from {}", UdpTransport::EndpointToString(datagram.endpoint));
 	}
 
-	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg, std::string& outName)
+	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
+		std::string& outName, std::string& outGender)
 	{
 #if defined(SHARD_POSITION_DB)
 		if (m_characterDbPool == nullptr || characterId == 0u)
@@ -987,8 +988,9 @@ namespace engine::server
 		}
 		char sql[256];
 		// TD.5 — on fetch aussi `name` pour le SnapshotEntity (plaque de nom).
+		// TD.6 — et `gender` (migration 0067) pour le rendu de l'avatar distant.
 		std::snprintf(sql, sizeof(sql),
-			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name FROM characters "
+			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender FROM characters "
 			"WHERE id = %llu AND deleted_at IS NULL",
 			static_cast<unsigned long long>(characterId));
 		MYSQL_RES* res = db::DbQuery(mysql, sql);
@@ -1004,12 +1006,13 @@ namespace engine::server
 			z = row[2] ? std::strtof(row[2], nullptr) : 0.0f;
 			yawDeg = row[3] ? std::strtof(row[3], nullptr) : 0.0f;
 			outName = row[4] ? std::string(row[4]) : std::string{};
+			outGender = row[5] ? std::string(row[5]) : std::string{};
 			found = true;
 		}
 		db::DbFreeResult(res);
 		return found;
 #else
-		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName;
+		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender;
 		return false;
 #endif
 	}
@@ -1167,7 +1170,8 @@ namespace engine::server
 		{
 			float dbX = 0.0f, dbY = 0.0f, dbZ = 0.0f, dbYawDeg = 0.0f;
 			std::string dbName;
-			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName))
+			std::string dbGender;
+			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender))
 			{
 				acceptedClient.positionMetersX = dbX;
 				acceptedClient.positionMetersY = dbY;
@@ -1175,27 +1179,44 @@ namespace engine::server
 				acceptedClient.yawRadians = dbYawDeg * 0.01745329252f; // deg -> rad
 				// TD.5 — nom du personnage destiné aux plaques de nom des avatars distants.
 				acceptedClient.characterName = std::move(dbName);
+				// TD.6 — genre du personnage destiné au rendu des avatars distants.
+				acceptedClient.gender = std::move(dbGender);
 				LOG_INFO(Net,
-					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
-					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, dbX, dbY, dbZ);
+					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", gender=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
+					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, acceptedClient.gender, dbX, dbY, dbZ);
 			}
-			// TD.5 — fallback nom : en mode no-DB (deploiement sans MySQL cote shard),
-			// LoadSpawnFromDb renvoie false et characterName reste vide → la plaque
-			// retomberait sur le fallback "P<clientId>" cote client. Le master nous a
-			// pousse le nom via kOpcodeMasterToShardAdmitCharacter (TD.5), on le recupere
-			// du registre d'admission qui le stocke depuis cette PR.
-			if (acceptedClient.characterName.empty() && m_admittedRegistry != nullptr)
+			// TD.5/TD.6 — fallback nom/genre : en mode no-DB (deploiement sans MySQL cote shard),
+			// LoadSpawnFromDb renvoie false et characterName/gender restent vides → le client
+			// retomberait sur le fallback "P<clientId>" + skin male par defaut. Le master nous a
+			// pousse nom et genre via kOpcodeMasterToShardAdmitCharacter, on les recupere du
+			// registre d'admission.
+			if (m_admittedRegistry != nullptr)
 			{
 				const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
 					std::chrono::steady_clock::now().time_since_epoch()).count());
-				std::string admittedName = m_admittedRegistry->AdmittedCharacterName(
-					acceptedClient.persistenceCharacterKey, nowMs);
-				if (!admittedName.empty())
+				if (acceptedClient.characterName.empty())
 				{
-					acceptedClient.characterName = std::move(admittedName);
-					LOG_INFO(Net,
-						"[ServerApp] Nom personnage recupere du registre d'admission (character_key={}, name=\"{}\")",
-						acceptedClient.persistenceCharacterKey, acceptedClient.characterName);
+					std::string admittedName = m_admittedRegistry->AdmittedCharacterName(
+						acceptedClient.persistenceCharacterKey, nowMs);
+					if (!admittedName.empty())
+					{
+						acceptedClient.characterName = std::move(admittedName);
+						LOG_INFO(Net,
+							"[ServerApp] Nom personnage recupere du registre d'admission (character_key={}, name=\"{}\")",
+							acceptedClient.persistenceCharacterKey, acceptedClient.characterName);
+					}
+				}
+				if (acceptedClient.gender.empty())
+				{
+					std::string admittedGender = m_admittedRegistry->AdmittedGender(
+						acceptedClient.persistenceCharacterKey, nowMs);
+					if (!admittedGender.empty())
+					{
+						acceptedClient.gender = std::move(admittedGender);
+						LOG_INFO(Net,
+							"[ServerApp] Genre personnage recupere du registre d'admission (character_key={}, gender=\"{}\")",
+							acceptedClient.persistenceCharacterKey, acceptedClient.gender);
+					}
 				}
 			}
 		}
@@ -3839,6 +3860,9 @@ namespace engine::server
 			// avec le vrai nom au lieu du fallback "P<clientId>". Vide si la DB n'a pas pu
 			// servir (Windows / DB indisponible), le client retombe sur "P<clientId>".
 			outEntity.characterName = client->characterName;
+			// TD.6 : genre du perso (migration 0067, "male"/"female") → le client sélectionne
+			// le bon mesh skinné pour l'avatar distant. Vide = fallback "male" côté rendu.
+			outEntity.gender = client->gender;
 			return true;
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -103,6 +103,11 @@ namespace engine::server
 		/// SnapshotEntity pour ce client → les avatars distants peuvent afficher le vrai
 		/// nom dans leur plaque (au lieu du fallback "P<clientId>").
 		std::string characterName;
+		/// TD.6 — genre du personnage ("male"/"female", cf. migration 0067). Même chaîne
+		/// d'acquisition que `characterName` : LoadSpawnFromDb avec pool DB, sinon via
+		/// AdmittedCharacterRegistry::AdmittedGender. Recopié dans chaque SnapshotEntity
+		/// pour permettre au client de sélectionner le mesh skinné des avatars distants.
+		std::string gender;
 		uint32_t experiencePoints = 0;
 		uint32_t gold = 0;
 		/// M35.1 — additional currencies (wallet); gold remains primary trade currency.
@@ -303,7 +308,8 @@ namespace engine::server
 		/// `name` pour le porter dans le SnapshotEntity (plaque de nom des avatars distants).
 		/// Renvoie false si pas de pool DB (Windows / DB non configurée) ou si character
 		/// introuvable ; dans ce cas les out-params ne sont pas modifiés.
-		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg, std::string& outName);
+		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
+		std::string& outName, std::string& outGender);
 
 		/// Accept a new client or refresh an existing handshake.
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).


### PR DESCRIPTION
## Contexte

Préparation de **PR B (rendu skinné des avatars distants)** en ajoutant le genre du personnage à la chaîne de transport. Cette PR change uniquement la propagation des données ; le rendu reste sur le placeholder. PR B (à suivre) consommera le genre pour sélectionner `Male_Ranger.glb` / `Female_Ranger.glb` via `SkinnedRenderer`.

## Pattern réutilisé

Identique à TD.5 (PR #711 + #713 pour `characterName`) :

```
DB master.characters.gender (migration 0067)
       ↓ CharacterEnterWorldHandler SELECT
       ↓ BuildAdmitCharacterPacket (master→shard TCP)
       ↓ ShardToMasterClient::AdmitCharacterCallback
       ↓ AdmittedCharacterRegistry::Admit
       ↓ ServerApp::HandleHello fallback (mode no-DB)
       ↓ ConnectedClient.gender
       ↓ TryBuildSnapshotEntity copie dans SnapshotEntity.gender
       ↓ EncodeSnapshot → wire UDP
       ↓ DecodeSnapshot côté client
       ↓ UIModelBinding::ApplySnapshot copie dans UIRemoteEntity.gender
```

## Changements wire

**UDP gameplay (client ↔ shard)** — kProtocolVersion **6 → 7**

Chaque `SnapshotEntity` gagne une seconde chaîne préfixée u16 (genre) **après** `characterName`. Min payload/entité : 54 → **56 octets** (nom et genre vides). Borne dure côté décodeur : 8 octets (cf. `VARCHAR(8)` en DB).

**TCP master ↔ shard (AdmitCharacter, opcode 199)** — backward compat

Payload étend `(account_id, character_id, character_name)` → `(account_id, character_id, character_name, gender)`. `ParseAdmitCharacterPayload` lit le genre seulement si `Remaining() > 0`, donc un shard neuf accepte un master legacy (gender = "" → fallback "male" côté rendu).

## Tests

- `TestSnapshotRoundTripWithPlayerClientId` étendu : 2 joueurs avec genre `"male"`/`"female"`, 1 mob avec genre vide. Round-trip + assertions complètes.
- `TestSnapshotRejectsTruncatedPayload` ajusté pour le nouveau seuil (56 octets/entité).
- `TestAdmitWithGender` + `TestReAdmitWithoutGenderPreservesGender` ajoutés dans `AdmittedCharacterRegistryTests`.
- Surcharges legacy de `Admit` (3 et 4 args) **préservées** → `ShardTicketHandshakeHandler` (ticket TCP avant EnterWorld, ni nom ni genre) compile sans modif.

Compilé + run local : 9/9 tests registry verts (les 2 nouveaux compris).

## Logs visibles après déploiement

```
[CharacterEnterWorldHandler] -> SELECT ... gender FROM characters ... (master)
[ShardToMasterClient] AdmitCharacter received (... name='homme', gender='male')
[ShardMain] Admit pushed by master (... name='homme', gender='male', nowMs=...)
[ServerApp] Spawn position chargee depuis la DB (... name="homme", gender="male", ...)
// mode no-DB :
[ServerApp] Genre personnage recupere du registre d'admission (... gender="male")
```

## Pas dans cette PR

Le rendu des avatars distants reste sur `avatar_placeholder.mesh`. Le consommation effective du genre via `SkinnedRenderer` (refactor fan-out 1 → N avatars/frame, sélection mesh par genre, animation dérivée de la vélocité) viendra dans **PR B** dédiée.

## Déploiement

> **Déploiement** : ⚠️ **redéploiement serveur (master + shard) requis en lock-step** + **redéploiement client requis**. Wire UDP bumpé (v6→v7) : un client ancien face à un shard neuf (ou inverse) sera rejeté par `DecodeHeader`. La compat backward sur AdmitCharacter (master↔shard) protège seulement contre un master ancien face à un shard neuf, pas l'inverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_