### PR TITLE
ops(deploy): TD.10 — TZ=Europe/Paris sur master + shard

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -96,6 +96,12 @@ services:
       - ./config/smtp.local.json:/app/smtp.local.json:ro
       - ./game/data:/app/game/data:ro
       - ./data/logs/master:/app/logs
+    environment:
+      # TD.10 — fuseau horaire des logs aligné sur la zone d'exploitation (FR/CEST).
+      # Sans cette variable, les containers Ubuntu 24.04 utilisent UTC par défaut →
+      # les timestamps serveur sont décalés de 1-2 h vs ceux du client Windows, ce qui
+      # complique la corrélation cross-machine. La valeur est surchargeable via .env.
+      TZ: ${TZ:-Europe/Paris}
     # HTTP 3842 (/healthz) : le TCP 3840 est le protocole jeu ; nc -z le pollue dans les logs NetServer.
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3842/healthz"]
@@ -142,6 +148,8 @@ services:
       - ./data/persistence/characters:/app/game/data/persistence/characters:rw
       - ./data/logs/shard:/app/logs
     environment:
+      # TD.10 — fuseau horaire aligné sur le master (cf. service master ci-dessus).
+      TZ: ${TZ:-Europe/Paris}
       SHARD_REGISTER_ENDPOINT: ${SHARD_REGISTER_ENDPOINT:-127.0.0.1:3843}
       # TB.1/TE.3 : endpoint UDP gameplay annonce aux clients via le master
       # (SERVER_LIST). Vide => non annonce (clients ne pourront pas se connecter


### PR DESCRIPTION
## Contexte

Décalage de 1-2 h observé entre les timestamps serveur (containers Docker) et ceux du client Windows :

```
shard:  [27/05/2026][10:34:30][INFO][AntiCheat] runtime configured
client: [27/05/2026][12:35:37][INFO][Core] [Boot] Log initialized
```

Sans variable `TZ` explicite, les containers Ubuntu 24.04 tournent en **UTC** par défaut. Le client Windows est en **CEST (UTC+2)**. Différence = 2 h → correlation cross-machine pénible au débogage.

## Fix

Ajoute `TZ: ${TZ:-Europe/Paris}` aux services `master` et `shard` dans `docker-compose.yml`. Surchargeable via `.env` si déploiement dans une autre zone.

```yaml
master:
  environment:
    TZ: ${TZ:-Europe/Paris}

shard:
  environment:
    TZ: ${TZ:-Europe/Paris}
    SHARD_REGISTER_ENDPOINT: ...
```

## Pas modifié

- **mysql** : timezone DB sensible (colonnes DATETIME, `SELECT NOW()`). On garde UTC pour éviter des écarts entre données persistées vs récupérées. Si voulu plus tard : passer aussi à Europe/Paris **et** rejouer un audit des migrations.
- **web-portal** / **phpmyadmin** : moins critiques pour la corrélation logs côté C++.

## Déploiement

> **Déploiement** : ✅ **non urgent**, cosmétique. Applicable au prochain `docker compose up -d --force-recreate master shard`. Aucun changement de code, aucun changement wire. Pas de risque de régression.

Vérification post-redéploiement :
```bash
docker logs lcdlln-shard 2>&1 | grep "AntiCheat.*configured"
# Doit afficher un timestamp aligné avec date locale (heure de Paris)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Koy443mw7sFpAuWpMq2Cdg)_