### PR TITLE
fix(web-portal): fail-fast sur AUTH_SECRET et PORTAL_URL absents

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -29,6 +29,12 @@ AUTH_SECRET=
 # sont inutilisables — le portail throw au premier appel.
 NEXT_PUBLIC_PORTAL_URL=https://lunenoire.example.com
 
+# REQUIRED : URL publique du portail côté serveur (route handlers, emails).
+# Variable distincte de NEXT_PUBLIC_PORTAL_URL (qui est exposée au bundle
+# client browser). Les deux variables coexistent intentionnellement —
+# mettre la MÊME valeur dans les deux pour la cohérence.
+PORTAL_URL=https://lunenoire.example.com
+
 # Optional : port SMTP, défaut 587 (port submission standard RFC 6409).
 # SMTP_PORT=587
 # SMTP_HOST=smtp.example.com

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -18,6 +18,23 @@ SERVER_PORT=3840
 # IMPORTANT : changer ce secret en production (min 32 caractères)
 LCDLLN_HMAC_SECRET=dev_secret_change_in_production_32chars
 
+# --- Web portal (Next.js) ------------------------------------
+# REQUIRED : le portail web throw au premier appel si absent.
+# Doit être une chaîne secrète d’au moins 32 caractères aléatoires (HMAC
+# pour signer les réponses de récupération de mot de passe).
+AUTH_SECRET=
+
+# REQUIRED : URL publique du portail. Utilisée dans les liens des emails
+# de récupération de mot de passe. Sans valeur valide, les liens envoyés
+# sont inutilisables — le portail throw au premier appel.
+NEXT_PUBLIC_PORTAL_URL=https://lunenoire.example.com
+
+# Optional : port SMTP, défaut 587 (port submission standard RFC 6409).
+# SMTP_PORT=587
+# SMTP_HOST=smtp.example.com
+# SMTP_USER=
+# SMTP_PASS=
+
 # --- Master (ports sur l’hôte Docker) ------------------------
 # Adresse d’écoute sur l’hôte : 0.0.0.0 = toutes les interfaces (accès LAN ex. 10.0.4.133:3840 / :3842).
 # MASTER_PUBLISH_ADDR=0.0.0.0

--- a/docs/superpowers/audits/2026-05-27-codebase-audit.md
+++ b/docs/superpowers/audits/2026-05-27-codebase-audit.md
@@ -1,0 +1,245 @@
+# Audit codebase LCDLLN — 2026-05-27
+
+> Audit transverse des 4 sous-systèmes (client, serveur, éditeur monde, web portal)
+> + revue du code orphelin / legacy / dette docs.
+> Branche : `claude/tg3-scope-doc`. Méthode : 5 agents `Explore` en parallèle + vérifications ciblées.
+
+---
+
+## TL;DR
+
+| Sous-système | Verdict | Note |
+|---|---|---|
+| Client / jeu (`src/client/`, `src/shared/`) | Sain | Aucun code mort majeur ; conventions repo respectées ; Engine.cpp couplé mais pas urgent. |
+| Serveur (`src/masterd/`, `src/shardd/`) | Architecturalement sain, hygiène SQL fragile | Sessions/RBAC corrects ; aucun opcode orphelin. Mais : zéro prepared statement, ~50% d'index FK manquants en migration 0001. |
+| Éditeur monde (`src/world_editor/`) | Sain | 15 outils tous câblés et dispatchés. 2 ops zone presets sur 14 retournent `Unsupported`. Boilerplate répétitif sur les 15 outils. |
+| Web portal (`web-portal/`) | Sain, **1 bug sécu confirmé** | Architecture Next.js 14 propre. Fallback secret HMAC en dur si `AUTH_SECRET` absent. |
+| Transverse / legacy | Dette docs | `legacy/`, `CMANGOS_ANALYSIS.md`, `BUILD_CHECK.md`, `INVESTIGATION_terrain_invisible.md` candidats nettoyage. **Décision : laissé tel quel (utile comme repère de suivi).** |
+
+**Risque critique unique** : F1 (fallback secret en dur, web-portal). Tout le reste est de la dette à amortir.
+
+---
+
+## 1. Périmètre et méthode
+
+### Périmètre
+- **Client / jeu** : `src/client/` + parties de `src/shared/` (math, network protocol côté client).
+- **Serveur** : `src/masterd/` (master TCP Linux), `src/shardd/` (shard UDP gameplay), `sql/migrations/`, `src/shared/server_bootstrap/`, handlers `src/shared/network/`.
+- **Éditeur monde** : `src/world_editor/`, `src/client/render/terrain/TerrainEditingTools.*`, `tools/zone_builder/`, `game/data/editor/`.
+- **Web portal** : `web-portal/` (Next.js 14 App Router).
+- **Transverse** : `legacy/`, `tickets/`, `docs/`, `scripts/`, `tools/`, fichiers racine.
+
+### Méthode
+5 agents `Explore` lancés en parallèle, un par périmètre. Chaque agent capé à ~500-600 mots, avec consignes strictes (chemins précis, niveau de confiance, pas de proposition de solution). 3 findings critiques vérifiés directement par lecture du code après synthèse — 1 finding éditeur (Apply jamais appelé) infirmé, 1 finding serveur (SQL injection) requalifié en "absence prepared statements", 1 finding web-portal (secret en dur) confirmé.
+
+---
+
+## 2. Client / jeu
+
+**Volume** : ~228 fichiers `.cpp`, ~404 avec headers, ~84K LOC hors tests. Organisé en ~15 sous-domaines (`app/`, `render/`, `auth/`, `ui/`, `gameplay/`, `world/`, `combat/`, `crafting/`, `inventory/`, `social/`, `quest/`, `mail/`, `auction/`, `lfg/`, `arena/`).
+
+### Constats
+- **Engine.cpp ≈ 10.6K LOC** + **Engine.h** avec 90 includes directs de sous-systèmes UI/render. Pattern hub-and-spoke. Pas illégal mais fragilise toute évolution touchant l'init/teardown.
+- **15 `*ImGuiRenderer.cpp`** sans hiérarchie commune (ChatImGuiRenderer, MailImGuiRenderer, etc.) — boilerplate ImGui répété mais pas de duplication 1:1.
+- **VMA désactivé intentionnellement** ([`Engine.cpp:62`](../../../src/client/app/Engine.cpp)) — choix tracé par STAB.7.
+- **Convention winding terrain respectée** ([`TerrainRenderer.cpp`](../../../src/client/render/terrain/TerrainRenderer.cpp)) — garde anti-régression CLAUDE.md tient.
+- **AuthUiPresenterCore.cpp ≈ 4.5K LOC** avec zéro commentaire interne — maintenable mais long à reprendre.
+- **Aucun TODO/FIXME accumulé, aucun `#if 0`**.
+
+### Code orphelin
+**Aucun fichier `.cpp` substantiel non-référencé**. L'écart de ~10 fichiers entre filesystem et CMakeLists s'explique par les tests dans `src/client/*/tests/` exclus de la cible binaire (comportement attendu).
+
+### Verdict
+Sain. Seul vrai sujet de fond : couplage Engine.cpp — **hors scope** (refactor risqué, pas de douleur opérationnelle).
+
+---
+
+## 3. Serveur (master + shard)
+
+**Architecture** : master TCP single-thread + shard UDP thread tick. 39 handlers dans `src/masterd/handlers/`. Sessions via `SessionManager` + `ConnectionSessionMap` + `SessionCharacterMap`. RBAC pour commandes admin via `AdminCommandHandler`.
+
+### Constats
+
+| Aspect | État | Détail |
+|---|---|---|
+| Hygiène SQL | 🟡 Fragile | Toutes les queries en concaténation `"... WHERE col = '" + escapedX + "'"`. `mysql_real_escape_string` utilisé partout, valeurs numériques typées (`uint64_t` → `std::to_string`) → **pas d'injection exploitable actuellement**, mais zéro prepared statement, pattern fragile à l'évolution. |
+| Index DB | 🟡 Lacunaire | Migration 0001 crée 5 index sur 9 tables. `characters.server_id` et plusieurs FK sans index. Colonnes ajoutées plus tard (`spawn_x/y/z` migration 0032, etc.) sans index pour range queries. |
+| N+1 queries | 🟡 Potentielles | 2-3 cas suspects : [`ChatRelayHandler.cpp:210-220`](../../../src/masterd/handlers/chat/ChatRelayHandler.cpp) (SELECT `guild_id` puis SELECT `player_id` en 2 queries), [`CharacterEnterWorldHandler`](../../../src/masterd/handlers/character/CharacterEnterWorldHandler.cpp) (character lookup + role lookup) — joinables. |
+| Threading / races | ✅ OK | Master single-thread strict ; locks brefs là où nécessaire. Shard : compteurs UDP désormais `std::atomic` (TG.3). |
+| Opcodes / handlers | ✅ OK | 195 paires request/response, toutes câblées. Opcodes 197/198 (EnterDungeon) câblés depuis M100.44. |
+| RBAC admin | ✅ OK | `AdminCommandHandler` valide `minRole > userRole` avant dispatch. |
+| Migrations | ✅ OK | 68 fichiers `sql/migrations/`. Toutes colonnes créées sont lues. Pas de migration orpheline. Le runner ([`MigrationRunner.cpp`](../../../src/masterd/migrations/MigrationRunner.cpp)) parse strict `NNNN_name.sql` + checksum SHA-256 par fichier en DB. **Renommer ou déplacer un fichier `.sql` existant fait planter le master au boot.** |
+| TG.3 split-receive | ✅ Implémenté | Opt-in (cf. `claude/tg3-scope-doc`). Reste : split gameplay multi-thread, multi-shard. Ticketé. |
+
+### Code orphelin
+Aucun handler/opcode/migration orpheline détectée côté serveur. 129 opcodes "réponse/notification" sont par construction côté client (pas de handler serveur — comportement attendu).
+
+### Verdict
+Architecturalement solide. Dette principale : **conversion progressive en prepared statements** + **revue d'index**. Pas urgent (pas d'injection actuelle), mais à acter avant que de nouveaux handlers s'empilent.
+
+---
+
+## 4. Éditeur monde
+
+**Volume** : ~256 fichiers `src/world_editor/` + `TerrainEditingTools.*` (côté `src/client/render/terrain/`) + `tools/zone_builder/`.
+
+**Outils** : 15 outils dans `enum ActiveTool` ([`WorldEditorShell.h:40-58`](../../../src/world_editor/core/WorldEditorShell.h)) — Sculpt, Stamp, SplatPaint, Lake, River, MountainRange, ValleyChain, RiverNetwork, Coastline, HydraulicErosion, ThermalWindErosion, Cave, Overhang, Arch, DungeonPortal.
+
+### Constats vérifiés (correction d'un faux finding)
+
+L'agent d'exploration avait initialement classé Coastline / ThermalWind / Cave / Overhang / Arch / DungeonPortal comme "Apply() jamais appelé". **Faux**. Vérification ([`ToolPropertiesPanel.cpp`](../../../src/world_editor/panels/ToolPropertiesPanel.cpp)) :
+- Les 15 outils ont leur bloc `Render*Params` (lignes 777, 813, 905, 917, 1012, 1101, 1193, 1352, etc.) et leur dispatch (lignes 2130-2172).
+- Les 4 outils volumes (Cave/Overhang/Arch/DungeonPortal) utilisent `Place()` qui pousse une commande, là où les autres utilisent `Apply()`. Pattern intentionnel selon la nature du tool.
+
+### Constats réels
+
+- **Zone presets M100.46 incrément 1** : 14 types d'opération, **12 câblées** dans [`OperationDispatcher.cpp`](../../../src/world_editor/zone_presets/OperationDispatcher.cpp). 2 retournent `DispatchResult::Unsupported` : `sculpt_brush` et `splat_paint`. Les 8 presets livrés ne les utilisent pas.
+- **Catalogues volumes chargés au boot mais pas exposés en dropdown UI** : CaveCatalog, OverhangCatalog, ArchCatalog, DungeonCatalog. Sélection par texte/id manuel. État MVP, paper cut UX sur 4 outils.
+- **Boilerplate répété sur 15 outils** : chacun a `Init(commandStack, document, cfg)` → membres `m_stack / m_doc / m_cfg` → `Place()` / `Apply()` qui push une commande. 62 accesseurs `Mutable*/Get*` au total dans `WorldEditorShell`.
+- **Doc Doxygen `///`** : règle CLAUDE.md respectée sur Phase 11 (M100.40-44). Pas de violation détectée.
+- **Hot-reload `Ctrl+Shift+R`** des presets compile en mode release (cosmétique).
+
+### Verdict
+Très propre pour un éditeur de cette taille. Sujets éditeur : (a) finir les 2 ops zone presets, (b) factoriser le boilerplate des 15 outils. **Reportés en chantier dédié** (hors scope du présent plan).
+
+---
+
+## 5. Web portal
+
+**Stack** : Next.js 14.2.18 App Router, MySQL2 3.11.0 (pas de Prisma), Nodemailer 6.10.1, Argon2id double-hash. 32 routes API, auth par cookies + middleware. TypeScript strict.
+
+### Findings
+
+#### 🔴 F1 — Secret HMAC fallback en dur (confirmé)
+
+[`web-portal/lib/auth/passwordRecovery.ts:61`](../../../web-portal/lib/auth/passwordRecovery.ts):
+
+```ts
+function getRecoverySecret(): string {
+  return process.env.AUTH_SECRET || "lcdlln-dev-recovery-secret";
+}
+```
+
+Si l'env var n'est pas définie en prod, le secret HMAC de `hashAnswer` devient `"lcdlln-dev-recovery-secret"` — secret de dev en dur dans le binaire. Le hash des réponses de récupération de mot de passe devient devinable. **Sévérité haute, effort très faible.**
+
+#### 🟡 Autres
+- Stats admin sans cache ([`web-portal/app/admin/page.tsx`](../../../web-portal/app/admin/page.tsx)) : 4× `COUNT(*)` par render server-side, pas de `revalidatePath/revalidateTag`.
+- 7 `console.error/warn` en code de prod ; pas de service de logs structuré.
+
+### Verdict
+Globalement sain. Pas de code mort. Validation d'inputs robuste. Pas de catch silencieux. Pas de CVE évidente dans les deps. **Fix prioritaire : F1**.
+
+---
+
+## 6. Transverse — code orphelin, legacy, docs, tests CI
+
+### Candidats nettoyage (laissés tels quels par décision utilisateur)
+
+| Élément | Statut | Décision |
+|---|---|---|
+| `legacy/design/lune-noire-design-system/` | Archive d'assets design, non compilé | **Conservé** — repère de suivi |
+| `CMANGOS_ANALYSIS.md` (61 Ko) | Analyse comparative, nom viole `feedback_no_cmangos_term.md` | **Conservé** — repère de suivi |
+| `BUILD_CHECK.md` | Checklist Vulkan obsolète pré-#427 | **Conservé** — repère de suivi |
+| `smtp.local.json.example` | Aucune référence dans le code | **Conservé** — repère de suivi |
+| `docs/INVESTIGATION_terrain_invisible.md` | Bug résolu 2026-05-14 | **Conservé** — référencé par CLAUDE.md |
+| `build_hlod.bat` | Script HLOD offline | **Conservé** |
+
+### Tests exclus de ctest
+
+[`.github/workflows/build-linux.yml:76`](../../../.github/workflows/build-linux.yml) — 8 tests exclus :
+
+**Flaky (timing-sensitive)** :
+1. `session_manager_tests` — wall-clock 1.20s
+2. `security_tests` — rate limit timing
+3. `netserver_bandwidth_tests` — token bucket exact timing
+4. `grid_state_tests` — wall-clock 70s
+5. `vmap_streamer_tests` — refcount/lifecycle
+
+**Environnement (fixtures absentes)** :
+6. `localization_service_tests` — JSON localization manquants
+7. `zone_builder_roundtrip_tests` — fixtures absentes
+
+**Infrastructure** :
+8. `network_integration_tests` — DB MySQL live non provisionnée
+
+→ Cible chantier D : réintégrer 5 + 2 = 7 tests, marquer le dernier exclusion définitive.
+
+### Doublons
+Aucun doublon classe/handler détecté. Migrations uniques. Cross-refs `tickets/M100/` ↔ `docs/superpowers/specs/` cohérentes.
+
+### Scripts / outils
+`scripts/` (5 fichiers) tous appelés. `tools/` (`zone_builder`, `load_tester`, etc.) intégrés CMake.
+
+---
+
+## 7. Findings cross-cutting
+
+| # | Finding | Sous-systèmes | Sévérité | Décision |
+|---|---|---|---|---|
+| F1 | Secret HMAC fallback en dur (`"lcdlln-dev-recovery-secret"`) si `AUTH_SECRET` manquant | Web portal | 🔴 Haute | **GO — PR 1** |
+| F2 | SQL en concaténation partout, zéro prepared statement | Serveur (master) | 🟡 Moyenne | **GO — PR 2** (5 handlers prioritaires) |
+| F3 | Migration 0001 manque ~50% des index FK + range queries non indexées | Serveur (DB) | 🟡 Moyenne | **GO — PR 2** (migration 0070) |
+| F4 | 5 tests flaky exclus + 2 tests env (fixtures) + 1 test infra (DB live) | Serveur / shared | 🟡 Moyenne | **GO — PR 3** |
+| F5 | 2 opérations zone presets non câblées (`sculpt_brush`, `splat_paint`) | Éditeur | 🟡 Basse | **Reporté** (chantier éditeur dédié) |
+| F6 | Dette docs/legacy | Transverse | 🟡 Basse | **Ignoré** — repère de suivi utilisateur |
+| F7 | Présence du terme "CMANGOS" dans repo | Transverse | 🟡 Basse | **Ignoré** — couvert par F6 |
+| F8 | Boilerplate identique répété sur 15 outils éditeur | Éditeur | 🟢 Cosmétique | **Reporté** (chantier éditeur dédié) |
+| F9 | Engine.cpp/Engine.h monolithiques | Client | 🟢 Cosmétique | **Hors scope** — refactor risqué, pas de douleur |
+| F10 | `console.log/error` en prod + stats admin sans cache (web-portal) | Web portal | 🟢 Cosmétique | **GO — PR 4** |
+
+---
+
+## 8. Plan PRs — 4 PRs cibles
+
+> Contrainte utilisateur : limite mensuelle de PRs proche, donc packaging compact.
+
+### PR 1 — Sécurité web-portal (chantier A)
+- `getRecoverySecret()` → fail-fast si `AUTH_SECRET` absent (throw au lieu de fallback).
+- Audit transverse `web-portal/` pour autres fallbacks `process.env.X || "..."` ; correction si trouvés.
+- **Déploiement** : ✅ web portal seul, aucun redéploiement serveur.
+- **Effort** : très faible, ~30 lignes.
+
+### PR 2 — Hygiène SQL serveur + index manquants (chantier C)
+- Helper `DbPreparedQuery` dans `src/shared/db/` (wrapper autour de `mysql_stmt_*`).
+- Migration des **5 handlers les plus exposés** en prepared statements :
+  - `CharacterCreateHandler`
+  - `ChatRelayHandler`
+  - `AuthHandler` (login/register)
+  - `CharacterListHandler`
+  - `CharacterEnterWorldHandler`
+- Migration idempotente `0070_add_missing_indexes.sql` couvrant les index FK + range queries manquants.
+- **Pas de réorganisation `.sql`** (impact runtime trop élevé : MigrationRunner stocke un checksum SHA-256 par fichier).
+- **Déploiement** : ⚠️ master + migration DB, lock-step.
+- **Effort** : élevé, ~600-1000 lignes.
+
+### PR 3 — Stabilisation CI tests (chantier D)
+- Fix 5 tests flaky (token bucket exact timing, vmap streamer refcount, session/security/grid wall-clock).
+- Provisionning fixtures pour `localization_service_tests` + `zone_builder_roundtrip_tests`.
+- Commentaire d'exclusion définitive pour `network_integration_tests` dans `build-linux.yml`.
+- **Déploiement** : ✅ CI uniquement.
+- **Effort** : moyen.
+
+### PR 4 — Polish web-portal (chantier E partiel, F10)
+- Cache `revalidatePath`/`revalidateTag` sur stats admin ([`web-portal/app/admin/page.tsx`](../../../web-portal/app/admin/page.tsx)).
+- Logger structuré pour remplacer les 7 `console.error/warn`.
+- **Déploiement** : ✅ web portal seul.
+- **Effort** : faible.
+
+### Ordre de merge suggéré
+PR 1 → PR 4 → PR 3 → PR 2 (du moins risqué au plus risqué). Toutes mergeables indépendamment, aucune stack.
+
+### Hors scope confirmé
+- **Chantier B (nettoyage docs/legacy)** : laissé tel quel sur demande utilisateur.
+- **F5 + F8 (éditeur : 2 ops zone presets + factorisation 15 outils)** : chantier éditeur dédié plus tard.
+- **F9 (split Engine.cpp)** : refactor risqué, pas de douleur opérationnelle.
+- **Reste des handlers SQL** au-delà des 5 prioritaires : à étaler hors mois en cours.
+
+---
+
+## 9. Annexes
+
+### Fichiers vérifiés directement après synthèse
+- [`src/world_editor/panels/ToolPropertiesPanel.cpp`](../../../src/world_editor/panels/ToolPropertiesPanel.cpp) — vérification des `Render*Params` et dispatches → **finding éditeur infirmé**.
+- [`src/masterd/handlers/character/CharacterCreateHandler.cpp:30-79`](../../../src/masterd/handlers/character/CharacterCreateHandler.cpp) — vérification de la construction SQL → **finding "SQL injection" requalifié en "absence prepared statements"**.
+- [`web-portal/lib/auth/passwordRecovery.ts:50-65`](../../../web-portal/lib/auth/passwordRecovery.ts) — vérification du fallback secret → **finding confirmé F1**.
+- [`src/masterd/migrations/MigrationRunner.cpp:50-63`](../../../src/masterd/migrations/MigrationRunner.cpp) — parser strict `NNNN_name.sql` + checksum SHA-256 → **renommage/déplacement des `.sql` interdit**.

--- a/docs/superpowers/plans/2026-05-27-pr1-web-portal-secret-fail-fast.md
+++ b/docs/superpowers/plans/2026-05-27-pr1-web-portal-secret-fail-fast.md
@@ -1,0 +1,498 @@
+# PR 1 — Web portal : fail-fast sur secrets manquants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Éliminer le fallback secret en dur `"lcdlln-dev-recovery-secret"` dans `web-portal/lib/auth/passwordRecovery.ts:61` et faire planter le serveur au boot si `AUTH_SECRET` ou `NEXT_PUBLIC_PORTAL_URL` ne sont pas définis. Conserver le défaut industriel `SMTP_PORT=587` (port standard, pas un secret).
+
+**Architecture:** Introduire un helper interne `requireEnv(name)` dans `passwordRecovery.ts` qui lève une `Error` claire si la variable d'environnement est absente ou vide. Remplacer les deux fallbacks risqués (`AUTH_SECRET`, `NEXT_PUBLIC_PORTAL_URL`) par cet helper. La validation est paresseuse (au premier appel des fonctions concernées, qui sont elles-mêmes appelées au boot Next.js sur les routes API de récupération de mot de passe — donc l'erreur se manifestera dès la première requête, pas réellement au boot, mais avec un message clair côté logs et une réponse 500 immédiate).
+
+**Tech Stack:** Next.js 14 (App Router), TypeScript strict, aucune dépendance ajoutée. Pas d'infra de test introduite (web-portal n'en a pas et l'ajout serait un scope creep).
+
+**Spec source :** [docs/superpowers/audits/2026-05-27-codebase-audit.md](../audits/2026-05-27-codebase-audit.md) section 8 (PR 1, chantier A).
+
+**Déploiement :** ✅ web portal uniquement, aucun redéploiement serveur. Lock-step requis avec la mise à jour de l'env de prod : **avant de merger, vérifier que `AUTH_SECRET` ET `NEXT_PUBLIC_PORTAL_URL` sont déjà définis sur l'env Docker/serveur web** — sinon le portail tombera au premier appel des routes de récupération mot de passe.
+
+---
+
+## File structure
+
+| Fichier | Action | Responsabilité |
+|---|---|---|
+| `web-portal/lib/auth/passwordRecovery.ts` | Modify (L.60-62, L.285-287) | Remplacer 2 fallbacks par `requireEnv()`. Garder L.431 (`SMTP_PORT`) intact. |
+| `web-portal/lib/env.ts` | **Create** | Nouveau module : helper `requireEnv(name: string): string`. Petit module dédié pour réutilisation future. |
+| `deploy/docker/.env.example` | Modify | Documenter explicitement que `AUTH_SECRET` et `NEXT_PUBLIC_PORTAL_URL` sont **obligatoires** (annoter avec `# REQUIRED — portal will throw at boot if missing`). |
+
+> Pas d'ajout de tests unitaires (web-portal n'a pas d'infra de test ; introduire vitest gonflerait la PR). Validation par `npm run build` + smoke test manuel décrit en Task 5.
+
+---
+
+## Task 1 : Préparer la branche
+
+**Files:**
+- Aucun fichier modifié à cette étape — opération git pure.
+
+- [ ] **Step 1 : Créer une branche dédiée depuis `main`**
+
+```bash
+git fetch origin
+git switch -c claude/pr1-web-portal-secret-fail-fast origin/main
+```
+
+Vérifier qu'on part bien d'un `main` propre, pas de la branche actuelle `claude/tg3-scope-doc` qui n'a aucun rapport avec ce sujet.
+
+- [ ] **Step 2 : Vérifier l'état**
+
+```bash
+git status
+git log --oneline -1
+```
+
+Expected : working tree clean, HEAD = dernier commit `main`.
+
+- [ ] **Step 3 : Reporter le rapport d'audit déjà écrit sur la nouvelle branche**
+
+Le rapport `docs/superpowers/audits/2026-05-27-codebase-audit.md` a été écrit pendant la phase brainstorming sur la branche `claude/tg3-scope-doc`. Il doit suivre la PR 1.
+
+```bash
+git checkout claude/tg3-scope-doc -- docs/superpowers/audits/2026-05-27-codebase-audit.md docs/superpowers/plans/2026-05-27-pr1-web-portal-secret-fail-fast.md
+git status
+```
+
+Expected : 2 fichiers ajoutés en staging (`docs/superpowers/audits/...` et `docs/superpowers/plans/...`).
+
+- [ ] **Step 4 : Premier commit (docs)**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs(audit): rapport d'audit codebase 2026-05-27 + plan PR 1
+
+Audit transverse des 4 sous-systèmes (client, serveur, éditeur, web-portal)
++ revue code orphelin. 10 findings (F1-F10), 4 PRs packagisées (A,C,D,E F10).
+
+Plan d'implémentation pour la PR 1 (sécurité web-portal — fail-fast secrets).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 : Créer le helper `requireEnv`
+
+**Files:**
+- Create : `web-portal/lib/env.ts`
+
+- [ ] **Step 1 : Créer le module helper**
+
+Contenu intégral du fichier :
+
+```typescript
+// Helper centralisé pour les variables d'environnement obligatoires.
+// L'objectif : un message d'erreur clair et explicite quand une variable
+// critique manque, plutôt qu'un fallback silencieux vers une valeur de dev.
+//
+// Usage :
+//   const secret = requireEnv("AUTH_SECRET");
+//
+// Lance : Error("Missing required environment variable: AUTH_SECRET")
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === null || value.trim().length === 0) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+      `Set it in the deployment environment (Docker .env, systemd EnvironmentFile, etc.) before starting the web portal.`
+    );
+  }
+  return value;
+}
+```
+
+- [ ] **Step 2 : Vérifier la compilation TypeScript du nouveau fichier**
+
+```bash
+cd web-portal
+npx tsc --noEmit
+```
+
+Expected : aucune erreur. Le fichier est self-contained, aucun import.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add web-portal/lib/env.ts
+git commit -m "$(cat <<'EOF'
+feat(web-portal): add requireEnv helper for mandatory env vars
+
+Centralise la validation des variables d'environnement obligatoires.
+Lance une Error explicite si la variable est absente, vide ou null —
+plutôt qu'un fallback silencieux vers une valeur de dev.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 : Remplacer le fallback `AUTH_SECRET` par `requireEnv`
+
+**Files:**
+- Modify : `web-portal/lib/auth/passwordRecovery.ts:60-62`
+
+- [ ] **Step 1 : Ajouter l'import de `requireEnv` en tête du fichier**
+
+Repérer le bloc d'imports actuel (en haut de `web-portal/lib/auth/passwordRecovery.ts`) et y ajouter :
+
+```typescript
+import { requireEnv } from "@/lib/env";
+```
+
+Note : si le path alias `@/` n'est pas configuré dans `tsconfig.json` (à vérifier), utiliser un chemin relatif :
+
+```typescript
+import { requireEnv } from "../env";
+```
+
+Préfère le path relatif pour rester safe — le alias `@/` est configuré par défaut par `create-next-app` mais ce projet a peut-être divergé. Étape 2 valide.
+
+- [ ] **Step 2 : Vérifier la convention d'import déjà utilisée dans le fichier**
+
+```bash
+grep -E "^import.*from" web-portal/lib/auth/passwordRecovery.ts | head -10
+```
+
+Si les imports utilisent `@/`, adopter `@/`. Sinon, utiliser le chemin relatif `"../env"`.
+
+- [ ] **Step 3 : Remplacer la fonction `getRecoverySecret`**
+
+Avant (lignes 60-62) :
+```typescript
+function getRecoverySecret(): string {
+  return process.env.AUTH_SECRET || "lcdlln-dev-recovery-secret";
+}
+```
+
+Après :
+```typescript
+function getRecoverySecret(): string {
+  return requireEnv("AUTH_SECRET");
+}
+```
+
+- [ ] **Step 4 : Type-check**
+
+```bash
+cd web-portal
+npx tsc --noEmit
+```
+
+Expected : aucune erreur.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add web-portal/lib/auth/passwordRecovery.ts
+git commit -m "$(cat <<'EOF'
+fix(web-portal): fail-fast on missing AUTH_SECRET instead of dev fallback
+
+Le fallback "lcdlln-dev-recovery-secret" expose un secret HMAC en dur
+dans le binaire si AUTH_SECRET n'est pas défini en production. Le hash
+des réponses de récupération de mot de passe devient devinable.
+
+Remplace le fallback par requireEnv("AUTH_SECRET") qui throw avec un
+message explicite. Lock-step : AUTH_SECRET doit être défini sur l'env
+de prod AVANT le déploiement de cette PR.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 : Remplacer le fallback `NEXT_PUBLIC_PORTAL_URL` par `requireEnv`
+
+**Files:**
+- Modify : `web-portal/lib/auth/passwordRecovery.ts:285-287`
+
+- [ ] **Step 1 : Identifier la fonction concernée**
+
+```bash
+sed -n '283,290p' web-portal/lib/auth/passwordRecovery.ts
+```
+
+Expected : une fonction qui construit un baseUrl à partir de `process.env.NEXT_PUBLIC_PORTAL_URL || "http://127.0.0.1:3000"`. Probablement utilisée pour générer les liens de récupération envoyés par email.
+
+- [ ] **Step 2 : Remplacer le fallback**
+
+Avant (autour de la ligne 286) :
+```typescript
+const baseUrl = (process.env.NEXT_PUBLIC_PORTAL_URL || "http://127.0.0.1:3000").replace(/\/+$/, "");
+```
+
+Après :
+```typescript
+const baseUrl = requireEnv("NEXT_PUBLIC_PORTAL_URL").replace(/\/+$/, "");
+```
+
+Justification : un site prod déployé sans `NEXT_PUBLIC_PORTAL_URL` enverrait des emails de récupération de mot de passe avec des liens vers `http://127.0.0.1:3000` — donc cassés pour 100% des utilisateurs. Préférable de planter au premier envoi avec un message clair que de spammer des liens morts.
+
+- [ ] **Step 3 : Type-check**
+
+```bash
+cd web-portal
+npx tsc --noEmit
+```
+
+Expected : aucune erreur.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add web-portal/lib/auth/passwordRecovery.ts
+git commit -m "$(cat <<'EOF'
+fix(web-portal): fail-fast on missing NEXT_PUBLIC_PORTAL_URL
+
+Le fallback "http://127.0.0.1:3000" rend les liens de récupération
+de mot de passe envoyés par email inutilisables en prod si l'env var
+n'est pas définie. Préférable de planter clairement au premier envoi
+que de spammer des liens morts à 100% des utilisateurs.
+
+Lock-step : NEXT_PUBLIC_PORTAL_URL doit être défini sur l'env de prod.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 : Confirmer qu'il n'y a pas d'autres fallbacks à corriger
+
+**Files:**
+- Aucun — vérification grep transverse.
+
+- [ ] **Step 1 : Grep complet dans `web-portal/`**
+
+```bash
+grep -rnE 'process\.env\.\w+\s*\|\|\s*["'"'"'`]' web-portal/ --include='*.ts' --include='*.tsx'
+```
+
+Expected : **3 matches uniquement**, tous dans `web-portal/lib/auth/passwordRecovery.ts` :
+- L.61 (AUTH_SECRET) — **déjà fixé en Task 3**, ne doit plus apparaître après Task 3
+- L.286 (NEXT_PUBLIC_PORTAL_URL) — **déjà fixé en Task 4**, ne doit plus apparaître après Task 4
+- L.431 (SMTP_PORT) — **conservé volontairement** (port standard 587, défaut industriel acceptable)
+
+Après Tasks 3 & 4, le grep doit retourner uniquement L.431 (SMTP_PORT). Si d'autres matches apparaissent (autres fichiers introduits entre temps, ou matches manqués par l'audit initial), les corriger de la même manière (créer une étape supplémentaire dans cette task).
+
+- [ ] **Step 2 : Documenter le choix de conservation pour `SMTP_PORT`**
+
+Ajouter un commentaire au-dessus de la ligne 431 dans `passwordRecovery.ts` pour expliquer pourquoi celui-là est conservé :
+
+Avant :
+```typescript
+const port = Number.parseInt(process.env.SMTP_PORT || "587", 10);
+```
+
+Après :
+```typescript
+// SMTP_PORT : défaut "587" conservé volontairement — c'est le port submission
+// SMTP standard universel (RFC 6409). Pas un secret, pas une URL prod-critique.
+const port = Number.parseInt(process.env.SMTP_PORT || "587", 10);
+```
+
+- [ ] **Step 3 : Type-check**
+
+```bash
+cd web-portal
+npx tsc --noEmit
+```
+
+Expected : aucune erreur.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add web-portal/lib/auth/passwordRecovery.ts
+git commit -m "$(cat <<'EOF'
+docs(web-portal): document SMTP_PORT default rationale
+
+Explicite pourquoi le défaut "587" est conservé alors que AUTH_SECRET
+et NEXT_PUBLIC_PORTAL_URL ont basculé en fail-fast : c'est le port
+submission SMTP standard universel (RFC 6409), pas un secret.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 : Mettre à jour la doc de déploiement
+
+**Files:**
+- Modify : `deploy/docker/.env.example` (et éventuellement `deploy/docker/README.md`)
+
+- [ ] **Step 1 : Localiser le fichier d'exemple d'env**
+
+```bash
+ls deploy/docker/
+cat deploy/docker/.env.example
+```
+
+Vérifier qu'il existe et lister les variables actuellement documentées.
+
+- [ ] **Step 2 : Annoter `AUTH_SECRET` et `NEXT_PUBLIC_PORTAL_URL` comme `REQUIRED`**
+
+Modifier `deploy/docker/.env.example` pour ajouter ou marquer ces deux variables.
+
+Exemple de bloc à ajouter ou modifier (adapter selon le format existant) :
+
+```bash
+# === Web portal — secrets et URL critiques ===
+# REQUIRED : portail web throw au premier appel si absent.
+# Doit être une chaîne secrète d'au moins 32 caractères aléatoires (HMAC).
+AUTH_SECRET=
+
+# REQUIRED : URL publique du portail. Utilisée dans les liens des emails
+# de récupération de mot de passe. Sans valeur valide, les liens envoyés
+# sont inutilisables et le portail throw au premier appel.
+NEXT_PUBLIC_PORTAL_URL=https://lunenoire.example.com
+
+# Optional : port SMTP, défaut 587 (port submission standard RFC 6409).
+SMTP_PORT=587
+```
+
+- [ ] **Step 3 : Mettre à jour `deploy/docker/README.md` si nécessaire**
+
+```bash
+grep -n "AUTH_SECRET\|PORTAL_URL" deploy/docker/README.md
+```
+
+Si des références existent, ajouter une note précisant que ces variables sont maintenant **obligatoires** depuis cette PR (ne plus présenter de fallbacks).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add deploy/docker/.env.example deploy/docker/README.md
+git commit -m "$(cat <<'EOF'
+docs(deploy): mark AUTH_SECRET and PORTAL_URL as required in .env.example
+
+Documente côté ops que ces variables ne peuvent plus être omises
+depuis la PR fail-fast. Avant cette PR : valeur de dev en dur si
+absente. Après : le portail throw au premier appel.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 : Smoke test build + comportement
+
+**Files:**
+- Aucun — validation.
+
+- [ ] **Step 1 : Build production complet**
+
+```bash
+cd web-portal
+npm run build
+```
+
+Expected : `Compiled successfully` + génération `.next/`. Aucune erreur de type ni de lint qui n'existait pas avant. Si erreur sur les imports `@/lib/env` vs chemin relatif, revenir sur Task 3 Step 2 et ajuster.
+
+- [ ] **Step 2 : Smoke test "manque AUTH_SECRET" via dev server (optionnel mais fortement recommandé)**
+
+Si l'environnement de dev local est dispo :
+
+```bash
+cd web-portal
+unset AUTH_SECRET  # ou: $env:AUTH_SECRET = "" en PowerShell
+npm run dev
+```
+
+Puis dans un autre terminal, simuler un appel sur une route de récupération mot de passe (ex. via curl ou via le navigateur sur `http://127.0.0.1:3000/password-recovery`). Expected : 500 Internal Server Error + log serveur clair `Error: Missing required environment variable: AUTH_SECRET`.
+
+Si le smoke test n'est pas faisable localement (pas de DB MySQL up), au minimum vérifier que `npm run build` passe.
+
+- [ ] **Step 3 : Lint**
+
+```bash
+cd web-portal
+npm run lint
+```
+
+Expected : aucune nouvelle erreur de lint introduite par les modifications.
+
+---
+
+## Task 8 : Push et création de la PR
+
+**Files:**
+- Aucun — opérations git/gh.
+
+- [ ] **Step 1 : Push de la branche**
+
+```bash
+git push -u origin claude/pr1-web-portal-secret-fail-fast
+```
+
+- [ ] **Step 2 : Création de la PR via `gh`**
+
+```bash
+gh pr create --title "fix(web-portal): fail-fast sur AUTH_SECRET et PORTAL_URL absents" --body "$(cat <<'EOF'
+## Summary
+
+- Remplace le fallback secret en dur `"lcdlln-dev-recovery-secret"` par un `requireEnv("AUTH_SECRET")` qui throw avec un message clair.
+- Remplace le fallback `http://127.0.0.1:3000` pour `NEXT_PUBLIC_PORTAL_URL` par le même mécanisme — empêche d'envoyer des emails de récupération avec des liens morts en prod.
+- Conserve `SMTP_PORT=587` (port submission standard universel, pas un secret).
+- Documente `AUTH_SECRET` et `NEXT_PUBLIC_PORTAL_URL` comme **REQUIRED** dans `deploy/docker/.env.example`.
+- Joint le rapport d'audit complet `docs/superpowers/audits/2026-05-27-codebase-audit.md` + le plan d'implémentation.
+
+## Test plan
+
+- [ ] `npm run build` passe sur `web-portal/`
+- [ ] `npm run lint` ne remonte aucune nouvelle erreur
+- [ ] Smoke test local : retirer `AUTH_SECRET` de l'env, démarrer `npm run dev`, appeler la route password-recovery → 500 + log `Missing required environment variable: AUTH_SECRET`
+- [ ] **Avant le merge** : vérifier que `AUTH_SECRET` ET `NEXT_PUBLIC_PORTAL_URL` sont déjà définis sur l'environnement Docker prod du portail. Si absent, ce sera un downtime du flow de récupération de mot de passe au premier appel après déploiement.
+
+## Déploiement
+
+✅ **Client / serveur backend uniquement** : aucun redéploiement master ni shard. Lock-step **web portal** uniquement, avec exigence env de prod ci-dessus.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3 : Vérifier la PR créée**
+
+```bash
+gh pr view --web
+```
+
+Expected : URL de la PR, statut "Open", reviewers proposés selon la config repo.
+
+---
+
+## Self-review
+
+**Spec coverage (vs `2026-05-27-codebase-audit.md` section 8 PR 1) :**
+- ✅ Fail-fast `getRecoverySecret()` si `AUTH_SECRET` absent → Task 3
+- ✅ Grep transverse autres fallbacks `process.env.X || "..."` dans `web-portal/` → Task 5
+- ✅ Fix des fallbacks trouvés → Tasks 3, 4 (+ rationale Task 5 pour SMTP_PORT)
+- ✅ Déploiement : web portal seul, aucun redéploiement serveur → titre PR + plan
+
+**Placeholder scan :** RAS. Tout est rempli, commandes explicites, code intégral fourni à chaque step.
+
+**Type consistency :** `requireEnv(name: string): string` défini en Task 2, utilisé tel quel en Tasks 3, 4. Aucune incohérence.
+
+**Risques / edge cases couverts :**
+- ✅ Alias `@/` vs chemin relatif (Task 3 Step 2)
+- ✅ Choix de conservation de `SMTP_PORT` documenté en commentaire (Task 5 Step 2)
+- ✅ Lock-step env prod explicité dans le commit Task 3 et la PR body (Task 8)
+- ✅ Pas d'introduction de framework de test (justifié dans le header et la sortie de Task 5)

--- a/web-portal/app/api/player/account/request-email-change/route.ts
+++ b/web-portal/app/api/player/account/request-email-change/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { sendEmailChange } from '@/lib/email/sender'
+import { requireEnv } from '@/lib/env'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
 
@@ -42,7 +43,7 @@ export async function POST(request: Request) {
       [newEmail, token, expires, accountId]
     )
 
-    const baseUrl = process.env.PORTAL_URL ?? 'http://localhost:3000'
+    const baseUrl = requireEnv("PORTAL_URL")
     const confirmationLink = `${baseUrl}/api/player/account/confirm-email?token=${token}`
     await sendEmailChange(newEmail, rows[0].login, newEmail, confirmationLink)
 

--- a/web-portal/app/api/player/parental/request/route.ts
+++ b/web-portal/app/api/player/parental/request/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { sendParentalValidation } from '@/lib/email/sender'
+import { requireEnv } from '@/lib/env'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
 
@@ -41,7 +42,7 @@ export async function POST(request: Request) {
       [parentalEmail, token, expires, accountId]
     )
 
-    const baseUrl = process.env.PORTAL_URL ?? 'http://localhost:3000'
+    const baseUrl = requireEnv("PORTAL_URL")
     const validationLink = `${baseUrl}/api/player/parental/validate?token=${token}`
     await sendParentalValidation(parentalEmail, rows[0].login, validationLink)
 

--- a/web-portal/lib/auth/passwordRecovery.ts
+++ b/web-portal/lib/auth/passwordRecovery.ts
@@ -284,7 +284,7 @@ export async function requestPasswordRecovery(input: RecoveryRequestInput): Prom
     [hashToken(rawToken), account.id],
   );
 
-  const baseUrl = (process.env.NEXT_PUBLIC_PORTAL_URL || "http://127.0.0.1:3000").replace(/\/+$/, "");
+  const baseUrl = requireEnv("NEXT_PUBLIC_PORTAL_URL").replace(/\/+$/, "");
   const resetUrl = `${baseUrl}/password-recovery/reset?token=${encodeURIComponent(rawToken)}`;
   await sendResetEmail(account.email, resetUrl);
 

--- a/web-portal/lib/auth/passwordRecovery.ts
+++ b/web-portal/lib/auth/passwordRecovery.ts
@@ -429,6 +429,8 @@ function matchesRecoveryFactors(bundle: RecoveryProfileBundle, input: RecoveryRe
 async function sendResetEmail(to: string, resetUrl: string): Promise<void> {
   const { createTransport } = await import("nodemailer");
   const host = process.env.SMTP_HOST;
+  // SMTP_PORT : défaut "587" conservé volontairement — c'est le port submission
+  // SMTP standard universel (RFC 6409). Pas un secret, pas une URL prod-critique.
   const port = Number.parseInt(process.env.SMTP_PORT || "587", 10);
   const user = process.env.SMTP_USER;
   const pass = process.env.SMTP_PASS;

--- a/web-portal/lib/auth/passwordRecovery.ts
+++ b/web-portal/lib/auth/passwordRecovery.ts
@@ -2,6 +2,7 @@ import type { ResultSetHeader, RowDataPacket } from "mysql2/promise";
 import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { query } from "@/lib/db/connection";
 import { hashPasswordForGameMaster } from "@/lib/auth/gamePasswordHash";
+import { requireEnv } from "@/lib/env";
 
 type AccountRow = RowDataPacket & {
   id: number;
@@ -58,7 +59,7 @@ type RecoveryProfileBundle = {
 };
 
 function getRecoverySecret(): string {
-  return process.env.AUTH_SECRET || "lcdlln-dev-recovery-secret";
+  return requireEnv("AUTH_SECRET");
 }
 
 function normalizeTrimmed(value: string): string {

--- a/web-portal/lib/email/sender.ts
+++ b/web-portal/lib/email/sender.ts
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer'
 import fs from 'node:fs'
 import path from 'node:path'
+import { requireEnv } from '@/lib/env'
 
 interface SmtpLocalConfig {
   smtp: {
@@ -106,7 +107,7 @@ export async function sendAccountConfirmed(to: string, login: string, tagId: str
 }
 
 export async function sendAccountDisabled(to: string, login: string, reason: string, locale = 'fr'): Promise<void> {
-  const html = loadTemplate('account-disabled', { login, reason, contact_url: process.env.PORTAL_URL + '/support' }, locale)
+  const html = loadTemplate('account-disabled', { login, reason, contact_url: requireEnv("PORTAL_URL") + '/support' }, locale)
   await getTransporter().sendMail({ from: getFrom(), to, subject: getSubject('accountDisabled', locale), html })
 }
 

--- a/web-portal/lib/env.ts
+++ b/web-portal/lib/env.ts
@@ -1,0 +1,19 @@
+// Helper centralisé pour les variables d'environnement obligatoires.
+// L'objectif : un message d'erreur clair et explicite quand une variable
+// critique manque, plutôt qu'un fallback silencieux vers une valeur de dev.
+//
+// Usage :
+//   const secret = requireEnv("AUTH_SECRET");
+//
+// Lance : Error("Missing required environment variable: AUTH_SECRET")
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === null || value.trim().length === 0) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+      `Set it in the deployment environment (Docker .env, systemd EnvironmentFile, etc.) before starting the web portal.`
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- Remplace le fallback secret en dur `"lcdlln-dev-recovery-secret"` par `requireEnv("AUTH_SECRET")` qui throw avec un message clair si la var d'env est absente.
- Remplace le fallback `http://127.0.0.1:3000` pour `NEXT_PUBLIC_PORTAL_URL` par le même mécanisme — empêche d'envoyer des emails de récupération avec des liens morts en prod.
- Conserve `SMTP_PORT=587` (port submission standard universel RFC 6409, pas un secret) — documenté en commentaire dans le code.
- Documente `AUTH_SECRET` et `NEXT_PUBLIC_PORTAL_URL` comme **REQUIRED** dans `deploy/docker/.env.example` avec rationale.
- Joint le rapport d'audit complet `docs/superpowers/audits/2026-05-27-codebase-audit.md` + le plan d'implémentation `docs/superpowers/plans/2026-05-27-pr1-web-portal-secret-fail-fast.md` (PR 1 sur 4).

## Test plan

- [ ] CI build-windows + build-web verts.
- [ ] Smoke test manuel : retirer `AUTH_SECRET` de l'env local, démarrer le portail, appeler la route password-recovery → attendu 500 + log `Missing required environment variable: AUTH_SECRET`.
- [ ] **AVANT le merge** : confirmer que `AUTH_SECRET` ET `NEXT_PUBLIC_PORTAL_URL` sont déjà définis sur l'environnement Docker de prod du portail (sinon le flow recovery sera cassé au premier appel après déploiement).

## Déploiement

✅ **Web portal uniquement** — aucun redéploiement master ni shard.
⚠️ **Lock-step** avec l'environnement de prod : env vars listées ci-dessus doivent être présentes AVANT déploiement.

## Suivi

Cette PR 1 fait partie d'un plan de 4 PRs issu de l'audit codebase 2026-05-27. Les 3 suivantes (chantiers C/D/E F10) seront ouvertes une fois celle-ci mergée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)