### PR TITLE
db: ajoute index characters.server_id (migration 0069)

### DIFF
--- a/docs/superpowers/plans/2026-05-27-pr2-sql-characters-server-id-index.md
+++ b/docs/superpowers/plans/2026-05-27-pr2-sql-characters-server-id-index.md
@@ -1,0 +1,64 @@
+# PR 2 — Index `characters.server_id` (scope ultra-minimal)
+
+> Plan exécuté directement (sans subagent-driven-development) vu la simplicité — 1 fichier SQL + 1 plan, ~30 minutes.
+
+**Goal:** Ajouter un index `ix_characters_server_id` sur `characters(server_id)` via une migration SQL idempotente. C'est la seule lacune d'index réellement confirmée par l'audit codebase 2026-05-27 — les autres tables des hot queries (friends, guild_members) sont déjà bien indexées.
+
+**Spec source :** [docs/superpowers/audits/2026-05-27-codebase-audit.md](../audits/2026-05-27-codebase-audit.md) section 8 PR 2, **scope ultra-minimal** validé par utilisateur (option A : "migration d'index seule") vu l'absence de toolchain C++ locale pour valider du refactor de handlers.
+
+**Architecture:** Migration MySQL 8.0 idempotente via le pattern déjà utilisé dans `0040_factions.sql:101-108` (`SET @idx_exists := SELECT FROM INFORMATION_SCHEMA.STATISTICS` + `PREPARE`/`EXECUTE` conditionnel). Pas de DELIMITER (le `MigrationRunner` du repo gère le multi-statement mais pas les procédures avec body custom).
+
+**Tech Stack:** MySQL 8.0 (image Docker `mysql:8.0`), MigrationRunner C++ avec checksum SHA-256 par fichier.
+
+---
+
+## Justification
+
+### Query bénéficiant de l'index
+
+`characters.server_id` est utilisé en `WHERE` ou `AND` dans 3 hot handlers :
+
+| Handler | Référence | Query |
+|---|---|---|
+| `CharacterCreateHandler.cpp:67` | [lien](../../../src/masterd/handlers/character/CharacterCreateHandler.cpp) | `SELECT id FROM characters WHERE server_id = X AND ...` |
+| `CharacterCreateHandler.cpp:116` | idem | `... AND server_id = X ...` |
+| `CharacterListHandler.cpp:79` | [lien](../../../src/masterd/handlers/character/CharacterListHandler.cpp) | `JOIN ... AND c.server_id = X` |
+
+Sans index, ces queries font un table scan filtré ensuite par `account_id` (qui lui est indexé via `ix_characters_account_id`). Avec une grande table `characters` (multi-comptes × multi-personnages), c'est sous-optimal.
+
+### Pas de composite index pour l'instant
+
+Le plan d'audit pouvait suggérer un composite `(server_id, account_id)`. **YAGNI** :
+- L'index existant `ix_characters_account_id` couvre déjà `WHERE account_id = X` pour la query character list.
+- Pour `WHERE account_id = X AND server_id = Y`, MySQL peut utiliser `ix_characters_account_id` puis filtrer Y en mémoire (rapide si le scan account_id est petit).
+- Un index single-column `server_id` est suffisant pour les queries directes server-wide.
+- Si un benchmark montre que c'est insuffisant, on ajoutera un composite plus tard.
+
+### Choix du numéro de migration
+
+Dernière migration existante : `0068_characters_skin_color.sql`. Nouvelle migration : **`0069_add_characters_server_id_index.sql`**.
+
+---
+
+## File structure
+
+| Fichier | Action | Responsabilité |
+|---|---|---|
+| `sql/migrations/0069_add_characters_server_id_index.sql` | **Create** | Migration idempotente qui ajoute `ix_characters_server_id` si absent. |
+
+---
+
+## Déploiement
+
+⚠️ **REDÉPLOIEMENT SERVEUR (master) requis** — la migration s'applique au boot du master via `MigrationRunner`. Pas de bump `kProtocolVersion` (pas de wire change). Shard non concerné.
+
+L'ajout d'index sur une table existante peut prendre quelques secondes selon la taille de `characters`. MySQL 8 supporte `INSTANT` ALGORITHM pour beaucoup d'opérations DDL, mais l'ajout d'index reste un `INPLACE` algorithm avec un lock partiel — table reste lisible pendant la création, mais les writes sont brièvement bloqués. Sur une table de quelques milliers de characters, l'opération devrait être instantanée.
+
+---
+
+## Suivi
+
+PR 2 sur 4 du plan d'audit. Cette PR clôt le scope minimaliste accepté par l'utilisateur. Reste hors scope (à programmer en PRs séparées avec build C++ local disponible) :
+- Helper `DbPreparedQuery` dans `src/shared/db/`
+- Migration des 5 handlers les plus exposés vers prepared statements
+- Audit d'autres index manquants (s'il y en a — investigation jusqu'ici n'en a pas confirmé d'autres)

--- a/sql/migrations/0069_add_characters_server_id_index.sql
+++ b/sql/migrations/0069_add_characters_server_id_index.sql
@@ -1,0 +1,32 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- 0069 — Ajoute l'index `ix_characters_server_id` sur `characters(server_id)`
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Issu de l'audit codebase 2026-05-27 (PR 2, chantier C — scope ultra-minimal).
+-- Réf : docs/superpowers/audits/2026-05-27-codebase-audit.md
+--       docs/superpowers/plans/2026-05-27-pr2-sql-characters-server-id-index.md
+--
+-- Motivation :
+--   `characters.server_id` est utilisé en `WHERE`/`AND` dans 3 hot handlers
+--   (CharacterCreateHandler:67, :116 ; CharacterListHandler:79). Sans index,
+--   ces queries font un table scan filtré ensuite par `account_id`. Avec
+--   une table characters multi-comptes × multi-personnages qui grandit,
+--   l'absence d'index sur server_id finit par dominer le coût des
+--   requêtes character-list et character-create.
+--
+-- Idempotence : on vérifie INFORMATION_SCHEMA.STATISTICS avant CREATE.
+-- Pattern repris de sql/migrations/0040_factions.sql:101-108 pour la
+-- cohérence stylistique du repo.
+
+SET @idx_exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE table_schema = DATABASE()
+    AND table_name = 'characters'
+    AND index_name = 'ix_characters_server_id'
+);
+SET @stmt := IF(@idx_exists = 0,
+  'CREATE INDEX ix_characters_server_id ON characters (server_id)',
+  'SELECT ''index ix_characters_server_id already exists, skipping'' AS msg');
+PREPARE addidx FROM @stmt;
+EXECUTE addidx;
+DEALLOCATE PREPARE addidx;


### PR DESCRIPTION
## Summary

Issue de l'audit codebase 2026-05-27 ([rapport](docs/superpowers/audits/2026-05-27-codebase-audit.md), chantier C, **scope ultra-minimal validé par l'utilisateur**).

Investigation approfondie : l'audit initial flag plusieurs tables comme manquant d'index, mais `friends` + `guild_members` sont déjà bien indexées. **Seule lacune réellement confirmée** : `characters.server_id`.

Cette PR ajoute UN seul index :
- `ix_characters_server_id` sur `characters(server_id)` via migration 0069 idempotente.

Pattern idempotent via `INFORMATION_SCHEMA.STATISTICS` check (repris de [0040_factions.sql:101-108](sql/migrations/0040_factions.sql)).

### Queries bénéficiaires

| Handler | Référence | Query |
|---|---|---|
| `CharacterCreateHandler.cpp:67` | [lien](src/masterd/handlers/character/CharacterCreateHandler.cpp) | `SELECT id FROM characters WHERE server_id = X AND ...` |
| `CharacterCreateHandler.cpp:116` | idem | `... AND server_id = X ...` |
| `CharacterListHandler.cpp:79` | [lien](src/masterd/handlers/character/CharacterListHandler.cpp) | `JOIN ... AND c.server_id = X` |

### Choix scope minimaliste

- **Pas d'index composite** `(server_id, account_id)` — YAGNI. L'index existant `ix_characters_account_id` couvre déjà `WHERE account_id = X`. Si benchmark futur justifie, on ajoutera.
- **Pas de helper `DbPreparedQuery`** — l'utilisateur a opté pour le scope index seul vu l'absence de toolchain C++ locale pour valider du refactor de 5 handlers en aveugle (leçon PR #721).

## Test plan

- [ ] CI verte.
- [ ] La migration s'applique au boot du master sans erreur (cf. logs `MigrationRunner`).
- [ ] Re-rejouer la migration une 2e fois (idempotence) doit afficher `'index ix_characters_server_id already exists, skipping'` au lieu d'erreur.

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR (master) requis** — la migration s'applique au boot via `MigrationRunner` avec checksum SHA-256. Pas de bump `kProtocolVersion` (pas de wire change). Shard non concerné.

L'ajout d'index sur une table existante avec MySQL 8 InnoDB est `INPLACE` algorithm — table reste lisible, writes brièvement bloqués. Sur une table de quelques milliers de characters, opération quasi-instantanée.

## Suivi

PR 2 sur 4 du plan d'audit. **Plan d'audit terminé** avec cette PR (PRs 1, 3, 4 déjà mergées). Hors scope, à programmer en PRs séparées avec build C++ local disponible :
- Helper `DbPreparedQuery` + migration des 5 handlers les plus exposés vers prepared statements
- FU-5 à FU-7 (réintégration des 3 tests CI Linux-specific) cf. [doc follow-ups](docs/superpowers/audits/2026-05-27-codebase-audit-followups.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)