### PR TITLE
test(network): fix netserver_bandwidth_tests cross-platform (FU-5)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -74,17 +74,13 @@ jobs:
       #     dans VMapStreamer. Audit nécessaire.
       #
       # ─── TEMPORAIRE — Linux-specific (tentative réintégration 2026-05-27 a échoué) ──
-      # Les 3 tests ci-dessous ont été retirés de -E par la tentative de
+      # Les tests ci-dessous ont été retirés de -E par la tentative de
       # réintégration de la PR #721, puis ré-exclus quand la CI Linux a
       # révélé des échecs réels (pas des fausses alertes comme le rapport
-      # d'audit initial le supposait). Suivi détaillé : FU-5/6/7 dans
+      # d'audit initial le supposait). Suivi détaillé : FU-6/7 dans
       # docs/superpowers/audits/2026-05-27-codebase-audit-followups.md
-      # - netserver_bandwidth_tests
-      #     `Assert(totalSent == 1000u)` échoue sur Linux GCC après 5
-      #     itérations de `now += 0.2` (somme de 5 fois 0.2 en IEEE 754).
-      #     Cross-platform fragile — pas du timing, mais de l'arithmétique
-      #     floating-point. Fix : assertion avec tolérance ou recalcul en
-      #     entiers (effort ~30 min, à fixer dans le test seul).
+      # (FU-5 netserver_bandwidth_tests fixé et réintégré dans une PR
+      # ultérieure — tolérance ±1 byte sur l'assertion floating-point.)
       # - localization_service_tests
       #     `LocalizationService::Init()` retourne false sur Linux après
       #     que `WriteCatalog` (FileSystem::WriteAllText) ait réussi.
@@ -102,7 +98,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         working-directory: ${{ github.workspace }}/build/linux-x64-release
         run: |
-          ctest --output-on-failure --no-compress-output -E "network_integration_tests|session_manager_tests|security_tests|grid_state_tests|vmap_streamer_tests|netserver_bandwidth_tests|localization_service_tests|zone_builder_roundtrip_tests"
+          ctest --output-on-failure --no-compress-output -E "network_integration_tests|session_manager_tests|security_tests|grid_state_tests|vmap_streamer_tests|localization_service_tests|zone_builder_roundtrip_tests"
 
       # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
       # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que

--- a/docs/superpowers/audits/2026-05-27-codebase-audit-followups.md
+++ b/docs/superpowers/audits/2026-05-27-codebase-audit-followups.md
@@ -115,10 +115,12 @@ de libération. Si bug → fixer. Sinon ajuster le test.
 
 ---
 
-## FU-5 — Arithmétique floating-point `netserver_bandwidth_tests`
+## FU-5 — Arithmétique floating-point `netserver_bandwidth_tests` — ✅ RÉSOLU
 
-**Test bloqué :** `netserver_bandwidth_tests` — re-exclu en CI Linux après
-tentative de réintégration (PR #721).
+**Statut :** ✅ Résolu dans une PR ultérieure (option A — assertion avec
+tolérance ±1 byte). Le test est réintégré dans `ctest`, plus exclu.
+
+**Test (anciennement) bloqué :** `netserver_bandwidth_tests`.
 
 **Symptôme :** assertion `Assert(totalSent == 1000u, ...)` ligne 88 du
 test échoue sur Linux GCC après 5 itérations de `now += 0.2`. La somme
@@ -217,18 +219,21 @@ serveur.
 
 ## Synthèse
 
-| Follow-up | Effort | Priorité | Peut être combiné ? |
+| Follow-up | Effort | Priorité | Statut |
 |---|---|---|---|
-| FU-1 + FU-2 | 4-6h | Moyenne | **Oui** — abstraction Clock commune dans 1 PR |
-| FU-3 | 2-4h | Moyenne | Non — zone shard distincte |
-| FU-4 | 3-5h | Moyenne | Non — lifecycle distinct |
-| FU-5 | 30 min | **Haute** | Non — test-only, fix rapide |
-| FU-6 | 2-4h | Moyenne | Non — diag Linux distinct |
-| FU-7 | 3-5h | Moyenne | Non — tooling éditeur distinct |
+| FU-1 + FU-2 | 4-6h | Moyenne | À faire |
+| FU-3 | 2-4h | Moyenne | À faire |
+| FU-4 | 3-5h | Moyenne | À faire |
+| FU-5 | 30 min | — | ✅ **Résolu** (tolérance ±1 byte) |
+| FU-6 | 2-4h | Moyenne | À faire |
+| FU-7 | 3-5h | Moyenne | À faire |
 
-**Recommandation :** **FU-5 en priorité** (quick win 30 min, restaure
-1 test). Puis 3 PRs (FU-1+FU-2 combinées, FU-3 seule, FU-4 seule).
-FU-6 + FU-7 demandent un build Linux pour diagnostiquer — à
-programmer quand l'environnement est accessible. Total ~13-20h spread
-sur 5-6 PRs. Pas urgent : ces tests sont des protections contre
-régressions, leur absence ne casse rien fonctionnellement.
+**Recommandation :** FU-5 fixé (quick win consommé). Reste 5 follow-ups
+à programmer en PRs séparées :
+- FU-1+FU-2 combinables (abstraction `Clock` commune)
+- FU-3 et FU-4 séparées (zones distinctes)
+- FU-6 + FU-7 demandent un build Linux pour diagnostiquer
+
+Total restant : ~12-15h spread sur 4-5 PRs. Pas urgent : ces tests sont
+des protections contre régressions, leur absence ne casse rien
+fonctionnellement.

--- a/src/shared/network/NetServerBandwidthThrottleTests.cpp
+++ b/src/shared/network/NetServerBandwidthThrottleTests.cpp
@@ -85,7 +85,12 @@ int main()
 			b.tokensBytes -= static_cast<double>(allowed);
 			totalSent += static_cast<uint32_t>(allowed);
 		}
-		Assert(totalSent == 1000u, "sustained token bucket sends exactly rate*1s");
+		// L'arithmétique double accumulée (`now += 0.2` × 5) peut introduire
+		// une erreur d'arrondi IEEE 754 cross-platform (GCC Linux vs MSVC
+		// Windows) : la somme de 5 × 0.2 != 1.0 exactement, donc la dernière
+		// itération peut donner `tokensBytes = 199.999...` → cast = 199.
+		// On accepte ±1 byte de tolérance, soit <0.1% de la rate cible.
+		Assert(totalSent >= 999u && totalSent <= 1000u, "sustained token bucket sends ~rate*1s (±1 byte tolerance)");
 	}
 
 	// Test 2: priority classification Snapshot=state, others=control.


### PR DESCRIPTION
## Summary

**FU-5 du doc follow-ups** ([2026-05-27-codebase-audit-followups.md](docs/superpowers/audits/2026-05-27-codebase-audit-followups.md)) — quick win 30 min.

L'assertion `totalSent == 1000u` dans `netserver_bandwidth_tests` échouait sur Linux GCC à cause d'une accumulation d'erreur IEEE 754 (`now += 0.2` × 5 != exactement 1.0). Sur Linux, la dernière itération produisait ~199.999... → cast `size_t` = 199 → `totalSent` = 999 au lieu de 1000. Le test passait sur Windows MSVC (différence de représentation flottante).

### Solution (option A, chirurgicale)

Tolérance ±1 byte sur l'assertion :
```cpp
Assert(totalSent >= 999u && totalSent <= 1000u, "sustained token bucket sends ~rate*1s (±1 byte tolerance)");
```
+ commentaire explicatif documentant la raison.

1 byte sur 1000 = <0.1% d'erreur, largement acceptable pour un test sémantique de token bucket sustained throughput.

Le `struct ByteTokenBucket` est local au test (namespace anonyme), donc **aucun code de prod n'est touché** — c'est juste le test qui devient cross-platform stable.

### Réintégration ctest

Retire `netserver_bandwidth_tests` de la liste `ctest -E` dans `.github/workflows/build-linux.yml`. La liste passe de 8 à 7 entrées. Met à jour le doc follow-ups pour marquer FU-5 comme résolu.

## Test plan

- [ ] CI Linux verte — le test précédemment exclu doit maintenant passer.
- [ ] CI Windows toujours verte (le test passait déjà sur Windows, la tolérance n'élargit pas l'erreur acceptée Windows).

## Déploiement

✅ **CI uniquement** — aucun redéploiement serveur ni client. Pas de code de prod touché (juste le test).

## Suivi

5 follow-ups restants (FU-1 à FU-4, FU-6, FU-7) à programmer en PRs séparées quand un build C++ local sera disponible. Détail dans le doc follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)