### PR TITLE
feat(masterd): log les parses d'args admin échoués (N6)

### DIFF
--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -193,7 +193,11 @@ namespace engine::server
 			}
 			int phase = -1;
 			try { phase = std::stoi(args[0]); }
-			catch (...) { phase = -1; }
+			catch (...)
+			{
+				LOG_WARN(Net, "/sky moon : argument <phase> invalide ('{}')", args[0]);
+				phase = -1;
+			}
 			if (phase < 0 || phase > 15)
 			{
 				resp.status = AdminCommandStatus::InvalidArgs;
@@ -232,7 +236,11 @@ namespace engine::server
 			}
 			float hours = -1.0f;
 			try { hours = std::stof(args[0]); }
-			catch (...) { hours = -1.0f; }
+			catch (...)
+			{
+				LOG_WARN(Net, "/sky time : argument <hours> invalide ('{}')", args[0]);
+				hours = -1.0f;
+			}
 			if (!(hours >= 0.0f) || hours >= 24.0f)
 			{
 				resp.status = AdminCommandStatus::InvalidArgs;
@@ -306,7 +314,11 @@ namespace engine::server
 			}
 			uint64_t targetId = 0;
 			try { targetId = std::stoull(args[0]); }
-			catch (...) { targetId = 0; }
+			catch (...)
+			{
+				LOG_WARN(Net, "/promote : argument <account_id> invalide ('{}')", args[0]);
+				targetId = 0;
+			}
 			if (targetId == 0u)
 			{
 				resp.status = AdminCommandStatus::InvalidArgs;
@@ -699,7 +711,11 @@ namespace engine::server
 
 		int durationMin = -1;
 		try { durationMin = std::stoi(args[1]); }
-		catch (...) { durationMin = -1; }
+		catch (...)
+		{
+			LOG_WARN(Net, "/mute : argument <duration_minutes> invalide ('{}')", args[1]);
+			durationMin = -1;
+		}
 		if (durationMin <= 0 || durationMin > 60 * 24 * 365)
 		{
 			resp.status = AdminCommandStatus::InvalidArgs;
@@ -996,7 +1012,11 @@ namespace engine::server
 			}
 			uint32_t connId = 0u;
 			try { connId = static_cast<uint32_t>(std::stoul(args[0])); }
-			catch (...) { connId = 0u; }
+			catch (...)
+			{
+				LOG_WARN(Net, "/packet log dump : argument <connId> invalide ('{}')", args[0]);
+				connId = 0u;
+			}
 			// Note : connId == 0 est une valeur valide (slot NetServer
 			// commence a 0 ou 1 selon allocations). On ne rejette pas.
 
@@ -1004,7 +1024,11 @@ namespace engine::server
 			if (args.size() >= 2u)
 			{
 				try { n = static_cast<size_t>(std::stoul(args[1])); }
-				catch (...) { n = kDefaultN; }
+				catch (...)
+				{
+					LOG_WARN(Net, "/packet log dump : argument <n> invalide ('{}')", args[1]);
+					n = kDefaultN;
+				}
 				if (n == 0u) n = kDefaultN;
 			}
 
@@ -1030,7 +1054,11 @@ namespace engine::server
 			if (!args.empty())
 			{
 				try { n = static_cast<size_t>(std::stoul(args[0])); }
-				catch (...) { n = kDefaultN; }
+				catch (...)
+				{
+					LOG_WARN(Net, "/packet log dump_all : argument <n> invalide ('{}')", args[0]);
+					n = kDefaultN;
+				}
 				if (n == 0u) n = kDefaultN;
 			}
 


### PR DESCRIPTION
## Summary

**PR 2 (chantier N6)** du cycle d'audit 2026-05-28.

Instrumente les **7 catch(...) silencieux** identifiés dans `AdminCommandHandler.cpp` (l'audit en annonçait 8, il y en a en fait 7). Chacun mangeait une exception de parsing d'argument admin sans aucune trace serveur.

## Détail

| Ligne | Commande admin | Argument | Type |
|---|---|---|---|
| 196 | `/sky moon <phase>` | `args[0]` | `int` (0..15) |
| 235 | `/sky time <hours>` | `args[0]` | `float` [0..24) |
| 309 | `/promote <account_id> <role>` | `args[0]` | `uint64_t` |
| 702 | `/mute <player> <duration_minutes>` | `args[1]` | `int` |
| 999 | `/packet log dump <connId> [n]` | `args[0]` | `uint32_t` |
| 1007 | `/packet log dump <connId> [n]` | `args[1]` | `size_t` |
| 1033 | `/packet log dump_all [n]` | `args[0]` | `size_t` |

Chaque catch est désormais :

```cpp
catch (...)
{
    LOG_WARN(Net, "/<cmd> : argument <name> invalide ('{}')", args[k]);
    <default assignment>
}
```

## Choix

- **Sous-système `Net`** : aligné sur la convention déjà en place dans `src/masterd/admin/SlashCommandRegistry.cpp:266,274,281` et tous les stores MySQL voisins (`MysqlAccountStore`, `MysqlAuctionStore`, `MysqlArenaStore`, etc.). Aucun précédent pour un subsystem `Admin` dans masterd.
- **Niveau `WARN`** : approprié pour une input utilisateur mal formée (pas un bug serveur, pas une erreur silencieuse).
- **Aucun changement de logique** : la sentinelle de parse échoué (`phase = -1`, `hours = -1.0f`, etc.) reste la même ; la validation downstream rejette toujours avec `InvalidArgs`. La PR ajoute uniquement la visibilité opérateur.

## Diff

- `src/masterd/handlers/admin/AdminCommandHandler.cpp` : **+35 / -7** lignes (refactor à isovaleur fonctionnelle)
- Aucun autre fichier touché
- `Log.h` était déjà inclus (ligne 17) — aucun nouveau include nécessaire

## Test plan

- [ ] CI build green (Linux GCC + Windows MSVC)
- [ ] Tests CTest existants (anticheat, entities, mail, etc.) continuent de passer
- [ ] Vérification manuelle post-déploiement : envoyer `/sky moon abc` depuis un compte admin, observer la ligne `[WARN][Net] /sky moon : argument <phase> invalide ('abc')` dans le log serveur

## Déploiement

⚠️ **Master + lock-step** — binaire serveur recompilé requis. Pas de migration DB, pas de wire-breaking, pas de changement de protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)