### PR TITLE
feat(web-portal): instrumente logError sur tous les catch des routes API (N2)

### DIFF
--- a/web-portal/app/api/admin/bugs/[id]/route.ts
+++ b/web-portal/app/api/admin/bugs/[id]/route.ts
@@ -13,6 +13,7 @@ import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -53,7 +54,8 @@ export async function PATCH(
   let body: Record<string, unknown>
   try {
     body = await request.json() as Record<string, unknown>
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/bugs/[id]', 'Invalid JSON body', { err })
     return NextResponse.json({ error: 'Corps JSON invalide' }, { status: 400 })
   }
 
@@ -129,7 +131,8 @@ export async function PATCH(
     )
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/bugs/[id]', 'Bug update / exploit award failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/cgu/[id]/publish/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/publish/route.ts
@@ -5,6 +5,7 @@ import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(
   _request: Request,
@@ -38,7 +39,8 @@ export async function POST(
     )
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/admin/cgu/[id]/publish', 'Publish CGU edition failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/cgu/[id]/retire/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/retire/route.ts
@@ -6,6 +6,7 @@ import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(
   request: Request,
@@ -48,7 +49,8 @@ export async function POST(
     )
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/admin/cgu/[id]/retire', 'Retire CGU edition failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/cgu/[id]/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -86,7 +87,8 @@ export async function PATCH(
     }
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/cgu/[id]', 'Update CGU draft failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }
@@ -115,7 +117,8 @@ export async function DELETE(
     await query('DELETE FROM terms_editions WHERE id = ?', [id])
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('DELETE /api/admin/cgu/[id]', 'Delete CGU draft failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
+++ b/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
@@ -3,6 +3,7 @@ import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
@@ -23,7 +24,8 @@ export async function PATCH(_req: Request, { params }: { params: { id: string } 
 
     await query('UPDATE characters SET force_rename = 1 WHERE id = ?', [id])
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/characters/[id]/force-rename', 'Force-rename failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/faq/[id]/route.ts
+++ b/web-portal/app/api/admin/faq/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -51,7 +52,8 @@ export async function PATCH(
       values
     )
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/faq/[id]', 'Update FAQ item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }
@@ -70,7 +72,8 @@ export async function DELETE(
   try {
     await query('DELETE FROM faq_items WHERE id = ?', [id])
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('DELETE /api/admin/faq/[id]', 'Delete FAQ item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/faq/route.ts
+++ b/web-portal/app/api/admin/faq/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -20,7 +21,8 @@ export async function GET() {
       'SELECT id, question, answer, category, display_order, published FROM faq_items ORDER BY display_order ASC, id ASC'
     )
     return NextResponse.json(items)
-  } catch {
+  } catch (err) {
+    logError('GET /api/admin/faq', 'Fetch FAQ items failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }
@@ -57,7 +59,8 @@ export async function POST(request: Request) {
       [question.trim(), answer.trim(), category ?? null, order, published ? 1 : 0]
     )
     return NextResponse.json({ ok: true }, { status: 201 })
-  } catch {
+  } catch (err) {
+    logError('POST /api/admin/faq', 'Create FAQ item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/players/[id]/activate/route.ts
+++ b/web-portal/app/api/admin/players/[id]/activate/route.ts
@@ -2,6 +2,7 @@
 import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { logError } from '@/lib/log'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
@@ -18,7 +19,8 @@ export async function PATCH(_req: Request, { params }: { params: { id: string } 
       [id]
     )
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/players/[id]/activate', 'Activate account failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/players/[id]/characters/route.ts
+++ b/web-portal/app/api/admin/players/[id]/characters/route.ts
@@ -3,6 +3,7 @@ import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
@@ -22,7 +23,8 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
       [id]
     )
     return NextResponse.json({ ok: true, characters })
-  } catch {
+  } catch (err) {
+    logError('GET /api/admin/players/[id]/characters', 'Fetch characters failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/players/[id]/disable/route.ts
+++ b/web-portal/app/api/admin/players/[id]/disable/route.ts
@@ -4,6 +4,7 @@ import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
 import { sendAccountDisabled } from '@/lib/email/sender'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError, logWarn } from '@/lib/log'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
@@ -18,7 +19,8 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   let body: { reason?: string }
   try {
     body = await req.json()
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/players/[id]/disable', 'Invalid JSON body', { err })
     return NextResponse.json({ ok: false, message: 'Corps invalide' }, { status: 400 })
   }
 
@@ -39,12 +41,14 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
 
     try {
       await sendAccountDisabled(rows[0].email, rows[0].login, reason)
-    } catch {
+    } catch (err) {
       // Email failure is non-fatal — account is already disabled
+      logWarn('PATCH /api/admin/players/[id]/disable', 'Account-disabled email send failed', { err, accountId: id })
     }
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/players/[id]/disable', 'Disable account failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/players/[id]/verify-email/route.ts
+++ b/web-portal/app/api/admin/players/[id]/verify-email/route.ts
@@ -2,6 +2,7 @@
 import { isStaff } from '@/lib/auth/roles'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { logError } from '@/lib/log'
 
 async function checkAdmin() {
   const role = cookies().get('lcdlln_portal_role')?.value
@@ -15,7 +16,8 @@ export async function PATCH(_req: Request, { params }: { params: { id: string } 
   try {
     await query('UPDATE accounts SET email_verified = 1 WHERE id = ?', [id])
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/players/[id]/verify-email', 'Force-verify email failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/roadmap/[id]/route.ts
+++ b/web-portal/app/api/admin/roadmap/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -51,7 +52,8 @@ export async function PATCH(
       values
     )
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/admin/roadmap/[id]', 'Update roadmap item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }
@@ -70,7 +72,8 @@ export async function DELETE(
   try {
     await query('DELETE FROM roadmap_items WHERE id = ?', [id])
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('DELETE /api/admin/roadmap/[id]', 'Delete roadmap item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/admin/roadmap/route.ts
+++ b/web-portal/app/api/admin/roadmap/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 function isAdmin(): boolean {
   const jar = cookies()
@@ -20,7 +21,8 @@ export async function GET() {
       'SELECT id, title, description, status, category, display_order FROM roadmap_items ORDER BY display_order ASC'
     )
     return NextResponse.json(items)
-  } catch {
+  } catch (err) {
+    logError('GET /api/admin/roadmap', 'Fetch roadmap items failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }
@@ -58,7 +60,8 @@ export async function POST(request: Request) {
       [title.trim(), description ?? null, status, category ?? null, order]
     )
     return NextResponse.json({ ok: true }, { status: 201 })
-  } catch {
+  } catch (err) {
+    logError('POST /api/admin/roadmap', 'Create roadmap item failed', { err })
     return NextResponse.json({ error: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/auth/login/route.ts
+++ b/web-portal/app/api/auth/login/route.ts
@@ -4,6 +4,7 @@ import { verifyPortalCredentials } from "@/lib/auth/portalLogin";
 import { query } from "@/lib/db/connection";
 import type { RowDataPacket } from "mysql2/promise";
 import { isStaff, normalizeRole } from "@/lib/auth/roles";
+import { logError } from "@/lib/log";
 
 const COOKIE_NAME = "lcdlln_portal_account";
 const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 7;
@@ -55,7 +56,8 @@ export async function POST(request: Request) {
       tagId: accountTagId,
       redirect: isStaff(accountRole) ? '/admin' : '/player',
     });
-  } catch {
+  } catch (err) {
+    logError("POST /api/auth/login", "Login handler failed", { err });
     return NextResponse.json({ ok: false, message: "Requête invalide." }, { status: 400 });
   }
 }

--- a/web-portal/app/api/password-recovery/profile/route.ts
+++ b/web-portal/app/api/password-recovery/profile/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getRecoveryProfile, upsertRecoveryProfile } from "@/lib/auth/passwordRecovery";
+import { logError } from "@/lib/log";
 
 function parseAccountId(value: string | null): number {
   const parsed = Number.parseInt(value || "", 10);
@@ -26,6 +27,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
+    logError("GET /api/password-recovery/profile", "Fetch recovery profile failed", { err: error });
     const message = error instanceof Error ? error.message : "Erreur inconnue.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -60,6 +62,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    logError("POST /api/password-recovery/profile", "Upsert recovery profile failed", { err: error });
     const message = error instanceof Error ? error.message : "Erreur inconnue.";
     return NextResponse.json({ error: message }, { status: 400 });
   }

--- a/web-portal/app/api/password-recovery/request/route.ts
+++ b/web-portal/app/api/password-recovery/request/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requestPasswordRecovery } from "@/lib/auth/passwordRecovery";
+import { logError } from "@/lib/log";
 
 export async function POST(request: Request) {
   try {
@@ -25,6 +26,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json(result);
   } catch (error) {
+    logError("POST /api/password-recovery/request", "Recovery request failed", { err: error });
     const message = error instanceof Error ? error.message : "Erreur inconnue.";
     return NextResponse.json({ accepted: false, delivery: "noop", message }, { status: 500 });
   }

--- a/web-portal/app/api/password-recovery/reset/route.ts
+++ b/web-portal/app/api/password-recovery/reset/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { resetPasswordWithToken } from "@/lib/auth/passwordRecovery";
+import { logError } from "@/lib/log";
 
 export async function POST(request: Request) {
   try {
@@ -11,6 +12,7 @@ export async function POST(request: Request) {
     const result = await resetPasswordWithToken(body.token || "", body.newPassword || "");
     return NextResponse.json(result, { status: result.ok ? 200 : 400 });
   } catch (error) {
+    logError("POST /api/password-recovery/reset", "Reset failed", { err: error });
     const message = error instanceof Error ? error.message : "Erreur inconnue.";
     return NextResponse.json({ ok: false, message }, { status: 500 });
   }

--- a/web-portal/app/api/player/account/cancel-email-change/route.ts
+++ b/web-portal/app/api/player/account/cancel-email-change/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { logError } from '@/lib/log'
 
 export async function POST() {
   const jar = cookies()
@@ -16,7 +17,8 @@ export async function POST() {
       [accountId]
     )
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/player/account/cancel-email-change', 'Cancel email change failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/account/confirm-email/route.ts
+++ b/web-portal/app/api/player/account/confirm-email/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
@@ -25,7 +26,8 @@ export async function GET(request: Request) {
     )
 
     return NextResponse.redirect(new URL('/player/account?success=email_confirme', request.url))
-  } catch {
+  } catch (err) {
+    logError('GET /api/player/account/confirm-email', 'Email confirmation failed', { err })
     return NextResponse.redirect(new URL('/player/account?error=erreur_serveur', request.url))
   }
 }

--- a/web-portal/app/api/player/account/request-email-change/route.ts
+++ b/web-portal/app/api/player/account/request-email-change/route.ts
@@ -7,6 +7,7 @@ import { sendEmailChange } from '@/lib/email/sender'
 import { requireEnv } from '@/lib/env'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
   const jar = cookies()
@@ -48,7 +49,8 @@ export async function POST(request: Request) {
     await sendEmailChange(newEmail, rows[0].login, newEmail, confirmationLink)
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/player/account/request-email-change', 'Email change request failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/account/route.ts
+++ b/web-portal/app/api/player/account/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
+import { logError } from '@/lib/log'
 
 export async function PATCH(request: Request) {
   const jar = cookies()
@@ -35,7 +36,8 @@ export async function PATCH(request: Request) {
     values.push(accountId)
     await query(`UPDATE accounts SET ${updates.join(', ')} WHERE id = ?`, values)
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/player/account', 'Account update failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/cgu/accept/route.ts
+++ b/web-portal/app/api/player/cgu/accept/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
   const jar = cookies()
@@ -37,7 +38,8 @@ export async function POST(request: Request) {
     )
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/player/cgu/accept', 'CGU acceptance failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/characters/[id]/delete/route.ts
+++ b/web-portal/app/api/player/characters/[id]/delete/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function PATCH(
   _request: Request,
@@ -25,7 +26,8 @@ export async function PATCH(
 
     await query('UPDATE characters SET deleted_at = NOW() WHERE id = ?', [characterId])
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('PATCH /api/player/characters/[id]/delete', 'Delete character failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/exploits/route.ts
+++ b/web-portal/app/api/player/exploits/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getPlayerExploitsData } from "@/lib/exploits/exploitsData";
+import { logError } from "@/lib/log";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -12,6 +13,7 @@ export async function GET(request: Request) {
     const data = await getPlayerExploitsData(n);
     return NextResponse.json(data);
   } catch (e) {
+    logError("GET /api/player/exploits", "Fetch exploits data failed", { err: e });
     const message = e instanceof Error ? e.message : "Erreur serveur";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/web-portal/app/api/player/parental/request/route.ts
+++ b/web-portal/app/api/player/parental/request/route.ts
@@ -7,6 +7,7 @@ import { sendParentalValidation } from '@/lib/email/sender'
 import { requireEnv } from '@/lib/env'
 import { randomBytes } from 'node:crypto'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
   const jar = cookies()
@@ -47,7 +48,8 @@ export async function POST(request: Request) {
     await sendParentalValidation(parentalEmail, rows[0].login, validationLink)
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/player/parental/request', 'Parental validation request failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }

--- a/web-portal/app/api/player/parental/validate/route.ts
+++ b/web-portal/app/api/player/parental/validate/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
@@ -25,7 +26,8 @@ export async function GET(request: Request) {
     )
 
     return NextResponse.redirect(new URL('/?parental=valide', request.url))
-  } catch {
+  } catch (err) {
+    logError('GET /api/player/parental/validate', 'Parental validation failed', { err })
     return NextResponse.redirect(new URL('/?parental=erreur', request.url))
   }
 }

--- a/web-portal/app/api/player/password/route.ts
+++ b/web-portal/app/api/player/password/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers'
 import { query } from '@/lib/db/connection'
 import { verifyGameMasterPassword, hashPasswordForGameMaster } from '@/lib/auth/gamePasswordHash'
 import type { RowDataPacket } from 'mysql2/promise'
+import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
   const jar = cookies()
@@ -39,7 +40,8 @@ export async function POST(request: Request) {
     await query('UPDATE accounts SET password_hash = ? WHERE id = ?', [newHash, accountId])
 
     return NextResponse.json({ ok: true })
-  } catch {
+  } catch (err) {
+    logError('POST /api/player/password', 'Password change failed', { err })
     return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary

**PR 3 (chantier N2)** du cycle d'audit 2026-05-28.

L'audit a révélé que la PR #720 avait migré 9 sites `console.error/warn` existants vers `lib/log.ts`, **sans auditer les catch blocs préexistants** des routes API. Résultat : sur 32 routes, seul `admin/cgu/route.ts:65` utilisait `logError`. Les 31 autres ont un `catch { return NextResponse.json(...) }` totalement silencieux.

Cette PR fait la passe transverse manquante.

## Détail

- **27 fichiers de routes touchés** (32 routes au total — 5 déjà conformes ou sans catch)
- **~36 catch blocs instrumentés**
- **+94 / -31 lignes**

### Pattern uniforme

```typescript
// Avant
} catch {
  return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
}

// Après
} catch (err) {
  logError('POST /api/<route>', 'Operation failed', { err })
  return NextResponse.json({ ok: false, message: 'Erreur serveur' }, { status: 500 })
}
```

### Cas particulier

`admin/players/[id]/disable/route.ts:42` — envoi de l'email "compte désactivé" après que l'opération principale a déjà réussi. C'est intentionnellement non-fatal (le commentaire le dit). Promu en `logWarn` au lieu de `logError` pour refléter cette sémantique : l'opération principale est OK, l'email est un bonus qui mérite trace mais pas alerte.

### Routes touchées (27)

| Catégorie | Routes |
|---|---|
| Auth | `auth/login` |
| Admin CGU | `admin/cgu/[id]`, `admin/cgu/[id]/publish`, `admin/cgu/[id]/retire` |
| Admin Bug/FAQ/Roadmap | `admin/bugs/[id]`, `admin/faq`, `admin/faq/[id]`, `admin/roadmap`, `admin/roadmap/[id]` |
| Admin Players | `admin/players/[id]/activate`, `.../characters`, `.../disable`, `.../verify-email`, `admin/characters/[id]/force-rename` |
| Player Account | `player/account`, `.../cancel-email-change`, `.../confirm-email`, `.../request-email-change`, `player/password` |
| Player CGU/Characters/Exploits | `player/cgu/accept`, `player/characters/[id]/delete`, `player/exploits` |
| Player Parental | `player/parental/request`, `.../validate` |
| Password Recovery | `password-recovery/profile`, `.../request`, `.../reset` |

### Routes inchangées (5)

- `health`, `auth/logout` — pas de catch
- `bugs`, `admin/cgu`, `player/privacy` — déjà migrés par PR #720

## Comportement runtime

- **Côté client** : 0 changement. Status HTTP, messages, body strictement identiques.
- **Côté serveur** : chaque catch émet désormais une ligne `[ERROR]` (ou `[WARN]` pour le cas non-fatal) parseable en JSON one-line en prod via `lib/log.ts` (stack ELK/Loki/Grafana ready).

## Test plan

- [ ] CI build green (Next.js build + lint TypeScript strict)
- [ ] Manuel post-déploiement : forcer une erreur DB sur une route admin (ex. couper temporairement le pool), observer la ligne `[ERROR][PATCH /api/admin/...]` dans le log Docker
- [ ] Vérifier sur dev qu'aucune route ne casse à cause d'un `err` non binded (TypeScript devrait nous protéger)

## Déploiement

✅ **Web portal uniquement** — aucun redéploiement serveur, pas de migration DB, pas de wire-breaking, aucune nouvelle dépendance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)