### PR TITLE
db: ajoute index compound characters (server_id, account_id) — migration 0070 (N3)

### DIFF
--- a/sql/migrations/0070_add_characters_server_account_index.sql
+++ b/sql/migrations/0070_add_characters_server_account_index.sql
@@ -1,0 +1,58 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- 0070 — Ajoute l'index compound `ix_characters_server_account`
+--         sur `characters(server_id, account_id)`
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Issu de l'audit codebase 2026-05-28 (finding N3, ouvert depuis l'audit
+-- 2026-05-27 finding F3 — partiellement résolu par la PR #722 / migration
+-- 0069 qui n'avait ajouté que l'index simple `ix_characters_server_id`).
+-- Réf : docs/superpowers/audits/2026-05-28-codebase-audit-fresh.md
+--
+-- Motivation :
+--   Plusieurs hot handlers du master font des SELECT sur `characters`
+--   avec un WHERE composite `server_id` + `account_id` :
+--     - CharacterListHandler.cpp:78-81
+--         WHERE c.account_id = X AND c.server_id = Y AND c.deleted_at IS NULL
+--         ORDER BY c.slot ASC
+--     - CharacterCreateHandler.cpp:115-117 (FindNextSlot)
+--         WHERE account_id = X AND server_id = Y AND deleted_at IS NULL
+--         ORDER BY slot ASC
+--
+--   Avec uniquement les index single-column `ix_characters_account_id`
+--   (migration 0001) et `ix_characters_server_id` (migration 0069), MySQL
+--   doit choisir l'un OU l'autre et fait un seek puis une lecture de
+--   toutes les lignes correspondantes pour filtrer le second prédicat.
+--   À mesure que la table grossit (multi-comptes × multi-personnages ×
+--   multi-shards), cette double-passe domine le coût de ces requêtes.
+--
+--   Un index compound `(server_id, account_id)` permet à l'optimiseur
+--   de faire un seek unique pour les 2 prédicats. L'ordre des colonnes
+--   suit la recommandation de l'audit 2026-05-27 ; l'ordre du WHERE en
+--   code C++ ne contraint pas l'optimiseur MySQL (qui re-ordonne).
+--
+-- Note de redondance (informationnelle, pas un nettoyage à faire ici) :
+--   L'index single `ix_characters_server_id` ajouté en migration 0069
+--   devient utilisable via le prefix de `ix_characters_server_account` ;
+--   il reste néanmoins en place pour ne pas casser le rollback éventuel
+--   de la migration 0070. Un nettoyage explicite peut être fait dans
+--   une migration ultérieure une fois cette PR validée en prod.
+--   L'index single `ix_characters_account_id` (migration 0001) reste
+--   utile pour les SELECT solo sur `WHERE account_id = ?` (ex :
+--   CharacterEnterWorldHandler:88) où server_id n'est pas dans le WHERE.
+--
+-- Idempotence : on vérifie INFORMATION_SCHEMA.STATISTICS avant CREATE.
+-- Pattern repris de sql/migrations/0040_factions.sql:101-108 et
+-- sql/migrations/0069_add_characters_server_id_index.sql.
+
+SET @idx_exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE table_schema = DATABASE()
+    AND table_name = 'characters'
+    AND index_name = 'ix_characters_server_account'
+);
+SET @stmt := IF(@idx_exists = 0,
+  'CREATE INDEX ix_characters_server_account ON characters (server_id, account_id)',
+  'SELECT ''index ix_characters_server_account already exists, skipping'' AS msg');
+PREPARE addidx FROM @stmt;
+EXECUTE addidx;
+DEALLOCATE PREPARE addidx;


### PR DESCRIPTION
## Summary

**PR 4 (chantier N3)** du cycle d'audit 2026-05-28.

Complète l'index simple `ix_characters_server_id` (ajouté par PR #722 / migration 0069) avec un index compound `(server_id, account_id)` pour optimiser les hot queries character-list / find-next-slot.

## Hot handlers concernés

| Handler | Ligne | Query (essentiel) |
|---|---|---|
| `CharacterListHandler.cpp` | 78-81 | `WHERE c.account_id = X AND c.server_id = Y AND c.deleted_at IS NULL ORDER BY slot ASC` |
| `CharacterCreateHandler.cpp` | 115-117 (FindNextSlot) | `WHERE account_id = X AND server_id = Y AND deleted_at IS NULL ORDER BY slot ASC` |

## Pourquoi un compound ?

Sans `(server_id, account_id)` compound, MySQL doit choisir entre `ix_characters_account_id` (0001) ou `ix_characters_server_id` (0069), faire un seek sur l'un, puis re-filtrer toutes les lignes correspondantes pour le second prédicat.

Avec le compound, un seek unique couvre les 2 prédicats → réduction significative du coût à mesure que la table grossit (multi-comptes × multi-personnages × multi-shards).

## Format

Migration **idempotente** via le pattern `INFORMATION_SCHEMA.STATISTICS` + `PREPARE`/`EXECUTE` conditionnel, identique à :
- `sql/migrations/0040_factions.sql:101-108`
- `sql/migrations/0069_add_characters_server_id_index.sql`

```sql
SET @idx_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS ...);
SET @stmt := IF(@idx_exists = 0,
  'CREATE INDEX ix_characters_server_account ON characters (server_id, account_id)',
  'SELECT ''already exists, skipping'' AS msg');
PREPARE addidx FROM @stmt;
EXECUTE addidx;
DEALLOCATE PREPARE addidx;
```

## Note de redondance documentée

`ix_characters_server_id` (0069) devient utilisable via le prefix de `ix_characters_server_account`. Il reste **en place volontairement** pour ne pas casser le rollback éventuel — un nettoyage explicite peut être fait dans une migration future une fois la PR validée en prod.

`ix_characters_account_id` (0001) **reste utile** pour les SELECT solo sur `WHERE account_id = ?` (ex. `CharacterEnterWorldHandler.cpp:88`, où `server_id` n'est pas dans le WHERE).

## Test plan

- [ ] CI build green (le `MigrationRunner` du master valide la syntaxe au lancement)
- [ ] Post-déploiement : `EXPLAIN SELECT id FROM characters WHERE account_id = X AND server_id = Y AND deleted_at IS NULL` doit montrer `Using index: ix_characters_server_account`
- [ ] Vérifier que l'idempotence fonctionne (relancer le binaire serveur ne fait pas planter)

## Déploiement

⚠️ **Master + DB lock-step requis**

- Migration appliquée au boot du binaire serveur via `MigrationRunner` (qui parse les fichiers `sql/migrations/NNNN_*.sql` et stocke un checksum SHA-256 par fichier)
- Pas de wire-breaking, pas de bump `kProtocolVersion`
- Pas de changement de code C++ — uniquement infra DB
- Pas d'impact client

🤖 Generated with [Claude Code](https://claude.com/claude-code)