### PR TITLE
feat(masterd): bloc prepared statements — 4 handlers + INSERT CharCreate (N1-B)

### DIFF
--- a/src/masterd/handlers/character/CharacterCreateHandler.cpp
+++ b/src/masterd/handlers/character/CharacterCreateHandler.cpp
@@ -86,28 +86,27 @@ namespace engine::server
 		return stmt->FetchRow();
 	}
 
-	uint64_t CharacterCreateHandler::ResolveDefaultServerId(void* mysqlPtr) const
+	uint64_t CharacterCreateHandler::ResolveDefaultServerId(void* mysqlPtr,
+		engine::server::db::SqlPreparedStatementCache* cache) const
 	{
 		MYSQL* mysql = reinterpret_cast<MYSQL*>(mysqlPtr);
 		const uint64_t configured = m_config ? static_cast<uint64_t>(std::max<int64_t>(0, m_config->GetInt("character_creation.default_server_id", 1))) : 1u;
-		std::string sql = "SELECT id FROM servers WHERE id = " + std::to_string(configured) + " LIMIT 1";
-		if (MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql))
+		if (!cache)
 		{
-			MYSQL_ROW row = mysql_fetch_row(res);
-			if (row && row[0])
-			{
-				uint64_t out = std::strtoull(row[0], nullptr, 10);
-				engine::server::db::DbFreeResult(res);
-				return out;
-			}
-			engine::server::db::DbFreeResult(res);
+			LOG_WARN(Net, "[CharacterCreateHandler] ResolveDefaultServerId : cache absent");
+			return 0;
 		}
-		if (MYSQL_RES* res = engine::server::db::DbQuery(mysql, "SELECT id FROM servers ORDER BY id ASC LIMIT 1"))
+		// Premier essai : ID configuré explicitement.
 		{
-			MYSQL_ROW row = mysql_fetch_row(res);
-			uint64_t out = (row && row[0]) ? std::strtoull(row[0], nullptr, 10) : 0u;
-			engine::server::db::DbFreeResult(res);
-			return out;
+			auto* stmt = cache->Acquire(mysql, "SELECT id FROM servers WHERE id = ? LIMIT 1");
+			if (stmt && stmt->Bind(0, configured) && stmt->Execute() && stmt->FetchRow())
+				return stmt->GetUInt64(0);
+		}
+		// Fallback : premier serveur de la table par ordre d'ID (pas de paramètre).
+		{
+			auto* stmt = cache->Acquire(mysql, "SELECT id FROM servers ORDER BY id ASC LIMIT 1");
+			if (stmt && stmt->Execute() && stmt->FetchRow())
+				return stmt->GetUInt64(0);
 		}
 		return 0;
 	}
@@ -196,7 +195,7 @@ namespace engine::server
 			return;
 		}
 
-		const uint64_t serverId = ResolveDefaultServerId(mysql);
+		const uint64_t serverId = ResolveDefaultServerId(mysql, stmtCache);
 		if (serverId == 0)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "no target server configured", requestId, sessionIdHeader);
@@ -230,9 +229,6 @@ namespace engine::server
 			return;
 		}
 
-		char escapedName[128]{};
-		mysql_real_escape_string(mysql, escapedName, parsed->name.c_str(), static_cast<unsigned long>(parsed->name.size()));
-
 		// Phase 3.6 — Spawn par défaut lu depuis la config serveur (peut être surchargé
 		// plus tard par le shard quand l'utilisateur se déconnecte / le serveur sauvegarde
 		// la position courante du personnage). Défauts cohérents avec le défaut client
@@ -243,13 +239,9 @@ namespace engine::server
 		const double spawnYaw   = m_config ? m_config->GetDouble("character_creation.default_spawn.yaw_deg", 0.0) : 0.0;
 		const double spawnPitch = m_config ? m_config->GetDouble("character_creation.default_spawn.pitch_deg", -10.0) : -10.0;
 
-		char spawnBuf[256]{};
-		std::snprintf(spawnBuf, sizeof(spawnBuf), "%.6f, %.6f, %.6f, %.6f, %.6f",
-			spawnX, spawnY, spawnZ, spawnYaw, spawnPitch);
-
 		// Phase 3.8 — Persistance des identifiants chaîne race/classe choisis par
 		// l'utilisateur (parsed->raceId / parsed->classId, ex. "humains" / "warrior").
-		// Limite à 32 chars (taille de la colonne) ; plus court côté SQL après escape.
+		// Limite à 32 chars (taille de la colonne).
 		auto truncate = [](const std::string& s) -> std::string {
 			constexpr size_t kMax = 32u;
 			return s.size() <= kMax ? s : s.substr(0, kMax);
@@ -275,33 +267,39 @@ namespace engine::server
 		const std::string genderStr = (parsed->gender == "female") ? "female" : "male";
 		// Teinte de peau (skinColorIdx) : entier non signé borné [0, 255] (0 = claire).
 		const uint32_t skinColorIdx = static_cast<uint32_t>(parsed->customization.skinColorIdx);
-		char escapedRace[80]{};
-		char escapedClass[80]{};
-		char escapedFaction[80]{};
-		char escapedGender[24]{};
-		mysql_real_escape_string(mysql, escapedRace,
-			raceIdTruncated.c_str(), static_cast<unsigned long>(raceIdTruncated.size()));
-		mysql_real_escape_string(mysql, escapedClass,
-			classIdTruncated.c_str(), static_cast<unsigned long>(classIdTruncated.size()));
-		mysql_real_escape_string(mysql, escapedFaction,
-			factionStr.c_str(), static_cast<unsigned long>(factionStr.size()));
-		mysql_real_escape_string(mysql, escapedGender,
-			genderStr.c_str(), static_cast<unsigned long>(genderStr.size()));
 
-		std::string sql =
+		// N1-B : INSERT via prepared statement. 14 paramètres bind (positions 0-13).
+		// Les 4 colonnes hardcodées (race_id=0, class_id=0, level=1, appearance_json='{}')
+		// restent en littéraux SQL — pas d'entrée utilisateur.
+		// Plus besoin de mysql_real_escape_string : le binding de string_view est safe.
+		if (!stmtCache)
+		{
+			LOG_WARN(Net, "[CharacterCreateHandler] INSERT : cache absent");
+			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "prepared statement cache unavailable", requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+		auto* insertStmt = stmtCache->Acquire(mysql,
 			"INSERT INTO characters (account_id, slot, name, server_id, race_id, class_id, level, appearance_json,"
-			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str, faction_str, gender, skin_color_idx) VALUES ("
-			+ std::to_string(*accountId) + ", "
-			+ std::to_string(slot) + ", '"
-			+ escapedName + "', "
-			+ std::to_string(serverId) + ", 0, 0, 1, '{}', "
-			+ spawnBuf + ", '"
-			+ escapedRace + "', '"
-			+ escapedClass + "', '"
-			+ escapedFaction + "', '"
-			+ escapedGender + "', "
-			+ std::to_string(skinColorIdx) + ")";
-		if (!engine::server::db::DbExecute(mysql, sql))
+			" spawn_x, spawn_y, spawn_z, spawn_yaw_deg, spawn_pitch_deg, race_str, class_str, faction_str, gender, skin_color_idx) "
+			"VALUES (?, ?, ?, ?, 0, 0, 1, '{}', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+		if (!insertStmt
+			|| !insertStmt->Bind(0,  *accountId)
+			|| !insertStmt->Bind(1,  static_cast<int32_t>(slot))
+			|| !insertStmt->Bind(2,  std::string_view(parsed->name))
+			|| !insertStmt->Bind(3,  serverId)
+			|| !insertStmt->Bind(4,  spawnX)
+			|| !insertStmt->Bind(5,  spawnY)
+			|| !insertStmt->Bind(6,  spawnZ)
+			|| !insertStmt->Bind(7,  spawnYaw)
+			|| !insertStmt->Bind(8,  spawnPitch)
+			|| !insertStmt->Bind(9,  std::string_view(raceIdTruncated))
+			|| !insertStmt->Bind(10, std::string_view(classIdTruncated))
+			|| !insertStmt->Bind(11, std::string_view(factionStr))
+			|| !insertStmt->Bind(12, std::string_view(genderStr))
+			|| !insertStmt->Bind(13, skinColorIdx)
+			|| !insertStmt->Execute())
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::BAD_REQUEST, "character creation failed", requestId, sessionIdHeader);
 			if (!pkt.empty())

--- a/src/masterd/handlers/character/CharacterCreateHandler.h
+++ b/src/masterd/handlers/character/CharacterCreateHandler.h
@@ -34,14 +34,15 @@ namespace engine::server
 
 	private:
 		bool IsValidCharacterName(std::string_view name) const;
-		/// Variantes par prepared statement (N1-A) :
+		/// Variantes par prepared statement (N1-A + N1-B) :
 		/// `cache` est récupéré depuis `ConnectionPool::Guard::cache()`. Null
 		/// désactive le chemin prepared et le helper retourne en erreur.
 		bool IsForbiddenCharacterName(void* mysqlPtr, engine::server::db::SqlPreparedStatementCache* cache,
 			std::string_view name) const;
 		bool CharacterNameExistsOnServer(void* mysqlPtr, engine::server::db::SqlPreparedStatementCache* cache,
 			std::string_view name, uint64_t serverId) const;
-		uint64_t ResolveDefaultServerId(void* mysqlPtr) const;
+		uint64_t ResolveDefaultServerId(void* mysqlPtr,
+			engine::server::db::SqlPreparedStatementCache* cache) const;
 		int FindNextSlot(void* mysqlPtr, engine::server::db::SqlPreparedStatementCache* cache,
 			uint64_t accountId, uint64_t serverId) const;
 

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -13,6 +13,7 @@
 #include "src/masterd/account/AccountRole.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -70,6 +71,7 @@ namespace engine::server
 
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
+		auto* stmtCache = guard.cache();
 		if (!mysql)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
@@ -83,30 +85,30 @@ namespace engine::server
 		// (rejette toute imposture comme un sender qui claim un autre nom que celui en DB).
 		// TA.3 : server_id sert au lookup du shard cible pour le push d'admission.
 		// TD.6 : gender (migration 0067, "male"/"female") propagé au shard via AdmitCharacter.
-		char queryBuf[256]{};
-		std::snprintf(queryBuf, sizeof(queryBuf),
-			"SELECT name, server_id, gender FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
-			static_cast<unsigned long long>(parsed->characterId),
-			static_cast<unsigned long long>(*accountId));
-
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
+		// N1-B : prepared statement (bind characterId, accountId).
 		std::string dbName;
 		std::string dbGender;
 		uint32_t dbServerId = 0;
 		bool found = false;
-		if (res)
+		if (stmtCache)
 		{
-			MYSQL_ROW row = mysql_fetch_row(res);
-			if (row && row[0])
+			auto* stmt = stmtCache->Acquire(mysql,
+				"SELECT name, server_id, gender FROM characters WHERE id = ? AND account_id = ? AND deleted_at IS NULL");
+			if (stmt
+				&& stmt->Bind(0, parsed->characterId)
+				&& stmt->Bind(1, *accountId)
+				&& stmt->Execute()
+				&& stmt->FetchRow())
 			{
-				dbName = row[0];
-				if (row[1])
-					dbServerId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-				if (row[2])
-					dbGender = row[2];
-				found = true;
+				dbName = stmt->GetString(0);
+				dbServerId = static_cast<uint32_t>(stmt->GetUInt64(1));
+				dbGender = stmt->GetString(2);
+				found = !dbName.empty();
 			}
-			engine::server::db::DbFreeResult(res);
+		}
+		else
+		{
+			LOG_WARN(Net, "[CharacterEnterWorldHandler] ownership query : cache absent");
 		}
 
 		if (!found)
@@ -132,19 +134,19 @@ namespace engine::server
 		// Rôle du compte : alimente la ventilation par rôle de l'API /status
 		// (players_by_role). Une requête séparée et tolérante aux erreurs — un rôle
 		// indéterminé retombe sur Player (sentinel sûr de ParseRole).
+		// N1-B : prepared statement (bind accountId).
 		AccountRole accountRole = AccountRole::Player;
+		if (stmtCache)
 		{
-			char roleQuery[160]{};
-			std::snprintf(roleQuery, sizeof(roleQuery),
-				"SELECT role FROM accounts WHERE id = %llu",
-				static_cast<unsigned long long>(*accountId));
-			MYSQL_RES* roleRes = engine::server::db::DbQuery(mysql, roleQuery);
-			if (roleRes)
+			auto* roleStmt = stmtCache->Acquire(mysql, "SELECT role FROM accounts WHERE id = ?");
+			if (roleStmt
+				&& roleStmt->Bind(0, *accountId)
+				&& roleStmt->Execute()
+				&& roleStmt->FetchRow())
 			{
-				MYSQL_ROW roleRow = mysql_fetch_row(roleRes);
-				if (roleRow && roleRow[0])
-					accountRole = engine::server::ParseRole(roleRow[0]);
-				engine::server::db::DbFreeResult(roleRes);
+				const std::string roleStr = roleStmt->GetString(0);
+				if (!roleStr.empty())
+					accountRole = engine::server::ParseRole(roleStr.c_str());
 			}
 		}
 

--- a/src/masterd/handlers/character/CharacterListHandler.cpp
+++ b/src/masterd/handlers/character/CharacterListHandler.cpp
@@ -9,6 +9,7 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -56,9 +57,18 @@ namespace engine::server
 
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
+		auto* stmtCache = guard.cache();
 		if (!mysql)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
+			if (!pkt.empty())
+				m_server->Send(connId, pkt);
+			return;
+		}
+		if (!stmtCache)
+		{
+			LOG_ERROR(Auth, "[CharacterListHandler] cache de prepared statements absent");
+			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "prepared statement cache unavailable", requestId, sessionIdHeader);
 			if (!pkt.empty())
 				m_server->Send(connId, pkt);
 			return;
@@ -67,7 +77,11 @@ namespace engine::server
 		// LEFT JOIN character_stats so characters who never logged in still appear (last_seen NULL → 0).
 		// Phase 3.6 — spawn position lue depuis characters.spawn_{x,y,z,yaw_deg,pitch_deg}.
 		// Phase 3.8 — race_str / class_str (chaînes ; cf. game/data/races/{races,classes}.json).
-		std::string sql =
+		// N1-B : prepared statement (bind accountId, serverId). Les colonnes float
+		// (spawn_*) sont lues via GetString() + strtof() — l'API SqlPreparedStatement
+		// lit tous les résultats en string (MYSQL_TYPE_STRING) et le parsing client
+		// préserve la précision.
+		auto* stmt = stmtCache->Acquire(mysql,
 			"SELECT c.id, c.slot, c.name, c.race_id, c.class_id, c.level, c.force_rename, "
 			"COALESCE(UNIX_TIMESTAMP(s.last_seen), 0) AS last_seen_unix, "
 			"COALESCE(s.total_play_seconds, 0) AS total_play, "
@@ -75,13 +89,12 @@ namespace engine::server
 			"c.race_str, c.class_str, c.gender, c.skin_color_idx "
 			"FROM characters c "
 			"LEFT JOIN character_stats s ON s.character_id = c.id AND s.server_id = c.server_id "
-			"WHERE c.account_id = " + std::to_string(*accountId)
-			+ " AND c.server_id = " + std::to_string(parsed->serverId)
-			+ " AND c.deleted_at IS NULL "
-			"ORDER BY c.slot ASC";
-
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"WHERE c.account_id = ? AND c.server_id = ? AND c.deleted_at IS NULL "
+			"ORDER BY c.slot ASC");
+		if (!stmt
+			|| !stmt->Bind(0, *accountId)
+			|| !stmt->Bind(1, static_cast<uint64_t>(parsed->serverId))
+			|| !stmt->Execute())
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "character list query failed", requestId, sessionIdHeader);
 			if (!pkt.empty())
@@ -90,36 +103,34 @@ namespace engine::server
 		}
 
 		std::vector<CharacterListEntry> entries;
-		MYSQL_ROW row = nullptr;
-		while ((row = mysql_fetch_row(res)) != nullptr)
+		while (stmt->FetchRow())
 		{
 			CharacterListEntry e;
-			if (row[0]) e.character_id    = std::strtoull(row[0], nullptr, 10);
-			if (row[1]) e.slot            = static_cast<uint8_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) e.name            = row[2];
-			if (row[3]) e.race_id         = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4]) e.class_id        = static_cast<uint16_t>(std::strtoul(row[4], nullptr, 10));
-			if (row[5]) e.level           = static_cast<uint16_t>(std::strtoul(row[5], nullptr, 10));
-			if (row[6]) e.force_rename    = static_cast<uint8_t>(std::strtoul(row[6], nullptr, 10) != 0u ? 1u : 0u);
-			if (row[7]) e.last_seen_unix  = std::strtoull(row[7], nullptr, 10);
-			if (row[8]) e.total_play_secs = std::strtoull(row[8], nullptr, 10);
-			// Phase 3.6 — spawn (5 colonnes ajoutées par migration 0032).
-			if (row[9])  e.spawn_x         = std::strtof(row[9], nullptr);
-			if (row[10]) e.spawn_y         = std::strtof(row[10], nullptr);
-			if (row[11]) e.spawn_z         = std::strtof(row[11], nullptr);
-			if (row[12]) e.spawn_yaw_deg   = std::strtof(row[12], nullptr);
-			if (row[13]) e.spawn_pitch_deg = std::strtof(row[13], nullptr);
+			e.character_id    = stmt->GetUInt64(0);
+			e.slot            = static_cast<uint8_t>(stmt->GetUInt64(1));
+			e.name            = stmt->GetString(2);
+			e.race_id         = static_cast<uint32_t>(stmt->GetUInt64(3));
+			e.class_id        = static_cast<uint16_t>(stmt->GetUInt64(4));
+			e.level           = static_cast<uint16_t>(stmt->GetUInt64(5));
+			e.force_rename    = static_cast<uint8_t>(stmt->GetUInt64(6) != 0u ? 1u : 0u);
+			e.last_seen_unix  = stmt->GetUInt64(7);
+			e.total_play_secs = stmt->GetUInt64(8);
+			// Phase 3.6 — spawn (5 colonnes ajoutées par migration 0032). Float via GetString + strtof.
+			e.spawn_x         = std::strtof(stmt->GetString(9).c_str(), nullptr);
+			e.spawn_y         = std::strtof(stmt->GetString(10).c_str(), nullptr);
+			e.spawn_z         = std::strtof(stmt->GetString(11).c_str(), nullptr);
+			e.spawn_yaw_deg   = std::strtof(stmt->GetString(12).c_str(), nullptr);
+			e.spawn_pitch_deg = std::strtof(stmt->GetString(13).c_str(), nullptr);
 			// Phase 3.8 — race / class strings (migration 0033).
-			if (row[14]) e.race_str  = row[14];
-			if (row[15]) e.class_str = row[15];
+			e.race_str  = stmt->GetString(14);
+			e.class_str = stmt->GetString(15);
 			// #1 serveur — genre (migration 0067). Defaut 'male' si vide/NULL.
-			if (row[16]) e.gender = row[16];
+			e.gender = stmt->GetString(16);
 			if (e.gender.empty()) e.gender = "male";
 			// Teinte de peau (migration 0068). Defaut 0 (claire) si vide/NULL.
-			if (row[17]) e.skin_color_idx = static_cast<uint8_t>(std::strtoul(row[17], nullptr, 10));
+			e.skin_color_idx = static_cast<uint8_t>(stmt->GetUInt64(17));
 			entries.push_back(std::move(e));
 		}
-		engine::server::db::DbFreeResult(res);
 
 		auto pkt = BuildCharacterListResponsePacket(1u, entries, requestId, sessionIdHeader);
 		if (pkt.empty() || !m_server->Send(connId, pkt))

--- a/src/masterd/handlers/chat/ChatRelayHandler.cpp
+++ b/src/masterd/handlers/chat/ChatRelayHandler.cpp
@@ -14,6 +14,7 @@
 #include "src/masterd/social/IgnoreList.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -326,6 +327,7 @@ namespace engine::server
 			{
 				auto guard = m_pool->Acquire();
 				MYSQL* mysql = guard.get();
+				auto* stmtCache = guard.cache();
 				if (!mysql)
 				{
 					auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
@@ -336,27 +338,26 @@ namespace engine::server
 
 				// Une seule requête : récupère tous les player_id qui partagent la guilde du sender.
 				// Si le sender n'a pas de ligne dans guild_members → result vide → on notice.
-				char queryBuf[512]{};
-				std::snprintf(queryBuf, sizeof(queryBuf),
-					"SELECT player_id FROM guild_members WHERE guild_id = "
-					"(SELECT guild_id FROM guild_members WHERE player_id = %llu LIMIT 1)",
-					static_cast<unsigned long long>(*accountId));
-
-				MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
+				// N1-B : prepared statement (bind accountId, utilisé dans la sub-query).
 				std::unordered_set<uint64_t> memberAccountIds;
-				if (res)
+				if (!stmtCache)
 				{
-					MYSQL_ROW row;
-					while ((row = mysql_fetch_row(res)) != nullptr)
+					LOG_WARN(Net, "[ChatRelayHandler] Guild routing : cache de prepared statements absent");
+				}
+				else
+				{
+					auto* stmt = stmtCache->Acquire(mysql,
+						"SELECT player_id FROM guild_members WHERE guild_id = "
+						"(SELECT guild_id FROM guild_members WHERE player_id = ? LIMIT 1)");
+					if (stmt && stmt->Bind(0, *accountId) && stmt->Execute())
 					{
-						if (row[0])
+						while (stmt->FetchRow())
 						{
-							const uint64_t pid = std::strtoull(row[0], nullptr, 10);
+							const uint64_t pid = stmt->GetUInt64(0);
 							if (pid != 0u)
 								memberAccountIds.insert(pid);
 						}
 					}
-					engine::server::db::DbFreeResult(res);
 				}
 
 				if (memberAccountIds.empty())
@@ -410,6 +411,7 @@ namespace engine::server
 			{
 				auto guard = m_pool->Acquire();
 				MYSQL* mysql = guard.get();
+				auto* stmtCache = guard.cache();
 				if (!mysql)
 				{
 					auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
@@ -418,27 +420,26 @@ namespace engine::server
 					return;
 				}
 
-				char queryBuf[256]{};
-				std::snprintf(queryBuf, sizeof(queryBuf),
-					"SELECT friend_id FROM friends WHERE player_id = %llu AND status = 1",
-					static_cast<unsigned long long>(*accountId));
-
-				MYSQL_RES* res = engine::server::db::DbQuery(mysql, queryBuf);
+				// N1-B : prepared statement (bind accountId).
 				std::unordered_set<uint64_t> friendAccountIds;
 				friendAccountIds.insert(*accountId); // sender voit son propre echo
-				if (res)
+				if (!stmtCache)
 				{
-					MYSQL_ROW row;
-					while ((row = mysql_fetch_row(res)) != nullptr)
+					LOG_WARN(Net, "[ChatRelayHandler] Friends routing : cache de prepared statements absent");
+				}
+				else
+				{
+					auto* stmt = stmtCache->Acquire(mysql,
+						"SELECT friend_id FROM friends WHERE player_id = ? AND status = 1");
+					if (stmt && stmt->Bind(0, *accountId) && stmt->Execute())
 					{
-						if (row[0])
+						while (stmt->FetchRow())
 						{
-							const uint64_t fid = std::strtoull(row[0], nullptr, 10);
+							const uint64_t fid = stmt->GetUInt64(0);
 							if (fid != 0u)
 								friendAccountIds.insert(fid);
 						}
 					}
-					engine::server::db::DbFreeResult(res);
 				}
 
 				if (friendAccountIds.size() == 1u)

--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -262,6 +262,14 @@ namespace engine::server::db
 		{
 			m_lru.splice(m_lru.begin(), m_lru, it->second);
 			it->second = m_lru.begin();
+			// Reset() avant retour : sans ça, une 2e exécution du même stmt après
+			// un FetchRow() consommé peut échouer (libmysql conserve l'état du
+			// résultat précédent jusqu'à mysql_stmt_free_result/mysql_stmt_reset).
+			// Reset() est no-op sur un stmt fraîchement préparé jamais exécuté.
+			// Si Reset() échoue (connexion morte / stmt corrompu), on retourne
+			// nullptr — le call site sait que l'acquisition a échoué.
+			if (!it->second->stmt->Reset())
+				return nullptr;
 			return it->second->stmt.get();
 		}
 


### PR DESCRIPTION
## Summary

**PR 6 (chantier N1-B)** du cycle d'audit 2026-05-28. Suite directe de [PR #730](https://github.com/tips-of-mine/LCDLLN-test/pull/730) (N1-A POC, mergée).

Convertit en prepared statements toutes les queries SQL avec entrée utilisateur des **4 handlers hot restants** + l'INSERT massive de `CharacterCreateHandler` + `ResolveDefaultServerId`. Ajoute aussi un correctif défensif au helper `SqlPreparedStatementCache::Acquire()` pour sécuriser la ré-exécution d'un cached stmt.

## Détail des conversions

### CharacterEnterWorldHandler (2 queries)
- `SELECT name, server_id, gender FROM characters WHERE id = ? AND account_id = ? AND deleted_at IS NULL`
- `SELECT role FROM accounts WHERE id = ?`

### CharacterListHandler (1 query, 18 colonnes)
Le gros SELECT JOIN avec spawn position. **Bind** : accountId, serverId. **Floats** (spawn_*) lus via `GetString()` + `strtof()` — l'API lit tous les résultats en `MYSQL_TYPE_STRING`, le parsing client préserve la précision.

### ChatRelayHandler (2 queries)
- `SELECT player_id FROM guild_members WHERE guild_id = (SELECT guild_id FROM guild_members WHERE player_id = ? LIMIT 1)`
- `SELECT friend_id FROM friends WHERE player_id = ? AND status = 1`

### CharacterCreateHandler (finition)
- **ResolveDefaultServerId** : 2 SELECTs (id configuré + fallback ASC)
- **INSERT massive** : 14 binds (positions 0-13). Les 4 colonnes hardcodées (race_id=0, class_id=0, level=1, appearance_json='{}') restent en littéraux SQL. Plus besoin de \`mysql_real_escape_string\` : le binding string_view est safe.
- \`mysql_insert_id(mysql)\` après \`mysql_stmt_execute\` fonctionne normalement (libmysql maintient le last insert id sur la connexion, pas le stmt).

## Correctif critique : Reset() automatique sur cache hit

⚠️ **Point critique détecté** : sans \`Reset()\` entre 2 exécutions du même cached stmt (après un \`FetchRow()\` consommé), \`mysql_stmt_execute\` peut échouer — libmysql conserve l'état du résultat précédent jusqu'à \`mysql_stmt_free_result\`/\`mysql_stmt_reset\`. Les tests existants ne couvrent pas la ré-exécution d'un stmt cached.

**Solution défensive** dans \`SqlPreparedStatement.cpp:Cache::Acquire()\` :
- Sur **cache hit** : appel automatique de \`stmt->Reset()\` AVANT retour
- \`Reset()\` est no-op sur un stmt fraîchement préparé jamais exécuté → compat ascendante OK
- Si \`Reset()\` échoue (connexion morte / stmt corrompu) → retour \`nullptr\`, le call site gère

→ Protège N1-A (déjà mergée) ET cette PR ET tous les futurs call sites.

## Hors scope

- **AuthRegisterHandler** : pas de SQL direct, passe par \`MysqlAccountStore\` (chantier séparé si voulu)
- **Autres handlers à concat SQL résiduelle** (\`EnterDungeonHandler\`, \`CharacterDeleteHandler\`, \`CharacterSavePositionHandler\`, \`TermsRepository\`, \`AdminCommandHandler\` INSERT) : pas dans les 5 hot handlers de l'audit, candidats follow-up

## Diff

- 6 fichiers, **+155 / -134 lignes**
- 0 occurence SQL legacy (\`DbQuery\`, \`DbExecute\`, \`mysql_real_escape_string\`, \`mysql_fetch_row\`) dans les 4 handlers cibles

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants (notamment \`sql_prepared_statement_tests\`, \`db_layer_tests\`)
- [ ] Manuel post-déploiement :
  - **Création de perso** : nom interdit / nom déjà pris / slot full → mêmes erreurs distinctes qu'avant
  - **Login + character list** : liste s'affiche avec spawn position correcte
  - **EnterWorld** : connexion en jeu fonctionne, ownership validée
  - **Chat Guild + Friends** : routage par membres / amis fonctionne
- [ ] Logs master : aucun \`[WARN][Net] ... cache absent\`

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)