### PR TITLE
fix(web-portal): aligne template password-reset sur le TTL réel (30→10 min)

### DIFF
--- a/web-portal/email-templates/password-reset.en.html
+++ b/web-portal/email-templates/password-reset.en.html
@@ -39,7 +39,7 @@
     <!-- Text -->
     <tr><td style="padding:28px 40px 20px;">
       <p style="font-family:'EB Garamond',Georgia,serif;font-size:16px;color:#D0D8E4;line-height:1.65;margin:0;">
-        Click the button below to choose a new password. This link is valid for <strong style="color:#F2F4F8;">30 minutes</strong> and can only be used once.
+        Click the button below to choose a new password. This link is valid for <strong style="color:#F2F4F8;">10 minutes</strong> and can only be used once.
       </p>
     </td></tr>
 

--- a/web-portal/email-templates/password-reset.fr.html
+++ b/web-portal/email-templates/password-reset.fr.html
@@ -39,7 +39,7 @@
     <!-- Texte -->
     <tr><td style="padding:28px 40px 20px;">
       <p style="font-family:'EB Garamond',Georgia,serif;font-size:16px;color:#D0D8E4;line-height:1.65;margin:0;">
-        Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe. Ce lien est valable <strong style="color:#F2F4F8;">30 minutes</strong> et ne peut être utilisé qu'une seule fois.
+        Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe. Ce lien est valable <strong style="color:#F2F4F8;">10 minutes</strong> et ne peut être utilisé qu'une seule fois.
       </p>
     </td></tr>
 


### PR DESCRIPTION
## Summary

Fix d'incohérence textuelle pré-existante signalée dans [PR #726](https://github.com/tips-of-mine/LCDLLN-test/pull/726) (N7) :

- Le **template HTML** password-reset (FR + EN) affichait « lien valable 30 minutes »
- Le **token réel** expire après `INTERVAL 10 MINUTE` (`lib/auth/passwordRecovery.ts:283`)
- Le **message de retour API** mentionnait correctement « valable 10 minutes » (`lib/auth/passwordRecovery.ts:295`)

→ Seuls les 2 templates HTML étaient out-of-sync.

## Diff

| Fichier | Avant | Après |
|---|---|---|
| `web-portal/email-templates/password-reset.fr.html:42` | « valable **30 minutes** » | « valable **10 minutes** » |
| `web-portal/email-templates/password-reset.en.html:42` | « valid for **30 minutes** » | « valid for **10 minutes** » |

**2 fichiers, +2 / -2 lignes**

## Test plan

- [ ] Trigger un password-reset sur un compte test
- [ ] Vérifier dans l'email reçu : le bouton dit « 10 minutes » (et plus 30)
- [ ] Optionnel : tester aussi côté EN si compte locale=en

## Déploiement

✅ **Web portal uniquement** — pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)