### PR TITLE
feat(masterd): bloc 5 handlers résiduels en prepared statements (N1-C)

### DIFF
--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -17,6 +17,7 @@
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 #include "src/shared/net/ChatSystem.h"
 #include "src/shared/network/AdminCommandPayloads.h"
 #include "src/shared/network/ChatPayloads.h"
@@ -160,20 +161,6 @@ namespace engine::server
 		{
 			using namespace std::chrono;
 			return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-		}
-
-		/// Echappe une chaine pour SQL (utilise par /mute : INSERT). Aligne
-		/// sur le helper DbHelpers (mais defini ici car on n'a pas
-		/// EscapeMysql exporte publiquement).
-		std::string EscapeForSql(MYSQL* mysql, std::string_view input)
-		{
-			if (!mysql)
-				return std::string(input);
-			std::string out(input.size() * 2u + 1u, '\0');
-			const unsigned long len = mysql_real_escape_string(mysql,
-				out.data(), input.data(), static_cast<unsigned long>(input.size()));
-			out.resize(len);
-			return out;
 		}
 
 		/// Dispatch metier pour "/sky moon <phase>". Valide l'argument et
@@ -745,21 +732,22 @@ namespace engine::server
 
 		auto guard = m_dbPool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* stmtCache = guard.cache();
+		if (!mysql || !stmtCache)
 		{
 			resp.status = AdminCommandStatus::ServerError;
 			resp.message = "DB indisponible";
 			return;
 		}
-		const std::string escReason = EscapeForSql(mysql, reason);
-		char sqlBuf[512];
-		std::snprintf(sqlBuf, sizeof(sqlBuf),
-			"REPLACE INTO chat_mutes (account_id, until_ts, reason) "
-			"VALUES (%llu, %llu, '%s')",
-			static_cast<unsigned long long>(target->account_id),
-			static_cast<unsigned long long>(untilTsMs),
-			escReason.c_str());
-		if (!engine::server::db::DbExecute(mysql, sqlBuf))
+		// N1-C : prepared statement (bind account_id, until_ts, reason).
+		// Plus besoin de EscapeForSql : le binding string_view est safe.
+		auto* stmt = stmtCache->Acquire(mysql,
+			"REPLACE INTO chat_mutes (account_id, until_ts, reason) VALUES (?, ?, ?)");
+		if (!stmt
+			|| !stmt->Bind(0, target->account_id)
+			|| !stmt->Bind(1, untilTsMs)
+			|| !stmt->Bind(2, std::string_view(reason))
+			|| !stmt->Execute())
 		{
 			resp.status = AdminCommandStatus::ServerError;
 			resp.message = "DB write failed";

--- a/src/masterd/handlers/character/CharacterDeleteHandler.cpp
+++ b/src/masterd/handlers/character/CharacterDeleteHandler.cpp
@@ -9,6 +9,7 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -54,7 +55,8 @@ namespace engine::server
 
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* stmtCache = guard.cache();
+		if (!mysql || !stmtCache)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
 			if (!pkt.empty())
@@ -65,12 +67,16 @@ namespace engine::server
 		// Soft delete : set deleted_at = NOW() conditionnellement à l'appartenance.
 		// Si le perso n'existe pas OU n'appartient pas au compte OU est déjà supprimé,
 		// l'UPDATE renvoie 0 affected rows — on répond NOT_FOUND sans révéler l'existence.
-		std::string sql =
+		// N1-C : prepared statement (bind characterId, accountId). On utilise
+		// stmt->AffectedRows() au lieu de mysql_affected_rows() pour fiabilité
+		// après mysql_stmt_execute.
+		auto* stmt = stmtCache->Acquire(mysql,
 			"UPDATE characters SET deleted_at = NOW() "
-			"WHERE id = " + std::to_string(parsed->characterId)
-			+ " AND account_id = " + std::to_string(*accountId)
-			+ " AND deleted_at IS NULL";
-		if (!engine::server::db::DbExecute(mysql, sql))
+			"WHERE id = ? AND account_id = ? AND deleted_at IS NULL");
+		if (!stmt
+			|| !stmt->Bind(0, parsed->characterId)
+			|| !stmt->Bind(1, *accountId)
+			|| !stmt->Execute())
 		{
 			LOG_ERROR(Auth, "[CharacterDeleteHandler] UPDATE failed (account_id={}, character_id={})",
 				*accountId, parsed->characterId);
@@ -80,7 +86,7 @@ namespace engine::server
 			return;
 		}
 
-		const my_ulonglong affected = mysql_affected_rows(mysql);
+		const uint64_t affected = stmt->AffectedRows();
 		if (affected == 0u)
 		{
 			LOG_WARN(Auth, "[CharacterDeleteHandler] no row updated (account_id={}, character_id={}) — not owned, missing or already deleted",

--- a/src/masterd/handlers/character/CharacterSavePositionHandler.cpp
+++ b/src/masterd/handlers/character/CharacterSavePositionHandler.cpp
@@ -9,6 +9,7 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -68,7 +69,8 @@ namespace engine::server
 
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* stmtCache = guard.cache();
+		if (!mysql || !stmtCache)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable", requestId, sessionIdHeader);
 			if (!pkt.empty())
@@ -78,17 +80,23 @@ namespace engine::server
 
 		// UPDATE gating par account_id : impossible de saver pour le perso d'un autre compte.
 		// Aussi gate sur deleted_at IS NULL — on ne sauve pas la position d'un perso supprimé.
-		char buf[512]{};
-		std::snprintf(buf, sizeof(buf),
-			"UPDATE characters SET spawn_x = %.6f, spawn_y = %.6f, spawn_z = %.6f, "
-			"spawn_yaw_deg = %.6f, spawn_pitch_deg = %.6f "
-			"WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
-			static_cast<double>(parsed->x), static_cast<double>(parsed->y), static_cast<double>(parsed->z),
-			static_cast<double>(parsed->yawDeg), static_cast<double>(parsed->pitchDeg),
-			static_cast<unsigned long long>(parsed->characterId),
-			static_cast<unsigned long long>(*accountId));
-
-		if (!engine::server::db::DbExecute(mysql, buf))
+		// N1-C : prepared statement (5 floats spawn + 2 ids). Bind double car
+		// l'API SqlPreparedStatement n'a pas de surcharge float (les float sont
+		// stockés en DOUBLE en interne MySQL si la colonne est FLOAT, la conversion
+		// est correcte).
+		auto* stmt = stmtCache->Acquire(mysql,
+			"UPDATE characters SET spawn_x = ?, spawn_y = ?, spawn_z = ?, "
+			"spawn_yaw_deg = ?, spawn_pitch_deg = ? "
+			"WHERE id = ? AND account_id = ? AND deleted_at IS NULL");
+		if (!stmt
+			|| !stmt->Bind(0, static_cast<double>(parsed->x))
+			|| !stmt->Bind(1, static_cast<double>(parsed->y))
+			|| !stmt->Bind(2, static_cast<double>(parsed->z))
+			|| !stmt->Bind(3, static_cast<double>(parsed->yawDeg))
+			|| !stmt->Bind(4, static_cast<double>(parsed->pitchDeg))
+			|| !stmt->Bind(5, parsed->characterId)
+			|| !stmt->Bind(6, *accountId)
+			|| !stmt->Execute())
 		{
 			LOG_ERROR(Auth, "[CharacterSavePositionHandler] UPDATE failed (account_id={}, character_id={})",
 				*accountId, parsed->characterId);
@@ -98,7 +106,7 @@ namespace engine::server
 			return;
 		}
 
-		const my_ulonglong affected = mysql_affected_rows(mysql);
+		const uint64_t affected = stmt->AffectedRows();
 		if (affected == 0u)
 		{
 			LOG_WARN(Auth, "[CharacterSavePositionHandler] no row updated (account_id={}, character_id={}) — not owned, missing or deleted",

--- a/src/masterd/handlers/dungeon/EnterDungeonHandler.cpp
+++ b/src/masterd/handlers/dungeon/EnterDungeonHandler.cpp
@@ -3,6 +3,7 @@
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 #include "src/shared/network/DungeonPayloads.h"
 #include "src/shared/network/ErrorPacket.h"
 #include "src/shared/network/NetServer.h"
@@ -61,7 +62,8 @@ namespace engine::server
 
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* stmtCache = guard.cache();
+		if (!mysql || !stmtCache)
 		{
 			auto pkt = BuildErrorPacket(NetErrorCode::INTERNAL_ERROR, "database unavailable",
 				requestId, sessionIdHeader);
@@ -71,18 +73,18 @@ namespace engine::server
 		}
 
 		// Ownership : le personnage doit appartenir au compte de la session.
-		char ownerQuery[256]{};
-		std::snprintf(ownerQuery, sizeof(ownerQuery),
-			"SELECT id FROM characters WHERE id = %llu AND account_id = %llu AND deleted_at IS NULL",
-			static_cast<unsigned long long>(parsed->characterId),
-			static_cast<unsigned long long>(*accountId));
-		MYSQL_RES* ownerRes = engine::server::db::DbQuery(mysql, ownerQuery);
+		// N1-C : prepared statement (bind characterId, accountId).
 		bool owned = false;
-		if (ownerRes)
 		{
-			MYSQL_ROW row = mysql_fetch_row(ownerRes);
-			owned = (row && row[0]);
-			engine::server::db::DbFreeResult(ownerRes);
+			auto* ownerStmt = stmtCache->Acquire(mysql,
+				"SELECT id FROM characters WHERE id = ? AND account_id = ? AND deleted_at IS NULL");
+			if (ownerStmt
+				&& ownerStmt->Bind(0, parsed->characterId)
+				&& ownerStmt->Bind(1, *accountId)
+				&& ownerStmt->Execute())
+			{
+				owned = ownerStmt->FetchRow();
+			}
 		}
 		if (!owned)
 		{
@@ -95,27 +97,18 @@ namespace engine::server
 			return;
 		}
 
-		// INSERT de l'instance de donjon. Le dungeon_template_id est
-		// échappé (valeur client). shard_endpoint reste vide (résolution
-		// multi-instance = follow-up).
-		std::string escapedTemplate;
-		escapedTemplate.resize(parsed->dungeonTemplateId.size() * 2u + 1u);
-		const unsigned long escLen = mysql_real_escape_string(mysql, escapedTemplate.data(),
-			parsed->dungeonTemplateId.c_str(),
-			static_cast<unsigned long>(parsed->dungeonTemplateId.size()));
-		escapedTemplate.resize(escLen);
-
-		std::string insertQuery =
+		// INSERT de l'instance de donjon. N1-C : prepared statement (bind 3 params).
+		// shard_endpoint reste '' (résolution multi-instance = follow-up).
+		// Plus besoin de mysql_real_escape_string : le binding string_view est safe.
+		auto* insertStmt = stmtCache->Acquire(mysql,
 			"INSERT INTO dungeon_instances "
-			"(dungeon_template_id, owner_character_id, difficulty, shard_endpoint) VALUES ('";
-		insertQuery += escapedTemplate;
-		insertQuery += "', ";
-		insertQuery += std::to_string(static_cast<unsigned long long>(parsed->characterId));
-		insertQuery += ", ";
-		insertQuery += std::to_string(static_cast<unsigned>(parsed->difficulty));
-		insertQuery += ", '')";
-
-		if (!engine::server::db::DbExecute(mysql, insertQuery))
+			"(dungeon_template_id, owner_character_id, difficulty, shard_endpoint) "
+			"VALUES (?, ?, ?, '')");
+		if (!insertStmt
+			|| !insertStmt->Bind(0, std::string_view(parsed->dungeonTemplateId))
+			|| !insertStmt->Bind(1, parsed->characterId)
+			|| !insertStmt->Bind(2, static_cast<uint32_t>(parsed->difficulty))
+			|| !insertStmt->Execute())
 		{
 			LOG_ERROR(Net, "[EnterDungeonHandler] INSERT dungeon_instances failed (character_id={}, template='{}')",
 				parsed->characterId, parsed->dungeonTemplateId);

--- a/src/masterd/handlers/terms/TermsRepository.cpp
+++ b/src/masterd/handlers/terms/TermsRepository.cpp
@@ -1,5 +1,7 @@
 #include "src/masterd/handlers/terms/TermsRepository.h"
 #include "src/shared/core/Log.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
@@ -61,32 +63,33 @@ namespace engine::server
 			return rows[0];
 		}
 
-		bool FetchAllLocales(MYSQL* mysql, uint64_t edition_id, std::vector<LocRow>& outRows)
+		// N1-C : conversion vers prepared statement. Le cache est requis ;
+		// retourne false si nullptr (le call site doit fournir un cache valide
+		// récupéré depuis ConnectionPool::Guard::cache()).
+		bool FetchAllLocales(MYSQL* mysql, engine::server::db::SqlPreparedStatementCache* cache,
+		                      uint64_t edition_id, std::vector<LocRow>& outRows)
 		{
-		std::string sql = "SELECT locale, title, content FROM terms_localizations WHERE edition_id = "
-			+ std::to_string(edition_id) + " ORDER BY locale ASC";
-			if (mysql_query(mysql, sql.c_str()) != 0)
+			if (!cache)
 			{
-				LOG_ERROR(Core, "[TermsRepository] query locales: {}", mysql_error(mysql));
+				LOG_ERROR(Core, "[TermsRepository] FetchAllLocales : cache absent");
 				return false;
 			}
-			MYSQL_RES* res = mysql_store_result(mysql);
-			if (!res)
+			auto* stmt = cache->Acquire(mysql,
+				"SELECT locale, title, content FROM terms_localizations WHERE edition_id = ? ORDER BY locale ASC");
+			if (!stmt || !stmt->Bind(0, edition_id) || !stmt->Execute())
 			{
-				LOG_ERROR(Core, "[TermsRepository] store_result locales failed");
+				LOG_ERROR(Core, "[TermsRepository] FetchAllLocales execute failed: {}", mysql_error(mysql));
 				return false;
 			}
 			outRows.clear();
-			MYSQL_ROW row;
-			while ((row = mysql_fetch_row(res)))
+			while (stmt->FetchRow())
 			{
 				LocRow lr;
-				if (row[0]) lr.locale = row[0];
-				if (row[1]) lr.title = row[1];
-				if (row[2]) lr.content = row[2];
+				lr.locale  = stmt->GetString(0);
+				lr.title   = stmt->GetString(1);
+				lr.content = stmt->GetString(2);
 				outRows.push_back(std::move(lr));
 			}
-			mysql_free_result(res);
 			return true;
 		}
 	} // namespace
@@ -108,27 +111,20 @@ namespace engine::server
 			return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
-		std::string sql =
+		// N1-C : prepared statement (bind account_id).
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT COUNT(*) FROM terms_editions e WHERE e.status = 'published' "
 			"AND e.published_at <= UTC_TIMESTAMP() AND NOT EXISTS ("
-			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = "
-			+ std::to_string(account_id) + " AND a.edition_id = e.id)";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = ? AND a.edition_id = e.id)");
+		if (!stmt || !stmt->Bind(0, account_id) || !stmt->Execute() || !stmt->FetchRow())
 		{
 			LOG_ERROR(Core, "[TermsRepository] HasPendingTerms query: {}", mysql_error(mysql));
 			return false;
 		}
-		MYSQL_RES* res = mysql_store_result(mysql);
-		if (!res)
-			return false;
-		MYSQL_ROW row = mysql_fetch_row(res);
-		unsigned long n = 0;
-		if (row && row[0])
-			n = std::strtoul(row[0], nullptr, 10);
-		mysql_free_result(res);
-		return n > 0;
+		return stmt->GetUInt64(0) > 0u;
 	}
 
 	uint32_t TermsRepository::CountPendingEditions(uint64_t account_id)
@@ -137,26 +133,21 @@ namespace engine::server
 			return 0;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return 0;
-		std::string sql =
+		// N1-C : prepared statement (bind account_id). Même query que HasPendingTerms
+		// mais retourne le count tel quel (capé à 999 pour rester dans uint32).
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT COUNT(*) FROM terms_editions e WHERE e.status = 'published' "
 			"AND e.published_at <= UTC_TIMESTAMP() AND NOT EXISTS ("
-			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = "
-			+ std::to_string(account_id) + " AND a.edition_id = e.id)";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = ? AND a.edition_id = e.id)");
+		if (!stmt || !stmt->Bind(0, account_id) || !stmt->Execute() || !stmt->FetchRow())
 		{
 			LOG_ERROR(Core, "[TermsRepository] CountPendingEditions: {}", mysql_error(mysql));
 			return 0;
 		}
-		MYSQL_RES* res = mysql_store_result(mysql);
-		if (!res)
-			return 0;
-		MYSQL_ROW row = mysql_fetch_row(res);
-		unsigned long n = 0;
-		if (row && row[0])
-			n = std::strtoul(row[0], nullptr, 10);
-		mysql_free_result(res);
+		const uint64_t n = stmt->GetUInt64(0);
 		return static_cast<uint32_t>(n > 999u ? 999u : n);
 	}
 
@@ -167,18 +158,14 @@ namespace engine::server
 			return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
-		std::string sql = "SELECT version_label FROM terms_editions WHERE id = " + std::to_string(edition_id) + " LIMIT 1";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT version_label FROM terms_editions WHERE id = ? LIMIT 1");
+		if (!stmt || !stmt->Bind(0, edition_id) || !stmt->Execute() || !stmt->FetchRow())
 			return false;
-		MYSQL_RES* res = mysql_store_result(mysql);
-		if (!res)
-			return false;
-		MYSQL_ROW row = mysql_fetch_row(res);
-		if (row && row[0])
-			out_label = row[0];
-		mysql_free_result(res);
+		out_label = stmt->GetString(0);
 		return !out_label.empty();
 	}
 
@@ -189,35 +176,27 @@ namespace engine::server
 			return true;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
-		std::string sql =
+		// N1-C : prepared statement (bind account_id).
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT e.id, e.version_label FROM terms_editions e WHERE e.status = 'published' "
 			"AND e.published_at <= UTC_TIMESTAMP() AND NOT EXISTS ("
-			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = "
-			+ std::to_string(account_id) + " AND a.edition_id = e.id) "
-			"ORDER BY e.published_at ASC, e.id ASC LIMIT 1";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+			"SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = ? AND a.edition_id = e.id) "
+			"ORDER BY e.published_at ASC, e.id ASC LIMIT 1");
+		if (!stmt || !stmt->Bind(0, account_id) || !stmt->Execute())
 		{
 			LOG_ERROR(Core, "[TermsRepository] GetFirstPending: {}", mysql_error(mysql));
 			return false;
 		}
-		MYSQL_RES* res = mysql_store_result(mysql);
-		if (!res)
-			return false;
-		MYSQL_ROW row = mysql_fetch_row(res);
-		if (!row || !row[0])
-		{
-			mysql_free_result(res);
-			return true;
-		}
-		out.edition_id = std::strtoull(row[0], nullptr, 10);
-		if (row[1])
-			out.version_label = row[1];
-		mysql_free_result(res);
+		if (!stmt->FetchRow())
+			return true; // aucune édition pending → OK, out reste vide
+		out.edition_id = stmt->GetUInt64(0);
+		out.version_label = stmt->GetString(1);
 
 		std::vector<LocRow> locs;
-		if (!FetchAllLocales(mysql, out.edition_id, locs))
+		if (!FetchAllLocales(mysql, cache, out.edition_id, locs))
 			return false;
 		auto pick = PickLocalization(locs, locale_pref, m_fallback_locale);
 		if (!pick)
@@ -234,10 +213,11 @@ namespace engine::server
 			return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
 		std::vector<LocRow> locs;
-		if (!FetchAllLocales(mysql, edition_id, locs) || locs.empty())
+		if (!FetchAllLocales(mysql, cache, edition_id, locs) || locs.empty())
 			return false;
 		auto pick = PickLocalization(locs, locale_pref, m_fallback_locale);
 		if (!pick)
@@ -253,26 +233,21 @@ namespace engine::server
 			return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
-		std::string sql =
-			"SELECT 1 FROM terms_editions e WHERE e.id = "
-			+ std::to_string(edition_id)
-			+ " AND e.status = 'published' AND e.published_at <= UTC_TIMESTAMP() "
-			"AND NOT EXISTS (SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = "
-			+ std::to_string(account_id) + " AND a.edition_id = e.id) LIMIT 1";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+		// N1-C : prepared statement (bind edition_id puis account_id — ordre des '?' dans le SQL).
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT 1 FROM terms_editions e WHERE e.id = ? "
+			"AND e.status = 'published' AND e.published_at <= UTC_TIMESTAMP() "
+			"AND NOT EXISTS (SELECT 1 FROM account_terms_acceptances a WHERE a.account_id = ? AND a.edition_id = e.id) "
+			"LIMIT 1");
+		if (!stmt || !stmt->Bind(0, edition_id) || !stmt->Bind(1, account_id) || !stmt->Execute())
 		{
 			LOG_ERROR(Core, "[TermsRepository] IsEditionPendingForAccount: {}", mysql_error(mysql));
 			return false;
 		}
-		MYSQL_RES* res = mysql_store_result(mysql);
-		if (!res)
-			return false;
-		MYSQL_ROW row = mysql_fetch_row(res);
-		const bool ok = (row != nullptr);
-		mysql_free_result(res);
-		return ok;
+		return stmt->FetchRow();
 	}
 
 	bool TermsRepository::RecordAcceptance(uint64_t account_id, uint64_t edition_id)
@@ -281,11 +256,13 @@ namespace engine::server
 			return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
-		std::string sql = "INSERT IGNORE INTO account_terms_acceptances (account_id, edition_id) VALUES ("
-			+ std::to_string(account_id) + ", " + std::to_string(edition_id) + ")";
-		if (mysql_query(mysql, sql.c_str()) != 0)
+		// N1-C : prepared statement (bind account_id, edition_id).
+		auto* stmt = cache->Acquire(mysql,
+			"INSERT IGNORE INTO account_terms_acceptances (account_id, edition_id) VALUES (?, ?)");
+		if (!stmt || !stmt->Bind(0, account_id) || !stmt->Bind(1, edition_id) || !stmt->Execute())
 		{
 			LOG_ERROR(Core, "[TermsRepository] RecordAcceptance: {}", mysql_error(mysql));
 			return false;

--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -232,6 +232,18 @@ namespace engine::server::db
 		return std::string(reinterpret_cast<const char*>(buf.data()), len);
 	}
 
+	uint64_t SqlPreparedStatement::AffectedRows() const
+	{
+		if (!m_stmt)
+			return 0;
+		const my_ulonglong n = mysql_stmt_affected_rows(m_stmt);
+		// my_ulonglong = uint64_t sur les builds standard, mais sentinelle (uint64_t)-1
+		// signifie erreur (ex. statement non exécuté). On normalise à 0.
+		if (n == static_cast<my_ulonglong>(-1))
+			return 0;
+		return static_cast<uint64_t>(n);
+	}
+
 	bool SqlPreparedStatement::Reset()
 	{
 		if (!m_stmt)

--- a/src/shared/db/SqlPreparedStatement.h
+++ b/src/shared/db/SqlPreparedStatement.h
@@ -50,6 +50,14 @@ namespace engine::server::db
 		uint64_t GetUInt64(size_t col, uint64_t fallback = 0) const;
 		std::string GetString(size_t col) const;
 
+		/// Nombre de rangs affectés par la dernière exécution INSERT/UPDATE/DELETE.
+		/// Pour SELECT, retourne le nombre de rangs résultat (idem mysql_num_rows).
+		/// À utiliser à la place de mysql_affected_rows(MYSQL*) après Execute() :
+		/// le compteur connexion-niveau de libmysql peut donner des valeurs incorrectes
+		/// après mysql_stmt_execute selon la version, alors que mysql_stmt_affected_rows
+		/// est garanti par la doc.
+		uint64_t AffectedRows() const;
+
 		/// Réinitialise les bindings et l'état pour une nouvelle exécution.
 		/// Le statement reste valide, on peut Bind+Execute à nouveau.
 		bool Reset();


### PR DESCRIPTION
## Summary

**Chantier 2 de la session 2** (suite de [PR #733](https://github.com/tips-of-mine/LCDLLN-test/pull/733) quick win template). Convertit en prepared statements les 5 handlers hot résiduels identifiés par l'audit 2026-05-28 comme candidats follow-up (hors scope initial des 5 hot handlers prioritaires).

Plus une extension API : ajout de `SqlPreparedStatement::AffectedRows()` nécessaire pour CharacterDelete + CharacterSavePosition.

## Handlers convertis (5 fichiers)

### 1. EnterDungeonHandler (2 queries)
- `SELECT id FROM characters WHERE id = ? AND account_id = ? AND deleted_at IS NULL` (ownership)
- `INSERT INTO dungeon_instances (dungeon_template_id, owner_character_id, difficulty, shard_endpoint) VALUES (?, ?, ?, '')` (3 binds, shard_endpoint='' littéral)

### 2. CharacterDeleteHandler (1 UPDATE)
- `UPDATE characters SET deleted_at = NOW() WHERE id = ? AND account_id = ? AND deleted_at IS NULL`
- `mysql_affected_rows()` → `stmt->AffectedRows()`

### 3. CharacterSavePositionHandler (1 UPDATE)
- `UPDATE characters SET spawn_x = ?, spawn_y = ?, spawn_z = ?, spawn_yaw_deg = ?, spawn_pitch_deg = ? WHERE id = ? AND account_id = ? AND deleted_at IS NULL`
- 7 binds (5 doubles spawn, 2 ids), `AffectedRows()` utilisé

### 4. TermsRepository (7 méthodes/fonctions)
| Méthode | Query |
|---|---|
| `FetchAllLocales` (helper) | SELECT locale, title, content FROM terms_localizations WHERE edition_id = ? |
| `HasPendingTerms` / `CountPendingEditions` | SELECT COUNT(*) FROM terms_editions e WHERE ... NOT EXISTS (... a.account_id = ?) |
| `GetEditionVersionLabel` | SELECT version_label FROM terms_editions WHERE id = ? LIMIT 1 |
| `GetFirstPending` | SELECT e.id, e.version_label FROM terms_editions ... ORDER BY ASC LIMIT 1 (+ FetchAllLocales) |
| `LoadEditionContent` | Appel FetchAllLocales |
| `IsEditionPendingForAccount` | SELECT 1 FROM terms_editions e WHERE e.id = ? AND NOT EXISTS (... a.account_id = ?) |
| `RecordAcceptance` | INSERT IGNORE INTO account_terms_acceptances (account_id, edition_id) VALUES (?, ?) |

### 5. AdminCommandHandler /mute (1 REPLACE INTO)
- `REPLACE INTO chat_mutes (account_id, until_ts, reason) VALUES (?, ?, ?)` (3 binds)
- Helper `EscapeForSql` supprimé (devenu orphelin, plus appelé après conversion)

## Extension API : SqlPreparedStatement::AffectedRows()

Nouvelle méthode `uint64_t AffectedRows() const` qui appelle `mysql_stmt_affected_rows(m_stmt)`. Nécessaire pour les UPDATE qui checkent affected rows pour discriminer « 0 rows = NOT_FOUND » vs « DB error ».

Plus fiable que `mysql_affected_rows(MYSQL*)` après `mysql_stmt_execute` selon les versions de libmysql — la doc MySQL recommande `mysql_stmt_affected_rows` après prepared execute.

Sentinelle `(my_ulonglong)-1` (statement non exécuté / erreur) normalisée à 0.

## Hors scope

- **AuthRegisterHandler via MysqlAccountStore** : volumineux, dans le **chantier 3** du plan utilisateur (PR séparée à venir)
- Autres queries dans masterd hors handlers principaux : non scannées systématiquement

## Diff

- 7 fichiers, **+159 / -167 lignes** (réduction nette grâce à la suppression d'`EscapeForSql` orphelin)
- 0 occurence SQL legacy (`DbQuery`, `DbExecute`, `mysql_real_escape_string`, `mysql_store_result`) dans les 5 fichiers cibles (sauf 3 commentaires de justification)

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants
- [ ] Manuel post-déploiement :
  - **Soft delete perso** : delete un perso → confirmer qu'il disparaît de la liste (CharacterDeleteHandler)
  - **Save position** : reconnecte un perso après mouvement → vérifier que la nouvelle position est conservée (CharacterSavePositionHandler)
  - **Entrée donjon** : tester `/dungeon enter` (si UI existe) ou EnterDungeonHandler via le client → instance créée en DB
  - **CGU pending** : utilisateur avec CGU pending → notice s'affiche (TermsRepository.HasPendingTerms / GetFirstPending / RecordAcceptance)
  - **/mute admin** : `/mute <player> 5` → ligne ajoutée dans `chat_mutes`, joueur muted 5 minutes

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)