### PR TITLE
feat(masterd): bloc 5 stores compacts en prepared statements (N1-E)

### DIFF
--- a/src/masterd/events/MysqlGameEventStore.cpp
+++ b/src/masterd/events/MysqlGameEventStore.cpp
@@ -1,14 +1,13 @@
 // Wave 5 Persistence (Phase 5.31b) - Implementation MysqlGameEventStore.
+// N1-E : converti en prepared statements (1 SELECT no-param).
 
 #include "src/masterd/events/MysqlGameEventStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdlib>
 
 namespace engine::server::events
 {
@@ -23,30 +22,28 @@ namespace engine::server::events
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		const char* sql =
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT event_id, name, start_ts_ms, duration_ms, recur_ms, "
-			"requires_lunar_phase_mask FROM game_events ORDER BY event_id ASC";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"requires_lunar_phase_mask FROM game_events ORDER BY event_id ASC");
+		if (!stmt || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlGameEventStore] LoadAll query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			GameEventRow r;
-			if (row[0]) r.eventId    = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.name       = row[1];
-			if (row[2]) r.startTsMs  = std::strtoull(row[2], nullptr, 10);
-			if (row[3]) r.durationMs = std::strtoull(row[3], nullptr, 10);
-			if (row[4]) r.recurMs    = std::strtoull(row[4], nullptr, 10);
-			if (row[5]) r.requiresLunarPhaseMask =
-				static_cast<uint16_t>(std::strtoul(row[5], nullptr, 10));
+			r.eventId    = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.name       = stmt->GetString(1);
+			r.startTsMs  = stmt->GetUInt64(2);
+			r.durationMs = stmt->GetUInt64(3);
+			r.recurMs    = stmt->GetUInt64(4);
+			r.requiresLunarPhaseMask = static_cast<uint16_t>(stmt->GetUInt64(5));
 			out.push_back(std::move(r));
 		}
-		engine::server::db::DbFreeResult(res);
 		LOG_INFO(Net, "[MysqlGameEventStore] LoadAll loaded {} events", out.size());
 		return out;
 	}

--- a/src/masterd/loot/MysqlLootStore.cpp
+++ b/src/masterd/loot/MysqlLootStore.cpp
@@ -1,15 +1,13 @@
 // Wave 5 Persistence (Phase 3.17b) - Implementation MysqlLootStore.
+// N1-E : converti en prepared statements (2 SELECTs).
 
 #include "src/masterd/loot/MysqlLootStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::loot_db
 {
@@ -24,26 +22,24 @@ namespace engine::server::loot_db
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		const char* sql =
-			"SELECT table_id, name, description FROM loot_tables "
-			"ORDER BY table_id ASC";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT table_id, name, description FROM loot_tables ORDER BY table_id ASC");
+		if (!stmt || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlLootStore] LoadAllTables query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			LootTableRow r;
-			if (row[0]) r.tableId     = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.name        = row[1];
-			if (row[2]) r.description = row[2];
+			r.tableId     = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.name        = stmt->GetString(1);
+			r.description = stmt->GetString(2);
 			out.push_back(std::move(r));
 		}
-		engine::server::db::DbFreeResult(res);
 		LOG_INFO(Net, "[MysqlLootStore] LoadAllTables loaded {} tables", out.size());
 		return out;
 	}
@@ -54,33 +50,30 @@ namespace engine::server::loot_db
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT entry_id, table_id, item_template_id, item_name, "
 			"drop_chance_pct, min_count, max_count "
-			"FROM loot_table_entries WHERE table_id = %u ORDER BY entry_id ASC",
-			tableId);
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM loot_table_entries WHERE table_id = ? ORDER BY entry_id ASC");
+		if (!stmt || !stmt->Bind(0, tableId) || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlLootStore] LoadEntriesForTable query failed tableId={}", tableId);
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			LootEntryRow r;
-			if (row[0]) r.entryId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.tableId          = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) r.itemTemplateId   = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
-			if (row[3]) r.itemName         = row[3];
-			if (row[4]) r.dropChancePct    = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
-			if (row[5]) r.minCount          = static_cast<uint32_t>(std::strtoul(row[5], nullptr, 10));
-			if (row[6]) r.maxCount          = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+			r.entryId         = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.tableId         = static_cast<uint32_t>(stmt->GetUInt64(1));
+			r.itemTemplateId  = static_cast<uint32_t>(stmt->GetUInt64(2));
+			r.itemName        = stmt->GetString(3);
+			r.dropChancePct   = static_cast<uint32_t>(stmt->GetUInt64(4));
+			r.minCount        = static_cast<uint32_t>(stmt->GetUInt64(5));
+			r.maxCount        = static_cast<uint32_t>(stmt->GetUInt64(6));
 			out.push_back(std::move(r));
 		}
-		engine::server::db::DbFreeResult(res);
 		LOG_INFO(Net, "[MysqlLootStore] LoadEntriesForTable tableId={} loaded {} entries", tableId, out.size());
 		return out;
 	}

--- a/src/masterd/quests/MysqlQuestStateStore.cpp
+++ b/src/masterd/quests/MysqlQuestStateStore.cpp
@@ -1,14 +1,14 @@
+// N1-E : converti en prepared statements (1 INSERT upsert + 1 DELETE + 1 SELECT).
+
 #include "src/masterd/quests/MysqlQuestStateStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
 #include <algorithm>
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::quests
 {
@@ -17,17 +17,18 @@ namespace engine::server::quests
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO account_quest_state (account_id, quest_id, status) "
-			"VALUES (%llu, %u, %u) "
-			"ON DUPLICATE KEY UPDATE status = VALUES(status)",
-			static_cast<unsigned long long>(accountId),
-			questId,
-			static_cast<unsigned>(status));
-		return engine::server::db::DbExecute(mysql, sql);
+			"VALUES (?, ?, ?) "
+			"ON DUPLICATE KEY UPDATE status = VALUES(status)");
+		return stmt
+			&& stmt->Bind(0, static_cast<uint64_t>(accountId))
+			&& stmt->Bind(1, static_cast<uint32_t>(questId))
+			&& stmt->Bind(2, static_cast<uint32_t>(status))
+			&& stmt->Execute();
 	}
 
 	bool MysqlQuestStateStore::Delete(AccountId accountId, QuestId questId)
@@ -35,13 +36,14 @@ namespace engine::server::quests
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"DELETE FROM account_quest_state WHERE account_id = %llu AND quest_id = %u",
-			static_cast<unsigned long long>(accountId),
-			questId);
-		return engine::server::db::DbExecute(mysql, sql);
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
+		auto* stmt = cache->Acquire(mysql,
+			"DELETE FROM account_quest_state WHERE account_id = ? AND quest_id = ?");
+		return stmt
+			&& stmt->Bind(0, static_cast<uint64_t>(accountId))
+			&& stmt->Bind(1, static_cast<uint32_t>(questId))
+			&& stmt->Execute();
 	}
 
 	std::vector<QuestStateRow> MysqlQuestStateStore::Load(AccountId accountId) const
@@ -50,25 +52,22 @@ namespace engine::server::quests
 		if (!m_pool || !m_pool->IsInitialized()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"SELECT account_id, quest_id, status FROM account_quest_state "
-			"WHERE account_id = %llu",
-			static_cast<unsigned long long>(accountId));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return out;
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT account_id, quest_id, status FROM account_quest_state WHERE account_id = ?");
+		if (!stmt || !stmt->Bind(0, static_cast<uint64_t>(accountId)) || !stmt->Execute())
+			return out;
+		while (stmt->FetchRow())
 		{
 			QuestStateRow r;
-			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
-			r.questId   = row[1] ? static_cast<QuestId>(std::strtoul(row[1], nullptr, 10)) : 0;
-			const auto st = row[2] ? static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10)) : 0u;
+			r.accountId = stmt->GetUInt64(0);
+			r.questId   = static_cast<QuestId>(stmt->GetUInt64(1));
+			const uint32_t st = static_cast<uint32_t>(stmt->GetUInt64(2));
 			r.status    = static_cast<QuestStatus>(std::min<uint32_t>(st, 5u));
 			out.push_back(r);
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 }

--- a/src/masterd/reputation/MysqlReputationStore.cpp
+++ b/src/masterd/reputation/MysqlReputationStore.cpp
@@ -1,13 +1,12 @@
+// N1-E : converti en prepared statements (1 INSERT upsert + 1 SELECT).
+
 #include "src/masterd/reputation/MysqlReputationStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::reputation
 {
@@ -16,18 +15,19 @@ namespace engine::server::reputation
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
 		// MySQL upsert : INSERT ... ON DUPLICATE KEY UPDATE.
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO account_reputation (account_id, faction_id, value) "
-			"VALUES (%llu, %u, %d) "
-			"ON DUPLICATE KEY UPDATE value = VALUES(value)",
-			static_cast<unsigned long long>(accountId),
-			factionId,
-			value);
-		return engine::server::db::DbExecute(mysql, sql);
+			"VALUES (?, ?, ?) "
+			"ON DUPLICATE KEY UPDATE value = VALUES(value)");
+		return stmt
+			&& stmt->Bind(0, static_cast<uint64_t>(accountId))
+			&& stmt->Bind(1, static_cast<uint32_t>(factionId))
+			&& stmt->Bind(2, value)
+			&& stmt->Execute();
 	}
 
 	std::vector<ReputationRow> MysqlReputationStore::Load(AccountId accountId) const
@@ -36,24 +36,21 @@ namespace engine::server::reputation
 		if (!m_pool || !m_pool->IsInitialized()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"SELECT account_id, faction_id, value FROM account_reputation "
-			"WHERE account_id = %llu",
-			static_cast<unsigned long long>(accountId));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return out;
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT account_id, faction_id, value FROM account_reputation WHERE account_id = ?");
+		if (!stmt || !stmt->Bind(0, static_cast<uint64_t>(accountId)) || !stmt->Execute())
+			return out;
+		while (stmt->FetchRow())
 		{
 			ReputationRow r;
-			r.accountId = row[0] ? std::strtoull(row[0], nullptr, 10) : 0;
-			r.factionId = row[1] ? static_cast<FactionId>(std::strtoul(row[1], nullptr, 10)) : 0;
-			r.value     = row[2] ? std::atoi(row[2]) : 0;
+			r.accountId = stmt->GetUInt64(0);
+			r.factionId = static_cast<FactionId>(stmt->GetUInt64(1));
+			r.value     = stmt->GetInt32(2);
 			out.push_back(r);
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 }

--- a/src/masterd/skills/MysqlSkillStore.cpp
+++ b/src/masterd/skills/MysqlSkillStore.cpp
@@ -1,15 +1,13 @@
 // Wave 5 Persistence (Phase 4.39b) - Implementation MysqlSkillStore.
+// N1-E : converti en prepared statements (1 SELECT + 1 INSERT upsert).
 
 #include "src/masterd/skills/MysqlSkillStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::skills
 {
@@ -24,30 +22,27 @@ namespace engine::server::skills
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT character_id, skill_id, value, cap, bonus "
-			"FROM character_skills WHERE character_id = %llu",
-			static_cast<unsigned long long>(characterId));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM character_skills WHERE character_id = ?");
+		if (!stmt || !stmt->Bind(0, characterId) || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlSkillStore] LoadForCharacter query failed character={}", characterId);
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			SkillRow r;
-			if (row[0]) r.characterId = std::strtoull(row[0], nullptr, 10);
-			if (row[1]) r.skillId     = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) r.value       = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
-			if (row[3]) r.cap         = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4]) r.bonus       = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
+			r.characterId = stmt->GetUInt64(0);
+			r.skillId     = static_cast<uint32_t>(stmt->GetUInt64(1));
+			r.value       = static_cast<uint32_t>(stmt->GetUInt64(2));
+			r.cap         = static_cast<uint32_t>(stmt->GetUInt64(3));
+			r.bonus       = static_cast<uint32_t>(stmt->GetUInt64(4));
 			out.push_back(r);
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 
@@ -56,18 +51,21 @@ namespace engine::server::skills
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO character_skills (character_id, skill_id, value, cap, bonus) "
-			"VALUES (%llu, %u, %u, %u, %u) "
+			"VALUES (?, ?, ?, ?, ?) "
 			"ON DUPLICATE KEY UPDATE "
-			"value = VALUES(value), cap = VALUES(cap), bonus = VALUES(bonus)",
-			static_cast<unsigned long long>(row.characterId),
-			row.skillId, row.value, row.cap, row.bonus);
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"value = VALUES(value), cap = VALUES(cap), bonus = VALUES(bonus)");
+		const bool ok = stmt
+			&& stmt->Bind(0, row.characterId)
+			&& stmt->Bind(1, row.skillId)
+			&& stmt->Bind(2, row.value)
+			&& stmt->Bind(3, row.cap)
+			&& stmt->Bind(4, row.bonus)
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlSkillStore] Upsert failed character={} skill={}",
 				row.characterId, row.skillId);


### PR DESCRIPTION
## Summary

**Bloc 1 du chantier stores Mysql restants** (suite de [PR #735](https://github.com/tips-of-mine/LCDLLN-test/pull/735) N1-D `MysqlAccountStore`). Convertit **5 stores compacts** (≤ 100 lignes chacun) en prepared statements.

## Stores convertis

| Store | Méthodes | Queries |
|---|---|---|
| `MysqlGameEventStore` | LoadAll | 1 SELECT no-param |
| `MysqlReputationStore` | Upsert + Load | 1 INSERT/ON DUPLICATE + 1 SELECT |
| `MysqlQuestStateStore` | Upsert + Delete + Load | 1 INSERT/ON DUPLICATE + 1 DELETE + 1 SELECT |
| `MysqlSkillStore` | LoadForCharacter + Upsert | 1 SELECT + 1 INSERT/ON DUPLICATE (5 cols) |
| `MysqlLootStore` | LoadAllTables + LoadEntriesForTable | 2 SELECTs |

## Impact sécurité

⚠️ **Faible** — aucun de ces stores n'avait d'entrée utilisateur côté string. Uniquement des `uint32_t`/`uint64_t` typés (`account_id`, `character_id`, `faction_id`, `quest_id`, `skill_id`, `table_id`, `value`).

Le bénéfice est **cohérence d'API** + protection future si un de ces paramètres devient un jour une string user-controlled.

## Diff

**5 fichiers, +117 / -133 lignes** (réduction nette grâce à la suppression du boilerplate `char sql[256]; snprintf(...)` remplacé par littéraux SQL + binds typés).

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants
- [ ] Manuel post-déploiement (non critique, ces stores sont peu sollicités) :
  - Chargement d'un personnage avec skills → `LoadForCharacter` OK
  - Quest progression → `Upsert/Load/Delete` OK
  - Réputation faction → `Upsert/Load` OK
  - Loot drop sur un mob → tables et entrées chargées
  - Events programmés visibles → `LoadAll` OK

## Restant pour le chantier complet

9 stores restants : `MysqlArenaStore` (105), `MysqlCinematicStore` (107), `MysqlIgnoreStore` (112), `MysqlBattleGroundStore` (114), `MysqlOutdoorPvpStore` (124), `MysqlGmTicketStore` (147), `MysqlAuctionStore` (173), `MysqlGuildStore` (209), `MysqlMailStore` (291). À faire en 2-3 PRs bloc supplémentaires.

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)