### PR TITLE
feat(masterd): bloc 5 stores moyens en prepared statements (N1-F)

### DIFF
--- a/src/masterd/arena/MysqlArenaStore.cpp
+++ b/src/masterd/arena/MysqlArenaStore.cpp
@@ -1,31 +1,16 @@
 // Wave 5 Persistence (Phase 5.21b) - Implementation MysqlArenaStore.
+// N1-F : converti en prepared statements (1 SELECT + 1 INSERT upsert).
 
 #include "src/masterd/arena/MysqlArenaStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
-#include <cstdio>
-#include <cstdlib>
-#include <vector>
-
 namespace engine::server::arena
 {
-	namespace
-	{
-		std::string EscapeMysql(MYSQL* mysql, const std::string& v)
-		{
-			if (!mysql) return {};
-			std::vector<char> buf(v.size() * 2 + 1);
-			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
-				static_cast<unsigned long>(v.size()));
-			return std::string(buf.data(), w);
-		}
-	}
-
 	bool MysqlArenaStore::IsAvailable() const noexcept
 	{
 		return m_pool && m_pool->IsInitialized();
@@ -37,35 +22,32 @@ namespace engine::server::arena
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT team_id, account_id_owner, name, size, rating, "
 			"weekly_games, weekly_wins, season_games, season_wins "
-			"FROM arena_teams WHERE account_id_owner = %llu ORDER BY team_id ASC",
-			static_cast<unsigned long long>(accountId));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM arena_teams WHERE account_id_owner = ? ORDER BY team_id ASC");
+		if (!stmt || !stmt->Bind(0, accountId) || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlArenaStore] LoadForAccount query failed account={}", accountId);
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			ArenaTeamRow r;
-			if (row[0]) r.teamId         = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.accountIdOwner = std::strtoull(row[1], nullptr, 10);
-			if (row[2]) r.name           = row[2];
-			if (row[3]) r.size           = static_cast<uint8_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4]) r.rating         = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
-			if (row[5]) r.weeklyGames    = static_cast<uint32_t>(std::strtoul(row[5], nullptr, 10));
-			if (row[6]) r.weeklyWins     = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
-			if (row[7]) r.seasonGames    = static_cast<uint32_t>(std::strtoul(row[7], nullptr, 10));
-			if (row[8]) r.seasonWins     = static_cast<uint32_t>(std::strtoul(row[8], nullptr, 10));
+			r.teamId         = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.accountIdOwner = stmt->GetUInt64(1);
+			r.name           = stmt->GetString(2);
+			r.size           = static_cast<uint8_t>(stmt->GetUInt64(3));
+			r.rating         = static_cast<uint32_t>(stmt->GetUInt64(4));
+			r.weeklyGames    = static_cast<uint32_t>(stmt->GetUInt64(5));
+			r.weeklyWins     = static_cast<uint32_t>(stmt->GetUInt64(6));
+			r.seasonGames    = static_cast<uint32_t>(stmt->GetUInt64(7));
+			r.seasonWins     = static_cast<uint32_t>(stmt->GetUInt64(8));
 			out.push_back(std::move(r));
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 
@@ -74,29 +56,29 @@ namespace engine::server::arena
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		const std::string name = EscapeMysql(mysql, row.name);
-
-		char sql[1024];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO arena_teams ("
 			"team_id, account_id_owner, name, size, rating, "
 			"weekly_games, weekly_wins, season_games, season_wins"
-			") VALUES (%u, %llu, '%s', %u, %u, %u, %u, %u, %u) "
+			") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
 			"ON DUPLICATE KEY UPDATE "
 			"name = VALUES(name), size = VALUES(size), rating = VALUES(rating), "
 			"weekly_games = VALUES(weekly_games), weekly_wins = VALUES(weekly_wins), "
-			"season_games = VALUES(season_games), season_wins = VALUES(season_wins)",
-			row.teamId,
-			static_cast<unsigned long long>(row.accountIdOwner),
-			name.c_str(),
-			static_cast<unsigned>(row.size),
-			row.rating,
-			row.weeklyGames, row.weeklyWins,
-			row.seasonGames, row.seasonWins);
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"season_games = VALUES(season_games), season_wins = VALUES(season_wins)");
+		const bool ok = stmt
+			&& stmt->Bind(0, row.teamId)
+			&& stmt->Bind(1, row.accountIdOwner)
+			&& stmt->Bind(2, std::string_view(row.name))
+			&& stmt->Bind(3, static_cast<uint32_t>(row.size))
+			&& stmt->Bind(4, row.rating)
+			&& stmt->Bind(5, row.weeklyGames)
+			&& stmt->Bind(6, row.weeklyWins)
+			&& stmt->Bind(7, row.seasonGames)
+			&& stmt->Bind(8, row.seasonWins)
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlArenaStore] Upsert failed team={} account={}",
 				row.teamId, row.accountIdOwner);

--- a/src/masterd/battleground/MysqlBattleGroundStore.cpp
+++ b/src/masterd/battleground/MysqlBattleGroundStore.cpp
@@ -1,32 +1,16 @@
 // Wave 5 Persistence (Phase 5.10b) - Implementation MysqlBattleGroundStore.
+// N1-F : converti en prepared statements (1 INSERT + 1 SELECT, LIMIT bindé).
 
 #include "src/masterd/battleground/MysqlBattleGroundStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
-#include <cstdio>
-#include <cstdlib>
-#include <vector>
-
 namespace engine::server::bg_db
 {
-	namespace
-	{
-		/// Echappe une chaine pour MySQL. Retourne vide si mysql null.
-		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
-		{
-			if (!mysql) return {};
-			std::vector<char> buf(v.size() * 2 + 1);
-			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
-				static_cast<unsigned long>(v.size()));
-			return std::string(buf.data(), w);
-		}
-	}
-
 	bool MysqlBattleGroundStore::IsAvailable() const noexcept
 	{
 		return m_pool && m_pool->IsInitialized();
@@ -40,25 +24,24 @@ namespace engine::server::bg_db
 		if (!IsAvailable()) return 0u;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return 0u;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0u;
 
-		const std::string mapEsc = EscapeMysql(mysql, mapName);
-
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO bg_match_history ("
 			"bg_type, map_name, alliance_score, horde_score, "
 			"winner_faction, duration_sec, started_at_unix_ms"
-			") VALUES (%u, '%s', %u, %u, %u, %u, %llu)",
-			static_cast<unsigned>(bgType),
-			mapEsc.c_str(),
-			allianceScore,
-			hordeScore,
-			static_cast<unsigned>(winnerFaction),
-			durationSec,
-			static_cast<unsigned long long>(startedAtUnixMs));
-
-		if (!engine::server::db::DbExecute(mysql, sql))
+			") VALUES (?, ?, ?, ?, ?, ?, ?)");
+		const bool ok = stmt
+			&& stmt->Bind(0, static_cast<uint32_t>(bgType))
+			&& stmt->Bind(1, mapName)
+			&& stmt->Bind(2, allianceScore)
+			&& stmt->Bind(3, hordeScore)
+			&& stmt->Bind(4, static_cast<uint32_t>(winnerFaction))
+			&& stmt->Bind(5, durationSec)
+			&& stmt->Bind(6, startedAtUnixMs)
+			&& stmt->Execute();
+		if (!ok)
 		{
 			LOG_WARN(Net, "[MysqlBattleGroundStore] InsertMatch failed bgType={} winner={}",
 				static_cast<unsigned>(bgType), static_cast<unsigned>(winnerFaction));
@@ -76,38 +59,36 @@ namespace engine::server::bg_db
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
 		// Clamp limit pour eviter une requete monstre par accident.
 		if (limit == 0u) limit = 1u;
 		if (limit > 1000u) limit = 1000u;
 
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		// LIMIT ? est supporté depuis MySQL 5.7 sur les prepared statements.
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT match_id, bg_type, map_name, alliance_score, "
 			"horde_score, winner_faction, duration_sec, started_at_unix_ms "
-			"FROM bg_match_history ORDER BY started_at_unix_ms DESC LIMIT %zu",
-			limit);
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM bg_match_history ORDER BY started_at_unix_ms DESC LIMIT ?");
+		if (!stmt || !stmt->Bind(0, static_cast<uint64_t>(limit)) || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlBattleGroundStore] LoadRecent query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			MatchHistoryRow r;
-			if (row[0]) r.matchId          = std::strtoull(row[0], nullptr, 10);
-			if (row[1]) r.bgType           = static_cast<uint16_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) r.mapName          = row[2];
-			if (row[3]) r.allianceScore    = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4]) r.hordeScore       = static_cast<uint32_t>(std::strtoul(row[4], nullptr, 10));
-			if (row[5]) r.winnerFaction    = static_cast<uint8_t>(std::strtoul(row[5], nullptr, 10));
-			if (row[6]) r.durationSec      = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
-			if (row[7]) r.startedAtUnixMs  = std::strtoull(row[7], nullptr, 10);
+			r.matchId          = stmt->GetUInt64(0);
+			r.bgType           = static_cast<uint16_t>(stmt->GetUInt64(1));
+			r.mapName          = stmt->GetString(2);
+			r.allianceScore    = static_cast<uint32_t>(stmt->GetUInt64(3));
+			r.hordeScore       = static_cast<uint32_t>(stmt->GetUInt64(4));
+			r.winnerFaction    = static_cast<uint8_t>(stmt->GetUInt64(5));
+			r.durationSec      = static_cast<uint32_t>(stmt->GetUInt64(6));
+			r.startedAtUnixMs  = stmt->GetUInt64(7);
 			out.push_back(std::move(r));
 		}
-		engine::server::db::DbFreeResult(res);
 		LOG_INFO(Net, "[MysqlBattleGroundStore] LoadRecent loaded {} rows (limit={})", out.size(), limit);
 		return out;
 	}

--- a/src/masterd/cinematics/MysqlCinematicStore.cpp
+++ b/src/masterd/cinematics/MysqlCinematicStore.cpp
@@ -1,26 +1,16 @@
 // Wave 11 Persistence Cinematics — Implementation MysqlCinematicStore.
+// N1-F : converti en prepared statements (1 INSERT IGNORE + 2 SELECTs).
 
 #include "src/masterd/cinematics/MysqlCinematicStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
-#include <cstdio>
-#include <cstdlib>
-
 namespace engine::server::cinematics
 {
-	namespace
-	{
-		// Pas de chaine a echapper pour cette table (cles numeriques uniquement),
-		// donc on omet EscapeMysql ici. Pattern Wave 5 garde la helper en
-		// anonymous namespace quand elle est utile ; on respecte la convention
-		// par absence quand on n'en a pas besoin.
-	}
-
 	bool MysqlCinematicStore::IsAvailable() const noexcept
 	{
 		return m_pool && m_pool->IsInitialized();
@@ -31,24 +21,22 @@ namespace engine::server::cinematics
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
 		// INSERT IGNORE : idempotent vis-a-vis de la PK (account_id, sequence_id).
 		// Si la ligne existe deja, on garde le first_seen_ts_ms d'origine.
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT IGNORE INTO cinematic_seen (account_id, sequence_id, first_seen_ts_ms) "
-			"VALUES (%llu, %u, %llu)",
-			static_cast<unsigned long long>(accountId),
-			sequenceId,
-			static_cast<unsigned long long>(nowMs));
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"VALUES (?, ?, ?)");
+		const bool ok = stmt
+			&& stmt->Bind(0, accountId)
+			&& stmt->Bind(1, sequenceId)
+			&& stmt->Bind(2, nowMs)
+			&& stmt->Execute();
 		if (!ok)
-		{
 			LOG_WARN(Net, "[MysqlCinematicStore] MarkSeen failed account={} sequenceId={}",
 				accountId, sequenceId);
-		}
 		return ok;
 	}
 
@@ -57,24 +45,21 @@ namespace engine::server::cinematics
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"SELECT 1 FROM cinematic_seen WHERE account_id = %llu AND sequence_id = %u LIMIT 1",
-			static_cast<unsigned long long>(accountId),
-			sequenceId);
-
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT 1 FROM cinematic_seen WHERE account_id = ? AND sequence_id = ? LIMIT 1");
+		if (!stmt
+			|| !stmt->Bind(0, accountId)
+			|| !stmt->Bind(1, sequenceId)
+			|| !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlCinematicStore] HasSeen query failed account={} sequenceId={}",
 				accountId, sequenceId);
 			return false;
 		}
-		const bool found = (mysql_fetch_row(res) != nullptr);
-		engine::server::db::DbFreeResult(res);
-		return found;
+		return stmt->FetchRow();
 	}
 
 	std::vector<uint32_t> MysqlCinematicStore::ListSeen(uint64_t accountId) const
@@ -83,25 +68,18 @@ namespace engine::server::cinematics
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"SELECT sequence_id FROM cinematic_seen WHERE account_id = %llu",
-			static_cast<unsigned long long>(accountId));
-
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT sequence_id FROM cinematic_seen WHERE account_id = ?");
+		if (!stmt || !stmt->Bind(0, accountId) || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlCinematicStore] ListSeen query failed account={}", accountId);
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
-		{
-			if (row[0])
-				out.push_back(static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10)));
-		}
-		engine::server::db::DbFreeResult(res);
+		while (stmt->FetchRow())
+			out.push_back(static_cast<uint32_t>(stmt->GetUInt64(0)));
 		return out;
 	}
 }

--- a/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
+++ b/src/masterd/outdoorpvp/MysqlOutdoorPvpStore.cpp
@@ -1,15 +1,13 @@
 // Wave 5 Persistence (Phase 5.36b) - Implementation MysqlOutdoorPvpStore.
+// N1-F : converti en prepared statements (2 SELECTs no-param + 2 INSERTs upsert).
 
 #include "src/masterd/outdoorpvp/MysqlOutdoorPvpStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::outdoorpvp_db
 {
@@ -24,28 +22,27 @@ namespace engine::server::outdoorpvp_db
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		const char* sql =
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT zone_id, objective_id, owner, capture_pct, capturing_by "
-			"FROM outdoor_pvp_state";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM outdoor_pvp_state");
+		if (!stmt || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlOutdoorPvpStore] LoadStates query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			ObjectiveRow r;
-			if (row[0]) r.zoneId      = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.objectiveId = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) r.owner       = static_cast<uint8_t>(std::strtoul(row[2], nullptr, 10));
-			if (row[3]) r.capturePct  = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4]) r.capturingBy = static_cast<uint8_t>(std::strtoul(row[4], nullptr, 10));
+			r.zoneId      = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.objectiveId = static_cast<uint32_t>(stmt->GetUInt64(1));
+			r.owner       = static_cast<uint8_t>(stmt->GetUInt64(2));
+			r.capturePct  = static_cast<uint32_t>(stmt->GetUInt64(3));
+			r.capturingBy = static_cast<uint8_t>(stmt->GetUInt64(4));
 			out.push_back(r);
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 
@@ -55,24 +52,24 @@ namespace engine::server::outdoorpvp_db
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		const char* sql = "SELECT zone_id, faction, score FROM outdoor_pvp_scores";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT zone_id, faction, score FROM outdoor_pvp_scores");
+		if (!stmt || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlOutdoorPvpStore] LoadScores query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
+		while (stmt->FetchRow())
 		{
 			ScoreRow r;
-			if (row[0]) r.zoneId  = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			if (row[1]) r.faction = static_cast<uint8_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2]) r.score   = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
+			r.zoneId  = static_cast<uint32_t>(stmt->GetUInt64(0));
+			r.faction = static_cast<uint8_t>(stmt->GetUInt64(1));
+			r.score   = static_cast<uint32_t>(stmt->GetUInt64(2));
 			out.push_back(r);
 		}
-		engine::server::db::DbFreeResult(res);
 		return out;
 	}
 
@@ -81,20 +78,22 @@ namespace engine::server::outdoorpvp_db
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO outdoor_pvp_state (zone_id, objective_id, owner, capture_pct, capturing_by) "
-			"VALUES (%u, %u, %u, %u, %u) "
+			"VALUES (?, ?, ?, ?, ?) "
 			"ON DUPLICATE KEY UPDATE "
 			"owner = VALUES(owner), capture_pct = VALUES(capture_pct), "
-			"capturing_by = VALUES(capturing_by)",
-			row.zoneId, row.objectiveId,
-			static_cast<unsigned>(row.owner), row.capturePct,
-			static_cast<unsigned>(row.capturingBy));
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"capturing_by = VALUES(capturing_by)");
+		const bool ok = stmt
+			&& stmt->Bind(0, row.zoneId)
+			&& stmt->Bind(1, row.objectiveId)
+			&& stmt->Bind(2, static_cast<uint32_t>(row.owner))
+			&& stmt->Bind(3, row.capturePct)
+			&& stmt->Bind(4, static_cast<uint32_t>(row.capturingBy))
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlOutdoorPvpStore] UpsertObjective failed zid={} oid={}",
 				row.zoneId, row.objectiveId);
@@ -106,16 +105,18 @@ namespace engine::server::outdoorpvp_db
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO outdoor_pvp_scores (zone_id, faction, score) "
-			"VALUES (%u, %u, %u) "
-			"ON DUPLICATE KEY UPDATE score = VALUES(score)",
-			row.zoneId, static_cast<unsigned>(row.faction), row.score);
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"VALUES (?, ?, ?) "
+			"ON DUPLICATE KEY UPDATE score = VALUES(score)");
+		const bool ok = stmt
+			&& stmt->Bind(0, row.zoneId)
+			&& stmt->Bind(1, static_cast<uint32_t>(row.faction))
+			&& stmt->Bind(2, row.score)
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlOutdoorPvpStore] UpsertScore failed zid={} fac={}",
 				row.zoneId, static_cast<unsigned>(row.faction));

--- a/src/masterd/social/MysqlIgnoreStore.cpp
+++ b/src/masterd/social/MysqlIgnoreStore.cpp
@@ -1,13 +1,12 @@
+// N1-F : converti en prepared statements (INSERT IGNORE + DELETE + 3 SELECTs).
+
 #include "src/masterd/social/MysqlIgnoreStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::social
 {
@@ -16,17 +15,17 @@ namespace engine::server::social
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
 		// INSERT IGNORE : si la PK (owner, target) existe deja, no-op.
 		// Le cap de 50 ignored est applique cote IgnoreListManager runtime.
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"INSERT IGNORE INTO account_ignore_list (owner_account_id, target_account_id) "
-			"VALUES (%llu, %llu)",
-			static_cast<unsigned long long>(owner),
-			static_cast<unsigned long long>(target));
-		return engine::server::db::DbExecute(mysql, sql);
+		auto* stmt = cache->Acquire(mysql,
+			"INSERT IGNORE INTO account_ignore_list (owner_account_id, target_account_id) VALUES (?, ?)");
+		return stmt
+			&& stmt->Bind(0, owner)
+			&& stmt->Bind(1, target)
+			&& stmt->Execute();
 	}
 
 	bool MysqlIgnoreStore::Remove(uint64_t owner, uint64_t target)
@@ -34,15 +33,16 @@ namespace engine::server::social
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"DELETE FROM account_ignore_list "
-			"WHERE owner_account_id = %llu AND target_account_id = %llu",
-			static_cast<unsigned long long>(owner),
-			static_cast<unsigned long long>(target));
-		return engine::server::db::DbExecute(mysql, sql);
+			"WHERE owner_account_id = ? AND target_account_id = ?");
+		return stmt
+			&& stmt->Bind(0, owner)
+			&& stmt->Bind(1, target)
+			&& stmt->Execute();
 	}
 
 	bool MysqlIgnoreStore::IsIgnored(uint64_t owner, uint64_t target) const
@@ -50,19 +50,18 @@ namespace engine::server::social
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT 1 FROM account_ignore_list "
-			"WHERE owner_account_id = %llu AND target_account_id = %llu LIMIT 1",
-			static_cast<unsigned long long>(owner),
-			static_cast<unsigned long long>(target));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return false;
-		const bool found = (mysql_fetch_row(res) != nullptr);
-		engine::server::db::DbFreeResult(res);
-		return found;
+			"WHERE owner_account_id = ? AND target_account_id = ? LIMIT 1");
+		if (!stmt
+			|| !stmt->Bind(0, owner)
+			|| !stmt->Bind(1, target)
+			|| !stmt->Execute())
+			return false;
+		return stmt->FetchRow();
 	}
 
 	std::vector<uint64_t> MysqlIgnoreStore::List(uint64_t owner) const
@@ -71,20 +70,16 @@ namespace engine::server::social
 		if (!m_pool || !m_pool->IsInitialized()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT target_account_id FROM account_ignore_list "
-			"WHERE owner_account_id = %llu ORDER BY target_account_id ASC",
-			static_cast<unsigned long long>(owner));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return out;
-		while (MYSQL_ROW row = mysql_fetch_row(res))
-		{
-			if (row[0]) out.push_back(std::strtoull(row[0], nullptr, 10));
-		}
-		engine::server::db::DbFreeResult(res);
+			"WHERE owner_account_id = ? ORDER BY target_account_id ASC");
+		if (!stmt || !stmt->Bind(0, owner) || !stmt->Execute())
+			return out;
+		while (stmt->FetchRow())
+			out.push_back(stmt->GetUInt64(0));
 		return out;
 	}
 
@@ -93,20 +88,13 @@ namespace engine::server::social
 		if (!m_pool || !m_pool->IsInitialized()) return 0;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return 0;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"SELECT COUNT(*) FROM account_ignore_list WHERE owner_account_id = %llu",
-			static_cast<unsigned long long>(owner));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return 0;
-		size_t count = 0;
-		if (MYSQL_ROW row = mysql_fetch_row(res))
-		{
-			if (row[0]) count = static_cast<size_t>(std::strtoull(row[0], nullptr, 10));
-		}
-		engine::server::db::DbFreeResult(res);
-		return count;
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT COUNT(*) FROM account_ignore_list WHERE owner_account_id = ?");
+		if (!stmt || !stmt->Bind(0, owner) || !stmt->Execute() || !stmt->FetchRow())
+			return 0;
+		return static_cast<size_t>(stmt->GetUInt64(0));
 	}
 }


### PR DESCRIPTION
## Summary

**Bloc 2 du chantier stores Mysql restants** (suite de [PR #736](https://github.com/tips-of-mine/LCDLLN-test/pull/736) N1-E bloc 1). Convertit 5 stores de taille moyenne (105-124 lignes) en prepared statements.

## Stores convertis

| Store | Méthodes | Strings user-controlled ? |
|---|---|---|
| `MysqlArenaStore` | LoadForAccount, Upsert | ✅ name (nom équipe) |
| `MysqlCinematicStore` | MarkSeen, HasSeen, ListSeen | ❌ uint only |
| `MysqlIgnoreStore` | Add, Remove, IsIgnored, List, Size | ❌ uint only |
| `MysqlBattleGroundStore` | InsertMatch, LoadRecent (LIMIT bindé) | ✅ mapName |
| `MysqlOutdoorPvpStore` | LoadStates, LoadScores, UpsertObjective, UpsertScore | ❌ uint only |

Total : 16 méthodes converties, ~20 queries.

## Highlights

- **2 stores avec strings user-controlled** (Arena.name, BattleGround.mapName) sont maintenant safe via `Bind(string_view)` au lieu de `mysql_real_escape_string`
- **LIMIT bindé** dans BattleGround : supporté depuis MySQL 5.7 sur les prepared statements. Clamp `[1, 1000]` préservé pour éviter une requête monstre par accident
- **2 helpers `EscapeMysql` supprimés** (orphelins après conversion)

## Diff

**5 fichiers, +179 / -249 lignes** (réduction nette grâce à la suppression du boilerplate `char sql[...]` + `snprintf` + helpers `EscapeMysql`)

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants
- [ ] Manuel post-déploiement :
  - Créer une équipe arena → ligne en `arena_teams`
  - Voir une cinématique → ligne en `cinematic_seen` (idempotent si revu)
  - `/ignore <joueur>` → ligne en `account_ignore_list`
  - Fin de bataille BG → ligne en `bg_match_history`
  - Objectif outdoor PvP capturé → upsert en `outdoor_pvp_state`

## Restant pour le chantier complet

4 stores restants : `MysqlGmTicketStore` (147), `MysqlAuctionStore` (173), `MysqlGuildStore` (209), `MysqlMailStore` (291). Soit ~820 lignes — 1 ou 2 PRs supplémentaires.

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)