### PR TITLE
feat(masterd): bloc GmTicket + Auction en prepared statements (N1-G)

### DIFF
--- a/src/masterd/auction/MysqlAuctionStore.cpp
+++ b/src/masterd/auction/MysqlAuctionStore.cpp
@@ -1,51 +1,37 @@
 // Wave 5 Persistence (Phase 5.09b) - Implementation MysqlAuctionStore.
+// N1-G : converti en prepared statements (LoadAllActive + Insert + UpdateBid + MarkEnded).
 
 #include "src/masterd/auction/MysqlAuctionStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
-
-#include <cstdio>
-#include <cstdlib>
-#include <vector>
 
 namespace engine::server::auctions
 {
 	namespace
 	{
-		/// Echappe une chaine pour MySQL via mysql_real_escape_string.
-		/// Retourne vide si mysql null.
-		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
-		{
-			if (!mysql) return {};
-			std::vector<char> buf(v.size() * 2 + 1);
-			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
-				static_cast<unsigned long>(v.size()));
-			return std::string(buf.data(), w);
-		}
-
-		/// Materialise une AuctionRow a partir d'un MYSQL_ROW.
-		/// L'ordre des colonnes est ALIGNE sur la query SELECT.
-		AuctionRow RowToAuction(MYSQL_ROW row)
+		/// Materialise une AuctionRow a partir d'un SqlPreparedStatement au FetchRow courant.
+		/// L'ordre des colonnes est ALIGNE sur la query SELECT (14 colonnes).
+		AuctionRow StmtToAuction(engine::server::db::SqlPreparedStatement* stmt)
 		{
 			AuctionRow a;
-			if (row[0])  a.auctionId               = std::strtoull(row[0], nullptr, 10);
-			if (row[1])  a.itemTemplateId          = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-			if (row[2])  a.itemName                = row[2];
-			if (row[3])  a.count                   = static_cast<uint32_t>(std::strtoul(row[3], nullptr, 10));
-			if (row[4])  a.startBidCopper          = std::strtoull(row[4], nullptr, 10);
-			if (row[5])  a.currentBidCopper        = std::strtoull(row[5], nullptr, 10);
-			if (row[6])  a.buyoutCopper            = std::strtoull(row[6], nullptr, 10);
-			if (row[7])  a.ownerAccountId          = std::strtoull(row[7], nullptr, 10);
-			if (row[8])  a.ownerName               = row[8];
-			if (row[9])  a.highestBidderAccountId  = std::strtoull(row[9], nullptr, 10);
-			if (row[10]) a.highestBidderName       = row[10];
-			if (row[11]) a.expiresAtUnixMs         = std::strtoull(row[11], nullptr, 10);
-			if (row[12]) a.ended                   = (std::strtoul(row[12], nullptr, 10) != 0u);
-			if (row[13]) a.wonByBuyout             = (std::strtoul(row[13], nullptr, 10) != 0u);
+			a.auctionId               = stmt->GetUInt64(0);
+			a.itemTemplateId          = static_cast<uint32_t>(stmt->GetUInt64(1));
+			a.itemName                = stmt->GetString(2);
+			a.count                   = static_cast<uint32_t>(stmt->GetUInt64(3));
+			a.startBidCopper          = stmt->GetUInt64(4);
+			a.currentBidCopper        = stmt->GetUInt64(5);
+			a.buyoutCopper            = stmt->GetUInt64(6);
+			a.ownerAccountId          = stmt->GetUInt64(7);
+			a.ownerName               = stmt->GetString(8);
+			a.highestBidderAccountId  = stmt->GetUInt64(9);
+			a.highestBidderName       = stmt->GetString(10);
+			a.expiresAtUnixMs         = stmt->GetUInt64(11);
+			a.ended                   = (stmt->GetUInt64(12) != 0u);
+			a.wonByBuyout             = (stmt->GetUInt64(13) != 0u);
 			return a;
 		}
 	}
@@ -61,26 +47,25 @@ namespace engine::server::auctions
 		if (!IsAvailable()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		// SELECT colonnes alignees sur RowToAuction (14 colonnes).
-		const char* sql =
+		// SELECT colonnes alignees sur StmtToAuction (14 colonnes).
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT auction_id, item_template_id, item_name, count, "
 			"start_bid_copper, current_bid_copper, buyout_copper, "
 			"owner_account_id, owner_name, "
 			"COALESCE(highest_bidder_account_id, 0), "
 			"COALESCE(highest_bidder_name, ''), "
 			"expires_at_unix_ms, ended, won_by_buyout "
-			"FROM auction_listings_v2 WHERE ended = 0";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res)
+			"FROM auction_listings_v2 WHERE ended = 0");
+		if (!stmt || !stmt->Execute())
 		{
 			LOG_WARN(Net, "[MysqlAuctionStore] LoadAllActive query failed");
 			return out;
 		}
-		while (MYSQL_ROW row = mysql_fetch_row(res))
-			out.push_back(RowToAuction(row));
-		engine::server::db::DbFreeResult(res);
+		while (stmt->FetchRow())
+			out.push_back(StmtToAuction(stmt));
 		LOG_INFO(Net, "[MysqlAuctionStore] LoadAllActive loaded {} active listings", out.size());
 		return out;
 	}
@@ -90,32 +75,29 @@ namespace engine::server::auctions
 		if (!IsAvailable()) return 0u;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return 0u;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0u;
 
-		const std::string itemName  = EscapeMysql(mysql, row.itemName);
-		const std::string ownerName = EscapeMysql(mysql, row.ownerName);
-
-		char sql[1024];
 		// AUTO_INCREMENT pour auction_id, on n'envoie pas la colonne.
-		std::snprintf(sql, sizeof(sql),
+		// 10 binds, ended=0 / won_by_buyout=0 littéraux (auction nouvellement créée).
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO auction_listings_v2 ("
 			"item_template_id, item_name, count, start_bid_copper, "
 			"current_bid_copper, buyout_copper, owner_account_id, owner_name, "
 			"expires_at_unix_ms, ended, won_by_buyout"
-			") VALUES ("
-			"%u, '%s', %u, %llu, %llu, %llu, %llu, '%s', %llu, 0, 0"
-			")",
-			row.itemTemplateId,
-			itemName.c_str(),
-			row.count,
-			static_cast<unsigned long long>(row.startBidCopper),
-			static_cast<unsigned long long>(row.currentBidCopper),
-			static_cast<unsigned long long>(row.buyoutCopper),
-			static_cast<unsigned long long>(row.ownerAccountId),
-			ownerName.c_str(),
-			static_cast<unsigned long long>(row.expiresAtUnixMs));
-
-		if (!engine::server::db::DbExecute(mysql, sql))
+			") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)");
+		const bool ok = stmt
+			&& stmt->Bind(0, row.itemTemplateId)
+			&& stmt->Bind(1, std::string_view(row.itemName))
+			&& stmt->Bind(2, row.count)
+			&& stmt->Bind(3, row.startBidCopper)
+			&& stmt->Bind(4, row.currentBidCopper)
+			&& stmt->Bind(5, row.buyoutCopper)
+			&& stmt->Bind(6, row.ownerAccountId)
+			&& stmt->Bind(7, std::string_view(row.ownerName))
+			&& stmt->Bind(8, row.expiresAtUnixMs)
+			&& stmt->Execute();
+		if (!ok)
 		{
 			LOG_WARN(Net, "[MysqlAuctionStore] Insert auction failed");
 			return 0u;
@@ -129,23 +111,21 @@ namespace engine::server::auctions
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		const std::string name = EscapeMysql(mysql, bidderName);
-
-		char sql[512];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"UPDATE auction_listings_v2 SET "
-			"current_bid_copper = %llu, "
-			"highest_bidder_account_id = %llu, "
-			"highest_bidder_name = '%s' "
-			"WHERE auction_id = %llu",
-			static_cast<unsigned long long>(newBidCopper),
-			static_cast<unsigned long long>(bidderAccountId),
-			name.c_str(),
-			static_cast<unsigned long long>(auctionId));
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+			"current_bid_copper = ?, "
+			"highest_bidder_account_id = ?, "
+			"highest_bidder_name = ? "
+			"WHERE auction_id = ?");
+		const bool ok = stmt
+			&& stmt->Bind(0, newBidCopper)
+			&& stmt->Bind(1, bidderAccountId)
+			&& stmt->Bind(2, bidderName)
+			&& stmt->Bind(3, auctionId)
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlAuctionStore] UpdateBid failed auctionId={}", auctionId);
 		return ok;
@@ -156,16 +136,16 @@ namespace engine::server::auctions
 		if (!IsAvailable()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
-			"UPDATE auction_listings_v2 SET ended = 1, won_by_buyout = %u "
-			"WHERE auction_id = %llu",
-			wonByBuyout ? 1u : 0u,
-			static_cast<unsigned long long>(auctionId));
-
-		const bool ok = engine::server::db::DbExecute(mysql, sql);
+		auto* stmt = cache->Acquire(mysql,
+			"UPDATE auction_listings_v2 SET ended = 1, won_by_buyout = ? "
+			"WHERE auction_id = ?");
+		const bool ok = stmt
+			&& stmt->Bind(0, static_cast<uint32_t>(wonByBuyout ? 1u : 0u))
+			&& stmt->Bind(1, auctionId)
+			&& stmt->Execute();
 		if (!ok)
 			LOG_WARN(Net, "[MysqlAuctionStore] MarkEnded failed auctionId={}", auctionId);
 		return ok;

--- a/src/masterd/gmtickets/MysqlGmTicketStore.cpp
+++ b/src/masterd/gmtickets/MysqlGmTicketStore.cpp
@@ -1,42 +1,30 @@
+// N1-G : converti en prepared statements (Insert, Update, Delete, Find, ListOpen).
+
 #include "src/masterd/gmtickets/MysqlGmTicketStore.h"
 
 #include "src/shared/core/Log.h"
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
 #include <algorithm>
-#include <cstdio>
-#include <cstdlib>
 
 namespace engine::server::gmtickets
 {
 	namespace
 	{
-		std::string EscapeMysql(MYSQL* mysql, std::string_view v)
-		{
-			if (!mysql) return {};
-			std::vector<char> buf(v.size() * 2 + 1);
-			const auto w = mysql_real_escape_string(mysql, buf.data(), v.data(),
-				static_cast<unsigned long>(v.size()));
-			return std::string(buf.data(), w);
-		}
-
-		GmTicket RowToTicket(MYSQL_ROW row)
+		GmTicket StmtToTicket(engine::server::db::SqlPreparedStatement* stmt)
 		{
 			GmTicket t;
-			if (row[0]) t.id           = std::strtoull(row[0], nullptr, 10);
-			if (row[1]) t.reporter     = std::strtoull(row[1], nullptr, 10);
-			if (row[2]) t.body         = row[2];
-			if (row[3]) t.createdTsMs  = std::strtoull(row[3], nullptr, 10);
-			if (row[4]) t.resolvedTsMs = std::strtoull(row[4], nullptr, 10);
-			if (row[5]) t.assignedGm   = std::strtoull(row[5], nullptr, 10);
-			if (row[6])
-			{
-				const auto st = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
-				t.state = static_cast<TicketState>(std::min<uint32_t>(st, 3));
-			}
+			t.id           = stmt->GetUInt64(0);
+			t.reporter     = stmt->GetUInt64(1);
+			t.body         = stmt->GetString(2);
+			t.createdTsMs  = stmt->GetUInt64(3);
+			t.resolvedTsMs = stmt->GetUInt64(4);
+			t.assignedGm   = stmt->GetUInt64(5);
+			const uint32_t st = static_cast<uint32_t>(stmt->GetUInt64(6));
+			t.state = static_cast<TicketState>(std::min<uint32_t>(st, 3));
 			return t;
 		}
 	}
@@ -46,22 +34,22 @@ namespace engine::server::gmtickets
 		if (!m_pool || !m_pool->IsInitialized()) return 0;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return 0;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0;
 
-		const std::string body = EscapeMysql(mysql, out.body);
-		char sql[1024];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"INSERT INTO gm_tickets (reporter_account_id, body, created_ts_ms, "
 			"resolved_ts_ms, assigned_gm, state) "
-			"VALUES (%llu, '%s', %llu, %llu, %llu, %u)",
-			static_cast<unsigned long long>(out.reporter),
-			body.c_str(),
-			static_cast<unsigned long long>(out.createdTsMs),
-			static_cast<unsigned long long>(out.resolvedTsMs),
-			static_cast<unsigned long long>(out.assignedGm),
-			static_cast<unsigned>(out.state));
-
-		if (!engine::server::db::DbExecute(mysql, sql))
+			"VALUES (?, ?, ?, ?, ?, ?)");
+		const bool ok = stmt
+			&& stmt->Bind(0, out.reporter)
+			&& stmt->Bind(1, std::string_view(out.body))
+			&& stmt->Bind(2, out.createdTsMs)
+			&& stmt->Bind(3, out.resolvedTsMs)
+			&& stmt->Bind(4, out.assignedGm)
+			&& stmt->Bind(5, static_cast<uint32_t>(out.state))
+			&& stmt->Execute();
+		if (!ok)
 		{
 			LOG_ERROR(Core, "[MysqlGmTicketStore] Insert failed");
 			return 0;
@@ -75,19 +63,19 @@ namespace engine::server::gmtickets
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
 
-		const std::string body = EscapeMysql(mysql, t.body);
-		char sql[1024];
-		std::snprintf(sql, sizeof(sql),
-			"UPDATE gm_tickets SET body = '%s', resolved_ts_ms = %llu, "
-			"assigned_gm = %llu, state = %u WHERE ticket_id = %llu",
-			body.c_str(),
-			static_cast<unsigned long long>(t.resolvedTsMs),
-			static_cast<unsigned long long>(t.assignedGm),
-			static_cast<unsigned>(t.state),
-			static_cast<unsigned long long>(t.id));
-		return engine::server::db::DbExecute(mysql, sql);
+		auto* stmt = cache->Acquire(mysql,
+			"UPDATE gm_tickets SET body = ?, resolved_ts_ms = ?, "
+			"assigned_gm = ?, state = ? WHERE ticket_id = ?");
+		return stmt
+			&& stmt->Bind(0, std::string_view(t.body))
+			&& stmt->Bind(1, t.resolvedTsMs)
+			&& stmt->Bind(2, t.assignedGm)
+			&& stmt->Bind(3, static_cast<uint32_t>(t.state))
+			&& stmt->Bind(4, t.id)
+			&& stmt->Execute();
 	}
 
 	bool MysqlGmTicketStore::Delete(TicketId id)
@@ -95,12 +83,10 @@ namespace engine::server::gmtickets
 		if (!m_pool || !m_pool->IsInitialized()) return false;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return false;
-		char sql[128];
-		std::snprintf(sql, sizeof(sql),
-			"DELETE FROM gm_tickets WHERE ticket_id = %llu",
-			static_cast<unsigned long long>(id));
-		return engine::server::db::DbExecute(mysql, sql);
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
+		auto* stmt = cache->Acquire(mysql, "DELETE FROM gm_tickets WHERE ticket_id = ?");
+		return stmt && stmt->Bind(0, static_cast<uint64_t>(id)) && stmt->Execute();
 	}
 
 	std::optional<GmTicket> MysqlGmTicketStore::Find(TicketId id) const
@@ -108,21 +94,16 @@ namespace engine::server::gmtickets
 		if (!m_pool || !m_pool->IsInitialized()) return std::nullopt;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return std::nullopt;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return std::nullopt;
 
-		char sql[256];
-		std::snprintf(sql, sizeof(sql),
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
 			"resolved_ts_ms, assigned_gm, state "
-			"FROM gm_tickets WHERE ticket_id = %llu LIMIT 1",
-			static_cast<unsigned long long>(id));
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return std::nullopt;
-		std::optional<GmTicket> out;
-		if (MYSQL_ROW row = mysql_fetch_row(res))
-			out = RowToTicket(row);
-		engine::server::db::DbFreeResult(res);
-		return out;
+			"FROM gm_tickets WHERE ticket_id = ? LIMIT 1");
+		if (!stmt || !stmt->Bind(0, static_cast<uint64_t>(id)) || !stmt->Execute() || !stmt->FetchRow())
+			return std::nullopt;
+		return StmtToTicket(stmt);
 	}
 
 	std::vector<GmTicket> MysqlGmTicketStore::ListOpen() const
@@ -131,17 +112,16 @@ namespace engine::server::gmtickets
 		if (!m_pool || !m_pool->IsInitialized()) return out;
 		auto guard = m_pool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql) return out;
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
 
-		const char* sql =
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT ticket_id, reporter_account_id, body, created_ts_ms, "
 			"resolved_ts_ms, assigned_gm, state "
-			"FROM gm_tickets WHERE state = 0 ORDER BY created_ts_ms ASC";
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-		if (!res) return out;
-		while (MYSQL_ROW row = mysql_fetch_row(res))
-			out.push_back(RowToTicket(row));
-		engine::server::db::DbFreeResult(res);
+			"FROM gm_tickets WHERE state = 0 ORDER BY created_ts_ms ASC");
+		if (!stmt || !stmt->Execute()) return out;
+		while (stmt->FetchRow())
+			out.push_back(StmtToTicket(stmt));
 		return out;
 	}
 }


### PR DESCRIPTION
## Summary

**Bloc 3 du chantier stores Mysql restants** (suite de [PR #737](https://github.com/tips-of-mine/LCDLLN-test/pull/737) N1-F). Convertit 2 stores moyens : `MysqlGmTicketStore` (147 lignes) + `MysqlAuctionStore` (173 lignes).

## Stores convertis

### MysqlGmTicketStore (5 méthodes, 6 queries)
- `Insert` : INSERT 6 cols (body string user-controlled)
- `Update` : UPDATE 4 cols + WHERE ticket_id (body string)
- `Delete` : DELETE WHERE ticket_id
- `Find` : SELECT 7 cols WHERE ticket_id
- `ListOpen` : SELECT 7 cols WHERE state = 0

Helper `RowToTicket(MYSQL_ROW)` → `StmtToTicket(SqlPreparedStatement*)`, `EscapeMysql` supprimé.

### MysqlAuctionStore (4 méthodes, 4 queries)
- `LoadAllActive` : SELECT 14 cols WHERE ended = 0
- `Insert` : INSERT 9 cols + 2 littéraux (ended=0, won_by_buyout=0). Inclut itemName + ownerName strings
- `UpdateBid` : UPDATE 3 cols + WHERE auction_id (bidderName string)
- `MarkEnded` : UPDATE 2 cols + WHERE auction_id

Helper `RowToAuction(MYSQL_ROW)` → `StmtToAuction(SqlPreparedStatement*)`, `EscapeMysql` supprimé.

## Impact sécurité

Strings user-controlled maintenant safe via `Bind(string_view)` :
- `gm_tickets.body` (rapport utilisateur, contenu libre)
- `auction_listings_v2.item_name` (nom item posté en vente)
- `auction_listings_v2.owner_name` (nom du vendeur)
- `auction_listings_v2.highest_bidder_name` (nom de l'enchérisseur)

## Diff

**2 fichiers, +122 / -162 lignes** (réduction nette -40 grâce à la suppression des helpers `EscapeMysql` + `RowTo*`)

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants
- [ ] Manuel post-déploiement :
  - Créer un ticket GM (`/gmticket new <body>`) → ligne en `gm_tickets`
  - GM résout un ticket → `Update` change state + resolved_ts
  - Poster un item à l'AH → ligne en `auction_listings_v2`
  - Faire une enchère → `UpdateBid` change current_bid + highest_bidder
  - Buyout → `MarkEnded` met ended=1, won_by_buyout=1

## Restant pour le chantier complet

2 stores restants : `MysqlGuildStore` (209 lignes), `MysqlMailStore` (291 lignes). Total ~500 lignes — 1 dernière PR `N1-H`.

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client/shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)