### PR TITLE
feat(masterd+shardd): tail-end prepared statements (N1-I) — clôture chantier complet

### DIFF
--- a/src/masterd/chat/ChatGate.cpp
+++ b/src/masterd/chat/ChatGate.cpp
@@ -5,6 +5,7 @@
 #include "src/masterd/account/AccountStore.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 
 #if defined(__unix__) || defined(__APPLE__)
 #include <mysql.h>
@@ -200,28 +201,20 @@ namespace engine::server::chat
 
 			auto guard = pool->Acquire();
 			MYSQL* mysql = guard.get();
-			if (!mysql)
+			auto* cache = guard.cache();
+			if (!mysql || !cache)
 				return std::nullopt;
 
-			char sql[256];
-			std::snprintf(sql, sizeof(sql),
-				"SELECT until_ts, reason FROM chat_mutes WHERE account_id = %llu LIMIT 1",
-				static_cast<unsigned long long>(accountId));
-
-			MYSQL_RES* res = engine::server::db::DbQuery(mysql, sql);
-			if (!res)
+			// N1-I : prepared statement (bind accountId).
+			auto* stmt = cache->Acquire(mysql,
+				"SELECT until_ts, reason FROM chat_mutes WHERE account_id = ? LIMIT 1");
+			if (!stmt || !stmt->Bind(0, accountId) || !stmt->Execute() || !stmt->FetchRow())
 				return std::nullopt;
 
-			std::optional<ChatMute> out;
-			if (MYSQL_ROW row = mysql_fetch_row(res))
-			{
-				ChatMute m;
-				m.untilTsMs = row[0] ? std::strtoull(row[0], nullptr, 10) : 0ULL;
-				m.reason    = row[1] ? row[1] : "";
-				out = std::move(m);
-			}
-			mysql_free_result(res);
-			return out;
+			ChatMute m;
+			m.untilTsMs = stmt->GetUInt64(0);
+			m.reason    = stmt->GetString(1);
+			return m;
 		};
 #else
 		(void)pool;

--- a/src/shardd/internals/globals/ConditionMgr.cpp
+++ b/src/shardd/internals/globals/ConditionMgr.cpp
@@ -1,12 +1,10 @@
 #include "src/shardd/internals/globals/ConditionMgr.h"
 
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 #include "src/shared/core/Log.h"
 
 #include <mysql.h>
-
-#include <cstdlib>
 
 namespace engine::server::shard::globals
 {
@@ -28,51 +26,46 @@ namespace engine::server::shard::globals
 
 		auto guard = pool.Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
 
-		// 1) Conditions atomiques.
+		// 1) Conditions atomiques. N1-I : prepared statement no-param.
 		{
-			MYSQL_RES* res = engine::server::db::DbQuery(mysql,
+			auto* stmt = cache->Acquire(mysql,
 				"SELECT condition_id, type, value1, value2, value3 FROM conditions");
-			if (!res)
+			if (!stmt || !stmt->Execute())
 				return false;
-			MYSQL_ROW row;
-			while ((row = mysql_fetch_row(res)) != nullptr)
+			while (stmt->FetchRow())
 			{
-				if (!row[0]) continue;
 				Condition c{};
-				c.conditionId = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-				c.type        = static_cast<ConditionType>(std::atoi(row[1]));
-				c.value1      = std::atoi(row[2]);
-				c.value2      = std::atoi(row[3]);
-				c.value3      = std::atoi(row[4]);
+				c.conditionId = static_cast<uint32_t>(stmt->GetUInt64(0));
+				c.type        = static_cast<ConditionType>(stmt->GetInt32(1));
+				c.value1      = stmt->GetInt32(2);
+				c.value2      = stmt->GetInt32(3);
+				c.value3      = stmt->GetInt32(4);
 				m_conditions.emplace(c.conditionId, c);
 			}
-			engine::server::db::DbFreeResult(res);
 		}
 
-		// 2) Condition groups (rows multiples par group_id).
+		// 2) Condition groups (rows multiples par group_id). N1-I : prepared statement.
 		{
-			MYSQL_RES* res = engine::server::db::DbQuery(mysql,
+			auto* stmt = cache->Acquire(mysql,
 				"SELECT group_id, logic, member_id, member_type FROM condition_groups "
 				"ORDER BY group_id, member_id");
-			if (!res)
+			if (!stmt || !stmt->Execute())
 				return false;
-			MYSQL_ROW row;
-			while ((row = mysql_fetch_row(res)) != nullptr)
+			while (stmt->FetchRow())
 			{
-				if (!row[0]) continue;
-				const uint32_t gid = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
+				const uint32_t gid = static_cast<uint32_t>(stmt->GetUInt64(0));
 				ConditionGroup& g = m_groups[gid];
 				g.groupId = gid;
-				g.logic   = static_cast<ConditionLogic>(std::atoi(row[1]));
+				g.logic   = static_cast<ConditionLogic>(stmt->GetInt32(1));
 				ConditionGroupMember m{};
-				m.memberId   = static_cast<uint32_t>(std::strtoul(row[2], nullptr, 10));
-				m.memberType = static_cast<ConditionMemberType>(std::atoi(row[3]));
+				m.memberId   = static_cast<uint32_t>(stmt->GetUInt64(2));
+				m.memberType = static_cast<ConditionMemberType>(stmt->GetInt32(3));
 				g.members.push_back(m);
 			}
-			engine::server::db::DbFreeResult(res);
 		}
 
 		// 3) Détection cycles dans les groups.

--- a/src/shardd/internals/globals/GraveyardManager.cpp
+++ b/src/shardd/internals/globals/GraveyardManager.cpp
@@ -1,7 +1,7 @@
 #include "src/shardd/internals/globals/GraveyardManager.h"
 
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 #include "src/shared/core/Log.h"
 
 #include <mysql.h>
@@ -19,30 +19,29 @@ namespace engine::server::shard::globals
 
 		auto guard = pool.Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
 
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql,
+		// N1-I : prepared statement no-param. Floats via GetString + strtof.
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT id, map_id, position_x, position_y, position_z, faction, zone_id "
 			"FROM graveyards");
-		if (!res)
+		if (!stmt || !stmt->Execute())
 			return false;
 
-		MYSQL_ROW row;
-		while ((row = mysql_fetch_row(res)) != nullptr)
+		while (stmt->FetchRow())
 		{
-			if (!row[0]) continue;
 			Graveyard g{};
-			g.id        = static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10));
-			g.mapId     = static_cast<uint32_t>(std::strtoul(row[1], nullptr, 10));
-			g.positionX = static_cast<float>(std::atof(row[2]));
-			g.positionY = static_cast<float>(std::atof(row[3]));
-			g.positionZ = static_cast<float>(std::atof(row[4]));
-			g.faction   = static_cast<FactionId>(std::atoi(row[5]));
-			g.zoneId    = static_cast<uint32_t>(std::strtoul(row[6], nullptr, 10));
+			g.id        = static_cast<uint32_t>(stmt->GetUInt64(0));
+			g.mapId     = static_cast<uint32_t>(stmt->GetUInt64(1));
+			g.positionX = std::strtof(stmt->GetString(2).c_str(), nullptr);
+			g.positionY = std::strtof(stmt->GetString(3).c_str(), nullptr);
+			g.positionZ = std::strtof(stmt->GetString(4).c_str(), nullptr);
+			g.faction   = static_cast<FactionId>(stmt->GetInt32(5));
+			g.zoneId    = static_cast<uint32_t>(stmt->GetUInt64(6));
 			m_graveyards.push_back(g);
 		}
-		engine::server::db::DbFreeResult(res);
 
 		m_loaded = true;
 		LOG_INFO(Core, "[GraveyardManager] Loaded {} graveyards", m_graveyards.size());

--- a/src/shardd/internals/globals/LocaleStrings.cpp
+++ b/src/shardd/internals/globals/LocaleStrings.cpp
@@ -1,12 +1,10 @@
 #include "src/shardd/internals/globals/LocaleStrings.h"
 
 #include "src/shared/db/ConnectionPool.h"
-#include "src/shared/db/DbHelpers.h"
+#include "src/shared/db/SqlPreparedStatement.h"
 #include "src/shared/core/Log.h"
 
 #include <mysql.h>
-
-#include <cstdlib>
 
 namespace engine::server::shard::globals
 {
@@ -19,25 +17,24 @@ namespace engine::server::shard::globals
 
 		auto guard = pool.Acquire();
 		MYSQL* mysql = guard.get();
-		if (!mysql)
+		auto* cache = guard.cache();
+		if (!mysql || !cache)
 			return false;
 
-		MYSQL_RES* res = engine::server::db::DbQuery(mysql,
+		// N1-I : prepared statement no-param.
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT string_id, locale_id, text FROM locale_strings");
-		if (!res)
+		if (!stmt || !stmt->Execute())
 			return false;
 
-		MYSQL_ROW row;
-		while ((row = mysql_fetch_row(res)) != nullptr)
+		while (stmt->FetchRow())
 		{
-			if (!row[0] || !row[1] || !row[2]) continue;
 			Key k{
-				static_cast<uint32_t>(std::strtoul(row[0], nullptr, 10)),
-				static_cast<LocaleId>(std::atoi(row[1]))
+				static_cast<uint32_t>(stmt->GetUInt64(0)),
+				static_cast<LocaleId>(stmt->GetInt32(1))
 			};
-			m_strings.emplace(k, std::string(row[2]));
+			m_strings.emplace(k, stmt->GetString(2));
 		}
-		engine::server::db::DbFreeResult(res);
 
 		m_loaded = true;
 		LOG_INFO(Core, "[LocaleStrings] Loaded {} strings, default locale = {}",

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -982,35 +982,28 @@ namespace engine::server
 		}
 		auto guard = m_characterDbPool->Acquire();
 		MYSQL* mysql = guard.get();
-		if (mysql == nullptr)
+		auto* cache = guard.cache();
+		if (mysql == nullptr || cache == nullptr)
 		{
 			return false;
 		}
-		char sql[256];
 		// TD.5 — on fetch aussi `name` pour le SnapshotEntity (plaque de nom).
 		// TD.6 — et `gender` (migration 0067) pour le rendu de l'avatar distant.
-		std::snprintf(sql, sizeof(sql),
+		// N1-I : prepared statement (bind characterId). Floats lus via GetString + strtof.
+		auto* stmt = cache->Acquire(mysql,
 			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender FROM characters "
-			"WHERE id = %llu AND deleted_at IS NULL",
-			static_cast<unsigned long long>(characterId));
-		MYSQL_RES* res = db::DbQuery(mysql, sql);
-		if (res == nullptr)
+			"WHERE id = ? AND deleted_at IS NULL");
+		if (!stmt || !stmt->Bind(0, characterId) || !stmt->Execute() || !stmt->FetchRow())
 		{
 			return false;
 		}
-		bool found = false;
-		if (MYSQL_ROW row = mysql_fetch_row(res))
-		{
-			x = row[0] ? std::strtof(row[0], nullptr) : 0.0f;
-			y = row[1] ? std::strtof(row[1], nullptr) : 0.0f;
-			z = row[2] ? std::strtof(row[2], nullptr) : 0.0f;
-			yawDeg = row[3] ? std::strtof(row[3], nullptr) : 0.0f;
-			outName = row[4] ? std::string(row[4]) : std::string{};
-			outGender = row[5] ? std::string(row[5]) : std::string{};
-			found = true;
-		}
-		db::DbFreeResult(res);
-		return found;
+		x = std::strtof(stmt->GetString(0).c_str(), nullptr);
+		y = std::strtof(stmt->GetString(1).c_str(), nullptr);
+		z = std::strtof(stmt->GetString(2).c_str(), nullptr);
+		yawDeg = std::strtof(stmt->GetString(3).c_str(), nullptr);
+		outName = stmt->GetString(4);
+		outGender = stmt->GetString(5);
+		return true;
 #else
 		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender;
 		return false;


### PR DESCRIPTION
## Summary

**Dernier bloc du chantier prepared statements transverse**. Convertit les 5 sites SQL résiduels qui ont accès au cache via `ConnectionPool::Guard`.

## Sites convertis (5 fichiers, 6 queries)

| Fichier | Query | Bind |
|---|---|---|
| `masterd/chat/ChatGate.cpp` | SELECT chat_mutes WHERE account_id = ? | accountId |
| `shared/server_bootstrap/ServerApp.cpp` | SELECT spawn_*+name+gender WHERE id = ? | characterId |
| `shardd/internals/globals/LocaleStrings.cpp` | SELECT locale_strings (no-param) | — |
| `shardd/internals/globals/GraveyardManager.cpp` | SELECT graveyards (no-param, 3 floats) | — |
| `shardd/internals/globals/ConditionMgr.cpp` | 2× SELECT (conditions + condition_groups) | — |

Floats lus via `GetString() + strtof()` (cohérent avec N1-B `CharacterListHandler`).

## Sites SKIP (et pourquoi)

| Fichier | Raison du skip |
|---|---|
| `masterd/shards/ServerRegistry.cpp` | Connexion `MYSQL*` directe (singleton lifetime, pas de pool — voir commentaire L15) |
| `shardd/gameplay/social/FriendSystem.cpp` | `#if ENGINE_HAS_MYSQL` + signatures `MYSQL*` direct, mode no-DB Windows |
| `shardd/gameplay/guild/GuildSystem.cpp` | Idem FriendSystem |
| `masterd/migrations/MigrationRunner.cpp` | Multi-statement SQL files + GET_LOCK pattern spécifique |
| `shared/db/{DbHelpers,SQLStorage,SqlDelayThread,DbLayerTests}` | Infrastructure SQL elle-même |

→ Pour Friend/Guild, c'est un chantier dédié futur si voulu (changer signatures pour propager `SqlPreparedStatementCache*`).

## Diff

**5 fichiers, +68 / -93 lignes** (-25 nettes grâce à la suppression du boilerplate `char sql[256]; snprintf(); MYSQL_RES*; mysql_fetch_row; DbFreeResult`).

## 🎯 Fin du chantier prepared statements

Avec cette PR, **tous les sites SQL accessibles au cache via `ConnectionPool::Guard` sont convertis** :

| Bloc | PRs | Couvre |
|---|---|---|
| Handlers hot path | N1-A #730 + N1-B #731 | CharCreate + 4 hot |
| Handlers résiduels | N1-C #734 | EnterDungeon, CharDelete, CharSavePos, Terms, AdminMute |
| Account store | N1-D #735 | AccountStore (12 méthodes) |
| Stores compacts | N1-E #736 | GameEvent, Reputation, QuestState, Skill, Loot |
| Stores moyens | N1-F #737 | Arena, Cinematic, Ignore, BattleGround, OutdoorPvp |
| Stores GmTicket + Auction | N1-G #738 | GmTicket, Auction |
| Stores Guild + Mail | N1-H #739 | Guild, Mail (transactions inside) |
| **Tail-end** | **N1-I (cette PR)** | **5 sites résiduels** |

**Total : ~35 fichiers, ~110 queries SQL converties**. Le pattern `prepared statement via guard.cache()` est devenu la norme du codebase serveur (master + shard).

## Test plan

- [ ] CI Linux build green
- [ ] Tests CTest existants
- [ ] Manuel post-déploiement :
  - `/mute` admin sur un joueur → ChatGate lookup correct (joueur muted)
  - Login + EnterWorld d'un perso → ServerApp lookup spawn correct (rendu position OK)
  - Localized strings affichées en jeu (LocaleStrings)
  - Mort d'un perso → réssurection au graveyard le plus proche (GraveyardManager)
  - Quest condition / spell condition gate vérifiées (ConditionMgr)

## Déploiement

⚠️ **Master + lock-step** (binaire serveur recompilé requis). Pas de migration DB, pas de wire-breaking, pas d'impact client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)