### PR TITLE
fix(shardd): GridStateTracker bug sentinel TimePoint{} (FU-6)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -64,10 +64,17 @@ jobs:
       # std::this_thread::sleep_for(1100ms), ce qui rend l'expiry des
       # sessions et des bans IP déterministes sans dépendre du wall-clock.
       #
+      # ─── (FU-6) RÉINTÉGRÉ — bug sentinel TimePoint{} corrigé ──────────────
+      # grid_state_tests : le bug "expected Idle after 70s" venait de l'usage
+      # de TimePoint{} (epoch) comme sentinel "non initialisé" dans
+      # GridStateTracker::Entry::lastEmptySince, alors que TimePoint{} est
+      # aussi une valeur LÉGITIME. Quand un test/callsite utilisait t0=epoch,
+      # OnPlayerLeave assignait lastEmptySince=epoch, indistinguable du
+      # sentinel → Tick suivant réinitialisait au lieu de mesurer elapsed.
+      # Fix : lastEmptySince passée à std::optional<TimePoint> — nullopt
+      # pour "non init", optional<epoch> pour "init à epoch".
+      #
       # ─── TEMPORAIRE — bug suspect à auditer ───────────────────────────────
-      # - grid_state_tests
-      #     Wall-clock simulé via Tick(t0 + 70s), fail "expected Idle after
-      #     70s" suggère un bug de logique idle dans GridStateTracker::Tick().
       # - vmap_streamer_tests
       #     Fail "expected 1 freed" suggère un bug refcount + releaseDelay
       #     dans VMapStreamer. Audit nécessaire.
@@ -97,7 +104,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         working-directory: ${{ github.workspace }}/build/linux-x64-release
         run: |
-          ctest --output-on-failure --no-compress-output -E "network_integration_tests|grid_state_tests|vmap_streamer_tests|localization_service_tests|zone_builder_roundtrip_tests"
+          ctest --output-on-failure --no-compress-output -E "network_integration_tests|vmap_streamer_tests|localization_service_tests|zone_builder_roundtrip_tests"
 
       # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
       # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que

--- a/src/shardd/world/GridState.cpp
+++ b/src/shardd/world/GridState.cpp
@@ -21,7 +21,7 @@ namespace engine::server
 		// Tout entry avec ≥ 1 joueur passe à Active. Reset le timer
 		// "no-player" — on n'est plus en attente.
 		e.state = GridState::Active;
-		e.lastEmptySince = TimePoint{};
+		e.lastEmptySince.reset();
 		(void)now;
 	}
 
@@ -42,7 +42,7 @@ namespace engine::server
 			// deux Tick.
 			if (e.state == GridState::Active)
 				e.state = GridState::Loaded;
-			if (e.lastEmptySince == TimePoint{})
+			if (!e.lastEmptySince)
 				e.lastEmptySince = now;
 		}
 	}
@@ -53,7 +53,7 @@ namespace engine::server
 		{
 			if (e.playerCount > 0)
 				continue;  // Active → reste Active
-			if (e.lastEmptySince == TimePoint{})
+			if (!e.lastEmptySince)
 			{
 				// Cellule jamais visitée OU revenue d'Active sans
 				// passer par OnPlayerLeave (cas anormal). Démarrer le
@@ -61,7 +61,7 @@ namespace engine::server
 				e.lastEmptySince = now;
 				continue;
 			}
-			const auto elapsed = now - e.lastEmptySince;
+			const auto elapsed = now - *e.lastEmptySince;
 			if (elapsed >= m_cfg.unloadTimeout)
 				e.state = GridState::Removal;
 			else if (elapsed >= m_cfg.idleTimeout)

--- a/src/shardd/world/GridState.h
+++ b/src/shardd/world/GridState.h
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -108,9 +109,15 @@ namespace engine::server
 		{
 			GridState   state         = GridState::Loaded;
 			int         playerCount   = 0;
-			/// Timestamp du dernier "no-player" (0 → inactif). Sert
-			/// pour les transitions vers Idle puis Removal.
-			TimePoint   lastEmptySince{};
+			/// Timestamp du dernier "no-player". `std::nullopt` tant que la
+			/// cellule n'a jamais été vidée OU a été ré-occupée depuis. Sert
+			/// pour les transitions vers Idle puis Removal. NB : utiliser un
+			/// `optional` (et NON un `TimePoint{}` sentinel) car `TimePoint{}`
+			/// est aussi une valeur LÉGITIME (epoch) — sans cette distinction,
+			/// quand `Tick` recevait un `now == epoch`, le sentinel et la
+			/// valeur initialisée étaient confondus → la cellule restait
+			/// éternellement Loaded au lieu de passer à Idle.
+			std::optional<TimePoint> lastEmptySince;
 		};
 
 		GridStateConfig                                              m_cfg;


### PR DESCRIPTION
## Summary

Résout **FU-6** : `grid_state_tests` était exclu de la CI Linux à cause d'un échec `[FAIL] expected Idle after 70s`. Cause racine identifiée par analyse statique :

**Bug sentinel** : `GridStateTracker::Entry::lastEmptySince` utilisait `TimePoint{}` (= epoch) à la fois comme sentinel \"non initialisé\" ET comme valeur potentielle. Quand un appelant passe `t0 = TimePoint{}` (typique des tests unitaires voulant un temps logique reproductible), `OnPlayerLeave` assigne `lastEmptySince = epoch` qui est indistinguable du sentinel → le `Tick` suivant ré-initialise au lieu de mesurer elapsed depuis Leave.

**Walkthrough du fail** :
1. `OnPlayerLeave(c, t0=epoch)` : assigne `lastEmptySince=epoch` ≡ sentinel
2. `Tick(t0+30s)` : sentinel détecté → ré-initialise à t0+30s
3. `Tick(t0+70s)` : elapsed = 40s (depuis t0+30s, pas depuis Leave) → < idleTimeout 60s → reste `Loaded` au lieu de `Idle` → FAIL

## Fix

`lastEmptySince` passée à `std::optional<TimePoint>`. `nullopt` = vraiment non init, `optional<epoch>` = valeur légitime distinguable. Trois sites modifiés :

- `OnPlayerEnter` : `e.lastEmptySince.reset()` au lieu de `= TimePoint{}`
- `OnPlayerLeave` : `if (!e.lastEmptySince) e.lastEmptySince = now`
- `Tick` : has-value check + déréférencement `*e.lastEmptySince`

Comportement runtime prod inchangé (en prod `steady_clock::now()` ne retourne jamais epoch).

## Test plan

- [ ] CI Linux exécute `grid_state_tests` (sortie du `-E`) et le test passe
- [ ] Autres tests `shardd` ne régressent pas (TestRemovalAfterTimeout, TestPlayerReturnsCancelsTimer, TestDrainRemoval utilisent aussi t0=epoch)
- [ ] CI Windows passe

## Déploiement

⚠️ **Redéploiement serveur shard recommandé** : `GridState.cpp` change (logique de transition cellule). Aucun protocole ni migration touché. Sans le redéploiement, le shard continue avec le bug latent (inoffensif en prod car `now()` n'est jamais epoch dans la vraie vie, mais robustesse améliorée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)