### PR TITLE
fix(shardd): ManagedModel bug sentinel TimePoint{} (FU-7)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -74,10 +74,14 @@ jobs:
       # Fix : lastEmptySince passée à std::optional<TimePoint> — nullopt
       # pour "non init", optional<epoch> pour "init à epoch".
       #
-      # ─── TEMPORAIRE — bug suspect à auditer ───────────────────────────────
-      # - vmap_streamer_tests
-      #     Fail "expected 1 freed" suggère un bug refcount + releaseDelay
-      #     dans VMapStreamer. Audit nécessaire.
+      # ─── (FU-7) RÉINTÉGRÉ — même bug sentinel TimePoint{} que FU-6 ───────
+      # vmap_streamer_tests : le fail "expected 1 freed" venait de
+      # ManagedModel::m_zeroRefSince utilisant TimePoint{} comme sentinel
+      # "refcount > 0 ou jamais Release", alors que TimePoint{} est aussi
+      # une valeur LÉGITIME. Quand un test/callsite faisait `Release(epoch)`,
+      # m_zeroRefSince = epoch était indistinguable du sentinel →
+      # ShouldRelease retournait éternellement false → tile jamais déchargé.
+      # Fix : std::optional<TimePoint> — même remède qu'en FU-6.
       #
       # ─── TEMPORAIRE — Linux-specific (tentative réintégration 2026-05-27 a échoué) ──
       # Les tests ci-dessous ont été retirés de -E par la tentative de
@@ -104,7 +108,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         working-directory: ${{ github.workspace }}/build/linux-x64-release
         run: |
-          ctest --output-on-failure --no-compress-output -E "network_integration_tests|vmap_streamer_tests|localization_service_tests|zone_builder_roundtrip_tests"
+          ctest --output-on-failure --no-compress-output -E "network_integration_tests|localization_service_tests|zone_builder_roundtrip_tests"
 
       # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
       # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que

--- a/src/shardd/internals/vmap/VMapStreamer.h
+++ b/src/shardd/internals/vmap/VMapStreamer.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -67,7 +68,7 @@ namespace engine::server::shard::vmap
 		void IncRef() noexcept
 		{
 			++m_refCount;
-			m_zeroRefSince = TimePoint{};
+			m_zeroRefSince.reset();
 		}
 		/// Decremente. Si retombe a 0, demarre le timer no-ref a \p now.
 		void DecRef(TimePoint now) noexcept
@@ -83,14 +84,22 @@ namespace engine::server::shard::vmap
 		bool ShouldRelease(TimePoint now, VMapStreamerConfig::Duration delay) const noexcept
 		{
 			if (m_refCount > 0) return false;
-			if (m_zeroRefSince == TimePoint{}) return false;
-			return (now - m_zeroRefSince) >= delay;
+			if (!m_zeroRefSince) return false;
+			return (now - *m_zeroRefSince) >= delay;
 		}
 
 	private:
 		VMapManager m_manager;
 		uint32_t    m_refCount = 0;
-		TimePoint   m_zeroRefSince{};  ///< 0 si refcount > 0
+		/// `nullopt` tant que refcount > 0 (ou avant le 1er Acquire/Release).
+		/// NB : utiliser `optional` (et NON un sentinel `TimePoint{}`) car
+		/// `TimePoint{}` est aussi une valeur LÉGITIME (epoch) — sans cette
+		/// distinction, un appelant utilisant `t0=TimePoint{}` (ex. tests
+		/// déterministes) voyait `DecRef(epoch)` assigner `m_zeroRefSince=epoch`,
+		/// indistinguable du sentinel → `ShouldRelease` retournait éternellement
+		/// false → tile jamais déchargé. Pattern identique à GridStateTracker
+		/// (FU-6).
+		std::optional<TimePoint> m_zeroRefSince;
 	};
 
 	class VMapStreamer


### PR DESCRIPTION
## Summary

Résout **FU-7** : `vmap_streamer_tests` était exclu de la CI Linux à cause d'un échec `[FAIL] expected 1 freed, got 0`. **Pattern strictement identique à FU-6** (PR [#744](https://github.com/tips-of-mine/LCDLLN-test/pull/744)) — d'où la rapidité du diagnostic.

**Bug sentinel** : `ManagedModel::m_zeroRefSince` utilisait `TimePoint{}` (epoch) à la fois comme sentinel \"refcount > 0 ou jamais Release\" ET comme valeur potentielle. Quand un appelant fait `Release(epoch)`, `m_zeroRefSince = epoch` est indistinguable du sentinel → `ShouldRelease` retourne éternellement `false` → le tile n'est jamais déchargé même après expiration de `releaseDelay`.

**Walkthrough du fail** :
1. `Acquire(\"a\")` → `IncRef` → refCount=1, zeroRefSince=TimePoint{}
2. `Release(\"a\", t0=epoch)` → `DecRef(epoch)` → refCount=0, zeroRefSince=epoch ≡ sentinel
3. `Tick(t0+10s)` → `ShouldRelease` voit `m_zeroRefSince == TimePoint{}` → return false → freed=0 au lieu de 1 → FAIL

## Fix

`m_zeroRefSince` passé à `std::optional<TimePoint>`. `nullopt` = vraiment non init / refcount > 0, `optional<epoch>` = valeur légitime distinguable. Trois sites :

- `IncRef` : `m_zeroRefSince.reset()` au lieu de `= TimePoint{}`
- `DecRef` : `m_zeroRefSince = now` (idem, mais maintenant assigne dans l'optional)
- `ShouldRelease` : `if (!m_zeroRefSince) return false; return (now - *m_zeroRefSince) >= delay`

## Test plan

- [ ] CI Linux exécute `vmap_streamer_tests` (sortie du `-E`) et le test passe
- [ ] Autres tests (`TestReAcquireBeforeUnloadCancelsTimer` notamment, qui dépend du même mécanisme) ne régressent pas
- [ ] CI Windows passe

## Déploiement

⚠️ **Redéploiement serveur shard recommandé** : `VMapStreamer.h` change (logique refcount + timer). Aucun protocole ni migration touché. Sans le redéploiement, le shard continue avec le bug latent (inoffensif en prod car `now()` n'est jamais epoch dans la vraie vie, mais robustesse améliorée).

## Statut FU global après cette PR

- ✅ FU-1, FU-2, FU-5, FU-6, FU-7 résolus
- 🔒 FU-3 (`localization_service_tests`), FU-4 (`zone_builder_roundtrip_tests`) : symptômes Linux-spécifiques (FileSystem encoding/path), pas analysables statiquement avec confiance — restent bloqués par toolchain locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)