### PR TITLE
fix(localization): structure path attendue par Init dans le test helper (FU-3)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -83,20 +83,26 @@ jobs:
       # ShouldRelease retournait éternellement false → tile jamais déchargé.
       # Fix : std::optional<TimePoint> — même remède qu'en FU-6.
       #
+      # ─── (FU-3) RÉINTÉGRÉ — bug dans le TEST, pas dans le code prod ──────
+      # localization_service_tests : le diagnostic initial pointait un
+      # supposé bug Linux dans FileSystem::WriteAllText, mais l'analyse
+      # statique a révélé que le helper de test `WriteCatalog` écrivait
+      # dans `<root>/localization/text/<locale>.json` alors que
+      # LocalizationService::Init/LoadCatalog attend
+      # `<root>/localization/<locale>/<locale>.json`. Le sous-dossier
+      # littéral "text" ne correspondait à aucun tag de locale → Init
+      # retournait toujours false. Bug invisible jusqu'ici car la CI
+      # Windows ne lance pas ctest (cf. build-windows.yml). Fix : helper
+      # `WriteCatalog` corrigé pour utiliser la structure attendue.
+      #
       # ─── TEMPORAIRE — Linux-specific (tentative réintégration 2026-05-27 a échoué) ──
       # Les tests ci-dessous ont été retirés de -E par la tentative de
       # réintégration de la PR #721, puis ré-exclus quand la CI Linux a
       # révélé des échecs réels (pas des fausses alertes comme le rapport
-      # d'audit initial le supposait). Suivi détaillé : FU-6/7 dans
+      # d'audit initial le supposait). Suivi détaillé : FU-4 dans
       # docs/superpowers/audits/closed/2026-05-27-codebase-audit-followups.md
       # (FU-5 netserver_bandwidth_tests fixé et réintégré dans une PR
       # ultérieure — tolérance ±1 byte sur l'assertion floating-point.)
-      # - localization_service_tests
-      #     `LocalizationService::Init()` retourne false sur Linux après
-      #     que `WriteCatalog` (FileSystem::WriteAllText) ait réussi.
-      #     Vrai bug Linux à diagnostiquer : FileSystem::ReadAllText ?
-      #     path traversal ? encoding ? Demande un build Linux pour
-      #     investiguer (effort ~2-4h).
       # - zone_builder_roundtrip_tests
       #     `ReadFileBytes(dirA/probes.bin)` retourne `.empty()` — les
       #     fichiers binaires écrits puis relus sont vides sur Linux.
@@ -108,7 +114,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         working-directory: ${{ github.workspace }}/build/linux-x64-release
         run: |
-          ctest --output-on-failure --no-compress-output -E "network_integration_tests|localization_service_tests|zone_builder_roundtrip_tests"
+          ctest --output-on-failure --no-compress-output -E "network_integration_tests|zone_builder_roundtrip_tests"
 
       # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
       # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que

--- a/src/client/localization/LocalizationServiceTests.cpp
+++ b/src/client/localization/LocalizationServiceTests.cpp
@@ -27,7 +27,17 @@ namespace
 
 	bool WriteCatalog(const std::filesystem::path& root, std::string_view locale, std::string_view json)
 	{
-		const std::filesystem::path file = root / "localization" / "text" / (std::string(locale) + ".json");
+		// Le LocalizationService attend la structure
+		// `<paths.content>/localization/<locale>/<locale>.json` (cf.
+		// LocalizationService::LoadCatalog l. 322-342 + Init l. 100-113 qui
+		// scanne les sous-dossiers de `localization/` et cherche
+		// `<entry>/<entry>.json`). La version pré-FU-3 du test écrivait dans
+		// `localization/text/<locale>.json` — un sous-dossier littéral "text"
+		// qui ne correspond à aucun tag de locale, donc Init ne trouvait
+		// jamais le catalogue. Bug masqué par l'exclusion ctest `-E` sur les
+		// deux plateformes (la CI Windows ne lance pas ctest du tout).
+		const std::string localeStr(locale);
+		const std::filesystem::path file = root / "localization" / localeStr / (localeStr + ".json");
 		return engine::platform::FileSystem::WriteAllText(file, json);
 	}
 


### PR DESCRIPTION
## Summary

Résout **FU-3** : `localization_service_tests` était exclu de la CI Linux avec un diagnostic initial de \"bug Linux dans FileSystem::WriteAllText\". L'analyse statique a révélé un **bug dans le test, pas dans le code prod**.

## Bug

Le helper `WriteCatalog` écrivait dans `<root>/localization/text/<locale>.json` — un sous-dossier littéral \"text\" qui n'est aucun tag de locale. Or `LocalizationService::Init` (l. 100-113) scanne `<root>/localization/` à la recherche de sous-dossiers nommés par tag (en, fr, …), puis cherche dans chacun le fichier `<entry>/<entry>.json`. `LoadCatalog` (l. 322-342) reconstruit le même chemin attendu.

→ Le sous-dossier `text/` ne matchant aucun tag, Init retournait toujours `false`. Sur **les deux plateformes** en réalité — la CI Windows ne lance pas ctest (cf. build-windows.yml l. 112-125), donc le bug n'était jamais détecté côté Win.

Probable origine : la refactor [#541](https://github.com/tips-of-mine/LCDLLN-test/pull/541) (\"regroup flat files into domain sub-folders\") a renommé la structure de localization, mais le helper de test n'a pas suivi.

## Vérification

Confirmé en grepant les vraies données :
\`\`\`
./game/data/localization/en/en.json
./game/data/localization/fr/fr.json
\`\`\`

→ Le format attendu est bien `<locale>/<locale>.json`.

## Fix

\`\`\`cpp
// AVANT
const std::filesystem::path file = root / \"localization\" / \"text\"
                                 / (std::string(locale) + \".json\");

// APRÈS
const std::filesystem::path file = root / \"localization\" / localeStr
                                 / (localeStr + \".json\");
\`\`\`

Les 3 sous-tests (`TestCatalogLoadAndTranslate`, `TestFallbackLocaleAndKey`, `TestInvalidCatalogRejected`) bénéficient du fix sans autre modification.

Retire `localization_service_tests` du pattern `ctest -E` dans `build-linux.yml`.

## Test plan

- [ ] CI Linux exécute `localization_service_tests` et le test passe
- [ ] CI Windows passe (compile inchangé — pas de production code touché)

## Déploiement

✅ **Pas de redéploiement** — uniquement un test helper, zéro changement dans le code prod (`LocalizationService.cpp` non modifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)