### PR TITLE
fix(zone_builder): 2 bugs latents dans RoundtripTests (FU-4)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -95,26 +95,30 @@ jobs:
       # Windows ne lance pas ctest (cf. build-windows.yml). Fix : helper
       # `WriteCatalog` corrigé pour utiliser la structure attendue.
       #
-      # ─── TEMPORAIRE — Linux-specific (tentative réintégration 2026-05-27 a échoué) ──
-      # Les tests ci-dessous ont été retirés de -E par la tentative de
-      # réintégration de la PR #721, puis ré-exclus quand la CI Linux a
-      # révélé des échecs réels (pas des fausses alertes comme le rapport
-      # d'audit initial le supposait). Suivi détaillé : FU-4 dans
-      # docs/superpowers/audits/closed/2026-05-27-codebase-audit-followups.md
-      # (FU-5 netserver_bandwidth_tests fixé et réintégré dans une PR
-      # ultérieure — tolérance ±1 byte sur l'assertion floating-point.)
-      # - zone_builder_roundtrip_tests
-      #     `ReadFileBytes(dirA/probes.bin)` retourne `.empty()` — les
-      #     fichiers binaires écrits puis relus sont vides sur Linux.
-      #     Plus assertion `rebuilt.positionX == source.positionX` qui
-      #     échoue (précision float). Bug serialize ou path Linux
-      #     spécifique (effort ~3-5h).
+      # ─── (FU-4) RÉINTÉGRÉ — 2 bugs dans le TEST, pas dans le code prod ───
+      # zone_builder_roundtrip_tests : (1) `Test_WriteChunkPackage_DeterministicBytes`
+      # faisait `REQUIRE(!a.empty())` pour TOUS les fichiers, y compris
+      # `instances.bin`/`navmesh.bin`/`probes.bin` que `WriteEmptyBin` crée
+      # légitimement vides (0 octet, par design — son nom le dit). Fix :
+      # vérifier `std::filesystem::exists` au lieu de `!empty()`, garder
+      # le check d'égalité de taille + hash FNV-1a pour le déterminisme.
+      # (2) `Test_LayoutDocument_JsonRoundtrip` sérialisait des doubles
+      # via `ostringstream << v` sans `setprecision` → précision par
+      # défaut 6 chiffres → `9000.125` → "9000.12" → re-parse 9000.12 →
+      # fail `rebuilt.positionX == source.positionX`. Fix : `setprecision(
+      # numeric_limits<double>::max_digits10)` = 17 chiffres garantis
+      # bit-à-bit. Aucun changement de code prod.
+      #
+      # Note historique : la PR #721 avait tenté de réintégrer plusieurs
+      # tests en bloc, puis ré-exclu quand la CI Linux avait révélé des
+      # échecs réels (pas des fausses alertes). FU-3/4/5/6/7 ont depuis
+      # diagnostiqué et fixé chacun, restaurant la couverture intégrale.
       - name: Run tests (ctest)
         env:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         working-directory: ${{ github.workspace }}/build/linux-x64-release
         run: |
-          ctest --output-on-failure --no-compress-output -E "network_integration_tests|zone_builder_roundtrip_tests"
+          ctest --output-on-failure --no-compress-output -E "network_integration_tests"
 
       # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
       # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que

--- a/tools/zone_builder/lib/tests/RoundtripTests.cpp
+++ b/tools/zone_builder/lib/tests/RoundtripTests.cpp
@@ -35,7 +35,9 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iterator>
+#include <limits>
 #include <random>
 #include <sstream>
 #include <string>
@@ -167,11 +169,20 @@ namespace
 
 		for (const char* name : kFileNames)
 		{
+			// Existence : `WriteChunkPackage` doit créer TOUS les fichiers,
+			// même ceux légitimement vides (instances.bin / navmesh.bin /
+			// probes.bin sont produits par `WriteEmptyBin` — leur taille
+			// est 0 octet par design). On vérifie donc l'existence sur
+			// disque, pas le `!empty()` du buffer lu.
+			REQUIRE(std::filesystem::exists(dirA / name));
+			REQUIRE(std::filesystem::exists(dirB / name));
+
 			const std::vector<uint8_t> a = ReadFileBytes(dirA / name);
 			const std::vector<uint8_t> b = ReadFileBytes(dirB / name);
 
-			REQUIRE(!a.empty());
-			REQUIRE(!b.empty());
+			// Déterminisme : tailles et contenus strictement identiques
+			// (deux fichiers vides hashent à la même valeur d'amorce
+			// FNV-1a, ce qui est correct pour la garantie testée ici).
 			REQUIRE(a.size() == b.size());
 
 			const uint64_t hashA = HashFnv1a64(a);
@@ -215,7 +226,15 @@ namespace
 
 		// Sérialisation manuelle (mêmes noms de membres que LoadLayoutDocument
 		// attend : version, instances[], guid, gltf, position[3]).
+		//
+		// `max_digits10` (= 17 pour double IEEE-754) garantit qu'un double
+		// sérialisé en décimal puis re-parsé retrouve EXACTEMENT la même
+		// valeur binaire. Sans cette précision, ostream utilise la précision
+		// par défaut de 6 chiffres → `9000.125` devenait "9000.12" puis se
+		// re-parsait comme 9000.12, faisant échouer l'égalité bit-à-bit
+		// `rebuilt.positionX == source.positionX` (bug du test, pas du parser).
 		std::ostringstream oss;
+		oss << std::setprecision(std::numeric_limits<double>::max_digits10);
 		oss << "{\n  \"version\": " << source.version << ",\n  \"instances\": [\n";
 		for (size_t i = 0; i < source.instances.size(); ++i)
 		{


### PR DESCRIPTION
## Summary

Résout **FU-4** : `zone_builder_roundtrip_tests` était exclu de la CI Linux avec un diagnostic initial pointant des bugs Linux-spécifiques (serialize/path/precision, effort estimé 3-5h). L'analyse statique révèle **deux bugs purement test-side, plateforme-indépendants** — invisibles jusqu'ici car la CI Windows ne lance pas ctest.

## Bug 1 — Test_WriteChunkPackage_DeterministicBytes : `REQUIRE(!a.empty())` sur fichiers légitimement vides

Le test boucle sur 6 fichiers attendus du package legacy et exige `!a.empty()` pour TOUS. Or `WriteChunkPackage` appelle `WriteEmptyBin` pour `instances.bin`/`navmesh.bin`/`probes.bin` — ces fichiers sont produits **vides par design** (0 octet, juste `ofstream` ouvert puis fermé sans write). La REQUIRE échouait au 1er empty file.

**Fix** : remplacer `!a.empty()` par `std::filesystem::exists(...)` (vérifie la création disque). Conserver l'égalité de taille + hash FNV-1a pour le déterminisme (deux fichiers vides hashent au même seed FNV-1a — correct pour la garantie testée).

## Bug 2 — Test_LayoutDocument_JsonRoundtrip : précision float par défaut perd des chiffres

Le test sérialisait des doubles via `oss << inst.positionX` sans `setprecision`. La précision par défaut d'un `ostream` est 6 chiffres significatifs → `9000.125` (avec 7 chiffres) était écrit \"9000.12\" → re-parsé en 9000.12 → `rebuilt.positionX == source.positionX` échouait bit-à-bit.

**Fix** : `oss << std::setprecision(std::numeric_limits<double>::max_digits10)`. `max_digits10` (= 17 pour double IEEE-754) garantit qu'un double sérialisé en décimal puis re-parsé retrouve EXACTEMENT la même valeur binaire — c'est la définition même de cette constante de la stdlib.

## Test plan

- [ ] CI Linux exécute `zone_builder_roundtrip_tests` (sortie du `-E`) et le test passe (3/3 sous-tests)
- [ ] CI Windows passe (compile inchangé — pas de production code touché)

## Déploiement

✅ **Pas de redéploiement** — uniquement le fichier de test, zéro changement dans `WriteChunkPackage` ou `JsonDocument`.

## Statut FU global après cette PR

- ✅ FU-1, FU-2, FU-3, FU-4, FU-5, FU-6, FU-7 (7/7 résolus une fois mergés)
- 🎯 Plus aucun follow-up CI restant — tous les ctest -E temporaires sont résolus

🤖 Generated with [Claude Code](https://claude.com/claude-code)