### PR TITLE
refactor: convertit les 2 derniers sentinels time_point{} en std::optional

### DIFF
--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -923,8 +924,13 @@ namespace engine::client
 		std::string m_infoBanner;
 		uint64_t m_pendingVerifyAccountId = 0;
 		/// Instant auquel le dernier code de vérification a été envoyé (steady_clock).
-		/// Vaut time_point{} si aucun code n'a encore été envoyé dans cette session.
-		std::chrono::steady_clock::time_point m_verifyCodeSentAt{};
+		/// `std::nullopt` si aucun code n'a encore été envoyé dans cette session.
+		/// NB : on utilise `optional` (et non `time_point{}` sentinel) pour aligner
+		/// sur la convention défensive introduite par FU-3/FU-4 — `time_point{}`
+		/// est aussi une valeur LÉGITIME (epoch) qui peut se confondre avec le
+		/// sentinel dans des contextes de test ou si une horloge alternative est
+		/// injectée. Pattern strictement identique à GridStateTracker / ManagedModel.
+		std::optional<std::chrono::steady_clock::time_point> m_verifyCodeSentAt;
 		uint64_t m_pendingTermsEditionId = 0;
 		bool m_termsScrolledToBottom = false;
 		bool m_termsAcknowledgeChecked = false;

--- a/src/client/auth/screens/AuthScreenVerifyEmail.cpp
+++ b/src/client/auth/screens/AuthScreenVerifyEmail.cpp
@@ -74,9 +74,9 @@ namespace engine::client
 	void AuthUiPresenter::BuildModel_EmailConfirmationPending(RenderModel& model) const
 	{
 		using namespace std::chrono;
-		const bool timerStarted = m_verifyCodeSentAt != steady_clock::time_point{};
+		const bool timerStarted = m_verifyCodeSentAt.has_value();
 		const bool codeExpired  = timerStarted
-			&& (steady_clock::now() - m_verifyCodeSentAt) >= minutes(15);
+			&& (steady_clock::now() - *m_verifyCodeSentAt) >= minutes(15);
 
 		model.titleLine2 = Tr("auth.email_confirmation.title");
 		model.sectionTitle = Tr("auth.panel.email_confirmation");

--- a/src/masterd/handlers/password/PasswordResetStore.cpp
+++ b/src/masterd/handlers/password/PasswordResetStore.cpp
@@ -160,8 +160,11 @@ namespace engine::server
 			return true;
 		using namespace std::chrono;
 		const auto& entry = it->second;
-		if (Clock::now() - entry.window_start >= hours(1))
-			return true; // Window has expired; will be reset on RecordEmailSent.
+		// Pas de window_start = aucun email envoyé encore = autoriser.
+		// window_start vieux d'≥ 1h = fenêtre expirée (RecordEmailSent
+		// la réinitialisera au prochain appel).
+		if (!entry.window_start || Clock::now() - *entry.window_start >= hours(1))
+			return true;
 		return entry.count < kMaxEmailsPerHour;
 	}
 
@@ -169,7 +172,7 @@ namespace engine::server
 	{
 		using namespace std::chrono;
 		auto& entry = m_email_rate[account_id];
-		if (Clock::now() - entry.window_start >= hours(1))
+		if (!entry.window_start || Clock::now() - *entry.window_start >= hours(1))
 		{
 			entry.count        = 1;
 			entry.window_start = Clock::now();

--- a/src/masterd/handlers/password/PasswordResetStore.h
+++ b/src/masterd/handlers/password/PasswordResetStore.h
@@ -71,8 +71,17 @@ namespace engine::server
 
 		struct EmailRateEntry
 		{
-			int               count        = 0;
-			Clock::time_point window_start = Clock::time_point{};
+			int                              count        = 0;
+			/// Début de la fenêtre glissante anti-spam (1h). `std::nullopt`
+			/// tant qu'aucun email n'a encore été envoyé pour ce compte —
+			/// distingue ce cas de "fenêtre démarrée à epoch UNIX". Pattern
+			/// aligné sur la convention défensive FU-3/FU-4. NB : ce store
+			/// utilise `system_clock` (wall-clock) et non `steady_clock` —
+			/// le sentinel `time_point{}` = epoch UNIX 1970 était inoffensif
+			/// en prod car `now()` ≈ 2026 → la condition "fenêtre expirée"
+			/// se déclenchait par coïncidence (~56 ans ≫ 1h). L'optional
+			/// rend l'intention explicite et protège des futurs cas de test.
+			std::optional<Clock::time_point> window_start;
 		};
 
 		/// token string → entry


### PR DESCRIPTION
## Summary

Cleanup défensif final : aligne les 2 dernières occurrences du pattern `time_point{}` sentinel sur la convention `std::optional<TimePoint>` introduite par [#744](https://github.com/tips-of-mine/LCDLLN-test/pull/744) (FU-6) et [#745](https://github.com/tips-of-mine/LCDLLN-test/pull/745) (FU-7).

Les deux étaient **inactifs en prod** mais relèvent de la même fragilité logique (sentinel confondable avec une valeur légitime), donc cohérent à harmoniser.

## Sites traités

### 1. `PasswordResetStore::EmailRateEntry::window_start`

**Métier** : anti-spam des emails de récupération de mot de passe (max 3 par compte par heure glissante, côté master).

**Pourquoi le bug était inactif** : utilise `system_clock` (wall-clock 1970+). Le sentinel `time_point{}` = epoch UNIX 1970 était inoffensif car `now() ≈ 2026` → la condition \"fenêtre expirée\" se déclenchait par coïncidence (~56 ans ≫ 1h). L'optional rend l'intention explicite et protège des futurs cas de test.

### 2. `AuthUi::m_verifyCodeSentAt` + `AuthScreenVerifyEmail.cpp`

**Métier** : timer du bouton \"Renvoyer mon code\" sur l'écran de vérification email post-inscription (15 min de cooldown).

**Pourquoi le bug était inactif** : utilise `steady_clock`. `now()` ne retourne jamais epoch en pratique (uptime > 0), et pas de test unitaire ne le déclenchait. L'optional formalise \"pas encore envoyé\" sans s'appuyer sur une coïncidence d'horloge.

## Vérification transverse

Après cette PR, `grep -rn \"TimePoint{}\|time_point{}\"` dans `src/masterd`, `src/shardd`, `src/shared`, `src/client` ne retourne plus AUCUNE occurrence active du pattern \"sentinel = valeur par défaut\" — uniquement des commentaires de documentation expliquant le pattern et des usages légitimes (instanciation à epoch dans `Clock.cpp` FakeClock, comparaison explicite dans des contextes test).

## Test plan

- [ ] CI Linux passe (build + ctest)
- [ ] CI Windows passe (compile AuthUi.h + AuthScreenVerifyEmail.cpp)
- [ ] Comportement runtime UI inchangé sur le golden path (auth → register → écran verify email → bouton renvoi grisé puis actif après 15 min)
- [ ] Comportement runtime master inchangé (CanSendEmail / RecordEmailSent même fenêtre 1h glissante)

## Déploiement

⚠️ **Lock-step client + master recommandé** : touche les deux côtés (PasswordResetStore master + AuthUi/Presenter client). Aucun protocole modifié, aucune migration DB. Le runtime prod est strictement identique aux appelants (les 2 sentinels étaient inactifs avant cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)