### PR TITLE
🔒 fix(web-portal): refactor auth vers session-ID DB (impersonation + escalation)

### DIFF
--- a/sql/migrations/0071_portal_sessions.sql
+++ b/sql/migrations/0071_portal_sessions.sql
@@ -1,0 +1,53 @@
+-- Migration 0071 — Table portal_sessions
+--
+-- Refactor sécurité critique : avant cette migration, l'authentification du
+-- web-portal reposait sur deux cookies non signés (`lcdlln_portal_account` =
+-- account_id en clair, `lcdlln_portal_role` = role en clair). Bien que
+-- `httpOnly: true` empêchait le JS de page d'y toucher, DevTools / curl /
+-- proxy / extensions pouvaient les modifier librement, ce qui permettait :
+--   1. Impersonation totale : qui que ce soit pouvait poser
+--      `lcdlln_portal_account=1` et se faire passer pour le compte 1 sans
+--      aucun mot de passe. Les account_id étant auto-increment, deviner un
+--      compte admin était trivial.
+--   2. Escalation de privilèges : un joueur normal pouvait poser
+--      `lcdlln_portal_role=SUPERADMIN` et accéder à 14 routes /api/admin/*
+--      qui faisaient confiance au cookie sans re-vérifier en DB.
+--
+-- Nouveau modèle : un seul cookie `lcdlln_portal_session` contient un
+-- session_token cryptographique random (256 bits, 64 chars hex). À chaque
+-- requête authentifiée, `getSession()` fait une LECTURE DB sur cette table
+-- pour matérialiser la session ; account_id et role viennent donc TOUJOURS
+-- de la DB (table accounts via JOIN), jamais d'un cookie. Modifier le
+-- cookie côté client ne permet plus rien : un token inexistant en DB
+-- retourne null (= non authentifié), et il est impossible de générer un
+-- token valide sans passer par /api/auth/login (qui exige des credentials).
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE IF NOT EXISTS portal_sessions (
+  id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  session_token   CHAR(64)        NOT NULL
+                  COMMENT 'Hex 64 chars = 32 octets random = 256 bits. Généré par /api/auth/login via crypto.randomBytes(32).',
+  account_id      BIGINT UNSIGNED NOT NULL
+                  COMMENT 'Compte propriétaire de la session (FK vers accounts.id, CASCADE delete pour purger les sessions d''un compte supprimé).',
+  created_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_seen_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                  ON UPDATE CURRENT_TIMESTAMP
+                  COMMENT 'MAJ par getSession() à chaque requête authentifiée. Sert à expirer les sessions inactives indépendamment de expires_at fixe.',
+  expires_at      DATETIME        NOT NULL
+                  COMMENT 'Borne haute absolue de la session (login + 7 jours par défaut, cf. PORTAL_SESSION_MAX_AGE_DAYS).',
+  user_agent      VARCHAR(255)    NULL
+                  COMMENT 'Capture du User-Agent au login pour observabilité (audit, détection abus).',
+  ip              VARCHAR(45)     NULL
+                  COMMENT 'IP au login (IPv6 jusqu''à 45 chars). Idem audit.',
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_session_token (session_token),
+  KEY idx_account_id (account_id),
+  KEY idx_expires_at (expires_at),
+  CONSTRAINT fk_portal_sessions_account
+    FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Sessions authentifiées du web-portal. Cookie côté client = session_token random ; identité réelle (account_id, role) lue ici par lookup à chaque requête.';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/web-portal/app/api/admin/bugs/[id]/route.ts
+++ b/web-portal/app/api/admin/bugs/[id]/route.ts
@@ -9,16 +9,10 @@
 //  4. Set exploit_awarded = 1 on the bug report.
 
 import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
 
 const VALID_STATUSES = ['pending', 'confirmed', 'in_progress', 'resolved', 'not_a_bug'] as const
 type AdminStatus = (typeof VALID_STATUSES)[number]
@@ -42,8 +36,9 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
-    return NextResponse.json({ error: 'AccÃ¨s refusÃ©' }, { status: 403 })
+  const admin = await requireAdmin()
+  if (!admin) {
+    return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
 
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/cgu/[id]/publish/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/publish/route.ts
@@ -1,8 +1,7 @@
 ﻿// POST /api/admin/cgu/[id]/publish
 // Publishes a draft CGU edition
 import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
@@ -11,10 +10,7 @@ export async function POST(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  if (!isStaff(jar.get('lcdlln_portal_role')?.value)) {
-    return NextResponse.json({ ok: false }, { status: 403 })
-  }
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/[id]/retire/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/retire/route.ts
@@ -2,9 +2,8 @@
 // Body: { reason: string } — required, non-empty
 // Retires a published CGU edition
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
@@ -12,10 +11,7 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  if (!isStaff(jar.get('lcdlln_portal_role')?.value)) {
-    return NextResponse.json({ ok: false }, { status: 403 })
-  }
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/[id]/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/route.ts
@@ -1,16 +1,10 @@
 // PATCH /api/admin/cgu/[id] — update draft edition
 // DELETE /api/admin/cgu/[id] — delete draft edition
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
 
 async function getEdition(id: number) {
   const rows = await query<Array<RowDataPacket & { id: number; status: string }>>(
@@ -24,7 +18,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
@@ -97,7 +91,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/route.ts
+++ b/web-portal/app/api/admin/cgu/route.ts
@@ -2,19 +2,13 @@
 // Body: { versionLabel, titleFr, contentFr, titleEn?, contentEn? }
 // Creates a new terms_edition (status='draft') + terms_localizations entries
 import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 import type { ResultSetHeader } from 'mysql2/promise'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
-
 export async function POST(request: Request) {
-  if (!isAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
 
   try {
     const body = await request.json() as {

--- a/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
+++ b/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
@@ -1,17 +1,11 @@
 ﻿import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return isStaff(role)
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/faq/[id]/route.ts
+++ b/web-portal/app/api/admin/faq/[id]/route.ts
@@ -1,21 +1,15 @@
 // PATCH /api/admin/faq/[id] — update faq item fields
 // DELETE /api/admin/faq/[id] — delete faq item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import { logError } from '@/lib/log'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -62,7 +56,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/faq/route.ts
+++ b/web-portal/app/api/admin/faq/route.ts
@@ -1,19 +1,13 @@
 // GET /api/admin/faq — returns all faq items ordered by display_order
 // POST /api/admin/faq — creates a new faq item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
-
 export async function GET() {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -28,7 +22,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/app/api/admin/players/[id]/activate/route.ts
+++ b/web-portal/app/api/admin/players/[id]/activate/route.ts
@@ -1,16 +1,10 @@
 ﻿import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return isStaff(role)
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/players/[id]/characters/route.ts
+++ b/web-portal/app/api/admin/players/[id]/characters/route.ts
@@ -1,17 +1,11 @@
 ﻿import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return isStaff(role)
-}
-
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/disable/route.ts
+++ b/web-portal/app/api/admin/players/[id]/disable/route.ts
@@ -1,18 +1,12 @@
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import { sendAccountDisabled } from '@/lib/email/sender'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError, logWarn } from '@/lib/log'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return isStaff(role)
-}
-
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/verify-email/route.ts
+++ b/web-portal/app/api/admin/players/[id]/verify-email/route.ts
@@ -1,16 +1,10 @@
 ﻿import { NextResponse } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
-async function checkAdmin() {
-  const role = cookies().get('lcdlln_portal_role')?.value
-  return isStaff(role)
-}
-
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!await checkAdmin()) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/roadmap/[id]/route.ts
+++ b/web-portal/app/api/admin/roadmap/[id]/route.ts
@@ -1,21 +1,15 @@
 // PATCH /api/admin/roadmap/[id] — update roadmap item fields
 // DELETE /api/admin/roadmap/[id] — delete roadmap item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import { logError } from '@/lib/log'
-
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -62,7 +56,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/roadmap/route.ts
+++ b/web-portal/app/api/admin/roadmap/route.ts
@@ -1,19 +1,13 @@
 // GET /api/admin/roadmap — returns all roadmap items ordered by display_order
 // POST /api/admin/roadmap — creates a new roadmap item
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { requireAdmin } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
-import { isStaff } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
-function isAdmin(): boolean {
-  const jar = cookies()
-  return isStaff(jar.get('lcdlln_portal_role')?.value)
-}
-
 export async function GET() {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -28,7 +22,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAdmin()) {
+  if (!(await requireAdmin())) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/app/api/auth/login/route.ts
+++ b/web-portal/app/api/auth/login/route.ts
@@ -4,10 +4,8 @@ import { verifyPortalCredentials } from "@/lib/auth/portalLogin";
 import { query } from "@/lib/db/connection";
 import type { RowDataPacket } from "mysql2/promise";
 import { isStaff, normalizeRole } from "@/lib/auth/roles";
+import { createSession, SESSION_COOKIE_NAME, SESSION_MAX_AGE_SEC } from "@/lib/auth/session";
 import { logError } from "@/lib/log";
-
-const COOKIE_NAME = "lcdlln_portal_account";
-const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 7;
 
 export async function POST(request: Request) {
   try {
@@ -34,20 +32,28 @@ export async function POST(request: Request) {
     const accountRole = normalizeRole(accountRows[0]?.role);
     const accountTagId = accountRows[0]?.tag_id ?? null;
 
+    // Crée une session côté serveur : génère un session_token de 256 bits,
+    // INSERT dans portal_sessions, et retourne le token à poser en cookie.
+    // C'est le SEUL mécanisme valide pour qu'un client soit reconnu comme
+    // authentifié par getSession() — le cookie est désormais opaque (un
+    // simple identifiant aléatoire) et non altérable utilement par un
+    // attaquant. L'autorité (account_id, role) est lue depuis la DB à
+    // chaque requête, jamais depuis un cookie.
+    const userAgent = request.headers.get('user-agent');
+    // x-forwarded-for est posé par les reverse-proxies (typiquement notre
+    // setup en prod). Sans proxy, on retombe sur null — la colonne est
+    // nullable côté DB.
+    const forwardedFor = request.headers.get('x-forwarded-for');
+    const ip = forwardedFor?.split(',')[0]?.trim() || null;
+    const sessionToken = await createSession(result.accountId, { userAgent, ip });
+
     const jar = cookies();
-    jar.set(COOKIE_NAME, String(result.accountId), {
+    jar.set(SESSION_COOKIE_NAME, sessionToken, {
       httpOnly: true,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",
       path: "/",
-      maxAge: COOKIE_MAX_AGE_SEC,
-    });
-    jar.set('lcdlln_portal_role', accountRole, {
-      httpOnly: true,
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-      path: '/',
-      maxAge: COOKIE_MAX_AGE_SEC,
+      maxAge: SESSION_MAX_AGE_SEC,
     });
 
     return NextResponse.json({

--- a/web-portal/app/api/auth/logout/route.ts
+++ b/web-portal/app/api/auth/logout/route.ts
@@ -1,8 +1,22 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { deleteSession, getRawSessionToken, SESSION_COOKIE_NAME } from '@/lib/auth/session'
 
 export async function POST() {
+  // DELETE côté serveur d'abord (révoque la session côté DB → un
+  // attaquant qui aurait volé le cookie ne peut plus s'en servir, même
+  // si le cookie est encore présent dans son navigateur). Puis efface
+  // le cookie côté client.
+  const token = getRawSessionToken()
+  if (token) {
+    await deleteSession(token).catch(() => undefined)
+  }
   const jar = cookies()
+  jar.set(SESSION_COOKIE_NAME, '', { maxAge: 0, path: '/' })
+  // Cleanup transitoire : si l'utilisateur a un ancien cookie résiduel
+  // d'avant le refactor session-ID, on le purge aussi pour éviter
+  // qu'il traîne avec sa fausse autorité (inoffensive maintenant que
+  // plus rien ne le lit, mais on assainit quand même).
   jar.set('lcdlln_portal_account', '', { maxAge: 0, path: '/' })
   jar.set('lcdlln_portal_role', '', { maxAge: 0, path: '/' })
   return NextResponse.json({ ok: true })

--- a/web-portal/app/api/bugs/route.ts
+++ b/web-portal/app/api/bugs/route.ts
@@ -1,7 +1,7 @@
 // POST /api/bugs
 // Body: { title, body, category }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 import type { ResultSetHeader } from 'mysql2/promise'
@@ -9,11 +9,9 @@ import type { ResultSetHeader } from 'mysql2/promise'
 const VALID_CATEGORIES = ['gameplay', 'graphique', 'reseau', 'interface', 'autre'] as const
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { title?: string; body?: string; category?: string }

--- a/web-portal/app/api/player/account/cancel-email-change/route.ts
+++ b/web-portal/app/api/player/account/cancel-email-change/route.ts
@@ -1,15 +1,13 @@
 // POST /api/player/account/cancel-email-change
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
 export async function POST() {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     await query(

--- a/web-portal/app/api/player/account/request-email-change/route.ts
+++ b/web-portal/app/api/player/account/request-email-change/route.ts
@@ -1,7 +1,7 @@
 // POST /api/player/account/request-email-change
 // Body: { newEmail: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { sendEmailChange } from '@/lib/email/sender'
 import { requireEnv } from '@/lib/env'
@@ -10,11 +10,9 @@ import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { newEmail?: string }

--- a/web-portal/app/api/player/account/route.ts
+++ b/web-portal/app/api/player/account/route.ts
@@ -1,16 +1,14 @@
 // PATCH /api/player/account
 // Body: { firstName?, lastName?, addressStreet?, addressCity?, addressZip?, addressCountry? }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
 export async function PATCH(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false, message: 'Session invalide' }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as Record<string, string>

--- a/web-portal/app/api/player/cgu/accept/route.ts
+++ b/web-portal/app/api/player/cgu/accept/route.ts
@@ -1,17 +1,15 @@
 // POST /api/player/cgu/accept
 // Body: { editionId: number }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { editionId?: number }

--- a/web-portal/app/api/player/characters/[id]/delete/route.ts
+++ b/web-portal/app/api/player/characters/[id]/delete/route.ts
@@ -1,6 +1,6 @@
 // PATCH /api/player/characters/[id]/delete
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
@@ -9,12 +9,11 @@ export async function PATCH(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
   const characterId = parseInt(params.id, 10)
-  if (isNaN(accountId) || isNaN(characterId)) return NextResponse.json({ ok: false }, { status: 400 })
+  if (isNaN(characterId)) return NextResponse.json({ ok: false }, { status: 400 })
 
   try {
     // Verify ownership

--- a/web-portal/app/api/player/parental/request/route.ts
+++ b/web-portal/app/api/player/parental/request/route.ts
@@ -1,7 +1,7 @@
 // POST /api/player/parental/request
 // Body: { parentalEmail: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { sendParentalValidation } from '@/lib/email/sender'
 import { requireEnv } from '@/lib/env'
@@ -10,11 +10,9 @@ import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { parentalEmail?: string }

--- a/web-portal/app/api/player/password/route.ts
+++ b/web-portal/app/api/player/password/route.ts
@@ -1,18 +1,16 @@
 // POST /api/player/password
 // Body: { currentPassword: string, newPassword: string }
 import { NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import { query } from '@/lib/db/connection'
 import { verifyGameMasterPassword, hashPasswordForGameMaster } from '@/lib/auth/gamePasswordHash'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function POST(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId)) return NextResponse.json({ ok: false }, { status: 401 })
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { currentPassword?: string; newPassword?: string }

--- a/web-portal/app/api/player/privacy/route.ts
+++ b/web-portal/app/api/player/privacy/route.ts
@@ -2,19 +2,15 @@
 // Body: { visibility: 'public' | 'friends' | 'none' }
 import { NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
-import { cookies } from 'next/headers'
+import { getSession } from '@/lib/auth/session'
 import type { ResultSetHeader } from 'mysql2/promise'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
 export async function PATCH(request: Request) {
-  const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId) || accountId <= 0) {
-    return NextResponse.json({ ok: false, message: 'Session invalide' }, { status: 401 })
-  }
+  const session = await getSession()
+  if (!session) return NextResponse.json({ ok: false, message: 'Non authentifié' }, { status: 401 })
+  const accountId = session.accountId
 
   try {
     const body = await request.json() as { visibility?: string }

--- a/web-portal/app/player/exploits/page.tsx
+++ b/web-portal/app/player/exploits/page.tsx
@@ -6,13 +6,12 @@ import { getSession } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
-// Source d'autorité = la session (cookie `lcdlln_portal_account` posé au login).
-// Avant ce fix la page exigeait `?accountId=N` manuellement dans l'URL — c'était
-// un TODO laissé en dev ("En production, la session connectée sera utilisée")
-// qui n'avait jamais été terminé. La présence du middleware `/player/:path*`
-// + getSession() suffit : le middleware redirige vers /login si non connecté,
-// et getSession() retourne null si le cookie est absent ou pointe vers un
-// compte supprimé.
+// Source d'autorité = la session (session_token random posé au login dans
+// le cookie `lcdlln_portal_session`, matérialisée par `getSession()` via
+// lookup `portal_sessions` JOIN `accounts`). Avant ce fix la page exigeait
+// `?accountId=N` manuellement dans l'URL — TODO dev jamais terminé. Le
+// middleware `/player/:path*` redirige vers /login si le cookie est absent,
+// et getSession() retourne null si le token est invalide / expiré / révoqué.
 export default async function PlayerExploitsPage() {
   const session = await getSession();
   if (!session) redirect("/login?redirect=/player/exploits");

--- a/web-portal/app/player/recovery-profile/page.tsx
+++ b/web-portal/app/player/recovery-profile/page.tsx
@@ -5,10 +5,10 @@ import { getSession } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
-// Source d'autorité = la session (cookie `lcdlln_portal_account` posé au login).
-// Avant ce fix la page exigeait `?accountId=N` manuellement dans l'URL — un
-// TODO dev qui n'avait jamais été terminé. Le middleware `/player/:path*` +
-// getSession() garantissent un accountId valide ici.
+// Source d'autorité = la session (session_token random posé au login dans
+// le cookie `lcdlln_portal_session`, matérialisée par `getSession()` via
+// lookup `portal_sessions` JOIN `accounts`). Le middleware `/player/:path*`
+// + getSession() garantissent un accountId valide ici.
 export default async function RecoveryProfilePage() {
   const session = await getSession();
   if (!session) redirect("/login?redirect=/player/recovery-profile");

--- a/web-portal/lib/auth/admin.ts
+++ b/web-portal/lib/auth/admin.ts
@@ -1,0 +1,25 @@
+import { getSession, type Session } from '@/lib/auth/session'
+import { isStaff } from '@/lib/auth/roles'
+
+// Helper unifié pour les 14 routes /api/admin/*. Avant cette refactor,
+// chaque route déclarait localement un `checkAdmin()` qui faisait
+// confiance au cookie `lcdlln_portal_role` (cookie en clair, modifiable
+// par DevTools/curl/proxy). N'importe quel joueur connecté pouvait poser
+// `lcdlln_portal_role=SUPERADMIN` et bypasser l'autorisation.
+//
+// Maintenant `getSession()` re-lit le rôle depuis la table accounts via
+// JOIN avec portal_sessions. Le cookie ne porte plus aucune autorité —
+// modifier le cookie ne fait rien tant que la session DB ne donne pas
+// le rôle staff.
+//
+// Retourne :
+//   - null si non authentifié OU si rôle non-staff. Le caller doit
+//     alors retourner NextResponse.json({...}, { status: 403 }).
+//   - la Session complète sinon. Le caller a accès à session.accountId
+//     pour audit log, etc.
+export async function requireAdmin(): Promise<Session> {
+  const session = await getSession()
+  if (!session) return null
+  if (!isStaff(session.role)) return null
+  return session
+}

--- a/web-portal/lib/auth/session.ts
+++ b/web-portal/lib/auth/session.ts
@@ -1,7 +1,20 @@
 import { cookies } from 'next/headers'
+import { randomBytes } from 'node:crypto'
+import type { ResultSetHeader, RowDataPacket } from 'mysql2/promise'
 import { query } from '@/lib/db/connection'
-import type { RowDataPacket } from 'mysql2/promise'
 import { normalizeRole, type AccountRole } from '@/lib/auth/roles'
+
+// Nom du seul cookie d'authentification. Contient un session_token random
+// (64 chars hex). Aucune information identifiante ou autoritative côté
+// client — toute la matérialisation de l'identité passe par une lecture
+// de la table portal_sessions à chaque appel de getSession().
+export const SESSION_COOKIE_NAME = 'lcdlln_portal_session'
+
+// Durée de vie maximale d'une session (login → expiration absolue). Le
+// rolling refresh (last_seen_at via ON UPDATE CURRENT_TIMESTAMP) ne
+// repousse PAS expires_at — c'est volontaire pour limiter les sessions
+// éternellement actives sur une machine partagée.
+export const SESSION_MAX_AGE_SEC = 60 * 60 * 24 * 7 // 7 jours
 
 export type Session = {
   accountId: number
@@ -10,21 +23,95 @@ export type Session = {
   login: string
 } | null
 
+// Génère un session_token de 256 bits (32 octets → 64 chars hex). C'est la
+// SEULE source d'autorité côté client après cette refactor.
+export function generateSessionToken(): string {
+  return randomBytes(32).toString('hex')
+}
+
+// Insère une nouvelle session pour `accountId` et retourne le token à
+// poser en cookie. Appelée par /api/auth/login après vérification des
+// credentials.
+export async function createSession(
+  accountId: number,
+  metadata?: { userAgent?: string | null; ip?: string | null }
+): Promise<string> {
+  const token = generateSessionToken()
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SEC * 1000)
+  await query<ResultSetHeader>(
+    `INSERT INTO portal_sessions (session_token, account_id, expires_at, user_agent, ip)
+     VALUES (?, ?, ?, ?, ?)`,
+    [token, accountId, expiresAt, metadata?.userAgent ?? null, metadata?.ip ?? null]
+  )
+  return token
+}
+
+// Supprime la session associée à `token`. Appelée par /api/auth/logout.
+// No-op silencieux si le token n'existe pas (ex. déjà expiré ou clic
+// double).
+export async function deleteSession(token: string): Promise<void> {
+  await query<ResultSetHeader>(
+    'DELETE FROM portal_sessions WHERE session_token = ?',
+    [token]
+  )
+}
+
+// Lecture-écriture : matérialise la session côté serveur. Lit le cookie,
+// fait un JOIN portal_sessions + accounts pour récupérer l'identité réelle
+// (account_id, role) depuis la DB. Met à jour last_seen_at par effet de
+// bord (ON UPDATE CURRENT_TIMESTAMP sur la colonne).
+//
+// Retourne null dans tous les cas non-authentifiés :
+//   - cookie absent
+//   - token de format invalide (non-hex / longueur != 64)
+//   - token non trouvé en DB (déconnecté, supprimé, ou jamais émis)
+//   - session expirée (expires_at < now)
+//   - compte associé supprimé (FK CASCADE retire la session, mais filet
+//     de sécurité au cas où)
+//
+// Quiconque modifie le cookie côté client tombe dans la branche "token
+// non trouvé" — il est cryptographiquement impossible de fabriquer un
+// session_token valide sans passer par createSession().
 export async function getSession(): Promise<Session> {
   const jar = cookies()
-  const raw = jar.get('lcdlln_portal_account')?.value
-  if (!raw) return null
-  const accountId = parseInt(raw, 10)
-  if (isNaN(accountId) || accountId <= 0) return null
+  const token = jar.get(SESSION_COOKIE_NAME)?.value
+  if (!token) return null
+  // Format-check rapide : on filtre les tokens qui ne respectent pas la
+  // forme hex 64-chars avant de toucher à la DB. Évite de polluer le
+  // pool MySQL avec des requêtes garanties non matching et bloque les
+  // tentatives d'injection ou de probing de format.
+  if (!/^[0-9a-f]{64}$/.test(token)) return null
   try {
     const rows = await query<Array<RowDataPacket & {
-      id: number; login: string; role: string; tag_id: string | null
+      id: number
+      login: string
+      role: string
+      tag_id: string | null
+      expires_at: string
     }>>(
-      'SELECT id, login, role, tag_id FROM accounts WHERE id = ? LIMIT 1',
-      [accountId]
+      `SELECT a.id, a.login, a.role, a.tag_id, s.expires_at
+       FROM portal_sessions s
+       INNER JOIN accounts a ON a.id = s.account_id
+       WHERE s.session_token = ?
+       LIMIT 1`,
+      [token]
     )
     const row = rows[0]
     if (!row) return null
+    if (new Date(row.expires_at).getTime() <= Date.now()) {
+      // Session expirée : nettoyage opportuniste (best-effort, on
+      // n'attend pas le résultat pour ne pas bloquer la réponse).
+      void deleteSession(token).catch(() => undefined)
+      return null
+    }
+    // Rolling touch : met à jour last_seen_at sans recalculer
+    // expires_at. Un UPDATE séparé serait redondant avec ON UPDATE
+    // CURRENT_TIMESTAMP qui se déclenche sur tout UPDATE — on lance
+    // un UPDATE explicite minimal pour matérialiser l'activité.
+    void query<ResultSetHeader>(
+      'UPDATE portal_sessions SET last_seen_at = CURRENT_TIMESTAMP WHERE session_token = ?',
+      [token]
+    ).catch(() => undefined)
     return {
       accountId: row.id,
       role: normalizeRole(row.role),
@@ -34,4 +121,11 @@ export async function getSession(): Promise<Session> {
   } catch {
     return null
   }
+}
+
+// Helper rare : retourne le token brut du cookie (utile pour le logout
+// qui doit DELETE la bonne ligne). Pas exposé aux routes consommatrices.
+export function getRawSessionToken(): string | null {
+  const jar = cookies()
+  return jar.get(SESSION_COOKIE_NAME)?.value ?? null
 }

--- a/web-portal/middleware.ts
+++ b/web-portal/middleware.ts
@@ -1,28 +1,34 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { isStaff } from '@/lib/auth/roles'
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session'
 
+// Le middleware vérifie uniquement la PRÉSENCE d'un cookie session_token.
+// Il NE DOIT PAS faire de lookup DB ici (le middleware tourne sur Edge
+// Runtime et un lookup MySQL serait coûteux + non disponible). La vraie
+// vérification (token existe en DB + non expiré + rôle staff pour /admin)
+// est faite dans chaque page/route via `getSession()` ou `requireAdmin()`.
+//
+// Conséquence : le middleware sert juste de filtre UX pour rediriger les
+// utilisateurs anonymes vers /login. Un attaquant qui pose un cookie
+// session_token bidon passe le middleware mais sera rejeté par
+// `getSession()` (token introuvable en DB → null → page redirige ou route
+// retourne 401/403). C'est de la défense-en-profondeur : middleware best-
+// effort UX, page/route = vraie autorité.
+//
+// Note historique : avant ce refactor, le middleware vérifiait aussi le
+// rôle via `isStaff(cookie.role)` pour /admin/*. Ce check trustait un
+// cookie modifiable et donnait une fausse impression de sécurité. Il est
+// retiré ici : la page admin elle-même fait le check rôle via
+// `getSession()`.
 export function middleware(request: NextRequest) {
-  const accountId = request.cookies.get('lcdlln_portal_account')?.value
-  const role = request.cookies.get('lcdlln_portal_role')?.value
+  const hasSession = Boolean(request.cookies.get(SESSION_COOKIE_NAME)?.value)
   const { pathname } = request.nextUrl
 
-  if (pathname.startsWith('/player')) {
-    if (!accountId) {
+  if (pathname.startsWith('/player') || pathname.startsWith('/admin')) {
+    if (!hasSession) {
       const loginUrl = new URL('/login', request.url)
       loginUrl.searchParams.set('redirect', pathname)
       return NextResponse.redirect(loginUrl)
-    }
-  }
-
-  if (pathname.startsWith('/admin')) {
-    if (!accountId) {
-      const loginUrl = new URL('/login', request.url)
-      loginUrl.searchParams.set('redirect', pathname)
-      return NextResponse.redirect(loginUrl)
-    }
-    if (!isStaff(role)) {
-      return NextResponse.redirect(new URL('/', request.url))
     }
   }
 


### PR DESCRIPTION
## 🚨 Failles résolues

### 1. IMPERSONATION COMPLÈTE SANS MOT DE PASSE

Le cookie \`lcdlln_portal_account\` contenait l'**account_id en clair**. Modifiable trivialement via DevTools/curl/proxy/extensions (httpOnly empêche seulement le JS de page, pas les outils externes).

\`\`\`bash
# Exploit — l'attaquant n'a PAS de compte, ne se connecte JAMAIS
curl -b \"lcdlln_portal_account=1; lcdlln_portal_role=SUPERADMIN\" \
     https://portal/api/admin/players/123/disable \
     -X PATCH -d '{\"reason\":\"pwned\"}'
# → Désactive le compte 123 en tant que \"compte 1\". Aucun mot de passe vérifié.
\`\`\`

Les \`account_id\` étant auto-increment (1, 2, 3, …), **deviner un compte admin était trivial**.

### 2. ESCALATION ADMIN (14 routes API)

Toutes les routes \`/api/admin/*\` trustaient \`cookies().get('lcdlln_portal_role')\` directement. Un joueur connecté pouvait poser \`lcdlln_portal_role=SUPERADMIN\` et exécuter n'importe quelle action admin.

## ✅ Nouveau modèle (robuste, propre, durable)

### Architecture

| Élément | Avant | Après |
|---|---|---|
| Cookies | 2 cookies en clair (account_id + role) | 1 cookie opaque (session_token random 256 bits) |
| Source de l'identité | Lue du cookie | Lue de la DB à chaque requête |
| Falsifier l'identité | Trivial (modifier cookie) | Cryptographiquement impossible (256 bits) |
| Révocation côté serveur | Impossible (cookie côté client) | DELETE depuis \`portal_sessions\` |
| Auditabilité | Aucune | user_agent + IP au login, last_seen_at par requête |

### Schéma

**Migration SQL 0071** — table \`portal_sessions\` :
\`\`\`
session_token CHAR(64) UNIQUE  -- random 256 bits = 32 octets hex
account_id    BIGINT FK accounts CASCADE
expires_at    DATETIME         -- absolu, login + 7 jours
last_seen_at  DATETIME ON UPDATE CURRENT_TIMESTAMP  -- rolling activity
user_agent    VARCHAR(255)     -- audit
ip            VARCHAR(45)      -- audit (IPv6 ok)
\`\`\`

**Cookie** : un SEUL cookie \`lcdlln_portal_session\` = session_token opaque.

**\`getSession()\`** :
- Filtre format (\`/^[0-9a-f]{64}$/\`) avant DB
- JOIN \`portal_sessions\` + \`accounts\` → \`{accountId, role, login, tagId}\`
- Vérifie expires_at → null si expiré (+ DELETE opportuniste)
- Touch last_seen_at (sans repousser expires_at, limite les sessions éternelles sur machines partagées)

**\`requireAdmin()\`** (\`lib/auth/admin.ts\`) : helper unifié pour les 14 routes admin, appelle \`getSession()\` + \`isStaff(session.role)\`.

## 📦 Périmètre des changements

| Type | Fichiers |
|---|---|
| Migration | \`sql/migrations/0071_portal_sessions.sql\` (nouveau) |
| Lib auth | \`session.ts\` (refactor) + \`admin.ts\` (nouveau) |
| Auth endpoints | \`/api/auth/login\` (crée session) + \`/api/auth/logout\` (révoque + cleanup transitoire) |
| Middleware | \`middleware.ts\` (check présence cookie, plus de check rôle qui trustait un cookie) |
| Routes admin | 14 routes \`/api/admin/*\` migrées vers \`requireAdmin()\` |
| Routes player | 9 routes \`/api/player/*\` + \`/api/bugs\` migrées vers \`getSession()\` |
| Pages SSR | 2 commentaires obsolètes mis à jour |

**Total** : 31 fichiers modifiés / créés, 316 insertions, 217 suppressions.

## 🧪 Test plan

- [ ] Migration 0071 appliquée sans erreur
- [ ] Login → cookie \`lcdlln_portal_session\` posé, INSERT dans \`portal_sessions\`
- [ ] Logout → DELETE depuis \`portal_sessions\`, cookie effacé
- [ ] Pages \`/player/*\` accessibles connecté
- [ ] Pages \`/admin/*\` accessibles seulement si role staff (vérification DB, pas cookie)
- [ ] Routes \`/api/admin/*\` : un joueur normal qui pose \`lcdlln_portal_role=ADMIN\` via curl reçoit **403** (vs auparavant **200 OK**)
- [ ] Routes \`/api/player/*\` : poser \`lcdlln_portal_account=1\` via curl sans login → **401**
- [ ] Anciens cookies (\`lcdlln_portal_account\` / \`lcdlln_portal_role\`) sont effacés au logout (cleanup transitoire)
- [ ] Anciens utilisateurs déconnectés au déploiement → flux re-login OK

## ⚠️ Déploiement

**Migration DB obligatoire** : 0071 doit être appliquée AVANT le rollout du portail. Le MigrationRunner du master gère ça automatiquement — **déployer master + portal en lock-step**.

**Déconnexion globale au déploiement** : tous les utilisateurs actuellement connectés seront déconnectés (leur ancien cookie ne sera plus reconnu). Comportement acceptable pour une mise à jour sécurité de cette gravité.

**Pas de redéploiement shard** : zéro modification gameplay / protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)