### PR TITLE
fix(web-portal): isole les constantes de session pour le bundle Edge

### DIFF
--- a/web-portal/lib/auth/session-cookie.ts
+++ b/web-portal/lib/auth/session-cookie.ts
@@ -1,0 +1,18 @@
+// Constantes du cookie de session — extraites de session.ts pour pouvoir être
+// importées depuis le middleware sans tirer les dépendances Node.js
+// (mysql2, node:crypto) qui ne sont pas disponibles en Edge Runtime.
+//
+// Le middleware Next.js tourne sur l'Edge Runtime (V8 isolate, pas Node.js)
+// — il a accès aux Web APIs mais PAS aux modules `node:*` ni à `mysql2`.
+// Si on importe `SESSION_COOKIE_NAME` depuis `session.ts`, webpack bundle
+// tout `session.ts` (incluant ses imports transitifs) pour Edge → fail
+// "Unhandled scheme 'node:'". En isolant les constantes dans ce module
+// pur, le middleware reste léger et bundle-friendly.
+
+export const SESSION_COOKIE_NAME = 'lcdlln_portal_session'
+
+// Durée de vie maximale d'une session (login → expiration absolue). Le
+// rolling refresh de last_seen_at ne repousse PAS expires_at — c'est
+// volontaire pour limiter les sessions éternellement actives sur une
+// machine partagée.
+export const SESSION_MAX_AGE_SEC = 60 * 60 * 24 * 7 // 7 jours

--- a/web-portal/lib/auth/session.ts
+++ b/web-portal/lib/auth/session.ts
@@ -1,20 +1,16 @@
 import { cookies } from 'next/headers'
-import { randomBytes } from 'node:crypto'
+import { randomBytes } from 'crypto'
 import type { ResultSetHeader, RowDataPacket } from 'mysql2/promise'
 import { query } from '@/lib/db/connection'
 import { normalizeRole, type AccountRole } from '@/lib/auth/roles'
+import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_SEC } from '@/lib/auth/session-cookie'
 
-// Nom du seul cookie d'authentification. Contient un session_token random
-// (64 chars hex). Aucune information identifiante ou autoritative côté
-// client — toute la matérialisation de l'identité passe par une lecture
-// de la table portal_sessions à chaque appel de getSession().
-export const SESSION_COOKIE_NAME = 'lcdlln_portal_session'
-
-// Durée de vie maximale d'une session (login → expiration absolue). Le
-// rolling refresh (last_seen_at via ON UPDATE CURRENT_TIMESTAMP) ne
-// repousse PAS expires_at — c'est volontaire pour limiter les sessions
-// éternellement actives sur une machine partagée.
-export const SESSION_MAX_AGE_SEC = 60 * 60 * 24 * 7 // 7 jours
+// Re-export pour conserver la compatibilité des imports existants
+// (`import { SESSION_COOKIE_NAME } from '@/lib/auth/session'`). Le code
+// runtime de session reste dans ce module ; les constantes pures vivent
+// dans `session-cookie.ts` pour pouvoir être consommées par le middleware
+// Edge sans tirer les dépendances Node.js (`crypto`, `mysql2`).
+export { SESSION_COOKIE_NAME, SESSION_MAX_AGE_SEC }
 
 export type Session = {
   accountId: number

--- a/web-portal/middleware.ts
+++ b/web-portal/middleware.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { SESSION_COOKIE_NAME } from '@/lib/auth/session'
+// Import depuis `session-cookie` (module pur, sans deps Node.js) plutôt
+// que `session` (qui importe crypto + mysql2). Cela permet au middleware
+// de tourner sur l'Edge Runtime de Next.js sans casser le webpack bundle.
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session-cookie'
 
 // Le middleware vérifie uniquement la PRÉSENCE d'un cookie session_token.
 // Il NE DOIT PAS faire de lookup DB ici (le middleware tourne sur Edge


### PR DESCRIPTION
## Contexte

Suite au merge du refactor auth (#751), le build Docker du conteneur web-portal échouait :

\`\`\`
Module build failed: UnhandledSchemeError: Reading from "node:crypto"
is not handled by plugins (Unhandled scheme).
Import trace: node:crypto → ./lib/auth/session.ts
              node:diagnostics_channel → mysql2 → ./lib/db/connection.ts → ./lib/auth/session.ts
\`\`\`

## Cause

Le `middleware.ts` de Next.js tourne sur l'**Edge Runtime** (V8 isolate, pas Node.js). En important `SESSION_COOKIE_NAME` depuis `lib/auth/session.ts`, webpack devait bundler **tout** `session.ts` pour Edge — y compris `node:crypto` et `mysql2` (via `@/lib/db/connection`). Indisponibles côté Edge → crash.

## Fix

| Fichier | Changement |
|---|---|
| `lib/auth/session-cookie.ts` (nouveau) | Module **pur** : `SESSION_COOKIE_NAME` + `SESSION_MAX_AGE_SEC`. Zéro dépendance Node.js. |
| `lib/auth/session.ts` | Re-exporte les 2 constantes depuis `session-cookie.ts`. `node:crypto` → `crypto`. |
| `middleware.ts` | Importe depuis `session-cookie.ts`. |

Aucun changement fonctionnel. Côté Node.js (routes API + SSR), `import { SESSION_COOKIE_NAME } from '@/lib/auth/session'` fonctionne toujours via re-export.

## Note

Cette PR remplace les PRs #752 / #754 (mal stackées après le squash-merge de #751). Elle est basée sur `main` à jour donc **sans conflit**.

## Test plan

- [ ] `docker compose up -d` : stage `web-portal builder` → `npm run build` réussit
- [ ] Image `lcdlln-web-portal` construite, conteneur démarre

## Déploiement

✅ Web-portal uniquement. Indispensable pour reconstruire l'image après #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)