### PR TITLE
🔴 fix(db): mysql_stmt_store_result manquant — régression création de personnage

### DIFF
--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -191,7 +191,41 @@ namespace engine::server::db
 				return false;
 		}
 
-		return mysql_stmt_execute(m_stmt) == 0;
+		if (mysql_stmt_execute(m_stmt) != 0)
+			return false;
+
+		// CRITIQUE : bufferiser tout le result set côté client immédiatement
+		// après l'exécution (pour les SELECT, c.-à-d. m_resultColumnCount > 0).
+		//
+		// Sans `mysql_stmt_store_result`, libmysql laisse le result set en mode
+		// "unbuffered" (streaming serveur) : la connexion reste bloquée tant que
+		// le client n'a pas fetché TOUTES les lignes jusqu'à MYSQL_NO_DATA. Or
+		// de nombreux call sites font un `FetchRow()` unique sur un lookup
+		// LIMIT 1 qui renvoie 1 ligne (ex. AUTH FindByLogin, IsForbiddenName,
+		// NameExists) puis s'arrêtent SANS drainer la ligne EOF. La connexion
+		// reste alors en état "commands out of sync" → le PROCHAIN
+		// `mysql_stmt_prepare` sur cette même connexion poolée échoue avec
+		// CR_COMMANDS_OUT_OF_SYNC (2014), et `mysql_ping` finit par échouer →
+		// reconnexions permanentes.
+		//
+		// `store_result` transfère l'intégralité des lignes côté client en une
+		// fois : la connexion redevient immédiatement réutilisable pour un autre
+		// statement, peu importe combien de lignes le caller fetche ensuite.
+		// FetchRow() lit alors depuis le buffer client, Reset()/free_result le
+		// libère. C'est le pattern standard libmysql pour multiplexer plusieurs
+		// prepared statements sur une connexion partagée.
+		//
+		// Régression introduite par la conversion N1 (mysql_query +
+		// mysql_store_result bufferisé par défaut → prepared statements
+		// unbuffered). Restée latente car network_integration_tests (seul test
+		// exerçant MySQL live multi-requêtes/connexion) est exclu de la CI.
+		if (m_resultColumnCount > 0)
+		{
+			if (mysql_stmt_store_result(m_stmt) != 0)
+				return false;
+		}
+
+		return true;
 	}
 
 	bool SqlPreparedStatement::FetchRow()


### PR DESCRIPTION
## 🚨 Régression critique en production

**Symptôme** : impossible de créer un nouveau personnage. Le master logge en boucle :
\`\`\`
[CharacterCreateHandler] IsForbiddenCharacterName : Acquire prepared stmt a échoué
[CharacterCreateHandler] CharacterNameExistsOnServer : Acquire prepared stmt a échoué
[CharacterCreateHandler] FindNextSlot : Acquire prepared stmt a échoué
[ConnectionPool] Reconnected after ping failure   ← à CHAQUE opération
\`\`\`
→ le client reçoit \`ERROR code=100 "character slots full"\` (car \`FindNextSlot\` renvoie -1).

## Cause racine

\`SqlPreparedStatement::Execute()\` appelait \`mysql_stmt_execute()\` **sans \`mysql_stmt_store_result()\` ensuite**. Les résultats d'un SELECT préparé restent donc en mode **unbuffered** (streaming serveur) : la connexion reste verrouillée tant que toutes les lignes ne sont pas fetchées jusqu'à \`MYSQL_NO_DATA\`.

Or beaucoup de call sites font un **\`FetchRow()\` unique** sur un lookup \`LIMIT 1\` (AUTH \`FindByLogin\`, \`IsForbiddenName\`, \`NameExists\`…) puis s'arrêtent sans drainer l'EOF → la connexion poolée est rendue en état **« commands out of sync »**.

**Conséquences en chaîne :**
1. Le prochain \`mysql_stmt_prepare()\` sur cette connexion échoue avec \`CR_COMMANDS_OUT_OF_SYNC (2014)\` → \`Acquire\` renvoie nullptr → les 3 lookups de création échouent → \"character slots full\".
2. \`mysql_ping()\` finit par échouer sur ces connexions polluées → la pool **reconnecte en permanence** (les \"Reconnected after ping failure\" omniprésents dans le log).

## Fix

\`\`\`cpp
if (mysql_stmt_execute(m_stmt) != 0)
    return false;
if (m_resultColumnCount > 0) {
    if (mysql_stmt_store_result(m_stmt) != 0)   // ← buffer tout le result set
        return false;
}
return true;
\`\`\`

\`store_result\` transfère l'intégralité des lignes côté client en une fois → la connexion redevient immédiatement réutilisable, peu importe combien de lignes le caller fetche. \`FetchRow()\` lit depuis le buffer, \`Reset()\`/\`free_result\` le libère. **Pattern standard libmysql** pour multiplexer plusieurs prepared statements sur une connexion partagée. Les INSERT/UPDATE (\`resultColumnCount=0\`) ne sont pas affectés.

Un seul site appelle \`mysql_stmt_execute\` (vérifié) → fix centralisé, couvre tous les handlers.

## Pourquoi régression / non détecté

- **Régression** : avant la conversion N1, le code utilisait \`mysql_query\` + \`mysql_store_result\` (bufferisé par défaut → lectures partielles sûres). La conversion prepared statements a introduit l'unbuffered sans le \`store_result\`.
- **Non détecté en CI** : \`SqlPreparedStatementTests::TestBindExecuteFetch\` reproduit exactement le pattern (FetchRow once + réutilisation connexion par \`TestCacheHitMiss\`), mais **skip quand \`db.host\` est vide** (cas CI sans MySQL), et \`network_integration_tests\` (qui a un MySQL live) est **exclu du \`ctest -E\`**. Le seul test capable de l'attraper ne tourne jamais avec une vraie DB.

## Test plan

- [ ] CI build-linux + build-windows verts
- [ ] **En prod (avec MySQL live)** : créer un personnage → succès
- [ ] Vérifier que les \"Reconnected after ping failure\" en boucle disparaissent du log master
- [ ] AUTH, character list, et autres lookups continuent de fonctionner

> ⚠️ Ce fix touche du comportement runtime MySQL non couvrable par la CI (network_integration_tests exclu). Validation finale = test manuel en prod.

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR MASTER REQUIS** — corrige un bug runtime critique (création de personnage cassée + reconnexions DB en boucle). Pas de changement de protocole ni de schéma. Le shard n'est pas concerné (mode fichier, sans DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)