### PR TITLE
🔴 fix(db): troncature colonnes longues prepared statement — régression CGU

### DIFF
--- a/src/shared/db/SqlPreparedStatement.cpp
+++ b/src/shared/db/SqlPreparedStatement.cpp
@@ -16,6 +16,12 @@ namespace engine::server::db
 {
 	namespace
 	{
+		// Taille inline du buffer de résultat par colonne. Couvre la grande
+		// majorité des colonnes (ids, noms, labels, dates…). Les colonnes plus
+		// longues (TEXT/MEDIUMTEXT : contenu CGU, corps de mail…) déclenchent
+		// MYSQL_DATA_TRUNCATED et sont re-fetchées dans l'overflow.
+		constexpr size_t kResultInlineBytes = 256;
+
 		MYSQL_STMT* PrepareStatement(MYSQL* mysql, std::string_view sql)
 		{
 			MYSQL_STMT* stmt = mysql_stmt_init(mysql);
@@ -45,9 +51,11 @@ namespace engine::server::db
 		}
 		if (resultColumnCount > 0)
 		{
-			m_resultBuffers.assign(resultColumnCount, std::vector<uint8_t>(256));
+			m_resultBuffers.assign(resultColumnCount, std::vector<uint8_t>(kResultInlineBytes));
 			m_resultLengths.assign(resultColumnCount, 0);
 			m_resultIsNull.assign(resultColumnCount, 0);
+			m_resultOverflow.assign(resultColumnCount, std::vector<uint8_t>());
+			m_resultTruncated.assign(resultColumnCount, 0);
 		}
 	}
 
@@ -232,8 +240,60 @@ namespace engine::server::db
 	{
 		if (!m_stmt)
 			return false;
+
+		// Réinitialise les drapeaux de troncature pour la nouvelle ligne.
+		if (!m_resultTruncated.empty())
+			std::fill(m_resultTruncated.begin(), m_resultTruncated.end(), static_cast<char>(0));
+
 		const int rc = mysql_stmt_fetch(m_stmt);
-		return rc == 0;  // 0 = OK, MYSQL_NO_DATA = fin, autres = erreur
+
+		// rc == 0 : ligne complète, toutes les colonnes tenaient dans leur buffer inline.
+		if (rc == 0)
+			return true;
+
+		// MYSQL_NO_DATA : fin du result set. Toute autre valeur ≠ TRUNCATED = erreur.
+		if (rc != MYSQL_DATA_TRUNCATED)
+			return false;  // MYSQL_NO_DATA (plus de lignes) ou erreur réelle
+
+		// MYSQL_DATA_TRUNCATED : au moins une colonne dépasse kResultInlineBytes.
+		// m_resultLengths[col] contient la longueur RÉELLE (libmysql l'écrit même
+		// en cas de troncature). On re-fetch chaque colonne tronquée dans son
+		// buffer overflow dimensionné, via mysql_stmt_fetch_column.
+		//
+		// IMPORTANT : on ne redimensionne PAS m_resultBuffers (le buffer lié par
+		// mysql_stmt_bind_result), seulement m_resultOverflow — sinon le pointeur
+		// lié deviendrait dangling pour le prochain mysql_stmt_fetch.
+		for (size_t col = 0; col < m_resultColumnCount; ++col)
+		{
+			if (m_resultIsNull[col])
+				continue;
+			const unsigned long actualLen = m_resultLengths[col];
+			if (actualLen <= m_resultBuffers[col].size())
+				continue;  // colonne tenait dans le buffer inline, déjà correcte
+
+			m_resultOverflow[col].assign(actualLen, 0);
+			MYSQL_BIND b;
+			std::memset(&b, 0, sizeof(b));
+			b.buffer        = m_resultOverflow[col].data();
+			b.buffer_length = static_cast<unsigned long>(m_resultOverflow[col].size());
+			b.length        = &m_resultLengths[col];
+			b.is_null       = reinterpret_cast<bool*>(&m_resultIsNull[col]);
+			b.buffer_type   = MYSQL_TYPE_STRING;
+			// offset 0 : re-lit la colonne depuis le début, complète cette fois.
+			if (mysql_stmt_fetch_column(m_stmt, &b, static_cast<unsigned int>(col), 0) != 0)
+				return false;
+			m_resultTruncated[col] = 1;  // GetXxx lira depuis l'overflow pour cette ligne
+		}
+		return true;  // ligne valide : colonnes tronquées re-fetchées en intégralité
+	}
+
+	// Sélection du buffer source pour la colonne \p col de la ligne courante :
+	// overflow si la colonne a été tronquée puis re-fetchée, sinon buffer inline.
+	const std::vector<uint8_t>& SqlPreparedStatement::resultBuffer(size_t col) const
+	{
+		if (col < m_resultTruncated.size() && m_resultTruncated[col])
+			return m_resultOverflow[col];
+		return m_resultBuffers[col];
 	}
 
 	int32_t SqlPreparedStatement::GetInt32(size_t col, int32_t fallback) const
@@ -241,7 +301,7 @@ namespace engine::server::db
 		if (col >= m_resultColumnCount || m_resultIsNull[col])
 			return fallback;
 		// Le buffer contient une string ASCII de l'entier (MYSQL_TYPE_STRING).
-		const auto& buf = m_resultBuffers[col];
+		const auto& buf = resultBuffer(col);
 		const unsigned long len = std::min(m_resultLengths[col], static_cast<unsigned long>(buf.size()));
 		const std::string s(reinterpret_cast<const char*>(buf.data()), len);
 		return std::atoi(s.c_str());
@@ -251,7 +311,7 @@ namespace engine::server::db
 	{
 		if (col >= m_resultColumnCount || m_resultIsNull[col])
 			return fallback;
-		const auto& buf = m_resultBuffers[col];
+		const auto& buf = resultBuffer(col);
 		const unsigned long len = std::min(m_resultLengths[col], static_cast<unsigned long>(buf.size()));
 		const std::string s(reinterpret_cast<const char*>(buf.data()), len);
 		return std::strtoull(s.c_str(), nullptr, 10);
@@ -261,7 +321,7 @@ namespace engine::server::db
 	{
 		if (col >= m_resultColumnCount || m_resultIsNull[col])
 			return {};
-		const auto& buf = m_resultBuffers[col];
+		const auto& buf = resultBuffer(col);
 		const unsigned long len = std::min(m_resultLengths[col], static_cast<unsigned long>(buf.size()));
 		return std::string(reinterpret_cast<const char*>(buf.data()), len);
 	}

--- a/src/shared/db/SqlPreparedStatement.h
+++ b/src/shared/db/SqlPreparedStatement.h
@@ -70,6 +70,10 @@ namespace engine::server::db
 		friend class SqlPreparedStatementCache;
 		SqlPreparedStatement(MYSQL_STMT* stmt, size_t paramCount, size_t resultColumnCount);
 
+		// Buffer source de la colonne \p col pour la ligne courante : overflow si
+		// la colonne a été tronquée puis re-fetchée par FetchRow, sinon inline.
+		const std::vector<uint8_t>& resultBuffer(size_t col) const;
+
 		MYSQL_STMT* m_stmt = nullptr;
 		size_t m_paramCount = 0;
 		size_t m_resultColumnCount = 0;
@@ -84,9 +88,22 @@ namespace engine::server::db
 		// Drapeau "non signé" pour les types entiers (MYSQL_BIND::is_unsigned).
 		std::vector<char> m_paramIsUnsigned;
 		// Buffers pour les colonnes de résultat (alloués au premier Execute).
+		// Taille fixe (kResultInlineBytes) : c'est CE buffer qui est lié via
+		// mysql_stmt_bind_result, il ne doit donc pas être réalloué tant que le
+		// statement vit (sinon le pointeur lié devient dangling pour le prochain
+		// mysql_stmt_fetch).
 		std::vector<std::vector<uint8_t>> m_resultBuffers;
 		std::vector<unsigned long> m_resultLengths;
 		std::vector<char> m_resultIsNull;
+		// Overflow par colonne : quand une colonne dépasse kResultInlineBytes,
+		// mysql_stmt_fetch retourne MYSQL_DATA_TRUNCATED ; FetchRow re-fetch alors
+		// la colonne complète ici via mysql_stmt_fetch_column (buffer dimensionné
+		// à la longueur réelle). m_resultTruncated[col] indique, pour la ligne
+		// courante, si la valeur doit être lue depuis l'overflow plutôt que le
+		// buffer inline. Sépare le buffer LIÉ (inline, stable) du buffer VALEUR
+		// (overflow, redimensionnable) pour éviter le dangling pointer.
+		std::vector<std::vector<uint8_t>> m_resultOverflow;
+		std::vector<char> m_resultTruncated;
 	};
 
 	/// Cache LRU de SqlPreparedStatement par connexion MYSQL*.

--- a/src/shared/db/SqlPreparedStatementTests.cpp
+++ b/src/shared/db/SqlPreparedStatementTests.cpp
@@ -87,6 +87,36 @@ namespace
 		LOG_INFO(Core, "[SqlPSTests] Cache hit/miss/LRU eviction OK");
 		return true;
 	}
+
+	// Non-régression : une colonne dépassant la taille inline du buffer (256 o)
+	// doit être lue EN INTÉGRALITÉ, pas tronquée ni perdue. Avant le fix, FetchRow
+	// traitait MYSQL_DATA_TRUNCATED comme un échec → la ligne était droppée
+	// (régression CGU : terms_localizations.content ~40 Ko → GetFirstPending vide).
+	// SELECT REPEAT('x', N) : self-contained, aucune table requise.
+	bool TestLargeColumnNoTruncation(MYSQL* mysql)
+	{
+		SqlPreparedStatementCache cache(4);
+		constexpr int kLen = 5000;  // >> 256 o inline
+		SqlPreparedStatement* stmt = cache.Acquire(mysql, "SELECT REPEAT('x', ?)");
+		if (!stmt || !stmt->Bind(0, static_cast<int32_t>(kLen)) || !stmt->Execute())
+		{
+			LOG_ERROR(Core, "[SqlPSTests] LargeColumn Acquire/Bind/Execute failed");
+			return false;
+		}
+		if (!stmt->FetchRow())
+		{
+			LOG_ERROR(Core, "[SqlPSTests] LargeColumn FetchRow failed (truncation dropped row?)");
+			return false;
+		}
+		const std::string s = stmt->GetString(0);
+		if (s.size() != static_cast<size_t>(kLen))
+		{
+			LOG_ERROR(Core, "[SqlPSTests] LargeColumn expected {} bytes, got {}", kLen, s.size());
+			return false;
+		}
+		LOG_INFO(Core, "[SqlPSTests] LargeColumn full {}-byte read OK (no truncation)", kLen);
+		return true;
+	}
 }
 
 int main(int argc, char** argv)
@@ -114,7 +144,8 @@ int main(int argc, char** argv)
 
 	auto guard = pool.Acquire();
 	MYSQL* mysql = guard.get();
-	bool ok = mysql && TestBindExecuteFetch(mysql) && TestCacheHitMiss(mysql);
+	bool ok = mysql && TestBindExecuteFetch(mysql) && TestCacheHitMiss(mysql)
+		&& TestLargeColumnNoTruncation(mysql);
 
 	guard = ConnectionPool::Guard();
 	pool.Shutdown();


### PR DESCRIPTION
## 🚨 Régression : CGU en attente non affichées / non validables

Distinct de #756 (store_result) — celui-ci ne corrige PAS la troncature.

## Cause racine

Les buffers de résultat de `SqlPreparedStatement` sont alloués à **256 octets fixes** (`m_resultBuffers`, liés via `mysql_stmt_bind_result`). Quand une colonne dépasse 256 o, `mysql_stmt_fetch` retourne `MYSQL_DATA_TRUNCATED` (101). Or `FetchRow()` faisait :

\`\`\`cpp
return rc == 0;  // MYSQL_DATA_TRUNCATED traité comme échec → ligne DROPPÉE
\`\`\`

**Impact CGU** : `terms_localizations.content` fait **~40 Ko** (markdown complet des CGU v2.0, migration 0038). `FetchAllLocales` lit cette colonne → troncature → `FetchRow` false → boucle `while` n'ajoute rien → `outRows` vide → `GetFirstPending` renvoie false → `TermsHandler` répond sans édition → **client n'affiche aucune CGU**.

## Pourquoi régression / pourquoi character create marche mais pas les CGU

- **Régression** : avant la conversion N1-C (#734), `TermsRepository` utilisait `mysql_query`+`mysql_fetch_row` (char* pleine longueur, aucun buffer fixe). La conversion prepared statements a introduit le buffer 256 o.
- **Character create OK, CGU KO** : les colonnes de character create (id, slot, name) sont toutes < 256 o → jamais tronquées. Seul le `content` CGU (40 Ko) déclenche le bug.

## Fix

`FetchRow()` gère `MYSQL_DATA_TRUNCATED` : pour chaque colonne dont la longueur réelle dépasse le buffer inline, re-fetch la colonne **complète** dans un buffer overflow dimensionné via `mysql_stmt_fetch_column`.

**Point clé** : on ne redimensionne PAS `m_resultBuffers` (le buffer lié — sinon pointeur dangling pour le prochain `mysql_stmt_fetch`). On sépare le buffer **LIÉ** (inline, 256 o stable) du buffer **VALEUR** (`m_resultOverflow`, redimensionnable). `m_resultTruncated[col]` indique par ligne quel buffer lire ; les getters passent par `resultBuffer(col)`.

## Test

`TestLargeColumnNoTruncation` : `SELECT REPEAT('x', 5000)` (self-contained, sans table) vérifie qu'une colonne de 5000 o est lue en entier. Skip si `db.host` vide (CI sans MySQL) — d'où la non-détection initiale (`network_integration_tests` exclu).

## Test plan

- [ ] CI build-linux + build-windows verts
- [ ] **En prod** : compte sans acceptation v2.0 → écran CGU s'affiche + contenu complet + validation OK
- [ ] Bénéficie aussi aux autres colonnes longues (corps de mail, etc.)

> ⚠️ Comportement MySQL runtime non couvrable en CI (network_integration_tests exclu). Validation finale = test manuel en prod.

## Déploiement

⚠️ **REDÉPLOIEMENT SERVEUR MASTER REQUIS** (avec #756). Pas de protocole ni schéma modifié. Le shard n'est pas concerné.

## Récap des 2 fixes nécessaires pour les CGU

| PR | Corrige | Sans lui |
|---|---|---|
| #756 (mergé) | `mysql_stmt_store_result` manquant | GetFirstPending échoue au 2e prepare (commands out of sync) |
| #757 (cette PR) | troncature buffer 256 o | GetFirstPending échoue car content 40 Ko droppé |

**Les deux sont nécessaires** pour que les CGU s'affichent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)