### PR TITLE
fix(client): saut realiste — jumpSpeed 9.0 -> 4.9 (apex ~0.60 m)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -943,6 +943,13 @@ auront beaucoup de clips Mixamo).
   (snap immédiat). À ajouter en B ultérieure si demandé.
 - **Pas de saut en longueur distinct** du saut vertical. `Running Jump.fbx`
   dans l'inbox, non utilisé.
+- **Hauteur de saut réaliste (2026-05-29)** : `CharacterController::Config::jumpSpeed`
+  est passé de `9.0` à **`4.9` m/s** (config `player.movement.jump_speed` aussi).
+  Apex = `jumpSpeed² / (2·|gravity|)` = `4.9² / 40` ≈ **0,60 m** (avant ~2,0 m,
+  irréaliste). Garde anti-régression : `character_controller_jump_tests`
+  (`src/client/gameplay/tests/CharacterControllerJumpTests.cpp`) vérifie l'apex
+  ∈ [0,50 ; 0,72] m. Pur client (le shard valide la position mais n'impose pas
+  la hauteur de saut).
 - **Pas de strafe / walk backward distincts** : le perso pivote toujours pour
   faire face à la direction de mouvement (convention free-look).
 - **First-frame** : à la première frame post-EnterWorld, `m_avatarYaw = 0` →

--- a/config.json
+++ b/config.json
@@ -110,7 +110,7 @@
             "walk_speed": 5.0,
             "run_speed": 9.0,
             "gravity": -20.0,
-            "jump_speed": 9.0,
+            "jump_speed": 4.9,
             "coyote_time_s": 0.1,
             "jump_buffer_s": 0.1
         }

--- a/docs/superpowers/specs/2026-05-29-replication-anomalies-design.md
+++ b/docs/superpowers/specs/2026-05-29-replication-anomalies-design.md
@@ -1,0 +1,102 @@
+# Design — Correction de 3 anomalies de réplication / mouvement (2026-05-29)
+
+## Contexte
+
+Avec deux sessions joueur observées simultanément, trois anomalies ont été
+constatées :
+
+1. **/dance et roulade invisibles aux autres** (le saut, lui, est visible).
+2. **Saut trop haut** (~1× la taille de l'avatar ; on veut un saut réaliste).
+3. **Invisibilité mutuelle à la première connexion** juste après création de
+   personnage ; une déconnexion/reconnexion répare tout.
+
+Livraison en **3 PR séparées**, ordre de merge **A → C → B**.
+
+---
+
+## Diagnostic (cause racine par anomalie)
+
+### #1 — Animation non répliquée
+`SnapshotEntity` (`src/shared/network/ReplicationTypes.h`) ne transporte pas
+l'état d'animation. Pour les avatars distants, `Engine::RecordRemoteAvatars`
+**dérive** l'animation de la seule vélocité serveur (`< 0.1 m/s → Idle`, sinon
+`Walk`, cf. CODEBASE_MAP §56). Conséquence :
+- Le **saut** semble visible parce que la position Y (répliquée) monte
+  réellement — pas parce que le clip Jump est joué.
+- **/dance** (sur place) et la **roulade** ne modifient pas l'animation perçue →
+  invisibles. **Run / Sprint / Attaque** ne sont pas répliqués non plus
+  (limite notée CODEBASE_MAP ligne ~1994, « TD.8 »).
+
+### #2 — Saut trop haut
+`CharacterController.h` : `jumpSpeed = 9.0` m/s, `gravity = -20` m/s². Apex ≈
+v²/(2·g) = 81/40 ≈ **2,0 m** (~1,1× la taille de 1,8 m). Réglage purement client.
+
+### #3 — Invisibilité 1ère connexion
+`Engine.cpp` (~7181) : à l'EnterWorld, le `character_key` de la session UDP
+n'est surchargé que **si `enterCmd.characterId != 0`**. Si le personnage
+fraîchement créé n'a pas (encore) d'`character_id` non nul dans la
+`CHARACTER_LIST` rechargée, le bloc est sauté ; `InitGameplayNet` (~9840) relit
+alors la valeur de config par défaut/résiduelle (1) et envoie le Hello UDP avec
+une **mauvaise clé** → le shard associe le client au mauvais personnage → pas de
+réplication AoI mutuelle. La reconnexion par login normal répare car la
+`CHARACTER_LIST` contient alors le perso avec un `character_id` valide. **Bug et
+fix côté client** (le shard est déjà correct).
+
+---
+
+## PR A — Saut réaliste (#2) · client uniquement
+
+- Cible ~0,6 m : `jumpSpeed = √(2·g·h) = √(2·20·0,6) ≈ 4.9` m/s.
+- `src/client/gameplay/CharacterController.h` : `jumpSpeed` default `9.0f → 4.9f`.
+- `config.json` → `player.movement.jump_speed` : `9.0 → 4.9`.
+- **Test** : test unitaire CharacterController — saut depuis le sol, apex ≈ 0,6 m ±5 %.
+- **Déploiement** : ✅ client uniquement.
+
+## PR C — Visibilité mutuelle 1ère connexion (#3) · client uniquement
+
+Défense en profondeur, côté client :
+1. **Garde dure** (`Engine.cpp` ~7181) : si `characterId == 0`, ne PAS lancer
+   `InitGameplayNet` avec une clé résiduelle ; logger une erreur claire et
+   forcer un rafraîchissement de `CHARACTER_LIST` au lieu de se connecter en
+   « fantôme 1 ».
+2. **Propagation fiable de l'id** : garantir que le `character_id` du perso
+   fraîchement créé est présent et sélectionné dans la `CHARACTER_LIST`
+   rechargée avant d'autoriser « Jouer » (capturer l'id retourné par
+   `CHARACTER_CREATE` comme fallback, ou bloquer l'entrée tant que l'id de
+   sélection est nul).
+3. **Étape 0 (debug confirmatoire)** : instrumenter le cas `characterId==0`,
+   reproduire (créer → entrer) pour confirmer le déclencheur exact.
+- **Test** : logique de sélection/propagation d'id (non nul après création) +
+  garde (refus si id 0).
+- **Déploiement** : ✅ client uniquement.
+
+## PR B — Réplication de l'état d'animation (#1) · lock-step client + serveur
+
+1. **Enum partagé** : `enum class AvatarAnimState : uint8_t` dans
+   `ReplicationTypes.h` (`Idle, Walk, Run, Sprint, Jump, Fall, Land,
+   CrouchIdle, CrouchWalk, Roll, Emote, Attack, …`), aligné sur
+   `AvatarLocomotionState` (`Engine.h`). Source de vérité wire.
+2. **Client → shard** : ajout de `animationState` au paquet d'input client→shard
+   (`HandleInput` + encodeur). Le shard le stocke sur `ConnectedClient`.
+3. **Shard → clients** : ajout de `uint8_t animationState` à `SnapshotEntity` ;
+   `EncodeSnapshot`/`DecodeSnapshot` écrivent/lisent ; min payload/entité
+   56 → 57 octets.
+4. **Bump protocole** : `kProtocolVersion 7 → 8` (`ServerProtocol.h`) —
+   lock-step obligatoire (double bump, deux directions).
+5. **Rendu distant** : `UIRemoteEntity` reçoit `animationState` ;
+   `RecordRemoteAvatars` mappe l'état reçu vers le clip (réutilise
+   `StateToClipName` / `ClipLoops` + crossfade 150 ms). Fallback dérivation
+   vélocité si état inconnu (master/mob legacy).
+- **Tests** : round-trip `ServerProtocolTests` (encode/decode avec
+  `animationState`, rejet payload tronqué < 57) + mapping état→clip.
+- **Déploiement** : ⚠️ redéploiement serveur (shard) requis + client neuf, en
+  **lock-step**.
+
+---
+
+## Ordre de merge
+1. **PR A** (saut) — indépendante, mergeable immédiatement.
+2. **PR C** (visibilité) — client only, indépendante.
+3. **PR B** (animation) — dernière, déploiement serveur lock-step (client + shard ensemble).
+
+CODEBASE_MAP.md mis à jour dans chaque PR.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -749,6 +749,11 @@ elseif(UNIX)
   lcdlln_add_simple_test(terrain_collider_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/TerrainColliderTests.cpp)
 
+  # Saut realiste : verifie l'apex (~0.60 m) du CharacterController apres le
+  # passage jumpSpeed 9.0 -> 4.9. Garde anti-regression (pas de saut ~2 m).
+  lcdlln_add_simple_test(character_controller_jump_tests
+    ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CharacterControllerJumpTests.cpp)
+
   # Sous-projet C MVP : RaceDefinition.meshPath parsing.
   # Verifie que les 3 races MVP (humains, nains, orcs) exposent un meshPath
   # non vide depuis races.json, et que les races hors-MVP exposent une

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -90,7 +90,10 @@ namespace engine::gameplay
 			float maxSlopeDeg = 45.0f; ///< walkable slope
 			float maxStep = 0.3f;      ///< m
 
-			float jumpSpeed = 9.0f;       ///< m/s, impulse applied when jumping
+			// Saut realiste : apex = jumpSpeed^2 / (2*|gravity|). Avec gravity=-20,
+			// jumpSpeed=4.9 -> ~0.60 m (env. 1/3 de la taille 1.8 m, saut humain pose).
+			// Auparavant 9.0 -> ~2.0 m (irrealiste, ~1.1x la taille).
+			float jumpSpeed = 4.9f;       ///< m/s, impulse applied when jumping
 			float airControlMultiplier = 0.5f; ///< 50% of ground control
 			float coyoteTimeSec = 0.1f;   ///< allow jump shortly after leaving ground
 			float jumpBufferSec = 0.1f;   ///< allow jump shortly before landing

--- a/src/client/gameplay/tests/CharacterControllerJumpTests.cpp
+++ b/src/client/gameplay/tests/CharacterControllerJumpTests.cpp
@@ -1,0 +1,154 @@
+// src/client/gameplay/tests/CharacterControllerJumpTests.cpp
+//
+// Verifie la hauteur du saut (apex) du CharacterController apres le passage a
+// un saut realiste (jumpSpeed=4.9 m/s, gravity=-20 m/s^2 -> apex ~0.60 m).
+// Garde anti-regression : empeche un retour a un saut irrealiste (~2 m) ou a
+// l'absence de saut (apex ~0).
+//
+// Le test integre le controller a 60 Hz contre un sol plat (FlatFloor) : un
+// saut depuis le sol, puis chute jusqu'a retoucher le sol, en suivant l'apex.
+
+#include "src/client/gameplay/CharacterController.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::gameplay::CharacterController;
+	using engine::gameplay::IWorldCollider;
+	using engine::gameplay::MoveInput;
+	using engine::math::Vec3;
+
+	// Sol plat horizontal a y = floorY. Bloque uniquement la composante verticale
+	// descendante du sweep (suffisant pour un saut vertical pur). Normale = +Y.
+	class FlatFloor final : public IWorldCollider
+	{
+	public:
+		explicit FlatFloor(float floorY) : m_floorY(floorY) {}
+
+		bool SweepCapsule(const Capsule& capsule,
+			const Vec3& startCenter,
+			const Vec3& endCenter,
+			SweepHit& outHit) const override
+		{
+			const float halfH = capsule.height * 0.5f;
+			const float startBottom = startCenter.y - halfH;
+			const float endBottom = endCenter.y - halfH;
+
+			outHit.normal = Vec3(0.0f, 1.0f, 0.0f);
+
+			// Mouvement non descendant ou qui ne franchit pas le sol : pas de hit.
+			if (endBottom >= m_floorY)
+			{
+				outHit.hit = false;
+				outHit.fraction = 1.0f;
+				return false;
+			}
+			// Deja au sol ou dessous : hit immediat.
+			if (startBottom <= m_floorY)
+			{
+				outHit.hit = true;
+				outHit.fraction = 0.0f;
+				return true;
+			}
+			// Franchissement du sol pendant le sweep : fraction = distance avant contact.
+			const float denom = (startBottom - endBottom);
+			float frac = (denom > 0.0f) ? (startBottom - m_floorY) / denom : 0.0f;
+			if (frac < 0.0f) frac = 0.0f;
+			if (frac > 1.0f) frac = 1.0f;
+			outHit.hit = true;
+			outHit.fraction = frac;
+			return true;
+		}
+
+	private:
+		float m_floorY = 0.0f;
+	};
+
+	// Simule un saut vertical pur et renvoie la hauteur d'apex (m) au-dessus de
+	// la position de depart. Le controller part pose au sol (feet a y=0).
+	float SimulateJumpApex(float jumpSpeed)
+	{
+		CharacterController::Config cfg{};
+		cfg.gravity = -20.0f;
+		cfg.jumpSpeed = jumpSpeed;
+		cfg.capsule.height = 1.8f;
+		cfg.capsule.radius = 0.3f;
+		cfg.enableFlying = false;
+
+		CharacterController cc(cfg);
+		// Centre de capsule pose : feet (center.y - height/2) = 0 -> center.y = 0.9.
+		const float startCenterY = cfg.capsule.height * 0.5f;
+		cc.Init(Vec3(0.0f, startCenterY, 0.0f));
+
+		FlatFloor floor(0.0f);
+		const float dt = 1.0f / 60.0f;
+
+		// Quelques frames sans input pour stabiliser l'etat "grounded".
+		MoveInput idle{};
+		for (int i = 0; i < 10; ++i)
+			cc.Update(dt, idle, floor);
+		REQUIRE(cc.IsGrounded());
+
+		// Frame de saut.
+		MoveInput jump{};
+		jump.jumpPressed = true;
+		cc.Update(dt, jump, floor);
+
+		// Suit l'apex pendant la phase aerienne (max ~2 s couvre largement).
+		float maxCenterY = cc.GetPosition().y;
+		for (int i = 0; i < 240; ++i)
+		{
+			cc.Update(dt, idle, floor);
+			const float y = cc.GetPosition().y;
+			if (y > maxCenterY) maxCenterY = y;
+			if (i > 5 && cc.IsGrounded()) break; // retombe au sol
+		}
+
+		return maxCenterY - startCenterY;
+	}
+
+	void Test_Jump_Apex_IsRealistic()
+	{
+		const float apex = SimulateJumpApex(4.9f);
+		std::fprintf(stderr, "[INFO] apex(jumpSpeed=4.9) = %.3f m (attendu ~0.60)\n", apex);
+		// Theorique 4.9^2 / (2*20) = 0.600 m. Tolerance large pour l'integration
+		// discrete a 60 Hz (l'apex Euler peut s'ecarter de quelques cm).
+		REQUIRE(apex > 0.50f);
+		REQUIRE(apex < 0.72f);
+	}
+
+	void Test_Jump_NotTheOldUnrealisticHeight()
+	{
+		// Garde explicite : l'ancien reglage (9.0) donnait ~2.0 m. On verifie que
+		// le saut realiste reste tres en-dessous de la moitie de cette hauteur.
+		const float apex = SimulateJumpApex(4.9f);
+		REQUIRE(apex < 1.0f);
+	}
+
+	void Test_Jump_HigherSpeedGivesHigherApex()
+	{
+		// Monotonie : plus de jumpSpeed -> apex plus haut (sanity de la simulation).
+		const float low = SimulateJumpApex(4.9f);
+		const float high = SimulateJumpApex(7.0f);
+		REQUIRE(high > low);
+	}
+}
+
+int main()
+{
+	Test_Jump_Apex_IsRealistic();
+	Test_Jump_NotTheOldUnrealisticHeight();
+	Test_Jump_HigherSpeedGivesHigherApex();
+	return g_failed;
+}


### PR DESCRIPTION
@
## Anomalie #2 — saut trop haut

Le saut atteignait ~2,0 m (~1,1× la taille de 1,8 m), irréaliste. Avec `gravity=-20`, `jumpSpeed=4.9` donne un apex de `4.9²/40 ≈ 0.60 m`, conforme à un saut humain posé.

### Changements
- `CharacterController::Config::jumpSpeed` : `9.0` → `4.9` m/s ([CharacterController.h](src/client/gameplay/CharacterController.h)).
- `config.json` → `player.movement.jump_speed` : `9.0` → `4.9`.
- Nouveau test `character_controller_jump_tests` : simule un saut vertical et vérifie lapex ∈ [0,50 ; 0,72] m (garde anti-régression contre un retour à un saut irréaliste ou à labsence de saut).
- Mise à jour `CODEBASE_MAP.md` + design des 3 anomalies dans `docs/superpowers/specs/`.

### Vérification
Le clamp `maxVy = jumpSpeed*2` (CharacterController.cpp:283) ne borne que la vitesse *montante* ; baisser `jumpSpeed` naffecte pas la chute.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@