### PR TITLE
feat(replication): propage l'etat d'animation sur le wire (TD.8)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2010,3 +2010,43 @@ Les logs `[AvatarSkinDiag]` ont montré : matériaux OK (idMale=2, idFemale=3), 
 ### Limites / reste
 - Aucun. Modification cosmétique, applicable au prochain `docker compose up -d --force-recreate master shard`. Aucun impact wire ni régression.
 - **Déploiement** : ✅ client uniquement.
+
+## 58. Réplication de l'état d'animation (TD.8, 2026-05-29)
+
+**But** : rendre visibles aux autres joueurs les animations qui ne déplacent pas
+la position — `/dance` (emote), roulade, et aussi Run/Sprint/Attaque. Avant TD.8,
+`RecordRemoteAvatars` dérivait l'animation distante de la seule vélocité serveur
+(`< 0.1 m/s → Idle`, sinon `Walk`), donc seul le **saut** semblait visible (via le
+déplacement vertical réel de la position). Cf. limite notée §56.
+
+### Wire — kProtocolVersion 7 → 8 (lock-step client + shard)
+- **Enum partagé** : `engine::server::AvatarAnimState : uint8_t` dans
+  `src/shared/network/ReplicationTypes.h` (19 états, même ordre que
+  `Engine::AvatarLocomotionState`). Mapping explicite côté client via
+  `ToWireAnimState` / `FromWireAnimState` (`Engine.cpp`, anonymous ns) gardé par
+  3 `static_assert` d'alignement (Idle/Emote/Roll/SwimForward).
+- **Client → shard** : `InputMessage` gagne `uint8_t animationState` ; payload
+  Input **24 → 25 octets** (`EncodeInput`/`DecodeInput`). `GameplayUdpClient::SendInput`
+  prend le paramètre ; `Engine::UpdateGameplayNet` envoie `ToWireAnimState(m_avatarLocoState)`.
+- **Shard** : `ConnectedClient::animationState` stocké dans `HandleInput` (après le
+  gate anti-triche) ; recopié dans `SnapshotEntity` par `TryBuildSnapshotEntity`.
+- **Shard → clients** : `SnapshotEntity` gagne `AvatarAnimState animationState` ;
+  min payload/entité **56 → 57 octets** (`EncodeSnapshot`/`DecodeSnapshot`).
+- **Client rendu** : `UIRemoteEntity::animationState` (recopié par `ApplySnapshot`) ;
+  `RecordRemoteAvatars` mappe l'état → clip via `StateToClipName`/`ClipLoops` (repli
+  Walk si Idle reçu mais l'avatar glisse). Le mesh distant est le même objet
+  `m_raceMeshes` que l'avatar local (rig UE5 → clips Roll/Dance/Sprint/… présents).
+
+### Limites / reste
+- **Emotes** : le wire ne porte qu'un état (1 octet), pas le rôle d'emote précis.
+  `kEmotes` compte 7 entrées (/dance, /sit, /talk, /torch, /kneel, /sittalk, /push)
+  mais TOUTES s'affichent comme **Dance** chez les autres joueurs. `/dance` est donc
+  exact ; les autres s'animent visuellement comme Dance (mieux que l'ancien figé).
+  Réplication du rôle exact = porter le rôle d'emote sur le wire (travail ultérieur).
+- Si un clip mappé manque sur le mesh distant, `FindClip` renvoie nullptr et l'anim
+  précédente est conservée (graceful, pas de crash).
+- **Tests** : `server_protocol_tests` — round-trip Input (animationState) + Snapshot
+  (Emote/Roll/Idle) + rejet payload tronqué (57/entité).
+- **Déploiement** : ⚠️ **redéploiement serveur (shard) requis** + client neuf, en
+  **lock-step** (double bump wire, deux directions ; un client v7 face à un shard v8
+  rejette tout via `DecodeHeader`).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -353,6 +353,33 @@ namespace engine
 				|| s == engine::Engine::AvatarLocomotionState::SwimForward;
 		}
 
+		/// TD.8 — conversions entre l'état de locomotion local (Engine) et l'enum wire
+		/// partagé (engine::server::AvatarAnimState). Les deux enums listent les mêmes états
+		/// dans le même ordre ; les static_assert garantissent l'alignement à la compilation
+		/// (un état inséré d'un seul côté casse la build au lieu d'un désync silencieux sur
+		/// le wire). On caste sur l'uint8_t sous-jacent — pas de switch à maintenir en double.
+		static_assert(static_cast<uint8_t>(engine::Engine::AvatarLocomotionState::Idle)
+			== static_cast<uint8_t>(engine::server::AvatarAnimState::Idle), "AvatarAnimState desync (Idle)");
+		static_assert(static_cast<uint8_t>(engine::Engine::AvatarLocomotionState::Emote)
+			== static_cast<uint8_t>(engine::server::AvatarAnimState::Emote), "AvatarAnimState desync (Emote)");
+		static_assert(static_cast<uint8_t>(engine::Engine::AvatarLocomotionState::Roll)
+			== static_cast<uint8_t>(engine::server::AvatarAnimState::Roll), "AvatarAnimState desync (Roll)");
+		static_assert(static_cast<uint8_t>(engine::Engine::AvatarLocomotionState::SwimForward)
+			== static_cast<uint8_t>(engine::server::AvatarAnimState::SwimForward), "AvatarAnimState desync (dernier état)");
+
+		uint8_t ToWireAnimState(engine::Engine::AvatarLocomotionState s)
+		{
+			return static_cast<uint8_t>(s);
+		}
+
+		engine::Engine::AvatarLocomotionState FromWireAnimState(uint8_t v)
+		{
+			// Borne défensive : une valeur hors enum (paquet corrompu) retombe sur Idle.
+			if (v > static_cast<uint8_t>(engine::server::AvatarAnimState::SwimForward))
+				return engine::Engine::AvatarLocomotionState::Idle;
+			return static_cast<engine::Engine::AvatarLocomotionState>(v);
+		}
+
 		engine::core::LogLevel ParseLogLevelConfig(std::string_view text)
 		{
 			if (text == "Trace" || text == "trace") return engine::core::LogLevel::Trace;
@@ -9609,19 +9636,34 @@ namespace engine
 			// où on voit cet entityId. L'horloge utilisée pour Sample() / Play() est la même
 			// (nowSec) pour tous les avatars : crossfade et boucle restent en phase.
 			RemoteAvatarAnim& anim = m_remoteAnims[re.entityId];
-			// Dérivation Idle/Walk depuis la vélocité serveur. On ignore la composante Y
-			// (chute libre / saut) pour éviter de jouer Walk quand l'avatar tombe vertical.
+			// TD.8 — clip dérivé de l'état d'animation RÉPLIQUÉ (emote/roulade/run/sprint/saut/…),
+			// plus seulement Idle/Walk dérivé de la vélocité. C'est ce qui rend /dance et la
+			// roulade visibles aux autres joueurs.
 			const float speedXZ = std::sqrt(re.velocityX * re.velocityX + re.velocityZ * re.velocityZ);
-			const char* desiredClipName = (speedXZ < kIdleSpeedThresholdMps) ? "Idle" : "Walk";
+			AvatarLocomotionState effState = FromWireAnimState(re.animationState);
+			// Repli : état Idle reçu mais l'avatar glisse encore (latence de propagation de
+			// l'état) → on joue Walk pour éviter une pose Idle qui dérape.
+			if (effState == AvatarLocomotionState::Idle && speedXZ >= kIdleSpeedThresholdMps)
+				effState = AvatarLocomotionState::Walk;
+			// L'état Emote ne désigne pas un clip unique : plusieurs emotes existent
+			// (cf. kEmotes : /dance, /sit, /talk, /torch, /kneel, /sittalk, /push) mais le wire
+			// ne porte pas le rôle précis (1 octet d'état seulement). V1 : on joue l'emote
+			// primaire "Dance" pour TOUTES les emotes distantes — /dance est donc exact, les
+			// autres s'animent visuellement comme Dance (mieux que l'ancien Idle/Walk figé).
+			// Réplication du rôle d'emote exact = travail ultérieur (porter le rôle sur le wire).
+			const char* desiredClipName = (effState == AvatarLocomotionState::Emote)
+				? "Dance"
+				: StateToClipName(effState);
 			if (anim.lastClipName != desiredClipName)
 			{
 				const engine::render::skinned::AnimationClip* clip = remoteMesh->FindClip(desiredClipName);
 				if (clip != nullptr)
 				{
-					// loops=true pour Idle et Walk (clips à répétition naturelle).
-					anim.crossfade.Play(*clip, /*loops=*/ true, nowSec);
+					anim.crossfade.Play(*clip, /*loops=*/ ClipLoops(effState), nowSec);
 					anim.lastClipName = desiredClipName;
 				}
+				// Si le clip n'existe pas sur ce mesh (asset manquant), on garde l'anim
+				// précédente (graceful) — pas de switch, pas de crash.
 			}
 			// Sample → globals → finals : même chaîne que l'avatar local (cf. ligne ~4723).
 			auto locals  = anim.crossfade.Sample(remoteMesh->skeleton, nowSec);
@@ -9925,8 +9967,11 @@ namespace engine
 			{
 				m_gameplayInputAccumSec = 0.0f;
 				const engine::math::Vec3 avatarPos = m_characterController.GetPosition();
+				// TD.8 — propage l'état d'animation local pour que les autres joueurs voient
+				// emotes/roulades/run/sprint/etc. (pas seulement Idle/Walk dérivé de la vélocité).
 				(void)m_gameplayUdp.SendInput(clientId, ++m_gameplayInputSeq,
-					avatarPos.x, avatarPos.y, avatarPos.z, m_avatarYaw);
+					avatarPos.x, avatarPos.y, avatarPos.z, m_avatarYaw,
+					ToWireAnimState(m_avatarLocoState));
 			}
 		}
 

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -213,7 +213,7 @@ namespace engine::client
 		return ok;
 	}
 
-	bool GameplayUdpClient::SendInput(uint32_t clientId, uint32_t inputSequence, float posX, float posY, float posZ, float yaw)
+	bool GameplayUdpClient::SendInput(uint32_t clientId, uint32_t inputSequence, float posX, float posY, float posZ, float yaw, uint8_t animationState)
 	{
 		engine::server::InputMessage im{};
 		im.clientId = clientId;
@@ -222,6 +222,7 @@ namespace engine::client
 		im.positionMetersY = posY;
 		im.positionMetersZ = posZ;
 		im.yawRadians = yaw;
+		im.animationState = animationState; // TD.8 : état d'animation local propagé au shard.
 		// Pas de log par paquet (cadence ~20 Hz) — éviterait de noyer la console.
 		return SendBytes(engine::server::EncodeInput(im));
 	}

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -38,7 +38,9 @@ namespace engine::client
 
 		/// TC.2 — envoie un Input (position + orientation de l'avatar local) au shard.
 		/// Appelé à la cadence `client.gameplay_udp.request_tick_hz` depuis la boucle de jeu.
-		bool SendInput(uint32_t clientId, uint32_t inputSequence, float posX, float posY, float posZ, float yaw);
+		/// TD.8 — `animationState` (valeur d'AvatarAnimState) propage l'animation courante
+		/// pour que les autres joueurs voient emotes/roulades/run/sprint/saut/etc.
+		bool SendInput(uint32_t clientId, uint32_t inputSequence, float posX, float posY, float posZ, float yaw, uint8_t animationState);
 
 		/// Send TalkRequest (e.g. `vendor:1` to open shop).
 		bool SendTalkRequest(uint32_t clientId, std::string_view targetId);

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -729,6 +729,8 @@ namespace engine::client
 			remote.displayName = entity.characterName;
 			// TD.6 : genre du perso pour le rendu de l'avatar distant (vide → fallback "male").
 			remote.gender = entity.gender;
+			// TD.8 : état d'animation pour jouer le bon clip sur l'avatar distant.
+			remote.animationState = static_cast<uint8_t>(entity.animationState);
 			m_model.remoteEntities.push_back(remote);
 		}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -312,6 +312,9 @@ namespace engine::client
 		/// le SnapshotEntity. Vide pour les mobs / lootbags, ou pour les joueurs si le
 		/// master n'a pas pu fournir le genre — le rendu retombe alors sur "male".
 		std::string gender;
+		/// TD.8 : état d'animation (valeur d'AvatarAnimState) propagé via le SnapshotEntity.
+		/// Consommé par RecordRemoteAvatars pour jouer le bon clip (emote/roulade/run/…).
+		uint8_t animationState = 0;
 	};
 
 	/// Pure data model consumed by UI views and debug panels.

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -63,6 +63,36 @@ namespace engine::server
 		EntityId entityId = 0;
 	};
 
+	/// TD.8 — état d'animation répliqué (client → shard → autres clients). Sans ce champ,
+	/// le client distant dérive Idle/Walk de la seule vélocité serveur : les emotes (/dance),
+	/// roulades, run/sprint/attaque restaient invisibles aux autres joueurs (seul le saut,
+	/// via le déplacement vertical de la position, semblait visible). Les valeurs sont
+	/// alignées 1:1 (même ordre) sur `Engine::AvatarLocomotionState`, mais le client fait
+	/// un mapping **explicite** (`ToWireAnimState` / `FromWireAnimState`, Engine.cpp) pour
+	/// ne pas dépendre de l'ordre de l'enum côté rendu.
+	enum class AvatarAnimState : uint8_t
+	{
+		Idle = 0,
+		StartWalking,
+		Walk,
+		WalkBack,
+		Run,
+		Sprint,
+		CrouchIdle,
+		CrouchWalk,
+		Roll,
+		Emote,
+		Attack,
+		Cast,
+		Interact,
+		Punch,
+		Jump,
+		Fall,
+		Land,
+		SwimIdle,
+		SwimForward
+	};
+
 	/// Snapshot payload for one already-spawned entity state update.
 	/// TD.4 — `playerClientId` ≠ 0 quand l'entité représente un **joueur connecté** ;
 	/// vaut 0 pour les mobs / loot bags. Sert au client à afficher une plaque de nom
@@ -81,5 +111,8 @@ namespace engine::server
 		uint32_t playerClientId = 0;
 		std::string characterName;
 		std::string gender;
+		/// TD.8 — état d'animation courant du joueur (Idle pour les mobs/lootbags).
+		/// Wire-bump v7→v8 : 1 octet ajouté après le genre dans chaque entité du Snapshot.
+		AvatarAnimState animationState = AvatarAnimState::Idle;
 	};
 }

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -212,7 +212,8 @@ namespace engine::server
 	bool DecodeInput(std::span<const std::byte> packet, InputMessage& outMessage)
 	{
 		std::span<const std::byte> payload;
-		if (!DecodeHeader(packet, MessageKind::Input, payload) || payload.size() != 24)
+		// TD.8 — payload 25 octets : 24 (TC.1) + 1 (animationState).
+		if (!DecodeHeader(packet, MessageKind::Input, payload) || payload.size() != 25)
 		{
 			return false;
 		}
@@ -223,19 +224,22 @@ namespace engine::server
 		outMessage.positionMetersY = std::bit_cast<float>(ReadU32(payload, 12));
 		outMessage.positionMetersZ = std::bit_cast<float>(ReadU32(payload, 16));
 		outMessage.yawRadians = std::bit_cast<float>(ReadU32(payload, 20));
+		outMessage.animationState = ReadU8(payload, 24);
 		return true;
 	}
 
 	std::vector<std::byte> EncodeInput(const InputMessage& message)
 	{
-		// TC.1 — payload 24 octets : clientId, inputSequence, posX, posY, posZ, yaw.
-		std::vector<std::byte> packet = BeginPacket(MessageKind::Input, 24);
+		// TC.1/TD.8 — payload 25 octets : clientId, inputSequence, posX, posY, posZ, yaw,
+		// animationState (1 octet).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Input, 25);
 		WriteU32(packet, message.clientId);
 		WriteU32(packet, message.inputSequence);
 		WriteU32(packet, std::bit_cast<uint32_t>(message.positionMetersX));
 		WriteU32(packet, std::bit_cast<uint32_t>(message.positionMetersY));
 		WriteU32(packet, std::bit_cast<uint32_t>(message.positionMetersZ));
 		WriteU32(packet, std::bit_cast<uint32_t>(message.yawRadians));
+		WriteU8(packet, message.animationState);
 		return packet;
 	}
 
@@ -292,11 +296,11 @@ namespace engine::server
 		outMessage.chunkCount = ReadU16(payload, 22);
 
 		const size_t entityCount = static_cast<size_t>(outMessage.entityCount);
-		// TD.6 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
-		// + 2 (nameLen) + N (name) + 2 (genderLen) + M (gender) octets. On vérifie un minimum
-		// (56 par entité, nom et genre vides), puis on parse sequentiellement et on rejette si
-		// on dépasse la fin du payload en cours de route. TG.1 — header a 24 octets.
-		const size_t minimumPayloadSize = 24 + (entityCount * 56);
+		// TD.6/TD.8 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name) + 2 (genderLen) + M (gender) + 1 (animationState) octets. On vérifie
+		// un minimum (57 par entité, nom et genre vides), puis on parse sequentiellement et on rejette
+		// si on dépasse la fin du payload en cours de route. TG.1 — header a 24 octets.
+		const size_t minimumPayloadSize = 24 + (entityCount * 57);
 		if (payload.size() < minimumPayloadSize)
 		{
 			return false;
@@ -334,6 +338,16 @@ namespace engine::server
 				outEntities.clear();
 				return false;
 			}
+			// TD.8 : état d'animation (1 octet) après le genre. ReadSizedString a avancé offset ;
+			// le minimum (57/entité, chaînes vides) garantit qu'il reste au moins 1 octet, mais
+			// avec des chaînes non vides on peut dépasser : on vérifie explicitement la borne.
+			if (offset + 1u > payload.size())
+			{
+				outEntities.clear();
+				return false;
+			}
+			entity.animationState = static_cast<AvatarAnimState>(ReadU8(payload, offset));
+			offset += 1u;
 		}
 
 		return true;
@@ -418,13 +432,13 @@ namespace engine::server
 
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities)
 	{
-		// TD.6 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
-		// + 2 (nameLen) + N (name bytes) + 2 (genderLen) + M (gender bytes, variable) octets.
-		// Wire-bump v6→v7 : ajout du genre du personnage après le nom. Pour le sizing :
-		// estimation à 8 + 40 + 4 + 2 + 2 = 56 par entité (nom et genre vides). BeginPacket.reserve
+		// TD.6/TD.8 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name bytes) + 2 (genderLen) + M (gender bytes) + 1 (animationState) octets.
+		// Wire-bump v7→v8 : ajout de l'état d'animation (1 octet) après le genre. Pour le sizing :
+		// estimation à 8 + 40 + 4 + 2 + 2 + 1 = 57 par entité (nom et genre vides). BeginPacket.reserve
 		// est juste un hint, pas une borne stricte (le vector grandit à l'append).
 		// TG.1 — header passe de 20 → 24 octets (ajout chunkIndex + chunkCount uint16 × 2).
-		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 56));
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 57));
 		WriteU32(packet, message.clientId);
 		WriteU32(packet, message.serverTick);
 		WriteU16(packet, message.connectedClients);
@@ -445,6 +459,8 @@ namespace engine::server
 			WriteSizedString(packet, entity.characterName);
 			// TD.6 : genre du personnage (préfixé u16). Vide pour les mobs / lootbags.
 			WriteSizedString(packet, entity.gender);
+			// TD.8 : état d'animation (1 octet). Idle (0) pour les mobs / lootbags.
+			WriteU8(packet, static_cast<uint8_t>(entity.animationState));
 		}
 		return packet;
 	}

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -22,8 +22,14 @@ namespace engine::server
 	/// pour autoriser le chunking d'un snapshot AoI dépassant le budget MTU UDP (~1200 o).
 	/// `chunkCount = 1` (mono-paquet) reste le cas dominant ; `chunkCount > 1` exige une
 	/// réassemblage côté client (cf. UIModelBinding::ApplySnapshot).
+	/// TD.5/TD.6 — bump 5 → 6 → 7 : `SnapshotEntity` gagne `characterName` puis `gender`
+	/// (chaînes préfixées u16) pour la plaque de nom et la sélection du mesh distant.
+	/// TD.8 — bump 7 → 8 : `InputMessage` gagne `animationState` (1 octet, client→shard) et
+	/// `SnapshotEntity` gagne `animationState` (1 octet, shard→clients) — propage l'état
+	/// d'animation (emote/roulade/run/sprint/saut/…) pour que les autres joueurs voient
+	/// les bonnes animations au lieu d'un Idle/Walk dérivé de la vélocité.
 	/// Wire-breaking : client + shard doivent se déployer ensemble.
-	inline constexpr uint16_t kProtocolVersion = 7;
+	inline constexpr uint16_t kProtocolVersion = 8;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -212,6 +218,10 @@ namespace engine::server
 		float positionMetersY = 0.0f; ///< TC.1 : altitude (terrain accidenté).
 		float positionMetersZ = 0.0f;
 		float yawRadians = 0.0f;      ///< TC.1 : orientation envoyée par le client.
+		/// TD.8 : état d'animation courant de l'avatar local (valeur d'AvatarAnimState).
+		/// Le shard le stocke et le réémet dans le SnapshotEntity pour que les autres
+		/// joueurs voient les emotes/roulades/etc. Payload Input 24 → 25 octets (v7→v8).
+		uint8_t animationState = 0;
 	};
 
 	/// Handshake acknowledgement emitted after a client is accepted.

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -39,6 +39,7 @@ namespace
 		in.positionMetersY = 100.25f;
 		in.positionMetersZ = -8.75f;
 		in.yawRadians = 1.5708f;
+		in.animationState = 9u; // TD.8 : Emote (valeur d'AvatarAnimState)
 
 		const std::vector<std::byte> packet = EncodeInput(in);
 		assert(!packet.empty());
@@ -51,6 +52,7 @@ namespace
 		assert(out.positionMetersY == in.positionMetersY);
 		assert(out.positionMetersZ == in.positionMetersZ);
 		assert(out.yawRadians == in.yawRadians);
+		assert(out.animationState == in.animationState); // TD.8
 		std::puts("[OK] TestInputRoundTrip");
 	}
 
@@ -111,6 +113,7 @@ namespace
 		ePlayerA.playerClientId = 7u;
 		ePlayerA.characterName = "homme"; // TD.5
 		ePlayerA.gender = "male";          // TD.6
+		ePlayerA.animationState = engine::server::AvatarAnimState::Emote; // TD.8
 		in.push_back(ePlayerA);
 
 		SnapshotEntity ePlayerB{};
@@ -120,6 +123,7 @@ namespace
 		ePlayerB.playerClientId = 12u;
 		ePlayerB.characterName = "femme"; // TD.5
 		ePlayerB.gender = "female";        // TD.6
+		ePlayerB.animationState = engine::server::AvatarAnimState::Roll; // TD.8
 		in.push_back(ePlayerB);
 
 		SnapshotEntity eMob{};
@@ -149,12 +153,14 @@ namespace
 		assert(out[0].playerClientId == 7u);
 		assert(out[0].characterName == "homme"); // TD.5
 		assert(out[0].gender == "male");          // TD.6
+		assert(out[0].animationState == engine::server::AvatarAnimState::Emote); // TD.8
 
 		assert(out[1].entityId == ePlayerB.entityId);
 		assert(out[1].state.positionX == ePlayerB.state.positionX);
 		assert(out[1].playerClientId == 12u);
 		assert(out[1].characterName == "femme"); // TD.5
 		assert(out[1].gender == "female");        // TD.6
+		assert(out[1].animationState == engine::server::AvatarAnimState::Roll); // TD.8
 
 		assert(out[2].entityId == eMob.entityId);
 		assert(out[2].state.currentHealth == 80u);
@@ -162,14 +168,15 @@ namespace
 		assert(out[2].playerClientId == 0u);
 		assert(out[2].characterName.empty()); // TD.5 : mob => pas de nom
 		assert(out[2].gender.empty());        // TD.6 : mob => pas de genre
+		assert(out[2].animationState == engine::server::AvatarAnimState::Idle); // TD.8 : défaut
 		std::puts("[OK] TestSnapshotRoundTripWithPlayerClientId");
 	}
 
 	/// TD.6 — un Snapshot dont la taille de payload est inferieure au minimum attendu
-	/// (56 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0
-	/// + 2 genderLen=0, au-delà de l'entête 24 octets) doit être rejeté. Defense en
-	/// profondeur contre un pair qui parlerait une version antérieure du wire. Le bump
-	/// kProtocolVersion à v7 filtre déjà la plupart des cas dans DecodeHeader, ce test
+	/// (57 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0
+	/// + 2 genderLen=0 + 1 animationState, au-delà de l'entête 24 octets) doit être rejeté.
+	/// Defense en profondeur contre un pair qui parlerait une version antérieure du wire. Le
+	/// bump kProtocolVersion à v8 filtre déjà la plupart des cas dans DecodeHeader, ce test
 	/// couvre une corruption après header valide.
 	void TestSnapshotRejectsTruncatedPayload()
 	{

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -661,7 +661,7 @@ namespace engine::server
 		InputMessage input{};
 		if (DecodeInput(packetBytes, input))
 		{
-			HandleInput(datagram.endpoint, input.clientId, input.inputSequence, input.positionMetersX, input.positionMetersY, input.positionMetersZ, input.yawRadians);
+			HandleInput(datagram.endpoint, input.clientId, input.inputSequence, input.positionMetersX, input.positionMetersY, input.positionMetersZ, input.yawRadians, input.animationState);
 			return;
 		}
 
@@ -1245,7 +1245,7 @@ namespace engine::server
 		OnClientLogin(acceptedClient);
 	}
 
-	void ServerApp::HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians)
+	void ServerApp::HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians, uint8_t animationState)
 	{
 		ConnectedClient* client = FindClient(endpoint);
 		if (client == nullptr)
@@ -1303,6 +1303,7 @@ namespace engine::server
 		client->positionMetersY = positionMetersY; // TC.1 : altitude fournie par le client
 		client->positionMetersZ = positionMetersZ;
 		client->yawRadians = yawRadians;            // TC.1 : orientation fournie par le client (plus dérivée de la vélocité)
+		client->animationState = animationState;    // TD.8 : état d'animation reporté par le client (emote/roll/run/…)
 		if (client->hasReplicatedState)
 		{
 			const float tickDt = 1.0f / static_cast<float>(m_tickHz);
@@ -3856,6 +3857,9 @@ namespace engine::server
 			// TD.6 : genre du perso (migration 0067, "male"/"female") → le client sélectionne
 			// le bon mesh skinné pour l'avatar distant. Vide = fallback "male" côté rendu.
 			outEntity.gender = client->gender;
+			// TD.8 : état d'animation reporté par ce joueur → les autres clients jouent le bon
+			// clip (emote/roll/run/sprint/jump/…) au lieu de dériver Idle/Walk de la vélocité.
+			outEntity.animationState = static_cast<AvatarAnimState>(client->animationState);
 			return true;
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -121,6 +121,9 @@ namespace engine::server
 		float velocityMetersPerSecondX = 0.0f;
 		float velocityMetersPerSecondY = 0.0f;
 		float velocityMetersPerSecondZ = 0.0f;
+		/// TD.8 — état d'animation reporté par le client (valeur d'AvatarAnimState). Recopié
+		/// dans chaque SnapshotEntity pour que les autres joueurs voient emotes/roulades/etc.
+		uint8_t animationState = 0;
 		uint32_t stateFlags = 0;
 		StatsComponent stats{};
 		CombatComponent combat{};
@@ -330,7 +333,7 @@ namespace engine::server
 		void EvictIdleUdpClients();
 
 		/// Record the last input sequence for a connected client.
-		void HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians);
+		void HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians, uint8_t animationState);
 
 		/// Advance one authoritative server tick.
 		void TickOnce();


### PR DESCRIPTION
## Anomalie #1 — /dance et roulade invisibles aux autres (mais saut visible)

`SnapshotEntity` ne transportait pas l'état d'animation : `RecordRemoteAvatars` dérivait l'animation des avatars distants de la seule **vélocité serveur** (`< 0.1 m/s → Idle`, sinon `Walk`). Conséquence : le **saut** semblait visible (la position Y monte réellement), mais `/dance` (sur place) et la **roulade** — comme Run/Sprint/Attaque — restaient invisibles.

## Solution — `kProtocolVersion` 7 → 8 (lock-step client + shard)

Enum partagé `AvatarAnimState` (1 octet) propagé dans les **deux** sens :

- **Client → shard** : `InputMessage.animationState` (payload Input 24 → 25 o). `Engine::UpdateGameplayNet` envoie `ToWireAnimState(m_avatarLocoState)`.
- **Shard** : stocké sur `ConnectedClient` (`HandleInput`, après le gate anti-triche) → recopié dans `SnapshotEntity` (`TryBuildSnapshotEntity`).
- **Shard → clients** : `SnapshotEntity.animationState` (min payload/entité 56 → 57 o).
- **Rendu** : `UIRemoteEntity.animationState` → `RecordRemoteAvatars` mappe l'état → clip via `StateToClipName`/`ClipLoops` (repli Walk si Idle reçu mais l'avatar glisse).

Alignement enum client↔wire garanti par `static_assert`. Mesh distant = même objet `m_raceMeshes` que l'avatar local (rig UE5 → clips Roll/Dance/… présents).

### Limite connue
Le wire ne porte qu'un état (1 octet), pas le **rôle d'emote** précis. `/dance` est exact ; les 6 autres emotes (`kEmotes` : /sit, /talk, /torch, /kneel, /sittalk, /push) s'affichent comme **Dance** chez les autres (mieux que l'ancien figé). Réplication du rôle exact = travail ultérieur.

### Tests
`server_protocol_tests` : round-trip Input (`animationState`) + Snapshot (Emote/Roll/Idle) + rejet payload tronqué (57/entité).

**Déploiement** : ⚠️ **REDÉPLOIEMENT SERVEUR (shard) requis** + client neuf, en **lock-step** (double bump wire, deux directions ; un client v7 face à un shard v8 rejette tout via `DecodeHeader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
