### PR TITLE
fix(client): visibilite mutuelle a la 1ere connexion apres creation

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2010,3 +2010,42 @@ Les logs `[AvatarSkinDiag]` ont montré : matériaux OK (idMale=2, idFemale=3), 
 ### Limites / reste
 - Aucun. Modification cosmétique, applicable au prochain `docker compose up -d --force-recreate master shard`. Aucun impact wire ni régression.
 - **Déploiement** : ✅ client uniquement.
+
+## 59. Visibilité mutuelle à la première connexion après création (2026-05-29)
+
+**Symptôme** : juste après avoir créé un personnage puis être entré en jeu avec
+lui, le joueur ne voyait pas les autres et n'était pas vu d'eux ; une
+déconnexion + reconnexion (login normal) réparait tout.
+
+**Cause racine (côté client)** : à l'EnterWorld (`Engine.cpp`, bloc
+`ConsumePendingEnterWorldCommand`), le `character_key` de la session gameplay UDP
+n'est surchargé que si `enterCmd.characterId != 0`. Si le `character_id` propagé
+est 0 — entrée sélectionnée sans id valide dans la `CHARACTER_LIST` rechargée
+après création (latence DB côté master) — le bloc est sauté ; `InitGameplayNet`
+relit alors la clé de config **résiduelle** (souvent 1) et envoie le Hello UDP
+avec une mauvaise clé. Le shard (`ServerApp::HandleHello`, `helloNonce` =
+`persistenceCharacterKey`) associe le client au **mauvais** personnage → pas de
+réplication AoI cohérente entre joueurs. La reconnexion par login normal répare
+car la `CHARACTER_LIST` contient alors le perso avec un `character_id` valide.
+
+**Correctif (client, défense en profondeur)** :
+- `AuthUiPresenter::m_lastCreatedCharacterId` (`AuthUi.h`) : mémorise le
+  `character_id` renvoyé par `CHARACTER_CREATE` (porté par `AsyncResult::accountId`).
+  Renseigné au succès de création (`AuthUiPresenterCore.cpp`), remis à 0 au login
+  et après consommation à l'entrée en jeu.
+- Après rechargement de la `CHARACTER_LIST` post-création
+  (`AuthUiPresenterCore.cpp`), on **sélectionne l'entrée du perso créé** (par id)
+  au lieu de l'index 0 ; si absente (latence DB), un `LOG_WARN` le signale.
+- `ImGuiActivateSelectedCharacter` (`AuthScreenCharacterSelect.cpp`) : l'id propagé
+  doit être non nul. Si l'entrée sélectionnée a un id 0 → **fallback** sur
+  `m_lastCreatedCharacterId`. Si toujours 0 → **refus d'entrer** (message d'erreur)
+  plutôt que se connecter en « personnage fantôme ».
+- `Engine.cpp` (EnterWorld) : `LOG_ERROR` diagnostic si `characterId == 0` à
+  l'entrée (doit rester muet en nominal — sert à confirmer un éventuel résidu).
+
+**Note** : la cause racine exacte (le déclencheur précis du `character_id == 0`)
+n'a pas pu être reproduite en local (pas de toolchain ni de serveur de test). Le
+correctif durcit le chemin post-création (provablement incorrect quand
+`characterId == 0`) et le diagnostic confirmera sur la prochaine reproduction.
+
+- **Déploiement** : ✅ client uniquement (le shard est déjà correct).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7185,6 +7185,19 @@ namespace engine
 								LOG_INFO(Core, "[EnterWorld] propagating character_id={} as gameplay UDP character_key (uint64)",
 									enterCmd.characterId);
 							}
+							else
+							{
+								// Correctif visibilité 1ère connexion — diagnostic : un characterId==0
+								// ici signifie que le Hello UDP partirait avec la clé de config
+								// résiduelle (souvent 1) → le shard associerait ce client au mauvais
+								// personnage → invisibilité mutuelle (corrigé en amont côté
+								// AuthUiPresenter, cf. CODEBASE_MAP §59). Ce log doit rester muet en
+								// fonctionnement nominal ; s'il apparaît, le fallback d'id amont a
+								// échoué et il faut investiguer le flux post-création.
+								LOG_ERROR(Core, "[EnterWorld] character_id == 0 a l'entree en jeu : le character_key "
+									"gameplay UDP n'est PAS surcharge (risque d'invisibilite mutuelle). "
+									"Verifier la CHARACTER_LIST / le fallback de creation.");
+							}
 							// Si la session UDP a été ouverte au boot avec un host différent
 							// (config par défaut), on la coupe avant de la rouvrir sur le bon shard.
 							if (m_gameplayNetInitialized)

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -951,6 +951,14 @@ namespace engine::client
 		std::vector<engine::network::CharacterListEntry> m_characterList;
 		/// Phase 2 — Index du personnage actuellement sélectionné dans \ref m_characterList (-1 = rien).
 		int m_selectedCharacterIndex = -1;
+		/// Correctif visibilité 1ère connexion — character_id du personnage qui vient d'être
+		/// créé (réponse CHARACTER_CREATE). Sert à (1) re-sélectionner ce perso précis dans la
+		/// CHARACTER_LIST rechargée après création, et (2) fournir un fallback d'id non nul à
+		/// l'entrée en jeu si la liste rechargée le manque encore (latence DB). Sans cela, un
+		/// `character_id == 0` à l'EnterWorld faisait partir le Hello UDP avec une clé erronée
+		/// → le shard associait le client au mauvais personnage → invisibilité mutuelle jusqu'à
+		/// une reconnexion. 0 = aucune création récente en attente. Cf. CODEBASE_MAP §59.
+		uint64_t m_lastCreatedCharacterId = 0;
 		/// Phase 3.9 — Index du perso pour lequel l'utilisateur est en train de
 		/// confirmer la suppression. -1 = pas de confirmation en cours.
 		int m_pendingDeleteCharacterIndex = -1;

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1985,6 +1985,13 @@ namespace engine::client
 			{
 				ResetMasterSession();
 				m_infoBanner = copy.message.empty() ? Tr("auth.info.character_created") : copy.message;
+				// Correctif visibilité 1ère connexion — mémorise le character_id renvoyé par
+				// CHARACTER_CREATE (porté par accountId, cf. AuthScreenCharacterCreate). Permet de
+				// re-sélectionner ce perso précis dans la CHARACTER_LIST rechargée et de fournir un
+				// fallback d'id non nul à l'EnterWorld si la liste le manque encore (latence DB).
+				m_lastCreatedCharacterId = copy.accountId;
+				LOG_INFO(Core, "[AuthUiPresenter] CharacterCreate OK (character_id={}) — memorise pour l'entree en jeu",
+					m_lastCreatedCharacterId);
 				// Le personnage existe désormais sur m_chosenShardId : on saute l'écran ShardPick au tour suivant.
 				m_postRegistrationCharacterCreatePending = false;
 				m_shardFlowOverrideId = m_chosenShardId;
@@ -2099,6 +2106,31 @@ namespace engine::client
 			// Sinon : 0 perso => CharacterCreate ; ≥1 perso => CharacterSelect.
 			m_characterList = std::move(copy.characterList);
 			m_selectedCharacterIndex = m_characterList.empty() ? -1 : 0;
+			// Correctif visibilité 1ère connexion — si on vient de créer un personnage, on
+			// sélectionne SON entrée (et pas l'index 0 par défaut) afin que le clic « Jouer »
+			// parte avec le bon character_id. Si la liste rechargée ne le contient pas encore
+			// (latence DB côté master), on le signale : le fallback à l'entrée en jeu
+			// (ImGuiActivateSelectedCharacter) couvrira ce cas via m_lastCreatedCharacterId.
+			if (m_lastCreatedCharacterId != 0u && !m_characterList.empty())
+			{
+				bool found = false;
+				for (size_t i = 0; i < m_characterList.size(); ++i)
+				{
+					if (m_characterList[i].character_id == m_lastCreatedCharacterId)
+					{
+						m_selectedCharacterIndex = static_cast<int>(i);
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+				{
+					LOG_WARN(Core,
+						"[AuthUiPresenter] Perso cree (character_id={}) absent de la CHARACTER_LIST rechargee "
+						"({} entrees) — fallback d'id a l'entree en jeu actif",
+						m_lastCreatedCharacterId, m_characterList.size());
+				}
+			}
 			// Phase 3 — Persister l'endpoint du shard pour pouvoir le re-publier dans la
 			// EnterWorldCommand quand l'utilisateur cliquera Jouer / validera CharacterCreate.
 			if (!copy.shardEndpoint.empty())
@@ -2149,6 +2181,9 @@ namespace engine::client
 		}
 
 		ResetMasterSession();
+		// Correctif visibilité 1ère connexion — repart d'un login propre : pas d'id de
+		// création résiduel d'une session précédente qui pourrait fausser le fallback d'entrée.
+		m_lastCreatedCharacterId = 0u;
 		m_masterClient = std::make_unique<engine::network::NetClient>();
 		const std::string host = cfg.GetEffectiveMasterHost("localhost");
 		const uint16_t port = static_cast<uint16_t>(cfg.GetInt("client.master_port", 3840));

--- a/src/client/auth/screens/AuthScreenCharacterSelect.cpp
+++ b/src/client/auth/screens/AuthScreenCharacterSelect.cpp
@@ -43,8 +43,31 @@ namespace engine::client
 			return;
 		}
 		const auto& chosen = m_characterList[static_cast<size_t>(m_selectedCharacterIndex)];
+		// Correctif visibilité 1ère connexion — l'id à propager doit être NON NUL : un
+		// character_id == 0 ferait partir le Hello UDP avec une clé erronée (le shard associerait
+		// le client au mauvais personnage → invisibilité mutuelle). Si l'entrée sélectionnée a un
+		// id 0 (liste pas encore réécrite après création, latence DB), on retombe sur le
+		// character_id mémorisé à la création (m_lastCreatedCharacterId). Cf. CODEBASE_MAP §59.
+		uint64_t resolvedCharacterId = chosen.character_id;
+		if (resolvedCharacterId == 0u && m_lastCreatedCharacterId != 0u)
+		{
+			LOG_WARN(Core,
+				"[AuthUiPresenter] character_id selectionne == 0 — fallback sur l'id du perso cree ({})",
+				m_lastCreatedCharacterId);
+			resolvedCharacterId = m_lastCreatedCharacterId;
+		}
+		if (resolvedCharacterId == 0u)
+		{
+			// Aucun id valide disponible : refuser l'entrée plutôt que de se connecter en
+			// « personnage fantôme ». L'utilisateur voit une erreur et peut réessayer
+			// (la liste sera rechargée correctement au prochain tour de flow).
+			LOG_ERROR(Core, "[AuthUiPresenter] Entree en jeu refusee : character_id introuvable (index={})",
+				m_selectedCharacterIndex);
+			m_userErrorText = Tr("auth.error.character_session_inactive");
+			return;
+		}
 		LOG_INFO(Core, "[AuthUiPresenter] CharacterSelect -> activate (character_id={}, name={}, shard={}, endpoint={}, spawn=({},{},{}))",
-			chosen.character_id, chosen.name, m_chosenShardId, m_chosenShardEndpoint,
+			resolvedCharacterId, chosen.name, m_chosenShardId, m_chosenShardEndpoint,
 			chosen.spawn_x, chosen.spawn_y, chosen.spawn_z);
 		// Phase 3 — émission de la commande d'entrée dans le monde, consommée par
 		// Engine::Update sur la première frame post-auth (cf. AuthGate else branch).
@@ -53,7 +76,7 @@ namespace engine::client
 		// créé pas encore réécrit), hasSpawn reste false et l'engine appliquera son défaut.
 		m_pendingEnterWorld = {};
 		m_pendingEnterWorld.applyRequested = true;
-		m_pendingEnterWorld.characterId = chosen.character_id;
+		m_pendingEnterWorld.characterId = resolvedCharacterId;
 		m_pendingEnterWorld.shardId = m_chosenShardId;
 		m_pendingEnterWorld.shardEndpoint = m_chosenShardEndpoint;
 		m_pendingEnterWorld.characterName = chosen.name;
@@ -78,6 +101,9 @@ namespace engine::client
 		m_userErrorText.clear();
 		m_infoBanner.clear();
 		m_postRegistrationCharacterCreatePending = false;
+		// Correctif visibilité 1ère connexion — id de création consommé : on le réinitialise
+		// pour ne pas le réutiliser à tort lors d'une entrée ultérieure (autre perso/session).
+		m_lastCreatedCharacterId = 0u;
 		m_flowComplete = true;
 	}
 


### PR DESCRIPTION
## Anomalie #3 — invisibilité mutuelle à la 1ère connexion après création

Juste après avoir créé un personnage et être entré en jeu avec lui, le joueur ne voyait pas les autres et n'était pas vu d'eux. Une **déconnexion + reconnexion** (login normal) réparait tout.

### Cause racine (côté client)
À l'EnterWorld ([Engine.cpp](src/client/app/Engine.cpp), bloc `ConsumePendingEnterWorldCommand`), le `character_key` de la session gameplay UDP n'est surchargé que si `enterCmd.characterId != 0`. Si l'entrée sélectionnée a un id 0 (la `CHARACTER_LIST` rechargée après création n'est pas encore réécrite — latence DB côté master), `InitGameplayNet` relit la clé de config **résiduelle** (souvent 1) et envoie le Hello UDP avec une mauvaise clé → le shard (`HandleHello`, `helloNonce` = `persistenceCharacterKey`) associe le client au **mauvais personnage** → pas de réplication AoI cohérente. Le login normal répare car la liste contient alors le perso avec un `character_id` valide.

### Correctif (client, défense en profondeur)
- `m_lastCreatedCharacterId` : mémorise le `character_id` renvoyé par `CHARACTER_CREATE` (`AsyncResult::accountId`). Reset au login et après consommation.
- Après rechargement post-création : on **sélectionne l'entrée du perso créé** (par id) au lieu de l'index 0 ; `LOG_WARN` si absente (latence DB).
- `ImGuiActivateSelectedCharacter` : **fallback** sur `m_lastCreatedCharacterId` si l'id sélectionné est 0 ; **refus d'entrer** (erreur) si toujours 0 (pas de « personnage fantôme »).
- `Engine` EnterWorld : `LOG_ERROR` diagnostic si `characterId == 0` (muet en nominal).

### ⚠️ Transparence sur la cause racine
La cause exacte (le déclencheur précis du `character_id == 0`) **n'a pas pu être reproduite en local** (pas de toolchain ni de serveur de test à disposition). L'analyse statique a écarté plusieurs hypothèses serveur (position hors-limites, `hasReplicatedState`, anti-triche qui seede OK au 1er input). Le correctif **durcit le chemin post-création** — provablement incorrect quand `characterId == 0` — et le **diagnostic** confirmera le déclencheur sur la prochaine reproduction. Si le symptôme persiste après ce correctif, fournir les logs serveur + client d'une repro fraîche permettra un suivi ciblé.

**Déploiement** : ✅ client uniquement (le shard est déjà correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
