### PR TITLE
fix(replication): eviction immediate a la deconnexion (message Goodbye)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2096,3 +2096,38 @@ correctif durcit le chemin post-création (provablement incorrect quand
 `characterId == 0`) et le diagnostic confirmera sur la prochaine reproduction.
 
 - **Déploiement** : ✅ client uniquement (le shard est déjà correct).
+
+## 60. Éviction immédiate à la déconnexion — message Goodbye (2026-05-29)
+
+**Symptôme (cause racine #3 réelle)** : un joueur qui quitte (fermeture client /
+retour menu) reste un **avatar « fantôme »** visible et compté (`total_clients`)
+par les autres joueurs jusqu'à l'expiration du timeout d'inactivité UDP
+(`EvictIdleClients`). Confirmé par log : à 14:50:05 un nouveau client se connecte
+avec `total_clients=2` alors que l'autre joueur s'était déjà déconnecté — son
+entité (entity_id=2) traînait et était rendue chez le nouveau venu. Explique
+aussi les confusions « je vois quelqu'un de déjà parti » et « reconnexion répare »
+(la reconnexion repart d'un AoI propre).
+
+**Correctif** : départ propre via un nouveau message UDP **Goodbye** (client → shard).
+- `src/shared/network/ServerProtocol.h` : `MessageKind::Goodbye = 78` +
+  `GoodbyeMessage { uint32 clientId }` + `EncodeGoodbye`/`DecodeGoodbye` (payload
+  4 octets). **Pas de bump `kProtocolVersion`** : ajout d'opcode rétro-compatible
+  (un shard qui ne gère pas Goodbye l'ignore → fallback timeout ; aucun cassage).
+- Client : `GameplayUdpClient::SendGoodbye()` appelé par `Shutdown()` si la session
+  est active (`m_serverClientId != 0`), **avant** la fermeture de la socket.
+  Best-effort (UDP sans accusé) : datagramme perdu → le timeout serveur prend le relais.
+- Shard : `ProcessPacket` dispatche `DecodeGoodbye` → `HandleGoodbye(endpoint, clientId)`
+  → `DisconnectConnectedClient(clientId, "client_goodbye")` (retrait grille
+  `RemoveEntity` + reset anti-triche + `OnClientLogout` + `m_clients.erase` +
+  reindex). Le despawn chez les autres suit au prochain `RefreshReplication`.
+  Garde : Goodbye dont le `clientId` ≠ endpoint ignoré (anti-usurpation).
+
+### Tests
+- `server_protocol_tests::TestGoodbyeRoundTrip` : round-trip Goodbye + rejet payload tronqué.
+
+### Limites / reste
+- Best-effort : un Goodbye perdu retombe sur l'éviction par timeout (comportement actuel).
+- **Déploiement** : ⚠️ **redéploiement serveur (shard) requis** pour l'éviction
+  immédiate (nouveau handler). **Non lock-step / non wire-breaking** : client neuf ↔
+  shard ancien (ou inverse) fonctionnent, mais sans l'éviction immédiate tant que le
+  shard n'est pas redéployé (fallback timeout).

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -126,6 +126,13 @@ namespace engine::client
 
 	void GameplayUdpClient::Shutdown()
 	{
+		// Départ propre : prévient le shard AVANT de fermer la socket pour qu'il évince
+		// immédiatement notre entité (sinon avatar « fantôme » jusqu'au timeout). Best-effort
+		// (UDP, sans accusé) : si le datagramme se perd, le timeout serveur prend le relais.
+		if (m_active && m_serverClientId != 0u)
+		{
+			(void)SendGoodbye();
+		}
 #if defined(_WIN32)
 		if (m_socket != nullptr)
 		{
@@ -225,6 +232,15 @@ namespace engine::client
 		im.animationState = animationState; // TD.8 : état d'animation local propagé au shard.
 		// Pas de log par paquet (cadence ~20 Hz) — éviterait de noyer la console.
 		return SendBytes(engine::server::EncodeInput(im));
+	}
+
+	bool GameplayUdpClient::SendGoodbye()
+	{
+		engine::server::GoodbyeMessage gm{};
+		gm.clientId = m_serverClientId;
+		const bool ok = SendBytes(engine::server::EncodeGoodbye(gm));
+		LOG_INFO(Net, "[GameplayUdpClient] Goodbye sent (client_id={}, ok={})", m_serverClientId, ok ? 1 : 0);
+		return ok;
 	}
 
 	bool GameplayUdpClient::SendTalkRequest(uint32_t clientId, std::string_view targetId)

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -42,6 +42,11 @@ namespace engine::client
 		/// pour que les autres joueurs voient emotes/roulades/run/sprint/saut/etc.
 		bool SendInput(uint32_t clientId, uint32_t inputSequence, float posX, float posY, float posZ, float yaw, uint8_t animationState);
 
+		/// Envoie un GOODBYE (départ propre) pour que le shard évince immédiatement l'entité
+		/// au lieu d'attendre le timeout d'inactivité (sinon l'avatar reste un « fantôme »
+		/// visible des autres). Appelé automatiquement par Shutdown() si la session est active.
+		bool SendGoodbye();
+
 		/// Send TalkRequest (e.g. `vendor:1` to open shop).
 		bool SendTalkRequest(uint32_t clientId, std::string_view targetId);
 

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -243,6 +243,26 @@ namespace engine::server
 		return packet;
 	}
 
+	std::vector<std::byte> EncodeGoodbye(const GoodbyeMessage& message)
+	{
+		// Départ propre : payload 4 octets (clientId). Pas de bump de version — un shard
+		// qui ne gère pas cet opcode l'ignore simplement (fallback timeout d'inactivité).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Goodbye, 4);
+		WriteU32(packet, message.clientId);
+		return packet;
+	}
+
+	bool DecodeGoodbye(std::span<const std::byte> packet, GoodbyeMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::Goodbye, payload) || payload.size() != 4)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		return true;
+	}
+
 	bool PeekMessageKind(std::span<const std::byte> packet, MessageKind& outKind)
 	{
 		if (packet.size() < kHeaderSize)

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -195,7 +195,12 @@ namespace engine::server
 		/// Client → server: cancel the current crafting session (M36.2).
 		CraftCancelRequest = 76,
 		/// Server → client: crafting session was cancelled (M36.2).
-		CraftCancelled = 77
+		CraftCancelled = 77,
+		/// Client → server: départ propre du joueur (fermeture / retour menu). Permet au
+		/// shard d'évincer immédiatement l'entité au lieu d'attendre le timeout d'inactivité
+		/// (sinon l'avatar du joueur parti reste un « fantôme » visible des autres). Ajout
+		/// rétro-compatible : un shard qui ne connaît pas cet opcode l'ignore (fallback timeout).
+		Goodbye = 78
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -230,6 +235,12 @@ namespace engine::server
 		uint32_t clientId = 0;
 		uint16_t tickHz = 0;
 		uint16_t snapshotHz = 0;
+	};
+
+	/// Départ propre du joueur (client → shard). Permet l'éviction immédiate de l'entité.
+	struct GoodbyeMessage
+	{
+		uint32_t clientId = 0;
 	};
 
 	/// Snapshot envelope carrying timing, connection stats and entity state count.
@@ -375,6 +386,10 @@ namespace engine::server
 	/// TC.1 — encode un INPUT (client→shard) : symétrique de DecodeInput. 24 octets de payload
 	/// (clientId, inputSequence, posX, posY, posZ, yaw).
 	std::vector<std::byte> EncodeInput(const InputMessage& message);
+
+	/// Encode/decode un GOODBYE (client→shard) : départ propre, payload 4 octets (clientId).
+	std::vector<std::byte> EncodeGoodbye(const GoodbyeMessage& message);
+	bool DecodeGoodbye(std::span<const std::byte> packet, GoodbyeMessage& outMessage);
 
 	/// Read only the packet kind after validating the shared protocol header.
 	bool PeekMessageKind(std::span<const std::byte> packet, MessageKind& outKind);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -18,6 +18,9 @@
 using engine::server::DecodeHello;
 using engine::server::DecodeInput;
 using engine::server::DecodeSnapshot;
+using engine::server::DecodeGoodbye;
+using engine::server::EncodeGoodbye;
+using engine::server::GoodbyeMessage;
 using engine::server::EncodeHello;
 using engine::server::EncodeInput;
 using engine::server::EncodeSnapshot;
@@ -260,10 +263,31 @@ namespace
 	}
 }
 
+	/// Départ propre : un Goodbye encodé puis décodé restitue le clientId, et un paquet
+	/// tronqué (payload != 4 octets) est rejeté par DecodeGoodbye.
+	void TestGoodbyeRoundTrip()
+	{
+		GoodbyeMessage in{};
+		in.clientId = 4242u;
+		const std::vector<std::byte> packet = EncodeGoodbye(in);
+		assert(!packet.empty());
+
+		GoodbyeMessage out{};
+		assert(DecodeGoodbye(packet, out));
+		assert(out.clientId == in.clientId);
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		GoodbyeMessage bad{};
+		assert(!DecodeGoodbye(truncated, bad));
+		std::puts("[OK] TestGoodbyeRoundTrip");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
 	TestInputRejectsTruncated();
+	TestGoodbyeRoundTrip();
 	TestHelloRoundTrip();
 	TestSnapshotRoundTripWithPlayerClientId();
 	TestSnapshotRejectsTruncatedPayload();

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -665,6 +665,15 @@ namespace engine::server
 			return;
 		}
 
+		// Départ propre du client : éviction immédiate (sinon l'avatar resterait un fantôme
+		// visible des autres jusqu'au timeout d'inactivité). Cf. CODEBASE_MAP §60.
+		GoodbyeMessage goodbye{};
+		if (DecodeGoodbye(packetBytes, goodbye))
+		{
+			HandleGoodbye(datagram.endpoint, goodbye.clientId);
+			return;
+		}
+
 		AttackRequestMessage attackRequest{};
 		if (DecodeAttackRequest(packetBytes, attackRequest))
 		{
@@ -1318,6 +1327,31 @@ namespace engine::server
 			client->positionMetersX,
 			client->positionMetersZ);
 		UpdateClientInterest(*client);
+	}
+
+	void ServerApp::HandleGoodbye(const Endpoint& endpoint, uint32_t clientId)
+	{
+		// Départ propre : on évince immédiatement le client (retrait grille + despawn au
+		// prochain RefreshReplication + OnClientLogout + persistance), au lieu d'attendre
+		// EvictIdleClients. Évite l'avatar « fantôme » d'un joueur déconnecté.
+		const ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			// Endpoint inconnu (Goodbye en double, ou déjà évincé) : rien à faire.
+			return;
+		}
+		// Défense : un Goodbye dont le clientId ne correspond pas à l'endpoint est ignoré
+		// (paquet usurpé / obsolète). clientId==0 (client legacy) → on fait confiance à l'endpoint.
+		if (clientId != 0u && client->clientId != clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] Goodbye ignoré : client_id mismatch (endpoint={}, attendu={}, reçu={})",
+				UdpTransport::EndpointToString(endpoint), client->clientId, clientId);
+			return;
+		}
+		const uint32_t resolvedClientId = client->clientId;
+		LOG_INFO(Net, "[ServerApp] Goodbye reçu — éviction immédiate (client_id={}, endpoint={})",
+			resolvedClientId, UdpTransport::EndpointToString(endpoint));
+		DisconnectConnectedClient(resolvedClientId, "client_goodbye");
 	}
 
 	void ServerApp::DrainPendingHellos()

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -334,6 +334,9 @@ namespace engine::server
 
 		/// Record the last input sequence for a connected client.
 		void HandleInput(const Endpoint& endpoint, uint32_t clientId, uint32_t inputSequence, float positionMetersX, float positionMetersY, float positionMetersZ, float yawRadians, uint8_t animationState);
+		/// Départ propre du client (message Goodbye) : éviction immédiate de l'entité au lieu
+		/// d'attendre le timeout d'inactivité. Évite l'avatar « fantôme » (cf. CODEBASE_MAP §60).
+		void HandleGoodbye(const Endpoint& endpoint, uint32_t clientId);
 
 		/// Advance one authoritative server tick.
 		void TickOnce();


### PR DESCRIPTION
## Cause racine #3 (la vraie) — avatar « fantôme » après déconnexion

Débogage mené avec les logs serveur + client de l'utilisateur (méthode systématique). Découverte décisive : à 2 joueurs réellement simultanés, **ils se voient** ✅ (`entities` 4→5, `[RecordRemoteAvatars] OK remotes=5`). Le « bug » d'invisibilité venait d'ailleurs :

```
14:50:05 Client accepted (client_id=3, endpoint=10.0.4.55, total_clients=2)
```
`total_clients=2` alors que l'autre joueur (10.0.4.86) **s'était déjà déconnecté** → son entité traînait sur le shard et était rendue chez le nouveau venu. Le shard n'évince un client qu'au **timeout d'inactivité UDP** (`EvictIdleClients`) : entre-temps, l'avatar d'un joueur parti reste un **fantôme**. Cela explique aussi « je vois quelqu'un de déjà parti » et « la reconnexion répare » (l'AoI repart propre).

## Correctif — message `Goodbye` (départ propre)
- **Wire** : `MessageKind::Goodbye = 78` + `GoodbyeMessage{clientId}` + `Encode/DecodeGoodbye` (4 o). **Pas de bump `kProtocolVersion`** → ajout d'opcode **rétro-compatible** (un shard qui ne gère pas Goodbye l'ignore → fallback timeout ; aucun cassage en versions mixtes).
- **Client** : `GameplayUdpClient::SendGoodbye()` appelé par `Shutdown()` (session active), **avant** la fermeture socket. Best-effort UDP.
- **Shard** : `ProcessPacket` → `DecodeGoodbye` → `HandleGoodbye` → `DisconnectConnectedClient` (retrait grille + reset anti-triche + `OnClientLogout` + erase + reindex). Le despawn chez les autres suit au prochain `RefreshReplication`. Garde anti-usurpation (clientId ≠ endpoint ignoré).

### Tests
`server_protocol_tests::TestGoodbyeRoundTrip` (round-trip + rejet payload tronqué).

### Note (PR #760)
Le durcissement `characterId==0` de [#760](https://github.com/tips-of-mine/LCDLLN-test/pull/760) reste utile (garde + diagnostic) mais n'était pas la cause de #3 — c'est bien ce fantôme. À 2 joueurs co-présents, la visibilité mutuelle fonctionne déjà.

**Déploiement** : ⚠️ **REDÉPLOIEMENT SERVEUR (shard) requis** pour l'éviction immédiate (nouveau handler). **Non lock-step / non wire-breaking** : versions mixtes fonctionnent, mais sans l'éviction immédiate tant que le shard n'est pas redéployé (fallback timeout). Côté client : nouveau build requis pour émettre le Goodbye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
