### PR TITLE
fix(anim): pied coupe a l'arret — fallback bind pose des os non animes

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2096,3 +2096,26 @@ correctif durcit le chemin post-création (provablement incorrect quand
 `characterId == 0`) et le diagnostic confirmera sur la prochaine reproduction.
 
 - **Déploiement** : ✅ client uniquement (le shard est déjà correct).
+
+## 61. Pied « coupé » à l'arrêt — fallback bind pose du sampler (2026-05-29)
+
+**Symptôme** : à l'**arrêt** (clip Idle), la pointe des bottes apparaît tranchée/aplatie
+(orteil effondré) ; en marche, les pieds sont normaux. Visible local ET distant.
+
+**Cause racine** : `AnimationSampler::SamplePose`
+(`src/client/render/skinned/AnimationSampler.cpp`) recomposait chaque os en TRS avec,
+pour un canal vide, **rotation = identité** / **scale = 1** (seule la translation
+retombait sur la bind). Or les clips UE5 (ex. `Idle_Loop`) **n'animent pas l'os
+d'orteil** → sa rotation de bind était écrasée par l'identité → la pointe de la botte
+s'effondrait. `Walk_Loop` keye l'orteil → pied normal (d'où « seulement à l'arrêt »).
+
+**Correctif** : pour un os qu'un clip n'anime **pas du tout** (pistes vides, ou index
+hors `clip.tracks`), on conserve **`bindLocal` complet** (T+R+S de bind) au lieu de
+recomposer. Les os animés passent par le même chemin TRS qu'avant. Strictement plus
+correct pour les os non keyés, identique pour les os keyés.
+
+### Tests
+- `animation_sampler_bind_fallback_tests` : un os non animé (bind à rotation 90° Z) →
+  `SamplePose` renvoie sa bind pose exacte ; un os animé suit sa piste.
+
+- **Déploiement** : ✅ client uniquement (rendu/anim ; aucun impact wire ni serveur).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -741,6 +741,12 @@ elseif(UNIX)
   lcdlln_add_simple_test(animation_crossfade_tests
     ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/AnimationCrossfadeTests.cpp)
 
+  # Bug "pied coupe a l'arret" : un os non anime par un clip (ex. l'orteil dans
+  # Idle_Loop) doit conserver sa bind pose complete (rotation comprise), pas une
+  # rotation identite qui effondrait la pointe de la botte. Garde anti-regression.
+  lcdlln_add_simple_test(animation_sampler_bind_fallback_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/AnimationSamplerBindFallbackTests.cpp)
+
   # Sous-projet B.1 (locomotion state machine) etape 6/14 : TerrainCollider.
   # Tests du fallback "no terrain bound" (GroundHeightAt = 0, SweepCapsule
   # detection traversee Y=0) + edge cases (sweep ascendant, sweep horizontal).

--- a/src/client/render/skinned/AnimationSampler.cpp
+++ b/src/client/render/skinned/AnimationSampler.cpp
@@ -36,23 +36,33 @@ std::vector<engine::math::Mat4> AnimationSampler::SamplePose(const Skeleton& ske
     for (size_t i = 0; i < skeleton.bones.size(); ++i) {
         const Bone& b = skeleton.bones[i];
 
-        // Valeurs de fallback : translation = colonne 3 de bindLocal,
-        // rotation = identite, scale = (1,1,1). Les clips Mixamo animent
-        // chaque bone a chaque frame donc ce chemin est rarement utilise sur
-        // les vrais assets, mais reste correct pour les clips synthetiques.
-        const engine::math::Vec3 bindT{b.bindLocal.m[12], b.bindLocal.m[13], b.bindLocal.m[14]};
-
-        engine::math::Vec3 tr = bindT;
-        engine::math::Quat ro = engine::math::Quat::Identity();
-        engine::math::Vec3 sc{1.0f, 1.0f, 1.0f};
-
-        if (i < clip.tracks.size()) {
-            const BoneTracks& trk = clip.tracks[i];
-            tr = InterpolateKeyframes(trk.translation, t, bindT);
-            ro = InterpolateKeyframes(trk.rotation, t, engine::math::Quat::Identity());
-            sc = InterpolateKeyframes(trk.scale, t, engine::math::Vec3{1.0f, 1.0f, 1.0f});
+        // Par defaut, un os garde sa transform de BIND POSE complete (bindLocal).
+        // C'est correct pour les os qu'un clip n'anime PAS du tout : avant, on
+        // recomposait avec rotation=identite/scale=1 (translation seule conservee),
+        // ce qui ECRASAIT la rotation de bind d'un os non keye. Symptome observe :
+        // les clips UE5 (ex. Idle_Loop) n'animent pas l'os d'orteil -> la pointe de
+        // la botte s'effondrait ("pied coupe") a l'arret, alors que Walk_Loop keye
+        // l'orteil (pied normal). Les clips Mixamo animent chaque os a chaque frame,
+        // donc ce chemin par defaut ne les concerne pas.
+        if (i >= clip.tracks.size()) {
+            locals[i] = b.bindLocal;
+            continue;
         }
 
+        const BoneTracks& trk = clip.tracks[i];
+        if (trk.translation.empty() && trk.rotation.empty() && trk.scale.empty()) {
+            // Os non anime par ce clip -> on conserve sa pose de bind exacte.
+            locals[i] = b.bindLocal;
+            continue;
+        }
+
+        // Os anime : on compose depuis les pistes. Fallback par canal vide conserve
+        // (translation = bind, rotation = identite, scale = 1) : cas rare d'un clip
+        // qui keyerait certains canaux mais pas d'autres pour un meme os.
+        const engine::math::Vec3 bindT{b.bindLocal.m[12], b.bindLocal.m[13], b.bindLocal.m[14]};
+        const engine::math::Vec3 tr = InterpolateKeyframes(trk.translation, t, bindT);
+        const engine::math::Quat ro = InterpolateKeyframes(trk.rotation, t, engine::math::Quat::Identity());
+        const engine::math::Vec3 sc = InterpolateKeyframes(trk.scale, t, engine::math::Vec3{1.0f, 1.0f, 1.0f});
         locals[i] = ComposeTRS(tr, ro, sc);
     }
     return locals;

--- a/src/client/render/skinned/AnimationSampler.h
+++ b/src/client/render/skinned/AnimationSampler.h
@@ -24,12 +24,15 @@ public:
     /// Echantillonne le clip a l'instant t (secondes) et renvoie une matrice
     /// locale 4x4 par bone (taille = skeleton.bones.size()).
     ///
-    /// Pour chaque bone, compose une matrice TRS a partir des keyframes des trois
-    /// canaux (translation / rotation / scale). Si un canal est absent (track
-    /// vide), retombe sur une valeur par defaut :
-    ///   - translation : colonne 3 de bindLocal (translation de la bind pose)
-    ///   - rotation    : identite
-    ///   - scale       : (1, 1, 1)
+    /// Pour un bone que le clip n'anime PAS (aucune piste), la matrice locale est
+    /// sa BIND POSE complete (bindLocal) — translation ET rotation ET scale de bind.
+    /// (Auparavant on recomposait avec rotation=identite, ce qui ecrasait la rotation
+    /// de bind d'un os non keye : un clip UE5 type Idle_Loop n'animant pas l'orteil
+    /// faisait s'effondrer la pointe de la botte a l'arret.)
+    ///
+    /// Pour un bone anime, compose une matrice TRS a partir des keyframes des trois
+    /// canaux ; un canal vide d'un os par ailleurs anime retombe sur translation=bind,
+    /// rotation=identite, scale=(1,1,1) (cas rare).
     ///
     /// \param skeleton Squelette de reference (definit le nombre de bones et la bind pose).
     /// \param clip     Clip d'animation. Si clip.tracks.size() < bones.size(), les bones

--- a/src/client/render/skinned/tests/AnimationSamplerBindFallbackTests.cpp
+++ b/src/client/render/skinned/tests/AnimationSamplerBindFallbackTests.cpp
@@ -1,0 +1,120 @@
+// src/client/render/skinned/tests/AnimationSamplerBindFallbackTests.cpp
+//
+// Garde anti-régression du bug « pied coupé à l'arrêt » : un os qu'un clip
+// n'anime pas (pistes vides, ex. l'orteil dans le clip UE5 Idle_Loop) doit
+// conserver sa BIND POSE complète (rotation + scale de bind compris), et non
+// retomber sur une rotation identité qui écrasait la pose et effondrait la
+// pointe de la botte. Vérifie aussi qu'un os réellement animé suit sa piste.
+
+#include "src/client/render/skinned/AnimationSampler.h"
+#include "src/client/render/skinned/Skeleton.h"
+#include "src/client/render/skinned/AnimationClip.h"
+#include "src/shared/math/Quat.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::render::skinned::AnimationClip;
+	using engine::render::skinned::AnimationSampler;
+	using engine::render::skinned::Skeleton;
+	using engine::math::Mat4;
+	using engine::math::Quat;
+	using engine::math::Vec3;
+
+	bool MatApproxEq(const Mat4& a, const Mat4& b, float eps = 1e-4f)
+	{
+		for (int i = 0; i < 16; ++i)
+		{
+			if (std::fabs(a.m[i] - b.m[i]) > eps) return false;
+		}
+		return true;
+	}
+
+	// Squelette d'un seul os, avec une bind pose à rotation NON identité (90° autour
+	// de Z) + translation : reproduit un os comme l'orteil dont la rotation de bind
+	// est significative.
+	Skeleton MakeOneBoneSkeleton(const Mat4& bindLocal)
+	{
+		Skeleton skel;
+		skel.bones.resize(1);
+		skel.bones[0].name = "toe";
+		skel.bones[0].parentIndex = -1;
+		skel.bones[0].bindLocal = bindLocal;
+		skel.bones[0].inverseBindGlobal = Mat4::Identity();
+		return skel;
+	}
+
+	void Test_UnanimatedBone_KeepsFullBindPose()
+	{
+		const Mat4 bind = AnimationSampler::ComposeTRS(
+			Vec3{1.0f, 2.0f, 3.0f},
+			Quat::FromAxisAngle(Vec3{0.0f, 0.0f, 1.0f}, 1.5707963f), // 90° Z
+			Vec3{1.0f, 1.0f, 1.0f});
+		const Skeleton skel = MakeOneBoneSkeleton(bind);
+
+		// Clip qui n'anime pas l'os : une piste présente mais entièrement vide.
+		AnimationClip clipEmptyTrack;
+		clipEmptyTrack.name = "Idle";
+		clipEmptyTrack.duration = 1.0f;
+		clipEmptyTrack.tracks.resize(1); // BoneTracks par défaut = 3 vecteurs vides
+
+		const auto locals1 = AnimationSampler::SamplePose(skel, clipEmptyTrack, 0.0f);
+		REQUIRE(locals1.size() == 1u);
+		// Doit être EXACTEMENT la bind pose (rotation 90° Z conservée), pas une identité.
+		REQUIRE(MatApproxEq(locals1[0], bind));
+
+		// Clip sans aucune piste (tracks.size() < bones.size()) : même résultat.
+		AnimationClip clipNoTracks;
+		clipNoTracks.name = "Idle";
+		clipNoTracks.duration = 1.0f;
+		const auto locals2 = AnimationSampler::SamplePose(skel, clipNoTracks, 0.0f);
+		REQUIRE(locals2.size() == 1u);
+		REQUIRE(MatApproxEq(locals2[0], bind));
+
+		std::puts("[OK] Test_UnanimatedBone_KeepsFullBindPose");
+	}
+
+	void Test_AnimatedBone_FollowsTrack()
+	{
+		// Bind = rotation 90° Z. Le clip keye explicitement une rotation IDENTITÉ.
+		const Mat4 bind = AnimationSampler::ComposeTRS(
+			Vec3{0.0f, 0.0f, 0.0f},
+			Quat::FromAxisAngle(Vec3{0.0f, 0.0f, 1.0f}, 1.5707963f),
+			Vec3{1.0f, 1.0f, 1.0f});
+		const Skeleton skel = MakeOneBoneSkeleton(bind);
+
+		AnimationClip clip;
+		clip.name = "Walk";
+		clip.duration = 1.0f;
+		clip.tracks.resize(1);
+		clip.tracks[0].rotation.push_back({0.0f, Quat::Identity()}); // os animé : rotation identité
+
+		const auto locals = AnimationSampler::SamplePose(skel, clip, 0.0f);
+		REQUIRE(locals.size() == 1u);
+		// L'os est animé → on suit la piste (rotation identité), donc PAS la bind (90° Z).
+		const Mat4 expected = AnimationSampler::ComposeTRS(
+			Vec3{0.0f, 0.0f, 0.0f}, Quat::Identity(), Vec3{1.0f, 1.0f, 1.0f});
+		REQUIRE(MatApproxEq(locals[0], expected));
+		REQUIRE(!MatApproxEq(locals[0], bind)); // différent de la bind pose
+
+		std::puts("[OK] Test_AnimatedBone_FollowsTrack");
+	}
+}
+
+int main()
+{
+	Test_UnanimatedBone_KeepsFullBindPose();
+	Test_AnimatedBone_FollowsTrack();
+	return g_failed;
+}


### PR DESCRIPTION
## Symptôme
À l'**arrêt** (clip Idle), la pointe des bottes du personnage apparaît **tranchée/aplatie** (orteil effondré). En **marche**, les pieds sont normaux. Confirmé sur les captures fournies (fond uni → ce n'est pas une occlusion par le sol).

## Cause racine
[`AnimationSampler::SamplePose`](src/client/render/skinned/AnimationSampler.cpp) recomposait chaque os en TRS où, pour un **canal vide**, la rotation retombait sur **identité** et le scale sur **1** (seule la translation utilisait la bind pose). Or les clips **UE5** (ex. `Idle_Loop`) **n'animent pas l'os d'orteil** → sa rotation de bind était **écrasée par l'identité** → la pointe de la botte s'effondrait. `Walk_Loop` keye l'orteil → pied normal. D'où *« visible seulement à l'arrêt »*. Le commentaire d'origine l'anticipait : *« les clips Mixamo animent chaque os… ce chemin est rarement utilisé »* — mais les clips UE5 animent un sous-ensemble d'os.

## Correctif (client only)
Un os qu'un clip **n'anime pas du tout** (pistes vides, ou index hors `clip.tracks`) conserve désormais sa **`bindLocal` complète** (T+R+S de bind) au lieu d'être recomposé. Les os animés passent par le même chemin TRS qu'avant.
→ Strictement plus correct pour les os non keyés, identique pour les os keyés. Profite aussi aux remotes (même sampler).

## Tests
`animation_sampler_bind_fallback_tests` : un os **non animé** (bind à rotation 90° Z) → `SamplePose` renvoie sa **bind pose exacte** (régression : avant, rotation identité) ; un os **animé** suit bien sa piste.

**Déploiement** : ✅ **client uniquement** (rendu/animation ; aucun impact wire ni serveur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
