### PR TITLE
feat(portal): pastille "en ligne" dans Gestion des joueurs (API live master)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4016,11 +4016,9 @@ namespace engine
 											}
 										}
 
-										if (!m_waterMeshGpu.Init(m_vkDeviceContext.GetDevice(), m_vmaAllocator))
+										if (!m_waterMeshGpu.Init(m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice()))
 										{
-											LOG_WARN(Render,
-												"[Boot] WaterMeshGpu::Init failed (vmaAllocator={}) — Water_Passthrough fallback",
-												m_vmaAllocator ? "set" : "null (STAB.7)");
+											LOG_WARN(Render, "[Boot] WaterMeshGpu::Init failed — Water_Passthrough fallback");
 										}
 
 										// Init WaterPass : shaders + textures muettes 1×1.

--- a/src/client/render/WaterMeshGpu.cpp
+++ b/src/client/render/WaterMeshGpu.cpp
@@ -3,7 +3,7 @@
 #include "src/client/world/water/WaterMeshBuilder.h"
 #include "src/shared/core/Log.h"
 
-#include <vk_mem_alloc.h>
+#include <vulkan/vulkan_core.h>
 
 #include <cassert>
 #include <cmath>
@@ -19,12 +19,10 @@ namespace engine::render
 			"WaterVertex layout must match kFloatsPerVertex");
 
 		// UV pour un lac : projection top-down (XZ) normalisee par la BBox du polygone.
-		// Cela garantit des UV [0..1] coherents quelle que soit la taille du lac.
 		void EmitLakeVertices(const engine::world::water::LakeInstance& lake,
 			const engine::world::water::WaterMeshCpu& cpuMesh,
 			std::vector<float>& outVerts)
 		{
-			// Calcule la BBox XZ du polygone.
 			float minX = lake.polygon[0].x, maxX = lake.polygon[0].x;
 			float minZ = lake.polygon[0].z, maxZ = lake.polygon[0].z;
 			for (const auto& p : lake.polygon)
@@ -40,54 +38,143 @@ namespace engine::render
 				outVerts.push_back(v.position.x);
 				outVerts.push_back(v.position.y);
 				outVerts.push_back(v.position.z);
-				outVerts.push_back((v.position.x - minX) / dx);  // u
-				outVerts.push_back((v.position.z - minZ) / dz);  // v
-				outVerts.push_back(0.0f);                         // flowDir.x = 0 (lac)
-				outVerts.push_back(0.0f);                         // flowDir.y = 0 (lac)
+				outVerts.push_back((v.position.x - minX) / dx);
+				outVerts.push_back((v.position.z - minZ) / dz);
+				outVerts.push_back(0.0f);
+				outVerts.push_back(0.0f);
 			}
 		}
 
 		// UV pour une riviere : u le long du flow, v perpendiculaire.
-		// Le ribbon mesh produit par BuildRiverMesh emet 2 vertices par node
-		// (gauche/droite). On peut donc deriver u depuis l'index pair/impair.
 		void EmitRiverVertices(const engine::world::water::RiverInstance& river,
 			const engine::world::water::WaterMeshCpu& cpuMesh,
 			std::vector<float>& outVerts)
 		{
-			// Flow direction par segment, depuis ComputeFlowDirections (M100.13).
 			const auto flows = engine::world::water::ComputeFlowDirections(river);
-
-			// Le ribbon BuildRiverMesh emet vertices dans l'ordre :
-			//   node 0 left, node 0 right, node 1 left, node 1 right, ..., node N-1 left, node N-1 right.
-			// Soit 2 * N_nodes vertices, ou N_nodes = river.nodes.size().
-			// Le vertex 2*i est "left" du node i, le vertex 2*i+1 est "right".
 			const size_t nNodes = river.nodes.size();
 			for (size_t vi = 0; vi < cpuMesh.vertices.size(); ++vi)
 			{
 				const auto& v = cpuMesh.vertices[vi];
 				const size_t nodeIdx = vi / 2;
 				const bool isLeft = (vi % 2) == 0;
-
-				// u = nodeIdx / (nNodes - 1) (longueur le long du flow)
-				const float u = (nNodes > 1) ? static_cast<float>(nodeIdx) / static_cast<float>(nNodes - 1) : 0.0f;
+				const float u = (nNodes > 1)
+					? static_cast<float>(nodeIdx) / static_cast<float>(nNodes - 1) : 0.0f;
 				const float vCoord = isLeft ? 0.0f : 1.0f;
-
-				// flowDir : utilise le flow du segment courant (clamp au dernier pour le dernier node).
-				assert(!flows.empty());  // Précondition BuildRiverMesh : nodes.size() >= 2
+				assert(!flows.empty());
 				const size_t segIdx = (nodeIdx < flows.size()) ? nodeIdx : flows.size() - 1;
-				const float fx = flows[segIdx].x;
-				const float fz = flows[segIdx].z;
-
 				outVerts.push_back(v.position.x);
 				outVerts.push_back(v.position.y);
 				outVerts.push_back(v.position.z);
 				outVerts.push_back(u);
 				outVerts.push_back(vCoord);
-				outVerts.push_back(fx);
-				outVerts.push_back(fz);
+				outVerts.push_back(flows[segIdx].x);
+				outVerts.push_back(flows[segIdx].z);
 			}
 		}
+
+		/// Recherche un type memoire satisfaisant \p requiredFlags dans \p memProps.
+		/// \return Index du type memoire, ou UINT32_MAX si aucun.
+		static uint32_t FindMemoryType(const VkPhysicalDeviceMemoryProperties& memProps,
+			uint32_t memoryTypeBits, VkMemoryPropertyFlags requiredFlags)
+		{
+			for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+			{
+				if ((memoryTypeBits & (1u << i)) &&
+				    (memProps.memoryTypes[i].propertyFlags & requiredFlags) == requiredFlags)
+					return i;
+			}
+			return UINT32_MAX;
+		}
+
+		/// Alloue un VkBuffer + VkDeviceMemory de type DEVICE_LOCAL.
+		/// \return false si une etape Vulkan echoue (outBuf/outMem laisses inchanges).
+		static bool AllocDeviceLocalBuffer(
+			VkDevice device, VkPhysicalDevice physDev,
+			VkDeviceSize size, VkBufferUsageFlags usage,
+			VkBuffer& outBuf, VkDeviceMemory& outMem)
+		{
+			VkBufferCreateInfo bi{};
+			bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+			bi.size        = size;
+			bi.usage       = usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+			bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+			if (vkCreateBuffer(device, &bi, nullptr, &outBuf) != VK_SUCCESS) return false;
+
+			VkMemoryRequirements req{};
+			vkGetBufferMemoryRequirements(device, outBuf, &req);
+
+			VkPhysicalDeviceMemoryProperties props{};
+			vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+			const uint32_t memType = FindMemoryType(props, req.memoryTypeBits,
+				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+			if (memType == UINT32_MAX)
+			{
+				vkDestroyBuffer(device, outBuf, nullptr);
+				outBuf = VK_NULL_HANDLE;
+				return false;
+			}
+
+			VkMemoryAllocateInfo ai{};
+			ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			ai.allocationSize  = req.size;
+			ai.memoryTypeIndex = memType;
+			if (vkAllocateMemory(device, &ai, nullptr, &outMem) != VK_SUCCESS)
+			{
+				vkDestroyBuffer(device, outBuf, nullptr);
+				outBuf = VK_NULL_HANDLE;
+				return false;
+			}
+			vkBindBufferMemory(device, outBuf, outMem, 0);
+			return true;
+		}
+
+		/// Alloue un VkBuffer + VkDeviceMemory HOST_VISIBLE | HOST_COHERENT (staging).
+		static bool AllocHostVisibleBuffer(
+			VkDevice device, VkPhysicalDevice physDev,
+			VkDeviceSize size,
+			VkBuffer& outBuf, VkDeviceMemory& outMem)
+		{
+			VkBufferCreateInfo bi{};
+			bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+			bi.size        = size;
+			bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+			bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+			if (vkCreateBuffer(device, &bi, nullptr, &outBuf) != VK_SUCCESS) return false;
+
+			VkMemoryRequirements req{};
+			vkGetBufferMemoryRequirements(device, outBuf, &req);
+
+			VkPhysicalDeviceMemoryProperties props{};
+			vkGetPhysicalDeviceMemoryProperties(physDev, &props);
+			constexpr VkMemoryPropertyFlags kHostFlags =
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+			const uint32_t memType = FindMemoryType(props, req.memoryTypeBits, kHostFlags);
+			if (memType == UINT32_MAX)
+			{
+				vkDestroyBuffer(device, outBuf, nullptr);
+				outBuf = VK_NULL_HANDLE;
+				return false;
+			}
+
+			VkMemoryAllocateInfo ai{};
+			ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			ai.allocationSize  = req.size;
+			ai.memoryTypeIndex = memType;
+			if (vkAllocateMemory(device, &ai, nullptr, &outMem) != VK_SUCCESS)
+			{
+				vkDestroyBuffer(device, outBuf, nullptr);
+				outBuf = VK_NULL_HANDLE;
+				return false;
+			}
+			vkBindBufferMemory(device, outBuf, outMem, 0);
+			return true;
+		}
+
 	} // namespace
+
+	// -----------------------------------------------------------------------
+	// BuildDrawInfos (inchange — aucune dependance VMA)
+	// -----------------------------------------------------------------------
 
 	void BuildDrawInfos(const engine::world::water::WaterScene& scene,
 		std::vector<float>& outVertices,
@@ -100,7 +187,6 @@ namespace engine::render
 
 		uint32_t globalParamIdx = 0;
 
-		// 1) Lacs en tete.
 		for (const auto& lake : scene.lakes)
 		{
 			engine::world::water::WaterMeshCpu cpuMesh;
@@ -113,23 +199,20 @@ namespace engine::render
 			}
 			if (cpuMesh.indices.empty()) { ++globalParamIdx; continue; }
 
-			const int32_t baseVertex = static_cast<int32_t>(outVertices.size() / kFloatsPerVertex);
-			const uint32_t firstIndex = static_cast<uint32_t>(outIndices.size());
-
+			const int32_t  baseVertex  = static_cast<int32_t>(outVertices.size() / kFloatsPerVertex);
+			const uint32_t firstIndex  = static_cast<uint32_t>(outIndices.size());
 			EmitLakeVertices(lake, cpuMesh, outVertices);
 			for (uint32_t idx : cpuMesh.indices) outIndices.push_back(idx);
 
 			WaterInstanceDrawInfo info{};
-			info.firstIndex = firstIndex;
-			info.indexCount = static_cast<uint32_t>(cpuMesh.indices.size());
+			info.firstIndex  = firstIndex;
+			info.indexCount  = static_cast<uint32_t>(cpuMesh.indices.size());
 			info.vertexOffset = baseVertex;
 			info.paramsIndex = globalParamIdx;
 			outDrawInfos.push_back(info);
-
 			++globalParamIdx;
 		}
 
-		// 2) Rivieres ensuite.
 		for (const auto& river : scene.rivers)
 		{
 			engine::world::water::WaterMeshCpu cpuMesh;
@@ -142,107 +225,112 @@ namespace engine::render
 			}
 			if (cpuMesh.indices.empty()) { ++globalParamIdx; continue; }
 
-			const int32_t baseVertex = static_cast<int32_t>(outVertices.size() / kFloatsPerVertex);
-			const uint32_t firstIndex = static_cast<uint32_t>(outIndices.size());
-
+			const int32_t  baseVertex  = static_cast<int32_t>(outVertices.size() / kFloatsPerVertex);
+			const uint32_t firstIndex  = static_cast<uint32_t>(outIndices.size());
 			EmitRiverVertices(river, cpuMesh, outVertices);
 			for (uint32_t idx : cpuMesh.indices) outIndices.push_back(idx);
 
 			WaterInstanceDrawInfo info{};
-			info.firstIndex = firstIndex;
-			info.indexCount = static_cast<uint32_t>(cpuMesh.indices.size());
+			info.firstIndex  = firstIndex;
+			info.indexCount  = static_cast<uint32_t>(cpuMesh.indices.size());
 			info.vertexOffset = baseVertex;
 			info.paramsIndex = globalParamIdx;
 			outDrawInfos.push_back(info);
-
 			++globalParamIdx;
 		}
 	}
 
-	bool WaterMeshGpu::Init(VkDevice device, void* vmaAllocator)
+	// -----------------------------------------------------------------------
+	// WaterMeshGpu — raw Vulkan (STAB.7 compatible, sans VMA)
+	// -----------------------------------------------------------------------
+
+	bool WaterMeshGpu::Init(VkDevice device, VkPhysicalDevice physicalDevice)
 	{
-		if (device == VK_NULL_HANDLE || vmaAllocator == nullptr)
+		if (device == VK_NULL_HANDLE || physicalDevice == VK_NULL_HANDLE)
 		{
 			LOG_ERROR(Render, "[WaterMeshGpu] Init FAILED: invalid arguments");
 			return false;
 		}
-		m_device       = device;
-		m_vmaAllocator = vmaAllocator;
-		LOG_INFO(Render, "[WaterMeshGpu] Init OK");
+		m_device         = device;
+		m_physicalDevice = physicalDevice;
+		LOG_INFO(Render, "[WaterMeshGpu] Init OK (raw Vulkan, STAB.7 compatible)");
 		return true;
 	}
 
 	void WaterMeshGpu::Destroy()
 	{
-		if (m_vmaAllocator == nullptr) return;
-		auto* allocator = static_cast<VmaAllocator>(m_vmaAllocator);
+		if (m_device == VK_NULL_HANDLE) return;
 
 		if (m_vbo != VK_NULL_HANDLE)
 		{
-			vmaDestroyBuffer(allocator, m_vbo, static_cast<VmaAllocation>(m_vboAllocation));
-			m_vbo           = VK_NULL_HANDLE;
-			m_vboAllocation = nullptr;
-			m_vboCapacity   = 0;
+			vkDestroyBuffer(m_device, m_vbo, nullptr);
+			m_vbo = VK_NULL_HANDLE;
 		}
+		if (m_vboMemory != VK_NULL_HANDLE)
+		{
+			vkFreeMemory(m_device, m_vboMemory, nullptr);
+			m_vboMemory = VK_NULL_HANDLE;
+		}
+		m_vboCapacity = 0;
+
 		if (m_ibo != VK_NULL_HANDLE)
 		{
-			vmaDestroyBuffer(allocator, m_ibo, static_cast<VmaAllocation>(m_iboAllocation));
-			m_ibo           = VK_NULL_HANDLE;
-			m_iboAllocation = nullptr;
-			m_iboCapacity   = 0;
+			vkDestroyBuffer(m_device, m_ibo, nullptr);
+			m_ibo = VK_NULL_HANDLE;
 		}
+		if (m_iboMemory != VK_NULL_HANDLE)
+		{
+			vkFreeMemory(m_device, m_iboMemory, nullptr);
+			m_iboMemory = VK_NULL_HANDLE;
+		}
+		m_iboCapacity = 0;
+
 		m_drawInfos.clear();
-		m_device       = VK_NULL_HANDLE;
-		m_vmaAllocator = nullptr;
+		m_device         = VK_NULL_HANDLE;
+		m_physicalDevice = VK_NULL_HANDLE;
 		LOG_INFO(Render, "[WaterMeshGpu] Destroyed");
 	}
 
 	bool WaterMeshGpu::EnsureCapacity(VkDeviceSize newVboSize, VkDeviceSize newIboSize)
 	{
-		auto* allocator = static_cast<VmaAllocator>(m_vmaAllocator);
-
-		// Helper local : alloue un buffer device-local de taille donnee.
-		auto allocBuffer = [&](VkDeviceSize size, VkBufferUsageFlags usage,
-		                       VkBuffer& outBuf, void*& outAlloc) -> bool
-		{
-			VkBufferCreateInfo bi{};
-			bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			bi.size        = size;
-			bi.usage       = usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-			bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			VmaAllocationCreateInfo ai{};
-			ai.usage = VMA_MEMORY_USAGE_AUTO;
-			ai.flags = 0;  // Pas d'accès host pour buffers device-local
-			VmaAllocation alloc = nullptr;
-			VkResult r = vmaCreateBuffer(allocator, &bi, &ai, &outBuf, &alloc, nullptr);
-			if (r != VK_SUCCESS) return false;
-			outAlloc = alloc;
-			return true;
-		};
-
 		if (newVboSize > m_vboCapacity)
 		{
 			if (m_vbo != VK_NULL_HANDLE)
-				vmaDestroyBuffer(allocator, m_vbo, static_cast<VmaAllocation>(m_vboAllocation));
-			m_vbo           = VK_NULL_HANDLE;
-			m_vboAllocation = nullptr;
-			if (!allocBuffer(newVboSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, m_vbo, m_vboAllocation))
 			{
-				LOG_ERROR(Render, "[WaterMeshGpu] vmaCreateBuffer (VBO) failed (size={})", newVboSize);
+				vkDestroyBuffer(m_device, m_vbo, nullptr);
+				m_vbo = VK_NULL_HANDLE;
+			}
+			if (m_vboMemory != VK_NULL_HANDLE)
+			{
+				vkFreeMemory(m_device, m_vboMemory, nullptr);
+				m_vboMemory = VK_NULL_HANDLE;
+			}
+			if (!AllocDeviceLocalBuffer(m_device, m_physicalDevice,
+				newVboSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, m_vbo, m_vboMemory))
+			{
+				LOG_ERROR(Render, "[WaterMeshGpu] VBO allocation failed (size={})", newVboSize);
 				m_vboCapacity = 0;
 				return false;
 			}
 			m_vboCapacity = newVboSize;
 		}
+
 		if (newIboSize > m_iboCapacity)
 		{
 			if (m_ibo != VK_NULL_HANDLE)
-				vmaDestroyBuffer(allocator, m_ibo, static_cast<VmaAllocation>(m_iboAllocation));
-			m_ibo           = VK_NULL_HANDLE;
-			m_iboAllocation = nullptr;
-			if (!allocBuffer(newIboSize, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, m_ibo, m_iboAllocation))
 			{
-				LOG_ERROR(Render, "[WaterMeshGpu] vmaCreateBuffer (IBO) failed (size={})", newIboSize);
+				vkDestroyBuffer(m_device, m_ibo, nullptr);
+				m_ibo = VK_NULL_HANDLE;
+			}
+			if (m_iboMemory != VK_NULL_HANDLE)
+			{
+				vkFreeMemory(m_device, m_iboMemory, nullptr);
+				m_iboMemory = VK_NULL_HANDLE;
+			}
+			if (!AllocDeviceLocalBuffer(m_device, m_physicalDevice,
+				newIboSize, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, m_ibo, m_iboMemory))
+			{
+				LOG_ERROR(Render, "[WaterMeshGpu] IBO allocation failed (size={})", newIboSize);
 				m_iboCapacity = 0;
 				return false;
 			}
@@ -254,7 +342,7 @@ namespace engine::render
 	bool WaterMeshGpu::Rebuild(VkCommandPool transferPool, VkQueue transferQueue,
 	                           const engine::world::water::WaterScene& scene)
 	{
-		if (m_device == VK_NULL_HANDLE || m_vmaAllocator == nullptr)
+		if (m_device == VK_NULL_HANDLE || m_physicalDevice == VK_NULL_HANDLE)
 		{
 			LOG_ERROR(Render, "[WaterMeshGpu] Rebuild FAILED: not initialised");
 			return false;
@@ -265,47 +353,38 @@ namespace engine::render
 		std::vector<WaterInstanceDrawInfo> infos;
 		BuildDrawInfos(scene, verts, idx, infos);
 
-		// Cas vide : conserve les buffers existants mais drawInfos = empty.
-		// Record() fera no-op si GetInstanceCount() == 0.
 		if (verts.empty() || idx.empty())
 		{
 			m_drawInfos.clear();
 			return true;
 		}
 
-		const VkDeviceSize vboBytes = verts.size() * sizeof(float);
-		const VkDeviceSize iboBytes = idx.size() * sizeof(uint32_t);
+		const VkDeviceSize vboBytes    = verts.size() * sizeof(float);
+		const VkDeviceSize iboBytes    = idx.size() * sizeof(uint32_t);
+		const VkDeviceSize stagingSize = vboBytes + iboBytes;
 
 		if (!EnsureCapacity(vboBytes, iboBytes))
 			return false;
 
-		auto* allocator = static_cast<VmaAllocator>(m_vmaAllocator);
-
-		// Staging buffer host-visible mappe (CPU_ONLY + MAPPED).
-		VkBuffer          staging      = VK_NULL_HANDLE;
-		VmaAllocation     stagingAlloc = nullptr;
-		const VkDeviceSize stagingSize = vboBytes + iboBytes;
+		// Staging buffer HOST_VISIBLE + HOST_COHERENT.
+		VkBuffer       staging    = VK_NULL_HANDLE;
+		VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+		if (!AllocHostVisibleBuffer(m_device, m_physicalDevice, stagingSize, staging, stagingMem))
 		{
-			VkBufferCreateInfo bi{};
-			bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			bi.size        = stagingSize;
-			bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-			bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			VmaAllocationCreateInfo ai{};
-			ai.usage = VMA_MEMORY_USAGE_AUTO;
-			ai.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
-			         | VMA_ALLOCATION_CREATE_MAPPED_BIT;
-			VmaAllocationInfo allocInfo{};
-			if (vmaCreateBuffer(allocator, &bi, &ai, &staging, &stagingAlloc, &allocInfo) != VK_SUCCESS)
-			{
-				LOG_ERROR(Render, "[WaterMeshGpu] staging vmaCreateBuffer failed (size={})", stagingSize);
-				return false;
-			}
-			std::memcpy(allocInfo.pMappedData, verts.data(), vboBytes);
-			std::memcpy(static_cast<char*>(allocInfo.pMappedData) + vboBytes, idx.data(), iboBytes);
+			LOG_ERROR(Render, "[WaterMeshGpu] staging buffer allocation failed (size={})", stagingSize);
+			return false;
 		}
 
-		// Command buffer one-shot pour copier staging → buffers device-local.
+		// Copie CPU → staging.
+		{
+			void* mapped = nullptr;
+			vkMapMemory(m_device, stagingMem, 0, stagingSize, 0, &mapped);
+			std::memcpy(mapped, verts.data(), vboBytes);
+			std::memcpy(static_cast<char*>(mapped) + vboBytes, idx.data(), iboBytes);
+			vkUnmapMemory(m_device, stagingMem);
+		}
+
+		// Command buffer one-shot.
 		VkCommandBufferAllocateInfo cmdAlloc{};
 		cmdAlloc.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
 		cmdAlloc.commandPool        = transferPool;
@@ -314,7 +393,8 @@ namespace engine::render
 		VkCommandBuffer cmd = VK_NULL_HANDLE;
 		if (vkAllocateCommandBuffers(m_device, &cmdAlloc, &cmd) != VK_SUCCESS)
 		{
-			vmaDestroyBuffer(allocator, staging, stagingAlloc);
+			vkDestroyBuffer(m_device, staging, nullptr);
+			vkFreeMemory(m_device, stagingMem, nullptr);
 			LOG_ERROR(Render, "[WaterMeshGpu] vkAllocateCommandBuffers failed");
 			return false;
 		}
@@ -324,35 +404,29 @@ namespace engine::render
 		beg.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 		if (vkBeginCommandBuffer(cmd, &beg) != VK_SUCCESS)
 		{
-			LOG_ERROR(Render, "[WaterMeshGpu] vkBeginCommandBuffer failed");
 			vkFreeCommandBuffers(m_device, transferPool, 1, &cmd);
-			vmaDestroyBuffer(allocator, staging, stagingAlloc);
+			vkDestroyBuffer(m_device, staging, nullptr);
+			vkFreeMemory(m_device, stagingMem, nullptr);
+			LOG_ERROR(Render, "[WaterMeshGpu] vkBeginCommandBuffer failed");
 			return false;
 		}
 
-		VkBufferCopy copyVbo{};
-		copyVbo.srcOffset = 0;
-		copyVbo.dstOffset = 0;
-		copyVbo.size      = vboBytes;
+		VkBufferCopy copyVbo{0, 0, vboBytes};
 		vkCmdCopyBuffer(cmd, staging, m_vbo, 1, &copyVbo);
 
-		VkBufferCopy copyIbo{};
-		copyIbo.srcOffset = vboBytes;
-		copyIbo.dstOffset = 0;
-		copyIbo.size      = iboBytes;
+		VkBufferCopy copyIbo{vboBytes, 0, iboBytes};
 		vkCmdCopyBuffer(cmd, staging, m_ibo, 1, &copyIbo);
 
-		// Pipeline barrier : visibility entre transfer write et vertex/index read.
 		VkBufferMemoryBarrier barriers[2]{};
-		barriers[0].sType         = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-		barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-		barriers[0].dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
+		barriers[0].sType               = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+		barriers[0].srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+		barriers[0].dstAccessMask       = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
 		barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 		barriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-		barriers[0].buffer        = m_vbo;
-		barriers[0].offset        = 0;
-		barriers[0].size          = VK_WHOLE_SIZE;
-		barriers[1] = barriers[0];
+		barriers[0].buffer              = m_vbo;
+		barriers[0].offset              = 0;
+		barriers[0].size                = VK_WHOLE_SIZE;
+		barriers[1]               = barriers[0];
 		barriers[1].dstAccessMask = VK_ACCESS_INDEX_READ_BIT;
 		barriers[1].buffer        = m_ibo;
 		vkCmdPipelineBarrier(cmd,
@@ -361,9 +435,10 @@ namespace engine::render
 
 		if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
 		{
-			LOG_ERROR(Render, "[WaterMeshGpu] vkEndCommandBuffer failed");
 			vkFreeCommandBuffers(m_device, transferPool, 1, &cmd);
-			vmaDestroyBuffer(allocator, staging, stagingAlloc);
+			vkDestroyBuffer(m_device, staging, nullptr);
+			vkFreeMemory(m_device, stagingMem, nullptr);
+			LOG_ERROR(Render, "[WaterMeshGpu] vkEndCommandBuffer failed");
 			return false;
 		}
 
@@ -372,9 +447,10 @@ namespace engine::render
 		VkFence fence = VK_NULL_HANDLE;
 		if (vkCreateFence(m_device, &fci, nullptr, &fence) != VK_SUCCESS)
 		{
-			LOG_ERROR(Render, "[WaterMeshGpu] vkCreateFence failed");
 			vkFreeCommandBuffers(m_device, transferPool, 1, &cmd);
-			vmaDestroyBuffer(allocator, staging, stagingAlloc);
+			vkDestroyBuffer(m_device, staging, nullptr);
+			vkFreeMemory(m_device, stagingMem, nullptr);
+			LOG_ERROR(Render, "[WaterMeshGpu] vkCreateFence failed");
 			return false;
 		}
 
@@ -384,20 +460,22 @@ namespace engine::render
 		sub.pCommandBuffers    = &cmd;
 		if (vkQueueSubmit(transferQueue, 1, &sub, fence) != VK_SUCCESS)
 		{
-			LOG_ERROR(Render, "[WaterMeshGpu] vkQueueSubmit failed");
 			vkDestroyFence(m_device, fence, nullptr);
 			vkFreeCommandBuffers(m_device, transferPool, 1, &cmd);
-			vmaDestroyBuffer(allocator, staging, stagingAlloc);
+			vkDestroyBuffer(m_device, staging, nullptr);
+			vkFreeMemory(m_device, stagingMem, nullptr);
+			LOG_ERROR(Render, "[WaterMeshGpu] vkQueueSubmit failed");
 			return false;
 		}
 		vkWaitForFences(m_device, 1, &fence, VK_TRUE, UINT64_MAX);
 
 		vkDestroyFence(m_device, fence, nullptr);
 		vkFreeCommandBuffers(m_device, transferPool, 1, &cmd);
-		vmaDestroyBuffer(allocator, staging, stagingAlloc);
+		vkDestroyBuffer(m_device, staging, nullptr);
+		vkFreeMemory(m_device, stagingMem, nullptr);
 
 		m_drawInfos = std::move(infos);
-		LOG_INFO(Render, "[WaterMeshGpu] Rebuilt ({} instances, vbo={} B, ibo={} B)",
+		LOG_INFO(Render, "[WaterMeshGpu] Rebuilt ({} instance(s), vbo={} B, ibo={} B)",
 		         m_drawInfos.size(), static_cast<long long>(vboBytes), static_cast<long long>(iboBytes));
 		return true;
 	}

--- a/src/client/render/WaterMeshGpu.h
+++ b/src/client/render/WaterMeshGpu.h
@@ -46,7 +46,8 @@ namespace engine::render
 		std::vector<WaterInstanceDrawInfo>& outDrawInfos);
 
 	/// Buffer GPU contenant tous les meshes d'eau (lakes + rivers concatenes).
-	/// Reconstruit a la demande depuis une WaterScene CPU via VMA staging.
+	/// Reconstruit a la demande depuis une WaterScene CPU via staging raw Vulkan.
+	/// N'utilise pas VMA (compatible STAB.7 — VMA desactive).
 	class WaterMeshGpu final
 	{
 	public:
@@ -55,8 +56,8 @@ namespace engine::render
 		WaterMeshGpu& operator=(const WaterMeshGpu&) = delete;
 
 		/// Initialise l'objet. Pas d'allocation buffer ici — Rebuild s'en charge.
-		/// \param vmaAllocator Handle VmaAllocator opaque (evite de polluer le header avec vk_mem_alloc.h).
-		bool Init(VkDevice device, void* vmaAllocator);
+		/// \param physicalDevice Requis pour la recherche de type memoire (AllocateMemory).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice);
 
 		/// Reconstruit VBO/IBO depuis la scene. Realloue si capacite insuffisante,
 		/// reutilise l'allocation existante sinon. Retourne false en cas d'erreur
@@ -77,28 +78,26 @@ namespace engine::render
 		size_t GetInstanceCount() const { return m_drawInfos.size(); }
 		bool IsValid() const { return m_vbo != VK_NULL_HANDLE && m_ibo != VK_NULL_HANDLE; }
 
-		/// Returns true after a successful Init() (i.e., m_device + m_vmaAllocator stored).
-		/// Distinct from IsValid() which is true only after the first successful Rebuild
-		/// (when GPU buffers have been allocated). Use IsInitialized() as the gate to
-		/// attempt Rebuild ; use IsValid() as the gate to draw with the buffers.
+		/// Retourne true apres un Init() reussi (m_device stocke).
+		/// Distinct de IsValid() qui n'est vrai qu'apres le premier Rebuild reussi.
 		bool IsInitialized() const { return m_device != VK_NULL_HANDLE; }
 
 	private:
 		/// Alloue ou realloue VBO/IBO si la nouvelle taille depasse la capacite actuelle.
 		/// Reutilise les buffers existants si la capacite est suffisante.
-		/// \return false si vmaCreateBuffer echoue (logue ERROR).
+		/// \return false si l'allocation Vulkan echoue (logue ERROR).
 		bool EnsureCapacity(VkDeviceSize newVboSize, VkDeviceSize newIboSize);
 
 		VkDevice         m_device         = VK_NULL_HANDLE;
-		void*            m_vmaAllocator   = nullptr;  // VmaAllocator (opaque)
+		VkPhysicalDevice m_physicalDevice  = VK_NULL_HANDLE;
 
-		VkBuffer       m_vbo            = VK_NULL_HANDLE;
-		void*          m_vboAllocation  = nullptr;  // VmaAllocation
-		VkDeviceSize   m_vboCapacity    = 0;
+		VkBuffer       m_vbo         = VK_NULL_HANDLE;
+		VkDeviceMemory m_vboMemory   = VK_NULL_HANDLE;
+		VkDeviceSize   m_vboCapacity = 0;
 
-		VkBuffer       m_ibo            = VK_NULL_HANDLE;
-		void*          m_iboAllocation  = nullptr;  // VmaAllocation
-		VkDeviceSize   m_iboCapacity    = 0;
+		VkBuffer       m_ibo         = VK_NULL_HANDLE;
+		VkDeviceMemory m_iboMemory   = VK_NULL_HANDLE;
+		VkDeviceSize   m_iboCapacity = 0;
 
 		std::vector<WaterInstanceDrawInfo> m_drawInfos;
 	};

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -152,7 +152,7 @@ namespace engine::server
 
 		// Tout est validé : on enregistre le mapping pour le chat.
 		const std::string normalized = SessionCharacterMap::Normalize(parsed->characterName);
-		m_charMap->Set(connId, parsed->characterId, parsed->characterName, normalized, accountRole);
+		m_charMap->Set(connId, *accountId, parsed->characterId, parsed->characterName, normalized, accountRole);
 		LOG_INFO(Net, "[CharacterEnterWorldHandler] registered (account_id={}, character_id={}, name='{}')",
 			*accountId, parsed->characterId, parsed->characterName);
 

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -95,8 +95,10 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 namespace
 {
@@ -1373,7 +1375,38 @@ int main(int argc, char** argv)
 		return html;
 	};
 
-	if (healthEndpoint.Init(healthPort, healthBind, readyCheck, metricsProvider, statusProvider, webPortalStatusHtmlProvider))
+	// Présence "en ligne" exposée au web-portal (pastille admin). Deux listes :
+	//  - authenticated : comptes avec une session master active (login jeu réussi,
+	//    éventuellement encore au menu de sélection de personnage).
+	//  - inWorld        : comptes ayant validé EnterWorld (réellement en jeu).
+	// Source 100% en mémoire master, aucune persistance DB. Le portail interroge
+	// cette route en server-side et dégrade gracieusement si le master est injoignable.
+	auto onlineAccountsProvider = [&sessionManager, &sessionCharMap]() -> std::string {
+		auto appendJsonArray = [](std::string& out, const std::vector<uint64_t>& ids) {
+			out += "[";
+			for (size_t i = 0; i < ids.size(); ++i)
+			{
+				if (i != 0)
+					out += ",";
+				out += std::to_string(ids[i]);
+			}
+			out += "]";
+		};
+
+		const std::vector<uint64_t> authenticated = sessionManager.ListActiveAccountIds();
+		const std::vector<uint64_t> inWorld = sessionCharMap.ListInWorldAccountIds();
+
+		std::string body;
+		body.reserve(32 + (authenticated.size() + inWorld.size()) * 12);
+		body += "{\"authenticated\":";
+		appendJsonArray(body, authenticated);
+		body += ",\"inWorld\":";
+		appendJsonArray(body, inWorld);
+		body += "}";
+		return body;
+	};
+
+	if (healthEndpoint.Init(healthPort, healthBind, readyCheck, metricsProvider, statusProvider, webPortalStatusHtmlProvider, onlineAccountsProvider))
 		LOG_INFO(Net, "[ServerMain] Health endpoint listening on {}:{} (/healthz, /readyz, /metrics)", healthBind, healthPort);
 	else
 		LOG_WARN(Net, "[ServerMain] Health endpoint Init failed (port {}), continuing without health endpoint", healthPort);

--- a/src/masterd/metrics/HealthEndpoint.cpp
+++ b/src/masterd/metrics/HealthEndpoint.cpp
@@ -32,13 +32,14 @@ namespace engine::server
 			}
 		}
 
-		bool ParseRequestLine(const char* line, size_t len, bool& outHealthz, bool& outReadyz, bool& outMetrics, bool& outStatus, bool& outWebPortalStatus)
+		bool ParseRequestLine(const char* line, size_t len, bool& outHealthz, bool& outReadyz, bool& outMetrics, bool& outStatus, bool& outWebPortalStatus, bool& outOnlineAccounts)
 		{
 			outHealthz = false;
 			outReadyz = false;
 			outMetrics = false;
 			outStatus = false;
 			outWebPortalStatus = false;
+			outOnlineAccounts = false;
 			if (len < 14)
 				return false;
 			if (std::strncmp(line, "GET ", 4) != 0)
@@ -70,6 +71,11 @@ namespace engine::server
 			if (pathLen == 18 && std::strncmp(path, "/web-portal/status", 18) == 0)
 			{
 				outWebPortalStatus = true;
+				return true;
+			}
+			if (pathLen == 16 && std::strncmp(path, "/online-accounts", 16) == 0)
+			{
+				outOnlineAccounts = true;
 				return true;
 			}
 			return false;
@@ -114,7 +120,7 @@ namespace engine::server
 
 	bool HealthEndpoint::Init(uint16_t port, const std::string& bindAddress, std::function<bool()> readyCheck,
 		std::function<std::string()> metricsProvider, std::function<std::string()> statusProvider,
-		std::function<std::string()> webPortalStatusHtmlProvider)
+		std::function<std::string()> webPortalStatusHtmlProvider, std::function<std::string()> onlineAccountsProvider)
 	{
 		if (m_running.load(std::memory_order_relaxed))
 		{
@@ -126,6 +132,7 @@ namespace engine::server
 		m_metricsProvider = std::move(metricsProvider);
 		m_statusProvider = std::move(statusProvider);
 		m_webPortalStatusHtmlProvider = std::move(webPortalStatusHtmlProvider);
+		m_onlineAccountsProvider = std::move(onlineAccountsProvider);
 
 		m_listenFd = ::socket(AF_INET, SOCK_STREAM, 0);
 		if (m_listenFd < 0)
@@ -249,9 +256,22 @@ namespace engine::server
 			bool metrics = false;
 			bool status = false;
 			bool webPortalStatus = false;
-			bool valid = ParseRequestLine(buf, static_cast<size_t>(n), healthz, readyz, metrics, status, webPortalStatus);
+			bool onlineAccounts = false;
+			bool valid = ParseRequestLine(buf, static_cast<size_t>(n), healthz, readyz, metrics, status, webPortalStatus, onlineAccounts);
 
-			if (valid && webPortalStatus)
+			if (valid && onlineAccounts)
+			{
+				if (m_onlineAccountsProvider)
+				{
+					std::string body = m_onlineAccountsProvider();
+					SendResponse(clientFd, 200, "OK", "application/json", body.empty() ? "{\"authenticated\":[],\"inWorld\":[]}" : body.c_str());
+				}
+				else
+				{
+					SendResponse(clientFd, 404, "Not Found", "application/json", "{\"status\":\"error\",\"reason\":\"online-accounts not configured\"}");
+				}
+			}
+			else if (valid && webPortalStatus)
 			{
 				if (m_webPortalStatusHtmlProvider)
 				{

--- a/src/masterd/metrics/HealthEndpoint.h
+++ b/src/masterd/metrics/HealthEndpoint.h
@@ -26,11 +26,14 @@ namespace engine::server
 	/// \param metricsProvider Optional. Called for GET /metrics; returns Prometheus text (M23.2). If null, /metrics returns 404.
 	/// \param statusProvider Optional. Called for GET /status; returns JSON body. If null, /status returns 404.
 	/// \param webPortalStatusHtmlProvider Optional. Called for GET /web-portal/status; returns HTML page. If null, returns 404.
+	/// \param onlineAccountsProvider Optional. Called for GET /online-accounts; returns JSON body
+	///        (ex. {"authenticated":[...],"inWorld":[...]}). If null, /online-accounts returns 404.
 		/// \return true if listen socket created and thread started; false on error.
 		bool Init(uint16_t port, const std::string& bindAddress, std::function<bool()> readyCheck,
 		std::function<std::string()> metricsProvider = nullptr,
 		std::function<std::string()> statusProvider = nullptr,
-		std::function<std::string()> webPortalStatusHtmlProvider = nullptr);
+		std::function<std::string()> webPortalStatusHtmlProvider = nullptr,
+		std::function<std::string()> onlineAccountsProvider = nullptr);
 
 		/// Stops the server thread and closes the listen socket. Safe to call multiple times.
 		void Shutdown();
@@ -45,6 +48,7 @@ namespace engine::server
 		std::function<std::string()> m_metricsProvider;
 		std::function<std::string()> m_statusProvider;
 		std::function<std::string()> m_webPortalStatusHtmlProvider;
+		std::function<std::string()> m_onlineAccountsProvider;
 		std::atomic<bool> m_running{ false };
 		std::thread m_thread;
 		std::atomic<bool> m_lastReady{ false };

--- a/src/masterd/session/SessionCharacterMap.cpp
+++ b/src/masterd/session/SessionCharacterMap.cpp
@@ -1,5 +1,7 @@
 #include "src/masterd/session/SessionCharacterMap.h"
 
+#include <algorithm>
+
 namespace engine::server
 {
 	std::string SessionCharacterMap::Normalize(const std::string& name)
@@ -16,8 +18,8 @@ namespace engine::server
 		return out;
 	}
 
-	void SessionCharacterMap::Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName,
-		AccountRole role)
+	void SessionCharacterMap::Set(uint32_t connId, uint64_t accountId, uint64_t characterId, std::string characterName,
+		std::string normalizedName, AccountRole role)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -46,6 +48,7 @@ namespace engine::server
 		}
 
 		CharacterInfo info{};
+		info.accountId = accountId;
 		info.characterId = characterId;
 		info.characterName = std::move(characterName);
 		info.normalizedName = normalizedName;
@@ -88,6 +91,24 @@ namespace engine::server
 	{
 		std::lock_guard lock(m_mutex);
 		return m_byConn.size();
+	}
+
+	std::vector<uint64_t> SessionCharacterMap::ListInWorldAccountIds() const
+	{
+		std::lock_guard lock(m_mutex);
+		std::vector<uint64_t> ids;
+		ids.reserve(m_byConn.size());
+		for (const auto& [connId, info] : m_byConn)
+		{
+			(void)connId;
+			if (info.accountId == 0)
+				continue; // binding sans compte connu : ignoré (ne devrait pas arriver post-EnterWorld).
+			// Dédup linéaire : le nombre de joueurs en jeu reste petit (un seul connId
+			// par compte en pratique, le master kick les duplicate-login).
+			if (std::find(ids.begin(), ids.end(), info.accountId) == ids.end())
+				ids.push_back(info.accountId);
+		}
+		return ids;
 	}
 
 	SessionCharacterMap::RoleCounts SessionCharacterMap::CountByRole() const

--- a/src/masterd/session/SessionCharacterMap.h
+++ b/src/masterd/session/SessionCharacterMap.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace engine::server
 {
@@ -23,6 +24,7 @@ namespace engine::server
 	public:
 		struct CharacterInfo
 		{
+			uint64_t    accountId = 0;        ///< Compte propriétaire (pour la présence "en jeu" exposée au web-portal).
 			uint64_t    characterId = 0;
 			std::string characterName;        ///< Original UTF-8, displayed as-is.
 			std::string normalizedName;       ///< Lowercased ASCII for whisper target match.
@@ -43,8 +45,9 @@ namespace engine::server
 		/// Register or update the active character for \a connId.
 		/// Removes any previous binding for the same connId and any name → conn binding
 		/// that pointed at the old name (consistency under updates).
-		void Set(uint32_t connId, uint64_t characterId, std::string characterName, std::string normalizedName,
-			AccountRole role);
+		/// \param accountId compte propriétaire (présence "en jeu" exposée au web-portal).
+		void Set(uint32_t connId, uint64_t accountId, uint64_t characterId, std::string characterName,
+			std::string normalizedName, AccountRole role);
 
 		/// Drop the binding for \a connId (call on connection close).
 		void Remove(uint32_t connId);
@@ -58,6 +61,12 @@ namespace engine::server
 		/// Nombre de joueurs ayant valide EnterWorld (connId actuellement en jeu).
 		/// Utilise par l'API /status pour le compteur totalPlayers / per-shard players.
 		size_t Count() const;
+
+		/// Liste dédupliquée des accountId actuellement en jeu (post-EnterWorld).
+		/// Utilisée par l'API HTTP /online-accounts (champ "inWorld") consommée par le
+		/// web-portal pour la pastille "en jeu". L'ordre n'est pas garanti. Un compte
+		/// n'apparaît qu'une fois même s'il avait (théoriquement) plusieurs connId.
+		std::vector<uint64_t> ListInWorldAccountIds() const;
 
 		/// Ventilation de \ref Count() par rôle de compte. Utilisé par l'API /status
 		/// pour les sous-compteurs players_by_role.

--- a/src/masterd/session/SessionCharacterMapTests.cpp
+++ b/src/masterd/session/SessionCharacterMapTests.cpp
@@ -6,9 +6,11 @@
 #include "src/masterd/session/SessionCharacterMap.h"
 #include "src/masterd/account/AccountRole.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -20,6 +22,11 @@ namespace
 			++s_failCount;
 			std::cerr << "[FAIL] " << msg << std::endl;
 		}
+	}
+
+	bool Contains(const std::vector<uint64_t>& v, uint64_t value)
+	{
+		return std::find(v.begin(), v.end(), value) != v.end();
 	}
 }
 
@@ -40,12 +47,13 @@ static void TestNormalize()
 static void TestSetAndLookup()
 {
 	SessionCharacterMap m;
-	m.Set(42u, 1001ull, "Alyx", "alyx", AccountRole::GameMaster);
+	m.Set(42u, 5001ull, 1001ull, "Alyx", "alyx", AccountRole::GameMaster);
 
 	auto byConn = m.GetByConnId(42u);
 	Assert(byConn.has_value(), "GetByConnId returns set value");
 	if (byConn)
 	{
+		Assert(byConn->accountId == 5001ull, "accountId round-trips");
 		Assert(byConn->characterId == 1001ull, "characterId round-trips");
 		Assert(byConn->characterName == "Alyx", "characterName round-trips");
 		Assert(byConn->normalizedName == "alyx", "normalizedName round-trips");
@@ -62,7 +70,7 @@ static void TestSetAndLookup()
 static void TestRemoveCleansBothMaps()
 {
 	SessionCharacterMap m;
-	m.Set(7u, 999ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(7u, 5007ull, 999ull, "Alyx", "alyx", AccountRole::Player);
 	m.Remove(7u);
 
 	Assert(!m.GetByConnId(7u).has_value(), "Remove drops connId binding");
@@ -76,8 +84,8 @@ static void TestUpdateOldNameIsDropped()
 	// perso post-logout/re-login sur la même connexion), l'ancien nom doit
 	// disparaître du whisper directory.
 	SessionCharacterMap m;
-	m.Set(11u, 100ull, "Alyx", "alyx", AccountRole::Player);
-	m.Set(11u, 200ull, "Bob", "bob", AccountRole::Player);
+	m.Set(11u, 1100ull, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(11u, 1100ull, 200ull, "Bob", "bob", AccountRole::Player);
 
 	auto byConn = m.GetByConnId(11u);
 	Assert(byConn && byConn->characterName == "Bob", "Update overwrites characterName");
@@ -91,8 +99,8 @@ static void TestUpdateOldNameIsDropped()
 static void TestTwoConnectionsDifferentNames()
 {
 	SessionCharacterMap m;
-	m.Set(1u, 100ull, "Alyx", "alyx", AccountRole::Player);
-	m.Set(2u, 200ull, "Bob",  "bob", AccountRole::Player);
+	m.Set(1u, 101ull, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(2u, 102ull, 200ull, "Bob",  "bob", AccountRole::Player);
 
 	auto a = m.FindConnByNormalizedName("alyx");
 	auto b = m.FindConnByNormalizedName("bob");
@@ -109,11 +117,11 @@ static void TestCountAndCountByRole()
 	SessionCharacterMap m;
 	Assert(m.Count() == 0u, "Count empty == 0");
 
-	m.Set(1u, 100ull, "Alyx", "alyx", AccountRole::Player);
-	m.Set(2u, 200ull, "Bob", "bob", AccountRole::Player);
-	m.Set(3u, 300ull, "Mod", "mod", AccountRole::Moderator);
-	m.Set(4u, 400ull, "Gm", "gm", AccountRole::GameMaster);
-	m.Set(5u, 500ull, "Admin", "admin", AccountRole::Administrator);
+	m.Set(1u, 201ull, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(2u, 202ull, 200ull, "Bob", "bob", AccountRole::Player);
+	m.Set(3u, 203ull, 300ull, "Mod", "mod", AccountRole::Moderator);
+	m.Set(4u, 204ull, 400ull, "Gm", "gm", AccountRole::GameMaster);
+	m.Set(5u, 205ull, 500ull, "Admin", "admin", AccountRole::Administrator);
 
 	Assert(m.Count() == 5u, "Count == 5 after 5 Set");
 
@@ -126,7 +134,7 @@ static void TestCountAndCountByRole()
 		"CountByRole sums to Count");
 
 	// Une mise à jour du même connId vers un autre rôle ne double-compte pas.
-	m.Set(3u, 300ull, "Mod", "mod", AccountRole::Administrator);
+	m.Set(3u, 203ull, 300ull, "Mod", "mod", AccountRole::Administrator);
 	auto rc2 = m.CountByRole();
 	Assert(rc2.moderator == 0u, "CountByRole moderator == 0 after role change");
 	Assert(rc2.administrator == 2u, "CountByRole administrator == 2 after role change");
@@ -138,6 +146,31 @@ static void TestCountAndCountByRole()
 	Assert(m.Count() == 4u, "Count == 4 after Remove");
 }
 
+static void TestListInWorldAccountIds()
+{
+	SessionCharacterMap m;
+	Assert(m.ListInWorldAccountIds().empty(), "ListInWorldAccountIds empty == {}");
+
+	m.Set(1u, 201ull, 100ull, "Alyx", "alyx", AccountRole::Player);
+	m.Set(2u, 202ull, 200ull, "Bob", "bob", AccountRole::GameMaster);
+
+	auto ids = m.ListInWorldAccountIds();
+	Assert(ids.size() == 2u, "ListInWorldAccountIds size == 2");
+	Assert(Contains(ids, 201ull), "ListInWorldAccountIds contains 201");
+	Assert(Contains(ids, 202ull), "ListInWorldAccountIds contains 202");
+
+	// Le même compte sur deux connId (cas théorique) ne doit apparaître qu'une fois.
+	m.Set(3u, 201ull, 300ull, "Alyx2", "alyx2", AccountRole::Player);
+	auto idsDedup = m.ListInWorldAccountIds();
+	Assert(idsDedup.size() == 2u, "ListInWorldAccountIds dedup same account");
+	Assert(std::count(idsDedup.begin(), idsDedup.end(), 201ull) == 1, "account 201 appears once");
+
+	m.Remove(2u);
+	auto idsAfter = m.ListInWorldAccountIds();
+	Assert(!Contains(idsAfter, 202ull), "ListInWorldAccountIds drops removed account");
+	Assert(Contains(idsAfter, 201ull), "ListInWorldAccountIds keeps account 201 (still on conn 1/3)");
+}
+
 int main()
 {
 	TestNormalize();
@@ -146,6 +179,7 @@ int main()
 	TestUpdateOldNameIsDropped();
 	TestTwoConnectionsDifferentNames();
 	TestCountAndCountByRole();
+	TestListInWorldAccountIds();
 	std::cerr << (s_failCount == 0 ? "[OK] all session_character_map tests passed\n" : "[FAIL] some tests failed\n");
 	return s_failCount == 0 ? 0 : 1;
 }

--- a/web-portal/README.md
+++ b/web-portal/README.md
@@ -25,6 +25,15 @@ npm run dev
 
 Build production : `npm run build` puis `npm start` ou image Docker.
 
+## Variables d'environnement
+
+- `DATABASE_URL` — connexion MySQL `lcdlln_master` (obligatoire).
+- `SMTP_*` — configuration e-mail (récupération mot de passe, vérification, CGU).
+- `MASTER_STATUS_URL` *(optionnelle)* — URL de base du HealthEndpoint du master
+  (ex. `http://127.0.0.1:3842`). Sert à afficher la pastille « en ligne » dans
+  **Admin → Gestion des joueurs** (route `GET /online-accounts`). Si absente ou
+  master injoignable : dégradation gracieuse, aucune pastille (page fonctionnelle).
+
 ## Base de données
 
 - CGU : `terms_editions`, `terms_localizations`, `account_terms_acceptances` (migration `0007`).

--- a/web-portal/app/admin/players/page.tsx
+++ b/web-portal/app/admin/players/page.tsx
@@ -6,6 +6,29 @@ import { getSession } from '@/lib/auth/session'
 import { isStaff, type AccountRole } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { PlayerActions, type PlayerRow } from '@/components/admin/PlayerActions'
+import { fetchOnlineAccounts, presenceFor, type PlayerPresence } from '@/lib/serverStatus'
+
+/** Pastille de présence affichée à droite du nom du joueur (3 états). */
+function PresenceDot({ presence }: { presence: PlayerPresence }) {
+  if (presence === 'offline') return null
+  const inWorld = presence === 'in_world'
+  return (
+    <span
+      title={inWorld ? 'En jeu' : 'Connecté (menu)'}
+      aria-label={inWorld ? 'En jeu' : 'Connecté (menu)'}
+      style={{
+        display: 'inline-block',
+        width: 9,
+        height: 9,
+        borderRadius: '50%',
+        flexShrink: 0,
+        background: inWorld ? 'var(--ln-success)' : 'transparent',
+        border: `1.5px solid var(--ln-success)`,
+        boxShadow: inWorld ? '0 0 5px rgba(95,184,110,.6)' : 'none',
+      }}
+    />
+  )
+}
 
 function roleBadgeLabel(role: AccountRole): string {
   switch (role) {
@@ -76,6 +99,10 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
     logError("AdminPlayersPage", "DB error", { err })
     dbError = true
   }
+
+  // Présence "en ligne" lue en direct depuis le master (dégradation gracieuse :
+  // ensembles vides si MASTER_STATUS_URL absente ou master injoignable).
+  const online = await fetchOnlineAccounts()
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
@@ -189,6 +216,7 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
                       <span style={{ fontFamily: 'var(--font-display)', fontSize: 13, letterSpacing: '.12em', color: 'var(--ln-accent)' }}>
                         {displayName}
                       </span>
+                      <PresenceDot presence={presenceFor(player.id, online)} />
                       {player.tag_id && (
                         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ln-muted)' }}>
                           ({player.login})

--- a/web-portal/lib/serverStatus.ts
+++ b/web-portal/lib/serverStatus.ts
@@ -1,0 +1,69 @@
+// Présence "en ligne" des joueurs, lue en direct depuis le master.
+//
+// Le master expose une route HTTP `GET /online-accounts` sur son HealthEndpoint
+// (port server.health.port, défaut 3842) renvoyant :
+//   { "authenticated": [accountId, ...], "inWorld": [accountId, ...] }
+//   - authenticated : session master active (login jeu réussi, éventuellement au menu).
+//   - inWorld        : EnterWorld validé (réellement en jeu).
+//
+// Le portail interroge cette route côté serveur (jamais exposée au navigateur).
+// L'URL de base vient de MASTER_STATUS_URL (ex. "http://127.0.0.1:3842").
+//
+// Dégradation gracieuse : si la variable est absente, l'URL invalide, le master
+// injoignable ou la réponse malformée, on renvoie des ensembles VIDES sans lever
+// d'erreur — la page admin reste fonctionnelle, seules les pastilles disparaissent.
+
+export interface OnlineAccounts {
+  authenticated: Set<number>;
+  inWorld: Set<number>;
+}
+
+const EMPTY: OnlineAccounts = { authenticated: new Set(), inWorld: new Set() };
+
+function toIdSet(value: unknown): Set<number> {
+  if (!Array.isArray(value)) return new Set();
+  const out = new Set<number>();
+  for (const item of value) {
+    const id = typeof item === "number" ? item : Number(item);
+    if (Number.isFinite(id) && id > 0) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Récupère les comptes en ligne depuis le master. Ne lève jamais : en cas
+ * d'échec (env absente, timeout, master KO, JSON invalide), renvoie des
+ * ensembles vides. Timeout court (1,5 s) pour ne pas ralentir le rendu admin.
+ */
+export async function fetchOnlineAccounts(): Promise<OnlineAccounts> {
+  const base = process.env.MASTER_STATUS_URL?.trim();
+  if (!base) return EMPTY;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1500);
+  try {
+    const response = await fetch(`${base.replace(/\/$/, "")}/online-accounts`, {
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    if (!response.ok) return EMPTY;
+    const payload = (await response.json()) as { authenticated?: unknown; inWorld?: unknown };
+    return {
+      authenticated: toIdSet(payload.authenticated),
+      inWorld: toIdSet(payload.inWorld),
+    };
+  } catch {
+    return EMPTY;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export type PlayerPresence = "in_world" | "authenticated" | "offline";
+
+/** Statut de présence d'un compte à partir des ensembles renvoyés par le master. */
+export function presenceFor(accountId: number, online: OnlineAccounts): PlayerPresence {
+  if (online.inWorld.has(accountId)) return "in_world";
+  if (online.authenticated.has(accountId)) return "authenticated";
+  return "offline";
+}


### PR DESCRIPTION
## Feature 2 — Pastille « en ligne » dans Admin → Gestion des joueurs

Affiche une pastille de présence à droite du nom du joueur (**3 états**) :
- 🟢 **plein** = en jeu (post-EnterWorld)
- 🟢 **contour** = connecté au master (encore au menu de sélection)
- *(rien)* = hors ligne

### Master (C++)
- Nouvelle route HTTP `GET /online-accounts` sur `HealthEndpoint` renvoyant `{"authenticated":[...],"inWorld":[...]}`.
- `authenticated` ← `SessionManager::ListActiveAccountIds()` (existant).
- `inWorld` ← nouveau `SessionCharacterMap::ListInWorldAccountIds()` (ajout du champ `accountId` à `CharacterInfo`, peuplé à l'EnterWorld). Test unitaire ajouté.

### Portail (Next.js)
- Helper `lib/serverStatus.ts` (`fetchOnlineAccounts`) interroge le master **server-side** (var d'env optionnelle `MASTER_STATUS_URL`, `cache: no-store`, timeout 1,5 s).
- **Dégradation gracieuse** : ensembles vides si `MASTER_STATUS_URL` absente ou master injoignable → aucune pastille, page admin pleinement fonctionnelle.
- Rafraîchissement **au chargement de page** (pas de polling).

Spec design : `docs/superpowers/specs/2026-05-31-portal-secret-questions-online-pastille-design.md` (introduite par la PR #766).

**Déploiement** : ⚠️ **redéploiement serveur (master) requis** — nouvelle route HTTP `/online-accounts` + champ `accountId` dans `SessionCharacterMap`. Côté portail : renseigner la variable d'env `MASTER_STATUS_URL` (ex. `http://127.0.0.1:3842`) sinon pas de pastille (sans casse). Master et portail à déployer en lock-step pour que la pastille apparaisse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
