### PR TITLE
fix(portal): câbler MASTER_STATUS_URL dans docker-compose (pastille en ligne)

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -212,6 +212,12 @@ services:
       NODE_ENV: production
       # Aligné sur MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE du service mysql
       DATABASE_URL: mysql://${MYSQL_USER:-lcdlln_user}:${MYSQL_PASSWORD:-lcdlln_pass_dev}@mysql:3306/${MYSQL_DATABASE:-lcdlln_master}
+      # Présence "en ligne" (pastille admin > Gestion des joueurs) : HealthEndpoint
+      # du master, joignable sur le réseau Docker interne via le nom de service
+      # `master` (port health 3842, bind 0.0.0.0 cf. config/master.config.json).
+      # NE PAS mettre 127.0.0.1 ici : dans le conteneur portail cela pointerait
+      # sur le portail lui-même, pas sur le master -> aucune pastille.
+      MASTER_STATUS_URL: ${MASTER_STATUS_URL:-http://master:3842}
     expose:
       - "3000"
     ports:

--- a/web-portal/lib/serverStatus.ts
+++ b/web-portal/lib/serverStatus.ts
@@ -12,6 +12,11 @@
 // Dégradation gracieuse : si la variable est absente, l'URL invalide, le master
 // injoignable ou la réponse malformée, on renvoie des ensembles VIDES sans lever
 // d'erreur — la page admin reste fonctionnelle, seules les pastilles disparaissent.
+// Pour rester diagnosticable malgré cette dégradation, on logge la raison de
+// l'échec (logWarn) côté serveur : un admin qui ne voit aucune pastille peut
+// regarder les logs portail pour distinguer "non configuré" / "injoignable".
+
+import { logWarn } from "@/lib/log";
 
 export interface OnlineAccounts {
   authenticated: Set<number>;
@@ -37,22 +42,34 @@ function toIdSet(value: unknown): Set<number> {
  */
 export async function fetchOnlineAccounts(): Promise<OnlineAccounts> {
   const base = process.env.MASTER_STATUS_URL?.trim();
-  if (!base) return EMPTY;
+  if (!base) {
+    // Variable optionnelle non définie : pas de pastille. On le signale une fois
+    // par rendu pour qu'un admin surpris par l'absence de pastille comprenne.
+    logWarn("serverStatus", "MASTER_STATUS_URL non défini : présence en ligne désactivée (aucune pastille).");
+    return EMPTY;
+  }
 
+  const url = `${base.replace(/\/$/, "")}/online-accounts`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 1500);
   try {
-    const response = await fetch(`${base.replace(/\/$/, "")}/online-accounts`, {
+    const response = await fetch(url, {
       cache: "no-store",
       signal: controller.signal,
     });
-    if (!response.ok) return EMPTY;
+    if (!response.ok) {
+      logWarn("serverStatus", "Master /online-accounts a répondu en erreur.", { url, status: response.status });
+      return EMPTY;
+    }
     const payload = (await response.json()) as { authenticated?: unknown; inWorld?: unknown };
     return {
       authenticated: toIdSet(payload.authenticated),
       inWorld: toIdSet(payload.inWorld),
     };
-  } catch {
+  } catch (err) {
+    // Master injoignable / timeout / JSON invalide : on logge l'URL et l'erreur
+    // pour distinguer un mauvais host (ex. 127.0.0.1 en conteneur) d'un master KO.
+    logWarn("serverStatus", "Échec de la récupération de la présence en ligne.", { url, err });
     return EMPTY;
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Cause racine

La pastille « en ligne » n'apparaissait pas **malgré master redéployé et compte connecté au jeu**.

La PR #767 a ajouté le code (`fetchOnlineAccounts`), la doc README et `.env.example`, mais **n'a pas câblé `MASTER_STATUS_URL` dans le service `web-portal` du `docker-compose.yml`**. En stack déployée, `process.env.MASTER_STATUS_URL` était donc `undefined` → `fetchOnlineAccounts` retournait des ensembles vides → aucune pastille, **sans erreur** (dégradation gracieuse qui masquait le problème).

## Correctifs

- **`deploy/docker/docker-compose.yml`** : ajoute `MASTER_STATUS_URL` au service `web-portal`, pointant sur le nom de service Docker `master` :
  `MASTER_STATUS_URL: ${MASTER_STATUS_URL:-http://master:3842}`.
  ⚠️ En conteneur, `127.0.0.1:3842` ne marche pas (pointe sur le portail lui-même) — il faut le nom de service `master` (health bind `0.0.0.0` cf. `config/master.config.json`).
- **`web-portal/lib/serverStatus.ts`** : `logWarn` sur chaque mode d'échec (variable absente, HTTP non-OK, master injoignable/timeout) avec l'URL tentée → la dégradation gracieuse reste **diagnosticable** dans les logs portail.

## Déploiement

⚠️ Recréer le conteneur portail pour qu'il prenne la nouvelle variable :
```
docker compose up -d web-portal
```
Si tu as un `MASTER_STATUS_URL` dans ton `.env` racine pointant sur `127.0.0.1`, **retire-le** (ou mets `http://master:3842`). Pas de redéploiement master nécessaire (déjà à jour). Portail uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
