### PR TITLE
feat(server): présence en ligne enrichie (heartbeat v9 + cache + endpoint)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-online-presence-enriched-design.md
+++ b/docs/superpowers/specs/2026-05-31-online-presence-enriched-design.md
@@ -1,0 +1,141 @@
+# Design — Présence en ligne enrichie (login, perso, niveau, zone)
+
+Date : 2026-05-31
+Branche serveur : `feat/online-presence-enriched`
+
+## Contexte
+
+La route master `GET /online-accounts` (HealthEndpoint) renvoie aujourd'hui :
+```json
+{ "authenticated": [accountId, ...], "inWorld": [accountId, ...] }
+```
+On veut **enrichir** chaque joueur en ligne avec : login (utilisateur), nom du
+personnage, niveau, et zone in-game (région). Affichage : endpoint **et** UI
+admin (Gestion des joueurs).
+
+Disponibilité des données :
+- `login` : MySQL `accounts.login` (master a le pool DB).
+- `character` (nom) : `SessionCharacterMap` côté master (déjà peuplé à l'EnterWorld).
+- `level`, `zoneId` : **live côté shard** (`Unit::GetLevel()`, `WorldObject::GetZoneId()`),
+  PAS dans le master. Le heartbeat shard→master ne transporte que
+  `(shard_id, current_load, timestamp)`.
+
+Décisions (utilisateur) : zone = **zoneId in-game réel** ; transport = **enrichir
+le heartbeat existant** ; affichage = **endpoint + UI admin**. Le niveau et la
+zone viennent du **live shard** (autoritatif), pas de la DB (évite valeur périmée).
+
+## Architecture / flux
+
+```
+shard (live: account/char/level/zone)
+   │  heartbeat enrichi (périodique)
+   ▼
+master  ──► ShardPlayerPresenceCache (accountId → {characterId, level, zoneId, shardId, updatedAt})
+   │
+   │  GET /online-accounts : jointure
+   │    login   ← MySQL accounts (lookup par accountId)
+   │    character← SessionCharacterMap
+   │    level/zoneId ← ShardPlayerPresenceCache
+   ▼
+portail (server-side fetch) ──► Admin > Gestion des joueurs (sous le nom + tooltip pastille)
+```
+
+## 1. Protocole (wire-breaking → bump `kProtocolVersion` 8 → 9)
+
+`src/shared/network/ServerProtocol.h` : `kProtocolVersion = 9`.
+
+`src/shared/network/ShardPayloads.{h,cpp}` — heartbeat enrichi (champs en queue,
+parsing tolérant si absents pour robustesse, mais version bump impose lock-step) :
+- `struct ShardPlayerPresence { uint64_t accountId; uint64_t characterId; uint32_t level; uint32_t zoneId; };`
+- `ShardHeartbeatPayload` : ajouter `std::vector<ShardPlayerPresence> players;`.
+- Wire après les 16 octets fixes : `u16 playerCount`, puis `playerCount` × `{u64 accountId, u64 characterId, u32 level, u32 zoneId}` (24 octets/joueur).
+- `BuildShardHeartbeatPayload(shard_id, current_load, timestamp, const std::vector<ShardPlayerPresence>& players = {})`.
+- `ParseShardHeartbeatPayload` : lit le tableau si `Remaining() > 0`.
+- Tests `ShardPayloadsTests` : round-trip avec 0 / N joueurs.
+
+## 2. Shard — collecte et envoi
+
+`src/shared/network/ShardToMasterClient.{h,cpp}` :
+- `SetCurrentLoad` existe déjà ; ajouter un fournisseur de présence injecté :
+  `SetPlayerPresenceProvider(std::function<std::vector<ShardPlayerPresence>()>)`.
+- `SendHeartbeat()` appelle le provider (si câblé) et passe la liste à `BuildShardHeartbeatPayload`.
+
+`src/shardd/main_linux.cpp` (ou le composant monde) : câbler le provider pour
+itérer les joueurs connectés et produire `{accountId, characterId, level, zoneId}`
+depuis l'AdmittedCharacterRegistry (account/char) + l'entité monde du joueur
+(`GetLevel()`, `GetZoneId()`). Doit s'exécuter sur le thread monde (snapshot cohérent).
+
+## 3. Master — cache + endpoint
+
+Nouveau `src/masterd/shards/ShardPlayerPresenceCache.{h,cpp}` (thread-safe) :
+- `Update(uint32_t shardId, const std::vector<ShardPlayerPresence>&)` : remplace
+  l'ensemble des entrées de CE shard (clé accountId).
+- `Clear(uint32_t shardId)` : purge les entrées d'un shard (appelé au shard-down / evict).
+- `std::optional<Entry> Get(uint64_t accountId)` et `Snapshot()`.
+
+`ShardRegisterHandler::HandleHeartbeat` : après `UpdateHeartbeat`, appelle
+`presenceCache.Update(shard_id, parsed->players)`. Le callback shard-down
+(`SetShardDownCallback`) appelle `presenceCache.Clear(shard_id)`.
+
+`main_linux.cpp` `onlineAccountsProvider` enrichi → JSON :
+```json
+{
+  "authenticated":[1], "inWorld":[1],
+  "players":[
+    {"accountId":1,"login":"thedjinhn","character":"homme","level":7,"zoneId":42,"inWorld":true}
+  ]
+}
+```
+Construction des `players` :
+- Pour chaque accountId in-world : `login` (MySQL), `character` (SessionCharacterMap),
+  `level`/`zoneId` (presenceCache).
+- Pour chaque accountId authentifié non in-world : `login` seul, `character`=null,
+  `level`/`zoneId` absents, `inWorld`:false.
+- `login` : un seul `SELECT id, login FROM accounts WHERE id IN (...)` (batch),
+  échappé via la fonction `escapeJson` déjà présente.
+
+Note : `zoneId` part en numérique ; le **nom de région** est résolu côté portail
+(tableau maintenable), pas sur le wire — minimise le payload et garde la
+connaissance "présentation" côté portail.
+
+## 4. Portail — consommation + UI
+
+`web-portal/lib/serverStatus.ts` :
+- `OnlineAccounts` gagne `players: Map<number, OnlinePlayer>` où
+  `OnlinePlayer = { login?: string; character?: string|null; level?: number|null; zoneId?: number|null; inWorld: boolean }`.
+- Parse défensif du tableau `players` (rétro-compat : si absent, map vide ;
+  les sets `authenticated`/`inWorld` continuent d'alimenter la pastille).
+
+`web-portal/lib/zones.ts` (nouveau) : `regionName(zoneId): string` via table
+maintenable, fallback `"Zone {id}"`.
+
+`web-portal/app/admin/players/page.tsx` :
+- Sous le nom d'un joueur en ligne : ligne discrète `perso • niveau N • région`
+  (uniquement si in-world ; sinon rien de plus que la pastille).
+- `title` de la pastille enrichi (déjà présent) avec ces infos.
+
+## Découpage PR
+
+- **PR A — serveur** (`feat/online-presence-enriched`) : protocole (v9) + shard
+  (collecte/envoi) + master (cache + endpoint). Lock-step **master + shard**.
+- **PR B — portail** : `serverStatus` + `zones.ts` + UI admin. Client only.
+  Dégrade gracieusement si le master ne renvoie pas encore `players`.
+
+## Tests
+
+- `ShardPayloadsTests` : round-trip heartbeat 0 / N joueurs (build↔parse).
+- `ShardPlayerPresenceCacheTests` : Update remplace par shard, Clear purge, Get.
+- Endpoint : vérif manuelle `curl /online-accounts` (JSON `players`).
+- Portail : pas de framework JS ; `regionName` et le parse restent purs/typés.
+
+## Déploiement
+
+⚠️ **Redéploiement master ET shard en lock-step** (bump `kProtocolVersion` →
+incompatibilité client/serveur ancien). PR portail = client only.
+
+## Non-objectifs (YAGNI)
+
+- Pas de position x/y/z exposée (seulement la zone).
+- Pas d'historique de présence / métriques temporelles.
+- Pas de rafraîchissement temps réel (toujours au chargement de page, cf. choix précédent).
+- Pas de persistance DB de la présence (tout en mémoire master, alimenté par le shard).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,6 +197,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/security/CaptchaVerifier.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/security/BotDetector.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/shards/ShardRegistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/shards/ShardPlayerPresenceCache.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/shards/ServerRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ShardRegisterHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ShardTicketCrypto.cpp
@@ -843,6 +844,20 @@ elseif(UNIX)
   target_link_libraries(shard_ticket_tests PRIVATE engine_core OpenSSL::SSL)
   target_compile_options(shard_ticket_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME shard_ticket_tests COMMAND shard_ticket_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Présence enrichie (v9) : round-trip du payload SHARD_HEARTBEAT avec tableau joueurs.
+  add_executable(shard_payloads_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ShardPayloadsTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ShardPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ByteReader.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ByteWriter.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketBuilder.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
+  )
+  target_include_directories(shard_payloads_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(shard_payloads_tests PRIVATE engine_core)
+  target_compile_options(shard_payloads_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME shard_payloads_tests COMMAND shard_payloads_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # M22.5: Server list and shard selection policy tests
   add_executable(server_list_policy_tests

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -12,6 +12,7 @@
 #include "src/masterd/handlers/shard/ShardRegisterHandler.h"
 #include "src/shared/network/NetServer.h"
 #include "src/masterd/shards/ShardRegistry.h"
+#include "src/masterd/shards/ShardPlayerPresenceCache.h"
 #include "src/shared/network/ShardPayloads.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/core/Log.h"
@@ -22,6 +23,7 @@ namespace engine::server
 {
 	void ShardRegisterHandler::SetServer(NetServer* server) { m_server = server; }
 	void ShardRegisterHandler::SetShardRegistry(ShardRegistry* registry) { m_registry = registry; }
+	void ShardRegisterHandler::SetPlayerPresenceCache(ShardPlayerPresenceCache* cache) { m_presenceCache = cache; }
 
 	void ShardRegisterHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t /*sessionIdHeader*/,
 		const uint8_t* payload, size_t payloadSize)
@@ -137,5 +139,11 @@ namespace engine::server
 			return;
 		}
 		m_registry->UpdateHeartbeat(parsed->shard_id, parsed->current_load);
+
+		// Présence enrichie (v9) : répercute l'ensemble des joueurs rapportés par ce
+		// shard dans le cache (remplace les entrées du shard). Tolérant : un heartbeat
+		// legacy sans tableau laisse players vide -> le shard est considéré sans joueur.
+		if (m_presenceCache)
+			m_presenceCache->Update(parsed->shard_id, parsed->players);
 	}
 }

--- a/src/masterd/handlers/shard/ShardRegisterHandler.h
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.h
@@ -15,6 +15,7 @@ namespace engine::server
 {
 	class NetServer;
 	class ShardRegistry;
+	class ShardPlayerPresenceCache;
 }
 
 namespace engine::server
@@ -41,6 +42,11 @@ namespace engine::server
 		/// Injecte le registre des shards (requis avant HandlePacket).
 		/// @param registry  Instance ShardRegistry maintenant l'état de tous les shards.
 		void SetShardRegistry(ShardRegistry* registry);
+
+		/// Injecte le cache de présence enrichie (optionnel). Si câblé, HandleHeartbeat
+		/// y répercute le tableau de joueurs du heartbeat v9 (présence web-portal).
+		/// @param cache  Instance ShardPlayerPresenceCache. Non possédé. Peut être nul.
+		void SetPlayerPresenceCache(ShardPlayerPresenceCache* cache);
 
 		/// Point d'entrée principal : dispatche vers HandleRegister ou HandleHeartbeat.
 		///
@@ -83,5 +89,7 @@ namespace engine::server
 		NetServer* m_server = nullptr;
 		/// Registre en mémoire des shards connus. Non possédé.
 		ShardRegistry* m_registry = nullptr;
+		/// Cache de présence enrichie (optionnel, non possédé). Nul = présence enrichie désactivée.
+		ShardPlayerPresenceCache* m_presenceCache = nullptr;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -12,6 +12,7 @@
 #include "src/masterd/shards/ServerRegistry.h"
 #include "src/masterd/handlers/shard/ShardRegisterHandler.h"
 #include "src/masterd/shards/ShardRegistry.h"
+#include "src/masterd/shards/ShardPlayerPresenceCache.h"
 #include "src/masterd/handlers/shard/ShardTicketHandler.h"
 #include "src/masterd/handlers/shard/ServerListHandler.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -98,6 +99,8 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace
@@ -183,6 +186,10 @@ int main(int argc, char** argv)
 	engine::server::ShardRegistry shardRegistry;
 	engine::server::ShardRegisterHandler shardRegisterHandler;
 	shardRegisterHandler.SetShardRegistry(&shardRegistry);
+	// Présence enrichie (web-portal) : cache alimenté par le tableau joueurs des
+	// heartbeats v9, purgé quand un shard tombe (cf. SetShardDownCallback).
+	engine::server::ShardPlayerPresenceCache playerPresenceCache;
+	shardRegisterHandler.SetPlayerPresenceCache(&playerPresenceCache);
 	LOG_INFO(Server, "[MAIN_SRV] ShardRegistry setup OK");
 
 	engine::server::NetServer server;
@@ -1381,7 +1388,7 @@ int main(int argc, char** argv)
 	//  - inWorld        : comptes ayant validé EnterWorld (réellement en jeu).
 	// Source 100% en mémoire master, aucune persistance DB. Le portail interroge
 	// cette route en server-side et dégrade gracieusement si le master est injoignable.
-	auto onlineAccountsProvider = [&sessionManager, &sessionCharMap]() -> std::string {
+	auto onlineAccountsProvider = [&sessionManager, &sessionCharMap, &playerPresenceCache, &dbPool]() -> std::string {
 		auto appendJsonArray = [](std::string& out, const std::vector<uint64_t>& ids) {
 			out += "[";
 			for (size_t i = 0; i < ids.size(); ++i)
@@ -1392,17 +1399,127 @@ int main(int argc, char** argv)
 			}
 			out += "]";
 		};
+		// Échappement JSON minimal pour login / nom de personnage (peuvent contenir " \ etc.).
+		auto escapeJson = [](const std::string& s) -> std::string {
+			std::string out;
+			out.reserve(s.size() + 4);
+			for (unsigned char c : s)
+			{
+				switch (c)
+				{
+				case '"': out += "\\\""; break;
+				case '\\': out += "\\\\"; break;
+				case '\n': out += "\\n"; break;
+				case '\r': out += "\\r"; break;
+				case '\t': out += "\\t"; break;
+				default:
+					if (c < 0x20u)
+					{
+						const char hex[] = "0123456789ABCDEF";
+						out += "\\u00";
+						out += hex[(c >> 4) & 0xF];
+						out += hex[c & 0xF];
+					}
+					else
+					{
+						out.push_back(static_cast<char>(c));
+					}
+					break;
+				}
+			}
+			return out;
+		};
 
 		const std::vector<uint64_t> authenticated = sessionManager.ListActiveAccountIds();
 		const std::vector<uint64_t> inWorld = sessionCharMap.ListInWorldAccountIds();
+		const std::unordered_map<uint64_t, std::string> nameByAccount = sessionCharMap.SnapshotAccountIdToCharacterName();
+
+		// Présence enrichie (level/zoneId) indexée par accountId.
+		std::unordered_map<uint64_t, engine::server::ShardPlayerPresenceCache::Entry> presenceByAccount;
+		for (const auto& e : playerPresenceCache.Snapshot())
+			presenceByAccount[e.accountId] = e;
+
+		// Ensemble dédupliqué de tous les comptes à exposer (authentifiés ∪ en jeu).
+		std::unordered_set<uint64_t> inWorldSet(inWorld.begin(), inWorld.end());
+		std::unordered_set<uint64_t> allAccounts(authenticated.begin(), authenticated.end());
+		for (uint64_t id : inWorld)
+			allAccounts.insert(id);
+
+		// Login par compte : un lookup préparé par compte (N petit ; le cache Reset() le stmt
+		// à chaque Acquire, donc la réutilisation en boucle est sûre). DB absente -> login vide.
+		std::unordered_map<uint64_t, std::string> loginByAccount;
+		if (dbPool.IsInitialized() && !allAccounts.empty())
+		{
+			auto guard = dbPool.Acquire();
+			MYSQL* mysql = guard.get();
+			auto* cache = guard.cache();
+			if (mysql != nullptr && cache != nullptr)
+			{
+				for (uint64_t id : allAccounts)
+				{
+					auto* stmt = cache->Acquire(mysql, "SELECT login FROM accounts WHERE id = ? LIMIT 1");
+					if (stmt && stmt->Bind(0, id) && stmt->Execute() && stmt->FetchRow())
+						loginByAccount[id] = stmt->GetString(0);
+				}
+			}
+		}
 
 		std::string body;
-		body.reserve(32 + (authenticated.size() + inWorld.size()) * 12);
+		body.reserve(64 + allAccounts.size() * 96);
 		body += "{\"authenticated\":";
 		appendJsonArray(body, authenticated);
 		body += ",\"inWorld\":";
 		appendJsonArray(body, inWorld);
-		body += "}";
+		body += ",\"players\":[";
+		bool first = true;
+		for (uint64_t id : allAccounts)
+		{
+			if (!first)
+				body += ",";
+			first = false;
+			const bool inW = inWorldSet.count(id) > 0;
+			body += "{\"accountId\":";
+			body += std::to_string(id);
+			body += ",\"login\":\"";
+			auto lit = loginByAccount.find(id);
+			body += escapeJson(lit != loginByAccount.end() ? lit->second : std::string());
+			body += "\",\"inWorld\":";
+			body += (inW ? "true" : "false");
+			// Champs liés au personnage : seulement si en jeu (sinon null).
+			if (inW)
+			{
+				body += ",\"character\":";
+				auto nit = nameByAccount.find(id);
+				if (nit != nameByAccount.end())
+				{
+					body += "\"";
+					body += escapeJson(nit->second);
+					body += "\"";
+				}
+				else
+				{
+					body += "null";
+				}
+				auto pit = presenceByAccount.find(id);
+				if (pit != presenceByAccount.end())
+				{
+					body += ",\"level\":";
+					body += std::to_string(pit->second.level);
+					body += ",\"zoneId\":";
+					body += std::to_string(pit->second.zoneId);
+				}
+				else
+				{
+					body += ",\"level\":null,\"zoneId\":null";
+				}
+			}
+			else
+			{
+				body += ",\"character\":null,\"level\":null,\"zoneId\":null";
+			}
+			body += "}";
+		}
+		body += "]}";
 		return body;
 	};
 
@@ -1413,8 +1530,10 @@ int main(int argc, char** argv)
 
 	LOG_INFO(Server, "[MAIN_SRV] SetPacketHandler OK");
 	int shardHeartbeatTimeoutSec = static_cast<int>(config.GetInt("shard.heartbeat_timeout_sec", 90));
-	shardRegistry.SetShardDownCallback([](uint32_t shard_id) {
+	shardRegistry.SetShardDownCallback([&playerPresenceCache](uint32_t shard_id) {
 		LOG_INFO(Net, "[ServerMain] Shard down event: shard_id={}", shard_id);
+		// Présence enrichie : un shard tombé ne rapporte plus ses joueurs -> purge.
+		playerPresenceCache.Clear(shard_id);
 	});
 	double degradedLoadThreshold = config.GetDouble("shard.degraded_load_threshold", 0.90);
 	shardRegistry.SetDegradedLoadThreshold(degradedLoadThreshold);

--- a/src/masterd/session/SessionCharacterMap.cpp
+++ b/src/masterd/session/SessionCharacterMap.cpp
@@ -111,6 +111,21 @@ namespace engine::server
 		return ids;
 	}
 
+	std::unordered_map<uint64_t, std::string> SessionCharacterMap::SnapshotAccountIdToCharacterName() const
+	{
+		std::lock_guard lock(m_mutex);
+		std::unordered_map<uint64_t, std::string> out;
+		out.reserve(m_byConn.size());
+		for (const auto& [connId, info] : m_byConn)
+		{
+			(void)connId;
+			if (info.accountId == 0)
+				continue;
+			out[info.accountId] = info.characterName;
+		}
+		return out;
+	}
+
 	SessionCharacterMap::RoleCounts SessionCharacterMap::CountByRole() const
 	{
 		std::lock_guard lock(m_mutex);

--- a/src/masterd/session/SessionCharacterMap.h
+++ b/src/masterd/session/SessionCharacterMap.h
@@ -68,6 +68,11 @@ namespace engine::server
 		/// n'apparaît qu'une fois même s'il avait (théoriquement) plusieurs connId.
 		std::vector<uint64_t> ListInWorldAccountIds() const;
 
+		/// Snapshot accountId → nom de personnage en jeu, pour la présence enrichie
+		/// (/online-accounts). Si un compte a (théoriquement) plusieurs connId, l'un
+		/// d'eux gagne arbitrairement. Comptes sans accountId (0) omis.
+		std::unordered_map<uint64_t, std::string> SnapshotAccountIdToCharacterName() const;
+
 		/// Ventilation de \ref Count() par rôle de compte. Utilisé par l'API /status
 		/// pour les sous-compteurs players_by_role.
 		RoleCounts CountByRole() const;

--- a/src/masterd/shards/ShardPlayerPresenceCache.cpp
+++ b/src/masterd/shards/ShardPlayerPresenceCache.cpp
@@ -1,0 +1,65 @@
+#include "src/masterd/shards/ShardPlayerPresenceCache.h"
+
+namespace engine::server
+{
+	void ShardPlayerPresenceCache::Update(uint32_t shardId, const std::vector<engine::network::ShardPlayerPresence>& players)
+	{
+		std::lock_guard lock(m_mutex);
+		// Retire d'abord toutes les entrées actuelles de ce shard (un joueur déconnecté
+		// disparaît du rapport et doit donc sortir du cache).
+		for (auto it = m_byAccount.begin(); it != m_byAccount.end();)
+		{
+			if (it->second.shardId == shardId)
+				it = m_byAccount.erase(it);
+			else
+				++it;
+		}
+		// Réinsère l'ensemble courant rapporté par le shard.
+		for (const auto& p : players)
+		{
+			if (p.accountId == 0)
+				continue;
+			Entry e;
+			e.accountId = p.accountId;
+			e.characterId = p.characterId;
+			e.level = p.level;
+			e.zoneId = p.zoneId;
+			e.shardId = shardId;
+			m_byAccount[p.accountId] = e;
+		}
+	}
+
+	void ShardPlayerPresenceCache::Clear(uint32_t shardId)
+	{
+		std::lock_guard lock(m_mutex);
+		for (auto it = m_byAccount.begin(); it != m_byAccount.end();)
+		{
+			if (it->second.shardId == shardId)
+				it = m_byAccount.erase(it);
+			else
+				++it;
+		}
+	}
+
+	std::optional<ShardPlayerPresenceCache::Entry> ShardPlayerPresenceCache::Get(uint64_t accountId) const
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_byAccount.find(accountId);
+		if (it == m_byAccount.end())
+			return std::nullopt;
+		return it->second;
+	}
+
+	std::vector<ShardPlayerPresenceCache::Entry> ShardPlayerPresenceCache::Snapshot() const
+	{
+		std::lock_guard lock(m_mutex);
+		std::vector<Entry> out;
+		out.reserve(m_byAccount.size());
+		for (const auto& [accountId, e] : m_byAccount)
+		{
+			(void)accountId;
+			out.push_back(e);
+		}
+		return out;
+	}
+}

--- a/src/masterd/shards/ShardPlayerPresenceCache.h
+++ b/src/masterd/shards/ShardPlayerPresenceCache.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "src/shared/network/ShardPayloads.h"
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	/// Cache en mémoire de la présence enrichie des joueurs en jeu, alimenté par les
+	/// heartbeats enrichis shard→master (protocole v9). Clé = accountId.
+	///
+	/// Source de vérité volontairement volatile : aucune persistance DB. Le shard
+	/// remonte périodiquement l'ensemble de ses joueurs ; \ref Update remplace donc
+	/// l'intégralité des entrées de ce shard à chaque heartbeat (un joueur disparu du
+	/// rapport sort naturellement du cache). \ref Clear purge un shard tombé.
+	///
+	/// Thread-safe : le heartbeat est traité sur le thread réseau master, la lecture
+	/// (\ref Get / \ref Snapshot) depuis le thread du HealthEndpoint.
+	class ShardPlayerPresenceCache
+	{
+	public:
+		struct Entry
+		{
+			uint64_t accountId = 0;
+			uint64_t characterId = 0;
+			uint32_t level = 0;
+			uint32_t zoneId = 0;
+			uint32_t shardId = 0;
+		};
+
+		/// Remplace l'ensemble des entrées appartenant à \a shardId par \a players.
+		/// Les joueurs absents du nouveau rapport (mais présents avant) sont retirés.
+		void Update(uint32_t shardId, const std::vector<engine::network::ShardPlayerPresence>& players);
+
+		/// Purge toutes les entrées d'un shard (appelé quand le shard tombe / est évincé).
+		void Clear(uint32_t shardId);
+
+		/// Retourne l'entrée pour \a accountId si présente.
+		std::optional<Entry> Get(uint64_t accountId) const;
+
+		/// Copie de toutes les entrées (pour l'API /online-accounts).
+		std::vector<Entry> Snapshot() const;
+
+	private:
+		mutable std::mutex m_mutex;
+		std::unordered_map<uint64_t, Entry> m_byAccount;
+	};
+}

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -190,6 +190,11 @@ int main(int argc, char** argv)
 	// Cohabite avec la stack TCP ticket + heartbeat + runtimes (ports/protocoles distincts).
 	engine::server::ServerApp gameplayApp(config);
 	gameplayApp.SetAdmittedCharacterRegistry(&admittedRegistry);
+	// Présence enrichie (web-portal) : le heartbeat shard→master joint la liste des
+	// joueurs en jeu {accountId, characterId, level, zoneId}. Le snapshot est publié à
+	// ~1 Hz par TickOnce (thread gameplay) et lu ici de façon thread-safe. La lambda
+	// capture gameplayApp par référence : elle vit jusqu'à la fin de main(), comme toMaster.
+	toMaster.SetPlayerPresenceProvider([&gameplayApp]() { return gameplayApp.GetPlayerPresenceSnapshot(); });
 	// TA.4 : pont position — pool MySQL (meme base que le master, cles db.* du config).
 	// Injecte dans ServerApp pour lire characters.spawn_x/y/z au HandleHello. DB non
 	// configuree => Init false => spawn depuis le fichier (pont inactif, non bloquant).

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -29,7 +29,11 @@ namespace engine::server
 	/// d'animation (emote/roulade/run/sprint/saut/…) pour que les autres joueurs voient
 	/// les bonnes animations au lieu d'un Idle/Walk dérivé de la vélocité.
 	/// Wire-breaking : client + shard doivent se déployer ensemble.
-	inline constexpr uint16_t kProtocolVersion = 8;
+	/// Présence enrichie — bump 8 → 9 : `SHARD_HEARTBEAT` (shard→master) gagne un
+	/// tableau optionnel de joueurs `{accountId, characterId, level, zoneId}` pour
+	/// alimenter la présence enrichie exposée au web-portal (login/perso/niveau/zone).
+	/// Wire-breaking interne : master + shard doivent se déployer ensemble.
+	inline constexpr uint16_t kProtocolVersion = 9;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -94,15 +94,46 @@ namespace engine::network
 		ShardHeartbeatPayload out;
 		if (!r.ReadU32(out.shard_id) || !r.ReadU32(out.current_load) || !r.ReadU64(out.timestamp))
 			return std::nullopt;
+		// v9 : tableau optionnel de joueurs en queue. Absent pour un heartbeat legacy
+		// (Remaining() == 0). Si présent, on lit u16 playerCount puis chaque entrée.
+		if (r.Remaining() > 0u)
+		{
+			uint16_t playerCount = 0;
+			if (!r.ReadU16(playerCount))
+				return std::nullopt;
+			out.players.reserve(playerCount);
+			for (uint16_t i = 0; i < playerCount; ++i)
+			{
+				ShardPlayerPresence p;
+				if (!r.ReadU64(p.accountId) || !r.ReadU64(p.characterId)
+					|| !r.ReadU32(p.level) || !r.ReadU32(p.zoneId))
+					return std::nullopt;
+				out.players.push_back(p);
+			}
+		}
 		return out;
 	}
 
-	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp)
+	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp,
+		const std::vector<ShardPlayerPresence>& players)
 	{
-		std::vector<uint8_t> buf(16u, 0u);
+		// 16 octets fixes + (si joueurs) u16 count + 24 octets/joueur.
+		const size_t total = players.empty() ? 16u : (16u + 2u + players.size() * 24u);
+		std::vector<uint8_t> buf(total, 0u);
 		ByteWriter w(buf.data(), buf.size());
 		if (!w.WriteU32(shard_id) || !w.WriteU32(current_load) || !w.WriteU64(timestamp))
 			return {};
+		if (!players.empty())
+		{
+			if (!w.WriteU16(static_cast<uint16_t>(players.size())))
+				return {};
+			for (const auto& p : players)
+			{
+				if (!w.WriteU64(p.accountId) || !w.WriteU64(p.characterId)
+					|| !w.WriteU32(p.level) || !w.WriteU32(p.zoneId))
+					return {};
+			}
+		}
 		return buf;
 	}
 

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -57,17 +57,32 @@ namespace engine::network
 	/// Builds SHARD_REGISTER_ERROR packet (Master→Shard).
 	std::vector<uint8_t> BuildShardRegisterErrorPacket(ShardRegisterErrorCode code, uint32_t requestId);
 
+	/// Présence d'un joueur en jeu remontée par le shard dans le heartbeat enrichi
+	/// (protocole v9). Alimente la présence enrichie exposée au web-portal.
+	struct ShardPlayerPresence
+	{
+		uint64_t accountId = 0;
+		uint64_t characterId = 0;
+		uint32_t level = 0;
+		uint32_t zoneId = 0;
+	};
+
 	/// Parsed SHARD_HEARTBEAT payload: shard_id, current_load, timestamp (M22.3).
+	/// v9 : `players` est rempli si le payload contient le tableau optionnel en queue
+	/// (vide pour un heartbeat legacy sans joueurs).
 	struct ShardHeartbeatPayload
 	{
 		uint32_t shard_id = 0;
 		uint32_t current_load = 0;
 		uint64_t timestamp = 0;
+		std::vector<ShardPlayerPresence> players;
 	};
 	std::optional<ShardHeartbeatPayload> ParseShardHeartbeatPayload(const uint8_t* payload, size_t payloadSize);
 
 	/// Builds SHARD_HEARTBEAT payload (Shard→Master). timestamp: e.g. seconds since epoch or monotonic.
-	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0);
+	/// \param players liste optionnelle des joueurs en jeu (présence enrichie v9). Vide = heartbeat legacy.
+	std::vector<uint8_t> BuildShardHeartbeatPayload(uint32_t shard_id, uint32_t current_load, uint64_t timestamp = 0,
+		const std::vector<ShardPlayerPresence>& players = {});
 
 	/// Parsed MASTER_TO_SHARD_ADMIT_CHARACTER payload : (account_id, character_id, character_name, gender).
 	/// Émis par le master (CharacterEnterWorldHandler) à destination du shard via la

--- a/src/shared/network/ShardPayloadsTests.cpp
+++ b/src/shared/network/ShardPayloadsTests.cpp
@@ -1,0 +1,91 @@
+/**
+ * Tests unitaires — round-trip du payload SHARD_HEARTBEAT enrichi (protocole v9).
+ * Pur (pas de réseau, pas de DB). Retourne 0 si OK, non-zéro sinon.
+ *
+ * Couvre :
+ *  - heartbeat legacy (0 joueur) : build/parse, players vide.
+ *  - heartbeat enrichi (N joueurs) : chaque champ {accountId, characterId, level, zoneId}
+ *    fait l'aller-retour.
+ */
+
+#include "src/shared/network/ShardPayloads.h"
+
+#include <cstdlib>
+#include <iostream>
+
+using engine::network::ShardPlayerPresence;
+using engine::network::BuildShardHeartbeatPayload;
+using engine::network::ParseShardHeartbeatPayload;
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+static void TestHeartbeatLegacyNoPlayers()
+{
+	auto buf = BuildShardHeartbeatPayload(7u, 3u, 123456u);
+	Assert(buf.size() == 16u, "legacy heartbeat fait 16 octets (pas de tableau joueurs)");
+	auto parsed = ParseShardHeartbeatPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "parse legacy OK");
+	if (parsed)
+	{
+		Assert(parsed->shard_id == 7u, "shard_id round-trip");
+		Assert(parsed->current_load == 3u, "current_load round-trip");
+		Assert(parsed->timestamp == 123456u, "timestamp round-trip");
+		Assert(parsed->players.empty(), "players vide en legacy");
+	}
+}
+
+static void TestHeartbeatWithPlayers()
+{
+	std::vector<ShardPlayerPresence> players = {
+		{ 1ull, 100ull, 7u, 42u },
+		{ 2ull, 200ull, 1u, 0u },
+		{ 9999ull, 123456ull, 60u, 1337u },
+	};
+	auto buf = BuildShardHeartbeatPayload(5u, 3u, 999u, players);
+	Assert(buf.size() == 16u + 2u + 3u * 24u, "taille = 16 + 2 + 3*24");
+	auto parsed = ParseShardHeartbeatPayload(buf.data(), buf.size());
+	Assert(parsed.has_value(), "parse enrichi OK");
+	if (parsed)
+	{
+		Assert(parsed->shard_id == 5u, "shard_id round-trip (enrichi)");
+		Assert(parsed->current_load == 3u, "current_load round-trip (enrichi)");
+		Assert(parsed->players.size() == 3u, "3 joueurs parsés");
+		if (parsed->players.size() == 3u)
+		{
+			Assert(parsed->players[0].accountId == 1ull && parsed->players[0].characterId == 100ull
+				&& parsed->players[0].level == 7u && parsed->players[0].zoneId == 42u, "joueur 0 round-trip complet");
+			Assert(parsed->players[2].accountId == 9999ull && parsed->players[2].characterId == 123456ull
+				&& parsed->players[2].level == 60u && parsed->players[2].zoneId == 1337u, "joueur 2 round-trip complet");
+		}
+	}
+}
+
+static void TestHeartbeatTruncatedRejected()
+{
+	// Tableau annoncé (count=1) mais octets joueur tronqués -> parse échoue.
+	std::vector<ShardPlayerPresence> players = { { 1ull, 100ull, 7u, 42u } };
+	auto buf = BuildShardHeartbeatPayload(5u, 0u, 0u, players);
+	buf.resize(buf.size() - 4u); // ampute le dernier u32 (zoneId)
+	auto parsed = ParseShardHeartbeatPayload(buf.data(), buf.size());
+	Assert(!parsed.has_value(), "payload tronqué rejeté (nullopt)");
+}
+
+int main()
+{
+	TestHeartbeatLegacyNoPlayers();
+	TestHeartbeatWithPlayers();
+	TestHeartbeatTruncatedRejected();
+	std::cerr << (s_failCount == 0 ? "[OK] all shard_payloads tests passed\n" : "[FAIL] some tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -148,7 +148,11 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 		LOG_DEBUG(Net, "[STMC] SendHeartbeat shard_id={} load={}", m_shard_id, m_current_load);
 		uint64_t timestamp = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(
 			std::chrono::steady_clock::now().time_since_epoch()).count());
-		auto payload = BuildShardHeartbeatPayload(m_shard_id, m_current_load, timestamp);
+		// Présence enrichie (v9) : joint la liste des joueurs si un fournisseur est câblé.
+		std::vector<ShardPlayerPresence> players;
+		if (m_presence_provider)
+			players = m_presence_provider();
+		auto payload = BuildShardHeartbeatPayload(m_shard_id, m_current_load, timestamp, players);
 		if (payload.empty())
 			return;
 		PacketBuilder builder;

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -2,6 +2,7 @@
 
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/network/ServerMeta.h"
+#include "src/shared/network/ShardPayloads.h"
 
 #include <chrono>
 #include <cstdint>
@@ -9,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace engine::network
 {
@@ -51,6 +53,13 @@ namespace engine::network
 
 		/// Heartbeat interval in seconds. Default 10. Call before Start() to take effect.
 		void SetHeartbeatIntervalSec(int sec) { m_heartbeat_interval_sec = (sec > 0) ? sec : 10; }
+
+		/// Présence enrichie (v9) : fournisseur optionnel appelé à chaque heartbeat pour
+		/// joindre la liste des joueurs en jeu `{accountId, characterId, level, zoneId}`.
+		/// Doit renvoyer un snapshot cohérent (typiquement construit sur le thread monde).
+		/// `nullptr` (défaut) = heartbeat legacy sans tableau joueurs.
+		using PlayerPresenceProvider = std::function<std::vector<ShardPlayerPresence>()>;
+		void SetPlayerPresenceProvider(PlayerPresenceProvider provider) { m_presence_provider = std::move(provider); }
 
 		/// TA.3 — Callback invoqué quand le master pousse un `kOpcodeMasterToShardAdmitCharacter`
 		/// (suite à un EnterWorld réussi côté master). Le destinataire typique alimente
@@ -106,5 +115,7 @@ namespace engine::network
 		int m_heartbeat_interval_sec = 10;
 		/// TA.3 — callback admission (master push). Voir SetAdmitCharacterCallback.
 		AdmitCharacterCallback m_admit_callback;
+		/// Présence enrichie (v9) — fournisseur optionnel de la liste des joueurs. Voir SetPlayerPresenceProvider.
+		PlayerPresenceProvider m_presence_provider;
 	};
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -982,7 +982,7 @@ namespace engine::server
 	}
 
 	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender)
+		std::string& outName, std::string& outGender, uint32_t& outLevel)
 	{
 #if defined(SHARD_POSITION_DB)
 		if (m_characterDbPool == nullptr || characterId == 0u)
@@ -998,9 +998,10 @@ namespace engine::server
 		}
 		// TD.5 — on fetch aussi `name` pour le SnapshotEntity (plaque de nom).
 		// TD.6 — et `gender` (migration 0067) pour le rendu de l'avatar distant.
+		// Présence enrichie — `level` (migration 0004) pour la présence web-portal.
 		// N1-I : prepared statement (bind characterId). Floats lus via GetString + strtof.
 		auto* stmt = cache->Acquire(mysql,
-			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender FROM characters "
+			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender, level FROM characters "
 			"WHERE id = ? AND deleted_at IS NULL");
 		if (!stmt || !stmt->Bind(0, characterId) || !stmt->Execute() || !stmt->FetchRow())
 		{
@@ -1012,9 +1013,12 @@ namespace engine::server
 		yawDeg = std::strtof(stmt->GetString(3).c_str(), nullptr);
 		outName = stmt->GetString(4);
 		outGender = stmt->GetString(5);
+		outLevel = static_cast<uint32_t>(std::strtoul(stmt->GetString(6).c_str(), nullptr, 10));
+		if (outLevel == 0u)
+			outLevel = 1u; // garde-fou : niveau minimal 1.
 		return true;
 #else
-		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender;
+		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender; (void)outLevel;
 		return false;
 #endif
 	}
@@ -1173,7 +1177,8 @@ namespace engine::server
 			float dbX = 0.0f, dbY = 0.0f, dbZ = 0.0f, dbYawDeg = 0.0f;
 			std::string dbName;
 			std::string dbGender;
-			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender))
+			uint32_t dbLevel = 1u;
+			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender, dbLevel))
 			{
 				acceptedClient.positionMetersX = dbX;
 				acceptedClient.positionMetersY = dbY;
@@ -1183,6 +1188,8 @@ namespace engine::server
 				acceptedClient.characterName = std::move(dbName);
 				// TD.6 — genre du personnage destiné au rendu des avatars distants.
 				acceptedClient.gender = std::move(dbGender);
+				// Présence enrichie — niveau (table characters) reporté au master via heartbeat.
+				acceptedClient.level = dbLevel;
 				LOG_INFO(Net,
 					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", gender=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
 					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, acceptedClient.gender, dbX, dbY, dbZ);
@@ -1456,7 +1463,43 @@ namespace engine::server
 				m_clients.size(),
 				m_transport.ReceivedPacketCount(),
 				m_transport.SentPacketCount());
+
+			// Présence enrichie (web-portal) : republie le snapshot des joueurs en jeu à
+			// ~1 Hz (suffisant pour un affichage admin, et évite de reconstruire à chaque
+			// tick). Construit ici sur le thread gameplay (accès direct à m_clients), puis
+			// publié sous mutex pour lecture par GetPlayerPresenceSnapshot (autre thread).
+			std::vector<engine::network::ShardPlayerPresence> snapshot;
+			snapshot.reserve(m_clients.size());
+			const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+			for (const auto& client : m_clients)
+			{
+				const uint64_t characterId = client.persistenceCharacterKey;
+				if (characterId == 0u)
+					continue;
+				uint64_t accountId = 0u;
+				if (m_admittedRegistry != nullptr)
+					accountId = m_admittedRegistry->AdmittedAccountId(characterId, nowMs);
+				if (accountId == 0u)
+					continue; // accountId non résolu (registre absent / expiré) : omis.
+				engine::network::ShardPlayerPresence p;
+				p.accountId = accountId;
+				p.characterId = characterId;
+				p.level = client.level;
+				p.zoneId = client.zoneId;
+				snapshot.push_back(p);
+			}
+			{
+				std::lock_guard<std::mutex> lock(m_presenceMutex);
+				m_presenceSnapshot = std::move(snapshot);
+			}
 		}
+	}
+
+	std::vector<engine::network::ShardPlayerPresence> ServerApp::GetPlayerPresenceSnapshot() const
+	{
+		std::lock_guard<std::mutex> lock(m_presenceMutex);
+		return m_presenceSnapshot;
 	}
 
 	void ServerApp::Simulate()

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -17,6 +17,7 @@
 #include "src/shared/net/ChatSystem.h"
 #include "src/shardd/gameplay/chat/ChatCommandParser.h"
 #include "src/shared/network/ReplicationTypes.h"
+#include "src/shared/network/ShardPayloads.h"
 #include "src/shared/security/SecurityAuditLog.h"
 #include "src/shardd/anticheat/AntiCheatGameplay.h"
 #include "src/shared/network/ServerProtocol.h"
@@ -109,6 +110,9 @@ namespace engine::server
 		/// pour permettre au client de sélectionner le mesh skinné des avatars distants.
 		std::string gender;
 		uint32_t experiencePoints = 0;
+		/// Niveau du personnage (table characters.level, chargé au Hello via LoadSpawnFromDb).
+		/// Reporté au master dans le heartbeat enrichi (présence web-portal).
+		uint32_t level = 1;
 		uint32_t gold = 0;
 		/// M35.1 — additional currencies (wallet); gold remains primary trade currency.
 		uint32_t honor = 0;
@@ -262,6 +266,13 @@ namespace engine::server
 		/// registre appartient à l'appelant (shardd/main_linux) et doit survivre à ServerApp.
 		void SetAdmittedCharacterRegistry(AdmittedCharacterRegistry* registry) { m_admittedRegistry = registry; }
 
+		/// Présence enrichie (web-portal) : snapshot thread-safe des joueurs en jeu
+		/// `{accountId, characterId, level, zoneId}`. Publié à chaque TickOnce (thread
+		/// gameplay) et lu ici depuis un AUTRE thread (boucle shard→master). Renvoie une
+		/// copie sous mutex. accountId est résolu via l'AdmittedCharacterRegistry ; une
+		/// entrée dont l'accountId n'a pu être résolu (0) est omise.
+		std::vector<engine::network::ShardPlayerPresence> GetPlayerPresenceSnapshot() const;
+
 		/// TA.4 : pool MySQL (même base que le master) d'où lire la position de spawn
 		/// (table characters) au HandleHello. Optionnel : absent → spawn depuis le fichier
 		/// (build Windows ou DB non configurée). Possédé par l'appelant.
@@ -312,7 +323,7 @@ namespace engine::server
 		/// Renvoie false si pas de pool DB (Windows / DB non configurée) ou si character
 		/// introuvable ; dans ce cas les out-params ne sont pas modifiés.
 		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender);
+		std::string& outName, std::string& outGender, uint32_t& outLevel);
 
 		/// Accept a new client or refresh an existing handshake.
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).
@@ -825,6 +836,11 @@ namespace engine::server
 		UdpTransport m_transport;
 		std::vector<Datagram> m_pendingDatagrams;
 		std::vector<ConnectedClient> m_clients;
+		/// Présence enrichie : snapshot publié à chaque TickOnce (thread gameplay) et lu
+		/// par GetPlayerPresenceSnapshot depuis le thread shard→master. Protégé par son
+		/// propre mutex pour découpler les deux threads sans verrouiller m_clients.
+		mutable std::mutex m_presenceMutex;
+		std::vector<engine::network::ShardPlayerPresence> m_presenceSnapshot;
 		/// TG.2 : index O(1) sur m_clients pour les 3 lookups chauds (Find/FindByEntityId/
 		/// FindConnectedClient). Valeurs = index dans m_clients ; clé endpoint = (address<<16)|port.
 		/// Maintenance : insertion incrémentale dans HandleHello, reconstruction complète dans


### PR DESCRIPTION
## Présence en ligne enrichie — côté serveur (protocole v9)

Enrichit `GET /online-accounts` (master) avec, par joueur en ligne : **login**, **nom du personnage**, **niveau**, **zone in-game (zoneId)**.

### Protocole (wire-breaking → ⚠️ master + shard en lock-step)
- `kProtocolVersion` **8 → 9**.
- `SHARD_HEARTBEAT` gagne un tableau optionnel de joueurs `{accountId, characterId, level, zoneId}` (24 o/joueur, précédé d'un `u16` count). Parsing tolérant (heartbeat legacy sans tableau → `players` vide). Round-trip couvert par `shard_payloads_tests`.

### Shard
- `ServerApp` charge `characters.level` au Hello (`LoadSpawnFromDb`) → `ConnectedClient.level`.
- À ~1 Hz, `TickOnce` publie un **snapshot de présence thread-safe** (`accountId` résolu via `AdmittedCharacterRegistry`) ; `GetPlayerPresenceSnapshot()` le lit depuis le thread shard→master.
- `ShardToMasterClient` joint ce snapshot au heartbeat (provider injecté).

### Master
- Nouveau `ShardPlayerPresenceCache` (clé `accountId`), alimenté par `HandleHeartbeat`, **purgé au shard-down**.
- `/online-accounts` enrichi d'un tableau `players` `{accountId, login, character, level, zoneId, inWorld}` : `login` via MySQL `accounts`, `character` via `SessionCharacterMap`, `level`/`zoneId` via le cache. Les tableaux `authenticated`/`inWorld` restent (rétro-compat pastille).

Spec : `docs/superpowers/specs/2026-05-31-online-presence-enriched-design.md`.

**Déploiement** : ⚠️ **redéploiement master ET shard en lock-step** (bump protocole v9). La PR portail (UI) suit, client only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
