### PR TITLE
feat(portal): présence enrichie (login/perso/niveau/région) dans Gestion des joueurs

### DIFF
--- a/web-portal/app/admin/players/page.tsx
+++ b/web-portal/app/admin/players/page.tsx
@@ -6,16 +6,27 @@ import { getSession } from '@/lib/auth/session'
 import { isStaff, type AccountRole } from '@/lib/auth/roles'
 import type { RowDataPacket } from 'mysql2/promise'
 import { PlayerActions, type PlayerRow } from '@/components/admin/PlayerActions'
-import { fetchOnlineAccounts, presenceFor, type PlayerPresence } from '@/lib/serverStatus'
+import { fetchOnlineAccounts, presenceFor, type PlayerPresence, type OnlinePlayer } from '@/lib/serverStatus'
+import { regionName } from '@/lib/zones'
 
-/** Pastille de présence affichée à droite du nom du joueur (3 états). */
-function PresenceDot({ presence }: { presence: PlayerPresence }) {
+/** Pastille de présence affichée à droite du nom du joueur (3 états).
+ *  Le tooltip est enrichi (perso / niveau / région) si l'info est disponible. */
+function PresenceDot({ presence, detail }: { presence: PlayerPresence; detail?: OnlinePlayer }) {
   if (presence === 'offline') return null
   const inWorld = presence === 'in_world'
+  const base = inWorld ? 'En jeu' : 'Connecté (menu)'
+  let title = base
+  if (inWorld && detail) {
+    const parts: string[] = []
+    if (detail.character) parts.push(detail.character)
+    if (detail.level != null) parts.push(`niveau ${detail.level}`)
+    if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
+    if (parts.length > 0) title = `${base} — ${parts.join(' • ')}`
+  }
   return (
     <span
-      title={inWorld ? 'En jeu' : 'Connecté (menu)'}
-      aria-label={inWorld ? 'En jeu' : 'Connecté (menu)'}
+      title={title}
+      aria-label={title}
       style={{
         display: 'inline-block',
         width: 9,
@@ -27,6 +38,21 @@ function PresenceDot({ presence }: { presence: PlayerPresence }) {
         boxShadow: inWorld ? '0 0 5px rgba(95,184,110,.6)' : 'none',
       }}
     />
+  )
+}
+
+/** Ligne discrète sous le nom : perso • niveau N • région (joueurs en jeu seulement). */
+function OnlineDetailLine({ detail }: { detail?: OnlinePlayer }) {
+  if (!detail || !detail.inWorld) return null
+  const parts: string[] = []
+  if (detail.character) parts.push(detail.character)
+  if (detail.level != null) parts.push(`niveau ${detail.level}`)
+  if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
+  if (parts.length === 0) return null
+  return (
+    <div style={{ marginTop: 3, fontFamily: 'var(--font-body)', fontSize: 11.5, color: 'var(--ln-success)' }}>
+      {parts.join('  •  ')}
+    </div>
   )
 }
 
@@ -203,6 +229,7 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
             const st = statusLabel(player.account_status)
             const em = emailBadge(player.email_verified)
             const displayName = player.tag_id ?? player.login
+            const onlineDetail = online.players.get(player.id)
             const cguOk = player.accepted_cgu_count >= player.published_cgu_count && player.published_cgu_count > 0
             const cguLabel = `${player.accepted_cgu_count}/${player.published_cgu_count} acceptée${player.published_cgu_count !== 1 ? 's' : ''}`
 
@@ -216,7 +243,7 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
                       <span style={{ fontFamily: 'var(--font-display)', fontSize: 13, letterSpacing: '.12em', color: 'var(--ln-accent)' }}>
                         {displayName}
                       </span>
-                      <PresenceDot presence={presenceFor(player.id, online)} />
+                      <PresenceDot presence={presenceFor(player.id, online)} detail={onlineDetail} />
                       {player.tag_id && (
                         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ln-muted)' }}>
                           ({player.login})
@@ -229,6 +256,7 @@ export default async function AdminPlayersPage({ searchParams }: PageProps) {
                     <div style={{ marginTop: 4, fontFamily: 'var(--font-body)', fontSize: 12, color: 'var(--ln-muted)' }}>
                       {player.email}
                     </div>
+                    <OnlineDetailLine detail={onlineDetail} />
                   </div>
 
                   {/* Badges */}

--- a/web-portal/lib/serverStatus.ts
+++ b/web-portal/lib/serverStatus.ts
@@ -18,12 +18,24 @@
 
 import { logWarn } from "@/lib/log";
 
+/** Détail enrichi d'un joueur en ligne (présence v9). Champs perso null si pas en jeu. */
+export interface OnlinePlayer {
+  accountId: number;
+  login: string | null;
+  character: string | null;
+  level: number | null;
+  zoneId: number | null;
+  inWorld: boolean;
+}
+
 export interface OnlineAccounts {
   authenticated: Set<number>;
   inWorld: Set<number>;
+  /** Détails enrichis indexés par accountId (vide si le master ne renvoie pas "players"). */
+  players: Map<number, OnlinePlayer>;
 }
 
-const EMPTY: OnlineAccounts = { authenticated: new Set(), inWorld: new Set() };
+const EMPTY: OnlineAccounts = { authenticated: new Set(), inWorld: new Set(), players: new Map() };
 
 function toIdSet(value: unknown): Set<number> {
   if (!Array.isArray(value)) return new Set();
@@ -31,6 +43,38 @@ function toIdSet(value: unknown): Set<number> {
   for (const item of value) {
     const id = typeof item === "number" ? item : Number(item);
     if (Number.isFinite(id) && id > 0) out.add(id);
+  }
+  return out;
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// Parse le tableau "players" enrichi (présence v9). Rétro-compat : si absent ou
+// malformé, renvoie une map vide (les pastilles s'appuient alors sur les sets).
+function toPlayerMap(value: unknown): Map<number, OnlinePlayer> {
+  const out = new Map<number, OnlinePlayer>();
+  if (!Array.isArray(value)) return out;
+  for (const item of value) {
+    if (typeof item !== "object" || item === null) continue;
+    const row = item as Record<string, unknown>;
+    const accountId = toNumberOrNull(row.accountId);
+    if (accountId === null || accountId <= 0) continue;
+    out.set(accountId, {
+      accountId,
+      login: toStringOrNull(row.login),
+      character: toStringOrNull(row.character),
+      level: toNumberOrNull(row.level),
+      zoneId: toNumberOrNull(row.zoneId),
+      inWorld: row.inWorld === true,
+    });
   }
   return out;
 }
@@ -61,10 +105,11 @@ export async function fetchOnlineAccounts(): Promise<OnlineAccounts> {
       logWarn("serverStatus", "Master /online-accounts a répondu en erreur.", { url, status: response.status });
       return EMPTY;
     }
-    const payload = (await response.json()) as { authenticated?: unknown; inWorld?: unknown };
+    const payload = (await response.json()) as { authenticated?: unknown; inWorld?: unknown; players?: unknown };
     return {
       authenticated: toIdSet(payload.authenticated),
       inWorld: toIdSet(payload.inWorld),
+      players: toPlayerMap(payload.players),
     };
   } catch (err) {
     // Master injoignable / timeout / JSON invalide : on logge l'URL et l'erreur

--- a/web-portal/lib/zones.ts
+++ b/web-portal/lib/zones.ts
@@ -1,0 +1,18 @@
+// Résolution zoneId → nom de région lisible pour l'affichage admin (présence
+// enrichie). Le master/shard transmet un `zoneId` numérique ; la "présentation"
+// (nom humain) vit ici, côté portail, pour rester facilement éditable sans
+// toucher au serveur.
+//
+// Table volontairement maintenable à la main : compléter au fur et à mesure que
+// des zones stables sont définies côté jeu (game/data/zones). Tout zoneId absent
+// retombe sur « Zone {id} ».
+
+const ZONE_NAMES: Record<number, string> = {
+  // 42: "Forêt tempérée",   // exemple — à compléter avec les zoneId réels du jeu
+};
+
+/** Nom de région pour un zoneId. Fallback « Zone {id} ». null/0 → « — ». */
+export function regionName(zoneId: number | null | undefined): string {
+  if (zoneId === null || zoneId === undefined || zoneId <= 0) return "—";
+  return ZONE_NAMES[zoneId] ?? `Zone ${zoneId}`;
+}


### PR DESCRIPTION
## Présence en ligne enrichie — UI portail (client only)

Affiche login / nom de perso / niveau / région dans **Admin → Gestion des joueurs**, à partir du tableau `players` enrichi de `/online-accounts` (présence v9, PR serveur #770).

- `lib/serverStatus.ts` : type `OnlinePlayer` + parse défensif de `players` (Map indexée par `accountId`). **Rétro-compat** : si le master ne renvoie pas encore `players`, la map est vide et seules les pastilles restent (comportement inchangé).
- `lib/zones.ts` : `regionName(zoneId)` — table maintenable côté portail + fallback « Zone {id} ».
- `app/admin/players/page.tsx` : ligne discrète sous le nom (`perso • niveau N • région`) pour les joueurs **en jeu**, et **tooltip de pastille enrichi**.

**Déploiement** : ✅ portail uniquement. À déployer **après** la PR serveur #770 (master+shard) pour que les champs enrichis apparaissent ; sans elle, dégradation gracieuse (pastille seule).

> ⚠️ Conflit potentiel avec la PR #769 (qui modifie aussi `serverStatus.ts`). Merger #769 d'abord puis rebaser, ou l'inverse — je peux gérer le merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
