### PR TITLE
feat(shard): présence unifiée Phase 1 — FriendSystem consulte ShardPresenceService

### DIFF
--- a/docs/superpowers/specs/2026-05-31-unified-presence-service-design.md
+++ b/docs/superpowers/specs/2026-05-31-unified-presence-service-design.md
@@ -1,0 +1,117 @@
+# Design — Service de présence unifié (hybride 2 niveaux)
+
+Date : 2026-05-31
+Branche : `feat/presence-service-consolidation`
+
+## Problème
+
+La présence « joueur en ligne (+ où) » est aujourd'hui dupliquée dans **plusieurs
+stockages indépendants qui peuvent diverger** :
+
+| Stockage | Côté | Contenu | Consommateur |
+|---|---|---|---|
+| `FriendSystem.m_presence` | shard | online/offline + nom | liste d'amis, notifs |
+| `GuildSystem.m_onlinePlayers` | shard | set d'ids en ligne | routage guild-chat |
+| `SessionManager` | master | sessions authentifiées | auth |
+| `SessionCharacterMap` | master | perso en jeu par conn | chat, /status |
+| `ShardPlayerPresenceCache` | master | online + zone + niveau | web-portal |
+
+Objectif (demande utilisateur) : **une seule autorité de présence**. Un service
+dit si un joueur est en ligne et, si oui, donne l'info (zone, niveau…). Les
+systèmes amis / groupes / guildes / raids **s'y réfèrent** au lieu de tenir
+chacun leur propre comptabilité.
+
+## Décision : hybride à 2 niveaux
+
+Une seule **source par niveau**, avec une synchro claire (le shard pousse, le
+master agrège — c'est déjà le mécanisme du heartbeat enrichi).
+
+### Niveau 1 — `ShardPresenceService` (shard, NOUVEAU)
+Autorité **locale** des joueurs connectés à CE shard. Sert les chemins chauds
+(routage guild-chat, notifs amis même-shard) sans aller-retour réseau.
+
+- Enregistrement : `{ accountId, characterId, characterName, level, zoneId, status }`
+  (`status` ∈ Online/Away/Busy, cf. `PresenceStatus`).
+- API : `SetOnline(...)`, `SetOffline(accountId)`, `UpdateZone(accountId, zoneId)`,
+  `UpdateLevel(accountId, level)`, `Get(accountId)`, `IsOnline(accountId)`,
+  `Snapshot()`, `OnlineAccountIdsAmong(const std::vector<uint64_t>&)`.
+- Propriété : `ServerApp`. Alimenté aux hooks login (`HandleHello`) / logout
+  (`HandleGoodbye` / éviction) et sur changement de zone/niveau.
+- C'est aussi LUI qui produit le snapshot envoyé au master via le heartbeat
+  (remplace l'itération ad hoc de `m_clients` introduite côté #770).
+
+### Niveau 2 — `GlobalPresenceService` (master) = `ShardPlayerPresenceCache` (existant, renommé/élargi)
+Autorité **globale** : agrège la présence de **tous** les shards via les
+heartbeats enrichis (PR #770). Seule source pour « le joueur X est-il en ligne
+quelque part, et où (shard, zone, niveau) ». Cross-shard natif.
+
+- Entrée : `{ accountId, characterId, level, zoneId, shardId, lastUpdate }`.
+- Alimenté par `HandleHeartbeat` (déjà fait), purgé au shard-down (déjà fait).
+- Consommateurs : web-portal (`/online-accounts`, déjà fait) ; futurs handlers
+  master cross-shard (amis/guilde/raid répartis sur plusieurs shards).
+
+### Synchro Niveau 1 → Niveau 2
+`ShardPresenceService.Snapshot()` → heartbeat (`ShardPlayerPresence[]`, PR #770)
+→ `GlobalPresenceService.Update(shardId, …)`. Aucun nouveau canal : on formalise
+ce que #770 a déjà câblé.
+
+## Qui consulte quoi
+
+| Consommateur | Question | Niveau |
+|---|---|---|
+| Routage guild-chat (même shard, hot) | qui de la guilde est connecté ici ? | 1 (local) |
+| Liste d'amis « en ligne ? » (même shard) | mon ami connecté ici ? | 1 (local) |
+| Liste d'amis / guilde **cross-shard** | mon ami sur un AUTRE shard ? où ? | 2 (master) |
+| Web-portal | tous les joueurs en ligne + où | 2 (master) |
+| Futur : groupe / raid « où sont les membres » | localisation des membres | 1 si même shard, sinon 2 |
+
+Tant qu'un seul shard tourne, le Niveau 1 répond à tout ; le Niveau 2 reste
+indispensable pour le portail et pour le jour où il y aura plusieurs shards.
+
+## Migration (incrémentale, sans big-bang)
+
+- **Phase 1 — Amis (cette itération)** : introduire `ShardPresenceService` ;
+  faire pointer `FriendSystem` dessus ; **supprimer `FriendSystem.m_presence`**
+  (et `SetPresence/SetOffline/GetPresence` deviennent des délégations ou sont
+  retirés au profit du service). Comportement fonctionnel identique (même-shard).
+- **Phase 2 — Guilde** : retirer `GuildSystem.m_onlinePlayers` ; le routage
+  guild-chat interroge `ShardPresenceService`.
+- **Phase 3 — Cross-shard + nouveaux consommateurs** : handler master exposant
+  « où est le compte X » à partir du Niveau 2 ; Party/Raid (à venir) consomment
+  le même contrat. Décommissionner les reliquats.
+
+Chaque phase = sa propre PR, testable et déployable seule (lock-step master+shard
+seulement si la phase touche le wire ; Phase 1 est shard-only).
+
+## Relation avec les PR en cours
+
+- **#770 (serveur, heartbeat v9 + cache master)** : devient officiellement la
+  **synchro Niveau 1 → Niveau 2** et le **Niveau 2**. À conserver/merger.
+- **#771 (portail)** : consommateur du Niveau 2. À conserver.
+- Ce design **ne remet pas en cause** #770/#771 ; il les cadre et enchaîne la
+  consolidation des stockages shard (Friend/Guild) derrière le Niveau 1.
+
+## Composants & frontières (clarté/isolation)
+
+- `ShardPresenceService` : un fichier, une responsabilité (présence locale).
+  Testable isolément (set/clear/get/zone/level, OnlineAccountIdsAmong).
+- `GlobalPresenceService` : déjà isolé (`ShardPlayerPresenceCache`), thread-safe.
+- `FriendSystem` / `GuildSystem` : perdent la responsabilité « présence » et
+  gagnent une **dépendance** explicite vers `ShardPresenceService` (pointeur
+  injecté par ServerApp, comme `AdmittedCharacterRegistry`).
+
+## Tests
+
+- `ShardPresenceServiceTests` : online/offline, update zone/niveau, IsOnline,
+  OnlineAccountIdsAmong, snapshot.
+- `FriendSystem` (Phase 1) : les requêtes de présence reflètent le service
+  (pas de map interne). Adapter les tests existants si présents.
+- Le round-trip heartbeat reste couvert par `shard_payloads_tests` (#770).
+
+## Non-objectifs (YAGNI)
+
+- Pas de persistance DB de la présence (volatile, reconstruite à la connexion).
+- Pas de statuts riches au-delà de `PresenceStatus` existant (Online/Away/Busy).
+- Phase 1 ne touche PAS le wire (shard-only) ; pas de bump protocole.
+- Pas de refonte du chat ni des opcodes amis/guilde dans ce design — seulement
+  la **source de présence** qu'ils consultent.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shardd/main_win.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/server_bootstrap/ServerApp.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/AdmittedCharacterRegistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/chat/ChatCommandParser.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ServerProtocol.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/FriendSystem.cpp
@@ -859,6 +860,16 @@ elseif(UNIX)
   target_compile_options(shard_payloads_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME shard_payloads_tests COMMAND shard_payloads_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Présence unifiée (Niveau 1) : ShardPresenceService — présence shard-locale.
+  add_executable(shard_presence_service_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceServiceTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
+  )
+  target_include_directories(shard_presence_service_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(shard_presence_service_tests PRIVATE pthread)
+  target_compile_options(shard_presence_service_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME shard_presence_service_tests COMMAND shard_presence_service_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # M22.5: Server list and shard selection policy tests
   add_executable(server_list_policy_tests
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ServerListPolicyTests.cpp
@@ -929,6 +940,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/server_bootstrap/ServerApp.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/AdmittedCharacterRegistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/TickScheduler.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/SpatialPartition.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/GridState.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ServerListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/TermsPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/FriendSystem.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/PartySystem.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/guild/GuildSystem.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/guild/GuildTabard.cpp

--- a/src/shardd/gameplay/social/FriendSystem.cpp
+++ b/src/shardd/gameplay/social/FriendSystem.cpp
@@ -4,6 +4,7 @@
 // mode: presence tracking is fully functional; persistent DB operations are skipped.
 
 #include "src/shardd/gameplay/social/FriendSystem.h"
+#include "src/shardd/world/ShardPresenceService.h"
 #include "src/shared/core/Log.h"
 
 #if ENGINE_HAS_MYSQL
@@ -83,7 +84,7 @@ namespace engine::server
 
 	void FriendSystem::Shutdown()
 	{
-		m_presence.clear();
+		m_presenceService = nullptr;
 		m_requestRateLimit.clear();
 		m_initialized = false;
 		LOG_INFO(Core, "[FriendSystem] Destroyed");
@@ -423,35 +424,14 @@ namespace engine::server
 	}
 
 	// -------------------------------------------------------------------------
-	// Presence tracking
+	// Presence (déléguée à l'autorité unique ShardPresenceService, par character_id)
 	// -------------------------------------------------------------------------
 
-	void FriendSystem::SetPresence(uint64_t playerId, std::string_view playerName, PresenceStatus status)
+	PresenceStatus FriendSystem::GetPresence(uint64_t characterId) const
 	{
-		auto& entry       = m_presence[playerId];
-		entry.playerId    = playerId;
-		entry.playerName  = std::string(playerName);
-		entry.presence    = status;
-		LOG_DEBUG(Core, "[FriendSystem] Presence updated: player {} ('{}') status={}",
-			playerId, playerName, static_cast<int>(status));
-	}
-
-	void FriendSystem::SetOffline(uint64_t playerId)
-	{
-		auto it = m_presence.find(playerId);
-		if (it != m_presence.end())
-		{
-			LOG_DEBUG(Core, "[FriendSystem] Player {} ('{}') went offline", playerId, it->second.playerName);
-			m_presence.erase(it);
-		}
-	}
-
-	PresenceStatus FriendSystem::GetPresence(uint64_t playerId) const
-	{
-		auto it = m_presence.find(playerId);
-		if (it == m_presence.end())
+		if (m_presenceService == nullptr)
 			return PresenceStatus::Offline;
-		return it->second.presence;
+		return m_presenceService->GetStatusByCharacter(characterId);
 	}
 
 	// -------------------------------------------------------------------------
@@ -529,8 +509,8 @@ namespace engine::server
 			if (!row[0])
 				continue;
 			uint64_t fid = static_cast<uint64_t>(std::strtoull(row[0], nullptr, 10));
-			// Only include friends that are currently online.
-			if (m_presence.count(fid) > 0)
+			// Only include friends currently online (autorité unique, par character_id).
+			if (m_presenceService != nullptr && m_presenceService->IsCharacterOnline(fid))
 				result.push_back(fid);
 		}
 		db::DbFreeResult(res);

--- a/src/shardd/gameplay/social/FriendSystem.h
+++ b/src/shardd/gameplay/social/FriendSystem.h
@@ -15,6 +15,8 @@ struct MYSQL;
 
 namespace engine::server
 {
+	class ShardPresenceService;
+
 	/// Friendship record loaded from the DB (one directed row).
 	struct FriendRecord
 	{
@@ -25,15 +27,7 @@ namespace engine::server
 		std::string      friendName;
 	};
 
-	/// Presence entry held in-memory for one connected player.
-	struct FriendPresenceEntry
-	{
-		uint64_t       playerId = 0;
-		std::string    playerName;
-		PresenceStatus presence = PresenceStatus::Offline;
-	};
-
-	/// Server-side friend and presence manager (M32.1).
+	/// Server-side friend manager (M32.1).
 	///
 	/// Handles /friend add, /friend accept, /friend decline, /friend remove,
 	/// bilateral DB persistence, per-player rate limiting (≤5 requests/60 s),
@@ -91,17 +85,16 @@ namespace engine::server
 		                  MYSQL*           mysql);
 
 		// ------------------------------------------------------------------
-		// Presence tracking
+		// Presence (déléguée à l'autorité unique ShardPresenceService)
 		// ------------------------------------------------------------------
 
-		/// Mark a player as online (call on successful login).
-		void SetPresence(uint64_t playerId, std::string_view playerName, PresenceStatus status);
+		/// Injecte l'autorité de présence (Niveau 1). À appeler après Init.
+		/// FriendSystem ne tient plus de map de présence : il interroge ce service
+		/// par character_id (l'identité joueur des amis = id de personnage).
+		void SetPresenceService(ShardPresenceService* presence) { m_presenceService = presence; }
 
-		/// Mark a player as offline (call on disconnect/logout).
-		void SetOffline(uint64_t playerId);
-
-		/// Return the current presence for \p playerId (Offline when unknown).
-		PresenceStatus GetPresence(uint64_t playerId) const;
+		/// Présence d'un \p characterId (Offline si inconnu ou service non câblé).
+		PresenceStatus GetPresence(uint64_t characterId) const;
 
 		// ------------------------------------------------------------------
 		// Queries
@@ -129,8 +122,9 @@ namespace engine::server
 
 		bool m_initialized = false;
 
-		/// In-memory presence map: account_id → FriendPresenceEntry.
-		std::unordered_map<uint64_t, FriendPresenceEntry> m_presence;
+		/// Autorité de présence (Niveau 1), non possédée. Nul = présence indisponible
+		/// (GetPresence renvoie Offline, GetOnlineFriendIds renvoie vide).
+		ShardPresenceService* m_presenceService = nullptr;
 
 		/// Per-player request timestamps for rate limiting.
 		std::unordered_map<uint64_t, std::deque<Clock::time_point>> m_requestRateLimit;

--- a/src/shardd/world/ShardPresenceService.cpp
+++ b/src/shardd/world/ShardPresenceService.cpp
@@ -1,0 +1,89 @@
+#include "src/shardd/world/ShardPresenceService.h"
+
+namespace engine::server
+{
+	void ShardPresenceService::SetOnline(uint64_t accountId, uint64_t characterId, std::string characterName,
+		uint32_t level, uint32_t zoneId, PresenceStatus status)
+	{
+		if (accountId == 0)
+			return;
+		std::lock_guard lock(m_mutex);
+		Entry& e = m_byAccount[accountId];
+		e.accountId = accountId;
+		e.characterId = characterId;
+		e.characterName = std::move(characterName);
+		e.level = level;
+		e.zoneId = zoneId;
+		e.status = status;
+	}
+
+	void ShardPresenceService::SetOffline(uint64_t accountId)
+	{
+		std::lock_guard lock(m_mutex);
+		m_byAccount.erase(accountId);
+	}
+
+	void ShardPresenceService::UpdateZone(uint64_t accountId, uint32_t zoneId)
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_byAccount.find(accountId);
+		if (it != m_byAccount.end())
+			it->second.zoneId = zoneId;
+	}
+
+	void ShardPresenceService::UpdateLevel(uint64_t accountId, uint32_t level)
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_byAccount.find(accountId);
+		if (it != m_byAccount.end())
+			it->second.level = level;
+	}
+
+	bool ShardPresenceService::IsOnline(uint64_t accountId) const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_byAccount.find(accountId) != m_byAccount.end();
+	}
+
+	PresenceStatus ShardPresenceService::GetStatus(uint64_t accountId) const
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_byAccount.find(accountId);
+		return it != m_byAccount.end() ? it->second.status : PresenceStatus::Offline;
+	}
+
+	std::optional<ShardPresenceService::Entry> ShardPresenceService::Get(uint64_t accountId) const
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_byAccount.find(accountId);
+		if (it == m_byAccount.end())
+			return std::nullopt;
+		return it->second;
+	}
+
+	std::vector<uint64_t> ShardPresenceService::OnlineAccountIdsAmong(const std::vector<uint64_t>& candidates) const
+	{
+		std::lock_guard lock(m_mutex);
+		std::vector<uint64_t> out;
+		out.reserve(candidates.size());
+		for (uint64_t id : candidates)
+		{
+			if (m_byAccount.find(id) != m_byAccount.end())
+				out.push_back(id);
+		}
+		return out;
+	}
+
+	std::vector<ShardPresenceService::Entry> ShardPresenceService::Snapshot() const
+	{
+		std::lock_guard lock(m_mutex);
+		std::vector<Entry> out;
+		out.reserve(m_byAccount.size());
+		for (const auto& [accountId, e] : m_byAccount)
+		{
+			(void)accountId;
+			out.push_back(e);
+		}
+		return out;
+	}
+}

--- a/src/shardd/world/ShardPresenceService.cpp
+++ b/src/shardd/world/ShardPresenceService.cpp
@@ -9,18 +9,28 @@ namespace engine::server
 			return;
 		std::lock_guard lock(m_mutex);
 		Entry& e = m_byAccount[accountId];
+		// Si ce compte était associé à un autre character_id, purge l'ancien index.
+		if (e.characterId != 0 && e.characterId != characterId)
+			m_accountByCharacter.erase(e.characterId);
 		e.accountId = accountId;
 		e.characterId = characterId;
 		e.characterName = std::move(characterName);
 		e.level = level;
 		e.zoneId = zoneId;
 		e.status = status;
+		if (characterId != 0)
+			m_accountByCharacter[characterId] = accountId;
 	}
 
 	void ShardPresenceService::SetOffline(uint64_t accountId)
 	{
 		std::lock_guard lock(m_mutex);
-		m_byAccount.erase(accountId);
+		auto it = m_byAccount.find(accountId);
+		if (it == m_byAccount.end())
+			return;
+		if (it->second.characterId != 0)
+			m_accountByCharacter.erase(it->second.characterId);
+		m_byAccount.erase(it);
 	}
 
 	void ShardPresenceService::UpdateZone(uint64_t accountId, uint32_t zoneId)
@@ -70,6 +80,35 @@ namespace engine::server
 		{
 			if (m_byAccount.find(id) != m_byAccount.end())
 				out.push_back(id);
+		}
+		return out;
+	}
+
+	bool ShardPresenceService::IsCharacterOnline(uint64_t characterId) const
+	{
+		std::lock_guard lock(m_mutex);
+		return m_accountByCharacter.find(characterId) != m_accountByCharacter.end();
+	}
+
+	PresenceStatus ShardPresenceService::GetStatusByCharacter(uint64_t characterId) const
+	{
+		std::lock_guard lock(m_mutex);
+		auto it = m_accountByCharacter.find(characterId);
+		if (it == m_accountByCharacter.end())
+			return PresenceStatus::Offline;
+		auto acc = m_byAccount.find(it->second);
+		return acc != m_byAccount.end() ? acc->second.status : PresenceStatus::Offline;
+	}
+
+	std::vector<uint64_t> ShardPresenceService::OnlineCharacterIdsAmong(const std::vector<uint64_t>& candidateCharacterIds) const
+	{
+		std::lock_guard lock(m_mutex);
+		std::vector<uint64_t> out;
+		out.reserve(candidateCharacterIds.size());
+		for (uint64_t cid : candidateCharacterIds)
+		{
+			if (m_accountByCharacter.find(cid) != m_accountByCharacter.end())
+				out.push_back(cid);
 		}
 		return out;
 	}

--- a/src/shardd/world/ShardPresenceService.h
+++ b/src/shardd/world/ShardPresenceService.h
@@ -1,0 +1,74 @@
+#pragma once
+
+// Service de présence unifié — Niveau 1 (shard-local).
+//
+// Autorité UNIQUE de la présence des joueurs connectés à CE shard. Remplace les
+// comptabilités de présence dispersées (FriendSystem.m_presence, à terme
+// GuildSystem.m_onlinePlayers) : ces systèmes s'y réfèrent au lieu de tenir
+// chacun leur propre map (cf. docs/superpowers/specs/2026-05-31-unified-presence-service-design.md).
+//
+// Alimenté par ServerApp aux hooks login (HandleHello) / logout (HandleGoodbye,
+// éviction) et sur changement de zone/niveau. C'est aussi la source du snapshot
+// poussé au master via le heartbeat enrichi (Niveau 2 / web-portal).
+//
+// Thread-safe : muté sur le thread gameplay, lu aussi depuis le thread
+// shard→master (heartbeat) — protégé par mutex.
+
+#include "src/shared/network/ServerProtocol.h" // PresenceStatus
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	class ShardPresenceService
+	{
+	public:
+		/// État de présence d'un joueur connecté à ce shard.
+		struct Entry
+		{
+			uint64_t       accountId = 0;
+			uint64_t       characterId = 0;
+			std::string    characterName;
+			uint32_t       level = 1;
+			uint32_t       zoneId = 0;
+			PresenceStatus status = PresenceStatus::Online;
+		};
+
+		/// Marque \p accountId en ligne (à l'entrée en jeu). Remplace toute entrée existante.
+		void SetOnline(uint64_t accountId, uint64_t characterId, std::string characterName,
+			uint32_t level, uint32_t zoneId, PresenceStatus status = PresenceStatus::Online);
+
+		/// Retire la présence (déconnexion / éviction). No-op si inconnu.
+		void SetOffline(uint64_t accountId);
+
+		/// Met à jour la zone courante d'un joueur en ligne (no-op si inconnu).
+		void UpdateZone(uint64_t accountId, uint32_t zoneId);
+
+		/// Met à jour le niveau d'un joueur en ligne (no-op si inconnu).
+		void UpdateLevel(uint64_t accountId, uint32_t level);
+
+		/// True si \p accountId est connecté à ce shard.
+		bool IsOnline(uint64_t accountId) const;
+
+		/// Statut de présence (\ref PresenceStatus::Offline si inconnu).
+		PresenceStatus GetStatus(uint64_t accountId) const;
+
+		/// Copie de l'entrée pour \p accountId, ou nullopt si absent.
+		std::optional<Entry> Get(uint64_t accountId) const;
+
+		/// Sous-ensemble de \p candidates actuellement en ligne (pour amis/guilde).
+		std::vector<uint64_t> OnlineAccountIdsAmong(const std::vector<uint64_t>& candidates) const;
+
+		/// Copie de toutes les entrées (source du snapshot heartbeat → master).
+		std::vector<Entry> Snapshot() const;
+
+	private:
+		mutable std::mutex m_mutex;
+		std::unordered_map<uint64_t, Entry> m_byAccount;
+	};
+}

--- a/src/shardd/world/ShardPresenceService.h
+++ b/src/shardd/world/ShardPresenceService.h
@@ -61,8 +61,19 @@ namespace engine::server
 		/// Copie de l'entrée pour \p accountId, ou nullopt si absent.
 		std::optional<Entry> Get(uint64_t accountId) const;
 
-		/// Sous-ensemble de \p candidates actuellement en ligne (pour amis/guilde).
+		/// Sous-ensemble de \p candidates (account_ids) actuellement en ligne.
 		std::vector<uint64_t> OnlineAccountIdsAmong(const std::vector<uint64_t>& candidates) const;
+
+		// --- Index secondaire par character_id (consommateurs identifiant par perso : amis) ---
+
+		/// True si le \p characterId est connecté à ce shard.
+		bool IsCharacterOnline(uint64_t characterId) const;
+
+		/// Statut de présence par character_id (\ref PresenceStatus::Offline si inconnu).
+		PresenceStatus GetStatusByCharacter(uint64_t characterId) const;
+
+		/// Sous-ensemble de \p candidateCharacterIds actuellement en ligne (pour FriendSystem).
+		std::vector<uint64_t> OnlineCharacterIdsAmong(const std::vector<uint64_t>& candidateCharacterIds) const;
 
 		/// Copie de toutes les entrées (source du snapshot heartbeat → master).
 		std::vector<Entry> Snapshot() const;
@@ -70,5 +81,7 @@ namespace engine::server
 	private:
 		mutable std::mutex m_mutex;
 		std::unordered_map<uint64_t, Entry> m_byAccount;
+		/// Index secondaire : character_id → account_id (pour les lookups par perso).
+		std::unordered_map<uint64_t, uint64_t> m_accountByCharacter;
 	};
 }

--- a/src/shardd/world/ShardPresenceServiceTests.cpp
+++ b/src/shardd/world/ShardPresenceServiceTests.cpp
@@ -79,11 +79,35 @@ static void TestOnlineAmongAndSnapshot()
 	Assert(e && e->characterId == 101 && e->zoneId == 7, "re-SetOnline remplace l'entree");
 }
 
+static void TestCharacterIndex()
+{
+	ShardPresenceService svc;
+	svc.SetOnline(/*account*/10, /*character*/1000, "Alyx", 5, 3);
+	Assert(svc.IsCharacterOnline(1000), "IsCharacterOnline true pour perso connecté");
+	Assert(!svc.IsCharacterOnline(9999), "IsCharacterOnline false pour perso inconnu");
+	Assert(svc.GetStatusByCharacter(1000) == PresenceStatus::Online, "GetStatusByCharacter Online");
+	Assert(svc.GetStatusByCharacter(9999) == PresenceStatus::Offline, "GetStatusByCharacter inconnu => Offline");
+
+	auto online = svc.OnlineCharacterIdsAmong({ 1000, 2000 });
+	Assert(online.size() == 1 && online[0] == 1000, "OnlineCharacterIdsAmong filtre par perso");
+
+	// SetOffline purge aussi l'index character_id.
+	svc.SetOffline(10);
+	Assert(!svc.IsCharacterOnline(1000), "SetOffline purge l'index character");
+
+	// Changement de perso pour le même compte : l'ancien character sort de l'index.
+	svc.SetOnline(10, 1000, "Alyx", 5, 3);
+	svc.SetOnline(10, 1001, "Alyx2", 6, 4);
+	Assert(!svc.IsCharacterOnline(1000), "ancien character purgé apres changement");
+	Assert(svc.IsCharacterOnline(1001), "nouveau character indexé");
+}
+
 int main()
 {
 	TestOnlineOfflineAndGet();
 	TestUpdateZoneLevel();
 	TestOnlineAmongAndSnapshot();
+	TestCharacterIndex();
 	std::cerr << (s_failCount == 0 ? "[OK] all shard_presence_service tests passed\n" : "[FAIL] some tests failed\n");
 	return s_failCount == 0 ? 0 : 1;
 }

--- a/src/shardd/world/ShardPresenceServiceTests.cpp
+++ b/src/shardd/world/ShardPresenceServiceTests.cpp
@@ -1,0 +1,89 @@
+/**
+ * Tests unitaires — ShardPresenceService (présence shard-locale, Niveau 1).
+ * Pur (pas de réseau/DB). Retourne 0 si OK, non-zéro sinon.
+ */
+
+#include "src/shardd/world/ShardPresenceService.h"
+
+#include <cstdlib>
+#include <iostream>
+
+using engine::server::ShardPresenceService;
+using engine::server::PresenceStatus;
+
+namespace
+{
+	int s_failCount = 0;
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+static void TestOnlineOfflineAndGet()
+{
+	ShardPresenceService svc;
+	Assert(!svc.IsOnline(1), "inconnu => hors ligne");
+	Assert(svc.GetStatus(1) == PresenceStatus::Offline, "statut inconnu => Offline");
+
+	svc.SetOnline(1, 100, "Alyx", 7, 42, PresenceStatus::Online);
+	Assert(svc.IsOnline(1), "online apres SetOnline");
+	auto e = svc.Get(1);
+	Assert(e.has_value(), "Get renvoie l'entree");
+	if (e)
+	{
+		Assert(e->characterId == 100 && e->characterName == "Alyx" && e->level == 7 && e->zoneId == 42,
+			"champs round-trip");
+		Assert(e->status == PresenceStatus::Online, "statut round-trip");
+	}
+
+	svc.SetOffline(1);
+	Assert(!svc.IsOnline(1), "hors ligne apres SetOffline");
+	Assert(!svc.Get(1).has_value(), "Get nullopt apres SetOffline");
+}
+
+static void TestUpdateZoneLevel()
+{
+	ShardPresenceService svc;
+	svc.SetOnline(2, 200, "Bob", 1, 1, PresenceStatus::Online);
+	svc.UpdateZone(2, 99);
+	svc.UpdateLevel(2, 12);
+	auto e = svc.Get(2);
+	Assert(e && e->zoneId == 99, "UpdateZone applique");
+	Assert(e && e->level == 12, "UpdateLevel applique");
+	// no-op sur compte inconnu
+	svc.UpdateZone(999, 5);
+	Assert(!svc.IsOnline(999), "UpdateZone inconnu = no-op");
+}
+
+static void TestOnlineAmongAndSnapshot()
+{
+	ShardPresenceService svc;
+	svc.SetOnline(1, 100, "A", 1, 1);
+	svc.SetOnline(3, 300, "C", 1, 1);
+	auto online = svc.OnlineAccountIdsAmong({ 1, 2, 3, 4 });
+	Assert(online.size() == 2, "OnlineAccountIdsAmong filtre (2/4)");
+	bool has1 = false, has3 = false;
+	for (uint64_t id : online) { if (id == 1) has1 = true; if (id == 3) has3 = true; }
+	Assert(has1 && has3, "OnlineAccountIdsAmong contient 1 et 3");
+	Assert(svc.Snapshot().size() == 2, "Snapshot = 2 entrees");
+
+	// SetOnline du meme compte ne double-compte pas (remplace).
+	svc.SetOnline(1, 101, "A2", 2, 7);
+	Assert(svc.Snapshot().size() == 2, "re-SetOnline ne double-compte pas");
+	auto e = svc.Get(1);
+	Assert(e && e->characterId == 101 && e->zoneId == 7, "re-SetOnline remplace l'entree");
+}
+
+int main()
+{
+	TestOnlineOfflineAndGet();
+	TestUpdateZoneLevel();
+	TestOnlineAmongAndSnapshot();
+	std::cerr << (s_failCount == 0 ? "[OK] all shard_presence_service tests passed\n" : "[FAIL] some tests failed\n");
+	return s_failCount == 0 ? 0 : 1;
+}

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -380,6 +380,9 @@ namespace engine::server
 
 		// M32.1 — FriendSystem runs in no-DB mode on WIN32 (presence tracking only).
 		m_friendSystem.Init(nullptr);
+		// Présence unifiée : FriendSystem consulte l'autorité unique (par character_id)
+		// au lieu de tenir sa propre map de présence.
+		m_friendSystem.SetPresenceService(&m_shardPresence);
 
 		// M32.2 — PartySystem (in-memory, no DB dependency).
 		m_partySystem.Init();
@@ -1203,6 +1206,9 @@ namespace engine::server
 			{
 				const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
 					std::chrono::steady_clock::now().time_since_epoch()).count());
+				// Présence unifiée : résout le compte propriétaire (clé de ShardPresenceService).
+				acceptedClient.accountId = m_admittedRegistry->AdmittedAccountId(
+					acceptedClient.persistenceCharacterKey, nowMs);
 				if (acceptedClient.characterName.empty())
 				{
 					std::string admittedName = m_admittedRegistry->AdmittedCharacterName(
@@ -1463,43 +1469,24 @@ namespace engine::server
 				m_clients.size(),
 				m_transport.ReceivedPacketCount(),
 				m_transport.SentPacketCount());
-
-			// Présence enrichie (web-portal) : republie le snapshot des joueurs en jeu à
-			// ~1 Hz (suffisant pour un affichage admin, et évite de reconstruire à chaque
-			// tick). Construit ici sur le thread gameplay (accès direct à m_clients), puis
-			// publié sous mutex pour lecture par GetPlayerPresenceSnapshot (autre thread).
-			std::vector<engine::network::ShardPlayerPresence> snapshot;
-			snapshot.reserve(m_clients.size());
-			const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
-				std::chrono::steady_clock::now().time_since_epoch()).count());
-			for (const auto& client : m_clients)
-			{
-				const uint64_t characterId = client.persistenceCharacterKey;
-				if (characterId == 0u)
-					continue;
-				uint64_t accountId = 0u;
-				if (m_admittedRegistry != nullptr)
-					accountId = m_admittedRegistry->AdmittedAccountId(characterId, nowMs);
-				if (accountId == 0u)
-					continue; // accountId non résolu (registre absent / expiré) : omis.
-				engine::network::ShardPlayerPresence p;
-				p.accountId = accountId;
-				p.characterId = characterId;
-				p.level = client.level;
-				p.zoneId = client.zoneId;
-				snapshot.push_back(p);
-			}
-			{
-				std::lock_guard<std::mutex> lock(m_presenceMutex);
-				m_presenceSnapshot = std::move(snapshot);
-			}
 		}
 	}
 
 	std::vector<engine::network::ShardPlayerPresence> ServerApp::GetPlayerPresenceSnapshot() const
 	{
-		std::lock_guard<std::mutex> lock(m_presenceMutex);
-		return m_presenceSnapshot;
+		// Source unique : ShardPresenceService (Niveau 1). Alimenté aux hooks
+		// login/logout/zone ; thread-safe. On projette ses entrées sur le format wire.
+		std::vector<engine::network::ShardPlayerPresence> out;
+		for (const auto& e : m_shardPresence.Snapshot())
+		{
+			engine::network::ShardPlayerPresence p;
+			p.accountId = e.accountId;
+			p.characterId = e.characterId;
+			p.level = e.level;
+			p.zoneId = e.zoneId;
+			out.push_back(p);
+		}
+		return out;
 	}
 
 	void ServerApp::Simulate()
@@ -2501,6 +2488,10 @@ namespace engine::server
 		}
 
 		client.zoneId = zoneChange.zoneId;
+		// Présence unifiée : maintient la zone à jour pour le snapshot master / amis
+		// (même clé de repli qu'au login : account_id, sinon character_id).
+		m_shardPresence.UpdateZone(client.accountId != 0 ? client.accountId
+			: static_cast<uint64_t>(client.persistenceCharacterKey), client.zoneId);
 		client.positionMetersX = zoneChange.spawnPositionX;
 		client.positionMetersY = zoneChange.spawnPositionY;
 		client.positionMetersZ = zoneChange.spawnPositionZ;
@@ -4851,19 +4842,25 @@ namespace engine::server
 
 	void ServerApp::OnClientLogin(ConnectedClient& client)
 	{
+		// Présence unifiée (Niveau 1) : autorité UNIQUE. On y inscrit le joueur (clé
+		// account_id + index character_id) ; FriendSystem et le snapshot heartbeat la
+		// consultent. Remplace l'ancien FriendSystem.SetPresence (map dédiée supprimée).
+		// Repli : sur build sans gate d'admission (WIN32 no-DB), accountId n'est pas
+		// résolu (0) — on clé alors sur le character_id pour préserver la présence amis
+		// (le snapshot master n'est de toute façon pas consommé sur ces builds).
+		const uint64_t presenceKey = client.accountId != 0 ? client.accountId
+			: static_cast<uint64_t>(client.persistenceCharacterKey);
+		m_shardPresence.SetOnline(presenceKey, client.persistenceCharacterKey,
+			client.characterName, client.level, client.zoneId, PresenceStatus::Online);
+
 		if (!m_friendSystem.IsInitialized())
 			return;
-
-		const std::string playerLabel = "P" + std::to_string(client.clientId);
-		m_friendSystem.SetPresence(
-			static_cast<uint64_t>(client.persistenceCharacterKey),
-			playerLabel,
-			PresenceStatus::Online);
 
 		SendFriendListSync(client);
 		BroadcastFriendStatusUpdate(client, PresenceStatus::Online);
 
-		LOG_INFO(Net, "[ServerApp] OnClientLogin: friend presence set online (client_id={})", client.clientId);
+		LOG_INFO(Net, "[ServerApp] OnClientLogin: presence set online (client_id={}, account_id={})",
+			client.clientId, client.accountId);
 	}
 
 	void ServerApp::OnClientLogout(const ConnectedClient& client)
@@ -4883,13 +4880,16 @@ namespace engine::server
 			}
 		}
 
-		if (!m_friendSystem.IsInitialized())
-			return;
+		if (m_friendSystem.IsInitialized())
+			BroadcastFriendStatusUpdate(client, PresenceStatus::Offline);
 
-		BroadcastFriendStatusUpdate(client, PresenceStatus::Offline);
-		m_friendSystem.SetOffline(static_cast<uint64_t>(client.persistenceCharacterKey));
+		// Présence unifiée : retire le joueur (même clé de repli qu'au login).
+		const uint64_t presenceKey = client.accountId != 0 ? client.accountId
+			: static_cast<uint64_t>(client.persistenceCharacterKey);
+		m_shardPresence.SetOffline(presenceKey);
 
-		LOG_INFO(Net, "[ServerApp] OnClientLogout: friend presence cleared (client_id={})", client.clientId);
+		LOG_INFO(Net, "[ServerApp] OnClientLogout: presence cleared (client_id={}, account_id={})",
+			client.clientId, client.accountId);
 	}
 
 	void ServerApp::SendFriendListSync(const ConnectedClient& receiver)

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -18,6 +18,7 @@
 #include "src/shardd/gameplay/chat/ChatCommandParser.h"
 #include "src/shared/network/ReplicationTypes.h"
 #include "src/shared/network/ShardPayloads.h"
+#include "src/shardd/world/ShardPresenceService.h"
 #include "src/shared/security/SecurityAuditLog.h"
 #include "src/shardd/anticheat/AntiCheatGameplay.h"
 #include "src/shared/network/ServerProtocol.h"
@@ -110,6 +111,9 @@ namespace engine::server
 		/// pour permettre au client de sélectionner le mesh skinné des avatars distants.
 		std::string gender;
 		uint32_t experiencePoints = 0;
+		/// Compte propriétaire (résolu au Hello via AdmittedCharacterRegistry). Clé de la
+		/// présence unifiée (ShardPresenceService) ; 0 si non résolu (registre absent).
+		uint64_t accountId = 0;
 		/// Niveau du personnage (table characters.level, chargé au Hello via LoadSpawnFromDb).
 		/// Reporté au master dans le heartbeat enrichi (présence web-portal).
 		uint32_t level = 1;
@@ -836,11 +840,11 @@ namespace engine::server
 		UdpTransport m_transport;
 		std::vector<Datagram> m_pendingDatagrams;
 		std::vector<ConnectedClient> m_clients;
-		/// Présence enrichie : snapshot publié à chaque TickOnce (thread gameplay) et lu
-		/// par GetPlayerPresenceSnapshot depuis le thread shard→master. Protégé par son
-		/// propre mutex pour découpler les deux threads sans verrouiller m_clients.
-		mutable std::mutex m_presenceMutex;
-		std::vector<engine::network::ShardPlayerPresence> m_presenceSnapshot;
+		/// Présence unifiée (Niveau 1) : autorité UNIQUE de la présence shard-locale.
+		/// Alimentée aux hooks login/logout/zone ; consommée par FriendSystem (par
+		/// character_id) et, via GetPlayerPresenceSnapshot, par le heartbeat → master.
+		/// Thread-safe en interne (découple thread gameplay / thread shard→master).
+		ShardPresenceService m_shardPresence;
 		/// TG.2 : index O(1) sur m_clients pour les 3 lookups chauds (Find/FindByEntityId/
 		/// FindConnectedClient). Valeurs = index dans m_clients ; clé endpoint = (address<<16)|port.
 		/// Maintenance : insertion incrémentale dans HandleHello, reconstruction complète dans


### PR DESCRIPTION
## Service de présence unifié — Phase 1 (amis)

Met fin aux stockages de présence dupliqués (cf. spec `docs/superpowers/specs/2026-05-31-unified-presence-service-design.md`). Architecture **hybride 2 niveaux** : présence locale shard (chemins chauds) + autorité globale master (cross-shard/portail, = cache heartbeat #770).

### Nouveau — `ShardPresenceService` (Niveau 1, shard)
Autorité **unique** de la présence shard-locale. Clé primaire `account_id` (master/portail) **+ index secondaire `character_id`** (consommateurs identifiant par perso, comme les amis). API : online/offline, update zone/niveau, `IsOnline`/`IsCharacterOnline`, `OnlineAccountIdsAmong`/`OnlineCharacterIdsAmong`, `Snapshot`. Test unitaire dédié (`shard_presence_service_tests`).

### Intégration `ServerApp`
- Unique **écrivain** : `SetOnline`/`SetOffline` aux hooks login/logout, `UpdateZone` à la transition de zone.
- Devient la **source du snapshot heartbeat** → master (remplace l'itération ad hoc de `m_clients` introduite par #770).
- `ConnectedClient.accountId` résolu au Hello (repli `character_id` si pas de gate d'admission, ex. WIN32 no-DB).

### Migration `FriendSystem`
- **Suppression de `m_presence`** (map dédiée). `GetPresence`/`GetOnlineFriendIds` **délèguent** au service par `character_id`. Comportement fonctionnel **identique** (les amis restent identifiés par `character_id`, conformément au schéma `friends` réel ; pas de migration DB).

### Hors périmètre (phases suivantes)
- Phase 2 : `GuildSystem.m_onlinePlayers` → service. Phase 3 : handler master cross-shard + Party/Raid.

**Déploiement** : ⚠️ **stacked sur #770** (contient ses commits jusqu'à son merge). Shard + master à redéployer (Phase 1 ne change pas le wire au-delà de #770). Ordre de merge : **#770 → cette PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
