### PR TITLE
fix(gameplay): collision props ne teleporte plus le perso en hauteur

### DIFF
--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -50,27 +50,33 @@ namespace engine::gameplay
 			if (capHi < c.baseY || capLo > c.topY) continue;
 
 			const float fx = sx - c.cx, fz = sz - c.cz;
-			const float a = dx * dx + dz * dz;
-			const float b = 2.0f * (fx * dx + fz * dz);
-			const float cc = fx * fx + fz * fz - R * R;
+			const float a = dx * dx + dz * dz;            // mouvement horizontal au carré
+			const float cc = fx * fx + fz * fz - R * R;   // < 0 => déjà en chevauchement XZ
 
+			// IMPORTANT : la collision contre un prop ne concerne QUE le déplacement
+			// HORIZONTAL entrant dans le cylindre. On ne bloque JAMAIS un sweep vertical
+			// (gravité, sonde de sol, récupération anti-encastrement du CharacterController
+			// qui sonde depuis 50 m au-dessus). Sinon ces sweeps verticaux heurtent le
+			// cylindre et la récupération téléporte le perso au sommet de la sonde.
 			float tHit = -1.0f;
-			if (a < 1e-8f)
+			if (a >= 1e-8f)
 			{
-				// Déplacement XZ négligeable : test statique au point de départ.
-				if (cc <= 0.0f) tHit = 0.0f;
-			}
-			else
-			{
-				const float disc = b * b - 4.0f * a * cc;
-				if (disc >= 0.0f)
+				const float b = 2.0f * (fx * dx + fz * dz);  // = 2 d·(start-axe) ; < 0 = on se rapproche
+				if (cc <= 0.0f)
 				{
-					const float sq = std::sqrt(disc);
-					const float t0 = (-b - sq) / (2.0f * a);
-					const float t1 = (-b + sq) / (2.0f * a);
-					if (cc <= 0.0f) tHit = 0.0f;                  // déjà en intersection au départ
-					else if (t0 >= 0.0f && t0 <= 1.0f) tHit = t0; // entrée dans le cylindre
-					else if (t1 >= 0.0f && t1 <= 1.0f) tHit = t1; // sortie : on bloque quand même
+					// Déjà en chevauchement : bloquer seulement si on se RAPPROCHE de
+					// l'axe (closing). Permet de glisser le long et de ressortir.
+					if (b < 0.0f) tHit = 0.0f;
+				}
+				else
+				{
+					const float disc = b * b - 4.0f * a * cc;
+					if (disc >= 0.0f)
+					{
+						const float sq = std::sqrt(disc);
+						const float t0 = (-b - sq) / (2.0f * a);
+						if (t0 >= 0.0f && t0 <= 1.0f) tHit = t0;  // entrée dans le cylindre
+					}
 				}
 			}
 

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -68,6 +68,27 @@ int main()
 		check(!h, "sans_cylindre: pas de hit");
 	}
 
+	// 4bis) RÉGRESSION (téléport en hauteur) : un sweep VERTICAL traversant le
+	// cylindre par son axe (ex. sonde de récupération anti-encastrement qui sonde
+	// depuis 50 m au-dessus) NE DOIT PAS générer de hit. Sinon le CharacterController
+	// téléporte le perso au sommet de la sonde.
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 20, 0 }, Vec3{ 5, 1, 0 }, hit);
+		check(!h && !hit.hit, "sweep vertical dans cylindre: pas de hit (anti-teleport)");
+	}
+
+	// 4ter) Déjà en chevauchement, mouvement s'ÉLOIGNANT de l'axe : pas de hit
+	// (le perso doit pouvoir ressortir / glisser, pas rester collé).
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		// Départ au bord du cylindre (x=5.5 ~ R=0.8 de l'axe), on s'éloigne vers +x.
+		bool h = c.SweepCapsule(cap, Vec3{ 5.5f, 1, 0 }, Vec3{ 7.0f, 1, 0 }, hit);
+		check(!h, "chevauchement + eloignement: pas de hit (peut ressortir)");
+	}
+
 	// 5) QueryWater délégué au terrain.
 	{
 		CompositeWorldCollider c(&terrain);


### PR DESCRIPTION
## Probleme
Apres le merge de #773, toucher un objet solide (arbre, coffre) **teleporte le personnage ~50 m en l'air**, avec clignotement Fall/Land.

## Cause
Le `CompositeWorldCollider` (cylindres de collision des props) repondait AUSSI aux **sweeps verticaux** du `CharacterController` :
- la **recuperation anti-encastrement** sonde depuis 50 m au-dessus du perso vers le bas ; si le perso est dans le rayon XZ d'un cylindre, cette sonde verticale heurtait le cylindre a `fraction=0` -> `restY = pos.y + 50` -> teleport.
- la **sonde de sol** verticale heurtait aussi le cylindre (normale horizontale) -> `grounded` faux -> cycle Fall/Land.

## Correctif
Le cylindre ne bloque plus QUE le **mouvement horizontal entrant** (test `closing`) : aucun hit pour un sweep vertical, ni quand on s'eloigne de l'axe (permet de glisser/ressortir). La collision horizontale (le perso ne traverse pas) est conservee. Tests de regression ajoutes.

## Deploiement
[OK] Client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)