### PR TITLE
feat(guild): présence unifiée Phase 2 — roster online réel + nettoyage code mort

### DIFF
--- a/src/masterd/handlers/guild/GuildHandler.cpp
+++ b/src/masterd/handlers/guild/GuildHandler.cpp
@@ -11,6 +11,7 @@
 #include "src/shared/network/ProtocolV1Constants.h"
 
 #include <cstdio>
+#include <unordered_set>
 #include <vector>
 
 namespace engine::server
@@ -104,13 +105,13 @@ namespace engine::server
 					for (const auto& mr : r.members)
 					{
 						InMemoryGuildMember m;
+						m.accountId   = mr.accountId;
 						m.accountName = ResolveV1AccountName(mr.accountId);
 						m.rankId      = mr.rankId;
-						// online inconnu cote DB V1 (snapshot statique).
-						// Le handler ne push pas d'event presence V1 :
-						// online reste false par defaut sauf pour le leader
-						// (heuristique simple V1 : leader = online).
-						m.online      = (mr.accountId == r.leaderAccountId);
+						// online n'est plus figé ici : il est recalculé à l'envoi du roster
+						// (HandleMembers) via l'autorité de présence master (SessionManager).
+						// Valeur initiale neutre.
+						m.online      = false;
 						g.members.push_back(std::move(m));
 					}
 					for (const auto& bi : r.bank0)
@@ -334,6 +335,18 @@ namespace engine::server
 		}
 
 		const uint32_t guildId = parsed->guildId;
+
+		// Présence unifiée : le statut « en ligne » des membres vient de l'autorité
+		// master (SessionManager = comptes avec une session de jeu active), recalculé
+		// à CHAQUE envoi de roster — fini l'heuristique factice « leader=online ».
+		// Les membres seed hardcodés (accountId == 0) conservent leur online statique.
+		std::unordered_set<uint64_t> onlineAccounts;
+		if (m_sessionMgr)
+		{
+			const auto active = m_sessionMgr->ListActiveAccountIds();
+			onlineAccounts.insert(active.begin(), active.end());
+		}
+
 		std::vector<GuildMember> members;
 		bool found = false;
 		{
@@ -349,7 +362,9 @@ namespace engine::server
 					wm.accountName = mem.accountName;
 					wm.rankId      = mem.rankId;
 					wm.rankName    = RankName(mem.rankId);
-					wm.online      = mem.online;
+					wm.online      = (mem.accountId != 0)
+						? (onlineAccounts.count(mem.accountId) > 0)
+						: mem.online;
 					members.push_back(std::move(wm));
 				}
 			}

--- a/src/masterd/handlers/guild/GuildHandler.h
+++ b/src/masterd/handlers/guild/GuildHandler.h
@@ -62,8 +62,12 @@ namespace engine::server
 	/// Membre in-memory d'une guilde V1.
 	struct InMemoryGuildMember
 	{
+		uint64_t    accountId = 0;   ///< Compte du membre (0 = seed hardcodé sans compte réel).
 		std::string accountName;
 		uint8_t     rankId = 0;
+		/// Statut affiché. Pour les membres chargés depuis la DB (accountId != 0), il est
+		/// recalculé en direct à l'envoi du roster via l'autorité de présence master
+		/// (SessionManager). Conservé tel quel uniquement pour les membres seed (accountId 0).
 		bool        online = false;
 	};
 

--- a/src/shardd/gameplay/guild/GuildSystem.cpp
+++ b/src/shardd/gameplay/guild/GuildSystem.cpp
@@ -56,7 +56,6 @@ namespace engine::server
 	{
 		m_guilds.clear();
 		m_playerGuildMap.clear();
-		m_onlinePlayers.clear();
 		m_nextGuildId = 1;
 		m_initialized = true;
 
@@ -76,7 +75,6 @@ namespace engine::server
 	{
 		m_guilds.clear();
 		m_playerGuildMap.clear();
-		m_onlinePlayers.clear();
 		m_initialized = false;
 		LOG_INFO(Server, "[GuildSystem] Shutdown");
 	}
@@ -163,38 +161,11 @@ namespace engine::server
 		return (rank->permissionsBitfield & static_cast<uint32_t>(perm)) != 0u;
 	}
 
-	std::vector<uint64_t> GuildSystem::GetOnlineMemberIds(uint64_t guildId) const
-	{
-		const GuildRecord* guild = FindGuild(guildId);
-		if (!guild)
-			return {};
-		std::vector<uint64_t> result;
-		result.reserve(guild->members.size());
-		for (const auto& m : guild->members)
-		{
-			if (m_onlinePlayers.count(m.playerId))
-				result.push_back(m.playerId);
-		}
-		return result;
-	}
-
-	// =========================================================================
-	// Online presence
-	// =========================================================================
-
-	void GuildSystem::SetOnline(uint64_t playerId, uint64_t guildId)
-	{
-		m_onlinePlayers.insert(playerId);
-		if (guildId != 0u)
-			m_playerGuildMap[playerId] = guildId;
-		LOG_DEBUG(Server, "[GuildSystem] Player {} online (guild={})", playerId, guildId);
-	}
-
-	void GuildSystem::SetOffline(uint64_t playerId)
-	{
-		m_onlinePlayers.erase(playerId);
-		LOG_DEBUG(Server, "[GuildSystem] Player {} offline", playerId);
-	}
+	// Présence unifiée (Phase 2) : l'ancienne présence guilde shard-locale
+	// (m_onlinePlayers + SetOnline/SetOffline/GetOnlineMemberIds) était du code mort
+	// (aucun appelant) et a été supprimée. Le statut « en ligne » du roster de guilde
+	// est désormais calculé côté master (GuildHandler) via l'autorité de présence
+	// unique (SessionManager). Cf. spec service de présence unifié.
 
 	// =========================================================================
 	// Guild lifecycle — CreateGuild

--- a/src/shardd/gameplay/guild/GuildSystem.h
+++ b/src/shardd/gameplay/guild/GuildSystem.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 struct MYSQL;
@@ -175,25 +174,11 @@ namespace engine::server
 		               MYSQL*             mysql);
 
 		// ------------------------------------------------------------------
-		// Online presence (for guild chat routing)
-		// ------------------------------------------------------------------
-
-		/// Mark \p playerId as online and associate them with \p guildId (call on login).
-		void SetOnline(uint64_t playerId, uint64_t guildId);
-
-		/// Mark \p playerId as offline (call on disconnect/logout).
-		void SetOffline(uint64_t playerId);
-
-		// ------------------------------------------------------------------
 		// Queries
 		// ------------------------------------------------------------------
 
 		/// Return the guild id for \p playerId; 0 when not in any guild.
 		uint64_t GetGuildIdForPlayer(uint64_t playerId) const;
-
-		/// Return the account ids of all currently-online members of \p guildId.
-		/// Used to route guild chat messages and notifications.
-		std::vector<uint64_t> GetOnlineMemberIds(uint64_t guildId) const;
 
 		/// Return a const pointer to the guild record for \p guildId; nullptr when not found.
 		const GuildRecord* GetGuild(uint64_t guildId) const;
@@ -216,8 +201,6 @@ namespace engine::server
 		std::unordered_map<uint64_t, GuildRecord> m_guilds;
 		/// Reverse lookup: playerId → guildId (absent = not in a guild).
 		std::unordered_map<uint64_t, uint64_t>    m_playerGuildMap;
-		/// Set of currently-online player ids (for guild chat / notification routing).
-		std::unordered_set<uint64_t>              m_onlinePlayers;
 
 		/// Validate guild name: length and allowed characters.
 		bool ValidateGuildName(std::string_view name) const;


### PR DESCRIPTION
## Présence unifiée — Phase 2 (guildes)

Suite de la consolidation de présence (spec `2026-05-31-unified-presence-service-design.md`).

### 2a — Nettoyage shard
`GuildSystem` tenait une présence en mémoire (`m_onlinePlayers` + `SetOnline`/`SetOffline`/`GetOnlineMemberIds`) qui était **du code mort** : aucun appelant, ni alimentée ni lue. Supprimée.

### 2b — Roster guilde « en ligne » réel (master)
`GuildHandler` affichait un statut online **factice** (heuristique « leader=online », le reste offline). Désormais le statut est **calculé à chaque envoi du roster** via l'**autorité de présence unique** côté master — `SessionManager.ListActiveAccountIds()` (comptes ayant une session de jeu active).
- `InMemoryGuildMember` porte maintenant l'`accountId` (était résolu en nom et perdu).
- Les membres **seed hardcodés** (accountId 0, mode sans DB) conservent leur `online` statique de démo.

### Pas de changement de protocole
La réponse `GuildMembersResponse` (champ `online`) est **inchangée sur le wire** — seule sa valeur devient exacte. Le client en profite sans rebuild.

**Déploiement** : ⚠️ **master + shard** à redéployer (code shard `GuildSystem` + code master `GuildHandler`). **Pas** de bump protocole, **client inchangé**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
