### PR TITLE
feat(presence): noms de région depuis les manifestes de zone (master-side)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/security/BotDetector.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/shards/ShardRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/shards/ShardPlayerPresenceCache.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/world/ZoneNameRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/shards/ServerRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ShardRegisterHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/shard/ShardTicketCrypto.cpp

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -13,6 +13,7 @@
 #include "src/masterd/handlers/shard/ShardRegisterHandler.h"
 #include "src/masterd/shards/ShardRegistry.h"
 #include "src/masterd/shards/ShardPlayerPresenceCache.h"
+#include "src/masterd/world/ZoneNameRegistry.h"
 #include "src/masterd/handlers/shard/ShardTicketHandler.h"
 #include "src/masterd/handlers/shard/ServerListHandler.h"
 #include "src/shared/network/ProtocolV1Constants.h"
@@ -190,6 +191,11 @@ int main(int argc, char** argv)
 	// heartbeats v9, purgé quand un shard tombe (cf. SetShardDownCallback).
 	engine::server::ShardPlayerPresenceCache playerPresenceCache;
 	shardRegisterHandler.SetPlayerPresenceCache(&playerPresenceCache);
+	// Présence enrichie : noms de région lus depuis les manifestes de zone (game/data).
+	// Vide si les champs zone_numeric_id/display_name ne sont pas (encore) renseignés —
+	// le portail retombe alors sur « Zone N ». Aucun nom inventé.
+	engine::server::ZoneNameRegistry zoneNames;
+	zoneNames.Load(config.GetString("paths.content", "game/data") + std::string("/zones"));
 	LOG_INFO(Server, "[MAIN_SRV] ShardRegistry setup OK");
 
 	engine::server::NetServer server;
@@ -1388,7 +1394,7 @@ int main(int argc, char** argv)
 	//  - inWorld        : comptes ayant validé EnterWorld (réellement en jeu).
 	// Source 100% en mémoire master, aucune persistance DB. Le portail interroge
 	// cette route en server-side et dégrade gracieusement si le master est injoignable.
-	auto onlineAccountsProvider = [&sessionManager, &sessionCharMap, &playerPresenceCache, &dbPool]() -> std::string {
+	auto onlineAccountsProvider = [&sessionManager, &sessionCharMap, &playerPresenceCache, &dbPool, &zoneNames]() -> std::string {
 		auto appendJsonArray = [](std::string& out, const std::vector<uint64_t>& ids) {
 			out += "[";
 			for (size_t i = 0; i < ids.size(); ++i)
@@ -1507,10 +1513,15 @@ int main(int argc, char** argv)
 					body += std::to_string(pit->second.level);
 					body += ",\"zoneId\":";
 					body += std::to_string(pit->second.zoneId);
+					// region : nom lisible si le manifeste de zone le fournit, sinon
+					// chaîne vide (le portail retombe sur « Zone N »).
+					body += ",\"region\":\"";
+					body += escapeJson(zoneNames.NameFor(pit->second.zoneId));
+					body += "\"";
 				}
 				else
 				{
-					body += ",\"level\":null,\"zoneId\":null";
+					body += ",\"level\":null,\"zoneId\":null,\"region\":null";
 				}
 			}
 			else

--- a/src/masterd/world/ZoneNameRegistry.cpp
+++ b/src/masterd/world/ZoneNameRegistry.cpp
@@ -1,0 +1,51 @@
+#include "src/masterd/world/ZoneNameRegistry.h"
+
+#include "src/shared/core/Config.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <filesystem>
+
+namespace engine::server
+{
+	size_t ZoneNameRegistry::Load(const std::string& zonesRoot)
+	{
+		m_byId.clear();
+
+		std::filesystem::path root(zonesRoot);
+		if (!engine::platform::FileSystem::Exists(root))
+		{
+			LOG_INFO(Server, "[ZoneNameRegistry] dossier zones absent ({}) — noms de région indisponibles (fallback portail).", zonesRoot);
+			return 0;
+		}
+
+		for (const auto& entry : engine::platform::FileSystem::ListDirectory(root))
+		{
+			std::error_code ec;
+			if (!std::filesystem::is_directory(entry, ec))
+				continue;
+
+			const std::filesystem::path manifest = entry / "runtime_manifest.json";
+			if (!engine::platform::FileSystem::Exists(manifest))
+				continue;
+
+			engine::core::Config cfg;
+			if (!cfg.LoadFromFile(manifest.string()))
+				continue;
+
+			const int64_t numericId = cfg.GetInt("zone_numeric_id", 0);
+			const std::string name = cfg.GetString("display_name", "");
+			if (numericId > 0 && !name.empty())
+				m_byId[static_cast<uint32_t>(numericId)] = name;
+		}
+
+		LOG_INFO(Server, "[ZoneNameRegistry] {} zone(s) nommée(s) chargée(s) depuis {}", m_byId.size(), zonesRoot);
+		return m_byId.size();
+	}
+
+	std::string ZoneNameRegistry::NameFor(uint32_t zoneId) const
+	{
+		auto it = m_byId.find(zoneId);
+		return it != m_byId.end() ? it->second : std::string();
+	}
+}

--- a/src/masterd/world/ZoneNameRegistry.h
+++ b/src/masterd/world/ZoneNameRegistry.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Registre zoneId(numérique) → nom de zone lisible, chargé depuis les fichiers de
+// carte (manifestes de zone) côté master pour la présence enrichie (web-portal).
+//
+// Le master monte les mêmes `game/data` que le shard ; il lit donc les manifestes
+// directement et résout le nom de région dans /online-accounts, sans transport
+// shard→master supplémentaire ni changement de protocole.
+//
+// Format attendu dans chaque `<zonesRoot>/<dossier>/runtime_manifest.json` :
+//   { "zone_numeric_id": <entier = le zoneId runtime>, "display_name": "<nom lisible>" , ... }
+// Les deux champs sont OPTIONNELS : une zone sans ces champs est simplement absente
+// du registre (le portail retombe alors sur « Zone N »). Aucun nom n'est inventé.
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server
+{
+	class ZoneNameRegistry
+	{
+	public:
+		/// Scanne \p zonesRoot (ex. "game/data/zones") : pour chaque sous-dossier
+		/// contenant un runtime_manifest.json avec `zone_numeric_id` (>0) ET
+		/// `display_name` (non vide), enregistre la correspondance. Idempotent
+		/// (remplace le contenu). Tolérant : dossier absent / manifeste illisible
+		/// → entrée ignorée. Retourne le nombre d'entrées chargées.
+		size_t Load(const std::string& zonesRoot);
+
+		/// Nom lisible pour \p zoneId, ou chaîne vide si inconnu.
+		std::string NameFor(uint32_t zoneId) const;
+
+		/// Nombre d'entrées connues.
+		size_t Size() const { return m_byId.size(); }
+
+	private:
+		std::unordered_map<uint32_t, std::string> m_byId;
+	};
+}

--- a/web-portal/app/admin/players/page.tsx
+++ b/web-portal/app/admin/players/page.tsx
@@ -21,7 +21,8 @@ function PresenceDot({ presence, detail }: { presence: PlayerPresence; detail?: 
     const parts: string[] = []
     if (detail.character) parts.push(detail.character)
     if (detail.level != null) parts.push(`niveau ${detail.level}`)
-    if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
+    if (detail.region) parts.push(detail.region)
+    else if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
     if (parts.length > 0) title = `${base} — ${parts.join(' • ')}`
   }
   // Vert bien clair, pastille PLEINE pour les deux états en ligne (plus de cercle
@@ -51,7 +52,8 @@ function OnlineDetailLine({ detail }: { detail?: OnlinePlayer }) {
   const parts: string[] = []
   if (detail.character) parts.push(detail.character)
   if (detail.level != null) parts.push(`niveau ${detail.level}`)
-  if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
+  if (detail.region) parts.push(detail.region)
+  else if (detail.zoneId != null) parts.push(regionName(detail.zoneId))
   if (parts.length === 0) return null
   return (
     <div style={{ marginTop: 3, fontFamily: 'var(--font-body)', fontSize: 11.5, color: 'var(--ln-success)' }}>

--- a/web-portal/lib/serverStatus.ts
+++ b/web-portal/lib/serverStatus.ts
@@ -25,6 +25,9 @@ export interface OnlinePlayer {
   character: string | null;
   level: number | null;
   zoneId: number | null;
+  /** Nom de région lisible résolu par le master depuis les manifestes de zone
+   *  (null si la zone n'a pas de display_name → le portail retombe sur « Zone N »). */
+  region: string | null;
   inWorld: boolean;
 }
 
@@ -73,6 +76,7 @@ function toPlayerMap(value: unknown): Map<number, OnlinePlayer> {
       character: toStringOrNull(row.character),
       level: toNumberOrNull(row.level),
       zoneId: toNumberOrNull(row.zoneId),
+      region: toStringOrNull(row.region),
       inWorld: row.inWorld === true,
     });
   }


### PR DESCRIPTION
## Noms de région depuis les fichiers de carte

Affiche le **vrai nom de région** (au lieu de « Zone N ») dans Admin → Gestion des joueurs, lu depuis les **manifestes de zone**.

### Choix d'archi : lecture **côté master** (plus simple, zéro risque)
Le master monte déjà `game/data` (comme le shard). Il lit donc les manifestes **lui-même** et résout le nom dans `/online-accounts` — **aucun changement shard, aucun changement de heartbeat/protocole**.

- **`ZoneNameRegistry` (master)** : scanne `<paths.content>/zones/<dossier>/runtime_manifest.json`, lit les champs **optionnels** `zone_numeric_id` (>0) + `display_name`, construit `zoneId(num) → nom`. Vide si les champs ne sont pas (encore) renseignés → **aucun nom inventé**.
- **`/online-accounts`** : nouveau champ `region` par joueur en jeu (chaîne vide si la zone n'a pas de nom).
- **Portail** : `OnlinePlayer.region` ; l'admin **préfère** `region` (API), sinon fallback `zones.ts` / « Zone N ».

### Format manifeste (à remplir côté contenu)
```json
{ "zone_id": "demo_plains", "zone_numeric_id": 1, "display_name": "Plaines de départ", ... }
```
Tant que ces champs sont absents → comportement actuel (« Zone N »). Dès qu'ils sont remplis, le nom remonte automatiquement (master à redémarrer pour recharger).

**Déploiement** : ⚠️ **master** (lit les manifestes + émet `region`) + **portail** (affiche `region`). **Pas** de shard, **pas** de protocole, **client inchangé**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
