### PR TITLE
perf(render): meshes de props en memoire device-local (corrige le lag de fond)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3643,6 +3643,10 @@ namespace engine
 										m_pipeline = std::make_unique<engine::render::DeferredPipeline>();
 
 										m_assetRegistry.Init(m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(), m_vmaAllocator, m_cfg);
+										// Upload device-local des meshes de props (buffers GPU rapides via staging)
+										// au lieu de buffers HOST_VISIBLE lus par PCIe chaque frame (lag de la foret).
+										m_assetRegistry.SetUploadContext(m_vkDeviceContext.GetGraphicsQueue(),
+											m_vkDeviceContext.GetGraphicsQueueFamilyIndex());
 
 										if (!m_profiler.Init(m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(), 2u))
 										{

--- a/src/client/render/AssetRegistry.cpp
+++ b/src/client/render/AssetRegistry.cpp
@@ -351,8 +351,9 @@ namespace engine::render
 			asset.hasLocalBounds = true;
 		}
 
+		// createBuffer parametré par usage + propriétés mémoire (host-visible OU device-local).
 		auto createBuffer = [&](VkDeviceSize size, VkBufferUsageFlags usage,
-			VkBuffer& outBuffer, void*& outAlloc) -> bool
+			VkMemoryPropertyFlags memProps, VkBuffer& outBuffer, void*& outAlloc) -> bool
 		{
 			VkBufferCreateInfo bufInfo{};
 			bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -363,8 +364,7 @@ namespace engine::render
 				return false;
 			VkMemoryRequirements memReq{};
 			vkGetBufferMemoryRequirements(m_device, outBuffer, &memReq);
-			uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+			uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits, memProps);
 			if (memTypeIdx == UINT32_MAX) { vkDestroyBuffer(m_device, outBuffer, nullptr); outBuffer = VK_NULL_HANDLE; return false; }
 			VkMemoryAllocateInfo allocInfo{};
 			allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
@@ -377,9 +377,18 @@ namespace engine::render
 			return true;
 		};
 
-		if (!createBuffer(vertexBytes, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, asset.vertexBuffer, asset.vertexAlloc))
+		// Device-local si une queue d'upload est fournie (SetUploadContext) : buffers
+		// GPU rapides (lus localement par le GPU) au lieu de HOST_VISIBLE (PCIe/frame).
+		const bool deviceLocal = (m_uploadQueue != VK_NULL_HANDLE);
+		constexpr VkMemoryPropertyFlags kHostProps =
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+		const VkMemoryPropertyFlags meshProps = deviceLocal ? VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT : kHostProps;
+		const VkBufferUsageFlags vtxUsage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | (deviceLocal ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
+		const VkBufferUsageFlags idxUsage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT  | (deviceLocal ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
+
+		if (!createBuffer(vertexBytes, vtxUsage, meshProps, asset.vertexBuffer, asset.vertexAlloc))
 			return MeshHandle(this, kInvalidAssetId);
-		if (!createBuffer(indexBytes, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, asset.indexBuffer, asset.indexAlloc))
+		if (!createBuffer(indexBytes, idxUsage, meshProps, asset.indexBuffer, asset.indexAlloc))
 		{
 			VkDeviceMemory vMem = reinterpret_cast<VkDeviceMemory>(asset.vertexAlloc);
 			vkDestroyBuffer(m_device, asset.vertexBuffer, nullptr);
@@ -387,12 +396,69 @@ namespace engine::render
 			return MeshHandle(this, kInvalidAssetId);
 		}
 
-		void* pv = nullptr;
-		VkDeviceMemory vMem = reinterpret_cast<VkDeviceMemory>(asset.vertexAlloc);
-		if (vkMapMemory(m_device, vMem, 0, vertexBytes, 0, &pv) == VK_SUCCESS) { memcpy(pv, vBytes, vertexBytes); vkUnmapMemory(m_device, vMem); }
-		void* pi = nullptr;
-		VkDeviceMemory iMem = reinterpret_cast<VkDeviceMemory>(asset.indexAlloc);
-		if (vkMapMemory(m_device, iMem, 0, indexBytes, 0, &pi) == VK_SUCCESS) { memcpy(pi, indices, indexBytes); vkUnmapMemory(m_device, iMem); }
+		if (!deviceLocal)
+		{
+			// Repli HOST_VISIBLE : map + memcpy direct.
+			void* pv = nullptr;
+			VkDeviceMemory vMem = reinterpret_cast<VkDeviceMemory>(asset.vertexAlloc);
+			if (vkMapMemory(m_device, vMem, 0, vertexBytes, 0, &pv) == VK_SUCCESS) { memcpy(pv, vBytes, vertexBytes); vkUnmapMemory(m_device, vMem); }
+			void* pi = nullptr;
+			VkDeviceMemory iMem = reinterpret_cast<VkDeviceMemory>(asset.indexAlloc);
+			if (vkMapMemory(m_device, iMem, 0, indexBytes, 0, &pi) == VK_SUCCESS) { memcpy(pi, indices, indexBytes); vkUnmapMemory(m_device, iMem); }
+		}
+		else
+		{
+			// Upload device-local : 1 buffer de staging host -> copie GPU -> attente.
+			const VkDeviceSize stagingSize = static_cast<VkDeviceSize>(vertexBytes + indexBytes);
+			VkBuffer staging = VK_NULL_HANDLE; void* stagingAlloc = nullptr;
+			const bool stagingOk = createBuffer(stagingSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostProps, staging, stagingAlloc);
+			VkDeviceMemory sMem = reinterpret_cast<VkDeviceMemory>(stagingAlloc);
+			if (stagingOk)
+			{
+				void* ps = nullptr;
+				if (vkMapMemory(m_device, sMem, 0, stagingSize, 0, &ps) == VK_SUCCESS)
+				{
+					memcpy(ps, vBytes, vertexBytes);
+					memcpy(reinterpret_cast<uint8_t*>(ps) + vertexBytes, indices, indexBytes);
+					vkUnmapMemory(m_device, sMem);
+				}
+				VkCommandPoolCreateInfo poolCI{};
+				poolCI.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+				poolCI.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+				poolCI.queueFamilyIndex = m_uploadQueueFamily;
+				VkCommandPool pool = VK_NULL_HANDLE;
+				if (vkCreateCommandPool(m_device, &poolCI, nullptr, &pool) == VK_SUCCESS)
+				{
+					VkCommandBufferAllocateInfo cbAI{};
+					cbAI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+					cbAI.commandPool = pool;
+					cbAI.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+					cbAI.commandBufferCount = 1;
+					VkCommandBuffer cmd = VK_NULL_HANDLE;
+					if (vkAllocateCommandBuffers(m_device, &cbAI, &cmd) == VK_SUCCESS)
+					{
+						VkCommandBufferBeginInfo bi{};
+						bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+						bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+						vkBeginCommandBuffer(cmd, &bi);
+						VkBufferCopy vc{}; vc.srcOffset = 0; vc.dstOffset = 0; vc.size = vertexBytes;
+						vkCmdCopyBuffer(cmd, staging, asset.vertexBuffer, 1, &vc);
+						VkBufferCopy ic{}; ic.srcOffset = vertexBytes; ic.dstOffset = 0; ic.size = indexBytes;
+						vkCmdCopyBuffer(cmd, staging, asset.indexBuffer, 1, &ic);
+						vkEndCommandBuffer(cmd);
+						VkSubmitInfo si{};
+						si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+						si.commandBufferCount = 1;
+						si.pCommandBuffers = &cmd;
+						vkQueueSubmit(m_uploadQueue, 1, &si, VK_NULL_HANDLE);
+						vkQueueWaitIdle(m_uploadQueue);
+					}
+					vkDestroyCommandPool(m_device, pool, nullptr);
+				}
+			}
+			if (staging != VK_NULL_HANDLE) vkDestroyBuffer(m_device, staging, nullptr);
+			if (sMem != VK_NULL_HANDLE) vkFreeMemory(m_device, sMem, nullptr);
+		}
 
 		AssetId id = m_nextMeshId++;
 		m_meshes[id] = std::move(asset);

--- a/src/client/render/AssetRegistry.h
+++ b/src/client/render/AssetRegistry.h
@@ -118,6 +118,16 @@ namespace engine::render
 		/// Initializes the registry for loading. vmaAllocator = centralised GPU allocator (VMA); cast to VmaAllocator in impl.
 		void Init(VkDevice device, VkPhysicalDevice physicalDevice, void* vmaAllocator, const engine::core::Config& config);
 
+		/// Fournit la queue + famille servant aux uploads device-local (staging). Si
+		/// renseignée, CreateMeshFromData crée des buffers DEVICE_LOCAL (rapides en
+		/// rendu) via une copie de staging au lieu de buffers HOST_VISIBLE (lents,
+		/// lus par le GPU via PCIe à chaque frame). À appeler une fois après Init.
+		void SetUploadContext(VkQueue uploadQueue, uint32_t uploadQueueFamilyIndex)
+		{
+			m_uploadQueue = uploadQueue;
+			m_uploadQueueFamily = uploadQueueFamilyIndex;
+		}
+
 		/// Loads a mesh from content path (relative to paths.content). Returns cached asset if already loaded.
 		/// Format: minimal binary .mesh (see implementation). Returns invalid handle on failure.
 		MeshHandle LoadMesh(std::string_view relativePath);
@@ -164,6 +174,10 @@ namespace engine::render
 		VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
 		void* m_vmaAllocator = nullptr;
 		const engine::core::Config* m_config = nullptr;
+		/// Queue + famille pour les uploads device-local des meshes (cf. SetUploadContext).
+		/// VK_NULL_HANDLE = repli HOST_VISIBLE (pas de staging).
+		VkQueue m_uploadQueue = VK_NULL_HANDLE;
+		uint32_t m_uploadQueueFamily = 0;
 
 		AssetId m_nextMeshId = 1;
 		AssetId m_nextTextureId = 1;


### PR DESCRIPTION
Correctif de fond de la perf des props : passage en memoire **device-local**.

## Probleme
`CreateMeshFromData` allouait les buffers de props en **HOST_VISIBLE** : le GPU relit la geometrie via PCIe **a chaque frame**. Avec des centaines de props -> framerate effondre (cause racine du lag de la foret dense).

## Correctif
- `CreateMeshFromData` cree des buffers **DEVICE_LOCAL** (memoire GPU rapide) via une copie de **staging** (pattern identique a FinalizePresentBlit / UploadHeightmap deja en place).
- `AssetRegistry::SetUploadContext(queue, family)` (appele apres Init) fournit la queue d'upload. Repli HOST_VISIBLE si non fournie.
- Aucun changement de rendu visuel ; seulement la localisation memoire.

## Impact
Permet de **re-densifier la foret** (via scatter_forest) sans le lag. Surcout : quelques copies de staging au chargement de la zone (one-time, synchrone comme les autres uploads boot).

## Conflits
Touche `AssetRegistry.cpp/.h` (non touches par #784/#785) + 1 ligne `Engine.cpp` (pres de Init, loin des zones de #784/#785) -> mergeable independamment.

## Verification
Compilation CI. A valider au runtime : foret fluide ; possibilite de re-densifier.

## Deploiement
[OK] Client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)