### PR TITLE
feat(render): M45.1 — perspective aérienne (extinction exp + inscattering soleil)

### DIFF
--- a/config.json
+++ b/config.json
@@ -146,10 +146,12 @@
         "props": {
             "cull_distance_m": 80.0
         },
-        "_comment_fog": "Brouillard atmospherique LINEAIRE a distance (profondeur de champ). start_m : rayon CLAIR autour du joueur (aucun brouillard en deca) ; end_m : distance ou tout est fondu vers la couleur d'horizon du ciel. Le joueur n'est PAS noye dans le brouillard. Desactive si end_m <= start_m. Conseil : mettre end_m proche de world.props.cull_distance_m pour que les arbres se fondent dans le ciel juste avant d'etre cull (transition invisible). Lu a chaque frame -> reglage a chaud.",
+        "_comment_fog": "M45.1 Perspective aerienne a distance. start_m : rayon CLAIR autour du joueur (aucun brouillard en deca) ; end_m : distance de fondu COMPLET vers la teinte atmospherique (garantit le masquage de la coupe de distance des props). density : extinction exponentielle (1/m), <= 0 desactive l'effet ; inscatter : force du halo chaud directionnel quand on regarde le soleil. start/end : desactive si end_m <= start_m. density/inscatter : override des valeurs per-zone (atmosphere.json : aerial.density / aerial.inscatter) ; retirer ces cles ici pour piloter par zone. Lu a chaque frame -> reglage a chaud.",
         "fog": {
             "start_m": 35.0,
-            "end_m": 85.0
+            "end_m": 85.0,
+            "density": 0.012,
+            "inscatter": 0.6
         },
         "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet), mesh/scale/yaw_deg/rot_x_deg, dialogue. Seuls les VRAIS interactibles ici (PNJ, coffre). Le DECOR (arbres, props non interactifs mais solides) est dans world.scenery. Le coffre et le villageois sont solides (collision) comme tout le decor.",
         "interactables": {

--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -26,6 +26,12 @@
 //                         ready (alors on lit GBufferA pour la sky), 0.0
 //                         si on utilise la flat skyColor.
 //   float useIBL        – 1.0 = use IBL, 0.0 = constant ambient
+//
+// M45.1 — Perspective aérienne (upgrade du brouillard de distance) :
+//   lightColor.w = aerialDensity   – densité d'extinction (1/m). <= 0 désactive.
+//   ambientColor.w = aerialInscatter – force du halo directionnel vers le soleil.
+//   fogStart (cameraPos.w) = rayon clair ; fogEnd (lightDir.w) = distance de
+//   fondu complet (garantit le masquage de la coupe de distance des props).
 
 layout(location = 0) in  vec2 inUV;
 layout(location = 0) out vec4 outSceneColorHDR;
@@ -45,13 +51,18 @@ layout(set = 0, binding = 8) uniform sampler2D   decalOverlayTex;
 layout(push_constant) uniform PC
 {
     mat4  invVP;        // inverse view-projection (for world position reconstruction)
-    vec4  cameraPos;    // camera world-space position (xyz, w unused)
-    vec4  lightDir;     // normalised direction toward the directional light (xyz)
-    vec4  lightColor;   // RGB radiance (xyz = color * intensity)
-    vec4  ambientColor; // constant ambient RGB (fallback when useIBL == 0)
+    vec4  cameraPos;    // xyz = camera world-space position ; w = aerial fogStart (m)
+    vec4  lightDir;     // xyz = normalised direction toward the sun ; w = aerial fogEnd (m)
+    vec4  lightColor;   // xyz = RGB radiance (color * intensity) ; w = aerialDensity (1/m)
+    vec4  ambientColor; // xyz = constant ambient RGB (fallback) ; w = aerialInscatter
     vec4  skyColor;     // rgb = couleur du ciel flat (fallback) ; w = 1.0 si SkyPass ready
     float useIBL;       // 1.0 = use IBL, 0.0 = constant ambient
 } pc;
+
+// M45.1 — exposant d'anisotropie du halo directionnel d'inscattering vers le
+// soleil. Plus élevé = halo plus concentré autour du disque solaire. Constante
+// (pas de slot push-constant libre) ; ajuster ici si besoin de réglage visuel.
+const float kAerialSunExponent = 8.0;
 
 // ---- Constants --------------------------------------------------------------
 const float PI       = 3.14159265358979323846;
@@ -186,22 +197,39 @@ void main()
     // ---- Combine & output HDR ------------------------------------------
     vec3  color = ambient + Lo;
 
-    // ---- Brouillard atmospherique LINEAIRE (profondeur de champ) -------
-    // Brouillard a DISTANCE : zone CLAIRE autour du joueur (< fogStart), puis
-    // fondu lineaire vers la couleur d'horizon (pc.skyColor.rgb) jusqu'a
-    // fogEnd ou tout est ciel. Le joueur n'est donc PAS noye dans le
-    // brouillard ; ca ajoute de la profondeur au loin ET masque la coupe de
-    // distance des props (regler fogEnd ~ world.props.cull_distance_m).
-    // fogStart = pc.cameraPos.w, fogEnd = pc.lightDir.w (slots libres).
-    // Desactive si fogEnd <= fogStart. Applique UNIQUEMENT aux pixels avec
-    // geometrie (le ciel a deja ete ecrit via l'early-return depth>=1.0).
-    float fogStart = pc.cameraPos.w;
-    float fogEnd   = pc.lightDir.w;
-    if (fogEnd > fogStart)
+    // ---- M45.1 — Perspective aerienne (extinction + inscattering) ------
+    // Upgrade du brouillard de distance : zone CLAIRE autour du joueur
+    // (< fogStart), puis EXTINCTION EXPONENTIELLE vers une teinte
+    // atmospherique. Le joueur n'est PAS noye ; ca ajoute de la profondeur
+    // au loin, suit le cycle jour/nuit (base = skyHorizon) et masque la
+    // coupe de distance des props (regler fogEnd ~ world.props.cull_distance_m).
+    // Teinte = horizon, rechauffee vers le soleil quand on le regarde
+    // (inscattering directionnel, sans ray-march — c'est M45.2 qui marchera).
+    // Slots : fogStart=cameraPos.w, fogEnd=lightDir.w, density=lightColor.w,
+    // inscatter=ambientColor.w. Desactive si fogEnd<=fogStart ou density<=0.
+    // Applique UNIQUEMENT aux pixels avec geometrie (le ciel a deja ete ecrit
+    // via l'early-return depth>=1.0).
+    float fogStart  = pc.cameraPos.w;
+    float fogEnd    = pc.lightDir.w;
+    float density   = pc.lightColor.w;
+    float inscatter = pc.ambientColor.w;
+    if (fogEnd > fogStart && density > 0.0)
     {
         float dist = length(pc.cameraPos.xyz - P);
-        float fogF = clamp((dist - fogStart) / (fogEnd - fogStart), 0.0, 1.0);
-        color = mix(color, pc.skyColor.rgb, fogF);
+        float d    = max(dist - fogStart, 0.0);
+        // Extinction exponentielle (transmittance = exp(-d*density)).
+        float fog  = 1.0 - exp(-d * density);
+        // Filet de securite : garantit l'opacite complete a fogEnd (masquage du
+        // cull des props), meme si la densite seule n'y suffit pas. smoothstep
+        // reste ~0 pres de fogStart pour laisser l'exponentielle s'exprimer.
+        fog = max(fog, smoothstep(fogStart, fogEnd, dist));
+        // Inscattering directionnel : halo chaud vers le soleil (couleur du
+        // soleil = lightColor.rgb), base = couleur d'horizon (skyColor.rgb,
+        // pilotee jour/nuit). rayDir = direction camera->pixel.
+        vec3  rayDir = normalize(P - pc.cameraPos.xyz);
+        float sunAmt = pow(max(dot(rayDir, normalize(pc.lightDir.xyz)), 0.0), kAerialSunExponent) * inscatter;
+        vec3  tint   = mix(pc.skyColor.rgb, pc.lightColor.rgb, clamp(sunAmt, 0.0, 1.0));
+        color = mix(color, tint, fog);
     }
 
     outSceneColorHDR = vec4(color, 1.0);

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5525,12 +5525,17 @@ namespace engine
 												lp.cameraPos[3] = static_cast<float>(m_cfg.GetDouble("world.fog.start_m", 35.0));
 												lp.lightDir[0] = m_zoneAtmosphere.sunDirection[0]; lp.lightDir[1] = m_zoneAtmosphere.sunDirection[1]; lp.lightDir[2] = m_zoneAtmosphere.sunDirection[2];
 												lp.lightDir[3] = static_cast<float>(m_cfg.GetDouble("world.fog.end_m", 85.0)); // brouillard : distance de fondu total (cf. cameraPos.w = start)
-												lp.lightColor[0] = m_zoneAtmosphere.sunColor[0]; lp.lightColor[1] = m_zoneAtmosphere.sunColor[1]; lp.lightColor[2] = m_zoneAtmosphere.sunColor[2]; lp.lightColor[3] = 0.0f;
+												lp.lightColor[0] = m_zoneAtmosphere.sunColor[0]; lp.lightColor[1] = m_zoneAtmosphere.sunColor[1]; lp.lightColor[2] = m_zoneAtmosphere.sunColor[2];
+												// M45.1 — densité d'extinction de la perspective aérienne (slot lightColor.w).
+												// Override config.json (world.fog.density) sinon valeur per-zone (atmosphere.json).
+												lp.lightColor[3] = static_cast<float>(m_cfg.GetDouble("world.fog.density", static_cast<double>(m_zoneAtmosphere.aerialDensity)));
 												const float probeIntensity = GetGlobalProbeIntensity(m_zoneProbes);
 												lp.ambientColor[0] = m_zoneAtmosphere.ambientColor[0] * probeIntensity;
 												lp.ambientColor[1] = m_zoneAtmosphere.ambientColor[1] * probeIntensity;
 												lp.ambientColor[2] = m_zoneAtmosphere.ambientColor[2] * probeIntensity;
-												lp.ambientColor[3] = 0.0f;
+												// M45.1 — force d'inscattering directionnel (slot ambientColor.w).
+												// Override config.json (world.fog.inscatter) sinon valeur per-zone.
+												lp.ambientColor[3] = static_cast<float>(m_cfg.GetDouble("world.fog.inscatter", static_cast<double>(m_zoneAtmosphere.aerialInscatter)));
 												// Couleur du ciel utilisée par lighting.frag pour les pixels
 												// sans géométrie (depth==1.0). Pilotée par DayNightCycle pour
 												// rendre le cycle jour/nuit visible sans skybox dédié.

--- a/src/client/render/LightingPass.h
+++ b/src/client/render/LightingPass.h
@@ -30,10 +30,10 @@ namespace engine::render
 		struct LightParams
 		{
 			float invViewProj[16]; ///< Inverse view-projection matrix, column-major (64 bytes).
-			float cameraPos[4];   ///< Camera world-space position xyz, w unused (16 bytes).
-			float lightDir[4];    ///< Normalized direction *toward* the light, xyz, w unused.
-			float lightColor[4];   ///< RGB radiance (color * intensity), w unused.
-			float ambientColor[4]; ///< Constant ambient RGB, w unused (fallback when IBL absent).
+			float cameraPos[4];   ///< Camera world-space position xyz ; w = M45.1 aerial fogStart (m).
+			float lightDir[4];    ///< Normalized direction *toward* the light xyz ; w = M45.1 aerial fogEnd (m).
+			float lightColor[4];   ///< RGB radiance (color * intensity) ; w = M45.1 aerialDensity (1/m, <=0 désactive).
+			float ambientColor[4]; ///< Constant ambient RGB (fallback when IBL absent) ; w = M45.1 aerialInscatter.
 			float skyColor[4];     ///< RGB couleur du ciel (skyHorizon DayNightCycle) pour les pixels sans géométrie. w unused.
 			float useIBL;          ///< 1.0 = use IBL (irradiance + prefilter + BRDF LUT), 0.0 = fallback.
 		};

--- a/src/client/world/ProbeData.cpp
+++ b/src/client/world/ProbeData.cpp
@@ -116,6 +116,12 @@ namespace engine::world
 		ReadFloat3(atmosphereCfg, "sun.direction", outSettings.sunDirection);
 		ReadFloat3(atmosphereCfg, "sun.color", outSettings.sunColor);
 		ReadFloat3(atmosphereCfg, "ambient.color", outSettings.ambientColor);
+		// M45.1 — Perspective aérienne (per-zone, optionnel). Si la clé est
+		// absente d'atmosphere.json, on garde le défaut doux de la struct.
+		if (atmosphereCfg.Has("aerial.density"))
+			outSettings.aerialDensity = static_cast<float>(atmosphereCfg.GetDouble("aerial.density", static_cast<double>(outSettings.aerialDensity)));
+		if (atmosphereCfg.Has("aerial.inscatter"))
+			outSettings.aerialInscatter = static_cast<float>(atmosphereCfg.GetDouble("aerial.inscatter", static_cast<double>(outSettings.aerialInscatter)));
 		LOG_INFO(Core, "[ZoneProbes] Load atmosphere OK (path={})", fullPath.string());
 		return true;
 	}

--- a/src/client/world/ProbeData.h
+++ b/src/client/world/ProbeData.h
@@ -38,6 +38,11 @@ namespace engine::world
 		float sunDirection[3]{ 0.5774f, 0.5774f, 0.5774f };
 		float sunColor[3]{ 1.0f, 0.95f, 0.85f };
 		float ambientColor[3]{ 0.03f, 0.03f, 0.05f };
+		// M45.1 — Perspective aérienne (par zone). aerialDensity = densité
+		// d'extinction (1/m), <= 0 désactive l'effet. aerialInscatter = force du
+		// halo directionnel chaud vers le soleil. Défauts doux (effet léger).
+		float aerialDensity{ 0.012f };
+		float aerialInscatter{ 0.6f };
 	};
 
 	/// Load `probes.bin` from a content-relative path resolved via `paths.content`.

--- a/tickets/M45/M45.1_Atmosphere_aerial_perspective.md
+++ b/tickets/M45/M45.1_Atmosphere_aerial_perspective.md
@@ -1,0 +1,55 @@
+# M45.1 — Aerial perspective (scattering atmosphérique étendu)
+
+## Objectif
+Ajouter une perspective aérienne physique : les objets lointains se teintent et s'estompent progressivement selon la distance et la direction du soleil, créant la sensation de profondeur caractéristique des jeux AAA. S'appuie sur le `SkyPass` procédural existant et le `LightingPass` qui lit déjà GBufferA pour les pixels de ciel.
+
+## Dépendances
+- Aucune dépendance nouvelle. S'intègre dans le pipeline existant.
+- Pré-requis : `SkyPass`, `LightingPass`, `DayNightCycle` opérationnels (déjà présents).
+
+## Contexte du code réel (vérifié)
+- Le ciel est dessiné par `src/client/render/SkyPass.{h,cpp}` via `game/data/shaders/sky.vert` + `sky.frag`, dans le render pass `loadOp=LOAD` du `GeometryPass`, après la géométrie.
+- `src/client/render/LightingPass.{h,cpp}` lit déjà GBufferA pour les pixels de ciel (`depth==1.0`) et reçoit `LightParams` (dont `skyColor`, direction soleil) en push constants.
+- L'ordre des passes dans `src/client/app/Engine.cpp` est : Clear → GPU_Cull → Geometry(+Sky) → HiZ_Build → SSAO → Decals → Lighting → Water → Bloom → …
+- Le cycle jour/nuit fournit déjà direction et couleur du soleil (`DayNightCycle`).
+
+## Livrables
+- Extension du shader d'éclairage (`game/data/shaders/lighting.frag` ou équivalent réel consommé par `LightingPass`) : ajout du calcul d'aerial perspective appliqué aux pixels de géométrie en fonction de la profondeur reconstruite et de la transmittance atmosphérique.
+- Nouveaux paramètres dans `LightingPass::LightParams` (ou une struct dédiée) : densité atmosphérique, couleur de diffusion (inscattering), distances de début/fin, intensité. Valeurs par défaut neutres (effet quasi nul) pour ne rien changer visuellement tant que non réglé.
+- Câblage de ces paramètres depuis le `DayNightCycle` / réglages de zone (atmosphère par zone existe déjà dans `AtmosphereSettings`, cf. `src/client/world/ProbeData.h`).
+- Flag d'activation runtime (`bool aerialPerspectiveEnabled`), désactivable, défaut activé avec valeurs douces.
+
+## Spécification technique
+- Modèle : extinction + inscattering exponentiels par distance (approximation de type Hillaire, version analytique légère — pas de LUT 3D obligatoire pour ce ticket).
+- Reconstruire la position vue depuis le depth buffer (déjà disponible en entrée du `LightingPass`).
+- Appliquer : `couleur_finale = couleur_eclairee * transmittance + inscattering * (1 - transmittance)`.
+- L'inscattering doit utiliser la couleur et la direction du soleil du `DayNightCycle` pour rester cohérent jour/nuit.
+- Coût : calcul par pixel dans la passe lighting existante, négligeable (pas de nouvelle passe plein écran).
+
+## Étapes d'implémentation
+1. `git clone` et vérifier le nom réel du shader de lighting et la struct `LightParams`.
+2. Ajouter les paramètres atmosphériques à la struct de push constants / UBO du `LightingPass`.
+3. Étendre le fragment shader de lighting avec la fonction d'aerial perspective, appliquée seulement aux pixels de géométrie (pas aux pixels de ciel, qui sont déjà gérés).
+4. Câbler les valeurs depuis `DayNightCycle` / `AtmosphereSettings` de zone.
+5. Recompiler le `.spv` (suivre la convention de compilation des shaders du repo).
+6. Mettre à jour `CMakeLists.txt` si un fichier est ajouté.
+
+## Ne doit RIEN casser
+- **Ne pas ajouter de nouvelle passe** : l'effet vit dans le `LightingPass` existant. Aucun changement à l'ordre du frame graph.
+- **Ne pas modifier la signature publique** de `LightingPass::Record` au-delà de l'ajout de champs dans la struct de paramètres (champs avec valeurs par défaut neutres).
+- **Pixels de ciel inchangés** : l'effet ne s'applique qu'aux pixels avec `depth < 1.0`.
+- Avec les paramètres par défaut, le rendu doit rester visuellement identique à l'actuel à courte distance.
+- Tous les tests existants doivent continuer à passer sans modification.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK sur Windows et Linux (CI verte).
+- [ ] Aucune erreur de validation Vulkan.
+- [ ] À distance, les objets lointains s'estompent et se teintent vers la couleur atmosphérique ; de près, aucun changement visible.
+- [ ] L'effet suit le cycle jour/nuit (teinte chaude au couchant, froide la nuit).
+- [ ] Désactivable via le flag ; désactivé = rendu strictement identique à l'état avant ticket.
+- [ ] Tous les tests existants passent sans avoir été modifiés.
+- [ ] DoD globale du repo respectée.
+
+## Notes / pièges à éviter
+- Bien reconstruire la profondeur linéaire (attention au reverse-Z si utilisé par le pipeline — vérifier la configuration du depth dans le repo).
+- Ne pas confondre avec le futur volumetric fog (M45.2) : ici, pas de marching, juste un terme analytique par pixel.

--- a/tickets/M45/M45.2_Atmosphere_volumetric_fog.md
+++ b/tickets/M45/M45.2_Atmosphere_volumetric_fog.md
@@ -1,0 +1,56 @@
+# M45.2 — Volumetric fog (brouillard volumique + god rays)
+
+## Objectif
+Ajouter un brouillard volumique éclairé par le soleil et les lumières dynamiques, produisant des rayons de lumière (god rays / shafts) cohérents avec les ombres cascadées. C'est un des plus forts multiplicateurs d'ambiance AAA.
+
+## Dépendances
+- **M45.1** (aerial perspective) — recommandé d'abord pour que la profondeur atmosphérique soit cohérente.
+- Pré-requis existants : `CascadedShadowMaps`, `LightingPass`, `DynamicLightSystem`, `DayNightCycle`, `FrameGraph`.
+
+## Contexte du code réel (vérifié)
+- `src/client/render/CascadedShadowMaps.{h,cpp}` fournit la carte d'ombres du soleil.
+- `src/client/render/DynamicLightSystem.{h,cpp}` gère les lumières ponctuelles.
+- Le `FrameGraph` (`src/client/render/FrameGraph.*`) permet d'ajouter une passe compute via `addPass`, avec déclaration read/write pour les barrières (voir `PassBuilder::read/write` et le pattern `SSAO_Generate` dans `Engine.cpp`).
+- Les passes de post (SSAO, bloom) montrent le pattern d'une passe plein écran consommant le depth + GBuffer.
+
+## Livrables
+- Nouvelle passe compute `src/client/render/VolumetricFogPass.{h,cpp}` suivant le pattern des passes existantes (Init/Record/Shutdown, gating par flag de readiness comme `m_skyPassReady`).
+- Shaders : `game/data/shaders/volumetric_fog.comp` (froxel ray-march) + intégration dans la composition (lecture par `LightingPass` ou passe de composite dédiée).
+- Volume de diffusion en froxels (grille alignée au frustum), échantillonnant la shadow map cascadée pour l'occlusion de la lumière.
+- Paramètres : densité, anisotropie (Henyey-Greenstein), couleur, hauteur de brouillard, contribution des lumières dynamiques.
+- Flag d'activation runtime, désactivable, **défaut désactivé** (à activer par zone une fois réglé).
+
+## Spécification technique
+- Approche froxel : grille 3D (ex. 160×90×64) couvrant le frustum, ray-march en compute, accumulation de scattering + transmittance, puis application en composite.
+- Échantillonner `CascadedShadowMaps` pour déterminer si chaque froxel est éclairé par le soleil.
+- Phase function Henyey-Greenstein pour l'anisotropie (rayons orientés soleil).
+- Intégration temporelle optionnelle (réutiliser le jitter de `TaaJitter.h`) pour réduire le bruit — mais ne pas casser le TAA existant.
+
+## Étapes d'implémentation
+1. `git clone`, vérifier l'API réelle de `CascadedShadowMaps` (accès aux matrices/cartes) et le format du depth.
+2. Créer `VolumetricFogPass` (Init crée pipeline compute + ressources froxel ; Shutdown détruit ; Record dispatch).
+3. Écrire `volumetric_fog.comp`, compiler en `.spv`.
+4. Insérer la passe dans le frame graph **après Lighting et avant Bloom**, en lecture du depth + shadow map, écriture dans une ressource de scattering dédiée (pas d'écriture sur une ressource déjà écrite).
+5. Composer le résultat sur l'image éclairée (passe de composite ou ajout contrôlé dans la lighting).
+6. Câbler densité/couleur depuis `AtmosphereSettings` de zone.
+7. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- **Passe dédiée, gated** : si `VolumetricFogPass::Init` échoue (shader manquant, etc.), `m_volumetricFogReady=false` et la passe n'est pas ajoutée au frame graph — pipeline identique à l'actuel.
+- **Respecter l'interdiction du frame graph** : pas de double writer sur une ressource existante. La passe écrit dans SA propre ressource de scattering, puis le composite lit ; ne pas écrire directement dans le buffer déjà rempli par Lighting.
+- **Ne pas perturber le TAA** : si l'intégration temporelle est utilisée, valider que les vecteurs de mouvement et le jitter existants restent corrects.
+- Défaut désactivé : aucun changement visuel tant qu'une zone ne l'active pas explicitement.
+- Tous les tests existants doivent continuer à passer.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux (CI verte), aucune erreur de validation Vulkan.
+- [ ] Brouillard visible et god rays cohérents avec les ombres du soleil quand activé.
+- [ ] Désactivé (défaut) = rendu strictement identique à l'état avant ticket.
+- [ ] Pas de scintillement TAA introduit.
+- [ ] Le coût GPU de la passe est mesuré et reporté (via le `Profiler` du frame graph).
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- Le ray-march froxel peut être bruité : limiter la densité par défaut et documenter les bornes de réglage.
+- Attention à l'ordre d'insertion : après Lighting (besoin de la scène éclairée + depth), avant Bloom (pour que les rayons bloomment naturellement).

--- a/tickets/M45/M45.3_Composition_depth_of_field.md
+++ b/tickets/M45/M45.3_Composition_depth_of_field.md
@@ -1,0 +1,51 @@
+# M45.3 — Depth of field (bokeh)
+
+## Objectif
+Ajouter une profondeur de champ (flou de mise au point) en post-traitement : netteté sur le plan focal, flou progressif au premier plan et à l'arrière-plan. Petit ajout dans une chaîne de post-process déjà mature.
+
+## Dépendances
+- Indépendant de M45.1/M45.2 (peut être fait en parallèle), mais listé en 3e car il complète la couche composition.
+- Pré-requis existants : `BloomPass`, `TonemapPass`, `AutoExposure`, `FrameGraph`, `TaaPass`.
+
+## Contexte du code réel (vérifié)
+- Chaîne de composition existante : Lighting → (Water) → Bloom_Prefilter → … → Tonemap, orchestrée dans `src/client/app/Engine.cpp` via `m_frameGraph.addPass`.
+- Le depth buffer est disponible et déjà consommé par SSAO et le futur fog.
+- Pattern de passe plein écran établi (cf. `BloomPass`, `SsaoPass`).
+
+## Livrables
+- Nouvelle passe `src/client/render/DepthOfFieldPass.{h,cpp}` (Init/Record/Shutdown + gating).
+- Shaders : `game/data/shaders/dof_coc.comp` ou `.frag` (calcul du Circle of Confusion depuis le depth) + `dof_blur` (flou séparable ou bokeh).
+- Paramètres : distance focale, ouverture (force du flou), bornes near/far. Câblage optionnel sur la caméra (`src/client/render/Camera.*`).
+- Flag d'activation runtime, **défaut désactivé**.
+
+## Spécification technique
+- Calculer le CoC par pixel depuis la profondeur linéaire et la distance focale.
+- Flou guidé par le CoC : approche en deux passes (near/far) ou bokeh disque léger.
+- Insérer **après le tonemap** (DOF sur image LDR perçue) ou **avant** (sur HDR, meilleur pour les highlights bokeh) — choisir avant-tonemap pour la qualité, le documenter.
+
+## Étapes d'implémentation
+1. `git clone`, repérer l'emplacement exact du tonemap dans le frame graph et le format de l'image à ce stade.
+2. Créer `DepthOfFieldPass`.
+3. Écrire les shaders CoC + blur, compiler en `.spv`.
+4. Insérer la passe au bon point de la chaîne, en lecture depth + image couleur, écriture dans une ressource dédiée.
+5. Câbler distance focale sur la caméra (auto-focus sur le centre de l'écran optionnel).
+6. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- Passe dédiée et gated : si Init échoue, passe non ajoutée, pipeline inchangé.
+- Pas de double writer : écrire dans une ressource propre, pas par-dessus l'image déjà composée par une autre passe.
+- Défaut désactivé : rendu identique à l'actuel tant que non activé.
+- Ne pas modifier l'ordre des passes existantes ni les signatures publiques de `BloomPass`/`TonemapPass`.
+- Tous les tests existants doivent passer.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux, aucune erreur de validation Vulkan.
+- [ ] Flou progressif correct selon la distance focale ; plan focal net.
+- [ ] Désactivé (défaut) = rendu strictement identique à l'état avant ticket.
+- [ ] Coût GPU mesuré et reporté.
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- Éviter le « bleeding » du flou à travers les arêtes nettes (respecter le CoC en pondérant les samples).
+- Vérifier l'interaction avec le TAA (le flou peut amplifier le ghosting si placé avant la résolution TAA — préférer après).

--- a/tickets/M45/M45.4_LOD_impostor_builder_offline.md
+++ b/tickets/M45/M45.4_LOD_impostor_builder_offline.md
@@ -1,0 +1,51 @@
+# M45.4 — Génération offline des impostors octaédriques
+
+## Objectif
+Créer l'outil offline qui pré-rend des impostors octaédriques (atlas de vues d'un mesh sous plusieurs angles) pour la végétation et les objets répétitifs lointains. C'est le pré-requis data du rendu runtime (M45.5).
+
+## Dépendances
+- Aucune dépendance runtime. Utilise les meshes statiques existants (`src/client/render/static_mesh/StaticMeshLoader`).
+- Pré-requis : connaître le format de mesh statique du repo.
+
+## Contexte du code réel (vérifié)
+- Meshes statiques : `src/client/render/static_mesh/StaticMeshLoader.{h,cpp}`.
+- Outils offline : sous `tools/` (le repo a déjà un dossier `tools/` et un `build_hlod.bat` pour le HLOD — calquer ce pattern d'outil de génération d'assets).
+- Le HLOD (`src/client/world/HlodRuntime`) montre que le pipeline d'assets pré-calculés existe déjà.
+- Contenu produit : sous `game/data/...`, résolu via `paths.content`.
+
+## Livrables
+- Outil offline `tools/impostor_builder/...` (exécutable CMake, calqué sur l'outillage existant type `zone_builder`).
+- Format binaire d'impostor documenté : atlas de N×N vues (albedo + normale + profondeur/alpha), mapping octaédrique.
+- Génération : pour un mesh donné, rendu hors-ligne sous N×N directions, packing dans un atlas, écriture du fichier binaire sous `game/data/...`.
+- Script/batch d'invocation calqué sur `build_hlod.bat`.
+
+## Spécification technique
+- Mapping octaédrique des directions de vue (standard, 8×8 ou 16×16 vues selon qualité).
+- Par vue : capturer albedo, normale monde (ou tangente), masque alpha, et profondeur relative pour le parallaxe.
+- Packing ORM cohérent avec la convention du repo (R=AO, G=Roughness, B=Metallic) si applicable.
+- Format binaire versionné (magic + version, comme `kProbeSetMagic`/`kProbeSetVersion` dans `ProbeData.h`).
+
+## Étapes d'implémentation
+1. `git clone`, étudier `StaticMeshLoader` et l'outillage existant (`tools/`, `build_hlod.bat`, `zone_builder`).
+2. Créer le projet outil sous `tools/impostor_builder/` et l'enregistrer dans `CMakeLists.txt`.
+3. Implémenter le rendu offline multi-vues (peut réutiliser un contexte Vulkan offscreen, ou un rasterizer CPU simple si suffisant).
+4. Définir et écrire le format binaire d'atlas d'impostor sous `game/data/...`.
+5. Fournir un batch d'invocation type `build_impostors.bat`.
+
+## Ne doit RIEN casser
+- **Outil offline pur** : n'ajoute aucun code dans le chemin de rendu runtime. Zéro impact sur le client en jeu.
+- Ne crée aucun dossier racine non autorisé ; les assets produits vont sous `game/data/...`, le code outil sous `tools/`.
+- Aucun chemin absolu ; tout via `paths.content` + relatif.
+- Tous les tests existants doivent passer.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux ; l'outil se lance et produit un fichier d'impostor valide.
+- [ ] Le format binaire est versionné et documenté (un court `.md` à côté de l'outil).
+- [ ] Round-trip : un test de relecture du format produit confirme l'intégrité (magic, version, dimensions, nombre de vues).
+- [ ] Aucun fichier ajouté dans le chemin runtime du client.
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- Garder l'atlas raisonnable en mémoire (résolution par vue modérée).
+- Documenter clairement le mapping octaédrique pour que M45.5 décode exactement les mêmes directions.

--- a/tickets/M45/M45.5_LOD_impostor_runtime.md
+++ b/tickets/M45/M45.5_LOD_impostor_runtime.md
@@ -1,0 +1,56 @@
+# M45.5 — Rendu runtime des impostors végétation
+
+## Objectif
+Afficher au loin les impostors octaédriques produits par M45.4, en remplacement des meshes complets au-delà d'une distance seuil, avec transition douce (fade) pour éviter le popping. Donne la densité de végétation lointaine caractéristique AAA pour un coût minime.
+
+## Dépendances
+- **M45.4** (génération offline des impostors) — obligatoire, fournit les assets.
+- Pré-requis existants : `GpuDrivenCullingPass`, `InstanceBatch`, `TerrainGrassDetail`, `StreamingScheduler`, `LodConfig`, `HlodRuntime`.
+
+## Contexte du code réel (vérifié)
+- Instancing existant : `src/client/render/InstanceBatch.h`, `src/client/render/ParticleBillboardPass.{h,cpp}` (montre déjà un pattern de billboard GPU réutilisable).
+- Détail de végétation : `src/client/render/terrain/TerrainGrassDetail.{h,cpp}`.
+- Config LOD : `src/client/world/LodConfig.{h,cpp}` + chaîne HLOD `src/client/world/HlodRuntime.{h,cpp}` (point d'intégration naturel pour la sélection mesh→impostor par distance).
+- Culling GPU : `src/client/render/GpuDrivenCullingPass.{h,cpp}`.
+
+## Livrables
+- Nouvelle passe ou extension `src/client/render/ImpostorPass.{h,cpp}` (rendu instancié des impostors) + shaders `game/data/shaders/impostor.vert/.frag`.
+- Chargeur runtime du format d'impostor (lecture du binaire produit par M45.4), via `paths.content`.
+- Sélection LOD : au-delà du seuil de `LodConfig`, basculer l'instance de mesh complet vers impostor, avec une bande de fade (dither ou alpha) sur la transition.
+- Flag d'activation runtime, **défaut désactivé** au début, à activer une fois validé visuellement.
+
+## Spécification technique
+- Décodage octaédrique : choisir la(les) vue(s) de l'atlas la(les) plus proche(s) de la direction caméra→instance, interpoler entre vues adjacentes pour fluidité.
+- Rendu en cartes alignées caméra, lisant albedo + normale de l'atlas pour rester éclairées par le `LightingPass`/ombres (pas un billboard plat non éclairé).
+- Transition fade sur une bande de distance (dither stable temporellement, compatible TAA).
+- S'appuyer sur le culling GPU existant pour ne rendre que les impostors visibles.
+
+## Étapes d'implémentation
+1. `git clone`, étudier `InstanceBatch`, `ParticleBillboardPass`, `LodConfig`, `HlodRuntime`, `TerrainGrassDetail`.
+2. Implémenter le chargeur du format M45.4.
+3. Créer `ImpostorPass` + shaders, compiler `.spv`.
+4. Brancher la sélection mesh↔impostor dans la logique LOD existante (étendre `LodConfig`/`HlodRuntime`, ne pas la réécrire).
+5. Implémenter la bande de fade anti-popping.
+6. Insérer la passe dans le frame graph au bon endroit (avec la géométrie opaque), gated.
+7. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- **Extension, pas réécriture** : étendre `LodConfig`/`HlodRuntime` ; ne pas changer leur comportement quand les impostors sont désactivés.
+- Passe gated : si les assets impostor ou les shaders sont absents, fallback transparent sur le rendu mesh actuel.
+- Défaut désactivé : rendu identique à l'actuel tant que non activé par zone.
+- Respecter l'instancing et le culling GPU existants ; ne pas dupliquer le culling.
+- Compatibilité TAA pour le dither de transition (pas de scintillement).
+- Tous les tests existants doivent passer.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux, aucune erreur de validation Vulkan.
+- [ ] Au-delà du seuil, les meshes deviennent des impostors ; la transition est douce (pas de pop visible).
+- [ ] Les impostors restent correctement éclairés (réagissent au cycle jour/nuit et aux ombres).
+- [ ] Désactivé (défaut) = rendu strictement identique à l'état avant ticket.
+- [ ] Gain de performance mesuré sur une scène dense (nombre de triangles / temps GPU avant/après).
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- Le décodage octaédrique doit correspondre EXACTEMENT au mapping de M45.4 — sinon vues décalées.
+- Régler la distance de bascule pour que la transition tombe là où l'œil ne distingue plus mesh et impostor.

--- a/tickets/M45/M45.6_GI_ddgi_structure_phase1.md
+++ b/tickets/M45/M45.6_GI_ddgi_structure_phase1.md
@@ -1,0 +1,51 @@
+# M45.6 — GI dynamique, phase 1 : structure DDGI + intégration data
+
+## Objectif
+Poser la fondation d'un éclairage global dynamique (approche DDGI — grille de probes d'irradiance dynamiques) SANS encore l'activer dans le rendu. Cette phase ne fait que créer les structures de données, l'allocation des ressources GPU et l'intégration avec le système de probes existant. Aucun changement visuel attendu.
+
+## Dépendances
+- **M45.1, M45.2, M45.3 livrés et stables** (premier lot validé) avant de démarrer ce chantier.
+- Pré-requis existants : `ProbeData`/`ProbeSet` (probes IBL statiques MVP), `LightingPass`, `DeferredPipeline`, `FrameGraph`.
+
+## Contexte du code réel (vérifié)
+- Un système de probes statiques existe déjà : `src/client/world/ProbeData.{h,cpp}` définit `ProbeRecord`, `ProbeSet`, `AtmosphereSettings`, avec format binaire versionné (`kProbeSetMagic`, `kProbeSetVersion`), chargé depuis `probes.bin`. Commentaire explicite : « MVP runtime fallback ».
+- Le `LightingPass` consomme déjà ces probes pour l'IBL. C'est le point d'extension naturel.
+- Le `FrameGraph` gère les ressources transient/persistantes et les barrières sync2.
+
+## Livrables
+- Nouvelle structure de grille DDGI : `src/client/render/gi/DdgiVolume.{h,cpp}` (description de la grille de probes : origine, espacement, dimensions, ressources GPU pour irradiance + profondeur/visibilité).
+- Allocation des ressources GPU (textures d'irradiance octaédriques par probe + texture de profondeur/visibilité), via le frame graph ou allocation persistante.
+- Intégration avec `ProbeData` : la grille DDGI lit la configuration de zone (origine/extents) depuis les données existantes, sans casser le chemin statique.
+- Tests unitaires : `src/client/render/gi/tests/DdgiVolumeTests.cpp` (dimensions, indexation des probes, layout des atlas).
+- **Aucune injection ni propagation runtime dans ce ticket** (réservées à M45.7).
+
+## Spécification technique
+- Grille de probes régulière alignée monde, paramètres par zone (espacement, dimensions) depuis `AtmosphereSettings`/config de zone.
+- Stockage d'irradiance en encodage octaédrique par probe (atlas), + carte de profondeur pour la visibilité (anti-light-leak Chebyshev), conformément au schéma DDGI standard.
+- Définir clairement les formats et tailles, documentés dans un `.md` à côté du code.
+
+## Étapes d'implémentation
+1. `git clone`, étudier `ProbeData.{h,cpp}` et la façon dont `LightingPass` consomme les probes.
+2. Créer `src/client/render/gi/DdgiVolume.{h,cpp}` : description + allocation ressources.
+3. Câbler la lecture de la config de grille depuis les données de zone existantes.
+4. Écrire les tests d'indexation/layout.
+5. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- **Zéro changement visuel** : ce ticket n'altère AUCUNE passe de rendu. Il alloue des ressources et structures, point.
+- **Ne pas toucher au chemin probes statiques** : `ProbeData`/`ProbeSet` et leur consommation par `LightingPass` restent intacts et restent le comportement par défaut.
+- Aucune nouvelle passe ajoutée au frame graph dans ce ticket.
+- Tous les tests existants doivent passer ; les nouveaux tests s'ajoutent sans modifier les anciens.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux (CI verte).
+- [ ] Les ressources DDGI s'allouent sans erreur de validation Vulkan.
+- [ ] Tests `DdgiVolumeTests` verts (indexation, layout atlas).
+- [ ] Le rendu en jeu est strictement identique à l'état avant ticket (aucune passe modifiée).
+- [ ] Le système de probes statiques fonctionne exactement comme avant.
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- VRAM : dimensionner la grille avec prudence, documenter le coût mémoire par zone.
+- Ce ticket est volontairement « invisible » : sa valeur est de dérisquer M45.7 en isolant l'allocation et le layout des problèmes de rendu.

--- a/tickets/M45/M45.7_GI_ddgi_runtime_phase2.md
+++ b/tickets/M45/M45.7_GI_ddgi_runtime_phase2.md
@@ -1,0 +1,54 @@
+# M45.7 — GI dynamique, phase 2 : injection + propagation runtime
+
+## Objectif
+Rendre la grille DDGI (créée en M45.6) vivante : mettre à jour l'irradiance des probes chaque frame (ou en amorti) à partir de la lumière de la scène, et la consommer dans l'éclairage pour produire un éclairage indirect dynamique. C'est le cœur technique du chantier GI.
+
+## Dépendances
+- **M45.6** (structure DDGI) — obligatoire.
+- Pré-requis : `CascadedShadowMaps`, `DayNightCycle`, `LightingPass`, `SkyPass`, `FrameGraph`.
+
+## Contexte du code réel (vérifié)
+- `DdgiVolume` (M45.6) fournit les ressources d'irradiance + visibilité.
+- `LightingPass` est le consommateur d'IBL actuel (probes statiques) — c'est là que l'irradiance DDGI doit être lue, en remplacement/complément contrôlé.
+- Soleil + ombres disponibles via `CascadedShadowMaps` + `DayNightCycle`.
+
+## Livrables
+- Passe(s) compute de mise à jour DDGI : `src/client/render/gi/DdgiUpdatePass.{h,cpp}` + shaders (`game/data/shaders/ddgi_trace.comp`, `ddgi_blend.comp` ou équivalents) :
+  - tracé/échantillonnage de rayons par probe (vers la scène : sky, soleil ombré, surfaces),
+  - mise à jour temporelle (blend) de l'irradiance et de la profondeur des probes.
+- Extension du shader de lighting pour échantillonner l'irradiance DDGI (avec visibilité Chebyshev anti-leak) pour le terme indirect.
+- Insertion gated dans le frame graph (mise à jour avant Lighting).
+- Flag d'activation runtime, **défaut désactivé** (le défaut reste les probes statiques de M45.6/ProbeData).
+
+## Spécification technique
+- Mise à jour amortie : ne pas forcément tracer toutes les probes chaque frame ; rotation/budget par frame pour lisser le coût.
+- Anti-light-leak : utiliser la carte de profondeur des probes (test de visibilité de type variance/Chebyshev).
+- Cohérence jour/nuit : le terme indirect doit évoluer avec la lumière du `DayNightCycle`.
+- Hystérésis temporelle pour la stabilité (éviter le flickering d'irradiance).
+
+## Étapes d'implémentation
+1. `git clone`, relire `DdgiVolume` et le point de consommation IBL dans `LightingPass`.
+2. Implémenter `DdgiUpdatePass` (trace + blend), shaders compilés `.spv`.
+3. Insérer la mise à jour dans le frame graph avant la passe Lighting, en lecture shadow map + scène, écriture des ressources DDGI (writer unique).
+4. Étendre le lighting pour lire l'irradiance DDGI comme terme indirect, derrière le flag.
+5. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- **Gated, défaut désactivé** : avec le flag off, le `LightingPass` utilise exactement le chemin probes statiques actuel — rendu identique à avant.
+- **Writer unique** sur les ressources DDGI (la `DdgiUpdatePass`) ; le lighting est lecteur seul. Respecter l'interdiction de double writer du frame graph.
+- Ne pas dégrader le TAA : la GI temporelle ne doit pas injecter de bruit non filtré dans le signal géométrique.
+- Garder un budget GPU borné et mesuré (mise à jour amortie).
+- Tous les tests existants doivent passer.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux, aucune erreur de validation Vulkan.
+- [ ] Avec GI activée : éclairage indirect visible et cohérent (rebonds de lumière, suivi du cycle jour/nuit).
+- [ ] Pas de light-leak grossier à travers les murs (visibilité Chebyshev efficace).
+- [ ] Désactivé (défaut) = rendu strictement identique à l'état avant ticket, via probes statiques.
+- [ ] Coût GPU mesuré et borné (reporté via le Profiler).
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- C'est la phase la plus délicate : prévoir des allers-retours visuels avec Hubert. Livrer d'abord une version conservatrice (mise à jour lente, intensité modérée) plutôt qu'agressive.
+- Documenter tous les paramètres de réglage pour la phase 3.

--- a/tickets/M45/M45.8_GI_ddgi_tuning_fallback_phase3.md
+++ b/tickets/M45/M45.8_GI_ddgi_tuning_fallback_phase3.md
@@ -1,0 +1,53 @@
+# M45.8 — GI dynamique, phase 3 : tuning, debug, fallback probes statiques
+
+## Objectif
+Stabiliser et régler la GI dynamique livrée en M45.7 : outils de debug visuel, paramètres exposés, gestion gracieuse de la dégradation et garantie explicite du fallback sur les probes statiques (`ProbeData`) pour les configs modestes ou en cas d'échec. Ce ticket transforme un prototype fonctionnel en système exploitable.
+
+## Dépendances
+- **M45.7** (injection + propagation runtime) — obligatoire.
+
+## Contexte du code réel (vérifié)
+- `ProbeData`/`ProbeSet` reste le système de fallback de référence (« MVP runtime fallback » selon le commentaire du code).
+- `ShaderHotReload` (`src/client/render/ShaderHotReload.{h,cpp}`) permet l'itération rapide sur les shaders — à exploiter pour le tuning.
+- Le `Profiler` du frame graph fournit les temps GPU par passe.
+
+## Livrables
+- Mode debug DDGI : visualisation des probes (sphères colorées par irradiance), de la grille, de la carte de visibilité — derrière un flag de debug, via le système ImGui de debug existant (`src/client/debug/`).
+- Paramètres exposés (intensité GI, vitesse de mise à jour, hystérésis, budget de probes par frame) réglables à chaud.
+- Logique de fallback explicite et testée :
+  - si le matériel ne supporte pas / GI désactivée → bascule propre sur probes statiques `ProbeData`, sans discontinuité de pipeline ;
+  - si `DdgiUpdatePass` échoue à l'init → fallback automatique.
+- Tests de non-régression du fallback : `src/client/render/gi/tests/DdgiFallbackTests.cpp`.
+
+## Spécification technique
+- Niveau de qualité GI configurable (off / static-probes / dynamic-low / dynamic-high) piloté par les réglages graphiques (`src/client/settings/`).
+- Le mode « static-probes » doit produire exactement le comportement d'avant le cluster M45.6.
+- Dégradation gracieuse sous faible framerate : possibilité de réduire le budget de mise à jour des probes sans artefact brutal.
+
+## Étapes d'implémentation
+1. `git clone`, relire `DdgiUpdatePass`, le panneau debug ImGui existant, le système de settings.
+2. Ajouter la visualisation debug des probes.
+3. Exposer les paramètres de tuning à chaud (réutiliser `ShaderHotReload` pour itérer).
+4. Implémenter et tester la matrice de fallback (off / static / dynamic-low / dynamic-high).
+5. Écrire les tests de fallback.
+6. Mettre à jour `CMakeLists.txt`.
+
+## Ne doit RIEN casser
+- **Le fallback statique doit être bit-pour-bit le comportement d'avant le cluster GI** quand sélectionné — c'est la garantie centrale de ce ticket.
+- Les outils de debug sont gated derrière un flag debug ; aucun coût en build release / mode normal.
+- Ne pas modifier le comportement des passes non-GI.
+- Tous les tests existants doivent passer ; les nouveaux tests de fallback s'ajoutent sans toucher aux anciens.
+
+## Critères de validation (DoD)
+- [ ] Build CMake OK Windows + Linux, aucune erreur de validation Vulkan.
+- [ ] Visualisation debug des probes fonctionnelle.
+- [ ] Les 4 niveaux de qualité (off / static / dynamic-low / dynamic-high) commutent proprement sans crash ni artefact de transition de pipeline.
+- [ ] Le niveau « static-probes » reproduit exactement le rendu probes statiques d'avant le cluster.
+- [ ] Tests `DdgiFallbackTests` verts.
+- [ ] Dégradation gracieuse vérifiée (réduction de budget sans artefact brutal).
+- [ ] Tous les tests existants passent sans modification.
+- [ ] DoD globale respectée.
+
+## Notes / pièges à éviter
+- Ce ticket est itératif par nature : prévoir plusieurs passes de réglage visuel avec Hubert avant de figer les valeurs par défaut.
+- La valeur par défaut livrée devrait rester conservatrice (static-probes ou dynamic-low) pour ne pas surprendre sur les configs modestes.

--- a/tickets/M45/M45_INDEX.md
+++ b/tickets/M45/M45_INDEX.md
@@ -1,0 +1,46 @@
+# M45 — Cluster « Profondeur visuelle AAA » — INDEX
+
+## But du cluster
+Faire franchir au rendu du client le seuil visuel AAA en **complétant** les deux couches partielles du pipeline (atmosphère/profondeur et éclairage global) et en **étendant** la chaîne de post-traitement, sans rien casser de l'existant.
+
+Ce cluster s'appuie sur un pipeline déjà mature : frame graph (`src/client/render/FrameGraph.*`), rendu différé (`DeferredPipeline`, `GeometryPass`, `LightingPass`), culling GPU + Hi-Z, ombres cascadées (`CascadedShadowMaps`), SSAO, TAA, bloom, auto-exposure, tonemap, ciel procédural (`SkyPass`), cycle jour/nuit, météo, eau, streaming par chunks (`src/client/world/StreamingScheduler` + `StreamCache`), HLOD (`HlodRuntime`), LOD terrain (`TerrainLodChain`).
+
+## Règle de chemins (IMPORTANT — lire avant tout)
+La structure **réelle** du dépôt n'utilise PAS `/engine/`. Les anciens tickets mentionnant `/engine/` sont obsolètes sur ce point. Les chemins réels sont :
+- Code client de rendu : `src/client/render/...`
+- Code client monde/streaming : `src/client/world/...`
+- Shaders : `game/data/shaders/...` (un `.vert`/`.frag`/`.comp` source + son `.spv` compilé)
+- Contenu de jeu : `game/data/...`, toujours résolu via `paths.content` de `config.json`, jamais en dur.
+- `CMakeLists.txt` racine doit être mis à jour à chaque ticket qui ajoute un fichier.
+
+Avant d'écrire le moindre chemin, Code doit `git clone` le dépôt et vérifier la structure réelle. Ne jamais inventer de chemin.
+
+## Principe directeur de non-régression (s'applique à TOUS les tickets)
+Chaque nouvelle passe ou fonctionnalité doit être :
+1. **Additive et gated** : insérée dans le frame graph via `m_frameGraph.addPass(...)` en suivant le pattern existant (voir `src/client/app/Engine.cpp`), et activable/désactivable par un flag. Si la passe échoue à s'initialiser (shader manquant, etc.), elle se désactive proprement et le pipeline retombe sur le comportement actuel — exactement comme `m_skyPassReady` le fait déjà.
+2. **Sans nouveau writer sur une ressource déjà écrite** sauf passe dédiée : le frame graph MVP interdit deux writers sur la même ressource. Respecter ce contrat.
+3. **Sans modifier l'ordre des passes existantes** ni leurs signatures publiques, sauf mention explicite dans le ticket.
+4. **Vérifiée par les tests existants** : tous les tests déjà présents (`*Tests.cpp`) doivent continuer à passer. Aucun test existant ne doit être modifié pour « faire passer » du nouveau code.
+
+## Ordre d'implémentation (dépendances strictes)
+
+| Ordre | Ticket | Titre | Couche | Risque |
+|-------|--------|-------|--------|--------|
+| 1 | M45.1 | Aerial perspective (scattering atmosphérique étendu) | Atmosphère | Faible |
+| 2 | M45.2 | Volumetric fog (brouillard volumique + god rays) | Atmosphère | Moyen |
+| 3 | M45.3 | Depth of field (bokeh) | Composition | Faible |
+| 4 | M45.4 | Génération offline des impostors octaédriques | Géométrie/LOD | Moyen |
+| 5 | M45.5 | Rendu runtime des impostors végétation | Géométrie/LOD | Moyen |
+| 6 | M45.6 | GI dynamique — phase 1 : structure DDGI + intégration data | Éclairage | Élevé |
+| 7 | M45.7 | GI dynamique — phase 2 : injection + propagation runtime | Éclairage | Élevé |
+| 8 | M45.8 | GI dynamique — phase 3 : tuning, debug, fallback probes statiques | Éclairage | Élevé (itératif) |
+
+## Logique de l'ordre
+- **M45.1–M45.3** d'abord : meilleur rapport effort/résultat, faible risque, s'appuient sur des systèmes déjà solides (`SkyPass`, chaîne de post-process). Ce sont des extensions, pas du greenfield.
+- **M45.4–M45.5** ensuite : indépendants de l'éclairage, donnent la densité de végétation caractéristique AAA. M45.4 (offline) doit précéder M45.5 (runtime) car le runtime consomme les assets produits par l'outil.
+- **M45.6–M45.8** en dernier : le seul vrai gros chantier. Découpé en 3 phases pour rester scopé. La phase 3 garantit explicitement le fallback sur le système de probes IBL statiques existant (`ProbeData`/`ProbeSet`) — donc même si la GI dynamique est désactivée, le rendu reste correct.
+
+## Recommandation de livraison
+Livrer et valider M45.1, M45.2, M45.3 en premier lot (gain visuel immédiat, risque faible). Ne lancer M45.6+ qu'une fois ce premier lot stable et mergé.
+
+Un ticket = une branche = une PR. Fichiers livrés complets (jamais en diff/patch).


### PR DESCRIPTION
## M45.1 — Perspective aérienne (cluster M45 « Profondeur visuelle AAA »)

### Contexte / décision de design
Le ticket supposait qu'aucune perspective aérienne n'existait. **Faux depuis le merge #787** : un brouillard de distance **linéaire** a été ajouté dans `lighting.frag` (pour masquer la coupe de distance des props). Plutôt que d'empiler un second effet (doublon), cette PR fait un **upgrade sur place** : le `mix` linéaire→horizon devient une vraie perspective aérienne.

### Ce que ça fait
- **Extinction exponentielle** : `fog = 1 - exp(-d * density)` (au lieu du fondu linéaire).
- **Filet de sécurité** `smoothstep(fogStart, fogEnd, dist)` : garantit l'opacité complète vers `fogEnd` → le masquage de la coupe des props est préservé.
- **Inscattering directionnel** : teinte = `mix(horizon, couleur soleil)` selon `dot(rayDir, sunDir)` → halo chaud quand on regarde le soleil, froid ailleurs ; suit le cycle jour/nuit (base = `skyHorizon`).

### Implémentation (additif, gated, non-régressif)
- `lighting.frag` : remplace le bloc fog. **Aucune nouvelle passe**, aucun changement du frame graph.
- `LightParams` : réutilise les slots `.w` libres (`lightColor.w`=density, `ambientColor.w`=inscatter). **Struct reste 148 octets**, `static_assert` inchangé, signatures publiques intactes.
- `AtmosphereSettings` (`ProbeData.h`) : `aerialDensity` / `aerialInscatter` per-zone (défauts doux), lus depuis `atmosphere.json` (`aerial.density` / `aerial.inscatter`).
- `Engine.cpp` : câblage avec **override `config.json`** (`world.fog.density` / `world.fog.inscatter`) → valeur per-zone par défaut.
- `config.json` : `density=0.012`, `inscatter=0.6` ajoutés au bloc `world.fog`.

### Désactivation
Effet off si `density<=0` **ou** `fogEnd<=fogStart`. Pixels de ciel intacts (early-return `depth>=1.0`).

### Shaders
Seule la **source GLSL** est modifiée — la CI Windows régénère le `.spv` via `tools/compile_game_shaders.ps1` (convention du dépôt ; les `.spv` committés sont des artefacts hérités).

### Déploiement
✅ **100% client** (shader + wiring). **Aucun redéploiement serveur** (pas d'opcode, handler ni migration).

### Note
La nuance « désactivé = aucune atténuation » (vs. le fog linéaire précédent) est la conséquence assumée du choix « upgrade sur place » ; le **défaut livré reproduit-ou-améliore** le rendu actuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)