### PR TITLE
feat(render): M45.2 — brouillard volumique + god rays (passe plein écran)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,7 @@ add_library(engine_core
   src/client/render/GpuDrivenCullingPass.cpp
   src/client/render/HiZPyramidPass.cpp
   src/client/render/LightingPass.cpp
+  src/client/render/VolumetricFogPass.cpp
   src/client/render/TonemapPass.cpp
   src/client/render/BloomPass.cpp
   src/client/render/AutoExposure.cpp

--- a/config.json
+++ b/config.json
@@ -153,6 +153,16 @@
             "density": 0.012,
             "inscatter": 0.6
         },
+        "_comment_volfog": "M45.2 Brouillard VOLUMIQUE + god rays (rayons crepusculaires). Distinct du brouillard de distance (world.fog ci-dessus) : ici une passe plein ecran ray-marche par pixel le long du rayon camera->pixel en echantillonnant la shadow map cascade 0 pour l'occlusion solaire (god rays). DESACTIVE par defaut (density = 0). density : densite du milieu (<= 0 desactive entierement la passe) ; anisotropy : g de Henyey-Greenstein [-1..1] (>0 = diffusion vers l'avant, halo concentre autour du soleil) ; inscatter : intensite globale de l'inscattering ; steps : nombre de pas de marche (cout GPU ~ lineaire) ; max_dist_m : distance max de marche (m) ; height_m : hauteur de reference du fog (m, plus dense en dessous) ; height_falloff : taux d'attenuation en hauteur. Lu a chaque frame -> reglage a chaud.",
+        "volfog": {
+            "density": 0.0,
+            "anisotropy": 0.6,
+            "inscatter": 1.0,
+            "steps": 32,
+            "max_dist_m": 120.0,
+            "height_m": 10.0,
+            "height_falloff": 0.1
+        },
         "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet), mesh/scale/yaw_deg/rot_x_deg, dialogue. Seuls les VRAIS interactibles ici (PNJ, coffre). Le DECOR (arbres, props non interactifs mais solides) est dans world.scenery. Le coffre et le villageois sont solides (collision) comme tout le decor.",
         "interactables": {
             "count": 7,

--- a/game/data/shaders/volumetric_fog.frag
+++ b/game/data/shaders/volumetric_fog.frag
@@ -1,0 +1,140 @@
+#version 450
+
+// M45.2 — Brouillard volumique + god rays (rayons crépusculaires), version v1.
+//
+// Passe GRAPHIQUE plein écran (fullscreen triangle, comme lighting.frag). Pour
+// CHAQUE pixel on ray-marche depuis la caméra vers la position monde du pixel,
+// en échantillonnant UNE cascade de shadow map (cascade 0) pour décider si chaque
+// point du rayon est éclairé par le soleil → god rays. Pas de volume froxel 3D,
+// pas de compute (v1 conservatrice).
+//
+// Entrées (descriptor set 0) :
+//   binding 0 = scene color HDR post-water (sampler linéaire clamp)
+//   binding 1 = depth scene (D32_SFLOAT, sampler nearest clamp, lu en .r)
+//   binding 2 = shadow map cascade 0 (image DEPTH, sampler nearest clamp, lue en .r)
+//
+// Sortie :
+//   outColor (location 0) — scene color HDR brouillardée.
+//
+// Push constants (192 octets, stage fragment) — cf. FogParams (VolumetricFogPass.h) :
+//   mat4 invVP        — inverse view-projection (reconstruction world pos depuis depth)
+//   mat4 sunViewProj  — lightViewProj de la cascade 0 (transforme world -> clip ombre)
+//   vec4 cameraPos    — xyz = position caméra ; w = densité fog (<= 0 désactive)
+//   vec4 sunDir       — xyz = direction VERS le soleil (normalisée) ; w = anisotropie HG g
+//   vec4 sunColor     — xyz = couleur soleil ; w = intensité inscattering
+//   vec4 fogParams    — x = nb de steps, y = distance max de marche (m),
+//                       z = hauteur de référence (m), w = atténuation en hauteur
+
+layout(location = 0) in  vec2 inUV;
+layout(location = 0) out vec4 outColor;
+
+// ---- Samplers ---------------------------------------------------------------
+layout(set = 0, binding = 0) uniform sampler2D sceneColorTex; // HDR post-water
+layout(set = 0, binding = 1) uniform sampler2D depthTex;      // depth scene, .r = [0,1]
+layout(set = 0, binding = 2) uniform sampler2D shadowTex;     // shadow cascade 0, .r = depth
+
+// ---- Push constants ---------------------------------------------------------
+layout(push_constant) uniform PC
+{
+    mat4 invVP;        // inverse view-projection
+    mat4 sunViewProj;  // lightViewProj cascade 0
+    vec4 cameraPos;    // xyz = caméra ; w = densité fog
+    vec4 sunDir;       // xyz = dir vers le soleil ; w = anisotropie HG g
+    vec4 sunColor;     // xyz = couleur soleil ; w = intensité inscattering
+    vec4 fogParams;    // x = steps, y = maxDist (m), z = height (m), w = heightFalloff
+} pc;
+
+const float PI = 3.14159265358979;
+
+void main()
+{
+    // ---- (1) Couleur de scène en entrée --------------------------------
+    vec3 sceneColor = texture(sceneColorTex, inUV).rgb;
+
+    // ---- (2) Gating runtime : densité <= 0 -> passthrough --------------
+    float density = pc.cameraPos.w;
+    if (density <= 0.0)
+    {
+        outColor = vec4(sceneColor, 1.0);
+        return;
+    }
+
+    // ---- (3) Reconstruction de la position monde P du pixel ------------
+    // NDC xy in [-1,+1] ; depth in [0,1] (convention Vulkan).
+    float depth = texture(depthTex, inUV).r;
+    vec2  ndcXY = inUV * 2.0 - 1.0;
+    vec4  posClip  = vec4(ndcXY, depth, 1.0);
+    vec4  posWorld = pc.invVP * posClip;
+    posWorld      /= posWorld.w;
+    vec3  P        = posWorld.xyz;
+
+    vec3  cam = pc.cameraPos.xyz;
+
+    // Distance de marche : si le pixel est du ciel (depth >= 1.0), on marche
+    // quand même jusqu'à fogParams.y (brume d'horizon). Sinon on s'arrête à la
+    // géométrie, borné à la distance max.
+    float maxDist = max(pc.fogParams.y, 0.0);
+    float marchDist;
+    if (depth >= 1.0)
+        marchDist = maxDist;
+    else
+        marchDist = min(length(P - cam), maxDist);
+
+    // Direction du rayon caméra -> pixel (pour la phase + la marche).
+    // Si P ~ cam (cas dégénéré), on garde une direction sûre.
+    vec3 toP = P - cam;
+    float toPLen = length(toP);
+    vec3 rayDir = (toPLen > 1e-4) ? (toP / toPLen) : vec3(0.0, 0.0, 1.0);
+
+    // ---- (4) Ray-march -------------------------------------------------
+    int   steps   = int(max(pc.fogParams.x, 1.0));
+    float stepLen = marchDist / float(steps);
+
+    float g     = clamp(pc.sunDir.w, -0.99, 0.99);
+    vec3  sunL  = normalize(pc.sunDir.xyz);
+    float cosA  = dot(rayDir, sunL);
+    // Phase de Henyey-Greenstein (anisotropie de la diffusion vers le soleil).
+    float denom = max(1.0 + g * g - 2.0 * g * cosA, 1e-4);
+    float phase = (1.0 - g * g) / (4.0 * PI * pow(denom, 1.5));
+
+    float heightRef     = pc.fogParams.z;
+    float heightFalloff = pc.fogParams.w;
+    const float bias    = 0.0015; // biais d'ombre (anti acné)
+
+    float scatter = 0.0;
+    for (int i = 0; i < steps; ++i)
+    {
+        // Position du sample (milieu du segment pour réduire le biais).
+        float t   = (float(i) + 0.5) * stepLen;
+        vec3  sp  = cam + rayDir * t;
+
+        // Atténuation en hauteur : fog plus dense en bas.
+        float heightFactor = exp(-max(sp.y - heightRef, 0.0) * heightFalloff);
+
+        // Test d'ombre soleil : projette sp dans l'espace de la shadow map.
+        float lit = 1.0;
+        vec4  shadowClip = pc.sunViewProj * vec4(sp, 1.0);
+        if (shadowClip.w > 0.0)
+        {
+            vec3 shadowNdc = shadowClip.xyz / shadowClip.w;
+            // xy de NDC [-1,1] vers UV [0,1] ; z (depth Vulkan) déjà dans [0,1].
+            vec2  shadowUV    = shadowNdc.xy * 0.5 + 0.5;
+            float sampleDepth = shadowNdc.z;
+            if (shadowUV.x >= 0.0 && shadowUV.x <= 1.0 &&
+                shadowUV.y >= 0.0 && shadowUV.y <= 1.0 &&
+                sampleDepth >= 0.0 && sampleDepth <= 1.0)
+            {
+                float shadowDepth = texture(shadowTex, shadowUV).r;
+                lit = (shadowDepth >= sampleDepth - bias) ? 1.0 : 0.0;
+            }
+            // Hors de la shadow map -> considéré éclairé (lit reste 1.0).
+        }
+
+        scatter += lit * heightFactor * phase * stepLen * density;
+    }
+
+    // ---- (5) Composition finale ----------------------------------------
+    scatter = clamp(scatter * pc.sunColor.w, 0.0, 1.0);
+    vec3 fogColor = pc.sunColor.rgb;
+    outColor = vec4(mix(sceneColor, fogColor, scatter), 1.0);
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3831,6 +3831,12 @@ namespace engine
 										// le fallback Water_Passthrough (vkCmdCopyImage TransferDst). Lu en
 										// SampledRead par Bloom_Prefilter / Bloom_Combine.
 										m_fgSceneColorHDRPostWaterId = m_frameGraph.createImage("SceneColor_HDR_PostWater", sceneColorHDRDesc);
+										// M45.2 — SceneColor_HDR_Fogged : cible de la passe VolumetricFog
+										// (brouillard volumique + god rays), ou copie passthrough si la
+										// passe fog est invalide. Meme desc que PostWater (qui inclut deja
+										// TRANSFER_DST pour le passthrough vkCmdCopyImage). Lu en aval par
+										// Bloom_Prefilter / Bloom_Combine.
+										m_fgSceneColorFoggedId = m_frameGraph.createImage("SceneColor_HDR_Fogged", sceneColorHDRDesc);
 
 										engine::render::ImageDesc sceneColorLDRDesc{};
 										sceneColorLDRDesc.format = m_vkSwapchain.GetImageFormat();
@@ -3947,6 +3953,11 @@ namespace engine
 										    loadSpirv
 										);
 									LOG_INFO(Core, "[Boot] DeferredPipeline init OK");
+
+									// M45.2 — la passe VolumetricFog est active uniquement si son Init a
+									// reussi (shaders presents). Sinon Engine enregistre un passthrough
+									// (copie PostWater -> Fogged) pour que Bloom lise une image valide.
+									m_volumetricFogReady = m_pipeline->GetVolumetricFogPass().IsValid();
 
 									// M100 — Task 12 : Terrain Chunk Runtime — drawcall mesh-terrain par
 									// chunk avec splat 8-layer. Co-existe avec le legacy TerrainRenderer
@@ -5712,9 +5723,119 @@ namespace engine
 												});
 										}
 
+										// M45.2 — Brouillard volumique + god rays. Lit SceneColor_HDR_PostWater,
+										// le depth et la shadow map cascade 0, ray-marche par pixel et ecrit
+										// SceneColor_HDR_Fogged. Si la passe fog est invalide (shaders absents /
+										// Init KO), on enregistre a la place un passthrough vkCmdCopyImage qui
+										// recopie PostWater -> Fogged, exactement comme Water_Passthrough, pour
+										// garantir que Bloom_Prefilter (qui lit desormais Fogged) trouve une
+										// image valide. Le gating runtime (density<=0) est gere dans le shader.
+										if (m_volumetricFogReady)
+										{
+											m_frameGraph.addPass("VolumetricFog",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgSceneColorHDRPostWaterId, engine::render::ImageUsage::SampledRead);
+													b.read(m_fgDepthId,                  engine::render::ImageUsage::SampledRead);
+													b.read(m_fgShadowMapIds[0],          engine::render::ImageUsage::SampledRead);
+													b.write(m_fgSceneColorFoggedId,      engine::render::ImageUsage::ColorWrite);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													if (!m_pipeline->GetVolumetricFogPass().IsValid()) return;
+													const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+													const engine::RenderState& rs = m_renderStates[readIdx];
+													engine::render::VolumetricFogPass::FogParams fp{};
+													// invViewProj = inverse de rs.viewProjMatrix (meme routine que Lighting).
+													const float* vp = rs.viewProjMatrix.m;
+													const float a00=vp[0], a10=vp[1], a20=vp[2],  a30=vp[3];
+													const float a01=vp[4], a11=vp[5], a21=vp[6],  a31=vp[7];
+													const float a02=vp[8], a12=vp[9], a22=vp[10], a32=vp[11];
+													const float a03=vp[12],a13=vp[13],a23=vp[14], a33=vp[15];
+													const float b00=a00*a11-a10*a01, b01=a00*a21-a20*a01, b02=a00*a31-a30*a01;
+													const float b03=a10*a21-a20*a11, b04=a10*a31-a30*a11, b05=a20*a31-a30*a21;
+													const float b06=a02*a13-a12*a03, b07=a02*a23-a22*a03, b08=a02*a33-a32*a03;
+													const float b09=a12*a23-a22*a13, b10=a12*a33-a32*a13, b11=a22*a33-a32*a23;
+													const float det = b00*b11-b01*b10+b02*b09+b03*b08-b04*b07+b05*b06;
+													if (det > 1e-7f || det < -1e-7f)
+													{
+														const float inv = 1.0f / det;
+														fp.invViewProj[0]  = ( a11*b11-a21*b10+a31*b09)*inv;
+														fp.invViewProj[1]  = (-a10*b11+a20*b10-a30*b09)*inv;
+														fp.invViewProj[2]  = ( a13*b05-a23*b04+a33*b03)*inv;
+														fp.invViewProj[3]  = (-a12*b05+a22*b04-a32*b03)*inv;
+														fp.invViewProj[4]  = (-a01*b11+a21*b08-a31*b07)*inv;
+														fp.invViewProj[5]  = ( a00*b11-a20*b08+a30*b07)*inv;
+														fp.invViewProj[6]  = (-a03*b05+a23*b02-a33*b01)*inv;
+														fp.invViewProj[7]  = ( a02*b05-a22*b02+a32*b01)*inv;
+														fp.invViewProj[8]  = ( a01*b10-a11*b08+a31*b06)*inv;
+														fp.invViewProj[9]  = (-a00*b10+a10*b08-a30*b06)*inv;
+														fp.invViewProj[10] = ( a03*b04-a13*b02+a33*b00)*inv;
+														fp.invViewProj[11] = (-a02*b04+a12*b02-a32*b00)*inv;
+														fp.invViewProj[12] = (-a01*b09+a11*b07-a21*b06)*inv;
+														fp.invViewProj[13] = ( a00*b09-a10*b07+a20*b06)*inv;
+														fp.invViewProj[14] = (-a03*b03+a13*b01-a23*b00)*inv;
+														fp.invViewProj[15] = ( a02*b03-a12*b01+a22*b00)*inv;
+													}
+													// sunViewProj = lightViewProj de la cascade 0.
+													std::memcpy(fp.sunViewProj, rs.cascades.lightViewProj[0].m, sizeof(float) * 16);
+													fp.cameraPos[0] = rs.camera.position.x;
+													fp.cameraPos[1] = rs.camera.position.y;
+													fp.cameraPos[2] = rs.camera.position.z;
+													// densite fog (defaut 0 = desactive ; gating runtime dans le shader).
+													fp.cameraPos[3] = static_cast<float>(m_cfg.GetDouble("world.volfog.density", 0.0));
+													// direction VERS le soleil (normalisee).
+													{
+														float sx = m_zoneAtmosphere.sunDirection[0];
+														float sy = m_zoneAtmosphere.sunDirection[1];
+														float sz = m_zoneAtmosphere.sunDirection[2];
+														float sl = std::sqrt(sx*sx + sy*sy + sz*sz);
+														if (sl > 1e-6f) { sx /= sl; sy /= sl; sz /= sl; }
+														fp.sunDir[0] = sx; fp.sunDir[1] = sy; fp.sunDir[2] = sz;
+													}
+													fp.sunDir[3]   = static_cast<float>(m_cfg.GetDouble("world.volfog.anisotropy", 0.6));
+													fp.sunColor[0] = m_zoneAtmosphere.sunColor[0];
+													fp.sunColor[1] = m_zoneAtmosphere.sunColor[1];
+													fp.sunColor[2] = m_zoneAtmosphere.sunColor[2];
+													fp.sunColor[3] = static_cast<float>(m_cfg.GetDouble("world.volfog.inscatter", 1.0));
+													fp.fogParams[0] = static_cast<float>(m_cfg.GetDouble("world.volfog.steps", 32.0));
+													fp.fogParams[1] = static_cast<float>(m_cfg.GetDouble("world.volfog.max_dist_m", 120.0));
+													fp.fogParams[2] = static_cast<float>(m_cfg.GetDouble("world.volfog.height_m", 10.0));
+													fp.fogParams[3] = static_cast<float>(m_cfg.GetDouble("world.volfog.height_falloff", 0.1));
+													m_pipeline->GetVolumetricFogPass().Record(
+														m_vkDeviceContext.GetDevice(), cmd, reg,
+														m_vkSwapchain.GetExtent(),
+														m_fgSceneColorHDRPostWaterId, m_fgDepthId, m_fgShadowMapIds[0],
+														m_fgSceneColorFoggedId, fp, m_currentFrame % 2);
+												});
+										}
+										else
+										{
+											// Fog indisponible -> copie PostWater -> Fogged (writer unique) pour
+											// que Bloom_Prefilter lise une image valide. Meme pattern que
+											// Water_Passthrough (les barrieres FG posent TransferSrc/TransferDst).
+											m_frameGraph.addPass("VolumetricFog_Passthrough",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgSceneColorHDRPostWaterId, engine::render::ImageUsage::TransferSrc);
+													b.write(m_fgSceneColorFoggedId,      engine::render::ImageUsage::TransferDst);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													VkImage src = reg.getImage(m_fgSceneColorHDRPostWaterId);
+													VkImage dst = reg.getImage(m_fgSceneColorFoggedId);
+													if (src == VK_NULL_HANDLE || dst == VK_NULL_HANDLE) return;
+													VkImageCopy copy{};
+													copy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+													copy.srcSubresource.layerCount = 1;
+													copy.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+													copy.dstSubresource.layerCount = 1;
+													VkExtent2D ext = m_vkSwapchain.GetExtent();
+													copy.extent = { ext.width, ext.height, 1 };
+													vkCmdCopyImage(cmd, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+														dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+												});
+										}
+
 										m_frameGraph.addPass("Bloom_Prefilter",
 											[this](engine::render::PassBuilder& b) {
-												b.read(m_fgSceneColorHDRPostWaterId, engine::render::ImageUsage::SampledRead);
+												b.read(m_fgSceneColorFoggedId, engine::render::ImageUsage::SampledRead);
 												b.write(m_fgBloomDownMipIds[0], engine::render::ImageUsage::ColorWrite);
 											},
 											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
@@ -5726,7 +5847,7 @@ namespace engine
 												m_pipeline->GetBloomPrefilterPass().Record(
 													m_vkDeviceContext.GetDevice(), cmd, reg,
 													m_vkSwapchain.GetExtent(),
-													m_fgSceneColorHDRPostWaterId, m_fgBloomDownMipIds[0], pp, frameIdx);
+													m_fgSceneColorFoggedId, m_fgBloomDownMipIds[0], pp, frameIdx);
 											});
 
 										for (uint32_t i = 0; i < engine::render::kBloomMipCount - 1; ++i)
@@ -5775,7 +5896,11 @@ namespace engine
 
 										m_frameGraph.addPass("Bloom_Combine",
 											[this](engine::render::PassBuilder& b) {
-												b.read(m_fgSceneColorHDRPostWaterId,  engine::render::ImageUsage::SampledRead);
+												// M45.2 — base de composition = SceneColor_HDR_Fogged (scene + fog
+												// volumique), pas PostWater, sinon le fog serait bypasse dans
+												// l'image finale (Combine produit l'image post-bloom consommee par
+												// AutoExposure/Tonemap).
+												b.read(m_fgSceneColorFoggedId,        engine::render::ImageUsage::SampledRead);
 												b.read(m_fgBloomUpMipIds[0],         engine::render::ImageUsage::SampledRead);
 												b.write(m_fgSceneColorHDRWithBloomId, engine::render::ImageUsage::ColorWrite);
 											},
@@ -5784,7 +5909,7 @@ namespace engine
 												engine::render::BloomCombinePass::CombineParams cp{};
 												cp.intensity = static_cast<float>(m_cfg.GetDouble("bloom.intensity", 1.0));
 												const uint32_t frameIdx = m_currentFrame % 2;
-												m_pipeline->GetBloomCombinePass().Record(m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(), m_fgSceneColorHDRPostWaterId, m_fgBloomUpMipIds[0], m_fgSceneColorHDRWithBloomId, cp, frameIdx);
+												m_pipeline->GetBloomCombinePass().Record(m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(), m_fgSceneColorFoggedId, m_fgBloomUpMipIds[0], m_fgSceneColorHDRWithBloomId, cp, frameIdx);
 											});
 
 										m_frameGraph.addPass("AutoExposure_Luminance",

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -339,6 +339,13 @@ namespace engine
 		/// m_fgSceneColorHDRId. Si WaterPass::Init échoue, un fallback Water_Passthrough
 		/// (vkCmdCopyImage) garantit que cette ressource est bien renseignée chaque frame.
 		engine::render::ResourceId m_fgSceneColorHDRPostWaterId = engine::render::kInvalidResourceId;
+		/// M45.2 — SceneColor_HDR_Fogged: SceneColor_HDR_PostWater après application du
+		/// brouillard volumique + god rays (VolumetricFog), ou copie passthrough si la
+		/// passe fog est invalide. Lu en SampledRead par Bloom_Prefilter / Bloom_Combine.
+		engine::render::ResourceId m_fgSceneColorFoggedId = engine::render::kInvalidResourceId;
+		/// M45.2 — true si VolumetricFogPass::IsValid() au boot (passe fog active) ;
+		/// sinon Engine enregistre un passthrough (copie PostWater -> Fogged).
+		bool m_volumetricFogReady = false;
 		/// SceneColor_LDR: output of the tonemap pass (R8G8B8A8_UNORM). Added in M03.4.
 		engine::render::ResourceId m_fgSceneColorLDRId   = engine::render::kInvalidResourceId;
 		/// M08.2: SceneColor_HDR + bloom (combine pass output); tonemap reads this.

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -241,6 +241,25 @@ namespace engine::render
 				LOG_WARN(Render, "M03.2: lighting shaders not found — lighting pass disabled");
 		}
 
+		// M45.2 — Volumetric fog pass (brouillard volumique + god rays).
+		// Reutilise le vertex shader fullscreen triangle de la passe lighting.
+		// N'echoue jamais le boot : si shaders absents ou Init KO, la passe reste
+		// invalide et Engine enregistre un passthrough (copie PostWater -> Fogged).
+		{
+			std::vector<uint32_t> fogVert = loadSpirv("shaders/lighting.vert.spv");
+			std::vector<uint32_t> fogFrag = loadSpirv("shaders/volumetric_fog.frag.spv");
+			if (!fogVert.empty() && !fogFrag.empty())
+			{
+				if (m_volumetricFogPass.Init(device, physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT,
+						fogVert.data(), fogVert.size(), fogFrag.data(), fogFrag.size(), 2u, pipelineCacheHandle))
+					LOG_INFO(Render, "[Boot] DeferredPipeline VolumetricFogPass OK");
+				else
+					LOG_WARN(Render, "M45.2: volumetric fog pass init failed, passthrough fallback");
+			}
+			else
+				LOG_WARN(Render, "M45.2: volumetric fog shaders not found, passthrough fallback");
+		}
+
 		// Tonemap pass
 		{
 			std::vector<uint32_t> tmVert = loadSpirv("shaders/tonemap.vert.spv");

--- a/src/client/render/DeferredPipeline.h
+++ b/src/client/render/DeferredPipeline.h
@@ -12,6 +12,7 @@
 #include "src/client/render/SsaoBlurPass.h"
 #include "src/client/render/DecalPass.h"
 #include "src/client/render/LightingPass.h"
+#include "src/client/render/VolumetricFogPass.h"
 #include "src/client/render/TonemapPass.h"
 #include "src/client/render/BloomPass.h"
 #include "src/client/render/AutoExposure.h"
@@ -84,6 +85,8 @@ namespace engine::render
 		const DecalPass&      GetDecalPass() const      { return m_decalPass; }
 		LightingPass&         GetLightingPass()         { return m_lightingPass; }
 		const LightingPass&  GetLightingPass() const    { return m_lightingPass; }
+		VolumetricFogPass&        GetVolumetricFogPass()        { return m_volumetricFogPass; }
+		const VolumetricFogPass&  GetVolumetricFogPass() const  { return m_volumetricFogPass; }
 		TonemapPass&          GetTonemapPass()          { return m_tonemapPass; }
 		const TonemapPass&    GetTonemapPass() const    { return m_tonemapPass; }
 		BloomPrefilterPass&   GetBloomPrefilterPass()   { return m_bloomPrefilterPass; }
@@ -108,6 +111,7 @@ namespace engine::render
 		SsaoBlurPass          m_ssaoBlurPass;
 		DecalPass             m_decalPass;
 		LightingPass          m_lightingPass;
+		VolumetricFogPass     m_volumetricFogPass;
 		TonemapPass           m_tonemapPass;
 		BloomPrefilterPass    m_bloomPrefilterPass;
 		BloomDownsamplePass   m_bloomDownsamplePass;

--- a/src/client/render/VolumetricFogPass.cpp
+++ b/src/client/render/VolumetricFogPass.cpp
@@ -1,0 +1,506 @@
+#include "src/client/render/VolumetricFogPass.h"
+#include "src/client/render/PipelineCache.h"
+#include "src/shared/core/Log.h"
+
+#include <array>
+#include <cstring>
+
+namespace engine::render
+{
+	// -------------------------------------------------------------------------
+	// Helpers internes
+	// -------------------------------------------------------------------------
+
+	namespace
+	{
+		/// Crée un VkShaderModule à partir de mots SPIR-V.
+		/// \param code      Pointeur sur les mots SPIR-V.
+		/// \param wordCount Nombre de mots (32 bits) du module.
+		/// \return Le module créé, ou VK_NULL_HANDLE en cas d'échec.
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* code, size_t wordCount)
+		{
+			VkShaderModuleCreateInfo info{};
+			info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			info.codeSize = wordCount * sizeof(uint32_t);
+			info.pCode    = code;
+			VkShaderModule mod = VK_NULL_HANDLE;
+			vkCreateShaderModule(device, &info, nullptr, &mod);
+			return mod;
+		}
+
+	} // namespace anonyme
+
+	// -------------------------------------------------------------------------
+	// VolumetricFogPass::Init
+	// -------------------------------------------------------------------------
+
+	bool VolumetricFogPass::Init(VkDevice device, VkPhysicalDevice /*physicalDevice*/,
+		VkFormat sceneColorHDRFormat,
+		const uint32_t* vertSpirv, size_t vertWordCount,
+		const uint32_t* fragSpirv, size_t fragWordCount,
+		uint32_t maxFrames,
+		VkPipelineCache pipelineCache)
+	{
+		if (device == VK_NULL_HANDLE || !vertSpirv || !fragSpirv
+			|| vertWordCount == 0 || fragWordCount == 0)
+		{
+			LOG_ERROR(Render, "VolumetricFogPass::Init: invalid arguments");
+			return false;
+		}
+
+		m_maxFrames = maxFrames > 0 ? maxFrames : 1;
+
+		// -----------------------------------------------------------------
+		// 1. Render pass : 1 color attachment (SceneColor_HDR brouillardée)
+		// -----------------------------------------------------------------
+		{
+			VkAttachmentDescription colorAtt{};
+			colorAtt.format         = sceneColorHDRFormat;
+			colorAtt.samples        = VK_SAMPLE_COUNT_1_BIT;
+			colorAtt.loadOp         = VK_ATTACHMENT_LOAD_OP_DONT_CARE; // on réécrit tout le plein écran
+			colorAtt.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+			colorAtt.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			colorAtt.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			colorAtt.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+			colorAtt.finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+			VkAttachmentReference colorRef = { 0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
+
+			VkSubpassDescription subpass{};
+			subpass.pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS;
+			subpass.colorAttachmentCount = 1;
+			subpass.pColorAttachments    = &colorRef;
+
+			// Dépendance : on lit scene color / depth / shadow map (écrits par les passes
+			// amont en color/depth) en fragment shader avant de réécrire le plein écran.
+			VkSubpassDependency dep{};
+			dep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+			dep.dstSubpass    = 0;
+			dep.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+				| VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT
+				| VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			dep.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+				| VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+			dep.dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+			dep.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+			VkRenderPassCreateInfo rpInfo{};
+			rpInfo.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+			rpInfo.attachmentCount = 1;
+			rpInfo.pAttachments    = &colorAtt;
+			rpInfo.subpassCount    = 1;
+			rpInfo.pSubpasses      = &subpass;
+			rpInfo.dependencyCount = 1;
+			rpInfo.pDependencies   = &dep;
+
+			VkResult res = vkCreateRenderPass(device, &rpInfo, nullptr, &m_renderPass);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateRenderPass failed: {}", static_cast<int>(res));
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 2. Descriptor set layout : 3 combined image samplers
+		//    (scene color HDR, depth, shadow map cascade 0)
+		// -----------------------------------------------------------------
+		{
+			std::array<VkDescriptorSetLayoutBinding, 3> bindings{};
+			for (size_t i = 0; i < bindings.size(); ++i)
+			{
+				bindings[i].binding            = static_cast<uint32_t>(i);
+				bindings[i].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount    = 1;
+				bindings[i].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+				bindings[i].pImmutableSamplers = nullptr;
+			}
+
+			VkDescriptorSetLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+			layoutInfo.pBindings    = bindings.data();
+
+			VkResult res = vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_descriptorSetLayout);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateDescriptorSetLayout failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 3. Descriptor pool : maxFrames sets, 3 combined image samplers chacun
+		// -----------------------------------------------------------------
+		{
+			VkDescriptorPoolSize poolSize{};
+			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSize.descriptorCount = 3 * m_maxFrames;
+
+			VkDescriptorPoolCreateInfo poolInfo{};
+			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+			poolInfo.poolSizeCount = 1;
+			poolInfo.pPoolSizes    = &poolSize;
+			poolInfo.maxSets       = m_maxFrames;
+
+			VkResult res = vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateDescriptorPool failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 4. Alloue un descriptor set par frame
+		// -----------------------------------------------------------------
+		{
+			std::vector<VkDescriptorSetLayout> layouts(m_maxFrames, m_descriptorSetLayout);
+
+			VkDescriptorSetAllocateInfo allocInfo{};
+			allocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+			allocInfo.descriptorPool     = m_descriptorPool;
+			allocInfo.descriptorSetCount = m_maxFrames;
+			allocInfo.pSetLayouts        = layouts.data();
+
+			m_descriptorSets.resize(m_maxFrames, VK_NULL_HANDLE);
+			VkResult res = vkAllocateDescriptorSets(device, &allocInfo, m_descriptorSets.data());
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkAllocateDescriptorSets failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 5. Samplers : linéaire clamp (scene color), nearest clamp (depth + shadow)
+		// -----------------------------------------------------------------
+		{
+			VkSamplerCreateInfo si{};
+			si.sType         = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+			si.magFilter     = VK_FILTER_LINEAR;
+			si.minFilter     = VK_FILTER_LINEAR;
+			si.mipmapMode    = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+			si.addressModeU  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.addressModeV  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.addressModeW  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.compareEnable = VK_FALSE;
+			si.compareOp     = VK_COMPARE_OP_ALWAYS;
+			si.maxLod        = 0.0f;
+
+			VkResult res = vkCreateSampler(device, &si, nullptr, &m_linearSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateSampler (linear) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+
+			// Nearest clamp : depth + shadow map (lecture plain, pas de compare).
+			si.magFilter = VK_FILTER_NEAREST;
+			si.minFilter = VK_FILTER_NEAREST;
+			res = vkCreateSampler(device, &si, nullptr, &m_nearestSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateSampler (nearest) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 6. Pipeline layout : descriptor set 0 + push constants (192 o, fragment)
+		// -----------------------------------------------------------------
+		{
+			VkPushConstantRange pushRange{};
+			pushRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+			pushRange.offset     = 0;
+			pushRange.size       = static_cast<uint32_t>(sizeof(FogParams)); // 192 octets
+
+			VkPipelineLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			layoutInfo.setLayoutCount         = 1;
+			layoutInfo.pSetLayouts            = &m_descriptorSetLayout;
+			layoutInfo.pushConstantRangeCount = 1;
+			layoutInfo.pPushConstantRanges    = &pushRange;
+
+			VkResult res = vkCreatePipelineLayout(device, &layoutInfo, nullptr, &m_pipelineLayout);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreatePipelineLayout failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 7. Pipeline graphique : fullscreen triangle, pas de vertex input, pas de depth test
+		// -----------------------------------------------------------------
+		{
+			VkShaderModule vertMod = CreateShaderModule(device, vertSpirv, vertWordCount);
+			VkShaderModule fragMod = CreateShaderModule(device, fragSpirv, fragWordCount);
+			if (vertMod == VK_NULL_HANDLE || fragMod == VK_NULL_HANDLE)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: shader module creation failed");
+				if (vertMod) vkDestroyShaderModule(device, vertMod, nullptr);
+				if (fragMod) vkDestroyShaderModule(device, fragMod, nullptr);
+				Destroy(device);
+				return false;
+			}
+
+			VkPipelineShaderStageCreateInfo stages[2]{};
+			stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+			stages[0].module = vertMod;
+			stages[0].pName  = "main";
+			stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+			stages[1].module = fragMod;
+			stages[1].pName  = "main";
+
+			// Pas de vertex input : le triangle plein écran est généré depuis gl_VertexIndex.
+			VkPipelineVertexInputStateCreateInfo vi{};
+			vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+			VkPipelineInputAssemblyStateCreateInfo ia{};
+			ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+			ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+			VkPipelineViewportStateCreateInfo vp{};
+			vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+			vp.viewportCount = 1;
+			vp.scissorCount  = 1;
+
+			VkPipelineRasterizationStateCreateInfo rs{};
+			rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+			rs.polygonMode = VK_POLYGON_MODE_FILL;
+			rs.cullMode    = VK_CULL_MODE_NONE; // pas de culling pour le triangle plein écran
+			rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+			rs.lineWidth   = 1.0f;
+
+			VkPipelineMultisampleStateCreateInfo ms{};
+			ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+			ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+			// Pas de depth test/write pour la passe plein écran.
+			VkPipelineDepthStencilStateCreateInfo ds{};
+			ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+			ds.depthTestEnable  = VK_FALSE;
+			ds.depthWriteEnable = VK_FALSE;
+
+			VkPipelineColorBlendAttachmentState blendAtt{};
+			blendAtt.blendEnable    = VK_FALSE;
+			blendAtt.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+				| VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+			VkPipelineColorBlendStateCreateInfo cb{};
+			cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+			cb.attachmentCount = 1;
+			cb.pAttachments    = &blendAtt;
+
+			VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+			VkPipelineDynamicStateCreateInfo dyn{};
+			dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+			dyn.dynamicStateCount = 2;
+			dyn.pDynamicStates    = dynStates;
+
+			VkGraphicsPipelineCreateInfo gpInfo{};
+			gpInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+			gpInfo.stageCount          = 2;
+			gpInfo.pStages             = stages;
+			gpInfo.pVertexInputState   = &vi;
+			gpInfo.pInputAssemblyState = &ia;
+			gpInfo.pViewportState      = &vp;
+			gpInfo.pRasterizationState = &rs;
+			gpInfo.pMultisampleState   = &ms;
+			gpInfo.pDepthStencilState  = &ds;
+			gpInfo.pColorBlendState    = &cb;
+			gpInfo.pDynamicState       = &dyn;
+			gpInfo.layout              = m_pipelineLayout;
+			gpInfo.renderPass          = m_renderPass;
+			gpInfo.subpass             = 0;
+
+			AssertPipelineCreationAllowed();
+			PipelineCache::RegisterWarmupKey(HashGraphicsPsoKey(m_renderPass, 0, m_pipelineLayout, sceneColorHDRFormat, VK_FORMAT_UNDEFINED));
+			VkResult res = vkCreateGraphicsPipelines(device, pipelineCache, 1, &gpInfo, nullptr, &m_pipeline);
+			vkDestroyShaderModule(device, vertMod, nullptr);
+			vkDestroyShaderModule(device, fragMod, nullptr);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass: vkCreateGraphicsPipelines failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		LOG_INFO(Render, "VolumetricFogPass: initialized (maxFrames={})", m_maxFrames);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// VolumetricFogPass::Record
+	// -------------------------------------------------------------------------
+
+	void VolumetricFogPass::Record(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+		VkExtent2D extent,
+		ResourceId idSceneColorIn, ResourceId idDepth, ResourceId idShadowCascade0,
+		ResourceId idSceneColorOut, const FogParams& params, uint32_t frameIndex)
+	{
+		if (!IsValid() || extent.width == 0 || extent.height == 0)
+			return;
+
+		// Récupère les vues depuis le registry du frame graph.
+		VkImageView viewSceneIn = registry.getImageView(idSceneColorIn);
+		VkImageView viewDepth   = registry.getImageView(idDepth);
+		VkImageView viewShadow  = registry.getImageView(idShadowCascade0);
+		VkImageView viewOut     = registry.getImageView(idSceneColorOut);
+
+		if (viewSceneIn == VK_NULL_HANDLE || viewDepth == VK_NULL_HANDLE
+			|| viewShadow == VK_NULL_HANDLE || viewOut == VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "VolumetricFogPass::Record: missing image views, skipping");
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Met à jour le descriptor set de cette frame avec les 3 vues.
+		// ------------------------------------------------------------------
+		const uint32_t setIdx = frameIndex % m_maxFrames;
+		VkDescriptorSet ds = m_descriptorSets[setIdx];
+
+		std::array<VkDescriptorImageInfo, 3> imageInfos{};
+		imageInfos[0] = { m_linearSampler,  viewSceneIn, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[1] = { m_nearestSampler, viewDepth,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[2] = { m_nearestSampler, viewShadow,  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+
+		std::array<VkWriteDescriptorSet, 3> writes{};
+		for (size_t i = 0; i < writes.size(); ++i)
+		{
+			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[i].dstSet          = ds;
+			writes[i].dstBinding      = static_cast<uint32_t>(i);
+			writes[i].dstArrayElement = 0;
+			writes[i].descriptorCount = 1;
+			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[i].pImageInfo      = &imageInfos[i];
+		}
+		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+
+		// ------------------------------------------------------------------
+		// Crée un framebuffer temporaire sur l'image de sortie.
+		// ------------------------------------------------------------------
+		VkFramebufferCreateInfo fbInfo{};
+		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		fbInfo.renderPass      = m_renderPass;
+		fbInfo.attachmentCount = 1;
+		fbInfo.pAttachments    = &viewOut;
+		fbInfo.width           = extent.width;
+		fbInfo.height          = extent.height;
+		fbInfo.layers          = 1;
+
+		VkFramebuffer fb = VK_NULL_HANDLE;
+		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+		if (res != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "VolumetricFogPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Ouvre la render pass.
+		// ------------------------------------------------------------------
+		VkClearValue clearVal{};
+		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
+
+		VkRenderPassBeginInfo rpBegin{};
+		rpBegin.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+		rpBegin.renderPass      = m_renderPass;
+		rpBegin.framebuffer     = fb;
+		rpBegin.renderArea      = { { 0, 0 }, extent };
+		rpBegin.clearValueCount = 1;
+		rpBegin.pClearValues    = &clearVal;
+
+		vkCmdBeginRenderPass(cmd, &rpBegin, VK_SUBPASS_CONTENTS_INLINE);
+
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+			m_pipelineLayout, 0, 1, &ds, 0, nullptr);
+
+		VkViewport viewport{};
+		viewport.width    = static_cast<float>(extent.width);
+		viewport.height   = static_cast<float>(extent.height);
+		viewport.minDepth = 0.0f;
+		viewport.maxDepth = 1.0f;
+		vkCmdSetViewport(cmd, 0, 1, &viewport);
+		VkRect2D scissor = { { 0, 0 }, extent };
+		vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+		// Push constants : FogParams (192 octets, stage fragment).
+		vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT,
+			0, static_cast<uint32_t>(sizeof(FogParams)), &params);
+
+		// Triangle plein écran (3 sommets, pas de vertex buffer).
+		vkCmdDraw(cmd, 3, 1, 0, 0);
+
+		vkCmdEndRenderPass(cmd);
+
+		// Détruit le framebuffer temporaire immédiatement.
+		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// -------------------------------------------------------------------------
+	// VolumetricFogPass::Destroy
+	// -------------------------------------------------------------------------
+
+	void VolumetricFogPass::Destroy(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE)
+		{
+			LOG_INFO(Render, "[VolumetricFogPass] Destroyed");
+			return;
+		}
+
+		if (m_pipeline != VK_NULL_HANDLE)
+		{
+			vkDestroyPipeline(device, m_pipeline, nullptr);
+			m_pipeline = VK_NULL_HANDLE;
+		}
+		if (m_pipelineLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+			m_pipelineLayout = VK_NULL_HANDLE;
+		}
+		if (m_nearestSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_nearestSampler, nullptr);
+			m_nearestSampler = VK_NULL_HANDLE;
+		}
+		if (m_linearSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_linearSampler, nullptr);
+			m_linearSampler = VK_NULL_HANDLE;
+		}
+		// Les descriptor sets sont libérés implicitement à la destruction du pool.
+		m_descriptorSets.clear();
+		if (m_descriptorPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
+			m_descriptorPool = VK_NULL_HANDLE;
+		}
+		if (m_descriptorSetLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorSetLayout(device, m_descriptorSetLayout, nullptr);
+			m_descriptorSetLayout = VK_NULL_HANDLE;
+		}
+		if (m_renderPass != VK_NULL_HANDLE)
+		{
+			vkDestroyRenderPass(device, m_renderPass, nullptr);
+			m_renderPass = VK_NULL_HANDLE;
+		}
+		LOG_INFO(Render, "[VolumetricFogPass] Destroyed");
+	}
+
+} // namespace engine::render

--- a/src/client/render/VolumetricFogPass.h
+++ b/src/client/render/VolumetricFogPass.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "src/client/render/FrameGraph.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine::render
+{
+	/// Passe GRAPHIQUE plein écran de brouillard volumique + god rays (M45.2 — v1).
+	///
+	/// Version conservatrice v1 : ray-march PAR PIXEL dans un FRAGMENT shader le long
+	/// du rayon caméra→pixel, en échantillonnant UNE seule cascade de shadow map
+	/// (cascade 0) pour l'occlusion solaire → god rays (rayons crépusculaires).
+	/// PAS de passe compute, PAS de volume froxel 3D (le frame graph ne gère ni les
+	/// images 3D ni les barrières storage-image). Le multi-cascade est un suivi.
+	///
+	/// Structure calquée EXACTEMENT sur LightingPass : render pass 1 attachment color,
+	/// descriptor set 0 de N combined image samplers, push constants fragment, pipeline
+	/// fullscreen triangle (3 sommets, pas de vertex input, pas de depth test), framebuffer
+	/// temporaire créé/détruit dans Record.
+	///
+	/// Descriptor set 0 : 3 combined image samplers
+	///   binding 0 = scene color HDR post-water (sampler linéaire clamp)
+	///   binding 1 = depth                       (sampler nearest clamp)
+	///   binding 2 = shadow map cascade 0        (sampler nearest clamp, image DEPTH lue en .r)
+	class VolumetricFogPass
+	{
+	public:
+		/// Représentation CPU des push constants envoyées chaque frame (stage fragment).
+		/// Le layout DOIT correspondre EXACTEMENT au bloc push_constant GLSL de
+		/// volumetric_fog.frag (std430 / push-constant : vec4 = 16 o, mat4 = 64 o).
+		struct FogParams
+		{
+			float invViewProj[16]; ///< Inverse view-projection, column-major (64 o).
+			float sunViewProj[16]; ///< lightViewProj de la cascade 0 (matrice ombre) (64 o).
+			float cameraPos[4];    ///< xyz = position caméra ; w = densité fog (<= 0 désactive) (16 o).
+			float sunDir[4];       ///< xyz = direction VERS le soleil (normalisée) ; w = anisotropie HG g [-1..1] (16 o).
+			float sunColor[4];     ///< xyz = couleur soleil ; w = intensité inscattering (16 o).
+			float fogParams[4];    ///< x = nb de steps, y = distance max de marche (m), z = hauteur de réf (m), w = atténuation hauteur (16 o).
+		};
+		static_assert(sizeof(FogParams) == 192, "FogParams must be exactly 192 bytes");
+
+		VolumetricFogPass() = default;
+		VolumetricFogPass(const VolumetricFogPass&) = delete;
+		VolumetricFogPass& operator=(const VolumetricFogPass&) = delete;
+
+		/// Crée la render pass, le descriptor set layout, le descriptor pool, les samplers
+		/// et le pipeline graphique plein écran.
+		/// \param sceneColorHDRFormat  Format de l'image de sortie (doit être VK_FORMAT_R16G16B16A16_SFLOAT).
+		/// \param vertSpirv / vertWordCount  SPIR-V du vertex shader (fullscreen triangle réutilisé).
+		/// \param fragSpirv / fragWordCount  SPIR-V du fragment shader (volumetric_fog.frag).
+		/// \param maxFrames  Nombre de frames en vol ; un descriptor set est alloué par frame.
+		/// \return false si un objet Vulkan échoue (l'appelant ne doit pas faire échouer le boot).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkFormat sceneColorHDRFormat,
+			const uint32_t* vertSpirv, size_t vertWordCount,
+			const uint32_t* fragSpirv, size_t fragWordCount,
+			uint32_t maxFrames = 2,
+			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Enregistre la passe brouillard volumique dans cmd.
+		/// Met à jour le descriptor set de la frame avec les 3 vues (scene color, depth,
+		/// shadow cascade 0), crée un framebuffer temporaire sur idSceneColorOut, ouvre la
+		/// render pass, push les FogParams, dessine le triangle plein écran, ferme la render
+		/// pass et détruit le framebuffer immédiatement.
+		/// \param idSceneColorIn    SceneColor HDR post-water (lu en entrée).
+		/// \param idDepth           Depth scene (D32_SFLOAT).
+		/// \param idShadowCascade0  Shadow map cascade 0 (image DEPTH).
+		/// \param idSceneColorOut   Cible de sortie (SceneColor HDR brouillardée).
+		/// \param frameIndex        Index de frame en vol (0 .. maxFrames-1).
+		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
+			ResourceId idSceneColorIn, ResourceId idDepth, ResourceId idShadowCascade0,
+			ResourceId idSceneColorOut, const FogParams& params, uint32_t frameIndex);
+
+		/// Libère toutes les ressources Vulkan. Sûr à appeler même si non initialisé.
+		void Destroy(VkDevice device);
+
+		/// Renvoie true si le pipeline et la render pass sont valides.
+		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
+
+	private:
+		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
+		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
+		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
+		VkPipelineLayout      m_pipelineLayout      = VK_NULL_HANDLE;
+		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
+		VkSampler             m_linearSampler       = VK_NULL_HANDLE; ///< Linéaire clamp, pour la scene color HDR.
+		VkSampler             m_nearestSampler      = VK_NULL_HANDLE; ///< Nearest clamp, pour depth + shadow map.
+
+		std::vector<VkDescriptorSet> m_descriptorSets; ///< Un par frame en vol.
+		uint32_t m_maxFrames = 2;
+	};
+
+} // namespace engine::render


### PR DESCRIPTION
## M45.2 — Brouillard volumique + god rays (cluster M45)

> ⚠️ **PR stackée sur #788 (M45.1)** — merger #788 d'abord. La base de cette PR est `feat/m45.1-aerial-perspective`.

### Décision d'architecture (déviation assumée vs ticket)
Le ticket demandait une **passe compute froxel 3D**. Après vérification du code réel : le frame graph **ne gère ni images 3D ni barrières storage-image** (`ImageUsage` n'a pas de mode compute-write). J'ai donc implémenté une **passe GRAPHIQUE plein écran** (fragment ray-march par pixel), qui produit **les mêmes god rays** en s'intégrant proprement au modèle FG existant (calquée sur `LightingPass`). Le froxel + multi-cascade reste un suivi (optimisation). Version conservatrice v1, comme recommandé par le ticket.

### Ce que ça fait
Pour chaque pixel, ray-march caméra→pixel ; à chaque pas : test d'occlusion soleil via la **shadow map cascade 0**, phase de **Henyey-Greenstein** (anisotropie vers le soleil), atténuation en hauteur. → rayons crépusculaires cohérents avec les ombres.

### Intégration (additif, gated, non-régressif)
- `VolumetricFogPass.{h,cpp}` : `Init`/`Record`/`Destroy`, 3 samplers (scene/depth/shadow), push constants `FogParams` (192 o, `static_assert`), fullscreen triangle. **Aucune signature publique existante modifiée.**
- `volumetric_fog.frag` : gating `density<=0` → passthrough ; reconstruction world pos ; ray-march + ombre + HG ; clamps anti-NaN.
- `DeferredPipeline` : possède la passe, init via `loadSpirv` (réutilise `lighting.vert`), **n'échoue jamais le boot**.
- `Engine` : nouvelle ressource FG `SceneColor_HDR_Fogged` (writer unique) ; passe `VolumetricFog` si init OK, sinon **passthrough** `vkCmdCopyImage` (calqué sur `Water_Passthrough`) ; `Bloom_Prefilter` **et** `Bloom_Combine` repointés `PostWater → Fogged` (sinon le fog serait bypassé dans l'image finale — corrigé en revue).
- `config.json` : bloc `world.volfog` (**`density=0` par défaut → désactivé**).
- `CMakeLists.txt` : `VolumetricFogPass.cpp`.

### Gating / non-régression
- Défaut **désactivé** (`density=0`) → passthrough dans le shader, rendu identique.
- Init échouée → passe `VolumetricFog_Passthrough` (copie) → Bloom lit une image valide.
- Pas de double writer (Fogged est neuf ; PostWater reste écrit par Water uniquement).

### Shaders
Source GLSL seule modifiée ; la CI Windows régénère le `.spv`.

### À valider visuellement (par toi, `world.volfog.density>0`)
- Cohérence god rays / ombres (échantillonnage cascade 0, biais 0.0015).
- Layout d'échantillonnage de la shadow map (image DEPTH lue en `SHADER_READ_ONLY`) — peut générer un avertissement de validation Vulkan à surveiller ; sans impact tant que désactivé.

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)