### PR TITLE
feat(render): M45.3 — depth of field / bokeh (passe plein écran HDR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ add_library(engine_core
   src/client/render/HiZPyramidPass.cpp
   src/client/render/LightingPass.cpp
   src/client/render/VolumetricFogPass.cpp
+  src/client/render/DepthOfFieldPass.cpp
   src/client/render/TonemapPass.cpp
   src/client/render/BloomPass.cpp
   src/client/render/AutoExposure.cpp

--- a/config.json
+++ b/config.json
@@ -163,6 +163,14 @@
             "height_m": 10.0,
             "height_falloff": 0.1
         },
+        "_comment_dof": "M45.3 Profondeur de champ / bokeh. Passe plein ecran sur l'image HDR APRES bloom et AVANT tonemap : reconstruit la distance monde par pixel (depth + invViewProj), calcule un Circle of Confusion depuis l'ecart au plan focal, et applique un flou en disque (16 samples) ponderé par le CoC (un sample ne bave que s'il est lui-meme flou). DESACTIVE par defaut (focus_range_m = 0 -> passthrough). focus_distance_m : distance du plan de nettete (m) ; focus_range_m : demi-largeur de la zone nette (m ; <= 0 desactive entierement la passe) ; max_blur_px : rayon de flou max (pixels) ; near_scale : echelle du flou pour l'avant-plan (devant le plan focal) ; far_scale : echelle du flou pour l'arriere-plan. Lu a chaque frame -> reglage a chaud.",
+        "dof": {
+            "focus_distance_m": 12.0,
+            "focus_range_m": 0.0,
+            "max_blur_px": 8.0,
+            "near_scale": 1.0,
+            "far_scale": 1.0
+        },
         "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet), mesh/scale/yaw_deg/rot_x_deg, dialogue. Seuls les VRAIS interactibles ici (PNJ, coffre). Le DECOR (arbres, props non interactifs mais solides) est dans world.scenery. Le coffre et le villageois sont solides (collision) comme tout le decor.",
         "interactables": {
             "count": 7,

--- a/game/data/shaders/dof.frag
+++ b/game/data/shaders/dof.frag
@@ -1,0 +1,154 @@
+#version 450
+
+// M45.3 — Profondeur de champ / bokeh, version v1.
+//
+// Passe GRAPHIQUE plein écran (fullscreen triangle, comme volumetric_fog.frag).
+// S'exécute sur l'image HDR APRÈS bloom et AVANT tonemap (sur HDR pour des
+// highlights bokeh propres). Pour CHAQUE pixel on reconstruit la position monde
+// depuis le depth, on calcule un Circle of Confusion (CoC) depuis la distance au
+// plan focal, puis on fait un flou en disque (16 samples fixes) pondéré par le
+// CoC. Un sample n'est mélangé QUE si son propre CoC le place dans le flou, pour
+// éviter le bleeding du flou à travers une arête nette de premier plan.
+//
+// Entrées (descriptor set 0) :
+//   binding 0 = scene color HDR post-bloom (sampler LINÉAIRE clamp)
+//   binding 1 = depth scene (D32_SFLOAT, sampler NEAREST clamp, lu en .r)
+//
+// Sortie :
+//   outColor (location 0) — scene color HDR floutée.
+//
+// Push constants (112 octets, stage fragment) — cf. DofParams (DepthOfFieldPass.h) :
+//   mat4 invVP      — inverse view-projection (reconstruction world pos depuis depth)
+//   vec4 cameraPos  — xyz = position caméra ; w = distance focale (m)
+//   vec4 dofParams  — x = plage de netteté (m, demi-largeur ; <=0 désactive = passthrough),
+//                     y = rayon de flou max (px), z = échelle flou near, w = échelle flou far
+//   vec4 texelSize  — x = 1/width, y = 1/height, z/w = padding
+
+layout(location = 0) in  vec2 inUV;
+layout(location = 0) out vec4 outColor;
+
+// ---- Samplers ---------------------------------------------------------------
+layout(set = 0, binding = 0) uniform sampler2D colorTex; // HDR post-bloom
+layout(set = 0, binding = 1) uniform sampler2D depthTex; // depth scene, .r = [0,1]
+
+// ---- Push constants ---------------------------------------------------------
+layout(push_constant) uniform PC
+{
+    mat4 invVP;      // inverse view-projection
+    vec4 cameraPos;  // xyz = caméra ; w = distance focale (m)
+    vec4 dofParams;  // x = focusRange (m), y = maxBlurPx, z = nearScale, w = farScale
+    vec4 texelSize;  // x = 1/w, y = 1/h, z/w = padding
+} pc;
+
+// 16 offsets fixes en disque (spirale de Fermat / anneaux), rayon normalisé [0,1].
+// Hardcodés pour éviter toute boucle dépendante de données non bornée.
+const vec2 kDiskOffsets[16] = vec2[16](
+    vec2( 0.0000,  0.0000),
+    vec2( 0.5400,  0.0000),
+    vec2( 0.1670,  0.5130),
+    vec2(-0.4360,  0.3170),
+    vec2(-0.4360, -0.3170),
+    vec2( 0.1670, -0.5130),
+    vec2( 0.7600,  0.4400),
+    vec2(-0.0000,  0.8800),
+    vec2(-0.7600,  0.4400),
+    vec2(-0.7600, -0.4400),
+    vec2( 0.0000, -0.8800),
+    vec2( 0.7600, -0.4400),
+    vec2( 1.0000,  0.0000),
+    vec2(-0.5000,  0.8660),
+    vec2(-0.5000, -0.8660),
+    vec2( 0.3090,  0.9510)
+);
+
+// Reconstruit la distance caméra->surface (en mètres) pour un UV donné.
+// \param uv         Coordonnée d'échantillonnage de l'image.
+// \param isSky      out : true si le pixel est le ciel (depth >= 1.0).
+// \return Distance monde en mètres ; pour le ciel, renvoie une grande valeur
+//         (flou far max, le ciel étant à l'infini).
+float sampleDistance(vec2 uv, out bool isSky)
+{
+    float depth = texture(depthTex, uv).r;
+    if (depth >= 1.0)
+    {
+        isSky = true;
+        return 1.0e6; // très loin : CoC -> far max
+    }
+    isSky = false;
+    vec2 ndcXY    = uv * 2.0 - 1.0;
+    vec4 posClip  = vec4(ndcXY, depth, 1.0);
+    vec4 posWorld = pc.invVP * posClip;
+    posWorld     /= posWorld.w;
+    return length(posWorld.xyz - pc.cameraPos.xyz);
+}
+
+// Calcule le rayon de flou (en pixels) à partir d'une distance monde.
+// \param dist Distance caméra->surface (m).
+// \return Rayon de flou en pixels, dans [0, maxBlurPx].
+float blurRadiusFromDist(float dist)
+{
+    float focus      = pc.cameraPos.w;
+    float focusRange = pc.dofParams.x;
+    float maxBlurPx  = pc.dofParams.y;
+    // CoC signé : négatif = near (devant le plan focal), positif = far.
+    float coc = (dist - focus) / max(focusRange, 1e-4);
+    coc = clamp(coc, -1.0, 1.0);
+    float blurPx;
+    if (coc < 0.0)
+        blurPx = min(-coc * pc.dofParams.z, 1.0) * maxBlurPx;
+    else
+        blurPx = min( coc * pc.dofParams.w, 1.0) * maxBlurPx;
+    return blurPx;
+}
+
+void main()
+{
+    // ---- (1) Couleur centrale ------------------------------------------
+    vec3 centerColor = texture(colorTex, inUV).rgb;
+
+    // ---- (2) Gating runtime : focusRange <= 0 -> passthrough -----------
+    float focusRange = pc.dofParams.x;
+    if (focusRange <= 0.0)
+    {
+        outColor = vec4(centerColor, 1.0);
+        return;
+    }
+
+    // ---- (3)/(4) CoC du pixel central ----------------------------------
+    bool centerSky;
+    float centerDist = sampleDistance(inUV, centerSky);
+    float blurPx = blurRadiusFromDist(centerDist);
+
+    // Trop peu de flou -> passthrough (évite un coût inutile + scintillement).
+    if (blurPx < 0.5)
+    {
+        outColor = vec4(centerColor, 1.0);
+        return;
+    }
+
+    // ---- (5) Flou en disque pondéré par le CoC des samples -------------
+    // On ne mélange un sample QUE si son PROPRE CoC le place dans le flou,
+    // pour éviter le bleeding d'un fond flou par-dessus un avant-plan net.
+    vec2 radiusUV = vec2(blurPx) * pc.texelSize.xy; // rayon en UV
+    vec3  accumColor  = vec3(0.0);
+    float accumWeight = 0.0;
+    for (int i = 0; i < 16; ++i)
+    {
+        vec2 sampleUV = inUV + kDiskOffsets[i] * radiusUV;
+        bool sampleSky;
+        float sampleDist = sampleDistance(sampleUV, sampleSky);
+        float sampleBlur = blurRadiusFromDist(sampleDist);
+        // Poids : 1 si le sample est lui-même flou au moins autant que la
+        // distance qui le sépare du centre (en pixels), sinon 0. Cela écarte
+        // les samples nets d'avant-plan qui ne devraient pas baver dans le flou.
+        float sampleOffsetPx = length(kDiskOffsets[i]) * blurPx;
+        float w = (sampleBlur >= sampleOffsetPx - 0.5) ? 1.0 : 0.0;
+        accumColor  += texture(colorTex, sampleUV).rgb * w;
+        accumWeight += w;
+    }
+
+    vec3 blurredColor = (accumWeight > 0.0) ? (accumColor / accumWeight) : centerColor;
+
+    // ---- (6) Sortie ----------------------------------------------------
+    outColor = vec4(blurredColor, 1.0);
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3837,6 +3837,11 @@ namespace engine
 										// TRANSFER_DST pour le passthrough vkCmdCopyImage). Lu en aval par
 										// Bloom_Prefilter / Bloom_Combine.
 										m_fgSceneColorFoggedId = m_frameGraph.createImage("SceneColor_HDR_Fogged", sceneColorHDRDesc);
+										// M45.3 — SceneColor_HDR_Dof : cible de la passe DepthOfField (bokeh),
+										// ou copie passthrough si la passe DoF est invalide. Meme desc que
+										// WithBloom/Fogged (qui inclut deja TRANSFER_DST pour le passthrough
+										// vkCmdCopyImage). Lu en aval par Tonemap (a la place de WithBloom).
+										m_fgSceneColorDofId = m_frameGraph.createImage("SceneColor_HDR_Dof", sceneColorHDRDesc);
 
 										engine::render::ImageDesc sceneColorLDRDesc{};
 										sceneColorLDRDesc.format = m_vkSwapchain.GetImageFormat();
@@ -3958,6 +3963,11 @@ namespace engine
 									// reussi (shaders presents). Sinon Engine enregistre un passthrough
 									// (copie PostWater -> Fogged) pour que Bloom lise une image valide.
 									m_volumetricFogReady = m_pipeline->GetVolumetricFogPass().IsValid();
+
+									// M45.3 — la passe DepthOfField est active uniquement si son Init a
+									// reussi (shaders presents). Sinon Engine enregistre un passthrough
+									// (copie WithBloom -> Dof) pour que Tonemap lise une image valide.
+									m_dofReady = m_pipeline->GetDepthOfFieldPass().IsValid();
 
 									// M100 — Task 12 : Terrain Chunk Runtime — drawcall mesh-terrain par
 									// chunk avec splat 8-layer. Co-existe avec le legacy TerrainRenderer
@@ -5924,9 +5934,107 @@ namespace engine
 													m_fgSceneColorHDRWithBloomId, m_vkSwapchain.GetExtent(), frameIdx);
 											});
 
+										// M45.3 — Profondeur de champ / bokeh. Lit SceneColor_HDR_WithBloom
+										// (HDR post-bloom) et le depth, calcule un CoC par pixel et ecrit
+										// SceneColor_HDR_Dof. Si la passe DoF est invalide (shaders absents /
+										// Init KO), on enregistre a la place un passthrough vkCmdCopyImage qui
+										// recopie WithBloom -> Dof, exactement comme VolumetricFog_Passthrough,
+										// pour garantir que Tonemap (qui lit desormais Dof) trouve une image
+										// valide. Le gating runtime (focus_range_m<=0) est gere dans le shader.
+										if (m_dofReady)
+										{
+											m_frameGraph.addPass("DepthOfField",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgSceneColorHDRWithBloomId, engine::render::ImageUsage::SampledRead);
+													b.read(m_fgDepthId,                  engine::render::ImageUsage::SampledRead);
+													b.write(m_fgSceneColorDofId,         engine::render::ImageUsage::ColorWrite);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													if (!m_pipeline->GetDepthOfFieldPass().IsValid()) return;
+													const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+													const engine::RenderState& rs = m_renderStates[readIdx];
+													engine::render::DepthOfFieldPass::DofParams dp{};
+													// invViewProj = inverse de rs.viewProjMatrix (meme routine que VolumetricFog).
+													const float* vp = rs.viewProjMatrix.m;
+													const float a00=vp[0], a10=vp[1], a20=vp[2],  a30=vp[3];
+													const float a01=vp[4], a11=vp[5], a21=vp[6],  a31=vp[7];
+													const float a02=vp[8], a12=vp[9], a22=vp[10], a32=vp[11];
+													const float a03=vp[12],a13=vp[13],a23=vp[14], a33=vp[15];
+													const float b00=a00*a11-a10*a01, b01=a00*a21-a20*a01, b02=a00*a31-a30*a01;
+													const float b03=a10*a21-a20*a11, b04=a10*a31-a30*a11, b05=a20*a31-a30*a21;
+													const float b06=a02*a13-a12*a03, b07=a02*a23-a22*a03, b08=a02*a33-a32*a03;
+													const float b09=a12*a23-a22*a13, b10=a12*a33-a32*a13, b11=a22*a33-a32*a23;
+													const float det = b00*b11-b01*b10+b02*b09+b03*b08-b04*b07+b05*b06;
+													if (det > 1e-7f || det < -1e-7f)
+													{
+														const float inv = 1.0f / det;
+														dp.invViewProj[0]  = ( a11*b11-a21*b10+a31*b09)*inv;
+														dp.invViewProj[1]  = (-a10*b11+a20*b10-a30*b09)*inv;
+														dp.invViewProj[2]  = ( a13*b05-a23*b04+a33*b03)*inv;
+														dp.invViewProj[3]  = (-a12*b05+a22*b04-a32*b03)*inv;
+														dp.invViewProj[4]  = (-a01*b11+a21*b08-a31*b07)*inv;
+														dp.invViewProj[5]  = ( a00*b11-a20*b08+a30*b07)*inv;
+														dp.invViewProj[6]  = (-a03*b05+a23*b02-a33*b01)*inv;
+														dp.invViewProj[7]  = ( a02*b05-a22*b02+a32*b01)*inv;
+														dp.invViewProj[8]  = ( a01*b10-a11*b08+a31*b06)*inv;
+														dp.invViewProj[9]  = (-a00*b10+a10*b08-a30*b06)*inv;
+														dp.invViewProj[10] = ( a03*b04-a13*b02+a33*b00)*inv;
+														dp.invViewProj[11] = (-a02*b04+a12*b02-a32*b00)*inv;
+														dp.invViewProj[12] = (-a01*b09+a11*b07-a21*b06)*inv;
+														dp.invViewProj[13] = ( a00*b09-a10*b07+a20*b06)*inv;
+														dp.invViewProj[14] = (-a03*b03+a13*b01-a23*b00)*inv;
+														dp.invViewProj[15] = ( a02*b03-a12*b01+a22*b00)*inv;
+													}
+													dp.cameraPos[0] = rs.camera.position.x;
+													dp.cameraPos[1] = rs.camera.position.y;
+													dp.cameraPos[2] = rs.camera.position.z;
+													// w = distance focale (m).
+													dp.cameraPos[3] = static_cast<float>(m_cfg.GetDouble("world.dof.focus_distance_m", 12.0));
+													// x = plage de nettete (m ; defaut 0 = desactive ; gating runtime dans le shader).
+													dp.dofParams[0] = static_cast<float>(m_cfg.GetDouble("world.dof.focus_range_m", 0.0));
+													dp.dofParams[1] = static_cast<float>(m_cfg.GetDouble("world.dof.max_blur_px", 8.0));
+													dp.dofParams[2] = static_cast<float>(m_cfg.GetDouble("world.dof.near_scale", 1.0));
+													dp.dofParams[3] = static_cast<float>(m_cfg.GetDouble("world.dof.far_scale", 1.0));
+													VkExtent2D ext = m_vkSwapchain.GetExtent();
+													dp.texelSize[0] = (ext.width  > 0) ? (1.0f / static_cast<float>(ext.width))  : 0.0f;
+													dp.texelSize[1] = (ext.height > 0) ? (1.0f / static_cast<float>(ext.height)) : 0.0f;
+													dp.texelSize[2] = 0.0f;
+													dp.texelSize[3] = 0.0f;
+													m_pipeline->GetDepthOfFieldPass().Record(
+														m_vkDeviceContext.GetDevice(), cmd, reg,
+														ext,
+														m_fgSceneColorHDRWithBloomId, m_fgDepthId,
+														m_fgSceneColorDofId, dp, m_currentFrame % 2);
+												});
+										}
+										else
+										{
+											// DoF indisponible -> copie WithBloom -> Dof (writer unique) pour que
+											// Tonemap lise une image valide. Meme pattern que VolumetricFog_Passthrough.
+											m_frameGraph.addPass("DepthOfField_Passthrough",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgSceneColorHDRWithBloomId, engine::render::ImageUsage::TransferSrc);
+													b.write(m_fgSceneColorDofId,         engine::render::ImageUsage::TransferDst);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													VkImage src = reg.getImage(m_fgSceneColorHDRWithBloomId);
+													VkImage dst = reg.getImage(m_fgSceneColorDofId);
+													if (src == VK_NULL_HANDLE || dst == VK_NULL_HANDLE) return;
+													VkImageCopy copy{};
+													copy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+													copy.srcSubresource.layerCount = 1;
+													copy.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+													copy.dstSubresource.layerCount = 1;
+													VkExtent2D ext = m_vkSwapchain.GetExtent();
+													copy.extent = { ext.width, ext.height, 1 };
+													vkCmdCopyImage(cmd, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+														dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+												});
+										}
+
 										m_frameGraph.addPass("Tonemap",
 											[this](engine::render::PassBuilder& b) {
-												b.read(m_fgSceneColorHDRWithBloomId, engine::render::ImageUsage::SampledRead);
+												b.read(m_fgSceneColorDofId,          engine::render::ImageUsage::SampledRead);
 												b.write(m_fgSceneColorLDRId,         engine::render::ImageUsage::ColorWrite);
 											},
 											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
@@ -5940,7 +6048,7 @@ namespace engine
 												VkImageView lutView = VK_NULL_HANDLE;
 												if (lutEnabled) { engine::render::TextureAsset* lutTex = m_colorGradingLutHandle.Get(); if (lutTex && lutTex->view != VK_NULL_HANDLE) lutView = lutTex->view; }
 												const uint32_t frameIdx = m_currentFrame % 2;
-												m_pipeline->GetTonemapPass().Record(m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(), m_fgSceneColorHDRWithBloomId, m_fgSceneColorLDRId, tp, lutView, frameIdx);
+												m_pipeline->GetTonemapPass().Record(m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(), m_fgSceneColorDofId, m_fgSceneColorLDRId, tp, lutView, frameIdx);
 											});
 
 										m_frameGraph.addPass("TAA",

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -346,6 +346,13 @@ namespace engine
 		/// M45.2 — true si VolumetricFogPass::IsValid() au boot (passe fog active) ;
 		/// sinon Engine enregistre un passthrough (copie PostWater -> Fogged).
 		bool m_volumetricFogReady = false;
+		/// M45.3 — SceneColor_HDR_Dof : SceneColor_HDR_WithBloom après profondeur de
+		/// champ / bokeh (DepthOfField), ou copie passthrough si la passe DoF est
+		/// invalide. Lu en SampledRead par Tonemap (à la place de WithBloom).
+		engine::render::ResourceId m_fgSceneColorDofId = engine::render::kInvalidResourceId;
+		/// M45.3 — true si DepthOfFieldPass::IsValid() au boot (passe DoF active) ;
+		/// sinon Engine enregistre un passthrough (copie WithBloom -> Dof).
+		bool m_dofReady = false;
 		/// SceneColor_LDR: output of the tonemap pass (R8G8B8A8_UNORM). Added in M03.4.
 		engine::render::ResourceId m_fgSceneColorLDRId   = engine::render::kInvalidResourceId;
 		/// M08.2: SceneColor_HDR + bloom (combine pass output); tonemap reads this.

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -260,6 +260,25 @@ namespace engine::render
 				LOG_WARN(Render, "M45.2: volumetric fog shaders not found, passthrough fallback");
 		}
 
+		// M45.3 — Depth of field / bokeh pass (sur HDR, apres bloom, avant tonemap).
+		// Reutilise le vertex shader fullscreen triangle de la passe lighting.
+		// N'echoue jamais le boot : si shaders absents ou Init KO, la passe reste
+		// invalide et Engine enregistre un passthrough (copie WithBloom -> Dof).
+		{
+			std::vector<uint32_t> dofVert = loadSpirv("shaders/lighting.vert.spv");
+			std::vector<uint32_t> dofFrag = loadSpirv("shaders/dof.frag.spv");
+			if (!dofVert.empty() && !dofFrag.empty())
+			{
+				if (m_depthOfFieldPass.Init(device, physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT,
+						dofVert.data(), dofVert.size(), dofFrag.data(), dofFrag.size(), 2u, pipelineCacheHandle))
+					LOG_INFO(Render, "[Boot] DeferredPipeline DepthOfFieldPass OK");
+				else
+					LOG_WARN(Render, "M45.3: depth of field pass init failed, passthrough fallback");
+			}
+			else
+				LOG_WARN(Render, "M45.3: depth of field shaders not found, passthrough fallback");
+		}
+
 		// Tonemap pass
 		{
 			std::vector<uint32_t> tmVert = loadSpirv("shaders/tonemap.vert.spv");
@@ -365,6 +384,8 @@ namespace engine::render
 		m_bloomDownsamplePass.Destroy(device);
 		m_bloomPrefilterPass.Destroy(device);
 		m_tonemapPass.Destroy(device);
+		m_depthOfFieldPass.Destroy(device); // M45.3
+		m_volumetricFogPass.Destroy(device); // M45.2
 		m_lightingPass.Destroy(device);
 		m_decalPass.Destroy(device);
 		m_shadowMapPass.Destroy(device);

--- a/src/client/render/DeferredPipeline.h
+++ b/src/client/render/DeferredPipeline.h
@@ -13,6 +13,7 @@
 #include "src/client/render/DecalPass.h"
 #include "src/client/render/LightingPass.h"
 #include "src/client/render/VolumetricFogPass.h"
+#include "src/client/render/DepthOfFieldPass.h"
 #include "src/client/render/TonemapPass.h"
 #include "src/client/render/BloomPass.h"
 #include "src/client/render/AutoExposure.h"
@@ -87,6 +88,8 @@ namespace engine::render
 		const LightingPass&  GetLightingPass() const    { return m_lightingPass; }
 		VolumetricFogPass&        GetVolumetricFogPass()        { return m_volumetricFogPass; }
 		const VolumetricFogPass&  GetVolumetricFogPass() const  { return m_volumetricFogPass; }
+		DepthOfFieldPass&         GetDepthOfFieldPass()         { return m_depthOfFieldPass; }
+		const DepthOfFieldPass&   GetDepthOfFieldPass() const   { return m_depthOfFieldPass; }
 		TonemapPass&          GetTonemapPass()          { return m_tonemapPass; }
 		const TonemapPass&    GetTonemapPass() const    { return m_tonemapPass; }
 		BloomPrefilterPass&   GetBloomPrefilterPass()   { return m_bloomPrefilterPass; }
@@ -112,6 +115,7 @@ namespace engine::render
 		DecalPass             m_decalPass;
 		LightingPass          m_lightingPass;
 		VolumetricFogPass     m_volumetricFogPass;
+		DepthOfFieldPass      m_depthOfFieldPass;
 		TonemapPass           m_tonemapPass;
 		BloomPrefilterPass    m_bloomPrefilterPass;
 		BloomDownsamplePass   m_bloomDownsamplePass;

--- a/src/client/render/DepthOfFieldPass.cpp
+++ b/src/client/render/DepthOfFieldPass.cpp
@@ -1,0 +1,504 @@
+#include "src/client/render/DepthOfFieldPass.h"
+#include "src/client/render/PipelineCache.h"
+#include "src/shared/core/Log.h"
+
+#include <array>
+#include <cstring>
+
+namespace engine::render
+{
+	// -------------------------------------------------------------------------
+	// Helpers internes
+	// -------------------------------------------------------------------------
+
+	namespace
+	{
+		/// Crée un VkShaderModule à partir de mots SPIR-V.
+		/// \param code      Pointeur sur les mots SPIR-V.
+		/// \param wordCount Nombre de mots (32 bits) du module.
+		/// \return Le module créé, ou VK_NULL_HANDLE en cas d'échec.
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* code, size_t wordCount)
+		{
+			VkShaderModuleCreateInfo info{};
+			info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			info.codeSize = wordCount * sizeof(uint32_t);
+			info.pCode    = code;
+			VkShaderModule mod = VK_NULL_HANDLE;
+			vkCreateShaderModule(device, &info, nullptr, &mod);
+			return mod;
+		}
+
+	} // namespace anonyme
+
+	// -------------------------------------------------------------------------
+	// DepthOfFieldPass::Init
+	// -------------------------------------------------------------------------
+
+	bool DepthOfFieldPass::Init(VkDevice device, VkPhysicalDevice /*physicalDevice*/,
+		VkFormat sceneColorHDRFormat,
+		const uint32_t* vertSpirv, size_t vertWordCount,
+		const uint32_t* fragSpirv, size_t fragWordCount,
+		uint32_t maxFrames,
+		VkPipelineCache pipelineCache)
+	{
+		if (device == VK_NULL_HANDLE || !vertSpirv || !fragSpirv
+			|| vertWordCount == 0 || fragWordCount == 0)
+		{
+			LOG_ERROR(Render, "DepthOfFieldPass::Init: invalid arguments");
+			return false;
+		}
+
+		m_maxFrames = maxFrames > 0 ? maxFrames : 1;
+
+		// -----------------------------------------------------------------
+		// 1. Render pass : 1 color attachment (SceneColor_HDR floutée)
+		// -----------------------------------------------------------------
+		{
+			VkAttachmentDescription colorAtt{};
+			colorAtt.format         = sceneColorHDRFormat;
+			colorAtt.samples        = VK_SAMPLE_COUNT_1_BIT;
+			colorAtt.loadOp         = VK_ATTACHMENT_LOAD_OP_DONT_CARE; // on réécrit tout le plein écran
+			colorAtt.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+			colorAtt.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			colorAtt.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			colorAtt.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+			colorAtt.finalLayout    = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+			VkAttachmentReference colorRef = { 0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL };
+
+			VkSubpassDescription subpass{};
+			subpass.pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS;
+			subpass.colorAttachmentCount = 1;
+			subpass.pColorAttachments    = &colorRef;
+
+			// Dépendance : on lit scene color / depth (écrits par les passes amont en
+			// color/depth) en fragment shader avant de réécrire le plein écran.
+			VkSubpassDependency dep{};
+			dep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+			dep.dstSubpass    = 0;
+			dep.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+				| VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT
+				| VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			dep.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+				| VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+			dep.dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+			dep.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+			VkRenderPassCreateInfo rpInfo{};
+			rpInfo.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+			rpInfo.attachmentCount = 1;
+			rpInfo.pAttachments    = &colorAtt;
+			rpInfo.subpassCount    = 1;
+			rpInfo.pSubpasses      = &subpass;
+			rpInfo.dependencyCount = 1;
+			rpInfo.pDependencies   = &dep;
+
+			VkResult res = vkCreateRenderPass(device, &rpInfo, nullptr, &m_renderPass);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateRenderPass failed: {}", static_cast<int>(res));
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 2. Descriptor set layout : 2 combined image samplers
+		//    (scene color HDR post-bloom, depth)
+		// -----------------------------------------------------------------
+		{
+			std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
+			for (size_t i = 0; i < bindings.size(); ++i)
+			{
+				bindings[i].binding            = static_cast<uint32_t>(i);
+				bindings[i].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount    = 1;
+				bindings[i].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+				bindings[i].pImmutableSamplers = nullptr;
+			}
+
+			VkDescriptorSetLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+			layoutInfo.pBindings    = bindings.data();
+
+			VkResult res = vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_descriptorSetLayout);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateDescriptorSetLayout failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 3. Descriptor pool : maxFrames sets, 2 combined image samplers chacun
+		// -----------------------------------------------------------------
+		{
+			VkDescriptorPoolSize poolSize{};
+			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSize.descriptorCount = 2 * m_maxFrames;
+
+			VkDescriptorPoolCreateInfo poolInfo{};
+			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+			poolInfo.poolSizeCount = 1;
+			poolInfo.pPoolSizes    = &poolSize;
+			poolInfo.maxSets       = m_maxFrames;
+
+			VkResult res = vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateDescriptorPool failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 4. Alloue un descriptor set par frame
+		// -----------------------------------------------------------------
+		{
+			std::vector<VkDescriptorSetLayout> layouts(m_maxFrames, m_descriptorSetLayout);
+
+			VkDescriptorSetAllocateInfo allocInfo{};
+			allocInfo.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+			allocInfo.descriptorPool     = m_descriptorPool;
+			allocInfo.descriptorSetCount = m_maxFrames;
+			allocInfo.pSetLayouts        = layouts.data();
+
+			m_descriptorSets.resize(m_maxFrames, VK_NULL_HANDLE);
+			VkResult res = vkAllocateDescriptorSets(device, &allocInfo, m_descriptorSets.data());
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkAllocateDescriptorSets failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 5. Samplers : linéaire clamp (scene color), nearest clamp (depth)
+		// -----------------------------------------------------------------
+		{
+			VkSamplerCreateInfo si{};
+			si.sType         = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+			si.magFilter     = VK_FILTER_LINEAR;
+			si.minFilter     = VK_FILTER_LINEAR;
+			si.mipmapMode    = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+			si.addressModeU  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.addressModeV  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.addressModeW  = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			si.compareEnable = VK_FALSE;
+			si.compareOp     = VK_COMPARE_OP_ALWAYS;
+			si.maxLod        = 0.0f;
+
+			VkResult res = vkCreateSampler(device, &si, nullptr, &m_linearSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateSampler (linear) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+
+			// Nearest clamp : depth (lecture plain, pas de compare).
+			si.magFilter = VK_FILTER_NEAREST;
+			si.minFilter = VK_FILTER_NEAREST;
+			res = vkCreateSampler(device, &si, nullptr, &m_nearestSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateSampler (nearest) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 6. Pipeline layout : descriptor set 0 + push constants (112 o, fragment)
+		// -----------------------------------------------------------------
+		{
+			VkPushConstantRange pushRange{};
+			pushRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+			pushRange.offset     = 0;
+			pushRange.size       = static_cast<uint32_t>(sizeof(DofParams)); // 112 octets
+
+			VkPipelineLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			layoutInfo.setLayoutCount         = 1;
+			layoutInfo.pSetLayouts            = &m_descriptorSetLayout;
+			layoutInfo.pushConstantRangeCount = 1;
+			layoutInfo.pPushConstantRanges    = &pushRange;
+
+			VkResult res = vkCreatePipelineLayout(device, &layoutInfo, nullptr, &m_pipelineLayout);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreatePipelineLayout failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 7. Pipeline graphique : fullscreen triangle, pas de vertex input, pas de depth test
+		// -----------------------------------------------------------------
+		{
+			VkShaderModule vertMod = CreateShaderModule(device, vertSpirv, vertWordCount);
+			VkShaderModule fragMod = CreateShaderModule(device, fragSpirv, fragWordCount);
+			if (vertMod == VK_NULL_HANDLE || fragMod == VK_NULL_HANDLE)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: shader module creation failed");
+				if (vertMod) vkDestroyShaderModule(device, vertMod, nullptr);
+				if (fragMod) vkDestroyShaderModule(device, fragMod, nullptr);
+				Destroy(device);
+				return false;
+			}
+
+			VkPipelineShaderStageCreateInfo stages[2]{};
+			stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+			stages[0].module = vertMod;
+			stages[0].pName  = "main";
+			stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+			stages[1].module = fragMod;
+			stages[1].pName  = "main";
+
+			// Pas de vertex input : le triangle plein écran est généré depuis gl_VertexIndex.
+			VkPipelineVertexInputStateCreateInfo vi{};
+			vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+			VkPipelineInputAssemblyStateCreateInfo ia{};
+			ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+			ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+			VkPipelineViewportStateCreateInfo vp{};
+			vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+			vp.viewportCount = 1;
+			vp.scissorCount  = 1;
+
+			VkPipelineRasterizationStateCreateInfo rs{};
+			rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+			rs.polygonMode = VK_POLYGON_MODE_FILL;
+			rs.cullMode    = VK_CULL_MODE_NONE; // pas de culling pour le triangle plein écran
+			rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+			rs.lineWidth   = 1.0f;
+
+			VkPipelineMultisampleStateCreateInfo ms{};
+			ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+			ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+			// Pas de depth test/write pour la passe plein écran.
+			VkPipelineDepthStencilStateCreateInfo ds{};
+			ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+			ds.depthTestEnable  = VK_FALSE;
+			ds.depthWriteEnable = VK_FALSE;
+
+			VkPipelineColorBlendAttachmentState blendAtt{};
+			blendAtt.blendEnable    = VK_FALSE;
+			blendAtt.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+				| VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+			VkPipelineColorBlendStateCreateInfo cb{};
+			cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+			cb.attachmentCount = 1;
+			cb.pAttachments    = &blendAtt;
+
+			VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+			VkPipelineDynamicStateCreateInfo dyn{};
+			dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+			dyn.dynamicStateCount = 2;
+			dyn.pDynamicStates    = dynStates;
+
+			VkGraphicsPipelineCreateInfo gpInfo{};
+			gpInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+			gpInfo.stageCount          = 2;
+			gpInfo.pStages             = stages;
+			gpInfo.pVertexInputState   = &vi;
+			gpInfo.pInputAssemblyState = &ia;
+			gpInfo.pViewportState      = &vp;
+			gpInfo.pRasterizationState = &rs;
+			gpInfo.pMultisampleState   = &ms;
+			gpInfo.pDepthStencilState  = &ds;
+			gpInfo.pColorBlendState    = &cb;
+			gpInfo.pDynamicState       = &dyn;
+			gpInfo.layout              = m_pipelineLayout;
+			gpInfo.renderPass          = m_renderPass;
+			gpInfo.subpass             = 0;
+
+			AssertPipelineCreationAllowed();
+			PipelineCache::RegisterWarmupKey(HashGraphicsPsoKey(m_renderPass, 0, m_pipelineLayout, sceneColorHDRFormat, VK_FORMAT_UNDEFINED));
+			VkResult res = vkCreateGraphicsPipelines(device, pipelineCache, 1, &gpInfo, nullptr, &m_pipeline);
+			vkDestroyShaderModule(device, vertMod, nullptr);
+			vkDestroyShaderModule(device, fragMod, nullptr);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass: vkCreateGraphicsPipelines failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		LOG_INFO(Render, "DepthOfFieldPass: initialized (maxFrames={})", m_maxFrames);
+		return true;
+	}
+
+	// -------------------------------------------------------------------------
+	// DepthOfFieldPass::Record
+	// -------------------------------------------------------------------------
+
+	void DepthOfFieldPass::Record(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+		VkExtent2D extent,
+		ResourceId idColorIn, ResourceId idDepth, ResourceId idColorOut,
+		const DofParams& params, uint32_t frameIndex)
+	{
+		if (!IsValid() || extent.width == 0 || extent.height == 0)
+			return;
+
+		// Récupère les vues depuis le registry du frame graph.
+		VkImageView viewColorIn = registry.getImageView(idColorIn);
+		VkImageView viewDepth   = registry.getImageView(idDepth);
+		VkImageView viewOut     = registry.getImageView(idColorOut);
+
+		if (viewColorIn == VK_NULL_HANDLE || viewDepth == VK_NULL_HANDLE
+			|| viewOut == VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "DepthOfFieldPass::Record: missing image views, skipping");
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Met à jour le descriptor set de cette frame avec les 2 vues.
+		// ------------------------------------------------------------------
+		const uint32_t setIdx = frameIndex % m_maxFrames;
+		VkDescriptorSet ds = m_descriptorSets[setIdx];
+
+		std::array<VkDescriptorImageInfo, 2> imageInfos{};
+		imageInfos[0] = { m_linearSampler,  viewColorIn, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[1] = { m_nearestSampler, viewDepth,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+
+		std::array<VkWriteDescriptorSet, 2> writes{};
+		for (size_t i = 0; i < writes.size(); ++i)
+		{
+			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[i].dstSet          = ds;
+			writes[i].dstBinding      = static_cast<uint32_t>(i);
+			writes[i].dstArrayElement = 0;
+			writes[i].descriptorCount = 1;
+			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[i].pImageInfo      = &imageInfos[i];
+		}
+		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+
+		// ------------------------------------------------------------------
+		// Crée un framebuffer temporaire sur l'image de sortie.
+		// ------------------------------------------------------------------
+		VkFramebufferCreateInfo fbInfo{};
+		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		fbInfo.renderPass      = m_renderPass;
+		fbInfo.attachmentCount = 1;
+		fbInfo.pAttachments    = &viewOut;
+		fbInfo.width           = extent.width;
+		fbInfo.height          = extent.height;
+		fbInfo.layers          = 1;
+
+		VkFramebuffer fb = VK_NULL_HANDLE;
+		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+		if (res != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "DepthOfFieldPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Ouvre la render pass.
+		// ------------------------------------------------------------------
+		VkClearValue clearVal{};
+		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
+
+		VkRenderPassBeginInfo rpBegin{};
+		rpBegin.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+		rpBegin.renderPass      = m_renderPass;
+		rpBegin.framebuffer     = fb;
+		rpBegin.renderArea      = { { 0, 0 }, extent };
+		rpBegin.clearValueCount = 1;
+		rpBegin.pClearValues    = &clearVal;
+
+		vkCmdBeginRenderPass(cmd, &rpBegin, VK_SUBPASS_CONTENTS_INLINE);
+
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+			m_pipelineLayout, 0, 1, &ds, 0, nullptr);
+
+		VkViewport viewport{};
+		viewport.width    = static_cast<float>(extent.width);
+		viewport.height   = static_cast<float>(extent.height);
+		viewport.minDepth = 0.0f;
+		viewport.maxDepth = 1.0f;
+		vkCmdSetViewport(cmd, 0, 1, &viewport);
+		VkRect2D scissor = { { 0, 0 }, extent };
+		vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+		// Push constants : DofParams (112 octets, stage fragment).
+		vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT,
+			0, static_cast<uint32_t>(sizeof(DofParams)), &params);
+
+		// Triangle plein écran (3 sommets, pas de vertex buffer).
+		vkCmdDraw(cmd, 3, 1, 0, 0);
+
+		vkCmdEndRenderPass(cmd);
+
+		// Détruit le framebuffer temporaire immédiatement.
+		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// -------------------------------------------------------------------------
+	// DepthOfFieldPass::Destroy
+	// -------------------------------------------------------------------------
+
+	void DepthOfFieldPass::Destroy(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE)
+		{
+			LOG_INFO(Render, "[DepthOfFieldPass] Destroyed");
+			return;
+		}
+
+		if (m_pipeline != VK_NULL_HANDLE)
+		{
+			vkDestroyPipeline(device, m_pipeline, nullptr);
+			m_pipeline = VK_NULL_HANDLE;
+		}
+		if (m_pipelineLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+			m_pipelineLayout = VK_NULL_HANDLE;
+		}
+		if (m_nearestSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_nearestSampler, nullptr);
+			m_nearestSampler = VK_NULL_HANDLE;
+		}
+		if (m_linearSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_linearSampler, nullptr);
+			m_linearSampler = VK_NULL_HANDLE;
+		}
+		// Les descriptor sets sont libérés implicitement à la destruction du pool.
+		m_descriptorSets.clear();
+		if (m_descriptorPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
+			m_descriptorPool = VK_NULL_HANDLE;
+		}
+		if (m_descriptorSetLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorSetLayout(device, m_descriptorSetLayout, nullptr);
+			m_descriptorSetLayout = VK_NULL_HANDLE;
+		}
+		if (m_renderPass != VK_NULL_HANDLE)
+		{
+			vkDestroyRenderPass(device, m_renderPass, nullptr);
+			m_renderPass = VK_NULL_HANDLE;
+		}
+		LOG_INFO(Render, "[DepthOfFieldPass] Destroyed");
+	}
+
+} // namespace engine::render

--- a/src/client/render/DepthOfFieldPass.h
+++ b/src/client/render/DepthOfFieldPass.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "src/client/render/FrameGraph.h"
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine::render
+{
+	/// Passe GRAPHIQUE plein écran de profondeur de champ / bokeh (M45.3 — v1).
+	///
+	/// S'exécute sur l'image HDR APRÈS bloom et AVANT tonemap (sur HDR, pour des
+	/// highlights bokeh propres). Pour CHAQUE pixel on calcule un Circle of Confusion
+	/// (CoC) depuis la distance monde reconstruite (depth + invViewProj), puis on fait
+	/// un flou en disque pondéré par le CoC (16 samples fixes). Un sample n'est mélangé
+	/// que si son PROPRE CoC le place dans le flou (anti-bleeding à travers une arête
+	/// nette de premier plan). PAS de passe compute, PAS de pré-pass CoC séparée
+	/// (v1 conservatrice, tout dans un seul fragment shader).
+	///
+	/// Structure calquée EXACTEMENT sur VolumetricFogPass : render pass 1 attachment
+	/// color (load DONT_CARE, on réécrit tout le plein écran), descriptor set 0 de N
+	/// combined image samplers, push constants fragment, pipeline fullscreen triangle
+	/// (3 sommets, pas de vertex input, pas de depth test), framebuffer temporaire
+	/// créé/détruit dans Record.
+	///
+	/// Descriptor set 0 : 2 combined image samplers
+	///   binding 0 = scene color HDR post-bloom (sampler LINÉAIRE clamp)
+	///   binding 1 = depth                       (sampler NEAREST clamp)
+	class DepthOfFieldPass
+	{
+	public:
+		/// Représentation CPU des push constants envoyées chaque frame (stage fragment).
+		/// Le layout DOIT correspondre EXACTEMENT au bloc push_constant GLSL de
+		/// dof.frag (std430 / push-constant : vec4 = 16 o, mat4 = 64 o).
+		struct DofParams
+		{
+			float invViewProj[16]; ///< Inverse view-projection, column-major (64 o) — reconstruction world pos depuis depth.
+			float cameraPos[4];    ///< xyz = position caméra ; w = distance focale (m) (16 o).
+			float dofParams[4];    ///< x = plage de netteté (m, demi-largeur ; <=0 désactive la passe = passthrough), y = rayon de flou max (px), z = échelle flou near, w = échelle flou far (16 o).
+			float texelSize[4];    ///< x = 1/width, y = 1/height, z/w = 0 (padding) (16 o).
+		};
+		static_assert(sizeof(DofParams) == 112, "DofParams must be exactly 112 bytes");
+
+		DepthOfFieldPass() = default;
+		DepthOfFieldPass(const DepthOfFieldPass&) = delete;
+		DepthOfFieldPass& operator=(const DepthOfFieldPass&) = delete;
+
+		/// Crée la render pass, le descriptor set layout, le descriptor pool, les samplers
+		/// et le pipeline graphique plein écran.
+		/// \param sceneColorHDRFormat  Format de l'image de sortie (doit être VK_FORMAT_R16G16B16A16_SFLOAT).
+		/// \param vertSpirv / vertWordCount  SPIR-V du vertex shader (fullscreen triangle réutilisé).
+		/// \param fragSpirv / fragWordCount  SPIR-V du fragment shader (dof.frag).
+		/// \param maxFrames  Nombre de frames en vol ; un descriptor set est alloué par frame.
+		/// \return false si un objet Vulkan échoue (l'appelant ne doit pas faire échouer le boot).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkFormat sceneColorHDRFormat,
+			const uint32_t* vertSpirv, size_t vertWordCount,
+			const uint32_t* fragSpirv, size_t fragWordCount,
+			uint32_t maxFrames = 2,
+			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Enregistre la passe profondeur de champ dans cmd.
+		/// Met à jour le descriptor set de la frame avec les 2 vues (scene color, depth),
+		/// crée un framebuffer temporaire sur idColorOut, ouvre la render pass, push les
+		/// DofParams, dessine le triangle plein écran, ferme la render pass et détruit le
+		/// framebuffer immédiatement.
+		/// \param idColorIn   SceneColor HDR post-bloom (lu en entrée, sampler linéaire).
+		/// \param idDepth     Depth scene (D32_SFLOAT, sampler nearest).
+		/// \param idColorOut  Cible de sortie (SceneColor HDR floutée).
+		/// \param frameIndex  Index de frame en vol (0 .. maxFrames-1).
+		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
+			ResourceId idColorIn, ResourceId idDepth, ResourceId idColorOut,
+			const DofParams& params, uint32_t frameIndex);
+
+		/// Libère toutes les ressources Vulkan. Sûr à appeler même si non initialisé.
+		void Destroy(VkDevice device);
+
+		/// Renvoie true si le pipeline et la render pass sont valides.
+		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
+
+	private:
+		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
+		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
+		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
+		VkPipelineLayout      m_pipelineLayout      = VK_NULL_HANDLE;
+		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
+		VkSampler             m_linearSampler       = VK_NULL_HANDLE; ///< Linéaire clamp, pour la scene color HDR.
+		VkSampler             m_nearestSampler      = VK_NULL_HANDLE; ///< Nearest clamp, pour depth.
+
+		std::vector<VkDescriptorSet> m_descriptorSets; ///< Un par frame en vol.
+		uint32_t m_maxFrames = 2;
+	};
+
+} // namespace engine::render


### PR DESCRIPTION
## M45.3 — Depth of field / bokeh (cluster M45)

> ⚠️ **PR stackée sur #789 (M45.2)** — base `feat/m45.2-volumetric-fog`. Merger #788 puis #789 d'abord.

### Ce que ça fait
Passe plein écran sur l'image **HDR après bloom, avant tonemap** (pour des highlights bokeh propres). CoC par pixel calculé depuis la distance monde (reconstruite via `invVP`), flou en disque 16 samples **pondéré par le CoC propre de chaque sample** → pas de bleeding du fond flou sur un avant-plan net.

### Intégration (additif, gated, non-régressif)
- `DepthOfFieldPass.{h,cpp}` : calquée sur `VolumetricFogPass`, 2 samplers (color/depth), push constants `DofParams` (112 o, `static_assert`).
- `dof.frag` : gating `focus_range<=0` → passthrough ; CoC signé near/far ; ciel = flou far max.
- `DeferredPipeline` : possède la passe, init via `loadSpirv` (réutilise `lighting.vert`), n'échoue jamais le boot.
- `Engine` : ressource FG `SceneColor_HDR_Dof` ; passe `DepthOfField` si init OK, sinon passthrough `vkCmdCopyImage` ; `Tonemap` repointé `WithBloom → Dof`. `AutoExposure` reste sur `WithBloom` (expo sur image nette, voulu).
- `config.json` : bloc `world.dof` (**`focus_range_m=0` par défaut → désactivé**).
- `CMakeLists.txt` : `DepthOfFieldPass.cpp`.

### Correctif inclus (M45.2 follow-up)
`VolumetricFogPass` n'était pas détruit dans `DeferredPipeline::Destroy` (fuite Vulkan au shutdown) → ajout des `Destroy` fog + dof. Fuite shutdown-only ; corrigée ici.

### Gating / non-régression
Défaut désactivé → passthrough shader, rendu identique. Init échouée → passe passthrough. Pas de double writer (`Dof` neuf ; `WithBloom` écrit par `Bloom_Combine` uniquement). Pas d'interaction TAA (DoF sur HDR avant tonemap, TAA résout après).

### Shaders
Source GLSL seule ; la CI Windows régénère le `.spv`.

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)