### PR TITLE
feat(render): M45.5 — rendu runtime des impostors végétation (gated, défaut off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,8 @@ add_library(engine_core
   src/client/render/LightingPass.cpp
   src/client/render/VolumetricFogPass.cpp
   src/client/render/DepthOfFieldPass.cpp
+  src/client/render/ImpostorPass.cpp
+  src/client/render/ImpostorAsset.cpp
   src/client/render/TonemapPass.cpp
   src/client/render/BloomPass.cpp
   src/client/render/AutoExposure.cpp

--- a/config.json
+++ b/config.json
@@ -146,6 +146,12 @@
         "props": {
             "cull_distance_m": 80.0
         },
+        "_comment_impostor": "M45.5 — Impostors vegetation (billboards octaedriques) au LOIN, a la place des meshes de decor, eclaires via le GBuffer deferred. DESACTIVE par defaut (enabled=false) : aucun changement de rendu tant que non active. Necessite des atlas .mipo (generes par tools/impostor_builder) places A COTE de chaque mesh (meme nom, extension .mipo). distance_m : distance (m) au-dela de laquelle un prop de DECOR (non interactible) est rendu en impostor au lieu de son mesh, jusqu'a world.props.cull_distance_m ou il disparait. fade_band_m : largeur (m) de la bande de fondu (dither anti-popping) juste apres distance_m. Lu a chaque frame -> reglage a chaud.",
+        "impostor": {
+            "enabled": false,
+            "distance_m": 60.0,
+            "fade_band_m": 10.0
+        },
         "_comment_fog": "M45.1 Perspective aerienne a distance. start_m : rayon CLAIR autour du joueur (aucun brouillard en deca) ; end_m : distance de fondu COMPLET vers la teinte atmospherique (garantit le masquage de la coupe de distance des props). density : extinction exponentielle (1/m), <= 0 desactive l'effet ; inscatter : force du halo chaud directionnel quand on regarde le soleil. start/end : desactive si end_m <= start_m. density/inscatter : override des valeurs per-zone (atmosphere.json : aerial.density / aerial.inscatter) ; retirer ces cles ici pour piloter par zone. Lu a chaque frame -> reglage a chaud.",
         "fog": {
             "start_m": 35.0,

--- a/game/data/shaders/impostor.frag
+++ b/game/data/shaders/impostor.frag
@@ -1,0 +1,104 @@
+// game/data/shaders/impostor.frag (M45.5 — impostors végétation runtime)
+//
+// Décode la direction caméra->instance en coords octaédriques (INVERSE de
+// OctaToDir de tools/impostor_builder/OctahedralMap.h) pour choisir la tile
+// (i,j), échantillonne albedo + normal dans la tile, applique l'alpha-test de
+// silhouette + un dither fade anti-popping, puis écrit les 4 sorties GBuffer
+// (ordre/format IDENTIQUE à gbuffer_geometry.frag).
+//
+// Sorties GBuffer (cf. gbuffer_geometry.frag) :
+//   location 0 (GBufferA, sRGB)            : albedo (rgb, a=1)
+//   location 1 (GBufferB, A2B10G10R10)     : normale monde encodée n*0.5+0.5
+//   location 2 (GBufferC, RGBA8)           : ORM (R=AO, G=Roughness, B=Metallic)
+//   location 3 (GBufferVelocity, R16G16F)  : velocity (0 en v1)
+#version 450
+
+layout(location = 0) in vec2 vUv;       // UV du quad billboard [0,1]²
+layout(location = 1) in vec3 vViewDir;   // direction monde instance -> caméra (unitaire)
+
+layout(set = 0, binding = 0) uniform sampler2D uAlbedo; // atlas albedo (sRGB)
+layout(set = 0, binding = 1) uniform sampler2D uNormal;  // atlas normal (UNORM, a=masque)
+
+layout(push_constant) uniform PushConstants {
+    mat4 viewProj;
+    mat4 prevViewProj;
+    vec4 cameraPos;
+    vec4 atlasParams;   // x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=0
+    vec4 instancePos;
+} pc;
+
+layout(location = 0) out vec4 outAlbedo;   // GBufferA
+layout(location = 1) out vec4 outNormal;   // GBufferB
+layout(location = 2) out vec4 outORM;      // GBufferC
+layout(location = 3) out vec4 outVelocity; // GBufferVelocity
+
+// Encode une direction unitaire en coords octaédriques (u,v) ∈ [0,1]².
+// INVERSE EXACT de OctaToDir (Cigolle 2014, octahedron complet) :
+//   p = dir.xy / (|x|+|y|+|z|)
+//   si z < 0 : p = (1 - |p.yx|) * sign(p.xy)
+//   uv = p * 0.5 + 0.5
+vec2 DirToOcta(vec3 dir)
+{
+    vec3 n = dir / (abs(dir.x) + abs(dir.y) + abs(dir.z));
+    vec2 p = n.xy;
+    if (n.z < 0.0)
+    {
+        p = (1.0 - abs(vec2(n.y, n.x))) * vec2(n.x >= 0.0 ? 1.0 : -1.0,
+                                               n.y >= 0.0 ? 1.0 : -1.0);
+    }
+    return p * 0.5 + 0.5;
+}
+
+// Matrice de Bayer 4x4 (seuils [0,1)) pour le dither fade stable, compatible TAA.
+float Bayer4x4(ivec2 p)
+{
+    const float m[16] = float[16](
+        0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+        12.0/16.0, 4.0/16.0, 14.0/16.0,  6.0/16.0,
+        3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+        15.0/16.0, 7.0/16.0, 13.0/16.0,  5.0/16.0
+    );
+    int idx = (p.y & 3) * 4 + (p.x & 3);
+    return m[idx];
+}
+
+void main()
+{
+    float viewsPerAxis = pc.atlasParams.x;
+    float fadeAlpha    = pc.atlasParams.z;
+
+    // 1) Dither fade anti-popping : discard pseudo-aléatoire stable sur l'écran.
+    if (fadeAlpha < 1.0)
+    {
+        float threshold = Bayer4x4(ivec2(gl_FragCoord.xy));
+        if (fadeAlpha < threshold)
+            discard;
+    }
+
+    // 2) Choix de la tile (i,j) depuis la direction de vue.
+    vec2 octUv = DirToOcta(normalize(vViewDir));
+    // (i,j) = floor(octUv * N), clampé à [0, N-1].
+    vec2 tileF = floor(octUv * viewsPerAxis);
+    tileF = clamp(tileF, vec2(0.0), vec2(viewsPerAxis - 1.0));
+
+    // 3) UV dans l'atlas : origine de la tile + UV du quad ramenée à la tile.
+    //    L'atlas est une grille N×N ; chaque tile occupe 1/N de l'atlas.
+    //    quadUv [0,1] -> sous-région [tile/N, (tile+1)/N].
+    vec2 atlasUv = (tileF + clamp(vUv, vec2(0.0), vec2(1.0))) / viewsPerAxis;
+
+    vec4 albedo = texture(uAlbedo, atlasUv);
+    vec4 normalSample = texture(uNormal, atlasUv); // .rgb = n*0.5+0.5, .a = masque silhouette
+
+    // 4) Alpha-test de silhouette (masque de couverture M45.4 stocké en normal.a).
+    if (normalSample.a < 0.5)
+        discard;
+
+    // 5) Écriture GBuffer.
+    outAlbedo = vec4(albedo.rgb, 1.0);
+    // L'atlas stocke déjà la normale encodée n*0.5+0.5 -> on la réécrit telle quelle.
+    outNormal = vec4(normalSample.rgb, 1.0);
+    // ORM : AO=1, Roughness=1 (feuillage mat), Metallic=0.
+    outORM = vec4(1.0, 1.0, 0.0, 1.0);
+    // Velocity nulle en v1 (impostors statiques ; pas de reprojection dédiée).
+    outVelocity = vec4(0.0, 0.0, 0.0, 1.0);
+}

--- a/game/data/shaders/impostor.vert
+++ b/game/data/shaders/impostor.vert
@@ -1,0 +1,60 @@
+// game/data/shaders/impostor.vert (M45.5 — impostors végétation runtime)
+//
+// Génère un quad camera-facing (billboard) de 2 triangles (6 sommets via
+// gl_VertexIndex) centré sur instancePos.xyz, de demi-taille instancePos.w
+// (radius), aligné sur les axes right/up dérivés de la matrice viewProj.
+//
+// Sorties :
+//   - position clip = viewProj * coin monde du quad ;
+//   - vUv  : UV du quad dans [0,1]² ;
+//   - vViewDir : direction monde INSTANCE -> CAMÉRA (unitaire), décodée en
+//                coords octaédriques dans le fragment (cf. impostor.frag).
+#version 450
+
+// Push constants : cf. ImpostorPushConstants (ImpostorPass.h), 176 octets.
+layout(push_constant) uniform PushConstants {
+    mat4 viewProj;      // 64
+    mat4 prevViewProj;  // 64 (réservé velocity, non utilisé ici)
+    vec4 cameraPos;     // 16 (xyz)
+    vec4 atlasParams;   // 16 (x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=0)
+    vec4 instancePos;   // 16 (xyz centre monde, w=radius)
+} pc;
+
+layout(location = 0) out vec2 vUv;
+layout(location = 1) out vec3 vViewDir;
+
+void main()
+{
+    // Quad unitaire [-0.5,0.5]² en 2 triangles (6 sommets). offsets : coin local.
+    // Triangle 1 : (0,0)(1,0)(1,1) ; Triangle 2 : (0,0)(1,1)(0,1) (UV [0,1]²).
+    vec2 quadUv[6] = vec2[6](
+        vec2(0.0, 0.0), vec2(1.0, 0.0), vec2(1.0, 1.0),
+        vec2(0.0, 0.0), vec2(1.0, 1.0), vec2(0.0, 1.0)
+    );
+    vec2 uv = quadUv[gl_VertexIndex];
+    vUv = uv;
+    // Offset centré : [-0.5, 0.5].
+    vec2 corner = uv - vec2(0.5);
+
+    vec3 center = pc.instancePos.xyz;
+    float radius = pc.instancePos.w;
+
+    // Axes caméra (right/up) monde extraits de viewProj. La Mat4 moteur est
+    // column-major (cf. Math.h) : GLSL charge donc le buffer directement, et
+    // viewProj[col] est une COLONNE. Le vecteur "right" monde de la caméra est
+    // la LIGNE 0 de viewProj (axe X de l'espace vue), soit
+    // vec3(viewProj[0].x, viewProj[1].x, viewProj[2].x) ; "up" = LIGNE 1.
+    // On normalise pour éliminer la mise à l'échelle de la projection.
+    vec3 camRight = normalize(vec3(pc.viewProj[0].x, pc.viewProj[1].x, pc.viewProj[2].x));
+    vec3 camUp    = normalize(vec3(pc.viewProj[0].y, pc.viewProj[1].y, pc.viewProj[2].y));
+
+    // Position monde du coin du billboard.
+    vec3 worldPos = center
+        + camRight * (corner.x * 2.0 * radius)
+        + camUp    * (corner.y * 2.0 * radius);
+
+    // Direction instance -> caméra (mesh -> caméra), pour le décodage octaédrique.
+    vViewDir = normalize(pc.cameraPos.xyz - center);
+
+    gl_Position = pc.viewProj * vec4(worldPos, 1.0);
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4889,6 +4889,11 @@ namespace engine
 											// du coffre (m_chestLoaded). Si le chargement skinne echoue, le coffre
 											// retombe sur le rendu statique (pas de disparition).
 											LoadAnimatedChest();
+											// M45.5 — flag global impostors végétation (défaut OFF). Lu une fois ici ;
+											// quand false, RecordPropsGeometry s'exécute exactement comme l'historique.
+											m_impostorEnabled = m_cfg.GetBool("world.impostor.enabled", false);
+											if (m_impostorEnabled)
+												LOG_INFO(Render, "[Impostor] M45.5 activé (world.impostor.enabled=true)");
 											// Chantier B : charge les meshes statiques des props (coffre si non anime + interactibles).
 											LoadInteractableProps();
 											// Décor solide (arbres, props nature) depuis world.scenery. Doit suivre
@@ -10361,6 +10366,18 @@ namespace engine
 		}
 		prop.modelMatrix = engine::math::Mat4::Identity();  // sommets deja en espace monde
 
+		// M45.5 — sphère englobante monde du prop (centre du billboard impostor +
+		// rayon = demi-taille). Le centre XZ est (wx,wz) ; en Y, milieu entre le
+		// sol (groundY) et le sommet (topY). Le rayon couvre largeur (radiusAuto)
+		// ET hauteur (demi-hauteur), pour un quad qui englobe tout le mesh.
+		prop.meshPath = meshPath;
+		{
+			const float halfHeight = 0.5f * (topY - groundY);
+			prop.impostorCenter = engine::math::Vec3{ wx, groundY + halfHeight, wz };
+			prop.impostorRadius = std::max(radiusAuto, halfHeight);
+			if (prop.impostorRadius < 0.05f) prop.impostorRadius = 0.5f;
+		}
+
 		for (const auto& kv : idxByMat)
 		{
 			const std::string& matName = kv.first;
@@ -10444,6 +10461,36 @@ namespace engine
 		}
 	}
 
+	bool Engine::EnsureImpostorAtlas(const std::string& meshPath)
+	{
+		if (!m_impostorEnabled || meshPath.empty()) return false;
+		auto it = m_impostorAtlases.find(meshPath);
+		if (it != m_impostorAtlases.end())
+			return it->second.IsValid();
+
+		// Chemin de l'atlas : à côté du .gltf, même nom, extension `.mipo`.
+		// Ex. meshes/props/DeadTree_2.gltf -> <content>/meshes/props/DeadTree_2.mipo.
+		const std::string contentRoot = m_cfg.GetString("paths.content", "game/data");
+		std::string base = meshPath;
+		const auto dot = base.find_last_of('.');
+		if (dot != std::string::npos) base = base.substr(0, dot);
+		const std::string mipoPath = contentRoot + "/" + base + ".mipo";
+
+		engine::render::ImpostorAsset asset;
+		std::string err;
+		const bool ok = asset.LoadFromFile(mipoPath, m_assetRegistry, err);
+		if (!ok)
+		{
+			// Absence d'atlas = cas normal (tous les meshes n'en ont pas) -> Debug, pas Warn.
+			LOG_DEBUG(Render, "[Impostor] pas d'atlas pour '{}' ({})", meshPath, err);
+		}
+		// On insère même un asset invalide pour mémoriser l'échec (évite de retenter
+		// le chargement disque à chaque frame/prop partageant ce mesh).
+		auto [insIt, inserted] = m_impostorAtlases.emplace(meshPath, std::move(asset));
+		(void)inserted;
+		return insIt->second.IsValid();
+	}
+
 	void Engine::RecordPropsGeometry(VkCommandBuffer cmd, engine::render::Registry& reg,
 	                                 const engine::RenderState& rs)
 	{
@@ -10463,16 +10510,51 @@ namespace engine
 		const float cullDist = static_cast<float>(m_cfg.GetDouble("world.props.cull_distance_m", 80.0));
 		const float cullDist2 = cullDist * cullDist;
 		const bool cullEnabled = cullDist > 0.0f;
-		int drawn = 0, culled = 0;
+
+		// M45.5 — bascule mesh -> impostor. GATED world.impostor.enabled : par défaut
+		// false => `impostorActive` reste false et le chemin ci-dessous est STRICTEMENT
+		// l'historique (aucun changement de rendu). Quand actif : un prop de DÉCOR
+		// (interactableIndex<0) dont la distance XZ ∈ [impostorDist, cullDist] ET qui a
+		// un atlas chargé est rendu en impostor au lieu de son mesh ; en deçà
+		// d'impostorDist, mesh normal (inchangé).
+		const bool impostorPassValid = m_pipeline->GetImpostorPass().IsValid();
+		const bool impostorActive = m_impostorEnabled && impostorPassValid;
+		const float impostorDist = impostorActive
+			? static_cast<float>(m_cfg.GetDouble("world.impostor.distance_m", 60.0)) : 1e30f;
+		const float impostorDist2 = impostorDist * impostorDist;
+		// Instances d'impostors accumulées, groupées par chemin de mesh (= clé atlas).
+		std::unordered_map<std::string, std::vector<engine::render::ImpostorInstance>> impostorBatches;
+
+		int drawn = 0, culled = 0, impostored = 0;
 		for (const auto& prop : m_props)
 		{
+			const float dxp = prop.worldPos.x - camPos.x;
+			const float dzp = prop.worldPos.z - camPos.z;
+			const float dist2 = dxp * dxp + dzp * dzp;
+
 			if (cullEnabled && prop.interactableIndex < 0)
 			{
-				const float dxp = prop.worldPos.x - camPos.x;
-				const float dzp = prop.worldPos.z - camPos.z;
-				if (dxp * dxp + dzp * dzp > cullDist2)
+				if (dist2 > cullDist2)
 					{ ++culled; continue; }  // decor trop loin -> non dessine
 			}
+
+			// Bascule impostor (décor uniquement, distance >= seuil, atlas dispo).
+			if (impostorActive && prop.interactableIndex < 0 && dist2 >= impostorDist2)
+			{
+				if (EnsureImpostorAtlas(prop.meshPath))
+				{
+					engine::render::ImpostorInstance inst;
+					inst.worldPos[0] = prop.impostorCenter.x;
+					inst.worldPos[1] = prop.impostorCenter.y;
+					inst.worldPos[2] = prop.impostorCenter.z;
+					inst.radius      = prop.impostorRadius;
+					impostorBatches[prop.meshPath].push_back(inst);
+					++impostored;
+					continue; // NE PAS dessiner le mesh : l'impostor le remplace.
+				}
+				// Pas d'atlas pour ce mesh -> fallback mesh normal (continue plus bas).
+			}
+
 			++drawn;
 			// Surbrillance (chantier C) : si ce prop est l'interactible a portee, on
 			// dessine ses parties avec la variante de materiau Highlight (teinte).
@@ -10493,10 +10575,46 @@ namespace engine
 					true);
 			}
 		}
+
+		// M45.5 — dessine les impostors accumulés DANS le GBuffer, via le render pass
+		// loadOp=LOAD de la GeometryPass (RecordTerrainChunkBatch ouvre exactement ce
+		// render pass + framebuffer + viewport/scissor). Un RecordInstances par atlas
+		// distinct (le descriptor de l'ImpostorPass est réécrit à chaque appel).
+		if (impostorActive && !impostorBatches.empty())
+		{
+			auto& impostorPass = m_pipeline->GetImpostorPass();
+			geom.RecordTerrainChunkBatch(
+				m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(),
+				m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId, m_fgGBufferVelocityId, m_fgDepthId,
+				[this, &impostorPass, &impostorBatches, &rs](VkCommandBuffer innerCmd) {
+					const float camPos3[3] = {
+						rs.camera.position.x, rs.camera.position.y, rs.camera.position.z };
+					for (auto& kv : impostorBatches)
+					{
+						auto atlasIt = m_impostorAtlases.find(kv.first);
+						if (atlasIt == m_impostorAtlases.end() || !atlasIt->second.IsValid())
+							continue;
+						const engine::render::ImpostorAsset& atlas = atlasIt->second;
+						engine::render::TextureAsset* albedo = atlas.Albedo().Get();
+						engine::render::TextureAsset* normal = atlas.Normal().Get();
+						if (albedo == nullptr || normal == nullptr
+							|| albedo->view == VK_NULL_HANDLE || normal->view == VK_NULL_HANDLE)
+							continue;
+						const VkSampler samp = impostorPass.GetSampler();
+						impostorPass.RecordInstances(
+							m_vkDeviceContext.GetDevice(), innerCmd, m_vkSwapchain.GetExtent(),
+							kv.second.data(), static_cast<uint32_t>(kv.second.size()),
+							albedo->view, samp, normal->view, samp,
+							rs.viewProjMatrix.m, rs.prevViewProjMatrix.m, camPos3,
+							atlas.Info().viewsPerAxis, atlas.Info().tileSize);
+					}
+				});
+		}
+
 		// Diag throttle (1/60 frames) : visible uniquement en log.level=Debug.
 		if ((m_currentFrame % 60) == 0)
-			LOG_DEBUG(Render, "[Props] cull_dist={:.0f}m dessines={} coupes={} (total={})",
-			          cullDist, drawn, culled, static_cast<int>(m_props.size()));
+			LOG_DEBUG(Render, "[Props] cull_dist={:.0f}m dessines={} impostors={} coupes={} (total={})",
+			          cullDist, drawn, impostored, culled, static_cast<int>(m_props.size()));
 	}
 
 	void Engine::RecordRemoteAvatars(VkCommandBuffer cmd, engine::render::Registry& reg,

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -33,6 +33,7 @@
 #include "src/shared/platform/Input.h"
 #include "src/shared/platform/Window.h"
 #include "src/client/render/AssetRegistry.h"
+#include "src/client/render/ImpostorAsset.h"
 #include "src/client/render/DecalSystem.h"
 #include "src/client/render/FrameGraph.h"
 #include "src/client/render/vk/VkDeviceContext.h"
@@ -754,10 +755,34 @@ namespace engine
 			/// Position monde (base) du prop, pour le culling de distance dans
 			/// RecordPropsGeometry (sommets cuits en monde, modelMatrix=identité).
 			engine::math::Vec3 worldPos{ 0.0f, 0.0f, 0.0f };
+			/// M45.5 — chemin du mesh source (relatif à paths.content), clé du cache
+			/// d'atlas d'impostors `m_impostorAtlases`. Vide pour les interactibles.
+			std::string meshPath;
+			/// M45.5 — centre monde de la sphère englobante du prop (= centre du
+			/// billboard impostor). Calculé au build depuis les sommets cuits.
+			engine::math::Vec3 impostorCenter{ 0.0f, 0.0f, 0.0f };
+			/// M45.5 — rayon (m) de la sphère englobante (demi-taille du billboard).
+			float impostorRadius = 0.0f;
 		};
 		/// Props statiques rendus (chantier B), construits au boot depuis les
 		/// interactibles ayant un meshPath. Cf. LoadInteractableProps / RecordPropsGeometry.
 		std::vector<PropRenderable> m_props;
+
+		/// M45.5 — atlas d'impostors par chemin de mesh (clé = PropRenderable::meshPath).
+		/// Peuplé à la demande dans BuildPropFromMesh quand world.impostor.enabled :
+		/// pour chaque mesh de DÉCOR, tente de charger `<même nom>.mipo` à côté du
+		/// .gltf. Absent => le prop n'aura pas d'impostor (fallback mesh). Les atlas
+		/// (textures GPU) appartiennent à m_assetRegistry.
+		std::unordered_map<std::string, engine::render::ImpostorAsset> m_impostorAtlases;
+		/// M45.5 — flag global impostors (lu depuis world.impostor.enabled au boot).
+		/// false par défaut => AUCUN code impostor ne s'exécute (rendu inchangé).
+		bool m_impostorEnabled = false;
+
+		/// M45.5 — tente de charger l'atlas `.mipo` associé à `meshPath` (à côté du
+		/// .gltf, même nom + extension `.mipo`) dans `m_impostorAtlases` s'il n'y est
+		/// pas déjà. No-op si !m_impostorEnabled. \return true si un atlas valide est
+		/// disponible pour ce mesh après l'appel.
+		bool EnsureImpostorAtlas(const std::string& meshPath);
 
 		/// Élément de décor solide non interactif (arbres, props nature) chargé depuis
 		/// world.scenery. Rendu comme un prop ; ne participe pas à l'interaction (touche E).

--- a/src/client/render/AssetRegistry.cpp
+++ b/src/client/render/AssetRegistry.cpp
@@ -612,6 +612,109 @@ namespace engine::render
 		return id;
 	}
 
+	AssetId AssetRegistry::createSampledRgba8Texture(uint32_t width, uint32_t height,
+		VkFormat format, const uint8_t* pixels)
+	{
+		if (m_device == VK_NULL_HANDLE || width == 0u || height == 0u || pixels == nullptr)
+			return kInvalidAssetId;
+
+		TextureAsset asset{};
+		asset.width = width;
+		asset.height = height;
+		VkImageCreateInfo imgInfo{};
+		imgInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imgInfo.imageType = VK_IMAGE_TYPE_2D;
+		imgInfo.format = format;
+		imgInfo.extent = { width, height, 1 };
+		imgInfo.mipLevels = 1;
+		imgInfo.arrayLayers = 1;
+		imgInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imgInfo.tiling = VK_IMAGE_TILING_LINEAR;
+		imgInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+		imgInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+		imgInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+		if (vkCreateImage(m_device, &imgInfo, nullptr, &asset.image) != VK_SUCCESS || asset.image == VK_NULL_HANDLE)
+			return kInvalidAssetId;
+
+		VkMemoryRequirements memReq{};
+		vkGetImageMemoryRequirements(m_device, asset.image, &memReq);
+		uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+		if (memTypeIdx == UINT32_MAX)
+		{
+			vkDestroyImage(m_device, asset.image, nullptr);
+			return kInvalidAssetId;
+		}
+
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memReq.size;
+		allocInfo.memoryTypeIndex = memTypeIdx;
+		VkDeviceMemory imgMem = VK_NULL_HANDLE;
+		if (vkAllocateMemory(m_device, &allocInfo, nullptr, &imgMem) != VK_SUCCESS || imgMem == VK_NULL_HANDLE)
+		{
+			vkDestroyImage(m_device, asset.image, nullptr);
+			return kInvalidAssetId;
+		}
+		if (vkBindImageMemory(m_device, asset.image, imgMem, 0) != VK_SUCCESS)
+		{
+			vkFreeMemory(m_device, imgMem, nullptr);
+			vkDestroyImage(m_device, asset.image, nullptr);
+			return kInvalidAssetId;
+		}
+		asset.allocation = reinterpret_cast<void*>(imgMem);
+
+		void* ptr = nullptr;
+		if (vkMapMemory(m_device, imgMem, 0, memReq.size, 0, &ptr) == VK_SUCCESS)
+		{
+			VkImageSubresource subres{};
+			subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			subres.mipLevel = 0;
+			subres.arrayLayer = 0;
+			VkSubresourceLayout layout{};
+			vkGetImageSubresourceLayout(m_device, asset.image, &subres, &layout);
+			uint8_t* dst = static_cast<uint8_t*>(ptr);
+			for (uint32_t y = 0; y < height; ++y)
+				memcpy(dst + y * layout.rowPitch, pixels + static_cast<size_t>(y) * width * 4, static_cast<size_t>(width) * 4);
+			vkUnmapMemory(m_device, imgMem);
+		}
+
+		VkImageViewCreateInfo viewInfo{};
+		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewInfo.image = asset.image;
+		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewInfo.format = format;
+		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		viewInfo.subresourceRange.baseMipLevel = 0;
+		viewInfo.subresourceRange.levelCount = 1;
+		viewInfo.subresourceRange.baseArrayLayer = 0;
+		viewInfo.subresourceRange.layerCount = 1;
+		if (vkCreateImageView(m_device, &viewInfo, nullptr, &asset.view) != VK_SUCCESS)
+		{
+			vkDestroyImage(m_device, asset.image, nullptr);
+			vkFreeMemory(m_device, imgMem, nullptr);
+			return kInvalidAssetId;
+		}
+
+		AssetId id = m_nextTextureId++;
+		m_textures[id] = std::move(asset);
+		return id;
+	}
+
+	TextureHandle AssetRegistry::CreateTextureFromMemory(const uint8_t* rgba, uint32_t width,
+		uint32_t height, bool useSrgb)
+	{
+		const VkFormat format = useSrgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
+		const AssetId id = createSampledRgba8Texture(width, height, format, rgba);
+		if (id != kInvalidAssetId)
+			LOG_INFO(Render, "[AssetRegistry] CreateTextureFromMemory OK ({}x{}, {})",
+				width, height, useSrgb ? "sRGB" : "linear");
+		else
+			LOG_ERROR(Render, "[AssetRegistry] CreateTextureFromMemory failed ({}x{})", width, height);
+		return TextureHandle(this, id);
+	}
+
 	namespace
 	{
 		bool IsPngFile(const uint8_t* data, size_t size)
@@ -829,87 +932,12 @@ namespace engine::render
 				return id;
 			}
 
-			const uint8_t* pixels = owned.data();
-
-			TextureAsset asset{};
-			asset.width = width;
-			asset.height = height;
-			VkImageCreateInfo imgInfo{};
-			imgInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-			imgInfo.imageType = VK_IMAGE_TYPE_2D;
-			imgInfo.format = format;
-			imgInfo.extent = { width, height, 1 };
-			imgInfo.mipLevels = 1;
-			imgInfo.arrayLayers = 1;
-			imgInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-			imgInfo.tiling = VK_IMAGE_TILING_LINEAR;
-			imgInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-			imgInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-			imgInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-			if (vkCreateImage(m_device, &imgInfo, nullptr, &asset.image) != VK_SUCCESS || asset.image == VK_NULL_HANDLE)
+			// Chemin factorisé (M45.5) : création image LINEAR host-visible + view + upload
+			// ligne par ligne. Identique au code précédent, désormais partagé avec
+			// CreateTextureFromMemory via createSampledRgba8Texture.
+			const AssetId id = createSampledRgba8Texture(width, height, format, owned.data());
+			if (id == kInvalidAssetId)
 				return kInvalidAssetId;
-
-			VkMemoryRequirements memReq{};
-			vkGetImageMemoryRequirements(m_device, asset.image, &memReq);
-			uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-			if (memTypeIdx == UINT32_MAX)
-			{
-				vkDestroyImage(m_device, asset.image, nullptr);
-				return kInvalidAssetId;
-			}
-
-			VkMemoryAllocateInfo allocInfo{};
-			allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-			allocInfo.allocationSize = memReq.size;
-			allocInfo.memoryTypeIndex = memTypeIdx;
-			VkDeviceMemory imgMem = VK_NULL_HANDLE;
-			if (vkAllocateMemory(m_device, &allocInfo, nullptr, &imgMem) != VK_SUCCESS || imgMem == VK_NULL_HANDLE)
-			{
-				vkDestroyImage(m_device, asset.image, nullptr);
-				return kInvalidAssetId;
-			}
-			if (vkBindImageMemory(m_device, asset.image, imgMem, 0) != VK_SUCCESS)
-			{
-				vkFreeMemory(m_device, imgMem, nullptr);
-				vkDestroyImage(m_device, asset.image, nullptr);
-				return kInvalidAssetId;
-			}
-			asset.allocation = reinterpret_cast<void*>(imgMem);
-
-			void* ptr = nullptr;
-			if (vkMapMemory(m_device, imgMem, 0, memReq.size, 0, &ptr) == VK_SUCCESS)
-			{
-				VkImageSubresource subres{};
-				subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-				subres.mipLevel = 0;
-				subres.arrayLayer = 0;
-				VkSubresourceLayout layout{};
-				vkGetImageSubresourceLayout(m_device, asset.image, &subres, &layout);
-				uint8_t* dst = static_cast<uint8_t*>(ptr);
-				for (uint32_t y = 0; y < height; ++y)
-					memcpy(dst + y * layout.rowPitch, pixels + y * width * 4, width * 4);
-				vkUnmapMemory(m_device, imgMem);
-			}
-			VkImageViewCreateInfo viewInfo{};
-			viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-			viewInfo.image = asset.image;
-			viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-			viewInfo.format = format;
-			viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			viewInfo.subresourceRange.baseMipLevel = 0;
-			viewInfo.subresourceRange.levelCount = 1;
-			viewInfo.subresourceRange.baseArrayLayer = 0;
-			viewInfo.subresourceRange.layerCount = 1;
-			if (vkCreateImageView(m_device, &viewInfo, nullptr, &asset.view) != VK_SUCCESS)
-			{
-				vkDestroyImage(m_device, asset.image, nullptr);
-				vkFreeMemory(m_device, imgMem, nullptr);
-				return kInvalidAssetId;
-			}
-			AssetId id = m_nextTextureId++;
-			m_textures[id] = std::move(asset);
 			LOG_INFO(Render, "AssetRegistry: loaded PNG texture {} ({}x{}, LINEAR)", relativePath, width, height, useSrgb ? "sRGB" : "linear");
 			return id;
 		}
@@ -937,87 +965,12 @@ namespace engine::render
 		}
 		const uint8_t* pixels = data.data() + 16;
 
-		TextureAsset asset{};
-		asset.width = width;
-		asset.height = height;
-		VkFormat format = useSrgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
-		VkImageCreateInfo imgInfo{};
-		imgInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-		imgInfo.imageType = VK_IMAGE_TYPE_2D;
-		imgInfo.format = format;
-		imgInfo.extent = { width, height, 1 };
-		imgInfo.mipLevels = 1;
-		imgInfo.arrayLayers = 1;
-		imgInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-		imgInfo.tiling = VK_IMAGE_TILING_LINEAR;
-		imgInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-		imgInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-		imgInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-		if (vkCreateImage(m_device, &imgInfo, nullptr, &asset.image) != VK_SUCCESS || asset.image == VK_NULL_HANDLE)
+		// Chemin factorisé (M45.5) : même création image LINEAR host-visible + view + upload
+		// ligne par ligne que le code précédent, désormais partagé via createSampledRgba8Texture.
+		const VkFormat format = useSrgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
+		const AssetId id = createSampledRgba8Texture(width, height, format, pixels);
+		if (id == kInvalidAssetId)
 			return kInvalidAssetId;
-
-		VkMemoryRequirements memReq{};
-		vkGetImageMemoryRequirements(m_device, asset.image, &memReq);
-		uint32_t memTypeIdx = FindMemoryType(m_physicalDevice, memReq.memoryTypeBits,
-			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-		if (memTypeIdx == UINT32_MAX)
-		{
-			vkDestroyImage(m_device, asset.image, nullptr);
-			return kInvalidAssetId;
-		}
-
-		VkMemoryAllocateInfo allocInfo{};
-		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-		allocInfo.allocationSize = memReq.size;
-		allocInfo.memoryTypeIndex = memTypeIdx;
-		VkDeviceMemory imgMem = VK_NULL_HANDLE;
-		if (vkAllocateMemory(m_device, &allocInfo, nullptr, &imgMem) != VK_SUCCESS || imgMem == VK_NULL_HANDLE)
-		{
-			vkDestroyImage(m_device, asset.image, nullptr);
-			return kInvalidAssetId;
-		}
-		if (vkBindImageMemory(m_device, asset.image, imgMem, 0) != VK_SUCCESS)
-		{
-			vkFreeMemory(m_device, imgMem, nullptr);
-			vkDestroyImage(m_device, asset.image, nullptr);
-			return kInvalidAssetId;
-		}
-		asset.allocation = reinterpret_cast<void*>(imgMem);
-
-		void* ptr = nullptr;
-		if (vkMapMemory(m_device, imgMem, 0, memReq.size, 0, &ptr) == VK_SUCCESS)
-		{
-			VkImageSubresource subres{};
-			subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subres.mipLevel = 0;
-			subres.arrayLayer = 0;
-			VkSubresourceLayout layout{};
-			vkGetImageSubresourceLayout(m_device, asset.image, &subres, &layout);
-			const uint8_t* src = pixels;
-			uint8_t* dst = static_cast<uint8_t*>(ptr);
-			for (uint32_t y = 0; y < height; ++y)
-				memcpy(dst + y * layout.rowPitch, src + y * width * 4, width * 4);
-			vkUnmapMemory(m_device, imgMem);
-		}
-		VkImageViewCreateInfo viewInfo{};
-		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-		viewInfo.image = asset.image;
-		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-		viewInfo.format = format;
-		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-		viewInfo.subresourceRange.baseMipLevel = 0;
-		viewInfo.subresourceRange.levelCount = 1;
-		viewInfo.subresourceRange.baseArrayLayer = 0;
-		viewInfo.subresourceRange.layerCount = 1;
-		if (vkCreateImageView(m_device, &viewInfo, nullptr, &asset.view) != VK_SUCCESS)
-		{
-			vkDestroyImage(m_device, asset.image, nullptr);
-			vkFreeMemory(m_device, imgMem, nullptr);
-			return kInvalidAssetId;
-		}
-		AssetId id = m_nextTextureId++;
-		m_textures[id] = std::move(asset);
 		LOG_INFO(Render, "AssetRegistry: loaded texture {} ({}x{}, {})", relativePath, width, height, useSrgb ? "sRGB" : "linear");
 		return id;
 	}

--- a/src/client/render/AssetRegistry.h
+++ b/src/client/render/AssetRegistry.h
@@ -150,6 +150,21 @@ namespace engine::render
 		/// Format: raw .texr (magic, width, height, sRGB flag, RGBA pixels) ou PNG (8-bit RGBA).
 		TextureHandle LoadTexture(std::string_view relativePath, bool useSrgb = false);
 
+		/// M45.5 — Crée une texture GPU RGBA8 échantillonnable directement depuis un buffer
+		/// mémoire (sans fichier disque). Utilisée par les atlas d'impostors (ImpostorAsset)
+		/// dont les pixels sont décodés du format .mipo en RAM. Réutilise EXACTEMENT le chemin
+		/// de création d'image + view de \ref LoadTexture (image LINEAR host-visible, map +
+		/// memcpy par ligne via rowPitch) via le helper interne `createSampledRgba8Texture`.
+		/// Aucun cache (chaque appel crée un nouvel asset, libéré au \ref Destroy du registry).
+		/// \param rgba    Pointeur vers `width*height*4` octets RGBA8.
+		/// \param width   Largeur en texels (> 0).
+		/// \param height  Hauteur en texels (> 0).
+		/// \param useSrgb true = format sRGB (albedo, linéarisé au sample) ; false = UNORM
+		///                (normales encodées, lues telles quelles).
+		/// \return Handle invalide si device absent, args nuls/zéro, ou échec Vulkan.
+		TextureHandle CreateTextureFromMemory(const uint8_t* rgba, uint32_t width, uint32_t height,
+		                                      bool useSrgb);
+
 		/// Charge une PNG pour blit plein écran vers la swapchain (canal BGRA si la surface est B8G8R8A8).
 		/// Ignoré pour les .texr (même chargement que \ref LoadTexture).
 		TextureHandle LoadTextureForPresentBlit(std::string_view relativePath, VkFormat swapchainColorFormat);
@@ -188,6 +203,19 @@ namespace engine::render
 
 		AssetId loadMeshInternal(std::string_view relativePath);
 		AssetId loadTextureInternal(std::string_view relativePath, bool useSrgb, VkFormat presentBlitDstFormat = VK_FORMAT_UNDEFINED);
+
+		/// Helper interne partagé : crée une VkImage 2D RGBA8 LINEAR host-visible
+		/// échantillonnable, copie `pixels` (width*height*4 octets) ligne par ligne en
+		/// respectant le `rowPitch` de la subresource, crée la view, et enregistre
+		/// l'asset dans `m_textures`. C'est la factorisation EXACTE du chemin de upload
+		/// déjà utilisé par les branches PNG (non-blit) et TEXR de `loadTextureInternal`
+		/// (mêmes flags : TILING_LINEAR, USAGE_SAMPLED, INITIAL_PREINITIALIZED, mémoire
+		/// HOST_VISIBLE|HOST_COHERENT). Réutilisé par `CreateTextureFromMemory`.
+		/// \param format Format Vulkan (sRGB ou UNORM) déjà résolu par l'appelant.
+		/// \param pixels Pointeur vers width*height*4 octets RGBA8.
+		/// \return kInvalidAssetId en cas d'échec Vulkan (ressources libérées).
+		AssetId createSampledRgba8Texture(uint32_t width, uint32_t height,
+		                                  VkFormat format, const uint8_t* pixels);
 
 		void ReleasePendingPresentBlitStaging();
 

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -279,6 +279,35 @@ namespace engine::render
 				LOG_WARN(Render, "M45.3: depth of field shaders not found, passthrough fallback");
 		}
 
+		// M45.5: Impostor pass (impostors végétation). Dessine dans le GBuffer via
+		// le render pass loadOp=LOAD de la GeometryPass (réutilisé, pas de nouvelle
+		// ressource FrameGraph). Init non bloquant : si les shaders manquent ou
+		// l'init échoue, on log un WARN et la feature reste simplement inactive
+		// (gated par world.impostor.enabled côté Engine, défaut OFF de toute façon).
+		{
+			std::vector<uint32_t> impVert = loadSpirv("shaders/impostor.vert.spv");
+			std::vector<uint32_t> impFrag = loadSpirv("shaders/impostor.frag.spv");
+			const VkRenderPass gbufferLoad = m_geometryPass.GetRenderPassLoad();
+			if (impVert.empty() || impFrag.empty())
+			{
+				LOG_WARN(Render, "M45.5: impostor shaders not found — impostors disabled");
+			}
+			else if (gbufferLoad == VK_NULL_HANDLE)
+			{
+				LOG_WARN(Render, "M45.5: GeometryPass load render pass absent — impostors disabled");
+			}
+			else if (m_impostorPass.Init(device, physicalDevice, gbufferLoad,
+					impVert.data(), impVert.size(), impFrag.data(), impFrag.size(),
+					pipelineCacheHandle))
+			{
+				LOG_INFO(Render, "[Boot] DeferredPipeline ImpostorPass OK");
+			}
+			else
+			{
+				LOG_WARN(Render, "M45.5: impostor pass init failed — impostors disabled");
+			}
+		}
+
 		// Tonemap pass
 		{
 			std::vector<uint32_t> tmVert = loadSpirv("shaders/tonemap.vert.spv");
@@ -384,6 +413,7 @@ namespace engine::render
 		m_bloomDownsamplePass.Destroy(device);
 		m_bloomPrefilterPass.Destroy(device);
 		m_tonemapPass.Destroy(device);
+		m_impostorPass.Destroy(device); // M45.5
 		m_depthOfFieldPass.Destroy(device); // M45.3
 		m_volumetricFogPass.Destroy(device); // M45.2
 		m_lightingPass.Destroy(device);

--- a/src/client/render/DeferredPipeline.h
+++ b/src/client/render/DeferredPipeline.h
@@ -14,6 +14,7 @@
 #include "src/client/render/LightingPass.h"
 #include "src/client/render/VolumetricFogPass.h"
 #include "src/client/render/DepthOfFieldPass.h"
+#include "src/client/render/ImpostorPass.h"
 #include "src/client/render/TonemapPass.h"
 #include "src/client/render/BloomPass.h"
 #include "src/client/render/AutoExposure.h"
@@ -90,6 +91,8 @@ namespace engine::render
 		const VolumetricFogPass&  GetVolumetricFogPass() const  { return m_volumetricFogPass; }
 		DepthOfFieldPass&         GetDepthOfFieldPass()         { return m_depthOfFieldPass; }
 		const DepthOfFieldPass&   GetDepthOfFieldPass() const   { return m_depthOfFieldPass; }
+		ImpostorPass&             GetImpostorPass()             { return m_impostorPass; }
+		const ImpostorPass&       GetImpostorPass() const       { return m_impostorPass; }
 		TonemapPass&          GetTonemapPass()          { return m_tonemapPass; }
 		const TonemapPass&    GetTonemapPass() const    { return m_tonemapPass; }
 		BloomPrefilterPass&   GetBloomPrefilterPass()   { return m_bloomPrefilterPass; }
@@ -116,6 +119,7 @@ namespace engine::render
 		LightingPass          m_lightingPass;
 		VolumetricFogPass     m_volumetricFogPass;
 		DepthOfFieldPass      m_depthOfFieldPass;
+		ImpostorPass          m_impostorPass; ///< M45.5 — impostors végétation (gated world.impostor.enabled)
 		TonemapPass           m_tonemapPass;
 		BloomPrefilterPass    m_bloomPrefilterPass;
 		BloomDownsamplePass   m_bloomDownsamplePass;

--- a/src/client/render/ImpostorAsset.cpp
+++ b/src/client/render/ImpostorAsset.cpp
@@ -1,0 +1,191 @@
+// src/client/render/ImpostorAsset.cpp (M45.5)
+//
+// Implémentation du loader runtime du format `.mipo` (M45.4). Voir
+// ImpostorAsset.h pour l'API. La lecture du header + métadonnées + blocs
+// albedo/normal est faite champ-par-champ en little-endian, RÉPLIQUANT la
+// disposition documentée dans tools/impostor_builder/FORMAT.md, sans dépendre
+// du code de l'outil offline.
+
+#include "src/client/render/ImpostorAsset.h"
+
+#include "src/shared/core/Log.h"
+
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Magic du format `.mipo` : ASCII 'M''I''P''O' en little-endian
+		/// (0x4F50494D), IDENTIQUE à `tools::impostor_builder::kImpostorMagic`.
+		constexpr uint32_t kImpostorMagic   = 0x4F50494Du;
+		/// Version du format disque supportée (cf. kImpostorVersion outil).
+		constexpr uint32_t kImpostorVersion = 1u;
+
+		/// Lit un uint32 little-endian depuis `data` à `offset`, avance `offset`.
+		/// \return false si dépassement de buffer.
+		bool ReadU32LE(const std::vector<uint8_t>& data, size_t& offset, uint32_t& out)
+		{
+			if (offset + 4u > data.size()) return false;
+			out = static_cast<uint32_t>(data[offset + 0]) |
+			      (static_cast<uint32_t>(data[offset + 1]) << 8) |
+			      (static_cast<uint32_t>(data[offset + 2]) << 16) |
+			      (static_cast<uint32_t>(data[offset + 3]) << 24);
+			offset += 4u;
+			return true;
+		}
+
+		/// Lit un uint64 little-endian depuis `data` à `offset`, avance `offset`.
+		/// \return false si dépassement de buffer.
+		bool ReadU64LE(const std::vector<uint8_t>& data, size_t& offset, uint64_t& out)
+		{
+			if (offset + 8u > data.size()) return false;
+			out = 0u;
+			for (int i = 0; i < 8; ++i)
+				out |= static_cast<uint64_t>(data[offset + i]) << (8 * i);
+			offset += 8u;
+			return true;
+		}
+
+		/// Lit un float32 little-endian (bit-cast depuis un uint32), avance `offset`.
+		/// \return false si dépassement de buffer.
+		bool ReadF32LE(const std::vector<uint8_t>& data, size_t& offset, float& out)
+		{
+			uint32_t bits = 0u;
+			if (!ReadU32LE(data, offset, bits)) return false;
+			std::memcpy(&out, &bits, sizeof(out)); // bit-cast (little-endian sur nos plateformes cibles)
+			return true;
+		}
+	} // namespace
+
+	bool ImpostorAsset::IsValid() const
+	{
+		return m_valid && m_albedo.IsValid() && m_normal.IsValid();
+	}
+
+	bool ImpostorAsset::LoadFromFile(const std::string& absOrContentPath, AssetRegistry& reg, std::string& err)
+	{
+		m_valid = false;
+
+		// 1) Lecture brute du fichier.
+		std::ifstream f(absOrContentPath, std::ios::binary | std::ios::ate);
+		if (!f.is_open())
+		{
+			err = "ImpostorAsset: fichier introuvable: '" + absOrContentPath + "'";
+			return false;
+		}
+		const std::streamsize size = f.tellg();
+		if (size <= 0)
+		{
+			err = "ImpostorAsset: fichier vide: '" + absOrContentPath + "'";
+			return false;
+		}
+		std::vector<uint8_t> data(static_cast<size_t>(size));
+		f.seekg(0, std::ios::beg);
+		f.read(reinterpret_cast<char*>(data.data()), size);
+		if (!f)
+		{
+			err = "ImpostorAsset: lecture incomplète: '" + absOrContentPath + "'";
+			return false;
+		}
+
+		// 2) Header 24 octets : magic, formatVersion, builderVersion, engineVersion (4×u32),
+		//    contentHash (u64). Cf. FORMAT.md offsets 0..23.
+		size_t off = 0;
+		uint32_t magic = 0, formatVersion = 0, builderVersion = 0, engineVersion = 0;
+		uint64_t contentHash = 0;
+		if (!ReadU32LE(data, off, magic) || !ReadU32LE(data, off, formatVersion)
+			|| !ReadU32LE(data, off, builderVersion) || !ReadU32LE(data, off, engineVersion)
+			|| !ReadU64LE(data, off, contentHash))
+		{
+			err = "ImpostorAsset: header tronqué (<24 octets)";
+			return false;
+		}
+		(void)builderVersion;
+		(void)engineVersion;
+		(void)contentHash;
+		if (magic != kImpostorMagic)
+		{
+			err = "ImpostorAsset: magic invalide (attendu MIPO 0x4F50494D)";
+			return false;
+		}
+		if (formatVersion != kImpostorVersion)
+		{
+			err = "ImpostorAsset: version de format non supportée: " + std::to_string(formatVersion);
+			return false;
+		}
+
+		// 3) ImpostorAtlasInfo : viewsPerAxis, tileSize, channels (3×u32),
+		//    boundsMin[3], boundsMax[3] (6×f32). Cf. FORMAT.md offsets 24..59.
+		uint32_t viewsPerAxis = 0, tileSize = 0, channels = 0;
+		if (!ReadU32LE(data, off, viewsPerAxis) || !ReadU32LE(data, off, tileSize)
+			|| !ReadU32LE(data, off, channels))
+		{
+			err = "ImpostorAsset: ImpostorAtlasInfo tronqué (grille)";
+			return false;
+		}
+		float boundsMin[3]{}, boundsMax[3]{};
+		for (int i = 0; i < 3; ++i)
+			if (!ReadF32LE(data, off, boundsMin[i]))
+			{ err = "ImpostorAsset: boundsMin tronqué"; return false; }
+		for (int i = 0; i < 3; ++i)
+			if (!ReadF32LE(data, off, boundsMax[i]))
+			{ err = "ImpostorAsset: boundsMax tronqué"; return false; }
+
+		if (viewsPerAxis == 0u || tileSize == 0u || channels != 4u)
+		{
+			err = "ImpostorAsset: métadonnées invalides (viewsPerAxis/tileSize/channels)";
+			return false;
+		}
+
+		const uint32_t atlasSidePx = viewsPerAxis * tileSize;
+		const uint64_t expectedBytes = static_cast<uint64_t>(atlasSidePx) * atlasSidePx * 4ull;
+
+		// 4) Bloc albedo : u64 albedoSize + albedoSize octets RGBA8.
+		uint64_t albedoSize = 0;
+		if (!ReadU64LE(data, off, albedoSize))
+		{ err = "ImpostorAsset: albedoSize tronqué"; return false; }
+		if (albedoSize != expectedBytes || off + albedoSize > data.size())
+		{
+			err = "ImpostorAsset: bloc albedo invalide (taille=" + std::to_string(albedoSize)
+				+ ", attendu=" + std::to_string(expectedBytes) + ")";
+			return false;
+		}
+		const uint8_t* albedoPtr = data.data() + off;
+		off += static_cast<size_t>(albedoSize);
+
+		// 5) Bloc normal : u64 normalSize + normalSize octets RGBA8.
+		uint64_t normalSize = 0;
+		if (!ReadU64LE(data, off, normalSize))
+		{ err = "ImpostorAsset: normalSize tronqué"; return false; }
+		if (normalSize != expectedBytes || off + normalSize > data.size())
+		{
+			err = "ImpostorAsset: bloc normal invalide (taille=" + std::to_string(normalSize)
+				+ ", attendu=" + std::to_string(expectedBytes) + ")";
+			return false;
+		}
+		const uint8_t* normalPtr = data.data() + off;
+
+		// 6) Upload des deux atlas en VkImage échantillonnable.
+		//    Albedo en sRGB (couleur, linéarisée au sample), normal en UNORM
+		//    (valeurs encodées n*0.5+0.5 lues telles quelles, + masque alpha).
+		m_albedo = reg.CreateTextureFromMemory(albedoPtr, atlasSidePx, atlasSidePx, /*useSrgb=*/true);
+		m_normal = reg.CreateTextureFromMemory(normalPtr, atlasSidePx, atlasSidePx, /*useSrgb=*/false);
+		if (!m_albedo.IsValid() || !m_normal.IsValid())
+		{
+			err = "ImpostorAsset: échec upload GPU des atlas";
+			return false;
+		}
+
+		m_info.viewsPerAxis = viewsPerAxis;
+		m_info.tileSize     = tileSize;
+		for (int i = 0; i < 3; ++i) { m_info.boundsMin[i] = boundsMin[i]; m_info.boundsMax[i] = boundsMax[i]; }
+		m_valid = true;
+
+		LOG_INFO(Render, "[ImpostorAsset] chargé '{}' (N={} tile={} atlas={}px)",
+			absOrContentPath, viewsPerAxis, tileSize, atlasSidePx);
+		return true;
+	}
+}

--- a/src/client/render/ImpostorAsset.h
+++ b/src/client/render/ImpostorAsset.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// src/client/render/ImpostorAsset.h (M45.5 — rendu RUNTIME des impostors végétation)
+//
+// Loader runtime du format binaire d'atlas d'impostors octaédriques produit par
+// l'outil offline `tools/impostor_builder` (M45.4, voir tools/impostor_builder/
+// FORMAT.md). Détient les deux textures GPU (albedo sRGB + normal linéaire)
+// uploadées via `AssetRegistry::CreateTextureFromMemory`, ainsi que les
+// métadonnées de grille (viewsPerAxis, tileSize, bounds) nécessaires au shader.
+//
+// IMPORTANT : la lecture du format est RÉPLIQUÉE ici champ-par-champ en
+// little-endian (cf. ImpostorFormat.h) pour NE PAS dépendre du code de l'outil
+// (`tools::impostor_builder`), qui n'est pas linké dans engine_core.
+
+#include "src/client/render/AssetRegistry.h"
+
+#include <cstdint>
+#include <string>
+
+namespace engine::render
+{
+	/// Métadonnées runtime décrivant la grille d'atlas + les bounds du mesh source.
+	/// Réplique le sous-ensemble utile de `tools::impostor_builder::ImpostorAtlasInfo`.
+	struct ImpostorAtlasInfoRuntime
+	{
+		uint32_t viewsPerAxis = 0u;   ///< N : la grille fait N×N tiles (vues).
+		uint32_t tileSize     = 0u;   ///< Côté d'une tile en pixels (carrée).
+		float    boundsMin[3] = {0.0f, 0.0f, 0.0f}; ///< Coin min de l'AABB monde du mesh.
+		float    boundsMax[3] = {0.0f, 0.0f, 0.0f}; ///< Coin max de l'AABB monde du mesh.
+	};
+
+	/// Détenteur d'un atlas d'impostors chargé : métadonnées + 2 textures GPU.
+	/// Cycle de vie : `LoadFromFile` une fois (au chargement du décor si
+	/// `world.impostor.enabled`), lecture via `Albedo()`/`Normal()`/`Info()` à
+	/// chaque frame de rendu. Les textures appartiennent au `AssetRegistry`
+	/// passé à `LoadFromFile` (libérées au `Destroy` du registry) — cette classe
+	/// ne possède donc rien à détruire elle-même (handles non-owning).
+	class ImpostorAsset
+	{
+	public:
+		ImpostorAsset() = default;
+
+		/// Lit le fichier `.mipo` à `absOrContentPath` (chemin disque ABSOLU ou
+		/// relatif au cwd — la résolution est faite par l'appelant), valide le
+		/// magic/version, extrait `ImpostorAtlasInfo` + albedo[] + normal[], puis
+		/// uploade les deux atlas en VkImage via `reg.CreateTextureFromMemory`
+		/// (albedo en sRGB, normal en linéaire/UNORM).
+		///
+		/// Effet de bord : crée deux textures GPU dans `reg`. À appeler en main
+		/// thread (uploads synchrones internes au registry).
+		///
+		/// \param absOrContentPath Chemin disque du fichier `.mipo`.
+		/// \param reg              Registry cible pour l'upload des textures.
+		/// \param err              Message d'erreur lisible en cas d'échec.
+		/// \return true si lecture + validation + upload ont réussi.
+		bool LoadFromFile(const std::string& absOrContentPath, AssetRegistry& reg, std::string& err);
+
+		/// True si `LoadFromFile` a réussi et les deux textures sont valides.
+		bool IsValid() const;
+
+		/// Métadonnées de la grille (valides seulement si `IsValid()`).
+		const ImpostorAtlasInfoRuntime& Info() const { return m_info; }
+
+		/// Handle de la texture albedo (sRGB). Invalide si non chargé.
+		TextureHandle Albedo() const { return m_albedo; }
+		/// Handle de la texture normal (linéaire/UNORM). Invalide si non chargé.
+		TextureHandle Normal() const { return m_normal; }
+
+	private:
+		ImpostorAtlasInfoRuntime m_info{};
+		TextureHandle            m_albedo;
+		TextureHandle            m_normal;
+		bool                     m_valid = false;
+	};
+}

--- a/src/client/render/ImpostorPass.cpp
+++ b/src/client/render/ImpostorPass.cpp
@@ -329,8 +329,14 @@ namespace engine::render
 		if (m_pipeline != VK_NULL_HANDLE)       { vkDestroyPipeline(device, m_pipeline, nullptr);             m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_sampler != VK_NULL_HANDLE)        { vkDestroySampler(device, m_sampler, nullptr);               m_sampler = VK_NULL_HANDLE; }
-		// Le pool libère implicitement m_descSet.
-		if (m_descPool != VK_NULL_HANDLE)       { vkDestroyDescriptorPool(device, m_descPool, nullptr);       m_descPool = VK_NULL_HANDLE; m_descSet = VK_NULL_HANDLE; }
+		// Le pool libère implicitement tout l'anneau m_descSets.
+		if (m_descPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descPool, nullptr);
+			m_descPool = VK_NULL_HANDLE;
+			for (uint32_t i = 0; i < kDescRing; ++i) m_descSets[i] = VK_NULL_HANDLE;
+			m_descCursor = 0;
+		}
 		if (m_setLayout != VK_NULL_HANDLE)      { vkDestroyDescriptorSetLayout(device, m_setLayout, nullptr); m_setLayout = VK_NULL_HANDLE; }
 	}
 }

--- a/src/client/render/ImpostorPass.cpp
+++ b/src/client/render/ImpostorPass.cpp
@@ -1,0 +1,336 @@
+// src/client/render/ImpostorPass.cpp (M45.5)
+//
+// Implémentation de `ImpostorPass`. Voir ImpostorPass.h pour l'API. Le pipeline
+// est calqué sur `TerrainChunkPipeline`/`GeometryPass` pour rester compatible
+// avec le render pass GBuffer loadOp=LOAD (4 color + 1 depth) : même état MRT
+// (4 blend attachments, blend OFF), depth test+write ON. Pas de vertex buffer :
+// le quad billboard est généré dans le VS depuis gl_VertexIndex (6 sommets).
+
+#include "src/client/render/ImpostorPass.h"
+
+#include "src/client/render/PipelineCache.h"
+#include "src/shared/core/Log.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Crée un module shader Vulkan depuis un blob SPIR-V (mêmes conventions
+		/// que TerrainChunkPipeline). \return VK_NULL_HANDLE en cas d'échec.
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* spirv,
+			size_t wordCount, const char* tag)
+		{
+			VkShaderModuleCreateInfo info{};
+			info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			info.codeSize = wordCount * sizeof(uint32_t);
+			info.pCode    = spirv;
+			VkShaderModule mod = VK_NULL_HANDLE;
+			const VkResult r = vkCreateShaderModule(device, &info, nullptr, &mod);
+			if (r != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkCreateShaderModule({}) failed: {}",
+					tag, static_cast<int>(r));
+				return VK_NULL_HANDLE;
+			}
+			return mod;
+		}
+	} // namespace
+
+	bool ImpostorPass::Init(VkDevice device, VkPhysicalDevice /*physicalDevice*/,
+		VkRenderPass gbufferLoadRenderPass,
+		const uint32_t* vertSpirv, size_t vertWordCount,
+		const uint32_t* fragSpirv, size_t fragWordCount,
+		VkPipelineCache pipelineCache)
+	{
+		if (device == VK_NULL_HANDLE || gbufferLoadRenderPass == VK_NULL_HANDLE
+			|| vertSpirv == nullptr || vertWordCount == 0
+			|| fragSpirv == nullptr || fragWordCount == 0)
+		{
+			LOG_WARN(Render, "[ImpostorPass] Init: args invalides (device/renderPass/spirv null)");
+			return false;
+		}
+
+		// 1) Descriptor set layout (set 0) : 2 combined image samplers
+		//    (binding 0 = albedo, binding 1 = normal), stage FRAGMENT.
+		{
+			VkDescriptorSetLayoutBinding bindings[2]{};
+			for (uint32_t i = 0; i < 2u; ++i)
+			{
+				bindings[i].binding         = i;
+				bindings[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount = 1;
+				bindings[i].stageFlags      = VK_SHADER_STAGE_FRAGMENT_BIT;
+			}
+			VkDescriptorSetLayoutCreateInfo info{};
+			info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			info.bindingCount = 2;
+			info.pBindings    = bindings;
+			if (vkCreateDescriptorSetLayout(device, &info, nullptr, &m_setLayout) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkCreateDescriptorSetLayout failed");
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// 2) Descriptor pool + anneau de kDescRing sets (un par atlas/draw, cf. .h).
+		//    2 image samplers par set.
+		{
+			VkDescriptorPoolSize poolSize{};
+			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSize.descriptorCount = 2u * kDescRing;
+			VkDescriptorPoolCreateInfo pci{};
+			pci.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+			pci.maxSets       = kDescRing;
+			pci.poolSizeCount = 1;
+			pci.pPoolSizes    = &poolSize;
+			if (vkCreateDescriptorPool(device, &pci, nullptr, &m_descPool) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkCreateDescriptorPool failed");
+				Destroy(device);
+				return false;
+			}
+			VkDescriptorSetLayout layouts[kDescRing];
+			for (uint32_t i = 0; i < kDescRing; ++i) layouts[i] = m_setLayout;
+			VkDescriptorSetAllocateInfo dsai{};
+			dsai.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+			dsai.descriptorPool     = m_descPool;
+			dsai.descriptorSetCount = kDescRing;
+			dsai.pSetLayouts        = layouts;
+			if (vkAllocateDescriptorSets(device, &dsai, m_descSets) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkAllocateDescriptorSets failed");
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// 3) Sampler linéaire CLAMP_TO_EDGE (évite le bleeding entre tiles de l'atlas).
+		{
+			VkSamplerCreateInfo sci{};
+			sci.sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+			sci.magFilter    = VK_FILTER_LINEAR;
+			sci.minFilter    = VK_FILTER_LINEAR;
+			sci.mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+			sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+			sci.maxLod       = 0.0f;
+			if (vkCreateSampler(device, &sci, nullptr, &m_sampler) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkCreateSampler failed");
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// 4) Pipeline layout : set 0 + 1 push constant range (VERTEX+FRAGMENT).
+		{
+			VkPushConstantRange pushRange{};
+			pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+			pushRange.offset     = 0;
+			pushRange.size       = static_cast<uint32_t>(sizeof(ImpostorPushConstants));
+
+			VkPipelineLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			layoutInfo.setLayoutCount         = 1;
+			layoutInfo.pSetLayouts            = &m_setLayout;
+			layoutInfo.pushConstantRangeCount = 1;
+			layoutInfo.pPushConstantRanges    = &pushRange;
+			if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[ImpostorPass] vkCreatePipelineLayout failed");
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// 5) Shader modules.
+		VkShaderModule vertModule = CreateShaderModule(device, vertSpirv, vertWordCount, "impostor.vert");
+		VkShaderModule fragModule = CreateShaderModule(device, fragSpirv, fragWordCount, "impostor.frag");
+		if (vertModule == VK_NULL_HANDLE || fragModule == VK_NULL_HANDLE)
+		{
+			if (vertModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, vertModule, nullptr);
+			if (fragModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, fragModule, nullptr);
+			Destroy(device);
+			return false;
+		}
+
+		// 6) État du pipeline graphique. Pas de vertex input (quad via gl_VertexIndex).
+		VkPipelineShaderStageCreateInfo stages[2]{};
+		stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+		stages[0].module = vertModule;
+		stages[0].pName  = "main";
+		stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+		stages[1].module = fragModule;
+		stages[1].pName  = "main";
+
+		VkPipelineVertexInputStateCreateInfo vi{};
+		vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+		VkPipelineInputAssemblyStateCreateInfo ia{};
+		ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+		ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+		VkPipelineViewportStateCreateInfo vp{};
+		vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+		vp.viewportCount = 1;
+		vp.scissorCount  = 1;
+
+		// Billboard camera-facing : pas de winding cohérent garanti -> cull OFF
+		// (le quad fait toujours face à la caméra ; le coût d'un cull erroné serait
+		// un billboard invisible). Sûr et conservateur.
+		VkPipelineRasterizationStateCreateInfo rs{};
+		rs.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+		rs.polygonMode = VK_POLYGON_MODE_FILL;
+		rs.cullMode    = VK_CULL_MODE_NONE;
+		rs.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		rs.lineWidth   = 1.0f;
+
+		VkPipelineMultisampleStateCreateInfo ms{};
+		ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+		ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+		// Depth test+write ON : les impostors s'intègrent au depth buffer comme les
+		// props/terrain (occlusion correcte vis-à-vis du reste de la scène).
+		VkPipelineDepthStencilStateCreateInfo ds{};
+		ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+		ds.depthTestEnable  = VK_TRUE;
+		ds.depthWriteEnable = VK_TRUE;
+		ds.depthCompareOp   = VK_COMPARE_OP_LESS_OR_EQUAL;
+
+		// 4 color blend attachments (albedo/normal/ORM/velocity), blend OFF, RGBA write.
+		VkPipelineColorBlendAttachmentState blendAtt[4]{};
+		for (int i = 0; i < 4; ++i)
+		{
+			blendAtt[i].blendEnable    = VK_FALSE;
+			blendAtt[i].colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+				| VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+		}
+		VkPipelineColorBlendStateCreateInfo cb{};
+		cb.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+		cb.attachmentCount = 4;
+		cb.pAttachments    = blendAtt;
+
+		VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+		VkPipelineDynamicStateCreateInfo dyn{};
+		dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+		dyn.dynamicStateCount = 2;
+		dyn.pDynamicStates    = dynStates;
+
+		VkGraphicsPipelineCreateInfo gpInfo{};
+		gpInfo.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+		gpInfo.stageCount          = 2;
+		gpInfo.pStages             = stages;
+		gpInfo.pVertexInputState   = &vi;
+		gpInfo.pInputAssemblyState = &ia;
+		gpInfo.pViewportState      = &vp;
+		gpInfo.pRasterizationState = &rs;
+		gpInfo.pMultisampleState   = &ms;
+		gpInfo.pDepthStencilState  = &ds;
+		gpInfo.pColorBlendState    = &cb;
+		gpInfo.pDynamicState       = &dyn;
+		gpInfo.layout              = m_pipelineLayout;
+		gpInfo.renderPass          = gbufferLoadRenderPass;
+		gpInfo.subpass             = 0;
+
+		AssertPipelineCreationAllowed();
+		const VkResult r = vkCreateGraphicsPipelines(device, pipelineCache, 1, &gpInfo, nullptr, &m_pipeline);
+		vkDestroyShaderModule(device, vertModule, nullptr);
+		vkDestroyShaderModule(device, fragModule, nullptr);
+		if (r != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[ImpostorPass] vkCreateGraphicsPipelines failed: {}", static_cast<int>(r));
+			Destroy(device);
+			return false;
+		}
+
+		LOG_INFO(Render, "[Boot] ImpostorPass init OK");
+		return true;
+	}
+
+	void ImpostorPass::RecordInstances(VkDevice device, VkCommandBuffer cmd, VkExtent2D /*extent*/,
+		const ImpostorInstance* instances, uint32_t count,
+		VkImageView albedoView, VkSampler albedoSamp,
+		VkImageView normalView, VkSampler normalSamp,
+		const float* viewProj, const float* prevViewProj, const float* cameraPos3,
+		uint32_t viewsPerAxis, uint32_t tileSize)
+	{
+		if (m_pipeline == VK_NULL_HANDLE || cmd == VK_NULL_HANDLE || instances == nullptr
+			|| count == 0 || albedoView == VK_NULL_HANDLE || normalView == VK_NULL_HANDLE
+			|| albedoSamp == VK_NULL_HANDLE || normalSamp == VK_NULL_HANDLE
+			|| viewProj == nullptr || cameraPos3 == nullptr)
+		{
+			return;
+		}
+
+		// Prend le prochain set de l'anneau (évite d'écraser un set encore
+		// référencé par un draw précédent ou une frame en vol — cf. kDescRing).
+		VkDescriptorSet descSet = m_descSets[m_descCursor];
+		m_descCursor = (m_descCursor + 1u) % kDescRing;
+
+		// Met à jour CE set avec l'atlas courant.
+		VkDescriptorImageInfo imgInfos[2]{};
+		imgInfos[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		imgInfos[0].imageView   = albedoView;
+		imgInfos[0].sampler     = albedoSamp;
+		imgInfos[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		imgInfos[1].imageView   = normalView;
+		imgInfos[1].sampler     = normalSamp;
+		VkWriteDescriptorSet writes[2]{};
+		for (uint32_t i = 0; i < 2u; ++i)
+		{
+			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[i].dstSet          = descSet;
+			writes[i].dstBinding      = i;
+			writes[i].descriptorCount = 1u;
+			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[i].pImageInfo      = &imgInfos[i];
+		}
+		vkUpdateDescriptorSets(device, 2u, writes, 0, nullptr);
+
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+			m_pipelineLayout, 0, 1, &descSet, 0, nullptr);
+
+		// Push constants : partie commune (matrices/caméra/atlas) constante pour
+		// toutes les instances de cet atlas ; seule instancePos change par draw.
+		ImpostorPushConstants pc{};
+		for (int i = 0; i < 16; ++i) pc.viewProj[i] = viewProj[i];
+		if (prevViewProj != nullptr) { for (int i = 0; i < 16; ++i) pc.prevViewProj[i] = prevViewProj[i]; }
+		else                          { for (int i = 0; i < 16; ++i) pc.prevViewProj[i] = viewProj[i]; }
+		pc.cameraPos[0] = cameraPos3[0];
+		pc.cameraPos[1] = cameraPos3[1];
+		pc.cameraPos[2] = cameraPos3[2];
+		pc.cameraPos[3] = 0.0f;
+		pc.atlasParams[0] = static_cast<float>(viewsPerAxis);
+		pc.atlasParams[1] = static_cast<float>(tileSize);
+		pc.atlasParams[2] = 1.0f; // fadeAlpha (v1 : pas de fondu, opaque)
+		pc.atlasParams[3] = 0.0f;
+
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			pc.instancePos[0] = instances[i].worldPos[0];
+			pc.instancePos[1] = instances[i].worldPos[1];
+			pc.instancePos[2] = instances[i].worldPos[2];
+			pc.instancePos[3] = instances[i].radius;
+			vkCmdPushConstants(cmd, m_pipelineLayout,
+				VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
+				sizeof(ImpostorPushConstants), &pc);
+			vkCmdDraw(cmd, 6, 1, 0, 0);
+		}
+	}
+
+	void ImpostorPass::Destroy(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+		if (m_pipeline != VK_NULL_HANDLE)       { vkDestroyPipeline(device, m_pipeline, nullptr);             m_pipeline = VK_NULL_HANDLE; }
+		if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
+		if (m_sampler != VK_NULL_HANDLE)        { vkDestroySampler(device, m_sampler, nullptr);               m_sampler = VK_NULL_HANDLE; }
+		// Le pool libère implicitement m_descSet.
+		if (m_descPool != VK_NULL_HANDLE)       { vkDestroyDescriptorPool(device, m_descPool, nullptr);       m_descPool = VK_NULL_HANDLE; m_descSet = VK_NULL_HANDLE; }
+		if (m_setLayout != VK_NULL_HANDLE)      { vkDestroyDescriptorSetLayout(device, m_setLayout, nullptr); m_setLayout = VK_NULL_HANDLE; }
+	}
+}

--- a/src/client/render/ImpostorPass.h
+++ b/src/client/render/ImpostorPass.h
@@ -1,0 +1,133 @@
+#pragma once
+
+// src/client/render/ImpostorPass.h (M45.5 — rendu RUNTIME des impostors végétation)
+//
+// Passe de rendu d'impostors instanciés DANS le GBuffer deferred. Chaque
+// instance = un billboard camera-facing (quad 2 triangles généré dans le VS
+// depuis gl_VertexIndex) texturé depuis l'atlas octaédrique (M45.4) en fonction
+// de la direction caméra→instance. Les sorties écrivent les 4 attachments
+// GBuffer (albedo / normal / ORM / velocity) afin d'être éclairées par le
+// LightingPass existant comme n'importe quelle géométrie opaque.
+//
+// Intégration : le pipeline est créé compatible avec le render pass GBuffer
+// loadOp=LOAD exposé par `GeometryPass::GetRenderPassLoad()`. `RecordInstances`
+// doit être appelé À L'INTÉRIEUR du callback de
+// `GeometryPass::RecordTerrainChunkBatch` (render pass déjà ouvert + viewport/
+// scissor configurés) — exactement comme SkyPass / SkinnedRenderer. Cette passe
+// n'ouvre/ne ferme JAMAIS de render pass elle-même.
+//
+// Contraintes thread/timing : main thread uniquement ; `RecordInstances` entre
+// vkCmdBeginRenderPass et vkCmdEndRenderPass du caller.
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::render
+{
+	/// Une instance d'impostor à dessiner : centre monde + rayon de la sphère
+	/// englobante du prop (demi-taille du billboard, en mètres).
+	struct ImpostorInstance
+	{
+		float worldPos[3] = {0.0f, 0.0f, 0.0f};
+		float radius      = 1.0f;
+	};
+
+	/// Push constants poussées par instance (stage VERTEX + FRAGMENT).
+	/// Disposition (std430-compatible, 176 octets ≤ 256 garanti par le spec) :
+	///   viewProj      : 64  (mat4 caméra)
+	///   prevViewProj  : 64  (mat4 frame précédente — réservé velocity, écrit 0)
+	///   cameraPos     : 16  (xyz position caméra monde, w pad)
+	///   atlasParams   : 16  (x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=0)
+	///   instancePos   : 16  (xyz centre monde, w=radius)
+	struct ImpostorPushConstants
+	{
+		float viewProj[16]     = {};
+		float prevViewProj[16] = {};
+		float cameraPos[4]     = {};
+		float atlasParams[4]   = {};
+		float instancePos[4]   = {};
+	};
+	static_assert(sizeof(ImpostorPushConstants) == 176,
+		"ImpostorPushConstants doit faire 176 octets (cf. layout shader impostor.vert/.frag)");
+
+	/// Passe de rendu d'impostors. Voir docstring fichier pour le cycle de vie.
+	class ImpostorPass
+	{
+	public:
+		ImpostorPass() = default;
+		ImpostorPass(const ImpostorPass&) = delete;
+		ImpostorPass& operator=(const ImpostorPass&) = delete;
+
+		/// Crée le pipeline graphique compatible avec `gbufferLoadRenderPass`
+		/// (4 color attachments + depth, depthTest ON, depthWrite ON, blend OFF
+		/// sur les 4 — calque l'état MRT de GeometryPass/TerrainChunkRenderer
+		/// pour ce render pass). Crée aussi le descriptor set layout (set 0 =
+		/// 2 combined image samplers : albedo, normal), le pool, le set, et un
+		/// sampler linéaire CLAMP_TO_EDGE partagé.
+		///
+		/// \param gbufferLoadRenderPass Render pass GBuffer loadOp=LOAD du caller.
+		/// \param vertSpirv/vertWordCount  SPIR-V de impostor.vert.
+		/// \param fragSpirv/fragWordCount  SPIR-V de impostor.frag.
+		/// \return false si un objet Vulkan échoue (et l'état est nettoyé).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+		          VkRenderPass gbufferLoadRenderPass,
+		          const uint32_t* vertSpirv, size_t vertWordCount,
+		          const uint32_t* fragSpirv, size_t fragWordCount,
+		          VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Dessine `count` impostors partageant le même atlas (albedo+normal).
+		/// À APPELER DANS le callback de `RecordTerrainChunkBatch` (render pass
+		/// déjà ouvert). Bind pipeline + descriptor (atlas), puis pour chaque
+		/// instance : push constants (avec instancePos), `vkCmdDraw(cmd,6,1,0,0)`.
+		/// N'ouvre/ne ferme PAS de render pass.
+		///
+		/// \param extent        Étendue du viewport (informelle ; viewport/scissor
+		///                      sont déjà posés par le caller via le render pass).
+		/// \param instances     Tableau de `count` instances (même atlas).
+		/// \param albedoView/albedoSamp  Atlas albedo (sRGB) + sampler.
+		/// \param normalView/normalSamp  Atlas normal (UNORM) + sampler.
+		/// \param viewProj      Matrice viewProj (16 floats, row-major `.m`).
+		/// \param prevViewProj  Matrice viewProj frame précédente (16 floats).
+		/// \param cameraPos3    Position caméra monde (3 floats).
+		/// \param viewsPerAxis  N de la grille N×N de l'atlas.
+		/// \param tileSize      Côté d'une tile en pixels.
+		///
+		/// Effet de bord : met à jour le descriptor set partagé (vkUpdateDescriptorSets)
+		/// à chaque appel — un seul atlas peut donc être lié à la fois ; appeler
+		/// une fois par atlas distinct.
+		void RecordInstances(VkDevice device, VkCommandBuffer cmd, VkExtent2D extent,
+		          const ImpostorInstance* instances, uint32_t count,
+		          VkImageView albedoView, VkSampler albedoSamp,
+		          VkImageView normalView, VkSampler normalSamp,
+		          const float* viewProj, const float* prevViewProj, const float* cameraPos3,
+		          uint32_t viewsPerAxis, uint32_t tileSize);
+
+		/// Sampler linéaire CLAMP_TO_EDGE créé au Init, partagé pour albedo+normal.
+		/// Le caller peut le passer comme `albedoSamp`/`normalSamp` à RecordInstances.
+		VkSampler GetSampler() const { return m_sampler; }
+
+		/// Libère tous les objets Vulkan. Sûr d'appeler même non initialisé.
+		void Destroy(VkDevice device);
+
+		/// True si Init a réussi (pipeline valide).
+		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
+
+	private:
+		/// Anneau de descriptor sets : un set est consommé par RecordInstances (un
+		/// par atlas distinct). Comme les descriptors sont lus À L'EXÉCUTION du draw,
+		/// réécrire un set déjà lié par un draw précédent (même cmd buffer) ou encore
+		/// référencé par une frame en vol corromprait le rendu. On tourne donc sur un
+		/// anneau assez grand pour couvrir (atlas distincts/frame × frames en vol).
+		static constexpr uint32_t kDescRing = 64u;
+
+		VkPipeline            m_pipeline       = VK_NULL_HANDLE;
+		VkPipelineLayout      m_pipelineLayout = VK_NULL_HANDLE;
+		VkDescriptorSetLayout m_setLayout      = VK_NULL_HANDLE;
+		VkDescriptorPool      m_descPool       = VK_NULL_HANDLE;
+		VkDescriptorSet       m_descSets[kDescRing] = {}; ///< Anneau (cf. kDescRing).
+		uint32_t              m_descCursor     = 0;       ///< Prochain set à utiliser (mod kDescRing).
+		VkSampler             m_sampler        = VK_NULL_HANDLE;
+	};
+}


### PR DESCRIPTION
## M45.5 — Impostors végétation runtime (cluster M45)

Affiche au loin des impostors octaédriques (atlas produits par #791 / M45.4) **à la place des meshes de décor**, **éclairés par le pipeline deferred** (écriture GBuffer). **DÉSACTIVÉ par défaut** (`world.impostor.enabled=false`) → rendu strictement identique tant que non activé.

### Intégration deferred (chemin sûr)
L'`ImpostorPass` crée un pipeline **compatible avec le render pass GBuffer `loadOp=LOAD`** de `GeometryPass` (`GetRenderPassLoad()`) et dessine **dans le GBuffer** via `RecordTerrainChunkBatch` (exactement comme `TerrainChunkRenderer`). → pas de nouvelle ressource FrameGraph, pas de double writer. Les impostors sont donc éclairés/ombrés comme la géométrie opaque. Bascule mesh→impostor dans `RecordPropsGeometry`.

### Contenu
- `ImpostorAsset.{h,cpp}` — loader runtime du `.mipo` (M45.4), échec gracieux, upload atlas albedo(sRGB)+normal via `AssetRegistry::CreateTextureFromMemory`.
- `AssetRegistry` — `CreateTextureFromMemory` + factorisation `createSampledRgba8Texture` (partagé PNG/.texr/mémoire ; **`LoadTexture` byte-identique**, aucune régression).
- `ImpostorPass.{h,cpp}` + `impostor.vert/.frag` — billboard camera-facing instancié, **décodage octaédrique inverse exact de `OctaToDir`**, alpha-test silhouette, dither Bayer anti-popping, 4 sorties GBuffer (ordre/format = `gbuffer_geometry.frag`). **Anneau de 64 descriptor sets** (1/atlas) pour gérer plusieurs essences sans corruption.
- `Engine` — bascule gated dans `RecordPropsGeometry` (décor au-delà de `world.impostor.distance_m`).
- `config.json` (`world.impostor`, off) + `CMakeLists.txt`.

### Gating / non-régression
`enabled=false` (défaut) → `impostorActive=false` → aucun prop ne bascule, bloc impostor sauté → **chemin historique strictement inchangé**. Init échouée → impostors inactifs (fallback mesh). Atlas `.mipo` absent → fallback mesh.

### À valider visuellement (par toi)
Nécessite de générer des atlas `.mipo` (via `impostor_builder`, #791) à côté des meshes, puis `world.impostor.enabled=true`. Points à juger : alignement des vues octaédriques (encode/decode), orientation intra-tile, billboard right/up (approx. depuis viewProj — voir commentaires).

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)