### PR TITLE
feat(render): M45.6 — structure DDGI phase 1 (grille + layout + tests, invisible)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,7 @@ add_library(engine_core
   src/client/render/GpuDrivenCullingPass.cpp
   src/client/render/HiZPyramidPass.cpp
   src/client/render/LightingPass.cpp
+  src/client/render/gi/DdgiVolume.cpp
   src/client/render/VolumetricFogPass.cpp
   src/client/render/DepthOfFieldPass.cpp
   src/client/render/TonemapPass.cpp
@@ -809,6 +810,11 @@ add_executable(protocol_v1_tests src/shared/network/ProtocolV1Tests.cpp)
 target_link_libraries(protocol_v1_tests PRIVATE engine_core)
 enable_testing()
 add_test(NAME protocol_v1_tests COMMAND protocol_v1_tests)
+
+# M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
+add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)
+target_link_libraries(ddgi_volume_tests PRIVATE engine_core)
+add_test(NAME ddgi_volume_tests COMMAND ddgi_volume_tests)
 
 # Phase 1: CHARACTER_LIST request/response payload round-trip tests
 add_executable(character_list_payloads_tests src/shared/network/CharacterListPayloadsTests.cpp)

--- a/config.json
+++ b/config.json
@@ -608,5 +608,16 @@
             "flood_max_messages": 5,
             "max_tracked_accounts": 4096
         }
+    },
+    "gi": {
+        "_comment_gi": "DDGI phase 1 (M45.6) — structure seulement. DESACTIVE (enabled=false) => aucune allocation GPU, aucun rendu, usage VRAM strictement inchange. Les ressources persistantes (atlas irradiance/visibilite) ne s'allouent que si enabled=true (reserve M45.7). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px).",
+        "ddgi": {
+            "enabled": false,
+            "origin_m": [0, 0, 0],
+            "spacing_m": [2, 2, 2],
+            "counts": [8, 8, 4],
+            "irradiance_texels": 8,
+            "visibility_texels": 16
+        }
     }
 }

--- a/src/client/render/gi/DdgiVolume.cpp
+++ b/src/client/render/gi/DdgiVolume.cpp
@@ -1,0 +1,259 @@
+#include "src/client/render/gi/DdgiVolume.h"
+#include "src/shared/core/Log.h"
+
+#include <vulkan/vulkan.h>
+
+namespace engine::render::gi
+{
+	// ---------------------------------------------------------------------------
+	// Indexation des sondes (CPU pur — aucune dépendance Vulkan dans ces méthodes)
+	// ---------------------------------------------------------------------------
+
+	uint32_t DdgiVolume::ProbeCount() const
+	{
+		return m_config.counts[0] * m_config.counts[1] * m_config.counts[2];
+	}
+
+	uint32_t DdgiVolume::ProbeIndex(uint32_t ix, uint32_t iy, uint32_t iz) const
+	{
+		// X le plus rapide, puis Y, puis Z.
+		return ix + iy * m_config.counts[0] + iz * m_config.counts[0] * m_config.counts[1];
+	}
+
+	void DdgiVolume::GridCoord(uint32_t index, uint32_t& ix, uint32_t& iy, uint32_t& iz) const
+	{
+		const uint32_t cx = m_config.counts[0];
+		const uint32_t cy = m_config.counts[1];
+		const uint32_t plane = cx * cy; // sondes par étage XY
+		iz = (plane != 0u) ? (index / plane) : 0u;
+		const uint32_t rem = (plane != 0u) ? (index % plane) : 0u;
+		iy = (cx != 0u) ? (rem / cx) : 0u;
+		ix = (cx != 0u) ? (rem % cx) : 0u;
+	}
+
+	void DdgiVolume::ProbeWorldPos(uint32_t ix, uint32_t iy, uint32_t iz, float& x, float& y, float& z) const
+	{
+		x = m_config.origin[0] + static_cast<float>(ix) * m_config.spacing[0];
+		y = m_config.origin[1] + static_cast<float>(iy) * m_config.spacing[1];
+		z = m_config.origin[2] + static_cast<float>(iz) * m_config.spacing[2];
+	}
+
+	// ---------------------------------------------------------------------------
+	// Layout d'atlas (CPU pur) — cf. section PACKING D'ATLAS dans le header.
+	// ---------------------------------------------------------------------------
+
+	void DdgiVolume::ProbeAtlasTileOrigin(uint32_t probeIndex, uint32_t tileSize, uint32_t& px, uint32_t& py) const
+	{
+		uint32_t ix = 0u, iy = 0u, iz = 0u;
+		GridCoord(probeIndex, ix, iy, iz);
+		// Plan XZ déplié horizontalement : col = ix + iz * counts[0] ; row = iy.
+		const uint32_t col = ix + iz * m_config.counts[0];
+		const uint32_t row = iy;
+		px = col * tileSize;
+		py = row * tileSize;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Ressources GPU (gated — NON appelées par défaut)
+	//
+	// Coût VRAM estimé par zone (config par défaut 8x8x4 = 256 sondes) :
+	//   - Irradiance : atlas (8*4)*(8+2) x (8)*(8+2) = 320 x 80 px, R16G16B16A16_SFLOAT
+	//     (8 octets/px) => 320*80*8 ≈ 200 Kio.
+	//   - Visibilité : atlas (8*4)*(16+2) x (8)*(16+2) = 576 x 144 px, R16G16_SFLOAT
+	//     (4 octets/px) => 576*144*4 ≈ 324 Kio.
+	//   Total ≈ 0,5 Mio par zone à la résolution par défaut. Croît linéairement avec
+	//   ProbeCount et quadratiquement avec la résolution octaédrique par sonde.
+	// ---------------------------------------------------------------------------
+
+	bool DdgiVolume::CreateImage(VkDevice device, VkPhysicalDevice phys,
+		uint32_t width, uint32_t height, VkFormat format,
+		VkImage& outImage, VkDeviceMemory& outMemory, std::string& err) const
+	{
+		VkImageCreateInfo imageInfo{};
+		imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imageInfo.imageType = VK_IMAGE_TYPE_2D;
+		imageInfo.format = format;
+		imageInfo.extent = { width, height, 1u };
+		imageInfo.mipLevels = 1u;
+		imageInfo.arrayLayers = 1u;
+		imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		imageInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+		if (vkCreateImage(device, &imageInfo, nullptr, &outImage) != VK_SUCCESS)
+		{
+			err = "vkCreateImage a echoue";
+			return false;
+		}
+
+		VkMemoryRequirements memoryRequirements{};
+		vkGetImageMemoryRequirements(device, outImage, &memoryRequirements);
+
+		VkPhysicalDeviceMemoryProperties memoryProperties{};
+		vkGetPhysicalDeviceMemoryProperties(phys, &memoryProperties);
+
+		uint32_t memoryTypeIndex = UINT32_MAX;
+		for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i)
+		{
+			if ((memoryRequirements.memoryTypeBits & (1u << i)) != 0
+				&& (memoryProperties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0)
+			{
+				memoryTypeIndex = i;
+				break;
+			}
+		}
+
+		if (memoryTypeIndex == UINT32_MAX)
+		{
+			err = "aucun type de memoire device-local compatible";
+			vkDestroyImage(device, outImage, nullptr);
+			outImage = VK_NULL_HANDLE;
+			return false;
+		}
+
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memoryRequirements.size;
+		allocInfo.memoryTypeIndex = memoryTypeIndex;
+		if (vkAllocateMemory(device, &allocInfo, nullptr, &outMemory) != VK_SUCCESS)
+		{
+			err = "vkAllocateMemory a echoue";
+			vkDestroyImage(device, outImage, nullptr);
+			outImage = VK_NULL_HANDLE;
+			return false;
+		}
+
+		if (vkBindImageMemory(device, outImage, outMemory, 0) != VK_SUCCESS)
+		{
+			err = "vkBindImageMemory a echoue";
+			vkFreeMemory(device, outMemory, nullptr);
+			vkDestroyImage(device, outImage, nullptr);
+			outMemory = VK_NULL_HANDLE;
+			outImage = VK_NULL_HANDLE;
+			return false;
+		}
+
+		return true;
+	}
+
+	VkImageView DdgiVolume::CreateView(VkDevice device, VkImage image, VkFormat format) const
+	{
+		VkImageViewCreateInfo viewInfo{};
+		viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		viewInfo.image = image;
+		viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		viewInfo.format = format;
+		viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		viewInfo.subresourceRange.baseMipLevel = 0u;
+		viewInfo.subresourceRange.levelCount = 1u;
+		viewInfo.subresourceRange.baseArrayLayer = 0u;
+		viewInfo.subresourceRange.layerCount = 1u;
+
+		VkImageView view = VK_NULL_HANDLE;
+		if (vkCreateImageView(device, &viewInfo, nullptr, &view) != VK_SUCCESS)
+			return VK_NULL_HANDLE;
+		return view;
+	}
+
+	bool DdgiVolume::Allocate(VkDevice device, VkPhysicalDevice phys, void* /*vmaAllocator*/, std::string& err)
+	{
+		// vmaAllocator est volontairement ignoré : on miroite le pattern d'image
+		// persistante de HiZPyramidPass (vkCreateImage + vkAllocateMemory device-local),
+		// autonome et sans dépendance à l'allocateur VMA du moteur.
+		if (device == VK_NULL_HANDLE || phys == VK_NULL_HANDLE)
+		{
+			err = "device ou physical device invalide";
+			return false;
+		}
+		if (m_allocated)
+		{
+			err = "deja alloue";
+			return false;
+		}
+
+		const uint32_t irrW = IrradianceAtlasWidth();
+		const uint32_t irrH = IrradianceAtlasHeight();
+		const uint32_t visW = VisibilityAtlasWidth();
+		const uint32_t visH = VisibilityAtlasHeight();
+
+		if (irrW == 0u || irrH == 0u || visW == 0u || visH == 0u)
+		{
+			err = "dimensions d'atlas nulles (config invalide)";
+			return false;
+		}
+
+		if (!CreateImage(device, phys, irrW, irrH, VK_FORMAT_R16G16B16A16_SFLOAT,
+			m_irradianceImage, m_irradianceMemory, err))
+		{
+			LOG_ERROR(Render, "[DdgiVolume] Allocation irradiance FAILED: {}", err);
+			Destroy(device, nullptr);
+			return false;
+		}
+
+		if (!CreateImage(device, phys, visW, visH, VK_FORMAT_R16G16_SFLOAT,
+			m_visibilityImage, m_visibilityMemory, err))
+		{
+			LOG_ERROR(Render, "[DdgiVolume] Allocation visibilite FAILED: {}", err);
+			Destroy(device, nullptr);
+			return false;
+		}
+
+		m_irradianceView = CreateView(device, m_irradianceImage, VK_FORMAT_R16G16B16A16_SFLOAT);
+		if (m_irradianceView == VK_NULL_HANDLE)
+		{
+			err = "creation vue irradiance a echoue";
+			LOG_ERROR(Render, "[DdgiVolume] {}", err);
+			Destroy(device, nullptr);
+			return false;
+		}
+
+		m_visibilityView = CreateView(device, m_visibilityImage, VK_FORMAT_R16G16_SFLOAT);
+		if (m_visibilityView == VK_NULL_HANDLE)
+		{
+			err = "creation vue visibilite a echoue";
+			LOG_ERROR(Render, "[DdgiVolume] {}", err);
+			Destroy(device, nullptr);
+			return false;
+		}
+
+		m_allocated = true;
+
+		// VRAM estimée (8 octets/px irradiance RGBA16F, 4 octets/px visibilité RG16F).
+		const uint64_t irrBytes = static_cast<uint64_t>(irrW) * irrH * 8ull;
+		const uint64_t visBytes = static_cast<uint64_t>(visW) * visH * 4ull;
+		const double totalKib = static_cast<double>(irrBytes + visBytes) / 1024.0;
+		LOG_INFO(Render,
+			"[DdgiVolume] Alloue : {} sondes, irradiance {}x{} (RGBA16F), visibilite {}x{} (RG16F), VRAM estimee ~{:.1f} Kio",
+			ProbeCount(), irrW, irrH, visW, visH, totalKib);
+		return true;
+	}
+
+	void DdgiVolume::Destroy(VkDevice device, void* /*vmaAllocator*/)
+	{
+		if (device != VK_NULL_HANDLE)
+		{
+			if (m_irradianceView != VK_NULL_HANDLE)
+				vkDestroyImageView(device, m_irradianceView, nullptr);
+			if (m_visibilityView != VK_NULL_HANDLE)
+				vkDestroyImageView(device, m_visibilityView, nullptr);
+			if (m_irradianceImage != VK_NULL_HANDLE)
+				vkDestroyImage(device, m_irradianceImage, nullptr);
+			if (m_visibilityImage != VK_NULL_HANDLE)
+				vkDestroyImage(device, m_visibilityImage, nullptr);
+			if (m_irradianceMemory != VK_NULL_HANDLE)
+				vkFreeMemory(device, m_irradianceMemory, nullptr);
+			if (m_visibilityMemory != VK_NULL_HANDLE)
+				vkFreeMemory(device, m_visibilityMemory, nullptr);
+		}
+
+		m_irradianceView = VK_NULL_HANDLE;
+		m_visibilityView = VK_NULL_HANDLE;
+		m_irradianceImage = VK_NULL_HANDLE;
+		m_visibilityImage = VK_NULL_HANDLE;
+		m_irradianceMemory = VK_NULL_HANDLE;
+		m_visibilityMemory = VK_NULL_HANDLE;
+		m_allocated = false;
+	}
+} // namespace engine::render::gi

--- a/src/client/render/gi/DdgiVolume.h
+++ b/src/client/render/gi/DdgiVolume.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
+#include <string>
+
+namespace engine::render::gi
+{
+	/// Configuration d'une grille DDGI (Dynamic Diffuse Global Illumination).
+	///
+	/// La grille est un pavage régulier de sondes (probes) dans le monde. Chaque
+	/// sonde stocke une irradiance encodée en projection octaédrique (irradianceTexels²)
+	/// et une visibilité/profondeur (visibilityTexels²). M45.6 ne fait que décrire
+	/// la STRUCTURE : aucune sonde n'est rendue, aucune ressource GPU n'est allouée
+	/// tant que l'utilisateur ne l'active pas explicitement (gating côté Engine).
+	struct DdgiGridConfig
+	{
+		float origin[3]{ 0.0f, 0.0f, 0.0f }; ///< Origine monde de la sonde (0,0,0), en mètres.
+		float spacing[3]{ 2.0f, 2.0f, 2.0f }; ///< Espacement entre sondes par axe, en mètres.
+		uint32_t counts[3]{ 8u, 8u, 4u }; ///< Nombre de sondes par axe (X, Y, Z).
+		uint32_t irradianceTexels{ 8u }; ///< Résolution octaédrique d'irradiance par sonde (côté, hors bordure).
+		uint32_t visibilityTexels{ 16u }; ///< Résolution octaédrique de visibilité par sonde (côté, hors bordure).
+	};
+
+	/// Structure et ressources d'un volume DDGI.
+	///
+	/// PHASE 1 (M45.6) : la classe fournit toute la math d'indexation et de layout
+	/// d'atlas (méthodes CPU pures, testables sans device Vulkan) ainsi qu'une
+	/// allocation de ressources GPU persistantes (Allocate/Destroy) qui n'est JAMAIS
+	/// appelée par défaut. Aucune passe de rendu, aucun shader, aucun usage VRAM avec
+	/// la configuration par défaut.
+	///
+	/// PACKING D'ATLAS (figé, réutilisé par M45.7) :
+	/// Chaque sonde occupe une tuile carrée de (texels + 2) pixels : 1 pixel de bordure
+	/// de chaque côté pour permettre un filtrage bilinéaire correct au bord octaédrique.
+	/// Les tuiles sont disposées en grille 2D :
+	///   - AtlasCols = counts[0] * counts[2]  (le plan XZ « déplié » sur une ligne)
+	///   - AtlasRows = counts[1]              (un étage vertical par rangée)
+	/// La colonne d'une sonde d'indice (ix, iy, iz) est col = ix + iz * counts[0],
+	/// sa rangée est row = iy. L'origine pixel de sa tuile est donc
+	/// (col * tileSize, row * tileSize). Ce mapping est déterministe et identique
+	/// pour l'atlas d'irradiance et de visibilité (seul tileSize diffère).
+	class DdgiVolume
+	{
+	public:
+		DdgiVolume() = default;
+		DdgiVolume(const DdgiVolume&) = delete;
+		DdgiVolume& operator=(const DdgiVolume&) = delete;
+
+		// --- Configuration (CPU pur) ---
+
+		/// Renvoie la configuration courante de la grille.
+		const DdgiGridConfig& Config() const { return m_config; }
+
+		/// Remplace la configuration de la grille. N'alloue rien : à appeler avant Allocate.
+		void SetConfig(const DdgiGridConfig& config) { m_config = config; }
+
+		// --- Indexation des sondes (CPU pur) ---
+
+		/// Nombre total de sondes = counts[0] * counts[1] * counts[2].
+		uint32_t ProbeCount() const;
+
+		/// Indice linéaire d'une sonde à partir de ses coordonnées de grille.
+		/// Ordre : X varie le plus vite, puis Y, puis Z.
+		uint32_t ProbeIndex(uint32_t ix, uint32_t iy, uint32_t iz) const;
+
+		/// Inverse de ProbeIndex : retrouve (ix, iy, iz) depuis l'indice linéaire.
+		void GridCoord(uint32_t index, uint32_t& ix, uint32_t& iy, uint32_t& iz) const;
+
+		/// Position monde du centre d'une sonde = origin + i * spacing par axe (mètres).
+		void ProbeWorldPos(uint32_t ix, uint32_t iy, uint32_t iz, float& x, float& y, float& z) const;
+
+		// --- Layout d'atlas (CPU pur, cf. PACKING D'ATLAS ci-dessus) ---
+
+		/// Côté en pixels d'une tuile d'irradiance = irradianceTexels + 2 (bordure 1px).
+		uint32_t IrradianceTileSize() const { return m_config.irradianceTexels + 2u; }
+
+		/// Côté en pixels d'une tuile de visibilité = visibilityTexels + 2 (bordure 1px).
+		uint32_t VisibilityTileSize() const { return m_config.visibilityTexels + 2u; }
+
+		/// Nombre de colonnes de tuiles dans l'atlas = counts[0] * counts[2] (plan XZ déplié).
+		uint32_t AtlasCols() const { return m_config.counts[0] * m_config.counts[2]; }
+
+		/// Nombre de rangées de tuiles dans l'atlas = counts[1] (un étage par rangée).
+		uint32_t AtlasRows() const { return m_config.counts[1]; }
+
+		/// Largeur en pixels de l'atlas d'irradiance = AtlasCols * IrradianceTileSize.
+		uint32_t IrradianceAtlasWidth() const { return AtlasCols() * IrradianceTileSize(); }
+
+		/// Hauteur en pixels de l'atlas d'irradiance = AtlasRows * IrradianceTileSize.
+		uint32_t IrradianceAtlasHeight() const { return AtlasRows() * IrradianceTileSize(); }
+
+		/// Largeur en pixels de l'atlas de visibilité = AtlasCols * VisibilityTileSize.
+		uint32_t VisibilityAtlasWidth() const { return AtlasCols() * VisibilityTileSize(); }
+
+		/// Hauteur en pixels de l'atlas de visibilité = AtlasRows * VisibilityTileSize.
+		uint32_t VisibilityAtlasHeight() const { return AtlasRows() * VisibilityTileSize(); }
+
+		/// Origine pixel (coin haut-gauche) de la tuile d'une sonde dans l'atlas.
+		/// \param probeIndex indice linéaire de la sonde (cf. ProbeIndex).
+		/// \param tileSize côté de tuile à utiliser (IrradianceTileSize ou VisibilityTileSize).
+		/// \param px [out] colonne pixel de l'origine de la tuile.
+		/// \param py [out] rangée pixel de l'origine de la tuile.
+		void ProbeAtlasTileOrigin(uint32_t probeIndex, uint32_t tileSize, uint32_t& px, uint32_t& py) const;
+
+		// --- Ressources GPU (NON appelées par défaut, gated côté Engine) ---
+
+		/// Alloue les 2 images persistantes (irradiance R16G16B16A16_SFLOAT, visibilité
+		/// R16G16_SFLOAT) + leurs vues, dimensionnées sur les atlas ci-dessus.
+		/// Usage STORAGE | SAMPLED. Mémoire device-local via vkAllocateMemory (miroir du
+		/// pattern d'image persistante de HiZPyramidPass — pas de dépendance VMA requise).
+		/// Logue la VRAM estimée. En cas d'échec, nettoie tout et renseigne `err`.
+		/// \param vmaAllocator inutilisé en phase 1 (pattern vkAllocateMemory) ; réservé.
+		/// \return true si les deux images + vues sont prêtes.
+		/// \note NE PAS appeler depuis un chemin de rendu ; réservé à un boot gated (gi.ddgi.enabled).
+		bool Allocate(VkDevice device, VkPhysicalDevice phys, void* vmaAllocator, std::string& err);
+
+		/// Libère les images, mémoires et vues. Sûr même si rien n'est alloué.
+		/// \param vmaAllocator inutilisé en phase 1 ; réservé pour symétrie avec Allocate.
+		void Destroy(VkDevice device, void* vmaAllocator);
+
+		/// Vue de l'atlas d'irradiance (VK_NULL_HANDLE si non alloué).
+		VkImageView IrradianceView() const { return m_irradianceView; }
+
+		/// Vue de l'atlas de visibilité (VK_NULL_HANDLE si non alloué).
+		VkImageView VisibilityView() const { return m_visibilityView; }
+
+		/// true si Allocate a réussi et que les ressources GPU sont vivantes.
+		bool IsAllocated() const { return m_allocated; }
+
+	private:
+		/// Crée une VkImage 2D device-local + mémoire (pattern vkCreateImage/vkAllocateMemory).
+		/// \param format format de l'image (ex. R16G16B16A16_SFLOAT).
+		/// \param outImage [out] image créée. \param outMemory [out] mémoire liée.
+		/// \return false (et nettoie) si une étape Vulkan échoue.
+		bool CreateImage(VkDevice device, VkPhysicalDevice phys,
+			uint32_t width, uint32_t height, VkFormat format,
+			VkImage& outImage, VkDeviceMemory& outMemory, std::string& err) const;
+
+		/// Crée une vue 2D couleur, mip 0, layer 0 sur `image` au format `format`.
+		VkImageView CreateView(VkDevice device, VkImage image, VkFormat format) const;
+
+		DdgiGridConfig m_config{};
+
+		VkImage m_irradianceImage = VK_NULL_HANDLE;
+		VkDeviceMemory m_irradianceMemory = VK_NULL_HANDLE;
+		VkImageView m_irradianceView = VK_NULL_HANDLE;
+
+		VkImage m_visibilityImage = VK_NULL_HANDLE;
+		VkDeviceMemory m_visibilityMemory = VK_NULL_HANDLE;
+		VkImageView m_visibilityView = VK_NULL_HANDLE;
+
+		bool m_allocated = false;
+	};
+} // namespace engine::render::gi

--- a/src/client/render/gi/tests/DdgiVolumeTests.cpp
+++ b/src/client/render/gi/tests/DdgiVolumeTests.cpp
@@ -1,0 +1,203 @@
+/**
+ * M45.6 : tests unitaires CPU PURS pour la structure DDGI (DdgiVolume).
+ * Aucune dépendance Vulkan runtime : on n'appelle QUE les méthodes CPU
+ * (indexation, positions monde, layout d'atlas). Jamais Allocate/Destroy.
+ *
+ * Convention identique à ProtocolV1Tests.cpp : main() renvoie 0 si tout passe,
+ * non-zero (+ message sur stderr) au premier échec.
+ */
+
+#include "src/client/render/gi/DdgiVolume.h"
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+	static int s_failCount = 0;
+
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+
+	template<typename T>
+	void AssertEq(T a, T b, const char* msg)
+	{
+		if (a != b)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << " (attendu " << static_cast<uint64_t>(b)
+				<< " obtenu " << static_cast<uint64_t>(a) << ")" << std::endl;
+		}
+	}
+}
+
+using engine::render::gi::DdgiGridConfig;
+using engine::render::gi::DdgiVolume;
+
+static bool TestProbeCount()
+{
+	DdgiVolume vol; // config par défaut 8x8x4
+	AssertEq(vol.ProbeCount(), 8u * 8u * 4u, "ProbeCount defaut");
+
+	DdgiGridConfig cfg;
+	cfg.counts[0] = 5u;
+	cfg.counts[1] = 3u;
+	cfg.counts[2] = 7u;
+	vol.SetConfig(cfg);
+	AssertEq(vol.ProbeCount(), 5u * 3u * 7u, "ProbeCount custom");
+	return s_failCount == 0;
+}
+
+static bool TestIndexRoundTrip()
+{
+	DdgiVolume vol;
+	DdgiGridConfig cfg;
+	cfg.counts[0] = 6u;
+	cfg.counts[1] = 4u;
+	cfg.counts[2] = 5u;
+	vol.SetConfig(cfg);
+
+	// Round-trip ProbeIndex <-> GridCoord sur quelques triplets.
+	const uint32_t samples[][3] = {
+		{ 0u, 0u, 0u },
+		{ 5u, 3u, 4u },
+		{ 1u, 2u, 3u },
+		{ 3u, 0u, 4u },
+		{ 0u, 3u, 0u },
+	};
+	for (const auto& s : samples)
+	{
+		const uint32_t idx = vol.ProbeIndex(s[0], s[1], s[2]);
+		uint32_t ix = 99u, iy = 99u, iz = 99u;
+		vol.GridCoord(idx, ix, iy, iz);
+		AssertEq(ix, s[0], "round-trip ix");
+		AssertEq(iy, s[1], "round-trip iy");
+		AssertEq(iz, s[2], "round-trip iz");
+	}
+
+	// Round-trip exhaustif sur tout l'espace + indices uniques et bornés.
+	std::vector<uint8_t> seen(vol.ProbeCount(), 0u);
+	for (uint32_t iz = 0; iz < cfg.counts[2]; ++iz)
+		for (uint32_t iy = 0; iy < cfg.counts[1]; ++iy)
+			for (uint32_t ix = 0; ix < cfg.counts[0]; ++ix)
+			{
+				const uint32_t idx = vol.ProbeIndex(ix, iy, iz);
+				Assert(idx < vol.ProbeCount(), "index dans les bornes");
+				Assert(seen[idx] == 0u, "index unique");
+				seen[idx] = 1u;
+				uint32_t rx = 0u, ry = 0u, rz = 0u;
+				vol.GridCoord(idx, rx, ry, rz);
+				Assert(rx == ix && ry == iy && rz == iz, "round-trip exhaustif");
+			}
+	return s_failCount == 0;
+}
+
+static bool TestWorldPos()
+{
+	DdgiVolume vol;
+	DdgiGridConfig cfg;
+	cfg.origin[0] = 10.0f; cfg.origin[1] = -5.0f; cfg.origin[2] = 2.0f;
+	cfg.spacing[0] = 2.0f; cfg.spacing[1] = 3.0f; cfg.spacing[2] = 4.0f;
+	cfg.counts[0] = 8u; cfg.counts[1] = 8u; cfg.counts[2] = 4u;
+	vol.SetConfig(cfg);
+
+	float x = 0.f, y = 0.f, z = 0.f;
+	// Coin origine.
+	vol.ProbeWorldPos(0u, 0u, 0u, x, y, z);
+	Assert(x == 10.0f && y == -5.0f && z == 2.0f, "ProbeWorldPos origine");
+
+	// Coin opposé : origin + (counts-1) * spacing.
+	vol.ProbeWorldPos(cfg.counts[0] - 1u, cfg.counts[1] - 1u, cfg.counts[2] - 1u, x, y, z);
+	const float ex = 10.0f + 7.0f * 2.0f;   // 24
+	const float ey = -5.0f + 7.0f * 3.0f;   // 16
+	const float ez = 2.0f + 3.0f * 4.0f;    // 14
+	Assert(x == ex && y == ey && z == ez, "ProbeWorldPos coin oppose");
+	return s_failCount == 0;
+}
+
+static bool TestAtlasDimensions()
+{
+	DdgiVolume vol; // 8x8x4, irr=8, vis=16
+	AssertEq(vol.IrradianceTileSize(), 8u + 2u, "IrradianceTileSize = texels+2");
+	AssertEq(vol.VisibilityTileSize(), 16u + 2u, "VisibilityTileSize = texels+2");
+	AssertEq(vol.AtlasCols(), 8u * 4u, "AtlasCols = counts[0]*counts[2]");
+	AssertEq(vol.AtlasRows(), 8u, "AtlasRows = counts[1]");
+
+	// width = AtlasCols * tileSize ; height = AtlasRows * tileSize.
+	AssertEq(vol.IrradianceAtlasWidth(), vol.AtlasCols() * vol.IrradianceTileSize(), "IrradianceAtlasWidth");
+	AssertEq(vol.IrradianceAtlasHeight(), vol.AtlasRows() * vol.IrradianceTileSize(), "IrradianceAtlasHeight");
+	AssertEq(vol.VisibilityAtlasWidth(), vol.AtlasCols() * vol.VisibilityTileSize(), "VisibilityAtlasWidth");
+	AssertEq(vol.VisibilityAtlasHeight(), vol.AtlasRows() * vol.VisibilityTileSize(), "VisibilityAtlasHeight");
+	return s_failCount == 0;
+}
+
+static bool TestAtlasTileOrigins()
+{
+	DdgiVolume vol;
+	DdgiGridConfig cfg; // garde irr/vis par défaut, change la grille
+	cfg.counts[0] = 6u; cfg.counts[1] = 5u; cfg.counts[2] = 3u;
+	cfg.irradianceTexels = 8u;
+	cfg.visibilityTexels = 16u;
+	vol.SetConfig(cfg);
+
+	// Pour chaque sonde : tuile dans les bornes + unicité (irradiance et visibilité).
+	const uint32_t irrTile = vol.IrradianceTileSize();
+	const uint32_t irrW = vol.IrradianceAtlasWidth();
+	const uint32_t irrH = vol.IrradianceAtlasHeight();
+	const uint32_t visTile = vol.VisibilityTileSize();
+	const uint32_t visW = vol.VisibilityAtlasWidth();
+	const uint32_t visH = vol.VisibilityAtlasHeight();
+
+	std::vector<uint64_t> irrOrigins;
+	std::vector<uint64_t> visOrigins;
+	irrOrigins.reserve(vol.ProbeCount());
+	visOrigins.reserve(vol.ProbeCount());
+
+	for (uint32_t p = 0; p < vol.ProbeCount(); ++p)
+	{
+		uint32_t px = 0u, py = 0u;
+		vol.ProbeAtlasTileOrigin(p, irrTile, px, py);
+		Assert(px + irrTile <= irrW, "tuile irradiance dans largeur");
+		Assert(py + irrTile <= irrH, "tuile irradiance dans hauteur");
+		Assert((px % irrTile) == 0u && (py % irrTile) == 0u, "origine irradiance alignee tuile");
+		irrOrigins.push_back((static_cast<uint64_t>(px) << 32) | py);
+
+		uint32_t vx = 0u, vy = 0u;
+		vol.ProbeAtlasTileOrigin(p, visTile, vx, vy);
+		Assert(vx + visTile <= visW, "tuile visibilite dans largeur");
+		Assert(vy + visTile <= visH, "tuile visibilite dans hauteur");
+		visOrigins.push_back((static_cast<uint64_t>(vx) << 32) | vy);
+	}
+
+	// Unicité des origines (chaque sonde occupe une tuile distincte).
+	for (size_t i = 0; i < irrOrigins.size(); ++i)
+		for (size_t j = i + 1; j < irrOrigins.size(); ++j)
+		{
+			Assert(irrOrigins[i] != irrOrigins[j], "origines irradiance uniques");
+			Assert(visOrigins[i] != visOrigins[j], "origines visibilite uniques");
+		}
+	return s_failCount == 0;
+}
+
+int main()
+{
+	TestProbeCount();
+	TestIndexRoundTrip();
+	TestWorldPos();
+	TestAtlasDimensions();
+	TestAtlasTileOrigins();
+	if (s_failCount != 0)
+	{
+		std::cerr << "Total echecs : " << s_failCount << std::endl;
+		return 1;
+	}
+	std::cout << "DdgiVolume tests : tout est passe." << std::endl;
+	return 0;
+}


### PR DESCRIPTION
## M45.6 — Structure DDGI, phase 1 (cluster M45)

> Ticket **volontairement invisible** : pose la fondation DDGI **sans aucun rendu**. Indépendant de #792 (M45.5). À merger **avant M45.7**.

### Ce que ça fait (et ne fait pas)
Crée la structure de données DDGI (grille de sondes + indexation + layout d'atlas octaédrique) et une allocation GPU persistante **gated**. **Aucune passe** ajoutée au frame graph, **aucun shader**, **aucune modif** de `ProbeData`/`LightingPass`. Avec `gi.ddgi.enabled=false` (défaut) → **rien n'est alloué, rendu strictement inchangé**.

### Contenu
- `src/client/render/gi/DdgiVolume.{h,cpp}` — config grille (origin/spacing/counts), indexation **CPU pure** (`ProbeIndex`/`GridCoord`/`ProbeWorldPos`), **layout d'atlas figé et documenté** (réutilisé par M45.7 : `col=ix+iz*counts[0]`, `row=iy`, tuile=`texels+2`), + `Allocate`/`Destroy` GPU persistant (vkCreateImage+vkAllocateMemory device-local, calqué sur `HiZPyramidPass`) **non appelé par défaut**.
- `src/client/render/gi/tests/DdgiVolumeTests.cpp` — **tests CPU purs** (pas de device Vulkan) : round-trip index↔coord exhaustif + unicité, world pos, dimensions/bornes/unicité des tuiles. Tournent dans **ctest (build-linux)**.
- `CMakeLists.txt` — `DdgiVolume.cpp` dans `engine_core` + cible `ddgi_volume_tests` (`add_test`).
- `config.json` — bloc `gi.ddgi` (`enabled=false` → aucune allocation).

### Non-régression
Zéro passe, zéro shader, `ProbeData`/`LightingPass` intacts. Allocation gated default-off → 0 VRAM, 0 changement. Le nouveau test s'ajoute sans toucher aux anciens.

### Note
L'intégration Engine (allocation au boot) est **optionnelle au ticket** et non faite ici : la structure + tests + config gated suffisent à la phase 1 ; **M45.7** branchera l'allocation et l'usage runtime.

### Déploiement
✅ **100% client.** Aucun redéploiement serveur (la clé `gi` est lue côté client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)