### PR TITLE
feat(render): M45.7 — DDGI runtime (injection sky/soleil + hook lighting, gated off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ add_library(engine_core
   src/client/render/HiZPyramidPass.cpp
   src/client/render/LightingPass.cpp
   src/client/render/gi/DdgiVolume.cpp
+  src/client/render/gi/DdgiUpdatePass.cpp
   src/client/render/VolumetricFogPass.cpp
   src/client/render/DepthOfFieldPass.cpp
   src/client/render/ImpostorPass.cpp

--- a/config.json
+++ b/config.json
@@ -616,14 +616,16 @@
         }
     },
     "gi": {
-        "_comment_gi": "DDGI phase 1 (M45.6) — structure seulement. DESACTIVE (enabled=false) => aucune allocation GPU, aucun rendu, usage VRAM strictement inchange. Les ressources persistantes (atlas irradiance/visibilite) ne s'allouent que si enabled=true (reserve M45.7). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px).",
+        "_comment_gi": "DDGI phase 2 (M45.7) — injection + propagation runtime. DESACTIVE (enabled=false, DEFAUT) => aucune allocation GPU, passe DDGI_Update NON enregistree, LightingPass useDdgi=0 => rendu STRICTEMENT identique au chemin probes statiques. enabled=true alloue l'atlas irradiance et active la passe compute ddgi_update (ciel/soleil dynamique par sonde, base conservatrice SANS rebonds — pas de RT/voxelisation). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px). hysteresis = blend temporel [0..1] (eleve = lent/stable), intensity = facteur du terme indirect DDGI dans le lighting.",
         "ddgi": {
             "enabled": false,
             "origin_m": [0, 0, 0],
             "spacing_m": [2, 2, 2],
             "counts": [8, 8, 4],
             "irradiance_texels": 8,
-            "visibility_texels": 16
+            "visibility_texels": 16,
+            "hysteresis": 0.95,
+            "intensity": 1.0
         }
     }
 }

--- a/game/data/shaders/ddgi_update.comp
+++ b/game/data/shaders/ddgi_update.comp
@@ -1,0 +1,143 @@
+#version 450
+
+// M45.7 — Mise à jour runtime de l'atlas d'irradiance DDGI (GI dynamique phase 2).
+//
+// PORTÉE v1 ASSUMÉE (conservatrice — PAS de DDGI à rebonds) : le moteur n'a NI
+// ray tracing NI voxelisation. Ce shader N'ÉCHANTILLONNE PAS la géométrie de la
+// scène. Pour chaque texel octaédrique de chaque sonde, la radiance entrante est
+// composée de :
+//   - le CIEL : gradient procédural horizon (skyColor) -> zénith, fonction de dir.y ;
+//   - le SOLEIL : sunColor * max(dot(dir, sunDir), 0) ;
+//   - une occlusion soleil GROSSIÈRE : on projette le CENTRE de la sonde dans la
+//     shadow map cascade 0 ; si la sonde est en ombre, on atténue le terme soleil.
+// Le résultat est combiné temporellement avec l'irradiance précédente (hysteresis).
+//
+// WRITER UNIQUE : ce shader est le seul écrivain de l'atlas d'irradiance.
+// Le LightingPass est lecteur seul.
+//
+// Décodage octaédrique : MÊME convention que tools/impostor_builder/OctahedralMap.h
+// (OctaToDir, Cigolle et al. 2014). Toute divergence casserait l'échantillonnage
+// côté lighting.frag.
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+layout(binding = 0, rgba16f) uniform image2D uIrradiance; // atlas irradiance (storage)
+layout(binding = 1) uniform sampler2D uShadow;            // shadow map cascade 0 (depth)
+
+// Push constants — DOIT rester aligné sur DdgiUpdatePass::DdgiUpdateParams (C++).
+layout(push_constant) uniform PC
+{
+    vec4  gridOrigin;  // xyz = origine monde sonde (0,0,0) en mètres ; w inutilisé
+    vec4  gridSpacing; // xyz = espacement par axe (mètres) ; w inutilisé
+    uvec4 counts;      // xyz = nb sondes par axe ; w = irradianceTexels (côté hors bordure)
+    vec4  sunDir;      // xyz = direction NORMALISÉE vers le soleil ; w inutilisé
+    vec4  sunColor;    // xyz = couleur/intensité soleil ; w inutilisé
+    vec4  skyColor;    // xyz = couleur horizon du ciel ; w inutilisé
+    vec4  params;      // x = hysteresis [0..1], y = atlasCols, z = tileSize (texels+2), w inutilisé
+    // sunViewProj n'est PAS passée : l'occlusion soleil v1 reste grossière (cf. note).
+} pc;
+
+// Décodage octaédrique (u,v) ∈ [0,1]² -> direction unitaire.
+// Réplique EXACTE de tools/impostor_builder/OctahedralMap.h::OctaToDir.
+vec3 octaToDir(vec2 uv)
+{
+    float px = 2.0 * uv.x - 1.0;
+    float py = 2.0 * uv.y - 1.0;
+
+    float x = px;
+    float y = py;
+    float z = 1.0 - abs(px) - abs(py);
+
+    if (z < 0.0)
+    {
+        float oldX = x;
+        float signX = (x >= 0.0) ? 1.0 : -1.0;
+        float signY = (y >= 0.0) ? 1.0 : -1.0;
+        x = (1.0 - abs(y)) * signX;
+        y = (1.0 - abs(oldX)) * signY;
+    }
+
+    float len = sqrt(x * x + y * y + z * z);
+    if (len > 1e-8) { x /= len; y /= len; z /= len; }
+    return vec3(x, y, z);
+}
+
+void main()
+{
+    ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
+
+    uint irradianceTexels = counts.w;           // côté octaédrique hors bordure
+    uint tileSize = uint(pc.params.z);           // = irradianceTexels + 2 (bordure 1px)
+    uint atlasCols = uint(pc.params.y);          // = counts.x * counts.z
+    if (tileSize == 0u || irradianceTexels == 0u || atlasCols == 0u)
+        return;
+
+    uint atlasRows = counts.y;                   // = un étage vertical par rangée
+    uint atlasW = atlasCols * tileSize;
+    uint atlasH = atlasRows * tileSize;
+
+    // 1) Hors de l'atlas -> rien à faire.
+    if (uint(texel.x) >= atlasW || uint(texel.y) >= atlasH)
+        return;
+
+    // 2) Sonde (col,row) et texel local dans la tuile.
+    uint col = uint(texel.x) / tileSize;
+    uint row = uint(texel.y) / tileSize;
+    uint lx = uint(texel.x) - col * tileSize;    // [0, tileSize-1]
+    uint ly = uint(texel.y) - row * tileSize;
+
+    // Bordure 1px : on ne calcule que l'intérieur [1, tileSize-2].
+    // Les pixels de bordure restent inchangés (filtrage géré côté lecture en v1).
+    if (lx == 0u || ly == 0u || lx >= tileSize - 1u || ly >= tileSize - 1u)
+        return;
+
+    // 3) Direction octaédrique : centre du texel intérieur (lx-1, ly-1) sur N=irradianceTexels.
+    float u = (float(lx) - 1.0 + 0.5) / float(irradianceTexels);
+    float v = (float(ly) - 1.0 + 0.5) / float(irradianceTexels);
+    vec3 dir = octaToDir(vec2(u, v));
+
+    // Reconstruction des indices de grille de la sonde (cf. packing M45.6) :
+    //   col = ix + iz * counts.x ; row = iy.
+    uint ix = (counts.x != 0u) ? (col % counts.x) : 0u;
+    uint iz = (counts.x != 0u) ? (col / counts.x) : 0u;
+    uint iy = row;
+
+    // 4) Radiance entrante : ciel (gradient horizon->zénith) + soleil.
+    //    Gradient ciel : t = composante verticale de la direction remappée [0..1].
+    float skyT = clamp(dir.y * 0.5 + 0.5, 0.0, 1.0);
+    // Le zénith est ~1.3x l'horizon : ciel légèrement plus lumineux vers le haut.
+    vec3 sky = pc.skyColor.rgb * mix(1.0, 1.3, skyT);
+
+    // Soleil : lobe diffus simple (cosinus) dans la direction du soleil.
+    float sunDot = max(dot(dir, normalize(pc.sunDir.xyz)), 0.0);
+    vec3 sun = pc.sunColor.rgb * sunDot;
+
+    // 5) Occlusion soleil GROSSIÈRE via shadow map cascade 0 au CENTRE de la sonde.
+    //    NOTE v1 : on n'a pas la matrice sunViewProj en push constants (budget), on
+    //    se contente d'un échantillon central de la shadow map. Faute de projection
+    //    exacte, on utilise une heuristique conservatrice : la profondeur centrale
+    //    de la cascade 0 sert d'indicateur global d'ombrage. Le suivi (M45.8)
+    //    branchera la vraie projection par sonde. On lit le texel central (0.5,0.5)
+    //    pour rester déterministe et borné.
+    float shadowDepth = texture(uShadow, vec2(0.5, 0.5)).r;
+    // Atténuation douce : si la zone centrale est fortement occultée (depth faible),
+    // on réduit légèrement le soleil. Heuristique bornée pour ne pas surcorriger.
+    float sunVisibility = mix(0.6, 1.0, clamp(shadowDepth, 0.0, 1.0));
+    sun *= sunVisibility;
+
+    vec3 radiance = sky + sun;
+    // Borne anti-NaN / anti-débordement (atlas RGBA16F).
+    radiance = clamp(radiance, vec3(0.0), vec3(64.0));
+    if (any(isnan(radiance)) || any(isinf(radiance)))
+        radiance = vec3(0.0);
+
+    // 6) Blend temporel : hysteresis élevé = lent/stable.
+    float hysteresis = clamp(pc.params.x, 0.0, 0.999);
+    vec3 prev = imageLoad(uIrradiance, texel).rgb;
+    if (any(isnan(prev)) || any(isinf(prev)))
+        prev = radiance;
+    vec3 outRgb = mix(radiance, prev, hysteresis);
+    outRgb = clamp(outRgb, vec3(0.0), vec3(64.0));
+
+    imageStore(uIrradiance, texel, vec4(outRgb, 1.0));
+}

--- a/game/data/shaders/ddgi_update.comp
+++ b/game/data/shaders/ddgi_update.comp
@@ -66,13 +66,13 @@ void main()
 {
     ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
 
-    uint irradianceTexels = counts.w;           // côté octaédrique hors bordure
+    uint irradianceTexels = pc.counts.w;        // côté octaédrique hors bordure
     uint tileSize = uint(pc.params.z);           // = irradianceTexels + 2 (bordure 1px)
     uint atlasCols = uint(pc.params.y);          // = counts.x * counts.z
     if (tileSize == 0u || irradianceTexels == 0u || atlasCols == 0u)
         return;
 
-    uint atlasRows = counts.y;                   // = un étage vertical par rangée
+    uint atlasRows = pc.counts.y;                // = un étage vertical par rangée
     uint atlasW = atlasCols * tileSize;
     uint atlasH = atlasRows * tileSize;
 
@@ -98,8 +98,8 @@ void main()
 
     // Reconstruction des indices de grille de la sonde (cf. packing M45.6) :
     //   col = ix + iz * counts.x ; row = iy.
-    uint ix = (counts.x != 0u) ? (col % counts.x) : 0u;
-    uint iz = (counts.x != 0u) ? (col / counts.x) : 0u;
+    uint ix = (pc.counts.x != 0u) ? (col % pc.counts.x) : 0u;
+    uint iz = (pc.counts.x != 0u) ? (col / pc.counts.x) : 0u;
     uint iy = row;
 
     // 4) Radiance entrante : ciel (gradient horizon->zénith) + soleil.

--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -10,11 +10,14 @@
 //   (M05.4)  binding 4 – irradiance cubemap, 5 – prefiltered specular cubemap, 6 – BRDF LUT
 //   (M06.4)  binding 7 – SSAO_Blur (R16F, .r = screen-space AO)
 //   (M17.3)  binding 8 – DecalOverlay (RGBA, rgb = decal albedo, a = blend)
+//   (M45.7)  binding 9 – DDGI irradiance atlas (RGBA16F). Lu UNIQUEMENT si
+//                        useDdgi > 0.5 ; sinon binding lié à un fallback valide
+//                        mais jamais échantillonné (rendu byte-identique).
 //
 // Outputs:
 //   outSceneColorHDR (location 0) – SceneColor_HDR, R16G16B16A16_SFLOAT
 //
-// Push constants (148 bytes, fragment stage):
+// Push constants (224 bytes, fragment stage ; +80 o DDGI/pad ajoutés en M45.7):
 //   mat4  invVP         – inverse view-projection matrix
 //   vec4  cameraPos     – camera world-space position (xyz, w unused)
 //   vec4  lightDir      – normalised direction *toward* the light (xyz, w unused)
@@ -26,6 +29,12 @@
 //                         ready (alors on lit GBufferA pour la sky), 0.0
 //                         si on utilise la flat skyColor.
 //   float useIBL        – 1.0 = use IBL, 0.0 = constant ambient
+//   float useDdgi       – M45.7 : 1.0 = ajoute l'irradiance DDGI dynamique, 0.0 = inchangé
+//   vec3  pad0..2       – padding (alignement vec4)
+//   vec4  ddgiOrigin    – xyz origine monde grille (m)
+//   vec4  ddgiSpacing   – xyz espacement par axe (m)
+//   vec4  ddgiCounts    – xyz nb sondes par axe ; w = irradianceTexels
+//   vec4  ddgiAtlas     – x atlasCols, y atlasRows, z tileSize, w intensity
 //
 // M45.1 — Perspective aérienne (upgrade du brouillard de distance) :
 //   lightColor.w = aerialDensity   – densité d'extinction (1/m). <= 0 désactive.
@@ -46,6 +55,7 @@ layout(set = 0, binding = 5) uniform samplerCube prefilterMap;  // M05.4 specula
 layout(set = 0, binding = 6) uniform sampler2D   brdfLut;       // M05.4 BRDF LUT (scale, bias)
 layout(set = 0, binding = 7) uniform sampler2D   ssaoTex;       // M06.4 SSAO_Blur (R16F, .r = AO)
 layout(set = 0, binding = 8) uniform sampler2D   decalOverlayTex;
+layout(set = 0, binding = 9) uniform sampler2D   ddgiIrradiance; // M45.7 atlas irradiance DDGI (RGBA16F)
 
 // ---- Push constants ---------------------------------------------------------
 layout(push_constant) uniform PC
@@ -57,7 +67,69 @@ layout(push_constant) uniform PC
     vec4  ambientColor; // xyz = constant ambient RGB (fallback) ; w = aerialInscatter
     vec4  skyColor;     // rgb = couleur du ciel flat (fallback) ; w = 1.0 si SkyPass ready
     float useIBL;       // 1.0 = use IBL, 0.0 = constant ambient
+    // --- M45.7 — DDGI dynamique (ADDITIF). useDdgi=0 (défaut) => aucun changement.
+    // useIBL+useDdgi+pad0+pad1 = 16 o pour aligner les vec4 DDGI sur 16 (std140). ---
+    float useDdgi;      // 1.0 = ajoute l'irradiance DDGI dynamique, 0.0 = inchangé
+    float pad0;         // padding (alignement vec4)
+    float pad1;         // padding (alignement vec4)
+    vec4  ddgiOrigin;   // xyz = origine monde grille (mètres) ; w inutilisé
+    vec4  ddgiSpacing;  // xyz = espacement par axe (mètres) ; w inutilisé
+    vec4  ddgiCounts;   // xyz = nb sondes par axe ; w = irradianceTexels (côté hors bordure)
+    vec4  ddgiAtlas;    // x = atlasCols, y = atlasRows, z = tileSize (texels+2), w = intensity
 } pc;
+
+// M45.7 — Encodage octaédrique direction -> (u,v) ∈ [0,1]². Inverse de
+// OctaToDir (tools/impostor_builder/OctahedralMap.h) : MÊME convention que la
+// passe d'écriture ddgi_update.comp, sinon l'échantillonnage serait décalé.
+vec2 ddgiDirToOcta(vec3 dir)
+{
+    vec3 n = dir / max(abs(dir.x) + abs(dir.y) + abs(dir.z), 1e-8);
+    vec2 uv;
+    if (n.z >= 0.0)
+    {
+        uv = n.xy;
+    }
+    else
+    {
+        // Repli de l'hémisphère inférieur (symétrique d'OctaToDir).
+        uv = vec2((1.0 - abs(n.y)) * (n.x >= 0.0 ? 1.0 : -1.0),
+                  (1.0 - abs(n.x)) * (n.y >= 0.0 ? 1.0 : -1.0));
+    }
+    return uv * 0.5 + 0.5; // [-1,1] -> [0,1]
+}
+
+// M45.7 — Échantillonne l'irradiance DDGI pour la position monde P selon la
+// normale N. v1 : SONDE LA PLUS PROCHE (pas de trilinéaire, pas de Chebyshev
+// anti-leak — suivi M45.8). Reconstruit l'indice de grille le plus proche,
+// déplie en (col,row) selon le packing M45.6 (col = ix + iz*counts.x, row = iy),
+// encode N en octaédrique -> texel intérieur dans la tuile, échantillonne l'atlas.
+vec3 ddgiSampleNearest(vec3 P, vec3 N)
+{
+    vec3 counts = max(pc.ddgiCounts.xyz, vec3(1.0));
+    // Coords continues dans la grille puis arrondi à la sonde la plus proche.
+    vec3 gf = (P - pc.ddgiOrigin.xyz) / max(pc.ddgiSpacing.xyz, vec3(1e-4));
+    vec3 gi = clamp(floor(gf + 0.5), vec3(0.0), counts - 1.0);
+
+    float atlasCols = max(pc.ddgiAtlas.x, 1.0);
+    float atlasRows = max(pc.ddgiAtlas.y, 1.0);
+    float tileSize  = max(pc.ddgiAtlas.z, 3.0);
+    float texels    = max(pc.ddgiCounts.w, 1.0); // côté octaédrique hors bordure
+
+    // Déplie l'indice de grille en (col,row) selon le packing M45.6.
+    float col = gi.x + gi.z * counts.x;
+    float row = gi.y;
+
+    // Octa (u,v) sur N -> texel intérieur [1, tileSize-2]. On borne dans
+    // [1, texels] (la bordure 1px n'est pas mise à jour par ddgi_update.comp en v1).
+    vec2 octa  = ddgiDirToOcta(normalize(N));
+    vec2 local = clamp(vec2(1.0) + octa * texels, vec2(1.0), vec2(texels)); // décalage bordure 1px
+
+    // Coord pixel (centre du texel) dans l'atlas -> UV [0,1].
+    vec2 pixel = vec2(col * tileSize, row * tileSize) + local;
+    vec2 uv = (pixel + 0.5) / vec2(atlasCols * tileSize, atlasRows * tileSize);
+
+    return texture(ddgiIrradiance, uv).rgb;
+}
 
 // M45.1 — exposant d'anisotropie du halo directionnel d'inscattering vers le
 // soleil. Plus élevé = halo plus concentré autour du disque solaire. Constante
@@ -192,6 +264,19 @@ void main()
     else
     {
         ambient = pc.ambientColor.rgb * albedo * ao_final;
+    }
+
+    // ---- M45.7 — Terme indirect DDGI dynamique (ADDITIF, gated) --------
+    // Quand useDdgi <= 0.5 (DÉFAUT), ce bloc est entièrement sauté : le rendu
+    // est STRICTEMENT identique au chemin probes statiques (byte-identique).
+    // v1 : SONDE LA PLUS PROCHE (pas de trilinéaire ni de Chebyshev anti-leak —
+    // suivi M45.8). On échantillonne l'irradiance dynamique le long de la
+    // normale, modulée par albedo, AO et l'intensité (ddgiAtlas.w).
+    if (pc.useDdgi > 0.5)
+    {
+        vec3 ddgiIrr = ddgiSampleNearest(P, normalW);
+        ddgiIrr = clamp(ddgiIrr, vec3(0.0), vec3(64.0));
+        ambient += ddgiIrr * albedo * ao_final * pc.ddgiAtlas.w;
     }
 
     // ---- Combine & output HDR ------------------------------------------

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3969,6 +3969,51 @@ namespace engine
 									// (copie WithBloom -> Dof) pour que Tonemap lise une image valide.
 									m_dofReady = m_pipeline->GetDepthOfFieldPass().IsValid();
 
+									// M45.7 — GI dynamique DDGI. DÉSACTIVÉ par défaut : si gi.ddgi.enabled
+									// est false (cas par défaut), on n'alloue rien, on n'enregistre pas la
+									// passe DDGI_Update et le LightingPass garde useDdgi=0 => rendu
+									// strictement identique. Si tout réussit, on bascule m_ddgiEnabled=true.
+									m_ddgiEnabled = false;
+									if (m_cfg.GetBool("gi.ddgi.enabled", false))
+									{
+										engine::render::gi::DdgiGridConfig gridCfg{};
+										gridCfg.origin[0]  = static_cast<float>(m_cfg.GetDouble("gi.ddgi.origin_m[0]", 0.0));
+										gridCfg.origin[1]  = static_cast<float>(m_cfg.GetDouble("gi.ddgi.origin_m[1]", 0.0));
+										gridCfg.origin[2]  = static_cast<float>(m_cfg.GetDouble("gi.ddgi.origin_m[2]", 0.0));
+										gridCfg.spacing[0] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.spacing_m[0]", 2.0));
+										gridCfg.spacing[1] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.spacing_m[1]", 2.0));
+										gridCfg.spacing[2] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.spacing_m[2]", 2.0));
+										gridCfg.counts[0]  = static_cast<uint32_t>(m_cfg.GetInt("gi.ddgi.counts[0]", 8));
+										gridCfg.counts[1]  = static_cast<uint32_t>(m_cfg.GetInt("gi.ddgi.counts[1]", 8));
+										gridCfg.counts[2]  = static_cast<uint32_t>(m_cfg.GetInt("gi.ddgi.counts[2]", 4));
+										gridCfg.irradianceTexels = static_cast<uint32_t>(m_cfg.GetInt("gi.ddgi.irradiance_texels", 8));
+										gridCfg.visibilityTexels = static_cast<uint32_t>(m_cfg.GetInt("gi.ddgi.visibility_texels", 16));
+										m_ddgiVolume.SetConfig(gridCfg);
+
+										std::string ddgiErr;
+										if (!m_ddgiVolume.Allocate(m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(), m_vmaAllocator, ddgiErr))
+										{
+											LOG_WARN(Render, "[Engine] DDGI desactive : allocation volume KO ({}) -> fallback probes statiques", ddgiErr);
+										}
+										else
+										{
+											std::vector<uint32_t> ddgiComp = loadSpirv("shaders/ddgi_update.comp.spv");
+											if (ddgiComp.empty()
+												|| !m_ddgiUpdatePass.Init(m_vkDeviceContext.GetDevice(), m_vkDeviceContext.GetPhysicalDevice(),
+													ddgiComp.data(), ddgiComp.size(),
+													VK_NULL_HANDLE))
+											{
+												LOG_WARN(Render, "[Engine] DDGI desactive : DdgiUpdatePass init KO (shader absent ?) -> fallback probes statiques");
+												m_ddgiVolume.Destroy(m_vkDeviceContext.GetDevice(), m_vmaAllocator);
+											}
+											else
+											{
+												m_ddgiEnabled = true;
+												LOG_INFO(Render, "[Engine] DDGI runtime ACTIF (gi.ddgi.enabled=true)");
+											}
+										}
+									}
+
 									// M100 — Task 12 : Terrain Chunk Runtime — drawcall mesh-terrain par
 									// chunk avec splat 8-layer. Co-existe avec le legacy TerrainRenderer
 									// (skip strict si fichiers chunk absents). Cf.
@@ -5493,6 +5538,64 @@ namespace engine
 											LOG_WARN(Render, "[Engine] Decal pass disabled, overlay clear fallback registered");
 										}
 
+										// M45.7 — DDGI_Update : passe COMPUTE qui rafraîchit l'atlas
+										// d'irradiance du volume DDGI AVANT le LightingPass. Enregistrée
+										// UNIQUEMENT si m_ddgiEnabled (gi.ddgi.enabled=true + alloc/init OK) ;
+										// sinon le LightingPass garde useDdgi=0 et le rendu est inchangé.
+										// L'écriture de l'atlas (image persistante hors frame graph) est
+										// gérée par les barrières internes de la passe ; on déclare en READ
+										// la shadow cascade 0 pour que le FG la rende lisible (SAMPLED).
+										if (m_ddgiEnabled && m_ddgiUpdatePass.IsValid())
+										{
+											m_frameGraph.addPass("DDGI_Update",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgShadowMapIds[0], engine::render::ImageUsage::SampledRead);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													if (!m_ddgiEnabled || !m_ddgiUpdatePass.IsValid() || !m_ddgiVolume.IsAllocated())
+														return;
+													const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+													const engine::RenderState& rs = m_renderStates[readIdx];
+
+													engine::render::gi::DdgiUpdatePass::DdgiUpdateParams up{};
+													const engine::render::gi::DdgiGridConfig& gc = m_ddgiVolume.Config();
+													up.gridOrigin[0] = gc.origin[0]; up.gridOrigin[1] = gc.origin[1]; up.gridOrigin[2] = gc.origin[2];
+													up.gridSpacing[0] = gc.spacing[0]; up.gridSpacing[1] = gc.spacing[1]; up.gridSpacing[2] = gc.spacing[2];
+													up.counts[0] = gc.counts[0]; up.counts[1] = gc.counts[1]; up.counts[2] = gc.counts[2];
+													up.counts[3] = gc.irradianceTexels;
+													// Direction VERS le soleil (normalisée), couleur soleil per-zone.
+													{
+														float sx = m_zoneAtmosphere.sunDirection[0];
+														float sy = m_zoneAtmosphere.sunDirection[1];
+														float sz = m_zoneAtmosphere.sunDirection[2];
+														float sl = std::sqrt(sx*sx + sy*sy + sz*sz);
+														if (sl > 1e-6f) { sx /= sl; sy /= sl; sz /= sl; }
+														up.sunDir[0] = sx; up.sunDir[1] = sy; up.sunDir[2] = sz;
+													}
+													up.sunColor[0] = m_zoneAtmosphere.sunColor[0];
+													up.sunColor[1] = m_zoneAtmosphere.sunColor[1];
+													up.sunColor[2] = m_zoneAtmosphere.sunColor[2];
+													// Horizon du ciel piloté par DayNightCycle.
+													{
+														const engine::render::DayNightCycle::State& dn = m_dayNight.GetState();
+														up.skyColor[0] = dn.skyHorizon[0];
+														up.skyColor[1] = dn.skyHorizon[1];
+														up.skyColor[2] = dn.skyHorizon[2];
+													}
+													up.params[0] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.hysteresis", 0.95));
+													up.params[1] = static_cast<float>(m_ddgiVolume.AtlasCols());
+													up.params[2] = static_cast<float>(m_ddgiVolume.IrradianceTileSize());
+													up.params[3] = 0.0f;
+													(void)rs; // rs réservé (cascade 0 lue via le registry ci-dessous).
+
+													// Shadow cascade 0 : on lit sa vue via le registry (comme VolumetricFog).
+													VkImageView shadowView = reg.getImageView(m_fgShadowMapIds[0]);
+													m_ddgiUpdatePass.Record(
+														m_vkDeviceContext.GetDevice(), cmd, m_ddgiVolume,
+														shadowView, m_ddgiUpdatePass.GetShadowSampler(), up);
+												});
+										}
+
 										m_frameGraph.addPass("Lighting",
 											[this](engine::render::PassBuilder& b) {
 												b.read(m_fgGBufferAId,       engine::render::ImageUsage::SampledRead);
@@ -5586,6 +5689,31 @@ namespace engine
 												VkImageView brdfView      = m_pipeline->GetBrdfLutPass().GetImageView();
 												VkSampler   brdfSamp      = m_pipeline->GetBrdfLutPass().GetSampler();
 												lp.useIBL = (irrView != VK_NULL_HANDLE && prefilterView != VK_NULL_HANDLE && brdfView != VK_NULL_HANDLE) ? 1.0f : 0.0f;
+
+												// M45.7 — DDGI dynamique. Par défaut (m_ddgiEnabled=false ou volume
+												// non alloué) : useDdgi reste 0 et la vue DDGI reste VK_NULL_HANDLE
+												// (LightingPass lie alors un fallback valide mais non lu) => rendu
+												// strictement identique au chemin probes statiques.
+												VkImageView ddgiView = VK_NULL_HANDLE;
+												VkSampler   ddgiSamp = VK_NULL_HANDLE;
+												if (m_ddgiEnabled && m_ddgiVolume.IsAllocated())
+												{
+													lp.useDdgi = 1.0f;
+													const engine::render::gi::DdgiGridConfig& gc = m_ddgiVolume.Config();
+													lp.ddgiOrigin[0] = gc.origin[0]; lp.ddgiOrigin[1] = gc.origin[1]; lp.ddgiOrigin[2] = gc.origin[2];
+													lp.ddgiSpacing[0] = gc.spacing[0]; lp.ddgiSpacing[1] = gc.spacing[1]; lp.ddgiSpacing[2] = gc.spacing[2];
+													lp.ddgiCounts[0] = static_cast<float>(gc.counts[0]);
+													lp.ddgiCounts[1] = static_cast<float>(gc.counts[1]);
+													lp.ddgiCounts[2] = static_cast<float>(gc.counts[2]);
+													lp.ddgiCounts[3] = static_cast<float>(gc.irradianceTexels);
+													lp.ddgiAtlas[0] = static_cast<float>(m_ddgiVolume.AtlasCols());
+													lp.ddgiAtlas[1] = static_cast<float>(m_ddgiVolume.AtlasRows());
+													lp.ddgiAtlas[2] = static_cast<float>(m_ddgiVolume.IrradianceTileSize());
+													lp.ddgiAtlas[3] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.intensity", 1.0));
+													ddgiView = m_ddgiVolume.IrradianceView();
+													ddgiSamp = m_ddgiUpdatePass.GetShadowSampler(); // sampler linéaire-équivalent (NEAREST clamp) interne
+												}
+
 												const uint32_t frameIdx = m_currentFrame % 2;
 												m_pipeline->GetLightingPass().Record(
 													m_vkDeviceContext.GetDevice(), cmd, reg,
@@ -5593,6 +5721,7 @@ namespace engine
 													m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId, m_fgDepthId,
 													m_fgSceneColorHDRId, m_fgSsaoBlurId, m_fgDecalOverlayId,
 													irrView, irrSamp, prefilterView, prefilterSamp, brdfView, brdfSamp,
+													ddgiView, ddgiSamp,
 													lp, frameIdx);
 											});
 
@@ -6789,6 +6918,11 @@ namespace engine
 			m_currentSkinnedMesh = nullptr;
 			m_skinnedRenderer.Destroy(m_vkDeviceContext.GetDevice());
 			m_skinnedAvatarReady = false;
+			// M45.7 — libère le volume DDGI + sa passe de mise à jour (idempotent :
+			// sûr même si DDGI n'a jamais été activé/alloué).
+			m_ddgiUpdatePass.Destroy(m_vkDeviceContext.GetDevice());
+			m_ddgiVolume.Destroy(m_vkDeviceContext.GetDevice(), m_vmaAllocator);
+			m_ddgiEnabled = false;
 			if (m_pipeline)
 			{
 				m_pipeline->Destroy(m_vkDeviceContext.GetDevice());

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -53,6 +53,8 @@
 #include "src/client/render/WaterPass.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/client/render/SkyPass.h"
+#include "src/client/render/gi/DdgiVolume.h"
+#include "src/client/render/gi/DdgiUpdatePass.h"
 #include "src/client/render/WeatherSystem.h"
 #include "src/client/render/DynamicLightSystem.h"
 #include "src/client/world/water/WaterSurfaces.h"
@@ -354,6 +356,15 @@ namespace engine
 		/// M45.3 — true si DepthOfFieldPass::IsValid() au boot (passe DoF active) ;
 		/// sinon Engine enregistre un passthrough (copie WithBloom -> Dof).
 		bool m_dofReady = false;
+		/// M45.7 — GI dynamique DDGI. DÉSACTIVÉ par défaut (gi.ddgi.enabled=false) :
+		/// le volume n'est PAS alloué, la passe DDGI_Update n'est PAS enregistrée et
+		/// le LightingPass garde useDdgi=0 => rendu STRICTEMENT identique au chemin
+		/// probes statiques. Activé seulement si la config + l'allocation réussissent.
+		engine::render::gi::DdgiVolume m_ddgiVolume;
+		/// M45.7 — passe compute qui met à jour l'atlas d'irradiance du volume DDGI.
+		engine::render::gi::DdgiUpdatePass m_ddgiUpdatePass;
+		/// M45.7 — true uniquement si gi.ddgi.enabled ET allocation/init réussis.
+		bool m_ddgiEnabled = false;
 		/// SceneColor_LDR: output of the tonemap pass (R8G8B8A8_UNORM). Added in M03.4.
 		engine::render::ResourceId m_fgSceneColorLDRId   = engine::render::kInvalidResourceId;
 		/// M08.2: SceneColor_HDR + bloom (combine pass output); tonemap reads this.

--- a/src/client/render/LightingPass.cpp
+++ b/src/client/render/LightingPass.cpp
@@ -153,10 +153,10 @@ namespace engine::render
 		}
 
 		// -----------------------------------------------------------------
-		// 2. Descriptor set layout: 9 combined image samplers (GBufA/B/C, Depth, irradiance, prefilter, BRDF LUT, SSAO_Blur, DecalOverlay)
+		// 2. Descriptor set layout: 10 combined image samplers (GBufA/B/C, Depth, irradiance, prefilter, BRDF LUT, SSAO_Blur, DecalOverlay, DDGI irradiance [M45.7])
 		// -----------------------------------------------------------------
 		{
-			std::array<VkDescriptorSetLayoutBinding, 9> bindings{};
+			std::array<VkDescriptorSetLayoutBinding, 10> bindings{};
 			for (size_t i = 0; i < bindings.size(); ++i)
 			{
 				bindings[i].binding            = i;
@@ -181,12 +181,12 @@ namespace engine::render
 		}
 
 		// -----------------------------------------------------------------
-		// 3. Descriptor pool: maxFrames sets, 9 combined image samplers each
+		// 3. Descriptor pool: maxFrames sets, 10 combined image samplers each
 		// -----------------------------------------------------------------
 		{
 			VkDescriptorPoolSize poolSize{};
 			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-			poolSize.descriptorCount = 9 * m_maxFrames;
+			poolSize.descriptorCount = 10 * m_maxFrames;
 
 			VkDescriptorPoolCreateInfo poolInfo{};
 			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
@@ -266,7 +266,7 @@ namespace engine::render
 			VkPushConstantRange pushRange{};
 			pushRange.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 			pushRange.offset     = 0;
-			pushRange.size       = static_cast<uint32_t>(sizeof(LightParams)); // 148 bytes (skyColor ajouté)
+			pushRange.size       = static_cast<uint32_t>(sizeof(LightParams)); // 224 bytes (M45.7: champs DDGI ajoutés)
 
 			VkPipelineLayoutCreateInfo layoutInfo{};
 			layoutInfo.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -401,6 +401,7 @@ namespace engine::render
 		VkImageView irradianceView, VkSampler irradianceSampler,
 		VkImageView prefilterView, VkSampler prefilterSampler,
 		VkImageView brdfLutView, VkSampler brdfLutSampler,
+		VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
 		const LightParams& params, uint32_t frameIndex)
 	{
 		if (!IsValid() || extent.width == 0 || extent.height == 0)
@@ -430,13 +431,20 @@ namespace engine::render
 		if (brdfLutView == VK_NULL_HANDLE) { brdfLutView = viewA; brdfLutSampler = m_sampler; }
 		if (irrView == VK_NULL_HANDLE) { irrView = viewA; irrSamp = m_sampler; }
 
+		// M45.7 — binding 9 (DDGI). Quand l'atlas DDGI est absent (chemin par
+		// défaut, useDdgi=0), on lie un fallback valide (GBufferA + m_sampler) pour
+		// garder le descriptor set valide. Le shader ne le lit JAMAIS dans ce cas
+		// (gate `if (pc.useDdgi > 0.5)`), garantissant un rendu byte-identique.
+		if (ddgiIrradianceView == VK_NULL_HANDLE) { ddgiIrradianceView = viewA; ddgiSampler = m_sampler; }
+		if (ddgiSampler == VK_NULL_HANDLE) { ddgiSampler = m_sampler; }
+
 		// ------------------------------------------------------------------
 		// Update descriptor set for this frame with GBuffer + IBL views.
 		// ------------------------------------------------------------------
 		const uint32_t setIdx = frameIndex % m_maxFrames;
 		VkDescriptorSet ds = m_descriptorSets[setIdx];
 
-		std::array<VkDescriptorImageInfo, 9> imageInfos{};
+		std::array<VkDescriptorImageInfo, 10> imageInfos{};
 		imageInfos[0] = { m_sampler,         viewA,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[1] = { m_sampler,         viewB,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[2] = { m_sampler,         viewC,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
@@ -446,8 +454,9 @@ namespace engine::render
 		imageInfos[6] = { brdfLutSampler,    brdfLutView,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[7] = { m_sampler,         viewSsao, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[8] = { m_sampler,         viewDecal, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[9] = { ddgiSampler,       ddgiIrradianceView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }; // M45.7 DDGI
 
-		std::array<VkWriteDescriptorSet, 9> writes{};
+		std::array<VkWriteDescriptorSet, 10> writes{};
 		for (size_t i = 0; i < writes.size(); ++i)
 		{
 			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;

--- a/src/client/render/LightingPass.h
+++ b/src/client/render/LightingPass.h
@@ -18,9 +18,10 @@ namespace engine::render
 	/// ambient fallback, and writes SceneColor_HDR (R16G16B16A16_SFLOAT). M05.4.
 	///
 	/// Pipeline: fullscreen triangle (3 vertices, no vertex buffer).
-		/// Descriptor set 0: 9 combined image samplers (GBufA, GBufB, GBufC, Depth, irradiance,
-		/// prefiltered specular, BRDF LUT, SSAO_Blur, DecalOverlay). Push constants (148 bytes): invVP, cameraPos,
-	/// lightDir, lightColor, ambientColor, skyColor, useIBL.
+		/// Descriptor set 0: 10 combined image samplers (GBufA, GBufB, GBufC, Depth, irradiance,
+		/// prefiltered specular, BRDF LUT, SSAO_Blur, DecalOverlay, DDGI irradiance [M45.7]).
+	/// Push constants (224 bytes): invVP, cameraPos, lightDir, lightColor, ambientColor, skyColor,
+	/// useIBL, puis champs DDGI (useDdgi + grille/atlas) ajoutés en M45.7.
 	class LightingPass
 	{
 	public:
@@ -36,8 +37,20 @@ namespace engine::render
 			float ambientColor[4]; ///< Constant ambient RGB (fallback when IBL absent) ; w = M45.1 aerialInscatter.
 			float skyColor[4];     ///< RGB couleur du ciel (skyHorizon DayNightCycle) pour les pixels sans géométrie. w unused.
 			float useIBL;          ///< 1.0 = use IBL (irradiance + prefilter + BRDF LUT), 0.0 = fallback.
+			// --- M45.7 — DDGI dynamique (ADDITIF). useDdgi=0 (défaut) => chemin
+			// strictement inchangé (binding 9 lié à un fallback valide mais jamais lu).
+			// useIBL + useDdgi + pad0 + pad1 = 16 octets pour que les vec4 DDGI
+			// suivants soient alignés sur 16 (règle std140 des push_constant GLSL).
+			float useDdgi;         ///< 1.0 = échantillonne l'irradiance DDGI dynamique, 0.0 = aucun changement.
+			float pad0;            ///< Padding (alignement vec4 std140).
+			float pad1;            ///< Padding (alignement vec4 std140).
+			float ddgiOrigin[4];   ///< xyz = origine monde de la grille DDGI (mètres) ; w inutilisé.
+			float ddgiSpacing[4];  ///< xyz = espacement par axe (mètres) ; w inutilisé.
+			float ddgiCounts[4];   ///< xyz = nb de sondes par axe ; w = irradianceTexels (côté hors bordure).
+			float ddgiAtlas[4];    ///< x = atlasCols, y = atlasRows, z = tileSize (texels+2), w = intensity.
 		};
-		static_assert(sizeof(LightParams) == 148, "LightParams must be exactly 148 bytes");
+		// 144 (jusqu'à skyColor) + 16 (useIBL+useDdgi+pad0+pad1) + 64 (4 vec4 DDGI) = 224.
+		static_assert(sizeof(LightParams) == 224, "LightParams must be exactly 224 bytes (144 + 16 + 64 DDGI)");
 
 		LightingPass() = default;
 		LightingPass(const LightingPass&) = delete;
@@ -64,6 +77,10 @@ namespace engine::render
 		/// \param irradianceView / irradianceSampler  Irradiance cubemap (M05.2); may be null.
 		/// \param prefilterView / prefilterSampler     Prefiltered specular cubemap (M05.3).
 		/// \param brdfLutView / brdfLutSampler         BRDF LUT 2D (M05.1).
+		/// \param ddgiIrradianceView / ddgiSampler     M45.7 — atlas d'irradiance DDGI dynamique
+		///        (binding 9). Quand ddgiIrradianceView == VK_NULL_HANDLE (défaut),
+		///        un fallback valide (GBufferA / m_sampler) est lié pour garder le
+		///        descriptor valide ; params.useDdgi=0 garantit que le shader ne le lit pas.
 		/// \param frameIndex  Current in-flight frame index (0 .. maxFrames-1).
 		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
 			ResourceId idGBufA, ResourceId idGBufB, ResourceId idGBufC, ResourceId idDepth,
@@ -71,6 +88,7 @@ namespace engine::render
 			VkImageView irradianceView, VkSampler irradianceSampler,
 			VkImageView prefilterView, VkSampler prefilterSampler,
 			VkImageView brdfLutView, VkSampler brdfLutSampler,
+			VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
 			const LightParams& params, uint32_t frameIndex);
 
 		/// Releases all Vulkan resources. Safe to call even when not initialized.

--- a/src/client/render/gi/DdgiUpdatePass.cpp
+++ b/src/client/render/gi/DdgiUpdatePass.cpp
@@ -1,0 +1,303 @@
+#include "src/client/render/gi/DdgiUpdatePass.h"
+#include "src/client/render/gi/DdgiVolume.h"
+#include "src/client/render/PipelineCache.h"
+#include "src/shared/core/Log.h"
+
+#include <vulkan/vulkan.h>
+
+namespace engine::render::gi
+{
+	namespace
+	{
+		/// Crée un VkShaderModule à partir de mots SPIR-V. Renvoie VK_NULL_HANDLE
+		/// si les arguments sont invalides ou si la création Vulkan échoue.
+		VkShaderModule CreateShaderModule(VkDevice device, const uint32_t* spirv, size_t wordCount)
+		{
+			if (device == VK_NULL_HANDLE || !spirv || wordCount == 0)
+				return VK_NULL_HANDLE;
+
+			VkShaderModuleCreateInfo createInfo{};
+			createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+			createInfo.codeSize = wordCount * sizeof(uint32_t);
+			createInfo.pCode = spirv;
+
+			VkShaderModule shaderModule = VK_NULL_HANDLE;
+			if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS)
+				return VK_NULL_HANDLE;
+			return shaderModule;
+		}
+	} // namespace anonyme
+
+	bool DdgiUpdatePass::Init(VkDevice device, VkPhysicalDevice /*phys*/,
+		const uint32_t* compSpirv, size_t compWordCount,
+		VkPipelineCache pipelineCache)
+	{
+		if (device == VK_NULL_HANDLE || !compSpirv || compWordCount == 0)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: parametres invalides");
+			return false;
+		}
+
+		// --- Descriptor set layout : 0 = storage image (irradiance), 1 = sampled (shadow cascade 0) ---
+		VkDescriptorSetLayoutBinding bindings[2]{};
+		bindings[0].binding = 0;
+		bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		bindings[0].descriptorCount = 1;
+		bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+		bindings[1].binding = 1;
+		bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		bindings[1].descriptorCount = 1;
+		bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+		VkDescriptorSetLayoutCreateInfo layoutInfo{};
+		layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+		layoutInfo.bindingCount = 2;
+		layoutInfo.pBindings = bindings;
+		if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_descriptorSetLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: descriptor set layout");
+			Destroy(device);
+			return false;
+		}
+
+		// --- Descriptor pool : 1 set (storage + sampled) ---
+		VkDescriptorPoolSize poolSizes[2]{};
+		poolSizes[0].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		poolSizes[0].descriptorCount = 1;
+		poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		poolSizes[1].descriptorCount = 1;
+
+		VkDescriptorPoolCreateInfo poolInfo{};
+		poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+		poolInfo.maxSets = 1;
+		poolInfo.poolSizeCount = 2;
+		poolInfo.pPoolSizes = poolSizes;
+		if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: descriptor pool");
+			Destroy(device);
+			return false;
+		}
+
+		VkDescriptorSetAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+		allocInfo.descriptorPool = m_descriptorPool;
+		allocInfo.descriptorSetCount = 1;
+		allocInfo.pSetLayouts = &m_descriptorSetLayout;
+		if (vkAllocateDescriptorSets(device, &allocInfo, &m_descriptorSet) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: descriptor set");
+			Destroy(device);
+			return false;
+		}
+
+		// --- Pipeline layout : push constants DdgiUpdateParams (compute) ---
+		VkPushConstantRange pushRange{};
+		pushRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+		pushRange.offset = 0;
+		pushRange.size = static_cast<uint32_t>(sizeof(DdgiUpdateParams));
+
+		VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+		pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		pipelineLayoutInfo.setLayoutCount = 1;
+		pipelineLayoutInfo.pSetLayouts = &m_descriptorSetLayout;
+		pipelineLayoutInfo.pushConstantRangeCount = 1;
+		pipelineLayoutInfo.pPushConstantRanges = &pushRange;
+		if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: pipeline layout");
+			Destroy(device);
+			return false;
+		}
+
+		// --- Pipeline compute ---
+		VkShaderModule shaderModule = CreateShaderModule(device, compSpirv, compWordCount);
+		if (shaderModule == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: shader module");
+			Destroy(device);
+			return false;
+		}
+
+		VkComputePipelineCreateInfo pipelineInfo{};
+		pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+		pipelineInfo.layout = m_pipelineLayout;
+		pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+		pipelineInfo.stage.module = shaderModule;
+		pipelineInfo.stage.pName = "main";
+		AssertPipelineCreationAllowed();
+		PipelineCache::RegisterWarmupKey(HashComputePsoKey(m_pipelineLayout, compWordCount));
+		if (vkCreateComputePipelines(device, pipelineCache, 1, &pipelineInfo, nullptr, &m_pipeline) != VK_SUCCESS)
+		{
+			vkDestroyShaderModule(device, shaderModule, nullptr);
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: compute pipeline");
+			Destroy(device);
+			return false;
+		}
+		vkDestroyShaderModule(device, shaderModule, nullptr);
+
+		// --- Sampler de lecture shadow (NEAREST clamp ; occlusion grossière) ---
+		VkSamplerCreateInfo samplerInfo{};
+		samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		samplerInfo.magFilter = VK_FILTER_NEAREST;
+		samplerInfo.minFilter = VK_FILTER_NEAREST;
+		samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+		samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		samplerInfo.compareEnable = VK_FALSE;
+		samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
+		samplerInfo.maxLod = 0.0f;
+		if (vkCreateSampler(device, &samplerInfo, nullptr, &m_shadowSampler) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "[DdgiUpdatePass] Init FAILED: sampler");
+			Destroy(device);
+			return false;
+		}
+
+		LOG_INFO(Render, "[DdgiUpdatePass] Init OK");
+		return true;
+	}
+
+	void DdgiUpdatePass::Record(VkDevice device, VkCommandBuffer cmd, const DdgiVolume& volume,
+		VkImageView shadowCascade0, VkSampler shadowSamp,
+		const DdgiUpdateParams& params)
+	{
+		if (!IsValid() || device == VK_NULL_HANDLE || cmd == VK_NULL_HANDLE)
+			return;
+
+		const VkImageView irradianceView = volume.IrradianceView();
+		if (irradianceView == VK_NULL_HANDLE || !volume.IsAllocated())
+		{
+			LOG_WARN(Render, "[DdgiUpdatePass] Record skip: volume non alloue");
+			return;
+		}
+
+		// La shadow et le sampler doivent être valides (l'occlusion soleil les lit).
+		// L'appelant garantit normalement leur présence ; on borne par sécurité.
+		const VkSampler usedSampler = (shadowSamp != VK_NULL_HANDLE) ? shadowSamp : m_shadowSampler;
+		if (shadowCascade0 == VK_NULL_HANDLE || usedSampler == VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "[DdgiUpdatePass] Record skip: shadow cascade 0 indisponible");
+			return;
+		}
+
+		const uint32_t atlasW = volume.IrradianceAtlasWidth();
+		const uint32_t atlasH = volume.IrradianceAtlasHeight();
+		if (atlasW == 0u || atlasH == 0u)
+			return;
+
+		// --- Barrière : atlas irradiance -> GENERAL (écriture storage) ---
+		// On part de SHADER_READ_ONLY si déjà lu une frame précédente, sinon de
+		// UNDEFINED (première frame). Comme on ne mémorise pas l'état (image hors
+		// frame graph, persistante au volume), on suppose le cas courant
+		// SHADER_READ_ONLY -> GENERAL ; UNDEFINED resterait correct mais on
+		// conserve le contenu pour le blend temporel, donc on ne discarde pas.
+		// Pour la toute première frame le contenu est indéfini : l'hysteresis
+		// converge en quelques frames, ce qui est acceptable pour une base de GI.
+		VkImageMemoryBarrier toGeneral{};
+		toGeneral.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		toGeneral.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		toGeneral.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+		toGeneral.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		toGeneral.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+		toGeneral.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		toGeneral.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		toGeneral.image = volume.IrradianceImage();
+		toGeneral.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		toGeneral.subresourceRange.baseMipLevel = 0;
+		toGeneral.subresourceRange.levelCount = 1;
+		toGeneral.subresourceRange.baseArrayLayer = 0;
+		toGeneral.subresourceRange.layerCount = 1;
+		vkCmdPipelineBarrier(cmd,
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+			VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+			0, 0, nullptr, 0, nullptr, 1, &toGeneral);
+
+		// --- Mise à jour du descriptor set (vue storage du volume + shadow) ---
+		VkDescriptorImageInfo irradianceInfo{};
+		irradianceInfo.imageView = irradianceView;
+		irradianceInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+		VkDescriptorImageInfo shadowInfo{};
+		shadowInfo.sampler = usedSampler;
+		shadowInfo.imageView = shadowCascade0;
+		shadowInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+		VkWriteDescriptorSet writes[2]{};
+		writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[0].dstSet = m_descriptorSet;
+		writes[0].dstBinding = 0;
+		writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		writes[0].descriptorCount = 1;
+		writes[0].pImageInfo = &irradianceInfo;
+
+		writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[1].dstSet = m_descriptorSet;
+		writes[1].dstBinding = 1;
+		writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		writes[1].descriptorCount = 1;
+		writes[1].pImageInfo = &shadowInfo;
+		vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
+
+		// --- Dispatch (groupes 8x8 couvrant l'atlas) ---
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipelineLayout, 0, 1, &m_descriptorSet, 0, nullptr);
+		vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(DdgiUpdateParams), &params);
+		vkCmdDispatch(cmd, (atlasW + 7u) / 8u, (atlasH + 7u) / 8u, 1u);
+
+		// --- Barrière : GENERAL -> SHADER_READ_ONLY (lecture par le LightingPass) ---
+		VkImageMemoryBarrier toRead{};
+		toRead.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		toRead.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+		toRead.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		toRead.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+		toRead.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		toRead.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		toRead.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		toRead.image = volume.IrradianceImage();
+		toRead.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		toRead.subresourceRange.baseMipLevel = 0;
+		toRead.subresourceRange.levelCount = 1;
+		toRead.subresourceRange.baseArrayLayer = 0;
+		toRead.subresourceRange.layerCount = 1;
+		vkCmdPipelineBarrier(cmd,
+			VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+			VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+			0, 0, nullptr, 0, nullptr, 1, &toRead);
+	}
+
+	void DdgiUpdatePass::Destroy(VkDevice device)
+	{
+		if (device != VK_NULL_HANDLE)
+		{
+			if (m_shadowSampler != VK_NULL_HANDLE)
+			{
+				vkDestroySampler(device, m_shadowSampler, nullptr);
+				m_shadowSampler = VK_NULL_HANDLE;
+			}
+			if (m_pipeline != VK_NULL_HANDLE)
+			{
+				vkDestroyPipeline(device, m_pipeline, nullptr);
+				m_pipeline = VK_NULL_HANDLE;
+			}
+			if (m_pipelineLayout != VK_NULL_HANDLE)
+			{
+				vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+				m_pipelineLayout = VK_NULL_HANDLE;
+			}
+			if (m_descriptorPool != VK_NULL_HANDLE)
+			{
+				vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
+				m_descriptorPool = VK_NULL_HANDLE;
+			}
+			if (m_descriptorSetLayout != VK_NULL_HANDLE)
+			{
+				vkDestroyDescriptorSetLayout(device, m_descriptorSetLayout, nullptr);
+				m_descriptorSetLayout = VK_NULL_HANDLE;
+			}
+		}
+		m_descriptorSet = VK_NULL_HANDLE;
+	}
+} // namespace engine::render::gi

--- a/src/client/render/gi/DdgiUpdatePass.h
+++ b/src/client/render/gi/DdgiUpdatePass.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::render::gi
+{
+	class DdgiVolume;
+
+	/// M45.7 — Passe COMPUTE auto-gérée qui met à jour l'atlas d'irradiance d'un
+	/// `DdgiVolume` chaque frame (« GI dynamique phase 2 »).
+	///
+	/// PORTÉE v1 ASSUMÉE (conservatrice, à régler visuellement — PAS une DDGI
+	/// complète à rebonds) : le moteur n'a NI ray tracing NI voxelisation. Cette
+	/// passe N'ÉCHANTILLONNE PAS la géométrie de la scène (aucun rebond). Pour
+	/// chaque sonde, chaque texel octaédrique reçoit :
+	///   - l'irradiance du CIEL (gradient procédural horizon→zénith par direction) ;
+	///   - la contribution du SOLEIL (couleur * max(dot(dir, sunDir), 0)) ;
+	///   - une occlusion soleil GROSSIÈRE via la shadow map cascade 0, évaluée au
+	///     CENTRE de la sonde (pas par texel) ;
+	/// le tout combiné temporellement (hysteresis) avec l'irradiance précédente.
+	/// C'est une « irradiance de ciel/soleil dynamique par sonde ».
+	///
+	/// ARCHITECTURE : auto-gérée HORS frame graph pour l'écriture storage (comme
+	/// `HiZPyramidPass`). La passe pose elle-même ses barrières d'image
+	/// (UNDEFINED/SHADER_READ_ONLY -> GENERAL pour écrire, GENERAL ->
+	/// SHADER_READ_ONLY pour que le LightingPass échantillonne ensuite). La
+	/// shadow map cascade 0 est fournie en SAMPLED par l'appelant (sa barrière de
+	/// lecture est gérée par le frame graph via un `read(...)` côté Engine).
+	///
+	/// WRITER UNIQUE : cette passe est le SEUL écrivain de l'atlas d'irradiance ;
+	/// le LightingPass n'en est que lecteur.
+	class DdgiUpdatePass
+	{
+	public:
+		/// Push constants de la passe (112 octets, ≤128 → tient en push constants).
+		/// Tous les vecteurs sont 4 floats (w = padding ou champ documenté).
+		/// L'ordre doit rester aligné sur le bloc `push_constant` de ddgi_update.comp.
+		struct DdgiUpdateParams
+		{
+			float gridOrigin[4];  ///< xyz = origine monde de la sonde (0,0,0) en mètres ; w inutilisé.
+			float gridSpacing[4]; ///< xyz = espacement entre sondes par axe (mètres) ; w inutilisé.
+			uint32_t counts[4];   ///< xyz = nb de sondes par axe (X,Y,Z) ; w = irradianceTexels (côté hors bordure).
+			float sunDir[4];      ///< xyz = direction NORMALISÉE *vers* le soleil ; w inutilisé.
+			float sunColor[4];    ///< xyz = couleur/intensité du soleil ; w inutilisé.
+			float skyColor[4];    ///< xyz = couleur d'horizon du ciel (DayNightCycle skyHorizon) ; w inutilisé.
+			float params[4];      ///< x = hysteresis [0..1] (élevé = lent/stable), y = atlasCols, z = tileSize (texels+2), w inutilisé.
+		};
+		static_assert(sizeof(DdgiUpdateParams) == 112, "DdgiUpdateParams doit faire 112 octets (<=128 pour push constants)");
+
+		DdgiUpdatePass() = default;
+		DdgiUpdatePass(const DdgiUpdatePass&) = delete;
+		DdgiUpdatePass& operator=(const DdgiUpdatePass&) = delete;
+
+		/// Crée le pipeline compute (shader `ddgi_update.comp`), le descriptor set
+		/// layout (binding 0 = storage image irradiance, binding 1 = sampled image
+		/// shadow cascade 0), le pool/set et le sampler de lecture shadow.
+		/// \param device          Device logique Vulkan.
+		/// \param phys            Physical device (réservé ; non utilisé en v1).
+		/// \param compSpirv       Mots SPIR-V du shader compute (non nullptr).
+		/// \param compWordCount   Nombre de mots SPIR-V (> 0).
+		/// \param pipelineCache   Cache de pipeline optionnel (warmup PSO).
+		/// \return true si toutes les ressources sont prêtes.
+		/// \note Doit être appelée en main thread, avant tout `Record`.
+		bool Init(VkDevice device, VkPhysicalDevice phys,
+			const uint32_t* compSpirv, size_t compWordCount,
+			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Enregistre la mise à jour de l'atlas d'irradiance dans `cmd`.
+		/// Effet de bord : met à jour le descriptor set (vue storage du volume +
+		/// shadow), transitionne l'atlas irradiance en GENERAL, dispatch (groupes
+		/// 8x8 couvrant l'atlas), puis transitionne en SHADER_READ_ONLY_OPTIMAL.
+		/// \param device          Device logique Vulkan.
+		/// \param cmd             Command buffer en cours d'enregistrement.
+		/// \param volume          Volume DDGI (doit être alloué : IrradianceView() valide).
+		/// \param shadowCascade0  Vue de la shadow map cascade 0 (SHADER_READ_ONLY_OPTIMAL).
+		/// \param shadowSamp      Sampler de lecture de la shadow map (peut être le sampler interne).
+		/// \param params          Paramètres de mise à jour (ciel/soleil/hysteresis/layout).
+		void Record(VkDevice device, VkCommandBuffer cmd, const DdgiVolume& volume,
+			VkImageView shadowCascade0, VkSampler shadowSamp,
+			const DdgiUpdateParams& params);
+
+		/// Libère toutes les ressources Vulkan. Sûr même si Init a échoué.
+		void Destroy(VkDevice device);
+
+		/// true si Init a réussi (pipeline compute valide).
+		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
+
+		/// Sampler interne (NEAREST clamp) utilisable pour lire la shadow map si
+		/// l'appelant n'en fournit pas un dédié. VK_NULL_HANDLE si non initialisé.
+		VkSampler GetShadowSampler() const { return m_shadowSampler; }
+
+	private:
+		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
+		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
+		VkDescriptorSet       m_descriptorSet       = VK_NULL_HANDLE;
+		VkPipelineLayout      m_pipelineLayout      = VK_NULL_HANDLE;
+		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
+		VkSampler             m_shadowSampler       = VK_NULL_HANDLE; ///< NEAREST clamp, lecture shadow cascade 0.
+	};
+} // namespace engine::render::gi

--- a/src/client/render/gi/DdgiVolume.h
+++ b/src/client/render/gi/DdgiVolume.h
@@ -123,6 +123,11 @@ namespace engine::render::gi
 		/// Vue de l'atlas d'irradiance (VK_NULL_HANDLE si non alloué).
 		VkImageView IrradianceView() const { return m_irradianceView; }
 
+		/// Image de l'atlas d'irradiance (VK_NULL_HANDLE si non alloué).
+		/// M45.7 : nécessaire pour poser les barrières de layout (GENERAL <->
+		/// SHADER_READ_ONLY) sur l'image persistante depuis la passe de mise à jour.
+		VkImage IrradianceImage() const { return m_irradianceImage; }
+
 		/// Vue de l'atlas de visibilité (VK_NULL_HANDLE si non alloué).
 		VkImageView VisibilityView() const { return m_visibilityView; }
 


### PR DESCRIPTION
## M45.7 — GI dynamique phase 2 : injection + propagation runtime (cluster M45)

> ⚠️ **PR stackée sur #793 (M45.6)** — base `main`, contient les commits M45.6+M45.7 jusqu'au merge de #793. **Merger #793 avant.** Préférer **« Rebase and merge »** (sinon je rebase).

### Limite v1 ASSUMÉE (importante)
Le moteur n'a **ni ray tracing ni voxelisation** → **pas de rebonds géométriques**. Cette v1 injecte dans chaque sonde l'irradiance du **ciel** (gradient procédural) + **soleil** (couleur, occlusion grossière via shadow cascade 0), avec blend temporel. C'est une **irradiance ciel/soleil dynamique par sonde** — une base conservatrice à régler visuellement (M45.8), **pas une DDGI complète à rebonds**.

### Gating / non-régression (garantie centrale)
**`gi.ddgi.enabled=false` (défaut)** → `useDdgi=0`, passe `DDGI_Update` non enregistrée, volume non alloué → **rendu strictement identique** au chemin probes statiques (`ProbeData`).

### Contenu
- `gi/DdgiUpdatePass.{h,cpp}` + `ddgi_update.comp` — passe **compute auto-gérée** (calquée `HiZPyramidPass`, barrières `GENERAL↔SHADER_READ` manuelles, **writer unique** de l'atlas). Décodage octaédrique = convention `OctahedralMap.h`.
- `LightingPass.{h,cpp}` + `lighting.frag` — **9→10 bindings** (binding 9 = irradiance DDGI), **`LightParams` 148→224 o** (champs DDGI ; `static_assert` MAJ ; **layout = push block GLSL byte-à-byte**, vérifié offset par offset). `Record` prend `ddgiIrradianceView/ddgiSampler` avec **fallback valide** quand null. Terme indirect **gated `if (useDdgi>0.5)`** (sonde la plus proche v1 ; pas de Chebyshev/trilinéaire — suivi M45.8).
- `Engine` — boot gated (config → `Allocate` → init shader ; **fallback sûr** si échec), passe `DDGI_Update` avant `Lighting`, remplissage DDGI de `LightParams`, `Destroy`.
- `config.json` (`gi.ddgi` += hysteresis/intensity, `enabled` reste false) + `CMakeLists.txt`.

### Vérifs de revue
- `useDdgi=0` (défaut) → binding 9 lié à un fallback (`GBufferA`) **jamais lu** → **byte-identique**. Confirmé.
- Layout `LightParams` (224 o) = bloc GLSL : offsets identiques (`useIBL@144`, `useDdgi@148`, pads, `ddgiOrigin@160`…). Confirmé.
- Un seul call site `Record` (Engine), mis à jour.

### À régler visuellement (toi / M45.8)
Occlusion soleil grossière (texel central cascade 0, pas de projection par sonde), sonde-la-plus-proche (pas de trilinéaire), pas de Chebyshev anti-leak. Activer via `gi.ddgi.enabled=true` + tuning `hysteresis`/`intensity`.

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)