### PR TITLE
ci: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -172,7 +172,7 @@ jobs:
           ls -la "$ZIP_NAME"
 
       - name: Upload Docker bundle artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v6
         with:
           name: lcdlln-docker-linux-${{ github.sha }}
           path: lcdlln-docker-linux-${{ github.sha }}.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5
 
       - name: Clone vcpkg
         shell: pwsh
@@ -67,7 +67,7 @@ jobs:
       # Les .spv ne sont pas versionnés (sources GLSL seulement) ; le moteur charge uniquement le SPIR-V depuis game/data/shaders/.
       - name: Cache Vulkan SDK (glslangValidator)
         id: vk-sdk-cache
-        uses: actions/cache@v4.2.2
+        uses: actions/cache@v5
         with:
           path: C:\VulkanSDK\1.3.296.0
           key: lunarg-vulkan-sdk-1.3.296.0-windows-x64-glslang
@@ -217,7 +217,7 @@ jobs:
           }
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v6
         with:
           name: windows-release-${{ github.sha }}
           path: artifacts/


### PR DESCRIPTION
## Contexte

GitHub forcera les actions tournant sur **Node.js 20** à passer en **Node.js 24** le **16 juin 2026**, et supprimera le runner Node 20 le **16 septembre 2026**. L'avertissement remonte sur le build Linux (`actions/checkout`, `actions/upload-artifact`).

## Changements

Montée de version des actions encore épinglées sur node20 (cibles vérifiées dans leurs `action.yml`) :

| Fichier | Action | Avant → Après | Runtime |
|---|---|---|---|
| `build-linux.yml` | checkout | `v4.2.2` → `v5` | node24 |
| `build-linux.yml` | upload-artifact | `v4.6.2` → `v6` | node24 |
| `build-windows.yml` | checkout | `v4.2.2` → `v5` | node24 |
| `build-windows.yml` | cache | `v4.2.2` → `v5` | node24 |
| `build-windows.yml` | upload-artifact | `v4.6.2` → `v6` | node24 |

### Points de vigilance
- **`upload-artifact` → `v6`, pas `v5`** : `v5` tourne encore sur node20 (`runs.using: node20`). Seul `v6` est en node24.
- **`build-windows` corrigé aussi** alors que l'avertissement CI ne citait que `build-linux` : `checkout` + `cache` + `upload-artifact`.
- Pinning sur tags majeurs (`@v5`/`@v6`) plutôt que patch exact, pour absorber les futurs bumps node sans rejouer cette dépréciation.

## Déploiement
✅ Purement CI/infra GitHub Actions — **pas de redéploiement serveur** (master/shard), aucun impact wire/DB/handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)