### PR TITLE
feat(render): M45.4b/M45.5b — impostors texturés + ORM + profondeur/parallaxe (format v2)

### DIFF
--- a/config.json
+++ b/config.json
@@ -150,7 +150,8 @@
         "impostor": {
             "enabled": false,
             "distance_m": 60.0,
-            "fade_band_m": 10.0
+            "fade_band_m": 10.0,
+            "parallax_scale": 0.08
         },
         "_comment_fog": "M45.1 Perspective aerienne a distance. start_m : rayon CLAIR autour du joueur (aucun brouillard en deca) ; end_m : distance de fondu COMPLET vers la teinte atmospherique (garantit le masquage de la coupe de distance des props). density : extinction exponentielle (1/m), <= 0 desactive l'effet ; inscatter : force du halo chaud directionnel quand on regarde le soleil. start/end : desactive si end_m <= start_m. density/inscatter : override des valeurs per-zone (atmosphere.json : aerial.density / aerial.inscatter) ; retirer ces cles ici pour piloter par zone. Lu a chaque frame -> reglage a chaud.",
         "fog": {

--- a/game/data/shaders/impostor.frag
+++ b/game/data/shaders/impostor.frag
@@ -1,9 +1,10 @@
-// game/data/shaders/impostor.frag (M45.5 — impostors végétation runtime)
+// game/data/shaders/impostor.frag (M45.4b — impostors végétation runtime, format v2)
 //
 // Décode la direction caméra->instance en coords octaédriques (INVERSE de
 // OctaToDir de tools/impostor_builder/OctahedralMap.h) pour choisir la tile
-// (i,j), échantillonne albedo + normal dans la tile, applique l'alpha-test de
-// silhouette + un dither fade anti-popping, puis écrit les 4 sorties GBuffer
+// (i,j), échantillonne albedo + normal + ORM dans la tile, applique un décalage
+// de parallax single-step (depth en normal.a), l'alpha-test de silhouette (sur
+// albedo.a) + un dither fade anti-popping, puis écrit les 4 sorties GBuffer
 // (ordre/format IDENTIQUE à gbuffer_geometry.frag).
 //
 // Sorties GBuffer (cf. gbuffer_geometry.frag) :
@@ -15,15 +16,17 @@
 
 layout(location = 0) in vec2 vUv;       // UV du quad billboard [0,1]²
 layout(location = 1) in vec3 vViewDir;   // direction monde instance -> caméra (unitaire)
+layout(location = 2) in vec2 vViewTangent; // inclinaison de vue (right/up) pour la parallax
 
-layout(set = 0, binding = 0) uniform sampler2D uAlbedo; // atlas albedo (sRGB)
-layout(set = 0, binding = 1) uniform sampler2D uNormal;  // atlas normal (UNORM, a=masque)
+layout(set = 0, binding = 0) uniform sampler2D uAlbedo; // atlas albedo (sRGB, a=couverture)
+layout(set = 0, binding = 1) uniform sampler2D uNormal;  // atlas normal (UNORM, a=profondeur)
+layout(set = 0, binding = 2) uniform sampler2D uOrm;     // atlas ORM (UNORM, r=AO g=rough b=metal)
 
 layout(push_constant) uniform PushConstants {
     mat4 viewProj;
     mat4 prevViewProj;
     vec4 cameraPos;
-    vec4 atlasParams;   // x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=0
+    vec4 atlasParams;   // x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=parallaxScale
     vec4 instancePos;
 } pc;
 
@@ -64,8 +67,9 @@ float Bayer4x4(ivec2 p)
 
 void main()
 {
-    float viewsPerAxis = pc.atlasParams.x;
-    float fadeAlpha    = pc.atlasParams.z;
+    float viewsPerAxis  = pc.atlasParams.x;
+    float fadeAlpha     = pc.atlasParams.z;
+    float parallaxScale = pc.atlasParams.w;
 
     // 1) Dither fade anti-popping : discard pseudo-aléatoire stable sur l'écran.
     if (fadeAlpha < 1.0)
@@ -81,24 +85,38 @@ void main()
     vec2 tileF = floor(octUv * viewsPerAxis);
     tileF = clamp(tileF, vec2(0.0), vec2(viewsPerAxis - 1.0));
 
-    // 3) UV dans l'atlas : origine de la tile + UV du quad ramenée à la tile.
-    //    L'atlas est une grille N×N ; chaque tile occupe 1/N de l'atlas.
-    //    quadUv [0,1] -> sous-région [tile/N, (tile+1)/N].
-    vec2 atlasUv = (tileF + clamp(vUv, vec2(0.0), vec2(1.0))) / viewsPerAxis;
+    // 3) Repère de la tile dans l'atlas (grille N×N, chaque tile = 1/N).
+    //    tileSpan = taille d'une tile en UV atlas ; tileOrigin = coin de la tile.
+    float tileSpan  = 1.0 / viewsPerAxis;
+    vec2  tileOrigin = tileF * tileSpan;
+    vec2  quadUv     = clamp(vUv, vec2(0.0), vec2(1.0));
 
-    vec4 albedo = texture(uAlbedo, atlasUv);
-    vec4 normalSample = texture(uNormal, atlasUv); // .rgb = n*0.5+0.5, .a = masque silhouette
+    // 4) Parallax v1 (single-step) : on lit la profondeur relative (normal.a) à
+    //    l'UV non décalée, puis on décale l'UV intra-tuile selon l'inclinaison de
+    //    vue. depth ∈ [0,1] (0.5 = surface du billboard). L'offset est borné à la
+    //    tile (clamp du quadUv décalé) pour éviter le bleeding inter-tuiles.
+    vec2 atlasUv0 = tileOrigin + quadUv * tileSpan;
+    float depth   = texture(uNormal, atlasUv0).a;
+    vec2  par     = vViewTangent * (depth - 0.5) * parallaxScale;
+    vec2  quadUvP = clamp(quadUv + par, vec2(0.0), vec2(1.0));
+    vec2  atlasUv = tileOrigin + quadUvP * tileSpan;
 
-    // 4) Alpha-test de silhouette (masque de couverture M45.4 stocké en normal.a).
-    if (normalSample.a < 0.5)
+    // 5) Ré-échantillonnage à l'UV décalée.
+    vec4 albedo       = texture(uAlbedo, atlasUv); // .rgb = albedo, .a = couverture
+    vec4 normalSample = texture(uNormal, atlasUv); // .rgb = n*0.5+0.5, .a = profondeur
+    vec4 orm          = texture(uOrm,    atlasUv); // .r = AO, .g = rough, .b = metal
+
+    // 6) Alpha-test de silhouette : en v2 la COUVERTURE est dans albedo.a
+    //    (normal.a porte désormais la profondeur).
+    if (albedo.a < 0.5)
         discard;
 
-    // 5) Écriture GBuffer.
+    // 7) Écriture GBuffer.
     outAlbedo = vec4(albedo.rgb, 1.0);
     // L'atlas stocke déjà la normale encodée n*0.5+0.5 -> on la réécrit telle quelle.
     outNormal = vec4(normalSample.rgb, 1.0);
-    // ORM : AO=1, Roughness=1 (feuillage mat), Metallic=0.
-    outORM = vec4(1.0, 1.0, 0.0, 1.0);
+    // ORM échantillonné depuis l'atlas v2 (au lieu du codé en dur v1).
+    outORM = vec4(orm.rgb, 1.0);
     // Velocity nulle en v1 (impostors statiques ; pas de reprojection dédiée).
     outVelocity = vec4(0.0, 0.0, 0.0, 1.0);
 }

--- a/game/data/shaders/impostor.vert
+++ b/game/data/shaders/impostor.vert
@@ -9,6 +9,11 @@
 //   - vUv  : UV du quad dans [0,1]² ;
 //   - vViewDir : direction monde INSTANCE -> CAMÉRA (unitaire), décodée en
 //                coords octaédriques dans le fragment (cf. impostor.frag).
+//   - vViewTangent : direction de vue (instance->caméra) projetée dans le repère
+//                tangent (camRight, camUp) du billboard. Sert d'inclinaison de
+//                vue pour le décalage de parallax single-step (frag v2). C'est
+//                une APPROXIMATION v1 (billboard plan, pas de vraie reconstruction
+//                de la profondeur de surface).
 #version 450
 
 // Push constants : cf. ImpostorPushConstants (ImpostorPass.h), 176 octets.
@@ -22,6 +27,7 @@ layout(push_constant) uniform PushConstants {
 
 layout(location = 0) out vec2 vUv;
 layout(location = 1) out vec3 vViewDir;
+layout(location = 2) out vec2 vViewTangent; // inclinaison de vue dans le repère tangent (parallax)
 
 void main()
 {
@@ -54,7 +60,13 @@ void main()
         + camUp    * (corner.y * 2.0 * radius);
 
     // Direction instance -> caméra (mesh -> caméra), pour le décodage octaédrique.
-    vViewDir = normalize(pc.cameraPos.xyz - center);
+    vec3 toCam = normalize(pc.cameraPos.xyz - center);
+    vViewDir = toCam;
+
+    // Projection de la direction de vue dans le repère tangent (right/up) du
+    // billboard : composantes de l'inclinaison de vue utilisées par le décalage
+    // de parallax intra-tuile dans le fragment. Approximation v1.
+    vViewTangent = vec2(dot(toCam, camRight), dot(toCam, camUp));
 
     gl_Position = pc.viewProj * vec4(worldPos, 1.0);
 }

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10723,6 +10723,9 @@ namespace engine
 				[this, &impostorPass, &impostorBatches, &rs](VkCommandBuffer innerCmd) {
 					const float camPos3[3] = {
 						rs.camera.position.x, rs.camera.position.y, rs.camera.position.z };
+					// Échelle de parallax single-step (frag v2) ; gated par enabled.
+					const float parallaxScale = static_cast<float>(
+						m_cfg.GetDouble("world.impostor.parallax_scale", 0.08));
 					for (auto& kv : impostorBatches)
 					{
 						auto atlasIt = m_impostorAtlases.find(kv.first);
@@ -10731,16 +10734,18 @@ namespace engine
 						const engine::render::ImpostorAsset& atlas = atlasIt->second;
 						engine::render::TextureAsset* albedo = atlas.Albedo().Get();
 						engine::render::TextureAsset* normal = atlas.Normal().Get();
-						if (albedo == nullptr || normal == nullptr
-							|| albedo->view == VK_NULL_HANDLE || normal->view == VK_NULL_HANDLE)
+						engine::render::TextureAsset* orm    = atlas.Orm().Get();
+						if (albedo == nullptr || normal == nullptr || orm == nullptr
+							|| albedo->view == VK_NULL_HANDLE || normal->view == VK_NULL_HANDLE
+							|| orm->view == VK_NULL_HANDLE)
 							continue;
 						const VkSampler samp = impostorPass.GetSampler();
 						impostorPass.RecordInstances(
 							m_vkDeviceContext.GetDevice(), innerCmd, m_vkSwapchain.GetExtent(),
 							kv.second.data(), static_cast<uint32_t>(kv.second.size()),
-							albedo->view, samp, normal->view, samp,
+							albedo->view, samp, normal->view, samp, orm->view, samp,
 							rs.viewProjMatrix.m, rs.prevViewProjMatrix.m, camPos3,
-							atlas.Info().viewsPerAxis, atlas.Info().tileSize);
+							atlas.Info().viewsPerAxis, atlas.Info().tileSize, parallaxScale);
 					}
 				});
 		}

--- a/src/client/render/ImpostorAsset.cpp
+++ b/src/client/render/ImpostorAsset.cpp
@@ -1,8 +1,8 @@
 // src/client/render/ImpostorAsset.cpp (M45.5)
 //
-// Implémentation du loader runtime du format `.mipo` (M45.4). Voir
+// Implémentation du loader runtime du format `.mipo` v2 (M45.4b). Voir
 // ImpostorAsset.h pour l'API. La lecture du header + métadonnées + blocs
-// albedo/normal est faite champ-par-champ en little-endian, RÉPLIQUANT la
+// albedo/normal/orm est faite champ-par-champ en little-endian, RÉPLIQUANT la
 // disposition documentée dans tools/impostor_builder/FORMAT.md, sans dépendre
 // du code de l'outil offline.
 
@@ -21,8 +21,8 @@ namespace engine::render
 		/// Magic du format `.mipo` : ASCII 'M''I''P''O' en little-endian
 		/// (0x4F50494D), IDENTIQUE à `tools::impostor_builder::kImpostorMagic`.
 		constexpr uint32_t kImpostorMagic   = 0x4F50494Du;
-		/// Version du format disque supportée (cf. kImpostorVersion outil).
-		constexpr uint32_t kImpostorVersion = 1u;
+		/// Version du format disque supportée (v2 : 3 atlas albedo/normal/orm).
+		constexpr uint32_t kImpostorVersion = 2u;
 
 		/// Lit un uint32 little-endian depuis `data` à `offset`, avance `offset`.
 		/// \return false si dépassement de buffer.
@@ -58,11 +58,35 @@ namespace engine::render
 			std::memcpy(&out, &bits, sizeof(out)); // bit-cast (little-endian sur nos plateformes cibles)
 			return true;
 		}
+
+		/// Lit un bloc `[u64 size][size octets]` depuis `data` à `offset`. Valide
+		/// que `size == expectedBytes` et que les octets tiennent dans le buffer,
+		/// renvoie via `outPtr` un pointeur DANS `data` (non-owning), avance `offset`.
+		/// \param label    Nom du bloc, injecté dans le message d'erreur.
+		/// \param expectedBytes Taille attendue ((views*tile)^2 * 4).
+		/// \return false (avec `err` renseigné) si tronqué ou taille incohérente.
+		bool ReadBlock(const std::vector<uint8_t>& data, size_t& offset,
+			uint64_t expectedBytes, const char* label,
+			const uint8_t*& outPtr, std::string& err)
+		{
+			uint64_t blockSize = 0;
+			if (!ReadU64LE(data, offset, blockSize))
+			{ err = std::string("ImpostorAsset: taille bloc ") + label + " tronquée"; return false; }
+			if (blockSize != expectedBytes || offset + blockSize > data.size())
+			{
+				err = std::string("ImpostorAsset: bloc ") + label + " invalide (taille="
+					+ std::to_string(blockSize) + ", attendu=" + std::to_string(expectedBytes) + ")";
+				return false;
+			}
+			outPtr = data.data() + offset;
+			offset += static_cast<size_t>(blockSize);
+			return true;
+		}
 	} // namespace
 
 	bool ImpostorAsset::IsValid() const
 	{
-		return m_valid && m_albedo.IsValid() && m_normal.IsValid();
+		return m_valid && m_albedo.IsValid() && m_normal.IsValid() && m_orm.IsValid();
 	}
 
 	bool ImpostorAsset::LoadFromFile(const std::string& absOrContentPath, AssetRegistry& reg, std::string& err)
@@ -105,7 +129,6 @@ namespace engine::render
 		}
 		(void)builderVersion;
 		(void)engineVersion;
-		(void)contentHash;
 		if (magic != kImpostorMagic)
 		{
 			err = "ImpostorAsset: magic invalide (attendu MIPO 0x4F50494D)";
@@ -113,9 +136,13 @@ namespace engine::render
 		}
 		if (formatVersion != kImpostorVersion)
 		{
-			err = "ImpostorAsset: version de format non supportée: " + std::to_string(formatVersion);
+			// Rejet propre (pas de crash) : l'appelant retombe sur le rendu mesh.
+			err = "ImpostorAsset: version de format non supportée: " + std::to_string(formatVersion)
+				+ " (attendu v" + std::to_string(kImpostorVersion) + ")";
 			return false;
 		}
+		// contentHash stocké pour diagnostic (non vérifié en v2).
+		m_contentHash = contentHash;
 
 		// 3) ImpostorAtlasInfo : viewsPerAxis, tileSize, channels (3×u32),
 		//    boundsMin[3], boundsMax[3] (6×f32). Cf. FORMAT.md offsets 24..59.
@@ -143,37 +170,25 @@ namespace engine::render
 		const uint32_t atlasSidePx = viewsPerAxis * tileSize;
 		const uint64_t expectedBytes = static_cast<uint64_t>(atlasSidePx) * atlasSidePx * 4ull;
 
-		// 4) Bloc albedo : u64 albedoSize + albedoSize octets RGBA8.
-		uint64_t albedoSize = 0;
-		if (!ReadU64LE(data, off, albedoSize))
-		{ err = "ImpostorAsset: albedoSize tronqué"; return false; }
-		if (albedoSize != expectedBytes || off + albedoSize > data.size())
-		{
-			err = "ImpostorAsset: bloc albedo invalide (taille=" + std::to_string(albedoSize)
-				+ ", attendu=" + std::to_string(expectedBytes) + ")";
-			return false;
-		}
-		const uint8_t* albedoPtr = data.data() + off;
-		off += static_cast<size_t>(albedoSize);
+		// 4) Trois blocs `[u64 size][size octets RGBA8]` dans l'ordre VERROUILLÉ
+		//    albedo (rgb=albedo a=couverture), normal (rgb=normale encodée a=profondeur
+		//    relative), orm (r=AO g=roughness b=metallic a=255). Chacun de
+		//    expectedBytes octets.
+		const uint8_t* albedoPtr = nullptr;
+		const uint8_t* normalPtr = nullptr;
+		const uint8_t* ormPtr    = nullptr;
+		if (!ReadBlock(data, off, expectedBytes, "albedo", albedoPtr, err)) return false;
+		if (!ReadBlock(data, off, expectedBytes, "normal", normalPtr, err)) return false;
+		if (!ReadBlock(data, off, expectedBytes, "orm",    ormPtr,    err)) return false;
 
-		// 5) Bloc normal : u64 normalSize + normalSize octets RGBA8.
-		uint64_t normalSize = 0;
-		if (!ReadU64LE(data, off, normalSize))
-		{ err = "ImpostorAsset: normalSize tronqué"; return false; }
-		if (normalSize != expectedBytes || off + normalSize > data.size())
-		{
-			err = "ImpostorAsset: bloc normal invalide (taille=" + std::to_string(normalSize)
-				+ ", attendu=" + std::to_string(expectedBytes) + ")";
-			return false;
-		}
-		const uint8_t* normalPtr = data.data() + off;
-
-		// 6) Upload des deux atlas en VkImage échantillonnable.
-		//    Albedo en sRGB (couleur, linéarisée au sample), normal en UNORM
-		//    (valeurs encodées n*0.5+0.5 lues telles quelles, + masque alpha).
+		// 5) Upload des trois atlas en VkImage échantillonnable.
+		//    Albedo en sRGB (couleur, linéarisée au sample) ; normal en UNORM
+		//    (valeurs encodées n*0.5+0.5 + profondeur en alpha, lues telles quelles) ;
+		//    ORM en UNORM (canaux PBR linéaires, lus tels quels).
 		m_albedo = reg.CreateTextureFromMemory(albedoPtr, atlasSidePx, atlasSidePx, /*useSrgb=*/true);
 		m_normal = reg.CreateTextureFromMemory(normalPtr, atlasSidePx, atlasSidePx, /*useSrgb=*/false);
-		if (!m_albedo.IsValid() || !m_normal.IsValid())
+		m_orm    = reg.CreateTextureFromMemory(ormPtr,    atlasSidePx, atlasSidePx, /*useSrgb=*/false);
+		if (!m_albedo.IsValid() || !m_normal.IsValid() || !m_orm.IsValid())
 		{
 			err = "ImpostorAsset: échec upload GPU des atlas";
 			return false;

--- a/src/client/render/ImpostorAsset.h
+++ b/src/client/render/ImpostorAsset.h
@@ -4,9 +4,10 @@
 //
 // Loader runtime du format binaire d'atlas d'impostors octaédriques produit par
 // l'outil offline `tools/impostor_builder` (M45.4, voir tools/impostor_builder/
-// FORMAT.md). Détient les deux textures GPU (albedo sRGB + normal linéaire)
-// uploadées via `AssetRegistry::CreateTextureFromMemory`, ainsi que les
-// métadonnées de grille (viewsPerAxis, tileSize, bounds) nécessaires au shader.
+// FORMAT.md). Format v2 : détient TROIS textures GPU (albedo sRGB rgb+couverture,
+// normal linéaire rgb+profondeur, ORM linéaire) uploadées via
+// `AssetRegistry::CreateTextureFromMemory`, ainsi que les métadonnées de grille
+// (viewsPerAxis, tileSize, bounds) nécessaires au shader.
 //
 // IMPORTANT : la lecture du format est RÉPLIQUÉE ici champ-par-champ en
 // little-endian (cf. ImpostorFormat.h) pour NE PAS dépendre du code de l'outil
@@ -29,24 +30,25 @@ namespace engine::render
 		float    boundsMax[3] = {0.0f, 0.0f, 0.0f}; ///< Coin max de l'AABB monde du mesh.
 	};
 
-	/// Détenteur d'un atlas d'impostors chargé : métadonnées + 2 textures GPU.
+	/// Détenteur d'un atlas d'impostors chargé : métadonnées + 3 textures GPU.
 	/// Cycle de vie : `LoadFromFile` une fois (au chargement du décor si
-	/// `world.impostor.enabled`), lecture via `Albedo()`/`Normal()`/`Info()` à
-	/// chaque frame de rendu. Les textures appartiennent au `AssetRegistry`
-	/// passé à `LoadFromFile` (libérées au `Destroy` du registry) — cette classe
-	/// ne possède donc rien à détruire elle-même (handles non-owning).
+	/// `world.impostor.enabled`), lecture via `Albedo()`/`Normal()`/`Orm()`/
+	/// `Info()` à chaque frame de rendu. Les textures appartiennent au
+	/// `AssetRegistry` passé à `LoadFromFile` (libérées au `Destroy` du registry)
+	/// — cette classe ne possède donc rien à détruire elle-même (handles non-owning).
 	class ImpostorAsset
 	{
 	public:
 		ImpostorAsset() = default;
 
-		/// Lit le fichier `.mipo` à `absOrContentPath` (chemin disque ABSOLU ou
+		/// Lit le fichier `.mipo` v2 à `absOrContentPath` (chemin disque ABSOLU ou
 		/// relatif au cwd — la résolution est faite par l'appelant), valide le
-		/// magic/version, extrait `ImpostorAtlasInfo` + albedo[] + normal[], puis
-		/// uploade les deux atlas en VkImage via `reg.CreateTextureFromMemory`
-		/// (albedo en sRGB, normal en linéaire/UNORM).
+		/// magic + version==2 (rejette toute autre version sans crash), extrait
+		/// `ImpostorAtlasInfo` + albedo[] + normal[] + orm[], puis uploade les trois
+		/// atlas en VkImage via `reg.CreateTextureFromMemory` (albedo en sRGB,
+		/// normal et ORM en linéaire/UNORM).
 		///
-		/// Effet de bord : crée deux textures GPU dans `reg`. À appeler en main
+		/// Effet de bord : crée trois textures GPU dans `reg`. À appeler en main
 		/// thread (uploads synchrones internes au registry).
 		///
 		/// \param absOrContentPath Chemin disque du fichier `.mipo`.
@@ -55,21 +57,25 @@ namespace engine::render
 		/// \return true si lecture + validation + upload ont réussi.
 		bool LoadFromFile(const std::string& absOrContentPath, AssetRegistry& reg, std::string& err);
 
-		/// True si `LoadFromFile` a réussi et les deux textures sont valides.
+		/// True si `LoadFromFile` a réussi et les trois textures sont valides.
 		bool IsValid() const;
 
 		/// Métadonnées de la grille (valides seulement si `IsValid()`).
 		const ImpostorAtlasInfoRuntime& Info() const { return m_info; }
 
-		/// Handle de la texture albedo (sRGB). Invalide si non chargé.
+		/// Handle de la texture albedo (sRGB, rgb=albedo a=couverture). Invalide si non chargé.
 		TextureHandle Albedo() const { return m_albedo; }
-		/// Handle de la texture normal (linéaire/UNORM). Invalide si non chargé.
+		/// Handle de la texture normal (linéaire/UNORM, rgb=normale a=profondeur). Invalide si non chargé.
 		TextureHandle Normal() const { return m_normal; }
+		/// Handle de la texture ORM (linéaire/UNORM, r=AO g=roughness b=metallic). Invalide si non chargé.
+		TextureHandle Orm() const { return m_orm; }
 
 	private:
 		ImpostorAtlasInfoRuntime m_info{};
 		TextureHandle            m_albedo;
 		TextureHandle            m_normal;
+		TextureHandle            m_orm;
+		uint64_t                 m_contentHash = 0u; ///< Hash de contenu du header v2 (diagnostic, non vérifié).
 		bool                     m_valid = false;
 	};
 }

--- a/src/client/render/ImpostorPass.cpp
+++ b/src/client/render/ImpostorPass.cpp
@@ -50,11 +50,11 @@ namespace engine::render
 			return false;
 		}
 
-		// 1) Descriptor set layout (set 0) : 2 combined image samplers
-		//    (binding 0 = albedo, binding 1 = normal), stage FRAGMENT.
+		// 1) Descriptor set layout (set 0) : 3 combined image samplers
+		//    (binding 0 = albedo, binding 1 = normal, binding 2 = orm), stage FRAGMENT.
 		{
-			VkDescriptorSetLayoutBinding bindings[2]{};
-			for (uint32_t i = 0; i < 2u; ++i)
+			VkDescriptorSetLayoutBinding bindings[3]{};
+			for (uint32_t i = 0; i < 3u; ++i)
 			{
 				bindings[i].binding         = i;
 				bindings[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -63,7 +63,7 @@ namespace engine::render
 			}
 			VkDescriptorSetLayoutCreateInfo info{};
 			info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-			info.bindingCount = 2;
+			info.bindingCount = 3;
 			info.pBindings    = bindings;
 			if (vkCreateDescriptorSetLayout(device, &info, nullptr, &m_setLayout) != VK_SUCCESS)
 			{
@@ -74,11 +74,11 @@ namespace engine::render
 		}
 
 		// 2) Descriptor pool + anneau de kDescRing sets (un par atlas/draw, cf. .h).
-		//    2 image samplers par set.
+		//    3 image samplers par set.
 		{
 			VkDescriptorPoolSize poolSize{};
 			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-			poolSize.descriptorCount = 2u * kDescRing;
+			poolSize.descriptorCount = 3u * kDescRing;
 			VkDescriptorPoolCreateInfo pci{};
 			pci.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
 			pci.maxSets       = kDescRing;
@@ -255,12 +255,15 @@ namespace engine::render
 		const ImpostorInstance* instances, uint32_t count,
 		VkImageView albedoView, VkSampler albedoSamp,
 		VkImageView normalView, VkSampler normalSamp,
+		VkImageView ormView, VkSampler ormSamp,
 		const float* viewProj, const float* prevViewProj, const float* cameraPos3,
-		uint32_t viewsPerAxis, uint32_t tileSize)
+		uint32_t viewsPerAxis, uint32_t tileSize, float parallaxScale)
 	{
 		if (m_pipeline == VK_NULL_HANDLE || cmd == VK_NULL_HANDLE || instances == nullptr
 			|| count == 0 || albedoView == VK_NULL_HANDLE || normalView == VK_NULL_HANDLE
+			|| ormView == VK_NULL_HANDLE
 			|| albedoSamp == VK_NULL_HANDLE || normalSamp == VK_NULL_HANDLE
+			|| ormSamp == VK_NULL_HANDLE
 			|| viewProj == nullptr || cameraPos3 == nullptr)
 		{
 			return;
@@ -271,16 +274,19 @@ namespace engine::render
 		VkDescriptorSet descSet = m_descSets[m_descCursor];
 		m_descCursor = (m_descCursor + 1u) % kDescRing;
 
-		// Met à jour CE set avec l'atlas courant.
-		VkDescriptorImageInfo imgInfos[2]{};
+		// Met à jour CE set avec l'atlas courant (3 samplers : albedo, normal, orm).
+		VkDescriptorImageInfo imgInfos[3]{};
 		imgInfos[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		imgInfos[0].imageView   = albedoView;
 		imgInfos[0].sampler     = albedoSamp;
 		imgInfos[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		imgInfos[1].imageView   = normalView;
 		imgInfos[1].sampler     = normalSamp;
-		VkWriteDescriptorSet writes[2]{};
-		for (uint32_t i = 0; i < 2u; ++i)
+		imgInfos[2].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		imgInfos[2].imageView   = ormView;
+		imgInfos[2].sampler     = ormSamp;
+		VkWriteDescriptorSet writes[3]{};
+		for (uint32_t i = 0; i < 3u; ++i)
 		{
 			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 			writes[i].dstSet          = descSet;
@@ -289,7 +295,7 @@ namespace engine::render
 			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 			writes[i].pImageInfo      = &imgInfos[i];
 		}
-		vkUpdateDescriptorSets(device, 2u, writes, 0, nullptr);
+		vkUpdateDescriptorSets(device, 3u, writes, 0, nullptr);
 
 		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
 		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -307,8 +313,8 @@ namespace engine::render
 		pc.cameraPos[3] = 0.0f;
 		pc.atlasParams[0] = static_cast<float>(viewsPerAxis);
 		pc.atlasParams[1] = static_cast<float>(tileSize);
-		pc.atlasParams[2] = 1.0f; // fadeAlpha (v1 : pas de fondu, opaque)
-		pc.atlasParams[3] = 0.0f;
+		pc.atlasParams[2] = 1.0f;            // fadeAlpha (v1 : pas de fondu, opaque)
+		pc.atlasParams[3] = parallaxScale;   // v2 : échelle du décalage de parallax (frag)
 
 		for (uint32_t i = 0; i < count; ++i)
 		{

--- a/src/client/render/ImpostorPass.h
+++ b/src/client/render/ImpostorPass.h
@@ -39,8 +39,10 @@ namespace engine::render
 	///   viewProj      : 64  (mat4 caméra)
 	///   prevViewProj  : 64  (mat4 frame précédente — réservé velocity, écrit 0)
 	///   cameraPos     : 16  (xyz position caméra monde, w pad)
-	///   atlasParams   : 16  (x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=0)
+	///   atlasParams   : 16  (x=viewsPerAxis, y=tileSize, z=fadeAlpha, w=parallaxScale)
 	///   instancePos   : 16  (xyz centre monde, w=radius)
+	/// NB : `atlasParams.w` (réservé en v1) porte désormais l'échelle de parallax
+	/// du fragment v2 — pas de changement de taille (toujours 176 octets).
 	struct ImpostorPushConstants
 	{
 		float viewProj[16]     = {};
@@ -64,7 +66,7 @@ namespace engine::render
 		/// (4 color attachments + depth, depthTest ON, depthWrite ON, blend OFF
 		/// sur les 4 — calque l'état MRT de GeometryPass/TerrainChunkRenderer
 		/// pour ce render pass). Crée aussi le descriptor set layout (set 0 =
-		/// 2 combined image samplers : albedo, normal), le pool, le set, et un
+		/// 3 combined image samplers : albedo, normal, orm), le pool, le set, et un
 		/// sampler linéaire CLAMP_TO_EDGE partagé.
 		///
 		/// \param gbufferLoadRenderPass Render pass GBuffer loadOp=LOAD du caller.
@@ -77,7 +79,7 @@ namespace engine::render
 		          const uint32_t* fragSpirv, size_t fragWordCount,
 		          VkPipelineCache pipelineCache = VK_NULL_HANDLE);
 
-		/// Dessine `count` impostors partageant le même atlas (albedo+normal).
+		/// Dessine `count` impostors partageant le même atlas (albedo+normal+orm).
 		/// À APPELER DANS le callback de `RecordTerrainChunkBatch` (render pass
 		/// déjà ouvert). Bind pipeline + descriptor (atlas), puis pour chaque
 		/// instance : push constants (avec instancePos), `vkCmdDraw(cmd,6,1,0,0)`.
@@ -87,12 +89,15 @@ namespace engine::render
 		///                      sont déjà posés par le caller via le render pass).
 		/// \param instances     Tableau de `count` instances (même atlas).
 		/// \param albedoView/albedoSamp  Atlas albedo (sRGB) + sampler.
-		/// \param normalView/normalSamp  Atlas normal (UNORM) + sampler.
+		/// \param normalView/normalSamp  Atlas normal (UNORM, a=profondeur) + sampler.
+		/// \param ormView/ormSamp        Atlas ORM (UNORM, r=AO g=rough b=metal) + sampler.
 		/// \param viewProj      Matrice viewProj (16 floats, row-major `.m`).
 		/// \param prevViewProj  Matrice viewProj frame précédente (16 floats).
 		/// \param cameraPos3    Position caméra monde (3 floats).
 		/// \param viewsPerAxis  N de la grille N×N de l'atlas.
 		/// \param tileSize      Côté d'une tile en pixels.
+		/// \param parallaxScale Échelle du décalage de parallax single-step (frag v2),
+		///                      écrite dans `atlasParams.w` des push constants.
 		///
 		/// Effet de bord : met à jour le descriptor set partagé (vkUpdateDescriptorSets)
 		/// à chaque appel — un seul atlas peut donc être lié à la fois ; appeler
@@ -101,11 +106,12 @@ namespace engine::render
 		          const ImpostorInstance* instances, uint32_t count,
 		          VkImageView albedoView, VkSampler albedoSamp,
 		          VkImageView normalView, VkSampler normalSamp,
+		          VkImageView ormView, VkSampler ormSamp,
 		          const float* viewProj, const float* prevViewProj, const float* cameraPos3,
-		          uint32_t viewsPerAxis, uint32_t tileSize);
+		          uint32_t viewsPerAxis, uint32_t tileSize, float parallaxScale);
 
-		/// Sampler linéaire CLAMP_TO_EDGE créé au Init, partagé pour albedo+normal.
-		/// Le caller peut le passer comme `albedoSamp`/`normalSamp` à RecordInstances.
+		/// Sampler linéaire CLAMP_TO_EDGE créé au Init, partagé pour albedo+normal+orm.
+		/// Le caller peut le passer comme `albedoSamp`/`normalSamp`/`ormSamp` à RecordInstances.
 		VkSampler GetSampler() const { return m_sampler; }
 
 		/// Libère tous les objets Vulkan. Sûr d'appeler même non initialisé.

--- a/tools/impostor_builder/CMakeLists.txt
+++ b/tools/impostor_builder/CMakeLists.txt
@@ -13,10 +13,12 @@ add_executable(impostor_builder
 # Include dirs :
 #  - dossier courant (headers de l'outil)
 #  - external/cgltf (cgltf.h, header-only)
+#  - external/stb   (stb_image.h, header-only — décodage textures baseColor)
 #  - racine du dépôt (au cas où un header partagé autonome serait inclus)
 target_include_directories(impostor_builder PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/external/cgltf
+  ${CMAKE_SOURCE_DIR}/external/stb
   ${CMAKE_SOURCE_DIR}
 )
 

--- a/tools/impostor_builder/FORMAT.md
+++ b/tools/impostor_builder/FORMAT.md
@@ -1,18 +1,22 @@
-# Format de l'atlas d'impostors octaédriques (M45.4)
+# Format de l'atlas d'impostors octaédriques (M45.4 — FORMAT v2)
 
 Fichier binaire produit par `impostor_builder`, consommé au runtime par M45.5.
 Toutes les valeurs multi-octets sont en **little-endian**, sérialisées
 **champ par champ** (indépendant du layout mémoire / padding des structs).
+
+La **version 2** du format ajoute un **troisième atlas** (ORM) après albedo et
+normal, échantillonne l'albedo depuis les **textures baseColor** du matériau,
+applique un **anti-aliasing par supersampling** et renseigne un `contentHash`.
 
 ## Disposition
 
 | Offset | Taille | Champ            | Type    | Description                              |
 |-------:|-------:|------------------|---------|------------------------------------------|
 | 0      | 4      | `magic`          | uint32  | `0x4F50494D` = ASCII `MIPO` (LE)         |
-| 4      | 4      | `formatVersion`  | uint32  | Version du format (=1)                   |
-| 8      | 4      | `builderVersion` | uint32  | Version de l'outil                       |
-| 12     | 4      | `engineVersion`  | uint32  | Version moteur cible (0 = indéfini v1)   |
-| 16     | 8      | `contentHash`    | uint64  | Hash du mesh source (0 si non calculé)   |
+| 4      | 4      | `formatVersion`  | uint32  | Version du format (=2)                   |
+| 8      | 4      | `builderVersion` | uint32  | Version de l'outil (=2)                  |
+| 12     | 4      | `engineVersion`  | uint32  | Version moteur cible (0 = indéfini)      |
+| 16     | 8      | `contentHash`    | uint64  | FNV-1a 64 des octets du .gltf source     |
 | 24     | 4      | `viewsPerAxis`   | uint32  | N : grille N×N de vues                   |
 | 28     | 4      | `tileSize`       | uint32  | Côté d'une tile en pixels                |
 | 32     | 4      | `channels`       | uint32  | Canaux par texel (=4, RGBA8)             |
@@ -21,12 +25,30 @@ Toutes les valeurs multi-octets sont en **little-endian**, sérialisées
 | 60     | 8      | `albedoSize`     | uint64  | Taille en octets de l'atlas albedo       |
 | 68     | albedoSize | `albedo`     | uint8[] | Atlas albedo RGBA8                       |
 | …      | 8      | `normalSize`     | uint64  | Taille en octets de l'atlas normal       |
-| …      | normalSize | `normal`     | uint8[] | Atlas normal RGBA8 (encodé + masque)     |
+| …      | normalSize | `normal`     | uint8[] | Atlas normal RGBA8 (encodé + profondeur) |
+| …      | 8      | `ormSize`        | uint64  | Taille en octets de l'atlas ORM          |
+| …      | ormSize | `orm`           | uint8[] | Atlas ORM RGBA8 (AO/rough/metal)         |
 
-`albedoSize == normalSize == (viewsPerAxis*tileSize)^2 * 4`.
+`albedoSize == normalSize == ormSize == (viewsPerAxis*tileSize)^2 * 4`.
 
 Le header logique fait 24 octets (`ImpostorHeader`), suivi des métadonnées
-`ImpostorAtlasInfo`, puis des deux blocs taille+données.
+`ImpostorAtlasInfo`, puis des **trois** blocs taille+données dans l'ordre disque
+**albedo, normal, orm**.
+
+## Hash de contenu (`contentHash`)
+
+`contentHash` est le **FNV-1a 64 bits** des **octets bruts** du fichier `.gltf`
+source (offset basis `1469598103934665603`, prime `1099511628211`). Il s'agit
+bien de FNV-1a, **pas** de xxHash. Il permet de détecter qu'un mesh source a
+changé sans rejouer le rendu.
+
+## Anti-aliasing par supersampling
+
+Chaque tile est rendue à une résolution **SS×** (`--ss`, défaut 2) :
+`ssTile = tileSize * SS`. Après rendu de toutes les vues, chaque atlas est
+**box-downsamplé** vers la résolution finale en moyennant, par canal RGBA, le
+bloc `SS×SS` de texels source pour chaque texel final (moyenne simple). Le
+fichier ne contient que les atlas à la résolution finale (`tileSize`).
 
 ## Disposition de l'atlas (tiles)
 
@@ -71,20 +93,23 @@ orthographique cadrant la sphère englobante (côté `2*radius`).
 
 Référence d'implémentation : `OctahedralMap.h` (`OctaToDir`, `ViewDir`).
 
-## Encodage des canaux
+## Encodage des canaux (v2)
 
-- **Albedo** : RGBA8. En v1, l'albedo provient de la **couleur de sommet**
-  (`COLOR_0`) interpolée — voir limites ci-dessous. Alpha = alpha couleur.
-- **Normale** : RGBA8. La normale monde interpolée est encodée
-  `n * 0.5 + 0.5` par canal. L'**alpha vaut 255 si le texel est couvert**
-  (masque de silhouette), 0 sinon.
+- **Albedo** : RGBA8. `rgb` = albedo = texture **baseColor** échantillonnée via
+  les UV (`TEXCOORD_0`) × `baseColorFactor.rgb` (ou simplement `baseColorFactor`
+  si le matériau n'a pas de texture). `a` = **couverture** (255 sur un fragment
+  écrit). Le **cutout** feuillage : pour un matériau `alphaMode` BLEND/MASK, un
+  fragment dont la couverture interpolée est < 0.5 **n'est pas écrit** (préserve
+  la silhouette + le z-buffer). Après downsample, l'alpha exprime la couverture
+  partielle (bords antialiasés).
+- **Normale** : RGBA8. `rgb` = normale monde interpolée encodée `n * 0.5 + 0.5`
+  par canal. `a` = **profondeur relative** normalisée sur `[depthNear, depthFar]`
+  (0 = près du plan de vue, 255 = loin).
+- **ORM** : RGBA8. `r` = AO (255 par défaut), `g` = `roughnessFactor`×255,
+  `b` = `metallicFactor`×255, `a` = 255.
 
-## Limites v1 (suivi)
+## Limites (suivi)
 
-- **Albedo = couleur de sommet uniquement.** Les textures matériau
-  (baseColorTexture, UV `TEXCOORD_0`) **ne sont pas échantillonnées** en v1.
-  Un mesh sans `COLOR_0` rend en blanc opaque. Échantillonnage de textures =
-  évolution future (v2).
 - Projection **orthographique** uniquement (pas de parallaxe perspective).
-- Pas d'anti-aliasing (1 échantillon par pixel, test de couverture binaire).
-- Pas de hash de contenu calculé (`contentHash = 0`).
+- Anti-aliasing par **supersampling box** uniquement (pas de filtrage avancé).
+- AO toujours 255 (pas de bake d'occlusion ambiante).

--- a/tools/impostor_builder/GltfMeshLoader.cpp
+++ b/tools/impostor_builder/GltfMeshLoader.cpp
@@ -1,13 +1,19 @@
 /// M45.4 — Implémentation du chargement glTF via cgltf.
-/// CGLTF_IMPLEMENTATION n'est défini QUE dans ce .cpp (unique TU).
+/// CGLTF_IMPLEMENTATION et STB_IMAGE_IMPLEMENTATION ne sont définis QUE dans ce
+/// .cpp (unique TU pour chaque bibliothèque header-only).
 
 #define CGLTF_IMPLEMENTATION
 #include "cgltf.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
 
 #include "GltfMeshLoader.h"
 
 #include <cfloat>
 #include <cstring>
+#include <filesystem>
+#include <iostream>
 
 namespace tools::impostor_builder
 {
@@ -21,6 +27,77 @@ namespace tools::impostor_builder
 				if (prim.attributes[a].type == type)
 					return prim.attributes[a].data;
 			return nullptr;
+		}
+
+		/// Résout l'URI d'une image glTF en chemin absolu sur disque.
+		/// \param gltfPath Chemin du .gltf source (sert de base pour l'URI relative).
+		/// \param image    Image cgltf (peut avoir image->uri == nullptr si embarquée).
+		/// \return Chemin résolu, ou chaîne vide si l'URI est absente/data-uri/buffer.
+		std::string ResolveImagePath(const std::string& gltfPath, const cgltf_image* image)
+		{
+			if (image == nullptr || image->uri == nullptr)
+				return {}; // image embarquée (buffer view / data-uri) non gérée ici
+
+			// Les data-URI (base64 inline) commencent par "data:" — non gérées.
+			if (std::strncmp(image->uri, "data:", 5) == 0)
+				return {};
+
+			// Décode les éventuels %20 etc. sur une copie locale.
+			std::string uri = image->uri;
+			std::vector<char> buf(uri.begin(), uri.end());
+			buf.push_back('\0');
+			cgltf_decode_uri(buf.data());
+			uri = buf.data();
+
+			const std::filesystem::path base = std::filesystem::path(gltfPath).parent_path();
+			return (base / uri).string();
+		}
+
+		/// Charge la texture baseColor d'un matériau dans LoadedMaterial.
+		/// Non-fatale : en cas de PNG manquante, warne et laisse bcW=bcH=0.
+		/// \param gltfPath Chemin du .gltf (base de résolution).
+		/// \param src      Matériau cgltf source.
+		/// \param dst      Matériau destination (rempli).
+		/// Effet de bord : warnings sur stderr ; appelle stbi_load/stbi_image_free.
+		void FillMaterial(const std::string& gltfPath, const cgltf_material& src, LoadedMaterial& dst)
+		{
+			if (src.has_pbr_metallic_roughness)
+			{
+				const cgltf_pbr_metallic_roughness& pbr = src.pbr_metallic_roughness;
+				for (int k = 0; k < 4; ++k)
+					dst.baseColorFactor[k] = pbr.base_color_factor[k];
+				dst.metallic  = pbr.metallic_factor;
+				dst.roughness = pbr.roughness_factor;
+
+				const cgltf_texture* tex = pbr.base_color_texture.texture;
+				if (tex != nullptr && tex->image != nullptr)
+				{
+					const std::string imgPath = ResolveImagePath(gltfPath, tex->image);
+					if (!imgPath.empty())
+					{
+						int w = 0, h = 0, comp = 0;
+						// Force RGBA (4 canaux) pour un échantillonnage uniforme.
+						stbi_uc* pixels = stbi_load(imgPath.c_str(), &w, &h, &comp, 4);
+						if (pixels != nullptr && w > 0 && h > 0)
+						{
+							dst.bcW = w;
+							dst.bcH = h;
+							dst.baseColorRGBA.assign(pixels,
+								pixels + static_cast<size_t>(w) * h * 4);
+							stbi_image_free(pixels);
+						}
+						else
+						{
+							std::cerr << "[impostor_builder] WARN: baseColor PNG introuvable/illisible: "
+							          << imgPath << " (fallback baseColorFactor)\n";
+							if (pixels != nullptr) stbi_image_free(pixels);
+						}
+					}
+				}
+			}
+
+			dst.alphaBlendOrMask = (src.alpha_mode == cgltf_alpha_mode_blend ||
+			                        src.alpha_mode == cgltf_alpha_mode_mask);
 		}
 	}
 
@@ -47,6 +124,19 @@ namespace tools::impostor_builder
 			return false;
 		}
 
+		// --- Charge tous les matériaux (index cgltf == index LoadedMesh) -----
+		out.materials.resize(data->materials_count);
+		for (cgltf_size mi = 0; mi < data->materials_count; ++mi)
+			FillMaterial(path, data->materials[mi], out.materials[mi]);
+
+		/// Retrouve l'index global d'un matériau cgltf dans data->materials.
+		/// \return index [0,materials_count) ou -1 si nullptr.
+		auto materialIndexOf = [&](const cgltf_material* m) -> int {
+			if (m == nullptr) return -1;
+			const cgltf_size idx = cgltf_material_index(data, m);
+			return static_cast<int>(idx);
+		};
+
 		float bmin[3] = {FLT_MAX, FLT_MAX, FLT_MAX};
 		float bmax[3] = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
@@ -64,6 +154,7 @@ namespace tools::impostor_builder
 					continue; // POSITION obligatoire ; primitive ignorée si absente
 				const cgltf_accessor* nrmAcc = FindAttr(prim, cgltf_attribute_type_normal);
 				const cgltf_accessor* colAcc = FindAttr(prim, cgltf_attribute_type_color);
+				const cgltf_accessor* uvAcc  = FindAttr(prim, cgltf_attribute_type_texcoord);
 
 				const cgltf_size vcount = posAcc->count;
 				const uint32_t baseVertex = static_cast<uint32_t>(out.vertices.size());
@@ -94,7 +185,14 @@ namespace tools::impostor_builder
 					}
 					// sinon défaut blanc opaque déjà dans RasterVertex.
 
-					// Mise à jour des bounds.
+					if (uvAcc != nullptr)
+					{
+						float uv[2] = {0, 0};
+						cgltf_accessor_read_float(uvAcc, v, uv, 2);
+						rv.uv[0] = uv[0]; rv.uv[1] = uv[1];
+					}
+					// sinon défaut (0,0) déjà dans RasterVertex.
+
 					for (int k = 0; k < 3; ++k)
 					{
 						if (rv.pos[k] < bmin[k]) bmin[k] = rv.pos[k];
@@ -104,7 +202,8 @@ namespace tools::impostor_builder
 					out.vertices.push_back(rv);
 				}
 
-				// Indices (réindexés avec l'offset baseVertex).
+				// --- Indices du sous-mesh (réindexés avec baseVertex) --------
+				const uint32_t firstIndex = static_cast<uint32_t>(out.indices.size());
 				if (prim.indices != nullptr)
 				{
 					const cgltf_size icount = prim.indices->count;
@@ -116,16 +215,22 @@ namespace tools::impostor_builder
 				}
 				else
 				{
-					// Pas d'indices : triangles séquentiels.
 					for (cgltf_size i = 0; i < vcount; ++i)
 						out.indices.push_back(baseVertex + static_cast<uint32_t>(i));
 				}
+
+				LoadedSubMesh sm;
+				sm.firstIndex    = firstIndex;
+				sm.indexCount    = static_cast<uint32_t>(out.indices.size()) - firstIndex;
+				sm.materialIndex = materialIndexOf(prim.material);
+				if (sm.indexCount >= 3)
+					out.subMeshes.push_back(sm);
 			}
 		}
 
 		cgltf_free(data);
 
-		if (out.vertices.empty() || out.indices.empty())
+		if (out.vertices.empty() || out.indices.empty() || out.subMeshes.empty())
 		{
 			err = "LoadGltf: aucune primitive triangle exploitable dans " + path;
 			return false;

--- a/tools/impostor_builder/GltfMeshLoader.h
+++ b/tools/impostor_builder/GltfMeshLoader.h
@@ -1,5 +1,7 @@
 /// M45.4 — Chargement d'un mesh glTF statique via cgltf (outil offline).
 /// Aucune dépendance moteur/Vulkan : cgltf est inclus en header-only.
+/// FORMAT v2 : conserve les sous-meshes séparés (un par primitive) avec leur
+/// matériau, et charge les textures baseColor (PNG voisins) via stb_image.
 
 #pragma once
 
@@ -11,26 +13,55 @@
 
 namespace tools::impostor_builder
 {
-	/// Mesh chargé et aplati en un seul buffer de sommets + indices.
+	/// Matériau chargé : facteurs PBR + texture baseColor décodée (si présente).
+	struct LoadedMaterial
+	{
+		std::vector<uint8_t> baseColorRGBA;       ///< Pixels RGBA8 baseColor (vide si pas de texture).
+		int bcW = 0;                              ///< Largeur baseColor (0x0 si pas de texture).
+		int bcH = 0;                              ///< Hauteur baseColor.
+		float baseColorFactor[4] = {1, 1, 1, 1};  ///< Facteur multiplicatif RGBA.
+		float metallic = 0.0f;                    ///< metallicFactor [0,1].
+		float roughness = 1.0f;                   ///< roughnessFactor [0,1].
+		bool  alphaBlendOrMask = false;           ///< alphaMode == BLEND ou MASK (active le cutout feuillage).
+	};
+
+	/// Sous-mesh : plage d'indices contiguë associée à un matériau.
+	/// Permet de savoir quel matériau/texture s'applique à quel triangle.
+	struct LoadedSubMesh
+	{
+		uint32_t firstIndex = 0;   ///< Offset du premier indice dans LoadedMesh::indices.
+		uint32_t indexCount = 0;   ///< Nombre d'indices (multiple de 3).
+		int      materialIndex = -1; ///< Index dans LoadedMesh::materials (-1 = aucun matériau).
+	};
+
+	/// Mesh chargé : sommets + indices globaux, découpés en sous-meshes par matériau.
 	struct LoadedMesh
 	{
-		std::vector<RasterVertex> vertices; ///< Sommets fusionnés (toutes primitives).
-		std::vector<uint32_t>     indices;  ///< Indices de triangles (multiple de 3).
+		std::vector<RasterVertex>  vertices;  ///< Sommets fusionnés (toutes primitives).
+		std::vector<uint32_t>      indices;   ///< Indices de triangles (multiple de 3).
+		std::vector<LoadedSubMesh> subMeshes; ///< Plages d'indices + matériau par primitive.
+		std::vector<LoadedMaterial> materials;///< Matériaux référencés par les sous-meshes.
 		float boundsMin[3] = {0.0f, 0.0f, 0.0f}; ///< Coin min de l'AABB monde.
 		float boundsMax[3] = {0.0f, 0.0f, 0.0f}; ///< Coin max de l'AABB monde.
 	};
 
-	/// Charge un fichier glTF (.gltf/.glb) et fusionne ses primitives triangles.
+	/// Charge un fichier glTF (.gltf/.glb) en conservant les sous-meshes/matériaux.
 	///
 	/// Attributs lus par sommet :
-	///   - POSITION  (obligatoire ; échec si absent).
-	///   - NORMAL    (défaut (0,1,0) si absent).
-	///   - COLOR_0   (défaut blanc opaque si absent ; RGB étendu en RGBA si vec3).
-	/// Les textures et UV ne sont PAS échantillonnés en v1 (cf. FORMAT.md).
+	///   - POSITION   (obligatoire ; primitive ignorée si absente).
+	///   - NORMAL     (défaut (0,1,0) si absent).
+	///   - COLOR_0    (défaut blanc opaque si absent ; RGB étendu en RGBA si vec3).
+	///   - TEXCOORD_0 (défaut (0,0) si absent).
+	///
+	/// Matériaux : metallic/roughness/baseColor factors + alphaMode lus depuis
+	/// cgltf. Si une baseColorTexture est présente, son image (URI relative au
+	/// dossier du .gltf) est chargée en RGBA8 via stbi_load. Une PNG manquante
+	/// est non-fatale (warning sur stderr, matériau retombe sur baseColorFactor).
 	///
 	/// \param path Chemin du fichier glTF.
-	/// \param out  Mesh résultant (sommets + indices + bounds).
+	/// \param out  Mesh résultant (sommets + indices + sous-meshes + matériaux + bounds).
 	/// \param err  Message d'erreur lisible en cas d'échec.
 	/// \return true si au moins une primitive triangle a été chargée.
+	/// Effet de bord : peut écrire des warnings sur stderr (PNG introuvable).
 	bool LoadGltf(const std::string& path, LoadedMesh& out, std::string& err);
 }

--- a/tools/impostor_builder/ImpostorFormat.cpp
+++ b/tools/impostor_builder/ImpostorFormat.cpp
@@ -70,35 +70,83 @@ namespace tools::impostor_builder
 		}
 	}
 
+	namespace
+	{
+		/// Lit un bloc [u64 size][size octets] et valide size == expected.
+		/// \param label Nom de l'atlas pour les messages d'erreur ("albedo"…).
+		/// \return true si la taille et les données ont été lues et validées.
+		bool ReadAtlasBlock(std::istream& is, uint64_t expected,
+		                    std::vector<uint8_t>& out, const char* label,
+		                    std::string& err)
+		{
+			bool ok = true;
+			const uint64_t size = ReadU64(is, ok);
+			if (!ok)
+			{
+				err = std::string("ReadImpostorFile: fichier tronqué (taille ") + label + ")";
+				return false;
+			}
+			if (size != expected)
+			{
+				err = std::string("ReadImpostorFile: taille ") + label +
+				      " incohérente avec les métadonnées";
+				return false;
+			}
+			out.resize(static_cast<size_t>(size));
+			if (size > 0)
+			{
+				is.read(reinterpret_cast<char*>(out.data()),
+				        static_cast<std::streamsize>(size));
+				if (!is)
+				{
+					err = std::string("ReadImpostorFile: fichier tronqué (données ") + label + ")";
+					return false;
+				}
+			}
+			return true;
+		}
+
+		/// Écrit un bloc [u64 size][size octets] dans le flux.
+		void WriteAtlasBlock(std::ostream& os, const std::vector<uint8_t>& data)
+		{
+			WriteU64(os, static_cast<uint64_t>(data.size()));
+			if (!data.empty())
+				os.write(reinterpret_cast<const char*>(data.data()),
+				         static_cast<std::streamsize>(data.size()));
+		}
+	}
+
 	bool WriteImpostorFile(const std::string& path,
 	                       const ImpostorAtlasInfo& info,
-	                       const std::vector<uint8_t>& albedoAtlas,
-	                       const std::vector<uint8_t>& normalAtlas,
-	                       std::string& outError)
+	                       uint64_t contentHash,
+	                       const std::vector<uint8_t>& albedo,
+	                       const std::vector<uint8_t>& normal,
+	                       const std::vector<uint8_t>& orm,
+	                       std::string& err)
 	{
 		// Vérification de cohérence des tailles avant écriture.
 		const uint64_t atlasDim = static_cast<uint64_t>(info.viewsPerAxis) * info.tileSize;
 		const uint64_t expected = atlasDim * atlasDim * info.channels;
-		if (albedoAtlas.size() != expected || normalAtlas.size() != expected)
+		if (albedo.size() != expected || normal.size() != expected || orm.size() != expected)
 		{
-			outError = "WriteImpostorFile: taille d'atlas incohérente avec viewsPerAxis/tileSize/channels";
+			err = "WriteImpostorFile: taille d'atlas incohérente avec viewsPerAxis/tileSize/channels";
 			return false;
 		}
 
 		std::ofstream os(path, std::ios::binary | std::ios::trunc);
 		if (!os)
 		{
-			outError = "WriteImpostorFile: impossible d'ouvrir en écriture: " + path;
+			err = "WriteImpostorFile: impossible d'ouvrir en écriture: " + path;
 			return false;
 		}
 
 		// --- Header (24 octets) -----------------------------------------
-		ImpostorHeader header; // valeurs par défaut = magic/version courants
+		ImpostorHeader header; // magic/version/builderVersion = défauts courants (v2)
 		WriteU32(os, header.magic);
 		WriteU32(os, header.formatVersion);
 		WriteU32(os, header.builderVersion);
 		WriteU32(os, header.engineVersion);
-		WriteU64(os, header.contentHash);
+		WriteU64(os, contentHash); // hash FNV-1a 64 fourni par l'appelant
 
 		// --- ImpostorAtlasInfo ------------------------------------------
 		WriteU32(os, info.viewsPerAxis);
@@ -107,21 +155,14 @@ namespace tools::impostor_builder
 		for (int i = 0; i < 3; ++i) WriteF32(os, info.boundsMin[i]);
 		for (int i = 0; i < 3; ++i) WriteF32(os, info.boundsMax[i]);
 
-		// --- Atlas albedo -----------------------------------------------
-		WriteU64(os, static_cast<uint64_t>(albedoAtlas.size()));
-		if (!albedoAtlas.empty())
-			os.write(reinterpret_cast<const char*>(albedoAtlas.data()),
-			         static_cast<std::streamsize>(albedoAtlas.size()));
-
-		// --- Atlas normal -----------------------------------------------
-		WriteU64(os, static_cast<uint64_t>(normalAtlas.size()));
-		if (!normalAtlas.empty())
-			os.write(reinterpret_cast<const char*>(normalAtlas.data()),
-			         static_cast<std::streamsize>(normalAtlas.size()));
+		// --- Trois atlas dans l'ordre disque : albedo, normal, orm ------
+		WriteAtlasBlock(os, albedo);
+		WriteAtlasBlock(os, normal);
+		WriteAtlasBlock(os, orm);
 
 		if (!os)
 		{
-			outError = "WriteImpostorFile: erreur d'écriture sur " + path;
+			err = "WriteImpostorFile: erreur d'écriture sur " + path;
 			return false;
 		}
 		return true;
@@ -129,14 +170,16 @@ namespace tools::impostor_builder
 
 	bool ReadImpostorFile(const std::string& path,
 	                      ImpostorAtlasInfo& outInfo,
+	                      uint64_t& outContentHash,
 	                      std::vector<uint8_t>& outAlbedo,
 	                      std::vector<uint8_t>& outNormal,
-	                      std::string& outError)
+	                      std::vector<uint8_t>& outOrm,
+	                      std::string& err)
 	{
 		std::ifstream is(path, std::ios::binary);
 		if (!is)
 		{
-			outError = "ReadImpostorFile: impossible d'ouvrir en lecture: " + path;
+			err = "ReadImpostorFile: impossible d'ouvrir en lecture: " + path;
 			return false;
 		}
 
@@ -147,20 +190,20 @@ namespace tools::impostor_builder
 		const uint32_t fmtVer  = ReadU32(is, ok);
 		(void)ReadU32(is, ok); // builderVersion
 		(void)ReadU32(is, ok); // engineVersion
-		(void)ReadU64(is, ok); // contentHash
+		outContentHash = ReadU64(is, ok);
 		if (!ok)
 		{
-			outError = "ReadImpostorFile: fichier tronqué (header)";
+			err = "ReadImpostorFile: fichier tronqué (header)";
 			return false;
 		}
 		if (magic != kImpostorMagic)
 		{
-			outError = "ReadImpostorFile: magic invalide";
+			err = "ReadImpostorFile: magic invalide";
 			return false;
 		}
 		if (fmtVer != kImpostorVersion)
 		{
-			outError = "ReadImpostorFile: version de format non supportée";
+			err = "ReadImpostorFile: version de format non supportée (attendu 2)";
 			return false;
 		}
 
@@ -172,59 +215,17 @@ namespace tools::impostor_builder
 		for (int i = 0; i < 3; ++i) outInfo.boundsMax[i] = ReadF32(is, ok);
 		if (!ok)
 		{
-			outError = "ReadImpostorFile: fichier tronqué (atlas info)";
+			err = "ReadImpostorFile: fichier tronqué (atlas info)";
 			return false;
 		}
 
-		// --- Atlas albedo -----------------------------------------------
-		const uint64_t albedoSize = ReadU64(is, ok);
-		if (!ok)
-		{
-			outError = "ReadImpostorFile: fichier tronqué (taille albedo)";
-			return false;
-		}
 		const uint64_t atlasDim = static_cast<uint64_t>(outInfo.viewsPerAxis) * outInfo.tileSize;
 		const uint64_t expected = atlasDim * atlasDim * outInfo.channels;
-		if (albedoSize != expected)
-		{
-			outError = "ReadImpostorFile: taille albedo incohérente avec les métadonnées";
-			return false;
-		}
-		outAlbedo.resize(static_cast<size_t>(albedoSize));
-		if (albedoSize > 0)
-		{
-			is.read(reinterpret_cast<char*>(outAlbedo.data()),
-			        static_cast<std::streamsize>(albedoSize));
-			if (!is)
-			{
-				outError = "ReadImpostorFile: fichier tronqué (données albedo)";
-				return false;
-			}
-		}
 
-		// --- Atlas normal -----------------------------------------------
-		const uint64_t normalSize = ReadU64(is, ok);
-		if (!ok)
-		{
-			outError = "ReadImpostorFile: fichier tronqué (taille normal)";
-			return false;
-		}
-		if (normalSize != expected)
-		{
-			outError = "ReadImpostorFile: taille normal incohérente avec les métadonnées";
-			return false;
-		}
-		outNormal.resize(static_cast<size_t>(normalSize));
-		if (normalSize > 0)
-		{
-			is.read(reinterpret_cast<char*>(outNormal.data()),
-			        static_cast<std::streamsize>(normalSize));
-			if (!is)
-			{
-				outError = "ReadImpostorFile: fichier tronqué (données normal)";
-				return false;
-			}
-		}
+		// --- Trois atlas dans l'ordre disque : albedo, normal, orm ------
+		if (!ReadAtlasBlock(is, expected, outAlbedo, "albedo", err)) return false;
+		if (!ReadAtlasBlock(is, expected, outNormal, "normal", err)) return false;
+		if (!ReadAtlasBlock(is, expected, outOrm, "orm", err)) return false;
 
 		return true;
 	}

--- a/tools/impostor_builder/ImpostorFormat.h
+++ b/tools/impostor_builder/ImpostorFormat.h
@@ -5,11 +5,12 @@
 /// en little-endian pour la portabilité (Windows/Linux), à la manière de
 /// OutputVersion.cpp côté moteur, mais répliqué inline ici.
 ///
-/// Disposition du fichier (voir FORMAT.md pour le détail des offsets) :
+/// Disposition du fichier FORMAT v2 (voir FORMAT.md pour le détail des offsets) :
 ///   [ ImpostorHeader      24 octets, champ par champ ]
 ///   [ ImpostorAtlasInfo   métadonnées atlas         ]
 ///   [ uint64 albedoSize ][ albedoSize octets RGBA8  ]
 ///   [ uint64 normalSize ][ normalSize octets RGBA8  ]
+///   [ uint64 ormSize    ][ ormSize    octets RGBA8  ]
 
 #pragma once
 
@@ -26,7 +27,9 @@ namespace tools::impostor_builder
 
 	/// Version du format binaire. Incrémenter à chaque changement non
 	/// rétro-compatible de la disposition disque.
-	constexpr uint32_t kImpostorVersion = 1u;
+	/// v2 : ajoute un TROISIÈME atlas (orm) après albedo+normal, albedo
+	/// échantillonné depuis les textures baseColor, contentHash = FNV-1a 64.
+	constexpr uint32_t kImpostorVersion = 2u;
 
 	/// En-tête fixe de 24 octets, écrit/lu champ par champ (little-endian).
 	/// IMPORTANT : ne JAMAIS dépendre du layout mémoire du struct sur disque —
@@ -36,9 +39,9 @@ namespace tools::impostor_builder
 	{
 		uint32_t magic         = kImpostorMagic;  ///< kImpostorMagic.
 		uint32_t formatVersion = kImpostorVersion; ///< Version du format disque.
-		uint32_t builderVersion = 1u;             ///< Version de l'outil ayant produit le fichier.
-		uint32_t engineVersion  = 0u;             ///< Version moteur cible (0 = indéfini en v1).
-		uint64_t contentHash    = 0u;             ///< Hash du contenu (mesh source), 0 si non calculé.
+		uint32_t builderVersion = 2u;             ///< Version de l'outil ayant produit le fichier.
+		uint32_t engineVersion  = 0u;             ///< Version moteur cible (0 = indéfini).
+		uint64_t contentHash    = 0u;             ///< Hash FNV-1a 64 du .gltf source (0 si non calculé).
 	};
 	static_assert(sizeof(ImpostorHeader) == 24, "ImpostorHeader doit faire 24 octets");
 
@@ -47,36 +50,45 @@ namespace tools::impostor_builder
 	{
 		uint32_t viewsPerAxis = 0u; ///< N : la grille fait N×N tiles (vues).
 		uint32_t tileSize     = 0u; ///< Côté d'une tile en pixels (carrée).
-		uint32_t channels     = 4u; ///< Canaux par texel (toujours 4 = RGBA8 en v1).
+		uint32_t channels     = 4u; ///< Canaux par texel (toujours 4 = RGBA8).
 		float    boundsMin[3] = {0.0f, 0.0f, 0.0f}; ///< Coin min de l'AABB monde du mesh.
 		float    boundsMax[3] = {0.0f, 0.0f, 0.0f}; ///< Coin max de l'AABB monde du mesh.
 	};
 
-	/// Écrit un fichier d'atlas d'impostors complet (header + info + atlas).
+	/// Écrit un fichier d'atlas d'impostors complet (header + info + 3 atlas).
+	/// FORMAT v2 : sérialise les trois atlas dans l'ordre disque albedo, normal, orm.
 	/// \param path        Chemin de sortie (créé/écrasé).
 	/// \param info        Métadonnées de la grille (viewsPerAxis, tileSize, bounds).
-	/// \param albedoAtlas Atlas albedo RGBA8, taille attendue =
+	/// \param contentHash Hash du mesh source (FNV-1a 64) écrit dans header.contentHash.
+	/// \param albedo      Atlas albedo RGBA8, taille attendue =
 	///                    (viewsPerAxis*tileSize)^2 * 4 octets.
-	/// \param normalAtlas Atlas normal RGBA8, même taille que l'albedo.
-	/// \param outError    Message d'erreur lisible en cas d'échec.
+	/// \param normal      Atlas normal RGBA8, même taille que l'albedo.
+	/// \param orm         Atlas ORM RGBA8, même taille que l'albedo.
+	/// \param err         Message d'erreur lisible en cas d'échec.
 	/// \return true si l'écriture a réussi.
 	/// Effet de bord : crée/écrase le fichier sur disque.
 	bool WriteImpostorFile(const std::string& path,
 	                       const ImpostorAtlasInfo& info,
-	                       const std::vector<uint8_t>& albedoAtlas,
-	                       const std::vector<uint8_t>& normalAtlas,
-	                       std::string& outError);
+	                       uint64_t contentHash,
+	                       const std::vector<uint8_t>& albedo,
+	                       const std::vector<uint8_t>& normal,
+	                       const std::vector<uint8_t>& orm,
+	                       std::string& err);
 
-	/// Relit un fichier d'atlas d'impostors et restitue info + atlas (round-trip).
-	/// \param path      Chemin du fichier à lire.
-	/// \param outInfo   Métadonnées restituées.
-	/// \param outAlbedo Atlas albedo RGBA8 restitué.
-	/// \param outNormal Atlas normal RGBA8 restitué.
-	/// \param outError  Message d'erreur lisible en cas d'échec.
-	/// \return true si la lecture et la validation (magic/version/tailles) ont réussi.
+	/// Relit un fichier d'atlas d'impostors et restitue info + 3 atlas (round-trip).
+	/// \param path          Chemin du fichier à lire.
+	/// \param outInfo       Métadonnées restituées.
+	/// \param outContentHash Hash de contenu lu depuis le header.
+	/// \param outAlbedo     Atlas albedo RGBA8 restitué.
+	/// \param outNormal     Atlas normal RGBA8 restitué.
+	/// \param outOrm        Atlas ORM RGBA8 restitué.
+	/// \param err           Message d'erreur lisible en cas d'échec.
+	/// \return true si la lecture et la validation (magic/version==2/tailles) ont réussi.
 	bool ReadImpostorFile(const std::string& path,
 	                      ImpostorAtlasInfo& outInfo,
+	                      uint64_t& outContentHash,
 	                      std::vector<uint8_t>& outAlbedo,
 	                      std::vector<uint8_t>& outNormal,
-	                      std::string& outError);
+	                      std::vector<uint8_t>& outOrm,
+	                      std::string& err);
 }

--- a/tools/impostor_builder/Rasterizer.cpp
+++ b/tools/impostor_builder/Rasterizer.cpp
@@ -1,4 +1,6 @@
 /// M45.4 — Implémentation du mini-rasterizer CPU (barycentrique + z-buffer).
+/// FORMAT v2 : trois atlas (albedo/normal/orm), échantillonnage de texture
+/// baseColor bilinéaire (wrap REPEAT), alpha cutout, profondeur relative.
 
 #include "Rasterizer.h"
 
@@ -26,19 +28,61 @@ namespace tools::impostor_builder
 			v = std::clamp(v, 0.0f, 1.0f);
 			return static_cast<uint8_t>(v * 255.0f + 0.5f);
 		}
+
+		/// Replie une coordonnée de texture continue en mode REPEAT vers [0,dim).
+		/// \param c   Coordonnée en texels (peut être négative ou > dim).
+		/// \param dim Dimension de l'axe (largeur ou hauteur).
+		/// \return Index entier dans [0,dim-1].
+		int WrapRepeat(int c, int dim)
+		{
+			if (dim <= 0) return 0;
+			int r = c % dim;
+			if (r < 0) r += dim;
+			return r;
+		}
+
+		/// Échantillonne une texture RGBA8 en bilinéaire avec wrap REPEAT.
+		/// \param tex  Pixels RGBA8 (origine haut-gauche).
+		/// \param w    Largeur en texels.
+		/// \param h    Hauteur en texels.
+		/// \param u    Coordonnée U (0=gauche, 1=droite ; non bornée -> REPEAT).
+		/// \param v    Coordonnée V (0=haut, 1=bas selon convention glTF).
+		/// \param out  Couleur échantillonnée RGBA en [0,1].
+		void SampleBilinear(const uint8_t* tex, int w, int h, float u, float v, float out[4])
+		{
+			// Espace texel centré (-0.5 pour le centre du texel).
+			const float fx = u * static_cast<float>(w) - 0.5f;
+			const float fy = v * static_cast<float>(h) - 0.5f;
+			const int x0 = static_cast<int>(std::floor(fx));
+			const int y0 = static_cast<int>(std::floor(fy));
+			const float tx = fx - static_cast<float>(x0);
+			const float ty = fy - static_cast<float>(y0);
+
+			const int xa = WrapRepeat(x0, w);
+			const int xb = WrapRepeat(x0 + 1, w);
+			const int ya = WrapRepeat(y0, h);
+			const int yb = WrapRepeat(y0 + 1, h);
+
+			auto texel = [&](int x, int y, int c) -> float {
+				return static_cast<float>(tex[(static_cast<size_t>(y) * w + x) * 4 + c]) / 255.0f;
+			};
+
+			for (int c = 0; c < 4; ++c)
+			{
+				const float top    = texel(xa, ya, c) * (1.0f - tx) + texel(xb, ya, c) * tx;
+				const float bottom = texel(xa, yb, c) * (1.0f - tx) + texel(xb, yb, c) * tx;
+				out[c] = top * (1.0f - ty) + bottom * ty;
+			}
+		}
 	}
 
-	void RasterizeTile(const std::vector<RasterVertex>& verts,
-	                   const std::vector<uint32_t>& indices,
-	                   const float viewProj[16],
-	                   const RasterTarget& target,
-	                   std::vector<float>& zbuf)
+	void ClearTile(const RasterTarget& target, std::vector<float>& zbuf)
 	{
 		const uint32_t ts = target.tileSize;
-		if (ts == 0 || target.albedo == nullptr || target.normal == nullptr)
+		if (ts == 0 || target.albedo == nullptr || target.normal == nullptr ||
+		    target.orm == nullptr)
 			return;
 
-		// Réinitialise le z-buffer de la tile et efface la tile (transparent).
 		zbuf.assign(static_cast<size_t>(ts) * ts, std::numeric_limits<float>::infinity());
 		const uint32_t baseX = target.tileX * ts;
 		const uint32_t baseY = target.tileY * ts;
@@ -51,10 +95,39 @@ namespace tools::impostor_builder
 				target.albedo[px + 2] = 0; target.albedo[px + 3] = 0;
 				target.normal[px + 0] = 0; target.normal[px + 1] = 0;
 				target.normal[px + 2] = 0; target.normal[px + 3] = 0;
+				target.orm[px + 0] = 0; target.orm[px + 1] = 0;
+				target.orm[px + 2] = 0; target.orm[px + 3] = 0;
 			}
 		}
+	}
 
+	void RasterizeSubMesh(const std::vector<RasterVertex>& verts,
+	                      const std::vector<uint32_t>& indices,
+	                      const float viewProj[16],
+	                      const RasterTarget& target,
+	                      std::vector<float>& zbuf,
+	                      const RasterMaterial& mat,
+	                      float depthNear,
+	                      float depthFar)
+	{
+		const uint32_t ts = target.tileSize;
+		if (ts == 0 || target.albedo == nullptr || target.normal == nullptr ||
+		    target.orm == nullptr)
+			return;
+
+		const uint32_t baseX = target.tileX * ts;
+		const uint32_t baseY = target.tileY * ts;
 		const float fts = static_cast<float>(ts);
+
+		// Étendue de profondeur pour normaliser la depth relative (atlas normal.a).
+		float depthRange = depthFar - depthNear;
+		if (std::fabs(depthRange) < 1e-8f) depthRange = 1.0f;
+
+		const bool hasTex = (mat.baseColorRGBA != nullptr && mat.bcW > 0 && mat.bcH > 0);
+		// ORM constant par sous-mesh (pas de texture ORM échantillonnée en v2).
+		const uint8_t ormAo = 255;
+		const uint8_t ormR  = ToU8(mat.roughness);
+		const uint8_t ormM  = ToU8(mat.metallic);
 
 		for (size_t t = 0; t + 2 < indices.size(); t += 3)
 		{
@@ -74,13 +147,11 @@ namespace tools::impostor_builder
 			TransformPoint(viewProj, v1.pos[0], v1.pos[1], v1.pos[2], c1);
 			TransformPoint(viewProj, v2.pos[0], v2.pos[1], v2.pos[2], c2);
 
-			// Ortho : w == 1 (pas de division perspective réelle), mais on
-			// divise quand même par w par robustesse.
+			// Ortho : w == 1, mais on divise par w par robustesse.
 			const float w0 = (c0[3] != 0.0f) ? c0[3] : 1.0f;
 			const float w1 = (c1[3] != 0.0f) ? c1[3] : 1.0f;
 			const float w2 = (c2[3] != 0.0f) ? c2[3] : 1.0f;
 
-			// NDC -> coordonnées écran tile [0,ts]. NDC x,y dans [-1,1].
 			const float sx0 = (c0[0] / w0 * 0.5f + 0.5f) * fts;
 			const float sy0 = (c0[1] / w0 * 0.5f + 0.5f) * fts;
 			const float sx1 = (c1[0] / w1 * 0.5f + 0.5f) * fts;
@@ -92,7 +163,6 @@ namespace tools::impostor_builder
 			const float z1 = c1[2] / w1;
 			const float z2 = c2[2] / w2;
 
-			// Bounding box écran clippée aux bords de la tile.
 			int minX = static_cast<int>(std::floor(std::min({sx0, sx1, sx2})));
 			int maxX = static_cast<int>(std::ceil (std::max({sx0, sx1, sx2})));
 			int minY = static_cast<int>(std::floor(std::min({sy0, sy1, sy2})));
@@ -104,7 +174,6 @@ namespace tools::impostor_builder
 			if (minX > maxX || minY > maxY)
 				continue;
 
-			// Aire signée (×2) pour les coordonnées barycentriques.
 			const float area = (sx1 - sx0) * (sy2 - sy0) - (sx2 - sx0) * (sy1 - sy0);
 			if (std::fabs(area) < 1e-8f)
 				continue; // triangle dégénéré
@@ -114,16 +183,13 @@ namespace tools::impostor_builder
 			{
 				for (int px = minX; px <= maxX; ++px)
 				{
-					// Centre du pixel.
 					const float fx = static_cast<float>(px) + 0.5f;
 					const float fy = static_cast<float>(py) + 0.5f;
 
-					// Poids barycentriques.
 					float w0b = ((sx1 - fx) * (sy2 - fy) - (sx2 - fx) * (sy1 - fy)) * invArea;
 					float w1b = ((sx2 - fx) * (sy0 - fy) - (sx0 - fx) * (sy2 - fy)) * invArea;
 					float w2b = 1.0f - w0b - w1b;
 
-					// Couverture : tous les poids du même signe que l'aire.
 					if (w0b < 0.0f || w1b < 0.0f || w2b < 0.0f)
 						continue;
 
@@ -132,35 +198,72 @@ namespace tools::impostor_builder
 					const size_t zi = static_cast<size_t>(py) * ts + px;
 					if (depth >= zbuf[zi])
 						continue; // déjà un fragment plus proche
+
+					// --- Albedo : couleur sommet × facteur, optionnellement texturé.
+					float baseR = w0b * v0.color[0] + w1b * v1.color[0] + w2b * v2.color[0];
+					float baseG = w0b * v0.color[1] + w1b * v1.color[1] + w2b * v2.color[1];
+					float baseB = w0b * v0.color[2] + w1b * v1.color[2] + w2b * v2.color[2];
+					float baseA = w0b * v0.color[3] + w1b * v1.color[3] + w2b * v2.color[3];
+
+					float texA = 1.0f;
+					if (hasTex)
+					{
+						const float u = w0b * v0.uv[0] + w1b * v1.uv[0] + w2b * v2.uv[0];
+						const float vv = w0b * v0.uv[1] + w1b * v1.uv[1] + w2b * v2.uv[1];
+						float tex[4];
+						SampleBilinear(mat.baseColorRGBA, mat.bcW, mat.bcH, u, vv, tex);
+						// Combine texture × couleur sommet (le feuillage encode souvent
+						// la teinte dans COLOR_0). L'alpha de couverture vient de la
+						// texture (canal alpha du PNG) modulé par la couleur sommet.
+						baseR *= tex[0]; baseG *= tex[1]; baseB *= tex[2];
+						texA = tex[3];
+					}
+
+					// albedo.rgb = base × baseColorFactor.rgb
+					float albR = baseR * mat.baseColorFactor[0];
+					float albG = baseG * mat.baseColorFactor[1];
+					float albB = baseB * mat.baseColorFactor[2];
+					// coverage = texAlpha × colorAlpha × baseColorFactor.a
+					const float coverage = texA * baseA * mat.baseColorFactor[3];
+
+					// Alpha cutout (feuillage BLEND/MASK) : sous le seuil -> non couvert.
+					if (mat.alphaCutout && coverage < 0.5f)
+						continue;
+
+					// Le fragment couvre : on engage le z-buffer maintenant.
 					zbuf[zi] = depth;
 
-					// Interpolation couleur.
-					float r = w0b * v0.color[0] + w1b * v1.color[0] + w2b * v2.color[0];
-					float g = w0b * v0.color[1] + w1b * v1.color[1] + w2b * v2.color[1];
-					float b = w0b * v0.color[2] + w1b * v1.color[2] + w2b * v2.color[2];
-					float a = w0b * v0.color[3] + w1b * v1.color[3] + w2b * v2.color[3];
-
-					// Interpolation normale + renormalisation.
+					// Normale monde interpolée + renormalisation.
 					float nx = w0b * v0.normal[0] + w1b * v1.normal[0] + w2b * v2.normal[0];
 					float ny = w0b * v0.normal[1] + w1b * v1.normal[1] + w2b * v2.normal[1];
 					float nz = w0b * v0.normal[2] + w1b * v1.normal[2] + w2b * v2.normal[2];
 					const float nlen = std::sqrt(nx * nx + ny * ny + nz * nz);
 					if (nlen > 1e-6f) { nx /= nlen; ny /= nlen; nz /= nlen; }
 
+					// Profondeur relative normalisée [0,1] sur l'étendue de la vue.
+					const float depthRel = (depth - depthNear) / depthRange;
+
 					const uint32_t ax = baseX + static_cast<uint32_t>(px);
 					const uint32_t ay = baseY + static_cast<uint32_t>(py);
 					const size_t off = (static_cast<size_t>(ay) * target.atlasWidth + ax) * 4;
 
-					target.albedo[off + 0] = ToU8(r);
-					target.albedo[off + 1] = ToU8(g);
-					target.albedo[off + 2] = ToU8(b);
-					target.albedo[off + 3] = ToU8(a);
+					// Atlas albedo : rgb = albedo (sRGB), a = couverture (255).
+					target.albedo[off + 0] = ToU8(albR);
+					target.albedo[off + 1] = ToU8(albG);
+					target.albedo[off + 2] = ToU8(albB);
+					target.albedo[off + 3] = 255;
 
-					// Encodage monde -> [0,1]. Alpha = masque de couverture.
+					// Atlas normal : rgb = n*0.5+0.5, a = depth relative.
 					target.normal[off + 0] = ToU8(nx * 0.5f + 0.5f);
 					target.normal[off + 1] = ToU8(ny * 0.5f + 0.5f);
 					target.normal[off + 2] = ToU8(nz * 0.5f + 0.5f);
-					target.normal[off + 3] = 255;
+					target.normal[off + 3] = ToU8(depthRel);
+
+					// Atlas ORM : r = AO, g = roughness, b = metallic, a = 255.
+					target.orm[off + 0] = ormAo;
+					target.orm[off + 1] = ormR;
+					target.orm[off + 2] = ormM;
+					target.orm[off + 3] = 255;
 				}
 			}
 		}

--- a/tools/impostor_builder/Rasterizer.h
+++ b/tools/impostor_builder/Rasterizer.h
@@ -1,10 +1,15 @@
 /// M45.4 — Mini-rasterizer CPU autonome (pas de Vulkan, pas de moteur).
 ///
-/// Rasterise des triangles dans une tile RGBA8 (albedo + normale encodée)
+/// Rasterise des triangles dans une tile RGBA8 (albedo + normale encodée + ORM)
 /// avec z-buffer par tile. Projection orthographique fournie par l'appelant
 /// sous forme d'une view-projection 4x4 (column-major, NDC Vulkan : Y vers le
 /// bas, Z dans [0,1]). Le rasterizer écrit directement dans des sous-régions
 /// (tiles) d'atlas plus larges.
+///
+/// FORMAT v2 : trois atlas sont produits (albedo, normal, orm). L'échantillonnage
+/// albedo provient des TEXTURES matériau (baseColorTexture) interpolées via les UV
+/// du sommet, avec alpha cutout pour le feuillage. Anti-aliasing par supersampling
+/// (SS=2) géré au niveau de l'appelant qui rend une tile SS× puis box-downsample.
 
 #pragma once
 
@@ -13,43 +18,86 @@
 
 namespace tools::impostor_builder
 {
-	/// Sommet d'entrée du rasterizer : position monde, normale monde, couleur RGBA.
+	/// Sommet d'entrée du rasterizer : position monde, normale monde, couleur RGBA, UV.
 	struct RasterVertex
 	{
 		float pos[3]    = {0.0f, 0.0f, 0.0f};
 		float normal[3] = {0.0f, 1.0f, 0.0f};
 		float color[4]  = {1.0f, 1.0f, 1.0f, 1.0f};
+		float uv[2]     = {0.0f, 0.0f}; ///< TEXCOORD_0 (défaut (0,0) si absent).
 	};
 
-	/// Cible de rendu d'une tile : pointeurs vers les atlas et placement de la tile.
+	/// Matériau courant utilisé par le rasterizer pour échantillonner l'albedo et
+	/// remplir l'atlas ORM. Pointe sur les pixels d'une texture baseColor déjà
+	/// chargée (RGBA8, origine haut-gauche), ou bcW=bcH=0 si pas de texture
+	/// (l'albedo se réduit alors au baseColorFactor).
+	struct RasterMaterial
+	{
+		const uint8_t* baseColorRGBA = nullptr; ///< Pixels baseColor RGBA8 (peut être nullptr).
+		int bcW = 0;                            ///< Largeur texture baseColor (0 = pas de texture).
+		int bcH = 0;                            ///< Hauteur texture baseColor.
+		float baseColorFactor[4] = {1, 1, 1, 1};///< Multiplie l'albedo échantillonné (RGBA).
+		float metallic = 0.0f;                  ///< metallicFactor [0,1] -> atlas orm.b.
+		float roughness = 1.0f;                 ///< roughnessFactor [0,1] -> atlas orm.g.
+		bool  alphaCutout = false;              ///< true si BLEND/MASK : applique le cutout coverage<0.5.
+	};
+
+	/// Cible de rendu d'une tile : pointeurs vers les TROIS atlas et placement.
 	/// Les atlas font (atlasWidth*atlasWidth) texels RGBA8 ; la tile occupe le
 	/// carré [tileX*tileSize, tileX*tileSize+tileSize) × [tileY*tileSize, …).
+	/// IMPORTANT : pour l'anti-aliasing, ces atlas sont les atlas SUPERSAMPLÉS
+	/// (atlasWidth et tileSize incluent déjà le facteur SS) ; le downsample vers
+	/// la résolution finale est fait par l'appelant après rasterisation.
 	struct RasterTarget
 	{
-		uint8_t* albedo  = nullptr; ///< Atlas albedo RGBA8 (atlasWidth^2 * 4 octets).
-		uint8_t* normal  = nullptr; ///< Atlas normal RGBA8 (atlasWidth^2 * 4 octets).
+		uint8_t* albedo  = nullptr; ///< Atlas albedo RGBA8 : rgb=albedo, a=couverture.
+		uint8_t* normal  = nullptr; ///< Atlas normal RGBA8 : rgb=normale encodée, a=depth relative.
+		uint8_t* orm     = nullptr; ///< Atlas ORM RGBA8 : r=AO, g=roughness, b=metallic, a=255.
 		uint32_t atlasWidth = 0;    ///< Côté de l'atlas en texels (= viewsPerAxis*tileSize).
 		uint32_t tileSize   = 0;    ///< Côté d'une tile en texels.
 		uint32_t tileX      = 0;    ///< Index colonne de la tile (0..viewsPerAxis-1).
 		uint32_t tileY      = 0;    ///< Index ligne de la tile (0..viewsPerAxis-1).
 	};
 
-	/// Rasterise une liste de triangles indexés dans la tile cible.
+	/// Efface la tile (les trois atlas) en transparent et réinitialise le z-buffer.
 	///
-	/// \param verts     Sommets (position/normale/couleur monde).
-	/// \param indices   Indices de triangles (multiple de 3).
+	/// À appeler UNE FOIS par tile, AVANT de rasteriser les sous-meshes successifs
+	/// (qui partagent le même z-buffer). Sépare l'effacement de la rasterisation
+	/// pour que plusieurs sous-meshes (matériaux différents) s'accumulent dans la
+	/// même tile avec un test de profondeur commun.
+	///
+	/// \param target Tile cible (atlas + placement).
+	/// \param zbuf   Z-buffer de tileSize*tileSize floats, mis à +inf.
+	/// Effet de bord : écrit dans la sous-région tile des trois atlas.
+	void ClearTile(const RasterTarget& target, std::vector<float>& zbuf);
+
+	/// Rasterise une liste de triangles indexés d'UN sous-mesh dans la tile cible.
+	///
+	/// N'efface PAS la tile : appeler ClearTile une fois avant la série de
+	/// sous-meshes. Le z-buffer est partagé entre sous-meshes (occlusion correcte).
+	///
+	/// \param verts     Sommets (position/normale/couleur/UV monde).
+	/// \param indices   Indices de triangles du sous-mesh (multiple de 3).
 	/// \param viewProj  Matrice view-projection orthographique 16 floats column-major.
 	/// \param target    Tile cible (atlas + placement).
-	/// \param zbuf      Z-buffer temporaire de tileSize*tileSize floats, réinitialisé
-	///                  en interne à +inf avant rasterisation.
+	/// \param zbuf      Z-buffer partagé (déjà initialisé par ClearTile).
+	/// \param mat       Matériau du sous-mesh (texture baseColor + facteurs ORM).
+	/// \param depthNear Borne min de profondeur NDC [0,1] pour normaliser la depth.
+	/// \param depthFar  Borne max de profondeur NDC [0,1] pour normaliser la depth.
 	///
-	/// Effet de bord : écrit dans la sous-région tile des atlas albedo/normal.
-	/// L'alpha de la normale vaut 255 si le texel est couvert (masque), 0 sinon.
-	/// L'encodage normale est n*0.5+0.5 mappé en [0,255]. Les texels non couverts
-	/// de la tile sont remis à 0 (transparent) au début.
-	void RasterizeTile(const std::vector<RasterVertex>& verts,
-	                   const std::vector<uint32_t>& indices,
-	                   const float viewProj[16],
-	                   const RasterTarget& target,
-	                   std::vector<float>& zbuf);
+	/// Effet de bord : écrit dans la sous-région tile des trois atlas.
+	/// Atlas albedo : rgb = albedo (texAlbedo.rgb * baseColorFactor.rgb), a = 255
+	///   (couverture). Alpha cutout : si la couverture interpolée < 0.5, le
+	///   fragment N'EST PAS écrit (préserve le z-buffer).
+	/// Atlas normal : rgb = normale monde encodée (n*0.5+0.5), a = depth relative
+	///   normalisée sur [depthNear, depthFar] (0 = près du plan de vue, 255 = loin).
+	/// Atlas orm   : r = AO (255), g = roughness*255, b = metallic*255, a = 255.
+	void RasterizeSubMesh(const std::vector<RasterVertex>& verts,
+	                      const std::vector<uint32_t>& indices,
+	                      const float viewProj[16],
+	                      const RasterTarget& target,
+	                      std::vector<float>& zbuf,
+	                      const RasterMaterial& mat,
+	                      float depthNear,
+	                      float depthFar);
 }

--- a/tools/impostor_builder/main.cpp
+++ b/tools/impostor_builder/main.cpp
@@ -3,15 +3,18 @@
 ///
 /// Usage (mode build) :
 ///   impostor_builder --input <mesh.gltf> [--output impostor_atlas.bin]
-///                    [--views 8] [--tile 64]
+///                    [--views 8] [--tile 64] [--ss 2]
 ///
 /// Usage (mode vérification round-trip) :
 ///   impostor_builder --verify <atlas.bin>
 ///
-/// Mode build : charge le mesh glTF, pour chaque vue (i,j) calcule la direction
-/// octaédrique, construit une view-projection orthographique cadrant l'AABB,
-/// rasterise albedo + normale dans la tile (i,j), écrit le fichier, puis
-/// auto-vérifie par relecture (round-trip).
+/// Mode build (FORMAT v2) : charge le mesh glTF, calcule un hash de contenu
+/// FNV-1a 64 bits des octets bruts du .gltf, puis pour chaque vue (i,j) calcule
+/// la direction octaédrique, construit une view-projection orthographique
+/// cadrant l'AABB, et rasterise les TROIS atlas (albedo / normal / orm) à une
+/// résolution supersamplée (SS×) tile par tile. Après toutes les vues, downsample
+/// box SS→final, écrit le fichier (albedo, normal, orm), puis auto-vérifie par
+/// relecture (round-trip + comparaison contentHash).
 
 #include "GltfMeshLoader.h"
 #include "ImpostorFormat.h"
@@ -22,6 +25,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -114,12 +118,85 @@ namespace
 		return o;
 	}
 
+	/// Calcule le hash FNV-1a 64 bits des octets bruts d'un fichier.
+	/// NOTE : c'est bien FNV-1a (offset basis 1469598103934665603, prime
+	/// 1099511628211), PAS xxHash. Utilisé comme contentHash du .gltf source
+	/// pour détecter les changements de mesh entre deux builds.
+	/// \param path  Chemin du fichier source (lu en binaire).
+	/// \param outOk Mis à false si le fichier ne peut pas être lu.
+	/// \return Hash FNV-1a 64 (0 et outOk=false si lecture impossible).
+	uint64_t Fnv1a64File(const std::string& path, bool& outOk)
+	{
+		std::ifstream is(path, std::ios::binary);
+		if (!is)
+		{
+			outOk = false;
+			return 0u;
+		}
+		outOk = true;
+		uint64_t hash = 1469598103934665603ull; // offset basis FNV-1a 64
+		constexpr uint64_t prime = 1099511628211ull;
+		char buf[65536];
+		while (is)
+		{
+			is.read(buf, sizeof(buf));
+			const std::streamsize n = is.gcount();
+			for (std::streamsize k = 0; k < n; ++k)
+			{
+				hash ^= static_cast<uint8_t>(buf[k]);
+				hash *= prime;
+			}
+		}
+		return hash;
+	}
+
+	/// Box-downsample un atlas supersamplé (ssDim×ssDim) vers la résolution
+	/// finale (dstDim×dstDim) en moyennant, par canal RGBA, le bloc ss×ss de
+	/// texels source correspondant à chaque texel final.
+	///
+	/// \param src    Atlas source RGBA8 supersamplé (ssDim*ssDim*4 octets).
+	/// \param ssDim  Côté de l'atlas source en texels (= dstDim*ss).
+	/// \param dstDim Côté de l'atlas final en texels (= views*tile).
+	/// \param ss     Facteur de supersampling (>=1).
+	/// \param dst    Atlas final RGBA8 (dstDim*dstDim*4 octets, redimensionné).
+	void DownsampleBox(const std::vector<uint8_t>& src, uint32_t ssDim,
+	                   uint32_t dstDim, uint32_t ss, std::vector<uint8_t>& dst)
+	{
+		dst.assign(static_cast<size_t>(dstDim) * dstDim * 4, 0);
+		const uint32_t blockArea = ss * ss; // nombre d'échantillons moyennés
+		for (uint32_t dy = 0; dy < dstDim; ++dy)
+		{
+			for (uint32_t dx = 0; dx < dstDim; ++dx)
+			{
+				uint32_t acc[4] = {0, 0, 0, 0};
+				for (uint32_t sy = 0; sy < ss; ++sy)
+				{
+					const uint32_t srcY = dy * ss + sy;
+					for (uint32_t sx = 0; sx < ss; ++sx)
+					{
+						const uint32_t srcX = dx * ss + sx;
+						const size_t si = (static_cast<size_t>(srcY) * ssDim + srcX) * 4;
+						acc[0] += src[si + 0];
+						acc[1] += src[si + 1];
+						acc[2] += src[si + 2];
+						acc[3] += src[si + 3];
+					}
+				}
+				const size_t di = (static_cast<size_t>(dy) * dstDim + dx) * 4;
+				dst[di + 0] = static_cast<uint8_t>(acc[0] / blockArea);
+				dst[di + 1] = static_cast<uint8_t>(acc[1] / blockArea);
+				dst[di + 2] = static_cast<uint8_t>(acc[2] / blockArea);
+				dst[di + 3] = static_cast<uint8_t>(acc[3] / blockArea);
+			}
+		}
+	}
+
 	void PrintUsage()
 	{
 		std::cerr <<
 			"Usage:\n"
 			"  impostor_builder --input <mesh.gltf> [--output impostor_atlas.bin]\n"
-			"                   [--views 8] [--tile 64]\n"
+			"                   [--views 8] [--tile 64] [--ss 2]\n"
 			"  impostor_builder --verify <atlas.bin>\n"
 			"\n"
 			"Options:\n"
@@ -127,16 +204,18 @@ namespace
 			"  --output <file>  Fichier atlas de sortie (défaut: impostor_atlas.bin)\n"
 			"  --views <N>      Vues par axe -> grille N×N (défaut: 8)\n"
 			"  --tile <px>      Côté d'une tile en pixels (défaut: 64)\n"
+			"  --ss <N>         Facteur de supersampling AA (défaut: 2)\n"
 			"  --verify <file>  Relit un atlas et vérifie le round-trip\n";
 	}
 
-	/// Mode vérification : relit un atlas et affiche ses métadonnées.
+	/// Mode vérification : relit un atlas v2 et affiche ses métadonnées.
 	int RunVerify(const std::string& path)
 	{
 		ImpostorAtlasInfo info;
-		std::vector<uint8_t> albedo, normal;
+		uint64_t contentHash = 0;
+		std::vector<uint8_t> albedo, normal, orm;
 		std::string err;
-		if (!ReadImpostorFile(path, info, albedo, normal, err))
+		if (!ReadImpostorFile(path, info, contentHash, albedo, normal, orm, err))
 		{
 			std::cerr << "[impostor_builder] verify FAILED: " << err << "\n";
 			return 1;
@@ -147,7 +226,9 @@ namespace
 		          << "  tileSize      : " << info.tileSize << "\n"
 		          << "  channels      : " << info.channels << "\n"
 		          << "  albedo bytes  : " << albedo.size() << "\n"
-		          << "  normal bytes  : " << normal.size() << "\n";
+		          << "  normal bytes  : " << normal.size() << "\n"
+		          << "  orm bytes     : " << orm.size() << "\n"
+		          << "  contentHash   : 0x" << std::hex << contentHash << std::dec << "\n";
 		return 0;
 	}
 }
@@ -159,6 +240,7 @@ int main(int argc, char** argv)
 	std::string verifyPath;
 	uint32_t views = 8;
 	uint32_t tile  = 64;
+	uint32_t ss    = 2; // facteur supersampling AA (défaut 2)
 
 	for (int i = 1; i < argc; ++i)
 	{
@@ -171,6 +253,8 @@ int main(int argc, char** argv)
 			views = static_cast<uint32_t>(std::stoul(argv[++i]));
 		else if (arg == "--tile" && i + 1 < argc)
 			tile = static_cast<uint32_t>(std::stoul(argv[++i]));
+		else if (arg == "--ss" && i + 1 < argc)
+			ss = static_cast<uint32_t>(std::stoul(argv[++i]));
 		else if (arg == "--verify" && i + 1 < argc)
 			verifyPath = argv[++i];
 		else if (arg == "--help" || arg == "-h")
@@ -191,9 +275,19 @@ int main(int argc, char** argv)
 		PrintUsage();
 		return 1;
 	}
-	if (views == 0 || tile == 0)
+	if (views == 0 || tile == 0 || ss == 0)
 	{
-		std::cerr << "[impostor_builder] --views et --tile doivent être > 0\n";
+		std::cerr << "[impostor_builder] --views, --tile et --ss doivent être > 0\n";
+		return 1;
+	}
+
+	// --- Hash de contenu FNV-1a 64 du .gltf source ----------------------
+	bool hashOk = false;
+	const uint64_t contentHash = Fnv1a64File(inputPath, hashOk);
+	if (!hashOk)
+	{
+		std::cerr << "[impostor_builder] impossible de lire le fichier d'entrée pour le hash: "
+		          << inputPath << "\n";
 		return 1;
 	}
 
@@ -229,13 +323,20 @@ int main(int argc, char** argv)
 		info.boundsMax[k] = mesh.boundsMax[k];
 	}
 
+	// Résolution finale et résolution supersamplée (SS×).
 	const uint32_t atlasDim = views * tile;
-	const size_t   atlasBytes = static_cast<size_t>(atlasDim) * atlasDim * 4;
-	std::vector<uint8_t> albedo(atlasBytes, 0);
-	std::vector<uint8_t> normal(atlasBytes, 0);
-	std::vector<float>   zbuf;
+	const uint32_t ssDim    = views * tile * ss; // côté atlas supersamplé
+	const uint32_t ssTile   = tile * ss;         // côté tile supersamplée
+	const size_t   ssBytes  = static_cast<size_t>(ssDim) * ssDim * 4;
 
-	// --- Rendu de chaque vue --------------------------------------------
+	// Atlas rendus à la résolution supersamplée (downsamplés ensuite).
+	std::vector<uint8_t> albedoSS(ssBytes, 0);
+	std::vector<uint8_t> normalSS(ssBytes, 0);
+	std::vector<uint8_t> ormSS(ssBytes, 0);
+	// Z-buffer d'UNE tile supersamplée (partagé entre sous-meshes d'une vue).
+	std::vector<float>   zbuf(static_cast<size_t>(ssTile) * ssTile, 0.0f);
+
+	// --- Rendu de chaque vue (résolution SS×) ---------------------------
 	for (uint32_t j = 0; j < views; ++j)
 	{
 		for (uint32_t i = 0; i < views; ++i)
@@ -258,17 +359,56 @@ int main(int argc, char** argv)
 			const Mat4 proj = OrthoVulkan(-radius, radius, -radius, radius, 0.0f, dist * 2.0f);
 			const Mat4 vp = Mul(proj, view);
 
+			// Cible = tile (i,j) dans les atlas SUPERSAMPLÉS.
 			RasterTarget target;
-			target.albedo     = albedo.data();
-			target.normal     = normal.data();
-			target.atlasWidth = atlasDim;
-			target.tileSize   = tile;
+			target.albedo     = albedoSS.data();
+			target.normal     = normalSS.data();
+			target.orm        = ormSS.data();
+			target.atlasWidth = ssDim;
+			target.tileSize   = ssTile;
 			target.tileX      = i;
 			target.tileY      = j;
 
-			RasterizeTile(mesh.vertices, mesh.indices, vp.m, target, zbuf);
+			// Efface la tile + le z-buffer UNE fois avant les sous-meshes.
+			ClearTile(target, zbuf);
+
+			// Accumule chaque sous-mesh (matériau propre) dans la même tile.
+			for (const LoadedSubMesh& sm : mesh.subMeshes)
+			{
+				RasterMaterial mat; // défaut : pas de texture, blanc, rough=1
+				if (sm.materialIndex >= 0 &&
+				    static_cast<size_t>(sm.materialIndex) < mesh.materials.size())
+				{
+					const LoadedMaterial& lm = mesh.materials[sm.materialIndex];
+					mat.baseColorRGBA = lm.baseColorRGBA.empty() ? nullptr
+					                                             : lm.baseColorRGBA.data();
+					mat.bcW = lm.bcW;
+					mat.bcH = lm.bcH;
+					for (int k = 0; k < 4; ++k) mat.baseColorFactor[k] = lm.baseColorFactor[k];
+					mat.metallic    = lm.metallic;
+					mat.roughness   = lm.roughness;
+					mat.alphaCutout = lm.alphaBlendOrMask;
+				}
+
+				// Slice d'indices de ce sous-mesh.
+				if (sm.indexCount == 0) continue;
+				const size_t first = sm.firstIndex;
+				const size_t last  = first + sm.indexCount;
+				if (last > mesh.indices.size()) continue; // garde-fou
+				std::vector<uint32_t> sub(mesh.indices.begin() + first,
+				                          mesh.indices.begin() + last);
+
+				RasterizeSubMesh(mesh.vertices, sub, vp.m, target, zbuf, mat, 0.0f, 1.0f);
+			}
 		}
 	}
+
+	// --- Downsample box SS -> résolution finale -------------------------
+	std::vector<uint8_t> albedo, normal, orm;
+	DownsampleBox(albedoSS, ssDim, atlasDim, ss, albedo);
+	DownsampleBox(normalSS, ssDim, atlasDim, ss, normal);
+	DownsampleBox(ormSS, ssDim, atlasDim, ss, orm);
+	const size_t atlasBytes = static_cast<size_t>(atlasDim) * atlasDim * 4;
 
 	// --- Création du dossier de sortie ----------------------------------
 	{
@@ -278,22 +418,24 @@ int main(int argc, char** argv)
 			std::filesystem::create_directories(parent, ec);
 	}
 
-	// --- Écriture -------------------------------------------------------
-	if (!WriteImpostorFile(outputPath, info, albedo, normal, err))
+	// --- Écriture (FORMAT v2 : albedo, normal, orm) ---------------------
+	if (!WriteImpostorFile(outputPath, info, contentHash, albedo, normal, orm, err))
 	{
 		std::cerr << "[impostor_builder] échec écriture: " << err << "\n";
 		return 1;
 	}
 	std::cout << "[impostor_builder] atlas écrit: " << outputPath
 	          << " (" << views << "x" << views << " vues, tile " << tile
-	          << "px, " << atlasBytes << " octets/canal)\n";
+	          << "px, ss " << ss << "x, " << atlasBytes << " octets/canal, "
+	          << "contentHash 0x" << std::hex << contentHash << std::dec << ")\n";
 
 	// --- Auto-vérification round-trip -----------------------------------
 	{
 		ImpostorAtlasInfo rInfo;
-		std::vector<uint8_t> rAlbedo, rNormal;
+		uint64_t rHash = 0;
+		std::vector<uint8_t> rAlbedo, rNormal, rOrm;
 		std::string rErr;
-		if (!ReadImpostorFile(outputPath, rInfo, rAlbedo, rNormal, rErr))
+		if (!ReadImpostorFile(outputPath, rInfo, rHash, rAlbedo, rNormal, rOrm, rErr))
 		{
 			std::cerr << "[impostor_builder] round-trip FAILED (relecture): " << rErr << "\n";
 			return 1;
@@ -301,10 +443,12 @@ int main(int argc, char** argv)
 		if (rInfo.viewsPerAxis != info.viewsPerAxis ||
 		    rInfo.tileSize != info.tileSize ||
 		    rInfo.channels != info.channels ||
+		    rHash != contentHash ||
 		    rAlbedo.size() != albedo.size() ||
-		    rNormal.size() != normal.size())
+		    rNormal.size() != normal.size() ||
+		    rOrm.size() != orm.size())
 		{
-			std::cerr << "[impostor_builder] round-trip FAILED: métadonnées/tailles incohérentes\n";
+			std::cerr << "[impostor_builder] round-trip FAILED: métadonnées/tailles/hash incohérents\n";
 			return 1;
 		}
 		std::cout << "[impostor_builder] round-trip OK\n";


### PR DESCRIPTION
## M45.4b / M45.5b — Comblement des reports impostors (cluster M45)

Comble les écarts identifiés à l'audit de **M45.4** (offline) et les consomme côté **M45.5** (runtime). **Le runtime reste gated `world.impostor.enabled=false` par défaut → aucune dégradation du jeu actuel.**

### Ce que ça corrige (vs audit)
| Report | Avant | Maintenant |
|--------|-------|-----------|
| Albedo | vertex color (aplats) | **textures baseColor** échantillonnées (UV + cutout feuillage) |
| ORM | absent (codé en dur runtime) | **atlas ORM** (AO/rough/metal depuis facteurs matériau) → écrit dans GBufferC |
| Profondeur/parallaxe | absente (impostors plats) | **profondeur capturée** (z-buffer → `normal.a`) + **parallax single-step** au runtime |
| Anti-aliasing | aucun (crénelé) | **supersampling** SS (défaut 2) + downsample box |
| contentHash | 0 | **FNV-1a 64** du `.gltf` |

### Offline (`tools/impostor_builder`, autonome)
- `GltfMeshLoader` : sous-meshes + matériaux (baseColor via **stb_image**, factors, alphaMode), `TEXCOORD_0`.
- `Rasterizer` : sampling baseColor par UV, alpha-cutout, **3 atlas** (albedo+couverture / normale+profondeur / ORM), z-buffer partagé entre sous-meshes.
- `main.cpp` : SS + downsample, contentHash, round-trip + `--verify` v2, `--ss`.
- `ImpostorFormat` **v2** (3 blocs albedo/normal/orm + contentHash) ; CMake `external/stb` ; `FORMAT.md` à jour.

### Runtime (gated off)
- `ImpostorAsset` : lecture **v2** (3 atlas), **rejet propre des autres versions** (fallback mesh), upload des 3 textures.
- `ImpostorPass` : descriptor **2→3 bindings** (+ORM), `parallaxScale` logé dans `atlasParams.w` (**push constants 176 o inchangées**).
- `impostor.vert/.frag` : `vViewTangent` pour la parallaxe ; **parallax single-step** (depth=`normal.a`) ; alpha-test sur **albedo.a** (couverture) ; **ORM→GBufferC**.
- `Engine` : passe l'atlas ORM + `parallaxScale`, guard non-null sur les 3 atlas.
- `config.json` : `world.impostor.parallax_scale=0.08`.

### Non-régression
`enabled=false` (défaut) → aucun impostor dessiné, aucun chemin always-on touché. Atlas absent ou version≠2 → fallback mesh (pas de crash). L'outil offline n'a aucun impact runtime.

### Limites v1 documentées
Parallaxe single-step (approx, réglable via `parallax_scale`) ; normale géométrique (pas de normal-map, qui exigerait un repère tangent) ; downsample box de la profondeur sur les bords (le runtime se fie à la couverture).

### Shaders
Source GLSL seule ; la CI Windows régénère les `.spv`.

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)