### PR TITLE
feat(render): M45.5b — impostors cross-fade + interpolation de vues + intégration LOD

### DIFF
--- a/config.json
+++ b/config.json
@@ -140,16 +140,23 @@
         "histogram_percentile_low": 0.10,
         "histogram_percentile_high": 0.90
     },
+    "_comment_lod": "Seuils de LOD lus par engine::world::LodConfig (M09.3). distance_lodX_max : distance max (m) du niveau de detail X (0 = plus detaille). distance_impostor_m (M45.5b) : distance (m) au-dela de laquelle un prop de DECOR (non interactible) bascule en impostor (billboard octaedrique) au lieu de son mesh, jusqu'a world.props.cull_distance_m. Remplace l'ancienne cle world.impostor.distance_m. Lu a l'init (LodConfig.Init).",
+    "lod": {
+        "distance_lod0_max": 25.0,
+        "distance_lod1_max": 60.0,
+        "distance_lod2_max": 150.0,
+        "distance_lod3_max": 400.0,
+        "distance_impostor_m": 60.0
+    },
     "world": {
         "max_draw_distance_m": 0.0,
         "_comment_props": "Rendu des props de decor (world.scenery). cull_distance_m : au-dela de ce rayon (m) autour de la camera, un prop de DECOR n'est plus dessine (les INTERACTIBLES coffre/villageois/caisses sont toujours dessines). Lu a chaque frame -> reglage a chaud (modifier config.json puis relancer suffit, AUCUNE recompilation). Reduire si la foret dense fait chuter le framerate ; augmenter pour plus de profondeur visuelle. <= 0 = desactive (tout est dessine). Repli 80 si la cle est absente.",
         "props": {
             "cull_distance_m": 80.0
         },
-        "_comment_impostor": "M45.5 — Impostors vegetation (billboards octaedriques) au LOIN, a la place des meshes de decor, eclaires via le GBuffer deferred. DESACTIVE par defaut (enabled=false) : aucun changement de rendu tant que non active. Necessite des atlas .mipo (generes par tools/impostor_builder) places A COTE de chaque mesh (meme nom, extension .mipo). distance_m : distance (m) au-dela de laquelle un prop de DECOR (non interactible) est rendu en impostor au lieu de son mesh, jusqu'a world.props.cull_distance_m ou il disparait. fade_band_m : largeur (m) de la bande de fondu (dither anti-popping) juste apres distance_m. Lu a chaque frame -> reglage a chaud.",
+        "_comment_impostor": "M45.5 — Impostors vegetation (billboards octaedriques) au LOIN, a la place des meshes de decor, eclaires via le GBuffer deferred. DESACTIVE par defaut (enabled=false) : aucun changement de rendu tant que non active. Necessite des atlas .mipo (generes par tools/impostor_builder) places A COTE de chaque mesh (meme nom, extension .mipo). Le SEUIL de bascule mesh->impostor est desormais lod.distance_impostor_m (l'ancienne cle distance_m a ete retiree). fade_band_m : largeur (m) de la bande de fondu (cross-fade dither anti-popping) juste apres ce seuil : dans cette bande, le mesh ET l'impostor coexistent (l'impostor monte en dither 0->1). parallax_scale : echelle du decalage de parallax single-step (frag v2). Lu a chaque frame -> reglage a chaud.",
         "impostor": {
             "enabled": false,
-            "distance_m": 60.0,
             "fade_band_m": 10.0,
             "parallax_scale": 0.08
         },

--- a/game/data/shaders/impostor.frag
+++ b/game/data/shaders/impostor.frag
@@ -1,11 +1,14 @@
-// game/data/shaders/impostor.frag (M45.4b — impostors végétation runtime, format v2)
+// game/data/shaders/impostor.frag (M45.5b — impostors végétation runtime, format v2)
 //
 // Décode la direction caméra->instance en coords octaédriques (INVERSE de
-// OctaToDir de tools/impostor_builder/OctahedralMap.h) pour choisir la tile
-// (i,j), échantillonne albedo + normal + ORM dans la tile, applique un décalage
-// de parallax single-step (depth en normal.a), l'alpha-test de silhouette (sur
-// albedo.a) + un dither fade anti-popping, puis écrit les 4 sorties GBuffer
-// (ordre/format IDENTIQUE à gbuffer_geometry.frag).
+// OctaToDir de tools/impostor_builder/OctahedralMap.h), puis INTERPOLE
+// BILINÉAIREMENT les 4 vues (tiles) voisines de la grille octaédrique (réduit le
+// snap de vue, M45.5b) : pour chaque tile on échantillonne albedo + normal + ORM
+// avec un décalage de parallax single-step (depth en normal.a), et on blende les
+// 4 par les poids bilinéaires. L'alpha-test de silhouette porte sur la couverture
+// BLENDÉE (albedo.a). Un dither fade anti-popping (atlasParams.z) discard les
+// fragments en cours d'apparition AVANT le blend. Enfin on écrit les 4 sorties
+// GBuffer (ordre/format IDENTIQUE à gbuffer_geometry.frag).
 //
 // Sorties GBuffer (cf. gbuffer_geometry.frag) :
 //   location 0 (GBufferA, sRGB)            : albedo (rgb, a=1)
@@ -65,6 +68,33 @@ float Bayer4x4(ivec2 p)
     return m[idx];
 }
 
+// Échantillonne UNE tile octaédrique (i,j) = `tileF` et renvoie albedo (rgb +
+// a=couverture), normale encodée (rgb) et ORM (rgb), avec le MÊME parallax
+// single-step que la v1 appliqué intra-tuile.
+//   tileF       : indices entiers (i,j) de la tile, déjà clampés à [0, N-1].
+//   quadUv      : UV du quad billboard ∈ [0,1]² (non décalée).
+//   tileSpan    : taille d'une tile en UV atlas (= 1/N).
+//   parallaxScale : échelle du décalage de parallax (atlasParams.w).
+// Sorties par référence : albedoOut (.a=couverture), normalOut (.rgb encodé), ormOut.
+// NB : la profondeur de parallax est lue dans CETTE tile (normal.a à l'UV non
+// décalée), donc chaque tile a son propre décalage cohérent avec sa vue.
+void sampleTile(vec2 tileF, vec2 quadUv, float tileSpan, float parallaxScale,
+                out vec4 albedoOut, out vec4 normalOut, out vec4 ormOut)
+{
+    vec2 tileOrigin = tileF * tileSpan;
+    // Parallax single-step : profondeur relative (normal.a) à l'UV non décalée,
+    // puis décalage intra-tuile borné à la tile (clamp -> pas de bleeding).
+    vec2  atlasUv0 = tileOrigin + quadUv * tileSpan;
+    float depth    = texture(uNormal, atlasUv0).a;
+    vec2  par      = vViewTangent * (depth - 0.5) * parallaxScale;
+    vec2  quadUvP  = clamp(quadUv + par, vec2(0.0), vec2(1.0));
+    vec2  atlasUv  = tileOrigin + quadUvP * tileSpan;
+
+    albedoOut = texture(uAlbedo, atlasUv); // .rgb = albedo, .a = couverture
+    normalOut = texture(uNormal, atlasUv); // .rgb = n*0.5+0.5, .a = profondeur
+    ormOut    = texture(uOrm,    atlasUv); // .r = AO, .g = rough, .b = metal
+}
+
 void main()
 {
     float viewsPerAxis  = pc.atlasParams.x;
@@ -72,6 +102,7 @@ void main()
     float parallaxScale = pc.atlasParams.w;
 
     // 1) Dither fade anti-popping : discard pseudo-aléatoire stable sur l'écran.
+    //    Appliqué AVANT le blend de vues (un fragment fondu est purement éliminé).
     if (fadeAlpha < 1.0)
     {
         float threshold = Bayer4x4(ivec2(gl_FragCoord.xy));
@@ -79,44 +110,57 @@ void main()
             discard;
     }
 
-    // 2) Choix de la tile (i,j) depuis la direction de vue.
+    float tileSpan = 1.0 / viewsPerAxis;
+    vec2  quadUv   = clamp(vUv, vec2(0.0), vec2(1.0));
+
+    // 2) Interpolation BILINÉAIRE des 4 vues octaédriques voisines (M45.5b) :
+    //    réduit le snap visible quand la direction de vue traverse une frontière
+    //    de tile. On place octUv sur la grille des CENTRES de tiles (- 0.5), d'où
+    //    g0 = coin bas-gauche du carré de 4 tiles et f = poids fractionnaires.
     vec2 octUv = DirToOcta(normalize(vViewDir));
-    // (i,j) = floor(octUv * N), clampé à [0, N-1].
-    vec2 tileF = floor(octUv * viewsPerAxis);
-    tileF = clamp(tileF, vec2(0.0), vec2(viewsPerAxis - 1.0));
+    vec2 g  = octUv * viewsPerAxis - 0.5;
+    vec2 g0 = floor(g);
+    vec2 f  = g - g0; // poids bilinéaires ∈ [0,1]²
+    // Indices des 4 tiles, clampés à [0, N-1]. APPROX bordure : aux bords de la
+    // grille octaédrique, le clamp répète la tile de bord au lieu de "wrapper" sur
+    // la vue antipodale repliée (couture octaédrique). Acceptable en v1.5 — le
+    // fondu reste continu, l'erreur n'apparaît qu'au tout dernier rang de tiles.
+    float nMax = viewsPerAxis - 1.0;
+    float i0 = clamp(g0.x,        0.0, nMax);
+    float i1 = clamp(g0.x + 1.0,  0.0, nMax);
+    float j0 = clamp(g0.y,        0.0, nMax);
+    float j1 = clamp(g0.y + 1.0,  0.0, nMax);
 
-    // 3) Repère de la tile dans l'atlas (grille N×N, chaque tile = 1/N).
-    //    tileSpan = taille d'une tile en UV atlas ; tileOrigin = coin de la tile.
-    float tileSpan  = 1.0 / viewsPerAxis;
-    vec2  tileOrigin = tileF * tileSpan;
-    vec2  quadUv     = clamp(vUv, vec2(0.0), vec2(1.0));
+    // 3) Échantillonne les 4 tiles (chacune avec son propre parallax).
+    vec4 a00, n00, o00; sampleTile(vec2(i0, j0), quadUv, tileSpan, parallaxScale, a00, n00, o00);
+    vec4 a10, n10, o10; sampleTile(vec2(i1, j0), quadUv, tileSpan, parallaxScale, a10, n10, o10);
+    vec4 a01, n01, o01; sampleTile(vec2(i0, j1), quadUv, tileSpan, parallaxScale, a01, n01, o01);
+    vec4 a11, n11, o11; sampleTile(vec2(i1, j1), quadUv, tileSpan, parallaxScale, a11, n11, o11);
 
-    // 4) Parallax v1 (single-step) : on lit la profondeur relative (normal.a) à
-    //    l'UV non décalée, puis on décale l'UV intra-tuile selon l'inclinaison de
-    //    vue. depth ∈ [0,1] (0.5 = surface du billboard). L'offset est borné à la
-    //    tile (clamp du quadUv décalé) pour éviter le bleeding inter-tuiles.
-    vec2 atlasUv0 = tileOrigin + quadUv * tileSpan;
-    float depth   = texture(uNormal, atlasUv0).a;
-    vec2  par     = vViewTangent * (depth - 0.5) * parallaxScale;
-    vec2  quadUvP = clamp(quadUv + par, vec2(0.0), vec2(1.0));
-    vec2  atlasUv = tileOrigin + quadUvP * tileSpan;
+    // 4) Poids bilinéaires.
+    float w00 = (1.0 - f.x) * (1.0 - f.y);
+    float w10 = f.x         * (1.0 - f.y);
+    float w01 = (1.0 - f.x) * f.y;
+    float w11 = f.x         * f.y;
 
-    // 5) Ré-échantillonnage à l'UV décalée.
-    vec4 albedo       = texture(uAlbedo, atlasUv); // .rgb = albedo, .a = couverture
-    vec4 normalSample = texture(uNormal, atlasUv); // .rgb = n*0.5+0.5, .a = profondeur
-    vec4 orm          = texture(uOrm,    atlasUv); // .r = AO, .g = rough, .b = metal
+    // 5) Blend des 4 résultats (albedo rgb+a couverture, normale rgb, orm rgb).
+    vec4 albedo = a00 * w00 + a10 * w10 + a01 * w01 + a11 * w11;
+    vec3 normalEnc = n00.rgb * w00 + n10.rgb * w10 + n01.rgb * w01 + n11.rgb * w11;
+    vec3 orm    = o00.rgb * w00 + o10.rgb * w10 + o01.rgb * w01 + o11.rgb * w11;
 
-    // 6) Alpha-test de silhouette : en v2 la COUVERTURE est dans albedo.a
-    //    (normal.a porte désormais la profondeur).
+    // 6) Alpha-test de silhouette sur la COUVERTURE BLENDÉE (albedo.a interpolée).
     if (albedo.a < 0.5)
         discard;
 
     // 7) Écriture GBuffer.
     outAlbedo = vec4(albedo.rgb, 1.0);
-    // L'atlas stocke déjà la normale encodée n*0.5+0.5 -> on la réécrit telle quelle.
-    outNormal = vec4(normalSample.rgb, 1.0);
-    // ORM échantillonné depuis l'atlas v2 (au lieu du codé en dur v1).
-    outORM = vec4(orm.rgb, 1.0);
+    // Normale : on décode la moyenne pondérée (n*0.5+0.5), renormalise, ré-encode.
+    //   Le blend d'encodages reste proche de la moyenne des normales pour des vues
+    //   voisines ; la renormalisation corrige la dérive de longueur.
+    vec3 nWorld = normalize(normalEnc * 2.0 - 1.0);
+    outNormal = vec4(nWorld * 0.5 + 0.5, 1.0);
+    // ORM blendé depuis l'atlas v2.
+    outORM = vec4(orm, 1.0);
     // Velocity nulle en v1 (impostors statiques ; pas de reprojection dédiée).
     outVelocity = vec4(0.0, 0.0, 0.0, 1.0);
 }

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10653,9 +10653,18 @@ namespace engine
 		// d'impostorDist, mesh normal (inchangé).
 		const bool impostorPassValid = m_pipeline->GetImpostorPass().IsValid();
 		const bool impostorActive = m_impostorEnabled && impostorPassValid;
+		// Seuil de bascule mesh -> impostor : centralisé dans LodConfig (M45.5b),
+		// plus de duplication avec world.impostor.distance_m. Gated : si inactif,
+		// D = +inf => aucune des branches impostor ne s'active (historique strict).
 		const float impostorDist = impostorActive
-			? static_cast<float>(m_cfg.GetDouble("world.impostor.distance_m", 60.0)) : 1e30f;
+			? m_lodConfig.GetImpostorDistanceMax() : 1e30f;
+		// Largeur de la bande de cross-fade (m) juste après le seuil : le mesh et
+		// l'impostor coexistent, l'impostor monte en dither 0->1 (anti-popping).
+		const float impostorBand = impostorActive
+			? static_cast<float>(m_cfg.GetDouble("world.impostor.fade_band_m", 10.0)) : 0.0f;
 		const float impostorDist2 = impostorDist * impostorDist;
+		// Borne haute de la bande de fondu (au-delà : impostor seul, fadeAlpha=1).
+		const float impostorFadeEnd = impostorDist + impostorBand;
 		// Instances d'impostors accumulées, groupées par chemin de mesh (= clé atlas).
 		std::unordered_map<std::string, std::vector<engine::render::ImpostorInstance>> impostorBatches;
 
@@ -10672,22 +10681,44 @@ namespace engine
 					{ ++culled; continue; }  // decor trop loin -> non dessine
 			}
 
-			// Bascule impostor (décor uniquement, distance >= seuil, atlas dispo).
+			// Cross-fade mesh <-> impostor (M45.5b, décor uniquement, atlas dispo).
+			// Trois régimes selon la distance XZ `dist` :
+			//   dist < D                : mesh seul (drawImpostorOnly=false, pas d'impostor).
+			//   D <= dist < D+band      : mesh PLEIN + impostor en dither montant (fadeAlpha
+			//                             = smoothstep(D, D+band, dist)) -> aucun pop.
+			//   dist >= D+band          : impostor SEUL (fadeAlpha=1), pas de mesh.
+			// Gated : si impostorActive est false, D = +inf => on n'entre jamais ici.
+			bool drawImpostorOnly = false;
 			if (impostorActive && prop.interactableIndex < 0 && dist2 >= impostorDist2)
 			{
 				if (EnsureImpostorAtlas(prop.meshPath))
 				{
+					const float dist = std::sqrt(dist2);
+					// smoothstep(D, D+band, dist) : 0 au seuil, 1 en fin de bande.
+					float fade = 1.0f;
+					if (impostorBand > 0.0f && dist < impostorFadeEnd)
+					{
+						const float t = std::clamp((dist - impostorDist) / impostorBand, 0.0f, 1.0f);
+						fade = t * t * (3.0f - 2.0f * t); // smoothstep
+					}
 					engine::render::ImpostorInstance inst;
 					inst.worldPos[0] = prop.impostorCenter.x;
 					inst.worldPos[1] = prop.impostorCenter.y;
 					inst.worldPos[2] = prop.impostorCenter.z;
 					inst.radius      = prop.impostorRadius;
+					inst.fadeAlpha   = fade;
 					impostorBatches[prop.meshPath].push_back(inst);
 					++impostored;
-					continue; // NE PAS dessiner le mesh : l'impostor le remplace.
+					// Hors de la bande de fondu : l'impostor REMPLACE le mesh (pas de mesh).
+					// Dans la bande : on dessine AUSSI le mesh par-dessous (drawImpostorOnly
+					// reste false) pour que l'impostor monte en fondu sans pop.
+					if (dist >= impostorFadeEnd)
+						drawImpostorOnly = true;
 				}
-				// Pas d'atlas pour ce mesh -> fallback mesh normal (continue plus bas).
+				// Pas d'atlas pour ce mesh -> fallback mesh normal (dessin plus bas).
 			}
+			if (drawImpostorOnly)
+				continue; // NE PAS dessiner le mesh : l'impostor le remplace entièrement.
 
 			++drawn;
 			// Surbrillance (chantier C) : si ce prop est l'interactible a portee, on

--- a/src/client/render/ImpostorPass.cpp
+++ b/src/client/render/ImpostorPass.cpp
@@ -313,11 +313,13 @@ namespace engine::render
 		pc.cameraPos[3] = 0.0f;
 		pc.atlasParams[0] = static_cast<float>(viewsPerAxis);
 		pc.atlasParams[1] = static_cast<float>(tileSize);
-		pc.atlasParams[2] = 1.0f;            // fadeAlpha (v1 : pas de fondu, opaque)
+		// atlasParams[2] (fadeAlpha) est désormais poussé PAR instance dans la boucle
+		// ci-dessous (cross-fade M45.5b) — plus de valeur codée en dur ici.
 		pc.atlasParams[3] = parallaxScale;   // v2 : échelle du décalage de parallax (frag)
 
 		for (uint32_t i = 0; i < count; ++i)
 		{
+			pc.atlasParams[2] = instances[i].fadeAlpha; // fondu dither anti-popping par instance
 			pc.instancePos[0] = instances[i].worldPos[0];
 			pc.instancePos[1] = instances[i].worldPos[1];
 			pc.instancePos[2] = instances[i].worldPos[2];

--- a/src/client/render/ImpostorPass.h
+++ b/src/client/render/ImpostorPass.h
@@ -28,10 +28,15 @@ namespace engine::render
 {
 	/// Une instance d'impostor à dessiner : centre monde + rayon de la sphère
 	/// englobante du prop (demi-taille du billboard, en mètres).
+	/// `fadeAlpha` (M45.5b) pilote le cross-fade dither anti-popping PAR instance :
+	/// 1.0 = impostor pleinement opaque ; <1.0 = en cours d'apparition (le mesh est
+	/// encore dessiné par-dessous dans la bande de fondu). Poussé dans
+	/// `atlasParams.z` au moment du draw (cf. RecordInstances).
 	struct ImpostorInstance
 	{
 		float worldPos[3] = {0.0f, 0.0f, 0.0f};
 		float radius      = 1.0f;
+		float fadeAlpha   = 1.0f;
 	};
 
 	/// Push constants poussées par instance (stage VERTEX + FRAGMENT).
@@ -98,6 +103,8 @@ namespace engine::render
 		/// \param tileSize      Côté d'une tile en pixels.
 		/// \param parallaxScale Échelle du décalage de parallax single-step (frag v2),
 		///                      écrite dans `atlasParams.w` des push constants.
+		///                      Le fondu (`atlasParams.z`) est pris PAR instance dans
+		///                      `instances[i].fadeAlpha` (cross-fade M45.5b), plus codé en dur.
 		///
 		/// Effet de bord : met à jour le descriptor set partagé (vkUpdateDescriptorSets)
 		/// à chaque appel — un seul atlas peut donc être lié à la fois ; appeler

--- a/src/client/world/LodConfig.cpp
+++ b/src/client/world/LodConfig.cpp
@@ -16,6 +16,10 @@ namespace engine::world
 		for (int i = 1; i < kLodLevelCount; ++i)
 			if (m_distanceMax[i] < m_distanceMax[i - 1])
 				m_distanceMax[i] = m_distanceMax[i - 1];
+
+		// Seuil de bascule mesh -> impostor (M45.5b). Centralise ici plutot que
+		// dans world.impostor.distance_m. Defaut 60 m si la cle est absente.
+		m_impostorDistanceMax = static_cast<float>(config.GetDouble("lod.distance_impostor_m", 60.0));
 	}
 
 	int LodConfig::GetLodLevel(float distanceMeters) const

--- a/src/client/world/LodConfig.h
+++ b/src/client/world/LodConfig.h
@@ -24,7 +24,13 @@ namespace engine::world
 		/// Returns the max distance (meters) for the given LOD level (0..3).
 		float GetDistanceMax(int lodLevel) const;
 
+		/// Distance (meters) beyond which a decor prop switches from its mesh to an
+		/// impostor billboard (M45.5b). Config key: lod.distance_impostor_m (default 60).
+		/// Centralizes the impostor threshold previously read from world.impostor.distance_m.
+		float GetImpostorDistanceMax() const { return m_impostorDistanceMax; }
+
 	private:
 		float m_distanceMax[kLodLevelCount] = { 25.0f, 60.0f, 150.0f, 400.0f };
+		float m_impostorDistanceMax = 60.0f;
 	};
 }


### PR DESCRIPTION
## M45.5b — Comblement des reports M45.5 (cluster M45)

> ⚠️ **Stackée sur #796** (format impostor v2). Merger #796 d'abord. Base `main`.

Comble les 3 écarts de l'audit M45.5. **Gated `world.impostor.enabled=false` par défaut → aucune dégradation** (chemin off byte-identique).

### Ce que ça corrige
| Report | Avant | Maintenant |
|--------|-------|-----------|
| **Fade anti-popping** | `fadeAlpha=1.0` codé en dur, pas de fondu | **cross-fade** : mesh + impostor coexistent sur `[D, D+band]`, l'impostor monte en dither 0→1 (`fadeAlpha=smoothstep` **par instance**) → pas de pop |
| **Interpolation de vues** | vue la plus proche (`floor`) → snap | **bilinéaire des 4 vues octaédriques** voisines (parallax par tile, alpha-test sur couverture blendée) |
| **Intégration LOD** | seuil `world.impostor.distance_m` dupliqué | centralisé dans **`LodConfig::GetImpostorDistanceMax()`** (`lod.distance_impostor_m`) |

### Non-régression (vérifiée)
- `enabled=false` → `D=+inf` → aucune branche impostor, mesh dessiné comme avant. **Byte-identique.**
- Le nouveau bloc `lod` dans `config.json` utilise **exactement les défauts** (25/60/150/400) que `LodConfig` avait en dur → **la sélection LOD des meshes (always-on) ne change pas.**
- Push constants `ImpostorPushConstants` inchangées (176 o).

### Détails
- `Engine.cpp RecordPropsGeometry` : 3 régimes (mesh seul / cross-fade / impostor seul).
- `impostor.frag` : `sampleTile()` factorisé, blend 4-tiles + poids bilinéaires, normale renormalisée.
- `ImpostorInstance.fadeAlpha` poussé par instance (`atlasParams.z`).
- `LodConfig` : getter + clé ; `config.json` : bloc `lod` + retrait de `world.impostor.distance_m`.

### Limites v1.5 documentées
Approximation au bord octaédrique (clamp au lieu du wrap antipodal) ; ~16 fetches/fragment dans le blend (acceptable, impostors lointains peu couvrants, gated).

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)