### PR TITLE
feat(render): M45.8 — DDGI niveaux de qualité + fallback statique + tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,7 @@ add_library(engine_core
   src/client/render/LightingPass.cpp
   src/client/render/gi/DdgiVolume.cpp
   src/client/render/gi/DdgiUpdatePass.cpp
+  src/client/render/gi/DdgiQuality.cpp
   src/client/render/VolumetricFogPass.cpp
   src/client/render/DepthOfFieldPass.cpp
   src/client/render/ImpostorPass.cpp
@@ -818,6 +819,11 @@ add_test(NAME protocol_v1_tests COMMAND protocol_v1_tests)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)
 target_link_libraries(ddgi_volume_tests PRIVATE engine_core)
 add_test(NAME ddgi_volume_tests COMMAND ddgi_volume_tests)
+
+# M45.8: niveaux de qualité / fallback DDGI (DdgiQuality) — tests CPU purs (pas de device Vulkan)
+add_executable(ddgi_fallback_tests src/client/render/gi/tests/DdgiFallbackTests.cpp)
+target_link_libraries(ddgi_fallback_tests PRIVATE engine_core)
+add_test(NAME ddgi_fallback_tests COMMAND ddgi_fallback_tests)
 
 # Phase 1: CHARACTER_LIST request/response payload round-trip tests
 add_executable(character_list_payloads_tests src/shared/network/CharacterListPayloadsTests.cpp)

--- a/config.json
+++ b/config.json
@@ -624,8 +624,10 @@
         }
     },
     "gi": {
-        "_comment_gi": "DDGI phase 2 (M45.7) — injection + propagation runtime. DESACTIVE (enabled=false, DEFAUT) => aucune allocation GPU, passe DDGI_Update NON enregistree, LightingPass useDdgi=0 => rendu STRICTEMENT identique au chemin probes statiques. enabled=true alloue l'atlas irradiance et active la passe compute ddgi_update (ciel/soleil dynamique par sonde, base conservatrice SANS rebonds — pas de RT/voxelisation). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px). hysteresis = blend temporel [0..1] (eleve = lent/stable), intensity = facteur du terme indirect DDGI dans le lighting.",
+        "_comment_gi": "DDGI (M45.7 phase 2 / M45.8 phase 3) — injection + propagation runtime. PILOTE PAR 'quality' (DEFAUT 'off'). quality in {off, static-probes, dynamic-low, dynamic-high} : off/static-probes => aucune DDGI dynamique => aucune allocation GPU, passe DDGI_Update NON enregistree, LightingPass useDdgi=0 => rendu STRICTEMENT identique au chemin probes statiques. dynamic-low (amortissement /8, intensite 0.5) et dynamic-high (amortissement /2, intensite 1.0) allouent l'atlas irradiance et activent la passe compute ddgi_update (ciel/soleil dynamique par sonde, base conservatrice SANS rebonds — pas de RT/voxelisation). RETRO-COMPAT : si 'quality' est absent mais 'enabled'=true, traite comme dynamic-high ; sinon 'quality' prime et 'enabled' est ignore. La QUALITE pilote desormais l'amortissement (divisor) et l'intensite (l'ancienne cle 'intensity' n'est plus lue). 'debug'=true loggue l'etat DDGI au boot (qualite/alloc/probeCount/divisor/intensity ; PAS de visualisation 3D des sondes, reportee). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px). hysteresis = blend temporel [0..1] (eleve = lent/stable).",
         "ddgi": {
+            "quality": "off",
+            "debug": false,
             "enabled": false,
             "origin_m": [0, 0, 0],
             "spacing_m": [2, 2, 2],

--- a/game/data/shaders/ddgi_update.comp
+++ b/game/data/shaders/ddgi_update.comp
@@ -28,7 +28,7 @@ layout(binding = 1) uniform sampler2D uShadow;            // shadow map cascade 
 layout(push_constant) uniform PC
 {
     vec4  gridOrigin;  // xyz = origine monde sonde (0,0,0) en mètres ; w inutilisé
-    vec4  gridSpacing; // xyz = espacement par axe (mètres) ; w inutilisé
+    vec4  gridSpacing; // xyz = espacement par axe (mètres) ; w = diviseur d'amortissement (M45.8)
     uvec4 counts;      // xyz = nb sondes par axe ; w = irradianceTexels (côté hors bordure)
     vec4  sunDir;      // xyz = direction NORMALISÉE vers le soleil ; w inutilisé
     vec4  sunColor;    // xyz = couleur/intensité soleil ; w inutilisé
@@ -38,11 +38,12 @@ layout(push_constant) uniform PC
     // sunViewProj n'est PAS passée : l'occlusion soleil v1 reste grossière (cf. note).
 } pc;
 
-// M45.7b — MISE À JOUR AMORTIE. Diviseur fixe (v1) : chaque sonde n'est mise à
-// jour qu'1 frame sur kUpdateDivisor (les autres frames conservent l'irradiance
-// précédente, AUCUNE écriture). Réduit le coût ~kUpdateDivisor×. L'hystérésis
-// lisse déjà le résultat ; au repos une sonde se rafraîchit en kUpdateDivisor frames.
-const uint kUpdateDivisor = 4u;
+// M45.7b/M45.8 — MISE À JOUR AMORTIE. Chaque sonde n'est mise à jour qu'1 frame
+// sur `divisor` (les autres frames conservent l'irradiance précédente, AUCUNE
+// écriture). Réduit le coût ~divisor×. L'hystérésis lisse déjà le résultat ; au
+// repos une sonde se rafraîchit en `divisor` frames.
+// M45.8 : le diviseur est piloté par le NIVEAU DE QUALITÉ côté CPU et passé via
+// gridSpacing.w (DynamicLow=8, DynamicHigh=2). max(.,1) anti division par zéro.
 
 // Décodage octaédrique (u,v) ∈ [0,1]² -> direction unitaire.
 // Réplique EXACTE de tools/impostor_builder/OctahedralMap.h::OctaToDir.
@@ -115,7 +116,9 @@ void main()
     //     IMPORTANT : tous les texels d'une même sonde partagent probeLinear, donc
     //     une sonde est mise à jour entièrement (tous ses texels) ou pas du tout.
     uint probeLinear = ix + iy * pc.counts.x + iz * pc.counts.x * pc.counts.y;
-    if ((probeLinear % kUpdateDivisor) != (uint(pc.params.w) % kUpdateDivisor))
+    // gridSpacing.w = diviseur d'amortissement (piloté par la qualité, M45.8).
+    uint divisor = max(uint(pc.gridSpacing.w), 1u);
+    if ((probeLinear % divisor) != (uint(pc.params.w) % divisor))
         return;
 
     // 4) Radiance entrante : ciel (gradient horizon->zénith) + soleil.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3969,12 +3969,32 @@ namespace engine
 									// (copie WithBloom -> Dof) pour que Tonemap lise une image valide.
 									m_dofReady = m_pipeline->GetDepthOfFieldPass().IsValid();
 
-									// M45.7 — GI dynamique DDGI. DÉSACTIVÉ par défaut : si gi.ddgi.enabled
-									// est false (cas par défaut), on n'alloue rien, on n'enregistre pas la
-									// passe DDGI_Update et le LightingPass garde useDdgi=0 => rendu
-									// strictement identique. Si tout réussit, on bascule m_ddgiEnabled=true.
+									// M45.7/M45.8 — GI dynamique DDGI pilotée par NIVEAUX DE QUALITÉ.
+									// DÉFAUT quality="off" => s.dynamic=false => aucune allocation, passe
+									// DDGI_Update NON enregistrée, LightingPass useDdgi=0 => rendu
+									// STRICTEMENT identique au chemin probes statiques. Seuls
+									// dynamic-low/dynamic-high allouent le volume et activent la passe.
+									//
+									// Rétro-compat : si la clé gi.ddgi.quality est ABSENTE mais
+									// gi.ddgi.enabled==true, on traite comme DynamicHigh (ancien
+									// comportement « DDGI runtime pleine qualité »). Sinon, quality
+									// prime (défaut "off").
 									m_ddgiEnabled = false;
-									if (m_cfg.GetBool("gi.ddgi.enabled", false))
+									engine::render::gi::DdgiQuality ddgiQuality;
+									if (!m_cfg.Has("gi.ddgi.quality") && m_cfg.GetBool("gi.ddgi.enabled", false))
+									{
+										ddgiQuality = engine::render::gi::DdgiQuality::DynamicHigh;
+									}
+									else
+									{
+										const std::string q = m_cfg.GetString("gi.ddgi.quality", "off");
+										ddgiQuality = engine::render::gi::ParseDdgiQuality(q);
+									}
+									const engine::render::gi::DdgiQualitySettings ddgiSettings =
+										engine::render::gi::ResolveDdgiQuality(ddgiQuality);
+									m_ddgiUpdateDivisor = (ddgiSettings.updateDivisor >= 1u) ? ddgiSettings.updateDivisor : 1u;
+									m_ddgiIntensity = ddgiSettings.intensity;
+									if (ddgiSettings.dynamic)
 									{
 										engine::render::gi::DdgiGridConfig gridCfg{};
 										gridCfg.origin[0]  = static_cast<float>(m_cfg.GetDouble("gi.ddgi.origin_m[0]", 0.0));
@@ -4009,9 +4029,26 @@ namespace engine
 											else
 											{
 												m_ddgiEnabled = true;
-												LOG_INFO(Render, "[Engine] DDGI runtime ACTIF (gi.ddgi.enabled=true)");
+												LOG_INFO(Render, "[Engine] DDGI runtime ACTIF (quality={})",
+													engine::render::gi::DdgiQualityName(ddgiQuality));
 											}
 										}
+									}
+
+									// M45.8 — log debug de l'état DDGI (gated par gi.ddgi.debug).
+									// PÉRIMÈTRE : le « debug » se limite ici à ce log. La visualisation
+									// 3D des sondes (sphères colorées en ImGui) est REPORTÉE — elle
+									// nécessite un debug-draw 3D dédié (non couvert par ce ticket).
+									if (m_cfg.GetBool("gi.ddgi.debug", false))
+									{
+										LOG_INFO(Render,
+											"[Engine][DDGI debug] quality={} dynamic={} allouee={} probeCount={} divisor={} intensity={:.3f}",
+											engine::render::gi::DdgiQualityName(ddgiQuality),
+											ddgiSettings.dynamic ? 1 : 0,
+											m_ddgiEnabled ? 1 : 0,
+											m_ddgiVolume.ProbeCount(),
+											m_ddgiUpdateDivisor,
+											m_ddgiIntensity);
 									}
 
 									// M100 — Task 12 : Terrain Chunk Runtime — drawcall mesh-terrain par
@@ -5561,6 +5598,9 @@ namespace engine
 													const engine::render::gi::DdgiGridConfig& gc = m_ddgiVolume.Config();
 													up.gridOrigin[0] = gc.origin[0]; up.gridOrigin[1] = gc.origin[1]; up.gridOrigin[2] = gc.origin[2];
 													up.gridSpacing[0] = gc.spacing[0]; up.gridSpacing[1] = gc.spacing[1]; up.gridSpacing[2] = gc.spacing[2];
+													// M45.8 — slot .w (sinon inutilisé) = diviseur d'amortissement,
+													// lu par ddgi_update.comp (1 sonde sur N mise à jour par frame).
+													up.gridSpacing[3] = static_cast<float>(m_ddgiUpdateDivisor);
 													up.counts[0] = gc.counts[0]; up.counts[1] = gc.counts[1]; up.counts[2] = gc.counts[2];
 													up.counts[3] = gc.irradianceTexels;
 													// Direction VERS le soleil (normalisée), couleur soleil per-zone.
@@ -5711,7 +5751,9 @@ namespace engine
 													lp.ddgiAtlas[0] = static_cast<float>(m_ddgiVolume.AtlasCols());
 													lp.ddgiAtlas[1] = static_cast<float>(m_ddgiVolume.AtlasRows());
 													lp.ddgiAtlas[2] = static_cast<float>(m_ddgiVolume.IrradianceTileSize());
-													lp.ddgiAtlas[3] = static_cast<float>(m_cfg.GetDouble("gi.ddgi.intensity", 1.0));
+													// M45.8 — intensité pilotée par le niveau de qualité (DynamicLow=0.5,
+													// DynamicHigh=1.0). Remplace l'ancienne lecture de gi.ddgi.intensity.
+													lp.ddgiAtlas[3] = m_ddgiIntensity;
 													ddgiView = m_ddgiVolume.IrradianceView();
 													ddgiSamp = m_ddgiUpdatePass.GetShadowSampler(); // sampler linéaire-équivalent (NEAREST clamp) interne
 												}

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -55,6 +55,7 @@
 #include "src/client/render/SkyPass.h"
 #include "src/client/render/gi/DdgiVolume.h"
 #include "src/client/render/gi/DdgiUpdatePass.h"
+#include "src/client/render/gi/DdgiQuality.h"
 #include "src/client/render/WeatherSystem.h"
 #include "src/client/render/DynamicLightSystem.h"
 #include "src/client/world/water/WaterSurfaces.h"
@@ -363,8 +364,16 @@ namespace engine
 		engine::render::gi::DdgiVolume m_ddgiVolume;
 		/// M45.7 — passe compute qui met à jour l'atlas d'irradiance du volume DDGI.
 		engine::render::gi::DdgiUpdatePass m_ddgiUpdatePass;
-		/// M45.7 — true uniquement si gi.ddgi.enabled ET allocation/init réussis.
+		/// M45.7 — true uniquement si la qualité DDGI est dynamique ET allocation/init réussis.
 		bool m_ddgiEnabled = false;
+		/// M45.8 — amortissement : 1 sonde sur N mise à jour par frame (>= 1).
+		/// Dérivé du niveau de qualité (DynamicLow=8, DynamicHigh=2). Poussé au
+		/// shader ddgi_update via DdgiUpdateParams::gridSpacing.w.
+		uint32_t m_ddgiUpdateDivisor = 4;
+		/// M45.8 — intensité du terme indirect DDGI dans le lighting. Dérivée du
+		/// niveau de qualité (DynamicLow=0.5, DynamicHigh=1.0 ; 0 si statique).
+		/// Poussée au LightingPass via LightParams::ddgiAtlas[3].
+		float m_ddgiIntensity = 1.0f;
 		/// SceneColor_LDR: output of the tonemap pass (R8G8B8A8_UNORM). Added in M03.4.
 		engine::render::ResourceId m_fgSceneColorLDRId   = engine::render::kInvalidResourceId;
 		/// M08.2: SceneColor_HDR + bloom (combine pass output); tonemap reads this.

--- a/src/client/render/gi/DdgiQuality.cpp
+++ b/src/client/render/gi/DdgiQuality.cpp
@@ -1,0 +1,67 @@
+#include "src/client/render/gi/DdgiQuality.h"
+
+#include <cctype>
+#include <string>
+
+namespace engine::render::gi
+{
+	namespace
+	{
+		/// Met une chaîne en minuscules (ASCII) pour la comparaison insensible
+		/// à la casse. CPU pur, sans dépendance locale.
+		std::string ToLowerAscii(std::string_view s)
+		{
+			std::string out;
+			out.reserve(s.size());
+			for (char c : s)
+				out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+			return out;
+		}
+	}
+
+	DdgiQuality ParseDdgiQuality(std::string_view s)
+	{
+		const std::string v = ToLowerAscii(s);
+		if (v == "off")
+			return DdgiQuality::Off;
+		if (v == "static" || v == "static-probes")
+			return DdgiQuality::StaticProbes;
+		if (v == "dynamic-low")
+			return DdgiQuality::DynamicLow;
+		if (v == "dynamic-high")
+			return DdgiQuality::DynamicHigh;
+		// Inconnu / vide : défaut Off (une coquille ne doit jamais activer la DDGI).
+		return DdgiQuality::Off;
+	}
+
+	DdgiQualitySettings ResolveDdgiQuality(DdgiQuality q)
+	{
+		switch (q)
+		{
+			// Off et StaticProbes => dynamic=false => useDdgi=0 => rendu probes
+			// statiques inchangé (garantie de non-régression).
+			case DdgiQuality::Off:
+				return DdgiQualitySettings{ /*dynamic*/ false, /*updateDivisor*/ 4u, /*intensity*/ 0.0f };
+			case DdgiQuality::StaticProbes:
+				return DdgiQualitySettings{ /*dynamic*/ false, /*updateDivisor*/ 4u, /*intensity*/ 0.0f };
+			case DdgiQuality::DynamicLow:
+				return DdgiQualitySettings{ /*dynamic*/ true, /*updateDivisor*/ 8u, /*intensity*/ 0.5f };
+			case DdgiQuality::DynamicHigh:
+				return DdgiQualitySettings{ /*dynamic*/ true, /*updateDivisor*/ 2u, /*intensity*/ 1.0f };
+		}
+		// Défensif : tout enum non couvert retombe sur Off (statique).
+		return DdgiQualitySettings{ false, 4u, 0.0f };
+	}
+
+	const char* DdgiQualityName(DdgiQuality q)
+	{
+		switch (q)
+		{
+			case DdgiQuality::Off:          return "off";
+			case DdgiQuality::StaticProbes: return "static-probes";
+			case DdgiQuality::DynamicLow:   return "dynamic-low";
+			case DdgiQuality::DynamicHigh:  return "dynamic-high";
+		}
+		return "off";
+	}
+} // namespace engine::render::gi

--- a/src/client/render/gi/DdgiQuality.h
+++ b/src/client/render/gi/DdgiQuality.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::render::gi
+{
+	/// M45.8 — Niveaux de qualité de la GI dynamique (DDGI), phase 3.
+	///
+	/// Remplace le simple booléen `gi.ddgi.enabled` par une échelle de qualité
+	/// pilotée par la clé `gi.ddgi.quality`. Le DÉFAUT est `Off` : aucune DDGI
+	/// dynamique, rendu STRICTEMENT identique au chemin probes statiques / IBL
+	/// d'avant la GI dynamique.
+	///
+	/// Garantie de fallback (centrale au ticket) : `Off` ET `StaticProbes`
+	/// résolvent tous deux `dynamic=false` => `m_ddgiEnabled=false` côté Engine
+	/// => `useDdgi=0` côté LightingPass => rendu probes statiques inchangé. Seuls
+	/// `DynamicLow` / `DynamicHigh` activent l'allocation du volume et la passe
+	/// compute `DDGI_Update`.
+	enum class DdgiQuality
+	{
+		Off,           ///< Pas de DDGI. Rendu identique à l'historique (défaut).
+		StaticProbes,  ///< Fallback explicite probes statiques (= Off pour le rendu dynamique).
+		DynamicLow,    ///< DDGI dynamique économique (amortissement fort, intensité réduite).
+		DynamicHigh    ///< DDGI dynamique pleine qualité (amortissement faible, intensité 1.0).
+	};
+
+	/// Parse une chaîne de configuration en niveau de qualité DDGI.
+	/// Insensible à la casse. Correspondances :
+	///   "off"                          -> Off
+	///   "static" / "static-probes"     -> StaticProbes
+	///   "dynamic-low"                  -> DynamicLow
+	///   "dynamic-high"                 -> DynamicHigh
+	/// Toute valeur inconnue, vide ou non reconnue retombe sur `Off` (sécurité :
+	/// une coquille de config ne doit jamais activer la DDGI par accident).
+	/// \param s Chaîne brute issue de la config (peut être vide).
+	/// \return Le niveau de qualité résolu (Off par défaut).
+	DdgiQuality ParseDdgiQuality(std::string_view s);
+
+	/// Paramètres effectifs dérivés d'un niveau de qualité.
+	/// \note `updateDivisor` est garanti >= 1 par `ResolveDdgiQuality` (le shader
+	///       l'utilise comme diviseur de modulo : 0 provoquerait une division par
+	///       zéro côté GPU). L'appelant peut quand même reclamper par sécurité.
+	struct DdgiQualitySettings
+	{
+		bool     dynamic;       ///< true => allouer le volume + enregistrer DDGI_Update + useDdgi=1.
+		uint32_t updateDivisor; ///< Amortissement : 1 sonde sur N mise à jour par frame (>= 1).
+		float    intensity;     ///< Facteur du terme indirect DDGI dans le lighting (0 = neutre).
+	};
+
+	/// Résout un niveau de qualité en paramètres concrets.
+	///   Off          -> { dynamic=false, updateDivisor=4, intensity=0.0 }
+	///   StaticProbes -> { dynamic=false, updateDivisor=4, intensity=0.0 }
+	///   DynamicLow   -> { dynamic=true,  updateDivisor=8, intensity=0.5 }
+	///   DynamicHigh  -> { dynamic=true,  updateDivisor=2, intensity=1.0 }
+	/// `Off` et `StaticProbes` => `dynamic=false` => useDdgi=0 => rendu probes
+	/// statiques inchangé (garantie de non-régression du ticket).
+	/// \param q Niveau de qualité.
+	/// \return Paramètres effectifs (`updateDivisor` toujours >= 1).
+	DdgiQualitySettings ResolveDdgiQuality(DdgiQuality q);
+
+	/// Nom lisible du niveau de qualité, pour les logs debug.
+	/// \param q Niveau de qualité.
+	/// \return Littéral statique ("off", "static-probes", "dynamic-low",
+	///         "dynamic-high"). Jamais nullptr.
+	const char* DdgiQualityName(DdgiQuality q);
+} // namespace engine::render::gi

--- a/src/client/render/gi/tests/DdgiFallbackTests.cpp
+++ b/src/client/render/gi/tests/DdgiFallbackTests.cpp
@@ -1,0 +1,112 @@
+/**
+ * M45.8 : tests unitaires CPU PURS pour les niveaux de qualité / fallback DDGI
+ * (DdgiQuality). Aucune dépendance Vulkan : on ne teste QUE le parsing de la
+ * config et la résolution en paramètres effectifs.
+ *
+ * Convention identique à DdgiVolumeTests.cpp / ProtocolV1Tests.cpp : main()
+ * renvoie 0 si tout passe, non-zero (+ message sur stderr) au premier échec.
+ *
+ * Garantie centrale couverte ici : "off" ET "static-probes" => dynamic==false
+ * (pas de DDGI dynamique => rendu probes statiques inchangé).
+ */
+
+#include "src/client/render/gi/DdgiQuality.h"
+
+#include <cstdint>
+#include <iostream>
+
+namespace
+{
+	static int s_failCount = 0;
+
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using engine::render::gi::DdgiQuality;
+using engine::render::gi::DdgiQualitySettings;
+using engine::render::gi::ParseDdgiQuality;
+using engine::render::gi::ResolveDdgiQuality;
+
+static bool TestParse()
+{
+	// Valeurs canoniques.
+	Assert(ParseDdgiQuality("off") == DdgiQuality::Off, "parse off");
+	Assert(ParseDdgiQuality("static") == DdgiQuality::StaticProbes, "parse static");
+	Assert(ParseDdgiQuality("static-probes") == DdgiQuality::StaticProbes, "parse static-probes");
+	Assert(ParseDdgiQuality("dynamic-low") == DdgiQuality::DynamicLow, "parse dynamic-low");
+	Assert(ParseDdgiQuality("dynamic-high") == DdgiQuality::DynamicHigh, "parse dynamic-high");
+
+	// Insensible à la casse.
+	Assert(ParseDdgiQuality("OFF") == DdgiQuality::Off, "parse OFF (casse)");
+	Assert(ParseDdgiQuality("Static-Probes") == DdgiQuality::StaticProbes, "parse Static-Probes (casse)");
+	Assert(ParseDdgiQuality("DYNAMIC-HIGH") == DdgiQuality::DynamicHigh, "parse DYNAMIC-HIGH (casse)");
+
+	// Inconnu / vide -> Off (sécurité : pas d'activation accidentelle).
+	Assert(ParseDdgiQuality("") == DdgiQuality::Off, "parse vide -> Off");
+	Assert(ParseDdgiQuality("bidon") == DdgiQuality::Off, "parse inconnu -> Off");
+	return s_failCount == 0;
+}
+
+static bool TestResolveFallback()
+{
+	// GARANTIE FALLBACK : Off et StaticProbes => dynamic == false.
+	const DdgiQualitySettings off = ResolveDdgiQuality(DdgiQuality::Off);
+	Assert(off.dynamic == false, "Off => dynamic false (rendu statique inchange)");
+	Assert(off.intensity == 0.0f, "Off => intensity 0");
+
+	const DdgiQualitySettings stat = ResolveDdgiQuality(DdgiQuality::StaticProbes);
+	Assert(stat.dynamic == false, "StaticProbes => dynamic false (rendu statique inchange)");
+	Assert(stat.intensity == 0.0f, "StaticProbes => intensity 0");
+	return s_failCount == 0;
+}
+
+static bool TestResolveDynamic()
+{
+	const DdgiQualitySettings low = ResolveDdgiQuality(DdgiQuality::DynamicLow);
+	Assert(low.dynamic == true, "DynamicLow => dynamic true");
+	Assert(low.updateDivisor == 8u, "DynamicLow => divisor 8");
+	Assert(low.intensity == 0.5f, "DynamicLow => intensity 0.5");
+
+	const DdgiQualitySettings high = ResolveDdgiQuality(DdgiQuality::DynamicHigh);
+	Assert(high.dynamic == true, "DynamicHigh => dynamic true");
+	Assert(high.updateDivisor == 2u, "DynamicHigh => divisor 2");
+	Assert(high.intensity == 1.0f, "DynamicHigh => intensity 1.0");
+	return s_failCount == 0;
+}
+
+static bool TestDivisorNonZero()
+{
+	// Cohérence : updateDivisor toujours >= 1 (sinon division par zéro shader).
+	const DdgiQuality all[] = {
+		DdgiQuality::Off, DdgiQuality::StaticProbes,
+		DdgiQuality::DynamicLow, DdgiQuality::DynamicHigh
+	};
+	for (DdgiQuality q : all)
+	{
+		const DdgiQualitySettings s = ResolveDdgiQuality(q);
+		Assert(s.updateDivisor >= 1u, "updateDivisor >= 1 (anti division par zero)");
+	}
+	return s_failCount == 0;
+}
+
+int main()
+{
+	TestParse();
+	TestResolveFallback();
+	TestResolveDynamic();
+	TestDivisorNonZero();
+	if (s_failCount != 0)
+	{
+		std::cerr << "Total echecs : " << s_failCount << std::endl;
+		return 1;
+	}
+	std::cout << "DdgiFallback tests : tout est passe." << std::endl;
+	return 0;
+}


### PR DESCRIPTION
## M45.8 — DDGI phase 3 : tuning / fallback / tests (cluster M45 — final)

> ⚠️ **Stackée sur #798 → #797 → #796**. Merger #796, #797, #798 d'abord. Base `main`.

Rend la DDGI **exploitable** : niveaux de qualité, **garantie de fallback statique**, paramètres réglables, **tests de non-régression**. **Défaut `quality="off"` → rendu strictement identique au chemin probes statiques** (garantie centrale du ticket).

### Niveaux de qualité (`gi.ddgi.quality`)
| Niveau | dynamic | amortissement | intensité |
|--------|---------|---------------|-----------|
| `off` (défaut) | non | — | 0 → **rendu inchangé** |
| `static-probes` | non | — | 0 → **rendu inchangé** (probes statiques, = avant M45.6) |
| `dynamic-low` | oui | 1 sonde/8 frames | 0.5 |
| `dynamic-high` | oui | 1 sonde/2 frames | 1.0 |

### Contenu
- `gi/DdgiQuality.{h,cpp}` : enum + `ParseDdgiQuality` (insensible casse, **défaut Off** pour inconnu) + `ResolveDdgiQuality` (mapping ci-dessus) + `DdgiQualityName`. CPU pur.
- `gi/tests/DdgiFallbackTests.cpp` : **tests ctest** (parse, **garantie off/static ⇒ dynamic=false**, valeurs dynamiques, divisor≥1).
- `Engine` : boot piloté par `quality` ; alloue le volume + active la passe **uniquement si `dynamic`** ; **rétro-compat** `gi.ddgi.enabled=true ⇒ DynamicHigh` ; diviseur d'amortissement réglable poussé via `gridSpacing.w` (slot libre, **pas de resize** de `DdgiUpdateParams`) ; intensité pilotée par la qualité ; log debug gated `gi.ddgi.debug`.
- `ddgi_update.comp` : diviseur lu depuis `pc.gridSpacing.w` (au lieu du 4 codé en dur).
- `config.json` : `gi.ddgi.quality="off"` + `debug=false`.

### Non-régression (vérifiée)
`quality="off"` (défaut) → `dynamic=false` → pas d'allocation, passe `DDGI_Update` non enregistrée, `useDdgi=0` → **byte-identique**. `static-probes` idem. `DdgiUpdateParams` inchangé (112 o).

### Non fait (documenté)
**Visualisation 3D des sondes (sphères ImGui)** : reportée (nécessite un debug-draw 3D dédié). Le « debug » se limite ici à un **log d'état** DDGI. (Le ticket prévoit de toute façon plusieurs passes de réglage visuel itératives.)

### Déploiement
✅ **100% client.** Aucun redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)