### PR TITLE
feat(coffre): animation PickUp_Table + verrou déplacement à l'ouverture

### DIFF
--- a/docs/superpowers/plans/2026-06-02-coffre-anim-perso-verrou.md
+++ b/docs/superpowers/plans/2026-06-02-coffre-anim-perso-verrou.md
@@ -1,0 +1,325 @@
+# Animation d'ouverture de coffre + verrou de déplacement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** À l'appui sur E près d'un coffre, le personnage joue l'animation `PickUp_Table` (penché → saisie → redressé) et son déplacement est verrouillé pendant toute la durée du clip ; ailleurs, le geste `Interact` générique reste inchangé.
+
+**Architecture:** Réutilise l'état de locomotion `Interact` existant (pas de nouvel état réseau). Un rôle de clip dynamique (`m_currentInteractRole`, calqué sur `m_currentPunchRole`) sélectionne `PickUp_Table` près d'un coffre, `Interact` ailleurs. Un horodatage `m_avatarMoveLockUntilSec` neutralise les entrées de déplacement (`MoveInput` vide) avant `CharacterController::Update` tant que le clip joue. Caméra non touchée.
+
+**Tech Stack:** C++ / Engine client (`src/client/app/Engine.{h,cpp}`), Vulkan, state machine de locomotion inline dans `Engine::Update`.
+
+**Note sur la vérification (lire avant de commencer) :** La state machine de locomotion est codée inline dans `Engine::Update` (pas de fonction extraite testable) et le poste n'a **pas** de toolchain de build local (cf. mémoire projet : cmake/MSVC/vcpkg absents). Il n'y a donc **pas de test unitaire** pour ce code. La vérification se fait par (1) **compilation via la CI GitHub** (build-windows + build-linux) et (2) un **protocole de test manuel en jeu** (Task 5). Ne pas inventer de faux tests unitaires.
+
+**Spec de référence :** [docs/superpowers/specs/2026-06-02-coffre-animation-perso-verrou-design.md](../specs/2026-06-02-coffre-animation-perso-verrou-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `src/client/app/Engine.h` — 2 nouveaux membres (`m_currentInteractRole`, `m_avatarMoveLockUntilSec`) à côté des champs d'anim avatar existants (~ligne 716).
+- **Modify** `src/client/app/Engine.cpp` — 4 points :
+  1. Lecture dynamique du clip de l'état `Interact` (fetch ~ligne 8363 + ternaire de transition ~ligne 8690).
+  2. Déclenchement near-chest : rôle + verrou au site du trigger Interact (~ligne 8634).
+  3. Neutralisation des entrées quand verrouillé, avant `CharacterController::Update` (~ligne 8280).
+  4. Garde anti-roulade pendant le verrou (~ligne 8596).
+
+Aucun fichier créé. Pur client. Pas de migration, pas d'opcode, pas de changement de `ToWireAnimState`.
+
+---
+
+## Task 1 : Déclarer les deux nouveaux membres dans Engine.h
+
+**Files:**
+- Modify: `src/client/app/Engine.h` (après `m_punchAlt`, ~ligne 717)
+
+- [ ] **Step 1 : Ajouter les membres**
+
+Dans `src/client/app/Engine.h`, juste après la ligne `bool m_punchAlt = false;` (~717), insérer :
+
+```cpp
+		/// Interaction : rôle d'anim joué par l'état Interact (clip dynamique, calqué
+		/// sur m_currentPunchRole). "Interact" par défaut (geste générique sur E) ;
+		/// passe à "PickUp_Table" près d'un coffre (se pencher → saisir → se redresser).
+		std::string                                              m_currentInteractRole = "Interact";
+		/// Verrou de déplacement : instant (s, EngineNowSec) jusqu'auquel les entrées
+		/// de déplacement de l'avatar sont neutralisées (MoveInput vide) pendant un
+		/// geste verrouillant (ouverture de coffre). 0 = aucun verrou actif.
+		float                                                    m_avatarMoveLockUntilSec = 0.0f;
+```
+
+- [ ] **Step 2 : Vérifier la cohérence locale (lecture)**
+
+Relire le bloc 705-722 de `Engine.h` : les nouveaux membres doivent être dans la même section que `m_currentPunchRole` / `m_castPhase` (état d'animation avatar). Aucune autre déclaration touchée.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/client/app/Engine.h
+git commit -m "feat(avatar): champs m_currentInteractRole + m_avatarMoveLockUntilSec (coffre)"
+```
+
+---
+
+## Task 2 : Rendre le clip de l'état Interact dynamique
+
+L'état `Interact` joue actuellement le clip littéral `"Interact"`. On le fait pointer sur `m_currentInteractRole`. Deux points à modifier.
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp:8363` (fetch du clip Interact)
+- Modify: `src/client/app/Engine.cpp:8690-8693` (ternaire de sélection du clip à la transition)
+
+- [ ] **Step 1 : Fetch dynamique du clip Interact**
+
+Remplacer (~ligne 8363) :
+
+```cpp
+						const engine::render::skinned::AnimationClip* interactClip =
+							m_currentSkinnedMesh->FindClip("Interact");
+```
+
+par :
+
+```cpp
+						// Clip dynamique : "Interact" (geste générique) ou "PickUp_Table"
+						// (près d'un coffre). m_currentInteractRole est fixé au déclenchement.
+						const engine::render::skinned::AnimationClip* interactClip =
+							m_currentSkinnedMesh->FindClip(m_currentInteractRole.c_str());
+```
+
+> `interactClip` ne sert qu'à la condition de fin du one-shot dans le `case Interact`
+> (~ligne 8550), évaluée seulement quand l'avatar est *déjà* en état Interact —
+> à ce moment `m_currentInteractRole` est stable depuis le dernier appui. OK.
+
+- [ ] **Step 2 : Sélection dynamique du clip à la transition**
+
+Remplacer le ternaire (~ligne 8690-8693) :
+
+```cpp
+							const char* clipName =
+								(newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty()) ? m_currentEmoteRole.c_str()
+								: (newState == AvatarLocomotionState::Punch) ? m_currentPunchRole.c_str()
+								: StateToClipName(newState);
+```
+
+par :
+
+```cpp
+							const char* clipName =
+								(newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty()) ? m_currentEmoteRole.c_str()
+								: (newState == AvatarLocomotionState::Punch) ? m_currentPunchRole.c_str()
+								: (newState == AvatarLocomotionState::Interact) ? m_currentInteractRole.c_str()
+								: StateToClipName(newState);
+```
+
+> Ce ternaire s'exécute APRÈS les triggers (le bloc transition ~8669 vient après
+> le trigger Interact ~8634), donc `m_currentInteractRole` est déjà à jour ce frame.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(avatar): clip dynamique pour l'état Interact (rôle m_currentInteractRole)"
+```
+
+---
+
+## Task 3 : Déclencher PickUp_Table + armer le verrou près d'un coffre
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp:8633-8635` (trigger de l'état Interact)
+
+- [ ] **Step 1 : Remplacer le trigger Interact**
+
+Remplacer (~ligne 8633-8635) :
+
+```cpp
+						// Interagir (touche E par defaut) : geste Interact one-shot, action non-combat.
+						if (interactPressed && !moveInput.jumpPressed && !busyOneShot())
+							newState = AvatarLocomotionState::Interact;
+```
+
+par :
+
+```cpp
+						// Interagir (touche E par defaut) : geste Interact one-shot, action non-combat.
+						// Près d'un coffre : joue "PickUp_Table" (se pencher → saisir → se redresser)
+						// et verrouille le déplacement le temps du clip. Ailleurs : geste "Interact"
+						// générique, sans verrou (comportement historique inchangé).
+						if (interactPressed && !moveInput.jumpPressed && !busyOneShot())
+						{
+							const bool nearChest =
+								m_chestLoaded && m_interactableInRange == m_chestInteractableIndex;
+							if (nearChest)
+							{
+								m_currentInteractRole = "PickUp_Table";
+								const engine::render::skinned::AnimationClip* puClip =
+									m_currentSkinnedMesh->FindClip("PickUp_Table");
+								// Clip absent (race non-UE5 / fallback) -> durée 0 -> verrou expire
+								// immédiatement, pas de gel permanent ; le repli sur "Interact"
+								// est géré juste en dessous.
+								m_avatarMoveLockUntilSec = nowSec + (puClip ? puClip->duration : 0.0f);
+								if (!puClip)
+									m_currentInteractRole = "Interact";
+							}
+							else
+							{
+								m_currentInteractRole = "Interact";
+							}
+							newState = AvatarLocomotionState::Interact;
+						}
+```
+
+> `nearChest` s'appuie sur `m_interactableInRange` (mis à jour à la frame
+> précédente dans le bloc interactibles ~8745) et `m_chestInteractableIndex`
+> (stable). Les deux valent -1 par défaut, mais `m_chestLoaded` garde le cas
+> (faux tant qu'aucun coffre animé n'est chargé). `nowSec` est déjà défini
+> (~ligne 8344) dans ce bloc.
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(coffre): E près d'un coffre -> PickUp_Table + arme le verrou déplacement"
+```
+
+---
+
+## Task 4 : Neutraliser le déplacement pendant le verrou
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp:8280-8282` (neutralisation avant CharacterController::Update)
+- Modify: `src/client/app/Engine.cpp:8596` (garde anti-roulade pendant le verrou)
+
+- [ ] **Step 1 : Neutraliser MoveInput avant le CharacterController**
+
+Remplacer (~ligne 8280-8282) :
+
+```cpp
+					const auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout, sprintKey, crouchKey);
+					// Collisionneur composite : terrain (sol + eau) + cylindres des props/décor.
+					m_characterController.Update(static_cast<float>(dt), moveInput, m_worldCollider);
+```
+
+par :
+
+```cpp
+					auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout, sprintKey, crouchKey);
+					// Verrou de geste (ouverture de coffre) : tant qu'il est actif, on
+					// neutralise toutes les entrées de déplacement (direction + saut) pour
+					// que l'avatar reste immobile pendant l'animation. La caméra reste libre
+					// (m_orbitalCameraController non touché).
+					const bool moveLocked = EngineNowSec() < m_avatarMoveLockUntilSec;
+					if (moveLocked)
+						moveInput = engine::gameplay::MoveInput{};
+					// Collisionneur composite : terrain (sol + eau) + cylindres des props/décor.
+					m_characterController.Update(static_cast<float>(dt), moveInput, m_worldCollider);
+```
+
+> Changement `const auto` -> `auto` car on réaffecte `moveInput`. Le reste du code
+> qui lit `moveInput` (yaw, state machine) voit alors des entrées nulles pendant
+> le verrou : `moving` devient faux, la SM laisse l'état Interact se terminer puis
+> repasse Idle. Le `jumpPressed` neutralisé empêche aussi le saut.
+
+- [ ] **Step 2 : Empêcher la roulade pendant le verrou**
+
+Le trigger de roulade/esquive (double-tap Ctrl) ne passe PAS par `busyOneShot()`,
+il faut donc l'exclure explicitement. Remplacer (~ligne 8596) :
+
+```cpp
+						// Esquive/roulade (double-appui Crouch) : Roll one-shot, prioritaire sur crouch.
+						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll)
+```
+
+par :
+
+```cpp
+						// Esquive/roulade (double-appui Crouch) : Roll one-shot, prioritaire sur crouch.
+						// Bloquée pendant le verrou de geste (ouverture de coffre).
+						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll
+							&& nowSec >= m_avatarMoveLockUntilSec)
+```
+
+> Les autres actions one-shot (attaque clic gauche, punch, cast) sont déjà
+> bloquées par `busyOneShot()` puisque l'avatar est en état `Interact` pendant
+> le verrou — pas de garde supplémentaire nécessaire pour elles.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(coffre): verrou déplacement (MoveInput neutralisé + roulade bloquée)"
+```
+
+---
+
+## Task 5 : Vérification (compilation CI + test manuel en jeu)
+
+Pas de test unitaire possible (SM inline, pas de toolchain locale). Vérification en deux temps.
+
+**Files:** aucun (vérification).
+
+- [ ] **Step 1 : Pousser la branche et lancer la CI**
+
+```bash
+git push -u origin feat/coffre-anim-perso-verrou
+```
+
+Ouvrir une PR (ou laisser la CI tourner sur la branche). Attendre la CI GitHub :
+- `build-windows` : DOIT compiler sans erreur (c'est le binaire client réel).
+- `build-linux` : DOIT compiler ; `ctest` ne couvre pas ce code mais ne doit pas régresser.
+
+Attendu : ✅ vert sur les deux. (Build Windows ~30 min, cf. mémoire projet.)
+
+- [ ] **Step 2 : Vérifier l'absence de warning de compilation sur les zones touchées**
+
+Dans les logs CI, vérifier qu'aucun nouveau warning n'apparaît sur `Engine.cpp`
+(notamment autour du changement `const auto` -> `auto moveInput`).
+
+- [ ] **Step 3 : Protocole de test manuel en jeu (sur le poste client Windows)**
+
+Lancer le client de jeu, entrer dans le monde, s'approcher du coffre `Chest_Wood`
+(message « Près de Coffre - appuyez sur E »), puis vérifier dans l'ordre :
+
+1. **Animation perso** : appuyer sur E → l'avatar se penche (saisie) puis se
+   redresse (clip `PickUp_Table`). Le couvercle du coffre s'ouvre (instantané).
+2. **Verrou** : pendant l'animation, presser Z/Q/S/D (ou WASD), Espace (saut),
+   double-Ctrl (roulade), clic gauche (attaque) → l'avatar ne bouge PAS, ne saute
+   PAS, ne roule PAS, n'attaque PAS jusqu'à la fin du clip.
+3. **Caméra libre** : pendant le verrou, le clic droit + souris tourne toujours
+   la caméra (non bloquée).
+4. **Reprise** : à la fin du clip, le déplacement redevient immédiat (Z avance).
+5. **Refermeture** : le coffre se referme bien ~2 s après l'ouverture (inchangé).
+6. **Hors coffre** : appuyer sur E loin de tout coffre → geste `Interact`
+   générique, AUCUN verrou (on peut bouger immédiatement). Comportement historique.
+7. **Clip absent (optionnel)** : si une race sans `PickUp_Table` est testable,
+   E près d'un coffre joue `Interact` et ne fige PAS l'avatar (pas de gel).
+
+Vérifier aussi les logs `[Avatar SM]` : la transition `-> Interact` doit logguer
+`Play('PickUp_Table')` près d'un coffre, `Play('Interact')` ailleurs.
+
+- [ ] **Step 4 : Renseigner le résultat du test manuel**
+
+Noter dans la PR (case cochée) le résultat des points 1-6 (7 si testé). Si un
+point échoue, repasser par superpowers:systematic-debugging avant de merger.
+
+---
+
+## Notes de livraison
+
+- **Déploiement** : ✅ client uniquement, **pas de redéploiement serveur** (aucun
+  opcode, aucun changement `ToWireAnimState`, aucune migration).
+- **Merge** : une seule PR, mergeable dès que la CI est verte ET le test manuel
+  (Task 5 Step 3) validé. Pas de stack, pas de lock-step serveur.
+- **Limite connue (v1)** : les joueurs distants voient l'état réseau `Interact`
+  (rôle de clip local) → ils voient le geste `Interact` générique, pas
+  `PickUp_Table`. Cosmétique, hors périmètre (cf. spec).
+
+## Self-review (couverture spec)
+
+- Animation `PickUp_Table` près d'un coffre → Task 2 + Task 3. ✅
+- Verrou « tout bloqué, durée du clip » → Task 3 (durée) + Task 4 (déplacement/saut/roulade ; attaque/cast/punch via `busyOneShot`). ✅
+- Caméra libre → Task 4 Step 1 (orbital controller non touché). ✅
+- Portée coffres uniquement, `Interact` générique inchangé ailleurs → Task 3 (`nearChest`). ✅
+- Couvercle instantané inchangé → aucun changement du bloc coffre ~8763. ✅
+- Garde-fou clip absent → Task 3 Step 1 (durée 0 + repli `Interact`). ✅
+- Pas de redéploiement serveur → confirmé (client only). ✅

--- a/docs/superpowers/specs/2026-06-02-coffre-animation-perso-verrou-design.md
+++ b/docs/superpowers/specs/2026-06-02-coffre-animation-perso-verrou-design.md
@@ -1,0 +1,124 @@
+# Design — Animation d'ouverture de coffre + verrou de déplacement
+
+**Date** : 2026-06-02
+**Portée** : client uniquement (rendu / gameplay), pas de redéploiement serveur.
+
+## Problème
+
+À l'appui sur **E** près d'un coffre (`Chest_Wood`) :
+
+1. Le couvercle s'ouvre puis se referme automatiquement à +2 s. **Déjà en place**
+   ([`Engine.cpp:8753`](../../../src/client/app/Engine.cpp) et suivantes).
+2. Aucune animation du **personnage** n'accompagne le geste de façon spécifique
+   au coffre. Un état `Interact` générique existe et se déclenche à *chaque*
+   appui sur E, mais il n'est ni spécifique au coffre ni verrouillant.
+3. **Bug constaté** : le joueur peut repartir immédiatement. Le
+   `CharacterController` est mis à jour **inconditionnellement** avec les entrées
+   de déplacement ([`Engine.cpp:8282`](../../../src/client/app/Engine.cpp)), donc
+   le mouvement n'est jamais verrouillé pendant un geste.
+
+## Découverte préalable
+
+Il **n'existe pas** de clip « Chest Open » pour l'avatar. `Chest_Open` est
+l'animation du **couvercle** du coffre. La bibliothèque d'animations du
+personnage (`Humanoid_Base_Standard.glb`) contient comme candidats pour « se
+pencher dans le coffre puis se redresser » :
+
+- `PickUp_Table` — penché → saisie → redressé (**retenu**)
+- `Interact` — geste d'interaction générique (déjà câblé)
+- `Fixing_Kneeling` — s'agenouille
+
+## Décisions
+
+| Sujet | Décision |
+|---|---|
+| Animation perso | `PickUp_Table` |
+| Verrou | Tout bloqué (déplacement + saut + attaque/sort/roulade), **durée du clip** ; caméra libre |
+| Portée | Coffres uniquement ; le geste `Interact` générique ailleurs reste inchangé |
+| Couvercle | Ouverture instantanée à l'appui (comportement actuel inchangé) |
+
+## Approche retenue (A) — Verrou temporel + clip d'interaction dynamique
+
+Réutilise l'état de locomotion `Interact` existant ; pas de nouvel état
+(éviter de toucher l'enum répliqué `ToWireAnimState` et ses `static_assert`).
+
+### Nouveaux membres `Engine`
+
+- `std::string m_currentInteractRole` — rôle de clip joué par l'état `Interact`.
+  Défaut `"Interact"`. Mis à `"PickUp_Table"` près d'un coffre. Calque le
+  pattern existant `m_currentPunchRole` (alternance Jab/Cross).
+- `float m_avatarMoveLockUntilSec = 0.0f` — horodatage (base `EngineNowSec()`)
+  jusqu'auquel les entrées de déplacement sont neutralisées.
+
+### Détection « près d'un coffre »
+
+Sans réordonner le code, la state machine dispose déjà de
+`m_interactableInRange` (valeur de la frame précédente) et de
+`m_chestInteractableIndex` :
+
+```
+nearChest = m_chestLoaded && m_interactableInRange == m_chestInteractableIndex
+```
+
+### Déclenchement
+
+Au site où l'état `Interact` est armé (~[`Engine.cpp:8634`](../../../src/client/app/Engine.cpp)) :
+
+- si `nearChest` :
+  - `m_currentInteractRole = "PickUp_Table"`
+  - récupérer le clip via `m_currentSkinnedMesh->FindClip("PickUp_Table")`
+  - `m_avatarMoveLockUntilSec = EngineNowSec() + (clip ? clip->duration : 0.0f)`
+- sinon :
+  - `m_currentInteractRole = "Interact"`
+  - pas de verrou (comportement actuel)
+
+### Lecture du clip dans l'état `Interact`
+
+L'état `Interact` cherche `FindClip(m_currentInteractRole.c_str())` au lieu du
+littéral `"Interact"`. La condition de fin de one-shot
+(`stateElapsed >= clip->duration`) utilise le même clip dynamique.
+
+### Verrou de déplacement
+
+Juste avant `m_characterController.Update(...)` ([`Engine.cpp:8282`](../../../src/client/app/Engine.cpp)) :
+
+```
+const bool moveLocked = EngineNowSec() < m_avatarMoveLockUntilSec;
+auto moveInput = BuildMoveInput(...);
+if (moveLocked) moveInput = engine::gameplay::MoveInput{};  // zéro dir + jumpPressed=false
+m_characterController.Update(dt, moveInput, m_worldCollider);
+```
+
+Les déclencheurs d'actions one-shot (attaque, sort, roulade, punch) reçoivent
+en plus `&& !moveLocked` pour empêcher toute action pendant le verrou.
+
+La caméra (`m_orbitalCameraController`) n'est **pas** touchée → reste libre.
+
+## Garde-fous / cas limites
+
+- **Clip absent** (race non-UE5 / fallback y_bot) : `clip` nul → durée 0 → verrou
+  expire immédiatement (pas de gel permanent). Repli sur le clip `Interact`.
+- **Re-presser E pendant le verrou** : bloqué par `busyOneShot()` / `moveLocked` ;
+  la refermeture auto à +2 s reste pilotée comme aujourd'hui (re-arme le timer).
+- **Yaw avatar** : aucun mouvement pendant le verrou → l'avatar reste orienté tel
+  quel face au coffre. (Snap explicite vers le coffre non demandé ; hors périmètre.)
+
+## Limite connue (v1)
+
+Les autres joueurs reçoivent l'état réseau `Interact` (le rôle de clip est
+**local**), donc côté distant l'avatar joue le geste `Interact` générique et non
+`PickUp_Table`. Strictement cosmétique pour les observateurs distants ; acceptable
+pour la v1. Une réplication du rôle de clip serait un travail séparé.
+
+## Déploiement
+
+✅ **Client uniquement, pas de redéploiement serveur.** Aucun nouvel opcode,
+aucun changement de `ToWireAnimState`, aucune migration. Pur rendu/gameplay
+client.
+
+## Hors périmètre
+
+- Réplication réseau du clip `PickUp_Table` aux joueurs distants.
+- Synchro fine couvercle ↔ mi-animation (couvercle reste instantané).
+- Snap d'orientation de l'avatar vers le coffre.
+- Contenu / loot du coffre.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8277,7 +8277,14 @@ namespace engine
 				// avant le CC, son repere (Forward/Right XZ) servirait a projeter
 				// l'input du frame courant mais sa position cible utiliserait la
 				// position de la frame precedente -> 1-frame lag visible.
-				const auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout, sprintKey, crouchKey);
+				auto moveInput = BuildMoveInput(m_input, m_orbitalCameraController, movementLayout, sprintKey, crouchKey);
+				// Verrou de geste (ouverture de coffre) : tant qu'il est actif, on
+				// neutralise toutes les entrées de déplacement (direction + saut) pour
+				// que l'avatar reste immobile pendant l'animation. La caméra reste libre
+				// (m_orbitalCameraController non touché).
+				const bool moveLocked = EngineNowSec() < m_avatarMoveLockUntilSec;
+				if (moveLocked)
+					moveInput = engine::gameplay::MoveInput{};
 				// Collisionneur composite : terrain (sol + eau) + cylindres des props/décor.
 				m_characterController.Update(static_cast<float>(dt), moveInput, m_worldCollider);
 				const engine::math::Vec3 ccPos = m_characterController.GetPosition();
@@ -8595,7 +8602,9 @@ namespace engine
 							newState = moving ? AvatarLocomotionState::CrouchWalk : AvatarLocomotionState::CrouchIdle;
 
 						// Esquive/roulade (double-appui Crouch) : Roll one-shot, prioritaire sur crouch.
-						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll)
+						// Bloquée pendant le verrou de geste (ouverture de coffre).
+						if (dodgePressed && m_avatarLocoState != AvatarLocomotionState::Roll
+							&& nowSec >= m_avatarMoveLockUntilSec)
 						{
 							newState = AvatarLocomotionState::Roll;
 							// Impulsion d'esquive : direction = mouvement si actif, sinon l'avant camera.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8633,8 +8633,31 @@ namespace engine
 							newState = AvatarLocomotionState::Cast;
 
 						// Interagir (touche E par defaut) : geste Interact one-shot, action non-combat.
+						// Près d'un coffre : joue "PickUp_Table" (se pencher → saisir → se redresser)
+						// et verrouille le déplacement le temps du clip. Ailleurs : geste "Interact"
+						// générique, sans verrou (comportement historique inchangé).
 						if (interactPressed && !moveInput.jumpPressed && !busyOneShot())
+						{
+							const bool nearChest =
+								m_chestLoaded && m_interactableInRange == m_chestInteractableIndex;
+							if (nearChest)
+							{
+								m_currentInteractRole = "PickUp_Table";
+								const engine::render::skinned::AnimationClip* puClip =
+									m_currentSkinnedMesh->FindClip("PickUp_Table");
+								// Clip absent (race non-UE5 / fallback) -> durée 0 -> verrou expire
+								// immédiatement, pas de gel permanent ; le repli sur "Interact"
+								// est géré juste en dessous.
+								m_avatarMoveLockUntilSec = nowSec + (puClip ? puClip->duration : 0.0f);
+								if (!puClip)
+									m_currentInteractRole = "Interact";
+							}
+							else
+							{
+								m_currentInteractRole = "Interact";
+							}
 							newState = AvatarLocomotionState::Interact;
+						}
 					}
 					else
 					{

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8360,8 +8360,10 @@ namespace engine
 						m_currentSkinnedMesh->FindClip("CastShoot");
 					const engine::render::skinned::AnimationClip* castExitClip =
 						m_currentSkinnedMesh->FindClip("CastExit");
+					// Clip dynamique : "Interact" (geste générique) ou "PickUp_Table"
+					// (près d'un coffre). m_currentInteractRole est fixé au déclenchement.
 					const engine::render::skinned::AnimationClip* interactClip =
-						m_currentSkinnedMesh->FindClip("Interact");
+						m_currentSkinnedMesh->FindClip(m_currentInteractRole.c_str());
 					const engine::render::skinned::AnimationClip* punchClip =
 						m_currentSkinnedMesh->FindClip(m_currentPunchRole.c_str());
 
@@ -8690,6 +8692,7 @@ namespace engine
 						const char* clipName =
 							(newState == AvatarLocomotionState::Emote && !m_currentEmoteRole.empty()) ? m_currentEmoteRole.c_str()
 							: (newState == AvatarLocomotionState::Punch) ? m_currentPunchRole.c_str()
+							: (newState == AvatarLocomotionState::Interact) ? m_currentInteractRole.c_str()
 							: StateToClipName(newState);
 						const engine::render::skinned::AnimationClip* newClip = m_currentSkinnedMesh->FindClip(clipName);
 						if (newClip)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1,4 +1,4 @@
-﻿#include "src/client/app/Engine.h"
+#include "src/client/app/Engine.h"
 
 #include "src/client/render/static_mesh/StaticMeshLoader.h"
 #include "src/shared/core/Log.h"

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1,4 +1,4 @@
-#include "src/client/app/Engine.h"
+﻿#include "src/client/app/Engine.h"
 
 #include "src/client/render/static_mesh/StaticMeshLoader.h"
 #include "src/shared/core/Log.h"
@@ -8281,7 +8281,9 @@ namespace engine
 				// Verrou de geste (ouverture de coffre) : tant qu'il est actif, on
 				// neutralise toutes les entrées de déplacement (direction + saut) pour
 				// que l'avatar reste immobile pendant l'animation. La caméra reste libre
-				// (m_orbitalCameraController non touché).
+				// (m_orbitalCameraController non touché). nowSec est recalculé ici (le
+				// nowSec de la state machine n'est pas encore en portée à ce point) ;
+				// l'écart sub-ms avec la garde roulade plus bas est sans effet visible.
 				const bool moveLocked = EngineNowSec() < m_avatarMoveLockUntilSec;
 				if (moveLocked)
 					moveInput = engine::gameplay::MoveInput{};

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -715,13 +715,14 @@ namespace engine
 		/// et bascule Jab<->Cross a chaque coup. Clip dynamique (cf. point de lecture).
 		std::string                                              m_currentPunchRole = "Punch";
 		bool                                                     m_punchAlt = false;
-		/// Interaction : rôle d'anim joué par l'état Interact (clip dynamique, calqué
-		/// sur m_currentPunchRole). "Interact" par défaut (geste générique sur E) ;
+		/// Interaction : rôle d'anim joué par l'état Interact (clip dynamique, même
+		/// patron que m_currentPunchRole). "Interact" par défaut (geste générique sur E) ;
 		/// passe à "PickUp_Table" près d'un coffre (se pencher → saisir → se redresser).
 		std::string                                              m_currentInteractRole = "Interact";
 		/// Verrou de déplacement : instant (s, EngineNowSec) jusqu'auquel les entrées
 		/// de déplacement de l'avatar sont neutralisées (MoveInput vide) pendant un
-		/// geste verrouillant (ouverture de coffre). 0 = aucun verrou actif.
+		/// geste verrouillant (ouverture de coffre). Toujours tester via
+		/// `EngineNowSec() < m_avatarMoveLockUntilSec` (jamais `!= 0`). 0 = aucun verrou.
 		float                                                    m_avatarMoveLockUntilSec = 0.0f;
 		/// Sequence de sort : phase (0=Enter,1=Shoot,2=Exit) + clip a rejouer en
 		/// cours d'etat (vide=aucun ; consomme 1 fois par la SM, rejoue un one-shot

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -715,6 +715,14 @@ namespace engine
 		/// et bascule Jab<->Cross a chaque coup. Clip dynamique (cf. point de lecture).
 		std::string                                              m_currentPunchRole = "Punch";
 		bool                                                     m_punchAlt = false;
+		/// Interaction : rôle d'anim joué par l'état Interact (clip dynamique, calqué
+		/// sur m_currentPunchRole). "Interact" par défaut (geste générique sur E) ;
+		/// passe à "PickUp_Table" près d'un coffre (se pencher → saisir → se redresser).
+		std::string                                              m_currentInteractRole = "Interact";
+		/// Verrou de déplacement : instant (s, EngineNowSec) jusqu'auquel les entrées
+		/// de déplacement de l'avatar sont neutralisées (MoveInput vide) pendant un
+		/// geste verrouillant (ouverture de coffre). 0 = aucun verrou actif.
+		float                                                    m_avatarMoveLockUntilSec = 0.0f;
 		/// Sequence de sort : phase (0=Enter,1=Shoot,2=Exit) + clip a rejouer en
 		/// cours d'etat (vide=aucun ; consomme 1 fois par la SM, rejoue un one-shot
 		/// sans changer d'etat). Garde-fou 3s dans le case Cast => jamais bloque.


### PR DESCRIPTION
## Résumé

À l'appui sur **E** près d'un coffre (`Chest_Wood`), le personnage joue désormais l'animation **`PickUp_Table`** (se pencher → saisir → se redresser) et son **déplacement est verrouillé** pendant toute la durée du clip (plus de « je repars tout de suite »). Loin d'un coffre, le geste `Interact` générique reste **inchangé** (pas de verrou).

Corrige le bug signalé : avant, le `CharacterController` était mis à jour inconditionnellement → le joueur pouvait bouger immédiatement pendant le geste.

## Détail technique (approche A — pur client)

- **`Engine.h`** : 2 nouveaux membres — `m_currentInteractRole` (clip dynamique de l'état `Interact`, défaut `"Interact"`) et `m_avatarMoveLockUntilSec` (horodatage de fin de verrou).
- **État `Interact` dynamique** : joue `m_currentInteractRole` au lieu du littéral `"Interact"` (fetch du clip + ternaire de transition crossfade). Même patron que `m_currentPunchRole`.
- **Déclenchement near-chest** : `nearChest = m_chestLoaded && m_interactableInRange == m_chestInteractableIndex` → rôle `"PickUp_Table"` + arme `m_avatarMoveLockUntilSec = nowSec + durée(clip)`. Repli sur `"Interact"` (sans gel) si le clip est absent.
- **Verrou consommé** : avant `CharacterController::Update`, `moveInput` est neutralisé (`MoveInput{}`) tant que le verrou est actif → bloque déplacement + saut. La roulade reçoit une garde explicite. Attaque/sort/punch déjà bloqués par `busyOneShot()` (état `Interact`). **Caméra libre.**
- Bonus : retrait d'un BOM UTF-8 accidentel en tête de `Engine.cpp`.

Inchangé : ouverture/fermeture du couvercle (`Chest_Open` + auto-close 2 s).

## Limite connue (v1)

Les joueurs distants voient l'état réseau `Interact` (rôle de clip local) → côté distant l'avatar joue le geste `Interact` générique, pas `PickUp_Table`. Cosmétique, hors périmètre.

## Vérification

- ✅ Revue spec + qualité par tâche, + revue finale de bout en bout (modèle le plus capable).
- ⏳ **CI** : compilation `build-windows` (binaire client réel) + `build-linux` attendues vertes.
- ⏳ **Test manuel en jeu (à faire côté client Windows)** — protocole dans [le plan](docs/superpowers/plans/2026-06-02-coffre-anim-perso-verrou.md) :
  1. E près du coffre → l'avatar se penche puis se redresse (`PickUp_Table`), couvercle s'ouvre.
  2. Pendant l'anim : WASD / Espace / double-Ctrl / clic gauche → l'avatar ne bouge/saute/roule/attaque PAS.
  3. Caméra (clic droit + souris) reste libre.
  4. Fin du clip → déplacement immédiat à nouveau.
  5. Coffre se referme ~2 s après ouverture.
  6. E loin de tout coffre → geste `Interact` générique, aucun verrou.

Spec : `docs/superpowers/specs/2026-06-02-coffre-animation-perso-verrou-design.md`

## Déploiement

✅ **Client uniquement, pas de redéploiement serveur** — aucun opcode, aucun changement de `ToWireAnimState`, aucune migration. Pur rendu/gameplay client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)