### PR TITLE
feat(gameplay): épic A — saut plus haut & dessus de props atterrissable

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2153,19 +2153,27 @@ l'exploration de zones cachées. Spec : `docs/superpowers/specs/2026-06-02-saut-
     sweep part à ≤ 4 m au-dessus de `topY`. La sonde anti-encastrement du
     `CharacterController` (depuis 50 m) reste donc ignorée par les props → aucune
     téléportation au sommet (préserve la parade documentée dans le fichier).
+  - **Zone d'atterrissage = rayon combiné** (`c.radius + capsule.radius`), aligné sur
+    l'empreinte de blocage horizontal : « si ça te bloque latéralement, tu peux te poser
+    dessus ». Sans ça, le dessus (petit disque de rayon `c.radius`) est quasi impossible
+    à viser en sautant, car le blocage latéral maintient le joueur à
+    `c.radius + capsule.radius` du centre (bug constaté au test : on passait au-dessus
+    sans s'arrêter dessus).
 
-### Règle loot — caisses non-lootables
-Les caisses `Crate_Metal` et `Crate_Wooden` (`game/data/meshes/props/`) ne sont **pas**
-des emplacements de loot. Le loot reste réservé aux nœuds de récolte (`GatheringSystem`)
-— et, à terme, aux coffres dédiés (épic B « coffres à clé »). Ne pas associer de table
-de loot à ces props.
+### Caisses : décor solide non-interactif (plus de loot/interaction)
+Les caisses `Crate_Metal` (« Caisse metal ») et `Crate_Wooden` (« Caisse en bois »)
+**ne sont plus des interactables** : déplacées de `config.json` `world.interactables`
+vers `world.scenery` (`solid: true`). Elles restent **visibles et solides/atterrissables**
+mais **sans interaction touche E ni message**. Elles **ne sont pas** des emplacements de
+loot (le loot reste réservé aux nœuds de récolte `GatheringSystem` — et, à terme, aux
+coffres dédiés de l'épic B). Ne pas leur réassocier d'interaction ni de table de loot.
 
 ### Tests
 - `character_controller_jump_tests::Test_Jump_DefaultClearsMetalCrate` : apex par défaut
   ≥ 0.97 m (franchit la caisse + marge).
-- `composite_world_collider_tests` cas 6/7/8 : atterrissage sur le dessus, posé immédiat
-  (frac 0, garde « grounded »), hors empreinte XZ (pas de hit). Le cas **4bis** (sweep
-  50 m → pas de hit) reste la garde anti-téléport.
+- `composite_world_collider_tests` cas 6/6b/7/8 : atterrissage sur le dessus, en **bord**
+  (rayon combiné), posé immédiat (frac 0, garde « grounded »), hors empreinte XZ (pas de
+  hit). Le cas **4bis** (sweep 50 m → pas de hit) reste la garde anti-téléport.
 
 ### Conséquences / limites
 - **Tous** les props solides ont un dessus plat atterrissable à leur point le plus haut

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2131,3 +2131,45 @@ aussi les confusions « je vois quelqu'un de déjà parti » et « reconnexion r
   immédiate (nouveau handler). **Non lock-step / non wire-breaking** : client neuf ↔
   shard ancien (ou inverse) fonctionnent, mais sans l'éviction immédiate tant que le
   shard n'est pas redéployé (fallback timeout).
+
+## 61. Saut plus haut & dessus de props atterrissable (épic A, 2026-06-02)
+
+**But** : permettre de sauter **sur** les caisses (et tout prop solide) pour ouvrir
+l'exploration de zones cachées. Spec : `docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md`.
+
+### Composants
+- `src/client/gameplay/CharacterController.h` : `Config::jumpSpeed` 4.9 → **6.25**
+  (apex `6.25²/(2·20) ≈ 0.98 m`). Calibré pour franchir une « caisse métal »
+  (`Crate_Metal.gltf`, ~0.87 m de haut à l'échelle 1) avec marge +0.1 m. Saut **global**
+  (toutes les situations), **client uniquement** (le controller vit côté client).
+- `src/client/gameplay/CompositeWorldCollider.cpp` : `SweepCapsule` émet désormais un
+  contact **sol** (normale +Y) sur le **dessus** d'un `PropCylinder` (`topY`) pour les
+  **sweeps descendants de proximité** — miroir d'un sol plat à `y=topY`. Le perso peut
+  donc atterrir et se tenir sur tout prop solide. Le blocage **horizontal** des flancs
+  est inchangé.
+  - **Garde anti-sonde (`kPropTopMargin = 4.0f`)** : le couvercle n'est émis que si le
+    sweep part à ≤ 4 m au-dessus de `topY`. La sonde anti-encastrement du
+    `CharacterController` (depuis 50 m) reste donc ignorée par les props → aucune
+    téléportation au sommet (préserve la parade documentée dans le fichier).
+
+### Règle loot — caisses non-lootables
+Les caisses `Crate_Metal` et `Crate_Wooden` (`game/data/meshes/props/`) ne sont **pas**
+des emplacements de loot. Le loot reste réservé aux nœuds de récolte (`GatheringSystem`)
+— et, à terme, aux coffres dédiés (épic B « coffres à clé »). Ne pas associer de table
+de loot à ces props.
+
+### Tests
+- `character_controller_jump_tests::Test_Jump_DefaultClearsMetalCrate` : apex par défaut
+  ≥ 0.97 m (franchit la caisse + marge).
+- `composite_world_collider_tests` cas 6/7/8 : atterrissage sur le dessus, posé immédiat
+  (frac 0, garde « grounded »), hors empreinte XZ (pas de hit). Le cas **4bis** (sweep
+  50 m → pas de hit) reste la garde anti-téléport.
+
+### Conséquences / limites
+- **Tous** les props solides ont un dessus plat atterrissable à leur point le plus haut
+  (y compris les arbres — un peu artificiel au-dessus du feuillage ; opt-out par prop
+  possible plus tard, hors périmètre).
+- Saut global → beaucoup de rebords du monde deviennent atteignables (c'est l'objectif).
+- **Déploiement** : ✅ **client uniquement, pas de redéploiement serveur**. L'anti-cheat
+  (`AntiCheatGameplay.h`) contrôle la vitesse 3D (19.5 m/s) et le téléport (50 m), pas la
+  hauteur de saut ; sprint+saut = √(13²+6.25²) ≈ 14.4 m/s < 19.5. Gravité inchangée.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2138,10 +2138,12 @@ aussi les confusions « je vois quelqu'un de déjà parti » et « reconnexion r
 l'exploration de zones cachées. Spec : `docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md`.
 
 ### Composants
-- `src/client/gameplay/CharacterController.h` : `Config::jumpSpeed` 4.9 → **6.25**
-  (apex `6.25²/(2·20) ≈ 0.98 m`). Calibré pour franchir une « caisse métal »
-  (`Crate_Metal.gltf`, ~0.87 m de haut à l'échelle 1) avec marge +0.1 m. Saut **global**
-  (toutes les situations), **client uniquement** (le controller vit côté client).
+- **Saut `jumpSpeed` 4.9 → 6.25** (apex `6.25²/(2·20) ≈ 0.98 m`) — calibré pour franchir
+  une « caisse métal » (`Crate_Metal.gltf`, ~0.87 m à l'échelle 1) + marge +0.1 m. Saut
+  **global**, **client uniquement**. ⚠️ **Le levier runtime est `config.json`**
+  (`player.movement.jump_speed`), lu par `Engine.cpp:4952` (fallback aligné 9.0 → 6.25) ;
+  le défaut de `CharacterController::Config` n'est PAS utilisé en jeu (seulement par les
+  tests). Les 3 (config.json, Engine fallback, header) sont alignés à 6.25.
 - `src/client/gameplay/CompositeWorldCollider.cpp` : `SweepCapsule` émet désormais un
   contact **sol** (normale +Y) sur le **dessus** d'un `PropCylinder` (`topY`) pour les
   **sweeps descendants de proximité** — miroir d'un sol plat à `y=topY`. Le perso peut

--- a/config.json
+++ b/config.json
@@ -110,7 +110,7 @@
             "walk_speed": 5.0,
             "run_speed": 9.0,
             "gravity": -20.0,
-            "jump_speed": 4.9,
+            "jump_speed": 6.25,
             "coyote_time_s": 0.1,
             "jump_buffer_s": 0.1
         }

--- a/config.json
+++ b/config.json
@@ -179,18 +179,16 @@
         },
         "_comment_interactables": "Interagir (touche E) : count = nombre de cibles ; chaque index i a x/z (metres monde), radius (portee m), npc (bool : PNJ vs objet), label, message (dialogue PNJ ou effet objet), mesh/scale/yaw_deg/rot_x_deg, dialogue. Seuls les VRAIS interactibles ici (PNJ, coffre). Le DECOR (arbres, props non interactifs mais solides) est dans world.scenery. Le coffre et le villageois sont solides (collision) comme tout le decor.",
         "interactables": {
-            "count": 7,
+            "count": 5,
             "0": { "x": 4.0, "z": 0.0, "radius": 2.5, "npc": true, "label": "Villageois", "message": "Villageois : Bonjour !", "mesh": "models/characters/humains/Male_Ranger/Male_Ranger.glb", "scale": 95.0, "rot_x_deg": -90.0, "yaw_deg": 270.0, "dialogue": { "count": 3, "0": "Bonjour, aventurier ! Bienvenue par ici.", "1": "Le bassin de test est a l'est, si tu veux nager.", "2": "Reviens me voir quand tu veux." } },
             "1": { "x": -4.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Coffre", "message": "Vous fouillez le coffre... vide pour l'instant.", "mesh": "meshes/props/Chest_Wood.gltf", "scale": 1.0, "yaw_deg": 0.0 },
-            "2": { "x": -9.0, "z": -4.0, "radius": 2.0, "npc": false, "label": "Caisse en bois", "message": "Caisse en bois (comparaison).", "mesh": "meshes/props/Crate_Wooden.gltf", "scale": 1.0, "yaw_deg": 0.0 },
-            "3": { "x": -9.0, "z": 0.0, "radius": 2.0, "npc": false, "label": "Caisse metal", "message": "Caisse en metal (comparaison).", "mesh": "meshes/props/Crate_Metal.gltf", "scale": 1.0, "yaw_deg": 0.0 },
-            "4": { "x": -9.0, "z": 4.0, "radius": 2.0, "npc": false, "label": "Cageot", "message": "Cageot de ferme vide (comparaison).", "mesh": "meshes/props/FarmCrate_Empty.gltf", "scale": 1.0, "yaw_deg": 0.0 },
-            "5": { "x": -13.0, "z": -2.0, "radius": 2.0, "npc": false, "label": "Cage", "message": "Petite cage (comparaison).", "mesh": "meshes/props/Cage_Small.gltf", "scale": 1.0, "yaw_deg": 0.0 },
-            "6": { "x": -13.0, "z": 2.0, "radius": 2.0, "npc": false, "label": "Tonneau", "message": "Tonneau (comparaison).", "mesh": "meshes/props/Barrel.gltf", "scale": 1.0, "yaw_deg": 0.0 }
+            "2": { "x": -9.0, "z": 4.0, "radius": 2.0, "npc": false, "label": "Cageot", "message": "Cageot de ferme vide (comparaison).", "mesh": "meshes/props/FarmCrate_Empty.gltf", "scale": 1.0, "yaw_deg": 0.0 },
+            "3": { "x": -13.0, "z": -2.0, "radius": 2.0, "npc": false, "label": "Cage", "message": "Petite cage (comparaison).", "mesh": "meshes/props/Cage_Small.gltf", "scale": 1.0, "yaw_deg": 0.0 },
+            "4": { "x": -13.0, "z": 2.0, "radius": 2.0, "npc": false, "label": "Tonneau", "message": "Tonneau (comparaison).", "mesh": "meshes/props/Barrel.gltf", "scale": 1.0, "yaw_deg": 0.0 }
         },
         "_comment_scenery": "Decor solide/non-solide (foret riveraine dense + sous-bois). Genere par tools/world_gen/scatter_forest.py (deterministe). Chaque index i : mesh, x/z (metres monde, Y au sol au runtime), yaw_deg, scale, collision_radius (cylindre, m), solid (false = traversable : herbe/fougeres/fleurs ; true = bloque : arbres, rochers).",
         "scenery": {
-            "count": 310,
+            "count": 312,
             "0": { "mesh": "meshes/props/DeadTree_2.gltf", "x": -11.81, "z": -32.97, "yaw_deg": 62.3, "scale": 1.14, "collision_radius": 0.50, "solid": true },
             "1": { "mesh": "meshes/props/TwistedTree_3.gltf", "x": -12.50, "z": 50.24, "yaw_deg": 266.1, "scale": 1.18, "collision_radius": 0.80, "solid": true },
             "2": { "mesh": "meshes/props/DeadTree_4.gltf", "x": 63.57, "z": 45.89, "yaw_deg": 68.4, "scale": 1.03, "collision_radius": 0.50, "solid": true },
@@ -500,7 +498,9 @@
             "306": { "mesh": "meshes/props/Bush_Common.gltf", "x": 101.95, "z": -17.44, "yaw_deg": 256.5, "scale": 0.93, "collision_radius": 0.00, "solid": false },
             "307": { "mesh": "meshes/props/Mushroom_Laetiporus.gltf", "x": 119.01, "z": 72.83, "yaw_deg": 199.4, "scale": 1.21, "collision_radius": 0.00, "solid": false },
             "308": { "mesh": "meshes/props/Clover_2.gltf", "x": 23.08, "z": -47.71, "yaw_deg": 282.3, "scale": 0.93, "collision_radius": 0.00, "solid": false },
-            "309": { "mesh": "meshes/props/Bush_Common.gltf", "x": -0.75, "z": -47.65, "yaw_deg": 245.0, "scale": 1.04, "collision_radius": 0.00, "solid": false }
+            "309": { "mesh": "meshes/props/Bush_Common.gltf", "x": -0.75, "z": -47.65, "yaw_deg": 245.0, "scale": 1.04, "collision_radius": 0.00, "solid": false },
+            "310": { "mesh": "meshes/props/Crate_Wooden.gltf", "x": -9.0, "z": -4.0, "yaw_deg": 0.0, "scale": 1.0, "collision_radius": 0.00, "solid": true },
+            "311": { "mesh": "meshes/props/Crate_Metal.gltf", "x": -9.0, "z": 0.0, "yaw_deg": 0.0, "scale": 1.0, "collision_radius": 0.00, "solid": true }
         },
         "_comment_test_water": "Nage : bassin de TEST procedural. Le heightmap demo_plains a ete CREUSE en bol lisse centre sur (center_x,center_z) (fond a y=94, berge a y=100) ; l'eau est posee au niveau du sol creuse + depth_m. niveauY = GroundHeightAt(centre) + depth_m = 96 + 3 = 99 (1 m sous la berge). Le depth-test du water.frag clippe la nappe au rivage reel du bol (pas de bord carre, pas de recouvrement plein ecran). Centre eloigne du spawn/props (x=50) pour ne pas creuser sous le coffre/villageois (resolution heightmap ~16 m/sample). enabled=false pour retirer l'eau (le bol reste creuse dans le heightmap). Sera remplace par une vraie etendue d'eau via instances/water.bin.",
         "test_water": {

--- a/docs/superpowers/plans/2026-06-02-saut-caisses-atterrissables.md
+++ b/docs/superpowers/plans/2026-06-02-saut-caisses-atterrissables.md
@@ -1,0 +1,278 @@
+# Saut plus haut & dessus de props atterrissables — Plan d'implémentation (Épic A)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre de sauter plus haut (global) et d'atterrir/se tenir sur le dessus de tout prop solide (caisses incluses), pour ouvrir l'exploration de zones cachées.
+
+**Architecture:** Deux changements client isolés — (1) relever `jumpSpeed` dans `CharacterController::Config` ; (2) faire émettre à `CompositeWorldCollider::SweepCapsule` un contact « sol » sur le dessus d'un `PropCylinder` pour les sweeps descendants de proximité (en préservant l'exclusion de la sonde anti-encastrement à 50 m). Plus une note de doc « caisses non-lootables ».
+
+**Tech Stack:** C++ (engine maison), tests C++ « simple test » (exécutables `main()` renvoyant le nombre d'échecs), CMake + CTest. Build via CI uniquement (pas de toolchain locale). Spec : `docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md`.
+
+---
+
+## Task 1 : Saut plus haut (clear caisse métal + 0,1 m)
+
+**Files:**
+- Modify: `src/client/gameplay/CharacterController.h` (struct `Config`, ~93-96)
+- Test: `src/client/gameplay/tests/CharacterControllerJumpTests.cpp`
+- Modify (commentaire): `src/CMakeLists.txt:756-759`
+
+- [ ] **Step 1 : Écrire le test qui échoue (apex par défaut franchit une caisse).**
+
+Ajouter dans `CharacterControllerJumpTests.cpp` (dans l'espace anonyme, après `Test_Jump_HigherSpeedGivesHigherApex`) :
+
+```cpp
+	// Le saut PAR DEFAUT doit franchir une caisse metal (~0.87 m) avec marge 0.1 m,
+	// soit un apex >= 0.97 m. Garde le calibrage "sauter sur les caisses".
+	void Test_Jump_DefaultClearsMetalCrate()
+	{
+		const float defaultSpeed = CharacterController::Config{}.jumpSpeed;
+		const float apex = SimulateJumpApex(defaultSpeed);
+		std::fprintf(stderr, "[INFO] apex(default=%.2f) = %.3f m (attendu >= 0.97)\n",
+			defaultSpeed, apex);
+		REQUIRE(apex >= 0.97f);   // 0.87 (caisse) + 0.10 (marge)
+		REQUIRE(apex < 1.30f);    // borne haute : pas de saut absurde
+	}
+```
+
+Et l'appeler dans `main()` :
+
+```cpp
+	Test_Jump_DefaultClearsMetalCrate();
+```
+
+- [ ] **Step 2 : (CI) Vérifier que le test échoue.**
+
+Le test échoue tant que `jumpSpeed` par défaut = 4.9 (apex ~0.60 < 0.97).
+Run (CI build-linux) : `ctest -R character_controller_jump_tests --output-on-failure`
+Expected : FAIL sur `apex >= 0.97f`.
+
+- [ ] **Step 3 : Relever `jumpSpeed` par défaut.**
+
+Dans `src/client/gameplay/CharacterController.h`, remplacer le bloc commentaire + la valeur (lignes ~93-96) par :
+
+```cpp
+			// Saut : apex = jumpSpeed^2 / (2*|gravity|). Avec gravity=-20,
+			// jumpSpeed=6.25 -> ~0.98 m. Calibre pour sauter SUR une "caisse metal"
+			// (~0.87 m de haut) avec une marge de securite de +0.1 m. Le dessus des
+			// props solides est atterrissable (cf. CompositeWorldCollider::SweepCapsule).
+			// Historique : 9.0 (~2.0 m, irrealiste) -> 4.9 (~0.60 m) -> 6.25 (~0.98 m).
+			float jumpSpeed = 6.25f;       ///< m/s, impulse applied when jumping
+```
+
+- [ ] **Step 4 : (CI) Vérifier que tous les tests de saut passent.**
+
+Run : `ctest -R character_controller_jump_tests --output-on-failure`
+Expected : PASS. (`Test_Jump_Apex_IsRealistic` et `Test_Jump_NotTheOldUnrealisticHeight`
+passent toujours : ils appellent `SimulateJumpApex(4.9f)` explicitement.)
+
+- [ ] **Step 5 : MAJ commentaire CMake.**
+
+Dans `src/CMakeLists.txt:756-757`, remplacer :
+
+```
+  # Saut realiste : verifie l'apex (~0.60 m) du CharacterController apres le
+  # passage jumpSpeed 9.0 -> 4.9. Garde anti-regression (pas de saut ~2 m).
+```
+
+par :
+
+```
+  # Saut : verifie l'apex par defaut (~0.98 m, jumpSpeed=6.25) qui franchit une
+  # caisse metal (~0.87 m) + marge 0.1. Garde anti-regression (pas de saut ~2 m).
+```
+
+- [ ] **Step 6 : Commit.**
+
+```bash
+git add src/client/gameplay/CharacterController.h \
+        src/client/gameplay/tests/CharacterControllerJumpTests.cpp \
+        src/CMakeLists.txt
+git commit -m "feat(gameplay): saut plus haut (apex ~0.98 m) pour monter sur les caisses"
+```
+
+---
+
+## Task 2 : Dessus de prop atterrissable (`CompositeWorldCollider`)
+
+**Files:**
+- Modify: `src/client/gameplay/CompositeWorldCollider.cpp` (boucle des cylindres dans `SweepCapsule`)
+- Test: `src/client/gameplay/tests/CompositeWorldColliderTests.cpp`
+- Modify (commentaire): `src/CMakeLists.txt:761-765`
+
+- [ ] **Step 1 : Écrire les tests qui échouent.**
+
+Ajouter dans `CompositeWorldColliderTests.cpp`, dans `main()`, avant le bloc `// 5)` :
+
+```cpp
+	// 6) ATTERRISSAGE sur le DESSUS : sweep descendant court dont le bas de capsule
+	//    (center.y - halfH) franchit topY de haut en bas, dans l'empreinte XZ.
+	//    -> hit "sol" (normale +Y) au niveau topY.
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl); // topY = 3
+		IWorldCollider::SweepHit hit;
+		// halfH = 0.9 ; start bottom = 4.5-0.9 = 3.6 (>3) ; end bottom = 3.5-0.9 = 2.6 (<3).
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 4.5f, 0 }, Vec3{ 5, 3.5f, 0 }, hit);
+		check(h && hit.hit, "dessus: hit attendu");
+		check(hit.normal.y > 0.99f, "dessus: normale verticale (sol)");
+		check(hit.fraction > 0.5f && hit.fraction < 0.7f, "dessus: fraction ~0.6");
+	}
+
+	// 7) Déjà posé sur le dessus (start bottom <= topY) : hit immédiat (frac ~0) ->
+	//    le sticky ground probe garde le perso "grounded" sur la caisse.
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		// start bottom = 3.9-0.9 = 3.0 (== topY) ; end bottom = 3.8-0.9 = 2.9 (<3).
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 3.9f, 0 }, Vec3{ 5, 3.8f, 0 }, hit);
+		check(h && hit.hit, "dessus pose: hit attendu");
+		check(hit.fraction < 0.01f, "dessus pose: fraction ~0");
+		check(hit.normal.y > 0.99f, "dessus pose: normale verticale");
+	}
+
+	// 8) Sweep descendant HORS empreinte XZ : pas de hit dessus (ni horizontal).
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 7, 4.5f, 0 }, Vec3{ 7, 3.5f, 0 }, hit);
+		check(!h && !hit.hit, "dessus hors empreinte: pas de hit");
+	}
+```
+
+Note : le test **4bis** existant (sweep de 50 m `Vec3{5,20,0} -> Vec3{5,1,0}` → pas de hit)
+est la garde anti-régression du couvercle ; il doit continuer à passer grâce à la marge.
+
+- [ ] **Step 2 : (CI) Vérifier que les nouveaux tests échouent.**
+
+Run : `ctest -R composite_world_collider_tests --output-on-failure`
+Expected : FAIL sur `dessus: hit attendu` (le couvercle n'existe pas encore).
+
+- [ ] **Step 3 : Implémenter le couvercle.**
+
+Dans `src/client/gameplay/CompositeWorldCollider.cpp`, à l'intérieur de la boucle
+`for (const auto& c : m_cylinders)`, **tout au début du corps** (avant le calcul de
+`R` et la garde de recouvrement vertical), insérer :
+
+```cpp
+		// Atterrissage sur le DESSUS du prop (couvercle). Le perso peut se poser et
+		// se tenir sur tout prop solide. On ne traite QUE les sweeps descendants de
+		// PROXIMITE : le bas de la capsule (center.y - halfH, meme convention que le
+		// sol/terrain) franchit `topY` de haut en bas, a l'interieur de l'empreinte XZ.
+		// GARDE ANTI-SONDE : on ignore les sweeps qui partent loin au-dessus du sommet
+		// (ex. sonde anti-encastrement du CharacterController, depuis 50 m), pour
+		// preserver "jamais de blocage vertical par un prop" hors atterrissage proche.
+		{
+			constexpr float kPropTopMargin = 4.0f; // >> demi-capsule, << 50 m (sonde)
+			const bool descending = endCenter.y < startCenter.y;
+			if (descending && (startCenter.y - c.topY) <= kPropTopMargin)
+			{
+				const float startBottom = startCenter.y - halfH;
+				const float endBottom   = endCenter.y   - halfH;
+				const float ex = endCenter.x - c.cx, ez = endCenter.z - c.cz;
+				const bool insideXZ = (ex * ex + ez * ez) <= (c.radius * c.radius);
+				// Franchissement de topY de haut en bas dans l'empreinte (mirroir du
+				// sol plat a y=topY). startBottom <= topY => deja pose (frac 0).
+				if (insideXZ && endBottom < c.topY && startBottom >= c.topY)
+				{
+					const float denom = startBottom - endBottom;
+					float frac = (denom > 1e-8f) ? (startBottom - c.topY) / denom : 0.0f;
+					if (frac < 0.0f) frac = 0.0f;
+					if (frac > 1.0f) frac = 1.0f;
+					if (frac < best.fraction)
+					{
+						best.hit = true;
+						best.fraction = frac;
+						best.normal = engine::math::Vec3{ 0.0f, 1.0f, 0.0f };
+					}
+					// On est au-dessus : ce cylindre ne bloque pas horizontalement cette
+					// frame. Passer au cylindre suivant.
+					continue;
+				}
+			}
+		}
+```
+
+(`halfH` est déjà calculé juste avant la boucle : `const float halfH = capsule.height * 0.5f;`.)
+
+- [ ] **Step 4 : (CI) Vérifier que tous les tests du collisionneur passent.**
+
+Run : `ctest -R composite_world_collider_tests --output-on-failure`
+Expected : PASS (cas 1-8 + 4bis/4ter + querywater). En particulier **4bis** (sweep 50 m)
+reste sans hit (marge `kPropTopMargin` = 4 ≪ 17 = 20−3).
+
+- [ ] **Step 5 : MAJ commentaire CMake.**
+
+Dans `src/CMakeLists.txt:761-763`, remplacer :
+
+```
+  # Collision props : CompositeWorldCollider (terrain + cylindres verticaux).
+  # Verifie sweep capsule-vs-cylindre (traversee bloquee, a-cote ignore, hors
+  # bornes Y ignore, delegation QueryWater au terrain).
+```
+
+par :
+
+```
+  # Collision props : CompositeWorldCollider (terrain + cylindres verticaux).
+  # Verifie sweep capsule-vs-cylindre (traversee bloquee, a-cote ignore, hors
+  # bornes Y ignore, ATTERRISSAGE sur le dessus + anti-teleport sonde 50 m,
+  # delegation QueryWater au terrain).
+```
+
+- [ ] **Step 6 : Commit.**
+
+```bash
+git add src/client/gameplay/CompositeWorldCollider.cpp \
+        src/client/gameplay/tests/CompositeWorldColliderTests.cpp \
+        src/CMakeLists.txt
+git commit -m "feat(gameplay): dessus des props atterrissable (se tenir sur les caisses)"
+```
+
+---
+
+## Task 3 : Documenter « caisses non-lootables »
+
+**Files:**
+- Modify: `CODEBASE_MAP.md` (section props / loot)
+
+- [ ] **Step 1 : Trouver la section props/loot.**
+
+Run (recherche) : repérer dans `CODEBASE_MAP.md` la section qui décrit les props
+(`game/data/meshes/props/`) ou le loot (`GatheringSystem` / nœuds de récolte).
+
+- [ ] **Step 2 : Ajouter la note.**
+
+Insérer (à l'endroit pertinent) :
+
+```markdown
+> **Règle loot — caisses non-lootables.** Les caisses `Crate_Metal` et `Crate_Wooden`
+> (`game/data/meshes/props/`) ne sont **pas** des emplacements de loot. Le loot reste
+> réservé aux nœuds de récolte (`GatheringSystem`) — et, à terme, aux coffres dédiés
+> (épic B « coffres à clé »). Ne pas associer de table de loot à ces props.
+```
+
+- [ ] **Step 3 : Commit.**
+
+```bash
+git add CODEBASE_MAP.md
+git commit -m "docs: acter que les caisses (metal/bois) ne sont pas des spots de loot"
+```
+
+---
+
+## Vérification finale (CI)
+
+- [ ] Pousser la branche, ouvrir la PR, laisser tourner `build-windows` + `build-linux` (ctest).
+- [ ] Confirmer dans les logs CI : `character_controller_jump_tests` et
+      `composite_world_collider_tests` au vert.
+- [ ] **Déploiement** : ✅ client uniquement, pas de redéploiement serveur (vérifié,
+      cf. spec §8 : l'anti-cheat contrôle la vitesse 3D 19,5 m/s et le téléport 50 m,
+      pas la hauteur de saut ; sprint+saut = 14,4 m/s < 19,5).
+
+## Self-review (couverture spec)
+
+- Spec §4.1 (saut) → Task 1. §4.2 (couvercle) → Task 2. §4.3 (doc loot) → Task 3.
+- Spec §7 (tests) → tests dans Task 1 (apex défaut) et Task 2 (cas 6/7/8 + 4bis régression).
+- Spec §8 (déploiement) → note de vérification finale.
+- Pas de placeholder ; types/champs (`PropCylinder.topY`, `SweepHit.normal/fraction`,
+  `Config.jumpSpeed`, `halfH`) cohérents avec le code existant lu.

--- a/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
+++ b/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
@@ -101,10 +101,12 @@ Condition d'émission d'un contact « sol sur prop » :
 1. Sweep descendant : `endCenter.y < startCenter.y`.
 2. Le **bas de la capsule** (`center.y - halfHeight - radius`) part au-dessus de `topY`
    au début du sweep et finit à/sous `topY` à la fin.
-3. La position XZ au moment du franchissement est **dans l'empreinte** du cylindre
-   (distance horizontale à l'axe ≤ `c.radius` ; tolérance possible de `+capsule.radius`
-   pour rester cohérent avec le rayon combiné utilisé en horizontal — à figer à
-   l'implémentation).
+3. La position XZ au moment du franchissement est **dans l'empreinte** du cylindre.
+   **Décision (corrigée après test en jeu)** : rayon **combiné** `c.radius + capsule.radius`
+   (et non `c.radius` seul), aligné sur l'empreinte de blocage horizontal. Sinon le dessus
+   (petit disque) est quasi impossible à viser : le blocage latéral maintient le joueur à
+   `c.radius + capsule.radius` du centre, donc en sautant droit il retombe **à côté** du
+   disque (bug constaté : « on passe au-dessus sans s'arrêter dessus »).
 4. **Garde anti-sonde 50 m** : n'émettre que si `startCenter.y - c.topY ≤ kPropTopMargin`,
    avec `kPropTopMargin` une petite marge (quelques mètres, ≪ 50). La sonde
    anti-encastrement part de 50 m → exclue → comportement actuel préservé.
@@ -123,12 +125,20 @@ Le blocage **horizontal** existant (côtés du cylindre) reste inchangé : les d
 contributions coexistent (approche latérale → côté ; approche descendante dans
 l'empreinte → couvercle).
 
-### 4.3 Documentation « caisses non-lootables »
+### 4.3 Caisses non-lootables **et non-interactives**
 
-- Ajouter une note dans `CODEBASE_MAP.md` (section props/loot) actant la règle :
-  les caisses (`Crate_Metal`, `Crate_Wooden`) **ne sont pas** des emplacements de loot ;
-  le loot reste réservé aux nœuds de récolte (et, plus tard, aux coffres de l'épic B).
-- Aucune suppression de code (rien n'associe de loot aux caisses aujourd'hui).
+**Correction après test** : les caisses étaient en réalité des **interactables**
+(`config.json` `world.interactables` : « Caisse metal » = `Crate_Metal`, « Caisse en
+bois » = `Crate_Wooden`) avec interaction touche E + message. Demande utilisateur :
+**supprimer toute possibilité d'interaction** (et elles ne sont pas des spots de loot).
+
+- **Déplacer** `Crate_Metal` et `Crate_Wooden` de `world.interactables` vers
+  `world.scenery` (`solid: true`) : elles restent **visibles et solides/atterrissables**,
+  mais **sans interaction ni message**. Renuméroter les interactables restants
+  (count 7 → 5).
+- Mettre à jour `CODEBASE_MAP.md` : caisses = décor solide non-interactif, pas de loot
+  (réservé aux nœuds de récolte, et aux coffres de l'épic B).
+- Aucune table de loot n'était associée aux caisses (rien à retirer de ce côté).
 
 ## 5. Flux nominal
 

--- a/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
+++ b/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
@@ -154,20 +154,24 @@ l'empreinte → couvercle).
 
 Tests à enregistrer dans la liste CTest (`build-linux.yml` lance `ctest`).
 
-## 8. Impact déploiement serveur
+## 8. Impact déploiement serveur — **vérifié : client uniquement**
 
-À lever au moment du plan :
+La position est client-autoritaire avec validation serveur (réplication T0.1). Le
+validateur de mouvement côté shard (`src/shardd/anticheat/AntiCheatGameplay.h`)
+contrôle :
 
-- La position est **client-autoritaire avec validation serveur** (réplication T0.1).
-  **Vérifier** s'il existe un clamp de vitesse/déplacement vertical côté shard
-  (validateur de mouvement). Recherche : `src/shardd/` autour de la validation de
-  position/mouvement.
-  - **Si un clamp vertical existe** → relever sa tolérance pour accepter le nouvel apex
-    ⇒ **redéploiement serveur (shard) requis** (et lock-step client+serveur).
-  - **Si aucun clamp vertical** (client-autoritaire pur sur le vertical) ⇒ **client
-    uniquement, pas de redéploiement serveur**.
-- Les sections 4.1/4.2/4.3 sont sinon **purement client** (collision et controller
-  vivent dans `src/client/`, docs).
+- la **vitesse 3D** : `dist/dt` vs `maxSpeedMps (13) × speedTolerance (1.5) = 19,5 m/s` ;
+- un **saut de téléport** : `dist > maxSingleStepM (50 m)`.
+
+Il ne contrôle **pas** la hauteur de saut en tant que telle. Avec `jumpSpeed = 6.25` :
+
+- sprint + saut simultanés = `√(13² + 6,25²) ≈ 14,4 m/s < 19,5 m/s` → pas de faux
+  positif `SpeedHack` ;
+- la gravité (`-20`) est **inchangée** → vitesse de chute identique à aujourd'hui ;
+- pas de déplacement > 50 m introduit.
+
+**Conclusion : ✅ client uniquement, pas de redéploiement serveur.** Les sections
+4.1/4.2/4.3 vivent toutes dans `src/client/` (controller, collision) ou la doc.
 
 ## 9. Hors périmètre (épics suivants)
 

--- a/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
+++ b/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
@@ -66,14 +66,30 @@ Le tout livré dans **une seule PR**.
 
 Trois unités isolées.
 
-### 4.1 Hauteur de saut — `CharacterController::Config`
+### 4.1 Hauteur de saut
 
-- `jumpSpeed : 4.9f → 6.25f`.
-  - Apex = `6.25² / (2·20) = 39,0625 / 40 ≈ **0,977 m**` > 0,87 + 0,1 = 0,97. ✓
-- Mettre à jour le commentaire de calibrage (lignes ~93-96) pour refléter le nouveau
-  calcul et la raison (sauter sur une caisse métal de ~0,87 m avec marge 0,1 m).
+> **⚠️ Levier runtime = `config.json`, PAS le défaut du header.** L'Engine construit le
+> `CharacterController::Config` en lisant `config.json` (`player.movement.jump_speed`) à
+> [Engine.cpp:4952](src/client/app/Engine.cpp:4952), avec un fallback en dur. Le défaut
+> de la struct `Config` n'est **pas** utilisé au runtime du client de jeu. **Tous** les
+> emplacements doivent être alignés, sinon le changement n'a aucun effet en jeu (bug
+> constaté au test : le perso ne sautait pas plus haut car `config.json` valait 4.9).
+
+Aligner `jumpSpeed` à **6.25** aux trois endroits :
+
+- **`config.json`** : `player.movement.jump_speed : 4.9 → 6.25` (**valeur réelle en jeu**).
+- **`src/client/app/Engine.cpp:4952`** : fallback `9.0 → 6.25` (cohérence si la clé est
+  absente d'un `config.json` déployé).
+- **`src/client/gameplay/CharacterController.h`** : défaut de struct `4.9 → 6.25` (doc +
+  utilisé par les tests).
+
+Apex = `6.25² / (2·20) = 39,0625 / 40 ≈ **0,977 m**` > 0,87 + 0,1 = 0,97. ✓
+
 - **Effet de bord assumé** : tous les sauts montent à ~0,98 m → beaucoup de rebords du
-  monde deviennent atteignables (c'est l'objectif « zones cachées »).
+  monde deviennent atteignables (objectif « zones cachées »).
+- **Leçon test** : `Test_Jump_DefaultClearsMetalCrate` valide la *physique* (apex pour la
+  vitesse par défaut) mais **pas le câblage `config.json`** — vérifié manuellement en jeu
+  (instancier l'Engine en test nécessite un `VkDevice`).
 
 ### 4.2 Couvercle atterrissable — `CompositeWorldCollider::SweepCapsule`
 

--- a/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
+++ b/docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md
@@ -1,0 +1,176 @@
+# Spec — Saut plus haut & dessus de props atterrissables (Épic A)
+
+Date : 2026-06-02
+Statut : **à implémenter** (branche `feat/saut-caisses-atterrissables`).
+
+Premier sous-projet d'un ensemble de 8 épics issus d'un brainstorming. Périmètre
+volontairement restreint et autonome : il débloque la mécanique d'exploration de
+« zones cachées » en permettant de sauter **sur** les caisses (et plus généralement
+sur le dessus de tout prop solide).
+
+## 1. Objectif
+
+1. **Augmenter la hauteur de saut** des personnages, globalement, pour qu'un saut
+   permette d'atteindre le dessus d'une « caisse métal » avec une marge de sécurité
+   de +0,1 m.
+2. **Rendre le dessus des props solides atterrissable** : aujourd'hui la collision
+   des props ne bloque que l'horizontal, jamais le vertical — on retombe donc *à
+   travers* une caisse. Il faut pouvoir atterrir et se tenir dessus.
+3. **Confirmer/documenter** que les caisses (`Crate_Metal`, `Crate_Wooden`) ne sont
+   pas des emplacements de loot.
+
+Le tout livré dans **une seule PR**.
+
+## 2. État actuel (contexte vérifié)
+
+- **Saut** — `src/client/gameplay/CharacterController.h`, struct `Config` :
+  - `jumpSpeed = 4.9f`, `gravity = -20.0f` → apex `4.9² / (2·20) ≈ 0,60 m`.
+  - Saut intégralement **côté client** (le controller vit dans `src/client/gameplay`).
+  - `maxStep = 0.3f` (marche d'escalier max), `coyoteTimeSec = 0.1f`, `jumpBufferSec = 0.1f`.
+- **Caisse métal** — `game/data/meshes/props/Crate_Metal.gltf` :
+  - Bounding box locale (échelle 1) : Y de ~0,003 à **~0,87 m** (deux sous-mesh : max Y
+    0,8473 et 0,8705). Hauteur ≈ **0,87 m**. Le nœud glTF n'a **pas** de scale propre.
+- **Placement des props** — `src/client/app/Engine.cpp` (~10255 et ~10464) :
+  - L'échelle de placement est lue depuis `config.json` (`...scale`, défaut 1.0), cuite
+    dans les sommets monde. La hauteur de collision `topY` est calculée **à partir des
+    sommets après scale** (`topY = maxY + lift`, Engine.cpp:10492) → reflète la hauteur
+    réelle dans le monde.
+  - Si solide, on enregistre `PropCylinder{ wx, wz, radius, groundY, topY }`
+    (Engine.cpp:10591).
+- **Collision props** — `src/client/gameplay/CompositeWorldCollider.{h,cpp}` :
+  - `PropCylinder` = cylindre vertical `(cx, cz, radius)` borné en Y par `[baseY, topY]`.
+  - `SweepCapsule` ne bloque **que le déplacement horizontal** entrant dans le cylindre.
+    Les sweeps verticaux ne sont **jamais** bloqués (commentaire explicite
+    CompositeWorldCollider.cpp:56-60), pour éviter que la **sonde anti-encastrement**
+    du `CharacterController` (départ 50 m au-dessus) ne téléporte le perso au sommet
+    d'un prop.
+- **Détection de sol** — `src/client/gameplay/CharacterController.cpp` :
+  - Sweep de gravité par frame (court, ~`vitesse·dt`) (~ligne 300).
+  - « Sticky ground probe » : sweep descendant court quand déjà au sol (~ligne 228).
+  - Sonde anti-encastrement : `kRecoverProbeUp = 50.0f`, sweep depuis 50 m au-dessus
+    vers la position (~ligne 376) — **doit rester ignorée par les props**.
+- **Loot** — le loot n'est branché que sur les nœuds de récolte
+  (`GatheringSystem`, `game/data/gathering/*.json`). Aucune table de loot n'est
+  associée à `Crate_Metal`/`Crate_Wooden`. Rien à retirer.
+
+## 3. Décisions de design (validées au brainstorming)
+
+| Sujet | Décision |
+|---|---|
+| Surfaces atterrissables | **Tous les props solides** (réutilise `PropCylinder.topY`). |
+| Portée du saut | **Global, partout**. Constante en dur (pas de clé config). |
+| Hauteur cible | **Valeur fixe ~0,97 m** d'apex (caisse 0,87 + marge 0,1). |
+| Approche collision | **Approche 1** : couvercle de cylindre conditionné à la descente. |
+
+## 4. Changements
+
+Trois unités isolées.
+
+### 4.1 Hauteur de saut — `CharacterController::Config`
+
+- `jumpSpeed : 4.9f → 6.25f`.
+  - Apex = `6.25² / (2·20) = 39,0625 / 40 ≈ **0,977 m**` > 0,87 + 0,1 = 0,97. ✓
+- Mettre à jour le commentaire de calibrage (lignes ~93-96) pour refléter le nouveau
+  calcul et la raison (sauter sur une caisse métal de ~0,87 m avec marge 0,1 m).
+- **Effet de bord assumé** : tous les sauts montent à ~0,98 m → beaucoup de rebords du
+  monde deviennent atteignables (c'est l'objectif « zones cachées »).
+
+### 4.2 Couvercle atterrissable — `CompositeWorldCollider::SweepCapsule`
+
+Dans la boucle des cylindres, **ajouter** un test « dessus de cylindre » qui s'applique
+uniquement aux **sweeps descendants courts**, sans toucher au blocage horizontal existant.
+
+Condition d'émission d'un contact « sol sur prop » :
+
+1. Sweep descendant : `endCenter.y < startCenter.y`.
+2. Le **bas de la capsule** (`center.y - halfHeight - radius`) part au-dessus de `topY`
+   au début du sweep et finit à/sous `topY` à la fin.
+3. La position XZ au moment du franchissement est **dans l'empreinte** du cylindre
+   (distance horizontale à l'axe ≤ `c.radius` ; tolérance possible de `+capsule.radius`
+   pour rester cohérent avec le rayon combiné utilisé en horizontal — à figer à
+   l'implémentation).
+4. **Garde anti-sonde 50 m** : n'émettre que si `startCenter.y - c.topY ≤ kPropTopMargin`,
+   avec `kPropTopMargin` une petite marge (quelques mètres, ≪ 50). La sonde
+   anti-encastrement part de 50 m → exclue → comportement actuel préservé.
+   - Borne basse de la marge : elle doit couvrir le « sticky ground probe » et le sweep
+     de gravité par frame quand le centre de la capsule est juste au-dessus du prop
+     (≈ `halfHeight + radius` + `vitesse·dt`). Valeur retenue à figer après lecture des
+     distances de sonde, p. ex. `kPropTopMargin = 4.0f` (≫ demi-capsule, ≪ 50).
+
+Sortie quand la condition est remplie et que la fraction est meilleure que `best` :
+- `best.hit = true`.
+- `best.normal = {0, 1, 0}` (sol horizontal → `IsWalkable` vrai).
+- `best.fraction` = fraction du sweep à laquelle le **bas de la capsule** atteint `topY`
+  (le `CharacterController` en déduit la position de repos, comme pour le terrain).
+
+Le blocage **horizontal** existant (côtés du cylindre) reste inchangé : les deux
+contributions coexistent (approche latérale → côté ; approche descendante dans
+l'empreinte → couvercle).
+
+### 4.3 Documentation « caisses non-lootables »
+
+- Ajouter une note dans `CODEBASE_MAP.md` (section props/loot) actant la règle :
+  les caisses (`Crate_Metal`, `Crate_Wooden`) **ne sont pas** des emplacements de loot ;
+  le loot reste réservé aux nœuds de récolte (et, plus tard, aux coffres de l'épic B).
+- Aucune suppression de code (rien n'associe de loot aux caisses aujourd'hui).
+
+## 5. Flux nominal
+
+1. Le joueur saute → apex ~0,98 m.
+2. Il retombe au-dessus d'une caisse.
+3. Le sweep de gravité descendant croise `topY` dans l'empreinte du cylindre.
+4. `SweepCapsule` renvoie un contact sol (normale haut) à `topY`.
+5. `CharacterController` passe `grounded = true` ; le perso se tient sur la caisse.
+6. En marchant hors de l'empreinte → plus de contact couvercle → chute naturelle.
+
+## 6. Cas limites
+
+- **Approche horizontale** : bloquée par le côté du cylindre (inchangé). Le step-up
+  (0,3 m) ne suffit pas pour 0,87 m → il faut sauter (voulu).
+- **Sonde anti-encastrement (50 m)** : exclue par `kPropTopMargin` → pas de
+  téléportation au sommet du prop (préserve la parade existante).
+- **Bord de plateforme** : sortie d'empreinte XZ → plus de hit → chute.
+- **Arbres / piliers** : auront aussi un dessus plat atterrissable à leur point le plus
+  haut (conséquence assumée de « tous les props solides »). Un opt-out par prop pourra
+  être ajouté plus tard si nécessaire (hors périmètre).
+- **Empilement / props imbriqués** : on retient le hit de plus petite fraction (le plus
+  proche), donc le couvercle le plus haut rencontré en premier en descente l'emporte.
+
+## 7. Tests
+
+- **`CharacterControllerJumpTests`** (MAJ) : apex attendu ≈ 0,98 m (au lieu de 0,60).
+  Ajuster la/les valeurs attendues et le commentaire.
+- **`CompositeWorldCollider`** (nouveaux) :
+  - (a) sweep descendant court dont le bas de capsule franchit `topY` dans l'empreinte
+    → `hit`, `normal ≈ (0,1,0)`, position de repos au niveau `topY`.
+  - (b) sweep depuis 50 m au-dessus (`start.y - topY > kPropTopMargin`) → **pas** de hit
+    couvercle (régression anti-encastrement).
+  - (c) sweep purement horizontal entrant dans le cylindre → toujours bloqué (normale
+    horizontale) — régression du comportement existant.
+  - (d) sweep descendant **hors** empreinte XZ → pas de hit couvercle.
+- **Intégration** : capsule lâchée au-dessus d'une caisse (cylindre `topY = 0,87`) →
+  après quelques `Update`, `IsGrounded()` vrai et `GetPosition().y` stabilisé au niveau
+  du dessus de la caisse.
+
+Tests à enregistrer dans la liste CTest (`build-linux.yml` lance `ctest`).
+
+## 8. Impact déploiement serveur
+
+À lever au moment du plan :
+
+- La position est **client-autoritaire avec validation serveur** (réplication T0.1).
+  **Vérifier** s'il existe un clamp de vitesse/déplacement vertical côté shard
+  (validateur de mouvement). Recherche : `src/shardd/` autour de la validation de
+  position/mouvement.
+  - **Si un clamp vertical existe** → relever sa tolérance pour accepter le nouvel apex
+    ⇒ **redéploiement serveur (shard) requis** (et lock-step client+serveur).
+  - **Si aucun clamp vertical** (client-autoritaire pur sur le vertical) ⇒ **client
+    uniquement, pas de redéploiement serveur**.
+- Les sections 4.1/4.2/4.3 sont sinon **purement client** (collision et controller
+  vivent dans `src/client/`, docs).
+
+## 9. Hors périmètre (épics suivants)
+
+- Coffres à clé (épic B), progression/XP (épic C), etc.
+- Opt-out « prop non atterrissable » par donnée.
+- Volume « plateforme invisible » plaçable dans l'éditeur monde.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -753,8 +753,8 @@ elseif(UNIX)
   lcdlln_add_simple_test(terrain_collider_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/TerrainColliderTests.cpp)
 
-  # Saut realiste : verifie l'apex (~0.60 m) du CharacterController apres le
-  # passage jumpSpeed 9.0 -> 4.9. Garde anti-regression (pas de saut ~2 m).
+  # Saut : verifie l'apex par defaut (~0.98 m, jumpSpeed=6.25) qui franchit une
+  # caisse metal (~0.87 m) + marge 0.1. Garde anti-regression (pas de saut ~2 m).
   lcdlln_add_simple_test(character_controller_jump_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CharacterControllerJumpTests.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -760,7 +760,8 @@ elseif(UNIX)
 
   # Collision props : CompositeWorldCollider (terrain + cylindres verticaux).
   # Verifie sweep capsule-vs-cylindre (traversee bloquee, a-cote ignore, hors
-  # bornes Y ignore, delegation QueryWater au terrain).
+  # bornes Y ignore, ATTERRISSAGE sur le dessus + anti-teleport sonde 50 m,
+  # delegation QueryWater au terrain).
   lcdlln_add_simple_test(composite_world_collider_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CompositeWorldColliderTests.cpp)
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4949,7 +4949,10 @@ namespace engine
 											ccCfg.walkSpeed     = static_cast<float>(m_cfg.GetDouble("player.movement.walk_speed",      5.0));
 											ccCfg.runSpeed      = static_cast<float>(m_cfg.GetDouble("player.movement.run_speed",       9.0));
 											ccCfg.gravity       = static_cast<float>(m_cfg.GetDouble("player.movement.gravity",       -20.0));
-											ccCfg.jumpSpeed     = static_cast<float>(m_cfg.GetDouble("player.movement.jump_speed",      9.0));
+											// Defaut aligne sur CharacterController::Config (6.25 -> apex ~0.98 m,
+											// permet de sauter sur une caisse metal ~0.87 m + marge). Valeur reelle
+											// pilotee par config.json "player.movement.jump_speed".
+											ccCfg.jumpSpeed     = static_cast<float>(m_cfg.GetDouble("player.movement.jump_speed",      6.25));
 											ccCfg.coyoteTimeSec = static_cast<float>(m_cfg.GetDouble("player.movement.coyote_time_s",   0.1));
 											ccCfg.jumpBufferSec = static_cast<float>(m_cfg.GetDouble("player.movement.jump_buffer_s",   0.1));
 											ccCfg.capsule.radius = 0.3f;

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -90,10 +90,12 @@ namespace engine::gameplay
 			float maxSlopeDeg = 45.0f; ///< walkable slope
 			float maxStep = 0.3f;      ///< m
 
-			// Saut realiste : apex = jumpSpeed^2 / (2*|gravity|). Avec gravity=-20,
-			// jumpSpeed=4.9 -> ~0.60 m (env. 1/3 de la taille 1.8 m, saut humain pose).
-			// Auparavant 9.0 -> ~2.0 m (irrealiste, ~1.1x la taille).
-			float jumpSpeed = 4.9f;       ///< m/s, impulse applied when jumping
+			// Saut : apex = jumpSpeed^2 / (2*|gravity|). Avec gravity=-20,
+			// jumpSpeed=6.25 -> ~0.98 m. Calibre pour sauter SUR une "caisse metal"
+			// (~0.87 m de haut) avec une marge de securite de +0.1 m. Le dessus des
+			// props solides est atterrissable (cf. CompositeWorldCollider::SweepCapsule).
+			// Historique : 9.0 (~2.0 m, irrealiste) -> 4.9 (~0.60 m) -> 6.25 (~0.98 m).
+			float jumpSpeed = 6.25f;       ///< m/s, impulse applied when jumping
 			float airControlMultiplier = 0.5f; ///< 50% of ground control
 			float coyoteTimeSec = 0.1f;   ///< allow jump shortly after leaving ground
 			float jumpBufferSec = 0.1f;   ///< allow jump shortly before landing

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -56,7 +56,13 @@ namespace engine::gameplay
 					const float startBottom = startCenter.y - halfH;
 					const float endBottom   = endCenter.y   - halfH;
 					const float ex = endCenter.x - c.cx, ez = endCenter.z - c.cz;
-					const bool insideXZ = (ex * ex + ez * ez) <= (c.radius * c.radius);
+					// Zone d'atterrissage alignee sur l'empreinte de blocage horizontal
+					// (rayon cylindre + rayon capsule) : "si ca te bloque lateralement,
+					// tu peux te poser dessus". Sinon le dessus (petit disque de rayon
+					// c.radius) serait quasi impossible a viser en sautant (le blocage
+					// lateral maintient le joueur a c.radius+capsule.radius du centre).
+					const float landR = c.radius + capsule.radius;
+					const bool insideXZ = (ex * ex + ez * ez) <= (landR * landR);
 					// Franchissement de topY de haut en bas dans l'empreinte (miroir du
 					// sol plat a y=topY). startBottom <= topY => deja pose (frac 0).
 					if (insideXZ && endBottom < c.topY && startBottom >= c.topY)

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -41,6 +41,43 @@ namespace engine::gameplay
 
 		for (const auto& c : m_cylinders)
 		{
+			// Atterrissage sur le DESSUS du prop (couvercle). Le perso peut se poser et
+			// se tenir sur tout prop solide. On ne traite QUE les sweeps descendants de
+			// PROXIMITE : le bas de la capsule (center.y - halfH, meme convention que le
+			// sol/terrain) franchit `topY` de haut en bas, a l'interieur de l'empreinte XZ.
+			// GARDE ANTI-SONDE : on ignore les sweeps qui partent loin au-dessus du sommet
+			// (ex. sonde anti-encastrement du CharacterController, depuis 50 m), pour
+			// preserver "jamais de blocage vertical par un prop" hors atterrissage proche.
+			{
+				constexpr float kPropTopMargin = 4.0f; // >> demi-capsule, << 50 m (sonde)
+				const bool descending = endCenter.y < startCenter.y;
+				if (descending && (startCenter.y - c.topY) <= kPropTopMargin)
+				{
+					const float startBottom = startCenter.y - halfH;
+					const float endBottom   = endCenter.y   - halfH;
+					const float ex = endCenter.x - c.cx, ez = endCenter.z - c.cz;
+					const bool insideXZ = (ex * ex + ez * ez) <= (c.radius * c.radius);
+					// Franchissement de topY de haut en bas dans l'empreinte (miroir du
+					// sol plat a y=topY). startBottom <= topY => deja pose (frac 0).
+					if (insideXZ && endBottom < c.topY && startBottom >= c.topY)
+					{
+						const float denom = startBottom - endBottom;
+						float frac = (denom > 1e-8f) ? (startBottom - c.topY) / denom : 0.0f;
+						if (frac < 0.0f) frac = 0.0f;
+						if (frac > 1.0f) frac = 1.0f;
+						if (frac < best.fraction)
+						{
+							best.hit = true;
+							best.fraction = frac;
+							best.normal = engine::math::Vec3{ 0.0f, 1.0f, 0.0f };
+						}
+						// On est au-dessus : ce cylindre ne bloque pas horizontalement
+						// cette frame. Passer au cylindre suivant.
+						continue;
+					}
+				}
+			}
+
 			const float R = capsule.radius + c.radius;
 
 			// Recouvrement vertical (au point d'arrivée, conservateur) : si la capsule

--- a/src/client/gameplay/tests/CharacterControllerJumpTests.cpp
+++ b/src/client/gameplay/tests/CharacterControllerJumpTests.cpp
@@ -143,6 +143,18 @@ namespace
 		const float high = SimulateJumpApex(7.0f);
 		REQUIRE(high > low);
 	}
+
+	// Le saut PAR DEFAUT doit franchir une caisse metal (~0.87 m) avec marge 0.1 m,
+	// soit un apex >= 0.97 m. Garde le calibrage "sauter sur les caisses".
+	void Test_Jump_DefaultClearsMetalCrate()
+	{
+		const float defaultSpeed = CharacterController::Config{}.jumpSpeed;
+		const float apex = SimulateJumpApex(defaultSpeed);
+		std::fprintf(stderr, "[INFO] apex(default=%.2f) = %.3f m (attendu >= 0.97)\n",
+			defaultSpeed, apex);
+		REQUIRE(apex >= 0.97f);   // 0.87 (caisse) + 0.10 (marge)
+		REQUIRE(apex < 1.30f);    // borne haute : pas de saut absurde
+	}
 }
 
 int main()
@@ -150,5 +162,6 @@ int main()
 	Test_Jump_Apex_IsRealistic();
 	Test_Jump_NotTheOldUnrealisticHeight();
 	Test_Jump_HigherSpeedGivesHigherApex();
+	Test_Jump_DefaultClearsMetalCrate();
 	return g_failed;
 }

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -89,6 +89,39 @@ int main()
 		check(!h, "chevauchement + eloignement: pas de hit (peut ressortir)");
 	}
 
+	// 6) ATTERRISSAGE sur le DESSUS : sweep descendant court dont le bas de capsule
+	//    (center.y - halfH) franchit topY de haut en bas, dans l'empreinte XZ.
+	//    -> hit "sol" (normale +Y) au niveau topY.
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl); // topY = 3
+		IWorldCollider::SweepHit hit;
+		// halfH = 0.9 ; start bottom = 4.5-0.9 = 3.6 (>3) ; end bottom = 3.5-0.9 = 2.6 (<3).
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 4.5f, 0 }, Vec3{ 5, 3.5f, 0 }, hit);
+		check(h && hit.hit, "dessus: hit attendu");
+		check(hit.normal.y > 0.99f, "dessus: normale verticale (sol)");
+		check(hit.fraction > 0.5f && hit.fraction < 0.7f, "dessus: fraction ~0.6");
+	}
+
+	// 7) Déjà posé sur le dessus (start bottom <= topY) : hit immédiat (frac ~0) ->
+	//    le sticky ground probe garde le perso "grounded" sur la caisse.
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		// start bottom = 3.9-0.9 = 3.0 (== topY) ; end bottom = 3.8-0.9 = 2.9 (<3).
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 3.9f, 0 }, Vec3{ 5, 3.8f, 0 }, hit);
+		check(h && hit.hit, "dessus pose: hit attendu");
+		check(hit.fraction < 0.01f, "dessus pose: fraction ~0");
+		check(hit.normal.y > 0.99f, "dessus pose: normale verticale");
+	}
+
+	// 8) Sweep descendant HORS empreinte XZ : pas de hit dessus (ni horizontal).
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 7, 4.5f, 0 }, Vec3{ 7, 3.5f, 0 }, hit);
+		check(!h && !hit.hit, "dessus hors empreinte: pas de hit");
+	}
+
 	// 5) QueryWater délégué au terrain.
 	{
 		CompositeWorldCollider c(&terrain);

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -102,6 +102,18 @@ int main()
 		check(hit.fraction > 0.5f && hit.fraction < 0.7f, "dessus: fraction ~0.6");
 	}
 
+	// 6b) Atterrissage en BORD : centre hors du rayon cylindre (0.5) mais dans le
+	//     rayon combiné (cyl 0.5 + capsule 0.3 = 0.8) -> on se pose quand même
+	//     ("si ça te bloque latéralement, tu peux te poser dessus").
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl); // topY = 3, radius 0.5
+		IWorldCollider::SweepHit hit;
+		// ex = 5.7 - 5.0 = 0.7 : hors 0.5 mais dans 0.8.
+		bool h = c.SweepCapsule(cap, Vec3{ 5.7f, 4.5f, 0 }, Vec3{ 5.7f, 3.5f, 0 }, hit);
+		check(h && hit.hit, "bord: hit attendu (rayon combine)");
+		check(hit.normal.y > 0.99f, "bord: normale verticale");
+	}
+
 	// 7) Déjà posé sur le dessus (start bottom <= topY) : hit immédiat (frac ~0) ->
 	//    le sticky ground probe garde le perso "grounded" sur la caisse.
 	{


### PR DESCRIPTION
## Épic A — Saut plus haut & dessus de props atterrissable

Premier des 8 sous-projets issus du brainstorming. Débloque la mécanique d'exploration de **zones cachées** en permettant de sauter **sur** les caisses (et tout prop solide).

### Changements
- **Saut plus haut (client)** — `CharacterController::Config::jumpSpeed` 4.9 → **6.25**, apex `≈ 0.98 m`. Calibré pour franchir une « caisse métal » (`Crate_Metal.gltf`, ~0.87 m) avec marge **+0.1 m**. Saut **global**.
- **Dessus de props atterrissable (client)** — `CompositeWorldCollider::SweepCapsule` émet un contact sol (normale +Y) sur le **dessus** d'un `PropCylinder` (`topY`) pour les sweeps descendants de proximité (miroir d'un sol plat à `y=topY`). On peut se tenir sur tout prop solide ; le blocage horizontal des flancs est inchangé.
  - **Garde anti-sonde** (`kPropTopMargin = 4 m`) : la sonde anti-encastrement (depuis 50 m) reste ignorée par les props → pas de téléportation au sommet (préserve la parade existante, cas de test `4bis`).
- **Caisses non-lootables** — documenté (`CODEBASE_MAP.md` §61) : `Crate_Metal`/`Crate_Wooden` ne sont pas des spots de loot. Aucun code à retirer (rien ne leur associe de loot aujourd'hui).

### Tests (CTest, lancés par `build-linux`)
- `character_controller_jump_tests::Test_Jump_DefaultClearsMetalCrate` : apex par défaut ≥ 0.97 m.
- `composite_world_collider_tests` cas 6/7/8 : atterrissage sur le dessus, posé immédiat (frac 0), hors empreinte XZ ; le cas `4bis` (sweep 50 m → pas de hit) reste la garde anti-téléport.

### Déploiement
> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

Vérifié : l'anti-cheat (`AntiCheatGameplay.h`) contrôle la vitesse 3D (`19.5 m/s`) et le téléport (`50 m`), **pas** la hauteur de saut. Sprint+saut = `√(13² + 6.25²) ≈ 14.4 m/s < 19.5`. Gravité inchangée.

### Docs
- Spec : `docs/superpowers/specs/2026-06-02-saut-caisses-atterrissables-design.md`
- Plan : `docs/superpowers/plans/2026-06-02-saut-caisses-atterrissables.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
