### PR TITLE
docs(tickets): cluster M101 — éditeur de routines visuel nodal + audit 22 systèmes

### DIFF
--- a/tickets/M101/AUDIT_22_SYSTEMES.md
+++ b/tickets/M101/AUDIT_22_SYSTEMES.md
@@ -1,0 +1,107 @@
+# M101 — Audit des 22 systèmes de référence (éditeur de monde UE5)
+
+> **Objectif.** Prouver, fichier à l'appui, ce qui existe déjà dans l'éditeur de
+> monde LCDLLN et son runtime, afin de **ne rien dupliquer**. Chaque ligne mappe
+> un système de référence (vocabulaire Unreal Engine 5) sur le(s) ticket(s) M100
+> et/ou les fichiers source réels du dépôt `tips-of-mine/LCDLLN-test` (branche
+> `main`, audit du 2026-06-03).
+>
+> **Méthode.** Audit en lecture seule de l'arbre de travail local (qui *est* le
+> dépôt public — remote `origin`), pas d'un clone `--depth=1` redondant. Tous les
+> chemins ci-dessous ont été vérifiés.
+
+## Légende des statuts
+
+| Statut | Sens |
+|--------|------|
+| **Couvert** | Un ou plusieurs tickets M100 livrent le système, et/ou le code existe. |
+| **Partiel** | Le besoin est partiellement adressé ; le manque est précisé. |
+| **Absent** | Aucun ticket ni code ; candidat à un ticket neuf (non créé par cet audit, sauf le cluster routines M101). |
+
+## Tableau de cartographie
+
+| # | Système UE5 | Statut | Ticket(s) M100 / fichiers source | Manque éventuel |
+|---|-------------|--------|----------------------------------|-----------------|
+| 1 | Terrain heightmap sculptable (raise/lower/smooth/flatten) | **Couvert** | M100.5 (Heightmap), M100.6 (Sculpting Brushes) ; `src/world_editor/terrain/TerrainSculptTool.h`, `TerrainBrush.h`, `TerrainSculptCommand.h` | — |
+| 2 | Splines de terrain (routes/rivières conformées) | **Couvert** | M100.29 (Spline Tool & Roads), M100.36 (River Network) ; `src/world_editor/water/RiverNetworkTool.h`, `MacroPolylineCommandBase.h` | — |
+| 3 | Outils de sculpt avancés (noise/ramp/érosion) | **Couvert** | M100.7 (Stamps & Procedural Generators), M100.38 (Hydraulic Erosion), M100.39 (Thermal & Wind Erosion) ; `src/world_editor/terrain/erosion/*`, `ProceduralStampGenerators.h` | — |
+| 4 | Foliage instancié (densité, règles pente/altitude) | **Couvert** | M100.18 (Vegetation Library & Density Painting), M100.19 (Procedural Forest & Field) ; `instances/foliage.bin`, `src/world_editor/ui/TreeSpeciesCatalog.h` | — |
+| 5 | Placement manuel / drag & drop / snapping | **Couvert** | M100.17 (Easy Placement Tool) | — |
+| 6 | PCG — génération procédurale par règles | **Partiel** | Règles dédiées par outil : M100.19 (forêt/champ), M100.31 (Hamlet Generator), M100.46 (Zone Presets), M100.50 (Quick Start Wizard, seed déterministe) | Pas de **graphe PCG générique** façon UE (règles arbitraires composables). Le VM de routines M101 **n'est pas** un système PCG (à ne pas confondre). Candidat ticket futur. |
+| 7 | Partitionnement du monde (grille de cellules + streaming) | **Couvert** | M09/M10 + `src/client/world/WorldModel.h`, `StreamingScheduler.h`, `StreamCache.h`, `ZonePreloadHook.h` ; grille `N000_E000` (zones 4 km / chunks 256 m) | — |
+| 8 | Data Layers (couches togglables) | **Couvert** | M100.34 (Selection, Layers, Minimap & Save/Load Zone) | — |
+| 9 | Level Instances (sous-ensembles réutilisables, type hamlet) | **Partiel** | M100.31 (Hamlet Generator), M100.46 (Zone Presets Library) | Pas de **level instance générique imbriquée** éditable in-place. Couvert pour les cas concrets (hamlet, presets). Complément éventuel. |
+| 10 | World Outliner (arborescence d'acteurs) | **Couvert** | `src/world_editor/panels/OutlinerPanel.h/.cpp` + M100.34 (sélection/layers) | — |
+| 11 | Gizmos de transform + snapping | **Couvert** | M100.1 (shell + sélection/gizmos), M100.17 (snapping / align-to-ground) | — |
+| 12 | Pivot Tool | **Partiel** | Pivot configurable sur props interactifs (M100.32 `pivotLocal`/`axisLocal`) + point focal orbital (M100.4) | Pas d'**outil Pivot global** (repositionnement d'origine d'un acteur). Complément mineur. |
+| 13 | Viewports multiples (perspective + orthos) | **Partiel** | M100.4 (Editor Camera Modes : FPS / Orbital / **TopDownOrtho**) ; `src/world_editor/render/EditorViewportRenderTarget.h` (cible unique) | Un seul viewport, modes **commutables** (perspective + ortho dispo), pas **simultanés** (pas de quad-view). Complément éventuel. |
+| 14 | Bookmarks de caméra | **Absent** | — | M100.4 déclare explicitement les bookmarks **Hors scope / no-op / « futur »** (lignes 26, 175-177). Candidat petit ticket. |
+| 15 | Outil de mesure | **Absent** | — | Aucun `Ruler`/`Measure` dans `src/`. Candidat petit ticket. |
+| 16 | Sky Atmosphere / nuages volumétriques / cycle jour-nuit | **Couvert** (nuages **Partiel**) | M100.24 (Sun, Sky & Probes), M100.25 (Season & Time-of-Year, cycle), M100.22 (Volumetric Fog) | **Nuages volumétriques** dédiés non spécifiés (le fog volumétrique existe). Complément éventuel. |
+| 17 | Post Process Volumes | **Partiel** | Post-FX global : M07 (TAA), M08 (Bloom / auto-exposure / color grading) ; zones atmosphère M100.23/24 | Pas de **Post Process Volume générique** éditable par volume (override local de paramètres post). Complément éventuel. |
+| 18 | Lighting Scenarios / probes IBL | **Couvert** (scenarios **Partiel**) | M100.24 (Probes Editor IBL), M05 (IBL split-sum) ; cycle jour/nuit via M100.25 | Pas de **lighting scenarios** génériques (presets d'éclairage commutables multi-états). Complément éventuel. |
+| 19 | Brouillard (height fog / volumétrique) | **Couvert** | M100.22 (Volumetric Fog Volumes), M100.23 (Distance & Height Fog Tuning) | — |
+| 20 | NavMesh (génération pour pathfinding PNJ) | **Partiel** | Segment `Nav` du chunk (`ChunkSegment::Nav`), M100.44 (VMap Bridge : LOS / GetHeight / Raycast serveur) | Pas de **génération navmesh dédiée au pathfinding PNJ** ni de pathfinding PNJ runtime spécifié. Lié à un futur milestone PNJ. |
+| 21 | Blocking / Trigger Volumes | **Couvert** | M100.16 (Hazard Volume System), M100.28 (Gameplay Zones & Weather Zones) | — |
+| 22 | Nav Modifier Volumes (zones de coût IA) | **Absent** / **Partiel** | M100.28 (gameplay zones) approche le concept | Pas de **modificateur de coût de nav** pour pathfinding IA. Lié au futur PNJ/nav. |
+
+## Le manque réel : éditeur de routines visuel nodal
+
+| # | Système | Statut | Constat |
+|---|---------|--------|---------|
+| **23** | **Éditeur de routines visuel nodal (type n8n / Blueprint / StateTree)** | **Absent** | Aucune lib node-graph réutilisable dans `src/` (ni `ImNodes`, ni `NodeEditor`, ni `RoutineGraph`). Les tickets `M43.1` (material node graph) et `M43.3` (quest flowchart) sont **d'anciens tickets jamais implémentés**, au format obsolète `/engine/` + DoD Windows-only, et ne fournissent **aucun code**. |
+
+→ **C'est l'objet du cluster M101** (voir `INDEX.md`).
+
+## Systèmes Absent / Partiel — candidats à un ticket neuf (NON créés ici)
+
+Conformément aux règles d'exécution, l'audit **liste** ces manques sans créer de
+ticket (hors cluster routines M101) :
+
+| Système | Reco | Justification |
+|---------|------|---------------|
+| Bookmarks de caméra (#14) | **Complément M100.4 bis** | Petit ajout (`Save view 1..9`) déjà anticipé en « futur » par M100.4. Faible effort. |
+| Outil de mesure (#15) | **Ticket neuf léger** | Outil overlay 2D/3D simple, indépendant. |
+| Viewports multiples simultanés (#13) | **Ticket neuf (optionnel)** | Quad-view ortho. Effort moyen (multi-render-target). Priorité basse. |
+| Pivot Tool global (#12) | **Complément M100.17** | Repositionnement d'origine d'acteur. Faible effort. |
+| Graphe PCG générique (#6) | **Milestone séparé** | Système conséquent ; ne pas confondre avec M101 (routines ≠ PCG). |
+| Level Instances génériques (#9) | **Complément M100.46** | Étendre les zone presets en instances imbriquées éditables. |
+| Nuages volumétriques (#16) | **Ticket neuf rendu** | Effort rendu non trivial. Priorité basse. |
+| Post Process Volumes (#17) | **Complément M100.23/24** | Override local de paramètres post par volume. |
+| Lighting Scenarios (#18) | **Complément M100.24** | Presets d'éclairage commutables. |
+| NavMesh PNJ + Nav Modifier Volumes (#20, #22) | **Milestone PNJ futur** | Dépend de l'infra PNJ (Role Registry / pathfinding) **absente** — voir note ci-dessous. |
+
+## Note critique : infrastructure PNJ largement absente
+
+L'audit du runtime (cf. §1bis du prompt directeur) révèle un écart important entre
+les hypothèses et le code réel :
+
+| Concept attendu | Réalité dans le code |
+|-----------------|----------------------|
+| `EventAI` (machine à états IA data-driven côté shard) | **EXISTE** — `src/shardd/ai/EventAI.h` + `EventAIRuntime.h`. Table simple : 6 triggers (`Timer`, `HpPctBelow`, `OnAggro`, `OnSpawn`, `OnDeath`, `OnTargetHpPctBelow`), 6 actions (`Say`, `Cast`, `Flee`, `Summon`, `Despawn`, `Custom`). **Ce n'est PAS** un StateTree hiérarchique à sélection par utilité. |
+| `Role Registry` | **ABSENT** du code (`RoleRegistry` introuvable). |
+| `Utility AI` | **ABSENT** (le pattern data-driven d'`EventAI` n'est pas de l'Utility AI). |
+| `Smart Objects` | **ABSENT** (`SmartObject` introuvable). |
+| `AI-LOD` | **Spécifié en ticket uniquement** — enum `AiLod` (Near/Medium/Far/Hibernate) dans `tickets/CHAR-MODEL/CHAR-MODEL.37_AmbientLifeSystem.md`, **pas encore en code**. |
+| `ARCHITECTURE_PNJ.md` | **N'EXISTE PAS**. Docs réels : `docs/superpowers/specs/2026-06-02-dialogue-pnj-design.md`, `docs/superpowers/plans/2026-06-02-dialogue-pnj.md`, ticket `CHAR-MODEL.37`. |
+
+**Conséquence pour M101.** La cible PNJ (cible A) ne peut pas s'appuyer sur Role
+Registry / Smart Objects (inexistants). Le ticket **M101.7 est `Blocked`** : il
+documente ses dépendances manquantes et fournit, en attendant, l'intégration
+**réaliste** disponible — la génération d'`EventAIRow` depuis le graphe, consommée
+par l'`EventAIRuntime` existant. Décision actée avec Hubert (2026-06-03).
+
+## Écarts factuels corrigés par rapport au prompt directeur
+
+| Affirmation du prompt | Réalité vérifiée | Correction appliquée dans M101 |
+|-----------------------|------------------|--------------------------------|
+| `kChunkMetaHasRoutines = 1u << 5` | Bit 5 = `kChunkMetaHasTerrain`, bit 6 = `kChunkMetaHasSplat` (déjà pris) | **`kChunkMetaHasRoutines = 1u << 7`** (M101.3) |
+| `ChunkSegment::Routines` ajouté en fin | `kChunkSegmentCount` actuel = 7 (Geo…Probes) | `Routines = 7`, `kChunkSegmentCount → 8` ✓ correct |
+| Writer dans `tools/zone_builder/lib/ChunkPackageWriter.*` | Chemin réel : `tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h` | Chemin corrigé dans M101.3 |
+| Pattern VM « `engine_sim` » | **`engine_sim` n'existe pas** | M101.2 décrit une lib pure autonome `routine_vm` (aucune référence à `engine_sim`) |
+| Opcodes `kOp*` dans `ProtocolV1Constants.h` | Le gameplay passe par l'enum `MessageKind` dans `ServerProtocol.h` (`kProtocolVersion = 8`) ; gabarit = `GameEventPayloads.h` (`GameEventErrorCode{Ok=0,…}` + Request/Response + Notification) | M101.8 suit le gabarit `GameEventPayloads.h` et l'enum `MessageKind` |
+| `ARCHITECTURE_PNJ.md` (dépendance) | N'existe pas | Remplacé par les docs réels (cf. ci-dessus) |
+
+---
+
+*Audit produit le 2026-06-03. Lecture seule, aucun fichier de production modifié.*

--- a/tickets/M101/INDEX.md
+++ b/tickets/M101/INDEX.md
@@ -1,0 +1,189 @@
+# Milestone M101 — Éditeur de routines visuel nodal (type n8n)
+
+> **Cluster M101.** Distinct de M100 (éditeur de monde 3D + simulation
+> environnementale) et de M43 (anciens panneaux ImGui). M101 livre **l'éditeur de
+> routines visuel nodal** : un panneau dockable à droite de l'éditeur de monde
+> permettant de **programmer visuellement des routines** par graphe de nœuds, à la
+> manière de n8n / Blueprint / StateTree.
+>
+> **Le seul système réellement absent** identifié par `AUDIT_22_SYSTEMES.md`
+> (système #23). Tous les autres systèmes de référence UE5 sont déjà Couverts ou
+> Partiels dans M100.
+>
+> **Pré-requis livrés :** M43.4 (ImGui foundation), M100.1 (World Editor
+> Bootstrap), M100.2 (Command Stack & Undo/Redo).
+
+## Principes architecturaux structurants
+
+| Couche | Rôle pour les routines | Ne fait PAS |
+|--------|------------------------|-------------|
+| **Éditeur (`lcdlln_world_editor`)** | Écrit le graphe de routine (nouveau segment de chunk **additif** `routines.bin`). UI nodale ImGui, validation, mode Playtest F5. | Pas de pipeline de rendu séparé. N'exécute pas la logique gameplay « pour de vrai » hors Playtest (qui utilise le code client de prod). |
+| **Client (`engine_core` + Vulkan)** | Interprète les graphes **zone/gameplay** au runtime via une **VM pure** (lib `routine_vm`, aucune dépendance Vulkan/GLFW). Charge `routines.bin` par le même chemin de streaming que les autres segments. | Ne simule pas l'IA PNJ (elle vit côté shard). |
+| **Shard (`shardd`)** | Pour la cible PNJ : consomme des `EventAIRow` **générés depuis le graphe** par `RoutineToEventAI`, via l'`EventAIRuntime` existant. | N'introduit **pas** une seconde IA concurrente d'`EventAI`. |
+| **Master (`masterd`)** | **Relaie uniquement** les changements d'état (gabarit `GameEventPayloads.h`). | Aucune exécution de graphe. Aucune validation gameplay propriétaire. |
+
+**Data-driven, zéro recompilation.** Un graphe est un **artefact JSON** édité par
+l'éditeur, sérialisé dans `routines.bin`, et **interprété** au runtime. Aucun nœud
+ne génère ni ne compile du C++. Même philosophie que l'`EventAI` data-driven déjà
+en place côté shard.
+
+**Contrat de parité éditeur ↔ client.** Format binaire unique (`routines.bin`),
+VM unique, **évaluation déterministe** (mêmes entrées → même sortie). Tests de
+round-trip obligatoires (édité → écrit → relu → réinterprété = état identique),
+exécutables headless en CI Linux **et** Windows.
+
+`engine_core` (client + éditeur) **ne linke pas** la cible serveur. La VM est une
+lib pure réutilisable par le client ; le shard ne linke que la sérialisation
+(`routine_graph`) + le pont `RoutineToEventAI`.
+
+## Décision de format actée : deux types de graphes distincts
+
+> Le prompt directeur laissait ce choix à Hubert. **Décision prise le 2026-06-03 :**
+> **deux types de graphes distincts**, partageant la sérialisation mais avec deux
+> schémas et deux VM séparés.
+
+| Type de graphe | Modèle de référence | VM | Cible |
+|----------------|---------------------|-----|-------|
+| `npc_routine` | StateTree (états hiérarchiques + sélection par utilité + tick rate par AI-LOD + séparation capteurs/actions) | `NpcRoutineEvaluator` → génère des `EventAIRow` (cible A) | Comportements PNJ (M101.7, **Blocked**) |
+| `zone_event` | Blueprint event graph (nœuds Event racines, execution wires + data pins typés, graphe attaché à une cellule de zone) | `ZoneEventVm` (exécution data-flow client) | Événements de zone / gameplay (M101.8) |
+
+**Justification.** Deux VM simples et bornées (un schéma par cible) sont plus
+faciles à tester, à valider en CI et à raisonner qu'une VM unifiée à sémantique
+double (un nœud pouvant être state OU event). La sérialisation JSON et le segment
+`routines.bin` sont **communs** : un champ `RoutineGraphKind` discrimine. On garde
+ainsi un format binaire unique tout en isolant les sémantiques d'exécution.
+
+## Conventions de cet INDEX
+
+### Statuts
+
+| Statut | Sens |
+|--------|------|
+| **Done** | Spec figée + code mergé sur `main` + CI verte. |
+| **Ready** | Spec figée, dépendances livrées, prêt à coder, aucun blocage. |
+| **Draft** | Spec proposée, **en attente de validation Hubert** (feu vert ticket par ticket). |
+| **Blocked** | Spec figée mais bloqué par une dépendance non résolue (raison documentée). |
+
+> **Tous les tickets M101 sont en `Draft`** tant que Hubert ne les a pas validés
+> un par un (règle « Stop & validate » du prompt). À la validation, les tickets
+> dont toutes les dépendances sont livrées passent à `Ready`. **M101.7** reste
+> `Blocked` indépendamment de la validation (infra PNJ absente).
+
+### Phases logiques (4)
+
+| # | Phase | Tickets | But |
+|---|-------|---------|-----|
+| 1 | Modèle de données & VM | M101.1–3 | Modèle de graphe + sérialisation JSON, VM déterministe (lib pure), segment `routines.bin` additif. |
+| 2 | UI nodale (ImGui) | M101.4–6 | Panneau nodal dockable, palette + inspecteur, validation visuelle. |
+| 3 | Bibliothèques de nœuds | M101.7–8 | Nœuds PNJ (Blocked) et nœuds zone/gameplay. |
+| 4 | Intégration & tests | M101.9–11 | Mode Playtest F5, round-trip & tests CI headless, doc F1 + tooltips. |
+
+## Liste complète des tickets (11)
+
+### Phase 1 — Modèle de données & VM
+
+| Ticket | Titre | Dépendances | Statut |
+|--------|-------|-------------|--------|
+| M101.1 | Modèle de graphe & sérialisation JSON | — (lib pure) | Draft |
+| M101.2 | VM d'interprétation déterministe (lib pure `routine_vm`) | M101.1 | Draft |
+| M101.3 | Segment de chunk `routines.bin` (extension additive) | M101.1, M100.3 (lib `zone_builder`, Done) | Draft |
+
+### Phase 2 — UI nodale (ImGui)
+
+| Ticket | Titre | Dépendances | Statut |
+|--------|-------|-------------|--------|
+| M101.4 | Panneau nodal dockable (canvas, pan/zoom, CRUD) | M101.1, M100.1 (Done), M100.2 (Done) | Draft |
+| M101.5 | Palette de nœuds + inspecteur de propriétés | M101.4 | Draft |
+| M101.6 | Validation visuelle du graphe | M101.4, M101.1 | Draft |
+
+### Phase 3 — Bibliothèques de nœuds (les deux cibles)
+
+| Ticket | Titre | Dépendances | Statut |
+|--------|-------|-------------|--------|
+| M101.7 | Nœuds **PNJ** (génère `EventAIRow`) | M101.1, M101.2, `EventAI` (Done) ; **Role Registry + Smart Objects (ABSENTS)** | **Blocked** |
+| M101.8 | Nœuds **zone/gameplay** | M101.1, M101.2, M100.16 (Ready), M100.28 (Ready), M100.32 (Ready) | Draft |
+
+### Phase 4 — Intégration & tests
+
+| Ticket | Titre | Dépendances | Statut |
+|--------|-------|-------------|--------|
+| M101.9 | Mode Playtest (F5) — exécution via code client de prod | M101.2, M101.8, M100.33 (Ready, Playtest F5) | Draft |
+| M101.10 | Round-trip & tests CI (headless, Linux + Windows) | M101.1, M101.2, M101.3 | Draft |
+| M101.11 | Documentation F1 + tooltips | M101.4, M101.5, M100.47 (Tooltips & F1 Doc) | Draft |
+
+## Ordre d'implémentation recommandé
+
+```
+M101.1 → M101.2 → M101.3 → M101.4 → M101.5 → M101.6 → M101.8 → M101.10 → M101.9 → M101.11
+                                                          ↘ M101.7 (Blocked, hors séquence)
+```
+
+Remarques :
+
+1. **M101.1 d'abord** : tout dépend du modèle de graphe + sérialisation.
+2. **M101.2 (VM) et M101.3 (segment binaire) peuvent être parallèles** une fois
+   M101.1 figé ; M101.10 (round-trip) exige les deux.
+3. **M101.7 (PNJ) est hors séquence** car `Blocked` : il sera débloqué quand
+   l'infra Role Registry / Smart Objects sera livrée par un futur milestone PNJ.
+   La partie « génération d'`EventAIRow` » est livrable indépendamment et sert de
+   preuve d'intégration.
+4. **M101.9 (Playtest) après M101.8** : il exécute des graphes `zone_event`
+   réels dans le code client de prod (pas de chemin « preview » séparé).
+
+## Décisions laissées à Hubert (posées, non tranchées)
+
+| Décision | Où | Reco |
+|----------|----|------|
+| **Autorité shard ↔ client** sur l'état déclenché par une routine `zone_event` (qui fait foi si client et shard divergent ?) | M101.8, M101.9 | Posée. Reco : client-autoritaire pour les objets de zone locaux (cohérent M100.32), master relais pur. À trancher si un cas d'usage compétitif émerge. |
+| **Déblocage de M101.7** : créer un milestone PNJ (Role Registry, Smart Objects, Utility AI runtime) avant ou après M101 ? | M101.7 | Posée. Reco : livrer M101.1–6 + M101.8–11 d'abord (cible zone fonctionnelle), puis le milestone PNJ, puis débloquer M101.7. |
+| **Tick rate AI-LOD** pour `npc_routine` : réutiliser l'enum `AiLod` du ticket CHAR-MODEL.37 (non codé) ou en définir un dans `routine_vm` ? | M101.2, M101.7 | Posée. Reco : aligner sur `AiLod` de CHAR-MODEL.37 quand il sera codé ; en attendant, M101.2 expose un `tickRateHz` paramétrable neutre. |
+
+## Gates de déploiement serveur
+
+| Ticket | Impact serveur | Gate |
+|--------|----------------|------|
+| M101.1–6 | Aucun (modèle, VM cliente, UI éditeur, validation). | ✅ client/éditeur uniquement. |
+| M101.7 (Blocked) | À son déblocage : le shard charge des `EventAIRow` générés → **redéploiement shard requis** quand livré. | ⚠️ (futur, à la levée du blocage). |
+| M101.8 | Les nœuds « broadcast » **réutilisent les opcodes existants** M100.25 (`SeasonBroadcast`), M100.26 (`WeatherBroadcast`), M100.32 (`InteractiveStateChange`). **Aucun nouvel opcode** introduit par M101.8 lui-même. | ✅ pas de redéploiement propre à M101.8 (les opcodes réutilisés ont déjà leur gate dans M100). |
+| M101.9–11 | Aucun. | ✅ client/éditeur uniquement. |
+
+> **Synthèse déploiement M101.** Le cluster est **client/éditeur uniquement**, à
+> **une exception future** : M101.7, une fois débloqué, ajoutera un chargement de
+> routines PNJ côté shard (redéploiement shard). Aucun nouvel opcode n'est créé par
+> M101 ; les nœuds broadcast s'appuient sur les opcodes M100 existants.
+
+## Contrats partagés (référencés transversalement)
+
+### Formats
+
+| Contrat | Défini dans | Consommé par |
+|---------|-------------|--------------|
+| Modèle `RoutineGraph`/`RoutineNode`/`RoutinePin`/`RoutineLink` + JSON | M101.1 | M101.2, M101.3, M101.4, M101.5, M101.6, M101.7, M101.8 |
+| Segment `routines.bin` (+ `ChunkSegment::Routines`, `kChunkMetaHasRoutines = 1u << 7`) | M101.3 | M101.9 (chargement client), M101.10 (round-trip), M100.34 (ré-export — note de compat) |
+| Lib pure `routine_vm` (`ZoneEventVm`, `NpcRoutineEvaluator`) | M101.2 | M101.7, M101.8, M101.9, M101.10 |
+
+### Structures C++ et services partagés
+
+| Contrat | Défini dans | Consommé par |
+|---------|-------------|--------------|
+| `RoutineNodeSchema` (bornage des types de nœuds par cible, versionné) | M101.1 | M101.5 (palette), M101.6 (validation), M101.7, M101.8 |
+| `RoutineToEventAI` (graphe `npc_routine` → `EventAIRow`) | M101.7 | shard `EventAIRuntime` (existant) |
+| `RoutineGraphPanel` (canvas) + intégration `CommandStack` | M101.4 | M101.5, M101.6 |
+
+## Format des tickets
+
+Chaque ticket calque `tickets/M100/M100.32-InteractiveProps.md` et ajoute la
+section obligatoire `## Code runtime référencé` (fichiers client/shard/réseau
+réels étendus ou appelés, étiquetés « étendu » / « appelé en lecture » / « hook
+manquant → Blocked »). Voir `tickets/DEFINITION_OF_DONE.md` pour la DoD globale ;
+chaque DoD M101 ajoute les **trois axes** : CI Linux verte, CI Windows verte, test
+de round-trip headless passant — plus le checkpoint de validation manuelle Hubert.
+
+> **Note convention chemins.** La DoD globale mentionne `/engine` ; l'arbre réel
+> du dépôt est `src/`. Les tickets M101 utilisent les chemins réels `src/`,
+> `game/data/`, `tools/`, conformément à l'ensemble du cluster M100.
+
+---
+
+*Index produit le 2026-06-03. Cluster en attente de validation Hubert, ticket par
+ticket (« Stop & validate »). Aucun code de production écrit.*

--- a/tickets/M101/M101.1-RoutineGraphModelAndSerialization.md
+++ b/tickets/M101/M101.1-RoutineGraphModelAndSerialization.md
@@ -1,0 +1,274 @@
+# M101.1 — Modèle de graphe & sérialisation JSON
+
+## Résumé
+
+Périmètre **strictement borné** : définir les structures de données d'un graphe
+de routine (`RoutineGraph`, `RoutineNode`, `RoutinePin`, `RoutineLink`,
+`RoutineProperty`), l'enum **borné et versionné** des types de nœuds
+(`RoutineNodeType`), le discriminant de cible (`RoutineGraphKind`), le **schéma**
+de bornage (`RoutineNodeSchema`), et la **sérialisation JSON déterministe**
+(`RoutineSerialization`). Aucune VM, aucune UI, aucun segment binaire ici — ce
+ticket pose uniquement le **contrat de données partagé** par tout le cluster
+M101. Lib **pure** (aucune dépendance Vulkan/GLFW/réseau).
+
+## Dépendances
+
+- Aucune dépendance code (lib pure, autonome).
+- Réutilise l'**utilitaire JSON du projet** (le même que celui qui charge
+  `config.json` / `surface_table.json`) — référencé en lecture, non modifié.
+
+## Portée
+
+### Inclus
+- Structs `RoutineGraph`, `RoutineNode`, `RoutinePin`, `RoutineLink`,
+  `RoutineProperty`.
+- Enums **bornés** : `RoutineGraphKind`, `RoutineNodeType` (versionné),
+  `PinDirection`, `PinKind`, `RoutineDataType`.
+- `RoutineNodeSchema` : descripteur statique par `RoutineNodeType` (pins
+  attendus, propriétés, cibles `RoutineGraphKind` valides).
+- `RoutineSerialization::ToJson(const RoutineGraph&)` /
+  `FromJson(...) → expected<RoutineGraph, Error>` **déterministes**.
+- Constante de version `kRoutineGraphVersion`.
+
+### Hors scope (formellement)
+- La VM d'interprétation (→ M101.2).
+- Le segment binaire `routines.bin` (→ M101.3).
+- L'UI nodale, la palette, la validation visuelle (→ M101.4–6).
+- Toute logique gameplay (les sémantiques d'exécution des nœuds PNJ/zone sont en
+  M101.7/8).
+- Le contenu concret des nœuds (seul un **sous-ensemble minimal** est déclaré ici
+  pour valider le schéma ; les bibliothèques complètes sont en M101.7/8).
+
+## Spécification fonctionnelle
+
+### Enums bornés et versionnés
+
+```cpp
+namespace engine::routine
+{
+    inline constexpr uint32_t kRoutineGraphVersion = 1u;
+
+    enum class RoutineGraphKind : uint8_t
+    {
+        NpcRoutine = 0,   // StateTree-like (cible A — voir M101.7)
+        ZoneEvent  = 1    // Blueprint-like (cible B — voir M101.8)
+    };
+
+    enum class PinDirection : uint8_t { Input = 0, Output = 1 };
+
+    // Deux familles de pins (distinction fondamentale héritée de Blueprint) :
+    enum class PinKind : uint8_t { Exec = 0, Data = 1 };
+
+    enum class RoutineDataType : uint8_t
+    {
+        None = 0, Bool = 1, Int = 2, Float = 3, Vec3 = 4, String = 5, EntityRef = 6
+    };
+
+    // Enum BORNÉ ET VERSIONNÉ. Plages réservées par cible. Tout ajout se fait
+    // EN FIN de la plage concernée et, si le wire JSON change, bump
+    // kRoutineGraphVersion. Ne JAMAIS réordonner ni recycler une valeur.
+    enum class RoutineNodeType : uint16_t
+    {
+        // --- commun (0..99) ---
+        Comment              = 0,
+
+        // --- zone_event / Blueprint-like (100..199) — détaillé en M101.8 ---
+        EventOnZoneEnter     = 100,
+        EventOnZoneExit      = 101,
+        EventOnInteract      = 102,
+        BranchIf             = 120,
+        ActionOpenInteractive= 130,
+        ActionBroadcastSeason= 131,
+        ActionBroadcastWeather=132,
+
+        // --- npc_routine / StateTree-like (200..299) — détaillé en M101.7 ---
+        NpcStateRoot         = 200,
+        NpcState             = 201,
+        SensorPlayerInRange  = 210,   // « evaluator » : lit/calcule, ne déclenche pas
+        SensorTimeOfDay      = 211,
+        TaskPlayAnim         = 220,   // « task » : agit
+        TaskMoveTo           = 221,
+        TaskSetEmotion       = 222
+    };
+}
+```
+
+### Structures (gelées pour la v1)
+
+```cpp
+namespace engine::routine
+{
+    struct RoutineProperty
+    {
+        std::string      key;
+        RoutineDataType  type;
+        // Valeur portée selon `type` (un seul champ pertinent) :
+        bool             bValue   = false;
+        int64_t          iValue   = 0;
+        float            fValue   = 0.0f;
+        engine::math::Vec3 vValue { 0.0f, 0.0f, 0.0f };
+        std::string      sValue;     // String, ou id textuel pour EntityRef
+    };
+
+    struct RoutinePin
+    {
+        uint32_t        id;          // unique dans le graphe
+        PinDirection    direction;
+        PinKind         kind;
+        RoutineDataType dataType;    // pertinent si kind == Data ; None si Exec
+        std::string     name;
+    };
+
+    struct RoutineNode
+    {
+        uint32_t        id;          // unique dans le graphe
+        RoutineNodeType type;
+        float           canvasX;     // disposition éditeur uniquement
+        float           canvasY;
+        std::vector<RoutinePin>      pins;
+        std::vector<RoutineProperty> properties;
+    };
+
+    struct RoutineLink
+    {
+        uint32_t id;
+        uint32_t fromNodeId;
+        uint32_t fromPinId;
+        uint32_t toNodeId;
+        uint32_t toPinId;
+    };
+
+    struct RoutineGraph
+    {
+        uint32_t              version;   // == kRoutineGraphVersion à l'écriture
+        RoutineGraphKind      kind;
+        std::string           name;
+        std::vector<RoutineNode> nodes;
+        std::vector<RoutineLink> links;
+    };
+}
+```
+
+### Schéma de bornage (`RoutineNodeSchema`)
+
+Descripteur **statique** (table en dur, pas de données externes) qui décrit, pour
+chaque `RoutineNodeType` : les pins attendus (nom, direction, kind, dataType), les
+propriétés attendues, et l'ensemble des `RoutineGraphKind` où le type est valide.
+Sert la palette (M101.5) et la validation (M101.6).
+
+```cpp
+struct RoutineNodeSchema
+{
+    RoutineNodeType type;
+    const char*     displayName;
+    uint8_t         validKindsMask;   // bit RoutineGraphKind → autorisé
+    std::vector<RoutinePin>      pinTemplate;
+    std::vector<RoutineProperty> propertyTemplate;
+};
+
+// Accès : table immuable indexée par type.
+const RoutineNodeSchema* FindSchema(RoutineNodeType type);
+std::span<const RoutineNodeSchema> AllSchemas();
+```
+
+### Sérialisation JSON déterministe
+
+```cpp
+namespace engine::routine::serialization
+{
+    // Ordre de clés canonique, floats formatés de façon stable (même locale,
+    // même précision), nœuds triés par id croissant, liens triés par id.
+    std::string ToJson(const RoutineGraph& graph);
+
+    struct ParseError { std::string message; int nodeIndex = -1; };
+    std::optional<RoutineGraph> FromJson(std::string_view json, ParseError& outError);
+}
+```
+
+Schéma JSON (v1) :
+
+```json
+{
+  "version": 1,
+  "kind": "zone_event",
+  "name": "porte_taverne",
+  "nodes": [
+    { "id": 1, "type": "EventOnInteract", "x": 120.0, "y": 64.0,
+      "pins": [ { "id": 10, "dir": "out", "kind": "exec", "data": "none", "name": "fired" } ],
+      "props": [] }
+  ],
+  "links": [ { "id": 100, "from": [1, 10], "to": [2, 20] } ]
+}
+```
+
+**Invariant de déterminisme.** `FromJson(ToJson(g)) == g` (égalité champ à champ),
+et `ToJson(g)` est **stable** (octet pour octet) pour un même `g`. Garanti par
+l'ordre de clés fixe et le formatage float canonique. C'est le socle du round-trip
+de M101.3/M101.10.
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/shared/math/Math.h` (`engine::math::Vec3`) | **appelé en lecture** (type `Vec3` dans `RoutineProperty`/pins `Vec3`). |
+| Utilitaire JSON du projet (celui chargeant `config.json`) | **appelé en lecture** (parse/emit JSON). À identifier précisément à l'implémentation ; ne pas introduire de nouvelle dépendance tierce si une existe déjà. |
+| `src/client/world/ChunkPackageLayout.h` | **appelé en lecture seule** (référence : ce ticket NE le modifie PAS ; l'extension est en M101.3). |
+
+Aucun hook manquant pour ce ticket (lib pure et autonome).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/RoutineGraph.h` | Créer (enums + structs gelés). |
+| `src/shared/routine/RoutineNodeSchema.h` | Créer (descripteur). |
+| `src/shared/routine/RoutineNodeSchema.cpp` | Créer (table statique des schémas v1). |
+| `src/shared/routine/RoutineSerialization.h` | Créer (API ToJson/FromJson). |
+| `src/shared/routine/RoutineSerialization.cpp` | Créer (implémentation déterministe). |
+| `src/shared/routine/tests/RoutineSerializationTests.cpp` | Créer (round-trip + déterminisme). |
+| `src/CMakeLists.txt` | Modifier : nouvelle lib **`routine_graph`** (STATIC, pure) ; ajout aux cibles `engine_core` ET `server_app`/`engine_core_server` (le shard en a besoin pour M101.7) ; **interdit** à `routine_graph` de linker Vulkan/GLFW. Nouveau test `routine_serialization_tests`. |
+
+### Diff CMake (esquisse)
+
+```
+add_library(routine_graph STATIC
+    src/shared/routine/RoutineNodeSchema.cpp
+    src/shared/routine/RoutineSerialization.cpp
+)
+target_include_directories(routine_graph PUBLIC src)
+# routine_graph NE linke NI Vulkan NI GLFW (lib pure).
+
+target_link_libraries(engine_core PUBLIC routine_graph)
+target_link_libraries(server_app  PUBLIC routine_graph)   # shard : RoutineToEventAI (M101.7)
+
+add_executable(routine_serialization_tests src/shared/routine/tests/RoutineSerializationTests.cpp)
+target_link_libraries(routine_serialization_tests PRIVATE routine_graph)
+add_test(NAME routine_serialization_tests COMMAND routine_serialization_tests)
+```
+
+## Definition of Done
+
+Reprend `tickets/DEFINITION_OF_DONE.md`, **plus** :
+
+- [ ] CI Linux verte (configure + build + CTest, dont `routine_serialization_tests`).
+- [ ] CI Windows verte.
+- [ ] Test de round-trip headless passant : `FromJson(ToJson(g)) == g` et stabilité octet pour octet de `ToJson(g)`.
+- [ ] `RoutineNodeType` est commenté **borné/versionné** ; aucun ajout non documenté.
+- [ ] `routine_graph` ne linke ni Vulkan ni GLFW (vérifié dans CMake).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Déterminisme** : pas de `std::unordered_map` à l'écriture (ordre non
+  déterministe) ; trier explicitement par `id`. Formatage float canonique (éviter
+  les variations de locale ; utiliser un format fixe type `%.6g` ou équivalent
+  maison).
+- **Bornage** : ce ticket ne déclare qu'un **sous-ensemble** des types de nœuds,
+  suffisant pour tester le schéma et la sérialisation. Les bibliothèques complètes
+  (M101.7/8) **étendent la table `RoutineNodeSchema`** sans réordonner l'enum.
+- **Pureté** : aucune inclusion de header client/réseau ; `Vec3` vient de
+  `src/shared/math/Math.h` (déjà partagé). C'est la garantie que la VM (M101.2) et
+  le shard (M101.7) peuvent réutiliser ce modèle sans tirer Vulkan.
+- **Versioning** : `kRoutineGraphVersion = 1`. Toute évolution du wire JSON bump
+  cette constante ; `FromJson` doit rejeter proprement une version supérieure
+  inconnue (erreur, pas de crash).

--- a/tickets/M101/M101.10-RoundTripAndCiTests.md
+++ b/tickets/M101/M101.10-RoundTripAndCiTests.md
@@ -1,0 +1,112 @@
+# M101.10 — Round-trip & tests CI (headless, Linux + Windows)
+
+## Résumé
+
+Périmètre **strictement borné** : la **suite de tests de round-trip et de
+déterminisme** de bout en bout du cluster M101, exécutable **headless** (sans
+Vulkan/GLFW) en CI **Linux et Windows**. Vérifie qu'un graphe édité → écrit
+(`routines.bin`) → relu → réinterprété produit un **état identique**.
+
+## Dépendances
+
+- **M101.1** — Sérialisation JSON.
+- **M101.2** — VM (`ZoneEventVm`, `MockRoutineHost`).
+- **M101.3** — Segment `routines.bin` (writer + reader).
+
+## Portée
+
+### Inclus
+- Test end-to-end `RoutineRoundTrip` : `RoutineGraph` (construit en mémoire) →
+  `ToJson` → `WriteRoutines` → `ReadRoutines` → `FromJson` → **égalité** au graphe
+  d'origine.
+- Test `RoutineExecutionStability` : exécuter le graphe relu via `ZoneEventVm` +
+  `MockRoutineHost` produit **la même trace** que le graphe d'origine.
+- Test `RoutineSerializationStable` : `ToJson` est **stable octet pour octet**.
+- Intégration CI : les exécutables de test sont **headless** (aucun lien Vulkan),
+  enregistrés via `add_test` et lancés par `ctest` sur les deux OS.
+
+### Hors scope (formellement)
+- L'UI (testée en M101.4–6) ; les nœuds PNJ (M101.7, Blocked).
+- Tout test nécessitant un contexte de rendu.
+
+## Spécification fonctionnelle
+
+```cpp
+// Pseudo-structure des cas :
+TEST(RoutineRoundTrip, ZoneEventGraphIsIdenticalAfterDiskCycle) {
+    RoutineGraph g = MakeSampleZoneEventGraph();
+    // 1. JSON
+    std::string json = serialization::ToJson(g);
+    // 2. binaire
+    WriteRoutines(tmpDir, 0, 0, { g }, err);
+    LoadedRoutines loaded; ReadRoutines(ReadFile(tmpDir/...), loaded, err);
+    // 3. égalité
+    ASSERT_EQ(loaded.graphs.size(), 1u);
+    ASSERT_TRUE(GraphEquals(loaded.graphs[0], g));
+}
+
+TEST(RoutineExecutionStability, SameTraceBeforeAndAfterRoundTrip) {
+    RoutineGraph g = MakeSampleZoneEventGraph();
+    auto traceA = RunAndCaptureTrace(g);
+    auto g2 = RoundTrip(g);
+    auto traceB = RunAndCaptureTrace(g2);
+    ASSERT_EQ(traceA, traceB);
+}
+```
+
+`RunAndCaptureTrace` utilise un `MockRoutineHost` dont chaque méthode enregistre
+un appel ordonné (la trace). Déterminisme = traces identiques.
+
+## Code runtime référencé
+
+| Fichier réel | Statut |
+|--------------|--------|
+| `src/shared/routine/RoutineSerialization.h` (M101.1) | **appelé**. |
+| `src/shared/routine/vm/ZoneEventVm.h` + `MockRoutineHost.h` (M101.2) | **appelé**. |
+| `tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h` (`WriteRoutines`, M101.3) | **appelé**. |
+| `src/client/world/routine/RoutineSegmentReader.h` (M101.3) | **appelé**. |
+| `.github/workflows/build-linux.yml` (lance `ctest`) | **étendu** — les nouveaux tests sont déjà couverts si enregistrés via `add_test`. |
+| `.github/workflows/build-windows.yml` | **appelé en lecture** — build sans ctest ; ces tests devront être lancés explicitement si l'on veut leur exécution Windows. |
+
+> **Note CI (mémoire projet)** : `build-linux.yml` exécute `ctest` (avec
+> exclusions `-E`) ; `build-windows.yml` build **sans** ctest. Ce ticket doit
+> donc **soit** rendre les tests round-trip exécutables sur Windows via un step
+> dédié, **soit** documenter explicitement que la couverture round-trip Windows
+> passe par l'exécution locale + le build Windows vert. Attention au piège
+> `assert` + `NDEBUG` (un test reposant sur `assert` ne vérifie rien en Release).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/tests/RoutineRoundTripTests.cpp` | Créer (E2E, headless). |
+| `src/shared/routine/tests/RoutineTestFixtures.h` | Créer (`MakeSampleZoneEventGraph`, `GraphEquals`, `RunAndCaptureTrace`). |
+| `.github/workflows/build-windows.yml` | Modifier **si** on veut l'exécution round-trip sur Windows (step ctest ciblé). |
+| `src/CMakeLists.txt` | Modifier : test `routine_roundtrip_tests` (linke `routine_graph` + `routine_vm` + `zone_builder` + reader client ; **pas** de Vulkan) ; `add_test`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte : `routine_roundtrip_tests` exécuté par `ctest`, vert.
+- [ ] CI Windows verte (build) ; exécution round-trip Windows assurée par un step
+      dédié **ou** documentée comme couverte par build + run local.
+- [ ] `FromJson(ToJson(g)) == g`, round-trip binaire `Write→Read` identique, et
+      traces d'exécution identiques avant/après round-trip.
+- [ ] `ToJson` stable octet pour octet (anti-régression de déterminisme).
+- [ ] Tests **headless** : aucun lien Vulkan/GLFW dans les exécutables de test.
+- [ ] Pas de dépendance à `assert` pour les invariants vérifiés (robuste en Release).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Headless = pas de Vulkan.** Les exécutables ne linkent que les libs pures
+  (`routine_graph`, `routine_vm`) + `zone_builder` + le reader client (qui ne doit
+  pas exiger un device GPU pour lire un fichier). Si le reader client tire une
+  dépendance GPU, l'isoler dans une fonction pure de parsing testable.
+- **Trace déterministe** : la trace `MockRoutineHost` est la preuve d'égalité
+  d'exécution la plus robuste (indépendante du rendu).
+- **Le piège Windows/ctest** : le build Windows ne lance pas ctest par défaut ;
+  trancher explicitement (step dédié vs run local documenté) pour que la DoD
+  « round-trip Windows » soit honnête.
+- **Déploiement** : ✅ client/éditeur/CI uniquement.

--- a/tickets/M101/M101.11-DocsAndTooltips.md
+++ b/tickets/M101/M101.11-DocsAndTooltips.md
@@ -1,0 +1,106 @@
+# M101.11 — Documentation F1 + tooltips
+
+## Résumé
+
+Périmètre **strictement borné** : intégrer la documentation contextuelle de
+l'éditeur de routines au système d'aide **existant** (M100.47) — tooltips riches
+sur les nœuds/pins de la palette et de l'inspecteur, et page d'aide F1 dédiée.
+**Réutilise** `HelpContentStore` + `RichTooltipWidget` ; ne crée pas de second
+système d'aide.
+
+## Dépendances
+
+- **M101.4** — Panneau nodal.
+- **M101.5** — Palette + inspecteur (cibles des tooltips).
+- **M100.47** — Tooltips & F1 Doc (**Draft**) : `HelpContentStore` +
+  `RichTooltipWidget` (infra d'aide réutilisée).
+
+## Portée
+
+### Inclus
+- Contenu d'aide par `RoutineNodeType` (rôle, pins, propriétés, cible
+  `RoutineGraphKind`), enregistré dans `HelpContentStore`.
+- Tooltips riches au survol d'un nœud dans la palette et dans le canvas, et au
+  survol d'un champ de l'inspecteur (via `RichTooltipWidget`).
+- Page F1 « Éditeur de routines » : concepts (graphe, pins exec/data, Event,
+  validation), et la distinction des deux cibles (`npc_routine` / `zone_event`).
+- Textes **localisables** (clés de string table, pas de texte codé en dur).
+
+### Hors scope (formellement)
+- La création d'un nouveau système d'aide (interdit — réutiliser M100.47).
+- Un tutoriel interactif (relève de M100.49, hors cluster M101).
+- La documentation des nœuds PNJ bloqués au-delà de la mention de leur statut
+  `Blocked`.
+
+## Spécification fonctionnelle
+
+```cpp
+// Enregistrement (au boot de l'éditeur, après HelpContentStore prêt) :
+void RegisterRoutineHelpContent(HelpContentStore& store);
+// → pour chaque RoutineNodeType, une entrée { titleKey, bodyKey, pinHelp[] }.
+
+// Tooltip : la palette/inspecteur appellent RichTooltipWidget avec la clé
+// d'aide du type de nœud survolé.
+```
+
+Page F1 (contenu textuel, localisé) :
+
+```
+[F1] Éditeur de routines
+ 1. Qu'est-ce qu'une routine ? (graphe de nœuds data-driven, interprété au runtime)
+ 2. Pins d'exécution (flux) vs pins de données (valeurs typées)
+ 3. Nœuds Event = points de départ
+ 4. Deux cibles : zone_event (gameplay de zone) / npc_routine (PNJ, via EventAI)
+ 5. Valider un graphe (cycles, pins, orphelins) → ConsolePanel
+ 6. Tester en Playtest (F5)
+```
+
+## Code runtime référencé
+
+| Fichier réel | Statut |
+|--------------|--------|
+| `HelpContentStore` (M100.47) | **appelé / étendu** — enregistrement du contenu routines. |
+| `RichTooltipWidget` (M100.47) | **appelé** — rendu des tooltips. |
+| `src/world_editor/routine/RoutineNodePalette.cpp` + `RoutineNodeInspector.cpp` (M101.5) | **étendus** — déclenchent les tooltips. |
+| `src/shared/routine/RoutineNodeSchema.h` (M101.1) | **appelé en lecture** — `displayName` + énumération des types pour générer les entrées d'aide. |
+| Système de string tables / localization (M42.1) | **appelé** — clés de texte localisables. |
+
+> **Dépendance Draft** : M100.47 est en `Draft` ; M101.11 reste `Draft` et se
+> séquence après. Si `HelpContentStore`/`RichTooltipWidget` ne sont pas encore
+> livrés au moment d'implémenter, ce ticket passe **Blocked** avec raison
+> documentée (hook d'aide manquant).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/world_editor/routine/RoutineHelpContent.h/.cpp` | Créer (enregistrement du contenu). |
+| `src/world_editor/routine/RoutineNodePalette.cpp` / `RoutineNodeInspector.cpp` | Modifier (déclenchement tooltips). |
+| `game/data/localization/...` (clés routines) | Ajouter (contenu localisé, sous `paths.content`). |
+| `src/world_editor/routine/tests/RoutineHelpContentTests.cpp` | Créer (chaque `RoutineNodeType` a une entrée d'aide). |
+| `src/CMakeLists.txt` | Modifier : source → `engine_core` ; test `routine_help_content_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (dont `routine_help_content_tests`).
+- [ ] CI Windows verte.
+- [ ] Test headless : chaque `RoutineNodeType` exposé dans la palette possède une
+      entrée d'aide (titre + corps) ; aucune clé manquante.
+- [ ] Tous les textes passent par la string table (aucun texte codé en dur,
+      vérifié).
+- [ ] L'aide réutilise `HelpContentStore`/`RichTooltipWidget` (aucun second
+      système d'aide créé).
+- [ ] Contenu sous `game/data/` via `paths.content` (aucun chemin absolu).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Réutilisation stricte** de l'infra M100.47 ; M101.11 n'apporte que du
+  **contenu** + le câblage des tooltips, pas un nouveau moteur d'aide.
+- **Localisation** : clés de string table, pas de littéraux français dans le code
+  (cf. M42.1 / convention multilang du dépôt).
+- **Source de vérité** : générer les entrées d'aide à partir de
+  `RoutineNodeSchema` pour éviter la dérive entre l'UI et la doc.
+- **Déploiement** : ✅ client/éditeur uniquement.

--- a/tickets/M101/M101.2-DeterministicRoutineVm.md
+++ b/tickets/M101/M101.2-DeterministicRoutineVm.md
@@ -1,0 +1,175 @@
+# M101.2 — VM d'interprétation déterministe (lib pure `routine_vm`)
+
+## Résumé
+
+Périmètre **strictement borné** : implémenter la **machine virtuelle**
+d'interprétation des graphes de routine, sous forme de **lib pure** `routine_vm`
+(aucune dépendance Vulkan/GLFW/réseau, **ne linke pas la cible serveur depuis
+`engine_core`**). Deux évaluateurs distincts (un par `RoutineGraphKind`) :
+
+- **`ZoneEventVm`** — interprète les graphes `zone_event` (data-flow façon
+  Blueprint : un nœud Event racine déclenché, flux d'exécution le long des
+  *exec wires*, pins de données évalués à la demande). Exécution **cliente**.
+- **`NpcRoutineEvaluator`** — **traduit** un graphe `npc_routine` en une liste
+  d'`EventAIRow` consommables par l'`EventAIRuntime` shard existant (cible A,
+  décision actée 2026-06-03). La VM hiérarchique « live » StateTree + utilité
+  reste **hors scope** ici (dépend de l'infra PNJ absente — voir M101.7).
+
+**Évaluation déterministe** : mêmes entrées → même sortie, aucune horloge murale,
+aucun RNG non-seedé. C'est le socle du round-trip et des tests CI sans rendu.
+
+## Dépendances
+
+- **M101.1** — Modèle de graphe & sérialisation (structs, enums, schéma).
+- `src/shardd/ai/EventAI.h` (structs `EventAIRow`/`EventTrigger`/`EventAction`)
+  pour la cible de traduction de `NpcRoutineEvaluator`.
+
+## Portée
+
+### Inclus
+- Interface d'hôte abstraite `IRoutineHost` (le pont vers le monde réel : ouvrir
+  un objet interactif, interroger une surface, lire l'heure in-game, etc.). La VM
+  appelle l'hôte ; elle ne connaît **rien** du rendu ni du réseau.
+- `ZoneEventVm` : moteur data-flow déterministe pour `zone_event`.
+- `NpcRoutineEvaluator` : traducteur `npc_routine` → `std::vector<EventAIRow>`.
+- Contexte d'exécution `RoutineRunContext` (entrées : temps logique fourni,
+  paramètres d'événement) — **pas** d'accès direct au temps système.
+- Hôte de test `MockRoutineHost` (pour CI headless).
+
+### Hors scope (formellement)
+- L'UI nodale (M101.4–6).
+- Les bibliothèques de nœuds concrètes et leur sémantique métier (M101.7/8) — ce
+  ticket fournit le **moteur** ; les nœuds branchent leurs effets via `IRoutineHost`.
+- La VM StateTree hiérarchique « live » avec sélection par utilité et tick rate
+  AI-LOD (reste un objectif **futur**, posé dans M101.7 ; bloqué par l'absence de
+  Role Registry / Smart Objects).
+- Le chargement disque (`routines.bin` → M101.3).
+
+## Spécification fonctionnelle
+
+### Interface d'hôte (frontière de pureté)
+
+```cpp
+namespace engine::routine::vm
+{
+    // La VM ne dépend QUE de cette interface. Le client de prod l'implémente
+    // (M101.8/9) ; les tests fournissent un MockRoutineHost. Aucun appel à du
+    // code Vulkan/GLFW/réseau depuis la VM.
+    class IRoutineHost
+    {
+    public:
+        virtual ~IRoutineHost() = default;
+
+        // --- capteurs (lecture) ---
+        virtual float    GetTimeOfDayHours() const = 0;       // 0..24, fourni, jamais l'horloge système
+        virtual bool     IsPlayerInRange(uint64_t entityId, float meters) const = 0;
+
+        // --- actions (effets) ---
+        virtual void     OpenInteractive(uint64_t interactiveId, bool open) = 0;
+        virtual void     BroadcastSeason(int seasonIndex) = 0;
+        virtual void     BroadcastWeather(int weatherIndex) = 0;
+
+        // --- journalisation déterministe (trace, pour M101.6/10) ---
+        virtual void     Trace(std::string_view nodeLabel) {}
+    };
+}
+```
+
+### `ZoneEventVm` (data-flow, cible B)
+
+```cpp
+struct RoutineRunContext
+{
+    double  logicalTimeMs = 0.0;   // temps LOGIQUE fourni par l'appelant (déterministe)
+    uint64_t eventEntityId = 0;    // entité ayant déclenché l'Event (zone enter, interact…)
+};
+
+class ZoneEventVm
+{
+public:
+    explicit ZoneEventVm(const RoutineGraph& graph);   // exige kind == ZoneEvent
+
+    // Déclenche l'exécution à partir du nœud Event correspondant.
+    // Le flux suit les exec wires ; les pins Data sont évalués en pull.
+    // Retourne false si aucun nœud Event de ce type n'existe.
+    bool Fire(RoutineNodeType eventType, const RoutineRunContext& ctx, IRoutineHost& host);
+};
+```
+
+Règles d'exécution (déterministes) :
+1. Le point d'entrée est un nœud `Event*` (pas de pin Exec d'entrée).
+2. On suit le pin Exec de sortie déclenché vers le nœud cible, et ainsi de suite.
+3. Quand un nœud a besoin d'une valeur (pin Data d'entrée), on **évalue en pull**
+   le sous-graphe data en amont (pas d'effet de bord, idempotent).
+4. `BranchIf` choisit son exec de sortie selon un pin Data `Bool`.
+5. Garde-fou : profondeur d'exécution bornée (anti-boucle) ; un graphe cyclique
+   sur les exec wires est **rejeté à la validation** (M101.6), pas exécuté.
+
+### `NpcRoutineEvaluator` (traduction → EventAI, cible A)
+
+```cpp
+class NpcRoutineEvaluator
+{
+public:
+    explicit NpcRoutineEvaluator(const RoutineGraph& graph); // exige kind == NpcRoutine
+
+    // Traduit le graphe en lignes EventAI consommables par EventAIRuntime (shard).
+    // Mapping documenté en M101.7. Déterministe (ordre stable).
+    std::vector<engine::shard::ai::EventAIRow> ToEventAIRows(std::string& outWarnings) const;
+};
+```
+
+> **Note cible A.** Conformément à la décision du 2026-06-03, la cible PNJ passe
+> par une **traduction** vers `EventAIRow` (réutilisation de l'IA shard existante),
+> **pas** par une seconde IA. Le mapping nœud → `EventAIRow` est spécifié en
+> M101.7 (`Blocked` pour les nœuds qui exigent Role Registry / Smart Objects).
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/shared/routine/RoutineGraph.h` (M101.1) | **étendu** conceptuellement (consommé) ; non modifié. |
+| `src/shardd/ai/EventAI.h` (`EventAIRow`, `EventTrigger`, `EventAction`) | **appelé en lecture** (cible de traduction de `NpcRoutineEvaluator`). |
+| `src/shardd/ai/EventAIRuntime.h` | **appelé en lecture** (consommateur final des `EventAIRow` ; non modifié ici, branché en M101.7). |
+| `src/client/gameplay/CharacterController.h`, `src/client/world/surface/SurfaceQueryService.h`, `src/client/world/interactive/InteractiveSimulator.h` (M100.32) | **non appelés directement** — accédés **via `IRoutineHost`** implémenté par le client en M101.8/9 (frontière de pureté). |
+
+Aucun hook manquant : la VM ne dépend que de `IRoutineHost`, dont
+l'implémentation concrète est fournie par les tickets aval.
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/vm/IRoutineHost.h` | Créer (interface abstraite). |
+| `src/shared/routine/vm/ZoneEventVm.h/.cpp` | Créer (moteur data-flow). |
+| `src/shared/routine/vm/NpcRoutineEvaluator.h/.cpp` | Créer (traducteur → EventAIRow). |
+| `src/shared/routine/vm/MockRoutineHost.h` | Créer (hôte de test, header-only). |
+| `src/shared/routine/vm/tests/RoutineVmTests.cpp` | Créer (exécution + déterminisme). |
+| `src/CMakeLists.txt` | Modifier : nouvelle lib **`routine_vm`** (STATIC, pure, dépend de `routine_graph`) ; ajoutée à `engine_core` ; **interdit** de linker Vulkan/GLFW. Le shard linke `routine_graph` (traducteur), pas nécessairement `routine_vm`. Nouveau test `routine_vm_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (configure + build + CTest dont `routine_vm_tests`).
+- [ ] CI Windows verte.
+- [ ] Test de round-trip / déterminisme : `Test_Vm_Deterministic_SameInputSameOutput` (deux exécutions du même graphe avec le même `RoutineRunContext` produisent une trace `IRoutineHost` identique).
+- [ ] `routine_vm` ne linke ni Vulkan ni GLFW ; `engine_core` ne linke pas la cible serveur via `routine_vm`.
+- [ ] Garde-fou anti-boucle vérifié (un graphe à exec cyclique est refusé/borné, pas de boucle infinie).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Frontière de pureté = `IRoutineHost`.** C'est l'invariant central : la VM ne
+  `#include` aucun header de rendu/réseau. Toute interaction avec le monde passe
+  par l'hôte. C'est ce qui permet le test headless en CI.
+- **Pas de temps système.** Le temps est **fourni** via `RoutineRunContext` /
+  `IRoutineHost::GetTimeOfDayHours()`. Aucun `std::chrono::now()` dans la VM
+  (casserait le déterminisme et le round-trip).
+- **Pas de RNG non-seedé.** Si un nœud futur a besoin d'aléa, la graine vient du
+  contexte (déterministe).
+- **Pas de `engine_sim`.** Cette lib **n'existe pas** dans le dépôt ; la VM est
+  autonome (ne pas s'appuyer sur une référence fantôme du prompt directeur).
+- **Cible A = traduction, pas tick.** Garder `NpcRoutineEvaluator` comme un
+  compilateur graphe → `EventAIRow`. La VM hiérarchique live est un objectif futur
+  (M101.7), explicitement bloqué par l'absence d'infra PNJ.

--- a/tickets/M101/M101.3-RoutinesChunkSegment.md
+++ b/tickets/M101/M101.3-RoutinesChunkSegment.md
@@ -1,0 +1,169 @@
+# M101.3 — Segment de chunk `routines.bin` (extension additive)
+
+## Résumé
+
+Périmètre **strictement borné** : ajouter un **nouveau segment de chunk
+versionné** `routines.bin` au format de package, **par extension additive
+uniquement** — sans modifier ni réordonner aucun segment existant. Côté éditeur :
+writer dans la lib `zone_builder`. Côté client : reader dans le chemin de
+streaming. **Round-trip test obligatoire** (graphe édité → écrit → relu →
+désérialisé = égal).
+
+## Dépendances
+
+- **M101.1** — Modèle de graphe & sérialisation JSON (`ToJson`/`FromJson`).
+- **M100.3** — Zone Builder Library Extraction (**Done**) : la lib `zone_builder`
+  et `ChunkPackageWriter` existent déjà.
+
+## Portée
+
+### Inclus
+- Extension **additive** de `enum class ChunkSegment` : ajout de `Routines` **en
+  fin** (valeur 7), `kChunkSegmentCount` passe de 7 à 8.
+- Nouveau flag `kChunkMetaHasRoutines = 1u << 7` (les bits 0..6 sont déjà pris).
+- Format binaire `routines.bin` (en-tête versionné + N graphes encodés en JSON
+  canonique length-prefixé).
+- Writer `ChunkPackageWriter::WriteRoutines(...)`.
+- Reader client `RoutineSegmentReader` + branchement `StreamCache::LoadRoutines`.
+- Round-trip test bloquant.
+
+### Hors scope (formellement)
+- L'UI d'édition (M101.4–6) ; l'exécution (M101.2/8/9).
+- Toute modification d'un segment existant (interdit).
+- L'orchestrateur d'export global (M100.34 — une note de compat y sera ajoutée
+  quand ce ticket sera Ready).
+
+## Spécification fonctionnelle
+
+### État ACTUEL vérifié de `ChunkPackageLayout.h`
+
+```cpp
+// AVANT (existant — NE PAS RÉORDONNER) :
+enum class ChunkSegment : uint8_t {
+    Geo = 0, Terrain = 1, Splat = 2, Tex = 3, Instances = 4, Nav = 5, Probes = 6
+};
+inline constexpr int kChunkSegmentCount = 7;
+
+// flags déjà utilisés (bits 0..6) :
+// kChunkMetaHasGeo=1<<0, HasTex=1<<1, HasInstances=1<<2, HasNav=1<<3,
+// HasProbes=1<<4, HasTerrain=1<<5, HasSplat=1<<6
+```
+
+### Extension additive (APRÈS)
+
+```cpp
+enum class ChunkSegment : uint8_t {
+    Geo = 0, Terrain = 1, Splat = 2, Tex = 3, Instances = 4, Nav = 5, Probes = 6,
+    Routines = 7            // AJOUT EN FIN — ne décale aucun segment existant
+};
+inline constexpr int kChunkSegmentCount = 8;   // 7 → 8
+
+// AJOUT (bits 0..6 déjà pris ; bit 7 libre) :
+inline constexpr uint32_t kChunkMetaHasRoutines = 1u << 7;
+```
+
+> **Correction par rapport au prompt directeur.** Le prompt indiquait
+> `kChunkMetaHasRoutines = 1u << 5` ; **faux** : le bit 5 est déjà
+> `kChunkMetaHasTerrain` et le bit 6 `kChunkMetaHasSplat`. Le premier bit libre
+> est **`1u << 7`**. Vérifié dans `src/client/world/ChunkPackageLayout.h`.
+
+### Constantes & layout `routines.bin`
+
+```cpp
+constexpr uint32_t kRoutinesMagic   = 0x4E545552u; // "RUTN"
+constexpr uint32_t kRoutinesVersion = 1u;
+```
+
+```
+[0..23]   OutputVersionHeader (même en-tête 24 octets que les autres segments)
+[24..27]  uint32 magic   == kRoutinesMagic
+[28..31]  uint32 version == kRoutinesVersion
+[32..35]  uint32 graphCount
+
+Pour chaque graphe :
+  [8]    uint64 graphId
+  [1]    uint8  kind            (RoutineGraphKind : 0=NpcRoutine, 1=ZoneEvent)
+  [4]    uint32 jsonByteLen
+  [N]    bytes  jsonUtf8        (JSON CANONIQUE produit par M101.1 ToJson)
+```
+
+**Choix d'encodage.** Le corps de chaque graphe est le **JSON canonique** de
+M101.1 (length-prefixé). On réutilise ainsi la sérialisation déjà testée et
+déterministe : pas de second encodeur binaire à maintenir, round-trip garanti par
+construction (`FromJson(ToJson(g)) == g`).
+
+### Writer (éditeur / zone_builder)
+
+```cpp
+// dans ChunkPackageWriter
+bool WriteRoutines(const std::string& outputRootDir,
+                   int chunkX, int chunkZ,
+                   const std::vector<engine::routine::RoutineGraph>& graphs,
+                   std::string& outError);
+```
+Met aussi à jour `ChunkMeta::flags |= kChunkMetaHasRoutines` quand au moins un
+graphe est présent.
+
+### Reader (client)
+
+```cpp
+// src/client/world/routine/RoutineSegmentReader.h
+namespace engine::world::routine
+{
+    struct LoadedRoutines { std::vector<engine::routine::RoutineGraph> graphs; };
+
+    bool ReadRoutines(std::span<const uint8_t> bytes, LoadedRoutines& out, std::string& err);
+}
+```
+Branché dans `StreamCache` : `LoadRoutines(chunkX, chunkZ)` n'est appelé que si
+`ChunkMeta::flags & kChunkMetaHasRoutines`. Rétro-compatibilité : un chunk
+**sans** segment Routines (paquet ancien) se charge normalement (flag à 0).
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/client/world/ChunkPackageLayout.h` | **étendu** (ajout `ChunkSegment::Routines`, `kChunkSegmentCount`, `kChunkMetaHasRoutines`). Additif strict. |
+| `tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h` (+ `.cpp` associé) | **étendu** (nouvelle fonction `WriteRoutines`). Chemin réel corrigé. |
+| `src/client/world/StreamCache.h/.cpp` | **étendu** (nouveau `LoadRoutines`, gardé par le flag). |
+| `src/client/world/StreamingScheduler.h` | **appelé en lecture** (le segment Routines suit le même chemin de priorité que les autres). |
+| `src/shared/routine/RoutineSerialization.h` (M101.1) | **appelé en lecture** (`ToJson`/`FromJson`). |
+
+Aucun hook manquant.
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/client/world/ChunkPackageLayout.h` | Modifier (extension additive). |
+| `tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h` | Modifier (déclaration `WriteRoutines`). |
+| `tools/zone_builder/lib/.../ChunkPackageWriter.cpp` | Modifier (implémentation). |
+| `src/client/world/routine/RoutineSegmentReader.h/.cpp` | Créer. |
+| `src/client/world/StreamCache.h/.cpp` | Modifier (`LoadRoutines`). |
+| `src/client/world/routine/tests/RoutinesSegmentTests.cpp` | Créer (round-trip binaire). |
+| `src/CMakeLists.txt` | Modifier : `RoutineSegmentReader.cpp` → `engine_core` ; `WriteRoutines` dans la lib `zone_builder` ; nouveau test `routines_segment_tests` (linke `engine_core` + `zone_builder` + `routine_graph`). |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (configure + build + CTest dont `routines_segment_tests`).
+- [ ] CI Windows verte.
+- [ ] Test de round-trip éditeur→client passant (headless) : `WriteRoutines` →
+      `ReadRoutines` → graphes **égaux** aux graphes d'origine.
+- [ ] Aucun segment existant réordonné ni modifié (vérifié par diff sur l'enum).
+- [ ] Un paquet **sans** segment Routines se charge sans erreur (rétro-compat).
+- [ ] `kChunkMetaHasRoutines == (1u << 7)` (pas `1u << 5`).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Additif uniquement.** Ne jamais réordonner `ChunkSegment` : des paquets déjà
+  produits par l'éditeur seraient cassés. Ajout strict en fin.
+- **Round-trip = JSON canonique.** En stockant le JSON canonique de M101.1, le
+  round-trip binaire se ramène au round-trip JSON déjà couvert par M101.1 ; le
+  test ici vérifie en plus l'en-tête, le `graphCount` et le length-prefix.
+- **Gardé par flag.** Le reader ne tente la lecture que si
+  `kChunkMetaHasRoutines` est set, ce qui préserve la compatibilité ascendante.
+- **Déploiement** : ✅ client/éditeur uniquement (le serveur ne lit pas
+  `routines.bin` ; la cible PNJ passe par M101.7 côté shard, pas par ce segment).

--- a/tickets/M101/M101.4-NodalCanvasPanel.md
+++ b/tickets/M101/M101.4-NodalCanvasPanel.md
@@ -1,0 +1,160 @@
+# M101.4 — Panneau nodal dockable (canvas, pan/zoom, CRUD)
+
+## Résumé
+
+Périmètre **strictement borné** : un panneau ImGui **dockable** `RoutineGraphPanel`
+(implémente `IPanel`) affichant un **canvas nodal** (pan/zoom, grille), avec
+création/suppression/déplacement de nœuds et tracé/suppression de liens à la
+souris. Toutes les éditions passent par le **`CommandStack` existant** (undo/redo).
+**Canvas custom ImGui** (DrawList), sans dépendance tierce de node-editor.
+
+## Dépendances
+
+- **M101.1** — Modèle de graphe (structs édités par le panneau).
+- **M100.1** — World Editor Bootstrap (**Done**) : shell + `IPanel` +
+  enregistrement de panneaux dans `WorldEditorShell`.
+- **M100.2** — Command Stack & Undo/Redo (**Done**).
+
+## Portée
+
+### Inclus
+- `RoutineGraphPanel : public engine::editor::world::IPanel`.
+- Canvas : pan (drag milieu/espace), zoom (molette), grille de fond, rendu des
+  nœuds (boîtes + pins) et des liens (courbes de Bézier) via `ImDrawList`.
+- Interactions : sélection nœud, déplacement (drag), création de lien (drag
+  pin→pin), suppression (Suppr) de nœud/lien sélectionné.
+- Commandes undo/redo : `AddNodeCommand`, `RemoveNodeCommand`, `MoveNodeCommand`,
+  `AddLinkCommand`, `RemoveLinkCommand` (toutes via `CommandStack`).
+- Document d'édition `RoutineGraphDocument` (détient le `RoutineGraph` courant +
+  l'état de sélection éditeur).
+
+### Hors scope (formellement)
+- La palette de création et l'inspecteur de propriétés (→ M101.5).
+- La validation visuelle des erreurs (→ M101.6).
+- La sémantique d'exécution (→ M101.2/7/8).
+- Le chargement/sauvegarde disque (→ M101.3 ; l'orchestration d'export est M100.34).
+
+## Spécification fonctionnelle
+
+### Layout textuel du panneau
+
+```
+┌─ Routines ───────────────────────────────────────────────┐
+│ [Graphe: porte_taverne ▼]   Type: zone_event    [+ Nœud]  │   ← barre (palette en M101.5)
+│ ······························· grille ····················│
+│        ┌──────────────┐            ┌──────────────┐       │
+│        │ EventOnInteract│●───────●│ BranchIf       │       │   ● = pin exec
+│        │            fired│         │cond ○    true ●│──● …  │   ○ = pin data
+│        └──────────────┘            └──────────────┘       │
+│ (pan: drag milieu | zoom: molette | suppr: Suppr)         │
+└───────────────────────────────────────────────────────────┘
+```
+
+### Document & état
+
+```cpp
+namespace engine::editor::world
+{
+    struct RoutineGraphDocument
+    {
+        engine::routine::RoutineGraph graph;     // M101.1
+        uint32_t selectedNodeId = 0;             // 0 = aucun
+        uint32_t selectedLinkId = 0;
+        // transform canvas
+        engine::math::Vec3 panOffset{0,0,0};     // x,y utilisés
+        float zoom = 1.0f;                       // 0.25 .. 2.0
+        // allocation d'id monotone (déterministe par session d'édition)
+        uint32_t nextNodeId = 1;
+        uint32_t nextLinkId = 1;
+        uint32_t nextPinId  = 1;
+    };
+
+    class RoutineGraphPanel : public IPanel
+    {
+    public:
+        RoutineGraphPanel(RoutineGraphDocument& doc, CommandStack& undo);
+        const char* GetName() const override { return "Routines"; }
+        void Render() override;
+        bool IsVisible() const override { return m_visible; }
+        void SetVisible(bool v) override { m_visible = v; }
+    private:
+        RoutineGraphDocument& m_doc;
+        CommandStack&         m_undo;
+        bool                  m_visible = false;
+    };
+}
+```
+
+### Commandes (undo/redo)
+
+Chaque commande implémente l'interface du `CommandStack` (M100.2) avec
+`Apply()`/`Undo()` symétriques. Exemple :
+
+```cpp
+class AddNodeCommand : public ICommand
+{
+public:
+    AddNodeCommand(RoutineGraphDocument& doc, engine::routine::RoutineNode node);
+    void Apply() override;   // insère le nœud, sélectionne
+    void Undo() override;    // retire le nœud (et les liens incidents), restaure sélection
+private:
+    RoutineGraphDocument& m_doc;
+    engine::routine::RoutineNode m_node;
+    std::vector<engine::routine::RoutineLink> m_removedLinks; // pour Undo de RemoveNode
+};
+```
+
+`RemoveNodeCommand` mémorise les liens incidents supprimés pour les restaurer à
+l'undo. `MoveNodeCommand` mémorise l'ancienne et la nouvelle position (coalescence
+possible pendant un drag continu, commit au relâchement).
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/world_editor/core/IPanel.h` | **étendu** (nouvelle implémentation `RoutineGraphPanel`). |
+| `src/world_editor/core/CommandStack.h` | **appelé** (push des commandes d'édition de graphe). |
+| `src/world_editor/core/WorldEditorShell.h/.cpp` | **étendu** (enregistrement + toggle du panneau, comme `OutlinerPanel`/`ConsolePanel`). |
+| `src/world_editor/panels/OutlinerPanel.h`, `panels/HistoryPanel.h` | **appelés en lecture** (modèles d'implémentation d'`IPanel` existants à suivre). |
+| `src/shared/routine/RoutineGraph.h` (M101.1) | **appelé** (modèle édité). |
+
+Aucun hook manquant.
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/world_editor/routine/RoutineGraphDocument.h` | Créer. |
+| `src/world_editor/routine/RoutineGraphPanel.h/.cpp` | Créer (canvas + interactions). |
+| `src/world_editor/routine/RoutineGraphCommands.h/.cpp` | Créer (commandes undo/redo). |
+| `src/world_editor/core/WorldEditorShell.cpp` | Modifier (enregistrer le panneau + raccourci de toggle). |
+| `src/world_editor/routine/tests/RoutineGraphCommandsTests.cpp` | Créer (apply/undo symétriques). |
+| `src/CMakeLists.txt` | Modifier : sources `routine/*.cpp` → `engine_core` ; nouveau test `routine_graph_commands_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (configure + build + CTest dont `routine_graph_commands_tests`).
+- [ ] CI Windows verte.
+- [ ] Test headless : pour chaque commande, `Apply()` puis `Undo()` ramène le
+      document à l'état initial (égalité du `RoutineGraph` via M101.1).
+- [ ] Le panneau s'ancre dans le shell et se toggle comme les autres `IPanel`.
+- [ ] Aucune passe de rendu Vulkan ajoutée (canvas = `ImDrawList` ImGui pur).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Canvas custom, pas de dépendance tierce.** Le canvas est dessiné via
+  `ImGui::GetWindowDrawList()` (lignes, courbes de Bézier pour les liens, boîtes
+  pour les nœuds). Aucun vendoring d'`ImNodes` — contrôle total, cohérent avec le
+  shell ImGui M43.4/M100.1. Décision posée dans `INDEX.md`.
+- **Ids déterministes** : allocation monotone par document ; ne pas réutiliser un
+  id libéré dans la même session (simplifie l'undo).
+- **Undo/redo intégral** : toute mutation du graphe passe par le `CommandStack` ;
+  aucune édition « directe » du `RoutineGraph` hors commande (sinon l'historique
+  diverge — cf. `HistoryPanel`).
+- **Coalescence du drag** : pendant un déplacement de nœud, mettre à jour la
+  position en direct mais ne pousser le `MoveNodeCommand` qu'au relâchement, pour
+  ne pas saturer l'historique.
+- **Déploiement** : ✅ client/éditeur uniquement.

--- a/tickets/M101/M101.5-NodePaletteAndInspector.md
+++ b/tickets/M101/M101.5-NodePaletteAndInspector.md
@@ -1,0 +1,142 @@
+# M101.5 — Palette de nœuds + inspecteur de propriétés
+
+## Résumé
+
+Périmètre **strictement borné** : une **palette** de nœuds (liste filtrée par
+`RoutineGraphKind`, créée à partir de `RoutineNodeSchema` de M101.1) pour
+instancier des nœuds dans le canvas, et un **inspecteur** de propriétés du nœud
+sélectionné (édition typée des `RoutineProperty` selon le schéma). Les deux sont
+**schema-driven** : aucun type de nœud n'est codé en dur dans l'UI.
+
+## Dépendances
+
+- **M101.1** — `RoutineNodeSchema` + structs.
+- **M101.4** — `RoutineGraphPanel`/`RoutineGraphDocument` + `CommandStack`.
+- **M100.1** — `InspectorPanel` existant (modèle d'inspecteur à suivre).
+
+## Portée
+
+### Inclus
+- Palette : `AllSchemas()` filtrée par `validKindsMask` selon le `kind` du graphe
+  courant ; recherche texte ; insertion d'un nœud (via `AddNodeCommand` de M101.4)
+  avec pins et propriétés **clonés depuis le `pinTemplate`/`propertyTemplate`** du
+  schéma.
+- Inspecteur : pour le nœud sélectionné, rend un champ d'édition **par propriété**
+  adapté à `RoutineDataType` (checkbox/Bool, drag int/Int, drag float/Float,
+  3×float/Vec3, input text/String, combo d'entités/EntityRef). Toute édition passe
+  par une `SetNodePropertyCommand` (undo/redo).
+- Réutilisation/extension du `InspectorPanel` existant **ou** sous-vue dédiée
+  (au choix de l'implémentation, sans casser l'`InspectorPanel` actuel).
+
+### Hors scope (formellement)
+- La validation des erreurs (→ M101.6).
+- Le contenu métier des nœuds PNJ/zone (→ M101.7/8) — la palette affiche ce que la
+  table de schémas déclare ; les bibliothèques aval **étendent la table**, pas l'UI.
+- Tout widget de prévisualisation d'exécution.
+
+## Spécification fonctionnelle
+
+### Layout textuel
+
+```
+Palette (sous-panneau gauche)        Inspecteur (sous-panneau droit)
+┌─ Nœuds (zone_event) ─────┐         ┌─ Nœud sélectionné ───────────┐
+│ [recherche…]             │         │ Type : ActionOpenInteractive │
+│ ▸ Événements             │         │ ──────────────────────────── │
+│   • EventOnZoneEnter      │         │ interactiveId [ 42        ]   │  (EntityRef → combo)
+│   • EventOnInteract       │         │ open          [x] true        │  (Bool → checkbox)
+│ ▸ Flux                    │         │                               │
+│   • BranchIf              │         │ (les champs viennent du schéma│
+│ ▸ Actions                 │         │  RoutineNodeSchema, pas codés │
+│   • ActionOpenInteractive │         │  en dur)                      │
+└──────────────────────────┘         └───────────────────────────────┘
+```
+
+### API
+
+```cpp
+namespace engine::editor::world
+{
+    // Construit l'arbre de palette à partir des schémas valides pour le kind.
+    class RoutineNodePalette
+    {
+    public:
+        void Render(RoutineGraphDocument& doc, CommandStack& undo);
+    private:
+        char m_search[64] = {};
+    };
+
+    // Inspecteur schema-driven du nœud sélectionné.
+    class RoutineNodeInspector
+    {
+    public:
+        void Render(RoutineGraphDocument& doc, CommandStack& undo);
+    };
+
+    // Commande d'édition d'une propriété (undo/redo).
+    class SetNodePropertyCommand : public ICommand
+    {
+    public:
+        SetNodePropertyCommand(RoutineGraphDocument& doc, uint32_t nodeId,
+                               std::string key, engine::routine::RoutineProperty newValue);
+        void Apply() override;  void Undo() override;
+    };
+}
+```
+
+### Règle de création schema-driven
+
+```cpp
+// À l'insertion depuis la palette :
+RoutineNode MakeNodeFromSchema(const RoutineNodeSchema& s, uint32_t& nextNodeId,
+                               uint32_t& nextPinId, float x, float y);
+// → copie pinTemplate (en réassignant des ids uniques) et propertyTemplate.
+```
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/world_editor/panels/InspectorPanel.h` | **appelé en lecture** (modèle d'inspecteur) ; éventuellement **étendu** sans régression. |
+| `src/world_editor/core/CommandStack.h` | **appelé** (`SetNodePropertyCommand`, `AddNodeCommand`). |
+| `src/shared/routine/RoutineNodeSchema.h` (M101.1) | **appelé** (source de vérité de la palette et de l'inspecteur). |
+| `src/world_editor/routine/RoutineGraphDocument.h` (M101.4) | **appelé** (document édité). |
+
+Aucun hook manquant.
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/world_editor/routine/RoutineNodePalette.h/.cpp` | Créer. |
+| `src/world_editor/routine/RoutineNodeInspector.h/.cpp` | Créer. |
+| `src/world_editor/routine/RoutineGraphCommands.h/.cpp` | Modifier (ajout `SetNodePropertyCommand`). |
+| `src/world_editor/routine/RoutineGraphPanel.cpp` | Modifier (héberge palette + inspecteur). |
+| `src/world_editor/routine/tests/RoutinePaletteTests.cpp` | Créer (création schema-driven, édition de propriété undo/redo). |
+| `src/CMakeLists.txt` | Modifier : nouvelles sources → `engine_core` ; test `routine_palette_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (dont `routine_palette_tests`).
+- [ ] CI Windows verte.
+- [ ] Test headless : un nœud créé depuis un schéma a exactement les pins et
+      propriétés du template ; une `SetNodePropertyCommand` est annulable.
+- [ ] La palette ne montre que les types valides pour le `kind` du graphe courant
+      (filtrage par `validKindsMask`).
+- [ ] Aucun type de nœud codé en dur dans l'UI (vérifié : tout vient de
+      `RoutineNodeSchema`).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Schema-driven strict.** La palette et l'inspecteur lisent `AllSchemas()` /
+  `FindSchema()` ; ajouter un type de nœud (M101.7/8) = ajouter une ligne dans la
+  table de schémas, **sans toucher** à l'UI. C'est l'invariant d'extensibilité.
+- **EntityRef** : rendu en combo alimenté par les entités disponibles dans la zone
+  éditée (objets interactifs M100.32, points de spawn) — la source exacte dépend
+  du contexte d'édition ; en attendant, champ texte + validation en M101.6.
+- **Cohérence inspecteur** : suivre les conventions de `InspectorPanel` pour ne
+  pas diverger visuellement.
+- **Déploiement** : ✅ client/éditeur uniquement.

--- a/tickets/M101/M101.6-GraphValidation.md
+++ b/tickets/M101/M101.6-GraphValidation.md
@@ -1,0 +1,130 @@
+# M101.6 — Validation visuelle du graphe
+
+## Résumé
+
+Périmètre **strictement borné** : un **validateur de graphe** pur
+(`RoutineGraphValidation`) qui détecte les erreurs structurelles — cycles
+d'exécution interdits, pins incompatibles (type/kind), nœuds orphelins, propriétés
+manquantes par rapport au schéma — et leur **restitution dans le `ConsolePanel`
+existant** avec mise en évidence du nœud fautif dans le canvas. Validation
+**déterministe** (réutilisable en CI headless, sans rendu).
+
+## Dépendances
+
+- **M101.1** — Modèle + `RoutineNodeSchema` (référence de conformité).
+- **M101.4** — Canvas (mise en évidence visuelle du nœud fautif).
+- **M100.1** — `ConsolePanel` existant (sortie des erreurs).
+
+## Portée
+
+### Inclus
+- Fonction pure `Validate(const RoutineGraph&) → std::vector<ValidationIssue>`.
+- Règles :
+  1. **Cycle d'exécution** : pas de cycle le long des *exec wires* (les graphes
+     `zone_event` sont des DAG d'exécution). Pour `npc_routine`, la hiérarchie
+     d'états doit être un arbre (pas de parent multiple).
+  2. **Pins incompatibles** : un lien Exec ne connecte que des pins Exec ; un lien
+     Data ne connecte que des pins Data **de `RoutineDataType` compatible** ; une
+     sortie ne va que vers une entrée.
+  3. **Nœuds orphelins** : nœud sans aucun chemin d'exécution depuis un nœud
+     racine (`Event*` pour `zone_event`, `NpcStateRoot` pour `npc_routine`).
+  4. **Conformité au schéma** : pins/propriétés présents et typés conformément à
+     `RoutineNodeSchema` ; type de nœud autorisé pour le `kind` du graphe.
+  5. **Cardinalité** : exactement un nœud racine attendu (0 ou >1 = erreur).
+- Restitution `ConsolePanel` (niveau Error/Warning) + surbrillance du nœud/lien
+  fautif dans le canvas (M101.4).
+
+### Hors scope (formellement)
+- Toute validation **sémantique gameplay** (« cette porte existe-t-elle ? ») — au
+  mieux un Warning sur `EntityRef` inconnue ; la résolution réelle est runtime.
+- L'exécution (M101.2).
+- L'auto-réparation du graphe.
+
+## Spécification fonctionnelle
+
+```cpp
+namespace engine::routine::validation
+{
+    enum class IssueSeverity : uint8_t { Warning = 0, Error = 1 };
+    enum class IssueKind : uint8_t {
+        ExecCycle = 0, IncompatiblePins = 1, OrphanNode = 2,
+        SchemaMismatch = 3, RootCardinality = 4, UnknownEntityRef = 5
+    };
+
+    struct ValidationIssue
+    {
+        IssueSeverity severity;
+        IssueKind     kind;
+        uint32_t      nodeId;   // 0 si global
+        uint32_t      linkId;   // 0 si non pertinent
+        std::string   message;  // localisable (clé + texte par défaut)
+    };
+
+    // PURE et DÉTERMINISTE : issues triées (kind, nodeId, linkId).
+    std::vector<ValidationIssue> Validate(const RoutineGraph& graph);
+}
+```
+
+### Restitution éditeur
+
+```cpp
+namespace engine::editor::world
+{
+    // Lance la validation et écrit les issues dans le ConsolePanel ; renvoie le
+    // set d'ids de nœuds/liens à surligner dans le canvas (M101.4).
+    struct ValidationOverlay { std::vector<uint32_t> badNodeIds, badLinkIds; };
+
+    ValidationOverlay RunValidationToConsole(const RoutineGraphDocument& doc,
+                                             ConsolePanel& console);
+}
+```
+
+Déclenchée : à la demande (bouton « Valider »), et automatiquement à la
+sauvegarde du graphe. La surbrillance (M101.4) colore en rouge les nœuds
+`Error`, en orange les `Warning`.
+
+## Code runtime référencé
+
+| Fichier réel | Usage |
+|--------------|-------|
+| `src/world_editor/panels/ConsolePanel.h/.cpp` | **appelé** (écriture des issues : niveau, message, navigation au nœud). |
+| `src/shared/routine/RoutineGraph.h` + `RoutineNodeSchema.h` (M101.1) | **appelé** (modèle + référence de conformité). |
+| `src/world_editor/routine/RoutineGraphPanel.cpp` (M101.4) | **étendu** (surbrillance des nœuds/liens fautifs). |
+
+Aucun hook manquant (`ConsolePanel` existe).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/RoutineGraphValidation.h/.cpp` | Créer (fonction pure `Validate`, dans `routine_graph`). |
+| `src/world_editor/routine/RoutineValidationView.h/.cpp` | Créer (pont vers `ConsolePanel` + overlay). |
+| `src/world_editor/routine/RoutineGraphPanel.cpp` | Modifier (surbrillance). |
+| `src/shared/routine/tests/RoutineValidationTests.cpp` | Créer (chaque règle). |
+| `src/CMakeLists.txt` | Modifier : `RoutineGraphValidation.cpp` → lib `routine_graph` ; `RoutineValidationView.cpp` → `engine_core` ; test `routine_validation_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (dont `routine_validation_tests`).
+- [ ] CI Windows verte.
+- [ ] Test headless par règle : un graphe avec cycle exec / pins incompatibles /
+      nœud orphelin / mismatch schéma / cardinalité racine produit l'issue
+      attendue, et un graphe valide n'en produit aucune.
+- [ ] `Validate` est pure et déterministe (issues triées, même entrée → même sortie).
+- [ ] Les issues apparaissent dans le `ConsolePanel` et surlignent le bon nœud.
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **`Validate` dans `routine_graph` (lib pure)** : ainsi la même validation tourne
+  en CI headless **et** dans l'éditeur, sans duplication. La couche
+  `RoutineValidationView` (éditeur) ne fait que présenter.
+- **Cycle exec** : détection par DFS avec marquage (gris/noir). Ne pas confondre
+  avec les liens Data, qui peuvent former un DAG distinct (évalués en pull).
+- **Orphelin** : accessibilité depuis le(s) nœud(s) racine via les exec wires.
+- **`UnknownEntityRef`** : Warning seulement (la résolution réelle est runtime ;
+  l'éditeur ne connaît pas toujours toutes les entités). Ne pas bloquer la
+  sauvegarde sur un Warning.
+- **Déploiement** : ✅ client/éditeur uniquement.

--- a/tickets/M101/M101.7-NpcNodeLibrary.md
+++ b/tickets/M101/M101.7-NpcNodeLibrary.md
@@ -1,0 +1,148 @@
+# M101.7 — Nœuds PNJ (génère `EventAIRow`) — **Blocked**
+
+> **Statut : Blocked.** L'infrastructure PNJ avancée (Role Registry, Smart
+> Objects, Utility AI runtime) est **absente du code** (vérifié 2026-06-03). Ce
+> ticket **documente ses dépendances manquantes** et livre la part **réalisable
+> immédiatement** : la traduction d'un graphe `npc_routine` en `EventAIRow`
+> consommés par l'`EventAIRuntime` shard **existant**. Les nœuds qui exigent
+> Role Registry / Smart Objects / une action de déplacement sont déclarés
+> `Blocked` jusqu'à livraison de ces hooks.
+
+## Résumé
+
+Définir la **bibliothèque de nœuds PNJ** (schémas, dans la table
+`RoutineNodeSchema`) pour les graphes `npc_routine`, et le pont `RoutineToEventAI`
+qui **génère des `EventAIRow`** (décision actée : option (a) du prompt — pas de
+seconde IA, on réutilise/étend `EventAI`). La VM hiérarchique « live » StateTree +
+sélection par utilité + tick rate AI-LOD reste un **objectif futur**, bloqué par
+l'absence d'infra PNJ.
+
+## Dépendances
+
+- **M101.1** — Modèle + schéma.
+- **M101.2** — `NpcRoutineEvaluator` (squelette de traduction).
+- `src/shardd/ai/EventAI.h` + `EventAIRuntime.h` — **EXISTENT** (cible de traduction).
+- **MANQUANTES (cause du Blocked)** :
+  - `RoleRegistry` (points de rôle / smart objects) — **ABSENT du code**.
+  - `SmartObject` — **ABSENT**.
+  - Action de déplacement dans `EventAI` (`EventAction` n'a **pas** de `MoveTo`) — **hook manquant**.
+  - `AiLod` runtime (enum spécifié en ticket `CHAR-MODEL.37`, **pas codé**).
+- Docs de référence réels (remplacent `ARCHITECTURE_PNJ.md`, inexistant) :
+  `docs/superpowers/specs/2026-06-02-dialogue-pnj-design.md`,
+  `tickets/CHAR-MODEL/CHAR-MODEL.37_AmbientLifeSystem.md`.
+
+## Portée
+
+### Inclus (réalisable maintenant)
+- Schémas des nœuds PNJ ajoutés à la table `RoutineNodeSchema` (M101.1), plage
+  200..299.
+- `RoutineToEventAI` : mapping **déterministe** graphe `npc_routine` → liste
+  d'`EventAIRow`, pour le **sous-ensemble qui a un hook existant**.
+- Avertissements explicites (`outWarnings`) pour tout nœud sans hook (au lieu d'un
+  échec silencieux).
+
+### Hors scope / Bloqué (hooks manquants)
+- Nœud `TaskMoveTo` vers un **point de rôle** ou un **Smart Object** : nécessite
+  `RoleRegistry`/`SmartObject` (absents) **et** une action de déplacement dans
+  `EventAI` (absente). → **Blocked**.
+- Sélection par **utilité** (Utility AI) : pas d'infra. → **Blocked**.
+- Tick rate par **AI-LOD** : `AiLod` non codé. → **Blocked** (param neutre en
+  attendant, cf. M101.2).
+- VM StateTree hiérarchique « live » côté shard. → **futur**.
+
+## Spécification fonctionnelle
+
+### Nœuds PNJ (schémas, plage 200..299)
+
+| Type | Famille | Mapping `EventAIRow` | Hook |
+|------|---------|----------------------|------|
+| `NpcStateRoot` | racine | (organisation ; pas d'`EventAIRow` direct) | OK |
+| `NpcState` | état | regroupe des tasks sous une condition d'entrée | OK |
+| `SensorTimeOfDay` | capteur | `EventTrigger::Timer` (param1 = période ms) | **OK** |
+| `SensorPlayerInRange` | capteur | *(aucun trigger « range » dans EventAI)* | **MANQUANT → Blocked** |
+| `TaskPlayAnim` | action | `EventAction::Custom` (`actionString` = id anim) | **OK (via Custom)** |
+| `TaskSetEmotion` | action | `EventAction::Custom` (`actionString` = clé émotion) | **OK (via Custom)** |
+| `TaskMoveTo` | action | *(pas d'action de déplacement dans EventAI ; cible = point de rôle/SmartObject absents)* | **MANQUANT → Blocked** |
+
+> Les actions `Say`/`Cast`/`Flee`/`Summon`/`Despawn` d'`EventAI` sont exposées
+> telles quelles comme nœuds tasks supplémentaires (mapping 1:1), car leurs hooks
+> existent déjà dans `EventAIRuntime`.
+
+### Pont de traduction
+
+```cpp
+namespace engine::shard::ai
+{
+    // Traduit un graphe npc_routine en lignes EventAI. Déterministe.
+    // Tout nœud sans hook (range, move-to, utilité) est ignoré et signalé dans
+    // outWarnings ; il ne provoque PAS d'échec (le reste du graphe reste valide).
+    std::vector<EventAIRow> RoutineToEventAI(const engine::routine::RoutineGraph& graph,
+                                             std::string& outWarnings);
+}
+```
+
+Branchement : `SpawnerRuntime` (existant) associe un graphe `npc_routine` à un
+archétype de spawn ; au chargement, `RoutineToEventAI` produit les `EventAIRow`
+injectées dans l'`EventAIRuntime` de la créature.
+
+## Code runtime référencé
+
+| Fichier réel | Statut |
+|--------------|--------|
+| `src/shardd/ai/EventAI.h` (`EventAIRow`, `EventTrigger`, `EventAction`) | **étendu / appelé** — cible de traduction. |
+| `src/shardd/ai/EventAIRuntime.h` (`SeedV1Events`, `Tick`) | **appelé** — consomme les `EventAIRow` générées. |
+| `src/shardd/entities/Creature.h`, `Unit.h` | **appelés en lecture** — entités sur lesquelles les actions s'appliquent (via `EventAIRuntime`). |
+| `src/shardd/gameplay/spawner/SpawnerRuntime.h` (`SpawnerDefinition`) | **appelé en lecture** — rattachement routine ↔ archétype de spawn. |
+| `src/shared/routine/RoutineGraph.h` + `NpcRoutineEvaluator` (M101.2) | **appelé**. |
+| **`RoleRegistry`** (points de rôle) | **hook manquant → Blocked** (n'existe pas). |
+| **`SmartObject`** | **hook manquant → Blocked** (n'existe pas). |
+| **`EventAction::MoveTo`** (déplacement piloté) | **hook manquant → Blocked** (`EventAction` n'a pas cette valeur). |
+| **`AiLod` runtime** | **hook manquant → Blocked** (spécifié en ticket CHAR-MODEL.37, pas codé). |
+
+## Livrables (à la levée du blocage, sauf le pont déjà livrable)
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/RoutineNodeSchema.cpp` | Modifier (ajouter les schémas PNJ 200..299). |
+| `src/shardd/ai/RoutineToEventAI.h/.cpp` | Créer (pont de traduction). |
+| `src/shardd/ai/tests/RoutineToEventAITests.cpp` | Créer (mapping déterministe + warnings pour hooks manquants). |
+| `src/CMakeLists.txt` | Modifier : `RoutineToEventAI.cpp` → `server_app`/`engine_core_server` (le shard) **et** lien `routine_graph` (déjà ajouté en M101.1) ; **pas** de lien Vulkan. Test `routine_to_eventai_tests`. |
+
+> **Rappel mémoire projet** : tout nouveau `.cpp` partagé côté serveur doit aussi
+> être ajouté à la liste `server_app` dans `src/CMakeLists.txt` (cf. la convention
+> du dépôt — `server_app` ne linke pas `engine_core`).
+
+## Definition of Done
+
+> **Bloquante tant que `Blocked`** : seule la partie « pont `RoutineToEventAI` pour
+> le sous-ensemble à hook existant » est livrable et testable. Les nœuds
+> `SensorPlayerInRange` / `TaskMoveTo` / utilité / AI-LOD restent **non livrés**
+> jusqu'à création de leurs hooks.
+
+- [ ] CI Linux verte (dont `routine_to_eventai_tests`).
+- [ ] CI Windows verte.
+- [ ] Round-trip headless : un graphe `npc_routine` (sous-ensemble à hook) →
+      `RoutineToEventAI` → `EventAIRow` déterministes, rejoués par `EventAIRuntime`.
+- [ ] Tout nœud sans hook produit un **warning explicite**, jamais un crash ni un
+      échec silencieux.
+- [ ] Les dépendances manquantes (Role Registry, Smart Objects, MoveTo, AI-LOD)
+      restent documentées comme conditions de déblocage.
+- [ ] **Redéploiement shard requis** quand ce ticket est livré (le shard charge des
+      routines PNJ).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Pas de seconde IA.** On ne crée **aucune** machine à états concurrente
+  d'`EventAI`. Le graphe est une **source d'édition** ; la vérité d'exécution reste
+  `EventAIRuntime`. C'est l'invariant anti-duplication.
+- **Honnêteté sur les manques.** Plutôt que de simuler un MoveTo bancal, on déclare
+  le hook manquant. Le déblocage viendra d'un milestone PNJ (Role Registry +
+  actions de déplacement + Smart Objects), à séquencer avec Hubert (cf. `INDEX.md`,
+  décisions laissées à Hubert).
+- **Déterminisme** : ordre stable des `EventAIRow` (tri par id de nœud source).
+- **Terme** : éviter toute mention « CMANGOS » ; décrire `EventAI` comme une
+  machine à états IA **data-driven** issue d'une étude clean-room de serveurs MMO
+  open-source.
+- **Déploiement** : ⚠️ **redéploiement serveur (shard) requis** à la livraison
+  (chargement de routines PNJ côté shard).

--- a/tickets/M101/M101.8-ZoneGameplayNodeLibrary.md
+++ b/tickets/M101/M101.8-ZoneGameplayNodeLibrary.md
@@ -1,0 +1,147 @@
+# M101.8 — Nœuds zone / gameplay
+
+## Résumé
+
+Périmètre **strictement borné** : la **bibliothèque de nœuds `zone_event`**
+(schémas + sémantique d'exécution via `IRoutineHost`) pour les graphes attachés à
+une cellule de zone. Nœuds Event (entrée/sortie de volume, interaction), flux
+(`BranchIf`), et actions branchées sur le **code client de prod existant** :
+ouvrir un objet interactif (M100.32), émettre un broadcast saison/météo (M100.25/26).
+L'implémentation concrète de `IRoutineHost` (`ClientRoutineHost`) **réutilise les
+systèmes et opcodes existants — aucun nouvel opcode**.
+
+## Dépendances
+
+- **M101.1** — Modèle + schéma.
+- **M101.2** — `ZoneEventVm` + `IRoutineHost`.
+- **M100.16** — Hazard Volume System (**Ready**) : source des événements de volume.
+- **M100.28** — Gameplay Zones & Weather Zones (**Ready**) : zones de déclenchement.
+- **M100.32** — Interactive Props (**Ready**) : `InteractiveSimulator` +
+  `InteractiveStateChange` (action « ouvrir »).
+- **M100.25 / M100.26** — opcodes `SeasonBroadcast` / `WeatherBroadcast`
+  (**Ready**) : actions broadcast (réutilisés tels quels).
+
+> Dépendances M100 en statut **Ready** (spec figée, pas encore mergées). M101.8
+> reste **Draft** et se séquence **après** leur merge. Aucun *forward reference*
+> vers un milestone non livré : ces tickets appartiennent au même cluster
+> environnemental et leurs contrats sont figés.
+
+## Portée
+
+### Inclus
+- Schémas des nœuds `zone_event` (table `RoutineNodeSchema`, plage 100..199).
+- `ClientRoutineHost : public IRoutineHost` — implémentation cliente branchée sur
+  les systèmes de prod existants.
+- Liaison déclenchement : un volume (M100.16/28) qui détecte une entrée/sortie
+  appelle `ZoneEventVm::Fire(EventOnZoneEnter/Exit, …)` ; une interaction
+  (M100.32) appelle `Fire(EventOnInteract, …)`.
+- Nœuds action : `ActionOpenInteractive` (→ `InteractiveSimulator`),
+  `ActionBroadcastSeason` (→ opcode M100.25), `ActionBroadcastWeather` (→ opcode
+  M100.26).
+
+### Hors scope (formellement)
+- Tout **nouvel opcode** réseau (on réutilise M100.25/26/32). → aucun gate serveur
+  propre à M101.8.
+- Les nœuds PNJ (M101.7).
+- Le mode Playtest F5 (M101.9) — ce ticket fournit les nœuds, M101.9 les exécute
+  via le code client de prod.
+- Toute validation gameplay côté serveur (le master ne fait que relayer).
+
+## Spécification fonctionnelle
+
+### Nœuds `zone_event` (plage 100..199)
+
+| Type | Famille | Effet via `IRoutineHost` / déclencheur |
+|------|---------|----------------------------------------|
+| `EventOnZoneEnter` | Event racine | déclenché par M100.28 (entrée de gameplay zone) |
+| `EventOnZoneExit` | Event racine | déclenché par M100.28 (sortie) |
+| `EventOnInteract` | Event racine | déclenché par M100.32 (joueur presse E sur un prop) |
+| `BranchIf` | flux | sélectionne l'exec de sortie selon un pin Data `Bool` |
+| `ActionOpenInteractive` | action | `host.OpenInteractive(interactiveId, open)` → `InteractiveSimulator` (animation locale + `InteractiveStateChange`) |
+| `ActionBroadcastSeason` | action | `host.BroadcastSeason(idx)` → opcode `SeasonBroadcast` (M100.25) |
+| `ActionBroadcastWeather` | action | `host.BroadcastWeather(idx)` → opcode `WeatherBroadcast` (M100.26) |
+
+### Hôte client concret
+
+```cpp
+namespace engine::world::routine
+{
+    // Implémente l'interface pure de M101.2 en branchant les systèmes de prod.
+    class ClientRoutineHost : public engine::routine::vm::IRoutineHost
+    {
+    public:
+        ClientRoutineHost(engine::world::interactive::InteractiveSimulator& sim,
+                          /* émetteurs season/weather existants */);
+
+        float GetTimeOfDayHours() const override;                 // lit SeasonClock (M100.25)
+        bool  IsPlayerInRange(uint64_t e, float m) const override;// lit position locale
+        void  OpenInteractive(uint64_t id, bool open) override;   // → InteractiveSimulator
+        void  BroadcastSeason(int idx) override;                  // → opcode M100.25
+        void  BroadcastWeather(int idx) override;                 // → opcode M100.26
+    };
+}
+```
+
+### Flux de déclenchement
+
+```
+[M100.28] joueur entre dans une gameplay zone
+   → ZoneEventVm(zoneGraph).Fire(EventOnZoneEnter, ctx, clientRoutineHost)
+       → BranchIf (heure < 20h ?) → ActionOpenInteractive(porte_taverne, open=true)
+           → InteractiveSimulator anime la porte + envoie InteractiveStateChange (M100.32)
+```
+
+## Code runtime référencé
+
+| Fichier réel | Statut |
+|--------------|--------|
+| `src/client/world/interactive/InteractiveSimulator.h` (M100.32) | **appelé** — action `OpenInteractive`. |
+| `src/shared/network/InteractivePayloads.h` + opcodes `InteractiveStateChange*` (M100.32) | **appelés** — réutilisés (pas de nouvel opcode). |
+| `src/shared/network/ServerProtocol.h` (`MessageKind`, `kProtocolVersion`) | **appelé en lecture** — réutilise les opcodes M100.25/26/32 ; **aucun ajout**, **pas de bump**. |
+| `src/shared/network/GameEventPayloads.h` | **appelé en lecture** — gabarit de payload de référence. |
+| Systèmes saison/météo de M100.25/26 (`SeasonClock`, broadcast) | **appelés** — actions broadcast. |
+| Volumes M100.16 (`HazardVolume`) / M100.28 (gameplay zones) | **appelés en lecture** — sources de déclenchement. |
+| `src/shared/routine/vm/IRoutineHost.h` (M101.2) | **étendu** — `ClientRoutineHost` l'implémente. |
+
+Aucun hook manquant pour la cible zone (tous les systèmes existent en Ready).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/shared/routine/RoutineNodeSchema.cpp` | Modifier (schémas zone 100..199). |
+| `src/client/world/routine/ClientRoutineHost.h/.cpp` | Créer. |
+| `src/client/world/routine/ZoneEventDispatch.h/.cpp` | Créer (liaison volumes/interactions → `ZoneEventVm::Fire`). |
+| `src/client/world/routine/tests/ZoneEventNodesTests.cpp` | Créer (avec `MockRoutineHost` + `ClientRoutineHost` mocké). |
+| `src/CMakeLists.txt` | Modifier : sources → `engine_core` ; test `zone_event_nodes_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (dont `zone_event_nodes_tests`).
+- [ ] CI Windows verte.
+- [ ] Round-trip headless : un graphe `zone_event` (Event → BranchIf → Action)
+      exécuté via `ZoneEventVm` + `MockRoutineHost` produit la trace d'actions
+      attendue, déterministe.
+- [ ] **Aucun nouvel opcode** ni bump `kProtocolVersion` (vérifié par diff de
+      `ServerProtocol.h`).
+- [ ] Les actions broadcast réutilisent strictement les opcodes M100.25/26 ;
+      `OpenInteractive` réutilise M100.32.
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Réutilisation, pas de nouvel opcode.** Toute la valeur de M101.8 est de
+  **câbler** les nœuds sur les systèmes existants via `IRoutineHost`. Si un nœud
+  futur exigeait un message d'état inédit, il suivrait le gabarit
+  `GameEventPayloads.h` (Request/Response + Notification, `*ErrorCode` 0=OK) et
+  introduirait alors son propre gate serveur — **ce n'est pas le cas ici**.
+- **Autorité shard ↔ client** : posée dans `INDEX.md`, non tranchée. Reco par
+  défaut : client-autoritaire pour les objets de zone locaux (cohérent M100.32),
+  master relais pur.
+- **Frontière de pureté préservée** : la VM (M101.2) ne connaît que `IRoutineHost` ;
+  `ClientRoutineHost` est le **seul** point qui touche le code de rendu/réseau.
+- **Déploiement** : ✅ client/éditeur uniquement **pour M101.8 lui-même** ; les
+  opcodes réutilisés (M100.25/26/32) ont déjà leur propre gate de redéploiement
+  master dans M100.

--- a/tickets/M101/M101.9-PlaytestExecution.md
+++ b/tickets/M101/M101.9-PlaytestExecution.md
@@ -1,0 +1,104 @@
+# M101.9 — Mode Playtest (F5) : exécution via le code client de prod
+
+## Résumé
+
+Périmètre **strictement borné** : exécuter les graphes `zone_event` **dans le mode
+Playtest F5 existant** (M100.33), en passant par le **code client de prod** —
+`ZoneEventVm` (M101.2) + `ClientRoutineHost` (M101.8) — **sans aucun chemin
+« preview » séparé**. Quand l'éditeur entre en Playtest, les routines de la zone
+éditée se comportent exactement comme en jeu.
+
+## Dépendances
+
+- **M101.2** — `ZoneEventVm`.
+- **M101.8** — `ClientRoutineHost` + `ZoneEventDispatch` (nœuds zone branchés).
+- **M100.33** — Footstep Audio Surface Hook & **Playtest Mode (F5)** (**Ready**) :
+  le mode Playtest existant.
+
+## Portée
+
+### Inclus
+- Au passage en Playtest (F5), instanciation d'un `ClientRoutineHost` réel et
+  chargement des graphes `zone_event` de la zone éditée (depuis le document, ou
+  depuis `routines.bin` si déjà sauvegardé — M101.3).
+- Branchement de `ZoneEventDispatch` (M101.8) aux volumes/interactions de la
+  session Playtest : entrer dans une gameplay zone déclenche réellement les
+  routines.
+- Sortie de Playtest : démontage propre (pas de routine résiduelle en mode
+  édition).
+
+### Hors scope (formellement)
+- Les graphes `npc_routine` (cible PNJ — exécutés côté shard, M101.7, Blocked).
+- Tout moteur d'exécution **autre** que le code de prod (interdiction du chemin
+  « preview »).
+- L'UI nodale (M101.4–6) et la sauvegarde (M101.3).
+
+## Spécification fonctionnelle
+
+```
+F5 (entrée Playtest, M100.33)
+  → RoutinePlaytestBridge::OnEnterPlaytest()
+      → construit ClientRoutineHost (InteractiveSimulator réel, SeasonClock réel)
+      → charge les RoutineGraph zone_event de la zone (document ou routines.bin)
+      → enregistre ZoneEventDispatch auprès des volumes/interactions de la session
+
+[pendant le Playtest] joueur joue normalement → les routines s'exécutent via
+                       ZoneEventVm + ClientRoutineHost (code de prod)
+
+Échap / F5 (sortie)
+  → RoutinePlaytestBridge::OnExitPlaytest() : désenregistre tout, libère l'hôte
+```
+
+```cpp
+namespace engine::editor::world
+{
+    class RoutinePlaytestBridge
+    {
+    public:
+        void OnEnterPlaytest(const std::vector<engine::routine::RoutineGraph>& zoneGraphs);
+        void OnExitPlaytest();
+    };
+}
+```
+
+## Code runtime référencé
+
+| Fichier réel | Statut |
+|--------------|--------|
+| Mode Playtest F5 de M100.33 (hook d'entrée/sortie) | **appelé / étendu** — point d'accroche du bridge. |
+| `src/shared/routine/vm/ZoneEventVm.h` (M101.2) | **appelé** — exécution. |
+| `src/client/world/routine/ClientRoutineHost.h` (M101.8) | **appelé** — hôte de prod. |
+| `src/client/world/routine/ZoneEventDispatch.h` (M101.8) | **appelé** — liaison déclencheurs. |
+| `src/client/world/interactive/InteractiveSimulator.h` (M100.32) | **appelé en lecture** — déjà utilisé par `ClientRoutineHost`. |
+
+Aucun hook manquant (le mode Playtest existe en M100.33, Ready).
+
+## Livrables
+
+| Chemin | Action |
+|--------|--------|
+| `src/world_editor/routine/RoutinePlaytestBridge.h/.cpp` | Créer. |
+| Hook d'entrée/sortie Playtest de M100.33 | Modifier (appeler le bridge). |
+| `src/world_editor/routine/tests/RoutinePlaytestBridgeTests.cpp` | Créer (entrée → exécution simulée → sortie propre). |
+| `src/CMakeLists.txt` | Modifier : source → `engine_core` ; test `routine_playtest_bridge_tests`. |
+
+## Definition of Done
+
+Reprend la DoD globale, **plus** :
+
+- [ ] CI Linux verte (dont `routine_playtest_bridge_tests`).
+- [ ] CI Windows verte.
+- [ ] Test headless : `OnEnterPlaytest` câble l'exécution sur `ClientRoutineHost` ;
+      un déclencheur simulé fait s'exécuter le graphe ; `OnExitPlaytest` ne laisse
+      aucune routine active.
+- [ ] **Aucun chemin d'exécution « preview »** distinct du code de prod (vérifié :
+      Playtest utilise `ZoneEventVm` + `ClientRoutineHost`, comme le jeu).
+- [ ] Checkpoint de validation manuelle Hubert avant merge.
+
+## Notes d'implémentation
+
+- **Parité stricte.** L'exigence centrale : ce qui tourne en Playtest est ce qui
+  tourne en jeu. Pas de moteur « éditeur » parallèle.
+- **Démontage propre** : à la sortie, désenregistrer `ZoneEventDispatch` et
+  détruire l'hôte, sinon des routines fantômes persistent en mode édition.
+- **Déploiement** : ✅ client/éditeur uniquement.


### PR DESCRIPTION
## Résumé

Arbre de tickets validable (markdown uniquement, **zéro code de production**) pour l'**éditeur de routines visuel nodal** (type n8n), précédé d'un **audit des 22 systèmes de référence** de l'éditeur de monde.

Conclusion de l'audit : la grande majorité des 22 systèmes UE5 est déjà **Couverte** par M100.1–51. Le seul système **réellement absent** est l'éditeur de routines nodal → objet du nouveau cluster **M101**.

## Contenu (13 fichiers, `tickets/M101/`)
- `AUDIT_22_SYSTEMES.md` — cartographie des 22 systèmes (Couvert / Partiel / Absent), chemins vérifiés.
- `INDEX.md` — 4 phases, statuts, dépendances, gates de déploiement, décisions laissées à Hubert.
- `M101.1` → `M101.11` — tickets complets (format calqué sur M100.32 + section `## Code runtime référencé`).

## Décisions actées
- **Deux types de graphe distincts** : `npc_routine` (StateTree-like) / `zone_event` (Blueprint-like), sérialisation commune.
- **M101.7 (PNJ) en `Blocked`** : Role Registry / Smart Objects / Utility AI **absents du code** ; génère des `EventAIRow` en attendant (pas de seconde IA concurrente d'EventAI).
- Tous les autres tickets en `Draft`, en attente de validation **ticket par ticket** (« Stop & validate »).

## Corrections factuelles vs hypothèses du prompt
- `kChunkMetaHasRoutines = 1u << 7` (bits 5/6 déjà pris par Terrain/Splat).
- `ARCHITECTURE_PNJ.md` inexistant → docs réels (dialogue-pnj-design, CHAR-MODEL.37).
- `engine_sim` inexistant → VM = lib pure autonome `routine_vm`.
- Chemins réels `zone_builder` / réseau (`MessageKind`, `GameEventPayloads.h`) vérifiés.

## Déploiement
✅ **Documentation uniquement — aucun redéploiement serveur.** Les redéploiements signalés *dans* les tickets (shard pour M101.7, gates master réutilisés M100.25/26/32 pour M101.8) ne se déclenchent qu'à l'implémentation, après feu vert ticket par ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)