### PR TITLE
feat(routine): M101 — implémentation éditeur de routines visuel nodal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,11 @@ add_library(engine_core
   # editor.world.enabled. Pas référencé par engine/server/.
   src/world_editor/core/WorldEditorShell.cpp
   src/world_editor/core/CommandStack.cpp
+  # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
+  src/world_editor/routine/RoutineGraphCommands.cpp
+  src/world_editor/routine/RoutineGraphPanel.cpp
+  src/world_editor/routine/RoutineNodePalette.cpp
+  src/world_editor/routine/RoutineNodeInspector.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -882,6 +887,11 @@ add_executable(routine_to_eventai_tests
   src/shardd/ai/RoutineToEventAI.cpp)
 target_link_libraries(routine_to_eventai_tests PRIVATE routine_graph)
 add_test(NAME routine_to_eventai_tests COMMAND routine_to_eventai_tests)
+
+# M101.4 / M101.5 — Tests des commandes d'edition de graphe (apply/undo).
+add_executable(routine_graph_commands_tests src/world_editor/routine/tests/RoutineGraphCommandsTests.cpp)
+target_link_libraries(routine_graph_commands_tests PRIVATE engine_core)
+add_test(NAME routine_graph_commands_tests COMMAND routine_graph_commands_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,13 @@ add_executable(routine_segment_codec_tests src/shared/routine/tests/RoutineSegme
 target_link_libraries(routine_segment_codec_tests PRIVATE routine_graph)
 add_test(NAME routine_segment_codec_tests COMMAND routine_segment_codec_tests)
 
+# M101.7 (partiel) — Traduction npc_routine -> EventAIRow (cote shard).
+add_executable(routine_to_eventai_tests
+  src/shardd/ai/tests/RoutineToEventAITests.cpp
+  src/shardd/ai/RoutineToEventAI.cpp)
+target_link_libraries(routine_to_eventai_tests PRIVATE routine_graph)
+add_test(NAME routine_to_eventai_tests COMMAND routine_to_eventai_tests)
+
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)
 target_link_libraries(ddgi_volume_tests PRIVATE engine_core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,11 @@ add_executable(routine_graph_commands_tests src/world_editor/routine/tests/Routi
 target_link_libraries(routine_graph_commands_tests PRIVATE engine_core)
 add_test(NAME routine_graph_commands_tests COMMAND routine_graph_commands_tests)
 
+# M101.11 — Test de parsing du contenu d'aide des routines (format M100.47).
+add_executable(routine_help_content_tests src/world_editor/routine/tests/RoutineHelpContentTests.cpp)
+target_link_libraries(routine_help_content_tests PRIVATE engine_core)
+add_test(NAME routine_help_content_tests COMMAND routine_help_content_tests)
+
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)
 target_link_libraries(ddgi_volume_tests PRIVATE engine_core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,19 @@ else()
   target_compile_options(routine_graph PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
+# M101.2 — VM d'interpretation deterministe des graphes zone_event. Lib pure
+# (depend de routine_graph + IRoutineHost ; aucune dependance Vulkan/GLFW).
+add_library(routine_vm STATIC
+  src/shared/routine/vm/ZoneEventVm.cpp
+)
+target_include_directories(routine_vm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(routine_vm PUBLIC routine_graph)
+if(MSVC)
+  target_compile_options(routine_vm PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(routine_vm PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
 # Dear ImGui (branche docking) — World Editor Windows : overlay Vulkan (dynamic rendering), pas d’OpenGL.
 if(WIN32)
   FetchContent_Declare(imgui_lcdlln_fc
@@ -662,6 +675,7 @@ target_link_libraries(engine_core PUBLIC
   engine_auth
   spdlog::spdlog
   routine_graph
+  routine_vm
 )
 if(WIN32)
   target_link_libraries(engine_core PRIVATE imgui_lcdlln)
@@ -844,6 +858,11 @@ add_test(NAME protocol_v1_tests COMMAND protocol_v1_tests)
 add_executable(routine_serialization_tests src/shared/routine/tests/RoutineSerializationTests.cpp)
 target_link_libraries(routine_serialization_tests PRIVATE routine_graph)
 add_test(NAME routine_serialization_tests COMMAND routine_serialization_tests)
+
+# M101.2 — Tests de la VM zone_event (execution + determinisme).
+add_executable(routine_vm_tests src/shared/routine/vm/tests/RoutineVmTests.cpp)
+target_link_libraries(routine_vm_tests PRIVATE routine_vm)
+add_test(NAME routine_vm_tests COMMAND routine_vm_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(routine_graph STATIC
   src/shared/routine/RoutineNodeSchema.cpp
   src/shared/routine/RoutineSerialization.cpp
   src/shared/routine/RoutineGraphValidation.cpp
+  src/shared/routine/RoutineSegmentCodec.cpp
 )
 target_include_directories(routine_graph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(MSVC)
@@ -869,6 +870,11 @@ add_test(NAME routine_vm_tests COMMAND routine_vm_tests)
 add_executable(routine_validation_tests src/shared/routine/tests/RoutineValidationTests.cpp)
 target_link_libraries(routine_validation_tests PRIVATE routine_graph)
 add_test(NAME routine_validation_tests COMMAND routine_validation_tests)
+
+# M101.3 — Tests du codec routines.bin (round-trip en memoire).
+add_executable(routine_segment_codec_tests src/shared/routine/tests/RoutineSegmentCodecTests.cpp)
+target_link_libraries(routine_segment_codec_tests PRIVATE routine_graph)
+add_test(NAME routine_segment_codec_tests COMMAND routine_segment_codec_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,20 @@ if(MSVC)
   target_compile_options(engine_auth PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 
+# M101.1 — Lib pure du modele de graphe de routine (cluster M101 : editeur de
+# routines nodal). AUCUNE dependance Vulkan/GLFW/reseau : reutilisable par
+# engine_core (client + editeur) ET par server_app (shard, traduction PNJ M101.7).
+add_library(routine_graph STATIC
+  src/shared/routine/RoutineNodeSchema.cpp
+  src/shared/routine/RoutineSerialization.cpp
+)
+target_include_directories(routine_graph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+if(MSVC)
+  target_compile_options(routine_graph PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(routine_graph PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
 # Dear ImGui (branche docking) — World Editor Windows : overlay Vulkan (dynamic rendering), pas d’OpenGL.
 if(WIN32)
   FetchContent_Declare(imgui_lcdlln_fc
@@ -647,6 +661,7 @@ target_link_libraries(engine_core PUBLIC
   glfw
   engine_auth
   spdlog::spdlog
+  routine_graph
 )
 if(WIN32)
   target_link_libraries(engine_core PRIVATE imgui_lcdlln)
@@ -824,6 +839,11 @@ add_executable(protocol_v1_tests src/shared/network/ProtocolV1Tests.cpp)
 target_link_libraries(protocol_v1_tests PRIVATE engine_core)
 enable_testing()
 add_test(NAME protocol_v1_tests COMMAND protocol_v1_tests)
+
+# M101.1 — Tests de serialisation/round-trip/determinisme du modele de routine.
+add_executable(routine_serialization_tests src/shared/routine/tests/RoutineSerializationTests.cpp)
+target_link_libraries(routine_serialization_tests PRIVATE routine_graph)
+add_test(NAME routine_serialization_tests COMMAND routine_serialization_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ endif()
 add_library(routine_graph STATIC
   src/shared/routine/RoutineNodeSchema.cpp
   src/shared/routine/RoutineSerialization.cpp
+  src/shared/routine/RoutineGraphValidation.cpp
 )
 target_include_directories(routine_graph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(MSVC)
@@ -863,6 +864,11 @@ add_test(NAME routine_serialization_tests COMMAND routine_serialization_tests)
 add_executable(routine_vm_tests src/shared/routine/vm/tests/RoutineVmTests.cpp)
 target_link_libraries(routine_vm_tests PRIVATE routine_vm)
 add_test(NAME routine_vm_tests COMMAND routine_vm_tests)
+
+# M101.6 — Tests de validation de graphe.
+add_executable(routine_validation_tests src/shared/routine/tests/RoutineValidationTests.cpp)
+target_link_libraries(routine_validation_tests PRIVATE routine_graph)
+add_test(NAME routine_validation_tests COMMAND routine_validation_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/game/data/editor/tooltips/routine.json
+++ b/game/data/editor/tooltips/routine.json
@@ -1,0 +1,61 @@
+{
+  "toolId": "routine",
+  "tooltips": {
+    "graph": {
+      "label": "Graphe de routine",
+      "description_simple": "Programme visuel fait de noeuds relies par des fils.",
+      "description_advanced": "Artefact JSON interprete au runtime par la VM (zone_event) ou traduit en EventAIRow (npc_routine). Aucune recompilation : editer = changer le JSON.",
+      "defaultValue": "zone_event",
+      "range": "zone_event / npc_routine",
+      "docSectionId": "routine/graph"
+    },
+    "execPin": {
+      "label": "Pin d'execution",
+      "description_simple": "Fil qui declenche le noeud suivant.",
+      "description_advanced": "Flux de controle (Blueprint-like) : un noeud ne s'execute que lorsqu'un fil exec entrant est active.",
+      "defaultValue": "",
+      "range": "",
+      "docSectionId": "routine/pins#exec"
+    },
+    "dataPin": {
+      "label": "Pin de donnee",
+      "description_simple": "Valeur typee passee entre noeuds.",
+      "description_advanced": "Bool / Int / Float / Vec3 / String / EntityRef. Evalue en pull lorsqu'un noeud a besoin de la valeur.",
+      "defaultValue": "",
+      "range": "Bool / Int / Float / Vec3 / String / EntityRef",
+      "docSectionId": "routine/pins#data"
+    },
+    "EventOnInteract": {
+      "label": "Evenement : interaction",
+      "description_simple": "Demarre la routine quand le joueur interagit avec un objet.",
+      "description_advanced": "Noeud racine zone_event. Declenche par M100.32 (prop interactif). Fournit l'entite interagie au contexte.",
+      "defaultValue": "",
+      "range": "",
+      "docSectionId": "routine/nodes#EventOnInteract"
+    },
+    "BranchIf": {
+      "label": "Branche (si)",
+      "description_simple": "Choisit la suite selon une condition vraie/fausse.",
+      "description_advanced": "Lit un pin Data Bool ; suit l'exec 'true' ou 'false'. Condition non liee => false (deterministe).",
+      "defaultValue": "",
+      "range": "",
+      "docSectionId": "routine/nodes#BranchIf"
+    },
+    "ActionOpenInteractive": {
+      "label": "Action : ouvrir/fermer objet",
+      "description_simple": "Ouvre ou ferme une porte/objet interactif.",
+      "description_advanced": "Appelle l'hote (InteractiveSimulator, M100.32). Reutilise l'opcode InteractiveStateChange ; aucun nouvel opcode.",
+      "defaultValue": "open=true",
+      "range": "",
+      "docSectionId": "routine/nodes#ActionOpenInteractive"
+    },
+    "NpcStateRoot": {
+      "label": "PNJ : racine d'etats",
+      "description_simple": "Point de depart d'une routine de PNJ.",
+      "description_advanced": "Cible npc_routine. Traduit en EventAIRow (M101.7). Hierarchie d'etats facon StateTree.",
+      "defaultValue": "",
+      "range": "",
+      "docSectionId": "routine/nodes#NpcStateRoot"
+    }
+  }
+}

--- a/src/client/world/ChunkPackageLayout.cpp
+++ b/src/client/world/ChunkPackageLayout.cpp
@@ -13,6 +13,7 @@ namespace engine::world
 		case ChunkSegment::Instances: return "instances.bin";
 		case ChunkSegment::Nav:       return "navmesh.bin";
 		case ChunkSegment::Probes:    return "probes.bin";
+		case ChunkSegment::Routines:  return "routines.bin";
 		}
 		return "geo.pak";
 	}
@@ -26,7 +27,8 @@ namespace engine::world
 			ChunkSegment::Tex,
 			ChunkSegment::Instances,
 			ChunkSegment::Nav,
-			ChunkSegment::Probes
+			ChunkSegment::Probes,
+			ChunkSegment::Routines
 		}};
 	}
 }

--- a/src/client/world/ChunkPackageLayout.h
+++ b/src/client/world/ChunkPackageLayout.h
@@ -19,11 +19,12 @@ namespace engine::world
 		Tex,       /// tex.pak — textures
 		Instances, /// instances.bin
 		Nav,       /// navmesh.bin
-		Probes     /// probes.bin
+		Probes,    /// probes.bin
+		Routines   /// routines.bin — graphes de routine zone_event/npc_routine (M101.3)
 	};
 
 	/// Number of segment types.
-	constexpr uint32_t kChunkSegmentCount = 7u;
+	constexpr uint32_t kChunkSegmentCount = 8u;
 
 	/// Returns the relative filename for the segment (e.g. "geo.pak", "instances.bin").
 	std::string_view GetChunkSegmentFilename(ChunkSegment segment);
@@ -52,4 +53,7 @@ namespace engine::world
 	constexpr uint32_t kChunkMetaHasTerrain = 1u << 5;
 	/// Présence de `splat.bin` (8-layer splat-map 257², M100.9).
 	constexpr uint32_t kChunkMetaHasSplat = 1u << 6;
+	/// Présence de `routines.bin` (graphes de routine, M101.3). Bit 7 : premier
+	/// bit libre (les bits 0..6 sont déjà pris ci-dessus).
+	constexpr uint32_t kChunkMetaHasRoutines = 1u << 7;
 }

--- a/src/client/world/routine/RoutineSegmentReader.h
+++ b/src/client/world/routine/RoutineSegmentReader.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// M101.3 — Lecteur client du segment `routines.bin`.
+//
+// Mince wrapper autour du codec pur `routine_graph` : lit les octets d'un
+// fichier et les décode en graphes. Header-only (pas d'ajout à la liste de
+// sources d'engine_core). Le runtime ne tente la lecture que si le flag
+// `kChunkMetaHasRoutines` est présent (rétro-compatibilité des paquets anciens).
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/RoutineSegmentCodec.h"
+
+namespace engine::world::routine
+{
+	struct LoadedRoutines
+	{
+		std::vector<engine::routine::RoutineGraph> graphs;
+	};
+
+	/// Décode des octets `routines.bin` déjà en mémoire.
+	inline bool ReadRoutines(const std::vector<uint8_t>& bytes, LoadedRoutines& out, std::string& err)
+	{
+		auto graphs = engine::routine::codec::DecodeRoutinesBin(bytes, err);
+		if (!graphs) return false;
+		out.graphs = std::move(*graphs);
+		return true;
+	}
+
+	/// Lit et décode un fichier `routines.bin`.
+	inline bool ReadRoutinesFile(const std::string& path, LoadedRoutines& out, std::string& err)
+	{
+		std::ifstream in(path, std::ios::binary);
+		if (!in.good())
+		{
+			err = "ReadRoutinesFile: open failed: " + path;
+			return false;
+		}
+		std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+		                           std::istreambuf_iterator<char>());
+		return ReadRoutines(bytes, out, err);
+	}
+}

--- a/src/shardd/ai/RoutineToEventAI.cpp
+++ b/src/shardd/ai/RoutineToEventAI.cpp
@@ -1,0 +1,101 @@
+// M101.7 (partiel) — Implémentation du pont npc_routine -> EventAIRow.
+
+#include "src/shardd/ai/RoutineToEventAI.h"
+
+#include <algorithm>
+
+namespace engine::server::ai
+{
+	namespace
+	{
+		const engine::routine::RoutineProperty* FindProp(
+			const engine::routine::RoutineNode& n, std::string_view key)
+		{
+			for (const auto& p : n.properties)
+				if (p.key == key) return &p;
+			return nullptr;
+		}
+
+		void Warn(std::string& out, const std::string& msg)
+		{
+			if (!out.empty()) out.push_back('\n');
+			out += msg;
+		}
+	} // namespace
+
+	std::vector<EventAIRow> RoutineToEventAI(const engine::routine::RoutineGraph& graph,
+	                                         std::string& outWarnings)
+	{
+		using namespace engine::routine;
+
+		std::vector<EventAIRow> rows;
+		outWarnings.clear();
+
+		if (graph.kind != RoutineGraphKind::NpcRoutine)
+		{
+			Warn(outWarnings, "graphe non npc_routine : aucune ligne EventAI generee");
+			return rows;
+		}
+
+		// Ordre déterministe : tri des nœuds par id.
+		std::vector<const RoutineNode*> nodes;
+		nodes.reserve(graph.nodes.size());
+		for (const auto& n : graph.nodes) nodes.push_back(&n);
+		std::sort(nodes.begin(), nodes.end(),
+		          [](const RoutineNode* a, const RoutineNode* b) { return a->id < b->id; });
+
+		uint32_t nextEventId = 1;
+		for (const RoutineNode* np : nodes)
+		{
+			const RoutineNode& n = *np;
+			switch (n.type)
+			{
+				case RoutineNodeType::TaskPlayAnim:
+				{
+					EventAIRow row;
+					row.eventId = nextEventId++;
+					row.trigger = EventTrigger::Timer;
+					row.param1 = 5000; // période par défaut (ms) ; affinable plus tard.
+					row.param2 = 5000;
+					row.action = EventAction::Custom;
+					if (const auto* p = FindProp(n, "animId")) row.actionString = "anim:" + p->sValue;
+					rows.push_back(row);
+					break;
+				}
+				case RoutineNodeType::TaskSetEmotion:
+				{
+					EventAIRow row;
+					row.eventId = nextEventId++;
+					row.trigger = EventTrigger::OnSpawn;
+					row.action = EventAction::Custom;
+					if (const auto* p = FindProp(n, "emotion")) row.actionString = "emotion:" + p->sValue;
+					row.oneShot = true;
+					rows.push_back(row);
+					break;
+				}
+				case RoutineNodeType::TaskMoveTo:
+					// Hook manquant : EventAction n'a pas d'action de déplacement ;
+					// la cible (point de rôle / Smart Object) n'existe pas encore.
+					Warn(outWarnings, "noeud " + std::to_string(n.id) +
+					     " (TaskMoveTo) non supporte : hook MoveTo / Role Registry / Smart Object manquant (Blocked)");
+					break;
+				case RoutineNodeType::SensorPlayerInRange:
+					// Hook manquant : EventAI n'a pas de trigger 'joueur a portee'.
+					Warn(outWarnings, "noeud " + std::to_string(n.id) +
+					     " (SensorPlayerInRange) non supporte : pas de trigger de portee dans EventAI (Blocked)");
+					break;
+				case RoutineNodeType::NpcStateRoot:
+				case RoutineNodeType::NpcState:
+				case RoutineNodeType::SensorTimeOfDay:
+				case RoutineNodeType::Comment:
+					// Structurels / non encore mappes : silencieux.
+					break;
+				default:
+					Warn(outWarnings, "noeud " + std::to_string(n.id) +
+					     " : type non gere par la traduction PNJ");
+					break;
+			}
+		}
+		return rows;
+	}
+}

--- a/src/shardd/ai/RoutineToEventAI.h
+++ b/src/shardd/ai/RoutineToEventAI.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// M101.7 (partiel) — Pont de traduction graphe npc_routine -> EventAIRow.
+//
+// Décision actée : la cible PNJ réutilise l'IA data-driven existante (EventAI)
+// plutôt que d'introduire une seconde IA concurrente. Ce pont génère des
+// EventAIRow consommables par l'EventAIRuntime existant, pour le SOUS-ENSEMBLE
+// de nœuds qui a un hook existant. Les nœuds sans hook (déplacement vers un
+// point de rôle / Smart Object, capteur de portée) sont signalés dans
+// `outWarnings` — leur support reste BLOQUÉ tant que l'infra PNJ (Role
+// Registry, Smart Objects, action MoveTo) n'est pas livrée.
+
+#include <string>
+#include <vector>
+
+#include "src/shardd/ai/EventAI.h"
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::server::ai
+{
+	/// Traduit un graphe npc_routine en lignes EventAI (déterministe : ordre
+	/// stable par id de nœud). Renseigne `outWarnings` (une ligne par nœud non
+	/// supporté) sans échouer : le reste du graphe est traduit normalement.
+	std::vector<EventAIRow> RoutineToEventAI(const engine::routine::RoutineGraph& graph,
+	                                         std::string& outWarnings);
+}

--- a/src/shardd/ai/tests/RoutineToEventAITests.cpp
+++ b/src/shardd/ai/tests/RoutineToEventAITests.cpp
@@ -1,0 +1,107 @@
+// M101.7 (partiel) — Tests de traduction npc_routine -> EventAIRow, headless.
+
+#include "src/shardd/ai/RoutineToEventAI.h"
+#include "src/shared/routine/RoutineGraph.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace engine::routine;
+using namespace engine::server::ai;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Contains(const std::string& hay, const char* needle)
+	{
+		return hay.find(needle) != std::string::npos;
+	}
+
+	RoutineNode TaskNode(uint32_t id, RoutineNodeType type, const char* propKey, const char* propVal)
+	{
+		RoutineNode n; n.id = id; n.type = type;
+		if (propKey)
+		{
+			RoutineProperty p; p.key = propKey; p.type = RoutineDataType::String; p.sValue = propVal;
+			n.properties.push_back(p);
+		}
+		return n;
+	}
+
+	void Test_MappableTasks()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::NpcRoutine;
+		g.nodes.push_back(TaskNode(1, RoutineNodeType::NpcStateRoot, nullptr, nullptr));
+		g.nodes.push_back(TaskNode(2, RoutineNodeType::TaskPlayAnim, "animId", "idle_01"));
+		g.nodes.push_back(TaskNode(3, RoutineNodeType::TaskSetEmotion, "emotion", "happy"));
+
+		std::string warn;
+		auto rows = RoutineToEventAI(g, warn);
+		REQUIRE(rows.size() == 2);
+		REQUIRE(warn.empty());
+		if (rows.size() == 2)
+		{
+			REQUIRE(rows[0].action == EventAction::Custom);
+			REQUIRE(Contains(rows[0].actionString, "idle_01"));
+			REQUIRE(rows[1].trigger == EventTrigger::OnSpawn);
+			REQUIRE(Contains(rows[1].actionString, "happy"));
+		}
+	}
+
+	void Test_BlockedNodesWarn()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::NpcRoutine;
+		g.nodes.push_back(TaskNode(1, RoutineNodeType::TaskMoveTo, "targetRef", "post_garde"));
+		g.nodes.push_back(TaskNode(2, RoutineNodeType::SensorPlayerInRange, nullptr, nullptr));
+
+		std::string warn;
+		auto rows = RoutineToEventAI(g, warn);
+		REQUIRE(rows.empty());
+		REQUIRE(Contains(warn, "TaskMoveTo"));
+		REQUIRE(Contains(warn, "SensorPlayerInRange"));
+	}
+
+	void Test_WrongKind()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		std::string warn;
+		auto rows = RoutineToEventAI(g, warn);
+		REQUIRE(rows.empty());
+		REQUIRE(!warn.empty());
+	}
+
+	void Test_Deterministic()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::NpcRoutine;
+		g.nodes.push_back(TaskNode(3, RoutineNodeType::TaskPlayAnim, "animId", "a"));
+		g.nodes.push_back(TaskNode(1, RoutineNodeType::TaskSetEmotion, "emotion", "e"));
+		std::string w1, w2;
+		auto a = RoutineToEventAI(g, w1);
+		auto b = RoutineToEventAI(g, w2);
+		REQUIRE(a.size() == b.size());
+		for (size_t i = 0; i < a.size() && i < b.size(); ++i)
+			REQUIRE(a[i].eventId == b[i].eventId && a[i].actionString == b[i].actionString);
+	}
+}
+
+int main()
+{
+	Test_MappableTasks();
+	Test_BlockedNodesWarn();
+	Test_WrongKind();
+	Test_Deterministic();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineToEventAITests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineToEventAITests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/shared/routine/RoutineGraph.h
+++ b/src/shared/routine/RoutineGraph.h
@@ -1,0 +1,208 @@
+#pragma once
+
+// M101.1 — Modèle de graphe de routine (cluster M101 : éditeur de routines nodal).
+//
+// Lib PURE `routine_graph` : aucune dépendance Vulkan/GLFW/réseau, et aucune
+// dépendance à `engine_core` (le shard, qui ne linke pas `engine_core`, doit
+// pouvoir réutiliser ce modèle pour la traduction PNJ — voir M101.7). Seule
+// dépendance externe autorisée : `engine::math::Vec3` (header-only, partagé).
+//
+// Ce header pose le CONTRAT DE DONNÉES partagé par tout le cluster M101 :
+// structs du graphe, enums bornés/versionnés, et les conversions enum<->chaîne
+// utilisées par la sérialisation JSON (M101.1) et le schéma (M101.1).
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::routine
+{
+	/// Version du wire JSON / du modèle. Tout changement de format de
+	/// sérialisation incrémente cette constante ; `FromJson` rejette proprement
+	/// une version supérieure inconnue (erreur, pas de crash).
+	inline constexpr uint32_t kRoutineGraphVersion = 1u;
+
+	/// Cible d'un graphe. Discrimine les deux schémas/VM (décision M101 : deux
+	/// types de graphes distincts partageant la sérialisation).
+	enum class RoutineGraphKind : uint8_t
+	{
+		NpcRoutine = 0,   ///< StateTree-like (cible A — M101.7, Blocked).
+		ZoneEvent  = 1    ///< Blueprint-like (cible B — M101.8).
+	};
+
+	/// Direction d'un pin.
+	enum class PinDirection : uint8_t { Input = 0, Output = 1 };
+
+	/// Famille d'un pin : flux d'exécution (Exec) ou valeur typée (Data). Cette
+	/// distinction est fondamentale (héritée du modèle Blueprint).
+	enum class PinKind : uint8_t { Exec = 0, Data = 1 };
+
+	/// Type de donnée porté par un pin Data (ou une propriété).
+	enum class RoutineDataType : uint8_t
+	{
+		None = 0, Bool = 1, Int = 2, Float = 3, Vec3 = 4, String = 5, EntityRef = 6
+	};
+
+	/// Type de nœud. Enum BORNÉ ET VERSIONNÉ : plages réservées par cible.
+	/// Tout ajout se fait EN FIN de la plage concernée ; ne JAMAIS réordonner ni
+	/// recycler une valeur (casse les graphes déjà sérialisés).
+	enum class RoutineNodeType : uint16_t
+	{
+		// --- commun (0..99) ---
+		Comment               = 0,
+
+		// --- zone_event / Blueprint-like (100..199) — détaillé en M101.8 ---
+		EventOnZoneEnter      = 100,
+		EventOnZoneExit       = 101,
+		EventOnInteract       = 102,
+		BranchIf              = 120,
+		ActionOpenInteractive = 130,
+		ActionBroadcastSeason = 131,
+		ActionBroadcastWeather= 132,
+
+		// --- npc_routine / StateTree-like (200..299) — détaillé en M101.7 ---
+		NpcStateRoot          = 200,
+		NpcState              = 201,
+		SensorPlayerInRange   = 210,   ///< « evaluator » : lit/calcule, ne déclenche pas.
+		SensorTimeOfDay       = 211,
+		TaskPlayAnim          = 220,   ///< « task » : agit.
+		TaskMoveTo            = 221,
+		TaskSetEmotion        = 222
+	};
+
+	/// Propriété typée d'un nœud (sac clé->valeur). Un seul champ « value » est
+	/// pertinent selon `type`.
+	struct RoutineProperty
+	{
+		std::string       key;
+		RoutineDataType   type = RoutineDataType::None;
+		bool              bValue = false;
+		int64_t           iValue = 0;
+		float             fValue = 0.0f;
+		engine::math::Vec3 vValue{ 0.0f, 0.0f, 0.0f };
+		std::string       sValue;   ///< String, ou id textuel pour EntityRef.
+	};
+
+	/// Pin d'un nœud (point de connexion).
+	struct RoutinePin
+	{
+		uint32_t        id = 0;          ///< Unique dans le graphe.
+		PinDirection    direction = PinDirection::Input;
+		PinKind         kind = PinKind::Exec;
+		RoutineDataType dataType = RoutineDataType::None; ///< Pertinent si kind == Data.
+		std::string     name;
+	};
+
+	/// Nœud du graphe.
+	struct RoutineNode
+	{
+		uint32_t        id = 0;          ///< Unique dans le graphe.
+		RoutineNodeType type = RoutineNodeType::Comment;
+		float           canvasX = 0.0f;  ///< Disposition éditeur uniquement.
+		float           canvasY = 0.0f;
+		std::vector<RoutinePin>      pins;
+		std::vector<RoutineProperty> properties;
+	};
+
+	/// Lien orienté pin->pin.
+	struct RoutineLink
+	{
+		uint32_t id = 0;
+		uint32_t fromNodeId = 0;
+		uint32_t fromPinId = 0;
+		uint32_t toNodeId = 0;
+		uint32_t toPinId = 0;
+	};
+
+	/// Graphe complet.
+	struct RoutineGraph
+	{
+		uint32_t              version = kRoutineGraphVersion;
+		RoutineGraphKind      kind = RoutineGraphKind::ZoneEvent;
+		std::string           name;
+		std::vector<RoutineNode> nodes;
+		std::vector<RoutineLink> links;
+	};
+
+	// ---------------------------------------------------------------------
+	// Conversions enum <-> chaîne (utilisées par la sérialisation + le schéma).
+	// Déterministes et stables. Toute nouvelle valeur d'enum DOIT être ajoutée
+	// ici en parallèle, sinon la sérialisation échoue (volontairement).
+	// ---------------------------------------------------------------------
+
+	inline const char* ToString(RoutineGraphKind k)
+	{
+		switch (k)
+		{
+			case RoutineGraphKind::NpcRoutine: return "npc_routine";
+			case RoutineGraphKind::ZoneEvent:  return "zone_event";
+		}
+		return "zone_event";
+	}
+
+	inline bool FromString(std::string_view s, RoutineGraphKind& out)
+	{
+		if (s == "npc_routine") { out = RoutineGraphKind::NpcRoutine; return true; }
+		if (s == "zone_event")  { out = RoutineGraphKind::ZoneEvent;  return true; }
+		return false;
+	}
+
+	inline const char* ToString(PinDirection d)
+	{
+		return d == PinDirection::Input ? "in" : "out";
+	}
+
+	inline bool FromString(std::string_view s, PinDirection& out)
+	{
+		if (s == "in")  { out = PinDirection::Input;  return true; }
+		if (s == "out") { out = PinDirection::Output; return true; }
+		return false;
+	}
+
+	inline const char* ToString(PinKind k)
+	{
+		return k == PinKind::Exec ? "exec" : "data";
+	}
+
+	inline bool FromString(std::string_view s, PinKind& out)
+	{
+		if (s == "exec") { out = PinKind::Exec; return true; }
+		if (s == "data") { out = PinKind::Data; return true; }
+		return false;
+	}
+
+	inline const char* ToString(RoutineDataType t)
+	{
+		switch (t)
+		{
+			case RoutineDataType::None:      return "none";
+			case RoutineDataType::Bool:      return "bool";
+			case RoutineDataType::Int:       return "int";
+			case RoutineDataType::Float:     return "float";
+			case RoutineDataType::Vec3:      return "vec3";
+			case RoutineDataType::String:    return "string";
+			case RoutineDataType::EntityRef: return "entity_ref";
+		}
+		return "none";
+	}
+
+	inline bool FromString(std::string_view s, RoutineDataType& out)
+	{
+		if (s == "none")       { out = RoutineDataType::None;      return true; }
+		if (s == "bool")       { out = RoutineDataType::Bool;      return true; }
+		if (s == "int")        { out = RoutineDataType::Int;       return true; }
+		if (s == "float")      { out = RoutineDataType::Float;     return true; }
+		if (s == "vec3")       { out = RoutineDataType::Vec3;      return true; }
+		if (s == "string")     { out = RoutineDataType::String;    return true; }
+		if (s == "entity_ref") { out = RoutineDataType::EntityRef; return true; }
+		return false;
+	}
+
+	/// Nom stable d'un type de nœud (clé de sérialisation + libellé schéma).
+	const char* ToString(RoutineNodeType t);
+	/// Inverse de `ToString(RoutineNodeType)`. Retourne false si inconnu.
+	bool FromString(std::string_view s, RoutineNodeType& out);
+}

--- a/src/shared/routine/RoutineGraphValidation.cpp
+++ b/src/shared/routine/RoutineGraphValidation.cpp
@@ -1,0 +1,217 @@
+// M101.6 — Implémentation de la validation de graphe (pure, déterministe).
+
+#include "src/shared/routine/RoutineGraphValidation.h"
+
+#include "src/shared/routine/RoutineNodeSchema.h"
+
+#include <algorithm>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace engine::routine::validation
+{
+	namespace
+	{
+		bool IsEventRoot(RoutineNodeType t)
+		{
+			return t == RoutineNodeType::EventOnZoneEnter ||
+			       t == RoutineNodeType::EventOnZoneExit ||
+			       t == RoutineNodeType::EventOnInteract;
+		}
+
+		bool IsRootForKind(const RoutineNode& n, RoutineGraphKind kind)
+		{
+			if (kind == RoutineGraphKind::ZoneEvent) return IsEventRoot(n.type);
+			return n.type == RoutineNodeType::NpcStateRoot;
+		}
+
+		const RoutineNode* FindNode(const RoutineGraph& g, uint32_t id)
+		{
+			for (const auto& n : g.nodes) if (n.id == id) return &n;
+			return nullptr;
+		}
+
+		const RoutinePin* FindPin(const RoutineNode& n, uint32_t pinId)
+		{
+			for (const auto& p : n.pins) if (p.id == pinId) return &p;
+			return nullptr;
+		}
+
+		bool HasExecInput(const RoutineNode& n)
+		{
+			for (const auto& p : n.pins)
+				if (p.kind == PinKind::Exec && p.direction == PinDirection::Input) return true;
+			return false;
+		}
+	} // namespace
+
+	std::vector<ValidationIssue> Validate(const RoutineGraph& graph)
+	{
+		std::vector<ValidationIssue> issues;
+
+		// --- Conformité au schéma (type valide pour la cible) ---
+		for (const auto& n : graph.nodes)
+		{
+			const RoutineNodeSchema* s = FindSchema(n.type);
+			if (!s)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::SchemaMismatch, n.id, 0,
+				                   "type de noeud inconnu" });
+				continue;
+			}
+			if (!SchemaValidForKind(*s, graph.kind))
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::SchemaMismatch, n.id, 0,
+				                   std::string("noeud '") + s->displayName + "' invalide pour cette cible" });
+			}
+			// EntityRef vide → avertissement (impossible de résoudre à l'édition).
+			for (const auto& pr : n.properties)
+			{
+				if (pr.type == RoutineDataType::EntityRef && pr.sValue.empty())
+				{
+					issues.push_back({ IssueSeverity::Warning, IssueKind::UnknownEntityRef, n.id, 0,
+					                   "reference d'entite vide : '" + pr.key + "'" });
+				}
+			}
+		}
+
+		// --- Pins des liens : direction + compatibilité kind/type ---
+		for (const auto& l : graph.links)
+		{
+			const RoutineNode* from = FindNode(graph, l.fromNodeId);
+			const RoutineNode* to = FindNode(graph, l.toNodeId);
+			if (!from || !to)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::IncompatiblePins, 0, l.id,
+				                   "lien vers un noeud inexistant" });
+				continue;
+			}
+			const RoutinePin* fp = FindPin(*from, l.fromPinId);
+			const RoutinePin* tp = FindPin(*to, l.toPinId);
+			if (!fp || !tp)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::IncompatiblePins, 0, l.id,
+				                   "lien vers un pin inexistant" });
+				continue;
+			}
+			if (fp->direction != PinDirection::Output || tp->direction != PinDirection::Input)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::IncompatiblePins, 0, l.id,
+				                   "lien doit aller d'une sortie vers une entree" });
+			}
+			if (fp->kind != tp->kind)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::IncompatiblePins, 0, l.id,
+				                   "melange de pins exec et data" });
+			}
+			else if (fp->kind == PinKind::Data && fp->dataType != tp->dataType)
+			{
+				issues.push_back({ IssueSeverity::Error, IssueKind::IncompatiblePins, 0, l.id,
+				                   "types de donnees incompatibles" });
+			}
+		}
+
+		// --- Cardinalité des racines ---
+		uint32_t rootCount = 0;
+		uint32_t npcRootCount = 0;
+		for (const auto& n : graph.nodes)
+		{
+			if (IsRootForKind(n, graph.kind)) ++rootCount;
+			if (n.type == RoutineNodeType::NpcStateRoot) ++npcRootCount;
+		}
+		if (rootCount == 0)
+		{
+			issues.push_back({ IssueSeverity::Error, IssueKind::RootCardinality, 0, 0,
+			                   "aucun noeud racine (Event / NpcStateRoot)" });
+		}
+		if (graph.kind == RoutineGraphKind::NpcRoutine && npcRootCount > 1)
+		{
+			issues.push_back({ IssueSeverity::Error, IssueKind::RootCardinality, 0, 0,
+			                   "un seul NpcStateRoot autorise" });
+		}
+
+		// --- Détection de cycle d'exécution + accessibilité (exec wires) ---
+		// Adjacence exec : nodeId -> nodeIds atteints par un lien exec sortant.
+		std::unordered_map<uint32_t, std::vector<uint32_t>> adj;
+		for (const auto& l : graph.links)
+		{
+			const RoutineNode* from = FindNode(graph, l.fromNodeId);
+			if (!from) continue;
+			const RoutinePin* fp = FindPin(*from, l.fromPinId);
+			if (fp && fp->kind == PinKind::Exec) adj[l.fromNodeId].push_back(l.toNodeId);
+		}
+
+		// DFS de détection de cycle (gris/noir).
+		std::unordered_set<uint32_t> visiting, visited;
+		bool cycleReported = false;
+		std::function<void(uint32_t)> dfs = [&](uint32_t id)
+		{
+			if (cycleReported) return;
+			visiting.insert(id);
+			auto it = adj.find(id);
+			if (it != adj.end())
+			{
+				for (uint32_t nxt : it->second)
+				{
+					if (visiting.count(nxt))
+					{
+						issues.push_back({ IssueSeverity::Error, IssueKind::ExecCycle, nxt, 0,
+						                   "cycle d'execution detecte" });
+						cycleReported = true;
+						return;
+					}
+					if (!visited.count(nxt)) dfs(nxt);
+				}
+			}
+			visiting.erase(id);
+			visited.insert(id);
+		};
+		for (const auto& n : graph.nodes)
+		{
+			if (!visited.count(n.id) && !cycleReported) dfs(n.id);
+		}
+
+		// Accessibilité depuis les racines (orphelins).
+		std::unordered_set<uint32_t> reachable;
+		std::vector<uint32_t> stack;
+		for (const auto& n : graph.nodes)
+			if (IsRootForKind(n, graph.kind)) { reachable.insert(n.id); stack.push_back(n.id); }
+		while (!stack.empty())
+		{
+			uint32_t id = stack.back(); stack.pop_back();
+			auto it = adj.find(id);
+			if (it == adj.end()) continue;
+			for (uint32_t nxt : it->second)
+				if (reachable.insert(nxt).second) stack.push_back(nxt);
+		}
+		for (const auto& n : graph.nodes)
+		{
+			if (n.type == RoutineNodeType::Comment) continue;        // libre
+			if (IsRootForKind(n, graph.kind)) continue;              // racine
+			if (!HasExecInput(n)) continue;                          // capteur data-only
+			if (!reachable.count(n.id))
+			{
+				issues.push_back({ IssueSeverity::Warning, IssueKind::OrphanNode, n.id, 0,
+				                   "noeud non atteignable depuis une racine" });
+			}
+		}
+
+		// Tri stable et déterministe.
+		std::sort(issues.begin(), issues.end(),
+		          [](const ValidationIssue& a, const ValidationIssue& b)
+		          {
+			          if (a.kind != b.kind) return static_cast<int>(a.kind) < static_cast<int>(b.kind);
+			          if (a.nodeId != b.nodeId) return a.nodeId < b.nodeId;
+			          return a.linkId < b.linkId;
+		          });
+		return issues;
+	}
+
+	bool HasError(const std::vector<ValidationIssue>& issues)
+	{
+		for (const auto& i : issues)
+			if (i.severity == IssueSeverity::Error) return true;
+		return false;
+	}
+}

--- a/src/shared/routine/RoutineGraphValidation.h
+++ b/src/shared/routine/RoutineGraphValidation.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// M101.6 — Validation structurelle d'un graphe de routine.
+//
+// Fonction PURE et DÉTERMINISTE (dans la lib routine_graph) : utilisable en CI
+// headless ET par l'éditeur (la couche UI ne fait que présenter les issues).
+
+#include <string>
+#include <vector>
+
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::routine::validation
+{
+	enum class IssueSeverity : uint8_t { Warning = 0, Error = 1 };
+
+	enum class IssueKind : uint8_t
+	{
+		ExecCycle = 0,
+		IncompatiblePins = 1,
+		OrphanNode = 2,
+		SchemaMismatch = 3,
+		RootCardinality = 4,
+		UnknownEntityRef = 5
+	};
+
+	struct ValidationIssue
+	{
+		IssueSeverity severity = IssueSeverity::Error;
+		IssueKind     kind = IssueKind::SchemaMismatch;
+		uint32_t      nodeId = 0;   ///< 0 si global.
+		uint32_t      linkId = 0;   ///< 0 si non pertinent.
+		std::string   message;
+	};
+
+	/// Valide le graphe. Issues triées de façon stable (kind, nodeId, linkId).
+	std::vector<ValidationIssue> Validate(const RoutineGraph& graph);
+
+	/// True si au moins une issue de sévérité Error est présente.
+	bool HasError(const std::vector<ValidationIssue>& issues);
+}

--- a/src/shared/routine/RoutineNodeSchema.cpp
+++ b/src/shared/routine/RoutineNodeSchema.cpp
@@ -1,0 +1,166 @@
+// M101.1 — Implémentation du schéma + mapping RoutineNodeType <-> chaîne.
+
+#include "src/shared/routine/RoutineNodeSchema.h"
+
+namespace engine::routine
+{
+	namespace
+	{
+		// Fabriques de pins/propriétés concises pour la table de schémas. Les ids
+		// de pin sont des placeholders locaux au gabarit (réassignés à
+		// l'instanciation, M101.5).
+		RoutinePin ExecPin(uint32_t id, PinDirection dir, const char* name)
+		{
+			RoutinePin p;
+			p.id = id; p.direction = dir; p.kind = PinKind::Exec;
+			p.dataType = RoutineDataType::None; p.name = name;
+			return p;
+		}
+
+		RoutinePin DataPin(uint32_t id, PinDirection dir, RoutineDataType dt, const char* name)
+		{
+			RoutinePin p;
+			p.id = id; p.direction = dir; p.kind = PinKind::Data;
+			p.dataType = dt; p.name = name;
+			return p;
+		}
+
+		RoutineProperty Prop(const char* key, RoutineDataType type)
+		{
+			RoutineProperty pr;
+			pr.key = key; pr.type = type;
+			return pr;
+		}
+
+		constexpr uint8_t kNpc  = 1u << static_cast<int>(RoutineGraphKind::NpcRoutine);
+		constexpr uint8_t kZone = 1u << static_cast<int>(RoutineGraphKind::ZoneEvent);
+		constexpr uint8_t kBoth = kNpc | kZone;
+
+		std::vector<RoutineNodeSchema> BuildSchemas()
+		{
+			std::vector<RoutineNodeSchema> t;
+
+			// --- commun ---
+			t.push_back({ RoutineNodeType::Comment, "Commentaire", kBoth,
+				{}, { Prop("text", RoutineDataType::String) } });
+
+			// --- zone_event ---
+			t.push_back({ RoutineNodeType::EventOnZoneEnter, "Événement : entrée de zone", kZone,
+				{ ExecPin(1, PinDirection::Output, "fired") },
+				{ Prop("zoneId", RoutineDataType::EntityRef) } });
+
+			t.push_back({ RoutineNodeType::EventOnZoneExit, "Événement : sortie de zone", kZone,
+				{ ExecPin(1, PinDirection::Output, "fired") },
+				{ Prop("zoneId", RoutineDataType::EntityRef) } });
+
+			t.push_back({ RoutineNodeType::EventOnInteract, "Événement : interaction", kZone,
+				{ ExecPin(1, PinDirection::Output, "fired") },
+				{ Prop("interactiveId", RoutineDataType::EntityRef) } });
+
+			t.push_back({ RoutineNodeType::BranchIf, "Branche (si)", kZone,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "true"),
+				  ExecPin(3, PinDirection::Output, "false"),
+				  DataPin(4, PinDirection::Input, RoutineDataType::Bool, "cond") },
+				{} });
+
+			t.push_back({ RoutineNodeType::ActionOpenInteractive, "Action : ouvrir/fermer objet", kZone,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("interactiveId", RoutineDataType::EntityRef),
+				  Prop("open", RoutineDataType::Bool) } });
+
+			t.push_back({ RoutineNodeType::ActionBroadcastSeason, "Action : broadcast saison", kZone,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("seasonIndex", RoutineDataType::Int) } });
+
+			t.push_back({ RoutineNodeType::ActionBroadcastWeather, "Action : broadcast météo", kZone,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("weatherIndex", RoutineDataType::Int) } });
+
+			// --- npc_routine ---
+			t.push_back({ RoutineNodeType::NpcStateRoot, "PNJ : racine d'états", kNpc,
+				{ ExecPin(1, PinDirection::Output, "enter") }, {} });
+
+			t.push_back({ RoutineNodeType::NpcState, "PNJ : état", kNpc,
+				{ ExecPin(1, PinDirection::Input, "enter"),
+				  ExecPin(2, PinDirection::Output, "tasks") },
+				{ Prop("name", RoutineDataType::String) } });
+
+			t.push_back({ RoutineNodeType::SensorPlayerInRange, "Capteur : joueur à portée", kNpc,
+				{ DataPin(1, PinDirection::Output, RoutineDataType::Bool, "inRange") },
+				{ Prop("rangeMeters", RoutineDataType::Float) } });
+
+			t.push_back({ RoutineNodeType::SensorTimeOfDay, "Capteur : heure du jour", kNpc,
+				{ DataPin(1, PinDirection::Output, RoutineDataType::Float, "hours") }, {} });
+
+			t.push_back({ RoutineNodeType::TaskPlayAnim, "Tâche : jouer animation", kNpc,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("animId", RoutineDataType::String) } });
+
+			t.push_back({ RoutineNodeType::TaskMoveTo, "Tâche : se déplacer vers", kNpc,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("targetRef", RoutineDataType::EntityRef) } });
+
+			t.push_back({ RoutineNodeType::TaskSetEmotion, "Tâche : changer d'émotion", kNpc,
+				{ ExecPin(1, PinDirection::Input, "in"),
+				  ExecPin(2, PinDirection::Output, "out") },
+				{ Prop("emotion", RoutineDataType::String) } });
+
+			return t;
+		}
+	} // namespace
+
+	const std::vector<RoutineNodeSchema>& AllSchemas()
+	{
+		static const std::vector<RoutineNodeSchema> kSchemas = BuildSchemas();
+		return kSchemas;
+	}
+
+	const RoutineNodeSchema* FindSchema(RoutineNodeType type)
+	{
+		for (const auto& s : AllSchemas())
+		{
+			if (s.type == type) return &s;
+		}
+		return nullptr;
+	}
+
+	// ---- mapping RoutineNodeType <-> chaîne (déclaré dans RoutineGraph.h) ----
+
+	const char* ToString(RoutineNodeType t)
+	{
+		switch (t)
+		{
+			case RoutineNodeType::Comment:               return "Comment";
+			case RoutineNodeType::EventOnZoneEnter:      return "EventOnZoneEnter";
+			case RoutineNodeType::EventOnZoneExit:       return "EventOnZoneExit";
+			case RoutineNodeType::EventOnInteract:       return "EventOnInteract";
+			case RoutineNodeType::BranchIf:              return "BranchIf";
+			case RoutineNodeType::ActionOpenInteractive: return "ActionOpenInteractive";
+			case RoutineNodeType::ActionBroadcastSeason: return "ActionBroadcastSeason";
+			case RoutineNodeType::ActionBroadcastWeather:return "ActionBroadcastWeather";
+			case RoutineNodeType::NpcStateRoot:          return "NpcStateRoot";
+			case RoutineNodeType::NpcState:              return "NpcState";
+			case RoutineNodeType::SensorPlayerInRange:   return "SensorPlayerInRange";
+			case RoutineNodeType::SensorTimeOfDay:       return "SensorTimeOfDay";
+			case RoutineNodeType::TaskPlayAnim:          return "TaskPlayAnim";
+			case RoutineNodeType::TaskMoveTo:            return "TaskMoveTo";
+			case RoutineNodeType::TaskSetEmotion:        return "TaskSetEmotion";
+		}
+		return "Comment";
+	}
+
+	bool FromString(std::string_view s, RoutineNodeType& out)
+	{
+		for (const auto& sch : AllSchemas())
+		{
+			if (s == ToString(sch.type)) { out = sch.type; return true; }
+		}
+		return false;
+	}
+}

--- a/src/shared/routine/RoutineNodeSchema.h
+++ b/src/shared/routine/RoutineNodeSchema.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// M101.1 — Schéma de bornage des types de nœuds.
+//
+// Table STATIQUE (en dur, pas de données externes) décrivant, pour chaque
+// `RoutineNodeType` : son libellé, les cibles `RoutineGraphKind` où il est
+// valide, et les gabarits de pins/propriétés. Source de vérité unique pour la
+// palette (M101.5), la validation (M101.6) et la doc (M101.11) — l'UI ne code
+// AUCUN type de nœud en dur.
+
+#include <vector>
+
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::routine
+{
+	/// Descripteur statique d'un type de nœud.
+	struct RoutineNodeSchema
+	{
+		RoutineNodeType type = RoutineNodeType::Comment;
+		const char*     displayName = "";
+		/// Masque des cibles valides : bit (1u << int(RoutineGraphKind)).
+		uint8_t         validKindsMask = 0;
+		std::vector<RoutinePin>      pinTemplate;
+		std::vector<RoutineProperty> propertyTemplate;
+	};
+
+	/// Masque de cible pour un `RoutineGraphKind`.
+	inline uint8_t KindMask(RoutineGraphKind k)
+	{
+		return static_cast<uint8_t>(1u << static_cast<int>(k));
+	}
+
+	/// True si le schéma est utilisable dans un graphe de cette cible.
+	inline bool SchemaValidForKind(const RoutineNodeSchema& s, RoutineGraphKind k)
+	{
+		return (s.validKindsMask & KindMask(k)) != 0;
+	}
+
+	/// Table immuable de tous les schémas connus (ordre stable).
+	const std::vector<RoutineNodeSchema>& AllSchemas();
+
+	/// Schéma d'un type donné, ou nullptr si inconnu.
+	const RoutineNodeSchema* FindSchema(RoutineNodeType type);
+}

--- a/src/shared/routine/RoutineSegmentCodec.cpp
+++ b/src/shared/routine/RoutineSegmentCodec.cpp
@@ -1,0 +1,90 @@
+// M101.3 — Implémentation du codec `routines.bin`.
+
+#include "src/shared/routine/RoutineSegmentCodec.h"
+
+#include "src/shared/routine/RoutineSerialization.h"
+
+namespace engine::routine::codec
+{
+	namespace
+	{
+		void WriteU32LE(std::vector<uint8_t>& out, uint32_t v)
+		{
+			out.push_back(static_cast<uint8_t>(v & 0xFFu));
+			out.push_back(static_cast<uint8_t>((v >> 8) & 0xFFu));
+			out.push_back(static_cast<uint8_t>((v >> 16) & 0xFFu));
+			out.push_back(static_cast<uint8_t>((v >> 24) & 0xFFu));
+		}
+
+		bool ReadU32LE(const std::vector<uint8_t>& in, size_t& pos, uint32_t& out)
+		{
+			if (pos + 4 > in.size()) return false;
+			out = static_cast<uint32_t>(in[pos]) |
+			      (static_cast<uint32_t>(in[pos + 1]) << 8) |
+			      (static_cast<uint32_t>(in[pos + 2]) << 16) |
+			      (static_cast<uint32_t>(in[pos + 3]) << 24);
+			pos += 4;
+			return true;
+		}
+	} // namespace
+
+	std::vector<uint8_t> EncodeRoutinesBin(const std::vector<RoutineGraph>& graphs)
+	{
+		std::vector<uint8_t> out;
+		WriteU32LE(out, kRoutinesMagic);
+		WriteU32LE(out, kRoutinesContainerVersion);
+		WriteU32LE(out, static_cast<uint32_t>(graphs.size()));
+		for (const RoutineGraph& g : graphs)
+		{
+			const std::string json = serialization::ToJson(g);
+			WriteU32LE(out, static_cast<uint32_t>(json.size()));
+			out.insert(out.end(), json.begin(), json.end());
+		}
+		return out;
+	}
+
+	std::optional<std::vector<RoutineGraph>> DecodeRoutinesBin(
+		const std::vector<uint8_t>& bytes, std::string& outError)
+	{
+		size_t pos = 0;
+		uint32_t magic = 0, version = 0, count = 0;
+		if (!ReadU32LE(bytes, pos, magic) || magic != kRoutinesMagic)
+		{
+			outError = "routines.bin : magic invalide";
+			return std::nullopt;
+		}
+		if (!ReadU32LE(bytes, pos, version) || version > kRoutinesContainerVersion)
+		{
+			outError = "routines.bin : version de conteneur non supportee";
+			return std::nullopt;
+		}
+		if (!ReadU32LE(bytes, pos, count))
+		{
+			outError = "routines.bin : compteur manquant";
+			return std::nullopt;
+		}
+
+		std::vector<RoutineGraph> graphs;
+		graphs.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			uint32_t jsonLen = 0;
+			if (!ReadU32LE(bytes, pos, jsonLen) || pos + jsonLen > bytes.size())
+			{
+				outError = "routines.bin : longueur JSON invalide";
+				return std::nullopt;
+			}
+			std::string json(reinterpret_cast<const char*>(bytes.data() + pos), jsonLen);
+			pos += jsonLen;
+			serialization::ParseError perr;
+			auto g = serialization::FromJson(json, perr);
+			if (!g)
+			{
+				outError = "routines.bin : graphe " + std::to_string(i) + " : " + perr.message;
+				return std::nullopt;
+			}
+			graphs.push_back(std::move(*g));
+		}
+		return graphs;
+	}
+}

--- a/src/shared/routine/RoutineSegmentCodec.h
+++ b/src/shared/routine/RoutineSegmentCodec.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// M101.3 — Codec du segment de chunk `routines.bin`.
+//
+// Encode/décode une liste de graphes en mémoire (pur, dans routine_graph, donc
+// testable headless). Les wrappers fichier (zone_builder writer, client reader)
+// sont de minces appels autour de ce codec. Le corps de chaque graphe est le
+// JSON canonique de M101.1 (length-prefixé) : le round-trip binaire se ramène
+// au round-trip JSON déjà éprouvé.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::routine::codec
+{
+	/// "RUTN" en little-endian.
+	inline constexpr uint32_t kRoutinesMagic = 0x4E545552u;
+	/// Version du conteneur binaire (distincte de kRoutineGraphVersion).
+	inline constexpr uint32_t kRoutinesContainerVersion = 1u;
+
+	/// Sérialise une liste de graphes en octets `routines.bin`.
+	std::vector<uint8_t> EncodeRoutinesBin(const std::vector<RoutineGraph>& graphs);
+
+	/// Désérialise des octets `routines.bin`. Retourne std::nullopt + `outError`
+	/// si l'en-tête, la version ou un graphe est invalide.
+	std::optional<std::vector<RoutineGraph>> DecodeRoutinesBin(
+		const std::vector<uint8_t>& bytes, std::string& outError);
+}

--- a/src/shared/routine/RoutineSerialization.cpp
+++ b/src/shared/routine/RoutineSerialization.cpp
@@ -1,0 +1,557 @@
+// M101.1 — Implémentation de la sérialisation JSON déterministe.
+//
+// Parser et émetteur JSON internes (la lib `routine_graph` est pure : pas de
+// dépendance à un parseur JSON tiers ni à engine_core/zone_builder). Le format
+// émis est volontairement minimal et contrôlé, ce qui garantit le round-trip.
+
+#include "src/shared/routine/RoutineSerialization.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace engine::routine::serialization
+{
+	namespace
+	{
+		// ---------------- Émission ----------------
+
+		void EmitString(std::string& out, std::string_view s)
+		{
+			out.push_back('"');
+			for (char c : s)
+			{
+				switch (c)
+				{
+					case '"':  out += "\\\""; break;
+					case '\\': out += "\\\\"; break;
+					case '\n': out += "\\n";  break;
+					case '\r': out += "\\r";  break;
+					case '\t': out += "\\t";  break;
+					default:
+						if (static_cast<unsigned char>(c) < 0x20)
+						{
+							char buf[8];
+							std::snprintf(buf, sizeof(buf), "\\u%04x",
+							              static_cast<unsigned>(static_cast<unsigned char>(c)));
+							out += buf;
+						}
+						else
+						{
+							out.push_back(c);
+						}
+						break;
+				}
+			}
+			out.push_back('"');
+		}
+
+		void EmitInt(std::string& out, long long v)
+		{
+			char buf[32];
+			std::snprintf(buf, sizeof(buf), "%lld", v);
+			out += buf;
+		}
+
+		void EmitFloat(std::string& out, float v)
+		{
+			// %.9g garantit le round-trip d'un float IEEE-754 32 bits. On
+			// normalise le séparateur décimal en '.' au cas où une locale
+			// exotique serait active (robustesse).
+			char buf[64];
+			std::snprintf(buf, sizeof(buf), "%.9g", static_cast<double>(v));
+			for (char& c : buf)
+			{
+				if (c == ',') c = '.';
+			}
+			out += buf;
+		}
+
+		void EmitPropValue(std::string& out, const RoutineProperty& p)
+		{
+			switch (p.type)
+			{
+				case RoutineDataType::Bool:  out += (p.bValue ? "true" : "false"); break;
+				case RoutineDataType::Int:   EmitInt(out, static_cast<long long>(p.iValue)); break;
+				case RoutineDataType::Float: EmitFloat(out, p.fValue); break;
+				case RoutineDataType::Vec3:
+					out.push_back('[');
+					EmitFloat(out, p.vValue.x); out.push_back(',');
+					EmitFloat(out, p.vValue.y); out.push_back(',');
+					EmitFloat(out, p.vValue.z);
+					out.push_back(']');
+					break;
+				case RoutineDataType::String:
+				case RoutineDataType::EntityRef:
+					EmitString(out, p.sValue);
+					break;
+				case RoutineDataType::None:
+				default:
+					out += "null";
+					break;
+			}
+		}
+
+		// ---------------- Parsing ----------------
+
+		struct JVal
+		{
+			enum class T { Null, Bool, Num, Str, Arr, Obj } t = T::Null;
+			bool b = false;
+			double num = 0.0;
+			std::string str;
+			std::vector<JVal> arr;
+			std::vector<std::pair<std::string, JVal>> obj;
+
+			const JVal* Find(std::string_view key) const
+			{
+				for (const auto& kv : obj)
+				{
+					if (kv.first == key) return &kv.second;
+				}
+				return nullptr;
+			}
+		};
+
+		class Parser
+		{
+		public:
+			Parser(std::string_view s, std::string& err) : m_s(s), m_err(err) {}
+
+			bool Parse(JVal& out)
+			{
+				SkipWs();
+				if (!ParseValue(out)) return false;
+				SkipWs();
+				if (m_pos != m_s.size())
+				{
+					Fail("contenu inattendu après la valeur racine");
+					return false;
+				}
+				return true;
+			}
+
+		private:
+			void Fail(const char* msg)
+			{
+				if (m_err.empty()) m_err = msg;
+			}
+
+			void SkipWs()
+			{
+				while (m_pos < m_s.size())
+				{
+					char c = m_s[m_pos];
+					if (c == ' ' || c == '\t' || c == '\n' || c == '\r') ++m_pos;
+					else break;
+				}
+			}
+
+			bool Eof() const { return m_pos >= m_s.size(); }
+			char Peek() const { return m_s[m_pos]; }
+
+			bool Expect(char c)
+			{
+				if (Eof() || m_s[m_pos] != c) { Fail("caractère attendu manquant"); return false; }
+				++m_pos;
+				return true;
+			}
+
+			bool ParseValue(JVal& out)
+			{
+				SkipWs();
+				if (Eof()) { Fail("fin de chaîne inattendue"); return false; }
+				char c = Peek();
+				switch (c)
+				{
+					case '{': return ParseObject(out);
+					case '[': return ParseArray(out);
+					case '"': out.t = JVal::T::Str; return ParseString(out.str);
+					case 't': case 'f': return ParseBool(out);
+					case 'n': return ParseNull(out);
+					default:
+						if (c == '-' || (c >= '0' && c <= '9')) return ParseNumber(out);
+						Fail("valeur JSON invalide");
+						return false;
+				}
+			}
+
+			bool ParseObject(JVal& out)
+			{
+				out.t = JVal::T::Obj;
+				if (!Expect('{')) return false;
+				SkipWs();
+				if (!Eof() && Peek() == '}') { ++m_pos; return true; }
+				for (;;)
+				{
+					SkipWs();
+					if (Eof() || Peek() != '"') { Fail("clé d'objet attendue"); return false; }
+					std::string key;
+					if (!ParseString(key)) return false;
+					SkipWs();
+					if (!Expect(':')) return false;
+					JVal v;
+					if (!ParseValue(v)) return false;
+					out.obj.emplace_back(std::move(key), std::move(v));
+					SkipWs();
+					if (Eof()) { Fail("objet non terminé"); return false; }
+					char c = Peek();
+					if (c == ',') { ++m_pos; continue; }
+					if (c == '}') { ++m_pos; return true; }
+					Fail("',' ou '}' attendu");
+					return false;
+				}
+			}
+
+			bool ParseArray(JVal& out)
+			{
+				out.t = JVal::T::Arr;
+				if (!Expect('[')) return false;
+				SkipWs();
+				if (!Eof() && Peek() == ']') { ++m_pos; return true; }
+				for (;;)
+				{
+					JVal v;
+					if (!ParseValue(v)) return false;
+					out.arr.push_back(std::move(v));
+					SkipWs();
+					if (Eof()) { Fail("tableau non terminé"); return false; }
+					char c = Peek();
+					if (c == ',') { ++m_pos; continue; }
+					if (c == ']') { ++m_pos; return true; }
+					Fail("',' ou ']' attendu");
+					return false;
+				}
+			}
+
+			bool ParseString(std::string& out)
+			{
+				if (!Expect('"')) return false;
+				out.clear();
+				while (!Eof())
+				{
+					char c = m_s[m_pos++];
+					if (c == '"') return true;
+					if (c == '\\')
+					{
+						if (Eof()) { Fail("échappement non terminé"); return false; }
+						char e = m_s[m_pos++];
+						switch (e)
+						{
+							case '"':  out.push_back('"');  break;
+							case '\\': out.push_back('\\'); break;
+							case '/':  out.push_back('/');  break;
+							case 'n':  out.push_back('\n'); break;
+							case 'r':  out.push_back('\r'); break;
+							case 't':  out.push_back('\t'); break;
+							case 'b':  out.push_back('\b'); break;
+							case 'f':  out.push_back('\f'); break;
+							case 'u':
+							{
+								if (m_pos + 4 > m_s.size()) { Fail("\\u incomplet"); return false; }
+								unsigned code = 0;
+								for (int i = 0; i < 4; ++i)
+								{
+									char h = m_s[m_pos++];
+									code <<= 4;
+									if (h >= '0' && h <= '9') code |= static_cast<unsigned>(h - '0');
+									else if (h >= 'a' && h <= 'f') code |= static_cast<unsigned>(h - 'a' + 10);
+									else if (h >= 'A' && h <= 'F') code |= static_cast<unsigned>(h - 'A' + 10);
+									else { Fail("hex \\u invalide"); return false; }
+								}
+								// Encodage UTF-8 minimal (suffisant pour notre contenu).
+								if (code < 0x80)
+								{
+									out.push_back(static_cast<char>(code));
+								}
+								else if (code < 0x800)
+								{
+									out.push_back(static_cast<char>(0xC0 | (code >> 6)));
+									out.push_back(static_cast<char>(0x80 | (code & 0x3F)));
+								}
+								else
+								{
+									out.push_back(static_cast<char>(0xE0 | (code >> 12)));
+									out.push_back(static_cast<char>(0x80 | ((code >> 6) & 0x3F)));
+									out.push_back(static_cast<char>(0x80 | (code & 0x3F)));
+								}
+								break;
+							}
+							default: Fail("séquence d'échappement inconnue"); return false;
+						}
+					}
+					else
+					{
+						out.push_back(c);
+					}
+				}
+				Fail("chaîne non terminée");
+				return false;
+			}
+
+			bool ParseNumber(JVal& out)
+			{
+				size_t start = m_pos;
+				if (!Eof() && Peek() == '-') ++m_pos;
+				while (!Eof())
+				{
+					char c = Peek();
+					if ((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' ||
+					    c == '+' || c == '-')
+						++m_pos;
+					else
+						break;
+				}
+				if (m_pos == start) { Fail("nombre invalide"); return false; }
+				std::string tok(m_s.substr(start, m_pos - start));
+				out.t = JVal::T::Num;
+				out.num = std::strtod(tok.c_str(), nullptr);
+				return true;
+			}
+
+			bool ParseBool(JVal& out)
+			{
+				if (m_s.compare(m_pos, 4, "true") == 0) { m_pos += 4; out.t = JVal::T::Bool; out.b = true; return true; }
+				if (m_s.compare(m_pos, 5, "false") == 0) { m_pos += 5; out.t = JVal::T::Bool; out.b = false; return true; }
+				Fail("booléen invalide");
+				return false;
+			}
+
+			bool ParseNull(JVal& out)
+			{
+				if (m_s.compare(m_pos, 4, "null") == 0) { m_pos += 4; out.t = JVal::T::Null; return true; }
+				Fail("null invalide");
+				return false;
+			}
+
+			std::string_view m_s;
+			size_t m_pos = 0;
+			std::string& m_err;
+		};
+
+		// Accès typés tolérants (renvoient un défaut si absent/mauvais type).
+		bool AsString(const JVal* v, std::string& out)
+		{
+			if (!v || v->t != JVal::T::Str) return false;
+			out = v->str;
+			return true;
+		}
+		bool AsNumber(const JVal* v, double& out)
+		{
+			if (!v || v->t != JVal::T::Num) return false;
+			out = v->num;
+			return true;
+		}
+	} // namespace
+
+	std::string ToJson(const RoutineGraph& graph)
+	{
+		// Copies triées : nœuds par id, liens par id (canonicité).
+		std::vector<RoutineNode> nodes = graph.nodes;
+		std::vector<RoutineLink> links = graph.links;
+		std::sort(nodes.begin(), nodes.end(),
+		          [](const RoutineNode& a, const RoutineNode& b) { return a.id < b.id; });
+		std::sort(links.begin(), links.end(),
+		          [](const RoutineLink& a, const RoutineLink& b) { return a.id < b.id; });
+
+		std::string out;
+		out.reserve(256 + nodes.size() * 128);
+		out.push_back('{');
+		out += "\"version\":";
+		EmitInt(out, static_cast<long long>(graph.version));
+		out += ",\"kind\":";
+		EmitString(out, ToString(graph.kind));
+		out += ",\"name\":";
+		EmitString(out, graph.name);
+
+		out += ",\"nodes\":[";
+		for (size_t i = 0; i < nodes.size(); ++i)
+		{
+			const RoutineNode& n = nodes[i];
+			if (i) out.push_back(',');
+			out.push_back('{');
+			out += "\"id\":";   EmitInt(out, static_cast<long long>(n.id));
+			out += ",\"type\":"; EmitString(out, ToString(n.type));
+			out += ",\"x\":";   EmitFloat(out, n.canvasX);
+			out += ",\"y\":";   EmitFloat(out, n.canvasY);
+			out += ",\"pins\":[";
+			for (size_t j = 0; j < n.pins.size(); ++j)
+			{
+				const RoutinePin& p = n.pins[j];
+				if (j) out.push_back(',');
+				out.push_back('{');
+				out += "\"id\":";    EmitInt(out, static_cast<long long>(p.id));
+				out += ",\"dir\":";  EmitString(out, ToString(p.direction));
+				out += ",\"kind\":"; EmitString(out, ToString(p.kind));
+				out += ",\"data\":"; EmitString(out, ToString(p.dataType));
+				out += ",\"name\":"; EmitString(out, p.name);
+				out.push_back('}');
+			}
+			out += "],\"props\":[";
+			for (size_t j = 0; j < n.properties.size(); ++j)
+			{
+				const RoutineProperty& p = n.properties[j];
+				if (j) out.push_back(',');
+				out.push_back('{');
+				out += "\"key\":";    EmitString(out, p.key);
+				out += ",\"type\":";  EmitString(out, ToString(p.type));
+				out += ",\"value\":"; EmitPropValue(out, p);
+				out.push_back('}');
+			}
+			out += "]}";
+		}
+		out += "],\"links\":[";
+		for (size_t i = 0; i < links.size(); ++i)
+		{
+			const RoutineLink& l = links[i];
+			if (i) out.push_back(',');
+			out.push_back('{');
+			out += "\"id\":";   EmitInt(out, static_cast<long long>(l.id));
+			out += ",\"from\":["; EmitInt(out, l.fromNodeId); out.push_back(','); EmitInt(out, l.fromPinId); out.push_back(']');
+			out += ",\"to\":[";   EmitInt(out, l.toNodeId);   out.push_back(','); EmitInt(out, l.toPinId);   out.push_back(']');
+			out.push_back('}');
+		}
+		out += "]}";
+		return out;
+	}
+
+	std::optional<RoutineGraph> FromJson(std::string_view json, ParseError& outError)
+	{
+		std::string err;
+		JVal root;
+		Parser parser(json, err);
+		if (!parser.Parse(root) || root.t != JVal::T::Obj)
+		{
+			outError.message = err.empty() ? "JSON racine invalide (objet attendu)" : err;
+			return std::nullopt;
+		}
+
+		RoutineGraph g;
+
+		double ver = 0.0;
+		if (!AsNumber(root.Find("version"), ver))
+		{
+			outError.message = "champ 'version' manquant";
+			return std::nullopt;
+		}
+		g.version = static_cast<uint32_t>(ver);
+		if (g.version > kRoutineGraphVersion)
+		{
+			outError.message = "version de graphe non supportée (trop récente)";
+			return std::nullopt;
+		}
+
+		std::string kindStr;
+		if (!AsString(root.Find("kind"), kindStr) || !FromString(kindStr, g.kind))
+		{
+			outError.message = "champ 'kind' invalide";
+			return std::nullopt;
+		}
+
+		AsString(root.Find("name"), g.name); // optionnel
+
+		const JVal* nodes = root.Find("nodes");
+		if (nodes && nodes->t == JVal::T::Arr)
+		{
+			for (const JVal& jn : nodes->arr)
+			{
+				if (jn.t != JVal::T::Obj) { outError.message = "nœud non-objet"; return std::nullopt; }
+				RoutineNode n;
+				double idv = 0.0;
+				if (!AsNumber(jn.Find("id"), idv)) { outError.message = "nœud sans 'id'"; return std::nullopt; }
+				n.id = static_cast<uint32_t>(idv);
+				std::string typeStr;
+				if (!AsString(jn.Find("type"), typeStr) || !FromString(typeStr, n.type))
+				{
+					outError.message = "type de nœud inconnu : " + typeStr;
+					return std::nullopt;
+				}
+				double xv = 0.0, yv = 0.0;
+				AsNumber(jn.Find("x"), xv); n.canvasX = static_cast<float>(xv);
+				AsNumber(jn.Find("y"), yv); n.canvasY = static_cast<float>(yv);
+
+				const JVal* pins = jn.Find("pins");
+				if (pins && pins->t == JVal::T::Arr)
+				{
+					for (const JVal& jp : pins->arr)
+					{
+						RoutinePin p;
+						double pid = 0.0; AsNumber(jp.Find("id"), pid); p.id = static_cast<uint32_t>(pid);
+						std::string dir, kind, data;
+						AsString(jp.Find("dir"), dir);   FromString(dir, p.direction);
+						AsString(jp.Find("kind"), kind); FromString(kind, p.kind);
+						AsString(jp.Find("data"), data); FromString(data, p.dataType);
+						AsString(jp.Find("name"), p.name);
+						n.pins.push_back(std::move(p));
+					}
+				}
+
+				const JVal* props = jn.Find("props");
+				if (props && props->t == JVal::T::Arr)
+				{
+					for (const JVal& jpr : props->arr)
+					{
+						RoutineProperty pr;
+						AsString(jpr.Find("key"), pr.key);
+						std::string typeS;
+						AsString(jpr.Find("type"), typeS); FromString(typeS, pr.type);
+						const JVal* val = jpr.Find("value");
+						if (val)
+						{
+							switch (pr.type)
+							{
+								case RoutineDataType::Bool:
+									pr.bValue = (val->t == JVal::T::Bool) ? val->b : false; break;
+								case RoutineDataType::Int:
+									pr.iValue = (val->t == JVal::T::Num) ? static_cast<int64_t>(val->num) : 0; break;
+								case RoutineDataType::Float:
+									pr.fValue = (val->t == JVal::T::Num) ? static_cast<float>(val->num) : 0.0f; break;
+								case RoutineDataType::Vec3:
+									if (val->t == JVal::T::Arr && val->arr.size() == 3)
+									{
+										pr.vValue.x = static_cast<float>(val->arr[0].num);
+										pr.vValue.y = static_cast<float>(val->arr[1].num);
+										pr.vValue.z = static_cast<float>(val->arr[2].num);
+									}
+									break;
+								case RoutineDataType::String:
+								case RoutineDataType::EntityRef:
+									if (val->t == JVal::T::Str) pr.sValue = val->str; break;
+								case RoutineDataType::None:
+								default: break;
+							}
+						}
+						n.properties.push_back(std::move(pr));
+					}
+				}
+				g.nodes.push_back(std::move(n));
+			}
+		}
+
+		const JVal* links = root.Find("links");
+		if (links && links->t == JVal::T::Arr)
+		{
+			for (const JVal& jl : links->arr)
+			{
+				if (jl.t != JVal::T::Obj) { outError.message = "lien non-objet"; return std::nullopt; }
+				RoutineLink l;
+				double idv = 0.0; AsNumber(jl.Find("id"), idv); l.id = static_cast<uint32_t>(idv);
+				const JVal* from = jl.Find("from");
+				const JVal* to   = jl.Find("to");
+				if (from && from->t == JVal::T::Arr && from->arr.size() == 2)
+				{
+					l.fromNodeId = static_cast<uint32_t>(from->arr[0].num);
+					l.fromPinId  = static_cast<uint32_t>(from->arr[1].num);
+				}
+				if (to && to->t == JVal::T::Arr && to->arr.size() == 2)
+				{
+					l.toNodeId = static_cast<uint32_t>(to->arr[0].num);
+					l.toPinId  = static_cast<uint32_t>(to->arr[1].num);
+				}
+				g.links.push_back(std::move(l));
+			}
+		}
+
+		return g;
+	}
+}

--- a/src/shared/routine/RoutineSerialization.h
+++ b/src/shared/routine/RoutineSerialization.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// M101.1 — Sérialisation JSON déterministe d'un RoutineGraph.
+//
+// `ToJson` produit un JSON canonique STABLE octet pour octet pour un même
+// graphe (ordre de clés fixe, nœuds/liens triés par id, floats formatés de
+// façon locale-indépendante). `FromJson` est l'inverse. Invariant garanti :
+// FromJson(ToJson(g)) reconstruit g à l'identique (cf. round-trip M101.3/.10).
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::routine::serialization
+{
+	/// Sérialise un graphe en JSON canonique déterministe.
+	std::string ToJson(const RoutineGraph& graph);
+
+	/// Erreur de parsing (message lisible).
+	struct ParseError
+	{
+		std::string message;
+	};
+
+	/// Désérialise un graphe. Retourne std::nullopt et renseigne `outError` en
+	/// cas d'échec (JSON invalide, version inconnue, enum inconnu…).
+	std::optional<RoutineGraph> FromJson(std::string_view json, ParseError& outError);
+}

--- a/src/shared/routine/tests/RoutineSegmentCodecTests.cpp
+++ b/src/shared/routine/tests/RoutineSegmentCodecTests.cpp
@@ -1,0 +1,100 @@
+// M101.3 — Tests du codec routines.bin (round-trip en mémoire), headless.
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/RoutineSegmentCodec.h"
+#include "src/shared/routine/RoutineSerialization.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace engine::routine;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	RoutineGraph MakeGraph(RoutineGraphKind kind, const std::string& name, RoutineNodeType nodeType)
+	{
+		RoutineGraph g;
+		g.kind = kind;
+		g.name = name;
+		RoutineNode n; n.id = 1; n.type = nodeType; n.canvasX = 10.0f; n.canvasY = 20.0f;
+		g.nodes.push_back(n);
+		return g;
+	}
+
+	void Test_Codec_RoundTrip()
+	{
+		std::vector<RoutineGraph> graphs = {
+			MakeGraph(RoutineGraphKind::ZoneEvent, "porte", RoutineNodeType::EventOnInteract),
+			MakeGraph(RoutineGraphKind::NpcRoutine, "garde", RoutineNodeType::NpcStateRoot),
+		};
+
+		std::vector<uint8_t> bytes = codec::EncodeRoutinesBin(graphs);
+		std::string err;
+		auto decoded = codec::DecodeRoutinesBin(bytes, err);
+		REQUIRE(decoded.has_value());
+		if (decoded)
+		{
+			REQUIRE(decoded->size() == graphs.size());
+			for (size_t i = 0; i < graphs.size() && i < decoded->size(); ++i)
+			{
+				// Comparaison via JSON canonique (égalité JSON ⇒ graphes égaux).
+				REQUIRE(serialization::ToJson(graphs[i]) == serialization::ToJson((*decoded)[i]));
+			}
+		}
+	}
+
+	void Test_Codec_EmptyList()
+	{
+		std::vector<RoutineGraph> graphs;
+		std::vector<uint8_t> bytes = codec::EncodeRoutinesBin(graphs);
+		std::string err;
+		auto decoded = codec::DecodeRoutinesBin(bytes, err);
+		REQUIRE(decoded.has_value());
+		if (decoded) REQUIRE(decoded->empty());
+	}
+
+	void Test_Codec_RejectBadMagic()
+	{
+		std::vector<uint8_t> bytes = { 0xDE, 0xAD, 0xBE, 0xEF, 1, 0, 0, 0, 0, 0, 0, 0 };
+		std::string err;
+		auto decoded = codec::DecodeRoutinesBin(bytes, err);
+		REQUIRE(!decoded.has_value());
+		REQUIRE(!err.empty());
+	}
+
+	void Test_Codec_RejectTruncated()
+	{
+		std::vector<RoutineGraph> graphs = {
+			MakeGraph(RoutineGraphKind::ZoneEvent, "x", RoutineNodeType::EventOnInteract),
+		};
+		std::vector<uint8_t> bytes = codec::EncodeRoutinesBin(graphs);
+		bytes.resize(bytes.size() - 4); // tronque le JSON
+		std::string err;
+		auto decoded = codec::DecodeRoutinesBin(bytes, err);
+		REQUIRE(!decoded.has_value());
+	}
+}
+
+int main()
+{
+	Test_Codec_RoundTrip();
+	Test_Codec_EmptyList();
+	Test_Codec_RejectBadMagic();
+	Test_Codec_RejectTruncated();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineSegmentCodecTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineSegmentCodecTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/shared/routine/tests/RoutineSerializationTests.cpp
+++ b/src/shared/routine/tests/RoutineSerializationTests.cpp
@@ -1,0 +1,238 @@
+// M101.1 — Tests de sérialisation / round-trip / déterminisme.
+// Harnais maison : main() retourne le nombre d'assertions échouées (0 = OK).
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/RoutineNodeSchema.h"
+#include "src/shared/routine/RoutineSerialization.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+using namespace engine::routine;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	// Égalité de graphes indépendante de l'ordre (tri par id avant comparaison).
+	bool PinEquals(const RoutinePin& a, const RoutinePin& b)
+	{
+		return a.id == b.id && a.direction == b.direction && a.kind == b.kind &&
+		       a.dataType == b.dataType && a.name == b.name;
+	}
+
+	bool PropEquals(const RoutineProperty& a, const RoutineProperty& b)
+	{
+		if (a.key != b.key || a.type != b.type) return false;
+		switch (a.type)
+		{
+			case RoutineDataType::Bool:  return a.bValue == b.bValue;
+			case RoutineDataType::Int:   return a.iValue == b.iValue;
+			case RoutineDataType::Float: return a.fValue == b.fValue;
+			case RoutineDataType::Vec3:
+				return a.vValue.x == b.vValue.x && a.vValue.y == b.vValue.y && a.vValue.z == b.vValue.z;
+			case RoutineDataType::String:
+			case RoutineDataType::EntityRef: return a.sValue == b.sValue;
+			default: return true;
+		}
+	}
+
+	bool GraphEquals(RoutineGraph a, RoutineGraph b)
+	{
+		if (a.version != b.version || a.kind != b.kind || a.name != b.name) return false;
+		if (a.nodes.size() != b.nodes.size() || a.links.size() != b.links.size()) return false;
+
+		auto byNodeId = [](const RoutineNode& x, const RoutineNode& y) { return x.id < y.id; };
+		auto byLinkId = [](const RoutineLink& x, const RoutineLink& y) { return x.id < y.id; };
+		std::sort(a.nodes.begin(), a.nodes.end(), byNodeId);
+		std::sort(b.nodes.begin(), b.nodes.end(), byNodeId);
+		std::sort(a.links.begin(), a.links.end(), byLinkId);
+		std::sort(b.links.begin(), b.links.end(), byLinkId);
+
+		for (size_t i = 0; i < a.nodes.size(); ++i)
+		{
+			const RoutineNode& na = a.nodes[i];
+			const RoutineNode& nb = b.nodes[i];
+			if (na.id != nb.id || na.type != nb.type) return false;
+			if (na.canvasX != nb.canvasX || na.canvasY != nb.canvasY) return false;
+			if (na.pins.size() != nb.pins.size()) return false;
+			if (na.properties.size() != nb.properties.size()) return false;
+			for (size_t j = 0; j < na.pins.size(); ++j)
+				if (!PinEquals(na.pins[j], nb.pins[j])) return false;
+			for (size_t j = 0; j < na.properties.size(); ++j)
+				if (!PropEquals(na.properties[j], nb.properties[j])) return false;
+		}
+		for (size_t i = 0; i < a.links.size(); ++i)
+		{
+			const RoutineLink& la = a.links[i];
+			const RoutineLink& lb = b.links[i];
+			if (la.id != lb.id || la.fromNodeId != lb.fromNodeId || la.fromPinId != lb.fromPinId ||
+			    la.toNodeId != lb.toNodeId || la.toPinId != lb.toPinId)
+				return false;
+		}
+		return true;
+	}
+
+	RoutineGraph MakeSampleZoneEventGraph()
+	{
+		RoutineGraph g;
+		g.version = kRoutineGraphVersion;
+		g.kind = RoutineGraphKind::ZoneEvent;
+		g.name = "porte_taverne";
+
+		RoutineNode ev;
+		ev.id = 1; ev.type = RoutineNodeType::EventOnInteract;
+		ev.canvasX = 120.0f; ev.canvasY = 64.0f;
+		{
+			RoutinePin p; p.id = 10; p.direction = PinDirection::Output; p.kind = PinKind::Exec;
+			p.dataType = RoutineDataType::None; p.name = "fired";
+			ev.pins.push_back(p);
+		}
+		{
+			RoutineProperty pr; pr.key = "interactiveId"; pr.type = RoutineDataType::EntityRef;
+			pr.sValue = "porte_taverne_42";
+			ev.properties.push_back(pr);
+		}
+
+		RoutineNode act;
+		act.id = 2; act.type = RoutineNodeType::ActionOpenInteractive;
+		act.canvasX = 360.0f; act.canvasY = 64.0f;
+		{
+			RoutinePin pin; pin.id = 20; pin.direction = PinDirection::Input; pin.kind = PinKind::Exec;
+			pin.name = "in";
+			act.pins.push_back(pin);
+		}
+		{
+			RoutineProperty pr1; pr1.key = "interactiveId"; pr1.type = RoutineDataType::EntityRef;
+			pr1.sValue = "porte_taverne_42";
+			RoutineProperty pr2; pr2.key = "open"; pr2.type = RoutineDataType::Bool; pr2.bValue = true;
+			act.properties.push_back(pr1);
+			act.properties.push_back(pr2);
+		}
+
+		g.nodes.push_back(ev);
+		g.nodes.push_back(act);
+
+		RoutineLink l;
+		l.id = 100; l.fromNodeId = 1; l.fromPinId = 10; l.toNodeId = 2; l.toPinId = 20;
+		g.links.push_back(l);
+		return g;
+	}
+
+	void Test_RoundTrip_Identical()
+	{
+		RoutineGraph g = MakeSampleZoneEventGraph();
+		std::string json = serialization::ToJson(g);
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(json, err);
+		REQUIRE(parsed.has_value());
+		if (parsed) REQUIRE(GraphEquals(g, *parsed));
+	}
+
+	void Test_Serialization_StableByteForByte()
+	{
+		RoutineGraph g = MakeSampleZoneEventGraph();
+		std::string a = serialization::ToJson(g);
+		std::string b = serialization::ToJson(g);
+		REQUIRE(a == b);
+		// Et stable après un cycle complet.
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(a, err);
+		REQUIRE(parsed.has_value());
+		if (parsed) REQUIRE(serialization::ToJson(*parsed) == a);
+	}
+
+	void Test_FloatRoundTrip()
+	{
+		RoutineGraph g;
+		g.kind = RoutineGraphKind::NpcRoutine;
+		RoutineNode n; n.id = 1; n.type = RoutineNodeType::SensorPlayerInRange;
+		n.canvasX = 123.456f; n.canvasY = -987.654f;
+		RoutineProperty pr; pr.key = "rangeMeters"; pr.type = RoutineDataType::Float; pr.fValue = 3.14159f;
+		n.properties.push_back(pr);
+		g.nodes.push_back(n);
+
+		std::string json = serialization::ToJson(g);
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(json, err);
+		REQUIRE(parsed.has_value());
+		if (parsed)
+		{
+			REQUIRE(parsed->nodes.size() == 1);
+			REQUIRE(parsed->nodes[0].canvasX == 123.456f);
+			REQUIRE(parsed->nodes[0].canvasY == -987.654f);
+			REQUIRE(parsed->nodes[0].properties.size() == 1);
+			REQUIRE(parsed->nodes[0].properties[0].fValue == 3.14159f);
+		}
+	}
+
+	void Test_RejectFutureVersion()
+	{
+		std::string json = "{\"version\":9999,\"kind\":\"zone_event\",\"name\":\"x\",\"nodes\":[],\"links\":[]}";
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(json, err);
+		REQUIRE(!parsed.has_value());
+		REQUIRE(!err.message.empty());
+	}
+
+	void Test_RejectUnknownNodeType()
+	{
+		std::string json =
+			"{\"version\":1,\"kind\":\"zone_event\",\"name\":\"x\","
+			"\"nodes\":[{\"id\":1,\"type\":\"TotallyBogus\",\"x\":0,\"y\":0,\"pins\":[],\"props\":[]}],"
+			"\"links\":[]}";
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(json, err);
+		REQUIRE(!parsed.has_value());
+	}
+
+	void Test_SchemaTableCoversAllNodeTypes()
+	{
+		// Chaque type listé dans le schéma a un nom stable et est retrouvable.
+		for (const auto& s : AllSchemas())
+		{
+			REQUIRE(FindSchema(s.type) != nullptr);
+			RoutineNodeType rt;
+			REQUIRE(FromString(ToString(s.type), rt));
+			REQUIRE(rt == s.type);
+			REQUIRE(s.validKindsMask != 0);
+		}
+	}
+
+	void Test_EmptyGraphRoundTrip()
+	{
+		RoutineGraph g;
+		g.kind = RoutineGraphKind::ZoneEvent;
+		g.name = "";
+		std::string json = serialization::ToJson(g);
+		serialization::ParseError err;
+		auto parsed = serialization::FromJson(json, err);
+		REQUIRE(parsed.has_value());
+		if (parsed) REQUIRE(GraphEquals(g, *parsed));
+	}
+}
+
+int main()
+{
+	Test_RoundTrip_Identical();
+	Test_Serialization_StableByteForByte();
+	Test_FloatRoundTrip();
+	Test_RejectFutureVersion();
+	Test_RejectUnknownNodeType();
+	Test_SchemaTableCoversAllNodeTypes();
+	Test_EmptyGraphRoundTrip();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineSerializationTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineSerializationTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/shared/routine/tests/RoutineValidationTests.cpp
+++ b/src/shared/routine/tests/RoutineValidationTests.cpp
@@ -1,0 +1,150 @@
+// M101.6 — Tests de validation de graphe (une règle par cas), headless.
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/RoutineGraphValidation.h"
+
+#include <cstdio>
+
+using namespace engine::routine;
+using namespace engine::routine::validation;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	RoutinePin Pin(uint32_t id, PinDirection dir, PinKind kind, const char* name,
+	               RoutineDataType dt = RoutineDataType::None)
+	{
+		RoutinePin p; p.id = id; p.direction = dir; p.kind = kind; p.dataType = dt; p.name = name;
+		return p;
+	}
+
+	bool HasKind(const std::vector<ValidationIssue>& v, IssueKind k)
+	{
+		for (const auto& i : v) if (i.kind == k) return true;
+		return false;
+	}
+
+	RoutineNode EventNode()
+	{
+		RoutineNode ev; ev.id = 1; ev.type = RoutineNodeType::EventOnInteract;
+		ev.pins.push_back(Pin(10, PinDirection::Output, PinKind::Exec, "fired"));
+		return ev;
+	}
+
+	void Test_ValidGraph_NoErrors()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode();
+		RoutineNode act; act.id = 2; act.type = RoutineNodeType::ActionBroadcastSeason;
+		act.pins.push_back(Pin(20, PinDirection::Input, PinKind::Exec, "in"));
+		act.pins.push_back(Pin(21, PinDirection::Output, PinKind::Exec, "out"));
+		g.nodes = { ev, act };
+		g.links = { RoutineLink{ 100, 1, 10, 2, 20 } };
+		auto issues = Validate(g);
+		REQUIRE(!HasError(issues));
+	}
+
+	void Test_IncompatiblePins()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode();
+		RoutineNode act; act.id = 2; act.type = RoutineNodeType::BranchIf;
+		act.pins.push_back(Pin(20, PinDirection::Input, PinKind::Data, "cond", RoutineDataType::Bool));
+		g.nodes = { ev, act };
+		// Lien exec (sortie) -> data (entrée) : incompatible.
+		g.links = { RoutineLink{ 100, 1, 10, 2, 20 } };
+		auto issues = Validate(g);
+		REQUIRE(HasKind(issues, IssueKind::IncompatiblePins));
+	}
+
+	void Test_ExecCycle()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode();
+		RoutineNode a; a.id = 2; a.type = RoutineNodeType::ActionBroadcastSeason;
+		a.pins.push_back(Pin(20, PinDirection::Input, PinKind::Exec, "in"));
+		a.pins.push_back(Pin(21, PinDirection::Output, PinKind::Exec, "out"));
+		RoutineNode b; b.id = 3; b.type = RoutineNodeType::ActionBroadcastWeather;
+		b.pins.push_back(Pin(30, PinDirection::Input, PinKind::Exec, "in"));
+		b.pins.push_back(Pin(31, PinDirection::Output, PinKind::Exec, "out"));
+		g.nodes = { ev, a, b };
+		g.links = {
+			RoutineLink{ 100, 1, 10, 2, 20 }, // event -> a
+			RoutineLink{ 101, 2, 21, 3, 30 }, // a -> b
+			RoutineLink{ 102, 3, 31, 2, 20 }, // b -> a  (cycle)
+		};
+		auto issues = Validate(g);
+		REQUIRE(HasKind(issues, IssueKind::ExecCycle));
+	}
+
+	void Test_OrphanNode()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode(); // racine, pas de lien
+		RoutineNode lone; lone.id = 2; lone.type = RoutineNodeType::ActionBroadcastSeason;
+		lone.pins.push_back(Pin(20, PinDirection::Input, PinKind::Exec, "in"));
+		g.nodes = { ev, lone };
+		auto issues = Validate(g);
+		REQUIRE(HasKind(issues, IssueKind::OrphanNode));
+	}
+
+	void Test_SchemaMismatch()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode();
+		RoutineNode npc; npc.id = 2; npc.type = RoutineNodeType::TaskPlayAnim; // npc dans zone
+		g.nodes = { ev, npc };
+		auto issues = Validate(g);
+		REQUIRE(HasKind(issues, IssueKind::SchemaMismatch));
+	}
+
+	void Test_RootCardinalityZero()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode c; c.id = 1; c.type = RoutineNodeType::Comment;
+		g.nodes = { c };
+		auto issues = Validate(g);
+		REQUIRE(HasKind(issues, IssueKind::RootCardinality));
+	}
+
+	void Test_Deterministic()
+	{
+		RoutineGraph g; g.kind = RoutineGraphKind::ZoneEvent;
+		RoutineNode ev = EventNode();
+		RoutineNode npc; npc.id = 2; npc.type = RoutineNodeType::TaskMoveTo;
+		g.nodes = { ev, npc };
+		auto a = Validate(g);
+		auto b = Validate(g);
+		REQUIRE(a.size() == b.size());
+		for (size_t i = 0; i < a.size() && i < b.size(); ++i)
+		{
+			REQUIRE(a[i].kind == b[i].kind);
+			REQUIRE(a[i].nodeId == b[i].nodeId);
+		}
+	}
+}
+
+int main()
+{
+	Test_ValidGraph_NoErrors();
+	Test_IncompatiblePins();
+	Test_ExecCycle();
+	Test_OrphanNode();
+	Test_SchemaMismatch();
+	Test_RootCardinalityZero();
+	Test_Deterministic();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineValidationTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineValidationTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/shared/routine/vm/IRoutineHost.h
+++ b/src/shared/routine/vm/IRoutineHost.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// M101.2 — Interface d'hôte de la VM de routines (frontière de pureté).
+//
+// La VM ne dépend QUE de cette interface : elle ne connaît rien du rendu, du
+// réseau ni des systèmes de jeu. Le client de prod l'implémente (M101.8,
+// ClientRoutineHost) ; les tests fournissent MockRoutineHost. C'est cette
+// indirection qui rend la VM testable headless en CI.
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::routine::vm
+{
+	/// Contexte d'une exécution. Le temps est LOGIQUE (fourni par l'appelant) :
+	/// jamais d'horloge système dans la VM (déterminisme).
+	struct RoutineRunContext
+	{
+		double   logicalTimeMs = 0.0;   ///< Temps logique fourni.
+		uint64_t eventEntityId = 0;     ///< Entité ayant déclenché l'Event.
+	};
+
+	/// Pont abstrait entre la VM et le monde réel.
+	class IRoutineHost
+	{
+	public:
+		virtual ~IRoutineHost() = default;
+
+		// --- capteurs (lecture) ---
+		/// Heure du jour [0..24[, fournie par l'hôte (ex. SeasonClock côté client).
+		virtual float GetTimeOfDayHours() const = 0;
+		/// True si une entité joueur est à `meters` de l'entité `entityId`.
+		virtual bool  IsPlayerInRange(uint64_t entityId, float meters) const = 0;
+
+		// --- actions (effets) ---
+		/// Ouvre (open=true) ou ferme un objet interactif.
+		virtual void OpenInteractive(uint64_t interactiveId, bool open) = 0;
+		/// Émet un broadcast de saison (réutilise l'opcode M100.25 côté client).
+		virtual void BroadcastSeason(int seasonIndex) = 0;
+		/// Émet un broadcast de météo (réutilise l'opcode M100.26 côté client).
+		virtual void BroadcastWeather(int weatherIndex) = 0;
+
+		// --- trace déterministe (diagnostic / tests) ---
+		/// Journalise une étape (nœud exécuté). Optionnel ; no-op par défaut.
+		virtual void Trace(std::string_view nodeLabel) { (void)nodeLabel; }
+	};
+}

--- a/src/shared/routine/vm/MockRoutineHost.h
+++ b/src/shared/routine/vm/MockRoutineHost.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// M101.2 — Hôte de test : enregistre une trace ordonnée des appels de la VM.
+// Header-only. Sert aux tests headless (déterminisme = traces identiques).
+
+#include <string>
+#include <vector>
+
+#include "src/shared/routine/vm/IRoutineHost.h"
+
+namespace engine::routine::vm
+{
+	class MockRoutineHost : public IRoutineHost
+	{
+	public:
+		// Valeurs de capteurs réglables par le test.
+		float timeOfDayHours = 12.0f;
+		bool  playerInRange = false;
+
+		// Trace ordonnée des évènements/actions (preuve de déterminisme).
+		std::vector<std::string> trace;
+		// Détail des appels d'action (vérifications fines).
+		std::vector<std::pair<uint64_t, bool>> openCalls;
+		std::vector<int> seasonCalls;
+		std::vector<int> weatherCalls;
+
+		float GetTimeOfDayHours() const override { return timeOfDayHours; }
+		bool  IsPlayerInRange(uint64_t, float) const override { return playerInRange; }
+
+		void OpenInteractive(uint64_t id, bool open) override
+		{
+			openCalls.emplace_back(id, open);
+		}
+		void BroadcastSeason(int idx) override { seasonCalls.push_back(idx); }
+		void BroadcastWeather(int idx) override { weatherCalls.push_back(idx); }
+
+		void Trace(std::string_view label) override { trace.emplace_back(label); }
+	};
+}

--- a/src/shared/routine/vm/ZoneEventVm.cpp
+++ b/src/shared/routine/vm/ZoneEventVm.cpp
@@ -1,0 +1,164 @@
+// M101.2 — Implémentation de la VM data-flow `zone_event`.
+
+#include "src/shared/routine/vm/ZoneEventVm.h"
+
+#include <cstdlib>
+
+namespace engine::routine::vm
+{
+	ZoneEventVm::ZoneEventVm(const RoutineGraph& graph) : m_graph(graph) {}
+
+	const RoutineNode* ZoneEventVm::FindNode(uint32_t id) const
+	{
+		for (const auto& n : m_graph.nodes)
+			if (n.id == id) return &n;
+		return nullptr;
+	}
+
+	const RoutineNode* ZoneEventVm::FindEventNode(RoutineNodeType type) const
+	{
+		for (const auto& n : m_graph.nodes)
+			if (n.type == type) return &n;
+		return nullptr;
+	}
+
+	const RoutineProperty* ZoneEventVm::FindProp(const RoutineNode& n, std::string_view key) const
+	{
+		for (const auto& p : n.properties)
+			if (p.key == key) return &p;
+		return nullptr;
+	}
+
+	uint32_t ZoneEventVm::OutputExecPinByName(const RoutineNode& n, std::string_view name) const
+	{
+		for (const auto& p : n.pins)
+			if (p.kind == PinKind::Exec && p.direction == PinDirection::Output && p.name == name)
+				return p.id;
+		return 0;
+	}
+
+	uint32_t ZoneEventVm::FirstOutputExecPin(const RoutineNode& n) const
+	{
+		for (const auto& p : n.pins)
+			if (p.kind == PinKind::Exec && p.direction == PinDirection::Output)
+				return p.id;
+		return 0;
+	}
+
+	uint32_t ZoneEventVm::InputDataPinByName(const RoutineNode& n, std::string_view name) const
+	{
+		for (const auto& p : n.pins)
+			if (p.kind == PinKind::Data && p.direction == PinDirection::Input && p.name == name)
+				return p.id;
+		return 0;
+	}
+
+	bool ZoneEventVm::Fire(RoutineNodeType eventType, const RoutineRunContext& ctx, IRoutineHost& host)
+	{
+		if (m_graph.kind != RoutineGraphKind::ZoneEvent) return false;
+		const RoutineNode* ev = FindEventNode(eventType);
+		if (!ev) return false;
+		host.Trace(ToString(eventType));
+		const uint32_t outPin = FirstOutputExecPin(*ev);
+		if (outPin != 0)
+			ExecFrom(*ev, outPin, ctx, host, 0);
+		return true;
+	}
+
+	void ZoneEventVm::ExecFrom(const RoutineNode& node, uint32_t outPinId,
+	                           const RoutineRunContext& ctx, IRoutineHost& host, int depth)
+	{
+		if (depth >= kMaxDepth)
+		{
+			host.Trace("__depth_limit__");
+			return;
+		}
+		for (const auto& link : m_graph.links)
+		{
+			if (link.fromNodeId == node.id && link.fromPinId == outPinId)
+			{
+				const RoutineNode* tgt = FindNode(link.toNodeId);
+				if (tgt) ExecuteNode(*tgt, ctx, host, depth + 1);
+			}
+		}
+	}
+
+	void ZoneEventVm::ExecuteNode(const RoutineNode& node,
+	                              const RoutineRunContext& ctx, IRoutineHost& host, int depth)
+	{
+		host.Trace(ToString(node.type));
+
+		switch (node.type)
+		{
+			case RoutineNodeType::BranchIf:
+			{
+				const uint32_t condPin = InputDataPinByName(node, "cond");
+				const bool cond = EvalBoolInput(node, condPin, ctx, host);
+				const uint32_t branchPin = OutputExecPinByName(node, cond ? "true" : "false");
+				if (branchPin != 0) ExecFrom(node, branchPin, ctx, host, depth);
+				return;
+			}
+			case RoutineNodeType::ActionOpenInteractive:
+			{
+				uint64_t id = 0;
+				if (const RoutineProperty* p = FindProp(node, "interactiveId"); p && !p->sValue.empty())
+					id = std::strtoull(p->sValue.c_str(), nullptr, 10);
+				bool open = false;
+				if (const RoutineProperty* p = FindProp(node, "open")) open = p->bValue;
+				host.OpenInteractive(id, open);
+				break;
+			}
+			case RoutineNodeType::ActionBroadcastSeason:
+			{
+				int idx = 0;
+				if (const RoutineProperty* p = FindProp(node, "seasonIndex")) idx = static_cast<int>(p->iValue);
+				host.BroadcastSeason(idx);
+				break;
+			}
+			case RoutineNodeType::ActionBroadcastWeather:
+			{
+				int idx = 0;
+				if (const RoutineProperty* p = FindProp(node, "weatherIndex")) idx = static_cast<int>(p->iValue);
+				host.BroadcastWeather(idx);
+				break;
+			}
+			default:
+				// Nœud sans effet propre (commentaire, etc.) : on suit quand même
+				// le flux d'exécution.
+				break;
+		}
+
+		// Suite du flux par le pin Exec de sortie standard ("out"), sinon le
+		// premier pin Exec de sortie disponible.
+		uint32_t outPin = OutputExecPinByName(node, "out");
+		if (outPin == 0) outPin = FirstOutputExecPin(node);
+		if (outPin != 0) ExecFrom(node, outPin, ctx, host, depth);
+	}
+
+	bool ZoneEventVm::EvalBoolInput(const RoutineNode& node, uint32_t inPinId,
+	                                const RoutineRunContext& ctx, IRoutineHost& host) const
+	{
+		if (inPinId == 0) return false;
+		// Cherche un lien Data alimentant ce pin d'entrée.
+		for (const auto& link : m_graph.links)
+		{
+			if (link.toNodeId == node.id && link.toPinId == inPinId)
+			{
+				const RoutineNode* src = FindNode(link.fromNodeId);
+				if (!src) return false;
+				switch (src->type)
+				{
+					case RoutineNodeType::SensorPlayerInRange:
+					{
+						float range = 0.0f;
+						if (const RoutineProperty* p = FindProp(*src, "rangeMeters")) range = p->fValue;
+						return host.IsPlayerInRange(ctx.eventEntityId, range);
+					}
+					default:
+						return false;
+				}
+			}
+		}
+		return false; // non lié → défaut déterministe.
+	}
+}

--- a/src/shared/routine/vm/ZoneEventVm.h
+++ b/src/shared/routine/vm/ZoneEventVm.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// M101.2 — VM data-flow déterministe pour les graphes `zone_event`.
+//
+// Modèle Blueprint : un nœud Event racine est déclenché, le flux suit les
+// « exec wires », les pins de données sont évalués en pull. Exécution cliente
+// (lib pure, via IRoutineHost). Déterministe : mêmes entrées → même trace.
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/vm/IRoutineHost.h"
+
+namespace engine::routine::vm
+{
+	class ZoneEventVm
+	{
+	public:
+		/// Construit la VM pour un graphe (doit être de kind ZoneEvent ; sinon
+		/// Fire renverra false).
+		explicit ZoneEventVm(const RoutineGraph& graph);
+
+		/// Déclenche l'exécution à partir du nœud Event du type donné.
+		/// Retourne false si aucun nœud Event de ce type n'existe (ou mauvais kind).
+		bool Fire(RoutineNodeType eventType, const RoutineRunContext& ctx, IRoutineHost& host);
+
+	private:
+		const RoutineNode* FindNode(uint32_t id) const;
+		const RoutineNode* FindEventNode(RoutineNodeType type) const;
+		const RoutineProperty* FindProp(const RoutineNode& n, std::string_view key) const;
+		uint32_t OutputExecPinByName(const RoutineNode& n, std::string_view name) const;
+		uint32_t FirstOutputExecPin(const RoutineNode& n) const;
+		uint32_t InputDataPinByName(const RoutineNode& n, std::string_view name) const;
+
+		// Suit les exec wires depuis (node, outPinId) et exécute les cibles.
+		void ExecFrom(const RoutineNode& node, uint32_t outPinId,
+		              const RoutineRunContext& ctx, IRoutineHost& host, int depth);
+		// Exécute un nœud (effet + suite du flux).
+		void ExecuteNode(const RoutineNode& node,
+		                 const RoutineRunContext& ctx, IRoutineHost& host, int depth);
+		// Évalue en pull un pin Data d'entrée booléen (défaut false si non lié).
+		bool EvalBoolInput(const RoutineNode& node, uint32_t inPinId,
+		                   const RoutineRunContext& ctx, IRoutineHost& host) const;
+
+		const RoutineGraph& m_graph;
+		static constexpr int kMaxDepth = 256; // garde-fou anti-boucle.
+	};
+}

--- a/src/shared/routine/vm/tests/RoutineVmTests.cpp
+++ b/src/shared/routine/vm/tests/RoutineVmTests.cpp
@@ -1,0 +1,159 @@
+// M101.2 — Tests de la VM zone_event (exécution + déterminisme), headless.
+// Harnais maison : main() retourne le nombre d'assertions échouées (0 = OK).
+
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/vm/MockRoutineHost.h"
+#include "src/shared/routine/vm/ZoneEventVm.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace engine::routine;
+using namespace engine::routine::vm;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	RoutinePin Pin(uint32_t id, PinDirection dir, PinKind kind, const char* name,
+	               RoutineDataType dt = RoutineDataType::None)
+	{
+		RoutinePin p; p.id = id; p.direction = dir; p.kind = kind; p.dataType = dt; p.name = name;
+		return p;
+	}
+
+	RoutineGraph MakeOpenDoorGraph()
+	{
+		RoutineGraph g;
+		g.kind = RoutineGraphKind::ZoneEvent;
+
+		RoutineNode ev; ev.id = 1; ev.type = RoutineNodeType::EventOnInteract;
+		ev.pins.push_back(Pin(10, PinDirection::Output, PinKind::Exec, "fired"));
+
+		RoutineNode act; act.id = 2; act.type = RoutineNodeType::ActionOpenInteractive;
+		act.pins.push_back(Pin(20, PinDirection::Input, PinKind::Exec, "in"));
+		act.pins.push_back(Pin(21, PinDirection::Output, PinKind::Exec, "out"));
+		{
+			RoutineProperty pid; pid.key = "interactiveId"; pid.type = RoutineDataType::EntityRef; pid.sValue = "42";
+			RoutineProperty op; op.key = "open"; op.type = RoutineDataType::Bool; op.bValue = true;
+			act.properties.push_back(pid);
+			act.properties.push_back(op);
+		}
+
+		g.nodes.push_back(ev);
+		g.nodes.push_back(act);
+
+		RoutineLink l; l.id = 100; l.fromNodeId = 1; l.fromPinId = 10; l.toNodeId = 2; l.toPinId = 20;
+		g.links.push_back(l);
+		return g;
+	}
+
+	RoutineGraph MakeBranchGraph()
+	{
+		RoutineGraph g;
+		g.kind = RoutineGraphKind::ZoneEvent;
+
+		RoutineNode ev; ev.id = 1; ev.type = RoutineNodeType::EventOnInteract;
+		ev.pins.push_back(Pin(10, PinDirection::Output, PinKind::Exec, "fired"));
+
+		RoutineNode br; br.id = 2; br.type = RoutineNodeType::BranchIf;
+		br.pins.push_back(Pin(20, PinDirection::Input, PinKind::Exec, "in"));
+		br.pins.push_back(Pin(21, PinDirection::Output, PinKind::Exec, "true"));
+		br.pins.push_back(Pin(22, PinDirection::Output, PinKind::Exec, "false"));
+		br.pins.push_back(Pin(23, PinDirection::Input, PinKind::Data, "cond", RoutineDataType::Bool));
+
+		RoutineNode season; season.id = 3; season.type = RoutineNodeType::ActionBroadcastSeason;
+		season.pins.push_back(Pin(30, PinDirection::Input, PinKind::Exec, "in"));
+		season.pins.push_back(Pin(31, PinDirection::Output, PinKind::Exec, "out"));
+		{ RoutineProperty p; p.key = "seasonIndex"; p.type = RoutineDataType::Int; p.iValue = 1; season.properties.push_back(p); }
+
+		RoutineNode weather; weather.id = 4; weather.type = RoutineNodeType::ActionBroadcastWeather;
+		weather.pins.push_back(Pin(40, PinDirection::Input, PinKind::Exec, "in"));
+		weather.pins.push_back(Pin(41, PinDirection::Output, PinKind::Exec, "out"));
+		{ RoutineProperty p; p.key = "weatherIndex"; p.type = RoutineDataType::Int; p.iValue = 3; weather.properties.push_back(p); }
+
+		g.nodes = { ev, br, season, weather };
+		g.links = {
+			RoutineLink{ 100, 1, 10, 2, 20 },  // event -> branch
+			RoutineLink{ 101, 2, 21, 3, 30 },  // true  -> season
+			RoutineLink{ 102, 2, 22, 4, 40 },  // false -> weather
+		};
+		return g;
+	}
+
+	void Test_OpenDoorChain()
+	{
+		RoutineGraph g = MakeOpenDoorGraph();
+		ZoneEventVm vm(g);
+		MockRoutineHost host;
+		RoutineRunContext ctx;
+		bool fired = vm.Fire(RoutineNodeType::EventOnInteract, ctx, host);
+		REQUIRE(fired);
+		REQUIRE(host.openCalls.size() == 1);
+		if (!host.openCalls.empty())
+		{
+			REQUIRE(host.openCalls[0].first == 42u);
+			REQUIRE(host.openCalls[0].second == true);
+		}
+	}
+
+	void Test_BranchDefaultFalse()
+	{
+		RoutineGraph g = MakeBranchGraph();
+		ZoneEventVm vm(g);
+		MockRoutineHost host; // cond non lié → false → branche "false" → weather
+		RoutineRunContext ctx;
+		REQUIRE(vm.Fire(RoutineNodeType::EventOnInteract, ctx, host));
+		REQUIRE(host.weatherCalls.size() == 1);
+		REQUIRE(host.seasonCalls.empty());
+		if (!host.weatherCalls.empty()) REQUIRE(host.weatherCalls[0] == 3);
+	}
+
+	void Test_Determinism_SameTrace()
+	{
+		RoutineGraph g = MakeOpenDoorGraph();
+		ZoneEventVm vm(g);
+		MockRoutineHost a, b;
+		RoutineRunContext ctx;
+		vm.Fire(RoutineNodeType::EventOnInteract, ctx, a);
+		vm.Fire(RoutineNodeType::EventOnInteract, ctx, b);
+		REQUIRE(a.trace == b.trace);
+		REQUIRE(!a.trace.empty());
+	}
+
+	void Test_WrongKindOrMissingEvent()
+	{
+		RoutineGraph g = MakeOpenDoorGraph();
+		ZoneEventVm vm(g);
+		MockRoutineHost host;
+		RoutineRunContext ctx;
+		// Type d'event absent du graphe.
+		REQUIRE(!vm.Fire(RoutineNodeType::EventOnZoneExit, ctx, host));
+
+		// Mauvais kind.
+		RoutineGraph npc; npc.kind = RoutineGraphKind::NpcRoutine;
+		ZoneEventVm vm2(npc);
+		REQUIRE(!vm2.Fire(RoutineNodeType::EventOnInteract, ctx, host));
+	}
+}
+
+int main()
+{
+	Test_OpenDoorChain();
+	Test_BranchDefaultFalse();
+	Test_Determinism_SameTrace();
+	Test_WrongKindOrMissingEvent();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineVmTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineVmTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -10,6 +10,7 @@
 #include "src/world_editor/panels/HistoryPanel.h"
 #include "src/world_editor/panels/SurfaceTablePanel.h"
 #include "src/world_editor/panels/CollisionEditorPanel.h"
+#include "src/world_editor/routine/RoutineGraphPanel.h"
 #include "src/world_editor/ui/EditorToolbar.h"
 
 #include "src/shared/core/Config.h"
@@ -107,6 +108,10 @@ namespace engine::editor::world
 		collisionPanel->Init(
 			std::filesystem::path(cfg.GetString("paths.content", "game/data")));
 		m_panels.emplace_back(std::move(collisionPanel));
+		// M101.4 — Panel nodal de routines. AJOUTÉ EN FIN pour ne pas décaler
+		// les indices fixes (Scene=0, ToolProperties=5). Caché par défaut,
+		// toggle via le menu View. Partage la pile undo/redo du shell.
+		m_panels.emplace_back(std::make_unique<RoutineGraphPanel>(&m_commandStack));
 
 #if defined(_WIN32)
 		std::error_code ec;

--- a/src/world_editor/routine/RoutineGraphCommands.cpp
+++ b/src/world_editor/routine/RoutineGraphCommands.cpp
@@ -1,0 +1,180 @@
+// M101.4 / M101.5 — Implémentation des commandes d'édition de graphe.
+
+#include "src/world_editor/routine/RoutineGraphCommands.h"
+
+#include <algorithm>
+
+namespace engine::editor::world
+{
+	using engine::routine::RoutineLink;
+	using engine::routine::RoutineNode;
+	using engine::routine::RoutineProperty;
+
+	// ---- AddNodeCommand ----
+
+	AddNodeCommand::AddNodeCommand(RoutineGraphDocument& doc, RoutineNode node)
+		: m_doc(doc), m_node(std::move(node)) {}
+
+	size_t AddNodeCommand::GetMemoryFootprint() const
+	{
+		return sizeof(*this) + m_node.pins.size() * sizeof(engine::routine::RoutinePin) +
+		       m_node.properties.size() * sizeof(RoutineProperty);
+	}
+
+	void AddNodeCommand::Execute()
+	{
+		m_prevSelected = m_doc.selectedNodeId;
+		m_doc.graph.nodes.push_back(m_node);
+		m_doc.selectedNodeId = m_node.id;
+	}
+
+	void AddNodeCommand::Undo()
+	{
+		auto& nodes = m_doc.graph.nodes;
+		nodes.erase(std::remove_if(nodes.begin(), nodes.end(),
+			[this](const RoutineNode& n) { return n.id == m_node.id; }), nodes.end());
+		m_doc.selectedNodeId = m_prevSelected;
+	}
+
+	// ---- RemoveNodeCommand ----
+
+	RemoveNodeCommand::RemoveNodeCommand(RoutineGraphDocument& doc, uint32_t nodeId)
+		: m_doc(doc), m_nodeId(nodeId) {}
+
+	size_t RemoveNodeCommand::GetMemoryFootprint() const
+	{
+		return sizeof(*this) + m_removedLinks.size() * sizeof(RoutineLink);
+	}
+
+	void RemoveNodeCommand::Execute()
+	{
+		auto& nodes = m_doc.graph.nodes;
+		auto& links = m_doc.graph.links;
+
+		if (!m_captured)
+		{
+			if (const RoutineNode* n = m_doc.FindNode(m_nodeId)) m_node = *n;
+			for (const auto& l : links)
+				if (l.fromNodeId == m_nodeId || l.toNodeId == m_nodeId)
+					m_removedLinks.push_back(l);
+			m_captured = true;
+		}
+
+		links.erase(std::remove_if(links.begin(), links.end(),
+			[this](const RoutineLink& l) { return l.fromNodeId == m_nodeId || l.toNodeId == m_nodeId; }),
+			links.end());
+		nodes.erase(std::remove_if(nodes.begin(), nodes.end(),
+			[this](const RoutineNode& n) { return n.id == m_nodeId; }), nodes.end());
+		if (m_doc.selectedNodeId == m_nodeId) m_doc.selectedNodeId = 0;
+	}
+
+	void RemoveNodeCommand::Undo()
+	{
+		m_doc.graph.nodes.push_back(m_node);
+		for (const auto& l : m_removedLinks) m_doc.graph.links.push_back(l);
+	}
+
+	// ---- MoveNodeCommand ----
+
+	MoveNodeCommand::MoveNodeCommand(RoutineGraphDocument& doc, uint32_t nodeId,
+		float oldX, float oldY, float newX, float newY)
+		: m_doc(doc), m_nodeId(nodeId), m_oldX(oldX), m_oldY(oldY), m_newX(newX), m_newY(newY) {}
+
+	void MoveNodeCommand::Execute()
+	{
+		if (RoutineNode* n = m_doc.FindNode(m_nodeId)) { n->canvasX = m_newX; n->canvasY = m_newY; }
+	}
+
+	void MoveNodeCommand::Undo()
+	{
+		if (RoutineNode* n = m_doc.FindNode(m_nodeId)) { n->canvasX = m_oldX; n->canvasY = m_oldY; }
+	}
+
+	bool MoveNodeCommand::TryMerge(const ICommand& other)
+	{
+		const auto* o = dynamic_cast<const MoveNodeCommand*>(&other);
+		if (!o || o->m_nodeId != m_nodeId) return false;
+		// Le sommet absorbe : la position finale devient celle du nouveau move.
+		m_newX = o->m_newX;
+		m_newY = o->m_newY;
+		return true;
+	}
+
+	// ---- AddLinkCommand ----
+
+	AddLinkCommand::AddLinkCommand(RoutineGraphDocument& doc, RoutineLink link)
+		: m_doc(doc), m_link(link) {}
+
+	void AddLinkCommand::Execute() { m_doc.graph.links.push_back(m_link); }
+
+	void AddLinkCommand::Undo()
+	{
+		auto& links = m_doc.graph.links;
+		links.erase(std::remove_if(links.begin(), links.end(),
+			[this](const RoutineLink& l) { return l.id == m_link.id; }), links.end());
+	}
+
+	// ---- RemoveLinkCommand ----
+
+	RemoveLinkCommand::RemoveLinkCommand(RoutineGraphDocument& doc, uint32_t linkId)
+		: m_doc(doc), m_linkId(linkId) {}
+
+	void RemoveLinkCommand::Execute()
+	{
+		auto& links = m_doc.graph.links;
+		if (!m_captured)
+		{
+			for (const auto& l : links)
+				if (l.id == m_linkId) { m_link = l; m_captured = true; break; }
+		}
+		links.erase(std::remove_if(links.begin(), links.end(),
+			[this](const RoutineLink& l) { return l.id == m_linkId; }), links.end());
+	}
+
+	void RemoveLinkCommand::Undo()
+	{
+		if (m_captured) m_doc.graph.links.push_back(m_link);
+	}
+
+	// ---- SetNodePropertyCommand ----
+
+	SetNodePropertyCommand::SetNodePropertyCommand(RoutineGraphDocument& doc, uint32_t nodeId,
+		RoutineProperty newValue)
+		: m_doc(doc), m_nodeId(nodeId), m_newValue(std::move(newValue)) {}
+
+	void SetNodePropertyCommand::Execute()
+	{
+		RoutineNode* n = m_doc.FindNode(m_nodeId);
+		if (!n) return;
+		for (auto& p : n->properties)
+		{
+			if (p.key == m_newValue.key)
+			{
+				m_oldValue = p;
+				m_existed = true;
+				p = m_newValue;
+				return;
+			}
+		}
+		// Propriété absente : on l'ajoute (Undo la retirera).
+		m_existed = false;
+		n->properties.push_back(m_newValue);
+	}
+
+	void SetNodePropertyCommand::Undo()
+	{
+		RoutineNode* n = m_doc.FindNode(m_nodeId);
+		if (!n) return;
+		if (m_existed)
+		{
+			for (auto& p : n->properties)
+				if (p.key == m_newValue.key) { p = m_oldValue; return; }
+		}
+		else
+		{
+			auto& props = n->properties;
+			props.erase(std::remove_if(props.begin(), props.end(),
+				[this](const RoutineProperty& p) { return p.key == m_newValue.key; }), props.end());
+		}
+	}
+}

--- a/src/world_editor/routine/RoutineGraphCommands.h
+++ b/src/world_editor/routine/RoutineGraphCommands.h
@@ -1,0 +1,114 @@
+#pragma once
+
+// M101.4 / M101.5 — Commandes d'édition de graphe (undo/redo via CommandStack).
+//
+// Toutes les mutations du RoutineGraphDocument passent par ces ICommand, pour
+// que l'historique reste cohérent (cf. HistoryPanel). Logique pure (aucun
+// ImGui) : testable headless en CI Linux.
+
+#include <string>
+#include <vector>
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/routine/RoutineGraphDocument.h"
+
+namespace engine::editor::world
+{
+	/// Ajoute un nœud (et le sélectionne). Undo le retire.
+	class AddNodeCommand final : public ICommand
+	{
+	public:
+		AddNodeCommand(RoutineGraphDocument& doc, engine::routine::RoutineNode node);
+		const char* GetLabel() const override { return "Add node"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+	private:
+		RoutineGraphDocument& m_doc;
+		engine::routine::RoutineNode m_node;
+		uint32_t m_prevSelected = 0;
+	};
+
+	/// Retire un nœud et ses liens incidents. Undo les restaure.
+	class RemoveNodeCommand final : public ICommand
+	{
+	public:
+		RemoveNodeCommand(RoutineGraphDocument& doc, uint32_t nodeId);
+		const char* GetLabel() const override { return "Remove node"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+	private:
+		RoutineGraphDocument& m_doc;
+		uint32_t m_nodeId;
+		engine::routine::RoutineNode m_node;          // copie pour restauration
+		std::vector<engine::routine::RoutineLink> m_removedLinks;
+		bool m_captured = false;
+	};
+
+	/// Déplace un nœud. Coalesçable pendant un drag (même mergeKey = nodeId).
+	class MoveNodeCommand final : public ICommand
+	{
+	public:
+		MoveNodeCommand(RoutineGraphDocument& doc, uint32_t nodeId,
+		                float oldX, float oldY, float newX, float newY);
+		const char* GetLabel() const override { return "Move node"; }
+		size_t GetMemoryFootprint() const override { return sizeof(*this); }
+		CommandMergeKey GetMergeKey() const override { return m_nodeId; }
+		void Execute() override;
+		void Undo() override;
+		bool TryMerge(const ICommand& other) override;
+	private:
+		RoutineGraphDocument& m_doc;
+		uint32_t m_nodeId;
+		float m_oldX, m_oldY, m_newX, m_newY;
+	};
+
+	/// Ajoute un lien. Undo le retire.
+	class AddLinkCommand final : public ICommand
+	{
+	public:
+		AddLinkCommand(RoutineGraphDocument& doc, engine::routine::RoutineLink link);
+		const char* GetLabel() const override { return "Add link"; }
+		size_t GetMemoryFootprint() const override { return sizeof(*this); }
+		void Execute() override;
+		void Undo() override;
+	private:
+		RoutineGraphDocument& m_doc;
+		engine::routine::RoutineLink m_link;
+	};
+
+	/// Retire un lien. Undo le restaure.
+	class RemoveLinkCommand final : public ICommand
+	{
+	public:
+		RemoveLinkCommand(RoutineGraphDocument& doc, uint32_t linkId);
+		const char* GetLabel() const override { return "Remove link"; }
+		size_t GetMemoryFootprint() const override { return sizeof(*this); }
+		void Execute() override;
+		void Undo() override;
+	private:
+		RoutineGraphDocument& m_doc;
+		uint32_t m_linkId;
+		engine::routine::RoutineLink m_link;
+		bool m_captured = false;
+	};
+
+	/// Modifie une propriété d'un nœud (par clé). Undo restaure l'ancienne.
+	class SetNodePropertyCommand final : public ICommand
+	{
+	public:
+		SetNodePropertyCommand(RoutineGraphDocument& doc, uint32_t nodeId,
+		                       engine::routine::RoutineProperty newValue);
+		const char* GetLabel() const override { return "Set node property"; }
+		size_t GetMemoryFootprint() const override { return sizeof(*this); }
+		void Execute() override;
+		void Undo() override;
+	private:
+		RoutineGraphDocument& m_doc;
+		uint32_t m_nodeId;
+		engine::routine::RoutineProperty m_newValue;
+		engine::routine::RoutineProperty m_oldValue;
+		bool m_existed = false;
+	};
+}

--- a/src/world_editor/routine/RoutineGraphDocument.h
+++ b/src/world_editor/routine/RoutineGraphDocument.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// M101.4 — Document d'édition d'un graphe de routine (état éditeur).
+//
+// Données pures (aucun ImGui) : le RoutineGraph en cours d'édition + l'état de
+// sélection et de canvas. Manipulé exclusivement via des ICommand
+// (RoutineGraphCommands) pour préserver l'historique undo/redo.
+
+#include <cstdint>
+
+#include "src/shared/routine/RoutineGraph.h"
+
+namespace engine::editor::world
+{
+	struct RoutineGraphDocument
+	{
+		engine::routine::RoutineGraph graph;
+
+		// Sélection (0 = aucune).
+		uint32_t selectedNodeId = 0;
+		uint32_t selectedLinkId = 0;
+
+		// Transform du canvas (édition uniquement).
+		float panX = 0.0f;
+		float panY = 0.0f;
+		float zoom = 1.0f;
+
+		// Allocation d'ids monotone et déterministe (par session d'édition).
+		uint32_t nextNodeId = 1;
+		uint32_t nextLinkId = 1;
+		uint32_t nextPinId = 1;
+
+		// --- accès utilitaires (sans effet d'historique) ---
+
+		engine::routine::RoutineNode* FindNode(uint32_t id)
+		{
+			for (auto& n : graph.nodes) if (n.id == id) return &n;
+			return nullptr;
+		}
+		const engine::routine::RoutineNode* FindNode(uint32_t id) const
+		{
+			for (const auto& n : graph.nodes) if (n.id == id) return &n;
+			return nullptr;
+		}
+
+		bool HasLink(uint32_t id) const
+		{
+			for (const auto& l : graph.links) if (l.id == id) return true;
+			return false;
+		}
+	};
+}

--- a/src/world_editor/routine/RoutineGraphPanel.cpp
+++ b/src/world_editor/routine/RoutineGraphPanel.cpp
@@ -1,0 +1,130 @@
+// M101.4 / M101.5 — Rendu du panneau nodal. Corps ImGui guardé Windows.
+
+#include "src/world_editor/routine/RoutineGraphPanel.h"
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/routine/RoutineGraphCommands.h"
+#include "src/world_editor/routine/RoutineNodeInspector.h"
+#include "src/world_editor/routine/RoutineNodePalette.h"
+#include "src/shared/routine/RoutineGraph.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <memory>
+#endif
+
+namespace engine::editor::world
+{
+	void RoutineGraphPanel::Render()
+	{
+#if defined(_WIN32)
+		if (!m_visible) return;
+		if (ImGui::Begin("Routines", &m_visible))
+		{
+			// Barre : nom + type de graphe + bouton palette.
+			ImGui::Text("Graphe: %s",
+				m_doc.graph.name.empty() ? "(sans nom)" : m_doc.graph.name.c_str());
+			ImGui::SameLine();
+			ImGui::Text("| Type: %s", engine::routine::ToString(m_doc.graph.kind));
+			ImGui::SameLine();
+			if (ImGui::Button("+ Noeud")) ImGui::OpenPopup("routine_palette");
+			if (ImGui::BeginPopup("routine_palette"))
+			{
+				if (m_stack) RenderRoutineNodePalette(m_doc, *m_stack);
+				ImGui::EndPopup();
+			}
+			ImGui::Separator();
+
+			ImGui::Columns(2, "routine_cols", true);
+
+			// --- canvas ---
+			ImGui::BeginChild("routine_canvas", ImVec2(0.0f, 0.0f), true);
+			ImDrawList* dl = ImGui::GetWindowDrawList();
+			const ImVec2 origin = ImGui::GetCursorScreenPos();
+			const float zoom = (m_doc.zoom <= 0.0f) ? 1.0f : m_doc.zoom;
+			const ImVec2 nodeSize(140.0f * zoom, 48.0f * zoom);
+
+			// Liens (courbes de Bézier sortie -> entrée).
+			for (const auto& l : m_doc.graph.links)
+			{
+				const engine::routine::RoutineNode* a = m_doc.FindNode(l.fromNodeId);
+				const engine::routine::RoutineNode* b = m_doc.FindNode(l.toNodeId);
+				if (!a || !b) continue;
+				const ImVec2 pa(origin.x + (a->canvasX + m_doc.panX) * zoom + nodeSize.x,
+				                origin.y + (a->canvasY + m_doc.panY) * zoom + nodeSize.y * 0.5f);
+				const ImVec2 pb(origin.x + (b->canvasX + m_doc.panX) * zoom,
+				                origin.y + (b->canvasY + m_doc.panY) * zoom + nodeSize.y * 0.5f);
+				dl->AddBezierCubic(pa, ImVec2(pa.x + 50.0f, pa.y), ImVec2(pb.x - 50.0f, pb.y), pb,
+				                   IM_COL32(180, 180, 120, 255), 2.0f);
+			}
+
+			// Nœuds (boîtes + sélection + drag).
+			for (auto& n : m_doc.graph.nodes)
+			{
+				const ImVec2 p(origin.x + (n.canvasX + m_doc.panX) * zoom,
+				               origin.y + (n.canvasY + m_doc.panY) * zoom);
+				ImGui::PushID(static_cast<int>(n.id));
+				ImGui::SetCursorScreenPos(p);
+				ImGui::InvisibleButton("node", nodeSize);
+
+				if (ImGui::IsItemActivated())
+				{
+					m_doc.selectedNodeId = n.id;
+					m_dragging = true;
+					m_dragNodeId = n.id;
+					m_dragStartX = n.canvasX;
+					m_dragStartY = n.canvasY;
+				}
+				if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+				{
+					const ImVec2 d = ImGui::GetIO().MouseDelta;
+					n.canvasX += d.x / zoom;
+					n.canvasY += d.y / zoom;
+				}
+
+				const bool sel = (m_doc.selectedNodeId == n.id);
+				const ImU32 fill = sel ? IM_COL32(90, 90, 140, 230) : IM_COL32(60, 60, 70, 230);
+				dl->AddRectFilled(p, ImVec2(p.x + nodeSize.x, p.y + nodeSize.y), fill, 5.0f);
+				dl->AddRect(p, ImVec2(p.x + nodeSize.x, p.y + nodeSize.y),
+				            IM_COL32(200, 200, 210, 255), 5.0f);
+				dl->AddText(ImVec2(p.x + 6.0f, p.y + 6.0f), IM_COL32(235, 235, 240, 255),
+				            engine::routine::ToString(n.type));
+				ImGui::PopID();
+			}
+
+			// Au relâchement : enregistre un MoveNodeCommand (undo) si déplacé.
+			if (m_dragging && !ImGui::IsMouseDown(ImGuiMouseButton_Left))
+			{
+				if (m_stack && m_dragNodeId != 0)
+				{
+					if (engine::routine::RoutineNode* n = m_doc.FindNode(m_dragNodeId))
+					{
+						const float curX = n->canvasX;
+						const float curY = n->canvasY;
+						if (curX != m_dragStartX || curY != m_dragStartY)
+						{
+							// Remet à l'origine puis pousse la commande (Execute
+							// réapplique la position finale ; Undo restaure).
+							n->canvasX = m_dragStartX;
+							n->canvasY = m_dragStartY;
+							m_stack->Push(std::make_unique<MoveNodeCommand>(
+								m_doc, m_dragNodeId, m_dragStartX, m_dragStartY, curX, curY));
+						}
+					}
+				}
+				m_dragging = false;
+				m_dragNodeId = 0;
+			}
+
+			ImGui::EndChild();
+
+			// --- inspecteur ---
+			ImGui::NextColumn();
+			if (m_stack) RenderRoutineNodeInspector(m_doc, *m_stack);
+
+			ImGui::Columns(1);
+		}
+		ImGui::End();
+#endif
+	}
+}

--- a/src/world_editor/routine/RoutineGraphPanel.h
+++ b/src/world_editor/routine/RoutineGraphPanel.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// M101.4 / M101.5 — Panneau nodal dockable (canvas + palette + inspecteur).
+//
+// Implémente IPanel. Le rendu ImGui est compilé uniquement sur Windows (comme
+// les autres panneaux du repo : ImGui n'est lié que sur WIN32) ; sur Linux le
+// corps de Render est vide. Toute mutation du graphe passe par le CommandStack
+// (undo/redo). Le panneau possède son RoutineGraphDocument.
+
+#include "src/world_editor/core/IPanel.h"
+#include "src/world_editor/routine/RoutineGraphDocument.h"
+
+namespace engine::editor::world
+{
+	class CommandStack;
+
+	class RoutineGraphPanel final : public IPanel
+	{
+	public:
+		/// \param stack Pile undo/redo possédée par WorldEditorShell (doit
+		/// survivre au panneau).
+		explicit RoutineGraphPanel(CommandStack* stack) : m_stack(stack) {}
+
+		const char* GetName() const override { return "Routines"; }
+		void Render() override;
+		bool IsVisible() const override { return m_visible; }
+		void SetVisible(bool visible) override { m_visible = visible; }
+
+		/// Accès au document (tests / intégration Playtest M101.9).
+		RoutineGraphDocument& Document() { return m_doc; }
+		const RoutineGraphDocument& Document() const { return m_doc; }
+
+	private:
+		CommandStack* m_stack = nullptr;
+		RoutineGraphDocument m_doc;
+		bool m_visible = false;
+
+		// État de drag d'un nœud (pour pousser un MoveNodeCommand au relâchement).
+		bool m_dragging = false;
+		uint32_t m_dragNodeId = 0;
+		float m_dragStartX = 0.0f;
+		float m_dragStartY = 0.0f;
+	};
+}

--- a/src/world_editor/routine/RoutineNodeInspector.cpp
+++ b/src/world_editor/routine/RoutineNodeInspector.cpp
@@ -1,0 +1,108 @@
+// M101.5 — Implémentation de l'inspecteur de propriétés de nœud.
+
+#include "src/world_editor/routine/RoutineNodeInspector.h"
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/routine/RoutineGraphCommands.h"
+#include "src/world_editor/routine/RoutineGraphDocument.h"
+#include "src/shared/routine/RoutineNodeSchema.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstring>
+#	include <memory>
+#endif
+
+namespace engine::editor::world
+{
+	void RenderRoutineNodeInspector(RoutineGraphDocument& doc, CommandStack& undo)
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Inspecteur");
+		ImGui::Separator();
+
+		engine::routine::RoutineNode* n = doc.FindNode(doc.selectedNodeId);
+		if (!n)
+		{
+			ImGui::TextUnformatted("(aucun noeud selectionne)");
+			return;
+		}
+
+		if (const engine::routine::RoutineNodeSchema* s = engine::routine::FindSchema(n->type))
+			ImGui::Text("Type : %s", s->displayName);
+
+		for (size_t i = 0; i < n->properties.size(); ++i)
+		{
+			engine::routine::RoutineProperty& pr = n->properties[i];
+			ImGui::PushID(static_cast<int>(i));
+
+			switch (pr.type)
+			{
+				case engine::routine::RoutineDataType::Bool:
+				{
+					bool v = pr.bValue;
+					if (ImGui::Checkbox(pr.key.c_str(), &v))
+					{
+						engine::routine::RoutineProperty np = pr; np.bValue = v;
+						undo.Push(std::make_unique<SetNodePropertyCommand>(doc, n->id, np));
+					}
+					break;
+				}
+				case engine::routine::RoutineDataType::Int:
+				{
+					int v = static_cast<int>(pr.iValue);
+					if (ImGui::InputInt(pr.key.c_str(), &v))
+					{
+						engine::routine::RoutineProperty np = pr; np.iValue = v;
+						undo.Push(std::make_unique<SetNodePropertyCommand>(doc, n->id, np));
+					}
+					break;
+				}
+				case engine::routine::RoutineDataType::Float:
+				{
+					float v = pr.fValue;
+					if (ImGui::InputFloat(pr.key.c_str(), &v))
+					{
+						engine::routine::RoutineProperty np = pr; np.fValue = v;
+						undo.Push(std::make_unique<SetNodePropertyCommand>(doc, n->id, np));
+					}
+					break;
+				}
+				case engine::routine::RoutineDataType::Vec3:
+				{
+					float v[3] = { pr.vValue.x, pr.vValue.y, pr.vValue.z };
+					if (ImGui::InputFloat3(pr.key.c_str(), v))
+					{
+						engine::routine::RoutineProperty np = pr;
+						np.vValue.x = v[0]; np.vValue.y = v[1]; np.vValue.z = v[2];
+						undo.Push(std::make_unique<SetNodePropertyCommand>(doc, n->id, np));
+					}
+					break;
+				}
+				case engine::routine::RoutineDataType::String:
+				case engine::routine::RoutineDataType::EntityRef:
+				{
+					char buf[256];
+					std::strncpy(buf, pr.sValue.c_str(), sizeof(buf) - 1);
+					buf[sizeof(buf) - 1] = '\0';
+					if (ImGui::InputText(pr.key.c_str(), buf, sizeof(buf)))
+					{
+						engine::routine::RoutineProperty np = pr; np.sValue = buf;
+						undo.Push(std::make_unique<SetNodePropertyCommand>(doc, n->id, np));
+					}
+					break;
+				}
+				case engine::routine::RoutineDataType::None:
+				default:
+					ImGui::Text("%s : (aucune valeur)", pr.key.c_str());
+					break;
+			}
+
+			ImGui::PopID();
+		}
+#else
+		(void)doc;
+		(void)undo;
+#endif
+	}
+}

--- a/src/world_editor/routine/RoutineNodeInspector.h
+++ b/src/world_editor/routine/RoutineNodeInspector.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// M101.5 — Inspecteur de propriétés du nœud sélectionné. Rendu ImGui guardé.
+
+namespace engine::editor::world
+{
+	class CommandStack;
+	struct RoutineGraphDocument;
+
+	/// Rend les propriétés du nœud sélectionné, éditables par type ; toute
+	/// modification passe par SetNodePropertyCommand (undo/redo). Définie sur
+	/// toutes les plateformes (no-op hors Windows).
+	void RenderRoutineNodeInspector(RoutineGraphDocument& doc, CommandStack& undo);
+}

--- a/src/world_editor/routine/RoutineNodePalette.cpp
+++ b/src/world_editor/routine/RoutineNodePalette.cpp
@@ -5,11 +5,13 @@
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/routine/RoutineGraphCommands.h"
 #include "src/world_editor/routine/RoutineGraphDocument.h"
+#include "src/world_editor/help/HelpContentStore.h"
 #include "src/shared/routine/RoutineNodeSchema.h"
 
 #if defined(_WIN32)
 #	include "imgui.h"
 #	include <memory>
+#	include <string>
 
 namespace
 {
@@ -51,6 +53,17 @@ namespace engine::editor::world
 			{
 				undo.Push(std::make_unique<AddNodeCommand>(doc, MakeNodeFromSchema(s, doc)));
 				ImGui::CloseCurrentPopup();
+			}
+			// M101.11 — tooltip de survol : réutilise HelpContentStore (M100.47)
+			// si une entrée "routine.<NodeType>" existe, sinon le libellé.
+			if (ImGui::IsItemHovered())
+			{
+				const std::string key = std::string("routine.") + engine::routine::ToString(s.type);
+				const auto* help = engine::editor::world::help::HelpContentStore::Instance().FindTooltip(key);
+				if (help && !help->descriptionSimple.empty())
+					ImGui::SetTooltip("%s\n%s", help->label.c_str(), help->descriptionSimple.c_str());
+				else
+					ImGui::SetTooltip("%s", s.displayName);
 			}
 		}
 #else

--- a/src/world_editor/routine/RoutineNodePalette.cpp
+++ b/src/world_editor/routine/RoutineNodePalette.cpp
@@ -1,0 +1,61 @@
+// M101.5 — Implémentation de la palette de nœuds.
+
+#include "src/world_editor/routine/RoutineNodePalette.h"
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/routine/RoutineGraphCommands.h"
+#include "src/world_editor/routine/RoutineGraphDocument.h"
+#include "src/shared/routine/RoutineNodeSchema.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <memory>
+
+namespace
+{
+	using namespace engine::routine;
+
+	// Instancie un nœud depuis un schéma : ids uniques (alloués sur le document),
+	// pins/propriétés clonés du gabarit, position au centre logique du canvas.
+	RoutineNode MakeNodeFromSchema(const RoutineNodeSchema& s,
+	                               engine::editor::world::RoutineGraphDocument& doc)
+	{
+		RoutineNode n;
+		n.id = doc.nextNodeId++;
+		n.type = s.type;
+		n.canvasX = 40.0f;
+		n.canvasY = 40.0f;
+		for (const RoutinePin& tmpl : s.pinTemplate)
+		{
+			RoutinePin p = tmpl;
+			p.id = doc.nextPinId++;
+			n.pins.push_back(p);
+		}
+		n.properties = s.propertyTemplate;
+		return n;
+	}
+}
+#endif
+
+namespace engine::editor::world
+{
+	void RenderRoutineNodePalette(RoutineGraphDocument& doc, CommandStack& undo)
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Ajouter un noeud");
+		ImGui::Separator();
+		for (const engine::routine::RoutineNodeSchema& s : engine::routine::AllSchemas())
+		{
+			if (!engine::routine::SchemaValidForKind(s, doc.graph.kind)) continue;
+			if (ImGui::Selectable(s.displayName))
+			{
+				undo.Push(std::make_unique<AddNodeCommand>(doc, MakeNodeFromSchema(s, doc)));
+				ImGui::CloseCurrentPopup();
+			}
+		}
+#else
+		(void)doc;
+		(void)undo;
+#endif
+	}
+}

--- a/src/world_editor/routine/RoutineNodePalette.h
+++ b/src/world_editor/routine/RoutineNodePalette.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// M101.5 — Palette de nœuds (schema-driven). Rendu ImGui guardé Windows.
+
+namespace engine::editor::world
+{
+	class CommandStack;
+	struct RoutineGraphDocument;
+
+	/// Rend la palette : liste les schémas valides pour la cible du graphe
+	/// courant ; un clic insère le nœud correspondant via AddNodeCommand.
+	/// La fonction est définie sur toutes les plateformes (no-op hors Windows).
+	void RenderRoutineNodePalette(RoutineGraphDocument& doc, CommandStack& undo);
+}

--- a/src/world_editor/routine/tests/RoutineGraphCommandsTests.cpp
+++ b/src/world_editor/routine/tests/RoutineGraphCommandsTests.cpp
@@ -1,0 +1,137 @@
+// M101.4 / M101.5 — Tests des commandes d'édition de graphe (apply/undo),
+// headless (aucun ImGui). Lié à engine_core.
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/routine/RoutineGraphCommands.h"
+#include "src/world_editor/routine/RoutineGraphDocument.h"
+
+#include <cstdio>
+#include <memory>
+
+using namespace engine::editor::world;
+using engine::routine::RoutineGraphKind;
+using engine::routine::RoutineLink;
+using engine::routine::RoutineNode;
+using engine::routine::RoutineNodeType;
+using engine::routine::RoutineProperty;
+using engine::routine::RoutineDataType;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	RoutineNode MakeNode(uint32_t id, float x = 0.0f, float y = 0.0f)
+	{
+		RoutineNode n; n.id = id; n.type = RoutineNodeType::EventOnInteract;
+		n.canvasX = x; n.canvasY = y;
+		return n;
+	}
+
+	void Test_AddNode_Undo()
+	{
+		RoutineGraphDocument doc;
+		CommandStack stack;
+		stack.Push(std::make_unique<AddNodeCommand>(doc, MakeNode(1)));
+		REQUIRE(doc.graph.nodes.size() == 1);
+		REQUIRE(doc.selectedNodeId == 1);
+		stack.Undo();
+		REQUIRE(doc.graph.nodes.empty());
+	}
+
+	void Test_RemoveNode_WithLinks_Undo()
+	{
+		RoutineGraphDocument doc;
+		doc.graph.nodes.push_back(MakeNode(1));
+		doc.graph.nodes.push_back(MakeNode(2));
+		doc.graph.links.push_back(RoutineLink{ 100, 1, 10, 2, 20 });
+
+		CommandStack stack;
+		stack.Push(std::make_unique<RemoveNodeCommand>(doc, 1));
+		REQUIRE(doc.graph.nodes.size() == 1);
+		REQUIRE(doc.graph.links.empty()); // lien incident retiré
+		stack.Undo();
+		REQUIRE(doc.graph.nodes.size() == 2);
+		REQUIRE(doc.graph.links.size() == 1);
+	}
+
+	void Test_MoveNode_Undo_AndMerge()
+	{
+		RoutineGraphDocument doc;
+		doc.graph.nodes.push_back(MakeNode(1, 0.0f, 0.0f));
+
+		CommandStack stack;
+		stack.Push(std::make_unique<MoveNodeCommand>(doc, 1, 0.0f, 0.0f, 10.0f, 5.0f));
+		REQUIRE(doc.FindNode(1)->canvasX == 10.0f);
+		// Deuxième move même nœud → coalescing (mergeKey = nodeId).
+		stack.Push(std::make_unique<MoveNodeCommand>(doc, 1, 10.0f, 5.0f, 20.0f, 8.0f));
+		REQUIRE(doc.FindNode(1)->canvasX == 20.0f);
+		REQUIRE(stack.UndoSize() == 1); // les deux moves fusionnés
+		stack.Undo();
+		REQUIRE(doc.FindNode(1)->canvasX == 0.0f); // retour à l'origine
+		REQUIRE(doc.FindNode(1)->canvasY == 0.0f);
+	}
+
+	void Test_AddRemoveLink_Undo()
+	{
+		RoutineGraphDocument doc;
+		doc.graph.nodes.push_back(MakeNode(1));
+		doc.graph.nodes.push_back(MakeNode(2));
+
+		CommandStack stack;
+		stack.Push(std::make_unique<AddLinkCommand>(doc, RoutineLink{ 100, 1, 10, 2, 20 }));
+		REQUIRE(doc.graph.links.size() == 1);
+		stack.Undo();
+		REQUIRE(doc.graph.links.empty());
+
+		doc.graph.links.push_back(RoutineLink{ 200, 1, 10, 2, 20 });
+		stack.Push(std::make_unique<RemoveLinkCommand>(doc, 200));
+		REQUIRE(doc.graph.links.empty());
+		stack.Undo();
+		REQUIRE(doc.graph.links.size() == 1);
+	}
+
+	void Test_SetNodeProperty_Undo()
+	{
+		RoutineGraphDocument doc;
+		RoutineNode n = MakeNode(1);
+		RoutineProperty existing; existing.key = "open"; existing.type = RoutineDataType::Bool; existing.bValue = false;
+		n.properties.push_back(existing);
+		doc.graph.nodes.push_back(n);
+
+		CommandStack stack;
+		RoutineProperty np; np.key = "open"; np.type = RoutineDataType::Bool; np.bValue = true;
+		stack.Push(std::make_unique<SetNodePropertyCommand>(doc, 1, np));
+		REQUIRE(doc.FindNode(1)->properties[0].bValue == true);
+		stack.Undo();
+		REQUIRE(doc.FindNode(1)->properties[0].bValue == false);
+
+		// Propriété absente → ajout puis undo (retrait).
+		RoutineProperty added; added.key = "newKey"; added.type = RoutineDataType::Int; added.iValue = 7;
+		stack.Push(std::make_unique<SetNodePropertyCommand>(doc, 1, added));
+		REQUIRE(doc.FindNode(1)->properties.size() == 2);
+		stack.Undo();
+		REQUIRE(doc.FindNode(1)->properties.size() == 1);
+	}
+}
+
+int main()
+{
+	Test_AddNode_Undo();
+	Test_RemoveNode_WithLinks_Undo();
+	Test_MoveNode_Undo_AndMerge();
+	Test_AddRemoveLink_Undo();
+	Test_SetNodeProperty_Undo();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineGraphCommandsTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineGraphCommandsTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/routine/tests/RoutineHelpContentTests.cpp
+++ b/src/world_editor/routine/tests/RoutineHelpContentTests.cpp
@@ -1,0 +1,79 @@
+// M101.11 — Test : le contenu d'aide des routines parse correctement, headless.
+// Vérifie le format des tooltips routine via le parser M100.47 existant.
+
+#include "src/world_editor/help/HelpContentStore.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace engine::editor::world::help;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	// JSON représentatif de game/data/editor/tooltips/routine.json.
+	const char* kRoutineJson = R"JSON({
+  "toolId": "routine",
+  "tooltips": {
+    "BranchIf": {
+      "label": "Branche (si)",
+      "description_simple": "Choisit la suite selon une condition.",
+      "description_advanced": "Lit un pin Data Bool ; suit true/false.",
+      "defaultValue": "",
+      "range": "",
+      "docSectionId": "routine/nodes#BranchIf"
+    },
+    "graph": {
+      "label": "Graphe de routine",
+      "description_simple": "Programme visuel de noeuds.",
+      "description_advanced": "Artefact JSON interprete au runtime.",
+      "defaultValue": "zone_event",
+      "range": "zone_event / npc_routine",
+      "docSectionId": "routine/graph"
+    }
+  }
+})JSON";
+
+	void Test_ParseRoutineTooltips()
+	{
+		TooltipFileContents out;
+		std::string err;
+		bool ok = ParseTooltipFileJson(kRoutineJson, out, err);
+		REQUIRE(ok);
+		REQUIRE(out.toolId == "routine");
+		REQUIRE(out.tooltips.size() == 2);
+		auto it = out.tooltips.find("BranchIf");
+		REQUIRE(it != out.tooltips.end());
+		if (it != out.tooltips.end())
+			REQUIRE(!it->second.label.empty());
+	}
+
+	void Test_RejectMissingToolId()
+	{
+		// Contrat M100.47 : toolId manquant => échec structurel.
+		TooltipFileContents out;
+		std::string err;
+		bool ok = ParseTooltipFileJson("{ \"tooltips\": {} }", out, err);
+		REQUIRE(!ok);
+	}
+}
+
+int main()
+{
+	Test_ParseRoutineTooltips();
+	Test_RejectMissingToolId();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutineHelpContentTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutineHelpContentTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/tools/zone_builder/lib/CMakeLists.txt
+++ b/tools/zone_builder/lib/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(zone_builder_lib PRIVATE
   ${CMAKE_SOURCE_DIR}
 )
 
-target_link_libraries(zone_builder_lib PUBLIC spdlog::spdlog)
+target_link_libraries(zone_builder_lib PUBLIC spdlog::spdlog routine_graph)
 
 if(MSVC)
   target_compile_options(zone_builder_lib PRIVATE /W4 /permissive- /Zc:preprocessor)
@@ -63,3 +63,14 @@ else()
   target_compile_options(zone_builder_roundtrip_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 add_test(NAME zone_builder_roundtrip_tests COMMAND zone_builder_roundtrip_tests)
+
+# M101.3 / M101.10 — Round-trip fichier editeur->client de routines.bin.
+add_executable(routines_segment_tests tests/RoutinesSegmentTests.cpp)
+target_link_libraries(routines_segment_tests PRIVATE zone_builder_lib)
+target_include_directories(routines_segment_tests PRIVATE ${CMAKE_SOURCE_DIR})
+if(MSVC)
+  target_compile_options(routines_segment_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(routines_segment_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+add_test(NAME routines_segment_tests COMMAND routines_segment_tests)

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -9,6 +9,7 @@
 #include "src/client/world/terrain/TerrainChunk.h"
 #include "src/client/world/terrain/TerrainLodChain.h"
 #include "src/client/world/water/WaterSurfaces.h"
+#include "src/shared/routine/RoutineSegmentCodec.h"
 
 #include <array>
 #include <cmath>
@@ -628,6 +629,40 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteWater: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteRoutines(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const std::vector<engine::routine::RoutineGraph>& graphs, std::string& outError)
+	{
+		// M101.3 — sérialise les graphes via le codec pur (parité éditeur ↔
+		// client : le client relit avec DecodeRoutinesBin), puis écrit
+		// `routines.bin` dans le dossier du chunk. Crée le dossier au besoin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "chunks" /
+			("chunk_" + std::to_string(chunkX) + "_" + std::to_string(chunkZ));
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteRoutines: create_directories failed: " + dir.string();
+			return false;
+		}
+
+		const std::vector<uint8_t> bytes = engine::routine::codec::EncodeRoutinesBin(graphs);
+		const std::filesystem::path file = dir / "routines.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteRoutines: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteRoutines: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -5,9 +5,11 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace engine::world::terrain { struct TerrainChunk; struct TerrainLodChain; struct SplatMap; }
 namespace engine::world::water { struct WaterScene; }
+namespace engine::routine { struct RoutineGraph; }
 
 namespace tools::zone_builder
 {
@@ -66,4 +68,13 @@ namespace tools::zone_builder
 		const engine::world::water::WaterScene& scene,
 		float seaLevelMeters,
 		std::string& outError);
+
+	/// Écrit `routines.bin` (M101.3) dans `<outputRootDir>/chunks/chunk_<x>_<z>/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::routine::codec::
+	/// EncodeRoutinesBin` (JSON canonique length-prefixé) ; format identique à
+	/// celui que le client relit avec `DecodeRoutinesBin` (parité éditeur ↔
+	/// client). Extension ADDITIVE du package : ne touche aucun segment existant.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteRoutines(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const std::vector<engine::routine::RoutineGraph>& graphs, std::string& outError);
 }

--- a/tools/zone_builder/lib/tests/RoutinesSegmentTests.cpp
+++ b/tools/zone_builder/lib/tests/RoutinesSegmentTests.cpp
@@ -1,0 +1,82 @@
+// M101.3 / M101.10 — Round-trip fichier éditeur→client de `routines.bin`.
+// Écrit via WriteRoutines (zone_builder) puis relit via ReadRoutinesFile
+// (client) et compare. Headless (filesystem temporaire, pas de Vulkan).
+
+#include <zone_builder/ChunkPackageWriter.h>
+
+#include "src/client/world/routine/RoutineSegmentReader.h"
+#include "src/shared/routine/RoutineGraph.h"
+#include "src/shared/routine/RoutineSerialization.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+using namespace engine::routine;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	RoutineGraph MakeSample()
+	{
+		RoutineGraph g;
+		g.kind = RoutineGraphKind::ZoneEvent;
+		g.name = "porte_taverne";
+		RoutineNode ev; ev.id = 1; ev.type = RoutineNodeType::EventOnInteract;
+		ev.canvasX = 64.0f; ev.canvasY = 32.0f;
+		RoutineProperty pr; pr.key = "interactiveId"; pr.type = RoutineDataType::EntityRef;
+		pr.sValue = "porte_42";
+		ev.properties.push_back(pr);
+		g.nodes.push_back(ev);
+		return g;
+	}
+
+	void Test_FileRoundTrip()
+	{
+		const std::filesystem::path root =
+			std::filesystem::temp_directory_path() / "lcdlln_m101_routines_test";
+		std::error_code ec;
+		std::filesystem::remove_all(root, ec);
+
+		std::vector<RoutineGraph> graphs = { MakeSample() };
+		std::string err;
+		bool wrote = tools::zone_builder::WriteRoutines(root.string(), 0, 0, graphs, err);
+		REQUIRE(wrote);
+		if (!wrote) { std::fprintf(stderr, "  write err: %s\n", err.c_str()); return; }
+
+		const std::filesystem::path file = root / "chunks" / "chunk_0_0" / "routines.bin";
+		REQUIRE(std::filesystem::exists(file));
+
+		engine::world::routine::LoadedRoutines loaded;
+		bool read = engine::world::routine::ReadRoutinesFile(file.string(), loaded, err);
+		REQUIRE(read);
+		if (read)
+		{
+			REQUIRE(loaded.graphs.size() == 1);
+			if (!loaded.graphs.empty())
+				REQUIRE(serialization::ToJson(loaded.graphs[0]) == serialization::ToJson(graphs[0]));
+		}
+
+		std::filesystem::remove_all(root, ec);
+	}
+}
+
+int main()
+{
+	Test_FileRoundTrip();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] RoutinesSegmentTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] RoutinesSegmentTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}


### PR DESCRIPTION
## Résumé

Implémentation du cluster **M101** (éditeur de routines visuel nodal), livrée dans **une seule PR** (consigne Hubert). Specs : tickets `tickets/M101/` (PR #805).

Périmètre : **tout ce qui est compilable maintenant**. **M101.8 / M101.9 différés** (dépendances M100.16/28/32/33 non mergées dans le code — vérifié).

## Tickets livrés
- [x] **M101.1** — Modèle de graphe + sérialisation JSON déterministe (lib pure `routine_graph`)
- [x] **M101.2** — VM `zone_event` + `IRoutineHost` (lib pure `routine_vm`)
- [x] **M101.3** — Segment `routines.bin` additif (`ChunkSegment::Routines`, `kChunkMetaHasRoutines=1u<<7`) + codec + writer/reader + round-trip
- [x] **M101.4** — Panneau nodal (canvas ImGui, commandes undo/redo via `CommandStack`)
- [x] **M101.5** — Palette schema-driven + inspecteur de propriétés typées
- [x] **M101.6** — Validation de graphe (cycles, pins, orphelins, schéma, cardinalité)
- [x] **M101.7 (partiel)** — Traduction `npc_routine → EventAIRow` ; hooks manquants (MoveTo, portée, Role Registry, Smart Objects) signalés → **reste Blocked**
- [x] **M101.11** — Contenu tooltips + parsing (réutilise `HelpContentStore` M100.47)
- [ ] M101.8 — différé (pas d'`InteractiveSimulator` / volumes M100.16/28/32 en code)
- [ ] M101.9 — différé (pas de Playtest F5 M100.33 en code)

## Tests headless (CI Linux ctest)
`routine_serialization_tests`, `routine_vm_tests`, `routine_validation_tests`, `routine_segment_codec_tests`, `routines_segment_tests`, `routine_to_eventai_tests`, `routine_graph_commands_tests`, `routine_help_content_tests`.

## Architecture
- `routine_graph` / `routine_vm` : **libs pures** (aucun Vulkan/GLFW), réutilisables par `engine_core` ET `server_app`.
- UI ImGui guardée `_WIN32` (comme tout le repo) : logique testée headless sur Linux, rendu validé en compilation sur Windows.
- Extension `routines.bin` **additive** (aucun segment existant modifié).
- Aucun nouvel opcode réseau.

## Déploiement
✅ **Client/éditeur uniquement.** (M101.7 entraînera un redéploiement shard à sa livraison complète ultérieure ; non déclenché ici.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)