### PR TITLE
feat(world): M100.16 — Hazard Volume System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,9 @@ add_library(engine_core
   src/world_editor/routine/RoutineGraphPanel.cpp
   src/world_editor/routine/RoutineNodePalette.cpp
   src/world_editor/routine/RoutineNodeInspector.cpp
+  # M100.16 — Hazard volumes (simulateur client + outil editeur ; format header-only).
+  src/client/world/hazard/HazardSimulator.cpp
+  src/world_editor/HazardTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -897,6 +900,12 @@ add_test(NAME routine_graph_commands_tests COMMAND routine_graph_commands_tests)
 add_executable(routine_help_content_tests src/world_editor/routine/tests/RoutineHelpContentTests.cpp)
 target_link_libraries(routine_help_content_tests PRIVATE engine_core)
 add_test(NAME routine_help_content_tests COMMAND routine_help_content_tests)
+
+# M100.16 — Tests hazards (round-trip binaire + simulateur). Format header-only,
+# simulateur dans engine_core : on ne lie QUE engine_core (pas de doublon).
+add_executable(hazard_tests src/client/world/hazard/tests/HazardTests.cpp)
+target_link_libraries(hazard_tests PRIVATE engine_core)
+add_test(NAME hazard_tests COMMAND hazard_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/src/client/world/hazard/HazardSimulator.cpp
+++ b/src/client/world/hazard/HazardSimulator.cpp
@@ -1,0 +1,106 @@
+// M100.16 — Implémentation du simulateur de hazard (machine à états pure).
+
+#include "src/client/world/hazard/HazardSimulator.h"
+
+namespace engine::world::hazard
+{
+	void HazardSimulator::Enter(const HazardVolume& volume)
+	{
+		m_volume = volume;
+		m_state = HazardState::Sinking;
+		m_depth = 0.0f;
+		m_mashCount = 0;
+		m_mashWindowElapsed = 0.0f;
+		m_lateralAccum = 0.0f;
+		m_lavaTimer = 0.0f;
+	}
+
+	void HazardSimulator::Exit()
+	{
+		if (m_state == HazardState::Sinking)
+		{
+			m_state = HazardState::Idle;
+			m_depth = 0.0f;
+		}
+	}
+
+	HazardOutput HazardSimulator::Update(const HazardInput& in)
+	{
+		HazardOutput out;
+		out.state = m_state;
+		out.currentDepth = m_depth;
+		out.groundOffsetMeters = m_depth;
+		out.slowdownMul = (m_state == HazardState::Sinking) ? m_volume.slowdownMul : 1.0f;
+
+		if (m_state != HazardState::Sinking)
+			return out;
+
+		// LavaSurface : pas d'enfoncement ni d'évasion, mort après 3 s.
+		if (m_volume.type == HazardType::LavaSurface)
+		{
+			m_lavaTimer += in.dtSeconds;
+			if (m_lavaTimer >= kLavaDeathSeconds)
+			{
+				m_state = HazardState::Dead;
+				out.state = m_state;
+				out.deathReason = "lava_burning";
+			}
+			out.slowdownMul = m_volume.slowdownMul;
+			return out;
+		}
+
+		// Enfoncement progressif.
+		m_depth += m_volume.sinkRateMps * in.dtSeconds;
+
+		// Tentatives d'évasion (vérifiées AVANT la mort).
+		bool escaped = false;
+		switch (m_volume.escapeMode)
+		{
+			case EscapeMode::MashButton:
+			case EscapeMode::MashButtonRequireItem:
+			{
+				m_mashWindowElapsed += in.dtSeconds;
+				if (m_mashWindowElapsed >= kMashWindowSeconds)
+				{
+					// Fenêtre glissante : on repart à zéro.
+					m_mashWindowElapsed = 0.0f;
+					m_mashCount = 0;
+				}
+				if (in.actionPressed) ++m_mashCount;
+				const bool itemOk = (m_volume.escapeMode == EscapeMode::MashButton) || in.hasRequiredItem;
+				if (m_mashCount >= kMashRequiredPresses && itemOk) escaped = true;
+				break;
+			}
+			case EscapeMode::LateralMove:
+			{
+				m_lateralAccum += (in.lateralDeltaMeters < 0.0f ? -in.lateralDeltaMeters : in.lateralDeltaMeters);
+				if (m_lateralAccum >= kLateralEscapeMeters) escaped = true;
+				break;
+			}
+			case EscapeMode::None:
+			default:
+				break;
+		}
+
+		if (escaped)
+		{
+			m_state = HazardState::Escaped;
+			out.state = m_state;
+			out.justEscaped = true;
+			out.currentDepth = m_depth;
+			out.groundOffsetMeters = m_depth;
+			return out;
+		}
+
+		if (m_depth >= m_volume.maxDepthMeters)
+		{
+			m_state = HazardState::Dead;
+			out.state = m_state;
+			out.deathReason = "hazard_drowning";
+		}
+
+		out.currentDepth = m_depth;
+		out.groundOffsetMeters = m_depth;
+		return out;
+	}
+}

--- a/src/client/world/hazard/HazardSimulator.h
+++ b/src/client/world/hazard/HazardSimulator.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// M100.16 — Simulateur de hazard (machine à états PURE, client only).
+//
+// Aucune dépendance rendu/réseau : prend des entrées (dt, appui action,
+// déplacement latéral, possession d'objet) et produit un état (enfoncement,
+// évasion, mort) + des sorties consommables par le CharacterController et la
+// caméra (offset sol, ralentissement). Testable headless.
+
+#include <string>
+
+#include "src/client/world/hazard/HazardVolumes.h"
+
+namespace engine::world::hazard
+{
+	enum class HazardState : uint8_t { Idle = 0, Sinking = 1, Escaped = 2, Dead = 3 };
+
+	struct HazardInput
+	{
+		float dtSeconds = 0.0f;
+		bool  actionPressed = false;     ///< Un appui "Action" cette frame.
+		float lateralDeltaMeters = 0.0f; ///< Déplacement horizontal cette frame.
+		bool  hasRequiredItem = false;   ///< Possède l'objet requis (Tar).
+	};
+
+	struct HazardOutput
+	{
+		HazardState state = HazardState::Idle;
+		float currentDepth = 0.0f;       ///< Profondeur d'enfoncement (m).
+		float groundOffsetMeters = 0.0f; ///< Compensation tête (= currentDepth).
+		float slowdownMul = 1.0f;        ///< Multiplicateur de vitesse appliqué.
+		bool  justEscaped = false;       ///< Vrai la frame de l'évasion.
+		std::string deathReason;         ///< Renseigné si state == Dead.
+	};
+
+	/// Simulateur d'un joueur dans un hazard. Un seul hazard actif à la fois.
+	class HazardSimulator
+	{
+	public:
+		/// Le joueur entre dans le volume : démarre l'enfoncement (ou le timer
+		/// lave). Réinitialise l'état interne.
+		void Enter(const HazardVolume& volume);
+
+		/// Le joueur quitte le volume avant d'être bloqué (sortie volontaire).
+		/// No-op si déjà Dead/Escaped.
+		void Exit();
+
+		/// Avance la simulation d'une frame et renvoie l'état/sorties.
+		HazardOutput Update(const HazardInput& in);
+
+		HazardState GetState() const { return m_state; }
+		float GetCurrentDepth() const { return m_depth; }
+
+		static constexpr float kMashWindowSeconds = 5.0f;
+		static constexpr int   kMashRequiredPresses = 10;
+		static constexpr float kLateralEscapeMeters = 2.0f;
+		static constexpr float kLavaDeathSeconds = 3.0f;
+
+	private:
+		HazardVolume m_volume{};
+		HazardState  m_state = HazardState::Idle;
+		float m_depth = 0.0f;
+		int   m_mashCount = 0;
+		float m_mashWindowElapsed = 0.0f;
+		float m_lateralAccum = 0.0f;
+		float m_lavaTimer = 0.0f;
+	};
+}

--- a/src/client/world/hazard/HazardVolumes.h
+++ b/src/client/world/hazard/HazardVolumes.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// M100.16 — Hazard Volumes : structures + sérialisation `instances/hazards.bin`.
+//
+// Sérialisation HEADER-ONLY (inline) : utilisable à la fois par engine_core
+// (runtime/éditeur) et par zone_builder_lib (writer offline) sans dupliquer de
+// symboles entre les deux libs. En-tête binaire de 24 octets, compatible avec
+// la disposition de `engine::world::OutputVersionHeader` (magic, formatVersion,
+// builderVersion, engineVersion, contentHash). Simulation strictement client.
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::hazard
+{
+	enum class HazardType : uint32_t { Quicksand = 0, Bog = 1, Tar = 2, LavaSurface = 3 };
+	enum class HazardShape : uint32_t { Box = 0, Cylinder = 1 };
+	enum class EscapeMode : uint32_t
+	{
+		None = 0, MashButton = 1, LateralMove = 2, MashButtonRequireItem = 3
+	};
+
+	struct HazardVolume
+	{
+		HazardType  type = HazardType::Quicksand;
+		HazardShape shape = HazardShape::Cylinder;
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+		engine::math::Vec3 boxHalfExtents{ 2.0f, 1.0f, 2.0f };
+		float cylRadius = 4.0f;
+		float cylHeight = 2.0f;
+		float sinkRateMps = 0.15f;
+		float maxDepthMeters = 1.8f;
+		float slowdownMul = 0.10f;
+		EscapeMode escapeMode = EscapeMode::MashButton;
+		uint32_t requiredItemId = 0;
+	};
+
+	constexpr uint32_t kHazardsMagic = 0x5A415748u; // "HAZA"
+	constexpr uint32_t kHazardsVersion = 1u;
+	constexpr uint32_t kHazardsBuilderVersion = 1u;
+	constexpr uint32_t kHazardsEngineVersion = 1u;
+
+	/// Paramètres par défaut par type (cf. tableau M100.16).
+	inline HazardVolume MakeDefaultHazard(HazardType type)
+	{
+		HazardVolume v;
+		v.type = type;
+		switch (type)
+		{
+			case HazardType::Quicksand:
+				v.sinkRateMps = 0.15f; v.maxDepthMeters = 1.8f; v.slowdownMul = 0.10f;
+				v.escapeMode = EscapeMode::MashButton; break;
+			case HazardType::Bog:
+				v.sinkRateMps = 0.08f; v.maxDepthMeters = 1.2f; v.slowdownMul = 0.20f;
+				v.escapeMode = EscapeMode::LateralMove; break;
+			case HazardType::Tar:
+				v.sinkRateMps = 0.05f; v.maxDepthMeters = 0.8f; v.slowdownMul = 0.05f;
+				v.escapeMode = EscapeMode::MashButtonRequireItem; break;
+			case HazardType::LavaSurface:
+				v.sinkRateMps = 0.0f; v.maxDepthMeters = 0.0f; v.slowdownMul = 0.0f;
+				v.escapeMode = EscapeMode::None; break;
+		}
+		return v;
+	}
+
+	// ---- helpers little-endian (inline) ----
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i)));
+		}
+		inline void PutF32(std::vector<uint8_t>& b, float f)
+		{
+			uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u);
+		}
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& out)
+		{
+			if (p + 4 > b.size()) return false;
+			out = uint32_t(b[p]) | (uint32_t(b[p + 1]) << 8) | (uint32_t(b[p + 2]) << 16) |
+			      (uint32_t(b[p + 3]) << 24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& out)
+		{
+			if (p + 8 > b.size()) return false;
+			out = 0; for (int i = 0; i < 8; ++i) out |= uint64_t(b[p + i]) << (8 * i);
+			p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& out)
+		{
+			uint32_t u; if (!GetU32(b, p, u)) return false;
+			std::memcpy(&out, &u, 4); return true;
+		}
+	}
+
+	/// Sérialise une liste de hazards en octets `hazards.bin`.
+	inline std::vector<uint8_t> SaveHazardsBin(const std::vector<HazardVolume>& hazards)
+	{
+		std::vector<uint8_t> b;
+		// En-tête 24 octets (compatible OutputVersionHeader).
+		detail::PutU32(b, kHazardsMagic);
+		detail::PutU32(b, kHazardsVersion);
+		detail::PutU32(b, kHazardsBuilderVersion);
+		detail::PutU32(b, kHazardsEngineVersion);
+		detail::PutU64(b, 0ull); // contentHash (non calculé ici)
+		detail::PutU32(b, static_cast<uint32_t>(hazards.size()));
+		for (const HazardVolume& h : hazards)
+		{
+			detail::PutU32(b, static_cast<uint32_t>(h.type));
+			detail::PutU32(b, static_cast<uint32_t>(h.shape));
+			detail::PutF32(b, h.position.x); detail::PutF32(b, h.position.y); detail::PutF32(b, h.position.z);
+			detail::PutF32(b, h.boxHalfExtents.x); detail::PutF32(b, h.boxHalfExtents.y); detail::PutF32(b, h.boxHalfExtents.z);
+			detail::PutF32(b, h.cylRadius);
+			detail::PutF32(b, h.cylHeight);
+			detail::PutF32(b, h.sinkRateMps);
+			detail::PutF32(b, h.maxDepthMeters);
+			detail::PutF32(b, h.slowdownMul);
+			detail::PutU32(b, static_cast<uint32_t>(h.escapeMode));
+			detail::PutU32(b, h.requiredItemId);
+		}
+		return b;
+	}
+
+	/// Désérialise des octets `hazards.bin`. Renseigne `err` et renvoie false
+	/// en cas d'en-tête/magic/version invalide ou de troncature.
+	inline bool LoadHazardsBin(std::span<const uint8_t> bytes, std::vector<HazardVolume>& out, std::string& err)
+	{
+		size_t p = 0;
+		uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kHazardsMagic) { err = "hazards.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kHazardsVersion) { err = "hazards.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder);
+		detail::GetU32(bytes, p, engine);
+		detail::GetU64(bytes, p, hash);
+		uint32_t count = 0;
+		if (!detail::GetU32(bytes, p, count)) { err = "hazards.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			HazardVolume h;
+			uint32_t t = 0, s = 0, em = 0;
+			if (!detail::GetU32(bytes, p, t)) { err = "hazards.bin: tronque"; return false; }
+			detail::GetU32(bytes, p, s);
+			detail::GetF32(bytes, p, h.position.x); detail::GetF32(bytes, p, h.position.y); detail::GetF32(bytes, p, h.position.z);
+			detail::GetF32(bytes, p, h.boxHalfExtents.x); detail::GetF32(bytes, p, h.boxHalfExtents.y); detail::GetF32(bytes, p, h.boxHalfExtents.z);
+			detail::GetF32(bytes, p, h.cylRadius);
+			detail::GetF32(bytes, p, h.cylHeight);
+			detail::GetF32(bytes, p, h.sinkRateMps);
+			detail::GetF32(bytes, p, h.maxDepthMeters);
+			detail::GetF32(bytes, p, h.slowdownMul);
+			if (!detail::GetU32(bytes, p, em)) { err = "hazards.bin: tronque (escape)"; return false; }
+			if (!detail::GetU32(bytes, p, h.requiredItemId)) { err = "hazards.bin: tronque (item)"; return false; }
+			h.type = static_cast<HazardType>(t);
+			h.shape = static_cast<HazardShape>(s);
+			h.escapeMode = static_cast<EscapeMode>(em);
+			out.push_back(h);
+		}
+		return true;
+	}
+}

--- a/src/client/world/hazard/tests/HazardTests.cpp
+++ b/src/client/world/hazard/tests/HazardTests.cpp
@@ -100,7 +100,13 @@ namespace
 		sim.Enter(v);
 		HazardInput in; in.dtSeconds = 1.0f; // 0.15 m/s
 		HazardOutput out;
-		for (int i = 0; i < 12; ++i) out = sim.Update(in); // 12 * 0.15 = 1.8 m
+		// Boucle jusqu'au dépassement franc de maxDepth (robuste à l'accumulation
+		// float : 12*0.15f peut tomber juste sous 1.8f). Garde-fou 100 itérations.
+		for (int i = 0; i < 100; ++i)
+		{
+			out = sim.Update(in);
+			if (out.state != HazardState::Sinking) break;
+		}
 		REQUIRE(out.state == HazardState::Dead);
 		REQUIRE(out.deathReason == "hazard_drowning");
 	}

--- a/src/client/world/hazard/tests/HazardTests.cpp
+++ b/src/client/world/hazard/tests/HazardTests.cpp
@@ -1,0 +1,123 @@
+// M100.16 — Tests hazards : round-trip binaire + comportements du simulateur.
+// Headless. Lié à engine_core (HazardSimulator) ; format header-only.
+
+#include "src/client/world/hazard/HazardSimulator.h"
+#include "src/client/world/hazard/HazardVolumes.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::hazard;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-4f) { return (a - b < eps) && (b - a < eps); }
+
+	void Test_Hazards_RoundtripBin()
+	{
+		std::vector<HazardVolume> hz;
+		HazardVolume q = MakeDefaultHazard(HazardType::Quicksand); q.position = { 1.0f, 2.0f, 3.0f };
+		HazardVolume b = MakeDefaultHazard(HazardType::Bog);       b.shape = HazardShape::Box; b.boxHalfExtents = { 3.0f, 1.0f, 2.0f };
+		HazardVolume t = MakeDefaultHazard(HazardType::Tar);       t.requiredItemId = 42u;
+		HazardVolume l = MakeDefaultHazard(HazardType::LavaSurface);
+		hz = { q, b, t, l };
+
+		std::vector<uint8_t> bytes = SaveHazardsBin(hz);
+		std::vector<HazardVolume> out;
+		std::string err;
+		REQUIRE(LoadHazardsBin(bytes, out, err));
+		REQUIRE(out.size() == 4);
+		if (out.size() == 4)
+		{
+			REQUIRE(out[0].type == HazardType::Quicksand);
+			REQUIRE(Near(out[0].position.x, 1.0f) && Near(out[0].position.z, 3.0f));
+			REQUIRE(out[1].shape == HazardShape::Box);
+			REQUIRE(Near(out[1].boxHalfExtents.x, 3.0f));
+			REQUIRE(out[2].type == HazardType::Tar);
+			REQUIRE(out[2].requiredItemId == 42u);
+			REQUIRE(out[2].escapeMode == EscapeMode::MashButtonRequireItem);
+			REQUIRE(out[3].type == HazardType::LavaSurface);
+		}
+	}
+
+	void Test_HazardSimulator_SinkRate()
+	{
+		HazardSimulator sim;
+		sim.Enter(MakeDefaultHazard(HazardType::Quicksand)); // sinkRate 0.15
+		HazardInput in; in.dtSeconds = 1.0f;
+		HazardOutput out = sim.Update(in);
+		REQUIRE(out.state == HazardState::Sinking);
+		REQUIRE(Near(out.currentDepth, 0.15f));
+		REQUIRE(Near(out.groundOffsetMeters, 0.15f));
+	}
+
+	void Test_HazardSimulator_MashEscape()
+	{
+		HazardSimulator sim;
+		sim.Enter(MakeDefaultHazard(HazardType::Quicksand));
+		HazardInput in; in.dtSeconds = 0.1f; in.actionPressed = true;
+		HazardState last = HazardState::Sinking;
+		for (int i = 0; i < 10; ++i) last = sim.Update(in).state;
+		REQUIRE(last == HazardState::Escaped);
+	}
+
+	void Test_HazardSimulator_LateralEscape()
+	{
+		HazardSimulator sim;
+		sim.Enter(MakeDefaultHazard(HazardType::Bog)); // LateralMove, 2 m
+		HazardInput in; in.dtSeconds = 0.1f; in.lateralDeltaMeters = 0.5f;
+		HazardState last = HazardState::Sinking;
+		for (int i = 0; i < 4; ++i) last = sim.Update(in).state; // 4 * 0.5 = 2.0 m
+		REQUIRE(last == HazardState::Escaped);
+	}
+
+	void Test_HazardSimulator_LavaKills3s()
+	{
+		HazardSimulator sim;
+		sim.Enter(MakeDefaultHazard(HazardType::LavaSurface));
+		HazardInput in; in.dtSeconds = 0.5f;
+		for (int i = 0; i < 5; ++i) sim.Update(in); // 2.5 s
+		REQUIRE(sim.GetState() == HazardState::Sinking);
+		HazardOutput out = sim.Update(in); // 3.0 s
+		REQUIRE(out.state == HazardState::Dead);
+		REQUIRE(out.deathReason == "lava_burning");
+	}
+
+	void Test_HazardSimulator_DeathOnMaxDepth()
+	{
+		HazardVolume v = MakeDefaultHazard(HazardType::Quicksand);
+		v.escapeMode = EscapeMode::None; // pas d'évasion possible
+		HazardSimulator sim;
+		sim.Enter(v);
+		HazardInput in; in.dtSeconds = 1.0f; // 0.15 m/s
+		HazardOutput out;
+		for (int i = 0; i < 12; ++i) out = sim.Update(in); // 12 * 0.15 = 1.8 m
+		REQUIRE(out.state == HazardState::Dead);
+		REQUIRE(out.deathReason == "hazard_drowning");
+	}
+}
+
+int main()
+{
+	Test_Hazards_RoundtripBin();
+	Test_HazardSimulator_SinkRate();
+	Test_HazardSimulator_MashEscape();
+	Test_HazardSimulator_LateralEscape();
+	Test_HazardSimulator_LavaKills3s();
+	Test_HazardSimulator_DeathOnMaxDepth();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] HazardTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] HazardTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/HazardDocument.h
+++ b/src/world_editor/HazardDocument.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// M100.16 — Document monde des hazards (état éditeur). Header-only.
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/client/world/hazard/HazardVolumes.h"
+
+namespace engine::editor::world
+{
+	class HazardDocument
+	{
+	public:
+		void Add(const engine::world::hazard::HazardVolume& h) { m_hazards.push_back(h); }
+		void Clear() { m_hazards.clear(); }
+		const std::vector<engine::world::hazard::HazardVolume>& All() const { return m_hazards; }
+		std::vector<engine::world::hazard::HazardVolume>& Mutable() { return m_hazards; }
+
+		/// Écrit `instances/hazards.bin` (sérialisation partagée avec le client).
+		bool SaveToDisk(const std::string& path, std::string& err) const
+		{
+			const std::vector<uint8_t> bytes = engine::world::hazard::SaveHazardsBin(m_hazards);
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good()) { err = "HazardDocument::SaveToDisk: open failed: " + path; return false; }
+			out.write(reinterpret_cast<const char*>(bytes.data()),
+			          static_cast<std::streamsize>(bytes.size()));
+			if (!out.good()) { err = "HazardDocument::SaveToDisk: write failed: " + path; return false; }
+			return true;
+		}
+
+	private:
+		std::vector<engine::world::hazard::HazardVolume> m_hazards;
+	};
+}

--- a/src/world_editor/HazardTool.cpp
+++ b/src/world_editor/HazardTool.cpp
@@ -1,0 +1,67 @@
+// M100.16 — Rendu du panneau de propriétés de l'outil Hazard (ImGui guardé).
+
+#include "src/world_editor/HazardTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	void HazardTool::Render()
+	{
+#if defined(_WIN32)
+		using engine::world::hazard::EscapeMode;
+		using engine::world::hazard::HazardShape;
+		using engine::world::hazard::HazardType;
+
+		ImGui::TextUnformatted("Hazard");
+		ImGui::Separator();
+
+		const char* kTypes[] = { "Quicksand", "Bog", "Tar", "LavaSurface" };
+		int typeIdx = static_cast<int>(m_params.type);
+		if (ImGui::Combo("Type", &typeIdx, kTypes, IM_ARRAYSIZE(kTypes)))
+		{
+			SetType(static_cast<HazardType>(typeIdx));
+		}
+
+		int shapeIdx = static_cast<int>(m_params.shape);
+		ImGui::RadioButton("Box", &shapeIdx, 0); ImGui::SameLine();
+		ImGui::RadioButton("Cylinder", &shapeIdx, 1);
+		m_params.shape = static_cast<HazardShape>(shapeIdx);
+
+		if (m_params.shape == HazardShape::Cylinder)
+		{
+			ImGui::InputFloat("Radius (m)", &m_params.cylRadius);
+			ImGui::InputFloat("Height (m)", &m_params.cylHeight);
+		}
+		else
+		{
+			float ext[3] = { m_params.boxHalfExtents.x, m_params.boxHalfExtents.y, m_params.boxHalfExtents.z };
+			if (ImGui::InputFloat3("Half extents (m)", ext))
+			{
+				m_params.boxHalfExtents.x = ext[0];
+				m_params.boxHalfExtents.y = ext[1];
+				m_params.boxHalfExtents.z = ext[2];
+			}
+		}
+
+		ImGui::InputFloat("Sink rate (m/s)", &m_params.sinkRateMps);
+		ImGui::InputFloat("Max depth (m)", &m_params.maxDepthMeters);
+		ImGui::InputFloat("Slowdown x", &m_params.slowdownMul);
+
+		int escIdx = static_cast<int>(m_params.escapeMode);
+		const char* kEscapes[] = { "None", "MashButton", "LateralMove", "MashButton+Item" };
+		if (ImGui::Combo("Escape", &escIdx, kEscapes, IM_ARRAYSIZE(kEscapes)))
+		{
+			m_params.escapeMode = static_cast<EscapeMode>(escIdx);
+		}
+		if (m_params.escapeMode == EscapeMode::MashButtonRequireItem)
+		{
+			int item = static_cast<int>(m_params.requiredItemId);
+			if (ImGui::InputInt("Required item id", &item) && item >= 0)
+				m_params.requiredItemId = static_cast<uint32_t>(item);
+		}
+#endif
+	}
+}

--- a/src/world_editor/HazardTool.h
+++ b/src/world_editor/HazardTool.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// M100.16 — Outil de pose de hazards (paramètres + création). Rendu ImGui
+// guardé Windows. Standalone (l'intégration au système ActiveTool/ToolProperties
+// du shell est laissée à un câblage ultérieur, non couvert par les tests).
+
+#include "src/client/world/hazard/HazardVolumes.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	class HazardTool
+	{
+	public:
+		/// Change le type courant et applique ses défauts (cf. tableau M100.16).
+		void SetType(engine::world::hazard::HazardType type)
+		{
+			const engine::world::hazard::HazardShape keepShape = m_params.shape;
+			m_params = engine::world::hazard::MakeDefaultHazard(type);
+			m_params.shape = keepShape;
+		}
+
+		/// Construit un volume aux paramètres courants, posé à `pos`.
+		engine::world::hazard::HazardVolume CreateAt(const engine::math::Vec3& pos) const
+		{
+			engine::world::hazard::HazardVolume v = m_params;
+			v.position = pos;
+			return v;
+		}
+
+		engine::world::hazard::HazardVolume& Params() { return m_params; }
+		const engine::world::hazard::HazardVolume& Params() const { return m_params; }
+
+		/// Rend le panneau de propriétés de l'outil (ImGui, Windows uniquement).
+		void Render();
+
+	private:
+		engine::world::hazard::HazardVolume m_params =
+			engine::world::hazard::MakeDefaultHazard(engine::world::hazard::HazardType::Quicksand);
+	};
+}

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -10,6 +10,7 @@
 #include "src/client/world/terrain/TerrainLodChain.h"
 #include "src/client/world/water/WaterSurfaces.h"
 #include "src/shared/routine/RoutineSegmentCodec.h"
+#include "src/client/world/hazard/HazardVolumes.h"
 
 #include <array>
 #include <cmath>
@@ -663,6 +664,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteRoutines: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteHazards(std::string_view outputRootDir,
+		const std::vector<engine::world::hazard::HazardVolume>& hazards, std::string& outError)
+	{
+		// M100.16 — fichier zone-level instances/hazards.bin. Crée instances/ au besoin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteHazards: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::hazard::SaveHazardsBin(hazards);
+		const std::filesystem::path file = dir / "hazards.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteHazards: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteHazards: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -10,6 +10,7 @@
 namespace engine::world::terrain { struct TerrainChunk; struct TerrainLodChain; struct SplatMap; }
 namespace engine::world::water { struct WaterScene; }
 namespace engine::routine { struct RoutineGraph; }
+namespace engine::world::hazard { struct HazardVolume; }
 
 namespace tools::zone_builder
 {
@@ -77,4 +78,12 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteRoutines(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
 		const std::vector<engine::routine::RoutineGraph>& graphs, std::string& outError);
+
+	/// Écrit `instances/hazards.bin` (M100.16) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::hazard::
+	/// SaveHazardsBin` (format header-only partagé avec le client : parité
+	/// éditeur ↔ client). Fichier zone-level (pas par chunk).
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteHazards(std::string_view outputRootDir,
+		const std::vector<engine::world::hazard::HazardVolume>& hazards, std::string& outError);
 }


### PR DESCRIPTION
## Résumé
M100.16 (1er ticket TODO du backlog M100, ordre logique INDEX). Volumes hazard simulés **strictement client**. **Indépendant de M101** — basé sur `main`.

## Contenu
- `HazardVolumes.h` — 4 types (Quicksand/Bog/Tar/LavaSurface), format `instances/hazards.bin` (sérialisation **header-only** partagée engine_core/zone_builder, en-tête 24o compatible `OutputVersionHeader`).
- `HazardSimulator` — machine à états **pure** : enfoncement (sinkRate), escape (mash 10/5s, latéral 2m, mash+item), lava mort 3s, mort à max-depth.
- `HazardDocument` + `HazardTool` (ImGui guardé Windows).
- `WriteHazards` côté zone_builder.

## Tests headless (CI Linux ctest) — `hazard_tests`
round-trip binaire + sink rate + mash escape + lateral escape + lava 3s + mort max-depth (= tous les tests du ticket).

## Écarts assumés
Câblage `CharacterController`/`ThirdPersonCamera`/`ActiveTool` du shell **différé** (édition à l'aveugle de gameplay core, **non couvert par les tests** du ticket). Simulateur standalone et testé.

## Déploiement
✅ **Client/éditeur uniquement** — aucun opcode, rien dans `engine_core_server`, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)