### PR TITLE
chore(tickets): clôture M101 (DONE → issues/) + maj TICKETS_STATUS

### DIFF
--- a/tickets/M101/INDEX.md
+++ b/tickets/M101/INDEX.md
@@ -80,36 +80,42 @@ ainsi un format binaire unique tout en isolant les sémantiques d'exécution.
 
 ## Liste complète des tickets (11)
 
+> **Statut au 2026-06-03 (post-merge #806).** Les tickets **Done** ont été
+> clôturés et déplacés vers `tickets/issues/M101.N-*_Issue.md` (convention dépôt :
+> le .md quitte le dossier milestone). Restent ici : M101.7 (PARTIAL/Blocked),
+> M101.8 et M101.9 (différés tant que leurs dépendances M100 ne sont pas livrées).
+> Source de vérité des statuts : `tickets/TICKETS_STATUS.md`.
+
 ### Phase 1 — Modèle de données & VM
 
 | Ticket | Titre | Dépendances | Statut |
 |--------|-------|-------------|--------|
-| M101.1 | Modèle de graphe & sérialisation JSON | — (lib pure) | Draft |
-| M101.2 | VM d'interprétation déterministe (lib pure `routine_vm`) | M101.1 | Draft |
-| M101.3 | Segment de chunk `routines.bin` (extension additive) | M101.1, M100.3 (lib `zone_builder`, Done) | Draft |
+| M101.1 | Modèle de graphe & sérialisation JSON | — (lib pure) | **Done** (→ issues/) |
+| M101.2 | VM d'interprétation déterministe (lib pure `routine_vm`) | M101.1 | **Done** (→ issues/) |
+| M101.3 | Segment de chunk `routines.bin` (extension additive) | M101.1, M100.3 (Done) | **Done** (→ issues/) |
 
 ### Phase 2 — UI nodale (ImGui)
 
 | Ticket | Titre | Dépendances | Statut |
 |--------|-------|-------------|--------|
-| M101.4 | Panneau nodal dockable (canvas, pan/zoom, CRUD) | M101.1, M100.1 (Done), M100.2 (Done) | Draft |
-| M101.5 | Palette de nœuds + inspecteur de propriétés | M101.4 | Draft |
-| M101.6 | Validation visuelle du graphe | M101.4, M101.1 | Draft |
+| M101.4 | Panneau nodal dockable (canvas, pan/zoom, CRUD) | M101.1, M100.1 (Done), M100.2 (Done) | **Done** (→ issues/) |
+| M101.5 | Palette de nœuds + inspecteur de propriétés | M101.4 | **Done** (→ issues/) |
+| M101.6 | Validation visuelle du graphe | M101.4, M101.1 | **Done** (→ issues/) |
 
 ### Phase 3 — Bibliothèques de nœuds (les deux cibles)
 
 | Ticket | Titre | Dépendances | Statut |
 |--------|-------|-------------|--------|
-| M101.7 | Nœuds **PNJ** (génère `EventAIRow`) | M101.1, M101.2, `EventAI` (Done) ; **Role Registry + Smart Objects (ABSENTS)** | **Blocked** |
-| M101.8 | Nœuds **zone/gameplay** | M101.1, M101.2, M100.16 (Ready), M100.28 (Ready), M100.32 (Ready) | Draft |
+| M101.7 | Nœuds **PNJ** (génère `EventAIRow`) | M101.1, M101.2, `EventAI` (Done) ; **Role Registry + Smart Objects (ABSENTS)** | **PARTIAL / Blocked** (`RoutineToEventAI` livré en #806) |
+| M101.8 | Nœuds **zone/gameplay** | M101.1, M101.2, M100.16 (TODO), M100.28 (TODO), M100.32 (TODO) | **TODO** (différé) |
 
 ### Phase 4 — Intégration & tests
 
 | Ticket | Titre | Dépendances | Statut |
 |--------|-------|-------------|--------|
-| M101.9 | Mode Playtest (F5) — exécution via code client de prod | M101.2, M101.8, M100.33 (Ready, Playtest F5) | Draft |
-| M101.10 | Round-trip & tests CI (headless, Linux + Windows) | M101.1, M101.2, M101.3 | Draft |
-| M101.11 | Documentation F1 + tooltips | M101.4, M101.5, M100.47 (Tooltips & F1 Doc) | Draft |
+| M101.9 | Mode Playtest (F5) — exécution via code client de prod | M101.2, M101.8, M100.33 (TODO, Playtest F5) | **TODO** (différé) |
+| M101.10 | Round-trip & tests CI (headless, Linux + Windows) | M101.1, M101.2, M101.3 | **Done** (→ issues/) |
+| M101.11 | Documentation F1 + tooltips | M101.4, M101.5, M100.47 (Done) | **Done** (→ issues/) |
 
 ## Ordre d'implémentation recommandé
 

--- a/tickets/TICKETS_STATUS.md
+++ b/tickets/TICKETS_STATUS.md
@@ -7,10 +7,10 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 
 | Statut | Nombre |
 |--------|-------:|
-| DONE (clotures) | 314 |
-| PARTIAL | 32 |
-| TODO | 56 |
-| **Total** | 402 |
+| DONE (clotures) | 322 |
+| PARTIAL | 33 |
+| TODO | 58 |
+| **Total** | 413 |
 
 ### Par milestone
 
@@ -63,6 +63,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M44 | 4 | 0 | 0 | 4 |
 | M45 | 8 | 0 | 0 | 8 |
 | M100 | 29 | 0 | 22 | 51 |
+| M101 | 8 | 1 | 2 | 11 |
 | AUTH-UI | 12 | 0 | 0 | 12 |
 | CHAR-MODEL | 3 | 12 | 22 | 37 |
 | SERVER-CORE | 32 | 11 | 1 | 44 |
@@ -585,6 +586,22 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M100.49 | TODO | spec doc only |
 | M100.50 | TODO | spec doc only |
 | M100.51 | TODO | spec doc only |
+
+### M101
+
+| Ticket | Statut | Detail |
+|--------|--------|--------|
+| M101.1 | DONE | Modele de graphe + serialisation JSON deterministe (routine_graph) |
+| M101.2 | DONE | VM zone_event deterministe (routine_vm, lib pure) |
+| M101.3 | DONE | Segment routines.bin additif + codec + round-trip |
+| M101.4 | DONE | Panneau nodal + commandes undo/redo (CommandStack) |
+| M101.5 | DONE | Palette schema-driven + inspecteur de proprietes |
+| M101.6 | DONE | Validation de graphe (cycles/pins/orphelins/schema) |
+| M101.7 | PARTIAL | RoutineToEventAI livre ; PNJ complet Blocked (Role Registry/Smart Objects/MoveTo absents) |
+| M101.8 | TODO | Noeuds zone/gameplay differes (deps M100.16/28/32 non livrees) |
+| M101.9 | TODO | Playtest F5 differe (dep M100.33 non livree) |
+| M101.10 | DONE | Round-trip + tests CI headless |
+| M101.11 | DONE | Tooltips + contenu d'aide (reutilise HelpContentStore) |
 
 ### AUTH-UI
 

--- a/tickets/issues/M101.1-RoutineGraphModelAndSerialization_Issue.md
+++ b/tickets/issues/M101.1-RoutineGraphModelAndSerialization_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.1
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.1 — Modèle de graphe & sérialisation JSON
 
 ## Résumé

--- a/tickets/issues/M101.10-RoundTripAndCiTests_Issue.md
+++ b/tickets/issues/M101.10-RoundTripAndCiTests_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.10
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.10 — Round-trip & tests CI (headless, Linux + Windows)
 
 ## Résumé

--- a/tickets/issues/M101.11-DocsAndTooltips_Issue.md
+++ b/tickets/issues/M101.11-DocsAndTooltips_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.11
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.11 — Documentation F1 + tooltips
 
 ## Résumé

--- a/tickets/issues/M101.2-DeterministicRoutineVm_Issue.md
+++ b/tickets/issues/M101.2-DeterministicRoutineVm_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.2
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.2 — VM d'interprétation déterministe (lib pure `routine_vm`)
 
 ## Résumé

--- a/tickets/issues/M101.3-RoutinesChunkSegment_Issue.md
+++ b/tickets/issues/M101.3-RoutinesChunkSegment_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.3
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.3 — Segment de chunk `routines.bin` (extension additive)
 
 ## Résumé

--- a/tickets/issues/M101.4-NodalCanvasPanel_Issue.md
+++ b/tickets/issues/M101.4-NodalCanvasPanel_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.4
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.4 — Panneau nodal dockable (canvas, pan/zoom, CRUD)
 
 ## Résumé

--- a/tickets/issues/M101.5-NodePaletteAndInspector_Issue.md
+++ b/tickets/issues/M101.5-NodePaletteAndInspector_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.5
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.5 — Palette de nœuds + inspecteur de propriétés
 
 ## Résumé

--- a/tickets/issues/M101.6-GraphValidation_Issue.md
+++ b/tickets/issues/M101.6-GraphValidation_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M101.6
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #806, CI verte Linux+Windows). Cloture le 2026-06-03._
+
+---
+
 # M101.6 — Validation visuelle du graphe
 
 ## Résumé


### PR DESCRIPTION
## Résumé
Bookkeeping de clôture suite au merge de #806 (implémentation M101). Applique la **convention dépôt** : ticket DONE → Issue de clôture dans `tickets/issues/`, .md retiré du dossier milestone, `TICKETS_STATUS.md` mis à jour.

## Changements (docs uniquement)
- **Déplacés vers `tickets/issues/`** (bannière `Status: Closed`, contenu conservé) : M101.1, .2, .3, .4, .5, .6, .10, .11 (8 tickets DONE).
- **Conservés dans `tickets/M101/`** :
  - **M101.7** — PARTIAL/Blocked (`RoutineToEventAI` livré ; PNJ complet bloqué : Role Registry / Smart Objects / `EventAction::MoveTo` absents).
  - **M101.8 / M101.9** — TODO, différés tant que M100.16/28/32/33 ne sont pas livrés.
- **`TICKETS_STATUS.md`** : section `### M101` + ligne synthèse (8 DONE / 1 PARTIAL / 2 TODO) + totaux (322 / 33 / 58 / **413**).
- **`tickets/M101/INDEX.md`** : statuts mis à jour + note de clôture.

## Note
La clôture de **M100.16** se fera à son tour quand **#808** sera mergée (même procédure). Je l'intègre désormais systématiquement à chaque ticket terminé.

## Déploiement
✅ Documentation uniquement — aucun code, aucun redéploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)