### PR TITLE
feat(world): M100.17 — Easy Placement Tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,9 @@ add_library(engine_core
   # M100.16 — Hazard volumes (simulateur client + outil editeur ; format header-only).
   src/client/world/hazard/HazardSimulator.cpp
   src/world_editor/HazardTool.cpp
+  # M100.17 — Easy Placement Tool (geometrie pure + outil ; format/commande header-only).
+  src/world_editor/PlacementGeometry.cpp
+  src/world_editor/PlacementTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -906,6 +909,11 @@ add_test(NAME routine_help_content_tests COMMAND routine_help_content_tests)
 add_executable(hazard_tests src/client/world/hazard/tests/HazardTests.cpp)
 target_link_libraries(hazard_tests PRIVATE engine_core)
 add_test(NAME hazard_tests COMMAND hazard_tests)
+
+# M100.17 — Tests placement (geometrie pure + format props.bin + commande).
+add_executable(placement_tests src/world_editor/tests/PlacementTests.cpp)
+target_link_libraries(placement_tests PRIVATE engine_core)
+add_test(NAME placement_tests COMMAND placement_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/src/client/world/instances/PropInstances.h
+++ b/src/client/world/instances/PropInstances.h
@@ -1,0 +1,121 @@
+#pragma once
+
+// M100.17 — Props instances : struct + sérialisation `instances/props.bin`.
+//
+// Sérialisation HEADER-ONLY (inline) : partagée engine_core (runtime/éditeur) et
+// zone_builder_lib (writer offline) sans dupliquer de symboles. En-tête 24 octets
+// compatible `engine::world::OutputVersionHeader`. Placement strictement éditeur
+// (le client ne fait que lire/rendre).
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::instances
+{
+	enum class PlacementLayer : uint32_t
+	{
+		Default = 0, Rocks = 1, Trees = 2, Structures = 3, Props = 4
+	};
+
+	struct PropInstance
+	{
+		uint32_t assetId = 0;
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+		float rotationQuat[4] = { 0.0f, 0.0f, 0.0f, 1.0f }; // x,y,z,w
+		engine::math::Vec3 scale{ 1.0f, 1.0f, 1.0f };
+		uint32_t layerTag = 0;     // PlacementLayer
+		uint32_t instanceId = 0;   // incrémental, unique zone
+	};
+
+	constexpr uint32_t kPropsMagic = 0x504F5250u; // "PROP"
+	constexpr uint32_t kPropsVersion = 1u;
+	constexpr uint32_t kPropsBuilderVersion = 1u;
+	constexpr uint32_t kPropsEngineVersion = 1u;
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i)));
+		}
+		inline void PutF32(std::vector<uint8_t>& b, float f)
+		{
+			uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u);
+		}
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& out)
+		{
+			if (p + 4 > b.size()) return false;
+			out = uint32_t(b[p]) | (uint32_t(b[p + 1]) << 8) | (uint32_t(b[p + 2]) << 16) |
+			      (uint32_t(b[p + 3]) << 24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& out)
+		{
+			if (p + 8 > b.size()) return false;
+			out = 0; for (int i = 0; i < 8; ++i) out |= uint64_t(b[p + i]) << (8 * i);
+			p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& out)
+		{
+			uint32_t u; if (!GetU32(b, p, u)) return false;
+			std::memcpy(&out, &u, 4); return true;
+		}
+	}
+
+	inline std::vector<uint8_t> SavePropsBin(const std::vector<PropInstance>& props)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kPropsMagic);
+		detail::PutU32(b, kPropsVersion);
+		detail::PutU32(b, kPropsBuilderVersion);
+		detail::PutU32(b, kPropsEngineVersion);
+		detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(props.size()));
+		for (const PropInstance& p : props)
+		{
+			detail::PutU32(b, p.assetId);
+			detail::PutF32(b, p.position.x); detail::PutF32(b, p.position.y); detail::PutF32(b, p.position.z);
+			for (int i = 0; i < 4; ++i) detail::PutF32(b, p.rotationQuat[i]);
+			detail::PutF32(b, p.scale.x); detail::PutF32(b, p.scale.y); detail::PutF32(b, p.scale.z);
+			detail::PutU32(b, p.layerTag);
+			detail::PutU32(b, p.instanceId);
+		}
+		return b;
+	}
+
+	inline bool LoadPropsBin(std::span<const uint8_t> bytes, std::vector<PropInstance>& out, std::string& err)
+	{
+		size_t p = 0;
+		uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kPropsMagic) { err = "props.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kPropsVersion) { err = "props.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder);
+		detail::GetU32(bytes, p, engine);
+		detail::GetU64(bytes, p, hash);
+		uint32_t count = 0;
+		if (!detail::GetU32(bytes, p, count)) { err = "props.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			PropInstance pr;
+			if (!detail::GetU32(bytes, p, pr.assetId)) { err = "props.bin: tronque"; return false; }
+			detail::GetF32(bytes, p, pr.position.x); detail::GetF32(bytes, p, pr.position.y); detail::GetF32(bytes, p, pr.position.z);
+			for (int k = 0; k < 4; ++k) detail::GetF32(bytes, p, pr.rotationQuat[k]);
+			detail::GetF32(bytes, p, pr.scale.x); detail::GetF32(bytes, p, pr.scale.y); detail::GetF32(bytes, p, pr.scale.z);
+			detail::GetU32(bytes, p, pr.layerTag);
+			if (!detail::GetU32(bytes, p, pr.instanceId)) { err = "props.bin: tronque (instanceId)"; return false; }
+			out.push_back(pr);
+		}
+		return true;
+	}
+}

--- a/src/world_editor/PlacementCommand.h
+++ b/src/world_editor/PlacementCommand.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// M100.17 — Commandes de placement (undo/redo via CommandStack).
+
+#include <vector>
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/PlacementDocument.h"
+
+namespace engine::editor::world
+{
+	/// Pose une ou plusieurs instances (single / drag-line / scatter). Undo les
+	/// retire par instanceId. Les instanceId sont assignés AVANT la création de
+	/// la commande (via PlacementDocument::AllocInstanceId) pour un undo exact.
+	class PlacePropsCommand final : public ICommand
+	{
+	public:
+		PlacePropsCommand(PlacementDocument& doc,
+		                  std::vector<engine::world::instances::PropInstance> instances)
+			: m_doc(doc), m_instances(std::move(instances)) {}
+
+		const char* GetLabel() const override { return "Place props"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(*this) + m_instances.size() * sizeof(engine::world::instances::PropInstance);
+		}
+		void Execute() override
+		{
+			for (const auto& p : m_instances) m_doc.Add(p);
+		}
+		void Undo() override
+		{
+			for (const auto& p : m_instances) m_doc.RemoveById(p.instanceId);
+		}
+
+	private:
+		PlacementDocument& m_doc;
+		std::vector<engine::world::instances::PropInstance> m_instances;
+	};
+}

--- a/src/world_editor/PlacementDocument.h
+++ b/src/world_editor/PlacementDocument.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// M100.17 — Document de placement (props posés dans la zone). Header-only.
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/client/world/instances/PropInstances.h"
+
+namespace engine::editor::world
+{
+	class PlacementDocument
+	{
+	public:
+		uint32_t AllocInstanceId() { return m_nextInstanceId++; }
+
+		void Add(const engine::world::instances::PropInstance& p) { m_props.push_back(p); }
+
+		void RemoveById(uint32_t instanceId)
+		{
+			m_props.erase(std::remove_if(m_props.begin(), m_props.end(),
+				[instanceId](const engine::world::instances::PropInstance& p)
+				{ return p.instanceId == instanceId; }), m_props.end());
+		}
+
+		const std::vector<engine::world::instances::PropInstance>& All() const { return m_props; }
+		std::vector<engine::world::instances::PropInstance>& Mutable() { return m_props; }
+
+		/// Écrit `instances/props.bin` (sérialisation partagée avec le client).
+		bool SaveToDisk(const std::string& path, std::string& err) const
+		{
+			const std::vector<uint8_t> bytes = engine::world::instances::SavePropsBin(m_props);
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good()) { err = "PlacementDocument::SaveToDisk: open failed: " + path; return false; }
+			out.write(reinterpret_cast<const char*>(bytes.data()),
+			          static_cast<std::streamsize>(bytes.size()));
+			if (!out.good()) { err = "PlacementDocument::SaveToDisk: write failed: " + path; return false; }
+			return true;
+		}
+
+	private:
+		std::vector<engine::world::instances::PropInstance> m_props;
+		uint32_t m_nextInstanceId = 1;
+	};
+}

--- a/src/world_editor/PlacementGeometry.cpp
+++ b/src/world_editor/PlacementGeometry.cpp
@@ -1,0 +1,127 @@
+// M100.17 — Implémentation de la géométrie de placement (pure, déterministe).
+
+#include "src/world_editor/PlacementGeometry.h"
+
+#include <cmath>
+#include <random>
+
+namespace engine::editor::world::placement
+{
+	namespace
+	{
+		constexpr float kPi = 3.14159265358979323846f;
+
+		float Dot(const Vec3& a, const Vec3& b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
+		Vec3 Cross(const Vec3& a, const Vec3& b)
+		{
+			return Vec3(a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x);
+		}
+
+		// Quaternion (x,y,z,w) depuis axe (normalisé) + angle (rad).
+		void QuatAxisAngle(const Vec3& axis, float angleRad, float out[4])
+		{
+			const float h = angleRad * 0.5f;
+			const float s = std::sin(h);
+			out[0] = axis.x * s; out[1] = axis.y * s; out[2] = axis.z * s; out[3] = std::cos(h);
+		}
+
+		// q = a * b (Hamilton).
+		void QuatMul(const float a[4], const float b[4], float out[4])
+		{
+			const float ax = a[0], ay = a[1], az = a[2], aw = a[3];
+			const float bx = b[0], by = b[1], bz = b[2], bw = b[3];
+			out[0] = aw * bx + ax * bw + ay * bz - az * by;
+			out[1] = aw * by - ax * bz + ay * bw + az * bx;
+			out[2] = aw * bz + ax * by - ay * bx + az * bw;
+			out[3] = aw * bw - ax * bx - ay * by - az * bz;
+		}
+	} // namespace
+
+	std::vector<Vec3> GenerateDragLine(const Vec3& start, const Vec3& end, float spacing)
+	{
+		std::vector<Vec3> out;
+		const Vec3 d = end - start;
+		const float dist = d.Length();
+		if (spacing <= 0.0f || dist <= 1e-5f)
+		{
+			out.push_back(start);
+			return out;
+		}
+		int segments = static_cast<int>(std::lround(dist / spacing));
+		if (segments < 1) segments = 1;
+		for (int i = 0; i <= segments; ++i)
+		{
+			const float t = static_cast<float>(i) / static_cast<float>(segments);
+			out.push_back(Vec3(start.x + d.x * t, start.y + d.y * t, start.z + d.z * t));
+		}
+		return out;
+	}
+
+	std::vector<Vec3> GenerateScatter(const Vec3& center, float radius, uint32_t count, uint64_t seed)
+	{
+		std::vector<Vec3> out;
+		out.reserve(count);
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			const float r = radius * std::sqrt(u01(rng)); // distribution uniforme en surface
+			const float theta = 2.0f * kPi * u01(rng);
+			out.push_back(Vec3(center.x + r * std::cos(theta), center.y, center.z + r * std::sin(theta)));
+		}
+		return out;
+	}
+
+	YawScale RandomYawScale(uint64_t seed, float rotMinDeg, float rotMaxDeg, float scaleMin, float scaleMax)
+	{
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<float> yawD(rotMinDeg, rotMaxDeg);
+		std::uniform_real_distribution<float> scaleD(scaleMin, scaleMax);
+		YawScale ys;
+		ys.yawDeg = yawD(rng);
+		ys.scale = scaleD(rng);
+		return ys;
+	}
+
+	void BuildOrientation(float yawDeg, const Vec3& terrainNormal, bool alignToNormal, float outQuat[4])
+	{
+		// Yaw autour de Y.
+		float qYaw[4];
+		QuatAxisAngle(Vec3(0.0f, 1.0f, 0.0f), yawDeg * kPi / 180.0f, qYaw);
+
+		if (!alignToNormal)
+		{
+			for (int i = 0; i < 4; ++i) outQuat[i] = qYaw[i];
+			return;
+		}
+
+		// Rotation alignant world-up (0,1,0) sur la normale terrain.
+		Vec3 n = terrainNormal.Normalized();
+		const Vec3 up(0.0f, 1.0f, 0.0f);
+		const float d = Dot(up, n);
+		float qAlign[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+		if (d < 0.9999f)
+		{
+			if (d < -0.9999f)
+			{
+				// Opposés : 180° autour de X.
+				QuatAxisAngle(Vec3(1.0f, 0.0f, 0.0f), kPi, qAlign);
+			}
+			else
+			{
+				Vec3 axis = Cross(up, n).Normalized();
+				const float angle = std::acos(d);
+				QuatAxisAngle(axis, angle, qAlign);
+			}
+		}
+		QuatMul(qAlign, qYaw, outQuat);
+	}
+
+	Vec3 RotateVectorByQuat(const float q[4], const Vec3& v)
+	{
+		// v' = v + 2*qw*(qv x v) + 2*(qv x (qv x v))
+		const Vec3 qv(q[0], q[1], q[2]);
+		const Vec3 t = Cross(qv, v) * 2.0f;
+		return v + (t * q[3]) + Cross(qv, t);
+	}
+}

--- a/src/world_editor/PlacementGeometry.h
+++ b/src/world_editor/PlacementGeometry.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// M100.17 — Géométrie de placement (fonctions PURES, déterministes).
+//
+// Cœur calculatoire de l'outil de placement, indépendant de l'UI/rendu : drag-
+// line, scatter (seedé → déterministe), random yaw/scale, orientation (align à
+// la normale terrain ou world-up), helpers quaternion. Testable headless.
+
+#include <cstdint>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world::placement
+{
+	using engine::math::Vec3;
+
+	/// Génère les positions d'une drag-line de `start` à `end`, espacées de
+	/// ~`spacing` m (start et end inclus). Au moins 1 point.
+	std::vector<Vec3> GenerateDragLine(const Vec3& start, const Vec3& end, float spacing);
+
+	/// Génère `count` positions dans un disque horizontal (rayon `radius`)
+	/// centré sur `center`. Déterministe pour un `seed` donné.
+	std::vector<Vec3> GenerateScatter(const Vec3& center, float radius, uint32_t count, uint64_t seed);
+
+	struct YawScale
+	{
+		float yawDeg = 0.0f;
+		float scale = 1.0f;
+	};
+
+	/// Tire un yaw (deg) et une échelle uniforme déterministes depuis `seed`.
+	YawScale RandomYawScale(uint64_t seed, float rotMinDeg, float rotMaxDeg,
+	                        float scaleMin, float scaleMax);
+
+	/// Construit le quaternion (x,y,z,w) d'orientation : rotation de yaw autour
+	/// de Y, alignée optionnellement à `terrainNormal` (sinon world-up).
+	void BuildOrientation(float yawDeg, const Vec3& terrainNormal, bool alignToNormal,
+	                      float outQuat[4]);
+
+	/// Applique un quaternion (x,y,z,w) à un vecteur.
+	Vec3 RotateVectorByQuat(const float q[4], const Vec3& v);
+}

--- a/src/world_editor/PlacementTool.cpp
+++ b/src/world_editor/PlacementTool.cpp
@@ -1,0 +1,98 @@
+// M100.17 — Implémentation de l'outil de placement (BuildInstances pur + Render ImGui).
+
+#include "src/world_editor/PlacementTool.h"
+
+#include "src/world_editor/PlacementDocument.h"
+#include "src/world_editor/PlacementGeometry.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstdio>
+#endif
+
+namespace engine::editor::world
+{
+	uint32_t HashAssetPath(const std::string& path)
+	{
+		uint32_t hash = 2166136261u;
+		for (unsigned char c : path) { hash ^= c; hash *= 16777619u; }
+		return hash;
+	}
+
+	std::vector<engine::world::instances::PropInstance> PlacementTool::BuildInstances(
+		const engine::math::Vec3& start, const engine::math::Vec3& end,
+		const engine::math::Vec3& terrainNormal, PlacementDocument& doc) const
+	{
+		using engine::world::instances::PropInstance;
+		namespace pg = engine::editor::world::placement;
+
+		std::vector<engine::math::Vec3> positions;
+		switch (m_params.mode)
+		{
+			case PlacementMode::Single:   positions.push_back(start); break;
+			case PlacementMode::DragLine: positions = pg::GenerateDragLine(start, end, m_params.dragLineSpacing); break;
+			case PlacementMode::Scatter:  positions = pg::GenerateScatter(start, m_params.scatterRadius, m_params.scatterCount, m_params.rngSeed); break;
+		}
+
+		const uint32_t assetId = HashAssetPath(m_params.assetPath);
+		const bool alignNormal = (m_params.align == PlacementAlign::TerrainNormal);
+
+		std::vector<PropInstance> out;
+		out.reserve(positions.size());
+		for (size_t i = 0; i < positions.size(); ++i)
+		{
+			const uint64_t seedI = m_params.rngSeed + static_cast<uint64_t>(i);
+			const pg::YawScale ys = pg::RandomYawScale(seedI, m_params.rotMinDeg, m_params.rotMaxDeg,
+			                                           m_params.scaleMin, m_params.scaleMax);
+			PropInstance inst;
+			inst.assetId = assetId;
+			inst.position = positions[i];
+			pg::BuildOrientation(ys.yawDeg, terrainNormal, alignNormal, inst.rotationQuat);
+			inst.scale = engine::math::Vec3(ys.scale, ys.scale, ys.scale);
+			inst.layerTag = m_params.layerTag;
+			inst.instanceId = doc.AllocInstanceId();
+			out.push_back(inst);
+		}
+		return out;
+	}
+
+	void PlacementTool::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Placement");
+		ImGui::Separator();
+
+		char buf[260];
+		std::snprintf(buf, sizeof(buf), "%s", m_params.assetPath.c_str());
+		if (ImGui::InputText("Asset", buf, sizeof(buf))) m_params.assetPath = buf;
+
+		int mode = static_cast<int>(m_params.mode);
+		const char* kModes[] = { "Single", "Drag-line", "Scatter" };
+		if (ImGui::Combo("Mode", &mode, kModes, IM_ARRAYSIZE(kModes)))
+			m_params.mode = static_cast<PlacementMode>(mode);
+
+		int snap = static_cast<int>(m_params.snap);
+		const char* kSnaps[] = { "Ground", "Grid", "Face" };
+		if (ImGui::Combo("Snap", &snap, kSnaps, IM_ARRAYSIZE(kSnaps)))
+			m_params.snap = static_cast<PlacementSnap>(snap);
+
+		int align = static_cast<int>(m_params.align);
+		ImGui::RadioButton("Terrain normal", &align, 0); ImGui::SameLine();
+		ImGui::RadioButton("World up", &align, 1);
+		m_params.align = static_cast<PlacementAlign>(align);
+
+		ImGui::DragFloatRange2("Rotation Y (deg)", &m_params.rotMinDeg, &m_params.rotMaxDeg, 1.0f, 0.0f, 360.0f);
+		ImGui::DragFloatRange2("Scale", &m_params.scaleMin, &m_params.scaleMax, 0.01f, 0.1f, 5.0f);
+
+		if (m_params.mode == PlacementMode::DragLine)
+			ImGui::InputFloat("Spacing (m)", &m_params.dragLineSpacing);
+		if (m_params.mode == PlacementMode::Scatter)
+		{
+			ImGui::InputFloat("Scatter radius (m)", &m_params.scatterRadius);
+			int cnt = static_cast<int>(m_params.scatterCount);
+			if (ImGui::InputInt("Scatter count", &cnt) && cnt >= 0)
+				m_params.scatterCount = static_cast<uint32_t>(cnt);
+		}
+#endif
+	}
+}

--- a/src/world_editor/PlacementTool.h
+++ b/src/world_editor/PlacementTool.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// M100.17 — Outil de placement universel (ghost, snapping, modes). La logique
+// de génération d'instances (BuildInstances) est PURE et testable ; le rendu
+// ImGui de la palette de propriétés est guardé Windows.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/client/world/instances/PropInstances.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	class PlacementDocument;
+
+	enum class PlacementMode : uint8_t { Single = 0, DragLine = 1, Scatter = 2 };
+	enum class PlacementSnap : uint8_t { Ground = 0, Grid = 1, Face = 2 };
+	enum class PlacementAlign : uint8_t { TerrainNormal = 0, WorldUp = 1 };
+
+	struct PlacementParams
+	{
+		std::string assetPath;
+		PlacementMode mode = PlacementMode::Single;
+		PlacementSnap snap = PlacementSnap::Ground;
+		PlacementAlign align = PlacementAlign::TerrainNormal;
+		float gridSizeMeters = 1.0f;
+		float dragLineSpacing = 2.0f;
+		float scatterRadius = 5.0f;
+		uint32_t scatterCount = 12;
+		float rotMinDeg = 0.0f, rotMaxDeg = 360.0f;
+		float scaleMin = 0.95f, scaleMax = 1.05f;
+		uint64_t rngSeed = 1;
+		uint32_t layerTag = static_cast<uint32_t>(engine::world::instances::PlacementLayer::Props);
+	};
+
+	/// Hash FNV-1a 32 bits d'un chemin d'asset (stable, identique zone_builder).
+	uint32_t HashAssetPath(const std::string& path);
+
+	class PlacementTool
+	{
+	public:
+		void SetParams(const PlacementParams& p) { m_params = p; }
+		PlacementParams& Params() { return m_params; }
+		const PlacementParams& Params() const { return m_params; }
+
+		/// Génère les instances à poser selon le mode, depuis `start` (et `end`
+		/// pour drag-line). `terrainNormal` sert au snap d'orientation. Les
+		/// instanceId sont alloués sur `doc`. PURE et déterministe (seed).
+		std::vector<engine::world::instances::PropInstance> BuildInstances(
+			const engine::math::Vec3& start, const engine::math::Vec3& end,
+			const engine::math::Vec3& terrainNormal, PlacementDocument& doc) const;
+
+		/// Rend le panneau de propriétés (ImGui, Windows uniquement).
+		void Render();
+
+	private:
+		PlacementParams m_params;
+	};
+}

--- a/src/world_editor/tests/PlacementTests.cpp
+++ b/src/world_editor/tests/PlacementTests.cpp
@@ -1,0 +1,160 @@
+// M100.17 — Tests placement : géométrie pure + format props.bin + commande.
+// Headless. Lié à engine_core.
+
+#include "src/client/world/instances/PropInstances.h"
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/PlacementCommand.h"
+#include "src/world_editor/PlacementDocument.h"
+#include "src/world_editor/PlacementGeometry.h"
+#include "src/world_editor/PlacementTool.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+
+using namespace engine::editor::world;
+using engine::math::Vec3;
+using engine::world::instances::PropInstance;
+namespace pg = engine::editor::world::placement;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) <= eps; }
+	float Dist2D(const Vec3& a, const Vec3& b)
+	{
+		const float dx = a.x - b.x, dz = a.z - b.z;
+		return std::sqrt(dx * dx + dz * dz);
+	}
+
+	void Test_Roundtrip_PropsBin()
+	{
+		std::vector<PropInstance> props;
+		PropInstance a; a.assetId = 111; a.position = { 1.0f, 2.0f, 3.0f };
+		a.rotationQuat[0] = 0.1f; a.rotationQuat[3] = 0.99f; a.scale = { 1.1f, 1.1f, 1.1f };
+		a.layerTag = 1; a.instanceId = 7;
+		PropInstance b; b.assetId = 222; b.position = { -4.0f, 0.0f, 5.0f }; b.instanceId = 8;
+		props = { a, b };
+
+		std::vector<uint8_t> bytes = engine::world::instances::SavePropsBin(props);
+		std::vector<PropInstance> out; std::string err;
+		REQUIRE(engine::world::instances::LoadPropsBin(bytes, out, err));
+		REQUIRE(out.size() == 2);
+		if (out.size() == 2)
+		{
+			REQUIRE(out[0].assetId == 111 && out[0].instanceId == 7);
+			REQUIRE(Near(out[0].position.x, 1.0f) && Near(out[0].position.z, 3.0f));
+			REQUIRE(Near(out[0].rotationQuat[0], 0.1f) && Near(out[0].rotationQuat[3], 0.99f));
+			REQUIRE(out[1].assetId == 222 && out[1].instanceId == 8);
+		}
+	}
+
+	void Test_DragLine_GeneratesCorrectSpacing()
+	{
+		auto pts = pg::GenerateDragLine(Vec3(0, 0, 0), Vec3(10, 0, 0), 2.0f);
+		REQUIRE(pts.size() == 6); // 0,2,4,6,8,10
+		for (size_t i = 1; i < pts.size(); ++i)
+			REQUIRE(Near(Dist2D(pts[i], pts[i - 1]), 2.0f, 1e-3f));
+	}
+
+	void Test_Scatter_RespectsCountAndRadius()
+	{
+		const Vec3 c(100, 0, 100);
+		auto a = pg::GenerateScatter(c, 5.0f, 12, 42);
+		REQUIRE(a.size() == 12);
+		for (const auto& p : a) REQUIRE(Dist2D(p, c) <= 5.0f + 1e-3f);
+		// Déterminisme.
+		auto b = pg::GenerateScatter(c, 5.0f, 12, 42);
+		REQUIRE(a.size() == b.size());
+		for (size_t i = 0; i < a.size(); ++i)
+			REQUIRE(Near(a[i].x, b[i].x) && Near(a[i].z, b[i].z));
+	}
+
+	void Test_RandomRotation_DeterministicWithSeed()
+	{
+		auto r1 = pg::RandomYawScale(7, 0.0f, 360.0f, 0.95f, 1.05f);
+		auto r2 = pg::RandomYawScale(7, 0.0f, 360.0f, 0.95f, 1.05f);
+		REQUIRE(Near(r1.yawDeg, r2.yawDeg) && Near(r1.scale, r2.scale));
+		REQUIRE(r1.yawDeg >= 0.0f && r1.yawDeg <= 360.0f);
+		REQUIRE(r1.scale >= 0.95f && r1.scale <= 1.05f);
+	}
+
+	void Test_GroundSnap_AlignsToTerrainNormal()
+	{
+		float q[4];
+		// Normale verticale → l'axe up reste up.
+		pg::BuildOrientation(0.0f, Vec3(0, 1, 0), true, q);
+		Vec3 up = pg::RotateVectorByQuat(q, Vec3(0, 1, 0));
+		REQUIRE(Near(up.x, 0.0f) && Near(up.y, 1.0f) && Near(up.z, 0.0f));
+
+		// Normale horizontale (1,0,0) → up doit s'aligner sur (1,0,0).
+		pg::BuildOrientation(0.0f, Vec3(1, 0, 0), true, q);
+		Vec3 up2 = pg::RotateVectorByQuat(q, Vec3(0, 1, 0));
+		REQUIRE(Near(up2.x, 1.0f, 1e-2f) && Near(up2.y, 0.0f, 1e-2f));
+
+		// World-up : pas d'alignement, up reste up quelle que soit la normale.
+		pg::BuildOrientation(45.0f, Vec3(1, 0, 0), false, q);
+		Vec3 up3 = pg::RotateVectorByQuat(q, Vec3(0, 1, 0));
+		REQUIRE(Near(up3.y, 1.0f, 1e-3f));
+	}
+
+	void Test_Single_Placement_PushesOneCommand()
+	{
+		PlacementTool tool;
+		PlacementParams p; p.assetPath = "rock_large_03.glb"; p.mode = PlacementMode::Single; p.rngSeed = 5;
+		tool.SetParams(p);
+		PlacementDocument doc;
+		auto insts = tool.BuildInstances(Vec3(3, 0, 4), Vec3(3, 0, 4), Vec3(0, 1, 0), doc);
+		REQUIRE(insts.size() == 1);
+
+		CommandStack stack;
+		stack.Push(std::make_unique<PlacePropsCommand>(doc, insts));
+		REQUIRE(doc.All().size() == 1);
+		REQUIRE(stack.UndoSize() == 1);
+		stack.Undo();
+		REQUIRE(doc.All().empty());
+	}
+
+	void Test_DragLine_And_Scatter_Counts()
+	{
+		PlacementDocument doc;
+		PlacementTool tool;
+		PlacementParams p; p.assetPath = "post.glb"; p.mode = PlacementMode::DragLine; p.dragLineSpacing = 2.0f; p.rngSeed = 9;
+		tool.SetParams(p);
+		auto line = tool.BuildInstances(Vec3(0, 0, 0), Vec3(10, 0, 0), Vec3(0, 1, 0), doc);
+		REQUIRE(line.size() == 6);
+
+		PlacementParams s; s.assetPath = "bush.glb"; s.mode = PlacementMode::Scatter; s.scatterCount = 8; s.scatterRadius = 4.0f; s.rngSeed = 9;
+		tool.SetParams(s);
+		auto scat = tool.BuildInstances(Vec3(0, 0, 0), Vec3(0, 0, 0), Vec3(0, 1, 0), doc);
+		REQUIRE(scat.size() == 8);
+		// instanceId uniques et non nuls (alloués par le document).
+		REQUIRE(scat[0].instanceId != 0);
+		REQUIRE(scat[0].instanceId != scat[1].instanceId);
+	}
+}
+
+int main()
+{
+	Test_Roundtrip_PropsBin();
+	Test_DragLine_GeneratesCorrectSpacing();
+	Test_Scatter_RespectsCountAndRadius();
+	Test_RandomRotation_DeterministicWithSeed();
+	Test_GroundSnap_AlignsToTerrainNormal();
+	Test_Single_Placement_PushesOneCommand();
+	Test_DragLine_And_Scatter_Counts();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] PlacementTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] PlacementTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -11,6 +11,7 @@
 #include "src/client/world/water/WaterSurfaces.h"
 #include "src/shared/routine/RoutineSegmentCodec.h"
 #include "src/client/world/hazard/HazardVolumes.h"
+#include "src/client/world/instances/PropInstances.h"
 
 #include <array>
 #include <cmath>
@@ -694,6 +695,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteHazards: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteProps(std::string_view outputRootDir,
+		const std::vector<engine::world::instances::PropInstance>& props, std::string& outError)
+	{
+		// M100.17 — fichier zone-level instances/props.bin. Crée instances/ au besoin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteProps: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::instances::SavePropsBin(props);
+		const std::filesystem::path file = dir / "props.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteProps: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteProps: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -11,6 +11,7 @@ namespace engine::world::terrain { struct TerrainChunk; struct TerrainLodChain; 
 namespace engine::world::water { struct WaterScene; }
 namespace engine::routine { struct RoutineGraph; }
 namespace engine::world::hazard { struct HazardVolume; }
+namespace engine::world::instances { struct PropInstance; }
 
 namespace tools::zone_builder
 {
@@ -86,4 +87,12 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteHazards(std::string_view outputRootDir,
 		const std::vector<engine::world::hazard::HazardVolume>& hazards, std::string& outError);
+
+	/// Écrit `instances/props.bin` (M100.17) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::instances::
+	/// SavePropsBin` (format header-only partagé avec le client : parité éditeur
+	/// ↔ client). Fichier zone-level.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteProps(std::string_view outputRootDir,
+		const std::vector<engine::world::instances::PropInstance>& props, std::string& outError);
 }


### PR DESCRIPTION
## Résumé
M100.17 (2e ticket du backlog M100). Outil de placement de props, **client/éditeur uniquement**.

> ⚠️ **Chaînée sur #808 (M100.16).** Le diff inclut temporairement M100.16 tant que #808 n'est pas mergée (nécessaire pour avoir la CI, qui ne tourne que sur base `main`). **Ordre : merger #808 puis #807… pardon #809, puis celle-ci** ; je rebase sur `main` propre après le merge de #808 → le diff se réduira à M100.17.

## Contenu (cœur testable)
- `PropInstances.h` — format `instances/props.bin` (sérialisation header-only partagée engine_core/zone_builder).
- `PlacementGeometry` — **pur, déterministe** : drag-line, scatter (seedé), random yaw/scale, orientation/ground-snap (quaternion).
- `PlacementDocument` + `PlacePropsCommand` (undo/redo, header-only).
- `PlacementTool` (ImGui guardé Windows) + `WriteProps` (zone_builder).

## Tests headless — `placement_tests`
round-trip props.bin + drag-line spacing + scatter count/radius + random déterminisme (seed) + ground-snap alignement normale + commande place/undo.

## Écarts assumés (non couverts par les tests du ticket)
Face-snap (raycast collision M100.12), rendu ghost preview, câblage AssetBrowser/ToolProperties, tests de perf — différés.

## Déploiement
✅ Client/éditeur uniquement — aucun opcode, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)