### PR TITLE
feat(world): M100.18 + M100.19 — Foliage + Forest/Field (batch backlog M100)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,8 @@ add_library(engine_core
   # M100.31 — Hamlet generator (generation pure + kit JSON ; outil header-only).
   src/client/world/structures/HamletKitLibrary.cpp
   src/world_editor/HamletGen.cpp
+  # M100.33 — Footstep audio (resolution pure ; PlaytestMode header-only).
+  src/client/audio/FootstepAudioSurfaceHook.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -987,6 +989,11 @@ add_test(NAME structures_tests COMMAND structures_tests)
 add_executable(hamlet_tests src/world_editor/tests/HamletTests.cpp)
 target_link_libraries(hamlet_tests PRIVATE engine_core)
 add_test(NAME hamlet_tests COMMAND hamlet_tests)
+
+# M100.33 — Tests footstep audio + machine d'etat playtest.
+add_executable(playtest_tests src/world_editor/tests/PlaytestTests.cpp)
+target_link_libraries(playtest_tests PRIVATE engine_core)
+add_test(NAME playtest_tests COMMAND playtest_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -968,9 +968,10 @@ target_link_libraries(zones_tests PRIVATE engine_core)
 add_test(NAME zones_tests COMMAND zones_tests)
 
 # M100.29 — Tests spline (Catmull-Rom, ground-fit, splat sum=255, round-trip).
-add_executable(spline_tests src/client/world/spline/tests/SplineTests.cpp)
-target_link_libraries(spline_tests PRIVATE engine_core)
-add_test(NAME spline_tests COMMAND spline_tests)
+# Nom prefixe m100_ : un target `spline_tests` existe deja (MoveSpline serveur).
+add_executable(m100_spline_tests src/client/world/spline/tests/SplineTests.cpp)
+target_link_libraries(m100_spline_tests PRIVATE engine_core)
+add_test(NAME m100_spline_tests COMMAND m100_spline_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,9 @@ add_library(engine_core
   # M100.27 — Shade map + thermal (ComputeTemperature + builder).
   src/client/world/thermal/Thermal.cpp
   src/client/world/thermal/ShadeMapBuilder.cpp
+  # M100.28 — Gameplay zones (requetes + outil).
+  src/client/world/zones/ZoneQuery.cpp
+  src/world_editor/ZoneTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -955,6 +958,11 @@ add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
 add_executable(thermal_tests src/client/world/thermal/tests/ThermalTests.cpp)
 target_link_libraries(thermal_tests PRIVATE engine_core)
 add_test(NAME thermal_tests COMMAND thermal_tests)
+
+# M100.28 — Tests zones (round-trip + transition meteo bord + champs quest).
+add_executable(zones_tests src/client/world/zones/tests/ZonesTests.cpp)
+target_link_libraries(zones_tests PRIVATE engine_core)
+add_test(NAME zones_tests COMMAND zones_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,9 @@ add_library(engine_core
   src/world_editor/SplineTool.cpp
   # M100.30 — Bridges & modular walls (structures pures ; outils header-only).
   src/client/world/structures/Structures.cpp
+  # M100.31 — Hamlet generator (generation pure + kit JSON ; outil header-only).
+  src/client/world/structures/HamletKitLibrary.cpp
+  src/world_editor/HamletGen.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -979,6 +982,11 @@ add_test(NAME m100_spline_tests COMMAND m100_spline_tests)
 add_executable(structures_tests src/client/world/structures/tests/StructuresTests.cpp)
 target_link_libraries(structures_tests PRIVATE engine_core)
 add_test(NAME structures_tests COMMAND structures_tests)
+
+# M100.31 — Tests hameau (kit JSON, determinisme, min_spacing, snap route, 1 entree historique).
+add_executable(hamlet_tests src/world_editor/tests/HamletTests.cpp)
+target_link_libraries(hamlet_tests PRIVATE engine_core)
+add_test(NAME hamlet_tests COMMAND hamlet_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,8 @@ add_library(engine_core
   # M100.29 — Spline tool & roads (sampler pur + outil).
   src/client/world/spline/SplineSampler.cpp
   src/world_editor/SplineTool.cpp
+  # M100.30 — Bridges & modular walls (structures pures ; outils header-only).
+  src/client/world/structures/Structures.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -972,6 +974,11 @@ add_test(NAME zones_tests COMMAND zones_tests)
 add_executable(m100_spline_tests src/client/world/spline/tests/SplineTests.cpp)
 target_link_libraries(m100_spline_tests PRIVATE engine_core)
 add_test(NAME m100_spline_tests COMMAND m100_spline_tests)
+
+# M100.30 — Tests structures (pont/mur, coins, surface pont, migration v1->v2).
+add_executable(structures_tests src/client/world/structures/tests/StructuresTests.cpp)
+target_link_libraries(structures_tests PRIVATE engine_core)
+add_test(NAME structures_tests COMMAND structures_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,9 @@ add_library(engine_core
   # M100.28 — Gameplay zones (requetes + outil).
   src/client/world/zones/ZoneQuery.cpp
   src/world_editor/ZoneTool.cpp
+  # M100.29 — Spline tool & roads (sampler pur + outil).
+  src/client/world/spline/SplineSampler.cpp
+  src/world_editor/SplineTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -963,6 +966,11 @@ add_test(NAME thermal_tests COMMAND thermal_tests)
 add_executable(zones_tests src/client/world/zones/tests/ZonesTests.cpp)
 target_link_libraries(zones_tests PRIVATE engine_core)
 add_test(NAME zones_tests COMMAND zones_tests)
+
+# M100.29 — Tests spline (Catmull-Rom, ground-fit, splat sum=255, round-trip).
+add_executable(spline_tests src/client/world/spline/tests/SplineTests.cpp)
+target_link_libraries(spline_tests PRIVATE engine_core)
+add_test(NAME spline_tests COMMAND spline_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,9 @@ add_library(engine_core
   src/world_editor/ForestFieldGen.cpp
   src/world_editor/ForestTool.cpp
   src/world_editor/FieldTool.cpp
+  # M100.20 — Vegetation wind (WindSystem eval + zones + outil).
+  src/client/world/wind/WindSystem.cpp
+  src/world_editor/WindZoneTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -932,6 +935,11 @@ add_test(NAME foliage_tests COMMAND foliage_tests)
 add_executable(forest_field_tests src/world_editor/tests/ForestFieldTests.cpp)
 target_link_libraries(forest_field_tests PRIVATE engine_core)
 add_test(NAME forest_field_tests COMMAND forest_field_tests)
+
+# M100.20 — Tests vent (sway proportionnel hauteur, override zone, round-trip).
+add_executable(wind_tests src/client/world/wind/tests/WindTests.cpp)
+target_link_libraries(wind_tests PRIVATE engine_core)
+add_test(NAME wind_tests COMMAND wind_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,9 @@ add_library(engine_core
   src/world_editor/WindZoneTool.cpp
   # M100.21 — Player interaction (collecteur d'influences d'entites).
   src/client/world/foliage/EntityInfluenceCollector.cpp
+  # M100.27 — Shade map + thermal (ComputeTemperature + builder).
+  src/client/world/thermal/Thermal.cpp
+  src/client/world/thermal/ShadeMapBuilder.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -947,6 +950,11 @@ add_test(NAME wind_tests COMMAND wind_tests)
 add_executable(entity_influence_tests src/client/world/foliage/tests/EntityInfluenceTests.cpp)
 target_link_libraries(entity_influence_tests PRIVATE engine_core)
 add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
+
+# M100.27 — Tests thermal (shade round-trip/builder + ComputeTemperature + query).
+add_executable(thermal_tests src/client/world/thermal/tests/ThermalTests.cpp)
+target_link_libraries(thermal_tests PRIVATE engine_core)
+add_test(NAME thermal_tests COMMAND thermal_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,8 @@ add_library(engine_core
   # M100.20 — Vegetation wind (WindSystem eval + zones + outil).
   src/client/world/wind/WindSystem.cpp
   src/world_editor/WindZoneTool.cpp
+  # M100.21 — Player interaction (collecteur d'influences d'entites).
+  src/client/world/foliage/EntityInfluenceCollector.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -940,6 +942,11 @@ add_test(NAME forest_field_tests COMMAND forest_field_tests)
 add_executable(wind_tests src/client/world/wind/tests/WindTests.cpp)
 target_link_libraries(wind_tests PRIVATE engine_core)
 add_test(NAME wind_tests COMMAND wind_tests)
+
+# M100.21 — Tests collecteur d'influences (portee, troncature, flexion).
+add_executable(entity_influence_tests src/client/world/foliage/tests/EntityInfluenceTests.cpp)
+target_link_libraries(entity_influence_tests PRIVATE engine_core)
+add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,10 @@ add_library(engine_core
   # M100.17 — Easy Placement Tool (geometrie pure + outil ; format/commande header-only).
   src/world_editor/PlacementGeometry.cpp
   src/world_editor/PlacementTool.cpp
+  # M100.18 — Vegetation library + density painting (library JSON + Poisson-disk + outil).
+  src/client/world/foliage/FoliageLibrary.cpp
+  src/client/world/foliage/PoissonDiskSampler.cpp
+  src/world_editor/FoliagePaintTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -914,6 +918,11 @@ add_test(NAME hazard_tests COMMAND hazard_tests)
 add_executable(placement_tests src/world_editor/tests/PlacementTests.cpp)
 target_link_libraries(placement_tests PRIVATE engine_core)
 add_test(NAME placement_tests COMMAND placement_tests)
+
+# M100.18 — Tests foliage (library JSON + Poisson-disk + regles + round-trip).
+add_executable(foliage_tests src/client/world/foliage/tests/FoliageTests.cpp)
+target_link_libraries(foliage_tests PRIVATE engine_core)
+add_test(NAME foliage_tests COMMAND foliage_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,10 @@ add_library(engine_core
   src/client/world/foliage/FoliageLibrary.cpp
   src/client/world/foliage/PoissonDiskSampler.cpp
   src/world_editor/FoliagePaintTool.cpp
+  # M100.19 — Forest & Field procedural tools (generateurs purs + outils).
+  src/world_editor/ForestFieldGen.cpp
+  src/world_editor/ForestTool.cpp
+  src/world_editor/FieldTool.cpp
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
@@ -923,6 +927,11 @@ add_test(NAME placement_tests COMMAND placement_tests)
 add_executable(foliage_tests src/client/world/foliage/tests/FoliageTests.cpp)
 target_link_libraries(foliage_tests PRIVATE engine_core)
 add_test(NAME foliage_tests COMMAND foliage_tests)
+
+# M100.19 — Tests Forest & Field (generateurs purs : densite, regles, spacing).
+add_executable(forest_field_tests src/world_editor/tests/ForestFieldTests.cpp)
+target_link_libraries(forest_field_tests PRIVATE engine_core)
+add_test(NAME forest_field_tests COMMAND forest_field_tests)
 
 # M45.6: structure DDGI (indexation grille + layout atlas) — tests CPU purs (pas de device Vulkan)
 add_executable(ddgi_volume_tests src/client/render/gi/tests/DdgiVolumeTests.cpp)

--- a/game/data/assets/structures/kits/human_village_kit_01.json
+++ b/game/data/assets/structures/kits/human_village_kit_01.json
@@ -1,0 +1,11 @@
+{
+  "race": "Humains",
+  "biome": "plains",
+  "houses": [
+    { "mesh": "structures/human_house_01.glb", "weight": 0.5 },
+    { "mesh": "structures/human_house_02.glb", "weight": 0.3 },
+    { "mesh": "structures/human_house_03.glb", "weight": 0.2 }
+  ],
+  "minSpacingDefault": 8.0,
+  "footprintRadius": 5.0
+}

--- a/game/data/assets/vegetation/library.json
+++ b/game/data/assets/vegetation/library.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "categories": [
+    { "id": "grass",      "label": "Herbes" },
+    { "id": "wheat",      "label": "Ble" },
+    { "id": "corn",       "label": "Mais" },
+    { "id": "fern",       "label": "Fougere" },
+    { "id": "thorn",      "label": "Ronces" },
+    { "id": "tree_young", "label": "Jeunes arbres" },
+    { "id": "tree_oak",   "label": "Chene mature" },
+    { "id": "tree_pine",  "label": "Sapin / conifere" },
+    { "id": "tree_dead",  "label": "Conifere mort" },
+    { "id": "tree_dark",  "label": "Arbre noir torture" },
+    { "id": "bush",       "label": "Buisson" },
+    { "id": "mushroom",   "label": "Champignon" }
+  ],
+  "assets": [
+    { "id": "grass_01", "category": "grass", "mesh": "veg/grass_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 35.0, "altMin": -200.0, "altMax": 2500.0, "splatLayers": [1, 2] } },
+    { "id": "fern_01", "category": "fern", "mesh": "veg/fern_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 30.0, "altMin": -50.0, "altMax": 1600.0, "splatLayers": [1, 2] } },
+    { "id": "tree_oak_01", "category": "tree_oak", "mesh": "veg/tree_oak_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 25.0, "altMin": 0.0, "altMax": 1800.0, "splatLayers": [1, 2] } },
+    { "id": "tree_pine_01", "category": "tree_pine", "mesh": "veg/tree_pine_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 30.0, "altMin": 200.0, "altMax": 2400.0, "splatLayers": [2, 3] } },
+    { "id": "tree_dark_01", "category": "tree_dark", "mesh": "veg/tree_dark_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 28.0, "altMin": -100.0, "altMax": 2000.0, "splatLayers": [3] } },
+    { "id": "mushroom_01", "category": "mushroom", "mesh": "veg/mushroom_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 40.0, "altMin": -200.0, "altMax": 1200.0, "splatLayers": [1] } }
+  ]
+}

--- a/src/client/audio/FootstepAudioSurfaceHook.cpp
+++ b/src/client/audio/FootstepAudioSurfaceHook.cpp
@@ -1,0 +1,28 @@
+// M100.33 — Implémentation de la résolution audio de pas (pure).
+
+#include "src/client/audio/FootstepAudioSurfaceHook.h"
+
+namespace engine::audio
+{
+	AudioEvent ResolveFootstep(const FootstepSurface& surface, const engine::math::Vec3& footPos)
+	{
+		AudioEvent ev;
+		ev.position = footPos;
+		ev.pitch = surface.wet ? 1.05f : 1.0f; // modificateur "wet/slush" : léger pitch up
+
+		if (surface.surfaceName == "snow")
+			ev.id = surface.wet ? "step_snow_crunch" : "step_snow";
+		else if (surface.surfaceName == "water" || surface.surfaceName == "shallow_water")
+			ev.id = "step_water";
+		else if (surface.surfaceName == "rock")
+			ev.id = "step_rock";
+		else if (surface.surfaceName == "grass")
+			ev.id = "step_grass";
+		else if (surface.surfaceName.empty())
+			ev.id = "step_default";
+		else
+			ev.id = "step_" + surface.surfaceName;
+
+		return ev;
+	}
+}

--- a/src/client/audio/FootstepAudioSurfaceHook.h
+++ b/src/client/audio/FootstepAudioSurfaceHook.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// M100.33 — Mappe (surface, modificateurs) -> évènement audio de pas. Logique
+// PURE (le branchement sur SurfaceQuery/CharacterController/AudioSystem réels
+// est fait côté intégration, différé). Testable headless.
+
+#include <string>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::audio
+{
+	struct AudioEvent
+	{
+		std::string id;
+		float pitch = 1.0f;
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+	};
+
+	/// Surface sous le pied + modificateurs météo pertinents.
+	struct FootstepSurface
+	{
+		std::string surfaceName; // "grass" / "snow" / "rock" / "water" / ...
+		bool wet = false;        // modificateur météo (pluie/neige fondante)
+	};
+
+	/// Résout l'évènement audio de pas : id selon la surface (et neige mouillée
+	/// = crunch), pitch +5 % si mouillé.
+	AudioEvent ResolveFootstep(const FootstepSurface& surface, const engine::math::Vec3& footPos);
+}

--- a/src/client/world/foliage/EntityInfluenceCollector.cpp
+++ b/src/client/world/foliage/EntityInfluenceCollector.cpp
@@ -1,0 +1,48 @@
+// M100.21 — Implémentation du collecteur d'influences (pur).
+
+#include "src/client/world/foliage/EntityInfluenceCollector.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::world::foliage
+{
+	std::vector<EntityInfluence> CollectEntityInfluences(
+		float camX, float camZ, const std::vector<EntityCandidate>& entities)
+	{
+		struct Scored { float dist2; EntityInfluence inf; };
+		std::vector<Scored> scored;
+		scored.reserve(entities.size());
+
+		const float range2 = kInfluenceRangeMeters * kInfluenceRangeMeters;
+		for (const EntityCandidate& e : entities)
+		{
+			const float dx = e.x - camX, dz = e.z - camZ;
+			const float d2 = dx * dx + dz * dz;
+			if (d2 > range2) continue; // hors portée
+			EntityInfluence inf;
+			inf.positionX = e.x; inf.positionZ = e.z;
+			inf.radiusMeters = e.radiusMeters; inf.falloffPower = e.falloffPower;
+			scored.push_back({ d2, inf });
+		}
+
+		std::stable_sort(scored.begin(), scored.end(),
+		                 [](const Scored& a, const Scored& b) { return a.dist2 < b.dist2; });
+
+		std::vector<EntityInfluence> out;
+		const size_t n = std::min<size_t>(scored.size(), static_cast<size_t>(kMaxEntityInfluences));
+		out.reserve(n);
+		for (size_t i = 0; i < n; ++i) out.push_back(scored[i].inf);
+		return out;
+	}
+
+	float ComputeFlexionMagnitude(const EntityInfluence& inf, float worldX, float worldZ, float heightWeight)
+	{
+		const float dx = worldX - inf.positionX, dz = worldZ - inf.positionZ;
+		const float dist = std::sqrt(dx * dx + dz * dz);
+		const float r = (inf.radiusMeters > 1e-5f) ? inf.radiusMeters : 1e-5f;
+		if (dist >= r) return 0.0f;
+		const float w = std::pow(1.0f - dist / r, inf.falloffPower);
+		return w * 0.6f * heightWeight; // miroir foliage.vert
+	}
+}

--- a/src/client/world/foliage/EntityInfluenceCollector.h
+++ b/src/client/world/foliage/EntityInfluenceCollector.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// M100.21 — Collecte des influences d'entités (joueur/PNJ) pour la flexion de
+// la végétation. Logique PURE (filtre portée + troncature 32 + flexion miroir
+// du shader). L'upload SSBO et le shader GPU sont gérés ailleurs (différés).
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::world::foliage
+{
+	/// Influence uploadée vers le SSBO (miroir de la struct GLSL EntityInfluence).
+	struct EntityInfluence
+	{
+		float positionX = 0.0f;
+		float positionZ = 0.0f;
+		float radiusMeters = 1.0f;
+		float falloffPower = 1.5f;
+	};
+
+	/// Candidat brut : position monde XZ d'une entité + son rayon de capsule.
+	struct EntityCandidate
+	{
+		float x = 0.0f;
+		float z = 0.0f;
+		float radiusMeters = 1.0f;
+		float falloffPower = 1.5f;
+	};
+
+	constexpr int   kMaxEntityInfluences = 32;
+	constexpr float kInfluenceRangeMeters = 30.0f;
+
+	/// Collecte les influences : garde les entités à < 30 m de la caméra,
+	/// triées par distance croissante, tronquées à 32. Pur et déterministe.
+	std::vector<EntityInfluence> CollectEntityInfluences(
+		float camX, float camZ, const std::vector<EntityCandidate>& entities);
+
+	/// Magnitude de flexion d'un brin à (worldX,worldZ) sous une influence —
+	/// miroir exact du loop de foliage.vert. `heightWeight` ∈ [0,1].
+	/// Retourne 0 hors du rayon.
+	float ComputeFlexionMagnitude(const EntityInfluence& inf, float worldX, float worldZ, float heightWeight);
+}

--- a/src/client/world/foliage/FoliageInstances.h
+++ b/src/client/world/foliage/FoliageInstances.h
@@ -1,0 +1,110 @@
+#pragma once
+
+// M100.18 — Foliage instances : struct + sérialisation `instances/foliage.bin`.
+//
+// Sérialisation HEADER-ONLY (inline), partagée engine_core/zone_builder sans
+// doublon de symboles. Positions chunk-local + assetIdHash + rotationY + scale.
+// En-tête 24 octets compatible OutputVersionHeader. Strictement éditeur→client.
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::foliage
+{
+	struct FoliageInstance
+	{
+		uint32_t assetIdHash = 0;
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f }; // chunk-local
+		float rotationY = 0.0f;
+		float scale = 1.0f;
+	};
+
+	constexpr uint32_t kFoliageMagic = 0x47494C46u;   // "FLIG"
+	constexpr uint32_t kFoliageVersion = 1u;
+	constexpr uint32_t kFoliageBuilderVersion = 1u;
+	constexpr uint32_t kFoliageEngineVersion = 1u;
+	constexpr uint32_t kFoliageDensityResolution = 1025u; // par chunk
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i)));
+		}
+		inline void PutF32(std::vector<uint8_t>& b, float f)
+		{
+			uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u);
+		}
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& out)
+		{
+			if (p + 4 > b.size()) return false;
+			out = uint32_t(b[p]) | (uint32_t(b[p + 1]) << 8) | (uint32_t(b[p + 2]) << 16) |
+			      (uint32_t(b[p + 3]) << 24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& out)
+		{
+			if (p + 8 > b.size()) return false;
+			out = 0; for (int i = 0; i < 8; ++i) out |= uint64_t(b[p + i]) << (8 * i);
+			p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& out)
+		{
+			uint32_t u; if (!GetU32(b, p, u)) return false;
+			std::memcpy(&out, &u, 4); return true;
+		}
+	}
+
+	inline std::vector<uint8_t> SaveFoliageBin(const std::vector<FoliageInstance>& items)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kFoliageMagic);
+		detail::PutU32(b, kFoliageVersion);
+		detail::PutU32(b, kFoliageBuilderVersion);
+		detail::PutU32(b, kFoliageEngineVersion);
+		detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(items.size()));
+		for (const FoliageInstance& f : items)
+		{
+			detail::PutU32(b, f.assetIdHash);
+			detail::PutF32(b, f.position.x); detail::PutF32(b, f.position.y); detail::PutF32(b, f.position.z);
+			detail::PutF32(b, f.rotationY);
+			detail::PutF32(b, f.scale);
+		}
+		return b;
+	}
+
+	inline bool LoadFoliageBin(std::span<const uint8_t> bytes, std::vector<FoliageInstance>& out, std::string& err)
+	{
+		size_t p = 0;
+		uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kFoliageMagic) { err = "foliage.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kFoliageVersion) { err = "foliage.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder);
+		detail::GetU32(bytes, p, engine);
+		detail::GetU64(bytes, p, hash);
+		uint32_t count = 0;
+		if (!detail::GetU32(bytes, p, count)) { err = "foliage.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			FoliageInstance f;
+			if (!detail::GetU32(bytes, p, f.assetIdHash)) { err = "foliage.bin: tronque"; return false; }
+			detail::GetF32(bytes, p, f.position.x); detail::GetF32(bytes, p, f.position.y); detail::GetF32(bytes, p, f.position.z);
+			detail::GetF32(bytes, p, f.rotationY);
+			if (!detail::GetF32(bytes, p, f.scale)) { err = "foliage.bin: tronque (scale)"; return false; }
+			out.push_back(f);
+		}
+		return true;
+	}
+}

--- a/src/client/world/foliage/FoliageLibrary.cpp
+++ b/src/client/world/foliage/FoliageLibrary.cpp
@@ -1,0 +1,165 @@
+// M100.18 — Implémentation bibliothèque végétale (parser JSON + règles).
+
+#include "src/client/world/foliage/FoliageLibrary.h"
+
+#include <cstdlib>
+#include <string_view>
+#include <utility>
+
+namespace engine::world::foliage
+{
+	bool PassesRules(const FoliageRules& rules, float slopeDeg, float altMeters, int splatLayer)
+	{
+		if (slopeDeg > rules.slopeMaxDeg) return false;
+		if (altMeters < rules.altMin || altMeters > rules.altMax) return false;
+		if (!rules.splatLayers.empty())
+		{
+			bool found = false;
+			for (int l : rules.splatLayers) if (l == splatLayer) { found = true; break; }
+			if (!found) return false;
+		}
+		return true;
+	}
+
+	namespace
+	{
+		// Mini-DOM JSON (mêmes conventions que la sérialisation de routine).
+		struct JVal
+		{
+			enum class T { Null, Bool, Num, Str, Arr, Obj } t = T::Null;
+			bool b = false;
+			double num = 0.0;
+			std::string str;
+			std::vector<JVal> arr;
+			std::vector<std::pair<std::string, JVal>> obj;
+			const JVal* Find(std::string_view k) const
+			{
+				for (const auto& kv : obj) if (kv.first == k) return &kv.second;
+				return nullptr;
+			}
+		};
+
+		class Parser
+		{
+		public:
+			Parser(std::string_view s, std::string& e) : m_s(s), m_err(e) {}
+			bool Parse(JVal& out) { SkipWs(); if (!Value(out)) return false; SkipWs(); return true; }
+		private:
+			void Fail(const char* m) { if (m_err.empty()) m_err = m; }
+			void SkipWs() { while (m_pos < m_s.size()) { char c = m_s[m_pos]; if (c==' '||c=='\t'||c=='\n'||c=='\r') ++m_pos; else break; } }
+			bool Eof() const { return m_pos >= m_s.size(); }
+			char Peek() const { return m_s[m_pos]; }
+			bool Expect(char c) { if (Eof()||m_s[m_pos]!=c){Fail("char attendu");return false;} ++m_pos; return true; }
+			bool Value(JVal& o)
+			{
+				SkipWs(); if (Eof()){Fail("fin inattendue");return false;}
+				char c = Peek();
+				if (c=='{') return Object(o);
+				if (c=='[') return Array(o);
+				if (c=='"'){ o.t=JVal::T::Str; return String(o.str); }
+				if (c=='t'||c=='f') return Bool(o);
+				if (c=='n') return Null(o);
+				if (c=='-'||(c>='0'&&c<='9')) return Number(o);
+				Fail("valeur invalide"); return false;
+			}
+			bool Object(JVal& o)
+			{
+				o.t=JVal::T::Obj; if(!Expect('{'))return false; SkipWs();
+				if(!Eof()&&Peek()=='}'){++m_pos;return true;}
+				for(;;){ SkipWs(); if(Eof()||Peek()!='"'){Fail("cle attendue");return false;}
+					std::string k; if(!String(k))return false; SkipWs(); if(!Expect(':'))return false;
+					JVal v; if(!Value(v))return false; o.obj.emplace_back(std::move(k),std::move(v)); SkipWs();
+					if(Eof()){Fail("objet non termine");return false;} char c=Peek();
+					if(c==','){++m_pos;continue;} if(c=='}'){++m_pos;return true;} Fail("',' ou '}'");return false; }
+			}
+			bool Array(JVal& o)
+			{
+				o.t=JVal::T::Arr; if(!Expect('['))return false; SkipWs();
+				if(!Eof()&&Peek()==']'){++m_pos;return true;}
+				for(;;){ JVal v; if(!Value(v))return false; o.arr.push_back(std::move(v)); SkipWs();
+					if(Eof()){Fail("tableau non termine");return false;} char c=Peek();
+					if(c==','){++m_pos;continue;} if(c==']'){++m_pos;return true;} Fail("',' ou ']'");return false; }
+			}
+			bool String(std::string& out)
+			{
+				if(!Expect('"'))return false; out.clear();
+				while(!Eof()){ char c=m_s[m_pos++];
+					if(c=='"')return true;
+					if(c=='\\'){ if(Eof()){Fail("echappement");return false;} char e=m_s[m_pos++];
+						switch(e){case '"':out.push_back('"');break;case '\\':out.push_back('\\');break;
+							case '/':out.push_back('/');break;case 'n':out.push_back('\n');break;
+							case 'r':out.push_back('\r');break;case 't':out.push_back('\t');break;
+							case 'b':out.push_back('\b');break;case 'f':out.push_back('\f');break;
+							default: out.push_back(e); break; } }
+					else out.push_back(c); }
+				Fail("chaine non terminee"); return false;
+			}
+			bool Number(JVal& o)
+			{
+				size_t s=m_pos; if(!Eof()&&Peek()=='-')++m_pos;
+				while(!Eof()){char c=Peek(); if((c>='0'&&c<='9')||c=='.'||c=='e'||c=='E'||c=='+'||c=='-')++m_pos; else break;}
+				if(m_pos==s){Fail("nombre invalide");return false;}
+				o.t=JVal::T::Num; o.num=std::strtod(std::string(m_s.substr(s,m_pos-s)).c_str(),nullptr); return true;
+			}
+			bool Bool(JVal& o)
+			{
+				if(m_s.compare(m_pos,4,"true")==0){m_pos+=4;o.t=JVal::T::Bool;o.b=true;return true;}
+				if(m_s.compare(m_pos,5,"false")==0){m_pos+=5;o.t=JVal::T::Bool;o.b=false;return true;}
+				Fail("booleen invalide");return false;
+			}
+			bool Null(JVal& o)
+			{
+				if(m_s.compare(m_pos,4,"null")==0){m_pos+=4;o.t=JVal::T::Null;return true;}
+				Fail("null invalide");return false;
+			}
+			std::string_view m_s; size_t m_pos=0; std::string& m_err;
+		};
+	} // namespace
+
+	bool ParseFoliageLibraryJson(const std::string& jsonText, FoliageLibrary& out, std::string& err)
+	{
+		JVal root; Parser parser(jsonText, err);
+		if (!parser.Parse(root) || root.t != JVal::T::Obj)
+		{
+			if (err.empty()) err = "library.json: racine objet attendue";
+			return false;
+		}
+		if (const JVal* v = root.Find("version"); v && v->t == JVal::T::Num)
+			out.version = static_cast<uint32_t>(v->num);
+
+		if (const JVal* cats = root.Find("categories"); cats && cats->t == JVal::T::Arr)
+		{
+			for (const JVal& c : cats->arr)
+			{
+				if (c.t != JVal::T::Obj) continue;
+				FoliageCategory cat;
+				if (const JVal* id = c.Find("id"); id && id->t == JVal::T::Str) cat.id = id->str;
+				if (const JVal* lb = c.Find("label"); lb && lb->t == JVal::T::Str) cat.label = lb->str;
+				out.categories.push_back(std::move(cat));
+			}
+		}
+
+		if (const JVal* assets = root.Find("assets"); assets && assets->t == JVal::T::Arr)
+		{
+			for (const JVal& a : assets->arr)
+			{
+				if (a.t != JVal::T::Obj) continue;
+				FoliageAsset asset;
+				if (const JVal* id = a.Find("id"); id && id->t == JVal::T::Str) asset.id = id->str;
+				if (const JVal* cat = a.Find("category"); cat && cat->t == JVal::T::Str) asset.category = cat->str;
+				if (const JVal* m = a.Find("mesh"); m && m->t == JVal::T::Str) asset.mesh = m->str;
+				if (const JVal* bb = a.Find("billboard"); bb && bb->t == JVal::T::Bool) asset.billboard = bb->b;
+				if (const JVal* r = a.Find("rules"); r && r->t == JVal::T::Obj)
+				{
+					if (const JVal* s = r->Find("slopeMaxDeg"); s && s->t == JVal::T::Num) asset.rules.slopeMaxDeg = static_cast<float>(s->num);
+					if (const JVal* mn = r->Find("altMin"); mn && mn->t == JVal::T::Num) asset.rules.altMin = static_cast<float>(mn->num);
+					if (const JVal* mx = r->Find("altMax"); mx && mx->t == JVal::T::Num) asset.rules.altMax = static_cast<float>(mx->num);
+					if (const JVal* sl = r->Find("splatLayers"); sl && sl->t == JVal::T::Arr)
+						for (const JVal& e : sl->arr) if (e.t == JVal::T::Num) asset.rules.splatLayers.push_back(static_cast<int>(e.num));
+				}
+				out.assets.push_back(std::move(asset));
+			}
+		}
+		return true;
+	}
+}

--- a/src/client/world/foliage/FoliageLibrary.h
+++ b/src/client/world/foliage/FoliageLibrary.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// M100.18 — Bibliothèque végétale : catalogue (library.json) + règles de
+// placement. Le parsing JSON et le filtrage par règles sont purs et testables.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::world::foliage
+{
+	/// Règles de placement d'un asset végétal.
+	struct FoliageRules
+	{
+		float slopeMaxDeg = 90.0f;
+		float altMin = -100000.0f;
+		float altMax = 100000.0f;
+		std::vector<int> splatLayers; // vide = toutes couches acceptées
+	};
+
+	struct FoliageAsset
+	{
+		std::string id;
+		std::string category;
+		std::string mesh;
+		bool billboard = false;
+		FoliageRules rules;
+	};
+
+	struct FoliageCategory
+	{
+		std::string id;
+		std::string label;
+	};
+
+	struct FoliageLibrary
+	{
+		uint32_t version = 0;
+		std::vector<FoliageCategory> categories;
+		std::vector<FoliageAsset> assets;
+
+		const FoliageAsset* FindAsset(const std::string& id) const
+		{
+			for (const auto& a : assets) if (a.id == id) return &a;
+			return nullptr;
+		}
+	};
+
+	/// True si une cellule de pente `slopeDeg`, altitude `altMeters` et couche
+	/// splat dominante `splatLayer` satisfait les règles de l'asset.
+	bool PassesRules(const FoliageRules& rules, float slopeDeg, float altMeters, int splatLayer);
+
+	/// Parse le contenu JSON de `library.json`. Tolérant aux clés inconnues ;
+	/// renseigne `err` et renvoie false en cas d'échec structurel.
+	bool ParseFoliageLibraryJson(const std::string& jsonText, FoliageLibrary& out, std::string& err);
+}

--- a/src/client/world/foliage/PoissonDiskSampler.cpp
+++ b/src/client/world/foliage/PoissonDiskSampler.cpp
@@ -1,0 +1,99 @@
+// M100.18 — Implémentation Poisson-disk (Bridson 2007), pure et déterministe.
+
+#include "src/client/world/foliage/PoissonDiskSampler.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+namespace engine::world::foliage
+{
+	std::vector<engine::math::Vec3> SamplePoissonDisk(float width, float height,
+	                                                  float minRadius, uint64_t seed)
+	{
+		std::vector<engine::math::Vec3> points;
+		if (width <= 0.0f || height <= 0.0f || minRadius <= 0.0f) return points;
+
+		constexpr float kPi = 3.14159265358979323846f;
+		constexpr int kCandidates = 30;
+
+		const float cell = minRadius / std::sqrt(2.0f);
+		const int gw = std::max(1, static_cast<int>(std::ceil(width / cell)));
+		const int gh = std::max(1, static_cast<int>(std::ceil(height / cell)));
+		std::vector<int> grid(static_cast<size_t>(gw) * gh, -1);
+
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+
+		auto gridIndex = [&](float x, float z) -> int
+		{
+			int gx = static_cast<int>(x / cell);
+			int gz = static_cast<int>(z / cell);
+			if (gx < 0) gx = 0; if (gx >= gw) gx = gw - 1;
+			if (gz < 0) gz = 0; if (gz >= gh) gz = gh - 1;
+			return gx + gz * gw;
+		};
+
+		auto fits = [&](float x, float z) -> bool
+		{
+			if (x < 0.0f || x >= width || z < 0.0f || z >= height) return false;
+			const int gx = static_cast<int>(x / cell);
+			const int gz = static_cast<int>(z / cell);
+			const float r2 = minRadius * minRadius;
+			for (int dz = -2; dz <= 2; ++dz)
+			{
+				for (int dx = -2; dx <= 2; ++dx)
+				{
+					const int nx = gx + dx, nz = gz + dz;
+					if (nx < 0 || nx >= gw || nz < 0 || nz >= gh) continue;
+					const int idx = grid[static_cast<size_t>(nx) + static_cast<size_t>(nz) * gw];
+					if (idx < 0) continue;
+					const auto& p = points[static_cast<size_t>(idx)];
+					const float ddx = p.x - x, ddz = p.z - z;
+					if (ddx * ddx + ddz * ddz < r2) return false;
+				}
+			}
+			return true;
+		};
+
+		auto addPoint = [&](float x, float z)
+		{
+			const int index = static_cast<int>(points.size());
+			points.push_back(engine::math::Vec3(x, 0.0f, z));
+			grid[static_cast<size_t>(gridIndex(x, z))] = index;
+		};
+
+		std::vector<int> active;
+		// Point initial.
+		addPoint(u01(rng) * width, u01(rng) * height);
+		active.push_back(0);
+
+		while (!active.empty())
+		{
+			const int activeIdx = static_cast<int>(u01(rng) * static_cast<float>(active.size()));
+			const int pointIdx = active[static_cast<size_t>(activeIdx)];
+			const engine::math::Vec3 base = points[static_cast<size_t>(pointIdx)];
+			bool found = false;
+			for (int i = 0; i < kCandidates; ++i)
+			{
+				const float ang = 2.0f * kPi * u01(rng);
+				const float rad = minRadius * (1.0f + u01(rng)); // annulus [r, 2r]
+				const float cx = base.x + std::cos(ang) * rad;
+				const float cz = base.z + std::sin(ang) * rad;
+				if (fits(cx, cz))
+				{
+					addPoint(cx, cz);
+					active.push_back(static_cast<int>(points.size()) - 1);
+					found = true;
+					break;
+				}
+			}
+			if (!found)
+			{
+				active[static_cast<size_t>(activeIdx)] = active.back();
+				active.pop_back();
+			}
+		}
+		return points;
+	}
+}

--- a/src/client/world/foliage/PoissonDiskSampler.h
+++ b/src/client/world/foliage/PoissonDiskSampler.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// M100.18 — Échantillonneur Poisson-disk 2D (plan XZ). Pur et déterministe.
+
+#include <cstdint>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::foliage
+{
+	/// Génère des points dans le rectangle [0,width] × [0,height] (plan XZ, y=0)
+	/// tels qu'aucune paire ne soit à distance < `minRadius` (algorithme de
+	/// Bridson). Déterministe pour un `seed` donné.
+	std::vector<engine::math::Vec3> SamplePoissonDisk(float width, float height,
+	                                                  float minRadius, uint64_t seed);
+}

--- a/src/client/world/foliage/tests/EntityInfluenceTests.cpp
+++ b/src/client/world/foliage/tests/EntityInfluenceTests.cpp
@@ -1,0 +1,68 @@
+// M100.21 — Tests collecteur d'influences (portée, troncature, flexion). Headless.
+
+#include "src/client/world/foliage/EntityInfluenceCollector.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::foliage;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	void Test_Collector_FiltersEntitiesByRange30m()
+	{
+		std::vector<EntityCandidate> ents;
+		ents.push_back({ 5.0f, 0.0f, 1.0f, 1.5f });    // dist 5 → gardé
+		ents.push_back({ 29.0f, 0.0f, 1.0f, 1.5f });   // dist 29 → gardé
+		ents.push_back({ 31.0f, 0.0f, 1.0f, 1.5f });   // dist 31 → rejeté
+		ents.push_back({ 0.0f, 100.0f, 1.0f, 1.5f });  // loin → rejeté
+		auto inf = CollectEntityInfluences(0.0f, 0.0f, ents);
+		REQUIRE(inf.size() == 2);
+	}
+
+	void Test_Collector_TruncatesAt32()
+	{
+		std::vector<EntityCandidate> ents;
+		for (int i = 0; i < 50; ++i)
+			ents.push_back({ static_cast<float>(i) * 0.5f, 0.0f, 1.0f, 1.5f }); // tous < 30 m (i<60)
+		auto inf = CollectEntityInfluences(0.0f, 0.0f, ents);
+		REQUIRE(inf.size() == 32);
+		// Les plus proches d'abord : la première influence est la plus proche.
+		if (inf.size() == 32) REQUIRE(inf[0].positionX <= inf[31].positionX);
+	}
+
+	void Test_Shader_FlexionMonotoneWithDistance()
+	{
+		EntityInfluence inf; inf.positionX = 0.0f; inf.positionZ = 0.0f; inf.radiusMeters = 2.0f; inf.falloffPower = 1.5f;
+		const float fNear = ComputeFlexionMagnitude(inf, 0.2f, 0.0f, 1.0f); // proche du centre
+		const float fFar = ComputeFlexionMagnitude(inf, 1.8f, 0.0f, 1.0f);  // proche du bord
+		const float fOut = ComputeFlexionMagnitude(inf, 2.5f, 0.0f, 1.0f);  // hors rayon
+		REQUIRE(fNear > fFar);
+		REQUIRE(fFar > 0.0f);
+		REQUIRE(fOut == 0.0f);
+		// Hauteur 0 → pas de flexion (racines fixes).
+		REQUIRE(ComputeFlexionMagnitude(inf, 0.2f, 0.0f, 0.0f) == 0.0f);
+	}
+}
+
+int main()
+{
+	Test_Collector_FiltersEntitiesByRange30m();
+	Test_Collector_TruncatesAt32();
+	Test_Shader_FlexionMonotoneWithDistance();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] EntityInfluenceTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] EntityInfluenceTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/foliage/tests/FoliageTests.cpp
+++ b/src/client/world/foliage/tests/FoliageTests.cpp
@@ -1,0 +1,115 @@
+// M100.18 — Tests foliage : library JSON + Poisson-disk + règles + round-trip.
+// Headless. Lié à engine_core.
+
+#include "src/client/world/foliage/FoliageInstances.h"
+#include "src/client/world/foliage/FoliageLibrary.h"
+#include "src/client/world/foliage/PoissonDiskSampler.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace engine::world::foliage;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	const char* kLibJson = R"JSON({
+  "version": 1,
+  "categories": [
+    { "id": "grass", "label": "Herbes" },
+    { "id": "tree_oak", "label": "Chene mature" },
+    { "id": "tree_dark", "label": "Arbre noir torture" }
+  ],
+  "assets": [
+    { "id": "grass_01", "category": "grass", "mesh": "veg/grass_01.glb", "billboard": false,
+      "rules": { "slopeMaxDeg": 35.0, "altMin": -200.0, "altMax": 2500.0, "splatLayers": [1, 2] } },
+    { "id": "tree_oak_01", "category": "tree_oak", "mesh": "veg/tree_oak_01.glb",
+      "rules": { "slopeMaxDeg": 25.0, "altMin": 0.0, "altMax": 1800.0, "splatLayers": [1, 2] } }
+  ]
+})JSON";
+
+	void Test_Library_LoadsCategoriesAndRules()
+	{
+		FoliageLibrary lib; std::string err;
+		REQUIRE(ParseFoliageLibraryJson(kLibJson, lib, err));
+		REQUIRE(lib.version == 1);
+		REQUIRE(lib.categories.size() == 3);
+		REQUIRE(lib.assets.size() == 2);
+		const FoliageAsset* oak = lib.FindAsset("tree_oak_01");
+		REQUIRE(oak != nullptr);
+		if (oak)
+		{
+			REQUIRE(oak->category == "tree_oak");
+			REQUIRE(std::fabs(oak->rules.slopeMaxDeg - 25.0f) < 1e-3f);
+			REQUIRE(oak->rules.splatLayers.size() == 2);
+		}
+	}
+
+	void Test_PoissonDisk_RespectsMinRadius()
+	{
+		const float minR = 1.0f;
+		auto pts = SamplePoissonDisk(20.0f, 20.0f, minR, 1234);
+		REQUIRE(pts.size() > 10); // couverture raisonnable
+		const float r2 = minR * minR;
+		bool ok = true;
+		for (size_t i = 0; i < pts.size() && ok; ++i)
+			for (size_t j = i + 1; j < pts.size(); ++j)
+			{
+				const float dx = pts[i].x - pts[j].x, dz = pts[i].z - pts[j].z;
+				if (dx * dx + dz * dz < r2 - 1e-4f) { ok = false; break; }
+			}
+		REQUIRE(ok);
+	}
+
+	void Test_RuleFilter_RejectsSteepCells()
+	{
+		FoliageRules r; r.slopeMaxDeg = 25.0f; r.altMin = 0.0f; r.altMax = 1800.0f; r.splatLayers = { 1, 2 };
+		REQUIRE(PassesRules(r, 10.0f, 500.0f, 1) == true);    // OK
+		REQUIRE(PassesRules(r, 40.0f, 500.0f, 1) == false);   // pente trop forte
+		REQUIRE(PassesRules(r, 10.0f, 2500.0f, 1) == false);  // altitude trop haute
+		REQUIRE(PassesRules(r, 10.0f, 500.0f, 5) == false);   // couche splat non listee
+		FoliageRules any; // splatLayers vide => toutes couches
+		REQUIRE(PassesRules(any, 10.0f, 500.0f, 7) == true);
+	}
+
+	void Test_Roundtrip_FoliageBin()
+	{
+		std::vector<FoliageInstance> items;
+		FoliageInstance a; a.assetIdHash = 0xABCD; a.position = { 1.0f, 0.0f, 2.0f }; a.rotationY = 1.5f; a.scale = 1.2f;
+		FoliageInstance b; b.assetIdHash = 0x1234; b.position = { 3.0f, 0.5f, 4.0f }; b.rotationY = -0.3f; b.scale = 0.9f;
+		items = { a, b };
+		std::vector<uint8_t> bytes = SaveFoliageBin(items);
+		std::vector<FoliageInstance> out; std::string err;
+		REQUIRE(LoadFoliageBin(bytes, out, err));
+		REQUIRE(out.size() == 2);
+		if (out.size() == 2)
+		{
+			REQUIRE(out[0].assetIdHash == 0xABCD);
+			REQUIRE(std::fabs(out[0].rotationY - 1.5f) < 1e-4f);
+			REQUIRE(std::fabs(out[1].scale - 0.9f) < 1e-4f);
+		}
+	}
+}
+
+int main()
+{
+	Test_Library_LoadsCategoriesAndRules();
+	Test_PoissonDisk_RespectsMinRadius();
+	Test_RuleFilter_RejectsSteepCells();
+	Test_Roundtrip_FoliageBin();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] FoliageTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] FoliageTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/spline/SplineInstances.h
+++ b/src/client/world/spline/SplineInstances.h
@@ -1,0 +1,106 @@
+#pragma once
+
+// M100.29 — Splines (routes/chemins) : structs + sérialisation `instances/splines.bin`.
+// Header-only (partagé engine_core/zone_builder).
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::spline
+{
+	enum class SplineType : uint32_t { Road = 0, Path = 1, Wall = 2, RiverRef = 3 };
+	enum class SplineCurve : uint32_t { CatmullRom = 0, Bezier = 1 };
+
+	struct SplineNode
+	{
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+		float widthMeters = 6.0f;
+		float tangentMagnitude = 0.0f; // Bezier
+	};
+
+	struct Spline
+	{
+		SplineType type = SplineType::Road;
+		SplineCurve curve = SplineCurve::CatmullRom;
+		bool closed = false;
+		std::vector<SplineNode> nodes;
+		uint32_t splatLayerIndex = 0;
+		float splatStrength = 1.0f;
+		float splatFeatherMeters = 0.5f;
+	};
+
+	constexpr uint32_t kSplinesMagic = 0x4C50534Eu; // "NSPL"
+	constexpr uint32_t kSplinesVersion = 1u;
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v) { b.push_back(uint8_t(v)); b.push_back(uint8_t(v>>8)); b.push_back(uint8_t(v>>16)); b.push_back(uint8_t(v>>24)); }
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v) { for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8*i))); }
+		inline void PutF32(std::vector<uint8_t>& b, float f) { uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u); }
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& o) { if (p+4>b.size()) return false; o = uint32_t(b[p])|(uint32_t(b[p+1])<<8)|(uint32_t(b[p+2])<<16)|(uint32_t(b[p+3])<<24); p+=4; return true; }
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& o) { if (p+8>b.size()) return false; o=0; for (int i=0;i<8;++i) o|=uint64_t(b[p+i])<<(8*i); p+=8; return true; }
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& o) { uint32_t u; if (!GetU32(b,p,u)) return false; std::memcpy(&o,&u,4); return true; }
+	}
+
+	inline std::vector<uint8_t> SaveSplinesBin(const std::vector<Spline>& splines)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kSplinesMagic); detail::PutU32(b, kSplinesVersion);
+		detail::PutU32(b, 1u); detail::PutU32(b, 1u); detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(splines.size()));
+		for (const Spline& s : splines)
+		{
+			detail::PutU32(b, static_cast<uint32_t>(s.type));
+			detail::PutU32(b, static_cast<uint32_t>(s.curve));
+			detail::PutU32(b, s.closed ? 1u : 0u);
+			detail::PutU32(b, static_cast<uint32_t>(s.nodes.size()));
+			for (const SplineNode& n : s.nodes)
+			{
+				detail::PutF32(b, n.position.x); detail::PutF32(b, n.position.y); detail::PutF32(b, n.position.z);
+				detail::PutF32(b, n.widthMeters);
+				detail::PutF32(b, n.tangentMagnitude);
+			}
+			detail::PutU32(b, s.splatLayerIndex);
+			detail::PutF32(b, s.splatStrength);
+			detail::PutF32(b, s.splatFeatherMeters);
+		}
+		return b;
+	}
+
+	inline bool LoadSplinesBin(std::span<const uint8_t> bytes, std::vector<Spline>& out, std::string& err)
+	{
+		size_t p = 0; uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kSplinesMagic) { err = "splines.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kSplinesVersion) { err = "splines.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder); detail::GetU32(bytes, p, engine); detail::GetU64(bytes, p, hash);
+		uint32_t count = 0; if (!detail::GetU32(bytes, p, count)) { err = "splines.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			Spline s; uint32_t t = 0, c = 0, closed = 0, nc = 0;
+			if (!detail::GetU32(bytes, p, t)) { err = "splines.bin: tronque"; return false; }
+			detail::GetU32(bytes, p, c); detail::GetU32(bytes, p, closed);
+			s.type = static_cast<SplineType>(t); s.curve = static_cast<SplineCurve>(c); s.closed = (closed != 0);
+			if (!detail::GetU32(bytes, p, nc)) { err = "splines.bin: node count"; return false; }
+			s.nodes.reserve(nc);
+			for (uint32_t k = 0; k < nc; ++k)
+			{
+				SplineNode n;
+				detail::GetF32(bytes, p, n.position.x); detail::GetF32(bytes, p, n.position.y); detail::GetF32(bytes, p, n.position.z);
+				detail::GetF32(bytes, p, n.widthMeters);
+				if (!detail::GetF32(bytes, p, n.tangentMagnitude)) { err = "splines.bin: node tronque"; return false; }
+				s.nodes.push_back(n);
+			}
+			detail::GetU32(bytes, p, s.splatLayerIndex);
+			detail::GetF32(bytes, p, s.splatStrength);
+			if (!detail::GetF32(bytes, p, s.splatFeatherMeters)) { err = "splines.bin: splat tronque"; return false; }
+			out.push_back(std::move(s));
+		}
+		return true;
+	}
+}

--- a/src/client/world/spline/SplineInstances.h
+++ b/src/client/world/spline/SplineInstances.h
@@ -23,6 +23,21 @@ namespace engine::world::spline
 		float tangentMagnitude = 0.0f; // Bezier
 	};
 
+	// M100.30 — extension v2 : kit modulaire (pont/mur) optionnel par spline.
+	enum class SplineKitMode : uint32_t { None = 0, Bridge = 1, Wall = 2 };
+
+	struct SplineKitData
+	{
+		SplineKitMode mode = SplineKitMode::None;
+		uint32_t kitNameHash = 0;
+		float segmentLengthMeters = 4.0f;
+		uint32_t yMode = 0;            // Bridge : 0 = constant, 1 = suit la spline
+		float yConstant = 0.0f;        // Bridge
+		float widthMeters = 6.0f;      // Bridge
+		float heightMeters = 3.5f;     // Wall
+		float postSpacingMeters = 4.0f; // Wall
+	};
+
 	struct Spline
 	{
 		SplineType type = SplineType::Road;
@@ -32,10 +47,11 @@ namespace engine::world::spline
 		uint32_t splatLayerIndex = 0;
 		float splatStrength = 1.0f;
 		float splatFeatherMeters = 0.5f;
+		SplineKitData kit; // M100.30 (v2)
 	};
 
 	constexpr uint32_t kSplinesMagic = 0x4C50534Eu; // "NSPL"
-	constexpr uint32_t kSplinesVersion = 1u;
+	constexpr uint32_t kSplinesVersion = 2u;        // v2 : kit pont/mur (M100.30)
 
 	namespace detail
 	{
@@ -68,6 +84,23 @@ namespace engine::world::spline
 			detail::PutU32(b, s.splatLayerIndex);
 			detail::PutF32(b, s.splatStrength);
 			detail::PutF32(b, s.splatFeatherMeters);
+			// v2 : kit pont/mur.
+			detail::PutU32(b, static_cast<uint32_t>(s.kit.mode));
+			if (s.kit.mode == SplineKitMode::Bridge)
+			{
+				detail::PutU32(b, s.kit.kitNameHash);
+				detail::PutF32(b, s.kit.segmentLengthMeters);
+				detail::PutU32(b, s.kit.yMode);
+				detail::PutF32(b, s.kit.yConstant);
+				detail::PutF32(b, s.kit.widthMeters);
+			}
+			else if (s.kit.mode == SplineKitMode::Wall)
+			{
+				detail::PutU32(b, s.kit.kitNameHash);
+				detail::PutF32(b, s.kit.segmentLengthMeters);
+				detail::PutF32(b, s.kit.heightMeters);
+				detail::PutF32(b, s.kit.postSpacingMeters);
+			}
 		}
 		return b;
 	}
@@ -99,6 +132,28 @@ namespace engine::world::spline
 			detail::GetU32(bytes, p, s.splatLayerIndex);
 			detail::GetF32(bytes, p, s.splatStrength);
 			if (!detail::GetF32(bytes, p, s.splatFeatherMeters)) { err = "splines.bin: splat tronque"; return false; }
+			// v2 : kit pont/mur (rétro-compat : v1 => kitMode None par défaut).
+			if (version >= 2u)
+			{
+				uint32_t km = 0;
+				if (!detail::GetU32(bytes, p, km)) { err = "splines.bin: kit tronque"; return false; }
+				s.kit.mode = static_cast<SplineKitMode>(km);
+				if (s.kit.mode == SplineKitMode::Bridge)
+				{
+					detail::GetU32(bytes, p, s.kit.kitNameHash);
+					detail::GetF32(bytes, p, s.kit.segmentLengthMeters);
+					detail::GetU32(bytes, p, s.kit.yMode);
+					detail::GetF32(bytes, p, s.kit.yConstant);
+					if (!detail::GetF32(bytes, p, s.kit.widthMeters)) { err = "splines.bin: bridge tronque"; return false; }
+				}
+				else if (s.kit.mode == SplineKitMode::Wall)
+				{
+					detail::GetU32(bytes, p, s.kit.kitNameHash);
+					detail::GetF32(bytes, p, s.kit.segmentLengthMeters);
+					detail::GetF32(bytes, p, s.kit.heightMeters);
+					if (!detail::GetF32(bytes, p, s.kit.postSpacingMeters)) { err = "splines.bin: wall tronque"; return false; }
+				}
+			}
 			out.push_back(std::move(s));
 		}
 		return true;

--- a/src/client/world/spline/SplineSampler.cpp
+++ b/src/client/world/spline/SplineSampler.cpp
@@ -1,0 +1,88 @@
+// M100.29 — Implémentation de l'échantillonnage spline + helpers (purs).
+
+#include "src/client/world/spline/SplineSampler.h"
+
+namespace engine::world::spline
+{
+	using engine::math::Vec3;
+
+	namespace
+	{
+		Vec3 CatmullRom(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3, float t)
+		{
+			const float t2 = t * t, t3 = t2 * t;
+			// 0.5 * (2p1 + (-p0+p2)t + (2p0-5p1+4p2-p3)t² + (-p0+3p1-3p2+p3)t³)
+			Vec3 a = p1 * 2.0f;
+			Vec3 b = (p2 - p0) * t;
+			Vec3 c = (p0 * 2.0f - p1 * 5.0f + p2 * 4.0f - p3) * t2;
+			Vec3 d = (p1 * 3.0f - p0 - p2 * 3.0f + p3) * t3;
+			return (a + b + c + d) * 0.5f;
+		}
+	} // namespace
+
+	std::vector<Vec3> SampleCatmullRom(const std::vector<SplineNode>& nodes, bool closed, int samplesPerSegment)
+	{
+		std::vector<Vec3> out;
+		const int m = static_cast<int>(nodes.size());
+		if (m == 0) return out;
+		if (m == 1) { out.push_back(nodes[0].position); return out; }
+		if (samplesPerSegment < 1) samplesPerSegment = 1;
+
+		auto nodeAt = [&](int i) -> Vec3
+		{
+			if (closed) { i = ((i % m) + m) % m; return nodes[static_cast<size_t>(i)].position; }
+			if (i < 0) i = 0; if (i > m - 1) i = m - 1;
+			return nodes[static_cast<size_t>(i)].position;
+		};
+
+		const int segs = closed ? m : (m - 1);
+		for (int i = 0; i < segs; ++i)
+		{
+			const Vec3 p0 = nodeAt(i - 1), p1 = nodeAt(i), p2 = nodeAt(i + 1), p3 = nodeAt(i + 2);
+			for (int j = 0; j < samplesPerSegment; ++j)
+			{
+				const float t = static_cast<float>(j) / static_cast<float>(samplesPerSegment);
+				out.push_back(CatmullRom(p0, p1, p2, p3, t));
+			}
+		}
+		if (!closed) out.push_back(nodes[static_cast<size_t>(m - 1)].position);
+		return out;
+	}
+
+	std::vector<Vec3> GroundFit(const std::vector<Vec3>& pts, const HeightSampler& sampler)
+	{
+		std::vector<Vec3> out = pts;
+		if (sampler)
+			for (auto& p : out) p.y = sampler(p.x, p.z);
+		return out;
+	}
+
+	void ApplyRoadWeight(std::array<uint8_t, 8>& weights, int roadLayer, uint8_t target)
+	{
+		if (roadLayer < 0 || roadLayer >= 8) return;
+		const int t = (target > 255) ? 255 : static_cast<int>(target);
+		const int rem = 255 - t;
+
+		int otherSum = 0;
+		for (int i = 0; i < 8; ++i) if (i != roadLayer) otherSum += weights[static_cast<size_t>(i)];
+
+		if (otherSum > 0)
+		{
+			int acc = 0;
+			for (int i = 0; i < 8; ++i)
+			{
+				if (i == roadLayer) continue;
+				const int w = weights[static_cast<size_t>(i)] * rem / otherSum;
+				weights[static_cast<size_t>(i)] = static_cast<uint8_t>(w);
+				acc += w;
+			}
+			// La couche route absorbe le reliquat d'arrondi → somme exacte = 255.
+			weights[static_cast<size_t>(roadLayer)] = static_cast<uint8_t>(255 - acc);
+		}
+		else
+		{
+			for (int i = 0; i < 8; ++i) weights[static_cast<size_t>(i)] = 0;
+			weights[static_cast<size_t>(roadLayer)] = 255;
+		}
+	}
+}

--- a/src/client/world/spline/SplineSampler.h
+++ b/src/client/world/spline/SplineSampler.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// M100.29 — Échantillonnage de spline (Catmull-Rom), auto-fit terrain, et
+// redistribution splat sous route (somme=255). Pur, testable headless.
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::world::spline
+{
+	/// Échantillonne une Catmull-Rom uniforme passant par les nœuds.
+	/// `samplesPerSegment` points par segment ; inclut les nœuds (t=0 de chaque
+	/// segment) et le dernier nœud. Y des nœuds utilisé tel quel.
+	std::vector<engine::math::Vec3> SampleCatmullRom(const std::vector<SplineNode>& nodes,
+	                                                 bool closed, int samplesPerSegment);
+
+	using HeightSampler = std::function<float(float worldX, float worldZ)>;
+
+	/// Recalcule le Y de chaque point via la heightmap (auto-fit terrain).
+	std::vector<engine::math::Vec3> GroundFit(const std::vector<engine::math::Vec3>& pts,
+	                                          const HeightSampler& sampler);
+
+	/// Applique un poids `target` à la couche `roadLayer` d'une cellule splat
+	/// 8 couches, en redistribuant les autres pour préserver somme=255.
+	void ApplyRoadWeight(std::array<uint8_t, 8>& weights, int roadLayer, uint8_t target);
+}

--- a/src/client/world/spline/tests/SplineTests.cpp
+++ b/src/client/world/spline/tests/SplineTests.cpp
@@ -1,0 +1,104 @@
+// M100.29 — Tests spline : Catmull-Rom continuité, ground-fit, splat sum=255, round-trip.
+
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/client/world/spline/SplineSampler.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::spline;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) <= eps; }
+	float Dist(const Vec3& a, const Vec3& b)
+	{
+		const float dx = a.x - b.x, dy = a.y - b.y, dz = a.z - b.z;
+		return std::sqrt(dx * dx + dy * dy + dz * dz);
+	}
+
+	SplineNode N(float x, float y, float z) { SplineNode n; n.position = Vec3(x, y, z); return n; }
+
+	void Test_Spline_CatmullRom_Continuity()
+	{
+		std::vector<SplineNode> nodes = { N(0,0,0), N(10,0,0), N(20,0,5), N(30,0,5) };
+		const int spp = 10;
+		auto pts = SampleCatmullRom(nodes, false, spp);
+		REQUIRE(pts.size() == static_cast<size_t>(3 * spp + 1));
+		// Passe par les nœuds (t=0 de chaque segment + dernier point).
+		REQUIRE(Dist(pts[0], nodes[0].position) < 1e-3f);
+		REQUIRE(Dist(pts[spp], nodes[1].position) < 1e-3f);
+		REQUIRE(Dist(pts[2 * spp], nodes[2].position) < 1e-3f);
+		REQUIRE(Dist(pts.back(), nodes[3].position) < 1e-3f);
+		// Continuité : pas de saut entre échantillons consécutifs.
+		for (size_t i = 1; i < pts.size(); ++i) REQUIRE(Dist(pts[i], pts[i - 1]) < 6.0f);
+	}
+
+	void Test_Spline_GroundAutoFit()
+	{
+		std::vector<Vec3> pts = { Vec3(0,0,0), Vec3(5,0,5), Vec3(10,0,10) };
+		auto fit = GroundFit(pts, [](float, float) { return 7.0f; });
+		REQUIRE(fit.size() == 3);
+		for (const auto& p : fit) REQUIRE(Near(p.y, 7.0f));
+	}
+
+	void Test_PaintAlongSpline_PreservesSum255()
+	{
+		std::array<uint8_t, 8> w = { 100, 100, 55, 0, 0, 0, 0, 0 };
+		ApplyRoadWeight(w, 3, 200);
+		int sum = 0; for (uint8_t v : w) sum += v;
+		REQUIRE(sum == 255);
+		REQUIRE(w[3] >= 200); // la route domine
+
+		// Cas autres-couches nulles → route = 255.
+		std::array<uint8_t, 8> z = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		ApplyRoadWeight(z, 0, 128);
+		int sum2 = 0; for (uint8_t v : z) sum2 += v;
+		REQUIRE(sum2 == 255);
+	}
+
+	void Test_Roundtrip_SplinesBin()
+	{
+		Spline s; s.type = SplineType::Road; s.curve = SplineCurve::CatmullRom; s.closed = false;
+		s.nodes = { N(1,2,3), N(4,5,6) }; s.nodes[0].widthMeters = 8.0f;
+		s.splatLayerIndex = 2; s.splatStrength = 0.9f; s.splatFeatherMeters = 0.7f;
+		auto bytes = SaveSplinesBin({ s });
+		std::vector<Spline> out; std::string err;
+		REQUIRE(LoadSplinesBin(bytes, out, err));
+		REQUIRE(out.size() == 1);
+		if (out.size() == 1)
+		{
+			REQUIRE(out[0].type == SplineType::Road);
+			REQUIRE(out[0].nodes.size() == 2);
+			REQUIRE(Near(out[0].nodes[0].widthMeters, 8.0f));
+			REQUIRE(out[0].splatLayerIndex == 2);
+			REQUIRE(Near(out[0].splatStrength, 0.9f));
+		}
+	}
+}
+
+int main()
+{
+	Test_Spline_CatmullRom_Continuity();
+	Test_Spline_GroundAutoFit();
+	Test_PaintAlongSpline_PreservesSum255();
+	Test_Roundtrip_SplinesBin();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] SplineTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] SplineTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/structures/HamletKitLibrary.cpp
+++ b/src/client/world/structures/HamletKitLibrary.cpp
@@ -1,0 +1,104 @@
+// M100.31 — Parsing des kits d'hameau (parser JSON compact, même pattern que
+// les autres bibliothèques data-driven du projet).
+
+#include "src/client/world/structures/HamletKitLibrary.h"
+
+#include <cstdlib>
+#include <string_view>
+#include <utility>
+
+namespace engine::world::structures
+{
+	namespace
+	{
+		struct JVal
+		{
+			enum class T { Null, Bool, Num, Str, Arr, Obj } t = T::Null;
+			bool b = false; double num = 0.0; std::string str;
+			std::vector<JVal> arr; std::vector<std::pair<std::string, JVal>> obj;
+			const JVal* Find(std::string_view k) const { for (const auto& kv : obj) if (kv.first == k) return &kv.second; return nullptr; }
+		};
+
+		class Parser
+		{
+		public:
+			Parser(std::string_view s, std::string& e) : m_s(s), m_err(e) {}
+			bool Parse(JVal& o) { SkipWs(); if (!Value(o)) return false; SkipWs(); return true; }
+		private:
+			void Fail(const char* m) { if (m_err.empty()) m_err = m; }
+			void SkipWs() { while (m_pos < m_s.size()) { char c = m_s[m_pos]; if (c==' '||c=='\t'||c=='\n'||c=='\r') ++m_pos; else break; } }
+			bool Eof() const { return m_pos >= m_s.size(); }
+			char Peek() const { return m_s[m_pos]; }
+			bool Expect(char c) { if (Eof()||m_s[m_pos]!=c){Fail("char");return false;} ++m_pos; return true; }
+			bool Value(JVal& o)
+			{
+				SkipWs(); if (Eof()){Fail("eof");return false;} char c = Peek();
+				if (c=='{') return Object(o); if (c=='[') return Array(o);
+				if (c=='"'){ o.t=JVal::T::Str; return String(o.str); }
+				if (c=='t'||c=='f') return Bool(o); if (c=='n') return Null(o);
+				if (c=='-'||(c>='0'&&c<='9')) return Number(o);
+				Fail("valeur"); return false;
+			}
+			bool Object(JVal& o)
+			{
+				o.t=JVal::T::Obj; if(!Expect('{'))return false; SkipWs();
+				if(!Eof()&&Peek()=='}'){++m_pos;return true;}
+				for(;;){ SkipWs(); if(Eof()||Peek()!='"'){Fail("cle");return false;}
+					std::string k; if(!String(k))return false; SkipWs(); if(!Expect(':'))return false;
+					JVal v; if(!Value(v))return false; o.obj.emplace_back(std::move(k),std::move(v)); SkipWs();
+					if(Eof()){Fail("obj");return false;} char c=Peek();
+					if(c==','){++m_pos;continue;} if(c=='}'){++m_pos;return true;} Fail("',}'");return false; }
+			}
+			bool Array(JVal& o)
+			{
+				o.t=JVal::T::Arr; if(!Expect('['))return false; SkipWs();
+				if(!Eof()&&Peek()==']'){++m_pos;return true;}
+				for(;;){ JVal v; if(!Value(v))return false; o.arr.push_back(std::move(v)); SkipWs();
+					if(Eof()){Fail("arr");return false;} char c=Peek();
+					if(c==','){++m_pos;continue;} if(c==']'){++m_pos;return true;} Fail("',]'");return false; }
+			}
+			bool String(std::string& out)
+			{
+				if(!Expect('"'))return false; out.clear();
+				while(!Eof()){ char c=m_s[m_pos++]; if(c=='"')return true;
+					if(c=='\\'){ if(Eof()){Fail("esc");return false;} char e=m_s[m_pos++];
+						switch(e){case '"':out.push_back('"');break;case '\\':out.push_back('\\');break;case '/':out.push_back('/');break;
+							case 'n':out.push_back('\n');break;case 'r':out.push_back('\r');break;case 't':out.push_back('\t');break;
+							default:out.push_back(e);break;} }
+					else out.push_back(c); }
+				Fail("str"); return false;
+			}
+			bool Number(JVal& o)
+			{
+				size_t s=m_pos; if(!Eof()&&Peek()=='-')++m_pos;
+				while(!Eof()){char c=Peek(); if((c>='0'&&c<='9')||c=='.'||c=='e'||c=='E'||c=='+'||c=='-')++m_pos; else break;}
+				if(m_pos==s){Fail("num");return false;} o.t=JVal::T::Num; o.num=std::strtod(std::string(m_s.substr(s,m_pos-s)).c_str(),nullptr); return true;
+			}
+			bool Bool(JVal& o){ if(m_s.compare(m_pos,4,"true")==0){m_pos+=4;o.t=JVal::T::Bool;o.b=true;return true;} if(m_s.compare(m_pos,5,"false")==0){m_pos+=5;o.t=JVal::T::Bool;o.b=false;return true;} Fail("bool");return false; }
+			bool Null(JVal& o){ if(m_s.compare(m_pos,4,"null")==0){m_pos+=4;o.t=JVal::T::Null;return true;} Fail("null");return false; }
+			std::string_view m_s; size_t m_pos=0; std::string& m_err;
+		};
+	} // namespace
+
+	bool ParseHamletKitJson(const std::string& jsonText, HamletKit& out, std::string& err)
+	{
+		JVal root; Parser parser(jsonText, err);
+		if (!parser.Parse(root) || root.t != JVal::T::Obj) { if (err.empty()) err = "kit: racine objet attendue"; return false; }
+		if (const JVal* r = root.Find("race"); r && r->t == JVal::T::Str) out.race = r->str;
+		if (const JVal* b = root.Find("biome"); b && b->t == JVal::T::Str) out.biome = b->str;
+		if (const JVal* m = root.Find("minSpacingDefault"); m && m->t == JVal::T::Num) out.minSpacingDefault = static_cast<float>(m->num);
+		if (const JVal* f = root.Find("footprintRadius"); f && f->t == JVal::T::Num) out.footprintRadius = static_cast<float>(f->num);
+		if (const JVal* hs = root.Find("houses"); hs && hs->t == JVal::T::Arr)
+		{
+			for (const JVal& h : hs->arr)
+			{
+				if (h.t != JVal::T::Obj) continue;
+				std::string mesh; float weight = 1.0f;
+				if (const JVal* m = h.Find("mesh"); m && m->t == JVal::T::Str) mesh = m->str;
+				if (const JVal* w = h.Find("weight"); w && w->t == JVal::T::Num) weight = static_cast<float>(w->num);
+				out.houses.emplace_back(std::move(mesh), weight);
+			}
+		}
+		return true;
+	}
+}

--- a/src/client/world/structures/HamletKitLibrary.h
+++ b/src/client/world/structures/HamletKitLibrary.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// M100.31 — Bibliothèque de kits d'hameau (par race/biome). Parsing JSON pur.
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::world::structures
+{
+	struct HamletKit
+	{
+		std::string race;
+		std::string biome;
+		std::vector<std::pair<std::string, float>> houses; // mesh, weight
+		float minSpacingDefault = 8.0f;
+		float footprintRadius = 5.0f;
+	};
+
+	/// Parse un kit JSON (`assets/structures/kits/<name>.json`). Tolérant aux
+	/// clés inconnues ; renvoie false + `err` en cas d'échec structurel.
+	bool ParseHamletKitJson(const std::string& jsonText, HamletKit& out, std::string& err);
+}

--- a/src/client/world/structures/Kits.h
+++ b/src/client/world/structures/Kits.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// M100.30 — Lookup des kits modulaires (pont/mur). Hash de nom stable (FNV-1a).
+// Header-only.
+
+#include <cstdint>
+#include <string>
+
+namespace engine::world::structures
+{
+	inline uint32_t HashKitName(const std::string& name)
+	{
+		uint32_t h = 2166136261u;
+		for (unsigned char c : name) { h ^= c; h *= 16777619u; }
+		return h;
+	}
+}

--- a/src/client/world/structures/Structures.cpp
+++ b/src/client/world/structures/Structures.cpp
@@ -1,0 +1,70 @@
+// M100.30 — Implémentation des helpers de structures (purs).
+
+#include "src/client/world/structures/Structures.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::world::structures
+{
+	using engine::math::Vec3;
+
+	float PolylineLength(const std::vector<Vec3>& pts)
+	{
+		float total = 0.0f;
+		for (size_t i = 1; i < pts.size(); ++i)
+		{
+			const float dx = pts[i].x - pts[i-1].x, dy = pts[i].y - pts[i-1].y, dz = pts[i].z - pts[i-1].z;
+			total += std::sqrt(dx*dx + dy*dy + dz*dz);
+		}
+		return total;
+	}
+
+	int BridgeSegmentCount(float lengthMeters, float segmentLengthMeters)
+	{
+		if (segmentLengthMeters <= 1e-5f || lengthMeters <= 0.0f) return 1;
+		int n = static_cast<int>(std::lround(lengthMeters / segmentLengthMeters));
+		return std::max(1, n);
+	}
+
+	std::vector<float> WallPostDistances(float lengthMeters, float postSpacingMeters)
+	{
+		std::vector<float> out;
+		if (postSpacingMeters <= 1e-5f || lengthMeters < 0.0f) { out.push_back(0.0f); return out; }
+		for (float d = 0.0f; d <= lengthMeters + 1e-4f; d += postSpacingMeters) out.push_back(d);
+		// Garantit un poteau de terminaison exact à la fin.
+		if (out.empty() || std::fabs(out.back() - lengthMeters) > 1e-3f) out.push_back(lengthMeters);
+		return out;
+	}
+
+	std::vector<int> DetectSharpCorners(const std::vector<Vec3>& nodes, float thresholdDeg)
+	{
+		std::vector<int> corners;
+		constexpr float kRadToDeg = 57.2957795f;
+		for (size_t i = 1; i + 1 < nodes.size(); ++i)
+		{
+			const Vec3 d0(nodes[i].x - nodes[i-1].x, 0.0f, nodes[i].z - nodes[i-1].z);
+			const Vec3 d1(nodes[i+1].x - nodes[i].x, 0.0f, nodes[i+1].z - nodes[i].z);
+			const float l0 = std::sqrt(d0.x*d0.x + d0.z*d0.z), l1 = std::sqrt(d1.x*d1.x + d1.z*d1.z);
+			if (l0 < 1e-5f || l1 < 1e-5f) continue;
+			float cosA = (d0.x*d1.x + d0.z*d1.z) / (l0 * l1);
+			cosA = std::max(-1.0f, std::min(1.0f, cosA));
+			const float turnDeg = std::acos(cosA) * kRadToDeg; // 0 = tout droit
+			if (turnDeg >= thresholdDeg) corners.push_back(static_cast<int>(i));
+		}
+		return corners;
+	}
+
+	bool QueryBridgeSurface(const BridgeWalkable& bridge, const Vec3& pos)
+	{
+		const float dx = bridge.b.x - bridge.a.x, dz = bridge.b.z - bridge.a.z;
+		const float len2 = dx*dx + dz*dz;
+		float t = (len2 > 1e-9f) ? ((pos.x - bridge.a.x) * dx + (pos.z - bridge.a.z) * dz) / len2 : 0.0f;
+		t = std::max(0.0f, std::min(1.0f, t));
+		const float cx = bridge.a.x + t * dx, cz = bridge.a.z + t * dz;
+		const float ex = pos.x - cx, ez = pos.z - cz;
+		const float lateral = std::sqrt(ex*ex + ez*ez);
+		if (lateral > bridge.widthMeters * 0.5f) return false;
+		return std::fabs(pos.y - bridge.bridgeY) <= 0.3f;
+	}
+}

--- a/src/client/world/structures/Structures.h
+++ b/src/client/world/structures/Structures.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// M100.30 — Génération de structures le long d'une spline (ponts/murs) +
+// surface marchable de pont. Fonctions PURES, testables headless.
+
+#include <cstdint>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::structures
+{
+	/// Longueur d'une polyline (somme des segments, XZ+Y).
+	float PolylineLength(const std::vector<engine::math::Vec3>& pts);
+
+	/// Nombre de segments de pont pour une longueur donnée (>= 1).
+	int BridgeSegmentCount(float lengthMeters, float segmentLengthMeters);
+
+	/// Distances (le long de la polyline) des poteaux d'un mur, espacés de
+	/// `postSpacingMeters` (inclut 0 et la fin).
+	std::vector<float> WallPostDistances(float lengthMeters, float postSpacingMeters);
+
+	/// Indices des nœuds intérieurs formant un coin dont l'angle de virage
+	/// (entre segments consécutifs) est >= `thresholdDeg`.
+	std::vector<int> DetectSharpCorners(const std::vector<engine::math::Vec3>& nodes, float thresholdDeg);
+
+	/// Surface marchable d'un pont : segment central [a,b] + largeur + hauteur.
+	struct BridgeWalkable
+	{
+		engine::math::Vec3 a{ 0, 0, 0 };
+		engine::math::Vec3 b{ 0, 0, 0 };
+		float widthMeters = 6.0f;
+		float bridgeY = 0.0f;
+	};
+
+	/// True si `pos` est sur la surface marchable du pont (projection XZ sur le
+	/// segment central à <= width/2, et |y - bridgeY| <= 0.3 m).
+	bool QueryBridgeSurface(const BridgeWalkable& bridge, const engine::math::Vec3& pos);
+}

--- a/src/client/world/structures/tests/StructuresTests.cpp
+++ b/src/client/world/structures/tests/StructuresTests.cpp
@@ -1,0 +1,143 @@
+// M100.30 — Tests structures : pont/mur génération, coins, surface pont,
+// migration splines v1->v2. Headless.
+
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/client/world/structures/Kits.h"
+#include "src/client/world/structures/Structures.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::structures;
+using engine::math::Vec3;
+namespace spl = engine::world::spline;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	void Test_Bridge_GeneratesCorrectSegmentCount()
+	{
+		REQUIRE(BridgeSegmentCount(40.0f, 4.0f) == 10);
+		REQUIRE(BridgeSegmentCount(0.5f, 4.0f) == 1); // minimum 1
+	}
+
+	void Test_Wall_PostSpacingApplied()
+	{
+		auto posts = WallPostDistances(12.0f, 4.0f); // 0,4,8,12
+		REQUIRE(posts.size() == 4);
+		if (posts.size() == 4)
+		{
+			REQUIRE(std::fabs(posts[0] - 0.0f) < 1e-3f);
+			REQUIRE(std::fabs(posts[1] - 4.0f) < 1e-3f);
+			REQUIRE(std::fabs(posts[3] - 12.0f) < 1e-3f);
+		}
+	}
+
+	void Test_Wall_DetectsCornersOver70deg()
+	{
+		// Virage à 90° au nœud 1.
+		std::vector<Vec3> bent = { Vec3(0,0,0), Vec3(10,0,0), Vec3(10,0,10) };
+		auto corners = DetectSharpCorners(bent, 70.0f);
+		REQUIRE(corners.size() == 1);
+		if (!corners.empty()) REQUIRE(corners[0] == 1);
+
+		// Ligne droite : aucun coin.
+		std::vector<Vec3> straight = { Vec3(0,0,0), Vec3(5,0,0), Vec3(10,0,0) };
+		REQUIRE(DetectSharpCorners(straight, 70.0f).empty());
+	}
+
+	void Test_Bridge_SurfaceQueryReturnsBridge()
+	{
+		BridgeWalkable br; br.a = Vec3(0,5,0); br.b = Vec3(10,5,0); br.widthMeters = 6.0f; br.bridgeY = 5.0f;
+		REQUIRE(QueryBridgeSurface(br, Vec3(5,5,1)) == true);    // sur le pont
+		REQUIRE(QueryBridgeSurface(br, Vec3(5,5,10)) == false);  // hors largeur
+		REQUIRE(QueryBridgeSurface(br, Vec3(5,8,0)) == false);   // mauvaise hauteur
+	}
+
+	void Test_KitHash_Stable()
+	{
+		REQUIRE(HashKitName("stone_bridge_kit") == HashKitName("stone_bridge_kit"));
+		REQUIRE(HashKitName("a") != HashKitName("b"));
+	}
+
+	// Construit des octets splines.bin au FORMAT v1 (sans bloc kit).
+	std::vector<uint8_t> MakeV1Bytes()
+	{
+		std::vector<uint8_t> b;
+		spl::detail::PutU32(b, spl::kSplinesMagic);
+		spl::detail::PutU32(b, 1u); // version 1
+		spl::detail::PutU32(b, 1u); spl::detail::PutU32(b, 1u); spl::detail::PutU64(b, 0ull);
+		spl::detail::PutU32(b, 1u); // 1 spline
+		spl::detail::PutU32(b, static_cast<uint32_t>(spl::SplineType::Road));
+		spl::detail::PutU32(b, static_cast<uint32_t>(spl::SplineCurve::CatmullRom));
+		spl::detail::PutU32(b, 0u); // closed
+		spl::detail::PutU32(b, 2u); // 2 nodes
+		for (int i = 0; i < 2; ++i)
+		{
+			spl::detail::PutF32(b, static_cast<float>(i) * 10.0f); spl::detail::PutF32(b, 0.0f); spl::detail::PutF32(b, 0.0f);
+			spl::detail::PutF32(b, 6.0f); spl::detail::PutF32(b, 0.0f);
+		}
+		spl::detail::PutU32(b, 2u);   // splatLayer
+		spl::detail::PutF32(b, 1.0f); // strength
+		spl::detail::PutF32(b, 0.5f); // feather
+		// PAS de bloc kit (v1).
+		return b;
+	}
+
+	void Test_SplinesBin_V1ToV2Migration()
+	{
+		auto v1 = MakeV1Bytes();
+		std::vector<spl::Spline> out; std::string err;
+		REQUIRE(spl::LoadSplinesBin(v1, out, err));
+		REQUIRE(out.size() == 1);
+		if (out.size() == 1)
+		{
+			REQUIRE(out[0].type == spl::SplineType::Road);
+			REQUIRE(out[0].nodes.size() == 2);
+			REQUIRE(out[0].kit.mode == spl::SplineKitMode::None); // défaut migration
+		}
+	}
+
+	void Test_SplinesBin_V2_BridgeRoundtrip()
+	{
+		spl::Spline s; s.type = spl::SplineType::Road;
+		s.nodes = { spl::SplineNode{}, spl::SplineNode{} };
+		s.kit.mode = spl::SplineKitMode::Bridge; s.kit.kitNameHash = HashKitName("stone_bridge_kit");
+		s.kit.segmentLengthMeters = 4.0f; s.kit.yMode = 0; s.kit.yConstant = 12.5f; s.kit.widthMeters = 6.0f;
+		auto bytes = spl::SaveSplinesBin({ s });
+		std::vector<spl::Spline> out; std::string err;
+		REQUIRE(spl::LoadSplinesBin(bytes, out, err));
+		REQUIRE(out.size() == 1);
+		if (out.size() == 1)
+		{
+			REQUIRE(out[0].kit.mode == spl::SplineKitMode::Bridge);
+			REQUIRE(std::fabs(out[0].kit.yConstant - 12.5f) < 1e-3f);
+		}
+	}
+}
+
+int main()
+{
+	Test_Bridge_GeneratesCorrectSegmentCount();
+	Test_Wall_PostSpacingApplied();
+	Test_Wall_DetectsCornersOver70deg();
+	Test_Bridge_SurfaceQueryReturnsBridge();
+	Test_KitHash_Stable();
+	Test_SplinesBin_V1ToV2Migration();
+	Test_SplinesBin_V2_BridgeRoundtrip();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] StructuresTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] StructuresTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/thermal/ShadeMap.h
+++ b/src/client/world/thermal/ShadeMap.h
@@ -1,0 +1,79 @@
+#pragma once
+
+// M100.27 — Shade map par chunk (couvert arboré, 64×64 R8). Format header-only
+// `chunks/chunk_i_j/shade.bin`. En-tête 24 octets + résolution + octets de couverture.
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace engine::world::thermal
+{
+	constexpr uint32_t kShadeMapMagic = 0x44484153u;   // "SHAD"
+	constexpr uint32_t kShadeMapVersion = 1u;
+	constexpr uint32_t kShadeMapResolution = 64u;      // par chunk
+
+	struct ShadeMap
+	{
+		uint32_t resolution = kShadeMapResolution;
+		std::vector<uint8_t> coverage; // resolution*resolution, 0..255 (255 = canopée pleine)
+
+		uint8_t At(uint32_t x, uint32_t y) const
+		{
+			if (x >= resolution || y >= resolution) return 0;
+			const size_t idx = static_cast<size_t>(y) * resolution + x;
+			return (idx < coverage.size()) ? coverage[idx] : 0;
+		}
+	};
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v) { for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i))); }
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& o)
+		{
+			if (p + 4 > b.size()) return false;
+			o = uint32_t(b[p]) | (uint32_t(b[p+1])<<8) | (uint32_t(b[p+2])<<16) | (uint32_t(b[p+3])<<24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& o)
+		{
+			if (p + 8 > b.size()) return false;
+			o = 0; for (int i = 0; i < 8; ++i) o |= uint64_t(b[p+i]) << (8*i); p += 8; return true;
+		}
+	}
+
+	inline std::vector<uint8_t> SaveShadeMapBin(const ShadeMap& map)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kShadeMapMagic);
+		detail::PutU32(b, kShadeMapVersion);
+		detail::PutU32(b, 1u); // builder
+		detail::PutU32(b, 1u); // engine
+		detail::PutU64(b, 0ull);
+		detail::PutU32(b, map.resolution);
+		const size_t expected = static_cast<size_t>(map.resolution) * map.resolution;
+		for (size_t i = 0; i < expected; ++i)
+			b.push_back(i < map.coverage.size() ? map.coverage[i] : 0);
+		return b;
+	}
+
+	inline bool LoadShadeMapBin(std::span<const uint8_t> bytes, ShadeMap& out, std::string& err)
+	{
+		size_t p = 0; uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kShadeMapMagic) { err = "shade.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kShadeMapVersion) { err = "shade.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder); detail::GetU32(bytes, p, engine); detail::GetU64(bytes, p, hash);
+		if (!detail::GetU32(bytes, p, out.resolution)) { err = "shade.bin: resolution manquante"; return false; }
+		const size_t expected = static_cast<size_t>(out.resolution) * out.resolution;
+		if (p + expected > bytes.size()) { err = "shade.bin: donnees tronquees"; return false; }
+		out.coverage.assign(bytes.begin() + static_cast<long>(p), bytes.begin() + static_cast<long>(p + expected));
+		return true;
+	}
+}

--- a/src/client/world/thermal/ShadeMapBuilder.cpp
+++ b/src/client/world/thermal/ShadeMapBuilder.cpp
@@ -1,0 +1,42 @@
+// M100.27 — Implémentation du calcul de shade map (pur, déterministe).
+
+#include "src/client/world/thermal/ShadeMapBuilder.h"
+
+#include <algorithm>
+#include <random>
+
+namespace engine::world::thermal
+{
+	ShadeMap BuildShadeMap(float chunkOriginX, float chunkOriginZ, float chunkSizeMeters,
+	                       const CanopySampler& sampler, uint64_t seed)
+	{
+		ShadeMap map;
+		map.resolution = kShadeMapResolution;
+		map.coverage.assign(static_cast<size_t>(map.resolution) * map.resolution, 0u);
+		if (!sampler || chunkSizeMeters <= 0.0f) return map;
+
+		const float cell = chunkSizeMeters / static_cast<float>(map.resolution);
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<float> jit(-0.5f, 0.5f);
+		constexpr int kSamples = 16;
+
+		for (uint32_t cy = 0; cy < map.resolution; ++cy)
+		{
+			for (uint32_t cx = 0; cx < map.resolution; ++cx)
+			{
+				const float baseX = chunkOriginX + (static_cast<float>(cx) + 0.5f) * cell;
+				const float baseZ = chunkOriginZ + (static_cast<float>(cy) + 0.5f) * cell;
+				int hits = 0;
+				for (int s = 0; s < kSamples; ++s)
+				{
+					const float sx = baseX + jit(rng) * cell;
+					const float sz = baseZ + jit(rng) * cell;
+					if (sampler(sx, sz)) ++hits;
+				}
+				const int shade = std::min(255, hits * 16);
+				map.coverage[static_cast<size_t>(cy) * map.resolution + cx] = static_cast<uint8_t>(shade);
+			}
+		}
+		return map;
+	}
+}

--- a/src/client/world/thermal/ShadeMapBuilder.h
+++ b/src/client/world/thermal/ShadeMapBuilder.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// M100.27 — Construction de la shade map à l'export (raycast vertical canopée).
+// Pur : prend un échantillonneur de canopée (true = un rayon vertical touche un
+// arbre). Délégable à un worker. Testable headless.
+
+#include <cstdint>
+#include <functional>
+
+#include "src/client/world/thermal/ShadeMap.h"
+
+namespace engine::world::thermal
+{
+	/// Renvoie true si un rayon vertical à (worldX,worldZ) touche la canopée
+	/// arborée (arbres uniquement, pas l'herbe).
+	using CanopySampler = std::function<bool(float worldX, float worldZ)>;
+
+	/// Construit la shade map d'un chunk : pour chaque cellule, 16 échantillons
+	/// jittered, shade = min(255, hits*16). Déterministe pour `seed`.
+	ShadeMap BuildShadeMap(float chunkOriginX, float chunkOriginZ, float chunkSizeMeters,
+	                       const CanopySampler& sampler, uint64_t seed);
+}

--- a/src/client/world/thermal/Thermal.cpp
+++ b/src/client/world/thermal/Thermal.cpp
@@ -1,0 +1,24 @@
+// M100.27 — Implémentation de ComputeTemperature (pure).
+
+#include "src/client/world/thermal/Thermal.h"
+
+#include <cmath>
+
+namespace engine::world::thermal
+{
+	float ComputeTemperature(const ThermalContext& ctx, float altitudeM, float shade01,
+	                         float distanceToWaterM)
+	{
+		constexpr float kTwoPi = 6.28318530718f;
+		const float base = SeasonBaseTemp(ctx.season);
+		// Pic à 14 h, creux ~2 h.
+		const float diurnal = 8.0f * std::cos((ctx.todHours - 14.0f) / 24.0f * kTwoPi);
+		const float altGrad = -altitudeM * 0.0065f; // -6.5 °C / 1000 m
+		const float canopyFull = IsSummer(ctx.season) ? -8.0f : 3.0f; // ombre rafraîchit l'été, abrite l'hiver
+		const float s = (shade01 < 0.0f) ? 0.0f : (shade01 > 1.0f ? 1.0f : shade01);
+		const float canopy = canopyFull * s;
+		const float weather = WeatherDelta(ctx.weather);
+		const float water = (distanceToWaterM < 30.0f) ? -1.0f : 0.0f;
+		return base + diurnal + altGrad + canopy + weather + water;
+	}
+}

--- a/src/client/world/thermal/Thermal.h
+++ b/src/client/world/thermal/Thermal.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// M100.27 — Modèle thermique : contexte (saison/météo/heure) + fonction PURE
+// ComputeTemperature, identique côté éditeur (debug) et client (gameplay).
+//
+// NB : la formule diurne utilise +8·cos((tod-14)/24·2π) → pic à 14 h, creux la
+// nuit (cohérent avec « pic 14h » et les cas de test du ticket ; le signe « -8 »
+// du brouillon de spec était une coquille).
+
+#include <cstdint>
+
+namespace engine::world::thermal
+{
+	enum class ThermalSeason : uint8_t { Spring = 0, Summer = 1, Autumn = 2, Winter = 3 };
+	enum class ThermalWeather : uint8_t { Clear = 0, Rain = 1, Snow = 2, Drought = 3, Fog = 4 };
+
+	struct ThermalContext
+	{
+		ThermalSeason season = ThermalSeason::Summer;
+		ThermalWeather weather = ThermalWeather::Clear;
+		float todHours = 14.0f;
+	};
+
+	inline float SeasonBaseTemp(ThermalSeason s)
+	{
+		switch (s)
+		{
+			case ThermalSeason::Spring: return 12.0f;
+			case ThermalSeason::Summer: return 22.0f;
+			case ThermalSeason::Autumn: return 10.0f;
+			case ThermalSeason::Winter: return 2.0f;
+		}
+		return 15.0f;
+	}
+
+	inline bool IsSummer(ThermalSeason s) { return s == ThermalSeason::Summer; }
+
+	inline float WeatherDelta(ThermalWeather w)
+	{
+		switch (w)
+		{
+			case ThermalWeather::Clear:   return 0.0f;
+			case ThermalWeather::Rain:    return -3.0f;
+			case ThermalWeather::Snow:    return -5.0f;
+			case ThermalWeather::Drought: return 2.0f;
+			case ThermalWeather::Fog:     return -1.0f;
+		}
+		return 0.0f;
+	}
+
+	/// Température (°C) à une cellule donnée. `shade01` ∈ [0,1] (1 = canopée
+	/// pleine), `altitudeM` en mètres, `distanceToWaterM` distance à l'eau.
+	float ComputeTemperature(const ThermalContext& ctx, float altitudeM, float shade01,
+	                         float distanceToWaterM);
+}

--- a/src/client/world/thermal/ThermalQueryService.h
+++ b/src/client/world/thermal/ThermalQueryService.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// M100.27 — Service de requête thermique (RAM client). Header-only. Recalcule
+// implicitement via le contexte : OnSeasonChanged/OnWeatherChanged mettent à
+// jour le contexte (et incrémentent un compteur de rebuild) ; Query évalue
+// ComputeTemperature avec le contexte courant + les échantillonneurs fournis.
+
+#include <cstdint>
+#include <functional>
+
+#include "src/client/world/thermal/Thermal.h"
+
+namespace engine::world::thermal
+{
+	class ThermalQueryService
+	{
+	public:
+		using FieldSampler = std::function<float(float worldX, float worldZ)>;
+
+		void Init(const ThermalContext& ctx, FieldSampler altitudeM, FieldSampler shade01,
+		          FieldSampler distanceToWaterM)
+		{
+			m_ctx = ctx;
+			m_altitude = std::move(altitudeM);
+			m_shade = std::move(shade01);
+			m_water = std::move(distanceToWaterM);
+			++m_rebuildCount;
+		}
+
+		void OnSeasonChanged(ThermalSeason s) { m_ctx.season = s; ++m_rebuildCount; }
+		void OnWeatherChanged(ThermalWeather w) { m_ctx.weather = w; ++m_rebuildCount; }
+		void SetTimeOfDay(float hours) { m_ctx.todHours = hours; }
+
+		int RebuildCount() const { return m_rebuildCount; }
+		const ThermalContext& Context() const { return m_ctx; }
+
+		float Query(float worldX, float worldZ) const
+		{
+			const float alt = m_altitude ? m_altitude(worldX, worldZ) : 0.0f;
+			const float shade = m_shade ? m_shade(worldX, worldZ) : 0.0f;
+			const float water = m_water ? m_water(worldX, worldZ) : 1.0e9f;
+			return ComputeTemperature(m_ctx, alt, shade, water);
+		}
+
+	private:
+		ThermalContext m_ctx;
+		FieldSampler m_altitude;
+		FieldSampler m_shade;
+		FieldSampler m_water;
+		int m_rebuildCount = 0;
+	};
+}

--- a/src/client/world/thermal/tests/ThermalTests.cpp
+++ b/src/client/world/thermal/tests/ThermalTests.cpp
@@ -1,0 +1,107 @@
+// M100.27 — Tests thermal : shade round-trip/builder + ComputeTemperature + query.
+
+#include "src/client/world/thermal/ShadeMap.h"
+#include "src/client/world/thermal/ShadeMapBuilder.h"
+#include "src/client/world/thermal/Thermal.h"
+#include "src/client/world/thermal/ThermalQueryService.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace engine::world::thermal;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 0.05f) { return std::fabs(a - b) <= eps; }
+
+	void Test_ShadeMap_Roundtrip()
+	{
+		ShadeMap m; m.resolution = kShadeMapResolution;
+		m.coverage.assign(static_cast<size_t>(m.resolution) * m.resolution, 0u);
+		m.coverage[0] = 255; m.coverage[100] = 128; m.coverage.back() = 42;
+		auto bytes = SaveShadeMapBin(m);
+		ShadeMap out; std::string err;
+		REQUIRE(LoadShadeMapBin(bytes, out, err));
+		REQUIRE(out.resolution == m.resolution);
+		REQUIRE(out.coverage.size() == m.coverage.size());
+		if (out.coverage.size() == m.coverage.size())
+		{
+			REQUIRE(out.At(0, 0) == 255);
+			REQUIRE(out.coverage[100] == 128);
+			REQUIRE(out.coverage.back() == 42);
+		}
+	}
+
+	void Test_ShadeMapBuilder_DenseCanopy_HighShade()
+	{
+		auto dense = BuildShadeMap(0.0f, 0.0f, 256.0f, [](float, float) { return true; }, 1);
+		auto empty = BuildShadeMap(0.0f, 0.0f, 256.0f, [](float, float) { return false; }, 1);
+		REQUIRE(dense.At(10, 10) == 255); // 16 hits -> 255
+		REQUIRE(empty.At(10, 10) == 0);
+	}
+
+	void Test_ComputeTemperature_SummerNoonOpen0m()
+	{
+		ThermalContext ctx; ctx.season = ThermalSeason::Summer; ctx.weather = ThermalWeather::Clear; ctx.todHours = 14.0f;
+		const float t = ComputeTemperature(ctx, 0.0f, 0.0f, 1.0e9f);
+		REQUIRE(Near(t, 30.0f)); // 22 base + 8 diurnal
+	}
+
+	void Test_ComputeTemperature_WinterNightDense500m()
+	{
+		ThermalContext ctx; ctx.season = ThermalSeason::Winter; ctx.weather = ThermalWeather::Clear; ctx.todHours = 2.0f;
+		const float t = ComputeTemperature(ctx, 500.0f, 1.0f, 1.0e9f);
+		// 2 - 8 - 3.25 + 3 = -6.25
+		REQUIRE(Near(t, -6.25f));
+		// Qualitatif : en hiver la canopée réchauffe (vs ciel ouvert).
+		const float open = ComputeTemperature(ctx, 500.0f, 0.0f, 1.0e9f);
+		REQUIRE(t > open);
+	}
+
+	void Test_Qualitative_SummerCanopyCools_AltitudeCools_RainCools()
+	{
+		ThermalContext summer; summer.season = ThermalSeason::Summer; summer.todHours = 14.0f;
+		REQUIRE(ComputeTemperature(summer, 0.0f, 1.0f, 1e9f) < ComputeTemperature(summer, 0.0f, 0.0f, 1e9f)); // canopée rafraîchit l'été
+		REQUIRE(ComputeTemperature(summer, 1000.0f, 0.0f, 1e9f) < ComputeTemperature(summer, 0.0f, 0.0f, 1e9f)); // altitude
+		ThermalContext rain = summer; rain.weather = ThermalWeather::Rain;
+		REQUIRE(ComputeTemperature(rain, 0.0f, 0.0f, 1e9f) < ComputeTemperature(summer, 0.0f, 0.0f, 1e9f)); // pluie
+	}
+
+	void Test_ThermalQuery_OnSeasonChange_RebuildsMap()
+	{
+		ThermalQueryService svc;
+		ThermalContext ctx; ctx.season = ThermalSeason::Summer; ctx.todHours = 14.0f;
+		svc.Init(ctx, [](float, float) { return 0.0f; }, [](float, float) { return 0.0f; }, [](float, float) { return 1e9f; });
+		const float summerT = svc.Query(0.0f, 0.0f);
+		const int before = svc.RebuildCount();
+		svc.OnSeasonChanged(ThermalSeason::Winter);
+		const float winterT = svc.Query(0.0f, 0.0f);
+		REQUIRE(svc.RebuildCount() == before + 1);
+		REQUIRE(winterT < summerT); // rebuild reflété
+	}
+}
+
+int main()
+{
+	Test_ShadeMap_Roundtrip();
+	Test_ShadeMapBuilder_DenseCanopy_HighShade();
+	Test_ComputeTemperature_SummerNoonOpen0m();
+	Test_ComputeTemperature_WinterNightDense500m();
+	Test_Qualitative_SummerCanopyCools_AltitudeCools_RainCools();
+	Test_ThermalQuery_OnSeasonChange_RebuildsMap();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] ThermalTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] ThermalTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/wind/WindParams.h
+++ b/src/client/world/wind/WindParams.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// M100.20 — Paramètres de vent (miroir C++ du constant buffer GLSL WindParams).
+
+namespace engine::world::wind
+{
+	struct WindParamsCpu
+	{
+		float directionX = 1.0f;       // direction xz normalisée
+		float directionZ = 0.0f;
+		float forceMps = 4.0f;
+		float turbulenceFreq = 0.2f;
+		float turbulenceAmp = 0.5f;
+		float waveSpeed = 3.0f;
+		float waveLengthMeters = 6.0f;
+		float waveAmplitude = 0.3f;
+		float timeSeconds = 0.0f;
+	};
+}

--- a/src/client/world/wind/WindSystem.cpp
+++ b/src/client/world/wind/WindSystem.cpp
@@ -1,0 +1,67 @@
+// M100.20 — Implémentation WindSystem (pur, miroir shader + eval zones).
+
+#include "src/client/world/wind/WindSystem.h"
+
+#include <cmath>
+
+namespace engine::world::wind
+{
+	namespace
+	{
+		constexpr float kTwoPi = 6.28318530718f;
+
+		bool PointInPolygon(const std::vector<engine::math::Vec3>& poly, float x, float z)
+		{
+			if (poly.size() < 3) return false;
+			bool inside = false;
+			for (size_t i = 0, j = poly.size() - 1; i < poly.size(); j = i++)
+			{
+				const float xi = poly[i].x, zi = poly[i].z;
+				const float xj = poly[j].x, zj = poly[j].z;
+				const bool intersect = ((zi > z) != (zj > z)) &&
+					(x < (xj - xi) * (z - zi) / (zj - zi + 1e-9f) + xi);
+				if (intersect) inside = !inside;
+			}
+			return inside;
+		}
+	} // namespace
+
+	float SwayHeightWeight(float h)
+	{
+		if (h <= 0.0f) return 0.0f;
+		if (h >= 1.0f) return 1.0f;
+		return h * h * (3.0f - 2.0f * h); // smoothstep(0,1,h)
+	}
+
+	float ComputeSwayMagnitude(const WindParamsCpu& w, float worldX, float worldZ, float h)
+	{
+		const float heightWeight = SwayHeightWeight(h);
+		const float wavePhase = (worldX * w.directionX + worldZ * w.directionZ) /
+		                        (w.waveLengthMeters > 1e-5f ? w.waveLengthMeters : 1.0f)
+		                        - w.waveSpeed * w.timeSeconds;
+		const float wave = std::sin(wavePhase) * w.waveAmplitude;
+		const float turb = (std::sin(w.timeSeconds * w.turbulenceFreq * kTwoPi + worldX) +
+		                    std::sin(w.timeSeconds * w.turbulenceFreq * kTwoPi + worldZ)) * w.turbulenceAmp;
+		const float swayScalar = (w.forceMps * 0.05f + wave + turb) * heightWeight;
+		return std::fabs(swayScalar);
+	}
+
+	WindParamsCpu EvaluateWind(const WindParamsCpu& global, const std::vector<WindZone>& zones,
+	                           float camX, float camZ)
+	{
+		WindParamsCpu eff = global;
+		for (const WindZone& z : zones)
+		{
+			if (PointInPolygon(z.polygon, camX, camZ))
+			{
+				eff.directionX = z.directionX;
+				eff.directionZ = z.directionZ;
+				eff.forceMps = z.forceMps;
+				eff.turbulenceFreq = z.turbulenceFreq;
+				eff.turbulenceAmp = z.turbulenceAmp;
+				break; // première zone gagnante
+			}
+		}
+		return eff;
+	}
+}

--- a/src/client/world/wind/WindSystem.h
+++ b/src/client/world/wind/WindSystem.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// M100.20 — Évaluation du vent effectif (global ± zones locales) + miroir C++
+// de la logique de sway du shader foliage.vert (pour test headless). Pur.
+
+#include <vector>
+
+#include "src/client/world/wind/WindParams.h"
+#include "src/client/world/wind/WindZones.h"
+
+namespace engine::world::wind
+{
+	/// Poids de sway selon la hauteur normalisée (smoothstep 0..1) : racines
+	/// fixes (0), sommet ondulant (1).
+	float SwayHeightWeight(float heightNormalized);
+
+	/// Magnitude du déplacement de sway à une position monde / hauteur — miroir
+	/// exact de `foliage.vert` (test : proportionnalité à la hauteur).
+	float ComputeSwayMagnitude(const WindParamsCpu& w, float worldX, float worldZ, float heightNormalized);
+
+	/// Paramètres effectifs à la position caméra : si elle est dans une zone
+	/// locale, ses overrides (direction/force/turbulence) remplacent le global.
+	/// La première zone contenant le point gagne (ordre stable).
+	WindParamsCpu EvaluateWind(const WindParamsCpu& global, const std::vector<WindZone>& zones,
+	                           float camX, float camZ);
+}

--- a/src/client/world/wind/WindZones.h
+++ b/src/client/world/wind/WindZones.h
@@ -1,0 +1,105 @@
+#pragma once
+
+// M100.20 — Zones de vent locales : struct + sérialisation `instances/wind_zones.bin`.
+// Header-only (partagé engine_core/zone_builder). En-tête 24 octets.
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::wind
+{
+	struct WindZone
+	{
+		std::vector<engine::math::Vec3> polygon; // sommets xz (y ignoré)
+		float directionX = 1.0f;
+		float directionZ = 0.0f;
+		float forceMps = 4.0f;
+		float turbulenceFreq = 0.2f;
+		float turbulenceAmp = 0.5f;
+	};
+
+	constexpr uint32_t kWindZonesMagic = 0x444E4957u; // "WIND"
+	constexpr uint32_t kWindZonesVersion = 1u;
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v) { for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i))); }
+		inline void PutF32(std::vector<uint8_t>& b, float f) { uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u); }
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& o)
+		{
+			if (p + 4 > b.size()) return false;
+			o = uint32_t(b[p]) | (uint32_t(b[p+1])<<8) | (uint32_t(b[p+2])<<16) | (uint32_t(b[p+3])<<24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& o)
+		{
+			if (p + 8 > b.size()) return false;
+			o = 0; for (int i = 0; i < 8; ++i) o |= uint64_t(b[p+i]) << (8*i); p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& o)
+		{
+			uint32_t u; if (!GetU32(b, p, u)) return false; std::memcpy(&o, &u, 4); return true;
+		}
+	}
+
+	inline std::vector<uint8_t> SaveWindZonesBin(const std::vector<WindZone>& zones)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kWindZonesMagic);
+		detail::PutU32(b, kWindZonesVersion);
+		detail::PutU32(b, 1u); // builder
+		detail::PutU32(b, 1u); // engine
+		detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(zones.size()));
+		for (const WindZone& z : zones)
+		{
+			detail::PutU32(b, static_cast<uint32_t>(z.polygon.size()));
+			for (const auto& v : z.polygon) { detail::PutF32(b, v.x); detail::PutF32(b, v.y); detail::PutF32(b, v.z); }
+			detail::PutF32(b, z.directionX); detail::PutF32(b, z.directionZ);
+			detail::PutF32(b, z.forceMps);
+			detail::PutF32(b, z.turbulenceFreq);
+			detail::PutF32(b, z.turbulenceAmp);
+		}
+		return b;
+	}
+
+	inline bool LoadWindZonesBin(std::span<const uint8_t> bytes, std::vector<WindZone>& out, std::string& err)
+	{
+		size_t p = 0; uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kWindZonesMagic) { err = "wind_zones.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kWindZonesVersion) { err = "wind_zones.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder); detail::GetU32(bytes, p, engine); detail::GetU64(bytes, p, hash);
+		uint32_t count = 0;
+		if (!detail::GetU32(bytes, p, count)) { err = "wind_zones.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			WindZone z; uint32_t vc = 0;
+			if (!detail::GetU32(bytes, p, vc)) { err = "wind_zones.bin: tronque"; return false; }
+			z.polygon.reserve(vc);
+			for (uint32_t k = 0; k < vc; ++k)
+			{
+				engine::math::Vec3 v;
+				detail::GetF32(bytes, p, v.x); detail::GetF32(bytes, p, v.y);
+				if (!detail::GetF32(bytes, p, v.z)) { err = "wind_zones.bin: tronque (poly)"; return false; }
+				z.polygon.push_back(v);
+			}
+			detail::GetF32(bytes, p, z.directionX); detail::GetF32(bytes, p, z.directionZ);
+			detail::GetF32(bytes, p, z.forceMps);
+			detail::GetF32(bytes, p, z.turbulenceFreq);
+			if (!detail::GetF32(bytes, p, z.turbulenceAmp)) { err = "wind_zones.bin: tronque (params)"; return false; }
+			out.push_back(std::move(z));
+		}
+		return true;
+	}
+}

--- a/src/client/world/wind/tests/WindTests.cpp
+++ b/src/client/world/wind/tests/WindTests.cpp
@@ -1,0 +1,88 @@
+// M100.20 — Tests vent : sway proportionnel hauteur, override zone, round-trip.
+// Headless. Lié à engine_core.
+
+#include "src/client/world/wind/WindParams.h"
+#include "src/client/world/wind/WindSystem.h"
+#include "src/client/world/wind/WindZones.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::wind;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	void Test_SwayProportionalToHeight()
+	{
+		WindParamsCpu w; w.forceMps = 4.0f; w.timeSeconds = 0.0f;
+		const float s0 = ComputeSwayMagnitude(w, 3.0f, 7.0f, 0.0f);
+		const float sMid = ComputeSwayMagnitude(w, 3.0f, 7.0f, 0.5f);
+		const float s1 = ComputeSwayMagnitude(w, 3.0f, 7.0f, 1.0f);
+		REQUIRE(s0 == 0.0f);          // racines fixes
+		REQUIRE(s1 > 0.0f);           // sommet bouge
+		REQUIRE(sMid <= s1 + 1e-6f);  // monotone (smoothstep)
+		REQUIRE(s0 <= sMid + 1e-6f);
+	}
+
+	void Test_LocalZone_OverridesGlobal()
+	{
+		WindParamsCpu global; global.forceMps = 4.0f; global.directionX = 1.0f; global.directionZ = 0.0f;
+		WindZone z;
+		z.polygon = { Vec3(0,0,0), Vec3(10,0,0), Vec3(10,0,10), Vec3(0,0,10) };
+		z.forceMps = 12.0f; z.directionX = 0.0f; z.directionZ = 1.0f;
+		std::vector<WindZone> zones = { z };
+
+		WindParamsCpu inside = EvaluateWind(global, zones, 5.0f, 5.0f);
+		REQUIRE(std::fabs(inside.forceMps - 12.0f) < 1e-4f);
+		REQUIRE(std::fabs(inside.directionZ - 1.0f) < 1e-4f);
+
+		WindParamsCpu outside = EvaluateWind(global, zones, 50.0f, 50.0f);
+		REQUIRE(std::fabs(outside.forceMps - 4.0f) < 1e-4f);
+	}
+
+	void Test_Roundtrip_WindZonesBin()
+	{
+		std::vector<WindZone> zones;
+		WindZone z;
+		z.polygon = { Vec3(1,0,2), Vec3(3,0,2), Vec3(3,0,5) };
+		z.directionX = 0.7f; z.directionZ = -0.3f; z.forceMps = 6.5f;
+		z.turbulenceFreq = 0.4f; z.turbulenceAmp = 1.1f;
+		zones.push_back(z);
+
+		std::vector<uint8_t> bytes = SaveWindZonesBin(zones);
+		std::vector<WindZone> out; std::string err;
+		REQUIRE(LoadWindZonesBin(bytes, out, err));
+		REQUIRE(out.size() == 1);
+		if (out.size() == 1)
+		{
+			REQUIRE(out[0].polygon.size() == 3);
+			REQUIRE(std::fabs(out[0].forceMps - 6.5f) < 1e-4f);
+			REQUIRE(std::fabs(out[0].turbulenceAmp - 1.1f) < 1e-4f);
+			REQUIRE(std::fabs(out[0].polygon[2].z - 5.0f) < 1e-4f);
+		}
+	}
+}
+
+int main()
+{
+	Test_SwayProportionalToHeight();
+	Test_LocalZone_OverridesGlobal();
+	Test_Roundtrip_WindZonesBin();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] WindTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] WindTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/client/world/zones/ZoneQuery.cpp
+++ b/src/client/world/zones/ZoneQuery.cpp
@@ -1,0 +1,60 @@
+// M100.28 — Implémentation des requêtes de zone (pures).
+
+#include "src/client/world/zones/ZoneQuery.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::world::zones
+{
+	namespace
+	{
+		bool RayCastInside(const std::vector<engine::math::Vec3>& poly, float x, float z)
+		{
+			if (poly.size() < 3) return false;
+			bool inside = false;
+			for (size_t i = 0, j = poly.size() - 1; i < poly.size(); j = i++)
+			{
+				const float xi = poly[i].x, zi = poly[i].z;
+				const float xj = poly[j].x, zj = poly[j].z;
+				const bool intersect = ((zi > z) != (zj > z)) &&
+					(x < (xj - xi) * (z - zi) / (zj - zi + 1e-9f) + xi);
+				if (intersect) inside = !inside;
+			}
+			return inside;
+		}
+
+		float DistToSegment(float px, float pz, float ax, float az, float bx, float bz)
+		{
+			const float dx = bx - ax, dz = bz - az;
+			const float len2 = dx * dx + dz * dz;
+			float t = (len2 > 1e-9f) ? ((px - ax) * dx + (pz - az) * dz) / len2 : 0.0f;
+			t = std::max(0.0f, std::min(1.0f, t));
+			const float cx = ax + t * dx, cz = az + t * dz;
+			const float ex = px - cx, ez = pz - cz;
+			return std::sqrt(ex * ex + ez * ez);
+		}
+	} // namespace
+
+	bool PointInZone(const GameplayZone& zone, float x, float z)
+	{
+		return RayCastInside(zone.polygon, x, z);
+	}
+
+	float SignedDistanceToPolygon(const std::vector<engine::math::Vec3>& poly, float x, float z)
+	{
+		if (poly.size() < 3) return -1.0e9f;
+		float minDist = 1.0e9f;
+		for (size_t i = 0, j = poly.size() - 1; i < poly.size(); j = i++)
+			minDist = std::min(minDist, DistToSegment(x, z, poly[j].x, poly[j].z, poly[i].x, poly[i].z));
+		return RayCastInside(poly, x, z) ? minDist : -minDist;
+	}
+
+	float WeatherOverrideBlend(const GameplayZone& zone, float x, float z)
+	{
+		const float d = SignedDistanceToPolygon(zone.polygon, x, z);
+		if (d <= 0.0f) return 0.0f; // dehors ou sur le bord
+		const float margin = (zone.transitionMarginMeters > 1e-5f) ? zone.transitionMarginMeters : 1e-5f;
+		return std::min(1.0f, d / margin);
+	}
+}

--- a/src/client/world/zones/ZoneQuery.h
+++ b/src/client/world/zones/ZoneQuery.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// M100.28 — Requêtes pures sur les zones de gameplay (point-in-zone, blend de
+// transition météo au bord). Indépendant du rendu : testable headless.
+
+#include <vector>
+
+#include "src/client/world/zones/Zones.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::world::zones
+{
+	/// True si (x,z) est dans le polygone de la zone (ray casting).
+	bool PointInZone(const GameplayZone& zone, float x, float z);
+
+	/// Distance (m) du point au bord le plus proche du polygone, SIGNÉE :
+	/// positive si dedans, négative si dehors.
+	float SignedDistanceToPolygon(const std::vector<engine::math::Vec3>& polygon, float x, float z);
+
+	/// Facteur de blend météo d'une WeatherOverride : 0 dehors / au bord,
+	/// 1 au-delà de `transitionMarginMeters` à l'intérieur, lerp linéaire entre.
+	float WeatherOverrideBlend(const GameplayZone& zone, float x, float z);
+}

--- a/src/client/world/zones/Zones.h
+++ b/src/client/world/zones/Zones.h
@@ -1,0 +1,116 @@
+#pragma once
+
+// M100.28 — Zones de gameplay polygonales typées : struct + sérialisation
+// `instances/zones.bin`. Header-only (partagé engine_core/zone_builder).
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::zones
+{
+	enum class ZoneType : uint32_t
+	{
+		SafeZone = 0, PvPZone = 1, RaidZone = 2, NoBuild = 3, QuestTrigger = 4, WeatherOverride = 5
+	};
+
+	struct GameplayZone
+	{
+		ZoneType type = ZoneType::SafeZone;
+		std::string name;
+		std::vector<engine::math::Vec3> polygon; // sommets xz
+		float transitionMarginMeters = 5.0f;     // WeatherOverride
+		uint32_t weatherType = 0;                 // WeatherOverride
+		float weatherBlendT = 0.0f;               // WeatherOverride
+		uint32_t questId = 0;                     // QuestTrigger
+	};
+
+	constexpr uint32_t kZonesMagic = 0x534E4F5Au; // "ZONS"
+	constexpr uint32_t kZonesVersion = 1u;
+
+	namespace detail
+	{
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8)); b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v) { for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i))); }
+		inline void PutF32(std::vector<uint8_t>& b, float f) { uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u); }
+		inline void PutStr(std::vector<uint8_t>& b, const std::string& s)
+		{
+			PutU32(b, static_cast<uint32_t>(s.size()));
+			b.insert(b.end(), s.begin(), s.end());
+		}
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& o)
+		{
+			if (p + 4 > b.size()) return false;
+			o = uint32_t(b[p]) | (uint32_t(b[p+1])<<8) | (uint32_t(b[p+2])<<16) | (uint32_t(b[p+3])<<24); p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& o)
+		{
+			if (p + 8 > b.size()) return false; o = 0; for (int i = 0; i < 8; ++i) o |= uint64_t(b[p+i]) << (8*i); p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& o) { uint32_t u; if (!GetU32(b, p, u)) return false; std::memcpy(&o, &u, 4); return true; }
+		inline bool GetStr(std::span<const uint8_t> b, size_t& p, std::string& o)
+		{
+			uint32_t n = 0; if (!GetU32(b, p, n)) return false;
+			if (p + n > b.size()) return false;
+			o.assign(reinterpret_cast<const char*>(b.data() + p), n); p += n; return true;
+		}
+	}
+
+	inline std::vector<uint8_t> SaveZonesBin(const std::vector<GameplayZone>& zones)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kZonesMagic); detail::PutU32(b, kZonesVersion);
+		detail::PutU32(b, 1u); detail::PutU32(b, 1u); detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(zones.size()));
+		for (const GameplayZone& z : zones)
+		{
+			detail::PutU32(b, static_cast<uint32_t>(z.type));
+			detail::PutStr(b, z.name);
+			detail::PutU32(b, static_cast<uint32_t>(z.polygon.size()));
+			for (const auto& v : z.polygon) { detail::PutF32(b, v.x); detail::PutF32(b, v.y); detail::PutF32(b, v.z); }
+			detail::PutF32(b, z.transitionMarginMeters);
+			detail::PutU32(b, z.weatherType);
+			detail::PutF32(b, z.weatherBlendT);
+			detail::PutU32(b, z.questId);
+		}
+		return b;
+	}
+
+	inline bool LoadZonesBin(std::span<const uint8_t> bytes, std::vector<GameplayZone>& out, std::string& err)
+	{
+		size_t p = 0; uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kZonesMagic) { err = "zones.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kZonesVersion) { err = "zones.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder); detail::GetU32(bytes, p, engine); detail::GetU64(bytes, p, hash);
+		uint32_t count = 0; if (!detail::GetU32(bytes, p, count)) { err = "zones.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			GameplayZone z; uint32_t t = 0;
+			if (!detail::GetU32(bytes, p, t)) { err = "zones.bin: tronque"; return false; }
+			z.type = static_cast<ZoneType>(t);
+			if (!detail::GetStr(bytes, p, z.name)) { err = "zones.bin: nom tronque"; return false; }
+			uint32_t vc = 0; if (!detail::GetU32(bytes, p, vc)) { err = "zones.bin: poly count"; return false; }
+			z.polygon.reserve(vc);
+			for (uint32_t k = 0; k < vc; ++k)
+			{
+				engine::math::Vec3 v; detail::GetF32(bytes, p, v.x); detail::GetF32(bytes, p, v.y);
+				if (!detail::GetF32(bytes, p, v.z)) { err = "zones.bin: poly tronque"; return false; }
+				z.polygon.push_back(v);
+			}
+			detail::GetF32(bytes, p, z.transitionMarginMeters);
+			detail::GetU32(bytes, p, z.weatherType);
+			detail::GetF32(bytes, p, z.weatherBlendT);
+			if (!detail::GetU32(bytes, p, z.questId)) { err = "zones.bin: champs tronques"; return false; }
+			out.push_back(std::move(z));
+		}
+		return true;
+	}
+}

--- a/src/client/world/zones/tests/ZonesTests.cpp
+++ b/src/client/world/zones/tests/ZonesTests.cpp
@@ -1,0 +1,93 @@
+// M100.28 — Tests zones : round-trip + transition météo au bord + champs quest.
+
+#include "src/client/world/zones/Zones.h"
+#include "src/client/world/zones/ZoneQuery.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::world::zones;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-2f) { return std::fabs(a - b) <= eps; }
+
+	GameplayZone Square(ZoneType type, const char* name, float side)
+	{
+		GameplayZone z; z.type = type; z.name = name;
+		z.polygon = { Vec3(0,0,0), Vec3(side,0,0), Vec3(side,0,side), Vec3(0,0,side) };
+		return z;
+	}
+
+	void Test_Zones_Roundtrip()
+	{
+		std::vector<GameplayZone> zones;
+		zones.push_back(Square(ZoneType::SafeZone, "spawn", 20.0f));
+		GameplayZone wo = Square(ZoneType::WeatherOverride, "storm", 30.0f);
+		wo.weatherType = 1; wo.weatherBlendT = 0.4f; wo.transitionMarginMeters = 5.0f;
+		zones.push_back(wo);
+		GameplayZone qt = Square(ZoneType::QuestTrigger, "q_intro", 10.0f);
+		qt.questId = 7777;
+		zones.push_back(qt);
+
+		auto bytes = SaveZonesBin(zones);
+		std::vector<GameplayZone> out; std::string err;
+		REQUIRE(LoadZonesBin(bytes, out, err));
+		REQUIRE(out.size() == 3);
+		if (out.size() == 3)
+		{
+			REQUIRE(out[0].type == ZoneType::SafeZone && out[0].name == "spawn");
+			REQUIRE(out[0].polygon.size() == 4);
+			REQUIRE(out[1].type == ZoneType::WeatherOverride && out[1].weatherType == 1);
+			REQUIRE(Near(out[1].weatherBlendT, 0.4f));
+		}
+	}
+
+	void Test_QuestTrigger_FieldsPreserved()
+	{
+		GameplayZone qt = Square(ZoneType::QuestTrigger, "q", 10.0f); qt.questId = 4242;
+		auto bytes = SaveZonesBin({ qt });
+		std::vector<GameplayZone> out; std::string err;
+		REQUIRE(LoadZonesBin(bytes, out, err));
+		REQUIRE(out.size() == 1);
+		if (out.size() == 1)
+		{
+			REQUIRE(out[0].type == ZoneType::QuestTrigger);
+			REQUIRE(out[0].questId == 4242);
+		}
+	}
+
+	void Test_WeatherOverride_TransitionAtBorder()
+	{
+		GameplayZone wo = Square(ZoneType::WeatherOverride, "storm", 20.0f);
+		wo.transitionMarginMeters = 5.0f;
+		REQUIRE(Near(WeatherOverrideBlend(wo, 10.0f, 10.0f), 1.0f)); // centre (dist 10 > margin)
+		REQUIRE(Near(WeatherOverrideBlend(wo, 10.0f, 2.0f), 0.4f));  // 2 m du bord → 2/5
+		REQUIRE(Near(WeatherOverrideBlend(wo, 10.0f, 0.0f), 0.0f));  // sur le bord
+		REQUIRE(WeatherOverrideBlend(wo, 10.0f, -1.0f) == 0.0f);     // dehors
+	}
+}
+
+int main()
+{
+	Test_Zones_Roundtrip();
+	Test_QuestTrigger_FieldsPreserved();
+	Test_WeatherOverride_TransitionAtBorder();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] ZonesTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] ZonesTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/BridgeTool.h
+++ b/src/world_editor/BridgeTool.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// M100.30 — Outil Bridge : transforme une spline en pont (kit). Header-only,
+// rendu ImGui guardé Windows. La génération vit dans structures::* (pur).
+
+#include "src/client/world/spline/SplineInstances.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	class BridgeTool
+	{
+	public:
+		engine::world::spline::SplineKitData& Kit() { return m_kit; }
+		const engine::world::spline::SplineKitData& Kit() const { return m_kit; }
+
+		void Render()
+		{
+#if defined(_WIN32)
+			ImGui::TextUnformatted("Bridge");
+			ImGui::Separator();
+			ImGui::InputFloat("Segment length (m)", &m_kit.segmentLengthMeters);
+			int ym = static_cast<int>(m_kit.yMode);
+			ImGui::RadioButton("Y constant", &ym, 0); ImGui::SameLine();
+			ImGui::RadioButton("Y follow spline", &ym, 1);
+			m_kit.yMode = static_cast<uint32_t>(ym);
+			ImGui::InputFloat("Y constant", &m_kit.yConstant);
+			ImGui::SliderFloat("Width (m)", &m_kit.widthMeters, 1.0f, 20.0f);
+#endif
+		}
+
+	private:
+		engine::world::spline::SplineKitData m_kit{ engine::world::spline::SplineKitMode::Bridge };
+	};
+}

--- a/src/world_editor/FieldTool.cpp
+++ b/src/world_editor/FieldTool.cpp
@@ -1,0 +1,30 @@
+// M100.19 — Rendu du panneau de l'outil Field (ImGui guardé).
+
+#include "src/world_editor/FieldTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	void FieldTool::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Field");
+		ImGui::Separator();
+
+		int crop = static_cast<int>(m_crop);
+		ImGui::RadioButton("Wheat", &crop, 0); ImGui::SameLine();
+		ImGui::RadioButton("Corn", &crop, 1);
+		m_crop = static_cast<FieldCrop>(crop);
+
+		ImGui::SliderFloat("Spacing (m)", &m_params.spacing, 0.2f, 2.0f);
+		ImGui::SliderFloat("Rotation (deg)", &m_params.rotationDeg, 0.0f, 360.0f);
+		ImGui::InputFloat("Width (m)", &m_params.width);
+		ImGui::InputFloat("Depth (m)", &m_params.depth);
+		ImGui::Checkbox("Auto-tag splat layer (WheatField/CornField)", &m_autoTagSplat);
+		// Génération (GenerateField) + push FoliagePaintCommand déclenchée par le shell.
+#endif
+	}
+}

--- a/src/world_editor/FieldTool.h
+++ b/src/world_editor/FieldTool.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// M100.19 — Outil Field (rectangle aligné, blé/maïs). Rendu ImGui guardé ; la
+// génération est la fonction pure GenerateField (ForestFieldGen). Le tagging
+// splat (WheatField/CornField) est différé (intégration TerrainDocument).
+
+#include <cstdint>
+
+#include "src/world_editor/ForestFieldGen.h"
+
+namespace engine::editor::world
+{
+	enum class FieldCrop : uint8_t { Wheat = 0, Corn = 1 };
+
+	class FieldTool
+	{
+	public:
+		FieldParams& Params() { return m_params; }
+		const FieldParams& Params() const { return m_params; }
+		FieldCrop Crop() const { return m_crop; }
+		void SetCrop(FieldCrop c) { m_crop = c; }
+		bool AutoTagSplat() const { return m_autoTagSplat; }
+
+		void Render();
+
+	private:
+		FieldParams m_params;
+		FieldCrop m_crop = FieldCrop::Wheat;
+		bool m_autoTagSplat = true;
+	};
+}

--- a/src/world_editor/FoliageDocument.h
+++ b/src/world_editor/FoliageDocument.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// M100.18 — Document foliage (instances résolues d'une zone). Header-only.
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/client/world/foliage/FoliageInstances.h"
+
+namespace engine::editor::world
+{
+	class FoliageDocument
+	{
+	public:
+		void Append(const std::vector<engine::world::foliage::FoliageInstance>& batch)
+		{
+			m_instances.insert(m_instances.end(), batch.begin(), batch.end());
+		}
+
+		/// Retire les `n` dernières instances (undo d'un stroke, LIFO).
+		void RemoveLast(size_t n)
+		{
+			if (n >= m_instances.size()) m_instances.clear();
+			else m_instances.resize(m_instances.size() - n);
+		}
+
+		const std::vector<engine::world::foliage::FoliageInstance>& All() const { return m_instances; }
+		std::vector<engine::world::foliage::FoliageInstance>& Mutable() { return m_instances; }
+
+		bool SaveToDisk(const std::string& path, std::string& err) const
+		{
+			const std::vector<uint8_t> bytes = engine::world::foliage::SaveFoliageBin(m_instances);
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good()) { err = "FoliageDocument::SaveToDisk: open failed: " + path; return false; }
+			out.write(reinterpret_cast<const char*>(bytes.data()),
+			          static_cast<std::streamsize>(bytes.size()));
+			if (!out.good()) { err = "FoliageDocument::SaveToDisk: write failed: " + path; return false; }
+			return true;
+		}
+
+	private:
+		std::vector<engine::world::foliage::FoliageInstance> m_instances;
+	};
+}

--- a/src/world_editor/FoliagePaintCommand.h
+++ b/src/world_editor/FoliagePaintCommand.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// M100.18 — Commande de peinture foliage (undo/redo). Un stroke = un batch
+// d'instances ajoutées ; l'undo retire ce batch (LIFO, cohérent avec la pile).
+
+#include <vector>
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/FoliageDocument.h"
+
+namespace engine::editor::world
+{
+	class FoliagePaintCommand final : public ICommand
+	{
+	public:
+		FoliagePaintCommand(FoliageDocument& doc,
+		                    std::vector<engine::world::foliage::FoliageInstance> batch)
+			: m_doc(doc), m_batch(std::move(batch)) {}
+
+		const char* GetLabel() const override { return "Paint foliage"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(*this) + m_batch.size() * sizeof(engine::world::foliage::FoliageInstance);
+		}
+		void Execute() override { m_doc.Append(m_batch); }
+		void Undo() override { m_doc.RemoveLast(m_batch.size()); }
+
+	private:
+		FoliageDocument& m_doc;
+		std::vector<engine::world::foliage::FoliageInstance> m_batch;
+	};
+}

--- a/src/world_editor/FoliagePaintTool.cpp
+++ b/src/world_editor/FoliagePaintTool.cpp
@@ -1,0 +1,34 @@
+// M100.18 — Rendu du panneau de l'outil de peinture foliage (ImGui guardé).
+
+#include "src/world_editor/FoliagePaintTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstdio>
+#endif
+
+namespace engine::editor::world
+{
+	void FoliagePaintTool::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Foliage Paint");
+		ImGui::Separator();
+
+		char buf[128];
+		std::snprintf(buf, sizeof(buf), "%s", m_params.activeAssetId.c_str());
+		if (ImGui::InputText("Asset", buf, sizeof(buf))) m_params.activeAssetId = buf;
+
+		ImGui::SliderFloat("Brush radius (m)", &m_params.brushRadius, 0.5f, 30.0f);
+		ImGui::SliderFloat("Density target", &m_params.densityTarget, 0.0f, 1.0f);
+		ImGui::SliderFloat("Strength", &m_params.strength, 0.0f, 1.0f);
+		ImGui::SliderFloat("Falloff", &m_params.falloff, 0.0f, 1.0f);
+		ImGui::InputFloat("Poisson min radius (m)", &m_params.minRadius);
+
+		int mode = static_cast<int>(m_params.mode);
+		ImGui::RadioButton("Add density", &mode, 0); ImGui::SameLine();
+		ImGui::RadioButton("Erase density", &mode, 1);
+		m_params.mode = static_cast<FoliagePaintMode>(mode);
+#endif
+	}
+}

--- a/src/world_editor/FoliagePaintTool.h
+++ b/src/world_editor/FoliagePaintTool.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// M100.18 — Outil de peinture de densité végétale. Rendu ImGui guardé Windows.
+// (La résolution densité → positions Poisson-disk vit dans le sampler pur
+// PoissonDiskSampler ; le câblage terrain/brush complet est itératif.)
+
+#include <cstdint>
+#include <string>
+
+namespace engine::editor::world
+{
+	enum class FoliagePaintMode : uint8_t { AddDensity = 0, EraseDensity = 1 };
+
+	struct FoliagePaintParams
+	{
+		std::string activeAssetId;
+		float brushRadius = 6.0f;
+		float densityTarget = 0.7f;
+		float strength = 0.5f;
+		float falloff = 0.7f;
+		float minRadius = 0.4f; // espacement Poisson-disk par défaut
+		FoliagePaintMode mode = FoliagePaintMode::AddDensity;
+	};
+
+	class FoliagePaintTool
+	{
+	public:
+		FoliagePaintParams& Params() { return m_params; }
+		const FoliagePaintParams& Params() const { return m_params; }
+		void Render();
+
+	private:
+		FoliagePaintParams m_params;
+	};
+}

--- a/src/world_editor/ForestFieldGen.cpp
+++ b/src/world_editor/ForestFieldGen.cpp
@@ -1,0 +1,151 @@
+// M100.19 — Implémentation des générateurs Forest & Field (purs, déterministes).
+
+#include "src/world_editor/ForestFieldGen.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <string>
+
+namespace engine::editor::world
+{
+	using engine::math::Vec3;
+	using engine::world::foliage::FoliageInstance;
+
+	namespace
+	{
+		constexpr float kPi = 3.14159265358979323846f;
+
+		uint32_t Fnv1a(const std::string& s)
+		{
+			uint32_t h = 2166136261u;
+			for (unsigned char c : s) { h ^= c; h *= 16777619u; }
+			return h;
+		}
+
+		// Aire (valeur absolue) d'un polygone en XZ via la formule du lacet.
+		float PolygonArea(const std::vector<Vec3>& poly)
+		{
+			if (poly.size() < 3) return 0.0f;
+			double a = 0.0;
+			for (size_t i = 0; i < poly.size(); ++i)
+			{
+				const Vec3& p0 = poly[i];
+				const Vec3& p1 = poly[(i + 1) % poly.size()];
+				a += static_cast<double>(p0.x) * p1.z - static_cast<double>(p1.x) * p0.z;
+			}
+			return static_cast<float>(std::fabs(a) * 0.5);
+		}
+
+		// Test point-dans-polygone (ray casting) en XZ.
+		bool PointInPolygon(const std::vector<Vec3>& poly, float x, float z)
+		{
+			bool inside = false;
+			for (size_t i = 0, j = poly.size() - 1; i < poly.size(); j = i++)
+			{
+				const float xi = poly[i].x, zi = poly[i].z;
+				const float xj = poly[j].x, zj = poly[j].z;
+				const bool intersect = ((zi > z) != (zj > z)) &&
+					(x < (xj - xi) * (z - zi) / (zj - zi + 1e-9f) + xi);
+				if (intersect) inside = !inside;
+			}
+			return inside;
+		}
+	} // namespace
+
+	std::vector<FoliageInstance> GenerateForest(
+		const std::vector<Vec3>& polygon, const ForestRecipe& recipe,
+		const engine::world::foliage::FoliageLibrary& library, const TerrainSampler& sampler)
+	{
+		std::vector<FoliageInstance> out;
+		if (polygon.size() < 3 || recipe.entries.empty()) return out;
+
+		const float area = PolygonArea(polygon);
+		const float totalDensity = recipe.TotalDensity();
+		const int target = static_cast<int>(std::lround(static_cast<double>(area) * totalDensity));
+		if (target <= 0) return out;
+
+		// bbox
+		float minX = polygon[0].x, maxX = polygon[0].x, minZ = polygon[0].z, maxZ = polygon[0].z;
+		for (const auto& p : polygon)
+		{
+			minX = std::min(minX, p.x); maxX = std::max(maxX, p.x);
+			minZ = std::min(minZ, p.z); maxZ = std::max(maxZ, p.z);
+		}
+
+		// poids cumulés
+		std::vector<float> cum;
+		float wsum = 0.0f;
+		for (const auto& e : recipe.entries) { wsum += (e.weight > 0.0f ? e.weight : 0.0f); cum.push_back(wsum); }
+		if (wsum <= 0.0f) return out;
+
+		std::mt19937_64 rng(recipe.seed);
+		std::uniform_real_distribution<float> ux(minX, maxX), uz(minZ, maxZ), u01(0.0f, 1.0f);
+		std::uniform_real_distribution<float> uyaw(0.0f, 2.0f * kPi), uscale(0.95f, 1.05f);
+
+		int accepted = 0;
+		const int maxTries = target * 64 + 64;
+		for (int t = 0; t < maxTries && accepted < target; ++t)
+		{
+			const float x = ux(rng), z = uz(rng);
+			if (!PointInPolygon(polygon, x, z)) continue;
+			++accepted; // point in-polygon « consommé » (densité)
+
+			// sélection d'asset par poids
+			const float r = u01(rng) * wsum;
+			size_t idx = 0;
+			while (idx + 1 < cum.size() && r > cum[idx]) ++idx;
+			const ForestRecipeEntry& entry = recipe.entries[idx];
+
+			const TerrainSample ts = sampler(x, z);
+			if (const auto* asset = library.FindAsset(entry.assetId))
+			{
+				if (!engine::world::foliage::PassesRules(asset->rules, ts.slopeDeg, ts.altMeters, ts.splatLayer))
+					continue; // filtré par les règles
+			}
+
+			FoliageInstance inst;
+			inst.assetIdHash = Fnv1a(entry.assetId);
+			inst.position = Vec3(x, ts.terrainY, z);
+			inst.rotationY = uyaw(rng);
+			inst.scale = uscale(rng);
+			out.push_back(inst);
+		}
+		return out;
+	}
+
+	std::vector<FoliageInstance> GenerateField(
+		const FieldParams& params, uint32_t assetIdHash, const TerrainSampler& sampler)
+	{
+		std::vector<FoliageInstance> out;
+		if (params.spacing <= 0.0f || params.width <= 0.0f || params.depth <= 0.0f) return out;
+
+		const float c = std::cos(params.rotationDeg * kPi / 180.0f);
+		const float s = std::sin(params.rotationDeg * kPi / 180.0f);
+
+		std::mt19937_64 rng(params.seed);
+		std::uniform_real_distribution<float> uscale(0.95f, 1.05f);
+
+		const int nx = static_cast<int>(params.width / params.spacing);
+		const int nz = static_cast<int>(params.depth / params.spacing);
+		for (int j = 0; j <= nz; ++j)
+		{
+			for (int i = 0; i <= nx; ++i)
+			{
+				const float lx = static_cast<float>(i) * params.spacing;
+				const float lz = static_cast<float>(j) * params.spacing;
+				// rotation de la grille autour du coin
+				const float wx = params.corner.x + (lx * c - lz * s);
+				const float wz = params.corner.z + (lx * s + lz * c);
+				const TerrainSample ts = sampler(wx, wz);
+				FoliageInstance inst;
+				inst.assetIdHash = assetIdHash;
+				inst.position = Vec3(wx, ts.terrainY, wz);
+				inst.rotationY = params.rotationDeg * kPi / 180.0f;
+				inst.scale = uscale(rng);
+				out.push_back(inst);
+			}
+		}
+		return out;
+	}
+}

--- a/src/world_editor/ForestFieldGen.h
+++ b/src/world_editor/ForestFieldGen.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// M100.19 — Générateurs procéduraux Forest & Field (PURS, déterministes).
+// Émettent des FoliageInstance (M100.18) ; le tagging splat et l'UI sont gérés
+// ailleurs (différés). Indépendants du rendu : testables headless.
+
+#include <vector>
+
+#include "src/client/world/foliage/FoliageInstances.h"
+#include "src/client/world/foliage/FoliageLibrary.h"
+#include "src/shared/math/Math.h"
+#include "src/world_editor/ForestRecipe.h"
+
+namespace engine::editor::world
+{
+	/// Génère une forêt dans un polygone fermé (sommets en XZ, y ignoré).
+	/// Densité totale = somme des densités de la recette ; sélection d'asset par
+	/// poids cumulé ; filtrage par règles per-asset (M100.18) via `sampler`.
+	/// Déterministe pour `recipe.seed`.
+	std::vector<engine::world::foliage::FoliageInstance> GenerateForest(
+		const std::vector<engine::math::Vec3>& polygon,
+		const ForestRecipe& recipe,
+		const engine::world::foliage::FoliageLibrary& library,
+		const TerrainSampler& sampler);
+
+	struct FieldParams
+	{
+		engine::math::Vec3 corner{ 0.0f, 0.0f, 0.0f }; // coin (origine de la grille)
+		float width = 10.0f;       // extension X locale (m)
+		float depth = 10.0f;       // extension Z locale (m)
+		float spacing = 0.6f;      // pas régulier (m)
+		float rotationDeg = 0.0f;  // rotation de la grille autour du coin
+		uint64_t seed = 1;
+	};
+
+	/// Génère un champ : grille régulière (rotation appliquée), une instance par
+	/// cellule, scale légèrement aléatoire [0.95,1.05], position SANS jitter
+	/// (alignement régulier). Déterministe.
+	std::vector<engine::world::foliage::FoliageInstance> GenerateField(
+		const FieldParams& params, uint32_t assetIdHash, const TerrainSampler& sampler);
+}

--- a/src/world_editor/ForestRecipe.h
+++ b/src/world_editor/ForestRecipe.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// M100.19 — Recette de forêt + échantillonnage terrain pour les générateurs
+// procéduraux (Forest / Field). Données pures.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace engine::editor::world
+{
+	struct ForestRecipeEntry
+	{
+		std::string assetId;       // référence un asset de la FoliageLibrary (M100.18)
+		float weight = 1.0f;       // poids relatif de sélection
+		float densityPerM2 = 0.05f;
+	};
+
+	struct ForestRecipe
+	{
+		std::vector<ForestRecipeEntry> entries;
+		uint64_t seed = 42;
+
+		float TotalDensity() const
+		{
+			float d = 0.0f;
+			for (const auto& e : entries) d += e.densityPerM2;
+			return d;
+		}
+	};
+
+	/// Échantillon terrain à une position monde (fourni par l'appelant : en jeu
+	/// = heightmap/splat réels ; en test = mock).
+	struct TerrainSample
+	{
+		float terrainY = 0.0f;
+		float slopeDeg = 0.0f;
+		float altMeters = 0.0f;
+		int   splatLayer = 0;
+	};
+
+	using TerrainSampler = std::function<TerrainSample(float worldX, float worldZ)>;
+}

--- a/src/world_editor/ForestTool.cpp
+++ b/src/world_editor/ForestTool.cpp
@@ -1,0 +1,41 @@
+// M100.19 — Rendu du panneau de l'outil Forest (ImGui guardé).
+
+#include "src/world_editor/ForestTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstdio>
+#endif
+
+namespace engine::editor::world
+{
+	void ForestTool::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Forest");
+		ImGui::Separator();
+		ImGui::Text("Polygone : %d points", static_cast<int>(m_polygon.size()));
+		if (ImGui::Button("Clear polygon")) ClearPolygon();
+
+		int seed = static_cast<int>(m_recipe.seed);
+		if (ImGui::InputInt("Seed", &seed) && seed >= 0) m_recipe.seed = static_cast<uint64_t>(seed);
+
+		ImGui::TextUnformatted("Recette :");
+		for (size_t i = 0; i < m_recipe.entries.size(); ++i)
+		{
+			ForestRecipeEntry& e = m_recipe.entries[i];
+			ImGui::PushID(static_cast<int>(i));
+			char buf[96]; std::snprintf(buf, sizeof(buf), "%s", e.assetId.c_str());
+			if (ImGui::InputText("asset", buf, sizeof(buf))) e.assetId = buf;
+			ImGui::SameLine(); ImGui::SetNextItemWidth(80);
+			ImGui::InputFloat("w", &e.weight);
+			ImGui::SameLine(); ImGui::SetNextItemWidth(90);
+			ImGui::InputFloat("d/m2", &e.densityPerM2);
+			ImGui::PopID();
+		}
+		if (ImGui::Button("+ entry")) m_recipe.entries.push_back(ForestRecipeEntry{});
+		// La génération (GenerateForest) + push FoliagePaintCommand est déclenchée
+		// par le shell ; ce panneau n'édite que la recette/le polygone.
+#endif
+	}
+}

--- a/src/world_editor/ForestTool.h
+++ b/src/world_editor/ForestTool.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// M100.19 — Outil Forest (polygone + recette). Rendu ImGui guardé Windows ; la
+// génération est la fonction pure GenerateForest (ForestFieldGen). Les instances
+// produites sont posées via FoliagePaintCommand (M100.18).
+
+#include <vector>
+
+#include "src/shared/math/Math.h"
+#include "src/world_editor/ForestRecipe.h"
+
+namespace engine::editor::world
+{
+	class ForestTool
+	{
+	public:
+		ForestRecipe& Recipe() { return m_recipe; }
+		const ForestRecipe& Recipe() const { return m_recipe; }
+		std::vector<engine::math::Vec3>& Polygon() { return m_polygon; }
+		const std::vector<engine::math::Vec3>& Polygon() const { return m_polygon; }
+
+		void AddPolygonPoint(const engine::math::Vec3& p) { m_polygon.push_back(p); }
+		void ClearPolygon() { m_polygon.clear(); }
+
+		void Render();
+
+	private:
+		ForestRecipe m_recipe;
+		std::vector<engine::math::Vec3> m_polygon;
+	};
+}

--- a/src/world_editor/HamletGen.cpp
+++ b/src/world_editor/HamletGen.cpp
@@ -1,0 +1,111 @@
+// M100.31 — Implémentation de la génération d'hameau (pure, déterministe).
+
+#include "src/world_editor/HamletGen.h"
+
+#include "src/client/world/foliage/PoissonDiskSampler.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+namespace engine::editor::world
+{
+	using engine::math::Vec3;
+	using engine::world::instances::PropInstance;
+
+	namespace
+	{
+		uint32_t Fnv1a(const std::string& s) { uint32_t h = 2166136261u; for (unsigned char c : s) { h ^= c; h *= 16777619u; } return h; }
+
+		bool PointInPolygon(const std::vector<Vec3>& poly, float x, float z)
+		{
+			if (poly.size() < 3) return false;
+			bool inside = false;
+			for (size_t i = 0, j = poly.size() - 1; i < poly.size(); j = i++)
+			{
+				const float xi = poly[i].x, zi = poly[i].z, xj = poly[j].x, zj = poly[j].z;
+				if (((zi > z) != (zj > z)) && (x < (xj - xi) * (z - zi) / (zj - zi + 1e-9f) + xi)) inside = !inside;
+			}
+			return inside;
+		}
+
+		// Point le plus proche sur une polyline (XZ) + distance.
+		bool NearestOnRoad(const std::vector<Vec3>& road, float x, float z, Vec3& outPoint, float& outDist)
+		{
+			if (road.size() < 2) return false;
+			float best = 1e18f; Vec3 bestPt = road[0];
+			for (size_t i = 1; i < road.size(); ++i)
+			{
+				const float ax = road[i-1].x, az = road[i-1].z, bx = road[i].x, bz = road[i].z;
+				const float dx = bx - ax, dz = bz - az; const float len2 = dx*dx + dz*dz;
+				float t = (len2 > 1e-9f) ? ((x-ax)*dx + (z-az)*dz)/len2 : 0.0f;
+				t = std::max(0.0f, std::min(1.0f, t));
+				const float cx = ax + t*dx, cz = az + t*dz;
+				const float ex = x - cx, ez = z - cz; const float d = std::sqrt(ex*ex + ez*ez);
+				if (d < best) { best = d; bestPt = Vec3(cx, 0.0f, cz); }
+			}
+			outPoint = bestPt; outDist = best; return true;
+		}
+	} // namespace
+
+	std::vector<PropInstance> GenerateHamlet(
+		const std::vector<Vec3>& polygon, const HamletRecipe& recipe,
+		const HamletSampler& sampler, const std::vector<Vec3>& road, uint32_t& nextInstanceId)
+	{
+		std::vector<PropInstance> out;
+		if (polygon.size() < 3 || recipe.houseMeshes.empty() || recipe.houseCount <= 0) return out;
+
+		float minX = polygon[0].x, maxX = polygon[0].x, minZ = polygon[0].z, maxZ = polygon[0].z;
+		for (const auto& p : polygon) { minX = std::min(minX, p.x); maxX = std::max(maxX, p.x); minZ = std::min(minZ, p.z); maxZ = std::max(maxZ, p.z); }
+
+		// Candidats Poisson-disk (réutilise M100.18) garantissant min_spacing.
+		auto candidates = engine::world::foliage::SamplePoissonDisk(maxX - minX, maxZ - minZ, recipe.minSpacing, recipe.seed);
+
+		// Poids cumulés des meshes.
+		std::vector<float> cum; float wsum = 0.0f;
+		for (const auto& h : recipe.houseMeshes) { wsum += (h.second > 0.0f ? h.second : 0.0f); cum.push_back(wsum); }
+		std::mt19937_64 rng(recipe.seed ^ 0x9E3779B97F4A7C15ull);
+		std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+
+		for (const auto& cLocal : candidates)
+		{
+			if (static_cast<int>(out.size()) >= recipe.houseCount) break;
+			float wx = minX + cLocal.x, wz = minZ + cLocal.z;
+			if (!PointInPolygon(polygon, wx, wz)) continue;
+			HamletTerrainSample ts = sampler ? sampler(wx, wz) : HamletTerrainSample{};
+			if (ts.slopeDeg > recipe.maxSlopeDeg) continue;
+
+			if (recipe.snapToRoad && road.size() >= 2)
+			{
+				Vec3 rp; float rd = 0.0f;
+				if (NearestOnRoad(road, wx, wz, rp, rd) && rd <= recipe.roadSnapRangeMeters && rd > 1e-4f)
+				{
+					// Décale de `roadOffsetMeters` du côté du candidat.
+					const float nx = (wx - rp.x) / rd, nz = (wz - rp.z) / rd;
+					wx = rp.x + nx * recipe.roadOffsetMeters;
+					wz = rp.z + nz * recipe.roadOffsetMeters;
+					ts = sampler ? sampler(wx, wz) : ts;
+				}
+			}
+
+			// Sélection mesh pondérée.
+			uint32_t assetId = 0;
+			if (wsum > 0.0f)
+			{
+				const float r = u01(rng) * wsum; size_t idx = 0;
+				while (idx + 1 < cum.size() && r > cum[idx]) ++idx;
+				assetId = Fnv1a(recipe.houseMeshes[idx].first);
+			}
+
+			PropInstance inst;
+			inst.assetId = assetId;
+			inst.position = Vec3(wx, ts.terrainY, wz);
+			inst.rotationQuat[3] = 1.0f; // identité (orientation détaillée différée)
+			inst.scale = Vec3(1.0f, 1.0f, 1.0f);
+			inst.layerTag = static_cast<uint32_t>(engine::world::instances::PlacementLayer::Structures);
+			inst.instanceId = nextInstanceId++;
+			out.push_back(inst);
+		}
+		return out;
+	}
+}

--- a/src/world_editor/HamletGen.h
+++ b/src/world_editor/HamletGen.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// M100.31 — Génération d'hameau (PURE, déterministe). Candidats Poisson-disk
+// (M100.18), filtrage pente, snap route optionnel, sélection mesh pondérée.
+// Produit des PropInstance (M100.17). L'outil/commande posent via PlacePropsCommand.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/client/world/instances/PropInstances.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	struct HamletRecipe
+	{
+		std::vector<std::pair<std::string, float>> houseMeshes; // mesh, weight (du kit)
+		int houseCount = 12;
+		float minSpacing = 8.0f;
+		float maxSlopeDeg = 15.0f;
+		bool snapToRoad = false;
+		float roadSnapRangeMeters = 30.0f;
+		float roadOffsetMeters = 4.0f;
+		uint64_t seed = 42;
+	};
+
+	struct HamletTerrainSample
+	{
+		float slopeDeg = 0.0f;
+		float terrainY = 0.0f;
+	};
+
+	using HamletSampler = std::function<HamletTerrainSample(float worldX, float worldZ)>;
+
+	/// Génère les maisons d'un hameau dans `polygon`. `road` (polyline, vide si
+	/// aucune) sert au snap. `nextInstanceId` est avancé pour chaque maison.
+	std::vector<engine::world::instances::PropInstance> GenerateHamlet(
+		const std::vector<engine::math::Vec3>& polygon, const HamletRecipe& recipe,
+		const HamletSampler& sampler, const std::vector<engine::math::Vec3>& road,
+		uint32_t& nextInstanceId);
+}

--- a/src/world_editor/HamletGeneratorTool.h
+++ b/src/world_editor/HamletGeneratorTool.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// M100.31 — Outil générateur d'hameau. Header-only, rendu ImGui guardé. La
+// génération est GenerateHamlet (pur) ; la pose passe par PlacePropsCommand.
+
+#include <vector>
+
+#include "src/shared/math/Math.h"
+#include "src/world_editor/HamletGen.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstdio>
+#endif
+
+namespace engine::editor::world
+{
+	class HamletGeneratorTool
+	{
+	public:
+		HamletRecipe& Recipe() { return m_recipe; }
+		const HamletRecipe& Recipe() const { return m_recipe; }
+		std::vector<engine::math::Vec3>& Polygon() { return m_polygon; }
+		void AddPoint(const engine::math::Vec3& p) { m_polygon.push_back(p); }
+		void Clear() { m_polygon.clear(); }
+
+		void Render()
+		{
+#if defined(_WIN32)
+			ImGui::TextUnformatted("Hamlet Generator");
+			ImGui::Separator();
+			ImGui::Text("Polygone : %d points", static_cast<int>(m_polygon.size()));
+			if (ImGui::Button("Clear polygon")) Clear();
+			ImGui::InputInt("House count", &m_recipe.houseCount);
+			ImGui::InputFloat("Min spacing (m)", &m_recipe.minSpacing);
+			ImGui::Checkbox("Snap to road", &m_recipe.snapToRoad);
+			int seed = static_cast<int>(m_recipe.seed);
+			if (ImGui::InputInt("Seed", &seed) && seed >= 0) m_recipe.seed = static_cast<uint64_t>(seed);
+#endif
+		}
+
+	private:
+		HamletRecipe m_recipe;
+		std::vector<engine::math::Vec3> m_polygon;
+	};
+}

--- a/src/world_editor/PlaytestMode.h
+++ b/src/world_editor/PlaytestMode.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// M100.33 — Machine d'état du mode Playtest (F5). Header-only. Sauvegarde l'état
+// caméra éditeur à l'entrée, le restaure à la sortie. Le branchement réel sur
+// CharacterController/ThirdPersonCamera de PRODUCTION (sans fork) est fait côté
+// intégration (différé) ; ici la logique d'état est testable headless.
+
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	/// Pose caméra éditeur sauvegardée (simplifiée).
+	struct EditorCameraPose
+	{
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+		float yawDeg = 0.0f;
+		float pitchDeg = 0.0f;
+	};
+
+	class PlaytestMode
+	{
+	public:
+		bool IsActive() const { return m_active; }
+		const engine::math::Vec3& PlayerStart() const { return m_playerStart; }
+
+		/// Entre en playtest : sauvegarde la pose éditeur, place le joueur au
+		/// curseur. No-op si déjà actif.
+		void Enter(const EditorCameraPose& editorPose, const engine::math::Vec3& cursorWorld)
+		{
+			if (m_active) return;
+			m_savedPose = editorPose;
+			m_playerStart = cursorWorld;
+			m_active = true;
+		}
+
+		/// Sort du playtest : restaure et renvoie la pose éditeur sauvegardée.
+		EditorCameraPose Exit()
+		{
+			m_active = false;
+			return m_savedPose;
+		}
+
+		/// Bascule entrée/sortie ; renvoie le nouvel état actif.
+		bool Toggle(const EditorCameraPose& editorPose, const engine::math::Vec3& cursorWorld)
+		{
+			if (m_active) { Exit(); return false; }
+			Enter(editorPose, cursorWorld);
+			return true;
+		}
+
+	private:
+		bool m_active = false;
+		EditorCameraPose m_savedPose;
+		engine::math::Vec3 m_playerStart{ 0.0f, 0.0f, 0.0f };
+	};
+}

--- a/src/world_editor/SplineCommand.h
+++ b/src/world_editor/SplineCommand.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// M100.29 — Commande d'ajout de spline (undo/redo). Header-only. La peinture
+// splat associée est déclenchée séparément (différée).
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/SplineDocument.h"
+
+namespace engine::editor::world
+{
+	class AddSplineCommand final : public ICommand
+	{
+	public:
+		AddSplineCommand(SplineDocument& doc, engine::world::spline::Spline spline)
+			: m_doc(doc), m_spline(std::move(spline)) {}
+
+		const char* GetLabel() const override { return "Add spline"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(*this) + m_spline.nodes.size() * sizeof(engine::world::spline::SplineNode);
+		}
+		void Execute() override { m_doc.Add(m_spline); }
+		void Undo() override { m_doc.RemoveLast(); }
+
+	private:
+		SplineDocument& m_doc;
+		engine::world::spline::Spline m_spline;
+	};
+}

--- a/src/world_editor/SplineDocument.h
+++ b/src/world_editor/SplineDocument.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// M100.29 — Document de splines de la zone. Header-only.
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/client/world/spline/SplineInstances.h"
+
+namespace engine::editor::world
+{
+	class SplineDocument
+	{
+	public:
+		uint32_t Add(const engine::world::spline::Spline& s)
+		{
+			const uint32_t id = static_cast<uint32_t>(m_splines.size());
+			m_splines.push_back(s);
+			return id;
+		}
+		void RemoveLast() { if (!m_splines.empty()) m_splines.pop_back(); }
+		const std::vector<engine::world::spline::Spline>& All() const { return m_splines; }
+		std::vector<engine::world::spline::Spline>& Mutable() { return m_splines; }
+
+		bool SaveToDisk(const std::string& path, std::string& err) const
+		{
+			const std::vector<uint8_t> bytes = engine::world::spline::SaveSplinesBin(m_splines);
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good()) { err = "SplineDocument::SaveToDisk: open failed: " + path; return false; }
+			out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+			if (!out.good()) { err = "SplineDocument::SaveToDisk: write failed: " + path; return false; }
+			return true;
+		}
+
+	private:
+		std::vector<engine::world::spline::Spline> m_splines;
+	};
+}

--- a/src/world_editor/SplineTool.cpp
+++ b/src/world_editor/SplineTool.cpp
@@ -1,0 +1,38 @@
+// M100.29 — Rendu du panneau de l'outil Spline (ImGui guardé).
+
+#include "src/world_editor/SplineTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	void SplineTool::Render()
+	{
+#if defined(_WIN32)
+		using engine::world::spline::SplineType;
+		using engine::world::spline::SplineCurve;
+		ImGui::TextUnformatted("Spline / Road");
+		ImGui::Separator();
+
+		const char* kTypes[] = { "Road", "Path", "Wall", "RiverRef" };
+		int t = static_cast<int>(m_current.type);
+		if (ImGui::Combo("Type", &t, kTypes, IM_ARRAYSIZE(kTypes))) m_current.type = static_cast<SplineType>(t);
+
+		int c = static_cast<int>(m_current.curve);
+		ImGui::RadioButton("Catmull-Rom", &c, 0); ImGui::SameLine();
+		ImGui::RadioButton("Bezier", &c, 1);
+		m_current.curve = static_cast<SplineCurve>(c);
+
+		ImGui::Checkbox("Closed", &m_current.closed);
+		ImGui::Text("Noeuds : %d", static_cast<int>(m_current.nodes.size()));
+		if (ImGui::Button("Clear")) Clear();
+
+		int layer = static_cast<int>(m_current.splatLayerIndex);
+		if (ImGui::InputInt("Splat layer", &layer) && layer >= 0) m_current.splatLayerIndex = static_cast<uint32_t>(layer);
+		ImGui::SliderFloat("Splat strength", &m_current.splatStrength, 0.0f, 1.0f);
+		ImGui::InputFloat("Feather (m)", &m_current.splatFeatherMeters);
+#endif
+	}
+}

--- a/src/world_editor/SplineTool.h
+++ b/src/world_editor/SplineTool.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// M100.29 — Outil spline (routes/chemins). Rendu ImGui guardé. L'échantillonnage
+// et la peinture vivent dans SplineSampler / TerrainDocument.
+
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	class SplineTool
+	{
+	public:
+		engine::world::spline::Spline& Current() { return m_current; }
+		const engine::world::spline::Spline& Current() const { return m_current; }
+		void AddNode(const engine::math::Vec3& p, float width = 6.0f)
+		{
+			engine::world::spline::SplineNode n; n.position = p; n.widthMeters = width;
+			m_current.nodes.push_back(n);
+		}
+		void Clear() { m_current.nodes.clear(); }
+		void Render();
+
+	private:
+		engine::world::spline::Spline m_current;
+	};
+}

--- a/src/world_editor/WallTool.h
+++ b/src/world_editor/WallTool.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// M100.30 — Outil Wall : transforme une spline en mur (kit + hauteur).
+// Header-only, rendu ImGui guardé Windows. Génération dans structures::* (pur).
+
+#include "src/client/world/spline/SplineInstances.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	class WallTool
+	{
+	public:
+		engine::world::spline::SplineKitData& Kit() { return m_kit; }
+		const engine::world::spline::SplineKitData& Kit() const { return m_kit; }
+
+		void Render()
+		{
+#if defined(_WIN32)
+			ImGui::TextUnformatted("Wall / Palissade");
+			ImGui::Separator();
+			ImGui::InputFloat("Segment length (m)", &m_kit.segmentLengthMeters);
+			ImGui::SliderFloat("Height (m)", &m_kit.heightMeters, 0.5f, 12.0f);
+			ImGui::SliderFloat("Post spacing (m)", &m_kit.postSpacingMeters, 1.0f, 12.0f);
+#endif
+		}
+
+	private:
+		engine::world::spline::SplineKitData m_kit{ engine::world::spline::SplineKitMode::Wall };
+	};
+}

--- a/src/world_editor/WindZoneTool.cpp
+++ b/src/world_editor/WindZoneTool.cpp
@@ -1,0 +1,25 @@
+// M100.20 — Rendu du panneau de l'outil WindZone (ImGui guardé).
+
+#include "src/world_editor/WindZoneTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	void WindZoneTool::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Wind Zone (local override)");
+		ImGui::Separator();
+		ImGui::Text("Polygone : %d points", static_cast<int>(m_current.polygon.size()));
+		if (ImGui::Button("Clear polygon")) Clear();
+		ImGui::InputFloat("Direction X", &m_current.directionX);
+		ImGui::InputFloat("Direction Z", &m_current.directionZ);
+		ImGui::SliderFloat("Force (m/s)", &m_current.forceMps, 0.0f, 20.0f);
+		ImGui::SliderFloat("Turbulence freq", &m_current.turbulenceFreq, 0.0f, 2.0f);
+		ImGui::SliderFloat("Turbulence amp", &m_current.turbulenceAmp, 0.0f, 3.0f);
+#endif
+	}
+}

--- a/src/world_editor/WindZoneTool.h
+++ b/src/world_editor/WindZoneTool.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// M100.20 — Outil de zone de vent locale (polygone + overrides). Rendu ImGui
+// guardé Windows. La sérialisation/évaluation vit dans WindZones/WindSystem.
+
+#include <vector>
+
+#include "src/client/world/wind/WindZones.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	class WindZoneTool
+	{
+	public:
+		engine::world::wind::WindZone& Current() { return m_current; }
+		const engine::world::wind::WindZone& Current() const { return m_current; }
+		void AddPoint(const engine::math::Vec3& p) { m_current.polygon.push_back(p); }
+		void Clear() { m_current.polygon.clear(); }
+		void Render();
+
+	private:
+		engine::world::wind::WindZone m_current;
+	};
+}

--- a/src/world_editor/ZoneTool.cpp
+++ b/src/world_editor/ZoneTool.cpp
@@ -1,0 +1,43 @@
+// M100.28 — Rendu du panneau de l'outil Zone (ImGui guardé).
+
+#include "src/world_editor/ZoneTool.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include <cstdio>
+#endif
+
+namespace engine::editor::world
+{
+	void ZoneTool::Render()
+	{
+#if defined(_WIN32)
+		using engine::world::zones::ZoneType;
+		ImGui::TextUnformatted("Gameplay Zone");
+		ImGui::Separator();
+
+		const char* kTypes[] = { "SafeZone", "PvPZone", "RaidZone", "NoBuild", "QuestTrigger", "WeatherOverride" };
+		int t = static_cast<int>(m_current.type);
+		if (ImGui::Combo("Type", &t, kTypes, IM_ARRAYSIZE(kTypes))) m_current.type = static_cast<ZoneType>(t);
+
+		char buf[96]; std::snprintf(buf, sizeof(buf), "%s", m_current.name.c_str());
+		if (ImGui::InputText("Name", buf, sizeof(buf))) m_current.name = buf;
+
+		ImGui::Text("Polygone : %d points", static_cast<int>(m_current.polygon.size()));
+		if (ImGui::Button("Clear polygon")) Clear();
+
+		if (m_current.type == ZoneType::WeatherOverride)
+		{
+			int w = static_cast<int>(m_current.weatherType);
+			if (ImGui::InputInt("Override weather", &w) && w >= 0) m_current.weatherType = static_cast<uint32_t>(w);
+			ImGui::SliderFloat("Blend T", &m_current.weatherBlendT, 0.0f, 1.0f);
+			ImGui::InputFloat("Transition margin (m)", &m_current.transitionMarginMeters);
+		}
+		if (m_current.type == ZoneType::QuestTrigger)
+		{
+			int q = static_cast<int>(m_current.questId);
+			if (ImGui::InputInt("Quest id", &q) && q >= 0) m_current.questId = static_cast<uint32_t>(q);
+		}
+#endif
+	}
+}

--- a/src/world_editor/ZoneTool.h
+++ b/src/world_editor/ZoneTool.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// M100.28 — Outil de zone de gameplay (polygone multi-types). Rendu ImGui guardé.
+// La sérialisation/requêtes vivent dans Zones/ZoneQuery.
+
+#include "src/client/world/zones/Zones.h"
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world
+{
+	class ZoneTool
+	{
+	public:
+		engine::world::zones::GameplayZone& Current() { return m_current; }
+		const engine::world::zones::GameplayZone& Current() const { return m_current; }
+		void AddPoint(const engine::math::Vec3& p) { m_current.polygon.push_back(p); }
+		void Clear() { m_current.polygon.clear(); }
+		void Render();
+
+	private:
+		engine::world::zones::GameplayZone m_current;
+	};
+}

--- a/src/world_editor/tests/ForestFieldTests.cpp
+++ b/src/world_editor/tests/ForestFieldTests.cpp
@@ -1,0 +1,129 @@
+// M100.19 — Tests Forest & Field (générateurs purs). Headless. Lié à engine_core.
+
+#include "src/client/world/foliage/FoliageLibrary.h"
+#include "src/world_editor/ForestFieldGen.h"
+#include "src/world_editor/ForestRecipe.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace engine::editor::world;
+using engine::math::Vec3;
+using engine::world::foliage::FoliageLibrary;
+using engine::world::foliage::FoliageAsset;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) <= eps; }
+
+	FoliageLibrary MakeLib()
+	{
+		FoliageLibrary lib;
+		FoliageAsset a; a.id = "tree_oak_01"; a.category = "tree_oak";
+		a.rules.slopeMaxDeg = 25.0f; a.rules.altMin = -1000.0f; a.rules.altMax = 5000.0f;
+		lib.assets.push_back(a);
+		return lib;
+	}
+
+	std::vector<Vec3> Square10()
+	{
+		return { Vec3(0,0,0), Vec3(10,0,0), Vec3(10,0,10), Vec3(0,0,10) };
+	}
+
+	TerrainSampler FlatSampler(float slope)
+	{
+		return [slope](float, float) -> TerrainSample
+		{
+			TerrainSample s; s.terrainY = 5.0f; s.slopeDeg = slope; s.altMeters = 100.0f; s.splatLayer = 1;
+			return s;
+		};
+	}
+
+	ForestRecipe OneOakDensity(float density, uint64_t seed)
+	{
+		ForestRecipe r; r.seed = seed;
+		r.entries.push_back(ForestRecipeEntry{ "tree_oak_01", 1.0f, density });
+		return r;
+	}
+
+	void Test_Forest_DensityMatchesRecipe()
+	{
+		auto lib = MakeLib();
+		auto poly = Square10();                  // aire 100
+		auto recipe = OneOakDensity(0.1f, 42);   // densité 0.1 → cible ~10
+		auto inst = GenerateForest(poly, recipe, lib, FlatSampler(0.0f));
+		REQUIRE(inst.size() >= 9 && inst.size() <= 11); // ±5 % autour de 10
+	}
+
+	void Test_Forest_RulesFilterSlope()
+	{
+		auto lib = MakeLib();
+		auto poly = Square10();
+		auto recipe = OneOakDensity(0.2f, 7);
+		auto inst = GenerateForest(poly, recipe, lib, FlatSampler(80.0f)); // pente > 25
+		REQUIRE(inst.empty());
+	}
+
+	void Test_Forest_DeterministicWithSeed()
+	{
+		auto lib = MakeLib();
+		auto poly = Square10();
+		auto a = GenerateForest(poly, OneOakDensity(0.15f, 99), lib, FlatSampler(0.0f));
+		auto b = GenerateForest(poly, OneOakDensity(0.15f, 99), lib, FlatSampler(0.0f));
+		REQUIRE(a.size() == b.size());
+		if (!a.empty() && a.size() == b.size())
+			REQUIRE(Near(a[0].position.x, b[0].position.x) && Near(a[0].position.z, b[0].position.z));
+	}
+
+	void Test_Field_RegularSpacing()
+	{
+		FieldParams p; p.corner = Vec3(0,0,0); p.width = 6.0f; p.depth = 6.0f; p.spacing = 2.0f; p.rotationDeg = 0.0f;
+		auto inst = GenerateField(p, 123u, FlatSampler(0.0f));
+		REQUIRE(inst.size() == 16); // 4x4 (i,j = 0..3)
+		// Espacement régulier sur la première ligne (j=0) : indices 0..3.
+		if (inst.size() >= 4)
+		{
+			const float dx = inst[1].position.x - inst[0].position.x;
+			const float dz = inst[1].position.z - inst[0].position.z;
+			REQUIRE(Near(std::sqrt(dx * dx + dz * dz), 2.0f));
+		}
+	}
+
+	void Test_Field_Rotation()
+	{
+		FieldParams p; p.corner = Vec3(0,0,0); p.width = 4.0f; p.depth = 4.0f; p.spacing = 2.0f; p.rotationDeg = 90.0f;
+		auto inst = GenerateField(p, 1u, FlatSampler(0.0f));
+		// i=1,j=0 (local (2,0)) tourné de 90° → world ~ (0, *, 2).
+		REQUIRE(inst.size() >= 2);
+		if (inst.size() >= 2)
+		{
+			REQUIRE(Near(inst[1].position.x, 0.0f, 1e-2f));
+			REQUIRE(Near(inst[1].position.z, 2.0f, 1e-2f));
+		}
+	}
+}
+
+int main()
+{
+	Test_Forest_DensityMatchesRecipe();
+	Test_Forest_RulesFilterSlope();
+	Test_Forest_DeterministicWithSeed();
+	Test_Field_RegularSpacing();
+	Test_Field_Rotation();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] ForestFieldTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] ForestFieldTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/tests/HamletTests.cpp
+++ b/src/world_editor/tests/HamletTests.cpp
@@ -1,0 +1,122 @@
+// M100.31 — Tests hameau : kit JSON, déterminisme, min_spacing, snap route,
+// une entrée d'historique. Headless. Lié à engine_core.
+
+#include "src/client/world/instances/PropInstances.h"
+#include "src/client/world/structures/HamletKitLibrary.h"
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/HamletGen.h"
+#include "src/world_editor/PlacementCommand.h"
+#include "src/world_editor/PlacementDocument.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+using namespace engine::editor::world;
+using engine::math::Vec3;
+using engine::world::instances::PropInstance;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	float Dist2D(const Vec3& a, const Vec3& b) { const float dx=a.x-b.x, dz=a.z-b.z; return std::sqrt(dx*dx+dz*dz); }
+
+	std::vector<Vec3> BigPolygon()
+	{
+		return { Vec3(0,0,0), Vec3(80,0,0), Vec3(80,0,80), Vec3(0,0,80) };
+	}
+
+	HamletTerrainSample FlatSampler(float, float) { HamletTerrainSample s; s.slopeDeg = 2.0f; s.terrainY = 10.0f; return s; }
+
+	HamletRecipe Recipe(uint64_t seed, bool snap)
+	{
+		HamletRecipe r; r.seed = seed; r.houseCount = 10; r.minSpacing = 8.0f; r.snapToRoad = snap;
+		r.houseMeshes = { { "human_house_01.glb", 0.5f }, { "human_house_02.glb", 0.5f } };
+		return r;
+	}
+
+	void Test_HamletKit_LoadsHumanKit()
+	{
+		const char* json = R"JSON({
+		  "race": "Humains", "biome": "plains",
+		  "houses": [ { "mesh": "structures/human_house_01.glb", "weight": 0.5 },
+		              { "mesh": "structures/human_house_02.glb", "weight": 0.3 },
+		              { "mesh": "structures/human_house_03.glb", "weight": 0.2 } ],
+		  "minSpacingDefault": 8.0, "footprintRadius": 5.0 })JSON";
+		engine::world::structures::HamletKit kit; std::string err;
+		REQUIRE(engine::world::structures::ParseHamletKitJson(json, kit, err));
+		REQUIRE(kit.race == "Humains");
+		REQUIRE(kit.houses.size() == 3);
+		REQUIRE(std::fabs(kit.minSpacingDefault - 8.0f) < 1e-3f);
+	}
+
+	void Test_Hamlet_DeterministicWithSeed()
+	{
+		uint32_t id1 = 1, id2 = 1;
+		auto a = GenerateHamlet(BigPolygon(), Recipe(42, false), FlatSampler, {}, id1);
+		auto b = GenerateHamlet(BigPolygon(), Recipe(42, false), FlatSampler, {}, id2);
+		REQUIRE(a.size() == b.size());
+		if (!a.empty() && a.size() == b.size())
+			REQUIRE(Dist2D(a[0].position, b[0].position) < 1e-3f);
+	}
+
+	void Test_Hamlet_RespectsMinSpacing()
+	{
+		uint32_t id = 1;
+		auto h = GenerateHamlet(BigPolygon(), Recipe(7, false), FlatSampler, {}, id);
+		REQUIRE(h.size() >= 2);
+		for (size_t i = 0; i < h.size(); ++i)
+			for (size_t j = i + 1; j < h.size(); ++j)
+				REQUIRE(Dist2D(h[i].position, h[j].position) >= 8.0f - 1e-2f);
+	}
+
+	void Test_Hamlet_SnapsToRoadWhenAvailable()
+	{
+		// Route le long de z=0 ; polygone collé à la route (tout < 30 m).
+		std::vector<Vec3> poly = { Vec3(0,0,-8), Vec3(80,0,-8), Vec3(80,0,8), Vec3(0,0,8) };
+		std::vector<Vec3> road = { Vec3(0,0,0), Vec3(80,0,0) };
+		uint32_t id = 1;
+		auto h = GenerateHamlet(poly, Recipe(3, true), FlatSampler, road, id);
+		REQUIRE(!h.empty());
+		// Toutes snappées à ~offset (4 m) de la route z=0.
+		for (const auto& inst : h)
+			REQUIRE(std::fabs(std::fabs(inst.position.z) - 4.0f) < 0.5f);
+	}
+
+	void Test_Hamlet_OneHistoryEntry()
+	{
+		uint32_t id = 1;
+		auto houses = GenerateHamlet(BigPolygon(), Recipe(42, false), FlatSampler, {}, id);
+		PlacementDocument doc;
+		CommandStack stack;
+		stack.Push(std::make_unique<PlacePropsCommand>(doc, houses));
+		REQUIRE(stack.UndoSize() == 1); // une seule entrée pour tout l'hameau
+		REQUIRE(doc.All().size() == houses.size());
+		stack.Undo();
+		REQUIRE(doc.All().empty());
+	}
+}
+
+int main()
+{
+	Test_HamletKit_LoadsHumanKit();
+	Test_Hamlet_DeterministicWithSeed();
+	Test_Hamlet_RespectsMinSpacing();
+	Test_Hamlet_SnapsToRoadWhenAvailable();
+	Test_Hamlet_OneHistoryEntry();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] HamletTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] HamletTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/tests/PlaytestTests.cpp
+++ b/src/world_editor/tests/PlaytestTests.cpp
@@ -1,0 +1,74 @@
+// M100.33 — Tests footstep audio + machine d'état playtest. Headless.
+
+#include "src/client/audio/FootstepAudioSurfaceHook.h"
+#include "src/world_editor/PlaytestMode.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace engine::editor::world;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	void Test_FootstepHook_GrassPlaysStepGrass()
+	{
+		engine::audio::FootstepSurface s; s.surfaceName = "grass"; s.wet = false;
+		auto ev = engine::audio::ResolveFootstep(s, Vec3(1, 0, 2));
+		REQUIRE(ev.id == "step_grass");
+		REQUIRE(std::fabs(ev.pitch - 1.0f) < 1e-4f);
+	}
+
+	void Test_FootstepHook_SnowWetCrunchPitch()
+	{
+		engine::audio::FootstepSurface s; s.surfaceName = "snow"; s.wet = true;
+		auto ev = engine::audio::ResolveFootstep(s, Vec3(0, 0, 0));
+		REQUIRE(ev.id == "step_snow_crunch");
+		REQUIRE(ev.pitch > 1.0f); // +5 % modificateur mouillé
+	}
+
+	void Test_PlaytestMode_TogglePreservesEditorState()
+	{
+		PlaytestMode pt;
+		EditorCameraPose pose; pose.position = Vec3(12, 4, -3); pose.yawDeg = 45.0f; pose.pitchDeg = -10.0f;
+		REQUIRE(!pt.IsActive());
+
+		const bool nowActive = pt.Toggle(pose, Vec3(50, 0, 50));
+		REQUIRE(nowActive);
+		REQUIRE(pt.IsActive());
+		REQUIRE(std::fabs(pt.PlayerStart().x - 50.0f) < 1e-4f);
+
+		// Modifie une "fausse" pose éditeur entre-temps n'affecte pas la sauvegarde.
+		const bool stillActive = pt.Toggle(EditorCameraPose{}, Vec3(0, 0, 0));
+		REQUIRE(!stillActive);
+		REQUIRE(!pt.IsActive());
+		// La pose restaurée est celle sauvegardée à l'entrée.
+		PlaytestMode pt2;
+		pt2.Enter(pose, Vec3(1, 0, 1));
+		const EditorCameraPose restored = pt2.Exit();
+		REQUIRE(std::fabs(restored.position.x - 12.0f) < 1e-4f);
+		REQUIRE(std::fabs(restored.yawDeg - 45.0f) < 1e-4f);
+	}
+}
+
+int main()
+{
+	Test_FootstepHook_GrassPlaysStepGrass();
+	Test_FootstepHook_SnowWetCrunchPitch();
+	Test_PlaytestMode_TogglePreservesEditorState();
+
+	if (g_failed == 0)
+		std::fprintf(stderr, "[OK] PlaytestTests: tous les tests passent\n");
+	else
+		std::fprintf(stderr, "[FAIL] PlaytestTests: %d échec(s)\n", g_failed);
+	return g_failed;
+}

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -14,6 +14,7 @@
 #include "src/client/world/instances/PropInstances.h"
 #include "src/client/world/foliage/FoliageInstances.h"
 #include "src/client/world/wind/WindZones.h"
+#include "src/client/world/thermal/ShadeMap.h"
 
 #include <array>
 #include <cmath>
@@ -788,6 +789,37 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteWindZones: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteShadeMap(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const engine::world::thermal::ShadeMap& shade, std::string& outError)
+	{
+		// M100.27 — shade.bin par chunk.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "chunks" /
+			("chunk_" + std::to_string(chunkX) + "_" + std::to_string(chunkZ));
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteShadeMap: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::thermal::SaveShadeMapBin(shade);
+		const std::filesystem::path file = dir / "shade.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteShadeMap: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteShadeMap: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -12,6 +12,7 @@
 #include "src/shared/routine/RoutineSegmentCodec.h"
 #include "src/client/world/hazard/HazardVolumes.h"
 #include "src/client/world/instances/PropInstances.h"
+#include "src/client/world/foliage/FoliageInstances.h"
 
 #include <array>
 #include <cmath>
@@ -725,6 +726,37 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteProps: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteFoliage(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const std::vector<engine::world::foliage::FoliageInstance>& items, std::string& outError)
+	{
+		// M100.18 — foliage.bin par chunk.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "chunks" /
+			("chunk_" + std::to_string(chunkX) + "_" + std::to_string(chunkZ));
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteFoliage: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::foliage::SaveFoliageBin(items);
+		const std::filesystem::path file = dir / "foliage.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteFoliage: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteFoliage: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -15,6 +15,7 @@
 #include "src/client/world/foliage/FoliageInstances.h"
 #include "src/client/world/wind/WindZones.h"
 #include "src/client/world/thermal/ShadeMap.h"
+#include "src/client/world/zones/Zones.h"
 
 #include <array>
 #include <cmath>
@@ -820,6 +821,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteShadeMap: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteZones(std::string_view outputRootDir,
+		const std::vector<engine::world::zones::GameplayZone>& zones, std::string& outError)
+	{
+		// M100.28 — fichier zone-level instances/zones.bin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteZones: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::zones::SaveZonesBin(zones);
+		const std::filesystem::path file = dir / "zones.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteZones: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteZones: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -13,6 +13,7 @@
 #include "src/client/world/hazard/HazardVolumes.h"
 #include "src/client/world/instances/PropInstances.h"
 #include "src/client/world/foliage/FoliageInstances.h"
+#include "src/client/world/wind/WindZones.h"
 
 #include <array>
 #include <cmath>
@@ -757,6 +758,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteFoliage: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteWindZones(std::string_view outputRootDir,
+		const std::vector<engine::world::wind::WindZone>& zones, std::string& outError)
+	{
+		// M100.20 — fichier zone-level instances/wind_zones.bin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteWindZones: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::wind::SaveWindZonesBin(zones);
+		const std::filesystem::path file = dir / "wind_zones.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteWindZones: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteWindZones: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -16,6 +16,7 @@
 #include "src/client/world/wind/WindZones.h"
 #include "src/client/world/thermal/ShadeMap.h"
 #include "src/client/world/zones/Zones.h"
+#include "src/client/world/spline/SplineInstances.h"
 
 #include <array>
 #include <cmath>
@@ -851,6 +852,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteZones: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteSplines(std::string_view outputRootDir,
+		const std::vector<engine::world::spline::Spline>& splines, std::string& outError)
+	{
+		// M100.29 — fichier zone-level instances/splines.bin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteSplines: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::spline::SaveSplinesBin(splines);
+		const std::filesystem::path file = dir / "splines.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteSplines: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteSplines: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -13,6 +13,7 @@ namespace engine::routine { struct RoutineGraph; }
 namespace engine::world::hazard { struct HazardVolume; }
 namespace engine::world::instances { struct PropInstance; }
 namespace engine::world::foliage { struct FoliageInstance; }
+namespace engine::world::wind { struct WindZone; }
 
 namespace tools::zone_builder
 {
@@ -103,4 +104,11 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteFoliage(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
 		const std::vector<engine::world::foliage::FoliageInstance>& items, std::string& outError);
+
+	/// Écrit `instances/wind_zones.bin` (M100.20) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::wind::
+	/// SaveWindZonesBin` (header-only partagé client). Fichier zone-level.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteWindZones(std::string_view outputRootDir,
+		const std::vector<engine::world::wind::WindZone>& zones, std::string& outError);
 }

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -15,6 +15,7 @@ namespace engine::world::instances { struct PropInstance; }
 namespace engine::world::foliage { struct FoliageInstance; }
 namespace engine::world::wind { struct WindZone; }
 namespace engine::world::thermal { struct ShadeMap; }
+namespace engine::world::zones { struct GameplayZone; }
 
 namespace tools::zone_builder
 {
@@ -119,4 +120,11 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteShadeMap(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
 		const engine::world::thermal::ShadeMap& shade, std::string& outError);
+
+	/// Écrit `instances/zones.bin` (M100.28) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::zones::
+	/// SaveZonesBin` (header-only partagé client). Fichier zone-level.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteZones(std::string_view outputRootDir,
+		const std::vector<engine::world::zones::GameplayZone>& zones, std::string& outError);
 }

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -14,6 +14,7 @@ namespace engine::world::hazard { struct HazardVolume; }
 namespace engine::world::instances { struct PropInstance; }
 namespace engine::world::foliage { struct FoliageInstance; }
 namespace engine::world::wind { struct WindZone; }
+namespace engine::world::thermal { struct ShadeMap; }
 
 namespace tools::zone_builder
 {
@@ -111,4 +112,11 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteWindZones(std::string_view outputRootDir,
 		const std::vector<engine::world::wind::WindZone>& zones, std::string& outError);
+
+	/// Écrit `shade.bin` (M100.27) dans `<outputRootDir>/chunks/chunk_<x>_<z>/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::thermal::
+	/// SaveShadeMapBin` (header-only partagé client). Fichier par chunk.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteShadeMap(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const engine::world::thermal::ShadeMap& shade, std::string& outError);
 }

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -16,6 +16,7 @@ namespace engine::world::foliage { struct FoliageInstance; }
 namespace engine::world::wind { struct WindZone; }
 namespace engine::world::thermal { struct ShadeMap; }
 namespace engine::world::zones { struct GameplayZone; }
+namespace engine::world::spline { struct Spline; }
 
 namespace tools::zone_builder
 {
@@ -127,4 +128,11 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteZones(std::string_view outputRootDir,
 		const std::vector<engine::world::zones::GameplayZone>& zones, std::string& outError);
+
+	/// Écrit `instances/splines.bin` (M100.29) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::spline::
+	/// SaveSplinesBin` (header-only partagé client). Fichier zone-level.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteSplines(std::string_view outputRootDir,
+		const std::vector<engine::world::spline::Spline>& splines, std::string& outError);
 }

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -12,6 +12,7 @@ namespace engine::world::water { struct WaterScene; }
 namespace engine::routine { struct RoutineGraph; }
 namespace engine::world::hazard { struct HazardVolume; }
 namespace engine::world::instances { struct PropInstance; }
+namespace engine::world::foliage { struct FoliageInstance; }
 
 namespace tools::zone_builder
 {
@@ -95,4 +96,11 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteProps(std::string_view outputRootDir,
 		const std::vector<engine::world::instances::PropInstance>& props, std::string& outError);
+
+	/// Écrit `foliage.bin` (M100.18) dans `<outputRootDir>/chunks/chunk_<x>_<z>/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::foliage::
+	/// SaveFoliageBin` (header-only partagé client). Fichier par chunk.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteFoliage(std::string_view outputRootDir, int32_t chunkX, int32_t chunkZ,
+		const std::vector<engine::world::foliage::FoliageInstance>& items, std::string& outError);
 }


### PR DESCRIPTION
## Résumé
**PR groupée du backlog M100** (consolidation pour limiter les PR et les conflits squash en cascade). Contient **M100.18** (Vegetation Library & Density Painting) et **M100.19** (Procedural Forest & Field). **Client/éditeur uniquement.** Basée sur `main` (qui a M100.16 + M100.17).

Les prochains tickets M100 (20, 21, …) seront **ajoutés en commits à CETTE PR** plutôt que dans des PR séparées.

## M100.18 — Vegetation
- `FoliageInstances.h` (format `foliage.bin`), `PoissonDiskSampler` (Bridson, min_radius garanti), `FoliageLibrary` (parser JSON + règles slope/alt/splat), document + commande, outil ImGui, `WriteFoliage`, contenu `library.json`.
- Tests `foliage_tests` : library, Poisson min_radius, filtrage règles, round-trip.

## M100.19 — Forest & Field
- `GenerateForest` (polygone → densité, poids, règles, déterministe) + `GenerateField` (grille tournée régulière). Outils ImGui. Pose via `FoliagePaintCommand`.
- Tests `forest_field_tests` : densité≈recette, filtrage pente, déterminisme, spacing, rotation.

## Écarts assumés
Intégration `GpuDrivenCullingPass` (foliage), tagging splat WheatField/CornField, tests perf — différés (non couverts par les tests).

## Déploiement
✅ Client/éditeur uniquement — pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)