### PR TITLE
chore(tickets): cloture M100.16,17 + M100.18-33 (12 tickets mergés)

### DIFF
--- a/tickets/TICKETS_STATUS.md
+++ b/tickets/TICKETS_STATUS.md
@@ -7,9 +7,9 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 
 | Statut | Nombre |
 |--------|-------:|
-| DONE (clotures) | 322 |
+| DONE (clotures) | 324 |
 | PARTIAL | 33 |
-| TODO | 58 |
+| TODO | 56 |
 | **Total** | 413 |
 
 ### Par milestone
@@ -62,7 +62,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M43 | 1 | 1 | 6 | 8 |
 | M44 | 4 | 0 | 0 | 4 |
 | M45 | 8 | 0 | 0 | 8 |
-| M100 | 29 | 0 | 22 | 51 |
+| M100 | 31 | 0 | 20 | 51 |
 | M101 | 8 | 1 | 2 | 11 |
 | AUTH-UI | 12 | 0 | 0 | 12 |
 | CHAR-MODEL | 3 | 12 | 22 | 37 |
@@ -550,8 +550,8 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M100.13 | DONE | Lacs/rivieres + mesh + flow |
 | M100.14 | DONE | Passe eau SSR + refraction |
 | M100.15 | DONE | Wading/swimming detection |
-| M100.16 | TODO | HazardVolumes/Simulator/Tool absents |
-| M100.17 | TODO | PlacementTool/Ghost/Snapping absents |
+| M100.16 | DONE | Hazard volumes + simulateur + outil (cloture #808) |
+| M100.17 | DONE | Easy placement tool + props.bin (cloture #810) |
 | M100.18 | TODO | FoliagePaintTool/Library/PoissonDisk absents |
 | M100.19 | TODO | ForestTool/FieldTool absents |
 | M100.20 | TODO | WindZoneTool/WindSystem absents |

--- a/tickets/TICKETS_STATUS.md
+++ b/tickets/TICKETS_STATUS.md
@@ -7,9 +7,9 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 
 | Statut | Nombre |
 |--------|-------:|
-| DONE (clotures) | 324 |
+| DONE (clotures) | 334 |
 | PARTIAL | 33 |
-| TODO | 56 |
+| TODO | 46 |
 | **Total** | 413 |
 
 ### Par milestone
@@ -62,7 +62,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M43 | 1 | 1 | 6 | 8 |
 | M44 | 4 | 0 | 0 | 4 |
 | M45 | 8 | 0 | 0 | 8 |
-| M100 | 31 | 0 | 20 | 51 |
+| M100 | 41 | 0 | 10 | 51 |
 | M101 | 8 | 1 | 2 | 11 |
 | AUTH-UI | 12 | 0 | 0 | 12 |
 | CHAR-MODEL | 3 | 12 | 22 | 37 |
@@ -552,22 +552,22 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M100.15 | DONE | Wading/swimming detection |
 | M100.16 | DONE | Hazard volumes + simulateur + outil (cloture #808) |
 | M100.17 | DONE | Easy placement tool + props.bin (cloture #810) |
-| M100.18 | TODO | FoliagePaintTool/Library/PoissonDisk absents |
-| M100.19 | TODO | ForestTool/FieldTool absents |
-| M100.20 | TODO | WindZoneTool/WindSystem absents |
-| M100.21 | TODO | EntityInfluenceCollector/foliage shader absents |
+| M100.18 | DONE | Vegetation library + Poisson-disk + density (cloture #811) |
+| M100.19 | DONE | Forest/Field generators procéduraux (cloture #811) |
+| M100.20 | DONE | Wind system + zones (sway/override) (cloture #811) |
+| M100.21 | DONE | EntityInfluenceCollector + flexion (cloture #811) |
 | M100.22 | DONE | Fog volumetrique froxel |
 | M100.23 | DONE | Distance/height fog + zones |
 | M100.24 | DONE | Sun/sky ToDxToY + probes |
 | M100.25 | DONE | Saisons client+broadcaster |
 | M100.26 | DONE | Meteo 6 types + modifiers |
-| M100.27 | TODO | ShadeMap/ThermalQueryService absents |
-| M100.28 | TODO | ZoneTool/Zones absents |
-| M100.29 | TODO | SplineTool/SplineInstances absents |
-| M100.30 | TODO | BridgeTool/WallTool absents |
-| M100.31 | TODO | HamletGeneratorTool absent |
+| M100.27 | DONE | Shade map + ComputeTemperature + ThermalQuery (cloture #811) |
+| M100.28 | DONE | Gameplay zones + WeatherOverride blend (cloture #811) |
+| M100.29 | DONE | Spline sampler + roads (Catmull-Rom, splat) (cloture #811) |
+| M100.30 | DONE | Bridges/walls + splines v2 + surface pont (cloture #811) |
+| M100.31 | DONE | Hamlet generator + kits (cloture #811) |
 | M100.32 | TODO | InteractiveProps/relay absents |
-| M100.33 | TODO | FootstepAudio/PlaytestMode absents |
+| M100.33 | DONE | Footstep audio + PlaytestMode (cloture #811) |
 | M100.34 | TODO | SelectionTool/Layers/Minimap/Exporter absents |
 | M100.35 | DONE | Mountain range tools |
 | M100.36 | DONE | River network generator |

--- a/tickets/issues/M100.16-HazardVolumeSystem_Issue.md
+++ b/tickets/issues/M100.16-HazardVolumeSystem_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.16
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #808, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.16 — Hazard Volume System
 
 ## Résumé

--- a/tickets/issues/M100.17-EasyPlacementTool_Issue.md
+++ b/tickets/issues/M100.17-EasyPlacementTool_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.17
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #810, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.17 — Easy Placement Tool
 
 ## Résumé

--- a/tickets/issues/M100.18-VegetationLibraryAndDensityPainting_Issue.md
+++ b/tickets/issues/M100.18-VegetationLibraryAndDensityPainting_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.18
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.18 — Vegetation Library & Density Painting
 
 ## Résumé

--- a/tickets/issues/M100.19-ProceduralForestAndFieldTools_Issue.md
+++ b/tickets/issues/M100.19-ProceduralForestAndFieldTools_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.19
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.19 — Procedural Forest & Field Tools
 
 ## Résumé

--- a/tickets/issues/M100.20-VegetationWindAnimation_Issue.md
+++ b/tickets/issues/M100.20-VegetationWindAnimation_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.20
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.20 — Vegetation Wind Animation
 
 ## Résumé

--- a/tickets/issues/M100.21-VegetationPlayerInteractionShader_Issue.md
+++ b/tickets/issues/M100.21-VegetationPlayerInteractionShader_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.21
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.21 — Vegetation Player Interaction Shader
 
 ## Résumé

--- a/tickets/issues/M100.27-ShadeMapAndThermalMap_Issue.md
+++ b/tickets/issues/M100.27-ShadeMapAndThermalMap_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.27
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.27 — Shade Map & Thermal Map (`ThermalQuery`)
 
 ## Résumé

--- a/tickets/issues/M100.28-GameplayZonesAndWeatherZones_Issue.md
+++ b/tickets/issues/M100.28-GameplayZonesAndWeatherZones_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.28
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.28 — Gameplay Zones & Weather Zones
 
 ## Résumé

--- a/tickets/issues/M100.29-SplineToolAndRoads_Issue.md
+++ b/tickets/issues/M100.29-SplineToolAndRoads_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.29
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.29 — Spline Tool & Roads
 
 ## Résumé

--- a/tickets/issues/M100.30-BridgesAndModularWalls_Issue.md
+++ b/tickets/issues/M100.30-BridgesAndModularWalls_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.30
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.30 — Bridges & Modular Walls
 
 ## Résumé

--- a/tickets/issues/M100.31-HamletGenerator_Issue.md
+++ b/tickets/issues/M100.31-HamletGenerator_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.31
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.31 — Hamlet Generator
 
 ## Résumé

--- a/tickets/issues/M100.33-FootstepAudioAndPlaytestMode_Issue.md
+++ b/tickets/issues/M100.33-FootstepAudioAndPlaytestMode_Issue.md
@@ -1,3 +1,11 @@
+# Issue: M100.33
+
+**Status:** Closed
+
+_Implemente et merge sur `main` (PR #811, batch M100, CI verte Linux+Windows). Cloture le 2026-06-04._
+
+---
+
 # M100.33 — Footstep Audio Surface Hook & Playtest Mode (F5)
 
 ## Résumé


### PR DESCRIPTION
Bookkeeping de cloture pour tous les tickets M100 mergés à ce jour : #808 (16), #810 (17), #811 (18,19,20,21,27,28,29,30,31,33).

- 12 tickets déplacés `tickets/M100/` -> `tickets/issues/*_Issue.md` (bannière Closed).
- `TICKETS_STATUS.md` : ces 12 -> DONE ; synthèse M100 = **41 DONE / 0 PARTIAL / 10 TODO** ; totaux **334 / 33 / 46 / 413**.

Restent dans `tickets/M100/` (TODO) : M100.32, 34, 41, 42 + doc 45, 47, 48, 49, 50, 51.

Docs uniquement — aucun code, aucun redéploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)