### PR TITLE
feat(world): M100.32 — Interactive Props (portes/fenêtres/trappes/coffres)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,10 @@ add_library(engine_core
   # M100.17 — Easy Placement Tool (geometrie pure + outil ; format/commande header-only).
   src/world_editor/PlacementGeometry.cpp
   src/world_editor/PlacementTool.cpp
+  # M100.32 — Interactive Props (simulateur d'animation pur + panneau editeur ;
+  # types/format/relais header-only ; payloads reseau partages).
+  src/client/world/interactive/InteractiveSimulator.cpp
+  src/world_editor/InteractivePanel.cpp
   # M100.18 — Vegetation library + density painting (library JSON + Poisson-disk + outil).
   src/client/world/foliage/FoliageLibrary.cpp
   src/client/world/foliage/PoissonDiskSampler.cpp
@@ -690,6 +694,7 @@ add_library(engine_core
   src/shared/network/OutdoorPvpPayloads.cpp
   src/shared/network/WeatherPayloads.cpp
   src/shared/network/GameEventPayloads.cpp
+  src/shared/network/InteractivePayloads.cpp
   src/shared/network/GuildPayloads.cpp
   src/shared/network/AuctionPayloads.cpp
   src/shared/network/LootPayloads.cpp
@@ -938,6 +943,13 @@ add_test(NAME routine_help_content_tests COMMAND routine_help_content_tests)
 add_executable(hazard_tests src/client/world/hazard/tests/HazardTests.cpp)
 target_link_libraries(hazard_tests PRIVATE engine_core)
 add_test(NAME hazard_tests COMMAND hazard_tests)
+
+# M100.32 — Tests Interactive Props (round-trip binaire + simulateur + reseau +
+# relais serveur). Types/format/relais header-only ; simulateur + payloads dans
+# engine_core : on ne lie QUE engine_core (pas de doublon).
+add_executable(interactive_tests src/client/world/interactive/tests/InteractiveTests.cpp)
+target_link_libraries(interactive_tests PRIVATE engine_core)
+add_test(NAME interactive_tests COMMAND interactive_tests)
 
 # M100.17 — Tests placement (geometrie pure + format props.bin + commande).
 add_executable(placement_tests src/world_editor/tests/PlacementTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/weather/WeatherHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/events/GameEventHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/interactive/InteractiveHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/guild/GuildHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/loot/LootHandler.cpp
@@ -161,6 +162,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/OutdoorPvpPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/WeatherPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GameEventPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/InteractivePayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/GuildPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LootPayloads.cpp

--- a/src/client/world/interactive/InteractiveInstances.h
+++ b/src/client/world/interactive/InteractiveInstances.h
@@ -1,0 +1,156 @@
+#pragma once
+
+// M100.32 — Sérialisation `instances/interactives.bin`.
+//
+// Sérialisation HEADER-ONLY (inline) : partagée engine_core (runtime/éditeur)
+// et zone_builder_lib (writer offline) sans dupliquer de symboles. En-tête
+// 24 octets compatible `engine::world::OutputVersionHeader`. Round-trip parfait
+// (parité éditeur ↔ client). Fichier zone-level (pas par chunk).
+//
+// Layout (cf. ticket M100.32) :
+//   [0..3]   uint32 magic ("INCT")
+//   [4..7]   uint32 version
+//   [8..11]  uint32 builderVersion
+//   [12..15] uint32 engineVersion
+//   [16..23] uint64 contentHash (0 ici, réservé)
+//   [24..27] uint32 instanceCount
+//   par instance : id(u64) type(u16) position(3xf32) rotationY(f32)
+//                  meshAssetId(u32) pivotLocal(3xf32) axisLocal(3xf32)
+//                  openAngleDeg(f32) animDurationSec(f32) initialState(u8)
+//                  audioOpenEvent(u32 len + bytes) audioCloseEvent(u32 len + bytes)
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "src/client/world/interactive/InteractiveTypes.h"
+
+namespace engine::world::interactive
+{
+	namespace detail
+	{
+		inline void PutU16(std::vector<uint8_t>& b, uint16_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+		}
+		inline void PutU32(std::vector<uint8_t>& b, uint32_t v)
+		{
+			b.push_back(uint8_t(v)); b.push_back(uint8_t(v >> 8));
+			b.push_back(uint8_t(v >> 16)); b.push_back(uint8_t(v >> 24));
+		}
+		inline void PutU64(std::vector<uint8_t>& b, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i) b.push_back(uint8_t(v >> (8 * i)));
+		}
+		inline void PutF32(std::vector<uint8_t>& b, float f)
+		{
+			uint32_t u; std::memcpy(&u, &f, 4); PutU32(b, u);
+		}
+		inline void PutStr(std::vector<uint8_t>& b, const std::string& s)
+		{
+			PutU32(b, static_cast<uint32_t>(s.size()));
+			for (char c : s) b.push_back(static_cast<uint8_t>(c));
+		}
+		inline bool GetU16(std::span<const uint8_t> b, size_t& p, uint16_t& out)
+		{
+			if (p + 2 > b.size()) return false;
+			out = uint16_t(b[p]) | (uint16_t(b[p + 1]) << 8);
+			p += 2; return true;
+		}
+		inline bool GetU32(std::span<const uint8_t> b, size_t& p, uint32_t& out)
+		{
+			if (p + 4 > b.size()) return false;
+			out = uint32_t(b[p]) | (uint32_t(b[p + 1]) << 8) | (uint32_t(b[p + 2]) << 16) |
+			      (uint32_t(b[p + 3]) << 24);
+			p += 4; return true;
+		}
+		inline bool GetU64(std::span<const uint8_t> b, size_t& p, uint64_t& out)
+		{
+			if (p + 8 > b.size()) return false;
+			out = 0; for (int i = 0; i < 8; ++i) out |= uint64_t(b[p + i]) << (8 * i);
+			p += 8; return true;
+		}
+		inline bool GetF32(std::span<const uint8_t> b, size_t& p, float& out)
+		{
+			uint32_t u; if (!GetU32(b, p, u)) return false;
+			std::memcpy(&out, &u, 4); return true;
+		}
+		inline bool GetStr(std::span<const uint8_t> b, size_t& p, std::string& out)
+		{
+			uint32_t len = 0;
+			if (!GetU32(b, p, len)) return false;
+			if (p + len > b.size()) return false;
+			out.assign(reinterpret_cast<const char*>(b.data() + p), len);
+			p += len; return true;
+		}
+	}
+
+	/// Sérialise une liste d'instances interactives dans le format
+	/// `instances/interactives.bin`. Round-trip exact avec `LoadInteractivesBin`.
+	inline std::vector<uint8_t> SaveInteractivesBin(const std::vector<InteractivePropInstance>& items)
+	{
+		std::vector<uint8_t> b;
+		detail::PutU32(b, kInteractivesMagic);
+		detail::PutU32(b, kInteractivesVersion);
+		detail::PutU32(b, kInteractivesBuilderVersion);
+		detail::PutU32(b, kInteractivesEngineVersion);
+		detail::PutU64(b, 0ull);
+		detail::PutU32(b, static_cast<uint32_t>(items.size()));
+		for (const InteractivePropInstance& it : items)
+		{
+			detail::PutU64(b, it.id);
+			detail::PutU16(b, static_cast<uint16_t>(it.type));
+			detail::PutF32(b, it.position.x); detail::PutF32(b, it.position.y); detail::PutF32(b, it.position.z);
+			detail::PutF32(b, it.rotationY);
+			detail::PutU32(b, it.meshAssetId);
+			detail::PutF32(b, it.pivotLocal.x); detail::PutF32(b, it.pivotLocal.y); detail::PutF32(b, it.pivotLocal.z);
+			detail::PutF32(b, it.axisLocal.x); detail::PutF32(b, it.axisLocal.y); detail::PutF32(b, it.axisLocal.z);
+			detail::PutF32(b, it.openAngleDeg);
+			detail::PutF32(b, it.animDurationSec);
+			b.push_back(it.initialState);
+			detail::PutStr(b, it.audioOpenEvent);
+			detail::PutStr(b, it.audioCloseEvent);
+		}
+		return b;
+	}
+
+	/// Désérialise `instances/interactives.bin`. Retourne false + `err` rempli
+	/// si magic invalide, version non supportée ou buffer tronqué.
+	inline bool LoadInteractivesBin(std::span<const uint8_t> bytes,
+		std::vector<InteractivePropInstance>& out, std::string& err)
+	{
+		size_t p = 0;
+		uint32_t magic = 0, version = 0, builder = 0, engine = 0; uint64_t hash = 0;
+		if (!detail::GetU32(bytes, p, magic) || magic != kInteractivesMagic) { err = "interactives.bin: magic invalide"; return false; }
+		if (!detail::GetU32(bytes, p, version) || version > kInteractivesVersion) { err = "interactives.bin: version non supportee"; return false; }
+		detail::GetU32(bytes, p, builder);
+		detail::GetU32(bytes, p, engine);
+		detail::GetU64(bytes, p, hash);
+		uint32_t count = 0;
+		if (!detail::GetU32(bytes, p, count)) { err = "interactives.bin: compteur manquant"; return false; }
+		out.clear(); out.reserve(count);
+		for (uint32_t i = 0; i < count; ++i)
+		{
+			InteractivePropInstance it;
+			uint16_t typeRaw = 0;
+			if (!detail::GetU64(bytes, p, it.id)) { err = "interactives.bin: tronque (id)"; return false; }
+			if (!detail::GetU16(bytes, p, typeRaw)) { err = "interactives.bin: tronque (type)"; return false; }
+			it.type = static_cast<InteractiveType>(typeRaw);
+			detail::GetF32(bytes, p, it.position.x); detail::GetF32(bytes, p, it.position.y); detail::GetF32(bytes, p, it.position.z);
+			detail::GetF32(bytes, p, it.rotationY);
+			detail::GetU32(bytes, p, it.meshAssetId);
+			detail::GetF32(bytes, p, it.pivotLocal.x); detail::GetF32(bytes, p, it.pivotLocal.y); detail::GetF32(bytes, p, it.pivotLocal.z);
+			detail::GetF32(bytes, p, it.axisLocal.x); detail::GetF32(bytes, p, it.axisLocal.y); detail::GetF32(bytes, p, it.axisLocal.z);
+			detail::GetF32(bytes, p, it.openAngleDeg);
+			detail::GetF32(bytes, p, it.animDurationSec);
+			if (p + 1 > bytes.size()) { err = "interactives.bin: tronque (initialState)"; return false; }
+			it.initialState = bytes[p]; p += 1;
+			if (!detail::GetStr(bytes, p, it.audioOpenEvent)) { err = "interactives.bin: tronque (audioOpen)"; return false; }
+			if (!detail::GetStr(bytes, p, it.audioCloseEvent)) { err = "interactives.bin: tronque (audioClose)"; return false; }
+			out.push_back(std::move(it));
+		}
+		return true;
+	}
+}

--- a/src/client/world/interactive/InteractiveSimulator.cpp
+++ b/src/client/world/interactive/InteractiveSimulator.cpp
@@ -1,0 +1,107 @@
+// M100.32 — Implémentation InteractiveSimulator (logique pure).
+
+#include "src/client/world/interactive/InteractiveSimulator.h"
+
+namespace engine::world::interactive
+{
+	namespace
+	{
+		inline float Clamp01(float v)
+		{
+			if (v < 0.0f) return 0.0f;
+			if (v > 1.0f) return 1.0f;
+			return v;
+		}
+
+		inline bool IsRotational(InteractiveType t)
+		{
+			return t != InteractiveType::DoorSliding;
+		}
+	}
+
+	InteractiveRuntimeState MakeInitialRuntimeState(const InteractivePropInstance& def)
+	{
+		InteractiveRuntimeState rt;
+		rt.targetState = def.initialState != 0u ? 1u : 0u;
+		rt.openFactor  = rt.targetState != 0u ? 1.0f : 0.0f;
+		return rt;
+	}
+
+	uint8_t ToggleInteractive(InteractiveRuntimeState& rt)
+	{
+		rt.targetState = rt.targetState != 0u ? 0u : 1u;
+		return rt.targetState;
+	}
+
+	void SetInteractiveTarget(InteractiveRuntimeState& rt, uint8_t newState)
+	{
+		rt.targetState = newState != 0u ? 1u : 0u;
+	}
+
+	void UpdateInteractive(InteractiveRuntimeState& rt, const InteractivePropInstance& def, float dtSec)
+	{
+		const float target = rt.targetState != 0u ? 1.0f : 0.0f;
+
+		// Durée non positive : application instantanée.
+		if (def.animDurationSec <= 0.0f)
+		{
+			rt.openFactor = target;
+			return;
+		}
+
+		if (dtSec < 0.0f) dtSec = 0.0f;
+		const float step = dtSec / def.animDurationSec; // fraction de course parcourue.
+
+		if (rt.openFactor < target)
+		{
+			rt.openFactor = Clamp01(rt.openFactor + step);
+			if (rt.openFactor > target) rt.openFactor = target;
+		}
+		else if (rt.openFactor > target)
+		{
+			rt.openFactor = Clamp01(rt.openFactor - step);
+			if (rt.openFactor < target) rt.openFactor = target;
+		}
+	}
+
+	void ApplyRemoteState(InteractiveRuntimeState& rt, const InteractivePropInstance& def,
+		uint8_t newState, float latencySec)
+	{
+		SetInteractiveTarget(rt, newState);
+		if (latencySec < 0.0f) latencySec = 0.0f;
+
+		const float target = rt.targetState != 0u ? 1.0f : 0.0f;
+
+		// Durée non positive : la porte est déjà à destination.
+		if (def.animDurationSec <= 0.0f)
+		{
+			rt.openFactor = target;
+			return;
+		}
+
+		// Avance la course de la fraction écoulée depuis l'évènement distant.
+		const float advanced = Clamp01(latencySec / def.animDurationSec);
+		if (target >= 1.0f)
+			rt.openFactor = Clamp01(rt.openFactor + advanced);
+		else
+			rt.openFactor = Clamp01(rt.openFactor - advanced);
+	}
+
+	float ComputeOpenAngleDeg(const InteractivePropInstance& def, const InteractiveRuntimeState& rt)
+	{
+		if (!IsRotational(def.type)) return 0.0f;
+		return def.openAngleDeg * Clamp01(rt.openFactor);
+	}
+
+	float ComputeSlideOffsetMeters(const InteractivePropInstance& def, const InteractiveRuntimeState& rt)
+	{
+		if (IsRotational(def.type)) return 0.0f;
+		return def.openAngleDeg * Clamp01(rt.openFactor);
+	}
+
+	bool IsAnimating(const InteractiveRuntimeState& rt)
+	{
+		const float target = rt.targetState != 0u ? 1.0f : 0.0f;
+		return rt.openFactor != target;
+	}
+}

--- a/src/client/world/interactive/InteractiveSimulator.h
+++ b/src/client/world/interactive/InteractiveSimulator.h
@@ -1,0 +1,67 @@
+#pragma once
+
+// M100.32 — InteractiveSimulator : animation locale open/close (logique PURE,
+// déterministe, sans dépendance rendu/audio/réseau). STRICTEMENT CLIENT/ÉDITEUR
+// (jamais compilé côté serveur : le master ne fait que relayer l'état).
+//
+// Le simulateur fait évoluer un facteur d'ouverture `openFactor` ∈ [0,1]
+// (0 = fermé, 1 = ouvert) vers l'état cible, à la vitesse 1/animDurationSec.
+// Le bouton "Trigger" de l'éditeur et le client en jeu appellent les mêmes
+// fonctions (parité éditeur ↔ client) ; seul l'envoi réseau diffère.
+//
+// Compensation de latence : à la réception d'un évènement distant daté, on
+// avance immédiatement `openFactor` de `latencySec / animDurationSec` vers la
+// cible pour que la porte ne « saute » pas (transition visible, pas de pop).
+
+#include <cstdint>
+
+#include "src/client/world/interactive/InteractiveTypes.h"
+
+namespace engine::world::interactive
+{
+	/// État runtime d'une instance interactive côté client/éditeur.
+	struct InteractiveRuntimeState
+	{
+		uint8_t targetState = 0;   ///< Cible logique : 0 = fermé, 1 = ouvert.
+		float   openFactor  = 0.0f; ///< Avancement courant ∈ [0,1] (0 fermé, 1 ouvert).
+	};
+
+	/// Construit l'état runtime initial à partir de la définition (initialState).
+	/// `openFactor` est aligné sur l'état initial (0 ou 1) — pas d'animation.
+	InteractiveRuntimeState MakeInitialRuntimeState(const InteractivePropInstance& def);
+
+	/// Bascule la cible (fermé ↔ ouvert) sans téléportation : `openFactor`
+	/// animera vers la nouvelle cible aux prochains `UpdateInteractive`.
+	/// \return le nouvel état logique cible (0/1).
+	uint8_t ToggleInteractive(InteractiveRuntimeState& rt);
+
+	/// Force une cible explicite (utilisé pour appliquer un état réseau).
+	void SetInteractiveTarget(InteractiveRuntimeState& rt, uint8_t newState);
+
+	/// Avance l'animation de `dtSec` secondes vers la cible. `openFactor` est
+	/// clampé dans [0,1]. `animDurationSec` ≤ 0 ⇒ application instantanée.
+	void UpdateInteractive(InteractiveRuntimeState& rt, const InteractivePropInstance& def, float dtSec);
+
+	/// Applique un état distant reçu du serveur avec compensation de latence :
+	/// fixe la cible à `newState`, puis avance `openFactor` de
+	/// `latencySec / animDurationSec` vers la cible (clampé). L'évènement étant
+	/// survenu `latencySec` plus tôt côté émetteur, l'animation démarre déjà
+	/// avancée — la porte ne saute pas.
+	/// \param latencySec délai estimé depuis l'évènement (s) ; < 0 traité comme 0.
+	void ApplyRemoteState(InteractiveRuntimeState& rt, const InteractivePropInstance& def,
+		uint8_t newState, float latencySec);
+
+	/// Angle d'ouverture courant en degrés (types rotatifs : DoorHinge /
+	/// WindowHinge / Trapdoor / ChestSimple). Vaut `openAngleDeg * openFactor`.
+	/// Pour DoorSliding, renvoie 0 (utiliser ComputeSlideOffsetMeters).
+	float ComputeOpenAngleDeg(const InteractivePropInstance& def, const InteractiveRuntimeState& rt);
+
+	/// Décalage de translation courant en mètres (DoorSliding uniquement).
+	/// Vaut `openAngleDeg * openFactor` (le champ porte la translation max).
+	/// Pour les types rotatifs, renvoie 0.
+	float ComputeSlideOffsetMeters(const InteractivePropInstance& def, const InteractiveRuntimeState& rt);
+
+	/// True si l'objet est en cours d'animation (openFactor strictement entre
+	/// les deux extrêmes, ou pas encore aligné sur la cible).
+	bool IsAnimating(const InteractiveRuntimeState& rt);
+}

--- a/src/client/world/interactive/InteractiveTypes.h
+++ b/src/client/world/interactive/InteractiveTypes.h
@@ -1,0 +1,60 @@
+#pragma once
+
+// M100.32 — Interactive Props : enum + struct (GELÉS).
+//
+// Périmètre strictement borné : porte battante, porte coulissante, fenêtre
+// battante, trappe, coffre simple. AUCUN autre type. Toute extension doit
+// passer par un futur ticket dédié bumpant `kInteractivesVersion`.
+//
+// Ce header ne dépend que de Math.h (Vec3) : il est inclus côté client
+// (rendu/animation), côté éditeur (panneau de pose) et côté serveur relais
+// (uniquement pour `InteractiveType`/id, jamais l'animation).
+
+#include <cstdint>
+#include <string>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::world::interactive
+{
+	/// Types d'objets interactifs supportés. VOLONTAIREMENT FIGÉ à 5 valeurs.
+	/// Tout ajout doit être fait par un futur ticket dédié, en bumpant
+	/// `kInteractivesVersion` et en versionnant la sérialisation.
+	enum class InteractiveType : uint16_t
+	{
+		DoorHinge   = 0, ///< Porte battante (rotation autour d'un pivot/axe local).
+		DoorSliding = 1, ///< Porte coulissante (translation le long de l'axe local).
+		WindowHinge = 2, ///< Fenêtre battante (rotation, comme DoorHinge).
+		Trapdoor    = 3, ///< Trappe (rotation, pivot au bord).
+		ChestSimple = 4  ///< Coffre simple (rotation du couvercle ; pas d'inventaire — hors scope).
+		// FIGÉ. Ne rien ajouter ici sans bumper kInteractivesVersion (ticket dédié).
+	};
+
+	/// Une instance d'objet interactif posée par l'éditeur monde.
+	///
+	/// `openAngleDeg` est interprété en degrés pour les types rotatifs
+	/// (DoorHinge / WindowHinge / Trapdoor / ChestSimple) et en MÈTRES de
+	/// translation pour DoorSliding (déplacement le long de `axisLocal`).
+	struct InteractivePropInstance
+	{
+		uint64_t           id              = 0;          ///< Identifiant unique de l'objet dans la zone.
+		InteractiveType    type            = InteractiveType::DoorHinge;
+		engine::math::Vec3 position{ 0.0f, 0.0f, 0.0f };
+		float              rotationY       = 0.0f;       ///< Orientation de pose (radians, autour de +Y).
+		uint32_t           meshAssetId     = 0;          ///< Hash de l'asset glTF rendu.
+		engine::math::Vec3 pivotLocal{ 0.0f, 0.0f, 0.0f }; ///< Pivot de rotation (espace local de l'objet).
+		engine::math::Vec3 axisLocal{ 0.0f, 1.0f, 0.0f };  ///< Axe de rotation OU direction de translation (espace local).
+		float              openAngleDeg    = 90.0f;      ///< Angle d'ouverture (°) ou translation (m) pour DoorSliding.
+		float              animDurationSec = 0.5f;       ///< Durée d'animation open/close (secondes).
+		uint8_t            initialState    = 0;          ///< 0 = fermé, 1 = ouvert.
+		std::string        audioOpenEvent;               ///< Clé d'évènement audio à l'ouverture (vide = aucun).
+		std::string        audioCloseEvent;              ///< Clé d'évènement audio à la fermeture (vide = aucun).
+	};
+
+	/// Magic du fichier `instances/interactives.bin` ("INCT" little-endian).
+	constexpr uint32_t kInteractivesMagic        = 0x54434E49u;
+	/// Version de format. À bumper pour toute évolution du layout/enum.
+	constexpr uint32_t kInteractivesVersion       = 1u;
+	constexpr uint32_t kInteractivesBuilderVersion = 1u;
+	constexpr uint32_t kInteractivesEngineVersion  = 1u;
+}

--- a/src/client/world/interactive/tests/InteractiveTests.cpp
+++ b/src/client/world/interactive/tests/InteractiveTests.cpp
@@ -1,0 +1,278 @@
+// M100.32 — Tests Interactive Props : round-trip binaire + simulateur
+// (animation des 5 types + compensation de latence) + round-trip réseau
+// (3 messages) + relai serveur (no-validation + sync initial).
+//
+// Headless. Lié à engine_core (InteractiveSimulator + InteractivePayloads) ;
+// format binaire + InteractiveStateRelay header-only.
+
+#include "src/client/world/interactive/InteractiveInstances.h"
+#include "src/client/world/interactive/InteractiveSimulator.h"
+#include "src/client/world/interactive/InteractiveTypes.h"
+#include "src/masterd/InteractiveStateRelay.h"
+#include "src/shared/network/InteractivePayloads.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace engine::world::interactive;
+using namespace engine::network;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-4f) { return (a - b < eps) && (b - a < eps); }
+
+	InteractivePropInstance MakeDef(InteractiveType type, float openVal, float dur)
+	{
+		InteractivePropInstance d;
+		d.id = 1;
+		d.type = type;
+		d.openAngleDeg = openVal;
+		d.animDurationSec = dur;
+		d.initialState = 0;
+		return d;
+	}
+
+	// ---------------------------------------------------------------------
+	// Round-trip binaire interactives.bin
+	// ---------------------------------------------------------------------
+	void Test_Interactives_Roundtrip()
+	{
+		std::vector<InteractivePropInstance> in;
+		InteractivePropInstance a;
+		a.id = 42; a.type = InteractiveType::DoorHinge;
+		a.position = { 1.0f, 2.0f, 3.0f }; a.rotationY = 1.57f;
+		a.meshAssetId = 0xABCDu;
+		a.pivotLocal = { -0.4f, 0.0f, 0.0f }; a.axisLocal = { 0.0f, 1.0f, 0.0f };
+		a.openAngleDeg = 90.0f; a.animDurationSec = 0.5f; a.initialState = 0;
+		a.audioOpenEvent = "door_creak_open"; a.audioCloseEvent = "door_thud_close";
+
+		InteractivePropInstance b;
+		b.id = 7; b.type = InteractiveType::DoorSliding;
+		b.openAngleDeg = 2.5f; b.animDurationSec = 1.0f; b.initialState = 1;
+		b.audioOpenEvent = ""; b.audioCloseEvent = "slide";
+
+		InteractivePropInstance c;
+		c.id = 99; c.type = InteractiveType::ChestSimple;
+		c.meshAssetId = 5;
+
+		in = { a, b, c };
+		std::vector<uint8_t> bytes = SaveInteractivesBin(in);
+		std::vector<InteractivePropInstance> out;
+		std::string err;
+		REQUIRE(LoadInteractivesBin(bytes, out, err));
+		REQUIRE(out.size() == 3);
+		if (out.size() == 3)
+		{
+			REQUIRE(out[0].id == 42 && out[0].type == InteractiveType::DoorHinge);
+			REQUIRE(Near(out[0].position.x, 1.0f) && Near(out[0].position.z, 3.0f));
+			REQUIRE(Near(out[0].rotationY, 1.57f));
+			REQUIRE(out[0].meshAssetId == 0xABCDu);
+			REQUIRE(Near(out[0].pivotLocal.x, -0.4f));
+			REQUIRE(Near(out[0].openAngleDeg, 90.0f));
+			REQUIRE(out[0].audioOpenEvent == "door_creak_open");
+			REQUIRE(out[0].audioCloseEvent == "door_thud_close");
+			REQUIRE(out[1].type == InteractiveType::DoorSliding);
+			REQUIRE(out[1].initialState == 1);
+			REQUIRE(out[1].audioOpenEvent.empty() && out[1].audioCloseEvent == "slide");
+			REQUIRE(out[2].id == 99 && out[2].type == InteractiveType::ChestSimple);
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Simulateur — animations
+	// ---------------------------------------------------------------------
+	void Test_Simulator_AnimatesDoorHinge()
+	{
+		InteractivePropInstance d = MakeDef(InteractiveType::DoorHinge, 90.0f, 0.5f);
+		InteractiveRuntimeState rt = MakeInitialRuntimeState(d);
+		REQUIRE(Near(rt.openFactor, 0.0f));
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 0.0f));
+
+		ToggleInteractive(rt);
+		REQUIRE(rt.targetState == 1);
+		UpdateInteractive(rt, d, 0.25f); // mi-course
+		REQUIRE(Near(rt.openFactor, 0.5f));
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 45.0f));
+		UpdateInteractive(rt, d, 0.5f); // dépasse la fin → clampé
+		REQUIRE(Near(rt.openFactor, 1.0f));
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 90.0f));
+		REQUIRE(!IsAnimating(rt));
+
+		// Fermeture.
+		ToggleInteractive(rt);
+		UpdateInteractive(rt, d, 0.5f);
+		REQUIRE(Near(rt.openFactor, 0.0f));
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 0.0f));
+	}
+
+	void Test_Simulator_AnimatesSliding()
+	{
+		InteractivePropInstance d = MakeDef(InteractiveType::DoorSliding, 2.0f, 1.0f); // 2 m
+		InteractiveRuntimeState rt = MakeInitialRuntimeState(d);
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 0.0f)); // pas un type rotatif
+		ToggleInteractive(rt);
+		UpdateInteractive(rt, d, 0.5f);
+		REQUIRE(Near(ComputeSlideOffsetMeters(d, rt), 1.0f)); // mi-course = 1 m
+		UpdateInteractive(rt, d, 0.5f);
+		REQUIRE(Near(ComputeSlideOffsetMeters(d, rt), 2.0f));
+	}
+
+	void Test_Simulator_AnimatesTrapdoor()
+	{
+		InteractivePropInstance d = MakeDef(InteractiveType::Trapdoor, 80.0f, 0.4f);
+		InteractiveRuntimeState rt = MakeInitialRuntimeState(d);
+		ToggleInteractive(rt);
+		UpdateInteractive(rt, d, 0.4f);
+		REQUIRE(Near(rt.openFactor, 1.0f));
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 80.0f));
+		REQUIRE(Near(ComputeSlideOffsetMeters(d, rt), 0.0f)); // pas un slider
+	}
+
+	void Test_Simulator_AnimatesChest()
+	{
+		InteractivePropInstance d = MakeDef(InteractiveType::ChestSimple, 60.0f, 0.3f);
+		InteractiveRuntimeState rt = MakeInitialRuntimeState(d);
+		ToggleInteractive(rt);
+		UpdateInteractive(rt, d, 0.15f); // mi-course
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 30.0f));
+		UpdateInteractive(rt, d, 0.15f);
+		REQUIRE(Near(ComputeOpenAngleDeg(d, rt), 60.0f));
+	}
+
+	// ---------------------------------------------------------------------
+	// Compensation de latence
+	// ---------------------------------------------------------------------
+	void Test_Client_RemoteAnimationLatencyCompensation()
+	{
+		InteractivePropInstance d = MakeDef(InteractiveType::DoorHinge, 90.0f, 0.5f);
+		InteractiveRuntimeState rt = MakeInitialRuntimeState(d); // fermé, openFactor=0
+
+		// Évènement distant survenu 0.25 s plus tôt (50% de la durée).
+		ApplyRemoteState(rt, d, /*newState=*/1, /*latencySec=*/0.25f);
+		// La porte ne saute pas à 0 ni à 1 : elle démarre déjà à mi-course.
+		REQUIRE(rt.targetState == 1);
+		REQUIRE(Near(rt.openFactor, 0.5f));
+		REQUIRE(IsAnimating(rt));
+
+		// Le reste de l'animation aboutit à l'ouverture complète.
+		UpdateInteractive(rt, d, 0.25f);
+		REQUIRE(Near(rt.openFactor, 1.0f));
+
+		// Latence supérieure à la durée → clamp à la cible (pas de dépassement).
+		InteractiveRuntimeState rt2 = MakeInitialRuntimeState(d);
+		ApplyRemoteState(rt2, d, 1, 5.0f);
+		REQUIRE(Near(rt2.openFactor, 1.0f));
+	}
+
+	// ---------------------------------------------------------------------
+	// Round-trip réseau (3 messages)
+	// ---------------------------------------------------------------------
+	void Test_Network_StateChangeRoundtrip()
+	{
+		// StateChange
+		{
+			auto buf = BuildInteractiveStateChangePayload(0x1122334455667788ull, 1, 0xDEADBEEFull);
+			auto p = ParseInteractiveStateChangePayload(buf.data(), buf.size());
+			REQUIRE(p.has_value());
+			if (p) { REQUIRE(p->id == 0x1122334455667788ull); REQUIRE(p->newState == 1); REQUIRE(p->clientTimeMs == 0xDEADBEEFull); }
+		}
+		// Broadcast
+		{
+			auto buf = BuildInteractiveStateBroadcastPayload(7ull, 0, 123456ull);
+			auto p = ParseInteractiveStateBroadcastPayload(buf.data(), buf.size());
+			REQUIRE(p.has_value());
+			if (p) { REQUIRE(p->id == 7ull); REQUIRE(p->newState == 0); REQUIRE(p->serverTimeMs == 123456ull); }
+		}
+		// Sync
+		{
+			std::vector<InteractiveSyncEntry> entries = { {1ull, 1}, {2ull, 0}, {99ull, 1} };
+			auto buf = BuildInteractiveStateSyncPayload(entries);
+			auto p = ParseInteractiveStateSyncPayload(buf.data(), buf.size());
+			REQUIRE(p.has_value());
+			if (p)
+			{
+				REQUIRE(p->entries.size() == 3);
+				REQUIRE(p->entries[0].id == 1ull && p->entries[0].state == 1);
+				REQUIRE(p->entries[2].id == 99ull && p->entries[2].state == 1);
+			}
+		}
+		// Malformé (trop court) → nullopt.
+		{
+			std::vector<uint8_t> tooShort = { 0x01, 0x02 };
+			REQUIRE(!ParseInteractiveStateChangePayload(tooShort.data(), tooShort.size()).has_value());
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Relai serveur — pas de validation gameplay
+	// ---------------------------------------------------------------------
+	void Test_Server_NoGameplayValidation()
+	{
+		engine::server::interactive::InteractiveStateRelay relay;
+		relay.Seed(10, 0);
+		relay.Seed(20, 1);
+		REQUIRE(relay.Count() == 2);
+
+		// id connu : appliqué.
+		REQUIRE(relay.ApplyStateChange(10, 1) == engine::server::interactive::ChangeResult::Applied);
+		bool found = false;
+		REQUIRE(relay.GetState(10, &found) == 1 && found);
+
+		// id inconnu : ignoré (UnknownId), aucune erreur, count inchangé.
+		REQUIRE(relay.ApplyStateChange(999, 1) == engine::server::interactive::ChangeResult::UnknownId);
+		REQUIRE(relay.Count() == 2);
+		relay.GetState(999, &found);
+		REQUIRE(!found);
+	}
+
+	void Test_Server_InitialSyncOnConnect()
+	{
+		engine::server::interactive::InteractiveStateRelay relay;
+		relay.Seed(1, 0);
+		relay.Seed(2, 0);
+		relay.Seed(3, 1);
+		// Un joueur ouvre l'objet 2.
+		relay.ApplyStateChange(2, 1);
+
+		auto snap = relay.Snapshot();
+		REQUIRE(snap.size() == 3);
+		// Vérifie les états (ordre non garanti — on recherche par id).
+		int seen = 0;
+		for (const auto& [id, st] : snap)
+		{
+			if (id == 1) { REQUIRE(st == 0); ++seen; }
+			if (id == 2) { REQUIRE(st == 1); ++seen; }
+			if (id == 3) { REQUIRE(st == 1); ++seen; }
+		}
+		REQUIRE(seen == 3);
+	}
+}
+
+int main()
+{
+	Test_Interactives_Roundtrip();
+	Test_Simulator_AnimatesDoorHinge();
+	Test_Simulator_AnimatesSliding();
+	Test_Simulator_AnimatesTrapdoor();
+	Test_Simulator_AnimatesChest();
+	Test_Client_RemoteAnimationLatencyCompensation();
+	Test_Network_StateChangeRoundtrip();
+	Test_Server_NoGameplayValidation();
+	Test_Server_InitialSyncOnConnect();
+
+	if (g_failed == 0)
+		std::printf("[interactive_tests] all tests passed\n");
+	else
+		std::fprintf(stderr, "[interactive_tests] %d check(s) failed\n", g_failed);
+	return g_failed;
+}

--- a/src/masterd/InteractiveStateRelay.h
+++ b/src/masterd/InteractiveStateRelay.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// M100.32 — InteractiveStateRelay : état RAM des objets interactifs d'une zone
+// côté master. HEADER-ONLY (logique pure, testable sans NetServer) : la classe
+// ne fait QUE gérer la map id → state et les décisions de relai. L'envoi réseau
+// (broadcast / sync) est assuré par InteractiveHandler qui consomme cette classe.
+//
+// AUCUNE validation gameplay : pas de portée, pas de droit d'ouverture, pas
+// d'anti-triche (cf. ticket M100.32 §"Côté master"). Un StateChange pour un id
+// inconnu est ignoré (ChangeResult::UnknownId) — le handler loggue un warning.
+//
+// Persistance : RAM uniquement. À la coupure du serveur, l'état est perdu et
+// re-seedé depuis `initialState` au prochain démarrage (hors scope : persistance
+// disque serveur).
+//
+// Thread-safety : la classe n'est PAS auto-synchronisée. Le handler la protège
+// par son propre mutex (cf. InteractiveHandler), comme GameEventHandler le fait
+// pour GameEventManager.
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::server::interactive
+{
+	/// Résultat d'une tentative d'application d'un changement d'état.
+	enum class ChangeResult
+	{
+		Applied,   ///< id connu : état écrit.
+		UnknownId, ///< id non seedé : ignoré (le handler loggue un warning).
+	};
+
+	/// État RAM des objets interactifs d'une zone (map id → state 0/1).
+	class InteractiveStateRelay
+	{
+	public:
+		/// Enregistre un objet avec son état initial. Appelé au chargement de
+		/// la zone (depuis interactives.bin). Idempotent : un re-seed écrase
+		/// l'état courant par `initialState`.
+		void Seed(uint64_t id, uint8_t initialState)
+		{
+			m_states[id] = initialState != 0u ? 1u : 0u;
+		}
+
+		/// Applique un changement d'état reçu d'un client. Retourne UnknownId
+		/// (sans rien modifier) si l'objet n'a pas été seedé.
+		ChangeResult ApplyStateChange(uint64_t id, uint8_t newState)
+		{
+			auto it = m_states.find(id);
+			if (it == m_states.end())
+				return ChangeResult::UnknownId;
+			it->second = newState != 0u ? 1u : 0u;
+			return ChangeResult::Applied;
+		}
+
+		/// Lit l'état d'un objet. `*found` (si non-null) indique si l'id existe.
+		/// Retourne 0 si inconnu.
+		uint8_t GetState(uint64_t id, bool* found = nullptr) const
+		{
+			auto it = m_states.find(id);
+			if (it == m_states.end())
+			{
+				if (found) *found = false;
+				return 0u;
+			}
+			if (found) *found = true;
+			return it->second;
+		}
+
+		/// Snapshot complet (id, state) pour la synchronisation initiale d'un
+		/// client entrant. L'ordre n'est pas garanti (map non ordonnée).
+		std::vector<std::pair<uint64_t, uint8_t>> Snapshot() const
+		{
+			std::vector<std::pair<uint64_t, uint8_t>> out;
+			out.reserve(m_states.size());
+			for (const auto& [id, st] : m_states)
+				out.emplace_back(id, st);
+			return out;
+		}
+
+		/// Nombre d'objets interactifs suivis.
+		size_t Count() const { return m_states.size(); }
+
+		/// Vide la map (rechargement de zone).
+		void Clear() { m_states.clear(); }
+
+	private:
+		std::unordered_map<uint64_t, uint8_t> m_states;
+	};
+}

--- a/src/masterd/handlers/interactive/InteractiveHandler.cpp
+++ b/src/masterd/handlers/interactive/InteractiveHandler.cpp
@@ -1,0 +1,149 @@
+// M100.32 — Implémentation InteractiveHandler (relai sans validation gameplay).
+
+#include "src/masterd/handlers/interactive/InteractiveHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/InteractivePayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <chrono>
+#include <utility>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::server::interactive::ChangeResult;
+
+	namespace
+	{
+		/// system_clock now en ms depuis epoch (horloge serveur, pour la
+		/// compensation de latence côté clients distants).
+		uint64_t NowMs()
+		{
+			const auto v = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count();
+			return static_cast<uint64_t>(v);
+		}
+	}
+
+	void InteractiveHandler::SeedInteractive(uint64_t id, uint8_t initialState)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_relay.Seed(id, initialState);
+	}
+
+	void InteractiveHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t /*requestId*/,
+		uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+
+		if (opcode != kOpInteractiveStateChange)
+			return; // 201/202 sont des pushes serveur→client, jamais reçus.
+
+		if (!m_server || !m_sessionMgr || !m_connMap)
+		{
+			LOG_WARN(Net, "[InteractiveHandler] Drop opcode={} : handler not fully wired", opcode);
+			return;
+		}
+
+		// Résolution session/account. Session requise (mais aucune validation
+		// gameplay au-delà : pas de droit d'ouverture, pas de portée).
+		bool sessionOk = false;
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (connSessionId && *connSessionId != 0u
+			&& sessionIdHeader != 0u && *connSessionId == sessionIdHeader)
+		{
+			auto acc = m_sessionMgr->GetAccountId(*connSessionId);
+			if (acc && *acc != 0u)
+				sessionOk = true;
+		}
+		if (!sessionOk)
+		{
+			LOG_WARN(Net, "[InteractiveHandler] StateChange dropped connId={} : no valid session", connId);
+			return;
+		}
+
+		auto parsed = ParseInteractiveStateChangePayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Net, "[InteractiveHandler] StateChange malformed payload connId={}", connId);
+			return;
+		}
+
+		ChangeResult result;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			result = m_relay.ApplyStateChange(parsed->id, parsed->newState);
+		}
+
+		if (result == ChangeResult::UnknownId)
+		{
+			// Critère d'acceptation : id inconnu → warning + ignore, SANS
+			// erreur de protocole.
+			LOG_WARN(Net, "[InteractiveHandler] StateChange id={} inconnu (ignore, pas d'erreur)", parsed->id);
+			return;
+		}
+
+		LOG_INFO(Net, "[InteractiveHandler] StateChange id={} newState={} connId={} -> broadcast",
+			parsed->id, static_cast<unsigned>(parsed->newState), connId);
+
+		BroadcastStateChange(connId, parsed->id, parsed->newState);
+	}
+
+	void InteractiveHandler::BroadcastStateChange(uint32_t exceptConn, uint64_t id, uint8_t newState)
+	{
+		using namespace engine::network;
+		if (!m_server || !m_connMap) return;
+
+		const uint64_t serverTimeMs = NowMs();
+		const auto snapshot = m_connMap->Snapshot();
+		size_t delivered = 0;
+		for (const auto& [destConn, destSession] : snapshot)
+		{
+			if (destConn == exceptConn) continue; // l'émetteur a déjà animé localement.
+			if (destSession == 0u) continue;
+			auto pkt = BuildInteractiveStateBroadcastPacket(id, newState, serverTimeMs, destSession);
+			if (pkt.empty()) continue;
+			if (m_server->Send(destConn, pkt))
+				++delivered;
+		}
+		LOG_INFO(Net, "[InteractiveHandler] Broadcast id={} state={} delivered={}/{}",
+			id, static_cast<unsigned>(newState), delivered, snapshot.size());
+	}
+
+	bool InteractiveHandler::SendInitialSync(uint32_t connId)
+	{
+		using namespace engine::network;
+		if (!m_server || !m_connMap || connId == 0u)
+			return false;
+
+		auto sid = m_connMap->GetSessionId(connId);
+		if (!sid || *sid == 0u)
+		{
+			LOG_WARN(Net, "[InteractiveHandler] SendInitialSync connId={} : no session (skip)", connId);
+			return false;
+		}
+
+		std::vector<InteractiveSyncEntry> entries;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			auto snap = m_relay.Snapshot();
+			entries.reserve(snap.size());
+			for (const auto& [id, state] : snap)
+				entries.push_back(InteractiveSyncEntry{ id, state });
+		}
+
+		auto pkt = BuildInteractiveStateSyncPacket(entries, *sid);
+		if (pkt.empty())
+		{
+			LOG_WARN(Net, "[InteractiveHandler] SendInitialSync build failed connId={}", connId);
+			return false;
+		}
+		m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[InteractiveHandler] InitialSync connId={} count={}", connId, entries.size());
+		return true;
+	}
+}

--- a/src/masterd/handlers/interactive/InteractiveHandler.h
+++ b/src/masterd/handlers/interactive/InteractiveHandler.h
@@ -1,0 +1,78 @@
+#pragma once
+// M100.32 — InteractiveHandler : dispatch de l'opcode InteractiveStateChange
+// (200) côté master + relai sans validation gameplay.
+//
+// Le handler est instancié dans main_linux.cpp au boot du master, câblé via
+// SetXxx(...), seedé depuis l'état initial des objets de la zone (SeedInteractive),
+// puis enregistré dans le packetHandler du NetServer pour l'opcode 200.
+//
+// À réception d'un StateChange :
+//   1. Résout connId → session → account (session requise ; sinon drop silencieux).
+//   2. Applique au InteractiveStateRelay. Si id inconnu : warning + ignore
+//      (PAS de paquet d'erreur — cf. critère d'acceptation).
+//   3. Broadcast un StateBroadcast (opcode 201) à toutes les AUTRES sessions
+//      actives (l'émetteur a déjà animé localement).
+//
+// SendInitialSync(connId) envoie un StateSync (opcode 202) avec l'état complet
+// de la zone ; appelé quand un client entre en jeu.
+//
+// AUCUNE validation gameplay : pas de portée, pas de droit d'ouverture, pas
+// d'anti-triche.
+
+#include "src/masterd/InteractiveStateRelay.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher Interactive Props côté master. Doit être configuré via Set*()
+	/// avant tout HandlePacket.
+	class InteractiveHandler
+	{
+	public:
+		/// Branche le NetServer pour envoyer broadcasts + sync.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour résoudre sessionId → accountId.
+		void SetSessionManager(SessionManager* sm) { m_sessionMgr = sm; }
+		/// Branche la map connId ↔ sessionId (résolution + broadcast).
+		void SetConnectionSessionMap(ConnectionSessionMap* cm) { m_connMap = cm; }
+
+		/// Enregistre un objet interactif avec son état initial (au chargement
+		/// de la zone). Thread-safe (pris sous m_mutex).
+		void SeedInteractive(uint64_t id, uint8_t initialState);
+
+		/// Point d'entrée appelé par NetServer pour l'opcode 200. Les opcodes
+		/// 201/202 sont des pushes serveur→client : jamais reçus ici.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader,
+		                  const uint8_t* payload, size_t payloadSize);
+
+		/// Envoie l'état complet de la zone (StateSync, opcode 202) au client
+		/// `connId`. Appelé quand le client entre en jeu. No-op si server null,
+		/// connId=0 ou pas de session pour ce connId.
+		/// \return true si le paquet a été envoyé.
+		bool SendInitialSync(uint32_t connId);
+
+	private:
+		/// Diffuse un StateBroadcast (201) à toutes les sessions actives SAUF
+		/// `exceptConn` (l'émetteur, qui a déjà animé localement).
+		void BroadcastStateChange(uint32_t exceptConn, uint64_t id, uint8_t newState);
+
+		NetServer*                                m_server     = nullptr;
+		SessionManager*                           m_sessionMgr = nullptr;
+		ConnectionSessionMap*                     m_connMap    = nullptr;
+
+		/// Protège m_relay.
+		mutable std::mutex                        m_mutex;
+		engine::server::interactive::InteractiveStateRelay m_relay;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1051,7 +1051,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &interactiveHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -49,6 +49,7 @@
 #include "src/masterd/handlers/outdoorpvp/OutdoorPvpHandler.h"
 #include "src/masterd/handlers/weather/WeatherHandler.h"
 #include "src/masterd/handlers/events/GameEventHandler.h"
+#include "src/masterd/handlers/interactive/InteractiveHandler.h"
 #include "src/masterd/handlers/guild/GuildHandler.h"
 #include "src/masterd/handlers/auction/AuctionHandler.h"
 #include "src/masterd/handlers/loot/LootHandler.h"
@@ -808,6 +809,18 @@ int main(int argc, char** argv)
 	gameEventHandler.SeedV1Events();
 	LOG_INFO(Net, "[ServerMain] GameEventHandler configured (CMANGOS.31 step 3+4, in-memory, 4 events seed)");
 
+	// M100.32 — InteractiveHandler : relai sans validation gameplay des objets
+	// interactifs (portes/fenêtres/trappes/coffres). Opcode 200 (StateChange)
+	// dispatché au handler ; 201 (broadcast) et 202 (sync) sont des pushes émis
+	// par le handler. État RAM par zone (perdu au reboot, re-seedé depuis
+	// interactives.bin). V1 : pas de seed depuis fichier au boot (le seed se fera
+	// au chargement de la zone via SeedInteractive ; voir StreamCache 2e passe).
+	engine::server::InteractiveHandler interactiveHandler;
+	interactiveHandler.SetServer(&server);
+	interactiveHandler.SetSessionManager(&sessionManager);
+	interactiveHandler.SetConnectionSessionMap(&connSessionMap);
+	LOG_INFO(Net, "[ServerMain] InteractiveHandler configured (M100.32, relai sans validation gameplay)");
+
 	// CMANGOS.21 (Phase 5.21 step 3+4 Guilds) — GuildHandler : list /
 	// members / permissions / bank + push MotdUpdate. V1 : 2 guildes
 	// seedees au boot ("Les Gardiens", "L'Ombre") avec membres + bank
@@ -1144,6 +1157,8 @@ int main(int argc, char** argv)
 			lootHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeLunarStateRequest)
 			lunarHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpInteractiveStateChange)
+			interactiveHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeAdminCommandRequest)
 			adminCommandHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else

--- a/src/shared/network/InteractivePayloads.cpp
+++ b/src/shared/network/InteractivePayloads.cpp
@@ -1,0 +1,165 @@
+// M100.32 — Implémentation Parse/Build des payloads Interactive Props.
+//
+// Convention identique aux autres *Payloads.cpp du repo :
+//   - Build*Payload retourne un std::vector<uint8_t> ne contenant que le
+//     payload (sans header protocol_v1). Utilisé pour tests round-trip et
+//     pour les requests côté client.
+//   - Build*Packet utilise PacketBuilder pour assembler le paquet complet
+//     header + payload, prêt à passer à NetServer::Send.
+//   - Parse* lit le payload nu (sans header).
+
+#include "src/shared/network/InteractivePayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+#include <vector>
+
+namespace engine::network
+{
+	// -------------------------------------------------------------------------
+	// INTERACTIVE_STATE_CHANGE (200)
+	// -------------------------------------------------------------------------
+
+	std::optional<InteractiveStateChangePayload> ParseInteractiveStateChangePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// uint64 id (8) + uint8 newState (1) + uint64 clientTimeMs (8) = 17.
+		if (!payload || payloadSize < 17u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		InteractiveStateChangePayload out;
+		uint8_t stateByte = 0;
+		if (!r.ReadU64(out.id))            return std::nullopt;
+		if (!r.ReadBytes(&stateByte, 1u))  return std::nullopt;
+		out.newState = stateByte;
+		if (!r.ReadU64(out.clientTimeMs))  return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateChangePayload(uint64_t id, uint8_t newState, uint64_t clientTimeMs)
+	{
+		std::vector<uint8_t> buf(17u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(id))                 return {};
+		if (!w.WriteBytes(&newState, 1u))    return {};
+		if (!w.WriteU64(clientTimeMs))       return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateChangePacket(uint64_t id, uint8_t newState, uint64_t clientTimeMs,
+		uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(id))               return {};
+		if (!w.WriteBytes(&newState, 1u))  return {};
+		if (!w.WriteU64(clientTimeMs))     return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpInteractiveStateChange, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// INTERACTIVE_STATE_BROADCAST (201)
+	// -------------------------------------------------------------------------
+
+	std::optional<InteractiveStateBroadcastPayload> ParseInteractiveStateBroadcastPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 17u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		InteractiveStateBroadcastPayload out;
+		uint8_t stateByte = 0;
+		if (!r.ReadU64(out.id))            return std::nullopt;
+		if (!r.ReadBytes(&stateByte, 1u))  return std::nullopt;
+		out.newState = stateByte;
+		if (!r.ReadU64(out.serverTimeMs))  return std::nullopt;
+		return out;
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateBroadcastPayload(uint64_t id, uint8_t newState, uint64_t serverTimeMs)
+	{
+		std::vector<uint8_t> buf(17u, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!w.WriteU64(id))               return {};
+		if (!w.WriteBytes(&newState, 1u))  return {};
+		if (!w.WriteU64(serverTimeMs))     return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateBroadcastPacket(uint64_t id, uint8_t newState, uint64_t serverTimeMs,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!w.WriteU64(id))               return {};
+		if (!w.WriteBytes(&newState, 1u))  return {};
+		if (!w.WriteU64(serverTimeMs))     return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpInteractiveStateBroadcast, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+
+	// -------------------------------------------------------------------------
+	// INTERACTIVE_STATE_SYNC (202)
+	// -------------------------------------------------------------------------
+
+	std::optional<InteractiveStateSyncPayload> ParseInteractiveStateSyncPayload(const uint8_t* payload, size_t payloadSize)
+	{
+		if (!payload || payloadSize < 2u) return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		InteractiveStateSyncPayload out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count)) return std::nullopt;
+		out.entries.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			InteractiveSyncEntry e;
+			uint8_t stateByte = 0;
+			if (!r.ReadU64(e.id))             return std::nullopt;
+			if (!r.ReadBytes(&stateByte, 1u)) return std::nullopt;
+			e.state = stateByte;
+			out.entries.push_back(e);
+		}
+		return out;
+	}
+
+	namespace
+	{
+		bool WriteSyncBody(ByteWriter& w, const std::vector<InteractiveSyncEntry>& entries)
+		{
+			if (!w.WriteArrayCount(static_cast<uint16_t>(entries.size()))) return false;
+			for (const auto& e : entries)
+			{
+				if (!w.WriteU64(e.id))            return false;
+				if (!w.WriteBytes(&e.state, 1u))  return false;
+			}
+			return true;
+		}
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateSyncPayload(const std::vector<InteractiveSyncEntry>& entries)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteSyncBody(w, entries)) return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildInteractiveStateSyncPacket(const std::vector<InteractiveSyncEntry>& entries,
+		uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteSyncBody(w, entries)) return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpInteractiveStateSync, 0u, 0u, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/InteractivePayloads.h
+++ b/src/shared/network/InteractivePayloads.h
@@ -1,0 +1,100 @@
+#pragma once
+// M100.32 — Wire payloads pour les opcodes Interactive Props (200/201/202).
+//   - StateChange    (200) : Client → Master. Le joueur a ouvert/fermé un objet.
+//   - StateBroadcast (201) : Master → autres clients. Relai de l'évènement.
+//   - StateSync      (202) : Master → client entrant. État complet de la zone.
+//
+// Le master maintient une `std::unordered_map<uint64,uint8>` par zone (cf.
+// InteractiveStateRelay). Il reçoit StateChange, écrit l'état, broadcast à
+// tous les autres clients, et envoie StateSync à un client qui se connecte.
+// AUCUNE validation gameplay (portée, droit d'ouverture, anti-triche).
+//
+// Format wire : ByteReader/ByteWriter little-endian. uint64 via WriteU64/ReadU64.
+// La liste de sync utilise WriteArrayCount/ReadArrayCount (uint16 count).
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace engine::network
+{
+	// =========================================================================
+	// INTERACTIVE_STATE_CHANGE (200) — Client → Master.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 id            (identifiant de l'objet interactif)
+	///   uint8  newState      (0 = fermé, 1 = ouvert)
+	///   uint64 clientTimeMs  (horloge client à l'évènement, pour latence)
+	struct InteractiveStateChangePayload
+	{
+		uint64_t id           = 0;
+		uint8_t  newState     = 0;
+		uint64_t clientTimeMs = 0;
+	};
+
+	// =========================================================================
+	// INTERACTIVE_STATE_BROADCAST (201) — Master → autres clients.
+	// =========================================================================
+
+	/// Wire format :
+	///   uint64 id
+	///   uint8  newState
+	///   uint64 serverTimeMs  (horloge serveur au relai, pour compensation latence)
+	struct InteractiveStateBroadcastPayload
+	{
+		uint64_t id           = 0;
+		uint8_t  newState     = 0;
+		uint64_t serverTimeMs = 0;
+	};
+
+	// =========================================================================
+	// INTERACTIVE_STATE_SYNC (202) — Master → client entrant (état complet).
+	// =========================================================================
+
+	/// Un couple (id, état) dans le set de synchronisation initiale.
+	struct InteractiveSyncEntry
+	{
+		uint64_t id    = 0;
+		uint8_t  state = 0;
+	};
+
+	/// Wire format :
+	///   uint16 count
+	///   count × { uint64 id, uint8 state }
+	struct InteractiveStateSyncPayload
+	{
+		std::vector<InteractiveSyncEntry> entries;
+	};
+
+	// -------------------------------------------------------------------------
+	// Parse / Build — payload nu (sans header protocol_v1).
+	// -------------------------------------------------------------------------
+
+	std::optional<InteractiveStateChangePayload>    ParseInteractiveStateChangePayload   (const uint8_t* payload, size_t payloadSize);
+	std::optional<InteractiveStateBroadcastPayload> ParseInteractiveStateBroadcastPayload(const uint8_t* payload, size_t payloadSize);
+	std::optional<InteractiveStateSyncPayload>      ParseInteractiveStateSyncPayload     (const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildInteractiveStateChangePayload   (uint64_t id, uint8_t newState, uint64_t clientTimeMs);
+	std::vector<uint8_t> BuildInteractiveStateBroadcastPayload(uint64_t id, uint8_t newState, uint64_t serverTimeMs);
+	std::vector<uint8_t> BuildInteractiveStateSyncPayload     (const std::vector<InteractiveSyncEntry>& entries);
+
+	// -------------------------------------------------------------------------
+	// Build full packets (header + payload). Utilisé côté handler serveur.
+	// -------------------------------------------------------------------------
+
+	/// Request client → master (opcode 200). `requestId` libre (réponse non
+	/// requise : le master relaie via broadcast).
+	std::vector<uint8_t> BuildInteractiveStateChangePacket(uint64_t id, uint8_t newState, uint64_t clientTimeMs,
+		uint32_t requestId, uint64_t sessionIdHeader);
+
+	/// Push master → autres clients (opcode 201, request_id=0).
+	std::vector<uint8_t> BuildInteractiveStateBroadcastPacket(uint64_t id, uint8_t newState, uint64_t serverTimeMs,
+		uint64_t sessionIdHeader);
+
+	/// Push master → client entrant (opcode 202, request_id=0).
+	std::vector<uint8_t> BuildInteractiveStateSyncPacket(const std::vector<InteractiveSyncEntry>& entries,
+		uint64_t sessionIdHeader);
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -822,4 +822,17 @@ namespace engine::network
 	// -------------------------------------------------------------------------
 
 	constexpr uint16_t kOpcodeMasterToShardAdmitCharacter = 199u; ///< Master to Shard (push, request_id=0) : (account_id, character_id) à admettre dans AdmittedCharacterRegistry, suite à un EnterWorld réussi côté master.
+
+	// -------------------------------------------------------------------------
+	// Opcodes Interactive Props (valeurs 200-202)
+	// Référence : M100.32 — Interactive Props (portes/fenêtres/trappes/coffres).
+	// Relai master SANS validation gameplay (cf. InteractiveStateRelay). Le master
+	// maintient une map id → state par zone, relaie les changements et envoie un
+	// snapshot complet à tout client entrant. Wire-additif : un master ancien
+	// répondrait BAD_REQUEST à kOpInteractiveStateChange — déployer en lock-step.
+	// -------------------------------------------------------------------------
+
+	constexpr uint16_t kOpInteractiveStateChange    = 200u; ///< Client → Master : un objet a été ouvert/fermé (id, newState, clientTimeMs).
+	constexpr uint16_t kOpInteractiveStateBroadcast = 201u; ///< Master → autres clients (push, request_id=0) : relai d'un changement d'état (id, newState, serverTimeMs).
+	constexpr uint16_t kOpInteractiveStateSync      = 202u; ///< Master → client entrant (push, request_id=0) : état complet de la zone (count × {id, state}).
 }

--- a/src/world_editor/InteractivePanel.cpp
+++ b/src/world_editor/InteractivePanel.cpp
@@ -1,0 +1,102 @@
+// M100.32 — Implémentation du panneau « Interactive Props » (ImGui guardé).
+
+#include "src/world_editor/InteractivePanel.h"
+
+#include <cstdio>
+#include <cstring>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	using engine::world::interactive::InteractiveType;
+
+	/// Réinitialise l'aperçu sur l'état initial de la définition.
+	void InteractivePanel::ResetPreview()
+	{
+		m_preview = engine::world::interactive::MakeInitialRuntimeState(m_def);
+	}
+
+	/// Bascule l'aperçu (parité avec un trigger client, sans réseau).
+	void InteractivePanel::Trigger()
+	{
+		engine::world::interactive::ToggleInteractive(m_preview);
+	}
+
+	/// Avance l'animation d'aperçu.
+	void InteractivePanel::Update(float dtSec)
+	{
+		engine::world::interactive::UpdateInteractive(m_preview, m_def, dtSec);
+	}
+
+	/// Rendu ImGui du panneau. No-op hors Windows.
+	void InteractivePanel::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Interactive Props");
+		ImGui::Separator();
+
+		const char* kTypes[] = { "DoorHinge", "DoorSliding", "WindowHinge", "Trapdoor", "ChestSimple" };
+		int typeIdx = static_cast<int>(m_def.type);
+		if (ImGui::Combo("Type", &typeIdx, kTypes, IM_ARRAYSIZE(kTypes)))
+		{
+			m_def.type = static_cast<InteractiveType>(typeIdx);
+		}
+
+		float pivot[3] = { m_def.pivotLocal.x, m_def.pivotLocal.y, m_def.pivotLocal.z };
+		if (ImGui::InputFloat3("Pivot local", pivot))
+		{
+			m_def.pivotLocal.x = pivot[0]; m_def.pivotLocal.y = pivot[1]; m_def.pivotLocal.z = pivot[2];
+		}
+
+		float axis[3] = { m_def.axisLocal.x, m_def.axisLocal.y, m_def.axisLocal.z };
+		if (ImGui::InputFloat3("Axis local", axis))
+		{
+			m_def.axisLocal.x = axis[0]; m_def.axisLocal.y = axis[1]; m_def.axisLocal.z = axis[2];
+		}
+
+		// Pour DoorSliding, le champ porte la translation (m) ; sinon l'angle (°).
+		if (m_def.type == InteractiveType::DoorSliding)
+			ImGui::InputFloat("Open translation (m)", &m_def.openAngleDeg);
+		else
+			ImGui::InputFloat("Open angle (deg)", &m_def.openAngleDeg);
+
+		ImGui::InputFloat("Anim duration (s)", &m_def.animDurationSec);
+
+		int initIdx = m_def.initialState != 0u ? 1 : 0;
+		ImGui::RadioButton("Closed", &initIdx, 0); ImGui::SameLine();
+		ImGui::RadioButton("Opened (rare)", &initIdx, 1);
+		const uint8_t newInit = static_cast<uint8_t>(initIdx);
+		if (newInit != m_def.initialState)
+		{
+			m_def.initialState = newInit;
+			ResetPreview();
+		}
+
+		// Champs audio : tampons simples (la library d'évènements audio viendra
+		// en 2e passe client ; ici on édite la clé brute).
+		char openBuf[64];
+		char closeBuf[64];
+#if defined(_MSC_VER)
+		strncpy_s(openBuf, m_def.audioOpenEvent.c_str(), sizeof(openBuf) - 1);
+		strncpy_s(closeBuf, m_def.audioCloseEvent.c_str(), sizeof(closeBuf) - 1);
+#else
+		std::snprintf(openBuf, sizeof(openBuf), "%s", m_def.audioOpenEvent.c_str());
+		std::snprintf(closeBuf, sizeof(closeBuf), "%s", m_def.audioCloseEvent.c_str());
+#endif
+		if (ImGui::InputText("Audio open", openBuf, sizeof(openBuf)))
+			m_def.audioOpenEvent = openBuf;
+		if (ImGui::InputText("Audio close", closeBuf, sizeof(closeBuf)))
+			m_def.audioCloseEvent = closeBuf;
+
+		ImGui::Separator();
+		if (ImGui::Button("Trigger"))
+			Trigger();
+		ImGui::SameLine();
+		ImGui::Text("openFactor=%.2f target=%u", m_preview.openFactor,
+			static_cast<unsigned>(m_preview.targetState));
+#endif
+	}
+}

--- a/src/world_editor/InteractivePanel.h
+++ b/src/world_editor/InteractivePanel.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// M100.32 — Panneau secondaire « Interactive Props » de l'éditeur monde.
+//
+// Apparaît dans PlacementTool quand l'asset placé est marqué `interactive`
+// dans la library. Permet de configurer type/pivot/axe/angle/durée/état
+// initial/audios, et d'appeler le même InteractiveSimulator que le client en
+// jeu via le bouton « Trigger » (parité éditeur ↔ client, sans envoi réseau).
+//
+// Rendu ImGui guardé Windows (_WIN32) ; l'état édité et la logique de trigger
+// sont disponibles sur toutes plateformes (testables headless via le simulateur).
+
+#include "src/client/world/interactive/InteractiveSimulator.h"
+#include "src/client/world/interactive/InteractiveTypes.h"
+
+namespace engine::editor::world
+{
+	/// Panneau d'édition d'une instance interactive en cours de pose.
+	class InteractivePanel
+	{
+	public:
+		/// Définition en cours d'édition (modifiée par les champs ImGui).
+		engine::world::interactive::InteractivePropInstance& Def() { return m_def; }
+		const engine::world::interactive::InteractivePropInstance& Def() const { return m_def; }
+
+		/// État runtime d'aperçu (animé par Trigger + Update).
+		const engine::world::interactive::InteractiveRuntimeState& Preview() const { return m_preview; }
+
+		/// Réinitialise l'aperçu sur l'état initial de la définition courante.
+		/// À appeler après modification de `initialState`.
+		void ResetPreview();
+
+		/// Bascule l'aperçu (ouvre/ferme) — exactement comme un trigger client,
+		/// mais sans envoi réseau. Utilisé par le bouton « Trigger ».
+		void Trigger();
+
+		/// Avance l'animation d'aperçu de `dtSec` secondes (appelé chaque frame
+		/// éditeur). Sans effet hors animation.
+		void Update(float dtSec);
+
+		/// Rendu du panneau ImGui. No-op hors Windows. Doit être appelé en main
+		/// thread, dans une frame ImGui active.
+		void Render();
+
+	private:
+		engine::world::interactive::InteractivePropInstance m_def;
+		engine::world::interactive::InteractiveRuntimeState  m_preview;
+	};
+}

--- a/tools/zone_builder/lib/ChunkPackageWriter.cpp
+++ b/tools/zone_builder/lib/ChunkPackageWriter.cpp
@@ -12,6 +12,7 @@
 #include "src/shared/routine/RoutineSegmentCodec.h"
 #include "src/client/world/hazard/HazardVolumes.h"
 #include "src/client/world/instances/PropInstances.h"
+#include "src/client/world/interactive/InteractiveInstances.h"
 #include "src/client/world/foliage/FoliageInstances.h"
 #include "src/client/world/wind/WindZones.h"
 #include "src/client/world/thermal/ShadeMap.h"
@@ -730,6 +731,36 @@ namespace tools::zone_builder
 		if (!out.good())
 		{
 			outError = "WriteProps: write failed: " + file.string();
+			return false;
+		}
+		return true;
+	}
+
+	bool WriteInteractives(std::string_view outputRootDir,
+		const std::vector<engine::world::interactive::InteractivePropInstance>& items, std::string& outError)
+	{
+		// M100.32 — fichier zone-level instances/interactives.bin. Crée instances/ au besoin.
+		const std::filesystem::path dir = std::filesystem::path(outputRootDir) / "instances";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec)
+		{
+			outError = "WriteInteractives: create_directories failed: " + dir.string();
+			return false;
+		}
+		const std::vector<uint8_t> bytes = engine::world::interactive::SaveInteractivesBin(items);
+		const std::filesystem::path file = dir / "interactives.bin";
+		std::ofstream out(file, std::ios::binary | std::ios::trunc);
+		if (!out.good())
+		{
+			outError = "WriteInteractives: open failed: " + file.string();
+			return false;
+		}
+		out.write(reinterpret_cast<const char*>(bytes.data()),
+			static_cast<std::streamsize>(bytes.size()));
+		if (!out.good())
+		{
+			outError = "WriteInteractives: write failed: " + file.string();
 			return false;
 		}
 		return true;

--- a/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
+++ b/tools/zone_builder/lib/Public/zone_builder/ChunkPackageWriter.h
@@ -12,6 +12,7 @@ namespace engine::world::water { struct WaterScene; }
 namespace engine::routine { struct RoutineGraph; }
 namespace engine::world::hazard { struct HazardVolume; }
 namespace engine::world::instances { struct PropInstance; }
+namespace engine::world::interactive { struct InteractivePropInstance; }
 namespace engine::world::foliage { struct FoliageInstance; }
 namespace engine::world::wind { struct WindZone; }
 namespace engine::world::thermal { struct ShadeMap; }
@@ -100,6 +101,14 @@ namespace tools::zone_builder
 	/// \return true si OK ; sinon `outError` est renseigné.
 	bool WriteProps(std::string_view outputRootDir,
 		const std::vector<engine::world::instances::PropInstance>& props, std::string& outError);
+
+	/// Écrit `instances/interactives.bin` (M100.32) sous `<outputRootDir>/instances/`.
+	/// Crée le dossier au besoin. Sérialise via `engine::world::interactive::
+	/// SaveInteractivesBin` (format header-only partagé avec le client : parité
+	/// éditeur ↔ client). Fichier zone-level.
+	/// \return true si OK ; sinon `outError` est renseigné.
+	bool WriteInteractives(std::string_view outputRootDir,
+		const std::vector<engine::world::interactive::InteractivePropInstance>& items, std::string& outError);
 
 	/// Écrit `foliage.bin` (M100.18) dans `<outputRootDir>/chunks/chunk_<x>_<z>/`.
 	/// Crée le dossier au besoin. Sérialise via `engine::world::foliage::


### PR DESCRIPTION
## M100.32 — Interactive Props

Périmètre **strictement borné** : 5 types **gelés** (DoorHinge, DoorSliding, WindowHinge, Trapdoor, ChestSimple). Modèle de données fermé, sérialisation `instances/interactives.bin` versionnée, animation client locale + compensation de latence, relai master **sans validation gameplay**.

### Cœur testable (engine_core + zone_builder — CI Linux)
- `InteractiveTypes.h` — enum gelé (commenté FIGÉ) + `InteractivePropInstance`.
- `InteractiveInstances.h` — format header-only `interactives.bin` (magic `INCT`), round-trip parfait (parité éditeur ↔ client).
- `InteractiveSimulator.{h,cpp}` — machine d'animation open/close pure : angle (types rotatifs) ou translation (DoorSliding), `ApplyRemoteState` avec compensation de latence (la porte ne saute pas).
- `InteractivePayloads.{h,cpp}` — 3 messages sur le gabarit `ByteReader/ByteWriter` + `PacketBuilder`.
- `InteractiveStateRelay.h` — map RAM `id → state` header-only ; id inconnu → `UnknownId` (ignoré).
- `WriteInteractives()` dans `ChunkPackageWriter`.
- `interactive_tests` — **9 cas** : round-trip binaire, 5 animations, compensation latence, round-trip réseau (3 messages), no-validation serveur, sync initial.

### Serveur (server_app — **redéploiement requis**)
- 3 opcodes **200/201/202** dans `ProtocolV1Constants.h` (additifs : un master ancien répondrait BAD_REQUEST).
- `InteractiveHandler` — dispatch opcode 200, relai broadcast aux **autres** clients, `SendInitialSync` ; **aucune** validation gameplay (portée/droit d'ouverture/anti-triche).
- Enregistrement dans `main_linux.cpp`.

### Éditeur (Windows)
- `InteractivePanel.{h,cpp}` — panneau secondaire ImGui guardé `_WIN32` + bouton **Trigger** (même simulateur que le client en jeu, sans réseau).

### Différé (2e passe client, cohérent stratégie server-first)
- Chargement `StreamCache.LoadInteractives` et déclenchement du sync initial sur EnterWorld (la zone n'est pas encore seedée au boot). `SendInitialSync` existe et est testé via le relais.

### Déploiement
> ⚠️ **redéploiement serveur (master) requis** — 3 nouveaux opcodes (`kOpInteractiveStateChange`, `kOpInteractiveStateBroadcast`, `kOpInteractiveStateSync`) + composant `InteractiveHandler`. À déployer en **lock-step** avec le client (un client neuf parlant à un master ancien recevrait BAD_REQUEST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)