### PR TITLE
chore(tickets): clôture M100.32 (Interactive Props, mergé #814)

### DIFF
--- a/tickets/TICKETS_STATUS.md
+++ b/tickets/TICKETS_STATUS.md
@@ -7,9 +7,9 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 
 | Statut | Nombre |
 |--------|-------:|
-| DONE (clotures) | 334 |
+| DONE (clotures) | 335 |
 | PARTIAL | 33 |
-| TODO | 46 |
+| TODO | 45 |
 | **Total** | 413 |
 
 ### Par milestone
@@ -62,7 +62,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M43 | 1 | 1 | 6 | 8 |
 | M44 | 4 | 0 | 0 | 4 |
 | M45 | 8 | 0 | 0 | 8 |
-| M100 | 41 | 0 | 10 | 51 |
+| M100 | 42 | 0 | 9 | 51 |
 | M101 | 8 | 1 | 2 | 11 |
 | AUTH-UI | 12 | 0 | 0 | 12 |
 | CHAR-MODEL | 3 | 12 | 22 | 37 |
@@ -566,7 +566,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M100.29 | DONE | Spline sampler + roads (Catmull-Rom, splat) (cloture #811) |
 | M100.30 | DONE | Bridges/walls + splines v2 + surface pont (cloture #811) |
 | M100.31 | DONE | Hamlet generator + kits (cloture #811) |
-| M100.32 | TODO | InteractiveProps/relay absents |
+| M100.32 | DONE | Interactive props + relay master + simulateur (cloture #814) |
 | M100.33 | DONE | Footstep audio + PlaytestMode (cloture #811) |
 | M100.34 | TODO | SelectionTool/Layers/Minimap/Exporter absents |
 | M100.35 | DONE | Mountain range tools |

--- a/tickets/issues/M100.32_Issue.md
+++ b/tickets/issues/M100.32_Issue.md
@@ -1,4 +1,17 @@
-# M100.32 — Interactive Props (Doors, Windows, Trapdoors, Simple Chests)
+# Issue: M100.32 — Interactive Props (Doors, Windows, Trapdoors, Simple Chests)
+
+**Status:** Closed
+
+_Implémenté et mergé par la PR #814. Cœur testable (types gelés, format
+`interactives.bin` round-trip, simulateur d'animation + compensation de latence,
+3 payloads réseau 200/201/202, relais master sans validation gameplay) + handler
+master enregistré dans `main_linux.cpp` + panneau éditeur ImGui. Tests :
+`interactive_tests` (9 cas), CI Linux+Windows verte. Différé en 2e passe client :
+`StreamCache.LoadInteractives` et déclenchement du sync initial sur EnterWorld
+(`InteractiveHandler::SendInitialSync` existe et est testé via le relais).
+Redéploiement serveur master requis (3 opcodes additifs + handler)._
+
+---
 
 ## Résumé
 


### PR DESCRIPTION
Clôture documentaire de **M100.32** (Interactive Props), implémenté et mergé par #814.

- Déplace `tickets/M100/M100.32-InteractiveProps.md` → `tickets/issues/M100.32_Issue.md` + bannière `Closed`.
- `TICKETS_STATUS.md` : ligne détail M100.32 → DONE ; totaux M100 **42/0/9** ; synthèse DONE **335** / TODO **45**.

Docs only — aucun impact code.

> **Déploiement** : ✅ docs uniquement, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)