### PR TITLE
feat(world): M100.34 — Selection / Layers / Minimap & Export complet de zone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,13 @@ add_library(engine_core
   # types/format/relais header-only ; payloads reseau partages).
   src/client/world/interactive/InteractiveSimulator.cpp
   src/world_editor/InteractivePanel.cpp
+  # M100.34 — Selection/Layers/Minimap/Export zone (geometrie + calques + export
+  # via Save*Bin header-only ; panneau minimap ImGui guarde).
+  src/world_editor/SelectionTool.cpp
+  src/world_editor/LayersDocument.cpp
+  src/world_editor/DeleteCommand.cpp
+  src/world_editor/WorldEditorExporter.cpp
+  src/world_editor/panels/MinimapPanel.cpp
   # M100.18 — Vegetation library + density painting (library JSON + Poisson-disk + outil).
   src/client/world/foliage/FoliageLibrary.cpp
   src/client/world/foliage/PoissonDiskSampler.cpp
@@ -950,6 +957,13 @@ add_test(NAME hazard_tests COMMAND hazard_tests)
 add_executable(interactive_tests src/client/world/interactive/tests/InteractiveTests.cpp)
 target_link_libraries(interactive_tests PRIVATE engine_core)
 add_test(NAME interactive_tests COMMAND interactive_tests)
+
+# M100.34 — Tests Selection/Layers/Minimap/DeleteCommand + export zone round-trip.
+# Tout est dans engine_core (Save*Bin header-only) ; on lie zone_builder_lib
+# comme le demande le ticket (writers offline partages, pas de doublon de format).
+add_executable(export_zone_tests src/world_editor/tests/ExportZoneTests.cpp)
+target_link_libraries(export_zone_tests PRIVATE engine_core zone_builder_lib)
+add_test(NAME export_zone_tests COMMAND export_zone_tests)
 
 # M100.17 — Tests placement (geometrie pure + format props.bin + commande).
 add_executable(placement_tests src/world_editor/tests/PlacementTests.cpp)

--- a/src/world_editor/DeleteCommand.cpp
+++ b/src/world_editor/DeleteCommand.cpp
@@ -1,0 +1,56 @@
+// M100.34 — Implémentation DeleteCommand (ICommand réversible).
+
+#include "src/world_editor/DeleteCommand.h"
+
+#include <algorithm>
+
+namespace engine::editor::world
+{
+	using engine::world::instances::PropInstance;
+
+	DeleteCommand::DeleteCommand(std::vector<PropInstance>& target, std::vector<uint32_t> instanceIds)
+		: m_target(target)
+		, m_ids(std::move(instanceIds))
+	{
+	}
+
+	size_t DeleteCommand::GetMemoryFootprint() const
+	{
+		return sizeof(DeleteCommand)
+			+ m_ids.capacity() * sizeof(uint32_t)
+			+ m_removed.capacity() * sizeof(std::pair<size_t, PropInstance>);
+	}
+
+	void DeleteCommand::Execute()
+	{
+		m_removed.clear();
+		// Parcourt en mémorisant l'index d'origine ; reconstruit le vecteur sans
+		// les ids supprimés. Index d'origine = position AVANT suppression, pour
+		// une réinsertion exacte au Undo.
+		std::vector<PropInstance> kept;
+		kept.reserve(m_target.size());
+		for (size_t i = 0; i < m_target.size(); ++i)
+		{
+			const PropInstance& p = m_target[i];
+			const bool toDelete = std::find(m_ids.begin(), m_ids.end(), p.instanceId) != m_ids.end();
+			if (toDelete)
+				m_removed.emplace_back(i, p);
+			else
+				kept.push_back(p);
+		}
+		m_target = std::move(kept);
+	}
+
+	void DeleteCommand::Undo()
+	{
+		// Réinsère dans l'ordre croissant des index d'origine. Comme chaque
+		// insertion décale les suivants, et que m_removed est trié par index
+		// croissant, insérer à `index` reconstruit l'ordre initial.
+		for (const auto& [index, inst] : m_removed)
+		{
+			const size_t clamped = index <= m_target.size() ? index : m_target.size();
+			m_target.insert(m_target.begin() + static_cast<std::ptrdiff_t>(clamped), inst);
+		}
+		m_removed.clear();
+	}
+}

--- a/src/world_editor/DeleteCommand.h
+++ b/src/world_editor/DeleteCommand.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// M100.34 — DeleteCommand : suppression réversible d'un ensemble de props
+// (sélection). Implémente ICommand (undo/redo). Opère directement sur le
+// vecteur de PropInstance du document éditeur (référence non-owning).
+//
+// Execute : retire les props dont l'instanceId est dans le set ; mémorise les
+// instances retirées + leur index d'origine pour pouvoir les réinsérer.
+// Undo : réinsère les instances à leur position d'origine (ordre préservé).
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "src/client/world/instances/PropInstances.h"
+#include "src/world_editor/core/CommandStack.h"
+
+namespace engine::editor::world
+{
+	/// Commande de suppression d'une sélection de props (réversible).
+	class DeleteCommand : public ICommand
+	{
+	public:
+		/// \param target       vecteur de props du document (modifié en place).
+		/// \param instanceIds  identifiants d'instance à supprimer.
+		DeleteCommand(std::vector<engine::world::instances::PropInstance>& target,
+			std::vector<uint32_t> instanceIds);
+
+		const char* GetLabel() const override { return "Delete selection"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+
+	private:
+		std::vector<engine::world::instances::PropInstance>& m_target;
+		std::vector<uint32_t> m_ids;
+		/// Sauvegarde pour Undo : (indexOriginal, instance). Trié par index
+		/// croissant pour réinsertion déterministe.
+		std::vector<std::pair<size_t, engine::world::instances::PropInstance>> m_removed;
+	};
+}

--- a/src/world_editor/LayersDocument.cpp
+++ b/src/world_editor/LayersDocument.cpp
@@ -1,0 +1,63 @@
+// M100.34 — Implémentation LayersDocument (logique pure).
+
+#include "src/world_editor/LayersDocument.h"
+
+namespace engine::editor::world
+{
+	LayersDocument::LayersDocument()
+	{
+		// Calque 0 = "Default", les autres "Layer N" masquables/verrouillables.
+		m_layers[0].name = "Default";
+		for (uint8_t i = 1; i < kLayerCount; ++i)
+			m_layers[i].name = "Layer " + std::to_string(static_cast<int>(i));
+	}
+
+	Layer& LayersDocument::LayerAt(uint8_t index)
+	{
+		if (index >= kLayerCount) index = 0;
+		return m_layers[index];
+	}
+
+	const Layer& LayersDocument::LayerAt(uint8_t index) const
+	{
+		if (index >= kLayerCount) index = 0;
+		return m_layers[index];
+	}
+
+	void LayersDocument::SetLayerName(uint8_t index, const std::string& name)
+	{
+		LayerAt(index).name = name;
+	}
+
+	void LayersDocument::SetVisible(uint8_t index, bool visible)
+	{
+		LayerAt(index).visible = visible;
+	}
+
+	void LayersDocument::SetLocked(uint8_t index, bool locked)
+	{
+		LayerAt(index).locked = locked;
+	}
+
+	void LayersDocument::AssignEntity(uint64_t entityKey, uint8_t layerIndex)
+	{
+		if (layerIndex >= kLayerCount) layerIndex = 0;
+		m_assignment[entityKey] = layerIndex;
+	}
+
+	uint8_t LayersDocument::GetEntityLayer(uint64_t entityKey) const
+	{
+		auto it = m_assignment.find(entityKey);
+		return it == m_assignment.end() ? 0u : it->second;
+	}
+
+	bool LayersDocument::IsEntityVisible(uint64_t entityKey) const
+	{
+		return LayerAt(GetEntityLayer(entityKey)).visible;
+	}
+
+	bool LayersDocument::IsEntityLocked(uint64_t entityKey) const
+	{
+		return LayerAt(GetEntityLayer(entityKey)).locked;
+	}
+}

--- a/src/world_editor/LayersDocument.h
+++ b/src/world_editor/LayersDocument.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// M100.34 — LayersDocument : 16 calques nommés (visibilité + verrou + couleur
+// d'overlay) + assignment des entités à un calque. Logique PURE (testable
+// headless) ; l'Outliner consomme ce document pour afficher/grouper.
+//
+// L'assignment est conservé EN MÉMOIRE (clé = identifiant d'entité). La
+// persistance d'un `layerIndex` dans les formats binaires (props/hazards/zones)
+// est différée en 2e passe (bump de version dédié) afin de ne pas casser les
+// formats v1 existants ; ce document reste la source d'autorité runtime.
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace engine::editor::world
+{
+	/// Nombre fixe de calques (cf. ticket : 16 max).
+	constexpr uint8_t kLayerCount = 16u;
+
+	/// Un calque de l'éditeur.
+	struct Layer
+	{
+		std::string name;                 ///< Nom affiché dans l'Outliner.
+		bool        visible = true;       ///< Masqué → entités non rendues.
+		bool        locked  = false;      ///< Verrouillé → édition bloquée.
+		uint32_t    overlayColorRgba = 0xFFFFFFFFu; ///< Couleur d'overlay (RGBA8).
+	};
+
+	/// Document des 16 calques + table d'assignment entité → calque.
+	class LayersDocument
+	{
+	public:
+		LayersDocument();
+
+		/// Accès à un calque par index (0..15). Indices hors borne renvoient le
+		/// calque 0 (Default) pour rester sûr.
+		Layer&       LayerAt(uint8_t index);
+		const Layer& LayerAt(uint8_t index) const;
+
+		void SetLayerName(uint8_t index, const std::string& name);
+		void SetVisible(uint8_t index, bool visible);
+		void SetLocked(uint8_t index, bool locked);
+
+		/// Assigne l'entité `entityKey` au calque `layerIndex` (clampé 0..15).
+		void AssignEntity(uint64_t entityKey, uint8_t layerIndex);
+
+		/// Calque de l'entité (Default=0 si non assignée).
+		uint8_t GetEntityLayer(uint64_t entityKey) const;
+
+		/// True si l'entité est visible (= son calque est visible). Une entité
+		/// non assignée suit le calque Default.
+		bool IsEntityVisible(uint64_t entityKey) const;
+
+		/// True si l'entité est verrouillée (= son calque est verrouillé).
+		bool IsEntityLocked(uint64_t entityKey) const;
+
+	private:
+		std::array<Layer, kLayerCount>          m_layers;
+		std::unordered_map<uint64_t, uint8_t>   m_assignment;
+	};
+}

--- a/src/world_editor/SelectionTool.cpp
+++ b/src/world_editor/SelectionTool.cpp
@@ -1,0 +1,70 @@
+// M100.34 — Implémentation SelectionTool (géométrie pure).
+
+#include "src/world_editor/SelectionTool.h"
+
+#include <utility>
+
+namespace engine::editor::world
+{
+	void SelectionRect::Normalize()
+	{
+		if (minX > maxX) std::swap(minX, maxX);
+		if (minZ > maxZ) std::swap(minZ, maxZ);
+	}
+
+	bool SelectionRect::Contains(float x, float z) const
+	{
+		return x >= minX && x <= maxX && z >= minZ && z <= maxZ;
+	}
+
+	std::vector<uint32_t> SelectInRect(const std::vector<SelectablePoint>& points, SelectionRect rect)
+	{
+		rect.Normalize();
+		std::vector<uint32_t> out;
+		for (const auto& p : points)
+		{
+			if (rect.Contains(p.x, p.z))
+				out.push_back(p.id);
+		}
+		return out;
+	}
+
+	namespace
+	{
+		/// Test d'inclusion d'un point dans un polygone par ray-casting horizontal
+		/// (règle pair/impair). `poly` : sommets {x,z}.
+		bool PointInPolygon(float x, float z, const std::vector<std::pair<float, float>>& poly)
+		{
+			bool inside = false;
+			const size_t n = poly.size();
+			for (size_t i = 0, j = n - 1; i < n; j = i++)
+			{
+				const float xi = poly[i].first,  zi = poly[i].second;
+				const float xj = poly[j].first,  zj = poly[j].second;
+				// L'arête (j→i) croise-t-elle la demi-droite horizontale partant
+				// de (x,z) vers +X ? Comparaison sur Z, intersection sur X.
+				const bool straddles = (zi > z) != (zj > z);
+				if (straddles)
+				{
+					const float xCross = xj + (z - zj) / (zi - zj) * (xi - xj);
+					if (x < xCross)
+						inside = !inside;
+				}
+			}
+			return inside;
+		}
+	}
+
+	std::vector<uint32_t> SelectInLasso(const std::vector<SelectablePoint>& points,
+		const std::vector<std::pair<float, float>>& polygon)
+	{
+		std::vector<uint32_t> out;
+		if (polygon.size() < 3) return out;
+		for (const auto& p : points)
+		{
+			if (PointInPolygon(p.x, p.z, polygon))
+				out.push_back(p.id);
+		}
+		return out;
+	}
+}

--- a/src/world_editor/SelectionTool.h
+++ b/src/world_editor/SelectionTool.h
@@ -1,0 +1,53 @@
+#pragma once
+
+// M100.34 — SelectionTool : sélection rectangulaire et lasso (géométrie PURE,
+// testable headless). L'outil ne connaît ni ImGui ni le viewport : il reçoit
+// les positions 2D (projection top-down X/Z) des entités sélectionnables et
+// retourne les identifiants contenus dans la zone. Le câblage viewport (drag
+// rectangle / main levée) et l'alimentation de la sélection multiple vivent
+// dans le shell éditeur (2e passe UI).
+//
+// Ne dépend pas de EditorSelection (sélection simple existante) : SelectionTool
+// produit une LISTE d'ids, que le shell peut ensuite appliquer.
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::world
+{
+	/// Un point sélectionnable : identifiant d'instance + position projetée X/Z.
+	struct SelectablePoint
+	{
+		uint32_t id = 0;
+		float    x  = 0.0f;
+		float    z  = 0.0f;
+	};
+
+	/// Rectangle de sélection aligné aux axes (coordonnées monde X/Z).
+	struct SelectionRect
+	{
+		float minX = 0.0f;
+		float minZ = 0.0f;
+		float maxX = 0.0f;
+		float maxZ = 0.0f;
+
+		/// Normalise pour garantir min ≤ max (drag dans n'importe quel sens).
+		void Normalize();
+
+		/// True si le point (x,z) est dans le rectangle (bornes incluses).
+		bool Contains(float x, float z) const;
+	};
+
+	/// Sélectionne tous les points contenus dans `rect`. Le rectangle est
+	/// normalisé localement (pas de mutation de l'argument).
+	std::vector<uint32_t> SelectInRect(const std::vector<SelectablePoint>& points, SelectionRect rect);
+
+	/// Sélectionne tous les points contenus dans le polygone lasso `polygon`
+	/// (suite de sommets X/Z, fermeture implicite dernier→premier). Test
+	/// d'inclusion par ray-casting (règle pair/impair). Un polygone de moins de
+	/// 3 sommets ne sélectionne rien.
+	/// \param polygon sommets {x,z} entrelacés dans l'ordre de tracé.
+	std::vector<uint32_t> SelectInLasso(const std::vector<SelectablePoint>& points,
+		const std::vector<std::pair<float, float>>& polygon);
+}

--- a/src/world_editor/WorldEditorExporter.cpp
+++ b/src/world_editor/WorldEditorExporter.cpp
@@ -1,0 +1,77 @@
+// M100.34 — Implémentation WorldEditorExporter (Save Zone).
+
+#include "src/world_editor/WorldEditorExporter.h"
+
+#include <filesystem>
+#include <fstream>
+
+namespace engine::editor::world
+{
+	namespace
+	{
+		/// Écrit `bytes` dans `path`, créant le dossier parent au besoin.
+		/// Retourne false + `outError` rempli en cas d'échec.
+		bool WriteFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes, std::string& outError)
+		{
+			std::error_code ec;
+			std::filesystem::create_directories(path.parent_path(), ec);
+			if (ec)
+			{
+				outError = "SaveZone: create_directories failed: " + path.parent_path().string();
+				return false;
+			}
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good())
+			{
+				outError = "SaveZone: open failed: " + path.string();
+				return false;
+			}
+			out.write(reinterpret_cast<const char*>(bytes.data()),
+				static_cast<std::streamsize>(bytes.size()));
+			if (!out.good())
+			{
+				outError = "SaveZone: write failed: " + path.string();
+				return false;
+			}
+			return true;
+		}
+	}
+
+	bool SaveZone(const std::string& outputDir, const ZoneExportInputs& inputs, std::string& outError)
+	{
+		namespace fs = std::filesystem;
+		const fs::path root(outputDir);
+		const fs::path inst = root / "instances";
+
+		// Couches d'instances zone-level (toujours écrites, même vides : un
+		// fichier avec count=0 est valide et explicite l'absence de données).
+		if (!WriteFile(inst / "props.bin",
+			engine::world::instances::SavePropsBin(inputs.props), outError)) return false;
+		if (!WriteFile(inst / "hazards.bin",
+			engine::world::hazard::SaveHazardsBin(inputs.hazards), outError)) return false;
+		if (!WriteFile(inst / "interactives.bin",
+			engine::world::interactive::SaveInteractivesBin(inputs.interactives), outError)) return false;
+		if (!WriteFile(inst / "zones.bin",
+			engine::world::zones::SaveZonesBin(inputs.zones), outError)) return false;
+		if (!WriteFile(inst / "splines.bin",
+			engine::world::spline::SaveSplinesBin(inputs.splines), outError)) return false;
+		if (!WriteFile(inst / "wind_zones.bin",
+			engine::world::wind::SaveWindZonesBin(inputs.windZones), outError)) return false;
+
+		// Données par-chunk : foliage + shade map.
+		for (const ChunkExportData& c : inputs.chunks)
+		{
+			const fs::path chunkDir = root / "chunks" /
+				("chunk_" + std::to_string(c.chunkX) + "_" + std::to_string(c.chunkZ));
+			if (!WriteFile(chunkDir / "foliage.bin",
+				engine::world::foliage::SaveFoliageBin(c.foliage), outError)) return false;
+			if (c.hasShade)
+			{
+				if (!WriteFile(chunkDir / "shade.bin",
+					engine::world::thermal::SaveShadeMapBin(c.shade), outError)) return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/world_editor/WorldEditorExporter.h
+++ b/src/world_editor/WorldEditorExporter.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// M100.34 — WorldEditorExporter : orchestrateur "Save Zone". Écrit une
+// arborescence chunk-package complète à partir des données instances de la
+// zone, en réutilisant les sérialiseurs header-only partagés avec le client
+// (Save*Bin dans engine_core) — AUCUNE duplication de format, et pas de
+// dépendance vers zone_builder_lib (évite un cycle ; le format est la même
+// source de vérité que les writers offline).
+//
+// Périmètre v1 de l'exporteur : couches d'instances zone-level (props, hazards,
+// interactives, zones, splines, wind zones) + par-chunk (foliage, shade map).
+// Le terrain / splat / LODs restent produits par les writers existants de
+// zone_builder_lib (WriteTerrainChunk/WriteSplatMap/WriteTerrainLods, couverts
+// par leurs propres tests) ; ils ne sont pas ré-implémentés ici.
+//
+// Parité éditeur ↔ client : une zone exportée est relue à l'identique par les
+// Load*Bin (cf. ExportZoneTests::FullRoundtrip).
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "src/client/world/foliage/FoliageInstances.h"
+#include "src/client/world/hazard/HazardVolumes.h"
+#include "src/client/world/instances/PropInstances.h"
+#include "src/client/world/interactive/InteractiveInstances.h"
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/client/world/thermal/ShadeMap.h"
+#include "src/client/world/wind/WindZones.h"
+#include "src/client/world/zones/Zones.h"
+
+namespace engine::editor::world
+{
+	/// Données d'un chunk pour l'export par-chunk.
+	struct ChunkExportData
+	{
+		int32_t chunkX = 0;
+		int32_t chunkZ = 0;
+		std::vector<engine::world::foliage::FoliageInstance> foliage;
+		engine::world::thermal::ShadeMap shade;
+		bool hasShade = false; ///< true si `shade` doit être écrit.
+	};
+
+	/// Agrégat des données exportables d'une zone (couches d'instances).
+	struct ZoneExportInputs
+	{
+		std::vector<engine::world::instances::PropInstance>            props;
+		std::vector<engine::world::hazard::HazardVolume>              hazards;
+		std::vector<engine::world::interactive::InteractivePropInstance> interactives;
+		std::vector<engine::world::zones::GameplayZone>              zones;
+		std::vector<engine::world::spline::Spline>                   splines;
+		std::vector<engine::world::wind::WindZone>                   windZones;
+		std::vector<ChunkExportData>                                 chunks;
+	};
+
+	/// Écrit l'arborescence complète sous `outputDir` :
+	///   <outputDir>/instances/{props,hazards,interactives,zones,splines,wind_zones}.bin
+	///   <outputDir>/chunks/chunk_<x>_<z>/{foliage,shade}.bin
+	/// Crée les dossiers au besoin. Retourne false + `outError` rempli au premier
+    /// échec d'écriture.
+	bool SaveZone(const std::string& outputDir, const ZoneExportInputs& inputs, std::string& outError);
+}

--- a/src/world_editor/panels/MinimapPanel.cpp
+++ b/src/world_editor/panels/MinimapPanel.cpp
@@ -1,0 +1,70 @@
+// M100.34 — Implémentation MinimapPanel (helper pur + rendu ImGui guardé).
+
+#include "src/world_editor/panels/MinimapPanel.h"
+
+#include <algorithm>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+	MinimapView BuildMinimapView(int32_t centerX, int32_t centerZ, int32_t radius,
+		const std::vector<std::pair<int32_t, int32_t>>& loaded)
+	{
+		if (radius < 0) radius = 0;
+		MinimapView view;
+		view.centerX = centerX;
+		view.centerZ = centerZ;
+		view.radius  = radius;
+		const int32_t side = 2 * radius + 1;
+		view.cells.reserve(static_cast<size_t>(side) * static_cast<size_t>(side));
+		for (int32_t dz = -radius; dz <= radius; ++dz)
+		{
+			for (int32_t dx = -radius; dx <= radius; ++dx)
+			{
+				const int32_t cx = centerX + dx;
+				const int32_t cz = centerZ + dz;
+				MinimapCell cell;
+				cell.chunkX = cx;
+				cell.chunkZ = cz;
+				cell.isCurrent = (dx == 0 && dz == 0);
+				cell.isLoaded = std::find(loaded.begin(), loaded.end(),
+					std::make_pair(cx, cz)) != loaded.end();
+				view.cells.push_back(cell);
+			}
+		}
+		return view;
+	}
+
+	void MinimapPanel::Render()
+	{
+#if defined(_WIN32)
+		ImGui::TextUnformatted("Minimap");
+		ImGui::Separator();
+		ImGui::Text("Center chunk (%d, %d)  radius %d", m_centerX, m_centerZ, m_radius);
+
+		const MinimapView view = BuildMinimapView(m_centerX, m_centerZ, m_radius, m_loaded);
+		const int32_t side = 2 * m_radius + 1;
+		const float cellPx = 16.0f;
+		ImDrawList* dl = ImGui::GetWindowDrawList();
+		const ImVec2 origin = ImGui::GetCursorScreenPos();
+		for (int32_t row = 0; row < side; ++row)
+		{
+			for (int32_t col = 0; col < side; ++col)
+			{
+				const MinimapCell& c = view.cells[static_cast<size_t>(row) * side + col];
+				const ImVec2 a(origin.x + col * cellPx, origin.y + row * cellPx);
+				const ImVec2 b(a.x + cellPx - 1.0f, a.y + cellPx - 1.0f);
+				ImU32 col32;
+				if (c.isCurrent)      col32 = IM_COL32(255, 230, 80, 255);  // chunk courant.
+				else if (c.isLoaded)  col32 = IM_COL32(120, 160, 200, 255); // chargé.
+				else                  col32 = IM_COL32(60, 60, 70, 255);    // vide.
+				dl->AddRectFilled(a, b, col32);
+			}
+		}
+		ImGui::Dummy(ImVec2(side * cellPx, side * cellPx));
+#endif
+	}
+}

--- a/src/world_editor/panels/MinimapPanel.h
+++ b/src/world_editor/panels/MinimapPanel.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// M100.34 — MinimapPanel : mini-carte 2D top-down du chunk courant et de ses
+// voisins. La construction de la grille (BuildMinimapView) est PURE et testable
+// headless ; le rendu ImGui (Render) est guardé Windows.
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::world
+{
+	/// Une cellule de la mini-carte (un chunk).
+	struct MinimapCell
+	{
+		int32_t chunkX    = 0;
+		int32_t chunkZ    = 0;
+		bool    isCurrent = false; ///< true pour le chunk centré (caméra).
+		bool    isLoaded  = false; ///< true si le chunk est chargé/visible.
+	};
+
+	/// Vue de mini-carte : grille (2*radius+1)² centrée sur (centerX, centerZ).
+	struct MinimapView
+	{
+		int32_t centerX = 0;
+		int32_t centerZ = 0;
+		int32_t radius  = 0;
+		std::vector<MinimapCell> cells; ///< Ordre ligne par ligne (z croissant, x croissant).
+	};
+
+	/// Construit la vue centrée sur (centerX, centerZ) avec un rayon `radius`
+	/// (en chunks). `loaded` liste les chunks chargés (marqués isLoaded). Le
+	/// chunk central est toujours marqué isCurrent.
+	/// \param radius rayon en chunks (clampé ≥ 0).
+	MinimapView BuildMinimapView(int32_t centerX, int32_t centerZ, int32_t radius,
+		const std::vector<std::pair<int32_t, int32_t>>& loaded);
+
+	/// Panneau ImGui de mini-carte.
+	class MinimapPanel
+	{
+	public:
+		void SetCenter(int32_t cx, int32_t cz) { m_centerX = cx; m_centerZ = cz; }
+		void SetRadius(int32_t r) { m_radius = r < 0 ? 0 : r; }
+		void SetLoadedChunks(std::vector<std::pair<int32_t, int32_t>> loaded) { m_loaded = std::move(loaded); }
+
+		/// Rendu ImGui. No-op hors Windows. Main thread, frame ImGui active.
+		void Render();
+
+	private:
+		int32_t m_centerX = 0;
+		int32_t m_centerZ = 0;
+		int32_t m_radius  = 3;
+		std::vector<std::pair<int32_t, int32_t>> m_loaded;
+	};
+}

--- a/src/world_editor/tests/ExportZoneTests.cpp
+++ b/src/world_editor/tests/ExportZoneTests.cpp
@@ -1,0 +1,291 @@
+// M100.34 — Tests Selection / Layers / Minimap / DeleteCommand / Export zone.
+//
+// Headless. Lié à engine_core (+ zone_builder_lib). Le round-trip d'export
+// écrit une arborescence chunk-package via WorldEditorExporter (Save*Bin
+// header-only, mêmes sérialiseurs que le client) puis relit chaque fichier
+// avec les Load*Bin (parité éditeur ↔ client : "consommé par le client").
+
+#include "src/world_editor/DeleteCommand.h"
+#include "src/world_editor/LayersDocument.h"
+#include "src/world_editor/SelectionTool.h"
+#include "src/world_editor/WorldEditorExporter.h"
+#include "src/world_editor/panels/MinimapPanel.h"
+
+#include "src/client/world/foliage/FoliageInstances.h"
+#include "src/client/world/hazard/HazardVolumes.h"
+#include "src/client/world/instances/PropInstances.h"
+#include "src/client/world/interactive/InteractiveInstances.h"
+#include "src/client/world/spline/SplineInstances.h"
+#include "src/client/world/thermal/ShadeMap.h"
+#include "src/client/world/wind/WindZones.h"
+#include "src/client/world/zones/Zones.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace engine::editor::world;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Near(float a, float b, float eps = 1e-4f) { return (a - b < eps) && (b - a < eps); }
+
+	std::vector<uint8_t> ReadFile(const std::filesystem::path& p)
+	{
+		std::ifstream in(p, std::ios::binary);
+		if (!in.good()) return {};
+		return std::vector<uint8_t>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	}
+
+	engine::world::instances::PropInstance MakeProp(uint32_t id, float x)
+	{
+		engine::world::instances::PropInstance p;
+		p.instanceId = id;
+		p.assetId = id * 10u;
+		p.position = { x, 0.0f, 0.0f };
+		return p;
+	}
+
+	// -------------------------------------------------------------------------
+	// Selection
+	// -------------------------------------------------------------------------
+	void Test_Selection_Rect_SelectsContainedProps()
+	{
+		std::vector<SelectablePoint> pts = {
+			{1, 0.0f, 0.0f}, {2, 5.0f, 5.0f}, {3, 20.0f, 20.0f}, {4, -3.0f, 2.0f}
+		};
+		// Rectangle [-1..10]x[-1..10] : contient ids 1 et 2, pas 3 (trop loin)
+		// ni 4 (x=-3 < -1).
+		SelectionRect rect{ -1.0f, -1.0f, 10.0f, 10.0f };
+		auto sel = SelectInRect(pts, rect);
+		REQUIRE(sel.size() == 2);
+		bool has1 = false, has2 = false;
+		for (uint32_t id : sel) { if (id == 1) has1 = true; if (id == 2) has2 = true; }
+		REQUIRE(has1 && has2);
+
+		// Rectangle inversé (drag bas-droite → haut-gauche) : même résultat.
+		SelectionRect inv{ 10.0f, 10.0f, -1.0f, -1.0f };
+		REQUIRE(SelectInRect(pts, inv).size() == 2);
+	}
+
+	void Test_Selection_Lasso_SelectsContainedProps()
+	{
+		std::vector<SelectablePoint> pts = {
+			{1, 1.0f, 1.0f}, {2, 2.0f, 8.0f}, {3, 50.0f, 50.0f}
+		};
+		// Triangle (0,0)-(10,0)-(0,10) : contient id 1, pas 2 (au-dessus de
+		// l'hypoténuse x+z<=10 ? 2+8=10 → sur la limite, exclu), pas 3.
+		std::vector<std::pair<float, float>> poly = { {0,0}, {10,0}, {0,10} };
+		auto sel = SelectInLasso(pts, poly);
+		bool has1 = false, has3 = false;
+		for (uint32_t id : sel) { if (id == 1) has1 = true; if (id == 3) has3 = true; }
+		REQUIRE(has1);
+		REQUIRE(!has3);
+
+		// Polygone dégénéré (< 3 sommets) → rien.
+		std::vector<std::pair<float, float>> deg = { {0,0}, {1,1} };
+		REQUIRE(SelectInLasso(pts, deg).empty());
+	}
+
+	// -------------------------------------------------------------------------
+	// Layers
+	// -------------------------------------------------------------------------
+	void Test_Layer_Visibility_HidesPropsInOutliner()
+	{
+		LayersDocument doc;
+		doc.AssignEntity(42, 3);
+		REQUIRE(doc.GetEntityLayer(42) == 3);
+		REQUIRE(doc.IsEntityVisible(42)); // calque visible par défaut.
+		doc.SetVisible(3, false);
+		REQUIRE(!doc.IsEntityVisible(42)); // masqué.
+		// Entité non assignée suit Default (visible).
+		REQUIRE(doc.IsEntityVisible(999));
+	}
+
+	void Test_Layer_Lock_BlocksEdits()
+	{
+		LayersDocument doc;
+		doc.AssignEntity(7, 2);
+		REQUIRE(!doc.IsEntityLocked(7));
+		doc.SetLocked(2, true);
+		REQUIRE(doc.IsEntityLocked(7));
+		// 16 calques max ; index hors borne retombe sur Default sans crash.
+		doc.AssignEntity(8, 99);
+		REQUIRE(doc.GetEntityLayer(8) == 0);
+	}
+
+	// -------------------------------------------------------------------------
+	// Minimap
+	// -------------------------------------------------------------------------
+	void Test_Minimap_RendersCurrentChunk()
+	{
+		std::vector<std::pair<int32_t, int32_t>> loaded = { {0,0}, {1,0} };
+		MinimapView v = BuildMinimapView(0, 0, 1, loaded);
+		REQUIRE(v.cells.size() == 9); // (2*1+1)^2
+		int currentCount = 0, loadedCount = 0;
+		for (const auto& c : v.cells)
+		{
+			if (c.isCurrent) { ++currentCount; REQUIRE(c.chunkX == 0 && c.chunkZ == 0); }
+			if (c.isLoaded) ++loadedCount;
+		}
+		REQUIRE(currentCount == 1);
+		REQUIRE(loadedCount == 2); // (0,0) et (1,0)
+	}
+
+	// -------------------------------------------------------------------------
+	// DeleteCommand
+	// -------------------------------------------------------------------------
+	void Test_DeleteCommand_RoundTrip()
+	{
+		std::vector<engine::world::instances::PropInstance> props = {
+			MakeProp(1, 1.0f), MakeProp(2, 2.0f), MakeProp(3, 3.0f), MakeProp(4, 4.0f)
+		};
+		DeleteCommand cmd(props, { 2, 4 });
+		cmd.Execute();
+		REQUIRE(props.size() == 2);
+		REQUIRE(props[0].instanceId == 1 && props[1].instanceId == 3);
+		cmd.Undo();
+		REQUIRE(props.size() == 4);
+		// Ordre d'origine restauré.
+		REQUIRE(props[0].instanceId == 1);
+		REQUIRE(props[1].instanceId == 2);
+		REQUIRE(props[2].instanceId == 3);
+		REQUIRE(props[3].instanceId == 4);
+		REQUIRE(Near(props[3].position.x, 4.0f));
+	}
+
+	// -------------------------------------------------------------------------
+	// Export zone — round-trip complet (parité éditeur ↔ client)
+	// -------------------------------------------------------------------------
+	void Test_ExportZone_FullRoundtrip()
+	{
+		ZoneExportInputs in;
+		// Props.
+		in.props = { MakeProp(10, 1.5f), MakeProp(11, 2.5f) };
+		// Hazards.
+		engine::world::hazard::HazardVolume hz;
+		hz.type = engine::world::hazard::HazardType::Tar;
+		hz.position = { 7.0f, 0.0f, 9.0f };
+		in.hazards = { hz };
+		// Interactives.
+		engine::world::interactive::InteractivePropInstance it;
+		it.id = 77; it.type = engine::world::interactive::InteractiveType::DoorHinge;
+		it.openAngleDeg = 90.0f; it.audioOpenEvent = "creak";
+		in.interactives = { it };
+		// Zones.
+		engine::world::zones::GameplayZone gz;
+		gz.type = engine::world::zones::ZoneType::PvPZone;
+		gz.name = "arena";
+		gz.polygon = { {0,0,0}, {10,0,0}, {10,0,10} };
+		in.zones = { gz };
+		// Splines.
+		engine::world::spline::Spline sp;
+		sp.type = engine::world::spline::SplineType::Road;
+		sp.nodes.push_back({ {1.0f, 0.0f, 1.0f}, 6.0f, 0.0f });
+		sp.nodes.push_back({ {2.0f, 0.0f, 2.0f}, 5.0f, 0.0f });
+		in.splines = { sp };
+		// Wind zones.
+		engine::world::wind::WindZone wz;
+		wz.directionX = 0.0f; wz.directionZ = 1.0f; wz.forceMps = 7.5f;
+		wz.polygon = { {0,0,0}, {5,0,0}, {5,0,5} };
+		in.windZones = { wz };
+		// Chunk : foliage + shade.
+		ChunkExportData chunk;
+		chunk.chunkX = 1; chunk.chunkZ = 2;
+		chunk.foliage.push_back({ 0xABCDu, {1.0f, 0.0f, 2.0f}, 0.5f, 1.25f });
+		chunk.shade.resolution = engine::world::thermal::kShadeMapResolution;
+		chunk.shade.coverage.assign(
+			static_cast<size_t>(chunk.shade.resolution) * chunk.shade.resolution, 128u);
+		chunk.shade.coverage[0] = 200u;
+		chunk.hasShade = true;
+		in.chunks = { chunk };
+
+		// Dossier temporaire unique.
+		const std::filesystem::path dir =
+			std::filesystem::temp_directory_path() / "lcdlln_export_zone_test";
+		std::error_code ec;
+		std::filesystem::remove_all(dir, ec);
+
+		std::string err;
+		REQUIRE(SaveZone(dir.string(), in, err));
+		if (!err.empty()) std::fprintf(stderr, "  SaveZone err: %s\n", err.c_str());
+
+		// Relit chaque fichier via les Load*Bin (= ce que fait le client).
+		const std::filesystem::path inst = dir / "instances";
+		std::string lerr;
+
+		std::vector<engine::world::instances::PropInstance> props2;
+		REQUIRE(engine::world::instances::LoadPropsBin(ReadFile(inst / "props.bin"), props2, lerr));
+		REQUIRE(props2.size() == 2);
+		if (props2.size() == 2) { REQUIRE(props2[0].instanceId == 10); REQUIRE(Near(props2[1].position.x, 2.5f)); }
+
+		std::vector<engine::world::hazard::HazardVolume> hz2;
+		REQUIRE(engine::world::hazard::LoadHazardsBin(ReadFile(inst / "hazards.bin"), hz2, lerr));
+		REQUIRE(hz2.size() == 1);
+		if (hz2.size() == 1) { REQUIRE(hz2[0].type == engine::world::hazard::HazardType::Tar); REQUIRE(Near(hz2[0].position.z, 9.0f)); }
+
+		std::vector<engine::world::interactive::InteractivePropInstance> it2;
+		REQUIRE(engine::world::interactive::LoadInteractivesBin(ReadFile(inst / "interactives.bin"), it2, lerr));
+		REQUIRE(it2.size() == 1);
+		if (it2.size() == 1) { REQUIRE(it2[0].id == 77); REQUIRE(it2[0].audioOpenEvent == "creak"); }
+
+		std::vector<engine::world::zones::GameplayZone> gz2;
+		REQUIRE(engine::world::zones::LoadZonesBin(ReadFile(inst / "zones.bin"), gz2, lerr));
+		REQUIRE(gz2.size() == 1);
+		if (gz2.size() == 1) { REQUIRE(gz2[0].type == engine::world::zones::ZoneType::PvPZone); REQUIRE(gz2[0].name == "arena"); REQUIRE(gz2[0].polygon.size() == 3); }
+
+		std::vector<engine::world::spline::Spline> sp2;
+		REQUIRE(engine::world::spline::LoadSplinesBin(ReadFile(inst / "splines.bin"), sp2, lerr));
+		REQUIRE(sp2.size() == 1);
+		if (sp2.size() == 1) { REQUIRE(sp2[0].nodes.size() == 2); REQUIRE(Near(sp2[0].nodes[1].widthMeters, 5.0f)); }
+
+		std::vector<engine::world::wind::WindZone> wz2;
+		REQUIRE(engine::world::wind::LoadWindZonesBin(ReadFile(inst / "wind_zones.bin"), wz2, lerr));
+		REQUIRE(wz2.size() == 1);
+		if (wz2.size() == 1) { REQUIRE(Near(wz2[0].forceMps, 7.5f)); REQUIRE(Near(wz2[0].directionZ, 1.0f)); }
+
+		// Par-chunk.
+		const std::filesystem::path chunkDir = dir / "chunks" / "chunk_1_2";
+		std::vector<engine::world::foliage::FoliageInstance> fol2;
+		REQUIRE(engine::world::foliage::LoadFoliageBin(ReadFile(chunkDir / "foliage.bin"), fol2, lerr));
+		REQUIRE(fol2.size() == 1);
+		if (fol2.size() == 1) { REQUIRE(fol2[0].assetIdHash == 0xABCDu); REQUIRE(Near(fol2[0].scale, 1.25f)); }
+
+		engine::world::thermal::ShadeMap shade2;
+		REQUIRE(engine::world::thermal::LoadShadeMapBin(ReadFile(chunkDir / "shade.bin"), shade2, lerr));
+		REQUIRE(shade2.resolution == engine::world::thermal::kShadeMapResolution);
+		REQUIRE(shade2.coverage.size() == chunk.shade.coverage.size());
+		if (!shade2.coverage.empty()) REQUIRE(shade2.coverage[0] == 200u);
+
+		std::filesystem::remove_all(dir, ec);
+	}
+}
+
+int main()
+{
+	Test_Selection_Rect_SelectsContainedProps();
+	Test_Selection_Lasso_SelectsContainedProps();
+	Test_Layer_Visibility_HidesPropsInOutliner();
+	Test_Layer_Lock_BlocksEdits();
+	Test_Minimap_RendersCurrentChunk();
+	Test_DeleteCommand_RoundTrip();
+	Test_ExportZone_FullRoundtrip();
+
+	if (g_failed == 0)
+		std::printf("[export_zone_tests] all tests passed\n");
+	else
+		std::fprintf(stderr, "[export_zone_tests] %d check(s) failed\n", g_failed);
+	return g_failed;
+}


### PR DESCRIPTION
## M100.34 — Selection, Layers, Minimap & Save/Load Zone

Ticket de polissage éditeur. Sélection rect/lasso, 16 calques, mini-carte 2D, suppression réversible, et **export complet de zone** vers chunk packages versionnés — réutilisant les sérialiseurs header-only partagés avec le client (`Save*Bin`), **sans duplication de format** ni dépendance vers `zone_builder_lib` (évite un cycle).

### Cœur testable (engine_core — CI Linux)
- `SelectionTool.{h,cpp}` — rect (AABB, normalisé) + lasso (ray-casting pair/impair), pur.
- `LayersDocument.{h,cpp}` — 16 calques (nom/visibilité/verrou/couleur) + assignment `id → calque`.
- `DeleteCommand.{h,cpp}` — `ICommand` réversible sur le vecteur de props (Undo réinsère à l'index d'origine).
- `WorldEditorExporter.{h,cpp}` — `SaveZone` écrit `instances/{props,hazards,interactives,zones,splines,wind_zones}.bin` + `chunks/.../{foliage,shade}.bin`.
- `panels/MinimapPanel.{h,cpp}` — `BuildMinimapView` pur + rendu ImGui guardé `_WIN32`.
- `export_zone_tests` — **7 cas** dont `FullRoundtrip` : écrit puis relit via `Load*Bin` (= parité éditeur ↔ client, « consommé par le client »).

### Différé (2e passe UI/format — cohérent stratégie server-first)
- Câblage live `WorldEditorShell` (raccourci Suppr) + `OutlinerPanel` (affichage calques).
- Persistance d'un `layerIndex` dans les formats binaires (bump de version dédié) : `LayersDocument` reste l'autorité runtime en mémoire pour l'instant — **les formats v1 existants ne sont pas touchés** (tests existants verts).
- Terrain/splat/LODs : déjà produits par les writers `zone_builder` existants (couverts par leurs propres tests `terrain_chunk_tests`/`splat_map_tests`/`terrain_lod_tests`) ; l'exporteur couvre les couches d'instances + données par-chunk (foliage/shade).
- `fog_volumes.bin` / `atmosphere_zones.bin` : formats non encore implémentés (tickets distincts) — non écrits.

### Déploiement
> ✅ **client/éditeur uniquement, pas de redéploiement serveur.** (M100.32 déjà déployé couvre l'opcode interactif ; rien de nouveau côté wire ici.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)