### PR TITLE
feat(world_editor): M100.49 (partie 1) — Tutoriel interactif + Overlay guidance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,12 @@ add_library(engine_core
   src/world_editor/presets/ToolPresetIo.cpp
   src/world_editor/presets/ToolPresetRegistry.cpp
   src/world_editor/prefs/UserPrefsStore.cpp
+  # M100.49 — Tutorial & Overlay guidance (coeur pur ; diagnostic differe car
+  # depend de M100.48). OverlayGuidanceSystem = moteur de sequence ;
+  # TutorialSystem = pilotage + flags ; TutorialIo = tutoriel "first_launch" code.
+  src/world_editor/help/OverlayGuidanceSystem.cpp
+  src/world_editor/tutorial/TutorialSystem.cpp
+  src/world_editor/tutorial/TutorialIo.cpp
   # M100.46 — Zone Presets Library. Incrément 1 : socle data (format
   # JSON + parsing + registry + validation). Incrément 2a : couche de
   # paramètres typés (OperationParams) + customisation (relief/eau/
@@ -970,6 +976,13 @@ add_test(NAME forest_field_tests COMMAND forest_field_tests)
 add_executable(wind_tests src/client/world/wind/tests/WindTests.cpp)
 target_link_libraries(wind_tests PRIVATE engine_core)
 add_test(NAME wind_tests COMMAND wind_tests)
+
+# M100.49 — Tests Tutorial & Overlay (moteur de sequence + systeme tutoriel +
+# registre widgets). Diagnostic differe (depend de M100.48). Ancrage distinct
+# pour eviter les conflits CMake avec d'autres PR M100 en vol.
+add_executable(tutorial_diagnostic_tests src/world_editor/tests/TutorialDiagnosticTests.cpp)
+target_link_libraries(tutorial_diagnostic_tests PRIVATE engine_core)
+add_test(NAME tutorial_diagnostic_tests COMMAND tutorial_diagnostic_tests)
 
 # M100.21 — Tests collecteur d'influences (portee, troncature, flexion).
 add_executable(entity_influence_tests src/client/world/foliage/tests/EntityInfluenceTests.cpp)

--- a/game/data/editor/tutorials/first_launch.json
+++ b/game/data/editor/tutorials/first_launch.json
@@ -1,0 +1,30 @@
+{
+  "id": "first_launch",
+  "version": 1,
+  "displayName": "Premier lancement",
+  "estimatedMinutes": 5,
+  "_note": "M100.49 MVP — contenu defini en code dans TutorialIo.cpp (BuildFirstLaunchTutorial). Ce fichier documente le format ; le chargement JSON via TutorialIo est differe (2e passe).",
+  "introModal": {
+    "titleFr": "Bienvenue dans l'editeur LCDLLN",
+    "bodyFr": "Vous etes ici pour la premiere fois. Voulez-vous suivre le tutoriel de 5 minutes qui vous guidera dans la creation de votre premiere zone ?",
+    "bulletsFr": [
+      "Creer une zone a partir d'un template",
+      "Ajuster les parametres de terrain",
+      "Valider et exporter votre zone"
+    ]
+  },
+  "steps": [
+    { "id": "step1_open_zone_preset", "titleFr": "Etape 1/8 — Ouvre le dialog", "bodyFr": "Clique sur Fichier -> Nouvelle zone depuis preset.", "iconHint": "point_up", "targetWidget": "menubar.file.new_from_preset", "validatesOn": "zone_preset_dialog.opened" },
+    { "id": "step2_select_forest", "titleFr": "Etape 2/8 — Choisis un preset", "bodyFr": "Choisis la Foret temperee.", "iconHint": "point_up", "targetWidget": "zone_preset_dialog.thumbnail.temperate_forest", "validatesOn": "zone_preset_dialog.selected.temperate_forest" },
+    { "id": "step3_create_zone", "titleFr": "Etape 3/8 — Cree la zone", "bodyFr": "Laisse les sliders par defaut et clique Creer la zone.", "iconHint": "point_up", "targetWidget": "zone_preset_dialog.button.create", "validatesOn": "zone.created" },
+    { "id": "step4_select_cave_tool", "titleFr": "Etape 4/8 — Outil Cave", "bodyFr": "Clique sur Cave dans la barre d'outils.", "iconHint": "point_up", "targetWidget": "toolbar.button.cave", "validatesOn": "tool.cave.active" },
+    { "id": "step5_select_cave_asset", "titleFr": "Etape 5/8 — Choisis un asset", "bodyFr": "Selectionne cave_small_01 dans le catalogue.", "iconHint": "point_up", "targetWidget": "panel.tool_properties.catalog_item.cave_small_01", "validatesOn": "catalog.cave_small_01.selected" },
+    { "id": "step6_place_cave", "titleFr": "Etape 6/8 — Pose la grotte", "bodyFr": "Clique sur le terrain pour poser la grotte.", "iconHint": "point_up", "targetWidget": "viewport", "validatesOn": "mesh_insert.cave.placed" },
+    { "id": "step7_validate", "titleFr": "Etape 7/8 — Valide ta zone", "bodyFr": "Clique sur le bouton Valider dans la barre d'outils.", "iconHint": "shield", "targetWidget": "toolbar.button.validate", "validatesOn": "panel.validation.opened" },
+    { "id": "step8_export_info", "titleFr": "Etape 8/8 — Exporter", "bodyFr": "Exporte via Fichier -> Exporter. Le tutoriel s'arrete ici !", "iconHint": "check", "targetWidget": "menubar.file.export", "validatesOn": "" }
+  ],
+  "outroModal": {
+    "titleFr": "Felicitations !",
+    "bodyFr": "Tu sais maintenant l'essentiel. F1 ouvre la doc complete, et « Pourquoi ca ne marche pas ? » (menu Aide) t'aide a diagnostiquer les problemes."
+  }
+}

--- a/src/world_editor/help/OverlayGuidanceSystem.cpp
+++ b/src/world_editor/help/OverlayGuidanceSystem.cpp
@@ -1,0 +1,62 @@
+// M100.49 — Implémentation OverlayGuidanceSystem (moteur de séquence pur).
+
+#include "src/world_editor/help/OverlayGuidanceSystem.h"
+
+#include <utility>
+
+namespace engine::editor::world::help
+{
+	void OverlayGuidanceSystem::StartSequence(std::vector<OverlayInstruction> instructions, OnCompleteCallback onComplete)
+	{
+		m_instructions = std::move(instructions);
+		m_onComplete = std::move(onComplete);
+		m_index = 0;
+		m_active = !m_instructions.empty();
+		if (!m_active && m_onComplete)
+		{
+			// Séquence vide : considérée immédiatement complète.
+			auto cb = m_onComplete;
+			m_onComplete = nullptr;
+			cb();
+		}
+	}
+
+	void OverlayGuidanceSystem::AdvanceStep()
+	{
+		if (!m_active) return;
+		if (m_index + 1 < m_instructions.size())
+		{
+			++m_index;
+			return;
+		}
+		// Dernière étape franchie → complétion.
+		m_active = false;
+		auto cb = m_onComplete;
+		m_onComplete = nullptr;
+		m_index = 0;
+		m_instructions.clear();
+		if (cb) cb();
+	}
+
+	bool OverlayGuidanceSystem::NotifyAction(const WidgetTargetId& widgetId)
+	{
+		if (!m_active) return false;
+		const OverlayInstruction& cur = m_instructions[m_index];
+		// Avance si l'étape attend explicitement cette action, ou si son widget
+		// cible correspond (cas où validatesOnAction n'est pas renseigné).
+		const bool matches =
+			(!cur.validatesOnAction.empty() && cur.validatesOnAction == widgetId) ||
+			(cur.validatesOnAction.empty() && !cur.targetWidget.empty() && cur.targetWidget == widgetId);
+		if (!matches) return false;
+		AdvanceStep();
+		return true;
+	}
+
+	void OverlayGuidanceSystem::AbortSequence()
+	{
+		m_active = false;
+		m_index = 0;
+		m_instructions.clear();
+		m_onComplete = nullptr;
+	}
+}

--- a/src/world_editor/help/OverlayGuidanceSystem.h
+++ b/src/world_editor/help/OverlayGuidanceSystem.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// M100.49 — OverlayGuidanceSystem : moteur de SÉQUENCE d'instructions (logique
+// PURE, testable headless). Partagé entre tutoriel et (futur) diagnostic.
+//
+// Le moteur gère l'enchaînement des étapes : démarrage d'une séquence, étape
+// courante, avancement (manuel ou sur action validée), abandon, complétion. Le
+// rendu visuel (voile, rectangle pulsant, bulle) est une passe UI séparée
+// (Windows) qui lit CurrentInstruction() + le WidgetTargetRegistry — non incluse
+// dans ce cœur pour le garder pur.
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#include "src/world_editor/tutorial/Tutorial.h"
+
+namespace engine::editor::world::help
+{
+	/// Moteur de séquence d'OverlayInstruction. Instanciable (pas un singleton
+	/// global) pour rester testable ; le shell en tient une instance.
+	class OverlayGuidanceSystem
+	{
+	public:
+		using OnCompleteCallback = std::function<void()>;
+
+		/// Démarre une séquence. Remplace toute séquence active. `onComplete` est
+		/// appelé quand la dernière étape est franchie (ou null).
+		void StartSequence(std::vector<OverlayInstruction> instructions, OnCompleteCallback onComplete = nullptr);
+
+		/// Avance d'une étape. Si c'était la dernière, termine la séquence et
+		/// invoque le callback de complétion. No-op si aucune séquence active.
+		void AdvanceStep();
+
+		/// Signale qu'une action utilisateur a eu lieu sur `widgetId`. Si l'étape
+		/// courante attend cette action (validatesOnAction == widgetId), avance.
+		/// \return true si l'action a fait avancer la séquence.
+		bool NotifyAction(const WidgetTargetId& widgetId);
+
+		/// Abandonne la séquence en cours (sans appeler onComplete). No-op si
+		/// aucune séquence active.
+		void AbortSequence();
+
+		/// True si une séquence est en cours.
+		bool IsActiveSequence() const { return m_active; }
+
+		/// Index de l'étape courante (0-based ; 0 si inactive).
+		size_t CurrentIndex() const { return m_index; }
+
+		/// Nombre total d'étapes de la séquence active (0 si inactive).
+		size_t StepCount() const { return m_instructions.size(); }
+
+		/// Instruction courante (valide seulement si IsActiveSequence()).
+		const OverlayInstruction& CurrentInstruction() const { return m_instructions[m_index]; }
+
+	private:
+		std::vector<OverlayInstruction> m_instructions;
+		size_t                          m_index   = 0;
+		bool                            m_active  = false;
+		OnCompleteCallback              m_onComplete;
+	};
+}

--- a/src/world_editor/help/WidgetTargetRegistry.h
+++ b/src/world_editor/help/WidgetTargetRegistry.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// M100.49 — WidgetTargetRegistry : enregistre les rectangles écran des widgets
+// par leur id stable, pour que l'overlay sache où dessiner le surlignage.
+// Pure (rectangle = struct simple, pas d'ImVec2) → testable headless. Le shell
+// éditeur remplit le registre chaque frame depuis les positions ImGui réelles.
+
+#include <string>
+#include <unordered_map>
+
+#include "src/world_editor/tutorial/Tutorial.h"
+
+namespace engine::editor::world::help
+{
+	/// Rectangle écran (coordonnées pixels, top-left + bottom-right).
+	struct WidgetRect
+	{
+		float x0 = 0.0f, y0 = 0.0f, x1 = 0.0f, y1 = 0.0f;
+		bool Valid() const { return x1 > x0 && y1 > y0; }
+	};
+
+	/// Registre id → rectangle. Rempli par frame ; lu par l'overlay.
+	class WidgetTargetRegistry
+	{
+	public:
+		/// Enregistre/maj le rectangle d'un widget.
+		void Register(const WidgetTargetId& id, const WidgetRect& rect) { m_rects[id] = rect; }
+
+		/// Récupère le rectangle d'un widget. `*found` indique la présence.
+		WidgetRect Get(const WidgetTargetId& id, bool* found = nullptr) const
+		{
+			auto it = m_rects.find(id);
+			if (it == m_rects.end()) { if (found) *found = false; return {}; }
+			if (found) *found = true;
+			return it->second;
+		}
+
+		/// Vide le registre (début de frame).
+		void Clear() { m_rects.clear(); }
+
+		size_t Count() const { return m_rects.size(); }
+
+	private:
+		std::unordered_map<WidgetTargetId, WidgetRect> m_rects;
+	};
+}

--- a/src/world_editor/tests/TutorialDiagnosticTests.cpp
+++ b/src/world_editor/tests/TutorialDiagnosticTests.cpp
@@ -1,0 +1,174 @@
+// M100.49 — Tests Tutorial & Overlay (cœur indépendant de M100.48).
+//
+// Couvre le moteur de séquence (OverlayGuidanceSystem) + le système de tutoriel
+// (progression 8 étapes, validation d'action, skip, pause/resume, flags) +
+// WidgetTargetRegistry. Le système de DIAGNOSTIC (10 règles) dépend du
+// ValidationContext de M100.48 (#817) et sera livré en 2e passe une fois #817
+// mergé — non couvert ici.
+
+#include "src/world_editor/help/OverlayGuidanceSystem.h"
+#include "src/world_editor/help/WidgetTargetRegistry.h"
+#include "src/world_editor/tutorial/TutorialIo.h"
+#include "src/world_editor/tutorial/TutorialSystem.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace engine::editor::world::help;
+using namespace engine::editor::world::tutorial;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	OverlayInstruction Instr(const std::string& target, const std::string& validatesOn)
+	{
+		OverlayInstruction i;
+		i.targetWidget = target;
+		i.validatesOnAction = validatesOn;
+		i.requiresAction = true;
+		return i;
+	}
+
+	void Test_Overlay_SequenceAdvanceAndComplete()
+	{
+		OverlayGuidanceSystem ov;
+		bool done = false;
+		ov.StartSequence({ Instr("a", "a.done"), Instr("b", "b.done"), Instr("c", "c.done") },
+			[&done]() { done = true; });
+		REQUIRE(ov.IsActiveSequence());
+		REQUIRE(ov.StepCount() == 3);
+		REQUIRE(ov.CurrentIndex() == 0);
+
+		// Mauvaise action : pas d'avancement.
+		REQUIRE(!ov.NotifyAction("x.done"));
+		REQUIRE(ov.CurrentIndex() == 0);
+
+		// Bonnes actions successives.
+		REQUIRE(ov.NotifyAction("a.done"));
+		REQUIRE(ov.CurrentIndex() == 1);
+		REQUIRE(ov.NotifyAction("b.done"));
+		REQUIRE(ov.CurrentIndex() == 2);
+		REQUIRE(!done);
+		REQUIRE(ov.NotifyAction("c.done")); // dernière → complétion
+		REQUIRE(done);
+		REQUIRE(!ov.IsActiveSequence());
+	}
+
+	void Test_Overlay_AbortDoesNotComplete()
+	{
+		OverlayGuidanceSystem ov;
+		bool done = false;
+		ov.StartSequence({ Instr("a", "a.done") }, [&done]() { done = true; });
+		ov.AbortSequence();
+		REQUIRE(!ov.IsActiveSequence());
+		REQUIRE(!done);
+	}
+
+	void Test_WidgetRegistry_RegisterAndGet()
+	{
+		WidgetTargetRegistry reg;
+		reg.Register("toolbar.button.cave", { 10.0f, 20.0f, 50.0f, 60.0f });
+		bool found = false;
+		WidgetRect r = reg.Get("toolbar.button.cave", &found);
+		REQUIRE(found);
+		REQUIRE(r.Valid());
+		reg.Get("inconnu", &found);
+		REQUIRE(!found);
+		reg.Clear();
+		REQUIRE(reg.Count() == 0);
+	}
+
+	void Test_Tutorial_FirstLaunchEightSteps()
+	{
+		auto def = LoadTutorialById("first_launch");
+		REQUIRE(def.has_value());
+		if (!def) return;
+		REQUIRE(def->steps.size() == 8);
+		REQUIRE(def->id == "first_launch");
+
+		TutorialSystem sys;
+		sys.LoadTutorial(*def);
+		OverlayGuidanceSystem ov;
+		sys.Start(ov);
+		REQUIRE(sys.State() == TutorialState::Running);
+		REQUIRE(ov.StepCount() == 8);
+
+		// Franchit les 8 étapes via leurs validatesOnAction (la dernière a un
+		// validatesOnAction vide → on avance via son targetWidget).
+		const char* validations[8] = {
+			"zone_preset_dialog.opened",
+			"zone_preset_dialog.selected.temperate_forest",
+			"zone.created",
+			"tool.cave.active",
+			"catalog.cave_small_01.selected",
+			"mesh_insert.cave.placed",
+			"panel.validation.opened",
+			"menubar.file.export", // step 8 : validatesOnAction vide → match sur targetWidget
+		};
+		for (int i = 0; i < 8; ++i)
+			REQUIRE(ov.NotifyAction(validations[i]));
+
+		REQUIRE(sys.State() == TutorialState::Completed);
+		REQUIRE(sys.GetFlag(kFirstLaunchFlag) == "completed");
+		REQUIRE(!ov.IsActiveSequence());
+	}
+
+	void Test_Tutorial_Skip()
+	{
+		TutorialSystem sys;
+		sys.LoadTutorial(BuildFirstLaunchTutorial());
+		sys.Skip();
+		REQUIRE(sys.State() == TutorialState::Skipped);
+		REQUIRE(sys.IsSkipped());
+		REQUIRE(sys.GetFlag(kFirstLaunchFlag) == "skipped");
+	}
+
+	void Test_Tutorial_PauseAndResume()
+	{
+		TutorialSystem sys;
+		sys.LoadTutorial(BuildFirstLaunchTutorial());
+		OverlayGuidanceSystem ov;
+		sys.Start(ov);
+
+		// Avance de 2 étapes puis met en pause.
+		REQUIRE(ov.NotifyAction("zone_preset_dialog.opened"));
+		REQUIRE(ov.NotifyAction("zone_preset_dialog.selected.temperate_forest"));
+		REQUIRE(ov.CurrentIndex() == 2);
+		sys.PauseFrom(ov);
+		REQUIRE(sys.State() == TutorialState::Paused);
+		REQUIRE(sys.SavedProgress() == 2);
+		REQUIRE(!ov.IsActiveSequence());
+
+		// Reprend : la sous-séquence repart à l'étape 2 (sur 8).
+		sys.Resume(ov);
+		REQUIRE(sys.State() == TutorialState::Running);
+		REQUIRE(ov.StepCount() == 6); // 8 - 2
+		// Première action attendue à la reprise = step3 (zone.created).
+		REQUIRE(ov.NotifyAction("zone.created"));
+		REQUIRE(ov.CurrentIndex() == 1);
+	}
+}
+
+int main()
+{
+	Test_Overlay_SequenceAdvanceAndComplete();
+	Test_Overlay_AbortDoesNotComplete();
+	Test_WidgetRegistry_RegisterAndGet();
+	Test_Tutorial_FirstLaunchEightSteps();
+	Test_Tutorial_Skip();
+	Test_Tutorial_PauseAndResume();
+
+	if (g_failed == 0)
+		std::printf("[tutorial_diagnostic_tests] all tests passed\n");
+	else
+		std::fprintf(stderr, "[tutorial_diagnostic_tests] %d check(s) failed\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/tutorial/Tutorial.h
+++ b/src/world_editor/tutorial/Tutorial.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// M100.49 — Structures de données d'un tutoriel interactif. Pures (aucune
+// dépendance ImGui/rendu) : le moteur OverlayGuidanceSystem les consomme et le
+// rendu visuel (surlignage, bulle) est une passe UI séparée (Windows).
+
+#include <string>
+#include <vector>
+
+namespace engine::editor::world::help
+{
+	/// Identifiant stable d'un widget cible de l'UI éditeur.
+	/// Convention : <panel>.<sous-élément>.<id> (ex. "menubar.file.new_from_preset").
+	using WidgetTargetId = std::string;
+
+	/// Une instruction overlay : quoi surligner + texte + condition de validation.
+	struct OverlayInstruction
+	{
+		WidgetTargetId targetWidget;       ///< Widget à surligner (vide = aucun).
+		std::string    titleFr;
+		std::string    bodyFr;
+		std::string    iconHint;           ///< "👆", "✓", "⚠"…
+		bool           requiresAction = false; ///< Si true, on attend l'action utilisateur.
+		WidgetTargetId validatesOnAction;  ///< Action attendue (ex. "zone_preset_dialog.opened").
+	};
+}
+
+namespace engine::editor::world::tutorial
+{
+	/// Une étape de tutoriel (= une instruction overlay + un id stable).
+	struct TutorialStep
+	{
+		std::string                                  id;
+		engine::editor::world::help::OverlayInstruction instruction;
+	};
+
+	/// Modal d'accueil / de fin.
+	struct TutorialModal
+	{
+		std::string              titleFr;
+		std::string              bodyFr;
+		std::vector<std::string> bulletsFr;
+	};
+
+	/// Un tutoriel complet (data-driven : code ou JSON).
+	struct Tutorial
+	{
+		std::string               id;
+		uint32_t                  version = 1u;
+		std::string               displayName;
+		uint32_t                  estimatedMinutes = 5u;
+		TutorialModal             introModal;
+		std::vector<TutorialStep> steps;
+		TutorialModal             outroModal;
+	};
+
+	/// Construit le tutoriel MVP "first_launch" (8 étapes) en code. Le fichier
+	/// `game/data/editor/tutorials/first_launch.json` documente le même contenu ;
+	/// le chargement JSON via TutorialIo est différé (2e passe).
+	Tutorial BuildFirstLaunchTutorial();
+}

--- a/src/world_editor/tutorial/Tutorial.h
+++ b/src/world_editor/tutorial/Tutorial.h
@@ -4,6 +4,7 @@
 // dépendance ImGui/rendu) : le moteur OverlayGuidanceSystem les consomme et le
 // rendu visuel (surlignage, bulle) est une passe UI séparée (Windows).
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/world_editor/tutorial/TutorialIo.cpp
+++ b/src/world_editor/tutorial/TutorialIo.cpp
@@ -1,0 +1,85 @@
+// M100.49 — Définition code-déf’inie du tutoriel "first_launch" (8 étapes) +
+// loader par id. Contenu identique à game/data/editor/tutorials/first_launch.json
+// (loader JSON différé).
+
+#include "src/world_editor/tutorial/TutorialIo.h"
+
+namespace engine::editor::world::tutorial
+{
+	namespace
+	{
+		using engine::editor::world::help::OverlayInstruction;
+
+		TutorialStep Step(const std::string& id, const std::string& title, const std::string& body,
+			const std::string& icon, const std::string& target, const std::string& validatesOn)
+		{
+			TutorialStep s;
+			s.id = id;
+			s.instruction.targetWidget = target;
+			s.instruction.titleFr = title;
+			s.instruction.bodyFr = body;
+			s.instruction.iconHint = icon;
+			s.instruction.requiresAction = !validatesOn.empty() || !target.empty();
+			s.instruction.validatesOnAction = validatesOn;
+			return s;
+		}
+	}
+
+	Tutorial BuildFirstLaunchTutorial()
+	{
+		Tutorial t;
+		t.id = "first_launch";
+		t.version = 1u;
+		t.displayName = "Premier lancement";
+		t.estimatedMinutes = 5u;
+
+		t.introModal.titleFr = "Bienvenue dans l'éditeur LCDLLN";
+		t.introModal.bodyFr = "Vous êtes ici pour la première fois. Voulez-vous suivre le "
+			"tutoriel de 5 minutes qui vous guidera dans la création de votre première zone ?";
+		t.introModal.bulletsFr = {
+			"Créer une zone à partir d'un template",
+			"Ajuster les paramètres de terrain",
+			"Valider et exporter votre zone"
+		};
+
+		t.steps = {
+			Step("step1_open_zone_preset", "Étape 1/8 — Ouvre le dialog",
+				"Clique sur Fichier → Nouvelle zone depuis preset.", "👆",
+				"menubar.file.new_from_preset", "zone_preset_dialog.opened"),
+			Step("step2_select_forest", "Étape 2/8 — Choisis un preset",
+				"Choisis la Forêt tempérée. C'est un bon point de départ.", "👆",
+				"zone_preset_dialog.thumbnail.temperate_forest", "zone_preset_dialog.selected.temperate_forest"),
+			Step("step3_create_zone", "Étape 3/8 — Crée la zone",
+				"Laisse les sliders par défaut et clique Créer la zone.", "👆",
+				"zone_preset_dialog.button.create", "zone.created"),
+			Step("step4_select_cave_tool", "Étape 4/8 — Outil Cave",
+				"Bravo ! Ajoutons un mesh insert : clique sur Cave dans la barre d'outils.", "👆",
+				"toolbar.button.cave", "tool.cave.active"),
+			Step("step5_select_cave_asset", "Étape 5/8 — Choisis un asset",
+				"Sélectionne cave_small_01 dans le catalogue.", "👆",
+				"panel.tool_properties.catalog_item.cave_small_01", "catalog.cave_small_01.selected"),
+			Step("step6_place_cave", "Étape 6/8 — Pose la grotte",
+				"Clique sur le terrain pour poser la grotte, dans une zone montagneuse.", "👆",
+				"viewport", "mesh_insert.cave.placed"),
+			Step("step7_validate", "Étape 7/8 — Valide ta zone",
+				"Clique sur le bouton 🛡 Valider dans la barre d'outils.", "🛡",
+				"toolbar.button.validate", "panel.validation.opened"),
+			Step("step8_export_info", "Étape 8/8 — Exporter",
+				"Si tu as 0 erreur (ou seulement des warnings), exporte via Fichier → Exporter. "
+				"Le tutoriel s'arrête ici, tu sais l'essentiel !", "✓",
+				"menubar.file.export", ""),
+		};
+
+		t.outroModal.titleFr = "Félicitations !";
+		t.outroModal.bodyFr = "Tu sais maintenant l'essentiel. F1 ouvre la doc complète, et "
+			"« Pourquoi ça ne marche pas ? » (menu Aide) t'aide à diagnostiquer les problèmes.";
+		return t;
+	}
+
+	std::optional<Tutorial> LoadTutorialById(const std::string& id)
+	{
+		if (id == "first_launch")
+			return BuildFirstLaunchTutorial();
+		return std::nullopt;
+	}
+}

--- a/src/world_editor/tutorial/TutorialIo.h
+++ b/src/world_editor/tutorial/TutorialIo.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// M100.49 — TutorialIo : source des définitions de tutoriel. Le MVP fournit le
+// tutoriel "first_launch" défini EN CODE (BuildFirstLaunchTutorial, déclaré dans
+// Tutorial.h). Le chargement depuis `game/data/editor/tutorials/*.json` est
+// différé (2e passe) ; le fichier JSON committé documente le contenu attendu.
+//
+// Ce header expose un helper de chargement par id qui, pour le MVP, route vers
+// le builder code-défini.
+
+#include <optional>
+#include <string>
+
+#include "src/world_editor/tutorial/Tutorial.h"
+
+namespace engine::editor::world::tutorial
+{
+	/// Charge un tutoriel par id. MVP : seul "first_launch" est connu (code).
+	/// Retourne nullopt si l'id est inconnu.
+	std::optional<Tutorial> LoadTutorialById(const std::string& id);
+}

--- a/src/world_editor/tutorial/TutorialSystem.cpp
+++ b/src/world_editor/tutorial/TutorialSystem.cpp
@@ -1,0 +1,56 @@
+// M100.49 — Implémentation TutorialSystem.
+
+#include "src/world_editor/tutorial/TutorialSystem.h"
+
+namespace engine::editor::world::tutorial
+{
+	using engine::editor::world::help::OverlayGuidanceSystem;
+	using engine::editor::world::help::OverlayInstruction;
+
+	void TutorialSystem::StartFrom(OverlayGuidanceSystem& overlay, size_t fromStep)
+	{
+		std::vector<OverlayInstruction> instructions;
+		instructions.reserve(m_tutorial.steps.size());
+		for (size_t i = fromStep; i < m_tutorial.steps.size(); ++i)
+			instructions.push_back(m_tutorial.steps[i].instruction);
+
+		m_state = TutorialState::Running;
+		overlay.StartSequence(std::move(instructions), [this]() { OnSequenceComplete(); });
+	}
+
+	void TutorialSystem::Start(OverlayGuidanceSystem& overlay)
+	{
+		m_savedProgress = 0;
+		StartFrom(overlay, 0);
+	}
+
+	void TutorialSystem::Resume(OverlayGuidanceSystem& overlay)
+	{
+		const size_t from = m_savedProgress < m_tutorial.steps.size() ? m_savedProgress : 0;
+		StartFrom(overlay, from);
+	}
+
+	void TutorialSystem::PauseFrom(OverlayGuidanceSystem& overlay)
+	{
+		// L'index overlay est relatif à la sous-séquence démarrée ; on l'ajoute à
+		// la progression de départ pour retrouver l'index absolu d'étape.
+		m_savedProgress += overlay.CurrentIndex();
+		if (m_savedProgress > m_tutorial.steps.size())
+			m_savedProgress = m_tutorial.steps.size();
+		overlay.AbortSequence();
+		m_state = TutorialState::Paused;
+	}
+
+	void TutorialSystem::Skip()
+	{
+		m_state = TutorialState::Skipped;
+		SetFlag(kFirstLaunchFlag, "skipped");
+	}
+
+	void TutorialSystem::OnSequenceComplete()
+	{
+		m_state = TutorialState::Completed;
+		m_savedProgress = m_tutorial.steps.size();
+		SetFlag(kFirstLaunchFlag, "completed");
+	}
+}

--- a/src/world_editor/tutorial/TutorialSystem.h
+++ b/src/world_editor/tutorial/TutorialSystem.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// M100.49 — TutorialSystem : pilote un tutoriel via l'OverlayGuidanceSystem.
+// Logique pure (état + flags en mémoire) ; testable headless en pilotant
+// l'overlay par NotifyAction. La persistance des flags dans UserPrefs (M100.45)
+// est différée (2e passe) — le système expose une table de flags en mémoire.
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "src/world_editor/help/OverlayGuidanceSystem.h"
+#include "src/world_editor/tutorial/Tutorial.h"
+
+namespace engine::editor::world::tutorial
+{
+	/// État courant du tutoriel.
+	enum class TutorialState
+	{
+		NotStarted,
+		Running,
+		Paused,    ///< Quitté pour l'instant ; reprenable.
+		Skipped,   ///< Passé explicitement ; ne se relance pas auto.
+		Completed, ///< Terminé jusqu'au bout.
+	};
+
+	/// Clé de flag standard pour le tutoriel de premier lancement.
+	inline constexpr const char* kFirstLaunchFlag = "first_launch_tutorial_completed";
+
+	class TutorialSystem
+	{
+	public:
+		/// Charge la définition de tutoriel active (copie).
+		void LoadTutorial(Tutorial tutorial) { m_tutorial = std::move(tutorial); }
+		const Tutorial& Def() const { return m_tutorial; }
+
+		/// Démarre le tutoriel depuis l'étape 0 : construit les instructions des
+		/// étapes et lance la séquence sur `overlay`. État → Running.
+		void Start(engine::editor::world::help::OverlayGuidanceSystem& overlay);
+
+		/// Reprend depuis l'étape sauvegardée (SavedProgress). État → Running.
+		void Resume(engine::editor::world::help::OverlayGuidanceSystem& overlay);
+
+		/// Quitte pour l'instant : mémorise l'index courant de `overlay`, abandonne
+		/// la séquence, état → Paused.
+		void PauseFrom(engine::editor::world::help::OverlayGuidanceSystem& overlay);
+
+		/// Passe le tutoriel : état → Skipped, flag = "skipped".
+		void Skip();
+
+		TutorialState State() const { return m_state; }
+		size_t SavedProgress() const { return m_savedProgress; }
+		bool IsCompleted() const { return m_state == TutorialState::Completed; }
+		bool IsSkipped() const { return m_state == TutorialState::Skipped; }
+
+		/// Flags de complétion (clé → valeur). Persistance disque différée.
+		void SetFlag(const std::string& key, const std::string& value) { m_flags[key] = value; }
+		std::string GetFlag(const std::string& key) const
+		{
+			auto it = m_flags.find(key);
+			return it == m_flags.end() ? std::string() : it->second;
+		}
+
+	private:
+		/// Démarre la séquence overlay à partir de `fromStep` (interne).
+		void StartFrom(engine::editor::world::help::OverlayGuidanceSystem& overlay, size_t fromStep);
+		/// Callback de complétion de la séquence : état → Completed + flag.
+		void OnSequenceComplete();
+
+		Tutorial      m_tutorial;
+		TutorialState m_state = TutorialState::NotStarted;
+		size_t        m_savedProgress = 0;
+		std::unordered_map<std::string, std::string> m_flags;
+	};
+}


### PR DESCRIPTION
## M100.49 (partie 1) — Tutoriel interactif & Overlay guidance

Première partie du système d'aide interactif (Phase 12 Accessibilité). **Cœur indépendant de M100.48** — le système de diagnostic (qui réutilise le `ValidationContext` de M100.48) suivra une fois #817 mergé.

### Cœur testable (engine_core — CI Linux)
- `help/OverlayGuidanceSystem.{h,cpp}` — moteur de **séquence pur** : `StartSequence` / `AdvanceStep` / `NotifyAction(widgetId)` / `AbortSequence` / `IsActiveSequence` / `CurrentInstruction`. Instanciable (pas de singleton global). Rendu ImGui (voile, rectangle pulsant, bulle) = passe UI séparée (2e passe Windows).
- `help/WidgetTargetRegistry.h` — `id widget → rectangle écran` (struct simple, pas `ImVec2`, header-only).
- `tutorial/Tutorial.h` — structs data-driven (`TutorialStep`, `OverlayInstruction`, `TutorialModal`).
- `tutorial/TutorialSystem.{h,cpp}` — `Start` / `Resume` / `PauseFrom` / `Skip` + état (`NotStarted/Running/Paused/Skipped/Completed`) + flags de complétion (in-memory).
- `tutorial/TutorialIo.{h,cpp}` — tutoriel **"first_launch" (8 étapes) défini en code** ; le JSON committé documente le format (loader JSON différé — pas de parseur JSON partagé dans le repo).
- `tutorial_diagnostic_tests` — **6 cas** : séquence+complétion, abort, registre widgets, 8 étapes first_launch, skip, pause/resume.

### Différé (2e passe — documenté)
- **Système de diagnostic** (`IDiagnosticRule` + 10 règles + `DiagnosticContext`) : dépend du `ValidationContext` de **M100.48 (#817)** → livré après merge de #817.
- **UI ImGui** : modal accueil/outro, bulle d'étape, panel diagnostic, surlignage, modal one-click, branchement `WorldEditorShell`/`MenuBar`/`StatusBar`.
- Chargement JSON des tutoriels + persistance des flags dans `UserPrefs`.

### Anti-conflit
Ancrages CMake (sources + cible de test) **distincts** de #816/#817 pour éviter tout conflit textuel.

### Déploiement
> ✅ **client/éditeur uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)