### PR TITLE
feat(world_editor): M100.49 (partie 2) — Système de diagnostic workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,12 @@ add_library(engine_core
   src/world_editor/help/OverlayGuidanceSystem.cpp
   src/world_editor/tutorial/TutorialSystem.cpp
   src/world_editor/tutorial/TutorialIo.cpp
+  # M100.49 partie 2 — Système de diagnostic « Pourquoi ça ne marche pas ? »
+  # (registre + système + 10 règles workflow). S'appuie sur le ValidationContext
+  # de M100.48. Cœur pur ; UI panel/one-click = passe séparée.
+  src/world_editor/diagnostic/DiagnosticRuleRegistry.cpp
+  src/world_editor/diagnostic/DiagnosticSystem.cpp
+  src/world_editor/diagnostic/rules/WorkflowRules.cpp
   # M100.46 — Zone Presets Library. Incrément 1 : socle data (format
   # JSON + parsing + registry + validation). Incrément 2a : couche de
   # paramètres typés (OperationParams) + customisation (relief/eau/
@@ -1012,6 +1018,12 @@ add_test(NAME wind_tests COMMAND wind_tests)
 add_executable(tutorial_diagnostic_tests src/world_editor/tests/TutorialDiagnosticTests.cpp)
 target_link_libraries(tutorial_diagnostic_tests PRIVATE engine_core)
 add_test(NAME tutorial_diagnostic_tests COMMAND tutorial_diagnostic_tests)
+
+# M100.49 partie 2 — Tests du système de diagnostic (registre + 10 règles +
+# tri par importance). Pure logique dans engine_core.
+add_executable(diagnostic_tests src/world_editor/tests/DiagnosticTests.cpp)
+target_link_libraries(diagnostic_tests PRIVATE engine_core)
+add_test(NAME diagnostic_tests COMMAND diagnostic_tests)
 
 # M100.21 — Tests collecteur d'influences (portee, troncature, flexion).
 add_executable(entity_influence_tests src/client/world/foliage/tests/EntityInfluenceTests.cpp)

--- a/src/world_editor/diagnostic/DiagnosticRuleRegistry.cpp
+++ b/src/world_editor/diagnostic/DiagnosticRuleRegistry.cpp
@@ -1,0 +1,29 @@
+// M100.49 partie 2 — Implémentation DiagnosticRuleRegistry + enregistrement MVP.
+
+#include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
+
+#include "src/world_editor/diagnostic/rules/WorkflowRules.h"
+
+namespace engine::editor::world::diagnostic
+{
+	void DiagnosticRuleRegistry::RegisterRule(std::unique_ptr<IDiagnosticRule> rule)
+	{
+		if (!rule) return;
+		m_view.push_back(rule.get());
+		m_rules.push_back(std::move(rule));
+	}
+
+	void RegisterMvpDiagnosticRules(DiagnosticRuleRegistry& registry)
+	{
+		registry.RegisterRule(std::make_unique<EmptyZoneActiveToolRule>());
+		registry.RegisterRule(std::make_unique<NoActiveToolRule>());
+		registry.RegisterRule(std::make_unique<ExportAttemptedWithErrorsRule>());
+		registry.RegisterRule(std::make_unique<UnsavedChangesLongTimeRule>());
+		registry.RegisterRule(std::make_unique<RiversAfterErosionRule>());
+		registry.RegisterRule(std::make_unique<ToolSelectedButNoActionRule>());
+		registry.RegisterRule(std::make_unique<PresetJustAppliedNoSaveRule>());
+		registry.RegisterRule(std::make_unique<CavePlacedNoCamouflageRule>());
+		registry.RegisterRule(std::make_unique<SimpleModeAdvancedAttemptedRule>());
+		registry.RegisterRule(std::make_unique<NoSeaLevelSetRule>());
+	}
+}

--- a/src/world_editor/diagnostic/DiagnosticRuleRegistry.h
+++ b/src/world_editor/diagnostic/DiagnosticRuleRegistry.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// M100.49 partie 2 — Registre des règles de diagnostic (instanciable, pas un
+// singleton global = testable). RegisterMvpDiagnosticRules enregistre les
+// règles workflow MVP.
+
+#include <memory>
+#include <vector>
+
+#include "src/world_editor/diagnostic/IDiagnosticRule.h"
+
+namespace engine::editor::world::diagnostic
+{
+	class DiagnosticRuleRegistry
+	{
+	public:
+		void RegisterRule(std::unique_ptr<IDiagnosticRule> rule);
+		const std::vector<IDiagnosticRule*>& GetAllRules() const { return m_view; }
+		size_t Count() const { return m_rules.size(); }
+
+	private:
+		std::vector<std::unique_ptr<IDiagnosticRule>> m_rules;
+		std::vector<IDiagnosticRule*>                 m_view;
+	};
+
+	/// Enregistre les règles workflow MVP dans `registry`.
+	void RegisterMvpDiagnosticRules(DiagnosticRuleRegistry& registry);
+}

--- a/src/world_editor/diagnostic/DiagnosticSystem.cpp
+++ b/src/world_editor/diagnostic/DiagnosticSystem.cpp
@@ -1,0 +1,34 @@
+// M100.49 partie 2 — Implémentation DiagnosticSystem.
+
+#include "src/world_editor/diagnostic/DiagnosticSystem.h"
+
+#include <algorithm>
+
+namespace engine::editor::world::diagnostic
+{
+	DiagnosticSystem::Report DiagnosticSystem::Analyze(const DiagnosticContext& ctx) const
+	{
+		Report report;
+		for (IDiagnosticRule* rule : m_registry.GetAllRules())
+		{
+			if (rule) rule->Run(ctx, report.suggestions);
+		}
+
+		// Tri stable par importance décroissante (Critical d'abord).
+		std::stable_sort(report.suggestions.begin(), report.suggestions.end(),
+			[](const DiagnosticSuggestion& a, const DiagnosticSuggestion& b) {
+				return static_cast<uint8_t>(a.importance) > static_cast<uint8_t>(b.importance);
+			});
+
+		for (const auto& s : report.suggestions)
+		{
+			switch (s.importance)
+			{
+			case SuggestionImportance::Critical: ++report.criticalCount; break;
+			case SuggestionImportance::Strong:   ++report.strongCount;   break;
+			case SuggestionImportance::Tip:      ++report.tipCount;      break;
+			}
+		}
+		return report;
+	}
+}

--- a/src/world_editor/diagnostic/DiagnosticSystem.h
+++ b/src/world_editor/diagnostic/DiagnosticSystem.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// M100.49 partie 2 — DiagnosticSystem : exécute les règles de diagnostic et
+// renvoie les suggestions triées par importance décroissante (Critical d'abord).
+// Lecture seule ; ne déclenche aucune action.
+
+#include <vector>
+
+#include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
+#include "src/world_editor/diagnostic/IDiagnosticRule.h"
+
+namespace engine::editor::world::diagnostic
+{
+	class DiagnosticSystem
+	{
+	public:
+		explicit DiagnosticSystem(const DiagnosticRuleRegistry& registry) : m_registry(registry) {}
+
+		struct Report
+		{
+			std::vector<DiagnosticSuggestion> suggestions; ///< Triées importance desc.
+			uint32_t criticalCount = 0;
+			uint32_t strongCount   = 0;
+			uint32_t tipCount      = 0;
+
+			/// True si aucune suggestion (« tu as l'air sur les bons rails ! »).
+			bool IsClean() const { return suggestions.empty(); }
+		};
+
+		/// Analyse l'état courant : exécute toutes les règles, trie, compte.
+		Report Analyze(const DiagnosticContext& ctx) const;
+
+	private:
+		const DiagnosticRuleRegistry& m_registry;
+	};
+}

--- a/src/world_editor/diagnostic/IDiagnosticRule.h
+++ b/src/world_editor/diagnostic/IDiagnosticRule.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// M100.49 partie 2 — Système de diagnostic « Pourquoi ça ne marche pas ? ».
+// Contrairement à la validation (M100.48, cohérence des DONNÉES), le diagnostic
+// analyse la cohérence d'USAGE / workflow et propose des suggestions
+// actionnables. Architecture jumelle de IValidationRule.
+//
+// Le diagnostic PROPOSE, ne décide pas : les suggestions portent un libellé
+// d'action « one-click » et un message de confirmation, mais n'EXÉCUTENT
+// jamais rien ici (le câblage de l'action effective + la modale de confirmation
+// sont une passe UI séparée). Le cœur (règles + système) est pur et testable.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "src/world_editor/validation/ValidationTypes.h"
+
+namespace engine::editor::world::diagnostic
+{
+	/// Importance d'une suggestion de diagnostic.
+	enum class SuggestionImportance : uint8_t
+	{
+		Tip      = 0, ///< Astuce / best-practice.
+		Strong   = 1, ///< Forte suspicion que c'est la cause.
+		Critical = 2, ///< Bloquant ou cause certaine.
+	};
+
+	/// Une suggestion émise par une règle de diagnostic.
+	struct DiagnosticSuggestion
+	{
+		std::string          ruleId;
+		std::string          titleFr;
+		std::string          explanationFr;
+		SuggestionImportance importance = SuggestionImportance::Tip;
+		std::string          docSectionId;          ///< Lien doc M100.47 (optionnel).
+		/// Action « one-click » PROPOSÉE (libellé + confirmation). Non exécutée
+		/// ici : l'UI branche l'action réelle derrière une modale de confirmation.
+		std::string          oneClickActionLabelFr; ///< Vide = pas d'action proposée.
+		std::string          confirmationMessageFr;
+	};
+
+	/// Contexte d'analyse : état d'usage courant de l'éditeur (champs simples,
+	/// injectés par le shell) + accès optionnel aux données validées de M100.48.
+	struct DiagnosticContext
+	{
+		// --- État outil / dialogues ---
+		bool        hasActiveTool         = false;
+		std::string activeToolId;                 ///< Ex. "cave", "coastline", "hydraulic".
+		bool        hasOpenedDialog       = false;
+		double      secondsSinceToolSelected = 0.0;
+		uint32_t    commandsSinceToolSelected = 0;
+
+		// --- État zone / chunks ---
+		uint32_t    chunkCount            = 0;
+		bool        presetJustAppliedNotSaved = false;
+
+		// --- Sauvegarde ---
+		uint32_t    commandsSinceLastSave = 0;
+
+		// --- Export / validation (peuplé depuis un ZoneValidator::Report) ---
+		bool        hasUserAttemptedExport = false;
+		uint32_t    validationErrorCount   = 0;
+
+		// --- Pièges d'usage spécifiques ---
+		bool        erosionAppliedAfterRivers = false; ///< Hydraulic après RiverNetwork.
+		bool        cavePlacedWithoutCamouflage = false;
+		bool        coastlineToolActive   = false;
+		bool        seaLevelSet           = false;
+		bool        simpleModeActive      = false;
+		bool        attemptedAdvancedFeature = false;
+
+		// --- Historique récent (10 dernières commandes) ---
+		std::vector<std::string> recentCommandHistory;
+
+		/// Accès optionnel aux données de zone validées (M100.48). Peut être null ;
+		/// les règles MVP s'appuient sur les champs simples ci-dessus.
+		const engine::editor::world::validation::ValidationContext* validation = nullptr;
+	};
+
+	/// Règle de diagnostic : analyse le contexte et ajoute des suggestions.
+	class IDiagnosticRule
+	{
+	public:
+		virtual ~IDiagnosticRule() = default;
+		virtual const char* GetRuleId() const = 0;
+		virtual void Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const = 0;
+	};
+}

--- a/src/world_editor/diagnostic/rules/WorkflowRules.cpp
+++ b/src/world_editor/diagnostic/rules/WorkflowRules.cpp
@@ -1,0 +1,142 @@
+// M100.49 partie 2 — Implémentation des 10 règles de diagnostic workflow.
+// Les libellés « one-click » sont PROPOSÉS (texte) ; l'action n'est pas exécutée
+// ici (câblage UI + confirmation = passe séparée).
+
+#include "src/world_editor/diagnostic/rules/WorkflowRules.h"
+
+namespace engine::editor::world::diagnostic
+{
+	namespace
+	{
+		DiagnosticSuggestion Make(const char* id, SuggestionImportance imp,
+			const std::string& title, const std::string& explanation,
+			const std::string& actionLabel = "", const std::string& confirm = "")
+		{
+			DiagnosticSuggestion s;
+			s.ruleId = id;
+			s.importance = imp;
+			s.titleFr = title;
+			s.explanationFr = explanation;
+			s.oneClickActionLabelFr = actionLabel;
+			s.confirmationMessageFr = confirm;
+			return s;
+		}
+	}
+
+	void EmptyZoneActiveToolRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.hasActiveTool && ctx.chunkCount == 0)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Strong,
+				"Outil actif mais aucune zone",
+				"Tu as un outil sélectionné mais 0 chunk chargé. Crée d'abord une zone "
+				"(Fichier → Nouvelle zone depuis preset).",
+				"Ouvrir le dialog Zone Preset"));
+		}
+	}
+
+	void NoActiveToolRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (!ctx.hasActiveTool)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Aucun outil sélectionné",
+				"Aucun outil n'est actif. Clique sur un outil dans la barre d'outils pour commencer.",
+				"Mettre la toolbar en évidence"));
+		}
+	}
+
+	void ExportAttemptedWithErrorsRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.hasUserAttemptedExport && ctx.validationErrorCount > 0)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Critical,
+				"Export bloqué par des erreurs",
+				"Tu as essayé d'exporter mais ta zone a " + std::to_string(ctx.validationErrorCount) +
+				" erreur(s). L'export est bloqué tant qu'elles ne sont pas corrigées.",
+				"Ouvrir le panel Validation"));
+		}
+	}
+
+	void UnsavedChangesLongTimeRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.commandsSinceLastSave > 30u)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Modifications non sauvegardées",
+				"Tu as fait " + std::to_string(ctx.commandsSinceLastSave) +
+				" modifications sans sauvegarder.",
+				"Sauvegarder maintenant"));
+		}
+	}
+
+	void RiversAfterErosionRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.erosionAppliedAfterRivers)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Strong,
+				"Tes rivières flottent au-dessus du terrain",
+				"Tu as appliqué une érosion hydraulique APRÈS avoir généré ton réseau de "
+				"rivières. Les rivières suivent l'ancienne topographie. Re-lance le watershed.",
+				"Re-lancer le watershed",
+				"Re-lancer le watershed ? Cela va re-générer le réseau hydrographique, "
+				"remplacer les rivières actuelles, et ajouter une commande annulable."));
+		}
+	}
+
+	void ToolSelectedButNoActionRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.hasActiveTool && ctx.secondsSinceToolSelected > 120.0 && ctx.commandsSinceToolSelected == 0u)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Outil sélectionné mais inutilisé",
+				"L'outil « " + ctx.activeToolId + " » est actif depuis plus de 2 minutes sans "
+				"aucune action. Consulte la doc de l'outil (F1) si tu es bloqué."));
+		}
+	}
+
+	void PresetJustAppliedNoSaveRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.presetJustAppliedNotSaved)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Preset appliqué non sauvegardé",
+				"Tu viens d'appliquer un zone preset mais tu ne l'as pas encore sauvegardé.",
+				"Sauvegarder"));
+		}
+	}
+
+	void CavePlacedNoCamouflageRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.cavePlacedWithoutCamouflage)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Grotte sans camouflage de jointure",
+				"Une grotte a été posée sans patch splat de camouflage : la jointure mesh ↔ "
+				"terrain risque d'être visible.",
+				"Ré-éditer pour ajouter le camouflage"));
+		}
+	}
+
+	void SimpleModeAdvancedAttemptedRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.simpleModeActive && ctx.attemptedAdvancedFeature)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Fonctionnalité avancée en mode Simple",
+				"Tu essaies d'accéder à un paramètre avancé alors que le mode Simple est actif.",
+				"Basculer en mode Advanced"));
+		}
+	}
+
+	void NoSeaLevelSetRule::Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const
+	{
+		if (ctx.coastlineToolActive && !ctx.seaLevelSet)
+		{
+			out.push_back(Make(GetRuleId(), SuggestionImportance::Tip,
+				"Aucun niveau de mer défini",
+				"L'outil Coastline est actif mais aucun sea level n'est défini. La côte n'aura "
+				"pas de référence d'altitude cohérente."));
+		}
+	}
+}

--- a/src/world_editor/diagnostic/rules/WorkflowRules.h
+++ b/src/world_editor/diagnostic/rules/WorkflowRules.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// M100.49 partie 2 — Règles de diagnostic workflow (catalogue MVP, 10 règles).
+// Consolidées dans un seul fichier (au lieu de 10) : chaque règle reste une
+// classe distincte enregistrée individuellement, mais on évite l'éparpillement.
+
+#include "src/world_editor/diagnostic/IDiagnosticRule.h"
+
+namespace engine::editor::world::diagnostic
+{
+	/// Macro interne : déclare une règle simple (id + Run).
+#define LCDLLN_DIAG_RULE(ClassName, RuleIdStr)                                  \
+	class ClassName : public IDiagnosticRule                                    \
+	{                                                                           \
+	public:                                                                     \
+		const char* GetRuleId() const override { return RuleIdStr; }            \
+		void Run(const DiagnosticContext& ctx, std::vector<DiagnosticSuggestion>& out) const override; \
+	}
+
+	LCDLLN_DIAG_RULE(EmptyZoneActiveToolRule,            "workflow.empty_zone_active_tool");
+	LCDLLN_DIAG_RULE(NoActiveToolRule,                   "workflow.no_active_tool");
+	LCDLLN_DIAG_RULE(ExportAttemptedWithErrorsRule,      "workflow.export_attempted_with_errors");
+	LCDLLN_DIAG_RULE(UnsavedChangesLongTimeRule,         "workflow.unsaved_changes_long_time");
+	LCDLLN_DIAG_RULE(RiversAfterErosionRule,             "workflow.rivers_after_erosion");
+	LCDLLN_DIAG_RULE(ToolSelectedButNoActionRule,        "workflow.tool_selected_but_no_action");
+	LCDLLN_DIAG_RULE(PresetJustAppliedNoSaveRule,        "workflow.preset_just_applied_no_save");
+	LCDLLN_DIAG_RULE(CavePlacedNoCamouflageRule,         "workflow.cave_placed_no_camouflage");
+	LCDLLN_DIAG_RULE(SimpleModeAdvancedAttemptedRule,    "workflow.simple_mode_advanced_features_attempted");
+	LCDLLN_DIAG_RULE(NoSeaLevelSetRule,                  "workflow.no_sea_level_set");
+
+#undef LCDLLN_DIAG_RULE
+}

--- a/src/world_editor/tests/DiagnosticTests.cpp
+++ b/src/world_editor/tests/DiagnosticTests.cpp
@@ -1,0 +1,160 @@
+// M100.49 partie 2 — Tests du système de diagnostic : registre, chaque règle
+// workflow MVP, tri par importance, compteurs, cas « propre ». Headless,
+// engine_core.
+
+#include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
+#include "src/world_editor/diagnostic/DiagnosticSystem.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace engine::editor::world::diagnostic;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool Has(const DiagnosticSystem::Report& r, const std::string& ruleId)
+	{
+		for (const auto& s : r.suggestions) if (s.ruleId == ruleId) return true;
+		return false;
+	}
+
+	const DiagnosticSuggestion* Find(const DiagnosticSystem::Report& r, const std::string& ruleId)
+	{
+		for (const auto& s : r.suggestions) if (s.ruleId == ruleId) return &s;
+		return nullptr;
+	}
+
+	void Test_Registry_RegistersTenRules()
+	{
+		DiagnosticRuleRegistry reg;
+		RegisterMvpDiagnosticRules(reg);
+		REQUIRE(reg.Count() == 10);
+	}
+
+	void Test_EmptyZoneActiveTool()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx;
+		ctx.hasActiveTool = true;
+		ctx.chunkCount = 0;
+		auto r = sys.Analyze(ctx);
+		REQUIRE(Has(r, "workflow.empty_zone_active_tool"));
+		const auto* s = Find(r, "workflow.empty_zone_active_tool");
+		REQUIRE(s && s->importance == SuggestionImportance::Strong);
+		REQUIRE(s && !s->oneClickActionLabelFr.empty());
+	}
+
+	void Test_NoActiveTool()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx; // hasActiveTool=false par défaut
+		ctx.chunkCount = 5;    // évite empty_zone (qui exige hasActiveTool de toute façon)
+		auto r = sys.Analyze(ctx);
+		REQUIRE(Has(r, "workflow.no_active_tool"));
+	}
+
+	void Test_ExportWithErrors_Critical()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx;
+		ctx.hasActiveTool = true; ctx.chunkCount = 3;
+		ctx.hasUserAttemptedExport = true;
+		ctx.validationErrorCount = 2;
+		auto r = sys.Analyze(ctx);
+		const auto* s = Find(r, "workflow.export_attempted_with_errors");
+		REQUIRE(s && s->importance == SuggestionImportance::Critical);
+		// Critical doit être trié en tête.
+		REQUIRE(!r.suggestions.empty());
+		REQUIRE(r.suggestions.front().importance == SuggestionImportance::Critical);
+		REQUIRE(r.criticalCount >= 1);
+	}
+
+	void Test_UnsavedChanges()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx;
+		ctx.hasActiveTool = true; ctx.chunkCount = 1;
+		ctx.commandsSinceLastSave = 47;
+		auto r = sys.Analyze(ctx);
+		REQUIRE(Has(r, "workflow.unsaved_changes_long_time"));
+		// Seuil : 30 exact ne déclenche pas (> 30).
+		DiagnosticContext ctx2; ctx2.hasActiveTool = true; ctx2.chunkCount = 1; ctx2.commandsSinceLastSave = 30;
+		REQUIRE(!Has(sys.Analyze(ctx2), "workflow.unsaved_changes_long_time"));
+	}
+
+	void Test_RiversAfterErosion_Strong()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx;
+		ctx.hasActiveTool = true; ctx.chunkCount = 4;
+		ctx.erosionAppliedAfterRivers = true;
+		auto r = sys.Analyze(ctx);
+		const auto* s = Find(r, "workflow.rivers_after_erosion");
+		REQUIRE(s && s->importance == SuggestionImportance::Strong);
+		REQUIRE(s && !s->confirmationMessageFr.empty()); // action one-click avec confirmation
+	}
+
+	void Test_RemainingTipRules()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+
+		{ DiagnosticContext c; c.hasActiveTool = true; c.chunkCount = 1; c.secondsSinceToolSelected = 200.0; c.commandsSinceToolSelected = 0; c.activeToolId = "cave";
+		  REQUIRE(Has(sys.Analyze(c), "workflow.tool_selected_but_no_action")); }
+		{ DiagnosticContext c; c.hasActiveTool = true; c.chunkCount = 1; c.presetJustAppliedNotSaved = true;
+		  REQUIRE(Has(sys.Analyze(c), "workflow.preset_just_applied_no_save")); }
+		{ DiagnosticContext c; c.hasActiveTool = true; c.chunkCount = 1; c.cavePlacedWithoutCamouflage = true;
+		  REQUIRE(Has(sys.Analyze(c), "workflow.cave_placed_no_camouflage")); }
+		{ DiagnosticContext c; c.hasActiveTool = true; c.chunkCount = 1; c.simpleModeActive = true; c.attemptedAdvancedFeature = true;
+		  REQUIRE(Has(sys.Analyze(c), "workflow.simple_mode_advanced_features_attempted")); }
+		{ DiagnosticContext c; c.hasActiveTool = true; c.chunkCount = 1; c.coastlineToolActive = true; c.seaLevelSet = false;
+		  REQUIRE(Has(sys.Analyze(c), "workflow.no_sea_level_set")); }
+	}
+
+	void Test_CleanState_NoSuggestions()
+	{
+		DiagnosticRuleRegistry reg; RegisterMvpDiagnosticRules(reg);
+		DiagnosticSystem sys(reg);
+		DiagnosticContext ctx;
+		// Tout va bien : outil actif, zone non vide, rien d'anormal.
+		ctx.hasActiveTool = true;
+		ctx.chunkCount = 4;
+		ctx.commandsSinceLastSave = 3;
+		ctx.seaLevelSet = true;
+		auto r = sys.Analyze(ctx);
+		REQUIRE(r.IsClean());
+		REQUIRE(r.criticalCount == 0 && r.strongCount == 0 && r.tipCount == 0);
+	}
+}
+
+int main()
+{
+	Test_Registry_RegistersTenRules();
+	Test_EmptyZoneActiveTool();
+	Test_NoActiveTool();
+	Test_ExportWithErrors_Critical();
+	Test_UnsavedChanges();
+	Test_RiversAfterErosion_Strong();
+	Test_RemainingTipRules();
+	Test_CleanState_NoSuggestions();
+
+	if (g_failed == 0)
+		std::printf("[diagnostic_tests] all tests passed\n");
+	else
+		std::fprintf(stderr, "[diagnostic_tests] %d check(s) failed\n", g_failed);
+	return g_failed;
+}


### PR DESCRIPTION
## M100.49 (partie 2) — Diagnostic « Pourquoi ça ne marche pas ? »

Deuxième partie du système d'aide (Phase 12). Le diagnostic analyse la cohérence **d'usage / workflow** et propose des suggestions actionnables — distinct de la validation M100.48 (cohérence des **données**). Débloqué par le merge de M100.48.

### Cœur testable (engine_core — CI Linux)
- `IDiagnosticRule` + `DiagnosticContext` (champs workflow + pointeur optionnel vers le `ValidationContext` de M100.48) + `DiagnosticSuggestion` (importance `Tip`/`Strong`/`Critical` + action one-click **proposée**, jamais exécutée ici).
- `DiagnosticRuleRegistry` (instanciable) + `RegisterMvpDiagnosticRules`.
- `DiagnosticSystem::Analyze` — exécute les règles, **trie par importance décroissante** (Critical en tête), compte ; `IsClean()` si aucune suggestion.
- **10 règles workflow MVP** (empty_zone_active_tool, no_active_tool, export_attempted_with_errors, unsaved_changes_long_time, rivers_after_erosion, tool_selected_but_no_action, preset_just_applied_no_save, cave_placed_no_camouflage, simple_mode_advanced_features_attempted, no_sea_level_set).
- `diagnostic_tests` — **8 cas**.

Le diagnostic **propose, ne décide pas** : aucune action exécutée dans le cœur (câblage UI + confirmation = passe séparée).

### Déploiement
> ✅ **client/éditeur uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)