### PR TITLE
feat(world_editor): M100.50 — Quick Start Wizard (cœur pur)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,13 @@ add_library(engine_core
   src/world_editor/diagnostic/DiagnosticRuleRegistry.cpp
   src/world_editor/diagnostic/DiagnosticSystem.cpp
   src/world_editor/diagnostic/rules/WorkflowRules.cpp
+  # M100.50 — Quick Start Wizard (cœur pur : FSM 5 étapes + résolution choix →
+  # ZonePreset M100.46 + conditions/substitution + auto-gen déterministe).
+  # UI (cartes, aperçu 3D) + exécution = passe séparée.
+  src/world_editor/wizard/QuickStartWizard.cpp
+  src/world_editor/wizard/ConditionEvaluator.cpp
+  src/world_editor/wizard/AutoGenerators.cpp
+  src/world_editor/wizard/WizardTemplateResolver.cpp
   # M100.46 — Zone Presets Library. Incrément 1 : socle data (format
   # JSON + parsing + registry + validation). Incrément 2a : couche de
   # paramètres typés (OperationParams) + customisation (relief/eau/
@@ -1039,6 +1046,12 @@ add_test(NAME thermal_tests COMMAND thermal_tests)
 add_executable(zones_tests src/client/world/zones/tests/ZonesTests.cpp)
 target_link_libraries(zones_tests PRIVATE engine_core)
 add_test(NAME zones_tests COMMAND zones_tests)
+
+# M100.50 — Tests Quick Start Wizard (FSM + resolver 192 combinaisons + conditions
+# + substitution + determinisme auto-gen). Pure logique dans engine_core.
+add_executable(quick_start_wizard_tests src/world_editor/tests/QuickStartWizardTests.cpp)
+target_link_libraries(quick_start_wizard_tests PRIVATE engine_core)
+add_test(NAME quick_start_wizard_tests COMMAND quick_start_wizard_tests)
 
 # M100.29 — Tests spline (Catmull-Rom, ground-fit, splat sum=255, round-trip).
 # Nom prefixe m100_ : un target `spline_tests` existe deja (MoveSpline serveur).

--- a/src/world_editor/tests/QuickStartWizardTests.cpp
+++ b/src/world_editor/tests/QuickStartWizardTests.cpp
@@ -1,0 +1,177 @@
+// M100.50 — Tests Quick Start Wizard : machine d'état, résolution template →
+// ZonePreset (toutes combinaisons valides), conditions "if", substitution de
+// variables, déterminisme des auto-générateurs. Headless, engine_core.
+
+#include "src/world_editor/wizard/AutoGenerators.h"
+#include "src/world_editor/wizard/ConditionEvaluator.h"
+#include "src/world_editor/wizard/QuickStartWizard.h"
+#include "src/world_editor/wizard/WizardTemplateResolver.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace engine::editor::world::wizard;
+
+namespace
+{
+	int g_failed = 0;
+
+#define REQUIRE(cond) do { \
+	if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+		++g_failed; \
+	} \
+} while (0)
+
+	bool HasOpType(const engine::editor::world::zone_presets::ZonePreset& p, const std::string& type)
+	{
+		for (const auto& op : p.operations) if (op.type == type) return true;
+		return false;
+	}
+
+	void Test_Wizard_StateMachine()
+	{
+		QuickStartWizard w;
+		REQUIRE(w.CurrentStep() == WizardStep::Climate);
+
+		// Choix invalide refusé.
+		REQUIRE(!w.SetChoiceForCurrentStep("banana"));
+		REQUIRE(w.SetChoiceForCurrentStep("arid"));
+		REQUIRE(w.Choices().climate == "arid");
+		REQUIRE(w.Next());
+		REQUIRE(w.CurrentStep() == WizardStep::Relief);
+
+		REQUIRE(w.SetChoiceForCurrentStep("mountains"));
+		REQUIRE(w.Next());
+		REQUIRE(w.SetChoiceForCurrentStep("dramatic")); // coast
+		REQUIRE(w.Next());
+		REQUIRE(w.SetChoiceForCurrentStep("dungeon"));   // poi
+		REQUIRE(w.Next());
+		REQUIRE(w.CurrentStep() == WizardStep::Preview);
+		REQUIRE(!w.Next()); // dernière étape
+		REQUIRE(w.IsReadyToGenerate());
+
+		// Prev fonctionne.
+		REQUIRE(w.Prev());
+		REQUIRE(w.CurrentStep() == WizardStep::Poi);
+		REQUIRE(!w.IsReadyToGenerate()); // plus à Preview
+
+		w.SetSeed(123u);
+		REQUIRE(w.Choices().seed == 123u);
+	}
+
+	void Test_Resolver_AllCombinations_ProduceValidPresets()
+	{
+		WizardTemplateResolver resolver;
+		const char* climates[] = { "temperate", "arid", "polar", "tropical" };
+		const char* reliefs[]  = { "plains", "hills", "mountains", "escarped" };
+		const char* coasts[]   = { "interior", "moderate", "dramatic" };
+		const char* pois[]     = { "none", "cave", "ruin", "dungeon" };
+		int count = 0, valid = 0;
+		for (const char* cl : climates)
+			for (const char* r : reliefs)
+				for (const char* co : coasts)
+					for (const char* po : pois)
+					{
+						WizardChoices ch; ch.climate = cl; ch.relief = r; ch.coast = co; ch.poi = po;
+						auto preset = resolver.Resolve(ch);
+						std::string err;
+						++count;
+						if (preset.Validate(err)) ++valid;
+						else std::fprintf(stderr, "  invalide %s/%s/%s/%s: %s\n", cl, r, co, po, err.c_str());
+					}
+		REQUIRE(count == 192);
+		REQUIRE(valid == 192);
+	}
+
+	void Test_Resolver_ConditionIf_SkipsOperation()
+	{
+		WizardTemplateResolver resolver;
+		// poi == none → pas de place_*. coast == interior → pas de coastline.
+		WizardChoices a; a.poi = "none"; a.coast = "interior";
+		auto pa = resolver.Resolve(a);
+		REQUIRE(!HasOpType(pa, "place_cave"));
+		REQUIRE(!HasOpType(pa, "place_dungeon"));
+		REQUIRE(!HasOpType(pa, "place_arch"));
+		REQUIRE(!HasOpType(pa, "coastline"));
+
+		// poi == cave → place_cave présent ; coast dramatic → coastline présent.
+		WizardChoices b; b.poi = "cave"; b.coast = "dramatic";
+		auto pb = resolver.Resolve(b);
+		REQUIRE(HasOpType(pb, "place_cave"));
+		REQUIRE(HasOpType(pb, "coastline"));
+	}
+
+	void Test_Resolver_VariableSubstitution_Works()
+	{
+		WizardTemplateResolver resolver;
+		WizardChoices ch; ch.climate = "temperate";
+		auto p = resolver.Resolve(ch);
+		// Au moins une opération doit contenir la valeur substituée, pas le
+		// placeholder.
+		bool foundSubstituted = false;
+		bool foundPlaceholder = false;
+		for (const auto& op : p.operations)
+		{
+			if (op.rawJson.find("temperate") != std::string::npos) foundSubstituted = true;
+			if (op.rawJson.find("{{climate}}") != std::string::npos) foundPlaceholder = true;
+		}
+		REQUIRE(foundSubstituted);
+		REQUIRE(!foundPlaceholder);
+	}
+
+	void Test_AutoGenerators_Deterministic_SameSeedSameOutput()
+	{
+		auto a = GenerateMountainPolyline("mountains", 42u);
+		auto b = GenerateMountainPolyline("mountains", 42u);
+		REQUIRE(a.size() == b.size());
+		REQUIRE(a.size() == 5); // mountains = 5 points
+		bool identical = a.size() == b.size();
+		for (size_t i = 0; i < a.size() && identical; ++i)
+			if (a[i].x != b[i].x || a[i].y != b[i].y || a[i].z != b[i].z) identical = false;
+		REQUIRE(identical);
+	}
+
+	void Test_AutoGenerators_DifferentSeeds_DifferentOutputs()
+	{
+		auto a = GenerateMountainPolyline("mountains", 42u);
+		auto b = GenerateMountainPolyline("mountains", 43u);
+		bool different = false;
+		for (size_t i = 0; i < a.size() && i < b.size(); ++i)
+			if (a[i].x != b[i].x || a[i].y != b[i].y || a[i].z != b[i].z) different = true;
+		REQUIRE(different);
+
+		// hills = 3 points, plains = 2.
+		REQUIRE(GenerateMountainPolyline("hills", 1u).size() == 3);
+		REQUIRE(GenerateMountainPolyline("plains", 1u).size() == 2);
+	}
+
+	void Test_Condition_OperatorsAndQuotes()
+	{
+		WizardChoices ch; ch.poi = "cave"; ch.coast = "interior";
+		REQUIRE(EvaluateCondition("poi == 'cave'", ch));
+		REQUIRE(!EvaluateCondition("poi == 'none'", ch));
+		REQUIRE(EvaluateCondition("poi != 'none'", ch));
+		REQUIRE(EvaluateCondition("coast == 'interior'", ch));
+		REQUIRE(EvaluateCondition("", ch));           // vide = vrai
+		REQUIRE(EvaluateCondition("garbage", ch));    // non reconnu = vrai
+	}
+}
+
+int main()
+{
+	Test_Wizard_StateMachine();
+	Test_Resolver_AllCombinations_ProduceValidPresets();
+	Test_Resolver_ConditionIf_SkipsOperation();
+	Test_Resolver_VariableSubstitution_Works();
+	Test_AutoGenerators_Deterministic_SameSeedSameOutput();
+	Test_AutoGenerators_DifferentSeeds_DifferentOutputs();
+	Test_Condition_OperatorsAndQuotes();
+
+	if (g_failed == 0)
+		std::printf("[quick_start_wizard_tests] all tests passed\n");
+	else
+		std::fprintf(stderr, "[quick_start_wizard_tests] %d check(s) failed\n", g_failed);
+	return g_failed;
+}

--- a/src/world_editor/wizard/AutoGenerators.cpp
+++ b/src/world_editor/wizard/AutoGenerators.cpp
@@ -1,0 +1,44 @@
+// M100.50 — Implémentation des auto-générateurs (déterministes, seedés).
+
+#include "src/world_editor/wizard/AutoGenerators.h"
+
+#include <random>
+
+namespace engine::editor::world::wizard
+{
+	namespace
+	{
+		struct ReliefProfile { int points; float amplitude; float sinuosity; };
+
+		ReliefProfile ProfileFor(const std::string& relief)
+		{
+			if (relief == "plains")    return { 2, 5.0f,   2.0f };
+			if (relief == "hills")     return { 3, 40.0f,  8.0f };
+			if (relief == "mountains") return { 5, 220.0f, 20.0f };
+			if (relief == "escarped")  return { 5, 480.0f, 35.0f };
+			return { 3, 40.0f, 8.0f }; // défaut = hills.
+		}
+	}
+
+	std::vector<engine::math::Vec3> GenerateMountainPolyline(const std::string& relief, uint32_t seed)
+	{
+		const ReliefProfile p = ProfileFor(relief);
+		std::mt19937_64 rng(static_cast<uint64_t>(seed));
+		std::uniform_real_distribution<float> jitterXZ(-1.0f, 1.0f);
+		std::uniform_real_distribution<float> heightFrac(0.6f, 1.0f);
+
+		std::vector<engine::math::Vec3> out;
+		out.reserve(static_cast<size_t>(p.points));
+		const float span = 512.0f;
+		const float step = p.points > 1 ? span / static_cast<float>(p.points - 1) : 0.0f;
+		for (int i = 0; i < p.points; ++i)
+		{
+			const float baseX = static_cast<float>(i) * step;
+			const float x = baseX + jitterXZ(rng) * p.sinuosity;
+			const float z = 256.0f + jitterXZ(rng) * p.sinuosity;
+			const float y = p.amplitude * heightFrac(rng);
+			out.push_back({ x, y, z });
+		}
+		return out;
+	}
+}

--- a/src/world_editor/wizard/AutoGenerators.h
+++ b/src/world_editor/wizard/AutoGenerators.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// M100.50 — Fonctions d'auto-génération ($auto_xxx du template). Déterministes
+// (std::mt19937_64 seedé) : même seed → même sortie. Pures, testables.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "src/shared/math/Math.h"
+
+namespace engine::editor::world::wizard
+{
+	/// Génère une polyline de chaîne montagneuse adaptée au relief.
+	///   plains    : 2 points, quasi plat.
+	///   hills     : 3 points, sinuosité légère, hauteur modérée.
+	///   mountains : 5 points, plus dramatique.
+	///   escarped  : 5 points, amplitude maximale.
+	/// Déterministe pour (relief, seed) : un même couple produit la même polyline.
+	std::vector<engine::math::Vec3> GenerateMountainPolyline(const std::string& relief, uint32_t seed);
+}

--- a/src/world_editor/wizard/ConditionEvaluator.cpp
+++ b/src/world_editor/wizard/ConditionEvaluator.cpp
@@ -1,0 +1,76 @@
+// M100.50 — Implémentation ConditionEvaluator.
+
+#include "src/world_editor/wizard/ConditionEvaluator.h"
+
+#include <cstdint>
+
+namespace engine::editor::world::wizard
+{
+	namespace
+	{
+		void ReplaceAll(std::string& s, const std::string& from, const std::string& to)
+		{
+			if (from.empty()) return;
+			size_t pos = 0;
+			while ((pos = s.find(from, pos)) != std::string::npos)
+			{
+				s.replace(pos, from.size(), to);
+				pos += to.size();
+			}
+		}
+
+		std::string Trim(const std::string& s)
+		{
+			size_t a = s.find_first_not_of(" \t");
+			if (a == std::string::npos) return "";
+			size_t b = s.find_last_not_of(" \t");
+			return s.substr(a, b - a + 1);
+		}
+
+		/// Valeur d'un champ de choix par nom (vide si inconnu).
+		std::string FieldValue(const std::string& field, const WizardChoices& c)
+		{
+			if (field == "climate") return c.climate;
+			if (field == "relief")  return c.relief;
+			if (field == "coast")   return c.coast;
+			if (field == "poi")     return c.poi;
+			return "";
+		}
+	}
+
+	std::string SubstituteVariables(const std::string& text, const WizardChoices& choices)
+	{
+		std::string out = text;
+		ReplaceAll(out, "{{climate}}", choices.climate);
+		ReplaceAll(out, "{{relief}}",  choices.relief);
+		ReplaceAll(out, "{{coast}}",   choices.coast);
+		ReplaceAll(out, "{{poi}}",     choices.poi);
+		ReplaceAll(out, "{{seed}}",    std::to_string(choices.seed));
+		return out;
+	}
+
+	bool EvaluateCondition(const std::string& condition, const WizardChoices& choices)
+	{
+		const std::string cond = Trim(condition);
+		if (cond.empty()) return true;
+
+		// Détecte l'opérateur (== ou !=).
+		bool negate = false;
+		size_t opPos = cond.find("==");
+		if (opPos == std::string::npos)
+		{
+			opPos = cond.find("!=");
+			if (opPos == std::string::npos) return true; // forme non reconnue → gardée.
+			negate = true;
+		}
+
+		const std::string field = Trim(cond.substr(0, opPos));
+		std::string rhs = Trim(cond.substr(opPos + 2));
+		// Retire les quotes simples/doubles autour de la valeur.
+		if (rhs.size() >= 2 && (rhs.front() == '\'' || rhs.front() == '"') && rhs.back() == rhs.front())
+			rhs = rhs.substr(1, rhs.size() - 2);
+
+		const bool equal = (FieldValue(field, choices) == rhs);
+		return negate ? !equal : equal;
+	}
+}

--- a/src/world_editor/wizard/ConditionEvaluator.h
+++ b/src/world_editor/wizard/ConditionEvaluator.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// M100.50 — Évaluation des conditions "if" et substitution des variables
+// {{var}} du template du wizard. Pur, testable.
+
+#include <string>
+
+#include "src/world_editor/wizard/WizardChoices.h"
+
+namespace engine::editor::world::wizard
+{
+	/// Remplace les placeholders {{climate}}, {{relief}}, {{coast}}, {{poi}},
+	/// {{seed}} dans `text` par les valeurs de `choices`. Les placeholders
+	/// inconnus sont laissés tels quels.
+	std::string SubstituteVariables(const std::string& text, const WizardChoices& choices);
+
+	/// Évalue une condition simple de la forme `field op 'value'` où `field` ∈
+	/// {climate, relief, coast, poi}, `op` ∈ {==, !=}. Espaces tolérés. Une
+	/// condition vide ou non reconnue est considérée vraie (opération non gardée).
+	bool EvaluateCondition(const std::string& condition, const WizardChoices& choices);
+}

--- a/src/world_editor/wizard/QuickStartWizard.cpp
+++ b/src/world_editor/wizard/QuickStartWizard.cpp
@@ -1,0 +1,82 @@
+// M100.50 — Implémentation WizardChoices (validation) + QuickStartWizard (FSM).
+
+#include "src/world_editor/wizard/QuickStartWizard.h"
+
+namespace engine::editor::world::wizard
+{
+	bool IsValidClimate(const std::string& v)
+	{
+		return v == "temperate" || v == "arid" || v == "polar" || v == "tropical";
+	}
+	bool IsValidRelief(const std::string& v)
+	{
+		return v == "plains" || v == "hills" || v == "mountains" || v == "escarped";
+	}
+	bool IsValidCoast(const std::string& v)
+	{
+		return v == "interior" || v == "moderate" || v == "dramatic";
+	}
+	bool IsValidPoi(const std::string& v)
+	{
+		return v == "none" || v == "cave" || v == "ruin" || v == "dungeon";
+	}
+
+	bool QuickStartWizard::SetChoiceForCurrentStep(const std::string& value)
+	{
+		switch (m_step)
+		{
+		case WizardStep::Climate:
+			if (!IsValidClimate(value)) return false;
+			m_choices.climate = value; return true;
+		case WizardStep::Relief:
+			if (!IsValidRelief(value)) return false;
+			m_choices.relief = value; return true;
+		case WizardStep::Coast:
+			if (!IsValidCoast(value)) return false;
+			m_choices.coast = value; return true;
+		case WizardStep::Poi:
+			if (!IsValidPoi(value)) return false;
+			m_choices.poi = value; return true;
+		case WizardStep::Preview:
+		default:
+			return false; // Preview ne porte pas de choix textuel.
+		}
+	}
+
+	bool QuickStartWizard::CanProceed() const
+	{
+		switch (m_step)
+		{
+		case WizardStep::Climate: return IsValidClimate(m_choices.climate);
+		case WizardStep::Relief:  return IsValidRelief(m_choices.relief);
+		case WizardStep::Coast:   return IsValidCoast(m_choices.coast);
+		case WizardStep::Poi:     return IsValidPoi(m_choices.poi);
+		case WizardStep::Preview: return true;
+		default:                  return false;
+		}
+	}
+
+	bool QuickStartWizard::Next()
+	{
+		if (m_step == WizardStep::Preview) return false; // dernière étape.
+		if (!CanProceed()) return false;
+		m_step = static_cast<WizardStep>(static_cast<uint8_t>(m_step) + 1);
+		return true;
+	}
+
+	bool QuickStartWizard::Prev()
+	{
+		if (m_step == WizardStep::Climate) return false;
+		m_step = static_cast<WizardStep>(static_cast<uint8_t>(m_step) - 1);
+		return true;
+	}
+
+	bool QuickStartWizard::IsReadyToGenerate() const
+	{
+		return m_step == WizardStep::Preview
+			&& IsValidClimate(m_choices.climate)
+			&& IsValidRelief(m_choices.relief)
+			&& IsValidCoast(m_choices.coast)
+			&& IsValidPoi(m_choices.poi);
+	}
+}

--- a/src/world_editor/wizard/QuickStartWizard.h
+++ b/src/world_editor/wizard/QuickStartWizard.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// M100.50 — QuickStartWizard : machine d'état des 5 étapes guidées (logique
+// PURE, testable headless). L'UI (cartes de choix, aperçu 3D) est une passe
+// séparée ; la résolution choix → ZonePreset est dans WizardTemplateResolver.
+
+#include <cstdint>
+#include <string>
+
+#include "src/world_editor/wizard/WizardChoices.h"
+
+namespace engine::editor::world::wizard
+{
+	/// Les 5 étapes du wizard.
+	enum class WizardStep : uint8_t
+	{
+		Climate = 0,
+		Relief  = 1,
+		Coast   = 2,
+		Poi     = 3,
+		Preview = 4,
+	};
+
+	/// Machine d'état du wizard. Valide chaque choix, autorise next/prev, et
+	/// signale quand on peut générer.
+	class QuickStartWizard
+	{
+	public:
+		WizardStep CurrentStep() const { return m_step; }
+		const WizardChoices& Choices() const { return m_choices; }
+		WizardChoices& Choices() { return m_choices; }
+
+		/// Affecte le choix de l'étape courante (ignore les étapes Preview).
+		/// \return true si la valeur est valide pour l'étape courante.
+		bool SetChoiceForCurrentStep(const std::string& value);
+
+		/// True si l'étape courante a un choix valide → on peut avancer.
+		/// L'étape Preview peut toujours avancer (= générer).
+		bool CanProceed() const;
+
+		/// Avance d'une étape si possible. \return true si on a avancé.
+		bool Next();
+
+		/// Recule d'une étape si possible. \return true si on a reculé.
+		bool Prev();
+
+		/// True si on est à l'étape Preview avec tous les choix valides : prêt à
+		/// générer la zone.
+		bool IsReadyToGenerate() const;
+
+		/// Fixe le seed (étape Preview).
+		void SetSeed(uint32_t seed) { m_choices.seed = seed; }
+
+	private:
+		WizardStep    m_step = WizardStep::Climate;
+		WizardChoices m_choices;
+	};
+}

--- a/src/world_editor/wizard/WizardChoices.h
+++ b/src/world_editor/wizard/WizardChoices.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// M100.50 — Choix de l'assistant Quick Start (5 étapes). Valeurs en chaînes
+// (cohérent avec la substitution {{var}} et les conditions "poi == 'none'").
+
+#include <cstdint>
+#include <string>
+
+namespace engine::editor::world::wizard
+{
+	/// Les 4 choix paramétriques + le seed. La prévisualisation (étape 5) ne
+	/// modifie que le seed.
+	struct WizardChoices
+	{
+		std::string climate = "temperate"; ///< temperate | arid | polar | tropical
+		std::string relief  = "hills";     ///< plains | hills | mountains | escarped
+		std::string coast   = "interior";  ///< interior | moderate | dramatic
+		std::string poi     = "none";      ///< none | cave | ruin | dungeon
+		uint32_t    seed    = 42u;
+	};
+
+	/// Valeurs valides par dimension (pour validation + UI).
+	bool IsValidClimate(const std::string& v);
+	bool IsValidRelief(const std::string& v);
+	bool IsValidCoast(const std::string& v);
+	bool IsValidPoi(const std::string& v);
+}

--- a/src/world_editor/wizard/WizardTemplateResolver.cpp
+++ b/src/world_editor/wizard/WizardTemplateResolver.cpp
@@ -1,0 +1,108 @@
+// M100.50 — Implémentation WizardTemplateResolver (template code-défini).
+
+#include "src/world_editor/wizard/WizardTemplateResolver.h"
+
+#include "src/world_editor/wizard/AutoGenerators.h"
+#include "src/world_editor/wizard/ConditionEvaluator.h"
+
+#include <string>
+
+namespace engine::editor::world::wizard
+{
+	using engine::editor::world::zone_presets::ZonePreset;
+	using engine::editor::world::zone_presets::ZonePresetOperation;
+
+	namespace
+	{
+		/// Une entrée du template : type d'opération + condition "if" + affectedBy
+		/// + un fragment rawJson (avec placeholders {{var}}).
+		struct TemplateOp
+		{
+			std::string type;
+			std::string condition;   ///< vide = toujours inclus.
+			std::vector<std::string> affectedBy;
+			std::string rawJsonTemplate;
+		};
+
+		/// Type d'opération « point d'intérêt » selon le choix POI.
+		std::string PoiOpType(const std::string& poi)
+		{
+			if (poi == "cave")    return "place_cave";
+			if (poi == "ruin")    return "place_arch";   // ruine ≈ structure (MVP).
+			if (poi == "dungeon") return "place_dungeon";
+			return ""; // "none"
+		}
+
+		/// Template code-défini (placeholders {{var}} + conditions "if").
+		std::vector<TemplateOp> BuildTemplate(const WizardChoices& c)
+		{
+			std::vector<TemplateOp> ops;
+
+			// 1. Macro relief (toujours) : valley pour plains, mountain sinon.
+			if (c.relief == "plains")
+				ops.push_back({ "valley_macro", "", { "relief" }, "{ \"relief\": \"{{relief}}\" }" });
+			else
+				ops.push_back({ "mountain_macro", "", { "relief" }, "{ \"relief\": \"{{relief}}\", \"seed\": {{seed}} }" });
+
+			// 2. Splat selon climat (toujours).
+			ops.push_back({ "splat_paint", "", { "dryness" }, "{ \"climate\": \"{{climate}}\" }" });
+
+			// 3. Érosion hydraulique (toujours) — eau selon climat.
+			ops.push_back({ "hydraulic_erosion", "", { "water_density" }, "{ \"climate\": \"{{climate}}\" }" });
+
+			// 4. Côte (si pas intérieur).
+			ops.push_back({ "coastline", "coast != 'interior'", {}, "{ \"coast\": \"{{coast}}\" }" });
+
+			// 5. Point d'intérêt (si pas none).
+			const std::string poiType = PoiOpType(c.poi);
+			if (!poiType.empty())
+				ops.push_back({ poiType, "poi != 'none'", {}, "{ \"poi\": \"{{poi}}\" }" });
+
+			return ops;
+		}
+	}
+
+	ZonePreset WizardTemplateResolver::Resolve(const WizardChoices& choices) const
+	{
+		ZonePreset preset;
+		preset.version = 1;
+		preset.id = "quickstart_" + choices.climate + "_" + choices.relief + "_" +
+			choices.coast + "_" + choices.poi;
+		preset.displayName.fr = "Assistant : " + choices.climate + " / " + choices.relief;
+		preset.displayName.en = "Wizard: " + choices.climate + " / " + choices.relief;
+		preset.tags = { "quickstart", choices.climate, choices.relief };
+		preset.decorationEntryCount = 0u;
+
+		for (const TemplateOp& t : BuildTemplate(choices))
+		{
+			// Condition "if" → skip si fausse.
+			if (!EvaluateCondition(t.condition, choices))
+				continue;
+
+			ZonePresetOperation op;
+			op.type = t.type;
+			op.affectedBy = t.affectedBy;
+			op.rawJson = SubstituteVariables(t.rawJsonTemplate, choices);
+			preset.operations.push_back(std::move(op));
+		}
+
+		// Auto-gen : la polyline du macro relief (déterministe) est calculée ici
+		// pour que l'exécuteur (ou les tests) puisse la consommer. On l'encode
+		// dans le rawJson de la 1re opération (macro) pour rester self-contained.
+		if (!preset.operations.empty())
+		{
+			const auto polyline = GenerateMountainPolyline(choices.relief, choices.seed);
+			std::string pts = "[";
+			for (size_t i = 0; i < polyline.size(); ++i)
+			{
+				if (i) pts += ",";
+				pts += "[" + std::to_string(polyline[i].x) + "," +
+					std::to_string(polyline[i].y) + "," + std::to_string(polyline[i].z) + "]";
+			}
+			pts += "]";
+			preset.operations.front().rawJson += " /*polyline=*/ " + pts;
+		}
+
+		return preset;
+	}
+}

--- a/src/world_editor/wizard/WizardTemplateResolver.h
+++ b/src/world_editor/wizard/WizardTemplateResolver.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// M100.50 — WizardTemplateResolver : transforme les choix du wizard + seed en
+// un ZonePreset (M100.46) prêt à passer au ZonePresetExecutor. Le template est
+// défini EN CODE pour le MVP (pas de parseur JSON partagé) ; conditions "if",
+// substitution {{var}} et auto-générateurs sont appliqués.
+
+#include "src/world_editor/wizard/WizardChoices.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+
+namespace engine::editor::world::wizard
+{
+	class WizardTemplateResolver
+	{
+	public:
+		/// Résout les choix en un ZonePreset complet et valide. id déterministe
+		/// dérivé des choix ; chaque combinaison (climat × relief × côte × POI)
+		/// produit un preset distinct mais structurellement valide.
+		engine::editor::world::zone_presets::ZonePreset Resolve(const WizardChoices& choices) const;
+	};
+}


### PR DESCRIPTION
## M100.50 — Quick Start Wizard

Assistant 5 étapes (**climat × relief × côte × POI**, ~192 combinaisons) produisant un `ZonePreset` (M100.46) consommable par le `ZonePresetExecutor`. **Cœur pur testable** ; UI (cartes de choix, aperçu 3D) + exécution = passe séparée.

### Cœur testable (engine_core — CI Linux)
- `WizardChoices` — 4 dimensions (chaînes) + seed + validation des valeurs.
- `QuickStartWizard` — machine d'état 5 étapes (`Climate`/`Relief`/`Coast`/`Poi`/`Preview`), `SetChoice` validé, `Next`/`Prev` gardés, `IsReadyToGenerate`.
- `ConditionEvaluator` — conditions `field op 'value'` (`==`/`!=`) + substitution `{{climate}}`/`{{relief}}`/`{{coast}}`/`{{poi}}`/`{{seed}}`.
- `AutoGenerators` — polyline relief **déterministe** (`mt19937_64` seedé ; même seed → même sortie ; plains=2 / hills=3 / mountains=5 / escarped=5 points).
- `WizardTemplateResolver` — template **code-défini** → `ZonePreset` **valide** (types d'opération M100.46 connus, `affectedBy` valides, décoration vide) ; conditions `if` appliquées (poi=none → pas de `place_*`, coast=interior → pas de `coastline`).
- `quick_start_wizard_tests` — **7 cas** dont les **192 combinaisons → 192 presets valides**.

### Différé (passe UI/intégration)
`WizardStepCard`, aperçu 3D, `PreviewImageRegistry` (PNG), `WizardTemplateIo` (JSON), exécution réelle via `OperationDispatcher`, hooks Fichier→Nouvelle zone / fin du tutoriel M100.49.

### Déploiement
> ✅ **client/éditeur uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)