### PR TITLE
chore(tickets): clôture M100.34/41/42/48/49 + correction tracking

### DIFF
--- a/tickets/M100/M100.45-SimpleAdvancedMode_ToolPresets.md
+++ b/tickets/M100/M100.45-SimpleAdvancedMode_ToolPresets.md
@@ -1,5 +1,11 @@
 # M100.45 — Simple/Advanced Mode Toggle + Tool Parameter Presets (Phase 12 — Accessibilité)
 
+> **État : PARTIAL.** Phase A livrée (PR #611) — EditorModeRegistry,
+> ToolPresetRegistry, UserPrefsStore. **Phase B restante** : migration des 13
+> outils (définition mode Simple + fichier `tool_presets/<id>.json` + tests par
+> outil). Ticket conservé jusqu'à complétion de la Phase B.
+
+
 ## Résumé
 
 **Démarre la Phase 12 « Accessibilité éditeur »** en livrant deux mécaniques transverses qui s'appliquent à **tous les outils** déjà existants (M100.6, .7, .9, .13, .17, .35-43) et futurs :

--- a/tickets/M100/M100.47-TooltipsAndF1Doc.md
+++ b/tickets/M100/M100.47-TooltipsAndF1Doc.md
@@ -1,5 +1,11 @@
 # M100.47 — Tooltips & F1 Doc (Phase 12 — Accessibilité)
 
+> **État : PARTIAL.** Incréments 1 et 3 livrés (PR #620, #622) — HelpContentStore
+> (tooltips JSON) + RichTooltipWidget chargé au boot. **Restant** : couverture
+> complète des tooltips par widget + fenêtre de doc F1. Ticket conservé jusqu'à
+> complétion.
+
+
 ## Résumé
 
 Système d'aide intégré à l'éditeur, en deux volets :

--- a/tickets/TICKETS_STATUS.md
+++ b/tickets/TICKETS_STATUS.md
@@ -7,9 +7,9 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 
 | Statut | Nombre |
 |--------|-------:|
-| DONE (clotures) | 335 |
-| PARTIAL | 33 |
-| TODO | 45 |
+| DONE (clotures) | 340 |
+| PARTIAL | 35 |
+| TODO | 38 |
 | **Total** | 413 |
 
 ### Par milestone
@@ -62,7 +62,7 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M43 | 1 | 1 | 6 | 8 |
 | M44 | 4 | 0 | 0 | 4 |
 | M45 | 8 | 0 | 0 | 8 |
-| M100 | 42 | 0 | 9 | 51 |
+| M100 | 47 | 2 | 2 | 51 |
 | M101 | 8 | 1 | 2 | 11 |
 | AUTH-UI | 12 | 0 | 0 | 12 |
 | CHAR-MODEL | 3 | 12 | 22 | 37 |
@@ -568,23 +568,23 @@ Convention : **DONE** = implemente, cloture par une Issue dans `tickets/issues/`
 | M100.31 | DONE | Hamlet generator + kits (cloture #811) |
 | M100.32 | DONE | Interactive props + relay master + simulateur (cloture #814) |
 | M100.33 | DONE | Footstep audio + PlaytestMode (cloture #811) |
-| M100.34 | TODO | SelectionTool/Layers/Minimap/Exporter absents |
+| M100.34 | DONE | Selection/Layers/Minimap + export round-trip (cloture #816) |
 | M100.35 | DONE | Mountain range tools |
 | M100.36 | DONE | River network generator |
 | M100.37 | DONE | Coastline + sea level |
 | M100.38 | DONE | Hydraulic erosion |
 | M100.39 | DONE | Thermal/wind erosion |
 | M100.40 | DONE | Mesh insert + cave tool |
-| M100.41 | TODO | src/world_editor/volumes/overhangs/ absent |
-| M100.42 | TODO | src/world_editor/volumes/arches/ absent |
+| M100.41 | DONE | Overhang Cliff Tool (cloture corrective, commit d16cbcc2) |
+| M100.42 | DONE | Natural Arch Tool (cloture corrective, commit 910f97da) |
 | M100.43 | DONE | Dungeon portal system |
 | M100.44 | DONE | VMap bridge |
-| M100.45 | TODO | spec doc only |
+| M100.45 | PARTIAL | Phase A faite (modes+presets, #611) ; Phase B (13 outils) restante |
 | M100.46 | DONE | ZonePresets library + tests (corrige) |
-| M100.47 | TODO | spec doc only |
-| M100.48 | TODO | spec doc only |
-| M100.49 | TODO | spec doc only |
-| M100.50 | TODO | spec doc only |
+| M100.47 | PARTIAL | HelpContentStore + RichTooltipWidget (incr 1+3) ; couverture tooltips/F1 restante |
+| M100.48 | DONE | Zone Validation Service (cloture #817) |
+| M100.49 | DONE | Tutoriel + Diagnostic (cloture #818 + #819) |
+| M100.50 | TODO | Quick Start Wizard — PR #820 en cours (cloture au merge) |
 | M100.51 | TODO | spec doc only |
 
 ### M101

--- a/tickets/issues/M100.34-SelectionLayersMinimapSaveLoadZone_Issue.md
+++ b/tickets/issues/M100.34-SelectionLayersMinimapSaveLoadZone_Issue.md
@@ -1,3 +1,15 @@
+# Issue: M100.34 — Selection, Layers, Minimap & Save/Load Zone
+
+**Status:** Closed
+
+_Implémenté et mergé par la PR #816. Cœur livré : SelectionTool (rect/lasso),
+LayersDocument (16 calques), DeleteCommand (réversible), WorldEditorExporter
+(`SaveZone` round-trip complet via les Save*Bin header-only) + MinimapPanel.
+Tests : `export_zone_tests` (7 cas dont FullRoundtrip). Différé 2e passe UI :
+câblage live shell/outliner + persistance d'un layerIndex dans les formats._
+
+---
+
 # M100.34 — Selection, Layers, Minimap & Save/Load Zone
 
 ## Résumé

--- a/tickets/issues/M100.41-OverhangCliffTool_Issue.md
+++ b/tickets/issues/M100.41-OverhangCliffTool_Issue.md
@@ -1,3 +1,13 @@
+# Issue: M100.41 — Overhang Cliff Tool (Phase 11 — Volumes 3D)
+
+**Status:** Closed
+
+_Implémenté et mergé (commit `d16cbcc2`) ; `overhang_tool_tests` présent.
+Réutilise le MeshInsertSystem (M100.40). Clôture correctrice : le ticket était
+marqué TODO à tort dans TICKETS_STATUS.md (faux-négatif de la regen 2026-06-03)._
+
+---
+
 # M100.41 — Overhang Cliff Tool (Phase 11 — Volumes 3D)
 
 ## Résumé

--- a/tickets/issues/M100.42-NaturalArchTool_Issue.md
+++ b/tickets/issues/M100.42-NaturalArchTool_Issue.md
@@ -1,3 +1,13 @@
+# Issue: M100.42 — Natural Arch Tool (Phase 11 — Volumes 3D)
+
+**Status:** Closed
+
+_Implémenté et mergé (commit `910f97da`) ; `arch_tool_tests` présent. Réutilise
+le MeshInsertSystem (M100.40). Clôture correctrice : le ticket était marqué TODO
+à tort dans TICKETS_STATUS.md (faux-négatif de la regen 2026-06-03)._
+
+---
+
 # M100.42 — Natural Arch Tool (Phase 11 — Volumes 3D)
 
 ## Résumé

--- a/tickets/issues/M100.48-ZoneValidationService_Issue.md
+++ b/tickets/issues/M100.48-ZoneValidationService_Issue.md
@@ -1,3 +1,14 @@
+# Issue: M100.48 — Zone Validation Service (Phase 12 — Accessibilité)
+
+**Status:** Closed
+
+_Implémenté et mergé par la PR #817. Cœur livré : IValidationRule +
+ValidationRuleRegistry + ZoneValidator (full + incrémental, tri par sévérité) +
+6 règles MVP (heightmap/splat/mesh inserts). Tests : `zone_validation_tests`
+(8 cas). Différé 2e passe : panel ImGui + « Aller à » + règles water._
+
+---
+
 # M100.48 — Zone Validation Service (Phase 12 — Accessibilité)
 
 ## Résumé

--- a/tickets/issues/M100.49-TutorialDiagnostic_Issue.md
+++ b/tickets/issues/M100.49-TutorialDiagnostic_Issue.md
@@ -1,3 +1,15 @@
+# Issue: M100.49 — Tutoriel interactif & Diagnostic (Phase 12 — Accessibilité)
+
+**Status:** Closed
+
+_Implémenté et mergé en deux PR : #818 (partie 1 — OverlayGuidanceSystem +
+TutorialSystem 8 étapes + WidgetTargetRegistry, tests `tutorial_diagnostic_tests`)
+et #819 (partie 2 — IDiagnosticRule + DiagnosticSystem + 10 règles workflow,
+tests `diagnostic_tests`). Différé 2e passe : UI ImGui (modales, panel, bulle,
+surlignage, one-click), chargement JSON des tutoriels, persistance UserPrefs._
+
+---
+
 # M100.49 — Tutoriel interactif & Diagnostic (Phase 12 — Accessibilité)
 
 ## Résumé


### PR DESCRIPTION
Clôture des tickets M100 réalisés et mergés, + correction des faux-négatifs du `TICKETS_STATUS.md` (regen 2026-06-03). **Docs uniquement.**

### Clôtures (→ `tickets/issues/` + bannière `Closed`)
- **M100.34** Selection/Layers/Minimap/Export — mergé #816.
- **M100.48** Zone Validation Service — mergé #817.
- **M100.49** Tutoriel + Diagnostic — mergé #818 (p1) + #819 (p2).
- **M100.41** Overhang Cliff Tool — clôture **corrective** (déjà mergé, commit `d16cbcc2`, `overhang_tool_tests`).
- **M100.42** Natural Arch Tool — clôture **corrective** (déjà mergé, commit `910f97da`, `arch_tool_tests`).

### Corrections de statut
- **M100.45** → **PARTIAL** (Phase A faite #611 ; Phase B = migration 13 outils restante) + encart d'état.
- **M100.47** → **PARTIAL** (incréments 1+3 faits ; couverture tooltips/F1 restante) + encart d'état.

### Compteurs
`TICKETS_STATUS.md` : **M100 = 47 DONE / 2 PARTIAL / 2 TODO** ; synthèse **340 / 35 / 38** (total 413).
Restent TODO : **M100.50** (PR #820 en vol) et **M100.51**.

> **Déploiement** : ✅ docs uniquement, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)