### PR TITLE
fix(terrain): rendu exclusif legacy/chunks — supprime le z-fighting (Phase 0, chantier C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1037,6 +1037,10 @@ add_executable(entity_influence_tests src/client/world/foliage/tests/EntityInflu
 target_link_libraries(entity_influence_tests PRIVATE engine_core)
 add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
 
+# Phase 0 chantier C — Test fonction pure ShouldDrawLegacyTerrain (header-only).
+add_executable(terrain_render_selection_tests src/client/render/tests/TerrainRenderSelectionTests.cpp)
+add_test(NAME terrain_render_selection_tests COMMAND terrain_render_selection_tests)
+
 # M100.27 — Tests thermal (shade round-trip/builder + ComputeTemperature + query).
 add_executable(thermal_tests src/client/world/thermal/tests/ThermalTests.cpp)
 target_link_libraries(thermal_tests PRIVATE engine_core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,6 +1039,7 @@ add_test(NAME entity_influence_tests COMMAND entity_influence_tests)
 
 # Phase 0 chantier C — Test fonction pure ShouldDrawLegacyTerrain (header-only).
 add_executable(terrain_render_selection_tests src/client/render/tests/TerrainRenderSelectionTests.cpp)
+target_include_directories(terrain_render_selection_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME terrain_render_selection_tests COMMAND terrain_render_selection_tests)
 
 # M100.27 — Tests thermal (shade round-trip/builder + ComputeTemperature + query).

--- a/docs/audit/2026-06-05-moteur-rendu-client.md
+++ b/docs/audit/2026-06-05-moteur-rendu-client.md
@@ -1,0 +1,140 @@
+# Audit du moteur de rendu & du client — LCDLLN
+
+**Date** : 2026-06-05
+**Périmètre** : moteur graphique en profondeur (`src/client/render/`) + reste du client (`src/client/`) en couverture. `legacy/` exclu.
+**Angles prioritaires** : fidélité visuelle, architecture/dette (code orphelin), anomalies/bugs.
+**Méthode** : analyse en éventail par 5 agents spécialisés (architecture rendu, fidélité visuelle, anomalies Vulkan, code orphelin client, sous-systèmes hors-rendu), avec preuves `fichier:ligne` et recoupement croisé.
+
+---
+
+## Verdict global
+
+Le moteur **n'est pas un moteur indie sous-développé** : c'est un deferred renderer Vulkan moderne dont les fondations sont **réellement de niveau AA/AAA** sur le papier — PBR Cook-Torrance/GGX de référence, IBL split-sum correct, CSM mathématiquement bonne (snap au texel anti-swimming), DDGI, auto-exposure par histogramme, frame graph à tri topologique avec barrières sync2 automatiques, terrain splat triplanaire.
+
+**Le problème n'est pas la qualité du code des features, c'est qu'une grande partie de ces features de luxe sont CODÉES MAIS DÉBRANCHÉES du rendu réel.** On paie le coût CPU/GPU de les calculer, mais leur résultat n'arrive jamais à l'écran. C'est l'explication centrale du ressenti « pas à la hauteur d'un AAA » : l'image finale est bridée alors que le moteur en a les moyens.
+
+> **Métaphore** : une voiture de sport dont le moteur tourne, mais dont l'embrayage n'est pas connecté aux roues sur la moitié des rapports.
+
+---
+
+## 1. Le « moteur fantôme » — systèmes calculés mais non consommés
+
+C'est, de loin, le constat le plus important. Plusieurs agents l'ont confirmé indépendamment.
+
+| Système | État | Preuve | Conséquence visible |
+|---|---|---|---|
+| **Ombres soleil (CSM)** | 4 cascades **rendues** chaque frame, mais **jamais échantillonnées** dans `lighting.frag` | `Engine.cpp:5410-5432` (rendu) ; aucun sampling shadow dans `lighting.frag` ; lues seulement par DDGI + fog | **Le soleil ne projette aucune ombre** sur terrain/objets. On paie 4 rendus de depth pour les seuls god-rays. |
+| **Lumières ponctuelles** | `DynamicLightSystem` calcule les lampes/torches chaque frame, `GetActiveLights()` **a 0 consommateur** | `DynamicLightSystem.h:32,93` ; `LightingPass` n'a aucun support point-light | **Nuit sans lampes** : lampadaires, torches, fenêtres invisibles. Une seule lumière directionnelle éclaire tout. |
+| **IBL (irradiance + spéculaire)** | `irrView` reste `VK_NULL_HANDLE`, donc `useIBL` **toujours 0** | `Engine.cpp:5733,5739` | Réflexions d'environnement absentes. `BrdfLut` + `SpecularPrefilter` (1000 l.) calculés pour rien. |
+| **GPU-driven culling + Hi-Z** | Ne traitent que le **cube placeholder** (≤1 item) ; tout le reste (terrain, props, avatars, impostors) contourne le culling par des `Record` directs | `Engine.cpp:5026-5052` | 1300+ lignes + 2 shaders compute exécutés par frame pour ~0 bénéfice. |
+| **Eau (géométrie)** | Surface **totalement plate**, aucune Gerstner/FFT, animation uniquement par normal maps | `water.vert:30` (`viewProj*pos` sans displacement) | Eau d'étang stylisée, pas d'océan/houle crédible. |
+
+**Conditionnelles OFF par défaut (saines, fallbacks propres)** : DDGI (`gi.ddgi.enabled=false`), volumetric fog (`density=0`), DoF (`focus_range_m=0`), impostors (`enabled=false`). Architecturalement correctes — juste inactives en config par défaut.
+
+---
+
+## 2. Dualité terrain — défaut de correction réel
+
+Deux systèmes terrain tournent **simultanément**, pas l'un OU l'autre :
+
+- `terrain/TerrainRenderer` (heightmap legacy) — dessiné en premier (`Engine.cpp:5074`).
+- `terrain_chunk/TerrainChunkRenderer` (chunks data-driven, canonique M100) — dessiné « par-dessus » (`Engine.cpp:5285-5305`), **sans éteindre** le premier (commentaire explicite `Engine.cpp:5281-5282`).
+
+Conséquences :
+- **Overdraw** systématique (deux terrains rendus).
+- **Collision ≠ rendu** : `TerrainCollider` est bindé sur la heightmap `m_terrain` (`TerrainCollider.cpp:16-32`), jamais sur les chunks. `TerrainChunkRenderer` n'expose **aucune** API de hauteur. → **Le joueur marche à côté du terrain affiché** en zone chunkée (cause profonde du fix partiel PR #824).
+
+**Proposition** : interface unique `IHeightField` implémentée par les deux backends ; rendre `m_terrain` exclusif (fallback uniquement si aucun chunk valide) ; binder la collision sur la source réellement rendue.
+
+---
+
+## 3. Anomalies & bugs Vulkan (correction)
+
+| Sév. | Bug | Preuve | Risque |
+|---|---|---|---|
+| **Critique** | `HiZPyramidPass` : un seul descriptor set réécrit pendant qu'il est en vol (mis à jour `mipCount` fois après un bind unique, partagé entre 2 frames in-flight) | `HiZPyramidPass.cpp:271,448` + `.h:71` | Violation sync Vulkan active chaque frame ; descriptor « déchiré », culling occlusion corrompu. Toléré par chance sur beaucoup de drivers. |
+| **Majeur** | `TerrainChunkRenderer` : l'éviction LRU détruit des `VkBuffer` **encore référencés** par une frame en vol (`Tick` dans `BeginFrame`, avant le `vkWaitForFences`) | `TerrainChunkRenderer.cpp:1149,443` ; `Engine.cpp:7344,10130` | Use-after-free GPU intermittent au streaming terrain ; crash device-lost difficile à reproduire. |
+| **Majeur** | `DeferredDestroyQueue` : ne libère **jamais** la `VkDeviceMemory` + n'est **branché nulle part** | `DeferredDestroyQueue.cpp:40-43` ; `Engine.h:1210` | Fuite mémoire GPU si utilisé ; et c'est précisément le mécanisme qui rendrait l'éviction terrain (#ci-dessus) sûre — mort. |
+| **Majeur (cond.)** | `FrameGraph` fallback barrières legacy lossy : `ToLegacyStage/Access` incomplets → `stageMask=0` possible | `FrameGraph.cpp:263-285,431-445` | Erreur de validation / sous-synchronisation, **uniquement** si synchronization2 absent (toujours présent en Vulkan 1.3). |
+| **Mineur (latent)** | `GpuUploadQueue` : deadlock de file si un job dépasse le budget (`while sizeBytes<=budget` ne pop jamais) | `GpuUploadQueue.cpp:41` | Dormant (file non câblée), piège à retardement. |
+
+**Conformité winding/culling** : ✅ vérifiée conforme à `CLAUDE.md` (terrain CCW+BACK respecté ; pipelines falaises/skinned/geometry ont chacun leur justification documentée). **Ne pas uniformiser.**
+
+---
+
+## 4. Fidélité visuelle — écarts vs AAA (même là où c'est branché)
+
+- **Normal mapping cassé (Important)** : pas de base tangente dans le G-buffer. La normale est « perturbée » par `N = normalize(N + normalSample.xy*0.5)` (`gbuffer_geometry.frag:76-80`) — géométriquement faux (pas de TBN), relief des matériaux plat/incohérent. → ajouter tangente+bitangente (ou dérivées d'écran).
+- **Modèle matériau minimal** : metallic/roughness/AO/normal seulement ; pas d'émissif réel, ni clearcoat/sheen/SSS. Bindless plafonné à **64 textures / 64 matériaux** (`Material.h:80`) — très bas pour un MMO à monde large.
+- **Bloom basique** : downsample box 2×2 + upsample bilinéaire 1-tap (`bloom_downsample.frag:23`, `bloom_upsample.frag:13`) → scintille et blocky. Standard AAA = 13-tap + tente 3×3 + Karis average.
+- **TAA basique** : opère en **LDR** (post-tonemap), clamp AABB dur, pas de dilatation de vitesse, historique bilinéaire → ghosting + flou cumulatif. Standard = HDR + variance/YCoCg clipping + Catmull-Rom.
+- **LUT tonemap échantillonnée en nearest** (`tonemap.frag:54-58`) → banding sur dégradés ; passer en lerp trilinéaire.
+- **SSAO** : hémisphère 32 taps correct, mais pas HBAO/GTAO (pas de bent normals).
+- **Bon niveau** : terrain (splat triplanaire 4 couches + detail/macro normals + ORM) = solide AA ; PBR/IBL de référence ; CSM bien calculée ; auto-exposure histogramme.
+
+**Niveau visuel** : fondations AA bien architecturées, mais **rendu effectif aujourd'hui plus proche de indie+/AA-faible** à cause des systèmes débranchés (ombres, lampes, eau).
+
+---
+
+## 5. Architecture & dette
+
+- **God-object `Engine`** : `Engine.cpp` = **12 391 lignes**, `Engine.h` = **245 variables membres**, ~70 includes. Concentre boot Vulkan, assets, gameplay, ~20 presenters UI, réseau master+UDP, orchestration **complète** du frame graph (27 `addPass`), éditeur, état d'auth.
+  - Inverse de matrice 4×4 **copiée-collée 5+ fois** inline (Decals/Lighting/VolFog/DoF/Sky).
+  - Push handler master = **switch de ~1150 lignes / 71 cas** copiés-collés (`Engine.cpp:2385-3523`).
+  - `SetSendCallback` : même lambda dupliquée **~20 fois** (`Engine.cpp:1425…1614`).
+  - Input gameplay (achat/vente/talk/tri enchères au clavier) enfoui dans `UpdateGameplayNet` (`Engine.cpp:11583+`).
+- **Orchestration mal placée** : `FrameGraph` est un graphe générique sain, `DeferredPipeline` ne fait qu'`Init/Destroy` — mais c'est `Engine.cpp` qui enregistre et exécute toutes les passes. → extraire un `RenderGraphBuilder`.
+- **Réseau** : couche modèle→UI (`UIModel`/`UIModelBinding`) saine et thread-checkée, pattern Presenter cohérent. Mais : UDP gameplay **sans reconnexion ni détection de timeout** (seul le master TCP reconnecte) ; `PollIncoming` draine la socket sans plafond par frame (`GameplayUdpClient.cpp:398`) ; accumulateur de snapshots chunkés sensible aux duplicatas UDP (`UIModel.cpp:647-680`).
+- **`ClientPrediction`** (422 l. de prédiction/réconciliation) **jamais câblé** — le client envoie sa position brute. Soit l'activer, soit assumer explicitement client-authoritative.
+- **213 occurrences « CMANGOS »** dans `src/client/` — viole une règle projet explicite (mémoire `feedback_no_cmangos_term`).
+
+### Code orphelin confirmé (~7 400 lignes)
+
+20 fichiers compilés mais **jamais référencés** (hors leur propre fichier / tests). Top 10 par taille :
+
+| Lignes | Fichier |
+|---:|---|
+| 978 | `hud/HudLayoutEditor.{cpp,h}` |
+| 812 | `combat/AdvancedCombatUi.{cpp,h}` |
+| 810 | `settings/SettingsMenuUi.{cpp,h}` |
+| 616 | `render/UnderwaterPass.{cpp,h}` (+ membre `m_underwaterPass` mort dans `Engine.h`) |
+| 492 | `fx/FXManager.{cpp,h}` |
+| 435 | `crafting/CraftingUi.{cpp,h}` |
+| 396 | `combat/AuraFXSystem.{cpp,h}` |
+| 393 | `gameplay/ThirdPersonCamera.{cpp,h}` (Engine utilise `OrbitalCameraController`) |
+| 328 | `combat/BuffBarPresenter.{cpp,h}` |
+| 325 | `ui_common/ThemeManager.{cpp,h}` (0 réf dans tout le repo) |
+
+Autres orphelins : `AoEPreviewSystem` (310), `FriendsUi` (304), `PartyHud` (249), `HarvestCastBar` (187), `ParticleBillboardPass` (141), `PakReader`+`PakFormat` (160), `HamletKitLibrary` (127), `ZonePreloadHook` (127), et la feature « son de pas par couche splat » entièrement codée mais jamais reliée (`SplatSampling` 107 + `FootstepAudioSurfaceHook` 58).
+
+**Utilisés seulement par les tests** (à surveiller, NE PAS supprimer) : `ClientPrediction`, `HazardSimulator`, `InteractiveSimulator`, `FoliageLibrary`, `EntityInfluenceCollector`, `SurfaceQueryService`, etc. — sous-systèmes monde testés mais pas branchés au runtime (architecture author→bake→stream défendable, mais nommage trompeur, ex. `InteractiveSimulator` est éditeur-only).
+
+---
+
+## Synthèse des propositions (à discuter, par thème)
+
+### A. « Rebrancher le moteur » — fort impact visuel, coût modéré, client pur
+Le meilleur ratio impact/effort. Tout est déjà calculé, il s'agit surtout de *consommer* l'existant.
+1. **Échantillonner les CSM dans `lighting.frag`** (sélection cascade + PCF + visibilité soleil). Ombres portées = gain de réalisme énorme, coût quasi nul (depth déjà rendu).
+2. **Passe de lumières ponctuelles (clustered/tiled)** consommant `DynamicLightSystem`. Débloque toutes les ambiances de nuit.
+3. **Câbler l'IBL** (capture cubemap → prefilter → `irrView`) ou retirer BrdfLut/SpecularPrefilter du boot.
+
+### B. Correction des bugs Vulkan — fiabilité
+4. Corriger le descriptor set en vol de `HiZPyramidPass` (Critique).
+5. Finir + brancher `DeferredDestroyQueue` (libérer la `VkDeviceMemory`) et l'utiliser pour l'éviction terrain (corrige le use-after-free).
+
+### C. Unifier le terrain — correction + perf
+6. Interface `IHeightField`, rendu exclusif (plus de double terrain), collision sur la source rendue.
+
+### D. Polish visuel — là où c'est déjà branché
+7. TBN réel pour le normal mapping. 8. Bloom 13-tap + Karis. 9. TAA HDR + variance clipping. 10. Eau Gerstner. 11. LUT tonemap trilinéaire.
+
+### E. Hygiène / dette — abaisse le coût de tout le reste
+12. Supprimer les ~7 400 lignes orphelines (risque faible).
+13. Décider du sort des systèmes « débranchés mais coûteux » (GPU-cull/Hi-Z, ParticleSystem) : câbler ou retirer du chemin frame.
+14. Extraire `RenderGraphBuilder` hors d'`Engine.cpp` ; table de dispatch d'opcodes (−1000 l.) ; factoriser `Mat4::Inverse` et `SetSendCallback`.
+15. Reconnexion/timeout UDP gameplay ; décision `ClientPrediction` (câbler ou assumer). Purge « CMANGOS ».
+
+---
+
+**Déploiement** : ✅ Cet audit est en lecture seule — **aucun redéploiement serveur**. Les propositions A, B, C-rendu, D sont **client uniquement** (shaders/rendu Vulkan). C-collision et E touchent du gameplay/réseau client mais restent client (aucun wire/handler/DB modifié à ce stade). Attention à la convention winding de `CLAUDE.md` si on touche aux pipelines.

--- a/docs/superpowers/plans/2026-06-05-terrain-phase0-rendu-exclusif.md
+++ b/docs/superpowers/plans/2026-06-05-terrain-phase0-rendu-exclusif.md
@@ -1,0 +1,405 @@
+# Terrain Phase 0 — Rendu exclusif (anti z-fighting) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Supprimer le z-fighting (triangles scintillants au sol) en n'affichant le terrain heightmap legacy que lorsque les chunks ne couvrent pas la scène.
+
+**Architecture:** La décision « dessiner le terrain legacy ? » est extraite dans une fonction pure header-only (`ShouldDrawLegacyTerrain`), unit-testée. `TerrainChunkRenderer` compte les chunks réellement dessinés lors de son dernier `RenderVisibleChunks`. `Engine` mémorise ce compte par frame (`m_lastFrameChunkDrawCount`, remis à zéro chaque frame) et l'injecte dans la fonction de décision au moment du gating. Latence assumée d'une frame (le gating lit le compte de la frame précédente).
+
+**Tech Stack:** C++17, Vulkan, tests C++ autonomes (macro `REQUIRE` maison + `main()` retournant le nombre d'échecs), enregistrés via `add_executable`/`add_test` dans `CMakeLists.txt`, exécutés par `ctest` en CI Linux. **Pas de build local** : compilation et tests validés via CI ; le rendu est validé manuellement en jeu.
+
+**Référence spec :** `docs/superpowers/specs/2026-06-05-unification-terrain-design.md` (Phase 0).
+
+**Portée :** client uniquement — **pas de redéploiement serveur**. Aucune modification de `frontFace`/`cullMode`/winding (convention stricte `CLAUDE.md`).
+
+---
+
+## Décomposition
+
+Ce plan couvre **uniquement la Phase 0** du spec (livrable indépendant, mergeable seul). Les Phases 1 à 3 (réconciliation taille de chunk, `IHeightField`, retrait du legacy) feront l'objet de plans dédiés après validation en jeu de la Phase 0.
+
+## File Structure
+
+- **Create** `src/client/render/terrain/TerrainRenderSelection.h` — fonction pure `ShouldDrawLegacyTerrain` (header-only, sans dépendance Vulkan).
+- **Create** `src/client/render/tests/TerrainRenderSelectionTests.cpp` — test unitaire de la fonction pure.
+- **Modify** `CMakeLists.txt` — enregistrer le nouvel exécutable de test.
+- **Modify** `src/client/render/terrain_chunk/TerrainChunkRenderer.h` — getter `GetLastDrawnChunkCount()` + membre compteur.
+- **Modify** `src/client/render/terrain_chunk/TerrainChunkRenderer.cpp` — reset + incrément du compteur dans `RenderVisibleChunks`.
+- **Modify** `src/client/app/Engine.h` — membre `m_lastFrameChunkDrawCount`.
+- **Modify** `src/client/app/Engine.cpp` — include + gating via la fonction pure + mise à jour du compteur par frame.
+
+---
+
+### Task 1: Fonction pure de décision `ShouldDrawLegacyTerrain`
+
+**Files:**
+- Create: `src/client/render/terrain/TerrainRenderSelection.h`
+- Test: `src/client/render/tests/TerrainRenderSelectionTests.cpp`
+- Modify: `CMakeLists.txt` (section des `add_test`, ~après la ligne 1038 `add_test(NAME entity_influence_tests ...)`)
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Create `src/client/render/tests/TerrainRenderSelectionTests.cpp` :
+
+```cpp
+// src/client/render/tests/TerrainRenderSelectionTests.cpp
+#include "src/client/render/terrain/TerrainRenderSelection.h"
+
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::render::ShouldDrawLegacyTerrain;
+
+	// Carte heightmap-only : aucun chunk dessiné -> on DOIT dessiner le legacy.
+	void Test_NoChunks_DrawsLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(/*legacyValid=*/true, /*hasLoadPass=*/true, /*chunkCount=*/0u) == true);
+	}
+
+	// Carte chunkée : des chunks dessinés -> on N'AFFICHE PAS le legacy (anti z-fight).
+	void Test_ChunksCover_HidesLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, true, 5u) == false);
+	}
+
+	// Borne : un seul chunk suffit à masquer le legacy.
+	void Test_OneChunk_HidesLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, true, 1u) == false);
+	}
+
+	// Legacy invalide -> jamais dessiné, peu importe le reste.
+	void Test_LegacyInvalid_NeverDraws()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(false, true, 0u) == false);
+	}
+
+	// Pas de LOAD pass disponible -> on ne dessine pas le legacy ici.
+	void Test_NoLoadPass_NeverDraws()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, false, 0u) == false);
+	}
+}
+
+int main()
+{
+	Test_NoChunks_DrawsLegacy();
+	Test_ChunksCover_HidesLegacy();
+	Test_OneChunk_HidesLegacy();
+	Test_LegacyInvalid_NeverDraws();
+	Test_NoLoadPass_NeverDraws();
+
+	if (g_failed == 0)
+		std::printf("[OK] TerrainRenderSelectionTests: tous les cas passent\n");
+	return g_failed;
+}
+```
+
+- [ ] **Step 2: Vérifier que le test échoue (header absent)**
+
+Le test ne compile pas tant que `TerrainRenderSelection.h` n'existe pas. En CI, l'étape de build du test échouera avec « fichier introuvable » / `ShouldDrawLegacyTerrain` non déclaré. C'est l'échec attendu.
+
+Localement (pas de build) : impossible — on s'appuie sur la CI. Ne pas committer avant le Step 3 (le repo doit rester compilable).
+
+- [ ] **Step 3: Écrire l'implémentation minimale**
+
+Create `src/client/render/terrain/TerrainRenderSelection.h` :
+
+```cpp
+#pragma once
+
+// src/client/render/terrain/TerrainRenderSelection.h
+//
+// Phase 0 du chantier C (unification terrain). Décision pure : faut-il
+// dessiner le terrain heightmap legacy (`TerrainRenderer`) cette frame ?
+//
+// Contexte : deux terrains coexistent (heightmap legacy + chunks data-driven).
+// Les dessiner ensemble crée du z-fighting (triangles scintillants au sol).
+// On rend donc le legacy EXCLUSIF : il n'est dessiné que si les chunks ne
+// couvrent pas la scène (carte heightmap-only, ou chunks pas encore streamés).
+//
+// Fonction pure, sans état ni dépendance Vulkan -> unit-testable.
+
+#include <cstdint>
+
+namespace engine::render
+{
+	/// Retourne true si le terrain heightmap legacy doit être dessiné cette frame.
+	///
+	/// \param legacyTerrainValid  `TerrainRenderer::IsValid()` — une heightmap est chargée.
+	/// \param geometryHasLoadPass `GeometryPass::HasLoadPass()` — la passe LOAD est dispo.
+	/// \param lastFrameChunkDrawCount Nombre de chunks réellement dessinés à la frame
+	///        précédente (0 si le renderer chunk est invalide ou n'a rien dessiné).
+	/// \return true si on dessine le legacy ; false si les chunks couvrent la scène
+	///         (>0 chunk dessiné), pour éviter le z-fighting / l'overdraw.
+	inline bool ShouldDrawLegacyTerrain(bool legacyTerrainValid,
+		bool geometryHasLoadPass,
+		std::uint32_t lastFrameChunkDrawCount)
+	{
+		const bool chunksCoveredScene = lastFrameChunkDrawCount > 0u;
+		return legacyTerrainValid && geometryHasLoadPass && !chunksCoveredScene;
+	}
+}
+```
+
+- [ ] **Step 4: Enregistrer le test dans CMake**
+
+Dans `CMakeLists.txt`, juste après le bloc `entity_influence_tests` (la ligne `add_test(NAME entity_influence_tests COMMAND entity_influence_tests)`, ~ligne 1038), ajouter :
+
+```cmake
+add_executable(terrain_render_selection_tests src/client/render/tests/TerrainRenderSelectionTests.cpp)
+add_test(NAME terrain_render_selection_tests COMMAND terrain_render_selection_tests)
+```
+
+(Header-only sans dépendance : aucune `target_link_libraries` nécessaire, comme les autres tests purs du repo. Le chemin d'include `src/...` est résolu depuis la racine du projet, conformément aux tests existants p.ex. `WaterMeshGpuTests.cpp`.)
+
+- [ ] **Step 5: Vérifier que le test passe (CI)**
+
+Pousser la branche et laisser la CI Linux compiler + exécuter ctest.
+Attendu : `terrain_render_selection_tests` PASS (sortie `[OK] TerrainRenderSelectionTests: tous les cas passent`, code retour 0).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/client/render/terrain/TerrainRenderSelection.h \
+        src/client/render/tests/TerrainRenderSelectionTests.cpp \
+        CMakeLists.txt
+git commit -m "test(terrain): fonction pure ShouldDrawLegacyTerrain (Phase 0)"
+```
+
+---
+
+### Task 2: Compteur de chunks dessinés dans `TerrainChunkRenderer`
+
+**Files:**
+- Modify: `src/client/render/terrain_chunk/TerrainChunkRenderer.h` (ajout getter + membre)
+- Modify: `src/client/render/terrain_chunk/TerrainChunkRenderer.cpp:1038-1133` (reset + incrément dans `RenderVisibleChunks`)
+
+> Pas de test unitaire : `RenderVisibleChunks` est couplé à Vulkan (device, descriptor pool, command buffer). Vérification = compilation CI + validation en jeu (Task 4). La logique décisionnelle, elle, est couverte par le test pur de la Task 1.
+
+- [ ] **Step 1: Ajouter le getter et le membre dans le header**
+
+Dans `src/client/render/terrain_chunk/TerrainChunkRenderer.h`, juste après la méthode `IsValid()` (actuellement lignes 208-211, fin du commentaire + `bool IsValid() const { return m_pipeline.IsValid(); }`), ajouter :
+
+```cpp
+		/// Nombre de chunks réellement dessinés lors du dernier appel à
+		/// `RenderVisibleChunks` (hors chunks skippés faute de terrain.bin/
+		/// splat.bin/descriptor). Remis à zéro au début de chaque appel.
+		/// Utilisé par l'Engine pour décider du rendu exclusif terrain
+		/// legacy vs chunks (anti z-fighting, Phase 0 chantier C).
+		std::uint32_t GetLastDrawnChunkCount() const { return m_lastDrawnChunkCount; }
+```
+
+Puis, dans la section `private:` (après le membre `m_slotToCoord` à la ligne 231, ou à côté des autres compteurs/états), ajouter :
+
+```cpp
+		// Compteur de chunks dessinés au dernier RenderVisibleChunks (Phase 0).
+		std::uint32_t m_lastDrawnChunkCount = 0u;
+```
+
+(`<cstdint>` est déjà inclus ligne 35.)
+
+- [ ] **Step 2: Reset du compteur en tête de `RenderVisibleChunks`**
+
+Dans `src/client/render/terrain_chunk/TerrainChunkRenderer.cpp`, au tout début de `RenderVisibleChunks` (juste après l'ouverture `{` ligne 1042, AVANT les gardes `if (!IsValid() ...) return;`), ajouter :
+
+```cpp
+	// Phase 0 : remis à zéro à chaque appel pour que tout retour anticipé
+	// (renderer invalide, PBR non chargé) laisse un compte de 0.
+	m_lastDrawnChunkCount = 0u;
+```
+
+- [ ] **Step 3: Incrémenter après chaque draw émis**
+
+Toujours dans `RenderVisibleChunks`, juste après l'émission du draw `m_pipeline.RecordChunkDraw(...)` (ligne 1131), avant la fermeture `}` de la boucle `for` (ligne 1132), ajouter :
+
+```cpp
+			++m_lastDrawnChunkCount;
+```
+
+(Placé après `RecordChunkDraw` : tous les `continue` au-dessus — fichier absent, mesh/splat/descriptor échoués — sortent de l'itération sans incrémenter, donc seul un draw réellement émis compte.)
+
+- [ ] **Step 4: Vérifier la compilation (CI)**
+
+Pousser ; la CI compile `engine_app` + `world_editor_app`. Attendu : build OK (changement additif, pas de site d'appel cassé — le getter est nouveau et le comportement existant inchangé tant que personne ne le lit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/client/render/terrain_chunk/TerrainChunkRenderer.h \
+        src/client/render/terrain_chunk/TerrainChunkRenderer.cpp
+git commit -m "feat(terrain): TerrainChunkRenderer expose GetLastDrawnChunkCount (Phase 0)"
+```
+
+---
+
+### Task 3: Câbler le gating exclusif dans `Engine`
+
+**Files:**
+- Modify: `src/client/app/Engine.h` (membre `m_lastFrameChunkDrawCount`)
+- Modify: `src/client/app/Engine.cpp` (include + gating ligne 5070-5071 + mise à jour du compteur après le bloc chunk ~5305)
+
+> Pas de test unitaire (couplé Engine/Vulkan). Vérification = compilation CI + validation en jeu (Task 4).
+
+- [ ] **Step 1: Ajouter le membre dans `Engine.h`**
+
+Dans `src/client/app/Engine.h`, à côté de la déclaration `m_terrainChunkRenderer` (ligne 983), ajouter :
+
+```cpp
+		// Phase 0 (chantier C) : nombre de chunks dessinés à la frame précédente.
+		// Lu par le gating terrain legacy (rendu exclusif anti z-fighting).
+		// Remis à jour chaque frame à la fin du bloc de dessin des chunks.
+		std::uint32_t m_lastFrameChunkDrawCount = 0u;
+```
+
+(`<cstdint>` : vérifier qu'il est inclus dans `Engine.h` ; sinon les `uint32_t` déjà présents dans le fichier confirment sa disponibilité transitive — ne rien ajouter si d'autres `uint32_t` membres existent déjà.)
+
+- [ ] **Step 2: Inclure le header de décision dans `Engine.cpp`**
+
+Dans `src/client/app/Engine.cpp`, dans le bloc d'includes en tête de fichier (à côté des autres `#include "src/client/render/..."`), ajouter :
+
+```cpp
+#include "src/client/render/terrain/TerrainRenderSelection.h"
+```
+
+- [ ] **Step 3: Remplacer le gating du terrain legacy**
+
+Dans `src/client/app/Engine.cpp`, remplacer les lignes 5070-5071 :
+
+```cpp
+												const bool terrainBeforeGeometry = m_terrain.IsValid()
+													&& m_pipeline->GetGeometryPass().HasLoadPass();
+```
+
+par :
+
+```cpp
+												// Phase 0 (chantier C) : rendu exclusif. On ne dessine le terrain
+												// heightmap legacy que si les chunks n'ont pas couvert la scène à la
+												// frame précédente -> supprime le z-fighting du double terrain.
+												const bool terrainBeforeGeometry = engine::render::ShouldDrawLegacyTerrain(
+													m_terrain.IsValid(),
+													m_pipeline->GetGeometryPass().HasLoadPass(),
+													m_lastFrameChunkDrawCount);
+```
+
+- [ ] **Step 4: Mettre à jour le compteur après le bloc de dessin des chunks**
+
+Dans `src/client/app/Engine.cpp`, le bloc de dessin des chunks va de la ligne 5285 (`if (m_terrainChunkRenderer && m_terrainChunkRenderer->IsValid())`) à 5305 (`}` fermant ce `if`). Remplacer ce bloc :
+
+```cpp
+												if (m_terrainChunkRenderer && m_terrainChunkRenderer->IsValid())
+												{
+													UpdateTerrainChunkCameraUbo(rs.viewProjMatrix.m);
+													const std::vector<engine::world::GlobalChunkCoord> visibleChunks =
+														m_world.GetActiveAndVisibleChunks();
+													if (!visibleChunks.empty())
+													{
+														m_pipeline->GetGeometryPass().RecordTerrainChunkBatch(
+															m_vkDeviceContext.GetDevice(), cmd, reg,
+															m_vkSwapchain.GetExtent(),
+															m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId,
+															m_fgGBufferVelocityId, m_fgDepthId,
+															[this, &visibleChunks](VkCommandBuffer innerCmd) {
+																m_terrainChunkRenderer->RenderVisibleChunks(
+																	innerCmd,
+																	m_terrainChunkCameraSet,
+																	m_world,
+																	visibleChunks);
+															});
+													}
+												}
+```
+
+par (ajout de la capture du compte en fin de bloc) :
+
+```cpp
+												std::uint32_t chunksDrawnThisFrame = 0u;
+												if (m_terrainChunkRenderer && m_terrainChunkRenderer->IsValid())
+												{
+													UpdateTerrainChunkCameraUbo(rs.viewProjMatrix.m);
+													const std::vector<engine::world::GlobalChunkCoord> visibleChunks =
+														m_world.GetActiveAndVisibleChunks();
+													if (!visibleChunks.empty())
+													{
+														m_pipeline->GetGeometryPass().RecordTerrainChunkBatch(
+															m_vkDeviceContext.GetDevice(), cmd, reg,
+															m_vkSwapchain.GetExtent(),
+															m_fgGBufferAId, m_fgGBufferBId, m_fgGBufferCId,
+															m_fgGBufferVelocityId, m_fgDepthId,
+															[this, &visibleChunks](VkCommandBuffer innerCmd) {
+																m_terrainChunkRenderer->RenderVisibleChunks(
+																	innerCmd,
+																	m_terrainChunkCameraSet,
+																	m_world,
+																	visibleChunks);
+															});
+														chunksDrawnThisFrame = m_terrainChunkRenderer->GetLastDrawnChunkCount();
+													}
+												}
+												// Phase 0 : mémorise pour le gating legacy de la frame SUIVANTE.
+												// Remis à 0 chaque frame (carte heightmap-only / chunks non visibles
+												// -> le legacy redevient visible sans rester "collé" éteint).
+												m_lastFrameChunkDrawCount = chunksDrawnThisFrame;
+```
+
+- [ ] **Step 5: Vérifier la compilation (CI)**
+
+Pousser ; la CI compile `engine_app` + `world_editor_app` et exécute ctest (dont `terrain_render_selection_tests` de la Task 1).
+Attendu : build OK + tous les tests verts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(terrain): rendu exclusif legacy/chunks via gating (Phase 0, chantier C)"
+```
+
+---
+
+### Task 4: Validation en jeu
+
+**Files:** aucun (validation manuelle).
+
+> Le rendu ne peut pas être validé par un test automatisé. Cette tâche est manuelle, à faire par l'utilisateur (ou en session de test sur build CI).
+
+- [ ] **Step 1: Lancer le jeu sur une carte chunkée**
+
+Lancer le client sur une zone disposant de chunks `terrain.bin` + `splat.bin`. Déplacer le personnage (pas à gauche/droite).
+Attendu : **plus de triangles scintillants au sol** ; le terrain ne « clignote » plus quand la caméra bouge.
+
+- [ ] **Step 2: Vérifier la non-régression heightmap-only**
+
+Lancer sur une carte sans chunks (heightmap legacy uniquement).
+Attendu : le terrain reste visible et correct (le legacy n'est PAS éteint, car `m_lastFrameChunkDrawCount == 0`).
+
+- [ ] **Step 3: Vérifier la transition zone chunkée -> zone heightmap**
+
+Faire traverser au personnage une frontière entre zone chunkée et zone heightmap-only (si une telle carte existe).
+Attendu : pas de disparition durable du terrain (le compteur est remis à 0 quand aucun chunk n'est dessiné -> le legacy réapparaît).
+
+---
+
+## Self-Review
+
+**Couverture spec (Phase 0) :**
+- « Exposer le nombre de chunks réellement dessinés » → Task 2. ✅
+- « Éteindre le legacy quand des chunks sont dessinés (gating `Engine.cpp:5070`) » → Task 3. ✅
+- « Vérifier que `terrainBeforeGeometry=false` n'empêche pas l'ouverture du render-pass LOAD » → géré : `terrainBeforeGeometry` reste un `bool` passé à `RecordIndirect`/`Record` (lignes 5117/5130) exactement comme avant ; seule sa **valeur** change. Le comportement d'ouverture du LOAD pass par `Record`/`RecordIndirect` quand le flag est faux est inchangé. ✅ (À confirmer en jeu, Task 4.)
+- Comportements carte chunkée / heightmap-only / mixte → couverts par les tests purs (Task 1) + validation (Task 4). ✅
+
+**Scan placeholders :** aucun TBD/TODO ; tout le code est fourni intégralement. ✅
+
+**Cohérence des types :** la fonction `ShouldDrawLegacyTerrain(bool, bool, std::uint32_t)` a la même signature en Task 1 (définition + test) et Task 3 (appel). Le getter `GetLastDrawnChunkCount()` (Task 2) retourne `std::uint32_t`, consommé en `std::uint32_t` (Task 3). Le membre `m_lastFrameChunkDrawCount` (Engine) et `m_lastDrawnChunkCount` (renderer) sont distincts et nommés sans ambiguïté. ✅
+
+**Latence d'une frame :** assumée et documentée — au pire, un frame de double-dessin lors de la toute première apparition des chunks, invisible à l'œil. Le reset par frame empêche tout état « collé ». ✅

--- a/docs/superpowers/specs/2026-06-05-unification-terrain-design.md
+++ b/docs/superpowers/specs/2026-06-05-unification-terrain-design.md
@@ -1,0 +1,152 @@
+# Spec — Unification du terrain (chantier C)
+
+**Date** : 2026-06-05
+**Statut** : conception validée, en attente de relecture utilisateur avant plan d'implémentation
+**Origine** : audit du moteur de rendu (`docs/audit/2026-06-05-moteur-rendu-client.md`), symptôme rapporté en jeu (triangles scintillants au sol quand le personnage se déplace).
+**Portée** : client uniquement. Aucun changement protocole / handler / DB → **pas de redéploiement serveur**.
+
+---
+
+## 1. Problème
+
+Deux systèmes terrain tournent **simultanément** dans le client de jeu :
+
+- `terrain/TerrainRenderer` — heightmap legacy (`.r16h`), dessiné inconditionnellement (`Engine.cpp:5074`).
+- `terrain_chunk/TerrainChunkRenderer` — chunks data-driven (`terrain.bin`), dessiné par-dessus (`Engine.cpp:5285-5305`), **sans éteindre le legacy**.
+
+Deux conséquences, confirmées par investigation :
+
+### 1.1 Z-fighting (symptôme visible)
+Les deux terrains écrivent dans le même depth buffer (`m_fgDepthId`), sur des surfaces quasi-coplanaires mais à des hauteurs calculées différemment (heightmap `× height_scale` vs `terrain.bin` brut). Le départage de profondeur bascule selon la position caméra → des plaques triangulaires apparaissent/disparaissent à chaque déplacement. **C'est le bug rapporté par l'utilisateur.**
+
+États depth : legacy `LESS` (`TerrainRenderer.cpp:551-553`), chunk `LESS_OR_EQUAL` (`TerrainChunkPipeline.cpp:294-296`), aucun depthBias.
+
+### 1.2 Collision ≠ rendu (défaut de fond)
+100 % du gameplay (collision, spawn, snap-au-sol, avatar éditeur) lit la **heightmap legacy** via `TerrainCollider` → `TerrainRenderer::SampleHeightAtWorldXZ` (`TerrainCollider.cpp:29-32`). Le système chunks **n'a aucun consommateur de hauteur**. En zone chunkée, le joueur marche donc sur la heightmap pendant que ses yeux voient les chunks (cause profonde du fix partiel PR #824).
+
+### 1.3 Cause racine annexe — taille de chunk incohérente (bug)
+Une seule constante `kChunkSize = 500 m` (`WorldModel.h:15`) sert deux grilles distinctes :
+- **Grille instances / streaming / zone** : 500 m, choisie car elle divise `kZoneSize = 10000` (512 ne le fait pas). **Légitime.**
+- **Grille du mesh terrain** : devrait être 256 m (= `(kTerrainResolution-1) × kTerrainCellSizeMeters` = 256×1, `TerrainChunk.h:15-19`). Mais `TerrainChunkRenderer.cpp:1129-1130` réutilise par erreur la constante 500 pour placer le mesh terrain.
+
+Résultat : chunks voisins placés à 0 m et 500 m, meshes ne couvrant que 256 m → **trou de 244 m**. L'éditeur, lui, place déjà les chunks à 256 m (`Engine.cpp:12169-12170`) → divergence silencieuse éditeur↔jeu. Confirmé par l'historique git (256→500 introduit pour le streaming ; mesh 256 arrivé après avec un commentaire d'alignement erroné) et par le fait que le binning d'instances (zone_builder, partition serveur) est le seul usage légitime de 500.
+
+---
+
+## 2. Décisions validées
+
+- **Destination** : chunk-canonique (les chunks deviennent la source de vérité unique du terrain — collision ET rendu), alignée sur ce que l'éditeur fait déjà (`TerrainDocument.h:74-79` : « les chunks sont la source de vérité, le r16h n'est qu'un cache GPU »).
+- **Trajectoire** : **phasée**, jeu jouable à chaque étape.
+- **Taille de chunk** : ne pas « choisir 256 ou 500 » — **séparer les deux constantes** et router la grille terrain sur 256, en laissant le binning d'instances sur 500.
+
+---
+
+## 3. Conception — 4 phases
+
+### Phase 0 — Correctif minimal (rendu exclusif)
+**But** : faire disparaître le z-fighting immédiatement, sans rien unifier.
+
+- Exposer le nombre de chunks réellement dessinés depuis `TerrainChunkRenderer` (compteur des `RecordChunkDraw`, `TerrainChunkRenderer.cpp:1131`) via un `GetLastDrawnChunkCount()`.
+- À `Engine.cpp:5070`, éteindre le legacy quand des chunks sont dessinés :
+  ```cpp
+  const bool chunksCoverScene =
+      m_terrainChunkRenderer && m_terrainChunkRenderer->IsValid()
+      && m_terrainChunkRenderer->GetLastDrawnChunkCount() > 0;
+  const bool terrainBeforeGeometry = m_terrain.IsValid()
+      && m_pipeline->GetGeometryPass().HasLoadPass()
+      && !chunksCoverScene;
+  ```
+
+**Comportement** : carte 100 % chunks → legacy éteint (z-fight + overdraw supprimés) ; carte 100 % heightmap → legacy conservé (fallback intact) ; carte mixte → seul cas ambigu, déjà cassé aujourd'hui de toute façon.
+
+**Vérifier** : que mettre `terrainBeforeGeometry=false` n'empêche pas l'ouverture du render-pass LOAD (RecordIndirect/Record gère l'ouverture quand le flag est faux ; les chunks rouvrent le LOAD pass via `RecordTerrainChunkBatch`).
+
+**Risque** : faible. Livrable indépendant.
+
+### Phase 1 — Réconcilier la taille de chunk
+**But** : aligner la grille terrain du jeu sur celle de l'éditeur (256 m), supprimer le trou de 244 m.
+
+- Introduire une constante terrain dédiée : `kTerrainChunkSizeMeters = (kTerrainResolution - 1) * kTerrainCellSizeMeters` (= 256).
+- Router sur cette constante terrain :
+  - placement du mesh : `TerrainChunkRenderer.cpp:1129-1130` ;
+  - conversion monde→coord terrain et bounds : `WorldModel.cpp:17-18, 33-36` ;
+  - centre de chunk pour la priorité de streaming : `StreamingScheduler.cpp:31-32`.
+- Renommer `kChunkSize` (500) en une constante explicitement « instances/zone » (ex. `kInstanceChunkSizeMeters`) ; conserver son usage dans zone_builder / partition serveur / binning d'instances.
+- Ajuster le `static_assert(kZoneSize % kChunkSize == 0)` : la grille terrain (256) n'a pas à diviser `kZoneSize` ; seul le binning d'instances (500) garde cette contrainte.
+- Référence d'implémentation : `Engine.cpp:12169-12170` (éditeur, déjà correct).
+
+**Résultat** : jeu et éditeur affichent le terrain au même endroit, sans trou. Pré-requis d'une requête monde→chunk fiable (Phase 2).
+
+**Risque** : moyen — touche au streaming/culling. Tester qu'aucun chunk ne manque/double au franchissement de frontière.
+
+### Phase 2 — `IHeightField` + collision sur les chunks
+**But** : la collision lit la même source que le rendu → on marche sur le terrain qu'on voit.
+
+- Interface minimale :
+  ```cpp
+  struct IHeightField {
+    virtual float HeightAt(float worldX, float worldZ) const = 0;   // tous consommateurs
+    virtual bool  IsLoadedAt(float worldX, float worldZ) const = 0; // streaming chunks
+    virtual ~IHeightField() = default;
+  };
+  ```
+- `ChunkHeightField` : `(worldX,worldZ)` → `GlobalChunkCoord` + offset local (avec la constante terrain de la Phase 1) → `StreamCache::LoadTerrainChunk(coord)` → `TerrainChunk::SampleHeight(localX, localZ)` (bilinéaire, déjà existant `TerrainChunk.cpp:19`). `IsLoadedAt` = chunk résident.
+- `HeightmapHeightField` : wrappe `TerrainRenderer::SampleHeightAtWorldXZ`. `IsLoadedAt` = (x,z) dans les bornes. Sert de fallback.
+- Rebrancher `TerrainCollider` : remplacer le `const TerrainRenderer*` par un `const IHeightField*` (`TerrainCollider.cpp:29, 72`). Pointer sur `ChunkHeightField` avec repli `HeightmapHeightField` quand `!IsLoadedAt`.
+- Transitivement rebranchés (via le collider) : spawn (`Engine.cpp:5006, 7933-7935`), snap entités (`9587, 10613, 10682, 10807`), reserve (`4897`), avatar éditeur (`9165`).
+
+**Contrats / décisions** :
+- Éviction LRU : on ne sample la hauteur que près du joueur → chunk toujours résident. Si `!IsLoadedAt` (cas limite), repli heightmap ; ne **jamais** déclencher de lecture disque synchrone dans le chemin de collision.
+- Thread-safety : la collision tourne en main-thread (cohérent avec `StreamCache`/`ChunkRuntime` main-thread-only). Aucune query hors main-thread introduite.
+- Hors périmètre : `NormalAt`/`WorldBounds` (aucun consommateur actuel — à ajouter quand un besoin réel apparaît) ; le footstep/splat (`SplatSampling`, `FootstepAudioSurfaceHook`) relève du **type de surface**, pas de la hauteur → domaine séparé, non traité ici.
+
+**Risque** : moyen. C'est le cœur du chantier.
+
+### Phase 3 — Retirer la heightmap legacy du chemin de jeu
+**But** : éliminer définitivement la dualité.
+
+- Une fois les chunks canoniques et les cartes pourvues de `terrain.bin`, sortir `TerrainRenderer` du rendu de jeu. Conserver au plus la reconstruction côté éditeur si elle reste utile, sinon supprimer.
+- Supprimer le code mort associé (cf. audit).
+
+**Dépendance** : migration des cartes existantes vers `terrain.bin` (Feyhin Lokcthat n'a pas encore de `terrain.bin` — `game/data/zones/demo_plains` n'a que `chunk.meta`+`instances.bin`). Cette migration de contenu est un pré-requis de la Phase 3, pas des phases 0-2.
+
+**Risque** : élevé tant que la migration de contenu n'est pas faite → à ne déclencher qu'après validation des phases 0-2 en jeu.
+
+---
+
+## 4. Découpage de livraison & ordre de merge
+
+| Phase | Livrable | Dépend de | Risque | Mergeable seul |
+|---|---|---|---|---|
+| 0 | Rendu exclusif (gating) | — | faible | ✅ oui (soulage le symptôme) |
+| 1 | Constante terrain 256 séparée | — (indépendant de 0) | moyen | ✅ oui |
+| 2 | `IHeightField` + collision chunks | Phase 1 | moyen | après Phase 1 |
+| 3 | Retrait heightmap legacy | Phase 2 + migration cartes | élevé | en dernier |
+
+Recommandation : livrer **Phase 0** d'abord (PR isolée, gain immédiat), puis **Phase 1**, puis **Phase 2**. **Phase 3** seulement après validation en jeu des précédentes et migration de contenu.
+
+---
+
+## 5. Validation
+
+- **Phase 0** : en jeu, le scintillement triangulaire au sol disparaît en zone chunkée ; le terrain reste visible (pas de trou) sur carte heightmap-only.
+- **Phase 1** : jeu et éditeur affichent le terrain aux mêmes coordonnées monde ; pas de trou entre chunks voisins ; streaming sans chunk manquant/dupliqué aux frontières.
+- **Phase 2** : le personnage marche exactement sur la surface visible en zone chunkée (plus de décalage hauteur) ; spawn/snap corrects.
+- **Phase 3** : aucune régression visuelle/collision après retrait du legacy sur cartes migrées.
+- Build validé via CI Windows (pas de toolchain local).
+- **Convention `CLAUDE.md` (winding/culling)** : aucune phase ne touche `frontFace`/`cullMode` — non négociable.
+
+---
+
+## 6. Fichiers clés
+
+- `src/client/app/Engine.cpp` — passe Geometry (`5059-5305`), gate Phase 0 (`5070`), consommateurs hauteur, placement éditeur de référence (`12169-12170`).
+- `src/client/render/terrain_chunk/TerrainChunkRenderer.{h,cpp}` — placement (`1129-1130`), à exposer `GetLastDrawnChunkCount()`.
+- `src/client/world/WorldModel.{h,cpp}` — constantes + conversion monde→coord + bounds.
+- `src/client/world/terrain/TerrainChunk.{h,cpp}` — `SampleHeight` (`19`), résolution/cellule (`15-19`).
+- `src/client/render/terrain/TerrainRenderer.{h,cpp}` — sampling legacy (`1311`), états pipeline (`551-553`).
+- `src/client/render/TerrainChunkPipeline.cpp` — état depth chunk (`294-296`).
+- `src/client/gameplay/TerrainCollider.cpp` — à rebrancher sur `IHeightField` (`29, 72`).
+- `src/client/world/StreamingScheduler.cpp` — centre chunk (`31-32`).
+
+**Déploiement** : ✅ client uniquement à toutes les phases — **pas de redéploiement serveur**.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -55,6 +55,7 @@
 #include "src/client/render/ShaderCompiler.h"
 #include "src/client/render/terrain/HeightmapLoader.h"
 #include "src/client/render/terrain/TerrainEditingTools.h"
+#include "src/client/render/terrain/TerrainRenderSelection.h"
 #include "src/client/character_creation/CharacterCreationUi.h"
 #include "src/shared/network/ServerProtocol.h"
 
@@ -5067,8 +5068,13 @@ namespace engine
 											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
 												const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
 												const engine::RenderState& rs = m_renderStates[readIdx];
-												const bool terrainBeforeGeometry = m_terrain.IsValid()
-													&& m_pipeline->GetGeometryPass().HasLoadPass();
+												// Phase 0 (chantier C) : rendu exclusif. On ne dessine le terrain
+												// heightmap legacy que si les chunks n'ont pas couvert la scène à la
+												// frame précédente -> supprime le z-fighting du double terrain.
+												const bool terrainBeforeGeometry = engine::render::ShouldDrawLegacyTerrain(
+													m_terrain.IsValid(),
+													m_pipeline->GetGeometryPass().HasLoadPass(),
+													m_lastFrameChunkDrawCount);
 												if (terrainBeforeGeometry)
 												{
 													m_terrain.Record(
@@ -5282,6 +5288,7 @@ namespace engine
 												// TerrainRenderer continue à les dessiner). PAS de branche
 												// m_editorEnabled — parité jeu/éditeur garantie par le format
 												// binaire identique (cf. critère M100.5/.9).
+												std::uint32_t chunksDrawnThisFrame = 0u;
 												if (m_terrainChunkRenderer && m_terrainChunkRenderer->IsValid())
 												{
 													UpdateTerrainChunkCameraUbo(rs.viewProjMatrix.m);
@@ -5301,8 +5308,13 @@ namespace engine
 																	m_world,
 																	visibleChunks);
 															});
+														chunksDrawnThisFrame = m_terrainChunkRenderer->GetLastDrawnChunkCount();
 													}
 												}
+												// Phase 0 : mémorise pour le gating legacy de la frame SUIVANTE.
+												// Remis à 0 chaque frame (carte heightmap-only / chunks non visibles
+												// -> le legacy redevient visible sans rester "collé" éteint).
+												m_lastFrameChunkDrawCount = chunksDrawnThisFrame;
 
 												// Phase 5 Lunar + M38.1 Sky : enregistre le draw fullscreen-quad
 												// du SkyPass (ciel + disque lunaire procedural) dans le render

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -981,6 +981,10 @@ namespace engine
 		/// M100 — Task 12 : runtime mesh-terrain par chunk avec splat 8-layer.
 		/// Cohabite avec `m_terrain` legacy : skippe les chunks sans terrain.bin/splat.bin.
 		std::unique_ptr<engine::render::terrain_chunk::TerrainChunkRenderer> m_terrainChunkRenderer;
+		// Phase 0 (chantier C) : nombre de chunks dessinés à la frame précédente.
+		// Lu par le gating terrain legacy (rendu exclusif anti z-fighting).
+		// Remis à jour chaque frame à la fin du bloc de dessin des chunks.
+		std::uint32_t m_lastFrameChunkDrawCount = 0u;
 		/// M100 — Task 12 : descriptor set layout pour le set 0 caméra
 		/// (UBO `CameraUBO { mat4 viewProj; }`) du `TerrainChunkPipeline`.
 		VkDescriptorSetLayout m_terrainChunkCameraSetLayout = VK_NULL_HANDLE;

--- a/src/client/render/terrain/TerrainRenderSelection.h
+++ b/src/client/render/terrain/TerrainRenderSelection.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// src/client/render/terrain/TerrainRenderSelection.h
+//
+// Phase 0 du chantier C (unification terrain). Décision pure : faut-il
+// dessiner le terrain heightmap legacy (`TerrainRenderer`) cette frame ?
+//
+// Contexte : deux terrains coexistent (heightmap legacy + chunks data-driven).
+// Les dessiner ensemble crée du z-fighting (triangles scintillants au sol).
+// On rend donc le legacy EXCLUSIF : il n'est dessiné que si les chunks ne
+// couvrent pas la scène (carte heightmap-only, ou chunks pas encore streamés).
+//
+// Fonction pure, sans état ni dépendance Vulkan -> unit-testable.
+
+#include <cstdint>
+
+namespace engine::render
+{
+	/// Retourne true si le terrain heightmap legacy doit être dessiné cette frame.
+	///
+	/// \param legacyTerrainValid  `TerrainRenderer::IsValid()` — une heightmap est chargée.
+	/// \param geometryHasLoadPass `GeometryPass::HasLoadPass()` — la passe LOAD est dispo.
+	/// \param lastFrameChunkDrawCount Nombre de chunks réellement dessinés à la frame
+	///        précédente (0 si le renderer chunk est invalide ou n'a rien dessiné).
+	/// \return true si on dessine le legacy ; false si les chunks couvrent la scène
+	///         (>0 chunk dessiné), pour éviter le z-fighting / l'overdraw.
+	inline bool ShouldDrawLegacyTerrain(bool legacyTerrainValid,
+		bool geometryHasLoadPass,
+		std::uint32_t lastFrameChunkDrawCount)
+	{
+		const bool chunksCoveredScene = lastFrameChunkDrawCount > 0u;
+		return legacyTerrainValid && geometryHasLoadPass && !chunksCoveredScene;
+	}
+}

--- a/src/client/render/terrain_chunk/TerrainChunkRenderer.cpp
+++ b/src/client/render/terrain_chunk/TerrainChunkRenderer.cpp
@@ -1040,6 +1040,10 @@ namespace engine::render::terrain_chunk
 		const engine::world::World& world,
 		const std::vector<engine::world::GlobalChunkCoord>& visibleChunks)
 	{
+		// Phase 0 : remis à zéro à chaque appel pour que tout retour anticipé
+		// (renderer invalide, PBR non chargé) laisse un compte de 0.
+		m_lastDrawnChunkCount = 0u;
+
 		if (!IsValid() || cmd == VK_NULL_HANDLE || cameraSet == VK_NULL_HANDLE
 			|| m_streamCache == nullptr || m_config == nullptr)
 			return;
@@ -1129,6 +1133,7 @@ namespace engine::render::terrain_chunk
 			const float originX = static_cast<float>(engine::world::kChunkSize) * coord.x;
 			const float originZ = static_cast<float>(engine::world::kChunkSize) * coord.z;
 			m_pipeline.RecordChunkDraw(cmd, cameraSet, descSet, mesh, originX, 0.0f, originZ);
+			++m_lastDrawnChunkCount;
 		}
 	}
 

--- a/src/client/render/terrain_chunk/TerrainChunkRenderer.h
+++ b/src/client/render/terrain_chunk/TerrainChunkRenderer.h
@@ -210,6 +210,13 @@ namespace engine::render::terrain_chunk
 		/// vers le legacy.
 		bool IsValid() const { return m_pipeline.IsValid(); }
 
+		/// Nombre de chunks réellement dessinés lors du dernier appel à
+		/// `RenderVisibleChunks` (hors chunks skippés faute de terrain.bin/
+		/// splat.bin/descriptor). Remis à zéro au début de chaque appel.
+		/// Utilisé par l'Engine pour décider du rendu exclusif terrain
+		/// legacy vs chunks (anti z-fighting, Phase 0 chantier C).
+		std::uint32_t GetLastDrawnChunkCount() const { return m_lastDrawnChunkCount; }
+
 	private:
 		/// Charge la palette + uploade les 3 arrays PBR (8 layers chacun) +
 		/// crée les 2 samplers. Délégué depuis `Init` après que le
@@ -229,6 +236,9 @@ namespace engine::render::terrain_chunk
 		/// Track slot → coord pour libérer les bonnes entrées caches lors des
 		/// evictions (alternative à un getter ChunkRuntime::GetCoordForSlot).
 		std::unordered_map<ChunkSlotId, engine::world::GlobalChunkCoord> m_slotToCoord;
+
+		// Compteur de chunks dessinés au dernier RenderVisibleChunks (Phase 0).
+		std::uint32_t m_lastDrawnChunkCount = 0u;
 
 		// Composants principaux.
 		TerrainChunkPipeline m_pipeline;

--- a/src/client/render/tests/TerrainRenderSelectionTests.cpp
+++ b/src/client/render/tests/TerrainRenderSelectionTests.cpp
@@ -1,0 +1,61 @@
+// src/client/render/tests/TerrainRenderSelectionTests.cpp
+#include "src/client/render/terrain/TerrainRenderSelection.h"
+
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::render::ShouldDrawLegacyTerrain;
+
+	// Carte heightmap-only : aucun chunk dessiné -> on DOIT dessiner le legacy.
+	void Test_NoChunks_DrawsLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(/*legacyValid=*/true, /*hasLoadPass=*/true, /*chunkCount=*/0u) == true);
+	}
+
+	// Carte chunkée : des chunks dessinés -> on N'AFFICHE PAS le legacy (anti z-fight).
+	void Test_ChunksCover_HidesLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, true, 5u) == false);
+	}
+
+	// Borne : un seul chunk suffit à masquer le legacy.
+	void Test_OneChunk_HidesLegacy()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, true, 1u) == false);
+	}
+
+	// Legacy invalide -> jamais dessiné, peu importe le reste.
+	void Test_LegacyInvalid_NeverDraws()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(false, true, 0u) == false);
+	}
+
+	// Pas de LOAD pass disponible -> on ne dessine pas le legacy ici.
+	void Test_NoLoadPass_NeverDraws()
+	{
+		REQUIRE(ShouldDrawLegacyTerrain(true, false, 0u) == false);
+	}
+}
+
+int main()
+{
+	Test_NoChunks_DrawsLegacy();
+	Test_ChunksCover_HidesLegacy();
+	Test_OneChunk_HidesLegacy();
+	Test_LegacyInvalid_NeverDraws();
+	Test_NoLoadPass_NeverDraws();
+
+	if (g_failed == 0)
+		std::printf("[OK] TerrainRenderSelectionTests: tous les cas passent\n");
+	return g_failed;
+}


### PR DESCRIPTION
## Contexte

En jeu, des « triangles » scintillent au sol et changent quand le personnage se déplace. Diagnostic confirmé (confiance haute) : **z-fighting entre deux terrains rendus simultanément** — le `TerrainRenderer` heightmap legacy et le `TerrainChunkRenderer` chunké écrivent dans le même depth buffer sur des surfaces quasi-coplanaires à des hauteurs calculées différemment. Le legacy était dessiné **inconditionnellement** (`Engine.cpp:5070`), sans jamais être éteint là où des chunks existent.

C'est la **Phase 0** du chantier C (unification terrain). Elle soulage le symptôme sans encore unifier les deux systèmes (phases 1-3 à venir : réconciliation taille de chunk 256/500, `IHeightField` + collision sur les chunks, retrait du legacy).

## Changements

- **`ShouldDrawLegacyTerrain(...)`** (`render/terrain/TerrainRenderSelection.h`) : fonction pure de décision — le legacy n'est dessiné que si les chunks n'ont **pas** couvert la scène à la frame précédente. Unit-testée (`render/tests/TerrainRenderSelectionTests.cpp`, 5 cas).
- **`TerrainChunkRenderer::GetLastDrawnChunkCount()`** : compte les chunks réellement dessinés au dernier `RenderVisibleChunks` (reset par appel, incrément après chaque draw émis).
- **`Engine`** : mémorise ce compte par frame (`m_lastFrameChunkDrawCount`, remis à 0 chaque frame) et l'injecte dans le gating du terrain legacy. Latence d'1 frame assumée.

Comportement : carte 100 % chunks → legacy éteint (z-fight + overdraw supprimés) ; carte 100 % heightmap → legacy conservé (fallback) ; pas d'état « collé » éteint.

**Aucune modification de `frontFace`/`cullMode`/winding** (convention stricte respectée).

## Documentation incluse

- `docs/audit/2026-06-05-moteur-rendu-client.md` — audit complet du moteur.
- `docs/superpowers/specs/2026-06-05-unification-terrain-design.md` — spec du chantier C (4 phases).
- `docs/superpowers/plans/2026-06-05-terrain-phase0-rendu-exclusif.md` — plan d'implémentation.

## Plan de test

- [ ] CI : build Linux (+ ctest, dont `terrain_render_selection_tests`) et build Windows verts.
- [ ] En jeu (carte chunkée) : plus de triangles scintillants au sol en déplaçant le personnage.
- [ ] En jeu (carte heightmap-only) : terrain toujours visible (legacy non éteint).
- [ ] Transition zone chunkée → heightmap : pas de disparition durable du terrain.

## Limites connues (assumées Phase 0)

- 1 frame de double-terrain possible au streaming-in d'un chunk (transitoire).
- Scène **mixte** (chunks + heightmap visibles ensemble) non gérée : hypothèse « carte heightmap-only OU chunkée ».

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur** (rendu Vulkan, aucun opcode/handler/payload/migration/config serveur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)