### PR TITLE
feat(render): le soleil projette des ombres — branchement CSM dans lighting.frag (rebrancher le moteur)

### DIFF
--- a/config.json
+++ b/config.json
@@ -116,10 +116,13 @@
         }
     },
     "shadows": {
+        "enabled": true,
         "resolution": 1024,
         "depth_bias_constant": 1.25,
         "depth_bias_slope": 1.75,
-        "cull_front_faces": false
+        "cull_front_faces": false,
+        "bias_constant": 0.0015,
+        "bias_slope_max": 0.005
     },
     "bloom": {
         "threshold": 1.0,

--- a/docs/superpowers/plans/2026-06-05-ombres-csm.md
+++ b/docs/superpowers/plans/2026-06-05-ombres-csm.md
@@ -1,0 +1,530 @@
+# Ombres soleil CSM — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Échantillonner les 4 cascades CSM déjà rendues dans `lighting.frag` pour que le soleil projette de vraies ombres portées.
+
+**Architecture:** Les cascades sont transportées vers `lighting.frag` via un UBO host-visible (binding 11) + un sampler array de 4 shadow maps (binding 10). Le shader sélectionne la cascade par *containment*, applique un PCF 3×3 avec biais slope-scaled, et multiplie le seul terme soleil direct par la visibilité. Gating runtime via `shadows.enabled`.
+
+**Tech Stack:** C++17, Vulkan (descripteurs raw, sans VMA), GLSL 450 (recompilé en SPIR-V par la CI). **Pas de build local** (cmake/MSVC/vcpkg absents) : compile validée en CI Windows/Linux, SPIR-V régénéré par `tools/compile_game_shaders.ps1`, **rendu validé manuellement en jeu**.
+
+**Référence spec :** `docs/superpowers/specs/2026-06-05-ombres-csm-design.md`.
+
+**Portée :** client uniquement — **pas de redéploiement serveur**. Aucune modification `frontFace`/`cullMode`/winding.
+
+---
+
+## Ordre & cohérence
+
+Les 3 tâches code forment **un tout cohérent** (le contrat de binding 10/11 doit être identique entre shader et C++). Ordre : Task 1 (LightingPass fournit les ressources) → Task 2 (Engine remplit/passe) → Task 3 (shader consomme). Chaque commit compile ; la cohérence runtime n'est atteinte qu'après les 3 (une seule PR). Numéros de binding **figés** : 10 = `sampler2D uShadowMaps[4]`, 11 = UBO `ShadowUbo`.
+
+## File Structure
+
+- **Modify** `src/client/render/LightingPass.h` — struct `ShadowUbo`, membres (sampler + UBO host-visible), signature `Record`.
+- **Modify** `src/client/render/LightingPass.cpp` — layout (bindings 10/11), pool, sampler shadow, UBO host-visible/frame, écriture descripteurs, `Destroy`.
+- **Modify** `src/client/app/Engine.cpp` — pass "Lighting" : `b.read` cascades, remplir `ShadowUbo`, appeler `Record`.
+- **Modify** `game/data/shaders/lighting.frag` — bindings 10/11, `ShadowVisibility`, multiplication de `Lo`.
+
+---
+
+### Task 1: LightingPass — descripteurs shadow + UBO cascades (C++)
+
+**Files:** `src/client/render/LightingPass.h`, `src/client/render/LightingPass.cpp`
+
+Ajoute le **binding 10** (4 shadow maps, `COMBINED_IMAGE_SAMPLER` `descriptorCount=4`), le **binding 11** (UBO cascades), un UBO host-visible **par frame** (272 o), un sampler shadow, et étend `Record`. Repère pour l'UBO host-visible (raw Vulkan, sans VMA) : `SsaoKernelNoise.cpp:90-187`. `physicalDevice` est déjà reçu par `LightingPass::Init` (`LightingPass.cpp:87`, actuellement `/*physicalDevice*/`).
+
+> Vérification globale Task 1 : pas de build local → compile validée CI Windows. Auto-vérifs : `static_assert(sizeof(ShadowUbo)==272)` ; `maxSets` inchangé (`m_maxFrames`) ; `descriptorCount=4` du binding 10 = `uShadowMaps[4]` (Task 3) ; chaque échec appelle `Destroy(device)` avant `return false`.
+
+- [ ] **Step 1 — `LightingPass.h` : struct `ShadowUbo` + membres + signature `Record`.**
+
+Après la déclaration de `LightParams` (~`LightingPass.h:53`), ajouter :
+```cpp
+		/// CPU-side de l'UBO cascades (binding 11, std140). 4 lightViewProj (256 o)
+		/// + shadowParams (16 o) = 272 o. SÉPARÉ de LightParams (push-constant figé
+		/// à 224 o). shadowParams : x=useShadows(0/1), y=texelSize(1/résolution),
+		/// z=biasConstant, w=biasSlopeMax. Voir lighting.frag binding 11.
+		struct ShadowUbo
+		{
+			float lightViewProj[16 * 4]; ///< 4 matrices colonne-major (cascade 0..3), 256 o.
+			float shadowParams[4];       ///< x=useShadows, y=texelSize, z=biasConstant, w=biasSlopeMax.
+		};
+		static_assert(sizeof(ShadowUbo) == 272, "ShadowUbo must be exactly 272 bytes (256 + 16)");
+```
+Étendre la signature `Record` (`LightingPass.h:91-92`). **Avant :**
+```cpp
+			VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
+			const LightParams& params, uint32_t frameIndex);
+```
+**Après** (avec doc Doxygen) :
+```cpp
+			VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
+			/// \param shadowViews 4 vues des shadow maps cascades (binding 10). Toute
+			///        entrée VK_NULL_HANDLE => fallback GBufferA ; shadowData.shadowParams[0]
+			///        (useShadows) doit alors valoir 0 (le shader ne lit pas le fallback).
+			/// \param shadowData lightViewProj[4] (256 o) + shadowParams (16 o), uploadés
+			///        dans l'UBO host-visible binding 11.
+			const VkImageView shadowViews[4], const ShadowUbo& shadowData,
+			const LightParams& params, uint32_t frameIndex);
+```
+Ajouter les membres privés (après `m_depthSampler`, ~`LightingPass.h:107`) :
+```cpp
+		VkSampler m_shadowSampler = VK_NULL_HANDLE; ///< nearest clamp, lecture plain de la profondeur shadow (binding 10).
+		std::vector<VkBuffer>       m_shadowUboBuffers; ///< UBO cascades host-visible, un par frame (binding 11).
+		std::vector<VkDeviceMemory> m_shadowUboMemory;  ///< Mémoire host-visible.
+		std::vector<void*>          m_shadowUboMapped;  ///< Pointeurs mappés persistants (HOST_VISIBLE|HOST_COHERENT).
+```
+
+- [ ] **Step 2 — `LightingPass.cpp` : descriptor set layout (bindings 10 + 11).**
+
+Remplacer le `std::array<...,10>` (`LightingPass.cpp:159-172`). **Avant :**
+```cpp
+			std::array<VkDescriptorSetLayoutBinding, 10> bindings{};
+			for (size_t i = 0; i < bindings.size(); ++i)
+			{
+				bindings[i].binding            = i;
+				bindings[i].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount    = 1;
+				bindings[i].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+				bindings[i].pImmutableSamplers = nullptr;
+			}
+
+			VkDescriptorSetLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+			layoutInfo.pBindings    = bindings.data();
+```
+**Après :**
+```cpp
+			// 0..9 : COMBINED_IMAGE_SAMPLER count=1. 10 : 4 shadow maps (count=4).
+			// 11 : UBO cascades.
+			std::array<VkDescriptorSetLayoutBinding, 12> bindings{};
+			for (size_t i = 0; i < 10; ++i)
+			{
+				bindings[i].binding            = static_cast<uint32_t>(i);
+				bindings[i].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount    = 1;
+				bindings[i].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+				bindings[i].pImmutableSamplers = nullptr;
+			}
+			bindings[10].binding            = 10;
+			bindings[10].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			bindings[10].descriptorCount    = 4;
+			bindings[10].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[10].pImmutableSamplers = nullptr;
+			bindings[11].binding            = 11;
+			bindings[11].descriptorType     = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+			bindings[11].descriptorCount    = 1;
+			bindings[11].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[11].pImmutableSamplers = nullptr;
+
+			VkDescriptorSetLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+			layoutInfo.pBindings    = bindings.data();
+```
+
+- [ ] **Step 3 — `LightingPass.cpp` : descriptor pool.**
+
+Remplacer (`LightingPass.cpp:187-195`). **Avant :**
+```cpp
+			VkDescriptorPoolSize poolSize{};
+			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSize.descriptorCount = 10 * m_maxFrames;
+
+			VkDescriptorPoolCreateInfo poolInfo{};
+			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+			poolInfo.poolSizeCount = 1;
+			poolInfo.pPoolSizes    = &poolSize;
+			poolInfo.maxSets       = m_maxFrames;
+```
+**Après :**
+```cpp
+			// Par set : 10 (bindings 0-9) + 4 (binding 10) = 14 image samplers,
+			// + 1 UNIFORM_BUFFER (binding 11).
+			std::array<VkDescriptorPoolSize, 2> poolSizes{};
+			poolSizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSizes[0].descriptorCount = 14 * m_maxFrames;
+			poolSizes[1].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+			poolSizes[1].descriptorCount = 1 * m_maxFrames;
+
+			VkDescriptorPoolCreateInfo poolInfo{};
+			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+			poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
+			poolInfo.pPoolSizes    = poolSizes.data();
+			poolInfo.maxSets       = m_maxFrames;
+```
+
+- [ ] **Step 4 — `LightingPass.cpp` : décommenter `physicalDevice` + sampler shadow + UBO/frame.**
+
+Décommenter le paramètre : `LightingPass.cpp:87` → `bool LightingPass::Init(VkDevice device, VkPhysicalDevice physicalDevice,`.
+
+Après la création de `m_depthSampler` (~`LightingPass.cpp:253-259`), créer `m_shadowSampler` (réutiliser la `VkSamplerCreateInfo si` du bloc samplers — nearest clamp, **pas** de compare) :
+```cpp
+			// Sampler des shadow maps (binding 10) : nearest clamp, PAS de compare
+			// (PCF + test profondeur faits manuellement dans lighting.frag).
+			res = vkCreateSampler(device, &si, nullptr, &m_shadowSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "LightingPass: vkCreateSampler (shadow) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+```
+> Si `si` n'est plus en scope à ce point, déclarer une nouvelle `VkSamplerCreateInfo` identique à celle du depth sampler (nearest, `addressMode=CLAMP_TO_EDGE`, `compareEnable=VK_FALSE`).
+
+Ajouter un nouveau bloc (après le bloc samplers, avant le bloc pipeline layout) créant un UBO cascades host-visible **par frame** (modèle `SsaoKernelNoise.cpp:90-187`) :
+```cpp
+		// UBO cascades (binding 11), host-visible, un par frame in-flight (272 o,
+		// mappé en permanence HOST_COHERENT). Repère : SsaoKernelNoise.cpp.
+		{
+			VkPhysicalDeviceMemoryProperties memProps{};
+			vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+			auto findMemoryType = [&](uint32_t typeBits, VkMemoryPropertyFlags want) -> uint32_t
+			{
+				for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+					if ((typeBits & (1u << i)) &&
+						(memProps.memoryTypes[i].propertyFlags & want) == want)
+						return i;
+				return UINT32_MAX;
+			};
+
+			m_shadowUboBuffers.resize(m_maxFrames, VK_NULL_HANDLE);
+			m_shadowUboMemory.resize(m_maxFrames, VK_NULL_HANDLE);
+			m_shadowUboMapped.resize(m_maxFrames, nullptr);
+
+			for (uint32_t f = 0; f < m_maxFrames; ++f)
+			{
+				VkBufferCreateInfo bi{};
+				bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+				bi.size        = sizeof(ShadowUbo);
+				bi.usage       = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+				bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+				if (vkCreateBuffer(device, &bi, nullptr, &m_shadowUboBuffers[f]) != VK_SUCCESS)
+				{
+					LOG_ERROR(Render, "LightingPass: vkCreateBuffer (shadow UBO) failed");
+					Destroy(device);
+					return false;
+				}
+
+				VkMemoryRequirements memReq{};
+				vkGetBufferMemoryRequirements(device, m_shadowUboBuffers[f], &memReq);
+				const uint32_t memTypeIdx = findMemoryType(memReq.memoryTypeBits,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+				if (memTypeIdx == UINT32_MAX)
+				{
+					LOG_ERROR(Render, "LightingPass: no host-visible memory type for shadow UBO");
+					Destroy(device);
+					return false;
+				}
+
+				VkMemoryAllocateInfo ai{};
+				ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+				ai.allocationSize  = memReq.size;
+				ai.memoryTypeIndex = memTypeIdx;
+				if (vkAllocateMemory(device, &ai, nullptr, &m_shadowUboMemory[f]) != VK_SUCCESS ||
+					vkBindBufferMemory(device, m_shadowUboBuffers[f], m_shadowUboMemory[f], 0) != VK_SUCCESS ||
+					vkMapMemory(device, m_shadowUboMemory[f], 0, sizeof(ShadowUbo), 0, &m_shadowUboMapped[f]) != VK_SUCCESS)
+				{
+					LOG_ERROR(Render, "LightingPass: shadow UBO alloc/bind/map failed");
+					Destroy(device);
+					return false;
+				}
+			}
+		}
+```
+
+- [ ] **Step 5 — `LightingPass.cpp` : `Record` — signature + fallback + descripteurs + upload UBO.**
+
+Étendre la signature de `Record` (`LightingPass.cpp:404-405`) comme dans le `.h`. Après le fallback DDGI (~`LightingPass.cpp:438-439`), ajouter le fallback shadow :
+```cpp
+			// binding 10 (4 shadow maps). Vue nulle => fallback GBufferA (viewA) ;
+			// useShadows (shadowParams.x) vaudra 0 et le shader ne lira pas le fallback.
+			VkImageView shView[4];
+			for (int i = 0; i < 4; ++i)
+				shView[i] = (shadowViews && shadowViews[i] != VK_NULL_HANDLE) ? shadowViews[i] : viewA;
+```
+Remplacer le bloc `imageInfos`/`writes` (`LightingPass.cpp:447-470`) — **conserver `imageInfos[0..9]` à l'identique**, élargir à 14, ajouter le binding 10 (count=4) et le binding 11 (UBO). Réutiliser le `setIdx` déjà calculé (`LightingPass.cpp:444`, `const uint32_t setIdx = frameIndex % m_maxFrames;`) pour indexer l'UBO :
+```cpp
+			std::array<VkDescriptorImageInfo, 14> imageInfos{};
+			imageInfos[0] = { m_sampler,        viewA,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[1] = { m_sampler,        viewB,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[2] = { m_sampler,        viewC,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[3] = { m_depthSampler,   viewD,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[4] = { irrSamp,          irrView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[5] = { prefilterSampler, prefilterView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[6] = { brdfLutSampler,   brdfLutView,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[7] = { m_sampler,        viewSsao,  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[8] = { m_sampler,        viewDecal, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			imageInfos[9] = { ddgiSampler,      ddgiIrradianceView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			for (int i = 0; i < 4; ++i)
+				imageInfos[10 + i] = { m_shadowSampler, shView[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+
+			std::memcpy(m_shadowUboMapped[setIdx], &shadowData, sizeof(ShadowUbo));
+			VkDescriptorBufferInfo shadowBufInfo{};
+			shadowBufInfo.buffer = m_shadowUboBuffers[setIdx];
+			shadowBufInfo.offset = 0;
+			shadowBufInfo.range  = sizeof(ShadowUbo);
+
+			std::array<VkWriteDescriptorSet, 12> writes{};
+			for (size_t i = 0; i < 10; ++i)
+			{
+				writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+				writes[i].dstSet          = ds;
+				writes[i].dstBinding      = static_cast<uint32_t>(i);
+				writes[i].dstArrayElement = 0;
+				writes[i].descriptorCount = 1;
+				writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				writes[i].pImageInfo      = &imageInfos[i];
+			}
+			writes[10].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[10].dstSet          = ds;
+			writes[10].dstBinding      = 10;
+			writes[10].dstArrayElement = 0;
+			writes[10].descriptorCount = 4;
+			writes[10].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[10].pImageInfo      = &imageInfos[10];
+			writes[11].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[11].dstSet          = ds;
+			writes[11].dstBinding      = 11;
+			writes[11].dstArrayElement = 0;
+			writes[11].descriptorCount = 1;
+			writes[11].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+			writes[11].pBufferInfo     = &shadowBufInfo;
+
+			vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+```
+> Vérifier par lecture que `ds` est bien le set indexé par `setIdx` (le buffer `m_shadowUboBuffers[setIdx]` doit correspondre au même set). `<cstring>` (`std::memcpy`) : vérifier qu'il est inclus dans `LightingPass.cpp` ; sinon l'ajouter.
+
+- [ ] **Step 6 — `LightingPass.cpp` : `Destroy` — libérer sampler + UBO.**
+
+Dans `Destroy` (`LightingPass.cpp:538-584`), avant la destruction du pool, ajouter :
+```cpp
+		if (m_shadowSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_shadowSampler, nullptr);
+			m_shadowSampler = VK_NULL_HANDLE;
+		}
+		for (size_t f = 0; f < m_shadowUboBuffers.size(); ++f)
+		{
+			if (m_shadowUboMemory[f] != VK_NULL_HANDLE)
+				vkFreeMemory(device, m_shadowUboMemory[f], nullptr); // unmappe implicitement
+			if (m_shadowUboBuffers[f] != VK_NULL_HANDLE)
+				vkDestroyBuffer(device, m_shadowUboBuffers[f], nullptr);
+		}
+		m_shadowUboBuffers.clear();
+		m_shadowUboMemory.clear();
+		m_shadowUboMapped.clear();
+```
+> Ne pas modifier le guard `if (device == VK_NULL_HANDLE) return;` existant en tête de `Destroy`.
+
+- [ ] **Step 7 — Commit**
+```bash
+git add src/client/render/LightingPass.h src/client/render/LightingPass.cpp
+git commit -m "feat(render): LightingPass expose bindings shadow + UBO cascades (CSM)"
+```
+
+---
+
+### Task 2: Engine — câbler le pass Lighting sur les shadow maps
+
+**Files:** `src/client/app/Engine.cpp` (lambda du pass "Lighting", ~5659-5788)
+
+`m_fgShadowMapIds[i]` (D32, SAMPLED) déjà créées (`Engine.cpp:3905-3910`) et écrites (`5427`). `rs.cascades` accessible (utilisé par VolumetricFog `5985` : `rs.cascades.lightViewProj[0].m`). `kCascadeCount` visible via `CascadedShadowMaps.h`.
+
+> Vérification Task 2 : lecture seule ; compile CI. Confirmer que `rs.cascades.lightViewProj[i].m` est un `float[16]` colonne-major (déjà utilisé tel quel `Engine.cpp:5444`, `5985`).
+
+- [ ] **Step 1 — `b.read` des 4 cascades dans le PassBuilder.**
+
+Après `b.read(m_fgDecalOverlayId, ...)` (~`Engine.cpp:5666`). **Avant :**
+```cpp
+				b.read(m_fgDecalOverlayId,   engine::render::ImageUsage::SampledRead);
+				b.write(m_fgSceneColorHDRId, engine::render::ImageUsage::ColorWrite);
+```
+**Après :**
+```cpp
+				b.read(m_fgDecalOverlayId,   engine::render::ImageUsage::SampledRead);
+				// CSM — les 4 shadow maps cascades (rendues lisibles SAMPLED par le FG).
+				for (uint32_t i = 0; i < engine::render::kCascadeCount; ++i)
+					b.read(m_fgShadowMapIds[i], engine::render::ImageUsage::SampledRead);
+				b.write(m_fgSceneColorHDRId, engine::render::ImageUsage::ColorWrite);
+```
+
+- [ ] **Step 2 — Remplir `ShadowUbo`, récupérer les vues, lire la config.**
+
+Dans la lambda d'exécution, après le bloc DDGI (~`Engine.cpp:5777`), avant l'appel `Record` :
+```cpp
+				// ---- CSM — Ombres cascades --------------------------------------
+				engine::render::LightingPass::ShadowUbo shadowUbo{};
+				VkImageView shadowViews[engine::render::kCascadeCount] = {};
+				bool shadowViewsOk = true;
+				for (uint32_t i = 0; i < engine::render::kCascadeCount; ++i)
+				{
+					shadowViews[i] = reg.getImageView(m_fgShadowMapIds[i]);
+					if (shadowViews[i] == VK_NULL_HANDLE) shadowViewsOk = false;
+					std::memcpy(&shadowUbo.lightViewProj[i * 16],
+						rs.cascades.lightViewProj[i].m, sizeof(float) * 16);
+				}
+				const bool shadowsEnabled = m_cfg.GetBool("shadows.enabled", true);
+				const uint32_t shadowRes  = static_cast<uint32_t>(m_cfg.GetInt("shadows.resolution", 1024));
+				shadowUbo.shadowParams[0] = (shadowsEnabled && shadowViewsOk) ? 1.0f : 0.0f;
+				shadowUbo.shadowParams[1] = (shadowRes > 0) ? (1.0f / static_cast<float>(shadowRes)) : 0.0f;
+				shadowUbo.shadowParams[2] = static_cast<float>(m_cfg.GetDouble("shadows.bias_constant", 0.0015));
+				shadowUbo.shadowParams[3] = static_cast<float>(m_cfg.GetDouble("shadows.bias_slope_max", 0.005));
+```
+> Vérifier par lecture le nom exact de l'objet config (`m_cfg` vs `m_config`) et les méthodes `GetBool/GetInt/GetDouble` (utiliser celles déjà employées ailleurs dans `Engine.cpp` pour `shadows.*`, ex. `shadows.resolution` à `Engine.cpp:3898`). Adapter si la signature diffère. `kCascadeCount` doit valoir 4 (sinon `shadowUbo.lightViewProj` n'a que 4 slots — vérifier).
+
+- [ ] **Step 3 — Étendre l'appel `Record`.**
+
+(`Engine.cpp:5780-5787`). **Avant :**
+```cpp
+					ddgiView, ddgiSamp,
+					lp, frameIdx);
+```
+**Après :**
+```cpp
+					ddgiView, ddgiSamp,
+					shadowViews, shadowUbo,
+					lp, frameIdx);
+```
+> Vérifier les noms réels des variables (`ddgiView`/`ddgiSamp`/`lp`/`frameIdx`) au site d'appel et insérer `shadowViews, shadowUbo` juste avant les 2 derniers arguments (`params`, `frameIndex`).
+
+- [ ] **Step 4 — Commit**
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(render): Engine câble les cascades shadow vers LightingPass (CSM)"
+```
+
+---
+
+### Task 3: lighting.frag — sélection cascade + PCF + multiplication
+
+**Files:** `game/data/shaders/lighting.frag`
+
+> Vérification Task 3 : SPIR-V recompilé par la CI (le runtime charge `lighting.frag.spv`). Cohérence : binding 10 = `sampler2D[4]` ↔ C++ count=4 ; binding 11 UBO ↔ C++ `ShadowUbo` ; ordre `lightViewProj[4]` puis `shadowParams`.
+
+- [ ] **Step 1 — Déclarer bindings 10 et 11.**
+
+Après le binding 9 (~`lighting.frag:58`) :
+```glsl
+// ---- CSM — Ombres cascades --------------------------------------------------
+// binding 10 : 4 shadow maps (depth Vulkan [0,1], sampler nearest clamp, compare
+//   manuel comme volumetric_fog.frag — PAS de sampler2DShadow).
+// binding 11 : UBO cascades (std140). shadowParams : x=useShadows, y=texelSize
+//   (1/résolution), z=biasConstant, w=biasSlopeMax.
+layout(set = 0, binding = 10) uniform sampler2D uShadowMaps[4];
+layout(set = 0, binding = 11) uniform ShadowUbo
+{
+    mat4 lightViewProj[4];
+    vec4 shadowParams;
+} uShadow;
+```
+
+- [ ] **Step 2 — Ajouter `SampleShadowDepth` (index constant) + `ShadowVisibility`.**
+
+Avant `void main()` (~`lighting.frag:222`). **Important** : l'échantillonnage utilise un **switch à index constant** (et non `uShadowMaps[i]` avec `i` variable) pour éviter l'indexation non-uniforme d'un tableau de samplers (UB possible sans `nonuniformEXT`) :
+```glsl
+// CSM — lit la profondeur stockée dans la cascade i à l'UV donné. Index CONSTANT
+// (switch) pour éviter l'indexation dynamique non-uniforme d'un sampler array.
+float SampleShadowDepth(int i, vec2 uv)
+{
+    if (i == 0) return texture(uShadowMaps[0], uv).r;
+    if (i == 1) return texture(uShadowMaps[1], uv).r;
+    if (i == 2) return texture(uShadowMaps[2], uv).r;
+    return texture(uShadowMaps[3], uv).r;
+}
+
+// CSM — visibilité du soleil. Sélectionne la première cascade i (0→3) où P se
+// projette dans [0,1]² (UV) et [0,1] (profondeur) [containment]. Hors de toutes
+// -> éclairé (1.0). PCF 3×3 (9 taps, pas = shadowParams.y) ; compare manuel sur
+// profondeur Vulkan [0,1] (cf. volumetric_fog.frag) ; biais slope-scaled.
+// \param P     Position monde du fragment.
+// \param NdotL normale·soleil (>=0), pour le biais.
+// \return [0,1] : 1 = éclairé, 0 = ombré.
+float ShadowVisibility(vec3 P, float NdotL)
+{
+    float texel = uShadow.shadowParams.y;
+    float bias  = max(uShadow.shadowParams.z,
+                      uShadow.shadowParams.w * (1.0 - NdotL));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        vec4 clip = uShadow.lightViewProj[i] * vec4(P, 1.0);
+        if (clip.w <= 0.0) continue;
+        vec3 ndc = clip.xyz / clip.w;
+        vec2 uv  = ndc.xy * 0.5 + 0.5;   // [-1,1] -> [0,1]
+        float refDepth = ndc.z;          // profondeur Vulkan, déjà [0,1]
+
+        if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 ||
+            refDepth < 0.0 || refDepth > 1.0)
+            continue; // pas dans cette cascade -> essaie la suivante
+
+        float vis = 0.0;
+        for (int dy = -1; dy <= 1; ++dy)
+        for (int dx = -1; dx <= 1; ++dx)
+        {
+            vec2  off = vec2(float(dx), float(dy)) * texel;
+            float occ = SampleShadowDepth(i, uv + off);
+            vis += (refDepth - bias <= occ) ? 1.0 : 0.0;
+        }
+        return vis / 9.0;
+    }
+    return 1.0; // hors de toutes les cascades -> éclairé
+}
+```
+
+- [ ] **Step 3 — Multiplier `Lo` par la visibilité.**
+
+(`lighting.frag:291-292`). **Avant :**
+```glsl
+    // ---- Direct lighting contribution ----------------------------------
+    vec3  Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL;
+```
+**Après :**
+```glsl
+    // ---- Direct lighting contribution ----------------------------------
+    // CSM — atténue le SEUL soleil direct par les ombres cascades. Ambient/IBL/DDGI
+    // non ombrés. Gating : shadowParams.x <= 0.5 (shadows off / maps invalides) -> 1.
+    float vis = (uShadow.shadowParams.x > 0.5) ? ShadowVisibility(P, NdotL) : 1.0;
+    vec3  Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL * vis;
+```
+> Vérifier que la variable de position monde s'appelle bien `P` et la normale·soleil `NdotL` à ce point (sinon adapter aux noms réels lus). Ne PAS toucher aux blocs ambient/IBL/DDGI ni à la perspective aérienne.
+
+- [ ] **Step 4 — Commit**
+```bash
+git add game/data/shaders/lighting.frag
+git commit -m "feat(shader): lighting.frag échantillonne les cascades CSM (ombres soleil)"
+```
+
+---
+
+### Task 4: Validation en jeu (manuelle)
+
+**Aucun build local.** Compile C++ + SPIR-V via CI ; rendu validé manuellement (build CI/VS).
+
+- [ ] **Ombres présentes** : `shadows.enabled=true` (défaut), soleil rasant → ombres portées visibles, alignées avec la géométrie et la direction du soleil.
+- [ ] **Pas d'acné** : surfaces éclairées non striées. Si acné → augmenter `shadows.bias_constant`/`shadows.bias_slope_max`.
+- [ ] **Pas de peter-panning** : ombres attachées au pied des objets. Si décollement → biais trop fort, réduire.
+- [ ] **Transition cascades** : pas de coupure brutale d'ombre en s'éloignant ; ombres lointaines présentes.
+- [ ] **Gating off** : `"shadows": { "enabled": false }` → rendu sans ombres, pas d'artefact, pas de crash.
+- [ ] **Validation layers Vulkan** : aucune erreur sur le set 0 (bindings 10/11), aucun type/array out-of-bounds.
+
+---
+
+## Self-Review
+
+**Couverture spec :**
+- Binding 10 `sampler2D[4]` + binding 11 UBO std140 → Task 1 (C++) + Task 3 (GLSL). ✅
+- Sélection containment i=0→3, sinon vis=1 → Task 3 Step 2. ✅
+- PCF 3×3 + compare manuel + profondeur Vulkan [0,1] + biais slope-scaled → Task 3 Step 2. ✅
+- `Lo` (soleil direct seul) × `vis` ; ambient/IBL/DDGI non ombrés → Task 3 Step 3. ✅
+- Transport UBO host-visible 272 o (pas push-constant) → Task 1 Steps 1,4. ✅
+- Gating `shadows.enabled` + repli éclairé si maps invalides → Task 2 Step 2. ✅
+- Aucune modif winding (raster du pass Lighting inchangée). ✅
+
+**Placeholders :** aucun ; code réel partout. Les « vérifier par lecture » portent sur des noms de variables/config existants, pas du code à inventer.
+
+**Cohérence bindings Task 1 ↔ Task 3 :** binding 10 (C++ count=4 ↔ GLSL `[4]`, write count=4 sur `imageInfos[10]`) ; binding 11 (C++ UNIFORM_BUFFER ↔ GLSL UBO, `range=272`). Pool : 14 image-samplers + 1 UBO ×maxFrames. ✅
+
+**Types :** `ShadowUbo{ float lightViewProj[64]; float shadowParams[4]; }` (272 o, `static_assert`) ↔ GLSL `mat4 lightViewProj[4]; vec4 shadowParams;`. Remplissage `memcpy` colonne-major depuis `rs.cascades.lightViewProj[i].m`. ✅
+
+**Risques :** (1) indexation sampler array → résolue par `SampleShadowDepth` à index constant ; (2) UBO per-frame indexé `setIdx` (= `frameIndex % m_maxFrames`), cohérent avec le set ; (3) std140 sans padding (verrouillé par `static_assert`) ; (4) régénération `.spv` à confirmer côté CI (Task 3/4) ; (5) noms config `m_cfg`/méthodes à confirmer (Task 2).

--- a/docs/superpowers/specs/2026-06-05-ombres-csm-design.md
+++ b/docs/superpowers/specs/2026-06-05-ombres-csm-design.md
@@ -1,0 +1,92 @@
+# Spec — Branchement des ombres soleil (CSM)
+
+**Date** : 2026-06-05
+**Statut** : conception validée
+**Origine** : audit du moteur (`docs/audit/2026-06-05-moteur-rendu-client.md`, thème A « rebrancher le moteur »).
+**Portée** : client uniquement (rendu Vulkan + shader). **Pas de redéploiement serveur.**
+
+---
+
+## 1. Problème
+
+Les 4 cascades d'ombre (CSM) sont **rendues chaque frame** (`Engine.cpp` zone "ShadowMap", boucle ~5427-5452), et `CascadedShadowMaps::ComputeCascades` produit des matrices monde→ombre de bonne qualité (split pratique, stabilisation par snap texel). **Mais `lighting.frag` ne contient aucun échantillonnage d'ombre** : le terme soleil n'est jamais multiplié par une visibilité. Conséquence : **le soleil ne projette aucune ombre** sur le terrain ni les objets. On paie 4 rendus de depth utilisés seulement par DDGI et le brouillard volumique.
+
+C'est le poste à plus fort impact visuel du moteur pour un effort modéré : tout est déjà calculé, il « suffit » de **consommer** les cascades dans le shading.
+
+## 2. Acquis (rien à refaire)
+
+- 4 shadow maps `m_fgShadowMapIds[0..3]` (images D32_SFLOAT, résolution `shadows.resolution`, défaut 1024), rendues chaque frame avec biais (`shadows.depth_bias_constant/slope`).
+- `CascadesUniform` calculé dans `rs.cascades` : `Mat4 lightViewProj[4]` (monde→clip ombre, déjà en Z[0,1] Y-down via `OrthoVulkan`) + `float splitDepths[4]`.
+- Reconstruction de la position monde `P` du fragment dans `lighting.frag` (depth + `invVP`).
+- Terme soleil isolé `Lo` (`lighting.frag` ligne 292).
+- Motif d'échantillonnage d'une cascade déjà présent dans `volumetric_fog.frag` (projection + compare manuel, profondeur Vulkan [0,1] sans remise à l'échelle) — à généraliser aux 4 cascades.
+- Câblage de référence : `DDGI_Update` lit déjà la cascade 0 via `b.read(m_fgShadowMapIds[0])` + `reg.getImageView(...)` + un sampler.
+- Compilation SPIR-V automatique en CI (`tools/compile_game_shaders.ps1`).
+
+## 3. Conception
+
+### 3.1 Sélection de cascade — par *containment*
+On projette `P` dans l'espace de chaque cascade, de la 0 (plus haute résolution) à la 3, et on retient la **première** cascade où le fragment tombe dans le domaine valide (UV ∈ [0,1] et profondeur ∈ [0,1]). Avantage : n'utilise **que** `lightViewProj[i]` (déjà calculées), pas besoin de la profondeur-vue ni des `splitDepths` (en mètres, plus délicats). Robuste aux transitions.
+
+### 3.2 Transport des données — UBO dédié (pas push-constant)
+Le push-constant `LightParams` fait déjà **224 octets** ; y ajouter 4 `mat4` le pousserait à ~480 o et risquerait de dépasser `maxPushConstantsSize` sur du matériel modeste. On passe donc les cascades par un **UBO** dédié.
+
+Layout (std140, set 0) :
+- **binding 10** : `uniform sampler2D uShadowMaps[4];` (array de 4 samplers → les 4 images D32 séparées via 4 `VkDescriptorImageInfo`).
+- **binding 11** : `uniform ShadowUbo { mat4 lightViewProj[4]; vec4 shadowParams; } uShadow;`
+  - `shadowParams.x` = `useShadows` (0/1),
+  - `shadowParams.y` = texel size = `1.0 / résolution` (pour le PCF),
+  - `shadowParams.z` = biais de profondeur constant,
+  - `shadowParams.w` = pente max du biais (slope, fonction de NdotL).
+  - Taille : 4×64 + 16 = **272 octets**.
+
+### 3.3 Échantillonnage — PCF 3×3 + anti-acné
+- Compare manuel (sampler normal, comme `volumetric_fog`) : `shadowDepth = texture(uShadowMaps[c], uv).r ; lit = shadowDepth >= sampleDepth - bias`.
+- **PCF 3×3** : moyenne de 9 taps espacés de `shadowParams.y` (texel). Donne un bord d'ombre doux.
+- **Biais** : `bias = max(shadowParams.z, shadowParams.w * (1.0 - NdotL))` (slope-scaled) pour limiter le shadow-acne sur les pentes.
+- Hors domaine de toutes les cascades → **éclairé** (visibility = 1).
+
+### 3.4 Insertion dans le shading
+`lighting.frag` ligne 292 :
+```glsl
+vec3 Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL;
+```
+→ multiplier le terme **soleil direct uniquement** par la visibilité :
+```glsl
+float vis = (uShadow.shadowParams.x > 0.5) ? ShadowVisibility(P, NdotL) : 1.0;
+vec3 Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL * vis;
+```
+L'ambient/IBL/DDGI (lignes ~295-327) **n'est PAS ombré**.
+
+### 3.5 Gating
+`useShadows` (`shadowParams.x`) piloté par la config `shadows.enabled` (défaut **activé**) ET par la validité des shadow maps. Repli sûr « éclairé » sinon. Permet de désactiver les ombres sans recompiler.
+
+### 3.6 Câblage Engine / LightingPass
+- **LightingPass** : étendre le descriptor layout (ajouter binding 10 = sampler array ×4, binding 11 = UBO), agrandir le pool en conséquence, créer un **buffer UBO host-visible** (272 o, mis à jour chaque frame), ajouter à `Record` les 4 `VkImageView` shadow + un sampler + les données cascades (matrices + `shadowParams`), écrire les descripteurs.
+- **Engine** (pass "Lighting", ~5664-5793) : ajouter `b.read(m_fgShadowMapIds[i])` pour i=0..3 (crée la dépendance FG ShadowMap→Lighting, comme DDGI pour la cascade 0), récupérer les vues via `reg.getImageView(...)`, remplir l'UBO depuis `rs.cascades.lightViewProj[i]` + `shadowParams` (résolution, biais, flag `shadows.enabled`), passer le tout à `Record`.
+- Réutiliser le sampler shadow existant (pattern DDGI/LightingPass : sampler normal, `compareEnable=false`, clamp).
+
+## 4. Hors périmètre
+
+- IBL (irradiance/specular prefilter) — autre item « rebrancher le moteur », séparé.
+- Lumières ponctuelles (clustered) — prochaine étape dédiée.
+- Front-face culling anti-acné côté rendu depth (toggle `shadows.cull_front_faces` aujourd'hui ignoré dans `ShadowMapPass::Record`) — fix séparé seulement si l'acné persiste après le biais slope-scaled.
+
+## 5. Validation
+
+- **CI** : build Linux + Windows verts ; `lighting.frag` recompile en SPIR-V sans erreur ; pas d'erreur de validation Vulkan (descriptor layout cohérent shader↔C++).
+- **En jeu** (validation manuelle, rendu non automatisable) :
+  - le soleil projette des ombres portées nettes sur le terrain et les objets ;
+  - pas de shadow-acne marqué (biais OK) ni de peter-panning excessif ;
+  - transition entre cascades peu visible ;
+  - `shadows.enabled=false` → plus d'ombres, scène toujours correcte (pas de crash, repli éclairé).
+- **Convention `CLAUDE.md`** : aucune modification `frontFace`/`cullMode`/winding.
+
+## 6. Risques
+
+- **Cohérence descriptor layout shader↔C++** : les binding 10/11 doivent correspondre exactement entre `lighting.frag` et `LightingPass`. Risque d'erreur de validation Vulkan au runtime (non détecté par la compilation). Mitigation : numéros de binding figés dans ce spec.
+- **std140** : `mat4 lightViewProj[4]` (4×64) + `vec4` est std140-propre (alignements 16) — pas de padding surprise.
+- **Acné/peter-panning** : à régler par les biais ; le terrain est grand → tuning probable en validation.
+- Pas de toolchain locale : compile + validation en CI / VS uniquement.
+
+**Déploiement** : ✅ client uniquement — pas de redéploiement serveur (aucun opcode/handler/DB/protocole touché).

--- a/game/data/shaders/lighting.frag
+++ b/game/data/shaders/lighting.frag
@@ -57,6 +57,18 @@ layout(set = 0, binding = 7) uniform sampler2D   ssaoTex;       // M06.4 SSAO_Bl
 layout(set = 0, binding = 8) uniform sampler2D   decalOverlayTex;
 layout(set = 0, binding = 9) uniform sampler2D   ddgiIrradiance; // M45.7 atlas irradiance DDGI (RGBA16F)
 
+// ---- CSM — Ombres cascades --------------------------------------------------
+// binding 10 : 4 shadow maps (depth Vulkan [0,1], sampler nearest clamp, compare
+//   manuel comme volumetric_fog.frag — PAS de sampler2DShadow).
+// binding 11 : UBO cascades (std140). shadowParams : x=useShadows, y=texelSize
+//   (1/résolution), z=biasConstant, w=biasSlopeMax.
+layout(set = 0, binding = 10) uniform sampler2D uShadowMaps[4];
+layout(set = 0, binding = 11) uniform ShadowUbo
+{
+    mat4 lightViewProj[4];
+    vec4 shadowParams;
+} uShadow;
+
 // ---- Push constants ---------------------------------------------------------
 layout(push_constant) uniform PC
 {
@@ -218,6 +230,54 @@ vec3 F_Schlick(float cosTheta, vec3 F0)
     return F0 + (1.0 - F0) * pow(max(1.0 - cosTheta, 0.0), 5.0);
 }
 
+// CSM — lit la profondeur stockée dans la cascade i à l'UV donné. Index CONSTANT
+// (switch) pour éviter l'indexation dynamique non-uniforme d'un sampler array.
+float SampleShadowDepth(int i, vec2 uv)
+{
+    if (i == 0) return texture(uShadowMaps[0], uv).r;
+    if (i == 1) return texture(uShadowMaps[1], uv).r;
+    if (i == 2) return texture(uShadowMaps[2], uv).r;
+    return texture(uShadowMaps[3], uv).r;
+}
+
+// CSM — visibilité du soleil. Sélectionne la première cascade i (0→3) où P se
+// projette dans [0,1]² (UV) et [0,1] (profondeur) [containment]. Hors de toutes
+// -> éclairé (1.0). PCF 3×3 (9 taps, pas = shadowParams.y) ; compare manuel sur
+// profondeur Vulkan [0,1] (cf. volumetric_fog.frag) ; biais slope-scaled.
+// \param P     Position monde du fragment.
+// \param NdotL normale·soleil (>=0), pour le biais.
+// \return [0,1] : 1 = éclairé, 0 = ombré.
+float ShadowVisibility(vec3 P, float NdotL)
+{
+    float texel = uShadow.shadowParams.y;
+    float bias  = max(uShadow.shadowParams.z,
+                      uShadow.shadowParams.w * (1.0 - NdotL));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        vec4 clip = uShadow.lightViewProj[i] * vec4(P, 1.0);
+        if (clip.w <= 0.0) continue;
+        vec3 ndc = clip.xyz / clip.w;
+        vec2 uv  = ndc.xy * 0.5 + 0.5;   // [-1,1] -> [0,1]
+        float refDepth = ndc.z;          // profondeur Vulkan, déjà [0,1]
+
+        if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 ||
+            refDepth < 0.0 || refDepth > 1.0)
+            continue; // pas dans cette cascade -> essaie la suivante
+
+        float vis = 0.0;
+        for (int dy = -1; dy <= 1; ++dy)
+        for (int dx = -1; dx <= 1; ++dx)
+        {
+            vec2  off = vec2(float(dx), float(dy)) * texel;
+            float occ = SampleShadowDepth(i, uv + off);
+            vis += (refDepth - bias <= occ) ? 1.0 : 0.0;
+        }
+        return vis / 9.0;
+    }
+    return 1.0; // hors de toutes les cascades -> éclairé
+}
+
 // ---- Main -------------------------------------------------------------------
 void main()
 {
@@ -289,7 +349,10 @@ void main()
     vec3  diffuse  = kD * albedo / PI;
 
     // ---- Direct lighting contribution ----------------------------------
-    vec3  Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL;
+    // CSM — atténue le SEUL soleil direct par les ombres cascades. Ambient/IBL/DDGI
+    // non ombrés. Gating : shadowParams.x <= 0.5 (shadows off / maps invalides) -> 1.
+    float vis = (uShadow.shadowParams.x > 0.5) ? ShadowVisibility(P, NdotL) : 1.0;
+    vec3  Lo = (diffuse + specular) * pc.lightColor.rgb * NdotL * vis;
 
     // ---- Ambient: IBL (split-sum diffuse + spec) or fallback constant -------
     vec3  ambient;

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5664,6 +5664,9 @@ namespace engine
 												b.read(m_fgDepthId,          engine::render::ImageUsage::SampledRead);
 												b.read(m_fgSsaoBlurId,       engine::render::ImageUsage::SampledRead);
 												b.read(m_fgDecalOverlayId,   engine::render::ImageUsage::SampledRead);
+												// CSM — les 4 shadow maps cascades (rendues lisibles SAMPLED par le FG).
+												for (uint32_t i = 0; i < engine::render::kCascadeCount; ++i)
+													b.read(m_fgShadowMapIds[i], engine::render::ImageUsage::SampledRead);
 												b.write(m_fgSceneColorHDRId, engine::render::ImageUsage::ColorWrite);
 											},
 											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
@@ -5776,6 +5779,28 @@ namespace engine
 													ddgiSamp = m_ddgiUpdatePass.GetShadowSampler(); // sampler linéaire-équivalent (NEAREST clamp) interne
 												}
 
+												// ---- CSM — Ombres cascades --------------------------------------
+												// Récupère les 4 vues shadow maps et remplit l'UBO cascades
+												// (binding 11). shadowParams : x=useShadows(0/1), y=texelSize
+												// (1/résolution), z=biasConstant, w=biasSlopeMax. Si une vue est
+												// invalide, useShadows tombe à 0 (le shader ignore alors le fallback).
+												engine::render::LightingPass::ShadowUbo shadowUbo{};
+												VkImageView shadowViews[engine::render::kCascadeCount] = {};
+												bool shadowViewsOk = true;
+												for (uint32_t i = 0; i < engine::render::kCascadeCount; ++i)
+												{
+													shadowViews[i] = reg.getImageView(m_fgShadowMapIds[i]);
+													if (shadowViews[i] == VK_NULL_HANDLE) shadowViewsOk = false;
+													std::memcpy(&shadowUbo.lightViewProj[i * 16],
+														rs.cascades.lightViewProj[i].m, sizeof(float) * 16);
+												}
+												const bool shadowsEnabled = m_cfg.GetBool("shadows.enabled", true);
+												const uint32_t shadowRes  = static_cast<uint32_t>(m_cfg.GetInt("shadows.resolution", 1024));
+												shadowUbo.shadowParams[0] = (shadowsEnabled && shadowViewsOk) ? 1.0f : 0.0f;
+												shadowUbo.shadowParams[1] = (shadowRes > 0) ? (1.0f / static_cast<float>(shadowRes)) : 0.0f;
+												shadowUbo.shadowParams[2] = static_cast<float>(m_cfg.GetDouble("shadows.bias_constant", 0.0015));
+												shadowUbo.shadowParams[3] = static_cast<float>(m_cfg.GetDouble("shadows.bias_slope_max", 0.005));
+
 												const uint32_t frameIdx = m_currentFrame % 2;
 												m_pipeline->GetLightingPass().Record(
 													m_vkDeviceContext.GetDevice(), cmd, reg,
@@ -5784,6 +5809,7 @@ namespace engine
 													m_fgSceneColorHDRId, m_fgSsaoBlurId, m_fgDecalOverlayId,
 													irrView, irrSamp, prefilterView, prefilterSamp, brdfView, brdfSamp,
 													ddgiView, ddgiSamp,
+													shadowViews, shadowUbo,
 													lp, frameIdx);
 											});
 

--- a/src/client/render/LightingPass.cpp
+++ b/src/client/render/LightingPass.cpp
@@ -84,7 +84,7 @@ namespace engine::render
 	// LightingPass::Init
 	// -------------------------------------------------------------------------
 
-	bool LightingPass::Init(VkDevice device, VkPhysicalDevice /*physicalDevice*/,
+	bool LightingPass::Init(VkDevice device, VkPhysicalDevice physicalDevice,
 		VkFormat sceneColorHDRFormat,
 		const uint32_t* vertSpirv, size_t vertWordCount,
 		const uint32_t* fragSpirv, size_t fragWordCount,
@@ -156,15 +156,27 @@ namespace engine::render
 		// 2. Descriptor set layout: 10 combined image samplers (GBufA/B/C, Depth, irradiance, prefilter, BRDF LUT, SSAO_Blur, DecalOverlay, DDGI irradiance [M45.7])
 		// -----------------------------------------------------------------
 		{
-			std::array<VkDescriptorSetLayoutBinding, 10> bindings{};
-			for (size_t i = 0; i < bindings.size(); ++i)
+			// 0..9 : COMBINED_IMAGE_SAMPLER count=1. 10 : 4 shadow maps (count=4).
+			// 11 : UBO cascades.
+			std::array<VkDescriptorSetLayoutBinding, 12> bindings{};
+			for (size_t i = 0; i < 10; ++i)
 			{
-				bindings[i].binding            = i;
+				bindings[i].binding            = static_cast<uint32_t>(i);
 				bindings[i].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 				bindings[i].descriptorCount    = 1;
 				bindings[i].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
 				bindings[i].pImmutableSamplers = nullptr;
 			}
+			bindings[10].binding            = 10;
+			bindings[10].descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			bindings[10].descriptorCount    = 4;
+			bindings[10].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[10].pImmutableSamplers = nullptr;
+			bindings[11].binding            = 11;
+			bindings[11].descriptorType     = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+			bindings[11].descriptorCount    = 1;
+			bindings[11].stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[11].pImmutableSamplers = nullptr;
 
 			VkDescriptorSetLayoutCreateInfo layoutInfo{};
 			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -184,14 +196,18 @@ namespace engine::render
 		// 3. Descriptor pool: maxFrames sets, 10 combined image samplers each
 		// -----------------------------------------------------------------
 		{
-			VkDescriptorPoolSize poolSize{};
-			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-			poolSize.descriptorCount = 10 * m_maxFrames;
+			// Par set : 10 (bindings 0-9) + 4 (binding 10) = 14 image samplers,
+			// + 1 UNIFORM_BUFFER (binding 11).
+			std::array<VkDescriptorPoolSize, 2> poolSizes{};
+			poolSizes[0].type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			poolSizes[0].descriptorCount = 14 * m_maxFrames;
+			poolSizes[1].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+			poolSizes[1].descriptorCount = 1 * m_maxFrames;
 
 			VkDescriptorPoolCreateInfo poolInfo{};
 			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-			poolInfo.poolSizeCount = 1;
-			poolInfo.pPoolSizes    = &poolSize;
+			poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
+			poolInfo.pPoolSizes    = poolSizes.data();
 			poolInfo.maxSets       = m_maxFrames;
 
 			VkResult res = vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool);
@@ -256,6 +272,76 @@ namespace engine::render
 				LOG_ERROR(Render, "LightingPass: vkCreateSampler (depth) failed: {}", static_cast<int>(res));
 				Destroy(device);
 				return false;
+			}
+
+			// Sampler des shadow maps (binding 10) : nearest clamp, PAS de compare
+			// (PCF + test profondeur faits manuellement dans lighting.frag).
+			res = vkCreateSampler(device, &si, nullptr, &m_shadowSampler);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "LightingPass: vkCreateSampler (shadow) failed: {}", static_cast<int>(res));
+				Destroy(device);
+				return false;
+			}
+		}
+
+		// -----------------------------------------------------------------
+		// 5b. UBO cascades (binding 11), host-visible, un par frame in-flight
+		// (272 o, mappé en permanence HOST_COHERENT). Repère : SsaoKernelNoise.cpp.
+		// -----------------------------------------------------------------
+		{
+			VkPhysicalDeviceMemoryProperties memProps{};
+			vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+			auto findMemoryType = [&](uint32_t typeBits, VkMemoryPropertyFlags want) -> uint32_t
+			{
+				for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+					if ((typeBits & (1u << i)) &&
+						(memProps.memoryTypes[i].propertyFlags & want) == want)
+						return i;
+				return UINT32_MAX;
+			};
+
+			m_shadowUboBuffers.resize(m_maxFrames, VK_NULL_HANDLE);
+			m_shadowUboMemory.resize(m_maxFrames, VK_NULL_HANDLE);
+			m_shadowUboMapped.resize(m_maxFrames, nullptr);
+
+			for (uint32_t f = 0; f < m_maxFrames; ++f)
+			{
+				VkBufferCreateInfo bi{};
+				bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+				bi.size        = sizeof(ShadowUbo);
+				bi.usage       = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+				bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+				if (vkCreateBuffer(device, &bi, nullptr, &m_shadowUboBuffers[f]) != VK_SUCCESS)
+				{
+					LOG_ERROR(Render, "LightingPass: vkCreateBuffer (shadow UBO) failed");
+					Destroy(device);
+					return false;
+				}
+
+				VkMemoryRequirements memReq{};
+				vkGetBufferMemoryRequirements(device, m_shadowUboBuffers[f], &memReq);
+				const uint32_t memTypeIdx = findMemoryType(memReq.memoryTypeBits,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+				if (memTypeIdx == UINT32_MAX)
+				{
+					LOG_ERROR(Render, "LightingPass: no host-visible memory type for shadow UBO");
+					Destroy(device);
+					return false;
+				}
+
+				VkMemoryAllocateInfo ai{};
+				ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+				ai.allocationSize  = memReq.size;
+				ai.memoryTypeIndex = memTypeIdx;
+				if (vkAllocateMemory(device, &ai, nullptr, &m_shadowUboMemory[f]) != VK_SUCCESS ||
+					vkBindBufferMemory(device, m_shadowUboBuffers[f], m_shadowUboMemory[f], 0) != VK_SUCCESS ||
+					vkMapMemory(device, m_shadowUboMemory[f], 0, sizeof(ShadowUbo), 0, &m_shadowUboMapped[f]) != VK_SUCCESS)
+				{
+					LOG_ERROR(Render, "LightingPass: shadow UBO alloc/bind/map failed");
+					Destroy(device);
+					return false;
+				}
 			}
 		}
 
@@ -402,6 +488,7 @@ namespace engine::render
 		VkImageView prefilterView, VkSampler prefilterSampler,
 		VkImageView brdfLutView, VkSampler brdfLutSampler,
 		VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
+		const VkImageView shadowViews[4], const ShadowUbo& shadowData,
 		const LightParams& params, uint32_t frameIndex)
 	{
 		if (!IsValid() || extent.width == 0 || extent.height == 0)
@@ -438,13 +525,19 @@ namespace engine::render
 		if (ddgiIrradianceView == VK_NULL_HANDLE) { ddgiIrradianceView = viewA; ddgiSampler = m_sampler; }
 		if (ddgiSampler == VK_NULL_HANDLE) { ddgiSampler = m_sampler; }
 
+		// binding 10 (4 shadow maps). Vue nulle => fallback GBufferA (viewA) ;
+		// useShadows (shadowParams.x) vaudra 0 et le shader ne lira pas le fallback.
+		VkImageView shView[4];
+		for (int i = 0; i < 4; ++i)
+			shView[i] = (shadowViews && shadowViews[i] != VK_NULL_HANDLE) ? shadowViews[i] : viewA;
+
 		// ------------------------------------------------------------------
 		// Update descriptor set for this frame with GBuffer + IBL views.
 		// ------------------------------------------------------------------
 		const uint32_t setIdx = frameIndex % m_maxFrames;
 		VkDescriptorSet ds = m_descriptorSets[setIdx];
 
-		std::array<VkDescriptorImageInfo, 10> imageInfos{};
+		std::array<VkDescriptorImageInfo, 14> imageInfos{};
 		imageInfos[0] = { m_sampler,         viewA,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[1] = { m_sampler,         viewB,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[2] = { m_sampler,         viewC,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
@@ -455,18 +548,41 @@ namespace engine::render
 		imageInfos[7] = { m_sampler,         viewSsao, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[8] = { m_sampler,         viewDecal, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[9] = { ddgiSampler,       ddgiIrradianceView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }; // M45.7 DDGI
+		for (int i = 0; i < 4; ++i)
+			imageInfos[10 + i] = { m_shadowSampler, shView[i], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 
-		std::array<VkWriteDescriptorSet, 10> writes{};
-		for (size_t i = 0; i < writes.size(); ++i)
+		std::memcpy(m_shadowUboMapped[setIdx], &shadowData, sizeof(ShadowUbo));
+		VkDescriptorBufferInfo shadowBufInfo{};
+		shadowBufInfo.buffer = m_shadowUboBuffers[setIdx];
+		shadowBufInfo.offset = 0;
+		shadowBufInfo.range  = sizeof(ShadowUbo);
+
+		std::array<VkWriteDescriptorSet, 12> writes{};
+		for (size_t i = 0; i < 10; ++i)
 		{
 			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 			writes[i].dstSet          = ds;
-			writes[i].dstBinding      = i;
+			writes[i].dstBinding      = static_cast<uint32_t>(i);
 			writes[i].dstArrayElement = 0;
 			writes[i].descriptorCount = 1;
 			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 			writes[i].pImageInfo      = &imageInfos[i];
 		}
+		writes[10].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[10].dstSet          = ds;
+		writes[10].dstBinding      = 10;
+		writes[10].dstArrayElement = 0;
+		writes[10].descriptorCount = 4;
+		writes[10].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		writes[10].pImageInfo      = &imageInfos[10];
+		writes[11].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+		writes[11].dstSet          = ds;
+		writes[11].dstBinding      = 11;
+		writes[11].dstArrayElement = 0;
+		writes[11].descriptorCount = 1;
+		writes[11].descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		writes[11].pBufferInfo     = &shadowBufInfo;
+
 		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
 		// ------------------------------------------------------------------
@@ -563,6 +679,21 @@ namespace engine::render
 			vkDestroySampler(device, m_sampler, nullptr);
 			m_sampler = VK_NULL_HANDLE;
 		}
+		if (m_shadowSampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_shadowSampler, nullptr);
+			m_shadowSampler = VK_NULL_HANDLE;
+		}
+		for (size_t f = 0; f < m_shadowUboBuffers.size(); ++f)
+		{
+			if (m_shadowUboMemory[f] != VK_NULL_HANDLE)
+				vkFreeMemory(device, m_shadowUboMemory[f], nullptr); // unmappe implicitement
+			if (m_shadowUboBuffers[f] != VK_NULL_HANDLE)
+				vkDestroyBuffer(device, m_shadowUboBuffers[f], nullptr);
+		}
+		m_shadowUboBuffers.clear();
+		m_shadowUboMemory.clear();
+		m_shadowUboMapped.clear();
 		// Descriptor sets are implicitly freed when the pool is destroyed.
 		m_descriptorSets.clear();
 		if (m_descriptorPool != VK_NULL_HANDLE)

--- a/src/client/render/LightingPass.h
+++ b/src/client/render/LightingPass.h
@@ -52,6 +52,17 @@ namespace engine::render
 		// 144 (jusqu'à skyColor) + 16 (useIBL+useDdgi+pad0+pad1) + 64 (4 vec4 DDGI) = 224.
 		static_assert(sizeof(LightParams) == 224, "LightParams must be exactly 224 bytes (144 + 16 + 64 DDGI)");
 
+		/// CPU-side de l'UBO cascades (binding 11, std140). 4 lightViewProj (256 o)
+		/// + shadowParams (16 o) = 272 o. SÉPARÉ de LightParams (push-constant figé
+		/// à 224 o). shadowParams : x=useShadows(0/1), y=texelSize(1/résolution),
+		/// z=biasConstant, w=biasSlopeMax. Voir lighting.frag binding 11.
+		struct ShadowUbo
+		{
+			float lightViewProj[16 * 4]; ///< 4 matrices colonne-major (cascade 0..3), 256 o.
+			float shadowParams[4];       ///< x=useShadows, y=texelSize, z=biasConstant, w=biasSlopeMax.
+		};
+		static_assert(sizeof(ShadowUbo) == 272, "ShadowUbo must be exactly 272 bytes (256 + 16)");
+
 		LightingPass() = default;
 		LightingPass(const LightingPass&) = delete;
 		LightingPass& operator=(const LightingPass&) = delete;
@@ -89,6 +100,12 @@ namespace engine::render
 			VkImageView prefilterView, VkSampler prefilterSampler,
 			VkImageView brdfLutView, VkSampler brdfLutSampler,
 			VkImageView ddgiIrradianceView, VkSampler ddgiSampler,
+			/// \param shadowViews 4 vues des shadow maps cascades (binding 10). Toute
+			///        entrée VK_NULL_HANDLE => fallback GBufferA ; shadowData.shadowParams[0]
+			///        (useShadows) doit alors valoir 0 (le shader ne lit pas le fallback).
+			/// \param shadowData lightViewProj[4] (256 o) + shadowParams (16 o), uploadés
+			///        dans l'UBO host-visible binding 11.
+			const VkImageView shadowViews[4], const ShadowUbo& shadowData,
 			const LightParams& params, uint32_t frameIndex);
 
 		/// Releases all Vulkan resources. Safe to call even when not initialized.
@@ -105,6 +122,10 @@ namespace engine::render
 		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
 		VkSampler             m_sampler             = VK_NULL_HANDLE; ///< Nearest clamp, for GBuf color channels.
 		VkSampler             m_depthSampler        = VK_NULL_HANDLE; ///< Nearest clamp, no compare, for depth.
+		VkSampler m_shadowSampler = VK_NULL_HANDLE; ///< nearest clamp, lecture plain de la profondeur shadow (binding 10).
+		std::vector<VkBuffer>       m_shadowUboBuffers; ///< UBO cascades host-visible, un par frame (binding 11).
+		std::vector<VkDeviceMemory> m_shadowUboMemory;  ///< Mémoire host-visible.
+		std::vector<void*>          m_shadowUboMapped;  ///< Pointeurs mappés persistants (HOST_VISIBLE|HOST_COHERENT).
 
 		std::vector<VkDescriptorSet> m_descriptorSets; ///< One per in-flight frame.
 		uint32_t m_maxFrames = 2;


### PR DESCRIPTION
## Contexte

Issu de l'audit du moteur (thème « rebrancher le moteur »). Les 4 cascades d'ombre (CSM) sont **rendues chaque frame** et `ComputeCascades` est de bonne qualité, **mais `lighting.frag` ne les échantillonne jamais** : le soleil ne projetait **aucune ombre portée**. On payait 4 rendus de depth utilisés seulement par DDGI et le fog. Cette PR **consomme** les cascades existantes dans le shading du soleil.

## Changements

- **`LightingPass`** : nouveau **binding 10** (`sampler2D uShadowMaps[4]`, les 4 shadow maps) + **binding 11** (UBO cascades `mat4 lightViewProj[4]` + `vec4 shadowParams`, 272 o, host-visible par frame). Sampler shadow dédié, descripteurs étendus, libération propre dans `Destroy`.
- **`Engine`** (pass Lighting) : `b.read` des 4 shadow maps (dépendance FrameGraph ShadowMap→Lighting), remplissage du `ShadowUbo` depuis `rs.cascades`, transmission à `Record`.
- **`lighting.frag`** : sélection de cascade par **containment**, **PCF 3×3** avec biais slope-scaled, compare manuel (profondeur Vulkan [0,1], comme `volumetric_fog.frag`). Le **seul terme soleil direct** est multiplié par la visibilité — l'ambient/IBL/DDGI ne sont pas ombrés.

Échantillonnage du sampler array à **index constant** (switch) pour éviter l'indexation non-uniforme. Transport par UBO (pas push-constant : `LightParams` est déjà à 224 o).

## Gating & sûreté

- `shadows.enabled` (config, défaut **activé**) + repli **éclairé** si les shadow maps sont invalides (`shadowParams.x=0` → `vis=1`, fallback descriptor valide). Pas de crash.
- Biais PCF : `shadows.bias_constant` (0.0015) / `shadows.bias_slope_max` (0.005), nouvelles clés client, ajustables sans recompiler (distinctes du biais rasterizer `shadows.depth_bias_*`).

## Plan de test

- [ ] CI : build Linux + Windows verts ; `lighting.frag` recompilé en SPIR-V sans erreur.
- [ ] En jeu : le soleil projette des ombres portées nettes, alignées avec la géométrie et la direction du soleil.
- [ ] Pas de shadow-acne marqué ni de peter-panning (ajuster les biais sinon).
- [ ] Transition entre cascades acceptable ; ombres lointaines présentes.
- [ ] `shadows.enabled=false` → scène sans ombres, sans artefact ni crash.
- [ ] Validation layers Vulkan : aucun warning sur le set 0 (bindings 10/11).

## Limites connues

- Sélection de cascade par containment sans bande de blend → couture possible entre cascades (acceptable en v1).
- IBL et lumières ponctuelles restent débranchés (items « rebrancher le moteur » suivants).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur** (rendu Vulkan/shader pur ; aucun opcode/handler/payload/migration/config serveur ; les clés `shadows.*` sont lues côté client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)