### PR TITLE
fix(render): borne l'auto-exposition — corrige le ciel cramé en blanc avec les ombres

### DIFF
--- a/config.json
+++ b/config.json
@@ -140,6 +140,8 @@
     "exposure": {
         "key": 0.18,
         "speed": 2.0,
+        "min": 0.1,
+        "max": 3.0,
         "histogram_percentile_low": 0.10,
         "histogram_percentile_high": 0.90
     },

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10190,7 +10190,12 @@ namespace engine
 	        const float dt    = static_cast<float>(m_time.DeltaSeconds());
 	        const float key   = static_cast<float>(m_cfg.GetDouble("exposure.key", 0.18));
 	        const float speed = static_cast<float>(m_cfg.GetDouble("exposure.speed", 2.0));
-	        m_pipeline->GetAutoExposure().Update(device, dt, key, speed, frameIndex);
+	        // Bornes de l'exposition adaptée. Le plafond (défaut 3.0 au lieu de 10.0)
+	        // empêche l'auto-exposition de surcompenser une scène assombrie par les
+	        // ombres et de cramer le ciel/horizon en blanc. Réglable via config.
+	        const float minExp = static_cast<float>(m_cfg.GetDouble("exposure.min", 0.1));
+	        const float maxExp = static_cast<float>(m_cfg.GetDouble("exposure.max", 3.0));
+	        m_pipeline->GetAutoExposure().Update(device, dt, key, speed, minExp, maxExp, frameIndex);
 	    }
 	
 	    auto handleSuboptimal = [this](const char* phase)

--- a/src/client/render/AutoExposure.cpp
+++ b/src/client/render/AutoExposure.cpp
@@ -547,7 +547,8 @@ namespace engine::render
 			0, 0, nullptr, 1, &stagingBarrier, 0, nullptr);
 	}
 
-	void AutoExposure::Update(VkDevice device, float dt, float key, float speed, uint32_t frameIndex)
+	void AutoExposure::Update(VkDevice device, float dt, float key, float speed,
+		float minExposure, float maxExposure, uint32_t frameIndex)
 	{
 		const uint32_t slot = (frameIndex + 1u) % kAESlots;
 		if (device == VK_NULL_HANDLE || m_stagingAlloc[slot] == nullptr)
@@ -564,12 +565,12 @@ namespace engine::render
 		float avgLuminance = std::exp2(avgLog);
 		const float kEpsilon = 1e-6f;
 		float targetExposure = key / (avgLuminance + kEpsilon);
-		targetExposure = std::max(0.001f, std::min(10.0f, targetExposure));
+		targetExposure = std::max(minExposure, std::min(maxExposure, targetExposure));
 
 		// exposure = lerp(prev, target, 1 - exp(-dt*speed))
 		float blend = 1.0f - std::exp(-dt * speed);
 		m_exposure = m_exposure + (targetExposure - m_exposure) * blend;
-		m_exposure = std::max(0.001f, std::min(10.0f, m_exposure));
+		m_exposure = std::max(minExposure, std::min(maxExposure, m_exposure));
 
 		// Write to persistent exposure buffer
 		if (m_exposureAlloc != nullptr)

--- a/src/client/render/AutoExposure.h
+++ b/src/client/render/AutoExposure.h
@@ -43,7 +43,11 @@ namespace engine::render
 		/// Call after fence wait. Reads the previous slot staging buffer, computes log-avg,
 		/// adapts exposure, writes exposure buffer.
 		/// key = target mid-gray (default 0.18); speed = adaptation speed.
-		void Update(VkDevice device, float dt, float key, float speed, uint32_t frameIndex);
+		/// minExposure/maxExposure : bornes de l'exposition adaptée (configurables
+		/// via exposure.min/exposure.max). Le plafond évite que l'auto-exposition
+		/// surcompense une scène assombrie (ex. par les ombres) et crame le ciel.
+		void Update(VkDevice device, float dt, float key, float speed,
+			float minExposure, float maxExposure, uint32_t frameIndex);
 
 		/// Returns current exposure for tonemap (valid after first Update).
 		float GetExposure() const { return m_exposure; }


### PR DESCRIPTION
## Symptôme

Après le merge des ombres CSM (#832), dans certaines zones le **haut de l'écran cramait en blanc pur** (ciel + horizon), alors que le proche restait correctement éclairé. Confirmé : `shadows.enabled=false` faisait disparaître le blanc.

## Cause racine

Ce n'est **pas** un bug des ombres. Chaîne :
1. Les ombres assombrissent localement la scène.
2. L'**auto-exposition** mesure la luminance moyenne et compense en montant l'exposition — jusqu'à **×10** (clamp codé en dur, `AutoExposure.cpp`).
3. Le **tonemap** applique cette exposition gonflée → le ciel/horizon (déjà ~1.0 en HDR via la perspective aérienne) **saturent en blanc**.

Le ciel ne peut pas être blanchi par un bug d'ombre direct (il court-circuite le code d'ombre dans le shader), ce qui confirme que c'est l'exposition.

## Correctif

- Bornes d'exposition **configurables** : `exposure.min` (0.1) / `exposure.max` (**3.0** au lieu de 10.0).
- Plafond ×3 : en journée, une scène avec ombres n'a jamais besoin de ×10 ; ×3 laisse une compensation raisonnable sans cramer le ciel.
- `AutoExposure::Update` reçoit `minExposure`/`maxExposure` (lus depuis la config), remplaçant les clamps codés en dur.

> Note : on **n'exclut pas** le ciel de l'histogramme — au contraire, le ciel clair maintient la moyenne haute et limite la montée d'exposition ; l'exclure aggraverait le problème.

## Pour tester

1. S'assurer que `config.json` a `"shadows": { "enabled": true }` (réactiver les ombres).
2. Lancer le jeu, s'approcher des zones qui craquaient → plus de blanc cramé, ombres visibles, ciel correct.
3. Réglage fin si besoin : baisser `exposure.max` (ex. 2.5) si encore un peu clair, ou monter (ex. 4.0) si les scènes sombres manquent de compensation.

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur** (rendu Vulkan + config client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)