### PR TITLE
fix(terrain): coutures/tirets sombres sur le relief — bug du morph geomorphing (× 2.0 parasite)

### DIFF
--- a/game/data/shaders/terrain.vert
+++ b/game/data/shaders/terrain.vert
@@ -77,12 +77,19 @@ void main()
     // morph towards their snapped parent position.
     if (pc.morphFactor > 0.0 && pc.lodLevel < 4)
     {
-        // Snap local position to nearest parent LOD grid vertex
+        // Snap local position to nearest parent LOD grid vertex.
+        // snappedLocalX/Z sont en indices FINS (mêmes unités que inPatchLocal),
+        // arrondis au sommet pair (= grille parent). La position monde doit donc
+        // utiliser EXACTEMENT la même conversion que worldX/worldZ ci-dessus
+        // (origin + localIndex * stepMult * vertStepWorld). L'ancien facteur
+        // « * 2.0 » échantillonnait la heightmap deux fois trop loin → la cible de
+        // morph n'était pas la vraie hauteur parent, d'où des sauts de hauteur
+        // (coutures/tirets sombres) dans la bande de transition de LOD.
         float snappedLocalX = floor(inPatchLocal.x / 2.0 + 0.5) * 2.0;
         float snappedLocalZ = floor(inPatchLocal.y / 2.0 + 0.5) * 2.0;
 
-        float snappedWorldX = pc.patchOriginX + snappedLocalX * stepMult * 2.0 * vertStepWorld;
-        float snappedWorldZ = pc.patchOriginZ + snappedLocalZ * stepMult * 2.0 * vertStepWorld;
+        float snappedWorldX = pc.patchOriginX + snappedLocalX * stepMult * vertStepWorld;
+        float snappedWorldZ = pc.patchOriginZ + snappedLocalZ * stepMult * vertStepWorld;
 
         vec2 snappedUV;
         snappedUV.x = clamp((snappedWorldX - terrainOriginX) / terrainSize, 0.0, 1.0);


### PR DESCRIPTION
## Symptôme

Des **tirets/marques sombres** apparaissent sur la surface du terrain, **uniquement sur le relief (collines/pentes), jamais sur le plat**, à une **distance fixe devant la caméra**. Ils **apparaissent en fondu quand le personnage se déplace** (translation) et sont **verrouillés au terrain** (tourner seulement la caméra ne les déplace pas).

Bug **pré-existant** — sans rapport avec les PR récentes (ombres/terrain/lumières). Confirmé par élimination : pas les ombres (`shadows.enabled=false` inopérant), pas le feuillage (`cull_distance_m=20` inopérant), pas le SSAO (`ssao.radius=0.05` inopérant), pas la TAA (rotation caméra ne déplace pas les marques).

## Cause racine

Le terrain heightmap est rendu en **patches** à 5 niveaux de LOD selon la distance caméra→patch, avec **geomorphing** dans `terrain.vert`. La cible de hauteur du morph contenait un **facteur `* 2.0` parasite** :

```glsl
// AVANT (bug)
float snappedWorldX = patchOriginX + snappedLocalX * stepMult * 2.0 * vertStepWorld;
```

Or `snappedLocalX` est déjà en **indices fins** (mêmes unités que `inPatchLocal.x`, arrondi au sommet pair). La position monde devait donc utiliser **exactement** la même conversion que le sommet courant (`origin + localIndex * stepMult * vertStepWorld`, ligne 63). Le `* 2.0` faisait échantillonner la heightmap **deux fois trop loin** → le morph tirait la hauteur vers un point arbitraire du terrain au lieu de la vraie hauteur parent → **sauts de hauteur** dans la bande de transition de LOD (les 20 % finaux de chaque anneau).

Ça explique les 3 signatures : verrouillé-terrain (LOD = distance monde, indépendant de l'orientation), pop en translation au loin (anneaux de LOD centrés caméra), relief-seulement (sur le plat, hauteurs égales → le morph ne change rien).

## Correctif

Retrait du `* 2.0` parasite (lignes 84-85). La cible de morph est désormais la **vraie** hauteur parent → le geomorphing fond proprement.

## Plan de test

- [ ] CI : `terrain.vert` recompile en SPIR-V ; build vert.
- [ ] En jeu : sur une colline, **plus de tirets sombres** qui apparaissent en fondu quand on avance.
- [ ] Le terrain reste correct (pas de nouvelle déformation à la transition de LOD).

## Si des coutures résiduelles subsistent

Le morph fixé devrait supprimer les marques de la **bande de transition** (le symptôme observé). S'il reste des **T-junctions franches** aux frontières entre patches de LOD voisins (cas classique), l'étape suivante sera d'ajouter des **skirts/jupes** au mesh de patch (`TerrainMesh.cpp`) — PR séparée.

## Déploiement

✅ **Client uniquement** (shader terrain) — pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)