### PR TITLE
feat(terrain): collision via IHeightField — la collision suivra la source rendue (Phase 2, chantier C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1027,10 +1027,14 @@ target_link_libraries(terrain_chunk_grid_tests PRIVATE engine_core)
 add_test(NAME terrain_chunk_grid_tests COMMAND terrain_chunk_grid_tests)
 
 # Chantier C Phase 2 — Tests des IHeightField (heightmap repli + chunk résident).
-# CPU pur (StreamCache::Insert + LoadFromCache, aucune I/O Vulkan/disque) : pas
-# de garde WIN32, exécuté par ctest Linux comme terrain_chunk_grid_tests.
-lcdlln_add_simple_test(height_field_tests
-  src/client/world/terrain/tests/HeightFieldTests.cpp)
+# CPU pur (StreamCache::Insert + LoadFromCache, aucune I/O Vulkan/disque).
+# Pattern cross-platform IDENTIQUE à terrain_chunk_grid_tests (add_executable +
+# link engine_core + add_test) : compile sur Windows ET Linux, exécuté par ctest.
+# NE PAS utiliser lcdlln_add_simple_test ici : ce helper applique -Wall/-Wextra/
+# -Wpedantic + pthread (GCC/Clang/Linux only) que MSVC rejette (D8021 /Wextra).
+add_executable(height_field_tests src/client/world/terrain/tests/HeightFieldTests.cpp)
+target_link_libraries(height_field_tests PRIVATE engine_core)
+add_test(NAME height_field_tests COMMAND height_field_tests)
 
 # M100.49 — Tests Tutorial & Overlay (moteur de sequence + systeme tutoriel +
 # registre widgets). Diagnostic differe (depend de M100.48). Ancrage distinct

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,8 @@ add_library(engine_core
   src/client/world/terrain/SplatMap.cpp
   src/client/world/terrain/TerrainChunk.cpp
   src/client/world/terrain/TerrainChunkLoader.cpp
+  src/client/world/terrain/HeightmapHeightField.cpp
+  src/client/world/terrain/ChunkHeightField.cpp
   src/client/world/terrain/TerrainLodChain.cpp
   src/client/world/terrain/TerrainLodWorker.cpp
   src/client/world/terrain/TerrainMeshBuilder.cpp
@@ -1023,6 +1025,12 @@ add_test(NAME wind_tests COMMAND wind_tests)
 add_executable(terrain_chunk_grid_tests src/client/world/tests/TerrainChunkGridTests.cpp)
 target_link_libraries(terrain_chunk_grid_tests PRIVATE engine_core)
 add_test(NAME terrain_chunk_grid_tests COMMAND terrain_chunk_grid_tests)
+
+# Chantier C Phase 2 — Tests des IHeightField (heightmap repli + chunk résident).
+# CPU pur (StreamCache::Insert + LoadFromCache, aucune I/O Vulkan/disque) : pas
+# de garde WIN32, exécuté par ctest Linux comme terrain_chunk_grid_tests.
+lcdlln_add_simple_test(height_field_tests
+  src/client/world/terrain/tests/HeightFieldTests.cpp)
 
 # M100.49 — Tests Tutorial & Overlay (moteur de sequence + systeme tutoriel +
 # registre widgets). Diagnostic differe (depend de M100.48). Ancrage distinct

--- a/docs/superpowers/plans/2026-06-05-terrain-phase2-iheightfield.md
+++ b/docs/superpowers/plans/2026-06-05-terrain-phase2-iheightfield.md
@@ -1,0 +1,315 @@
+# Terrain Phase 2 — Collision via `IHeightField` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Brancher la collision terrain sur la source réellement rendue, via une interface `IHeightField` (source chunkée prioritaire + repli heightmap), pour que « le joueur marche sur ce qu'il voit » dès que des zones chunkées seront embarquées.
+
+**Architecture:** Interface pure `IHeightField` avec deux implémentations — `HeightmapHeightField` (wrappe `TerrainRenderer`) et `ChunkHeightField` (chunks `terrain.bin` résidents via `StreamCache`, grille 256 m de la Phase 1). `TerrainCollider` prend une stratégie « chunk si résident, sinon heightmap ». Refactor **sûr** : aucune carte ne livre de `terrain.bin` aujourd'hui → `ChunkHeightField::IsLoadedAt` toujours faux → repli heightmap → comportement strictement inchangé sur le contenu actuel.
+
+**Tech Stack:** C++17. Tests : exécutables C++ autonomes (`lcdlln_add_simple_test`, exécutés par ctest Linux). **Pas de build local** : compile + ctest validés en CI ; effet runtime invisible tant qu'aucun chunk livré → valider surtout la **non-régression heightmap** + le test unitaire des height fields.
+
+**Référence spec :** `docs/superpowers/specs/2026-06-05-unification-terrain-design.md` (Phase 2).
+
+**Portée :** client uniquement — **pas de redéploiement serveur**. Ces `.cpp` ne vont PAS dans `server_app`. Aucune modif `frontFace`/`cullMode`/winding.
+
+---
+
+## Ordre
+
+Task 1 (interface + impls + test) → Task 2 (TerrainCollider) → Task 3 (Engine injection) → Task 4 (validation). Chaque commit compile.
+
+## File Structure
+
+- **Create** `src/client/world/terrain/IHeightField.h` — interface pure.
+- **Create** `src/client/world/terrain/HeightmapHeightField.{h,cpp}` — wrappe `TerrainRenderer`.
+- **Create** `src/client/world/terrain/ChunkHeightField.{h,cpp}` — chunks résidents (StreamCache + grille 256).
+- **Create** `src/client/world/terrain/tests/HeightFieldTests.cpp` — test unitaire.
+- **Modify** `CMakeLists.txt` — enregistrer les 2 `.cpp` (engine_core) + le test.
+- **Modify** `src/client/gameplay/TerrainCollider.{h,cpp}` — `BindTerrain` → `BindHeightFields`, `GroundHeightAt` stratégie.
+- **Modify** `src/client/app/Engine.{h,cpp}` — construire/injecter les height fields.
+
+---
+
+### Task 1: Interface `IHeightField` + implémentations + test
+
+> Vérif Task 1 : pas de build local → CI compile + ctest. Avant d'écrire le test, VÉRIFIER l'existence réelle des helpers utilisés (`StreamCache::Insert`/`Lookup`, `terrain::LoadFromCache`, `MakeTerrainCacheKey`, `TerrainChunk::SaveTerrainBin`/`MakeFlat`/`SampleHeight`) et ADAPTER aux signatures réelles ; sinon construire le test avec les primitives qui existent (l'objectif : prouver IsLoadedAt false→true quand un terrain.bin est inséré, et HeightAt = hauteur du chunk).
+
+- [ ] **Step 1 — `src/client/world/terrain/IHeightField.h`** (interface pure, aucun include lourd) :
+```cpp
+#pragma once
+
+namespace engine::world::terrain
+{
+    /// Phase 2 (chantier C) — abstraction d'une source de hauteur de sol
+    /// échantillonnable en coordonnées monde (mètres). Découple la collision
+    /// (`TerrainCollider`) de la source concrète (heightmap legacy ou chunks
+    /// streamés). Implémentations NON-BLOQUANTES, appelables en main thread
+    /// (aucune lecture disque synchrone dans le chemin collision).
+    class IHeightField
+    {
+    public:
+        virtual ~IHeightField() = default;
+
+        /// Altitude du sol (m monde) en (worldX, worldZ), filtrage bilinéaire.
+        /// Toujours fini (jamais NaN) : repli sûr 0.0 si indisponible.
+        virtual float HeightAt(float worldX, float worldZ) const = 0;
+
+        /// Vrai si cette source fournit une hauteur fiable en (worldX, worldZ)
+        /// SANS déclencher de chargement (aucune I/O). Sert d'aiguillage.
+        virtual bool IsLoadedAt(float worldX, float worldZ) const = 0;
+    };
+}
+```
+
+- [ ] **Step 2 — `HeightmapHeightField.{h,cpp}`** (wrappe `TerrainRenderer`).
+
+`.h` :
+```cpp
+#pragma once
+#include "src/client/world/terrain/IHeightField.h"
+
+namespace engine::render::terrain { class TerrainRenderer; }  // forward
+
+namespace engine::world::terrain
+{
+    /// `IHeightField` adossé à la heightmap legacy (`TerrainRenderer`). Non-owning.
+    class HeightmapHeightField final : public IHeightField
+    {
+    public:
+        explicit HeightmapHeightField(const engine::render::terrain::TerrainRenderer* renderer);
+        float HeightAt(float worldX, float worldZ) const override;
+        bool  IsLoadedAt(float worldX, float worldZ) const override;
+    private:
+        const engine::render::terrain::TerrainRenderer* m_renderer = nullptr;
+    };
+}
+```
+
+`.cpp` :
+```cpp
+#include "src/client/world/terrain/HeightmapHeightField.h"
+#include "src/client/render/terrain/TerrainRenderer.h"
+
+namespace engine::world::terrain
+{
+    HeightmapHeightField::HeightmapHeightField(
+        const engine::render::terrain::TerrainRenderer* renderer)
+        : m_renderer(renderer) {}
+
+    float HeightmapHeightField::HeightAt(float worldX, float worldZ) const
+    {
+        if (m_renderer == nullptr) return 0.0f;
+        return m_renderer->SampleHeightAtWorldXZ(worldX, worldZ);
+    }
+
+    bool HeightmapHeightField::IsLoadedAt(float /*worldX*/, float /*worldZ*/) const
+    {
+        return m_renderer != nullptr && m_renderer->IsValid();
+    }
+}
+```
+> Vérifier les signatures réelles : `SampleHeightAtWorldXZ(float,float) const` (`TerrainRenderer.h:185`), `IsValid()` (`.h:135`). `SampleHeightAtWorldXZ` retombe déjà sur 0 si pas de heightmap (pas de NaN).
+
+- [ ] **Step 3 — `ChunkHeightField.{h,cpp}`** (chunks résidents, grille 256).
+
+`.h` :
+```cpp
+#pragma once
+#include "src/client/world/terrain/IHeightField.h"
+#include <memory>
+
+namespace engine::core { class Config; }
+namespace engine::world { class StreamCache; }
+
+namespace engine::world::terrain
+{
+    class TerrainChunk;
+
+    /// `IHeightField` adossé aux chunks `terrain.bin` streamés (grille 256 m).
+    /// Échantillonne UNIQUEMENT des chunks DÉJÀ résidents (lookup LRU pur, 0 I/O).
+    /// Main-thread (StreamCache main-thread-only). Aujourd'hui : aucun terrain.bin
+    /// livré → IsLoadedAt toujours faux → repli heightmap (comportement inchangé).
+    class ChunkHeightField final : public IHeightField
+    {
+    public:
+        ChunkHeightField(engine::world::StreamCache* cache, const engine::core::Config* config);
+        float HeightAt(float worldX, float worldZ) const override;
+        bool  IsLoadedAt(float worldX, float worldZ) const override;
+    private:
+        std::shared_ptr<const TerrainChunk> ResidentChunkAt(float worldX, float worldZ) const;
+        engine::world::StreamCache* m_cache  = nullptr;
+        const engine::core::Config* m_config = nullptr;
+    };
+}
+```
+
+`.cpp` :
+```cpp
+#include "src/client/world/terrain/ChunkHeightField.h"
+
+#include "src/client/world/StreamCache.h"
+#include "src/client/world/WorldModel.h"                  // WorldToTerrainChunkCoord, kTerrainChunkSizeMeters
+#include "src/client/world/terrain/TerrainChunk.h"
+#include "src/client/world/terrain/TerrainChunkLoader.h"  // LoadFromCache, MakeTerrainCacheKey
+
+#include <string>
+
+namespace engine::world::terrain
+{
+    ChunkHeightField::ChunkHeightField(engine::world::StreamCache* cache,
+                                       const engine::core::Config* config)
+        : m_cache(cache), m_config(config) {}
+
+    std::shared_ptr<const TerrainChunk>
+    ChunkHeightField::ResidentChunkAt(float worldX, float worldZ) const
+    {
+        if (m_cache == nullptr) return nullptr;
+        const engine::world::GlobalChunkCoord c =
+            engine::world::WorldToTerrainChunkCoord(worldX, worldZ);
+        const std::string key = MakeTerrainCacheKey(c.x, c.z);
+        std::string err;
+        return LoadFromCache(*m_cache, key, err);  // lookup PUR (LRU), nullptr si absent
+    }
+
+    bool ChunkHeightField::IsLoadedAt(float worldX, float worldZ) const
+    {
+        return ResidentChunkAt(worldX, worldZ) != nullptr;
+    }
+
+    float ChunkHeightField::HeightAt(float worldX, float worldZ) const
+    {
+        auto chunk = ResidentChunkAt(worldX, worldZ);
+        if (!chunk) return 0.0f;
+        const engine::world::GlobalChunkCoord c =
+            engine::world::WorldToTerrainChunkCoord(worldX, worldZ);
+        const float originX = static_cast<float>(c.x) * static_cast<float>(engine::world::kTerrainChunkSizeMeters);
+        const float originZ = static_cast<float>(c.z) * static_cast<float>(engine::world::kTerrainChunkSizeMeters);
+        return chunk->SampleHeight(worldX - originX, worldZ - originZ);  // bilinéaire, clamp aux bords
+    }
+}
+```
+> VÉRIFIER les signatures réelles avant d'écrire : `WorldToTerrainChunkCoord` / `kTerrainChunkSizeMeters` (`WorldModel.h`), `MakeTerrainCacheKey(int,int)` + `LoadFromCache(StreamCache&, const std::string&, std::string&)` (`TerrainChunkLoader.h`), `TerrainChunk::SampleHeight(float,float) const` (`TerrainChunk.h`). Si `LoadFromCache` ne renvoie pas un `shared_ptr<TerrainChunk>`, adapter le type de retour de `ResidentChunkAt`. CONFIRMER que `LoadFromCache` ne fait AUCUNE I/O (juste `Lookup` + désérialisation) ; si la seule primitive disponible déclenche un load disque, NE PAS l'utiliser et signaler (NEEDS_CONTEXT).
+
+- [ ] **Step 4 — Test `src/client/world/terrain/tests/HeightFieldTests.cpp`** (CPU pur). Macro `REQUIRE` maison + `main()` retournant le nombre d'échecs (motif des tests du repo). Couvre :
+  - `HeightmapHeightField(nullptr)` → `HeightAt==0`, `IsLoadedAt==false`.
+  - `ChunkHeightField` avec `StreamCache` réel : insérer un `terrain.bin` synthétique (chunk plat de hauteur 42) pour la coord (0,0) ; vérifier `IsLoadedAt(10,10)==true`, `IsLoadedAt(300,10)==false` (chunk (1,0) absent), `HeightAt(10,10) ≈ 42`. Prouve la chaîne monde→chunk→local + l'aiguillage résident.
+
+  Adapter aux primitives réelles (insertion cache, construction d'un `TerrainChunk` plat, sérialisation). Si l'insertion d'un blob dans le `StreamCache` n'est pas possible simplement, tester au minimum `HeightmapHeightField(nullptr)` + la conversion via une sonde indirecte, et documenter la limite.
+
+- [ ] **Step 5 — CMake.** Ajouter les 2 `.cpp` aux sources `engine_core` (racine `CMakeLists.txt`, près des `src/client/world/terrain/*.cpp`). Enregistrer le test via `lcdlln_add_simple_test` (motif `terrain_collider_tests`, sans garde `WIN32`, exécuté par ctest Linux) — vérifier le nom exact du helper dans `cmake/` ou `src/CMakeLists.txt`. **Ne PAS** ajouter ces fichiers à `server_app`/`shard_app`.
+
+- [ ] **Step 6 — Commit**
+```bash
+git add src/client/world/terrain/IHeightField.h \
+        src/client/world/terrain/HeightmapHeightField.h src/client/world/terrain/HeightmapHeightField.cpp \
+        src/client/world/terrain/ChunkHeightField.h src/client/world/terrain/ChunkHeightField.cpp \
+        src/client/world/terrain/tests/HeightFieldTests.cpp CMakeLists.txt
+git commit -m "feat(terrain): IHeightField + heightmap/chunk height fields (Phase 2)"
+```
+
+---
+
+### Task 2: Rebrancher `TerrainCollider` sur `IHeightField`
+
+> Vérif Task 2 : compile CI. `SweepCapsule`/`QueryWater` n'appellent que `GroundHeightAt` en interne → bénéficient transparemment. Aucun test à modifier (les tests collision testent le cas non-bound). VÉRIFIER qu'aucun test n'appelle `BindTerrain`.
+
+- [ ] **Step 1 — `TerrainCollider.h`.** Remplacer le forward-declare `TerrainRenderer`, l'API `BindTerrain` et le membre `m_terrain` par :
+```cpp
+namespace engine::world::terrain { class IHeightField; }  // forward
+...
+public:
+    /// Bind les sources de hauteur (non-owning). chunkField = prioritaire si
+    /// résident ; heightmapField = repli. L'un/l'autre peut être nullptr.
+    /// Remplace BindTerrain(TerrainRenderer*) (Phase 2, chantier C).
+    void BindHeightFields(const engine::world::terrain::IHeightField* chunkField,
+                          const engine::world::terrain::IHeightField* heightmapField);
+...
+private:
+    const engine::world::terrain::IHeightField* m_chunkField = nullptr;
+    const engine::world::terrain::IHeightField* m_heightmapField = nullptr;
+```
+(Conserver `GroundHeightAt`, `SweepCapsule`, `QueryWater`, `BindWater` à l'identique.)
+
+- [ ] **Step 2 — `TerrainCollider.cpp`.** Remplacer `BindTerrain` + `GroundHeightAt` :
+```cpp
+void TerrainCollider::BindHeightFields(
+    const engine::world::terrain::IHeightField* chunkField,
+    const engine::world::terrain::IHeightField* heightmapField)
+{
+    m_chunkField     = chunkField;
+    m_heightmapField = heightmapField;
+}
+
+float TerrainCollider::GroundHeightAt(float worldX, float worldZ) const
+{
+    // Phase 2 : chunk résident prioritaire (autorité quand zones chunkées
+    // embarquées), sinon repli heightmap, sinon plat 0. Aucune I/O (IsLoadedAt
+    // = lookup cache pur). Aujourd'hui : pas de terrain.bin → toujours repli
+    // heightmap → comportement inchangé vs Phase 1.
+    if (m_chunkField != nullptr && m_chunkField->IsLoadedAt(worldX, worldZ))
+        return m_chunkField->HeightAt(worldX, worldZ);
+    if (m_heightmapField != nullptr)
+        return m_heightmapField->HeightAt(worldX, worldZ);
+    return 0.0f;
+}
+```
+Remplacer l'include `TerrainRenderer.h` (devenu inutile si plus référencé) par `#include "src/client/world/terrain/IHeightField.h"`. Vérifier que `WaterSurfaces.h` et les autres includes restent.
+
+- [ ] **Step 3 — Commit**
+```bash
+git add src/client/gameplay/TerrainCollider.h src/client/gameplay/TerrainCollider.cpp
+git commit -m "feat(terrain): TerrainCollider échantillonne via IHeightField (Phase 2)"
+```
+
+---
+
+### Task 3: Engine — construire et injecter les height fields
+
+> Vérif Task 3 : compile CI. VÉRIFIER l'ordre de boot (m_streamCache.Init et m_terrain.Init avant le bind) et les noms réels (`m_streamCache`, `m_terrain`, `m_cfg`, le call-site `BindTerrain`).
+
+- [ ] **Step 1 — `Engine.h`.** Inclure les 2 headers ; ajouter 2 membres `unique_ptr` près de `m_terrainCollider` :
+```cpp
+#include "src/client/world/terrain/HeightmapHeightField.h"
+#include "src/client/world/terrain/ChunkHeightField.h"
+...
+    std::unique_ptr<engine::world::terrain::HeightmapHeightField> m_heightmapField;
+    std::unique_ptr<engine::world::terrain::ChunkHeightField>     m_chunkField;
+```
+
+- [ ] **Step 2 — `Engine.cpp`.** Remplacer le bind au boot (chercher `m_terrainCollider.BindTerrain(&m_terrain);`) :
+```cpp
+// Phase 2 (chantier C) — construire les IHeightField et les injecter.
+// Chunk (terrain.bin résidents, grille 256) prioritaire si résident ; repli
+// heightmap (m_terrain) sinon. m_streamCache et m_terrain déjà Init à ce point.
+m_heightmapField = std::make_unique<engine::world::terrain::HeightmapHeightField>(&m_terrain);
+m_chunkField     = std::make_unique<engine::world::terrain::ChunkHeightField>(&m_streamCache, &m_cfg);
+m_terrainCollider.BindHeightFields(m_chunkField.get(), m_heightmapField.get());
+```
+VÉRIFIER : le nom réel du membre StreamCache (`m_streamCache` ?) et du Config (`m_cfg`), et que ce bloc s'exécute APRÈS `m_streamCache.Init(...)` et l'init de `m_terrain`. Si le StreamCache n'est pas un membre Engine accessible (ex. possédé par `TerrainChunkRenderer`), retourner NEEDS_CONTEXT avec l'emplacement réel.
+
+- [ ] **Step 3 — Aucun autre call-site.** Tous les `m_terrainCollider.GroundHeightAt(...)` restent inchangés. Laisser le `m_terrain.SampleHeightAtWorldXZ(...)` direct (cadrage caméra/HLOD, hors collision) tel quel.
+
+- [ ] **Step 4 — Commit**
+```bash
+git add src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(terrain): Engine injecte les height fields dans le collider (Phase 2)"
+```
+
+---
+
+### Task 4: Validation (non-régression + contrat futur)
+
+- [ ] **CI** : `build-windows` (compile) + `build-linux` (compile + ctest, dont `height_field_tests`, `terrain_collider_tests`) verts.
+- [ ] **Non-régression heightmap** (cœur de la Phase 2) sur `demo_plains` : spawn au sol, marche/saut/pente, snap des entités (coffre/villageois/props), nage — **comportement visuellement identique** à avant (aucun terrain.bin → repli heightmap systématique).
+- [ ] **Contrat futur** : le test unitaire prouve qu'un chunk résident fait basculer `IsLoadedAt`→true et `HeightAt` sur la hauteur du chunk → la collision suivra une zone chunkée dès qu'embarquée.
+- [ ] **Anti-NaN** : les 3 chemins de `GroundHeightAt` retournent fini.
+
+---
+
+## Self-Review
+
+- **Couverture spec** : `IHeightField` (HeightAt/IsLoadedAt) ; `HeightmapHeightField` (wrappe TerrainRenderer) ; `ChunkHeightField` (StreamCache résident + grille 256 + SampleHeight) ; `TerrainCollider` stratégie chunk+fallback ; injection Engine. ✅
+- **Sûreté** : aucune I/O en collision (lookup cache pur) ; main-thread (frame loop) ; repli sûr 3 niveaux (chunk→heightmap→0), jamais de NaN. ✅
+- **Refactor sans régression** : aucun terrain.bin livré → IsLoadedAt toujours faux → repli heightmap → comportement inchangé. ✅
+- **Périmètre** : 1 seul call-site change de signature (`BindTerrain`→`BindHeightFields`) ; tous les `GroundHeightAt` inchangés ; `9230` (cadrage) non touché ; client-only (pas de server_app). ✅
+- **Risques à surveiller (exécutant)** : (1) signatures réelles `LoadFromCache`/`MakeTerrainCacheKey`/`SampleHeight` à confirmer ; (2) StreamCache accessible depuis Engine ; (3) helper CMake de test (`lcdlln_add_simple_test`) et exécution ctest Linux ; (4) coût CPU de `LoadFromCache` par appel (nul aujourd'hui ; cache 1-entrée à différer) ; (5) si un `GroundHeightAt` hors main-thread apparaissait, ajouter une synchro (hors périmètre).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4875,7 +4875,14 @@ namespace engine
 										// echantillonnant le sol + half-capsule (0.9 m = height/2) pour eviter
 										// que la sphere du bas de la capsule traverse le sol au premier sweep.
 										{
-											m_terrainCollider.BindTerrain(&m_terrain);
+											// Phase 2 (chantier C) — construire les IHeightField et les
+											// injecter dans le collider. Chunk (terrain.bin residents,
+											// grille 256) prioritaire si resident ; repli heightmap
+											// (m_terrain) sinon. m_streamCache (Init ~ligne 1365) et
+											// m_terrain (Init ~ligne 3538) deja initialises a ce point.
+											m_heightmapField = std::make_unique<engine::world::terrain::HeightmapHeightField>(&m_terrain);
+											m_chunkField     = std::make_unique<engine::world::terrain::ChunkHeightField>(&m_streamCache, &m_cfg);
+											m_terrainCollider.BindHeightFields(m_chunkField.get(), m_heightmapField.get());
 
 											// Nage (v1) : eau-test procedurale. La zone demo est plate et sans
 											// eau ; on pose un BASSIN DE TEST au-dessus du sol pour valider la

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -72,6 +72,8 @@
 #include "src/client/render/GpuUploadQueue.h"
 #include "src/client/render/vk/StagingAllocator.h"
 #include "src/client/render/terrain/TerrainRenderer.h"
+#include "src/client/world/terrain/HeightmapHeightField.h"
+#include "src/client/world/terrain/ChunkHeightField.h"
 #include "src/client/render/terrain_chunk/TerrainChunkRenderer.h"
 // Sous-projet A (Task 15) : skinned humanoid avatar runtime.
 #include "src/client/render/skinned/SkinnedRenderer.h"
@@ -957,6 +959,12 @@ namespace engine
 		/// puisse decider Idle/Walk/Run/Jump sans avoir a reconstruire l'input.
 		engine::gameplay::CharacterController                     m_characterController;
 		engine::gameplay::TerrainCollider                         m_terrainCollider;
+		/// Phase 2 (chantier C) — sources de hauteur injectées dans
+		/// `m_terrainCollider` au boot (BindHeightFields). `m_chunkField`
+		/// (terrain.bin résidents) prioritaire si résident ; `m_heightmapField`
+		/// (wrappe `m_terrain`) en repli. Non-owning vis-à-vis de leurs sources.
+		std::unique_ptr<engine::world::terrain::HeightmapHeightField> m_heightmapField;
+		std::unique_ptr<engine::world::terrain::ChunkHeightField>     m_chunkField;
 		float                                                     m_avatarYaw = 3.14159265f;
 		uint32_t m_gameplayInputSeq = 0;         ///< TC.2 : séquence monotone des Input UDP.
 		float    m_gameplayInputAccumSec = 0.0f; ///< TC.2 : accumulateur de cadence d'envoi.

--- a/src/client/gameplay/TerrainCollider.cpp
+++ b/src/client/gameplay/TerrainCollider.cpp
@@ -1,5 +1,5 @@
 #include "src/client/gameplay/TerrainCollider.h"
-#include "src/client/render/terrain/TerrainRenderer.h"
+#include "src/client/world/terrain/IHeightField.h"
 #include "src/client/world/water/WaterSurfaces.h"
 
 #include <algorithm>
@@ -12,24 +12,33 @@ namespace engine::gameplay
 TerrainCollider::TerrainCollider() = default;
 TerrainCollider::~TerrainCollider() = default;
 
-/// Bind / debind le pointeur terrain (non-owning).
-void TerrainCollider::BindTerrain(const engine::render::terrain::TerrainRenderer* terrainRenderer)
+/// Bind / debind les sources de hauteur (non-owning).
+void TerrainCollider::BindHeightFields(
+    const engine::world::terrain::IHeightField* chunkField,
+    const engine::world::terrain::IHeightField* heightmapField)
 {
-    m_terrain = terrainRenderer;
+    m_chunkField     = chunkField;
+    m_heightmapField = heightmapField;
 }
 
 /// Echantillonne la hauteur du sol en metres a (worldX, worldZ).
-/// Delegue a `TerrainRenderer::SampleHeightAtWorldXZ` qui gere :
-///   - origine monde (config `terrain.origin_x/z`, defaut -512),
-///   - taille monde (config `terrain.world_size`, defaut 1024),
-///   - height_scale (config, defaut 200),
-///   - interpolation bilineaire,
-///   - edge-clamp hors-terrain.
-/// Retourne 0.0 si aucun terrain n'est bind (placeholder flat).
+///
+/// Phase 2 (chantier C) : strategie a trois niveaux, sans aucune I/O dans le
+/// chemin collision (`IsLoadedAt` = lookup cache pur) :
+///   1. chunk resident prioritaire (autorite quand des zones chunkees sont
+///      embarquees : le joueur marche sur ce qu'il voit),
+///   2. sinon repli sur la heightmap legacy,
+///   3. sinon sol plat a Y=0.
+/// Aujourd'hui aucune carte ne livre de `terrain.bin` -> `IsLoadedAt` toujours
+/// faux -> repli heightmap systematique -> comportement inchange vs Phase 1.
+/// Chaque chemin retourne une valeur finie (jamais NaN).
 float TerrainCollider::GroundHeightAt(float worldX, float worldZ) const
 {
-    if (m_terrain == nullptr) return 0.0f;
-    return m_terrain->SampleHeightAtWorldXZ(worldX, worldZ);
+    if (m_chunkField != nullptr && m_chunkField->IsLoadedAt(worldX, worldZ))
+        return m_chunkField->HeightAt(worldX, worldZ);
+    if (m_heightmapField != nullptr)
+        return m_heightmapField->HeightAt(worldX, worldZ);
+    return 0.0f;
 }
 
 /// Sweep vertical approxime contre le sol terrain (MVP B.1).

--- a/src/client/gameplay/TerrainCollider.h
+++ b/src/client/gameplay/TerrainCollider.h
@@ -2,9 +2,9 @@
 
 #include "src/client/gameplay/CharacterController.h"  // for IWorldCollider
 
-namespace engine::render::terrain
+namespace engine::world::terrain
 {
-    class TerrainRenderer;  // forward
+    class IHeightField;  // forward (Phase 2 : source de hauteur abstraite)
 }
 
 namespace engine::world::water
@@ -17,10 +17,11 @@ namespace engine::gameplay
 
 /// Implementation de IWorldCollider pour le terrain heightmap (B.1).
 ///
-/// Bind sur un TerrainRenderer deja initialise ; les requetes de hauteur
-/// passent par `TerrainRenderer::SampleHeightAtWorldXZ` (bilineaire, origin /
-/// worldSize / heightScale gerees par le renderer). `SweepCapsule` realise
-/// un sweep vertical approxime contre le sol : si la capsule traverse le
+/// Bind sur une ou deux sources `IHeightField` (Phase 2, chantier C) : un
+/// champ chunke prioritaire (residents) et un champ heightmap de repli. Les
+/// requetes de hauteur passent par `GroundHeightAt` qui aiguille chunk ->
+/// heightmap -> sol plat. `SweepCapsule` realise un sweep vertical approxime
+/// contre le sol echantillonne par `GroundHeightAt` : si la capsule traverse le
 /// terrain entre `startCenter` et `endCenter`, on renvoie le hit avec la
 /// fraction lineaire correspondante (approximation valable pour pentes
 /// faibles et pas de simulation court).
@@ -36,10 +37,13 @@ public:
     TerrainCollider();
     ~TerrainCollider() override;
 
-    /// Bind sur le terrain (non-owning). Doit etre appele avant toute
-    /// requete (`SweepCapsule`, `GroundHeightAt`). Passer `nullptr` pour
-    /// debinder (toutes les requetes renvoient alors un sol plat a Y=0).
-    void BindTerrain(const engine::render::terrain::TerrainRenderer* terrainRenderer);
+    /// Bind les sources de hauteur (non-owning). `chunkField` est prioritaire
+    /// quand il est resident (zones chunkees embarquees) ; `heightmapField`
+    /// sert de repli (heightmap legacy). L'un ou l'autre peut etre `nullptr`
+    /// (collider non-bound -> sol plat a Y=0). Remplace
+    /// `BindTerrain(TerrainRenderer*)` (Phase 2, chantier C).
+    void BindHeightFields(const engine::world::terrain::IHeightField* chunkField,
+                          const engine::world::terrain::IHeightField* heightmapField);
 
     /// IWorldCollider : sweep capsule du centre `startCenter` vers `endCenter`.
     /// Retourne true ssi le sweep traverse le sol pendant le mouvement ;
@@ -66,9 +70,12 @@ public:
     bool QueryWater(const engine::math::Vec3& worldCenter, WaterQuery& out) const override;
 
 private:
-    /// Non-owning. Lifetime garanti par l'appelant (le terrain vit aussi
-    /// longtemps que le collider qui s'y refere).
-    const engine::render::terrain::TerrainRenderer* m_terrain = nullptr;
+    /// Non-owning. Source de hauteur prioritaire (chunks residents, grille 256).
+    /// Lifetime garanti par l'appelant. nullptr = pas de source chunkee.
+    const engine::world::terrain::IHeightField* m_chunkField = nullptr;
+    /// Non-owning. Source de hauteur de repli (heightmap legacy). Lifetime
+    /// garanti par l'appelant. nullptr = pas de repli (sol plat a Y=0).
+    const engine::world::terrain::IHeightField* m_heightmapField = nullptr;
     /// Non-owning. Scene d'eau pour QueryWater (nage). nullptr = pas d'eau.
     const engine::world::water::WaterScene* m_water = nullptr;
 };

--- a/src/client/world/terrain/ChunkHeightField.cpp
+++ b/src/client/world/terrain/ChunkHeightField.cpp
@@ -1,0 +1,48 @@
+#include "src/client/world/terrain/ChunkHeightField.h"
+
+#include "src/client/world/StreamCache.h"
+#include "src/client/world/WorldModel.h"                  // WorldToTerrainChunkCoord, kTerrainChunkSizeMeters
+#include "src/client/world/terrain/TerrainChunk.h"
+#include "src/client/world/terrain/TerrainChunkLoader.h"  // LoadFromCache, MakeTerrainCacheKey
+
+#include <string>
+
+namespace engine::world::terrain
+{
+    ChunkHeightField::ChunkHeightField(engine::world::StreamCache* cache,
+                                       const engine::core::Config* config)
+        : m_cache(cache), m_config(config) {}
+
+    std::shared_ptr<const TerrainChunk>
+    ChunkHeightField::ResidentChunkAt(float worldX, float worldZ) const
+    {
+        if (m_cache == nullptr) return nullptr;
+        const engine::world::GlobalChunkCoord c =
+            engine::world::WorldToTerrainChunkCoord(worldX, worldZ);
+        const std::string key = MakeTerrainCacheKey(c.x, c.z);
+        std::string err;
+        // LoadFromCache = lookup PUR (StreamCache::Lookup + désérialisation) :
+        // aucune I/O disque, nullptr si la clé n'est pas résidente.
+        return LoadFromCache(*m_cache, key, err);
+    }
+
+    bool ChunkHeightField::IsLoadedAt(float worldX, float worldZ) const
+    {
+        return ResidentChunkAt(worldX, worldZ) != nullptr;
+    }
+
+    float ChunkHeightField::HeightAt(float worldX, float worldZ) const
+    {
+        auto chunk = ResidentChunkAt(worldX, worldZ);
+        if (!chunk) return 0.0f;
+        const engine::world::GlobalChunkCoord c =
+            engine::world::WorldToTerrainChunkCoord(worldX, worldZ);
+        // Origine monde du chunk = index * taille de la grille terrain (256 m).
+        const float originX = static_cast<float>(c.x)
+            * static_cast<float>(engine::world::kTerrainChunkSizeMeters);
+        const float originZ = static_cast<float>(c.z)
+            * static_cast<float>(engine::world::kTerrainChunkSizeMeters);
+        // SampleHeight attend des coords chunk-locales (m) ; bilinéaire + clamp.
+        return chunk->SampleHeight(worldX - originX, worldZ - originZ);
+    }
+}

--- a/src/client/world/terrain/ChunkHeightField.h
+++ b/src/client/world/terrain/ChunkHeightField.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "src/client/world/terrain/IHeightField.h"
+#include <memory>
+
+namespace engine::core { class Config; }
+namespace engine::world { class StreamCache; }
+
+namespace engine::world::terrain
+{
+    struct TerrainChunk;
+
+    /// `IHeightField` adossé aux chunks `terrain.bin` streamés (grille 256 m).
+    /// Échantillonne UNIQUEMENT des chunks DÉJÀ résidents (lookup LRU pur, 0 I/O).
+    /// Main-thread (StreamCache main-thread-only). Aujourd'hui : aucun terrain.bin
+    /// livré → IsLoadedAt toujours faux → repli heightmap (comportement inchangé).
+    class ChunkHeightField final : public IHeightField
+    {
+    public:
+        /// \param cache  Cache LRU des blobs `terrain.bin` (non-owning). Si
+        ///        nullptr, IsLoadedAt est toujours faux et HeightAt retombe sur 0.
+        /// \param config Réservé (cohérence d'API / futurs paramètres de zone) ;
+        ///        non utilisé dans le chemin résident pur (aucune I/O).
+        ChunkHeightField(engine::world::StreamCache* cache, const engine::core::Config* config);
+
+        float HeightAt(float worldX, float worldZ) const override;
+        bool  IsLoadedAt(float worldX, float worldZ) const override;
+
+    private:
+        /// Retourne le chunk terrain résident couvrant (worldX, worldZ) via un
+        /// lookup cache PUR (aucune I/O disque), ou nullptr si absent du cache.
+        std::shared_ptr<const TerrainChunk> ResidentChunkAt(float worldX, float worldZ) const;
+
+        engine::world::StreamCache* m_cache  = nullptr;
+        const engine::core::Config* m_config = nullptr;
+    };
+}

--- a/src/client/world/terrain/HeightmapHeightField.cpp
+++ b/src/client/world/terrain/HeightmapHeightField.cpp
@@ -1,0 +1,24 @@
+#include "src/client/world/terrain/HeightmapHeightField.h"
+#include "src/client/render/terrain/TerrainRenderer.h"
+
+namespace engine::world::terrain
+{
+    HeightmapHeightField::HeightmapHeightField(
+        const engine::render::terrain::TerrainRenderer* renderer)
+        : m_renderer(renderer) {}
+
+    float HeightmapHeightField::HeightAt(float worldX, float worldZ) const
+    {
+        // SampleHeightAtWorldXZ retombe déjà sur 0 si la heightmap n'est pas
+        // chargée (pas de NaN). On garde quand même la garde nullptr explicite.
+        if (m_renderer == nullptr) return 0.0f;
+        return m_renderer->SampleHeightAtWorldXZ(worldX, worldZ);
+    }
+
+    bool HeightmapHeightField::IsLoadedAt(float /*worldX*/, float /*worldZ*/) const
+    {
+        // La heightmap legacy couvre toute l'étendue terrain dès qu'elle est
+        // valide : pas de granularité par position (contrairement aux chunks).
+        return m_renderer != nullptr && m_renderer->IsValid();
+    }
+}

--- a/src/client/world/terrain/HeightmapHeightField.h
+++ b/src/client/world/terrain/HeightmapHeightField.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "src/client/world/terrain/IHeightField.h"
+
+namespace engine::render::terrain { class TerrainRenderer; }  // forward
+
+namespace engine::world::terrain
+{
+    /// `IHeightField` adossé à la heightmap legacy (`TerrainRenderer`). Non-owning.
+    /// Sert de source de repli quand aucun chunk `terrain.bin` n'est résident :
+    /// échantillonne la même heightmap que celle réellement rendue, donc « le
+    /// joueur marche sur ce qu'il voit » sur le contenu actuel.
+    class HeightmapHeightField final : public IHeightField
+    {
+    public:
+        /// \param renderer Source heightmap (non-owning). Peut être nullptr :
+        ///        HeightAt retombe alors sur 0 et IsLoadedAt sur false.
+        explicit HeightmapHeightField(const engine::render::terrain::TerrainRenderer* renderer);
+
+        float HeightAt(float worldX, float worldZ) const override;
+        bool  IsLoadedAt(float worldX, float worldZ) const override;
+
+    private:
+        const engine::render::terrain::TerrainRenderer* m_renderer = nullptr;
+    };
+}

--- a/src/client/world/terrain/IHeightField.h
+++ b/src/client/world/terrain/IHeightField.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace engine::world::terrain
+{
+    /// Phase 2 (chantier C) — abstraction d'une source de hauteur de sol
+    /// échantillonnable en coordonnées monde (mètres). Découple la collision
+    /// (`TerrainCollider`) de la source concrète (heightmap legacy ou chunks
+    /// streamés). Implémentations NON-BLOQUANTES, appelables en main thread
+    /// (aucune lecture disque synchrone dans le chemin collision).
+    class IHeightField
+    {
+    public:
+        virtual ~IHeightField() = default;
+
+        /// Altitude du sol (m monde) en (worldX, worldZ), filtrage bilinéaire.
+        /// Toujours fini (jamais NaN) : repli sûr 0.0 si indisponible.
+        virtual float HeightAt(float worldX, float worldZ) const = 0;
+
+        /// Vrai si cette source fournit une hauteur fiable en (worldX, worldZ)
+        /// SANS déclencher de chargement (aucune I/O). Sert d'aiguillage.
+        virtual bool IsLoadedAt(float worldX, float worldZ) const = 0;
+    };
+}

--- a/src/client/world/terrain/tests/HeightFieldTests.cpp
+++ b/src/client/world/terrain/tests/HeightFieldTests.cpp
@@ -1,0 +1,120 @@
+/// Tests unitaires pour les `IHeightField` de la collision terrain (Phase 2,
+/// chantier C).
+///
+/// Vérifient :
+///   - HeightmapHeightField(nullptr) : HeightAt == 0, IsLoadedAt == false
+///     (repli sûr quand aucune heightmap n'est branchée — anti-NaN).
+///   - ChunkHeightField avec StreamCache résident : on insère un `terrain.bin`
+///     synthétique (chunk plat à 42 m) pour la coord terrain (0,0), puis :
+///       * IsLoadedAt(10,10)  == true  (chunk (0,0) résident)
+///       * IsLoadedAt(300,10) == false (chunk (1,0) absent du cache)
+///       * HeightAt(10,10)    ≈ 42     (chaîne monde→chunk→local + SampleHeight)
+///   - ChunkHeightField(nullptr cache) : IsLoadedAt false, HeightAt 0.
+///
+/// L'insertion cache se fait via `StreamCache::Insert` (pas d'I/O disque) sur
+/// un blob produit par `SaveTerrainBin` : `LoadFromCache` (lookup pur) le
+/// retrouve sans toucher au disque. La grille terrain fait 256 m
+/// (`kTerrainChunkSizeMeters`), donc (10,10) tombe dans le chunk (0,0) et
+/// (300,10) dans le chunk (1,0).
+///
+/// HeightmapHeightField n'est testé qu'au cas nullptr : `TerrainRenderer`
+/// exige un device Vulkan et ne peut pas être instancié utilement en test CPU.
+///
+/// Style aligné sur src/client/world/terrain/tests/TerrainChunkTests.cpp
+/// (REQUIRE macro maison + main() retournant le nombre d'échecs).
+
+#include "src/client/world/terrain/ChunkHeightField.h"
+#include "src/client/world/terrain/HeightmapHeightField.h"
+#include "src/client/world/terrain/TerrainChunk.h"
+#include "src/client/world/terrain/TerrainChunkLoader.h"
+#include "src/client/world/StreamCache.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::world::StreamCache;
+	using engine::world::terrain::ChunkHeightField;
+	using engine::world::terrain::HeightmapHeightField;
+	using engine::world::terrain::TerrainChunk;
+	using engine::world::terrain::SaveTerrainBin;
+	using engine::world::terrain::MakeTerrainCacheKey;
+
+	bool ApproxEq(float a, float b, float eps = 1e-3f)
+	{
+		return std::fabs(a - b) <= eps;
+	}
+
+	/// HeightmapHeightField(nullptr) : repli sûr (0 / false), jamais de NaN.
+	void Test_HeightmapHeightField_Nullptr_SafeFallback()
+	{
+		HeightmapHeightField field(nullptr);
+		REQUIRE(ApproxEq(field.HeightAt(0.0f, 0.0f), 0.0f));
+		REQUIRE(ApproxEq(field.HeightAt(123.0f, -456.0f), 0.0f));
+		REQUIRE(field.IsLoadedAt(0.0f, 0.0f) == false);
+		REQUIRE(field.IsLoadedAt(123.0f, -456.0f) == false);
+	}
+
+	/// ChunkHeightField(nullptr cache) : pas de chunk résident → 0 / false.
+	void Test_ChunkHeightField_NullCache_SafeFallback()
+	{
+		ChunkHeightField field(nullptr, nullptr);
+		REQUIRE(field.IsLoadedAt(10.0f, 10.0f) == false);
+		REQUIRE(ApproxEq(field.HeightAt(10.0f, 10.0f), 0.0f));
+	}
+
+	/// Insère un chunk plat (42 m) en (0,0) dans le cache et vérifie
+	/// l'aiguillage résident + l'échantillonnage monde→chunk→local.
+	void Test_ChunkHeightField_ResidentChunk_SwitchesAndSamples()
+	{
+		StreamCache cache; // pas d'Init() nécessaire : capacité défaut 1 GB.
+
+		// Construire un terrain.bin synthétique : chunk plat à 42 m, coord (0,0).
+		TerrainChunk flat = TerrainChunk::MakeFlat(42.0f);
+		std::vector<uint8_t> blob;
+		std::string err;
+		REQUIRE(SaveTerrainBin(flat, blob, err));
+		REQUIRE(!blob.empty());
+
+		const std::string key = MakeTerrainCacheKey(0, 0);
+		cache.Insert(key, blob);
+
+		ChunkHeightField field(&cache, nullptr);
+
+		// (10,10) tombe dans le chunk terrain (0,0) (grille 256 m) → résident.
+		REQUIRE(field.IsLoadedAt(10.0f, 10.0f) == true);
+		REQUIRE(ApproxEq(field.HeightAt(10.0f, 10.0f), 42.0f));
+
+		// (300,10) tombe dans le chunk (1,0), non inséré → non résident → 0.
+		REQUIRE(field.IsLoadedAt(300.0f, 10.0f) == false);
+		REQUIRE(ApproxEq(field.HeightAt(300.0f, 10.0f), 0.0f));
+	}
+}
+
+int main()
+{
+	Test_HeightmapHeightField_Nullptr_SafeFallback();
+	Test_ChunkHeightField_NullCache_SafeFallback();
+	Test_ChunkHeightField_ResidentChunk_SwitchesAndSamples();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] HeightFieldTests (3/3)\n");
+		return 0;
+	}
+	std::printf("[FAIL] HeightFieldTests: %d failure(s)\n", g_failed);
+	return g_failed;
+}


### PR DESCRIPTION
## Contexte

Phase 2 du chantier C terrain. Aujourd'hui la collision (`TerrainCollider`) lit **uniquement la heightmap legacy** (`TerrainRenderer::SampleHeightAtWorldXZ`), alors que le rendu peut être chunké. Cette PR introduit une abstraction `IHeightField` pour que **la collision suive la source réellement rendue** : « marcher sur ce qu'on voit ».

## Changements

- **`IHeightField`** (interface pure) : `HeightAt(x,z)` + `IsLoadedAt(x,z)`.
- **`HeightmapHeightField`** : wrappe `TerrainRenderer` (repli, couvre tout le monde).
- **`ChunkHeightField`** : échantillonne les chunks `terrain.bin` **résidents** (`StreamCache`, lookup LRU **pur, zéro I/O**) sur la grille 256 m de la Phase 1 (`WorldToTerrainChunkCoord` + `TerrainChunk::SampleHeight`).
- **`TerrainCollider`** : `GroundHeightAt` applique la stratégie **chunk si résident → repli heightmap → 0** (signature inchangée → `SweepCapsule`/spawn/snap en bénéficient transparemment).
- **`Engine`** : construit et injecte les deux height fields.
- **Test** `height_field_tests` : prouve qu'un chunk résident fait basculer `IsLoadedAt` false→true et `HeightAt` sur la hauteur du chunk.

## Refactor SÛR (no-op sur le contenu actuel)

Aucune carte ne livre de `terrain.bin` → `ChunkHeightField::IsLoadedAt` **toujours faux** → repli heightmap **systématique** → **comportement strictement inchangé** vs Phase 1. C'est un **prérequis** : dès qu'une zone chunkée sera embarquée, la collision la suivra automatiquement.

## Sûreté

- **Aucune I/O** dans le chemin collision (lookup cache pur, jamais `LoadTerrainChunk` disque).
- **Main-thread** (cohérent avec `StreamCache` main-thread-only).
- Repli anti-NaN à tous les niveaux ; `unique_ptr` membres Engine (lifetime garanti).

## Plan de test

- [ ] CI : `build-windows` (compile) + `build-linux` (compile + ctest dont `height_field_tests`, `terrain_collider_tests`) verts.
- [ ] Non-régression `demo_plains` : spawn/marche/saut/pente, snap des entités, nage — **identique** à avant.

## Limites connues (par conception)

- Effet runtime invisible tant qu'aucune zone chunkée n'est embarquée.
- Pas de mémoïsation 1-entrée dans `ChunkHeightField` (à ajouter quand des chunks seront résidents ; inutile aujourd'hui).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur** (refactor collision client ; les `.cpp` sont dans `engine_core`, jamais appelés côté serveur ; aucun opcode/handler/migration/wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)