### PR TITLE
feat(render): IBL par capture du ciel — réflexions d'environnement + ambiant directionnel (rebrancher le moteur)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,7 @@ add_library(engine_core
   src/client/render/CascadedShadowMaps.cpp
   src/client/render/BrdfLutPass.cpp
   src/client/render/SpecularPrefilterPass.cpp
+  src/client/render/SkyCubeCapturePass.cpp
   src/client/render/SsaoKernelNoise.cpp
   src/client/render/SsaoPass.cpp
   src/client/render/SsaoBlurPass.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,7 @@ add_library(engine_core
   src/client/render/BrdfLutPass.cpp
   src/client/render/SpecularPrefilterPass.cpp
   src/client/render/SkyCubeCapturePass.cpp
+  src/client/render/IrradiancePass.cpp
   src/client/render/SsaoKernelNoise.cpp
   src/client/render/SsaoPass.cpp
   src/client/render/SsaoBlurPass.cpp

--- a/config.json
+++ b/config.json
@@ -637,6 +637,10 @@
         }
     },
     "gi": {
+        "_comment_ibl": "IBL (image-based lighting) statique : capture du ciel procedural dans une cubemap au boot (1x), puis specular prefilter + irradiance diffuse. ibl.enabled (bool, defaut true, CLIENT uniquement, pas de cle serveur) gate l'orchestration dans DeferredPipeline::Init. false => aucune des 3 passes IBL n'est generee => irrView NULL => LightingPass useIBL=0 => repli ambient plat (rendu inchange), sans crash. Tout echec d'init/generate (shader absent, format RGBA16F non storable) retombe aussi sur ce repli.",
+        "ibl": {
+            "enabled": true
+        },
         "_comment_gi": "DDGI (M45.7 phase 2 / M45.8 phase 3) — injection + propagation runtime. PILOTE PAR 'quality' (DEFAUT 'off'). quality in {off, static-probes, dynamic-low, dynamic-high} : off/static-probes => aucune DDGI dynamique => aucune allocation GPU, passe DDGI_Update NON enregistree, LightingPass useDdgi=0 => rendu STRICTEMENT identique au chemin probes statiques. dynamic-low (amortissement /8, intensite 0.5) et dynamic-high (amortissement /2, intensite 1.0) allouent l'atlas irradiance et activent la passe compute ddgi_update (ciel/soleil dynamique par sonde, base conservatrice SANS rebonds — pas de RT/voxelisation). RETRO-COMPAT : si 'quality' est absent mais 'enabled'=true, traite comme dynamic-high ; sinon 'quality' prime et 'enabled' est ignore. La QUALITE pilote desormais l'amortissement (divisor) et l'intensite (l'ancienne cle 'intensity' n'est plus lue). 'debug'=true loggue l'etat DDGI au boot (qualite/alloc/probeCount/divisor/intensity ; PAS de visualisation 3D des sondes, reportee). origin_m/spacing_m en metres, counts = nb de sondes par axe (X,Y,Z), *_texels = resolution octaedrique par sonde (hors bordure 1px). hysteresis = blend temporel [0..1] (eleve = lent/stable).",
         "ddgi": {
             "quality": "off",

--- a/docs/superpowers/plans/2026-06-05-ibl-sky-capture.md
+++ b/docs/superpowers/plans/2026-06-05-ibl-sky-capture.md
@@ -1,0 +1,122 @@
+# IBL par capture du ciel procédural (MVP statique) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activer l'IBL (réflexions d'environnement + ambiant directionnel) en capturant le ciel procédural dans une cubemap au boot, puis en générant irradiance + specular prefilter et en câblant `irrView`/`useIBL`.
+
+**Architecture:** 3 passes compute one-shot au boot : [1] `SkyCubeCapturePass` (ciel → cube RGBA16F 128²) → [2] `SpecularPrefilterPass::Generate` (existe, à appeler) → [3] `IrradiancePass` (convolution cosine → cube 32²). Câblage dans `DeferredPipeline::Init` + site Lighting de l'Engine. Statique (1×/boot) ; suivi jour/nuit différé.
+
+**Tech Stack:** C++17, Vulkan (compute one-shot, raw images sans VMA), GLSL compute (SPIR-V auto-compilé par `tools/compile_game_shaders.ps1`). **Pas de build local** : compile + SPIR-V validés en CI ; rendu validé manuellement.
+
+**Référence spec :** `docs/superpowers/specs/2026-06-05-ibl-sky-capture-design.md`.
+
+**Portée :** client uniquement — **pas de redéploiement serveur**. Modèles de référence à calquer : `BrdfLutPass`, `SpecularPrefilterPass`, `specular_prefilter.comp`, `sky.frag`.
+
+---
+
+## Contexte vérifié (à connaître avant d'exécuter)
+
+- **`BrdfLutPass`/`SpecularPrefilterPass`** = modèle de passe compute one-shot : image storage Vulkan brut (`vkCreateImage`+`vkAllocateMemory` DEVICE_LOCAL+`vkBindImageMemory`, **pas de VMA** malgré le param `vmaAllocator` conservé), descriptor set, pipeline compute SPIR-V, command pool interne, `Generate()` = begin → barrières → dispatch → barrière → `vkQueueSubmit`+`vkQueueWaitIdle`.
+- **Cube storable+samplable** : `SpecularPrefilterPass::Init` crée déjà le pattern : `flags=VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT`, `arrayLayers=6`, `format=VK_FORMAT_R16G16B16A16_SFLOAT`, `usage=STORAGE_BIT|SAMPLED_BIT` ; vue `VK_IMAGE_VIEW_TYPE_CUBE` (sampling) + vues 2D par face (storage). **Réutiliser tel quel.**
+- **Faces cube** : `specular_prefilter.comp` définit `FaceUvToDirection(face,u,v)` (`u,v∈[-1,1]`). **Copier à l'identique** dans les 2 nouveaux compute (sinon réflexions miroir).
+- **Couleur ciel** : `game/data/shaders/sky.frag:118-172` (gradient zénith/horizon, sun glow, below-horizon, `RenderMoonDisk:61-116`). Pour le compute, remplacer la reconstruction `viewDir` par `FaceUvToDirection` ; porter le reste tel quel.
+- **Uniformes ciel = `DayNightCycle::State`** (`DayNightCycle.h:33-73`) : `lightDir[3]`, `skyZenith[3]`, `skyHorizon[3]`, `isDaytime`, `moonPhase`, `moonIllumination` ; `moonDir = -lightDir` (`Engine.cpp:5394`).
+- **Site Lighting** : `Engine.cpp:5753-5759` (`irrView=VK_NULL_HANDLE` 5753, `prefilterView` lue 5755, `useIBL` 5759) ; Record reçoit les vues 5836.
+- **Boot** : `Engine.cpp:3952` appelle `m_pipeline->Init`. Specular est `Init`/`Generate` dans `DeferredPipeline::Init` (`DeferredPipeline.cpp:31-73`) → **orchestrer [1][2][3] là** (a accès device/physicalDevice/queue/queueFamily/config/loadSpirv/pipelineCache). Manque : l'état ciel initial → **étendre `DeferredPipeline::Init`** d'un param `const SkyCaptureParams&` rempli par l'Engine depuis `m_dayNight.GetState()` avant 3952.
+- **Compile shaders** : `tools/compile_game_shaders.ps1` compile auto tout `*.comp` de `game/data/shaders/`. **Déposer les 2 `.comp` suffit**, aucune liste à éditer.
+- **CMake** : ajouter les 2 `.cpp` à `engine_core` du **root** `CMakeLists.txt` (~ligne 626, à côté de `SpecularPrefilterPass.cpp`). Pas de glob.
+- **Config** : `m_cfg.GetBool("gi.ibl.enabled", true)`.
+
+---
+
+## Task 1 : `SkyCubeCapturePass` — compute, ciel → cube RGBA16F (128²)
+
+### 1.1 Shader `game/data/shaders/sky_capture.comp`
+- [ ] Créer le compute (1 binding storage image2D par face, push-constants `{uint face; uint faceSize; float pad0,pad1; vec4 lightDir; vec4 zenithColor; vec4 horizonColor; vec4 moonDir; vec4 moonParams;}`). `local_size 8×8`. Copier `FaceUvToDirection` de `specular_prefilter.comp`. Porter le gradient ciel + sun glow + below-horizon + `RenderMoonDisk` de `sky.frag` (substitutions `.xyz`/`moonParams`). `imageStore(uOut, coord, vec4(skyColor + sunContrib, 1.0))`. (Code GLSL détaillé : voir spec + `sky.frag`.)
+
+### 1.2 Header `src/client/render/SkyCubeCapturePass.h`
+- [ ] Classe `engine::render::SkyCubeCapturePass` (calque `BrdfLutPass.h`, mais cube 6 layers) + struct `SkyCaptureParams { float lightDir[3]; float zenithColor[3]; float horizonColor[3]; float moonDir[3]; float moonIntensity; float moonPhase; float moonIllumination; }`. Méthodes `Init(device, physDev, vma, faceSize, compSpirv, words, queueFamily, pipelineCache)`, `Generate(device, queue, const SkyCaptureParams&)`, `Destroy`, `GetImageView()` (cube), `GetSampler()`, `IsValid()`. Doc `///`.
+
+### 1.3 Implémentation `src/client/render/SkyCubeCapturePass.cpp`
+- [ ] Calquer `SpecularPrefilterPass.cpp` avec `mipLevels=1` : image cube RGBA16F (vérif `STORAGE_IMAGE_BIT` du format, repli `return false`), vue cube + 6 vues 2D par face, sampler linéaire (mip NEAREST, maxLod 0), descriptor layout 1 binding (STORAGE_IMAGE compute), push-constant range. Struct C++ miroir std430 (vec3→vec4) avec `static_assert(sizeof==96)`. Pipeline compute + `AssertPipelineCreationAllowed()` + `PipelineCache::RegisterWarmupKey(...)` (ne pas oublier). `Generate` : boucle 6 faces (update descriptor → barrière UNDEFINED→GENERAL face → push+dispatch `(faceSize+7)/8` → barrière GENERAL→SHADER_READ_ONLY) + submit+waitIdle. `Destroy` complet.
+- [ ] **CMake** : ajouter `src/client/render/SkyCubeCapturePass.cpp` à `engine_core` (root).
+
+> Vérif Task 1 : pas de build local → CI compile + SPIR-V. `static_assert` verrouille le push layout.
+
+---
+
+## Task 2 : `IrradiancePass` — compute convolution cosine (cube 32²)
+
+### 2.1 Shader `game/data/shaders/irradiance_convolve.comp`
+- [ ] Créer le compute : binding 0 `samplerCube uEnv`, binding 1 `writeonly image2D uOut` (rgba16f), push `{uint face; uint faceSize; float pad0,pad1;}`. `FaceUvToDirection` copié. Convolution cosine-hemisphere (double boucle φ∈[0,2π) θ∈[0,π/2), `deltaPhi=deltaTheta=0.025`, échantillon `textureLod(uEnv, sampleVec, 0.0).rgb * cos(theta)*sin(theta)`, repère tangent autour de N), `irradiance = PI * sum / nrSamples` (⚠️ voir Risque #3 : vérifier la division par PI côté `lighting.frag` avant de figer le facteur). `imageStore`.
+
+### 2.2 Header `src/client/render/IrradiancePass.h`
+- [ ] Classe `engine::render::IrradiancePass` (calque `SpecularPrefilterPass.h`, 1 mip, 2 bindings) : `Init(...)`, `Generate(device, queue, sourceCubeView, sourceCubeSampler)`, `Destroy`, `GetImageView()`/`GetSampler()`/`IsValid()`. Doc `///`.
+
+### 2.3 Implémentation `src/client/render/IrradiancePass.cpp`
+- [ ] Calquer `SpecularPrefilterPass.cpp` : cube RGBA16F 32², 1 mip ; descriptor 2 bindings (0=COMBINED_IMAGE_SAMPLER source, 1=STORAGE_IMAGE sortie) ; push 16 o ; `Generate` boucle 6 faces (binding0=source SHADER_READ_ONLY, binding1=face GENERAL ; barrières ; dispatch `(32+7)/8`). `Destroy` complet.
+- [ ] **CMake** : ajouter `src/client/render/IrradiancePass.cpp` à `engine_core` (root).
+
+---
+
+## Task 3 : Engine/DeferredPipeline — orchestration + wiring + gating
+
+### 3.0 Vérifier l'ordre d'init
+- [ ] Confirmer que `m_dayNight.Init(...)` (`Engine.cpp:1135`) s'exécute **avant** `m_pipeline->Init` (3952). Si oui → orchestration dans `DeferredPipeline::Init` (retenu). Sinon → déplacer l'orchestration IBL dans Engine via un `DeferredPipeline::GenerateIbl(...)` post-Init.
+
+### 3.1 Membres `DeferredPipeline`
+- [ ] `DeferredPipeline.h` : includes des 2 headers ; membres `SkyCubeCapturePass m_skyCubeCapturePass;` + `IrradiancePass m_irradiancePass;` (après `m_specularPrefilterPass`) ; accesseur `GetIrradiancePass()` (const+non-const) ; étendre `Init(...)` d'un param `const SkyCaptureParams& skyParams`.
+
+### 3.2 Orchestration dans `DeferredPipeline::Init`
+- [ ] Après le bloc Specular (~`DeferredPipeline.cpp:73`), bloc gardé `gi.ibl.enabled` :
+  - charger `sky_capture.comp.spv` + `irradiance_convolve.comp.spv` (loadSpirv) ;
+  - `m_skyCubeCapturePass.Init(...)` → `.Generate(skyParams)` → `m_specularPrefilterPass.Generate(device, queue, skyCubeView, skyCubeSampler)` → `m_irradiancePass.Init(...)` → `.Generate(device, queue, skyCubeView, skyCubeSampler)` ;
+  - tout échec / shader absent / format non supporté → LOG_WARN + laisser `m_irradiancePass` `!IsValid()` (→ useIBL=0, repli ambient plat, pas de crash).
+  - ⚠️ La prefilter `Generate` **tourne ici pour la 1re fois** — valider barrières en CI/jeu. Source 1-mip → `textureLod` clampe mip 0 (acceptable MVP).
+
+### 3.3 Appel Engine
+- [ ] Avant `Engine.cpp:3952`, remplir `SkyCaptureParams iblSky` depuis `m_dayNight.GetState()` (lightDir/skyZenith→zenithColor/skyHorizon→horizonColor/moonDir=-lightDir/moonIntensity=isDaytime?0:1/moonPhase/moonIllumination) et le passer à `m_pipeline->Init(...)`.
+
+### 3.4 Wiring du site Lighting
+- [ ] `Engine.cpp:5753-5754` : `irrView`/`irrSamp` = `GetIrradiancePass().IsValid() ? GetImageView()/GetSampler() : VK_NULL_HANDLE`. `prefilterView` (5755) inchangé (contenu désormais généré). `useIBL` (5759) inchangé (devient 1 quand les 3 vues sont non-NULL). Record (5836) inchangé.
+
+### 3.5 Config
+- [ ] Documenter `gi.ibl.enabled` (bool, défaut true, client). L'ajouter au `config.json` d'exemple à côté de `gi.ddgi.*` si une entrée explicite est attendue ; sinon défaut suffit. Pas de clé serveur.
+
+### 3.6 Destruction
+- [ ] `DeferredPipeline::Destroy` : `m_irradiancePass.Destroy(device)` + `m_skyCubeCapturePass.Destroy(device)` (ordre reverse, avec les autres passes IBL). Pas de fuite.
+
+> Vérif Task 3 : compile CI. Confirmer ordre d'init (3.0) et noms réels (`m_dayNight`, `GetState()`, champs `State`).
+
+---
+
+## Task 4 : Validation
+
+- [ ] **CI** : build Linux + Windows verts ; `sky_capture.comp`/`irradiance_convolve.comp` compilés en `.spv` (confirmer le step shaders dans `.github/workflows/`) ; **aucun warning de validation Vulkan** au boot (surtout `SpecularPrefilterPass::Generate`, 1re exécution).
+- [ ] **En jeu** : métal/brillant (`Crate_Metal`, avatar) **reflète les teintes du ciel** ; ambiant **directionnel** ; `gi.ibl.enabled=false` → ambient plat sans crash (log `[Boot] gi.ibl.enabled=false`).
+- [ ] **Pas de sur-exposition** : si laiteux/cramé → double-division par PI possible (irradiance_convolve ↔ lighting.frag). Lire `lighting.frag:419-432` AVANT de figer le facteur ; retirer `PI *` si l'irradiance est déjà divisée à la consommation.
+- [ ] **Pas de réflexion miroir** : `FaceUvToDirection` identique dans les 3 shaders.
+
+---
+
+## Self-Review
+
+- **Couverture spec** : [1] SkyCubeCapturePass (Task 1) ; [2] SpecularPrefilter.Generate enfin appelée (Task 3.2) ; [3] IrradiancePass (Task 2) ; [4] orchestration boot + wiring irrView/useIBL + gating gi.ibl.enabled + repli (Task 3). Statique 1×/boot. ✅
+- **Formats/bindings** : toutes cubes RGBA16F (= format source attendu par prefilter + samplerCube lighting). `FaceUvToDirection` copié à l'identique (orientation cohérente). ✅
+- **Gating/repli** : disabled / shader absent / Init|Generate échoué / format non supporté → `m_irradiancePass !IsValid()` → irrView NULL → useIBL=0 → ambient plat, pas de crash. ✅
+- **SPIR-V** : 2 `.comp` → compilés auto (glob), aucune liste. **À confirmer** que la CI exécute `compile_game_shaders.ps1` (Task 4). ✅
+- **CMake** : 2 `.cpp` → engine_core (root). ✅
+- **CLAUDE.md** : chemin compute (pas de render-pass cube) → aucun `frontFace`/`cullMode`/winding touché. ✅ PascalCase respecté.
+
+## Risques (exécutant)
+1. **`SpecularPrefilterPass::Generate` jamais exécutée** — point le plus susceptible de révéler un bug latent (barrières/layouts). Valider en premier (CI validation + jeu).
+2. **Ordre `m_dayNight` vs `m_pipeline->Init`** — confirmer avant de coder (Task 3.0).
+3. **Facteur irradiance / sur-exposition** — vérifier la division par PI dans `lighting.frag` (Task 4) avant de figer.
+4. **Format RGBA16F storage** — garde-fou présent (repli useIBL=0).
+5. **Orientation faces** — `FaceUvToDirection` copié strict.
+6. **Source 1-mip pour le prefilter** — `textureLod` clampe mip 0 (acceptable MVP ; mips sur skyCube différés).
+
+## Fichiers
+**Créer** : `game/data/shaders/sky_capture.comp`, `irradiance_convolve.comp` ; `src/client/render/SkyCubeCapturePass.{h,cpp}`, `IrradiancePass.{h,cpp}`.
+**Modifier** : `src/client/render/DeferredPipeline.{h,cpp}`, `src/client/app/Engine.cpp`, `CMakeLists.txt` (root).
+**Modèles (lecture seule)** : `BrdfLutPass.cpp`, `SpecularPrefilterPass.cpp`, `specular_prefilter.comp`, `sky.frag`.

--- a/docs/superpowers/specs/2026-06-05-ibl-sky-capture-design.md
+++ b/docs/superpowers/specs/2026-06-05-ibl-sky-capture-design.md
@@ -1,0 +1,84 @@
+# Spec — IBL par capture du ciel procédural (MVP statique)
+
+**Date** : 2026-06-05
+**Statut** : conception validée (option « capture ciel → IBL statique »)
+**Origine** : audit du moteur (thème A « rebrancher le moteur », 3ᵉ item).
+**Portée** : client uniquement (rendu Vulkan + shaders). **Pas de redéploiement serveur.**
+
+---
+
+## 1. Problème
+
+`lighting.frag` contient déjà tout le shading **IBL split-sum** (diffuse via `irradianceMap`, spéculaire via `prefilterMap` + `brdfLut`), mais il est **désactivé** : `Engine.cpp:5760` code en dur `irrView = VK_NULL_HANDLE`, donc `useIBL = (irrView && prefilterView && brdfView)` vaut toujours 0. Conséquences :
+- Les matériaux métalliques/brillants n'ont **aucune réflexion d'environnement**.
+- L'ambiant est un terme constant plat (pas d'éclairage indirect directionnel).
+- `BrdfLutPass` (binding 6) fonctionne mais est inutilisée ; `SpecularPrefilterPass` est `Init`'d mais son `Generate()` **n'est jamais appelé** (contenu non initialisé) ; **aucune passe d'irradiance n'existe**.
+
+## 2. Acquis (rien à refaire)
+
+- Shading split-sum complet (`lighting.frag:419-432`), mip count du prefilter lu dynamiquement (`textureQueryLevels`) → robuste à n'importe quel nombre de mips.
+- Bindings 4 (irradiance, samplerCube), 5 (prefilter, samplerCube), 6 (brdfLut) + params `Record(irradianceView/Sampler, prefilterView/Sampler, brdfLutView/Sampler, …)` (`LightingPass.h:112-128`).
+- `BrdfLutPass` : génère la LUT, `Generate()` appelée au boot, **bindée** (binding 6) — déjà fonctionnelle.
+- `SpecularPrefilterPass` : `Init`'d (cube 256², 5 mips, RGBA16F), `Generate(sourceCubemapView, sampler)` **prête** mais jamais appelée.
+- `SkyPass` + `sky.frag` : ciel procédural (couleur selon direction de vue + `DayNightCycle` : zénith/horizon/soleil/lune). Rendu aujourd'hui en **fullscreen dans GBufferA** (pas en cube).
+
+## 3. Conception (MVP statique)
+
+Pipeline de génération, exécuté **une fois au boot** (après que `DayNightCycle` et les assets ciel sont prêts) :
+
+```
+[1] SkyCubeCapturePass : rend le ciel procédural dans une cubemap RGBA16F (6 faces)
+        ↓ (skyCube, samplable VIEW_TYPE_CUBE)
+[2] SpecularPrefilterPass::Generate(skyCube)  → prefilter cube (256², 5 mips)   [EXISTE, à appeler]
+[3] IrradiancePass (NOUVELLE) : convolution cosine → irradiance cube (petit, ex. 32²)
+        ↓
+[4] Engine : irrView = irradiance, prefilterView = prefilter, useIBL = 1 → LightingPass
+```
+
+### 3.1 SkyCubeCapturePass (nouveau)
+- Cible : cubemap **RGBA16F**, **128²/face** (suffisant : l'irradiance est basse fréquence, le prefilter mip0 n'a pas besoin d'énorme résolution ; bon compromis coût/qualité).
+- Rend `sky.frag` dans chaque face via 6 caméras (directions ±X/±Y/±Z, up conventionnel), en réutilisant la logique de couleur de ciel du `SkyPass` (couleur = f(direction monde, `DayNightCycle`)). **Respecter la convention `PerspectiveVulkan` (inversion Y, cf. `CLAUDE.md`)** pour ne pas obtenir des faces miroir.
+- Le ciel n'a pas de géométrie : on rend un fullscreen-quad par face, la direction monde par texel étant dérivée de l'orientation de la face (ou via une petite passe compute écrivant directement la cube).
+- **Décision d'implémentation** (à trancher dans le plan) : (a) render-pass 6 faces avec une matrice par face, ou (b) **compute shader** écrivant les 6 faces d'un coup (chaque thread → direction monde → couleur ciel). L'option compute est souvent plus simple (pas de render-pass cube, pas de winding) — **privilégiée** si la logique de `sky.frag` est facilement portable en compute.
+
+### 3.2 SpecularPrefilterPass::Generate (existant, à appeler)
+- Appeler `Generate(skyCubeView, skyCubeSampler)` après [1]. Produit le prefilter cube 5 mips (roughness par mip). **Aucun nouveau code** hormis l'appel + récupérer la vue résultat.
+- ⚠️ Cette passe n'a **jamais tourné** : la valider (barrières, layouts, sampler mip linéaire). Risque latent à vérifier.
+
+### 3.3 IrradiancePass (nouvelle)
+- Convolution **cosine-weighted hemisphere** : pour chaque texel (direction N) de la cube d'irradiance, intégrer le ciel sur l'hémisphère autour de N. Compute shader `irradiance_convolve.comp` échantillonnant `skyCube` (N samples sur l'hémisphère, pondérés cos).
+- Cible : cube **RGBA16F**, petite (**32²/face** : l'irradiance est très basse fréquence). 
+- Sortie : `irradianceCubeView` (samplerCube) → binding 4.
+
+### 3.4 Câblage Engine
+- Au boot (nouvelle séquence, après init des passes IBL + sky + DayNightCycle) : exécuter [1]→[2]→[3] une fois, sur la queue graphics/compute (submit + wait, comme `BrdfLutPass::Generate`).
+- Stocker `m_iblIrradianceView` / `m_iblPrefilterView` (+ samplers).
+- Au site Lighting (`Engine.cpp:5760-5766`) : remplacer `irrView = VK_NULL_HANDLE` par `irrView = m_iblIrradianceView` ; `prefilterView` = la vraie prefilter générée ; `useIBL = (irr && prefilter && brdf) ? 1 : 0` (désormais satisfait).
+- **Gating config** : `gi.ibl.enabled` (défaut **true**). Si false (ou si une génération échoue), repli sûr `useIBL=0` (ambient constant actuel) — aucun crash.
+
+### 3.5 Statique (jour/nuit différé)
+Génération **une seule fois au boot** (au `DayNightCycle` initial). Le suivi du cycle (re-capture quand le soleil bouge) est une **étape ultérieure séparée** : les réflexions refléteront l'heure du boot. Acceptable pour le MVP (gain visuel immédiat sur les matériaux brillants).
+
+## 4. Hors périmètre
+
+- Re-capture dynamique jour/nuit (follow-up).
+- Cubemap HDR depuis disque + loader (option A écartée).
+- Probes locales / réflexions planaires / SSR (déjà partiel pour l'eau).
+- Parallax-corrected cubemaps.
+
+## 5. Validation
+
+- **CI** : build Linux + Windows verts ; nouveaux shaders compilés en SPIR-V ; pas d'erreur de validation Vulkan.
+- **En jeu** (manuel) : un matériau métallique/brillant (ex. la caisse métal `Crate_Metal`, l'avatar) **reflète les teintes du ciel** ; l'ambiant devient directionnel (plus clair côté ciel) ; pas de NaN/artefact ; `gi.ibl.enabled=false` → revient à l'ambient plat sans crash.
+- **Convention `CLAUDE.md`** : aucune modif `frontFace`/`cullMode` des pipelines existants ; si rendu cube par render-pass, respecter l'inversion Y.
+
+## 6. Risques
+
+- **`SpecularPrefilterPass::Generate` jamais exécutée** : bugs latents possibles (barrières/layouts/sampler). À valider en premier.
+- **Orientation cube** : 6 faces mal orientées → réflexions miroir/inversées. Le chemin **compute** (écriture directe par direction monde) évite le winding ; préféré.
+- **Gating strict `useIBL`** : exige les 3 vues non-NULL ; si l'irradiance ou le prefilter échoue, rester en repli (useIBL=0).
+- **Coût boot** : 3 passes one-shot au démarrage (capture + 2 convolutions) — négligeable (statique).
+- **Sur-luminosité** : l'IBL ajoute de l'ambient ; combiné à l'auto-exposition (déjà bornée, #834) → surveiller, ajuster l'intensité IBL si besoin (facteur optionnel).
+- Pas de toolchain locale : compile + validation en CI/VS.
+
+**Déploiement** : ✅ client uniquement — pas de redéploiement serveur (rendu/shaders ; aucun opcode/handler/DB/config serveur ; `gi.ibl.enabled` lu côté client).

--- a/game/data/shaders/irradiance_convolve.comp
+++ b/game/data/shaders/irradiance_convolve.comp
@@ -1,0 +1,91 @@
+#version 450
+
+// IBL — Convolution d'irradiance diffuse (cosine-weighted hemisphere).
+// Lit la cubemap d'environnement source (binding 0, samplerCube), écrit une
+// face de la cubemap d'irradiance (binding 1, image2D rgba16f).
+// Dispatché une fois par face. Modèle : specular_prefilter.comp (1 seul mip).
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(binding = 0) uniform samplerCube uEnv;
+layout(binding = 1, rgba16f) writeonly uniform image2D uOut;
+
+layout(push_constant, std430) uniform PC {
+	uint face;       // 0..5 face de la cubemap
+	uint faceSize;   // largeur/hauteur de la face (32)
+	float pad0;
+	float pad1;
+} pc;
+
+const float PI = 3.14159265359;
+
+// (face 0..5, u,v dans [-1,1]) -> direction depuis le centre du cube.
+// COPIE À L'IDENTIQUE de specular_prefilter.comp (orientation des faces cohérente
+// entre les 3 shaders IBL — sinon réflexions/ambiant en miroir).
+vec3 FaceUvToDirection(uint face, float u, float v)
+{
+	switch (face) {
+		case 0u: return normalize(vec3( 1.0, -v, -u)); // +X
+		case 1u: return normalize(vec3(-1.0, -v,  u)); // -X
+		case 2u: return normalize(vec3( u,  1.0, -v)); // +Y
+		case 3u: return normalize(vec3( u, -1.0,  v)); // -Y
+		case 4u: return normalize(vec3( u, -v,  1.0)); // +Z
+		default: return normalize(vec3(-u, -v, -1.0)); // -Z (5)
+	}
+}
+
+void main()
+{
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+	uint faceSize = pc.faceSize;
+	if (coord.x >= int(faceSize) || coord.y >= int(faceSize))
+		return;
+
+	float u = 2.0 * (float(coord.x) + 0.5) / float(faceSize) - 1.0;
+	float v = 2.0 * (float(coord.y) + 0.5) / float(faceSize) - 1.0;
+
+	// N = normale de la surface = direction du texel courant.
+	vec3 N = FaceUvToDirection(pc.face, u, v);
+
+	// Repère tangent autour de N (up arbitraire évitant la colinéarité).
+	vec3 up      = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+	vec3 right   = normalize(cross(up, N));
+	up           = normalize(cross(N, right));
+
+	// Convolution cosine-hemisphere : double boucle phi/theta.
+	const float deltaPhi   = 0.025;
+	const float deltaTheta = 0.025;
+	vec3  irradiance = vec3(0.0);
+	float nrSamples  = 0.0;
+
+	for (float phi = 0.0; phi < 2.0 * PI; phi += deltaPhi)
+	{
+		for (float theta = 0.0; theta < 0.5 * PI; theta += deltaTheta)
+		{
+			// Direction d'échantillonnage en espace tangent puis monde.
+			vec3 tangentSample = vec3(sin(theta) * cos(phi),
+			                          sin(theta) * sin(phi),
+			                          cos(theta));
+			vec3 sampleVec = tangentSample.x * right
+			               + tangentSample.y * up
+			               + tangentSample.z * N;
+
+			// Pondération cos(theta) (lambert) * sin(theta) (jacobien sphérique).
+			irradiance += textureLod(uEnv, sampleVec, 0.0).rgb
+			            * cos(theta) * sin(theta);
+			nrSamples += 1.0;
+		}
+	}
+
+	// FACTEUR D'IRRADIANCE — convention LearnOpenGL.
+	// `lighting.frag` (bloc useIBL, ~ligne 422) consomme l'irradiance ainsi :
+	//     vec3 diffuseIBL = texture(irradianceMap, normalW).rgb * albedo * kD;
+	// -> multiplication directe par albedo SANS division par PI. Le terme
+	// diffus Lambert (albedo/PI) n'est donc PAS divisé par PI côté lighting :
+	// le facteur PI doit être ABSORBÉ ici, dans l'irradiance pré-intégrée
+	// (irradiance = PI * moyenne des échantillons). On garde donc bien le `PI *` ;
+	// le retirer sous-exposerait l'ambiant d'un facteur PI.
+	irradiance = PI * irradiance * (1.0 / max(nrSamples, 1.0));
+
+	imageStore(uOut, coord, vec4(irradiance, 1.0));
+}

--- a/game/data/shaders/sky_capture.comp
+++ b/game/data/shaders/sky_capture.comp
@@ -1,0 +1,178 @@
+#version 450
+
+// IBL — Capture du ciel procédural dans une face de cubemap RGBA16F.
+//
+// Porte la logique couleur de sky.frag (gradient zénith/horizon, sun glow,
+// transition sous l'horizon, disque lunaire procédural RenderMoonDisk) en
+// remplaçant la reconstruction de viewDir par FaceUvToDirection(face, u, v).
+// Dispatché une fois par face au boot ; sortie écrite via imageStore.
+//
+// Push constants (96 octets, std430, miroir de SkyCaptureParams côté C++) :
+//   face          (uint)  — 0..5, face de cubemap courante
+//   faceSize      (uint)  — largeur/hauteur de la face en texels
+//   pad0, pad1    (float) — alignement
+//   lightDir      (vec4)  — .xyz direction vers le soleil (normalisée)
+//   zenithColor   (vec4)  — .xyz couleur du ciel au zénith
+//   horizonColor  (vec4)  — .xyz couleur du ciel à l'horizon
+//   moonDir       (vec4)  — .xyz direction vers la lune (normalisée)
+//   moonParams    (vec4)  — .x intensité (0..1), .y phase (0..15), .z illumination (0..1)
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(binding = 0, rgba16f) writeonly uniform image2D uOut;
+
+layout(push_constant, std430) uniform PC {
+	uint  face;
+	uint  faceSize;
+	float pad0;
+	float pad1;
+	vec4  lightDir;
+	vec4  zenithColor;
+	vec4  horizonColor;
+	vec4  moonDir;
+	vec4  moonParams;
+} pc;
+
+// (face 0..5, u,v in [-1,1]) -> direction from cube center.
+// Copié À L'IDENTIQUE depuis specular_prefilter.comp (orientation cohérente).
+vec3 FaceUvToDirection(uint face, float u, float v)
+{
+	switch (face) {
+		case 0u: return normalize(vec3( 1.0, -v, -u)); // +X
+		case 1u: return normalize(vec3(-1.0, -v,  u)); // -X
+		case 2u: return normalize(vec3( u,  1.0, -v)); // +Y
+		case 3u: return normalize(vec3( u, -1.0,  v)); // -Y
+		case 4u: return normalize(vec3( u, -v,  1.0)); // +Z
+		default: return normalize(vec3(-u, -v, -1.0)); // -Z (5)
+	}
+}
+
+// -------------------------------------------------------------------------
+// RenderMoonDisk : composite procedurale d'un disque lunaire avec ombre
+// dependant de la phase. Renvoie la couleur ciel modifiee (mix entre baseSky
+// et la surface lunaire ponderee par halo + intensity).
+//
+// Porté à l'identique depuis sky.frag (lignes 61-116) ; les uniformes
+// pc.moonIntensity / pc.moonPhase / pc.moonIllumination y sont remplacés par
+// pc.moonParams.x / .y / .z et pc.moonDir par pc.moonDir.xyz.
+// -------------------------------------------------------------------------
+vec3 RenderMoonDisk(vec3 viewDir, vec3 baseSky)
+{
+	float moonIntensity    = pc.moonParams.x;
+	float moonPhase        = pc.moonParams.y;
+	float moonIllumination = pc.moonParams.z;
+	vec3  moonDir          = pc.moonDir.xyz;
+
+	if (moonIntensity < 0.001) return baseSky;
+	float cosA = dot(viewDir, moonDir);
+	const float kMoonRadius = 0.012;
+	if (cosA <= cos(kMoonRadius * 1.5)) return baseSky;
+
+	vec3 right = normalize(cross(vec3(0.0, 1.0, 0.0), moonDir));
+	vec3 up    = cross(moonDir, right);
+	float u    = dot(viewDir, right) / sin(kMoonRadius);
+	float v    = dot(viewDir, up)    / sin(kMoonRadius);
+
+	// Decalage du cercle d'ombre selon l'illumination. Le signe depend de la
+	// phase : avant FullMoon (phase < 7.5) la lune croit a droite, apres elle
+	// decroit a gauche.
+	float shadowOffset = 1.0 - moonIllumination * 2.0;
+	if (moonPhase < 7.5) shadowOffset = -shadowOffset;
+
+	float distFromShadow = length(vec2(u - shadowOffset, v));
+	float shadowMask     = smoothstep(1.0, 0.95, distFromShadow);
+
+	vec3 moonSurface = vec3(0.95, 0.92, 0.85) * shadowMask;
+
+	// Wave 4 polish — texture surface lunaire procedurale (no asset needed).
+	// V1 simple : value-noise sparse pour simuler des cratere-spots, plus une
+	// tache plus large simulant un Mare (ex. Mare Tranquillitatis). La
+	// multiplication garde la tonalite generale et assombrit ponctuellement
+	// pour donner du relief visuel. Une PR future pourra remplacer par une
+	// vraie texture lunaire (cube ou sphere mapping). On applique uniquement
+	// si on est dans la zone illuminee (shadowMask > epsilon) pour ne pas
+	// crepiter la zone sombre.
+	if (shadowMask > 0.01)
+	{
+		// Value-noise simple a partir des coords (u, v) du disque.
+		float craterNoise = fract(sin(dot(vec2(u, v), vec2(12.9898, 78.233))) * 43758.5453);
+		// smoothstep(0.85, 0.95) -> ~10% des points donnent un cratere visible.
+		craterNoise = smoothstep(0.85, 0.95, craterNoise);
+		moonSurface *= 1.0 - craterNoise * 0.25;  // assombrissement 25% ponctuel.
+
+		// Cratere "Mare" plus grand a (u=0.2, v=0.1) — ombre douce ~15%.
+		float distFromMare = length(vec2(u - 0.2, v - 0.1));
+		float mareMask     = smoothstep(0.4, 0.3, distFromMare);
+		moonSurface *= 1.0 - mareMask * 0.15;
+	}
+
+	// Earthshine sur les phases tres sombres (0..2 et 13..15) : bleute discret
+	// sur la partie ombragee.
+	if (moonPhase < 3.0 || moonPhase > 13.0)
+	{
+		moonSurface += vec3(0.05, 0.06, 0.10) * (1.0 - shadowMask);
+	}
+
+	// Halo doux : transition smoothstep entre baseSky et moonSurface.
+	float haloFalloff = smoothstep(cos(kMoonRadius * 1.5), cos(kMoonRadius), cosA);
+	return mix(baseSky, moonSurface * moonIntensity, haloFalloff);
+}
+
+void main()
+{
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+	uint faceSize = pc.faceSize;
+	if (coord.x >= int(faceSize) || coord.y >= int(faceSize))
+		return;
+
+	float u = 2.0 * (float(coord.x) + 0.5) / float(faceSize) - 1.0;
+	float v = 2.0 * (float(coord.y) + 0.5) / float(faceSize) - 1.0;
+
+	// Direction monde correspondant à ce texel de face (substitution de la
+	// reconstruction viewDir par invViewProj de sky.frag).
+	vec3 viewDir = FaceUvToDirection(pc.face, u, v);
+
+	vec3 lightDir     = pc.lightDir.xyz;
+	vec3 zenithColor  = pc.zenithColor.xyz;
+	vec3 horizonColor = pc.horizonColor.xyz;
+
+	// ---- Sky gradient via view-zenith angle ---------------------------------
+	// viewDir.y is the sine of the elevation angle.
+	float t = clamp(viewDir.y, 0.0, 1.0);
+
+	// Rayleigh approximation: non-linear blend (slightly exponential).
+	float blendFactor = pow(t, 0.6);
+	vec3 skyColor = mix(horizonColor, zenithColor, blendFactor);
+
+	// ---- Mie-scatter-like sun glow ------------------------------------------
+	float sunDot = max(dot(viewDir, lightDir), 0.0);
+
+	// Sun disk: tight halo.
+	float sunGlow = pow(sunDot, 256.0);
+
+	// Atmospheric halo: wide bloom around sun.
+	float haloGlow = pow(sunDot, 8.0) * 0.35;
+
+	// Sun/moon colour: white tint.
+	vec3 sunContrib = vec3(1.0, 0.95, 0.85) * sunGlow
+	                + horizonColor          * haloGlow;
+
+	// Only add sun glow above the horizon.
+	if (viewDir.y < 0.02)
+	{
+		sunContrib = vec3(0.0);
+	}
+
+	// ---- Below-horizon transition -------------------------------------------
+	if (viewDir.y < 0.0)
+	{
+		float belowT = clamp(-viewDir.y / 0.1, 0.0, 1.0);
+		skyColor = mix(skyColor, horizonColor * 0.3, belowT);
+	}
+
+	// ---- Disque lunaire procedural ------------------------------------------
+	skyColor = RenderMoonDisk(viewDir, skyColor);
+
+	// ---- Final colour --------------------------------------------------------
+	imageStore(uOut, coord, vec4(skyColor + sunContrib, 1.0));
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -3949,6 +3949,26 @@ namespace engine
 											return {};
 										};
 
+										// IBL — état ciel figé au boot (statique, 1×). Rempli depuis
+										// DayNightCycle::State (déjà Init au-dessus, avant ce point) :
+										// gradient zénith/horizon + direction lumière (soleil/lune) +
+										// paramètres lunaires. moonDir = -lightDir (convention Engine) ;
+										// moonIntensity = 0 le jour, 1 la nuit (la lune n'éclaire que la nuit).
+										engine::render::SkyCaptureParams iblSky{};
+										{
+											const engine::render::DayNightCycle::State& dnIbl = m_dayNight.GetState();
+											for (int i = 0; i < 3; ++i)
+											{
+												iblSky.lightDir[i]     = dnIbl.lightDir[i];
+												iblSky.zenithColor[i]  = dnIbl.skyZenith[i];
+												iblSky.horizonColor[i] = dnIbl.skyHorizon[i];
+												iblSky.moonDir[i]      = -dnIbl.lightDir[i];
+											}
+											iblSky.moonIntensity    = dnIbl.isDaytime ? 0.0f : 1.0f;
+											iblSky.moonPhase        = static_cast<float>(dnIbl.moonPhase);
+											iblSky.moonIllumination = dnIbl.moonIllumination;
+										}
+
 										bool pipelineOk = m_pipeline->Init(
 										    m_vkDeviceContext.GetDevice(),
 										    m_vkDeviceContext.GetPhysicalDevice(),
@@ -3958,7 +3978,8 @@ namespace engine
 										    m_vkSwapchain.GetImageFormat(),
 										    m_vkDeviceContext.GetGraphicsQueue(),
 										    m_vkDeviceContext.GetGraphicsQueueFamilyIndex(),
-										    loadSpirv
+										    loadSpirv,
+										    iblSky
 										);
 									LOG_INFO(Core, "[Boot] DeferredPipeline init OK");
 
@@ -5750,8 +5771,8 @@ namespace engine
 													lp.skyColor[2] = dnLight.skyHorizon[2];
 													lp.skyColor[3] = m_skyPassReady ? 1.0f : 0.0f;
 												}
-												VkImageView irrView       = VK_NULL_HANDLE;
-												VkSampler   irrSamp       = VK_NULL_HANDLE;
+												VkImageView irrView       = m_pipeline->GetIrradiancePass().IsValid() ? m_pipeline->GetIrradiancePass().GetImageView() : VK_NULL_HANDLE;
+												VkSampler   irrSamp       = m_pipeline->GetIrradiancePass().IsValid() ? m_pipeline->GetIrradiancePass().GetSampler()   : VK_NULL_HANDLE;
 												VkImageView prefilterView = m_pipeline->GetSpecularPrefilterPass().IsValid() ? m_pipeline->GetSpecularPrefilterPass().GetImageView() : VK_NULL_HANDLE;
 												VkSampler   prefilterSamp = m_pipeline->GetSpecularPrefilterPass().IsValid() ? m_pipeline->GetSpecularPrefilterPass().GetSampler()    : VK_NULL_HANDLE;
 												VkImageView brdfView      = m_pipeline->GetBrdfLutPass().GetImageView();

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -14,7 +14,8 @@ namespace engine::render
 		VkFormat sceneColorLDRFormat,
 		VkQueue graphicsQueue,
 		uint32_t graphicsQueueFamilyIndex,
-		ShaderLoaderFn loadSpirv)
+		ShaderLoaderFn loadSpirv,
+		const engine::render::SkyCaptureParams& skyParams)
 	{
 
 		if (device == VK_NULL_HANDLE || physicalDevice == VK_NULL_HANDLE || !loadSpirv)
@@ -70,6 +71,81 @@ namespace engine::render
 			{
 				LOG_WARN(Render, "M05.3: SpecularPrefilter shader not found — disabled");
 			}
+		}
+
+		// IBL — capture du ciel procédural → cubemap, puis specular prefilter +
+		// irradiance (one-shot au boot, statique). Gardé par gi.ibl.enabled (défaut
+		// true). Tout échec (shader absent, format non supporté, Init/Generate KO)
+		// laisse m_irradiancePass !IsValid() → irrView NULL côté Lighting →
+		// useIBL=0 → repli ambient plat, sans crash. m_specularPrefilterPass doit
+		// être initialisée (bloc ci-dessus) pour que sa Generate tourne ici.
+		if (config.GetBool("gi.ibl.enabled", true))
+		{
+			std::vector<uint32_t> skyComp = loadSpirv("shaders/sky_capture.comp.spv");
+			std::vector<uint32_t> irrComp = loadSpirv("shaders/irradiance_convolve.comp.spv");
+			if (skyComp.empty())
+			{
+				LOG_WARN(Render, "[Boot] IBL: sky_capture.comp.spv not found — IBL disabled (flat ambient fallback)");
+			}
+			else if (irrComp.empty())
+			{
+				LOG_WARN(Render, "[Boot] IBL: irradiance_convolve.comp.spv not found — IBL disabled (flat ambient fallback)");
+			}
+			else if (!m_specularPrefilterPass.IsValid())
+			{
+				LOG_WARN(Render, "[Boot] IBL: SpecularPrefilter not initialised — IBL disabled (flat ambient fallback)");
+			}
+			else
+			{
+				const uint32_t skyFaceSize = 128u;
+				const uint32_t irrFaceSize = 32u;
+				bool iblOk = false;
+				// [1] Capture ciel procédural dans une cubemap RGBA16F 128².
+				if (m_skyCubeCapturePass.Init(device, physicalDevice, vmaAllocator,
+						skyFaceSize,
+						skyComp.data(), skyComp.size(),
+						graphicsQueueFamilyIndex, pipelineCacheHandle)
+					&& m_skyCubeCapturePass.Generate(device, graphicsQueue, skyParams))
+				{
+					const VkImageView skyCubeView    = m_skyCubeCapturePass.GetImageView();
+					const VkSampler   skyCubeSampler = m_skyCubeCapturePass.GetSampler();
+					// [2] Specular prefilter (1re exécution réelle de sa Generate).
+					if (m_specularPrefilterPass.Generate(device, graphicsQueue, skyCubeView, skyCubeSampler))
+					{
+						// [3] Irradiance diffuse (convolution cosine → cubemap 32²).
+						if (m_irradiancePass.Init(device, physicalDevice, vmaAllocator,
+								irrFaceSize,
+								irrComp.data(), irrComp.size(),
+								graphicsQueueFamilyIndex, pipelineCacheHandle)
+							&& m_irradiancePass.Generate(device, graphicsQueue, skyCubeView, skyCubeSampler))
+						{
+							iblOk = true;
+							LOG_INFO(Render, "[Boot] DeferredPipeline IBL OK (sky capture + specular prefilter + irradiance)");
+						}
+						else
+						{
+							LOG_WARN(Render, "[Boot] IBL: irradiance Init/Generate failed — IBL disabled (flat ambient fallback)");
+						}
+					}
+					else
+					{
+						LOG_WARN(Render, "[Boot] IBL: specular prefilter Generate failed — IBL disabled (flat ambient fallback)");
+					}
+				}
+				else
+				{
+					LOG_WARN(Render, "[Boot] IBL: sky cube capture Init/Generate failed — IBL disabled (flat ambient fallback)");
+				}
+
+				// En cas d'échec partiel, libérer l'irradiance pour garantir
+				// !IsValid() (repli propre côté Lighting).
+				if (!iblOk)
+					m_irradiancePass.Destroy(device);
+			}
+		}
+		else
+		{
+			LOG_INFO(Render, "[Boot] gi.ibl.enabled=false — IBL disabled (flat ambient)");
 		}
 
 		// M06.1: SSAO kernel + noise
@@ -426,6 +502,8 @@ namespace engine::render
 		m_ssaoBlurPass.Destroy(device);
 		m_ssaoPass.Destroy(device);
 		m_ssaoKernelNoise.Destroy(device);
+		m_irradiancePass.Destroy(device);      // IBL (reverse: irradiance avant sa source)
+		m_skyCubeCapturePass.Destroy(device);  // IBL (capture ciel, source de prefilter+irradiance)
 		m_specularPrefilterPass.Destroy(device);
 		m_brdfLutPass.Destroy(device);
 		m_pipelineCache.Destroy(device);

--- a/src/client/render/DeferredPipeline.h
+++ b/src/client/render/DeferredPipeline.h
@@ -7,6 +7,8 @@
 #include "src/client/render/ShadowMapPass.h"
 #include "src/client/render/BrdfLutPass.h"
 #include "src/client/render/SpecularPrefilterPass.h"
+#include "src/client/render/SkyCubeCapturePass.h"
+#include "src/client/render/IrradiancePass.h"
 #include "src/client/render/SsaoKernelNoise.h"
 #include "src/client/render/SsaoPass.h"
 #include "src/client/render/SsaoBlurPass.h"
@@ -48,6 +50,9 @@ namespace engine::render
 		/// Initialises all passes (BRDF LUT, specular prefilter, SSAO kernel/noise/pass/blur,
 		/// geometry, shadow, lighting, tonemap, bloom chain, auto-exposure, TAA).
 		/// \param loadSpirv  Returns SPIR-V words for a given path (e.g. "shaders/foo.vert.spv"); may compile on the fly.
+		/// \param skyParams  État ciel figé au boot (DayNightCycle::State), consommé
+		///                   par l'orchestration IBL (capture ciel → prefilter → irradiance)
+		///                   gardée par `gi.ibl.enabled`. Rempli par l'Engine avant l'appel.
 		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
 			void* vmaAllocator,
 			const engine::core::Config& config,
@@ -55,7 +60,8 @@ namespace engine::render
 			VkFormat sceneColorLDRFormat,
 			VkQueue graphicsQueue,
 			uint32_t graphicsQueueFamilyIndex,
-			ShaderLoaderFn loadSpirv);
+			ShaderLoaderFn loadSpirv,
+			const engine::render::SkyCaptureParams& skyParams);
 
 		/// Destroys all passes in reverse init order. Safe to call when not initialised.
 		void Destroy(VkDevice device);
@@ -77,6 +83,10 @@ namespace engine::render
 		const BrdfLutPass&    GetBrdfLutPass() const    { return m_brdfLutPass; }
 		SpecularPrefilterPass& GetSpecularPrefilterPass() { return m_specularPrefilterPass; }
 		const SpecularPrefilterPass& GetSpecularPrefilterPass() const { return m_specularPrefilterPass; }
+		SkyCubeCapturePass&   GetSkyCubeCapturePass()   { return m_skyCubeCapturePass; }
+		const SkyCubeCapturePass& GetSkyCubeCapturePass() const { return m_skyCubeCapturePass; }
+		IrradiancePass&       GetIrradiancePass()       { return m_irradiancePass; }
+		const IrradiancePass& GetIrradiancePass() const { return m_irradiancePass; }
 		SsaoKernelNoise&      GetSsaoKernelNoise()      { return m_ssaoKernelNoise; }
 		const SsaoKernelNoise& GetSsaoKernelNoise() const { return m_ssaoKernelNoise; }
 		SsaoPass&             GetSsaoPass()             { return m_ssaoPass; }
@@ -112,6 +122,8 @@ namespace engine::render
 		ShadowMapPass         m_shadowMapPass;
 		BrdfLutPass           m_brdfLutPass;
 		SpecularPrefilterPass m_specularPrefilterPass;
+		SkyCubeCapturePass    m_skyCubeCapturePass; ///< IBL — capture ciel procédural en cubemap (1×/boot)
+		IrradiancePass        m_irradiancePass;     ///< IBL — irradiance diffuse convoluée (1×/boot)
 		SsaoKernelNoise       m_ssaoKernelNoise;
 		SsaoPass              m_ssaoPass;
 		SsaoBlurPass          m_ssaoBlurPass;

--- a/src/client/render/IrradiancePass.cpp
+++ b/src/client/render/IrradiancePass.cpp
@@ -1,0 +1,504 @@
+#include "src/client/render/IrradiancePass.h"
+#include "src/client/render/PipelineCache.h"
+
+#include "src/shared/core/Log.h"
+
+#include <vulkan/vulkan.h>
+#include <cstdio>
+#include <cstring>
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Layout des push-constants miroir de irradiance_convolve.comp
+		/// (face, faceSize, pad0, pad1). 16 octets, std430.
+		struct IrradiancePushConstants
+		{
+			uint32_t face;
+			uint32_t faceSize;
+			float pad0;
+			float pad1;
+		};
+		static_assert(sizeof(IrradiancePushConstants) == 16,
+			"IrradiancePushConstants doit faire 16 octets (layout std430 du shader)");
+	}
+
+	bool IrradiancePass::Init(VkDevice device, VkPhysicalDevice physicalDevice,
+		void* vmaAllocator,
+		uint32_t faceSize,
+		const uint32_t* compSpirv, size_t compWordCount,
+		uint32_t queueFamilyIndex,
+		VkPipelineCache pipelineCache)
+	{
+		LOG_INFO(Render, "[IRRAD] Init enter size={}", faceSize);
+		if (device == VK_NULL_HANDLE || physicalDevice == VK_NULL_HANDLE
+			|| !compSpirv || compWordCount == 0 || faceSize == 0)
+		{
+			LOG_ERROR(Render, "IrradiancePass::Init: invalid arguments");
+			return false;
+		}
+
+		m_size = faceSize;
+		m_vmaAllocator = vmaAllocator; // conservé pour compat, plus utilisé pour l'alloc.
+
+		// ---------------------------------------------------------------------
+		// Garde-fou : le format RGBA16F doit supporter STORAGE_IMAGE (écriture
+		// compute). Sinon échec propre (-> repli useIBL=0 côté Engine).
+		// ---------------------------------------------------------------------
+		VkFormatProperties fmtProps{};
+		vkGetPhysicalDeviceFormatProperties(physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT, &fmtProps);
+		if ((fmtProps.optimalTilingFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) == 0)
+		{
+			LOG_WARN(Render, "IrradiancePass::Init: RGBA16F sans STORAGE_IMAGE_BIT, IBL diffus désactivé");
+			return false;
+		}
+
+		// ---------------------------------------------------------------------
+		// Cubemap image (6 layers, 1 mip) — Vulkan brut + DEVICE_LOCAL
+		// ---------------------------------------------------------------------
+		VkImageCreateInfo imgInfo{};
+		imgInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imgInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+		imgInfo.imageType = VK_IMAGE_TYPE_2D;
+		imgInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+		imgInfo.extent.width = faceSize;
+		imgInfo.extent.height = faceSize;
+		imgInfo.extent.depth = 1;
+		imgInfo.mipLevels = 1;
+		imgInfo.arrayLayers = 6;
+		imgInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imgInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		imgInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+		imgInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+		VkResult r = vkCreateImage(device, &imgInfo, nullptr, &m_image);
+		LOG_INFO(Render, "[IRRAD] vkCreateImage r={} img={}", (int)r, (void*)m_image);
+		if (r != VK_SUCCESS || m_image == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateImage failed");
+			return false;
+		}
+
+		VkMemoryRequirements memReq{};
+		vkGetImageMemoryRequirements(device, m_image, &memReq);
+
+		VkPhysicalDeviceMemoryProperties memProps{};
+		vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+
+		auto findMemoryType = [&](uint32_t typeBits, VkMemoryPropertyFlags desiredFlags) -> uint32_t
+		{
+			for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+			{
+				if ((typeBits & (1u << i)) &&
+					(memProps.memoryTypes[i].propertyFlags & desiredFlags) == desiredFlags)
+				{
+					return i;
+				}
+			}
+			return UINT32_MAX;
+		};
+
+		const VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+		uint32_t memTypeIdx = findMemoryType(memReq.memoryTypeBits, flags);
+		if (memTypeIdx == UINT32_MAX)
+		{
+			LOG_ERROR(Render, "IrradiancePass: no suitable DEVICE_LOCAL memory type");
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memReq.size;
+		allocInfo.memoryTypeIndex = memTypeIdx;
+
+		VkDeviceMemory memory = VK_NULL_HANDLE;
+		if (vkAllocateMemory(device, &allocInfo, nullptr, &memory) != VK_SUCCESS || memory == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkAllocateMemory failed");
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		if (vkBindImageMemory(device, m_image, memory, 0) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkBindImageMemory failed");
+			vkFreeMemory(device, memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		// On stocke VkDeviceMemory dans m_allocation (void*).
+		m_allocation = reinterpret_cast<void*>(memory);
+
+		// ---------------------------------------------------------------------
+		// Vue cubemap complète (échantillonnage) + 6 vues 2D par face (storage)
+		// ---------------------------------------------------------------------
+		VkImageViewCreateInfo cubeViewInfo{};
+		cubeViewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		cubeViewInfo.image = m_image;
+		cubeViewInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
+		cubeViewInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+		cubeViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		cubeViewInfo.subresourceRange.baseMipLevel = 0;
+		cubeViewInfo.subresourceRange.levelCount = 1;
+		cubeViewInfo.subresourceRange.baseArrayLayer = 0;
+		cubeViewInfo.subresourceRange.layerCount = 6;
+		if (vkCreateImageView(device, &cubeViewInfo, nullptr, &m_cubeView) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateImageView (cube) failed");
+			Destroy(device);
+			return false;
+		}
+
+		m_faceViews.reserve(6u);
+		for (uint32_t face = 0; face < 6u; ++face)
+		{
+			VkImageViewCreateInfo viewInfo{};
+			viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+			viewInfo.image = m_image;
+			viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+			viewInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+			viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			viewInfo.subresourceRange.baseMipLevel = 0;
+			viewInfo.subresourceRange.levelCount = 1;
+			viewInfo.subresourceRange.baseArrayLayer = face;
+			viewInfo.subresourceRange.layerCount = 1;
+			VkImageView view = VK_NULL_HANDLE;
+			if (vkCreateImageView(device, &viewInfo, nullptr, &view) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "IrradiancePass: vkCreateImageView (face) failed");
+				Destroy(device);
+				return false;
+			}
+			m_faceViews.push_back(view);
+		}
+
+		// ---------------------------------------------------------------------
+		// Sampler (linéaire, sans mip — 1 seul niveau)
+		// ---------------------------------------------------------------------
+		VkSamplerCreateInfo sampInfo{};
+		sampInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sampInfo.magFilter = VK_FILTER_LINEAR;
+		sampInfo.minFilter = VK_FILTER_LINEAR;
+		sampInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+		sampInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.maxLod = 0.0f;
+		if (vkCreateSampler(device, &sampInfo, nullptr, &m_sampler) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateSampler failed");
+			Destroy(device);
+			return false;
+		}
+
+		// ---------------------------------------------------------------------
+		// Descriptor set layout : binding 0 = samplerCube source, 1 = storage image
+		// ---------------------------------------------------------------------
+		VkDescriptorSetLayoutBinding bindings[2]{};
+		bindings[0].binding = 0;
+		bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		bindings[0].descriptorCount = 1;
+		bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+		bindings[1].binding = 1;
+		bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		bindings[1].descriptorCount = 1;
+		bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+		VkDescriptorSetLayoutCreateInfo setLayoutInfo{};
+		setLayoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+		setLayoutInfo.bindingCount = 2;
+		setLayoutInfo.pBindings = bindings;
+		if (vkCreateDescriptorSetLayout(device, &setLayoutInfo, nullptr, &m_setLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateDescriptorSetLayout failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkDescriptorPoolSize poolSizes[2]{};
+		poolSizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		poolSizes[0].descriptorCount = 1;
+		poolSizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		poolSizes[1].descriptorCount = 1;
+		VkDescriptorPoolCreateInfo poolInfo{};
+		poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+		poolInfo.poolSizeCount = 2;
+		poolInfo.pPoolSizes = poolSizes;
+		poolInfo.maxSets = 1;
+		if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descPool) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateDescriptorPool failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkDescriptorSetAllocateInfo descAllocInfo{};
+		descAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+		descAllocInfo.descriptorPool = m_descPool;
+		descAllocInfo.descriptorSetCount = 1;
+		descAllocInfo.pSetLayouts = &m_setLayout;
+		if (vkAllocateDescriptorSets(device, &descAllocInfo, &m_descSet) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkAllocateDescriptorSets failed");
+			Destroy(device);
+			return false;
+		}
+
+		// ---------------------------------------------------------------------
+		// Push constants + pipeline layout
+		// ---------------------------------------------------------------------
+		VkPushConstantRange pushRange{};
+		pushRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+		pushRange.offset = 0;
+		pushRange.size = sizeof(IrradiancePushConstants);
+		VkPipelineLayoutCreateInfo layoutInfo{};
+		layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		layoutInfo.setLayoutCount = 1;
+		layoutInfo.pSetLayouts = &m_setLayout;
+		layoutInfo.pushConstantRangeCount = 1;
+		layoutInfo.pPushConstantRanges = &pushRange;
+		if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreatePipelineLayout failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkShaderModuleCreateInfo smInfo{};
+		smInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+		smInfo.codeSize = compWordCount * sizeof(uint32_t);
+		smInfo.pCode = compSpirv;
+		VkShaderModule compModule = VK_NULL_HANDLE;
+		if (vkCreateShaderModule(device, &smInfo, nullptr, &compModule) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateShaderModule failed");
+			Destroy(device);
+			return false;
+		}
+		VkPipelineShaderStageCreateInfo stageInfo{};
+		stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+		stageInfo.module = compModule;
+		stageInfo.pName = "main";
+		VkComputePipelineCreateInfo cpInfo{};
+		cpInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+		cpInfo.stage = stageInfo;
+		cpInfo.layout = m_pipelineLayout;
+		AssertPipelineCreationAllowed();
+		PipelineCache::RegisterWarmupKey(HashComputePsoKey(m_pipelineLayout, compWordCount));
+		if (vkCreateComputePipelines(device, pipelineCache, 1, &cpInfo, nullptr, &m_pipeline) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateComputePipelines failed");
+			vkDestroyShaderModule(device, compModule, nullptr);
+			Destroy(device);
+			return false;
+		}
+		vkDestroyShaderModule(device, compModule, nullptr);
+
+		VkCommandPoolCreateInfo poolInfoCmd{};
+		poolInfoCmd.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		poolInfoCmd.queueFamilyIndex = queueFamilyIndex;
+		poolInfoCmd.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		if (vkCreateCommandPool(device, &poolInfoCmd, nullptr, &m_cmdPool) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "IrradiancePass: vkCreateCommandPool failed");
+			Destroy(device);
+			return false;
+		}
+
+		LOG_INFO(Render, "IrradiancePass: initialised (size={})", m_size);
+		return true;
+	}
+
+	bool IrradiancePass::Generate(VkDevice device, VkQueue queue,
+		VkImageView sourceCubemapView, VkSampler sourceCubemapSampler)
+	{
+		LOG_DEBUG(Render, "[IRRAD] Generate enter");
+		if (device == VK_NULL_HANDLE || queue == VK_NULL_HANDLE || m_cmdPool == VK_NULL_HANDLE
+			|| sourceCubemapView == VK_NULL_HANDLE || sourceCubemapSampler == VK_NULL_HANDLE)
+			return false;
+
+		VkCommandBufferAllocateInfo cmdBufAllocInfo{};
+		cmdBufAllocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		cmdBufAllocInfo.commandPool = m_cmdPool;
+		cmdBufAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		cmdBufAllocInfo.commandBufferCount = 1;
+		VkCommandBuffer cmd = VK_NULL_HANDLE;
+		if (vkAllocateCommandBuffers(device, &cmdBufAllocInfo, &cmd) != VK_SUCCESS)
+			return false;
+
+		VkCommandBufferBeginInfo beginInfo{};
+		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+		beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+		if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+
+		const uint32_t groupSize = 8u;
+		IrradiancePushConstants pc{};
+		pc.faceSize = m_size;
+		pc.pad0 = 0.0f;
+		pc.pad1 = 0.0f;
+
+		for (uint32_t face = 0; face < 6u; ++face)
+		{
+			pc.face = face;
+
+			// Update descriptor : cubemap source + vue face de sortie.
+			VkDescriptorImageInfo srcImgInfo{};
+			srcImgInfo.sampler = sourceCubemapSampler;
+			srcImgInfo.imageView = sourceCubemapView;
+			srcImgInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			VkDescriptorImageInfo outImgInfo{};
+			outImgInfo.imageView = m_faceViews[face];
+			outImgInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+			VkWriteDescriptorSet writes[2]{};
+			writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[0].dstSet = m_descSet;
+			writes[0].dstBinding = 0;
+			writes[0].descriptorCount = 1;
+			writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[0].pImageInfo = &srcImgInfo;
+			writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[1].dstSet = m_descSet;
+			writes[1].dstBinding = 1;
+			writes[1].descriptorCount = 1;
+			writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+			writes[1].pImageInfo = &outImgInfo;
+			vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
+
+			// Transition de cette face en GENERAL pour l'écriture.
+			VkImageMemoryBarrier toGeneral{};
+			toGeneral.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+			toGeneral.srcAccessMask = 0;
+			toGeneral.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+			toGeneral.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+			toGeneral.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+			toGeneral.image = m_image;
+			toGeneral.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			toGeneral.subresourceRange.baseMipLevel = 0;
+			toGeneral.subresourceRange.levelCount = 1;
+			toGeneral.subresourceRange.baseArrayLayer = face;
+			toGeneral.subresourceRange.layerCount = 1;
+			vkCmdPipelineBarrier(cmd,
+				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				0, 0, nullptr, 0, nullptr, 1, &toGeneral);
+
+			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
+			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+				m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
+			vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+				sizeof(IrradiancePushConstants), &pc);
+
+			const uint32_t groups = (m_size + groupSize - 1u) / groupSize;
+			vkCmdDispatch(cmd, groups, groups, 1u);
+
+			// Barrière : la prochaine face ou la transition finale voit l'écriture.
+			VkImageMemoryBarrier afterWrite{};
+			afterWrite.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+			afterWrite.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+			afterWrite.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+			afterWrite.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+			afterWrite.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			afterWrite.image = m_image;
+			afterWrite.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			afterWrite.subresourceRange.baseMipLevel = 0;
+			afterWrite.subresourceRange.levelCount = 1;
+			afterWrite.subresourceRange.baseArrayLayer = face;
+			afterWrite.subresourceRange.layerCount = 1;
+			vkCmdPipelineBarrier(cmd,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				0, 0, nullptr, 0, nullptr, 1, &afterWrite);
+		}
+
+		if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+		VkSubmitInfo submitInfo{};
+		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submitInfo.commandBufferCount = 1;
+		submitInfo.pCommandBuffers = &cmd;
+		if (vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+		vkQueueWaitIdle(queue);
+		vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+
+		LOG_INFO(Render, "IrradiancePass: irradiance cubemap generated");
+		return true;
+	}
+
+	void IrradiancePass::Destroy(VkDevice device)
+	{
+		LOG_DEBUG(Render, "[IRRAD] Destroy enter");
+		if (device == VK_NULL_HANDLE)
+			return;
+		for (VkImageView v : m_faceViews)
+		{
+			if (v != VK_NULL_HANDLE)
+				vkDestroyImageView(device, v, nullptr);
+		}
+		m_faceViews.clear();
+		if (m_cmdPool != VK_NULL_HANDLE)
+		{
+			vkDestroyCommandPool(device, m_cmdPool, nullptr);
+			m_cmdPool = VK_NULL_HANDLE;
+		}
+		if (m_pipeline != VK_NULL_HANDLE)
+		{
+			vkDestroyPipeline(device, m_pipeline, nullptr);
+			m_pipeline = VK_NULL_HANDLE;
+		}
+		if (m_pipelineLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+			m_pipelineLayout = VK_NULL_HANDLE;
+		}
+		if (m_descPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descPool, nullptr);
+			m_descPool = VK_NULL_HANDLE;
+		}
+		if (m_setLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorSetLayout(device, m_setLayout, nullptr);
+			m_setLayout = VK_NULL_HANDLE;
+		}
+		if (m_sampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_sampler, nullptr);
+			m_sampler = VK_NULL_HANDLE;
+		}
+		if (m_cubeView != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device, m_cubeView, nullptr);
+			m_cubeView = VK_NULL_HANDLE;
+		}
+		if (m_image != VK_NULL_HANDLE && m_allocation != nullptr)
+		{
+			VkDeviceMemory mem = reinterpret_cast<VkDeviceMemory>(m_allocation);
+			vkDestroyImage(device, m_image, nullptr);
+			vkFreeMemory(device, mem, nullptr);
+			m_image = VK_NULL_HANDLE;
+			m_allocation = nullptr;
+		}
+		m_vmaAllocator = nullptr;
+		m_size = 0;
+		LOG_INFO(Render, "[IRRAD] Destroy OK");
+	}
+}

--- a/src/client/render/IrradiancePass.h
+++ b/src/client/render/IrradiancePass.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::render
+{
+	/// IrradiancePass (IBL diffus) : convolue une cubemap d'environnement HDR
+	/// source en une cubemap d'irradiance diffuse (cosine-weighted hemisphere).
+	///
+	/// Calque quasi-identique de SpecularPrefilterPass mais : 1 SEUL mip, faces
+	/// de 32² (l'irradiance diffuse est basse fréquence), convolution cosine au
+	/// lieu de GGX. Sortie : cubemap RGBA16F 32² échantillonnable le long de la
+	/// normale pour le terme diffus split-sum. L'irradiance produite est
+	/// pré-intégrée avec un facteur PI (convention LearnOpenGL : `lighting.frag`
+	/// fait `irradiance * albedo` sans /PI). Generate() requiert une vue+sampler
+	/// de cubemap source valides ; sinon Generate() retourne false.
+	class IrradiancePass
+	{
+	public:
+		IrradiancePass() = default;
+		IrradiancePass(const IrradiancePass&) = delete;
+		IrradiancePass& operator=(const IrradiancePass&) = delete;
+
+		/// Initialise la cubemap de sortie (1 mip), le descriptor layout/pool
+		/// (2 bindings : source samplerCube + image storage), et le pipeline
+		/// compute. Ne requiert pas de cubemap source.
+		/// \param faceSize    Taille d'une face (typiquement 32).
+		/// \param compSpirv   SPIR-V du compute irradiance_convolve.comp.
+		/// \param compWordCount Nombre de mots 32 bits dans compSpirv.
+		/// \param vmaAllocator Allocateur GPU centralisé (VMA) ; conservé pour
+		///        compat (l'alloc réelle reste Vulkan brut DEVICE_LOCAL).
+		/// \return true en cas de succès. false propre (Destroy interne) si le
+		///         format RGBA16F ne supporte pas STORAGE_IMAGE ou si une
+		///         création Vulkan échoue.
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+			void* vmaAllocator,
+			uint32_t faceSize,
+			const uint32_t* compSpirv, size_t compWordCount,
+			uint32_t queueFamilyIndex,
+			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Exécute la convolution : pour chaque face, échantillonne la cubemap
+		/// source et écrit l'irradiance, puis transitionne la cubemap en
+		/// SHADER_READ_ONLY_OPTIMAL. submit + waitIdle (one-shot au boot).
+		/// \return true en cas de succès ; false si vue/sampler source nuls ou
+		///         si la soumission échoue.
+		bool Generate(VkDevice device, VkQueue queue,
+			VkImageView sourceCubemapView, VkSampler sourceCubemapSampler);
+
+		/// Libère toutes les ressources Vulkan. Sûr même si Init a échoué.
+		void Destroy(VkDevice device);
+
+		/// Vue cubemap couvrant les 6 faces (pour l'échantillonnage diffus).
+		VkImageView GetImageView() const { return m_cubeView; }
+
+		/// Sampler de la cubemap d'irradiance (linéaire, sans mip).
+		VkSampler GetSampler() const { return m_sampler; }
+
+		/// Indique si la passe est initialisée et utilisable (Generate peut ne
+		/// pas encore avoir tourné si aucune source n'a été fournie).
+		bool IsValid() const { return m_image != VK_NULL_HANDLE && m_cubeView != VK_NULL_HANDLE; }
+
+	private:
+		void*                      m_vmaAllocator = nullptr;
+		VkImage                    m_image       = VK_NULL_HANDLE;
+		void*                      m_allocation   = nullptr; ///< VkDeviceMemory
+		VkImageView                m_cubeView     = VK_NULL_HANDLE;
+		VkSampler                  m_sampler     = VK_NULL_HANDLE;
+		std::vector<VkImageView>   m_faceViews;  ///< 6 vues 2D (une par face) pour l'écriture.
+		VkDescriptorSetLayout      m_setLayout    = VK_NULL_HANDLE;
+		VkDescriptorPool           m_descPool    = VK_NULL_HANDLE;
+		VkDescriptorSet            m_descSet     = VK_NULL_HANDLE;
+		VkPipelineLayout           m_pipelineLayout = VK_NULL_HANDLE;
+		VkPipeline                 m_pipeline    = VK_NULL_HANDLE;
+		VkCommandPool              m_cmdPool     = VK_NULL_HANDLE;
+		uint32_t                   m_size        = 0;
+	};
+}

--- a/src/client/render/SkyCubeCapturePass.cpp
+++ b/src/client/render/SkyCubeCapturePass.cpp
@@ -1,0 +1,518 @@
+#include "src/client/render/SkyCubeCapturePass.h"
+#include "src/client/render/PipelineCache.h"
+
+#include "src/shared/core/Log.h"
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <cstring>
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Layout push-constant miroir std430 EXACT de `sky_capture.comp`.
+		/// vec3 alignés en vec4 ; total verrouillé à 96 octets par static_assert.
+		struct SkyCapturePushConstants
+		{
+			uint32_t face;          // offset 0
+			uint32_t faceSize;      // offset 4
+			float    pad0;          // offset 8
+			float    pad1;          // offset 12
+			float    lightDir[4];   // offset 16 (vec4 : .xyz utilisé)
+			float    zenithColor[4]; // offset 32
+			float    horizonColor[4]; // offset 48
+			float    moonDir[4];    // offset 64
+			float    moonParams[4]; // offset 80 : {intensity, phase, illumination, pad}
+		};
+		static_assert(sizeof(SkyCapturePushConstants) == 96,
+			"SkyCapturePushConstants doit faire 96 octets (miroir std430 de sky_capture.comp)");
+	}
+
+	bool SkyCubeCapturePass::Init(VkDevice device, VkPhysicalDevice physicalDevice,
+		void* vmaAllocator,
+		uint32_t faceSize,
+		const uint32_t* compSpirv, size_t compWordCount,
+		uint32_t queueFamilyIndex,
+		VkPipelineCache pipelineCache)
+	{
+		LOG_INFO(Render, "[SKYCAP] Init enter faceSize={}", faceSize);
+		if (device == VK_NULL_HANDLE || physicalDevice == VK_NULL_HANDLE
+			|| !compSpirv || compWordCount == 0 || faceSize == 0)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass::Init: invalid arguments");
+			return false;
+		}
+
+		m_faceSize = faceSize;
+		m_vmaAllocator = vmaAllocator; // conservé pour compat, plus utilisé pour l'alloc.
+
+		// ---------------------------------------------------------------------
+		// Vérif support storage du format RGBA16F (repli propre si absent).
+		// ---------------------------------------------------------------------
+		{
+			VkFormatProperties fmtProps{};
+			vkGetPhysicalDeviceFormatProperties(physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT, &fmtProps);
+			if (!(fmtProps.optimalTilingFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT))
+			{
+				LOG_ERROR(Render, "SkyCubeCapturePass: VK_FORMAT_R16G16B16A16_SFLOAT does not support STORAGE_IMAGE on this device — sky capture disabled");
+				return false;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// Cubemap image (6 layers, 1 mip) — Vulkan brut + DEVICE_LOCAL
+		// ---------------------------------------------------------------------
+		VkImageCreateInfo imgInfo{};
+		imgInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		imgInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+		imgInfo.imageType = VK_IMAGE_TYPE_2D;
+		imgInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+		imgInfo.extent.width = faceSize;
+		imgInfo.extent.height = faceSize;
+		imgInfo.extent.depth = 1;
+		imgInfo.mipLevels = 1;
+		imgInfo.arrayLayers = 6;
+		imgInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		imgInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		imgInfo.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+		imgInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+		VkResult r = vkCreateImage(device, &imgInfo, nullptr, &m_image);
+		LOG_INFO(Render, "[SKYCAP] vkCreateImage r={} img={}", (int)r, (void*)m_image);
+		if (r != VK_SUCCESS || m_image == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateImage failed");
+			return false;
+		}
+
+		VkMemoryRequirements memReq{};
+		vkGetImageMemoryRequirements(device, m_image, &memReq);
+
+		VkPhysicalDeviceMemoryProperties memProps{};
+		vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+
+		auto findMemoryType = [&](uint32_t typeBits, VkMemoryPropertyFlags desiredFlags) -> uint32_t
+		{
+			for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+			{
+				if ((typeBits & (1u << i)) &&
+					(memProps.memoryTypes[i].propertyFlags & desiredFlags) == desiredFlags)
+				{
+					return i;
+				}
+			}
+			return UINT32_MAX;
+		};
+
+		const VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+		uint32_t memTypeIdx = findMemoryType(memReq.memoryTypeBits, flags);
+		if (memTypeIdx == UINT32_MAX)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: no suitable DEVICE_LOCAL memory type");
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		VkMemoryAllocateInfo allocInfo{};
+		allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		allocInfo.allocationSize = memReq.size;
+		allocInfo.memoryTypeIndex = memTypeIdx;
+
+		VkDeviceMemory memory = VK_NULL_HANDLE;
+		if (vkAllocateMemory(device, &allocInfo, nullptr, &memory) != VK_SUCCESS || memory == VK_NULL_HANDLE)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkAllocateMemory failed");
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		if (vkBindImageMemory(device, m_image, memory, 0) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkBindImageMemory failed");
+			vkFreeMemory(device, memory, nullptr);
+			vkDestroyImage(device, m_image, nullptr);
+			m_image = VK_NULL_HANDLE;
+			return false;
+		}
+
+		// On stocke VkDeviceMemory dans m_allocation (void*).
+		m_allocation = reinterpret_cast<void*>(memory);
+
+		// ---------------------------------------------------------------------
+		// Full cubemap view (sampling) + per-face views (storage write)
+		// ---------------------------------------------------------------------
+		VkImageViewCreateInfo cubeViewInfo{};
+		cubeViewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		cubeViewInfo.image = m_image;
+		cubeViewInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
+		cubeViewInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+		cubeViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		cubeViewInfo.subresourceRange.baseMipLevel = 0;
+		cubeViewInfo.subresourceRange.levelCount = 1;
+		cubeViewInfo.subresourceRange.baseArrayLayer = 0;
+		cubeViewInfo.subresourceRange.layerCount = 6;
+		if (vkCreateImageView(device, &cubeViewInfo, nullptr, &m_cubeView) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateImageView (cube) failed");
+			Destroy(device);
+			return false;
+		}
+
+		m_faceViews.reserve(6u);
+		for (uint32_t face = 0; face < 6u; ++face)
+		{
+			VkImageViewCreateInfo viewInfo{};
+			viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+			viewInfo.image = m_image;
+			viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+			viewInfo.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+			viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			viewInfo.subresourceRange.baseMipLevel = 0;
+			viewInfo.subresourceRange.levelCount = 1;
+			viewInfo.subresourceRange.baseArrayLayer = face;
+			viewInfo.subresourceRange.layerCount = 1;
+			VkImageView view = VK_NULL_HANDLE;
+			if (vkCreateImageView(device, &viewInfo, nullptr, &view) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateImageView (face) failed");
+				Destroy(device);
+				return false;
+			}
+			m_faceViews.push_back(view);
+		}
+
+		// ---------------------------------------------------------------------
+		// Sampler (linear, mipmapMode NEAREST, maxLod 0 — 1 seul mip)
+		// ---------------------------------------------------------------------
+		VkSamplerCreateInfo sampInfo{};
+		sampInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+		sampInfo.magFilter = VK_FILTER_LINEAR;
+		sampInfo.minFilter = VK_FILTER_LINEAR;
+		sampInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+		sampInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+		sampInfo.maxLod = 0.0f;
+		if (vkCreateSampler(device, &sampInfo, nullptr, &m_sampler) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateSampler failed");
+			Destroy(device);
+			return false;
+		}
+
+		// ---------------------------------------------------------------------
+		// Descriptor set layout: binding 0 = storage image (output face)
+		// ---------------------------------------------------------------------
+		VkDescriptorSetLayoutBinding binding{};
+		binding.binding = 0;
+		binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		binding.descriptorCount = 1;
+		binding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+		VkDescriptorSetLayoutCreateInfo setLayoutInfo{};
+		setLayoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+		setLayoutInfo.bindingCount = 1;
+		setLayoutInfo.pBindings = &binding;
+		if (vkCreateDescriptorSetLayout(device, &setLayoutInfo, nullptr, &m_setLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateDescriptorSetLayout failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkDescriptorPoolSize poolSize{};
+		poolSize.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+		poolSize.descriptorCount = 1;
+		VkDescriptorPoolCreateInfo poolInfo{};
+		poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+		poolInfo.poolSizeCount = 1;
+		poolInfo.pPoolSizes = &poolSize;
+		poolInfo.maxSets = 1;
+		if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descPool) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateDescriptorPool failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkDescriptorSetAllocateInfo descAllocInfo{};
+		descAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+		descAllocInfo.descriptorPool = m_descPool;
+		descAllocInfo.descriptorSetCount = 1;
+		descAllocInfo.pSetLayouts = &m_setLayout;
+		if (vkAllocateDescriptorSets(device, &descAllocInfo, &m_descSet) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkAllocateDescriptorSets failed");
+			Destroy(device);
+			return false;
+		}
+
+		// ---------------------------------------------------------------------
+		// Push constants + pipeline layout
+		// ---------------------------------------------------------------------
+		VkPushConstantRange pushRange{};
+		pushRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+		pushRange.offset = 0;
+		pushRange.size = sizeof(SkyCapturePushConstants);
+		VkPipelineLayoutCreateInfo layoutInfo{};
+		layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		layoutInfo.setLayoutCount = 1;
+		layoutInfo.pSetLayouts = &m_setLayout;
+		layoutInfo.pushConstantRangeCount = 1;
+		layoutInfo.pPushConstantRanges = &pushRange;
+		if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreatePipelineLayout failed");
+			Destroy(device);
+			return false;
+		}
+
+		VkShaderModuleCreateInfo smInfo{};
+		smInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+		smInfo.codeSize = compWordCount * sizeof(uint32_t);
+		smInfo.pCode = compSpirv;
+		VkShaderModule compModule = VK_NULL_HANDLE;
+		if (vkCreateShaderModule(device, &smInfo, nullptr, &compModule) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateShaderModule failed");
+			Destroy(device);
+			return false;
+		}
+		VkPipelineShaderStageCreateInfo stageInfo{};
+		stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+		stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+		stageInfo.module = compModule;
+		stageInfo.pName = "main";
+		VkComputePipelineCreateInfo cpInfo{};
+		cpInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+		cpInfo.stage = stageInfo;
+		cpInfo.layout = m_pipelineLayout;
+		AssertPipelineCreationAllowed();
+		PipelineCache::RegisterWarmupKey(HashComputePsoKey(m_pipelineLayout, compWordCount));
+		if (vkCreateComputePipelines(device, pipelineCache, 1, &cpInfo, nullptr, &m_pipeline) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateComputePipelines failed");
+			vkDestroyShaderModule(device, compModule, nullptr);
+			Destroy(device);
+			return false;
+		}
+		vkDestroyShaderModule(device, compModule, nullptr);
+
+		VkCommandPoolCreateInfo poolInfoCmd{};
+		poolInfoCmd.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		poolInfoCmd.queueFamilyIndex = queueFamilyIndex;
+		poolInfoCmd.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		if (vkCreateCommandPool(device, &poolInfoCmd, nullptr, &m_cmdPool) != VK_SUCCESS)
+		{
+			LOG_ERROR(Render, "SkyCubeCapturePass: vkCreateCommandPool failed");
+			Destroy(device);
+			return false;
+		}
+
+		LOG_INFO(Render, "SkyCubeCapturePass: initialised (faceSize={})", m_faceSize);
+		return true;
+	}
+
+	bool SkyCubeCapturePass::Generate(VkDevice device, VkQueue queue, const SkyCaptureParams& params)
+	{
+		LOG_DEBUG(Render, "[SKYCAP] Generate enter");
+		if (device == VK_NULL_HANDLE || queue == VK_NULL_HANDLE || m_cmdPool == VK_NULL_HANDLE)
+			return false;
+
+		VkCommandBufferAllocateInfo cmdBufAllocInfo{};
+		cmdBufAllocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+		cmdBufAllocInfo.commandPool = m_cmdPool;
+		cmdBufAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+		cmdBufAllocInfo.commandBufferCount = 1;
+		VkCommandBuffer cmd = VK_NULL_HANDLE;
+		if (vkAllocateCommandBuffers(device, &cmdBufAllocInfo, &cmd) != VK_SUCCESS)
+			return false;
+
+		VkCommandBufferBeginInfo beginInfo{};
+		beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+		beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+		if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+
+		// Construit le push-constant miroir std430 depuis les paramètres ciel.
+		SkyCapturePushConstants pc{};
+		pc.faceSize = m_faceSize;
+		pc.pad0 = 0.0f;
+		pc.pad1 = 0.0f;
+		pc.lightDir[0] = params.lightDir[0];
+		pc.lightDir[1] = params.lightDir[1];
+		pc.lightDir[2] = params.lightDir[2];
+		pc.lightDir[3] = 0.0f;
+		pc.zenithColor[0] = params.zenithColor[0];
+		pc.zenithColor[1] = params.zenithColor[1];
+		pc.zenithColor[2] = params.zenithColor[2];
+		pc.zenithColor[3] = 0.0f;
+		pc.horizonColor[0] = params.horizonColor[0];
+		pc.horizonColor[1] = params.horizonColor[1];
+		pc.horizonColor[2] = params.horizonColor[2];
+		pc.horizonColor[3] = 0.0f;
+		pc.moonDir[0] = params.moonDir[0];
+		pc.moonDir[1] = params.moonDir[1];
+		pc.moonDir[2] = params.moonDir[2];
+		pc.moonDir[3] = 0.0f;
+		pc.moonParams[0] = params.moonIntensity;
+		pc.moonParams[1] = params.moonPhase;
+		pc.moonParams[2] = params.moonIllumination;
+		pc.moonParams[3] = 0.0f;
+
+		const uint32_t groupSize = 8u;
+		const uint32_t groups = (m_faceSize + groupSize - 1u) / groupSize;
+
+		for (uint32_t face = 0; face < 6u; ++face)
+		{
+			pc.face = face;
+
+			// Update descriptor: output face view (storage).
+			VkDescriptorImageInfo outImgInfo{};
+			outImgInfo.imageView = m_faceViews[face];
+			outImgInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+			VkWriteDescriptorSet write{};
+			write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			write.dstSet = m_descSet;
+			write.dstBinding = 0;
+			write.descriptorCount = 1;
+			write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+			write.pImageInfo = &outImgInfo;
+			vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
+
+			// Transition this face to GENERAL for write.
+			VkImageMemoryBarrier toGeneral{};
+			toGeneral.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+			toGeneral.srcAccessMask = 0;
+			toGeneral.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+			toGeneral.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+			toGeneral.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+			toGeneral.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+			toGeneral.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+			toGeneral.image = m_image;
+			toGeneral.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			toGeneral.subresourceRange.baseMipLevel = 0;
+			toGeneral.subresourceRange.levelCount = 1;
+			toGeneral.subresourceRange.baseArrayLayer = face;
+			toGeneral.subresourceRange.layerCount = 1;
+			vkCmdPipelineBarrier(cmd,
+				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				0, 0, nullptr, 0, nullptr, 1, &toGeneral);
+
+			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
+			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+				m_pipelineLayout, 0, 1, &m_descSet, 0, nullptr);
+			vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+				sizeof(SkyCapturePushConstants), &pc);
+
+			vkCmdDispatch(cmd, groups, groups, 1u);
+
+			// Barrier GENERAL -> SHADER_READ_ONLY for later sampling.
+			VkImageMemoryBarrier afterWrite{};
+			afterWrite.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+			afterWrite.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+			afterWrite.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+			afterWrite.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+			afterWrite.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			afterWrite.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+			afterWrite.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+			afterWrite.image = m_image;
+			afterWrite.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+			afterWrite.subresourceRange.baseMipLevel = 0;
+			afterWrite.subresourceRange.levelCount = 1;
+			afterWrite.subresourceRange.baseArrayLayer = face;
+			afterWrite.subresourceRange.layerCount = 1;
+			vkCmdPipelineBarrier(cmd,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+				0, 0, nullptr, 0, nullptr, 1, &afterWrite);
+		}
+
+		if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+		VkSubmitInfo submitInfo{};
+		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submitInfo.commandBufferCount = 1;
+		submitInfo.pCommandBuffers = &cmd;
+		if (vkQueueSubmit(queue, 1, &submitInfo, VK_NULL_HANDLE) != VK_SUCCESS)
+		{
+			vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+			return false;
+		}
+		vkQueueWaitIdle(queue);
+		vkFreeCommandBuffers(device, m_cmdPool, 1, &cmd);
+
+		LOG_INFO(Render, "SkyCubeCapturePass: sky cubemap captured");
+		return true;
+	}
+
+	void SkyCubeCapturePass::Destroy(VkDevice device)
+	{
+		LOG_DEBUG(Render, "[SKYCAP] Destroy enter");
+		if (device == VK_NULL_HANDLE)
+			return;
+		for (VkImageView v : m_faceViews)
+		{
+			if (v != VK_NULL_HANDLE)
+				vkDestroyImageView(device, v, nullptr);
+		}
+		m_faceViews.clear();
+		if (m_cmdPool != VK_NULL_HANDLE)
+		{
+			vkDestroyCommandPool(device, m_cmdPool, nullptr);
+			m_cmdPool = VK_NULL_HANDLE;
+		}
+		if (m_pipeline != VK_NULL_HANDLE)
+		{
+			vkDestroyPipeline(device, m_pipeline, nullptr);
+			m_pipeline = VK_NULL_HANDLE;
+		}
+		if (m_pipelineLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr);
+			m_pipelineLayout = VK_NULL_HANDLE;
+		}
+		if (m_descPool != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorPool(device, m_descPool, nullptr);
+			m_descPool = VK_NULL_HANDLE;
+		}
+		if (m_setLayout != VK_NULL_HANDLE)
+		{
+			vkDestroyDescriptorSetLayout(device, m_setLayout, nullptr);
+			m_setLayout = VK_NULL_HANDLE;
+		}
+		if (m_sampler != VK_NULL_HANDLE)
+		{
+			vkDestroySampler(device, m_sampler, nullptr);
+			m_sampler = VK_NULL_HANDLE;
+		}
+		if (m_cubeView != VK_NULL_HANDLE)
+		{
+			vkDestroyImageView(device, m_cubeView, nullptr);
+			m_cubeView = VK_NULL_HANDLE;
+		}
+		if (m_image != VK_NULL_HANDLE && m_allocation != nullptr)
+		{
+			VkDeviceMemory mem = reinterpret_cast<VkDeviceMemory>(m_allocation);
+			vkDestroyImage(device, m_image, nullptr);
+			vkFreeMemory(device, mem, nullptr);
+			m_image = VK_NULL_HANDLE;
+			m_allocation = nullptr;
+		}
+		m_vmaAllocator = nullptr;
+		m_faceSize = 0;
+		LOG_INFO(Render, "[SKYCAP] Destroy OK");
+	}
+}

--- a/src/client/render/SkyCubeCapturePass.h
+++ b/src/client/render/SkyCubeCapturePass.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::render
+{
+	/// Paramètres ciel pour la capture IBL, remplis par l'Engine depuis
+	/// `DayNightCycle::State` au boot. Servent à porter la logique de `sky.frag`
+	/// dans le compute `sky_capture.comp` (gradient + sun glow + disque lunaire).
+	///
+	/// `moonDir` = -lightDir (convention Engine) ; `moonIntensity` = 0 le jour,
+	/// 1 la nuit ; `moonPhase` ∈ [0,15] ; `moonIllumination` ∈ [0,1].
+	struct SkyCaptureParams
+	{
+		float lightDir[3]     = {0.0f, 1.0f, 0.0f};
+		float zenithColor[3]  = {0.0f, 0.0f, 0.0f};
+		float horizonColor[3] = {0.0f, 0.0f, 0.0f};
+		float moonDir[3]      = {0.0f, -1.0f, 0.0f};
+		float moonIntensity   = 0.0f;
+		float moonPhase       = 0.0f;
+		float moonIllumination = 0.0f;
+	};
+
+	/// SkyCubeCapturePass (IBL) : capture le ciel procédural dans une cubemap
+	/// RGBA16F (128² par face, 1 mip) via un compute one-shot au boot.
+	///
+	/// Modèle calqué sur `SpecularPrefilterPass` (image cube storage+sampled,
+	/// vue cube pour le sampling + 6 vues 2D par face pour l'écriture storage) et
+	/// `BrdfLutPass` (passe compute one-shot, command pool interne, submit +
+	/// waitIdle). La cubemap produite alimente ensuite `SpecularPrefilterPass` et
+	/// l'irradiance. `Generate()` dispatche le compute une fois par face.
+	class SkyCubeCapturePass
+	{
+	public:
+		SkyCubeCapturePass() = default;
+		SkyCubeCapturePass(const SkyCubeCapturePass&) = delete;
+		SkyCubeCapturePass& operator=(const SkyCubeCapturePass&) = delete;
+
+		/// Initialise la cubemap de sortie (storage+sampled), ses vues (cube +
+		/// 6 faces 2D), le sampler linéaire, le descriptor layout (1 binding
+		/// STORAGE_IMAGE compute), le range push-constant et le pipeline compute.
+		///
+		/// Vérifie le support `VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT` du format
+		/// `R16G16B16A16_SFLOAT` avant de créer l'image ; en cas d'absence,
+		/// retourne false (repli géré par l'appelant). Tout échec d'init appelle
+		/// `Destroy` et retourne false.
+		///
+		/// \param vmaAllocator      Alloc GPU centralisé (VMA) ; conservé pour
+		///                          compat mais non utilisé (alloc Vulkan brute).
+		/// \param faceSize          Taille d'une face en texels (ex. 128).
+		/// \param compSpirv         SPIR-V du compute `sky_capture.comp`.
+		/// \param compWordCount     Nombre de mots 32 bits dans compSpirv.
+		/// \param queueFamilyIndex  Famille de file pour le command pool interne.
+		/// \return true en cas de succès.
+		/// \note À appeler en phase de warmup (crée un pipeline compute).
+		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
+			void* vmaAllocator,
+			uint32_t faceSize,
+			const uint32_t* compSpirv, size_t compWordCount,
+			uint32_t queueFamilyIndex,
+			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
+
+		/// Exécute la capture : pour chaque face (0..5), met à jour le descriptor
+		/// (vue storage de la face), transitionne UNDEFINED→GENERAL, push les
+		/// paramètres ciel + dispatch, puis transitionne GENERAL→SHADER_READ_ONLY.
+		/// Soumet le command buffer et attend l'inactivité de la file.
+		///
+		/// \param params Paramètres ciel (lightDir, couleurs, lune) figés au boot.
+		/// \return true en cas de succès.
+		bool Generate(VkDevice device, VkQueue queue, const SkyCaptureParams& params);
+
+		/// Libère toutes les ressources Vulkan. Sûr même si Init a échoué.
+		void Destroy(VkDevice device);
+
+		/// Vue cube couvrant les 6 faces (pour le sampling en passes aval).
+		VkImageView GetImageView() const { return m_cubeView; }
+
+		/// Sampler de la cubemap (linéaire, mipmapMode NEAREST, maxLod 0).
+		VkSampler GetSampler() const { return m_sampler; }
+
+		/// Indique si la passe est initialisée et utilisable.
+		bool IsValid() const { return m_image != VK_NULL_HANDLE && m_cubeView != VK_NULL_HANDLE; }
+
+	private:
+		void*                    m_vmaAllocator   = nullptr;
+		VkImage                  m_image          = VK_NULL_HANDLE;
+		void*                    m_allocation     = nullptr; ///< VkDeviceMemory stocké en void*
+		VkImageView              m_cubeView       = VK_NULL_HANDLE;
+		VkSampler                m_sampler        = VK_NULL_HANDLE;
+		std::vector<VkImageView> m_faceViews;     ///< 6 vues 2D (une par face) pour l'écriture storage
+		VkDescriptorSetLayout    m_setLayout      = VK_NULL_HANDLE;
+		VkDescriptorPool         m_descPool       = VK_NULL_HANDLE;
+		VkDescriptorSet          m_descSet        = VK_NULL_HANDLE;
+		VkPipelineLayout         m_pipelineLayout = VK_NULL_HANDLE;
+		VkPipeline               m_pipeline       = VK_NULL_HANDLE;
+		VkCommandPool            m_cmdPool        = VK_NULL_HANDLE;
+		uint32_t                 m_faceSize       = 0;
+	};
+}


### PR DESCRIPTION
## Contexte

Dernier item « rebrancher le moteur » de l'audit. `lighting.frag` contient déjà tout le shading **IBL split-sum** (irradiance diffuse + specular prefilter + BRDF LUT), mais il était **désactivé** : `irrView` codé en dur à `VK_NULL_HANDLE` → `useIBL` toujours 0. Résultat : matériaux métalliques/brillants sans réflexions, ambiant plat. La BRDF LUT marchait, mais `SpecularPrefilterPass::Generate` **n'avait jamais été appelée** et **aucune passe d'irradiance n'existait**.

Cette PR active l'IBL en **capturant le ciel procédural** dans une cubemap au boot (MVP statique).

## Changements (3 passes compute one-shot au boot)

- **`SkyCubeCapturePass`** (neuf) + `sky_capture.comp` : porte la couleur de `sky.frag` en compute, écrit le ciel dans une cubemap RGBA16F (128²).
- **`SpecularPrefilterPass::Generate`** (existait, **enfin appelée**) : prefilter spéculaire (5 mips) depuis la sky cube.
- **`IrradiancePass`** (neuf) + `irradiance_convolve.comp` : convolution cosine-hemisphere → cube d'irradiance diffuse (32²). Facteur `PI` cohérent avec `lighting.frag:422` (`* albedo` sans `/PI`).
- **`DeferredPipeline`** orchestre `[1] capture → [2] prefilter → [3] irradiance` au boot ; **`Engine`** câble `irrView`/`irrSamp` ; `useIBL` bascule à 1.

Tout calqué sur `BrdfLutPass`/`SpecularPrefilterPass` ; `FaceUvToDirection` copié à l'identique dans les 3 shaders (orientation cohérente).

## Gating & sûreté

- **`gi.ibl.enabled`** (config, défaut **true**). Si false OU échec de génération (shader absent, format non-storable, Init/Generate KO) → `IrradiancePass` `!IsValid()` → `irrView=NULL` → `useIBL=0` → **ambient plat, pas de crash**.
- Génération **statique au boot** (reflète l'heure de boot). Le suivi jour/nuit (re-capture) est un follow-up séparé.

## À VALIDER EN JEU (rendu manuel — la CI sans GPU ne le couvre pas)

- [ ] **Validation Vulkan** : 0 erreur sur la 1re exécution réelle de `SpecularPrefilterPass::Generate` + les barrières des 3 passes (log `[Boot] DeferredPipeline IBL OK`).
- [ ] **Réflexions** : un matériau métal/brillant (`Crate_Metal`, avatar) reflète les teintes du ciel.
- [ ] **Exposition** : pas de cramage ni d'assombrissement anormal de l'ambiant (facteur PI = point sensible).
- [ ] **Pas de miroir** : la réflexion du ciel n'est pas inversée (orientation des faces).
- [ ] **Repli** : `gi.ibl.enabled=false` → ambient plat, log dédié, pas de crash.

## Plan de test CI

- [ ] build Linux + Windows verts ; `sky_capture.comp` + `irradiance_convolve.comp` compilés en SPIR-V.

## Limites connues (par conception)

- Statique (pas de suivi jour/nuit). Source 1-mip pour le prefilter (`textureLod` clampe mip 0 — qualité spéculaire haute roughness légèrement moindre). Fallback viewType 2D→cube quand IBL off (warning validation pré-existant, jamais échantillonné).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur** (rendu Vulkan/shaders ; `gi.ibl.enabled` lu côté client ; aucun opcode/handler/migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)