### PR TITLE
fix(render): éteint la passe Hi-Z (bug descriptor en vol) — sous-système inerte

### DIFF
--- a/config.json
+++ b/config.json
@@ -77,6 +77,10 @@
             "grass_mask": "zones/demo_plains/terrain_grass.grms",
             "grass_mask_visual_strength": 0.35,
             "hole_mask": ""
+        },
+        "hiz": {
+            "_comment": "Occlusion culling Hi-Z (GPU-driven cull). Defaut false : la passe HiZ_Build n'est PAS enregistree dans le frame graph (HiZPyramidPass reecrivait son descriptor set unique en vol => erreur de validation Vulkan chaque frame) et le GpuDrivenCullingPass recoit un view Hi-Z nul => fallback conservateur. Sa sortie etait inerte (seul le cube placeholder etait cull). Repasser a true uniquement si le GPU-cull est reellement branche sur plusieurs draw-items.",
+            "enabled": false
         }
     },
     "audio": {

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4983,6 +4983,15 @@ namespace engine
 											m_impostorEnabled = m_cfg.GetBool("world.impostor.enabled", false);
 											if (m_impostorEnabled)
 												LOG_INFO(Render, "[Impostor] M45.5 activé (world.impostor.enabled=true)");
+											// fix/hiz-gate-off — flag global Hi-Z occlusion (défaut OFF). Lu une fois
+											// ici. Quand false : la passe HiZ_Build n'est pas enregistrée (plus de
+											// réécriture de descriptor en vol => plus de violation de validation), et
+											// le GpuDrivenCullingPass reçoit un view Hi-Z nul => fallback conservateur.
+											m_hiZEnabled = m_cfg.GetBool("render.hiz.enabled", false);
+											if (m_hiZEnabled)
+												LOG_INFO(Render, "[Boot] Hi-Z occlusion enabled (render.hiz.enabled=true)");
+											else
+												LOG_INFO(Render, "[Boot] Hi-Z occlusion disabled (render.hiz.enabled=false)");
 											// Chantier B : charge les meshes statiques des props (coffre si non anime + interactibles).
 											LoadInteractableProps();
 											// Décor solide (arbres, props nature) depuis world.scenery. Doit suivre
@@ -5045,12 +5054,28 @@ namespace engine
 													return;
 												}
 
-												const auto& hiZPass = m_pipeline->GetHiZPyramidPass();
-												cullingPass.Record(
-													m_vkDeviceContext.GetDevice(), cmd, rs.viewProjMatrix.m, m_currentFrame,
-													hiZPass.GetImageView(m_currentFrame),
-													hiZPass.GetExtent(),
-													hiZPass.GetMipCount());
+												// fix/hiz-gate-off — quand la Hi-Z est désactivée (m_hiZEnabled=false,
+												// défaut), on passe un view nul + extent {0,0} + mipCount 0 : dans
+												// GpuDrivenCullingPass::Record, occlusionEnabled devient false et le cull
+												// retombe sur son fallback Hi-Z conservateur. On NE lit PAS les accesseurs
+												// HiZPyramidPass (la passe HiZ_Build n'est alors pas enregistrée).
+												if (m_hiZEnabled)
+												{
+													const auto& hiZPass = m_pipeline->GetHiZPyramidPass();
+													cullingPass.Record(
+														m_vkDeviceContext.GetDevice(), cmd, rs.viewProjMatrix.m, m_currentFrame,
+														hiZPass.GetImageView(m_currentFrame),
+														hiZPass.GetExtent(),
+														hiZPass.GetMipCount());
+												}
+												else
+												{
+													cullingPass.Record(
+														m_vkDeviceContext.GetDevice(), cmd, rs.viewProjMatrix.m, m_currentFrame,
+														VK_NULL_HANDLE,
+														VkExtent2D{ 0, 0 },
+														0u);
+												}
 											});
 
 										// Terrain prepass must not be a separate FrameGraph pass: it targets the same
@@ -5409,20 +5434,30 @@ namespace engine
 												}
 											});
 
-										m_frameGraph.addPass("HiZ_Build",
-											[this](engine::render::PassBuilder& b) {
-												b.read(m_fgDepthId, engine::render::ImageUsage::SampledRead);
-											},
-											[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
-												auto& hiZPass = m_pipeline->GetHiZPyramidPass();
-												if (!hiZPass.IsValid())
-													return;
+										// fix/hiz-gate-off — la passe HiZ_Build n'est enregistrée QUE si la Hi-Z
+										// est explicitement activée (render.hiz.enabled=true). Par défaut (false)
+										// elle est éteinte du chemin frame : HiZPyramidPass réécrivait son
+										// descriptor set unique pendant qu'il était en vol (violation Vulkan,
+										// erreur de validation chaque frame) alors que sa sortie était inerte
+										// (le GpuDrivenCullingPass ne traitait que le cube placeholder désactivé).
+										// La classe HiZPyramidPass est conservée, seulement débranchée ici.
+										if (m_hiZEnabled)
+										{
+											m_frameGraph.addPass("HiZ_Build",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgDepthId, engine::render::ImageUsage::SampledRead);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													auto& hiZPass = m_pipeline->GetHiZPyramidPass();
+													if (!hiZPass.IsValid())
+														return;
 
-												hiZPass.Record(
-													m_vkDeviceContext.GetDevice(), cmd,
-													reg.getImage(m_fgDepthId), reg.getImageView(m_fgDepthId),
-													m_vkSwapchain.GetExtent(), m_currentFrame);
-											});
+													hiZPass.Record(
+														m_vkDeviceContext.GetDevice(), cmd,
+														reg.getImage(m_fgDepthId), reg.getImageView(m_fgDepthId),
+														m_vkSwapchain.GetExtent(), m_currentFrame);
+												});
+										}
 
 										for (uint32_t cascade = 0; cascade < engine::render::kCascadeCount; ++cascade)
 										{

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -828,6 +828,16 @@ namespace engine
 		/// false par défaut => AUCUN code impostor ne s'exécute (rendu inchangé).
 		bool m_impostorEnabled = false;
 
+		/// fix/hiz-gate-off — flag global Hi-Z occlusion culling (lu depuis
+		/// render.hiz.enabled au boot). false par défaut : la passe HiZ_Build n'est
+		/// PAS enregistrée dans le frame graph (sinon HiZPyramidPass réécrit son
+		/// descriptor set unique en vol => violation de validation chaque frame), et
+		/// le GpuDrivenCullingPass reçoit un view Hi-Z nul => il retombe sur son
+		/// fallback Hi-Z conservateur (occlusionEnabled=false). Rendu inchangé car le
+		/// cull ne culait que le cube placeholder inerte. Réactivable (=true) si le
+		/// GPU-cull est un jour réellement branché sur plusieurs draw-items.
+		bool m_hiZEnabled = false;
+
 		/// M45.5 — tente de charger l'atlas `.mipo` associé à `meshPath` (à côté du
 		/// .gltf, même nom + extension `.mipo`) dans `m_impostorAtlases` s'il n'y est
 		/// pas déjà. No-op si !m_impostorEnabled. \return true si un atlas valide est


### PR DESCRIPTION
## Bug (audit, Critique latent)

`HiZPyramidPass` réécrit un **descriptor set unique pendant qu'il est en vol** (`vkUpdateDescriptorSets` en boucle sur un set déjà bind + partagé entre les 2 frames in-flight) → violation Vulkan / erreur de validation **à chaque frame**.

## Constat : sous-système inerte

La passe `HiZ_Build` est exécutée chaque frame, mais sa sortie n'élimine **rien de visible** : le `GpuDrivenCullingPass` ne traite qu'un seul draw-item (le **cube placeholder**), lui-même désactivé dès que l'avatar skinné est prêt. La Hi-Z n'alimente donc aucune décision de rendu sur le contenu actuel.

## Correctif (le plus sûr)

Plutôt que réécrire la plomberie de descripteurs d'un sous-système mort, on **éteint l'enregistrement de la passe** derrière une clé config **`render.hiz.enabled` (défaut false)** :
- `HiZ_Build` n'est plus ajoutée au frame graph → plus de réécriture de descriptor en vol → plus de violation de validation.
- Le `GpuDrivenCullingPass` reçoit un view nul → `occlusionEnabled=false` → bascule sur son **fallback Hi-Z conservateur** (déjà vivant). Rendu inchangé (le cull ne culait que le cube placeholder inerte).
- `HiZPyramidPass.{h,cpp}` **conservés** ; réactivable via `render.hiz.enabled=true` si le GPU-cull est un jour réellement câblé sur la géométrie réelle.

## Plan de test

- [ ] CI build verte.
- [ ] En jeu : rendu identique (aucune régression visible) ; logs de validation Vulkan sans l'erreur de descriptor Hi-Z.

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)