### PR TITLE
fix(vk): cycle de vie ressources — fuite VkDeviceMemory + UAF éviction terrain (audit)

### DIFF
--- a/src/client/render/terrain_chunk/TerrainChunkRenderer.cpp
+++ b/src/client/render/terrain_chunk/TerrainChunkRenderer.cpp
@@ -1154,6 +1154,17 @@ namespace engine::render::terrain_chunk
 
 		// Eviction LRU des chunks Far excédant le budget.
 		auto evictions = m_runtime.CollectEvictionsForBudget();
+		if (!evictions.empty())
+		{
+			// UAF guard : l'eviction tourne dans BeginFrame, AVANT le wait de fence
+			// du Render -> une frame en vol pourrait encore referencer les VBO/IBO
+			// evinces (m_meshCache/m_splatCache.Evict detruit immediatement les
+			// VkBuffer). device-idle garantit qu'aucune commande GPU ne les utilise
+			// au moment de la destruction. Cout nul en pratique (eviction = streaming
+			// terrain, rare ; jamais sur le contenu actuel). Optimisation future :
+			// differer via DeferredDestroyQueue.
+			vkDeviceWaitIdle(device);
+		}
 		for (auto slot : evictions)
 		{
 			engine::world::GlobalChunkCoord coord{0, 0};

--- a/src/client/render/vk/DeferredDestroyQueue.cpp
+++ b/src/client/render/vk/DeferredDestroyQueue.cpp
@@ -2,27 +2,31 @@
 
 namespace engine::render
 {
-	void DeferredDestroyQueue::PushBuffer(VkBuffer buffer, uint64_t fenceValue)
+	void DeferredDestroyQueue::PushBuffer(VkBuffer buffer, VkDeviceMemory memory, uint64_t fenceValue)
 	{
-		if (buffer == VK_NULL_HANDLE)
+		if (buffer == VK_NULL_HANDLE && memory == VK_NULL_HANDLE)
 			return;
 		Entry e;
 		e.fenceValue = fenceValue;
 		e.type = Entry::Type::Buffer;
 		e.buffer = buffer;
 		e.image = VK_NULL_HANDLE;
+		e.view = VK_NULL_HANDLE;
+		e.memory = memory;
 		m_queue.push(e);
 	}
 
-	void DeferredDestroyQueue::PushImage(VkImage image, uint64_t fenceValue)
+	void DeferredDestroyQueue::PushImage(VkImage image, VkImageView view, VkDeviceMemory memory, uint64_t fenceValue)
 	{
-		if (image == VK_NULL_HANDLE)
+		if (image == VK_NULL_HANDLE && view == VK_NULL_HANDLE && memory == VK_NULL_HANDLE)
 			return;
 		Entry e;
 		e.fenceValue = fenceValue;
 		e.type = Entry::Type::Image;
 		e.buffer = VK_NULL_HANDLE;
 		e.image = image;
+		e.view = view;
+		e.memory = memory;
 		m_queue.push(e);
 	}
 
@@ -37,10 +41,23 @@ namespace engine::render
 			m_queue.pop();
 			if (e.fenceValue <= completedFrameIndex)
 			{
-				if (e.type == Entry::Type::Buffer && e.buffer != VK_NULL_HANDLE)
-					vkDestroyBuffer(device, e.buffer, nullptr);
-				else if (e.type == Entry::Type::Image && e.image != VK_NULL_HANDLE)
-					vkDestroyImage(device, e.image, nullptr);
+				// Ordre obligatoire : détruire la vue + le buffer/image AVANT de
+				// libérer la mémoire (la mémoire ne doit plus être référencée par
+				// aucune ressource vivante au moment du vkFreeMemory).
+				if (e.type == Entry::Type::Buffer)
+				{
+					if (e.buffer != VK_NULL_HANDLE)
+						vkDestroyBuffer(device, e.buffer, nullptr);
+				}
+				else if (e.type == Entry::Type::Image)
+				{
+					if (e.view != VK_NULL_HANDLE)
+						vkDestroyImageView(device, e.view, nullptr);
+					if (e.image != VK_NULL_HANDLE)
+						vkDestroyImage(device, e.image, nullptr);
+				}
+				if (e.memory != VK_NULL_HANDLE)
+					vkFreeMemory(device, e.memory, nullptr);
 			}
 			else
 				remaining.push(e);

--- a/src/client/render/vk/DeferredDestroyQueue.h
+++ b/src/client/render/vk/DeferredDestroyQueue.h
@@ -14,10 +14,15 @@ namespace engine::render
 	public:
 		DeferredDestroyQueue() = default;
 
-		/// Queues a buffer for destruction after the given frame's fence is signaled.
-		void PushBuffer(VkBuffer buffer, uint64_t fenceValue);
-		/// Queues an image for destruction after the given frame's fence is signaled.
-		void PushImage(VkImage image, uint64_t fenceValue);
+		/// Queues a buffer (et sa mémoire associée) pour destruction après que le fence
+		/// de la frame donnée est signalé. La mémoire est libérée APRÈS le buffer.
+		/// \param memory mémoire à libérer (VK_NULL_HANDLE si gérée ailleurs).
+		void PushBuffer(VkBuffer buffer, VkDeviceMemory memory, uint64_t fenceValue);
+		/// Queues une image (sa vue + sa mémoire) pour destruction après que le fence
+		/// de la frame donnée est signalé. Ordre : vue, image, puis mémoire.
+		/// \param view vue d'image à détruire (VK_NULL_HANDLE si aucune).
+		/// \param memory mémoire à libérer (VK_NULL_HANDLE si gérée ailleurs).
+		void PushImage(VkImage image, VkImageView view, VkDeviceMemory memory, uint64_t fenceValue);
 
 		/// Frees all queued resources whose fenceValue <= completedFrameIndex. Call after vkWaitForFences(completedFrameIndex's frame).
 		void Collect(VkDevice device, uint64_t completedFrameIndex);
@@ -29,6 +34,8 @@ namespace engine::render
 			enum class Type { Buffer, Image } type = Type::Buffer;
 			VkBuffer buffer = VK_NULL_HANDLE;
 			VkImage image = VK_NULL_HANDLE;
+			VkImageView view = VK_NULL_HANDLE;
+			VkDeviceMemory memory = VK_NULL_HANDLE;
 		};
 		std::queue<Entry> m_queue;
 	};


### PR DESCRIPTION
Deux bugs Vulkan **latents** de l'audit (ne se déclenchent pas sur le contenu actuel — aucun `terrain.bin` livré → l'éviction terrain ne tourne jamais). Correctifs **prouvablement corrects** (code non validable en jeu → on privilégie la sûreté à l'optimisation).

## Bug 3 — `DeferredDestroyQueue` : fuite VkDeviceMemory

La file détruisait `VkBuffer`/`VkImage` mais **jamais la `VkDeviceMemory`** (ni les `VkImageView`) → fuite mémoire GPU à chaque destruction différée.

- `Entry` porte désormais `memory` + `view`.
- `PushBuffer(buffer, memory, fence)` / `PushImage(image, view, memory, fence)` étendus.
- `Collect` libère dans le bon ordre : détruire la view + le buffer/image **avant** `vkFreeMemory`.
- Aucun appelant existant (la file n'avait pas de producteur) → changement de signature sans risque.

## Bug 2 — `TerrainChunkRenderer` : use-after-free à l'éviction

`Tick` (appelé dans `BeginFrame`, **avant** le `vkWaitForFences` du Render) évince des chunks et détruit immédiatement leurs `VkBuffer`/`VkImage` → une frame en vol peut encore les référencer (UAF GPU).

- Correctif défensif : `vkDeviceWaitIdle(device)` **une fois, uniquement si la liste d'évictions n'est pas vide**, avant toute destruction → device idle ⇒ aucune commande GPU ne référence les ressources évincées.
- Coût nul en régime nominal (jamais appelé sans éviction ; l'éviction = streaming terrain, rare). `Shutdown` non touché (déjà sûr après device-idle global).

> **Optimisation future documentée** : remplacer le `vkDeviceWaitIdle` par un push dans la `DeferredDestroyQueue` (désormais correcte) pour éviter le stall quand le streaming terrain sera réellement actif.

## Plan de test

- [ ] CI build verte. (Chemins latents non exerçables en jeu sans contenu chunké ; correction validée par revue.)

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)