### PR TITLE
fix(terrain): SurfaceQueryService sur la grille 256 (cohérence Phase 1)

### DIFF
--- a/src/client/world/WorldModel.h
+++ b/src/client/world/WorldModel.h
@@ -168,6 +168,20 @@ namespace engine::world
 	/// sur la grille terrain. Pur, sans état.
 	GlobalChunkCoord WorldToTerrainChunkCoord(float worldX, float worldZ);
 
+	/// Bornes monde (m, XZ) d'un chunk TERRAIN (grille kTerrainChunkSizeMeters
+	/// = 256 m). Miroir de ChunkBounds mais sur la grille terrain — cohérent avec
+	/// le placement du renderer (Phase 1) et le chargement des splat.bin authorés
+	/// par l'éditeur. Pur, sans état.
+	inline struct ChunkBounds TerrainChunkBounds(GlobalChunkCoord c)
+	{
+		struct ChunkBounds b;
+		b.minX = static_cast<float>(c.x * kTerrainChunkSizeMeters);
+		b.minZ = static_cast<float>(c.z * kTerrainChunkSizeMeters);
+		b.maxX = static_cast<float>((c.x + 1) * kTerrainChunkSizeMeters);
+		b.maxZ = static_cast<float>((c.z + 1) * kTerrainChunkSizeMeters);
+		return b;
+	}
+
 	/// Retourne les chunks TERRAIN (grille 256 m) du carré 7×7 autour de la
 	/// position monde donnée. Miroir de World::GetActiveAndVisibleChunks mais sur
 	/// la grille terrain — utilisé par le chemin de RENDU terrain (Phase 1).

--- a/src/client/world/surface/SurfaceQueryService.cpp
+++ b/src/client/world/surface/SurfaceQueryService.cpp
@@ -30,11 +30,15 @@ namespace engine::world::surface
         if (!m_table || !m_cache || !m_cfg || !m_palette) return fallback;
 
         // 1. worldPos.xz → (chunkCoord, localCellX, localCellZ).
-        const auto coord = engine::world::WorldToGlobalChunkCoord(worldPos.x, worldPos.z);
+        // Grille TERRAIN 256 m (kTerrainChunkSizeMeters), cohérente avec le
+        // placement du renderer (Phase 1) ET avec les splat.bin authorés par
+        // l'éditeur (grille 256). L'ancienne grille 500 (WorldToGlobalChunkCoord/
+        // ChunkBounds) chargeait le mauvais chunk splat ET faussait la cellule.
+        const auto coord = engine::world::WorldToTerrainChunkCoord(worldPos.x, worldPos.z);
 
-        // ChunkBounds → cellule splat locale. ChunkSize en mètres = engine::world::kChunkSize.
+        // TerrainChunkBounds → cellule splat locale (chunkSize = 256 m).
         // localCell = (worldOffset / chunkSize) * splatResolution.
-        const auto bounds = engine::world::ChunkBounds(coord);
+        const auto bounds = engine::world::TerrainChunkBounds(coord);
         const float chunkSizeX = bounds.maxX - bounds.minX;
         const float chunkSizeZ = bounds.maxZ - bounds.minZ;
         if (chunkSizeX <= 0.0f || chunkSizeZ <= 0.0f) return fallback;

--- a/src/client/world/surface/tests/SurfaceQueryServiceTests.cpp
+++ b/src/client/world/surface/tests/SurfaceQueryServiceTests.cpp
@@ -198,6 +198,22 @@ namespace
         REQUIRE(!r.modifiers.frozen);
         REQUIRE(!r.modifiers.seasonalSnow);
     }
+
+    // Prouve que le service utilise la grille TERRAIN 256 m (et plus la grille
+    // 500 m). worldPos.x = 300 → chunk (1,0) sur la grille 256, mais (0,0) sur
+    // l'ancienne grille 500. On insère le splat UNIQUEMENT au chunk (1,0) :
+    //  - grille 256 (correcte) → charge (1,0) → Rock.
+    //  - grille 500 (bug) → chargerait (0,0) (vide) → fallback Dirt.
+    // Ce test échouerait donc si on revenait à WorldToGlobalChunkCoord/ChunkBounds.
+    void Test_Query_Uses256TerrainGrid()
+    {
+        Fixture fx;
+        InsertUniformSplatToCache(fx.cache, 1, 0, 4);  // chunk (1,0) = Rock
+        // x=300 ∈ [256,512) → chunk terrain (1,0) ; serait (0,0) en grille 500.
+        engine::math::Vec3 pos{ 300.0f, 0.0f, 1.0f };
+        SurfaceQueryResult r = fx.svc.Query(pos);
+        REQUIRE(r.base == SurfaceType::Rock);
+    }
 }
 
 int main()
@@ -209,5 +225,6 @@ int main()
     Test_Query_TieBreaker_LowestIndex();
     Test_Query_OutOfBoundsCell_FallbackDirt();
     Test_Query_ModifiersNeutralByDefault();
+    Test_Query_Uses256TerrainGrid();
     return g_failed;
 }


### PR DESCRIPTION
## Bug (latent, repéré en Phase 1)

`SurfaceQueryService` (type de sol sous un point — ex. son de pas selon le terrain) mappait la cellule splat sur la **grille 500 m** (`WorldToGlobalChunkCoord` / `ChunkBounds`) à la fois pour **charger** le `splat.bin` ET pour calculer la cellule locale — alors que les `splat.bin` sont authorés sur la **grille terrain 256 m** (cf. Phase 1, PR #831). Résultat : mauvais chunk splat chargé + cellule faussée. **Même bug** que celui corrigé pour le chemin de rendu en Phase 1, mais sur le chemin « requête de surface ».

## Correctif

- Ajoute le helper `TerrainChunkBounds` (grille 256) dans `WorldModel`, miroir de `ChunkBounds`.
- Route `SurfaceQueryService` sur `WorldToTerrainChunkCoord` + `TerrainChunkBounds` → la **même coord 256** sert à charger le splat ET à mapper la cellule (cohérent).
- Nouveau test `Test_Query_Uses256TerrainGrid` : prouve le comportement 256 (point où 500 et 256 divergent — `x=300` → chunk `(1,0)` en 256, `(0,0)` en 500). Échouerait si on revenait à la grille 500.

## « Rien de cassé »

- Tests existants : interrogent près de l'origine (`(1,1)` → chunk `(0,0)` sur les deux grilles) avec splat uniforme → **passent tels quels**.
- Aucun consommateur **runtime** : le service n'est référencé hors tests que par `ClientPrediction.h` (non câblé au jeu), via l'API publique `Query` (signature inchangée). → correction de fond, sans effet visible aujourd'hui.

## Plan de test

- [ ] CI : `surface_query_service_tests` (dont le nouveau cas) vert.

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)