### PR TITLE
feat(render): vraie base TBN pour le normal mapping (props + avatar)

### DIFF
--- a/game/data/shaders/gbuffer_geometry.frag
+++ b/game/data/shaders/gbuffer_geometry.frag
@@ -12,6 +12,7 @@ layout(location = 1) in vec2 vUv;
 layout(location = 2) in vec4 vPrevClip;
 layout(location = 3) in vec4 vCurrClip;
 layout(location = 4) in vec4 vColor;
+layout(location = 5) in vec3 vWorldPos; // position MONDE (base TBN cotangente)
 
 struct MaterialGpuData
 {
@@ -69,15 +70,31 @@ void main()
     if ((mat.flags & 1u) != 0u)
         outAlbedo.rgb = mix(outAlbedo.rgb, vec3(1.0, 0.85, 0.30), 0.45) * 1.25;
 
-    // ---- Normal -----------------------------------------------------------
-    // Decode the tangent-space normal map from [0,1] → [-1,1].
-    // Without per-vertex tangent data (MVP) we perturb the interpolated
-    // vertex normal using the XY deviation from the flat default (0,0,1).
+    // ---- Normal (base TBN cotangente, sans tangentes pré-calculées) -------
+    // Décode la normal-map tangent-space [0,1] → [-1,1], puis la transforme en
+    // espace MONDE via une base TBN reconstruite à partir des dérivées écran de
+    // la position monde et de l'UV (méthode « cotangent frame », Schüler).
+    // Remplace l'ancienne perturbation `N + xy*0.5` qui ignorait l'orientation
+    // réelle de la surface (relief plat/incohérent, dépendant de l'orientation).
     vec3 normalSample = texture(uTextures[mat.normalIndex], tiledUv).xyz * 2.0 - 1.0; // [-1,1]
     vec3 N = normalize(vNormal);
-    // Blend: add the tangent-space XY offset projected onto the hemisphere.
-    // This is a simplified approximation valid for meshes with low curvature.
-    N = normalize(N + vec3(normalSample.xy, 0.0) * 0.5);
+    vec3 dp1  = dFdx(vWorldPos);
+    vec3 dp2  = dFdy(vWorldPos);
+    vec2 duv1 = dFdx(tiledUv);
+    vec2 duv2 = dFdy(tiledUv);
+    vec3 dp2perp = cross(dp2, N);
+    vec3 dp1perp = cross(N, dp1);
+    vec3 T = dp2perp * duv1.x + dp1perp * duv2.x;
+    vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
+    float maxLen2 = max(dot(T, T), dot(B, B));
+    // Garde anti-NaN : UV dégénérée (ex. props vertex-color sans mapping, ou
+    // normal-map plate) -> T/B nuls -> on conserve la normale géométrique N.
+    if (maxLen2 > 1e-12)
+    {
+        float invmax = inversesqrt(maxLen2);
+        mat3 TBN = mat3(T * invmax, B * invmax, N);
+        N = normalize(TBN * normalSample);
+    }
     outNormal = vec4(N * 0.5 + 0.5, 1.0);
 
     // ---- ORM --------------------------------------------------------------

--- a/game/data/shaders/gbuffer_geometry.vert
+++ b/game/data/shaders/gbuffer_geometry.vert
@@ -24,6 +24,7 @@ layout(location = 1) out vec2 vUv;
 layout(location = 2) out vec4 vPrevClip;
 layout(location = 3) out vec4 vCurrClip;
 layout(location = 4) out vec4 vColor;
+layout(location = 5) out vec3 vWorldPos; // position MONDE (pour la base TBN cotangente du frag)
 
 void main() {
 	mat4 instanceMatrix = mat4(instanceRow0, instanceRow1, instanceRow2, instanceRow3);
@@ -31,9 +32,14 @@ void main() {
 	vec4 prevClip = pc.prevViewProj * worldPos;
 	vec4 currClip = pc.viewProj * worldPos;
 	gl_Position = currClip;
-	vNormal = inNormal;
+	// Normale en espace MONDE : mat3(instanceMatrix) applique la rotation (+
+	// échelle uniforme, sans incidence après normalize côté frag). Corrige les
+	// props TOURNÉS (yaw) dont la normale objet était auparavant écrite telle
+	// quelle dans le GBuffer monde. Indispensable aussi à la base TBN du frag.
+	vNormal = mat3(instanceMatrix) * inNormal;
 	vUv = inUv;
 	vPrevClip = prevClip;
 	vCurrClip = currClip;
 	vColor = inColor;
+	vWorldPos = worldPos.xyz;
 }

--- a/game/data/shaders/skinned_gbuffer.vert
+++ b/game/data/shaders/skinned_gbuffer.vert
@@ -3,7 +3,8 @@
 // - Per-vertex bone indices (uint16x4, widened to uvec4) at location 7
 // - Per-vertex weights (float4) at location 8
 // - Per-draw bone matrix palette via SSBO set 1 binding 0
-// Outputs: identical to gbuffer_geometry.vert -> paired with gbuffer_geometry.frag unchanged.
+// Outputs: identiques à gbuffer_geometry.vert (location 0-5, dont location 5 =
+// vWorldPos pour la base TBN cotangente) -> appairé à gbuffer_geometry.frag.
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
@@ -36,6 +37,7 @@ layout(location = 3) out vec4 vCurrClip;
 // n'utilise pas de vertex color : on émet du blanc (le bit VertexColorAlbedo n'est
 // jamais posé sur ses matériaux, donc vColor est ignoré côté frag).
 layout(location = 4) out vec4 vColor;
+layout(location = 5) out vec3 vWorldPos; // position MONDE (base TBN cotangente du frag partagé)
 
 void main() {
     // Build the per-vertex skinning matrix as a weighted sum of bone matrices.
@@ -61,4 +63,5 @@ void main() {
     vPrevClip = prevClip;
     vCurrClip = currClip;
     vColor = vec4(1.0);
+    vWorldPos = worldPos.xyz;
 }


### PR DESCRIPTION
## Contexte (audit — fidélité visuelle)

`gbuffer_geometry.frag` perturbait la normale par `N = normalize(N + normalSample.xy*0.5)` — **sans base tangente (TBN)**. Le relief des normal maps (pierre, écorce, métal…) était donc **plat/incohérent**, dépendant de l'orientation du mesh. C'était le plus gros écart visuel « matériaux » relevé par l'audit.

## Changements (shaders uniquement)

- **Base TBN cotangente** (méthode Schüler) : reconstruite par frag à partir des **dérivées écran** de la position monde + UV (`dFdx/dFdy`). Pas besoin de tangentes pré-calculées → **aucun changement de format de sommet ni du loader**. Le relief des normal maps suit enfin l'orientation réelle de la surface.
- **Garde anti-NaN** : UV dégénérée (props vertex-color sans mapping) ou normal-map plate → on conserve la normale géométrique (évite `0*inf=NaN`).
- **Bug n°2 corrigé** (props statiques) : la normale était exportée en **espace objet** (`vNormal = inNormal`) puis écrite telle quelle dans le GBuffer monde → **fausse pour les props tournés** (yaw). Désormais `vNormal = mat3(instanceMatrix) * inNormal` (espace monde).
- **Frag partagé** : `gbuffer_geometry.frag` sert aussi l'**avatar skinné** (`skinned_gbuffer.vert`). Les **deux** vertex shaders exportent désormais `vWorldPos` (location 5) — sinon l'avatar lirait un interpolant indéfini et son éclairage serait corrompu.

## À VALIDER EN JEU

- [ ] Le relief des **normal maps** (caisses métal/bois, rochers, écorces) est cohérent et suit la surface (pas plat).
- [ ] Les **props tournés** (arbres avec yaw) ont un éclairage correct (normales monde).
- [ ] L'**avatar** s'éclaire normalement (pas de scintillement / normales cassées).
- [ ] Pas d'artefact aux UV/coutures (la base cotangente peut friser aux seams — à juger).

## Plan de test CI

- [ ] build verte ; les 3 shaders recompilent en SPIR-V.

## Limite connue

Base cotangente (par-pixel) au lieu de tangentes par-sommet : robuste et auto-contenue, mais peut friser légèrement aux coutures UV/UV miroir. Une version « tangentes par-sommet » (depuis glTF) serait l'évolution qualité ultérieure. Échelle non-uniforme non gérée (props en échelle uniforme).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)