### PR TITLE
feat(render): polish bloom (13-tap + tente) & TAA (variance clamping)

### DIFF
--- a/game/data/shaders/bloom_downsample.frag
+++ b/game/data/shaders/bloom_downsample.frag
@@ -1,7 +1,9 @@
 #version 450
 
 // Bloom downsample pass (M08.1).
-// Box filter 2x2: samples four texels, outputs average to next mip level.
+// Filtre 13-tap « dual filtering » (Jimenez, "Next Generation Post Processing in
+// Call of Duty: Advanced Warfare"). Remplace l'ancien box 2x2 : échantillonnage
+// stable, supprime le scintillement et l'aspect « en blocs » du downsample box.
 
 layout(location = 0) in vec2 inUV;
 
@@ -11,14 +13,31 @@ layout(location = 0) out vec4 outBloom;
 
 void main()
 {
-    // Half-pixel offset to sample the four texels of the 2x2 block.
     vec2 texelSize = 1.0 / vec2(textureSize(texSource, 0));
-    vec2 off = texelSize * 0.5;
+    float dx = texelSize.x;
+    float dy = texelSize.y;
 
-    vec4 a = texture(texSource, inUV + vec2(-off.x, -off.y));
-    vec4 b = texture(texSource, inUV + vec2( off.x, -off.y));
-    vec4 c = texture(texSource, inUV + vec2(-off.x,  off.y));
-    vec4 d = texture(texSource, inUV + vec2( off.x,  off.y));
+    // 13 échantillons : un anneau extérieur (±2 texels) + un carré intérieur (±1 texel).
+    vec3 a = texture(texSource, inUV + vec2(-2.0 * dx,  2.0 * dy)).rgb;
+    vec3 b = texture(texSource, inUV + vec2( 0.0,       2.0 * dy)).rgb;
+    vec3 c = texture(texSource, inUV + vec2( 2.0 * dx,  2.0 * dy)).rgb;
+    vec3 d = texture(texSource, inUV + vec2(-2.0 * dx,  0.0)).rgb;
+    vec3 e = texture(texSource, inUV).rgb;
+    vec3 f = texture(texSource, inUV + vec2( 2.0 * dx,  0.0)).rgb;
+    vec3 g = texture(texSource, inUV + vec2(-2.0 * dx, -2.0 * dy)).rgb;
+    vec3 h = texture(texSource, inUV + vec2( 0.0,      -2.0 * dy)).rgb;
+    vec3 i = texture(texSource, inUV + vec2( 2.0 * dx, -2.0 * dy)).rgb;
+    vec3 j = texture(texSource, inUV + vec2(-dx,  dy)).rgb;
+    vec3 k = texture(texSource, inUV + vec2( dx,  dy)).rgb;
+    vec3 l = texture(texSource, inUV + vec2(-dx, -dy)).rgb;
+    vec3 m = texture(texSource, inUV + vec2( dx, -dy)).rgb;
 
-    outBloom = (a + b + c + d) * 0.25;
+    // Pondération Jimenez (somme = 1) : centre 0.125, carré intérieur 4×0.125,
+    // coins extérieurs 4×0.03125, arêtes extérieures 4×0.0625.
+    vec3 result = e * 0.125;
+    result += (a + c + g + i) * 0.03125;
+    result += (b + d + f + h) * 0.0625;
+    result += (j + k + l + m) * 0.125;
+
+    outBloom = vec4(result, 1.0);
 }

--- a/game/data/shaders/bloom_upsample.frag
+++ b/game/data/shaders/bloom_upsample.frag
@@ -1,6 +1,8 @@
 #version 450
 
-// Bloom upsample pass (M08.2). Samples smaller mip (bilinear), output is added to destination (additive blend).
+// Bloom upsample pass (M08.2). Échantillonne le mip plus petit, sortie ajoutée à
+// la destination (blend additif). Filtre TENTE 3x3 (Jimenez/COD) au lieu d'un
+// simple tap bilinéaire : étale doucement l'énergie, halo lisse sans aliasing.
 
 layout(location = 0) in vec2 inUV;
 
@@ -10,5 +12,21 @@ layout(location = 0) out vec4 outBloom;
 
 void main()
 {
-    outBloom = texture(texBloomMip, inUV);
+    vec2 texelSize = 1.0 / vec2(textureSize(texBloomMip, 0));
+    float dx = texelSize.x;
+    float dy = texelSize.y;
+
+    // Noyau tente 3x3 : centre 4, arêtes 2, coins 1 (somme = 16).
+    vec3 s  = texture(texBloomMip, inUV + vec2(-dx,  dy)).rgb * 1.0;
+    s      += texture(texBloomMip, inUV + vec2( 0.0, dy)).rgb * 2.0;
+    s      += texture(texBloomMip, inUV + vec2( dx,  dy)).rgb * 1.0;
+    s      += texture(texBloomMip, inUV + vec2(-dx,  0.0)).rgb * 2.0;
+    s      += texture(texBloomMip, inUV).rgb               * 4.0;
+    s      += texture(texBloomMip, inUV + vec2( dx,  0.0)).rgb * 2.0;
+    s      += texture(texBloomMip, inUV + vec2(-dx, -dy)).rgb * 1.0;
+    s      += texture(texBloomMip, inUV + vec2( 0.0,-dy)).rgb * 2.0;
+    s      += texture(texBloomMip, inUV + vec2( dx, -dy)).rgb * 1.0;
+    s      *= (1.0 / 16.0);
+
+    outBloom = vec4(s, 1.0);
 }

--- a/game/data/shaders/taa.frag
+++ b/game/data/shaders/taa.frag
@@ -1,9 +1,10 @@
 #version 450
 
-// M07.4: TAA — reproject history, clamp 3x3 neighborhood, blend.
+// M07.4: TAA — reproject history, variance clamping du voisinage 3x3, blend.
 // Binding 0: current LDR, 1: history prev, 2: velocity (R16G16, NDC delta), 3: depth (optional).
 // uvHistory = uv - velocity*0.5 (velocity is currNDC - prevNDC; UV = (NDC+1)*0.5).
-// Clamp history to 3x3 min/max of current; out = lerp(current, historyClamped, alpha).
+// Borne l'historique à mean ± sigma (variance clamping) du voisinage 3x3 courant ;
+// out = lerp(current, historyClamped, alpha). Moins de ghosting qu'un min/max dur.
 
 layout(location = 0) in vec2 inUV;
 layout(location = 0) out vec4 outColor;
@@ -35,19 +36,26 @@ void main()
 
     vec4 currentCenter = texture(uCurrent, inUV);
 
-    // 3x3 neighborhood min/max of current frame.
+    // Variance clamping (Salvi/Karis) : au lieu d'un AABB min/max dur du voisinage
+    // 3x3 (trop permissif -> ghosting), on borne l'historique à mean ± gamma*sigma.
+    // La boîte est plus serrée et adaptée au bruit local -> moins de traînées,
+    // tout en gardant assez de marge pour l'anti-aliasing.
     vec2 texelSize = 1.0 / vec2(textureSize(uCurrent, 0));
-    vec4 cMin = currentCenter;
-    vec4 cMax = currentCenter;
+    vec4 m1 = vec4(0.0);
+    vec4 m2 = vec4(0.0);
     for (int dy = -1; dy <= 1; ++dy)
         for (int dx = -1; dx <= 1; ++dx)
         {
-            if (dx == 0 && dy == 0) continue;
-            vec2 uv = inUV + vec2(float(dx), float(dy)) * texelSize;
-            vec4 c = texture(uCurrent, uv);
-            cMin = min(cMin, c);
-            cMax = max(cMax, c);
+            vec4 c = texture(uCurrent, inUV + vec2(float(dx), float(dy)) * texelSize);
+            m1 += c;
+            m2 += c * c;
         }
+    const float invN = 1.0 / 9.0;
+    vec4 mean  = m1 * invN;
+    vec4 sigma = sqrt(max(m2 * invN - mean * mean, vec4(0.0)));
+    const float gamma = 1.0; // largeur de la boîte en écarts-types
+    vec4 cMin = mean - gamma * sigma;
+    vec4 cMax = mean + gamma * sigma;
 
     vec4 history = texture(uHistory, uvHistory);
     vec4 historyClamped = clamp(history, cMin, cMax);


### PR DESCRIPTION
## Contexte (audit — propreté d'image)

Améliorations de qualité d'image, **shader uniquement** (structure des passes, bindings, push-constants et blend **inchangés** → aucun changement C++/pipeline, faible risque).

## Changements

- **Bloom downsample** : box 2×2 → **13-tap dual-filtering** (Jimenez, *Next Gen Post Processing in CoD*). Pondération canonique (somme = 1). Supprime le **scintillement** et l'aspect « en blocs » du downsample box.
- **Bloom upsample** : tap bilinéaire → **tente 3×3** (centre 4 / arêtes 2 / coins 1, somme 16). Halo **lisse**, sans aliasing à l'étalement. Blend additif préservé.
- **TAA** : clamp **min/max dur** du voisinage 3×3 → **variance clamping** (mean ± σ, Salvi/Karis). Boîte plus serrée et adaptée au bruit local → **moins de ghosting** (traînées), tout en gardant la marge d'anti-aliasing.

## À VALIDER EN JEU

- [ ] **Bloom** : halo lumineux plus doux/stable (moins de scintillement sur les sources vives, bords lisses).
- [ ] **TAA** : moins de traînées (ghosting) derrière les objets/le personnage en mouvement, sans flou excessif ni instabilité.
- [ ] Pas de régression de luminosité globale du bloom (pondérations normalisées à 1).

## Plan de test CI

- [ ] build verte ; les 3 shaders recompilent en SPIR-V.

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)