### PR TITLE
feat(worldclock) PR2: wire (opcodes 203-205 + payloads)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ add_library(engine_core
   src/shared/network/AuctionPayloads.cpp
   src/shared/network/LootPayloads.cpp
   src/shared/network/LunarPayloads.cpp
+  src/shared/network/WorldClockPayloads.cpp
   src/shared/network/AdminCommandPayloads.cpp
   src/shared/network/LfgPayloads.cpp
   src/shared/network/CinematicPayloads.cpp
@@ -1207,6 +1208,11 @@ add_test(NAME loot_payloads_tests COMMAND loot_payloads_tests)
 add_executable(lunar_payloads_tests src/shared/network/LunarPayloadsTests.cpp)
 target_link_libraries(lunar_payloads_tests PRIVATE engine_core)
 add_test(NAME lunar_payloads_tests COMMAND lunar_payloads_tests)
+
+# Phase 6 WorldClock — round-trip tests payloads (203-205).
+add_executable(world_clock_payloads_tests src/shared/network/tests/WorldClockPayloadsTests.cpp)
+target_link_libraries(world_clock_payloads_tests PRIVATE engine_core)
+add_test(NAME world_clock_payloads_tests COMMAND world_clock_payloads_tests)
 
 # AdminCommand RBAC — round-trip tests payloads (195/196).
 add_executable(admin_command_payloads_tests src/shared/network/AdminCommandPayloadsTests.cpp)

--- a/docs/superpowers/plans/2026-06-06-horloge-monde-serveur.md
+++ b/docs/superpowers/plans/2026-06-06-horloge-monde-serveur.md
@@ -4,7 +4,7 @@
 
 **Goal:** Rendre l'heure de jeu (jour/nuit + phase de lune) serveur-autoritaire : le master détient une horloge monde unique, les clients la synchronisent et la calculent localement, avec contrôle de dérive et commandes admin RBAC.
 
-**Architecture:** Une formule déterministe **partagée** (header-only `WorldClock`) calcule `gameSec` à partir de `{epoch, timeScale, offset, paused}` ; le master détient l'état mutable + le diffuse (opcodes 200-202, calque lunaire) ; le client le reçoit, calcule soleil **et** lune localement, et resynchronise périodiquement. Les modifications passent par les commandes admin existantes (opcode 195, RBAC `administrator`). Le système lunaire est rebranché sur la même horloge.
+**Architecture:** Une formule déterministe **partagée** (header-only `WorldClock`) calcule `gameSec` à partir de `{epoch, timeScale, offset, paused}` ; le master détient l'état mutable + le diffuse (opcodes 203-205, calque lunaire) ; le client le reçoit, calcule soleil **et** lune localement, et resynchronise périodiquement. Les modifications passent par les commandes admin existantes (opcode 195, RBAC `administrator`). Le système lunaire est rebranché sur la même horloge.
 
 **Tech Stack:** C++17, Vulkan (client), sérialisation wire little-endian maison, RBAC slash commands, ctest (CI Linux).
 
@@ -29,13 +29,13 @@
 - `src/masterd/handlers/worldclock/WorldClockHandler.h` / `.cpp` — état mutable + handler + broadcast.
 
 **Modifiés:**
-- `src/shared/network/ProtocolV1Constants.h` — opcodes 200-202.
+- `src/shared/network/ProtocolV1Constants.h` — opcodes 203-205.
 - `src/masterd/main_linux.cpp` — instanciation/wiring/dispatch/config.
 - `src/masterd/handlers/admin/AdminCommandHandler.{h,cpp}` — 3 commandes + wiring vers WorldClockHandler.
 - `game/data/config/slash_commands.json` — 3 commandes admin.
 - `src/masterd/handlers/lunar/LunarHandler.cpp` — phase dérivée de l'horloge monde.
 - `src/client/render/DayNightCycle.{h,cpp}` — mode piloté par horloge synchronisée.
-- `src/client/app/Engine.cpp` — sync (req 200, handle 201/202) + contrôle dérive.
+- `src/client/app/Engine.cpp` — sync (req 203, handle 204/205) + contrôle dérive.
 - `config.json` — bloc `game.worldclock` (epoch, timeScale, lunarPeriodGameDays, driftCheckSec, driftThresholdGameSec).
 - `src/CMakeLists.txt` — sources partagées dans `server_app`/`shard_app` + cibles de test.
 
@@ -181,22 +181,25 @@ git commit -m "feat(worldclock): formule horloge monde deterministe partagee + t
 
 # Sous-chantier 2 — Wire (payloads + opcodes) + tests  [PR 2]
 
-### Task 2.1 : Opcodes 200-202
+### Task 2.1 : Opcodes 203-205
 
-**Files:** Modify `src/shared/network/ProtocolV1Constants.h` (après la ligne 794, bloc lunaire)
+> NOTE : 200-202 sont déjà pris par Interactive Props (`kOpInteractive*`). Le vrai
+> max d'opcode = 202 → on prend **203-205**.
+
+**Files:** Modify `src/shared/network/ProtocolV1Constants.h` (après le bloc Interactive Props ~837)
 
 - [ ] **Step 1 : Ajouter les opcodes**
 
 ```cpp
 	// Phase 6 — Horloge monde serveur-autoritaire (jour/nuit + lune unifies).
-	//   - State (200/201)                 : etat de l'horloge sur connexion / contrôle de derive.
-	//   - ChangeNotification (202, push)   : un admin a modifie le temps.
-	constexpr uint16_t kOpcodeWorldClockStateRequest        = 200u; ///< Client to Master : etat horloge (vide).
-	constexpr uint16_t kOpcodeWorldClockStateResponse       = 201u; ///< Master to Client : epoch, timeScale, offset, paused, lunarPeriod + serverTimeUnixMs.
-	constexpr uint16_t kOpcodeWorldClockChangeNotification  = 202u; ///< Master to Client (push, request_id=0) : changement admin.
+	//   - State (203/204)                 : etat de l'horloge sur connexion / contrôle de derive.
+	//   - ChangeNotification (205, push)   : un admin a modifie le temps.
+	constexpr uint16_t kOpcodeWorldClockStateRequest        = 203u; ///< Client to Master : etat horloge (vide).
+	constexpr uint16_t kOpcodeWorldClockStateResponse       = 204u; ///< Master to Client : epoch, timeScale, offset, paused, lunarPeriod + serverTimeUnixMs.
+	constexpr uint16_t kOpcodeWorldClockChangeNotification  = 205u; ///< Master to Client (push, request_id=0) : changement admin.
 ```
 
-- [ ] **Step 2 : Commit** `git add -A && git commit -m "feat(worldclock): opcodes 200-202"`
+- [ ] **Step 2 : Commit** `git add -A && git commit -m "feat(worldclock): opcodes 203-205"`
 
 ### Task 2.2 : Payloads (calque `LunarPayloads`)
 
@@ -268,7 +271,7 @@ namespace engine::network::worldclock
 
     struct WorldClockStateRequest {}; // vide
 
-    /// État complet de l'horloge (réponse 201 ET notification 202 : mêmes champs).
+    /// État complet de l'horloge (réponse 204 ET notification 205 : mêmes champs).
     struct WorldClockStateResponse
     {
         WorldClockStatus status = WorldClockStatus::Ok;
@@ -317,13 +320,13 @@ add_test(NAME world_clock_payloads_tests COMMAND world_clock_payloads_tests)
 - [ ] **Step 1 : `WorldClockHandler.h`** — classe avec :
   - `SetServer/SetSessionManager/SetConnectionSessionMap` (comme LunarHandler).
   - `void Configure(const engine::world::WorldClockParams& p)` (params boot depuis config).
-  - `void HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, size)` → si opcode 200, valide session (comme LunarHandler) → `BuildWorldClockStateResponsePayload` avec `serverTimeUnixMs = now()`, params courants → Send 201. Si session invalide → `status=Unauthorized`.
+  - `void HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, size)` → si opcode 203, valide session (comme LunarHandler) → `BuildWorldClockStateResponsePayload` avec `serverTimeUnixMs = now()`, params courants → Send 204. Si session invalide → `status=Unauthorized`.
   - **Mutateurs (appelés par AdminCommandHandler), chacun broadcast** :
     - `bool SetTimeOfDay(float hours)` → calcule `offsetGameSec` pour que `TimeOfDayHours(GameSeconds(now)) == hours` (voir formule ci-dessous) → broadcast.
     - `bool SetPaused(bool paused)` → si on met paused, mémoriser `pausedAtGameSec = GameSeconds(now)` ; broadcast.
     - `bool SetTimeScale(float realMinPerDay)` → borne [1,1440] ; **conserver la continuité** : recalculer `offsetGameSec` pour que `GameSeconds(now)` soit inchangé juste après le changement de scale ; broadcast.
   - `engine::world::WorldClockParams GetParams() const` (mutex-protégé) — pour le shard/lunaire/queries.
-  - `void BroadcastChange()` (privé) : `BuildWorldClockChangeNotificationPayload` + `BuildPushPacket(202, payload)` + `m_connMap->Snapshot()` + Send-all (exact calque `LunarHandler::PushPhaseChangeBroadcast`).
+  - `void BroadcastChange()` (privé) : `BuildWorldClockChangeNotificationPayload` + `BuildPushPacket(205, payload)` + `m_connMap->Snapshot()` + Send-all (exact calque `LunarHandler::PushPhaseChangeBroadcast`).
   - Membres : `WorldClockParams m_params; std::mutex m_mutex;` + pointeurs services.
 
   **Formule `SetTimeOfDay`** : `targetSec = hours*3600` ; `base = GameSeconds(now, paramsAvecOffset0) `; `m_params.offsetGameSec += targetSec - std::fmod(base + m_params.offsetGameSec, 86400.0)` (ramène la composante jour à `targetSec` sans toucher la composante long-terme). Documenter que cela décale aussi la phase lunaire (effet de bord assumé v1).
@@ -410,7 +413,7 @@ else if (opcode == kOpcodeWorldClockStateRequest)
 
 **Files:** Modify `src/client/app/Engine.cpp`, `config.json`
 
-- [ ] **Step 1** : À l'entrée monde (là où le client envoie déjà `LunarStateRequest`), envoyer aussi `WorldClockStateRequest` (opcode 200) via le même dispatcher.
+- [ ] **Step 1** : À l'entrée monde (là où le client envoie déjà `LunarStateRequest`), envoyer aussi `WorldClockStateRequest` (opcode 203) via le même dispatcher.
 - [ ] **Step 2** : Ajouter le handling réception (calque le bloc lunaire `case kOpcodeLunarStateResponse`) :
 ```cpp
 case kOpcodeWorldClockStateResponse:
@@ -431,7 +434,7 @@ case kOpcodeWorldClockChangeNotification: {
 ```
 - [ ] **Step 2b** : Contrôle de dérive — toutes les `game.worldclock.drift_check_sec` (config, défaut 300), renvoyer un `WorldClockStateRequest` léger (timer dans `Update`). La réception (ci-dessus) recale ; `DayNightCycle` corrige en douceur si l'écart > `drift_threshold_game_sec` (config, défaut 30).
 - [ ] **Step 3** : `config.json` — bloc `game.worldclock` (epoch_ms, timescale_real_min_per_day, lunar_period_game_days, drift_check_sec, drift_threshold_game_sec). Documenter « CLIENT lit drift_* ; epoch/timescale/lunar_period sont AUTORITÉ master ».
-- [ ] **Step 4** : Commit `git commit -m "feat(client): sync horloge monde (req 200, handle 201/202) + controle derive"`
+- [ ] **Step 4** : Commit `git commit -m "feat(client): sync horloge monde (req 203, handle 204/205) + controle derive"`
 
 ---
 
@@ -439,7 +442,7 @@ case kOpcodeWorldClockChangeNotification: {
 
 PR 1 → PR 2 → PR 3 → PR 4 → PR 5 → PR 6 (dépendances séquentielles). Les PR 1-2 (formule + wire) sont sûres (tests CI). PR 3-5 = serveur. PR 6 = client.
 
-⚠️ **REDÉPLOIEMENT SERVEUR MASTER REQUIS** dès PR 3 (nouveau handler/opcodes). **Lock-step** : déployer master neuf AVANT/AVEC le client neuf. Tant que PR 6 n'est pas livré, le client garde son horloge locale (fallback) — pas de casse. Tant que le master neuf n'est pas déployé, le client neuf retombe sur le fallback local (pas de réponse 201).
+⚠️ **REDÉPLOIEMENT SERVEUR MASTER REQUIS** dès PR 3 (nouveau handler/opcodes). **Lock-step** : déployer master neuf AVANT/AVEC le client neuf. Tant que PR 6 n'est pas livré, le client garde son horloge locale (fallback) — pas de casse. Tant que le master neuf n'est pas déployé, le client neuf retombe sur le fallback local (pas de réponse 204).
 
 ## Plan de test
 

--- a/docs/superpowers/specs/2026-06-06-horloge-monde-serveur-autoritaire-design.md
+++ b/docs/superpowers/specs/2026-06-06-horloge-monde-serveur-autoritaire-design.md
@@ -86,13 +86,13 @@ avec `timeScale=60`, 1 s réelle = 24 s de jeu.)
 
 ### 5.1 Nouveaux opcodes — sync horloge (calque lunaire 192-194)
 
-Max opcode actuel = 199. On prend **200-202** :
+200-202 sont déjà pris par Interactive Props (`kOpInteractive*`) ; max opcode = 202. On prend **203-205** :
 
 | Opcode | Nom | Sens | Charge |
 |---|---|---|---|
-| 200 | `kOpcodeWorldClockStateRequest` | Client → Master | vide |
-| 201 | `kOpcodeWorldClockStateResponse` | Master → Client | `status`, `serverTimeUnixMs`, `epochRefUnixMs`, `timeScale`, `offsetGameSec`, `paused`, `pausedAtGameSec`, `lunarPeriodGameSec` |
-| 202 | `kOpcodeWorldClockChangeNotification` | Master → Client (push, request_id=0) | mêmes champs que 201 |
+| 203 | `kOpcodeWorldClockStateRequest` | Client → Master | vide |
+| 204 | `kOpcodeWorldClockStateResponse` | Master → Client | `status`, `serverTimeUnixMs`, `epochRefUnixMs`, `timeScale`, `offsetGameSec`, `paused`, `pausedAtGameSec`, `lunarPeriodGameSec` |
+| 205 | `kOpcodeWorldClockChangeNotification` | Master → Client (push, request_id=0) | mêmes champs que 204 |
 
 `status` = `Ok` / `Unauthorized` (réutilise le pattern `LunarStatus`). La réponse
 porte `serverTimeUnixMs` pour que le client cale son horloge (compense la latence
@@ -103,11 +103,11 @@ Payloads dans un nouveau `src/shared/network/WorldClockPayloads.h` (calque de
 
 ### 5.2 Lecture libre, modification gated
 
-- **200/201/202** (lecture/sync) : tout client authentifié (session valide). Pas
+- **203/204/205** (lecture/sync) : tout client authentifié (session valide). Pas
   de RBAC — c'est de la lecture.
 - **Modification** : passe **exclusivement** par les commandes admin (§6), donc
   par l'opcode existant `kOpcodeAdminCommandRequest` (195) qui applique déjà le
-  RBAC + le log. Aucun chemin de modification direct via 200-202.
+  RBAC + le log. Aucun chemin de modification direct via 203-205.
 
 ## 6. RBAC & commandes admin
 
@@ -124,7 +124,7 @@ commands, **rôle requis = `admin`** :
 Chaque commande, **après vérification RBAC `admin` côté master** (un client sans
 le droit reçoit `Unauthorized`, comme les autres commandes admin) :
 1. mute le `WorldClockState` master,
-2. **broadcaste** une `WorldClockChangeNotification` (202) à tous les clients,
+2. **broadcaste** une `WorldClockChangeNotification` (205) à tous les clients,
 3. est **loggée côté serveur** (conforme à la règle « commandes admin loggées »).
 
 ## 7. Intégration client
@@ -132,9 +132,9 @@ le droit reçoit `Unauthorized`, comme les autres commandes admin) :
 - `DayNightCycle` **n'avance plus en autonomie** (`Advance(dt)` libre supprimé du
   pilotage) : son `timeOfDay` (et la phase de lune) sont **calculés depuis
   l'horloge monde synchronisée**. Le calcul reste local chaque frame (fluide).
-- **Au login / entrée monde** : le client envoie `WorldClockStateRequest` (200),
+- **Au login / entrée monde** : le client envoie `WorldClockStateRequest` (203),
   reçoit l'état, cale son horloge de référence (`localUnixMs ↔ serverTimeUnixMs`).
-- **Sur `WorldClockChangeNotification` (202)** : re-cale immédiatement (un admin a
+- **Sur `WorldClockChangeNotification` (205)** : re-cale immédiatement (un admin a
   modifié le temps).
 - **Contrôle de dérive** : toutes les **N minutes** (config, défaut 5), renvoie un
   `WorldClockStateRequest` léger ; si l'écart entre l'heure calculée localement et
@@ -174,7 +174,7 @@ monde. Tests lunaires existants (`ObjectGuidTests`/`LunarCalendar`) à adapter.
 
 1. **WorldClock master (état + formule + config)** — `WorldClockState`, lecture
    `config.json` (epoch, timeScale, lunarPeriodGameDays), calcul `gameSec`.
-2. **Wire** — `WorldClockPayloads.h` + opcodes 200-202 + handler master
+2. **Wire** — `WorldClockPayloads.h` + opcodes 203-205 + handler master
    (request→response, broadcast notification).
 3. **Commandes admin** — 3 slash commands `admin` dans `slash_commands.json` +
    branchement `AdminCommandHandler` → mute état + broadcast + log.
@@ -186,7 +186,7 @@ monde. Tests lunaires existants (`ObjectGuidTests`/`LunarCalendar`) à adapter.
 
 ## 10. Déploiement
 
-⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master)** — nouveaux opcodes 200-202, nouveau
+⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master)** — nouveaux opcodes 203-205, nouveau
 handler master, 3 commandes admin, refactor lunaire. **Client + serveur en
 lock-step** : un client neuf parlant à un master ancien ne recevrait pas l'état
 (→ fallback local), et un master neuf avec client ancien garderait l'ancien

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/AuctionPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LootPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/LunarPayloads.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/WorldClockPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/AdminCommandPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatSanitizer.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatGate.cpp

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -835,4 +835,17 @@ namespace engine::network
 	constexpr uint16_t kOpInteractiveStateChange    = 200u; ///< Client → Master : un objet a été ouvert/fermé (id, newState, clientTimeMs).
 	constexpr uint16_t kOpInteractiveStateBroadcast = 201u; ///< Master → autres clients (push, request_id=0) : relai d'un changement d'état (id, newState, serverTimeMs).
 	constexpr uint16_t kOpInteractiveStateSync      = 202u; ///< Master → client entrant (push, request_id=0) : état complet de la zone (count × {id, state}).
+
+	// =====================================================================
+	// Phase 6 — Horloge monde serveur-autoritaire (jour/nuit + lune unifies).
+	//   - State (203/204)                : etat de l'horloge sur connexion / controle de derive.
+	//   - ChangeNotification (205, push)  : un admin a modifie le temps.
+	//
+	// NOTE : les opcodes 200-202 initialement envisages sont DEJA pris par
+	// Interactive Props (M100.32). Ce bloc utilise donc 203-205, premiere plage
+	// libre au-dessus du max courant (202).
+	// =====================================================================
+	constexpr uint16_t kOpcodeWorldClockStateRequest        = 203u; ///< Client to Master : etat horloge (vide).
+	constexpr uint16_t kOpcodeWorldClockStateResponse       = 204u; ///< Master to Client : epoch, timeScale, offset, paused, lunarPeriod + serverTimeUnixMs.
+	constexpr uint16_t kOpcodeWorldClockChangeNotification  = 205u; ///< Master to Client (push, request_id=0) : changement admin.
 }

--- a/src/shared/network/WorldClockPayloads.cpp
+++ b/src/shared/network/WorldClockPayloads.cpp
@@ -1,0 +1,160 @@
+// Implementation Build/Parse des payloads WorldClock (opcodes 203-205).
+// Format little-endian, sans PacketBuilder : ce module produit uniquement
+// le payload nu (calque exact de LunarPayloads.cpp). Le WorldClockHandler
+// futur appellera BuildPushPacket (pour le 205) ou PacketBuilder::Finalize
+// (pour le 204) pour ajouter le header protocol_v1.
+
+#include "src/shared/network/WorldClockPayloads.h"
+
+#include <cstring>
+
+namespace engine::network::worldclock
+{
+	namespace
+	{
+		/// Ecrit un uint8 a la fin de \p out.
+		void WriteU8(std::vector<uint8_t>& out, uint8_t v)
+		{
+			out.push_back(v);
+		}
+
+		/// Ecrit un uint32 little-endian a la fin de \p out.
+		void WriteU32LE(std::vector<uint8_t>& out, uint32_t v)
+		{
+			out.push_back(static_cast<uint8_t>(v));
+			out.push_back(static_cast<uint8_t>(v >> 8));
+			out.push_back(static_cast<uint8_t>(v >> 16));
+			out.push_back(static_cast<uint8_t>(v >> 24));
+		}
+
+		/// Ecrit un uint64 little-endian a la fin de \p out.
+		void WriteU64LE(std::vector<uint8_t>& out, uint64_t v)
+		{
+			for (int i = 0; i < 8; ++i)
+				out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+		}
+
+		/// Ecrit un float little-endian (bit-cast vers uint32) a la fin de \p out.
+		void WriteFloatLE(std::vector<uint8_t>& out, float v)
+		{
+			uint32_t bits = 0;
+			std::memcpy(&bits, &v, sizeof(bits));
+			WriteU32LE(out, bits);
+		}
+
+		/// Ecrit un double little-endian (bit-cast vers uint64) a la fin de \p out.
+		/// Calque sur le pattern float/u64 : memcpy 8 octets puis ecriture LE.
+		void WriteDoubleLE(std::vector<uint8_t>& out, double v)
+		{
+			uint64_t bits = 0;
+			std::memcpy(&bits, &v, sizeof(bits));
+			WriteU64LE(out, bits);
+		}
+
+		/// Lit un uint8 et avance \p pos. Retourne false si insuffisant.
+		bool ReadU8(const uint8_t* d, size_t sz, size_t& pos, uint8_t& out)
+		{
+			if (pos + 1 > sz) return false;
+			out = d[pos];
+			pos += 1;
+			return true;
+		}
+
+		/// Lit un uint32 little-endian et avance \p pos. Retourne false si insuffisant.
+		bool ReadU32LE(const uint8_t* d, size_t sz, size_t& pos, uint32_t& out)
+		{
+			if (pos + 4 > sz) return false;
+			out = static_cast<uint32_t>(d[pos])
+			    | (static_cast<uint32_t>(d[pos + 1]) << 8)
+			    | (static_cast<uint32_t>(d[pos + 2]) << 16)
+			    | (static_cast<uint32_t>(d[pos + 3]) << 24);
+			pos += 4;
+			return true;
+		}
+
+		/// Lit un uint64 little-endian et avance \p pos. Retourne false si insuffisant.
+		bool ReadU64LE(const uint8_t* d, size_t sz, size_t& pos, uint64_t& out)
+		{
+			if (pos + 8 > sz) return false;
+			out = 0;
+			for (int i = 0; i < 8; ++i)
+				out |= static_cast<uint64_t>(d[pos + i]) << (i * 8);
+			pos += 8;
+			return true;
+		}
+
+		/// Lit un float little-endian (bit-cast depuis uint32) et avance \p pos.
+		bool ReadFloatLE(const uint8_t* d, size_t sz, size_t& pos, float& out)
+		{
+			uint32_t bits = 0;
+			if (!ReadU32LE(d, sz, pos, bits)) return false;
+			std::memcpy(&out, &bits, sizeof(out));
+			return true;
+		}
+
+		/// Lit un double little-endian (bit-cast depuis uint64) et avance \p pos.
+		bool ReadDoubleLE(const uint8_t* d, size_t sz, size_t& pos, double& out)
+		{
+			uint64_t bits = 0;
+			if (!ReadU64LE(d, sz, pos, bits)) return false;
+			std::memcpy(&out, &bits, sizeof(out));
+			return true;
+		}
+	}
+
+	void BuildWorldClockStateRequestPayload(std::vector<uint8_t>& out)
+	{
+		out.clear();
+	}
+
+	void BuildWorldClockStateResponsePayload(const WorldClockStateResponse& msg, std::vector<uint8_t>& out)
+	{
+		out.clear();
+		WriteU8(out, static_cast<uint8_t>(msg.status));
+		WriteU64LE(out, msg.serverTimeUnixMs);
+		WriteU64LE(out, msg.epochRefUnixMs);
+		WriteFloatLE(out, msg.timeScaleRealMinPerDay);
+		WriteDoubleLE(out, msg.offsetGameSec);
+		WriteU8(out, msg.paused);
+		WriteDoubleLE(out, msg.pausedAtGameSec);
+		WriteDoubleLE(out, msg.lunarPeriodGameSec);
+		// Taille totale = 1+8+8+4+8+1+8+8 = 46 octets.
+	}
+
+	void BuildWorldClockChangeNotificationPayload(const WorldClockStateResponse& msg, std::vector<uint8_t>& out)
+	{
+		// Corps identique a StateResponse (memes champs).
+		BuildWorldClockStateResponsePayload(msg, out);
+	}
+
+	bool ParseWorldClockStateRequestPayload(const uint8_t* /*data*/, size_t size, WorldClockStateRequest& out)
+	{
+		out = {};
+		return size == 0;
+	}
+
+	bool ParseWorldClockStateResponsePayload(const uint8_t* d, size_t sz, WorldClockStateResponse& out)
+	{
+		// Reject-short ET reject-extra : la taille doit egaler exactement 46.
+		if (sz != 46) return false;
+		size_t pos = 0;
+		uint8_t status = 0;
+		if (!ReadU8(d, sz, pos, status)) return false;
+		if (!ReadU64LE(d, sz, pos, out.serverTimeUnixMs)) return false;
+		if (!ReadU64LE(d, sz, pos, out.epochRefUnixMs)) return false;
+		if (!ReadFloatLE(d, sz, pos, out.timeScaleRealMinPerDay)) return false;
+		if (!ReadDoubleLE(d, sz, pos, out.offsetGameSec)) return false;
+		if (!ReadU8(d, sz, pos, out.paused)) return false;
+		if (!ReadDoubleLE(d, sz, pos, out.pausedAtGameSec)) return false;
+		if (!ReadDoubleLE(d, sz, pos, out.lunarPeriodGameSec)) return false;
+		if (status > static_cast<uint8_t>(WorldClockStatus::Unauthorized)) return false;
+		out.status = static_cast<WorldClockStatus>(status);
+		return pos == sz;
+	}
+
+	bool ParseWorldClockChangeNotificationPayload(const uint8_t* d, size_t sz, WorldClockStateResponse& out)
+	{
+		// Corps identique a StateResponse (46 octets).
+		return ParseWorldClockStateResponsePayload(d, sz, out);
+	}
+}

--- a/src/shared/network/WorldClockPayloads.h
+++ b/src/shared/network/WorldClockPayloads.h
@@ -1,0 +1,32 @@
+// src/shared/network/WorldClockPayloads.h
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace engine::network::worldclock
+{
+    enum class WorldClockStatus : uint8_t { Ok = 0, Unauthorized = 1 };
+
+    struct WorldClockStateRequest {}; // vide
+
+    /// Etat complet de l'horloge (reponse 204 ET notification 205 : memes champs).
+    struct WorldClockStateResponse
+    {
+        WorldClockStatus status = WorldClockStatus::Ok;
+        uint64_t serverTimeUnixMs    = 0;
+        uint64_t epochRefUnixMs      = 0;
+        float    timeScaleRealMinPerDay = 60.0f;
+        double   offsetGameSec       = 0.0;
+        uint8_t  paused              = 0;
+        double   pausedAtGameSec     = 0.0;
+        double   lunarPeriodGameSec  = 0.0;
+    };
+
+    void BuildWorldClockStateRequestPayload(std::vector<uint8_t>& out);
+    void BuildWorldClockStateResponsePayload(const WorldClockStateResponse& msg, std::vector<uint8_t>& out);
+    void BuildWorldClockChangeNotificationPayload(const WorldClockStateResponse& msg, std::vector<uint8_t>& out);
+
+    bool ParseWorldClockStateRequestPayload(const uint8_t* data, size_t size, WorldClockStateRequest& out);
+    bool ParseWorldClockStateResponsePayload(const uint8_t* data, size_t size, WorldClockStateResponse& out);
+    bool ParseWorldClockChangeNotificationPayload(const uint8_t* data, size_t size, WorldClockStateResponse& out);
+}

--- a/src/shared/network/tests/WorldClockPayloadsTests.cpp
+++ b/src/shared/network/tests/WorldClockPayloadsTests.cpp
@@ -1,0 +1,56 @@
+#include "src/shared/network/WorldClockPayloads.h"
+#include <cstdio>
+#include <cmath>
+using namespace engine::network::worldclock;
+static int g_failed=0;
+#define CHECK(c) do{ if(!(c)){ std::fprintf(stderr,"[FAIL] %s:%d %s\n",__FILE__,__LINE__,#c); ++g_failed; } }while(0)
+
+int main()
+{
+    WorldClockStateResponse r;
+    r.status = WorldClockStatus::Ok;
+    r.serverTimeUnixMs = 123456789ull;
+    r.epochRefUnixMs   = 1767225600000ull;
+    r.timeScaleRealMinPerDay = 60.0f;
+    r.offsetGameSec    = 43200.0;
+    r.paused           = 1;
+    r.pausedAtGameSec  = 7200.0;
+    r.lunarPeriodGameSec = 16.0*86400.0;
+
+    std::vector<uint8_t> buf;
+    BuildWorldClockStateResponsePayload(r, buf);
+    CHECK(buf.size() == 46);
+    WorldClockStateResponse out;
+    CHECK(ParseWorldClockStateResponsePayload(buf.data(), buf.size(), out));
+    CHECK(out.status == WorldClockStatus::Ok);
+    CHECK(out.serverTimeUnixMs == r.serverTimeUnixMs);
+    CHECK(out.epochRefUnixMs == r.epochRefUnixMs);
+    CHECK(std::fabs(out.offsetGameSec - r.offsetGameSec) < 1e-6);
+    CHECK(out.paused == 1);
+    CHECK(std::fabs(out.pausedAtGameSec - 7200.0) < 1e-6);
+    CHECK(std::fabs(out.lunarPeriodGameSec - r.lunarPeriodGameSec) < 1e-3);
+
+    // Reject-short : un payload tronque d'un octet doit etre refuse.
+    CHECK(!ParseWorldClockStateResponsePayload(buf.data(), buf.size()-1, out));
+    // Reject-extra : un octet de trop doit aussi etre refuse (taille != 46).
+    {
+        std::vector<uint8_t> extra = buf;
+        extra.push_back(0u);
+        CHECK(!ParseWorldClockStateResponsePayload(extra.data(), extra.size(), out));
+    }
+
+    std::vector<uint8_t> req;
+    BuildWorldClockStateRequestPayload(req);
+    CHECK(req.empty());
+    WorldClockStateRequest rq;
+    CHECK(ParseWorldClockStateRequestPayload(req.data(), req.size(), rq));
+
+    std::vector<uint8_t> nbuf;
+    BuildWorldClockChangeNotificationPayload(r, nbuf);
+    WorldClockStateResponse n;
+    CHECK(ParseWorldClockChangeNotificationPayload(nbuf.data(), nbuf.size(), n));
+    CHECK(std::fabs(n.timeScaleRealMinPerDay - 60.0f) < 1e-3f);
+
+    if(g_failed==0) std::printf("[OK] WorldClockPayloadsTests\n");
+    return g_failed;
+}


### PR DESCRIPTION
**Sous-chantier 2/6** du chantier « horloge monde serveur-autoritaire ». **Stackée sur #845** (base = `feat/worldclock-foundation`) → merger #845 d'abord.

## Contenu

- **Opcodes 203-205** (`ProtocolV1Constants.h`) : `kOpcodeWorldClockStateRequest/Response/ChangeNotification`. (200-202 étaient déjà pris par Interactive Props `kOpInteractive*` → 203-205, première plage libre. Spec/plan corrigés en conséquence.)
- **`WorldClockPayloads.{h,cpp}`** : structs + sérialisation little-endian (calque `LunarPayloads`), réponse/notification = **46 octets**, Parse rejette short/extra. Ajout `WriteDoubleLE/ReadDoubleLE`.
- **Tests** `world_clock_payloads_tests` (round-trip complet + reject short/extra + requête vide).
- CMake : `WorldClockPayloads.cpp` → `engine_core` **et** `server_app` (règle repo).

## Plan de test

- [ ] CI : `world_clock_payloads_tests` vert.

## Déploiement

✅ **Wire-only — pas de redéploiement à ce stade** : aucun handler ne répond encore à 203, aucun client ne l'émet. Le redéploiement master deviendra obligatoire à **PR 3** (WorldClockHandler), en lock-step avec le client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)