### PR TITLE
feat(worldclock) PR3: handler master + état mutable + broadcast

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/auction/AuctionHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/loot/LootHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/lunar/LunarHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/worldclock/WorldClockHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/handlers/admin/AdminCommandHandler.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/admin/SlashCommandRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/trade/TradeSessionRegistry.cpp

--- a/src/masterd/handlers/worldclock/WorldClockHandler.cpp
+++ b/src/masterd/handlers/worldclock/WorldClockHandler.cpp
@@ -1,0 +1,231 @@
+// Implementation WorldClockHandler : dispatch + etat mutable + broadcast admin.
+
+#include "src/masterd/handlers/worldclock/WorldClockHandler.h"
+
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/core/Log.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/network/WorldClockPayloads.h"
+#include "src/shared/world/WorldClock.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace engine::server
+{
+	using engine::world::GameSeconds;
+	using engine::world::WorldClockParams;
+
+	uint64_t WorldClockHandler::NowMs()
+	{
+		return static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::system_clock::now().time_since_epoch()).count());
+	}
+
+	double WorldClockHandler::RealSecSinceEpoch(uint64_t now) const
+	{
+		// Suppose m_mutex deja pris par l'appelant.
+		return (now >= m_params.epochRefUnixMs)
+			? static_cast<double>(now - m_params.epochRefUnixMs) / 1000.0 : 0.0;
+	}
+
+	void WorldClockHandler::Configure(const WorldClockParams& p)
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_params = p;
+	}
+
+	WorldClockParams WorldClockHandler::GetParams() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_params;
+	}
+
+	void WorldClockHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+	                                     uint64_t sessionIdHeader, const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		using namespace engine::network;
+		using namespace engine::network::worldclock;
+
+		if (opcode != kOpcodeWorldClockStateRequest) return;
+
+		WorldClockStateResponse resp;
+		resp.serverTimeUnixMs = NowMs();
+
+		LOG_INFO(Net, "[WorldClockHandler] HandleStateRequest received (connId={} requestId={} sessionIdHeader={})",
+			connId, requestId, static_cast<unsigned long long>(sessionIdHeader));
+
+		// Validation session : si pas de session valide -> Unauthorized.
+		if (m_connMap && m_sessionMgr)
+		{
+			auto sessIdOpt = m_connMap->GetSessionId(connId);
+			const uint64_t sessIdResolved = sessIdOpt.has_value() ? *sessIdOpt : 0u;
+			if (!sessIdOpt || *sessIdOpt == 0u || sessionIdHeader == 0u
+				|| *sessIdOpt != sessionIdHeader)
+			{
+				resp.status = WorldClockStatus::Unauthorized;
+				LOG_WARN(Net, "[WorldClockHandler] auth REJECTED (connId={} sessIdResolved={} sessionIdHeader={} match={})",
+					connId, static_cast<unsigned long long>(sessIdResolved),
+					static_cast<unsigned long long>(sessionIdHeader),
+					(sessIdOpt.has_value() && *sessIdOpt == sessionIdHeader) ? 1 : 0);
+			}
+			else
+			{
+				auto accIdOpt = m_sessionMgr->GetAccountId(*sessIdOpt);
+				if (!accIdOpt || *accIdOpt == 0u)
+				{
+					resp.status = WorldClockStatus::Unauthorized;
+					LOG_WARN(Net, "[WorldClockHandler] auth REJECTED account_id missing (connId={} sessId={})",
+						connId, static_cast<unsigned long long>(sessIdResolved));
+				}
+				else
+				{
+					LOG_INFO(Net, "[WorldClockHandler] auth OK (connId={} sessId={} accountId={})",
+						connId, static_cast<unsigned long long>(sessIdResolved),
+						static_cast<unsigned long long>(*accIdOpt));
+				}
+			}
+		}
+		else
+		{
+			// Handler pas cable -> repond Unauthorized par defaut (defensive).
+			resp.status = WorldClockStatus::Unauthorized;
+			LOG_WARN(Net, "[WorldClockHandler] handler not wired (connMap={} sessionMgr={})",
+				m_connMap ? 1 : 0, m_sessionMgr ? 1 : 0);
+		}
+
+		if (resp.status == WorldClockStatus::Ok)
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			resp.epochRefUnixMs        = m_params.epochRefUnixMs;
+			resp.timeScaleRealMinPerDay = m_params.timeScaleRealMinPerDay;
+			resp.offsetGameSec         = m_params.offsetGameSec;
+			resp.paused                = m_params.paused ? 1u : 0u;
+			resp.pausedAtGameSec       = m_params.pausedAtGameSec;
+			resp.lunarPeriodGameSec    = m_params.lunarPeriodGameSec;
+			LOG_INFO(Net, "[WorldClockHandler] sending WorldClockStateResponse (connId={} timeScale={:.2f} offset={:.1f} paused={} lunarPeriod={:.1f})",
+				connId, resp.timeScaleRealMinPerDay, resp.offsetGameSec,
+				static_cast<unsigned>(resp.paused), resp.lunarPeriodGameSec);
+		}
+
+		std::vector<uint8_t> payload;
+		BuildWorldClockStateResponsePayload(resp, payload);
+
+		// Construction du packet complet via PacketBuilder (header + payload).
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (w.Remaining() < payload.size()) return;
+		if (!w.WriteBytes(payload.data(), payload.size())) return;
+		if (!builder.Finalize(kOpcodeWorldClockStateResponse, 0u, requestId, sessionIdHeader, payload.size())) return;
+		if (m_server)
+			m_server->Send(connId, builder.Data());
+	}
+
+	bool WorldClockHandler::SetTimeOfDay(float hours)
+	{
+		if (hours < 0.0f || hours >= 24.0f) return false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const double gs = GameSeconds(NowMs(), m_params);
+			double dayComp = std::fmod(gs, 86400.0);
+			if (dayComp < 0.0) dayComp += 86400.0;
+			m_params.offsetGameSec += (static_cast<double>(hours) * 3600.0 - dayComp);
+		}
+		LOG_INFO(Net, "[WorldClockHandler] SetTimeOfDay({:.2f}h) applied", hours);
+		BroadcastChange();
+		return true;
+	}
+
+	bool WorldClockHandler::SetPaused(bool paused)
+	{
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			if (paused)
+			{
+				// Fige la valeur courante avant de marquer paused.
+				m_params.pausedAtGameSec = GameSeconds(NowMs(), m_params);
+				m_params.paused = true;
+			}
+			else
+			{
+				// Reprise : recale l'offset pour la continuite (pas de saut).
+				const double realSec = RealSecSinceEpoch(NowMs());
+				const double gsPerRs = 86400.0 / std::max(1e-6,
+					static_cast<double>(m_params.timeScaleRealMinPerDay) * 60.0);
+				m_params.offsetGameSec = m_params.pausedAtGameSec - realSec * gsPerRs;
+				m_params.paused = false;
+			}
+		}
+		LOG_INFO(Net, "[WorldClockHandler] SetPaused({}) applied", paused ? 1 : 0);
+		BroadcastChange();
+		return true;
+	}
+
+	bool WorldClockHandler::SetTimeScale(float realMinPerDay)
+	{
+		if (realMinPerDay < 1.0f || realMinPerDay > 1440.0f) return false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			// Continuite : on garde la meme heure de jeu a l'instant de bascule.
+			const double gsBefore = GameSeconds(NowMs(), m_params);
+			if (m_params.paused)
+			{
+				// En pause : la valeur figee prime, on ne touche pas l'offset.
+				// On change uniquement la cadence (effet visible a la reprise).
+				m_params.timeScaleRealMinPerDay = realMinPerDay;
+			}
+			else
+			{
+				const double realSec = RealSecSinceEpoch(NowMs());
+				const double gsPerRs = 86400.0 / (static_cast<double>(realMinPerDay) * 60.0);
+				m_params.timeScaleRealMinPerDay = realMinPerDay;
+				m_params.offsetGameSec = gsBefore - realSec * gsPerRs;
+			}
+		}
+		LOG_INFO(Net, "[WorldClockHandler] SetTimeScale({:.2f}) applied", realMinPerDay);
+		BroadcastChange();
+		return true;
+	}
+
+	void WorldClockHandler::BroadcastChange()
+	{
+		using namespace engine::network;
+		using namespace engine::network::worldclock;
+
+		// Instantane des params courants (prend le mutex en interne).
+		WorldClockParams snap = GetParams();
+
+		WorldClockStateResponse notif;
+		notif.status               = WorldClockStatus::Ok;
+		notif.serverTimeUnixMs     = NowMs();
+		notif.epochRefUnixMs       = snap.epochRefUnixMs;
+		notif.timeScaleRealMinPerDay = snap.timeScaleRealMinPerDay;
+		notif.offsetGameSec        = snap.offsetGameSec;
+		notif.paused               = snap.paused ? 1u : 0u;
+		notif.pausedAtGameSec      = snap.pausedAtGameSec;
+		notif.lunarPeriodGameSec   = snap.lunarPeriodGameSec;
+
+		std::vector<uint8_t> payload;
+		BuildWorldClockChangeNotificationPayload(notif, payload);
+
+		// Push asynchrone : requestId=0, sessionId=0 dans le header.
+		auto packet = BuildPushPacket(kOpcodeWorldClockChangeNotification,
+			std::span<const uint8_t>(payload.data(), payload.size()));
+		if (packet.empty()) return;
+
+		if (!m_server || !m_connMap) return;
+		auto snapshot = m_connMap->Snapshot();
+		for (const auto& [connId, sessId] : snapshot)
+		{
+			(void)sessId;
+			m_server->Send(connId, packet);
+		}
+	}
+}

--- a/src/masterd/handlers/worldclock/WorldClockHandler.h
+++ b/src/masterd/handlers/worldclock/WorldClockHandler.h
@@ -1,0 +1,123 @@
+#pragma once
+// WorldClockHandler : etat horloge monde authoritative master + push broadcast
+// sur changement admin. Contrairement au LunarHandler (etat purement stateless,
+// recalcule a chaque appel depuis l'epoch), l'horloge monde a un etat MUTABLE
+// (offset, pause, time scale) modifiable au runtime via les commandes admin
+// (/settime, /pausetime, /timescale). Toute mutation declenche un broadcast 205.
+//
+// Le handler est instancie dans main_linux.cpp au boot, cable via
+// SetServer/SetSessionManager/SetConnectionSessionMap, configure une fois via
+// Configure() (params boot lus depuis config.json), puis enregistre dans le
+// dispatch du NetServer pour l'opcode 203. La response 204 est emise avec le
+// meme requestId/sessionId que la request recue. Le push 205 est broadcast a
+// tous les clients connectes (pas de subscribe explicite : l'horloge est
+// globale et permanente, comme la lune).
+//
+// La formule de calcul des secondes de jeu vit dans WorldClock.h (engine::world,
+// pure et deterministe) : master, shard et client utilisent la MEME fonction
+// pour rester synchronises. Le handler ne fait que detenir les params courants
+// et les muter.
+//
+// V1 limitations :
+//   - SetTimeOfDay decale aussi la phase lunaire (offset partage). OK v1.
+//   - Pas de persistance de l'offset/pause (cf. WorldClockParams : offsetGameSec
+//     non persiste). Un reboot master retombe sur les params config.
+//   - Pas de Tick periodique : l'horloge ne change qu'a la demande admin
+//     (mutateurs). La derive temporelle est implicite dans GameSeconds().
+
+#include "src/shared/world/WorldClock.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+}
+
+namespace engine::server
+{
+	/// Dispatcher WorldClock cote master + etat mutable + broadcast admin.
+	/// Doit etre configure via Set*() avant tout HandlePacket / mutateur.
+	class WorldClockHandler
+	{
+	public:
+		/// Branche le NetServer pour pouvoir envoyer les reponses + push notifications.
+		void SetServer(NetServer* s) { m_server = s; }
+		/// Branche le SessionManager pour resoudre sessionId -> accountId (validation auth).
+		void SetSessionManager(SessionManager* mgr) { m_sessionMgr = mgr; }
+		/// Branche la map connId -> sessionId pour valider les requests + iterer pour le push.
+		void SetConnectionSessionMap(ConnectionSessionMap* m) { m_connMap = m; }
+
+		/// Fixe les parametres boot de l'horloge. Appele une fois au boot avant
+		/// tout HandlePacket / mutateur. Ecrit sous mutex.
+		/// \param p Parametres initiaux (epoch, time scale, periode lunaire...).
+		void Configure(const engine::world::WorldClockParams& p);
+
+		/// Dispatch packet : opcode 203 (WorldClockStateRequest) -> response 204.
+		/// Si l'opcode n'est pas WorldClock, ignore silencieusement.
+		///
+		/// \param connId           identifiant de connexion TCP (pour Send response).
+		/// \param opcode           opcode du paquet entrant (203).
+		/// \param requestId        request_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param sessionIdHeader  session_id du paquet entrant ; renvoye tel quel dans la reponse.
+		/// \param payload          pointeur sur le payload (sans header).
+		/// \param payloadSize      taille du payload en octets.
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		                  uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize);
+
+		/// Cale l'heure du jour a `hours` (commande admin /settime). Decale
+		/// l'offset de jeu pour que TimeOfDayHours == hours immediatement.
+		/// Effet de bord : decale aussi la phase lunaire (offset partage, OK v1).
+		/// Broadcast 205 si succes.
+		/// \param hours Heure cible dans [0,24). Hors borne -> false, pas de mutation.
+		/// \return true si applique et broadcaste, false si hors borne.
+		bool SetTimeOfDay(float hours);
+
+		/// Met en pause ou reprend l'horloge (commande admin /pausetime).
+		/// A la pause : fige pausedAtGameSec a la valeur courante. A la reprise :
+		/// recale l'offset pour la continuite (pas de saut temporel). Broadcast 205.
+		/// \param paused true pour figer, false pour reprendre.
+		/// \return true (toujours applique).
+		bool SetPaused(bool paused);
+
+		/// Change la vitesse d'ecoulement du temps (commande admin /timescale),
+		/// en minutes REELLES par jour de jeu. Recale l'offset pour la continuite
+		/// (l'instant de bascule garde la meme heure de jeu). Si l'horloge est en
+		/// pause, l'offset n'est PAS touche (la valeur figee pausedAtGameSec prime).
+		/// Broadcast 205 si succes.
+		/// \param realMinPerDay Minutes reelles par jour de jeu, borne [1,1440].
+		///                      Hors borne -> false, pas de mutation.
+		/// \return true si applique et broadcaste, false si hors borne.
+		bool SetTimeScale(float realMinPerDay);
+
+		/// Copie des parametres courants sous mutex (pour le futur lunaire/shard).
+		engine::world::WorldClockParams GetParams() const;
+
+	private:
+		/// Push une WorldClockChangeNotification (opcode 205, push) a tous les
+		/// clients connectes (snapshot de ConnectionSessionMap). A appeler hors
+		/// mutex (prend un instantane des params via GetParams()).
+		void BroadcastChange();
+
+		/// Timestamp Unix courant en ms (system_clock).
+		static uint64_t NowMs();
+
+		/// Secondes reelles ecoulees depuis l'epoch de reference. Suppose le
+		/// mutex deja pris (lit m_params.epochRefUnixMs).
+		/// \param now Timestamp Unix courant en ms.
+		double RealSecSinceEpoch(uint64_t now) const;
+
+		NetServer*            m_server     = nullptr;
+		SessionManager*       m_sessionMgr = nullptr;
+		ConnectionSessionMap* m_connMap    = nullptr;
+
+		/// Mutex protegeant m_params (etat mutable de l'horloge).
+		mutable std::mutex                  m_mutex;
+		/// Etat courant de l'horloge (defaults WorldClockParams jusqu'a Configure()).
+		engine::world::WorldClockParams     m_params;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -54,6 +54,7 @@
 #include "src/masterd/handlers/auction/AuctionHandler.h"
 #include "src/masterd/handlers/loot/LootHandler.h"
 #include "src/masterd/handlers/lunar/LunarHandler.h"
+#include "src/masterd/handlers/worldclock/WorldClockHandler.h"
 #include "src/masterd/handlers/admin/AdminCommandHandler.h"
 #include "src/masterd/admin/SlashCommandRegistry.h"
 #include "src/masterd/account/AccountRoleService.h"
@@ -953,6 +954,35 @@ int main(int argc, char** argv)
 		lunarHandler.Tick(bootNowMs);
 	}
 
+	// Phase 3 step 1 WorldClock — WorldClockHandler : etat horloge monde
+	// authoritative master (epoch, time scale, offset, pause). Etat MUTABLE
+	// (contrairement a la lune stateless) modifiable au runtime via commandes
+	// admin (/settime, /pausetime, /timescale) ; chaque mutation broadcast 205.
+	// Pas de Subscribe : l'horloge est globale.
+	engine::server::WorldClockHandler worldClockHandler;
+	worldClockHandler.SetServer(&server);
+	worldClockHandler.SetSessionManager(&sessionManager);
+	worldClockHandler.SetConnectionSessionMap(&connSessionMap);
+
+	// Parametres boot lus depuis config.json (cles game.worldclock.*). Defaults
+	// identiques aux defaults WorldClockParams (epoch 2026-01-01 UTC, 60 min
+	// reelles/jour de jeu, periode lunaire 16 jours de jeu). Doit etre appele
+	// AVANT le premier HandlePacket.
+	{
+		engine::world::WorldClockParams wcParams;
+		wcParams.epochRefUnixMs = static_cast<uint64_t>(
+			config.GetInt("game.worldclock.epoch_ms", 1767225600000ll));
+		wcParams.timeScaleRealMinPerDay = static_cast<float>(
+			config.GetDouble("game.worldclock.timescale_real_min_per_day", 60.0));
+		wcParams.lunarPeriodGameSec =
+			config.GetDouble("game.worldclock.lunar_period_game_days", 16.0) * 86400.0;
+		worldClockHandler.Configure(wcParams);
+		LOG_INFO(Net, "[ServerMain] WorldClock config : epoch={}ms timeScale={:.2f}min/jour lunarPeriod={:.0f}s",
+			static_cast<unsigned long long>(wcParams.epochRefUnixMs),
+			wcParams.timeScaleRealMinPerDay, wcParams.lunarPeriodGameSec);
+	}
+	LOG_INFO(Net, "[ServerMain] WorldClockHandler configured (Phase 3 WorldClock, opcodes 203-205)");
+
 	// AdminCommand RBAC — registre des slash commands (charge depuis
 	// game/data/config/slash_commands.json) + handler central qui valide
 	// le role + log audit pour TOUTES les slash commands. Pattern central
@@ -1051,7 +1081,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &interactiveHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &questHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &interactiveHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &worldClockHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
@@ -1157,6 +1187,8 @@ int main(int argc, char** argv)
 			lootHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeLunarStateRequest)
 			lunarHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		else if (opcode == kOpcodeWorldClockStateRequest)
+			worldClockHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpInteractiveStateChange)
 			interactiveHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeAdminCommandRequest)


### PR DESCRIPTION
**Sous-chantier 3/6**. **Stackée sur #846** (→ merger #845, #846 d'abord).

## Contenu
- **`src/masterd/handlers/worldclock/WorldClockHandler.{h,cpp}`** (`engine::server`) — calque de `LunarHandler` :
  - `HandlePacket` opcode **203** → auth session → réponse **204** (`serverTimeUnixMs` + params).
  - Mutateurs `SetTimeOfDay` / `SetPaused` / `SetTimeScale` (bornés, **formules de continuité** : pas de saut à la reprise/au changement de vitesse), chacun **broadcast** une notif **205** (`Snapshot` + Send-all).
  - `GetParams()` (copie sous mutex) pour la suite (lune/shard).
- Wiring `main_linux.cpp` (instanciation, `Configure` depuis `config.json` `game.worldclock.*`, dispatch 203).
- CMake : `server_app`.

Concurrence vérifiée : mutation sous lock puis broadcast hors lock (pas de deadlock), notif construite depuis une copie sous lock (pas de data race).

## ⚠️ Déploiement
**REDÉPLOIEMENT SERVEUR MASTER REQUIS** — 1er handler répondant aux opcodes 203-205. Le shard n'est pas touché. Le client (PR 6) devra être déployé en lock-step.

## Plan de test
- [ ] CI build (compile). Validation fonctionnelle : en jeu une fois client (PR 6) prêt + master redéployé.

## Limite connue (v1)
`/settime` pendant une pause est sans effet visible (l'offset est écrasé à la reprise) — documenté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)