### PR TITLE
feat(worldclock) PR4: commandes admin RBAC (/settime, /pausetime, /settimescale)

### DIFF
--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -419,6 +419,42 @@
       "status": "implemented",
       "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
       "notes": "Wave 16 RBAC : utilise PacketLog::Drain() puis FormatEntries. n optionnel (defaut 20). Resultat tronque a ~4 KB pour tenir dans un seul paquet wire."
+    },
+    {
+      "command": "/settime <HH:MM>",
+      "aliases": [],
+      "description": "Fixe l'heure du jour (horloge monde serveur, broadcast a tous les clients).",
+      "category": "admin",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Commande admin horloge monde : le master parse HH:MM, valide 0<=h<24 et 0<=m<60, puis appelle WorldClockHandler::SetTimeOfDay (broadcast 205 a tous les clients). Etat serveur authoritative modifie."
+    },
+    {
+      "command": "/pausetime <on|off>",
+      "aliases": [],
+      "description": "Gele ou reprend l'horloge monde serveur.",
+      "category": "admin",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Commande admin horloge monde : le master appelle WorldClockHandler::SetPaused (true si on, false si off) puis broadcast 205. Argument hors {on,off} -> InvalidArgs."
+    },
+    {
+      "command": "/settimescale <minutes reelles par jour>",
+      "aliases": [],
+      "description": "Vitesse du cycle jour/nuit (1..1440 ; 60 = 1 jour de jeu par heure reelle).",
+      "category": "admin",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "implemented",
+      "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
+      "notes": "Commande admin horloge monde : le master appelle WorldClockHandler::SetTimeScale qui borne [1,1440] et broadcast 205. Hors bornes ou argument non numerique -> InvalidArgs."
     }
   ]
 }

--- a/src/masterd/handlers/admin/AdminCommandHandler.cpp
+++ b/src/masterd/handlers/admin/AdminCommandHandler.cpp
@@ -11,6 +11,7 @@
 #include "src/masterd/account/AccountValidation.h"
 #include "src/masterd/admin/SlashCommandRegistry.h"
 #include "src/masterd/gmtickets/GmTicketSystem.h"
+#include "src/masterd/handlers/worldclock/WorldClockHandler.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shardd/world/LunarCalendar.h"
@@ -495,6 +496,21 @@ namespace engine::server
 		else if (req.command == "/packetlog dump_all")
 		{
 			DispatchPacketLog("dump_all", req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/settime")
+		{
+			DispatchSetTime(req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/pausetime")
+		{
+			DispatchPauseTime(req.args, resp);
+			handled = true;
+		}
+		else if (req.command == "/settimescale")
+		{
+			DispatchSetTimeScale(req.args, resp);
 			handled = true;
 		}
 		else if (UiPanelCommandSet().count(req.command) > 0)
@@ -1069,5 +1085,153 @@ namespace engine::server
 		// dispatcher en amont matche par nom canonique).
 		resp.status = AdminCommandStatus::InvalidArgs;
 		resp.message = "Sous-commande /packetlog inconnue : " + subCommand;
+	}
+
+	// ============================================================
+	// WorldClock : commandes admin /settime, /pausetime, /settimescale.
+	// Le RBAC (minRole=administrator) et le LogAudit sont deja appliques
+	// par HandleRequest avant le dispatch ; ces methodes ne font que la
+	// logique metier (parsing + appel des mutateurs WorldClockHandler).
+	// ============================================================
+
+	/// Fixe l'heure du jour de l'horloge monde a partir d'un "HH:MM".
+	/// Parse split sur ':', valide 0<=h<24 et 0<=m<60, convertit en hours
+	/// flottant (h + m/60) puis applique via WorldClockHandler::SetTimeOfDay
+	/// (qui broadcast 205 a tous les clients). Sans handler cable -> ServerError.
+	void AdminCommandHandler::DispatchSetTime(const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (!m_worldClock)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/settime : WorldClockHandler non cable";
+			return;
+		}
+		if (args.size() != 1)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /settime <HH:MM>";
+			return;
+		}
+
+		// Parse "HH:MM" : split sur ':'.
+		const std::string& arg = args[0];
+		const auto colon = arg.find(':');
+		if (colon == std::string::npos)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /settime <HH:MM>";
+			return;
+		}
+		int h = -1;
+		int m = -1;
+		try
+		{
+			h = std::stoi(arg.substr(0, colon));
+			m = std::stoi(arg.substr(colon + 1));
+		}
+		catch (...)
+		{
+			LOG_WARN(Net, "/settime : argument <HH:MM> invalide ('{}')", arg);
+			h = -1;
+			m = -1;
+		}
+		if (h < 0 || h >= 24 || m < 0 || m >= 60)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /settime <HH:MM> (HH dans 0..23, MM dans 0..59)";
+			return;
+		}
+
+		const float hours = static_cast<float>(h) + static_cast<float>(m) / 60.0f;
+		if (!m_worldClock->SetTimeOfDay(hours))
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Heure hors plage [0..24)";
+			return;
+		}
+
+		char hmBuf[16];
+		std::snprintf(hmBuf, sizeof(hmBuf), "%02d:%02d", h, m);
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(std::string("time=") + hmBuf);
+		resp.message = std::string("Heure reglee a ") + hmBuf;
+	}
+
+	/// Gele (on) ou reprend (off) l'horloge monde via SetPaused. Rejette tout
+	/// argument hors {on,off} en InvalidArgs. SetPaused broadcast 205.
+	void AdminCommandHandler::DispatchPauseTime(const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (!m_worldClock)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/pausetime : WorldClockHandler non cable";
+			return;
+		}
+		if (args.size() != 1)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /pausetime <on|off>";
+			return;
+		}
+
+		const std::string& arg = args[0];
+		if (arg != "on" && arg != "off")
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /pausetime <on|off>";
+			return;
+		}
+		const bool paused = (arg == "on");
+		m_worldClock->SetPaused(paused);
+
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(std::string("paused=") + (paused ? "true" : "false"));
+		resp.message = paused ? "Horloge gelee" : "Horloge reprise";
+	}
+
+	/// Change la vitesse du cycle jour/nuit (minutes reelles par jour de jeu)
+	/// via SetTimeScale. Le handler borne [1,1440] et renvoie false si hors
+	/// bornes -> InvalidArgs. Argument non numerique -> InvalidArgs (try/catch).
+	void AdminCommandHandler::DispatchSetTimeScale(const std::vector<std::string>& args,
+		engine::network::admin::AdminCommandResponse& resp)
+	{
+		using namespace engine::network::admin;
+		if (!m_worldClock)
+		{
+			resp.status = AdminCommandStatus::ServerError;
+			resp.message = "/settimescale : WorldClockHandler non cable";
+			return;
+		}
+		if (args.size() != 1)
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "Usage : /settimescale <minutes 1..1440>";
+			return;
+		}
+
+		float scale = -1.0f;
+		try { scale = std::stof(args[0]); }
+		catch (...)
+		{
+			LOG_WARN(Net, "/settimescale : argument <minutes> invalide ('{}')", args[0]);
+			scale = -1.0f;
+		}
+		if (!m_worldClock->SetTimeScale(scale))
+		{
+			resp.status = AdminCommandStatus::InvalidArgs;
+			resp.message = "time scale hors bornes (minutes reelles par jour : 1..1440)";
+			return;
+		}
+
+		char scaleBuf[48];
+		std::snprintf(scaleBuf, sizeof(scaleBuf), "real_min_per_day=%.3f",
+			static_cast<double>(scale));
+		resp.status = AdminCommandStatus::Ok;
+		resp.result.push_back(scaleBuf);
+		resp.message = "Time scale mis a jour";
 	}
 }

--- a/src/masterd/handlers/admin/AdminCommandHandler.h
+++ b/src/masterd/handlers/admin/AdminCommandHandler.h
@@ -52,6 +52,7 @@ namespace engine::server
 	class AccountRoleService;
 	class AccountStore;
 	class SlashCommandRegistry;
+	class WorldClockHandler;
 }
 
 namespace engine::server::db
@@ -111,6 +112,11 @@ namespace engine::server
 		/// nullptr (cas server.debug.packetlog.enabled=false), les
 		/// commandes repondront Ok avec un message "PacketLog disabled".
 		void SetPacketLog(engine::server::netdebug::PacketLog* log) { m_packetLog = log; }
+
+		/// Branche le WorldClockHandler (etat horloge monde authoritative)
+		/// pour les commandes admin /settime, /pausetime, /settimescale.
+		/// Si nullptr, ces commandes repondront ServerError.
+		void SetWorldClockHandler(engine::server::WorldClockHandler* h) { m_worldClock = h; }
 
 		/// Dispatch packet : traite uniquement opcode 195
 		/// (kOpcodeAdminCommandRequest). Pour tout autre opcode, no-op.
@@ -201,6 +207,30 @@ namespace engine::server
 		                       const std::vector<std::string>& args,
 		                       engine::network::admin::AdminCommandResponse& resp);
 
+		/// Dispatch "/settime <HH:MM>" : parse l'heure (split sur ':'),
+		/// valide 0<=h<24 et 0<=m<60, convertit en hours flottant, puis
+		/// applique via WorldClockHandler::SetTimeOfDay (broadcast 205).
+		/// \param args args[0] = heure au format "HH:MM".
+		/// \param resp Reponse a remplir (Ok / InvalidArgs / ServerError).
+		void DispatchSetTime(const std::vector<std::string>& args,
+		                     engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/pausetime <on|off>" : gele (on) ou reprend (off)
+		/// l'horloge monde via WorldClockHandler::SetPaused. Argument hors
+		/// {on,off} -> InvalidArgs.
+		/// \param args args[0] = "on" ou "off".
+		/// \param resp Reponse a remplir.
+		void DispatchPauseTime(const std::vector<std::string>& args,
+		                       engine::network::admin::AdminCommandResponse& resp);
+
+		/// Dispatch "/settimescale <minutes>" : change la vitesse du cycle
+		/// jour/nuit via WorldClockHandler::SetTimeScale (borne [1,1440] cote
+		/// handler). Argument non numerique ou hors bornes -> InvalidArgs.
+		/// \param args args[0] = minutes reelles par jour de jeu (1..1440).
+		/// \param resp Reponse a remplir.
+		void DispatchSetTimeScale(const std::vector<std::string>& args,
+		                          engine::network::admin::AdminCommandResponse& resp);
+
 		NetServer*            m_server      = nullptr;
 		SessionManager*       m_sessionMgr  = nullptr;
 		ConnectionSessionMap* m_connMap     = nullptr;
@@ -210,5 +240,6 @@ namespace engine::server
 		engine::server::gmtickets::GmTicketSystem* m_gmTicketSys = nullptr;
 		engine::server::db::ConnectionPool*        m_dbPool      = nullptr;
 		engine::server::netdebug::PacketLog*       m_packetLog   = nullptr;
+		engine::server::WorldClockHandler*         m_worldClock  = nullptr;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1025,7 +1025,10 @@ int main(int argc, char** argv)
 	// Si packetLogOpt est nullptr (server.debug.packetlog.enabled=false),
 	// le handler bascule naturellement sur le chemin "PacketLog disabled".
 	adminCommandHandler.SetPacketLog(packetLogOpt.get());
-	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log + Wave 2 moderation + Wave 16 packetlog wiring)");
+	// WorldClock : branche l'horloge monde pour /settime, /pausetime, /settimescale
+	// (mutateurs authoritative master + broadcast 205 a tous les clients).
+	adminCommandHandler.SetWorldClockHandler(&worldClockHandler);
+	LOG_INFO(Net, "[ServerMain] AdminCommandHandler configured (RBAC + audit log + Wave 2 moderation + Wave 16 packetlog + worldclock wiring)");
 
 	// Phase 5 Lunar — Branche le GameEventHandler sur le LunarHandler pour
 	// pouvoir filtrer les events par phase lunaire (event "Nuit de la


### PR DESCRIPTION
**Sous-chantier 4/6**. **Stackée sur #847** (→ merger #845→#846→#847 d'abord).

## Contenu
- **`slash_commands.json`** : 3 commandes `minRole: administrator`, `serverInteraction/serverLogged: true` :
  - `/settime <HH:MM>`, `/pausetime <on|off>`, `/settimescale <minutes réelles par jour>`.
- **`AdminCommandHandler`** : 3 dispatch (calque `/sky moon`) → appellent `WorldClockHandler::SetTimeOfDay/SetPaused/SetTimeScale`. Parsing robuste (try/catch, bornes, args validés), garde `!m_worldClock`. Routage par nom canonicalisé.
- **RBAC + LogAudit** : non réimplémentés — appliqués par le flux `HandleRequest` (rôle `administrator` requis vérifié AVANT dispatch, action loggée APRÈS). Un non-admin reçoit `Denied`.
- Wiring `main_linux.cpp` (`SetWorldClockHandler`). Réutilise l'opcode AdminCommand 195/196 (pas de nouvel opcode).

## ⚠️ Déploiement
**REDÉPLOIEMENT SERVEUR MASTER REQUIS** (nouveau dispatch + `slash_commands.json` rejoué). Shard non concerné.

## Suite (hors périmètre de cette PR)
L'**envoi côté client** de ces commandes (chat → AdminCommandRequest) sera vérifié/câblé en **PR 6 (client)** — si le chemin chat→AdminCommand n'est pas générique.

## Plan de test
- [ ] CI build. RBAC : non-admin → Denied (validable via test handler si infra dispo, sinon manuel). Fonctionnel en jeu une fois client (PR 6) + master redéployé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)