### PR TITLE
refactor(worldclock) PR5: unification lune sur l'horloge monde

### DIFF
--- a/src/masterd/handlers/lunar/LunarHandler.cpp
+++ b/src/masterd/handlers/lunar/LunarHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "src/masterd/handlers/lunar/LunarHandler.h"
 
+#include "src/masterd/handlers/worldclock/WorldClockHandler.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/core/Log.h"
@@ -26,14 +27,30 @@ namespace engine::server
 		m_cycleDurationMs = cycleDurationMs;
 	}
 
+	LunarPhaseInfo LunarHandler::ComputePhaseNow(uint64_t realNowMs) const
+	{
+		// Unifie : la phase derive de l'horloge MONDE (temps de jeu) si disponible.
+		// On garde LunarCalendar comme point de calcul : seule son ENTREE change
+		// (gameMs / periodMs derives de l'horloge au lieu de realNowMs / cycle reel).
+		if (m_worldClock)
+		{
+			const engine::world::WorldClockParams p = m_worldClock->GetParams();
+			const double gameSec = engine::world::GameSeconds(realNowMs, p);
+			const uint64_t gameMs = static_cast<uint64_t>(gameSec * 1000.0);
+			const uint64_t periodMs = static_cast<uint64_t>(p.lunarPeriodGameSec * 1000.0);
+			return LunarCalendar::Compute(gameMs, 0ull, periodMs);
+		}
+		// Fallback (horloge non cablee) : ancien comportement temps reel.
+		return LunarCalendar::Compute(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+	}
+
 	uint8_t LunarHandler::CurrentPhase() const
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 		const uint64_t nowMs = static_cast<uint64_t>(
 			std::chrono::duration_cast<std::chrono::milliseconds>(
 				std::chrono::system_clock::now().time_since_epoch()).count());
-		auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
-		return info.phase;
+		return ComputePhaseNow(nowMs).phase;
 	}
 
 	void LunarHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
@@ -101,11 +118,24 @@ namespace engine::server
 			const uint64_t nowMs = static_cast<uint64_t>(
 				std::chrono::duration_cast<std::chrono::milliseconds>(
 					std::chrono::system_clock::now().time_since_epoch()).count());
-			auto info = LunarCalendar::Compute(nowMs, m_cycleStartMs, m_cycleDurationMs);
+			auto info = ComputePhaseNow(nowMs);
 			resp.phase = info.phase;
 			resp.illumination = info.illumination;
-			resp.cycleStartMs = m_cycleStartMs;
-			resp.cycleDurationMs = m_cycleDurationMs;
+			// Champs cycle (informationnels : le client utilise phase + illumination).
+			// Si l'horloge monde est branchee, on renvoie l'epoch + la periode lunaire
+			// derivees de l'horloge (temps de jeu) pour rester coherent avec la source
+			// reelle de la phase. Sinon, anciennes valeurs temps reel. Wire inchange.
+			if (m_worldClock)
+			{
+				const engine::world::WorldClockParams p = m_worldClock->GetParams();
+				resp.cycleStartMs = p.epochRefUnixMs;
+				resp.cycleDurationMs = static_cast<uint64_t>(p.lunarPeriodGameSec * 1000.0);
+			}
+			else
+			{
+				resp.cycleStartMs = m_cycleStartMs;
+				resp.cycleDurationMs = m_cycleDurationMs;
+			}
 			LOG_INFO(Net, "[LunarHandler] sending LunarStateResponse (connId={} phase={} illumination={:.3f} cycleStartMs={} cycleDurationMs={})",
 				connId, static_cast<unsigned>(resp.phase), resp.illumination,
 				static_cast<unsigned long long>(resp.cycleStartMs),
@@ -134,12 +164,20 @@ namespace engine::server
 
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
-			auto info = LunarCalendar::Compute(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+			auto info = ComputePhaseNow(realNowMs);
 			if (info.phase != m_lastBroadcastPhase)
 			{
 				newPhase = info.phase;
 				newIllumination = info.illumination;
-				nextChangeTs = LunarCalendar::NextChangeTsMs(realNowMs, m_cycleStartMs, m_cycleDurationMs);
+				// nextChangeTsMs (informationnel) : si l'horloge monde est branchee,
+				// la phase derive du temps de jeu et il n'y a pas de mapping direct
+				// vers un timestamp Unix de prochain changement (la cadence depend du
+				// timeScale, qui peut changer). On laisse 0 dans ce cas (le client
+				// rafraichit via le push 194 a chaque changement de phase). Sinon,
+				// calcul temps reel d'origine.
+				nextChangeTs = m_worldClock
+					? 0ull
+					: LunarCalendar::NextChangeTsMs(realNowMs, m_cycleStartMs, m_cycleDurationMs);
 				m_lastBroadcastPhase = info.phase;
 				needBroadcast = true;
 			}

--- a/src/masterd/handlers/lunar/LunarHandler.h
+++ b/src/masterd/handlers/lunar/LunarHandler.h
@@ -30,6 +30,7 @@ namespace engine::server
 	class NetServer;
 	class SessionManager;
 	class ConnectionSessionMap;
+	class WorldClockHandler;
 }
 
 namespace engine::server
@@ -45,6 +46,12 @@ namespace engine::server
 		void SetSessionManager(SessionManager* mgr) { m_sessionMgr = mgr; }
 		/// Branche la map connId -> sessionId pour valider les requests + iterer pour le push.
 		void SetConnectionSessionMap(ConnectionSessionMap* m) { m_connMap = m; }
+		/// Branche l'horloge monde : si non-null, la phase lunaire derive du temps
+		/// de JEU (GameSeconds + lunarPeriodGameSec) au lieu du temps reel, ce qui
+		/// unifie la cadence lunaire avec la cadence jour/nuit (timeScale, pause,
+		/// /settime s'appliquent aussi a la lune). Si null, fallback temps reel
+		/// (comportement d'origine via m_cycleStartMs / m_cycleDurationMs).
+		void SetWorldClock(WorldClockHandler* wc) { m_worldClock = wc; }
 
 		/// Configure les parametres du cycle. Appele une fois au boot avant le
 		/// premier Tick. Modifie uniquement les parametres ; ne reset pas
@@ -77,6 +84,15 @@ namespace engine::server
 		uint8_t CurrentPhase() const;
 
 	private:
+		/// Calcule la phase lunaire courante de maniere centralisee. Unifie la
+		/// source : si l'horloge monde est branchee (m_worldClock != null), la
+		/// phase derive du temps de JEU (GameSeconds + lunarPeriodGameSec), sinon
+		/// fallback temps reel (m_cycleStartMs / m_cycleDurationMs, comportement
+		/// d'origine). NE prend PAS m_mutex (lit m_worldClock/m_cycleStartMs/
+		/// m_cycleDurationMs ; les appelants qui mutent ces champs verrouillent
+		/// deja). \param realNowMs Timestamp Unix courant en ms (entree du calcul).
+		engine::server::world::LunarPhaseInfo ComputePhaseNow(uint64_t realNowMs) const;
+
 		/// Traite LUNAR_STATE_REQUEST : valide session, calcule phase courante,
 		/// envoie une reponse 193 avec la phase + cycle params.
 		void HandleStateRequest(uint32_t connId, uint32_t requestId, uint64_t sessionIdHeader);
@@ -88,6 +104,9 @@ namespace engine::server
 		NetServer*            m_server     = nullptr;
 		SessionManager*       m_sessionMgr = nullptr;
 		ConnectionSessionMap* m_connMap    = nullptr;
+		/// Horloge monde optionnelle. Si non-null, ComputePhaseNow derive la
+		/// phase du temps de jeu ; sinon fallback temps reel. Non possede.
+		WorldClockHandler*    m_worldClock = nullptr;
 
 		/// Mutex protegeant m_cycleStartMs / m_cycleDurationMs / m_lastBroadcastPhase.
 		mutable std::mutex m_mutex;

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -983,6 +983,14 @@ int main(int argc, char** argv)
 	}
 	LOG_INFO(Net, "[ServerMain] WorldClockHandler configured (Phase 3 WorldClock, opcodes 203-205)");
 
+	// Unification lunaire <-> horloge monde : branche l'horloge sur le LunarHandler
+	// pour que la phase lunaire derive du temps de JEU (GameSeconds + periode
+	// lunaire en secondes de jeu) au lieu du temps reel. Doit etre fait apres
+	// l'instanciation des deux handlers (lunarHandler ci-dessus, worldClockHandler
+	// juste au-dessus). Si non branche, le LunarHandler retombe sur le temps reel.
+	lunarHandler.SetWorldClock(&worldClockHandler);
+	LOG_INFO(Net, "[ServerMain] LunarHandler branched to WorldClockHandler (lunar phase derives from game time)");
+
 	// AdminCommand RBAC — registre des slash commands (charge depuis
 	// game/data/config/slash_commands.json) + handler central qui valide
 	// le role + log audit pour TOUTES les slash commands. Pattern central


### PR DESCRIPTION
**Sous-chantier 5/6** — le refactor sensible. **Stackée sur #848** (→ merger #845→#846→#847→#848 d'abord).

## Contenu
- **`LunarHandler`** dérive désormais la phase lunaire de l'**horloge monde** (temps de jeu) au lieu du temps réel, **en gardant `LunarCalendar` comme calcul** (on change juste son input) :
  - helper `ComputePhaseNow()` : `gameSec = GameSeconds(now, worldClock.GetParams())` → `LunarCalendar::Compute(gameMs, 0, lunarPeriodMs)`.
  - **Fallback bit-pour-bit** : si l'horloge n'est pas câblée (`m_worldClock==nullptr`), comportement temps-réel d'origine → aucune régression.
- Wire lunaire (opcodes 192-194) et `LunarCalendar` **inchangés** ; `GameEventManager` intact (signature `CurrentPhase()` inchangée).
- Wiring `main_linux.cpp` (`SetWorldClock`).

## Conséquence assumée (cf. spec §8)
La cadence lunaire devient **liée au temps de jeu** : `timeScale`, `/pausetime`, `/settime` affectent maintenant aussi la lune (soleil + lune sur la même horloge). Les events filtrés par phase lunaire suivent cette cadence. Pas un bug — l'objectif de l'unification.

## Concurrence
Verrouillage inter-handlers unidirectionnel (Lunar → WorldClock, `GetParams` copie sans callback) → pas de deadlock.

## ⚠️ Déploiement
**REDÉPLOIEMENT MASTER REQUIS** (comportement `LunarHandler` modifié). Pas de changement wire/shard/client.

## Plan de test
- [ ] CI : `LunarCalendarTests` (inchangé) vert. Validation cadence lune en jeu (avec master redéployé + `/settimescale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)