### PR TITLE
fix(render): SSAO sans damier — Interleaved Gradient Noise (rectangles écran)

### DIFF
--- a/game/data/shaders/ssao.frag
+++ b/game/data/shaders/ssao.frag
@@ -39,8 +39,15 @@ void main()
     vec4 posVS = pc.invProj * vec4(ndc, depth, 1.0);
     posVS /= posVS.w;
 
-    vec2 noiseUV = inUV * vec2(textureSize(noiseTex, 0));
-    vec3 noiseVec = vec3(texture(noiseTex, noiseUV).rg * 2.0 - 1.0, 0.0);
+    // Rotation du kernel par-pixel via Interleaved Gradient Noise (Jimenez).
+    // Remplace l'ancienne texture de bruit 4x4 echantillonnee en REPEAT, qui
+    // produisait un DAMIER 4 px colle a l'ecran (rendu visible par l'ambient IBL,
+    // ambient = IBL * ao). IGN est procedural, par-pixel, SANS motif repete -> pas
+    // de damier. (noiseTex binding 3 reste declare mais inutilise : evite de
+    // toucher le descriptor set / le C++.)
+    float ign = fract(52.9829189 * fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
+    float noiseAngle = ign * 6.28318530718; // 2*PI : angle de rotation aleatoire par pixel
+    vec3 noiseVec = vec3(cos(noiseAngle), sin(noiseAngle), 0.0);
     vec3 tangent = normalize(noiseVec - normalVS * dot(noiseVec, normalVS));
     vec3 bitangent = cross(normalVS, tangent);
     mat3 tbn = mat3(tangent, bitangent, normalVS);


### PR DESCRIPTION
## Bug (rapporté en jeu)
Un **damier de rectangles fixe à l'écran** (variation subtile de luminosité) sur les surfaces. Diagnostic confirmé par l'utilisateur (« collé à l'écran » = espace-écran).

## Cause
`ssao.frag` rotait le kernel d'occlusion via une **texture de bruit 4×4 échantillonnée en mode REPEAT** (`SsaoKernelNoise.cpp`) → motif **4 px répété, fixe à l'écran**, que le flou bilatéral 7-tap n'effaçait pas. **Devenu visible depuis le branchement de l'IBL** : l'ambient (`= IBL × ao_final`) étant plus lumineux, il révélait la variation d'occlusion tilée (artefact préexistant, amplifié).

## Correctif (shader uniquement)
Remplace l'échantillonnage de la texture de bruit par un **Interleaved Gradient Noise** (Jimenez) : rotation du kernel **par-pixel, procédurale, sans motif répété** → plus de damier. Déterministe (basé sur `gl_FragCoord`, pas de temps) → compatible TAA, pas de scintillement.

- `noiseTex` (binding 3) reste déclaré mais inutilisé → **aucun changement de descriptor set / C++**.
- SSAO déjà en pleine résolution (pas un souci d'upscale).

## À valider en jeu
- [ ] Le **damier disparaît** sur le terrain/les surfaces ; le SSAO reste cohérent (occlusion douce dans les creux), sans grain excessif.

## Déploiement
✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)