### PR TITLE
feat(render): nuit plus sombre — plafond d'exposition piloté par l'heure

### DIFF
--- a/config.json
+++ b/config.json
@@ -146,6 +146,8 @@
         "speed": 2.0,
         "min": 0.1,
         "max": 3.0,
+        "_comment_night_max": "plafond d'auto-exposition la NUIT (interpole vers `max` le jour via l'elevation solaire) ; baisser pour une nuit plus noire (ex. 0.5), monter pour plus clair.",
+        "night_max": 0.8,
         "histogram_percentile_low": 0.10,
         "histogram_percentile_high": 0.90
     },

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10469,8 +10469,16 @@ namespace engine
 	        // empêche l'auto-exposition de surcompenser une scène assombrie par les
 	        // ombres et de cramer le ciel/horizon en blanc. Réglable via config.
 	        const float minExp = static_cast<float>(m_cfg.GetDouble("exposure.min", 0.1));
-	        const float maxExp = static_cast<float>(m_cfg.GetDouble("exposure.max", 3.0));
-	        m_pipeline->GetAutoExposure().Update(device, dt, key, speed, minExp, maxExp, frameIndex);
+	        // Plafond d'exposition piloté par l'heure : bas la nuit (night_max),
+	        // normal le jour (max), interpolé linéairement via le facteur jour
+	        // (élévation solaire clampée [0,1]). À dayFactor=1, effectiveMax==dayMax
+	        // (jour inchangé). Comme tout passe par l'exposition, l'ambient IBL
+	        // nocturne est aussi assombri. Lu chaque frame → night_max réglable à chaud.
+	        const float dayMax    = static_cast<float>(m_cfg.GetDouble("exposure.max", 3.0));
+	        const float nightMax  = static_cast<float>(m_cfg.GetDouble("exposure.night_max", 0.8));
+	        const float dayFactor = m_dayNight.GetState().dayFactor; // 0=nuit, 1=jour
+	        const float effectiveMax = nightMax + (dayMax - nightMax) * dayFactor;
+	        m_pipeline->GetAutoExposure().Update(device, dt, key, speed, minExp, effectiveMax, frameIndex);
 	    }
 	
 	    auto handleSuboptimal = [this](const char* phase)

--- a/src/client/render/DayNightCycle.cpp
+++ b/src/client/render/DayNightCycle.cpp
@@ -264,6 +264,11 @@ namespace engine::render
 		// sunElevation in [−1, +1]; map to [0, 1] for day blend.
 		const float dayT = Clamp(sunElevation, 0.0f, 1.0f);
 
+		// Facteur jour exposé tel quel (réutilise la courbe d'élévation déjà
+		// clampée) : 0 = nuit profonde, 1 = plein jour. Pilote le plafond
+		// d'auto-exposition côté Engine pour assombrir la nuit.
+		m_state.dayFactor = dayT;
+
 		if (isSunUp)
 		{
 			// Sunrise/sunset transition zone: elevation in [0, 0.25] → warm orange.

--- a/src/client/render/DayNightCycle.h
+++ b/src/client/render/DayNightCycle.h
@@ -63,6 +63,9 @@ namespace engine::render
 			/// True when the sun is above the horizon (elevation > 0).
 			bool isDaytime = true;
 
+			/// 0 = nuit profonde, 1 = plein jour (pour piloter l'exposition).
+			float dayFactor = 1.0f;
+
 			// ---- Lunar phase (master-driven via OnLunarPhaseChange callback) ----
 
 			/// Index de la phase lunaire courante (0..15). 0=NewMoon, 7=FullMoon, 15=Earthshine late.


### PR DESCRIPTION
## Problème (rapporté en jeu)
Quand on force la nuit (`/settime`), il ne fait **pas assez noir**.

## Cause
L'**auto-exposition** ramène toute scène sombre vers le gris moyen (key=0.18) en montant l'exposition jusqu'à `exposure.max` (=3.0). Tant que ce plafond est haut, la nuit est **rééclaircie** et ne peut pas rester noire. (Même mécanisme que la sur-exposition du ciel corrigée plus tôt, à l'envers.)

## Correctif (réglable, cinématographique)
**Plafond d'auto-exposition piloté par l'heure** : bas la nuit, normal le jour.
- `DayNightCycle::State` expose `dayFactor` (0 = nuit profonde, 1 = plein jour), dérivé de l'**élévation solaire** déjà calculée (aucune nouvelle courbe).
- `Engine` : `effectiveMax = night_max + (max − night_max) × dayFactor`, passé comme plafond à l'auto-exposition.
- Comme tout passe par l'exposition, **l'ambient IBL nocturne est aussi assombri** d'un coup.

C'est un **plafond** (l'auto-expo choisit dans `[min, effectiveMax]`), pas une exposition forcée → l'aube/le crépuscule (scènes claires) ne sont pas sur-assombris ; le plafond ne mord que sur scène sombre.

- **Jour strictement inchangé** : à `dayFactor=1`, `effectiveMax = max = 3.0`.
- Nouvelle clé **`exposure.night_max` (défaut 0.8)**, lue à chaque frame → **réglage à chaud** : baisse-la (ex. 0.5) pour une nuit plus noire, monte-la pour plus clair.

## À valider en jeu
- [ ] `/settime 0` → nuit nettement plus sombre ; jour inchangé ; transition aube/crépuscule douce. Ajuster `exposure.night_max` au goût.

## Déploiement
✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)