### PR TITLE
feat(ui): refonte menu Pause variante C — centrage + cadre/boutons thematises

### DIFF
--- a/docs/superpowers/plans/2026-06-08-refonte-menu-pause.md
+++ b/docs/superpowers/plans/2026-06-08-refonte-menu-pause.md
@@ -1,0 +1,216 @@
+# Refonte du menu Pause (variante C) — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recentrer et restyler le menu Pause in-game (variante « médiéval accentué ») en pilotant toutes ses couleurs par `LnTheme::Active()`.
+
+**Architecture :** Remplacement du bloc `if (m_inGamePauseMenuVisible)` dans `src/client/app/Engine.cpp`. Cadre + titre + séparateur dorés (accent du thème), boutons thémés centrés avec halo de bordure au survol, *Quitter* en rouge danger. Aucune nouvelle classe/fichier. Stacké sur la branche `theming-runtime-spec` (PR #855) car dépend de `LnTheme::Active()`.
+
+**Tech Stack :** Dear ImGui (immediate mode), `LnTheme` runtime (sous-projet 1).
+
+---
+
+## Task 1 : Recentrage + restyle variante C du menu Pause
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` (bloc `if (m_inGamePauseMenuVisible)`, ~lignes 10183-10224)
+
+- [ ] **Step 1 : Remplacer le bloc complet du menu Pause**
+
+Dans `src/client/app/Engine.cpp`, remplacer EXACTEMENT ce bloc existant (le menu Pause ImGui, qui commence par `if (m_inGamePauseMenuVisible)` et finit au `ImGui::End();` correspondant — vérifier d'abord en lisant la zone que le texte ci-dessous correspond bien à l'actuel, car les numéros de ligne ont pu bouger) :
+
+```cpp
+			if (m_inGamePauseMenuVisible)
+			{
+				const float menuW = 320.f;
+				const float menuH = 220.f;
+				ImGui::SetNextWindowPos(ImVec2((dw - menuW) * 0.5f, (dh - menuH) * 0.5f), ImGuiCond_Always);
+				ImGui::SetNextWindowSize(ImVec2(menuW, menuH), ImGuiCond_Always);
+				ImGui::SetNextWindowBgAlpha(0.92f);
+				ImGui::Begin("##ln_pause_menu", nullptr,
+					ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize
+					| ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse
+					| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
+				ImGui::SetWindowFontScale(1.2f);
+				const char* title = "PAUSE";
+				const float titleW = ImGui::CalcTextSize(title).x;
+				ImGui::SetCursorPosX((menuW - titleW) * 0.5f);
+				ImGui::TextUnformatted(title);
+				ImGui::SetWindowFontScale(1.f);
+				ImGui::Separator();
+				ImGui::Spacing();
+				const float btnW = menuW - 40.f;
+				if (ImGui::Button("Reprendre", ImVec2(btnW, 32.f)))
+				{
+					m_inGamePauseMenuVisible = false;
+				}
+				ImGui::Spacing();
+				if (ImGui::Button("Options", ImVec2(btnW, 32.f)))
+				{
+					m_inGamePauseMenuVisible = false;
+					m_inGameOptionsPanelVisible = true;
+				}
+				ImGui::Spacing();
+				if (ImGui::Button("Se deconnecter", ImVec2(btnW, 32.f)))
+				{
+					RequestLogoutToLoginScreen();
+				}
+				ImGui::Spacing();
+				if (ImGui::Button("Quitter le jeu", ImVec2(btnW, 32.f)))
+				{
+					OnQuit();
+				}
+				ImGui::End();
+			}
+```
+
+…par EXACTEMENT ce nouveau bloc (indentation : tabulations, comme le fichier) :
+
+```cpp
+			if (m_inGamePauseMenuVisible)
+			{
+				const LnTheme::Palette& th = LnTheme::Active();
+				// Conversion couleur thème -> ImVec4 ImGui, locale au menu pause.
+				auto iv = [](const LnTheme::Rgba& c, float a) -> ImVec4 {
+					return ImVec4(c.r, c.g, c.b, a);
+				};
+				const float menuW = 340.f;
+				const float menuH = 250.f;
+				const float btnW = menuW - 64.f;
+				ImGui::SetNextWindowPos(ImVec2((dw - menuW) * 0.5f, (dh - menuH) * 0.5f), ImGuiCond_Always);
+				ImGui::SetNextWindowSize(ImVec2(menuW, menuH), ImGuiCond_Always);
+				// Chrome variante C : fond panneau + cadre accentué (doré en Or royal,
+				// vert en Sylve émeraude). On retire SetNextWindowBgAlpha : il écraserait
+				// l'alpha du WindowBg ci-dessous.
+				ImGui::PushStyleColor(ImGuiCol_WindowBg, iv(th.panel, 0.96f));
+				ImGui::PushStyleColor(ImGuiCol_Border, iv(th.accent, 1.f));
+				ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.5f);
+				ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.f);
+				ImGui::Begin("##ln_pause_menu", nullptr,
+					ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize
+					| ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse
+					| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
+
+				// Titre PAUSE : couleur accent, centré sur la zone de contenu réelle
+				// (GetContentRegionAvail tient compte du padding -> centrage correct).
+				ImGui::SetWindowFontScale(1.3f);
+				ImGui::PushStyleColor(ImGuiCol_Text, iv(th.accent, 1.f));
+				const char* title = "PAUSE";
+				const float titleW = ImGui::CalcTextSize(title).x;
+				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - titleW) * 0.5f);
+				ImGui::TextUnformatted(title);
+				ImGui::PopStyleColor();
+				ImGui::SetWindowFontScale(1.f);
+
+				// Séparateur doré.
+				ImGui::PushStyleColor(ImGuiCol_Separator, iv(th.accent, 0.7f));
+				ImGui::Separator();
+				ImGui::PopStyleColor();
+				ImGui::Spacing();
+				ImGui::Spacing();
+
+				// Bouton thémé centré, avec halo de bordure (accent, ou rouge danger)
+				// dessiné par-dessus au survol.
+				auto pauseButton = [&](const char* label, bool danger) -> bool {
+					const LnTheme::Rgba hov = danger ? th.errorCol : th.accent;
+					ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - btnW) * 0.5f);
+					ImGui::PushStyleColor(ImGuiCol_Button, iv(th.surface, 1.f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, iv(hov, 0.22f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, iv(hov, 0.35f));
+					ImGui::PushStyleColor(ImGuiCol_Border, iv(th.border, 1.f));
+					ImGui::PushStyleColor(ImGuiCol_Text, danger ? iv(th.errorCol, 1.f) : iv(th.text, 1.f));
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.f);
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
+					const bool pressed = ImGui::Button(label, ImVec2(btnW, 34.f));
+					if (ImGui::IsItemHovered())
+					{
+						ImGui::GetWindowDrawList()->AddRect(
+							ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+							ImGui::ColorConvertFloat4ToU32(iv(hov, 1.f)), 3.f, 0, 1.5f);
+					}
+					ImGui::PopStyleVar(2);
+					ImGui::PopStyleColor(5);
+					return pressed;
+				};
+
+				if (pauseButton("Reprendre", false))
+				{
+					m_inGamePauseMenuVisible = false;
+				}
+				ImGui::Spacing();
+				if (pauseButton("Options", false))
+				{
+					m_inGamePauseMenuVisible = false;
+					m_inGameOptionsPanelVisible = true;
+				}
+				ImGui::Spacing();
+				if (pauseButton("Se deconnecter", false))
+				{
+					RequestLogoutToLoginScreen();
+				}
+				ImGui::Spacing();
+				if (pauseButton("Quitter le jeu", true))
+				{
+					OnQuit();
+				}
+				ImGui::End();
+				ImGui::PopStyleVar(2);
+				ImGui::PopStyleColor(2);
+			}
+```
+
+- [ ] **Step 2 : Vérifier l'équilibrage Push/Pop ImGui (relecture)**
+
+Relire le bloc et confirmer, par paire :
+- Chrome fenêtre : 2 `PushStyleColor` (WindowBg, Border) + 2 `PushStyleVar`
+  (WindowBorderSize, WindowRounding) → après `End()` : `PopStyleVar(2)` +
+  `PopStyleColor(2)`. ✓
+- Titre : 1 push/1 pop couleur Text. ✓
+- Séparateur : 1 push/1 pop couleur Separator. ✓
+- `pauseButton` : 5 `PushStyleColor` + 2 `PushStyleVar` → `PopStyleVar(2)` +
+  `PopStyleColor(5)`. ✓
+
+Aucune logique d'action changée : Reprendre ferme le menu, Options ouvre le
+panneau, Se déconnecter appelle `RequestLogoutToLoginScreen()`, Quitter appelle
+`OnQuit()`.
+
+- [ ] **Step 3 : Build (CI uniquement)**
+
+Pas de toolchain locale (cmake/MSVC/vcpkg absents) → ne pas compiler en local.
+La compilation client est vérifiée par la CI (build-windows / build-linux).
+`LnTheme::Palette`/`Rgba`/`Active()` sont disponibles (`LnTheme.h` déjà inclus
+dans `Engine.cpp` depuis le sous-projet 1).
+
+- [ ] **Step 4 : Validation manuelle en jeu (post-merge ou build local utilisateur)**
+
+Ouvrir le menu Pause : titre/boutons centrés (marges égales), cadre + titre +
+séparateur dorés, survol dore la bordure des boutons, *Quitter* dore en rouge.
+Changer de thème (Options → Sylve émeraude) : le menu Pause se recolore en vert.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(ui): refonte menu Pause variante C — centrage + cadre/boutons thematises"
+```
+Terminer le corps du commit par :
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+
+---
+
+## Self-review (rédaction)
+
+- **Couverture spec** : centrage titre+boutons (zone de contenu réelle) ✓ ;
+  chrome doré (fond panel + bordure accent + rounding) ✓ ; titre accent centré ✓ ;
+  séparateur doré ✓ ; boutons thémés centrés + halo survol ✓ ; Quitter en danger ✓ ;
+  couleurs 100 % issues de `Active()` ✓ ; actions inchangées ✓ ; déploiement
+  client-only ✓.
+- **Placeholders** : aucun — bloc de remplacement complet fourni.
+- **Cohérence** : équilibrage Push/Pop vérifié à l'étape 2 ; `iv()`/`th` capturés
+  par la lambda dans la même portée (durée de vie OK, `Active()` renvoie une
+  référence au statique).
+
+## Déploiement
+
+> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur. Stacké sur
+> PR #855 — merger #855 **avant** cette PR (lock-step).

--- a/docs/superpowers/specs/2026-06-08-refonte-menu-pause-design.md
+++ b/docs/superpowers/specs/2026-06-08-refonte-menu-pause-design.md
@@ -1,0 +1,105 @@
+# Refonte du menu Pause (variante C) — Design
+
+**Date** : 2026-06-08
+**Statut** : Validé (direction visuelle « variante C » choisie en brainstorming)
+**Sous-projet** : 2 / 2 (le 1 = fondation theming runtime, PR #855)
+**Dépend de** : `LnTheme::Active()` (sous-projet 1) → branche stackée sur `theming-runtime-spec`.
+
+## Contexte et problème
+
+Demande initiale de l'utilisateur (capture à l'appui) : le menu Pause in-game
+« n'est pas beau » et « les boutons et les textes ne sont pas centrés ». Le
+sous-projet 1 a posé l'infrastructure de thèmes ; ce sous-projet livre enfin la
+correction visible.
+
+Le menu Pause est rendu en ImGui dans
+[`src/client/app/Engine.cpp`](../../../src/client/app/Engine.cpp), bloc
+`if (m_inGamePauseMenuVisible)` (vers la ligne 10183). Deux défauts :
+
+1. **Centrage cassé** : `const float btnW = menuW - 40.f;` puis `ImGui::Button(...)`
+   posé au curseur par défaut → marge gauche ≈ 8 px (padding fenêtre), marge
+   droite ≈ 32 px. Les boutons paraissent décalés vers la gauche. Le titre est
+   centré sur `menuW` sans tenir compte du padding (≈ correct mais fragile).
+2. **Aucun style** : `ImGui::Button` bruts avec les couleurs ImGui par défaut
+   (le bleu/gris de la capture), incohérents avec le reste du jeu.
+
+Direction retenue (maquette
+[`docs/superpowers/mockups/pause-menu-mockup.html`](../mockups/pause-menu-mockup.html),
+variante **C — médiéval accentué**) : cadre doré, titre lumineux, séparateur
+doré, boutons à survol doré, *Quitter* en rouge danger. Le tout **piloté par le
+thème actif** (`LnTheme::Active()`), donc recoloré automatiquement quand le
+joueur change de thème (Or royal → accent doré ; Sylve émeraude → accent vert).
+
+## Décisions
+
+| Sujet | Décision |
+|---|---|
+| Portée | Menu Pause uniquement (le panneau Options reste tel quel pour l'instant) |
+| Couleurs | Toutes issues de `LnTheme::Active()` (jamais codées en dur) |
+| Sémantique boutons | Reprendre / Options / Se déconnecter = neutre ; Quitter = danger (rouge) |
+| Centrage | Boutons à largeur fixe, centrés via la zone de contenu réelle |
+| « Halo » survol | Bordure accent (ou rouge danger) dessinée sur survol via `ImDrawList` |
+| Polices/accents | Libellés inchangés (ASCII, la police Windlass manque de glyphes accentués) |
+
+## Architecture
+
+Tout reste dans le bloc `if (m_inGamePauseMenuVisible)` de `Engine.cpp` — aucune
+nouvelle classe ni fichier. Les couleurs `LnTheme::Rgba` sont converties en
+`ImVec4` inline (`ImVec4{c.r, c.g, c.b, c.a}`) et en `ImU32` via
+`ImGui::ColorConvertFloat4ToU32`.
+
+### Chrome de la fenêtre
+- Fond = `Active().panel` (alpha ≈ 0.96) via `PushStyleColor(ImGuiCol_WindowBg)`
+  (on retire `SetNextWindowBgAlpha`, qui écraserait l'alpha).
+- Bordure = `Active().accent`, `WindowBorderSize = 1.5`, `WindowRounding = 4`.
+- Dimensions légèrement agrandies pour respirer : `menuW = 340`, `menuH = 250`.
+
+### Titre
+- `PAUSE` en couleur `Active().accent`, `SetWindowFontScale(1.3)`, **centré sur la
+  zone de contenu réelle** : `SetCursorPosX(GetCursorPosX() + (avail - titleW)/2)`
+  où `avail = GetContentRegionAvail().x`.
+
+### Séparateur
+- `PushStyleColor(ImGuiCol_Separator, accent @ 0.7)` autour de `ImGui::Separator()`.
+
+### Boutons (centrés + thémés)
+Une lambda locale `pauseButton(label, danger)` :
+1. Centre : `SetCursorPosX(GetCursorPosX() + (avail - btnW)/2)`.
+2. Couleurs depuis `Active()` : fond = `surface` ; survol/actif = teinte
+   `accent` (ou `errorCol` si `danger`) en alpha faible ; bordure = `border` ;
+   texte = `text` (ou rouge pour danger).
+3. `FrameRounding = 3`, `FrameBorderSize = 1`, hauteur 34, largeur `btnW`.
+4. Sur survol (`IsItemHovered`), dessine une bordure `accent`/`errorCol` pleine
+   par-dessus le bouton (`GetWindowDrawList()->AddRect`) — le « halo » de la
+   variante C, sans flou coûteux.
+5. Renvoie `pressed`.
+
+Ordre inchangé : **Reprendre** (ferme le menu), **Options** (ouvre le panneau
+Options), **Se déconnecter** (`RequestLogoutToLoginScreen()`), **Quitter le jeu**
+(`OnQuit()`, en `danger = true`). Les actions/`m_...` et appels restent
+identiques — seul le rendu change.
+
+## Tests
+
+Pas de test unitaire automatisé (rendu ImGui immédiat, pas de logique pure
+nouvelle). Validation **manuelle en jeu** :
+- Boutons et titre visuellement centrés (marges gauche = droite).
+- Cadre + titre + séparateur dorés en thème Or royal ; survol dore la bordure des
+  boutons ; *Quitter* dore en rouge au survol.
+- Bascule vers Sylve émeraude (via Options) : le menu Pause se recolore en vert
+  (preuve que les couleurs viennent bien de `LnTheme::Active()`).
+
+## Hors périmètre (YAGNI)
+
+- Refonte du **panneau Options** in-game (même bug de centrage du titre, mais
+  redesign de ses contrôles = autre passage). Optionnellement, un alignement
+  minimal du titre Options peut être inclus s'il est trivial, sinon différé.
+- Flou/glow gaussien réel (ImGui ne le fait pas à peu de frais) — approximé par
+  une bordure accent sur survol.
+- Animations d'ouverture/fermeture du menu.
+
+## Déploiement
+
+> **Déploiement** : ✅ client uniquement, pas de redéploiement serveur — rendu UI
+> pur, aucun opcode, handler ni migration. (Stacké sur PR #855 : merger #855
+> **avant** cette PR.)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10402,45 +10402,93 @@ namespace engine
 			// que le ImGui::Render() finalise les deux draw lists en une seule passe.
 			if (m_inGamePauseMenuVisible)
 			{
-				const float menuW = 320.f;
-				const float menuH = 220.f;
+				const LnTheme::Palette& th = LnTheme::Active();
+				// Conversion couleur thème -> ImVec4 ImGui, locale au menu pause.
+				auto iv = [](const LnTheme::Rgba& c, float a) -> ImVec4 {
+					return ImVec4(c.r, c.g, c.b, a);
+				};
+				const float menuW = 340.f;
+				const float menuH = 250.f;
+				const float btnW = menuW - 64.f;
 				ImGui::SetNextWindowPos(ImVec2((dw - menuW) * 0.5f, (dh - menuH) * 0.5f), ImGuiCond_Always);
 				ImGui::SetNextWindowSize(ImVec2(menuW, menuH), ImGuiCond_Always);
-				ImGui::SetNextWindowBgAlpha(0.92f);
+				// Chrome variante C : fond panneau + cadre accentué (doré en Or royal,
+				// vert en Sylve émeraude). On retire SetNextWindowBgAlpha : il écraserait
+				// l'alpha du WindowBg ci-dessous.
+				ImGui::PushStyleColor(ImGuiCol_WindowBg, iv(th.panel, 0.96f));
+				ImGui::PushStyleColor(ImGuiCol_Border, iv(th.accent, 1.f));
+				ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.5f);
+				ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.f);
 				ImGui::Begin("##ln_pause_menu", nullptr,
 					ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize
 					| ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse
 					| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
-				ImGui::SetWindowFontScale(1.2f);
+
+				// Titre PAUSE : couleur accent, centré sur la zone de contenu réelle
+				// (GetContentRegionAvail tient compte du padding -> centrage correct).
+				ImGui::SetWindowFontScale(1.3f);
+				ImGui::PushStyleColor(ImGuiCol_Text, iv(th.accent, 1.f));
 				const char* title = "PAUSE";
 				const float titleW = ImGui::CalcTextSize(title).x;
-				ImGui::SetCursorPosX((menuW - titleW) * 0.5f);
+				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - titleW) * 0.5f);
 				ImGui::TextUnformatted(title);
+				ImGui::PopStyleColor();
 				ImGui::SetWindowFontScale(1.f);
+
+				// Séparateur doré.
+				ImGui::PushStyleColor(ImGuiCol_Separator, iv(th.accent, 0.7f));
 				ImGui::Separator();
+				ImGui::PopStyleColor();
 				ImGui::Spacing();
-				const float btnW = menuW - 40.f;
-				if (ImGui::Button("Reprendre", ImVec2(btnW, 32.f)))
+				ImGui::Spacing();
+
+				// Bouton thémé centré, avec halo de bordure (accent, ou rouge danger)
+				// dessiné par-dessus au survol.
+				auto pauseButton = [&](const char* label, bool danger) -> bool {
+					const LnTheme::Rgba hov = danger ? th.errorCol : th.accent;
+					ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - btnW) * 0.5f);
+					ImGui::PushStyleColor(ImGuiCol_Button, iv(th.surface, 1.f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, iv(hov, 0.22f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, iv(hov, 0.35f));
+					ImGui::PushStyleColor(ImGuiCol_Border, iv(th.border, 1.f));
+					ImGui::PushStyleColor(ImGuiCol_Text, danger ? iv(th.errorCol, 1.f) : iv(th.text, 1.f));
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.f);
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
+					const bool pressed = ImGui::Button(label, ImVec2(btnW, 34.f));
+					if (ImGui::IsItemHovered())
+					{
+						ImGui::GetWindowDrawList()->AddRect(
+							ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+							ImGui::ColorConvertFloat4ToU32(iv(hov, 1.f)), 3.f, 0, 1.5f);
+					}
+					ImGui::PopStyleVar(2);
+					ImGui::PopStyleColor(5);
+					return pressed;
+				};
+
+				if (pauseButton("Reprendre", false))
 				{
 					m_inGamePauseMenuVisible = false;
 				}
 				ImGui::Spacing();
-				if (ImGui::Button("Options", ImVec2(btnW, 32.f)))
+				if (pauseButton("Options", false))
 				{
 					m_inGamePauseMenuVisible = false;
 					m_inGameOptionsPanelVisible = true;
 				}
 				ImGui::Spacing();
-				if (ImGui::Button("Se deconnecter", ImVec2(btnW, 32.f)))
+				if (pauseButton("Se deconnecter", false))
 				{
 					RequestLogoutToLoginScreen();
 				}
 				ImGui::Spacing();
-				if (ImGui::Button("Quitter le jeu", ImVec2(btnW, 32.f)))
+				if (pauseButton("Quitter le jeu", true))
 				{
 					OnQuit();
 				}
 				ImGui::End();
+				ImGui::PopStyleVar(2);
+				ImGui::PopStyleColor(2);
 			}
 			// Mini-panel Options in-game (ouvert via le bouton Options du menu pause).
 			// Contient les controles essentiels qu'on veut pouvoir ajuster sans


### PR DESCRIPTION
## Résumé

Sous-projet **2/2** — la refonte visible du menu Pause demandée à l'origine (« pas beau », « boutons et textes pas centrés »). Répond directement à la capture d'écran initiale.

- **Centrage corrigé** : le bug venait de `btnW = menuW - 40` posé au curseur par défaut (marges asymétriques). Titre et boutons sont désormais centrés sur la **zone de contenu réelle** (`GetContentRegionAvail`, padding inclus).
- **Restyle « variante C » (médiéval accentué)** : cadre accentué, titre lumineux, séparateur doré, boutons thémés avec **halo de bordure au survol**, *Quitter le jeu* en **rouge danger**.
- **100 % piloté par le thème** : toutes les couleurs viennent de `LnTheme::Active()` → le menu se recolore automatiquement quand le joueur change de thème (doré en Or royal, vert en Sylve émeraude).

Aucune logique d'action changée (Reprendre / Options / Se déconnecter / Quitter font exactement ce qu'avant). Tout reste dans le bloc ImGui de `Engine.cpp`, aucune nouvelle classe/fichier.

Spec/plan : `docs/superpowers/specs/2026-06-08-refonte-menu-pause-design.md`, `docs/superpowers/plans/2026-06-08-refonte-menu-pause.md`. Direction choisie en brainstorming via la maquette `docs/superpowers/mockups/pause-menu-mockup.html`.

## ⚠️ PR stackée — ordre de merge

Cette PR est **basée sur `theming-runtime-spec` (PR #855)** car elle consomme `LnTheme::Active()`. **Merger #855 d'abord**, puis cette PR (qui se reciblera automatiquement sur `main`).

## Plan de test

- [ ] CI `build-windows` / `build-linux` : compilation client OK.
- [ ] En jeu : menu Pause — titre + boutons centrés (marges égales), cadre/titre/séparateur dorés, survol dore la bordure des boutons, *Quitter* dore en rouge.
- [ ] Options → Sylve émeraude : le menu Pause se recolore en vert (preuve que les couleurs viennent de `LnTheme::Active()`).

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur — rendu UI pur, aucun opcode/handler/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
