### PR TITLE
fix(pause): gele l'input gameplay (deplacement/attaque) quand le menu Pause est ouvert

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8949,7 +8949,11 @@ namespace engine
 
 		if (!m_editorEnabled)
 		{
-			if (!authGateActive && !m_chatUi.IsChatFocusActive() && !m_inGameOptionsPanelVisible)
+			if (!authGateActive && !m_chatUi.IsChatFocusActive() && !m_inGameOptionsPanelVisible
+					// Menu Pause ouvert => gèle tout l'input gameplay (déplacement,
+					// caméra, attaque, sorts, interaction), comme le panneau Options :
+					// le joueur ne doit ni bouger ni attaquer tant que la pause est active.
+					&& !m_inGamePauseMenuVisible)
 			{
 				// Touches d'action remappables (controls.keybind.*), resolues chaque
 				// frame depuis la config pour refleter immediatement un rebind fait


### PR DESCRIPTION
## Résumé

Correctif gameplay du menu Pause : **quand le menu Pause est ouvert, le joueur ne peut plus se déplacer ni attaquer** (ni tourner la caméra, lancer un sort ou interagir).

Le bloc d'input gameplay de `Engine.cpp` (déplacement, caméra orbitale, attaque clic gauche, coup de poing, sort, interaction) n'était gardé que par `!m_inGameOptionsPanelVisible` (panneau Options) — **pas** par le menu Pause. On ajoute `&& !m_inGamePauseMenuVisible` à la même condition, exactement comme pour les Options : tout l'input gameplay est gelé tant que la pause est active.

Changement minimal (1 condition), cohérent avec le gating existant.

## Plan de test

- [ ] CI `build-windows` / `build-linux` : compilation OK.
- [ ] En jeu : ouvrir le menu Pause (Échap) → ZQSD/WASD ne déplacent plus l'avatar, clic gauche / touche d'attaque ne déclenchent plus l'attaque, le coup de poing et les sorts ne partent plus, la caméra ne tourne plus. Fermer le menu → tout refonctionne.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur — gating d'input local, aucun opcode/handler/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
