### PR TITLE
ci(tests): garder les assert() actifs en Release (anti-piège NDEBUG)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1994,3 +1994,11 @@ add_subdirectory(tools/load_tester)
 # visuellement distinct pour le shader 8-layer terrain en attendant les vrais
 # assets PBR. Pas de dépendance zlib externe (deflate stored block).
 add_subdirectory(tools/gen_terrain_placeholders)
+
+# Garde anti-NDEBUG : re-active les assert() pour TOUTES les cibles de test
+# declarees « manuellement » (add_executable + add_test) dans ce fichier.
+# En Release, NDEBUG desactiverait les assert et rendrait ces tests verts
+# sans rien verifier. A laisser en dernier (apres tous les add_test de ce
+# repertoire). Les tests crees via lcdlln_add_simple_test sont deja couverts
+# par le helper ; l'appel est idempotent. Cf. lcdlln_keep_asserts_all_dir_tests.
+lcdlln_keep_asserts_all_dir_tests()

--- a/cmake/LCDLLNHelpers.cmake
+++ b/cmake/LCDLLNHelpers.cmake
@@ -8,6 +8,56 @@
 
 include_guard(GLOBAL)
 
+# Garde anti-NDEBUG pour les tests CTest.
+#
+# Probleme : la CI compile en preset linux-x64-release (CMAKE_BUILD_TYPE=
+# Release), ce qui ajoute -DNDEBUG aux flags. -DNDEBUG desactive TOUS les
+# assert() de la stdlib. Or beaucoup de nos binaires de test reposent sur
+# assert(...) pour leurs verifications. Sans cette garde ils s'executent,
+# affichent leurs [OK] et retournent 0 SANS rien verifier : ils sont verts
+# en CI de facon trompeuse (regressions non detectees). Cf. memoire projet
+# « assert+NDEBUG = piege ».
+#
+# Solution : passer -UNDEBUG (/UNDEBUG sur MSVC) en option de compilation
+# PRIVEE sur la cible de test. Les options de cible arrivent APRES les flags
+# globaux (CMAKE_CXX_FLAGS_RELEASE) sur la ligne de commande, donc le -U
+# annule le -DNDEBUG : les assert restent actifs meme en Release, et
+# uniquement pour la cible de test (le code de production garde NDEBUG).
+#
+# Idempotent : marque la cible via une propriete pour ne pas empiler le flag
+# si appele plusieurs fois (helper + balayage de repertoire, cf. plus bas).
+function(lcdlln_keep_asserts target)
+  get_target_property(_already ${target} LCDLLN_ASSERTS_KEPT)
+  if(_already)
+    return()
+  endif()
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /UNDEBUG)
+  else()
+    target_compile_options(${target} PRIVATE -UNDEBUG)
+  endif()
+  set_target_properties(${target} PROPERTIES LCDLLN_ASSERTS_KEPT TRUE)
+endfunction()
+
+# Applique lcdlln_keep_asserts() a toutes les cibles de test (ctest)
+# enregistrees dans le repertoire courant. A appeler a la FIN d'un
+# CMakeLists.txt qui declare des tests « manuellement » (add_executable +
+# add_test), une fois tous les add_test faits. Convention du repo :
+# add_test(NAME x COMMAND x ...) => nom de test == nom de cible, donc on
+# peut retrouver la cible a partir du nom de test.
+#
+# Note : la propriete DIRECTORY/TESTS n'est PAS recursive (elle ne voit que
+# les tests du repertoire courant, pas ceux des add_subdirectory). Chaque
+# CMakeLists.txt qui declare des tests doit donc appeler cette fonction.
+function(lcdlln_keep_asserts_all_dir_tests)
+  get_property(_tests DIRECTORY PROPERTY TESTS)
+  foreach(_test ${_tests})
+    if(TARGET ${_test})
+      lcdlln_keep_asserts(${_test})
+    endif()
+  endforeach()
+endfunction()
+
 # Helper pour declarer un test simple sans deps externes (engine_core +
 # spdlog + pthread suffisent). Cible le pattern recurrent des tests
 # CMANGOS Phase 2+ (BIH, ObjectGuid, VMapFormat, GridState, ChatSanitizer,
@@ -31,5 +81,8 @@ function(lcdlln_add_simple_test target_name)
   target_include_directories(${target_name} PRIVATE ${CMAKE_SOURCE_DIR})
   target_link_libraries(${target_name} PRIVATE engine_core spdlog::spdlog pthread)
   target_compile_options(${target_name} PRIVATE -Wall -Wextra -Wpedantic)
+  # Garde anti-NDEBUG : conserve les assert() actifs meme en build Release
+  # (sinon le test serait vert sans rien verifier). Cf. lcdlln_keep_asserts.
+  lcdlln_keep_asserts(${target_name})
   add_test(NAME ${target_name} COMMAND ${target_name} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1084,3 +1084,11 @@ if(WIN32 AND DEFINED LCDLLN_OPENSSL_DLL_DIR AND NOT LCDLLN_OPENSSL_DLL_DIR STREQ
     COMMENT "Copie des DLL OpenSSL à côté de lcdlln_server.exe..."
   )
 endif()
+
+# Garde anti-NDEBUG : re-active les assert() pour TOUTES les cibles de test
+# de ce repertoire (helper lcdlln_add_simple_test + add_executable manuels).
+# En Release, NDEBUG desactiverait les assert et rendrait ces tests verts
+# sans rien verifier. A laisser en dernier (apres tous les add_test).
+# Idempotent (les tests via helper sont deja couverts). Cf.
+# lcdlln_keep_asserts_all_dir_tests dans cmake/LCDLLNHelpers.cmake.
+lcdlln_keep_asserts_all_dir_tests()

--- a/tools/zone_builder/lib/CMakeLists.txt
+++ b/tools/zone_builder/lib/CMakeLists.txt
@@ -74,3 +74,8 @@ else()
   target_compile_options(routines_segment_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 add_test(NAME routines_segment_tests COMMAND routines_segment_tests)
+
+# Garde anti-NDEBUG : re-active les assert() pour les cibles de test de ce
+# repertoire (sinon vertes sans rien verifier en Release). A laisser apres
+# tous les add_test. Cf. lcdlln_keep_asserts_all_dir_tests.
+lcdlln_keep_asserts_all_dir_tests()


### PR DESCRIPTION
## Problème

La CI compile en preset `linux-x64-release` (`CMAKE_BUILD_TYPE=Release`), ce qui définit `-DNDEBUG` et **désactive tous les `assert()`**. Les binaires de test qui reposent sur `assert(...)` pour leurs vérifications (entités : `UnitTests`, `PlayerTests`, `WorldObjectTests`, `ObjectGuidTests`, `UpdateMaskDeltaTests`, `CreatureTests`… **et de nombreux autres tests ctest** du repo) s'exécutaient, affichaient leurs `[OK]` et retournaient `0` **sans rien vérifier** : verts en CI de façon trompeuse → régressions non détectées.

Cf. mémoire projet « assert+NDEBUG = piège ». Problème **systémique et pré-existant**, découvert pendant la PR1 « Système de Personnages ».

## Correctif (CMake uniquement — **aucun code de production touché**)

Option 1 retenue (la plus propre/cohérente), généralisée à tout le repo :

- **`lcdlln_keep_asserts(target)`** dans `cmake/LCDLLNHelpers.cmake` : ajoute `-UNDEBUG` (`/UNDEBUG` sur MSVC) en option de compilation **privée** de la cible de test. L'option arrive **après** `CMAKE_CXX_FLAGS_RELEASE` sur la ligne de commande, donc le `-U` annule le `-DNDEBUG` → les `assert` restent actifs même en Release, **uniquement pour la cible de test**. Idempotent (propriété marqueur).
- **`lcdlln_add_simple_test`** l'applique automatiquement à chaque test créé via le helper.
- **`lcdlln_keep_asserts_all_dir_tests()`** balaye la propriété `DIRECTORY/TESTS` pour couvrir aussi les tests déclarés **manuellement** (`add_executable` + `add_test`). Appelé à la fin de `CMakeLists.txt`, `src/CMakeLists.txt` et `tools/zone_builder/lib/CMakeLists.txt` → couvre **tous** les tests ctest du repo (les 3 seuls fichiers déclarant des tests).

## Vérification

Mécanisme validé en isolation avec les flags Release exacts :

| Scénario | Résultat |
|---|---|
| Release sans `-UNDEBUG` (= bug actuel CI), assert cassée | exit `0`, affiche `[OK]` ❌ |
| Release **avec** `-UNDEBUG`, assert OK | test passe ✅ |
| Release **avec** `-UNDEBUG`, assert volontairement cassée | `Subprocess aborted`, ctest **FAILED** ✅ |

Le balayage répertoire produit bien `CXX_FLAGS = -O3 -DNDEBUG -UNDEBUG` (ordre correct) sur une cible déclarée manuellement.

---

**Déploiement** : ✅ pas de redéploiement serveur — changement purement build/CI (CMake), aucun opcode, payload, handler, migration DB ni config serveur touché.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAkp7vkH9suTsFBJ3fSrjX)_