### PR TITLE
feat: Système de Personnages PR1 (serveur) — moteur de stats + XP + réplication

### DIFF
--- a/cmake/EmbedJson.cmake
+++ b/cmake/EmbedJson.cmake
@@ -1,0 +1,16 @@
+# EmbedJson.cmake — convertit un fichier JSON en header C++ exposant le contenu
+# comme const char* (raw string literal). Invoqué via `cmake -P` par un
+# add_custom_command. Paramètres : -DINPUT, -DOUTPUT, -DSYMBOL.
+# Aucun chemin absolu en dur ; tout vient des -D.
+if(NOT DEFINED INPUT OR NOT DEFINED OUTPUT OR NOT DEFINED SYMBOL)
+  message(FATAL_ERROR "EmbedJson.cmake : INPUT, OUTPUT et SYMBOL requis")
+endif()
+file(READ "${INPUT}" CONTENT)
+# Délimiteur de raw string improbable dans le JSON de jeu.
+set(GEN "// AUTO-GENERATED par EmbedJson.cmake — NE PAS EDITER.\n")
+string(APPEND GEN "// Source : ${INPUT}\n#pragma once\n")
+string(APPEND GEN "namespace engine::server::gameplay {\n")
+string(APPEND GEN "inline constexpr const char* ${SYMBOL} = R\"LCDLLN_EMBED(\n")
+string(APPEND GEN "${CONTENT}")
+string(APPEND GEN "\n)LCDLLN_EMBED\";\n}\n")
+file(WRITE "${OUTPUT}" "${GEN}")

--- a/deploy/docker/sql/migrations/0072_factions_v2.sql
+++ b/deploy/docker/sql/migrations/0072_factions_v2.sql
@@ -1,0 +1,40 @@
+-- Migration 0072 — Factions v2 : alignement sur les ids courts du design
+-- (Système de Personnages). Renomme les slugs longs de 0040, ajoute les
+-- nouvelles factions, repasse Chevaliers-Dragons en race humains, et
+-- backfill characters.faction_str. Idempotent.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+START TRANSACTION;
+
+-- 1) Renommer les slugs existants vers les ids courts + corriger race_lock.
+UPDATE factions SET name='lumiere'    WHERE name='chevaliers_lumiere';
+UPDATE factions SET name='justice'    WHERE name='chevaliers_justice';
+UPDATE factions SET name='legion', display_name='Légion infernale' WHERE name='demons';
+UPDATE factions SET name='dragons', race_lock='humains' WHERE name='chevaliers_dragons';
+-- lune_noire, dzorak, empire_hynn : ids déjà alignés.
+
+-- 2) Ajouter les nouvelles factions (INSERT IGNORE = idempotent sur uq_factions_name).
+INSERT IGNORE INTO factions (name, display_name, race_lock, parent_faction_id, description) VALUES
+  ('serpent', 'Maison du Serpent', 'humains', NULL, 'Maison humaine versée dans la magie et l''ombre.'),
+  ('naine',   'Faction Naine',     'nains',   NULL, 'Peuple nain : guerriers tenaces et artisans.'),
+  ('elfe',    'Faction Elfe',      'elfes',   NULL, 'Peuple elfe : agilité, magie et discrétion.');
+
+-- 3) empire_hynn : conservée, NON sélectionnable. Ajouter la colonne `selectable`
+--    si absente (défaut 1), puis marquer empire_hynn à 0.
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE table_schema = DATABASE() AND table_name='factions' AND column_name='selectable');
+SET @stmt := IF(@col_exists = 0,
+  'ALTER TABLE factions ADD COLUMN selectable TINYINT(1) NOT NULL DEFAULT 1 COMMENT ''0 = présente mais non sélectionnable à la création''',
+  'SELECT ''column factions.selectable already exists, skipping''');
+PREPARE a FROM @stmt; EXECUTE a; DEALLOCATE PREPARE a;
+UPDATE factions SET selectable = 0 WHERE name = 'empire_hynn';
+
+-- 4) Backfill characters.faction_str pour les slugs renommés (persos existants).
+UPDATE characters SET faction_str='lumiere' WHERE faction_str='chevaliers_lumiere';
+UPDATE characters SET faction_str='justice' WHERE faction_str='chevaliers_justice';
+UPDATE characters SET faction_str='legion'  WHERE faction_str='demons';
+UPDATE characters SET faction_str='dragons' WHERE faction_str='chevaliers_dragons';
+
+COMMIT;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/docs/superpowers/plans/2026-06-08-character-system-pr1-server.md
+++ b/docs/superpowers/plans/2026-06-08-character-system-pr1-server.md
@@ -1,0 +1,1493 @@
+# Système de Personnages — PR1 (server-first) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Livrer le moteur de stats serveur (11 stats dérivées, déterministe, anti-triche par embarquement au build), la nouvelle courbe d'XP, et l'extension réplication `Unit`/`Player` — le tout testé et autonome, sans toucher au wire ni au client.
+
+**Architecture:** `shardd` calcule les 11 stats à partir de `(level, classId, factionId, gender)` et de tables **embarquées dans le binaire au build** (header C++ généré par CMake depuis `game/data/`). Le moteur (`CharacterStatsEngine`) est pur et compilé **uniquement** dans `shardd` (les multiplicateurs ne fuient jamais au client). L'extension `Unit`/`Player` ajoute les `UpdateField` de réplication delta. La taxonomie non secrète (factions/classes) vit dans `factions.json` (lisible client en PR2) ; les multiplicateurs secrets dans `character_stats.json`.
+
+**Tech Stack:** C++20, CMake (codegen via `cmake -P`), `engine::core::Config` (parseur JSON interne `JsonParser`/`MergeJsonFlatten`), tests « plain main() → 0/1 » enregistrés via `add_test`, CI GitHub (build-linux exécute ctest).
+
+---
+
+## Périmètre & reports (lire avant de commencer)
+
+**Dans PR1 :**
+- `game/data/races/factions.json` (NOUVEAU, taxonomie non secrète).
+- `game/data/gameplay/character_stats.json` (NOUVEAU, multiplicateurs — embarqué shardd).
+- Migration `0072_factions_v2.sql` (×2 arbres : `sql/migrations/` et `deploy/docker/sql/migrations/`).
+- `Config::LoadFromString` (parse JSON en mémoire, sans disque).
+- Codegen CMake (JSON → header `const`) + embarquement dans `server_app`.
+- `CharacterStatsTables` (parse les tables embarquées) + `CharacterStatsEngine` (calcul).
+- `Formulas.h` : nouvelle courbe XP paramétrée + `FormulasTests` mis à jour.
+- Extension `Unit`/`Player` + `UpdateFieldIndices.h` + `Player::ApplyDerivedStats`.
+- Tests serveur (ctest Linux).
+
+**Reporté en PR2 (client) — NE PAS toucher ici :**
+- `races.json` (flags `enabled`, suppression `corrompus`) → pairé avec la refonte UI et les tests client (`RaceDefinitionTests`, `CharacterCustomizationTests`) pour éviter de casser la CI Windows depuis une PR serveur.
+- Wire `factionId` (`CharacterPayloads`), `CharacterCreateHandler`, refonte `CharacterCreationUi`, localisation `faction.*`/`class.*`.
+
+**Différé — décision R1 (hors PR1, à trancher ensuite) :**
+- **Rendre les stats visibles au client live.** Constat d'audit : `entities::Player` n'est instancié qu'en tests ; la santé live passe par le chemin ECS `StatsComponent`/`SpawnEntity` (`src/shared/network/ReplicationTypes.h`), pas par `Unit`+`UpdateField`. PR1 livre le moteur + l'entité + les tests (capacité prouvée). Le câblage du moteur vers le chemin de réplication réellement consommé par le client est une décision séparée (étendre le snapshot ECS, ou adopter `Unit`/`Player` pour les joueurs live). **Ne pas l'implémenter dans PR1.**
+
+**Branche :** créer `feat/character-system-pr1-server` depuis `main`. Le spec de référence est `docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md` (valeurs §6.3 = source de vérité).
+
+---
+
+## File Structure
+
+| Fichier | Rôle |
+|---------|------|
+| `game/data/races/factions.json` (créer) | Taxonomie : 10 factions, classes (id/nom/sous-classe/profil/ressource), `selectable`. Non secret. |
+| `game/data/gameplay/character_stats.json` (créer) | Multiplicateurs : bases, `class_profiles`, `race_profiles`, `sex_profiles`, XP, cap crit. **Embarqué shardd**. |
+| `sql/migrations/0072_factions_v2.sql` + `deploy/docker/sql/migrations/0072_factions_v2.sql` (créer) | Aligne la table `factions` sur les ids courts + backfill. |
+| `cmake/EmbedJson.cmake` (créer) | Script `cmake -P` : fichier JSON → header `const char*` (raw string). |
+| `src/shared/core/Config.h` / `Config.cpp` (modifier) | Ajout `LoadFromString` (parse en mémoire). |
+| `src/shared/core/ConfigLoadFromStringTests.cpp` (créer) | Test du nouveau parseur en mémoire. |
+| `src/shardd/gameplay/character/CharacterStatsTables.{h,cpp}` (créer) | Charge les tables depuis les JSON embarqués (via `Config::LoadFromString`). |
+| `src/shardd/gameplay/character/CharacterStatsEngine.{h,cpp}` (créer) | Calcul déterministe des 11 stats. Compilé shardd-only. |
+| `src/shardd/gameplay/character/CharacterStatsEngineTests.cpp` (créer) | Tests moteur (anchors + invariants + round-trip). |
+| `src/shared/formulas/Formulas.h` (modifier) | Remplace `XpToNextLevel` par version paramétrée. |
+| `src/shared/formulas/FormulasTests.cpp` (modifier) | MAJ tests XP. |
+| `src/shardd/entities/UpdateFieldIndices.h` (modifier) | Nouveaux indices Unit (appended). |
+| `src/shardd/entities/Unit.h` (modifier) | Nouveaux `UpdateField` + accesseurs. |
+| `src/shardd/entities/UnitTests.cpp` (modifier) | Tests nouveaux champs. |
+| `src/shardd/entities/Player.h` / `Player.cpp` (modifier) | `ApplyDerivedStats`. |
+| `src/shardd/entities/PlayerTests.cpp` (modifier) | Test `ApplyDerivedStats`. |
+| `src/CMakeLists.txt` (modifier) | Sources + codegen + tests (branches Win **et** Linux de `server_app`). |
+
+---
+
+## Task 1: Branche de travail
+
+**Files:** (aucun fichier code)
+
+- [ ] **Step 1: Créer la branche depuis main**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+git checkout -b feat/character-system-pr1-server
+```
+
+- [ ] **Step 2: Vérifier l'état propre**
+
+Run: `git status`
+Expected: `On branch feat/character-system-pr1-server` / `nothing to commit, working tree clean`
+
+---
+
+## Task 2: `Config::LoadFromString` (parse JSON en mémoire)
+
+Le serveur doit parser les tables **embarquées** sans lire le disque. On factorise le chemin JSON de `LoadFromFile` dans une méthode publique réutilisable.
+
+**Files:**
+- Modify: `src/shared/core/Config.h`
+- Modify: `src/shared/core/Config.cpp:530-569`
+- Test: `src/shared/core/ConfigLoadFromStringTests.cpp` (créer)
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+Créer `src/shared/core/ConfigLoadFromStringTests.cpp` :
+
+```cpp
+// Test de Config::LoadFromString : parsing JSON depuis un buffer mémoire
+// (aucun accès disque). Sert l'embarquement anti-triche (tables compilées
+// dans le binaire shardd, lues via LoadFromString au boot).
+#include "src/shared/core/Config.h"
+#include "src/shared/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::core::Config;
+
+	bool TestParsesFlatObject()
+	{
+		Config cfg;
+		const std::string json = R"({ "a": { "b": 42 }, "name": "x" })";
+		if (!cfg.LoadFromString(json)) return false;
+		if (cfg.GetInt("a.b", -1) != 42) return false;
+		if (cfg.GetString("name", "") != "x") return false;
+		return true;
+	}
+
+	bool TestParsesArrayIndices()
+	{
+		Config cfg;
+		const std::string json = R"({ "items": [ { "id": "u" }, { "id": "v" } ] })";
+		if (!cfg.LoadFromString(json)) return false;
+		if (!cfg.Has("items[0].id")) return false;
+		if (cfg.GetString("items[0].id", "") != "u") return false;
+		if (cfg.GetString("items[1].id", "") != "v") return false;
+		if (cfg.Has("items[2].id")) return false;
+		return true;
+	}
+
+	bool TestRejectsNonObjectAndGarbage()
+	{
+		Config a; if (a.LoadFromString("not json")) return false;
+		Config b; if (b.LoadFromString("[1,2,3]")) return false; // racine non-objet
+		return true;
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+	const bool ok = TestParsesFlatObject() && TestParsesArrayIndices() && TestRejectsNonObjectAndGarbage();
+	if (ok) LOG_INFO(Core, "[ConfigLoadFromStringTests] ALL OK");
+	else    LOG_ERROR(Core, "[ConfigLoadFromStringTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}
+```
+
+- [ ] **Step 2: Déclarer la méthode dans le header**
+
+Dans `src/shared/core/Config.h`, après la déclaration de `LoadFromFile` (ligne 51) :
+
+```cpp
+		/// Parse un document JSON depuis un buffer mémoire (aucun accès disque).
+		/// Même sémantique que LoadFromFile pour du JSON : aplatit les objets en
+		/// clés pointées, les tableaux en indices `[i]`. Retourne false si le
+		/// texte n'est pas un JSON dont la racine est un objet.
+		/// Effet : fusionne les valeurs (priorité sur les défauts), comme LoadFromFile.
+		bool LoadFromString(std::string_view jsonText);
+```
+
+- [ ] **Step 3: Implémenter en factorisant le parseur JSON existant**
+
+Dans `src/shared/core/Config.cpp`, remplacer le bloc JSON de `LoadFromFile` (lignes 543-568, à partir du commentaire `// Default to JSON...`) par un appel à la nouvelle méthode, puis ajouter `LoadFromString` juste après `LoadFromFile`.
+
+Remplacer (dans `LoadFromFile`) :
+
+```cpp
+		// Default to JSON when extension is unknown.
+		std::stringstream ss;
+		ss << in.rdbuf();
+		const std::string text = ss.str();
+
+		JsonValue root;
+		JsonParser parser(text);
+		if (!parser.Parse(root))
+		{
+			return false;
+		}
+		if (root.type != JsonValue::Type::Object)
+		{
+			return false;
+		}
+
+		// Merge JSON into config by overriding defaults (file has higher priority than defaults).
+		// We flatten nested objects into dotted keys.
+		Config fileCfg;
+		MergeJsonFlatten(root, "", fileCfg);
+		for (const auto& [k, v] : fileCfg.m_values)
+		{
+			SetValue(k, v);
+		}
+
+		return true;
+	}
+```
+
+par :
+
+```cpp
+		// Default to JSON when extension is unknown : on délègue au parseur mémoire.
+		std::stringstream ss;
+		ss << in.rdbuf();
+		return LoadFromString(ss.str());
+	}
+
+	bool Config::LoadFromString(std::string_view jsonText)
+	{
+		JsonValue root;
+		JsonParser parser(std::string(jsonText));
+		if (!parser.Parse(root))
+		{
+			return false;
+		}
+		if (root.type != JsonValue::Type::Object)
+		{
+			return false;
+		}
+
+		// Merge JSON into config by overriding defaults (file has higher priority than defaults).
+		// On aplatit les objets imbriqués en clés pointées.
+		Config fileCfg;
+		MergeJsonFlatten(root, "", fileCfg);
+		for (const auto& [k, v] : fileCfg.m_values)
+		{
+			SetValue(k, v);
+		}
+
+		return true;
+	}
+```
+
+- [ ] **Step 4: Enregistrer le test dans CMake**
+
+Dans `src/CMakeLists.txt`, après le bloc d'un test existant (ex. `session_character_map_tests`, ~ligne 234-241), ajouter (zone Linux, près des autres `add_test`) :
+
+```cmake
+  add_executable(config_loadfromstring_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/core/ConfigLoadFromStringTests.cpp)
+  target_include_directories(config_loadfromstring_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(config_loadfromstring_tests PRIVATE engine_core spdlog::spdlog)
+  target_compile_options(config_loadfromstring_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME config_loadfromstring_tests COMMAND config_loadfromstring_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+```
+
+> Vérifier le nom exact de la lib qui contient `Config`/`Log` (probablement `engine_core`). Si `Config.cpp` est dans une autre cible, lier celle-ci. Inspecter `src/shared/CMakeLists.txt` pour confirmer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/core/Config.h src/shared/core/Config.cpp src/shared/core/ConfigLoadFromStringTests.cpp src/CMakeLists.txt
+git commit -m "feat(config): LoadFromString — parse JSON en mémoire (anti-triche embedding)"
+```
+
+> CI : pousser et vérifier `build-linux` (ctest) vert sur `config_loadfromstring_tests`. Pas de build local (cf. spec D7).
+
+---
+
+## Task 3: Données — `character_stats.json` (multiplicateurs, embarqué)
+
+Recopier les **valeurs §6.3 verbatim**. Ce fichier ne contient **que** les nombres (pas les noms factions/classes → ceux-ci vont dans `factions.json`, Task 4).
+
+**Files:**
+- Create: `game/data/gameplay/character_stats.json`
+
+- [ ] **Step 1: Créer le fichier**
+
+```json
+{
+  "schema_version": 1,
+  "level_max": 100,
+  "xp": { "formula": "base * level^factor", "factor": 2.6, "base": 6.185, "xp_per_hour_ref": 10000, "calibration": "niveau 60 ~= 420h de jeu" },
+  "bases": {
+    "hp":        { "lvl1": 100, "lvl100": 4000 },
+    "resource":  { "lvl1": 50,  "lvl100": 2000 },
+    "damage":    { "lvl1": 10,  "lvl100": 400 },
+    "accuracy":  { "lvl1": 70,  "lvl100": 95 },
+    "range":     { "lvl1": 20,  "lvl100": 45 },
+    "crit_rate": { "lvl1": 2,   "lvl100": 10, "cap": 10 },
+    "crit_mult": { "base": 1.5 },
+    "speed_walk": 2, "speed_run": 5, "speed_sprint": 8,
+    "stamina":   { "lvl1": 100, "lvl100": 1000 },
+    "stamina_cost_run_pct": 4, "stamina_cost_sprint_pct": 8,
+    "stamina_regen_t1_pct": 4, "stamina_regen_t2_pct": 7, "stamina_regen_t3_pct": 10,
+    "stamina_regen_idle_mult": 1.5,
+    "perception_lvl1": 10, "perception_per_level": 0.5
+  },
+  "class_profiles": {
+    "tank":     { "hp": 1.30, "resource": 0.80, "damage": 0.70, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.40, "crit_mult": 0.90, "speed": 0.85, "perception": 0.80, "stealth": 0.40 },
+    "melee":    { "hp": 1.15, "resource": 1.00, "damage": 1.05, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.70, "crit_mult": 1.00, "speed": 1.00, "perception": 0.90, "stealth": 0.70 },
+    "sacre":    { "hp": 1.10, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.70, "crit_mult": 1.00, "speed": 1.00, "perception": 0.95, "stealth": 0.70 },
+    "distance": { "hp": 0.90, "resource": 1.10, "damage": 1.15, "accuracy": 1.00, "range": 1.00, "crit_rate": 0.85, "crit_mult": 1.05, "speed": 1.00, "perception": 1.30, "stealth": 0.90 },
+    "pisteur":  { "hp": 0.95, "resource": 1.10, "damage": 1.10, "accuracy": 1.00, "range": 0.90, "crit_rate": 0.80, "crit_mult": 1.05, "speed": 1.10, "perception": 1.25, "stealth": 1.20 },
+    "voleur":   { "hp": 0.90, "resource": 1.10, "damage": 1.25, "accuracy": 1.00, "range": 0.30, "crit_rate": 1.00, "crit_mult": 1.20, "speed": 1.15, "perception": 1.00, "stealth": 1.40 },
+    "healer":   { "hp": 0.85, "resource": 1.20, "damage": 0.65, "accuracy": 1.00, "range": 0.70, "crit_rate": 0.40, "crit_mult": 0.90, "speed": 1.00, "perception": 1.00, "stealth": 0.70 },
+    "lanceur":  { "hp": 0.75, "resource": 1.30, "damage": 1.30, "accuracy": 1.00, "range": 1.10, "crit_rate": 0.70, "crit_mult": 1.20, "speed": 1.00, "perception": 1.15, "stealth": 0.60 }
+  },
+  "race_profiles": {
+    "humains": { "hp": 1.00, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 1.00, "crit_rate": 1.00, "crit_mult": 1.00, "speed_walk": 1.00, "speed_run": 1.00, "perception": 1.00, "stealth": 1.00 },
+    "nains":   { "hp": 1.20, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 0.95, "crit_rate": 0.90, "crit_mult": 1.05, "speed_walk": 0.85, "speed_run": 0.80, "perception": 0.90, "stealth": 0.80 },
+    "orcs":    { "hp": 1.15, "resource": 0.90, "damage": 1.20, "accuracy": 0.95, "range": 0.95, "crit_rate": 0.95, "crit_mult": 1.10, "speed_walk": 1.00, "speed_run": 1.00, "perception": 0.90, "stealth": 0.85 },
+    "elfes":   { "hp": 0.90, "resource": 1.10, "damage": 0.95, "accuracy": 1.10, "range": 1.15, "crit_rate": 1.10, "crit_mult": 0.95, "speed_walk": 1.05, "speed_run": 1.15, "perception": 1.25, "stealth": 1.20 },
+    "demons":  { "hp": 1.05, "resource": 1.20, "damage": 1.10, "accuracy": 1.00, "range": 1.00, "crit_rate": 1.00, "crit_mult": 1.10, "speed_walk": 1.00, "speed_run": 1.00, "perception": 1.05, "stealth": 0.90 }
+  },
+  "sex_profiles": {
+    "tank":     { "H": { "hp": 0.95, "crit_mult": 1.03 }, "F": { "hp": 1.05, "crit_mult": 0.97, "speed_walk": 1.08, "speed_run": 1.08 } },
+    "melee":    { "H": { "hp": 0.92, "damage": 1.08, "crit_mult": 1.05 }, "F": { "hp": 1.08, "damage": 0.92, "crit_mult": 0.95 } },
+    "sacre":    { "H": { "hp": 0.95, "damage": 1.06, "crit_mult": 1.04 }, "F": { "hp": 1.05, "resource": 1.06, "damage": 0.94, "crit_mult": 0.96 } },
+    "distance": { "H": { "resource": 1.08, "accuracy": 0.92, "range": 1.08, "crit_mult": 1.05 }, "F": { "resource": 0.92, "accuracy": 1.08, "range": 0.92, "crit_mult": 0.95 } },
+    "pisteur":  { "H": { "resource": 1.06, "accuracy": 0.94, "range": 1.06, "crit_mult": 1.04 }, "F": { "resource": 0.94, "accuracy": 1.06, "range": 0.94, "stealth": 1.06, "crit_mult": 0.96 } },
+    "voleur":   { "H": { "damage": 1.07, "stealth": 0.93, "crit_mult": 1.05 }, "F": { "damage": 0.93, "stealth": 1.07, "crit_mult": 0.95 } },
+    "healer":   { "H": { "hp": 0.95, "damage": 1.07, "accuracy": 0.94, "crit_mult": 1.04 }, "F": { "resource": 1.06, "damage": 0.93, "accuracy": 1.06, "crit_mult": 0.96 } },
+    "lanceur":  { "H": { "hp": 0.95, "resource": 0.92, "damage": 1.08, "accuracy": 0.94, "range": 1.06, "crit_mult": 1.05 }, "F": { "resource": 1.08, "damage": 0.92, "accuracy": 1.06, "range": 0.94, "crit_mult": 0.95 } }
+  }
+}
+```
+
+- [ ] **Step 2: Valider que c'est du JSON bien formé**
+
+Run: `python -c "import json;json.load(open('game/data/gameplay/character_stats.json'));print('OK')"`
+Expected: `OK`
+> (Outil de validation locale uniquement — n'introduit pas de dépendance build.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game/data/gameplay/character_stats.json
+git commit -m "feat(data): character_stats.json — bases/multiplicateurs/xp (valeurs §6.3)"
+```
+
+---
+
+## Task 4: Données — `factions.json` (taxonomie, non secrète)
+
+**Files:**
+- Create: `game/data/races/factions.json`
+
+- [ ] **Step 1: Créer le fichier** (ids courts alignés sur §6.3 ; `selectable`)
+
+```json
+{
+  "schema_version": 1,
+  "factions": [
+    { "id": "lumiere", "name": "Chevaliers de la Lumière", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "voleur", "name": "Voleur", "profile": "voleur", "resource": "reflexes" },
+      { "id": "inquisiteur_chatieur", "name": "Inquisiteur", "subclass": "Châtieur", "profile": "melee", "resource": "ferveur" },
+      { "id": "inquisiteur_hospitalier", "name": "Inquisiteur", "subclass": "Hospitalier", "profile": "healer", "resource": "ferveur" }
+    ] },
+    { "id": "justice", "name": "Chevaliers de la Justice", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "paladin", "name": "Paladin", "profile": "sacre", "resource": "ferveur" },
+      { "id": "pretre_jugement", "name": "Prêtre", "subclass": "du Jugement", "profile": "lanceur", "resource": "ferveur" },
+      { "id": "pretre_grace", "name": "Prêtre", "subclass": "de la Grâce", "profile": "healer", "resource": "ferveur" }
+    ] },
+    { "id": "lune_noire", "name": "La Lune Noire", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "arbaletrier", "name": "Arbalétrier", "profile": "distance", "resource": "souffle" },
+      { "id": "pretre_lune_noire", "name": "Prêtre de la Lune Noire", "profile": "lanceur", "resource": "devotion" },
+      { "id": "menthats", "name": "Menthats", "profile": "lanceur", "resource": "magie" }
+    ] },
+    { "id": "dzorak", "name": "Dzorak", "race": "orcs", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "chaman", "name": "Chaman", "profile": "lanceur", "resource": "transe" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "pisteur", "name": "Pisteur", "profile": "pisteur", "resource": "instinct" }
+    ] },
+    { "id": "legion", "name": "Légion infernale", "race": "demons", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "demoniste", "name": "Démoniste", "profile": "lanceur", "resource": "corruption" },
+      { "id": "tourmenteur", "name": "Tourmenteur", "profile": "melee", "resource": "corruption" },
+      { "id": "sorcier_sang", "name": "Sorcier de sang", "profile": "lanceur", "resource": "corruption" }
+    ] },
+    { "id": "dragons", "name": "Chevaliers-Dragons", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archimage", "name": "Archimage", "profile": "lanceur", "resource": "flamme_draconique" },
+      { "id": "dragonnier", "name": "Dragonnier", "profile": "melee", "resource": "furie_draconique" },
+      { "id": "gardien_ecailles", "name": "Gardien d'écailles", "profile": "tank", "resource": "ecaille" }
+    ] },
+    { "id": "serpent", "name": "Maison du Serpent", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archimage", "name": "Archimage", "profile": "lanceur", "resource": "magie_base" },
+      { "id": "assassin", "name": "Assassin", "profile": "voleur", "resource": "reflexes" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" }
+    ] },
+    { "id": "naine", "name": "Faction Naine", "race": "nains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "pisteur", "name": "Pisteur", "profile": "pisteur", "resource": "instinct" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" },
+      { "id": "brise_roc", "name": "Brise-roc", "profile": "tank", "resource": "endurance" }
+    ] },
+    { "id": "elfe", "name": "Faction Elfe", "race": "elfes", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer_bois", "name": "Archer", "subclass": "Bois", "profile": "distance", "resource": "souffle" },
+      { "id": "voleur_tenebreux", "name": "Voleur", "subclass": "Ténébreux", "profile": "voleur", "resource": "reflexes" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" }
+    ] },
+    { "id": "empire_hynn", "name": "L'Empire de L'hynn", "race": "humains", "selectable": false, "classes": [] }
+  ]
+}
+```
+
+- [ ] **Step 2: Valider JSON**
+
+Run: `python -c "import json;json.load(open('game/data/races/factions.json'));print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game/data/races/factions.json
+git commit -m "feat(data): factions.json — 9 factions jouables + empire_hynn (non sélectionnable)"
+```
+
+---
+
+## Task 5: Codegen CMake — JSON → header embarqué
+
+**Files:**
+- Create: `cmake/EmbedJson.cmake`
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1: Créer le script d'embarquement**
+
+`cmake/EmbedJson.cmake` :
+
+```cmake
+# EmbedJson.cmake — convertit un fichier JSON en header C++ exposant le contenu
+# comme const char* (raw string literal). Invoqué via `cmake -P` par un
+# add_custom_command. Paramètres : -DINPUT, -DOUTPUT, -DSYMBOL.
+# Aucun chemin absolu en dur ; tout vient des -D.
+if(NOT DEFINED INPUT OR NOT DEFINED OUTPUT OR NOT DEFINED SYMBOL)
+  message(FATAL_ERROR "EmbedJson.cmake : INPUT, OUTPUT et SYMBOL requis")
+endif()
+file(READ "${INPUT}" CONTENT)
+# Délimiteur de raw string improbable dans le JSON de jeu.
+set(GEN "// AUTO-GENERATED par EmbedJson.cmake — NE PAS EDITER.\n")
+string(APPEND GEN "// Source : ${INPUT}\n#pragma once\n")
+string(APPEND GEN "namespace engine::server::gameplay {\n")
+string(APPEND GEN "inline constexpr const char* ${SYMBOL} = R\"LCDLLN_EMBED(\n")
+string(APPEND GEN "${CONTENT}")
+string(APPEND GEN "\n)LCDLLN_EMBED\";\n}\n")
+file(WRITE "${OUTPUT}" "${GEN}")
+```
+
+- [ ] **Step 2: Ajouter les commandes de génération dans `src/CMakeLists.txt`**
+
+À placer **avant** la définition de `server_app` (les deux branches), au niveau racine du fichier (zone commune) :
+
+```cmake
+# ── Embarquement anti-triche : JSON game/data → headers const (générés au build).
+set(LCDLLN_GEN_DIR ${CMAKE_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${LCDLLN_GEN_DIR})
+
+set(STATS_JSON    ${CMAKE_SOURCE_DIR}/game/data/gameplay/character_stats.json)
+set(STATS_HDR     ${LCDLLN_GEN_DIR}/CharacterStatsData.h)
+set(FACTIONS_JSON ${CMAKE_SOURCE_DIR}/game/data/races/factions.json)
+set(FACTIONS_HDR  ${LCDLLN_GEN_DIR}/FactionsData.h)
+
+add_custom_command(
+  OUTPUT  ${STATS_HDR}
+  COMMAND ${CMAKE_COMMAND} -DINPUT=${STATS_JSON} -DOUTPUT=${STATS_HDR} -DSYMBOL=kCharacterStatsJson -P ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  DEPENDS ${STATS_JSON} ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  COMMENT "Embedding character_stats.json -> CharacterStatsData.h")
+
+add_custom_command(
+  OUTPUT  ${FACTIONS_HDR}
+  COMMAND ${CMAKE_COMMAND} -DINPUT=${FACTIONS_JSON} -DOUTPUT=${FACTIONS_HDR} -DSYMBOL=kFactionsJson -P ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  DEPENDS ${FACTIONS_JSON} ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  COMMENT "Embedding factions.json -> FactionsData.h")
+
+add_custom_target(lcdlln_gen_character_data DEPENDS ${STATS_HDR} ${FACTIONS_HDR})
+```
+
+> Les cibles qui incluent les headers générés devront : `add_dependencies(<cible> lcdlln_gen_character_data)` et `target_include_directories(<cible> PRIVATE ${LCDLLN_GEN_DIR})`. C'est fait dans les Tasks 7 et 11.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmake/EmbedJson.cmake src/CMakeLists.txt
+git commit -m "build(cmake): codegen JSON->header pour embarquement anti-triche shardd"
+```
+
+---
+
+## Task 6: `Formulas.h` — nouvelle courbe XP paramétrée
+
+**Files:**
+- Modify: `src/shared/formulas/Formulas.h:10-18`
+- Modify: `src/shared/formulas/FormulasTests.cpp:8-18`
+
+- [ ] **Step 1: Mettre à jour le test (échoue avant impl)**
+
+Remplacer `TestXpProgression` dans `src/shared/formulas/FormulasTests.cpp` par :
+
+```cpp
+	bool TestXpProgression()
+	{
+		// Params du design (character_stats.json) passés explicitement.
+		constexpr double kBase = 6.185;
+		constexpr double kFactor = 2.6;
+		constexpr uint8_t kMax = 100;
+
+		// Cap : 0 hors plage et au niveau max.
+		if (XpToNextLevel(0,   kBase, kFactor, kMax) != 0) return false;
+		if (XpToNextLevel(100, kBase, kFactor, kMax) != 0) return false;
+		// Positivité sur 1..99.
+		if (XpToNextLevel(1,  kBase, kFactor, kMax) == 0) return false;
+		if (XpToNextLevel(99, kBase, kFactor, kMax) == 0) return false;
+		// Monotonie stricte.
+		if (!(XpToNextLevel(1, kBase, kFactor, kMax) < XpToNextLevel(2, kBase, kFactor, kMax))) return false;
+		if (!(XpToNextLevel(2, kBase, kFactor, kMax) < XpToNextLevel(99, kBase, kFactor, kMax))) return false;
+		// Ancrage forme : XP(10) ~= round(6.185 * 10^2.6) = round(6.185 * 398.107) = 2463.
+		const uint32_t x10 = XpToNextLevel(10, kBase, kFactor, kMax);
+		if (x10 < 2460u || x10 > 2466u) return false;
+		LOG_INFO(Core, "[FormulasTests] xp progression OK");
+		return true;
+	}
+```
+
+- [ ] **Step 2: Lancer le test → échec attendu**
+
+Run (CI build-linux) : `ctest -R formulas`
+Expected: FAIL compilation (signature `XpToNextLevel` à 1 argument).
+
+- [ ] **Step 3: Remplacer `XpToNextLevel` dans `Formulas.h`**
+
+Remplacer les lignes 10-18 par :
+
+```cpp
+	/// XP requis pour passer du niveau \p level au level+1.
+	/// Courbe du design : round(base * level^factor). Paramètres fournis par
+	/// l'appelant (issus de character_stats.json embarqué côté serveur) — JAMAIS
+	/// codés en dur ici. Renvoie 0 si level == 0 ou level >= levelMax (cap).
+	/// \param base   coefficient multiplicateur de la courbe.
+	/// \param factor exposant (2.6 dans le design).
+	/// \param levelMax niveau maximum (100) ; au-delà, plus de progression.
+	inline uint32_t XpToNextLevel(uint8_t level, double base, double factor, uint8_t levelMax)
+	{
+		if (level == 0 || level >= levelMax) return 0;
+		const double xp = base * std::pow(static_cast<double>(level), factor);
+		if (xp <= 0.0) return 0;
+		return static_cast<uint32_t>(xp + 0.5); // round-half-up
+	}
+```
+
+Ajouter l'include `<cmath>` en tête de `Formulas.h` (après `<algorithm>`) :
+
+```cpp
+#include <cmath>
+```
+
+- [ ] **Step 4: Lancer le test → succès attendu**
+
+Run (CI) : `ctest -R formulas`
+Expected: PASS `[FormulasTests] ALL OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/formulas/Formulas.h src/shared/formulas/FormulasTests.cpp
+git commit -m "feat(formulas): courbe XP paramétrée base*N^2.6 cap 100 (remplace cubique cap 80)"
+```
+
+---
+
+## Task 7: `CharacterStatsTables` + `CharacterStatsEngine`
+
+Le cœur : parser les tables embarquées et calculer les 11 stats.
+
+**Files:**
+- Create: `src/shardd/gameplay/character/CharacterStatsTables.h`
+- Create: `src/shardd/gameplay/character/CharacterStatsTables.cpp`
+- Create: `src/shardd/gameplay/character/CharacterStatsEngine.h`
+- Create: `src/shardd/gameplay/character/CharacterStatsEngine.cpp`
+- Test: `src/shardd/gameplay/character/CharacterStatsEngineTests.cpp`
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1: Définir les structures de tables (`CharacterStatsTables.h`)**
+
+```cpp
+#pragma once
+// CharacterStatsTables : tables de stats chargées depuis le JSON embarqué
+// (character_stats.json) + la taxonomie embarquée (factions.json). Construites
+// une fois au boot via FromEmbedded(). Aucun accès disque (anti-triche).
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server::gameplay
+{
+	/// Base d'une stat interpolée linéairement lvl1 -> lvl100.
+	struct StatBase { double lvl1 = 0.0; double lvl100 = 0.0; };
+
+	/// Multiplicateurs d'un profil d'archétype (class_profiles).
+	/// Ordre logique : hp,resource,damage,accuracy,range,crit_rate,crit_mult,speed,perception,stealth.
+	struct ClassProfile
+	{
+		double hp=1, resource=1, damage=1, accuracy=1, range=1,
+		       crit_rate=1, crit_mult=1, speed=1, perception=1, stealth=1;
+	};
+
+	/// Multiplicateurs d'une race (race_profiles). speed_walk/speed_run séparés.
+	struct RaceProfile
+	{
+		double hp=1, resource=1, damage=1, accuracy=1, range=1,
+		       crit_rate=1, crit_mult=1, speed_walk=1, speed_run=1, perception=1, stealth=1;
+	};
+
+	/// Multiplicateurs de sexe pour un profil (clés absentes = 1.0).
+	/// On stocke par nom de stat pour gérer l'absence (get(stat,1.0)).
+	struct SexMods { std::unordered_map<std::string,double> H; std::unordered_map<std::string,double> F; };
+
+	/// Une classe dans une faction (factions.json) : mapping vers profil + ressource.
+	struct ClassEntry { std::string id; std::string profile; std::string resource; };
+
+	/// Une faction (factions.json).
+	struct FactionEntry { std::string id; std::string race; bool selectable=false;
+	                      std::unordered_map<std::string, ClassEntry> classesById; };
+
+	/// Ensemble des tables, prêt pour le calcul.
+	struct CharacterStatsTables
+	{
+		uint32_t levelMax = 100;
+		double xpBase = 0.0, xpFactor = 0.0;
+
+		std::unordered_map<std::string, StatBase> bases; // hp,resource,damage,accuracy,range,crit_rate,stamina
+		double critMultBase = 1.5;
+		double critRateCap = 10.0;
+		double speedWalkBase = 2.0, speedRunBase = 5.0, speedSprintBase = 8.0;
+		double perceptionLvl1 = 10.0, perceptionPerLevel = 0.5;
+
+		std::unordered_map<std::string, ClassProfile> classProfiles;
+		std::unordered_map<std::string, RaceProfile>  raceProfiles;
+		std::unordered_map<std::string, SexMods>      sexProfiles; // clé = profil
+		std::unordered_map<std::string, FactionEntry> factions;    // clé = factionId
+
+		/// Construit les tables depuis les chaînes JSON embarquées.
+		/// \param statsJson contenu de character_stats.json (kCharacterStatsJson).
+		/// \param factionsJson contenu de factions.json (kFactionsJson).
+		/// \return nullopt si un JSON est invalide ou incomplet.
+		static std::optional<CharacterStatsTables> FromEmbedded(
+			const char* statsJson, const char* factionsJson);
+	};
+}
+```
+
+- [ ] **Step 2: Implémenter le parsing (`CharacterStatsTables.cpp`)**
+
+```cpp
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shared/core/Config.h"
+
+#include <string>
+
+namespace engine::server::gameplay
+{
+	namespace
+	{
+		using engine::core::Config;
+
+		ClassProfile ParseClassProfile(const Config& c, const std::string& p)
+		{
+			ClassProfile cp;
+			cp.hp         = c.GetDouble(p + ".hp", 1.0);
+			cp.resource   = c.GetDouble(p + ".resource", 1.0);
+			cp.damage     = c.GetDouble(p + ".damage", 1.0);
+			cp.accuracy   = c.GetDouble(p + ".accuracy", 1.0);
+			cp.range      = c.GetDouble(p + ".range", 1.0);
+			cp.crit_rate  = c.GetDouble(p + ".crit_rate", 1.0);
+			cp.crit_mult  = c.GetDouble(p + ".crit_mult", 1.0);
+			cp.speed      = c.GetDouble(p + ".speed", 1.0);
+			cp.perception = c.GetDouble(p + ".perception", 1.0);
+			cp.stealth    = c.GetDouble(p + ".stealth", 1.0);
+			return cp;
+		}
+
+		RaceProfile ParseRaceProfile(const Config& c, const std::string& p)
+		{
+			RaceProfile rp;
+			rp.hp         = c.GetDouble(p + ".hp", 1.0);
+			rp.resource   = c.GetDouble(p + ".resource", 1.0);
+			rp.damage     = c.GetDouble(p + ".damage", 1.0);
+			rp.accuracy   = c.GetDouble(p + ".accuracy", 1.0);
+			rp.range      = c.GetDouble(p + ".range", 1.0);
+			rp.crit_rate  = c.GetDouble(p + ".crit_rate", 1.0);
+			rp.crit_mult  = c.GetDouble(p + ".crit_mult", 1.0);
+			rp.speed_walk = c.GetDouble(p + ".speed_walk", 1.0);
+			rp.speed_run  = c.GetDouble(p + ".speed_run", 1.0);
+			rp.perception = c.GetDouble(p + ".perception", 1.0);
+			rp.stealth    = c.GetDouble(p + ".stealth", 1.0);
+			return rp;
+		}
+
+		// Lit les sous-clés connues d'un profil de sexe (clé absente = non insérée => 1.0 au calcul).
+		void ParseSexSide(const Config& c, const std::string& p, std::unordered_map<std::string,double>& out)
+		{
+			static const char* kStats[] = { "hp","resource","damage","accuracy","range",
+			                                 "crit_mult","speed_walk","speed_run","perception","stealth" };
+			for (const char* s : kStats)
+			{
+				const std::string key = p + "." + s;
+				if (c.Has(key)) out[s] = c.GetDouble(key, 1.0);
+			}
+		}
+	}
+
+	std::optional<CharacterStatsTables> CharacterStatsTables::FromEmbedded(
+		const char* statsJson, const char* factionsJson)
+	{
+		if (!statsJson || !factionsJson) return std::nullopt;
+
+		Config s;
+		if (!s.LoadFromString(statsJson)) return std::nullopt;
+		Config f;
+		if (!f.LoadFromString(factionsJson)) return std::nullopt;
+
+		CharacterStatsTables t;
+		t.levelMax = static_cast<uint32_t>(s.GetInt("level_max", 100));
+		t.xpBase   = s.GetDouble("xp.base", 0.0);
+		t.xpFactor = s.GetDouble("xp.factor", 0.0);
+		if (t.levelMax < 2 || t.xpBase <= 0.0 || t.xpFactor <= 0.0) return std::nullopt;
+
+		auto base = [&](const char* name) {
+			StatBase b; b.lvl1 = s.GetDouble(std::string("bases.") + name + ".lvl1", 0.0);
+			b.lvl100 = s.GetDouble(std::string("bases.") + name + ".lvl100", 0.0); return b; };
+		t.bases["hp"]        = base("hp");
+		t.bases["resource"]  = base("resource");
+		t.bases["damage"]    = base("damage");
+		t.bases["accuracy"]  = base("accuracy");
+		t.bases["range"]     = base("range");
+		t.bases["crit_rate"] = base("crit_rate");
+		t.bases["stamina"]   = base("stamina");
+		t.critMultBase     = s.GetDouble("bases.crit_mult.base", 1.5);
+		t.critRateCap      = s.GetDouble("bases.crit_rate.cap", 10.0);
+		t.speedWalkBase    = s.GetDouble("bases.speed_walk", 2.0);
+		t.speedRunBase     = s.GetDouble("bases.speed_run", 5.0);
+		t.speedSprintBase  = s.GetDouble("bases.speed_sprint", 8.0);
+		t.perceptionLvl1   = s.GetDouble("bases.perception_lvl1", 10.0);
+		t.perceptionPerLevel = s.GetDouble("bases.perception_per_level", 0.5);
+
+		for (const char* p : { "tank","melee","sacre","distance","pisteur","voleur","healer","lanceur" })
+			t.classProfiles[p] = ParseClassProfile(s, std::string("class_profiles.") + p);
+		for (const char* r : { "humains","nains","orcs","elfes","demons" })
+			t.raceProfiles[r] = ParseRaceProfile(s, std::string("race_profiles.") + r);
+		for (const char* p : { "tank","melee","sacre","distance","pisteur","voleur","healer","lanceur" })
+		{
+			SexMods sm;
+			ParseSexSide(s, std::string("sex_profiles.") + p + ".H", sm.H);
+			ParseSexSide(s, std::string("sex_profiles.") + p + ".F", sm.F);
+			t.sexProfiles[p] = std::move(sm);
+		}
+
+		// Factions (factions.json).
+		size_t i = 0;
+		while (f.Has("factions[" + std::to_string(i) + "].id"))
+		{
+			const std::string fp = "factions[" + std::to_string(i) + "]";
+			FactionEntry fe;
+			fe.id         = f.GetString(fp + ".id", "");
+			fe.race       = f.GetString(fp + ".race", "");
+			fe.selectable = f.GetBool(fp + ".selectable", false);
+			size_t j = 0;
+			while (f.Has(fp + ".classes[" + std::to_string(j) + "].id"))
+			{
+				const std::string cp = fp + ".classes[" + std::to_string(j) + "]";
+				ClassEntry ce;
+				ce.id       = f.GetString(cp + ".id", "");
+				ce.profile  = f.GetString(cp + ".profile", "");
+				ce.resource = f.GetString(cp + ".resource", "");
+				if (!ce.id.empty()) fe.classesById[ce.id] = std::move(ce);
+				++j;
+			}
+			if (!fe.id.empty()) t.factions[fe.id] = std::move(fe);
+			++i;
+		}
+		if (t.factions.empty()) return std::nullopt;
+		return t;
+	}
+}
+```
+
+- [ ] **Step 3: Définir le moteur (`CharacterStatsEngine.h`)**
+
+```cpp
+#pragma once
+// CharacterStatsEngine : calcul déterministe des 11 stats à partir des tables
+// embarquées + (level, factionId, classId, gender). Pur, compilé shardd-only.
+
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace engine::server::gameplay
+{
+	/// Sexe du personnage.
+	enum class Sex : uint8_t { Male, Female };
+
+	/// Résultat : les 11 stats dérivées (valeurs finales, jamais les multiplicateurs).
+	struct DerivedStats
+	{
+		uint32_t hp = 0;            ///< PV max.
+		uint32_t resource = 0;      ///< ressource secondaire max.
+		uint32_t damage = 0;
+		float    accuracy = 0.0f;   ///< précision %.
+		float    range = 0.0f;      ///< portée m (0 si mêlée pure).
+		float    critRate = 0.0f;   ///< taux de crit % (cap 10).
+		float    critMult = 0.0f;   ///< multiplicateur de crit ×.
+		float    speedWalk = 0.0f;
+		float    speedRun = 0.0f;
+		float    speedSprint = 0.0f;
+		uint32_t stamina = 0;       ///< endurance max.
+		float    perception = 0.0f; ///< m.
+		float    stealth = 0.0f;    ///< discrétion m (bas = discret).
+		std::string resourceKey;    ///< clé de ressource secondaire (ex. "ferveur").
+	};
+
+	/// Calcule les stats pour un personnage. Renvoie nullopt si la faction/classe
+	/// est inconnue ou si le profil/la race référencés n'existent pas dans les tables.
+	std::optional<DerivedStats> ComputeStats(const CharacterStatsTables& t,
+	                                          const std::string& factionId,
+	                                          const std::string& classId,
+	                                          Sex sex, uint32_t level);
+}
+```
+
+- [ ] **Step 4: Implémenter le moteur (`CharacterStatsEngine.cpp`)**
+
+```cpp
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::server::gameplay
+{
+	namespace
+	{
+		// Interpolation linéaire lvl1 -> lvl100 (clamp level dans [1, levelMax]).
+		double BaseAt(const StatBase& b, uint32_t level, uint32_t levelMax)
+		{
+			const uint32_t N = std::clamp<uint32_t>(level, 1u, levelMax);
+			if (levelMax <= 1) return b.lvl1;
+			return b.lvl1 + (static_cast<double>(N) - 1.0) * (b.lvl100 - b.lvl1)
+			              / (static_cast<double>(levelMax) - 1.0);
+		}
+
+		double SexGet(const std::unordered_map<std::string,double>& m, const char* stat)
+		{
+			auto it = m.find(stat);
+			return it == m.end() ? 1.0 : it->second;
+		}
+
+		uint32_t RoundU(double v) { return v <= 0.0 ? 0u : static_cast<uint32_t>(v + 0.5); }
+	}
+
+	std::optional<DerivedStats> ComputeStats(const CharacterStatsTables& t,
+	                                          const std::string& factionId,
+	                                          const std::string& classId,
+	                                          Sex sex, uint32_t level)
+	{
+		auto fit = t.factions.find(factionId);
+		if (fit == t.factions.end()) return std::nullopt;
+		auto cit = fit->second.classesById.find(classId);
+		if (cit == fit->second.classesById.end()) return std::nullopt;
+
+		const std::string& profile = cit->second.profile;
+		const std::string& race    = fit->second.race;
+
+		auto pit = t.classProfiles.find(profile);
+		auto rit = t.raceProfiles.find(race);
+		auto sit = t.sexProfiles.find(profile);
+		if (pit == t.classProfiles.end() || rit == t.raceProfiles.end()) return std::nullopt;
+
+		const ClassProfile& cp = pit->second;
+		const RaceProfile&  rp = rit->second;
+		const auto& sx = (sit != t.sexProfiles.end())
+			? (sex == Sex::Male ? sit->second.H : sit->second.F)
+			: std::unordered_map<std::string,double>{};
+
+		const uint32_t lvlMax = t.levelMax;
+		auto B = [&](const char* name) -> double {
+			auto it = t.bases.find(name); return it == t.bases.end() ? 0.0 : BaseAt(it->second, level, lvlMax); };
+
+		DerivedStats d;
+		d.resourceKey = cit->second.resource;
+
+		d.hp       = RoundU(B("hp")       * cp.hp       * rp.hp       * SexGet(sx, "hp"));
+		d.resource = RoundU(B("resource") * cp.resource * rp.resource * SexGet(sx, "resource"));
+		d.damage   = RoundU(B("damage")   * cp.damage   * rp.damage   * SexGet(sx, "damage"));
+		d.stamina  = RoundU(B("stamina"));
+
+		// Mêlée pure : range profil == 0 -> portée ET précision nulles.
+		if (cp.range == 0.0)
+		{
+			d.range = 0.0f;
+			d.accuracy = 0.0f;
+		}
+		else
+		{
+			d.range    = static_cast<float>(B("range")    * cp.range    * rp.range    * SexGet(sx, "range"));
+			d.accuracy = static_cast<float>(B("accuracy") * cp.accuracy * rp.accuracy * SexGet(sx, "accuracy"));
+		}
+
+		// Crit rate : plafond garanti par la formule (jamais > cap).
+		const double critRaw = B("crit_rate") * cp.crit_rate * rp.crit_rate; // crit neutre au sexe
+		d.critRate = static_cast<float>(std::min(t.critRateCap, critRaw));
+
+		d.critMult = static_cast<float>(t.critMultBase * cp.crit_mult * rp.crit_mult * SexGet(sx, "crit_mult"));
+
+		// Vitesses : marche = walk ; course/sprint = base run (cf. spec §5).
+		d.speedWalk   = static_cast<float>(t.speedWalkBase  * cp.speed * rp.speed_walk * SexGet(sx, "speed_walk"));
+		d.speedRun    = static_cast<float>(t.speedRunBase   * cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
+		d.speedSprint = static_cast<float>(t.speedSprintBase* cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
+
+		const double perceptionBase = t.perceptionLvl1 + t.perceptionPerLevel * (static_cast<double>(std::max(1u, level)) - 1.0);
+		d.perception = static_cast<float>(perceptionBase * cp.perception * rp.perception * SexGet(sx, "perception"));
+
+		// Discrétion = (perception_base / 2) / (stealth classe*race*sexe). Bas = discret.
+		const double stealthDiv = cp.stealth * rp.stealth * SexGet(sx, "stealth");
+		d.stealth = static_cast<float>(stealthDiv > 0.0 ? (perceptionBase / 2.0) / stealthDiv : 0.0);
+
+		return d;
+	}
+}
+```
+
+- [ ] **Step 5: Écrire les tests (`CharacterStatsEngineTests.cpp`)**
+
+```cpp
+// Tests du moteur de stats : round-trip JSON embarqué -> tables -> calcul,
+// ancres exactes (niveau 1 et 60), invariants (cap crit, mêlée pure).
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shared/core/Log.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
+
+#include <cmath>
+
+namespace
+{
+	using namespace engine::server::gameplay;
+
+	bool nearF(float a, double b, double tol = 0.6) { return std::fabs(static_cast<double>(a) - b) <= tol; }
+
+	bool TestRoundTripAndAnchorsLvl1()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+
+		// Voleur Elfe F niv.1 (faction elfe -> race elfes, classe voleur_tenebreux -> profil voleur).
+		auto d = ComputeStats(*t, "elfe", "voleur_tenebreux", Sex::Female, 1);
+		if (!d) return false;
+		// hp = base(1)=100 * voleur.hp 0.90 * elfes.hp 0.90 * sex(absent)=1 = 81
+		if (d->hp != 81u) return false;
+		// damage = 10 * 1.25 * 0.95 * sex voleur F damage 0.93 = 11.04 -> 11
+		if (d->damage != 11u) return false;
+		// crit_rate = 2 * voleur 1.00 * elfes 1.10 = 2.2 (neutre sexe), < cap 10
+		if (!nearF(d->critRate, 2.2)) return false;
+		if (d->resourceKey != "reflexes") return false;
+		return true;
+	}
+
+	bool TestAnchorLvl60_GuerrierNainH()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		// Guerrier Nain H niv.60 (faction naine -> nains, classe guerrier -> melee).
+		auto d = ComputeStats(*t, "naine", "guerrier", Sex::Male, 60);
+		if (!d) return false;
+		// base hp(60) = 100 + 59*(3900)/99 = 2424.2424
+		// hp = 2424.2424 * melee.hp 1.15 * nains.hp 1.20 * sex melee H hp 0.92 ~= 3078
+		if (d->hp < 3076u || d->hp > 3080u) return false;
+		// melee : mêlée pure -> range 0 ET accuracy 0
+		if (d->range != 0.0f) return false;
+		if (d->accuracy != 0.0f) return false;
+		return true;
+	}
+
+	bool TestCritCapAndUnknownAndLanceurLvl100()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+
+		// Lanceur Démon F niv.100 (faction legion -> demons, classe demoniste -> lanceur).
+		auto d = ComputeStats(*t, "legion", "demoniste", Sex::Female, 100);
+		if (!d) return false;
+		// crit jamais > cap 10
+		if (d->critRate > 10.0f) return false;
+		// lanceur a une portée (range profil 1.10 != 0) -> accuracy > 0
+		if (!(d->range > 0.0f) || !(d->accuracy > 0.0f)) return false;
+		if (d->resourceKey != "corruption") return false;
+
+		// Faction/classe inconnue -> nullopt
+		if (ComputeStats(*t, "inconnue", "guerrier", Sex::Male, 1)) return false;
+		if (ComputeStats(*t, "naine", "inconnue", Sex::Male, 1)) return false;
+		return true;
+	}
+
+	bool TestDeterminism()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		auto a = ComputeStats(*t, "dzorak", "pisteur", Sex::Male, 42);
+		auto b = ComputeStats(*t, "dzorak", "pisteur", Sex::Male, 42);
+		if (!a || !b) return false;
+		return a->hp == b->hp && a->damage == b->damage && nearF(a->stealth, b->stealth, 0.0001);
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+	const bool ok = TestRoundTripAndAnchorsLvl1()
+	             && TestAnchorLvl60_GuerrierNainH()
+	             && TestCritCapAndUnknownAndLanceurLvl100()
+	             && TestDeterminism();
+	if (ok) LOG_INFO(Core, "[CharacterStatsEngineTests] ALL OK");
+	else    LOG_ERROR(Core, "[CharacterStatsEngineTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}
+```
+
+- [ ] **Step 6: Enregistrer sources + test dans `src/CMakeLists.txt`**
+
+Ajouter les deux `.cpp` aux **deux** listes sources de `server_app` (branche MSVC/Windows ~ligne 18-66 et branche Linux ~ligne 75-227), près des autres `gameplay/character/*` :
+
+```cmake
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+```
+
+Puis brancher la dépendance codegen + include sur `server_app` (dans chaque branche, après sa définition) :
+
+```cmake
+  add_dependencies(server_app lcdlln_gen_character_data)
+  target_include_directories(server_app PRIVATE ${LCDLLN_GEN_DIR})
+```
+
+Enfin, le test (zone Linux des tests) :
+
+```cmake
+  add_executable(character_stats_engine_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(character_stats_engine_tests lcdlln_gen_character_data)
+  target_include_directories(character_stats_engine_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(character_stats_engine_tests PRIVATE engine_core spdlog::spdlog)
+  target_compile_options(character_stats_engine_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME character_stats_engine_tests COMMAND character_stats_engine_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shardd/gameplay/character/CharacterStatsTables.h src/shardd/gameplay/character/CharacterStatsTables.cpp \
+        src/shardd/gameplay/character/CharacterStatsEngine.h src/shardd/gameplay/character/CharacterStatsEngine.cpp \
+        src/shardd/gameplay/character/CharacterStatsEngineTests.cpp src/CMakeLists.txt
+git commit -m "feat(shardd): CharacterStatsEngine — 11 stats déterministes depuis tables embarquées"
+```
+
+> CI : vérifier `build-linux` → `ctest -R character_stats_engine_tests` vert. Si un anchor échoue, comparer l'arithmétique (ordre : base(N) double → ×profil ×race ×sexe → round une seule fois).
+
+---
+
+## Task 8: Extension `Unit` — nouveaux `UpdateField`
+
+**Files:**
+- Modify: `src/shardd/entities/UpdateFieldIndices.h:47-59`
+- Modify: `src/shardd/entities/Unit.h`
+- Modify: `src/shardd/entities/UnitTests.cpp`
+
+- [ ] **Step 1: Écrire le test des nouveaux champs (échoue)**
+
+Ajouter dans `src/shardd/entities/UnitTests.cpp` une fonction de test (et l'appeler depuis `main`) :
+
+```cpp
+	bool TestNewStatFields()
+	{
+		using namespace engine::server::entities;
+		Unit u(ObjectGuid{ 1 });
+		u.SetDamage(123u);
+		u.SetCritRate(7.5f);
+		u.SetCritMult(1.8f);
+		u.SetSpeedWalk(2.0f); u.SetSpeedRun(5.0f); u.SetSpeedSprint(8.0f);
+		u.SetStamina(500u); u.SetMaxStamina(800u);
+		u.SetPerception(12.5f); u.SetStealth(9.0f);
+		u.SetAccuracy(88.0f); u.SetRange(30.0f);
+		u.SetSecondaryResource(40u); u.SetMaxSecondaryResource(100u);
+
+		if (u.GetDamage() != 123u) return false;
+		if (u.GetCritRate() < 7.49f || u.GetCritRate() > 7.51f) return false;
+		if (u.GetMaxStamina() != 800u) return false;
+		if (u.GetSecondaryResource() != 40u) return false;
+		// Le mask doit refléter au moins un champ modifié.
+		if (u.Mask().Empty()) return false;
+		return true;
+	}
+```
+
+> Vérifier dans `UnitTests.cpp` comment `main` agrège les tests et y ajouter `&& TestNewStatFields()`. Vérifier l'accès au mask (méthode `Mask()` héritée d'`Object` — confirmer son nom exact dans `Object.h`).
+
+- [ ] **Step 2: Ajouter les indices (appended) dans `UpdateFieldIndices.h`**
+
+Remplacer l'enum `UnitFieldIdx` (lignes 47-59) par :
+
+```cpp
+	/// Indices pour Unit (extends WorldObject). Demarre apres WorldObject end.
+	/// IMPORTANT : ne JAMAIS reordonner/reassigner ; ajouter en fin avant kUnitFieldEnd.
+	enum UnitFieldIdx : size_t
+	{
+		kUnitFieldHealth      = kWorldObjectFieldEnd,      // 11
+		kUnitFieldMaxHealth   = kWorldObjectFieldEnd + 1,  // 12
+		kUnitFieldMana        = kWorldObjectFieldEnd + 2,  // 13
+		kUnitFieldMaxMana     = kWorldObjectFieldEnd + 3,  // 14
+		kUnitFieldLevel       = kWorldObjectFieldEnd + 4,  // 15
+		kUnitFieldFaction     = kWorldObjectFieldEnd + 5,  // 16
+		// --- Stats étendues (Système de Personnages) ---
+		kUnitFieldDamage              = kWorldObjectFieldEnd + 6,  // 17
+		kUnitFieldAccuracy            = kWorldObjectFieldEnd + 7,  // 18
+		kUnitFieldRange               = kWorldObjectFieldEnd + 8,  // 19
+		kUnitFieldCritRate            = kWorldObjectFieldEnd + 9,  // 20
+		kUnitFieldCritMult            = kWorldObjectFieldEnd + 10, // 21
+		kUnitFieldSpeedWalk           = kWorldObjectFieldEnd + 11, // 22
+		kUnitFieldSpeedRun            = kWorldObjectFieldEnd + 12, // 23
+		kUnitFieldSpeedSprint         = kWorldObjectFieldEnd + 13, // 24
+		kUnitFieldStamina             = kWorldObjectFieldEnd + 14, // 25
+		kUnitFieldMaxStamina          = kWorldObjectFieldEnd + 15, // 26
+		kUnitFieldPerception          = kWorldObjectFieldEnd + 16, // 27
+		kUnitFieldStealth             = kWorldObjectFieldEnd + 17, // 28
+		kUnitFieldSecondaryResource   = kWorldObjectFieldEnd + 18, // 29
+		kUnitFieldMaxSecondaryResource= kWorldObjectFieldEnd + 19, // 30
+
+		kUnitFieldEnd         = kWorldObjectFieldEnd + 20   // 31
+	};
+```
+
+> `kPlayerFieldIdx` et `kCreatureFieldIdx` démarrent à `kUnitFieldEnd` : ils se décalent automatiquement (les valeurs Player/Creature passent de 17.. à 31..). C'est attendu (wire format Player/Creature non encore gelé en prod ; aucun client live ne consomme ce path — cf. R1).
+
+- [ ] **Step 3: Ajouter les `UpdateField` + accesseurs dans `Unit.h`**
+
+Dans le constructeur `Unit(...)`, après l'init de `m_faction` (ligne 34), ajouter aux initialisations :
+
+```cpp
+			, m_damage(kUnitFieldDamage, &Mask())
+			, m_accuracy(kUnitFieldAccuracy, &Mask())
+			, m_range(kUnitFieldRange, &Mask())
+			, m_critRate(kUnitFieldCritRate, &Mask())
+			, m_critMult(kUnitFieldCritMult, &Mask())
+			, m_speedWalk(kUnitFieldSpeedWalk, &Mask())
+			, m_speedRun(kUnitFieldSpeedRun, &Mask())
+			, m_speedSprint(kUnitFieldSpeedSprint, &Mask())
+			, m_stamina(kUnitFieldStamina, &Mask())
+			, m_maxStamina(kUnitFieldMaxStamina, &Mask())
+			, m_perception(kUnitFieldPerception, &Mask())
+			, m_stealth(kUnitFieldStealth, &Mask())
+			, m_secondaryResource(kUnitFieldSecondaryResource, &Mask())
+			, m_maxSecondaryResource(kUnitFieldMaxSecondaryResource, &Mask())
+```
+
+Avant le `private:` (après `IsAlive()`), ajouter les accesseurs :
+
+```cpp
+		void SetDamage(uint32_t v) { m_damage.Set(v); }
+		uint32_t GetDamage() const noexcept { return m_damage.Get(); }
+		void SetAccuracy(float v) { m_accuracy.Set(v); }
+		float GetAccuracy() const noexcept { return m_accuracy.Get(); }
+		void SetRange(float v) { m_range.Set(v); }
+		float GetRange() const noexcept { return m_range.Get(); }
+		void SetCritRate(float v) { m_critRate.Set(v); }
+		float GetCritRate() const noexcept { return m_critRate.Get(); }
+		void SetCritMult(float v) { m_critMult.Set(v); }
+		float GetCritMult() const noexcept { return m_critMult.Get(); }
+		void SetSpeedWalk(float v) { m_speedWalk.Set(v); }
+		float GetSpeedWalk() const noexcept { return m_speedWalk.Get(); }
+		void SetSpeedRun(float v) { m_speedRun.Set(v); }
+		float GetSpeedRun() const noexcept { return m_speedRun.Get(); }
+		void SetSpeedSprint(float v) { m_speedSprint.Set(v); }
+		float GetSpeedSprint() const noexcept { return m_speedSprint.Get(); }
+		void SetStamina(uint32_t v) { m_stamina.Set(v); }
+		uint32_t GetStamina() const noexcept { return m_stamina.Get(); }
+		void SetMaxStamina(uint32_t v) { m_maxStamina.Set(v); }
+		uint32_t GetMaxStamina() const noexcept { return m_maxStamina.Get(); }
+		void SetPerception(float v) { m_perception.Set(v); }
+		float GetPerception() const noexcept { return m_perception.Get(); }
+		void SetStealth(float v) { m_stealth.Set(v); }
+		float GetStealth() const noexcept { return m_stealth.Get(); }
+		void SetSecondaryResource(uint32_t v) { m_secondaryResource.Set(v); }
+		uint32_t GetSecondaryResource() const noexcept { return m_secondaryResource.Get(); }
+		void SetMaxSecondaryResource(uint32_t v) { m_maxSecondaryResource.Set(v); }
+		uint32_t GetMaxSecondaryResource() const noexcept { return m_maxSecondaryResource.Get(); }
+```
+
+Dans la section `private:`, après `m_faction` (ligne 77), ajouter les membres :
+
+```cpp
+		UpdateField<uint32_t> m_damage;
+		UpdateField<float>    m_accuracy;
+		UpdateField<float>    m_range;
+		UpdateField<float>    m_critRate;
+		UpdateField<float>    m_critMult;
+		UpdateField<float>    m_speedWalk;
+		UpdateField<float>    m_speedRun;
+		UpdateField<float>    m_speedSprint;
+		UpdateField<uint32_t> m_stamina;
+		UpdateField<uint32_t> m_maxStamina;
+		UpdateField<float>    m_perception;
+		UpdateField<float>    m_stealth;
+		UpdateField<uint32_t> m_secondaryResource;
+		UpdateField<uint32_t> m_maxSecondaryResource;
+```
+
+> Vérifier que `Mask()` est accessible dans le ctor (déjà utilisé pour `m_health`). Vérifier que `UpdateField<float>` compile (template générique : OK, `operator!=` sur float existe).
+
+- [ ] **Step 4: Lancer les tests Unit → succès**
+
+Run (CI) : `ctest -R unit`
+Expected: PASS (UnitTests inclut `TestNewStatFields`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shardd/entities/UpdateFieldIndices.h src/shardd/entities/Unit.h src/shardd/entities/UnitTests.cpp
+git commit -m "feat(entities): Unit — 14 UpdateField de stats étendues (réplication delta)"
+```
+
+---
+
+## Task 9: `Player::ApplyDerivedStats`
+
+Relie le moteur (Task 7) aux `UpdateField` (Task 8). Pas de câblage au runtime live (R1 différé) — méthode testée en isolation.
+
+**Files:**
+- Modify: `src/shardd/entities/Player.h`
+- Modify: `src/shardd/entities/Player.cpp`
+- Modify: `src/shardd/entities/PlayerTests.cpp`
+- Modify: `src/CMakeLists.txt` (PlayerTests doit linker le moteur + codegen)
+
+- [ ] **Step 1: Écrire le test (échoue)**
+
+Ajouter dans `src/shardd/entities/PlayerTests.cpp` (et appeler depuis `main`) :
+
+```cpp
+	bool TestApplyDerivedStats()
+	{
+		using namespace engine::server::entities;
+		using namespace engine::server::gameplay;
+
+		auto tables = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!tables) return false;
+
+		Player p(ObjectGuid{ 7 }, /*account*/ 1, /*char*/ 2, "Tester");
+		p.SetLevel(1);
+		// Voleur Elfe F niv.1 -> hp attendu 81 (cf. CharacterStatsEngineTests).
+		if (!p.ApplyDerivedStats(*tables, "elfe", "voleur_tenebreux", Sex::Female)) return false;
+		if (p.GetMaxHealth() != 81u) return false;
+		if (p.GetHealth() != 81u) return false; // plein à l'application
+		if (p.GetSecondaryResource() != p.GetMaxSecondaryResource()) return false;
+		return true;
+	}
+```
+
+Ajouter en tête de `PlayerTests.cpp` les includes :
+
+```cpp
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "CharacterStatsData.h"
+#include "FactionsData.h"
+```
+
+- [ ] **Step 2: Déclarer la méthode dans `Player.h`**
+
+Ajouter l'include en tête (après les includes existants) :
+
+```cpp
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+```
+
+Déclarer (dans la section public, après `SetXp`/`GetXp`) :
+
+```cpp
+		/// Recalcule et applique les 11 stats dérivées pour ce joueur depuis les
+		/// tables embarquées + (faction, classe, sexe, niveau courant). Remplit les
+		/// UpdateField (MarkDirty implicite via Set). HP et ressource sont mis au
+		/// plein. À appeler après chargement DB et à chaque level-up.
+		/// \return false si (faction, classe) est inconnue dans les tables.
+		bool ApplyDerivedStats(const engine::server::gameplay::CharacterStatsTables& tables,
+		                       const std::string& factionId,
+		                       const std::string& classId,
+		                       engine::server::gameplay::Sex sex);
+```
+
+- [ ] **Step 3: Implémenter dans `Player.cpp`**
+
+Remplacer le corps de `Player.cpp` par :
+
+```cpp
+// Player : translation unit.
+#include "src/shardd/entities/Player.h"
+
+namespace engine::server::entities
+{
+	bool Player::ApplyDerivedStats(const engine::server::gameplay::CharacterStatsTables& tables,
+	                               const std::string& factionId,
+	                               const std::string& classId,
+	                               engine::server::gameplay::Sex sex)
+	{
+		auto d = engine::server::gameplay::ComputeStats(tables, factionId, classId, sex, GetLevel());
+		if (!d) return false;
+
+		SetMaxHealth(d->hp);
+		SetHealth(d->hp);                    // plein à l'application
+		SetMaxSecondaryResource(d->resource);
+		SetSecondaryResource(d->resource);
+		SetDamage(d->damage);
+		SetAccuracy(d->accuracy);
+		SetRange(d->range);
+		SetCritRate(d->critRate);
+		SetCritMult(d->critMult);
+		SetSpeedWalk(d->speedWalk);
+		SetSpeedRun(d->speedRun);
+		SetSpeedSprint(d->speedSprint);
+		SetMaxStamina(d->stamina);
+		SetStamina(d->stamina);
+		SetPerception(d->perception);
+		SetStealth(d->stealth);
+		return true;
+	}
+}
+```
+
+> Note : `SetHealth` clampe à `maxHealth` — appeler `SetMaxHealth` **avant** `SetHealth` (déjà l'ordre ci-dessus).
+
+- [ ] **Step 4: CMake — lier le moteur au binaire + au test Player**
+
+Vérifier que `CharacterStatsEngine.cpp`/`CharacterStatsTables.cpp` sont déjà dans `server_app` (Task 7). Pour `player_tests` (chercher son `add_executable` ; sinon le créer sur le modèle des autres tests entités) :
+
+```cmake
+  add_executable(player_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/PlayerTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Player.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(player_tests lcdlln_gen_character_data)
+  target_include_directories(player_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(player_tests PRIVATE engine_core spdlog::spdlog)
+  target_compile_options(player_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME player_tests COMMAND player_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+```
+
+> Si un `player_tests` existe déjà, n'ajouter QUE les nouvelles sources/`add_dependencies`/include — ne pas dupliquer la cible.
+
+- [ ] **Step 5: Lancer → succès**
+
+Run (CI) : `ctest -R player`
+Expected: PASS (`TestApplyDerivedStats`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shardd/entities/Player.h src/shardd/entities/Player.cpp src/shardd/entities/PlayerTests.cpp src/CMakeLists.txt
+git commit -m "feat(entities): Player::ApplyDerivedStats — remplit les UpdateField depuis le moteur"
+```
+
+---
+
+## Task 10: Migration DB `0072_factions_v2.sql`
+
+Aligne la table `factions` (migration 0040) sur les ids courts + backfill `characters.faction_str`. Idempotente, dans **les deux** arbres.
+
+**Files:**
+- Create: `sql/migrations/0072_factions_v2.sql`
+- Create: `deploy/docker/sql/migrations/0072_factions_v2.sql` (contenu identique)
+
+- [ ] **Step 1: Écrire la migration**
+
+```sql
+-- Migration 0072 — Factions v2 : alignement sur les ids courts du design
+-- (Système de Personnages). Renomme les slugs longs de 0040, ajoute les
+-- nouvelles factions, repasse Chevaliers-Dragons en race humains, et
+-- backfill characters.faction_str. Idempotent.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+START TRANSACTION;
+
+-- 1) Renommer les slugs existants vers les ids courts + corriger race_lock.
+UPDATE factions SET name='lumiere'    WHERE name='chevaliers_lumiere';
+UPDATE factions SET name='justice'    WHERE name='chevaliers_justice';
+UPDATE factions SET name='legion', display_name='Légion infernale' WHERE name='demons';
+UPDATE factions SET name='dragons', race_lock='humains' WHERE name='chevaliers_dragons';
+-- lune_noire, dzorak, empire_hynn : ids déjà alignés.
+
+-- 2) Ajouter les nouvelles factions (INSERT IGNORE = idempotent sur uq_factions_name).
+INSERT IGNORE INTO factions (name, display_name, race_lock, parent_faction_id, description) VALUES
+  ('serpent', 'Maison du Serpent', 'humains', NULL, 'Maison humaine versée dans la magie et l''ombre.'),
+  ('naine',   'Faction Naine',     'nains',   NULL, 'Peuple nain : guerriers tenaces et artisans.'),
+  ('elfe',    'Faction Elfe',      'elfes',   NULL, 'Peuple elfe : agilité, magie et discrétion.');
+
+-- 3) empire_hynn : conservée, NON sélectionnable. Ajouter la colonne `selectable`
+--    si absente (défaut 1), puis marquer empire_hynn à 0.
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE table_schema = DATABASE() AND table_name='factions' AND column_name='selectable');
+SET @stmt := IF(@col_exists = 0,
+  'ALTER TABLE factions ADD COLUMN selectable TINYINT(1) NOT NULL DEFAULT 1 COMMENT ''0 = présente mais non sélectionnable à la création''',
+  'SELECT ''column factions.selectable already exists, skipping''');
+PREPARE a FROM @stmt; EXECUTE a; DEALLOCATE PREPARE a;
+UPDATE factions SET selectable = 0 WHERE name = 'empire_hynn';
+
+-- 4) Backfill characters.faction_str pour les slugs renommés (persos existants).
+UPDATE characters SET faction_str='lumiere' WHERE faction_str='chevaliers_lumiere';
+UPDATE characters SET faction_str='justice' WHERE faction_str='chevaliers_justice';
+UPDATE characters SET faction_str='legion'  WHERE faction_str='demons';
+UPDATE characters SET faction_str='dragons' WHERE faction_str='chevaliers_dragons';
+
+COMMIT;
+SET FOREIGN_KEY_CHECKS = 1;
+```
+
+- [ ] **Step 2: Dupliquer à l'identique dans l'arbre docker**
+
+```bash
+cp sql/migrations/0072_factions_v2.sql deploy/docker/sql/migrations/0072_factions_v2.sql
+```
+
+- [ ] **Step 3: Vérifier la cohérence des deux fichiers**
+
+Run: `diff sql/migrations/0072_factions_v2.sql deploy/docker/sql/migrations/0072_factions_v2.sql`
+Expected: (aucune sortie — fichiers identiques)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sql/migrations/0072_factions_v2.sql deploy/docker/sql/migrations/0072_factions_v2.sql
+git commit -m "feat(db): migration 0072 — factions ids courts + selectable + backfill"
+```
+
+---
+
+## Task 11: Vérification finale + push PR1
+
+**Files:** (aucun)
+
+- [ ] **Step 1: Vérifier qu'aucun multiplicateur n'a fui dans une cible client**
+
+Run: `grep -rn "character_stats.json\|kCharacterStatsJson" src/client src/world_editor`
+Expected: (aucune sortie — le client ne référence jamais les multiplicateurs)
+
+- [ ] **Step 2: Vérifier que les deux branches `server_app` listent bien les nouvelles sources**
+
+Run: `grep -n "CharacterStatsEngine.cpp\|CharacterStatsTables.cpp" src/CMakeLists.txt`
+Expected: au moins 2 occurrences de chaque (branche Windows + branche Linux ; +tests).
+
+- [ ] **Step 3: Pousser et ouvrir la PR**
+
+```bash
+git push -u origin feat/character-system-pr1-server
+gh pr create --base main --title "feat: Système de Personnages PR1 (serveur) — moteur de stats + XP + réplication" \
+  --body "Voir docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md (PR1).
+
+Inclut : factions.json + character_stats.json (embarqués shardd), migration 0072, CharacterStatsEngine (11 stats déterministes), courbe XP base*N^2.6 cap 100, extension Unit/Player UpdateField.
+
+R1 différé : câblage des stats au chemin de réplication live (snapshot ECS) hors PR1.
+
+**Déploiement** : ⚠️ redéploiement serveur requis — migration DB 0072 + binaire shardd. PR2 (wire+UI client) suivra en lock-step.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 4: Surveiller la CI**
+
+Vérifier `build-linux` (ctest : `config_loadfromstring_tests`, `formulas`, `character_stats_engine_tests`, `unit`, `player` verts) **et** `build-windows` (compilation `server_app` Windows OK). Corriger jusqu'au vert.
+
+---
+
+## Self-Review (effectué)
+
+- **Spec coverage** : courbe XP (T6), 11 stats + cap crit + mêlée pure (T7), embarquement build (T3-T5), Unit/Player UpdateField (T8-T9), migration factions ids courts + empire_hynn selectable + backfill (T10), tests impactés (FormulasTests T6, UnitTests T8, PlayerTests T9, + nouveaux T2/T7). **Reportés assumés** : races.json/corrompus + RaceDefinitionTests/CharacterCustomizationTests + wire + UI + localisation → PR2 ; câblage live → R1. Tracé explicitement (section Périmètre).
+- **Placeholders** : aucun TODO/TBD ; code complet par étape.
+- **Cohérence des types** : `ComputeStats`/`DerivedStats`/`CharacterStatsTables::FromEmbedded`/`ApplyDerivedStats`/`Sex` cohérents T7→T9 ; symboles générés `kCharacterStatsJson`/`kFactionsJson` cohérents codegen (T5) → consommateurs (T7/T9) ; indices `kUnitField*` cohérents T8.
+- **Points à confirmer par l'implémenteur au 1er build** (notés inline) : nom exact de la lib `engine_core` (Config/Log) ; existence/forme de `player_tests` ; nom de l'accesseur `Mask()` dans `Object.h`.

--- a/docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md
+++ b/docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md
@@ -1,0 +1,375 @@
+# Système de Personnages — Factions / Races / Classes / Stats
+
+**Date** : 2026-06-08
+**Type** : migration + extension (pas une création depuis zéro)
+**Projet** : LCDLLN (C++20 / Vulkan — client Windows, serveur Linux `masterd`+`shardd`, `shared`)
+**Langue** : communication FR, code et symboles EN.
+
+---
+
+## 1. Objectif
+
+Faire converger le système de personnages du code vers le design de référence
+(classeur `LCDLLN_Faction_Races_Classes.xlsx`, non présent dans le repo — ses
+valeurs numériques sont reportées ci-dessous) :
+
+- **9 factions jouables**, chacune avec ses **classes 100 % distinctes** (pas de
+  classes génériques partagées),
+- **5 races actives**, 2 désactivées, 1 supprimée,
+- un **modèle de stats à multiplicateurs** (11 stats dérivées) **calculé côté
+  serveur**, niveaux 1 → 100,
+- une **nouvelle courbe d'XP** (`base × N^2.6`, cap 100).
+
+Les valeurs vivent dans `game/data/` mais sont **embarquées dans le binaire
+`shardd` au build** (anti-triche).
+
+---
+
+## 2. État réel du code (constats d'audit)
+
+Ces constats reformulent le ticket d'origine — certaines de ses hypothèses sont
+inexactes.
+
+1. **Le serveur ne calcule aujourd'hui AUCUNE stat.** `Unit`
+   (`src/shardd/entities/Unit.h`) ne porte que
+   `health/maxHealth/mana/maxMana/level/faction` en `UpdateField`. Il n'existe
+   pas de moteur de stats serveur ni de lecture serveur de
+   `races.json`/`classes.json` (ces JSON sont lus **uniquement par le client**,
+   `src/client/character_creation/CharacterCreationUi.h`). Le modèle à
+   multiplicateurs est donc une **création**. La table `characters` stocke
+   `level=1` en dur + l'identité (race/class/faction/gender) ; **aucune stat
+   persistée**.
+
+2. **Une taxonomie de factions existe déjà en DB et diverge du ticket.** La
+   migration `sql/migrations/0040_factions.sql` définit **7 factions** :
+   `chevaliers_lumiere`, `chevaliers_justice`, `lune_noire`, `empire_hynn`,
+   `dzorak`, `demons`, `chevaliers_dragons` (cette dernière race-lockée sur une
+   pseudo-race `chevaliers_dragons`). Le §6.4 du ticket demande **9 factions**
+   dont **Maison du Serpent**, **Faction Naine**, **Faction Elfe** (absentes), et
+   pose **Chevaliers-Dragons = race Humain**.
+
+3. **Deux chemins de réplication coexistent.** Le modèle `Unit`+`UpdateField`/
+   `UpdateMask` (visé par le ticket) **et** un chemin snapshot
+   `EntityState`/`StatsComponent` UDP (`src/shared/network/ReplicationTypes.h`)
+   qui ne porte que `currentHealth/maxHealth`. Risque à lever (cf. §8).
+
+4. **Deux arbres de migrations SQL** divergents existent : `sql/migrations/` et
+   `deploy/docker/sql/migrations/`. Toute nouvelle migration doit être posée dans
+   **les deux**.
+
+---
+
+## 3. Décisions arbitrées avec le porteur du projet
+
+| # | Décision |
+|---|----------|
+| D1 | **Approche stats = recalcul déterministe (A)**, pas de persistance DB des stats. |
+| D2 | **Découpage en 2 PR server-first** : PR1 serveur/données, PR2 wire+client. Merge lock-step. |
+| D3 | **Factions** : 10 en table, **9 jouables** (= §6.4). `empire_hynn` conservée mais **non jouable** (`playable=false`, sans classes, masquée). `chevaliers_dragons` repasse en `race_lock = humains`. Ajout `maison_serpent`, `faction_naine`, `faction_elfe`. |
+| D4 | L'ancienne faction `demons` **garde son id technique** ; seul son `display_name` devient « Légion infernale » (préserve backfill + persos existants). |
+| D5 | **Moteur de stats + table embarquée = shardd uniquement** (jamais dans `shared`, sinon fuite des multiplicateurs au client). |
+| D6 | `XpToNextLevel(level)` renvoie **0** si `level == 0` ou `level >= 100` (cap). La ligne §10 « `XpToNextLevel(100) > 0` » est traitée comme une coquille (99). |
+| D7 | **Pas de build local** : la CI GitHub (Linux serveur + Windows client) valide tout. |
+
+### Pourquoi A est le choix le plus sûr anti-triche
+
+La protection vient de **l'autorité serveur**, pas du lieu de stockage. Dans A et
+B le serveur fait autorité et le client ne reçoit que les valeurs finales. A est
+**plus** sûre car :
+- les multiplicateurs sont **gravés dans le binaire shardd** (ni disque, ni DB),
+- **aucune colonne de stats modifiable** n'existe (rien à corrompre),
+- une stat ne peut jamais être « fausse » : elle est toujours redérivée de la
+  formule (le cap crit ≤ 10 est garanti *par la formule*).
+
+L'identité et la progression (faction, classe, sexe, niveau, XP, position,
+apparence, inventaire) restent **toujours stockées en DB** → changer
+d'ordinateur ne perd rien (les stats sont re-déduites au login).
+
+---
+
+## 4. Modèle de données
+
+### 4.1 `game/data/races/races.json` (migré)
+
+- Suppression de `corrompus` (+ `configuration/races/corrompus.json` + thème
+  `ui/races/corrompus/`).
+- Ajout d'un champ `"enabled"` par race :
+  `humains/elfes/orcs/nains/demons` → `true` ;
+  `morts_vivants/divins` → `false` (présentes, non sélectionnables, **assets
+  conservés**).
+- `id: "orcs"` conservé (ne pas casser meshs/thèmes).
+
+### 4.2 `game/data/races/factions.json` (NOUVEAU)
+
+Porte la taxonomie faction → classes (abandon de `classes.json` +
+`allowedRaces`). Chaque classe = (faction, race fixe via la faction, profil de
+stats parmi les 8 archétypes, ressource secondaire). Les sous-classes sont des
+**classes à part entière** (id distinct).
+
+```json
+{
+  "schema_version": 1,
+  "factions": [
+    {
+      "id": "chevaliers_lumiere", "displayName": "Chevaliers de la Lumière",
+      "race": "humains", "playable": true,
+      "classes": [
+        { "id": "guerrier",                "displayName": "Guerrier",                 "statProfile": "melee",    "secondaryResource": "endurance" },
+        { "id": "archer",                  "displayName": "Archer",                   "statProfile": "distance", "secondaryResource": "souffle"   },
+        { "id": "voleur",                  "displayName": "Voleur",                   "statProfile": "voleur",   "secondaryResource": "reflexes"  },
+        { "id": "inquisiteur_chatieur",    "displayName": "Inquisiteur · Châtieur",   "statProfile": "melee",    "secondaryResource": "ferveur"   },
+        { "id": "inquisiteur_hospitalier", "displayName": "Inquisiteur · Hospitalier","statProfile": "healer",   "secondaryResource": "ferveur"   }
+      ]
+    }
+  ]
+}
+```
+
+**Les 9 factions jouables et leurs classes** (§6.4, intitulés exacts du classeur) :
+
+1. **Chevaliers de la Lumière** (humains) : Guerrier(melee,Endurance),
+   Archer(distance,Souffle), Voleur(voleur,Réflexes),
+   Inquisiteur·Châtieur(melee,Ferveur), Inquisiteur·Hospitalier(healer,Ferveur).
+2. **Chevaliers de la Justice** (humains) : Guerrier(melee,Endurance),
+   Archer(distance,Souffle), Paladin(sacre,Ferveur),
+   Prêtre·du Jugement(lanceur,Ferveur), Prêtre·de la Grâce(healer,Ferveur).
+3. **La Lune Noire** (humains) : Guerrier(melee,Endurance),
+   Arbalétrier(distance,Souffle), Prêtre de la Lune Noire(lanceur,Dévotion),
+   Menthats(lanceur,Magie).
+4. **Dzorak** (orcs) : Guerrier(melee,Endurance), Chaman(lanceur,Transe),
+   Archer(distance,Souffle), Pisteur(pisteur,Instinct).
+5. **Légion infernale** (demons) : Guerrier(melee,Endurance),
+   Démoniste(lanceur,Corruption), Tourmenteur(melee,Corruption),
+   Sorcier de sang(lanceur,Corruption).
+6. **Chevaliers-Dragons** (humains) : Guerrier(melee,Endurance),
+   Archimage(lanceur,Flamme draconique), Dragonnier(melee,Furie draconique),
+   Gardien d'écailles(tank,Écaille).
+7. **Maison du Serpent** (humains) : Guerrier(melee,Endurance),
+   Archimage(lanceur,Magie de base), Assassin(voleur,Réflexes),
+   Mage(lanceur,Magie de base).
+8. **Faction Naine** (nains) : Guerrier(melee,Endurance),
+   Pisteur(pisteur,Instinct), Mage(lanceur,Magie de base),
+   Brise-roc(tank,Endurance).
+9. **Faction Elfe** (elfes) : Guerrier(melee,Endurance),
+   Archer·Bois(distance,Souffle), Voleur·Ténébreux(voleur,Réflexes),
+   Mage(lanceur,Magie de base).
+
+Plus **`empire_hynn`** : `playable=false`, sans classes (réservée lore).
+
+> Les classes existantes (`warrior`/`mage`/`rogue`/`priest`/`paladin`/`hunter`/
+> `necromancer`/`shaman`) sont remplacées par cette structure. `necromancer`
+> disparaît. Réutiliser `abilities`/`displayName` pertinents en les rattachant
+> aux nouvelles classes équivalentes.
+
+### 4.3 `game/data/gameplay/character_stats.json` (NOUVEAU — embarqué shardd)
+
+`schema_version`, `level_max: 100`, bases lvl1→lvl100 par stat, 8 profils
+d'archétype, multiplicateurs de race, profils de sexe, cap crit (10), params XP.
+
+**Bases** (lvl1 → lvl100) : PV 100→4000 · ressource 50→2000 · dégâts 10→400 ·
+précision 70→95 · portée 20→45 · crit 2→10 (cap 10) · mult crit base 1.5 ·
+marche 2 · course 5 · sprint 8 · endurance 100→1000 · perception 10 (+0.5/niv).
+
+**Profils d'archétype** (ordre hp/resource/damage/accuracy/range/crit_rate/
+crit_mult/speed/perception/stealth) :
+
+| profil   | hp | res | dmg | acc | rng | crit | cmul | spd | perc | stlth |
+|----------|----|-----|-----|-----|-----|------|------|-----|------|-------|
+| tank     |1.30|0.80 |0.70 |1.00 |0.00 |0.40  |0.90  |0.85 |0.80  |0.40   |
+| melee    |1.15|1.00 |1.05 |1.00 |0.00 |0.70  |1.00  |1.00 |0.90  |0.70   |
+| sacre    |1.10|1.00 |1.00 |1.00 |0.00 |0.70  |1.00  |1.00 |0.95  |0.70   |
+| distance |0.90|1.10 |1.15 |1.00 |1.00 |0.85  |1.05  |1.00 |1.30  |0.90   |
+| pisteur  |0.95|1.10 |1.10 |1.00 |0.90 |0.80  |1.05  |1.10 |1.25  |1.20   |
+| voleur   |0.90|1.10 |1.25 |1.00 |0.30 |1.00  |1.20  |1.15 |1.00  |1.40   |
+| healer   |0.85|1.20 |0.65 |1.00 |0.70 |0.40  |0.90  |1.00 |1.00  |0.70   |
+| lanceur  |0.75|1.30 |1.30 |1.00 |1.10 |0.70  |1.20  |1.00 |1.15  |0.60   |
+
+**Multiplicateurs de race** (hp/resource/damage/accuracy/range/crit_rate/
+crit_mult/speed_walk/speed_run/perception/stealth) :
+
+| race    | hp | res | dmg | acc | rng | crit | cmul | walk | run | perc | stlth |
+|---------|----|-----|-----|-----|-----|------|------|------|-----|------|-------|
+| humains |1.00|1.00 |1.00 |1.00 |1.00 |1.00  |1.00  |1.00  |1.00 |1.00  |1.00   |
+| nains   |1.20|1.00 |1.00 |1.00 |0.95 |0.90  |1.05  |0.85  |0.80 |0.90  |0.80   |
+| orcs    |1.15|0.90 |1.20 |0.95 |0.95 |0.95  |1.10  |1.00  |1.00 |0.90  |0.85   |
+| elfes   |0.90|1.10 |0.95 |1.10 |1.15 |1.10  |0.95  |1.05  |1.15 |1.25  |1.20   |
+| demons  |1.05|1.20 |1.10 |1.00 |1.00 |1.00  |1.10  |1.00  |1.00 |1.05  |0.90   |
+
+**Sexe** : multiplicateur par profil de classe, point fort/faible en miroir
+(homme/femme). Taux de crit **neutre** au sexe ; multiplicateur de crit
+légèrement favorable à l'homme.
+
+> **Dépendance de données (R3)** : les **valeurs numériques exactes** des
+> multiplicateurs de sexe ne figurent ni dans le ticket ni dans le repo (feuille
+> « Paramètres » du classeur). Sans elles, les échantillons §9 (« Guerrier Nain
+> H 60 » etc.) ne peuvent être comparés à des valeurs « du classeur ». Deux
+> options à trancher avant PR1 : (a) le porteur fournit les valeurs sexe ; ou
+> (b) on fige des valeurs sexe par défaut dans `character_stats.json` (miroir
+> symétrique léger, ex. ±5 % sur la stat forte/faible du profil) et les tests
+> deviennent **auto-cohérents** (assertion contre la table embarquée, pas contre
+> le classeur). Reco : (b) pour ne pas bloquer, avec ajustement ultérieur si le
+> classeur diffère.
+
+**Endurance (jauge universelle)** : 3 vitesses (marche gratuite / course /
+sprint), récup 3 paliers (t1 4%/s, t2 7%/s, t3 10%/s du max), immobile ×1.5,
+monture = 0, jauge vide = plus de course. Les **valeurs** vivent dans le JSON ;
+le runtime (vidage/remplissage) est géré serveur (cf. §8 pour le périmètre).
+
+### 4.4 Dépréciation `game/data/races/classes.json`
+
+Remplacé par `factions.json`. Le présenter client et les tests qui le lisent
+sont migrés.
+
+---
+
+## 5. Moteur de stats serveur (shardd uniquement)
+
+Emplacement : `src/shardd/gameplay/character/CharacterStatsEngine.{h,cpp}`
+(compilé **uniquement** dans `shardd`).
+
+**Calcul déterministe** pour `(level N, classId, factionId, gender)` :
+
+```
+base(N)   = base_lvl1 + (N-1) * (base_lvl100 - base_lvl1) / (level_max - 1)
+valeur    = round( base(N) * mult_profil[stat] * mult_race[stat]
+                            * mult_sexe[profil].get(stat, 1.0) )
+crit_rate = MIN(10, base_crit(N) * mults)        // plafond garanti par formule
+```
+
+La **faction** donne la race (race fixe) ; la **classe** donne le profil
+d'archétype + la ressource secondaire.
+
+**Embarquement (CMake)** : une cible custom convertit `character_stats.json` +
+la partie « calcul » de `factions.json` (faction→race, classe→profil/ressource)
+en **header C++ `const` généré** (octets → tableau), régénéré si le JSON change.
+Pas de chemin absolu. Au boot, `shardd` parse la table depuis la donnée
+**embarquée** (jamais le disque) une fois en mémoire. Format additif,
+`schema_version` versionné.
+
+---
+
+## 6. Courbe d'XP
+
+`XP(N→N+1) = base × N^2.6`, `level_max = 100`.
+
+**Calibration** : seul le ratio `base / xp_per_hour` fixe la durée. On fige
+`xp_per_hour` (référence classeur) dans `character_stats.json`, puis on dérive
+`base` pour que `Σ(N=1..59) base·N^2.6 / xp_per_hour ≈ 420 h`.
+
+**Découpage** : `src/shared/formulas/Formulas.h` garde une fonction **pure et
+paramétrée** `XpToNextLevel(level, base, factor, levelMax)` (forme de courbe,
+testable, modifiable). Les **valeurs calibrées** viennent du JSON embarqué
+shardd ; le moteur les passe à la fonction. Le client n'en a pas besoin (le
+serveur réplique `xp` + `level`). `XpToNextLevel` renvoie 0 si `level == 0` ou
+`level >= 100`.
+
+---
+
+## 7. Extension `Unit` / `Player` (réplication)
+
+**Nouveaux `UpdateField` sur `Unit`** — indices *appended* à la fin de
+`UnitFieldIdx` (ordre stable, le wire en dépend ; ne jamais réassigner un
+indice existant) :
+
+`damage`, `accuracy`, `range`, `crit_rate`, `crit_mult`, `speed_walk`,
+`speed_run`, `speed_sprint`, `stamina`, `maxStamina`, `perception`, `stealth`,
+`secondaryResource`, `maxSecondaryResource`.
+
+- Entiers → `UpdateField<uint32_t>` ; fractionnaires (crit_mult, vitesses,
+  perception, accuracy, range, crit_rate, stealth) → `UpdateField<float>`.
+- `health/mana/level/faction` conservés.
+- **Ressource secondaire** : on réplique seulement valeur + max. Le **libellé**
+  est résolu côté client depuis `factions.json` via la classe connue (pas de
+  champ wire pour le libellé).
+
+**`Player`** : méthode `ApplyDerivedStats(engine, classId, factionId, gender)`
+appelée après chargement DB et à chaque level-up — remplit les `UpdateField`,
+`MarkDirty()` pour la première réplication.
+
+---
+
+## 8. Risques & périmètre
+
+- **R1 — Chemin de réplication (BLOQUANT pour le plan)** : confirmer que les
+  stats joueur atteignent le client via `UpdateField`/`UpdateMask` et **pas** via
+  le snapshot `EntityState`/`StatsComponent` UDP. Si c'est le snapshot, étendre
+  aussi `SpawnEntity`/`EntityState` — sinon les `UpdateField` resteront
+  invisibles. À lever en début de plan.
+- **R2 — Runtime endurance** : ce design fournit les **données** (max stamina,
+  paliers de régén) et les **champs** répliqués. La boucle de vidage/remplissage
+  (sprint qui consomme, régén par palier, immobile ×1.5, monture=0) est une
+  addition gameplay ; à confirmer si elle entre dans PR1 ou en suivi.
+
+### Hors scope (tickets séparés)
+
+Déplacements spéciaux (téléport/vol/dragon), montures, gain d'XP/quêtes,
+économie, craft, armure/défense, résistances, relations de factions (PvP),
+statut hors-la-loi (stats inchangées).
+
+---
+
+## 9. Tests
+
+- `FormulasTests` : `XpToNextLevel` paramétrée — monotone 1..99, `= 0` à 100,
+  niveau 60 cumulé ≈ 420 h (tolérance), positivité.
+- **`CharacterStatsEngineTests`** (shardd, ctest Linux) : échantillons §10
+  (Guerrier Nain H 60, Lanceur Démon F 100, Voleur Elfe F 1) vs valeurs
+  attendues ; cap crit ≤ 10 avec multiplicateurs forcés ; mêlée → portée nulle
+  (mult range 0.00) ; round-trip JSON → header embarqué → mémoire.
+- `UnitTests`/`PlayerTests` : nouveaux setters/getters + `MarkDirty`.
+- `RaceDefinitionTests` : `corrompus` absente, `morts_vivants`/`divins`
+  `enabled=false`, 5 actives ; tests meshPath conservés.
+- `CharacterCustomizationTests` : retrait références `corrompus`.
+- **Nouveau test factions client** : 9 factions jouables chargées, classes
+  distinctes, `empire_hynn` non jouable.
+- CI : `build-linux` exécute `ctest` (vérifier que les nouveaux tests serveur ne
+  tombent pas dans les exclusions `-E`) ; `build-windows` pour le client.
+
+---
+
+## 10. Découpage en PR & déploiement
+
+### PR1 — server-first (CI Linux)
+
+`races.json` migré · `factions.json` · `character_stats.json` · migration
+`0072_factions_v2.sql` (dans **`sql/migrations/` ET `deploy/docker/sql/
+migrations/`**) · `CharacterStatsEngine` + header généré + cible CMake ·
+`Formulas.h` (XP) · extension `Unit`/`Player` + `UpdateFieldIndices.h` · tests
+serveur. **Autonome** : le serveur calcule les stats depuis l'identité déjà
+stockée, sans toucher au wire.
+
+> **Déploiement PR1** : ⚠️ **redéploiement serveur requis** — migration DB 0072
+> + nouveau binaire `shardd` (moteur de stats + champs de réplication).
+
+### PR2 — client (CI Windows + master)
+
+Wire (`factionId` dans `CharacterCreateRequestPayload` ; `faction_str` dans
+`CharacterListEntry`) · `CharacterCreateHandler` (masterd : validation
+faction/classe/race depuis payload) · refonte `CharacterCreationPresenter`/
+`CharacterCreationUi`/`AuthImGuiCharacterCreate.cpp` (flux faction → classe →
+sexe ; races désactivées + `empire_hynn` masquées) · tests client.
+
+> **Déploiement PR2** : ⚠️ **redéploiement serveur (master) requis** —
+> wire-breaking (nouveau champ payload) + handler master modifié ;
+> **client + master en lock-step**.
+
+### Ordre
+
+Merge **PR1 → PR2**, CI verte aux deux, déploiement lock-step.
+
+---
+
+## 11. Critères d'acceptation
+
+- `races.json` : 5 actives, `morts_vivants`+`divins` `enabled:false`, `corrompus`
+  supprimée partout (aucune référence résiduelle).
+- 9 factions jouables avec classes 100 % distinctes, chargées ; `empire_hynn`
+  présente mais non jouable.
+- 11 stats calculées correctement (base × profil × race × sexe).
+- `Formulas.h` : courbe `base × N^2.6`, niveau max 100, niveau 60 ≈ 420 h ;
+  `FormulasTests` à jour.
+- Crit de base jamais > 10 quel que soit le réglage.
+- Mêlée pure : portée nulle.
+- JSON embarqué au build : modifier + rebuild change les stats ; aucun accès
+  disque runtime ; client sans multiplicateurs bruts.
+- Tous les tests existants impactés au vert. CI Linux + Windows vertes.

--- a/docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md
+++ b/docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md
@@ -1,61 +1,58 @@
 # Système de Personnages — Factions / Races / Classes / Stats
 
-**Date** : 2026-06-08
+**Date** : 2026-06-08 (révisé : intégration du ticket complet avec valeurs §6.3)
 **Type** : migration + extension (pas une création depuis zéro)
 **Projet** : LCDLLN (C++20 / Vulkan — client Windows, serveur Linux `masterd`+`shardd`, `shared`)
 **Langue** : communication FR, code et symboles EN.
+**Source de vérité chiffrée** : le bloc JSON du §6.3 du ticket (reproduit §4.4 ci-dessous). L'agent n'a pas accès au classeur `.xlsx` ; ce JSON EST la référence à recopier verbatim.
 
 ---
 
 ## 1. Objectif
 
-Faire converger le système de personnages du code vers le design de référence
-(classeur `LCDLLN_Faction_Races_Classes.xlsx`, non présent dans le repo — ses
-valeurs numériques sont reportées ci-dessous) :
+Faire converger le système de personnages du code vers le design de référence :
 
-- **9 factions jouables**, chacune avec ses **classes 100 % distinctes** (pas de
-  classes génériques partagées),
+- **9 factions jouables** (+ 1 conservée non sélectionnable), chacune avec ses
+  **classes 100 % distinctes** (pas de classes génériques partagées),
 - **5 races actives**, 2 désactivées, 1 supprimée,
 - un **modèle de stats à multiplicateurs** (11 stats dérivées) **calculé côté
   serveur**, niveaux 1 → 100,
-- une **nouvelle courbe d'XP** (`base × N^2.6`, cap 100).
+- une **nouvelle courbe d'XP** (`base × N^2.6`, cap 100),
+- une **zone de texte descriptive** à la création (faction/classe), traduisible.
 
-Les valeurs vivent dans `game/data/` mais sont **embarquées dans le binaire
-`shardd` au build** (anti-triche).
+Les valeurs vivent dans `game/data/` mais les multiplicateurs sont **embarqués
+dans le binaire `shardd` au build** (anti-triche).
 
 ---
 
 ## 2. État réel du code (constats d'audit)
 
-Ces constats reformulent le ticket d'origine — certaines de ses hypothèses sont
-inexactes.
-
 1. **Le serveur ne calcule aujourd'hui AUCUNE stat.** `Unit`
    (`src/shardd/entities/Unit.h`) ne porte que
-   `health/maxHealth/mana/maxMana/level/faction` en `UpdateField`. Il n'existe
-   pas de moteur de stats serveur ni de lecture serveur de
-   `races.json`/`classes.json` (ces JSON sont lus **uniquement par le client**,
-   `src/client/character_creation/CharacterCreationUi.h`). Le modèle à
-   multiplicateurs est donc une **création**. La table `characters` stocke
-   `level=1` en dur + l'identité (race/class/faction/gender) ; **aucune stat
-   persistée**.
+   `health/maxHealth/mana/maxMana/level/faction` en `UpdateField`. Pas de moteur
+   de stats serveur ni de lecture serveur de `races.json`/`classes.json` (lus
+   **uniquement par le client**). La table `characters` stocke `level=1` en dur +
+   l'identité (race/class/faction/gender) ; **aucune stat persistée**.
 
-2. **Une taxonomie de factions existe déjà en DB et diverge du ticket.** La
-   migration `sql/migrations/0040_factions.sql` définit **7 factions** :
-   `chevaliers_lumiere`, `chevaliers_justice`, `lune_noire`, `empire_hynn`,
-   `dzorak`, `demons`, `chevaliers_dragons` (cette dernière race-lockée sur une
-   pseudo-race `chevaliers_dragons`). Le §6.4 du ticket demande **9 factions**
-   dont **Maison du Serpent**, **Faction Naine**, **Faction Elfe** (absentes), et
-   pose **Chevaliers-Dragons = race Humain**.
+2. **Une taxonomie de factions existe déjà en DB et diverge du ticket.**
+   `sql/migrations/0040_factions.sql` définit 7 factions avec des **slugs longs**
+   (`chevaliers_lumiere`, `chevaliers_justice`, `lune_noire`, `empire_hynn`,
+   `dzorak`, `demons`, `chevaliers_dragons`). Le §6.3 utilise des **ids courts**
+   (`lumiere`, `justice`, `lune_noire`, `dzorak`, `legion`, `dragons`, `serpent`,
+   `naine`, `elfe`, `empire_hynn`). → réconciliation (D4).
 
-3. **Deux chemins de réplication coexistent.** Le modèle `Unit`+`UpdateField`/
-   `UpdateMask` (visé par le ticket) **et** un chemin snapshot
-   `EntityState`/`StatsComponent` UDP (`src/shared/network/ReplicationTypes.h`)
-   qui ne porte que `currentHealth/maxHealth`. Risque à lever (cf. §8).
+3. **Deux chemins de réplication coexistent** : `Unit`+`UpdateField`/`UpdateMask`
+   (visé par le ticket) **et** un chemin snapshot `EntityState`/`StatsComponent`
+   UDP (`src/shared/network/ReplicationTypes.h`, `currentHealth/maxHealth` seuls).
+   Risque R1 (§8).
 
-4. **Deux arbres de migrations SQL** divergents existent : `sql/migrations/` et
-   `deploy/docker/sql/migrations/`. Toute nouvelle migration doit être posée dans
-   **les deux**.
+4. **Deux arbres de migrations SQL** divergents : `sql/migrations/` et
+   `deploy/docker/sql/migrations/`. Toute migration neuve va dans **les deux**.
+
+5. **Le wire de création** (`CharacterCreateRequestPayload`,
+   `src/shared/network/CharacterPayloads.h`) envoie aujourd'hui
+   `name/raceId/classId/customization/gender`. Pas de `factionId`. Le handler
+   `CharacterCreateHandler` (masterd) dérive la faction de la race via un lambda.
 
 ---
 
@@ -63,27 +60,24 @@ inexactes.
 
 | # | Décision |
 |---|----------|
-| D1 | **Approche stats = recalcul déterministe (A)**, pas de persistance DB des stats. |
-| D2 | **Découpage en 2 PR server-first** : PR1 serveur/données, PR2 wire+client. Merge lock-step. |
-| D3 | **Factions** : 10 en table, **9 jouables** (= §6.4). `empire_hynn` conservée mais **non jouable** (`playable=false`, sans classes, masquée). `chevaliers_dragons` repasse en `race_lock = humains`. Ajout `maison_serpent`, `faction_naine`, `faction_elfe`. |
-| D4 | L'ancienne faction `demons` **garde son id technique** ; seul son `display_name` devient « Légion infernale » (préserve backfill + persos existants). |
-| D5 | **Moteur de stats + table embarquée = shardd uniquement** (jamais dans `shared`, sinon fuite des multiplicateurs au client). |
-| D6 | `XpToNextLevel(level)` renvoie **0** si `level == 0` ou `level >= 100` (cap). La ligne §10 « `XpToNextLevel(100) > 0` » est traitée comme une coquille (99). |
-| D7 | **Pas de build local** : la CI GitHub (Linux serveur + Windows client) valide tout. |
+| D1 | **Approche stats = recalcul déterministe** sur `shardd`, pas de persistance DB des stats (§5.6 du ticket). |
+| D2 | **Découpage en 2 PR server-first** : PR1 serveur/données, PR2 wire+client+localisation. Merge lock-step. *(Garde le 2-PR malgré le §13 « une branche, un PR ».)* |
+| D3 | **Factions** : 10 en table, **9 sélectionnables**. `empire_hynn` conservée mais `selectable=false` (suzerain Lumière/Justice, PNJ/narration future). `chevaliers_dragons` → `race_lock = humains`. |
+| D4 | **Ids faction alignés sur le JSON §6.3 (ids courts)** : migration 0072 **renomme** les slugs DB vers `lumiere/justice/lune_noire/dzorak/legion/dragons/empire_hynn` + **backfill** `characters.faction_str` des persos existants ; **ajoute** `serpent/naine/elfe`. `legion` remplace `demons`. *(Supersede l'ancienne D4 « garder l'id technique ».)* |
+| D5 | **Moteur de stats + multiplicateurs embarqués = shardd uniquement** (jamais `shared`, sinon fuite client). |
+| D6 | `XpToNextLevel(level)` renvoie **0** si `level == 0` ou `level >= 100`. La ligne §10 « `XpToNextLevel(100) > 0` » est traitée comme coquille (99). |
+| D7 | **Pas de build local** : CI GitHub (Linux serveur + Windows client) valide tout. |
+| D8 | **Séparation anti-triche en 2 fichiers** : `factions.json` (taxonomie lisible client, sans multiplicateurs) + `character_stats.json` (bases/multiplicateurs/sexe/xp, embarqué shardd-only). Valeurs recopiées verbatim du §6.3. |
+| D9 | **Zone de texte descriptive** à la création (faction + classe), depuis `game/data/localization/<lang>/`, clés stables, traduisible (PR2). |
 
-### Pourquoi A est le choix le plus sûr anti-triche
+### Pourquoi le recalcul déterministe est le choix le plus sûr anti-triche
 
-La protection vient de **l'autorité serveur**, pas du lieu de stockage. Dans A et
-B le serveur fait autorité et le client ne reçoit que les valeurs finales. A est
-**plus** sûre car :
-- les multiplicateurs sont **gravés dans le binaire shardd** (ni disque, ni DB),
-- **aucune colonne de stats modifiable** n'existe (rien à corrompre),
-- une stat ne peut jamais être « fausse » : elle est toujours redérivée de la
-  formule (le cap crit ≤ 10 est garanti *par la formule*).
-
-L'identité et la progression (faction, classe, sexe, niveau, XP, position,
-apparence, inventaire) restent **toujours stockées en DB** → changer
-d'ordinateur ne perd rien (les stats sont re-déduites au login).
+La protection vient de **l'autorité serveur**, pas du lieu de stockage. Le
+serveur calcule et détient les stats ; le client ne reçoit que les valeurs
+finales. Le recalcul est **plus** sûr : multiplicateurs gravés dans le binaire
+shardd (ni disque, ni DB), **aucune colonne de stats modifiable**, stat toujours
+conforme à la formule (cap crit ≤ 10 garanti *par la formule*). L'identité et la
+progression restent **toujours** en DB → changer d'ordinateur ne perd rien.
 
 ---
 
@@ -93,132 +87,95 @@ d'ordinateur ne perd rien (les stats sont re-déduites au login).
 
 - Suppression de `corrompus` (+ `configuration/races/corrompus.json` + thème
   `ui/races/corrompus/`).
-- Ajout d'un champ `"enabled"` par race :
-  `humains/elfes/orcs/nains/demons` → `true` ;
-  `morts_vivants/divins` → `false` (présentes, non sélectionnables, **assets
-  conservés**).
-- `id: "orcs"` conservé (ne pas casser meshs/thèmes).
+- Ajout `"enabled"` : `humains/elfes/orcs/nains/demons` → `true` ;
+  `morts_vivants/divins` → `false` (assets **conservés**).
+- `id: "orcs"` conservé.
 
-### 4.2 `game/data/races/factions.json` (NOUVEAU)
+### 4.2 `game/data/races/factions.json` (NOUVEAU — taxonomie, lisible client)
 
-Porte la taxonomie faction → classes (abandon de `classes.json` +
-`allowedRaces`). Chaque classe = (faction, race fixe via la faction, profil de
-stats parmi les 8 archétypes, ressource secondaire). Les sous-classes sont des
-**classes à part entière** (id distinct).
+Porte faction → classes, **sans aucun multiplicateur** (D8). Chaque classe = (id
+unique dans la faction, nom, sous-classe optionnelle, nom de profil d'archétype,
+clé de ressource secondaire). Ids alignés sur le §6.3.
 
 ```json
 {
   "schema_version": 1,
   "factions": [
     {
-      "id": "chevaliers_lumiere", "displayName": "Chevaliers de la Lumière",
-      "race": "humains", "playable": true,
+      "id": "lumiere", "name": "Chevaliers de la Lumière",
+      "race": "humains", "selectable": true,
       "classes": [
-        { "id": "guerrier",                "displayName": "Guerrier",                 "statProfile": "melee",    "secondaryResource": "endurance" },
-        { "id": "archer",                  "displayName": "Archer",                   "statProfile": "distance", "secondaryResource": "souffle"   },
-        { "id": "voleur",                  "displayName": "Voleur",                   "statProfile": "voleur",   "secondaryResource": "reflexes"  },
-        { "id": "inquisiteur_chatieur",    "displayName": "Inquisiteur · Châtieur",   "statProfile": "melee",    "secondaryResource": "ferveur"   },
-        { "id": "inquisiteur_hospitalier", "displayName": "Inquisiteur · Hospitalier","statProfile": "healer",   "secondaryResource": "ferveur"   }
+        { "id": "guerrier",                "name": "Guerrier",     "profile": "melee",    "resource": "endurance" },
+        { "id": "archer",                  "name": "Archer",       "profile": "distance", "resource": "souffle"   },
+        { "id": "voleur",                  "name": "Voleur",       "profile": "voleur",   "resource": "reflexes"  },
+        { "id": "inquisiteur_chatieur",    "name": "Inquisiteur", "subclass": "Châtieur",    "profile": "melee",  "resource": "ferveur" },
+        { "id": "inquisiteur_hospitalier", "name": "Inquisiteur", "subclass": "Hospitalier", "profile": "healer", "resource": "ferveur" }
       ]
     }
   ]
 }
 ```
 
-**Les 9 factions jouables et leurs classes** (§6.4, intitulés exacts du classeur) :
+**Identité technique des classes (wire)** : `classId` = slug unique **dans** la
+faction (ex. `guerrier`, `inquisiteur_chatieur`). Comme le `factionId` est aussi
+envoyé, le couple `(factionId, classId)` est globalement non ambigu.
 
-1. **Chevaliers de la Lumière** (humains) : Guerrier(melee,Endurance),
-   Archer(distance,Souffle), Voleur(voleur,Réflexes),
-   Inquisiteur·Châtieur(melee,Ferveur), Inquisiteur·Hospitalier(healer,Ferveur).
-2. **Chevaliers de la Justice** (humains) : Guerrier(melee,Endurance),
-   Archer(distance,Souffle), Paladin(sacre,Ferveur),
-   Prêtre·du Jugement(lanceur,Ferveur), Prêtre·de la Grâce(healer,Ferveur).
-3. **La Lune Noire** (humains) : Guerrier(melee,Endurance),
-   Arbalétrier(distance,Souffle), Prêtre de la Lune Noire(lanceur,Dévotion),
-   Menthats(lanceur,Magie).
-4. **Dzorak** (orcs) : Guerrier(melee,Endurance), Chaman(lanceur,Transe),
-   Archer(distance,Souffle), Pisteur(pisteur,Instinct).
-5. **Légion infernale** (demons) : Guerrier(melee,Endurance),
-   Démoniste(lanceur,Corruption), Tourmenteur(melee,Corruption),
-   Sorcier de sang(lanceur,Corruption).
-6. **Chevaliers-Dragons** (humains) : Guerrier(melee,Endurance),
-   Archimage(lanceur,Flamme draconique), Dragonnier(melee,Furie draconique),
-   Gardien d'écailles(tank,Écaille).
-7. **Maison du Serpent** (humains) : Guerrier(melee,Endurance),
-   Archimage(lanceur,Magie de base), Assassin(voleur,Réflexes),
-   Mage(lanceur,Magie de base).
-8. **Faction Naine** (nains) : Guerrier(melee,Endurance),
-   Pisteur(pisteur,Instinct), Mage(lanceur,Magie de base),
-   Brise-roc(tank,Endurance).
-9. **Faction Elfe** (elfes) : Guerrier(melee,Endurance),
-   Archer·Bois(distance,Souffle), Voleur·Ténébreux(voleur,Réflexes),
-   Mage(lanceur,Magie de base).
+**Les 10 factions** (ids + classes, §6.4 / §6.3) :
 
-Plus **`empire_hynn`** : `playable=false`, sans classes (réservée lore).
+| id | name | race | selectable | classes (id : profil/ressource) |
+|----|------|------|-----------|---------------------------------|
+| `lumiere` | Chevaliers de la Lumière | humains | ✅ | guerrier:melee/endurance · archer:distance/souffle · voleur:voleur/reflexes · inquisiteur_chatieur:melee/ferveur · inquisiteur_hospitalier:healer/ferveur |
+| `justice` | Chevaliers de la Justice | humains | ✅ | guerrier:melee/endurance · archer:distance/souffle · paladin:sacre/ferveur · pretre_jugement:lanceur/ferveur · pretre_grace:healer/ferveur |
+| `lune_noire` | La Lune Noire | humains | ✅ | guerrier:melee/endurance · arbaletrier:distance/souffle · pretre_lune_noire:lanceur/devotion · menthats:lanceur/magie |
+| `dzorak` | Dzorak | orcs | ✅ | guerrier:melee/endurance · chaman:lanceur/transe · archer:distance/souffle · pisteur:pisteur/instinct |
+| `legion` | Légion infernale | demons | ✅ | guerrier:melee/endurance · demoniste:lanceur/corruption · tourmenteur:melee/corruption · sorcier_sang:lanceur/corruption |
+| `dragons` | Chevaliers-Dragons | humains | ✅ | guerrier:melee/endurance · archimage:lanceur/flamme_draconique · dragonnier:melee/furie_draconique · gardien_ecailles:tank/ecaille |
+| `serpent` | Maison du Serpent | humains | ✅ | guerrier:melee/endurance · archimage:lanceur/magie_base · assassin:voleur/reflexes · mage:lanceur/magie_base |
+| `naine` | Faction Naine | nains | ✅ | guerrier:melee/endurance · pisteur:pisteur/instinct · mage:lanceur/magie_base · brise_roc:tank/endurance |
+| `elfe` | Faction Elfe | elfes | ✅ | guerrier:melee/endurance · archer_bois:distance/souffle · voleur_tenebreux:voleur/reflexes · mage:lanceur/magie_base |
+| `empire_hynn` | L'Empire de L'hynn | humains | ❌ | (aucune) |
 
 > Les classes existantes (`warrior`/`mage`/`rogue`/`priest`/`paladin`/`hunter`/
 > `necromancer`/`shaman`) sont remplacées par cette structure. `necromancer`
-> disparaît. Réutiliser `abilities`/`displayName` pertinents en les rattachant
-> aux nouvelles classes équivalentes.
+> disparaît. Réutiliser `abilities`/`displayName` pertinents.
 
-### 4.3 `game/data/gameplay/character_stats.json` (NOUVEAU — embarqué shardd)
+### 4.3 Dépréciation `game/data/races/classes.json`
 
-`schema_version`, `level_max: 100`, bases lvl1→lvl100 par stat, 8 profils
-d'archétype, multiplicateurs de race, profils de sexe, cap crit (10), params XP.
+Remplacé par `factions.json`. Présenter client + tests migrés.
 
-**Bases** (lvl1 → lvl100) : PV 100→4000 · ressource 50→2000 · dégâts 10→400 ·
-précision 70→95 · portée 20→45 · crit 2→10 (cap 10) · mult crit base 1.5 ·
-marche 2 · course 5 · sprint 8 · endurance 100→1000 · perception 10 (+0.5/niv).
+### 4.4 `game/data/gameplay/character_stats.json` (NOUVEAU — embarqué shardd-only)
 
-**Profils d'archétype** (ordre hp/resource/damage/accuracy/range/crit_rate/
-crit_mult/speed/perception/stealth) :
+Contient **uniquement** les valeurs (bases, profils de classe, profils de race,
+profils de sexe, params XP, cap crit) — **pas** les noms factions/classes (ceux-ci
+sont dans `factions.json`, D8). Le lien se fait par le nom de profil
+(`class_profiles[profil]`) et la race (`race_profiles[race]`).
 
-| profil   | hp | res | dmg | acc | rng | crit | cmul | spd | perc | stlth |
-|----------|----|-----|-----|-----|-----|------|------|-----|------|-------|
-| tank     |1.30|0.80 |0.70 |1.00 |0.00 |0.40  |0.90  |0.85 |0.80  |0.40   |
-| melee    |1.15|1.00 |1.05 |1.00 |0.00 |0.70  |1.00  |1.00 |0.90  |0.70   |
-| sacre    |1.10|1.00 |1.00 |1.00 |0.00 |0.70  |1.00  |1.00 |0.95  |0.70   |
-| distance |0.90|1.10 |1.15 |1.00 |1.00 |0.85  |1.05  |1.00 |1.30  |0.90   |
-| pisteur  |0.95|1.10 |1.10 |1.00 |0.90 |0.80  |1.05  |1.10 |1.25  |1.20   |
-| voleur   |0.90|1.10 |1.25 |1.00 |0.30 |1.00  |1.20  |1.15 |1.00  |1.40   |
-| healer   |0.85|1.20 |0.65 |1.00 |0.70 |0.40  |0.90  |1.00 |1.00  |0.70   |
-| lanceur  |0.75|1.30 |1.30 |1.00 |1.10 |0.70  |1.20  |1.00 |1.15  |0.60   |
+Recopier verbatim depuis le §6.3 du ticket. Valeurs clés :
 
-**Multiplicateurs de race** (hp/resource/damage/accuracy/range/crit_rate/
-crit_mult/speed_walk/speed_run/perception/stealth) :
+- **XP** : `factor: 2.6`, `base: 6.185`, `xp_per_hour_ref: 10000`, calib niveau 60 ≈ 420 h.
+- **Bases (lvl1→lvl100)** : hp 100→4000 · resource 50→2000 · damage 10→400 ·
+  accuracy 70→95 · range 20→45 · crit_rate 2→10 (cap 10) · crit_mult base 1.5 ·
+  speed_walk 2 · speed_run 5 · speed_sprint 8 · stamina 100→1000 ·
+  perception_lvl1 10 (+0.5/niv).
+- **Stamina** : cost_run 4 % / cost_sprint 8 % ; régén t1 4 % / t2 7 % / t3 10 % ;
+  idle ×1.5.
+- **8 profils d'archétype** `class_profiles` (tank/melee/sacre/distance/pisteur/
+  voleur/healer/lanceur), ordre hp,resource,damage,accuracy,range,crit_rate,
+  crit_mult,speed,perception,stealth.
+- **5 profils de race** `race_profiles` (humains/nains/orcs/elfes/demons).
+- **8 profils de sexe** `sex_profiles` (un par profil de classe, sous-clés `H`/`F`),
+  crit_rate toujours neutre, multiplicateur de crit légèrement pro-homme.
 
-| race    | hp | res | dmg | acc | rng | crit | cmul | walk | run | perc | stlth |
-|---------|----|-----|-----|-----|-----|------|------|------|-----|------|-------|
-| humains |1.00|1.00 |1.00 |1.00 |1.00 |1.00  |1.00  |1.00  |1.00 |1.00  |1.00   |
-| nains   |1.20|1.00 |1.00 |1.00 |0.95 |0.90  |1.05  |0.85  |0.80 |0.90  |0.80   |
-| orcs    |1.15|0.90 |1.20 |0.95 |0.95 |0.95  |1.10  |1.00  |1.00 |0.90  |0.85   |
-| elfes   |0.90|1.10 |0.95 |1.10 |1.15 |1.10  |0.95  |1.05  |1.15 |1.25  |1.20   |
-| demons  |1.05|1.20 |1.10 |1.00 |1.00 |1.00  |1.10  |1.00  |1.00 |1.05  |0.90   |
+> Les tableaux numériques complets (class_profiles, race_profiles, sex_profiles)
+> sont ceux du §6.3 du ticket — copie octet pour octet, sans réinterprétation.
 
-**Sexe** : multiplicateur par profil de classe, point fort/faible en miroir
-(homme/femme). Taux de crit **neutre** au sexe ; multiplicateur de crit
-légèrement favorable à l'homme.
+### 4.5 Textes descriptifs (localisation, D9 / §5.5)
 
-> **Dépendance de données (R3)** : les **valeurs numériques exactes** des
-> multiplicateurs de sexe ne figurent ni dans le ticket ni dans le repo (feuille
-> « Paramètres » du classeur). Sans elles, les échantillons §9 (« Guerrier Nain
-> H 60 » etc.) ne peuvent être comparés à des valeurs « du classeur ». Deux
-> options à trancher avant PR1 : (a) le porteur fournit les valeurs sexe ; ou
-> (b) on fige des valeurs sexe par défaut dans `character_stats.json` (miroir
-> symétrique léger, ex. ±5 % sur la stat forte/faible du profil) et les tests
-> deviennent **auto-cohérents** (assertion contre la table embarquée, pas contre
-> le classeur). Reco : (b) pour ne pas bloquer, avec ajustement ultérieur si le
-> classeur diffère.
-
-**Endurance (jauge universelle)** : 3 vitesses (marche gratuite / course /
-sprint), récup 3 paliers (t1 4%/s, t2 7%/s, t3 10%/s du max), immobile ×1.5,
-monture = 0, jauge vide = plus de course. Les **valeurs** vivent dans le JSON ;
-le runtime (vidage/remplissage) est géré serveur (cf. §8 pour le périmètre).
-
-### 4.4 Dépréciation `game/data/races/classes.json`
-
-Remplacé par `factions.json`. Le présenter client et les tests qui le lisent
-sont migrés.
+Dans `game/data/localization/<lang>/` : clés stables `faction.<id>.desc` (ex.
+`faction.lumiere.desc`) et `class.<factionId>.<classId>.desc` (ex.
+`class.lumiere.guerrier.desc`). Traduisibles. L'UI les affiche dans une zone
+dédiée mise à jour selon la sélection (faction → classe → sous-classe). Pas de
+texte en dur dans le code.
 
 ---
 
@@ -230,46 +187,48 @@ Emplacement : `src/shardd/gameplay/character/CharacterStatsEngine.{h,cpp}`
 **Calcul déterministe** pour `(level N, classId, factionId, gender)` :
 
 ```
-base(N)   = base_lvl1 + (N-1) * (base_lvl100 - base_lvl1) / (level_max - 1)
-valeur    = round( base(N) * mult_profil[stat] * mult_race[stat]
-                            * mult_sexe[profil].get(stat, 1.0) )
-crit_rate = MIN(10, base_crit(N) * mults)        // plafond garanti par formule
+base(N)    = base_lvl1 + (N-1) * (base_lvl100 - base_lvl1) / (level_max - 1)
+valeur     = round( base(N) * mult_profil[stat] * mult_race[stat]
+                             * mult_sexe[profil].get(stat, 1.0) )   // mult absent => 1.0
+crit_rate  = MIN(10, base_crit(N) * mults)            // cap garanti par formule
+xp_next(N) = round( xp.base * N^xp.factor )
 ```
 
-La **faction** donne la race (race fixe) ; la **classe** donne le profil
-d'archétype + la ressource secondaire.
+**Règles dérivées** (§6.3) :
+- `class_profiles[profil].range == 0` → mêlée pure → **précision/portée nulles**.
+- Vitesses : marche = `speed_walk` (classe×race×sexe) ; course/sprint = `speed_run`.
+- Discrétion = `(perception_base/2) / (stealth_classe × stealth_race × stealth_sexe)`.
+- Endurance = jauge universelle (coûts/régén proportionnels au max).
 
-**Embarquement (CMake)** : une cible custom convertit `character_stats.json` +
-la partie « calcul » de `factions.json` (faction→race, classe→profil/ressource)
-en **header C++ `const` généré** (octets → tableau), régénéré si le JSON change.
-Pas de chemin absolu. Au boot, `shardd` parse la table depuis la donnée
-**embarquée** (jamais le disque) une fois en mémoire. Format additif,
-`schema_version` versionné.
+La **faction** donne la race ; la **classe** donne le profil + la ressource.
+
+**Embarquement (CMake)** : cible custom convertissant `character_stats.json` en
+**header C++ `const` généré** (octets → tableau), régénéré si le JSON change.
+Pas de chemin absolu. Au boot, `shardd` parse la table **embarquée** (jamais le
+disque) une fois en mémoire. `factions.json` (taxonomie) est aussi nécessaire au
+serveur pour le mapping faction→race et classe→profil/ressource → embarqué de la
+même façon (sa partie « calcul »), ou lu côté serveur ; **les multiplicateurs ne
+sont JAMAIS dans `factions.json`** (lisible client).
 
 ---
 
 ## 6. Courbe d'XP
 
-`XP(N→N+1) = base × N^2.6`, `level_max = 100`.
+`XP(N→N+1) = round(6.185 × N^2.6)`, `level_max = 100`. Params dans
+`character_stats.json` (embarqué), pas en dur.
 
-**Calibration** : seul le ratio `base / xp_per_hour` fixe la durée. On fige
-`xp_per_hour` (référence classeur) dans `character_stats.json`, puis on dérive
-`base` pour que `Σ(N=1..59) base·N^2.6 / xp_per_hour ≈ 420 h`.
-
-**Découpage** : `src/shared/formulas/Formulas.h` garde une fonction **pure et
-paramétrée** `XpToNextLevel(level, base, factor, levelMax)` (forme de courbe,
-testable, modifiable). Les **valeurs calibrées** viennent du JSON embarqué
-shardd ; le moteur les passe à la fonction. Le client n'en a pas besoin (le
-serveur réplique `xp` + `level`). `XpToNextLevel` renvoie 0 si `level == 0` ou
-`level >= 100`.
+`src/shared/formulas/Formulas.h` garde une fonction **pure et paramétrée**
+`XpToNextLevel(level, base, factor, levelMax)` (forme testable, modifiable). Les
+valeurs calibrées viennent du JSON embarqué shardd ; le moteur les passe à la
+fonction. `XpToNextLevel` renvoie 0 si `level == 0` ou `level >= 100` (D6). Le
+client n'a pas besoin des params (serveur réplique `xp` + `level`).
 
 ---
 
 ## 7. Extension `Unit` / `Player` (réplication)
 
-**Nouveaux `UpdateField` sur `Unit`** — indices *appended* à la fin de
-`UnitFieldIdx` (ordre stable, le wire en dépend ; ne jamais réassigner un
-indice existant) :
+**Nouveaux `UpdateField` sur `Unit`** — indices *appended* en fin de
+`UnitFieldIdx` (ordre stable ; ne jamais réassigner un indice existant) :
 
 `damage`, `accuracy`, `range`, `crit_rate`, `crit_mult`, `speed_walk`,
 `speed_run`, `speed_sprint`, `stamina`, `maxStamina`, `perception`, `stealth`,
@@ -278,9 +237,8 @@ indice existant) :
 - Entiers → `UpdateField<uint32_t>` ; fractionnaires (crit_mult, vitesses,
   perception, accuracy, range, crit_rate, stealth) → `UpdateField<float>`.
 - `health/mana/level/faction` conservés.
-- **Ressource secondaire** : on réplique seulement valeur + max. Le **libellé**
-  est résolu côté client depuis `factions.json` via la classe connue (pas de
-  champ wire pour le libellé).
+- **Ressource secondaire** : on réplique valeur + max seulement ; le **libellé**
+  est résolu côté client depuis `factions.json` via la classe connue.
 
 **`Player`** : méthode `ApplyDerivedStats(engine, classId, factionId, gender)`
 appelée après chargement DB et à chaque level-up — remplit les `UpdateField`,
@@ -292,19 +250,19 @@ appelée après chargement DB et à chaque level-up — remplit les `UpdateField
 
 - **R1 — Chemin de réplication (BLOQUANT pour le plan)** : confirmer que les
   stats joueur atteignent le client via `UpdateField`/`UpdateMask` et **pas** via
-  le snapshot `EntityState`/`StatsComponent` UDP. Si c'est le snapshot, étendre
-  aussi `SpawnEntity`/`EntityState` — sinon les `UpdateField` resteront
-  invisibles. À lever en début de plan.
-- **R2 — Runtime endurance** : ce design fournit les **données** (max stamina,
-  paliers de régén) et les **champs** répliqués. La boucle de vidage/remplissage
-  (sprint qui consomme, régén par palier, immobile ×1.5, monture=0) est une
-  addition gameplay ; à confirmer si elle entre dans PR1 ou en suivi.
+  le snapshot `EntityState`/`StatsComponent` UDP. Si snapshot : étendre aussi
+  `SpawnEntity`/`EntityState`. À lever en début de plan.
+- **R2 — Runtime endurance** : ce design fournit les **données** (max, coûts,
+  paliers de régén) et les **champs** répliqués. La boucle de
+  consommation/régén (sprint, idle ×1.5, monture=0, jauge vide → plus de course)
+  est une addition gameplay ; à confirmer PR1 vs suivi.
+- **R3 — RÉSOLU** : les multiplicateurs de sexe sont fournis (`sex_profiles`,
+  §6.3). Les échantillons §9 sont comparés à la table embarquée (déterministe).
 
 ### Hors scope (tickets séparés)
 
-Déplacements spéciaux (téléport/vol/dragon), montures, gain d'XP/quêtes,
-économie, craft, armure/défense, résistances, relations de factions (PvP),
-statut hors-la-loi (stats inchangées).
+Déplacements spéciaux, montures, gain d'XP/quêtes, économie, craft,
+armure/défense, résistances, relations de factions (PvP), statut hors-la-loi.
 
 ---
 
@@ -314,16 +272,15 @@ statut hors-la-loi (stats inchangées).
   niveau 60 cumulé ≈ 420 h (tolérance), positivité.
 - **`CharacterStatsEngineTests`** (shardd, ctest Linux) : échantillons §10
   (Guerrier Nain H 60, Lanceur Démon F 100, Voleur Elfe F 1) vs valeurs
-  attendues ; cap crit ≤ 10 avec multiplicateurs forcés ; mêlée → portée nulle
-  (mult range 0.00) ; round-trip JSON → header embarqué → mémoire.
+  calculées des tables ; cap crit ≤ 10 avec multiplicateurs forcés ; mêlée →
+  portée/précision nulles (range profil 0.0) ; round-trip JSON → header embarqué
+  → mémoire.
 - `UnitTests`/`PlayerTests` : nouveaux setters/getters + `MarkDirty`.
 - `RaceDefinitionTests` : `corrompus` absente, `morts_vivants`/`divins`
   `enabled=false`, 5 actives ; tests meshPath conservés.
 - `CharacterCustomizationTests` : retrait références `corrompus`.
-- **Nouveau test factions client** : 9 factions jouables chargées, classes
-  distinctes, `empire_hynn` non jouable.
-- CI : `build-linux` exécute `ctest` (vérifier que les nouveaux tests serveur ne
-  tombent pas dans les exclusions `-E`) ; `build-windows` pour le client.
+- **Nouveau test factions client** : 9 factions sélectionnables, classes
+  distinctes, `empire_hynn` non sélectionnable, clés de localisation présentes.
 
 ---
 
@@ -332,22 +289,25 @@ statut hors-la-loi (stats inchangées).
 ### PR1 — server-first (CI Linux)
 
 `races.json` migré · `factions.json` · `character_stats.json` · migration
-`0072_factions_v2.sql` (dans **`sql/migrations/` ET `deploy/docker/sql/
-migrations/`**) · `CharacterStatsEngine` + header généré + cible CMake ·
-`Formulas.h` (XP) · extension `Unit`/`Player` + `UpdateFieldIndices.h` · tests
-serveur. **Autonome** : le serveur calcule les stats depuis l'identité déjà
-stockée, sans toucher au wire.
+`0072_factions_v2.sql` (rename slugs → ids courts + backfill `faction_str` +
+`race_lock` dragons=humains + ajout serpent/naine/elfe + empire_hynn
+`selectable=false`, **dans `sql/migrations/` ET `deploy/docker/sql/migrations/`**)
+· `CharacterStatsEngine` + header généré + cible CMake · `Formulas.h` (XP) ·
+extension `Unit`/`Player` + `UpdateFieldIndices.h` · tests serveur. **Autonome** :
+le serveur calcule les stats depuis l'identité déjà stockée, sans toucher au wire.
 
 > **Déploiement PR1** : ⚠️ **redéploiement serveur requis** — migration DB 0072
-> + nouveau binaire `shardd` (moteur de stats + champs de réplication).
+> + nouveau binaire `shardd` (moteur de stats + champs réplication).
 
 ### PR2 — client (CI Windows + master)
 
 Wire (`factionId` dans `CharacterCreateRequestPayload` ; `faction_str` dans
 `CharacterListEntry`) · `CharacterCreateHandler` (masterd : validation
-faction/classe/race depuis payload) · refonte `CharacterCreationPresenter`/
-`CharacterCreationUi`/`AuthImGuiCharacterCreate.cpp` (flux faction → classe →
-sexe ; races désactivées + `empire_hynn` masquées) · tests client.
+faction/classe/race depuis payload, stocke `faction_str=factionId`) · refonte
+`CharacterCreationPresenter`/`CharacterCreationUi`/`AuthImGuiCharacterCreate.cpp`
+(flux faction → classe → sexe ; masquer races désactivées + `empire_hynn` ; zone
+de texte descriptive §5.5) · textes de localisation `faction.*`/`class.*` · tests
+client.
 
 > **Déploiement PR2** : ⚠️ **redéploiement serveur (master) requis** —
 > wire-breaking (nouveau champ payload) + handler master modifié ;
@@ -362,14 +322,17 @@ Merge **PR1 → PR2**, CI verte aux deux, déploiement lock-step.
 ## 11. Critères d'acceptation
 
 - `races.json` : 5 actives, `morts_vivants`+`divins` `enabled:false`, `corrompus`
-  supprimée partout (aucune référence résiduelle).
-- 9 factions jouables avec classes 100 % distinctes, chargées ; `empire_hynn`
-  présente mais non jouable.
-- 11 stats calculées correctement (base × profil × race × sexe).
-- `Formulas.h` : courbe `base × N^2.6`, niveau max 100, niveau 60 ≈ 420 h ;
-  `FormulasTests` à jour.
-- Crit de base jamais > 10 quel que soit le réglage.
-- Mêlée pure : portée nulle.
-- JSON embarqué au build : modifier + rebuild change les stats ; aucun accès
-  disque runtime ; client sans multiplicateurs bruts.
-- Tous les tests existants impactés au vert. CI Linux + Windows vertes.
+  supprimée partout.
+- `empire_hynn` conservée dans les données mais `selectable:false`.
+- 9 factions sélectionnables avec classes 100 % distinctes, chargées (ids courts).
+- Zone de texte descriptive affichée à la création, MAJ selon faction/classe,
+  textes issus de la localisation (traduisibles).
+- Stats **NON** stockées en DB : `characters` ne contient que
+  faction/classe/sous-classe/sexe/niveau/xp ; les 11 stats recalculées par `shardd`.
+- 11 stats calculées correctement (base × profil × race × sexe), conformes au §6.3.
+- `Formulas.h` : courbe `6.185 × N^2.6`, niveau max 100, niveau 60 ≈ 420 h.
+- Crit de base jamais > 10.
+- Mêlée pure : précision/portée nulles.
+- JSON embarqué : modifier + rebuild change les stats ; aucun accès disque
+  runtime ; client sans multiplicateurs bruts (`factions.json` seul côté client).
+- Tous les tests impactés au vert. CI Linux + Windows vertes.

--- a/game/data/gameplay/character_stats.json
+++ b/game/data/gameplay/character_stats.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "level_max": 100,
+  "xp": { "formula": "base * level^factor", "factor": 2.6, "base": 6.185, "xp_per_hour_ref": 10000, "calibration": "niveau 60 ~= 420h de jeu" },
+  "bases": {
+    "hp":        { "lvl1": 100, "lvl100": 4000 },
+    "resource":  { "lvl1": 50,  "lvl100": 2000 },
+    "damage":    { "lvl1": 10,  "lvl100": 400 },
+    "accuracy":  { "lvl1": 70,  "lvl100": 95 },
+    "range":     { "lvl1": 20,  "lvl100": 45 },
+    "crit_rate": { "lvl1": 2,   "lvl100": 10, "cap": 10 },
+    "crit_mult": { "base": 1.5 },
+    "speed_walk": 2, "speed_run": 5, "speed_sprint": 8,
+    "stamina":   { "lvl1": 100, "lvl100": 1000 },
+    "stamina_cost_run_pct": 4, "stamina_cost_sprint_pct": 8,
+    "stamina_regen_t1_pct": 4, "stamina_regen_t2_pct": 7, "stamina_regen_t3_pct": 10,
+    "stamina_regen_idle_mult": 1.5,
+    "perception_lvl1": 10, "perception_per_level": 0.5
+  },
+  "class_profiles": {
+    "tank":     { "hp": 1.30, "resource": 0.80, "damage": 0.70, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.40, "crit_mult": 0.90, "speed": 0.85, "perception": 0.80, "stealth": 0.40 },
+    "melee":    { "hp": 1.15, "resource": 1.00, "damage": 1.05, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.70, "crit_mult": 1.00, "speed": 1.00, "perception": 0.90, "stealth": 0.70 },
+    "sacre":    { "hp": 1.10, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 0.00, "crit_rate": 0.70, "crit_mult": 1.00, "speed": 1.00, "perception": 0.95, "stealth": 0.70 },
+    "distance": { "hp": 0.90, "resource": 1.10, "damage": 1.15, "accuracy": 1.00, "range": 1.00, "crit_rate": 0.85, "crit_mult": 1.05, "speed": 1.00, "perception": 1.30, "stealth": 0.90 },
+    "pisteur":  { "hp": 0.95, "resource": 1.10, "damage": 1.10, "accuracy": 1.00, "range": 0.90, "crit_rate": 0.80, "crit_mult": 1.05, "speed": 1.10, "perception": 1.25, "stealth": 1.20 },
+    "voleur":   { "hp": 0.90, "resource": 1.10, "damage": 1.25, "accuracy": 1.00, "range": 0.30, "crit_rate": 1.00, "crit_mult": 1.20, "speed": 1.15, "perception": 1.00, "stealth": 1.40 },
+    "healer":   { "hp": 0.85, "resource": 1.20, "damage": 0.65, "accuracy": 1.00, "range": 0.70, "crit_rate": 0.40, "crit_mult": 0.90, "speed": 1.00, "perception": 1.00, "stealth": 0.70 },
+    "lanceur":  { "hp": 0.75, "resource": 1.30, "damage": 1.30, "accuracy": 1.00, "range": 1.10, "crit_rate": 0.70, "crit_mult": 1.20, "speed": 1.00, "perception": 1.15, "stealth": 0.60 }
+  },
+  "race_profiles": {
+    "humains": { "hp": 1.00, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 1.00, "crit_rate": 1.00, "crit_mult": 1.00, "speed_walk": 1.00, "speed_run": 1.00, "perception": 1.00, "stealth": 1.00 },
+    "nains":   { "hp": 1.20, "resource": 1.00, "damage": 1.00, "accuracy": 1.00, "range": 0.95, "crit_rate": 0.90, "crit_mult": 1.05, "speed_walk": 0.85, "speed_run": 0.80, "perception": 0.90, "stealth": 0.80 },
+    "orcs":    { "hp": 1.15, "resource": 0.90, "damage": 1.20, "accuracy": 0.95, "range": 0.95, "crit_rate": 0.95, "crit_mult": 1.10, "speed_walk": 1.00, "speed_run": 1.00, "perception": 0.90, "stealth": 0.85 },
+    "elfes":   { "hp": 0.90, "resource": 1.10, "damage": 0.95, "accuracy": 1.10, "range": 1.15, "crit_rate": 1.10, "crit_mult": 0.95, "speed_walk": 1.05, "speed_run": 1.15, "perception": 1.25, "stealth": 1.20 },
+    "demons":  { "hp": 1.05, "resource": 1.20, "damage": 1.10, "accuracy": 1.00, "range": 1.00, "crit_rate": 1.00, "crit_mult": 1.10, "speed_walk": 1.00, "speed_run": 1.00, "perception": 1.05, "stealth": 0.90 }
+  },
+  "sex_profiles": {
+    "tank":     { "H": { "hp": 0.95, "crit_mult": 1.03 }, "F": { "hp": 1.05, "crit_mult": 0.97, "speed_walk": 1.08, "speed_run": 1.08 } },
+    "melee":    { "H": { "hp": 0.92, "damage": 1.08, "crit_mult": 1.05 }, "F": { "hp": 1.08, "damage": 0.92, "crit_mult": 0.95 } },
+    "sacre":    { "H": { "hp": 0.95, "damage": 1.06, "crit_mult": 1.04 }, "F": { "hp": 1.05, "resource": 1.06, "damage": 0.94, "crit_mult": 0.96 } },
+    "distance": { "H": { "resource": 1.08, "accuracy": 0.92, "range": 1.08, "crit_mult": 1.05 }, "F": { "resource": 0.92, "accuracy": 1.08, "range": 0.92, "crit_mult": 0.95 } },
+    "pisteur":  { "H": { "resource": 1.06, "accuracy": 0.94, "range": 1.06, "crit_mult": 1.04 }, "F": { "resource": 0.94, "accuracy": 1.06, "range": 0.94, "stealth": 1.06, "crit_mult": 0.96 } },
+    "voleur":   { "H": { "damage": 1.07, "stealth": 0.93, "crit_mult": 1.05 }, "F": { "damage": 0.93, "stealth": 1.07, "crit_mult": 0.95 } },
+    "healer":   { "H": { "hp": 0.95, "damage": 1.07, "accuracy": 0.94, "crit_mult": 1.04 }, "F": { "resource": 1.06, "damage": 0.93, "accuracy": 1.06, "crit_mult": 0.96 } },
+    "lanceur":  { "H": { "hp": 0.95, "resource": 0.92, "damage": 1.08, "accuracy": 0.94, "range": 1.06, "crit_mult": 1.05 }, "F": { "resource": 1.08, "damage": 0.92, "accuracy": 1.06, "range": 0.94, "crit_mult": 0.95 } }
+  }
+}

--- a/game/data/races/factions.json
+++ b/game/data/races/factions.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "factions": [
+    { "id": "lumiere", "name": "Chevaliers de la Lumière", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "voleur", "name": "Voleur", "profile": "voleur", "resource": "reflexes" },
+      { "id": "inquisiteur_chatieur", "name": "Inquisiteur", "subclass": "Châtieur", "profile": "melee", "resource": "ferveur" },
+      { "id": "inquisiteur_hospitalier", "name": "Inquisiteur", "subclass": "Hospitalier", "profile": "healer", "resource": "ferveur" }
+    ] },
+    { "id": "justice", "name": "Chevaliers de la Justice", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "paladin", "name": "Paladin", "profile": "sacre", "resource": "ferveur" },
+      { "id": "pretre_jugement", "name": "Prêtre", "subclass": "du Jugement", "profile": "lanceur", "resource": "ferveur" },
+      { "id": "pretre_grace", "name": "Prêtre", "subclass": "de la Grâce", "profile": "healer", "resource": "ferveur" }
+    ] },
+    { "id": "lune_noire", "name": "La Lune Noire", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "arbaletrier", "name": "Arbalétrier", "profile": "distance", "resource": "souffle" },
+      { "id": "pretre_lune_noire", "name": "Prêtre de la Lune Noire", "profile": "lanceur", "resource": "devotion" },
+      { "id": "menthats", "name": "Menthats", "profile": "lanceur", "resource": "magie" }
+    ] },
+    { "id": "dzorak", "name": "Dzorak", "race": "orcs", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "chaman", "name": "Chaman", "profile": "lanceur", "resource": "transe" },
+      { "id": "archer", "name": "Archer", "profile": "distance", "resource": "souffle" },
+      { "id": "pisteur", "name": "Pisteur", "profile": "pisteur", "resource": "instinct" }
+    ] },
+    { "id": "legion", "name": "Légion infernale", "race": "demons", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "demoniste", "name": "Démoniste", "profile": "lanceur", "resource": "corruption" },
+      { "id": "tourmenteur", "name": "Tourmenteur", "profile": "melee", "resource": "corruption" },
+      { "id": "sorcier_sang", "name": "Sorcier de sang", "profile": "lanceur", "resource": "corruption" }
+    ] },
+    { "id": "dragons", "name": "Chevaliers-Dragons", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archimage", "name": "Archimage", "profile": "lanceur", "resource": "flamme_draconique" },
+      { "id": "dragonnier", "name": "Dragonnier", "profile": "melee", "resource": "furie_draconique" },
+      { "id": "gardien_ecailles", "name": "Gardien d'écailles", "profile": "tank", "resource": "ecaille" }
+    ] },
+    { "id": "serpent", "name": "Maison du Serpent", "race": "humains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archimage", "name": "Archimage", "profile": "lanceur", "resource": "magie_base" },
+      { "id": "assassin", "name": "Assassin", "profile": "voleur", "resource": "reflexes" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" }
+    ] },
+    { "id": "naine", "name": "Faction Naine", "race": "nains", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "pisteur", "name": "Pisteur", "profile": "pisteur", "resource": "instinct" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" },
+      { "id": "brise_roc", "name": "Brise-roc", "profile": "tank", "resource": "endurance" }
+    ] },
+    { "id": "elfe", "name": "Faction Elfe", "race": "elfes", "selectable": true, "classes": [
+      { "id": "guerrier", "name": "Guerrier", "profile": "melee", "resource": "endurance" },
+      { "id": "archer_bois", "name": "Archer", "subclass": "Bois", "profile": "distance", "resource": "souffle" },
+      { "id": "voleur_tenebreux", "name": "Voleur", "subclass": "Ténébreux", "profile": "voleur", "resource": "reflexes" },
+      { "id": "mage", "name": "Mage", "profile": "lanceur", "resource": "magie_base" }
+    ] },
+    { "id": "empire_hynn", "name": "L'Empire de L'hynn", "race": "humains", "selectable": false, "classes": [] }
+  ]
+}

--- a/sql/migrations/0072_factions_v2.sql
+++ b/sql/migrations/0072_factions_v2.sql
@@ -1,0 +1,40 @@
+-- Migration 0072 — Factions v2 : alignement sur les ids courts du design
+-- (Système de Personnages). Renomme les slugs longs de 0040, ajoute les
+-- nouvelles factions, repasse Chevaliers-Dragons en race humains, et
+-- backfill characters.faction_str. Idempotent.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+START TRANSACTION;
+
+-- 1) Renommer les slugs existants vers les ids courts + corriger race_lock.
+UPDATE factions SET name='lumiere'    WHERE name='chevaliers_lumiere';
+UPDATE factions SET name='justice'    WHERE name='chevaliers_justice';
+UPDATE factions SET name='legion', display_name='Légion infernale' WHERE name='demons';
+UPDATE factions SET name='dragons', race_lock='humains' WHERE name='chevaliers_dragons';
+-- lune_noire, dzorak, empire_hynn : ids déjà alignés.
+
+-- 2) Ajouter les nouvelles factions (INSERT IGNORE = idempotent sur uq_factions_name).
+INSERT IGNORE INTO factions (name, display_name, race_lock, parent_faction_id, description) VALUES
+  ('serpent', 'Maison du Serpent', 'humains', NULL, 'Maison humaine versée dans la magie et l''ombre.'),
+  ('naine',   'Faction Naine',     'nains',   NULL, 'Peuple nain : guerriers tenaces et artisans.'),
+  ('elfe',    'Faction Elfe',      'elfes',   NULL, 'Peuple elfe : agilité, magie et discrétion.');
+
+-- 3) empire_hynn : conservée, NON sélectionnable. Ajouter la colonne `selectable`
+--    si absente (défaut 1), puis marquer empire_hynn à 0.
+SET @col_exists := (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE table_schema = DATABASE() AND table_name='factions' AND column_name='selectable');
+SET @stmt := IF(@col_exists = 0,
+  'ALTER TABLE factions ADD COLUMN selectable TINYINT(1) NOT NULL DEFAULT 1 COMMENT ''0 = présente mais non sélectionnable à la création''',
+  'SELECT ''column factions.selectable already exists, skipping''');
+PREPARE a FROM @stmt; EXECUTE a; DEALLOCATE PREPARE a;
+UPDATE factions SET selectable = 0 WHERE name = 'empire_hynn';
+
+-- 4) Backfill characters.faction_str pour les slugs renommés (persos existants).
+UPDATE characters SET faction_str='lumiere' WHERE faction_str='chevaliers_lumiere';
+UPDATE characters SET faction_str='justice' WHERE faction_str='chevaliers_justice';
+UPDATE characters SET faction_str='legion'  WHERE faction_str='demons';
+UPDATE characters SET faction_str='dragons' WHERE faction_str='chevaliers_dragons';
+
+COMMIT;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,29 @@ set(CMAKE_CXX_STANDARD 20)
 #   include(LCDLLNHelpers)
 # Le helper est donc disponible ici sans redefinition.
 
+# ── Embarquement anti-triche : JSON game/data → headers const (générés au build).
+set(LCDLLN_GEN_DIR ${CMAKE_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${LCDLLN_GEN_DIR})
+
+set(STATS_JSON    ${CMAKE_SOURCE_DIR}/game/data/gameplay/character_stats.json)
+set(STATS_HDR     ${LCDLLN_GEN_DIR}/CharacterStatsData.h)
+set(FACTIONS_JSON ${CMAKE_SOURCE_DIR}/game/data/races/factions.json)
+set(FACTIONS_HDR  ${LCDLLN_GEN_DIR}/FactionsData.h)
+
+add_custom_command(
+  OUTPUT  ${STATS_HDR}
+  COMMAND ${CMAKE_COMMAND} -DINPUT=${STATS_JSON} -DOUTPUT=${STATS_HDR} -DSYMBOL=kCharacterStatsJson -P ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  DEPENDS ${STATS_JSON} ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  COMMENT "Embedding character_stats.json -> CharacterStatsData.h")
+
+add_custom_command(
+  OUTPUT  ${FACTIONS_HDR}
+  COMMAND ${CMAKE_COMMAND} -DINPUT=${FACTIONS_JSON} -DOUTPUT=${FACTIONS_HDR} -DSYMBOL=kFactionsJson -P ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  DEPENDS ${FACTIONS_JSON} ${CMAKE_SOURCE_DIR}/cmake/EmbedJson.cmake
+  COMMENT "Embedding factions.json -> FactionsData.h")
+
+add_custom_target(lcdlln_gen_character_data DEPENDS ${STATS_HDR} ${FACTIONS_HDR})
+
 if(WIN32)
   add_executable(server_app
     ${CMAKE_SOURCE_DIR}/src/shardd/main_win.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -556,6 +556,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(formulas_tests
     ${CMAKE_SOURCE_DIR}/src/shared/formulas/FormulasTests.cpp)
 
+  # Character system PR1 — Config::LoadFromString : parsing JSON en mémoire (anti-triche).
+  lcdlln_add_simple_test(config_loadfromstring_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/core/ConfigLoadFromStringTests.cpp)
+
   # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
   lcdlln_add_simple_test(metric_registry_tests
     ${CMAKE_SOURCE_DIR}/src/shared/metric/MetricRegistryTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,9 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shared/net/ChatSystem.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/net/ChatEmotes.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistence.cpp
+    # Character system PR1 — moteur de stats (serveur-only, anti-triche).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp
@@ -88,6 +91,9 @@ if(WIN32)
   # M32.1: no MySQL on WIN32 game shard — FriendSystem compiles in no-DB mode.
   # Do NOT define ENGINE_HAS_MYSQL so #if ENGINE_HAS_MYSQL evaluates to false.
   target_link_libraries(server_app PRIVATE ws2_32 engine_auth spdlog::spdlog)
+  # Character system PR1 — accès aux headers JSON embarqués (anti-triche).
+  add_dependencies(server_app lcdlln_gen_character_data)
+  target_include_directories(server_app PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
 elseif(UNIX)
   find_package(OpenSSL REQUIRED)
   find_path(MYSQL_INCLUDE_DIR NAMES mysql.h mysql/mysql.h PATH_SUFFIXES mysql)
@@ -583,6 +589,21 @@ elseif(UNIX)
   lcdlln_add_simple_test(config_loadfromstring_tests
     ${CMAKE_SOURCE_DIR}/src/shared/core/ConfigLoadFromStringTests.cpp)
 
+  # Character system PR1 — CharacterStatsEngine : 11 stats déterministes depuis
+  # les tables JSON embarquées. Bloc explicite (pas lcdlln_add_simple_test) :
+  # le test a besoin du dossier des headers générés (${LCDLLN_GEN_DIR}) et de
+  # la dépendance au codegen lcdlln_gen_character_data, que le helper ne sait
+  # pas exprimer.
+  add_executable(character_stats_engine_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(character_stats_engine_tests lcdlln_gen_character_data)
+  target_include_directories(character_stats_engine_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(character_stats_engine_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(character_stats_engine_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME character_stats_engine_tests COMMAND character_stats_engine_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
   lcdlln_add_simple_test(metric_registry_tests
     ${CMAKE_SOURCE_DIR}/src/shared/metric/MetricRegistryTests.cpp)
@@ -1015,6 +1036,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/guild/GuildTabard.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/guild/GuildBank.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistence.cpp
+    # Character system PR1 — moteur de stats (serveur-only, anti-triche).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp
@@ -1041,7 +1065,9 @@ elseif(UNIX)
   # SHARD_POSITION_DB (et NON ENGINE_HAS_MYSQL) : n'active que le pont position dans
   # ServerApp, sans basculer les autres systèmes gameplay du shard en mode DB (ils restent
   # en mode fichier, config TA.2 prouvée linkable).
-  target_include_directories(shard_app PRIVATE ${CMAKE_SOURCE_DIR} ${MYSQL_INCLUDE_DIR})
+  target_include_directories(shard_app PRIVATE ${CMAKE_SOURCE_DIR} ${MYSQL_INCLUDE_DIR} ${LCDLLN_GEN_DIR})
+  # Character system PR1 — accès aux headers JSON embarqués (anti-triche).
+  add_dependencies(shard_app lcdlln_gen_character_data)
   target_compile_definitions(shard_app PRIVATE SHARD_POSITION_DB=1)
   target_link_libraries(shard_app PRIVATE engine_core OpenSSL::SSL pthread ${MYSQL_LIBRARY})
   target_compile_options(shard_app PRIVATE -Wall -Wextra -Wpedantic)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,8 +253,15 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Player.cpp
     # Wave 17 Entities suite : Creature (Unit + templateEntry/spawnId).
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Creature.cpp
+    # Character system PR1 — Player::ApplyDerivedStats référence le moteur de
+    # stats ; ce server_app (master Linux) compile Player.cpp, il doit donc
+    # aussi compiler le moteur sinon LINK FAILURE (ComputeStats/FromEmbedded).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
   )
-  target_include_directories(server_app PRIVATE ${MYSQL_INCLUDE_DIR} ${CMAKE_SOURCE_DIR})
+  # Character system PR1 — accès aux headers JSON embarqués (anti-triche).
+  add_dependencies(server_app lcdlln_gen_character_data)
+  target_include_directories(server_app PRIVATE ${MYSQL_INCLUDE_DIR} ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
   # M32.1: MySQL available on UNIX — FriendSystem compiles with full DB support.
   target_compile_definitions(server_app PRIVATE ENGINE_HAS_MYSQL=1)
   target_link_libraries(server_app PRIVATE pthread OpenSSL::SSL engine_auth spdlog::spdlog ${MYSQL_LIBRARY})
@@ -455,12 +462,23 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp)
 
   # Wave 17 Entities suite : Player tests (accountId/characterId/name/xp + heritage Unit).
-  lcdlln_add_simple_test(player_tests
+  # Character system PR1 — depuis Player::ApplyDerivedStats, PlayerTests référence
+  # le moteur de stats : bloc explicite (pas lcdlln_add_simple_test) pour ajouter
+  # les sources du moteur, la dépendance au codegen et le dossier des headers
+  # générés (${LCDLLN_GEN_DIR}), que le helper ne sait pas exprimer.
+  add_executable(player_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/PlayerTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Player.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Unit.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/WorldObject.cpp
-    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp)
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(player_tests lcdlln_gen_character_data)
+  target_include_directories(player_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(player_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(player_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME player_tests COMMAND player_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # Wave 17 Entities suite : Creature tests (templateEntry/spawnId + heritage Unit).
   lcdlln_add_simple_test(creature_tests
@@ -473,13 +491,24 @@ elseif(UNIX)
   # Wave 17 Entities suite : UpdateMask delta tests cross-classe.
   # Verifie que les modifications sur Unit/Player/Creature ne marquent que
   # les champs effectivement changes (critique pour delta replication).
-  lcdlln_add_simple_test(update_mask_delta_tests
+  # Character system PR1 — compile Player.cpp donc référence Player::ApplyDerivedStats
+  # -> doit lier le moteur de stats (ComputeStats/FromEmbedded) sinon LINK FAILURE.
+  # Bloc explicite (pas lcdlln_add_simple_test) pour ajouter les sources moteur +
+  # la dépendance au codegen.
+  add_executable(update_mask_delta_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/UpdateMaskDeltaTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Creature.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Player.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/Unit.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/entities/WorldObject.cpp
-    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp)
+    ${CMAKE_SOURCE_DIR}/src/shardd/entities/Object.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(update_mask_delta_tests lcdlln_gen_character_data)
+  target_include_directories(update_mask_delta_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(update_mask_delta_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(update_mask_delta_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME update_mask_delta_tests COMMAND update_mask_delta_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # TA.1 (replication des joueurs) : UdpTransport rendu cross-platform (Winsock +
   # BSD sockets POSIX). Le test loopback 127.0.0.1 valide le chemin POSIX a

--- a/src/shardd/entities/Player.cpp
+++ b/src/shardd/entities/Player.cpp
@@ -1,9 +1,34 @@
-// Player : translation unit. Toutes les methodes sont inline dans le header.
-// Ce .cpp existe pour CMake (cible nommee + symbole faible si methodes
-// deplacees out-of-line dans le futur).
+// Player : translation unit. La plupart des methodes sont inline dans le header ;
+// ApplyDerivedStats est out-of-line car elle depend du moteur de stats
+// (CharacterStatsEngine) — on garde le header leger cote dependances.
 #include "src/shardd/entities/Player.h"
 
 namespace engine::server::entities
 {
-	// Methodes out-of-line a ajouter au besoin.
+	bool Player::ApplyDerivedStats(const engine::server::gameplay::CharacterStatsTables& tables,
+	                               const std::string& factionId,
+	                               const std::string& classId,
+	                               engine::server::gameplay::Sex sex)
+	{
+		auto d = engine::server::gameplay::ComputeStats(tables, factionId, classId, sex, GetLevel());
+		if (!d) return false;
+
+		SetMaxHealth(d->hp);
+		SetHealth(d->hp);                    // plein a l'application (apres SetMaxHealth pour le clamp)
+		SetMaxSecondaryResource(d->resource);
+		SetSecondaryResource(d->resource);
+		SetDamage(d->damage);
+		SetAccuracy(d->accuracy);
+		SetRange(d->range);
+		SetCritRate(d->critRate);
+		SetCritMult(d->critMult);
+		SetSpeedWalk(d->speedWalk);
+		SetSpeedRun(d->speedRun);
+		SetSpeedSprint(d->speedSprint);
+		SetMaxStamina(d->stamina);
+		SetStamina(d->stamina);
+		SetPerception(d->perception);
+		SetStealth(d->stealth);
+		return true;
+	}
 }

--- a/src/shardd/entities/Player.h
+++ b/src/shardd/entities/Player.h
@@ -12,6 +12,7 @@
 #include "src/shardd/entities/Unit.h"
 #include "src/shardd/entities/UpdateField.h"
 #include "src/shardd/entities/UpdateFieldIndices.h"
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
 
 #include <cstdint>
 #include <cstddef>
@@ -50,6 +51,16 @@ namespace engine::server::entities
 
 		void SetXp(uint32_t xp) { m_xp.Set(xp); }
 		uint32_t GetXp() const noexcept { return m_xp.Get(); }
+
+		/// Recalcule et applique les 11 stats dérivées pour ce joueur depuis les
+		/// tables embarquées + (faction, classe, sexe, niveau courant). Remplit les
+		/// UpdateField (MarkDirty implicite via Set). HP et ressource sont mis au
+		/// plein. À appeler après chargement DB et à chaque level-up.
+		/// \return false si (faction, classe) est inconnue dans les tables.
+		bool ApplyDerivedStats(const engine::server::gameplay::CharacterStatsTables& tables,
+		                       const std::string& factionId,
+		                       const std::string& classId,
+		                       engine::server::gameplay::Sex sex);
 
 	private:
 		UpdateField<uint64_t> m_accountId;

--- a/src/shardd/entities/PlayerTests.cpp
+++ b/src/shardd/entities/PlayerTests.cpp
@@ -3,6 +3,11 @@
 // Cible CTest : player_tests (cf. src/CMakeLists.txt).
 
 #include "src/shardd/entities/Player.h"
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
 
 #include <cassert>
 #include <cstdio>
@@ -91,6 +96,57 @@ namespace
 		assert(p.GetMapId() == 1);
 		std::puts("[OK] TestPlayerHeriteWorldObject");
 	}
+
+	/// Câblage moteur de stats -> UpdateField via Player::ApplyDerivedStats.
+	/// Voleur Ténébreux Elfe Femme niv.1 -> hp attendu 81 (ancre vérifiée dans
+	/// CharacterStatsEngineTests : 100 * 0.90 * 0.90 = 81). Renvoie un bool et
+	/// N'UTILISE PAS assert (désactivé sous NDEBUG en CI Release) : le résultat
+	/// est propagé à main() qui sort en code non nul en cas d'échec.
+	bool TestApplyDerivedStats()
+	{
+		using namespace engine::server::gameplay;
+
+		auto tables = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!tables) { std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: FromEmbedded\n"); return false; }
+
+		ObjectGuid g(ObjectType::Player, 7);
+		Player p(g, /*accountId*/2002, /*characterId*/7, /*name*/"Ombre");
+		p.SetLevel(1);
+		if (!p.ApplyDerivedStats(*tables, "elfe", "voleur_tenebreux", Sex::Female))
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: ApplyDerivedStats returned false\n");
+			return false;
+		}
+		if (p.GetMaxHealth() != 81u)
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: maxHealth=%u (attendu 81)\n", p.GetMaxHealth());
+			return false;
+		}
+		if (p.GetHealth() != 81u)
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: health=%u (attendu 81)\n", p.GetHealth());
+			return false;
+		}
+		if (p.GetSecondaryResource() != p.GetMaxSecondaryResource())
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: resource %u != max %u\n",
+			             p.GetSecondaryResource(), p.GetMaxSecondaryResource());
+			return false;
+		}
+		if (p.GetMaxSecondaryResource() == 0u)
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: maxSecondaryResource == 0\n");
+			return false;
+		}
+		// Stat inconnue -> false, sans modifier l'état déjà appliqué.
+		if (p.ApplyDerivedStats(*tables, "faction_inexistante", "classe_bidon", Sex::Male))
+		{
+			std::fprintf(stderr, "[FAIL] TestApplyDerivedStats: faction inconnue aurait dû renvoyer false\n");
+			return false;
+		}
+		std::puts("[OK] TestApplyDerivedStats");
+		return true;
+	}
 }
 
 int main()
@@ -101,6 +157,9 @@ int main()
 	TestPlayerXp();
 	TestPlayerHeriteUnit();
 	TestPlayerHeriteWorldObject();
+	// Test robuste sous NDEBUG : échec signalé par le code de sortie process.
+	if (!TestApplyDerivedStats())
+		return 1;
 	std::puts("All Player tests passed");
 	return 0;
 }

--- a/src/shardd/entities/Unit.h
+++ b/src/shardd/entities/Unit.h
@@ -32,6 +32,20 @@ namespace engine::server::entities
 			, m_maxMana(kUnitFieldMaxMana, &Mask())
 			, m_level(kUnitFieldLevel, &Mask())
 			, m_faction(kUnitFieldFaction, &Mask())
+			, m_damage(kUnitFieldDamage, &Mask())
+			, m_accuracy(kUnitFieldAccuracy, &Mask())
+			, m_range(kUnitFieldRange, &Mask())
+			, m_critRate(kUnitFieldCritRate, &Mask())
+			, m_critMult(kUnitFieldCritMult, &Mask())
+			, m_speedWalk(kUnitFieldSpeedWalk, &Mask())
+			, m_speedRun(kUnitFieldSpeedRun, &Mask())
+			, m_speedSprint(kUnitFieldSpeedSprint, &Mask())
+			, m_stamina(kUnitFieldStamina, &Mask())
+			, m_maxStamina(kUnitFieldMaxStamina, &Mask())
+			, m_perception(kUnitFieldPerception, &Mask())
+			, m_stealth(kUnitFieldStealth, &Mask())
+			, m_secondaryResource(kUnitFieldSecondaryResource, &Mask())
+			, m_maxSecondaryResource(kUnitFieldMaxSecondaryResource, &Mask())
 		{}
 
 		~Unit() override = default;
@@ -68,6 +82,36 @@ namespace engine::server::entities
 		/// True si HP > 0.
 		bool IsAlive() const noexcept { return m_health.Get() > 0; }
 
+		// --- Stats étendues (Système de Personnages) ---
+		void SetDamage(uint32_t v) { m_damage.Set(v); }
+		uint32_t GetDamage() const noexcept { return m_damage.Get(); }
+		void SetAccuracy(float v) { m_accuracy.Set(v); }
+		float GetAccuracy() const noexcept { return m_accuracy.Get(); }
+		void SetRange(float v) { m_range.Set(v); }
+		float GetRange() const noexcept { return m_range.Get(); }
+		void SetCritRate(float v) { m_critRate.Set(v); }
+		float GetCritRate() const noexcept { return m_critRate.Get(); }
+		void SetCritMult(float v) { m_critMult.Set(v); }
+		float GetCritMult() const noexcept { return m_critMult.Get(); }
+		void SetSpeedWalk(float v) { m_speedWalk.Set(v); }
+		float GetSpeedWalk() const noexcept { return m_speedWalk.Get(); }
+		void SetSpeedRun(float v) { m_speedRun.Set(v); }
+		float GetSpeedRun() const noexcept { return m_speedRun.Get(); }
+		void SetSpeedSprint(float v) { m_speedSprint.Set(v); }
+		float GetSpeedSprint() const noexcept { return m_speedSprint.Get(); }
+		void SetStamina(uint32_t v) { m_stamina.Set(v); }
+		uint32_t GetStamina() const noexcept { return m_stamina.Get(); }
+		void SetMaxStamina(uint32_t v) { m_maxStamina.Set(v); }
+		uint32_t GetMaxStamina() const noexcept { return m_maxStamina.Get(); }
+		void SetPerception(float v) { m_perception.Set(v); }
+		float GetPerception() const noexcept { return m_perception.Get(); }
+		void SetStealth(float v) { m_stealth.Set(v); }
+		float GetStealth() const noexcept { return m_stealth.Get(); }
+		void SetSecondaryResource(uint32_t v) { m_secondaryResource.Set(v); }
+		uint32_t GetSecondaryResource() const noexcept { return m_secondaryResource.Get(); }
+		void SetMaxSecondaryResource(uint32_t v) { m_maxSecondaryResource.Set(v); }
+		uint32_t GetMaxSecondaryResource() const noexcept { return m_maxSecondaryResource.Get(); }
+
 	private:
 		UpdateField<uint32_t> m_health;
 		UpdateField<uint32_t> m_maxHealth;
@@ -75,5 +119,20 @@ namespace engine::server::entities
 		UpdateField<uint32_t> m_maxMana;
 		UpdateField<uint32_t> m_level;
 		UpdateField<uint32_t> m_faction;
+		// --- Stats étendues (Système de Personnages) ---
+		UpdateField<uint32_t> m_damage;
+		UpdateField<float>    m_accuracy;
+		UpdateField<float>    m_range;
+		UpdateField<float>    m_critRate;
+		UpdateField<float>    m_critMult;
+		UpdateField<float>    m_speedWalk;
+		UpdateField<float>    m_speedRun;
+		UpdateField<float>    m_speedSprint;
+		UpdateField<uint32_t> m_stamina;
+		UpdateField<uint32_t> m_maxStamina;
+		UpdateField<float>    m_perception;
+		UpdateField<float>    m_stealth;
+		UpdateField<uint32_t> m_secondaryResource;
+		UpdateField<uint32_t> m_maxSecondaryResource;
 	};
 }

--- a/src/shardd/entities/UnitTests.cpp
+++ b/src/shardd/entities/UnitTests.cpp
@@ -120,6 +120,43 @@ namespace
 		assert(u.GetMapId() == 1);
 		std::puts("[OK] TestUnitHeriteWorldObject");
 	}
+
+	/// Stats étendues (Système de Personnages) : round-trip des nouveaux
+	/// UpdateField (entiers + flottants) et flag dirty via le mask.
+	void TestUnitNewStatFields()
+	{
+		ObjectGuid g(ObjectType::Creature, 9);
+		Unit u(g, kUnitFieldCount);
+		u.SetDamage(123u);
+		u.SetAccuracy(88.0f);
+		u.SetRange(30.0f);
+		u.SetCritRate(7.5f);
+		u.SetCritMult(1.8f);
+		u.SetSpeedWalk(2.0f);
+		u.SetSpeedRun(5.0f);
+		u.SetSpeedSprint(8.0f);
+		u.SetStamina(500u);
+		u.SetMaxStamina(800u);
+		u.SetPerception(12.5f);
+		u.SetStealth(9.0f);
+		u.SetSecondaryResource(40u);
+		u.SetMaxSecondaryResource(100u);
+
+		// Round-trip valeurs (entiers exacts, flottants avec tolerance).
+		assert(u.GetDamage() == 123u);
+		assert(u.GetCritRate() >= 7.49f && u.GetCritRate() <= 7.51f);
+		assert(u.GetCritMult() >= 1.79f && u.GetCritMult() <= 1.81f);
+		assert(u.GetMaxStamina() == 800u);
+		assert(u.GetSecondaryResource() == 40u);
+		assert(u.GetMaxSecondaryResource() == 100u);
+		assert(u.GetPerception() >= 12.49f && u.GetPerception() <= 12.51f);
+
+		// Le mask reflete les champs modifies.
+		assert(u.IsDirty());
+		assert(u.Mask().TestBit(kUnitFieldDamage));
+		assert(u.Mask().TestBit(kUnitFieldMaxSecondaryResource));
+		std::puts("[OK] TestUnitNewStatFields");
+	}
 }
 
 int main()
@@ -132,6 +169,7 @@ int main()
 	TestUnitOnReplicationSentClearsMask();
 	TestUnitIsAliveToggle();
 	TestUnitHeriteWorldObject();
+	TestUnitNewStatFields();
 	std::puts("All Unit tests passed");
 	return 0;
 }

--- a/src/shardd/entities/UnitTests.cpp
+++ b/src/shardd/entities/UnitTests.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 
 using namespace engine::server::entities;
 
@@ -125,6 +126,7 @@ namespace
 	/// UpdateField (entiers + flottants) et flag dirty via le mask.
 	void TestUnitNewStatFields()
 	{
+#define CHECK_UNIT(cond) do { if (!(cond)) { std::fprintf(stderr, "[FAIL] UnitTests: %s\n", #cond); std::abort(); } } while (0)
 		ObjectGuid g(ObjectType::Creature, 9);
 		Unit u(g, kUnitFieldCount);
 		u.SetDamage(123u);
@@ -143,19 +145,20 @@ namespace
 		u.SetMaxSecondaryResource(100u);
 
 		// Round-trip valeurs (entiers exacts, flottants avec tolerance).
-		assert(u.GetDamage() == 123u);
-		assert(u.GetCritRate() >= 7.49f && u.GetCritRate() <= 7.51f);
-		assert(u.GetCritMult() >= 1.79f && u.GetCritMult() <= 1.81f);
-		assert(u.GetMaxStamina() == 800u);
-		assert(u.GetSecondaryResource() == 40u);
-		assert(u.GetMaxSecondaryResource() == 100u);
-		assert(u.GetPerception() >= 12.49f && u.GetPerception() <= 12.51f);
+		CHECK_UNIT(u.GetDamage() == 123u);
+		CHECK_UNIT(u.GetCritRate() >= 7.49f && u.GetCritRate() <= 7.51f);
+		CHECK_UNIT(u.GetCritMult() >= 1.79f && u.GetCritMult() <= 1.81f);
+		CHECK_UNIT(u.GetMaxStamina() == 800u);
+		CHECK_UNIT(u.GetSecondaryResource() == 40u);
+		CHECK_UNIT(u.GetMaxSecondaryResource() == 100u);
+		CHECK_UNIT(u.GetPerception() >= 12.49f && u.GetPerception() <= 12.51f);
 
 		// Le mask reflete les champs modifies.
-		assert(u.IsDirty());
-		assert(u.Mask().TestBit(kUnitFieldDamage));
-		assert(u.Mask().TestBit(kUnitFieldMaxSecondaryResource));
+		CHECK_UNIT(u.IsDirty());
+		CHECK_UNIT(u.Mask().TestBit(kUnitFieldDamage));
+		CHECK_UNIT(u.Mask().TestBit(kUnitFieldMaxSecondaryResource));
 		std::puts("[OK] TestUnitNewStatFields");
+#undef CHECK_UNIT
 	}
 }
 

--- a/src/shardd/entities/UpdateFieldIndices.h
+++ b/src/shardd/entities/UpdateFieldIndices.h
@@ -76,11 +76,11 @@ namespace engine::server::entities
 	/// Indices pour Player (extends Unit). Demarre apres Unit end.
 	enum PlayerFieldIdx : size_t
 	{
-		kPlayerFieldAccountId    = kUnitFieldEnd,      // 17
-		kPlayerFieldCharacterId  = kUnitFieldEnd + 1,  // 18
-		kPlayerFieldXp           = kUnitFieldEnd + 2,  // 19
+		kPlayerFieldAccountId    = kUnitFieldEnd,      // 31
+		kPlayerFieldCharacterId  = kUnitFieldEnd + 1,  // 32
+		kPlayerFieldXp           = kUnitFieldEnd + 2,  // 33
 
-		kPlayerFieldEnd          = kUnitFieldEnd + 3   // 20
+		kPlayerFieldEnd          = kUnitFieldEnd + 3   // 34
 	};
 
 	static constexpr size_t kPlayerFieldCount = kPlayerFieldEnd;
@@ -88,10 +88,10 @@ namespace engine::server::entities
 	/// Indices pour Creature (extends Unit). Demarre apres Unit end (parallele a Player).
 	enum CreatureFieldIdx : size_t
 	{
-		kCreatureFieldTemplateEntry = kUnitFieldEnd,      // 17
-		kCreatureFieldSpawnId       = kUnitFieldEnd + 1,  // 18
+		kCreatureFieldTemplateEntry = kUnitFieldEnd,      // 31
+		kCreatureFieldSpawnId       = kUnitFieldEnd + 1,  // 32
 
-		kCreatureFieldEnd           = kUnitFieldEnd + 2   // 19
+		kCreatureFieldEnd           = kUnitFieldEnd + 2   // 33
 	};
 
 	static constexpr size_t kCreatureFieldCount = kCreatureFieldEnd;

--- a/src/shardd/entities/UpdateFieldIndices.h
+++ b/src/shardd/entities/UpdateFieldIndices.h
@@ -52,8 +52,23 @@ namespace engine::server::entities
 		kUnitFieldMaxMana     = kWorldObjectFieldEnd + 3,  // 14
 		kUnitFieldLevel       = kWorldObjectFieldEnd + 4,  // 15
 		kUnitFieldFaction     = kWorldObjectFieldEnd + 5,  // 16
+		// --- Stats étendues (Système de Personnages) ---
+		kUnitFieldDamage              = kWorldObjectFieldEnd + 6,  // 17
+		kUnitFieldAccuracy            = kWorldObjectFieldEnd + 7,  // 18
+		kUnitFieldRange               = kWorldObjectFieldEnd + 8,  // 19
+		kUnitFieldCritRate            = kWorldObjectFieldEnd + 9,  // 20
+		kUnitFieldCritMult            = kWorldObjectFieldEnd + 10, // 21
+		kUnitFieldSpeedWalk           = kWorldObjectFieldEnd + 11, // 22
+		kUnitFieldSpeedRun            = kWorldObjectFieldEnd + 12, // 23
+		kUnitFieldSpeedSprint         = kWorldObjectFieldEnd + 13, // 24
+		kUnitFieldStamina             = kWorldObjectFieldEnd + 14, // 25
+		kUnitFieldMaxStamina          = kWorldObjectFieldEnd + 15, // 26
+		kUnitFieldPerception          = kWorldObjectFieldEnd + 16, // 27
+		kUnitFieldStealth             = kWorldObjectFieldEnd + 17, // 28
+		kUnitFieldSecondaryResource   = kWorldObjectFieldEnd + 18, // 29
+		kUnitFieldMaxSecondaryResource= kWorldObjectFieldEnd + 19, // 30
 
-		kUnitFieldEnd         = kWorldObjectFieldEnd + 6   // 17
+		kUnitFieldEnd         = kWorldObjectFieldEnd + 20   // 31
 	};
 
 	static constexpr size_t kUnitFieldCount = kUnitFieldEnd;

--- a/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsEngine.cpp
@@ -1,0 +1,97 @@
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::server::gameplay
+{
+	namespace
+	{
+		/// Interpolation linéaire d'une StatBase entre lvl1 et levelMax.
+		/// \param level niveau demandé (clampé [1, levelMax]).
+		/// \return la valeur de base au niveau donné.
+		double BaseAt(const StatBase& b, uint32_t level, uint32_t levelMax)
+		{
+			const uint32_t N = std::clamp<uint32_t>(level, 1u, levelMax);
+			if (levelMax <= 1) return b.lvl1;
+			return b.lvl1 + (static_cast<double>(N) - 1.0) * (b.lvl100 - b.lvl1)
+			              / (static_cast<double>(levelMax) - 1.0);
+		}
+
+		/// Lit un multiplicateur de sexe ; absent = 1.0 (neutre).
+		double SexGet(const std::unordered_map<std::string,double>& m, const char* stat)
+		{
+			auto it = m.find(stat);
+			return it == m.end() ? 1.0 : it->second;
+		}
+
+		/// Arrondi au plus proche entier non signé (valeurs <= 0 -> 0).
+		uint32_t RoundU(double v) { return v <= 0.0 ? 0u : static_cast<uint32_t>(v + 0.5); }
+	}
+
+	std::optional<DerivedStats> ComputeStats(const CharacterStatsTables& t,
+	                                          const std::string& factionId,
+	                                          const std::string& classId,
+	                                          Sex sex, uint32_t level)
+	{
+		auto fit = t.factions.find(factionId);
+		if (fit == t.factions.end()) return std::nullopt;
+		auto cit = fit->second.classesById.find(classId);
+		if (cit == fit->second.classesById.end()) return std::nullopt;
+
+		const std::string& profile = cit->second.profile;
+		const std::string& race    = fit->second.race;
+
+		auto pit = t.classProfiles.find(profile);
+		auto rit = t.raceProfiles.find(race);
+		auto sit = t.sexProfiles.find(profile);
+		if (pit == t.classProfiles.end() || rit == t.raceProfiles.end()) return std::nullopt;
+
+		const ClassProfile& cp = pit->second;
+		const RaceProfile&  rp = rit->second;
+		static const std::unordered_map<std::string,double> kEmptySex;
+		const auto& sx = (sit != t.sexProfiles.end())
+			? (sex == Sex::Male ? sit->second.H : sit->second.F)
+			: kEmptySex;
+
+		const uint32_t lvlMax = t.levelMax;
+		auto B = [&](const char* name) -> double {
+			auto it = t.bases.find(name); return it == t.bases.end() ? 0.0 : BaseAt(it->second, level, lvlMax); };
+
+		DerivedStats d;
+		d.resourceKey = cit->second.resource;
+
+		d.hp       = RoundU(B("hp")       * cp.hp       * rp.hp       * SexGet(sx, "hp"));
+		d.resource = RoundU(B("resource") * cp.resource * rp.resource * SexGet(sx, "resource"));
+		d.damage   = RoundU(B("damage")   * cp.damage   * rp.damage   * SexGet(sx, "damage"));
+		d.stamina  = RoundU(B("stamina"));
+
+		if (cp.range == 0.0)
+		{
+			d.range = 0.0f;
+			d.accuracy = 0.0f;
+		}
+		else
+		{
+			d.range    = static_cast<float>(B("range")    * cp.range    * rp.range    * SexGet(sx, "range"));
+			d.accuracy = static_cast<float>(B("accuracy") * cp.accuracy * rp.accuracy * SexGet(sx, "accuracy"));
+		}
+
+		const double critRaw = B("crit_rate") * cp.crit_rate * rp.crit_rate; // crit neutre au sexe
+		d.critRate = static_cast<float>(std::min(t.critRateCap, critRaw));
+
+		d.critMult = static_cast<float>(t.critMultBase * cp.crit_mult * rp.crit_mult * SexGet(sx, "crit_mult"));
+
+		d.speedWalk   = static_cast<float>(t.speedWalkBase  * cp.speed * rp.speed_walk * SexGet(sx, "speed_walk"));
+		d.speedRun    = static_cast<float>(t.speedRunBase   * cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
+		d.speedSprint = static_cast<float>(t.speedSprintBase* cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
+
+		const double perceptionBase = t.perceptionLvl1 + t.perceptionPerLevel * (static_cast<double>(std::max(1u, level)) - 1.0);
+		d.perception = static_cast<float>(perceptionBase * cp.perception * rp.perception * SexGet(sx, "perception"));
+
+		const double stealthDiv = cp.stealth * rp.stealth * SexGet(sx, "stealth");
+		d.stealth = static_cast<float>(stealthDiv > 0.0 ? (perceptionBase / 2.0) / stealthDiv : 0.0);
+
+		return d;
+	}
+}

--- a/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsEngine.cpp
@@ -84,7 +84,7 @@ namespace engine::server::gameplay
 
 		d.speedWalk   = static_cast<float>(t.speedWalkBase  * cp.speed * rp.speed_walk * SexGet(sx, "speed_walk"));
 		d.speedRun    = static_cast<float>(t.speedRunBase   * cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
-		d.speedSprint = static_cast<float>(t.speedSprintBase* cp.speed * rp.speed_run  * SexGet(sx, "speed_run"));
+		d.speedSprint = static_cast<float>(t.speedSprintBase* cp.speed * rp.speed_run  * SexGet(sx, "speed_run")); // sprint : pas de mult race/sexe dédié dans les données — seule la base diffère, on réutilise les mults de course.
 
 		const double perceptionBase = t.perceptionLvl1 + t.perceptionPerLevel * (static_cast<double>(std::max(1u, level)) - 1.0);
 		d.perception = static_cast<float>(perceptionBase * cp.perception * rp.perception * SexGet(sx, "perception"));

--- a/src/shardd/gameplay/character/CharacterStatsEngine.h
+++ b/src/shardd/gameplay/character/CharacterStatsEngine.h
@@ -1,0 +1,41 @@
+#pragma once
+// CharacterStatsEngine : calcul déterministe des 11 stats à partir des tables
+// embarquées + (level, factionId, classId, gender). Pur, compilé shardd-only.
+
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace engine::server::gameplay
+{
+	/// Sexe du personnage.
+	enum class Sex : uint8_t { Male, Female };
+
+	/// Résultat : les 11 stats dérivées (valeurs finales, jamais les multiplicateurs).
+	struct DerivedStats
+	{
+		uint32_t hp = 0;            ///< PV max.
+		uint32_t resource = 0;      ///< ressource secondaire max.
+		uint32_t damage = 0;
+		float    accuracy = 0.0f;   ///< précision %.
+		float    range = 0.0f;      ///< portée m (0 si mêlée pure).
+		float    critRate = 0.0f;   ///< taux de crit % (cap 10).
+		float    critMult = 0.0f;   ///< multiplicateur de crit ×.
+		float    speedWalk = 0.0f;
+		float    speedRun = 0.0f;
+		float    speedSprint = 0.0f;
+		uint32_t stamina = 0;       ///< endurance max.
+		float    perception = 0.0f; ///< m.
+		float    stealth = 0.0f;    ///< discrétion m (bas = discret).
+		std::string resourceKey;    ///< clé de ressource secondaire (ex. "ferveur").
+	};
+
+	/// Calcule les stats pour un personnage. Renvoie nullopt si la faction/classe
+	/// est inconnue ou si le profil/la race référencés n'existent pas dans les tables.
+	std::optional<DerivedStats> ComputeStats(const CharacterStatsTables& t,
+	                                          const std::string& factionId,
+	                                          const std::string& classId,
+	                                          Sex sex, uint32_t level);
+}

--- a/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
@@ -23,7 +23,7 @@ namespace
 		if (!d) return false;
 		if (d->hp != 81u) return false;       // 100 * 0.90 * 0.90 * 1 = 81
 		if (d->damage != 11u) return false;   // 10 * 1.25 * 0.95 * 0.93 = 11.04 -> 11
-		if (!nearF(d->critRate, 2.2)) return false; // 2 * 1.00 * 1.10
+		if (!nearF(d->critRate, 2.2, 0.05)) return false; // 2 * 1.00 * 1.10
 		if (d->resourceKey != "reflexes") return false;
 		return true;
 	}

--- a/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsEngineTests.cpp
@@ -1,0 +1,81 @@
+// Tests du moteur de stats : round-trip JSON embarqué -> tables -> calcul,
+// ancres exactes (niveau 1 et 60), invariants (cap crit, mêlée pure).
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shared/core/Log.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
+
+#include <cmath>
+
+namespace
+{
+	using namespace engine::server::gameplay;
+
+	bool nearF(float a, double b, double tol = 0.6) { return std::fabs(static_cast<double>(a) - b) <= tol; }
+
+	bool TestRoundTripAndAnchorsLvl1()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		auto d = ComputeStats(*t, "elfe", "voleur_tenebreux", Sex::Female, 1);
+		if (!d) return false;
+		if (d->hp != 81u) return false;       // 100 * 0.90 * 0.90 * 1 = 81
+		if (d->damage != 11u) return false;   // 10 * 1.25 * 0.95 * 0.93 = 11.04 -> 11
+		if (!nearF(d->critRate, 2.2)) return false; // 2 * 1.00 * 1.10
+		if (d->resourceKey != "reflexes") return false;
+		return true;
+	}
+
+	bool TestAnchorLvl60_GuerrierNainH()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		auto d = ComputeStats(*t, "naine", "guerrier", Sex::Male, 60);
+		if (!d) return false;
+		// base hp(60)=2424.2424 * 1.15 * 1.20 * 0.92 ~= 3078
+		if (d->hp < 3076u || d->hp > 3080u) return false;
+		if (d->range != 0.0f) return false;      // mêlée pure
+		if (d->accuracy != 0.0f) return false;
+		return true;
+	}
+
+	bool TestCritCapAndUnknownAndLanceurLvl100()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		auto d = ComputeStats(*t, "legion", "demoniste", Sex::Female, 100);
+		if (!d) return false;
+		if (d->critRate > 10.0f) return false;   // cap
+		if (!(d->range > 0.0f) || !(d->accuracy > 0.0f)) return false; // lanceur a une portée
+		if (d->resourceKey != "corruption") return false;
+		if (ComputeStats(*t, "inconnue", "guerrier", Sex::Male, 1)) return false;
+		if (ComputeStats(*t, "naine", "inconnue", Sex::Male, 1)) return false;
+		return true;
+	}
+
+	bool TestDeterminism()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) return false;
+		auto a = ComputeStats(*t, "dzorak", "pisteur", Sex::Male, 42);
+		auto b = ComputeStats(*t, "dzorak", "pisteur", Sex::Male, 42);
+		if (!a || !b) return false;
+		return a->hp == b->hp && a->damage == b->damage && nearF(a->stealth, b->stealth, 0.0001);
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+	const bool ok = TestRoundTripAndAnchorsLvl1()
+	             && TestAnchorLvl60_GuerrierNainH()
+	             && TestCritCapAndUnknownAndLanceurLvl100()
+	             && TestDeterminism();
+	if (ok) LOG_INFO(Core, "[CharacterStatsEngineTests] ALL OK");
+	else    LOG_ERROR(Core, "[CharacterStatsEngineTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shardd/gameplay/character/CharacterStatsTables.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsTables.cpp
@@ -1,0 +1,137 @@
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shared/core/Config.h"
+
+#include <string>
+
+namespace engine::server::gameplay
+{
+	namespace
+	{
+		using engine::core::Config;
+
+		/// Lit un profil d'archétype (class_profiles.<p>) en multiplicateurs.
+		/// \param p préfixe complet du profil (ex. "class_profiles.melee").
+		/// Clé absente = 1.0 (neutre).
+		ClassProfile ParseClassProfile(const Config& c, const std::string& p)
+		{
+			ClassProfile cp;
+			cp.hp         = c.GetDouble(p + ".hp", 1.0);
+			cp.resource   = c.GetDouble(p + ".resource", 1.0);
+			cp.damage     = c.GetDouble(p + ".damage", 1.0);
+			cp.accuracy   = c.GetDouble(p + ".accuracy", 1.0);
+			cp.range      = c.GetDouble(p + ".range", 1.0);
+			cp.crit_rate  = c.GetDouble(p + ".crit_rate", 1.0);
+			cp.crit_mult  = c.GetDouble(p + ".crit_mult", 1.0);
+			cp.speed      = c.GetDouble(p + ".speed", 1.0);
+			cp.perception = c.GetDouble(p + ".perception", 1.0);
+			cp.stealth    = c.GetDouble(p + ".stealth", 1.0);
+			return cp;
+		}
+
+		/// Lit un profil de race (race_profiles.<p>) en multiplicateurs.
+		/// speed_walk/speed_run sont distincts (vs class_profiles.speed unique).
+		RaceProfile ParseRaceProfile(const Config& c, const std::string& p)
+		{
+			RaceProfile rp;
+			rp.hp         = c.GetDouble(p + ".hp", 1.0);
+			rp.resource   = c.GetDouble(p + ".resource", 1.0);
+			rp.damage     = c.GetDouble(p + ".damage", 1.0);
+			rp.accuracy   = c.GetDouble(p + ".accuracy", 1.0);
+			rp.range      = c.GetDouble(p + ".range", 1.0);
+			rp.crit_rate  = c.GetDouble(p + ".crit_rate", 1.0);
+			rp.crit_mult  = c.GetDouble(p + ".crit_mult", 1.0);
+			rp.speed_walk = c.GetDouble(p + ".speed_walk", 1.0);
+			rp.speed_run  = c.GetDouble(p + ".speed_run", 1.0);
+			rp.perception = c.GetDouble(p + ".perception", 1.0);
+			rp.stealth    = c.GetDouble(p + ".stealth", 1.0);
+			return rp;
+		}
+
+		/// Lit un côté (H ou F) d'un sex_profile. Ne stocke que les clés présentes
+		/// dans le JSON : une clé absente reste neutre (1.0) au moment du calcul.
+		/// \param p préfixe du côté (ex. "sex_profiles.melee.H").
+		/// \param out map remplie en place (effet de bord).
+		void ParseSexSide(const Config& c, const std::string& p, std::unordered_map<std::string,double>& out)
+		{
+			static const char* kStats[] = { "hp","resource","damage","accuracy","range",
+			                                 "crit_mult","speed_walk","speed_run","perception","stealth" };
+			for (const char* s : kStats)
+			{
+				const std::string key = p + "." + s;
+				if (c.Has(key)) out[s] = c.GetDouble(key, 1.0);
+			}
+		}
+	}
+
+	std::optional<CharacterStatsTables> CharacterStatsTables::FromEmbedded(
+		const char* statsJson, const char* factionsJson)
+	{
+		if (!statsJson || !factionsJson) return std::nullopt;
+
+		Config s;
+		if (!s.LoadFromString(statsJson)) return std::nullopt;
+		Config f;
+		if (!f.LoadFromString(factionsJson)) return std::nullopt;
+
+		CharacterStatsTables t;
+		t.levelMax = static_cast<uint32_t>(s.GetInt("level_max", 100));
+		t.xpBase   = s.GetDouble("xp.base", 0.0);
+		t.xpFactor = s.GetDouble("xp.factor", 0.0);
+		if (t.levelMax < 2 || t.xpBase <= 0.0 || t.xpFactor <= 0.0) return std::nullopt;
+
+		auto base = [&](const char* name) {
+			StatBase b; b.lvl1 = s.GetDouble(std::string("bases.") + name + ".lvl1", 0.0);
+			b.lvl100 = s.GetDouble(std::string("bases.") + name + ".lvl100", 0.0); return b; };
+		t.bases["hp"]        = base("hp");
+		t.bases["resource"]  = base("resource");
+		t.bases["damage"]    = base("damage");
+		t.bases["accuracy"]  = base("accuracy");
+		t.bases["range"]     = base("range");
+		t.bases["crit_rate"] = base("crit_rate");
+		t.bases["stamina"]   = base("stamina");
+		t.critMultBase     = s.GetDouble("bases.crit_mult.base", 1.5);
+		t.critRateCap      = s.GetDouble("bases.crit_rate.cap", 10.0);
+		t.speedWalkBase    = s.GetDouble("bases.speed_walk", 2.0);
+		t.speedRunBase     = s.GetDouble("bases.speed_run", 5.0);
+		t.speedSprintBase  = s.GetDouble("bases.speed_sprint", 8.0);
+		t.perceptionLvl1   = s.GetDouble("bases.perception_lvl1", 10.0);
+		t.perceptionPerLevel = s.GetDouble("bases.perception_per_level", 0.5);
+
+		for (const char* p : { "tank","melee","sacre","distance","pisteur","voleur","healer","lanceur" })
+			t.classProfiles[p] = ParseClassProfile(s, std::string("class_profiles.") + p);
+		for (const char* r : { "humains","nains","orcs","elfes","demons" })
+			t.raceProfiles[r] = ParseRaceProfile(s, std::string("race_profiles.") + r);
+		for (const char* p : { "tank","melee","sacre","distance","pisteur","voleur","healer","lanceur" })
+		{
+			SexMods sm;
+			ParseSexSide(s, std::string("sex_profiles.") + p + ".H", sm.H);
+			ParseSexSide(s, std::string("sex_profiles.") + p + ".F", sm.F);
+			t.sexProfiles[p] = std::move(sm);
+		}
+
+		size_t i = 0;
+		while (f.Has("factions[" + std::to_string(i) + "].id"))
+		{
+			const std::string fp = "factions[" + std::to_string(i) + "]";
+			FactionEntry fe;
+			fe.id         = f.GetString(fp + ".id", "");
+			fe.race       = f.GetString(fp + ".race", "");
+			fe.selectable = f.GetBool(fp + ".selectable", false);
+			size_t j = 0;
+			while (f.Has(fp + ".classes[" + std::to_string(j) + "].id"))
+			{
+				const std::string cp = fp + ".classes[" + std::to_string(j) + "]";
+				ClassEntry ce;
+				ce.id       = f.GetString(cp + ".id", "");
+				ce.profile  = f.GetString(cp + ".profile", "");
+				ce.resource = f.GetString(cp + ".resource", "");
+				if (!ce.id.empty()) fe.classesById[ce.id] = std::move(ce);
+				++j;
+			}
+			if (!fe.id.empty()) t.factions[fe.id] = std::move(fe);
+			++i;
+		}
+		if (t.factions.empty()) return std::nullopt;
+		return t;
+	}
+}

--- a/src/shardd/gameplay/character/CharacterStatsTables.cpp
+++ b/src/shardd/gameplay/character/CharacterStatsTables.cpp
@@ -77,6 +77,7 @@ namespace engine::server::gameplay
 		t.levelMax = static_cast<uint32_t>(s.GetInt("level_max", 100));
 		t.xpBase   = s.GetDouble("xp.base", 0.0);
 		t.xpFactor = s.GetDouble("xp.factor", 0.0);
+		// xp.base / xp.factor sont obligatoires dès maintenant (contrat de la donnée embarquée) même si ComputeStats ne les consomme pas encore — la couche XP les utilisera.
 		if (t.levelMax < 2 || t.xpBase <= 0.0 || t.xpFactor <= 0.0) return std::nullopt;
 
 		auto base = [&](const char* name) {
@@ -97,6 +98,7 @@ namespace engine::server::gameplay
 		t.perceptionLvl1   = s.GetDouble("bases.perception_lvl1", 10.0);
 		t.perceptionPerLevel = s.GetDouble("bases.perception_per_level", 0.5);
 
+		// NB: ces listes doivent rester synchronisées avec character_stats.json — un profil/race présent dans le JSON mais absent ici est ignoré silencieusement.
 		for (const char* p : { "tank","melee","sacre","distance","pisteur","voleur","healer","lanceur" })
 			t.classProfiles[p] = ParseClassProfile(s, std::string("class_profiles.") + p);
 		for (const char* r : { "humains","nains","orcs","elfes","demons" })

--- a/src/shardd/gameplay/character/CharacterStatsTables.h
+++ b/src/shardd/gameplay/character/CharacterStatsTables.h
@@ -1,0 +1,62 @@
+#pragma once
+// CharacterStatsTables : tables de stats chargées depuis le JSON embarqué
+// (character_stats.json) + la taxonomie embarquée (factions.json). Construites
+// une fois au boot via FromEmbedded(). Aucun accès disque (anti-triche).
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server::gameplay
+{
+	/// Base d'une stat interpolée linéairement lvl1 -> lvl100.
+	struct StatBase { double lvl1 = 0.0; double lvl100 = 0.0; };
+
+	/// Multiplicateurs d'un profil d'archétype (class_profiles).
+	struct ClassProfile
+	{
+		double hp=1, resource=1, damage=1, accuracy=1, range=1,
+		       crit_rate=1, crit_mult=1, speed=1, perception=1, stealth=1;
+	};
+
+	/// Multiplicateurs d'une race (race_profiles). speed_walk/speed_run séparés.
+	struct RaceProfile
+	{
+		double hp=1, resource=1, damage=1, accuracy=1, range=1,
+		       crit_rate=1, crit_mult=1, speed_walk=1, speed_run=1, perception=1, stealth=1;
+	};
+
+	/// Multiplicateurs de sexe pour un profil (clés absentes = 1.0 au calcul).
+	struct SexMods { std::unordered_map<std::string,double> H; std::unordered_map<std::string,double> F; };
+
+	/// Une classe dans une faction (factions.json) : mapping vers profil + ressource.
+	struct ClassEntry { std::string id; std::string profile; std::string resource; };
+
+	/// Une faction (factions.json).
+	struct FactionEntry { std::string id; std::string race; bool selectable=false;
+	                      std::unordered_map<std::string, ClassEntry> classesById; };
+
+	/// Ensemble des tables, prêt pour le calcul.
+	struct CharacterStatsTables
+	{
+		uint32_t levelMax = 100;
+		double xpBase = 0.0, xpFactor = 0.0;
+
+		std::unordered_map<std::string, StatBase> bases; // hp,resource,damage,accuracy,range,crit_rate,stamina
+		double critMultBase = 1.5;
+		double critRateCap = 10.0;
+		double speedWalkBase = 2.0, speedRunBase = 5.0, speedSprintBase = 8.0;
+		double perceptionLvl1 = 10.0, perceptionPerLevel = 0.5;
+
+		std::unordered_map<std::string, ClassProfile> classProfiles;
+		std::unordered_map<std::string, RaceProfile>  raceProfiles;
+		std::unordered_map<std::string, SexMods>      sexProfiles; // clé = profil
+		std::unordered_map<std::string, FactionEntry> factions;    // clé = factionId
+
+		/// Construit les tables depuis les chaînes JSON embarquées.
+		/// \return nullopt si un JSON est invalide ou incomplet.
+		static std::optional<CharacterStatsTables> FromEmbedded(
+			const char* statsJson, const char* factionsJson);
+	};
+}

--- a/src/shardd/gameplay/character/CharacterStatsTables.h
+++ b/src/shardd/gameplay/character/CharacterStatsTables.h
@@ -41,7 +41,7 @@ namespace engine::server::gameplay
 	struct CharacterStatsTables
 	{
 		uint32_t levelMax = 100;
-		double xpBase = 0.0, xpFactor = 0.0;
+		double xpBase = 0.0, xpFactor = 0.0; // réservés à la couche XP (paramètres de courbe).
 
 		std::unordered_map<std::string, StatBase> bases; // hp,resource,damage,accuracy,range,crit_rate,stamina
 		double critMultBase = 1.5;

--- a/src/shared/core/Config.cpp
+++ b/src/shared/core/Config.cpp
@@ -540,13 +540,16 @@ namespace engine::core
 			return LoadIni(*this, in);
 		}
 
-		// Default to JSON when extension is unknown.
+		// Default to JSON when extension is unknown : on délègue au parseur mémoire.
 		std::stringstream ss;
 		ss << in.rdbuf();
-		const std::string text = ss.str();
+		return LoadFromString(ss.str());
+	}
 
+	bool Config::LoadFromString(std::string_view jsonText)
+	{
 		JsonValue root;
-		JsonParser parser(text);
+		JsonParser parser(jsonText);
 		if (!parser.Parse(root))
 		{
 			return false;
@@ -557,7 +560,7 @@ namespace engine::core
 		}
 
 		// Merge JSON into config by overriding defaults (file has higher priority than defaults).
-		// We flatten nested objects into dotted keys.
+		// On aplatit les objets imbriqués en clés pointées.
 		Config fileCfg;
 		MergeJsonFlatten(root, "", fileCfg);
 		for (const auto& [k, v] : fileCfg.m_values)

--- a/src/shared/core/Config.h
+++ b/src/shared/core/Config.h
@@ -50,6 +50,13 @@ namespace engine::core
 		/// Load values from a JSON/INI file (returns false if file is missing/unreadable).
 		bool LoadFromFile(std::string_view filePath);
 
+		/// Parse un document JSON depuis un buffer mémoire (aucun accès disque).
+		/// Même sémantique que LoadFromFile pour du JSON : aplatit les objets en
+		/// clés pointées, les tableaux en indices `[i]`. Retourne false si le
+		/// texte n'est pas un JSON dont la racine est un objet.
+		/// Effet : fusionne les valeurs (priorité sur les défauts), comme LoadFromFile.
+		bool LoadFromString(std::string_view jsonText);
+
 		/// Écrit toutes les valeurs scalaires courantes dans un fichier JSON
 		/// **plat** (clés pointées au niveau racine, valeurs scalaires). Conçu
 		/// pour round-tripper avec \ref LoadFromFile (qui aplatit les objets en

--- a/src/shared/core/ConfigLoadFromStringTests.cpp
+++ b/src/shared/core/ConfigLoadFromStringTests.cpp
@@ -1,0 +1,54 @@
+// Test de Config::LoadFromString : parsing JSON depuis un buffer mémoire
+// (aucun accès disque). Sert l'embarquement anti-triche (tables compilées
+// dans le binaire shardd, lues via LoadFromString au boot).
+#include "src/shared/core/Config.h"
+#include "src/shared/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::core::Config;
+
+	bool TestParsesFlatObject()
+	{
+		Config cfg;
+		const std::string json = R"({ "a": { "b": 42 }, "name": "x" })";
+		if (!cfg.LoadFromString(json)) return false;
+		if (cfg.GetInt("a.b", -1) != 42) return false;
+		if (cfg.GetString("name", "") != "x") return false;
+		return true;
+	}
+
+	bool TestParsesArrayIndices()
+	{
+		Config cfg;
+		const std::string json = R"({ "items": [ { "id": "u" }, { "id": "v" } ] })";
+		if (!cfg.LoadFromString(json)) return false;
+		if (!cfg.Has("items[0].id")) return false;
+		if (cfg.GetString("items[0].id", "") != "u") return false;
+		if (cfg.GetString("items[1].id", "") != "v") return false;
+		if (cfg.Has("items[2].id")) return false;
+		return true;
+	}
+
+	bool TestRejectsNonObjectAndGarbage()
+	{
+		Config a; if (a.LoadFromString("not json")) return false;
+		Config b; if (b.LoadFromString("[1,2,3]")) return false; // racine non-objet
+		return true;
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+	const bool ok = TestParsesFlatObject() && TestParsesArrayIndices() && TestRejectsNonObjectAndGarbage();
+	if (ok) LOG_INFO(Core, "[ConfigLoadFromStringTests] ALL OK");
+	else    LOG_ERROR(Core, "[ConfigLoadFromStringTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/formulas/Formulas.h
+++ b/src/shared/formulas/Formulas.h
@@ -4,17 +4,23 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <cmath>
 
 namespace engine::server::formulas
 {
 	/// XP requis pour passer du niveau \p level au level+1.
-	/// Approximation cubique douce : 100 * level^2 + 200 * level.
-	/// Cap a niveau 80 (XP = 0 au-dela).
-	inline uint32_t XpToNextLevel(uint8_t level)
+	/// Courbe du design : round(base * level^factor). Paramètres fournis par
+	/// l'appelant (issus de character_stats.json embarqué côté serveur) — JAMAIS
+	/// codés en dur ici. Renvoie 0 si level == 0 ou level >= levelMax (cap).
+	/// \param base   coefficient multiplicateur de la courbe.
+	/// \param factor exposant (2.6 dans le design).
+	/// \param levelMax niveau maximum (100) ; au-delà, plus de progression.
+	inline uint32_t XpToNextLevel(uint8_t level, double base, double factor, uint8_t levelMax)
 	{
-		if (level == 0 || level >= 80) return 0;
-		const uint32_t l = level;
-		return 100u * l * l + 200u * l;
+		if (level == 0 || level >= levelMax) return 0;
+		const double xp = base * std::pow(static_cast<double>(level), factor);
+		if (xp <= 0.0) return 0;
+		return static_cast<uint32_t>(xp + 0.5); // round-half-up
 	}
 
 	/// Distance d'agro (yards) selon difference de niveau (mob - player).

--- a/src/shared/formulas/FormulasTests.cpp
+++ b/src/shared/formulas/FormulasTests.cpp
@@ -7,12 +7,23 @@ namespace
 
 	bool TestXpProgression()
 	{
-		if (XpToNextLevel(0)  != 0) return false;
-		if (XpToNextLevel(80) != 0) return false;
-		if (XpToNextLevel(100)!= 0) return false;
-		// progression : level 1 < level 2 < level 79
-		if (!(XpToNextLevel(1) < XpToNextLevel(2))) return false;
-		if (!(XpToNextLevel(2) < XpToNextLevel(79))) return false;
+		// Params du design (character_stats.json) passés explicitement.
+		constexpr double kBase = 6.185;
+		constexpr double kFactor = 2.6;
+		constexpr uint8_t kMax = 100;
+
+		// Cap : 0 hors plage et au niveau max.
+		if (XpToNextLevel(0,   kBase, kFactor, kMax) != 0) return false;
+		if (XpToNextLevel(100, kBase, kFactor, kMax) != 0) return false;
+		// Positivité sur 1..99.
+		if (XpToNextLevel(1,  kBase, kFactor, kMax) == 0) return false;
+		if (XpToNextLevel(99, kBase, kFactor, kMax) == 0) return false;
+		// Monotonie stricte.
+		if (!(XpToNextLevel(1, kBase, kFactor, kMax) < XpToNextLevel(2, kBase, kFactor, kMax))) return false;
+		if (!(XpToNextLevel(2, kBase, kFactor, kMax) < XpToNextLevel(99, kBase, kFactor, kMax))) return false;
+		// Ancrage forme : XP(10) ~= round(6.185 * 10^2.6) = round(6.185 * 398.107) = 2463.
+		const uint32_t x10 = XpToNextLevel(10, kBase, kFactor, kMax);
+		if (x10 < 2460u || x10 > 2466u) return false;
 		LOG_INFO(Core, "[FormulasTests] xp progression OK");
 		return true;
 	}


### PR DESCRIPTION
## Système de Personnages — PR1 (server-first)

Première moitié (serveur) de la refonte du système de personnages.
Spec : `docs/superpowers/specs/2026-06-08-character-system-factions-races-classes-stats-design.md`
Plan : `docs/superpowers/plans/2026-06-08-character-system-pr1-server.md`

### Contenu
- **Données** : `game/data/races/factions.json` (taxonomie : 9 factions jouables + `empire_hynn` non sélectionnable, classes distinctes) et `game/data/gameplay/character_stats.json` (bases/multiplicateurs/sexe/XP, valeurs §6.3).
- **Anti-triche** : `character_stats.json` est **embarqué dans le binaire serveur au build** (header généré par CMake `cmake/EmbedJson.cmake`) ; aucun multiplicateur côté client.
- **Moteur** : `CharacterStatsEngine` (shardd-only) — 11 stats déterministes `base(N) × classe × race × sexe`, cap crit ≤ 10 garanti par la formule, mêlée pure → portée/précision nulles. Recalcul à la volée (pas de stats en DB).
- **XP** : `Formulas.h` — courbe `6.185 × N^2.6`, niveau max 100 (remplace l'ancienne cubique cap 80).
- **Réplication** : `Unit` étendu de 14 `UpdateField` (damage, crit, vitesses, endurance, perception, discrétion, ressource secondaire) ; `Player::ApplyDerivedStats` remplit les champs depuis le moteur.
- **DB** : migration `0072_factions_v2.sql` (ids courts + `selectable` + backfill `faction_str`), dans les deux arbres `sql/migrations/` et `deploy/docker/sql/migrations/`.
- **Config** : `Config::LoadFromString` (parse JSON en mémoire, sans disque).
- **Tests** (ctest Linux) : ConfigLoadFromString, Formulas (XP), CharacterStatsEngine (ancres exactes : Voleur Elfe F niv.1 = 81 PV ; Guerrier Nain H niv.60 ≈ 3078 PV ; cap crit ; mêlée), Unit, Player.

### Hors périmètre (suite)
- **PR2 (client)** : wire `factionId`, refonte `CharacterCreationUi`, textes descriptifs (localisation), migration `races.json` + suppression `corrompus`, tests client.
- **R1 différé** : câblage des stats au chemin de réplication live (le monde live utilise le snapshot ECS, pas encore `Unit`/`UpdateField`) — décision séparée.

### Déploiement
⚠️ **Redéploiement serveur requis** (master + shard Linux) : migration DB 0072 + nouveau binaire (moteur de stats embarqué). **Serveur uniquement** — aucun changement client dans cette PR. PR2 suivra en lock-step avec le client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
