### PR TITLE
feat: Système de Personnages R1-A — PV calculés à l'enter-world (serveur)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-character-system-r1a-server-stats.md
+++ b/docs/superpowers/plans/2026-06-08-character-system-r1a-server-stats.md
@@ -1,0 +1,80 @@
+# Système de Personnages — R1-A (PV calculés à l'enter-world) Plan
+
+**Goal:** À l'entrée en jeu, calculer les PV (et PV courants) du joueur depuis le moteur de stats (PR1) et les écrire dans le `StatsComponent` répliqué — la barre de vie affiche enfin la vraie valeur (ex. Guerrier Nain niv.60 = 3078 PV). 100 % serveur, **aucun changement de wire** (`currentHealth`/`maxHealth` se répliquent déjà).
+
+**Architecture:** Le shard charge faction/classe depuis la DB à l'enter-world, charge les tables embarquées une fois au boot, appelle `ComputeStats`, et remplit `ConnectedClient.stats`. Logique de résolution extraite dans une fonction pure **testée**. La ressource secondaire et les 9 autres stats restent pour R1-B (nécessitent opcode/UI).
+
+**Branche:** `feat/character-system-r1a-server-stats` (depuis main, après PR1).
+
+---
+
+## Contexte (cartographie)
+- Joueur live = `ConnectedClient` (struct, `src/shared/server_bootstrap/ServerApp.cpp` ~85-154 du .h) avec `StatsComponent { currentHealth, maxHealth }`. PV par défaut codés en dur (`kDefaultPlayerHealth`).
+- `HandleHello()` (~1029-1250) : enter-world. `LoadSpawnFromDb()` (~987-1027) charge `spawn_*, name, gender, level` (PAS faction/classe). `acceptedClient.level` posé ~1195. État persisté fusionné ~1142 (`acceptedClient.stats = persistedState.stats`).
+- Moteur PR1 : `engine::server::gameplay::ComputeStats(tables, factionId, classId, Sex, level) -> optional<DerivedStats>` ; `CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson)` (headers générés `CharacterStatsData.h`/`FactionsData.h`, dispo sur les targets de ServerApp via `${LCDLLN_GEN_DIR}`).
+- `ConnectedClient` a déjà `level`, `gender`, `characterName`.
+
+---
+
+## Task 1 — Helper pur testé : résolution des PV
+
+**Files:** Create `src/shardd/gameplay/character/SpawnStatsResolver.{h,cpp}`, `src/shardd/gameplay/character/SpawnStatsResolverTests.cpp`; Modify `src/CMakeLists.txt`.
+
+But : isoler la logique testable hors de `HandleHello` (intégration non testable unitairement).
+
+- [ ] **Step 1 (test first):** `SpawnStatsResolverTests.cpp` — table embarquée via `FromEmbedded(kCharacterStatsJson, kFactionsJson)`. Cas :
+  - Guerrier Nain (faction `naine`, classe `guerrier`, H, niv.60), pas de PV persistés (0) → `maxHealth` ∈ [3076,3080], `currentHealth == maxHealth`.
+  - Même perso, PV persistés = 100 → `maxHealth` ∈ [3076,3080], `currentHealth == 100` (conservé, ≤ max).
+  - PV persistés > max (ex. 999999) → `currentHealth == maxHealth` (clamp).
+  - Faction/classe inconnue → `resolved == false` (l'appelant garde le défaut).
+  Pattern plain-main return-0/1 (PAS assert — NDEBUG). Inclut `CharacterStatsData.h`/`FactionsData.h`.
+
+- [ ] **Step 2:** `SpawnStatsResolver.h` :
+```cpp
+#pragma once
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include <cstdint>
+#include <string>
+namespace engine::server::gameplay
+{
+	/// Résultat de la résolution des PV à l'enter-world.
+	struct SpawnHealth { bool resolved=false; uint32_t maxHealth=0; uint32_t currentHealth=0; };
+
+	/// Calcule maxHealth (=hp dérivé) et currentHealth pour un joueur entrant.
+	/// \param persistedCurrentHealth PV courants restaurés (0 = aucun → plein).
+	/// Si la faction/classe est inconnue, resolved=false (l'appelant garde le défaut).
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth);
+}
+```
+
+- [ ] **Step 3:** `SpawnStatsResolver.cpp` : appelle `ComputeStats`; si nullopt → `{false,0,0}`; sinon `maxHealth=hp`; `currentHealth = (persisted>0 ? min(persisted,max) : max)`.
+
+- [ ] **Step 4:** CMake — ajouter `SpawnStatsResolver.cpp` aux listes sources des targets serveur compilant déjà le moteur (WIN32 `server_app`, `shard_app`), et enregistrer `spawn_stats_resolver_tests` (bloc explicite avec `${LCDLLN_GEN_DIR}` + `add_dependencies(... lcdlln_gen_character_data)` + moteur + tables, comme `character_stats_engine_tests`).
+
+- [ ] **Step 5:** commit `feat(shardd): SpawnStatsResolver — PV dérivés à l'enter-world (+ tests)`.
+
+---
+
+## Task 2 — Charger faction/classe en DB + appeler le resolver dans HandleHello
+
+**Files:** Modify `src/shared/server_bootstrap/ServerApp.cpp` (+ `.h`).
+
+- [ ] **Step 1:** Charger les tables une fois : membre `std::optional<engine::server::gameplay::CharacterStatsTables> m_statsTables;` initialisé au boot (ou lazy au 1er HandleHello) via `FromEmbedded(kCharacterStatsJson, kFactionsJson)` ; log si nullopt. Include `CharacterStatsData.h`/`FactionsData.h` + le resolver.
+- [ ] **Step 2:** `LoadSpawnFromDb()` : ajouter `faction_str, class_str` au SELECT (~ligne 1007) ; renvoyer/retourner ces deux strings (via out-params ou struct). Ajouter `factionId`/`classId` à `ConnectedClient` (ou variables locales suffisantes pour l'appel).
+- [ ] **Step 3:** Dans `HandleHello`, après que `level`/`gender`/faction/classe sont connus ET après la fusion de l'état persisté (~après 1195), appeler `ResolveSpawnHealth(*m_statsTables, factionId, classId, sex, level, acceptedClient.stats.currentHealth)`. `sex` = `gender=="female"?Female:Male`. Si `m_statsTables` présent et `resolved` : `acceptedClient.stats.maxHealth = r.maxHealth; acceptedClient.stats.currentHealth = r.currentHealth;`. Sinon laisser le défaut (rétro-compat persos sans faction/classe).
+- [ ] **Step 4:** Log INFO : faction/classe/niveau → maxHealth calculé (utile au diag).
+- [ ] **Step 5:** commit `feat(shardd): enter-world calcule les PV du joueur depuis le moteur de stats`.
+
+---
+
+## Task 3 — Vérif + push + PR
+- [ ] grep : aucun nouveau wire/opcode ; `kProtocolVersion` inchangé.
+- [ ] push, PR base main. CI : build-linux (ctest `spawn_stats_resolver_tests`) + build-windows.
+
+> **Déploiement R1-A** : ⚠️ redéploiement serveur (shard) requis — nouveau binaire (PV calculés au boot du joueur). **Aucun changement client/wire** → pas de lock-step client. Indépendant de PR2 (peut se merger/déployer séparément, après PR1).
+
+## Hors périmètre (R1-B)
+Ressource secondaire + 9 autres stats répliquées + opcode « feuille de perso » + panneau UI client.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,8 @@ if(WIN32)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Character system R1-A — résolveur PV enter-world (dérive depuis le moteur).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp
@@ -633,6 +635,21 @@ elseif(UNIX)
   target_compile_options(character_stats_engine_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME character_stats_engine_tests COMMAND character_stats_engine_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Character system R1-A — SpawnStatsResolver : PV (max+courants) dérivés à
+  # l'enter-world. Bloc explicite (comme character_stats_engine_tests) : besoin
+  # du dossier des headers générés (${LCDLLN_GEN_DIR}) et de la dépendance au
+  # codegen lcdlln_gen_character_data.
+  add_executable(spawn_stats_resolver_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(spawn_stats_resolver_tests lcdlln_gen_character_data)
+  target_include_directories(spawn_stats_resolver_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(spawn_stats_resolver_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(spawn_stats_resolver_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME spawn_stats_resolver_tests COMMAND spawn_stats_resolver_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
   lcdlln_add_simple_test(metric_registry_tests
     ${CMAKE_SOURCE_DIR}/src/shared/metric/MetricRegistryTests.cpp)
@@ -1086,6 +1103,8 @@ elseif(UNIX)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Character system R1-A — résolveur PV enter-world (appelé par HandleHello).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp

--- a/src/shardd/gameplay/character/SpawnStatsResolver.cpp
+++ b/src/shardd/gameplay/character/SpawnStatsResolver.cpp
@@ -1,0 +1,19 @@
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
+#include <algorithm>
+namespace engine::server::gameplay
+{
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth)
+	{
+		auto d = ComputeStats(tables, factionId, classId, sex, level);
+		if (!d) return SpawnHealth{}; // resolved=false → l'appelant garde le défaut
+		SpawnHealth h;
+		h.resolved = true;
+		h.maxHealth = d->hp;
+		h.currentHealth = (persistedCurrentHealth > 0u)
+			? std::min(persistedCurrentHealth, h.maxHealth)
+			: h.maxHealth;
+		return h;
+	}
+}

--- a/src/shardd/gameplay/character/SpawnStatsResolver.h
+++ b/src/shardd/gameplay/character/SpawnStatsResolver.h
@@ -1,0 +1,19 @@
+#pragma once
+// SpawnStatsResolver : résout les PV (max + courants) d'un joueur à l'enter-world
+// depuis le moteur de stats. Pur et testable (séparé de HandleHello, intégration).
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include <cstdint>
+#include <string>
+namespace engine::server::gameplay
+{
+	/// PV résolus à l'entrée en jeu.
+	struct SpawnHealth { bool resolved = false; uint32_t maxHealth = 0; uint32_t currentHealth = 0; };
+
+	/// Calcule maxHealth (= hp dérivé) et currentHealth pour un joueur entrant.
+	/// \param persistedCurrentHealth PV courants restaurés (0 = aucun → plein).
+	/// \return resolved=false si la faction/classe est inconnue (l'appelant garde le défaut).
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth);
+}

--- a/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
+++ b/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
@@ -1,0 +1,75 @@
+// Tests du résolveur de PV à l'enter-world : ancre Guerrier Nain H niv.60
+// (maxHealth ~3078, identique à CharacterStatsEngineTests), restauration des PV
+// courants (plein si 0, conservé si fourni, plafonné à maxHealth), faction
+// inconnue → resolved=false. Plain-main, NDEBUG-safe (pas d'assert).
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
+#include "src/shared/core/Log.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
+
+#include <cstdio>
+
+namespace
+{
+	using namespace engine::server::gameplay;
+
+	// PV plein quand aucun PV courant n'est persisté (persisted == 0).
+	bool TestSpawnFull()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/0u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] full: resolved=false\n"); return false; }
+		if (h.maxHealth < 3076u || h.maxHealth > 3080u) { fprintf(stderr, "[SpawnStatsResolverTests] full: maxHealth=%u\n", h.maxHealth); return false; }
+		if (h.currentHealth != h.maxHealth) { fprintf(stderr, "[SpawnStatsResolverTests] full: current=%u != max=%u\n", h.currentHealth, h.maxHealth); return false; }
+		return true;
+	}
+
+	// PV courant persisté conservé tel quel (100 < maxHealth).
+	bool TestSpawnPersisted()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/100u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: resolved=false\n"); return false; }
+		if (h.maxHealth < 3076u || h.maxHealth > 3080u) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: maxHealth=%u\n", h.maxHealth); return false; }
+		if (h.currentHealth != 100u) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: current=%u != 100\n", h.currentHealth); return false; }
+		return true;
+	}
+
+	// PV courant persisté absurde (> maxHealth) plafonné à maxHealth.
+	bool TestSpawnClamped()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/999999u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] clamped: resolved=false\n"); return false; }
+		if (h.currentHealth != h.maxHealth) { fprintf(stderr, "[SpawnStatsResolverTests] clamped: current=%u != max=%u\n", h.currentHealth, h.maxHealth); return false; }
+		return true;
+	}
+
+	// Faction inconnue → resolved=false, l'appelant garde son défaut.
+	bool TestUnknownFaction()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "inconnue", "guerrier", Sex::Male, 1, /*persisted*/0u);
+		if (h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] unknown: resolved=true (attendu false)\n"); return false; }
+		return true;
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+	const bool ok = TestSpawnFull()
+	             && TestSpawnPersisted()
+	             && TestSpawnClamped()
+	             && TestUnknownFaction();
+	if (ok) LOG_INFO(Core, "[SpawnStatsResolverTests] ALL OK");
+	else    LOG_ERROR(Core, "[SpawnStatsResolverTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -8,6 +8,12 @@
 #include "src/shardd/world/AdmittedCharacterRegistry.h"
 #include "src/shared/network/ServerProtocol.h"
 
+// R1-A — JSON embarqués (générés au build) pour le moteur de stats des personnages.
+// Symboles const char* kCharacterStatsJson / kFactionsJson. Atteignables sur les targets
+// de ServerApp (server_app, shard_app) via ${LCDLLN_GEN_DIR} sur leur include path.
+#include "CharacterStatsData.h"
+#include "FactionsData.h"
+
 // TA.4 — pont position : compilé uniquement pour la cible shard Linux (SHARD_POSITION_DB),
 // pas pour le build Windows (ServerApp.cpp est partagé). Macro dédié plutôt qu'ENGINE_HAS_MYSQL
 // pour ne PAS basculer les autres systèmes gameplay du shard en mode DB.
@@ -985,7 +991,8 @@ namespace engine::server
 	}
 
 	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender, uint32_t& outLevel)
+		std::string& outName, std::string& outGender, uint32_t& outLevel,
+		std::string& outFactionId, std::string& outClassId)
 	{
 #if defined(SHARD_POSITION_DB)
 		if (m_characterDbPool == nullptr || characterId == 0u)
@@ -1003,8 +1010,11 @@ namespace engine::server
 		// TD.6 — et `gender` (migration 0067) pour le rendu de l'avatar distant.
 		// Présence enrichie — `level` (migration 0004) pour la présence web-portal.
 		// N1-I : prepared statement (bind characterId). Floats lus via GetString + strtof.
+		// R1-A — `faction_str`/`class_str` (cf. migrations 0040/0033) ajoutés EN FIN de SELECT
+		// (indices 7/8) pour ne pas décaler les indices des colonnes existantes (0..6).
+		// Alimentent le moteur de stats (PV à l'enter-world).
 		auto* stmt = cache->Acquire(mysql,
-			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender, level FROM characters "
+			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender, level, faction_str, class_str FROM characters "
 			"WHERE id = ? AND deleted_at IS NULL");
 		if (!stmt || !stmt->Bind(0, characterId) || !stmt->Execute() || !stmt->FetchRow())
 		{
@@ -1019,15 +1029,34 @@ namespace engine::server
 		outLevel = static_cast<uint32_t>(std::strtoul(stmt->GetString(6).c_str(), nullptr, 10));
 		if (outLevel == 0u)
 			outLevel = 1u; // garde-fou : niveau minimal 1.
+		outFactionId = stmt->GetString(7);
+		outClassId = stmt->GetString(8);
 		return true;
 #else
 		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender; (void)outLevel;
+		(void)outFactionId; (void)outClassId;
 		return false;
 #endif
 	}
 
 	void ServerApp::HandleHello(const Endpoint& endpoint, uint64_t helloNonce)
 	{
+		// R1-A — charge les tables de stats une seule fois (lazy). FromEmbedded renvoie
+		// directement un std::optional ; en cas d'échec on logue une fois et on garde nullopt
+		// (les PV par défaut s'appliqueront → pas de régression).
+		if (!m_statsTablesLoadAttempted)
+		{
+			m_statsTablesLoadAttempted = true;
+			m_statsTables = engine::server::gameplay::CharacterStatsTables::FromEmbedded(
+				kCharacterStatsJson, kFactionsJson);
+			if (!m_statsTables)
+			{
+				LOG_WARN(Net,
+					"[ServerApp] R1-A : moteur de stats indisponible (FromEmbedded a échoué) — "
+					"PV par défaut conservés à l'enter-world.");
+			}
+		}
+
 		// Phase 3.7.5 — tentativeCharacterKey élargi à uint64. Fallback sur m_nextClientId
 		// (uint32) si le client n'a pas envoyé de character_id ; cast widening explicite.
 		const uint64_t tentativeCharacterKey = helloNonce != 0u
@@ -1181,7 +1210,9 @@ namespace engine::server
 			std::string dbName;
 			std::string dbGender;
 			uint32_t dbLevel = 1u;
-			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender, dbLevel))
+			std::string dbFactionId;
+			std::string dbClassId;
+			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender, dbLevel, dbFactionId, dbClassId))
 			{
 				acceptedClient.positionMetersX = dbX;
 				acceptedClient.positionMetersY = dbY;
@@ -1193,6 +1224,9 @@ namespace engine::server
 				acceptedClient.gender = std::move(dbGender);
 				// Présence enrichie — niveau (table characters) reporté au master via heartbeat.
 				acceptedClient.level = dbLevel;
+				// R1-A — faction/classe pour le moteur de stats (PV à l'enter-world).
+				acceptedClient.factionId = std::move(dbFactionId);
+				acceptedClient.classId = std::move(dbClassId);
 				LOG_INFO(Net,
 					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", gender=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
 					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, acceptedClient.gender, dbX, dbY, dbZ);
@@ -1233,6 +1267,34 @@ namespace engine::server
 							acceptedClient.persistenceCharacterKey, acceptedClient.gender);
 					}
 				}
+			}
+		}
+
+		// R1-A — PV calculés depuis le moteur de stats (faction/classe/sexe/niveau). Placé
+		// après le merge de l'état persisté (acceptedClient.stats fait foi) ET après la
+		// résolution niveau/faction/classe (LoadSpawnFromDb ci-dessus). Le resolver clamp
+		// les PV courants persistés sur le nouveau max. Faction/classe vides (char legacy ou
+		// mode no-DB) → resolved=false → PV par défaut conservés (pas de régression).
+		if (m_statsTables)
+		{
+			const engine::server::gameplay::Sex sex =
+				(acceptedClient.gender == "female") ? engine::server::gameplay::Sex::Female
+				                                    : engine::server::gameplay::Sex::Male;
+			const engine::server::gameplay::SpawnHealth sh = engine::server::gameplay::ResolveSpawnHealth(
+				*m_statsTables, acceptedClient.factionId, acceptedClient.classId,
+				sex, acceptedClient.level, acceptedClient.stats.currentHealth);
+			if (sh.resolved)
+			{
+				acceptedClient.stats.maxHealth = sh.maxHealth;
+				acceptedClient.stats.currentHealth = sh.currentHealth;
+				LOG_INFO(Net,
+					"[ServerApp] R1-A enter-world stats (client_id={}, faction={}, class={}, level={}) -> maxHealth={}, currentHealth={}",
+					acceptedClient.clientId,
+					acceptedClient.factionId,
+					acceptedClient.classId,
+					acceptedClient.level,
+					sh.maxHealth,
+					sh.currentHealth);
 			}
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1048,7 +1048,8 @@ namespace engine::server
 		{
 			m_statsTablesLoadAttempted = true;
 			m_statsTables = engine::server::gameplay::CharacterStatsTables::FromEmbedded(
-				kCharacterStatsJson, kFactionsJson);
+				engine::server::gameplay::kCharacterStatsJson,
+				engine::server::gameplay::kFactionsJson);
 			if (!m_statsTables)
 			{
 				LOG_WARN(Net,

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -2,6 +2,8 @@
 
 #include "src/shardd/gameplay/auction/AuctionHouse.h"
 #include "src/shardd/gameplay/character/CharacterPersistence.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
 #include "src/shardd/gameplay/crafting/CraftingSystem.h"
 #include "src/shardd/gameplay/economy/CurrencyConfig.h"
 #include "src/shardd/gameplay/gathering/GatheringSystem.h"
@@ -32,6 +34,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <span>
 #include <string_view>
@@ -110,6 +113,12 @@ namespace engine::server
 		/// AdmittedCharacterRegistry::AdmittedGender. Recopié dans chaque SnapshotEntity
 		/// pour permettre au client de sélectionner le mesh skinné des avatars distants.
 		std::string gender;
+		/// R1-A — faction et classe du personnage (table characters.faction/class, chargées au
+		/// Hello via LoadSpawnFromDb). Alimentent le moteur de stats (ResolveSpawnHealth) pour
+		/// calculer les PV max à l'enter-world. Vides si char legacy / mode no-DB → le resolver
+		/// renvoie resolved=false et les PV par défaut (kDefaultPlayerHealth) sont conservés.
+		std::string factionId;
+		std::string classId;
 		uint32_t experiencePoints = 0;
 		/// Compte propriétaire (résolu au Hello via AdmittedCharacterRegistry). Clé de la
 		/// présence unifiée (ShardPresenceService) ; 0 si non résolu (registre absent).
@@ -326,8 +335,11 @@ namespace engine::server
 		/// `name` pour le porter dans le SnapshotEntity (plaque de nom des avatars distants).
 		/// Renvoie false si pas de pool DB (Windows / DB non configurée) ou si character
 		/// introuvable ; dans ce cas les out-params ne sont pas modifiés.
+		/// R1-A — récupère aussi `faction` et `class` (out-params) pour alimenter le moteur de
+		/// stats (PV à l'enter-world). Vides si la colonne est NULL/absente.
 		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender, uint32_t& outLevel);
+		std::string& outName, std::string& outGender, uint32_t& outLevel,
+		std::string& outFactionId, std::string& outClassId);
 
 		/// Accept a new client or refresh an existing handshake.
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).
@@ -825,6 +837,13 @@ namespace engine::server
 
 		engine::core::Config m_config;
 		CharacterPersistenceStore m_characterPersistence;
+		/// R1-A — tables de stats du personnage (JSON embarqué), chargées une seule fois
+		/// (lazy, au 1er HandleHello) via CharacterStatsTables::FromEmbedded. nullopt si le
+		/// JSON est invalide → les PV par défaut sont conservés (pas de régression).
+		std::optional<engine::server::gameplay::CharacterStatsTables> m_statsTables;
+		/// R1-A — passe à true une fois la tentative de chargement de m_statsTables effectuée
+		/// (évite de réessayer + de logguer l'avertissement à chaque Hello si elle échoue).
+		bool m_statsTablesLoadAttempted = false;
 		AuctionHouseService m_auctionHouse;
 		/// M35.1 — currency definitions + validation caps (config/currencies.json).
 		CurrencyConfig m_currencyConfig{};


### PR DESCRIPTION
## Système de Personnages — R1-A : PV calculés à l'enter-world

Rend la première stat **visible en jeu** : à l'entrée en jeu, le shard calcule les PV du joueur depuis le moteur de stats (PR1) et les écrit dans le `StatsComponent` répliqué. La barre de vie affiche enfin la vraie valeur (ex. Guerrier Nain niv.60 = 3078 PV au lieu du défaut codé en dur).
Plan : `docs/superpowers/plans/2026-06-08-character-system-r1a-server-stats.md`

### Contenu
- `SpawnStatsResolver` (helper pur testé) : `maxHealth = hp dérivé` ; `currentHealth = PV persistés (clampés) ou plein` ; `resolved=false` si faction/classe inconnue (défaut conservé).
- `LoadSpawnFromDb` : charge `faction_str`/`class_str` (colonnes appendues au SELECT, indices existants inchangés).
- `HandleHello` : charge les tables embarquées une fois, appelle `ResolveSpawnHealth` après la fusion de l'état persisté, applique PV/PV max.
- Tests : `spawn_stats_resolver_tests` (ancre Guerrier Nain niv.60 ≈ 3078, persistance, clamp, inconnu).

### Important
- **Aucun changement de wire/protocole** (`currentHealth`/`maxHealth` se répliquent déjà). `kProtocolVersion` inchangé.
- **Indépendant de PR2** (touche `shardd`/`ServerApp`, pas le wire de création) — peut se merger/déployer séparément, après PR1.
- Persos legacy sans faction/classe → PV par défaut conservés (rétro-compat).

### Hors périmètre (R1-B)
Ressource secondaire + 9 autres stats répliquées + opcode « feuille de perso » + panneau UI client.

### Déploiement
⚠️ **Redéploiement serveur (shard) requis** — nouveau comportement à l'enter-world. **Aucun déploiement client / pas de lock-step.** Migrations DB déjà en place (0033/0040/0072).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
