### PR TITLE
feat: Système de Personnages R1-B — feuille de perso (11 stats, message dédié + panneau)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,7 @@ add_library(engine_core
   src/client/render/MailImGuiRenderer.cpp
   src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/ReputationImGuiRenderer.cpp
+  src/client/render/CharacterSheetImGuiRenderer.cpp
   src/client/render/ArenaImGuiRenderer.cpp
   src/client/render/BattleGroundImGuiRenderer.cpp
   src/client/render/OutdoorPvpImGuiRenderer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1131,6 +1131,11 @@ add_executable(character_create_payloads_tests src/shared/network/CharacterCreat
 target_link_libraries(character_create_payloads_tests PRIVATE engine_core)
 add_test(NAME character_create_payloads_tests COMMAND character_create_payloads_tests)
 
+# R1-B: PLAYER_STATS gameplay message encode/decode round-trip test
+add_executable(player_stats_message_tests src/shared/network/PlayerStatsMessageTests.cpp)
+target_link_libraries(player_stats_message_tests PRIVATE engine_core)
+add_test(NAME player_stats_message_tests COMMAND player_stats_message_tests)
+
 # Chat MVP: CHAT_SEND_REQUEST / CHAT_RELAY payload round-trip tests
 add_executable(chat_payloads_tests src/shared/network/ChatPayloadsTests.cpp)
 target_link_libraries(chat_payloads_tests PRIVATE engine_core)

--- a/docs/superpowers/plans/2026-06-08-character-system-r1a-server-stats.md
+++ b/docs/superpowers/plans/2026-06-08-character-system-r1a-server-stats.md
@@ -1,0 +1,80 @@
+# Système de Personnages — R1-A (PV calculés à l'enter-world) Plan
+
+**Goal:** À l'entrée en jeu, calculer les PV (et PV courants) du joueur depuis le moteur de stats (PR1) et les écrire dans le `StatsComponent` répliqué — la barre de vie affiche enfin la vraie valeur (ex. Guerrier Nain niv.60 = 3078 PV). 100 % serveur, **aucun changement de wire** (`currentHealth`/`maxHealth` se répliquent déjà).
+
+**Architecture:** Le shard charge faction/classe depuis la DB à l'enter-world, charge les tables embarquées une fois au boot, appelle `ComputeStats`, et remplit `ConnectedClient.stats`. Logique de résolution extraite dans une fonction pure **testée**. La ressource secondaire et les 9 autres stats restent pour R1-B (nécessitent opcode/UI).
+
+**Branche:** `feat/character-system-r1a-server-stats` (depuis main, après PR1).
+
+---
+
+## Contexte (cartographie)
+- Joueur live = `ConnectedClient` (struct, `src/shared/server_bootstrap/ServerApp.cpp` ~85-154 du .h) avec `StatsComponent { currentHealth, maxHealth }`. PV par défaut codés en dur (`kDefaultPlayerHealth`).
+- `HandleHello()` (~1029-1250) : enter-world. `LoadSpawnFromDb()` (~987-1027) charge `spawn_*, name, gender, level` (PAS faction/classe). `acceptedClient.level` posé ~1195. État persisté fusionné ~1142 (`acceptedClient.stats = persistedState.stats`).
+- Moteur PR1 : `engine::server::gameplay::ComputeStats(tables, factionId, classId, Sex, level) -> optional<DerivedStats>` ; `CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson)` (headers générés `CharacterStatsData.h`/`FactionsData.h`, dispo sur les targets de ServerApp via `${LCDLLN_GEN_DIR}`).
+- `ConnectedClient` a déjà `level`, `gender`, `characterName`.
+
+---
+
+## Task 1 — Helper pur testé : résolution des PV
+
+**Files:** Create `src/shardd/gameplay/character/SpawnStatsResolver.{h,cpp}`, `src/shardd/gameplay/character/SpawnStatsResolverTests.cpp`; Modify `src/CMakeLists.txt`.
+
+But : isoler la logique testable hors de `HandleHello` (intégration non testable unitairement).
+
+- [ ] **Step 1 (test first):** `SpawnStatsResolverTests.cpp` — table embarquée via `FromEmbedded(kCharacterStatsJson, kFactionsJson)`. Cas :
+  - Guerrier Nain (faction `naine`, classe `guerrier`, H, niv.60), pas de PV persistés (0) → `maxHealth` ∈ [3076,3080], `currentHealth == maxHealth`.
+  - Même perso, PV persistés = 100 → `maxHealth` ∈ [3076,3080], `currentHealth == 100` (conservé, ≤ max).
+  - PV persistés > max (ex. 999999) → `currentHealth == maxHealth` (clamp).
+  - Faction/classe inconnue → `resolved == false` (l'appelant garde le défaut).
+  Pattern plain-main return-0/1 (PAS assert — NDEBUG). Inclut `CharacterStatsData.h`/`FactionsData.h`.
+
+- [ ] **Step 2:** `SpawnStatsResolver.h` :
+```cpp
+#pragma once
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include <cstdint>
+#include <string>
+namespace engine::server::gameplay
+{
+	/// Résultat de la résolution des PV à l'enter-world.
+	struct SpawnHealth { bool resolved=false; uint32_t maxHealth=0; uint32_t currentHealth=0; };
+
+	/// Calcule maxHealth (=hp dérivé) et currentHealth pour un joueur entrant.
+	/// \param persistedCurrentHealth PV courants restaurés (0 = aucun → plein).
+	/// Si la faction/classe est inconnue, resolved=false (l'appelant garde le défaut).
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth);
+}
+```
+
+- [ ] **Step 3:** `SpawnStatsResolver.cpp` : appelle `ComputeStats`; si nullopt → `{false,0,0}`; sinon `maxHealth=hp`; `currentHealth = (persisted>0 ? min(persisted,max) : max)`.
+
+- [ ] **Step 4:** CMake — ajouter `SpawnStatsResolver.cpp` aux listes sources des targets serveur compilant déjà le moteur (WIN32 `server_app`, `shard_app`), et enregistrer `spawn_stats_resolver_tests` (bloc explicite avec `${LCDLLN_GEN_DIR}` + `add_dependencies(... lcdlln_gen_character_data)` + moteur + tables, comme `character_stats_engine_tests`).
+
+- [ ] **Step 5:** commit `feat(shardd): SpawnStatsResolver — PV dérivés à l'enter-world (+ tests)`.
+
+---
+
+## Task 2 — Charger faction/classe en DB + appeler le resolver dans HandleHello
+
+**Files:** Modify `src/shared/server_bootstrap/ServerApp.cpp` (+ `.h`).
+
+- [ ] **Step 1:** Charger les tables une fois : membre `std::optional<engine::server::gameplay::CharacterStatsTables> m_statsTables;` initialisé au boot (ou lazy au 1er HandleHello) via `FromEmbedded(kCharacterStatsJson, kFactionsJson)` ; log si nullopt. Include `CharacterStatsData.h`/`FactionsData.h` + le resolver.
+- [ ] **Step 2:** `LoadSpawnFromDb()` : ajouter `faction_str, class_str` au SELECT (~ligne 1007) ; renvoyer/retourner ces deux strings (via out-params ou struct). Ajouter `factionId`/`classId` à `ConnectedClient` (ou variables locales suffisantes pour l'appel).
+- [ ] **Step 3:** Dans `HandleHello`, après que `level`/`gender`/faction/classe sont connus ET après la fusion de l'état persisté (~après 1195), appeler `ResolveSpawnHealth(*m_statsTables, factionId, classId, sex, level, acceptedClient.stats.currentHealth)`. `sex` = `gender=="female"?Female:Male`. Si `m_statsTables` présent et `resolved` : `acceptedClient.stats.maxHealth = r.maxHealth; acceptedClient.stats.currentHealth = r.currentHealth;`. Sinon laisser le défaut (rétro-compat persos sans faction/classe).
+- [ ] **Step 4:** Log INFO : faction/classe/niveau → maxHealth calculé (utile au diag).
+- [ ] **Step 5:** commit `feat(shardd): enter-world calcule les PV du joueur depuis le moteur de stats`.
+
+---
+
+## Task 3 — Vérif + push + PR
+- [ ] grep : aucun nouveau wire/opcode ; `kProtocolVersion` inchangé.
+- [ ] push, PR base main. CI : build-linux (ctest `spawn_stats_resolver_tests`) + build-windows.
+
+> **Déploiement R1-A** : ⚠️ redéploiement serveur (shard) requis — nouveau binaire (PV calculés au boot du joueur). **Aucun changement client/wire** → pas de lock-step client. Indépendant de PR2 (peut se merger/déployer séparément, après PR1).
+
+## Hors périmètre (R1-B)
+Ressource secondaire + 9 autres stats répliquées + opcode « feuille de perso » + panneau UI client.

--- a/docs/superpowers/plans/2026-06-08-character-system-r1b-stats-sheet.md
+++ b/docs/superpowers/plans/2026-06-08-character-system-r1b-stats-sheet.md
@@ -1,0 +1,98 @@
+# Système de Personnages — R1-B (feuille de perso : 11 stats répliquées + panneau) Plan
+
+**Goal:** Pousser au client local **toutes** les stats dérivées (ressource secondaire val+max, dégâts, précision, portée, crit %, mult crit, vitesses marche/course/sprint, endurance val+max, perception, discrétion, + clé de ressource) via un **message dédié** (rétro-additif, sans bump de protocole), et les afficher dans un **panneau « feuille de personnage »** (ImGui).
+
+**Architecture:** Nouveau `MessageKind::PlayerStats` (gameplay shardd→client). À l'enter-world, le shard calcule les `DerivedStats` complètes (réutilise `m_statsTables` + faction/classe de R1-A), encode un `PlayerStatsMessage`, l'envoie au client via `m_transport.Send`. Le client décode dans `UIPlayerStats` (étendu) et un panneau ImGui l'affiche (toggle clavier). **Pas de bump `kProtocolVersion`** (nouveau type ignoré par les vieux clients) → pas de lock-step strict (un vieux client ignore le message ; un nouveau client sur vieux shard n'en reçoit juste pas).
+
+**Branche:** `feat/character-system-r1b-stats-sheet`, **stackée sur** `feat/character-system-r1a-server-stats` (réutilise R1-A). Rebaser sur main après merge de R1-A.
+
+---
+
+## Contexte (cartographie)
+- Framing gameplay : header 8 octets (`ServerProtocol.cpp` ~155) = magic + version(8) + `MessageKind`(uint16). `MessageKind` enum `ServerProtocol.h:42-210` (dernier `Goodbye=78`). DecodeHeader rejette si version≠8, mais un **nouveau MessageKind à version 8** passe et tombe dans le `default` côté vieux client (ignoré) → additif.
+- Envoi 1 client : `m_transport.Send(client.endpoint, packet)` ; pattern `SendWelcome` (`ServerApp.cpp` ~4178), encode via `Encode*`. 
+- Level-up runtime : **n'existe pas** → push à l'enter-world seulement.
+- Client dispatch : `UIModel.cpp` ~548-608 `switch(kind)` → `Apply*`. `UIPlayerStats` `UIModel.h:181-204` (PAS de stats dérivées). HUD : `CombatHud` (`ApplyModel`/`UpdatePlayerBars`).
+- `DerivedStats` (`CharacterStatsEngine.h:17-33`) : hp, resource, damage, accuracy(f), range(f), critRate(f), critMult(f), speedWalk/Run/Sprint(f), stamina, perception(f), stealth(f), resourceKey(string). (hp/maxHealth déjà répliqués par R1-A via snapshot → la feuille peut quand même les inclure pour cohérence d'affichage.)
+
+---
+
+## Task 1 — Message wire `PlayerStats` (+ round-trip test)
+
+**Files:** Modify `src/shared/network/ServerProtocol.h` / `.cpp`; Create `src/shared/network/PlayerStatsMessageTests.cpp`; Modify root `CMakeLists.txt`.
+
+- [ ] **Step 1 (test first):** `PlayerStatsMessageTests.cpp` — plain-main return 0/1 (NDEBUG-safe, pas d'assert). Construire un `PlayerStatsMessage` avec valeurs distinctes pour chaque champ (dont `resourceKey="ferveur"`), `EncodePlayerStats`, `DecodePlayerStats`, vérifier round-trip de TOUS les champs (floats à tolérance 1e-4). Inclure un cas `resourceKey` vide.
+- [ ] **Step 2:** `ServerProtocol.h` — ajouter `PlayerStats = 79` à `MessageKind` (après `Goodbye = 78`, ne PAS réordonner). Définir :
+```cpp
+	/// Stats dérivées complètes du joueur local (R1-B). Poussé à l'enter-world.
+	struct PlayerStatsMessage
+	{
+		uint32_t clientId = 0;
+		uint32_t maxHealth = 0;
+		uint32_t resource = 0;      ///< ressource secondaire max
+		uint32_t stamina = 0;       ///< endurance max
+		uint32_t damage = 0;
+		float    accuracy = 0.0f;
+		float    range = 0.0f;
+		float    critRate = 0.0f;
+		float    critMult = 0.0f;
+		float    speedWalk = 0.0f;
+		float    speedRun = 0.0f;
+		float    speedSprint = 0.0f;
+		float    perception = 0.0f;
+		float    stealth = 0.0f;
+		std::string resourceKey;    ///< ex. "ferveur" (libellé résolu client via l10n)
+	};
+	std::vector<std::byte> EncodePlayerStats(const PlayerStatsMessage& m);
+	std::optional<PlayerStatsMessage> DecodePlayerStats(std::span<const std::byte> packet);
+```
+(Adapter les types span/vector exactement à ceux des autres Encode/Decode du fichier — LIRE un Encode/Decode existant, ex. EncodeWelcome/DecodeWelcome, et mirrorer le writer/reader helpers + l'écriture du header via le helper commun.)
+- [ ] **Step 3:** `ServerProtocol.cpp` — implémenter `EncodePlayerStats` (header via le helper commun avec `MessageKind::PlayerStats`, puis writer des champs dans l'ordre du struct ; string via le helper string existant) et `DecodePlayerStats` (symétrique, garde de taille). Mirrorer EXACTEMENT le style d'un couple Encode/Decode existant.
+- [ ] **Step 4:** Enregistrer `player_stats_message_tests` dans le **root** `CMakeLists.txt` (là où vivent les autres tests `*_message`/`*_payloads` — ex. `character_save_position_payloads_tests`).
+- [ ] **Step 5:** commit `feat(wire): MessageKind::PlayerStats + encode/decode (rétro-additif) + test round-trip`.
+
+---
+
+## Task 2 — Shard : calcul complet + `SendPlayerStats` à l'enter-world
+
+**Files:** Modify `src/shared/server_bootstrap/ServerApp.cpp` / `.h`.
+
+- [ ] **Step 1:** Ajouter `bool SendPlayerStats(const ConnectedClient& client);` (déclaration `.h` près de `SendWelcome`). 
+- [ ] **Step 2:** Implémenter : si `m_statsTables` (chargé en R1-A) et faction/classe non vides, `auto d = engine::server::gameplay::ComputeStats(*m_statsTables, client.factionId, client.classId, sex(client.gender), client.level);` ; si `d`, remplir un `PlayerStatsMessage` (clientId + tous les champs de `*d`, `resourceKey=d->resourceKey`), `EncodePlayerStats`, `m_transport.Send(client.endpoint, packet)`. Sinon return false (pas de feuille pour legacy). Qualifier `engine::server::gameplay::` (cf. piège R1-A). Log INFO.
+- [ ] **Step 3:** Appeler `SendPlayerStats(acceptedClient)` à l'enter-world, **après** le bloc R1-A (PV résolus) et après `SendWelcome` (le client doit être prêt). Trouver le point exact où les autres bootstrap par-client sont envoyés (ex. après SendWelcome / spawn initial). 
+- [ ] **Step 4:** commit `feat(shardd): SendPlayerStats — pousse les 11 stats au client à l'enter-world`.
+
+---
+
+## Task 3 — Client : décodage `PlayerStats` → `UIPlayerStats`
+
+**Files:** Modify `src/client/ui_common/UIModel.h` / `.cpp`.
+
+- [ ] **Step 1:** Étendre `UIPlayerStats` (UIModel.h ~204) : `uint32_t derivedMaxHealth, secondaryResourceMax, staminaMax, damage; float accuracy, range, critRate, critMult, speedWalk, speedRun, speedSprint, perception, stealth; std::string secondaryResourceKey; bool hasSheet=false;`. (Ne pas écraser les champs snapshot existants health/mana ; ces nouveaux champs viennent de la feuille.)
+- [ ] **Step 2:** `UIModel.cpp` — dans le `switch(kind)` (~605), ajouter `case MessageKind::PlayerStats: return ApplyPlayerStats(packet);` avant le `default`. Implémenter `ApplyPlayerStats` : `DecodePlayerStats`, remplir les champs `UIPlayerStats`, `hasSheet=true`, notifier (mask de changement approprié, ex. `UIModelChangeStats` — mirrorer un Apply existant). Déclarer `ApplyPlayerStats` dans UIModel.h (privé, comme les autres `Apply*`).
+- [ ] **Step 3:** commit `feat(client): décode PlayerStats dans UIPlayerStats`.
+
+---
+
+## Task 4 — Client UI : panneau « Feuille de personnage » (ImGui) — VISUEL, non vérifiable sans build
+
+**Files:** Modify `src/client/combat/CombatHud.{h,cpp}` (ou un nouveau module sœur) + le point d'appel de rendu HUD + le toggle clavier.
+
+- [ ] **Step 1:** LIRE comment le HUD est rendu et togglé (chercher un panneau existant togglable, ex. inventaire 'I', social 'O', et le système de keybind). Mirrorer ce pattern pour un toggle (ex. 'C' — vérifier qu'il est libre).
+- [ ] **Step 2:** Ajouter `RenderCharacterSheetPanel()` : une fenêtre/`ImGui::Begin` "Personnage" affichant, depuis `model.playerStats` (si `hasSheet`), un tableau libellé→valeur : PV max, Ressource (libellé via l10n `resource.<key>` si dispo sinon la clé), Endurance, Dégâts, Précision %, Portée m, Crit %, Mult crit ×, Vitesses marche/course/sprint, Perception m, Discrétion m. Formats : entiers tels quels, floats `%.1f`/`%.2f`. Si mêlée pure (range==0), afficher "—" pour portée/précision.
+- [ ] **Step 3:** Brancher le rendu (toggle) dans la boucle HUD. Minimal, pattern-matched.
+- [ ] **Step 4:** (Localisation, optionnel) ajouter des clés `resource.<key>` (ferveur→« Ferveur », etc.) dans fr.json/en.json pour le libellé de ressource ; sinon le client affiche la clé brute.
+- [ ] **Step 5:** commit `feat(client): panneau feuille de personnage (11 stats) + toggle`.
+
+> ⚠️ Tâche 4 non vérifiable visuellement sans build local — additions minimales, pattern-matched, à valider en jeu par l'utilisateur.
+
+---
+
+## Task 5 — Vérif + push + PR
+- [ ] grep : `kProtocolVersion` inchangé (8). Symboles `engine::server::gameplay::` qualifiés dans ServerApp.
+- [ ] push, PR base main (stackée — préciser « à merger après R1-A #863 »). CI : build-linux (ctest `player_stats_message_tests`) + build-windows (client compile).
+
+> **Déploiement R1-B** : ⚠️ redéploiement **shard + client** pour bénéficier de la feuille (mais **rétro-compatible** : nouveau type de message ignoré par anciens clients, donc pas de lock-step strict — le bénéfice n'apparaît que quand les deux sont neufs). Aucun changement master.
+
+## Hors périmètre
+Level-up runtime (re-push des stats au changement de niveau) — quand le système d'XP/level-up serveur existera.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,8 @@ if(WIN32)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Character system R1-A — résolveur PV enter-world (dérive depuis le moteur).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp
@@ -633,6 +635,21 @@ elseif(UNIX)
   target_compile_options(character_stats_engine_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME character_stats_engine_tests COMMAND character_stats_engine_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Character system R1-A — SpawnStatsResolver : PV (max+courants) dérivés à
+  # l'enter-world. Bloc explicite (comme character_stats_engine_tests) : besoin
+  # du dossier des headers générés (${LCDLLN_GEN_DIR}) et de la dépendance au
+  # codegen lcdlln_gen_character_data.
+  add_executable(spawn_stats_resolver_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(spawn_stats_resolver_tests lcdlln_gen_character_data)
+  target_include_directories(spawn_stats_resolver_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(spawn_stats_resolver_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(spawn_stats_resolver_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME spawn_stats_resolver_tests COMMAND spawn_stats_resolver_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
   lcdlln_add_simple_test(metric_registry_tests
     ${CMAKE_SOURCE_DIR}/src/shared/metric/MetricRegistryTests.cpp)
@@ -1094,6 +1111,8 @@ elseif(UNIX)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Character system R1-A — résolveur PV enter-world (appelé par HandleHello).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/VendorCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/PlayerWalletService.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -40,6 +40,7 @@
 #include "src/client/render/MailImGuiRenderer.h"
 #include "src/client/render/GmTicketImGuiRenderer.h"
 #include "src/client/render/ReputationImGuiRenderer.h"
+#include "src/client/render/CharacterSheetImGuiRenderer.h"
 #include "src/client/render/ArenaImGuiRenderer.h"
 #include "src/client/render/BattleGroundImGuiRenderer.h"
 #include "src/client/render/OutdoorPvpImGuiRenderer.h"
@@ -7698,6 +7699,19 @@ namespace engine
 				m_lootRollVisible = !m_lootRollVisible;
 				LOG_INFO(Core, "[Engine] L toggle loot roll (visible={})", m_lootRollVisible);
 			}
+			// R1-B (Task 4) — Touche X : toggle la feuille de personnage (stats
+			// derivees). Pas de fetch a l'ouverture : playerStats est deja peuple
+			// dans le modele UI a l'enter-world. La touche C (mnemonique naturel)
+			// est deja prise par l'action "punch" (controls.keybind.punch), et le
+			// jeu de touches plateforme n'expose pas K/J ; X est libre. Memes
+			// guards que les autres toggles (chat focus, pause, editor, auth flow).
+			if (inGameNoMenu && !chatBlocks
+				&& !m_input.IsDown(engine::platform::Key::Control)
+				&& m_input.WasPressed(engine::platform::Key::X))
+			{
+				m_characterSheetVisible = !m_characterSheetVisible;
+				LOG_INFO(Core, "[Engine] X toggle character sheet (visible={})", m_characterSheetVisible);
+			}
 		}
 
 		// M100.2 — Dispatch des raccourcis éditeur monde vers le shell. Ctrl+Z
@@ -7977,6 +7991,11 @@ namespace engine
 				// La taille viewport est mise a jour dans la boucle Render plus bas.
 				m_reputationImGui = std::make_unique<engine::render::ReputationImGuiRenderer>();
 				m_reputationImGui->SetPresenter(&m_reputationUi);
+				// R1-B (Task 4) — Renderer ImGui de la feuille de personnage. Lit
+				// directement m_uiModelBinding.GetModel().playerStats (pas de
+				// presenter). Visible quand m_characterSheetVisible (toggle touche C
+				// hors combat). Taille viewport mise a jour dans la boucle Render.
+				m_characterSheetImGui = std::make_unique<engine::render::CharacterSheetImGuiRenderer>();
 				// CMANGOS.33 (Phase 5.33 step 3+4) — Renderer ImGui du panneau LFG.
 				// Partage le contexte ImGui avec auth/chat/mail/gmtickets/reputation.
 				// Visible uniquement quand m_lfgVisible (toggle via /lfg).
@@ -10281,6 +10300,15 @@ namespace engine
 				m_reputationImGui->SetEnabled(true);
 				m_reputationImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_reputationImGui->Render();
+			}
+			// R1-B (Task 4) — Render de la feuille de personnage si visible. Lit
+			// directement le modele UI (playerStats) ; le renderer gere lui-meme
+			// le cas hasSheet == false (affiche "Statistiques indisponibles").
+			if (m_characterSheetVisible && m_characterSheetImGui)
+			{
+				m_characterSheetImGui->SetEnabled(true);
+				m_characterSheetImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_characterSheetImGui->Render(m_uiModelBinding.GetModel());
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Render du panneau LFG si visible.
 			// Le modal proposal s'affiche aussi quand hasProposal == true (meme si

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -110,6 +110,7 @@ namespace engine::render
 	class MailImGuiRenderer;
 	class GmTicketImGuiRenderer;
 	class ReputationImGuiRenderer;
+	class CharacterSheetImGuiRenderer;
 	class LfgImGuiRenderer;
 	class CinematicImGuiRenderer;
 	class SkillBookImGuiRenderer;
@@ -1114,6 +1115,13 @@ namespace engine
 		/// CMANGOS.24 (Phase 3.24 step 3+4) — Visibilite du panneau Reputation
 		/// (toggle via slash command \c /rep ou \c /reputation). Faux par defaut.
 		bool                                  m_reputationVisible = false;
+		/// R1-B (Task 4) — Renderer ImGui de la feuille de personnage (stats
+		/// derivees). Lit directement \c m_uiModelBinding.GetModel().playerStats
+		/// (pas de presenter dedie). Instancie avec les autres renderers ImGui.
+		std::unique_ptr<engine::render::CharacterSheetImGuiRenderer> m_characterSheetImGui;
+		/// R1-B (Task 4) — Visibilite de la feuille de personnage (toggle touche X
+		/// hors combat). Faux par defaut.
+		bool                                  m_characterSheetVisible = false;
 		/// CMANGOS.33 (Phase 5.33 step 3+4) — Presenter de la fenetre LFG
 		/// (LookForGroup). Recoit les responses opcodes 101/103/105 et la push
 		/// notification 106 via le push handler du master ; fire-and-forget des

--- a/src/client/render/CharacterSheetImGuiRenderer.cpp
+++ b/src/client/render/CharacterSheetImGuiRenderer.cpp
@@ -1,0 +1,154 @@
+// R1-B (Task 4) — CharacterSheetImGuiRenderer implementation.
+
+#include "src/client/render/CharacterSheetImGuiRenderer.h"
+
+#include "src/client/ui_common/UIModel.h"
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	namespace
+	{
+		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+
+		/// Met la premiere lettre d'une cle de ressource en majuscule pour
+		/// l'affichage (ex. "rage" -> "Rage"). Pas de table de libelles codee
+		/// en dur : on derive l'etiquette de la cle brute envoyee par le serveur.
+		std::string CapitalizeKey(const std::string& key)
+		{
+			if (key.empty())
+				return "Ressource";
+			std::string out = key;
+			out[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(out[0])));
+			return out;
+		}
+
+		/// Ouvre une ligne du tableau 2 colonnes et ecrit le label en colonne 0,
+		/// puis se positionne en colonne 1 ou l'appelant ecrit la valeur via
+		/// \c ImGui::Text(...). Evite un wrapper variadique (cf. siblings qui
+		/// appellent ImGui::Text directement dans les cellules).
+		void BeginStatRow(const char* label)
+		{
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			ImGui::TextUnformatted(label);
+			ImGui::TableSetColumnIndex(1);
+		}
+	}
+
+	void CharacterSheetImGuiRenderer::Render(const engine::client::UIModel& model)
+	{
+		if (!m_enabled)
+			return;
+
+		const auto& s = model.playerStats;
+
+		// Geometrie : panneau ancre a gauche, 320x420, centre vertical.
+		const float panelW = 320.f;
+		const float panelH = 420.f;
+		const float margin = 24.f;
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+		const float posX = margin;
+		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+		(void)vpW;
+
+		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.95f);
+
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+		if (ImGui::Begin("Personnage##ln_character_sheet", nullptr, flags))
+		{
+			if (!s.hasSheet)
+			{
+				// Feuille pas encore recue (pre enter-world ou paquet manquant).
+				ImGui::TextDisabled("Statistiques indisponibles");
+			}
+			else
+			{
+				const ImGuiTableFlags tableFlags = ImGuiTableFlags_RowBg
+					| ImGuiTableFlags_BordersInnerH;
+				if (ImGui::BeginTable("##ln_character_sheet_stats", 2, tableFlags, ImVec2(0.f, 0.f)))
+				{
+					ImGui::TableSetupColumn("Stat",   ImGuiTableColumnFlags_WidthStretch);
+					ImGui::TableSetupColumn("Valeur", ImGuiTableColumnFlags_WidthFixed, 110.f);
+
+					// Le serveur envoie range == 0 pour une classe melee pure :
+					// precision et portee n'ont alors pas de sens, on affiche "—".
+					const bool melee = (s.range == 0.0f);
+					const char* kDash = "\xE2\x80\x94"; // — (em dash UTF-8)
+
+					BeginStatRow("PV max");
+					ImGui::Text("%u", static_cast<unsigned>(s.sheetMaxHealth));
+
+					const std::string resLabel = CapitalizeKey(s.secondaryResourceKey);
+					BeginStatRow(resLabel.c_str());
+					ImGui::Text("%u", static_cast<unsigned>(s.secondaryResourceMax));
+
+					BeginStatRow("Endurance");
+					ImGui::Text("%u", static_cast<unsigned>(s.staminaMax));
+
+					BeginStatRow("Degats");
+					ImGui::Text("%u", static_cast<unsigned>(s.damage));
+
+					BeginStatRow("Precision");
+					if (melee)
+						ImGui::TextUnformatted(kDash);
+					else
+						ImGui::Text("%.1f %%", s.accuracy);
+
+					BeginStatRow("Portee");
+					if (melee)
+						ImGui::TextUnformatted(kDash);
+					else
+						ImGui::Text("%.1f m", s.range);
+
+					BeginStatRow("Taux crit");
+					ImGui::Text("%.1f %%", s.critRate);
+
+					BeginStatRow("Mult crit");
+					ImGui::Text("%.2f x", s.critMult);
+
+					BeginStatRow("Vitesse marche");
+					ImGui::Text("%.1f", s.speedWalk);
+
+					BeginStatRow("Vitesse course");
+					ImGui::Text("%.1f", s.speedRun);
+
+					BeginStatRow("Vitesse sprint");
+					ImGui::Text("%.1f", s.speedSprint);
+
+					BeginStatRow("Perception");
+					ImGui::Text("%.1f m", s.perception);
+
+					BeginStatRow("Discretion");
+					ImGui::Text("%.1f m", s.stealth);
+
+					ImGui::EndTable();
+				}
+			}
+		}
+		ImGui::End();
+		ImGui::PopStyleColor(2);
+	}
+}
+
+#else // !_WIN32
+
+namespace engine::render
+{
+	void CharacterSheetImGuiRenderer::Render(const engine::client::UIModel&) {}
+}
+
+#endif

--- a/src/client/render/CharacterSheetImGuiRenderer.h
+++ b/src/client/render/CharacterSheetImGuiRenderer.h
@@ -1,0 +1,41 @@
+#pragma once
+// R1-B (Task 4) — CharacterSheetImGuiRenderer : panneau ImGui en lecture seule
+// affichant les stats derivees du joueur local (feuille de personnage).
+//
+// Contrairement aux autres panneaux HUD qui lisent l'etat d'un presenter dedie,
+// ce panneau lit directement UIModel.playerStats (peuple par UIModel::ApplyPlayerStats
+// a l'enter-world, Task 3). Aucun fetch / parse cote renderer : il ne fait que
+// dessiner les champs deja resolus dans le modele.
+
+#include <cstdint>
+
+namespace engine::client { struct UIModel; }
+
+namespace engine::render
+{
+	/// Renderer ImGui du panneau "Personnage" (feuille de stats derivees).
+	/// Strictement en lecture : ne modifie pas le modele, n'envoie aucune requete.
+	class CharacterSheetImGuiRenderer
+	{
+	public:
+		CharacterSheetImGuiRenderer() = default;
+
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const   { return m_enabled; }
+
+		/// Met a jour la viewport pour le placement du panneau.
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+
+		/// Render le panel "Personnage" depuis \p model.playerStats.
+		/// A appeler entre \c ImGui::NewFrame() et \c ImGui::Render(), seulement
+		/// si IsEnabled(). Si playerStats.hasSheet est faux, affiche une ligne
+		/// grisee "Statistiques indisponibles".
+		/// \param model snapshot UI courant (non possede, lecture seule).
+		void Render(const engine::client::UIModel& model);
+
+	private:
+		bool     m_enabled  = false;
+		uint32_t m_viewportW = 0;
+		uint32_t m_viewportH = 0;
+	};
+}

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -602,6 +602,9 @@ namespace engine::client
 			return ApplyCraftComplete(packet);
 		case engine::server::MessageKind::CraftCancelled:
 			return ApplyCraftCancelled(packet);
+		// R1-B — feuille de personnage (stats dérivées poussées à l'enter-world)
+		case engine::server::MessageKind::PlayerStats:
+			return ApplyPlayerStats(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -1098,6 +1101,45 @@ namespace engine::client
 			m_walletScratch.premiumCurrency);
 
 		NotifyObservers(UIModelChangeWallet);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyPlayerStats(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodePlayerStats(packet, m_playerStatsScratch))
+		{
+			LOG_WARN(Net, "[UIModelBinding] PlayerStats FAILED: decode error");
+			return false;
+		}
+
+		// R1-B — recopie la feuille de stats dérivées dans la section stats du modèle.
+		// Champs distincts du snapshot (health/mana courants) : ici ce sont les maxima
+		// et stats statiques calculées par le shard à l'enter-world.
+		m_model.playerStats.hasSheet = true;
+		m_model.playerStats.sheetMaxHealth = m_playerStatsScratch.maxHealth;
+		m_model.playerStats.secondaryResourceMax = m_playerStatsScratch.resource;
+		m_model.playerStats.staminaMax = m_playerStatsScratch.stamina;
+		m_model.playerStats.damage = m_playerStatsScratch.damage;
+		m_model.playerStats.accuracy = m_playerStatsScratch.accuracy;
+		m_model.playerStats.range = m_playerStatsScratch.range;
+		m_model.playerStats.critRate = m_playerStatsScratch.critRate;
+		m_model.playerStats.critMult = m_playerStatsScratch.critMult;
+		m_model.playerStats.speedWalk = m_playerStatsScratch.speedWalk;
+		m_model.playerStats.speedRun = m_playerStatsScratch.speedRun;
+		m_model.playerStats.speedSprint = m_playerStatsScratch.speedSprint;
+		m_model.playerStats.perception = m_playerStatsScratch.perception;
+		m_model.playerStats.stealth = m_playerStatsScratch.stealth;
+		m_model.playerStats.secondaryResourceKey = m_playerStatsScratch.resourceKey;
+
+		LOG_INFO(Net,
+			"[UIModelBinding] PlayerStats applied (client_id={}, max_health={}, resource={}, stamina={}, damage={})",
+			m_playerStatsScratch.clientId,
+			m_playerStatsScratch.maxHealth,
+			m_playerStatsScratch.resource,
+			m_playerStatsScratch.stamina,
+			m_playerStatsScratch.damage);
+
+		NotifyObservers(UIModelChangeStats);
 		return true;
 	}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -201,6 +201,22 @@ namespace engine::client
 		bool hasMana = false;
 		bool hasCombo = false;
 		bool hasSnapshot = false;
+		// R1-B — feuille de personnage (poussée via MessageKind::PlayerStats à l'enter-world).
+		bool     hasSheet = false;
+		uint32_t sheetMaxHealth = 0;
+		uint32_t secondaryResourceMax = 0;
+		uint32_t staminaMax = 0;
+		uint32_t damage = 0;
+		float    accuracy = 0.0f;
+		float    range = 0.0f;
+		float    critRate = 0.0f;
+		float    critMult = 0.0f;
+		float    speedWalk = 0.0f;
+		float    speedRun = 0.0f;
+		float    speedSprint = 0.0f;
+		float    perception = 0.0f;
+		float    stealth = 0.0f;
+		std::string secondaryResourceKey;
 	};
 
 	/// Current combat target resolved from the latest player-originated combat event.
@@ -496,6 +512,9 @@ namespace engine::client
 		/// Apply one decoded CraftCancelled message (M36.2).
 		bool ApplyCraftCancelled(std::span<const std::byte> packet);
 
+		/// Applique un message PlayerStats (feuille de perso dérivée) à la section stats (R1-B).
+		bool ApplyPlayerStats(std::span<const std::byte> packet);
+
 		/// Advance world presenter ages (wall clock clamped).
 		void PumpWorldPresenterAge();
 
@@ -540,6 +559,7 @@ namespace engine::client
 		engine::server::CraftStartMessage          m_craftStartScratch{};
 		engine::server::CraftCompleteMessage       m_craftCompleteScratch{};
 		engine::server::CraftCancelledMessage      m_craftCancelledScratch{};
+		engine::server::PlayerStatsMessage         m_playerStatsScratch{};
 		ChatWorldVisualPresenter m_chatWorld{};
 		size_t m_nextObserverHandle = 1;
 		bool m_initialized = false;

--- a/src/shardd/gameplay/character/SpawnStatsResolver.cpp
+++ b/src/shardd/gameplay/character/SpawnStatsResolver.cpp
@@ -1,0 +1,19 @@
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
+#include <algorithm>
+namespace engine::server::gameplay
+{
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth)
+	{
+		auto d = ComputeStats(tables, factionId, classId, sex, level);
+		if (!d) return SpawnHealth{}; // resolved=false → l'appelant garde le défaut
+		SpawnHealth h;
+		h.resolved = true;
+		h.maxHealth = d->hp;
+		h.currentHealth = (persistedCurrentHealth > 0u)
+			? std::min(persistedCurrentHealth, h.maxHealth)
+			: h.maxHealth;
+		return h;
+	}
+}

--- a/src/shardd/gameplay/character/SpawnStatsResolver.h
+++ b/src/shardd/gameplay/character/SpawnStatsResolver.h
@@ -1,0 +1,19 @@
+#pragma once
+// SpawnStatsResolver : résout les PV (max + courants) d'un joueur à l'enter-world
+// depuis le moteur de stats. Pur et testable (séparé de HandleHello, intégration).
+#include "src/shardd/gameplay/character/CharacterStatsEngine.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include <cstdint>
+#include <string>
+namespace engine::server::gameplay
+{
+	/// PV résolus à l'entrée en jeu.
+	struct SpawnHealth { bool resolved = false; uint32_t maxHealth = 0; uint32_t currentHealth = 0; };
+
+	/// Calcule maxHealth (= hp dérivé) et currentHealth pour un joueur entrant.
+	/// \param persistedCurrentHealth PV courants restaurés (0 = aucun → plein).
+	/// \return resolved=false si la faction/classe est inconnue (l'appelant garde le défaut).
+	SpawnHealth ResolveSpawnHealth(const CharacterStatsTables& tables,
+	                               const std::string& factionId, const std::string& classId,
+	                               Sex sex, uint32_t level, uint32_t persistedCurrentHealth);
+}

--- a/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
+++ b/src/shardd/gameplay/character/SpawnStatsResolverTests.cpp
@@ -1,0 +1,75 @@
+// Tests du résolveur de PV à l'enter-world : ancre Guerrier Nain H niv.60
+// (maxHealth ~3078, identique à CharacterStatsEngineTests), restauration des PV
+// courants (plein si 0, conservé si fourni, plafonné à maxHealth), faction
+// inconnue → resolved=false. Plain-main, NDEBUG-safe (pas d'assert).
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
+#include "src/shared/core/Log.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
+
+#include <cstdio>
+
+namespace
+{
+	using namespace engine::server::gameplay;
+
+	// PV plein quand aucun PV courant n'est persisté (persisted == 0).
+	bool TestSpawnFull()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/0u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] full: resolved=false\n"); return false; }
+		if (h.maxHealth < 3076u || h.maxHealth > 3080u) { fprintf(stderr, "[SpawnStatsResolverTests] full: maxHealth=%u\n", h.maxHealth); return false; }
+		if (h.currentHealth != h.maxHealth) { fprintf(stderr, "[SpawnStatsResolverTests] full: current=%u != max=%u\n", h.currentHealth, h.maxHealth); return false; }
+		return true;
+	}
+
+	// PV courant persisté conservé tel quel (100 < maxHealth).
+	bool TestSpawnPersisted()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/100u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: resolved=false\n"); return false; }
+		if (h.maxHealth < 3076u || h.maxHealth > 3080u) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: maxHealth=%u\n", h.maxHealth); return false; }
+		if (h.currentHealth != 100u) { fprintf(stderr, "[SpawnStatsResolverTests] persisted: current=%u != 100\n", h.currentHealth); return false; }
+		return true;
+	}
+
+	// PV courant persisté absurde (> maxHealth) plafonné à maxHealth.
+	bool TestSpawnClamped()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "naine", "guerrier", Sex::Male, 60, /*persisted*/999999u);
+		if (!h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] clamped: resolved=false\n"); return false; }
+		if (h.currentHealth != h.maxHealth) { fprintf(stderr, "[SpawnStatsResolverTests] clamped: current=%u != max=%u\n", h.currentHealth, h.maxHealth); return false; }
+		return true;
+	}
+
+	// Faction inconnue → resolved=false, l'appelant garde son défaut.
+	bool TestUnknownFaction()
+	{
+		auto t = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+		if (!t) { fprintf(stderr, "[SpawnStatsResolverTests] FromEmbedded null\n"); return false; }
+		auto h = ResolveSpawnHealth(*t, "inconnue", "guerrier", Sex::Male, 1, /*persisted*/0u);
+		if (h.resolved) { fprintf(stderr, "[SpawnStatsResolverTests] unknown: resolved=true (attendu false)\n"); return false; }
+		return true;
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+	const bool ok = TestSpawnFull()
+	             && TestSpawnPersisted()
+	             && TestSpawnClamped()
+	             && TestUnknownFaction();
+	if (ok) LOG_INFO(Core, "[SpawnStatsResolverTests] ALL OK");
+	else    LOG_ERROR(Core, "[SpawnStatsResolverTests] FAIL");
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/network/PlayerStatsMessageTests.cpp
+++ b/src/shared/network/PlayerStatsMessageTests.cpp
@@ -1,0 +1,156 @@
+/**
+ * R1-B — Round-trip test for the PLAYER_STATS gameplay message.
+ *
+ * Vérifie qu'un PlayerStatsMessage encodé puis décodé restitue tous ses champs.
+ * Test pur (pas de DB / pas de réseau). NDEBUG-safe : pas d'assert ; retourne 0 en
+ * cas de succès, 1 à la première erreur.
+ */
+
+#include "src/shared/network/ServerProtocol.h"
+
+#include <cstdio>
+#include <string>
+
+using engine::server::PlayerStatsMessage;
+using engine::server::EncodePlayerStats;
+using engine::server::DecodePlayerStats;
+
+namespace
+{
+	/// Compare deux flottants à 1e-3 près (tolérance round-trip IEEE-754).
+	bool FloatNear(float a, float b)
+	{
+		const float diff = (a > b) ? (a - b) : (b - a);
+		return diff <= 1e-3f;
+	}
+
+	/// Encode/décode \p src et vérifie l'égalité champ-à-champ. Renvoie true si OK.
+	bool RoundTrip(const PlayerStatsMessage& src, const char* label)
+	{
+		const std::vector<std::byte> packet = EncodePlayerStats(src);
+
+		PlayerStatsMessage out;
+		if (!DecodePlayerStats(packet, out))
+		{
+			fprintf(stderr, "[FAIL] %s: DecodePlayerStats returned false\n", label);
+			return false;
+		}
+
+		if (out.clientId != src.clientId)
+		{
+			fprintf(stderr, "[FAIL] %s: clientId %u != %u\n", label, out.clientId, src.clientId);
+			return false;
+		}
+		if (out.maxHealth != src.maxHealth)
+		{
+			fprintf(stderr, "[FAIL] %s: maxHealth %u != %u\n", label, out.maxHealth, src.maxHealth);
+			return false;
+		}
+		if (out.resource != src.resource)
+		{
+			fprintf(stderr, "[FAIL] %s: resource %u != %u\n", label, out.resource, src.resource);
+			return false;
+		}
+		if (out.stamina != src.stamina)
+		{
+			fprintf(stderr, "[FAIL] %s: stamina %u != %u\n", label, out.stamina, src.stamina);
+			return false;
+		}
+		if (out.damage != src.damage)
+		{
+			fprintf(stderr, "[FAIL] %s: damage %u != %u\n", label, out.damage, src.damage);
+			return false;
+		}
+		if (!FloatNear(out.accuracy, src.accuracy))
+		{
+			fprintf(stderr, "[FAIL] %s: accuracy %f != %f\n", label, out.accuracy, src.accuracy);
+			return false;
+		}
+		if (!FloatNear(out.range, src.range))
+		{
+			fprintf(stderr, "[FAIL] %s: range %f != %f\n", label, out.range, src.range);
+			return false;
+		}
+		if (!FloatNear(out.critRate, src.critRate))
+		{
+			fprintf(stderr, "[FAIL] %s: critRate %f != %f\n", label, out.critRate, src.critRate);
+			return false;
+		}
+		if (!FloatNear(out.critMult, src.critMult))
+		{
+			fprintf(stderr, "[FAIL] %s: critMult %f != %f\n", label, out.critMult, src.critMult);
+			return false;
+		}
+		if (!FloatNear(out.speedWalk, src.speedWalk))
+		{
+			fprintf(stderr, "[FAIL] %s: speedWalk %f != %f\n", label, out.speedWalk, src.speedWalk);
+			return false;
+		}
+		if (!FloatNear(out.speedRun, src.speedRun))
+		{
+			fprintf(stderr, "[FAIL] %s: speedRun %f != %f\n", label, out.speedRun, src.speedRun);
+			return false;
+		}
+		if (!FloatNear(out.speedSprint, src.speedSprint))
+		{
+			fprintf(stderr, "[FAIL] %s: speedSprint %f != %f\n", label, out.speedSprint, src.speedSprint);
+			return false;
+		}
+		if (!FloatNear(out.perception, src.perception))
+		{
+			fprintf(stderr, "[FAIL] %s: perception %f != %f\n", label, out.perception, src.perception);
+			return false;
+		}
+		if (!FloatNear(out.stealth, src.stealth))
+		{
+			fprintf(stderr, "[FAIL] %s: stealth %f != %f\n", label, out.stealth, src.stealth);
+			return false;
+		}
+		if (out.resourceKey != src.resourceKey)
+		{
+			fprintf(stderr, "[FAIL] %s: resourceKey \"%s\" != \"%s\"\n",
+				label, out.resourceKey.c_str(), src.resourceKey.c_str());
+			return false;
+		}
+
+		return true;
+	}
+}
+
+int main()
+{
+	// Cas 1 — valeurs distinctes pour chaque champ + resourceKey non vide.
+	PlayerStatsMessage full;
+	full.clientId = 42;
+	full.maxHealth = 3078;
+	full.resource = 1200;
+	full.stamina = 800;
+	full.damage = 250;
+	full.accuracy = 88.5f;
+	full.range = 30.0f;
+	full.critRate = 7.5f;
+	full.critMult = 1.8f;
+	full.speedWalk = 2.0f;
+	full.speedRun = 5.0f;
+	full.speedSprint = 8.0f;
+	full.perception = 12.5f;
+	full.stealth = 9.0f;
+	full.resourceKey = "ferveur";
+
+	if (!RoundTrip(full, "full"))
+	{
+		return 1;
+	}
+
+	// Cas 2 — resourceKey vide (chaîne taillée de longueur 0).
+	PlayerStatsMessage empty = full;
+	empty.resourceKey = "";
+
+	if (!RoundTrip(empty, "emptyResourceKey"))
+	{
+		return 1;
+	}
+
+	printf("[OK] PlayerStatsMessage round-trip\n");
+	return 0;
+}

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -450,6 +450,66 @@ namespace engine::server
 		return packet;
 	}
 
+	std::vector<std::byte> EncodePlayerStats(const PlayerStatsMessage& message)
+	{
+		// R1-B — payload : 5 u32 (clientId, maxHealth, resource, stamina, damage) + 9 f32
+		// (accuracy, range, critRate, critMult, speedWalk, speedRun, speedSprint, perception,
+		// stealth) + 1 chaîne taillée (resourceKey, préfixe u16). Estimation pour reserve.
+		std::vector<std::byte> packet = BeginPacket(
+			MessageKind::PlayerStats, 5 * 4 + 9 * 4 + 2 + message.resourceKey.size());
+		WriteU32(packet, message.clientId);
+		WriteU32(packet, message.maxHealth);
+		WriteU32(packet, message.resource);
+		WriteU32(packet, message.stamina);
+		WriteU32(packet, message.damage);
+		WriteF32(packet, message.accuracy);
+		WriteF32(packet, message.range);
+		WriteF32(packet, message.critRate);
+		WriteF32(packet, message.critMult);
+		WriteF32(packet, message.speedWalk);
+		WriteF32(packet, message.speedRun);
+		WriteF32(packet, message.speedSprint);
+		WriteF32(packet, message.perception);
+		WriteF32(packet, message.stealth);
+		WriteSizedString(packet, message.resourceKey);
+		return packet;
+	}
+
+	bool DecodePlayerStats(std::span<const std::byte> packet, PlayerStatsMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		// Taille fixe minimale : 5 u32 + 9 f32 + 2 octets de préfixe de chaîne = 58 octets.
+		if (!DecodeHeader(packet, MessageKind::PlayerStats, payload) || payload.size() < 58)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.maxHealth = ReadU32(payload, 4);
+		outMessage.resource = ReadU32(payload, 8);
+		outMessage.stamina = ReadU32(payload, 12);
+		outMessage.damage = ReadU32(payload, 16);
+		outMessage.accuracy = ReadF32(payload, 20);
+		outMessage.range = ReadF32(payload, 24);
+		outMessage.critRate = ReadF32(payload, 28);
+		outMessage.critMult = ReadF32(payload, 32);
+		outMessage.speedWalk = ReadF32(payload, 36);
+		outMessage.speedRun = ReadF32(payload, 40);
+		outMessage.speedSprint = ReadF32(payload, 44);
+		outMessage.perception = ReadF32(payload, 48);
+		outMessage.stealth = ReadF32(payload, 52);
+		size_t offset = 56;
+		if (!ReadSizedString(payload, offset, outMessage.resourceKey))
+		{
+			return false;
+		}
+		if (offset != payload.size())
+		{
+			return false;
+		}
+		return true;
+	}
+
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities)
 	{
 		// TD.6/TD.8 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -207,7 +207,11 @@ namespace engine::server
 		/// shard d'évincer immédiatement l'entité au lieu d'attendre le timeout d'inactivité
 		/// (sinon l'avatar du joueur parti reste un « fantôme » visible des autres). Ajout
 		/// rétro-compatible : un shard qui ne connaît pas cet opcode l'ignore (fallback timeout).
-		Goodbye = 78
+		Goodbye = 78,
+		/// Server → client: stats dérivées complètes du joueur local (R1-B). Poussé à
+		/// l'enter-world. Ajout rétro-additif : un vieux client qui ne connaît pas cet
+		/// opcode l'ignore (pas de bump de `kProtocolVersion`).
+		PlayerStats = 79
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -248,6 +252,27 @@ namespace engine::server
 	struct GoodbyeMessage
 	{
 		uint32_t clientId = 0;
+	};
+
+	/// Stats dérivées complètes du joueur local (R1-B). Poussé à l'enter-world.
+	/// Type de message rétro-additif (vieux clients l'ignorent ; pas de bump de version).
+	struct PlayerStatsMessage
+	{
+		uint32_t clientId = 0;
+		uint32_t maxHealth = 0;
+		uint32_t resource = 0;   ///< ressource secondaire max
+		uint32_t stamina = 0;    ///< endurance max
+		uint32_t damage = 0;
+		float    accuracy = 0.0f;
+		float    range = 0.0f;
+		float    critRate = 0.0f;
+		float    critMult = 0.0f;
+		float    speedWalk = 0.0f;
+		float    speedRun = 0.0f;
+		float    speedSprint = 0.0f;
+		float    perception = 0.0f;
+		float    stealth = 0.0f;
+		std::string resourceKey; ///< ex. "ferveur" (libellé résolu côté client)
 	};
 
 	/// Snapshot envelope carrying timing, connection stats and entity state count.
@@ -406,6 +431,12 @@ namespace engine::server
 
 	/// Decode a welcome packet and validate the protocol header.
 	bool DecodeWelcome(std::span<const std::byte> packet, WelcomeMessage& outMessage);
+
+	/// Encode un PLAYER_STATS (shard→client) : stats dérivées complètes du joueur (R1-B).
+	std::vector<std::byte> EncodePlayerStats(const PlayerStatsMessage& message);
+
+	/// Decode un PLAYER_STATS et valide le header partagé du protocole (R1-B).
+	bool DecodePlayerStats(std::span<const std::byte> packet, PlayerStatsMessage& outMessage);
 
 	/// Encode a snapshot packet with the protocol header.
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities);

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1324,6 +1324,7 @@ namespace engine::server
 			UdpTransport::EndpointToString(endpoint),
 			m_clients.size());
 		(void)SendWelcome(acceptedClient);
+		(void)SendPlayerStats(acceptedClient);
 		SendDynamicEventBootstrap(acceptedClient);
 		SendQuestStateBootstrap(acceptedClient);
 		(void)SendWalletUpdate(acceptedClient);
@@ -4195,6 +4196,45 @@ namespace engine::server
 			UdpTransport::EndpointToString(client.endpoint),
 			m_tickHz,
 			m_snapshotHz);
+		return true;
+	}
+
+	bool ServerApp::SendPlayerStats(const ConnectedClient& client)
+	{
+		if (!m_statsTables) return false;
+		if (client.factionId.empty() || client.classId.empty()) return false;
+		const engine::server::gameplay::Sex sex =
+			(client.gender == "female") ? engine::server::gameplay::Sex::Female
+			                            : engine::server::gameplay::Sex::Male;
+		const auto d = engine::server::gameplay::ComputeStats(
+			*m_statsTables, client.factionId, client.classId, sex, client.level);
+		if (!d) return false;
+
+		PlayerStatsMessage msg{};
+		msg.clientId    = client.clientId;
+		msg.maxHealth   = d->hp;
+		msg.resource    = d->resource;
+		msg.stamina     = d->stamina;
+		msg.damage      = d->damage;
+		msg.accuracy    = d->accuracy;
+		msg.range       = d->range;
+		msg.critRate    = d->critRate;
+		msg.critMult    = d->critMult;
+		msg.speedWalk   = d->speedWalk;
+		msg.speedRun    = d->speedRun;
+		msg.speedSprint = d->speedSprint;
+		msg.perception  = d->perception;
+		msg.stealth     = d->stealth;
+		msg.resourceKey = d->resourceKey;
+
+		const std::vector<std::byte> packet = EncodePlayerStats(msg);
+		if (!m_transport.Send(client.endpoint, packet))
+		{
+			LOG_WARN(Net, "[ServerApp] SendPlayerStats failed (client_id={})", client.clientId);
+			return false;
+		}
+		LOG_INFO(Net, "[ServerApp] PlayerStats sent (client_id={}, faction={}, class={}, level={}, maxHp={})",
+			client.clientId, client.factionId, client.classId, client.level, d->hp);
 		return true;
 	}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -8,6 +8,12 @@
 #include "src/shardd/world/AdmittedCharacterRegistry.h"
 #include "src/shared/network/ServerProtocol.h"
 
+// R1-A — JSON embarqués (générés au build) pour le moteur de stats des personnages.
+// Symboles const char* kCharacterStatsJson / kFactionsJson. Atteignables sur les targets
+// de ServerApp (server_app, shard_app) via ${LCDLLN_GEN_DIR} sur leur include path.
+#include "CharacterStatsData.h"
+#include "FactionsData.h"
+
 // TA.4 — pont position : compilé uniquement pour la cible shard Linux (SHARD_POSITION_DB),
 // pas pour le build Windows (ServerApp.cpp est partagé). Macro dédié plutôt qu'ENGINE_HAS_MYSQL
 // pour ne PAS basculer les autres systèmes gameplay du shard en mode DB.
@@ -985,7 +991,8 @@ namespace engine::server
 	}
 
 	bool ServerApp::LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender, uint32_t& outLevel)
+		std::string& outName, std::string& outGender, uint32_t& outLevel,
+		std::string& outFactionId, std::string& outClassId)
 	{
 #if defined(SHARD_POSITION_DB)
 		if (m_characterDbPool == nullptr || characterId == 0u)
@@ -1003,8 +1010,11 @@ namespace engine::server
 		// TD.6 — et `gender` (migration 0067) pour le rendu de l'avatar distant.
 		// Présence enrichie — `level` (migration 0004) pour la présence web-portal.
 		// N1-I : prepared statement (bind characterId). Floats lus via GetString + strtof.
+		// R1-A — `faction_str`/`class_str` (cf. migrations 0040/0033) ajoutés EN FIN de SELECT
+		// (indices 7/8) pour ne pas décaler les indices des colonnes existantes (0..6).
+		// Alimentent le moteur de stats (PV à l'enter-world).
 		auto* stmt = cache->Acquire(mysql,
-			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender, level FROM characters "
+			"SELECT spawn_x, spawn_y, spawn_z, spawn_yaw_deg, name, gender, level, faction_str, class_str FROM characters "
 			"WHERE id = ? AND deleted_at IS NULL");
 		if (!stmt || !stmt->Bind(0, characterId) || !stmt->Execute() || !stmt->FetchRow())
 		{
@@ -1019,15 +1029,34 @@ namespace engine::server
 		outLevel = static_cast<uint32_t>(std::strtoul(stmt->GetString(6).c_str(), nullptr, 10));
 		if (outLevel == 0u)
 			outLevel = 1u; // garde-fou : niveau minimal 1.
+		outFactionId = stmt->GetString(7);
+		outClassId = stmt->GetString(8);
 		return true;
 #else
 		(void)characterId; (void)x; (void)y; (void)z; (void)yawDeg; (void)outName; (void)outGender; (void)outLevel;
+		(void)outFactionId; (void)outClassId;
 		return false;
 #endif
 	}
 
 	void ServerApp::HandleHello(const Endpoint& endpoint, uint64_t helloNonce)
 	{
+		// R1-A — charge les tables de stats une seule fois (lazy). FromEmbedded renvoie
+		// directement un std::optional ; en cas d'échec on logue une fois et on garde nullopt
+		// (les PV par défaut s'appliqueront → pas de régression).
+		if (!m_statsTablesLoadAttempted)
+		{
+			m_statsTablesLoadAttempted = true;
+			m_statsTables = engine::server::gameplay::CharacterStatsTables::FromEmbedded(
+				kCharacterStatsJson, kFactionsJson);
+			if (!m_statsTables)
+			{
+				LOG_WARN(Net,
+					"[ServerApp] R1-A : moteur de stats indisponible (FromEmbedded a échoué) — "
+					"PV par défaut conservés à l'enter-world.");
+			}
+		}
+
 		// Phase 3.7.5 — tentativeCharacterKey élargi à uint64. Fallback sur m_nextClientId
 		// (uint32) si le client n'a pas envoyé de character_id ; cast widening explicite.
 		const uint64_t tentativeCharacterKey = helloNonce != 0u
@@ -1181,7 +1210,9 @@ namespace engine::server
 			std::string dbName;
 			std::string dbGender;
 			uint32_t dbLevel = 1u;
-			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender, dbLevel))
+			std::string dbFactionId;
+			std::string dbClassId;
+			if (LoadSpawnFromDb(acceptedClient.persistenceCharacterKey, dbX, dbY, dbZ, dbYawDeg, dbName, dbGender, dbLevel, dbFactionId, dbClassId))
 			{
 				acceptedClient.positionMetersX = dbX;
 				acceptedClient.positionMetersY = dbY;
@@ -1193,6 +1224,9 @@ namespace engine::server
 				acceptedClient.gender = std::move(dbGender);
 				// Présence enrichie — niveau (table characters) reporté au master via heartbeat.
 				acceptedClient.level = dbLevel;
+				// R1-A — faction/classe pour le moteur de stats (PV à l'enter-world).
+				acceptedClient.factionId = std::move(dbFactionId);
+				acceptedClient.classId = std::move(dbClassId);
 				LOG_INFO(Net,
 					"[ServerApp] Spawn position chargee depuis la DB (character_key={}, name=\"{}\", gender=\"{}\", pos=({:.2f}, {:.2f}, {:.2f}))",
 					acceptedClient.persistenceCharacterKey, acceptedClient.characterName, acceptedClient.gender, dbX, dbY, dbZ);
@@ -1233,6 +1267,34 @@ namespace engine::server
 							acceptedClient.persistenceCharacterKey, acceptedClient.gender);
 					}
 				}
+			}
+		}
+
+		// R1-A — PV calculés depuis le moteur de stats (faction/classe/sexe/niveau). Placé
+		// après le merge de l'état persisté (acceptedClient.stats fait foi) ET après la
+		// résolution niveau/faction/classe (LoadSpawnFromDb ci-dessus). Le resolver clamp
+		// les PV courants persistés sur le nouveau max. Faction/classe vides (char legacy ou
+		// mode no-DB) → resolved=false → PV par défaut conservés (pas de régression).
+		if (m_statsTables)
+		{
+			const engine::server::gameplay::Sex sex =
+				(acceptedClient.gender == "female") ? engine::server::gameplay::Sex::Female
+				                                    : engine::server::gameplay::Sex::Male;
+			const engine::server::gameplay::SpawnHealth sh = engine::server::gameplay::ResolveSpawnHealth(
+				*m_statsTables, acceptedClient.factionId, acceptedClient.classId,
+				sex, acceptedClient.level, acceptedClient.stats.currentHealth);
+			if (sh.resolved)
+			{
+				acceptedClient.stats.maxHealth = sh.maxHealth;
+				acceptedClient.stats.currentHealth = sh.currentHealth;
+				LOG_INFO(Net,
+					"[ServerApp] R1-A enter-world stats (client_id={}, faction={}, class={}, level={}) -> maxHealth={}, currentHealth={}",
+					acceptedClient.clientId,
+					acceptedClient.factionId,
+					acceptedClient.classId,
+					acceptedClient.level,
+					sh.maxHealth,
+					sh.currentHealth);
 			}
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1048,7 +1048,8 @@ namespace engine::server
 		{
 			m_statsTablesLoadAttempted = true;
 			m_statsTables = engine::server::gameplay::CharacterStatsTables::FromEmbedded(
-				kCharacterStatsJson, kFactionsJson);
+				engine::server::gameplay::kCharacterStatsJson,
+				engine::server::gameplay::kFactionsJson);
 			if (!m_statsTables)
 			{
 				LOG_WARN(Net,

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -619,6 +619,12 @@ namespace engine::server
 		/// Send a welcome packet to the given connected client.
 		bool SendWelcome(const ConnectedClient& client);
 
+		/// R1-B — pousse les stats dérivées complètes (PLAYER_STATS) au client à
+		/// l'enter-world. Recalcule depuis le moteur (faction/classe/sexe/niveau).
+		/// Retourne false si tables absentes, char legacy (faction/classe vides) ou
+		/// calcul/envoi échoué — non fatal pour le handshake (log seulement).
+		bool SendPlayerStats(const ConnectedClient& client);
+
 		/// Send one empty snapshot packet to the given connected client.
 		bool SendSnapshot(const ConnectedClient& client);
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -2,6 +2,8 @@
 
 #include "src/shardd/gameplay/auction/AuctionHouse.h"
 #include "src/shardd/gameplay/character/CharacterPersistence.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shardd/gameplay/character/SpawnStatsResolver.h"
 #include "src/shardd/gameplay/crafting/CraftingSystem.h"
 #include "src/shardd/gameplay/economy/CurrencyConfig.h"
 #include "src/shardd/gameplay/gathering/GatheringSystem.h"
@@ -32,6 +34,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <span>
 #include <string_view>
@@ -110,6 +113,12 @@ namespace engine::server
 		/// AdmittedCharacterRegistry::AdmittedGender. Recopié dans chaque SnapshotEntity
 		/// pour permettre au client de sélectionner le mesh skinné des avatars distants.
 		std::string gender;
+		/// R1-A — faction et classe du personnage (table characters.faction/class, chargées au
+		/// Hello via LoadSpawnFromDb). Alimentent le moteur de stats (ResolveSpawnHealth) pour
+		/// calculer les PV max à l'enter-world. Vides si char legacy / mode no-DB → le resolver
+		/// renvoie resolved=false et les PV par défaut (kDefaultPlayerHealth) sont conservés.
+		std::string factionId;
+		std::string classId;
 		uint32_t experiencePoints = 0;
 		/// Compte propriétaire (résolu au Hello via AdmittedCharacterRegistry). Clé de la
 		/// présence unifiée (ShardPresenceService) ; 0 si non résolu (registre absent).
@@ -326,8 +335,11 @@ namespace engine::server
 		/// `name` pour le porter dans le SnapshotEntity (plaque de nom des avatars distants).
 		/// Renvoie false si pas de pool DB (Windows / DB non configurée) ou si character
 		/// introuvable ; dans ce cas les out-params ne sont pas modifiés.
+		/// R1-A — récupère aussi `faction` et `class` (out-params) pour alimenter le moteur de
+		/// stats (PV à l'enter-world). Vides si la colonne est NULL/absente.
 		bool LoadSpawnFromDb(uint64_t characterId, float& x, float& y, float& z, float& yawDeg,
-		std::string& outName, std::string& outGender, uint32_t& outLevel);
+		std::string& outName, std::string& outGender, uint32_t& outLevel,
+		std::string& outFactionId, std::string& outClassId);
 
 		/// Accept a new client or refresh an existing handshake.
 		/// Phase 3.7.5 — \p helloNonce élargi à uint64 (character_id complet).
@@ -825,6 +837,13 @@ namespace engine::server
 
 		engine::core::Config m_config;
 		CharacterPersistenceStore m_characterPersistence;
+		/// R1-A — tables de stats du personnage (JSON embarqué), chargées une seule fois
+		/// (lazy, au 1er HandleHello) via CharacterStatsTables::FromEmbedded. nullopt si le
+		/// JSON est invalide → les PV par défaut sont conservés (pas de régression).
+		std::optional<engine::server::gameplay::CharacterStatsTables> m_statsTables;
+		/// R1-A — passe à true une fois la tentative de chargement de m_statsTables effectuée
+		/// (évite de réessayer + de logguer l'avertissement à chaque Hello si elle échoue).
+		bool m_statsTablesLoadAttempted = false;
 		AuctionHouseService m_auctionHouse;
 		/// M35.1 — currency definitions + validation caps (config/currencies.json).
 		CurrencyConfig m_currencyConfig{};


### PR DESCRIPTION
## Système de Personnages — R1-B : feuille de personnage (11 stats)

Pousse au client local **toutes** les stats dérivées et les affiche dans un panneau « Personnage ».
**PR stackée sur R1-A (#863)** — à merger **après** #863. Plan : `docs/superpowers/plans/2026-06-08-character-system-r1b-stats-sheet.md`

### Contenu
- **Wire** : nouveau `MessageKind::PlayerStats` (=79) + `PlayerStatsMessage` (encode/decode + test round-trip). **Rétro-additif** : `kProtocolVersion` reste **8** ; les vieux clients ignorent l'opcode (branche `default`).
- **Shard** : `SendPlayerStats` calcule les `DerivedStats` complètes (réutilise `m_statsTables` + faction/classe de R1-A) et les pousse au client **à l'enter-world** (fire-and-forget après `SendWelcome`).
- **Client** : `UIPlayerStats` étendu + `ApplyPlayerStats` (décodage → modèle).
- **UI** : panneau ImGui « Personnage » (PV max, ressource, endurance, dégâts, précision, portée, crit %, mult crit, vitesses, perception, discrétion) ; mêlée pure → portée/précision « — ». **Toggle = touche X** (C déjà pris par « punch »).

### Réserves (à valider en jeu)
- ⚠️ **UI non vérifiée visuellement** (pas de build local) — additions minimales pattern-matched.
- **Toggle X** (pas C) : C est le keybind « punch ». Modifiable si tu préfères déplacer punch.
- Libellé de ressource = clé brute capitalisée (pas d'accès l10n dans la couche HUD gameplay).
- Le glyphe « — » (em-dash) dans la police HUD n'est pas garanti.

### Portée
- Stats poussées **à l'enter-world** uniquement (le level-up runtime serveur n'existe pas encore — re-push au level-up = futur).

### Déploiement
⚠️ **Redéploiement shard + client** pour bénéficier de la feuille. **Rétro-compatible** (nouveau type de message ignoré par anciens clients → pas de lock-step strict ; le bénéfice apparaît quand shard ET client sont neufs). Aucun changement master. À déployer après R1-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
