### PR TITLE
feat(client): barre ressource secondaire (HUD) + toggle feuille sur C

### DIFF
--- a/config.json
+++ b/config.json
@@ -124,7 +124,7 @@
             "crouch": "Ctrl",
             "cast": "R",
             "interact": "E",
-            "punch": "C",
+            "punch": "X",
             "attack": ""
         }
     },

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7699,18 +7699,17 @@ namespace engine
 				m_lootRollVisible = !m_lootRollVisible;
 				LOG_INFO(Core, "[Engine] L toggle loot roll (visible={})", m_lootRollVisible);
 			}
-			// R1-B (Task 4) — Touche X : toggle la feuille de personnage (stats
-			// derivees). Pas de fetch a l'ouverture : playerStats est deja peuple
-			// dans le modele UI a l'enter-world. La touche C (mnemonique naturel)
-			// est deja prise par l'action "punch" (controls.keybind.punch), et le
-			// jeu de touches plateforme n'expose pas K/J ; X est libre. Memes
-			// guards que les autres toggles (chat focus, pause, editor, auth flow).
+			// R1-B (Task 4) — Touche C (mnemonique naturel « Character ») : toggle la
+			// feuille de personnage (stats derivees). Pas de fetch a l'ouverture :
+			// playerStats est deja peuple dans le modele UI a l'enter-world. L'action
+			// "punch" (controls.keybind.punch) a ete deplacee sur X pour liberer C.
+			// Memes guards que les autres toggles (chat focus, pause, editor, auth flow).
 			if (inGameNoMenu && !chatBlocks
 				&& !m_input.IsDown(engine::platform::Key::Control)
-				&& m_input.WasPressed(engine::platform::Key::X))
+				&& m_input.WasPressed(engine::platform::Key::C))
 			{
 				m_characterSheetVisible = !m_characterSheetVisible;
-				LOG_INFO(Core, "[Engine] X toggle character sheet (visible={})", m_characterSheetVisible);
+				LOG_INFO(Core, "[Engine] C toggle character sheet (visible={})", m_characterSheetVisible);
 			}
 		}
 
@@ -8986,7 +8985,7 @@ namespace engine
 				const engine::platform::Key interactKey =
 					KeyFromName(m_cfg.GetString("controls.keybind.interact", "E"), engine::platform::Key::E);
 				const engine::platform::Key punchKey =
-					KeyFromName(m_cfg.GetString("controls.keybind.punch", "C"), engine::platform::Key::C);
+					KeyFromName(m_cfg.GetString("controls.keybind.punch", "X"), engine::platform::Key::X);
 				// Vue 3eme personne : controleur orbital pur (camera derriere la
 				// cible). Souris libre par defaut ; clic droit maintenu = rotate
 				// camera autour de la cible (yaw/pitch) ; molette = zoom.
@@ -9126,7 +9125,7 @@ namespace engine
 					const bool interactPressed =
 						m_input.WasPressed(interactKey);
 
-					// Coup de poing : 2e attaque melee, touche remappable (controls.keybind.punch, def. C).
+					// Coup de poing : 2e attaque melee, touche remappable (controls.keybind.punch, def. X).
 					const bool punchPressed =
 						m_input.WasPressed(punchKey) && !m_dialogueActive;
 
@@ -10654,7 +10653,7 @@ namespace engine
 										+ "      \"crouch\": \"" + m_cfg.GetString("controls.keybind.crouch", "Ctrl") + "\",\n"
 										+ "      \"cast\": \"" + m_cfg.GetString("controls.keybind.cast", "R") + "\",\n"
 										+ "      \"interact\": \"" + m_cfg.GetString("controls.keybind.interact", "E") + "\",\n"
-										+ "      \"punch\": \"" + m_cfg.GetString("controls.keybind.punch", "C") + "\"\n"
+										+ "      \"punch\": \"" + m_cfg.GetString("controls.keybind.punch", "X") + "\"\n"
 										+ "    }\n  }\n}\n";
 									if (!engine::platform::FileSystem::WriteAllText("keybinds.json", kb))
 										LOG_WARN(Core, "[Options] keybinds.json non ecrit (rebind non persiste)");
@@ -10683,7 +10682,7 @@ namespace engine
 				rebindRow("Accroupi", "controls.keybind.crouch", "Ctrl", 2);
 				rebindRow("Sort", "controls.keybind.cast", "R", 3);
 				rebindRow("Interagir", "controls.keybind.interact", "E", 4);
-				rebindRow("Coup de poing", "controls.keybind.punch", "C", 5);
+				rebindRow("Coup de poing", "controls.keybind.punch", "X", 5);
 				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
 				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
 				if (!m_keybindWarning.empty())

--- a/src/client/combat/CombatHud.cpp
+++ b/src/client/combat/CombatHud.cpp
@@ -3,6 +3,7 @@
 #include "src/shared/core/Log.h"
 
 #include <algorithm>
+#include <cctype>
 #include <string>
 #include <utility>
 
@@ -11,6 +12,22 @@ namespace engine::client
 	namespace
 	{
 		inline constexpr float kAutoAttackCooldownSeconds = 0.5f;
+
+		/// Formate une clef de ressource snake_case en libellé lisible « Titre » :
+		/// remplace les '_' par des espaces et met la 1re lettre en majuscule
+		/// (ex. "magie_base" -> "Magie base"). Clef vide -> "Ressource".
+		std::string FormatResourceLabel(const std::string& key)
+		{
+			if (key.empty())
+			{
+				return "Ressource";
+			}
+
+			std::string label = key;
+			std::replace(label.begin(), label.end(), '_', ' ');
+			label[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(label[0])));
+			return label;
+		}
 
 		/// Build one short combat log label from a retained combat entry.
 		std::string BuildCombatLogText(const UICombatLogEntry& entry)
@@ -214,10 +231,26 @@ namespace engine::client
 		m_state.playerHealthBar.maxValue = model.playerStats.maxHealth;
 		m_state.playerHealthBar.visible = model.playerStats.hasSnapshot;
 
-		m_state.playerManaBar.label = model.playerStats.hasMana ? "Mana" : "Mana (N/A)";
-		m_state.playerManaBar.currentValue = model.playerStats.hasMana ? model.playerStats.currentMana : 0u;
-		m_state.playerManaBar.maxValue = model.playerStats.hasMana ? model.playerStats.maxMana : 0u;
-		m_state.playerManaBar.visible = model.playerStats.hasSnapshot;
+		// La barre « mana » est conceptuellement la barre de ressource secondaire.
+		// R1-B : quand la feuille de perso est presente (PlayerStats a l'enter-world),
+		// on alimente la barre depuis les stats calculees (secondaryResourceMax/Key)
+		// plutot que depuis le snapshot mana (non peuple par le systeme de stats).
+		// Pas de systeme de consommation de ressource a l'execution pour l'instant :
+		// on affiche donc current = max (barre pleine) jusqu'a ce qu'il existe.
+		if (model.playerStats.hasSheet)
+		{
+			m_state.playerManaBar.label = FormatResourceLabel(model.playerStats.secondaryResourceKey);
+			m_state.playerManaBar.maxValue = model.playerStats.secondaryResourceMax;
+			m_state.playerManaBar.currentValue = model.playerStats.secondaryResourceMax;
+			m_state.playerManaBar.visible = true;
+		}
+		else
+		{
+			m_state.playerManaBar.label = model.playerStats.hasMana ? "Mana" : "Mana (N/A)";
+			m_state.playerManaBar.currentValue = model.playerStats.hasMana ? model.playerStats.currentMana : 0u;
+			m_state.playerManaBar.maxValue = model.playerStats.hasMana ? model.playerStats.maxMana : 0u;
+			m_state.playerManaBar.visible = model.playerStats.hasSnapshot;
+		}
 
 		m_state.playerHasCombo = model.playerStats.hasCombo;
 		m_state.playerComboPoints = model.playerStats.hasCombo ? model.playerStats.comboPoints : 0u;


### PR DESCRIPTION
Items 1 et 3 de la suite Système de Personnages.

- **Barre de ressource secondaire** dans le HUD principal : alimentée par les stats calculées (PlayerStats / R1-B) — max depuis secondaryResourceMax, label lisible, current=max (pas de consommation runtime encore). Legacy préservé si pas de feuille.
- **Toggle feuille de perso sur C** (au lieu de X) ; punch déplacé sur X. Aligné sur default_keybindings.json (open_character=C). Anti-collision vérifié.

Client uniquement.

**Déploiement** : client uniquement, pas de serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)