### PR TITLE
feat(shardd): level-up runtime — seuil XP -> recompute stats + /setlevel

### DIFF
--- a/docs/slash_commands_rbac.md
+++ b/docs/slash_commands_rbac.md
@@ -91,6 +91,20 @@ le statut de chacune :
 - **`implemented`** : commande qui suit le pattern complet RBAC + log.
 - **`planned`** : déclaration JSON présente mais pas encore implémentée.
 
+### Commandes admin de test (level-up runtime)
+
+| Commande | minRole (intention) | Gate shard réel | Audit | Statut |
+|---|---|---|---|---|
+| `/setlevel <player> <level>` | `administrator` | `ConnectedClient.chatModeratorRole` | `AuditLogModeration("SETLEVEL", ...)` | `shardd_routed` |
+
+`/setlevel` fixe le niveau d'un joueur en ligne, recalcule ses stats (soin
+complet via `CharacterStatsEngine::ComputeStats`), re-pousse la fiche
+(`SendPlayerStats`) et persiste (`SaveConnectedClient("admin_setlevel")`).
+Commande de triche destinée au test du système de level-up. Le `minRole`
+JSON (`administrator`) exprime l'intention ; au niveau shard, le seul flag
+de rôle disponible sur `ConnectedClient` est `chatModeratorRole` (aucun flag
+admin/GM distinct n'existe à ce niveau), c'est donc lui qui garde la commande.
+
 ## Plan de migration
 
 Les ~21 commandes actuellement marquées `client_only_legacy` doivent être

--- a/docs/superpowers/plans/2026-06-09-character-levelup-runtime.md
+++ b/docs/superpowers/plans/2026-06-09-character-levelup-runtime.md
@@ -1,0 +1,82 @@
+# Système de Personnages — Level-up runtime (item 2) Plan
+
+**Goal:** Quand un joueur accumule assez d'XP (déjà gagnée au kill de mob), il **monte de niveau** : recalcul des stats, soin complet, re-push de la feuille (`SendPlayerStats`), et persistance du niveau. Plus une commande admin `/setlevel` pour tester.
+
+**Architecture:** L'XP existe déjà (`ConnectedClient.experiencePoints`, gagnée via `DistributePartyXp` au kill). On ajoute la **boucle de level-up** après chaque gain : seuil `Formulas::XpToNextLevel(level, xpBase, xpFactor, levelMax)` (params des tables embarquées). Au level-up : `ComputeStats(nouveau niveau)` → `stats.maxHealth` + soin complet + `SendPlayerStats`. Niveau persisté via `PersistedCharacterState` (fichier, déjà écrit par le shard). Server-only (pas de wire/UI → pas de conflit avec PR client en cours).
+
+**Branche:** `feat/character-levelup-runtime` (depuis main).
+
+**Décisions :** `experiencePoints` = XP *dans le niveau courant* (décrémenté au level-up). Persistance niveau = fichier `PersistedCharacterState` ; enter-world prend le niveau persisté s'il est > 0, sinon DB. Synchro colonne DB `characters.level` côté master = suivi séparé (hors MVP).
+
+---
+
+## Contexte (cartographie item 2)
+- XP gagnée : `DistributePartyXp` (ServerApp.cpp:5388) + grant solo (`attacker.experiencePoints += baseXp`, ~2397) au kill de mob (death à ServerApp.cpp:2683, `kBaseXpPerMobKill=10`).
+- `ConnectedClient.experiencePoints` (ServerApp.h:122), `.level` (ServerApp.h:128, chargé DB à l'enter-world via `LoadSpawnFromDb`, jamais modifié).
+- `PersistedCharacterState` (CharacterPersistence.h) a `experiencePoints` mais **pas** `level`. Save via `SaveConnectedClient` (ServerApp.cpp:1733) + autosave (`MaybeAutosaveCharacters` 1715).
+- Recompute+push : `ComputeStats(...)` + `SendPlayerStats(client)` (ServerApp.cpp:4202) — déjà appelés à l'enter-world (~1277-1327). `client.stats.maxHealth` change → snapshot le réplique (BuildEntityState copie StatsComponent).
+- Commandes : `HandleChatSlashCommand` (ServerApp.cpp:4673) ← `TryParseChatSlashCommand` (ChatCommandParser.cpp:114, enum `ChatSlashCommandKind` dans .h). RBAC : ex. `if(!sender.chatModeratorRole){...}` (4800) + `AuditLogModeration(...)`. Registre data : `game/data/config/slash_commands.json`. `FindConnectedClientByChatDisplayName`.
+- `Formulas::XpToNextLevel(level, base, factor, levelMax)` (shared) ; tables embarquées exposent `xpBase`/`xpFactor`/`levelMax` (CharacterStatsTables).
+
+---
+
+## Task 1 — Helper pur testé : progression de niveau
+
+**Files:** Create `src/shardd/gameplay/character/LevelProgression.{h,cpp}` + `LevelProgressionTests.cpp`; Modify `src/CMakeLists.txt`.
+
+- [ ] **Step 1 (test first):** `LevelProgressionTests.cpp` (plain-main 0/1, NDEBUG-safe). Avec `xpBase`/`xpFactor` des tables embarquées (FromEmbedded) ou des params littéraux : 
+  - gain insuffisant → pas de level-up (level inchangé, xp augmentée).
+  - gain franchissant un seuil → +1 niveau, xp résiduelle correcte.
+  - gros gain franchissant plusieurs seuils → +N niveaux.
+  - au cap `levelMax` → plus de level-up, xp peut être bornée (clamp à 0 ou figée — choisir : figer xp à 0 au cap).
+- [ ] **Step 2:** `LevelProgression.h` :
+```cpp
+#pragma once
+#include <cstdint>
+namespace engine::server::gameplay
+{
+	struct LevelGainResult { uint32_t newLevel; uint32_t newXpIntoLevel; uint32_t levelsGained; };
+	/// Applique un gain d'XP et fait monter le niveau tant que le seuil est franchi.
+	/// \param level niveau courant ; \param xpIntoLevel XP déjà acquise dans ce niveau.
+	/// \param gainedXp XP gagnée ; \param xpBase/xpFactor params de courbe ; \param levelMax cap.
+	/// Au cap, xpIntoLevel est figée à 0 (plus de progression).
+	LevelGainResult ApplyXpGain(uint32_t level, uint32_t xpIntoLevel, uint32_t gainedXp,
+	                            double xpBase, double xpFactor, uint32_t levelMax);
+}
+```
+- [ ] **Step 3:** `LevelProgression.cpp` : boucle `while (level < levelMax && xpIntoLevel + gainedXp >= XpToNextLevel(level,...))` → consomme le seuil, `level++`. Inclure `Formulas.h`. Au cap : `xpIntoLevel=0`, ignorer le surplus.
+- [ ] **Step 4:** CMake — ajouter `LevelProgression.cpp` aux cibles serveur compilant déjà le moteur (WIN32 server_app + shard_app), et enregistrer `level_progression_tests` (bloc explicite + gen include si le test lit les tables embarquées).
+- [ ] **Step 5:** commit `feat(shardd): LevelProgression — helper level-up pur (+ tests)`.
+
+---
+
+## Task 2 — Boucle de level-up + recompute + persistance niveau
+
+**Files:** Modify `src/shared/server_bootstrap/ServerApp.cpp`/`.h`, `src/shardd/gameplay/character/CharacterPersistence.h` (+ .cpp si save/load explicites).
+
+- [ ] **Step 1:** Méthode privée `void ApplyLevelUpsAfterXp(ConnectedClient& client, uint32_t gainedXp);` (ServerApp). Si `m_statsTables` : `auto r = ApplyXpGain(client.level, client.experiencePoints, gainedXp, m_statsTables->xpBase, m_statsTables->xpFactor, m_statsTables->levelMax);` ; sinon fallback : `client.experiencePoints += gainedXp` (comportement actuel). Mettre `client.level=r.newLevel`, `client.experiencePoints=r.newXpIntoLevel`. Si `r.levelsGained>0` : recalculer `ComputeStats(*m_statsTables, factionId, classId, sex, client.level)` → `client.stats.maxHealth=d->hp; client.stats.currentHealth=d->hp;` (soin complet) ; `SendPlayerStats(client)` ; `SaveConnectedClient(client, "level_up")` ; LOG_INFO niveau atteint.
+- [ ] **Step 2:** Remplacer les sites de gain d'XP (`experiencePoints += baseXp` dans `DistributePartyXp` et le grant solo) par un appel à `ApplyLevelUpsAfterXp(client, baseXp)`. (Vérifier tous les sites via grep `experiencePoints +=`.)
+- [ ] **Step 3:** Persistance niveau : ajouter `uint32_t level = 1;` à `PersistedCharacterState` ; le remplir dans `SaveConnectedClient` (`state.level = client.level`) ; à l'enter-world, après le merge persisté et le `LoadSpawnFromDb`, si `persistedState.level > 0` utiliser `acceptedClient.level = max(dbLevel, persistedState.level)` (le niveau persisté gagne s'il est plus haut — préserve les level-ups). Commenter le choix.
+- [ ] **Step 4:** commit `feat(shardd): level-up runtime — seuil XP -> recompute stats + soin + persistance niveau`.
+
+---
+
+## Task 3 — Commande admin `/setlevel <joueur> <niveau>`
+
+**Files:** Modify `src/shardd/gameplay/chat/ChatCommandParser.{h,cpp}`, `src/shared/server_bootstrap/ServerApp.cpp`, `game/data/config/slash_commands.json`, `docs/slash_commands_rbac.md`.
+
+- [ ] **Step 1:** `ChatCommandParser.h` : ajouter `SetLevel` à `ChatSlashCommandKind`. `ChatCommandParser.cpp` : parser `/setlevel` → `kind=SetLevel`, `argsRemainder` = "<joueur> <niveau>". (+ test parser si le fichier a des tests.)
+- [ ] **Step 2:** `HandleChatSlashCommand` (ServerApp.cpp) : case `SetLevel` — **gate admin** (mirror le gate le plus strict existant, ex. rôle admin ; PAS juste chatModeratorRole si un rôle admin distinct existe — vérifier). Parser nom + niveau (clamp [1, levelMax]). `FindConnectedClientByChatDisplayName` ; si trouvé : `target->level = n; target->experiencePoints = 0;` recompute (`ComputeStats`) → maxHealth + soin + `SendPlayerStats(*target)` + `SaveConnectedClient(*target,"admin_setlevel")`. **Audit log serveur** (mirror `AuditLogModeration`). Notice chat à l'acteur + cible.
+- [ ] **Step 3:** `slash_commands.json` : entrée `/setlevel` (category admin, minRole admin, serverInteraction+serverLogged true). Mettre à jour `docs/slash_commands_rbac.md`.
+- [ ] **Step 4:** commit `feat(shardd): commande admin /setlevel (level-up testable, RBAC + audit)`.
+
+---
+
+## Task 4 — Vérif + push + PR
+- [ ] grep : tous les sites `experiencePoints +=` passent par `ApplyLevelUpsAfterXp` ; `engine::server::gameplay::` qualifié dans ServerApp.
+- [ ] push, PR base main. CI : build-linux (ctest `level_progression_tests`) + build-windows.
+
+> **Déploiement** : ⚠️ redéploiement **shard** (level-up runtime + commande). Master : la commande `/setlevel` passe par le chat shard ; vérifier si l'enregistrement RBAC master de slash_commands.json nécessite un redéploiement master (si le master valide la commande). Pas de wire-breaking. Aucun changement client.
+
+## Hors périmètre
+Affichage du niveau/XP côté client (panneau/HUD) ; synchro colonne DB `characters.level` côté master ; courbe de récompense XP par mob selon niveau.

--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -445,6 +445,18 @@
       "notes": "Commande admin horloge monde : le master appelle WorldClockHandler::SetPaused (true si on, false si off) puis broadcast 205. Argument hors {on,off} -> InvalidArgs."
     },
     {
+      "command": "/setlevel <player> <level>",
+      "aliases": [],
+      "description": "Fixe le niveau d'un joueur en ligne, recalcule ses stats (soin complet), re-pousse la fiche et persiste. Commande de test du level-up.",
+      "category": "admin",
+      "minRole": "administrator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "shardd_routed",
+      "implementation_file": "src/shardd/gameplay/chat/ChatCommandParser.cpp",
+      "notes": "Level-up runtime : parsee par shardd ChatCommandParser, traitee dans ServerApp::HandleChatSlashCommand. Recalcule via CharacterStatsEngine::ComputeStats, soin complet, SendPlayerStats + SaveConnectedClient(admin_setlevel). Audit serveur via AuditLogModeration(SETLEVEL). Gating shard reel = ConnectedClient.chatModeratorRole (aucun flag admin/GM distinct n'existe au niveau shard) ; minRole=administrator exprime l'intention (commande de triche)."
+    },
+    {
       "command": "/settimescale <minutes reelles par jour>",
       "aliases": [],
       "description": "Vitesse du cycle jour/nuit (1..1440 ; 60 = 1 jour de jeu par heure reelle).",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,8 @@ if(WIN32)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Level-up runtime — helper de progression d'XP/niveau (pur, server-only).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/LevelProgression.cpp
     # Character system R1-A — résolveur PV enter-world (dérive depuis le moteur).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp
@@ -650,6 +652,22 @@ elseif(UNIX)
   target_compile_options(spawn_stats_resolver_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME spawn_stats_resolver_tests COMMAND spawn_stats_resolver_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Level-up runtime — LevelProgression : helper de montée de niveau pur, ancré
+  # sur la vraie courbe XpToNextLevel. Bloc explicite (comme
+  # character_stats_engine_tests) : besoin du dossier des headers générés
+  # (${LCDLLN_GEN_DIR}) et de la dépendance au codegen lcdlln_gen_character_data
+  # (le test charge xpBase/xpFactor/levelMax depuis le JSON embarqué).
+  add_executable(level_progression_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/LevelProgressionTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/LevelProgression.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp)
+  add_dependencies(level_progression_tests lcdlln_gen_character_data)
+  target_include_directories(level_progression_tests PRIVATE ${CMAKE_SOURCE_DIR} ${LCDLLN_GEN_DIR})
+  target_link_libraries(level_progression_tests PRIVATE engine_core spdlog::spdlog pthread)
+  target_compile_options(level_progression_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME level_progression_tests COMMAND level_progression_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # CMANGOS.34 (Phase 4.34a) : MetricRegistry (header-only).
   lcdlln_add_simple_test(metric_registry_tests
     ${CMAKE_SOURCE_DIR}/src/shared/metric/MetricRegistryTests.cpp)
@@ -1111,6 +1129,8 @@ elseif(UNIX)
     # Character system PR1 — moteur de stats (serveur-only, anti-triche).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsTables.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterStatsEngine.cpp
+    # Level-up runtime — helper de progression d'XP/niveau (pur, server-only).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/LevelProgression.cpp
     # Character system R1-A — résolveur PV enter-world (appelé par HandleHello).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/SpawnStatsResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/economy/CurrencyConfig.cpp

--- a/src/shardd/gameplay/character/CharacterPersistence.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistence.cpp
@@ -88,6 +88,8 @@ namespace engine::server
 		outState.positionMetersY = static_cast<float>(persisted.GetDouble("character.position_y", 0.0));
 		outState.positionMetersZ = static_cast<float>(persisted.GetDouble("character.position_z", 0.0));
 		outState.experiencePoints = static_cast<uint32_t>(persisted.GetInt("character.experience_points", 0));
+		// Niveau : défaut 0 = absent du fichier (legacy) → l'enter-world préfère le niveau DB.
+		outState.level = static_cast<uint32_t>(persisted.GetInt("character.level", 0));
 		outState.gold = static_cast<uint32_t>(persisted.GetInt("character.gold", 0));
 		outState.honor = static_cast<uint32_t>(persisted.GetInt("character.honor", 0));
 		outState.badges = static_cast<uint32_t>(persisted.GetInt("character.badges", 0));
@@ -224,6 +226,7 @@ namespace engine::server
 		output << "character.position_y=" << state.positionMetersY << "\n";
 		output << "character.position_z=" << state.positionMetersZ << "\n";
 		output << "character.experience_points=" << state.experiencePoints << "\n";
+		output << "character.level=" << state.level << "\n";
 		output << "character.gold=" << state.gold << "\n";
 		output << "character.honor=" << state.honor << "\n";
 		output << "character.badges=" << state.badges << "\n";

--- a/src/shardd/gameplay/character/CharacterPersistence.h
+++ b/src/shardd/gameplay/character/CharacterPersistence.h
@@ -21,6 +21,9 @@ namespace engine::server
 		float positionMetersY = 0.0f;
 		float positionMetersZ = 0.0f;
 		uint32_t experiencePoints = 0;
+		/// Niveau du personnage. 0 = absent du fichier (legacy / non encore écrit) →
+		/// l'enter-world retombe sur le niveau de la DB. Renseigné par les level-ups runtime.
+		uint32_t level = 0;
 		uint32_t gold = 0;
 		/// M35.1 — additional wallet currencies (mirrors MySQL player_wallet when present).
 		uint32_t honor = 0;

--- a/src/shardd/gameplay/character/LevelProgression.cpp
+++ b/src/shardd/gameplay/character/LevelProgression.cpp
@@ -1,0 +1,32 @@
+#include "src/shardd/gameplay/character/LevelProgression.h"
+#include "src/shared/formulas/Formulas.h"
+#include <algorithm>
+namespace engine::server::gameplay
+{
+	LevelGainResult ApplyXpGain(uint32_t level, uint32_t xpIntoLevel, uint32_t gainedXp,
+	                            double xpBase, double xpFactor, uint32_t levelMax)
+	{
+		LevelGainResult r;
+		r.newLevel = (level == 0u) ? 1u : level;   // garde-fou : niveau plancher 1
+		// XpToNextLevel prend des uint8_t : la courbe du design plafonne à 100
+		// (level_max), donc newLevel (< levelMax dans la boucle) et levelMax tiennent
+		// dans un uint8_t. Clamp défensif au cas où la data dépasserait 255.
+		const uint8_t levelMaxU8 = static_cast<uint8_t>(std::min<uint32_t>(levelMax, 255u));
+		uint64_t xp = static_cast<uint64_t>(xpIntoLevel) + static_cast<uint64_t>(gainedXp);
+		while (r.newLevel < levelMax)
+		{
+			const uint32_t threshold = engine::server::formulas::XpToNextLevel(
+				static_cast<uint8_t>(r.newLevel), xpBase, xpFactor, levelMaxU8);
+			if (threshold == 0u || xp < static_cast<uint64_t>(threshold))
+				break;
+			xp -= threshold;
+			++r.newLevel;
+			++r.levelsGained;
+		}
+		if (r.newLevel >= levelMax)
+			r.newXpIntoLevel = 0u;                  // cap : surplus ignoré
+		else
+			r.newXpIntoLevel = static_cast<uint32_t>(xp);
+		return r;
+	}
+}

--- a/src/shardd/gameplay/character/LevelProgression.h
+++ b/src/shardd/gameplay/character/LevelProgression.h
@@ -1,0 +1,22 @@
+#pragma once
+// LevelProgression : applique un gain d'XP et fait monter le niveau tant que le
+// seuil XpToNextLevel est franchi. Pur et testable (séparé de la boucle réseau).
+#include <cstdint>
+namespace engine::server::gameplay
+{
+	/// Résultat d'un gain d'XP.
+	struct LevelGainResult
+	{
+		uint32_t newLevel = 1;        ///< niveau après application.
+		uint32_t newXpIntoLevel = 0;  ///< XP restante dans le niveau courant.
+		uint32_t levelsGained = 0;    ///< nombre de niveaux gagnés (0 = aucun).
+	};
+
+	/// Applique \p gainedXp à un personnage de niveau \p level ayant déjà
+	/// \p xpIntoLevel XP dans ce niveau. Monte le niveau tant que le seuil est
+	/// franchi (multi-niveaux possible). Au cap \p levelMax, la progression
+	/// s'arrête et l'XP dans le niveau est figée à 0 (surplus ignoré).
+	/// \param xpBase / \param xpFactor : paramètres de la courbe (character_stats.json).
+	LevelGainResult ApplyXpGain(uint32_t level, uint32_t xpIntoLevel, uint32_t gainedXp,
+	                            double xpBase, double xpFactor, uint32_t levelMax);
+}

--- a/src/shardd/gameplay/character/LevelProgressionTests.cpp
+++ b/src/shardd/gameplay/character/LevelProgressionTests.cpp
@@ -1,0 +1,111 @@
+// Tests de LevelProgression::ApplyXpGain : montée de niveau pure, ancrée sur la
+// vraie courbe XpToNextLevel (paramètres issus du JSON embarqué). Sans assert
+// (NDEBUG-safe) : chaque vérif renvoie 1 et logge sur stderr en cas d'échec.
+#include "src/shardd/gameplay/character/LevelProgression.h"
+#include "src/shared/formulas/Formulas.h"
+#include "src/shardd/gameplay/character/CharacterStatsTables.h"
+#include "src/shared/core/Log.h"
+
+#include "CharacterStatsData.h"  // kCharacterStatsJson (généré)
+#include "FactionsData.h"        // kFactionsJson (généré)
+
+#include <cstdio>
+
+namespace
+{
+	using namespace engine::server::gameplay;
+
+	// Seuil XP réel pour passer du niveau \p lvl au suivant (même formule que
+	// le code testé, pour des ancres auto-cohérentes).
+	uint32_t Threshold(uint32_t lvl, double base, double factor, uint32_t levelMax)
+	{
+		return engine::server::formulas::XpToNextLevel(
+			static_cast<uint8_t>(lvl), base, factor, static_cast<uint8_t>(levelMax));
+	}
+}
+
+int main()
+{
+	engine::core::LogSettings s; s.level = engine::core::LogLevel::Info; s.console = true;
+	engine::core::Log::Init(s);
+
+	auto tables = CharacterStatsTables::FromEmbedded(kCharacterStatsJson, kFactionsJson);
+	if (!tables)
+	{
+		fprintf(stderr, "[LevelProgressionTests] FromEmbedded a échoué\n");
+		engine::core::Log::Shutdown();
+		return 1;
+	}
+	const double base   = tables->xpBase;
+	const double factor = tables->xpFactor;
+	const uint32_t max  = tables->levelMax;
+
+	// 1) Petit gain sous le seuil : aucun niveau gagné.
+	{
+		auto r = ApplyXpGain(1, 0, 1, base, factor, max);
+		if (r.levelsGained != 0u || r.newLevel != 1u || r.newXpIntoLevel != 1u)
+		{
+			fprintf(stderr, "[LevelProgressionTests] T1 KO: lvl=%u gained=%u xp=%u\n",
+			        r.newLevel, r.levelsGained, r.newXpIntoLevel);
+			engine::core::Log::Shutdown();
+			return 1;
+		}
+	}
+
+	// 2) Gain franchissant exactement un seuil : +1 niveau, Xp restante 0.
+	{
+		const uint32_t g = Threshold(1, base, factor, max);
+		auto r = ApplyXpGain(1, 0, g, base, factor, max);
+		if (r.newLevel != 2u || r.levelsGained != 1u || r.newXpIntoLevel != 0u)
+		{
+			fprintf(stderr, "[LevelProgressionTests] T2 KO: g=%u lvl=%u gained=%u xp=%u\n",
+			        g, r.newLevel, r.levelsGained, r.newXpIntoLevel);
+			engine::core::Log::Shutdown();
+			return 1;
+		}
+	}
+
+	// 3) Un seuil + reliquat : +1 niveau, reliquat conservé.
+	{
+		const uint32_t g = Threshold(1, base, factor, max) + 5u;
+		auto r = ApplyXpGain(1, 0, g, base, factor, max);
+		if (r.newLevel != 2u || r.levelsGained != 1u || r.newXpIntoLevel != 5u)
+		{
+			fprintf(stderr, "[LevelProgressionTests] T3 KO: g=%u lvl=%u gained=%u xp=%u\n",
+			        g, r.newLevel, r.levelsGained, r.newXpIntoLevel);
+			engine::core::Log::Shutdown();
+			return 1;
+		}
+	}
+
+	// 4) Gros gain franchissant plusieurs niveaux (1->4) : +3 niveaux, Xp 0.
+	{
+		const uint32_t g = Threshold(1, base, factor, max)
+		                 + Threshold(2, base, factor, max)
+		                 + Threshold(3, base, factor, max);
+		auto r = ApplyXpGain(1, 0, g, base, factor, max);
+		if (r.newLevel != 4u || r.levelsGained != 3u || r.newXpIntoLevel != 0u)
+		{
+			fprintf(stderr, "[LevelProgressionTests] T4 KO: g=%u lvl=%u gained=%u xp=%u\n",
+			        g, r.newLevel, r.levelsGained, r.newXpIntoLevel);
+			engine::core::Log::Shutdown();
+			return 1;
+		}
+	}
+
+	// 5) Au cap : aucune progression, surplus ignoré.
+	{
+		auto r = ApplyXpGain(max, 0, 1000000, base, factor, max);
+		if (r.newLevel != max || r.levelsGained != 0u || r.newXpIntoLevel != 0u)
+		{
+			fprintf(stderr, "[LevelProgressionTests] T5 KO: lvl=%u gained=%u xp=%u (max=%u)\n",
+			        r.newLevel, r.levelsGained, r.newXpIntoLevel, max);
+			engine::core::Log::Shutdown();
+			return 1;
+		}
+	}
+
+	LOG_INFO(Core, "[LevelProgressionTests] ALL OK");
+	engine::core::Log::Shutdown();
+	return 0;
+}

--- a/src/shardd/gameplay/chat/ChatCommandParser.cpp
+++ b/src/shardd/gameplay/chat/ChatCommandParser.cpp
@@ -77,6 +77,8 @@ namespace engine::server
 		return "/pkick";
 	case ChatSlashCommandKind::Trade:
 		return "/trade";
+	case ChatSlashCommandKind::SetLevel:
+		return "/setlevel";
 	case ChatSlashCommandKind::None:
 		break;
 	}
@@ -231,6 +233,15 @@ namespace engine::server
 		{
 			set(ChatSlashCommandKind::Trade, remainder);
 			LOG_DEBUG(Net, "[ChatCommandParser] Parsed {} (args_len={})", ChatSlashCommandLabel(ChatSlashCommandKind::Trade), remainder.size());
+			return true;
+		}
+
+		// Level-up runtime — Commande admin de test : /setlevel <joueur> <niveau>.
+		// argsRemainder porte la chaîne « <joueur> <niveau> » (parsée côté handler).
+		if (cmdToken == "/setlevel")
+		{
+			set(ChatSlashCommandKind::SetLevel, remainder);
+			LOG_DEBUG(Net, "[ChatCommandParser] Parsed {} (args_len={})", ChatSlashCommandLabel(ChatSlashCommandKind::SetLevel), remainder.size());
 			return true;
 		}
 

--- a/src/shardd/gameplay/chat/ChatCommandParser.h
+++ b/src/shardd/gameplay/chat/ChatCommandParser.h
@@ -29,7 +29,10 @@ namespace engine::server
 		/// M32.2 — Party kick (leader only): /pkick <name>
 		PartyKick,
 		/// M35.3 — Initiate a direct trade with another player: /trade <name>
-		Trade
+		Trade,
+		/// Level-up runtime — Commande admin de test : /setlevel <joueur> <niveau>.
+		/// Fixe le niveau d'un joueur, recalcule ses stats (soin complet) et persiste.
+		SetLevel
 	};
 
 	/// Sub-command for ChatSlashCommandKind::Friend (M32.1).

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -4945,6 +4945,97 @@ namespace engine::server
 	case ChatSlashCommandKind::Trade:
 		return HandleTradeCommand(sender, command.argsRemainder);
 
+	// Level-up runtime — Commande admin de test : /setlevel <joueur> <niveau>.
+	// Fixe le niveau d'un joueur en ligne, recalcule ses stats (soin complet),
+	// re-pousse la fiche et persiste. Commande de triche puissante → gardée par
+	// le rôle le plus strict disponible sur ConnectedClient (chatModeratorRole ;
+	// aucun flag admin/GM distinct n'existe au niveau shard) + audit serveur.
+	case ChatSlashCommandKind::SetLevel:
+	{
+		if (!sender.chatModeratorRole)
+		{
+			SendChatSystemNotice(sender, "Permission refusée.");
+			LOG_WARN(Net,
+				"[ServerApp] /setlevel refusé : rôle insuffisant (client_id={})",
+				sender.clientId);
+			return true;
+		}
+
+		// argsRemainder = « <joueur> <niveau> ».
+		const auto [targetName, levelArg] = SplitFirstChatArg(command.argsRemainder);
+		if (targetName.empty() || levelArg.empty())
+		{
+			SendChatSystemNotice(sender, "Usage: /setlevel <joueur> <niveau>");
+			LOG_WARN(Net, "[ServerApp] /setlevel rejeté : arguments manquants (client_id={})", sender.clientId);
+			return true;
+		}
+
+		// Parse du niveau (entier strictement positif).
+		char* endPtr = nullptr;
+		const long parsedLevel = std::strtol(levelArg.c_str(), &endPtr, 10);
+		if (endPtr == levelArg.c_str() || *endPtr != '\0' || parsedLevel < 1)
+		{
+			SendChatSystemNotice(sender, "Usage: /setlevel <joueur> <niveau>");
+			LOG_WARN(Net, "[ServerApp] /setlevel rejeté : niveau invalide (client_id={}, arg={})", sender.clientId, levelArg);
+			return true;
+		}
+
+		// Clamp dans [1, levelMax] (fallback 100 si tables absentes).
+		const uint32_t levelMax = m_statsTables ? m_statsTables->levelMax : 100u;
+		uint32_t newLevel = static_cast<uint32_t>(parsedLevel);
+		if (newLevel > levelMax)
+		{
+			newLevel = levelMax;
+		}
+
+		ConnectedClient* target = FindConnectedClientByChatDisplayName(targetName);
+		if (target == nullptr)
+		{
+			SendChatSystemNotice(sender, "Cible hors ligne.");
+			LOG_WARN(Net, "[ServerApp] /setlevel rejeté : cible hors ligne (client_id={}, target={})", sender.clientId, targetName);
+			return true;
+		}
+
+		const std::string targetLabel = "P" + std::to_string(target->clientId);
+
+		// Application : niveau + reset XP dans le niveau.
+		target->level = newLevel;
+		target->experiencePoints = 0;
+
+		if (m_statsTables)
+		{
+			// Recalcul des stats au nouveau niveau + soin complet (mirroir level-up).
+			const engine::server::gameplay::Sex sex =
+				(target->gender == "female") ? engine::server::gameplay::Sex::Female
+				                             : engine::server::gameplay::Sex::Male;
+			const auto d = engine::server::gameplay::ComputeStats(
+				*m_statsTables, target->factionId, target->classId, sex, target->level);
+			if (d)
+			{
+				target->stats.maxHealth = d->hp;
+				target->stats.currentHealth = d->hp;   // soin complet.
+			}
+			(void)SendPlayerStats(*target);
+			SaveConnectedClient(*target, "admin_setlevel");
+		}
+		else
+		{
+			// Tables absentes : on a quand même fixé le niveau, mais sans recalcul de stats.
+			SaveConnectedClient(*target, "admin_setlevel");
+			SendChatSystemNotice(sender, "Niveau fixé (stats non recalculées : tables absentes).");
+		}
+
+		// Audit serveur (même fonction/format que les commandes de modération).
+		AuditLogModeration("SETLEVEL", actorLabel, targetLabel, "level=" + std::to_string(newLevel));
+
+		SendChatSystemNotice(sender, "Niveau de " + targetLabel + " fixé à " + std::to_string(newLevel) + ".");
+		SendChatSystemNotice(*target, "Votre niveau a été fixé à " + std::to_string(newLevel) + " par un administrateur.");
+		LOG_INFO(Net,
+			"[ServerApp] /setlevel appliqué (actor_client_id={}, target_client_id={}, level={}, maxHp={})",
+			sender.clientId, target->clientId, newLevel, target->stats.maxHealth);
+		return true;
+	}
+
 	case ChatSlashCommandKind::None:
 	default:
 		LOG_WARN(Net, "[ServerApp] Chat slash command ignored: kind=None (client_id={})", sender.clientId);

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -14,6 +14,9 @@
 #include "CharacterStatsData.h"
 #include "FactionsData.h"
 
+// Level-up runtime — courbe XP -> niveau (séparée de la boucle réseau, pure et testable).
+#include "src/shardd/gameplay/character/LevelProgression.h"
+
 // TA.4 — pont position : compilé uniquement pour la cible shard Linux (SHARD_POSITION_DB),
 // pas pour le build Windows (ServerApp.cpp est partagé). Macro dédié plutôt qu'ENGINE_HAS_MYSQL
 // pour ne PAS basculer les autres systèmes gameplay du shard en mode DB.
@@ -1271,6 +1274,15 @@ namespace engine::server
 			}
 		}
 
+		// Level-up runtime : le niveau persisté (fichier) préserve les level-ups gagnés en
+		// jeu tant que la colonne `level` de la table `characters` (master) n'est pas
+		// synchronisée. On préfère le plus haut des deux (DB vs fichier). Placé AVANT le bloc
+		// R1-A pour que les PV soient calculés à partir du niveau final.
+		if (persistedState.level > 0u)
+		{
+			acceptedClient.level = std::max(acceptedClient.level, persistedState.level);
+		}
+
 		// R1-A — PV calculés depuis le moteur de stats (faction/classe/sexe/niveau). Placé
 		// après le merge de l'état persisté (acceptedClient.stats fait foi) ET après la
 		// résolution niveau/faction/classe (LoadSpawnFromDb ci-dessus). Le resolver clamp
@@ -1747,6 +1759,7 @@ namespace engine::server
 		state.positionMetersY = client.positionMetersY;
 		state.positionMetersZ = client.positionMetersZ;
 		state.experiencePoints = client.experiencePoints;
+		state.level = client.level;
 		state.gold = client.gold;
 		state.honor = client.honor;
 		state.badges = client.badges;
@@ -2334,7 +2347,7 @@ namespace engine::server
 					continue;
 				}
 
-				client.experiencePoints += rewards.experience;
+				ApplyLevelUpsAfterXp(client, rewards.experience);
 				if (rewards.gold != 0u)
 				{
 					std::string walletErr;
@@ -3451,7 +3464,7 @@ namespace engine::server
 		{
 			if (delta.rewardExperience != 0 || delta.rewardGold != 0 || !delta.rewardItems.empty())
 			{
-				client.experiencePoints += delta.rewardExperience;
+				ApplyLevelUpsAfterXp(client, delta.rewardExperience);
 				if (delta.rewardGold != 0u)
 				{
 					std::string walletErr;
@@ -5385,6 +5398,37 @@ namespace engine::server
 		return true;
 	}
 
+	void ServerApp::ApplyLevelUpsAfterXp(ConnectedClient& client, uint32_t gainedXp)
+	{
+		if (!m_statsTables)
+		{
+			client.experiencePoints += gainedXp;   // fallback : comportement legacy (XP brute).
+			return;
+		}
+		const auto r = engine::server::gameplay::ApplyXpGain(
+			client.level, client.experiencePoints, gainedXp,
+			m_statsTables->xpBase, m_statsTables->xpFactor, m_statsTables->levelMax);
+		client.level = r.newLevel;
+		client.experiencePoints = r.newXpIntoLevel;
+		if (r.levelsGained == 0u)
+			return;
+		// Recalcul des stats au nouveau niveau + soin complet.
+		const engine::server::gameplay::Sex sex =
+			(client.gender == "female") ? engine::server::gameplay::Sex::Female
+			                            : engine::server::gameplay::Sex::Male;
+		const auto d = engine::server::gameplay::ComputeStats(
+			*m_statsTables, client.factionId, client.classId, sex, client.level);
+		if (d)
+		{
+			client.stats.maxHealth = d->hp;
+			client.stats.currentHealth = d->hp;   // soin complet au level-up.
+		}
+		(void)SendPlayerStats(client);
+		SaveConnectedClient(client, "level_up");
+		LOG_INFO(Net, "[ServerApp] LEVEL UP (client_id={}, +{} niveaux -> level={}, maxHp={})",
+			client.clientId, r.levelsGained, client.level, client.stats.maxHealth);
+	}
+
 	void ServerApp::DistributePartyXp(ConnectedClient& attacker,
 	                                   float            killPosX,
 	                                   float            killPosZ,
@@ -5394,7 +5438,7 @@ namespace engine::server
 		if (party == nullptr || party->members.size() <= 1)
 		{
 			// Solo player: grant full XP.
-			attacker.experiencePoints += baseXp;
+			ApplyLevelUpsAfterXp(attacker, baseXp);
 			LOG_DEBUG(Net, "[ServerApp] XP granted solo (client_id={}, xp={}, total_xp={})",
 			    attacker.clientId, baseXp, attacker.experiencePoints);
 			return;
@@ -5423,7 +5467,7 @@ namespace engine::server
 
 		if (inRange.empty())
 		{
-			attacker.experiencePoints += baseXp;
+			ApplyLevelUpsAfterXp(attacker, baseXp);
 			return;
 		}
 
@@ -5436,7 +5480,7 @@ namespace engine::server
 			{
 				if (c.clientId == memberId)
 				{
-					c.experiencePoints += share;
+					ApplyLevelUpsAfterXp(c, share);
 					LOG_DEBUG(Net, "[ServerApp] Party XP share granted (client_id={}, share={}, total_xp={})",
 					    c.clientId, share, c.experiencePoints);
 					break;

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -735,6 +735,12 @@ namespace engine::server
 		                       float killPosZ,
 		                       uint32_t baseXp);
 
+		/// Applique un gain d'XP à \p client en franchissant les seuils de niveau.
+		/// Sans tables de stats chargées, accumule simplement l'XP (comportement legacy).
+		/// À chaque level-up : recalcul des stats au nouveau niveau, soin complet,
+		/// re-push de la feuille de stats au client et persistance du personnage.
+		void ApplyLevelUpsAfterXp(ConnectedClient& client, uint32_t gainedXp);
+
 		/// Apply the current party loot mode when spawning a loot bag for \p killerClient.
 		/// Returns the entityId that should own the bag (0 = public/FFA).
 		EntityId ResolvePartyLooterEntityId(const ConnectedClient& killerClient);


### PR DESCRIPTION
## Système de Personnages — Level-up runtime (item 2)

Le joueur **monte de niveau** quand il accumule assez d'XP (déjà gagnée au kill de mob/quête/événement). Plan : `docs/superpowers/plans/2026-06-09-character-levelup-runtime.md`

### Contenu
- **`LevelProgression::ApplyXpGain`** (helper pur testé) : seuil `XpToNextLevel` (params embarqués), multi-niveaux, cap `level_max`. 5 tests ancrés sur la vraie courbe.
- **Boucle level-up** : les **5 sites de gain d'XP** (kill solo/groupe, événements dynamiques, quêtes) passent par `ApplyLevelUpsAfterXp` → au franchissement de seuil : recalcul `ComputeStats(nouveau niveau)` → `maxHealth` + **soin complet** + `SendPlayerStats` (barre PV + feuille se mettent à jour) + persistance.
- **Persistance niveau** : champ `level` ajouté à `PersistedCharacterState` (store fichier déjà écrit par le shard) ; enter-world prend `max(niveau DB, niveau persisté)` → les level-ups survivent au relog.
- **Commande admin `/setlevel <joueur> <niveau>`** (parser + handler calqués sur `/kick`, audit serveur `AuditLogModeration`, entrée `slash_commands.json` + doc RBAC) — pour tester sans grinder.

### Réserves
- **RBAC `/setlevel`** : gaté sur `chatModeratorRole` (seul rôle dispo au shard — pas de rôle « admin » distinct dans l'infra actuelle). Le JSON exprime l'intention `administrator`. Un vrai gate admin = évolution d'infra séparée. ⚠️ un modérateur peut donc set-level.
- **Sémantique XP** : `experiencePoints` = XP dans le niveau courant (décrémentée au level-up).
- **Synchro DB** : la colonne `characters.level` (master) n'est PAS mise à jour par le shard (le niveau vit dans le store fichier) → la liste de perso (master/DB) peut afficher un niveau périmé jusqu'à une future synchro master. Noté hors-MVP.

### Hors périmètre
Affichage du niveau/XP côté client (panneau/HUD/barre d'XP) ; synchro colonne DB côté master.

### Déploiement
⚠️ **Redéploiement shard** (level-up runtime + `/setlevel` + champ persisté). Pas de wire-breaking, **aucun changement client**, pas de lock-step. Indépendant des PR client en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
