### PR TITLE
feat(world_editor): Lot 0 — fondation d'édition (Selection / Delete / Layers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,7 @@ add_library(engine_core
   src/world_editor/panels/HistoryPanel.cpp
   src/world_editor/panels/SurfaceTablePanel.cpp
   src/world_editor/panels/CollisionEditorPanel.cpp
+  src/world_editor/panels/LayersPanel.cpp
   src/client/app/Engine.cpp
   src/shared/platform/FileSystem.cpp
   src/shared/platform/FileWatcher.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ add_library(engine_core
   # Sous-projet 1, bloc B — modele de scene + selection partagee.
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
+  src/world_editor/scene/EntityKey.cpp
   # Sous-projet 1, bloc D — commande undoable d'edition de transform.
   src/world_editor/inspector/SetEntityTransformCommand.cpp
   src/world_editor/terrain/TerrainDocument.cpp
@@ -1371,6 +1372,15 @@ if(MSVC)
   target_compile_options(editor_scene_model_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME editor_scene_model_tests COMMAND editor_scene_model_tests)
+
+# Lot 0 — Tests CPU pour EntityKey (clé stable de calque). Pur, ctest Linux.
+add_executable(entity_key_tests src/world_editor/tests/EntityKeyTests.cpp)
+target_include_directories(entity_key_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(entity_key_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(entity_key_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME entity_key_tests COMMAND entity_key_tests)
 
 # Sous-projet 1, bloc D — Tests CPU pour SetEntityTransformCommand (Execute/Undo,
 # TryMerge meme entite, coalescing via CommandStack). Pur CPU, non gate.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,7 @@ add_library(engine_core
   src/world_editor/scene/EditorSelection.cpp
   src/world_editor/scene/EditorSceneModel.cpp
   src/world_editor/scene/EntityKey.cpp
+  src/world_editor/scene/SelectionQuery.cpp
   # Sous-projet 1, bloc D — commande undoable d'edition de transform.
   src/world_editor/inspector/SetEntityTransformCommand.cpp
   src/world_editor/terrain/TerrainDocument.cpp
@@ -1381,6 +1382,15 @@ if(MSVC)
   target_compile_options(entity_key_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME entity_key_tests COMMAND entity_key_tests)
+
+# Lot 0 — Tests CPU pour SelectionQuery (encode/décode, pick, rect/lasso). ctest Linux.
+add_executable(selection_query_tests src/world_editor/tests/SelectionQueryTests.cpp)
+target_include_directories(selection_query_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(selection_query_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(selection_query_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME selection_query_tests COMMAND selection_query_tests)
 
 # Sous-projet 1, bloc D — Tests CPU pour SetEntityTransformCommand (Execute/Undo,
 # TryMerge meme entite, coalescing via CommandStack). Pur CPU, non gate.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1392,6 +1392,15 @@ if(MSVC)
 endif()
 add_test(NAME selection_query_tests COMMAND selection_query_tests)
 
+# Lot 0 — Tests CPU pour DeleteEntitiesOps (remove/restore par index). ctest Linux.
+add_executable(delete_entities_ops_tests src/world_editor/tests/DeleteEntitiesOpsTests.cpp)
+target_include_directories(delete_entities_ops_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(delete_entities_ops_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(delete_entities_ops_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME delete_entities_ops_tests COMMAND delete_entities_ops_tests)
+
 # Sous-projet 1, bloc D — Tests CPU pour SetEntityTransformCommand (Execute/Undo,
 # TryMerge meme entite, coalescing via CommandStack). Pur CPU, non gate.
 add_executable(set_entity_transform_command_tests src/world_editor/tests/SetEntityTransformCommandTests.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ add_library(engine_core
   src/world_editor/scene/EditorSceneModel.cpp
   src/world_editor/scene/EntityKey.cpp
   src/world_editor/scene/SelectionQuery.cpp
+  src/world_editor/scene/DeleteEntitiesCommand.cpp
   # Sous-projet 1, bloc D — commande undoable d'edition de transform.
   src/world_editor/inspector/SetEntityTransformCommand.cpp
   src/world_editor/terrain/TerrainDocument.cpp
@@ -1400,6 +1401,15 @@ if(MSVC)
   target_compile_options(delete_entities_ops_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME delete_entities_ops_tests COMMAND delete_entities_ops_tests)
+
+# Lot 0 — Tests CPU pour DeleteEntitiesCommand (Execute/Undo/Redo). ctest Linux.
+add_executable(delete_entities_command_tests src/world_editor/tests/DeleteEntitiesCommandTests.cpp)
+target_include_directories(delete_entities_command_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(delete_entities_command_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(delete_entities_command_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME delete_entities_command_tests COMMAND delete_entities_command_tests)
 
 # Sous-projet 1, bloc D — Tests CPU pour SetEntityTransformCommand (Execute/Undo,
 # TryMerge meme entite, coalescing via CommandStack). Pur CPU, non gate.

--- a/docs/superpowers/plans/2026-06-10-editeur-niveau-lot0-fondation.md
+++ b/docs/superpowers/plans/2026-06-10-editeur-niveau-lot0-fondation.md
@@ -1,0 +1,1672 @@
+# Éditeur de niveau — Lot 0 : Fondation d'édition — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendre l'éditeur de niveau utilisable en câblant la fondation d'édition — sélection (clic + marquee multi), suppression réversible, et calques — sur le modèle vivant `layoutInstances`.
+
+**Architecture:** Approche A (cf. spec) : on opère sur `WorldMapEditDocument::layoutInstances` (+ MeshInsert / DungeonPortal), pas sur les orphelins `PropInstance`. Cœur pur et testable (sélection multi, encode/décode `EntityId`, ops de suppression, clé de calque) compilé dans `engine_core` et testé sous ctest Linux ; UI ImGui (panneaux, toolbar) gardée `_WIN32` ; intégration des entrées dans `Engine.cpp`.
+
+**Tech Stack:** C++17, ImGui (gardé `_WIN32`), CMake, tests « maison » (macro `REQUIRE` + `main()`), réutilisation de la géométrie pure `SelectInRect`/`SelectInLasso` et du raycast `RaycastTerrainFromCamera`.
+
+**Spec de référence :** `docs/superpowers/specs/2026-06-10-editeur-niveau-lot0-fondation-design.md`
+**Branche :** `editeur-lot0-fondation-spec` (le plan continue dessus).
+**Déploiement :** ✅ client/éditeur uniquement — aucun redéploiement serveur.
+
+---
+
+## Structure des fichiers
+
+**Créés (cœur pur — compilés dans `engine_core`, testés Linux) :**
+- `src/world_editor/scene/EntityKey.h` / `.cpp` — clé stable `uint64` par entité (FNV-1a 64).
+- `src/world_editor/scene/SelectionQuery.h` / `.cpp` — encode/décode `EntityId↔uint32`, pick nearest, wrappers rect/lasso.
+- `src/world_editor/scene/DeleteEntitiesOps.h` — templates pures remove/restore par index (header-only).
+- `src/world_editor/scene/DeleteEntitiesCommand.h` / `.cpp` — `ICommand` réversible (callbacks remove/restore).
+- `src/world_editor/panels/LayersPanel.h` / `.cpp` — panneau ImGui des 16 calques.
+
+**Créés (tests) :**
+- `src/world_editor/tests/EntityKeyTests.cpp`
+- `src/world_editor/tests/SelectionQueryTests.cpp`
+- `src/world_editor/tests/DeleteEntitiesOpsTests.cpp`
+- `src/world_editor/tests/DeleteEntitiesCommandTests.cpp`
+
+**Modifiés :**
+- `src/world_editor/scene/EditorSelection.h` / `.cpp` — set multi + API.
+- `src/world_editor/tests/EditorSelectionTests.cpp` — tests multi.
+- `src/world_editor/core/WorldEditorShell.h` / `.cpp` — `ActiveTool::Select`, `LayersDocument` membre + accesseurs, résolveur de clé d'entité, enregistrement `LayersPanel`.
+- `src/world_editor/ui/EditorToolbar.cpp` — `Select` dans `m_orderedTools`.
+- `src/world_editor/ui/ToolbarIconAtlas.cpp` — style icône `Select`.
+- `src/world_editor/panels/OutlinerPanel.h` / `.cpp` — Ctrl+clic multi + toggles calque + pastille couleur.
+- `src/world_editor/panels/ToolPropertiesPanel.cpp` — bloc `Select`.
+- `src/world_editor/volumes/MeshInsertDocument.h`, `src/world_editor/volumes/dungeons/DungeonPortalDocument.h` — accesseur `Mutable()`.
+- `src/shared/platform/Input.h` — `Key::Delete`.
+- `src/world_editor/ui/WorldEditorImGui.h` / `.cpp` — masque de visibilité des marqueurs `layoutInstances`.
+- `src/client/app/Engine.cpp` — routage souris/clavier `Select`, build des candidats, push `DeleteEntitiesCommand`, install résolveurs, masque visibilité.
+- `CMakeLists.txt` (racine) — nouvelles sources `engine_core` + 4 cibles de test.
+
+---
+
+## Phase 1 — Cœur pur (testable sous ctest Linux)
+
+### Task 1 : Multi-sélection dans `EditorSelection`
+
+**Files:**
+- Modify: `src/world_editor/scene/EditorSelection.h`
+- Modify: `src/world_editor/scene/EditorSelection.cpp`
+- Test: `src/world_editor/tests/EditorSelectionTests.cpp`
+
+Contexte : `EditorSelection` est mono-sélection (`m_current`). On ajoute un **set** ordonné + un **primaire** (= `m_current`, inchangé) pour ne pas casser Outliner/Inspector.
+
+- [ ] **Step 1 : Écrire les tests qui échouent** — ajouter dans `EditorSelectionTests.cpp`, avant `int main()`, une nouvelle fonction de test et l'appeler depuis `main()` :
+
+```cpp
+	void Test_MultiSelection()
+	{
+		EditorSelection sel;
+		int calls = 0;
+		sel.SetOnChanged([&](EntityId) { ++calls; });
+
+		const EntityId a{EntityKind::LayoutInstance, 1};
+		const EntityId b{EntityKind::LayoutInstance, 2};
+		const EntityId c{EntityKind::MeshInsert, 0};
+
+		// SelectMany : set = {a,b,c}, primaire = premier (a).
+		sel.SelectMany({a, b, c});
+		REQUIRE(calls == 1);
+		REQUIRE(sel.SelectedSet().size() == 3);
+		REQUIRE(sel.Current() == a);
+		REQUIRE(sel.IsSelected(b));
+		REQUIRE(sel.IsSelected(c));
+
+		// Select mono : set = {b}, primaire = b.
+		sel.Select(b);
+		REQUIRE(sel.SelectedSet().size() == 1);
+		REQUIRE(sel.Current() == b);
+		REQUIRE(!sel.IsSelected(a));
+
+		// Toggle : ajoute a -> {b,a}.
+		sel.ToggleInSelection(a);
+		REQUIRE(sel.SelectedSet().size() == 2);
+		REQUIRE(sel.IsSelected(a));
+		// Toggle : retire b ; primaire se reporte sur un restant (a).
+		sel.ToggleInSelection(b);
+		REQUIRE(sel.SelectedSet().size() == 1);
+		REQUIRE(!sel.IsSelected(b));
+		REQUIRE(sel.Current() == a);
+
+		// Clear vide le set + le primaire.
+		sel.Clear();
+		REQUIRE(sel.SelectedSet().empty());
+		REQUIRE(!sel.HasSelection());
+
+		// SelectMany vide = Clear sémantique (set vide, primaire None).
+		sel.SelectMany({a});
+		sel.SelectMany({});
+		REQUIRE(sel.SelectedSet().empty());
+		REQUIRE(sel.Current().kind == EntityKind::None);
+	}
+```
+
+Et dans `main()` ajouter `Test_MultiSelection();` après `Test_SelectionNotifiesOnChange();`.
+
+- [ ] **Step 2 : Lancer le test, vérifier l'échec de compilation/exécution**
+
+Run: `cmake --build build --target editor_selection_tests` (ou compilation CI)
+Expected: échec de compilation (`SelectMany`, `SelectedSet`, `IsSelected`, `ToggleInSelection` n'existent pas).
+
+- [ ] **Step 3 : Implémenter dans `EditorSelection.h`** — ajouter `#include <vector>` en tête, puis dans la classe (après `Clear()`), déclarer :
+
+```cpp
+		/// Remplace la sélection par `ids` (ordre préservé). Le primaire devient
+		/// le premier élément (ou None si `ids` est vide). Notifie si changement.
+		void SelectMany(const std::vector<EntityId>& ids);
+
+		/// Ajoute `id` au set s'il est absent, l'en retire sinon. Ajuste le
+		/// primaire (reste valide ; se reporte sur un élément restant après un
+		/// retrait du primaire ; None si le set devient vide). Notifie.
+		void ToggleInSelection(EntityId id);
+
+		/// Set courant des entités sélectionnées (le primaire en fait partie).
+		const std::vector<EntityId>& SelectedSet() const { return m_set; }
+
+		/// true si `id` appartient au set.
+		bool IsSelected(EntityId id) const;
+```
+
+Et dans la section privée, après `EntityId m_current{};` :
+
+```cpp
+		std::vector<EntityId> m_set; ///< Set de sélection (primaire = m_current).
+```
+
+- [ ] **Step 4 : Implémenter dans `EditorSelection.cpp`** — modifier `Select`/`Clear` pour maintenir `m_set`, et ajouter les nouvelles méthodes :
+
+```cpp
+#include "src/world_editor/scene/EditorSelection.h"
+
+#include <algorithm>
+
+namespace engine::editor::scene
+{
+	void EditorSelection::Select(EntityId id)
+	{
+		if (m_set.size() == 1 && m_current == id) return; // déjà la seule sélection
+		m_current = id;
+		m_set.clear();
+		if (id.kind != EntityKind::None) m_set.push_back(id);
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	void EditorSelection::Clear()
+	{
+		if (m_current.kind == EntityKind::None && m_set.empty()) return; // déjà vide
+		m_current = EntityId{};
+		m_set.clear();
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	void EditorSelection::SelectMany(const std::vector<EntityId>& ids)
+	{
+		m_set = ids;
+		m_current = ids.empty() ? EntityId{} : ids.front();
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	void EditorSelection::ToggleInSelection(EntityId id)
+	{
+		auto it = std::find(m_set.begin(), m_set.end(), id);
+		if (it != m_set.end())
+			m_set.erase(it);
+		else
+			m_set.push_back(id);
+		m_current = m_set.empty() ? EntityId{} : m_set.front();
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	bool EditorSelection::IsSelected(EntityId id) const
+	{
+		return std::find(m_set.begin(), m_set.end(), id) != m_set.end();
+	}
+}
+```
+
+- [ ] **Step 5 : Lancer le test, vérifier le succès**
+
+Run: build + exécuter `editor_selection_tests`
+Expected: `[PASS] EditorSelectionTests`
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add src/world_editor/scene/EditorSelection.h src/world_editor/scene/EditorSelection.cpp src/world_editor/tests/EditorSelectionTests.cpp
+git commit -m "feat(world_editor): EditorSelection multi-sélection (set + primaire)"
+```
+
+---
+
+### Task 2 : Clé stable d'entité (`EntityKey`)
+
+**Files:**
+- Create: `src/world_editor/scene/EntityKey.h`
+- Create: `src/world_editor/scene/EntityKey.cpp`
+- Test: `src/world_editor/tests/EntityKeyTests.cpp`
+- Modify: `CMakeLists.txt`
+
+Contexte : `LayersDocument` indexe par `uint64 entityKey`. L'`EntityId.index` n'est pas stable au `Rebuild` ; on dérive une clé du `guid` (layout = string, mesh/dungeon = uint64), préfixée par le `kind` pour éviter les collisions inter-types. FNV-1a 64 bits (concern distinct du hash 32 bits `assetIdHash` existant — on n'y touche pas).
+
+- [ ] **Step 1 : Écrire le test qui échoue** — `src/world_editor/tests/EntityKeyTests.cpp` :
+
+```cpp
+/// Tests CPU pour EntityKey (clé stable de calque). Pur, ctest Linux.
+#include "src/world_editor/scene/EntityKey.h"
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_KeyStableAndDistinct()
+	{
+		// Déterministe : même entrée -> même clé.
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001")
+			== MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001"));
+		// Guid différent -> clé différente.
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001")
+			!= MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_002"));
+		// Même guid, kind différent -> clé différente (préfixe kind).
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "x")
+			!= MakeEntityKeyFromString(EntityKind::MeshInsert, "x"));
+		// Variante numérique (mesh/dungeon) : déterministe + séparée par kind.
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42)
+			== MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42));
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42)
+			!= MakeEntityKeyFromGuid(EntityKind::DungeonPortal, 42));
+		// Clé non nulle (0 = "non assigné" côté LayersDocument).
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 0) != 0u);
+	}
+}
+
+int main()
+{
+	Test_KeyStableAndDistinct();
+	if (g_failed == 0) { std::printf("[PASS] EntityKeyTests\n"); return 0; }
+	std::printf("[FAIL] EntityKeyTests: %d failure(s)\n", g_failed);
+	return 1;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec** — compilation impossible (`EntityKey.h` absent). Expected: FAIL.
+
+- [ ] **Step 3 : Créer `src/world_editor/scene/EntityKey.h`** :
+
+```cpp
+#pragma once
+
+#include "src/world_editor/scene/EditorSelection.h" // EntityKind
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::editor::scene
+{
+	/// Clé stable `uint64` d'une entité pour `LayersDocument` (assignement par
+	/// calque survivant aux `Rebuild`, contrairement à `EntityId.index`).
+	/// Dérive un FNV-1a 64 bits du `guid`, mélangé au `kind` pour éviter les
+	/// collisions inter-types. Concern distinct du hash 32 bits `assetIdHash`.
+
+	/// Clé pour une entité à guid textuel (LayoutInstance). Jamais nulle.
+	uint64_t MakeEntityKeyFromString(EntityKind kind, std::string_view guid);
+
+	/// Clé pour une entité à guid numérique (MeshInsert / DungeonPortal). Jamais nulle.
+	uint64_t MakeEntityKeyFromGuid(EntityKind kind, uint64_t guid);
+}
+```
+
+- [ ] **Step 4 : Créer `src/world_editor/scene/EntityKey.cpp`** :
+
+```cpp
+#include "src/world_editor/scene/EntityKey.h"
+
+namespace engine::editor::scene
+{
+	namespace
+	{
+		constexpr uint64_t kFnvOffset = 1469598103934665603ull;
+		constexpr uint64_t kFnvPrime  = 1099511628211ull;
+
+		uint64_t Fnv1a64(uint64_t seed, const unsigned char* data, size_t n)
+		{
+			uint64_t h = seed;
+			for (size_t i = 0; i < n; ++i) { h ^= data[i]; h *= kFnvPrime; }
+			return h;
+		}
+	}
+
+	uint64_t MakeEntityKeyFromString(EntityKind kind, std::string_view guid)
+	{
+		uint64_t h = kFnvOffset;
+		const unsigned char k = static_cast<unsigned char>(kind);
+		h = Fnv1a64(h, &k, 1);
+		h = Fnv1a64(h, reinterpret_cast<const unsigned char*>(guid.data()), guid.size());
+		return h | 1ull; // jamais 0 (0 = non assigné côté LayersDocument)
+	}
+
+	uint64_t MakeEntityKeyFromGuid(EntityKind kind, uint64_t guid)
+	{
+		unsigned char buf[9];
+		buf[0] = static_cast<unsigned char>(kind);
+		for (int i = 0; i < 8; ++i) buf[1 + i] = static_cast<unsigned char>((guid >> (i * 8)) & 0xFF);
+		return Fnv1a64(kFnvOffset, buf, sizeof(buf)) | 1ull;
+	}
+}
+```
+
+- [ ] **Step 5 : Enregistrer dans `CMakeLists.txt`** — (a) ajouter la source à `engine_core` juste après la ligne `src/world_editor/scene/EditorSceneModel.cpp` (≈ ligne 381) :
+
+```cmake
+  src/world_editor/scene/EntityKey.cpp
+```
+
+(b) ajouter une cible de test après le bloc `editor_scene_model_tests` (≈ ligne 1373) :
+
+```cmake
+# Lot 0 — Tests CPU pour EntityKey (clé stable de calque). Pur, ctest Linux.
+add_executable(entity_key_tests src/world_editor/tests/EntityKeyTests.cpp)
+target_include_directories(entity_key_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(entity_key_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(entity_key_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME entity_key_tests COMMAND entity_key_tests)
+```
+
+- [ ] **Step 6 : Lancer le test, vérifier le succès**
+
+Run: build + `entity_key_tests`
+Expected: `[PASS] EntityKeyTests`
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/world_editor/scene/EntityKey.h src/world_editor/scene/EntityKey.cpp src/world_editor/tests/EntityKeyTests.cpp CMakeLists.txt
+git commit -m "feat(world_editor): EntityKey — clé stable de calque (FNV-1a 64)"
+```
+
+---
+
+### Task 3 : `SelectionQuery` (encode/décode + pick + rect/lasso)
+
+**Files:**
+- Create: `src/world_editor/scene/SelectionQuery.h`
+- Create: `src/world_editor/scene/SelectionQuery.cpp`
+- Test: `src/world_editor/tests/SelectionQueryTests.cpp`
+- Modify: `CMakeLists.txt`
+
+Contexte : transite les `EntityId` à travers l'API `uint32` de `SelectionTool` (rect/lasso) et fournit le pick « plus proche en X/Z sous un rayon » (clic simple). `EntityKind` max = 5 → 8 bits suffisent ; index sur 24 bits.
+
+- [ ] **Step 1 : Écrire le test qui échoue** — `src/world_editor/tests/SelectionQueryTests.cpp` :
+
+```cpp
+/// Tests CPU pour SelectionQuery (encode/décode, pick nearest, rect/lasso).
+#include "src/world_editor/scene/SelectionQuery.h"
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+	using namespace engine::editor::world;
+
+	void Test_EncodeRoundTrip()
+	{
+		const EntityId id{EntityKind::MeshInsert, 1234567};
+		const uint32_t enc = EncodeEntityId(id);
+		const EntityId dec = DecodeEntityId(enc);
+		REQUIRE(dec.kind == EntityKind::MeshInsert);
+		REQUIRE(dec.index == 1234567u);
+	}
+
+	void Test_PickNearest()
+	{
+		std::vector<SelectableEntity> pts = {
+			{ {EntityKind::LayoutInstance, 0}, 0.f, 0.f },
+			{ {EntityKind::LayoutInstance, 1}, 10.f, 0.f },
+			{ {EntityKind::LayoutInstance, 2}, 0.f, 10.f },
+		};
+		// Clic près de (9,0) avec rayon 3 -> index 1.
+		auto hit = PickNearest(pts, 9.f, 0.f, 3.f);
+		REQUIRE(hit.has_value());
+		REQUIRE(hit->index == 1u);
+		// Clic loin de tout (rayon 1) -> rien.
+		REQUIRE(!PickNearest(pts, 50.f, 50.f, 1.f).has_value());
+	}
+
+	void Test_RectAndLasso()
+	{
+		std::vector<SelectableEntity> pts = {
+			{ {EntityKind::LayoutInstance, 0}, 1.f, 1.f },
+			{ {EntityKind::LayoutInstance, 1}, 5.f, 5.f },
+			{ {EntityKind::LayoutInstance, 2}, 20.f, 20.f },
+		};
+		SelectionRect rect; rect.minX = 0.f; rect.minZ = 0.f; rect.maxX = 10.f; rect.maxZ = 10.f;
+		auto inRect = PickInRect(pts, rect);
+		REQUIRE(inRect.size() == 2); // 0 et 1
+		// Lasso = même carré 0..10 -> mêmes 2 entités.
+		std::vector<std::pair<float, float>> poly = {{0,0},{10,0},{10,10},{0,10}};
+		auto inLasso = PickInLasso(pts, poly);
+		REQUIRE(inLasso.size() == 2);
+	}
+}
+
+int main()
+{
+	Test_EncodeRoundTrip();
+	Test_PickNearest();
+	Test_RectAndLasso();
+	if (g_failed == 0) { std::printf("[PASS] SelectionQueryTests\n"); return 0; }
+	std::printf("[FAIL] SelectionQueryTests: %d failure(s)\n", g_failed);
+	return 1;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec** — `SelectionQuery.h` absent. Expected: FAIL compilation.
+
+- [ ] **Step 3 : Créer `src/world_editor/scene/SelectionQuery.h`** :
+
+```cpp
+#pragma once
+
+#include "src/world_editor/SelectionTool.h"           // SelectionRect, SelectablePoint
+#include "src/world_editor/scene/EditorSelection.h"    // EntityId, EntityKind
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Candidat sélectionnable projeté au sol (X/Z monde).
+	struct SelectableEntity
+	{
+		EntityId id{};
+		float    x = 0.0f;
+		float    z = 0.0f;
+	};
+
+	/// Encode `(kind, index)` sur 32 bits (8 bits kind << 24 | index 24 bits)
+	/// pour transiter par l'API uint32 de SelectionTool.
+	uint32_t EncodeEntityId(EntityId id);
+	EntityId DecodeEntityId(uint32_t encoded);
+
+	/// Entité la plus proche de (x,z) dont la distance ≤ `radius` (monde).
+	/// std::nullopt si aucune dans le rayon.
+	std::optional<EntityId> PickNearest(const std::vector<SelectableEntity>& pts,
+		float x, float z, float radius);
+
+	/// Entités dont la projection X/Z tombe dans `rect` (réutilise SelectInRect).
+	std::vector<EntityId> PickInRect(const std::vector<SelectableEntity>& pts,
+		engine::editor::world::SelectionRect rect);
+
+	/// Entités dont la projection X/Z tombe dans le polygone lasso (SelectInLasso).
+	std::vector<EntityId> PickInLasso(const std::vector<SelectableEntity>& pts,
+		const std::vector<std::pair<float, float>>& polygon);
+}
+```
+
+- [ ] **Step 4 : Créer `src/world_editor/scene/SelectionQuery.cpp`** :
+
+```cpp
+#include "src/world_editor/scene/SelectionQuery.h"
+
+namespace engine::editor::scene
+{
+	using engine::editor::world::SelectablePoint;
+	using engine::editor::world::SelectionRect;
+
+	uint32_t EncodeEntityId(EntityId id)
+	{
+		return (static_cast<uint32_t>(id.kind) << 24) | (id.index & 0x00FFFFFFu);
+	}
+
+	EntityId DecodeEntityId(uint32_t encoded)
+	{
+		EntityId id;
+		id.kind  = static_cast<EntityKind>((encoded >> 24) & 0xFFu);
+		id.index = encoded & 0x00FFFFFFu;
+		return id;
+	}
+
+	std::optional<EntityId> PickNearest(const std::vector<SelectableEntity>& pts,
+		float x, float z, float radius)
+	{
+		const float r2 = radius * radius;
+		std::optional<EntityId> best;
+		float bestD2 = r2;
+		for (const auto& p : pts)
+		{
+			const float dx = p.x - x;
+			const float dz = p.z - z;
+			const float d2 = dx * dx + dz * dz;
+			if (d2 <= bestD2)
+			{
+				bestD2 = d2;
+				best = p.id;
+			}
+		}
+		return best;
+	}
+
+	std::vector<EntityId> PickInRect(const std::vector<SelectableEntity>& pts,
+		SelectionRect rect)
+	{
+		std::vector<SelectablePoint> raw;
+		raw.reserve(pts.size());
+		for (const auto& p : pts)
+			raw.push_back(SelectablePoint{ EncodeEntityId(p.id), p.x, p.z });
+
+		std::vector<uint32_t> ids = engine::editor::world::SelectInRect(raw, rect);
+		std::vector<EntityId> out;
+		out.reserve(ids.size());
+		for (uint32_t e : ids) out.push_back(DecodeEntityId(e));
+		return out;
+	}
+
+	std::vector<EntityId> PickInLasso(const std::vector<SelectableEntity>& pts,
+		const std::vector<std::pair<float, float>>& polygon)
+	{
+		std::vector<SelectablePoint> raw;
+		raw.reserve(pts.size());
+		for (const auto& p : pts)
+			raw.push_back(SelectablePoint{ EncodeEntityId(p.id), p.x, p.z });
+
+		std::vector<uint32_t> ids = engine::editor::world::SelectInLasso(raw, polygon);
+		std::vector<EntityId> out;
+		out.reserve(ids.size());
+		for (uint32_t e : ids) out.push_back(DecodeEntityId(e));
+		return out;
+	}
+}
+```
+
+- [ ] **Step 5 : Enregistrer dans `CMakeLists.txt`** — (a) source `engine_core` après `EntityKey.cpp` :
+
+```cmake
+  src/world_editor/scene/SelectionQuery.cpp
+```
+
+(b) cible de test après `entity_key_tests` :
+
+```cmake
+# Lot 0 — Tests CPU pour SelectionQuery (encode/décode, pick, rect/lasso). ctest Linux.
+add_executable(selection_query_tests src/world_editor/tests/SelectionQueryTests.cpp)
+target_include_directories(selection_query_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(selection_query_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(selection_query_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME selection_query_tests COMMAND selection_query_tests)
+```
+
+> Note : `SelectionTool.cpp` est déjà compilé dans `engine_core` (orphelin mais bâti). Vérifier sa présence dans la liste de sources ; si absent, l'ajouter à côté de `SelectionQuery.cpp`.
+
+- [ ] **Step 6 : Lancer le test, vérifier le succès** — `selection_query_tests` → `[PASS]`.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/world_editor/scene/SelectionQuery.h src/world_editor/scene/SelectionQuery.cpp src/world_editor/tests/SelectionQueryTests.cpp CMakeLists.txt
+git commit -m "feat(world_editor): SelectionQuery — encode/décode EntityId + pick + rect/lasso"
+```
+
+---
+
+### Task 4 : Ops pures de suppression/restauration par index
+
+**Files:**
+- Create: `src/world_editor/scene/DeleteEntitiesOps.h` (header-only, templates)
+- Test: `src/world_editor/tests/DeleteEntitiesOpsTests.cpp`
+- Modify: `CMakeLists.txt`
+
+Contexte : logique générique d'undo exact — supprimer par index (décroissant) en capturant `(index, copie)`, réinsérer (croissant). Réutilisée par les 3 conteneurs (layout/mesh/dungeon).
+
+- [ ] **Step 1 : Écrire le test qui échoue** — `src/world_editor/tests/DeleteEntitiesOpsTests.cpp` :
+
+```cpp
+/// Tests CPU pour DeleteEntitiesOps (remove/restore par index, undo exact).
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_RemoveRestoreExact()
+	{
+		std::vector<std::string> v = {"a", "b", "c", "d", "e"};
+		// Supprime indices {1,3} (b,d). Ordre d'entrée volontairement non trié.
+		auto removed = RemoveByIndexDescending(v, {3, 1});
+		REQUIRE(v.size() == 3);
+		REQUIRE(v[0] == "a"); REQUIRE(v[1] == "c"); REQUIRE(v[2] == "e");
+		// Snapshot trié croissant : (1,b),(3,d).
+		REQUIRE(removed.size() == 2);
+		REQUIRE(removed[0].first == 1u); REQUIRE(removed[0].second == "b");
+		REQUIRE(removed[1].first == 3u); REQUIRE(removed[1].second == "d");
+
+		// Restore -> état initial exact.
+		RestoreByIndexAscending(v, removed);
+		REQUIRE(v.size() == 5);
+		REQUIRE(v[0] == "a"); REQUIRE(v[1] == "b"); REQUIRE(v[2] == "c");
+		REQUIRE(v[3] == "d"); REQUIRE(v[4] == "e");
+	}
+
+	void Test_OutOfRangeIgnored()
+	{
+		std::vector<int> v = {10, 20};
+		auto removed = RemoveByIndexDescending(v, {5, 0}); // 5 hors borne -> ignoré
+		REQUIRE(v.size() == 1);
+		REQUIRE(v[0] == 20);
+		REQUIRE(removed.size() == 1);
+		REQUIRE(removed[0].first == 0u);
+		REQUIRE(removed[0].second == 10);
+	}
+}
+
+int main()
+{
+	Test_RemoveRestoreExact();
+	Test_OutOfRangeIgnored();
+	if (g_failed == 0) { std::printf("[PASS] DeleteEntitiesOpsTests\n"); return 0; }
+	std::printf("[FAIL] DeleteEntitiesOpsTests: %d failure(s)\n", g_failed);
+	return 1;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec** — header absent. Expected: FAIL.
+
+- [ ] **Step 3 : Créer `src/world_editor/scene/DeleteEntitiesOps.h`** :
+
+```cpp
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Supprime de `vec` les éléments aux `indices` donnés (ordre quelconque,
+	/// doublons tolérés). Retire en ordre décroissant pour ne pas invalider les
+	/// index restants. Retourne les `(index, copie)` retirés, **triés par index
+	/// croissant** (prêt pour `RestoreByIndexAscending`). Index hors borne ignorés.
+	template <class T>
+	std::vector<std::pair<uint32_t, T>> RemoveByIndexDescending(
+		std::vector<T>& vec, std::vector<uint32_t> indices)
+	{
+		std::sort(indices.begin(), indices.end());
+		indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
+
+		std::vector<std::pair<uint32_t, T>> removed;
+		removed.reserve(indices.size());
+		// Croissant pour le snapshot…
+		for (uint32_t idx : indices)
+			if (idx < vec.size())
+				removed.emplace_back(idx, vec[idx]);
+		// …mais on supprime en décroissant.
+		for (auto it = indices.rbegin(); it != indices.rend(); ++it)
+			if (*it < vec.size())
+				vec.erase(vec.begin() + static_cast<std::ptrdiff_t>(*it));
+		return removed;
+	}
+
+	/// Réinsère les `(index, copie)` (supposés triés croissants) à leur position
+	/// d'origine. Reconstruit l'état d'avant `RemoveByIndexDescending` exactement.
+	template <class T>
+	void RestoreByIndexAscending(std::vector<T>& vec,
+		const std::vector<std::pair<uint32_t, T>>& removed)
+	{
+		for (const auto& [idx, item] : removed)
+		{
+			const size_t clamped = idx <= vec.size() ? idx : vec.size();
+			vec.insert(vec.begin() + static_cast<std::ptrdiff_t>(clamped), item);
+		}
+	}
+}
+```
+
+- [ ] **Step 4 : Enregistrer la cible de test dans `CMakeLists.txt`** (header-only ⇒ pas de source `engine_core`) après `selection_query_tests` :
+
+```cmake
+# Lot 0 — Tests CPU pour DeleteEntitiesOps (remove/restore par index). ctest Linux.
+add_executable(delete_entities_ops_tests src/world_editor/tests/DeleteEntitiesOpsTests.cpp)
+target_include_directories(delete_entities_ops_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(delete_entities_ops_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(delete_entities_ops_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME delete_entities_ops_tests COMMAND delete_entities_ops_tests)
+```
+
+- [ ] **Step 5 : Lancer le test, vérifier le succès** — `delete_entities_ops_tests` → `[PASS]`.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add src/world_editor/scene/DeleteEntitiesOps.h src/world_editor/tests/DeleteEntitiesOpsTests.cpp CMakeLists.txt
+git commit -m "feat(world_editor): DeleteEntitiesOps — remove/restore par index (undo exact)"
+```
+
+---
+
+### Task 5 : `DeleteEntitiesCommand` (ICommand réversible)
+
+**Files:**
+- Create: `src/world_editor/scene/DeleteEntitiesCommand.h`
+- Create: `src/world_editor/scene/DeleteEntitiesCommand.cpp`
+- Test: `src/world_editor/tests/DeleteEntitiesCommandTests.cpp`
+- Modify: `CMakeLists.txt`
+
+Contexte : commande générique via 2 callbacks (`RemoveFn`/`RestoreFn`). Le snapshot `DeletedEntities` porte les 3 vecteurs `(index, copie)`. L'Engine fournira les callbacks (qui appellent les ops de la Task 4 sur les docs concrets). Le test fournit des lambdas triviales sur un vecteur local.
+
+- [ ] **Step 1 : Écrire le test qui échoue** — `src/world_editor/tests/DeleteEntitiesCommandTests.cpp` :
+
+```cpp
+/// Tests CPU pour DeleteEntitiesCommand (Execute/Undo/Redo via callbacks).
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_ExecuteUndoRedo()
+	{
+		// Modèle de test : un vecteur de strings simulant layoutInstances.
+		std::vector<std::string> model = {"a", "b", "c"};
+
+		std::vector<EntityId> ids = {
+			{EntityKind::LayoutInstance, 0}, {EntityKind::LayoutInstance, 2} };
+
+		// Snapshot custom du test : on réutilise le champ générique via lambdas.
+		std::vector<std::pair<uint32_t, std::string>> backup;
+
+		auto remove = [&](const std::vector<EntityId>& sel) -> DeletedEntities
+		{
+			std::vector<uint32_t> idx;
+			for (const EntityId& e : sel) idx.push_back(e.index);
+			backup = RemoveByIndexDescending(model, idx);
+			return DeletedEntities{}; // l'état réel est dans `backup` (capturé)
+		};
+		auto restore = [&](const DeletedEntities&)
+		{
+			RestoreByIndexAscending(model, backup);
+		};
+
+		DeleteEntitiesCommand cmd(ids, remove, restore);
+		REQUIRE(std::string(cmd.GetLabel()) != "");
+
+		cmd.Execute();
+		REQUIRE(model.size() == 1);
+		REQUIRE(model[0] == "b");
+
+		cmd.Undo();
+		REQUIRE(model.size() == 3);
+		REQUIRE(model[0] == "a"); REQUIRE(model[1] == "b"); REQUIRE(model[2] == "c");
+
+		// Redo = Execute à nouveau (indices valides car Undo a tout restitué).
+		cmd.Execute();
+		REQUIRE(model.size() == 1);
+		REQUIRE(model[0] == "b");
+	}
+}
+
+int main()
+{
+	Test_ExecuteUndoRedo();
+	if (g_failed == 0) { std::printf("[PASS] DeleteEntitiesCommandTests\n"); return 0; }
+	std::printf("[FAIL] DeleteEntitiesCommandTests: %d failure(s)\n", g_failed);
+	return 1;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec** — header absent. Expected: FAIL.
+
+- [ ] **Step 3 : Créer `src/world_editor/scene/DeleteEntitiesCommand.h`** :
+
+```cpp
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"        // ICommand
+#include "src/world_editor/scene/EditorSelection.h"     // EntityId
+#include "src/world_editor/ui/WorldMapEditDocument.h"   // WorldMapEditLayoutInstance
+#include "src/world_editor/volumes/MeshInsertInstance.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalInstance.h"
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Snapshot des entités retirées (index d'origine + copie) par type, pour
+	/// l'undo exact. Rempli par le `RemoveFn`, consommé par le `RestoreFn`.
+	struct DeletedEntities
+	{
+		std::vector<std::pair<uint32_t, engine::editor::WorldMapEditLayoutInstance>>     layout;
+		std::vector<std::pair<uint32_t, engine::editor::world::volumes::MeshInsertInstance>>          mesh;
+		std::vector<std::pair<uint32_t, engine::editor::world::volumes::dungeons::DungeonPortalInstance>> dungeon;
+	};
+
+	/// Commande réversible de suppression d'un ensemble d'entités sélectionnées
+	/// (modèle vivant : layoutInstances + mesh inserts + dungeon portals).
+	///
+	/// Découplée des documents concrets via deux callbacks fournis par l'Engine :
+	/// `RemoveFn` retire les entités et renvoie le snapshot ; `RestoreFn` les
+	/// réinsère depuis le snapshot. Implémente le contrat ICommand undo/redo.
+	///
+	/// Limite assumée (cf. spec §4.4) : `EntityId.index` n'est pas stable après
+	/// édition structurelle ; la commande suppose un undo/redo linéaire immédiat
+	/// (même compromis que SetEntityTransformCommand).
+	class DeleteEntitiesCommand : public engine::editor::world::ICommand
+	{
+	public:
+		using RemoveFn  = std::function<DeletedEntities(const std::vector<EntityId>&)>;
+		using RestoreFn = std::function<void(const DeletedEntities&)>;
+
+		DeleteEntitiesCommand(std::vector<EntityId> ids, RemoveFn remove, RestoreFn restore)
+			: m_ids(std::move(ids)), m_remove(std::move(remove)), m_restore(std::move(restore)) {}
+
+		const char* GetLabel() const override { return "Supprimer la sélection"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+
+	private:
+		std::vector<EntityId> m_ids;
+		RemoveFn  m_remove;
+		RestoreFn m_restore;
+		DeletedEntities m_snapshot;
+	};
+}
+```
+
+- [ ] **Step 4 : Créer `src/world_editor/scene/DeleteEntitiesCommand.cpp`** :
+
+```cpp
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+
+namespace engine::editor::scene
+{
+	void DeleteEntitiesCommand::Execute()
+	{
+		if (m_remove) m_snapshot = m_remove(m_ids);
+	}
+
+	void DeleteEntitiesCommand::Undo()
+	{
+		if (m_restore) m_restore(m_snapshot);
+	}
+
+	size_t DeleteEntitiesCommand::GetMemoryFootprint() const
+	{
+		return sizeof(DeleteEntitiesCommand)
+			+ m_ids.capacity() * sizeof(EntityId)
+			+ m_snapshot.layout.capacity()  * sizeof(m_snapshot.layout[0])
+			+ m_snapshot.mesh.capacity()    * sizeof(m_snapshot.mesh[0])
+			+ m_snapshot.dungeon.capacity() * sizeof(m_snapshot.dungeon[0]);
+	}
+}
+```
+
+> Si `sizeof(m_snapshot.layout[0])` ne compile pas sur un vecteur vide (il s'agit du type d'élément, pas d'un déréférencement — valide en C++), remplacer par `sizeof(std::pair<uint32_t, engine::editor::WorldMapEditLayoutInstance>)` etc.
+
+- [ ] **Step 5 : Enregistrer dans `CMakeLists.txt`** — (a) source `engine_core` après `SelectionQuery.cpp` :
+
+```cmake
+  src/world_editor/scene/DeleteEntitiesCommand.cpp
+```
+
+(b) cible de test après `delete_entities_ops_tests` :
+
+```cmake
+# Lot 0 — Tests CPU pour DeleteEntitiesCommand (Execute/Undo/Redo). ctest Linux.
+add_executable(delete_entities_command_tests src/world_editor/tests/DeleteEntitiesCommandTests.cpp)
+target_include_directories(delete_entities_command_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(delete_entities_command_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(delete_entities_command_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME delete_entities_command_tests COMMAND delete_entities_command_tests)
+```
+
+- [ ] **Step 6 : Lancer le test, vérifier le succès** — `delete_entities_command_tests` → `[PASS]`.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/world_editor/scene/DeleteEntitiesCommand.h src/world_editor/scene/DeleteEntitiesCommand.cpp src/world_editor/tests/DeleteEntitiesCommandTests.cpp CMakeLists.txt
+git commit -m "feat(world_editor): DeleteEntitiesCommand — suppression réversible (callbacks)"
+```
+
+---
+
+## Phase 2 — Shell & UI (gardée `_WIN32`, vérifiée au build)
+
+### Task 6 : `ActiveTool::Select` + toolbar + icône
+
+**Files:**
+- Modify: `src/world_editor/core/WorldEditorShell.h:42-60`
+- Modify: `src/world_editor/ui/EditorToolbar.cpp:14-30`
+- Modify: `src/world_editor/ui/ToolbarIconAtlas.cpp`
+
+- [ ] **Step 1 : Ajouter l'entrée enum** — dans `WorldEditorShell.h`, à la fin de l'enum `ActiveTool` (après `DungeonPortal = 15,`), ajouter :
+
+```cpp
+		Select              = 16,  // Lot 0 — sélection (clic + marquee), raccourci Q
+```
+
+- [ ] **Step 2 : Ajouter à la toolbar** — dans `EditorToolbar.cpp`, à la fin de l'initialisation de `m_orderedTools` (après `ActiveTool::DungeonPortal,`), ajouter :
+
+```cpp
+			ActiveTool::Select,             // Lot 0 — sélection / suppression
+```
+
+- [ ] **Step 3 : Ajouter le style d'icône** — dans `ToolbarIconAtlas.cpp`, repérer le `switch (tool)` de `Get(...)` et ajouter un `case` (avant le `default`) :
+
+```cpp
+		case ActiveTool::Select:
+			return ToolIconStyle{ 0xFF3A6EA5u, "S", "Sélection (clic / rectangle) — Suppr pour supprimer", true };
+```
+
+> Adapter l'ordre des champs à la définition de `ToolIconStyle` (`bgColorArgb`, `letter`, `tooltipFr`, `enabled`). Vérifier la forme exacte des `case` voisins (certains utilisent l'agrégat `{...}`, d'autres l'affectation champ par champ) et **suivre le style existant**.
+
+- [ ] **Step 4 : Build, vérifier la compilation** — `cmake --build build --target world_editor_app` ; pas d'erreur ; l'outil « S » apparaît dans la toolbar.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/world_editor/core/WorldEditorShell.h src/world_editor/ui/EditorToolbar.cpp src/world_editor/ui/ToolbarIconAtlas.cpp
+git commit -m "feat(world_editor): outil Select (enum + toolbar + icône)"
+```
+
+---
+
+### Task 7 : `LayersDocument` + résolveur de clé sur le shell
+
+**Files:**
+- Modify: `src/world_editor/core/WorldEditorShell.h`
+- Modify: `src/world_editor/core/WorldEditorShell.cpp`
+
+Contexte : le shell héberge le `LayersDocument` (source d'autorité runtime des calques) et un résolveur `EntityId → entityKey` installé par l'Engine (qui seul connaît les guids des docs).
+
+- [ ] **Step 1 : Inclure + déclarer les membres** — dans `WorldEditorShell.h`, ajouter en tête (avec les autres includes éditeur) :
+
+```cpp
+#include "src/world_editor/LayersDocument.h"
+#include "src/world_editor/scene/EditorSelection.h"
+```
+
+(le second est déjà tiré indirectement ; sans danger). Puis dans la section publique, après les accesseurs de sélection (`GetSelection()`), ajouter :
+
+```cpp
+		/// Lot 0 — Document des 16 calques (visibilité / verrou / couleur +
+		/// assignement par entityKey). Source d'autorité runtime ; non persisté
+		/// (cf. spec : persistance d'un layerIndex différée).
+		LayersDocument&       MutableLayersDocument()       { return m_layersDoc; }
+		const LayersDocument& GetLayersDocument()     const { return m_layersDoc; }
+
+		/// Lot 0 — Résolveur EntityId -> entityKey (clé stable de calque),
+		/// installé par l'Engine (capture les documents concrets pour lire le
+		/// guid). Retourne 0 si non installé ou entité inconnue.
+		using EntityKeyResolver = std::function<uint64_t(engine::editor::scene::EntityId)>;
+		void SetEntityKeyResolver(EntityKeyResolver r) { m_entityKeyResolver = std::move(r); }
+		uint64_t EntityKeyFor(engine::editor::scene::EntityId id) const
+		{
+			return m_entityKeyResolver ? m_entityKeyResolver(id) : 0ull;
+		}
+```
+
+Et en section privée, près des autres documents :
+
+```cpp
+		LayersDocument m_layersDoc;            // Lot 0
+		EntityKeyResolver m_entityKeyResolver; // Lot 0
+```
+
+- [ ] **Step 2 : Build, vérifier la compilation** — `world_editor_app` compile (les accesseurs ne sont pas encore consommés).
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/world_editor/core/WorldEditorShell.h src/world_editor/core/WorldEditorShell.cpp
+git commit -m "feat(world_editor): shell héberge LayersDocument + résolveur de clé d'entité"
+```
+
+---
+
+### Task 8 : Panneau `LayersPanel`
+
+**Files:**
+- Create: `src/world_editor/panels/LayersPanel.h`
+- Create: `src/world_editor/panels/LayersPanel.cpp`
+- Modify: `src/world_editor/core/WorldEditorShell.cpp` (Init : enregistrement + SetShell)
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1 : Créer `src/world_editor/panels/LayersPanel.h`** :
+
+```cpp
+#pragma once
+#include "src/world_editor/core/IPanel.h"
+
+namespace engine::editor::world
+{
+	class WorldEditorShell;
+}
+
+namespace engine::editor::world::panels
+{
+	/// Panneau des 16 calques (Lot 0). Renommage, visibilité, verrou, couleur,
+	/// et « assigner la sélection au calque ». Lit/écrit le `LayersDocument` et
+	/// la sélection via le shell injecté. Rendu ImGui gardé `_WIN32`.
+	class LayersPanel final : public IPanel
+	{
+	public:
+		const char* GetName() const override { return "Layers"; }
+		void Render() override;
+		bool IsVisible() const override { return m_visible; }
+		void SetVisible(bool visible) override { m_visible = visible; }
+
+		/// Injecte le shell (durée de vie garantie : le shell possède le panneau).
+		void SetShell(WorldEditorShell* shell) { m_shell = shell; }
+
+	private:
+		bool m_visible = true;
+		WorldEditorShell* m_shell = nullptr;
+		int m_assignTargetLayer = 0; ///< Calque cible du bouton « assigner ».
+	};
+}
+```
+
+- [ ] **Step 2 : Créer `src/world_editor/panels/LayersPanel.cpp`** :
+
+```cpp
+#include "src/world_editor/panels/LayersPanel.h"
+
+#include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/LayersDocument.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world::panels
+{
+	void LayersPanel::Render()
+	{
+#if defined(_WIN32)
+		if (!m_visible) return;
+		if (ImGui::Begin("Layers", &m_visible))
+		{
+			if (m_shell == nullptr)
+			{
+				ImGui::TextDisabled("Layers — shell non lié.");
+				ImGui::End();
+				return;
+			}
+
+			LayersDocument& doc = m_shell->MutableLayersDocument();
+
+			// Bouton d'assignement de la sélection au calque cible.
+			ImGui::SliderInt("Calque cible", &m_assignTargetLayer, 0, kLayerCount - 1);
+			if (ImGui::Button("Assigner la sélection à ce calque"))
+			{
+				const auto& sel = m_shell->GetSelection().SelectedSet();
+				for (const engine::editor::scene::EntityId& id : sel)
+				{
+					const uint64_t key = m_shell->EntityKeyFor(id);
+					if (key != 0ull)
+						doc.AssignEntity(key, static_cast<uint8_t>(m_assignTargetLayer));
+				}
+			}
+			ImGui::Separator();
+
+			// Liste des 16 calques : nom, visibilité, verrou, couleur.
+			for (uint8_t i = 0; i < kLayerCount; ++i)
+			{
+				Layer& layer = doc.LayerAt(i);
+				ImGui::PushID(static_cast<int>(i));
+
+				bool visible = layer.visible;
+				if (ImGui::Checkbox("##vis", &visible)) doc.SetVisible(i, visible);
+				ImGui::SameLine();
+
+				bool locked = layer.locked;
+				if (ImGui::Checkbox("##lock", &locked)) doc.SetLocked(i, locked);
+				ImGui::SameLine();
+
+				char buf[64];
+				std::snprintf(buf, sizeof(buf), "%s", layer.name.c_str());
+				if (ImGui::InputText("##name", buf, sizeof(buf)))
+					doc.SetLayerName(i, buf);
+
+				ImGui::SameLine();
+				float col[4] = {
+					((layer.overlayColorRgba >> 24) & 0xFF) / 255.0f,
+					((layer.overlayColorRgba >> 16) & 0xFF) / 255.0f,
+					((layer.overlayColorRgba >>  8) & 0xFF) / 255.0f,
+					( layer.overlayColorRgba        & 0xFF) / 255.0f };
+				if (ImGui::ColorEdit4("##col", col, ImGuiColorEditFlags_NoInputs))
+				{
+					layer.overlayColorRgba =
+						(static_cast<uint32_t>(col[0] * 255.0f) << 24) |
+						(static_cast<uint32_t>(col[1] * 255.0f) << 16) |
+						(static_cast<uint32_t>(col[2] * 255.0f) <<  8) |
+						(static_cast<uint32_t>(col[3] * 255.0f));
+				}
+
+				ImGui::PopID();
+			}
+		}
+		ImGui::End();
+#endif
+	}
+}
+```
+
+> `#include <cstdio>` est tiré via les en-têtes ImGui ; si `std::snprintf` manque, ajouter `#include <cstdio>` en tête.
+
+- [ ] **Step 3 : Enregistrer le panneau dans `WorldEditorShell.cpp::Init`** — après l'`emplace_back` du `ToolPropertiesPanel` (ligne 94) ou en fin de liste, ajouter (et inclure `#include "src/world_editor/panels/LayersPanel.h"` en tête du `.cpp`) :
+
+```cpp
+		auto layersPanel = std::make_unique<panels::LayersPanel>();
+		layersPanel->SetShell(this);
+		m_panels.emplace_back(std::move(layersPanel));
+```
+
+> Ne PAS réutiliser l'indexation fixe `m_panels[5]` ; on capture le pointeur localement avant le `move`. Le `SetShell(this)` du `ToolPropertiesPanel` existant (ligne 279) reste inchangé.
+
+- [ ] **Step 4 : Enregistrer la source dans `CMakeLists.txt`** — dans `engine_core`, près des autres panneaux (`src/world_editor/panels/...`) :
+
+```cmake
+  src/world_editor/panels/LayersPanel.cpp
+```
+
+- [ ] **Step 5 : Build + vérification visuelle** — lancer `lcdlln_world_editor.exe`, vérifier qu'un panneau « Layers » s'affiche avec 16 lignes (cases visibilité/verrou, nom éditable, couleur).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add src/world_editor/panels/LayersPanel.h src/world_editor/panels/LayersPanel.cpp src/world_editor/core/WorldEditorShell.cpp CMakeLists.txt
+git commit -m "feat(world_editor): panneau Layers (16 calques + assignement sélection)"
+```
+
+---
+
+### Task 9 : Outliner — Ctrl+clic multi-sélection
+
+**Files:**
+- Modify: `src/world_editor/panels/OutlinerPanel.h`
+- Modify: `src/world_editor/panels/OutlinerPanel.cpp`
+
+Contexte : l'Outliner sélectionne en mono (`m_selection->Select`). On ajoute le Ctrl+clic (toggle) et on surligne toute la multi-sélection (`IsSelected`). *(Périmètre : les toggles visibilité/verrou par calque vivent dans le `LayersPanel` — Task 8 ; la pastille de couleur de calque par ligne d'Outliner est différée pour garder la ligne simple. Le shell n'est donc PAS nécessaire ici.)*
+
+- [ ] **Step 1 : (aucun changement d'en-tête requis)** — `OutlinerPanel.h` reste inchangé : `m_selection` (déjà présent) suffit pour `IsSelected`/`ToggleInSelection`. Passer directement au Step 2.
+
+- [ ] **Step 2 : Gérer Ctrl+clic dans `RenderKindGroup`** — dans `OutlinerPanel.cpp`, remplacer le bloc `if (ImGui::Selectable(...))` par :
+
+```cpp
+				const bool selected = (m_selection != nullptr) && m_selection->IsSelected(e.id);
+				ImGui::PushID(static_cast<int>(e.id.index)
+					| (static_cast<int>(kind) << 24));
+				if (ImGui::Selectable(e.label.c_str(), selected))
+				{
+					if (m_selection != nullptr)
+					{
+						if (ImGui::GetIO().KeyCtrl)
+							m_selection->ToggleInSelection(e.id);
+						else
+							m_selection->Select(e.id);
+					}
+				}
+				ImGui::PopID();
+```
+
+> Note : on remplace `m_selection->Current() == e.id` par `IsSelected(e.id)` pour surligner toute la multi-sélection.
+
+- [ ] **Step 3 : Build + vérification** — lancer l'éditeur ; Ctrl+clic sur plusieurs entités de l'Outliner les surligne toutes ; clic simple en sélectionne une seule.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/world_editor/panels/OutlinerPanel.cpp
+git commit -m "feat(world_editor): Outliner — Ctrl+clic multi-sélection"
+```
+
+---
+
+### Task 10 : `ToolPropertiesPanel` — bloc `Select`
+
+**Files:**
+- Modify: `src/world_editor/panels/ToolPropertiesPanel.cpp`
+
+Contexte : quand `ActiveTool::Select`, afficher le rayon de pick, le mode, et le nombre d'entités sélectionnées. Le rayon de pick est stocké comme un état simple ; on le porte sur le shell pour que l'Engine le lise (Task 12). Pour le Lot 0, on l'expose via une variable membre du shell.
+
+- [ ] **Step 1 : Ajouter un champ « rayon de pick » au shell** — dans `WorldEditorShell.h`, section publique :
+
+```cpp
+		/// Lot 0 — Rayon de pick de l'outil Select (mètres monde), lu par l'Engine.
+		float  GetSelectPickRadiusMeters() const { return m_selectPickRadiusM; }
+		void   SetSelectPickRadiusMeters(float r) { m_selectPickRadiusM = r; }
+```
+
+section privée :
+
+```cpp
+		float m_selectPickRadiusM = 2.0f; // Lot 0
+```
+
+- [ ] **Step 2 : Ajouter le bloc UI** — dans `ToolPropertiesPanel.cpp`, repérer dans `Render()` la chaîne de `if (tool == ActiveTool::...)`. Ajouter un bloc (avant le placeholder par défaut) :
+
+```cpp
+			else if (tool == ActiveTool::Select)
+			{
+				ImGui::TextUnformatted("Outil : Sélection");
+				ImGui::Separator();
+				float r = m_shell->GetSelectPickRadiusMeters();
+				if (ImGui::SliderFloat("Rayon de pick (m)", &r, 0.25f, 20.0f, "%.2f"))
+					m_shell->SetSelectPickRadiusMeters(r);
+				ImGui::TextDisabled("Clic : sélectionne la plus proche.");
+				ImGui::TextDisabled("Glisser : rectangle (multi). Suppr : supprime.");
+				ImGui::Text("Sélection : %d entité(s)",
+					static_cast<int>(m_shell->GetSelection().SelectedSet().size()));
+			}
+```
+
+> Adapter `m_shell` / `tool` au code réel : vérifier comment `Render()` obtient `tool` (probablement `m_shell->GetActiveTool()`) et l'accès `m_shell`. S'aligner sur les blocs voisins (ex. `RenderCaveParams`).
+
+- [ ] **Step 3 : Build + vérification** — sélectionner l'outil « S » ; le panneau Tool Properties affiche le slider rayon + le compteur de sélection.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/world_editor/core/WorldEditorShell.h src/world_editor/panels/ToolPropertiesPanel.cpp
+git commit -m "feat(world_editor): Tool Properties — bloc outil Select (rayon + compteur)"
+```
+
+---
+
+## Phase 3 — Intégration Engine (vérifiée en application)
+
+### Task 11 : `Key::Delete` dans l'input
+
+**Files:**
+- Modify: `src/shared/platform/Input.h:45-62`
+
+- [ ] **Step 1 : Ajouter la touche** — dans l'enum `Key`, ajouter (à côté de `Escape = 0x1B`) :
+
+```cpp
+		Delete = 0x2E, ///< VK_DELETE — suppression de la sélection (éditeur).
+```
+
+- [ ] **Step 2 : Build, vérifier la compilation** — `m_down`/`m_pressed` sont indexés par le code VK (≤ 256) ; `WasPressed(Key::Delete)` fonctionne sans autre changement.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/shared/platform/Input.h
+git commit -m "feat(platform): touche Delete (VK_DELETE) dans l'enum Key"
+```
+
+---
+
+### Task 12 : Engine — candidats sélectionnables + routage clic/marquee `Select`
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` (bloc outils ≈ 9904-9965 ; bloc SceneModel/writers ≈ 8906-8963)
+
+Contexte : on installe le résolveur de clé (comme `SetTransformWriter`), on construit la liste des candidats (positions X/Z, filtrés calques cachés/verrouillés), et on route les clics/drag vers `EditorSelection`. Variables locales disponibles dans le bloc outils : `out.camera`, `vw`, `vh`, `pickX`, `pickZ`, `terrainPick`, `freeClick`, `m_input`.
+
+- [ ] **Step 1 : Installer le résolveur de clé d'entité** — dans le bloc `if (m_worldEditorSession)` (≈ 8906), après le `SetTransformWriter(...)`, ajouter :
+
+```cpp
+				m_worldEditorShell->SetEntityKeyResolver(
+					[this](engine::editor::scene::EntityId id) -> uint64_t
+					{
+						using K = engine::editor::scene::EntityKind;
+						if (id.kind == K::LayoutInstance && m_worldEditorSession)
+						{
+							const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+							if (id.index < insts.size())
+								return engine::editor::scene::MakeEntityKeyFromString(
+									K::LayoutInstance, insts[id.index].guid);
+						}
+						else if (id.kind == K::MeshInsert && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetMeshInsertDocument().All();
+							if (id.index < all.size())
+								return engine::editor::scene::MakeEntityKeyFromGuid(
+									K::MeshInsert, all[id.index].guid);
+						}
+						else if (id.kind == K::DungeonPortal && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetDungeonPortalDocument().All();
+							if (id.index < all.size())
+								return engine::editor::scene::MakeEntityKeyFromGuid(
+									K::DungeonPortal, all[id.index].guid);
+						}
+						return 0ull;
+					});
+```
+
+Ajouter en tête de `Engine.cpp` (avec les autres includes éditeur) :
+
+```cpp
+#include "src/world_editor/scene/EntityKey.h"
+#include "src/world_editor/scene/SelectionQuery.h"
+```
+
+> Vérifier le nom exact du champ guid : `MeshInsertInstance::guid` et `DungeonPortalInstance::guid` (uint64). Ajuster si le membre porte un autre nom (`guid`/`instanceGuid`).
+
+- [ ] **Step 2 : Construire un helper de candidats** — dans la même TU, ajouter une lambda/fonction locale (juste avant le bloc outils ≈ 9904) qui bâtit les candidats filtrés par calque :
+
+```cpp
+			// Lot 0 — candidats sélectionnables (X/Z), calques cachés/verrouillés exclus.
+			auto buildSelectables = [this]() -> std::vector<engine::editor::scene::SelectableEntity>
+			{
+				using K = engine::editor::scene::EntityKind;
+				std::vector<engine::editor::scene::SelectableEntity> out;
+				if (!m_worldEditorSession || !m_worldEditorShell) return out;
+				const auto& layers = m_worldEditorShell->GetLayersDocument();
+				auto pushIf = [&](engine::editor::scene::EntityId id, float x, float z)
+				{
+					const uint64_t key = m_worldEditorShell->EntityKeyFor(id);
+					if (key != 0ull && (!layers.IsEntityVisible(key) || layers.IsEntityLocked(key)))
+						return; // caché ou verrouillé -> non sélectionnable
+					out.push_back({ id, x, z });
+				};
+				const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+				for (uint32_t i = 0; i < insts.size(); ++i)
+					pushIf({ K::LayoutInstance, i },
+						static_cast<float>(insts[i].worldX), static_cast<float>(insts[i].worldZ));
+				const auto& mesh = m_worldEditorShell->GetMeshInsertDocument().All();
+				for (uint32_t i = 0; i < mesh.size(); ++i)
+					pushIf({ K::MeshInsert, i }, mesh[i].worldPosition.x, mesh[i].worldPosition.z);
+				const auto& dung = m_worldEditorShell->GetDungeonPortalDocument().All();
+				for (uint32_t i = 0; i < dung.size(); ++i)
+					pushIf({ K::DungeonPortal, i }, dung[i].worldPosition.x, dung[i].worldPosition.z);
+				return out;
+			};
+```
+
+> Vérifier les noms : `MeshInsertInstance::worldPosition` (Vec3) et `DungeonPortalInstance::worldPosition` — confirmés par `SetTransformWriter` (lignes 8944/8957). `layoutInstances[i].worldX/worldZ` sont des `double`.
+
+- [ ] **Step 3 : Router le clic simple** — dans la chaîne d'outils, après la branche `ValleyChain` (≈ ligne 9964), ajouter :
+
+```cpp
+				else if (tool == engine::editor::world::ActiveTool::Select)
+				{
+					modernEditActive = true;
+					if (freeClick && terrainPick
+						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						const auto cands = buildSelectables();
+						const float radius = m_worldEditorShell->GetSelectPickRadiusMeters();
+						auto hit = engine::editor::scene::PickNearest(cands, pickX, pickZ, radius);
+						if (hit.has_value())
+							m_worldEditorShell->MutableSelection().Select(*hit);
+						else
+							m_worldEditorShell->MutableSelection().Clear();
+					}
+				}
+```
+
+- [ ] **Step 4 : Build + vérification** — sélectionner l'outil S ; cliquer près d'un prop posé → il devient sélectionné (surligné dans l'Outliner + compteur Tool Properties = 1) ; cliquer dans le vide → désélection.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(world_editor): Engine — résolveur de clé + pick simple outil Select"
+```
+
+---
+
+### Task 13 : Engine — marquee rectangle (multi-sélection au drag)
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` (branche `ActiveTool::Select`)
+
+Contexte : on capte le début du drag (point sol au press) et la fin (point sol au release), on construit un `SelectionRect` monde, on appelle `PickInRect`. État de drag stocké en membres `Engine` (ajoutés). Shift = additif au set.
+
+- [ ] **Step 1 : Ajouter l'état de drag à `Engine.h`** — dans la classe `Engine`, près des autres membres éditeur :
+
+```cpp
+	bool  m_editorMarqueeActive = false;
+	float m_editorMarqueeStartX = 0.0f;
+	float m_editorMarqueeStartZ = 0.0f;
+```
+
+- [ ] **Step 2 : Étendre la branche `Select`** — remplacer le corps de la branche `ActiveTool::Select` (Task 12 Step 3) par la version gérant clic ET marquee :
+
+```cpp
+				else if (tool == engine::editor::world::ActiveTool::Select)
+				{
+					modernEditActive = true;
+					if (freeClick && terrainPick)
+					{
+						const bool shift = m_input.IsDown(engine::platform::Key::Shift);
+						if (m_input.WasMousePressed(engine::platform::MouseButton::Left))
+						{
+							m_editorMarqueeActive = true;
+							m_editorMarqueeStartX = pickX;
+							m_editorMarqueeStartZ = pickZ;
+						}
+						if (m_editorMarqueeActive
+							&& m_input.WasMouseReleased(engine::platform::MouseButton::Left))
+						{
+							m_editorMarqueeActive = false;
+							const float dx = pickX - m_editorMarqueeStartX;
+							const float dz = pickZ - m_editorMarqueeStartZ;
+							const auto cands = buildSelectables();
+							const float radius = m_worldEditorShell->GetSelectPickRadiusMeters();
+							// Drag négligeable -> clic simple ; sinon -> rectangle.
+							if (dx * dx + dz * dz < radius * radius)
+							{
+								auto hit = engine::editor::scene::PickNearest(cands, pickX, pickZ, radius);
+								if (hit.has_value()) m_worldEditorShell->MutableSelection().Select(*hit);
+								else if (!shift) m_worldEditorShell->MutableSelection().Clear();
+							}
+							else
+							{
+								engine::editor::world::SelectionRect rect;
+								rect.minX = m_editorMarqueeStartX; rect.maxX = pickX;
+								rect.minZ = m_editorMarqueeStartZ; rect.maxZ = pickZ;
+								auto ids = engine::editor::scene::PickInRect(cands, rect);
+								if (shift)
+									for (const auto& id : ids) m_worldEditorShell->MutableSelection().ToggleInSelection(id);
+								else
+									m_worldEditorShell->MutableSelection().SelectMany(ids);
+							}
+						}
+					}
+				}
+```
+
+> `SelectionRect::Normalize()` est appelé par `SelectInRect` ; on n'a donc pas à trier min/max ici.
+
+- [ ] **Step 3 : Build + vérification** — outil S ; glisser un rectangle au sol par-dessus plusieurs props → tous sélectionnés (compteur > 1) ; Shift+glisser → ajoute/retire au set existant.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp src/client/app/Engine.h
+git commit -m "feat(world_editor): Engine — marquee rectangle multi-sélection (outil Select)"
+```
+
+---
+
+### Task 14 : Engine — suppression réversible (touche Suppr) + `Mutable()` docs
+
+**Files:**
+- Modify: `src/world_editor/volumes/MeshInsertDocument.h`
+- Modify: `src/world_editor/volumes/dungeons/DungeonPortalDocument.h`
+- Modify: `src/client/app/Engine.cpp` (forward Suppr + build/push commande)
+
+Contexte : la touche Suppr (forwardée comme les autres raccourcis ≈ Engine.cpp:7720) construit une `DeleteEntitiesCommand` dont les callbacks utilisent `RemoveByIndexDescending`/`RestoreByIndexAscending` sur les 3 conteneurs. Les docs mesh/dungeon exposent un accès mutable au vecteur (comme `PlacementDocument::Mutable`).
+
+- [ ] **Step 1 : Ajouter `Mutable()` aux deux docs** — dans `MeshInsertDocument.h`, après `All()` :
+
+```cpp
+		/// Lot 0 — Accès mutable au vecteur (suppression réversible par index).
+		/// Le caller est responsable de `MarkDirty()` après mutation.
+		std::vector<MeshInsertInstance>& Mutable() { return m_instances; }
+```
+
+Dans `DungeonPortalDocument.h`, après `All()` :
+
+```cpp
+		/// Lot 0 — Accès mutable au vecteur (suppression réversible par index).
+		std::vector<DungeonPortalInstance>& Mutable() { return m_instances; }
+		void MarkDirty() noexcept { m_dirty = true; }
+```
+
+(MeshInsertDocument a déjà `MarkDirty()`.)
+
+- [ ] **Step 2 : Forwarder la touche Suppr** — dans `Engine.cpp` (≈ 7720, bloc `if (m_worldEditorShell && IsInitialized())` qui gère Z/Y), ajouter, mais **uniquement** quand l'outil Select est actif et qu'il y a une sélection, construire et pousser la commande. Préférable : un bloc dédié juste après le dispatch Z/Y :
+
+```cpp
+				if (m_input.WasPressed(engine::platform::Key::Delete)
+					&& m_worldEditorShell->GetActiveTool() == engine::editor::world::ActiveTool::Select
+					&& m_worldEditorSession)
+				{
+					const auto& set = m_worldEditorShell->GetSelection().SelectedSet();
+					if (!set.empty())
+					{
+						std::vector<engine::editor::scene::EntityId> ids(set.begin(), set.end());
+
+						auto remove = [this](const std::vector<engine::editor::scene::EntityId>& sel)
+							-> engine::editor::scene::DeletedEntities
+						{
+							using K = engine::editor::scene::EntityKind;
+							std::vector<uint32_t> layoutIdx, meshIdx, dungIdx;
+							const auto& layers = m_worldEditorShell->GetLayersDocument();
+							for (const auto& id : sel)
+							{
+								const uint64_t key = m_worldEditorShell->EntityKeyFor(id);
+								if (key != 0ull && layers.IsEntityLocked(key)) continue; // calque verrouillé
+								if (id.kind == K::LayoutInstance) layoutIdx.push_back(id.index);
+								else if (id.kind == K::MeshInsert)  meshIdx.push_back(id.index);
+								else if (id.kind == K::DungeonPortal) dungIdx.push_back(id.index);
+							}
+							engine::editor::scene::DeletedEntities snap;
+							snap.layout = engine::editor::scene::RemoveByIndexDescending(
+								m_worldEditorSession->MutableDoc().layoutInstances, layoutIdx);
+							snap.mesh = engine::editor::scene::RemoveByIndexDescending(
+								m_worldEditorShell->MutableMeshInsertDocument().Mutable(), meshIdx);
+							snap.dungeon = engine::editor::scene::RemoveByIndexDescending(
+								m_worldEditorShell->MutableDungeonPortalDocument().Mutable(), dungIdx);
+							m_worldEditorShell->MutableMeshInsertDocument().MarkDirty();
+							m_worldEditorShell->MutableDungeonPortalDocument().MarkDirty();
+							return snap;
+						};
+						auto restore = [this](const engine::editor::scene::DeletedEntities& snap)
+						{
+							engine::editor::scene::RestoreByIndexAscending(
+								m_worldEditorSession->MutableDoc().layoutInstances, snap.layout);
+							engine::editor::scene::RestoreByIndexAscending(
+								m_worldEditorShell->MutableMeshInsertDocument().Mutable(), snap.mesh);
+							engine::editor::scene::RestoreByIndexAscending(
+								m_worldEditorShell->MutableDungeonPortalDocument().Mutable(), snap.dungeon);
+							m_worldEditorShell->MutableMeshInsertDocument().MarkDirty();
+							m_worldEditorShell->MutableDungeonPortalDocument().MarkDirty();
+						};
+
+						m_worldEditorShell->MutableCommandStack().Push(
+							std::make_unique<engine::editor::scene::DeleteEntitiesCommand>(
+								std::move(ids), std::move(remove), std::move(restore)));
+						m_worldEditorShell->MutableSelection().Clear();
+						m_worldEditorShell->MarkDirty("delete selection");
+					}
+				}
+```
+
+Ajouter l'include en tête de `Engine.cpp` :
+
+```cpp
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
+```
+
+> Lifetime : la commande capture `[this]` (Engine), comme `SetTransformWriter` ; pas de référence directe aux vecteurs ⇒ pas de dangling si la session est recréée tant que la pile est vidée à chaque nouvelle carte. **Vérifier** que `CommandStack::Clear()` est appelé au chargement/à la création d'une carte ; sinon ajouter l'appel (hors périmètre si déjà présent).
+
+- [ ] **Step 3 : Build + vérification** — outil S ; sélectionner un/plusieurs props ; Suppr → disparaissent (Outliner se met à jour) ; Ctrl+Z → réapparaissent à leur place exacte ; Ctrl+Y → re-supprimés. Une entité sur un calque verrouillé n'est pas supprimée.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/world_editor/volumes/MeshInsertDocument.h src/world_editor/volumes/dungeons/DungeonPortalDocument.h src/client/app/Engine.cpp
+git commit -m "feat(world_editor): Engine — suppression réversible de la sélection (Suppr)"
+```
+
+---
+
+### Task 15 : Gating de visibilité — marqueurs `layoutInstances` cachés
+
+**Files:**
+- Modify: `src/world_editor/ui/WorldEditorImGui.h` (struct `WorldEditorViewportOverlayDesc`)
+- Modify: `src/world_editor/ui/WorldEditorImGui.cpp:341-360`
+- Modify: `src/client/app/Engine.cpp` (remplir le masque)
+
+Contexte : l'overlay dessine un **marqueur** (cercle) par instance, indexé par `ii` (WorldEditorImGui.cpp:345). On ajoute un set d'indices cachés ; le marqueur est sauté si l'index y figure. *(Le masquage du mesh 3D complet par calque est hors Lot 0 — cf. spec : marqueur + sélectabilité seulement.)*
+
+- [ ] **Step 1 : Ajouter le champ masque à la struct** — dans `WorldEditorImGui.h`, struct `WorldEditorViewportOverlayDesc`, après `selectedLayoutInstanceOverlay` :
+
+```cpp
+		/// Lot 0 — Indices d'instances de layout à NE PAS dessiner (calque caché).
+		/// Pointeur non possédé ; nullptr = tout visible.
+		const std::vector<uint8_t>* layoutInstanceHiddenMask = nullptr;
+```
+
+> On utilise un masque `vector<uint8_t>` aligné sur l'index `ii` (1 = caché). Plus simple/rapide qu'un set pour une itération indexée.
+
+- [ ] **Step 2 : Sauter les marqueurs cachés** — dans `WorldEditorImGui.cpp`, dans la boucle (ligne 345), juste après `const ... inst = (*d.layoutInstancesOverlay)[ii];` :
+
+```cpp
+						if (d.layoutInstanceHiddenMask != nullptr
+							&& ii < d.layoutInstanceHiddenMask->size()
+							&& (*d.layoutInstanceHiddenMask)[ii] != 0)
+							continue;
+```
+
+- [ ] **Step 3 : Remplir le masque côté Engine** — là où `overlay.layoutInstancesOverlay` est assigné (Engine.cpp:9855), construire le masque dans un membre `Engine` (durée de vie ≥ la frame) :
+
+Ajouter à `Engine.h` : `std::vector<uint8_t> m_editorLayoutHiddenMask;`
+
+Puis après l'assignation de `overlay.layoutInstancesOverlay` :
+
+```cpp
+				// Lot 0 — masque de visibilité par calque (marqueurs).
+				{
+					const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+					const auto& layers = m_worldEditorShell->GetLayersDocument();
+					m_editorLayoutHiddenMask.assign(insts.size(), 0u);
+					for (uint32_t i = 0; i < insts.size(); ++i)
+					{
+						const uint64_t key = m_worldEditorShell->EntityKeyFor(
+							{ engine::editor::scene::EntityKind::LayoutInstance, i });
+						if (key != 0ull && !layers.IsEntityVisible(key))
+							m_editorLayoutHiddenMask[i] = 1u;
+					}
+					overlay.layoutInstanceHiddenMask = &m_editorLayoutHiddenMask;
+				}
+```
+
+- [ ] **Step 4 : Build + vérification** — assigner des props à un calque, le rendre invisible dans le panneau Layers → leurs marqueurs disparaissent du viewport ; les rendre visibles → réapparaissent. (Le mesh 3D reste, c'est attendu pour le Lot 0.)
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/world_editor/ui/WorldEditorImGui.h src/world_editor/ui/WorldEditorImGui.cpp src/client/app/Engine.cpp src/client/app/Engine.h
+git commit -m "feat(world_editor): gating de visibilité des marqueurs layoutInstances par calque"
+```
+
+---
+
+## Vérification finale (avant PR)
+
+- [ ] **Build complet Windows** (`world_editor_app` + jeu) sans erreur/warning bloquant (`/W4`).
+- [ ] **Build Linux + ctest** : les 5 nouvelles/étendues cibles passent :
+  `editor_selection_tests`, `entity_key_tests`, `selection_query_tests`, `delete_entities_ops_tests`, `delete_entities_command_tests`.
+- [ ] **Parcours manuel éditeur** : pick simple, marquee, Ctrl+clic Outliner, Suppr + Undo/Redo exact, assignement calque, visibilité/verrou (marqueur + sélectabilité).
+- [ ] **Mention déploiement dans la PR** : ✅ client/éditeur uniquement, pas de redéploiement serveur.
+
+---
+
+## Notes pour l'implémenteur (pièges connus)
+
+1. **Ne pas toucher** aux pipelines de rasterization (`frontFace`/`cullMode`) : aucun rapport, et c'est une garde anti-régression (CLAUDE.md).
+2. **Noms de champs à confirmer au câblage** : `MeshInsertInstance::worldPosition` / `::guid`, `DungeonPortalInstance::worldPosition` / `::guid` — vérifiés via `SetTransformWriter` (Engine.cpp:8937-8960) mais re-confirmer en ouvrant les headers `MeshInsertInstance.h` / `DungeonPortalInstance.h`.
+3. **Tests Linux non gatés `_WIN32`** : les 5 cibles de test doivent compiler sans ImGui (le cœur pur n'en dépend pas). Ne jamais inclure `imgui.h` dans les fichiers `scene/`.
+4. **Hors périmètre, ne pas dériver** : pas de persistance de calque, pas de masquage 3D des meshes, pas de réveil des orphelins `PropInstance`, pas d'unification des deux modèles. Ce sont des tickets futurs (cf. spec §8).
+5. **`CommandStack::Clear()` au changement de carte** : vérifier l'existant pour éviter des commandes de suppression pointant vers une session recréée. Ajouter l'appel si manquant (petit ; sinon documenter).

--- a/docs/superpowers/specs/2026-06-10-editeur-niveau-lot0-fondation-design.md
+++ b/docs/superpowers/specs/2026-06-10-editeur-niveau-lot0-fondation-design.md
@@ -1,0 +1,250 @@
+# Éditeur de niveau — Lot 0 : Fondation d'édition (Selection / Delete / Layers)
+
+- **Date** : 2026-06-10
+- **Périmètre** : `src/world_editor/` + routage input éditeur dans `src/client/app/Engine.cpp`
+- **Statut** : design validé, prêt pour plan d'implémentation
+- **Déploiement** : ✅ client/éditeur uniquement — **pas de redéploiement serveur** (aucun
+  opcode, aucun format binaire exporté, aucune migration DB touchés).
+
+---
+
+## 1. Contexte & motivation
+
+L'éditeur de monde (`lcdlln_world_editor.exe`, ~47 000 lignes) embarque beaucoup de code
+« noyau + tests » jamais branché à l'UI. L'audit du 2026-06-05
+(`docs/audit/2026-06-05-editeur-carte-audit.md`, Thème 1) a recensé **14 outils
+inatteignables**. Rendre l'éditeur réellement utilisable passe d'abord par une **fondation
+d'édition** : pouvoir **sélectionner**, **supprimer** et **organiser en calques** les objets
+déjà posés. Sans elle, tout outil de pose (Placement, Forest, Bridge…) est inexploitable :
+on ne peut ni re-sélectionner, ni effacer, ni masquer ce qu'on a placé.
+
+Ce Lot 0 est le premier d'une série de lots de câblage. Lots suivants (hors périmètre ici) :
+Lot 1 (Bridge/Wall/Spline), Lot 2 (Placement/Foliage/Forest), Lot 3 (Zone/Hazard/WindZone/
+Field/Hamlet).
+
+## 2. Décision d'architecture centrale : le modèle d'objets cible
+
+Il existe **deux modèles d'objets placés en parallèle** dans la base :
+
+| Modèle | Type | Clé | État |
+|---|---|---|---|
+| **Vivant** | `WorldMapEditDocument::layoutInstances` (`WorldMapEditLayoutInstance`) | `guid` (string) + index | rendu, affiché Outliner/Inspector, sélectionné par `EditorSelection`, persisté JSON |
+| **Orphelin** | `PlacementDocument::m_props` (`PropInstance`) | `uint32 instanceId` | non instancié dans le shell (audit 7.2) |
+
+Les outils orphelins du Lot 0 (`SelectionTool` → liste de `uint32`, `DeleteCommand` →
+`std::vector<PropInstance>&`) ont été codés contre le modèle **orphelin**.
+
+**Décision (approche A)** : le Lot 0 opère sur le **modèle vivant** (`layoutInstances`).
+Conséquences :
+- On réutilise **la géométrie pure** de `SelectionTool` (`SelectInRect`/`SelectInLasso`) mais
+  on l'alimente avec les `layoutInstances` et on remappe le résultat vers `EntityId`.
+- On écrit une **nouvelle** commande de suppression sur le modèle vivant
+  (`DeleteEntitiesCommand`). Le `DeleteCommand`/`PropInstance` orphelin reste **parqué**
+  (réveillé au Lot 2 si `PlacementDocument` devient canonique).
+- L'unification des deux modèles est un **ticket futur** explicite (hors périmètre).
+
+## 3. Outillage existant réutilisé (ne pas réinventer)
+
+- **Raycast viewport→sol** : `RaycastTerrainFromCamera(camera, vw, vh, mx, my, …) → (X,Z)`
+  (`Engine.cpp:770`). Donne les coordonnées monde X/Z d'un clic.
+- **Pattern de dispatch par `EntityId`** : `SetTransformWriter` (`Engine.cpp:8919`) — l'Engine
+  installe un foncteur capturant les docs concrets et écrit par `EntityId`. Le Delete suivra
+  **exactement** ce pattern (« delete dispatcher »).
+- **Overlay de rendu** des `layoutInstances` (`Engine.cpp:9855`,
+  `overlay.layoutInstancesOverlay`) — point d'accroche pour le gating de calque.
+- **`SceneModel.Rebuild()`** appelé chaque frame (`Engine.cpp:8912`) : reflète immédiatement
+  placements/suppressions.
+- **Géométrie pure** : `SelectInRect` / `SelectInLasso` (`SelectionTool.{h,cpp}`).
+- **`LayersDocument`** (`LayersDocument.h`) : 16 calques (nom/visibilité/verrou/couleur) +
+  table d'assignement `entityKey(uint64) → layerIndex`. Logique pure déjà testée.
+- **`EditorSelection`** (`scene/EditorSelection.h`) : mono-sélection actuelle (`m_current`).
+- **`CommandStack`** : undo/redo (Ctrl+Z/Y déjà branchés).
+
+## 4. Composants à livrer
+
+### 4.1 `ActiveTool::Select` (outil mode)
+
+- Ajouter `Select` à l'enum `ActiveTool` (`WorldEditorShell.h`).
+- Ajouter à `EditorToolbar::m_orderedTools` + icône/lettre/tooltip FR dans `ToolbarIconAtlas`.
+- C'est le **seul** des trois composants qui est un *mode* d'outil. Delete = action ;
+  Layers = panneau.
+- Aucun outil concret à instancier comme membre du shell pour la sélection : la logique de
+  picking vit dans l'Engine (routage input) + `EditorSelection` (état). `SelectionTool` reste
+  une bibliothèque de géométrie pure appelée par l'Engine.
+
+### 4.2 Extension multi-sélection de `EditorSelection` (rétrocompatible)
+
+- Conserver `m_current` comme **primaire** ; `Current()`, `HasSelection()`, `Select(id)`,
+  `Clear()`, `SetOnChanged` **inchangés** (Outliner/Inspector continuent de marcher).
+- Ajouter un **set** ordonné de `EntityId` sélectionnés et les API :
+  - `void SelectMany(const std::vector<EntityId>& ids)` — remplace le set, primaire = premier.
+  - `void ToggleInSelection(EntityId id)` — ajoute/retire ; ajuste le primaire.
+  - `const std::vector<EntityId>& SelectedSet() const`
+  - `bool IsSelected(EntityId id) const`
+- `Select(id)` mono = `Clear` set + add + primaire (comportement actuel préservé).
+- Le callback `OnChanged` est invoqué sur tout changement effectif (set inclus).
+- **Inspector** : édite **le primaire** uniquement (pas de multi-édition de transform au Lot 0).
+- **Outliner** : clic = `Select` mono (comportement actuel) ; **Ctrl+clic** = `ToggleInSelection`.
+
+### 4.3 Picking viewport (routage dans `Engine.cpp`, branche `ActiveTool::Select`)
+
+Brancher dans la chaîne `if (tool == …)` (près de `Engine.cpp:9907`).
+
+- **Construire la liste des entités sélectionnables** (chaque frame d'interaction, ou à la
+  demande) : pour chaque kind couvert (LayoutInstance / MeshInsert / DungeonPortal), produire
+  des `SelectablePoint{ id = encodage(EntityId), x, z }` à partir de la position monde de
+  l'entité. `id` encode `(kind, index)` sur 32 bits (ex. 8 bits kind + 24 bits index — borné,
+  largement suffisant) pour transiter par l'API `uint32` de `SelectionTool`, décodé au retour.
+- **Clic simple** : raycast → (X,Z) ; sélectionner l'entité **la plus proche en X/Z** sous un
+  **rayon de pick** (paramètre monde, ex. dérivé d'un nombre de pixels via la distance caméra) ;
+  `Select(primaire)`. Si rien sous le rayon → `Clear`.
+- **Marquee drag** : capter début/fin de drag ; raycast des coins (rect) ou points (lasso) →
+  rect/lasso **monde X/Z** ; `SelectInRect`/`SelectInLasso` sur les `SelectablePoint` ;
+  `SelectMany`. Modificateur (Shift) = additif au set existant (optionnel ; sinon remplace).
+- **Exclusion** : les entités d'un calque **caché ou verrouillé** ne sont **pas**
+  sélectionnables (filtrées avant l'appel géométrie).
+- **Limite assumée & documentée** : la sélection raisonne en projection top-down X/Z
+  (cohérent avec le header de `SelectionTool`). En perspective rasante, le marquee est
+  approximatif. Acceptable pour le MVP éditeur (caméra souvent top-down) ; un picking
+  écran-espace exact est un raffinement ultérieur.
+
+### 4.4 `DeleteEntitiesCommand` (nouvelle, réversible)
+
+Fichier neuf (PascalCase) sous `src/world_editor/`, p. ex. `scene/DeleteEntitiesCommand.{h,cpp}`.
+
+- **Pattern « delete dispatcher »** calqué sur `SetTransformWriter` : l'Engine installe sur le
+  shell un foncteur `DeleteWriter`/`EntityDeleter` capturant les docs concrets. Deux primitives
+  par kind : *retirer par index* (Execute) et *réinsérer (index, copie)* (Undo). Le shell
+  expose `SetEntityDeleter(...)` (jumeau de `SetTransformWriter`).
+- **Execute** : grouper la sélection **par kind** ; pour chaque doc, **trier les indices
+  décroissants**, `erase`, et snapshot `(index, copie)`.
+- **Undo** : réinsérer par index **croissant** par doc → ordre initial reconstruit exactement.
+- **Déclenchement** : touche **Suppr** (l'Engine forwarde `VK_DELETE` au shell — aujourd'hui
+  seuls Z/Y sont forwardés) + entrée de menu. Supprime **tout le set** sélectionné. No-op si
+  set vide. Après Execute, vider la sélection.
+- **Couverture kinds** : LayoutInstance (priorité — arbres/props), MeshInsert, DungeonPortal.
+  Terrain/Water **non supprimables** (Terrain est implicite ; Water n'a pas de transform simple
+  et est hors SceneModel).
+- **Calque verrouillé** : les entités d'un calque verrouillé sont exclues de la suppression.
+- **Limite assumée & documentée** : `EntityId.index` n'est pas stable après édition
+  structurelle (audit 2.7). Le delete étant **immédiat** sur la sélection courante (même
+  frame), et l'undo réinsérant aux index capturés, c'est sûr en pratique — **même compromis
+  déjà assumé par `SetEntityTransformCommand`**. À documenter dans le `.h`.
+
+### 4.5 Câblage des calques (`LayersDocument`)
+
+- **Clé stable** : `entityKey = FNV1a(prefixe_kind + guid)`. Les 3 types portent un `guid`
+  (string). La clé **survit aux `Rebuild`** (contrairement à l'index). Helper unique
+  `uint64_t MakeEntityKey(EntityKind, std::string_view guid)` (réutiliser un FNV existant ;
+  l'audit Thème 8 note FNV-1a réécrit 3× — **factoriser**, ne pas en ajouter un 4e).
+  Résolution `EntityId → guid` via le doc concret (le shell/Engine sait le faire).
+- **Nouveau panneau `LayersPanel`** (`panels/LayersPanel.{h,cpp}`, implémente `IPanel`,
+  ajouté à `m_panels`) :
+  - liste des 16 calques : renommer, toggle visibilité, toggle verrou, couleur d'overlay ;
+  - bouton **« Assigner la sélection au calque N »** → `AssignEntity(entityKey, N)` pour chaque
+    entité du set ;
+  - indicateur du nombre d'entités par calque.
+- **Gating rendu** : dans le remplissage de `overlay.layoutInstancesOverlay` (`Engine.cpp:9855`),
+  **exclure** les entités dont `LayersDocument::IsEntityVisible(entityKey) == false`.
+  *(MeshInsert/Dungeon : gating de rendu différé si leur overlay n'a pas de hook équivalent —
+  à confirmer au plan ; la visibilité reste portée par le document pour cohérence.)*
+- **Verrou** : consulté par le picking (4.3) et le Delete (4.4).
+- **Outliner** : pastille couleur du calque + toggles visibilité/verrou par ligne (lecture/écrit
+  `LayersDocument`).
+- **Persistance** : assignement en mémoire uniquement (conforme au header `LayersDocument.h`).
+  La persistance d'un `layerIndex` dans les formats binaires/JSON est **différée** (ticket
+  ultérieur, bump de version dédié). À noter : à ce stade les calques ne survivent pas à un
+  rechargement de carte — comportement assumé du Lot 0.
+
+### 4.6 `ToolbarIconAtlas` & `ToolPropertiesPanel`
+
+- `ToolbarIconAtlas::Get(ActiveTool::Select)` : lettre/couleur/tooltip FR (« Sélection »).
+- `ToolPropertiesPanel` quand `ActiveTool::Select` : afficher le **rayon de pick**, le mode
+  (rect/lasso), et le compte d'entités sélectionnées. Pas de propriété lourde au Lot 0.
+
+## 5. Flux de données
+
+```
+Clic / drag viewport (ActiveTool::Select)
+  └─ Engine: RaycastTerrainFromCamera → (X,Z) [+ marquee corners]
+       └─ filtre calques cachés/verrouillés
+            └─ SelectionTool::SelectInRect/Lasso  (géométrie pure)  [marquee]
+            └─ nearest-by-XZ sous rayon                              [clic]
+                 └─ EditorSelection (set + primaire)
+                      ├─ Outliner / Inspector lisent (primaire = Inspector, set = surbrillance)
+                      └─ LayersPanel: « assigner sélection au calque »
+
+Suppr
+  └─ DeleteEntitiesCommand (push CommandStack)
+       └─ EntityDeleter (foncteur Engine) mute docs concrets (erase index décroissants)
+            └─ SceneModel.Rebuild() (frame suivante) → UI à jour
+       └─ Undo: réinsertion index croissants → état exact
+
+Rendu
+  └─ overlay.layoutInstancesOverlay filtré par LayersDocument::IsEntityVisible(entityKey)
+```
+
+## 6. Stratégie de tests (headless, sans ImGui — testables sur Linux/CI)
+
+- **`EditorSelection` multi** : `SelectMany`/`ToggleInSelection`/primaire/`IsSelected`/`Clear` ;
+  rétrocompat `Select` mono ; callback `OnChanged` sur changement effectif uniquement.
+- **`DeleteEntitiesCommand`** : Execute retire les bons index ; Undo restitue **exactement**
+  (ordre + contenu) ; multi-kind ; indices décroissants ; set vide = no-op ; exclusion calque
+  verrouillé.
+- **Mapping marquee** : encodage/décodage `EntityId ↔ uint32` ; rect/lasso monde → ensemble
+  d'`EntityId` attendu (réutilise les tests existants de `SelectInRect/Lasso` + un test
+  d'intégration de projection).
+- **Picking clic** : nearest-by-XZ sous rayon ; aucun candidat → `Clear` ; exclusion calques
+  cachés/verrouillés.
+- **`LayersDocument` + clé stable** : `MakeEntityKey` déterministe et stable au `Rebuild` ;
+  `IsEntityVisible`/`IsEntityLocked` ; gating logique (« entité d'un calque caché absente de la
+  liste de rendu »).
+- **Factorisation FNV** : test que le helper unique donne le même hash que les usages existants
+  qu'il remplace (non-régression).
+
+> Les parties ImGui (`LayersPanel::Render`, toolbar, ToolProperties) restent gardées `_WIN32`
+> et non testées headless, conformément à la convention de l'éditeur.
+
+## 7. Points de couture (récapitulatif d'intégration)
+
+| # | Fichier | Changement |
+|---|---|---|
+| 1 | `core/WorldEditorShell.h` | `ActiveTool::Select` ; `SetEntityDeleter(...)` + membre `LayersDocument` + accesseurs ; accès `EditorSelection` (déjà présent) |
+| 2 | `ui/EditorToolbar.cpp` | `Select` dans `m_orderedTools` |
+| 3 | `ui/ToolbarIconAtlas.*` | icône/tooltip `Select` |
+| 4 | `scene/EditorSelection.{h,cpp}` | set + API multi |
+| 5 | `scene/DeleteEntitiesCommand.{h,cpp}` | **nouveau** (ICommand) |
+| 6 | `panels/LayersPanel.{h,cpp}` | **nouveau** (IPanel) ; ajout à `m_panels` |
+| 7 | `panels/OutlinerPanel.cpp` | Ctrl+clic toggle ; pastille couleur + toggles calque |
+| 8 | `panels/ToolPropertiesPanel.cpp` | bloc `Select` (rayon, mode, compte) |
+| 9 | un util commun | `MakeEntityKey` + factorisation FNV-1a (supprime 2 doublons) |
+| 10 | `src/client/app/Engine.cpp` | routage picking (clic/marquee) ; forward `VK_DELETE` ; install `EntityDeleter` ; gating overlay par calque |
+| 11 | tests | nouveaux fichiers de tests + entrées CMake |
+
+> Convention CMake (cf. mémoire) : tout nouveau `.cpp` partagé côté serveur doit être ajouté à
+> la liste `server_app` — **non applicable ici** (tout est éditeur/client, dans `engine_core`).
+> Vérifier néanmoins que les nouveaux `.cpp` sont bien pris par le build de `engine_core`.
+
+## 8. Hors périmètre (différé, assumé)
+
+- `DeleteCommand`/`SelectionTool`-sur-`PropInstance` orphelins → **parqués** pour le Lot 2.
+- **Unification** des deux modèles d'objets (layoutInstances ↔ props) → ticket futur dédié.
+- **Persistance** d'un `layerIndex` dans les formats binaires/JSON → différée (bump version).
+- **Multi-édition** de transform dans l'Inspector → un primaire seulement au Lot 0.
+- **Picking écran-espace exact** en perspective → raffinement ultérieur (top-down X/Z au Lot 0).
+- Gating de rendu MeshInsert/Dungeon si pas de hook overlay équivalent → à confirmer au plan.
+
+## 9. Risques & mitigations
+
+| Risque | Mitigation |
+|---|---|
+| Index `EntityId` instable entre Execute et Undo | Delete immédiat sur set courant ; undo aux index capturés ; même compromis que l'existant. Documenté. |
+| 4e copie de FNV-1a | Factoriser en un helper unique + test de non-régression (réduit la dette Thème 8). |
+| Marquee approximatif en perspective | Assumé/documenté ; éditeur souvent top-down ; écran-espace = raffinement futur. |
+| Calques non persistés (perte au reload) | Comportement assumé du Lot 0 ; persistance = ticket version-bump. Mention UI possible. |
+| Régression winding/culling rendu | Aucun pipeline rasterization touché — **ne pas** modifier `frontFace`/`cullMode` (cf. CLAUDE.md). |
+
+## 10. Déploiement
+
+> **Déploiement** : ✅ client/éditeur uniquement, **pas de redéploiement serveur**. Aucun
+> opcode, format binaire exporté (LCDP/LCVC/LCMI), ni migration DB n'est touché.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7731,6 +7731,65 @@ namespace engine
 				m_worldEditorShell->HandleShortcut('Z', ctrl, shift);
 			if (m_input.WasPressed(engine::platform::Key::Y))
 				m_worldEditorShell->HandleShortcut('Y', ctrl, shift);
+
+			// Lot 0 (Phase C) — Suppr : supprime la sélection courante via une
+			// DeleteEntitiesCommand réversible (callbacks capturant [this]).
+			// Uniquement quand l'outil Select est actif, la session présente,
+			// et la sélection non vide. Les entités sur calque verrouillé sont
+			// ignorées. La pile undo/redo est linéaire immédiat (cf. spec §4.4).
+			if (m_input.WasPressed(engine::platform::Key::Delete)
+				&& m_worldEditorShell->GetActiveTool() == engine::editor::world::ActiveTool::Select
+				&& m_worldEditorSession)
+			{
+				const auto& set = m_worldEditorShell->GetSelection().SelectedSet();
+				if (!set.empty())
+				{
+					std::vector<engine::editor::scene::EntityId> ids(set.begin(), set.end());
+
+					auto remove = [this](const std::vector<engine::editor::scene::EntityId>& sel)
+						-> engine::editor::scene::DeletedEntities
+					{
+						using K = engine::editor::scene::EntityKind;
+						std::vector<uint32_t> layoutIdx, meshIdx, dungIdx;
+						const auto& layers = m_worldEditorShell->GetLayersDocument();
+						for (const auto& id : sel)
+						{
+							const uint64_t key = m_worldEditorShell->EntityKeyFor(id);
+							if (key != 0ull && layers.IsEntityLocked(key)) continue; // calque verrouillé
+							if (id.kind == K::LayoutInstance) layoutIdx.push_back(id.index);
+							else if (id.kind == K::MeshInsert)  meshIdx.push_back(id.index);
+							else if (id.kind == K::DungeonPortal) dungIdx.push_back(id.index);
+						}
+						engine::editor::scene::DeletedEntities snap;
+						snap.layout = engine::editor::scene::RemoveByIndexDescending(
+							m_worldEditorSession->MutableDoc().layoutInstances, layoutIdx);
+						snap.mesh = engine::editor::scene::RemoveByIndexDescending(
+							m_worldEditorShell->MutableMeshInsertDocument().Mutable(), meshIdx);
+						snap.dungeon = engine::editor::scene::RemoveByIndexDescending(
+							m_worldEditorShell->MutableDungeonPortalDocument().Mutable(), dungIdx);
+						m_worldEditorShell->MutableMeshInsertDocument().MarkDirty();
+						m_worldEditorShell->MutableDungeonPortalDocument().MarkDirty();
+						return snap;
+					};
+					auto restore = [this](const engine::editor::scene::DeletedEntities& snap)
+					{
+						engine::editor::scene::RestoreByIndexAscending(
+							m_worldEditorSession->MutableDoc().layoutInstances, snap.layout);
+						engine::editor::scene::RestoreByIndexAscending(
+							m_worldEditorShell->MutableMeshInsertDocument().Mutable(), snap.mesh);
+						engine::editor::scene::RestoreByIndexAscending(
+							m_worldEditorShell->MutableDungeonPortalDocument().Mutable(), snap.dungeon);
+						m_worldEditorShell->MutableMeshInsertDocument().MarkDirty();
+						m_worldEditorShell->MutableDungeonPortalDocument().MarkDirty();
+					};
+
+					m_worldEditorShell->MutableCommandStack().Push(
+						std::make_unique<engine::editor::scene::DeleteEntitiesCommand>(
+							std::move(ids), std::move(remove), std::move(restore)));
+					m_worldEditorShell->MutableSelection().Clear();
+					m_worldEditorShell->MarkDirty("delete selection");
+				}
+			}
 		}
 
 		m_shaderHotReload.Poll(m_cfg);

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7,6 +7,12 @@
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/panels/ScenePanel.h"
+// Lot 0 — câblage sélection / suppression éditeur (Phase C). Cœur pur tiré
+// directement (non garanti transitivement par WorldEditorShell.h).
+#include "src/world_editor/scene/EntityKey.h"
+#include "src/world_editor/scene/SelectionQuery.h"
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
 #include "src/shared/core/memory/Memory.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/network/ChatPayloads.h"
@@ -8960,6 +8966,37 @@ namespace engine
 							}
 						}
 					});
+
+				// Lot 0 (Phase C) — résolveur EntityId -> entityKey (clé stable de
+				// calque). Capture [this] : seul l'Engine connaît les guids des
+				// docs concrets. Calque sur le pattern de SetTransformWriter.
+				m_worldEditorShell->SetEntityKeyResolver(
+					[this](engine::editor::scene::EntityId id) -> uint64_t
+					{
+						using K = engine::editor::scene::EntityKind;
+						if (id.kind == K::LayoutInstance && m_worldEditorSession)
+						{
+							const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+							if (id.index < insts.size())
+								return engine::editor::scene::MakeEntityKeyFromString(
+									K::LayoutInstance, insts[id.index].guid);
+						}
+						else if (id.kind == K::MeshInsert && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetMeshInsertDocument().All();
+							if (id.index < all.size())
+								return engine::editor::scene::MakeEntityKeyFromGuid(
+									K::MeshInsert, all[id.index].guid);
+						}
+						else if (id.kind == K::DungeonPortal && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetDungeonPortalDocument().All();
+							if (id.index < all.size())
+								return engine::editor::scene::MakeEntityKeyFromGuid(
+									K::DungeonPortal, all[id.index].guid);
+						}
+						return 0ull;
+					});
 			}
 			m_worldEditorShell->RenderFrame();
 		}
@@ -9907,6 +9944,37 @@ namespace engine
 				const engine::editor::world::ActiveTool tool = m_worldEditorShell->GetActiveTool();
 				const bool freeClick = !m_worldEditorImGui->WantsCaptureMouse()
 					&& !m_input.IsDown(engine::platform::Key::Control);
+
+				// Lot 0 (Phase C) — construit la liste des candidats sélectionnables
+				// (positions X/Z monde), en excluant ceux des calques cachés ou
+				// verrouillés. Recalculée à la demande (pick / marquee) : l'index
+				// retourné (EntityId.index) reste cohérent avec le Doc de la frame.
+				auto buildSelectables = [this]() -> std::vector<engine::editor::scene::SelectableEntity>
+				{
+					using K = engine::editor::scene::EntityKind;
+					std::vector<engine::editor::scene::SelectableEntity> cands;
+					if (!m_worldEditorSession || !m_worldEditorShell) return cands;
+					const auto& layers = m_worldEditorShell->GetLayersDocument();
+					auto pushIf = [&](engine::editor::scene::EntityId id, float x, float z)
+					{
+						const uint64_t key = m_worldEditorShell->EntityKeyFor(id);
+						if (key != 0ull && (!layers.IsEntityVisible(key) || layers.IsEntityLocked(key)))
+							return; // caché ou verrouillé -> non sélectionnable
+						cands.push_back({ id, x, z });
+					};
+					const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+					for (uint32_t i = 0; i < insts.size(); ++i)
+						pushIf({ K::LayoutInstance, i },
+							static_cast<float>(insts[i].worldX), static_cast<float>(insts[i].worldZ));
+					const auto& mesh = m_worldEditorShell->GetMeshInsertDocument().All();
+					for (uint32_t i = 0; i < mesh.size(); ++i)
+						pushIf({ K::MeshInsert, i }, mesh[i].worldPosition.x, mesh[i].worldPosition.z);
+					const auto& dung = m_worldEditorShell->GetDungeonPortalDocument().All();
+					for (uint32_t i = 0; i < dung.size(); ++i)
+						pushIf({ K::DungeonPortal, i }, dung[i].worldPosition.x, dung[i].worldPosition.z);
+					return cands;
+				};
+
 				if (tool == engine::editor::world::ActiveTool::TerrainSculpt)
 				{
 					modernEditActive = true;
@@ -9960,6 +10028,25 @@ namespace engine
 						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
 					{
 						m_worldEditorShell->MutableValleyChainTool().AddVertex(pickX, pickZ);
+					}
+				}
+				else if (tool == engine::editor::world::ActiveTool::Select)
+				{
+					// Lot 0 (Phase C) — outil Sélection : clic simple = pick de
+					// l'entité la plus proche (X/Z) sous le rayon de pick ; clic
+					// dans le vide = désélection. Marque modernEditActive pour
+					// neutraliser le pinceau legacy.
+					modernEditActive = true;
+					if (freeClick && terrainPick
+						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						const auto cands = buildSelectables();
+						const float radius = m_worldEditorShell->GetSelectPickRadiusMeters();
+						auto hit = engine::editor::scene::PickNearest(cands, pickX, pickZ, radius);
+						if (hit.has_value())
+							m_worldEditorShell->MutableSelection().Select(*hit);
+						else
+							m_worldEditorShell->MutableSelection().Clear();
 					}
 				}
 			}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10032,21 +10032,48 @@ namespace engine
 				}
 				else if (tool == engine::editor::world::ActiveTool::Select)
 				{
-					// Lot 0 (Phase C) — outil Sélection : clic simple = pick de
-					// l'entité la plus proche (X/Z) sous le rayon de pick ; clic
-					// dans le vide = désélection. Marque modernEditActive pour
-					// neutraliser le pinceau legacy.
+					// Lot 0 (Phase C) — outil Sélection : press = début du drag
+					// (capture du point sol) ; release = clic simple (pick) si le
+					// déplacement est négligeable, sinon rectangle (marquee).
+					// Shift = additif (toggle au set existant). Marque
+					// modernEditActive pour neutraliser le pinceau legacy.
 					modernEditActive = true;
-					if (freeClick && terrainPick
-						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					if (freeClick && terrainPick)
 					{
-						const auto cands = buildSelectables();
-						const float radius = m_worldEditorShell->GetSelectPickRadiusMeters();
-						auto hit = engine::editor::scene::PickNearest(cands, pickX, pickZ, radius);
-						if (hit.has_value())
-							m_worldEditorShell->MutableSelection().Select(*hit);
-						else
-							m_worldEditorShell->MutableSelection().Clear();
+						const bool shift = m_input.IsDown(engine::platform::Key::Shift);
+						if (m_input.WasMousePressed(engine::platform::MouseButton::Left))
+						{
+							m_editorMarqueeActive = true;
+							m_editorMarqueeStartX = pickX;
+							m_editorMarqueeStartZ = pickZ;
+						}
+						if (m_editorMarqueeActive
+							&& m_input.WasMouseReleased(engine::platform::MouseButton::Left))
+						{
+							m_editorMarqueeActive = false;
+							const float dx = pickX - m_editorMarqueeStartX;
+							const float dz = pickZ - m_editorMarqueeStartZ;
+							const auto cands = buildSelectables();
+							const float radius = m_worldEditorShell->GetSelectPickRadiusMeters();
+							// Drag négligeable -> clic simple ; sinon -> rectangle.
+							if (dx * dx + dz * dz < radius * radius)
+							{
+								auto hit = engine::editor::scene::PickNearest(cands, pickX, pickZ, radius);
+								if (hit.has_value()) m_worldEditorShell->MutableSelection().Select(*hit);
+								else if (!shift) m_worldEditorShell->MutableSelection().Clear();
+							}
+							else
+							{
+								engine::editor::world::SelectionRect rect;
+								rect.minX = m_editorMarqueeStartX; rect.maxX = pickX;
+								rect.minZ = m_editorMarqueeStartZ; rect.maxZ = pickZ;
+								auto ids = engine::editor::scene::PickInRect(cands, rect);
+								if (shift)
+									for (const auto& id : ids) m_worldEditorShell->MutableSelection().ToggleInSelection(id);
+								else
+									m_worldEditorShell->MutableSelection().SelectMany(ids);
+							}
+						}
 					}
 				}
 			}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9950,6 +9950,24 @@ namespace engine
 				}
 				overlay.layoutInstancesOverlay = &m_worldEditorSession->MutableDoc().layoutInstances;
 				overlay.selectedLayoutInstanceOverlay = m_worldEditorSession->SelectedLayoutInstanceIndex();
+
+				// Lot 0 (Phase C) — masque de visibilité des marqueurs par calque.
+				// Reconstruit dans un membre Engine (durée de vie ≥ la frame) puis
+				// publié à l'overlay. Requiert le shell (résolveur de clé + calques).
+				if (m_worldEditorShell && m_worldEditorShell->IsInitialized())
+				{
+					const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+					const auto& layers = m_worldEditorShell->GetLayersDocument();
+					m_editorLayoutHiddenMask.assign(insts.size(), 0u);
+					for (uint32_t i = 0; i < insts.size(); ++i)
+					{
+						const uint64_t key = m_worldEditorShell->EntityKeyFor(
+							{ engine::editor::scene::EntityKind::LayoutInstance, i });
+						if (key != 0ull && !layers.IsEntityVisible(key))
+							m_editorLayoutHiddenMask[i] = 1u;
+					}
+					overlay.layoutInstanceHiddenMask = &m_editorLayoutHiddenMask;
+				}
 			}
 
 			m_worldEditorImGui->BuildUi(&overlay);

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -630,6 +630,17 @@ namespace engine
 		/// Le shell appelle ImGui (Windows-only) — toujours nul sur Linux.
 		std::unique_ptr<engine::editor::world::WorldEditorShell> m_worldEditorShell;
 
+		/// Lot 0 (Phase C) — état du drag « marquee » de l'outil Select : actif
+		/// entre le press et le release gauche, avec le point de sol (X/Z monde)
+		/// capturé au press. Sert à distinguer clic simple / rectangle.
+		bool  m_editorMarqueeActive = false;
+		float m_editorMarqueeStartX = 0.0f;
+		float m_editorMarqueeStartZ = 0.0f;
+		/// Lot 0 (Phase C) — masque de visibilité des marqueurs layoutInstances
+		/// (1 = caché car calque masqué), aligné sur l'index d'instance. Reconstruit
+		/// chaque frame ; durée de vie ≥ la frame (lu par l'overlay ImGui).
+		std::vector<uint8_t> m_editorLayoutHiddenMask;
+
 		/// M100.34 incrément 1 — Cible offscreen R8G8B8A8 dédiée au viewport
 		/// éditeur. Possédée par Engine, init après VkDeviceContext valide
 		/// + ImGui_ImplVulkan_Init OK, détruite avant le shutdown Vulkan.

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -43,6 +43,7 @@ namespace engine::platform
 		Y = 'Y',
 		Z = 'Z',
 		Escape = 0x1B,
+		Delete = 0x2E, ///< VK_DELETE — suppression de la sélection (éditeur).
 		Tab = 0x09,
 		Control = 0x11,
 		Alt = 0x12, ///< VK_MENU (gauche ou droite) — capturé via WM_SYSKEYDOWN. Sprint (CHAR-MODEL).

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -321,6 +321,7 @@ namespace engine::editor::world
 			case ActiveTool::Overhang:            name = "Overhang"; break;
 			case ActiveTool::Arch:                name = "Arch"; break;
 			case ActiveTool::DungeonPortal:       name = "DungeonPortal"; break;
+			case ActiveTool::Select:              name = "Select"; break;
 		}
 		(void)prev;
 		LOG_INFO(EditorWorld, "Active tool -> {}", name);

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -10,6 +10,7 @@
 #include "src/world_editor/panels/HistoryPanel.h"
 #include "src/world_editor/panels/SurfaceTablePanel.h"
 #include "src/world_editor/panels/CollisionEditorPanel.h"
+#include "src/world_editor/panels/LayersPanel.h"
 #include "src/world_editor/routine/RoutineGraphPanel.h"
 #include "src/world_editor/ui/EditorToolbar.h"
 
@@ -112,6 +113,14 @@ namespace engine::editor::world
 		// les indices fixes (Scene=0, ToolProperties=5). Caché par défaut,
 		// toggle via le menu View. Partage la pile undo/redo du shell.
 		m_panels.emplace_back(std::make_unique<RoutineGraphPanel>(&m_commandStack));
+		// Lot 0 — Panel des 16 calques. AJOUTÉ EN FIN pour ne pas décaler les
+		// indices fixes (Scene=0, ToolProperties=5). On capture le pointeur
+		// localement avant le `move` pour injecter le shell (pas d'index fixe).
+		{
+			auto layersPanel = std::make_unique<panels::LayersPanel>();
+			layersPanel->SetShell(this);
+			m_panels.emplace_back(std::move(layersPanel));
+		}
 
 #if defined(_WIN32)
 		std::error_code ec;

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -213,6 +213,10 @@ namespace engine::editor::world
 			return m_entityKeyResolver ? m_entityKeyResolver(id) : 0ull;
 		}
 
+		/// Lot 0 — Rayon de pick de l'outil Select (mètres monde), lu par l'Engine.
+		float  GetSelectPickRadiusMeters() const { return m_selectPickRadiusM; }
+		void   SetSelectPickRadiusMeters(float r) { m_selectPickRadiusM = r; }
+
 		/// Sous-projet 1, bloc B/C — Accès à la vue agrégée des entités de la
 		/// zone. L'Engine la lie aux documents sources (layout = session,
 		/// mesh/donjon = shell) et la reconstruit chaque frame avant le rendu
@@ -374,6 +378,7 @@ namespace engine::editor::world
 		TransformWriter m_transformWriter;                    // sous-projet 1, bloc D
 		LayersDocument m_layersDoc;                           // Lot 0
 		EntityKeyResolver m_entityKeyResolver;                // Lot 0
+		float m_selectPickRadiusM = 2.0f;                     // Lot 0
 		TerrainSculptTool m_sculptTool;
 		TerrainStampTool m_stampTool;
 		SplatPaintTool m_splatPaintTool;

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -57,6 +57,7 @@ namespace engine::editor::world
 		Overhang            = 13,  // M100.41 — raccourci Ctrl+Shift+O (Overhang)
 		Arch                = 14,  // M100.42 — raccourci Ctrl+Shift+A (Arche)
 		DungeonPortal       = 15,  // M100.43 — raccourci Ctrl+Shift+D (Donjon)
+		Select              = 16,  // Lot 0 — sélection (clic + marquee), raccourci Q
 	};
 
 	/// Coquille principale de l'éditeur de monde 3D (M100.1). Instanciée une

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -21,6 +21,8 @@
 #include "src/world_editor/terrain/ValleyChainTool.h"
 #include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/scene/EditorSceneModel.h" // sous-projet 1, bloc B (selection + scene)
+#include "src/world_editor/LayersDocument.h"          // Lot 0 — 16 calques
+#include "src/world_editor/scene/EditorSelection.h"   // Lot 0 — EntityId (déjà tiré indirectement)
 
 #include <functional>
 #include <memory>
@@ -190,6 +192,27 @@ namespace engine::editor::world
 		engine::editor::scene::EditorSelection&       MutableSelection()       { return m_selection; }
 		const engine::editor::scene::EditorSelection& GetSelection()     const { return m_selection; }
 
+		/// Lot 0 — Document des 16 calques (visibilité / verrou / couleur +
+		/// assignement par entityKey). Source d'autorité runtime ; non persisté
+		/// (cf. spec : persistance d'un layerIndex différée).
+		LayersDocument&       MutableLayersDocument()       { return m_layersDoc; }
+		const LayersDocument& GetLayersDocument()     const { return m_layersDoc; }
+
+		/// Lot 0 — Type du résolveur EntityId -> entityKey (clé stable de calque).
+		/// Installé par l'Engine, qui seul connaît les guids des documents concrets.
+		using EntityKeyResolver = std::function<uint64_t(engine::editor::scene::EntityId)>;
+
+		/// Lot 0 — Installe le résolveur de clé d'entité (appelé par l'Engine).
+		/// \param r foncteur capturant les documents concrets pour lire le guid.
+		void SetEntityKeyResolver(EntityKeyResolver r) { m_entityKeyResolver = std::move(r); }
+
+		/// Lot 0 — Résout la clé stable de calque d'une entité.
+		/// \return 0 si le résolveur n'est pas installé ou si l'entité est inconnue.
+		uint64_t EntityKeyFor(engine::editor::scene::EntityId id) const
+		{
+			return m_entityKeyResolver ? m_entityKeyResolver(id) : 0ull;
+		}
+
 		/// Sous-projet 1, bloc B/C — Accès à la vue agrégée des entités de la
 		/// zone. L'Engine la lie aux documents sources (layout = session,
 		/// mesh/donjon = shell) et la reconstruit chaque frame avant le rendu
@@ -349,6 +372,8 @@ namespace engine::editor::world
 		engine::editor::scene::EditorSelection  m_selection;  // sous-projet 1, bloc B
 		engine::editor::scene::EditorSceneModel m_sceneModel; // sous-projet 1, bloc B
 		TransformWriter m_transformWriter;                    // sous-projet 1, bloc D
+		LayersDocument m_layersDoc;                           // Lot 0
+		EntityKeyResolver m_entityKeyResolver;                // Lot 0
 		TerrainSculptTool m_sculptTool;
 		TerrainStampTool m_stampTool;
 		SplatPaintTool m_splatPaintTool;

--- a/src/world_editor/panels/LayersPanel.cpp
+++ b/src/world_editor/panels/LayersPanel.cpp
@@ -1,0 +1,88 @@
+#include "src/world_editor/panels/LayersPanel.h"
+
+#include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/LayersDocument.h"
+#include "src/world_editor/scene/EditorSelection.h"
+
+#include <cstdint>
+#include <cstdio>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world::panels
+{
+	/// Rend le panneau des 16 calques (Lot 0). Effet de bord : crée la window
+	/// ImGui "Layers", mute le `LayersDocument` du shell (visibilité, verrou,
+	/// nom, couleur, assignement). Doit être appelée en main thread (ImGui).
+	void LayersPanel::Render()
+	{
+#if defined(_WIN32)
+		if (!m_visible) return;
+		if (ImGui::Begin("Layers", &m_visible))
+		{
+			if (m_shell == nullptr)
+			{
+				ImGui::TextDisabled("Layers — shell non lié.");
+				ImGui::End();
+				return;
+			}
+
+			LayersDocument& doc = m_shell->MutableLayersDocument();
+
+			// Bouton d'assignement de la sélection au calque cible.
+			ImGui::SliderInt("Calque cible", &m_assignTargetLayer, 0, kLayerCount - 1);
+			if (ImGui::Button("Assigner la sélection à ce calque"))
+			{
+				const auto& sel = m_shell->GetSelection().SelectedSet();
+				for (const engine::editor::scene::EntityId& id : sel)
+				{
+					const uint64_t key = m_shell->EntityKeyFor(id);
+					if (key != 0ull)
+						doc.AssignEntity(key, static_cast<uint8_t>(m_assignTargetLayer));
+				}
+			}
+			ImGui::Separator();
+
+			// Liste des 16 calques : nom, visibilité, verrou, couleur.
+			for (uint8_t i = 0; i < kLayerCount; ++i)
+			{
+				Layer& layer = doc.LayerAt(i);
+				ImGui::PushID(static_cast<int>(i));
+
+				bool visible = layer.visible;
+				if (ImGui::Checkbox("##vis", &visible)) doc.SetVisible(i, visible);
+				ImGui::SameLine();
+
+				bool locked = layer.locked;
+				if (ImGui::Checkbox("##lock", &locked)) doc.SetLocked(i, locked);
+				ImGui::SameLine();
+
+				char buf[64];
+				std::snprintf(buf, sizeof(buf), "%s", layer.name.c_str());
+				if (ImGui::InputText("##name", buf, sizeof(buf)))
+					doc.SetLayerName(i, buf);
+
+				ImGui::SameLine();
+				float col[4] = {
+					((layer.overlayColorRgba >> 24) & 0xFF) / 255.0f,
+					((layer.overlayColorRgba >> 16) & 0xFF) / 255.0f,
+					((layer.overlayColorRgba >>  8) & 0xFF) / 255.0f,
+					( layer.overlayColorRgba        & 0xFF) / 255.0f };
+				if (ImGui::ColorEdit4("##col", col, ImGuiColorEditFlags_NoInputs))
+				{
+					layer.overlayColorRgba =
+						(static_cast<uint32_t>(col[0] * 255.0f) << 24) |
+						(static_cast<uint32_t>(col[1] * 255.0f) << 16) |
+						(static_cast<uint32_t>(col[2] * 255.0f) <<  8) |
+						(static_cast<uint32_t>(col[3] * 255.0f));
+				}
+
+				ImGui::PopID();
+			}
+		}
+		ImGui::End();
+#endif
+	}
+}

--- a/src/world_editor/panels/LayersPanel.h
+++ b/src/world_editor/panels/LayersPanel.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "src/world_editor/core/IPanel.h"
+
+namespace engine::editor::world
+{
+	class WorldEditorShell;
+}
+
+namespace engine::editor::world::panels
+{
+	/// Panneau des 16 calques (Lot 0). Renommage, visibilité, verrou, couleur,
+	/// et « assigner la sélection au calque ». Lit/écrit le `LayersDocument` et
+	/// la sélection via le shell injecté. Rendu ImGui gardé `_WIN32`.
+	class LayersPanel final : public IPanel
+	{
+	public:
+		const char* GetName() const override { return "Layers"; }
+
+		/// Rend la liste des 16 calques + le bouton d'assignement. No-op hors
+		/// Windows ou si le shell n'est pas lié. Effet de bord : window ImGui
+		/// "Layers" + mutations du `LayersDocument` au clic.
+		void Render() override;
+
+		bool IsVisible() const override { return m_visible; }
+		void SetVisible(bool visible) override { m_visible = visible; }
+
+		/// Injecte le shell (durée de vie garantie : le shell possède le panneau).
+		/// \param shell propriétaire du `LayersDocument` et de la sélection ; peut
+		///        être nul tant que `Init` ne l'a pas appelé.
+		void SetShell(WorldEditorShell* shell) { m_shell = shell; }
+
+	private:
+		bool m_visible = true;
+		WorldEditorShell* m_shell = nullptr;
+		int m_assignTargetLayer = 0; ///< Calque cible du bouton « assigner ».
+	};
+}

--- a/src/world_editor/panels/OutlinerPanel.cpp
+++ b/src/world_editor/panels/OutlinerPanel.cpp
@@ -33,13 +33,23 @@ namespace engine::editor::world::panels
 		for (const scene::SceneEntity& e : entities)
 		{
 			if (e.id.kind != kind) continue;
-			const bool selected = (m_selection != nullptr) && (m_selection->Current() == e.id);
+			// Lot 0 — surbrillance sur toute la multi-sélection (et plus
+			// seulement le primaire) : on teste l'appartenance au set.
+			const bool selected = (m_selection != nullptr) && m_selection->IsSelected(e.id);
 			// ID ImGui unique : combine kind (bits hauts) et index.
 			ImGui::PushID(static_cast<int>(e.id.index)
 				| (static_cast<int>(kind) << 24));
 			if (ImGui::Selectable(e.label.c_str(), selected))
 			{
-				if (m_selection != nullptr) m_selection->Select(e.id);
+				if (m_selection != nullptr)
+				{
+					// Ctrl+clic : bascule l'entité dans le set (multi) ;
+					// clic simple : sélection mono.
+					if (ImGui::GetIO().KeyCtrl)
+						m_selection->ToggleInSelection(e.id);
+					else
+						m_selection->Select(e.id);
+				}
 			}
 			ImGui::PopID();
 		}

--- a/src/world_editor/panels/ToolPropertiesPanel.cpp
+++ b/src/world_editor/panels/ToolPropertiesPanel.cpp
@@ -2171,6 +2171,21 @@ namespace engine::editor::world::panels
 				ImGui::Separator();
 				RenderDungeonPortalParams(*m_shell, m_shell->MutableDungeonPortalTool());
 			}
+			else if (m_shell != nullptr &&
+				m_shell->GetActiveTool() == engine::editor::world::ActiveTool::Select)
+			{
+				// Lot 0 — Outil de sélection : rayon de pick (porté par le shell,
+				// lu par l'Engine), aide-mémoire et compteur de sélection.
+				ImGui::TextUnformatted("Outil : Sélection");
+				ImGui::Separator();
+				float r = m_shell->GetSelectPickRadiusMeters();
+				if (ImGui::SliderFloat("Rayon de pick (m)", &r, 0.25f, 20.0f, "%.2f"))
+					m_shell->SetSelectPickRadiusMeters(r);
+				ImGui::TextDisabled("Clic : sélectionne la plus proche.");
+				ImGui::TextDisabled("Glisser : rectangle (multi). Suppr : supprime.");
+				ImGui::Text("Sélection : %d entité(s)",
+					static_cast<int>(m_shell->GetSelection().SelectedSet().size()));
+			}
 			else
 			{
 				ImGui::TextDisabled("Tool Properties — placeholder M100.1.");

--- a/src/world_editor/scene/DeleteEntitiesCommand.cpp
+++ b/src/world_editor/scene/DeleteEntitiesCommand.cpp
@@ -1,5 +1,7 @@
 #include "src/world_editor/scene/DeleteEntitiesCommand.h"
 
+#include <cstddef>
+
 namespace engine::editor::scene
 {
 	void DeleteEntitiesCommand::Execute()

--- a/src/world_editor/scene/DeleteEntitiesCommand.cpp
+++ b/src/world_editor/scene/DeleteEntitiesCommand.cpp
@@ -1,0 +1,28 @@
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+
+namespace engine::editor::scene
+{
+	void DeleteEntitiesCommand::Execute()
+	{
+		if (m_remove) m_snapshot = m_remove(m_ids);
+	}
+
+	void DeleteEntitiesCommand::Undo()
+	{
+		if (m_restore) m_restore(m_snapshot);
+	}
+
+	size_t DeleteEntitiesCommand::GetMemoryFootprint() const
+	{
+		// sizeof n'évalue pas l'opérande : on utilise les types d'élément
+		// explicitement pour rester valide même si les vecteurs sont vides.
+		return sizeof(DeleteEntitiesCommand)
+			+ m_ids.capacity() * sizeof(EntityId)
+			+ m_snapshot.layout.capacity()
+				* sizeof(std::pair<uint32_t, engine::editor::WorldMapEditLayoutInstance>)
+			+ m_snapshot.mesh.capacity()
+				* sizeof(std::pair<uint32_t, engine::editor::world::volumes::MeshInsertInstance>)
+			+ m_snapshot.dungeon.capacity()
+				* sizeof(std::pair<uint32_t, engine::editor::world::volumes::dungeons::DungeonPortalInstance>);
+	}
+}

--- a/src/world_editor/scene/DeleteEntitiesCommand.h
+++ b/src/world_editor/scene/DeleteEntitiesCommand.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"        // ICommand
+#include "src/world_editor/scene/EditorSelection.h"     // EntityId
+#include "src/world_editor/ui/WorldMapEditDocument.h"   // WorldMapEditLayoutInstance
+#include "src/world_editor/volumes/MeshInsertInstance.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalInstance.h"
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Snapshot des entités retirées (index d'origine + copie) par type, pour
+	/// l'undo exact. Rempli par le `RemoveFn`, consommé par le `RestoreFn`.
+	struct DeletedEntities
+	{
+		std::vector<std::pair<uint32_t, engine::editor::WorldMapEditLayoutInstance>>     layout;
+		std::vector<std::pair<uint32_t, engine::editor::world::volumes::MeshInsertInstance>>          mesh;
+		std::vector<std::pair<uint32_t, engine::editor::world::volumes::dungeons::DungeonPortalInstance>> dungeon;
+	};
+
+	/// Commande réversible de suppression d'un ensemble d'entités sélectionnées
+	/// (modèle vivant : layoutInstances + mesh inserts + dungeon portals).
+	///
+	/// Découplée des documents concrets via deux callbacks fournis par l'Engine :
+	/// `RemoveFn` retire les entités et renvoie le snapshot ; `RestoreFn` les
+	/// réinsère depuis le snapshot. Implémente le contrat ICommand undo/redo.
+	///
+	/// Limite assumée (cf. spec §4.4) : `EntityId.index` n'est pas stable après
+	/// édition structurelle ; la commande suppose un undo/redo linéaire immédiat
+	/// (même compromis que SetEntityTransformCommand).
+	class DeleteEntitiesCommand : public engine::editor::world::ICommand
+	{
+	public:
+		using RemoveFn  = std::function<DeletedEntities(const std::vector<EntityId>&)>;
+		using RestoreFn = std::function<void(const DeletedEntities&)>;
+
+		DeleteEntitiesCommand(std::vector<EntityId> ids, RemoveFn remove, RestoreFn restore)
+			: m_ids(std::move(ids)), m_remove(std::move(remove)), m_restore(std::move(restore)) {}
+
+		const char* GetLabel() const override { return "Supprimer la sélection"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+
+	private:
+		std::vector<EntityId> m_ids;
+		RemoveFn  m_remove;
+		RestoreFn m_restore;
+		DeletedEntities m_snapshot;
+	};
+}

--- a/src/world_editor/scene/DeleteEntitiesOps.h
+++ b/src/world_editor/scene/DeleteEntitiesOps.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Supprime de `vec` les éléments aux `indices` donnés (ordre quelconque,
+	/// doublons tolérés). Retire en ordre décroissant pour ne pas invalider les
+	/// index restants. Retourne les `(index, copie)` retirés, **triés par index
+	/// croissant** (prêt pour `RestoreByIndexAscending`). Index hors borne ignorés.
+	template <class T>
+	std::vector<std::pair<uint32_t, T>> RemoveByIndexDescending(
+		std::vector<T>& vec, std::vector<uint32_t> indices)
+	{
+		std::sort(indices.begin(), indices.end());
+		indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
+
+		std::vector<std::pair<uint32_t, T>> removed;
+		removed.reserve(indices.size());
+		// Croissant pour le snapshot…
+		for (uint32_t idx : indices)
+			if (idx < vec.size())
+				removed.emplace_back(idx, vec[idx]);
+		// …mais on supprime en décroissant.
+		for (auto it = indices.rbegin(); it != indices.rend(); ++it)
+			if (*it < vec.size())
+				vec.erase(vec.begin() + static_cast<std::ptrdiff_t>(*it));
+		return removed;
+	}
+
+	/// Réinsère les `(index, copie)` (supposés triés croissants) à leur position
+	/// d'origine. Reconstruit l'état d'avant `RemoveByIndexDescending` exactement.
+	template <class T>
+	void RestoreByIndexAscending(std::vector<T>& vec,
+		const std::vector<std::pair<uint32_t, T>>& removed)
+	{
+		for (const auto& [idx, item] : removed)
+		{
+			const size_t clamped = idx <= vec.size() ? idx : vec.size();
+			vec.insert(vec.begin() + static_cast<std::ptrdiff_t>(clamped), item);
+		}
+	}
+}

--- a/src/world_editor/scene/EditorSelection.cpp
+++ b/src/world_editor/scene/EditorSelection.cpp
@@ -1,18 +1,46 @@
 #include "src/world_editor/scene/EditorSelection.h"
 
+#include <algorithm>
+
 namespace engine::editor::scene
 {
 	void EditorSelection::Select(EntityId id)
 	{
-		if (id == m_current) return; // déjà sélectionné : pas de notification
+		if (m_set.size() == 1 && m_current == id) return; // déjà la seule sélection
 		m_current = id;
+		m_set.clear();
+		if (id.kind != EntityKind::None) m_set.push_back(id);
 		if (m_onChanged) m_onChanged(m_current);
 	}
 
 	void EditorSelection::Clear()
 	{
-		if (m_current.kind == EntityKind::None) return; // déjà vide
+		if (m_current.kind == EntityKind::None && m_set.empty()) return; // déjà vide
 		m_current = EntityId{};
+		m_set.clear();
 		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	void EditorSelection::SelectMany(const std::vector<EntityId>& ids)
+	{
+		m_set = ids;
+		m_current = ids.empty() ? EntityId{} : ids.front();
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	void EditorSelection::ToggleInSelection(EntityId id)
+	{
+		auto it = std::find(m_set.begin(), m_set.end(), id);
+		if (it != m_set.end())
+			m_set.erase(it);
+		else
+			m_set.push_back(id);
+		m_current = m_set.empty() ? EntityId{} : m_set.front();
+		if (m_onChanged) m_onChanged(m_current);
+	}
+
+	bool EditorSelection::IsSelected(EntityId id) const
+	{
+		return std::find(m_set.begin(), m_set.end(), id) != m_set.end();
 	}
 }

--- a/src/world_editor/scene/EditorSelection.h
+++ b/src/world_editor/scene/EditorSelection.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <utility>
+#include <vector>
 
 namespace engine::editor::scene
 {
@@ -53,6 +54,21 @@ namespace engine::editor::scene
 		/// Effet de bord : invoque le callback OnChanged si la sélection change.
 		void Clear();
 
+		/// Remplace la sélection par `ids` (ordre préservé). Le primaire devient
+		/// le premier élément (ou None si `ids` est vide). Notifie si changement.
+		void SelectMany(const std::vector<EntityId>& ids);
+
+		/// Ajoute `id` au set s'il est absent, l'en retire sinon. Ajuste le
+		/// primaire (reste valide ; se reporte sur un élément restant après un
+		/// retrait du primaire ; None si le set devient vide). Notifie.
+		void ToggleInSelection(EntityId id);
+
+		/// Set courant des entités sélectionnées (le primaire en fait partie).
+		const std::vector<EntityId>& SelectedSet() const { return m_set; }
+
+		/// true si `id` appartient au set.
+		bool IsSelected(EntityId id) const;
+
 		/// Sélection courante (kind = None si aucune).
 		EntityId Current() const { return m_current; }
 
@@ -64,6 +80,7 @@ namespace engine::editor::scene
 
 	private:
 		EntityId m_current{};
+		std::vector<EntityId> m_set; ///< Set de sélection (primaire = m_current).
 		OnChangedCallback m_onChanged;
 	};
 }

--- a/src/world_editor/scene/EntityKey.cpp
+++ b/src/world_editor/scene/EntityKey.cpp
@@ -1,5 +1,7 @@
 #include "src/world_editor/scene/EntityKey.h"
 
+#include <cstddef>
+
 namespace engine::editor::scene
 {
 	namespace

--- a/src/world_editor/scene/EntityKey.cpp
+++ b/src/world_editor/scene/EntityKey.cpp
@@ -1,0 +1,34 @@
+#include "src/world_editor/scene/EntityKey.h"
+
+namespace engine::editor::scene
+{
+	namespace
+	{
+		constexpr uint64_t kFnvOffset = 1469598103934665603ull;
+		constexpr uint64_t kFnvPrime  = 1099511628211ull;
+
+		uint64_t Fnv1a64(uint64_t seed, const unsigned char* data, size_t n)
+		{
+			uint64_t h = seed;
+			for (size_t i = 0; i < n; ++i) { h ^= data[i]; h *= kFnvPrime; }
+			return h;
+		}
+	}
+
+	uint64_t MakeEntityKeyFromString(EntityKind kind, std::string_view guid)
+	{
+		uint64_t h = kFnvOffset;
+		const unsigned char k = static_cast<unsigned char>(kind);
+		h = Fnv1a64(h, &k, 1);
+		h = Fnv1a64(h, reinterpret_cast<const unsigned char*>(guid.data()), guid.size());
+		return h | 1ull; // jamais 0 (0 = non assigné côté LayersDocument)
+	}
+
+	uint64_t MakeEntityKeyFromGuid(EntityKind kind, uint64_t guid)
+	{
+		unsigned char buf[9];
+		buf[0] = static_cast<unsigned char>(kind);
+		for (int i = 0; i < 8; ++i) buf[1 + i] = static_cast<unsigned char>((guid >> (i * 8)) & 0xFF);
+		return Fnv1a64(kFnvOffset, buf, sizeof(buf)) | 1ull;
+	}
+}

--- a/src/world_editor/scene/EntityKey.h
+++ b/src/world_editor/scene/EntityKey.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "src/world_editor/scene/EditorSelection.h" // EntityKind
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::editor::scene
+{
+	/// Clé stable `uint64` d'une entité pour `LayersDocument` (assignement par
+	/// calque survivant aux `Rebuild`, contrairement à `EntityId.index`).
+	/// Dérive un FNV-1a 64 bits du `guid`, mélangé au `kind` pour éviter les
+	/// collisions inter-types. Concern distinct du hash 32 bits `assetIdHash`.
+
+	/// Clé pour une entité à guid textuel (LayoutInstance). Jamais nulle.
+	uint64_t MakeEntityKeyFromString(EntityKind kind, std::string_view guid);
+
+	/// Clé pour une entité à guid numérique (MeshInsert / DungeonPortal). Jamais nulle.
+	uint64_t MakeEntityKeyFromGuid(EntityKind kind, uint64_t guid);
+}

--- a/src/world_editor/scene/SelectionQuery.cpp
+++ b/src/world_editor/scene/SelectionQuery.cpp
@@ -1,0 +1,70 @@
+#include "src/world_editor/scene/SelectionQuery.h"
+
+namespace engine::editor::scene
+{
+	using engine::editor::world::SelectablePoint;
+	using engine::editor::world::SelectionRect;
+
+	uint32_t EncodeEntityId(EntityId id)
+	{
+		return (static_cast<uint32_t>(id.kind) << 24) | (id.index & 0x00FFFFFFu);
+	}
+
+	EntityId DecodeEntityId(uint32_t encoded)
+	{
+		EntityId id;
+		id.kind  = static_cast<EntityKind>((encoded >> 24) & 0xFFu);
+		id.index = encoded & 0x00FFFFFFu;
+		return id;
+	}
+
+	std::optional<EntityId> PickNearest(const std::vector<SelectableEntity>& pts,
+		float x, float z, float radius)
+	{
+		const float r2 = radius * radius;
+		std::optional<EntityId> best;
+		float bestD2 = r2;
+		for (const auto& p : pts)
+		{
+			const float dx = p.x - x;
+			const float dz = p.z - z;
+			const float d2 = dx * dx + dz * dz;
+			if (d2 <= bestD2)
+			{
+				bestD2 = d2;
+				best = p.id;
+			}
+		}
+		return best;
+	}
+
+	std::vector<EntityId> PickInRect(const std::vector<SelectableEntity>& pts,
+		SelectionRect rect)
+	{
+		std::vector<SelectablePoint> raw;
+		raw.reserve(pts.size());
+		for (const auto& p : pts)
+			raw.push_back(SelectablePoint{ EncodeEntityId(p.id), p.x, p.z });
+
+		std::vector<uint32_t> ids = engine::editor::world::SelectInRect(raw, rect);
+		std::vector<EntityId> out;
+		out.reserve(ids.size());
+		for (uint32_t e : ids) out.push_back(DecodeEntityId(e));
+		return out;
+	}
+
+	std::vector<EntityId> PickInLasso(const std::vector<SelectableEntity>& pts,
+		const std::vector<std::pair<float, float>>& polygon)
+	{
+		std::vector<SelectablePoint> raw;
+		raw.reserve(pts.size());
+		for (const auto& p : pts)
+			raw.push_back(SelectablePoint{ EncodeEntityId(p.id), p.x, p.z });
+
+		std::vector<uint32_t> ids = engine::editor::world::SelectInLasso(raw, polygon);
+		std::vector<EntityId> out;
+		out.reserve(ids.size());
+		for (uint32_t e : ids) out.push_back(DecodeEntityId(e));
+		return out;
+	}
+}

--- a/src/world_editor/scene/SelectionQuery.h
+++ b/src/world_editor/scene/SelectionQuery.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "src/world_editor/SelectionTool.h"           // SelectionRect, SelectablePoint
+#include "src/world_editor/scene/EditorSelection.h"    // EntityId, EntityKind
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::scene
+{
+	/// Candidat sélectionnable projeté au sol (X/Z monde).
+	struct SelectableEntity
+	{
+		EntityId id{};
+		float    x = 0.0f;
+		float    z = 0.0f;
+	};
+
+	/// Encode `(kind, index)` sur 32 bits (8 bits kind << 24 | index 24 bits)
+	/// pour transiter par l'API uint32 de SelectionTool.
+	uint32_t EncodeEntityId(EntityId id);
+	EntityId DecodeEntityId(uint32_t encoded);
+
+	/// Entité la plus proche de (x,z) dont la distance ≤ `radius` (monde).
+	/// std::nullopt si aucune dans le rayon.
+	std::optional<EntityId> PickNearest(const std::vector<SelectableEntity>& pts,
+		float x, float z, float radius);
+
+	/// Entités dont la projection X/Z tombe dans `rect` (réutilise SelectInRect).
+	std::vector<EntityId> PickInRect(const std::vector<SelectableEntity>& pts,
+		engine::editor::world::SelectionRect rect);
+
+	/// Entités dont la projection X/Z tombe dans le polygone lasso (SelectInLasso).
+	std::vector<EntityId> PickInLasso(const std::vector<SelectableEntity>& pts,
+		const std::vector<std::pair<float, float>>& polygon);
+}

--- a/src/world_editor/tests/DeleteEntitiesCommandTests.cpp
+++ b/src/world_editor/tests/DeleteEntitiesCommandTests.cpp
@@ -1,0 +1,63 @@
+/// Tests CPU pour DeleteEntitiesCommand (Execute/Undo/Redo via callbacks).
+#include "src/world_editor/scene/DeleteEntitiesCommand.h"
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_ExecuteUndoRedo()
+	{
+		// Modèle de test : un vecteur de strings simulant layoutInstances.
+		std::vector<std::string> model = {"a", "b", "c"};
+
+		std::vector<EntityId> ids = {
+			{EntityKind::LayoutInstance, 0}, {EntityKind::LayoutInstance, 2} };
+
+		// Snapshot custom du test : on réutilise le champ générique via lambdas.
+		std::vector<std::pair<uint32_t, std::string>> backup;
+
+		auto remove = [&](const std::vector<EntityId>& sel) -> DeletedEntities
+		{
+			std::vector<uint32_t> idx;
+			for (const EntityId& e : sel) idx.push_back(e.index);
+			backup = RemoveByIndexDescending(model, idx);
+			return DeletedEntities{}; // l'état réel est dans `backup` (capturé)
+		};
+		auto restore = [&](const DeletedEntities&)
+		{
+			RestoreByIndexAscending(model, backup);
+		};
+
+		DeleteEntitiesCommand cmd(ids, remove, restore);
+		REQUIRE(std::string(cmd.GetLabel()) != "");
+
+		cmd.Execute();
+		REQUIRE(model.size() == 1);
+		REQUIRE(model[0] == "b");
+
+		cmd.Undo();
+		REQUIRE(model.size() == 3);
+		REQUIRE(model[0] == "a"); REQUIRE(model[1] == "b"); REQUIRE(model[2] == "c");
+
+		// Redo = Execute à nouveau (indices valides car Undo a tout restitué).
+		cmd.Execute();
+		REQUIRE(model.size() == 1);
+		REQUIRE(model[0] == "b");
+	}
+}
+
+int main()
+{
+	Test_ExecuteUndoRedo();
+	if (g_failed == 0) { std::printf("[PASS] DeleteEntitiesCommandTests\n"); return 0; }
+	std::printf("[FAIL] DeleteEntitiesCommandTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/tests/DeleteEntitiesOpsTests.cpp
+++ b/src/world_editor/tests/DeleteEntitiesOpsTests.cpp
@@ -1,0 +1,53 @@
+/// Tests CPU pour DeleteEntitiesOps (remove/restore par index, undo exact).
+#include "src/world_editor/scene/DeleteEntitiesOps.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_RemoveRestoreExact()
+	{
+		std::vector<std::string> v = {"a", "b", "c", "d", "e"};
+		// Supprime indices {1,3} (b,d). Ordre d'entrée volontairement non trié.
+		auto removed = RemoveByIndexDescending(v, {3, 1});
+		REQUIRE(v.size() == 3);
+		REQUIRE(v[0] == "a"); REQUIRE(v[1] == "c"); REQUIRE(v[2] == "e");
+		// Snapshot trié croissant : (1,b),(3,d).
+		REQUIRE(removed.size() == 2);
+		REQUIRE(removed[0].first == 1u); REQUIRE(removed[0].second == "b");
+		REQUIRE(removed[1].first == 3u); REQUIRE(removed[1].second == "d");
+
+		// Restore -> état initial exact.
+		RestoreByIndexAscending(v, removed);
+		REQUIRE(v.size() == 5);
+		REQUIRE(v[0] == "a"); REQUIRE(v[1] == "b"); REQUIRE(v[2] == "c");
+		REQUIRE(v[3] == "d"); REQUIRE(v[4] == "e");
+	}
+
+	void Test_OutOfRangeIgnored()
+	{
+		std::vector<int> v = {10, 20};
+		auto removed = RemoveByIndexDescending(v, {5, 0}); // 5 hors borne -> ignoré
+		REQUIRE(v.size() == 1);
+		REQUIRE(v[0] == 20);
+		REQUIRE(removed.size() == 1);
+		REQUIRE(removed[0].first == 0u);
+		REQUIRE(removed[0].second == 10);
+	}
+}
+
+int main()
+{
+	Test_RemoveRestoreExact();
+	Test_OutOfRangeIgnored();
+	if (g_failed == 0) { std::printf("[PASS] DeleteEntitiesOpsTests\n"); return 0; }
+	std::printf("[FAIL] DeleteEntitiesOpsTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/tests/EditorSelectionTests.cpp
+++ b/src/world_editor/tests/EditorSelectionTests.cpp
@@ -52,11 +52,58 @@ namespace
 		sel.Clear();
 		REQUIRE(calls == 3);
 	}
+
+	void Test_MultiSelection()
+	{
+		EditorSelection sel;
+		int calls = 0;
+		sel.SetOnChanged([&](EntityId) { ++calls; });
+
+		const EntityId a{EntityKind::LayoutInstance, 1};
+		const EntityId b{EntityKind::LayoutInstance, 2};
+		const EntityId c{EntityKind::MeshInsert, 0};
+
+		// SelectMany : set = {a,b,c}, primaire = premier (a).
+		sel.SelectMany({a, b, c});
+		REQUIRE(calls == 1);
+		REQUIRE(sel.SelectedSet().size() == 3);
+		REQUIRE(sel.Current() == a);
+		REQUIRE(sel.IsSelected(b));
+		REQUIRE(sel.IsSelected(c));
+
+		// Select mono : set = {b}, primaire = b.
+		sel.Select(b);
+		REQUIRE(sel.SelectedSet().size() == 1);
+		REQUIRE(sel.Current() == b);
+		REQUIRE(!sel.IsSelected(a));
+
+		// Toggle : ajoute a -> {b,a}.
+		sel.ToggleInSelection(a);
+		REQUIRE(sel.SelectedSet().size() == 2);
+		REQUIRE(sel.IsSelected(a));
+		// Toggle : retire b ; primaire se reporte sur un restant (a).
+		sel.ToggleInSelection(b);
+		REQUIRE(sel.SelectedSet().size() == 1);
+		REQUIRE(!sel.IsSelected(b));
+		REQUIRE(sel.Current() == a);
+
+		// Clear vide le set + le primaire.
+		sel.Clear();
+		REQUIRE(sel.SelectedSet().empty());
+		REQUIRE(!sel.HasSelection());
+
+		// SelectMany vide = Clear sémantique (set vide, primaire None).
+		sel.SelectMany({a});
+		sel.SelectMany({});
+		REQUIRE(sel.SelectedSet().empty());
+		REQUIRE(sel.Current().kind == EntityKind::None);
+	}
 }
 
 int main()
 {
 	Test_SelectionNotifiesOnChange();
+	Test_MultiSelection();
 
 	if (g_failed == 0)
 	{

--- a/src/world_editor/tests/EntityKeyTests.cpp
+++ b/src/world_editor/tests/EntityKeyTests.cpp
@@ -1,0 +1,40 @@
+/// Tests CPU pour EntityKey (clé stable de calque). Pur, ctest Linux.
+#include "src/world_editor/scene/EntityKey.h"
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+
+	void Test_KeyStableAndDistinct()
+	{
+		// Déterministe : même entrée -> même clé.
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001")
+			== MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001"));
+		// Guid différent -> clé différente.
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_001")
+			!= MakeEntityKeyFromString(EntityKind::LayoutInstance, "tree_oak_002"));
+		// Même guid, kind différent -> clé différente (préfixe kind).
+		REQUIRE(MakeEntityKeyFromString(EntityKind::LayoutInstance, "x")
+			!= MakeEntityKeyFromString(EntityKind::MeshInsert, "x"));
+		// Variante numérique (mesh/dungeon) : déterministe + séparée par kind.
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42)
+			== MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42));
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 42)
+			!= MakeEntityKeyFromGuid(EntityKind::DungeonPortal, 42));
+		// Clé non nulle (0 = "non assigné" côté LayersDocument).
+		REQUIRE(MakeEntityKeyFromGuid(EntityKind::MeshInsert, 0) != 0u);
+	}
+}
+
+int main()
+{
+	Test_KeyStableAndDistinct();
+	if (g_failed == 0) { std::printf("[PASS] EntityKeyTests\n"); return 0; }
+	std::printf("[FAIL] EntityKeyTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/tests/SelectionQueryTests.cpp
+++ b/src/world_editor/tests/SelectionQueryTests.cpp
@@ -1,0 +1,63 @@
+/// Tests CPU pour SelectionQuery (encode/décode, pick nearest, rect/lasso).
+#include "src/world_editor/scene/SelectionQuery.h"
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { if (!(cond)) { \
+		std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failed; } } while (0)
+
+	using namespace engine::editor::scene;
+	using namespace engine::editor::world;
+
+	void Test_EncodeRoundTrip()
+	{
+		const EntityId id{EntityKind::MeshInsert, 1234567};
+		const uint32_t enc = EncodeEntityId(id);
+		const EntityId dec = DecodeEntityId(enc);
+		REQUIRE(dec.kind == EntityKind::MeshInsert);
+		REQUIRE(dec.index == 1234567u);
+	}
+
+	void Test_PickNearest()
+	{
+		std::vector<SelectableEntity> pts = {
+			{ {EntityKind::LayoutInstance, 0}, 0.f, 0.f },
+			{ {EntityKind::LayoutInstance, 1}, 10.f, 0.f },
+			{ {EntityKind::LayoutInstance, 2}, 0.f, 10.f },
+		};
+		// Clic près de (9,0) avec rayon 3 -> index 1.
+		auto hit = PickNearest(pts, 9.f, 0.f, 3.f);
+		REQUIRE(hit.has_value());
+		REQUIRE(hit->index == 1u);
+		// Clic loin de tout (rayon 1) -> rien.
+		REQUIRE(!PickNearest(pts, 50.f, 50.f, 1.f).has_value());
+	}
+
+	void Test_RectAndLasso()
+	{
+		std::vector<SelectableEntity> pts = {
+			{ {EntityKind::LayoutInstance, 0}, 1.f, 1.f },
+			{ {EntityKind::LayoutInstance, 1}, 5.f, 5.f },
+			{ {EntityKind::LayoutInstance, 2}, 20.f, 20.f },
+		};
+		SelectionRect rect; rect.minX = 0.f; rect.minZ = 0.f; rect.maxX = 10.f; rect.maxZ = 10.f;
+		auto inRect = PickInRect(pts, rect);
+		REQUIRE(inRect.size() == 2); // 0 et 1
+		// Lasso = même carré 0..10 -> mêmes 2 entités.
+		std::vector<std::pair<float, float>> poly = {{0,0},{10,0},{10,10},{0,10}};
+		auto inLasso = PickInLasso(pts, poly);
+		REQUIRE(inLasso.size() == 2);
+	}
+}
+
+int main()
+{
+	Test_EncodeRoundTrip();
+	Test_PickNearest();
+	Test_RectAndLasso();
+	if (g_failed == 0) { std::printf("[PASS] SelectionQueryTests\n"); return 0; }
+	std::printf("[FAIL] SelectionQueryTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/ui/EditorToolbar.cpp
+++ b/src/world_editor/ui/EditorToolbar.cpp
@@ -27,6 +27,7 @@ namespace engine::editor::world
 			ActiveTool::Overhang,           // M100.41
 			ActiveTool::Arch,               // M100.42
 			ActiveTool::DungeonPortal,      // M100.43
+			ActiveTool::Select,             // Lot 0 — sélection / suppression
 		};
 	}
 

--- a/src/world_editor/ui/ToolbarIconAtlas.cpp
+++ b/src/world_editor/ui/ToolbarIconAtlas.cpp
@@ -38,6 +38,8 @@ namespace engine::editor::world
 				return { 0xFF5A4A36u, "A", "Placer une arche naturelle (Phase 11)", true };
 			case ActiveTool::DungeonPortal:
 				return { 0xFF6A2E5Au, "D", "Placer un portail de donjon (Phase 11)", true };
+			case ActiveTool::Select:
+				return { 0xFF3A6EA5u, "S", "Sélection (clic / rectangle) — Suppr pour supprimer", true };
 		}
 		// Fallback générique pour outils futurs non encore mappés : carré
 		// neutre, désactivé, tooltip standard "Bientôt disponible".

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -345,6 +345,11 @@ namespace engine::editor
 				for (size_t ii = 0; ii < d.layoutInstancesOverlay->size(); ++ii)
 				{
 					const engine::editor::WorldMapEditLayoutInstance& inst = (*d.layoutInstancesOverlay)[ii];
+					// Lot 0 (Phase C) — saute le marqueur si son calque est masqué.
+					if (d.layoutInstanceHiddenMask != nullptr
+						&& ii < d.layoutInstanceHiddenMask->size()
+						&& (*d.layoutInstanceHiddenMask)[ii] != 0)
+						continue;
 					const float wx = static_cast<float>(inst.worldX);
 					const float wy = static_cast<float>(inst.worldY);
 					const float wz = static_cast<float>(inst.worldZ);

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -66,6 +66,10 @@ namespace engine::editor
 		/// Marqueurs debug instances (monde m). Nullptr = rien à dessiner.
 		const std::vector<WorldMapEditLayoutInstance>* layoutInstancesOverlay = nullptr;
 		int selectedLayoutInstanceOverlay = -1;
+		/// Lot 0 (Phase C) — masque de visibilité des marqueurs, aligné sur
+		/// l'index d'instance (1 = caché car calque masqué). Pointeur non
+		/// possédé ; nullptr = tous les marqueurs visibles.
+		const std::vector<uint8_t>* layoutInstanceHiddenMask = nullptr;
 	};
 
 	/// ImGui + Vulkan (rendu dynamique) pour \c lcdlln_world_editor.exe uniquement (Windows).

--- a/src/world_editor/volumes/MeshInsertDocument.h
+++ b/src/world_editor/volumes/MeshInsertDocument.h
@@ -45,6 +45,12 @@ namespace engine::editor::world::volumes
 		std::vector<MeshInsertInstance> GetByCategory(const std::string& category) const;
 
 		const std::vector<MeshInsertInstance>& All() const { return m_instances; }
+
+		/// Lot 0 (Phase C) — Accès mutable au vecteur d'instances pour la
+		/// suppression réversible par index (DeleteEntitiesCommand). Le caller
+		/// est responsable d'appeler `MarkDirty()` après mutation.
+		std::vector<MeshInsertInstance>& Mutable() { return m_instances; }
+
 		size_t Size() const { return m_instances.size(); }
 
 		bool IsDirty() const noexcept { return m_dirty; }

--- a/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
+++ b/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
@@ -29,9 +29,18 @@ namespace engine::editor::world::volumes::dungeons
 
 		const DungeonPortalInstance* GetByGuid(uint64_t guid) const;
 		const std::vector<DungeonPortalInstance>& All() const { return m_instances; }
+
+		/// Lot 0 (Phase C) — Accès mutable au vecteur d'instances pour la
+		/// suppression réversible par index (DeleteEntitiesCommand). Le caller
+		/// est responsable d'appeler `MarkDirty()` après mutation.
+		std::vector<DungeonPortalInstance>& Mutable() { return m_instances; }
+
 		size_t Size() const { return m_instances.size(); }
 
 		bool IsDirty() const noexcept { return m_dirty; }
+		/// Lot 0 (Phase C) — Marque le document modifié (suppression / restauration
+		/// par index). Symétrique de `MeshInsertDocument::MarkDirty()`.
+		void MarkDirty() noexcept     { m_dirty = true; }
 		void ClearDirty() noexcept    { m_dirty = false; }
 
 		/// M100.46 — Vide intégralement le document. Marque `m_dirty`.


### PR DESCRIPTION
## Résumé

Lot 0 de câblage de l'éditeur de niveau (Thème 1 de l'audit `docs/audit/2026-06-05-editeur-carte-audit.md`) : rendre l'éditeur **utilisable** en branchant la **fondation d'édition** — sélectionner, supprimer, organiser en calques — sur le **modèle vivant** `WorldMapEditDocument::layoutInstances` (+ MeshInsert / DungeonPortal).

Issu du flux brainstorming → spec → plan → exécution subagent-driven :
- Spec : `docs/superpowers/specs/2026-06-10-editeur-niveau-lot0-fondation-design.md`
- Plan : `docs/superpowers/plans/2026-06-10-editeur-niveau-lot0-fondation.md`

## Ce qui est livré

**Cœur pur (testé sous ctest Linux)**
- `EditorSelection` étendu en **multi-sélection** (set + primaire, rétrocompatible).
- `EntityKey` — clé stable `uint64` de calque (FNV-1a 64, survit aux `Rebuild`).
- `SelectionQuery` — encode/décode `EntityId↔uint32`, pick « plus proche », wrappers rect/lasso (réutilise `SelectInRect`/`SelectInLasso`).
- `DeleteEntitiesOps` (templates) + `DeleteEntitiesCommand` (`ICommand` réversible, undo exact par index décroissant/croissant).

**UI éditeur (`_WIN32`)**
- Outil `ActiveTool::Select` (toolbar + icône).
- Panneau **Layers** (16 calques : visibilité / verrou / nom / couleur + « assigner la sélection »).
- Outliner : **Ctrl+clic** multi-sélection.
- Tool Properties : bloc Select (rayon de pick + compteur).

**Intégration Engine**
- `Key::Delete` ; pick simple + **marquee rectangle** (Shift = additif) ; **Suppr** → `DeleteEntitiesCommand` réversible (Ctrl+Z/Y) ; exclusion des calques cachés/verrouillés du picking et de la suppression ; gating de visibilité des **marqueurs** `layoutInstances` par calque.

## Hors périmètre (assumé, cf. spec §8)
Persistance d'un `layerIndex` ; masquage du **mesh 3D** par calque (seuls les marqueurs sont gatés au Lot 0) ; réveil des orphelins `PropInstance` ; unification des deux modèles d'objets ; multi-édition de transform.

## Suivi connu
- ⚠️ **Vider la pile undo au changement de carte** (`CommandStack::Clear()`) — concern transverse pré-existant (n'affecte pas que la suppression). Suivi séparé.
- Test dormant pré-existant `WorldEditorShellTests` (`Panels().size()==7`) déjà obsolète, non exécuté en CI — à rafraîchir.

## Plan de test
- [ ] CI `build-linux` : 4 nouvelles cibles ctest vertes (`entity_key_tests`, `selection_query_tests`, `delete_entities_ops_tests`, `delete_entities_command_tests`) + `editor_selection_tests` (étendu).
- [ ] CI `build-windows` : compile `/W4 /permissive-` sans erreur.
- [ ] Manuel (éditeur) : pick simple, marquee, Ctrl+clic Outliner, Suppr + Undo/Redo exact, assignement calque, visibilité/verrou.

> **Déploiement** : ✅ client/éditeur uniquement (`lcdlln_world_editor.exe`), **pas de redéploiement serveur** — aucun opcode, format binaire exporté (LCDP/LCVC/LCMI), handler ni migration DB touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)