### PR TITLE
feat(client): Combat SP1-B - rendu des creatures (mesh archetype + nameplates)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,8 @@ add_library(engine_core
   src/client/world/WorldModel.cpp
   src/client/world/OutputVersion.cpp
   src/client/world/ProbeData.cpp
+  # Combat SP1 — apparences d'archétypes de créatures (rendu des mobs).
+  src/client/world/CreatureCatalog.cpp
   src/client/world/PakReader.cpp
   src/client/world/ChunkPackageLayout.cpp
   src/client/world/StreamingScheduler.cpp

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2131,3 +2131,31 @@ aussi les confusions « je vois quelqu'un de déjà parti » et « reconnexion r
   immédiate (nouveau handler). **Non lock-step / non wire-breaking** : client neuf ↔
   shard ancien (ou inverse) fonctionnent, mais sans l'éviction immédiate tant que le
   shard n'est pas redéployé (fallback timeout).
+
+## Combat SP1 — créatures visibles (2026-06-10)
+
+Spec : `docs/superpowers/specs/2026-06-10-combat-system-design.md` (chantier combat SP1→SP4,
+ordre validé : combat → groupes → métiers/récolte → prédiction client). Plan SP1 :
+`docs/superpowers/plans/2026-06-10-combat-sp1-creatures-visibles.md`. Audit global 4 parties :
+`docs/audit/2026-06-10-audit-global-4-parties.md`.
+
+### PR-A (serveur)
+- `game/data/creatures/archetypes.json` — catalogue d''archétypes de créatures (id=100 « Sanglier
+  des collines ») : stats (hp/damage/accuracy/rangeMeters/critRate/critMult/attackPeriodMs),
+  `xpReward`, `model.mesh` (clé d''un set de mesh de race existant) + `model.scale`.
+- `src/shardd/gameplay/creature/CreatureArchetypeLibrary.{h,cpp}` — loader strict (pattern
+  SpawnerRuntime, parseur JSON local) ; `Init()` lit `creatures/archetypes.json`, `Find(id)`.
+  Chargé par `ServerApp::InitSpawners` AVANT les spawners ; spawner → archétype inconnu = échec boot.
+- `ServerApp` : `ApplyArchetypeStatsToMob` (namespace anonyme) applique hp/damage/range/cadence
+  aux 2 sites de spawn (spawner + événement dynamique) ; `MobEntity.xpReward` remplace
+  `kBaseXpPerMobKill` au kill (fallback si 0). Constantes `kDefaultMob*` conservées en fallback.
+- **Wire v8→v9** : `SnapshotEntity.archetypeId` (u32, 0 = joueur/loot bag) après `animationState` ;
+  entité min 57→61 octets, `kMaxEntitiesPerChunk` 20→18. Tests `server_protocol_tests` étendus +
+  `creature_archetype_library_tests` (nouveau).
+- **Déploiement** : ⚠️ wire-breaking — master + shardd + client en **lock-step** (kProtocolVersion
+  partagé par le framing client↔master).
+
+### PR-B (client) — stackée
+- `src/client/world/CreatureCatalog.{h,cpp}` — lecture tolérante du même JSON (name/level/mesh/scale).
+- `UIRemoteEntity.archetypeId` + copie dans `ApplySnapshot` ; rendu mobs dans Engine
+  (mesh via `GetRaceMesh(meshKey, "male")`, nameplate « Nom (niv. N) PV/PVmax »).

--- a/docs/audit/2026-06-10-audit-global-4-parties.md
+++ b/docs/audit/2026-06-10-audit-global-4-parties.md
@@ -1,0 +1,224 @@
+# Audit global du dépôt — 4 parties (2026-06-10)
+
+> Audit en lecture seule (aucun fichier de code modifié). Couverture : client de jeu,
+> serveurs masterd/shardd, éditeur de carte, web-portal, plus une passe transversale
+> « code orphelin » au niveau build & données. `legacy/` et `external/` exclus.
+> Méthode : croisement CMakeLists ↔ disque, greps de preuve pour chaque « jamais
+> utilisé », lecture intégrale des fichiers centraux (Engine, NetServer, mains des
+> daemons, routes API du portail, WorldEditorSession/TerrainDocument).
+
+## Légende
+
+- Sévérité : 🔴 haute / 🟠 moyenne / 🟡 basse
+- Confiance : **V** = vérifié (preuve grep/lecture) / **S** = suspecté
+
+---
+
+## 1. Constats transversaux (tout le dépôt)
+
+### 1.1 Doublons massifs
+
+| | Constat | Détail |
+|---|---|---|
+| 🔴 V | `src/client/assets/` (111 fichiers) est un arbre mort | Duplique `game/data/` ; le content root runtime est `paths.content = "game/data"` (config.json:576) ; zéro référence dans src/, CMake, scripts, CI. Reliquat de la réorg 2026-05-09 ; a déjà coûté du travail fantôme (PR #862). → **Supprimer l'arbre entier.** |
+| 🟠 V | Templates e-mail dupliqués et déjà divergents | `game/data/email/` (lu par masterd : verification, password-reset, cgu-accepted) vs `web-portal/email-templates/` (lu par le portail). `password-reset.{fr,en}.html` divergent déjà (diff non vide). → Choisir une source canonique ou répartir (ne garder dans game/data que les 3 templates masterd). |
+| 🟠 V | `deploy/docker/sql/migrations/` committé et périmé | Il manque 0050→0071 (mais 0072 présent) alors que la CI régénère ce dossier via `sync-db-to-docker-deploy.sh`. → Gitignorer ou resynchroniser. |
+| 🟠 S | Deux UIs d'hôtel des ventes compilées ET instanciées | `src/client/auction/AuctionUi.cpp` (`AuctionHousePresenter`, membre `m_auctionHouseUi`) et `src/client/economy/AuctionUi.cpp` (`AuctionUiPresenter`, membre `m_auctionUi`), toutes deux dans Engine.h:1209/1250. → Arbitrer laquelle fait foi. |
+
+### 1.2 Bugs latents de configuration (mismatch de chemins)
+
+| | Constat | Détail |
+|---|---|---|
+| 🟠 V | `world.default_spawn.{x,y,z,yaw_deg,pitch_deg}` (config.json:561) jamais lu | Le code lit `client.world.default_spawn.*` (Engine.cpp:8417-8421), chemin absent de config.json → les défauts code s'appliquent (identiques par coïncidence). → Harmoniser. |
+| 🟠 V | `client.character_creation.default_server_id` (config.json:609) jamais lu | Le code lit `character_creation.default_server_id` sans préfixe (CharacterCreateHandler.cpp:93). → Harmoniser. |
+| 🟡 V | 14 autres clés config mortes | `db.delay_thread_*`, `db.prepared_statement_cache_size_per_conn`, `db.sql_storage_log_load_durations`, `globals.default_locale`, `globals.fallback_locale`, `globals.graveyard_default_faction_neutral_radius_m`, `accounts.default_new_account_role`, `accounts.role_change_audit`, `editor.world.camera.fpsSpeed`, `editor.world.terrain.lodWorkers`, `gi.ddgi.intensity` (le commentaire de config.json l.677 dit lui-même qu'elle n'est plus lue). Note : `terms.fallback_locale` est lue par le code mais absente de config.json. |
+
+### 1.3 Tables SQL sans aucun lecteur/écrivain (grep `-w` src/ + web-portal/)
+
+- **V — candidates à DROP** : `reset_tokens` (0005, supplantée par `account_password_reset_tokens`), `auction_listings` (0013, supplantée par `auction_listings_v2`), `bounties`, `character_history`, `character_reputation`, `npc_memory`, `player_legacy`, `prison_records` (0011), `player_currency_log` (0012), `player_professions` (0019).
+- **V — scaffolds de phases serveur non câblés au runtime** : `phase_1a_test_storage` (0041), `pool_pool`/`pool_member_state` (0059), `groups`/`group_members`/`group_loot_rolls` (0060), `creature_movement` (0062), `locale_strings` (0042, touchée seulement par des tests). → Garder si les phases arrivent, sinon élaguer ; documenter le pré-provisionnement.
+- **S** : `character_auras`, `spell_proc_template` (0061, récente) — probablement du server-first dont le code shardd n'est pas encore mergé. Garder, vérifier que le code suit.
+
+### 1.4 Données / assets orphelins (V sauf mention)
+
+- `game/data/shaders/luminance_reduce.comp.spv` — artefact compilé sans source ni référence ; le ticket M08.6 demandait sa suppression. Idem `src/client/render/shaders/water.{vert,frag}` (copies octet-pour-octet de `game/data/shaders/water.*`, seul le .spv est chargé).
+- `game/data/themes/` (4 fichiers) — les vrais thèmes vivent dans `game/data/ui/themes/` ; ce dossier top-level n'est lu par personne.
+- `game/data/items/tabard.json` (le tabard est en constantes code), `game/data/particles/weather_rain.json` + `weather_snow.json` (WeatherSystem a des pools internes), `game/data/ui/server_list/server_online.txt`, `game/data/zones/cell_n000_e000/`.
+- `game/data/configuration/animations/animation_sets.json`, `equipment/armor_sets.json`, `equipment/sockets_attachments.json` — données anticipées, aucun loader. Garder si le chantier personnages les câblera.
+- Localization : `banner.png` ×7 locales + `drapeau.png` de/es/it/pl/pt — seuls fr/en sont chargés (Engine.cpp:3909-3917).
+- `game/data/editor/tutorials/first_launch.json` — jamais lu ; contenu dupliqué en dur dans `TutorialIo.cpp`.
+
+### 1.5 Scripts / outils
+
+- **V mort** : `tools/Migrate-CellNaming.ps1` (one-shot déjà joué), `tools/asset_pipeline/detect_fbx_fps.py` (zéro réf).
+- **À documenter** : `tools/world_gen/raise_hill.py`, `tools/asset_pipeline/texture_nature.py` (récents, manuels, non documentés).
+- Tout le reste (scripts/*.sh, 6 outils CMake) est vivant et référencé par la CI/docs.
+
+---
+
+## 2. Client de jeu (`src/client/`)
+
+### 2.1 Code orphelin
+
+| | Constat |
+|---|---|
+| 🔴 V | **Module combat entier compilé mais jamais instancié** : `src/client/combat/` (AdvancedCombatUi, AoEPreviewSystem, AuraFXSystem, BuffBarPresenter, CombatHud) + `src/client/social/PartyHud.cpp`. Grep exhaustif : seules auto-références. |
+| 🟠 V | Idem : `fx/FXManager.cpp`, `crafting/HarvestCastBar.cpp`, `crafting/CraftingUi.cpp`, `world/ZonePreloadHook.cpp`, `world/PakReader.cpp`. |
+| 🟠 V | `settings/SettingsMenuUi.cpp` jamais instancié (le menu Options réel = AuthScreenOptions) + include mort dans AuthUi.h:87. |
+| 🟠 V | `ui_common/ThemeManager.cpp/h` — ancien système de thème mort, doublon conceptuel de LnTheme.h (utilisé, lui, par ~20 renderers). |
+| 🟠 V | Compilés mais référencés uniquement par leurs tests : `gameplay/ClientPrediction.cpp`, `world/terrain/TerrainLodWorker.cpp`, HazardSimulator, ShadeMapBuilder, HamletKitLibrary, FootstepAudioSurfaceHook. |
+| 🟡 V | `world/routine/RoutineSegmentReader.h` — seul header de src/client jamais inclus (cohérent : M101.8/9 différés). |
+| 🟡 V | Hot-reload shaders mort : `Engine::WatchShader` (Engine.cpp:12033) sans aucun appelant ; `Poll()`/`ApplyPending()` tournent chaque frame pour rien. |
+
+### 2.2 Anomalies
+
+| | Constat |
+|---|---|
+| 🔴 V | **Pattern systémique Vulkan** : ~11 passes de post-process (`LightingPass.cpp:720`, `TonemapPass.cpp:435`, `SsaoPass.cpp:337`, `TaaPass.cpp:313`, `BloomPass.cpp:357/703/1053`, `CloudPass.cpp:340`, `UnderwaterPass.cpp:456`, `VolumetricFogPass.cpp:451`, `DepthOfFieldPass.cpp:449`, SsaoBlurPass, `GeometryPass.cpp:1075`) créent un framebuffer temporaire dans Record() puis le **détruisent avant le vkQueueSubmit** (Engine.cpp:11079) → command buffer invalide, UB toléré par le driver actuel. Correctif : router vers `m_deferredDestroyQueue` (existe) ou cache framebuffer (comme ShadowMapPass/WaterPass/DecalPass). |
+| 🔴 V | **Collisions de touches in-game** (Engine.cpp:7600/7622/7651 vs 480/12281/12383) : **A** (strafe) toggle aussi le panneau Arena + envoie RequestTeams ; **Y** confirme la vente shop ET toggle Weather ; **G** rafraîchit l'enchère ET toggle BattleGround. Pas de registre central de binds. |
+| 🟠 S | `SkinnedRenderer` (h:171, kFrameSlots=32) : ring SSBO de bones partagé entre tous les draws skinnés ; au-delà de ~16 draws/frame avec 2 frames en vol → réécriture d'un slot encore lu (pose corrompue). Aucun assert. |
+| 🟠 V | Logout volontaire (Engine.cpp:12014-12031) ne fait **pas** de `SavePositionAsync`, contrairement à la fermeture (7466-7481) → position perdue depuis la dernière sauvegarde périodique. |
+| 🟠 V | FrameGraph.cpp:653 (STAB.7) : VMA désactivé, un `vkAllocateMemory` par image → risque `maxMemoryAllocationCount` (souvent 4096) + fragmentation. |
+| 🟡 V | Engine.cpp:12132-12138 : commentaire promet un bit-cast préservant le bit 63, le code remplace par 1. |
+| 🟡 V | AuthUiPresenterCore.cpp:1683 : `m_asyncResult.ready` lu hors mutex (data race bénigne, UB formel). |
+| 🟡 V | Engine.cpp:4111-4123 : log « DeferredPipeline init OK » inconditionnel même si Init a échoué. |
+| 🟡 V | Engine.cpp:10895/11061 : échec Begin/EndCommandBuffer → return avec sémaphore `imageAvailable` signalé non consommé. |
+| 🟡 V | `WaitConnected` + `ApplyMasterTlsConfig` dupliqués à l'identique ×3 (AuthScreenRegister, AuthScreenForgotPassword, AuthUiPresenterCore). |
+
+### 2.3 Optimisations
+
+- 🟠 V — Config string-keyed : `ToOwnedKey` (Config.cpp:734) alloue un std::string par lookup × ~41 `Get*` par frame dans Update(). → lookup hétérogène ou cache des valeurs chaudes.
+- 🟠 V — Chat : `BuildPanelText()`/`BuildHudPanelText()` reconstruisent tout le texte **chaque frame** (Engine.cpp:8244, ChatUi.cpp:443). → reconstruire sur changement (compteur de révision).
+- 🟠 V — RecordRemoteAvatars (Engine.cpp:11860-11932) : 3 `vector<Mat4>` par valeur + string + clés concaténées **par avatar et par frame** ; `vkMap/UnmapMemory` par draw (SkinnedRenderer.cpp:580/593). → buffers de pose réutilisables + mapping persistant.
+- 🟡 V — Purge `m_remoteSmoothed`/`m_remoteAnims` en O(n·m) par frame (Engine.cpp:12253-12269).
+- 🟡 V — `GameplayUdpClient::PollIncoming` (389-424) : vector de vectors alloué par frame.
+- 🟡 V — Accumulateur d'envoi input remis à 0 au lieu de soustraire la période (Engine.cpp:12219-12221) → cadence effective < request_tick_hz.
+
+Négatif sain : aucune nouvelle incohérence winding/cullMode (tout est conforme à la doc anti-régression) ; caches framebuffer/descriptors présents là où ça compte ; conventions français/PascalCase respectées dans le code récent.
+
+---
+
+## 3. Serveurs (`src/masterd/`, `src/shardd/`, `src/shared/`)
+
+### 3.1 Anomalies
+
+| | Constat |
+|---|---|
+| 🔴 V | **Race de concurrence** : `NetServer` (NetServer.cpp:866-890) dispatche sur un pool de N workers (défaut 4, masterd main_linux.cpp:210) mais plusieurs handlers master mutent un état partagé **sans mutex** : `LfgQueue`, `GmTicketSystem`, `MailManager`, `QuestStateTracker` (alors que Weather/Guild/Auction ont leurs mutex). Deux paquets concurrents = data race sur unordered_map. → mutex sur ces structures ou `worker_threads=1` documenté. |
+| 🟠 S | Même classe de risque : `RateLimitAndBan` (RateLimitAndBan.h:91) et `PasswordResetStore` (PasswordResetStore.h:88-92) sans verrou, appelés depuis les workers. |
+| 🟠 V | `GuildSystem.cpp` (shardd, :564-730) : seul îlot SQL **non converti en prepared statements** (~10 `mysql_query` concaténés, échappés mais fragiles) ; `DbDeleteGuild` (:589-606) supprime 3 tables **sans ScopedTransaction**. Nuance : compilé en mode fichier côté shard (sans ENGINE_HAS_MYSQL) → code DB mort à l'exécution actuelle. → convertir ou retirer (l'autorité semble être MysqlGuildStore côté master). |
+| 🟠 V | `ShardTicketValidator.cpp:64-72` : l'ensemble anti-rejeu `m_used_ticket_ids` n'est **jamais purgé** → fuite mémoire lente (les tickets expirent en 60 s, la purge est facile). |
+| 🟡 V | `ServerRegistry.cpp:127` : `SELECT id FROM game_servers` — la colonne s'appelle `server_id` (migration 0017) → échec silencieux du chemin ON DUPLICATE KEY (actif seulement si `server.self_register=true`). |
+| 🟡 V | `ticket_hmac_secret = "dev_secret_change_in_production"` livré dans les 3 configs `deploy/docker/config/*.json` → si déployé tel quel, forge de tickets d'admission shard possible. → refuser le boot si secret == valeur dev connue. |
+| 🟡 V | `SessionManager` documenté « v1 single-threaded » mais son hook `SetOnSessionClosed` appelle `FindConnIdForSession` O(N) ; si `Close` venait d'un worker, race non protégée. → clarifier/verrouiller. |
+
+### 3.2 Code orphelin
+
+- 🟡 V — `src/shared/server_bootstrap/main.cpp` : seul .cpp serveur hors de toute cible CMake (main Windows supplanté par `src/shardd/main_win.cpp`). → supprimer.
+- 🟡 S — Opcode `kOpcodeEnterDungeonRequest` (197) + `EnterDungeonHandler` câblés côté serveur, **aucun émetteur côté client** → handler qui répond dans le vide (client différé ?).
+
+### 3.3 Optimisations
+
+- 🟠 V — `/status` portail (masterd main_linux.cpp:1529-1535) : lookup login en **N+1** (une requête par compte en ligne). → `WHERE id IN (...)` ou cache TTL.
+- 🟠 V — `ChatRelayHandler.cpp:340-360` : sous-requête guilde exécutée **à chaque message guilde** (idem friends :433), sans cache. → cache d'appartenance invalidé sur join/leave.
+- 🟡 V — `ServerApp.cpp:2486-2503` (`MaybeSendSnapshots`) : ré-encodage complet des entités **par destinataire** (O(clients × entités)). → mutualiser par cellule.
+
+Négatifs sains : ownership personnage gaté partout (`WHERE id=? AND account_id=?`), gate UDP `HandleHello` solide (AdmittedCharacterRegistry, TTL pending), pas d'opcode dupliqué, chantier prepared statements quasi complet (sauf l'îlot GuildSystem ci-dessus).
+
+---
+
+## 4. Éditeur de carte (`src/world_editor/` + parties éditeur d'Engine)
+
+### 4.1 État du rapport d'audit 2026-06-05 : **aucun point corrigé depuis**
+
+Toujours ouverts (re-vérifiés) : P0 3.1 `reserve(count)` non plafonné (MeshInsertIo.cpp:149, DungeonPortalIo.cpp:147, VMapBridge.cpp:265) ; P0 6.1 Zone Presets sans rollback ; P0 4.1 érosion thermale non conservative ; 6.4 presets d'outils ignorés (OperationParams.cpp:135 / OperationDispatcher.cpp:515) ; 3.3 atmosphère écrite imbriquée mais relue en clé plate (WorldMapIo.cpp:1310 vs :1471) → jamais relue ; 1.1-1.4, 5.1, 5.2, 5.6, bloc `#if 0` de ~245 lignes (WorldEditorImGui.cpp:1363).
+
+### 4.2 Anomalies nouvelles — intégrité des données ⚠️
+
+| | Constat |
+|---|---|
+| 🔴 V | **Charger une carte ne réinitialise pas `TerrainDocument`** (WorldEditorSession.cpp:482-508, 615-661) : les chunks de la carte A restent en mémoire ; la première commande moderne sur la carte B déclenche `SyncWorldEditorHeightmapFromDocument` (Engine.cpp:12793) qui **réécrit la heightmap de B avec les hauteurs de A**. |
+| 🔴 V | **Undo trans-cartes** : `InitNewZoneTerrain` (WorldEditorShell.cpp:752) vide les chunks mais jamais `m_commandStack` (`CommandStack::Clear()` existe — et n'est appelé nulle part). Ctrl+Z après « Nouvelle carte » rejoue les deltas inverses de l'ancienne carte. |
+| 🔴 V | **Chemins chunks non namespacés par zone** (TerrainDocument.cpp:62-65, 138-139, 254-256) : `game/data/chunks/chunk_X_Z/terrain.bin` sans zoneId → deux cartes s'écrasent mutuellement au save. |
+| 🔴 V | **Perte silencieuse au save** : `WaterDocument`, `MeshInsertDocument`, `DungeonPortalDocument` n'ont **aucun** appel `SaveToDisk` hors tests (seul SaveTerrainChunks persiste terrain+splat, WorldEditorShell.cpp:760). Lacs, rivières, grottes, arches et portails placés sont perdus à la fermeture. |
+| 🔴 V | **Câblage réel des outils : 4/15, pas 15/15** (Engine.cpp:9904-9965) : seuls Sculpt, Stamp, MountainRange, ValleyChain reçoivent les inputs viewport. `SplatPaintTool::OnMouseDown/Move/Up` n'est appelé nulle part ; pire, pour les 11 autres outils le **pinceau legacy Raise** sculpte le terrain quand on clique. |
+| 🔴 V | **Double vérité heightmap** (Engine.cpp:10021-10057 vs 12834-12861) : le pinceau legacy édite la heightmap seule ; la sync document→heightmap réécrit ensuite chaque cellule couverte → coups de pinceau legacy silencieusement effacés. |
+| 🟠 V | Pas de pont SplatMap chunks → GPU (SplatPaintCommand.cpp:27-74) : même câblé, le paint moderne ne s'affichera pas (aucun observer symétrique à la sync heightmap). |
+| 🟠 V | `terrain.bin` corrompu → chunk plat silencieux non-dirty (TerrainDocument.cpp:93-101) ; la première édition + save **écrase l'original**. |
+
+### 4.3 Code orphelin nouveau (le stock croît au lieu de se résorber)
+
+- 🔴 V — **Tutoriel interactif M100.49 (PR #818) non câblé** : `tutorial/` + `help/OverlayGuidanceSystem` + `WidgetTargetRegistry` référencés uniquement par leurs tests ; les cibles du tutoriel (`toolbar.button.validate`, `panel.validation`, `menubar.file.new_from_preset` — TutorialIo.cpp:46-70) **n'existent nulle part** dans le shell.
+- 🟠 V — `diagnostic/` (PR #819) : DiagnosticSystem + 10 règles jamais instanciés hors tests.
+- 🟠 V — `wizard/` (PR #820) : QuickStartWizard/AutoGenerators jamais instanciés hors tests ; dépendra de ZonePresetExecutor dont le P0 rollback est ouvert.
+- 🟠 V — `ui/EditorAudioPanel.{h,cpp}` : **hors CMake**, référencé par personne (M43.5 inachevé).
+- 🟠 V — `InteractivePanel.{h,cpp}` : compilé, référencé par personne, pas même un test.
+- 🟠 V — `WorldEditorExporter.{h,cpp}` : utilisé seulement par un test ; l'export réel passe par `WorldMapIo::ExportRuntimeBundle` → **deux pipelines d'export parallèles**.
+- 🟡 V — Headers jamais inclus (non compilés, donc même pas validés par le compilateur) : `BridgeTool.h`, `FoliagePaintCommand.h`, `HamletGeneratorTool.h`, `HazardDocument.h`, `SplineCommand.h`, `WallTool.h`, `ui/IToolPropertiesPanelContent.h`, `PlaytestMode.h`.
+- 🟡 S — `routine/RoutineGraphDocument` sans aucune sérialisation : tout graphe construit est perdu à la fermeture (cohérent M101.8/9 différés — dette à tracer).
+
+### 4.4 Optimisations
+
+- 🔴 V — Pinceau splat/grass legacy : `FlushSplatMap`/`FlushGrassMask` **à chaque frame du drag** = re-upload complet + `vkQueueSubmit` + **`vkQueueWaitIdle`** (stall GPU par frame) + command pool/staging recréés + LOG_INFO par frame (Engine.cpp:10033/10041, TerrainEditingTools.cpp:255-260, 806). → flush au mouse-up / throttle + staging du frame.
+- 🟠 V — `OnChunkChanged` jette la coordonnée (flag global, Engine.cpp:12692-12695) : chaque commit/undo re-parcourt **tous** les chunks et re-upload la heightmap entière (~10-30 ms admis). → set de coords dirty.
+- 🟠 V — `SplatPaintCommand::TryMerge` (:102-117) : le commentaire promet une map (x,z), le code fait un scan linéaire par cellule → O(N²) par tick de stroke.
+- 🟡 V — LOG_INFO à chaque sync document→heightmap (Engine.cpp:12862).
+
+### 4.5 Documentation
+
+🟡 V — Règle « toute fonction éditeur en `///` » globalement respectée, sauf `WorldEditorImGui.cpp` (1934 lignes, 0 `///`) et `InteractivePanel.cpp`.
+
+---
+
+## 5. Web-portal (`web-portal/`)
+
+### 5.1 Anomalies (sécurité d'abord)
+
+| | Constat |
+|---|---|
+| 🔴 V | **Aucun rate-limiting sur le login** (app/api/auth/login/route.ts) ; combiné à Argon2id 64 Mo par tentative → brute-force ET vecteur DoS. |
+| 🟠 V | **Oracle temporel d'énumération** (lib/auth/portalLogin.ts:52-54) : identifiant inconnu → retour immédiat sans Argon2 ; compte existant → 2 hashes. → dummy verify. |
+| 🟠 V | **Aucun header de sécurité** (ni next.config.mjs, ni nginx, ni middleware) : pas de CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy. |
+| 🟠 S | **Pas de défense CSRF** au-delà de `SameSite=lax` sur toutes les mutations player/admin. → vérifier `Origin` ou token CSRF. |
+| 🟠 V | **Endpoints GET mutants** : confirm-email (route.ts:1130) et parental/validate (:1417) modifient la base sur un GET (prefetch/CSRF par image) ; leurs tokens sont stockés **en clair** dans `accounts`, contrairement au reset password (haché SHA-256). → hacher + POST. |
+| 🟡 V | request-email-change renvoie 409 « déjà utilisée » → énumération d'e-mails (auth requise, mineur). |
+| 🟡 V | Pas de rate-limit sur request-email-change et parental/request (envoi d'e-mails) — seul le recovery plafonne (3/h). |
+| 🟡 V | PATCH FAQ : `display_order` non coercé en nombre (faq/[id]/route.ts:474). |
+| 🟡 V | Fallback `verifyLegacyScryptPassword` toujours actif (portalLogin.ts:10-24) — vérifier qu'aucun hash legacy ne subsiste puis retirer. |
+| 🟡 V | Calcul d'âge parental par 365.25 jours (parental/request/route.ts:1387) au lieu du calcul calendaire (`computeAgeYears` existe déjà) — enjeu légal aux bornes d'anniversaire. |
+
+Négatifs sains : SQL 100 % paramétré, Argon2id bien paramétré, sessions opaques 256 bits avec autorité re-lue en DB, IDOR corrigés, pas de secret en dur, reset password exemplaire (haché, 10 min, usage unique, anti-énumération).
+
+### 5.2 Code orphelin
+
+- 🟡 V — `lib/exploits/exploitTier.ts` entier (réimplémenté en SQL inline dans admin/bugs/[id]/route.ts:95).
+- 🟡 V — 3 senders e-mail jamais appelés (sendVerificationEmail, sendWelcome, sendAccountConfirmed — ces e-mails partent du serveur de jeu) + **8 templates morts** (verification/welcome/account-confirmed ×2 langues, et `cgu-accepted.{fr,en}` sans aucun sender côté portail).
+- 🟡 V — Hiérarchie de rôles jamais exploitée : `isPlayer`, `hasAtLeast`, `roleLevel` (l'autorisation est binaire staff/player).
+- 🟡 V — CSS mort : `wp-stat-val`, `wp-grid-4`, `wp-table-wrap`, `wp-table` + descendants (tout le style de table admin).
+
+### 5.3 Optimisations
+
+- 🟠 V — `ensurePasswordRecoveryTables()` : 3 `CREATE TABLE IF NOT EXISTS` **à chaque requête** recovery (passwordRecovery.ts:117-162 et appels). → migration SQL au boot, retirer du chemin requête.
+- 🟡 V — Pool mysql2 sans `connectionLimit` explicite ; transporter nodemailer recréé à chaque e-mail (mémoïser + pool SMTP).
+
+---
+
+## 6. Synthèse des thèmes dominants
+
+1. **Le pattern « noyau livré non câblé » est systémique** : module combat client, tutoriel/diagnostic/wizard éditeur, ClientPrediction, TerrainLodWorker, EnterDungeon serveur, hiérarchie de rôles portail… Le code est testé unitairement mais aucune passe de câblage UI/runtime ne suit. Le stock **augmente** (3 sous-systèmes éditeur ajoutés depuis l'audit du 05-06).
+2. **Intégrité des données de l'éditeur** : c'est le risque le plus concret pour le travail des mappeurs (corruption inter-cartes, perte eau/mesh/portails au save, chunks non namespacés, double vérité heightmap).
+3. **Deux bugs runtime sérieux côté infra** : la race multi-worker des handlers master sans mutex, et la destruction de framebuffers avant submit dans ~11 passes Vulkan.
+4. **Sécurité portail** : fondamentaux sains, mais le périmètre transverse (rate-limit login, headers, CSRF, GET mutants) reste à faire.
+5. **Ménage rentable** : ~50 fichiers orphelins vérifiés + l'arbre `src/client/assets/` (111 fichiers) + 10 tables SQL DROP-candidates + 16 clés config mortes (dont 2 mismatches = bugs latents).
+
+## 7. Propositions de lots (à discuter)
+
+- **Lot A — Ménage sans risque** (suppressions pures, zéro impact runtime) : `src/client/assets/`, `game/data/themes/`, shaders morts, scripts one-shot, templates e-mail morts, `server_bootstrap/main.cpp`, CSS mort, `exploitTier.ts` ; + migration DROP des tables supplantées (`reset_tokens`, `auction_listings`).
+- **Lot B — Corrections critiques** : B1 mutex handlers master (serveur) ; B2 framebuffers → DeferredDestroyQueue (client) ; B3 intégrité éditeur (reset document au load, Clear() du command stack, SaveToDisk eau/mesh/portails, namespacing chunks par zone) ; B4 rate-limit login + headers sécurité (portail) ; B5 collisions de touches A/Y/G (client) ; B6 save position au logout.
+- **Lot C — Câbler ou supprimer (décision par feature)** : combat UI client, tutoriel/diagnostic/wizard éditeur, EditorAudioPanel, doublon AuctionUi, EnterDungeon, ClientPrediction/TerrainLodWorker, hot-reload shaders.
+- **Lot D — Optimisations** : flush splat au mouse-up (éditeur, le plus gros gain perçu), sync heightmap par chunk dirty, cache config/chat client, N+1 `/status` et cache guilde (serveur), CREATE TABLE hors chemin requête (portail).
+- **Lot E — Process** : règle « pas de merge d'un sous-système sans sa passe de câblage » + registre central des binds clavier in-game.
+
+---
+
+*Rapports d'agents source : 5 audits parallèles (client, serveur, éditeur, portail, transversal), 2026-06-10. Aucune modification de code effectuée.*

--- a/docs/superpowers/plans/2026-06-10-combat-sp1-creatures-visibles.md
+++ b/docs/superpowers/plans/2026-06-10-combat-sp1-creatures-visibles.md
@@ -1,0 +1,603 @@
+# Combat SP1 — Créatures visibles : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendre les mobs (déjà spawnés et répliqués par le serveur) visibles dans le client, avec des stats data-driven par archétype à la place des constantes codées en dur.
+
+**Architecture:** Un catalogue JSON `game/data/creatures/archetypes.json` est chargé des deux côtés : par shardd (nouvelle `CreatureArchetypeLibrary`, pattern `SpawnerRuntime`) pour les stats/XP, et par le client (nouveau `CreatureCatalog`, pattern parseur local à la `SkillSystem`) pour nom/niveau/mesh/échelle. Le `SnapshotEntity` gagne un champ `archetypeId` (wire-bump v8→v9) pour que le client sache quel archétype rendre. Le rendu réutilise le pipeline avatars distants (`GetRaceMesh`) et la plaque de nom existante.
+
+**Tech Stack:** C++20, CMake, protocole UDP gameplay maison (`ServerProtocol`), parseurs JSON locaux maison (pas de dépendance), tests CTest exécutés par la CI build-linux (pas de toolchain locale — la compilation et les tests se valident via CI).
+
+**Découpage en 2 PRs stackées :**
+- **PR-A (serveur)** : Tasks 1-6 — branche `combat-sp1-server`
+- **PR-B (client)** : Tasks 7-10 — branche `combat-sp1-client` stackée sur PR-A
+
+**Conventions repo à respecter** : commentaires en français, PascalCase pour les nouveaux fichiers/classes, ne PAS utiliser le terme banni (l'ancien nom de serveur MMO open-source) dans code/commits/PR, indiquer le déploiement en fin de PR (ici : ⚠️ lock-step shardd + client, wire-breaking v9).
+
+---
+
+### Task 1: Catalogue de données `archetypes.json`
+
+**Files:**
+- Create: `game/data/creatures/archetypes.json`
+
+- [ ] **Step 1: Recenser les archetypeId réellement référencés**
+
+Run: `Grep "archetypeId" game/data/zones/ -rn` (et `game/data/events/` si présent)
+Expected: au moins `game/data/zones/zone_0/spawners.json` → `"archetypeId": 100`. Noter tout autre id (spawners d'autres zones, events dynamiques, loot tables `game/data/loot/loot_tables.txt` colonne 1 = sourceArchetypeId).
+
+- [ ] **Step 2: Écrire le catalogue avec une entrée par id recensé**
+
+```json
+{
+  "archetypes": [
+    {
+      "id": 100,
+      "name": "Sanglier des collines",
+      "level": 2,
+      "stats": {
+        "hp": 60,
+        "damage": 5,
+        "accuracy": 80.0,
+        "rangeMeters": 2.5,
+        "critRate": 2.0,
+        "critMult": 1.5,
+        "attackPeriodMs": 2000
+      },
+      "xpReward": 10,
+      "model": { "mesh": "orcs", "scale": 0.9 }
+    }
+  ]
+}
+```
+
+Valeurs `hp: 60`, `damage: 5`, `xpReward: 10` = iso-comportement avec les constantes actuelles (`kDefaultMobHealth = 60`, `kBaseXpPerMobKill = 10`, dégâts mob par défaut) pour ne pas changer l'équilibrage en SP1. `accuracy`/`critRate`/`critMult` sont portés par le schéma mais consommés en SP2 (documenté dans le JSON ? non — JSON sans commentaires ; documenté dans le header de la library, Task 2). Ajouter une entrée par id supplémentaire trouvé au Step 1 (mêmes stats par défaut, nom distinct).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game/data/creatures/archetypes.json
+git commit -m "feat(data): catalogue d'archétypes de créatures (combat SP1)"
+```
+
+---
+
+### Task 2: `CreatureArchetypeLibrary` (serveur) — tests d'abord
+
+**Files:**
+- Create: `src/shardd/gameplay/creature/CreatureArchetypeLibrary.h`
+- Create: `src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp`
+- Create: `src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp`
+- Modify: `src/CMakeLists.txt` (3 endroits, voir Task 3)
+
+- [ ] **Step 1: Écrire le header**
+
+```cpp
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace engine::server
+{
+	/// Un archétype de créature data-driven chargé depuis
+	/// `game/data/creatures/archetypes.json`. Porte les stats de combat du mob
+	/// (consommées par ServerApp au spawn), la récompense d'XP au kill, et les
+	/// informations d'apparence (mesh/scale/nom/niveau) que le client résout de
+	/// son côté via le même fichier (cf. CreatureCatalog client).
+	/// `accuracy`/`critRate`/`critMult` sont portés par le schéma dès SP1 mais ne
+	/// sont consommés qu'à partir de SP2 (jets de précision/critique).
+	struct CreatureArchetype
+	{
+		uint32_t archetypeId = 0;
+		std::string name;
+		uint32_t level = 1;
+		uint32_t hp = 1;
+		uint32_t damage = 0;
+		float accuracy = 100.0f;
+		float rangeMeters = 2.0f;
+		float critRate = 0.0f;
+		float critMult = 1.5f;
+		uint32_t attackPeriodMs = 2000;
+		uint32_t xpReward = 0;
+		std::string meshKey;
+		float scale = 1.0f;
+	};
+
+	/// Catalogue serveur des archétypes de créatures, résolu depuis
+	/// `paths.content` (même politique stricte que SpawnerRuntime : fichier
+	/// absent/illisible ou entrée invalide = échec d'Init, le shard ne boote pas
+	/// avec un catalogue corrompu).
+	class CreatureArchetypeLibrary final
+	{
+	public:
+		/// Capture la config utilisée pour résoudre le JSON du catalogue.
+		explicit CreatureArchetypeLibrary(const engine::core::Config& config);
+
+		/// Charge et valide `creatures/archetypes.json`. Idempotent (warn si déjà
+		/// initialisé). Retourne false si le fichier manque ou si une entrée est
+		/// invalide (id dupliqué, hp/attackPeriodMs nuls, champs manquants).
+		bool Init();
+
+		/// Retourne l'archétype demandé, ou nullptr s'il est inconnu.
+		const CreatureArchetype* Find(uint32_t archetypeId) const;
+
+		/// Nombre d'archétypes chargés (0 avant Init).
+		size_t Count() const { return m_archetypes.size(); }
+
+		/// Variante testable : parse depuis un texte JSON en mémoire (pas d'I/O).
+		/// Utilisée par Init() (qui lit le fichier) et par les tests unitaires.
+		bool LoadFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		engine::core::Config m_config;
+		std::unordered_map<uint32_t, CreatureArchetype> m_archetypes;
+		bool m_initialized = false;
+	};
+}
+```
+
+- [ ] **Step 2: Écrire les tests (CTest, mêmes conventions que les tests shardd existants — regarder `src/shardd/gameplay/spawner/` ou un `*Tests.cpp` voisin pour le harnais assert utilisé, et le reproduire)**
+
+Cas à couvrir (un `assert`/check par cas, harnais du repo) :
+
+```cpp
+// CreatureArchetypeLibraryTests.cpp — résumé des cas (code complet au moment
+// de l'implémentation, en copiant le harnais d'un *Tests.cpp shardd voisin) :
+// 1. LoadFromText(JSON valide à 2 archétypes) → true, Count()==2,
+//    Find(100)->hp == 60, Find(100)->meshKey == "orcs", Find(999) == nullptr.
+// 2. LoadFromText(JSON sans "archetypes") → false, erreur non vide.
+// 3. LoadFromText(id dupliqué) → false.
+// 4. LoadFromText(hp == 0) → false ; attackPeriodMs == 0 → false.
+// 5. LoadFromText(scale absent) → true, scale == 1.0f (défaut) ;
+//    model absent → false (mesh obligatoire).
+```
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Copier le parseur JSON local de `src/shardd/gameplay/spawner/SpawnerRuntime.cpp:21-403` (classe `JsonParser` + helpers `FindObjectMember`/`TryGetUint`/`TryGetFloat` dans le namespace anonyme — c'est la convention du repo : parseur local par module, pas de dépendance). `Init()` lit `creatures/archetypes.json` via `engine::platform::FileSystem::ReadAllTextContent(m_config, "creatures/archetypes.json")` puis délègue à `LoadFromText`. `LoadFromText` valide : racine objet avec tableau `archetypes` non vide ; par entrée : `id` uint > 0 unique, `name` string non vide, `level` uint ≥ 1, `stats.hp` > 0, `stats.damage` uint, `stats.accuracy`/`stats.rangeMeters`/`stats.critRate`/`stats.critMult` floats finis, `stats.attackPeriodMs` > 0, `xpReward` uint, `model.mesh` string non vide, `model.scale` float > 0 optionnel (défaut 1.0). Logs `[CreatureArchetypeLibrary]` même format que SpawnerRuntime. Toutes les fonctions documentées en `///` français.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shardd/gameplay/creature/
+git commit -m "feat(shardd): CreatureArchetypeLibrary — catalogue d'archétypes data-driven + tests"
+```
+
+---
+
+### Task 3: Câblage CMake
+
+**Files:**
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1: Ajouter le .cpp aux deux listes de sources qui contiennent déjà SpawnerRuntime.cpp**
+
+Aux deux occurrences de `${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spawner/SpawnerRuntime.cpp` (src/CMakeLists.txt:71 et :1144), ajouter juste au-dessus :
+
+```cmake
+    # Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
+```
+
+- [ ] **Step 2: Enregistrer le test**
+
+Localiser la liste de tests contenant `${CMAKE_SOURCE_DIR}/src/shared/network/ServerProtocolTests.cpp` (src/CMakeLists.txt:527) et repérer comment les `*Tests.cpp` shardd voisins sont enregistrés (exécutable de test + `add_test`). Ajouter `CreatureArchetypeLibraryTests.cpp` selon le même pattern, avec `CreatureArchetypeLibrary.cpp` dans les sources du même exécutable si la liste est explicite. Vérifier les exclusions ctest de `.github/workflows/build-linux.yml` (option `-E`) : ne pas nommer le test d'une façon qui matcherait une exclusion existante.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/CMakeLists.txt
+git commit -m "build: câblage CreatureArchetypeLibrary (server_app + shard_app + tests)"
+```
+
+---
+
+### Task 4: Stats d'archétype appliquées au spawn (ServerApp)
+
+**Files:**
+- Modify: `src/shared/server_bootstrap/ServerApp.h` (membre library + champ xpReward sur MobEntity, autour de :170-200)
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` (InitSpawners :1582+, SpawnSpawnerMob :1972-1984, mob d'événement dynamique :2246-2255, HandleAttackRequest :2725+ pour l'XP)
+
+- [ ] **Step 1: Ajouter le membre et le champ**
+
+Dans `ServerApp.h` : `#include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"` (même pattern d'include cross-dossier que SpawnerRuntime) ; dans la section des membres runtime (à côté de `m_spawnerRuntime`) :
+
+```cpp
+		/// Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
+		CreatureArchetypeLibrary m_archetypeLibrary;
+```
+
+(initialisé dans la liste d'init du constructeur avec `m_config`, comme `m_spawnerRuntime`). Dans `struct MobEntity` (ServerApp.h:170-200), après `leashDistanceMeters` :
+
+```cpp
+		/// Combat SP1 — XP attribuée au tueur, copiée depuis l'archétype au spawn.
+		uint32_t xpReward = 0;
+```
+
+- [ ] **Step 2: Init + validation croisée dans InitSpawners**
+
+Au début de `ServerApp::InitSpawners()` (ServerApp.cpp:1582), avant la boucle sur les définitions :
+
+```cpp
+		if (!m_archetypeLibrary.Init())
+		{
+			LOG_ERROR(Net, "[ServerApp] Spawner init FAILED: archetype library load failed");
+			return false;
+		}
+```
+
+Dans la boucle, après lecture de `definition`, valider :
+
+```cpp
+			if (m_archetypeLibrary.Find(definition.archetypeId) == nullptr)
+			{
+				LOG_ERROR(Net, "[ServerApp] Spawner init FAILED: unknown archetype (spawner_id={}, archetype_id={})",
+					definition.spawnerId,
+					definition.archetypeId);
+				m_spawners.clear();
+				return false;
+			}
+```
+
+- [ ] **Step 3: Appliquer les stats aux deux sites de spawn**
+
+À `SpawnSpawnerMob` (ServerApp.cpp:1972-1984), remplacer le bloc stats/combat par :
+
+```cpp
+		// Combat SP1 — stats data-driven depuis l'archétype (validé à l'init,
+		// Find ne peut pas échouer ici ; garde défensive quand même).
+		const CreatureArchetype* archetype = m_archetypeLibrary.Find(spawner.definition.archetypeId);
+		const uint32_t mobHealth = (archetype != nullptr) ? archetype->hp : kDefaultMobHealth;
+		const uint32_t mobDamage = (archetype != nullptr) ? archetype->damage : kDefaultMobDamage;
+		mob.stats.currentHealth = mobHealth;
+		mob.stats.maxHealth = mobHealth;
+		mob.combat = BuildDefaultCombatComponent(m_tickHz, mobDamage);
+		if (archetype != nullptr)
+		{
+			mob.combat.attackRangeMeters = archetype->rangeMeters;
+			// attackPeriodMs → ticks (arrondi au tick supérieur, minimum 1 tick).
+			mob.combat.cooldownTicks = std::max<uint32_t>(1u,
+				(archetype->attackPeriodMs * m_tickHz + 999u) / 1000u);
+			mob.xpReward = archetype->xpReward;
+		}
+```
+
+Appliquer le même bloc au spawn de mob d'événement dynamique (ServerApp.cpp:2246-2255, avec `spawnDefinition.archetypeId`). Vérifier la formule de `BuildDefaultCombatComponent` (ServerApp.cpp:166) pour garder `cooldownTicks` homogène (la formule existante sert de référence d'unité : si elle calcule déjà `tickHz * périodeSec`, réutiliser sa convention).
+
+- [ ] **Step 4: XP par archétype au kill**
+
+Dans `HandleAttackRequest` (ServerApp.cpp:~2740), remplacer :
+
+```cpp
+			DistributePartyXp(*client,
+			    target->positionMetersX,
+			    target->positionMetersZ,
+			    kBaseXpPerMobKill);
+```
+
+par :
+
+```cpp
+			// Combat SP1 — XP data-driven par archétype (fallback constante legacy
+			// pour un mob spawné avant l'introduction du catalogue).
+			DistributePartyXp(*client,
+			    target->positionMetersX,
+			    target->positionMetersZ,
+			    target->xpReward != 0u ? target->xpReward : kBaseXpPerMobKill);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/server_bootstrap/ServerApp.h src/shared/server_bootstrap/ServerApp.cpp
+git commit -m "feat(shardd): stats de mobs data-driven par archétype + XP au kill par archétype"
+```
+
+---
+
+### Task 5: `archetypeId` dans les snapshots (wire-bump v8→v9)
+
+**Files:**
+- Modify: `src/shared/network/ReplicationTypes.h` (struct SnapshotEntity :107-117)
+- Modify: `src/shared/network/ServerProtocol.h` (:39 kProtocolVersion)
+- Modify: `src/shared/network/ServerProtocol.cpp` (EncodeSnapshot :513-547, DecodeSnapshot :298-380)
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` (TryBuildSnapshotEntity :3989-4028, commentaire chunking :4268-4272 + constante kMaxEntitiesPerChunk)
+- Modify: `src/shared/network/ServerProtocolTests.cpp` (tests snapshot existants)
+
+- [ ] **Step 1: Étendre les tests de roundtrip snapshot existants**
+
+Dans `ServerProtocolTests.cpp`, localiser les tests Encode/DecodeSnapshot (chercher `EncodeSnapshot`) et : (a) ajouter `archetypeId` non nul sur une entité de test (ex. `entity.archetypeId = 100u;`) et l'assert correspondant après décodage ; (b) ajouter un cas « mob » : `playerClientId == 0`, `characterName` vide, `archetypeId == 100` → roundtrip intact.
+
+- [ ] **Step 2: Étendre la struct**
+
+Dans `ReplicationTypes.h`, après `animationState` :
+
+```cpp
+		/// Combat SP1 — archétype de créature (0 = joueur ou loot bag). Permet au
+		/// client de résoudre nom/niveau/mesh/échelle dans son CreatureCatalog.
+		/// Wire-bump v8→v9 : u32 ajouté après animationState dans chaque entité.
+		uint32_t archetypeId = 0;
+```
+
+- [ ] **Step 3: Bump + encode/decode**
+
+`ServerProtocol.h:39` : `inline constexpr uint16_t kProtocolVersion = 9;` (et adapter le commentaire au-dessus). Dans `EncodeSnapshot` (ServerProtocol.cpp:513) : après `WriteU8(packet, static_cast<uint8_t>(entity.animationState));` ajouter :
+
+```cpp
+			// Combat SP1 (wire v9) : archétype de créature (0 = joueur / loot bag).
+			WriteU32(packet, entity.archetypeId);
+```
+
+Mettre à jour le commentaire de sizing : « 8 + 40 + 4 + 2 + 2 + 1 + 4 = 61 par entité (nom et genre vides) » et le `BeginPacket(..., 24 + (entities.size() * 61))`. Dans `DecodeSnapshot` (ServerProtocol.cpp:298) : `minimumPayloadSize = 24 + (entityCount * 61)` (adapter le commentaire « 57 » → « 61 ») ; après la lecture d'`animationState` :
+
+```cpp
+			// Combat SP1 (wire v9) : archétype de créature, u32 après animationState.
+			if (offset + 4u > payload.size())
+			{
+				outEntities.clear();
+				return false;
+			}
+			entity.archetypeId = ReadU32(payload, offset);
+			offset += 4u;
+```
+
+- [ ] **Step 4: Producteur + budget MTU**
+
+Dans `TryBuildSnapshotEntity` (ServerApp.cpp:4011-4017), branche MobEntity :
+
+```cpp
+		if (const MobEntity* mob = FindMobByEntityId(entityId))
+		{
+			outEntity.entityId = mob->entityId;
+			outEntity.state = BuildEntityState(*mob);
+			// playerClientId reste 0 (entite non-joueur, pas de plaque joueur).
+			// Combat SP1 : l'archetypeId permet au client de rendre le mob
+			// (mesh/nom/niveau resolus dans son CreatureCatalog).
+			outEntity.archetypeId = mob->archetypeId;
+			return true;
+		}
+```
+
+Dans `SendSnapshot` (ServerApp.cpp:4268-4274) : adapter le commentaire (« Une entite = 61 o ») et la constante : `constexpr size_t kMaxEntitiesPerChunk = 19u;` (1160 / 61 = 19,0 — on garde la même marge de sécurité que le 20/22 précédent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/network/ReplicationTypes.h src/shared/network/ServerProtocol.h src/shared/network/ServerProtocol.cpp src/shared/server_bootstrap/ServerApp.cpp src/shared/network/ServerProtocolTests.cpp
+git commit -m "feat(net): archetypeId dans SnapshotEntity — wire-bump protocole v8->v9"
+```
+
+---
+
+### Task 6: PR-A — docs, push, CI
+
+**Files:**
+- Modify: `CODEBASE_MAP.md` (nouvelle section courte « Combat SP1 » ou enrichissement de la section serveur : catalogue d'archétypes + wire v9)
+- Create: PR GitHub
+
+- [ ] **Step 1: Mettre à jour CODEBASE_MAP.md** — 5-10 lignes : `game/data/creatures/archetypes.json`, `CreatureArchetypeLibrary` (shardd), champ `archetypeId` snapshot (v9), spec/plan sous docs/superpowers/. La spec et le plan sont committés dans cette PR (`git add docs/superpowers/specs/2026-06-10-combat-system-design.md docs/superpowers/plans/2026-06-10-combat-sp1-creatures-visibles.md docs/audit/2026-06-10-audit-global-4-parties.md`).
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin combat-sp1-server
+gh pr create --title "feat(shardd): Combat SP1-A — archétypes de créatures data-driven + archetypeId snapshot (wire v9)" --body "<résumé + section Déploiement : ⚠️ lock-step shardd + client requis (wire-bump v9) ; merger PR-A avant PR-B>"
+```
+
+- [ ] **Step 3: Surveiller la CI** (build-linux ~10 min, build-windows ~30 min — ScheduleWakeup ~1700s) et corriger les erreurs de compilation/tests jusqu'au vert.
+
+---
+
+### Task 7: `CreatureCatalog` client
+
+**Files:**
+- Create: `src/client/world/CreatureCatalog.h`
+- Create: `src/client/world/CreatureCatalog.cpp`
+- Modify: `src/CMakeLists.txt` (liste engine_core, à côté des entrées `src/client/world/` existantes, ex. PakReader.cpp src/CMakeLists.txt:~308)
+
+- [ ] **Step 1: Header**
+
+```cpp
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace engine::client
+{
+	/// Apparence client d'un archétype de créature, résolue depuis le même
+	/// `game/data/creatures/archetypes.json` que le serveur (le client n'utilise
+	/// que name/level/model — les stats restent l'autorité du serveur).
+	struct CreatureAppearance
+	{
+		std::string name;
+		uint32_t level = 1;
+		/// Clé de mesh de race existant ("orcs", "humains", …) réutilisé pour le
+		/// rendu du mob en attendant des assets créatures dédiés (cf. spec SP1).
+		std::string meshKey;
+		float scale = 1.0f;
+	};
+
+	/// Catalogue client des archétypes (lecture seule, chargé une fois au boot).
+	/// Politique tolérante côté client (contrairement au serveur) : fichier
+	/// absent/invalide = catalogue vide + LOG_WARN, les mobs sont alors rendus
+	/// avec le fallback (mesh humains, nom "Créature <id>").
+	class CreatureCatalog final
+	{
+	public:
+		/// Charge `creatures/archetypes.json` depuis `paths.content`. Retourne
+		/// false (catalogue vide) si absent/invalide — non bloquant côté client.
+		bool Init(const engine::core::Config& config);
+
+		/// Retourne l'apparence de l'archétype, ou nullptr si inconnu.
+		const CreatureAppearance* Find(uint32_t archetypeId) const;
+
+		/// Variante testable sans I/O (parse un texte JSON en mémoire).
+		bool LoadFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		std::unordered_map<uint32_t, CreatureAppearance> m_appearances;
+	};
+}
+```
+
+- [ ] **Step 2: Implémentation** — copier le parseur JSON local de `SkillSystem.cpp` (convention client) ; parsing des mêmes champs que Task 2 mais en ne retenant que name/level/model ; logs `[CreatureCatalog]`. Toutes fonctions en `///` français.
+
+- [ ] **Step 3: CMake + instanciation Engine** — ajouter `CreatureCatalog.cpp` à la liste engine_core (à côté des autres `src/client/world/*.cpp`) ; dans `Engine.h`, membre `engine::client::CreatureCatalog m_creatureCatalog;` (section des systèmes gameplay client) ; dans `Engine.cpp`, à l'init (près du chargement SkillSystem / des configs gameplay — chercher `SkillSystem` dans Engine.cpp pour le point d'ancrage) : `m_creatureCatalog.Init(m_cfg);` (non bloquant).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/client/world/CreatureCatalog.h src/client/world/CreatureCatalog.cpp src/CMakeLists.txt src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(client): CreatureCatalog — apparences d'archétypes de créatures"
+```
+
+---
+
+### Task 8: `archetypeId` propagé jusqu'au modèle UI
+
+**Files:**
+- Modify: `src/client/ui_common/UIModel.h` (struct UIRemoteEntity :308-334)
+- Modify: `src/client/ui_common/UIModel.cpp` (ApplySnapshot, boucle de remplissage des remoteEntities, ~:700-740)
+
+- [ ] **Step 1: Champ UIRemoteEntity**
+
+Après `animationState` (UIModel.h:333) :
+
+```cpp
+		/// Combat SP1 : archétype de créature propagé via le SnapshotEntity (wire
+		/// v9). 0 pour les joueurs et loot bags ; ≠ 0 pour les mobs — le rendu
+		/// résout nom/niveau/mesh/échelle via Engine::m_creatureCatalog.
+		uint32_t archetypeId = 0;
+```
+
+- [ ] **Step 2: Copie dans ApplySnapshot**
+
+Dans la boucle de `UIModel.cpp` qui construit `m_model.remoteEntities` depuis `m_snapshotScratch` (après la copie de `animationState`), ajouter `remote.archetypeId = entity.archetypeId;` (adapter au nom de variable locale réel de la boucle).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/client/ui_common/UIModel.h src/client/ui_common/UIModel.cpp
+git commit -m "feat(client): archetypeId propagé du snapshot au UIRemoteEntity"
+```
+
+---
+
+### Task 9: Rendu des mobs — mesh + plaque de nom
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` — boucle nameplates (~:10179-10215) et `RecordRemoteAvatars` (~:11855-11940)
+
+- [ ] **Step 1: Plaque de nom des mobs**
+
+Dans la boucle nameplate (Engine.cpp:10189), remplacer le `continue` inconditionnel :
+
+```cpp
+					if (re.playerClientId == 0u && re.archetypeId == 0u)
+						continue; // loot bag : pas de nameplate
+```
+
+et construire le label mob après le label joueur existant :
+
+```cpp
+					// Combat SP1 — plaque mob : "Nom (niv. N)  PV/PVmax" résolue
+					// via le CreatureCatalog ; fallback générique si l'archétype
+					// est inconnu du catalogue client (catalogue absent/désynchro).
+					std::string label;
+					if (re.playerClientId != 0u)
+					{
+						label = !re.displayName.empty()
+							? re.displayName
+							: ("P" + std::to_string(re.playerClientId));
+					}
+					else
+					{
+						const engine::client::CreatureAppearance* appearance =
+							m_creatureCatalog.Find(re.archetypeId);
+						const std::string mobName = (appearance != nullptr)
+							? appearance->name
+							: ("Creature " + std::to_string(re.archetypeId));
+						const uint32_t mobLevel = (appearance != nullptr) ? appearance->level : 1u;
+						label = mobName + " (niv. " + std::to_string(mobLevel) + ")  "
+							+ std::to_string(re.currentHealth) + "/" + std::to_string(re.maxHealth);
+					}
+```
+
+(La couleur du texte mob peut rester celle des joueurs en SP1 ; ne pas afficher la plaque si `(re.stateFlags & 1u) != 0` — mob mort en attente de despawn.)
+
+- [ ] **Step 2: Mesh des mobs dans RecordRemoteAvatars**
+
+Au `continue` des `playerClientId == 0u` (Engine.cpp:11866), remplacer par une résolution d'apparence :
+
+```cpp
+			// Combat SP1 — les mobs (archetypeId != 0) réutilisent un mesh de race
+			// existant déclaré par le catalogue ; les loot bags (archetypeId == 0)
+			// gardent leur pipeline dédié (pas de mesh humanoïde).
+			std::string meshRace;
+			std::string meshGender;
+			float meshScale = 1.0f;
+			if (re.playerClientId != 0u)
+			{
+				meshRace = "humains";
+				meshGender = (re.gender == "male" || re.gender == "female") ? re.gender : std::string{"male"};
+			}
+			else if (re.archetypeId != 0u)
+			{
+				const engine::client::CreatureAppearance* appearance = m_creatureCatalog.Find(re.archetypeId);
+				meshRace = (appearance != nullptr && !appearance->meshKey.empty()) ? appearance->meshKey : std::string{"humains"};
+				meshGender = "male";
+				meshScale = (appearance != nullptr) ? appearance->scale : 1.0f;
+			}
+			else
+			{
+				continue; // loot bag
+			}
+			engine::render::skinned::SkinnedMesh* remoteMesh = GetRaceMesh(meshRace, meshGender);
+			if (remoteMesh == nullptr && re.archetypeId != 0u)
+				remoteMesh = GetRaceMesh("humains", "male"); // fallback mob : race inconnue du registre
+			if (remoteMesh == nullptr)
+				continue;
+```
+
+puis appliquer `meshScale` à la matrice modèle du draw (localiser dans la suite de la boucle la construction de la matrice modèle — translation/rotation à partir de `px/py/pz/yaw` — et multiplier par une matrice d'échelle uniforme `Mat4::Scale(meshScale)` si l'API Mat4 du repo l'offre, sinon multiplier les 3 colonnes de rotation par `meshScale` ; vérifier `src/shared/math/Math.h`). Si l'échelle complexifie (skinning), la différer avec un commentaire `// Combat SP1 : échelle différée (skinning), cf. plan` — l'échelle est cosmétique, pas bloquante.
+
+Attention budget : les mobs entrent dans le ring SSBO partagé du SkinnedRenderer (kFrameSlots=32, constat d'audit : >16 draws skinnés/frame = risque de pose corrompue). La zone_0 n'a qu'1 mob ; ajouter un commentaire au site de draw mob rappelant la limite, sans la corriger ici.
+
+- [ ] **Step 3: Animation des mobs** — les mobs arrivent avec `animationState = Idle` ; vérifier que le chemin d'animation des avatars distants tolère une entité sans `gender`/`characterName` (déjà le cas pour les joueurs sans nom). Pas d'animation de combat en SP1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(client): rendu des mobs — mesh d'archétype + plaque nom/niveau/PV"
+```
+
+---
+
+### Task 10: PR-B — docs, push, CI
+
+- [ ] **Step 1: CODEBASE_MAP.md** — compléter la section Combat SP1 (CreatureCatalog client, rendu mobs).
+- [ ] **Step 2: Push + PR stackée**
+
+```bash
+git push -u origin combat-sp1-client
+gh pr create --base combat-sp1-server --title "feat(client): Combat SP1-B — rendu des créatures (mesh archétype + nameplates)" --body "<résumé + Déploiement : ⚠️ lock-step shardd + client (wire v9, porté par PR-A) ; ordre de merge : PR-A puis PR-B>"
+```
+
+- [ ] **Step 3: CI verte sur les deux PRs**, puis indiquer à l'utilisateur : merger PR-A puis PR-B, redéployer shardd ET redistribuer le client en lock-step (un client v8 ne décode plus les snapshots v9), valider en jeu : le sanglier de zone_0 visible avec sa plaque, attaquable… non — l'attaque client arrive en SP2 ; valider : mob visible, plaque correcte, pas de régression joueurs distants.
+
+---
+
+## Self-review (faite à l'écriture)
+
+- **Couverture spec §4** : 4.1 données → Task 1 ; 4.2 stats serveur + xpReward → Task 4 ; 4.3 wire → Task 5 ; 4.4 rendu → Tasks 7-9 ; 4.5 livraison/déploiement → Tasks 6/10. §8 tests → Tasks 2/5. §9 déploiement → Tasks 6/10. Pas d'écart.
+- **Placeholders** : les deux points volontairement délégués à l'exécution (harnais exact des tests shardd, API d'échelle de Mat4) sont bornés par des instructions de localisation précises et un fallback documenté — pas de « TBD » ouvert.
+- **Cohérence de types** : `CreatureArchetype.meshKey`/`CreatureAppearance.meshKey` string ; `archetypeId` uint32 partout (wire u32) ; `xpReward` uint32 ; `kMaxEntitiesPerChunk` 20→19 cohérent avec l'entité passée de 57 à 61 octets min.

--- a/docs/superpowers/specs/2026-06-10-combat-system-design.md
+++ b/docs/superpowers/specs/2026-06-10-combat-system-design.md
@@ -1,0 +1,249 @@
+# Spec — Système de Combat (chantier SP1→SP4)
+
+> Validée le 2026-06-10. Issue de l'audit global du même jour (le module combat
+> client existe, compilé, jamais câblé) et de la décision : **terminer plutôt que
+> supprimer**. Ordre des chantiers acté : combat → groupes/party → métiers/récolte
+> → prédiction client. Cette spec couvre le combat : SP1/SP2 en détail, SP3/SP4 en
+> cadrage (chacun aura sa propre passe de design détaillé).
+
+## 1. Objectif
+
+Faire vivre l'UI combat client déjà écrite (`src/client/combat/` : CombatHud,
+AdvancedCombatUi, BuffBarPresenter, AuraFXSystem, AoEPreviewSystem) en livrant la
+logique métier serveur manquante (shardd), la réplication, et le câblage client —
+en server-first, par sous-projets livrables séparément.
+
+## 2. Décisions de gameplay (validées utilisateur)
+
+| Sujet | Décision |
+|---|---|
+| Ciblage | **Clic** (raycast écran→monde sur les entités) **+ Tab** (cycle des hostiles par distance). |
+| Mort du joueur | **Écran de mort** (overlay + bouton « Réapparaître ») → respawn au **spawn de zone**, PV pleins. Cimetières/résurrection : plus tard. |
+| XP au kill | **Oui dès SP2** — `xpReward` par archétype, attribué au tueur, boucle sur la chaîne XP/level-up/recompute stats existante (PR #867). |
+| Riposte | **Dès SP2** : la créature rend les coups (sans déplacement). Poursuite/leash = SP4. |
+| Kits de sorts SP3 | **Kits starter par profil** (8 profils × 3-4 sorts) proposés par Claude, **validés par l'utilisateur avant implémentation**, déclinés par classe via `factions.json`. |
+
+## 3. Existant sur lequel on s'appuie (état 2026-06-10)
+
+- **Serveur** : `Unit` avec 11 stats dérivées dirty-trackées (hp, resource, damage,
+  accuracy, range, critRate, critMult, speeds, stamina, perception, stealth +
+  secondaryResource) ; `CharacterStatsEngine` déterministe (character_stats.json
+  embarqué) ; `Creature.h` (Unit + templateEntry + spawnId) ; spawners JSON par zone
+  (`game/data/zones/*/spawners.json` : id, archetypeId, position, count, respawnSec,
+  leashDistanceMeters) ; `HostileRefManager` (Wave 19) + `ThreatList` (Wave 8) ;
+  `SpellMgr`/`SpellTemplate`/`Aura` header-only (Wave 23) ; migration
+  `0061_spell_aura.sql` (tables `character_auras`, `spell_proc_template`) déjà en base.
+- **Réseau** : snapshots UDP périodiques (`SnapshotEntity` : entityId, EntityState
+  {pos, yaw, vel, currentHealth, maxHealth, stateFlags}, playerClientId,
+  characterName, gender, animationState) ; `CombatEventMessage` (struct + Encode/
+  Decode existants, **sans opcode assigné**) ; plage d'opcodes **206+ libre**.
+- **Client** : `UIModel` avec `combatLog` (`UICombatLogEntry`), `playerStats`,
+  `targetStats`, HUD PV/ressource câblé (PR #866) ; présentateurs combat complets
+  (cf. §1) qui ne demandent que des données.
+- **Ticket existant** : M14.1 « Combat serveur : validation + damage + events » —
+  SP2 le réalise et l'étend.
+
+### 3.bis État réel constaté à la lecture du code (2026-06-10, avant plan SP1)
+
+La lecture directe de `src/shared/server_bootstrap/ServerApp.{h,cpp}` et du
+protocole révèle un existant **bien plus avancé** que la cartographie initiale :
+
+- **Le serveur gameplay UDP (ServerApp, exécuté par shardd) a déjà un combat MVP
+  complet** : `MessageKind::AttackRequest = 8` et `CombatEvent = 9` sont des kinds
+  wire **déjà définis et encodables/décodables** ; `HandleAttackRequest`
+  (ServerApp.cpp:2596) valide endpoint/clientId/mort/cooldown/portée et applique
+  les dégâts ; `TryMobAttackPlayer` (riposte) existe, y compris la **mort du
+  joueur** (flag + save) ; les mobs ont une **IA patrol/aggro/leash**
+  (`MobAiState`, `threatTable`, `aggroTargetEntityId`), du **loot** (loot bags +
+  visibilité party) et l'**XP de groupe au kill** (`DistributePartyXp`).
+- Les mobs sont **déjà spawnés** (SpawnerRuntime JSON par zone) et **déjà inclus
+  dans les snapshots** (`TryBuildSnapshotEntity`, branche MobEntity).
+- Côté client, `UIModelBinding::ApplyCombatEvent` décode déjà CombatEvent et
+  remplit `UIModel::combatLog`.
+
+**Les manques réels sont donc** : (a) stats mobs **codées en dur**
+(`kDefaultMobHealth=60`, `kDefaultMobDamage`, `kDefaultPlayerDamage=10`,
+`kBaseXpPerMobKill=10`) ; (b) les 11 stats calculées (`ComputeStats`) sont
+envoyées au client (`SendPlayerStats`) mais **pas injectées** dans le
+`CombatComponent` du joueur ; (c) pas de jet de précision ni de critique ;
+(d) pas de respawn joueur après la mort ; (e) le `SnapshotEntity` ne porte
+**pas** l'`archetypeId` (le client ne peut pas savoir à quoi ressemble un mob) ;
+(f) le client **ne rend pas** les entités `playerClientId == 0` (ni mesh ni
+nameplate), **n'envoie jamais** `AttackRequest`, et n'instancie pas les
+présentateurs combat. Les périmètres SP1/SP2 ci-dessous sont à lire à travers
+ce correctif : SP1/SP2 consistent surtout à **données + branchements**, pas à
+créer la logique de combat serveur (elle existe).
+
+## 4. SP1 — Créatures visibles
+
+### 4.1 Données : `game/data/creatures/archetypes.json` (NOUVEAU)
+
+Catalogue d'archétypes ; la clé `id` correspond à l'`archetypeId` des spawners.
+
+```json
+{
+  "archetypes": [
+    {
+      "id": 100,
+      "name": "Sanglier des collines",
+      "level": 2,
+      "stats": { "hp": 180, "damage": 12, "accuracy": 80.0, "range": 2.5,
+                 "critRate": 2.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 35,
+      "model": { "mesh": "orcs", "scale": 0.9 }
+    }
+  ]
+}
+```
+
+- Stats **directes** (pas les profils de classes joueurs) — équilibrage indépendant.
+- `model.mesh` : V1 = nom d'un set de mesh de race existant (réutilisation en
+  attendant des assets créatures) ; `scale` pour différencier visuellement.
+- Chargé par shardd au boot (même pattern que `skills/*.json` : scan/lecture au
+  démarrage, log si archetypeId inconnu référencé par un spawner). Le **client**
+  charge le même fichier pour le mapping visuel (mesh, scale, name) — pas de
+  duplication d'un catalogue côté client.
+
+### 4.2 Serveur (shardd) — révisé d'après §3.bis
+
+- Les mobs sont déjà spawnés et répliqués : le travail SP1 serveur est
+  d'**appliquer les stats d'archétype** au spawn (hp, damage, portée,
+  `attackPeriodMs` → cooldownTicks) à la place de `kDefaultMobHealth`/
+  `kDefaultMobDamage`, et de porter `xpReward` par archétype dans
+  `DistributePartyXp` (à la place de `kBaseXpPerMobKill`).
+- Validation au boot : tout spawner référençant un `archetypeId` inconnu fait
+  échouer l'init (même politique stricte que SpawnerRuntime).
+- La riposte/mort/loot existants restent actifs (pas de régression volontaire).
+
+### 4.3 Réplication (wire-breaking)
+
+- `SnapshotEntity` + champ `archetypeId` (uint32, 0 = joueur) → **bump
+  `kProtocolVersion`** (UDP gameplay). Client ancien ↔ shard nouveau incompatibles.
+
+### 4.4 Client
+
+- Rendu des entités `archetypeId != 0` sur le chemin des avatars distants :
+  mesh/scale depuis archetypes.json, nameplate (name + niveau) + barre de PV
+  au-dessus (même style que les joueurs distants).
+- Aucune interaction en SP1.
+
+### 4.5 Livraison SP1
+
+- **PR-A (serveur)** : archetypes.json + loader + spawn créatures + champ
+  archetypeId dans les snapshots + bump protocole + tests (loader, spawn, encode/
+  decode snapshot). La spec (ce fichier) part avec cette PR.
+- **PR-B (client)** : rendu créatures + nameplates. Stackée sur PR-A (partage le
+  bump protocole).
+- **Déploiement** : ⚠️ lock-step shardd + client (wire-breaking snapshots).
+
+## 5. SP2 — Attaque, dégâts, mort, riposte, XP
+
+### 5.1 Protocole (UDP gameplay) — révisé d'après §3.bis
+
+`AttackRequest` (kind 8) et `CombatEvent` (kind 9) **existent déjà** sur le wire
+UDP gameplay ; SP2 n'ajoute que : un champ `flags` (bit crit, bit miss) à
+`CombatEventMessage`, et un kind `RespawnRequest` (client→shard, payload vide)
+dans la suite des `MessageKind` existants. `CombatEvent` reste broadcast à
+l'attaquant, la cible et les observateurs (périmètre snapshots, déjà codé).
+
+### 5.2 Serveur — résolution d'attaque (révisé d'après §3.bis)
+
+La validation (`HandleAttackRequest`), la riposte (`TryMobAttackPlayer` + IA
+aggro/leash existante) et le tick sont **déjà en place**. SP2 serveur ajoute :
+
+- **Stats réelles** : injecter les 11 stats calculées (`ComputeStats`) dans le
+  `CombatComponent` du joueur à l'enter-world et au level-up (damage, range,
+  accuracy, critRate, critMult) à la place de `kDefaultPlayerDamage`.
+- **Jets** : précision (`accuracy` % → touché/raté) puis critique (`critRate` %
+  → dégâts × `critMult`), reportés dans `CombatEventMessage.flags` (RNG injecté
+  pour les tests). **Pas d'armure/réduction en V1.**
+- **Respawn joueur** : handler `RespawnRequest` — joueur mort uniquement →
+  téléport au spawn de zone, PV/ressource pleins, flag dead retiré.
+
+### 5.3 Serveur — mort, respawn, XP (révisé d'après §3.bis)
+
+- **Mort créature** : déjà implémentée (flag dead, despawn, respawn spawner,
+  loot, XP party). L'`xpReward` par archétype est livré en **SP1** avec le
+  catalogue.
+- **Mort joueur** : flag + save déjà implémentés ; SP2 ajoute la purge de menace
+  côté mobs au décès et le respawn via `RespawnRequest` (cf. §5.2).
+
+### 5.4 Client
+
+- **Ciblage** : clic = raycast écran→monde sur les entités répliquées ; Tab =
+  cycle des créatures hostiles vivantes par distance croissante. La cible
+  alimente `UIModel::targetStats` (le cadre cible du CombatHud existe déjà).
+- **Attaque** : une touche/clic déclenche l'envoi d'`AttackRequest` (cadence
+  plafonnée client à la période d'auto-attaque ; le serveur revalide).
+- **Câblage des présentateurs existants** : `CombatEvent` décodé → entrées
+  `UICombatLogEntry` dans `UIModel::combatLog` → CombatHud (log court, barre PV
+  cible via targetCurrentHealth/Max) + AdvancedCombatUi (DPS meter, combat log
+  500 lignes, filtres). Cooldown d'auto-attaque affiché dans le slot existant.
+- **Écran de mort** (NOUVEAU, petit) : overlay sombre + « Réapparaître » →
+  `RespawnRequest`.
+- **Binds** : le bind d'attaque et Tab passent par un **registre central de binds
+  in-game** (nouveau, périmètre minimal : déclaration centralisée touche→action
+  pour les nouvelles touches, base pour résorber les collisions A/Y/G relevées
+  par l'audit — la migration des binds existants n'est pas dans ce chantier).
+
+### 5.5 Hors périmètre SP2
+
+Pas de loot, pas d'armure, pas de sorts (SP3), pas de déplacement créature (SP4),
+pas de PvP (cibles = créatures uniquement), pas de migration DB.
+
+### 5.6 Livraison SP2 (3-4 PRs)
+
+1. **PR serveur combat core** : opcodes + validation + dégâts + riposte + mort/
+   respawn/evade + XP + tests (résolution, bornes de portée, cooldown, evade,
+   attribution XP).
+2. **PR client ciblage + attaque + HUD** : picking, Tab, AttackRequest, décodage
+   CombatEvent, câblage CombatHud + AdvancedCombatUi, registre de binds minimal.
+3. **PR client écran de mort + RespawnRequest** (peut fusionner avec la 2 si
+   petite).
+- **Déploiement** : ⚠️ lock-step shardd + client (nouveaux opcodes UDP).
+
+## 6. SP3 — Sorts et auras par classe (cadrage)
+
+- **Kits starter par profil** (8 profils : melee, distance, voleur, healer, sacre,
+  lanceur, pisteur, tank) : 3-4 sorts mécaniques chacun, proposés et **validés
+  utilisateur avant implémentation**, déclinés par classe via `factions.json`.
+  Les coûts utilisent la ressource secondaire de la classe (ferveur, souffle…).
+- **Données** : sorts en JSON data-driven mappés sur `SpellTemplate` (castTimeMs,
+  cooldownMs, basePoints, durationMs, tickPeriodMs, rangeMeters, targetType).
+  Les 3 skills de test existants (fireball, combo_builder, combo_spender) migrent
+  vers ce format et deviennent fonctionnels.
+- **Serveur** : pipeline de cast (file de cast par Unit : temps de cast,
+  interruption, coût ressource, application des effets/auras via `Aura` existant,
+  ticks DoT/HoT) ; persistance des auras dans `character_auras` (0061).
+- **Réplication** : opcodes aura apply/remove/update → `StatusEffect` client →
+  câblage **BuffBarPresenter** (buff/debuff bars, stacks, timers).
+- Design détaillé (et liste des sorts) : passe dédiée au démarrage de SP3.
+
+## 7. SP4 — Agro et menace, complet (cadrage)
+
+- Déplacement/poursuite des créatures sur la heightmap, leash via
+  `leashDistanceMeters` (déjà dans spawners.json), retour au spawn + evade.
+- Menace multi-cibles alimentée et tickée (`ThreatList`), changement de cible par
+  agro, opcode ThreatUpdate → câblage du **threat meter** d'AdvancedCombatUi
+  (`UpdateThreat` existe déjà côté présentateur).
+- Câblage **AuraFXSystem** (FX visuels d'auras) et **AoEPreviewSystem**
+  (prévisualisation des zones d'effet, utile avec les sorts AoE de SP3).
+- Design détaillé : passe dédiée au démarrage de SP4.
+
+## 8. Tests et CI
+
+- Serveur : tests CTest (exécutés par build-linux) sur loader d'archétypes,
+  spawn, résolution d'attaque (hit/miss/crit déterministes via RNG injecté),
+  bornes de portée/cooldown, evade, mort/respawn, attribution XP, encode/decode
+  des nouveaux messages.
+- Client : tests de présentation existants (CombatHud/AdvancedCombatUi en ont
+  déjà) étendus au câblage UIModel ; pas de toolchain locale → validation par CI.
+- Rappel build : tout nouveau .cpp partagé (src/shared) doit être ajouté **aussi**
+  à la liste `server_app` de `src/CMakeLists.txt`.
+
+## 9. Déploiement (récapitulatif)
+
+Chaque SP introduit du wire-breaking UDP (champ snapshot en SP1, opcodes en
+SP2/SP3/SP4) : **redéploiement shardd + client en lock-step à chaque SP**, à
+signaler dans chaque PR. Le master n'est pas concerné par SP1/SP2 (tout passe
+par l'UDP gameplay du shard).

--- a/game/data/creatures/archetypes.json
+++ b/game/data/creatures/archetypes.json
@@ -1,0 +1,20 @@
+{
+  "archetypes": [
+    {
+      "id": 100,
+      "name": "Sanglier des collines",
+      "level": 2,
+      "stats": {
+        "hp": 60,
+        "damage": 5,
+        "accuracy": 80.0,
+        "rangeMeters": 2.5,
+        "critRate": 2.0,
+        "critMult": 1.5,
+        "attackPeriodMs": 2000
+      },
+      "xpReward": 10,
+      "model": { "mesh": "orcs", "scale": 0.9 }
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,8 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/auction/AuctionHouse.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spawner/SpawnerRuntime.cpp
+    # Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/event/EventRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/TickScheduler.cpp
@@ -525,6 +527,11 @@ elseif(UNIX)
   # + Hello. ServerProtocol.cpp est fourni par engine_core (lié par le helper).
   lcdlln_add_simple_test(server_protocol_tests
     ${CMAKE_SOURCE_DIR}/src/shared/network/ServerProtocolTests.cpp)
+
+  # Combat SP1 : catalogue d'archétypes de créatures (parse + validation JSON).
+  lcdlln_add_simple_test(creature_archetype_library_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp)
 
   # TA.3 (replication des joueurs) : registre des personnages admis (gate de la
   # session UDP, lié au character_id authentifié du ticket). Pure logique testable.
@@ -1142,6 +1149,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/auction/AuctionHouse.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spawner/SpawnerRuntime.cpp
+    # Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/event/EventRuntime.cpp
     # TA.4 : accès MySQL pour le pont position (lecture characters.spawn_x/y/z).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4978,6 +4978,10 @@ namespace engine
 													if (m_avatarGender != "male" && m_avatarGender != "female")
 														m_avatarGender = "male";
 
+													// Combat SP1 — catalogue d'apparences de creatures (non bloquant :
+													// catalogue absent/corrompu = mobs rendus en fallback humains).
+													m_creatureCatalog.Init(m_cfg);
+
 													// Pointe m_currentSkinnedMesh vers le mesh humain par defaut (le
 													// perso n'est pas encore "in world" avant EnterWorld, mais Engine
 													// peut etre questionne sur ce mesh pour des previews/tests).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10190,8 +10190,13 @@ namespace engine
 					const auto& remotes = m_uiModelBinding.GetModel().remoteEntities;
 					for (const engine::client::UIRemoteEntity& re : remotes)
 					{
-						if (re.playerClientId == 0u)
-							continue; // mob / loot bag : pas de nameplate
+						// Combat SP1 : les mobs (archetypeId != 0) ont desormais leur
+						// plaque ; seuls les loot bags (les deux ids a 0) restent muets.
+						if (re.playerClientId == 0u && re.archetypeId == 0u)
+							continue; // loot bag : pas de nameplate
+						// Mob mort en attente de despawn : pas de plaque (kEntityStateDead).
+						if (re.playerClientId == 0u && (re.stateFlags & 1u) != 0u)
+							continue;
 						float wx = re.positionX, wy = re.positionY, wz = re.positionZ;
 						const auto sit = m_remoteSmoothed.find(re.entityId);
 						if (sit != m_remoteSmoothed.end() && sit->second.valid)
@@ -10205,9 +10210,27 @@ namespace engine
 						// la DB serveur et propagé via le SnapshotEntity). Sinon, fallback sur
 						// "P<clientId>" — utile quand la DB serveur ne sert pas (Windows / DB
 						// indisponible) ou pour identifier l'entité dans un log.
-						const std::string label = !re.displayName.empty()
-							? re.displayName
-							: ("P" + std::to_string(re.playerClientId));
+						// Combat SP1 : plaque mob "Nom (niv. N)  PV/PVmax" résolue via le
+						// CreatureCatalog ; fallback générique si l'archétype est inconnu
+						// du catalogue client (catalogue absent ou désynchronisé).
+						std::string label;
+						if (re.playerClientId != 0u)
+						{
+							label = !re.displayName.empty()
+								? re.displayName
+								: ("P" + std::to_string(re.playerClientId));
+						}
+						else
+						{
+							const engine::client::CreatureAppearance* appearance =
+								m_creatureCatalog.Find(re.archetypeId);
+							const std::string mobName = (appearance != nullptr)
+								? appearance->name
+								: ("Creature " + std::to_string(re.archetypeId));
+							const uint32_t mobLevel = (appearance != nullptr) ? appearance->level : 1u;
+							label = mobName + " (niv. " + std::to_string(mobLevel) + ")  "
+								+ std::to_string(re.currentHealth) + "/" + std::to_string(re.maxHealth);
+						}
 						const ImVec2 ts = ImGui::CalcTextSize(label.c_str());
 						// Halo noir derriere le texte pour la lisibilite sur fond clair (ciel).
 						fg->AddRectFilled(
@@ -11864,16 +11887,47 @@ namespace engine
 		for (const engine::client::UIRemoteEntity& re : remotes)
 		{
 			// remoteEntities contient TOUTES les entités distantes (joueurs + mobs + lootbags).
-			// Les mobs ont leur propre pipeline de rendu (mesh dédié), donc ici on ne dessine
-			// le mesh humanoïde que pour les joueurs distants (playerClientId != 0). Même
-			// critère que la plaque de nom (cf. boucle TD.4 dans le HUD in-game).
-			if (re.playerClientId == 0u)
-				continue;
-			// TD.6 — genre du personnage propagé par le snapshot. Fallback "male" si vide
-			// (master sans migration 0067 ou avatar legacy). Récupère le mesh correspondant
-			// dans le registre m_raceMeshes (clé "humains|male" / "humains|female").
-			const std::string gender = (re.gender == "male" || re.gender == "female") ? re.gender : std::string{"male"};
-			engine::render::skinned::SkinnedMesh* remoteMesh = GetRaceMesh("humains", gender);
+			// Combat SP1 : les mobs (archetypeId != 0) réutilisent un mesh de race
+			// existant déclaré par le catalogue (cf. CreatureCatalog) ; seuls les loot
+			// bags (les deux ids à 0) gardent leur pipeline dédié (pas de mesh humanoïde).
+			// Attention budget : chaque mob = 1 draw skinné dans le ring SSBO partagé
+			// (kFrameSlots=32, cf. SkinnedRenderer.h) — au-delà de ~16 draws skinnés
+			// par frame le ring se réécrit pendant une frame en vol (limite connue,
+			// audit 2026-06-10) ; zone actuelle = 1 mob, marge OK.
+			std::string meshRace;
+			std::string gender;
+			float meshScale = 1.0f;
+			if (re.playerClientId != 0u)
+			{
+				// TD.6 — genre du personnage propagé par le snapshot. Fallback "male" si vide
+				// (master sans migration 0067 ou avatar legacy). Récupère le mesh correspondant
+				// dans le registre m_raceMeshes (clé "humains|male" / "humains|female").
+				meshRace = "humains";
+				gender = (re.gender == "male" || re.gender == "female") ? re.gender : std::string{"male"};
+			}
+			else if (re.archetypeId != 0u)
+			{
+				// Mob mort en attente de despawn : pas de rendu (kEntityStateDead).
+				if ((re.stateFlags & 1u) != 0u)
+					continue;
+				const engine::client::CreatureAppearance* appearance = m_creatureCatalog.Find(re.archetypeId);
+				meshRace = (appearance != nullptr && !appearance->meshKey.empty())
+					? appearance->meshKey
+					: std::string{"humains"};
+				gender = "male";
+				meshScale = (appearance != nullptr) ? appearance->scale : 1.0f;
+			}
+			else
+			{
+				continue; // loot bag : pipeline dédié, pas de mesh humanoïde
+			}
+			engine::render::skinned::SkinnedMesh* remoteMesh = GetRaceMesh(meshRace, gender);
+			if (remoteMesh == nullptr && re.archetypeId != 0u)
+			{
+				// Fallback mob : la race du catalogue n'est pas chargée dans
+				// m_raceMeshes (asset absent) → on retombe sur le mesh humain.
+				remoteMesh = GetRaceMesh("humains", "male");
+			}
 			if (remoteMesh == nullptr)
 			{
 				// Aucun mesh chargé pour cette combo race+genre → on saute. Pas de fallback
@@ -11930,9 +11984,17 @@ namespace engine
 				remoteMesh->skeleton, globals);
 			// Pieds au sol : le serveur réplique la position « centre capsule » comme pour
 			// l'avatar local (feetPos = ccPos.y - 0.9). Même offset ici pour la cohérence.
+			// Combat SP1 : échelle uniforme d'archétype (1.0 pour les joueurs) appliquée
+			// entre la rotation et l'importTransform — Mat4 n'a pas de helper Scale,
+			// on construit la diagonale (column-major) à la main.
+			engine::math::Mat4 scaleMat;
+			scaleMat.m[0] = meshScale;
+			scaleMat.m[5] = meshScale;
+			scaleMat.m[10] = meshScale;
 			const engine::math::Mat4 model =
 				engine::math::Mat4::Translate(engine::math::Vec3{ px, py - 0.9f, pz }) *
 				engine::math::Mat4::RotateY(yaw) *
+				scaleMat *
 				(remoteMesh->importTransform);
 			// Matériau : on prend le même matériau habit (m_avatarMaterialId) que l'avatar
 			// local. Pas encore de skin par-personnage côté serveur — toute la flotte distante

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -62,6 +62,7 @@
 #include "src/shared/math/Frustum.h"
 #include "src/shared/math/Math.h"
 #include "src/client/world/WorldModel.h"
+#include "src/client/world/CreatureCatalog.h"
 #include "src/client/world/ChunkBudgetStats.h"
 #include "src/client/world/LodConfig.h"
 #include "src/client/world/HlodRuntime.h"
@@ -701,6 +702,11 @@ namespace engine
 		/// les pointeurs `m_currentSkinnedMesh` restent stables tant que la map
 		/// n'est pas modifiee apres le boot (pas de rehash apres le remplissage).
 		std::unordered_map<std::string, engine::render::skinned::SkinnedMesh> m_raceMeshes;
+		/// Combat SP1 — apparences d'archétypes de créatures (nom/niveau/mesh/
+		/// échelle), chargées au boot depuis creatures/archetypes.json (tolérant :
+		/// catalogue vide = rendu mob en fallback). Consommé par la plaque de nom
+		/// et RecordRemoteAvatars pour les entités archetypeId != 0.
+		engine::client::CreatureCatalog                           m_creatureCatalog;
 		std::chrono::steady_clock::time_point                     m_playerAnimStartTime;
 		/// True une fois SkinnedRenderer::Init OK + SkinnedMeshLoader::Load OK.
 		/// Sert de gate per-frame : si false, on dessine le cube placeholder.

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -734,6 +734,8 @@ namespace engine::client
 			remote.gender = entity.gender;
 			// TD.8 : état d'animation pour jouer le bon clip sur l'avatar distant.
 			remote.animationState = static_cast<uint8_t>(entity.animationState);
+			// Combat SP1 : archétype de créature (0 = joueur/loot bag, ≠ 0 = mob).
+			remote.archetypeId = entity.archetypeId;
 			m_model.remoteEntities.push_back(remote);
 		}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -331,6 +331,10 @@ namespace engine::client
 		/// TD.8 : état d'animation (valeur d'AvatarAnimState) propagé via le SnapshotEntity.
 		/// Consommé par RecordRemoteAvatars pour jouer le bon clip (emote/roulade/run/…).
 		uint8_t animationState = 0;
+		/// Combat SP1 : archétype de créature propagé via le SnapshotEntity (wire v9).
+		/// 0 pour les joueurs et loot bags ; ≠ 0 pour les mobs — le rendu résout
+		/// nom/niveau/mesh/échelle via Engine::m_creatureCatalog.
+		uint32_t archetypeId = 0;
 	};
 
 	/// Pure data model consumed by UI views and debug panels.

--- a/src/client/world/CreatureCatalog.cpp
+++ b/src/client/world/CreatureCatalog.cpp
@@ -1,0 +1,533 @@
+#include "src/client/world/CreatureCatalog.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::client
+{
+	namespace
+	{
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		/// Parseur JSON minimal local au catalogue — même convention que les
+		/// autres loaders du repo (SpawnerRuntime, SkillSystem) : parseur par
+		/// module, aucune dépendance nouvelle.
+		class JsonParser final
+		{
+		public:
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			/// Parse le document complet ; rejette tout caractère résiduel.
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+
+				return true;
+			}
+
+		private:
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+
+				++m_pos;
+				return true;
+			}
+
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+
+				switch (m_input[m_pos])
+				{
+				case '{':
+					return ParseObject(outValue, outError);
+				case '[':
+					return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default:
+					break;
+				}
+
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+
+				return ParseNumber(outValue, outError);
+			}
+
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"': outValue.push_back('"'); break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/': outValue.push_back('/'); break;
+					case 'b': outValue.push_back('\b'); break;
+					case 'f': outValue.push_back('\f'); break;
+					case 'n': outValue.push_back('\n'); break;
+					case 'r': outValue.push_back('\r'); break;
+					case 't': outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+
+				outError = "unterminated string";
+				return false;
+			}
+
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Retourne un membre d'objet, ou nullptr si la clé est absente.
+		const JsonValue* FindObjectMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+
+			const auto it = object.objectValue.find(std::string(key));
+			if (it == object.objectValue.end())
+			{
+				return nullptr;
+			}
+
+			return &it->second;
+		}
+
+		/// Convertit un nombre JSON en uint32 validé (entier, borné, fini).
+		bool TryGetUint(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+
+		/// Convertit un nombre JSON en float fini validé.
+		bool TryGetFloat(const JsonValue& value, float& outValue)
+		{
+			if (value.type != JsonType::Number || !std::isfinite(value.numberValue))
+			{
+				return false;
+			}
+
+			outValue = static_cast<float>(value.numberValue);
+			return true;
+		}
+	}
+
+	bool CreatureCatalog::Init(const engine::core::Config& config)
+	{
+		const std::string relativePath = "creatures/archetypes.json";
+		const std::string jsonText = engine::platform::FileSystem::ReadAllTextContent(config, relativePath);
+		if (jsonText.empty())
+		{
+			LOG_WARN(Core, "[CreatureCatalog] Init skipped: empty or missing file ({}) — mobs rendus en fallback", relativePath);
+			return false;
+		}
+
+		std::string loadError;
+		if (!LoadFromText(jsonText, loadError))
+		{
+			LOG_WARN(Core, "[CreatureCatalog] Init FAILED: {} ({}) — mobs rendus en fallback", loadError, relativePath);
+			return false;
+		}
+
+		LOG_INFO(Core, "[CreatureCatalog] Init OK (archetypes={})", m_appearances.size());
+		return true;
+	}
+
+	const CreatureAppearance* CreatureCatalog::Find(uint32_t archetypeId) const
+	{
+		const auto it = m_appearances.find(archetypeId);
+		if (it == m_appearances.end())
+		{
+			return nullptr;
+		}
+
+		return &it->second;
+	}
+
+	bool CreatureCatalog::LoadFromText(std::string_view jsonText, std::string& outError)
+	{
+		m_appearances.clear();
+
+		JsonValue root;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, outError))
+		{
+			return false;
+		}
+
+		const JsonValue* archetypesValue = FindObjectMember(root, "archetypes");
+		if (archetypesValue == nullptr || archetypesValue->type != JsonType::Array || archetypesValue->arrayValue.empty())
+		{
+			outError = "root.archetypes must be a non-empty array";
+			return false;
+		}
+
+		for (size_t index = 0; index < archetypesValue->arrayValue.size(); ++index)
+		{
+			const JsonValue& entry = archetypesValue->arrayValue[index];
+			if (entry.type != JsonType::Object)
+			{
+				outError = "archetypes[" + std::to_string(index) + "] must be an object";
+				m_appearances.clear();
+				return false;
+			}
+
+			uint32_t archetypeId = 0;
+			const JsonValue* idValue = FindObjectMember(entry, "id");
+			if (idValue == nullptr || !TryGetUint(*idValue, archetypeId) || archetypeId == 0)
+			{
+				outError = "archetypes[" + std::to_string(index) + "].id must be a positive integer";
+				m_appearances.clear();
+				return false;
+			}
+
+			const std::string entryLabel = "archetype id=" + std::to_string(archetypeId);
+			CreatureAppearance appearance{};
+
+			const JsonValue* nameValue = FindObjectMember(entry, "name");
+			if (nameValue == nullptr || nameValue->type != JsonType::String || nameValue->stringValue.empty())
+			{
+				outError = entryLabel + ": name must be a non-empty string";
+				m_appearances.clear();
+				return false;
+			}
+			appearance.name = nameValue->stringValue;
+
+			const JsonValue* levelValue = FindObjectMember(entry, "level");
+			if (levelValue == nullptr || !TryGetUint(*levelValue, appearance.level) || appearance.level == 0)
+			{
+				outError = entryLabel + ": level must be a positive integer";
+				m_appearances.clear();
+				return false;
+			}
+
+			const JsonValue* modelValue = FindObjectMember(entry, "model");
+			if (modelValue == nullptr || modelValue->type != JsonType::Object)
+			{
+				outError = entryLabel + ": model must be an object";
+				m_appearances.clear();
+				return false;
+			}
+
+			const JsonValue* meshValue = FindObjectMember(*modelValue, "mesh");
+			if (meshValue == nullptr || meshValue->type != JsonType::String || meshValue->stringValue.empty())
+			{
+				outError = entryLabel + ": model.mesh must be a non-empty string";
+				m_appearances.clear();
+				return false;
+			}
+			appearance.meshKey = meshValue->stringValue;
+
+			const JsonValue* scaleValue = FindObjectMember(*modelValue, "scale");
+			if (scaleValue != nullptr)
+			{
+				if (!TryGetFloat(*scaleValue, appearance.scale) || appearance.scale <= 0.0f)
+				{
+					outError = entryLabel + ": model.scale must be a positive number";
+					m_appearances.clear();
+					return false;
+				}
+			}
+
+			if (!m_appearances.emplace(archetypeId, std::move(appearance)).second)
+			{
+				outError = "duplicate archetype id " + std::to_string(archetypeId);
+				m_appearances.clear();
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/client/world/CreatureCatalog.h
+++ b/src/client/world/CreatureCatalog.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace engine::client
+{
+	/// Combat SP1 — apparence client d'un archétype de créature, résolue depuis le
+	/// même `game/data/creatures/archetypes.json` que le serveur. Le client ne
+	/// consomme que name/level/model (les stats de combat restent l'autorité du
+	/// serveur, jamais relues ici).
+	struct CreatureAppearance
+	{
+		std::string name;
+		uint32_t level = 1;
+		/// Clé d'un set de mesh de race existant ("orcs", "humains", …) réutilisé
+		/// pour le rendu du mob en attendant des assets créatures dédiés.
+		std::string meshKey;
+		float scale = 1.0f;
+	};
+
+	/// Combat SP1 — catalogue client des archétypes de créatures (lecture seule,
+	/// chargé une fois au boot). Politique TOLÉRANTE, contrairement au serveur :
+	/// fichier absent/invalide = catalogue vide + LOG_WARN ; les mobs sont alors
+	/// rendus avec le fallback (mesh humains, nom générique "Creature <id>").
+	class CreatureCatalog final
+	{
+	public:
+		/// Charge `creatures/archetypes.json` depuis `paths.content`. Retourne
+		/// false (catalogue laissé vide) si le fichier est absent ou invalide —
+		/// non bloquant côté client. Main thread uniquement (pas de verrou).
+		bool Init(const engine::core::Config& config);
+
+		/// Retourne l'apparence de l'archétype, ou nullptr s'il est inconnu.
+		const CreatureAppearance* Find(uint32_t archetypeId) const;
+
+		/// Nombre d'archétypes chargés (0 si le catalogue n'a pas pu être lu).
+		size_t Count() const { return m_appearances.size(); }
+
+		/// Variante testable sans I/O : parse et valide un texte JSON en mémoire.
+		/// Remplace le contenu courant en cas de succès ; vide + outError sinon.
+		bool LoadFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		std::unordered_map<uint32_t, CreatureAppearance> m_appearances;
+	};
+}

--- a/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
+++ b/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
@@ -1,0 +1,629 @@
+#include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::server
+{
+	namespace
+	{
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		/// Parseur JSON minimal local au catalogue d'archétypes — même convention
+		/// que SpawnerRuntime : parseur par module, aucune dépendance nouvelle.
+		class JsonParser final
+		{
+		public:
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			/// Parse le document complet ; rejette tout caractère résiduel.
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+
+				return true;
+			}
+
+		private:
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+
+				++m_pos;
+				return true;
+			}
+
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+
+				switch (m_input[m_pos])
+				{
+				case '{':
+					return ParseObject(outValue, outError);
+				case '[':
+					return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default:
+					break;
+				}
+
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+
+				return ParseNumber(outValue, outError);
+			}
+
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"': outValue.push_back('"'); break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/': outValue.push_back('/'); break;
+					case 'b': outValue.push_back('\b'); break;
+					case 'f': outValue.push_back('\f'); break;
+					case 'n': outValue.push_back('\n'); break;
+					case 'r': outValue.push_back('\r'); break;
+					case 't': outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+
+				outError = "unterminated string";
+				return false;
+			}
+
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Retourne un membre d'objet, ou nullptr si la clé est absente.
+		const JsonValue* FindObjectMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+
+			const auto it = object.objectValue.find(std::string(key));
+			if (it == object.objectValue.end())
+			{
+				return nullptr;
+			}
+
+			return &it->second;
+		}
+
+		/// Convertit un nombre JSON en uint32 validé (entier, borné, fini).
+		bool TryGetUint(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+
+		/// Convertit un nombre JSON en float fini validé.
+		bool TryGetFloat(const JsonValue& value, float& outValue)
+		{
+			if (value.type != JsonType::Number || !std::isfinite(value.numberValue))
+			{
+				return false;
+			}
+
+			outValue = static_cast<float>(value.numberValue);
+			return true;
+		}
+	}
+
+	CreatureArchetypeLibrary::CreatureArchetypeLibrary(const engine::core::Config& config)
+		: m_config(config)
+	{
+		LOG_INFO(Net, "[CreatureArchetypeLibrary] Constructed");
+	}
+
+	bool CreatureArchetypeLibrary::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Net, "[CreatureArchetypeLibrary] Init ignored: already initialized");
+			return true;
+		}
+
+		const std::string relativePath = "creatures/archetypes.json";
+		const std::string jsonText = engine::platform::FileSystem::ReadAllTextContent(m_config, relativePath);
+		if (jsonText.empty())
+		{
+			LOG_ERROR(Net, "[CreatureArchetypeLibrary] Init FAILED: empty or missing file ({})", relativePath);
+			return false;
+		}
+
+		std::string loadError;
+		if (!LoadFromText(jsonText, loadError))
+		{
+			LOG_ERROR(Net, "[CreatureArchetypeLibrary] Init FAILED: {} ({})", loadError, relativePath);
+			return false;
+		}
+
+		m_initialized = true;
+		LOG_INFO(Net, "[CreatureArchetypeLibrary] Init OK (archetypes={})", m_archetypes.size());
+		return true;
+	}
+
+	const CreatureArchetype* CreatureArchetypeLibrary::Find(uint32_t archetypeId) const
+	{
+		const auto it = m_archetypes.find(archetypeId);
+		if (it == m_archetypes.end())
+		{
+			return nullptr;
+		}
+
+		return &it->second;
+	}
+
+	bool CreatureArchetypeLibrary::LoadFromText(std::string_view jsonText, std::string& outError)
+	{
+		m_archetypes.clear();
+
+		JsonValue root;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, outError))
+		{
+			return false;
+		}
+
+		const JsonValue* archetypesValue = FindObjectMember(root, "archetypes");
+		if (archetypesValue == nullptr || archetypesValue->type != JsonType::Array || archetypesValue->arrayValue.empty())
+		{
+			outError = "root.archetypes must be a non-empty array";
+			return false;
+		}
+
+		for (size_t index = 0; index < archetypesValue->arrayValue.size(); ++index)
+		{
+			const JsonValue& entry = archetypesValue->arrayValue[index];
+			if (entry.type != JsonType::Object)
+			{
+				outError = "archetypes[" + std::to_string(index) + "] must be an object";
+				m_archetypes.clear();
+				return false;
+			}
+
+			CreatureArchetype archetype{};
+
+			const JsonValue* idValue = FindObjectMember(entry, "id");
+			if (idValue == nullptr || !TryGetUint(*idValue, archetype.archetypeId) || archetype.archetypeId == 0)
+			{
+				outError = "archetypes[" + std::to_string(index) + "].id must be a positive integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const std::string entryLabel = "archetype id=" + std::to_string(archetype.archetypeId);
+
+			const JsonValue* nameValue = FindObjectMember(entry, "name");
+			if (nameValue == nullptr || nameValue->type != JsonType::String || nameValue->stringValue.empty())
+			{
+				outError = entryLabel + ": name must be a non-empty string";
+				m_archetypes.clear();
+				return false;
+			}
+			archetype.name = nameValue->stringValue;
+
+			const JsonValue* levelValue = FindObjectMember(entry, "level");
+			if (levelValue == nullptr || !TryGetUint(*levelValue, archetype.level) || archetype.level == 0)
+			{
+				outError = entryLabel + ": level must be a positive integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* statsValue = FindObjectMember(entry, "stats");
+			if (statsValue == nullptr || statsValue->type != JsonType::Object)
+			{
+				outError = entryLabel + ": stats must be an object";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* hpValue = FindObjectMember(*statsValue, "hp");
+			if (hpValue == nullptr || !TryGetUint(*hpValue, archetype.hp) || archetype.hp == 0)
+			{
+				outError = entryLabel + ": stats.hp must be a positive integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* damageValue = FindObjectMember(*statsValue, "damage");
+			if (damageValue == nullptr || !TryGetUint(*damageValue, archetype.damage))
+			{
+				outError = entryLabel + ": stats.damage must be an unsigned integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* accuracyValue = FindObjectMember(*statsValue, "accuracy");
+			if (accuracyValue == nullptr || !TryGetFloat(*accuracyValue, archetype.accuracy))
+			{
+				outError = entryLabel + ": stats.accuracy must be a finite number";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* rangeValue = FindObjectMember(*statsValue, "rangeMeters");
+			if (rangeValue == nullptr || !TryGetFloat(*rangeValue, archetype.rangeMeters) || archetype.rangeMeters <= 0.0f)
+			{
+				outError = entryLabel + ": stats.rangeMeters must be a positive number";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* critRateValue = FindObjectMember(*statsValue, "critRate");
+			if (critRateValue == nullptr || !TryGetFloat(*critRateValue, archetype.critRate))
+			{
+				outError = entryLabel + ": stats.critRate must be a finite number";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* critMultValue = FindObjectMember(*statsValue, "critMult");
+			if (critMultValue == nullptr || !TryGetFloat(*critMultValue, archetype.critMult))
+			{
+				outError = entryLabel + ": stats.critMult must be a finite number";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* attackPeriodValue = FindObjectMember(*statsValue, "attackPeriodMs");
+			if (attackPeriodValue == nullptr
+				|| !TryGetUint(*attackPeriodValue, archetype.attackPeriodMs)
+				|| archetype.attackPeriodMs == 0)
+			{
+				outError = entryLabel + ": stats.attackPeriodMs must be a positive integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* xpRewardValue = FindObjectMember(entry, "xpReward");
+			if (xpRewardValue == nullptr || !TryGetUint(*xpRewardValue, archetype.xpReward))
+			{
+				outError = entryLabel + ": xpReward must be an unsigned integer";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* modelValue = FindObjectMember(entry, "model");
+			if (modelValue == nullptr || modelValue->type != JsonType::Object)
+			{
+				outError = entryLabel + ": model must be an object";
+				m_archetypes.clear();
+				return false;
+			}
+
+			const JsonValue* meshValue = FindObjectMember(*modelValue, "mesh");
+			if (meshValue == nullptr || meshValue->type != JsonType::String || meshValue->stringValue.empty())
+			{
+				outError = entryLabel + ": model.mesh must be a non-empty string";
+				m_archetypes.clear();
+				return false;
+			}
+			archetype.meshKey = meshValue->stringValue;
+
+			const JsonValue* scaleValue = FindObjectMember(*modelValue, "scale");
+			if (scaleValue != nullptr)
+			{
+				if (!TryGetFloat(*scaleValue, archetype.scale) || archetype.scale <= 0.0f)
+				{
+					outError = entryLabel + ": model.scale must be a positive number";
+					m_archetypes.clear();
+					return false;
+				}
+			}
+
+			const uint32_t archetypeId = archetype.archetypeId;
+			if (!m_archetypes.emplace(archetypeId, std::move(archetype)).second)
+			{
+				outError = "duplicate archetype id " + std::to_string(archetypeId);
+				m_archetypes.clear();
+				return false;
+			}
+
+			LOG_INFO(Net,
+				"[CreatureArchetypeLibrary] Loaded archetype (id={}, name={}, level={}, hp={}, damage={}, xp_reward={})",
+				archetypeId,
+				m_archetypes.at(archetypeId).name,
+				m_archetypes.at(archetypeId).level,
+				m_archetypes.at(archetypeId).hp,
+				m_archetypes.at(archetypeId).damage,
+				m_archetypes.at(archetypeId).xpReward);
+		}
+
+		return true;
+	}
+}

--- a/src/shardd/gameplay/creature/CreatureArchetypeLibrary.h
+++ b/src/shardd/gameplay/creature/CreatureArchetypeLibrary.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace engine::server
+{
+	/// Combat SP1 — un archétype de créature data-driven chargé depuis
+	/// `game/data/creatures/archetypes.json`. Porte les stats de combat du mob
+	/// (consommées par ServerApp au spawn), la récompense d'XP au kill, et les
+	/// informations d'apparence (mesh/scale/nom/niveau) que le client résout de
+	/// son côté via le même fichier (cf. CreatureCatalog côté client).
+	/// `accuracy`/`critRate`/`critMult` sont portés par le schéma dès SP1 mais ne
+	/// seront consommés qu'à partir de SP2 (jets de précision/critique).
+	struct CreatureArchetype
+	{
+		uint32_t archetypeId = 0;
+		std::string name;
+		uint32_t level = 1;
+		uint32_t hp = 1;
+		uint32_t damage = 0;
+		float accuracy = 100.0f;
+		float rangeMeters = 2.0f;
+		float critRate = 0.0f;
+		float critMult = 1.5f;
+		uint32_t attackPeriodMs = 2000;
+		uint32_t xpReward = 0;
+		/// Clé d'un set de mesh de race existant ("orcs", "humains", …) réutilisé
+		/// pour le rendu du mob en attendant des assets créatures dédiés.
+		std::string meshKey;
+		float scale = 1.0f;
+	};
+
+	/// Combat SP1 — catalogue serveur des archétypes de créatures, résolu depuis
+	/// `paths.content` (même politique stricte que SpawnerRuntime : fichier
+	/// absent/illisible ou entrée invalide = échec d'Init, le shard ne boote pas
+	/// avec un catalogue corrompu).
+	class CreatureArchetypeLibrary final
+	{
+	public:
+		/// Capture la config utilisée pour résoudre le JSON du catalogue.
+		explicit CreatureArchetypeLibrary(const engine::core::Config& config);
+
+		/// Charge et valide `creatures/archetypes.json` depuis le content root.
+		/// Idempotent (warn + true si déjà initialisé). Retourne false si le
+		/// fichier manque, ne parse pas, ou si une entrée est invalide (id
+		/// dupliqué, hp/attackPeriodMs nuls, champs obligatoires manquants).
+		bool Init();
+
+		/// Retourne l'archétype demandé, ou nullptr s'il est inconnu.
+		const CreatureArchetype* Find(uint32_t archetypeId) const;
+
+		/// Nombre d'archétypes chargés (0 avant Init).
+		size_t Count() const { return m_archetypes.size(); }
+
+		/// Variante testable sans I/O : parse et valide un texte JSON en mémoire.
+		/// Utilisée par Init() (qui lit le fichier) et par les tests unitaires.
+		/// Remplace intégralement le contenu courant en cas de succès ; laisse le
+		/// catalogue vide et renseigne outError en cas d'échec.
+		bool LoadFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		engine::core::Config m_config;
+		std::unordered_map<uint32_t, CreatureArchetype> m_archetypes;
+		bool m_initialized = false;
+	};
+}

--- a/src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp
+++ b/src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp
@@ -1,0 +1,185 @@
+// Combat SP1 — tests du catalogue d'archétypes de créatures (parse + validation).
+
+#include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"
+#include "src/shared/core/Config.h"
+#include "src/shared/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::server::CreatureArchetype;
+	using engine::server::CreatureArchetypeLibrary;
+
+	/// Construit une library de test sans I/O (la Config vide n'est pas utilisée
+	/// par LoadFromText, seulement par Init qui n'est pas exercé ici).
+	CreatureArchetypeLibrary MakeLibrary()
+	{
+		engine::core::Config config;
+		return CreatureArchetypeLibrary(config);
+	}
+
+	const char* kValidJson = R"({
+  "archetypes": [
+    {
+      "id": 100,
+      "name": "Sanglier des collines",
+      "level": 2,
+      "stats": { "hp": 60, "damage": 5, "accuracy": 80.0, "rangeMeters": 2.5,
+                 "critRate": 2.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 10,
+      "model": { "mesh": "orcs", "scale": 0.9 }
+    },
+    {
+      "id": 101,
+      "name": "Loup gris",
+      "level": 3,
+      "stats": { "hp": 80, "damage": 7, "accuracy": 85.0, "rangeMeters": 2.0,
+                 "critRate": 3.0, "critMult": 1.5, "attackPeriodMs": 1500 },
+      "xpReward": 14,
+      "model": { "mesh": "humains" }
+    }
+  ]
+})";
+
+	bool TestValidCatalog()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		if (!library.LoadFromText(kValidJson, error))
+		{
+			LOG_ERROR(Core, "[CreatureArchetypeLibraryTests] valid catalog rejected: {}", error);
+			return false;
+		}
+		if (library.Count() != 2) return false;
+		const CreatureArchetype* boar = library.Find(100);
+		if (boar == nullptr) return false;
+		if (boar->hp != 60 || boar->damage != 5 || boar->xpReward != 10) return false;
+		if (boar->level != 2 || boar->meshKey != "orcs") return false;
+		if (boar->attackPeriodMs != 2000) return false;
+		if (boar->scale < 0.89f || boar->scale > 0.91f) return false;
+		if (library.Find(999) != nullptr) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] valid catalog OK");
+		return true;
+	}
+
+	bool TestScaleDefaultsToOne()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		if (!library.LoadFromText(kValidJson, error)) return false;
+		const CreatureArchetype* wolf = library.Find(101);
+		if (wolf == nullptr) return false;
+		// model.scale absent → défaut 1.0.
+		if (wolf->scale < 0.999f || wolf->scale > 1.001f) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] scale default OK");
+		return true;
+	}
+
+	bool TestMissingArchetypesArray()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		if (library.LoadFromText(R"({ "autre": [] })", error)) return false;
+		if (error.empty()) return false;
+		if (library.Count() != 0) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] missing array rejected OK");
+		return true;
+	}
+
+	bool TestDuplicateIdRejected()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		const char* duplicateJson = R"({
+  "archetypes": [
+    { "id": 100, "name": "A", "level": 1,
+      "stats": { "hp": 10, "damage": 1, "accuracy": 80.0, "rangeMeters": 2.0,
+                 "critRate": 0.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 1, "model": { "mesh": "orcs" } },
+    { "id": 100, "name": "B", "level": 1,
+      "stats": { "hp": 10, "damage": 1, "accuracy": 80.0, "rangeMeters": 2.0,
+                 "critRate": 0.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 1, "model": { "mesh": "orcs" } }
+  ]
+})";
+		if (library.LoadFromText(duplicateJson, error)) return false;
+		if (library.Count() != 0) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] duplicate id rejected OK");
+		return true;
+	}
+
+	bool TestZeroHpRejected()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		const char* zeroHpJson = R"({
+  "archetypes": [
+    { "id": 100, "name": "A", "level": 1,
+      "stats": { "hp": 0, "damage": 1, "accuracy": 80.0, "rangeMeters": 2.0,
+                 "critRate": 0.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 1, "model": { "mesh": "orcs" } }
+  ]
+})";
+		if (library.LoadFromText(zeroHpJson, error)) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] zero hp rejected OK");
+		return true;
+	}
+
+	bool TestZeroAttackPeriodRejected()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		const char* zeroPeriodJson = R"({
+  "archetypes": [
+    { "id": 100, "name": "A", "level": 1,
+      "stats": { "hp": 10, "damage": 1, "accuracy": 80.0, "rangeMeters": 2.0,
+                 "critRate": 0.0, "critMult": 1.5, "attackPeriodMs": 0 },
+      "xpReward": 1, "model": { "mesh": "orcs" } }
+  ]
+})";
+		if (library.LoadFromText(zeroPeriodJson, error)) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] zero attackPeriodMs rejected OK");
+		return true;
+	}
+
+	bool TestMissingModelRejected()
+	{
+		CreatureArchetypeLibrary library = MakeLibrary();
+		std::string error;
+		const char* missingModelJson = R"({
+  "archetypes": [
+    { "id": 100, "name": "A", "level": 1,
+      "stats": { "hp": 10, "damage": 1, "accuracy": 80.0, "rangeMeters": 2.0,
+                 "critRate": 0.0, "critMult": 1.5, "attackPeriodMs": 2000 },
+      "xpReward": 1 }
+  ]
+})";
+		if (library.LoadFromText(missingModelJson, error)) return false;
+		LOG_INFO(Core, "[CreatureArchetypeLibraryTests] missing model rejected OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestValidCatalog()
+		&& TestScaleDefaultsToOne()
+		&& TestMissingArchetypesArray()
+		&& TestDuplicateIdRejected()
+		&& TestZeroHpRejected()
+		&& TestZeroAttackPeriodRejected()
+		&& TestMissingModelRejected();
+
+	if (ok) LOG_INFO(Core, "[CreatureArchetypeLibraryTests] ALL OK");
+	else LOG_ERROR(Core, "[CreatureArchetypeLibraryTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -114,5 +114,9 @@ namespace engine::server
 		/// TD.8 — état d'animation courant du joueur (Idle pour les mobs/lootbags).
 		/// Wire-bump v7→v8 : 1 octet ajouté après le genre dans chaque entité du Snapshot.
 		AvatarAnimState animationState = AvatarAnimState::Idle;
+		/// Combat SP1 — archétype de créature (0 = joueur ou loot bag). Permet au
+		/// client de résoudre nom/niveau/mesh/échelle dans son CreatureCatalog.
+		/// Wire-bump v8→v9 : u32 ajouté après animationState dans chaque entité.
+		uint32_t archetypeId = 0;
 	};
 }

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -316,11 +316,12 @@ namespace engine::server
 		outMessage.chunkCount = ReadU16(payload, 22);
 
 		const size_t entityCount = static_cast<size_t>(outMessage.entityCount);
-		// TD.6/TD.8 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
-		// + 2 (nameLen) + N (name) + 2 (genderLen) + M (gender) + 1 (animationState) octets. On vérifie
-		// un minimum (57 par entité, nom et genre vides), puis on parse sequentiellement et on rejette
-		// si on dépasse la fin du payload en cours de route. TG.1 — header a 24 octets.
-		const size_t minimumPayloadSize = 24 + (entityCount * 57);
+		// TD.6/TD.8/SP1 — taille variable par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name) + 2 (genderLen) + M (gender) + 1 (animationState) + 4 (archetypeId)
+		// octets. On vérifie un minimum (61 par entité, nom et genre vides), puis on parse
+		// sequentiellement et on rejette si on dépasse la fin du payload en cours de route.
+		// TG.1 — header a 24 octets.
+		const size_t minimumPayloadSize = 24 + (entityCount * 61);
 		if (payload.size() < minimumPayloadSize)
 		{
 			return false;
@@ -359,7 +360,7 @@ namespace engine::server
 				return false;
 			}
 			// TD.8 : état d'animation (1 octet) après le genre. ReadSizedString a avancé offset ;
-			// le minimum (57/entité, chaînes vides) garantit qu'il reste au moins 1 octet, mais
+			// le minimum (61/entité, chaînes vides) garantit qu'il reste au moins 5 octets, mais
 			// avec des chaînes non vides on peut dépasser : on vérifie explicitement la borne.
 			if (offset + 1u > payload.size())
 			{
@@ -368,6 +369,15 @@ namespace engine::server
 			}
 			entity.animationState = static_cast<AvatarAnimState>(ReadU8(payload, offset));
 			offset += 1u;
+			// Combat SP1 (wire v9) : archétype de créature (u32) après animationState.
+			// 0 = joueur / loot bag ; ≠ 0 = mob (résolu par le CreatureCatalog client).
+			if (offset + 4u > payload.size())
+			{
+				outEntities.clear();
+				return false;
+			}
+			entity.archetypeId = ReadU32(payload, offset);
+			offset += 4u;
 		}
 
 		return true;
@@ -512,13 +522,14 @@ namespace engine::server
 
 	std::vector<std::byte> EncodeSnapshot(const SnapshotMessage& message, std::span<const SnapshotEntity> entities)
 	{
-		// TD.6/TD.8 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
-		// + 2 (nameLen) + N (name bytes) + 2 (genderLen) + M (gender bytes) + 1 (animationState) octets.
-		// Wire-bump v7→v8 : ajout de l'état d'animation (1 octet) après le genre. Pour le sizing :
-		// estimation à 8 + 40 + 4 + 2 + 2 + 1 = 57 par entité (nom et genre vides). BeginPacket.reserve
-		// est juste un hint, pas une borne stricte (le vector grandit à l'append).
+		// TD.6/TD.8/SP1 — taille par entite : 8 (entityId) + 40 (EntityState) + 4 (playerClientId)
+		// + 2 (nameLen) + N (name bytes) + 2 (genderLen) + M (gender bytes) + 1 (animationState)
+		// + 4 (archetypeId) octets. Wire-bump v8→v9 : ajout de l'archétype (u32) après l'état
+		// d'animation. Pour le sizing : estimation à 8 + 40 + 4 + 2 + 2 + 1 + 4 = 61 par entité
+		// (nom et genre vides). BeginPacket.reserve est juste un hint, pas une borne stricte
+		// (le vector grandit à l'append).
 		// TG.1 — header passe de 20 → 24 octets (ajout chunkIndex + chunkCount uint16 × 2).
-		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 57));
+		std::vector<std::byte> packet = BeginPacket(MessageKind::Snapshot, 24 + (entities.size() * 61));
 		WriteU32(packet, message.clientId);
 		WriteU32(packet, message.serverTick);
 		WriteU16(packet, message.connectedClients);
@@ -541,6 +552,8 @@ namespace engine::server
 			WriteSizedString(packet, entity.gender);
 			// TD.8 : état d'animation (1 octet). Idle (0) pour les mobs / lootbags.
 			WriteU8(packet, static_cast<uint8_t>(entity.animationState));
+			// Combat SP1 (wire v9) : archétype de créature (0 = joueur / loot bag).
+			WriteU32(packet, entity.archetypeId);
 		}
 		return packet;
 	}

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -34,9 +34,14 @@ namespace engine::server
 	/// en QUEUE de payload. C'est rétro-compatible : un master legacy lit les 16 octets
 	/// fixes et ignore la queue ; un master neuf lit la queue si présente ; un heartbeat
 	/// legacy (sans queue) reste valide. Comme `kProtocolVersion` borne aussi le framing
-	/// client↔master, le laisser à 8 évite de casser les clients v8 déjà distribués
+	/// client↔master, le laisser à 8 évitait de casser les clients v8 déjà distribués
 	/// (le bump 8→9 initial, PR #770, était inutile et a été annulé ici).
-	inline constexpr uint16_t kProtocolVersion = 8;
+	/// Combat SP1 — bump 8 → 9 : `SnapshotEntity` gagne `archetypeId` (uint32,
+	/// shard→clients) — 0 = joueur/loot bag, ≠ 0 = mob ; le client résout
+	/// nom/niveau/mesh/échelle dans son CreatureCatalog pour rendre la créature.
+	/// Wire-breaking : ce bump invalide AUSSI le framing client↔master (version
+	/// partagée) → déployer master + shardd + client en lock-step.
+	inline constexpr uint16_t kProtocolVersion = 9;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -135,6 +135,7 @@ namespace
 		eMob.state.maxHealth = 100u;
 		eMob.playerClientId = 0u; // mob => pas de nameplate
 		// characterName et gender restent vides pour les mobs / lootbags (TD.5/TD.6).
+		eMob.archetypeId = 100u; // Combat SP1 (wire v9) : archétype résolu côté client
 		in.push_back(eMob);
 
 		const std::vector<std::byte> packet = EncodeSnapshot(inMsg, in);
@@ -157,6 +158,7 @@ namespace
 		assert(out[0].characterName == "homme"); // TD.5
 		assert(out[0].gender == "male");          // TD.6
 		assert(out[0].animationState == engine::server::AvatarAnimState::Emote); // TD.8
+		assert(out[0].archetypeId == 0u); // Combat SP1 : joueur => pas d'archétype
 
 		assert(out[1].entityId == ePlayerB.entityId);
 		assert(out[1].state.positionX == ePlayerB.state.positionX);
@@ -172,15 +174,16 @@ namespace
 		assert(out[2].characterName.empty()); // TD.5 : mob => pas de nom
 		assert(out[2].gender.empty());        // TD.6 : mob => pas de genre
 		assert(out[2].animationState == engine::server::AvatarAnimState::Idle); // TD.8 : défaut
+		assert(out[2].archetypeId == 100u); // Combat SP1 (wire v9) : archétype du mob
 		std::puts("[OK] TestSnapshotRoundTripWithPlayerClientId");
 	}
 
 	/// TD.6 — un Snapshot dont la taille de payload est inferieure au minimum attendu
-	/// (57 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0
-	/// + 2 genderLen=0 + 1 animationState, au-delà de l'entête 24 octets) doit être rejeté.
-	/// Defense en profondeur contre un pair qui parlerait une version antérieure du wire. Le
-	/// bump kProtocolVersion à v8 filtre déjà la plupart des cas dans DecodeHeader, ce test
-	/// couvre une corruption après header valide.
+	/// (61 octets/entité = 8 entityId + 40 EntityState + 4 playerClientId + 2 nameLen=0
+	/// + 2 genderLen=0 + 1 animationState + 4 archetypeId, au-delà de l'entête 24 octets)
+	/// doit être rejeté. Defense en profondeur contre un pair qui parlerait une version
+	/// antérieure du wire. Le bump kProtocolVersion à v9 filtre déjà la plupart des cas
+	/// dans DecodeHeader, ce test couvre une corruption après header valide.
 	void TestSnapshotRejectsTruncatedPayload()
 	{
 		SnapshotMessage inMsg{};

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -4056,6 +4056,9 @@ namespace engine::server
 			outEntity.entityId = mob->entityId;
 			outEntity.state = BuildEntityState(*mob);
 			// playerClientId reste 0 par defaut (entite non-joueur, pas de plaque de nom).
+			// Combat SP1 (wire v9) : l'archetypeId permet au client de rendre le mob
+			// (mesh/nom/niveau/échelle résolus dans son CreatureCatalog).
+			outEntity.archetypeId = mob->archetypeId;
 			return true;
 		}
 
@@ -4310,10 +4313,10 @@ namespace engine::server
 
 		// TG.1 — chunking : decoupe le snapshot pour rester sous ~1200 octets MTU UDP.
 		// Le header est borne par BeginPacket (16 o) + meta SnapshotMessage (24 o, TG.1)
-		// = 40 o constants. Une entite = 52 o (TD.4). Budget restant pour les entites :
-		// 1200 - 40 = 1160 o ⇒ max 22 entites/chunk (1160 / 52). On garde une marge
-		// confortable en visant 20 entites par chunk.
-		constexpr size_t kMaxEntitiesPerChunk = 20u;
+		// = 40 o constants. Une entite = 61 o minimum (SP1, wire v9, chaines vides).
+		// Budget restant pour les entites : 1200 - 40 = 1160 o ⇒ max 19 entites/chunk
+		// (1160 / 61). On vise 18 pour garder la marge (noms/genres non vides).
+		constexpr size_t kMaxEntitiesPerChunk = 18u;
 		const size_t totalEntities = m_snapshotEntitiesScratch.size();
 		const size_t chunkCountSize = (totalEntities == 0u)
 			? 1u

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -173,6 +173,27 @@ namespace engine::server
 			return component;
 		}
 
+		/// Combat SP1 — applique les stats data-driven d'un archétype au mob
+		/// fraîchement construit (PV, dégâts, portée, cadence d'attaque en ticks,
+		/// XP au kill). \p archetype peut être nullptr (garde défensive : les
+		/// références sont validées à l'init) → le mob garde les constantes MVP.
+		void ApplyArchetypeStatsToMob(MobEntity& mob, const CreatureArchetype* archetype, uint16_t tickHz)
+		{
+			const uint32_t mobHealth = (archetype != nullptr) ? archetype->hp : kDefaultMobHealth;
+			const uint32_t mobDamage = (archetype != nullptr) ? archetype->damage : kDefaultMobDamage;
+			mob.stats.currentHealth = mobHealth;
+			mob.stats.maxHealth = mobHealth;
+			mob.combat = BuildDefaultCombatComponent(tickHz, mobDamage);
+			if (archetype != nullptr)
+			{
+				mob.combat.attackRangeMeters = archetype->rangeMeters;
+				// attackPeriodMs → ticks (arrondi au tick supérieur, minimum 1 tick).
+				mob.combat.cooldownTicks = std::max<uint32_t>(1u,
+					(archetype->attackPeriodMs * static_cast<uint32_t>(tickHz) + 999u) / 1000u);
+				mob.xpReward = archetype->xpReward;
+			}
+		}
+
 		/// Return the squared XZ distance used by the range validation.
 		float DistanceSquaredXZ(float ax, float az, float bx, float bz)
 		{
@@ -248,6 +269,7 @@ namespace engine::server
 		, m_eventRuntime(m_config)
 		, m_questRuntime(m_config)
 		, m_spawnerRuntime(m_config)
+		, m_archetypeLibrary(m_config)
 	{
 		LOG_INFO(Core, "[ServerApp] Constructed");
 	}
@@ -1583,6 +1605,15 @@ namespace engine::server
 	{
 		m_mobs.clear();
 		m_spawners.clear();
+		// Combat SP1 — le catalogue d'archétypes doit être chargé avant les
+		// spawners pour valider leurs références (politique stricte : catalogue
+		// absent/corrompu = le shard ne boote pas).
+		if (!m_archetypeLibrary.Init())
+		{
+			LOG_ERROR(Net, "[ServerApp] Spawner init FAILED: archetype library load failed");
+			return false;
+		}
+
 		if (!m_spawnerRuntime.Init())
 		{
 			LOG_ERROR(Net, "[ServerApp] Spawner init FAILED: runtime load failed");
@@ -1591,6 +1622,17 @@ namespace engine::server
 
 		for (const SpawnerDefinition& definition : m_spawnerRuntime.GetDefinitions())
 		{
+			// Combat SP1 — tout spawner référençant un archétype inconnu est une
+			// erreur de données : échec d'init plutôt qu'un mob aux stats MVP.
+			if (m_archetypeLibrary.Find(definition.archetypeId) == nullptr)
+			{
+				LOG_ERROR(Net, "[ServerApp] Spawner init FAILED: unknown archetype (spawner_id={}, archetype_id={})",
+					definition.spawnerId,
+					definition.archetypeId);
+				m_spawners.clear();
+				return false;
+			}
+
 			CellGrid* zoneGrid = GetOrCreateZoneGrid(definition.zoneId);
 			if (zoneGrid == nullptr)
 			{
@@ -1973,9 +2015,8 @@ namespace engine::server
 		mob.positionMetersX = spawner.definition.positionMetersX;
 		mob.positionMetersY = spawner.definition.positionMetersY;
 		mob.positionMetersZ = spawner.definition.positionMetersZ;
-		mob.stats.currentHealth = kDefaultMobHealth;
-		mob.stats.maxHealth = kDefaultMobHealth;
-		mob.combat = BuildDefaultCombatComponent(m_tickHz, kDefaultMobDamage);
+		// Combat SP1 — stats data-driven (archétype validé à l'init des spawners).
+		ApplyArchetypeStatsToMob(mob, m_archetypeLibrary.Find(mob.archetypeId), m_tickHz);
 		mob.homePositionMetersX = mob.positionMetersX;
 		mob.homePositionMetersY = mob.positionMetersY;
 		mob.homePositionMetersZ = mob.positionMetersZ;
@@ -2247,9 +2288,9 @@ namespace engine::server
 		mob.positionMetersX = spawnDefinition.positionMetersX;
 		mob.positionMetersY = spawnDefinition.positionMetersY;
 		mob.positionMetersZ = spawnDefinition.positionMetersZ;
-		mob.stats.currentHealth = kDefaultMobHealth;
-		mob.stats.maxHealth = kDefaultMobHealth;
-		mob.combat = BuildDefaultCombatComponent(m_tickHz, kDefaultMobDamage);
+		// Combat SP1 — stats data-driven ; un événement peut référencer un
+		// archétype absent du catalogue (non validé à l'init) → fallback MVP.
+		ApplyArchetypeStatsToMob(mob, m_archetypeLibrary.Find(mob.archetypeId), m_tickHz);
 		mob.homePositionMetersX = mob.positionMetersX;
 		mob.homePositionMetersY = mob.positionMetersY;
 		mob.homePositionMetersZ = mob.positionMetersZ;
@@ -2723,10 +2764,12 @@ namespace engine::server
 				SpawnLootBagForMob(*target, looterEntityId != 0 ? looterEntityId : client->entityId);
 			}
 			// M32.2 — Distribute XP to party members in range.
+			// Combat SP1 — XP data-driven par archétype (fallback constante MVP
+			// pour un mob dont l'archétype ne définit pas de récompense).
 			DistributePartyXp(*client,
 			    target->positionMetersX,
 			    target->positionMetersZ,
-			    kBaseXpPerMobKill);
+			    target->xpReward != 0u ? target->xpReward : kBaseXpPerMobKill);
 			ApplyQuestEvent(*client, QuestStepType::Kill, std::string("mob:") + std::to_string(target->archetypeId), 1, "kill");
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -15,6 +15,7 @@
 #include "src/shardd/gameplay/social/PartySystem.h"
 #include "src/shardd/gameplay/quest/QuestRuntime.h"
 #include "src/shardd/gameplay/spawner/SpawnerRuntime.h"
+#include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"
 #include "src/shared/core/Config.h"
 #include "src/shared/net/ChatSystem.h"
 #include "src/shardd/gameplay/chat/ChatCommandParser.h"
@@ -198,6 +199,9 @@ namespace engine::server
 		bool isDynamicEventMob = false;
 		std::vector<ThreatEntry> threatTable;
 		bool hasSpawnedLoot = false;
+		/// Combat SP1 — XP attribuée au(x) tueur(s), copiée depuis l'archétype au
+		/// spawn (0 = fallback sur kBaseXpPerMobKill, mob d'avant le catalogue).
+		uint32_t xpReward = 0;
 	};
 
 	/// One spawn slot tracked by the authoritative spawner runtime.
@@ -866,6 +870,9 @@ namespace engine::server
 		EventRuntime m_eventRuntime;
 		QuestRuntime m_questRuntime;
 		SpawnerRuntime m_spawnerRuntime;
+		/// Combat SP1 — catalogue d'archétypes de créatures (stats data-driven,
+		/// initialisé par InitSpawners avant le chargement des spawners).
+		CreatureArchetypeLibrary m_archetypeLibrary;
 		ZoneTransitionMap m_zoneTransitionMap;
 		TickScheduler m_tickScheduler;
 		UdpTransport m_transport;


### PR DESCRIPTION
## Combat SP1-B — créatures visibles, volet client

Stackée sur #873 (PR-A serveur). Spec : `docs/superpowers/specs/2026-06-10-combat-system-design.md`, plan : `docs/superpowers/plans/2026-06-10-combat-sp1-creatures-visibles.md`.

### Contenu
- **`CreatureCatalog`** (`src/client/world/`) : lecture **tolérante** du même `game/data/creatures/archetypes.json` que le serveur (catalogue absent/corrompu = LOG_WARN + rendu fallback, le client ne refuse jamais de booter). Ne consomme que name/level/model — les stats restent l''autorité du serveur. Init au boot d''Engine (bloc skinned-pipeline).
- **`UIRemoteEntity.archetypeId`** : propagé du `SnapshotEntity` (wire v9, PR-A) jusqu''au modèle UI dans `ApplySnapshot`.
- **Rendu des mobs** (Engine) :
  - *Mesh* : les entités `archetypeId != 0` passent par le pipeline avatars distants — mesh résolu via `GetRaceMesh(meshKey, male)` (réutilisation des sets de mesh de race, ex. « orcs » pour le sanglier), fallback humains si la race n''est pas chargée ; échelle uniforme d''archétype appliquée dans la matrice modèle. Mobs morts (flag dead) non rendus.
  - *Nameplate* : « Nom (niv. N)  PV/PVmax » au-dessus du mob (même pipeline que les plaques joueurs) ; les loot bags restent sans plaque.
  - Note budget : chaque mob = 1 draw skinné dans le ring SSBO partagé (limite ~16 draws/frame connue de l''audit 2026-06-10, commentée au site).

### Validation en jeu attendue (post-merge + déploiement)
Le sanglier de `zone_0` (spawner archetypeId 100) visible à (96, 96) avec sa plaque « Sanglier des collines (niv. 2)  60/60 », patrouille fluide, pas de régression sur les avatars joueurs distants. L''attaque arrive en SP2.

### Ordre de merge
**#873 (PR-A) d''abord, puis celle-ci.** Ne déployer qu''une fois les deux mergées.

**Déploiement** : ⚠️ **wire-breaking (kProtocolVersion 8→9, porté par PR-A)** — master + shardd + client en **lock-step**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)