### PR TITLE
feat(combat): SP2 - attaque joueur (ciblage clic+Tab), precision/critique, mort/respawn (wire v10)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2159,3 +2159,34 @@ ordre validé : combat → groupes → métiers/récolte → prédiction client)
 - `src/client/world/CreatureCatalog.{h,cpp}` — lecture tolérante du même JSON (name/level/mesh/scale).
 - `UIRemoteEntity.archetypeId` + copie dans `ApplySnapshot` ; rendu mobs dans Engine
   (mesh via `GetRaceMesh(meshKey, "male")`, nameplate « Nom (niv. N) PV/PVmax »).
+
+## Combat SP2 — attaque, précision/critique, mort/respawn (2026-06-11)
+
+Plan : `docs/superpowers/plans/2026-06-11-combat-sp2-attaque-mort.md` (spec §5 révisée §3.bis).
+1 PR serveur+client (lock-step). **Wire v9→v10** : `CombatEventMessage.flags` (bit0 crit,
+bit1 miss, payload 32→36 o) + kind `RespawnRequest = 80`.
+
+### Serveur
+- `src/shardd/gameplay/combat/AttackResolver.h` — résolveur PUR (jets [0,1) injectés) :
+  précision (accuracy %), critique (critRate % × critMult, plancher 1.0) ; tests
+  `attack_resolver_tests`.
+- `CombatComponent` étendu (accuracy/critRate/critMult, serveur only, pas sur le wire).
+- Enter-world + level-up : `ApplyDerivedCombatStats` injecte damage/range/accuracy/crit
+  des 11 stats calculées dans le composant combat (fini `kDefaultPlayerDamage`).
+- `HandleAttackRequest` + `TryMobAttackPlayer` : jets via `m_combatRng` (mt19937) ; un raté
+  émet quand même le CombatEvent (flags miss, damage 0) ; cooldown consommé.
+- Mort joueur : `PurgeThreatForEntity` (toutes tables de menace) ; `HandleRespawnRequest` :
+  mort uniquement → téléport au `spawnPositionMeters*` (mémorisé à l'admission), PV pleins,
+  flag dead retiré, save "respawn".
+
+### Client
+- `GameplayUdpClient::SendAttackRequest/SendRespawnRequest` ; `EncodeAttackRequest` +
+  `Encode/DecodeRespawnRequest` (ServerProtocol).
+- `UIModelBinding::SetLocalTarget/ClearLocalTarget` (sélection locale → targetStats +
+  notification Combat) ; la cible suit PV/flags des snapshots ; `UICombatLogEntry.wasCrit/wasMiss`.
+- Engine : **binds combat** (clic = pick écran-espace des mobs vivants via WorldToScreenPx,
+  Tab = cycle par distance, T = attaque avec throttle 250 ms, J = panneau combat avancé) ;
+  **CombatHudPresenter + AdvancedCombatPresenter enfin câblés** (observer + Tick + rendu :
+  cadre cible haut-centre, log combat bas-droite, panneau DPS/log filtrable) ; **écran de
+  mort** (overlay + bouton Réapparaître → RespawnRequest) ; mouvement bloqué pendant la mort.
+- **Déploiement** : ⚠️ wire-breaking v10 — master + shardd + client en lock-step.

--- a/docs/superpowers/plans/2026-06-11-combat-sp2-attaque-mort.md
+++ b/docs/superpowers/plans/2026-06-11-combat-sp2-attaque-mort.md
@@ -1,0 +1,117 @@
+# Combat SP2 — Attaque, précision/critique, mort/respawn : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Boucler le combat joueur↔créature de bout en bout : le joueur cible (clic+Tab), attaque (T), voit dégâts/critiques/ratés dans le HUD combat enfin câblé, peut mourir et réapparaître au spawn.
+
+**Architecture:** Le serveur a déjà la validation/dégâts/riposte/mort (constat spec §3.bis) — SP2 injecte les 11 stats calculées dans le `CombatComponent`, ajoute les jets précision/critique via un résolveur pur testable (`AttackResolver`), un flag crit/miss sur `CombatEventMessage` (wire v9→v10) et un kind `RespawnRequest` (80). Le client gagne l'envoi d'`AttackRequest`, la sélection de cible (écran-espace via `WorldToScreenPx`, pas de raycast 3D), le câblage des présentateurs combat existants (CombatHud, AdvancedCombatUi) et l'écran de mort (pattern menu pause).
+
+**Tech Stack:** C++20, protocole UDP maison, ImGui, tests CTest (CI build-linux). Pas de toolchain locale — validation par CI.
+
+**Livraison : 1 PR `combat-sp2` (serveur + client, base main)** — lock-step de toute façon (wire v10), et les PRs stackées n'ont pas de CI ici.
+
+**Décisions reprises de la spec** : ciblage clic+Tab ; mort = écran + bouton « Réapparaître » → spawn de zone PV pleins ; pas d'armure ; cadence d'attaque joueur inchangée (0,5 s MVP — la période 2 s envisagée en spec est abandonnée pour ne pas changer l'équilibrage et le cooldown HUD existant). Touches : **Tab** = cycle cible, **T** = attaque, **J** = panneau combat avancé (vérifier liberté de J au moment du câblage ; sinon prendre K).
+
+---
+
+### Task 1: `AttackResolver` pur + tests (serveur)
+
+**Files:**
+- Create: `src/shardd/gameplay/combat/AttackResolver.h` (header-only, pur)
+- Create: `src/shardd/gameplay/combat/AttackResolverTests.cpp`
+- Modify: `src/CMakeLists.txt` (lcdlln_add_simple_test `attack_resolver_tests`, à côté de `creature_archetype_library_tests`)
+
+```cpp
+// AttackResolver.h — résultat d'un jet d'attaque. Pur et déterministe : les
+// jets aléatoires [0,1) sont passés en paramètres (RNG injecté par l'appelant),
+// ce qui rend toutes les branches testables sans graine.
+struct AttackRollResult { bool miss; bool crit; uint32_t damage; };
+/// roll01Accuracy >= accuracy/100 → miss (damage 0) ;
+/// sinon roll01Crit < critRate/100 → crit (damage = base × critMult arrondi) ;
+/// sinon hit normal (damage = base). accuracy clampé [0,100], critRate [0,100],
+/// critMult plancher 1.0.
+AttackRollResult ResolveAttackRoll(uint32_t baseDamage, float accuracy,
+	float critRate, float critMult, float roll01Accuracy, float roll01Crit);
+```
+
+Tests : hit garanti (accuracy 100, roll 0.99) ; miss garanti (accuracy 0) ; crit garanti (critRate 100 → damage = base×mult) ; pas de crit (critRate 0) ; clamps (accuracy 150 = jamais de miss ; critMult 0.5 → plancher 1.0) ; base 0 → damage 0 même en crit. Harnais `bool Test*()` + main, pattern ThreatListTests.
+
+### Task 2: `CombatComponent` étendu + stats injectées (serveur)
+
+**Files:**
+- Modify: `src/shared/network/ReplicationTypes.h` (CombatComponent :22-28) — ajouter `float accuracy = 100.0f; float critRate = 0.0f; float critMult = 1.5f;` (composant serveur, PAS sur le wire).
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` :
+  - `ApplyArchetypeStatsToMob` (~:195) : remplir aussi `mob.combat.accuracy/critRate/critMult` depuis l'archétype.
+  - Enter-world, après le bloc R1-A `ResolveSpawnHealth` (:1313-1334) : `ComputeStats(...)` complet → helper `ApplyDerivedCombatStats(ConnectedClient&, const DerivedStats&)` (namespace anonyme) : `damagePerHit = d.damage`, `attackRangeMeters = (d.range > 0 ? d.range : kDefaultAttackRangeMeters)` (range 0 = mêlée pure), `accuracy/critRate/critMult` copiés.
+  - `ApplyLevelUpsAfterXp` (:5556-5562) : appeler le même helper après le recompute.
+
+### Task 3: Jets dans les deux sens + purge de menace (serveur)
+
+**Files:**
+- Modify: `src/shared/server_bootstrap/ServerApp.h` — membre `std::mt19937 m_combatRng;` (+ include `<random>`), méthode privée `float NextCombatRoll01();`, méthode privée `void PurgeThreatForEntity(EntityId entityId);`.
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` :
+  - Seed du RNG au constructeur (`std::random_device` une fois — pas de besoin déterministe au runtime, les tests passent par AttackResolver pur).
+  - `HandleAttackRequest` (:2596+) : après la validation portée, consommer le cooldown PUIS `ResolveAttackRoll(client->combat.damagePerHit, client->combat.accuracy, ...)`. Miss → CombatEvent `flags |= kCombatEventFlagMiss`, damage 0, PV cible inchangés (PAS de early-return : l'event part pour le log/HUD). Crit → `flags |= kCombatEventFlagCrit`. Le reste (mort, loot, XP) inchangé, exécuté seulement si dégâts > 0.
+  - `TryMobAttackPlayer` (:3398+) : même logique avec `mob.combat.*` (le mob rate/critique aussi).
+  - Mort du joueur (dans TryMobAttackPlayer, branche `target.stats.currentHealth == 0`) : appeler `PurgeThreatForEntity(target.entityId)` — boucle sur `m_mobs` : retirer l'entrée de `threatTable`, remettre `aggroTargetEntityId = 0` si c'était lui (l'IA repassera en patrouille au prochain tick).
+
+### Task 4: Wire — `CombatEventMessage.flags` + `RespawnRequest` (v9→v10)
+
+**Files:**
+- Modify: `src/shared/network/ServerProtocol.h` — `kProtocolVersion = 10` (+ ligne d'historique « Combat SP2 — bump 9→10 : CombatEvent gagne flags (u32 : bit0 crit, bit1 miss) ; nouveau kind RespawnRequest = 80 ») ; `CombatEventMessage` (:318) gagne `uint32_t flags = 0;` + constantes `inline constexpr uint32_t kCombatEventFlagCrit = 1u << 0; kCombatEventFlagMiss = 1u << 1;` ; enum `RespawnRequest = 80,` après `PlayerStats = 79` ; `struct RespawnRequestMessage { uint32_t clientId = 0; };` + déclarations Encode/Decode (RespawnRequest et **EncodeAttackRequest** qui manque côté client).
+- Modify: `src/shared/network/ServerProtocol.cpp` — `EncodeCombatEvent` : taille 32→36, `WriteU32(message.flags)` en queue ; `DecodeCombatEvent` : check `!= 36`, lecture flags ; `EncodeAttackRequest` (payload 12 : clientId u32 + targetEntityId u64, symétrique du Decode existant) ; `EncodeRespawnRequest`/`DecodeRespawnRequest` (payload 4).
+- Modify: `src/shared/network/ServerProtocolTests.cpp` — roundtrip CombatEvent avec flags crit|miss ; roundtrip AttackRequest (Encode→Decode) ; roundtrip RespawnRequest + rejet payload tronqué.
+
+### Task 5: Respawn serveur
+
+**Files:**
+- Modify: `src/shared/server_bootstrap/ServerApp.h` — `ConnectedClient` gagne `float spawnPositionMetersX/Y/Z = 0.0f;` (mémorisé à l'admission) ; déclaration `void HandleRespawnRequest(const Endpoint&, uint32_t clientId);`.
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` :
+  - Fin de `HandleHello` (après résolution position persistée/DB, avant `UpdateClientInterest`) : mémoriser `spawnPositionMeters* = positionMeters*`.
+  - Dispatch (:692 zone des `case MessageKind::`) : router `RespawnRequest` → handler.
+  - `HandleRespawnRequest` : client connu + clientId cohérent + **mort uniquement** (sinon warn+ignore) → téléport au `spawnPositionMeters*`, `stats.currentHealth = stats.maxHealth`, clear `kEntityStateDead`, mise à jour grille spatiale (même appel que le déplacement : `UpsertEntity`), `PurgeThreatForEntity`, `SaveConnectedClient(client, "respawn")`, log.
+
+### Task 6: Client — envoi UDP + ciblage
+
+**Files:**
+- Modify: `src/client/net/GameplayUdpClient.{h,cpp}` — `SendAttackRequest(uint64_t targetEntityId)` et `SendRespawnRequest()` (pattern exact de `SendTalkRequest` : struct + Encode + SendBytes, clientId du handshake).
+- Modify: `src/client/ui_common/UIModel.h/.cpp` :
+  - `UIModelBinding::SetLocalTarget(engine::server::EntityId)` : cherche l'entité dans `m_model.remoteEntities`, remplit `targetStats` (entityId, PV, flags, position, hasTarget/hasPosition), `NotifyObservers(UIModelChangeCombat)` ; `ClearLocalTarget()`.
+  - `ApplySnapshot` (:752, bloc cible) : en plus de la position, rafraîchir `currentHealth/maxHealth/stateFlags` de la cible depuis le snapshot ; si la cible a disparu de l'AoI ou est morte → conserver hasTarget mais marquer mort (le HUD griser/le cycle Tab l'ignorera).
+- Modify: `src/client/app/Engine.cpp` (bloc input in-game, voisin des toggles :7582-7717, gardes `inGameNoMenu && !chatBlocks`) :
+  - **Registre de binds minimal** : petit tableau local commenté `// Binds combat SP2 (embryon Lot E) : Tab=cycle cible, T=attaque, J=panneau combat` — les nouvelles touches déclarées à UN endroit.
+  - **Clic gauche** (`WasMousePressed(Left)`, hors éditeur, hors capture ImGui `ImGui::GetIO().WantCaptureMouse`) : pour chaque `remoteEntities` avec `archetypeId != 0` et vivante, `WorldToScreenPx(position lissée + 0.5f)` ; sélectionne la plus proche du curseur sous ~40 px ; trouvé → `SetLocalTarget`, sinon ne rien faire (pas de déselection au clic raté — V1).
+  - **Tab** : cycle les mobs vivants de l'AoI triés par distance monde croissante (suivant de la cible courante, wrap).
+  - **T** : si cible vivante → `m_gameplayUdp.SendAttackRequest(target.entityId)` avec throttle local 250 ms (le serveur revalide le cooldown réel).
+
+### Task 7: Client — câblage CombatHud + AdvancedCombatUi + rendu
+
+**Files:**
+- Modify: `src/client/app/Engine.h` — membres `engine::client::CombatHudPresenter m_combatHud;` et `engine::client::AdvancedCombatPresenter m_advancedCombat;` (namespaces exacts à reprendre des headers), `bool m_advancedCombatVisible = false;` (+ includes).
+- Modify: `src/client/app/Engine.cpp` :
+  - Observer existant (:12157-12163) : ajouter `m_combatHud.ApplyModel(model, changeMask)` et `m_advancedCombat.ApplyModel(model, changeMask)`.
+  - Update : `Tick(deltaSeconds)` des deux + `m_combatHud.SetViewportSize(w, h)` au resize/init.
+  - Rendu HUD (section in-game, près du HUD PV/ressource existant) depuis `GetState()` :
+    - **Cadre cible** (si `targetStats.hasTarget`) : nom (CreatureCatalog via archetypeId de la cible, fallback « Cible ») + barre PV + « MORT » grisé si flag dead.
+    - **Log combat HUD** : `combatLogLines` du CombatHudState (déjà formatées), ~6 dernières lignes, coin bas-droit ; les events miss/crit affichent « raté »/« CRITIQUE » (formatage : si flags présents dans UICombatLogEntry — ajouter `bool wasCrit/wasMiss` à `UICombatLogEntry` et les remplir dans `ApplyCombatEvent` depuis `message.flags`).
+    - **Panneau combat avancé** (touche J) : fenêtre ImGui listant le DPS meter (`dpsMeter[]` : nom + barre + valeur) et le log 20 lignes avec filtres (boutons Damage/Healing/Deaths → `SetLogFilter`).
+- Modify: `src/client/ui_common/UIModel.h/.cpp` — `UICombatLogEntry` gagne `bool wasCrit = false; bool wasMiss = false;` remplis depuis `m_combatEventMessage.flags`.
+- Modify: `src/client/combat/CombatHud.cpp` / `AdvancedCombatUi.cpp` — formatage des lignes : suffixe « (CRITIQUE) » / « raté » selon les nouveaux booléens (toucher uniquement les fonctions Format*).
+
+### Task 8: Client — écran de mort
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` — sur le pattern du menu pause (:10480-10550) : si `playerStats.stateFlags & kEntityStateDead` (et in-game) → overlay sombre plein écran « Vous êtes mort » + bouton « Réapparaître » → `SendRespawnRequest()`. Pendant la mort : bloquer l'envoi d'Input de déplacement (gate dans UpdateGameplayNet) et les touches combat. Pas d'état persistant : l'overlay disparaît quand le flag dead retombe (snapshot post-respawn).
+
+### Task 9: Docs + PR + CI
+
+- Modify: `CODEBASE_MAP.md` (section Combat : SP2), commit de ce plan.
+- Push `combat-sp2`, PR base main, CI (~35 min Windows). **Déploiement : ⚠️ wire v10 — master + shardd + client lock-step.**
+
+---
+
+## Self-review
+
+- **Spec §5 couverte** : 5.1 wire (Task 4), 5.2 stats+jets+respawn (Tasks 1-3, 5), 5.3 purge menace + respawn (Tasks 3, 5), 5.4 client complet (Tasks 6-8), 5.5 hors périmètre respecté (pas de loot/armure/sorts/PvP), 5.6 livraison adaptée (1 PR au lieu de 3 — justifié par CI/lock-step).
+- **Types cohérents** : flags u32 partout ; `DerivedStats.damage` u32 = `CombatComponent.damagePerHit` u32 ; rolls float [0,1).
+- **Pas de placeholder** : les deux points vérifiés à l'exécution (liberté touche J, position exacte du rendu HUD PV existant) sont bornés avec alternative.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -533,6 +533,10 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp)
 
+  # Combat SP2 : résolveur d'attaque pur (précision / critique, header-only).
+  lcdlln_add_simple_test(attack_resolver_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/combat/AttackResolverTests.cpp)
+
   # TA.3 (replication des joueurs) : registre des personnages admis (gate de la
   # session UDP, lié au character_id authentifié du ticket). Pure logique testable.
   lcdlln_add_simple_test(admitted_character_registry_tests

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9011,7 +9011,11 @@ namespace engine
 				// nowSec de la state machine n'est pas encore en portée à ce point) ;
 				// l'écart sub-ms avec la garde roulade plus bas est sans effet visible.
 				const bool moveLocked = EngineNowSec() < m_avatarMoveLockUntilSec;
-				if (m_dialogueActive || moveLocked)
+				// Combat SP2 — un joueur mort ne bouge plus (overlay « Vous êtes
+				// mort » affiché ; le respawn rend la main). kEntityStateDead = bit 0.
+				const bool localPlayerDead = m_gameplayNetInitialized
+					&& (m_uiModelBinding.GetModel().playerStats.stateFlags & 1u) != 0u;
+				if (m_dialogueActive || moveLocked || localPlayerDead)
 					moveInput = engine::gameplay::MoveInput{};
 				// Collisionneur composite : terrain (sol + eau) + cylindres des props/décor.
 				m_characterController.Update(static_cast<float>(dt), moveInput, m_worldCollider);
@@ -10238,6 +10242,253 @@ namespace engine
 							ImVec2(sxp + ts.x * 0.5f + 4.0f, syp + 2.0f),
 							IM_COL32(0, 0, 0, 140), 3.0f);
 						fg->AddText(ImVec2(sxp - ts.x * 0.5f, syp - ts.y), IM_COL32(220, 230, 255, 255), label.c_str());
+					}
+				}
+				// =============================================================
+				// Combat SP2 — ciblage (clic / Tab), attaque (T), cadre cible,
+				// log combat HUD, panneau avance (J) et ecran de mort. Touches
+				// declarees dans le registre de binds combat (cf. Engine.h).
+				// Libelles ASCII : la police in-game (Windlass) n'a pas tous
+				// les glyphes accentues (convention du menu pause).
+				// =============================================================
+				if (m_gameplayNetInitialized && m_authUi.IsInWorldShard())
+				{
+					const engine::client::UIModel& uiModel = m_uiModelBinding.GetModel();
+					const bool localDead = (uiModel.playerStats.stateFlags & 1u) != 0u;
+					const bool chatFocus = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
+					const bool menuOpen = m_inGamePauseMenuVisible || m_inGameOptionsPanelVisible;
+					const bool keysAllowed = !menuOpen && !chatFocus && !localDead
+						&& !ImGui::GetIO().WantCaptureKeyboard;
+					const bool mouseAllowed = !menuOpen && !chatFocus && !localDead
+						&& !ImGui::GetIO().WantCaptureMouse;
+
+					// --- Selection a la souris : pick ecran-espace du mob vivant le
+					// plus proche du curseur (rayon kPickRadiusPx), sans raycast 3D.
+					if (mouseAllowed && m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						constexpr float kPickRadiusPx = 40.0f;
+						const ImVec2 mousePos = ImGui::GetIO().MousePos;
+						engine::server::EntityId pickedId = 0;
+						float bestDistSq = kPickRadiusPx * kPickRadiusPx;
+						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
+						{
+							// V1 : seuls les mobs vivants sont ciblables (pas de PvP).
+							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u)
+								continue;
+							float wx = re.positionX, wy = re.positionY, wz = re.positionZ;
+							const auto sit = m_remoteSmoothed.find(re.entityId);
+							if (sit != m_remoteSmoothed.end() && sit->second.valid)
+							{
+								wx = sit->second.x; wy = sit->second.y; wz = sit->second.z;
+							}
+							float sxp = 0.0f, syp = 0.0f;
+							if (!WorldToScreenPx(out.viewProjMatrix.m, wx, wy + 0.5f, wz, ivw, ivh, sxp, syp))
+								continue;
+							const float dxPick = sxp - mousePos.x;
+							const float dyPick = syp - mousePos.y;
+							const float distSq = dxPick * dxPick + dyPick * dyPick;
+							if (distSq < bestDistSq)
+							{
+								bestDistSq = distSq;
+								pickedId = re.entityId;
+							}
+						}
+						if (pickedId != 0)
+							(void)m_uiModelBinding.SetLocalTarget(pickedId);
+					}
+
+					// --- Tab : cycle des mobs vivants par distance croissante au joueur.
+					if (keysAllowed && m_input.WasPressed(engine::platform::Key::Tab))
+					{
+						const engine::math::Vec3 playerPos = m_characterController.GetPosition();
+						std::vector<std::pair<float, engine::server::EntityId>> candidates;
+						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
+						{
+							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u)
+								continue;
+							const float dxc = re.positionX - playerPos.x;
+							const float dzc = re.positionZ - playerPos.z;
+							candidates.emplace_back(dxc * dxc + dzc * dzc, re.entityId);
+						}
+						if (!candidates.empty())
+						{
+							std::sort(candidates.begin(), candidates.end());
+							// Suivant de la cible courante (wrap) ; sans cible : la plus proche.
+							size_t nextIndex = 0;
+							if (uiModel.targetStats.hasTarget)
+							{
+								for (size_t ci = 0; ci < candidates.size(); ++ci)
+								{
+									if (candidates[ci].second == uiModel.targetStats.entityId)
+									{
+										nextIndex = (ci + 1u) % candidates.size();
+										break;
+									}
+								}
+							}
+							(void)m_uiModelBinding.SetLocalTarget(candidates[nextIndex].second);
+						}
+					}
+
+					// --- T : attaque de la cible courante. Throttle local anti-spam
+					// uniquement : portee, cooldown reel et cible vivante sont
+					// revalides par le serveur (HandleAttackRequest).
+					if (keysAllowed && m_input.WasPressed(engine::platform::Key::T)
+						&& uiModel.targetStats.hasTarget
+						&& (uiModel.targetStats.stateFlags & 1u) == 0u
+						&& m_attackSendCooldownSec <= 0.0f)
+					{
+						const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
+						if (gameplayClientId != 0u)
+						{
+							(void)m_gameplayUdp.SendAttackRequest(gameplayClientId, uiModel.targetStats.entityId);
+							m_attackSendCooldownSec = 0.25f;
+						}
+					}
+
+					// --- J : panneau combat avance (DPS meter + log filtrable).
+					if (keysAllowed && m_input.WasPressed(engine::platform::Key::J))
+					{
+						m_advancedCombatVisible = !m_advancedCombatVisible;
+					}
+
+					// --- Cadre cible (haut-centre) : nom + barre de PV. Les PV de la
+					// cible suivent les snapshots (cf. UIModelBinding::ApplySnapshot).
+					if (uiModel.targetStats.hasTarget)
+					{
+						const float frameW = 260.0f;
+						const float frameH = 54.0f;
+						const float fx = (dw - frameW) * 0.5f;
+						const float fy = 56.0f;
+						const bool targetDead = (uiModel.targetStats.stateFlags & 1u) != 0u;
+						// Nom : catalogue creatures (la cible V1 est toujours un mob).
+						std::string targetName = "Cible";
+						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
+						{
+							if (re.entityId != uiModel.targetStats.entityId)
+								continue;
+							const engine::client::CreatureAppearance* app = m_creatureCatalog.Find(re.archetypeId);
+							if (app != nullptr)
+								targetName = app->name;
+							break;
+						}
+						if (targetDead)
+							targetName += "  (MORT)";
+						fg->AddRectFilled(ImVec2(fx, fy), ImVec2(fx + frameW, fy + frameH), IM_COL32(10, 12, 16, 200), 6.0f);
+						fg->AddRect(ImVec2(fx, fy), ImVec2(fx + frameW, fy + frameH),
+							targetDead ? IM_COL32(120, 120, 120, 200) : IM_COL32(200, 60, 50, 220), 6.0f, 0, 2.0f);
+						fg->AddText(ImVec2(fx + 10.0f, fy + 6.0f),
+							targetDead ? IM_COL32(150, 150, 150, 255) : IM_COL32(235, 235, 235, 255), targetName.c_str());
+						const float barX = fx + 10.0f, barY = fy + 30.0f, barW = frameW - 20.0f, barH = 14.0f;
+						const float hpFrac = (uiModel.targetStats.maxHealth > 0u)
+							? std::clamp(static_cast<float>(uiModel.targetStats.currentHealth)
+								/ static_cast<float>(uiModel.targetStats.maxHealth), 0.0f, 1.0f)
+							: 0.0f;
+						fg->AddRectFilled(ImVec2(barX, barY), ImVec2(barX + barW, barY + barH), IM_COL32(40, 40, 44, 220), 3.0f);
+						fg->AddRectFilled(ImVec2(barX, barY), ImVec2(barX + barW * hpFrac, barY + barH),
+							targetDead ? IM_COL32(110, 110, 110, 230) : IM_COL32(190, 50, 40, 230), 3.0f);
+						const std::string hpText = std::to_string(uiModel.targetStats.currentHealth) + "/"
+							+ std::to_string(uiModel.targetStats.maxHealth);
+						const ImVec2 hpTs = ImGui::CalcTextSize(hpText.c_str());
+						fg->AddText(ImVec2(barX + (barW - hpTs.x) * 0.5f, barY - 1.0f), IM_COL32(255, 255, 255, 255), hpText.c_str());
+					}
+
+					// --- Log combat HUD (bas-droite) : dernieres lignes formatees par
+					// le CombatHudPresenter (suffixes critique/rate inclus).
+					const engine::client::CombatHudState& hudState = m_combatHud.GetState();
+					if (!hudState.combatLogLines.empty())
+					{
+						constexpr size_t kHudLogMaxLines = 6u;
+						const size_t lineCount = std::min(hudState.combatLogLines.size(), kHudLogMaxLines);
+						const float lineH = ImGui::GetTextLineHeight() + 2.0f;
+						float ly = dh - 140.0f - lineH * static_cast<float>(lineCount);
+						for (size_t li = hudState.combatLogLines.size() - lineCount; li < hudState.combatLogLines.size(); ++li)
+						{
+							const engine::client::HudCombatLogLine& logLine = hudState.combatLogLines[li];
+							const ImU32 col = logLine.incoming ? IM_COL32(255, 140, 120, 230) : IM_COL32(220, 220, 180, 230);
+							const ImVec2 lts = ImGui::CalcTextSize(logLine.text.c_str());
+							fg->AddText(ImVec2(dw - lts.x - 24.0f, ly), col, logLine.text.c_str());
+							ly += lineH;
+						}
+					}
+
+					// --- Panneau combat avance (J) : DPS meter + log filtrable (M39.4).
+					if (m_advancedCombatVisible)
+					{
+						const engine::client::AdvancedCombatState& acs = m_advancedCombat.GetState();
+						ImGui::SetNextWindowPos(ImVec2(dw - 420.0f, 90.0f), ImGuiCond_FirstUseEver);
+						ImGui::SetNextWindowSize(ImVec2(380.0f, 420.0f), ImGuiCond_FirstUseEver);
+						if (ImGui::Begin("Combat avance", &m_advancedCombatVisible))
+						{
+							ImGui::Text("Combat : %s  (%.1f s)", acs.inCombat ? "en cours" : "inactif", acs.fightElapsedSec);
+							ImGui::Separator();
+							ImGui::TextUnformatted("DPS");
+							for (const engine::client::DpsMeterEntry& row : acs.dpsMeter)
+							{
+								ImGui::Text("%u. %s", row.rank, row.displayName.c_str());
+								ImGui::SameLine(200.0f);
+								ImGui::Text("%.1f dps", row.dps);
+								ImGui::ProgressBar(row.barFraction, ImVec2(-1.0f, 6.0f), "");
+							}
+							ImGui::Separator();
+							uint32_t filter = acs.activeFilter;
+							bool filterChanged = false;
+							auto toggleChip = [&filter, &filterChanged](const char* lbl, uint32_t mask)
+							{
+								bool on = (filter & mask) != 0u;
+								if (ImGui::Checkbox(lbl, &on))
+								{
+									filter = on ? (filter | mask) : (filter & ~mask);
+									filterChanged = true;
+								}
+								ImGui::SameLine();
+							};
+							toggleChip("Degats", engine::client::CombatLogFilterDamage);
+							toggleChip("Soins", engine::client::CombatLogFilterHealing);
+							toggleChip("Morts", engine::client::CombatLogFilterDeaths);
+							ImGui::NewLine();
+							if (filterChanged)
+								m_advancedCombat.SetLogFilter(filter);
+							ImGui::Separator();
+							ImGui::BeginChild("##ln_combat_log", ImVec2(0.0f, 0.0f), true);
+							for (const engine::client::CombatLogLine& logLine : acs.visibleLogLines)
+								ImGui::TextUnformatted(logLine.text.c_str());
+							ImGui::EndChild();
+						}
+						ImGui::End();
+					}
+
+					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →
+					// RespawnRequest (le serveur ne l'honore que si le flag dead est pose ;
+					// l'overlay disparait quand le snapshot post-respawn retire le flag).
+					if (localDead)
+					{
+						fg->AddRectFilled(ImVec2(0.0f, 0.0f), ImVec2(dw, dh), IM_COL32(10, 0, 0, 140));
+						const float panelW = 360.0f;
+						const float panelH = 170.0f;
+						ImGui::SetNextWindowPos(ImVec2((dw - panelW) * 0.5f, (dh - panelH) * 0.5f), ImGuiCond_Always);
+						ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_Always);
+						ImGui::SetNextWindowBgAlpha(0.95f);
+						ImGui::Begin("##ln_death_overlay", nullptr,
+							ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove
+							| ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
+						ImGui::SetWindowFontScale(1.3f);
+						const char* deadTitle = "VOUS ETES MORT";
+						const float deadTitleW = ImGui::CalcTextSize(deadTitle).x;
+						ImGui::SetCursorPosX((panelW - deadTitleW) * 0.5f);
+						ImGui::TextUnformatted(deadTitle);
+						ImGui::SetWindowFontScale(1.0f);
+						ImGui::Separator();
+						ImGui::Spacing();
+						ImGui::Spacing();
+						ImGui::SetCursorPosX((panelW - 200.0f) * 0.5f);
+						if (ImGui::Button("Reapparaitre", ImVec2(200.0f, 40.0f)))
+						{
+							const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
+							if (gameplayClientId != 0u)
+								(void)m_gameplayUdp.SendRespawnRequest(gameplayClientId);
+						}
+						ImGui::End();
 					}
 				}
 			}
@@ -12139,6 +12390,17 @@ namespace engine
 			return;
 		}
 
+		// Combat SP2 — présentateurs combat (non bloquants : un échec d'Init
+		// désactive juste le HUD combat, le gameplay réseau reste fonctionnel).
+		if (!m_combatHud.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] CombatHudPresenter Init FAILED — HUD combat désactivé");
+		}
+		if (!m_advancedCombat.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] AdvancedCombatPresenter Init FAILED — panneau combat désactivé");
+		}
+
 		const uint32_t vw = static_cast<uint32_t>(std::max(1, m_width));
 		const uint32_t vh = static_cast<uint32_t>(std::max(1, m_height));
 		if (!m_shopUi.SetViewportSize(vw, vh))
@@ -12153,6 +12415,11 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] InventoryUiPresenter viewport FAILED — using fallback layout");
 		}
+		// Combat SP2 — layout pixel du HUD combat (cadre cible, log, cooldowns).
+		if (!m_combatHud.SetViewportSize(vw, vh))
+		{
+			LOG_WARN(Core, "[GameplayNet] CombatHudPresenter viewport FAILED — using fallback layout");
+		}
 
 		m_uiObserverHandle = m_uiModelBinding.AddObserver(
 			[this](const engine::client::UIModel& model, uint32_t changeMask)
@@ -12160,6 +12427,10 @@ namespace engine
 				(void)m_shopUi.ApplyModel(model, changeMask);
 				(void)m_auctionUi.ApplyModel(model, changeMask);
 				(void)m_invUi.ApplyModel(model, changeMask);
+				// Combat SP2 — les présentateurs combat consomment UIModelChangeCombat
+				// (combat log, cadre cible, DPS meter) et Stats (PV joueur).
+				(void)m_combatHud.ApplyModel(model, changeMask);
+				m_advancedCombat.ApplyModel(model, changeMask);
 			});
 		if (m_uiObserverHandle == 0u)
 		{
@@ -12226,6 +12497,11 @@ namespace engine
 			m_uiObserverHandle = 0;
 		}
 
+		// Combat SP2 — symétrie d'Init (présentateurs combat).
+		m_advancedCombat.Shutdown();
+		m_combatHud.Shutdown();
+		m_advancedCombatVisible = false;
+		m_attackSendCooldownSec = 0.0f;
 		m_invUi.Shutdown();
 		m_auctionUi.Shutdown();
 		m_shopUi.Shutdown();
@@ -12273,6 +12549,15 @@ namespace engine
 		if (clientId == 0u)
 		{
 			return;
+		}
+
+		// Combat SP2 — avance les timers des présentateurs combat (cooldowns HUD,
+		// fenêtre DPS) et le throttle local d'envoi d'attaque.
+		(void)m_combatHud.Tick(deltaSeconds);
+		m_advancedCombat.Tick(deltaSeconds);
+		if (m_attackSendCooldownSec > 0.0f)
+		{
+			m_attackSendCooldownSec -= deltaSeconds;
 		}
 
 		// TC.2 — émet la position + orientation de l'avatar local au shard, à la cadence

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -27,6 +27,9 @@
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
+// Combat SP2 — présentateurs combat câblés (HUD cible/log + panneau avancé).
+#include "src/client/combat/CombatHud.h"
+#include "src/client/combat/AdvancedCombatUi.h"
 #include "src/client/debug/ProfilerHud.h"
 #include "src/client/economy/ShopUi.h"
 #include "src/client/ui_common/UIModel.h"
@@ -1255,6 +1258,21 @@ namespace engine
 		engine::client::ShopUiPresenter m_shopUi{};
 		engine::client::AuctionUiPresenter m_auctionUi{};
 		engine::client::InventoryUiPresenter m_invUi{};
+		// ---------------------------------------------------------------------
+		// Combat SP2 — binds combat (embryon du registre central, Lot E) :
+		//   clic gauche = sélection de cible (pick écran-espace sur les mobs)
+		//   Tab         = cycle de cible (mobs vivants par distance croissante)
+		//   T           = attaque de la cible courante (AttackRequest)
+		//   J           = panneau combat avancé (DPS meter + log filtrable)
+		// Présentateurs : écrits en M16.2/M39.4, câblés ici pour la première fois.
+		// ---------------------------------------------------------------------
+		engine::client::CombatHudPresenter m_combatHud{};
+		engine::client::AdvancedCombatPresenter m_advancedCombat{};
+		/// Combat SP2 — visibilité du panneau combat avancé (touche J).
+		bool m_advancedCombatVisible = false;
+		/// Combat SP2 — throttle local d'envoi d'AttackRequest (le serveur reste
+		/// l'autorité du cooldown réel ; ceci évite juste le spam réseau).
+		float m_attackSendCooldownSec = 0.0f;
 		engine::client::GameplayUdpClient m_gameplayUdp{};
 		size_t m_uiObserverHandle = 0;
 		bool m_pendingSellActive = false;

--- a/src/client/combat/AdvancedCombatUi.cpp
+++ b/src/client/combat/AdvancedCombatUi.cpp
@@ -475,17 +475,30 @@ namespace engine::client
 		const std::string tgt   = MakeDisplayName(entry.targetEntityId);
 		const std::string dmgStr = std::to_string(entry.damage);
 
+		// Combat SP2 — libellés raté/critique depuis les flags wire v10.
+		const std::string critSuffix = entry.wasCrit ? " (CRIT)" : "";
+		if (entry.wasMiss)
+		{
+			if (entry.playerWasAttacker)
+				line.text = ts + " You miss " + tgt;
+			else if (entry.playerWasTarget)
+				line.text = ts + " " + atk + " misses you";
+			else
+				line.text = ts + " " + atk + " misses " + tgt;
+			return line;
+		}
+
 		if (entry.playerWasAttacker)
 		{
-			line.text = ts + " You hit " + tgt + " for " + dmgStr;
+			line.text = ts + " You hit " + tgt + " for " + dmgStr + critSuffix;
 		}
 		else if (entry.playerWasTarget)
 		{
-			line.text = ts + " " + atk + " hits you for " + dmgStr;
+			line.text = ts + " " + atk + " hits you for " + dmgStr + critSuffix;
 		}
 		else
 		{
-			line.text = ts + " " + atk + " hits " + tgt + " for " + dmgStr;
+			line.text = ts + " " + atk + " hits " + tgt + " for " + dmgStr + critSuffix;
 		}
 
 		return line;

--- a/src/client/combat/CombatHud.cpp
+++ b/src/client/combat/CombatHud.cpp
@@ -30,16 +30,26 @@ namespace engine::client
 		}
 
 		/// Build one short combat log label from a retained combat entry.
+		/// Combat SP2 — libellés raté/critique depuis les flags wire v10.
 		std::string BuildCombatLogText(const UICombatLogEntry& entry)
 		{
+			const char* critSuffix = entry.wasCrit ? " (CRITIQUE)" : "";
 			if (entry.playerWasAttacker)
 			{
-				return "Hit target " + std::to_string(entry.targetEntityId) + " for " + std::to_string(entry.damage);
+				if (entry.wasMiss)
+				{
+					return "Rate la cible " + std::to_string(entry.targetEntityId);
+				}
+				return "Hit target " + std::to_string(entry.targetEntityId) + " for " + std::to_string(entry.damage) + critSuffix;
 			}
 
 			if (entry.playerWasTarget)
 			{
-				return "Took " + std::to_string(entry.damage) + " from " + std::to_string(entry.attackerEntityId);
+				if (entry.wasMiss)
+				{
+					return std::to_string(entry.attackerEntityId) + " vous rate";
+				}
+				return "Took " + std::to_string(entry.damage) + " from " + std::to_string(entry.attackerEntityId) + critSuffix;
 			}
 
 			return "Combat " + std::to_string(entry.damage);

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -261,6 +261,42 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendAttackRequest(uint32_t clientId, uint64_t targetEntityId)
+	{
+		engine::server::AttackRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.targetEntityId = targetEntityId;
+		const std::vector<std::byte> packet = engine::server::EncodeAttackRequest(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_DEBUG(Net, "[GameplayUdpClient] AttackRequest sent (client_id={}, target_entity_id={})",
+				clientId, targetEntityId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] AttackRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendRespawnRequest(uint32_t clientId)
+	{
+		engine::server::RespawnRequestMessage msg{};
+		msg.clientId = clientId;
+		const std::vector<std::byte> packet = engine::server::EncodeRespawnRequest(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] RespawnRequest sent (client_id={})", clientId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] RespawnRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity)
 	{
 		engine::server::ShopBuyRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -50,6 +50,14 @@ namespace engine::client
 		/// Send TalkRequest (e.g. `vendor:1` to open shop).
 		bool SendTalkRequest(uint32_t clientId, std::string_view targetId);
 
+		/// Combat SP2 — demande d'attaque sur une entité ciblée. Le serveur
+		/// revalide tout (portée, cooldown, cible vivante) ; le client peut
+		/// throttler mais n'a pas d'autorité.
+		bool SendAttackRequest(uint32_t clientId, uint64_t targetEntityId);
+
+		/// Combat SP2 — demande de réapparition (joueur mort uniquement, validé serveur).
+		bool SendRespawnRequest(uint32_t clientId);
+
 		bool SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);
 
 		bool SendShopSellRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -83,6 +83,9 @@ namespace engine::client
 			entry.damage = message.damage;
 			entry.playerWasAttacker = (message.attackerEntityId == playerEntityId);
 			entry.playerWasTarget = (message.targetEntityId == playerEntityId);
+			// Combat SP2 — critique / raté propagés au log (wire v10).
+			entry.wasCrit = (message.flags & engine::server::kCombatEventFlagCrit) != 0u;
+			entry.wasMiss = (message.flags & engine::server::kCombatEventFlagMiss) != 0u;
 			entry.sequence = combatLog.empty() ? 1u : (combatLog.back().sequence + 1u);
 			combatLog.push_back(entry);
 			if (combatLog.size() > kMaxCombatLogEntries)
@@ -753,6 +756,11 @@ namespace engine::client
 				m_model.targetStats.positionY = entity.state.positionY;
 				m_model.targetStats.positionZ = entity.state.positionZ;
 				m_model.targetStats.hasPosition = true;
+				// Combat SP2 — la cible suit aussi ses PV/flags entre deux
+				// CombatEvent (régénération, dégâts d'un autre joueur, mort).
+				m_model.targetStats.currentHealth = entity.state.currentHealth;
+				m_model.targetStats.maxHealth = entity.state.maxHealth;
+				m_model.targetStats.stateFlags = entity.state.stateFlags;
 				break;
 			}
 		}
@@ -826,6 +834,56 @@ namespace engine::client
 			m_combatEventMessage.damage,
 			playerWasAttacker ? "attacker" : "target");
 		return true;
+	}
+
+	bool UIModelBinding::SetLocalTarget(engine::server::EntityId entityId)
+	{
+		if (!ValidateMainThread("SetLocalTarget"))
+		{
+			return false;
+		}
+
+		for (const UIRemoteEntity& remote : m_model.remoteEntities)
+		{
+			if (remote.entityId != entityId)
+			{
+				continue;
+			}
+
+			m_model.targetStats.entityId = remote.entityId;
+			m_model.targetStats.currentHealth = remote.currentHealth;
+			m_model.targetStats.maxHealth = remote.maxHealth;
+			m_model.targetStats.stateFlags = remote.stateFlags;
+			m_model.targetStats.positionX = remote.positionX;
+			m_model.targetStats.positionY = remote.positionY;
+			m_model.targetStats.positionZ = remote.positionZ;
+			m_model.targetStats.hasTarget = true;
+			m_model.targetStats.hasPosition = true;
+			NotifyObservers(UIModelChangeCombat);
+			LOG_INFO(Net, "[UIModelBinding] Local target set (entity_id={}, hp={}/{})",
+				remote.entityId, remote.currentHealth, remote.maxHealth);
+			return true;
+		}
+
+		LOG_DEBUG(Net, "[UIModelBinding] SetLocalTarget ignored: entity {} not in AoI", entityId);
+		return false;
+	}
+
+	void UIModelBinding::ClearLocalTarget()
+	{
+		if (!ValidateMainThread("ClearLocalTarget"))
+		{
+			return;
+		}
+
+		if (!m_model.targetStats.hasTarget)
+		{
+			return;
+		}
+
+		m_model.targetStats = UITargetStats{};
+		NotifyObservers(UIModelChangeCombat);
+		LOG_INFO(Net, "[UIModelBinding] Local target cleared");
 	}
 
 	bool UIModelBinding::ApplyZoneChange(std::span<const std::byte> packet)

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -242,6 +242,9 @@ namespace engine::client
 		bool playerWasAttacker = false;
 		bool playerWasTarget = false;
 		uint64_t sequence = 0;
+		/// Combat SP2 (wire v10) — coup critique / raté, depuis CombatEventMessage::flags.
+		bool wasCrit = false;
+		bool wasMiss = false;
 	};
 
 	/// One quest step displayed by the UI model.
@@ -425,6 +428,15 @@ namespace engine::client
 
 		/// Return the current immutable UI model snapshot.
 		const UIModel& GetModel() const { return m_model; }
+
+		/// Combat SP2 — sélection LOCALE de cible (clic / Tab). Cherche l'entité
+		/// dans les remoteEntities du dernier snapshot, remplit targetStats
+		/// (PV/flags/position) et notifie UIModelChangeCombat. Retourne false si
+		/// l'entité n'est pas (ou plus) dans l'AoI. Main thread uniquement.
+		bool SetLocalTarget(engine::server::EntityId entityId);
+
+		/// Combat SP2 — efface la cible courante (notifie UIModelChangeCombat).
+		void ClearLocalTarget();
 
 		/// M29.3: Refresh billboard projections (call from render/game thread with camera + viewport).
 		void TickChatWorldVisuals(

--- a/src/shardd/gameplay/combat/AttackResolver.h
+++ b/src/shardd/gameplay/combat/AttackResolver.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace engine::server::combat
+{
+	/// Combat SP2 — résultat d'un jet d'attaque résolu par ResolveAttackRoll.
+	struct AttackRollResult
+	{
+		bool miss = false;
+		bool crit = false;
+		uint32_t damage = 0;
+	};
+
+	/// Combat SP2 — résout un jet d'attaque de façon PURE et déterministe : les
+	/// deux jets aléatoires [0,1) sont fournis par l'appelant (RNG injecté), ce
+	/// qui rend toutes les branches testables sans graine ni mock.
+	///
+	/// Règles :
+	/// - précision : raté si roll01Accuracy >= accuracy/100 (accuracy clampée
+	///   [0,100] ; 100 = ne rate jamais, 0 = rate toujours). Raté → damage 0.
+	/// - critique : touché ET roll01Crit < critRate/100 (critRate clampé
+	///   [0,100]) → damage = baseDamage × critMult arrondi au plus proche
+	///   (critMult plancher 1.0 — un crit ne réduit jamais les dégâts).
+	/// - sinon touché normal → damage = baseDamage.
+	///
+	/// \param roll01Accuracy jet [0,1) consommé par le test de précision.
+	/// \param roll01Crit jet [0,1) consommé par le test de critique.
+	inline AttackRollResult ResolveAttackRoll(
+		uint32_t baseDamage,
+		float accuracy,
+		float critRate,
+		float critMult,
+		float roll01Accuracy,
+		float roll01Crit)
+	{
+		AttackRollResult result{};
+
+		const float clampedAccuracy = std::clamp(accuracy, 0.0f, 100.0f);
+		if (roll01Accuracy >= clampedAccuracy / 100.0f)
+		{
+			result.miss = true;
+			result.damage = 0;
+			return result;
+		}
+
+		const float clampedCritRate = std::clamp(critRate, 0.0f, 100.0f);
+		if (roll01Crit < clampedCritRate / 100.0f)
+		{
+			result.crit = true;
+			const float flooredMult = std::max(critMult, 1.0f);
+			const double critDamage = static_cast<double>(baseDamage) * static_cast<double>(flooredMult);
+			result.damage = static_cast<uint32_t>(std::llround(critDamage));
+			return result;
+		}
+
+		result.damage = baseDamage;
+		return result;
+	}
+}

--- a/src/shardd/gameplay/combat/AttackResolverTests.cpp
+++ b/src/shardd/gameplay/combat/AttackResolverTests.cpp
@@ -1,0 +1,105 @@
+// Combat SP2 — tests du résolveur d'attaque pur (précision / critique / clamps).
+
+#include "src/shardd/gameplay/combat/AttackResolver.h"
+#include "src/shared/core/Log.h"
+
+namespace
+{
+	using engine::server::combat::AttackRollResult;
+	using engine::server::combat::ResolveAttackRoll;
+
+	bool TestGuaranteedHit()
+	{
+		// accuracy 100 → ne rate jamais, même avec le pire jet (0.999...).
+		const AttackRollResult r = ResolveAttackRoll(50, 100.0f, 0.0f, 1.5f, 0.999f, 0.5f);
+		if (r.miss || r.crit || r.damage != 50) return false;
+		LOG_INFO(Core, "[AttackResolverTests] guaranteed hit OK");
+		return true;
+	}
+
+	bool TestGuaranteedMiss()
+	{
+		// accuracy 0 → rate toujours, même avec le meilleur jet (0.0).
+		const AttackRollResult r = ResolveAttackRoll(50, 0.0f, 100.0f, 2.0f, 0.0f, 0.0f);
+		if (!r.miss || r.crit || r.damage != 0) return false;
+		LOG_INFO(Core, "[AttackResolverTests] guaranteed miss OK");
+		return true;
+	}
+
+	bool TestGuaranteedCrit()
+	{
+		// critRate 100 → tout coup touché est critique ; 50 × 1.5 = 75.
+		const AttackRollResult r = ResolveAttackRoll(50, 100.0f, 100.0f, 1.5f, 0.0f, 0.999f);
+		if (r.miss || !r.crit || r.damage != 75) return false;
+		LOG_INFO(Core, "[AttackResolverTests] guaranteed crit OK");
+		return true;
+	}
+
+	bool TestNoCritWhenRateZero()
+	{
+		const AttackRollResult r = ResolveAttackRoll(50, 100.0f, 0.0f, 2.0f, 0.0f, 0.0f);
+		if (r.miss || r.crit || r.damage != 50) return false;
+		LOG_INFO(Core, "[AttackResolverTests] no crit at rate 0 OK");
+		return true;
+	}
+
+	bool TestAccuracyClampedAbove100()
+	{
+		// accuracy 150 clampée à 100 → jamais de raté.
+		const AttackRollResult r = ResolveAttackRoll(10, 150.0f, 0.0f, 1.5f, 0.999f, 0.5f);
+		if (r.miss || r.damage != 10) return false;
+		LOG_INFO(Core, "[AttackResolverTests] accuracy clamp OK");
+		return true;
+	}
+
+	bool TestCritMultFlooredToOne()
+	{
+		// critMult 0.5 plancher 1.0 → un crit ne réduit jamais les dégâts.
+		const AttackRollResult r = ResolveAttackRoll(40, 100.0f, 100.0f, 0.5f, 0.0f, 0.0f);
+		if (r.miss || !r.crit || r.damage != 40) return false;
+		LOG_INFO(Core, "[AttackResolverTests] critMult floor OK");
+		return true;
+	}
+
+	bool TestZeroBaseDamage()
+	{
+		// base 0 → 0 dégât même en critique (pas d'underflow / arrondi exotique).
+		const AttackRollResult r = ResolveAttackRoll(0, 100.0f, 100.0f, 3.0f, 0.0f, 0.0f);
+		if (r.miss || !r.crit || r.damage != 0) return false;
+		LOG_INFO(Core, "[AttackResolverTests] zero base damage OK");
+		return true;
+	}
+
+	bool TestCritRounding()
+	{
+		// 7 × 1.5 = 10.5 → arrondi au plus proche = 11 (llround).
+		const AttackRollResult r = ResolveAttackRoll(7, 100.0f, 100.0f, 1.5f, 0.0f, 0.0f);
+		if (r.damage != 11) return false;
+		LOG_INFO(Core, "[AttackResolverTests] crit rounding OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestGuaranteedHit()
+		&& TestGuaranteedMiss()
+		&& TestGuaranteedCrit()
+		&& TestNoCritWhenRateZero()
+		&& TestAccuracyClampedAbove100()
+		&& TestCritMultFlooredToOne()
+		&& TestZeroBaseDamage()
+		&& TestCritRounding();
+
+	if (ok) LOG_INFO(Core, "[AttackResolverTests] ALL OK");
+	else LOG_ERROR(Core, "[AttackResolverTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -19,12 +19,21 @@ namespace engine::server
 	};
 
 	/// Minimal combat component used by the authoritative attack validation.
+	/// Combat SP2 — accuracy/critRate/critMult alimentent les jets de précision
+	/// et de critique (cf. AttackResolver). Composant purement serveur : ces
+	/// champs ne transitent JAMAIS sur le wire (pas d'impact protocole).
 	struct CombatComponent
 	{
 		uint32_t damagePerHit = 0;
 		float attackRangeMeters = 0.0f;
 		uint32_t cooldownTicks = 0;
 		uint32_t nextAttackTick = 0;
+		/// Précision en % [0,100] — 100 = ne rate jamais (défaut conservateur).
+		float accuracy = 100.0f;
+		/// Taux de critique en % [0,100].
+		float critRate = 0.0f;
+		/// Multiplicateur de dégâts critiques (plancher 1.0 à la résolution).
+		float critMult = 1.5f;
 	};
 
 	/// Minimal item stack used by loot bags and player inventory.

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -593,13 +593,16 @@ namespace engine::server
 		WriteU32(packet, message.targetCurrentHealth);
 		WriteU32(packet, message.targetMaxHealth);
 		WriteU32(packet, message.targetStateFlags);
+		// Combat SP2 (wire v10) : flags critique/raté en queue de payload (32 → 36 o).
+		WriteU32(packet, message.flags);
 		return packet;
 	}
 
 	bool DecodeCombatEvent(std::span<const std::byte> packet, CombatEventMessage& outMessage)
 	{
 		std::span<const std::byte> payload;
-		if (!DecodeHeader(packet, MessageKind::CombatEvent, payload) || payload.size() != 32)
+		// Combat SP2 (wire v10) : payload passe de 32 à 36 octets (champ flags).
+		if (!DecodeHeader(packet, MessageKind::CombatEvent, payload) || payload.size() != 36)
 		{
 			return false;
 		}
@@ -610,6 +613,37 @@ namespace engine::server
 		outMessage.targetCurrentHealth = ReadU32(payload, 20);
 		outMessage.targetMaxHealth = ReadU32(payload, 24);
 		outMessage.targetStateFlags = ReadU32(payload, 28);
+		outMessage.flags = ReadU32(payload, 32);
+		return true;
+	}
+
+	std::vector<std::byte> EncodeAttackRequest(const AttackRequestMessage& message)
+	{
+		// Combat SP2 — symétrique de DecodeAttackRequest (payload 12 octets) ;
+		// jusqu'ici seul le serveur décodait, le client n'émettait pas.
+		std::vector<std::byte> packet = BeginPacket(MessageKind::AttackRequest, 12);
+		WriteU32(packet, message.clientId);
+		WriteU64(packet, message.targetEntityId);
+		return packet;
+	}
+
+	std::vector<std::byte> EncodeRespawnRequest(const RespawnRequestMessage& message)
+	{
+		// Combat SP2 — demande de réapparition (payload 4 octets).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::RespawnRequest, 4);
+		WriteU32(packet, message.clientId);
+		return packet;
+	}
+
+	bool DecodeRespawnRequest(std::span<const std::byte> packet, RespawnRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::RespawnRequest, payload) || payload.size() != 4)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
 		return true;
 	}
 

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -41,7 +41,11 @@ namespace engine::server
 	/// nom/niveau/mesh/échelle dans son CreatureCatalog pour rendre la créature.
 	/// Wire-breaking : ce bump invalide AUSSI le framing client↔master (version
 	/// partagée) → déployer master + shardd + client en lock-step.
-	inline constexpr uint16_t kProtocolVersion = 9;
+	/// Combat SP2 — bump 9 → 10 : `CombatEventMessage` gagne `flags` (uint32 :
+	/// bit0 critique, bit1 raté ; payload 32 → 36 o) et nouveau kind
+	/// `RespawnRequest` (80, client→shard, réapparition d'un joueur mort).
+	/// Wire-breaking : même contrainte lock-step master + shardd + client.
+	inline constexpr uint16_t kProtocolVersion = 10;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -216,7 +220,11 @@ namespace engine::server
 		/// Server → client: stats dérivées complètes du joueur local (R1-B). Poussé à
 		/// l'enter-world. Ajout rétro-additif : un vieux client qui ne connaît pas cet
 		/// opcode l'ignore (pas de bump de `kProtocolVersion`).
-		PlayerStats = 79
+		PlayerStats = 79,
+		/// Combat SP2 — client → shard : réapparition d'un joueur mort (téléport au
+		/// spawn mémorisé à l'admission, PV pleins, flag dead retiré). Refusé si le
+		/// joueur n'est pas mort. Livré avec le bump v9→v10.
+		RespawnRequest = 80
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -314,7 +322,13 @@ namespace engine::server
 		EntityId targetEntityId = 0;
 	};
 
+	/// Combat SP2 — bits du champ `CombatEventMessage::flags` (wire v10).
+	inline constexpr uint32_t kCombatEventFlagCrit = 1u << 0;
+	inline constexpr uint32_t kCombatEventFlagMiss = 1u << 1;
+
 	/// Authoritative combat result broadcast to interested clients.
+	/// Combat SP2 (wire v10) — `flags` porte critique/raté (cf. kCombatEventFlag*) ;
+	/// un raté a `damage == 0` et des PV cible inchangés.
 	struct CombatEventMessage
 	{
 		EntityId attackerEntityId = 0;
@@ -323,6 +337,14 @@ namespace engine::server
 		uint32_t targetCurrentHealth = 0;
 		uint32_t targetMaxHealth = 0;
 		uint32_t targetStateFlags = 0;
+		uint32_t flags = 0;
+	};
+
+	/// Combat SP2 — demande de réapparition d'un joueur mort (client → shard).
+	/// Le serveur ne l'honore que si le joueur porte kEntityStateDead.
+	struct RespawnRequestMessage
+	{
+		uint32_t clientId = 0;
 	};
 
 	/// Client request asking the authoritative server to pick up one loot bag entity.
@@ -463,6 +485,15 @@ namespace engine::server
 
 	/// Decode an attack request packet and validate the protocol header.
 	bool DecodeAttackRequest(std::span<const std::byte> packet, AttackRequestMessage& outMessage);
+
+	/// Combat SP2 — encode an attack request packet (client → server).
+	std::vector<std::byte> EncodeAttackRequest(const AttackRequestMessage& message);
+
+	/// Combat SP2 — encode a respawn request packet (client → server).
+	std::vector<std::byte> EncodeRespawnRequest(const RespawnRequestMessage& message);
+
+	/// Combat SP2 — decode a respawn request packet and validate the protocol header.
+	bool DecodeRespawnRequest(std::span<const std::byte> packet, RespawnRequestMessage& outMessage);
 
 	/// Encode a combat event packet with the protocol header.
 	std::vector<std::byte> EncodeCombatEvent(const CombatEventMessage& message);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -286,6 +286,83 @@ namespace
 		std::puts("[OK] TestGoodbyeRoundTrip");
 	}
 
+	/// Combat SP2 (wire v10) — un CombatEvent encodé puis décodé restitue les flags
+	/// critique/raté en plus des champs historiques.
+	void TestCombatEventRoundTripWithFlags()
+	{
+		engine::server::CombatEventMessage in{};
+		in.attackerEntityId = 0x200000001ull;
+		in.targetEntityId = 0x300000005ull;
+		in.damage = 75u;
+		in.targetCurrentHealth = 25u;
+		in.targetMaxHealth = 100u;
+		in.targetStateFlags = 0u;
+		in.flags = engine::server::kCombatEventFlagCrit;
+
+		const std::vector<std::byte> packet = engine::server::EncodeCombatEvent(in);
+		assert(!packet.empty());
+
+		engine::server::CombatEventMessage out{};
+		assert(engine::server::DecodeCombatEvent(packet, out));
+		assert(out.attackerEntityId == in.attackerEntityId);
+		assert(out.targetEntityId == in.targetEntityId);
+		assert(out.damage == 75u);
+		assert(out.targetCurrentHealth == 25u);
+		assert(out.targetMaxHealth == 100u);
+		assert(out.flags == engine::server::kCombatEventFlagCrit);
+
+		// Raté : damage 0 + bit miss.
+		in.damage = 0u;
+		in.flags = engine::server::kCombatEventFlagMiss;
+		const std::vector<std::byte> missPacket = engine::server::EncodeCombatEvent(in);
+		assert(engine::server::DecodeCombatEvent(missPacket, out));
+		assert(out.damage == 0u);
+		assert((out.flags & engine::server::kCombatEventFlagMiss) != 0u);
+
+		// Paquet tronqué (ancien format 32 octets) rejeté.
+		std::vector<std::byte> truncated = missPacket;
+		truncated.resize(truncated.size() - 4u);
+		assert(!engine::server::DecodeCombatEvent(truncated, out));
+		std::puts("[OK] TestCombatEventRoundTripWithFlags");
+	}
+
+	/// Combat SP2 — l'AttackRequest gagne son encodeur côté client : round-trip
+	/// contre le décodeur serveur existant.
+	void TestAttackRequestRoundTrip()
+	{
+		engine::server::AttackRequestMessage in{};
+		in.clientId = 7u;
+		in.targetEntityId = 0x300000005ull;
+
+		const std::vector<std::byte> packet = engine::server::EncodeAttackRequest(in);
+		assert(!packet.empty());
+
+		engine::server::AttackRequestMessage out{};
+		assert(engine::server::DecodeAttackRequest(packet, out));
+		assert(out.clientId == 7u);
+		assert(out.targetEntityId == 0x300000005ull);
+		std::puts("[OK] TestAttackRequestRoundTrip");
+	}
+
+	/// Combat SP2 — round-trip RespawnRequest + rejet d'un payload tronqué.
+	void TestRespawnRequestRoundTrip()
+	{
+		engine::server::RespawnRequestMessage in{};
+		in.clientId = 42u;
+
+		const std::vector<std::byte> packet = engine::server::EncodeRespawnRequest(in);
+		assert(!packet.empty());
+
+		engine::server::RespawnRequestMessage out{};
+		assert(engine::server::DecodeRespawnRequest(packet, out));
+		assert(out.clientId == 42u);
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 2u);
+		assert(!engine::server::DecodeRespawnRequest(truncated, out));
+		std::puts("[OK] TestRespawnRequestRoundTrip");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
@@ -296,6 +373,9 @@ int main()
 	TestSnapshotRejectsTruncatedPayload();
 	TestSnapshotRoundTripWithChunking();
 	TestSnapshotMonoChunkDefaultsRoundTrip();
+	TestCombatEventRoundTripWithFlags();
+	TestAttackRequestRoundTrip();
+	TestRespawnRequestRoundTrip();
 	std::puts("All ServerProtocol tests passed");
 	return 0;
 }

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -42,6 +42,10 @@ namespace engine::platform
 		X = 'X',
 		Y = 'Y',
 		Z = 'Z',
+		// Combat SP2 — touches d'attaque (T) et de panneau combat avancé (J).
+		// Valeurs = codes ASCII majuscules (== VK_* Windows), comme le reste.
+		T = 'T',
+		J = 'J',
 		Escape = 0x1B,
 		Tab = 0x09,
 		Control = 0x11,

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -191,7 +191,23 @@ namespace engine::server
 				mob.combat.cooldownTicks = std::max<uint32_t>(1u,
 					(archetype->attackPeriodMs * static_cast<uint32_t>(tickHz) + 999u) / 1000u);
 				mob.xpReward = archetype->xpReward;
+				// Combat SP2 — jets de précision/critique data-driven (cf. AttackResolver).
+				mob.combat.accuracy = archetype->accuracy;
+				mob.combat.critRate = archetype->critRate;
+				mob.combat.critMult = archetype->critMult;
 			}
+		}
+
+		/// Combat SP2 — copie les stats dérivées du moteur de personnages dans le
+		/// composant combat du joueur (enter-world + level-up). range 0 = mêlée
+		/// pure → on conserve la portée de mêlée MVP (kDefaultAttackRangeMeters).
+		void ApplyDerivedCombatStats(ConnectedClient& client, const engine::server::gameplay::DerivedStats& derived)
+		{
+			client.combat.damagePerHit = derived.damage;
+			client.combat.attackRangeMeters = (derived.range > 0.0f) ? derived.range : kDefaultAttackRangeMeters;
+			client.combat.accuracy = derived.accuracy;
+			client.combat.critRate = derived.critRate;
+			client.combat.critMult = derived.critMult;
 		}
 
 		/// Return the squared XZ distance used by the range validation.
@@ -1330,6 +1346,25 @@ namespace engine::server
 					acceptedClient.level,
 					sh.maxHealth,
 					sh.currentHealth);
+			}
+			// Combat SP2 — injecte aussi les stats offensives calculées (damage,
+			// portée, précision, critique) dans le composant combat, à la place
+			// des constantes MVP. Faction/classe vides → ComputeStats nullopt →
+			// le composant MVP est conservé (pas de régression mode no-DB).
+			const auto derived = engine::server::gameplay::ComputeStats(
+				*m_statsTables, acceptedClient.factionId, acceptedClient.classId,
+				sex, acceptedClient.level);
+			if (derived)
+			{
+				ApplyDerivedCombatStats(acceptedClient, *derived);
+				LOG_INFO(Net,
+					"[ServerApp] SP2 enter-world combat stats (client_id={}, damage={}, range={:.1f}, accuracy={:.1f}, crit={:.1f}%x{:.2f})",
+					acceptedClient.clientId,
+					acceptedClient.combat.damagePerHit,
+					acceptedClient.combat.attackRangeMeters,
+					acceptedClient.combat.accuracy,
+					acceptedClient.combat.critRate,
+					acceptedClient.combat.critMult);
 			}
 		}
 
@@ -5559,6 +5594,8 @@ namespace engine::server
 		{
 			client.stats.maxHealth = d->hp;
 			client.stats.currentHealth = d->hp;   // soin complet au level-up.
+			// Combat SP2 — les stats offensives suivent aussi le niveau.
+			ApplyDerivedCombatStats(client, *d);
 		}
 		(void)SendPlayerStats(client);
 		SaveConnectedClient(client, "level_up");

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -735,6 +735,14 @@ namespace engine::server
 			return;
 		}
 
+		// Combat SP2 — réapparition d'un joueur mort.
+		RespawnRequestMessage respawnRequest{};
+		if (DecodeRespawnRequest(packetBytes, respawnRequest))
+		{
+			HandleRespawnRequest(datagram.endpoint, respawnRequest.clientId);
+			return;
+		}
+
 		PickupRequestMessage pickupRequest{};
 		if (DecodePickupRequest(packetBytes, pickupRequest))
 		{
@@ -1387,6 +1395,13 @@ namespace engine::server
 			LOG_WARN(Net, "[ServerApp] Quest state bootstrap skipped: runtime sync failed (client_id={})",
 				acceptedClient.clientId);
 		}
+
+		// Combat SP2 — mémorise la position d'entrée en monde comme point de
+		// réapparition (la position finale est résolue à ce stade : persistance
+		// fichier, pont DB et défauts ont tous été appliqués).
+		acceptedClient.spawnPositionMetersX = acceptedClient.positionMetersX;
+		acceptedClient.spawnPositionMetersY = acceptedClient.positionMetersY;
+		acceptedClient.spawnPositionMetersZ = acceptedClient.positionMetersZ;
 
 		UpdateClientInterest(acceptedClient);
 		LOG_INFO(Net, "[ServerApp] Client accepted (client_id={}, entity_id={}, zone_id={}, hp={}, endpoint={}, total_clients={})",
@@ -2859,6 +2874,55 @@ namespace engine::server
 			combatEvent.targetMaxHealth,
 			client->combat.nextAttackTick);
 		BroadcastCombatEvent(combatEvent);
+	}
+
+	void ServerApp::HandleRespawnRequest(const Endpoint& endpoint, uint32_t clientId)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] RespawnRequest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] RespawnRequest ignored: client_id mismatch (expected={}, got={})",
+				client->clientId,
+				clientId);
+			return;
+		}
+
+		if ((client->stateFlags & kEntityStateDead) == 0u)
+		{
+			LOG_WARN(Net, "[ServerApp] RespawnRequest ignored: player is alive (client_id={})", client->clientId);
+			return;
+		}
+
+		// Téléport au point d'entrée en monde, soin complet, retour à la vie.
+		client->positionMetersX = client->spawnPositionMetersX;
+		client->positionMetersY = client->spawnPositionMetersY;
+		client->positionMetersZ = client->spawnPositionMetersZ;
+		client->velocityMetersPerSecondX = 0.0f;
+		client->velocityMetersPerSecondY = 0.0f;
+		client->velocityMetersPerSecondZ = 0.0f;
+		client->stats.currentHealth = client->stats.maxHealth;
+		client->stateFlags &= ~kEntityStateDead;
+		// Sécurité : plus aucune menace résiduelle ne doit pointer sur le ressuscité
+		// (déjà purgée à la mort, mais un mob a pu être spawné entre-temps).
+		PurgeThreatForEntity(client->entityId);
+		UpdateClientInterest(*client);
+		SaveConnectedClient(*client, "respawn");
+		LOG_INFO(Net,
+			"[ServerApp] Player respawned (client_id={}, entity_id={}, pos=({:.1f}, {:.1f}, {:.1f}), hp={}/{})",
+			client->clientId,
+			client->entityId,
+			client->positionMetersX,
+			client->positionMetersY,
+			client->positionMetersZ,
+			client->stats.currentHealth,
+			client->stats.maxHealth);
 	}
 
 	void ServerApp::HandlePickupRequest(const Endpoint& endpoint, uint32_t clientId, EntityId lootBagEntityId)

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -17,6 +17,9 @@
 // Level-up runtime — courbe XP -> niveau (séparée de la boucle réseau, pure et testable).
 #include "src/shardd/gameplay/character/LevelProgression.h"
 
+// Combat SP2 — résolveur d'attaque pur (précision / critique, RNG injecté).
+#include "src/shardd/gameplay/combat/AttackResolver.h"
+
 // TA.4 — pont position : compilé uniquement pour la cible shard Linux (SHARD_POSITION_DB),
 // pas pour le build Windows (ServerApp.cpp est partagé). Macro dédié plutôt qu'ENGINE_HAS_MYSQL
 // pour ne PAS basculer les autres systèmes gameplay du shard en mode DB.
@@ -286,6 +289,7 @@ namespace engine::server
 		, m_questRuntime(m_config)
 		, m_spawnerRuntime(m_config)
 		, m_archetypeLibrary(m_config)
+		, m_combatRng(std::random_device{}())
 	{
 		LOG_INFO(Core, "[ServerApp] Constructed");
 	}
@@ -2753,7 +2757,37 @@ namespace engine::server
 			return;
 		}
 
-		const uint32_t appliedDamage = std::min(client->combat.damagePerHit, target->stats.currentHealth);
+		// Combat SP2 — le cooldown est consommé même sur un raté (le coup est parti).
+		client->combat.nextAttackTick = m_currentTick + client->combat.cooldownTicks;
+		const combat::AttackRollResult roll = combat::ResolveAttackRoll(
+			client->combat.damagePerHit,
+			client->combat.accuracy,
+			client->combat.critRate,
+			client->combat.critMult,
+			NextCombatRoll01(),
+			NextCombatRoll01());
+		uint32_t eventFlags = 0u;
+		if (roll.miss) eventFlags |= kCombatEventFlagMiss;
+		if (roll.crit) eventFlags |= kCombatEventFlagCrit;
+		if (roll.miss)
+		{
+			// Raté : aucun dégât, mais l'événement part quand même (combat log/HUD).
+			CombatEventMessage missEvent{};
+			missEvent.attackerEntityId = client->entityId;
+			missEvent.targetEntityId = target->entityId;
+			missEvent.damage = 0u;
+			missEvent.targetCurrentHealth = target->stats.currentHealth;
+			missEvent.targetMaxHealth = target->stats.maxHealth;
+			missEvent.targetStateFlags = target->stateFlags;
+			missEvent.flags = eventFlags;
+			LOG_INFO(Net, "[ServerApp] Attack missed (attacker_entity_id={}, target_entity_id={})",
+				missEvent.attackerEntityId,
+				missEvent.targetEntityId);
+			BroadcastCombatEvent(missEvent);
+			return;
+		}
+
+		const uint32_t appliedDamage = std::min(roll.damage, target->stats.currentHealth);
 		if (appliedDamage == 0)
 		{
 			LOG_WARN(Net, "[ServerApp] AttackRequest ignored: zero damage after validation (client_id={}, target_entity_id={})",
@@ -2762,7 +2796,6 @@ namespace engine::server
 			return;
 		}
 
-		client->combat.nextAttackTick = m_currentTick + client->combat.cooldownTicks;
 		target->stats.currentHealth -= appliedDamage;
 		if (target->isDynamicEventMob && target->owningEventIndex < m_dynamicEvents.size())
 		{
@@ -2815,6 +2848,8 @@ namespace engine::server
 		combatEvent.targetCurrentHealth = target->stats.currentHealth;
 		combatEvent.targetMaxHealth = target->stats.maxHealth;
 		combatEvent.targetStateFlags = target->stateFlags;
+		// Combat SP2 — bit critique éventuel (le raté est parti plus haut).
+		combatEvent.flags = eventFlags;
 		LOG_INFO(Net,
 			"[ServerApp] Attack applied (attacker_entity_id={}, target_entity_id={}, damage={}, hp={}/{}, next_attack_tick={})",
 			combatEvent.attackerEntityId,
@@ -3448,6 +3483,38 @@ namespace engine::server
 			clearedCount);
 	}
 
+	void ServerApp::PurgeThreatForEntity(EntityId entityId)
+	{
+		size_t purgedMobs = 0;
+		for (MobEntity& mob : m_mobs)
+		{
+			const size_t before = mob.threatTable.size();
+			mob.threatTable.erase(
+				std::remove_if(mob.threatTable.begin(), mob.threatTable.end(),
+					[entityId](const ThreatEntry& entry) { return entry.entityId == entityId; }),
+				mob.threatTable.end());
+			if (mob.aggroTargetEntityId == entityId)
+			{
+				mob.aggroTargetEntityId = 0;
+			}
+			if (mob.threatTable.size() != before)
+			{
+				++purgedMobs;
+			}
+		}
+		if (purgedMobs > 0)
+		{
+			LOG_INFO(Net, "[ServerApp] Threat purged for entity (entity_id={}, mobs={})", entityId, purgedMobs);
+		}
+	}
+
+	float ServerApp::NextCombatRoll01()
+	{
+		// distribution locale (stateless) : [0,1), borne haute exclue.
+		std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
+		return distribution(m_combatRng);
+	}
+
 	bool ServerApp::TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target)
 	{
 		if (m_currentTick < mob.combat.nextAttackTick)
@@ -3466,20 +3533,39 @@ namespace engine::server
 			return false;
 		}
 
-		const uint32_t appliedDamage = std::min(mob.combat.damagePerHit, target.stats.currentHealth);
-		if (appliedDamage == 0)
+		// Combat SP2 — le mob rate/critique aussi (stats d'archétype) ; cooldown
+		// consommé même sur un raté.
+		mob.combat.nextAttackTick = m_currentTick + mob.combat.cooldownTicks;
+		const combat::AttackRollResult roll = combat::ResolveAttackRoll(
+			mob.combat.damagePerHit,
+			mob.combat.accuracy,
+			mob.combat.critRate,
+			mob.combat.critMult,
+			NextCombatRoll01(),
+			NextCombatRoll01());
+		uint32_t eventFlags = 0u;
+		if (roll.miss) eventFlags |= kCombatEventFlagMiss;
+		if (roll.crit) eventFlags |= kCombatEventFlagCrit;
+
+		const uint32_t appliedDamage = roll.miss ? 0u : std::min(roll.damage, target.stats.currentHealth);
+		if (!roll.miss && appliedDamage == 0)
 		{
 			return false;
 		}
 
-		mob.combat.nextAttackTick = m_currentTick + mob.combat.cooldownTicks;
-		target.stats.currentHealth -= appliedDamage;
+		if (appliedDamage > 0)
+		{
+			target.stats.currentHealth -= appliedDamage;
+		}
 		if (target.stats.currentHealth == 0)
 		{
 			target.stateFlags |= kEntityStateDead;
 			LOG_INFO(Net, "[ServerApp] Player died (entity_id={}, attacker_entity_id={})",
 				target.entityId,
 				mob.entityId);
+			// Combat SP2 — un joueur mort sort de toutes les tables de menace ;
+			// les mobs repassent en patrouille au prochain tick d'IA.
+			PurgeThreatForEntity(target.entityId);
 			SaveConnectedClient(target, "player_death");
 		}
 
@@ -3490,6 +3576,7 @@ namespace engine::server
 		combatEvent.targetCurrentHealth = target.stats.currentHealth;
 		combatEvent.targetMaxHealth = target.stats.maxHealth;
 		combatEvent.targetStateFlags = target.stateFlags;
+		combatEvent.flags = eventFlags;
 		LOG_INFO(Net,
 			"[ServerApp] Mob attack applied (attacker_entity_id={}, target_entity_id={}, damage={}, hp={}/{}, next_attack_tick={})",
 			combatEvent.attackerEntityId,

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <mutex>
 #include <optional>
+#include <random>
 #include <string>
 #include <span>
 #include <string_view>
@@ -496,6 +497,17 @@ namespace engine::server
 		/// Clear one mob threat table and active aggro target.
 		void ResetMobThreat(MobEntity& mob);
 
+		/// Combat SP2 — retire une entité de toutes les tables de menace des mobs
+		/// (mort ou respawn du joueur) ; les mobs qui la ciblaient repassent en
+		/// patrouille au prochain tick d'IA.
+		void PurgeThreatForEntity(EntityId entityId);
+
+		/// Combat SP2 — tire un jet uniforme [0,1) sur le RNG combat du serveur.
+		/// Les jets sont consommés par AttackResolver (pur) ; le RNG n'est PAS
+		/// déterministe (seed random_device au boot) — les tests passent par
+		/// ResolveAttackRoll directement.
+		float NextCombatRoll01();
+
 		/// Apply one mob attack against its current target when in range.
 		bool TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target);
 
@@ -873,6 +885,9 @@ namespace engine::server
 		/// Combat SP1 — catalogue d'archétypes de créatures (stats data-driven,
 		/// initialisé par InitSpawners avant le chargement des spawners).
 		CreatureArchetypeLibrary m_archetypeLibrary;
+		/// Combat SP2 — RNG des jets d'attaque (précision/critique), seedé au
+		/// constructeur. Main thread du tick monde uniquement (pas de verrou).
+		std::mt19937 m_combatRng;
 		ZoneTransitionMap m_zoneTransitionMap;
 		TickScheduler m_tickScheduler;
 		UdpTransport m_transport;

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -103,6 +103,12 @@ namespace engine::server
 		/// Phase 3.7.5 — élargi à uint64 pour porter le character_id complet.
 		uint64_t helloNonce = 0;
 		uint64_t persistenceCharacterKey = 0;
+		/// Combat SP2 — position de réapparition (mémorisée en fin d'admission,
+		/// après résolution de la position persistée/DB). Utilisée par
+		/// HandleRespawnRequest ; le « spawn de zone » V1 = point d'entrée en monde.
+		float spawnPositionMetersX = 0.0f;
+		float spawnPositionMetersY = 0.0f;
+		float spawnPositionMetersZ = 0.0f;
 		/// TD.5 — nom du personnage choisi par le joueur (cf. table SQL characters.name).
 		/// Chargé depuis la DB (LoadSpawnFromDb) si le shard a un pool MySQL configuré ;
 		/// sinon (mode no-DB) repris du push master AdmitCharacter via
@@ -466,6 +472,10 @@ namespace engine::server
 
 		/// Validate one attack request, apply damage and broadcast the authoritative event.
 		void HandleAttackRequest(const Endpoint& endpoint, uint32_t clientId, EntityId targetEntityId);
+
+		/// Combat SP2 — réapparition d'un joueur mort : téléport au spawn mémorisé
+		/// à l'admission, PV pleins, flag dead retiré. Ignoré si le joueur est vivant.
+		void HandleRespawnRequest(const Endpoint& endpoint, uint32_t clientId);
 
 		/// Validate one pickup request, update the inventory and despawn the bag.
 		void HandlePickupRequest(const Endpoint& endpoint, uint32_t clientId, EntityId lootBagEntityId);


### PR DESCRIPTION
## Combat SP2 — la boucle de combat joueur↔créature de bout en bout

Suite du chantier combat (SP1 = créatures visibles, #873/#874). Plan : `docs/superpowers/plans/2026-06-11-combat-sp2-attaque-mort.md`. Une seule PR serveur+client (lock-step de toute façon, et les PRs stackées n''ont pas de CI).

### Serveur (shardd)
- **`AttackResolver`** (nouveau, pur) : jets de précision (`accuracy`) et de critique (`critRate` × `critMult`, plancher 1.0) avec les jets [0,1) injectés → 8 tests CTest déterministes (`attack_resolver_tests`).
- **Stats réelles au combat** : les 11 stats calculées (damage, range, accuracy, critRate, critMult) sont injectées dans le `CombatComponent` du joueur à l''enter-world et au level-up — fini le `kDefaultPlayerDamage = 10` codé en dur. Les mobs utilisent les valeurs de leur archétype (SP1).
- **Jets dans les deux sens** : joueur ET mob peuvent rater/critiquer ; un raté consomme le cooldown et émet quand même le `CombatEvent` (flags miss, damage 0) pour le log/HUD.
- **Mort/respawn** : purge de menace à la mort du joueur (les mobs repassent en patrouille) ; `HandleRespawnRequest` (kind 80) — joueur mort uniquement → téléport au point d''entrée en monde mémorisé à l''admission, PV pleins, save.

### Wire v9→v10 (breaking)
`CombatEventMessage.flags` (bit0 crit, bit1 miss ; payload 32→36 o), `EncodeAttackRequest` (manquait côté client), kind `RespawnRequest = 80`. Tests roundtrip étendus (`server_protocol_tests`).

### Client
- **Ciblage** : clic gauche = pick écran-espace du mob vivant le plus proche du curseur (WorldToScreenPx, pas de raycast 3D) ; Tab = cycle par distance ; sélection locale via `UIModelBinding::SetLocalTarget` ; les PV de la cible suivent les snapshots.
- **Attaque** : touche T → `AttackRequest` (throttle local 250 ms, le serveur reste l''autorité). Binds déclarés dans un registre commenté (embryon Lot E de l''audit).
- **HUD combat enfin câblé** (orphelins M16.2/M39.4 de l''audit) : `CombatHudPresenter` + `AdvancedCombatPresenter` branchés sur l''observer UIModel — cadre cible haut-centre (nom via CreatureCatalog + barre PV + état MORT), log combat bas-droite avec libellés critique/raté, panneau combat avancé (touche J : DPS meter + log filtrable Dégâts/Soins/Morts).
- **Écran de mort** : overlay « VOUS ETES MORT » + bouton Réapparaître → `RespawnRequest` ; déplacement bloqué pendant la mort ; l''overlay disparaît au snapshot post-respawn.

### Validation en jeu attendue (post-merge + déploiement)
Cibler le sanglier (clic ou Tab) → cadre cible ; T → dégâts/critiques/ratés dans le log ; le sanglier riposte ; à 0 PV il meurt, loot + XP ; se laisser tuer → écran de mort → Réapparaître au point d''entrée. Vérifier qu''un personnage sans faction/classe (legacy) garde le comportement MVP.

**Déploiement** : ⚠️ **wire-breaking (kProtocolVersion 9→10)** — redéploiement **master + shardd + client en lock-step**. À déployer avec SP1 (v9 n''a jamais été déployé seul).

🤖 Generated with [Claude Code](https://claude.com/claude-code)