### PR TITLE
feat(client): Combat SP3-B - barre d'action, barre de cast, BuffBar (auras)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,6 +674,8 @@ add_library(engine_core
   src/client/gameplay/CompositeWorldCollider.cpp
   src/client/gameplay/ThirdPersonCamera.cpp
   src/client/gameplay/SkillSystem.cpp
+  # Combat SP3 — métadonnées d'affichage des kits de sorts (barre d'action).
+  src/client/gameplay/SpellKitCatalog.cpp
   src/client/gameplay/ClientPrediction.cpp
   src/client/gameplay/StatusEffect.cpp
   src/client/world/WorldModel.cpp

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2190,3 +2190,30 @@ bit1 miss, payload 32→36 o) + kind `RespawnRequest = 80`.
   cadre cible haut-centre, log combat bas-droite, panneau DPS/log filtrable) ; **écran de
   mort** (overlay + bouton Réapparaître → RespawnRequest) ; mouvement bloqué pendant la mort.
 - **Déploiement** : ⚠️ wire-breaking v10 — master + shardd + client en lock-step.
+
+## Combat SP3-A — sorts et auras, volet serveur (2026-06-11)
+
+Kits VALIDÉS : `docs/superpowers/specs/2026-06-11-combat-sp3-kits-starter-proposal.md` ;
+plan : `docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md`. **Wire v10→v11** :
+kinds `CastRequest=81`, `ResourceUpdate=82`, `CastBarUpdate=83`, `AuraUpdate=84` +
+`PlayerStatsMessage.profileId`.
+
+- **Données** : `game/data/gameplay/spells/<profil>.json` × 8 (3 sorts/profil, slots 1-4,
+  coûts en % ressource max, 9 types d''effets). Noms ASCII (police Windlass).
+- **`SpellKitLibrary`** (`src/shardd/gameplay/spell/`) : chargeur strict (kit corrompu =
+  pas de boot), tri par slot, validation par type d''effet ; tests `spell_kit_library_tests`.
+- **Ressource runtime** : `ConnectedClient.currentResource/maxResource` (depuis les stats
+  calculées), régén 5 %/s hors combat / 2 %/s en combat (CombatEvent < 5 s),
+  `ResourceUpdate` throttlé 500 ms (forcé au débit d''un cast).
+- **Cast** : `HandleCastRequest` (profil→kit, cooldown/sort, coût, cible par targetType,
+  portée) ; cast time → `TickActiveCasts` (annulation mort/déplacement > 0,5 m,
+  `CastBarUpdate` start/complete/cancel).
+- **Effets** : DirectDamage (jets SP2 + AoE AreaAroundSelf), DoT/HoT (`ActiveAura`
+  tickées dans Simulate, montants figés à l''application), Buff/Debuff de dégâts
+  (`ApplyAuraDamageModifiers` dans les deux sens), Slow (vitesse mob, plancher 10 %),
+  Taunt (menace ×N + agro forcée), Dérobade (menace −N % partout).
+- **Factorisation** : `ApplyPlayerDamageToMob` partagé auto-attaque/sorts/DoT (PV,
+  événement dynamique, mort/loot/XP, CombatEvent).
+- Persistance des auras : ABANDONNÉE en V1 (toutes ≤ 12 s) — cf. plan Task 7.
+- Reste : SP3-B client (barre d''action 1-4, barre de cast, BuffBar via StatusEffectManager).
+- **Déploiement** : ⚠️ wire v11 — lock-step master + shardd + client (avec SP3-B).

--- a/docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md
+++ b/docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md
@@ -120,12 +120,12 @@ Schéma (valeurs = kits VALIDÉS, recopier depuis la proposition §2) :
 - Encode/Decode + tests roundtrip chacun + rejets tronqués (pattern TestRespawnRequestRoundTrip).
 - `AuraUpdate` broadcast aux clients intéressés (même périmètre que CombatEvent) à chaque apply/refresh/expire ; payload = liste complète des auras de l'entité (idempotent, pas de delta).
 
-### Task 7: Persistance des auras (serveur)
+### Task 7: Persistance des auras (serveur) — ABANDONNÉE en V1 (décision d'exécution)
 
-**Files:** Modify `src/shardd/gameplay/character/CharacterPersistence.{h,cpp}` + ServerApp.cpp.
-
-- `struct PersistedAura { std::string spellId; uint8_t type; float value; float percentMaxHpPerTick; uint32_t remainingMs; uint32_t tickPeriodMs; float tickAmount; }` ; `std::vector<PersistedAura> auras;` dans PersistedCharacterState ; sérialisation dans le format fichier existant (suivre le pattern de `professions`).
-- Save : à chaque `SaveConnectedClient` (remainingMs = expiresAtMs - now). Load : réapplication à l'enter-world (expiresAt = now + remainingMs).
+Toutes les auras des kits validés durent ≤ 12 s : persister un effet de quelques
+secondes à travers un logout/login n'a aucun intérêt joueur et ajouterait un
+format de sérialisation à maintenir. Reportée à l'arrivée de buffs longs
+(heures) — la table `character_auras` (0061) reste réservée à cet usage.
 
 ### Task 8: PR SP3-A
 

--- a/docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md
+++ b/docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md
@@ -1,0 +1,149 @@
+# Combat SP3 — Sorts et auras par profil : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Donner vie aux 8 kits de sorts validés (docs/superpowers/specs/2026-06-11-combat-sp3-kits-starter-proposal.md — VALIDÉ utilisateur, 5/5 points dont coûts en % ressource, régén 5 %/s hors combat / 2 %/s en combat, touches 1-4) : cast serveur-autoritaire, ressource runtime, auras DoT/HoT/buffs répliquées, barre d'action + barre de cast + BuffBar côté client.
+
+**Architecture:** Data-driven de bout en bout : 8 fichiers `game/data/gameplay/spells/<profil>.json` chargés par une `SpellKitLibrary` serveur stricte (pattern CreatureArchetypeLibrary) ET par un `SpellKitCatalog` client tolérant (pattern CreatureCatalog). Le serveur résout le kit du joueur via `CharacterStatsTables::ClassEntry::profile` (existant). Les dégâts des sorts réutilisent le chemin SP2 (`ResolveAttackRoll` + flags crit/miss) avec un multiplicateur ; DoT/HoT/buffs = nouvelles `ActiveAura` tickées dans `Simulate`. Wire v10→v11 : kinds 81 CastRequest, 82 ResourceUpdate, 83 CastBarUpdate, 84 AuraUpdate. La BuffBar client passe par le `StatusEffectManager` existant (src/client/gameplay/StatusEffect.h) → `BuffBarPresenter` (orphelin M31.2, câblé ici).
+
+**Tech Stack:** identique SP1/SP2 (C++20, parseurs JSON locaux, tests CTest CI build-linux, pas de toolchain locale).
+
+**Livraison : 2 PRs séquentielles base main** (pas de stack — CI) : **SP3-A serveur+wire** (Tasks 1-8) puis, après merge, **SP3-B client** (Tasks 9-13). Dépend du merge de SP2 (#876). Déploiement : ⚠️ wire v11, lock-step master+shardd+client.
+
+**Décisions techniques actées** (déviations spec §6 justifiées) :
+- Persistance des auras dans `PersistedCharacterState` (fichier, mécanisme de persistance réel du shard — inventaire/or/quêtes y sont déjà) ; la table `character_auras` (0061) reste réservée à la future synchro master.
+- Les soins ne ratent pas et ne critiquent pas en V1.
+- `inCombat` (régén) = impliqué dans un CombatEvent (attaquant ou cible) depuis < 5 s.
+- Un cast est annulé si le joueur bouge de > 0.5 m ou meurt pendant le cast.
+- Les sorts de dégâts directs utilisent les jets SP2 (précision/critique) ; DoT/HoT tickent sans jets.
+
+---
+
+### Task 1: Données — 8 kits JSON
+
+**Files:** Create `game/data/gameplay/spells/{melee,tank,distance,voleur,healer,sacre,lanceur,pisteur}.json`
+
+Schéma (valeurs = kits VALIDÉS, recopier depuis la proposition §2) :
+
+```json
+{
+  "profile": "melee",
+  "spells": [
+    {
+      "id": "melee_frappe_brutale",
+      "name": "Frappe brutale",
+      "slot": 1,
+      "castTimeMs": 0,
+      "cooldownMs": 6000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.4 } ]
+    },
+    {
+      "id": "melee_entaille",
+      "name": "Entaille",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 10000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.25, "tickPeriodMs": 2000, "durationMs": 8000 } ]
+    },
+    {
+      "id": "melee_cri_de_guerre",
+      "name": "Cri de guerre",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 30000,
+      "resourceCostPercent": 25,
+      "rangeMeters": 0,
+      "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 15, "durationMs": 10000 } ]
+    }
+  ]
+}
+```
+
+- `rangeMeters: 0` = mêlée → le serveur substitue `combat.attackRangeMeters`.
+- `targetType` ∈ `SingleEnemy | SingleAlly | SelfOnly | AreaAroundSelf` (SingleAlly V1 : soi ou membre du groupe à portée ; sans groupe = soi).
+- Types d'effets et champs : `DirectDamage{mult}`, `DamageOverTime{mult,tickPeriodMs,durationMs}`, `DirectHeal{mult}`, `HealOverTime{mult,tickPeriodMs,durationMs}`, `BuffDamagePercent{percent,durationMs}`, `DebuffDamageTakenPercent{percent,durationMs}`, `TauntThreatMult{mult}`, `SlowMobPercent{percent,durationMs}`, `ThreatReducePercent{percent}`.
+- Cas particuliers validés : tank « Second souffle » = HealOverTime mult 0 + `percentMaxHpPerTick: 3` (champ optionnel, soin = % PV max) ; pisteur « Morsure du piège » = 2 effets (DoT + Slow) ; sacre « Imposition des mains » targetType SingleAlly.
+
+### Task 2: `SpellKitLibrary` serveur + tests
+
+**Files:** Create `src/shardd/gameplay/spell/SpellKitLibrary.{h,cpp}` + `SpellKitLibraryTests.cpp` ; Modify `src/CMakeLists.txt` (2 listes sources comme CreatureArchetypeLibrary src/CMakeLists.txt:72/:1148 + `lcdlln_add_simple_test(spell_kit_library_tests …)`).
+
+- Structs : `SpellEffectDef { enum class SpellEffectType {…9 types…}; float mult; float percent; uint32_t tickPeriodMs; uint32_t durationMs; float percentMaxHpPerTick; }` ; `SpellDef { std::string spellId; std::string name; uint32_t slot (1-4); uint32_t castTimeMs; uint32_t cooldownMs; uint32_t resourceCostPercent; float rangeMeters; enum class SpellTargetKind targetType; float areaRadiusMeters; std::vector<SpellEffectDef> effects; }`.
+- API : `Init()` (scan des 8 fichiers `gameplay/spells/*.json`, strict : fichier invalide = échec boot), `LoadFromText` testable, `const std::vector<SpellDef>* FindKit(std::string_view profile)`, `const SpellDef* FindSpell(std::string_view profile, std::string_view spellId)`.
+- Validation : slot ∈ [1,4] unique par kit, cooldownMs > 0 (sauf healer Soin rapide cd 0 autorisé), resourceCostPercent ≤ 100, effets non vides, champs requis par type.
+- Tests (pattern CreatureArchetypeLibraryTests) : kit valide (3 sorts, slots, effets typés), slot dupliqué rejeté, type d'effet inconnu rejeté, percentMaxHpPerTick accepté, multi-effets accepté.
+
+### Task 3: Ressource runtime + régénération (serveur)
+
+**Files:** Modify `src/shared/server_bootstrap/ServerApp.h` (ConnectedClient : `uint32_t currentResource = 0; uint32_t maxResource = 0; uint64_t lastCombatInvolvementMs = 0;`) ; ServerApp.cpp.
+
+- `maxResource = DerivedStats.resource` à l'enter-world et au level-up (dans le bloc `ApplyDerivedCombatStats` étendu ou à côté) ; `currentResource = maxResource` au spawn/level-up/respawn.
+- `BroadcastCombatEvent` : tamponner `lastCombatInvolvementMs` (now) sur l'attaquant et la cible s'ils sont des joueurs.
+- Dans `Simulate()` (ServerApp.cpp:1582 environ, à côté d'UpdateSpawners) : régén par tick = `maxResource × (inCombat ? 0.02 : 0.05) / tickHz` accumulée en float par client (champ `float resourceRegenCarry`), clamp à max. `inCombat` = `nowMs - lastCombatInvolvementMs < 5000`.
+- Wire `ResourceUpdate` (Task 6) poussé quand `currentResource` change de ≥ 1 (au plus 1 par tick de snapshot).
+
+### Task 4: Auras runtime + modificateurs (serveur)
+
+**Files:** Modify ServerApp.h/.cpp.
+
+- `struct ActiveAura { std::string spellId; SpellEffectType type; float value; float percentMaxHpPerTick; uint32_t stacks = 1; uint64_t expiresAtMs; uint64_t nextTickAtMs; uint32_t tickPeriodMs; EntityId casterEntityId; }` ; `std::vector<ActiveAura> auras;` sur ConnectedClient ET MobEntity.
+- Application : refresh si même spellId+caster (durée réinitialisée, pas de stack V1).
+- Tick dans `Simulate()` : DoT → dégâts = `mult × damage du casteur au moment du tick d'application` (snapshot de la valeur dans l'aura : champ `float tickAmount` calculé à l'apply — évite de retrouver le casteur déconnecté) + CombatEvent par tick (attacker = casterEntityId) ; HoT → soin (clamp max) + CombatEvent damage 0 ? NON : les soins n'émettent pas de CombatEvent V1 (le HUD cible suit les PV par snapshot) ; expiration → retrait + AuraUpdate.
+- Modificateurs consommés : dans `HandleAttackRequest`/`TryMobAttackPlayer`/résolution de sort, dégâts finaux × `(1 + ΣBuffDamagePercent(attaquant)/100) × (1 + ΣDebuffDamageTakenPercent(cible)/100)` ; `SlowMobPercent` → `mob.moveSpeedMetersPerSecond` effectif multiplié dans l'IA de déplacement (multiplicateur recalculé au tick, la valeur de base n'est jamais écrasée).
+- Mort (mob ou joueur) → purge des auras de l'entité ; respawn joueur → auras vides.
+
+### Task 5: Pipeline de cast (serveur)
+
+**Files:** Modify ServerApp.h/.cpp.
+
+- ConnectedClient : `std::string activeCastSpellId; uint64_t castFinishAtMs = 0; float castStartPosX/Z; std::unordered_map<std::string, uint64_t> spellCooldownUntilMs;` + `std::string profileId;` (résolu à l'enter-world via `m_statsTables` ClassEntry — accessor à ajouter si absent : `const ClassEntry* FindClass(factionId, classId)`).
+- `HandleCastRequest(endpoint, clientId, spellId)` : vivant, sort ∈ kit du profil, pas de cast en cours, cooldown du sort écoulé, `currentResource ≥ coût` (coût = `resourceCostPercent × maxResource / 100`), cible valide selon targetType (SingleEnemy = cible mob vivante à portée — le client envoie `targetEntityId` dans le message ; SelfOnly/AreaAroundSelf = pas de cible ; SingleAlly = soi ou membre du groupe à portée, fallback soi), portée vérifiée. Instant → `ResolveSpellCast` immédiat ; sinon `activeCast` + CastBarUpdate(start).
+- Dans `Simulate()` : cast en cours → annulation si mort ou déplacement > 0.5 m depuis castStartPos (CastBarUpdate cancel) ; échéance → revalider cible/portée puis `ResolveSpellCast` (CastBarUpdate complete).
+- `ResolveSpellCast` : débit ressource, démarrage cooldown, application des effets (Task 4) ; DirectDamage passe par `ResolveAttackRoll` (base = mult × damage) + modificateurs d'auras + chemin mort/loot/XP de SP2 (réutiliser le bloc existant de HandleAttackRequest — extraire un helper `ApplyDamageToMob(client, mob, rollDamage, eventFlags)` pour DRY) ; AoE = tous les mobs vivants à `areaRadiusMeters` du joueur (boucle m_mobs, même zone).
+
+### Task 6: Wire v10→v11
+
+**Files:** Modify `src/shared/network/ServerProtocol.{h,cpp}` + `ServerProtocolTests.cpp`.
+
+- `kProtocolVersion = 11` (+ historique).
+- Kinds : `CastRequest = 81` {clientId u32, targetEntityId u64 (0 si sans cible), spellId string u16-prefixed}, `ResourceUpdate = 82` {clientId u32, currentResource u32, maxResource u32}, `CastBarUpdate = 83` {clientId u32, status u8 (0 start/1 complete/2 cancel), durationMs u32, spellId string}, `AuraUpdate = 84` {targetEntityId u64, count u8, puis par aura : spellId string, type u8, remainingMs u32, stacks u8}.
+- Encode/Decode + tests roundtrip chacun + rejets tronqués (pattern TestRespawnRequestRoundTrip).
+- `AuraUpdate` broadcast aux clients intéressés (même périmètre que CombatEvent) à chaque apply/refresh/expire ; payload = liste complète des auras de l'entité (idempotent, pas de delta).
+
+### Task 7: Persistance des auras (serveur)
+
+**Files:** Modify `src/shardd/gameplay/character/CharacterPersistence.{h,cpp}` + ServerApp.cpp.
+
+- `struct PersistedAura { std::string spellId; uint8_t type; float value; float percentMaxHpPerTick; uint32_t remainingMs; uint32_t tickPeriodMs; float tickAmount; }` ; `std::vector<PersistedAura> auras;` dans PersistedCharacterState ; sérialisation dans le format fichier existant (suivre le pattern de `professions`).
+- Save : à chaque `SaveConnectedClient` (remainingMs = expiresAtMs - now). Load : réapplication à l'enter-world (expiresAt = now + remainingMs).
+
+### Task 8: PR SP3-A
+
+- CODEBASE_MAP (section SP3-A), commit du plan + de la proposition de kits validée, push `combat-sp3-server`, PR base main, CI. **Déploiement : ⚠️ wire v11 lock-step** (à déployer avec SP3-B ; un shard v11 rejette les clients v10).
+
+### Task 9-13: SP3-B client (PR séparée, après merge SP3-A)
+
+9. **`SpellKitCatalog`** client (pattern CreatureCatalog, tolérant) : charge les 8 JSON, expose le kit d'un profil (le client connaît son profil via la création de perso / factions.json — à défaut, nouveau champ `profileId` dans PlayerStatsMessage ? NON : `resourceKey` y est déjà ; ajouter `profileId` string au PlayerStatsMessage est rétro-additif côté contenu mais change le payload → il est DANS le bump v11 (Task 6) : l'ajouter là).
+10. **UIModel** : `ApplyResourceUpdate` → `playerStats.currentSecondaryResource` (la barre HUD ressource existante, PR #866, l'affiche déjà) ; `ApplyCastBarUpdate` → `UICastBarState {visible, spellName, progress01, durationMs}` ; `ApplyAuraUpdate` → push vers `StatusEffectManager` (membre du binding ou d'Engine) : mapping type wire → `StatusEffectType` client (Buff/Debuff/DoT/HoT/Slow existants).
+11. **Barre d'action** (Engine, section HUD SP2) : 4 slots bas-centre (nom du sort, coût %, sweep cooldown via fg->AddRectFilled proportionnel) ; touches `Digit1..Digit4` (enum Key existant) → `SendCastRequest(clientId, targetEntityId, spellId)` (GameplayUdpClient, pattern SendAttackRequest).
+12. **Barre de cast** : sous le cadre cible, progress = (now - start)/duration, annulation affichée.
+13. **BuffBar** : `BuffBarPresenter` (orphelin M31.2) câblé — `UpdatePlayer(effects du joueur)` / `UpdateTarget(effects de la cible)` chaque frame depuis le StatusEffectManager ; rendu : icônes texte (nom abrégé + timer) sous les barres joueur / sous le cadre cible. PR SP3-B, CI, déploiement lock-step avec SP3-A.
+
+---
+
+## Self-review
+
+- Couverture : 5 décisions utilisateur intégrées (kits §2 verbatim Task 1, coûts % Task 5, exclusions respectées — aucun effet vitesse joueur/stun/combo, régén Task 3, touches 1-4 Task 11).
+- Tous les sorts des 8 kits sont représentables par les 9 SpellEffectDef (vérifié sort par sort, y compris les 2 cas particuliers Second souffle / Morsure du piège).
+- Wire : 4 nouveaux kinds dans la plage libre 81-84 (80 = RespawnRequest SP2) ; profileId ajouté à PlayerStatsMessage dans le même bump v11.
+- DRY : extraction `ApplyDamageToMob` partagée auto-attaque/sorts (Task 5) plutôt que duplication du bloc mort/loot/XP.

--- a/docs/superpowers/specs/2026-06-11-combat-sp3-kits-starter-proposal.md
+++ b/docs/superpowers/specs/2026-06-11-combat-sp3-kits-starter-proposal.md
@@ -1,0 +1,121 @@
+# Combat SP3 — Proposition de kits starter par profil (à valider)
+
+> Statut : **PROPOSITION** soumise à validation utilisateur (décision SP3 :
+> « kits starter par profil, validés avant implémentation »). Rien n'est
+> implémenté tant que ce document n'est pas validé/amendé.
+
+## 1. Principes de conception
+
+- **8 profils** (cf. design système de personnages §6.3) : melee, tank,
+  distance, voleur, healer, sacre, lanceur, pisteur. Chaque **classe** hérite du
+  kit de son profil (déclinaison cosmétique par classe — noms/FX — possible plus
+  tard, la mécanique est par profil).
+- **3 sorts par profil** en V1 : un cœur de rotation (dégât/soin), un effet
+  périodique (DoT/HoT), un utilitaire (buff/debuff/taunt). L'auto-attaque (SP2)
+  reste la base du DPS.
+- **Les dégâts/soins scalent sur la stat `damage`** du personnage (déjà calculée
+  par niveau/classe/race/sexe) via un multiplicateur — aucun nouveau tuning par
+  niveau à maintenir.
+- **Coûts en % de la ressource max** (la ressource secondaire de la classe :
+  ferveur, souffle, corruption…) — scalent automatiquement avec le niveau.
+- **Types d'effets V1** (tous implémentables côté serveur sans nouveau système) :
+  1. `DirectDamage(mult)` — dégâts immédiats = mult × damage (jets précision/crit SP2 réutilisés)
+  2. `DamageOverTime(multPerTick, period, duration)` — aura DoT (Aura::Tick existant)
+  3. `DirectHeal(mult)` — soin immédiat = mult × damage
+  4. `HealOverTime(multPerTick, period, duration)` — aura HoT
+  5. `BuffDamagePercent(+X %, duration)` — buff de dégâts sur soi (multiplicateur attaquant)
+  6. `DebuffDamageTakenPercent(+X %, duration)` — la cible subit +X % de dégâts
+  7. `TauntThreatMult(×N)` — menace instantanée (ThreatList existant)
+  8. `SlowMobPercent(-X %, duration)` — ralentit le `moveSpeed` du mob (serveur-autoritaire)
+- **Exclu V1 (volontairement)** : modification de vitesse du **joueur**
+  (mouvement client-autoritaire — désync), effets positionnels (dans le dos),
+  absorptions/boucliers, CC durs (stun/root), points de combo (les
+  combo_builder/spender de test seront migrés quand le profil voleur passera
+  aux combos — V2).
+
+## 2. Les kits (3 sorts × 8 profils)
+
+Format : **Nom** — effet ; cast ; coût ; cooldown ; portée.
+
+### melee (guerrier, tourmenteur, dragonnier…)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Frappe brutale | DirectDamage ×1.4 | instant | 15 % | 6 s | mêlée |
+| Entaille | DoT ×0.25/2 s pendant 8 s | instant | 20 % | 10 s | mêlée |
+| Cri de guerre | BuffDamagePercent +15 % / 10 s | instant | 25 % | 30 s | soi |
+
+### tank (gardien_ecailles, brise_roc)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Provocation | TauntThreatMult ×3 (menace immédiate) | instant | 10 % | 8 s | 10 m |
+| Coup de bouclier | DirectDamage ×1.0 + SlowMob −30 % / 4 s | instant | 20 % | 12 s | mêlée |
+| Second souffle | HoT 3 % PV max/2 s pendant 10 s | instant | 30 % | 30 s | soi |
+
+### distance (archer, arbaletrier, archer_bois)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Tir visé | DirectDamage ×1.6 | 1.5 s | 20 % | 8 s | 30 m |
+| Flèche barbelée | DoT ×0.3/2 s pendant 8 s | instant | 20 % | 12 s | 30 m |
+| Tir rapide | DirectDamage ×0.8 | instant | 15 % | 3 s | 30 m |
+
+### voleur (assassin, voleur_tenebreux)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Attaque sournoise | DirectDamage ×1.7 | instant | 25 % | 10 s | mêlée |
+| Lame empoisonnée | DoT ×0.35/2 s pendant 10 s | instant | 20 % | 12 s | mêlée |
+| Dérobade | menace −50 % sur tous les mobs engagés | instant | 20 % | 25 s | soi |
+
+### healer (hospitalier, pretre_grace)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Soin rapide | DirectHeal ×2.0 | 1.5 s | 25 % | — | 30 m (allié/soi) |
+| Rémission | HoT ×0.5/2 s pendant 10 s | instant | 25 % | 8 s | 30 m (allié/soi) |
+| Châtiment | DirectDamage ×1.0 | 1.5 s | 15 % | 4 s | 30 m |
+
+### sacre (paladin)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Marteau sacré | DirectDamage ×1.3 | instant | 15 % | 6 s | mêlée |
+| Imposition des mains | DirectHeal ×3.0 | instant | 40 % | 60 s | soi/allié 10 m |
+| Aura de zèle | BuffDamagePercent +10 % / 12 s | instant | 20 % | 24 s | soi |
+
+### lanceur (mage, archimage, demoniste, chaman, menthats…)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Trait de feu | DirectDamage ×1.6 | 1.5 s | 20 % | 4 s | 30 m |
+| Brûlure | DoT ×0.35/2 s pendant 8 s | instant | 20 % | 10 s | 30 m |
+| Nova | DirectDamage ×0.9 en zone (AreaAroundSelf 8 m) | instant | 30 % | 15 s | soi (AoE) |
+
+### pisteur (pisteur orc/nain)
+| Sort | Effet | Cast | Coût | CD | Portée |
+|---|---|---|---|---|---|
+| Tir de chasse | DirectDamage ×1.5 | 1.5 s | 20 % | 8 s | 30 m |
+| Marque du chasseur | DebuffDamageTaken +15 % / 10 s | instant | 15 % | 12 s | 30 m |
+| Morsure du piège | DoT ×0.3/2 s pendant 8 s + SlowMob −20 % / 4 s | instant | 25 % | 15 s | 25 m |
+
+## 3. Ce que SP3 devra livrer techniquement (rappel spec §6, affiné)
+
+- **Données** : `game/data/gameplay/spells/<profil>.json` (schéma calé sur
+  `SpellTemplate` + extensions : `resourceCostPercent`, `effects[]` typés
+  ci-dessus, `healMult`/`damageMult`). Le serveur charge dans `SpellMgr`
+  (existant) ; le client charge le même fichier pour la barre d'action
+  (nom/coût/cd/icône).
+- **Serveur** : pipeline de cast par joueur (cast time, interruption au
+  mouvement, coût en ressource — la ressource courante devient une valeur
+  runtime serveur, aujourd'hui seule la max est calculée + régénération simple
+  % / s à définir) ; application des effets ; auras répliquées (apply/remove)
+  → `BuffBarPresenter` ; persistance `character_auras` (0061).
+- **Wire** : kind CastRequest (sortId), CastResult/CastBar, AuraUpdate —
+  bump v10→v11.
+- **Client** : barre d'action (touches 1-4), barre de cast, BuffBar câblée.
+- **Question ouverte n°4 (régén)** : proposition — régénération de ressource
+  5 %/s hors combat, 2 %/s en combat (modifiable par data ensuite).
+
+## 4. Questions à valider
+
+1. Les **8 kits** ci-dessus (noms, effets, valeurs) — amendements bienvenus,
+   les valeurs sont des points de départ d'équilibrage, modifiables en data.
+2. **Coûts en % de la ressource max** : OK ?
+3. **Exclusions V1** (pas de vitesse joueur, pas de stun/root, combos différés) : OK ?
+4. **Régénération de ressource** : 5 %/s hors combat / 2 %/s en combat ?
+5. **Touches** : sorts sur **1-4** (la barre d'action affiche le kit du profil) ?

--- a/game/data/gameplay/spells/distance.json
+++ b/game/data/gameplay/spells/distance.json
@@ -1,0 +1,41 @@
+{
+  "profile": "distance",
+  "spells": [
+    {
+      "id": "distance_tir_vise",
+      "name": "Tir vise",
+      "slot": 1,
+      "castTimeMs": 1500,
+      "cooldownMs": 8000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.6 } ]
+    },
+    {
+      "id": "distance_fleche_barbelee",
+      "name": "Fleche barbelee",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 12000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.3, "tickPeriodMs": 2000, "durationMs": 8000 } ]
+    },
+    {
+      "id": "distance_tir_rapide",
+      "name": "Tir rapide",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 3000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 0.8 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/healer.json
+++ b/game/data/gameplay/spells/healer.json
@@ -1,0 +1,41 @@
+{
+  "profile": "healer",
+  "spells": [
+    {
+      "id": "healer_soin_rapide",
+      "name": "Soin rapide",
+      "slot": 1,
+      "castTimeMs": 1500,
+      "cooldownMs": 0,
+      "resourceCostPercent": 25,
+      "rangeMeters": 30,
+      "targetType": "SingleAlly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectHeal", "mult": 2.0 } ]
+    },
+    {
+      "id": "healer_remission",
+      "name": "Remission",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 8000,
+      "resourceCostPercent": 25,
+      "rangeMeters": 30,
+      "targetType": "SingleAlly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "HealOverTime", "mult": 0.5, "tickPeriodMs": 2000, "durationMs": 10000 } ]
+    },
+    {
+      "id": "healer_chatiment",
+      "name": "Chatiment",
+      "slot": 3,
+      "castTimeMs": 1500,
+      "cooldownMs": 4000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.0 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/lanceur.json
+++ b/game/data/gameplay/spells/lanceur.json
@@ -1,0 +1,41 @@
+{
+  "profile": "lanceur",
+  "spells": [
+    {
+      "id": "lanceur_trait_de_feu",
+      "name": "Trait de feu",
+      "slot": 1,
+      "castTimeMs": 1500,
+      "cooldownMs": 4000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.6 } ]
+    },
+    {
+      "id": "lanceur_brulure",
+      "name": "Brulure",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 10000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.35, "tickPeriodMs": 2000, "durationMs": 8000 } ]
+    },
+    {
+      "id": "lanceur_nova",
+      "name": "Nova",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 15000,
+      "resourceCostPercent": 30,
+      "rangeMeters": 0,
+      "targetType": "AreaAroundSelf",
+      "areaRadiusMeters": 8,
+      "effects": [ { "type": "DirectDamage", "mult": 0.9 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/melee.json
+++ b/game/data/gameplay/spells/melee.json
@@ -1,0 +1,41 @@
+{
+  "profile": "melee",
+  "spells": [
+    {
+      "id": "melee_frappe_brutale",
+      "name": "Frappe brutale",
+      "slot": 1,
+      "castTimeMs": 0,
+      "cooldownMs": 6000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.4 } ]
+    },
+    {
+      "id": "melee_entaille",
+      "name": "Entaille",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 10000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.25, "tickPeriodMs": 2000, "durationMs": 8000 } ]
+    },
+    {
+      "id": "melee_cri_de_guerre",
+      "name": "Cri de guerre",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 30000,
+      "resourceCostPercent": 25,
+      "rangeMeters": 0,
+      "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 15, "durationMs": 10000 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/pisteur.json
+++ b/game/data/gameplay/spells/pisteur.json
@@ -1,0 +1,44 @@
+{
+  "profile": "pisteur",
+  "spells": [
+    {
+      "id": "pisteur_tir_de_chasse",
+      "name": "Tir de chasse",
+      "slot": 1,
+      "castTimeMs": 1500,
+      "cooldownMs": 8000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.5 } ]
+    },
+    {
+      "id": "pisteur_marque_du_chasseur",
+      "name": "Marque du chasseur",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 12000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 30,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DebuffDamageTakenPercent", "percent": 15, "durationMs": 10000 } ]
+    },
+    {
+      "id": "pisteur_morsure_du_piege",
+      "name": "Morsure du piege",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 15000,
+      "resourceCostPercent": 25,
+      "rangeMeters": 25,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [
+        { "type": "DamageOverTime", "mult": 0.3, "tickPeriodMs": 2000, "durationMs": 8000 },
+        { "type": "SlowMobPercent", "percent": 20, "durationMs": 4000 }
+      ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/sacre.json
+++ b/game/data/gameplay/spells/sacre.json
@@ -1,0 +1,41 @@
+{
+  "profile": "sacre",
+  "spells": [
+    {
+      "id": "sacre_marteau_sacre",
+      "name": "Marteau sacre",
+      "slot": 1,
+      "castTimeMs": 0,
+      "cooldownMs": 6000,
+      "resourceCostPercent": 15,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.3 } ]
+    },
+    {
+      "id": "sacre_imposition_des_mains",
+      "name": "Imposition des mains",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 60000,
+      "resourceCostPercent": 40,
+      "rangeMeters": 10,
+      "targetType": "SingleAlly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectHeal", "mult": 3.0 } ]
+    },
+    {
+      "id": "sacre_aura_de_zele",
+      "name": "Aura de zele",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 24000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 10, "durationMs": 12000 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/tank.json
+++ b/game/data/gameplay/spells/tank.json
@@ -1,0 +1,44 @@
+{
+  "profile": "tank",
+  "spells": [
+    {
+      "id": "tank_provocation",
+      "name": "Provocation",
+      "slot": 1,
+      "castTimeMs": 0,
+      "cooldownMs": 8000,
+      "resourceCostPercent": 10,
+      "rangeMeters": 10,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "TauntThreatMult", "mult": 3.0 } ]
+    },
+    {
+      "id": "tank_coup_de_bouclier",
+      "name": "Coup de bouclier",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 12000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [
+        { "type": "DirectDamage", "mult": 1.0 },
+        { "type": "SlowMobPercent", "percent": 30, "durationMs": 4000 }
+      ]
+    },
+    {
+      "id": "tank_second_souffle",
+      "name": "Second souffle",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 30000,
+      "resourceCostPercent": 30,
+      "rangeMeters": 0,
+      "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "HealOverTime", "mult": 0, "percentMaxHpPerTick": 3, "tickPeriodMs": 2000, "durationMs": 10000 } ]
+    }
+  ]
+}

--- a/game/data/gameplay/spells/voleur.json
+++ b/game/data/gameplay/spells/voleur.json
@@ -1,0 +1,41 @@
+{
+  "profile": "voleur",
+  "spells": [
+    {
+      "id": "voleur_attaque_sournoise",
+      "name": "Attaque sournoise",
+      "slot": 1,
+      "castTimeMs": 0,
+      "cooldownMs": 10000,
+      "resourceCostPercent": 25,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.7 } ]
+    },
+    {
+      "id": "voleur_lame_empoisonnee",
+      "name": "Lame empoisonnee",
+      "slot": 2,
+      "castTimeMs": 0,
+      "cooldownMs": 12000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.35, "tickPeriodMs": 2000, "durationMs": 10000 } ]
+    },
+    {
+      "id": "voleur_derobade",
+      "name": "Derobade",
+      "slot": 3,
+      "castTimeMs": 0,
+      "cooldownMs": 25000,
+      "resourceCostPercent": 20,
+      "rangeMeters": 0,
+      "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "ThreatReducePercent", "percent": 50 } ]
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,8 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spawner/SpawnerRuntime.cpp
     # Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
+    # Combat SP3 — kits de sorts par profil (data-driven).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spell/SpellKitLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/event/EventRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/TickScheduler.cpp
@@ -536,6 +538,11 @@ elseif(UNIX)
   # Combat SP2 : résolveur d'attaque pur (précision / critique, header-only).
   lcdlln_add_simple_test(attack_resolver_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/combat/AttackResolverTests.cpp)
+
+  # Combat SP3 : kits de sorts par profil (parse + validation JSON).
+  lcdlln_add_simple_test(spell_kit_library_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spell/SpellKitLibraryTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spell/SpellKitLibrary.cpp)
 
   # TA.3 (replication des joueurs) : registre des personnages admis (gate de la
   # session UDP, lié au character_id authentifié du ticket). Pure logique testable.
@@ -1155,6 +1162,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spawner/SpawnerRuntime.cpp
     # Combat SP1 — catalogue d'archétypes de créatures (stats data-driven).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/creature/CreatureArchetypeLibrary.cpp
+    # Combat SP3 — kits de sorts par profil (data-driven).
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/spell/SpellKitLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/event/EventRuntime.cpp
     # TA.4 : accès MySQL pour le pont position (lecture characters.spawn_x/y/z).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -81,6 +81,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <list>
 #include <filesystem>
 #include <optional>
 #include <span>
@@ -4981,6 +4982,9 @@ namespace engine
 													// Combat SP1 — catalogue d'apparences de creatures (non bloquant :
 													// catalogue absent/corrompu = mobs rendus en fallback humains).
 													m_creatureCatalog.Init(m_cfg);
+													// Combat SP3 — catalogue d'affichage des kits de sorts (non
+													// bloquant : absent = barre d'action masquée).
+													m_spellCatalog.Init(m_cfg);
 
 													// Pointe m_currentSkinnedMesh vers le mesh humain par defaut (le
 													// perso n'est pas encore "in world" avant EnterWorld, mais Engine
@@ -10458,6 +10462,203 @@ namespace engine
 						ImGui::End();
 					}
 
+					// --- Combat SP3 : barre d'action (touches 1-4, sorts du profil).
+					// Cooldowns affichés localement (cosmétique) ; le serveur revalide
+					// kit/cooldown/coût/cible/portée à chaque CastRequest.
+					const std::vector<engine::client::SpellDisplay>* actionKit =
+						uiModel.playerStats.profileId.empty()
+							? nullptr
+							: m_spellCatalog.FindKit(uiModel.playerStats.profileId);
+					if (actionKit != nullptr && !actionKit->empty())
+					{
+						const float nowSec = EngineNowSec();
+						const float slotSize = 58.0f;
+						const float slotGap = 8.0f;
+						const size_t slotCount = std::min<size_t>(actionKit->size(), 4u);
+						const float barWidth = slotSize * static_cast<float>(slotCount)
+							+ slotGap * static_cast<float>(slotCount - 1);
+						const float barX = (dw - barWidth) * 0.5f;
+						const float barY = dh - slotSize - 16.0f;
+						for (size_t slotIndex = 0; slotIndex < slotCount; ++slotIndex)
+						{
+							const engine::client::SpellDisplay& spell = (*actionKit)[slotIndex];
+							const float sx0 = barX + static_cast<float>(slotIndex) * (slotSize + slotGap);
+							// Coût payable + cooldown : visuel grisé si indisponible.
+							const uint32_t cost = spell.resourceCostPercent
+								* uiModel.playerStats.secondaryResourceMax / 100u;
+							const bool affordable = uiModel.playerStats.secondaryResourceCurrent >= cost;
+							const auto cooldownIt = m_spellCooldownUiUntilSec.find(spell.spellId);
+							const float cooldownRemaining = (cooldownIt != m_spellCooldownUiUntilSec.end())
+								? std::max(0.0f, cooldownIt->second - nowSec)
+								: 0.0f;
+							const bool ready = affordable && cooldownRemaining <= 0.0f;
+							fg->AddRectFilled(ImVec2(sx0, barY), ImVec2(sx0 + slotSize, barY + slotSize),
+								IM_COL32(14, 16, 22, 215), 6.0f);
+							fg->AddRect(ImVec2(sx0, barY), ImVec2(sx0 + slotSize, barY + slotSize),
+								ready ? IM_COL32(200, 180, 90, 220) : IM_COL32(90, 90, 96, 200), 6.0f, 0, 2.0f);
+							// Numéro de touche (haut-gauche) + nom du sort (bas, tronqué).
+							const std::string keyLabel = std::to_string(slotIndex + 1);
+							fg->AddText(ImVec2(sx0 + 4.0f, barY + 2.0f), IM_COL32(255, 230, 150, 230), keyLabel.c_str());
+							std::string spellLabel = spell.name.substr(0, 9);
+							fg->AddText(ImVec2(sx0 + 4.0f, barY + slotSize - 18.0f),
+								ready ? IM_COL32(225, 225, 225, 255) : IM_COL32(140, 140, 140, 255),
+								spellLabel.c_str());
+							// Voile + décompte pendant le cooldown affiché.
+							if (cooldownRemaining > 0.0f)
+							{
+								const float fillFraction = (spell.cooldownMs > 0u)
+									? std::clamp(cooldownRemaining / (static_cast<float>(spell.cooldownMs) / 1000.0f), 0.0f, 1.0f)
+									: 0.0f;
+								fg->AddRectFilled(
+									ImVec2(sx0, barY + slotSize * (1.0f - fillFraction)),
+									ImVec2(sx0 + slotSize, barY + slotSize),
+									IM_COL32(0, 0, 0, 150), 6.0f);
+								char cooldownText[16];
+								std::snprintf(cooldownText, sizeof(cooldownText), "%.0f", cooldownRemaining);
+								const ImVec2 cdTs = ImGui::CalcTextSize(cooldownText);
+								fg->AddText(ImVec2(sx0 + (slotSize - cdTs.x) * 0.5f, barY + (slotSize - cdTs.y) * 0.5f),
+									IM_COL32(255, 255, 255, 255), cooldownText);
+							}
+							// Touche 1-4 : envoi du CastRequest (Digit1..Digit4 = '1'..'4').
+							if (keysAllowed
+								&& m_input.WasPressed(static_cast<engine::platform::Key>('1' + static_cast<int>(slotIndex))))
+							{
+								const bool targetOk = !spell.needsEnemyTarget
+									|| (uiModel.targetStats.hasTarget
+										&& (uiModel.targetStats.stateFlags & 1u) == 0u);
+								const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
+								if (targetOk && ready && gameplayClientId != 0u)
+								{
+									const uint64_t castTarget = spell.needsEnemyTarget
+										? uiModel.targetStats.entityId
+										: 0ull;
+									(void)m_gameplayUdp.SendCastRequest(gameplayClientId, castTarget, spell.spellId);
+									if (spell.cooldownMs > 0u)
+									{
+										m_spellCooldownUiUntilSec[spell.spellId] =
+											nowSec + static_cast<float>(spell.cooldownMs) / 1000.0f;
+									}
+								}
+							}
+						}
+
+						// --- Barre de cast (au-dessus de la barre d'action) pilotée
+						// par CastBarUpdate ; progression calculée localement.
+						if (uiModel.castBar.active && uiModel.castBar.durationMs > 0u)
+						{
+							const uint64_t nowNs = static_cast<uint64_t>(
+								std::chrono::duration_cast<std::chrono::nanoseconds>(
+									std::chrono::steady_clock::now().time_since_epoch()).count());
+							const float elapsedSec = static_cast<float>(nowNs - uiModel.castBar.startedAtNs) / 1.0e9f;
+							const float durationSec = static_cast<float>(uiModel.castBar.durationMs) / 1000.0f;
+							const float progress = std::clamp(elapsedSec / durationSec, 0.0f, 1.0f);
+							const float castBarWidth = 260.0f;
+							const float castBarHeight = 18.0f;
+							const float cbx = (dw - castBarWidth) * 0.5f;
+							const float cby = barY - castBarHeight - 10.0f;
+							fg->AddRectFilled(ImVec2(cbx, cby), ImVec2(cbx + castBarWidth, cby + castBarHeight),
+								IM_COL32(20, 22, 28, 220), 4.0f);
+							fg->AddRectFilled(ImVec2(cbx, cby), ImVec2(cbx + castBarWidth * progress, cby + castBarHeight),
+								IM_COL32(120, 170, 230, 230), 4.0f);
+							const std::string castLabel = m_spellCatalog.ResolveSpellName(uiModel.castBar.spellId);
+							const ImVec2 castTs = ImGui::CalcTextSize(castLabel.c_str());
+							fg->AddText(ImVec2(cbx + (castBarWidth - castTs.x) * 0.5f, cby + 1.0f),
+								IM_COL32(255, 255, 255, 255), castLabel.c_str());
+						}
+					}
+
+					// --- Combat SP3 : BuffBar (M31.2 enfin câblée) — auras du joueur
+					// (au-dessus de la barre d'action) et de la cible (sous le cadre).
+					{
+						const uint64_t nowNs = static_cast<uint64_t>(
+							std::chrono::duration_cast<std::chrono::nanoseconds>(
+								std::chrono::steady_clock::now().time_since_epoch()).count());
+						// Construit la liste StatusEffect d'une entité depuis le modèle
+						// (les timers décrémentent localement entre deux AuraUpdate).
+						auto buildEffects = [&uiModel, nowNs](engine::server::EntityId entityId,
+							std::list<engine::gameplay::StatusEffect>& outEffects)
+						{
+							const auto auraIt = uiModel.entityAuras.find(entityId);
+							if (auraIt == uiModel.entityAuras.end())
+							{
+								return;
+							}
+							for (const engine::client::UIAuraEntry& aura : auraIt->second)
+							{
+								engine::gameplay::StatusEffect effect{};
+								effect.effectId = aura.spellId;
+								effect.targetId = entityId;
+								effect.stacks = aura.stacks;
+								// Mapping wire (SpellEffectType serveur) → type client.
+								switch (aura.effectType)
+								{
+								case 1u: effect.type = engine::gameplay::StatusEffectType::DoT; break;
+								case 3u: effect.type = engine::gameplay::StatusEffectType::HoT; break;
+								case 5u: effect.type = engine::gameplay::StatusEffectType::Debuff; break;
+								case 7u: effect.type = engine::gameplay::StatusEffectType::Slow; break;
+								default: effect.type = engine::gameplay::StatusEffectType::Buff; break;
+								}
+								effect.startTimeNs = aura.receivedAtNs;
+								effect.durationSeconds = static_cast<float>(aura.remainingMs) / 1000.0f;
+								effect.expireTimeNs = aura.receivedAtNs
+									+ static_cast<uint64_t>(aura.remainingMs) * 1000000ull;
+								outEffects.push_back(std::move(effect));
+							}
+						};
+						std::list<engine::gameplay::StatusEffect> playerEffects;
+						buildEffects(static_cast<engine::server::EntityId>(uiModel.playerStats.playerEntityId), playerEffects);
+						m_buffBar.UpdatePlayer(playerEffects.empty() ? nullptr : &playerEffects, nowNs);
+						std::list<engine::gameplay::StatusEffect> targetEffects;
+						if (uiModel.targetStats.hasTarget)
+						{
+							buildEffects(uiModel.targetStats.entityId, targetEffects);
+						}
+						m_buffBar.UpdateTarget(targetEffects.empty() ? nullptr : &targetEffects, nowNs);
+
+						// Rendu en pastilles texte (icônes graphiques = chantier atlas).
+						auto drawBar = [this, fg](const engine::client::BuffBarWidget& bar, float x, float y, bool harmful)
+						{
+							if (!bar.visible)
+							{
+								return;
+							}
+							float cursorX = x;
+							for (const engine::client::BuffIconWidget& icon : bar.icons)
+							{
+								if (!icon.visible)
+								{
+									continue;
+								}
+								std::string chip = m_spellCatalog.ResolveSpellName(icon.effectId);
+								if (!icon.isPermanent && icon.remainingSeconds > 0.0f)
+								{
+									char timerText[16];
+									std::snprintf(timerText, sizeof(timerText), " %.0fs", icon.remainingSeconds);
+									chip += timerText;
+								}
+								if (icon.stacks > 1u)
+								{
+									chip += " x" + std::to_string(icon.stacks);
+								}
+								const ImVec2 chipTs = ImGui::CalcTextSize(chip.c_str());
+								fg->AddRectFilled(ImVec2(cursorX, y), ImVec2(cursorX + chipTs.x + 10.0f, y + chipTs.y + 6.0f),
+									harmful ? IM_COL32(70, 20, 20, 210) : IM_COL32(20, 50, 25, 210), 4.0f);
+								fg->AddText(ImVec2(cursorX + 5.0f, y + 3.0f), IM_COL32(230, 230, 230, 255), chip.c_str());
+								cursorX += chipTs.x + 16.0f;
+							}
+						};
+						const engine::client::BuffBarState& playerBuffState = m_buffBar.GetPlayerState();
+						drawBar(playerBuffState.buffBar, 18.0f, dh - 120.0f, false);
+						drawBar(playerBuffState.debuffBar, 18.0f, dh - 92.0f, true);
+						if (uiModel.targetStats.hasTarget)
+						{
+							const engine::client::BuffBarState& targetBuffState = m_buffBar.GetTargetState();
+							// Sous le cadre cible (haut-centre, cf. bloc SP2 : fy 56 + 54).
+							drawBar(targetBuffState.buffBar, (dw - 260.0f) * 0.5f, 118.0f, false);
+							drawBar(targetBuffState.debuffBar, (dw - 260.0f) * 0.5f, 144.0f, true);
+						}
+					}
+
 					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →
 					// RespawnRequest (le serveur ne l'honore que si le flag dead est pose ;
 					// l'overlay disparait quand le snapshot post-respawn retire le flag).
@@ -12400,6 +12601,11 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] AdvancedCombatPresenter Init FAILED — panneau combat désactivé");
 		}
+		// Combat SP3 — BuffBar (auras du joueur / de la cible).
+		if (!m_buffBar.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] BuffBarPresenter Init FAILED — BuffBar désactivée");
+		}
 
 		const uint32_t vw = static_cast<uint32_t>(std::max(1, m_width));
 		const uint32_t vh = static_cast<uint32_t>(std::max(1, m_height));
@@ -12419,6 +12625,11 @@ namespace engine
 		if (!m_combatHud.SetViewportSize(vw, vh))
 		{
 			LOG_WARN(Core, "[GameplayNet] CombatHudPresenter viewport FAILED — using fallback layout");
+		}
+		// Combat SP3 — layout pixel de la BuffBar.
+		if (!m_buffBar.SetViewportSize(vw, vh))
+		{
+			LOG_WARN(Core, "[GameplayNet] BuffBarPresenter viewport FAILED — using fallback layout");
 		}
 
 		m_uiObserverHandle = m_uiModelBinding.AddObserver(
@@ -12497,7 +12708,9 @@ namespace engine
 			m_uiObserverHandle = 0;
 		}
 
-		// Combat SP2 — symétrie d'Init (présentateurs combat).
+		// Combat SP2/SP3 — symétrie d'Init (présentateurs combat + BuffBar).
+		m_buffBar.Shutdown();
+		m_spellCooldownUiUntilSec.clear();
 		m_advancedCombat.Shutdown();
 		m_combatHud.Shutdown();
 		m_advancedCombatVisible = false;

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -30,6 +30,9 @@
 // Combat SP2 — présentateurs combat câblés (HUD cible/log + panneau avancé).
 #include "src/client/combat/CombatHud.h"
 #include "src/client/combat/AdvancedCombatUi.h"
+// Combat SP3 — barre d'action (kits de sorts) + BuffBar (auras répliquées).
+#include "src/client/combat/BuffBarPresenter.h"
+#include "src/client/gameplay/SpellKitCatalog.h"
 #include "src/client/debug/ProfilerHud.h"
 #include "src/client/economy/ShopUi.h"
 #include "src/client/ui_common/UIModel.h"
@@ -1268,6 +1271,14 @@ namespace engine
 		// ---------------------------------------------------------------------
 		engine::client::CombatHudPresenter m_combatHud{};
 		engine::client::AdvancedCombatPresenter m_advancedCombat{};
+		/// Combat SP3 — binds : touches 1-4 = sorts du kit du profil (slots 1-4).
+		/// Catalogue d'affichage des sorts (même JSON que le serveur, tolérant).
+		engine::client::SpellKitCatalog m_spellCatalog{};
+		/// Combat SP3 — BuffBar (M31.2) : auras du joueur et de la cible.
+		engine::client::BuffBarPresenter m_buffBar{};
+		/// Combat SP3 — cooldowns AFFICHÉS de la barre d'action (spellId → fin en
+		/// secondes EngineNowSec) ; purement cosmétique, le serveur fait foi.
+		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;
 		/// Combat SP2 — visibilité du panneau combat avancé (touche J).
 		bool m_advancedCombatVisible = false;
 		/// Combat SP2 — throttle local d'envoi d'AttackRequest (le serveur reste

--- a/src/client/gameplay/SpellKitCatalog.cpp
+++ b/src/client/gameplay/SpellKitCatalog.cpp
@@ -1,0 +1,526 @@
+#include "src/client/gameplay/SpellKitCatalog.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+
+namespace engine::client
+{
+	namespace
+	{
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		/// Parseur JSON minimal local au catalogue — convention du repo
+		/// (SpawnerRuntime/CreatureCatalog) : parseur par module, zéro dépendance.
+		class JsonParser final
+		{
+		public:
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			/// Parse le document complet ; rejette tout caractère résiduel.
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+
+				return true;
+			}
+
+		private:
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+
+				++m_pos;
+				return true;
+			}
+
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+
+				switch (m_input[m_pos])
+				{
+				case '{':
+					return ParseObject(outValue, outError);
+				case '[':
+					return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default:
+					break;
+				}
+
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+
+				return ParseNumber(outValue, outError);
+			}
+
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"': outValue.push_back('"'); break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/': outValue.push_back('/'); break;
+					case 'b': outValue.push_back('\b'); break;
+					case 'f': outValue.push_back('\f'); break;
+					case 'n': outValue.push_back('\n'); break;
+					case 'r': outValue.push_back('\r'); break;
+					case 't': outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+
+				outError = "unterminated string";
+				return false;
+			}
+
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Retourne un membre d'objet, ou nullptr si la clé est absente.
+		const JsonValue* FindObjectMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+
+			const auto it = object.objectValue.find(std::string(key));
+			if (it == object.objectValue.end())
+			{
+				return nullptr;
+			}
+
+			return &it->second;
+		}
+
+		/// Convertit un nombre JSON en uint32 validé (entier, borné, fini).
+		bool TryGetUint(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+	}
+
+	bool SpellKitCatalog::Init(const engine::core::Config& config)
+	{
+		const std::filesystem::path spellsDirectory =
+			engine::platform::FileSystem::ResolveContentPath(config, "gameplay/spells");
+		const std::vector<std::filesystem::path> entries =
+			engine::platform::FileSystem::ListDirectory(spellsDirectory);
+		if (entries.empty())
+		{
+			LOG_WARN(Core, "[SpellKitCatalog] Init skipped: no spell kit files ({}) — barre d'action masquée",
+				spellsDirectory.string());
+			return false;
+		}
+
+		size_t loadedCount = 0;
+		for (const std::filesystem::path& entry : entries)
+		{
+			if (entry.extension() != ".json")
+			{
+				continue;
+			}
+
+			const std::string relativePath = "gameplay/spells/" + entry.filename().string();
+			const std::string jsonText = engine::platform::FileSystem::ReadAllTextContent(config, relativePath);
+			if (jsonText.empty())
+			{
+				LOG_WARN(Core, "[SpellKitCatalog] Kit skipped: empty or unreadable ({})", relativePath);
+				continue;
+			}
+
+			std::string loadError;
+			if (!LoadKitFromText(jsonText, loadError))
+			{
+				LOG_WARN(Core, "[SpellKitCatalog] Kit skipped: {} ({})", loadError, relativePath);
+				continue;
+			}
+			++loadedCount;
+		}
+
+		LOG_INFO(Core, "[SpellKitCatalog] Init OK (kits={})", loadedCount);
+		return loadedCount > 0;
+	}
+
+	const std::vector<SpellDisplay>* SpellKitCatalog::FindKit(std::string_view profile) const
+	{
+		const auto it = m_kits.find(std::string(profile));
+		if (it == m_kits.end())
+		{
+			return nullptr;
+		}
+
+		return &it->second;
+	}
+
+	std::string SpellKitCatalog::ResolveSpellName(std::string_view spellId) const
+	{
+		for (const auto& [profile, kit] : m_kits)
+		{
+			for (const SpellDisplay& spell : kit)
+			{
+				if (spell.spellId == spellId)
+				{
+					return spell.name;
+				}
+			}
+		}
+
+		return std::string(spellId);
+	}
+
+	bool SpellKitCatalog::LoadKitFromText(std::string_view jsonText, std::string& outError)
+	{
+		JsonValue root;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, outError))
+		{
+			return false;
+		}
+
+		const JsonValue* profileValue = FindObjectMember(root, "profile");
+		if (profileValue == nullptr || profileValue->type != JsonType::String || profileValue->stringValue.empty())
+		{
+			outError = "root.profile must be a non-empty string";
+			return false;
+		}
+
+		const JsonValue* spellsValue = FindObjectMember(root, "spells");
+		if (spellsValue == nullptr || spellsValue->type != JsonType::Array || spellsValue->arrayValue.empty())
+		{
+			outError = "root.spells must be a non-empty array";
+			return false;
+		}
+
+		std::vector<SpellDisplay> kit;
+		for (size_t index = 0; index < spellsValue->arrayValue.size(); ++index)
+		{
+			const JsonValue& entry = spellsValue->arrayValue[index];
+			if (entry.type != JsonType::Object)
+			{
+				outError = "spells[" + std::to_string(index) + "] must be an object";
+				return false;
+			}
+
+			SpellDisplay spell{};
+			const JsonValue* idValue = FindObjectMember(entry, "id");
+			const JsonValue* nameValue = FindObjectMember(entry, "name");
+			const JsonValue* slotValue = FindObjectMember(entry, "slot");
+			const JsonValue* castValue = FindObjectMember(entry, "castTimeMs");
+			const JsonValue* cooldownValue = FindObjectMember(entry, "cooldownMs");
+			const JsonValue* costValue = FindObjectMember(entry, "resourceCostPercent");
+			const JsonValue* targetValue = FindObjectMember(entry, "targetType");
+			if (idValue == nullptr || idValue->type != JsonType::String || idValue->stringValue.empty()
+				|| nameValue == nullptr || nameValue->type != JsonType::String || nameValue->stringValue.empty()
+				|| slotValue == nullptr || !TryGetUint(*slotValue, spell.slot) || spell.slot < 1 || spell.slot > 4
+				|| castValue == nullptr || !TryGetUint(*castValue, spell.castTimeMs)
+				|| cooldownValue == nullptr || !TryGetUint(*cooldownValue, spell.cooldownMs)
+				|| costValue == nullptr || !TryGetUint(*costValue, spell.resourceCostPercent)
+				|| targetValue == nullptr || targetValue->type != JsonType::String)
+			{
+				outError = "spells[" + std::to_string(index) + "]: missing or invalid display field";
+				return false;
+			}
+			spell.spellId = idValue->stringValue;
+			spell.name = nameValue->stringValue;
+			spell.needsEnemyTarget = (targetValue->stringValue == "SingleEnemy");
+			kit.push_back(std::move(spell));
+		}
+
+		std::sort(kit.begin(), kit.end(),
+			[](const SpellDisplay& a, const SpellDisplay& b) { return a.slot < b.slot; });
+		m_kits[profileValue->stringValue] = std::move(kit);
+		return true;
+	}
+}

--- a/src/client/gameplay/SpellKitCatalog.h
+++ b/src/client/gameplay/SpellKitCatalog.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::client
+{
+	/// Combat SP3 — métadonnées d'affichage d'un sort (barre d'action / cast bar).
+	/// Le client ne lit QUE l'affichage : la résolution des effets reste serveur.
+	struct SpellDisplay
+	{
+		std::string spellId;
+		std::string name;
+		/// Slot de la barre d'action [1,4].
+		uint32_t slot = 1;
+		uint32_t castTimeMs = 0;
+		uint32_t cooldownMs = 0;
+		uint32_t resourceCostPercent = 0;
+		/// true si le sort exige une cible ennemie (targetType SingleEnemy).
+		bool needsEnemyTarget = false;
+	};
+
+	/// Combat SP3 — catalogue client des kits de sorts (même
+	/// `game/data/gameplay/spells/*.json` que le serveur). Politique TOLÉRANTE :
+	/// fichier absent/invalide = catalogue vide + LOG_WARN, la barre d'action est
+	/// simplement masquée (le serveur reste l'autorité de toute façon).
+	class SpellKitCatalog final
+	{
+	public:
+		/// Charge tous les `gameplay/spells/*.json` depuis `paths.content`.
+		/// Retourne false (catalogue vide) si rien n'est lisible — non bloquant.
+		bool Init(const engine::core::Config& config);
+
+		/// Retourne le kit d'un profil (sorts triés par slot), ou nullptr.
+		const std::vector<SpellDisplay>* FindKit(std::string_view profile) const;
+
+		/// Retourne le nom d'affichage d'un sort (tous kits confondus), ou
+		/// l'identifiant brut si inconnu (catalogue désynchronisé).
+		std::string ResolveSpellName(std::string_view spellId) const;
+
+		/// Nombre de profils chargés (0 si le catalogue n'a pas pu être lu).
+		size_t KitCount() const { return m_kits.size(); }
+
+		/// Variante testable sans I/O : parse le JSON d'UN kit.
+		bool LoadKitFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		std::unordered_map<std::string, std::vector<SpellDisplay>> m_kits;
+	};
+}

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -297,6 +297,26 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendCastRequest(uint32_t clientId, uint64_t targetEntityId, std::string_view spellId)
+	{
+		engine::server::CastRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.targetEntityId = targetEntityId;
+		msg.spellId = std::string(spellId);
+		const std::vector<std::byte> packet = engine::server::EncodeCastRequest(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_DEBUG(Net, "[GameplayUdpClient] CastRequest sent (client_id={}, spell={}, target_entity_id={})",
+				clientId, msg.spellId, targetEntityId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] CastRequest FAILED (client_id={}, spell={})", clientId, msg.spellId);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity)
 	{
 		engine::server::ShopBuyRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -58,6 +58,11 @@ namespace engine::client
 		/// Combat SP2 — demande de réapparition (joueur mort uniquement, validé serveur).
 		bool SendRespawnRequest(uint32_t clientId);
 
+		/// Combat SP3 — cast d'un sort du kit du profil. targetEntityId = 0 pour
+		/// les sorts sans cible (le serveur revalide tout : kit, cooldown, coût,
+		/// cible, portée).
+		bool SendCastRequest(uint32_t clientId, uint64_t targetEntityId, std::string_view spellId);
+
 		bool SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);
 
 		bool SendShopSellRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -3,6 +3,8 @@
 #include "src/shared/core/Log.h"
 
 #include <algorithm>
+#include <chrono>
+#include <iterator>
 #include <string_view>
 #include <utility>
 
@@ -608,6 +610,13 @@ namespace engine::client
 		// R1-B — feuille de personnage (stats dérivées poussées à l'enter-world)
 		case engine::server::MessageKind::PlayerStats:
 			return ApplyPlayerStats(packet);
+		// Combat SP3 — sorts et auras (wire v11)
+		case engine::server::MessageKind::ResourceUpdate:
+			return ApplyResourceUpdate(packet);
+		case engine::server::MessageKind::CastBarUpdate:
+			return ApplyCastBarUpdate(packet);
+		case engine::server::MessageKind::AuraUpdate:
+			return ApplyAuraUpdate(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -742,6 +751,29 @@ namespace engine::client
 			m_model.remoteEntities.push_back(remote);
 		}
 
+		// Combat SP3 — purge des auras des entités sorties de l'AoI (le joueur
+		// local garde les siennes, les autres suivent le contenu du snapshot).
+		if (!m_model.entityAuras.empty())
+		{
+			for (auto auraIt = m_model.entityAuras.begin(); auraIt != m_model.entityAuras.end();)
+			{
+				const engine::server::EntityId auraEntityId = auraIt->first;
+				bool stillPresent = (auraEntityId == stats.playerEntityId);
+				if (!stillPresent)
+				{
+					for (const UIRemoteEntity& remote : m_model.remoteEntities)
+					{
+						if (remote.entityId == auraEntityId)
+						{
+							stillPresent = true;
+							break;
+						}
+					}
+				}
+				auraIt = stillPresent ? std::next(auraIt) : m_model.entityAuras.erase(auraIt);
+			}
+		}
+
 		if (m_model.targetStats.hasTarget)
 		{
 			m_model.targetStats.hasPosition = false;
@@ -833,6 +865,82 @@ namespace engine::client
 			m_combatEventMessage.targetEntityId,
 			m_combatEventMessage.damage,
 			playerWasAttacker ? "attacker" : "target");
+		return true;
+	}
+
+	bool UIModelBinding::ApplyResourceUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeResourceUpdate(packet, m_resourceUpdateMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] ResourceUpdate FAILED: decode error");
+			return false;
+		}
+
+		m_model.playerStats.secondaryResourceCurrent = m_resourceUpdateMessage.currentResource;
+		m_model.playerStats.secondaryResourceMax = m_resourceUpdateMessage.maxResource;
+		NotifyObservers(UIModelChangeStats);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyCastBarUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeCastBarUpdate(packet, m_castBarUpdateMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] CastBarUpdate FAILED: decode error");
+			return false;
+		}
+
+		if (m_castBarUpdateMessage.status == engine::server::kCastBarStatusStart)
+		{
+			m_model.castBar.active = true;
+			m_model.castBar.spellId = m_castBarUpdateMessage.spellId;
+			m_model.castBar.durationMs = m_castBarUpdateMessage.durationMs;
+			m_model.castBar.startedAtNs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::nanoseconds>(
+					std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+		else
+		{
+			// Complete et Cancel masquent la barre (le résultat du sort arrive
+			// par CombatEvent / AuraUpdate / ResourceUpdate, pas par cette voie).
+			m_model.castBar = UICastBarState{};
+		}
+		NotifyObservers(UIModelChangeCombat);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyAuraUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeAuraUpdate(packet, m_auraUpdateMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] AuraUpdate FAILED: decode error");
+			return false;
+		}
+
+		if (m_auraUpdateMessage.auras.empty())
+		{
+			m_model.entityAuras.erase(m_auraUpdateMessage.targetEntityId);
+		}
+		else
+		{
+			const uint64_t nowNs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::nanoseconds>(
+					std::chrono::steady_clock::now().time_since_epoch()).count());
+			std::vector<UIAuraEntry>& auraList = m_model.entityAuras[m_auraUpdateMessage.targetEntityId];
+			auraList.clear();
+			auraList.reserve(m_auraUpdateMessage.auras.size());
+			for (const engine::server::AuraWireEntry& wireAura : m_auraUpdateMessage.auras)
+			{
+				UIAuraEntry entry{};
+				entry.spellId = wireAura.spellId;
+				entry.effectType = wireAura.effectType;
+				entry.remainingMs = wireAura.remainingMs;
+				entry.stacks = wireAura.stacks;
+				entry.receivedAtNs = nowNs;
+				auraList.push_back(std::move(entry));
+			}
+		}
+		NotifyObservers(UIModelChangeCombat);
 		return true;
 	}
 
@@ -1190,6 +1298,11 @@ namespace engine::client
 		m_model.playerStats.perception = m_playerStatsScratch.perception;
 		m_model.playerStats.stealth = m_playerStatsScratch.stealth;
 		m_model.playerStats.secondaryResourceKey = m_playerStatsScratch.resourceKey;
+		// Combat SP3 — profil de classe (kit de la barre d'action) ; la ressource
+		// courante part de son max (pleine à l'enter-world, le serveur ne pousse
+		// un ResourceUpdate que sur variation).
+		m_model.playerStats.profileId = m_playerStatsScratch.profileId;
+		m_model.playerStats.secondaryResourceCurrent = m_playerStatsScratch.resource;
 
 		LOG_INFO(Net,
 			"[UIModelBinding] PlayerStats applied (client_id={}, max_health={}, resource={}, stamina={}, damage={})",

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -11,6 +11,7 @@
 #include <span>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::client
@@ -217,6 +218,37 @@ namespace engine::client
 		float    perception = 0.0f;
 		float    stealth = 0.0f;
 		std::string secondaryResourceKey;
+		/// Combat SP3 — ressource secondaire COURANTE (poussée par ResourceUpdate,
+		/// régén/débits serveur-autoritaires). Max = secondaryResourceMax.
+		uint32_t secondaryResourceCurrent = 0;
+		/// Combat SP3 — profil de classe ("melee", "tank", …) reçu via PlayerStats
+		/// (wire v11) ; résout le kit de la barre d'action. Vide = pas de barre.
+		std::string profileId;
+	};
+
+	/// Combat SP3 — état de la barre de cast du joueur local (CastBarUpdate).
+	struct UICastBarState
+	{
+		bool active = false;
+		std::string spellId;
+		uint32_t durationMs = 0;
+		/// Horodatage monotone (ns) de la réception du Start — le rendu calcule
+		/// la progression localement (pas de re-push serveur par frame).
+		uint64_t startedAtNs = 0;
+	};
+
+	/// Combat SP3 — une aura active répliquée (AuraUpdate, wire v11).
+	struct UIAuraEntry
+	{
+		std::string spellId;
+		/// Valeur de l'enum serveur SpellEffectType (1=DoT, 3=HoT, 4=Buff dégâts,
+		/// 5=Debuff dégâts subis, 7=Slow…).
+		uint8_t effectType = 0;
+		uint32_t remainingMs = 0;
+		uint8_t stacks = 1;
+		/// Horodatage monotone (ns) de réception — le timer affiché décrémente
+		/// localement entre deux AuraUpdate.
+		uint64_t receivedAtNs = 0;
 	};
 
 	/// Current combat target resolved from the latest player-originated combat event.
@@ -377,6 +409,12 @@ namespace engine::client
 		UIHarvestProgress harvest{};
 		/// M36.2 — crafting panel state (professions, recipe list, cast bar).
 		UICraftingState crafting{};
+		/// Combat SP3 — barre de cast du joueur local (sorts à incantation).
+		UICastBarState castBar{};
+		/// Combat SP3 — auras actives par entité (joueur local inclus), remplacées
+		/// intégralement à chaque AuraUpdate de l'entité. Une entité qui sort de
+		/// l'AoI garde une entrée périmée jusqu'au prochain ApplySnapshot (purge).
+		std::unordered_map<engine::server::EntityId, std::vector<UIAuraEntry>> entityAuras;
 		std::string debugDump;
 
 		/// Build a text dump suitable for a debug widget or logs.
@@ -464,6 +502,15 @@ namespace engine::client
 
 		/// Apply one decoded combat event to the stats section of the UI model.
 		bool ApplyCombatEvent(std::span<const std::byte> packet);
+
+		/// Combat SP3 — ressource secondaire courante du joueur (ResourceUpdate).
+		bool ApplyResourceUpdate(std::span<const std::byte> packet);
+
+		/// Combat SP3 — barre de cast du joueur local (CastBarUpdate start/complete/cancel).
+		bool ApplyCastBarUpdate(std::span<const std::byte> packet);
+
+		/// Combat SP3 — remplace les auras d'une entité (AuraUpdate, idempotent).
+		bool ApplyAuraUpdate(std::span<const std::byte> packet);
 
 		/// Apply one decoded zone change packet to the world section of the UI model.
 		bool ApplyZoneChange(std::span<const std::byte> packet);
@@ -555,6 +602,10 @@ namespace engine::client
 		};
 		ChunkedSnapshotAccumulator m_chunkAccumulator{};
 		engine::server::CombatEventMessage m_combatEventMessage{};
+		/// Combat SP3 — scratch des messages sorts/auras (réutilisés par paquet).
+		engine::server::ResourceUpdateMessage m_resourceUpdateMessage{};
+		engine::server::CastBarUpdateMessage m_castBarUpdateMessage{};
+		engine::server::AuraUpdateMessage m_auraUpdateMessage{};
 		engine::server::ZoneChangeMessage m_zoneChangeMessage{};
 		engine::server::InventoryDeltaMessage m_inventoryMessage{};
 		engine::server::QuestDeltaMessage m_questMessage{};

--- a/src/shardd/gameplay/spell/SpellKitLibrary.cpp
+++ b/src/shardd/gameplay/spell/SpellKitLibrary.cpp
@@ -1,0 +1,789 @@
+#include "src/shardd/gameplay/spell/SpellKitLibrary.h"
+
+#include "src/shared/core/Log.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace engine::server
+{
+	namespace
+	{
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		/// Parseur JSON minimal local aux kits de sorts — même convention que
+		/// SpawnerRuntime/CreatureArchetypeLibrary : parseur par module, zéro dépendance.
+		class JsonParser final
+		{
+		public:
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			/// Parse le document complet ; rejette tout caractère résiduel.
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+
+				return true;
+			}
+
+		private:
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+
+				++m_pos;
+				return true;
+			}
+
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+
+				switch (m_input[m_pos])
+				{
+				case '{':
+					return ParseObject(outValue, outError);
+				case '[':
+					return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default:
+					break;
+				}
+
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+
+				return ParseNumber(outValue, outError);
+			}
+
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"': outValue.push_back('"'); break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/': outValue.push_back('/'); break;
+					case 'b': outValue.push_back('\b'); break;
+					case 'f': outValue.push_back('\f'); break;
+					case 'n': outValue.push_back('\n'); break;
+					case 'r': outValue.push_back('\r'); break;
+					case 't': outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+
+				outError = "unterminated string";
+				return false;
+			}
+
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Retourne un membre d'objet, ou nullptr si la clé est absente.
+		const JsonValue* FindObjectMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+
+			const auto it = object.objectValue.find(std::string(key));
+			if (it == object.objectValue.end())
+			{
+				return nullptr;
+			}
+
+			return &it->second;
+		}
+
+		/// Convertit un nombre JSON en uint32 validé (entier, borné, fini).
+		bool TryGetUint(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+
+		/// Convertit un nombre JSON en float fini validé.
+		bool TryGetFloat(const JsonValue& value, float& outValue)
+		{
+			if (value.type != JsonType::Number || !std::isfinite(value.numberValue))
+			{
+				return false;
+			}
+
+			outValue = static_cast<float>(value.numberValue);
+			return true;
+		}
+
+		/// Mappe la chaîne `targetType` du JSON vers l'enum (false si inconnue).
+		bool TryParseTargetKind(std::string_view text, SpellTargetKind& outKind)
+		{
+			if (text == "SingleEnemy") { outKind = SpellTargetKind::SingleEnemy; return true; }
+			if (text == "SingleAlly") { outKind = SpellTargetKind::SingleAlly; return true; }
+			if (text == "SelfOnly") { outKind = SpellTargetKind::SelfOnly; return true; }
+			if (text == "AreaAroundSelf") { outKind = SpellTargetKind::AreaAroundSelf; return true; }
+			return false;
+		}
+
+		/// Mappe la chaîne `type` d'un effet vers l'enum (false si inconnue).
+		bool TryParseEffectType(std::string_view text, SpellEffectType& outType)
+		{
+			if (text == "DirectDamage") { outType = SpellEffectType::DirectDamage; return true; }
+			if (text == "DamageOverTime") { outType = SpellEffectType::DamageOverTime; return true; }
+			if (text == "DirectHeal") { outType = SpellEffectType::DirectHeal; return true; }
+			if (text == "HealOverTime") { outType = SpellEffectType::HealOverTime; return true; }
+			if (text == "BuffDamagePercent") { outType = SpellEffectType::BuffDamagePercent; return true; }
+			if (text == "DebuffDamageTakenPercent") { outType = SpellEffectType::DebuffDamageTakenPercent; return true; }
+			if (text == "TauntThreatMult") { outType = SpellEffectType::TauntThreatMult; return true; }
+			if (text == "SlowMobPercent") { outType = SpellEffectType::SlowMobPercent; return true; }
+			if (text == "ThreatReducePercent") { outType = SpellEffectType::ThreatReducePercent; return true; }
+			return false;
+		}
+
+		/// Valide la cohérence champ/type d'un effet parsé (DoT sans durée, etc.).
+		bool ValidateEffect(const SpellEffectDef& effect, std::string& outError, const std::string& label)
+		{
+			switch (effect.type)
+			{
+			case SpellEffectType::DirectDamage:
+			case SpellEffectType::DirectHeal:
+			case SpellEffectType::TauntThreatMult:
+				if (effect.mult <= 0.0f)
+				{
+					outError = label + ": mult must be positive for this effect type";
+					return false;
+				}
+				return true;
+			case SpellEffectType::DamageOverTime:
+				if (effect.mult <= 0.0f || effect.tickPeriodMs == 0 || effect.durationMs == 0)
+				{
+					outError = label + ": DamageOverTime requires mult, tickPeriodMs and durationMs";
+					return false;
+				}
+				return true;
+			case SpellEffectType::HealOverTime:
+				if ((effect.mult <= 0.0f && effect.percentMaxHpPerTick <= 0.0f)
+					|| effect.tickPeriodMs == 0 || effect.durationMs == 0)
+				{
+					outError = label + ": HealOverTime requires (mult or percentMaxHpPerTick), tickPeriodMs and durationMs";
+					return false;
+				}
+				return true;
+			case SpellEffectType::BuffDamagePercent:
+			case SpellEffectType::DebuffDamageTakenPercent:
+			case SpellEffectType::SlowMobPercent:
+				if (effect.percent <= 0.0f || effect.durationMs == 0)
+				{
+					outError = label + ": percent and durationMs required for this effect type";
+					return false;
+				}
+				return true;
+			case SpellEffectType::ThreatReducePercent:
+				if (effect.percent <= 0.0f || effect.percent > 100.0f)
+				{
+					outError = label + ": percent must be in (0,100] for ThreatReducePercent";
+					return false;
+				}
+				return true;
+			}
+
+			outError = label + ": unhandled effect type";
+			return false;
+		}
+	}
+
+	SpellKitLibrary::SpellKitLibrary(const engine::core::Config& config)
+		: m_config(config)
+	{
+		LOG_INFO(Net, "[SpellKitLibrary] Constructed");
+	}
+
+	bool SpellKitLibrary::Init()
+	{
+		if (m_initialized)
+		{
+			LOG_WARN(Net, "[SpellKitLibrary] Init ignored: already initialized");
+			return true;
+		}
+
+		const std::filesystem::path spellsDirectory =
+			engine::platform::FileSystem::ResolveContentPath(m_config, "gameplay/spells");
+		const std::vector<std::filesystem::path> entries =
+			engine::platform::FileSystem::ListDirectory(spellsDirectory);
+		if (entries.empty())
+		{
+			LOG_ERROR(Net, "[SpellKitLibrary] Init FAILED: no spell kit files found ({})", spellsDirectory.string());
+			return false;
+		}
+
+		for (const std::filesystem::path& entry : entries)
+		{
+			if (entry.extension() != ".json")
+			{
+				continue;
+			}
+
+			const std::string relativePath = "gameplay/spells/" + entry.filename().string();
+			const std::string jsonText = engine::platform::FileSystem::ReadAllTextContent(m_config, relativePath);
+			if (jsonText.empty())
+			{
+				LOG_ERROR(Net, "[SpellKitLibrary] Init FAILED: empty or unreadable kit ({})", relativePath);
+				m_kits.clear();
+				return false;
+			}
+
+			std::string loadError;
+			if (!LoadKitFromText(jsonText, loadError))
+			{
+				LOG_ERROR(Net, "[SpellKitLibrary] Init FAILED: {} ({})", loadError, relativePath);
+				m_kits.clear();
+				return false;
+			}
+		}
+
+		if (m_kits.empty())
+		{
+			LOG_ERROR(Net, "[SpellKitLibrary] Init FAILED: no kit loaded");
+			return false;
+		}
+
+		m_initialized = true;
+		LOG_INFO(Net, "[SpellKitLibrary] Init OK (kits={})", m_kits.size());
+		return true;
+	}
+
+	const std::vector<SpellDef>* SpellKitLibrary::FindKit(std::string_view profile) const
+	{
+		const auto it = m_kits.find(std::string(profile));
+		if (it == m_kits.end())
+		{
+			return nullptr;
+		}
+
+		return &it->second;
+	}
+
+	const SpellDef* SpellKitLibrary::FindSpell(std::string_view profile, std::string_view spellId) const
+	{
+		const std::vector<SpellDef>* kit = FindKit(profile);
+		if (kit == nullptr)
+		{
+			return nullptr;
+		}
+
+		for (const SpellDef& spell : *kit)
+		{
+			if (spell.spellId == spellId)
+			{
+				return &spell;
+			}
+		}
+
+		return nullptr;
+	}
+
+	bool SpellKitLibrary::LoadKitFromText(std::string_view jsonText, std::string& outError)
+	{
+		JsonValue root;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, outError))
+		{
+			return false;
+		}
+
+		const JsonValue* profileValue = FindObjectMember(root, "profile");
+		if (profileValue == nullptr || profileValue->type != JsonType::String || profileValue->stringValue.empty())
+		{
+			outError = "root.profile must be a non-empty string";
+			return false;
+		}
+		const std::string profile = profileValue->stringValue;
+
+		if (m_kits.find(profile) != m_kits.end())
+		{
+			outError = "duplicate profile kit '" + profile + "'";
+			return false;
+		}
+
+		const JsonValue* spellsValue = FindObjectMember(root, "spells");
+		if (spellsValue == nullptr || spellsValue->type != JsonType::Array || spellsValue->arrayValue.empty())
+		{
+			outError = "root.spells must be a non-empty array";
+			return false;
+		}
+
+		std::vector<SpellDef> kit;
+		std::unordered_set<uint32_t> usedSlots;
+		std::unordered_set<std::string> usedIds;
+		for (size_t index = 0; index < spellsValue->arrayValue.size(); ++index)
+		{
+			const JsonValue& entry = spellsValue->arrayValue[index];
+			const std::string entryLabel = profile + ".spells[" + std::to_string(index) + "]";
+			if (entry.type != JsonType::Object)
+			{
+				outError = entryLabel + " must be an object";
+				return false;
+			}
+
+			SpellDef spell{};
+
+			const JsonValue* idValue = FindObjectMember(entry, "id");
+			if (idValue == nullptr || idValue->type != JsonType::String || idValue->stringValue.empty())
+			{
+				outError = entryLabel + ".id must be a non-empty string";
+				return false;
+			}
+			spell.spellId = idValue->stringValue;
+			if (!usedIds.emplace(spell.spellId).second)
+			{
+				outError = "duplicate spell id '" + spell.spellId + "'";
+				return false;
+			}
+
+			const JsonValue* nameValue = FindObjectMember(entry, "name");
+			if (nameValue == nullptr || nameValue->type != JsonType::String || nameValue->stringValue.empty())
+			{
+				outError = spell.spellId + ": name must be a non-empty string";
+				return false;
+			}
+			spell.name = nameValue->stringValue;
+
+			const JsonValue* slotValue = FindObjectMember(entry, "slot");
+			if (slotValue == nullptr || !TryGetUint(*slotValue, spell.slot)
+				|| spell.slot < 1 || spell.slot > 4)
+			{
+				outError = spell.spellId + ": slot must be an integer in [1,4]";
+				return false;
+			}
+			if (!usedSlots.emplace(spell.slot).second)
+			{
+				outError = spell.spellId + ": duplicate slot " + std::to_string(spell.slot);
+				return false;
+			}
+
+			const JsonValue* castValue = FindObjectMember(entry, "castTimeMs");
+			if (castValue == nullptr || !TryGetUint(*castValue, spell.castTimeMs))
+			{
+				outError = spell.spellId + ": castTimeMs must be an unsigned integer";
+				return false;
+			}
+
+			// cooldownMs == 0 autorisé (sort spammable, ex. healer Soin rapide).
+			const JsonValue* cooldownValue = FindObjectMember(entry, "cooldownMs");
+			if (cooldownValue == nullptr || !TryGetUint(*cooldownValue, spell.cooldownMs))
+			{
+				outError = spell.spellId + ": cooldownMs must be an unsigned integer";
+				return false;
+			}
+
+			const JsonValue* costValue = FindObjectMember(entry, "resourceCostPercent");
+			if (costValue == nullptr || !TryGetUint(*costValue, spell.resourceCostPercent)
+				|| spell.resourceCostPercent > 100)
+			{
+				outError = spell.spellId + ": resourceCostPercent must be in [0,100]";
+				return false;
+			}
+
+			const JsonValue* rangeValue = FindObjectMember(entry, "rangeMeters");
+			if (rangeValue == nullptr || !TryGetFloat(*rangeValue, spell.rangeMeters) || spell.rangeMeters < 0.0f)
+			{
+				outError = spell.spellId + ": rangeMeters must be a non-negative number";
+				return false;
+			}
+
+			const JsonValue* targetValue = FindObjectMember(entry, "targetType");
+			if (targetValue == nullptr || targetValue->type != JsonType::String
+				|| !TryParseTargetKind(targetValue->stringValue, spell.targetType))
+			{
+				outError = spell.spellId + ": targetType must be one of SingleEnemy|SingleAlly|SelfOnly|AreaAroundSelf";
+				return false;
+			}
+
+			const JsonValue* areaValue = FindObjectMember(entry, "areaRadiusMeters");
+			if (areaValue == nullptr || !TryGetFloat(*areaValue, spell.areaRadiusMeters) || spell.areaRadiusMeters < 0.0f)
+			{
+				outError = spell.spellId + ": areaRadiusMeters must be a non-negative number";
+				return false;
+			}
+			if (spell.targetType == SpellTargetKind::AreaAroundSelf && spell.areaRadiusMeters <= 0.0f)
+			{
+				outError = spell.spellId + ": AreaAroundSelf requires a positive areaRadiusMeters";
+				return false;
+			}
+
+			const JsonValue* effectsValue = FindObjectMember(entry, "effects");
+			if (effectsValue == nullptr || effectsValue->type != JsonType::Array || effectsValue->arrayValue.empty())
+			{
+				outError = spell.spellId + ": effects must be a non-empty array";
+				return false;
+			}
+
+			for (size_t effectIndex = 0; effectIndex < effectsValue->arrayValue.size(); ++effectIndex)
+			{
+				const JsonValue& effectEntry = effectsValue->arrayValue[effectIndex];
+				const std::string effectLabel = spell.spellId + ".effects[" + std::to_string(effectIndex) + "]";
+				if (effectEntry.type != JsonType::Object)
+				{
+					outError = effectLabel + " must be an object";
+					return false;
+				}
+
+				SpellEffectDef effect{};
+				const JsonValue* typeValue = FindObjectMember(effectEntry, "type");
+				if (typeValue == nullptr || typeValue->type != JsonType::String
+					|| !TryParseEffectType(typeValue->stringValue, effect.type))
+				{
+					outError = effectLabel + ": unknown effect type";
+					return false;
+				}
+
+				// Champs optionnels selon le type — validés ensuite par ValidateEffect.
+				if (const JsonValue* multValue = FindObjectMember(effectEntry, "mult"))
+				{
+					if (!TryGetFloat(*multValue, effect.mult) || effect.mult < 0.0f)
+					{
+						outError = effectLabel + ": mult must be a non-negative number";
+						return false;
+					}
+				}
+				if (const JsonValue* percentValue = FindObjectMember(effectEntry, "percent"))
+				{
+					if (!TryGetFloat(*percentValue, effect.percent) || effect.percent < 0.0f)
+					{
+						outError = effectLabel + ": percent must be a non-negative number";
+						return false;
+					}
+				}
+				if (const JsonValue* tickValue = FindObjectMember(effectEntry, "tickPeriodMs"))
+				{
+					if (!TryGetUint(*tickValue, effect.tickPeriodMs))
+					{
+						outError = effectLabel + ": tickPeriodMs must be an unsigned integer";
+						return false;
+					}
+				}
+				if (const JsonValue* durationValue = FindObjectMember(effectEntry, "durationMs"))
+				{
+					if (!TryGetUint(*durationValue, effect.durationMs))
+					{
+						outError = effectLabel + ": durationMs must be an unsigned integer";
+						return false;
+					}
+				}
+				if (const JsonValue* hpTickValue = FindObjectMember(effectEntry, "percentMaxHpPerTick"))
+				{
+					if (!TryGetFloat(*hpTickValue, effect.percentMaxHpPerTick) || effect.percentMaxHpPerTick < 0.0f)
+					{
+						outError = effectLabel + ": percentMaxHpPerTick must be a non-negative number";
+						return false;
+					}
+				}
+
+				if (!ValidateEffect(effect, outError, effectLabel))
+				{
+					return false;
+				}
+
+				spell.effects.push_back(effect);
+			}
+
+			kit.push_back(std::move(spell));
+		}
+
+		// Tri par slot : la barre d'action client consomme l'ordre tel quel.
+		std::sort(kit.begin(), kit.end(),
+			[](const SpellDef& a, const SpellDef& b) { return a.slot < b.slot; });
+
+		LOG_INFO(Net, "[SpellKitLibrary] Kit loaded (profile={}, spells={})", profile, kit.size());
+		m_kits.emplace(profile, std::move(kit));
+		return true;
+	}
+}

--- a/src/shardd/gameplay/spell/SpellKitLibrary.h
+++ b/src/shardd/gameplay/spell/SpellKitLibrary.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "src/shared/core/Config.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::server
+{
+	/// Combat SP3 — type d'effet d'un sort (cf. proposition de kits validée).
+	/// Tous les types sont résolus côté serveur ; le client ne lit que les
+	/// métadonnées d'affichage (nom, coût, cooldown, slot).
+	enum class SpellEffectType : uint8_t
+	{
+		DirectDamage = 0,
+		DamageOverTime = 1,
+		DirectHeal = 2,
+		HealOverTime = 3,
+		BuffDamagePercent = 4,
+		DebuffDamageTakenPercent = 5,
+		TauntThreatMult = 6,
+		SlowMobPercent = 7,
+		ThreatReducePercent = 8,
+	};
+
+	/// Combat SP3 — type de cible d'un sort.
+	enum class SpellTargetKind : uint8_t
+	{
+		SingleEnemy = 0,
+		SingleAlly = 1,
+		SelfOnly = 2,
+		AreaAroundSelf = 3,
+	};
+
+	/// Combat SP3 — un effet d'un sort (un sort peut en porter plusieurs,
+	/// ex. pisteur « Morsure du piege » = DoT + ralentissement).
+	struct SpellEffectDef
+	{
+		SpellEffectType type = SpellEffectType::DirectDamage;
+		/// Multiplicateur de la stat `damage` du casteur (DirectDamage/DoT/Heal/HoT/Taunt).
+		float mult = 0.0f;
+		/// Pourcentage (Buff/Debuff/Slow/ThreatReduce).
+		float percent = 0.0f;
+		/// Période de tick en ms (DoT/HoT).
+		uint32_t tickPeriodMs = 0;
+		/// Durée de l'aura en ms (DoT/HoT/Buff/Debuff/Slow).
+		uint32_t durationMs = 0;
+		/// HoT exprimé en % des PV max par tick (tank « Second souffle ») ;
+		/// 0 = utiliser `mult` × damage du casteur.
+		float percentMaxHpPerTick = 0.0f;
+	};
+
+	/// Combat SP3 — un sort d'un kit de profil (immuable après chargement).
+	struct SpellDef
+	{
+		std::string spellId;
+		std::string name;
+		/// Slot de la barre d'action [1,4] — unique au sein du kit.
+		uint32_t slot = 1;
+		uint32_t castTimeMs = 0;
+		/// 0 autorisé (sort spammable, ex. healer « Soin rapide »).
+		uint32_t cooldownMs = 0;
+		/// Coût = resourceCostPercent × ressource max du joueur / 100.
+		uint32_t resourceCostPercent = 0;
+		/// 0 = mêlée → le serveur substitue la portée d'auto-attaque.
+		float rangeMeters = 0.0f;
+		SpellTargetKind targetType = SpellTargetKind::SingleEnemy;
+		/// Rayon AoE (mètres) — requis > 0 si targetType == AreaAroundSelf.
+		float areaRadiusMeters = 0.0f;
+		std::vector<SpellEffectDef> effects;
+	};
+
+	/// Combat SP3 — bibliothèque serveur des kits de sorts par profil, résolue
+	/// depuis `paths.content` (`gameplay/spells/*.json`). Politique stricte
+	/// (pattern CreatureArchetypeLibrary) : fichier illisible ou entrée invalide
+	/// = échec d'Init, le shard ne boote pas avec des kits corrompus.
+	class SpellKitLibrary final
+	{
+	public:
+		/// Capture la config utilisée pour résoudre les JSON des kits.
+		explicit SpellKitLibrary(const engine::core::Config& config);
+
+		/// Charge et valide tous les `gameplay/spells/*.json` du content root.
+		/// Idempotent (warn + true si déjà initialisé). Retourne false si aucun
+		/// kit n'est chargé ou si l'un d'eux est invalide.
+		bool Init();
+
+		/// Retourne le kit d'un profil (sorts triés par slot), ou nullptr.
+		const std::vector<SpellDef>* FindKit(std::string_view profile) const;
+
+		/// Retourne un sort d'un kit, ou nullptr (profil ou sort inconnu).
+		const SpellDef* FindSpell(std::string_view profile, std::string_view spellId) const;
+
+		/// Nombre de profils chargés (0 avant Init).
+		size_t KitCount() const { return m_kits.size(); }
+
+		/// Variante testable sans I/O : parse et valide le JSON d'UN kit et
+		/// l'insère dans la bibliothèque. outError renseigné en cas d'échec.
+		bool LoadKitFromText(std::string_view jsonText, std::string& outError);
+
+	private:
+		engine::core::Config m_config;
+		std::unordered_map<std::string, std::vector<SpellDef>> m_kits;
+		bool m_initialized = false;
+	};
+}

--- a/src/shardd/gameplay/spell/SpellKitLibraryTests.cpp
+++ b/src/shardd/gameplay/spell/SpellKitLibraryTests.cpp
@@ -1,0 +1,237 @@
+// Combat SP3 — tests de la bibliothèque de kits de sorts (parse + validation).
+
+#include "src/shardd/gameplay/spell/SpellKitLibrary.h"
+#include "src/shared/core/Config.h"
+#include "src/shared/core/Log.h"
+
+#include <string>
+
+namespace
+{
+	using engine::server::SpellDef;
+	using engine::server::SpellEffectType;
+	using engine::server::SpellKitLibrary;
+	using engine::server::SpellTargetKind;
+
+	/// Library de test sans I/O (LoadKitFromText seulement).
+	SpellKitLibrary MakeLibrary()
+	{
+		engine::core::Config config;
+		return SpellKitLibrary(config);
+	}
+
+	const char* kValidKit = R"({
+  "profile": "melee",
+  "spells": [
+    { "id": "melee_frappe", "name": "Frappe", "slot": 2, "castTimeMs": 0,
+      "cooldownMs": 6000, "resourceCostPercent": 15, "rangeMeters": 0,
+      "targetType": "SingleEnemy", "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 1.4 } ] },
+    { "id": "melee_cri", "name": "Cri", "slot": 1, "castTimeMs": 0,
+      "cooldownMs": 30000, "resourceCostPercent": 25, "rangeMeters": 0,
+      "targetType": "SelfOnly", "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 15, "durationMs": 10000 } ] }
+  ]
+})";
+
+	bool TestValidKitSortedBySlot()
+	{
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		if (!library.LoadKitFromText(kValidKit, error))
+		{
+			LOG_ERROR(Core, "[SpellKitLibraryTests] valid kit rejected: {}", error);
+			return false;
+		}
+		if (library.KitCount() != 1) return false;
+		const auto* kit = library.FindKit("melee");
+		if (kit == nullptr || kit->size() != 2) return false;
+		// Tri par slot : "Cri" (slot 1) doit précéder "Frappe" (slot 2).
+		if ((*kit)[0].spellId != "melee_cri" || (*kit)[1].spellId != "melee_frappe") return false;
+		const SpellDef* frappe = library.FindSpell("melee", "melee_frappe");
+		if (frappe == nullptr) return false;
+		if (frappe->cooldownMs != 6000 || frappe->resourceCostPercent != 15) return false;
+		if (frappe->targetType != SpellTargetKind::SingleEnemy) return false;
+		if (frappe->effects.size() != 1 || frappe->effects[0].type != SpellEffectType::DirectDamage) return false;
+		if (library.FindSpell("melee", "inconnu") != nullptr) return false;
+		if (library.FindKit("tank") != nullptr) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] valid kit OK");
+		return true;
+	}
+
+	bool TestZeroCooldownAccepted()
+	{
+		// healer « Soin rapide » : cooldownMs 0 = sort spammable, doit passer.
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "healer",
+  "spells": [
+    { "id": "healer_soin", "name": "Soin", "slot": 1, "castTimeMs": 1500,
+      "cooldownMs": 0, "resourceCostPercent": 25, "rangeMeters": 30,
+      "targetType": "SingleAlly", "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectHeal", "mult": 2.0 } ] }
+  ]
+})";
+		if (!library.LoadKitFromText(kit, error))
+		{
+			LOG_ERROR(Core, "[SpellKitLibraryTests] zero cooldown rejected: {}", error);
+			return false;
+		}
+		LOG_INFO(Core, "[SpellKitLibraryTests] zero cooldown OK");
+		return true;
+	}
+
+	bool TestDuplicateSlotRejected()
+	{
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "melee",
+  "spells": [
+    { "id": "a", "name": "A", "slot": 1, "castTimeMs": 0, "cooldownMs": 1000,
+      "resourceCostPercent": 10, "rangeMeters": 0, "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 5, "durationMs": 5000 } ] },
+    { "id": "b", "name": "B", "slot": 1, "castTimeMs": 0, "cooldownMs": 1000,
+      "resourceCostPercent": 10, "rangeMeters": 0, "targetType": "SelfOnly",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "BuffDamagePercent", "percent": 5, "durationMs": 5000 } ] }
+  ]
+})";
+		if (library.LoadKitFromText(kit, error)) return false;
+		if (error.empty()) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] duplicate slot rejected OK");
+		return true;
+	}
+
+	bool TestUnknownEffectTypeRejected()
+	{
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "melee",
+  "spells": [
+    { "id": "a", "name": "A", "slot": 1, "castTimeMs": 0, "cooldownMs": 1000,
+      "resourceCostPercent": 10, "rangeMeters": 0, "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "Teleport", "mult": 1.0 } ] }
+  ]
+})";
+		if (library.LoadKitFromText(kit, error)) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] unknown effect type rejected OK");
+		return true;
+	}
+
+	bool TestDotWithoutDurationRejected()
+	{
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "melee",
+  "spells": [
+    { "id": "a", "name": "A", "slot": 1, "castTimeMs": 0, "cooldownMs": 1000,
+      "resourceCostPercent": 10, "rangeMeters": 0, "targetType": "SingleEnemy",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DamageOverTime", "mult": 0.3, "tickPeriodMs": 2000 } ] }
+  ]
+})";
+		if (library.LoadKitFromText(kit, error)) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] DoT without duration rejected OK");
+		return true;
+	}
+
+	bool TestPercentMaxHpHotAccepted()
+	{
+		// tank « Second souffle » : HoT en % des PV max (mult 0).
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "tank",
+  "spells": [
+    { "id": "tank_souffle", "name": "Souffle", "slot": 1, "castTimeMs": 0,
+      "cooldownMs": 30000, "resourceCostPercent": 30, "rangeMeters": 0,
+      "targetType": "SelfOnly", "areaRadiusMeters": 0,
+      "effects": [ { "type": "HealOverTime", "mult": 0, "percentMaxHpPerTick": 3,
+                     "tickPeriodMs": 2000, "durationMs": 10000 } ] }
+  ]
+})";
+		if (!library.LoadKitFromText(kit, error))
+		{
+			LOG_ERROR(Core, "[SpellKitLibraryTests] percentMaxHp HoT rejected: {}", error);
+			return false;
+		}
+		LOG_INFO(Core, "[SpellKitLibraryTests] percentMaxHp HoT OK");
+		return true;
+	}
+
+	bool TestMultiEffectAccepted()
+	{
+		// pisteur « Morsure du piege » : DoT + ralentissement sur le même sort.
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "pisteur",
+  "spells": [
+    { "id": "pisteur_morsure", "name": "Morsure", "slot": 1, "castTimeMs": 0,
+      "cooldownMs": 15000, "resourceCostPercent": 25, "rangeMeters": 25,
+      "targetType": "SingleEnemy", "areaRadiusMeters": 0,
+      "effects": [
+        { "type": "DamageOverTime", "mult": 0.3, "tickPeriodMs": 2000, "durationMs": 8000 },
+        { "type": "SlowMobPercent", "percent": 20, "durationMs": 4000 }
+      ] }
+  ]
+})";
+		if (!library.LoadKitFromText(kit, error))
+		{
+			LOG_ERROR(Core, "[SpellKitLibraryTests] multi-effect rejected: {}", error);
+			return false;
+		}
+		const SpellDef* morsure = library.FindSpell("pisteur", "pisteur_morsure");
+		if (morsure == nullptr || morsure->effects.size() != 2) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] multi-effect OK");
+		return true;
+	}
+
+	bool TestAreaWithoutRadiusRejected()
+	{
+		SpellKitLibrary library = MakeLibrary();
+		std::string error;
+		const char* kit = R"({
+  "profile": "lanceur",
+  "spells": [
+    { "id": "a", "name": "A", "slot": 1, "castTimeMs": 0, "cooldownMs": 1000,
+      "resourceCostPercent": 10, "rangeMeters": 0, "targetType": "AreaAroundSelf",
+      "areaRadiusMeters": 0,
+      "effects": [ { "type": "DirectDamage", "mult": 0.9 } ] }
+  ]
+})";
+		if (library.LoadKitFromText(kit, error)) return false;
+		LOG_INFO(Core, "[SpellKitLibraryTests] AoE without radius rejected OK");
+		return true;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	(void)argc; (void)argv;
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Info;
+	logSettings.console = true;
+	engine::core::Log::Init(logSettings);
+
+	const bool ok = TestValidKitSortedBySlot()
+		&& TestZeroCooldownAccepted()
+		&& TestDuplicateSlotRejected()
+		&& TestUnknownEffectTypeRejected()
+		&& TestDotWithoutDurationRejected()
+		&& TestPercentMaxHpHotAccepted()
+		&& TestMultiEffectAccepted()
+		&& TestAreaWithoutRadiusRejected();
+
+	if (ok) LOG_INFO(Core, "[SpellKitLibraryTests] ALL OK");
+	else LOG_ERROR(Core, "[SpellKitLibraryTests] FAIL");
+
+	engine::core::Log::Shutdown();
+	return ok ? 0 : 1;
+}

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -482,6 +482,8 @@ namespace engine::server
 		WriteF32(packet, message.perception);
 		WriteF32(packet, message.stealth);
 		WriteSizedString(packet, message.resourceKey);
+		// Combat SP3 (wire v11) : profil de classe en queue (chaîne préfixée u16).
+		WriteSizedString(packet, message.profileId);
 		return packet;
 	}
 
@@ -510,6 +512,11 @@ namespace engine::server
 		outMessage.stealth = ReadF32(payload, 52);
 		size_t offset = 56;
 		if (!ReadSizedString(payload, offset, outMessage.resourceKey))
+		{
+			return false;
+		}
+		// Combat SP3 (wire v11) : profil de classe en queue.
+		if (!ReadSizedString(payload, offset, outMessage.profileId))
 		{
 			return false;
 		}
@@ -645,6 +652,156 @@ namespace engine::server
 
 		outMessage.clientId = ReadU32(payload, 0);
 		return true;
+	}
+
+	std::vector<std::byte> EncodeCastRequest(const CastRequestMessage& message)
+	{
+		// Combat SP3 — payload : clientId (4) + targetEntityId (8) + spellId (2 + N).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::CastRequest, 14 + message.spellId.size());
+		WriteU32(packet, message.clientId);
+		WriteU64(packet, message.targetEntityId);
+		WriteSizedString(packet, message.spellId);
+		return packet;
+	}
+
+	bool DecodeCastRequest(std::span<const std::byte> packet, CastRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::CastRequest, payload) || payload.size() < 14)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.targetEntityId = ReadU64(payload, 4);
+		size_t offset = 12;
+		// Borne dure défensive : un spellId fait < 64 octets (ids snake_case).
+		if (!ReadSizedString(payload, offset, outMessage.spellId)
+			|| outMessage.spellId.empty()
+			|| outMessage.spellId.size() > 64u
+			|| offset != payload.size())
+		{
+			return false;
+		}
+		return true;
+	}
+
+	std::vector<std::byte> EncodeResourceUpdate(const ResourceUpdateMessage& message)
+	{
+		// Combat SP3 — payload fixe 12 octets.
+		std::vector<std::byte> packet = BeginPacket(MessageKind::ResourceUpdate, 12);
+		WriteU32(packet, message.clientId);
+		WriteU32(packet, message.currentResource);
+		WriteU32(packet, message.maxResource);
+		return packet;
+	}
+
+	bool DecodeResourceUpdate(std::span<const std::byte> packet, ResourceUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::ResourceUpdate, payload) || payload.size() != 12)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.currentResource = ReadU32(payload, 4);
+		outMessage.maxResource = ReadU32(payload, 8);
+		return true;
+	}
+
+	std::vector<std::byte> EncodeCastBarUpdate(const CastBarUpdateMessage& message)
+	{
+		// Combat SP3 — payload : clientId (4) + status (1) + durationMs (4) + spellId (2 + N).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::CastBarUpdate, 11 + message.spellId.size());
+		WriteU32(packet, message.clientId);
+		WriteU8(packet, message.status);
+		WriteU32(packet, message.durationMs);
+		WriteSizedString(packet, message.spellId);
+		return packet;
+	}
+
+	bool DecodeCastBarUpdate(std::span<const std::byte> packet, CastBarUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::CastBarUpdate, payload) || payload.size() < 11)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.status = ReadU8(payload, 4);
+		outMessage.durationMs = ReadU32(payload, 5);
+		size_t offset = 9;
+		if (!ReadSizedString(payload, offset, outMessage.spellId)
+			|| outMessage.spellId.size() > 64u
+			|| offset != payload.size())
+		{
+			return false;
+		}
+		return outMessage.status <= kCastBarStatusCancel;
+	}
+
+	std::vector<std::byte> EncodeAuraUpdate(const AuraUpdateMessage& message)
+	{
+		// Combat SP3 — payload : targetEntityId (8) + count (1) puis par aura :
+		// spellId (2 + N) + effectType (1) + remainingMs (4) + stacks (1).
+		size_t payloadSize = 9;
+		for (const AuraWireEntry& aura : message.auras)
+		{
+			payloadSize += 2 + aura.spellId.size() + 6;
+		}
+		std::vector<std::byte> packet = BeginPacket(MessageKind::AuraUpdate, payloadSize);
+		WriteU64(packet, message.targetEntityId);
+		WriteU8(packet, static_cast<uint8_t>(std::min<size_t>(message.auras.size(), 0xFFu)));
+		for (const AuraWireEntry& aura : message.auras)
+		{
+			WriteSizedString(packet, aura.spellId);
+			WriteU8(packet, aura.effectType);
+			WriteU32(packet, aura.remainingMs);
+			WriteU8(packet, aura.stacks);
+		}
+		return packet;
+	}
+
+	bool DecodeAuraUpdate(std::span<const std::byte> packet, AuraUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::AuraUpdate, payload) || payload.size() < 9)
+		{
+			return false;
+		}
+
+		outMessage.targetEntityId = ReadU64(payload, 0);
+		const size_t auraCount = static_cast<size_t>(ReadU8(payload, 8));
+		size_t offset = 9;
+		outMessage.auras.clear();
+		outMessage.auras.reserve(auraCount);
+		for (size_t index = 0; index < auraCount; ++index)
+		{
+			AuraWireEntry aura{};
+			if (!ReadSizedString(payload, offset, aura.spellId)
+				|| aura.spellId.empty()
+				|| aura.spellId.size() > 64u)
+			{
+				outMessage.auras.clear();
+				return false;
+			}
+			if (offset + 6u > payload.size())
+			{
+				outMessage.auras.clear();
+				return false;
+			}
+			aura.effectType = ReadU8(payload, offset);
+			offset += 1;
+			aura.remainingMs = ReadU32(payload, offset);
+			offset += 4;
+			aura.stacks = ReadU8(payload, offset);
+			offset += 1;
+			outMessage.auras.push_back(std::move(aura));
+		}
+
+		return offset == payload.size();
 	}
 
 	std::vector<std::byte> EncodeInventoryDelta(const InventoryDeltaMessage& message, std::span<const ItemStack> items)

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -45,7 +45,12 @@ namespace engine::server
 	/// bit0 critique, bit1 raté ; payload 32 → 36 o) et nouveau kind
 	/// `RespawnRequest` (80, client→shard, réapparition d'un joueur mort).
 	/// Wire-breaking : même contrainte lock-step master + shardd + client.
-	inline constexpr uint16_t kProtocolVersion = 10;
+	/// Combat SP3 — bump 10 → 11 : sorts et auras. Nouveaux kinds `CastRequest`
+	/// (81), `ResourceUpdate` (82), `CastBarUpdate` (83), `AuraUpdate` (84) ;
+	/// `PlayerStatsMessage` gagne `profileId` (chaîne préfixée u16 en queue —
+	/// le client résout son kit de sorts gameplay/spells/<profil>.json).
+	/// Wire-breaking : lock-step master + shardd + client.
+	inline constexpr uint16_t kProtocolVersion = 11;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -224,7 +229,19 @@ namespace engine::server
 		/// Combat SP2 — client → shard : réapparition d'un joueur mort (téléport au
 		/// spawn mémorisé à l'admission, PV pleins, flag dead retiré). Refusé si le
 		/// joueur n'est pas mort. Livré avec le bump v9→v10.
-		RespawnRequest = 80
+		RespawnRequest = 80,
+
+		// Combat SP3 — sorts et auras (bump v10→v11) ------------------------
+
+		/// Client → shard : cast d'un sort du kit du profil (spellId + cible).
+		CastRequest = 81,
+		/// Shard → casteur : ressource secondaire courante/max (régén, coûts).
+		ResourceUpdate = 82,
+		/// Shard → casteur : barre de cast (début / fin / annulation).
+		CastBarUpdate = 83,
+		/// Shard → clients intéressés : liste complète des auras d'une entité
+		/// (idempotent — remplace l'état précédent côté client).
+		AuraUpdate = 84
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -286,6 +303,10 @@ namespace engine::server
 		float    perception = 0.0f;
 		float    stealth = 0.0f;
 		std::string resourceKey; ///< ex. "ferveur" (libellé résolu côté client)
+		/// Combat SP3 (wire v11) — profil de classe ("melee", "tank", …) ; le
+		/// client résout son kit de sorts gameplay/spells/<profil>.json. Vide =
+		/// perso legacy sans faction/classe → pas de barre d'action.
+		std::string profileId;
 	};
 
 	/// Snapshot envelope carrying timing, connection stats and entity state count.
@@ -345,6 +366,58 @@ namespace engine::server
 	struct RespawnRequestMessage
 	{
 		uint32_t clientId = 0;
+	};
+
+	// Combat SP3 — sorts et auras (wire v11) --------------------------------
+
+	/// Client → shard : cast d'un sort du kit du profil du joueur.
+	/// targetEntityId = 0 pour les sorts sans cible (SelfOnly / AreaAroundSelf) ;
+	/// pour SingleAlly, 0 = soi.
+	struct CastRequestMessage
+	{
+		uint32_t clientId = 0;
+		EntityId targetEntityId = 0;
+		std::string spellId;
+	};
+
+	/// Shard → casteur : ressource secondaire courante (poussée sur variation).
+	struct ResourceUpdateMessage
+	{
+		uint32_t clientId = 0;
+		uint32_t currentResource = 0;
+		uint32_t maxResource = 0;
+	};
+
+	/// Combat SP3 — états de la barre de cast (CastBarUpdateMessage::status).
+	inline constexpr uint8_t kCastBarStatusStart = 0;
+	inline constexpr uint8_t kCastBarStatusComplete = 1;
+	inline constexpr uint8_t kCastBarStatusCancel = 2;
+
+	/// Shard → casteur : début / fin / annulation d'un cast à temps d'incantation.
+	struct CastBarUpdateMessage
+	{
+		uint32_t clientId = 0;
+		uint8_t status = kCastBarStatusStart;
+		/// Durée totale du cast en ms (status Start) ; 0 sinon.
+		uint32_t durationMs = 0;
+		std::string spellId;
+	};
+
+	/// Une aura active répliquée (cf. SpellEffectType côté shardd pour effectType).
+	struct AuraWireEntry
+	{
+		std::string spellId;
+		uint8_t effectType = 0;
+		uint32_t remainingMs = 0;
+		uint8_t stacks = 1;
+	};
+
+	/// Shard → clients intéressés : liste COMPLÈTE des auras d'une entité
+	/// (le client remplace son état local — pas de delta, idempotent).
+	struct AuraUpdateMessage
+	{
+		EntityId targetEntityId = 0;
+		std::vector<AuraWireEntry> auras;
 	};
 
 	/// Client request asking the authoritative server to pick up one loot bag entity.
@@ -494,6 +567,16 @@ namespace engine::server
 
 	/// Combat SP2 — decode a respawn request packet and validate the protocol header.
 	bool DecodeRespawnRequest(std::span<const std::byte> packet, RespawnRequestMessage& outMessage);
+
+	/// Combat SP3 — encode/decode des messages sorts et auras (wire v11).
+	std::vector<std::byte> EncodeCastRequest(const CastRequestMessage& message);
+	bool DecodeCastRequest(std::span<const std::byte> packet, CastRequestMessage& outMessage);
+	std::vector<std::byte> EncodeResourceUpdate(const ResourceUpdateMessage& message);
+	bool DecodeResourceUpdate(std::span<const std::byte> packet, ResourceUpdateMessage& outMessage);
+	std::vector<std::byte> EncodeCastBarUpdate(const CastBarUpdateMessage& message);
+	bool DecodeCastBarUpdate(std::span<const std::byte> packet, CastBarUpdateMessage& outMessage);
+	std::vector<std::byte> EncodeAuraUpdate(const AuraUpdateMessage& message);
+	bool DecodeAuraUpdate(std::span<const std::byte> packet, AuraUpdateMessage& outMessage);
 
 	/// Encode a combat event packet with the protocol header.
 	std::vector<std::byte> EncodeCombatEvent(const CombatEventMessage& message);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -419,9 +419,10 @@ namespace
 		assert(out.durationMs == 1500u);
 		assert(out.spellId == "distance_tir_vise");
 
-		// status hors domaine rejeté (octet 4 du payload, après le header 16 o).
+		// status hors domaine rejeté. Offset absolu = header 8 octets (magic u32
+		// + version u16 + kind u16, cf. kHeaderSize) + 4 (clientId) = 12.
 		std::vector<std::byte> badStatus = packet;
-		badStatus[16 + 4] = static_cast<std::byte>(9);
+		badStatus[8 + 4] = static_cast<std::byte>(9);
 		assert(!engine::server::DecodeCastBarUpdate(badStatus, out));
 		std::puts("[OK] TestCastBarUpdateRoundTrip");
 	}

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -363,6 +363,128 @@ namespace
 		std::puts("[OK] TestRespawnRequestRoundTrip");
 	}
 
+	/// Combat SP3 (wire v11) — round-trips des messages sorts/auras + rejets tronqués.
+	void TestCastRequestRoundTrip()
+	{
+		engine::server::CastRequestMessage in{};
+		in.clientId = 7u;
+		in.targetEntityId = 0x300000005ull;
+		in.spellId = "melee_frappe_brutale";
+
+		const std::vector<std::byte> packet = engine::server::EncodeCastRequest(in);
+		assert(!packet.empty());
+
+		engine::server::CastRequestMessage out{};
+		assert(engine::server::DecodeCastRequest(packet, out));
+		assert(out.clientId == 7u);
+		assert(out.targetEntityId == 0x300000005ull);
+		assert(out.spellId == "melee_frappe_brutale");
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 3u);
+		assert(!engine::server::DecodeCastRequest(truncated, out));
+		std::puts("[OK] TestCastRequestRoundTrip");
+	}
+
+	void TestResourceUpdateRoundTrip()
+	{
+		engine::server::ResourceUpdateMessage in{};
+		in.clientId = 7u;
+		in.currentResource = 120u;
+		in.maxResource = 200u;
+
+		const std::vector<std::byte> packet = engine::server::EncodeResourceUpdate(in);
+		engine::server::ResourceUpdateMessage out{};
+		assert(engine::server::DecodeResourceUpdate(packet, out));
+		assert(out.clientId == 7u && out.currentResource == 120u && out.maxResource == 200u);
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 2u);
+		assert(!engine::server::DecodeResourceUpdate(truncated, out));
+		std::puts("[OK] TestResourceUpdateRoundTrip");
+	}
+
+	void TestCastBarUpdateRoundTrip()
+	{
+		engine::server::CastBarUpdateMessage in{};
+		in.clientId = 7u;
+		in.status = engine::server::kCastBarStatusStart;
+		in.durationMs = 1500u;
+		in.spellId = "distance_tir_vise";
+
+		const std::vector<std::byte> packet = engine::server::EncodeCastBarUpdate(in);
+		engine::server::CastBarUpdateMessage out{};
+		assert(engine::server::DecodeCastBarUpdate(packet, out));
+		assert(out.status == engine::server::kCastBarStatusStart);
+		assert(out.durationMs == 1500u);
+		assert(out.spellId == "distance_tir_vise");
+
+		// status hors domaine rejeté (octet 4 du payload, après le header 16 o).
+		std::vector<std::byte> badStatus = packet;
+		badStatus[16 + 4] = static_cast<std::byte>(9);
+		assert(!engine::server::DecodeCastBarUpdate(badStatus, out));
+		std::puts("[OK] TestCastBarUpdateRoundTrip");
+	}
+
+	void TestAuraUpdateRoundTrip()
+	{
+		engine::server::AuraUpdateMessage in{};
+		in.targetEntityId = 0x300000005ull;
+		engine::server::AuraWireEntry dot{};
+		dot.spellId = "melee_entaille";
+		dot.effectType = 1u; // DamageOverTime
+		dot.remainingMs = 6000u;
+		dot.stacks = 1u;
+		in.auras.push_back(dot);
+		engine::server::AuraWireEntry slow{};
+		slow.spellId = "tank_coup_de_bouclier";
+		slow.effectType = 7u; // SlowMobPercent
+		slow.remainingMs = 4000u;
+		slow.stacks = 1u;
+		in.auras.push_back(slow);
+
+		const std::vector<std::byte> packet = engine::server::EncodeAuraUpdate(in);
+		engine::server::AuraUpdateMessage out{};
+		assert(engine::server::DecodeAuraUpdate(packet, out));
+		assert(out.targetEntityId == in.targetEntityId);
+		assert(out.auras.size() == 2u);
+		assert(out.auras[0].spellId == "melee_entaille" && out.auras[0].remainingMs == 6000u);
+		assert(out.auras[1].effectType == 7u);
+
+		// Liste vide : valide (toutes les auras expirées → le client purge).
+		engine::server::AuraUpdateMessage empty{};
+		empty.targetEntityId = 42u;
+		const std::vector<std::byte> emptyPacket = engine::server::EncodeAuraUpdate(empty);
+		assert(engine::server::DecodeAuraUpdate(emptyPacket, out));
+		assert(out.targetEntityId == 42u && out.auras.empty());
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeAuraUpdate(truncated, out));
+		std::puts("[OK] TestAuraUpdateRoundTrip");
+	}
+
+	/// Combat SP3 (wire v11) — PlayerStats porte désormais profileId en queue.
+	void TestPlayerStatsRoundTripWithProfile()
+	{
+		engine::server::PlayerStatsMessage in{};
+		in.clientId = 7u;
+		in.maxHealth = 250u;
+		in.resource = 120u;
+		in.damage = 22u;
+		in.accuracy = 82.5f;
+		in.resourceKey = "ferveur";
+		in.profileId = "sacre";
+
+		const std::vector<std::byte> packet = engine::server::EncodePlayerStats(in);
+		engine::server::PlayerStatsMessage out{};
+		assert(engine::server::DecodePlayerStats(packet, out));
+		assert(out.clientId == 7u && out.maxHealth == 250u && out.resource == 120u);
+		assert(out.resourceKey == "ferveur");
+		assert(out.profileId == "sacre");
+		std::puts("[OK] TestPlayerStatsRoundTripWithProfile");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
@@ -376,6 +498,11 @@ int main()
 	TestCombatEventRoundTripWithFlags();
 	TestAttackRequestRoundTrip();
 	TestRespawnRequestRoundTrip();
+	TestCastRequestRoundTrip();
+	TestResourceUpdateRoundTrip();
+	TestCastBarUpdateRoundTrip();
+	TestAuraUpdateRoundTrip();
+	TestPlayerStatsRoundTripWithProfile();
 	std::puts("All ServerProtocol tests passed");
 	return 0;
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -201,6 +201,58 @@ namespace engine::server
 			}
 		}
 
+		/// Combat SP3 — horloge monotone en millisecondes (référence commune des
+		/// cooldowns de sorts, casts et expirations d'auras).
+		uint64_t NowMonotonicMs()
+		{
+			return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+
+		/// Combat SP3 — somme des pourcentages des auras d'un type donné (0 si aucune).
+		float SumAuraPercent(const std::vector<ActiveAura>& auras, SpellEffectType type)
+		{
+			float total = 0.0f;
+			for (const ActiveAura& aura : auras)
+			{
+				if (aura.type == type)
+				{
+					total += aura.percent;
+				}
+			}
+			return total;
+		}
+
+		/// Combat SP3 — applique les modificateurs d'auras à un jet de dégâts :
+		/// × (1 + buffs de dégâts de l'attaquant) × (1 + dégâts subis de la cible).
+		uint32_t ApplyAuraDamageModifiers(
+			uint32_t baseDamage,
+			const std::vector<ActiveAura>& attackerAuras,
+			const std::vector<ActiveAura>& targetAuras)
+		{
+			const float attackerBonus = SumAuraPercent(attackerAuras, SpellEffectType::BuffDamagePercent);
+			const float takenBonus = SumAuraPercent(targetAuras, SpellEffectType::DebuffDamageTakenPercent);
+			const double modified = static_cast<double>(baseDamage)
+				* (1.0 + static_cast<double>(attackerBonus) / 100.0)
+				* (1.0 + static_cast<double>(takenBonus) / 100.0);
+			return static_cast<uint32_t>(std::llround(modified));
+		}
+
+		/// Combat SP3 — insère ou rafraîchit une aura (même spellId + même casteur
+		/// = refresh de la durée, pas d'empilement en V1).
+		void UpsertAura(std::vector<ActiveAura>& auras, ActiveAura&& aura)
+		{
+			for (ActiveAura& existing : auras)
+			{
+				if (existing.spellId == aura.spellId && existing.casterEntityId == aura.casterEntityId)
+				{
+					existing = std::move(aura);
+					return;
+				}
+			}
+			auras.push_back(std::move(aura));
+		}
+
 		/// Combat SP2 — copie les stats dérivées du moteur de personnages dans le
 		/// composant combat du joueur (enter-world + level-up). range 0 = mêlée
 		/// pure → on conserve la portée de mêlée MVP (kDefaultAttackRangeMeters).
@@ -749,6 +801,14 @@ namespace engine::server
 		if (DecodeRespawnRequest(packetBytes, respawnRequest))
 		{
 			HandleRespawnRequest(datagram.endpoint, respawnRequest.clientId);
+			return;
+		}
+
+		// Combat SP3 — cast d'un sort du kit du profil.
+		CastRequestMessage castRequest{};
+		if (DecodeCastRequest(packetBytes, castRequest))
+		{
+			HandleCastRequest(datagram.endpoint, castRequest);
 			return;
 		}
 
@@ -1675,8 +1735,11 @@ namespace engine::server
 		ProcessAuctionHouseTick();
 		TickGathering();
 		TickCrafting();
-		// Combat SP3 — régénération de la ressource secondaire des joueurs.
+		// Combat SP3 — régénération de la ressource secondaire des joueurs,
+		// avancement des casts en cours et tick des auras (DoT/HoT/expirations).
 		RegenerateResources();
+		TickActiveCasts();
+		TickAuras();
 		LOG_TRACE(Core, "[ServerApp] Simulate tick {}", m_currentTick);
 	}
 
@@ -2827,30 +2890,40 @@ namespace engine::server
 			return;
 		}
 
-		const uint32_t appliedDamage = std::min(roll.damage, target->stats.currentHealth);
+		// Combat SP3 — modificateurs d'auras (buff de l'attaquant, debuff de la
+		// cible) appliqués au jet, puis chemin commun dégâts/mort/loot/XP.
+		const uint32_t modifiedDamage = ApplyAuraDamageModifiers(roll.damage, client->auras, target->auras);
+		ApplyPlayerDamageToMob(*client, *target, modifiedDamage, eventFlags);
+	}
+
+	void ServerApp::ApplyPlayerDamageToMob(ConnectedClient& attacker, MobEntity& target, uint32_t rolledDamage, uint32_t eventFlags)
+	{
+		const uint32_t appliedDamage = std::min(rolledDamage, target.stats.currentHealth);
 		if (appliedDamage == 0)
 		{
-			LOG_WARN(Net, "[ServerApp] AttackRequest ignored: zero damage after validation (client_id={}, target_entity_id={})",
-				client->clientId,
-				target->entityId);
+			LOG_DEBUG(Net, "[ServerApp] Damage ignored: zero after clamp (client_id={}, target_entity_id={})",
+				attacker.clientId,
+				target.entityId);
 			return;
 		}
 
-		target->stats.currentHealth -= appliedDamage;
-		if (target->isDynamicEventMob && target->owningEventIndex < m_dynamicEvents.size())
+		target.stats.currentHealth -= appliedDamage;
+		if (target.isDynamicEventMob && target.owningEventIndex < m_dynamicEvents.size())
 		{
-			DynamicEventState& eventState = m_dynamicEvents[target->owningEventIndex];
-			AddDynamicEventParticipant(eventState, *client);
+			DynamicEventState& eventState = m_dynamicEvents[target.owningEventIndex];
+			AddDynamicEventParticipant(eventState, attacker);
 		}
-		if (target->stats.currentHealth == 0)
+		if (target.stats.currentHealth == 0)
 		{
-			target->stateFlags |= kEntityStateDead;
-			target->pendingDespawn = true;
-			target->aggroTargetEntityId = 0;
-			target->threatTable.clear();
-			if (target->isDynamicEventMob && target->owningEventIndex < m_dynamicEvents.size())
+			target.stateFlags |= kEntityStateDead;
+			target.pendingDespawn = true;
+			target.aggroTargetEntityId = 0;
+			target.threatTable.clear();
+			// Combat SP3 — plus rien à ticker sur un mob mort.
+			target.auras.clear();
+			if (target.isDynamicEventMob && target.owningEventIndex < m_dynamicEvents.size())
 			{
-				DynamicEventState& eventState = m_dynamicEvents[target->owningEventIndex];
+				DynamicEventState& eventState = m_dynamicEvents[target.owningEventIndex];
 				if (eventState.currentPhaseIndex < eventState.definition.phases.size())
 				{
 					++eventState.currentPhaseProgress;
@@ -2863,41 +2936,40 @@ namespace engine::server
 					BroadcastDynamicEventState(eventState, phase.notificationText, 0, 0, 0, {});
 				}
 			}
-			LOG_INFO(Net, "[ServerApp] Mob died (entity_id={}, attacker_entity_id={})", target->entityId, client->entityId);
-			if (!target->hasSpawnedLoot)
+			LOG_INFO(Net, "[ServerApp] Mob died (entity_id={}, attacker_entity_id={})", target.entityId, attacker.entityId);
+			if (!target.hasSpawnedLoot)
 			{
-				target->hasSpawnedLoot = true;
+				target.hasSpawnedLoot = true;
 				// M32.2 — Resolve loot owner based on party loot mode.
-				const EntityId looterEntityId = ResolvePartyLooterEntityId(*client);
-				SpawnLootBagForMob(*target, looterEntityId != 0 ? looterEntityId : client->entityId);
+				const EntityId looterEntityId = ResolvePartyLooterEntityId(attacker);
+				SpawnLootBagForMob(target, looterEntityId != 0 ? looterEntityId : attacker.entityId);
 			}
 			// M32.2 — Distribute XP to party members in range.
 			// Combat SP1 — XP data-driven par archétype (fallback constante MVP
 			// pour un mob dont l'archétype ne définit pas de récompense).
-			DistributePartyXp(*client,
-			    target->positionMetersX,
-			    target->positionMetersZ,
-			    target->xpReward != 0u ? target->xpReward : kBaseXpPerMobKill);
-			ApplyQuestEvent(*client, QuestStepType::Kill, std::string("mob:") + std::to_string(target->archetypeId), 1, "kill");
+			DistributePartyXp(attacker,
+			    target.positionMetersX,
+			    target.positionMetersZ,
+			    target.xpReward != 0u ? target.xpReward : kBaseXpPerMobKill);
+			ApplyQuestEvent(attacker, QuestStepType::Kill, std::string("mob:") + std::to_string(target.archetypeId), 1, "kill");
 		}
 
 		CombatEventMessage combatEvent{};
-		combatEvent.attackerEntityId = client->entityId;
-		combatEvent.targetEntityId = target->entityId;
+		combatEvent.attackerEntityId = attacker.entityId;
+		combatEvent.targetEntityId = target.entityId;
 		combatEvent.damage = appliedDamage;
-		combatEvent.targetCurrentHealth = target->stats.currentHealth;
-		combatEvent.targetMaxHealth = target->stats.maxHealth;
-		combatEvent.targetStateFlags = target->stateFlags;
+		combatEvent.targetCurrentHealth = target.stats.currentHealth;
+		combatEvent.targetMaxHealth = target.stats.maxHealth;
+		combatEvent.targetStateFlags = target.stateFlags;
 		// Combat SP2 — bit critique éventuel (le raté est parti plus haut).
 		combatEvent.flags = eventFlags;
 		LOG_INFO(Net,
-			"[ServerApp] Attack applied (attacker_entity_id={}, target_entity_id={}, damage={}, hp={}/{}, next_attack_tick={})",
+			"[ServerApp] Attack applied (attacker_entity_id={}, target_entity_id={}, damage={}, hp={}/{})",
 			combatEvent.attackerEntityId,
 			combatEvent.targetEntityId,
 			combatEvent.damage,
 			combatEvent.targetCurrentHealth,
-			combatEvent.targetMaxHealth,
-			client->combat.nextAttackTick);
+			combatEvent.targetMaxHealth);
 		BroadcastCombatEvent(combatEvent);
 	}
 
@@ -3501,7 +3573,11 @@ namespace engine::server
 
 		const uint32_t intervalTicks = ResolveMobAiIntervalTicks();
 		const float simulationDt = static_cast<float>(intervalTicks) / static_cast<float>(m_tickHz);
-		const float maxStep = mob.moveSpeedMetersPerSecond * simulationDt;
+		// Combat SP3 — ralentissements actifs (SlowMobPercent cumulés, plancher
+		// 10 % de la vitesse de base ; la valeur de base n'est jamais écrasée).
+		const float slowFactor = std::clamp(
+			1.0f - SumAuraPercent(mob.auras, SpellEffectType::SlowMobPercent) / 100.0f, 0.1f, 1.0f);
+		const float maxStep = mob.moveSpeedMetersPerSecond * slowFactor * simulationDt;
 		const float distance = std::sqrt(distanceSquared);
 		if (distance <= maxStep)
 		{
@@ -3641,6 +3717,582 @@ namespace engine::server
 			const uint32_t whole = static_cast<uint32_t>(client.resourceRegenCarry);
 			client.resourceRegenCarry -= static_cast<float>(whole);
 			client.currentResource = std::min(client.maxResource, client.currentResource + whole);
+			// Push throttlé (≤ 1 / 500 ms) — le débit d'un cast force l'envoi, lui.
+			SendResourceUpdate(client, false);
+		}
+	}
+
+	void ServerApp::SendResourceUpdate(ConnectedClient& client, bool force)
+	{
+		const uint64_t nowMs = NowMonotonicMs();
+		if (!force)
+		{
+			if ((nowMs - client.lastResourceUpdateSentMs) < 500u)
+			{
+				return;
+			}
+			if (client.currentResource == client.lastResourceUpdateSentValue)
+			{
+				return;
+			}
+		}
+
+		ResourceUpdateMessage message{};
+		message.clientId = client.clientId;
+		message.currentResource = client.currentResource;
+		message.maxResource = client.maxResource;
+		if (!m_transport.Send(client.endpoint, EncodeResourceUpdate(message)))
+		{
+			LOG_WARN(Net, "[ServerApp] ResourceUpdate send failed (client_id={})", client.clientId);
+			return;
+		}
+		client.lastResourceUpdateSentMs = nowMs;
+		client.lastResourceUpdateSentValue = client.currentResource;
+	}
+
+	void ServerApp::HandleCastRequest(const Endpoint& endpoint, const CastRequestMessage& message)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != message.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: client_id mismatch (expected={}, got={})",
+				client->clientId, message.clientId);
+			return;
+		}
+
+		if ((client->stateFlags & kEntityStateDead) != 0u)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: caster is dead (client_id={})", client->clientId);
+			return;
+		}
+
+		if (client->profileId.empty())
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: no class profile (client_id={})", client->clientId);
+			return;
+		}
+
+		const SpellDef* spell = m_spellKits.FindSpell(client->profileId, message.spellId);
+		if (spell == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: spell '{}' not in kit '{}' (client_id={})",
+				message.spellId, client->profileId, client->clientId);
+			return;
+		}
+
+		if (!client->activeCastSpellId.empty())
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: cast already in progress (client_id={})", client->clientId);
+			return;
+		}
+
+		const uint64_t nowMs = NowMonotonicMs();
+		const auto cooldownIt = client->spellCooldownUntilMs.find(spell->spellId);
+		if (cooldownIt != client->spellCooldownUntilMs.end() && nowMs < cooldownIt->second)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: spell on cooldown (client_id={}, spell={})",
+				client->clientId, spell->spellId);
+			return;
+		}
+
+		const uint32_t cost = spell->resourceCostPercent * client->maxResource / 100u;
+		if (client->currentResource < cost)
+		{
+			LOG_WARN(Net, "[ServerApp] CastRequest ignored: not enough resource (client_id={}, spell={}, cost={}, current={})",
+				client->clientId, spell->spellId, cost, client->currentResource);
+			return;
+		}
+
+		// Résolution et validation de la cible selon le type du sort.
+		// rangeMeters 0 = mêlée → portée d'auto-attaque du joueur.
+		const float range = (spell->rangeMeters > 0.0f) ? spell->rangeMeters : client->combat.attackRangeMeters;
+		EntityId resolvedTarget = 0;
+		if (spell->targetType == SpellTargetKind::SingleEnemy)
+		{
+			MobEntity* target = FindMobByEntityId(message.targetEntityId);
+			if (target == nullptr || target->zoneId != client->zoneId
+				|| (target->stateFlags & kEntityStateDead) != 0u || target->stats.currentHealth == 0)
+			{
+				LOG_WARN(Net, "[ServerApp] CastRequest ignored: invalid enemy target (client_id={}, target_entity_id={})",
+					client->clientId, message.targetEntityId);
+				return;
+			}
+			const float distanceSquared = DistanceSquaredXZ(
+				client->positionMetersX, client->positionMetersZ,
+				target->positionMetersX, target->positionMetersZ);
+			if (distanceSquared > range * range)
+			{
+				LOG_WARN(Net, "[ServerApp] CastRequest ignored: target out of range (client_id={}, spell={})",
+					client->clientId, spell->spellId);
+				return;
+			}
+			resolvedTarget = target->entityId;
+		}
+		else if (spell->targetType == SpellTargetKind::SingleAlly)
+		{
+			// Défaut : soi. Un membre du même groupe vivant et à portée est accepté.
+			resolvedTarget = client->entityId;
+			if (message.targetEntityId != 0 && message.targetEntityId != client->entityId)
+			{
+				if (ConnectedClient* ally = FindClientByEntityId(message.targetEntityId))
+				{
+					const Party* casterParty = m_partySystem.FindPartyByMember(client->clientId);
+					const bool sameParty = casterParty != nullptr
+						&& m_partySystem.FindPartyByMember(ally->clientId) == casterParty;
+					const float allyDistanceSquared = DistanceSquaredXZ(
+						client->positionMetersX, client->positionMetersZ,
+						ally->positionMetersX, ally->positionMetersZ);
+					if (sameParty && (ally->stateFlags & kEntityStateDead) == 0u
+						&& allyDistanceSquared <= range * range)
+					{
+						resolvedTarget = ally->entityId;
+					}
+				}
+			}
+		}
+		// SelfOnly / AreaAroundSelf : pas de cible (résolus autour du casteur).
+
+		if (spell->castTimeMs == 0)
+		{
+			ResolveSpellCast(*client, *spell, resolvedTarget);
+			return;
+		}
+
+		// Cast à incantation : armé, résolu/annulé par TickActiveCasts.
+		client->activeCastSpellId = spell->spellId;
+		client->castFinishAtMs = nowMs + spell->castTimeMs;
+		client->castStartPosX = client->positionMetersX;
+		client->castStartPosZ = client->positionMetersZ;
+		client->castTargetEntityId = resolvedTarget;
+
+		CastBarUpdateMessage castBar{};
+		castBar.clientId = client->clientId;
+		castBar.status = kCastBarStatusStart;
+		castBar.durationMs = spell->castTimeMs;
+		castBar.spellId = spell->spellId;
+		(void)m_transport.Send(client->endpoint, EncodeCastBarUpdate(castBar));
+		LOG_INFO(Net, "[ServerApp] Cast started (client_id={}, spell={}, duration_ms={})",
+			client->clientId, spell->spellId, spell->castTimeMs);
+	}
+
+	void ServerApp::TickActiveCasts()
+	{
+		const uint64_t nowMs = NowMonotonicMs();
+		for (ConnectedClient& client : m_clients)
+		{
+			if (client.activeCastSpellId.empty())
+			{
+				continue;
+			}
+
+			const bool casterDead = (client.stateFlags & kEntityStateDead) != 0u;
+			const float dx = client.positionMetersX - client.castStartPosX;
+			const float dz = client.positionMetersZ - client.castStartPosZ;
+			// Annulation au déplacement > 0,5 m (décision plan SP3) ou à la mort.
+			const bool moved = (dx * dx + dz * dz) > 0.25f;
+			if (casterDead || moved)
+			{
+				CastBarUpdateMessage cancel{};
+				cancel.clientId = client.clientId;
+				cancel.status = kCastBarStatusCancel;
+				cancel.spellId = client.activeCastSpellId;
+				(void)m_transport.Send(client.endpoint, EncodeCastBarUpdate(cancel));
+				LOG_INFO(Net, "[ServerApp] Cast cancelled (client_id={}, spell={}, reason={})",
+					client.clientId, client.activeCastSpellId, casterDead ? "dead" : "moved");
+				client.activeCastSpellId.clear();
+				client.castFinishAtMs = 0;
+				client.castTargetEntityId = 0;
+				continue;
+			}
+
+			if (nowMs < client.castFinishAtMs)
+			{
+				continue;
+			}
+
+			const SpellDef* spell = m_spellKits.FindSpell(client.profileId, client.activeCastSpellId);
+			const EntityId target = client.castTargetEntityId;
+			const std::string finishedSpellId = client.activeCastSpellId;
+			client.activeCastSpellId.clear();
+			client.castFinishAtMs = 0;
+			client.castTargetEntityId = 0;
+			if (spell == nullptr)
+			{
+				continue;
+			}
+
+			CastBarUpdateMessage complete{};
+			complete.clientId = client.clientId;
+			complete.status = kCastBarStatusComplete;
+			complete.spellId = finishedSpellId;
+			(void)m_transport.Send(client.endpoint, EncodeCastBarUpdate(complete));
+			ResolveSpellCast(client, *spell, target);
+		}
+	}
+
+	void ServerApp::ResolveSpellCast(ConnectedClient& client, const SpellDef& spell, EntityId targetEntityId)
+	{
+		const uint64_t nowMs = NowMonotonicMs();
+		// Débit (clamp défensif : la ressource a pu varier pendant l'incantation)
+		// + cooldown. Validations de cible faites à la demande ; une cible morte
+		// entre-temps rend les effets ciblés no-op (le coût reste dû).
+		const uint32_t cost = spell.resourceCostPercent * client.maxResource / 100u;
+		client.currentResource = (client.currentResource >= cost) ? (client.currentResource - cost) : 0u;
+		SendResourceUpdate(client, true);
+		if (spell.cooldownMs > 0)
+		{
+			client.spellCooldownUntilMs[spell.spellId] = nowMs + spell.cooldownMs;
+		}
+
+		bool casterAurasChanged = false;
+		for (const SpellEffectDef& effect : spell.effects)
+		{
+			switch (effect.type)
+			{
+			case SpellEffectType::DirectDamage:
+			{
+				const uint32_t baseDamage = static_cast<uint32_t>(
+					std::llround(static_cast<double>(effect.mult) * static_cast<double>(client.combat.damagePerHit)));
+				if (spell.targetType == SpellTargetKind::AreaAroundSelf)
+				{
+					const float radiusSquared = spell.areaRadiusMeters * spell.areaRadiusMeters;
+					for (MobEntity& mob : m_mobs)
+					{
+						if (mob.zoneId != client.zoneId || mob.pendingDespawn
+							|| (mob.stateFlags & kEntityStateDead) != 0u || mob.stats.currentHealth == 0)
+						{
+							continue;
+						}
+						const float distanceSquared = DistanceSquaredXZ(
+							client.positionMetersX, client.positionMetersZ,
+							mob.positionMetersX, mob.positionMetersZ);
+						if (distanceSquared > radiusSquared)
+						{
+							continue;
+						}
+						const combat::AttackRollResult roll = combat::ResolveAttackRoll(
+							baseDamage, client.combat.accuracy, client.combat.critRate,
+							client.combat.critMult, NextCombatRoll01(), NextCombatRoll01());
+						if (roll.miss)
+						{
+							continue; // V1 : pas d'event raté par cible AoE (anti-spam log).
+						}
+						uint32_t eventFlags = roll.crit ? kCombatEventFlagCrit : 0u;
+						ApplyPlayerDamageToMob(client, mob,
+							ApplyAuraDamageModifiers(roll.damage, client.auras, mob.auras), eventFlags);
+					}
+				}
+				else if (MobEntity* target = FindMobByEntityId(targetEntityId))
+				{
+					if ((target->stateFlags & kEntityStateDead) == 0u && target->stats.currentHealth > 0)
+					{
+						const combat::AttackRollResult roll = combat::ResolveAttackRoll(
+							baseDamage, client.combat.accuracy, client.combat.critRate,
+							client.combat.critMult, NextCombatRoll01(), NextCombatRoll01());
+						uint32_t eventFlags = 0u;
+						if (roll.miss) eventFlags |= kCombatEventFlagMiss;
+						if (roll.crit) eventFlags |= kCombatEventFlagCrit;
+						if (roll.miss)
+						{
+							CombatEventMessage missEvent{};
+							missEvent.attackerEntityId = client.entityId;
+							missEvent.targetEntityId = target->entityId;
+							missEvent.targetCurrentHealth = target->stats.currentHealth;
+							missEvent.targetMaxHealth = target->stats.maxHealth;
+							missEvent.targetStateFlags = target->stateFlags;
+							missEvent.flags = eventFlags;
+							BroadcastCombatEvent(missEvent);
+						}
+						else
+						{
+							ApplyPlayerDamageToMob(client, *target,
+								ApplyAuraDamageModifiers(roll.damage, client.auras, target->auras), eventFlags);
+						}
+					}
+				}
+				break;
+			}
+			case SpellEffectType::DamageOverTime:
+			case SpellEffectType::SlowMobPercent:
+			case SpellEffectType::DebuffDamageTakenPercent:
+			{
+				MobEntity* target = FindMobByEntityId(targetEntityId);
+				if (target == nullptr || (target->stateFlags & kEntityStateDead) != 0u)
+				{
+					break;
+				}
+				ActiveAura aura{};
+				aura.spellId = spell.spellId;
+				aura.type = effect.type;
+				aura.percent = effect.percent;
+				aura.tickPeriodMs = effect.tickPeriodMs;
+				aura.expiresAtMs = nowMs + effect.durationMs;
+				aura.nextTickAtMs = nowMs + effect.tickPeriodMs;
+				aura.casterEntityId = client.entityId;
+				if (effect.type == SpellEffectType::DamageOverTime)
+				{
+					aura.tickAmount = static_cast<uint32_t>(std::llround(
+						static_cast<double>(effect.mult) * static_cast<double>(client.combat.damagePerHit)));
+				}
+				UpsertAura(target->auras, std::move(aura));
+				BroadcastAuraUpdate(target->entityId, target->auras);
+				break;
+			}
+			case SpellEffectType::TauntThreatMult:
+			{
+				MobEntity* target = FindMobByEntityId(targetEntityId);
+				if (target == nullptr || (target->stateFlags & kEntityStateDead) != 0u)
+				{
+					break;
+				}
+				// Taunt : menace du casteur = mult × menace max courante (plancher
+				// 100 pour engager un mob encore vierge), agro forcée immédiate.
+				uint32_t maxThreat = 0;
+				for (const ThreatEntry& entry : target->threatTable)
+				{
+					maxThreat = std::max(maxThreat, entry.threat);
+				}
+				const uint32_t tauntThreat = std::max(100u, static_cast<uint32_t>(
+					std::llround(static_cast<double>(maxThreat) * static_cast<double>(effect.mult))));
+				bool found = false;
+				for (ThreatEntry& entry : target->threatTable)
+				{
+					if (entry.entityId == client.entityId)
+					{
+						entry.threat = std::max(entry.threat, tauntThreat);
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+				{
+					target->threatTable.push_back(ThreatEntry{ client.entityId, tauntThreat });
+				}
+				target->aggroTargetEntityId = client.entityId;
+				LOG_INFO(Net, "[ServerApp] Taunt applied (client_id={}, mob_entity_id={}, threat={})",
+					client.clientId, target->entityId, tauntThreat);
+				break;
+			}
+			case SpellEffectType::ThreatReducePercent:
+			{
+				// Dérobade : réduit la menace du casteur sur TOUS les mobs engagés.
+				const double keepFactor = 1.0 - static_cast<double>(effect.percent) / 100.0;
+				for (MobEntity& mob : m_mobs)
+				{
+					for (ThreatEntry& entry : mob.threatTable)
+					{
+						if (entry.entityId == client.entityId)
+						{
+							entry.threat = static_cast<uint32_t>(std::llround(
+								static_cast<double>(entry.threat) * keepFactor));
+						}
+					}
+				}
+				LOG_INFO(Net, "[ServerApp] Threat reduced (client_id={}, percent={})",
+					client.clientId, effect.percent);
+				break;
+			}
+			case SpellEffectType::DirectHeal:
+			case SpellEffectType::HealOverTime:
+			case SpellEffectType::BuffDamagePercent:
+			{
+				// Cible alliée : soi par défaut, ou l'allié validé à la demande.
+				ConnectedClient* ally = &client;
+				if (targetEntityId != 0 && targetEntityId != client.entityId)
+				{
+					if (ConnectedClient* other = FindClientByEntityId(targetEntityId))
+					{
+						ally = other;
+					}
+				}
+				if ((ally->stateFlags & kEntityStateDead) != 0u)
+				{
+					break; // pas de soin/buff sur un mort (résurrection = hors V1).
+				}
+				if (effect.type == SpellEffectType::DirectHeal)
+				{
+					const uint32_t heal = static_cast<uint32_t>(std::llround(
+						static_cast<double>(effect.mult) * static_cast<double>(client.combat.damagePerHit)));
+					ally->stats.currentHealth = std::min(ally->stats.maxHealth, ally->stats.currentHealth + heal);
+					LOG_INFO(Net, "[ServerApp] Heal applied (caster={}, target_entity_id={}, heal={}, hp={}/{})",
+						client.clientId, ally->entityId, heal, ally->stats.currentHealth, ally->stats.maxHealth);
+				}
+				else
+				{
+					ActiveAura aura{};
+					aura.spellId = spell.spellId;
+					aura.type = effect.type;
+					aura.percent = effect.percent;
+					aura.tickPeriodMs = effect.tickPeriodMs;
+					aura.expiresAtMs = nowMs + effect.durationMs;
+					aura.nextTickAtMs = nowMs + effect.tickPeriodMs;
+					aura.casterEntityId = client.entityId;
+					if (effect.type == SpellEffectType::HealOverTime)
+					{
+						// % PV max de la CIBLE prioritaire (« Second souffle »),
+						// sinon mult × damage du casteur.
+						aura.tickAmount = (effect.percentMaxHpPerTick > 0.0f)
+							? static_cast<uint32_t>(std::llround(
+								static_cast<double>(ally->stats.maxHealth)
+								* static_cast<double>(effect.percentMaxHpPerTick) / 100.0))
+							: static_cast<uint32_t>(std::llround(
+								static_cast<double>(effect.mult) * static_cast<double>(client.combat.damagePerHit)));
+					}
+					UpsertAura(ally->auras, std::move(aura));
+					if (ally == &client)
+					{
+						casterAurasChanged = true;
+					}
+					else
+					{
+						BroadcastAuraUpdate(ally->entityId, ally->auras);
+					}
+				}
+				break;
+			}
+			}
+		}
+
+		if (casterAurasChanged)
+		{
+			BroadcastAuraUpdate(client.entityId, client.auras);
+		}
+		LOG_INFO(Net, "[ServerApp] Spell cast resolved (client_id={}, spell={}, cost={}, resource={}/{})",
+			client.clientId, spell.spellId, cost, client.currentResource, client.maxResource);
+	}
+
+	void ServerApp::TickAuras()
+	{
+		const uint64_t nowMs = NowMonotonicMs();
+
+		// Joueurs : HoT/buffs (aucune source de DoT sur joueur en V1).
+		for (ConnectedClient& client : m_clients)
+		{
+			if (client.auras.empty())
+			{
+				continue;
+			}
+			const bool clientDead = (client.stateFlags & kEntityStateDead) != 0u;
+			for (ActiveAura& aura : client.auras)
+			{
+				if (aura.tickPeriodMs == 0 || nowMs < aura.nextTickAtMs || nowMs >= aura.expiresAtMs)
+				{
+					continue;
+				}
+				aura.nextTickAtMs += aura.tickPeriodMs;
+				if (aura.type == SpellEffectType::HealOverTime && !clientDead)
+				{
+					client.stats.currentHealth = std::min(
+						client.stats.maxHealth, client.stats.currentHealth + aura.tickAmount);
+				}
+			}
+			const size_t beforeCount = client.auras.size();
+			client.auras.erase(
+				std::remove_if(client.auras.begin(), client.auras.end(),
+					[nowMs](const ActiveAura& aura) { return nowMs >= aura.expiresAtMs; }),
+				client.auras.end());
+			if (client.auras.size() != beforeCount)
+			{
+				BroadcastAuraUpdate(client.entityId, client.auras);
+			}
+		}
+
+		// Mobs : DoT (via le chemin commun dégâts/mort/loot/XP si le casteur est
+		// encore connecté) + expirations (slow/debuff).
+		for (MobEntity& mob : m_mobs)
+		{
+			if (mob.auras.empty())
+			{
+				continue;
+			}
+			if (mob.pendingDespawn || (mob.stateFlags & kEntityStateDead) != 0u)
+			{
+				mob.auras.clear();
+				continue;
+			}
+			for (ActiveAura& aura : mob.auras)
+			{
+				if (aura.type != SpellEffectType::DamageOverTime
+					|| aura.tickPeriodMs == 0 || nowMs < aura.nextTickAtMs || nowMs >= aura.expiresAtMs)
+				{
+					continue;
+				}
+				aura.nextTickAtMs += aura.tickPeriodMs;
+				if (ConnectedClient* caster = FindClientByEntityId(aura.casterEntityId))
+				{
+					// Le tick profite des debuffs « dégâts subis » de la cible mais
+					// pas des buffs du casteur (montant figé à l'application).
+					ApplyPlayerDamageToMob(*caster, mob,
+						ApplyAuraDamageModifiers(aura.tickAmount, {}, mob.auras), 0u);
+				}
+				else
+				{
+					// Casteur déconnecté : dégâts secs, sans loot/XP ni événement.
+					const uint32_t applied = std::min(aura.tickAmount, mob.stats.currentHealth);
+					mob.stats.currentHealth -= applied;
+					if (mob.stats.currentHealth == 0)
+					{
+						mob.stateFlags |= kEntityStateDead;
+						mob.pendingDespawn = true;
+						mob.aggroTargetEntityId = 0;
+						mob.threatTable.clear();
+						LOG_INFO(Net, "[ServerApp] Mob died from orphan DoT (entity_id={})", mob.entityId);
+					}
+				}
+				if ((mob.stateFlags & kEntityStateDead) != 0u)
+				{
+					break; // mort pendant le tick : les auras seront purgées ci-dessous.
+				}
+			}
+			if (mob.pendingDespawn || (mob.stateFlags & kEntityStateDead) != 0u)
+			{
+				mob.auras.clear();
+				continue;
+			}
+			const size_t beforeCount = mob.auras.size();
+			mob.auras.erase(
+				std::remove_if(mob.auras.begin(), mob.auras.end(),
+					[nowMs](const ActiveAura& aura) { return nowMs >= aura.expiresAtMs; }),
+				mob.auras.end());
+			if (mob.auras.size() != beforeCount)
+			{
+				BroadcastAuraUpdate(mob.entityId, mob.auras);
+			}
+		}
+	}
+
+	void ServerApp::BroadcastAuraUpdate(EntityId entityId, const std::vector<ActiveAura>& auras)
+	{
+		AuraUpdateMessage message{};
+		message.targetEntityId = entityId;
+		const uint64_t nowMs = NowMonotonicMs();
+		for (const ActiveAura& aura : auras)
+		{
+			AuraWireEntry entry{};
+			entry.spellId = aura.spellId;
+			entry.effectType = static_cast<uint8_t>(aura.type);
+			entry.remainingMs = (aura.expiresAtMs > nowMs)
+				? static_cast<uint32_t>(aura.expiresAtMs - nowMs)
+				: 0u;
+			entry.stacks = aura.stacks;
+			message.auras.push_back(std::move(entry));
+		}
+
+		const std::vector<std::byte> packet = EncodeAuraUpdate(message);
+		for (const ConnectedClient& receiver : m_clients)
+		{
+			if (receiver.entityId != entityId && !ContainsEntityId(receiver.interestEntityIds, entityId))
+			{
+				continue;
+			}
+			(void)m_transport.Send(receiver.endpoint, packet);
 		}
 	}
 
@@ -3676,7 +4328,12 @@ namespace engine::server
 		if (roll.miss) eventFlags |= kCombatEventFlagMiss;
 		if (roll.crit) eventFlags |= kCombatEventFlagCrit;
 
-		const uint32_t appliedDamage = roll.miss ? 0u : std::min(roll.damage, target.stats.currentHealth);
+		// Combat SP3 — modificateurs d'auras (debuff « dégâts subis » de la cible ;
+		// les mobs n'ont pas de buffs de dégâts en V1 mais le chemin est commun).
+		const uint32_t modifiedDamage = roll.miss
+			? 0u
+			: ApplyAuraDamageModifiers(roll.damage, mob.auras, target.auras);
+		const uint32_t appliedDamage = roll.miss ? 0u : std::min(modifiedDamage, target.stats.currentHealth);
 		if (!roll.miss && appliedDamage == 0)
 		{
 			return false;
@@ -3695,6 +4352,13 @@ namespace engine::server
 			// Combat SP2 — un joueur mort sort de toutes les tables de menace ;
 			// les mobs repassent en patrouille au prochain tick d'IA.
 			PurgeThreatForEntity(target.entityId);
+			// Combat SP3 — les auras du mort tombent (le cast en cours est annulé
+			// par TickActiveCasts via le flag dead).
+			if (!target.auras.empty())
+			{
+				target.auras.clear();
+				BroadcastAuraUpdate(target.entityId, target.auras);
+			}
 			SaveConnectedClient(target, "player_death");
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -289,6 +289,7 @@ namespace engine::server
 		, m_questRuntime(m_config)
 		, m_spawnerRuntime(m_config)
 		, m_archetypeLibrary(m_config)
+		, m_spellKits(m_config)
 		, m_combatRng(std::random_device{}())
 	{
 		LOG_INFO(Core, "[ServerApp] Constructed");
@@ -413,6 +414,14 @@ namespace engine::server
 		if (!InitSpawners())
 		{
 			LOG_ERROR(Core, "[ServerApp] Init FAILED: spawner bootstrap failed");
+			Shutdown();
+			return false;
+		}
+
+		// Combat SP3 — kits de sorts par profil (strict : kit corrompu = pas de boot).
+		if (!m_spellKits.Init())
+		{
+			LOG_ERROR(Core, "[ServerApp] Init FAILED: spell kit library startup failed");
 			Shutdown();
 			return false;
 		}
@@ -1369,14 +1378,28 @@ namespace engine::server
 			if (derived)
 			{
 				ApplyDerivedCombatStats(acceptedClient, *derived);
+				// Combat SP3 — profil de classe (kit de sorts) + ressource runtime.
+				const auto factionIt = m_statsTables->factions.find(acceptedClient.factionId);
+				if (factionIt != m_statsTables->factions.end())
+				{
+					const auto classIt = factionIt->second.classesById.find(acceptedClient.classId);
+					if (classIt != factionIt->second.classesById.end())
+					{
+						acceptedClient.profileId = classIt->second.profile;
+					}
+				}
+				acceptedClient.maxResource = derived->resource;
+				acceptedClient.currentResource = acceptedClient.maxResource;
 				LOG_INFO(Net,
-					"[ServerApp] SP2 enter-world combat stats (client_id={}, damage={}, range={:.1f}, accuracy={:.1f}, crit={:.1f}%x{:.2f})",
+					"[ServerApp] SP2 enter-world combat stats (client_id={}, damage={}, range={:.1f}, accuracy={:.1f}, crit={:.1f}%x{:.2f}, profile={}, resource={})",
 					acceptedClient.clientId,
 					acceptedClient.combat.damagePerHit,
 					acceptedClient.combat.attackRangeMeters,
 					acceptedClient.combat.accuracy,
 					acceptedClient.combat.critRate,
-					acceptedClient.combat.critMult);
+					acceptedClient.combat.critMult,
+					acceptedClient.profileId.empty() ? "<none>" : acceptedClient.profileId.c_str(),
+					acceptedClient.maxResource);
 			}
 		}
 
@@ -1652,6 +1675,8 @@ namespace engine::server
 		ProcessAuctionHouseTick();
 		TickGathering();
 		TickCrafting();
+		// Combat SP3 — régénération de la ressource secondaire des joueurs.
+		RegenerateResources();
 		LOG_TRACE(Core, "[ServerApp] Simulate tick {}", m_currentTick);
 	}
 
@@ -2908,6 +2933,8 @@ namespace engine::server
 		client->velocityMetersPerSecondY = 0.0f;
 		client->velocityMetersPerSecondZ = 0.0f;
 		client->stats.currentHealth = client->stats.maxHealth;
+		// Combat SP3 — la ressource revient aussi à plein au respawn.
+		client->currentResource = client->maxResource;
 		client->stateFlags &= ~kEntityStateDead;
 		// Sécurité : plus aucune menace résiduelle ne doit pointer sur le ressuscité
 		// (déjà purgée à la mort, mais un mob a pu être spawné entre-temps).
@@ -3577,6 +3604,44 @@ namespace engine::server
 		// distribution locale (stateless) : [0,1), borne haute exclue.
 		std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
 		return distribution(m_combatRng);
+	}
+
+	void ServerApp::RegenerateResources()
+	{
+		if (m_tickHz == 0)
+		{
+			return;
+		}
+
+		const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		for (ConnectedClient& client : m_clients)
+		{
+			if (client.maxResource == 0 || client.currentResource >= client.maxResource)
+			{
+				continue;
+			}
+			// Pas de régénération pour un joueur mort (le respawn refill à plein).
+			if ((client.stateFlags & kEntityStateDead) != 0u)
+			{
+				continue;
+			}
+
+			// 5 %/s hors combat, 2 %/s en combat (décision utilisateur SP3) ;
+			// « en combat » = impliqué dans un CombatEvent depuis < 5 s.
+			const bool inCombat = (nowMs - client.lastCombatInvolvementMs) < 5000u;
+			const float ratePerSecond = inCombat ? 0.02f : 0.05f;
+			client.resourceRegenCarry +=
+				static_cast<float>(client.maxResource) * ratePerSecond / static_cast<float>(m_tickHz);
+			if (client.resourceRegenCarry < 1.0f)
+			{
+				continue;
+			}
+
+			const uint32_t whole = static_cast<uint32_t>(client.resourceRegenCarry);
+			client.resourceRegenCarry -= static_cast<float>(whole);
+			client.currentResource = std::min(client.maxResource, client.currentResource + whole);
+		}
 	}
 
 	bool ServerApp::TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target)
@@ -4273,6 +4338,19 @@ namespace engine::server
 	void ServerApp::BroadcastCombatEvent(const CombatEventMessage& message)
 	{
 		UpdateThreatFromCombatEvent(message);
+
+		// Combat SP3 — tamponne l'implication au combat des joueurs concernés
+		// (la régénération de ressource passe en cadence « en combat » 5 s).
+		const uint64_t nowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		if (ConnectedClient* attacker = FindClientByEntityId(message.attackerEntityId))
+		{
+			attacker->lastCombatInvolvementMs = nowMs;
+		}
+		if (ConnectedClient* target = FindClientByEntityId(message.targetEntityId))
+		{
+			target->lastCombatInvolvementMs = nowMs;
+		}
 
 		size_t recipientCount = 0;
 		for (const ConnectedClient& client : m_clients)
@@ -5747,6 +5825,9 @@ namespace engine::server
 			client.stats.currentHealth = d->hp;   // soin complet au level-up.
 			// Combat SP2 — les stats offensives suivent aussi le niveau.
 			ApplyDerivedCombatStats(client, *d);
+			// Combat SP3 — la ressource max suit le niveau (refill complet).
+			client.maxResource = d->resource;
+			client.currentResource = client.maxResource;
 		}
 		(void)SendPlayerStats(client);
 		SaveConnectedClient(client, "level_up");

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -4549,6 +4549,8 @@ namespace engine::server
 		msg.perception  = d->perception;
 		msg.stealth     = d->stealth;
 		msg.resourceKey = d->resourceKey;
+		// Combat SP3 (wire v11) — le client résout son kit de sorts via le profil.
+		msg.profileId = client.profileId;
 
 		const std::vector<std::byte> packet = EncodePlayerStats(msg);
 		if (!m_transport.Send(client.endpoint, packet))

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -16,6 +16,7 @@
 #include "src/shardd/gameplay/quest/QuestRuntime.h"
 #include "src/shardd/gameplay/spawner/SpawnerRuntime.h"
 #include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"
+#include "src/shardd/gameplay/spell/SpellKitLibrary.h"
 #include "src/shared/core/Config.h"
 #include "src/shared/net/ChatSystem.h"
 #include "src/shardd/gameplay/chat/ChatCommandParser.h"
@@ -109,6 +110,19 @@ namespace engine::server
 		float spawnPositionMetersX = 0.0f;
 		float spawnPositionMetersY = 0.0f;
 		float spawnPositionMetersZ = 0.0f;
+		/// Combat SP3 — profil de classe ("melee", "tank", …) résolu à l'enter-world
+		/// via factions.json ; vide = pas de kit de sorts (perso legacy / no-DB).
+		std::string profileId;
+		/// Combat SP3 — ressource secondaire runtime (le coût des sorts est en %
+		/// du max ; régénérée par RegenerateResources : 5 %/s hors combat, 2 %/s
+		/// en combat — décision utilisateur).
+		uint32_t currentResource = 0;
+		uint32_t maxResource = 0;
+		/// Accumulateur fractionnaire de régénération (la régén par tick < 1).
+		float resourceRegenCarry = 0.0f;
+		/// Timestamp ms de la dernière implication dans un CombatEvent (attaquant
+		/// ou cible) ; « en combat » = moins de 5 s.
+		uint64_t lastCombatInvolvementMs = 0;
 		/// TD.5 — nom du personnage choisi par le joueur (cf. table SQL characters.name).
 		/// Chargé depuis la DB (LoadSpawnFromDb) si le shard a un pool MySQL configuré ;
 		/// sinon (mode no-DB) repris du push master AdmitCharacter via
@@ -518,6 +532,11 @@ namespace engine::server
 		/// ResolveAttackRoll directement.
 		float NextCombatRoll01();
 
+		/// Combat SP3 — régénère la ressource secondaire de chaque joueur connecté
+		/// (par tick : 5 %/s hors combat, 2 %/s en combat, accumulé en fractionnaire).
+		/// Appelée depuis Simulate (main thread du tick monde).
+		void RegenerateResources();
+
 		/// Apply one mob attack against its current target when in range.
 		bool TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target);
 
@@ -895,6 +914,8 @@ namespace engine::server
 		/// Combat SP1 — catalogue d'archétypes de créatures (stats data-driven,
 		/// initialisé par InitSpawners avant le chargement des spawners).
 		CreatureArchetypeLibrary m_archetypeLibrary;
+		/// Combat SP3 — kits de sorts par profil (gameplay/spells/*.json), strict.
+		SpellKitLibrary m_spellKits;
 		/// Combat SP2 — RNG des jets d'attaque (précision/critique), seedé au
 		/// constructeur. Main thread du tick monde uniquement (pas de verrou).
 		std::mt19937 m_combatRng;

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -64,6 +64,24 @@ namespace engine::server
 		uint32_t threat = 0;
 	};
 
+	/// Combat SP3 — une aura active sur une entité (joueur ou mob). Les montants
+	/// périodiques (`tickAmount`) sont FIGÉS à l'application (snapshot des stats
+	/// du casteur) : un casteur déconnecté ne casse pas le tick.
+	struct ActiveAura
+	{
+		std::string spellId;
+		SpellEffectType type = SpellEffectType::DirectDamage;
+		/// Pourcentage (Buff/Debuff/Slow) — 0 pour les effets périodiques.
+		float percent = 0.0f;
+		/// Montant par tick (DoT = dégâts, HoT = soin) — 0 pour les effets %.
+		uint32_t tickAmount = 0;
+		uint32_t tickPeriodMs = 0;
+		uint64_t expiresAtMs = 0;
+		uint64_t nextTickAtMs = 0;
+		uint8_t stacks = 1;
+		EntityId casterEntityId = 0;
+	};
+
 	/// Visibility mode applied to one authoritative loot bag.
 	enum class LootVisibility : uint8_t
 	{
@@ -123,6 +141,20 @@ namespace engine::server
 		/// Timestamp ms de la dernière implication dans un CombatEvent (attaquant
 		/// ou cible) ; « en combat » = moins de 5 s.
 		uint64_t lastCombatInvolvementMs = 0;
+		/// Combat SP3 — throttle d'envoi des ResourceUpdate (au plus 1 / 500 ms).
+		uint64_t lastResourceUpdateSentMs = 0;
+		uint32_t lastResourceUpdateSentValue = 0;
+		/// Combat SP3 — auras actives (buffs, HoT, debuffs subis).
+		std::vector<ActiveAura> auras;
+		/// Combat SP3 — cast en cours (vide = aucun). Annulé si le joueur meurt ou
+		/// se déplace de plus de 0,5 m pendant l'incantation.
+		std::string activeCastSpellId;
+		uint64_t castFinishAtMs = 0;
+		float castStartPosX = 0.0f;
+		float castStartPosZ = 0.0f;
+		EntityId castTargetEntityId = 0;
+		/// Combat SP3 — cooldowns par sort (spellId → fin de cooldown en ms).
+		std::unordered_map<std::string, uint64_t> spellCooldownUntilMs;
 		/// TD.5 — nom du personnage choisi par le joueur (cf. table SQL characters.name).
 		/// Chargé depuis la DB (LoadSpawnFromDb) si le shard a un pool MySQL configuré ;
 		/// sinon (mode no-DB) repris du push master AdmitCharacter via
@@ -223,6 +255,8 @@ namespace engine::server
 		/// Combat SP1 — XP attribuée au(x) tueur(s), copiée depuis l'archétype au
 		/// spawn (0 = fallback sur kBaseXpPerMobKill, mob d'avant le catalogue).
 		uint32_t xpReward = 0;
+		/// Combat SP3 — auras actives (DoT, ralentissements, debuffs).
+		std::vector<ActiveAura> auras;
 	};
 
 	/// One spawn slot tracked by the authoritative spawner runtime.
@@ -536,6 +570,36 @@ namespace engine::server
 		/// (par tick : 5 %/s hors combat, 2 %/s en combat, accumulé en fractionnaire).
 		/// Appelée depuis Simulate (main thread du tick monde).
 		void RegenerateResources();
+
+		/// Combat SP3 — pousse la ressource courante au casteur (throttle 500 ms,
+		/// sauf \p force pour les débits de cast — feedback immédiat).
+		void SendResourceUpdate(ConnectedClient& client, bool force);
+
+		/// Combat SP3 — demande de cast d'un sort du kit du profil du joueur.
+		/// Valide profil/sort/cooldown/ressource/cible/portée ; instant = résolution
+		/// immédiate, sinon cast armé (résolu/annulé par TickActiveCasts).
+		void HandleCastRequest(const Endpoint& endpoint, const CastRequestMessage& message);
+
+		/// Combat SP3 — avance les casts en cours (annulation mort/déplacement,
+		/// résolution à l'échéance). Appelée depuis Simulate.
+		void TickActiveCasts();
+
+		/// Combat SP3 — tick des auras (DoT/HoT dus, expirations) des joueurs et
+		/// des mobs + broadcast AuraUpdate sur changement. Appelée depuis Simulate.
+		void TickAuras();
+
+		/// Combat SP3 — applique tous les effets d'un sort validé (débit ressource,
+		/// cooldown, dégâts/soins/auras/menace) et émet les messages associés.
+		void ResolveSpellCast(ConnectedClient& client, const SpellDef& spell, EntityId targetEntityId);
+
+		/// Combat SP2/SP3 — applique des dégâts (déjà jetés/multipliés) d'un joueur
+		/// sur un mob : PV, événement dynamique, mort/loot/XP, CombatEvent broadcast.
+		/// Factorisé entre l'auto-attaque (HandleAttackRequest) et les sorts.
+		void ApplyPlayerDamageToMob(ConnectedClient& attacker, MobEntity& target, uint32_t rolledDamage, uint32_t eventFlags);
+
+		/// Combat SP3 — broadcast la liste complète des auras d'une entité aux
+		/// clients intéressés (idempotent côté client).
+		void BroadcastAuraUpdate(EntityId entityId, const std::vector<ActiveAura>& auras);
 
 		/// Apply one mob attack against its current target when in range.
 		bool TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target);


### PR DESCRIPTION
## Combat SP3-B — sorts et auras, volet client

Stackée sur #878 (SP3-A serveur + wire v11). Plan : `docs/superpowers/plans/2026-06-11-combat-sp3-sorts-auras.md` (Tasks 9-13).

### Contenu
- **`SpellKitCatalog`** (`src/client/gameplay/`) : lecture tolérante des mêmes `gameplay/spells/*.json` que le serveur — uniquement les métadonnées d''affichage (nom, slot, cast, cooldown, coût, besoin de cible). Catalogue absent = barre d''action masquée, jamais bloquant.
- **UIModel** : routage des 3 nouveaux messages serveur — `ResourceUpdate` (ressource courante → la barre de ressource HUD existante affiche enfin une valeur vivante), `CastBarUpdate` (état de cast, progression calculée localement), `AuraUpdate` (auras par entité, remplacement idempotent, purge automatique des entités sorties de l''AoI) ; `profileId` reçu via PlayerStats.
- **Barre d''action** (touches **1-4**) : 4 slots bas-centre — nom, numéro de touche, grisé si ressource insuffisante, voile + décompte pendant le cooldown (affichage local, le serveur revalide tout) ; envoi de `CastRequest` avec la cible courante pour les sorts offensifs.
- **Barre de cast** : au-dessus de la barre d''action, pilotée par le serveur (start/complete/cancel), nom du sort résolu par le catalogue.
- **BuffBar (M31.2 enfin câblée)** : dernier présentateur combat orphelin de l''audit — auras du joueur (pastilles bas-gauche, buffs/debuffs séparés) et de la cible (sous le cadre cible), timers décrémentés localement entre deux AuraUpdate, stacks affichés.

### Validation en jeu attendue (post-merge + déploiement v11)
Barre d''action visible avec le kit de sa classe ; sort 1 sur le sanglier → dégâts (jets crit/raté) ; DoT visible sous le cadre cible avec timer ; buff visible bas-gauche ; cast 1,5 s interrompu en bougeant ; ressource qui descend au cast et remonte (2 %/s en combat, 5 %/s hors combat) ; Provocation/Dérobade modifient l''agro.

### Ordre de merge
**#878 (SP3-A) d''abord, puis celle-ci.** La PR draft « CI only » valide le cumul A+B en attendant.

**Déploiement** : ⚠️ wire v11 (porté par SP3-A) — master + shardd + client en **lock-step** (groupable avec SP1/SP2, jamais déployés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)