### PR TITLE
feat(combat): SP4 - menace repliquee (threat meter) + FX d'auras (wire v12) - cloture chantier combat

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2217,3 +2217,19 @@ kinds `CastRequest=81`, `ResourceUpdate=82`, `CastBarUpdate=83`, `AuraUpdate=84`
 - Persistance des auras : ABANDONNÉE en V1 (toutes ≤ 12 s) — cf. plan Task 7.
 - Reste : SP3-B client (barre d''action 1-4, barre de cast, BuffBar via StatusEffectManager).
 - **Déploiement** : ⚠️ wire v11 — lock-step master + shardd + client (avec SP3-B).
+
+## Combat SP4 — menace répliquée + FX d''auras (2026-06-11) — CLÔT LE CHANTIER COMBAT
+
+Plan : `docs/superpowers/plans/2026-06-11-combat-sp4-menace-fx.md`. **Wire v11→v12** :
+kind `ThreatUpdate = 85` (table de menace d''un mob, liste complète idempotente, vide = effacement).
+
+- Serveur : `PushThreatUpdates` dans Simulate (throttle 1 s/mob + hash de changement) ;
+  push vide immédiat à la mort du mob et à l''evade (`ResetMobThreat`).
+- Client : `UIModel.threatByMob` (purge AoI) → `AdvancedCombatPresenter::UpdateThreat`
+  (threat meter du panneau J : nom/%/barre vert-jaune-rouge, « Vous » pour le local) ;
+  `AuraFXSystem` (M39.4) câblé — couche données Sync depuis entityAuras, rendu halo
+  écran-espace coloré aux pieds (couleur ResolveAuraVisuals, pas de nouvel asset).
+- AoEPreviewSystem : volontairement NON câblé (aucun sort ciblé-sol dans les kits
+  validés — sera branché avec le premier sort AreaAtTarget). Cf. plan.
+- L''IA d''agro (poursuite/leash/evade/threat tick) existait déjà (Waves 8/19).
+- **Déploiement** : ⚠️ wire v12 — lock-step master + shardd + client (avec SP1-SP3).

--- a/docs/superpowers/plans/2026-06-11-combat-sp4-menace-fx.md
+++ b/docs/superpowers/plans/2026-06-11-combat-sp4-menace-fx.md
@@ -1,0 +1,38 @@
+# Combat SP4 — Menace répliquée, threat meter, FX d'auras : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clore le chantier combat (spec §7) : la table de menace des mobs est répliquée aux clients (threat meter du panneau J enfin alimenté — `AdvancedCombatPresenter::UpdateThreat` attend ces données depuis M39.4), et les auras gagnent un retour visuel in-world (halo coloré aux pieds des entités, via l'`AuraFXSystem` orphelin).
+
+**Architecture:** L'IA d'agro serveur (poursuite, leash, threat tables, evade) existe depuis les Waves 8/19 et fonctionne — SP4 n'ajoute côté serveur QU'UN push `ThreatUpdate` (wire v11→v12, kind 85) throttlé par mob. Côté client : routage vers `AdvancedCombatPresenter::UpdateThreat` + rendu du threat meter dans le panneau J (la struct `threatMeter` existe), et câblage d'`AuraFXSystem` (couche données : Sync depuis `UIModel::entityAuras`) avec rendu écran-espace (cercle coloré aux pieds, couleur de `ResolveAuraVisuals` — pas de nouvel asset).
+
+**Décisions d'exécution :**
+- **AoEPreviewSystem reste non câblé** (déviation spec §7 assumée) : il prévisualise un placement souris→sol, or aucun sort des kits validés n'est `AreaAtTarget` (Nova = autour de soi). Il sera câblé avec le premier sort ciblé-sol. Documenté ici plutôt qu'un câblage artificiel.
+- Le push ThreatUpdate est throttlé à 1/s par mob ET seulement si la table a changé ; mob mort/évadé → push d'une liste vide (le client efface).
+
+**Livraison : 1 PR `combat-sp4`** (serveur+client, base main après merge de #878/#879). ⚠️ wire v12, lock-step.
+
+### Task 1: Wire v11→v12 — ThreatUpdate (kind 85)
+
+ServerProtocol.h/.cpp/Tests : `kProtocolVersion = 12` + historique ; kind `ThreatUpdate = 85` ; `struct ThreatWireEntry { EntityId playerEntityId; uint32_t threatValue; }` ; `struct ThreatUpdateMessage { EntityId mobEntityId; std::vector<ThreatWireEntry> entries; }` (payload : u64 + u8 count + n×12, liste complète idempotente, vide = effacement) ; Encode/Decode + roundtrip + tronqué.
+
+### Task 2: Push serveur
+
+ServerApp : `MobEntity` gagne `uint64_t lastThreatPushMs = 0; size_t lastThreatHash = 0;` (hash simple = somme entityId^threat). Dans le tick d'IA des mobs (ou TickAuras — choisir le site appelé ~1/s : `ResolveMobAiIntervalTicks`), pour chaque mob avec table non vide : si hash ≠ dernier ET now-last ≥ 1000 ms → `BroadcastThreatUpdate(mob)` (même périmètre d'intérêt que les auras). `ResetMobThreat`/mort → push vide immédiat.
+
+### Task 3: Client — routage + threat meter
+
+- UIModel : route `ThreatUpdate` → pour chaque entrée, résoudre le nom (joueur local = nom du perso ou « Vous » ; sinon displayName des remoteEntities, fallback "P<clientId>" impossible sans clientId → fallback "Joueur <entityId>") puis pousser au présentateur. Le présentateur n'est pas membre du binding → exposer les données : `UIModel.threatByMob[mobEntityId] = vector<{entityId, threat}>` + notif Combat ; Engine (observer) appelle `m_advancedCombat.UpdateThreat(...)` par entrée et `ClearThreat(mobId)` sur liste vide.
+- Rendu : dans le panneau J (bloc SP2), section « Menace » si `threatMeterVisible` : par entrée `threatMeter[]` — nom, % (threatPercent), barre colorée selon `ThreatColor` (vert/jaune/rouge).
+
+### Task 4: Client — AuraFXSystem câblé
+
+- Engine : membre `m_auraFx` + Init/Shutdown (GameplayNet) ; chaque frame (bloc combat SP2) : `Sync(entityId, effets, pos lissée)` pour le joueur local + toutes les entités de `entityAuras` visibles (réutilise le `buildEffects` SP3-B — le factoriser en méthode/lambda partagée) ; `RemoveEntity` géré par Sync(nullptr) via la purge AoI existante ; rendu : pour chaque `GetAuras()` — `WorldToScreenPx(pos aux pieds)` → `fg->AddCircle` (rayon ~22 px, couleur glowColor, 2 px) + léger remplissage alpha.
+
+### Task 5: Docs + PR
+
+CODEBASE_MAP (section SP4 + clôture chantier combat), push, PR base main, CI, mention déploiement lock-step v12.
+
+## Self-review
+- Spec §7 : poursuite/leash/evade déjà serveur (constaté SP1/SP2) ; menace tickée = existante ; ThreatUpdate+meter = Tasks 1-3 ; AuraFX = Task 4 ; AoEPreview = déviation documentée. Multi-cibles d'agro : déjà géré par ThreatList (TopTarget).
+- Types : threatValue u32 (= ThreatEntry.threat), EntityId u64 partout.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10434,6 +10434,24 @@ namespace engine
 								ImGui::Text("%.1f dps", row.dps);
 								ImGui::ProgressBar(row.barFraction, ImVec2(-1.0f, 6.0f), "");
 							}
+							// Combat SP4 — menace sur la cible courante (ThreatUpdate).
+							if (acs.threatMeterVisible && !acs.threatMeter.empty())
+							{
+								ImGui::Separator();
+								ImGui::TextUnformatted("Menace");
+								for (const engine::client::ThreatMeterEntry& threatRow : acs.threatMeter)
+								{
+									const ImVec4 rowColor = (threatRow.color == engine::client::ThreatColor::Red)
+										? ImVec4(0.9f, 0.3f, 0.25f, 1.0f)
+										: (threatRow.color == engine::client::ThreatColor::Yellow)
+											? ImVec4(0.9f, 0.8f, 0.3f, 1.0f)
+											: ImVec4(0.4f, 0.8f, 0.4f, 1.0f);
+									ImGui::TextColored(rowColor, "%s", threatRow.displayName.c_str());
+									ImGui::SameLine(200.0f);
+									ImGui::TextColored(rowColor, "%.0f %%", threatRow.threatPercent);
+									ImGui::ProgressBar(threatRow.barFraction, ImVec2(-1.0f, 6.0f), "");
+								}
+							}
 							ImGui::Separator();
 							uint32_t filter = acs.activeFilter;
 							bool filterChanged = false;
@@ -10656,6 +10674,101 @@ namespace engine
 							// Sous le cadre cible (haut-centre, cf. bloc SP2 : fy 56 + 54).
 							drawBar(targetBuffState.buffBar, (dw - 260.0f) * 0.5f, 118.0f, false);
 							drawBar(targetBuffState.debuffBar, (dw - 260.0f) * 0.5f, 144.0f, true);
+						}
+
+						// --- Combat SP4 : threat meter — alimente le présentateur pour la
+						// cible courante (rebuild complet, ≤ 5 entrées : coût négligeable).
+						if (uiModel.targetStats.hasTarget)
+						{
+							m_advancedCombat.ClearThreat(uiModel.targetStats.entityId);
+							const auto threatIt = uiModel.threatByMob.find(uiModel.targetStats.entityId);
+							if (threatIt != uiModel.threatByMob.end())
+							{
+								for (const engine::client::UIThreatEntry& threatEntry : threatIt->second)
+								{
+									std::string threatName = "Joueur";
+									if (threatEntry.playerEntityId == uiModel.playerStats.playerEntityId)
+									{
+										threatName = "Vous";
+									}
+									else
+									{
+										for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
+										{
+											if (re.entityId == threatEntry.playerEntityId)
+											{
+												threatName = !re.displayName.empty()
+													? re.displayName
+													: ("P" + std::to_string(re.playerClientId));
+												break;
+											}
+										}
+									}
+									m_advancedCombat.UpdateThreat(uiModel.targetStats.entityId,
+										threatEntry.playerEntityId, threatName, threatEntry.threatValue);
+								}
+							}
+						}
+
+						// --- Combat SP4 : FX d'auras — sync de la couche données
+						// (AuraFXSystem, M39.4 enfin câblé) puis halo écran-espace coloré
+						// aux pieds de chaque entité sous aura (couleur ResolveAuraVisuals).
+						{
+							const engine::math::Vec3 localFxPos = m_characterController.GetPosition();
+							std::list<engine::gameplay::StatusEffect> fxEffects;
+							for (const auto& auraPair : uiModel.entityAuras)
+							{
+								const engine::server::EntityId fxEntityId = auraPair.first;
+								float fxX = localFxPos.x, fxY = localFxPos.y, fxZ = localFxPos.z;
+								if (fxEntityId != uiModel.playerStats.playerEntityId)
+								{
+									const auto smoothedIt = m_remoteSmoothed.find(fxEntityId);
+									if (smoothedIt == m_remoteSmoothed.end() || !smoothedIt->second.valid)
+									{
+										continue; // entité sans position connue : pas de FX ce frame.
+									}
+									fxX = smoothedIt->second.x;
+									fxY = smoothedIt->second.y;
+									fxZ = smoothedIt->second.z;
+								}
+								fxEffects.clear();
+								buildEffects(fxEntityId, fxEffects);
+								m_auraFx.Sync(fxEntityId, fxEffects.empty() ? nullptr : &fxEffects, fxX, fxY, fxZ);
+							}
+							// Purge des FX d'entités qui n'ont plus aucune aura répliquée.
+							std::vector<uint64_t> staleFxEntities;
+							for (const engine::client::ActiveAura& fxAura : m_auraFx.GetAuras())
+							{
+								if (uiModel.entityAuras.find(fxAura.entityId) == uiModel.entityAuras.end())
+								{
+									staleFxEntities.push_back(fxAura.entityId);
+								}
+							}
+							for (const uint64_t staleEntityId : staleFxEntities)
+							{
+								m_auraFx.RemoveEntity(staleEntityId);
+							}
+							// Rendu : un anneau par aura, aux pieds de l'entité.
+							for (const engine::client::ActiveAura& fxAura : m_auraFx.GetAuras())
+							{
+								if (!fxAura.alive)
+								{
+									continue;
+								}
+								float haloX = 0.0f, haloY = 0.0f;
+								if (!WorldToScreenPx(out.viewProjMatrix.m,
+									fxAura.positionX, fxAura.positionY - 0.85f, fxAura.positionZ,
+									ivw, ivh, haloX, haloY))
+								{
+									continue;
+								}
+								const ImU32 haloColor = IM_COL32(
+									static_cast<int>(fxAura.glowColor.r * 255.0f),
+									static_cast<int>(fxAura.glowColor.g * 255.0f),
+									static_cast<int>(fxAura.glowColor.b * 255.0f),
+									190);
+								fg->AddCircle(ImVec2(haloX, haloY), 20.0f, haloColor, 24, 2.5f);
+							}
 						}
 					}
 
@@ -12606,6 +12719,11 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] BuffBarPresenter Init FAILED — BuffBar désactivée");
 		}
+		// Combat SP4 — FX d'auras (halo aux pieds des entités sous aura).
+		if (!m_auraFx.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] AuraFXSystem Init FAILED — FX d'auras désactivés");
+		}
 
 		const uint32_t vw = static_cast<uint32_t>(std::max(1, m_width));
 		const uint32_t vh = static_cast<uint32_t>(std::max(1, m_height));
@@ -12708,7 +12826,8 @@ namespace engine
 			m_uiObserverHandle = 0;
 		}
 
-		// Combat SP2/SP3 — symétrie d'Init (présentateurs combat + BuffBar).
+		// Combat SP2/SP3/SP4 — symétrie d'Init (présentateurs combat + BuffBar + FX).
+		m_auraFx.Shutdown();
 		m_buffBar.Shutdown();
 		m_spellCooldownUiUntilSec.clear();
 		m_advancedCombat.Shutdown();

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -33,6 +33,8 @@
 // Combat SP3 — barre d'action (kits de sorts) + BuffBar (auras répliquées).
 #include "src/client/combat/BuffBarPresenter.h"
 #include "src/client/gameplay/SpellKitCatalog.h"
+// Combat SP4 — FX visuels d'auras (halo aux pieds des entités).
+#include "src/client/combat/AuraFXSystem.h"
 #include "src/client/debug/ProfilerHud.h"
 #include "src/client/economy/ShopUi.h"
 #include "src/client/ui_common/UIModel.h"
@@ -1276,6 +1278,9 @@ namespace engine
 		engine::client::SpellKitCatalog m_spellCatalog{};
 		/// Combat SP3 — BuffBar (M31.2) : auras du joueur et de la cible.
 		engine::client::BuffBarPresenter m_buffBar{};
+		/// Combat SP4 — FX d'auras (couche données ; rendu = halo écran-espace
+		/// coloré aux pieds, couleur résolue par ResolveAuraVisuals).
+		engine::client::AuraFXSystem m_auraFx{};
 		/// Combat SP3 — cooldowns AFFICHÉS de la barre d'action (spellId → fin en
 		/// secondes EngineNowSec) ; purement cosmétique, le serveur fait foi.
 		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -617,6 +617,8 @@ namespace engine::client
 			return ApplyCastBarUpdate(packet);
 		case engine::server::MessageKind::AuraUpdate:
 			return ApplyAuraUpdate(packet);
+		case engine::server::MessageKind::ThreatUpdate:
+			return ApplyThreatUpdate(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -771,6 +773,23 @@ namespace engine::client
 					}
 				}
 				auraIt = stillPresent ? std::next(auraIt) : m_model.entityAuras.erase(auraIt);
+			}
+		}
+		// Combat SP4 — même purge AoI pour les tables de menace répliquées.
+		if (!m_model.threatByMob.empty())
+		{
+			for (auto threatIt = m_model.threatByMob.begin(); threatIt != m_model.threatByMob.end();)
+			{
+				bool mobPresent = false;
+				for (const UIRemoteEntity& remote : m_model.remoteEntities)
+				{
+					if (remote.entityId == threatIt->first)
+					{
+						mobPresent = true;
+						break;
+					}
+				}
+				threatIt = mobPresent ? std::next(threatIt) : m_model.threatByMob.erase(threatIt);
 			}
 		}
 
@@ -938,6 +957,32 @@ namespace engine::client
 				entry.stacks = wireAura.stacks;
 				entry.receivedAtNs = nowNs;
 				auraList.push_back(std::move(entry));
+			}
+		}
+		NotifyObservers(UIModelChangeCombat);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyThreatUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeThreatUpdate(packet, m_threatUpdateMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] ThreatUpdate FAILED: decode error");
+			return false;
+		}
+
+		if (m_threatUpdateMessage.entries.empty())
+		{
+			m_model.threatByMob.erase(m_threatUpdateMessage.mobEntityId);
+		}
+		else
+		{
+			std::vector<UIThreatEntry>& threatList = m_model.threatByMob[m_threatUpdateMessage.mobEntityId];
+			threatList.clear();
+			threatList.reserve(m_threatUpdateMessage.entries.size());
+			for (const engine::server::ThreatWireEntry& wireEntry : m_threatUpdateMessage.entries)
+			{
+				threatList.push_back(UIThreatEntry{ wireEntry.playerEntityId, wireEntry.threatValue });
 			}
 		}
 		NotifyObservers(UIModelChangeCombat);

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -237,6 +237,13 @@ namespace engine::client
 		uint64_t startedAtNs = 0;
 	};
 
+	/// Combat SP4 — une entrée de menace répliquée (ThreatUpdate, wire v12).
+	struct UIThreatEntry
+	{
+		engine::server::EntityId playerEntityId = 0;
+		uint32_t threatValue = 0;
+	};
+
 	/// Combat SP3 — une aura active répliquée (AuraUpdate, wire v11).
 	struct UIAuraEntry
 	{
@@ -415,6 +422,9 @@ namespace engine::client
 		/// intégralement à chaque AuraUpdate de l'entité. Une entité qui sort de
 		/// l'AoI garde une entrée périmée jusqu'au prochain ApplySnapshot (purge).
 		std::unordered_map<engine::server::EntityId, std::vector<UIAuraEntry>> entityAuras;
+		/// Combat SP4 — table de menace par mob (remplacée intégralement à chaque
+		/// ThreatUpdate ; liste vide reçue = entrée supprimée). Purgée avec l'AoI.
+		std::unordered_map<engine::server::EntityId, std::vector<UIThreatEntry>> threatByMob;
 		std::string debugDump;
 
 		/// Build a text dump suitable for a debug widget or logs.
@@ -512,6 +522,9 @@ namespace engine::client
 		/// Combat SP3 — remplace les auras d'une entité (AuraUpdate, idempotent).
 		bool ApplyAuraUpdate(std::span<const std::byte> packet);
 
+		/// Combat SP4 — remplace la table de menace d'un mob (ThreatUpdate).
+		bool ApplyThreatUpdate(std::span<const std::byte> packet);
+
 		/// Apply one decoded zone change packet to the world section of the UI model.
 		bool ApplyZoneChange(std::span<const std::byte> packet);
 
@@ -606,6 +619,7 @@ namespace engine::client
 		engine::server::ResourceUpdateMessage m_resourceUpdateMessage{};
 		engine::server::CastBarUpdateMessage m_castBarUpdateMessage{};
 		engine::server::AuraUpdateMessage m_auraUpdateMessage{};
+		engine::server::ThreatUpdateMessage m_threatUpdateMessage{};
 		engine::server::ZoneChangeMessage m_zoneChangeMessage{};
 		engine::server::InventoryDeltaMessage m_inventoryMessage{};
 		engine::server::QuestDeltaMessage m_questMessage{};

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -742,6 +742,47 @@ namespace engine::server
 		return outMessage.status <= kCastBarStatusCancel;
 	}
 
+	std::vector<std::byte> EncodeThreatUpdate(const ThreatUpdateMessage& message)
+	{
+		// Combat SP4 — payload : mobEntityId (8) + count (1) + n × (playerEntityId 8 + threat 4).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::ThreatUpdate, 9 + message.entries.size() * 12);
+		WriteU64(packet, message.mobEntityId);
+		WriteU8(packet, static_cast<uint8_t>(std::min<size_t>(message.entries.size(), 0xFFu)));
+		for (const ThreatWireEntry& entry : message.entries)
+		{
+			WriteU64(packet, entry.playerEntityId);
+			WriteU32(packet, entry.threatValue);
+		}
+		return packet;
+	}
+
+	bool DecodeThreatUpdate(std::span<const std::byte> packet, ThreatUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::ThreatUpdate, payload) || payload.size() < 9)
+		{
+			return false;
+		}
+
+		outMessage.mobEntityId = ReadU64(payload, 0);
+		const size_t entryCount = static_cast<size_t>(ReadU8(payload, 8));
+		if (payload.size() != 9 + entryCount * 12)
+		{
+			return false;
+		}
+
+		outMessage.entries.clear();
+		outMessage.entries.resize(entryCount);
+		size_t offset = 9;
+		for (size_t index = 0; index < entryCount; ++index)
+		{
+			outMessage.entries[index].playerEntityId = ReadU64(payload, offset);
+			outMessage.entries[index].threatValue = ReadU32(payload, offset + 8);
+			offset += 12;
+		}
+		return true;
+	}
+
 	std::vector<std::byte> EncodeAuraUpdate(const AuraUpdateMessage& message)
 	{
 		// Combat SP3 — payload : targetEntityId (8) + count (1) puis par aura :

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -50,7 +50,10 @@ namespace engine::server
 	/// `PlayerStatsMessage` gagne `profileId` (chaîne préfixée u16 en queue —
 	/// le client résout son kit de sorts gameplay/spells/<profil>.json).
 	/// Wire-breaking : lock-step master + shardd + client.
-	inline constexpr uint16_t kProtocolVersion = 11;
+	/// Combat SP4 — bump 11 → 12 : nouveau kind `ThreatUpdate` (85, shard →
+	/// clients intéressés) — table de menace d'un mob répliquée (threat meter).
+	/// Wire-breaking : lock-step master + shardd + client.
+	inline constexpr uint16_t kProtocolVersion = 12;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -241,7 +244,11 @@ namespace engine::server
 		CastBarUpdate = 83,
 		/// Shard → clients intéressés : liste complète des auras d'une entité
 		/// (idempotent — remplace l'état précédent côté client).
-		AuraUpdate = 84
+		AuraUpdate = 84,
+		/// Combat SP4 — shard → clients intéressés : table de menace d'un mob
+		/// (liste complète idempotente, vide = effacement). Alimente le threat
+		/// meter (AdvancedCombatUi). Bump v11→v12.
+		ThreatUpdate = 85
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -420,6 +427,21 @@ namespace engine::server
 		std::vector<AuraWireEntry> auras;
 	};
 
+	/// Combat SP4 — une entrée de menace répliquée (joueur → valeur brute).
+	struct ThreatWireEntry
+	{
+		EntityId playerEntityId = 0;
+		uint32_t threatValue = 0;
+	};
+
+	/// Combat SP4 — table de menace d'un mob (liste complète idempotente ;
+	/// vide = le client efface — mort, evade, reset).
+	struct ThreatUpdateMessage
+	{
+		EntityId mobEntityId = 0;
+		std::vector<ThreatWireEntry> entries;
+	};
+
 	/// Client request asking the authoritative server to pick up one loot bag entity.
 	struct PickupRequestMessage
 	{
@@ -577,6 +599,10 @@ namespace engine::server
 	bool DecodeCastBarUpdate(std::span<const std::byte> packet, CastBarUpdateMessage& outMessage);
 	std::vector<std::byte> EncodeAuraUpdate(const AuraUpdateMessage& message);
 	bool DecodeAuraUpdate(std::span<const std::byte> packet, AuraUpdateMessage& outMessage);
+
+	/// Combat SP4 — encode/decode de la table de menace répliquée (wire v12).
+	std::vector<std::byte> EncodeThreatUpdate(const ThreatUpdateMessage& message);
+	bool DecodeThreatUpdate(std::span<const std::byte> packet, ThreatUpdateMessage& outMessage);
 
 	/// Encode a combat event packet with the protocol header.
 	std::vector<std::byte> EncodeCombatEvent(const CombatEventMessage& message);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -465,6 +465,34 @@ namespace
 		std::puts("[OK] TestAuraUpdateRoundTrip");
 	}
 
+	/// Combat SP4 (wire v12) — round-trip de la table de menace + liste vide + tronqué.
+	void TestThreatUpdateRoundTrip()
+	{
+		engine::server::ThreatUpdateMessage in{};
+		in.mobEntityId = 0x300000005ull;
+		in.entries.push_back(engine::server::ThreatWireEntry{ 0x200000001ull, 450u });
+		in.entries.push_back(engine::server::ThreatWireEntry{ 0x200000002ull, 120u });
+
+		const std::vector<std::byte> packet = engine::server::EncodeThreatUpdate(in);
+		engine::server::ThreatUpdateMessage out{};
+		assert(engine::server::DecodeThreatUpdate(packet, out));
+		assert(out.mobEntityId == in.mobEntityId);
+		assert(out.entries.size() == 2u);
+		assert(out.entries[0].playerEntityId == 0x200000001ull && out.entries[0].threatValue == 450u);
+		assert(out.entries[1].threatValue == 120u);
+
+		// Liste vide = effacement côté client : valide.
+		engine::server::ThreatUpdateMessage empty{};
+		empty.mobEntityId = 42u;
+		assert(engine::server::DecodeThreatUpdate(engine::server::EncodeThreatUpdate(empty), out));
+		assert(out.mobEntityId == 42u && out.entries.empty());
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 4u);
+		assert(!engine::server::DecodeThreatUpdate(truncated, out));
+		std::puts("[OK] TestThreatUpdateRoundTrip");
+	}
+
 	/// Combat SP3 (wire v11) — PlayerStats porte désormais profileId en queue.
 	void TestPlayerStatsRoundTripWithProfile()
 	{
@@ -503,6 +531,7 @@ int main()
 	TestResourceUpdateRoundTrip();
 	TestCastBarUpdateRoundTrip();
 	TestAuraUpdateRoundTrip();
+	TestThreatUpdateRoundTrip();
 	TestPlayerStatsRoundTripWithProfile();
 	std::puts("All ServerProtocol tests passed");
 	return 0;

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1740,6 +1740,8 @@ namespace engine::server
 		RegenerateResources();
 		TickActiveCasts();
 		TickAuras();
+		// Combat SP4 — réplication des tables de menace modifiées (≤ 1/s par mob).
+		PushThreatUpdates();
 		LOG_TRACE(Core, "[ServerApp] Simulate tick {}", m_currentTick);
 	}
 
@@ -2921,6 +2923,8 @@ namespace engine::server
 			target.threatTable.clear();
 			// Combat SP3 — plus rien à ticker sur un mob mort.
 			target.auras.clear();
+			// Combat SP4 — effacement immédiat du threat meter côté clients.
+			BroadcastThreatUpdate(target);
 			if (target.isDynamicEventMob && target.owningEventIndex < m_dynamicEvents.size())
 			{
 				DynamicEventState& eventState = m_dynamicEvents[target.owningEventIndex];
@@ -3645,6 +3649,11 @@ namespace engine::server
 		const size_t clearedCount = mob.threatTable.size();
 		mob.threatTable.clear();
 		mob.aggroTargetEntityId = 0;
+		// Combat SP4 — effacement immédiat du threat meter côté clients.
+		if (clearedCount > 0)
+		{
+			BroadcastThreatUpdate(mob);
+		}
 		LOG_INFO(Net, "[ServerApp] Mob threat reset (mob_entity_id={}, cleared_entries={})",
 			mob.entityId,
 			clearedCount);
@@ -4266,6 +4275,73 @@ namespace engine::server
 				BroadcastAuraUpdate(mob.entityId, mob.auras);
 			}
 		}
+	}
+
+	void ServerApp::PushThreatUpdates()
+	{
+		const uint64_t nowMs = NowMonotonicMs();
+		for (MobEntity& mob : m_mobs)
+		{
+			if (mob.pendingDespawn || (mob.stateFlags & kEntityStateDead) != 0u)
+			{
+				continue; // l'effacement a été poussé au moment de la mort/evade.
+			}
+			if (mob.threatTable.empty() && mob.lastThreatHash == 0u)
+			{
+				continue; // jamais engagé : rien à pousser ni à effacer.
+			}
+			if ((nowMs - mob.lastThreatPushMs) < 1000u)
+			{
+				continue;
+			}
+			// Hash d'état (FNV-ish) : push uniquement si la table a changé.
+			uint64_t hash = 1469598103934665603ull;
+			for (const ThreatEntry& entry : mob.threatTable)
+			{
+				hash = (hash ^ entry.entityId) * 1099511628211ull;
+				hash = (hash ^ static_cast<uint64_t>(entry.threat)) * 1099511628211ull;
+			}
+			if (mob.threatTable.empty())
+			{
+				hash = 0u;
+			}
+			if (hash == mob.lastThreatHash)
+			{
+				continue;
+			}
+			BroadcastThreatUpdate(mob);
+		}
+	}
+
+	void ServerApp::BroadcastThreatUpdate(MobEntity& mob)
+	{
+		ThreatUpdateMessage message{};
+		message.mobEntityId = mob.entityId;
+		for (const ThreatEntry& entry : mob.threatTable)
+		{
+			message.entries.push_back(ThreatWireEntry{ entry.entityId, entry.threat });
+		}
+
+		const std::vector<std::byte> packet = EncodeThreatUpdate(message);
+		for (const ConnectedClient& receiver : m_clients)
+		{
+			if (receiver.entityId != mob.entityId
+				&& !ContainsEntityId(receiver.interestEntityIds, mob.entityId))
+			{
+				continue;
+			}
+			(void)m_transport.Send(receiver.endpoint, packet);
+		}
+
+		const uint64_t nowMs = NowMonotonicMs();
+		mob.lastThreatPushMs = nowMs;
+		uint64_t hash = 1469598103934665603ull;
+		for (const ThreatEntry& entry : mob.threatTable)
+		{
+			hash = (hash ^ entry.entityId) * 1099511628211ull;
+			hash = (hash ^ static_cast<uint64_t>(entry.threat)) * 1099511628211ull;
+		}
+		mob.lastThreatHash = mob.threatTable.empty() ? 0u : hash;
 	}
 
 	void ServerApp::BroadcastAuraUpdate(EntityId entityId, const std::vector<ActiveAura>& auras)

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -257,6 +257,9 @@ namespace engine::server
 		uint32_t xpReward = 0;
 		/// Combat SP3 — auras actives (DoT, ralentissements, debuffs).
 		std::vector<ActiveAura> auras;
+		/// Combat SP4 — throttle du push ThreatUpdate (≤ 1/s et sur changement).
+		uint64_t lastThreatPushMs = 0;
+		uint64_t lastThreatHash = 0;
 	};
 
 	/// One spawn slot tracked by the authoritative spawner runtime.
@@ -600,6 +603,14 @@ namespace engine::server
 		/// Combat SP3 — broadcast la liste complète des auras d'une entité aux
 		/// clients intéressés (idempotent côté client).
 		void BroadcastAuraUpdate(EntityId entityId, const std::vector<ActiveAura>& auras);
+
+		/// Combat SP4 — pousse les tables de menace modifiées (≤ 1/s par mob).
+		/// Appelée depuis Simulate.
+		void PushThreatUpdates();
+
+		/// Combat SP4 — broadcast immédiat de la table de menace d'un mob (liste
+		/// vide = effacement côté client : mort, evade, reset).
+		void BroadcastThreatUpdate(MobEntity& mob);
 
 		/// Apply one mob attack against its current target when in range.
 		bool TryMobAttackPlayer(MobEntity& mob, ConnectedClient& target);


### PR DESCRIPTION
## Combat SP4 — menace répliquée, threat meter, FX d''auras

**Dernier sous-projet du chantier combat** (SP1 #873/#874, SP2 #876, SP3 #878/#879). Plan : `docs/superpowers/plans/2026-06-11-combat-sp4-menace-fx.md`.

> **Draft tant que #879 n''est pas mergée** : la branche contient les commits SP3-B en attendant ; le diff convergera vers le seul SP4 après le merge. La CI valide le cumul.

### Serveur + wire (v11→v12)
- Kind **`ThreatUpdate = 85`** : table de menace d''un mob (liste complète idempotente, vide = effacement) + tests roundtrip.
- `PushThreatUpdates` dans Simulate : push throttlé (1 s/mob) et uniquement sur changement (hash) ; effacement immédiat à la mort du mob et à l''evade.
- Rappel : l''IA d''agro (poursuite, leash, evade, threat) existait déjà (Waves 8/19) — SP4 n''ajoute que la réplication.

### Client
- **Threat meter enfin alimenté** (AdvancedCombatUi M39.4) : section « Menace » du panneau J — nom (« Vous » pour le local), pourcentage et barre vert/jaune/rouge, pilotés par le présentateur existant.
- **AuraFXSystem câblé** (dernier système combat orphelin de l''audit) : couche données synchronisée depuis les auras répliquées, rendu halo écran-espace coloré aux pieds des entités sous aura (couleurs de `ResolveAuraVisuals`, aucun nouvel asset).
- **Déviation assumée** : `AoEPreviewSystem` reste non câblé — il prévisualise un placement souris→sol or aucun sort des kits validés n''est ciblé-sol (Nova = autour de soi). Sera branché avec le premier sort `AreaAtTarget`.

### Validation en jeu attendue
Deux joueurs sur le sanglier → panneau J : menace des deux visibles, rouge sur le tank après Provocation, chute après Dérobade ; halo vert (HoT) sous le joueur, halo violet/rouge (DoT) sous le mob.

**Déploiement** : ⚠️ **wire v12** — master + shardd + client en **lock-step**. Une seule fenêtre de déploiement pour SP1→SP4 (rien n''a été déployé depuis v8). Ordre de merge : #878 → #879 → celle-ci (ready après #879).

🤖 Generated with [Claude Code](https://claude.com/claude-code)