### PR TITLE
feat(client): Groupes SP1 - PartyHud + invitations + ciblage allie (100% client)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2233,3 +2233,20 @@ kind `ThreatUpdate = 85` (table de menace d''un mob, liste complète idempotente
   validés — sera branché avec le premier sort AreaAtTarget). Cf. plan.
 - L''IA d''agro (poursuite/leash/evade/threat tick) existait déjà (Waves 8/19).
 - **Déploiement** : ⚠️ wire v12 — lock-step master + shardd + client (avec SP1-SP3).
+
+## Groupes SP1 — PartyHud + invitations + ciblage allié (2026-06-11)
+
+Plan : `docs/superpowers/plans/2026-06-11-party-sp1-hud-invitations.md`. **100 % client, AUCUN
+changement wire** (kinds party 25-32 de M32.2 déjà complets côté serveur — le serveur partage
+déjà l''XP et broadcast PartyUpdate).
+
+- Bug d''usage corrigé : le client IGNORAIT `PartyInviteNotify` (kind 26 non routé) et
+  n''émettait jamais PartyAccept/Decline — l''invité ne pouvait pas rejoindre. Routage +
+  popup « X vous invite » [Accepter]/[Refuser] + `SendPartyAccept/Decline`.
+- `PartyHudPresenter` (M32.2, orphelin de l''audit) câblé : cadres à gauche (nom, badge [C]
+  chef, barres PV/mana, label loot mode), rendu depuis `GetState().frames[]`.
+- **Ciblage allié** : clic sur un cadre = allié sélectionné (bordure or) → les sorts
+  `SingleAlly` (SP3) envoient son entityId (== clientId, invariant HandleHello) ; re-clic =
+  désélection ; le pick de mob ignore les clics sur les cadres.
+- Hors périmètre : persistance des groupes (tables 0060) — session-scoped, documenté.
+- **Déploiement** : ✅ client uniquement (au-dessus du lock-step v12 du chantier combat).

--- a/docs/superpowers/plans/2026-06-11-party-sp1-hud-invitations.md
+++ b/docs/superpowers/plans/2026-06-11-party-sp1-hud-invitations.md
@@ -1,0 +1,34 @@
+# Groupes SP1 — PartyHud + invitations + ciblage allié : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendre le système de groupes (M32.2, serveur complet et déjà utilisé par l'XP de groupe) utilisable de bout en bout : aujourd'hui `/invite` part bien au serveur via le chat, mais le client IGNORE `PartyInviteNotify` (kind 26 non routé) et n'émet jamais `PartyAccept`/`PartyDecline` — l'invité ne peut littéralement pas rejoindre. Et le `PartyHudPresenter` (orphelin de l'audit) n'affiche rien.
+
+**Architecture:** 100 % client, AUCUN changement wire (kinds 25-32 et leurs Encode/Decode existent depuis M32.2 ; `ApplyPartyUpdate` remplit déjà `UIModel::partyMembers`). Trois briques : (1) routage `PartyInviteNotify` → état d'invitation + popup Accepter/Refuser → `SendPartyAccept/Decline` ; (2) câblage du `PartyHudPresenter` (cadres membres à gauche : nom, badge chef, barres PV/mana, mode de loot) ; (3) **ciblage allié** : clic sur un cadre = cible alliée des sorts `SingleAlly` de SP3 (le serveur l'accepte déjà — le client envoyait toujours 0/soi). Identité : `entityId == clientId` pour les joueurs (invariant ServerApp::HandleHello, documenté au site).
+
+**Hors périmètre (documenté) :** persistance des groupes (tables 0060) — les groupes sont session-scoped comme l'implémentation serveur actuelle ; les tables restent provisionnées pour un futur chantier raid/reconnexion.
+
+**Livraison : 1 PR `party-sp1` (client only)** → ✅ pas de redéploiement serveur (mais la PR part au-dessus du chantier combat : merge après #881).
+
+### Task 1: UIModel — état d'invitation
+- `struct UIPartyInviteState { bool pending = false; std::string inviterName; }` ; membre `UIModel::partyInvite`.
+- Routage `MessageKind::PartyInviteNotify` → `ApplyPartyInviteNotify` (scratch message, set pending + notify `UIModelChangeParty`).
+- `UIModelBinding::ClearPartyInvite()` public (appelé par Engine après Accepter/Refuser) ; `ApplyPartyUpdate` efface aussi `partyInvite` (l'invitation est consommée quand on rejoint).
+
+### Task 2: GameplayUdpClient — `SendPartyAccept(clientId)` / `SendPartyDecline(clientId)` (pattern SendRespawnRequest, encodeurs existants).
+
+### Task 3: Engine — PartyHud + popup + ciblage allié
+- Membres : `PartyHudPresenter m_partyHud` (+ include), `uint64_t m_selectedAllyEntityId = 0`.
+- GameplayNet Init/Shutdown/SetViewportSize + observer `ApplyModel`.
+- Rendu (bloc combat SP2, in-world) : si `inParty` — cadres depuis `GetState().frames[]` (fond, nom + badge « C » chef, barre PV verte, barre mana bleue, label loot mode) sur la gauche ; cadre de l'allié sélectionné surligné or.
+- Clic gauche sur un cadre (prioritaire sur le pick mob, mêmes gardes souris) : sélectionne l'allié (`entityId = clientId` du membre ; re-clic = désélection). Mort/départ du membre → reset.
+- Sorts `SingleAlly` (barre d'action SP3) : envoient `m_selectedAllyEntityId` si non nul (le serveur valide groupe/portée/vivant, fallback soi).
+- Popup invitation : fenêtre centrée « <inviter> vous invite dans un groupe » + [Accepter] [Refuser] → Send* + `ClearPartyInvite()` ; visible même hors gardes clavier (c'est une modale souris).
+- `SpellDisplay` (SpellKitCatalog) : + `bool targetsAlly` (targetType == "SingleAlly").
+
+### Task 4: Docs + PR
+CODEBASE_MAP (section Groupes SP1), push, PR (base main après merge #881 ; draft cumul sinon). **Déploiement : ✅ client uniquement** (au-dessus du lock-step v12 du chantier combat).
+
+## Self-review
+- Boucle complète : /invite (chat, existant) → notify (routé) → popup → accept/decline (émis) → PartyUpdate (déjà routé) → PartyHud (câblé) → XP partagée (déjà active) → soins ciblés (SP3 + ciblage allié).
+- Pas de nouveau bind clavier (souris uniquement) ; pas de changement serveur ni wire.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10272,6 +10272,29 @@ namespace engine
 					{
 						constexpr float kPickRadiusPx = 40.0f;
 						const ImVec2 mousePos = ImGui::GetIO().MousePos;
+						// Groupes SP1 — un clic sur un cadre de groupe est une sélection
+						// d'allié (gérée plus bas), jamais un pick de mob.
+						bool overPartyFrame = false;
+						if (uiModel.inParty)
+						{
+							const engine::client::PartyHudState& partyPickState = m_partyHud.GetState();
+							for (size_t pickFrame = 0; pickFrame < engine::client::kMaxPartyFrames; ++pickFrame)
+							{
+								const engine::client::PartyMemberFrame& pframe = partyPickState.frames[pickFrame];
+								if (!pframe.visible)
+								{
+									continue;
+								}
+								if (mousePos.x >= pframe.frameBounds.x
+									&& mousePos.x <= pframe.frameBounds.x + pframe.frameBounds.width
+									&& mousePos.y >= pframe.frameBounds.y
+									&& mousePos.y <= pframe.frameBounds.y + pframe.frameBounds.height)
+								{
+									overPartyFrame = true;
+									break;
+								}
+							}
+						}
 						engine::server::EntityId pickedId = 0;
 						float bestDistSq = kPickRadiusPx * kPickRadiusPx;
 						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
@@ -10297,7 +10320,7 @@ namespace engine
 								pickedId = re.entityId;
 							}
 						}
-						if (pickedId != 0)
+						if (pickedId != 0 && !overPartyFrame)
 							(void)m_uiModelBinding.SetLocalTarget(pickedId);
 					}
 
@@ -10547,9 +10570,17 @@ namespace engine
 								const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
 								if (targetOk && ready && gameplayClientId != 0u)
 								{
-									const uint64_t castTarget = spell.needsEnemyTarget
-										? uiModel.targetStats.entityId
-										: 0ull;
+									// Groupes SP1 — sorts d'allié : envoie l'allié sélectionné au
+									// cadre de groupe (0 = soi, défaut serveur).
+									uint64_t castTarget = 0ull;
+									if (spell.needsEnemyTarget)
+									{
+										castTarget = uiModel.targetStats.entityId;
+									}
+									else if (spell.targetsAlly)
+									{
+										castTarget = m_selectedAllyEntityId;
+									}
 									(void)m_gameplayUdp.SendCastRequest(gameplayClientId, castTarget, spell.spellId);
 									if (spell.cooldownMs > 0u)
 									{
@@ -10770,6 +10801,128 @@ namespace engine
 								fg->AddCircle(ImVec2(haloX, haloY), 20.0f, haloColor, 24, 2.5f);
 							}
 						}
+					}
+
+					// --- Groupes SP1 : cadres de groupe (PartyHudPresenter M32.2 enfin
+					// câblé) + ciblage allié au clic (consommé par les sorts SingleAlly).
+					if (uiModel.inParty)
+					{
+						const engine::client::PartyHudState& partyState = m_partyHud.GetState();
+						// Mapping cadre → membre : même ordre que le présentateur
+						// (slot 0 = joueur local, puis l'ordre de partyMembers).
+						std::vector<uint32_t> frameClientIds;
+						frameClientIds.push_back(uiModel.playerStats.clientId);
+						for (const engine::client::UIPartyMemberEntry& member : uiModel.partyMembers)
+						{
+							if (member.clientId != uiModel.playerStats.clientId)
+							{
+								frameClientIds.push_back(member.clientId);
+							}
+						}
+						const bool clickThisFrame = mouseAllowed
+							&& m_input.WasMousePressed(engine::platform::MouseButton::Left);
+						const ImVec2 mousePosParty = ImGui::GetIO().MousePos;
+						for (size_t frameIndex = 0; frameIndex < engine::client::kMaxPartyFrames; ++frameIndex)
+						{
+							const engine::client::PartyMemberFrame& frame = partyState.frames[frameIndex];
+							if (!frame.visible)
+							{
+								continue;
+							}
+							const engine::client::HudRect& fb = frame.frameBounds;
+							// entityId == clientId pour les joueurs (invariant HandleHello).
+							const uint64_t memberEntityId = (frameIndex < frameClientIds.size())
+								? static_cast<uint64_t>(frameClientIds[frameIndex])
+								: 0ull;
+							const bool isSelectedAlly = (memberEntityId != 0ull
+								&& memberEntityId == m_selectedAllyEntityId);
+							fg->AddRectFilled(ImVec2(fb.x, fb.y), ImVec2(fb.x + fb.width, fb.y + fb.height),
+								IM_COL32(12, 14, 20, 205), 5.0f);
+							fg->AddRect(ImVec2(fb.x, fb.y), ImVec2(fb.x + fb.width, fb.y + fb.height),
+								isSelectedAlly ? IM_COL32(220, 190, 90, 240) : IM_COL32(80, 84, 96, 200),
+								5.0f, 0, isSelectedAlly ? 2.5f : 1.5f);
+							std::string memberLabel = frame.displayName;
+							if (frame.isLeader)
+							{
+								memberLabel += "  [C]";
+							}
+							fg->AddText(ImVec2(fb.x + 6.0f, fb.y + 4.0f), IM_COL32(230, 230, 230, 255), memberLabel.c_str());
+							// Barres PV / mana depuis les widgets du présentateur.
+							auto drawMemberBar = [fg](const engine::client::HudBarWidget& bar, ImU32 fillColor)
+							{
+								if (!bar.visible || bar.bounds.width <= 0.0f)
+								{
+									return;
+								}
+								const float fillFraction = (bar.maxValue > 0u)
+									? std::clamp(static_cast<float>(bar.currentValue) / static_cast<float>(bar.maxValue), 0.0f, 1.0f)
+									: 0.0f;
+								fg->AddRectFilled(ImVec2(bar.bounds.x, bar.bounds.y),
+									ImVec2(bar.bounds.x + bar.bounds.width, bar.bounds.y + bar.bounds.height),
+									IM_COL32(34, 36, 42, 220), 2.0f);
+								fg->AddRectFilled(ImVec2(bar.bounds.x, bar.bounds.y),
+									ImVec2(bar.bounds.x + bar.bounds.width * fillFraction, bar.bounds.y + bar.bounds.height),
+									fillColor, 2.0f);
+							};
+							drawMemberBar(frame.hpBar, IM_COL32(70, 170, 80, 235));
+							drawMemberBar(frame.manaBar, IM_COL32(70, 110, 200, 235));
+							// Clic sur le cadre = sélection/désélection de l'allié (soins).
+							if (clickThisFrame && memberEntityId != 0ull
+								&& mousePosParty.x >= fb.x && mousePosParty.x <= fb.x + fb.width
+								&& mousePosParty.y >= fb.y && mousePosParty.y <= fb.y + fb.height)
+							{
+								m_selectedAllyEntityId = isSelectedAlly ? 0ull : memberEntityId;
+								LOG_INFO(Core, "[Engine] Allié sélectionné (entity_id={})", m_selectedAllyEntityId);
+							}
+						}
+						// Label du mode de loot sous les cadres.
+						if (partyState.visibleCount > 0u)
+						{
+							const engine::client::HudRect& lastFrame =
+								partyState.frames[partyState.visibleCount - 1u].frameBounds;
+							const std::string lootLabel = "Loot: " + partyState.lootModeLabel;
+							fg->AddText(ImVec2(lastFrame.x, lastFrame.y + lastFrame.height + 6.0f),
+								IM_COL32(190, 190, 190, 220), lootLabel.c_str());
+						}
+					}
+					else if (m_selectedAllyEntityId != 0ull)
+					{
+						// Sorti du groupe : plus d'allié sélectionnable.
+						m_selectedAllyEntityId = 0ull;
+					}
+
+					// --- Groupes SP1 : popup d'invitation (Accepter / Refuser).
+					// Modale souris : affichée même pendant un cast ou un menu.
+					if (uiModel.partyInvite.pending)
+					{
+						const float inviteW = 380.0f;
+						const float inviteH = 140.0f;
+						ImGui::SetNextWindowPos(ImVec2((dw - inviteW) * 0.5f, dh * 0.22f), ImGuiCond_Always);
+						ImGui::SetNextWindowSize(ImVec2(inviteW, inviteH), ImGuiCond_Always);
+						ImGui::SetNextWindowBgAlpha(0.96f);
+						ImGui::Begin("##ln_party_invite", nullptr,
+							ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove
+							| ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
+						const std::string inviteText = uiModel.partyInvite.inviterName + " vous invite dans un groupe";
+						const float inviteTextW = ImGui::CalcTextSize(inviteText.c_str()).x;
+						ImGui::SetCursorPosX((inviteW - inviteTextW) * 0.5f);
+						ImGui::TextUnformatted(inviteText.c_str());
+						ImGui::Separator();
+						ImGui::Spacing();
+						const uint32_t inviteClientId = m_gameplayUdp.ServerClientId();
+						ImGui::SetCursorPosX((inviteW - 2.0f * 150.0f - 12.0f) * 0.5f);
+						if (ImGui::Button("Accepter", ImVec2(150.0f, 36.0f)) && inviteClientId != 0u)
+						{
+							(void)m_gameplayUdp.SendPartyAccept(inviteClientId);
+							m_uiModelBinding.ClearPartyInvite();
+						}
+						ImGui::SameLine();
+						if (ImGui::Button("Refuser", ImVec2(150.0f, 36.0f)) && inviteClientId != 0u)
+						{
+							(void)m_gameplayUdp.SendPartyDecline(inviteClientId);
+							m_uiModelBinding.ClearPartyInvite();
+						}
+						ImGui::End();
 					}
 
 					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →
@@ -12724,6 +12877,11 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] AuraFXSystem Init FAILED — FX d'auras désactivés");
 		}
+		// Groupes SP1 — cadres de groupe (M32.2).
+		if (!m_partyHud.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] PartyHudPresenter Init FAILED — cadres de groupe désactivés");
+		}
 
 		const uint32_t vw = static_cast<uint32_t>(std::max(1, m_width));
 		const uint32_t vh = static_cast<uint32_t>(std::max(1, m_height));
@@ -12749,6 +12907,11 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] BuffBarPresenter viewport FAILED — using fallback layout");
 		}
+		// Groupes SP1 — layout pixel des cadres de groupe.
+		if (!m_partyHud.SetViewportSize(vw, vh))
+		{
+			LOG_WARN(Core, "[GameplayNet] PartyHudPresenter viewport FAILED — using fallback layout");
+		}
 
 		m_uiObserverHandle = m_uiModelBinding.AddObserver(
 			[this](const engine::client::UIModel& model, uint32_t changeMask)
@@ -12760,6 +12923,8 @@ namespace engine
 				// (combat log, cadre cible, DPS meter) et Stats (PV joueur).
 				(void)m_combatHud.ApplyModel(model, changeMask);
 				m_advancedCombat.ApplyModel(model, changeMask);
+				// Groupes SP1 — cadres de groupe (UIModelChangeParty).
+				(void)m_partyHud.ApplyModel(model, changeMask);
 			});
 		if (m_uiObserverHandle == 0u)
 		{
@@ -12826,7 +12991,9 @@ namespace engine
 			m_uiObserverHandle = 0;
 		}
 
-		// Combat SP2/SP3/SP4 — symétrie d'Init (présentateurs combat + BuffBar + FX).
+		// Combat SP2/SP3/SP4 + Groupes SP1 — symétrie d'Init.
+		m_partyHud.Shutdown();
+		m_selectedAllyEntityId = 0;
 		m_auraFx.Shutdown();
 		m_buffBar.Shutdown();
 		m_spellCooldownUiUntilSec.clear();

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -35,6 +35,8 @@
 #include "src/client/gameplay/SpellKitCatalog.h"
 // Combat SP4 — FX visuels d'auras (halo aux pieds des entités).
 #include "src/client/combat/AuraFXSystem.h"
+// Groupes SP1 — cadres de groupe (M32.2 enfin câblé).
+#include "src/client/social/PartyHud.h"
 #include "src/client/debug/ProfilerHud.h"
 #include "src/client/economy/ShopUi.h"
 #include "src/client/ui_common/UIModel.h"
@@ -1281,6 +1283,12 @@ namespace engine
 		/// Combat SP4 — FX d'auras (couche données ; rendu = halo écran-espace
 		/// coloré aux pieds, couleur résolue par ResolveAuraVisuals).
 		engine::client::AuraFXSystem m_auraFx{};
+		/// Groupes SP1 — cadres de groupe (PV/mana/nom/chef) + ciblage allié.
+		engine::client::PartyHudPresenter m_partyHud{};
+		/// Groupes SP1 — allié sélectionné au clic sur un cadre (entityId ==
+		/// clientId pour les joueurs, invariant ServerApp::HandleHello) ; 0 = soi.
+		/// Consommé par les sorts SingleAlly de la barre d'action (SP3).
+		uint64_t m_selectedAllyEntityId = 0;
 		/// Combat SP3 — cooldowns AFFICHÉS de la barre d'action (spellId → fin en
 		/// secondes EngineNowSec) ; purement cosmétique, le serveur fait foi.
 		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;

--- a/src/client/gameplay/SpellKitCatalog.cpp
+++ b/src/client/gameplay/SpellKitCatalog.cpp
@@ -515,6 +515,7 @@ namespace engine::client
 			spell.spellId = idValue->stringValue;
 			spell.name = nameValue->stringValue;
 			spell.needsEnemyTarget = (targetValue->stringValue == "SingleEnemy");
+			spell.targetsAlly = (targetValue->stringValue == "SingleAlly");
 			kit.push_back(std::move(spell));
 		}
 

--- a/src/client/gameplay/SpellKitCatalog.h
+++ b/src/client/gameplay/SpellKitCatalog.h
@@ -23,6 +23,9 @@ namespace engine::client
 		uint32_t resourceCostPercent = 0;
 		/// true si le sort exige une cible ennemie (targetType SingleEnemy).
 		bool needsEnemyTarget = false;
+		/// Groupes SP1 — true si le sort vise un allié (targetType SingleAlly) :
+		/// la barre d'action envoie alors l'allié sélectionné au cadre de groupe.
+		bool targetsAlly = false;
 	};
 
 	/// Combat SP3 — catalogue client des kits de sorts (même

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -317,6 +317,40 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendPartyAccept(uint32_t clientId)
+	{
+		engine::server::PartyAcceptMessage msg{};
+		msg.clientId = clientId;
+		const std::vector<std::byte> packet = engine::server::EncodePartyAccept(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] PartyAccept sent (client_id={})", clientId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] PartyAccept FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendPartyDecline(uint32_t clientId)
+	{
+		engine::server::PartyDeclineMessage msg{};
+		msg.clientId = clientId;
+		const std::vector<std::byte> packet = engine::server::EncodePartyDecline(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] PartyDecline sent (client_id={})", clientId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] PartyDecline FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity)
 	{
 		engine::server::ShopBuyRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -63,6 +63,12 @@ namespace engine::client
 		/// cible, portée).
 		bool SendCastRequest(uint32_t clientId, uint64_t targetEntityId, std::string_view spellId);
 
+		/// Groupes SP1 — accepte l'invitation de groupe en attente (M32.2).
+		bool SendPartyAccept(uint32_t clientId);
+
+		/// Groupes SP1 — refuse l'invitation de groupe en attente (M32.2).
+		bool SendPartyDecline(uint32_t clientId);
+
 		bool SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);
 
 		bool SendShopSellRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -619,6 +619,9 @@ namespace engine::client
 			return ApplyAuraUpdate(packet);
 		case engine::server::MessageKind::ThreatUpdate:
 			return ApplyThreatUpdate(packet);
+		// Groupes SP1 — invitation entrante (le reste du flux party était déjà routé).
+		case engine::server::MessageKind::PartyInviteNotify:
+			return ApplyPartyInviteNotify(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -989,6 +992,35 @@ namespace engine::client
 		return true;
 	}
 
+	bool UIModelBinding::ApplyPartyInviteNotify(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodePartyInviteNotify(packet, m_partyInviteNotifyMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] PartyInviteNotify FAILED: decode error");
+			return false;
+		}
+
+		m_model.partyInvite.pending = true;
+		m_model.partyInvite.inviterName = m_partyInviteNotifyMessage.inviterName;
+		LOG_INFO(Net, "[UIModelBinding] Party invite received (inviter={})", m_model.partyInvite.inviterName);
+		NotifyObservers(UIModelChangeParty);
+		return true;
+	}
+
+	void UIModelBinding::ClearPartyInvite()
+	{
+		if (!ValidateMainThread("ClearPartyInvite"))
+		{
+			return;
+		}
+		if (!m_model.partyInvite.pending)
+		{
+			return;
+		}
+		m_model.partyInvite = UIPartyInviteState{};
+		NotifyObservers(UIModelChangeParty);
+	}
+
 	bool UIModelBinding::SetLocalTarget(engine::server::EntityId entityId)
 	{
 		if (!ValidateMainThread("SetLocalTarget"))
@@ -1261,6 +1293,11 @@ namespace engine::client
 		m_model.partyMembers.reserve(msg.members.size());
 		m_model.partyLeaderId = msg.leaderId;
 		m_model.inParty       = !msg.members.empty();
+		// Groupes SP1 — rejoindre un groupe consomme l'invitation en attente.
+		if (m_model.inParty)
+		{
+			m_model.partyInvite = UIPartyInviteState{};
+		}
 
 		switch (msg.lootMode)
 		{

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -237,6 +237,13 @@ namespace engine::client
 		uint64_t startedAtNs = 0;
 	};
 
+	/// Groupes SP1 — invitation de groupe en attente (PartyInviteNotify, M32.2).
+	struct UIPartyInviteState
+	{
+		bool pending = false;
+		std::string inviterName;
+	};
+
 	/// Combat SP4 — une entrée de menace répliquée (ThreatUpdate, wire v12).
 	struct UIThreatEntry
 	{
@@ -398,6 +405,8 @@ namespace engine::client
 		/// TD.1 : avatars distants (≠ joueur local) reçus dans le dernier snapshot AoI.
 		/// Reconstruit à chaque ApplySnapshot. Consommé par le rendu monde (TD.2).
 		std::vector<UIRemoteEntity> remoteEntities;
+		/// Groupes SP1 — invitation en attente (popup Accepter/Refuser).
+		UIPartyInviteState partyInvite{};
 		/// M32.2: True when the local player is currently in a party.
 		bool        inParty          = false;
 		/// M32.2: Human-readable loot mode label received in the last PartyUpdate (e.g. "FreeForAll").
@@ -486,6 +495,10 @@ namespace engine::client
 		/// Combat SP2 — efface la cible courante (notifie UIModelChangeCombat).
 		void ClearLocalTarget();
 
+		/// Groupes SP1 — consomme l'invitation en attente (après Accepter/Refuser).
+		/// Notifie UIModelChangeParty. Main thread uniquement.
+		void ClearPartyInvite();
+
 		/// M29.3: Refresh billboard projections (call from render/game thread with camera + viewport).
 		void TickChatWorldVisuals(
 			const engine::math::Vec3& cameraWorld,
@@ -524,6 +537,9 @@ namespace engine::client
 
 		/// Combat SP4 — remplace la table de menace d'un mob (ThreatUpdate).
 		bool ApplyThreatUpdate(std::span<const std::byte> packet);
+
+		/// Groupes SP1 — invitation de groupe entrante (PartyInviteNotify).
+		bool ApplyPartyInviteNotify(std::span<const std::byte> packet);
 
 		/// Apply one decoded zone change packet to the world section of the UI model.
 		bool ApplyZoneChange(std::span<const std::byte> packet);
@@ -620,6 +636,7 @@ namespace engine::client
 		engine::server::CastBarUpdateMessage m_castBarUpdateMessage{};
 		engine::server::AuraUpdateMessage m_auraUpdateMessage{};
 		engine::server::ThreatUpdateMessage m_threatUpdateMessage{};
+		engine::server::PartyInviteNotifyMessage m_partyInviteNotifyMessage{};
 		engine::server::ZoneChangeMessage m_zoneChangeMessage{};
 		engine::server::InventoryDeltaMessage m_inventoryMessage{};
 		engine::server::QuestDeltaMessage m_questMessage{};


### PR DESCRIPTION
## Groupes SP1 — le système de groupes enfin utilisable de bout en bout

Chantier n°2 de la liste validée (combat → **groupes** → métiers → prédiction). Plan : `docs/superpowers/plans/2026-06-11-party-sp1-hud-invitations.md`. Stackée sur #881 (SP4) — **100 % client, aucun changement wire ni serveur**.

### Le bug d''usage découvert
Le serveur M32.2 est complet (invitations, kick, loot mode, partage d''XP déjà actif depuis le chantier combat) et `/invite` part bien via le chat… mais le client **ignorait `PartyInviteNotify`** (kind 26 non routé — warn « unsupported message kind ») et **n''émettait jamais `PartyAccept`/`PartyDecline`**. L''invité ne pouvait littéralement pas rejoindre un groupe.

### Contenu
- **Invitations** : routage de PartyInviteNotify → popup « X vous invite dans un groupe » [Accepter] [Refuser] → `SendPartyAccept/Decline` (encodeurs M32.2 existants) ; l''invitation est consommée au PartyUpdate.
- **PartyHud câblé** (orphelin M32.2 de l''audit) : cadres des membres à gauche — nom, badge [C] du chef, barres PV/mana, label du mode de loot — layout du présentateur existant.
- **Ciblage allié** : clic sur un cadre = allié sélectionné (bordure or, re-clic = désélection) → les sorts `SingleAlly` de SP3 (Soin rapide, Rémission, Imposition des mains) soignent enfin un AUTRE joueur (le serveur validait déjà groupe/portée/vivant ; `entityId == clientId` pour les joueurs, invariant HandleHello documenté au site). Le pick de mob ignore les clics sur les cadres.
- Hors périmètre documenté : persistance des groupes (tables 0060) — session-scoped comme le serveur actuel.

### Validation en jeu attendue
À deux clients : `/invite P2` → popup chez P2 → Accepter → cadres visibles des deux côtés, PV/mana qui vivent ; healer : clic sur le cadre de l''allié → Soin rapide le soigne ; XP partagée au kill (déjà active) ; `/leave` nettoie.

### Ordre de merge
Après #881 (la PR rebasculera alors sur main). **Déploiement : ✅ client uniquement** — porté par la fenêtre lock-step v12 du chantier combat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)