### PR TITLE
feat(metiers): SP1 - recolte et artisanat de bout en bout (nodes repliques, E/K, presentateurs cables)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2250,3 +2250,21 @@ déjà l''XP et broadcast PartyUpdate).
   désélection ; le pick de mob ignore les clics sur les cadres.
 - Hors périmètre : persistance des groupes (tables 0060) — session-scoped, documenté.
 - **Déploiement** : ✅ client uniquement (au-dessus du lock-step v12 du chantier combat).
+
+## Métiers SP1 — récolte + artisanat de bout en bout (2026-06-11)
+
+Plan : `docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md`. **Pas de bump wire**
+(kinds 64-68/70-77 de M36.x déjà complets) — serveur touché = réplication des nodes (additif).
+
+- Constat : nodes de récolte non répliqués (« no replication » d''origine), AUCUNE donnée de
+  zone, client n''émettant aucun message métiers, présentateurs orphelins.
+- Données : `game/data/zones/zone_0/gathering_nodes.json` (3 nodes : minerai/herbe/arbre).
+- Serveur : nodes dans la grille d''intérêt + branche `TryBuildSnapshotEntity` —
+  `archetypeId = kGatheringNodeArchetypeBase (1 000 000) + typeId` (plage réservée,
+  ReplicationTypes.h), flag dead = épuisé.
+- Client : labels flottants des nodes (noms FR par type + [E] à portée, grisé épuisé),
+  exclus du mesh/ciblage combat ; **E** = HarvestRequest (priorité interactibles) ;
+  `HarvestCastBarPresenter` câblé ; **K** = panneau Artisanat (`CraftingUiPresenter` câblé :
+  onglets métiers → CraftRecipeListRequest, sélection → CraftRequest, annulation, cast bar,
+  qualité M36.3). Touche K ajoutée à l''enum Key (leçon SP2).
+- **Déploiement** : ⚠️ shardd (réplication nodes) — porté par la fenêtre lock-step v12.

--- a/docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md
+++ b/docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md
@@ -1,0 +1,37 @@
+# Métiers SP1 — Récolte + artisanat de bout en bout : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Chantier n°3 de la liste validée. Les systèmes serveur M36.1/M36.2 (GatheringSystem, CraftingSystem) tournent et tous les kinds wire existent (64-68 récolte, 70-77 artisanat) — mais : (a) les **nodes de récolte ne sont pas répliqués** (le client ne peut ni les voir ni connaître leurs entityId — « no replication » assumé par le header d'origine), (b) **aucune donnée de nodes** n'existe en zone, (c) le client **n'émet aucun** des messages (HarvestRequest, CraftRecipeListRequest, CraftRequest…), (d) les présentateurs `HarvestCastBarPresenter` et `CraftingUiPresenter` sont orphelins (audit).
+
+**Architecture:** Réplication des nodes par le canal snapshot existant SANS bump wire : les nodes entrent dans la grille d'intérêt et `TryBuildSnapshotEntity` gagne une branche node avec `archetypeId = kGatheringNodeArchetypeBase (1 000 000) + typeId` (constante partagée dans ReplicationTypes.h ; le format u32 ne change pas). `stateFlags = kEntityStateDead` encode « épuisé » (label grisé). Côté client : labels flottants (pas de mesh V1 — noms FR par type), touche **E** (interact, déjà réservée) sur le node le plus proche à portée quand aucun interactible local n'a la priorité, `HarvestCastBar` câblée (UIModel.harvest déjà alimenté), panneau d'artisanat **K** (CraftingUi câblée : onglets métiers → CraftRecipeListRequest, ligne → sélection, bouton → CraftRequest, cast bar + qualité M36.3).
+
+**Livraison : 1 PR `metiers-sp1`** (serveur léger + client), stackée sur party-sp1. Déploiement : ⚠️ shardd à redéployer (réplication des nodes) — porté par la fenêtre lock-step v12 du chantier combat ; pas de bump de version.
+
+### Task 1 — Données : `game/data/zones/zone_0/gathering_nodes.json`
+Schéma de `GatheringSystem::LoadZoneNodes` : `{ "zoneId": 0, "nodes": [ { "id": "...", "type_id": 1-4, "position": [x,y,z] } ] }`. 3 nodes près du spawn (minerai type 1, herbe type 2, arbre type 3).
+
+### Task 2 — Réplication des nodes (serveur, pas de bump)
+- `ReplicationTypes.h` : `inline constexpr uint32_t kGatheringNodeArchetypeBase = 1000000u;` (doc : plage réservée, jamais un archétype de créature).
+- `GatheringSystem.h` : accesseur `const std::vector<ResourceNodeRuntimeState>& Nodes() const`.
+- `ServerApp::InitGathering` : enregistre chaque node dans la grille de sa zone (`UpsertEntity`) → ils entrent dans l'AoI/replicatedEntityIds.
+- `TryBuildSnapshotEntity` : branche node (position, hp 1/1, `stateFlags` = dead si épuisé, archetypeId = base + typeId).
+
+### Task 3 — Client : émissions réseau
+`GameplayUdpClient` : `SendHarvestRequest(clientId, nodeEntityId)`, `SendHarvestCancelRequest(clientId)`, `SendCraftRecipeListRequest(clientId, professionKey)`, `SendCraftRequest(clientId, recipeId)`, `SendCraftCancelRequest(clientId)` (encodeurs existants). `UIModelBinding::SelectCraftRecipe(rowIndex)` (mutation + notif Crafting).
+
+### Task 4 — Client : récolte
+- Rendu : labels flottants des nodes dans la boucle nameplates (archetypeId ≥ base) — noms FR par type (map locale V1 : 1 « Filon de minerai », 2 « Herbes », 3 « Arbre », 4 « Carcasse » — les noms en data = amélioration future) + « [E] » si à portée (~5 m) et disponible ; grisé si épuisé. Les nodes sont EXCLUS du rendu mesh des mobs (RecordRemoteAvatars saute archetypeId ≥ base) et du ciblage Tab/clic combat.
+- Interaction : E (gardes inGame habituelles) — si aucun interactible local actif (`m_interactableInRange < 0`) et node disponible le plus proche < 5 m → `SendHarvestRequest`. Le serveur valide tout ; l'annulation au mouvement est déjà serveur.
+- `HarvestCastBarPresenter` câblé (Init/viewport/observer/rendu barre depuis GetState()).
+
+### Task 5 — Client : artisanat (touche K)
+`CraftingUiPresenter` câblé + panneau ImGui : onglets métiers (`crafting.professions`) → `SendCraftRecipeListRequest` ; lignes de recettes → `SelectCraftRecipe` ; bouton Fabriquer (actif si sélection) → `SendCraftRequest` ; cast bar `craftFillFraction` ; libellé qualité M36.3 (couleur du présentateur) ; statut/compétence affichés. K déclaré au registre de binds (libre, vérifié).
+
+### Task 6 — Docs + PR
+CODEBASE_MAP, push, PR stackée + draft CI cumul si la pile n'est pas encore mergée.
+
+## Self-review
+- Bout en bout : voir un node → E → cast bar → loot en inventaire (InventoryDelta déjà routé) + skill-up (ProfessionUpdate déjà routé) → K → liste de recettes → fabrication → cast bar + qualité.
+- Pas de bump wire ; serveur touché = réplication des nodes uniquement (additif).
+- AoEPreview/SkillSystem non concernés. Touches : E réutilisée (priorité interactibles), K nouvelle (libre).

--- a/game/data/zones/zone_0/gathering_nodes.json
+++ b/game/data/zones/zone_0/gathering_nodes.json
@@ -1,0 +1,8 @@
+{
+  "zoneId": 0,
+  "nodes": [
+    { "id": "zone_0_ore_01", "type_id": 1, "position": [102.0, 0.0, 90.0] },
+    { "id": "zone_0_herb_01", "type_id": 2, "position": [88.0, 0.0, 100.0] },
+    { "id": "zone_0_tree_01", "type_id": 3, "position": [110.0, 0.0, 104.0] }
+  ]
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10203,7 +10203,10 @@ namespace engine
 						if (re.playerClientId == 0u && re.archetypeId == 0u)
 							continue; // loot bag : pas de nameplate
 						// Mob mort en attente de despawn : pas de plaque (kEntityStateDead).
-						if (re.playerClientId == 0u && (re.stateFlags & 1u) != 0u)
+						// Métiers SP1 — les nodes échappent à ce skip : un node épuisé
+						// garde sa plaque, grisée avec le suffixe « (epuise) ».
+						if (re.playerClientId == 0u && (re.stateFlags & 1u) != 0u
+							&& re.archetypeId < engine::server::kGatheringNodeArchetypeBase)
 							continue;
 						float wx = re.positionX, wy = re.positionY, wz = re.positionZ;
 						const auto sit = m_remoteSmoothed.find(re.entityId);
@@ -10227,6 +10230,38 @@ namespace engine
 							label = !re.displayName.empty()
 								? re.displayName
 								: ("P" + std::to_string(re.playerClientId));
+						}
+						else if (re.archetypeId >= engine::server::kGatheringNodeArchetypeBase)
+						{
+							// Métiers SP1 — label de node de récolte : nom FR par type
+							// (V1 : map locale ; les noms en data = amélioration future)
+							// + « [E] » si disponible et à portée de récolte (~5 m).
+							const uint32_t nodeTypeId =
+								re.archetypeId - engine::server::kGatheringNodeArchetypeBase;
+							const char* nodeName = "Ressource";
+							switch (nodeTypeId)
+							{
+							case 1u: nodeName = "Filon de minerai"; break;
+							case 2u: nodeName = "Herbes sauvages"; break;
+							case 3u: nodeName = "Arbre a abattre"; break;
+							case 4u: nodeName = "Carcasse"; break;
+							default: break;
+							}
+							label = nodeName;
+							if ((re.stateFlags & 1u) != 0u)
+							{
+								label += " (epuise)";
+							}
+							else
+							{
+								const engine::math::Vec3 playerPosNode = m_characterController.GetPosition();
+								const float dxNode = re.positionX - playerPosNode.x;
+								const float dzNode = re.positionZ - playerPosNode.z;
+								if ((dxNode * dxNode + dzNode * dzNode) <= 25.0f)
+								{
+									label += " [E]";
+								}
+							}
 						}
 						else
 						{
@@ -10299,8 +10334,10 @@ namespace engine
 						float bestDistSq = kPickRadiusPx * kPickRadiusPx;
 						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
 						{
-							// V1 : seuls les mobs vivants sont ciblables (pas de PvP).
-							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u)
+							// V1 : seuls les mobs vivants sont ciblables (pas de PvP ;
+							// les nodes de récolte — plage réservée — sont exclus).
+							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u
+								|| re.archetypeId >= engine::server::kGatheringNodeArchetypeBase)
 								continue;
 							float wx = re.positionX, wy = re.positionY, wz = re.positionZ;
 							const auto sit = m_remoteSmoothed.find(re.entityId);
@@ -10331,7 +10368,8 @@ namespace engine
 						std::vector<std::pair<float, engine::server::EntityId>> candidates;
 						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
 						{
-							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u)
+							if (re.archetypeId == 0u || (re.stateFlags & 1u) != 0u
+								|| re.archetypeId >= engine::server::kGatheringNodeArchetypeBase)
 								continue;
 							const float dxc = re.positionX - playerPos.x;
 							const float dzc = re.positionZ - playerPos.z;
@@ -10921,6 +10959,157 @@ namespace engine
 						{
 							(void)m_gameplayUdp.SendPartyDecline(inviteClientId);
 							m_uiModelBinding.ClearPartyInvite();
+						}
+						ImGui::End();
+					}
+
+					// --- Métiers SP1 : récolte — touche E sur le node disponible le
+					// plus proche (~5 m) ; les interactibles locaux gardent la priorité.
+					{
+						const engine::math::Vec3 playerPosHarvest = m_characterController.GetPosition();
+						uint64_t nearestNodeId = 0;
+						float nearestNodeDistSq = 25.0f; // 5 m de portée de récolte V1.
+						for (const engine::client::UIRemoteEntity& re : uiModel.remoteEntities)
+						{
+							if (re.archetypeId < engine::server::kGatheringNodeArchetypeBase)
+								continue;
+							if ((re.stateFlags & 1u) != 0u)
+								continue; // épuisé
+							const float dxn = re.positionX - playerPosHarvest.x;
+							const float dzn = re.positionZ - playerPosHarvest.z;
+							const float distSqN = dxn * dxn + dzn * dzn;
+							if (distSqN < nearestNodeDistSq)
+							{
+								nearestNodeDistSq = distSqN;
+								nearestNodeId = re.entityId;
+							}
+						}
+						if (keysAllowed && nearestNodeId != 0ull
+							&& m_interactableInRange < 0
+							&& !uiModel.harvest.inProgress
+							&& m_input.WasPressed(engine::platform::Key::E))
+						{
+							const uint32_t harvestClientId = m_gameplayUdp.ServerClientId();
+							if (harvestClientId != 0u)
+								(void)m_gameplayUdp.SendHarvestRequest(harvestClientId, nearestNodeId);
+						}
+						// Barre de progression de récolte (présentateur M36.1).
+						const engine::client::HarvestCastBarState& harvestState = m_harvestBar.GetState();
+						if (harvestState.visible)
+						{
+							fg->AddRectFilled(ImVec2(harvestState.barX, harvestState.barY),
+								ImVec2(harvestState.barX + harvestState.barWidth,
+									harvestState.barY + harvestState.barHeight),
+								IM_COL32(20, 22, 28, 220), 4.0f);
+							fg->AddRectFilled(ImVec2(harvestState.barX, harvestState.barY),
+								ImVec2(harvestState.barX + harvestState.barWidth
+										* std::clamp(harvestState.fillFraction, 0.0f, 1.0f),
+									harvestState.barY + harvestState.barHeight),
+								IM_COL32(120, 200, 120, 230), 4.0f);
+							fg->AddText(ImVec2(harvestState.barX, harvestState.barY - 18.0f),
+								IM_COL32(230, 230, 230, 255), harvestState.label.c_str());
+						}
+					}
+
+					// --- Métiers SP1 : panneau d'artisanat (touche K, M36.2/M36.3).
+					if (keysAllowed && m_input.WasPressed(engine::platform::Key::K))
+					{
+						m_craftingVisible = !m_craftingVisible;
+						// Première ouverture : charge la liste du premier métier connu.
+						if (m_craftingVisible && !uiModel.crafting.professions.empty()
+							&& uiModel.crafting.recipes.empty())
+						{
+							const uint32_t craftClientId = m_gameplayUdp.ServerClientId();
+							if (craftClientId != 0u)
+								(void)m_gameplayUdp.SendCraftRecipeListRequest(craftClientId,
+									uiModel.crafting.professions.front().professionKey);
+						}
+					}
+					if (m_craftingVisible)
+					{
+						ImGui::SetNextWindowPos(ImVec2(dw * 0.5f - 230.0f, 120.0f), ImGuiCond_FirstUseEver);
+						ImGui::SetNextWindowSize(ImVec2(460.0f, 430.0f), ImGuiCond_FirstUseEver);
+						if (ImGui::Begin("Artisanat", &m_craftingVisible))
+						{
+							const uint32_t craftClientId = m_gameplayUdp.ServerClientId();
+							if (uiModel.crafting.professions.empty())
+							{
+								ImGui::TextUnformatted("Aucun metier connu.");
+							}
+							// Onglets métiers → demande de liste de recettes.
+							for (size_t professionIndex = 0;
+								professionIndex < uiModel.crafting.professions.size(); ++professionIndex)
+							{
+								const engine::client::UIProfessionEntry& prof =
+									uiModel.crafting.professions[professionIndex];
+								if (professionIndex > 0)
+									ImGui::SameLine();
+								const std::string tabLabel = prof.professionKey
+									+ " (" + std::to_string(prof.skillLevel) + ")";
+								if (ImGui::SmallButton(tabLabel.c_str())
+									&& prof.professionKey != uiModel.crafting.activeProfessionKey
+									&& craftClientId != 0u)
+								{
+									(void)m_gameplayUdp.SendCraftRecipeListRequest(
+										craftClientId, prof.professionKey);
+								}
+							}
+							ImGui::Separator();
+							// Liste des recettes (clic = sélection).
+							ImGui::BeginChild("##ln_craft_recipes", ImVec2(0.0f, 220.0f), true);
+							for (size_t recipeIndex = 0;
+								recipeIndex < uiModel.crafting.recipes.size(); ++recipeIndex)
+							{
+								const engine::client::UICraftRecipeRow& recipe =
+									uiModel.crafting.recipes[recipeIndex];
+								const bool selected = (uiModel.crafting.selectedRecipeIndex
+									== static_cast<uint32_t>(recipeIndex));
+								const std::string rowLabel = recipe.recipeId
+									+ "  (comp. " + std::to_string(recipe.skillRequired)
+									+ ", x" + std::to_string(recipe.outputQuantity) + ")";
+								if (ImGui::Selectable(rowLabel.c_str(), selected))
+								{
+									(void)m_uiModelBinding.SelectCraftRecipe(
+										static_cast<uint32_t>(recipeIndex));
+								}
+							}
+							ImGui::EndChild();
+							// Fabrication : bouton + annulation + cast bar + qualité.
+							const bool craftInProgress = uiModel.crafting.craftFillFraction > 0.0f;
+							const bool canCraft = !craftInProgress
+								&& uiModel.crafting.selectedRecipeIndex < uiModel.crafting.recipes.size();
+							if (ImGui::Button("Fabriquer", ImVec2(150.0f, 32.0f))
+								&& canCraft && craftClientId != 0u)
+							{
+								(void)m_gameplayUdp.SendCraftRequest(craftClientId,
+									uiModel.crafting.recipes[uiModel.crafting.selectedRecipeIndex].recipeId);
+							}
+							if (craftInProgress)
+							{
+								ImGui::SameLine();
+								if (ImGui::Button("Annuler", ImVec2(110.0f, 32.0f)) && craftClientId != 0u)
+								{
+									(void)m_gameplayUdp.SendCraftCancelRequest(craftClientId);
+								}
+								ImGui::ProgressBar(uiModel.crafting.craftFillFraction, ImVec2(-1.0f, 10.0f), "");
+							}
+							else if (!canCraft)
+							{
+								ImGui::TextUnformatted("Selectionnez une recette.");
+							}
+							// Qualité du dernier craft (M36.3) via le présentateur câblé.
+							const engine::client::CraftingPanelState& craftState = m_craftingUi.GetState();
+							if (!craftState.lastQualityLabel.empty())
+							{
+								ImGui::TextColored(
+									ImVec4(craftState.lastQualityColor.r, craftState.lastQualityColor.g,
+										craftState.lastQualityColor.b, 1.0f),
+									"Derniere fabrication : %s", craftState.lastQualityLabel.c_str());
+							}
+							if (!craftState.statusText.empty())
+							{
+								ImGui::TextUnformatted(craftState.statusText.c_str());
+							}
 						}
 						ImGui::End();
 					}
@@ -12623,6 +12812,11 @@ namespace engine
 				meshRace = "humains";
 				gender = (re.gender == "male" || re.gender == "female") ? re.gender : std::string{"male"};
 			}
+			else if (re.archetypeId >= engine::server::kGatheringNodeArchetypeBase)
+			{
+				// Métiers SP1 — node de récolte : pas de mesh (label flottant seul).
+				continue;
+			}
 			else if (re.archetypeId != 0u)
 			{
 				// Mob mort en attente de despawn : pas de rendu (kEntityStateDead).
@@ -12882,6 +13076,15 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] PartyHudPresenter Init FAILED — cadres de groupe désactivés");
 		}
+		// Métiers SP1 — barre de récolte + panneau d'artisanat.
+		if (!m_harvestBar.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] HarvestCastBarPresenter Init FAILED — barre de récolte désactivée");
+		}
+		if (!m_craftingUi.Init())
+		{
+			LOG_WARN(Core, "[GameplayNet] CraftingUiPresenter Init FAILED — panneau d'artisanat désactivé");
+		}
 
 		const uint32_t vw = static_cast<uint32_t>(std::max(1, m_width));
 		const uint32_t vh = static_cast<uint32_t>(std::max(1, m_height));
@@ -12912,6 +13115,15 @@ namespace engine
 		{
 			LOG_WARN(Core, "[GameplayNet] PartyHudPresenter viewport FAILED — using fallback layout");
 		}
+		// Métiers SP1 — layouts récolte + artisanat.
+		if (!m_harvestBar.SetViewportSize(vw, vh))
+		{
+			LOG_WARN(Core, "[GameplayNet] HarvestCastBarPresenter viewport FAILED — using fallback layout");
+		}
+		if (!m_craftingUi.SetViewportSize(vw, vh))
+		{
+			LOG_WARN(Core, "[GameplayNet] CraftingUiPresenter viewport FAILED — using fallback layout");
+		}
 
 		m_uiObserverHandle = m_uiModelBinding.AddObserver(
 			[this](const engine::client::UIModel& model, uint32_t changeMask)
@@ -12925,6 +13137,9 @@ namespace engine
 				m_advancedCombat.ApplyModel(model, changeMask);
 				// Groupes SP1 — cadres de groupe (UIModelChangeParty).
 				(void)m_partyHud.ApplyModel(model, changeMask);
+				// Métiers SP1 — récolte (UIModelChangeHarvest) + artisanat (Crafting).
+				(void)m_harvestBar.ApplyModel(model, changeMask);
+				(void)m_craftingUi.ApplyModel(model, changeMask);
 			});
 		if (m_uiObserverHandle == 0u)
 		{
@@ -12991,7 +13206,10 @@ namespace engine
 			m_uiObserverHandle = 0;
 		}
 
-		// Combat SP2/SP3/SP4 + Groupes SP1 — symétrie d'Init.
+		// Combat SP2/SP3/SP4 + Groupes/Métiers SP1 — symétrie d'Init.
+		m_craftingUi.Shutdown();
+		m_harvestBar.Shutdown();
+		m_craftingVisible = false;
 		m_partyHud.Shutdown();
 		m_selectedAllyEntityId = 0;
 		m_auraFx.Shutdown();
@@ -13054,6 +13272,9 @@ namespace engine
 		// fenêtre DPS) et le throttle local d'envoi d'attaque.
 		(void)m_combatHud.Tick(deltaSeconds);
 		m_advancedCombat.Tick(deltaSeconds);
+		// Métiers SP1 — progression des cast bars récolte/artisanat.
+		(void)m_harvestBar.Tick(deltaSeconds);
+		(void)m_craftingUi.Tick(deltaSeconds);
 		if (m_attackSendCooldownSec > 0.0f)
 		{
 			m_attackSendCooldownSec -= deltaSeconds;

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -37,6 +37,9 @@
 #include "src/client/combat/AuraFXSystem.h"
 // Groupes SP1 — cadres de groupe (M32.2 enfin câblé).
 #include "src/client/social/PartyHud.h"
+// Métiers SP1 — barre de récolte (M36.1) + panneau d'artisanat (M36.2).
+#include "src/client/crafting/HarvestCastBar.h"
+#include "src/client/crafting/CraftingUi.h"
 #include "src/client/debug/ProfilerHud.h"
 #include "src/client/economy/ShopUi.h"
 #include "src/client/ui_common/UIModel.h"
@@ -1289,6 +1292,11 @@ namespace engine
 		/// clientId pour les joueurs, invariant ServerApp::HandleHello) ; 0 = soi.
 		/// Consommé par les sorts SingleAlly de la barre d'action (SP3).
 		uint64_t m_selectedAllyEntityId = 0;
+		/// Métiers SP1 — binds : E = récolter le node à portée (priorité aux
+		/// interactibles locaux), K = panneau d'artisanat.
+		engine::client::HarvestCastBarPresenter m_harvestBar{};
+		engine::client::CraftingUiPresenter m_craftingUi{};
+		bool m_craftingVisible = false;
 		/// Combat SP3 — cooldowns AFFICHÉS de la barre d'action (spellId → fin en
 		/// secondes EngineNowSec) ; purement cosmétique, le serveur fait foi.
 		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -351,6 +351,84 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendHarvestRequest(uint32_t clientId, uint64_t nodeEntityId)
+	{
+		engine::server::HarvestRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.nodeEntityId = nodeEntityId;
+		const bool ok = SendBytes(engine::server::EncodeHarvestRequest(msg));
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] HarvestRequest sent (client_id={}, node_entity_id={})",
+				clientId, nodeEntityId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] HarvestRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendHarvestCancelRequest(uint32_t clientId)
+	{
+		engine::server::HarvestCancelRequestMessage msg{};
+		msg.clientId = clientId;
+		const bool ok = SendBytes(engine::server::EncodeHarvestCancelRequest(msg));
+		if (!ok)
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] HarvestCancelRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendCraftRecipeListRequest(uint32_t clientId, std::string_view professionKey)
+	{
+		engine::server::CraftRecipeListRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.professionKey = std::string(professionKey);
+		const bool ok = SendBytes(engine::server::EncodeCraftRecipeListRequest(msg));
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] CraftRecipeListRequest sent (client_id={}, profession={})",
+				clientId, msg.professionKey);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] CraftRecipeListRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendCraftRequest(uint32_t clientId, std::string_view recipeId)
+	{
+		engine::server::CraftRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.recipeId = std::string(recipeId);
+		const bool ok = SendBytes(engine::server::EncodeCraftRequest(msg));
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] CraftRequest sent (client_id={}, recipe={})",
+				clientId, msg.recipeId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] CraftRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendCraftCancelRequest(uint32_t clientId)
+	{
+		engine::server::CraftCancelRequestMessage msg{};
+		msg.clientId = clientId;
+		const bool ok = SendBytes(engine::server::EncodeCraftCancelRequest(msg));
+		if (!ok)
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] CraftCancelRequest FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity)
 	{
 		engine::server::ShopBuyRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -69,6 +69,22 @@ namespace engine::client
 		/// Groupes SP1 — refuse l'invitation de groupe en attente (M32.2).
 		bool SendPartyDecline(uint32_t clientId);
 
+		/// Métiers SP1 — démarre une récolte sur un node répliqué (M36.1, le
+		/// serveur valide disponibilité/portée/session unique).
+		bool SendHarvestRequest(uint32_t clientId, uint64_t nodeEntityId);
+
+		/// Métiers SP1 — annule la récolte en cours (M36.1).
+		bool SendHarvestCancelRequest(uint32_t clientId);
+
+		/// Métiers SP1 — demande la liste des recettes d'un métier (M36.2).
+		bool SendCraftRecipeListRequest(uint32_t clientId, std::string_view professionKey);
+
+		/// Métiers SP1 — lance la fabrication d'une recette (M36.2).
+		bool SendCraftRequest(uint32_t clientId, std::string_view recipeId);
+
+		/// Métiers SP1 — annule la fabrication en cours (M36.2).
+		bool SendCraftCancelRequest(uint32_t clientId);
+
 		bool SendShopBuyRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);
 
 		bool SendShopSellRequest(uint32_t clientId, uint32_t vendorId, uint32_t itemId, uint32_t quantity);

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -1007,6 +1007,21 @@ namespace engine::client
 		return true;
 	}
 
+	bool UIModelBinding::SelectCraftRecipe(uint32_t rowIndex)
+	{
+		if (!ValidateMainThread("SelectCraftRecipe"))
+		{
+			return false;
+		}
+		if (rowIndex >= m_model.crafting.recipes.size())
+		{
+			return false;
+		}
+		m_model.crafting.selectedRecipeIndex = rowIndex;
+		NotifyObservers(UIModelChangeCrafting);
+		return true;
+	}
+
 	void UIModelBinding::ClearPartyInvite()
 	{
 		if (!ValidateMainThread("ClearPartyInvite"))

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -499,6 +499,10 @@ namespace engine::client
 		/// Notifie UIModelChangeParty. Main thread uniquement.
 		void ClearPartyInvite();
 
+		/// Métiers SP1 — sélectionne une recette du panneau d'artisanat (0-based).
+		/// Notifie UIModelChangeCrafting. Main thread uniquement.
+		bool SelectCraftRecipe(uint32_t rowIndex);
+
 		/// M29.3: Refresh billboard projections (call from render/game thread with camera + viewport).
 		void TickChatWorldVisuals(
 			const engine::math::Vec3& cameraWorld,

--- a/src/shardd/gameplay/gathering/GatheringSystem.h
+++ b/src/shardd/gameplay/gathering/GatheringSystem.h
@@ -149,6 +149,10 @@ namespace engine::server
 
 		bool IsInitialized() const { return m_initialized; }
 
+		/// Métiers SP1 — vue lecture seule de tous les nodes (réplication : la
+		/// grille d'intérêt et TryBuildSnapshotEntity en ont besoin côté ServerApp).
+		const std::vector<ResourceNodeRuntimeState>& Nodes() const { return m_nodes; }
+
 		size_t NodeCount()    const { return m_nodes.size(); }
 		size_t SessionCount() const { return m_sessions.size(); }
 

--- a/src/shared/network/ReplicationTypes.h
+++ b/src/shared/network/ReplicationTypes.h
@@ -11,6 +11,12 @@ namespace engine::server
 	/// Replicated state flag set when an entity reached 0 HP.
 	inline constexpr uint32_t kEntityStateDead = 1u << 0;
 
+	/// Métiers SP1 — plage d'archetypeId réservée aux NODES DE RÉCOLTE répliqués
+	/// (archetypeId = base + typeId du node). Jamais un archétype de créature :
+	/// le client rend un label flottant [E] au lieu d'un mesh, et le ciblage
+	/// combat les ignore. `kEntityStateDead` sur un node = épuisé (grisé).
+	inline constexpr uint32_t kGatheringNodeArchetypeBase = 1000000u;
+
 	/// Minimal authoritative stats component shared by players and mobs.
 	struct StatsComponent
 	{

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -46,6 +46,8 @@ namespace engine::platform
 		// Valeurs = codes ASCII majuscules (== VK_* Windows), comme le reste.
 		T = 'T',
 		J = 'J',
+		// Métiers SP1 — panneau d'artisanat (K).
+		K = 'K',
 		Escape = 0x1B,
 		Tab = 0x09,
 		Control = 0x11,

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -5060,6 +5060,24 @@ namespace engine::server
 			return true;
 		}
 
+		// Métiers SP1 — nodes de récolte : position statique, archetypeId dans la
+		// plage réservée (base + typeId), flag dead = épuisé (label grisé client).
+		if (m_gatheringSystem.IsInitialized())
+		{
+			if (const ResourceNodeRuntimeState* node = m_gatheringSystem.FindNode(entityId))
+			{
+				outEntity.entityId = node->entityId;
+				outEntity.state.positionX = node->definition.positionMetersX;
+				outEntity.state.positionY = node->definition.positionMetersY;
+				outEntity.state.positionZ = node->definition.positionMetersZ;
+				outEntity.state.currentHealth = node->available ? 1u : 0u;
+				outEntity.state.maxHealth = 1u;
+				outEntity.state.stateFlags = node->available ? 0u : kEntityStateDead;
+				outEntity.archetypeId = kGatheringNodeArchetypeBase + node->definition.typeId;
+				return true;
+			}
+		}
+
 		LOG_WARN(Net, "[ServerApp] Snapshot build ignored: unknown entity_id={}", entityId);
 		return false;
 	}
@@ -7777,6 +7795,26 @@ namespace engine::server
 		{
 			LOG_WARN(Core, "[ServerApp] GatheringSystem Init FAILED — harvesting disabled");
 			return false;
+		}
+		// Métiers SP1 — les nodes entrent dans la grille d'intérêt de leur zone :
+		// ils sont alors répliqués par les snapshots (TryBuildSnapshotEntity) et
+		// le client peut les afficher et cibler leur entityId au HarvestRequest.
+		for (const ResourceNodeRuntimeState& node : m_gatheringSystem.Nodes())
+		{
+			CellGrid* zoneGrid = GetOrCreateZoneGrid(node.definition.zoneId);
+			if (zoneGrid == nullptr)
+			{
+				LOG_WARN(Net, "[ServerApp] Gathering node grid skipped: no zone grid (node={}, zone_id={})",
+					node.definition.nodeId,
+					node.definition.zoneId);
+				continue;
+			}
+			CellCoord nodeCell{};
+			if (!zoneGrid->UpsertEntity(node.entityId,
+				node.definition.positionMetersX, node.definition.positionMetersZ, nodeCell))
+			{
+				LOG_WARN(Net, "[ServerApp] Gathering node grid insert FAILED (node={})", node.definition.nodeId);
+			}
 		}
 		LOG_INFO(Core, "[ServerApp] GatheringSystem Init OK (nodes={})", m_gatheringSystem.NodeCount());
 		return true;


### PR DESCRIPTION
## Métiers SP1 — récolte + artisanat enfin jouables

Chantier n°3 de la liste validée. Plan : `docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md`. Stackée sur #882 (Groupes SP1).

### Constat (même pattern que les groupes)
Les systèmes serveur M36.1/M36.2 tournent et tous les kinds wire existent (64-68, 70-77)… mais les **nodes de récolte n''étaient pas répliqués** (« no replication » assumé d''origine : le client ne pouvait ni les voir ni connaître leurs entityId), **aucune donnée de nodes** n''existait en zone, le client **n''émettait aucun message métiers**, et `HarvestCastBarPresenter`/`CraftingUiPresenter` étaient orphelins (audit).

### Contenu
- **Données** : `zones/zone_0/gathering_nodes.json` — 3 nodes près du spawn (minerai, herbe, arbre — les 4 types de `gathering/resource_nodes.json` existant).
- **Serveur (additif, pas de bump)** : les nodes entrent dans la grille d''intérêt et les snapshots — `archetypeId = kGatheringNodeArchetypeBase (1 000 000) + typeId` (plage réservée partagée dans ReplicationTypes.h), flag dead = épuisé.
- **Client** :
  - Labels flottants des nodes (noms FR par type, « [E] » à portée de 5 m, « (epuise) » grisé) ; exclus du mesh, du clic et du Tab combat.
  - **E** = `HarvestRequest` sur le node le plus proche (priorité aux interactibles locaux) ; annulation au mouvement déjà serveur ; **HarvestCastBar câblée** (barre de progression M36.1).
  - **K** = panneau **Artisanat** (`CraftingUiPresenter` câblé) : onglets métiers → `CraftRecipeListRequest`, sélection de recette, bouton Fabriquer → `CraftRequest`, Annuler, cast bar, **qualité M36.3** (label coloré Normal/Uncommon/Rare/Epic).
  - Touche **K ajoutée à l''enum Key** (leçon du build cassé SP2 : l''enum est lacunaire).

### Validation en jeu attendue
3 labels de nodes visibles près du spawn → E sur le filon → barre 3 s → minerai en inventaire (InventoryDelta) + skill-up (ProfessionUpdate) → re-E : « (epuise) » → respawn 10 min ; K → recettes du métier → Fabriquer → cast bar + qualité colorée.

### Ordre de merge
Après #882. **Déploiement** : ⚠️ shardd à redéployer (réplication des nodes) — porté par la fenêtre lock-step v12 du chantier combat, pas de bump supplémentaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)