### PR TITLE
feat(correction): SP1 - canal ForcePosition serveur->client (fix teleport respawn + rubber-band anti-triche)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2268,3 +2268,21 @@ Plan : `docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md`. **P
   onglets métiers → CraftRecipeListRequest, sélection → CraftRequest, annulation, cast bar,
   qualité M36.3). Touche K ajoutée à l''enum Key (leçon SP2).
 - **Déploiement** : ⚠️ shardd (réplication nodes) — porté par la fenêtre lock-step v12.
+
+## Correction SP1 — canal ForcePosition serveur→client (2026-06-12) — CLÔT LES 4 CHANTIERS
+
+Plan : `docs/superpowers/plans/2026-06-12-correction-sp1-force-position.md`. Chantier n°4
+re-cadré avec l''utilisateur : le mouvement reste client-autoritaire (T0.1) ; le serveur
+gagne un canal pour IMPOSER une position. Kind `ForcePosition = 86` **rétro-additif**
+(pas de bump — un client ancien l''ignore).
+
+- **Bug SP2 corrigé** : « Réapparaître » soignait SUR PLACE — le serveur téléportait au
+  spawn mais le client (autoritaire) écrasait la téléportation au tick suivant. Désormais :
+  reset anti-triche (sinon TeleportHack au 1er input depuis le spawn) + ForcePosition →
+  le client ré-Init son CharacterController (le téléport de facto, cf. Engine.cpp:8458).
+- **Désync anti-triche corrigée** : un input rejeté renvoie désormais la dernière position
+  valide au client (throttle 500 ms) au lieu de le laisser désynchronisé en silence.
+- **`ClientPredictionSystem` (M30.1/M30.2) : ARCHIVÉ, non câblé** — c''est la
+  prédiction-réconciliation d''un mouvement SERVEUR-autoritaire (inputs → simulation
+  serveur), l''inverse de T0.1. Socle d''un éventuel futur passage serveur-autoritaire.
+- **Déploiement** : ⚠️ shardd (producteurs) — fenêtre lock-step v12 déjà requise.

--- a/docs/superpowers/plans/2026-06-12-correction-sp1-force-position.md
+++ b/docs/superpowers/plans/2026-06-12-correction-sp1-force-position.md
@@ -1,0 +1,30 @@
+# Correction SP1 — canal ForcePosition serveur→client : Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Chantier n°4 de la liste validée, re-cadré avec l'utilisateur (option « canal de correction » choisie) : le mouvement reste client-autoritaire (décision T0.1), mais le serveur gagne le droit d'IMPOSER une position. Corrige deux trous réels : (1) **bug du respawn SP2** — le serveur téléporte au spawn mais le client (autoritaire) écrase la téléportation au tick suivant → « Réapparaître » soigne sur place ; (2) **désync silencieuse anti-triche** — un input rejeté (speed/teleport hack) laisse le client convaincu de sa position sans jamais le corriger.
+
+**Architecture:** Nouveau kind `ForcePosition = 86` (shard→client, ADDITIF — un client qui ne le connaît pas l'ignore, pas de bump de version ; v12 n'est de toute façon pas déployé). Producteurs serveur : `HandleRespawnRequest` (reason=Respawn, + **reset de l'état anti-triche** — sinon le premier input depuis le spawn serait vu comme un TeleportHack) et le rejet anti-triche de `HandleInput` (reason=AntiCheat, dernière position valide, throttlé 500 ms). Consommateur client : `m_characterController.Init(Vec3)` (le téléport de facto, déjà utilisé au changement de zone, Engine.cpp:8458) + yaw. V1 = snap immédiat dans tous les cas (le rubber-band lissé anti-triche = amélioration future ; un tricheur n'a pas droit au confort).
+
+**Décision archivée :** `ClientPredictionSystem` (M30.1/M30.2) reste NON câblé — il implémente la prédiction-réconciliation d'un mouvement serveur-autoritaire (inputs → simulation serveur), à l'opposé de T0.1. Il sera le socle d'un éventuel futur passage en serveur-autoritaire (anti-triche durci). Documenté ici et dans CODEBASE_MAP.
+
+### Task 1 — Wire (additif)
+`ServerProtocol.h/.cpp/Tests` : kind `ForcePosition = 86` ; constantes `kForcePositionReasonRespawn=0 / AntiCheat=1 / Teleport=2` ; `struct ForcePositionMessage { uint32_t clientId; float x, y, z, yawRadians; uint8_t reason; }` (payload fixe 21 o) ; Encode/Decode + roundtrip + tronqué + reason hors domaine rejeté.
+
+### Task 2 — Serveur
+- `ConnectedClient.lastForcePositionSentMs` (throttle anti-triche).
+- `SendForcePosition(client, reason)` (position courante serveur).
+- `HandleRespawnRequest` : `m_antiCheat.Reset(persistenceCharacterKey)` + `SendForcePosition(…, Respawn)` après le téléport.
+- Rejet anti-triche dans `HandleInput` : avant le `return`, `SendForcePosition(…, AntiCheat)` si ≥ 500 ms depuis le dernier.
+
+### Task 3 — Client
+- UIModel : `UIForcedPosition { bool pending; float x, y, z, yaw; uint8_t reason; }` + routage + `ClearForcedPosition()`.
+- Engine (`UpdateGameplayNet`, avant l'envoi d'Input) : si pending → `m_characterController.Init(Vec3{x,y,z})`, `m_avatarYaw = yaw`, log avec reason, `ClearForcedPosition()`. L'Input suivant porte la position imposée → plus d'écrasement.
+
+### Task 4 — Docs + PR
+CODEBASE_MAP (canal de correction + statut archivé de ClientPrediction), push `correction-sp1`, PR base main. **Déploiement** : ⚠️ shardd (nouveaux producteurs) — fenêtre lock-step v12 déjà requise ; le kind est additif.
+
+## Self-review
+- Le bug respawn est corrigé de bout en bout (téléport + reset anti-triche + position rejouée par le client).
+- Aucun changement de version wire ; rétro-additif.
+- Boucle infinie impossible : ForcePosition ne déclenche pas d'Input rejeté (le client adopte la position serveur, l'anti-triche est resetté au respawn et tolère le delta au rejet — la position imposée EST sa référence).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -13275,6 +13275,26 @@ namespace engine
 		// Métiers SP1 — progression des cast bars récolte/artisanat.
 		(void)m_harvestBar.Tick(deltaSeconds);
 		(void)m_craftingUi.Tick(deltaSeconds);
+
+		// Correction SP1 — position imposée par le serveur (respawn, rejet
+		// anti-triche, téléport) : téléporte le CharacterController AVANT
+		// l'envoi du prochain Input — le mouvement client-autoritaire reprend
+		// depuis la position imposée au lieu d'écraser la téléportation serveur
+		// (c'était le bug du respawn SP2 : « Réapparaître » soignait sur place).
+		{
+			const engine::client::UIForcedPosition& forced = m_uiModelBinding.GetModel().forcedPosition;
+			if (forced.pending)
+			{
+				const engine::math::Vec3 forcedPos{ forced.x, forced.y, forced.z };
+				(void)m_characterController.Init(forcedPos);
+				m_orbitalCameraController.SetTargetPosition(forcedPos);
+				m_avatarYaw = forced.yawRadians;
+				LOG_INFO(Core,
+					"[Engine] Position imposée par le serveur appliquée (pos=({:.1f},{:.1f},{:.1f}), reason={})",
+					forced.x, forced.y, forced.z, forced.reason);
+				m_uiModelBinding.ClearForcedPosition();
+			}
+		}
 		if (m_attackSendCooldownSec > 0.0f)
 		{
 			m_attackSendCooldownSec -= deltaSeconds;

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -622,6 +622,9 @@ namespace engine::client
 		// Groupes SP1 — invitation entrante (le reste du flux party était déjà routé).
 		case engine::server::MessageKind::PartyInviteNotify:
 			return ApplyPartyInviteNotify(packet);
+		// Correction SP1 — position imposée par le serveur (respawn/anti-triche).
+		case engine::server::MessageKind::ForcePosition:
+			return ApplyForcePosition(packet);
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;
@@ -990,6 +993,36 @@ namespace engine::client
 		}
 		NotifyObservers(UIModelChangeCombat);
 		return true;
+	}
+
+	bool UIModelBinding::ApplyForcePosition(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeForcePosition(packet, m_forcePositionMessage))
+		{
+			LOG_WARN(Net, "[UIModelBinding] ForcePosition FAILED: decode error");
+			return false;
+		}
+
+		m_model.forcedPosition.pending = true;
+		m_model.forcedPosition.x = m_forcePositionMessage.positionX;
+		m_model.forcedPosition.y = m_forcePositionMessage.positionY;
+		m_model.forcedPosition.z = m_forcePositionMessage.positionZ;
+		m_model.forcedPosition.yawRadians = m_forcePositionMessage.yawRadians;
+		m_model.forcedPosition.reason = m_forcePositionMessage.reason;
+		LOG_INFO(Net, "[UIModelBinding] ForcePosition received (pos=({:.1f},{:.1f},{:.1f}), reason={})",
+			m_model.forcedPosition.x, m_model.forcedPosition.y, m_model.forcedPosition.z,
+			m_model.forcedPosition.reason);
+		NotifyObservers(UIModelChangeWorld);
+		return true;
+	}
+
+	void UIModelBinding::ClearForcedPosition()
+	{
+		if (!ValidateMainThread("ClearForcedPosition"))
+		{
+			return;
+		}
+		m_model.forcedPosition = UIForcedPosition{};
 	}
 
 	bool UIModelBinding::ApplyPartyInviteNotify(std::span<const std::byte> packet)

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -237,6 +237,19 @@ namespace engine::client
 		uint64_t startedAtNs = 0;
 	};
 
+	/// Correction SP1 — position imposée par le serveur (ForcePosition) en
+	/// attente d'application par Engine (téléport du CharacterController).
+	struct UIForcedPosition
+	{
+		bool pending = false;
+		float x = 0.0f;
+		float y = 0.0f;
+		float z = 0.0f;
+		float yawRadians = 0.0f;
+		/// kForcePositionReason* (0 respawn, 1 anti-triche, 2 téléport).
+		uint8_t reason = 0;
+	};
+
 	/// Groupes SP1 — invitation de groupe en attente (PartyInviteNotify, M32.2).
 	struct UIPartyInviteState
 	{
@@ -405,6 +418,8 @@ namespace engine::client
 		/// TD.1 : avatars distants (≠ joueur local) reçus dans le dernier snapshot AoI.
 		/// Reconstruit à chaque ApplySnapshot. Consommé par le rendu monde (TD.2).
 		std::vector<UIRemoteEntity> remoteEntities;
+		/// Correction SP1 — position imposée par le serveur (consommée par Engine).
+		UIForcedPosition forcedPosition{};
 		/// Groupes SP1 — invitation en attente (popup Accepter/Refuser).
 		UIPartyInviteState partyInvite{};
 		/// M32.2: True when the local player is currently in a party.
@@ -503,6 +518,10 @@ namespace engine::client
 		/// Notifie UIModelChangeCrafting. Main thread uniquement.
 		bool SelectCraftRecipe(uint32_t rowIndex);
 
+		/// Correction SP1 — consomme la position imposée (après application par
+		/// Engine au CharacterController). Main thread uniquement.
+		void ClearForcedPosition();
+
 		/// M29.3: Refresh billboard projections (call from render/game thread with camera + viewport).
 		void TickChatWorldVisuals(
 			const engine::math::Vec3& cameraWorld,
@@ -544,6 +563,9 @@ namespace engine::client
 
 		/// Groupes SP1 — invitation de groupe entrante (PartyInviteNotify).
 		bool ApplyPartyInviteNotify(std::span<const std::byte> packet);
+
+		/// Correction SP1 — position imposée par le serveur (ForcePosition).
+		bool ApplyForcePosition(std::span<const std::byte> packet);
 
 		/// Apply one decoded zone change packet to the world section of the UI model.
 		bool ApplyZoneChange(std::span<const std::byte> packet);
@@ -641,6 +663,7 @@ namespace engine::client
 		engine::server::AuraUpdateMessage m_auraUpdateMessage{};
 		engine::server::ThreatUpdateMessage m_threatUpdateMessage{};
 		engine::server::PartyInviteNotifyMessage m_partyInviteNotifyMessage{};
+		engine::server::ForcePositionMessage m_forcePositionMessage{};
 		engine::server::ZoneChangeMessage m_zoneChangeMessage{};
 		engine::server::InventoryDeltaMessage m_inventoryMessage{};
 		engine::server::QuestDeltaMessage m_questMessage{};

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -783,6 +783,36 @@ namespace engine::server
 		return true;
 	}
 
+	std::vector<std::byte> EncodeForcePosition(const ForcePositionMessage& message)
+	{
+		// Correction SP1 — payload fixe : clientId (4) + x/y/z/yaw (4×4) + reason (1) = 21 o.
+		std::vector<std::byte> packet = BeginPacket(MessageKind::ForcePosition, 21);
+		WriteU32(packet, message.clientId);
+		WriteF32(packet, message.positionX);
+		WriteF32(packet, message.positionY);
+		WriteF32(packet, message.positionZ);
+		WriteF32(packet, message.yawRadians);
+		WriteU8(packet, message.reason);
+		return packet;
+	}
+
+	bool DecodeForcePosition(std::span<const std::byte> packet, ForcePositionMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::ForcePosition, payload) || payload.size() != 21)
+		{
+			return false;
+		}
+
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.positionX = ReadF32(payload, 4);
+		outMessage.positionY = ReadF32(payload, 8);
+		outMessage.positionZ = ReadF32(payload, 12);
+		outMessage.yawRadians = ReadF32(payload, 16);
+		outMessage.reason = ReadU8(payload, 20);
+		return outMessage.reason <= kForcePositionReasonTeleport;
+	}
+
 	std::vector<std::byte> EncodeAuraUpdate(const AuraUpdateMessage& message)
 	{
 		// Combat SP3 — payload : targetEntityId (8) + count (1) puis par aura :

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -248,7 +248,13 @@ namespace engine::server
 		/// Combat SP4 — shard → clients intéressés : table de menace d'un mob
 		/// (liste complète idempotente, vide = effacement). Alimente le threat
 		/// meter (AdvancedCombatUi). Bump v11→v12.
-		ThreatUpdate = 85
+		ThreatUpdate = 85,
+		/// Correction SP1 — shard → client : position IMPOSÉE par le serveur
+		/// (respawn, rejet anti-triche, téléport). Le mouvement reste
+		/// client-autoritaire (T0.1) ; ce kind est le canal de correction.
+		/// Ajout rétro-additif : un client qui ne le connaît pas l'ignore
+		/// (pas de bump de kProtocolVersion).
+		ForcePosition = 86
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -442,6 +448,24 @@ namespace engine::server
 		std::vector<ThreatWireEntry> entries;
 	};
 
+	/// Correction SP1 — raisons d'une position imposée (ForcePositionMessage::reason).
+	inline constexpr uint8_t kForcePositionReasonRespawn = 0;
+	inline constexpr uint8_t kForcePositionReasonAntiCheat = 1;
+	inline constexpr uint8_t kForcePositionReasonTeleport = 2;
+
+	/// Correction SP1 — shard → client : position imposée par le serveur. Le
+	/// client téléporte son CharacterController (le mouvement client-autoritaire
+	/// reprend ensuite depuis cette position). Payload fixe 21 octets.
+	struct ForcePositionMessage
+	{
+		uint32_t clientId = 0;
+		float positionX = 0.0f;
+		float positionY = 0.0f;
+		float positionZ = 0.0f;
+		float yawRadians = 0.0f;
+		uint8_t reason = kForcePositionReasonTeleport;
+	};
+
 	/// Client request asking the authoritative server to pick up one loot bag entity.
 	struct PickupRequestMessage
 	{
@@ -603,6 +627,10 @@ namespace engine::server
 	/// Combat SP4 — encode/decode de la table de menace répliquée (wire v12).
 	std::vector<std::byte> EncodeThreatUpdate(const ThreatUpdateMessage& message);
 	bool DecodeThreatUpdate(std::span<const std::byte> packet, ThreatUpdateMessage& outMessage);
+
+	/// Correction SP1 — encode/decode de la position imposée (rétro-additif).
+	std::vector<std::byte> EncodeForcePosition(const ForcePositionMessage& message);
+	bool DecodeForcePosition(std::span<const std::byte> packet, ForcePositionMessage& outMessage);
 
 	/// Encode a combat event packet with the protocol header.
 	std::vector<std::byte> EncodeCombatEvent(const CombatEventMessage& message);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -514,6 +514,37 @@ namespace
 		std::puts("[OK] TestPlayerStatsRoundTripWithProfile");
 	}
 
+	/// Correction SP1 — round-trip ForcePosition + rejets (tronqué, reason hors domaine).
+	void TestForcePositionRoundTrip()
+	{
+		engine::server::ForcePositionMessage in{};
+		in.clientId = 7u;
+		in.positionX = 96.0f;
+		in.positionY = 1.5f;
+		in.positionZ = 96.0f;
+		in.yawRadians = 1.57f;
+		in.reason = engine::server::kForcePositionReasonRespawn;
+
+		const std::vector<std::byte> packet = engine::server::EncodeForcePosition(in);
+		engine::server::ForcePositionMessage out{};
+		assert(engine::server::DecodeForcePosition(packet, out));
+		assert(out.clientId == 7u);
+		assert(out.positionX == 96.0f && out.positionY == 1.5f && out.positionZ == 96.0f);
+		assert(out.yawRadians == 1.57f);
+		assert(out.reason == engine::server::kForcePositionReasonRespawn);
+
+		// Paquet tronqué rejeté.
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 2u);
+		assert(!engine::server::DecodeForcePosition(truncated, out));
+
+		// Reason hors domaine rejeté (octet 20 du payload, après le header 8 o).
+		std::vector<std::byte> badReason = packet;
+		badReason[8 + 20] = static_cast<std::byte>(9);
+		assert(!engine::server::DecodeForcePosition(badReason, out));
+		std::puts("[OK] TestForcePositionRoundTrip");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
@@ -533,6 +564,7 @@ int main()
 	TestAuraUpdateRoundTrip();
 	TestThreatUpdateRoundTrip();
 	TestPlayerStatsRoundTripWithProfile();
+	TestForcePositionRoundTrip();
 	std::puts("All ServerProtocol tests passed");
 	return 0;
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1545,6 +1545,15 @@ namespace engine::server
 				LOG_WARN(AntiCheat,
 					"[ServerApp] Input rejete par anti-triche (verdict={}, client_id={}, character_key={}, pos=({:.2f},{:.2f}), seq={})",
 					static_cast<int>(verdict), client->clientId, client->persistenceCharacterKey, positionMetersX, positionMetersZ, inputSequence);
+				// Correction SP1 — informe le client de sa vraie position (dernière
+				// valide côté serveur) au lieu de le laisser désynchronisé en
+				// silence. Throttlé à 1 / 500 ms (un hack soutenu spammerait).
+				const uint64_t forceNowMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::steady_clock::now().time_since_epoch()).count());
+				if ((forceNowMs - client->lastForcePositionSentMs) >= 500u)
+				{
+					SendForcePosition(*client, kForcePositionReasonAntiCheat);
+				}
 				return;
 			}
 		}
@@ -3015,6 +3024,13 @@ namespace engine::server
 		// Sécurité : plus aucune menace résiduelle ne doit pointer sur le ressuscité
 		// (déjà purgée à la mort, mais un mob a pu être spawné entre-temps).
 		PurgeThreatForEntity(client->entityId);
+		// Correction SP1 — (1) reset de l'état anti-triche : sans ça, le premier
+		// Input émis depuis le spawn serait vu comme un TeleportHack (la trace
+		// anti-triche pointe encore le lieu de mort) ; (2) position IMPOSÉE au
+		// client : le mouvement étant client-autoritaire, sans ce message le
+		// client écraserait la téléportation au tick suivant (bug SP2 corrigé).
+		m_antiCheat.Reset(client->persistenceCharacterKey);
+		SendForcePosition(*client, kForcePositionReasonRespawn);
 		UpdateClientInterest(*client);
 		SaveConnectedClient(*client, "respawn");
 		LOG_INFO(Net,
@@ -3026,6 +3042,27 @@ namespace engine::server
 			client->positionMetersZ,
 			client->stats.currentHealth,
 			client->stats.maxHealth);
+	}
+
+	void ServerApp::SendForcePosition(ConnectedClient& client, uint8_t reason)
+	{
+		ForcePositionMessage message{};
+		message.clientId = client.clientId;
+		message.positionX = client.positionMetersX;
+		message.positionY = client.positionMetersY;
+		message.positionZ = client.positionMetersZ;
+		message.yawRadians = client.yawRadians;
+		message.reason = reason;
+		if (!m_transport.Send(client.endpoint, EncodeForcePosition(message)))
+		{
+			LOG_WARN(Net, "[ServerApp] ForcePosition send failed (client_id={}, reason={})",
+				client.clientId, reason);
+			return;
+		}
+		client.lastForcePositionSentMs = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		LOG_INFO(Net, "[ServerApp] ForcePosition sent (client_id={}, pos=({:.1f},{:.1f},{:.1f}), reason={})",
+			client.clientId, message.positionX, message.positionY, message.positionZ, reason);
 	}
 
 	void ServerApp::HandlePickupRequest(const Endpoint& endpoint, uint32_t clientId, EntityId lootBagEntityId)

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -144,6 +144,9 @@ namespace engine::server
 		/// Combat SP3 — throttle d'envoi des ResourceUpdate (au plus 1 / 500 ms).
 		uint64_t lastResourceUpdateSentMs = 0;
 		uint32_t lastResourceUpdateSentValue = 0;
+		/// Correction SP1 — throttle d'envoi des ForcePosition anti-triche
+		/// (au plus 1 / 500 ms ; les respawns/téléports ne sont pas throttlés).
+		uint64_t lastForcePositionSentMs = 0;
 		/// Combat SP3 — auras actives (buffs, HoT, debuffs subis).
 		std::vector<ActiveAura> auras;
 		/// Combat SP3 — cast en cours (vide = aucun). Annulé si le joueur meurt ou
@@ -527,6 +530,11 @@ namespace engine::server
 		/// Combat SP2 — réapparition d'un joueur mort : téléport au spawn mémorisé
 		/// à l'admission, PV pleins, flag dead retiré. Ignoré si le joueur est vivant.
 		void HandleRespawnRequest(const Endpoint& endpoint, uint32_t clientId);
+
+		/// Correction SP1 — impose la position serveur courante au client
+		/// (cf. MessageKind::ForcePosition). Le mouvement client-autoritaire
+		/// reprend ensuite depuis cette position.
+		void SendForcePosition(ConnectedClient& client, uint8_t reason);
 
 		/// Validate one pickup request, update the inventory and despawn the bag.
 		void HandlePickupRequest(const Endpoint& endpoint, uint32_t clientId, EntityId lootBagEntityId);


### PR DESCRIPTION
## Correction SP1 — le serveur peut enfin imposer une position

Chantier n°4 de la liste validée, **re-cadré avec l''utilisateur** (option « canal de correction » choisie) : le mouvement reste client-autoritaire (décision T0.1), mais le serveur gagne le droit d''imposer une position. Plan : `docs/superpowers/plans/2026-06-12-correction-sp1-force-position.md`. Base `main` directe — la pile précédente est intégralement mergée.

### Les deux trous corrigés
1. **Bug du respawn SP2** : « Réapparaître » soignait **sur place**. Le serveur téléportait bien au spawn, mais le client — autoritaire sur le mouvement — renvoyait sa position de mort au tick suivant et écrasait la téléportation (et l''anti-triche, qui suit la trace du client, ne voyait rien). Désormais : reset de l''état anti-triche (sans quoi le premier input depuis le spawn serait un faux TeleportHack) + `ForcePosition` → le client ré-initialise son CharacterController (le téléport de facto du moteur).
2. **Désync silencieuse anti-triche** : un input rejeté (speed/teleport hack) laissait le client convaincu de sa position, figé aux yeux des autres joueurs, sans jamais être corrigé. Désormais le serveur renvoie la dernière position valide (throttle 500 ms).

### Wire
Kind `ForcePosition = 86` (shard→client, payload fixe 21 o : clientId, x/y/z, yaw, reason ∈ {respawn, anti-triche, téléport}) — **rétro-additif, pas de bump** (un client qui ne le connaît pas l''ignore). Tests roundtrip + tronqué + reason hors domaine.

### Décision archivée
`ClientPredictionSystem` (M30.1/M30.2, l''orphelin qui motivait ce chantier) reste **volontairement non câblé** : c''est la prédiction-réconciliation d''un mouvement **serveur**-autoritaire (inputs → simulation serveur), l''inverse de T0.1. Il est documenté comme socle d''un éventuel futur durcissement anti-triche en serveur-autoritaire.

### Validation en jeu attendue
Se faire tuer par le sanglier → « Réapparaître » → le personnage **apparaît réellement au point d''entrée en monde** (caméra comprise), PV pleins, et peut rejouer immédiatement (pas de faux positif anti-triche).

**Déploiement** : ⚠️ shardd + client — porté par la fenêtre lock-step v12 (toujours pas déployée) ; le kind est additif, pas de bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)