### PR TITLE
fix(securite): Lot B1 audit - thread-safety des systemes du master + purge anti-rejeu tickets

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2269,6 +2269,7 @@ Plan : `docs/superpowers/plans/2026-06-11-metiers-sp1-recolte-artisanat.md`. **P
   qualité M36.3). Touche K ajoutée à l''enum Key (leçon SP2).
 - **Déploiement** : ⚠️ shardd (réplication nodes) — porté par la fenêtre lock-step v12.
 
+
 ## Correction SP1 — canal ForcePosition serveur→client (2026-06-12) — CLÔT LES 4 CHANTIERS
 
 Plan : `docs/superpowers/plans/2026-06-12-correction-sp1-force-position.md`. Chantier n°4
@@ -2286,3 +2287,15 @@ gagne un canal pour IMPOSER une position. Kind `ForcePosition = 86` **rétro-add
   prédiction-réconciliation d''un mouvement SERVEUR-autoritaire (inputs → simulation
   serveur), l''inverse de T0.1. Socle d''un éventuel futur passage serveur-autoritaire.
 - **Déploiement** : ⚠️ shardd (producteurs) — fenêtre lock-step v12 déjà requise.
+
+## Audit Lot B1 — thread-safety du master + purge anti-rejeu (2026-06-12)
+
+Correctifs du constat majeur de l''audit 2026-06-10 : le NetServer dispatche les
+handlers sur un pool de workers (défaut 4) mais plusieurs systèmes à état RAM
+n''avaient AUCUN verrou. Ajout d''un `std::mutex` (méthodes publiques verrouillées,
+helpers privés « Unlocked » quand une publique en appelait une autre) sur :
+`LfgQueue`, `GmTicketSystem`, `QuestStateTracker`, `MailManager` (sérialise les
+séquences Find→Update du store), `RateLimitAndBan`, `PasswordResetStore`.
+Et purge opportuniste de l''anti-rejeu `ShardTicketValidator::m_used_ticket_ids`
+(set → map ticket_id→expires_at ; l''ancien set grossissait sans fin).
+**Déploiement** : ⚠️ master + shardd — porté par la fenêtre lock-step v12.

--- a/src/masterd/gmtickets/GmTicketSystem.h
+++ b/src/masterd/gmtickets/GmTicketSystem.h
@@ -1,8 +1,13 @@
 #pragma once
 // CMANGOS.32 (Phase 5.32a) — GmTicketSystem : queue de tickets joueurs
 // pour le support GM. Header-only.
+//
+// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : les handlers du master sont
+// dispatchés sur un pool de workers NetServer (défaut 4) ; chaque méthode
+// publique verrouille m_mutex (aucune méthode publique n'en appelle une autre).
 
 #include <cstdint>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -37,6 +42,7 @@ namespace engine::server::gmtickets
 	public:
 		TicketId Open(AccountId reporter, std::string body, uint64_t nowMs)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			GmTicket t;
 			t.id           = m_nextId++;
 			t.reporter     = reporter;
@@ -48,6 +54,7 @@ namespace engine::server::gmtickets
 
 		bool Assign(TicketId id, AccountId gm)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_tickets.find(id);
 			if (it == m_tickets.end()) return false;
 			if (it->second.state != TicketState::Open) return false;
@@ -58,6 +65,7 @@ namespace engine::server::gmtickets
 
 		bool Resolve(TicketId id, uint64_t nowMs)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_tickets.find(id);
 			if (it == m_tickets.end()) return false;
 			if (it->second.state == TicketState::Resolved
@@ -70,6 +78,7 @@ namespace engine::server::gmtickets
 
 		bool Cancel(TicketId id)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_tickets.find(id);
 			if (it == m_tickets.end()) return false;
 			it->second.state = TicketState::Cancelled;
@@ -78,12 +87,14 @@ namespace engine::server::gmtickets
 
 		std::optional<GmTicket> Find(TicketId id) const
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_tickets.find(id);
 			return (it == m_tickets.end()) ? std::nullopt : std::optional<GmTicket>(it->second);
 		}
 
 		std::vector<GmTicket> OpenQueue() const
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			std::vector<GmTicket> out;
 			for (const auto& [id, t] : m_tickets)
 				if (t.state == TicketState::Open) out.push_back(t);
@@ -91,6 +102,8 @@ namespace engine::server::gmtickets
 		}
 
 	private:
+		/// Audit Lot B1 — protège m_tickets/m_nextId contre les workers concurrents.
+		mutable std::mutex m_mutex;
 		std::unordered_map<TicketId, GmTicket> m_tickets;
 		TicketId m_nextId = 1;
 	};

--- a/src/masterd/handlers/password/PasswordResetStore.cpp
+++ b/src/masterd/handlers/password/PasswordResetStore.cpp
@@ -46,6 +46,7 @@ namespace engine::server
 
 	std::string PasswordResetStore::CreateResetToken(uint64_t account_id)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string token = GenerateHexToken();
 		if (token.empty())
 		{
@@ -64,6 +65,7 @@ namespace engine::server
 
 	std::optional<uint64_t> PasswordResetStore::ValidateResetToken(const std::string& token) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_reset_tokens.find(token);
 		if (it == m_reset_tokens.end())
 		{
@@ -85,6 +87,7 @@ namespace engine::server
 
 	bool PasswordResetStore::MarkResetTokenUsed(const std::string& token)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_reset_tokens.find(token);
 		if (it == m_reset_tokens.end())
 		{
@@ -98,6 +101,7 @@ namespace engine::server
 
 	std::string PasswordResetStore::CreateVerificationCode(uint64_t account_id)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string code = GenerateSixDigitCode();
 		if (code.empty())
 		{
@@ -116,6 +120,7 @@ namespace engine::server
 
 	bool PasswordResetStore::ValidateVerificationCode(uint64_t account_id, const std::string& code) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_verifications.find(account_id);
 		if (it == m_verifications.end())
 		{
@@ -142,6 +147,7 @@ namespace engine::server
 
 	bool PasswordResetStore::MarkEmailVerified(uint64_t account_id)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_verifications.find(account_id);
 		if (it == m_verifications.end())
 		{
@@ -155,6 +161,7 @@ namespace engine::server
 
 	bool PasswordResetStore::CanSendEmail(uint64_t account_id) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto it = m_email_rate.find(account_id);
 		if (it == m_email_rate.end())
 			return true;
@@ -170,6 +177,7 @@ namespace engine::server
 
 	void PasswordResetStore::RecordEmailSent(uint64_t account_id)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		using namespace std::chrono;
 		auto& entry = m_email_rate[account_id];
 		if (!entry.window_start || Clock::now() - *entry.window_start >= hours(1))

--- a/src/masterd/handlers/password/PasswordResetStore.h
+++ b/src/masterd/handlers/password/PasswordResetStore.h
@@ -1,10 +1,15 @@
 #pragma once
 
 // M33.2 — In-memory store for password reset tokens and email verification codes.
-// All methods are single-threaded; caller must serialise access.
+//
+// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : appelé depuis les workers NetServer
+// (PasswordResetHandler) ; l'ancien contrat « caller must serialise access »
+// n'était pas honoré. Chaque méthode publique verrouille m_mutex (aucune
+// méthode publique n'en appelle une autre).
 
 #include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -84,6 +89,8 @@ namespace engine::server
 			std::optional<Clock::time_point> window_start;
 		};
 
+		/// Audit Lot B1 — protège les 3 maps contre les workers concurrents.
+		mutable std::mutex m_mutex;
 		/// token string → entry
 		std::unordered_map<std::string, ResetTokenEntry> m_reset_tokens;
 		/// account_id → verification entry (one active per account)

--- a/src/masterd/handlers/shard/ShardTicketValidator.cpp
+++ b/src/masterd/handlers/shard/ShardTicketValidator.cpp
@@ -4,6 +4,7 @@
 #include "src/shared/core/Log.h"
 
 #include <chrono>
+#include <iterator>
 #include <sstream>
 #include <iomanip>
 
@@ -63,12 +64,20 @@ namespace engine::server
 		std::string key = TicketIdToKey(data->ticket_id);
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
+			// Audit Lot B1 — purge opportuniste des entrées expirées : un ticket
+			// expiré est de toute façon rejeté plus haut (expires_at <= now),
+			// son id n'a plus besoin d'être retenu pour l'anti-rejeu. Sans cette
+			// purge, l'ensemble grossissait sans fin (fuite mémoire lente).
+			for (auto it = m_used_ticket_ids.begin(); it != m_used_ticket_ids.end(); )
+			{
+				it = (it->second <= now) ? m_used_ticket_ids.erase(it) : std::next(it);
+			}
 			if (m_used_ticket_ids.count(key) != 0)
 			{
 				LOG_WARN(Core, "[ShardTicketValidator] VerifyAndConsume: ticket already used (account_id={})", data->account_id);
 				return std::nullopt;
 			}
-			m_used_ticket_ids.insert(key);
+			m_used_ticket_ids.emplace(key, data->expires_at);
 		}
 		ShardTicketAccept accept;
 		accept.account_id = data->account_id;

--- a/src/masterd/handlers/shard/ShardTicketValidator.h
+++ b/src/masterd/handlers/shard/ShardTicketValidator.h
@@ -6,7 +6,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace engine::server
 {
@@ -37,7 +37,10 @@ namespace engine::server
 		mutable std::mutex m_mutex;
 		std::string m_secret;
 		uint32_t m_shard_id = 0;
-		std::unordered_set<std::string> m_used_ticket_ids;
+		/// Audit 2026-06-10 (Lot B1) — anti-rejeu : ticket_id consommé →
+		/// expires_at. Purgé opportunément à chaque VerifyAndConsume (les
+		/// tickets expirent en ~60 s ; l'ancien set grossissait sans fin).
+		std::unordered_map<std::string, uint64_t> m_used_ticket_ids;
 		static std::string TicketIdToKey(const engine::network::ShardTicketId& id);
 	};
 }

--- a/src/masterd/lfg/LfgQueue.h
+++ b/src/masterd/lfg/LfgQueue.h
@@ -2,10 +2,15 @@
 // CMANGOS.33 (Phase 5.33a) — LfgQueue : queue de matchmaking pour
 // donjons. Players join + role (Tank/Healer/Damage), queue forme un
 // groupe avec 1T+1H+3D. Header-only.
+//
+// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : les handlers du master sont
+// dispatchés sur un pool de workers NetServer (défaut 4) ; chaque méthode
+// publique verrouille m_mutex (aucune méthode publique n'en appelle une autre).
 
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
@@ -41,12 +46,14 @@ namespace engine::server::lfg
 	public:
 		void Join(DungeonId dungeon, PlayerId player, LfgRole role, uint64_t nowMs)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			LfgEntry e{player, role, nowMs};
 			m_byDungeon[dungeon].push_back(e);
 		}
 
 		bool Leave(DungeonId dungeon, PlayerId player)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_byDungeon.find(dungeon);
 			if (it == m_byDungeon.end()) return false;
 			auto& v = it->second;
@@ -59,6 +66,7 @@ namespace engine::server::lfg
 
 		size_t QueueSize(DungeonId dungeon) const
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_byDungeon.find(dungeon);
 			return (it == m_byDungeon.end()) ? 0 : it->second.size();
 		}
@@ -67,6 +75,7 @@ namespace engine::server::lfg
 		/// le groupe formé (et retire les membres de la queue) ou nullopt.
 		std::optional<LfgGroup> TryMatch(DungeonId dungeon)
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_byDungeon.find(dungeon);
 			if (it == m_byDungeon.end()) return std::nullopt;
 			auto& q = it->second;
@@ -97,6 +106,8 @@ namespace engine::server::lfg
 		}
 
 	private:
+		/// Audit Lot B1 — protège m_byDungeon contre les workers concurrents.
+		mutable std::mutex m_mutex;
 		std::unordered_map<DungeonId, std::vector<LfgEntry>> m_byDungeon;
 	};
 }

--- a/src/masterd/mail/MailManager.cpp
+++ b/src/masterd/mail/MailManager.cpp
@@ -14,6 +14,7 @@ namespace engine::server::mail
 		uint64_t nowMs, uint64_t expiresTsMs,
 		MailOpResult* outErr)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_store) return 0;
 
 		if (subject.size() > kMaxMailSubjectBytes)
@@ -51,6 +52,7 @@ namespace engine::server::mail
 
 	MailOpResult MailManager::MarkRead(uint64_t mailId, uint64_t receiverAccountId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_store) return MailOpResult::MailNotFound;
 		auto opt = m_store->Find(mailId);
 		if (!opt) return MailOpResult::MailNotFound;
@@ -67,6 +69,7 @@ namespace engine::server::mail
 	MailOpResult MailManager::TakeItems(uint64_t mailId, uint64_t receiverAccountId,
 		uint64_t paidCopper, std::vector<MailItemAttachment>& outItems)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		outItems.clear();
 		if (!m_store) return MailOpResult::MailNotFound;
 		auto opt = m_store->Find(mailId);
@@ -92,6 +95,7 @@ namespace engine::server::mail
 	MailOpResult MailManager::TakeGold(uint64_t mailId, uint64_t receiverAccountId,
 		uint64_t& outCopper)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		outCopper = 0;
 		if (!m_store) return MailOpResult::MailNotFound;
 		auto opt = m_store->Find(mailId);
@@ -110,6 +114,7 @@ namespace engine::server::mail
 
 	MailOpResult MailManager::Delete(uint64_t mailId, uint64_t receiverAccountId)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_store) return MailOpResult::MailNotFound;
 		auto opt = m_store->Find(mailId);
 		if (!opt) return MailOpResult::MailNotFound;
@@ -123,6 +128,7 @@ namespace engine::server::mail
 
 	std::vector<Mail> MailManager::Inbox(uint64_t receiverAccountId) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_store) return {};
 		auto v = m_store->ListInbox(receiverAccountId);
 		// Tri par sentTsMs decroissant (plus recent d'abord).
@@ -133,6 +139,7 @@ namespace engine::server::mail
 
 	std::vector<uint64_t> MailManager::ResolveExpired(uint64_t nowMs) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_store) return {};
 		return m_store->FindExpired(nowMs);
 	}

--- a/src/masterd/mail/MailManager.h
+++ b/src/masterd/mail/MailManager.h
@@ -8,10 +8,16 @@
 // InMemoryMailStore). La couche reseau (MailHandler + opcodes wire)
 // + la persistance MySQL viendront en sub-PRs ulterieures.
 
+// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : les handlers du master sont
+// dispatchés sur un pool de workers NetServer (défaut 4) ; chaque méthode
+// publique du manager verrouille m_mutex (sérialise les séquences
+// lecture-modification-écriture sur le store, quel qu'il soit).
+
 #include "src/masterd/mail/Mail.h"
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <vector>
@@ -118,6 +124,9 @@ namespace engine::server::mail
 		std::vector<uint64_t> ResolveExpired(uint64_t nowMs) const;
 
 	private:
+		/// Audit Lot B1 — sérialise les opérations mail entre workers (les
+		/// séquences Find→Update du store ne sont pas atomiques sans ça).
+		mutable std::mutex m_mutex;
 		IMailStore*       m_store;
 		MailManagerConfig m_cfg;
 	};

--- a/src/masterd/quests/QuestState.h
+++ b/src/masterd/quests/QuestState.h
@@ -2,8 +2,14 @@
 // CMANGOS.23 (Phase 3.23a) — QuestState : machine d'états par joueur+
 // quête (None → Available → Accepted → Completed → Rewarded → None).
 // Header-only, in-memory (DB persistence + handler en sub-PRs).
+//
+// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : les handlers du master sont
+// dispatchés sur un pool de workers NetServer (défaut 4) ; chaque méthode
+// publique verrouille m_mutex et délègue à GetUnlocked (privé) pour la
+// lecture interne — jamais de double verrouillage.
 
 #include <cstdint>
+#include <mutex>
 #include <unordered_map>
 
 namespace engine::server::quests
@@ -33,15 +39,14 @@ namespace engine::server::quests
 	public:
 		QuestStatus Get(AccountId account, QuestId quest) const
 		{
-			auto itAcc = m_state.find(account);
-			if (itAcc == m_state.end()) return QuestStatus::None;
-			auto itQ = itAcc->second.find(quest);
-			return (itQ == itAcc->second.end()) ? QuestStatus::None : itQ->second;
+			std::lock_guard<std::mutex> lock(m_mutex);
+			return GetUnlocked(account, quest);
 		}
 
 		QuestOpResult Accept(AccountId account, QuestId quest)
 		{
-			const auto cur = Get(account, quest);
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const auto cur = GetUnlocked(account, quest);
 			if (cur != QuestStatus::None && cur != QuestStatus::Available)
 				return QuestOpResult::WrongStatus;
 			m_state[account][quest] = QuestStatus::Accepted;
@@ -50,7 +55,8 @@ namespace engine::server::quests
 
 		QuestOpResult Complete(AccountId account, QuestId quest)
 		{
-			const auto cur = Get(account, quest);
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const auto cur = GetUnlocked(account, quest);
 			if (cur != QuestStatus::Accepted) return QuestOpResult::WrongStatus;
 			m_state[account][quest] = QuestStatus::Completed;
 			return QuestOpResult::OK;
@@ -58,7 +64,8 @@ namespace engine::server::quests
 
 		QuestOpResult Reward(AccountId account, QuestId quest)
 		{
-			const auto cur = Get(account, quest);
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const auto cur = GetUnlocked(account, quest);
 			if (cur != QuestStatus::Completed) return QuestOpResult::WrongStatus;
 			m_state[account][quest] = QuestStatus::Rewarded;
 			return QuestOpResult::OK;
@@ -66,19 +73,25 @@ namespace engine::server::quests
 
 		QuestOpResult Fail(AccountId account, QuestId quest)
 		{
-			const auto cur = Get(account, quest);
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const auto cur = GetUnlocked(account, quest);
 			if (cur != QuestStatus::Accepted) return QuestOpResult::WrongStatus;
 			m_state[account][quest] = QuestStatus::Failed;
 			return QuestOpResult::OK;
 		}
 
-		void Clear() { m_state.clear(); }
+		void Clear()
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_state.clear();
+		}
 
 		/// CMANGOS.23 (Phase 5.23 step 3+4) — Liste toutes les quetes connues du
 		/// compte. Utilise par QuestHandler::HandleList pour repondre au client.
 		/// Retourne une copie ; complexite O(n) sur le nombre de quetes du compte.
 		std::unordered_map<QuestId, QuestStatus> ListAll(AccountId account) const
 		{
+			std::lock_guard<std::mutex> lock(m_mutex);
 			auto it = m_state.find(account);
 			if (it == m_state.end())
 				return {};
@@ -86,6 +99,17 @@ namespace engine::server::quests
 		}
 
 	private:
+		/// Lecture interne SANS verrou — appelée uniquement sous m_mutex.
+		QuestStatus GetUnlocked(AccountId account, QuestId quest) const
+		{
+			auto itAcc = m_state.find(account);
+			if (itAcc == m_state.end()) return QuestStatus::None;
+			auto itQ = itAcc->second.find(quest);
+			return (itQ == itAcc->second.end()) ? QuestStatus::None : itQ->second;
+		}
+
+		/// Audit Lot B1 — protège m_state contre les workers concurrents.
+		mutable std::mutex m_mutex;
 		std::unordered_map<AccountId, std::unordered_map<QuestId, QuestStatus>> m_state;
 	};
 }

--- a/src/shared/security/RateLimitAndBan.cpp
+++ b/src/shared/security/RateLimitAndBan.cpp
@@ -19,6 +19,7 @@ namespace engine::server
 
 	void RateLimitAndBan::SetConfig(const RateLimitAndBanConfig& config)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_config = config;
 		LOG_DEBUG(Net, "[RateLimitAndBan] Config set: auth_per_min={} register_per_hour={} max_failures={} ban_duration_sec={}",
 			m_config.auth_per_minute, m_config.register_per_hour, m_config.max_failures_before_ban, m_config.ban_duration_sec);
@@ -73,8 +74,9 @@ namespace engine::server
 
 	bool RateLimitAndBan::TryConsumeAuth(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
-		if (IsBanned(ip))
+		if (isBannedUnlocked(ip))
 			return false;
 		double capacity = static_cast<double>(m_config.auth_per_minute);
 		double refill_per_sec = capacity / 60.0;
@@ -90,8 +92,9 @@ namespace engine::server
 
 	bool RateLimitAndBan::TryConsumeRegister(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
-		if (IsBanned(ip))
+		if (isBannedUnlocked(ip))
 			return false;
 		double capacity = static_cast<double>(m_config.register_per_hour);
 		double refill_per_sec = capacity / 3600.0;
@@ -107,6 +110,7 @@ namespace engine::server
 
 	void RateLimitAndBan::RecordAuthFailure(std::string_view ip)
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		std::string key(ip);
 		AuthState& state = getOrCreateState(key);
 		state.failure_count++;
@@ -121,6 +125,12 @@ namespace engine::server
 	}
 
 	bool RateLimitAndBan::IsBanned(std::string_view ip) const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return isBannedUnlocked(ip);
+	}
+
+	bool RateLimitAndBan::isBannedUnlocked(std::string_view ip) const
 	{
 		auto it = m_banned_until.find(std::string(ip));
 		if (it == m_banned_until.end())
@@ -154,6 +164,7 @@ namespace engine::server
 
 	void RateLimitAndBan::PurgeExpired()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		auto now = clock().Now();
 		for (auto it = m_banned_until.begin(); it != m_banned_until.end(); )
 		{
@@ -167,6 +178,7 @@ namespace engine::server
 
 	void RateLimitAndBan::GetCounters(SecurityCounters& out) const
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		out = m_counters;
 		out.bans_active = 0;
 		auto now = clock().Now();

--- a/src/shared/security/RateLimitAndBan.h
+++ b/src/shared/security/RateLimitAndBan.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -36,6 +37,9 @@ namespace engine::server
 	};
 
 	/// Token bucket + failure count + IP ban. Apply before costly auth/DB. In-memory + periodic purge.
+	/// Audit 2026-06-10 (Lot B1) — THREAD-SAFE : appelée depuis les workers
+	/// NetServer (AuthRegisterHandler…) ; chaque méthode publique verrouille
+	/// m_mutex (lecture interne via isBannedUnlocked, jamais de double lock).
 	class RateLimitAndBan
 	{
 	public:
@@ -86,6 +90,8 @@ namespace engine::server
 			int failure_count = 0;
 		};
 
+		/// Audit Lot B1 — protège maps/compteurs contre les workers concurrents.
+		mutable std::mutex m_mutex;
 		RateLimitAndBanConfig m_config;
 		mutable SecurityCounters m_counters;
 		std::unordered_map<std::string, AuthState> m_by_ip;
@@ -96,5 +102,7 @@ namespace engine::server
 		bool tryConsume(TokenBucket& bucket, double capacity, double refill_per_sec);
 		AuthState& getOrCreateState(const std::string& key);
 		void purgeOldEntries();
+		/// Lecture interne SANS verrou — appelée uniquement sous m_mutex.
+		bool isBannedUnlocked(std::string_view ip) const;
 	};
 }


### PR DESCRIPTION
## Audit Lot B1 — le constat n°1 de l''audit serveur, corrigé

Premier lot du backlog critique de l''audit global (`docs/audit/2026-06-10-audit-global-4-parties.md`, section serveur). **Aucun changement wire ni fonctionnel** — uniquement de la robustesse concurrence/mémoire.

### Le problème
Le `NetServer` du master dispatche les paquets sur un **pool de workers** (`worker_threads`, défaut 4) qui appellent les handlers en parallèle. Or six systèmes à état RAM mutaient leurs `unordered_map` **sans aucun verrou** — deux requêtes concurrentes du même type = corruption mémoire possible (UB), là où Weather/Guild/Auction avaient déjà leurs mutex.

### Correctifs
- **Mutex** sur `LfgQueue`, `GmTicketSystem`, `QuestStateTracker`, `MailManager`, `RateLimitAndBan`, `PasswordResetStore` : chaque méthode publique verrouille ; quand une méthode publique en appelait une autre (`QuestStateTracker::Get`, `RateLimitAndBan::IsBanned`), extraction d''un helper privé non verrouillé (`GetUnlocked`/`isBannedUnlocked`) — **zéro double verrouillage**. `MailManager` sérialise au niveau manager : les séquences Find→Update du store n''étaient pas atomiques.
- **Fuite mémoire lente corrigée** : l''anti-rejeu `ShardTicketValidator::m_used_ticket_ids` ne purgeait jamais (croissance monotone tant que le shard tourne). Set → map `ticket_id → expires_at` + purge opportuniste à chaque validation (les tickets expirent en ~60 s).
- Contrats docs mis à jour (les « caller must serialise access » n''étaient pas honorés).

### Hors périmètre (lots suivants de l''audit)
B2 framebuffers Vulkan, B3 intégrité éditeur, B4 sécurité portail — chacun son PR.

**Déploiement** : ⚠️ master + shardd — porté par la fenêtre lock-step v12 (toujours pas déployée) ; aucun changement de protocole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)