### PR TITLE
fix(render): Lot B2 audit - caches framebuffer par passe, fin de l'UB destroy-avant-submit

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2288,6 +2288,7 @@ gagne un canal pour IMPOSER une position. Kind `ForcePosition = 86` **rétro-add
   serveur), l''inverse de T0.1. Socle d''un éventuel futur passage serveur-autoritaire.
 - **Déploiement** : ⚠️ shardd (producteurs) — fenêtre lock-step v12 déjà requise.
 
+
 ## Audit Lot B1 — thread-safety du master + purge anti-rejeu (2026-06-12)
 
 Correctifs du constat majeur de l''audit 2026-06-10 : le NetServer dispatche les
@@ -2299,3 +2300,17 @@ séquences Find→Update du store), `RateLimitAndBan`, `PasswordResetStore`.
 Et purge opportuniste de l''anti-rejeu `ShardTicketValidator::m_used_ticket_ids`
 (set → map ticket_id→expires_at ; l''ancien set grossissait sans fin).
 **Déploiement** : ⚠️ master + shardd — porté par la fenêtre lock-step v12.
+
+## Audit Lot B2 — caches framebuffer des passes de post-process (2026-06-12)
+
+Correctif du 2e constat majeur de l''audit 2026-06-10 (client) : 12 classes de passes
+(Lighting, Tonemap, Ssao, SsaoBlur, Taa, Bloom×4 — un 4e site BloomCombine non vu par
+l''audit, Cloud, Underwater, VolumetricFog, DepthOfField + site instanced résiduel de
+GeometryPass) créaient un framebuffer temporaire dans Record() puis le DÉTRUISAIENT
+avant le vkQueueSubmit (UB, toléré par le driver actuel). Toutes passent au pattern
+cache de WaterPass (clé = vues d''attachement + extent, invalidation au resize via
+DeferredPipeline::InvalidateFramebufferCaches — 15 appels — + m_underwaterPass côté
+Engine, nettoyage au Destroy). Bonus perf : plus de create/destroy par frame.
+Constat annexe : `Engine::m_underwaterPass` est DORMANT (jamais Init/Record — M37.3
+non câblé au frame graph) ; corrigé quand même, à câbler ou supprimer (Lot C).
+**Déploiement** : ✅ client uniquement.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7753,6 +7753,10 @@ namespace engine
 				// VkImageView source : un resize détruit toutes les vues FG → cache
 				// stale. Invalidation au même endroit que terrain/pipeline.
 				m_waterPass.InvalidateFramebufferCache(m_vkDeviceContext.GetDevice());
+				// Audit 2026-06-10 (Lot B2) — UnderwaterPass cache désormais son
+				// framebuffer (pattern WaterPass) ; pas membre de DeferredPipeline,
+				// donc invalidation ici comme m_waterPass.
+				m_underwaterPass.InvalidateFramebufferCache(m_vkDeviceContext.GetDevice());
 
 				m_frameGraph.destroy(m_vkDeviceContext.GetDevice(), m_vmaAllocator);
 				// All frame-graph images are recreated after a resize/out-of-date event, so the

--- a/src/client/render/BloomPass.cpp
+++ b/src/client/render/BloomPass.cpp
@@ -314,17 +314,28 @@ namespace engine::render
 		write.pImageInfo      = &imageInfo;
 		vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewDst;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		BloomFramebufferKey fbKey{ viewDst, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewDst;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkClearValue clearVal{};
 		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
@@ -354,13 +365,27 @@ namespace engine::render
 			0, static_cast<uint32_t>(sizeof(PrefilterParams)), &params);
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void BloomPrefilterPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void BloomPrefilterPass::Destroy(VkDevice device)
 	{
 		LOG_DEBUG(Render, "[BLOOM] BloomPrefilterPass::Destroy enter");
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE)
 			{ vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE)
@@ -662,17 +687,28 @@ namespace engine::render
 		write.pImageInfo      = &imageInfo;
 		vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewDst;
-		fbInfo.width           = extentDst.width;
-		fbInfo.height          = extentDst.height;
-		fbInfo.layers          = 1;
-
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		BloomFramebufferKey fbKey{ viewDst, extentDst.width, extentDst.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewDst;
+			fbInfo.width           = extentDst.width;
+			fbInfo.height          = extentDst.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkClearValue clearVal{};
 		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
@@ -700,13 +736,27 @@ namespace engine::render
 
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void BloomDownsamplePass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void BloomDownsamplePass::Destroy(VkDevice device)
 	{
 		LOG_DEBUG(Render, "[BLOOM] BloomDownsamplePass::Destroy enter");
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE)
 			{ vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE)
@@ -1014,17 +1064,28 @@ namespace engine::render
 		write.pImageInfo      = &imageInfo;
 		vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewDst;
-		fbInfo.width           = extentDst.width;
-		fbInfo.height          = extentDst.height;
-		fbInfo.layers          = 1;
-
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		BloomFramebufferKey fbKey{ viewDst, extentDst.width, extentDst.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewDst;
+			fbInfo.width           = extentDst.width;
+			fbInfo.height          = extentDst.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkRenderPassBeginInfo rpBegin{};
 		rpBegin.sType       = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -1050,13 +1111,27 @@ namespace engine::render
 
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void BloomUpsamplePass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void BloomUpsamplePass::Destroy(VkDevice device)
 	{
 		LOG_DEBUG(Render, "[BLOOM] BloomUpsamplePass::Destroy enter");
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE)
 			{ vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE)
@@ -1380,17 +1455,28 @@ namespace engine::render
 		writes[1].pImageInfo      = &imageInfos[1];
 		vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewDst;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		BloomFramebufferKey fbKey{ viewDst, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewDst;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS) return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkClearValue clearVal{};
 		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
@@ -1420,13 +1506,27 @@ namespace engine::render
 			0, static_cast<uint32_t>(sizeof(CombineParams)), &params);
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void BloomCombinePass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void BloomCombinePass::Destroy(VkDevice device)
 	{
 		LOG_DEBUG(Render, "[BLOOM] BloomCombinePass::Destroy enter");
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE)
 			{ vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE)

--- a/src/client/render/BloomPass.h
+++ b/src/client/render/BloomPass.h
@@ -6,10 +6,37 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
 {
+	/// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+	/// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+	/// Clé partagée par les 4 sous-passes bloom (chaque sous-passe a SA map :
+	/// la vue de sortie + l'extent suffisent à différencier les cibles/mips).
+	struct BloomFramebufferKey
+	{
+		VkImageView outputView = VK_NULL_HANDLE;
+		uint32_t width = 0;
+		uint32_t height = 0;
+		bool operator==(const BloomFramebufferKey& o) const noexcept
+		{
+			return outputView == o.outputView && width == o.width && height == o.height;
+		}
+	};
+	struct BloomFramebufferKeyHash
+	{
+		size_t operator()(const BloomFramebufferKey& k) const noexcept
+		{
+			const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+			const size_t hW = std::hash<uint32_t>{}(k.width);
+			const size_t hH = std::hash<uint32_t>{}(k.height);
+			return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+		}
+	};
+
 	/// Bloom prefilter pass (M08.1): samples SceneColor_HDR, applies soft threshold (threshold + knee),
 	/// writes BloomMip0 (HDR). Fullscreen triangle, one combined image sampler, push constants (threshold, knee).
 	class BloomPrefilterPass
@@ -41,9 +68,16 @@ namespace engine::render
 			const PrefilterParams& params, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		/// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass).
+		std::unordered_map<BloomFramebufferKey, VkFramebuffer, BloomFramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout  m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
@@ -77,9 +111,16 @@ namespace engine::render
 			uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		/// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass).
+		std::unordered_map<BloomFramebufferKey, VkFramebuffer, BloomFramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout  m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
@@ -114,9 +155,16 @@ namespace engine::render
 			uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		/// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass).
+		std::unordered_map<BloomFramebufferKey, VkFramebuffer, BloomFramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
@@ -156,9 +204,16 @@ namespace engine::render
 			const CombineParams& params, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		/// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass).
+		std::unordered_map<BloomFramebufferKey, VkFramebuffer, BloomFramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/CloudPass.cpp
+++ b/src/client/render/CloudPass.cpp
@@ -296,19 +296,31 @@ namespace engine::render
 		}
 		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewOut;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "CloudPass::Record: vkCreateFramebuffer failed");
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewOut;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass::Record: vkCreateFramebuffer failed");
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		VkClearValue clearVal{};
@@ -337,12 +349,26 @@ namespace engine::render
 			0, static_cast<uint32_t>(sizeof(CloudPushConstants)), &params);
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void CloudPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void CloudPass::Destroy(VkDevice device)
 	{
 		if (device == VK_NULL_HANDLE) { LOG_INFO(Render, "[CloudPass] Destroyed"); return; }
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline)            { vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout)      { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_nearestSampler)      { vkDestroySampler(device, m_nearestSampler, nullptr); m_nearestSampler = VK_NULL_HANDLE; }

--- a/src/client/render/CloudPass.h
+++ b/src/client/render/CloudPass.h
@@ -2,7 +2,7 @@
 // Passe GRAPHIQUE plein écran de nuages volumétriques ray-marchés (fragment shader).
 // Calquée EXACTEMENT sur VolumetricFogPass : render pass 1 attachment color,
 // descriptor set 0 de 2 combined image samplers (scene color, depth), push
-// constants fragment, pipeline fullscreen triangle, framebuffer temporaire dans Record.
+// constants fragment, pipeline fullscreen triangle, framebuffer mis en cache dans Record.
 //
 // Descriptor set 0 :
 //   binding 0 = scene color HDR (post-fog)  (sampler linéaire clamp)
@@ -14,6 +14,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -60,9 +62,37 @@ namespace engine::render
 			ResourceId idSceneColorOut, const CloudPushConstants& params, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -556,5 +556,20 @@ namespace engine::render
 		m_geometryPass.InvalidateFramebufferCache(device);
 		m_shadowMapPass.InvalidateFramebufferCache(device);
 		m_decalPass.InvalidateFramebufferCache(device);
+		// Audit 2026-06-10 (Lot B2) — toutes les passes post-process cachent
+		// désormais leur framebuffer (pattern WaterPass) : invalider au resize
+		// car les VkImageView du frame graph sont détruites/recréées.
+		m_ssaoPass.InvalidateFramebufferCache(device);
+		m_ssaoBlurPass.InvalidateFramebufferCache(device);
+		m_lightingPass.InvalidateFramebufferCache(device);
+		m_volumetricFogPass.InvalidateFramebufferCache(device);
+		m_cloudPass.InvalidateFramebufferCache(device);
+		m_depthOfFieldPass.InvalidateFramebufferCache(device);
+		m_tonemapPass.InvalidateFramebufferCache(device);
+		m_bloomPrefilterPass.InvalidateFramebufferCache(device);
+		m_bloomDownsamplePass.InvalidateFramebufferCache(device);
+		m_bloomUpsamplePass.InvalidateFramebufferCache(device);
+		m_bloomCombinePass.InvalidateFramebufferCache(device);
+		m_taaPass.InvalidateFramebufferCache(device);
 	}
 }

--- a/src/client/render/DepthOfFieldPass.cpp
+++ b/src/client/render/DepthOfFieldPass.cpp
@@ -388,23 +388,33 @@ namespace engine::render
 		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
 		// ------------------------------------------------------------------
-		// Crée un framebuffer temporaire sur l'image de sortie.
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
 		// ------------------------------------------------------------------
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewOut;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
-		if (res != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "DepthOfFieldPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewOut;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "DepthOfFieldPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		// ------------------------------------------------------------------
@@ -444,9 +454,23 @@ namespace engine::render
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 
 		vkCmdEndRenderPass(cmd);
+	}
 
-		// Détruit le framebuffer temporaire immédiatement.
-		vkDestroyFramebuffer(device, fb, nullptr);
+	// -------------------------------------------------------------------------
+	// DepthOfFieldPass::InvalidateFramebufferCache
+	// -------------------------------------------------------------------------
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void DepthOfFieldPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	// -------------------------------------------------------------------------
@@ -460,6 +484,9 @@ namespace engine::render
 			LOG_INFO(Render, "[DepthOfFieldPass] Destroyed");
 			return;
 		}
+
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 
 		if (m_pipeline != VK_NULL_HANDLE)
 		{

--- a/src/client/render/DepthOfFieldPass.h
+++ b/src/client/render/DepthOfFieldPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -23,8 +25,8 @@ namespace engine::render
 	/// Structure calquée EXACTEMENT sur VolumetricFogPass : render pass 1 attachment
 	/// color (load DONT_CARE, on réécrit tout le plein écran), descriptor set 0 de N
 	/// combined image samplers, push constants fragment, pipeline fullscreen triangle
-	/// (3 sommets, pas de vertex input, pas de depth test), framebuffer temporaire
-	/// créé/détruit dans Record.
+	/// (3 sommets, pas de vertex input, pas de depth test), framebuffer mis en cache
+	/// dans Record (pattern WaterPass).
 	///
 	/// Descriptor set 0 : 2 combined image samplers
 	///   binding 0 = scene color HDR post-bloom (sampler LINÉAIRE clamp)
@@ -64,9 +66,8 @@ namespace engine::render
 
 		/// Enregistre la passe profondeur de champ dans cmd.
 		/// Met à jour le descriptor set de la frame avec les 2 vues (scene color, depth),
-		/// crée un framebuffer temporaire sur idColorOut, ouvre la render pass, push les
-		/// DofParams, dessine le triangle plein écran, ferme la render pass et détruit le
-		/// framebuffer immédiatement.
+		/// récupère (ou crée) le framebuffer dans le cache interne, ouvre la render pass,
+		/// push les DofParams, dessine le triangle plein écran et ferme la render pass.
 		/// \param idColorIn   SceneColor HDR post-bloom (lu en entrée, sampler linéaire).
 		/// \param idDepth     Depth scene (D32_SFLOAT, sampler nearest).
 		/// \param idColorOut  Cible de sortie (SceneColor HDR floutée).
@@ -78,10 +79,37 @@ namespace engine::render
 		/// Libère toutes les ressources Vulkan. Sûr à appeler même si non initialisé.
 		void Destroy(VkDevice device);
 
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		/// Renvoie true si le pipeline et la render pass sont valides.
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/GeometryPass.cpp
+++ b/src/client/render/GeometryPass.cpp
@@ -1000,19 +1000,37 @@ namespace engine::render
 		if (!viewA || !viewB || !viewC || !viewVel || !viewDepth)
 			return;
 
-		VkImageView views[5] = { viewA, viewB, viewC, viewVel, viewDepth };
-		VkFramebufferCreateInfo fbInfo = {};
-		fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass = activeRp;
-		fbInfo.attachmentCount = 5;
-		fbInfo.pAttachments = views;
-		fbInfo.width = extent.width;
-		fbInfo.height = extent.height;
-		fbInfo.layers = 1;
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		// RecordInstanced réutilise le m_fbCache existant des autres Record.
+		FramebufferKey key{};
+		key.renderPass = activeRp;
+		key.views[0]   = viewA;
+		key.views[1]   = viewB;
+		key.views[2]   = viewC;
+		key.views[3]   = viewVel;
+		key.views[4]   = viewDepth;
+		key.width      = extent.width;
+		key.height     = extent.height;
 
-		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
-			return;
+		auto it = m_fbCache.find(key);
+		if (it == m_fbCache.end())
+		{
+			VkImageView views[5] = { viewA, viewB, viewC, viewVel, viewDepth };
+			VkFramebufferCreateInfo fbInfo = {};
+			fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass = activeRp;
+			fbInfo.attachmentCount = 5;
+			fbInfo.pAttachments = views;
+			fbInfo.width = extent.width;
+			fbInfo.height = extent.height;
+			fbInfo.layers = 1;
+			VkFramebuffer created = VK_NULL_HANDLE;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &created) != VK_SUCCESS)
+				return;
+			it = m_fbCache.emplace(key, created).first;
+		}
+		VkFramebuffer fb = it->second;
 
 		VkClearValue clearValues[5] = {};
 		clearValues[0].color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
@@ -1072,7 +1090,6 @@ namespace engine::render
 		}
 
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
 	}
 
 } // namespace engine::render

--- a/src/client/render/LightingPass.cpp
+++ b/src/client/render/LightingPass.cpp
@@ -659,23 +659,33 @@ namespace engine::render
 		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
 		// ------------------------------------------------------------------
-		// Create a temporary framebuffer for this frame.
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
 		// ------------------------------------------------------------------
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewHDR;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		FramebufferKey fbKey{ viewHDR, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
-		if (res != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "LightingPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewHDR;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "LightingPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		// ------------------------------------------------------------------
@@ -715,9 +725,23 @@ namespace engine::render
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 
 		vkCmdEndRenderPass(cmd);
+	}
 
-		// Destroy the temporary framebuffer immediately.
-		vkDestroyFramebuffer(device, fb, nullptr);
+	// -------------------------------------------------------------------------
+	// LightingPass::InvalidateFramebufferCache
+	// -------------------------------------------------------------------------
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void LightingPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	// -------------------------------------------------------------------------
@@ -731,6 +755,9 @@ namespace engine::render
 			LOG_INFO(Render, "[LightingPass] Destroyed");
 			return;
 		}
+
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 
 		if (m_pipeline != VK_NULL_HANDLE)
 		{

--- a/src/client/render/LightingPass.h
+++ b/src/client/render/LightingPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -97,8 +99,8 @@ namespace engine::render
 
 		/// Records the lighting pass into cmd.
 		/// Updates the frame's descriptor set with the current GBuffer and IBL image views,
-		/// creates a temporary framebuffer, begins the render pass, draws the fullscreen triangle,
-		/// and ends the render pass (framebuffer is destroyed immediately after).
+		/// fetches (or creates) the framebuffer from the internal cache, begins the render
+		/// pass, draws the fullscreen triangle, and ends the render pass.
 		/// When irradianceView is VK_NULL_HANDLE, IBL is disabled (useIBL=0, constant ambient).
 		/// \param idDecalOverlay  M17.3 decal overlay texture written after geometry and composited into albedo.
 		/// \param irradianceView / irradianceSampler  Irradiance cubemap (M05.2); may be null.
@@ -130,10 +132,37 @@ namespace engine::render
 		/// Releases all Vulkan resources. Safe to call even when not initialized.
 		void Destroy(VkDevice device);
 
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		/// Returns true if the pipeline and render pass are valid.
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/SsaoBlurPass.cpp
+++ b/src/client/render/SsaoBlurPass.cpp
@@ -276,17 +276,29 @@ namespace engine::render
 		params.horizontal = horizontal ? 1.0f : 0.0f;
 		params._pad = 0.0f;
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments = &viewOut;
-		fbInfo.width = extent.width;
-		fbInfo.height = extent.height;
-		fbInfo.layers = 1;
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
-			return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments = &viewOut;
+			fbInfo.width = extent.width;
+			fbInfo.height = extent.height;
+			fbInfo.layers = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+				return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkRenderPassBeginInfo rpBegin{};
 		rpBegin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -310,12 +322,26 @@ namespace engine::render
 
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void SsaoBlurPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void SsaoBlurPass::Destroy(VkDevice device)
 	{
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_sampler != VK_NULL_HANDLE) { vkDestroySampler(device, m_sampler, nullptr); m_sampler = VK_NULL_HANDLE; }

--- a/src/client/render/SsaoBlurPass.h
+++ b/src/client/render/SsaoBlurPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 
 namespace engine::render
 {
@@ -42,9 +44,37 @@ namespace engine::render
 			bool horizontal, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass     = VK_NULL_HANDLE;
 		VkDescriptorSetLayout  m_setLayout      = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descPool       = VK_NULL_HANDLE;

--- a/src/client/render/SsaoPass.cpp
+++ b/src/client/render/SsaoPass.cpp
@@ -300,17 +300,29 @@ namespace engine::render
 		writes[3].pImageInfo = &noiseImg;
 		vkUpdateDescriptorSets(device, 4, writes.data(), 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments = &viewSsao;
-		fbInfo.width = extent.width;
-		fbInfo.height = extent.height;
-		fbInfo.layers = 1;
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		FramebufferKey fbKey{ viewSsao, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
-			return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments = &viewSsao;
+			fbInfo.width = extent.width;
+			fbInfo.height = extent.height;
+			fbInfo.layers = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+				return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkRenderPassBeginInfo rpBegin{};
 		rpBegin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -334,12 +346,26 @@ namespace engine::render
 
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void SsaoPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void SsaoPass::Destroy(VkDevice device)
 	{
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_sampler != VK_NULL_HANDLE) { vkDestroySampler(device, m_sampler, nullptr); m_sampler = VK_NULL_HANDLE; }

--- a/src/client/render/SsaoPass.h
+++ b/src/client/render/SsaoPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 
 namespace engine::render
 {
@@ -43,9 +45,37 @@ namespace engine::render
 			const SsaoParams& params, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout  m_setLayout           = VK_NULL_HANDLE;
 		VkDescriptorPool       m_descPool            = VK_NULL_HANDLE;

--- a/src/client/render/TaaPass.cpp
+++ b/src/client/render/TaaPass.cpp
@@ -276,17 +276,29 @@ namespace engine::render
 		}
 		vkUpdateDescriptorSets(device, 4, writes.data(), 0, nullptr);
 
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments = &viewOut;
-		fbInfo.width = extent.width;
-		fbInfo.height = extent.height;
-		fbInfo.layers = 1;
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
-			return;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments = &viewOut;
+			fbInfo.width = extent.width;
+			fbInfo.height = extent.height;
+			fbInfo.layers = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+				return;
+			m_framebufferCache[fbKey] = fb;
+		}
 
 		VkRenderPassBeginInfo rpBegin{};
 		rpBegin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -310,12 +322,26 @@ namespace engine::render
 
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
-		vkDestroyFramebuffer(device, fb, nullptr);
+	}
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void TaaPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	void TaaPass::Destroy(VkDevice device)
 	{
 		if (device == VK_NULL_HANDLE) return;
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 		if (m_pipeline != VK_NULL_HANDLE) { vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout != VK_NULL_HANDLE) { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_sampler != VK_NULL_HANDLE) { vkDestroySampler(device, m_sampler, nullptr); m_sampler = VK_NULL_HANDLE; }

--- a/src/client/render/TaaPass.h
+++ b/src/client/render/TaaPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 
 namespace engine::render
 {
@@ -41,9 +43,37 @@ namespace engine::render
 			const TaaParams& params, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
+
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass     = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_setLayout      = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descPool       = VK_NULL_HANDLE;

--- a/src/client/render/TonemapPass.cpp
+++ b/src/client/render/TonemapPass.cpp
@@ -375,23 +375,33 @@ namespace engine::render
 		vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
 
 		// ------------------------------------------------------------------
-		// Create a temporary framebuffer for the LDR output this frame.
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
 		// ------------------------------------------------------------------
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewLDR;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		FramebufferKey fbKey{ viewLDR, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
-		if (res != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "TonemapPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewLDR;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "TonemapPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		// ------------------------------------------------------------------
@@ -430,9 +440,23 @@ namespace engine::render
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 
 		vkCmdEndRenderPass(cmd);
+	}
 
-		// Destroy the temporary framebuffer immediately.
-		vkDestroyFramebuffer(device, fb, nullptr);
+	// -------------------------------------------------------------------------
+	// TonemapPass::InvalidateFramebufferCache
+	// -------------------------------------------------------------------------
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void TonemapPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	// -------------------------------------------------------------------------
@@ -444,6 +468,9 @@ namespace engine::render
 		LOG_DEBUG(Render, "[TONEMAP] Destroy enter");
 		if (device == VK_NULL_HANDLE)
 			return;
+
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 
 		if (m_pipeline != VK_NULL_HANDLE)
 		{

--- a/src/client/render/TonemapPass.h
+++ b/src/client/render/TonemapPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -49,9 +51,8 @@ namespace engine::render
 
 		/// Records the tonemap pass into cmd.
 		/// Updates the frame descriptor set with the current HDR image view,
-		/// creates a temporary framebuffer, begins the render pass, draws the
-		/// fullscreen triangle, and ends the render pass (framebuffer is
-		/// destroyed immediately after).
+		/// fetches (or creates) the framebuffer from the internal cache, begins
+		/// the render pass, draws the fullscreen triangle, and ends the render pass.
 		/// \param frameIndex  Current in-flight frame index (0 .. maxFrames-1).
 		/// \param lutView     Optional LUT texture view (256x16 strip or 32^3). If VK_NULL_HANDLE, LUT is disabled (binding 1 uses HDR view as fallback).
 		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry,
@@ -65,10 +66,37 @@ namespace engine::render
 		/// Releases all Vulkan resources. Safe to call even when not initialized.
 		void Destroy(VkDevice device);
 
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		/// Returns true if the pipeline and render pass are valid.
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/UnderwaterPass.cpp
+++ b/src/client/render/UnderwaterPass.cpp
@@ -405,22 +405,32 @@ namespace engine::render
 		writes[1].pImageInfo      = &imageInfos[1];
 		vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
 
-		// Create a temporary framebuffer for the underwater output RT.
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewUnderwaterOut;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		FramebufferKey fbKey{ viewUnderwaterOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
-		if (res != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "[UnderwaterPass] vkCreateFramebuffer failed: {}", static_cast<int>(res));
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewUnderwaterOut;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "[UnderwaterPass] vkCreateFramebuffer failed: {}", static_cast<int>(res));
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		VkRenderPassBeginInfo rpBegin{};
@@ -453,9 +463,24 @@ namespace engine::render
 
 		vkCmdEndRenderPass(cmd);
 
-		vkDestroyFramebuffer(device, fb, nullptr);
-
 		LOG_TRACE(Render, "[UnderwaterPass] Record OK (underwaterFactor={:.2f})", params.underwaterFactor);
+	}
+
+	// -------------------------------------------------------------------------
+	// UnderwaterPass::InvalidateFramebufferCache
+	// -------------------------------------------------------------------------
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void UnderwaterPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	// -------------------------------------------------------------------------
@@ -466,6 +491,9 @@ namespace engine::render
 	{
 		if (device == VK_NULL_HANDLE)
 			return;
+
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 
 		if (m_pipeline != VK_NULL_HANDLE)
 		{

--- a/src/client/render/UnderwaterPass.h
+++ b/src/client/render/UnderwaterPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -87,10 +89,37 @@ namespace engine::render
 		/// Releases all Vulkan resources. Safe to call even when not initialised.
 		void Destroy(VkDevice device);
 
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		/// Returns true when the pipeline and render pass are valid.
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;

--- a/src/client/render/VolumetricFogPass.cpp
+++ b/src/client/render/VolumetricFogPass.cpp
@@ -390,23 +390,33 @@ namespace engine::render
 		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
 
 		// ------------------------------------------------------------------
-		// Crée un framebuffer temporaire sur l'image de sortie.
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
 		// ------------------------------------------------------------------
-		VkFramebufferCreateInfo fbInfo{};
-		fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-		fbInfo.renderPass      = m_renderPass;
-		fbInfo.attachmentCount = 1;
-		fbInfo.pAttachments    = &viewOut;
-		fbInfo.width           = extent.width;
-		fbInfo.height          = extent.height;
-		fbInfo.layers          = 1;
-
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
 		VkFramebuffer fb = VK_NULL_HANDLE;
-		VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
-		if (res != VK_SUCCESS)
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
 		{
-			LOG_ERROR(Render, "VolumetricFogPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
-			return;
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewOut;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			VkResult res = vkCreateFramebuffer(device, &fbInfo, nullptr, &fb);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "VolumetricFogPass::Record: vkCreateFramebuffer failed: {}", static_cast<int>(res));
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
 		}
 
 		// ------------------------------------------------------------------
@@ -446,9 +456,23 @@ namespace engine::render
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 
 		vkCmdEndRenderPass(cmd);
+	}
 
-		// Détruit le framebuffer temporaire immédiatement.
-		vkDestroyFramebuffer(device, fb, nullptr);
+	// -------------------------------------------------------------------------
+	// VolumetricFogPass::InvalidateFramebufferCache
+	// -------------------------------------------------------------------------
+
+	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
+	void VolumetricFogPass::InvalidateFramebufferCache(VkDevice device)
+	{
+		if (device == VK_NULL_HANDLE) return;
+
+		for (auto& kv : m_framebufferCache)
+		{
+			if (kv.second != VK_NULL_HANDLE)
+				vkDestroyFramebuffer(device, kv.second, nullptr);
+		}
+		m_framebufferCache.clear();
 	}
 
 	// -------------------------------------------------------------------------
@@ -462,6 +486,9 @@ namespace engine::render
 			LOG_INFO(Render, "[VolumetricFogPass] Destroyed");
 			return;
 		}
+
+		// Lot B2 : vider le cache de framebuffers avant de détruire le render pass.
+		InvalidateFramebufferCache(device);
 
 		if (m_pipeline != VK_NULL_HANDLE)
 		{

--- a/src/client/render/VolumetricFogPass.h
+++ b/src/client/render/VolumetricFogPass.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <unordered_map>
 #include <vector>
 
 namespace engine::render
@@ -21,7 +23,7 @@ namespace engine::render
 	/// Structure calquée EXACTEMENT sur LightingPass : render pass 1 attachment color,
 	/// descriptor set 0 de N combined image samplers, push constants fragment, pipeline
 	/// fullscreen triangle (3 sommets, pas de vertex input, pas de depth test), framebuffer
-	/// temporaire créé/détruit dans Record.
+	/// mis en cache dans Record (pattern WaterPass).
 	///
 	/// Descriptor set 0 : 3 combined image samplers
 	///   binding 0 = scene color HDR post-water (sampler linéaire clamp)
@@ -64,9 +66,9 @@ namespace engine::render
 
 		/// Enregistre la passe brouillard volumique dans cmd.
 		/// Met à jour le descriptor set de la frame avec les 3 vues (scene color, depth,
-		/// shadow cascade 0), crée un framebuffer temporaire sur idSceneColorOut, ouvre la
-		/// render pass, push les FogParams, dessine le triangle plein écran, ferme la render
-		/// pass et détruit le framebuffer immédiatement.
+		/// shadow cascade 0), récupère (ou crée) le framebuffer dans le cache interne,
+		/// ouvre la render pass, push les FogParams, dessine le triangle plein écran et
+		/// ferme la render pass.
 		/// \param idSceneColorIn    SceneColor HDR post-water (lu en entrée).
 		/// \param idDepth           Depth scene (D32_SFLOAT).
 		/// \param idShadowCascade0  Shadow map cascade 0 (image DEPTH).
@@ -79,10 +81,37 @@ namespace engine::render
 		/// Libère toutes les ressources Vulkan. Sûr à appeler même si non initialisé.
 		void Destroy(VkDevice device);
 
+		/// Détruit les framebuffers cachés (appeler au resize avant FG destroy).
+		void InvalidateFramebufferCache(VkDevice device);
+
 		/// Renvoie true si le pipeline et la render pass sont valides.
 		bool IsValid() const { return m_pipeline != VK_NULL_HANDLE; }
 
 	private:
+		// Audit 2026-06-10 (Lot B2) — cache framebuffer (pattern WaterPass) :
+		// l'ancien framebuffer temporaire était détruit avant le vkQueueSubmit (UB).
+		struct FramebufferKey
+		{
+			VkImageView outputView = VK_NULL_HANDLE;
+			uint32_t width = 0;
+			uint32_t height = 0;
+			bool operator==(const FramebufferKey& o) const noexcept
+			{
+				return outputView == o.outputView && width == o.width && height == o.height;
+			}
+		};
+		struct FramebufferKeyHash
+		{
+			size_t operator()(const FramebufferKey& k) const noexcept
+			{
+				const size_t hView = std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(k.outputView));
+				const size_t hW = std::hash<uint32_t>{}(k.width);
+				const size_t hH = std::hash<uint32_t>{}(k.height);
+				return hView ^ (hW + 0x9e3779b9u) ^ (hH + 0x85ebca6bu);
+			}
+		};
+		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;


### PR DESCRIPTION
## Audit Lot B2 — l''UB Vulkan systémique des passes de post-process, corrigé

Deuxième lot du backlog critique de l''audit (`docs/audit/2026-06-10-audit-global-4-parties.md` §2.2). **100 % client (rendu Vulkan), zéro changement fonctionnel attendu** — et un gain perf (plus de vkCreateFramebuffer/vkDestroyFramebuffer par frame).

### Le problème
12 classes de passes créaient un framebuffer temporaire dans `Record()` puis le **détruisaient immédiatement après `vkCmdEndRenderPass` — avant le `vkQueueSubmit`**. Le command buffer encore exécutable référençait un framebuffer détruit : comportement indéfini, toléré par le driver actuel, signalé par les validation layers.

### La correction
Réplication du pattern **WaterPass** (la passe de référence saine) sur : `LightingPass`, `TonemapPass`, `SsaoPass`, `SsaoBlurPass`, `TaaPass`, **Bloom ×4** (Prefilter/Downsample/Upsample/Combine — l''audit n''avait vu que 3 sites, le 4e dans BloomCombine est corrigé aussi), `CloudPass`, `UnderwaterPass`, `VolumetricFogPass`, `DepthOfFieldPass`, plus le **site instanced résiduel de `GeometryPass`** (M09.3, 5 attachements) rangé dans son cache existant.

- Cache `FramebufferKey {vues d''attachement, extent} → VkFramebuffer` par passe ; création uniquement au premier usage.
- Invalidation au resize : `DeferredPipeline::InvalidateFramebufferCaches` passe de 3 à 15 appels ; `m_underwaterPass` (hors pipeline) câblée au bloc resize d''Engine à côté de WaterPass.
- Nettoyage dans chaque `Destroy()` (pas de fuite au shutdown).
- Vérifié : plus AUCUN `vkDestroyFramebuffer` dans un `Record()` ; les sites restants (Invalidate/Destroy, RacePreviewViewport, VkSwapchain) sont légitimes.

### Constat annexe (hors périmètre, pour le Lot C)
`Engine::m_underwaterPass` est **dormant** : jamais `Init()` ni `Record()` (effet sous-marin M37.3 jamais câblé au frame graph). Corrigée quand même — prête si elle est branchée un jour.

### Validation
CI (compilation des deux OS) + en jeu : aucun changement visuel attendu ; les validation layers Vulkan ne doivent plus signaler de framebuffer détruit en vol.

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)