### PR TITLE
fix(world-editor): Lot B3 audit - integrite des donnees de l'editeur monde

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2301,6 +2301,7 @@ Et purge opportuniste de l''anti-rejeu `ShardTicketValidator::m_used_ticket_ids`
 (set → map ticket_id→expires_at ; l''ancien set grossissait sans fin).
 **Déploiement** : ⚠️ master + shardd — porté par la fenêtre lock-step v12.
 
+
 ## Audit Lot B2 — caches framebuffer des passes de post-process (2026-06-12)
 
 Correctif du 2e constat majeur de l''audit 2026-06-10 (client) : 12 classes de passes
@@ -2314,3 +2315,23 @@ Engine, nettoyage au Destroy). Bonus perf : plus de create/destroy par frame.
 Constat annexe : `Engine::m_underwaterPass` est DORMANT (jamais Init/Record — M37.3
 non câblé au frame graph) ; corrigé quand même, à câbler ou supprimer (Lot C).
 **Déploiement** : ✅ client uniquement.
+
+## Audit Lot B3 — intégrité des données de l''éditeur monde (2026-06-12)
+
+Correctif des 4 constats 🔴 d''intégrité de l''audit 2026-06-10 §4.2 :
+1. **Reset au load** : RequestZoneDocumentsReload (Session) → WorldEditorShell::ResetForZoneChange
+   (réutilise TerrainDocument::Reset + zone_presets::ResetEditedZoneDocuments) — fini la
+   heightmap de la carte A réécrite sur la carte B.
+2. **Undo trans-cartes** : CommandStack::Clear() (existant, jamais appelé) câblé au
+   new/load via ResetForZoneChange + InitNewZoneTerrain.
+3. **Save eau/mesh/portails** : SaveToDisk des 3 documents (zéro appelant avant !) câblé
+   au point de save terrain (SaveZoneDocuments) + LoadZoneDocuments au chargement
+   (subtilité : dirty flag eau consommé par le rebuild GPU → save inconditionnel,
+   MarkDirty re-armé après load).
+4. **Namespacing par zone** : `core/ZonePaths.h` (helpers purs documentés) — écriture
+   `chunks/zone_<id>/…` + `instances/zone_<id>/…`, lecture avec fallback legacy plat
+   (migration douce), zoneId vide = legacy intégral. Test ctest ajouté
+   (Test_ZoneNamespacedPathsAndLegacyFallback).
+Suivi possible : StreamCache runtime lit encore les chemins plats (livraison normale =
+ExportRuntimeBundle) — rendre StreamCache zone-aware si partage direct éditeur→jeu voulu.
+**Déploiement** : ✅ client uniquement (éditeur monde).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5,6 +5,7 @@
 #include "src/world_editor/ui/EditorMode.h"
 #include "src/world_editor/ui/WorldEditorImGui.h"
 #include "src/world_editor/ui/WorldEditorSession.h"
+#include "src/world_editor/ui/WorldMapIo.h" // lot B3 : SanitizeZoneId (namespacing zone)
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/panels/ScenePanel.h"
 #include "src/shared/core/memory/Memory.h"
@@ -8110,7 +8111,30 @@ namespace engine
 				const float heightScale =
 					static_cast<float>(m_cfg.GetDouble("terrain.height_scale", 200.0));
 				const float flatHeightMeters = (32768.0f / 65535.0f) * heightScale;
+				// Lot B3 (audit 2026-06-10 §4.2, correctifs 1-2-4) — Nouvelle carte
+				// = changement de monde : vide la pile undo, reinitialise les 4
+				// documents (terrain/eau/mesh/portails) et propage le zoneId
+				// (namespacing disque chunks/zone_<id>/...) AVANT l'init des
+				// chunks plats. Pas de LoadZoneDocuments ici : une zone neuve
+				// demarre avec des documents vides.
+				m_worldEditorShell->ResetForZoneChange(
+					engine::editor::SanitizeZoneId(m_worldEditorSession->Doc().zoneId));
 				m_worldEditorShell->InitNewZoneTerrain(chunksPerAxis, flatHeightMeters);
+			}
+			// Lot B3 (correctifs 1+3) — Chargement d'une carte EXISTANTE :
+			// reinitialise les documents (les chunks de la carte precedente
+			// restaient en RAM et reecrivaient la heightmap de la nouvelle via
+			// SyncWorldEditorHeightmapFromDocument), vide l'undo, propage le
+			// zoneId, puis recharge eau / mesh inserts / portails depuis les
+			// chemins namespaces (fallback legacy plat en lecture). Place AVANT
+			// la consommation du reload GPU pour que le rebuild parte d'un
+			// etat document coherent.
+			if (m_worldEditorSession->ConsumeZoneDocumentsReloadRequest()
+				&& m_worldEditorShell && m_worldEditorShell->IsInitialized())
+			{
+				m_worldEditorShell->ResetForZoneChange(
+					engine::editor::SanitizeZoneId(m_worldEditorSession->Doc().zoneId));
+				m_worldEditorShell->LoadZoneDocuments(m_cfg);
 			}
 			if (m_worldEditorSession->ConsumeTerrainGpuReloadRequest())
 			{
@@ -8122,8 +8146,21 @@ namespace engine
 			if (m_worldEditorSession->ConsumeTerrainChunksSaveRequest()
 				&& m_worldEditorShell && m_worldEditorShell->IsInitialized())
 			{
+				// Lot B3 (correctif 4) — re-propage le zoneId courant avant la
+				// persistance : couvre le « save sous un autre nom de zone »
+				// (ActionSaveCurrentMap re-sanitize m_doc.zoneId depuis le
+				// buffer UI juste avant d'armer la requete de save).
+				m_worldEditorShell->PropagateZoneIdToDocuments(
+					engine::editor::SanitizeZoneId(m_worldEditorSession->Doc().zoneId));
 				const size_t nWritten = m_worldEditorShell->SaveTerrainChunks(m_cfg);
-				LOG_INFO(EditorWorld, "[Engine] Persisted {} terrain chunk file(s)", nWritten);
+				// Lot B3 (correctif 3) — persiste aussi les documents annexes
+				// (eau, mesh inserts, portails de donjon) : avant ce fix, aucun
+				// SaveToDisk n'etait appele hors tests -> lacs/rivieres/grottes/
+				// arches/portails places etaient perdus a la fermeture.
+				const size_t nDocs = m_worldEditorShell->SaveZoneDocuments(m_cfg);
+				LOG_INFO(EditorWorld,
+					"[Engine] Persisted {} terrain chunk file(s) + {} zone document(s)",
+					nWritten, nDocs);
 			}
 		}
 		// M100.46+ — Pont TerrainDocument → HeightmapData GPU. Consomme le

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -20,6 +20,7 @@
 #include "src/world_editor/prefs/UserPrefsStore.h"
 #include "src/world_editor/presets/ToolPresetRegistry.h"
 #include "src/world_editor/help/HelpContentStore.h"
+#include "src/world_editor/zone_presets/WorldMapEditDocumentReset.h"
 #include "src/world_editor/zone_presets/ZonePresetRegistry.h"
 
 #if defined(_WIN32)
@@ -751,10 +752,100 @@ namespace engine::editor::world
 
 	void WorldEditorShell::InitNewZoneTerrain(int chunksPerAxis, float flatHeightMeters)
 	{
+		// Lot B3 (correctif 2) — toute création de zone invalide l'historique
+		// undo/redo : les commandes mémorisées référencent les chunks de la
+		// carte précédente et rejoueraient ses deltas au Ctrl+Z. Idempotent
+		// si ResetForZoneChange a déjà vidé la pile juste avant.
+		m_commandStack.Clear();
 		m_terrainDoc.InitFlatZone(chunksPerAxis, flatHeightMeters);
 		LOG_INFO(EditorWorld,
 			"[WorldEditorShell] Init new zone terrain: {}x{} flat chunks at {:.1f} m",
 			chunksPerAxis, chunksPerAxis, flatHeightMeters);
+	}
+
+	void WorldEditorShell::PropagateZoneIdToDocuments(const std::string& zoneId)
+	{
+		m_terrainDoc.SetZoneId(zoneId);
+		m_waterDoc.SetZoneId(zoneId);
+		m_meshInsertDoc.SetZoneId(zoneId);
+		m_dungeonPortalDoc.SetZoneId(zoneId);
+	}
+
+	void WorldEditorShell::ResetForZoneChange(const std::string& zoneId)
+	{
+		// Correctif 2 — l'historique undo/redo appartient à la carte qui se
+		// ferme : on le détruit avant toute autre opération.
+		m_commandStack.Clear();
+		// Correctif 1 — évince de la RAM les chunks/instances de la carte
+		// précédente (sinon SyncWorldEditorHeightmapFromDocument réécrirait
+		// la heightmap de la nouvelle carte avec les hauteurs de l'ancienne).
+		zone_presets::ResetEditedZoneDocuments(
+			m_terrainDoc, m_waterDoc, m_meshInsertDoc, m_dungeonPortalDoc);
+		// Correctif 4 — namespace disque de la nouvelle carte.
+		PropagateZoneIdToDocuments(zoneId);
+		LOG_INFO(EditorWorld,
+			"[WorldEditorShell] Reset for zone change: zone='{}' (undo vide, documents reinitialises)",
+			zoneId);
+	}
+
+	void WorldEditorShell::LoadZoneDocuments(const engine::core::Config& cfg)
+	{
+		std::string err;
+		if (!m_waterDoc.LoadFromDisk(cfg, err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Water LoadFromDisk failed: {}", err);
+		}
+		// Le flag dirty du WaterDocument sert aussi de signal « rebuild GPU »
+		// (Engine::Render) ; LoadFromDisk le remet à false, on le ré-arme pour
+		// que la scène d'eau chargée s'affiche au prochain tick.
+		m_waterDoc.MarkDirty();
+		err.clear();
+		if (!m_meshInsertDoc.LoadFromDisk(cfg, err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] MeshInsert LoadFromDisk failed: {}", err);
+		}
+		err.clear();
+		if (!m_dungeonPortalDoc.LoadFromDisk(cfg, err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] DungeonPortal LoadFromDisk failed: {}", err);
+		}
+		LOG_INFO(EditorWorld,
+			"[WorldEditorShell] Loaded zone documents: {} lake(s)/{} river(s), {} mesh insert(s), {} portal(s)",
+			m_waterDoc.Get().lakes.size(), m_waterDoc.Get().rivers.size(),
+			m_meshInsertDoc.Size(), m_dungeonPortalDoc.Size());
+	}
+
+	size_t WorldEditorShell::SaveZoneDocuments(const engine::core::Config& cfg)
+	{
+		size_t written = 0;
+		std::string err;
+		if (m_waterDoc.SaveToDisk(cfg, err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Water SaveToDisk failed: {}", err);
+		}
+		err.clear();
+		if (m_meshInsertDoc.SaveToDisk(cfg, err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] MeshInsert SaveToDisk failed: {}", err);
+		}
+		err.clear();
+		if (m_dungeonPortalDoc.SaveToDisk(cfg, err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] DungeonPortal SaveToDisk failed: {}", err);
+		}
+		LOG_INFO(EditorWorld,
+			"[WorldEditorShell] Saved zone documents: {}/3 (eau, mesh inserts, portails)",
+			written);
+		return written;
 	}
 
 	size_t WorldEditorShell::SaveTerrainChunks(const engine::core::Config& cfg)

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -173,7 +173,62 @@ namespace engine::editor::world
 		///        (`SyncWorldEditorHeightmapFromDocument`) reecrit toute la
 		///        heightmap a la hauteur du chunk et fait « chuter » le sol hors
 		///        champ des la 1ere edition (regression terrain invisible).
+		/// Effet de bord (lot B3, correctif 2) : vide aussi la pile undo/redo
+		/// (`CommandStack::Clear`) — les commandes mémorisées pointent vers les
+		/// chunks de la carte précédente et rejoueraient ses deltas au Ctrl+Z.
 		void InitNewZoneTerrain(int chunksPerAxis, float flatHeightMeters);
+
+		/// Lot B3 (audit 2026-06-10 §4.2, correctifs 1-2-4) — Remise à zéro de
+		/// tout l'état d'édition dépendant de la carte. À appeler à CHAQUE
+		/// changement de monde (« Nouvelle carte » ET chargement d'une carte) :
+		///   1. vide la pile undo/redo (`CommandStack::Clear`) — sinon Ctrl+Z
+		///      rejouerait les deltas de la carte précédente sur la nouvelle ;
+		///   2. réinitialise les 4 documents (terrain, eau, mesh inserts,
+		///      portails de donjon) via `zone_presets::ResetEditedZoneDocuments`
+		///      — sinon les chunks de la carte A restent en RAM et réécrivent
+		///      la heightmap de la carte B à la première commande (via
+		///      `Engine::SyncWorldEditorHeightmapFromDocument`) ;
+		///   3. propage \p zoneId aux 4 documents pour le namespacing disque
+		///      (`chunks/zone_<id>/…`, `instances/zone_<id>/…`) via
+		///      `PropagateZoneIdToDocuments`.
+		/// \param zoneId identifiant de zone DÉJÀ sanitizé (`SanitizeZoneId`).
+		/// Effet de bord : détruit toutes les commandes undo/redo ; marque les
+		/// 4 documents dirty (cf. leurs `Reset()`).
+		/// Contrainte thread : main thread (comme tout le shell).
+		void ResetForZoneChange(const std::string& zoneId);
+
+		/// Lot B3 (correctif 4) — Propage \p zoneId (déjà sanitizé) aux 4
+		/// documents (terrain, eau, mesh inserts, portails) SANS toucher à
+		/// leur contenu ni à la pile undo. Utilisé par `ResetForZoneChange`
+		/// et, côté Engine, juste avant la persistance pour suivre un
+		/// éventuel « save sous un autre nom de zone ».
+		void PropagateZoneIdToDocuments(const std::string& zoneId);
+
+		/// Lot B3 (correctif 3) — Recharge depuis disque les documents annexes
+		/// de la zone courante (eau, mesh inserts, portails de donjon), avec
+		/// les chemins namespacés posés par `ResetForZoneChange` (fallback
+		/// LECTURE sur les anciens chemins plats). À appeler au CHARGEMENT
+		/// d'une carte, APRÈS `ResetForZoneChange`. Les chunks terrain, eux,
+		/// se rechargent en lazy via `TerrainDocument::EnsureLoaded`.
+		/// \param cfg source de `paths.content`.
+		/// Effet de bord : re-marque le WaterDocument dirty après chargement —
+		/// son flag dirty sert aussi de signal de rebuild GPU eau
+		/// (Engine::Render → ClearDirty) et `LoadFromDisk` le remet à false ;
+		/// sans ce re-arm la scène d'eau chargée ne s'afficherait pas.
+		void LoadZoneDocuments(const engine::core::Config& cfg);
+
+		/// Lot B3 (correctif 3) — Persiste sur disque les documents annexes de
+		/// la zone (eau, mesh inserts, portails de donjon), au même point de
+		/// save que `SaveTerrainChunks`. Avant ce fix, aucun `SaveToDisk`
+		/// n'était appelé hors tests : lacs/rivières/grottes/arches/portails
+		/// étaient perdus à la fermeture. Sauvegarde inconditionnelle (pas de
+		/// gating sur IsDirty) : le flag dirty du WaterDocument est consommé
+		/// par le rebuild GPU eau (Engine::Render → ClearDirty) et ne peut
+		/// donc pas servir de critère de persistance.
+		/// \param cfg source de `paths.content`.
+		/// \return nombre de documents écrits avec succès (0 à 3).
+		/// Effet de bord : écriture disque + LOG_WARN par document en échec.
+		size_t SaveZoneDocuments(const engine::core::Config& cfg);
 
 		/// Sous-projet 1 — Persiste sur disque les chunks terrain + splat dirty
 		/// (source de verite de la zone) sous `<paths.content>/chunks/`. Appelee

--- a/src/world_editor/core/ZonePaths.h
+++ b/src/world_editor/core/ZonePaths.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+namespace engine::editor::world::zone_paths
+{
+	/// Lot B3 (audit 2026-06-10 §4.2) — Conventions de chemins disque
+	/// namespacés par zone pour les documents de l'éditeur monde.
+	///
+	/// Historique : les chunks terrain/splat et les fichiers d'instances
+	/// (eau, mesh inserts, portails de donjon) étaient écrits dans des
+	/// chemins « plats » (`chunks/chunk_X_Z/…`, `instances/water.bin`)
+	/// sans identifiant de zone : deux cartes différentes s'écrasaient
+	/// mutuellement au save. Ces helpers centralisent la convention
+	/// namespacée et sa rétro-compatibilité :
+	///   - ÉCRITURE : toujours le chemin namespacé
+	///     (`chunks/zone_<zoneId>/chunk_X_Z/…`, `instances/zone_<zoneId>/…`)
+	///     dès que `zoneId` est non vide.
+	///   - LECTURE : d'abord le chemin namespacé ; s'il n'existe pas,
+	///     fallback sur l'ancien chemin plat (migration douce des cartes
+	///     créées avant le namespacing — elles sont ré-écrites au format
+	///     namespacé au prochain save).
+	///   - `zoneId` vide = comportement legacy intégral (chemins plats),
+	///     conservé pour les tests unitaires et le boot de l'éditeur avant
+	///     le chargement d'une première carte.
+	///
+	/// `zoneId` doit être DÉJÀ sanitizé (`SanitizeZoneId` : a-z, 0-9, _) —
+	/// aucun échappement supplémentaire n'est fait ici.
+	///
+	/// Contraintes thread : fonctions pures sans état global ; seule
+	/// `ResolveInstancesFileForRead` fait une E/S (un `exists()`).
+
+	/// Rôle : répertoire legacy (plat, pré-namespacing) du chunk
+	/// `(chunkX, chunkZ)` : `<contentRoot>/chunks/chunk_<x>_<z>`.
+	inline std::filesystem::path LegacyChunkDir(
+		const std::string& contentRoot, int chunkX, int chunkZ)
+	{
+		return std::filesystem::path(contentRoot) / "chunks"
+			/ ("chunk_" + std::to_string(chunkX) + "_" + std::to_string(chunkZ));
+	}
+
+	/// Rôle : répertoire namespacé par zone du chunk `(chunkX, chunkZ)` :
+	/// `<contentRoot>/chunks/zone_<zoneId>/chunk_<x>_<z>`. Si \p zoneId est
+	/// vide, retombe sur le chemin legacy plat (cf. bloc de doc ci-dessus).
+	inline std::filesystem::path ZoneChunkDir(
+		const std::string& contentRoot, const std::string& zoneId,
+		int chunkX, int chunkZ)
+	{
+		if (zoneId.empty()) return LegacyChunkDir(contentRoot, chunkX, chunkZ);
+		return std::filesystem::path(contentRoot) / "chunks" / ("zone_" + zoneId)
+			/ ("chunk_" + std::to_string(chunkX) + "_" + std::to_string(chunkZ));
+	}
+
+	/// Rôle : chemin legacy (plat) d'un fichier d'instances :
+	/// `<contentRoot>/instances/<filename>`.
+	inline std::filesystem::path LegacyInstancesFile(
+		const std::string& contentRoot, const char* filename)
+	{
+		return std::filesystem::path(contentRoot) / "instances" / filename;
+	}
+
+	/// Rôle : chemin namespacé par zone d'un fichier d'instances :
+	/// `<contentRoot>/instances/zone_<zoneId>/<filename>`. Si \p zoneId est
+	/// vide, retombe sur le chemin legacy plat. À utiliser pour toute
+	/// ÉCRITURE (jamais de fallback en écriture).
+	inline std::filesystem::path ZoneInstancesFile(
+		const std::string& contentRoot, const std::string& zoneId,
+		const char* filename)
+	{
+		if (zoneId.empty()) return LegacyInstancesFile(contentRoot, filename);
+		return std::filesystem::path(contentRoot) / "instances"
+			/ ("zone_" + zoneId) / filename;
+	}
+
+	/// Rôle : résolution LECTURE d'un fichier d'instances avec fallback
+	/// legacy : retourne le chemin namespacé s'il existe sur disque, sinon
+	/// l'ancien chemin plat (qu'il existe ou non — l'appelant gère le cas
+	/// « fichier absent » comme avant, i.e. document vide sans erreur).
+	/// Effet de bord : un test `exists()` disque sur le chemin namespacé.
+	inline std::filesystem::path ResolveInstancesFileForRead(
+		const std::string& contentRoot, const std::string& zoneId,
+		const char* filename)
+	{
+		const std::filesystem::path namespaced =
+			ZoneInstancesFile(contentRoot, zoneId, filename);
+		if (zoneId.empty()) return namespaced; // déjà le chemin legacy
+		std::error_code ec;
+		if (std::filesystem::exists(namespaced, ec)) return namespaced;
+		return LegacyInstancesFile(contentRoot, filename);
+	}
+}

--- a/src/world_editor/terrain/TerrainDocument.cpp
+++ b/src/world_editor/terrain/TerrainDocument.cpp
@@ -1,5 +1,7 @@
 #include "src/world_editor/terrain/TerrainDocument.h"
 
+#include "src/world_editor/core/ZonePaths.h"
+
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 #include "src/client/world/terrain/TerrainChunkLoader.h"
@@ -7,7 +9,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <utility>
 
 namespace engine::editor::world
@@ -58,12 +59,24 @@ namespace engine::editor::world
 		auto it = m_chunks.find(key);
 		if (it != m_chunks.end()) return it->second.chunk;
 
-		// Tentative de chargement disque via la clé canonique.
+		// Lot B3 — Tentative de chargement disque via la clé canonique
+		// namespacée par zone (`chunks/zone_<id>/chunk_X_Z/terrain.bin`).
+		// Fallback LECTURE sur l'ancien chemin plat si le fichier namespacé
+		// n'existe pas (migration douce des cartes d'avant le namespacing —
+		// elles seront ré-écrites au format namespacé au prochain save).
 		const std::string contentRoot = config.GetString("paths.content", "game/data");
-		std::ostringstream pathStream;
-		pathStream << contentRoot << "/chunks/chunk_" << chunkX << "_" << chunkZ
-		           << "/terrain.bin";
-		const std::string fullPath = pathStream.str();
+		std::filesystem::path filePath =
+			zone_paths::ZoneChunkDir(contentRoot, m_zoneId, chunkX, chunkZ) / "terrain.bin";
+		if (!m_zoneId.empty())
+		{
+			std::error_code ec;
+			if (!std::filesystem::exists(filePath, ec))
+			{
+				filePath = zone_paths::LegacyChunkDir(contentRoot, chunkX, chunkZ)
+					/ "terrain.bin";
+			}
+		}
+		const std::string fullPath = filePath.string();
 
 		std::shared_ptr<engine::world::terrain::TerrainChunk> chunk;
 		std::ifstream f(fullPath, std::ios::binary);
@@ -135,9 +148,10 @@ namespace engine::editor::world
 			const int chunkX = static_cast<int>(static_cast<int32_t>(hi));
 			const int chunkZ = static_cast<int>(static_cast<int32_t>(lo));
 
-			std::ostringstream dirStream;
-			dirStream << contentRoot << "/chunks/chunk_" << chunkX << "_" << chunkZ;
-			const std::filesystem::path dir(dirStream.str());
+			// Lot B3 — ÉCRITURE toujours sur le chemin namespacé par zone
+			// (jamais de fallback en écriture ; "" = legacy plat, tests).
+			const std::filesystem::path dir =
+				zone_paths::ZoneChunkDir(contentRoot, m_zoneId, chunkX, chunkZ);
 			std::error_code ec;
 			std::filesystem::create_directories(dir, ec);
 			if (ec)
@@ -204,15 +218,17 @@ namespace engine::editor::world
 		// Copie défensive du chunk pour que le worker travaille sur un snapshot
 		// indépendant des éditions ultérieures.
 		engine::world::terrain::TerrainChunk lod0 = *chunk;
-		const std::string contentRoot = m_contentRootForLods;
+		// Lot B3 — le répertoire (namespacé par zone) est résolu ICI, sur le
+		// main thread, pour capturer un chemin cohérent avec m_zoneId au
+		// moment du commit (le worker ne doit pas lire m_zoneId en concurrence).
+		const std::filesystem::path lodDir =
+			zone_paths::ZoneChunkDir(m_contentRootForLods, m_zoneId, coord.x, coord.z);
 		m_lodWorker->Enqueue(coord, std::move(lod0),
-			[contentRoot](engine::world::GlobalChunkCoord c,
+			[lodDir](engine::world::GlobalChunkCoord c,
 				engine::world::terrain::TerrainLodChain chain)
 			{
 				// Callback exécuté sur un thread worker — on peut faire de l'IO.
-				std::ostringstream dirStream;
-				dirStream << contentRoot << "/chunks/chunk_" << c.x << "_" << c.z;
-				const std::filesystem::path dir(dirStream.str());
+				const std::filesystem::path& dir = lodDir;
 				std::error_code ec;
 				std::filesystem::create_directories(dir, ec);
 				if (ec)
@@ -250,11 +266,21 @@ namespace engine::editor::world
 		auto it = m_splats.find(key);
 		if (it != m_splats.end()) return it->second.splat;
 
+		// Lot B3 — même résolution de chemin que EnsureLoaded : namespacé par
+		// zone en priorité, fallback LECTURE sur le chemin plat legacy.
 		const std::string contentRoot = config.GetString("paths.content", "game/data");
-		std::ostringstream pathStream;
-		pathStream << contentRoot << "/chunks/chunk_" << chunkX << "_" << chunkZ
-		           << "/splat.bin";
-		const std::string fullPath = pathStream.str();
+		std::filesystem::path filePath =
+			zone_paths::ZoneChunkDir(contentRoot, m_zoneId, chunkX, chunkZ) / "splat.bin";
+		if (!m_zoneId.empty())
+		{
+			std::error_code ec;
+			if (!std::filesystem::exists(filePath, ec))
+			{
+				filePath = zone_paths::LegacyChunkDir(contentRoot, chunkX, chunkZ)
+					/ "splat.bin";
+			}
+		}
+		const std::string fullPath = filePath.string();
 
 		std::shared_ptr<engine::world::terrain::SplatMap> splat;
 		std::ifstream f(fullPath, std::ios::binary);
@@ -318,9 +344,9 @@ namespace engine::editor::world
 			const int chunkX = static_cast<int>(static_cast<int32_t>(hi));
 			const int chunkZ = static_cast<int>(static_cast<int32_t>(lo));
 
-			std::ostringstream dirStream;
-			dirStream << contentRoot << "/chunks/chunk_" << chunkX << "_" << chunkZ;
-			const std::filesystem::path dir(dirStream.str());
+			// Lot B3 — ÉCRITURE toujours sur le chemin namespacé par zone.
+			const std::filesystem::path dir =
+				zone_paths::ZoneChunkDir(contentRoot, m_zoneId, chunkX, chunkZ);
 			std::error_code ec;
 			std::filesystem::create_directories(dir, ec);
 			if (ec)

--- a/src/world_editor/terrain/TerrainDocument.h
+++ b/src/world_editor/terrain/TerrainDocument.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace engine::core { class Config; }
 
@@ -27,8 +28,25 @@ namespace engine::editor::world
 	class TerrainDocument
 	{
 	public:
+		/// Lot B3 (audit 2026-06-10 §4.2) — Définit l'identifiant de la zone
+		/// éditée, utilisé pour namespacer les chemins disque des chunks
+		/// (`chunks/zone_<zoneId>/chunk_<i>_<j>/…`). \p zoneId doit être déjà
+		/// sanitizé (`SanitizeZoneId` : a-z, 0-9, _). Chaîne vide = chemins
+		/// legacy plats (`chunks/chunk_<i>_<j>/…`), comportement pré-B3
+		/// conservé pour les tests. À appeler à CHAQUE changement de carte
+		/// (nouvelle carte / chargement), AVANT tout `EnsureLoaded` /
+		/// `Save*ToDisk` — sinon les chunks seraient lus/écrits dans le
+		/// namespace de la carte précédente.
+		void SetZoneId(std::string zoneId) { m_zoneId = std::move(zoneId); }
+
+		/// Identifiant de zone courant ("" = chemins legacy plats).
+		const std::string& GetZoneId() const { return m_zoneId; }
+
 		/// Charge le chunk `(chunkX, chunkZ)` depuis disque si présent dans
-		/// `<paths.content>/chunks/chunk_<i>_<j>/terrain.bin`, sinon crée un
+		/// `<paths.content>/chunks/zone_<zoneId>/chunk_<i>_<j>/terrain.bin`
+		/// (fallback LECTURE sur l'ancien chemin plat
+		/// `chunks/chunk_<i>_<j>/terrain.bin` si le namespacé n'existe pas —
+		/// migration douce lot B3), sinon crée un
 		/// chunk plat à 0 m. Met le chunk en cache RAM dans `m_chunks` et
 		/// retourne le shared_ptr stable. Idempotent : appels successifs avec
 		/// les mêmes coords retournent le même pointeur.
@@ -46,7 +64,9 @@ namespace engine::editor::world
 		bool HasDirtyChunks() const;
 
 		/// Sauvegarde sur disque tous les chunks dirty, sous
-		/// `<paths.content>/chunks/chunk_<i>_<j>/terrain.bin`. Crée le dossier
+		/// `<paths.content>/chunks/zone_<zoneId>/chunk_<i>_<j>/terrain.bin`
+		/// (toujours le chemin namespacé en ÉCRITURE — lot B3 ; chemin plat
+		/// legacy seulement si `m_zoneId` est vide). Crée le dossier
 		/// parent au besoin.
 		/// \param config Source de la clé `paths.content`.
 		/// \return nombre de chunks effectivement écrits.
@@ -97,7 +117,8 @@ namespace engine::editor::world
 		void OnCommit(engine::world::GlobalChunkCoord coord);
 
 		/// Charge la `SplatMap` du chunk `(chunkX, chunkZ)` depuis disque
-		/// (`<paths.content>/chunks/chunk_<i>_<j>/splat.bin`) si présente,
+		/// (`<paths.content>/chunks/zone_<zoneId>/chunk_<i>_<j>/splat.bin`,
+		/// fallback LECTURE sur le chemin plat legacy — lot B3) si présente,
 		/// sinon crée une splat-map uniforme layer 0 (= "dirt"). Met en cache
 		/// dans `m_splats`. Idempotent (M100.9).
 		std::shared_ptr<engine::world::terrain::SplatMap> EnsureSplatLoaded(
@@ -144,6 +165,9 @@ namespace engine::editor::world
 		static uint64_t PackCoord(engine::world::GlobalChunkCoord c);
 
 		std::unordered_map<uint64_t, ChunkSlot> m_chunks;
+		/// Lot B3 — identifiant (sanitizé) de la zone éditée, namespace des
+		/// chemins disque. "" = chemins legacy plats (tests, boot).
+		std::string m_zoneId;
 		engine::world::terrain::TerrainLodWorker* m_lodWorker = nullptr;
 		std::string m_contentRootForLods;
 		OnChunkChangedCallback m_onChunkChanged;

--- a/src/world_editor/tests/TerrainDocumentRoundTripTests.cpp
+++ b/src/world_editor/tests/TerrainDocumentRoundTripTests.cpp
@@ -68,6 +68,68 @@ namespace
 		REQUIRE(doc.HasDirtyChunks());
 	}
 
+	/// Lot B3 (audit 2026-06-10 §4.2) — Namespacing des chunks par zone :
+	///   - ÉCRITURE : `chunks/zone_<id>/chunk_X_Z/terrain.bin` dès que le
+	///     zoneId est posé (chemin plat legacy seulement si zoneId vide) ;
+	///   - LECTURE : namespacé en priorité, fallback sur l'ancien chemin
+	///     plat si le fichier namespacé n'existe pas (migration douce des
+	///     cartes d'avant le namespacing) ;
+	///   - deux zones distinctes ne s'écrasent plus mutuellement au save.
+	void Test_ZoneNamespacedPathsAndLegacyFallback()
+	{
+		const std::filesystem::path tmp = MakeTempContentDir();
+		engine::core::Config cfg;
+		cfg.SetValue("paths.content", engine::core::Config::Value{ tmp.string() });
+
+		// 1) Écriture legacy (zoneId vide) : chemin plat, comportement pré-B3.
+		TerrainDocument legacy;
+		legacy.InitFlatZone(1, 0.0f);
+		auto cl = legacy.Find(engine::world::GlobalChunkCoord{0, 0});
+		REQUIRE(cl != nullptr);
+		cl->heights[0] = 3.0f;
+		cl->RecomputeBounds();
+		legacy.MarkDirty(engine::world::GlobalChunkCoord{0, 0});
+		REQUIRE(legacy.SaveDirtyToDisk(cfg) == 1u);
+		REQUIRE(std::filesystem::exists(tmp / "chunks" / "chunk_0_0" / "terrain.bin"));
+
+		// 2) Zone A : écriture namespacée, ne touche pas le fichier plat.
+		TerrainDocument zoneA;
+		zoneA.SetZoneId("map_a");
+		zoneA.InitFlatZone(1, 0.0f);
+		auto ca = zoneA.Find(engine::world::GlobalChunkCoord{0, 0});
+		REQUIRE(ca != nullptr);
+		ca->heights[0] = 7.0f;
+		ca->RecomputeBounds();
+		zoneA.MarkDirty(engine::world::GlobalChunkCoord{0, 0});
+		REQUIRE(zoneA.SaveDirtyToDisk(cfg) == 1u);
+		REQUIRE(std::filesystem::exists(
+			tmp / "chunks" / "zone_map_a" / "chunk_0_0" / "terrain.bin"));
+
+		// 3) Relecture zone A : prend le fichier namespacé (7), pas le plat (3).
+		TerrainDocument zoneA2;
+		zoneA2.SetZoneId("map_a");
+		auto ca2 = zoneA2.EnsureLoaded(cfg, 0, 0);
+		REQUIRE(ca2 != nullptr);
+		REQUIRE(ca2->heights[0] == 7.0f);
+
+		// 4) Fallback LECTURE : zone B sans fichier namespacé -> chemin plat (3).
+		TerrainDocument zoneB;
+		zoneB.SetZoneId("map_b");
+		auto cb = zoneB.EnsureLoaded(cfg, 0, 0);
+		REQUIRE(cb != nullptr);
+		REQUIRE(cb->heights[0] == 3.0f);
+
+		// 5) Le fichier plat d'origine n'a pas été modifié par les saves
+		//    namespacés (les zones ne s'écrasent plus mutuellement).
+		TerrainDocument legacy2;
+		auto cl2 = legacy2.EnsureLoaded(cfg, 0, 0);
+		REQUIRE(cl2 != nullptr);
+		REQUIRE(cl2->heights[0] == 3.0f);
+
+		std::error_code ec;
+		std::filesystem::remove_all(tmp, ec);
+	}
+
 	/// Round-trip disque : édition d'une hauteur -> save -> reload identique.
 	void Test_ChunkSaveLoadRoundTrip()
 	{
@@ -102,6 +164,7 @@ namespace
 int main()
 {
 	Test_InitFlatZoneAllocatesNxNFlatChunks();
+	Test_ZoneNamespacedPathsAndLegacyFallback();
 	Test_ChunkSaveLoadRoundTrip();
 
 	if (g_failed == 0)

--- a/src/world_editor/ui/WorldEditorSession.cpp
+++ b/src/world_editor/ui/WorldEditorSession.cpp
@@ -332,6 +332,25 @@ namespace engine::editor
 		return true;
 	}
 
+	// Lot B3 — arme le flag de reinitialisation/rechargement des documents
+	// de zone (consomme par l'Engine au tick suivant). Cf. doc du header.
+	void WorldEditorSession::RequestZoneDocumentsReload()
+	{
+		m_zoneDocumentsReloadRequested = true;
+	}
+
+	// Lot B3 — consommation one-shot du flag ci-dessus (pattern identique aux
+	// autres requetes session -> Engine).
+	bool WorldEditorSession::ConsumeZoneDocumentsReloadRequest()
+	{
+		if (!m_zoneDocumentsReloadRequested)
+		{
+			return false;
+		}
+		m_zoneDocumentsReloadRequested = false;
+		return true;
+	}
+
 	bool WorldEditorSession::ActionNewMap(const engine::core::Config& cfg)
 	{
 		SyncDocIdFromBuffer();
@@ -502,6 +521,10 @@ namespace engine::editor
 		m_routeDraftXz.clear();
 		m_routeApplyDraftRequested = false;
 		EnsureTreeCatalogLoaded(cfg);
+		// Lot B3 — changement de monde : l'Engine doit reinitialiser les
+		// documents editeur (chunks/undo de la carte precedente) puis
+		// recharger eau/mesh/portails de la carte chargee.
+		RequestZoneDocumentsReload();
 		RequestTerrainGpuReload();
 		SyncBuffersFromDoc();
 		return true;
@@ -644,6 +667,10 @@ namespace engine::editor
 		m_routeDraftXz.clear();
 		m_routeApplyDraftRequested = false;
 		EnsureTreeCatalogLoaded(cfg);
+		// Lot B3 — changement de monde : l'Engine doit reinitialiser les
+		// documents editeur (chunks/undo de la carte precedente) puis
+		// recharger eau/mesh/portails de la carte chargee.
+		RequestZoneDocumentsReload();
 		RequestTerrainGpuReload();
 		SyncBuffersFromDoc();
 		RefreshAvailableMaps(cfg);

--- a/src/world_editor/ui/WorldEditorSession.h
+++ b/src/world_editor/ui/WorldEditorSession.h
@@ -149,6 +149,20 @@ namespace engine::editor
 		/// \return true une fois par demande consommee (pour l'Engine).
 		bool ConsumeTerrainChunksSaveRequest();
 
+		/// Lot B3 (audit 2026-06-10 §4.2) — Demande la reinitialisation + le
+		/// rechargement des documents editeur dependant de la zone (terrain,
+		/// eau, mesh inserts, portails de donjon). Set par ActionLoadEditJson
+		/// et ActionLoadMapByZoneId (chargement d'une carte EXISTANTE).
+		/// L'Engine consomme ce flag pour appeler
+		/// `WorldEditorShell::ResetForZoneChange` (chunks/undo de la carte
+		/// precedente evinces, zoneId propage pour le namespacing disque)
+		/// puis `WorldEditorShell::LoadZoneDocuments` (eau/mesh/portails
+		/// recharges depuis disque). Sans ce flux, les chunks de la carte A
+		/// restaient en RAM et reecrivaient la heightmap de la carte B.
+		void RequestZoneDocumentsReload();
+		/// \return true une fois par demande consommee (pour l'Engine).
+		bool ConsumeZoneDocumentsReloadRequest();
+
 		/// Marque les references de textures de layer (splatLayerTextureRefs)
 		/// comme modifiees. A appeler par les UIs apres avoir change un element
 		/// du tableau (combo Peindre, vignette Bibliotheque). Engine::ProcessSplatRefsDirty
@@ -215,6 +229,7 @@ namespace engine::editor
 		bool m_terrainGpuReloadRequested = false;
 		bool m_newZoneChunkInitRequested = false; // sous-projet 1 (zone neuve)
 		bool m_terrainChunksSaveRequested = false; // sous-projet 1 (save chunks)
+		bool m_zoneDocumentsReloadRequested = false; // lot B3 (chargement carte)
 		bool m_splatRefsDirty = false;
 
 		std::vector<std::string> m_recentlyImported;

--- a/src/world_editor/volumes/MeshInsertDocument.cpp
+++ b/src/world_editor/volumes/MeshInsertDocument.cpp
@@ -1,6 +1,7 @@
 #include "src/world_editor/volumes/MeshInsertDocument.h"
 
 #include "src/shared/core/Config.h"
+#include "src/world_editor/core/ZonePaths.h"
 #include "src/world_editor/volumes/MeshInsertIo.h"
 
 #include <algorithm>
@@ -71,9 +72,10 @@ namespace engine::editor::world::volumes
 	bool MeshInsertDocument::SaveToDisk(const engine::core::Config& cfg,
 		std::string& outError)
 	{
+		// Lot B3 — ÉCRITURE toujours sur le chemin namespacé par zone.
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "mesh_inserts.bin";
+			zone_paths::ZoneInstancesFile(contentRoot, m_zoneId, "mesh_inserts.bin");
 		std::error_code ec;
 		std::filesystem::create_directories(path.parent_path(), ec);
 		if (ec)
@@ -105,9 +107,11 @@ namespace engine::editor::world::volumes
 	bool MeshInsertDocument::LoadFromDisk(const engine::core::Config& cfg,
 		std::string& outError)
 	{
+		// Lot B3 — LECTURE : chemin namespacé s'il existe, sinon fallback
+		// sur l'ancien chemin plat (migration douce).
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "mesh_inserts.bin";
+			zone_paths::ResolveInstancesFileForRead(contentRoot, m_zoneId, "mesh_inserts.bin");
 
 		std::ifstream f(path, std::ios::binary | std::ios::ate);
 		if (!f.good())

--- a/src/world_editor/volumes/MeshInsertDocument.h
+++ b/src/world_editor/volumes/MeshInsertDocument.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace engine::core { class Config; }
@@ -13,7 +14,8 @@ namespace engine::editor::world::volumes
 {
 	/// Document éditeur portant les instances de mesh inserts (M100.40).
 	/// CRUD + events pour les panels (Outliner, Inspector). Persiste dans
-	/// `instances/mesh_inserts.bin` via `MeshInsertIo`.
+	/// `instances/zone_<zoneId>/mesh_inserts.bin` via `MeshInsertIo` (lot B3
+	/// — chemin plat legacy en fallback de lecture / zoneId vide).
 	///
 	/// Le générateur de Guid est un compteur monotone initialisé à 1 ;
 	/// `kInvalidMeshInsertGuid` (0) reste réservé comme sentinelle.
@@ -22,6 +24,17 @@ namespace engine::editor::world::volumes
 	public:
 		using ChangeCallback = std::function<void(const MeshInsertInstance&)>;
 		using RemoveCallback = std::function<void(uint64_t /*removedGuid*/)>;
+
+		/// Lot B3 (audit 2026-06-10 §4.2) — Définit l'identifiant (sanitizé)
+		/// de la zone éditée : les chemins disque deviennent
+		/// `instances/zone_<zoneId>/mesh_inserts.bin` (écriture toujours
+		/// namespacée ; lecture avec fallback sur l'ancien chemin plat).
+		/// Chaîne vide = chemins legacy plats (tests, boot). À appeler à
+		/// chaque changement de carte, AVANT Save/LoadFromDisk.
+		void SetZoneId(std::string zoneId) { m_zoneId = std::move(zoneId); }
+
+		/// Identifiant de zone courant ("" = chemins legacy plats).
+		const std::string& GetZoneId() const { return m_zoneId; }
 
 		/// Génère un nouveau guid unique pour cette instance de document.
 		/// Thread-safe : non (main thread).
@@ -61,11 +74,13 @@ namespace engine::editor::world::volumes
 			m_dirty    = true;
 		}
 
-		/// Sauvegarde dans `<paths.content>/instances/mesh_inserts.bin`. Reset
-		/// `m_dirty`.
+		/// Sauvegarde dans `<paths.content>/instances/zone_<zoneId>/mesh_inserts.bin`
+		/// (chemin plat legacy si zoneId vide — lot B3). Reset `m_dirty`.
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);
 
-		/// Charge depuis `<paths.content>/instances/mesh_inserts.bin`. Si
+		/// Charge depuis `<paths.content>/instances/zone_<zoneId>/mesh_inserts.bin`
+		/// (fallback LECTURE sur le chemin plat legacy si le fichier namespacé
+		/// n'existe pas — lot B3). Si
 		/// fichier absent : retourne true avec doc vide (premier lancement).
 		/// Reset `m_dirty`. Initialise le compteur Guid au max+1 des
 		/// instances chargées.
@@ -79,6 +94,8 @@ namespace engine::editor::world::volumes
 
 	private:
 		std::vector<MeshInsertInstance> m_instances;
+		/// Lot B3 — identifiant (sanitizé) de la zone, namespace des chemins.
+		std::string m_zoneId;
 		uint64_t m_nextGuid = 0u;
 		bool     m_dirty    = false;
 

--- a/src/world_editor/volumes/dungeons/DungeonPortalDocument.cpp
+++ b/src/world_editor/volumes/dungeons/DungeonPortalDocument.cpp
@@ -1,6 +1,7 @@
 #include "src/world_editor/volumes/dungeons/DungeonPortalDocument.h"
 
 #include "src/shared/core/Config.h"
+#include "src/world_editor/core/ZonePaths.h"
 #include "src/world_editor/volumes/dungeons/DungeonPortalIo.h"
 
 #include <algorithm>
@@ -59,9 +60,10 @@ namespace engine::editor::world::volumes::dungeons
 	bool DungeonPortalDocument::SaveToDisk(const engine::core::Config& cfg,
 		std::string& outError)
 	{
+		// Lot B3 — ÉCRITURE toujours sur le chemin namespacé par zone.
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "dungeon_portals.bin";
+			zone_paths::ZoneInstancesFile(contentRoot, m_zoneId, "dungeon_portals.bin");
 		std::error_code ec;
 		std::filesystem::create_directories(path.parent_path(), ec);
 		if (ec)
@@ -91,9 +93,11 @@ namespace engine::editor::world::volumes::dungeons
 	bool DungeonPortalDocument::LoadFromDisk(const engine::core::Config& cfg,
 		std::string& outError)
 	{
+		// Lot B3 — LECTURE : chemin namespacé s'il existe, sinon fallback
+		// sur l'ancien chemin plat (migration douce).
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "dungeon_portals.bin";
+			zone_paths::ResolveInstancesFileForRead(contentRoot, m_zoneId, "dungeon_portals.bin");
 		std::ifstream f(path, std::ios::binary | std::ios::ate);
 		if (!f.good())
 		{

--- a/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
+++ b/src/world_editor/volumes/dungeons/DungeonPortalDocument.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace engine::core { class Config; }
@@ -14,12 +15,24 @@ namespace engine::editor::world::volumes::dungeons
 	/// Document éditeur portant les portails de donjon (M100.43). Distinct
 	/// du `MeshInsertDocument` (M100.40) car porte des metadata gameplay
 	/// (template id, difficulty range, level gating). Persiste dans
-	/// `instances/dungeon_portals.bin` (LCDP v1).
+	/// `instances/zone_<zoneId>/dungeon_portals.bin` (LCDP v1 ; lot B3 —
+	/// chemin plat legacy en fallback de lecture / zoneId vide).
 	class DungeonPortalDocument
 	{
 	public:
 		using ChangeCallback = std::function<void(const DungeonPortalInstance&)>;
 		using RemoveCallback = std::function<void(uint64_t)>;
+
+		/// Lot B3 (audit 2026-06-10 §4.2) — Définit l'identifiant (sanitizé)
+		/// de la zone éditée : les chemins disque deviennent
+		/// `instances/zone_<zoneId>/dungeon_portals.bin` (écriture toujours
+		/// namespacée ; lecture avec fallback sur l'ancien chemin plat).
+		/// Chaîne vide = chemins legacy plats (tests, boot). À appeler à
+		/// chaque changement de carte, AVANT Save/LoadFromDisk.
+		void SetZoneId(std::string zoneId) { m_zoneId = std::move(zoneId); }
+
+		/// Identifiant de zone courant ("" = chemins legacy plats).
+		const std::string& GetZoneId() const { return m_zoneId; }
 
 		uint64_t NextGuid() { return ++m_nextGuid; }
 
@@ -43,10 +56,12 @@ namespace engine::editor::world::volumes::dungeons
 			m_dirty    = true;
 		}
 
-		/// Sauve dans `<paths.content>/instances/dungeon_portals.bin`.
+		/// Sauve dans `<paths.content>/instances/zone_<zoneId>/dungeon_portals.bin`
+		/// (chemin plat legacy si zoneId vide — lot B3).
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);
-		/// Charge depuis `<paths.content>/instances/dungeon_portals.bin`.
-		/// Si absent : doc vide, pas d'erreur.
+		/// Charge depuis `<paths.content>/instances/zone_<zoneId>/dungeon_portals.bin`
+		/// (fallback LECTURE sur le chemin plat legacy si le fichier
+		/// namespacé n'existe pas — lot B3). Si absent : doc vide, pas d'erreur.
 		bool LoadFromDisk(const engine::core::Config& cfg, std::string& outError);
 
 		void SetOnAdded(ChangeCallback cb)   { m_onAdded   = std::move(cb); }
@@ -55,6 +70,8 @@ namespace engine::editor::world::volumes::dungeons
 
 	private:
 		std::vector<DungeonPortalInstance> m_instances;
+		/// Lot B3 — identifiant (sanitizé) de la zone, namespace des chemins.
+		std::string m_zoneId;
 		uint64_t m_nextGuid = 0u;
 		bool     m_dirty    = false;
 

--- a/src/world_editor/water/WaterDocument.cpp
+++ b/src/world_editor/water/WaterDocument.cpp
@@ -1,6 +1,8 @@
 // src/world_editor/water/WaterDocument.cpp
 #include "src/world_editor/water/WaterDocument.h"
 
+#include "src/world_editor/core/ZonePaths.h"
+
 #include "src/shared/core/Config.h"
 
 #include <filesystem>
@@ -10,9 +12,11 @@ namespace engine::editor::world
 {
 	bool WaterDocument::SaveToDisk(const engine::core::Config& cfg, std::string& outError)
 	{
+		// Lot B3 — ÉCRITURE toujours sur le chemin namespacé par zone
+		// (instances/zone_<id>/water.bin) ; chemin plat si zoneId vide.
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "water.bin";
+			zone_paths::ZoneInstancesFile(contentRoot, m_zoneId, "water.bin");
 
 		std::error_code ec;
 		std::filesystem::create_directories(path.parent_path(), ec);
@@ -55,9 +59,11 @@ namespace engine::editor::world
 
 	bool WaterDocument::LoadFromDisk(const engine::core::Config& cfg, std::string& outError)
 	{
+		// Lot B3 — LECTURE : chemin namespacé par zone s'il existe, sinon
+		// fallback sur l'ancien chemin plat (migration douce).
 		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
 		const std::filesystem::path path =
-			std::filesystem::path(contentRoot) / "instances" / "water.bin";
+			zone_paths::ResolveInstancesFileForRead(contentRoot, m_zoneId, "water.bin");
 
 		std::ifstream f(path, std::ios::binary | std::ios::ate);
 		if (!f.good())

--- a/src/world_editor/water/WaterDocument.h
+++ b/src/world_editor/water/WaterDocument.h
@@ -5,13 +5,16 @@
 #include "src/world_editor/water/OceanSettings.h"
 
 #include <string>
+#include <utility>
 
 namespace engine::core { class Config; }
 
 namespace engine::editor::world
 {
 	/// État des plans d'eau de la zone éditée (M100.13, étendu M100.36).
-	/// Persiste dans `<paths.content>/instances/water.bin` (format v2). Un
+	/// Persiste dans `<paths.content>/instances/zone_<zoneId>/water.bin`
+	/// (lot B3 — chemin plat legacy `instances/water.bin` en fallback de
+	/// lecture et quand le zoneId est vide). Un
 	/// seul WaterScene par éditeur (chunk-level partitioning vient avec
 	/// M100.34).
 	///
@@ -22,6 +25,18 @@ namespace engine::editor::world
 	class WaterDocument
 	{
 	public:
+		/// Lot B3 (audit 2026-06-10 §4.2) — Définit l'identifiant (sanitizé)
+		/// de la zone éditée : les chemins disque deviennent
+		/// `instances/zone_<zoneId>/water.bin` (écriture toujours namespacée ;
+		/// lecture avec fallback sur l'ancien chemin plat `instances/water.bin`).
+		/// Chaîne vide = chemins legacy plats (tests, boot avant chargement
+		/// d'une carte). À appeler à chaque changement de carte, AVANT
+		/// Save/LoadFromDisk.
+		void SetZoneId(std::string zoneId) { m_zoneId = std::move(zoneId); }
+
+		/// Identifiant de zone courant ("" = chemins legacy plats).
+		const std::string& GetZoneId() const { return m_zoneId; }
+
 		/// Accès mutable à la scene (modification par les outils de l'éditeur).
 		engine::world::water::WaterScene&       Mutable()       { return m_scene; }
 		/// Accès lecture seule à la scene (rendu, sérialisation).
@@ -60,11 +75,14 @@ namespace engine::editor::world
 			m_dirty = true;
 		}
 
-		/// Sauvegarde dans `<paths.content>/instances/water.bin`. Reset m_dirty.
+		/// Sauvegarde dans `<paths.content>/instances/zone_<zoneId>/water.bin`
+		/// (chemin plat legacy si zoneId vide — lot B3). Reset m_dirty.
 		/// Écrit toujours en format v2 (avec `m_ocean.seaLevelMeters`).
 		bool SaveToDisk(const engine::core::Config& cfg, std::string& outError);
 
-		/// Charge depuis `<paths.content>/instances/water.bin`. Accepte v1
+		/// Charge depuis `<paths.content>/instances/zone_<zoneId>/water.bin`
+		/// (fallback LECTURE sur le chemin plat legacy si le fichier
+		/// namespacé n'existe pas — lot B3). Accepte v1
 		/// (sans section ocean → `m_ocean` reste au défaut) ou v2. Si fichier
 		/// absent, retourne true avec scene vide (premier lancement) et
 		/// `m_ocean` au défaut. Reset m_dirty.
@@ -73,6 +91,8 @@ namespace engine::editor::world
 	private:
 		engine::world::water::WaterScene m_scene;
 		OceanSettings                    m_ocean;  // M100.36
+		/// Lot B3 — identifiant (sanitizé) de la zone, namespace des chemins.
+		std::string m_zoneId;
 		bool m_dirty = false;
 	};
 }


### PR DESCRIPTION
## Audit Lot B3 — le travail des mappeurs ne se perd plus

Troisième lot du backlog critique de l''audit (`docs/audit/2026-06-10-audit-global-4-parties.md` §4.2, les 4 constats 🔴 d''intégrité). **100 % éditeur monde (client)**.

### Les 4 trous corrigés
1. **Charger une carte ne réinitialisait pas `TerrainDocument`** : les chunks de la carte A restaient en mémoire et la première commande sur la carte B réécrivait sa heightmap avec les hauteurs de A. → nouvelle requête session `RequestZoneDocumentsReload`, consommée par Engine avant le reload GPU → `WorldEditorShell::ResetForZoneChange` (réutilise `TerrainDocument::Reset` et `zone_presets::ResetEditedZoneDocuments` existants).
2. **Ctrl+Z trans-cartes** : `CommandStack::Clear()` existait et n''était appelé NULLE PART — l''undo après « Nouvelle carte » rejouait les deltas de l''ancienne carte. → câblé au new ET au load.
3. **Lacs, rivières, grottes, arches et portails PERDUS à la fermeture** : les `SaveToDisk` de WaterDocument/MeshInsertDocument/DungeonPortalDocument n''avaient **zéro appelant** (constat audit confirmé et aggravé). → `SaveZoneDocuments` au point de save terrain + `LoadZoneDocuments` au chargement. Subtilités gérées : le dirty-flag eau est consommé par le rebuild GPU (→ save inconditionnel) ; `MarkDirty()` re-armé après load pour reconstruire le mesh eau.
4. **Deux cartes s''écrasaient mutuellement au save** : chunks `chunks/chunk_X_Z/…` et `instances/*.bin` sans zoneId (le défaut touchait AUSSI les 3 fichiers d''instances, au-delà du constat). → `core/ZonePaths.h` : écriture toujours namespacée `zone_<id>/`, **lecture avec fallback legacy plat** (migration douce des cartes existantes, ré-écrites namespacées au prochain save), zoneId vide = comportement legacy intégral (boot/tests inchangés). zoneId sanitizé (a-z, 0-9, _).

### Tests
`Test_ZoneNamespacedPathsAndLegacyFallback` ajouté à `terrain_document_roundtrip_tests` (ctest Linux) : écriture namespacée, priorité de lecture, fallback legacy, non-écrasement entre zones. Le round-trip legacy existant reste vert (zoneId vide).

### Risque résiduel documenté (suivi possible)
Le runtime jeu (`StreamCache`) lit encore les chemins plats — la livraison normale passe par `ExportRuntimeBundle` (zones/<id>/), mais un éventuel partage direct éditeur→jeu des fichiers plats ne verra pas les nouvelles sauvegardes namespacées. Chantier de suivi : rendre StreamCache zone-aware.

**Déploiement** : ✅ client uniquement (binaire éditeur monde), pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)