### PR TITLE
fix(client): snap visuel au sol des mobs et nodes (sanglier invisible en validation v12)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10255,6 +10255,10 @@ namespace engine
 						{
 							wx = sit->second.x; wy = sit->second.y; wz = sit->second.z;
 						}
+						// Combat SP1 fix — mobs/nodes : Y de spawn brut (souvent 0, jamais
+						// collé au terrain par le serveur) → snap visuel au sol client,
+						// sinon la plaque flotte au ras du sol (cf. ResolveRemoteDisplayCenterY).
+						wy = ResolveRemoteDisplayCenterY(re.playerClientId != 0u, wy, wx, wz);
 						float sxp = 0.0f, syp = 0.0f;
 						if (!WorldToScreenPx(out.viewProjMatrix.m, wx, wy + 1.2f, wz, ivw, ivh, sxp, syp))
 							continue;
@@ -10386,6 +10390,10 @@ namespace engine
 							{
 								wx = sit->second.x; wy = sit->second.y; wz = sit->second.z;
 							}
+							// Combat SP1 fix — même snap visuel au sol que la plaque : le
+							// point d'ancrage du pick doit correspondre à ce que voit le
+							// joueur (cf. ResolveRemoteDisplayCenterY).
+							wy = ResolveRemoteDisplayCenterY(false, wy, wx, wz);
 							float sxp = 0.0f, syp = 0.0f;
 							if (!WorldToScreenPx(out.viewProjMatrix.m, wx, wy + 0.5f, wz, ivw, ivh, sxp, syp))
 								continue;
@@ -10840,6 +10848,17 @@ namespace engine
 									fxX = smoothedIt->second.x;
 									fxY = smoothedIt->second.y;
 									fxZ = smoothedIt->second.z;
+									// Combat SP1 fix — un halo de mob doit suivre le snap visuel
+									// au sol (sinon l'anneau se projette sous le terrain). On
+									// retrouve l'entité pour distinguer joueur (Y fiable) / mob.
+									for (const engine::client::UIRemoteEntity& fxRe : uiModel.remoteEntities)
+									{
+										if (fxRe.entityId != fxEntityId)
+											continue;
+										fxY = ResolveRemoteDisplayCenterY(
+											fxRe.playerClientId != 0u, fxY, fxX, fxZ);
+										break;
+									}
 								}
 								fxEffects.clear();
 								buildEffects(fxEntityId, fxEffects);
@@ -12154,6 +12173,19 @@ namespace engine
 		return nullptr;
 	}
 
+	float Engine::ResolveRemoteDisplayCenterY(bool isPlayer, float serverY,
+	                                          float worldX, float worldZ) const
+	{
+		if (isPlayer)
+		{
+			return serverY; // joueur : centre capsule fiable répliqué par le shard
+		}
+		// Mob / node / loot bag : Y de spawn brut (souvent 0) → snap visuel au sol
+		// client. SampleHeightAtWorldXZ retombe sur 0 si la heightmap n'est pas
+		// chargée — comportement identique à l'ancien rendu dans ce cas.
+		return m_terrain.SampleHeightAtWorldXZ(worldX, worldZ) + 0.9f;
+	}
+
 	void Engine::SetAvatarGender(const std::string& gender)
 	{
 		if (gender != "male" && gender != "female") {
@@ -12896,6 +12928,13 @@ namespace engine
 			{
 				px = sit->second.x; py = sit->second.y; pz = sit->second.z; yaw = sit->second.yaw;
 			}
+			// Combat SP1 fix — mobs : le serveur réplique le Y BRUT du spawner
+			// (souvent 0.0, jamais collé au terrain — pas de heightfield serveur).
+			// Avec l'offset -0.9 « centre → pieds » ci-dessous, le mesh se dessinait
+			// SOUS le terrain (sanglier invisible, plaque flottante). Snap visuel au
+			// sol client : ResolveRemoteDisplayCenterY renvoie sol + 0.9 pour les
+			// non-joueurs, que le -0.9 ramène exactement au niveau des pieds.
+			py = ResolveRemoteDisplayCenterY(re.playerClientId != 0u, py, px, pz);
 			// TD.7 — état d'animation par avatar distant. Crée l'entrée à la première frame
 			// où on voit cet entityId. L'horloge utilisée pour Sample() / Play() est la même
 			// (nowSec) pour tous les avatars : crossfade et boucle restent en phase.

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -252,6 +252,23 @@ namespace engine
 		/// boot). Sans effet si gender invalide. Appele par le selecteur de creation.
 		void SetAvatarGender(const std::string& gender);
 
+		/// Combat SP1 fix — Y d'affichage « équivalent centre capsule » d'une
+		/// entité distante. Les JOUEURS répliquent un centre capsule fiable
+		/// (positionY serveur reprise telle quelle). Les MOBS, NODES de récolte
+		/// et LOOT BAGS répliquent le Y brut de leur donnée de spawn (souvent
+		/// 0.0) que le serveur ne colle jamais au terrain (pas de heightfield
+		/// serveur) : sans correction ils se dessinent SOUS le terrain — mesh
+		/// invisible (depth-testé) et plaque flottante au ras du sol (foreground
+		/// sans depth test). On échantillonne donc la heightmap CLIENT et on
+		/// renvoie sol + 0.9 m, cohérent avec l'offset -0.9 (centre→pieds) du
+		/// rendu skinné. Affichage uniquement : le Y serveur reste l'autorité
+		/// gameplay (les tests de portée serveur sont en XZ).
+		/// \param isPlayer    true si l'entité est un joueur (playerClientId != 0).
+		/// \param serverY     Y répliqué par le serveur (mètres monde).
+		/// \param worldX,worldZ  position horizontale pour l'échantillon terrain.
+		float ResolveRemoteDisplayCenterY(bool isPlayer, float serverY,
+		                                  float worldX, float worldZ) const;
+
 		/// Persiste et applique le genre d'un personnage donne, par NOM
 		/// (fix client interim #1 : le genre n'est pas encore stocke serveur).
 		/// Met a jour m_avatarGender pour la session ET ecrit


### PR DESCRIPTION
## Fix du premier constat de la validation en jeu v12 : sanglier invisible

**Cause racine (tracee dans le code, pas de speculation)** :
1. Cote serveur, le Y d''un mob = **le Y brut du spawner (0.0), pour toujours** (`ServerApp.cpp` : `mob.positionMetersY = spawner.definition.positionMetersY`, jamais colle au terrain — le serveur n''a pas de heightfield).
2. Cote client, le rendu skinne applique `py - 0.9` (conversion « centre capsule → pieds », valable pour les joueurs) — a tort pour les mobs dont le Y replique est deja un Y « sol ».

Resultat : mesh dessine sous le terrain (depth-teste → invisible), plaque dessinee en foreground ImGui **sans test de profondeur** → elle flotte au ras du sol. Exactement la capture de la validation. Les nodes de recolte (Y de donnees = 0.0) et les halos d''auras avaient le meme defaut.

### Le fix (100 % affichage, le Y serveur reste l''autorite gameplay)
Nouveau helper documente `Engine::ResolveRemoteDisplayCenterY` : joueurs → Y serveur tel quel (centre capsule fiable) ; mobs/nodes → `m_terrain.SampleHeightAtWorldXZ(x,z) + 0.9` (le -0.9 du rendu ramene les pieds exactement au sol). Applique aux 4 consommateurs : mesh skinne (RecordRemoteAvatars), plaques, pick souris (le point d''ancrage du clic correspond a ce que voit le joueur), halos d''auras. Les tests de portee serveur sont en XZ — aucun impact gameplay.

### Constat annexe (hors perimetre, suivi depose)
Le **loot est entierement non cable cote client** : aucun rendu des sacs de butin, aucune touche de ramassage, aucun PickupRequest emis — le serveur gere pourtant tout (HandlePickupRequest, sacs, TTL). A cabler dans un prochain lot.

### Validation attendue
Relancer le client (pas de redeploiement serveur) : le sanglier doit etre visible au sol pres du spawn (rendu orc echelle 0.9), les 3 nodes de recolte poses au sol, clic sur le sanglier → cadre cible rouge → T → degats dans le log combat.

**Deploiement** : ✅ client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)