### PR TITLE
Lot C — Vague 1A : câblage quick wins (portail rôles + exploitTier + AutoFitProxy)

### DIFF
--- a/docs/audit/2026-06-13-audit-global-independant.md
+++ b/docs/audit/2026-06-13-audit-global-independant.md
@@ -1,0 +1,250 @@
+# Audit global indépendant — 4 parties (2026-06-13)
+
+> Audit **en lecture seule** (aucun fichier de code modifié), conduit par 5 agents
+> parallèles **indépendants** : chacun a analysé son périmètre **sans consulter**
+> l'audit précédent (`2026-06-10-audit-global-4-parties.md`), pour fournir une
+> **confirmation croisée**. `legacy/` et `external/` exclus.
+> Méthode par agent : croisement `CMakeLists.txt` ↔ disque, grep de preuve pour
+> chaque « jamais utilisé », lecture intégrale des fichiers centraux.
+
+## Légende
+
+- Sévérité : 🔴 haute / 🟠 moyenne / 🟡 basse
+- Confiance : **V** = vérifié (preuve grep/lecture) / **S** = suspecté
+- État : 🆕 nouveau vs audit 06-10 / ✅ corrigé depuis (B1/B2/B3) / ⏳ toujours ouvert
+
+---
+
+## 0. Résultat du croisement avec l'audit du 2026-06-10
+
+L'audit indépendant **confirme** que les 3 lots de correctifs critiques mergés
+(`#887` B1, `#888` B2, `#889` B3) sont **réellement câblés**, pas seulement définis :
+
+| Lot | Constat 06-10 | Vérification indépendante 06-13 |
+|---|---|---|
+| **B2** (client) | UB destroy-framebuffer-avant-submit ×11 passes | ✅ Le chemin de resize fait `vkDeviceWaitIdle` + invalidation explicite de tous les caches framebuffer par passe avant `frameGraph.destroy`. Aucune anomalie de cycle de vie GPU restante détectée. |
+| **B1** (master) | races multi-worker sans mutex (Lfg, GmTicket, Mail, Quest) | ✅ `LfgQueue`, `GmTicketSystem` (commentaire « Audit Lot B1 »), `QuestStateTracker`, `WeatherHandler`, Guild/Auction/Arena/BG/OutdoorPvp tous verrouillés. Purge anti-rejeu tickets OK. **⚠️ MAIS un système a été oublié — voir 2.1.** |
+| **B3** (éditeur) | corruption inter-cartes, perte eau/mesh au save, undo trans-cartes, chunks non namespacés | ✅ `ResetForZoneChange` (clear undo + reset documents) câblé au new/load ; `SaveZoneDocuments`/`LoadZoneDocuments` câblés ; namespacing `chunks/zone_<id>/` + fallback legacy. Les 4 points 🔴 de la section 4.2 du 06-10 sont résorbés. |
+
+**Valeur ajoutée de la passe indépendante** : 1 nouvelle race critique côté serveur
+que B1 n'a pas couverte, 1 nouveau risque de perte de données éditeur, et plusieurs
+constats raffinés/corrigés (câblage outils éditeur, état du module combat client).
+
+---
+
+## 1. Client de jeu (`src/client/`)
+
+### 1.1 Code orphelin (compilé, jamais instancié — preuve grep)
+
+| Symbole | Fichier | Sév. | Conf. | État |
+|---|---|---|---|---|
+| `ZonePreloadHook` | `world/ZonePreloadHook.{h,cpp}` | 🟠 | V | ⏳ |
+| `FXManager` + chaîne `ParticleSystem`/`ParticleBillboardPass` | `fx/`, `render/` | 🟠 | V | ⏳ |
+| `AoEPreviewSystem` | `combat/AoEPreviewSystem.cpp` | 🟠 | V | ⏳ |
+| `ClientPredictionSystem` | `gameplay/ClientPrediction.{h,cpp}` | 🟠 | V | ⏳ (cohérent : prédiction = travail à venir) |
+| `AutoFitProxy` | `world/collision/AutoFitProxy.{h,cpp}` | 🟡 | V | ⏳ (test-only) |
+
+> **Correction vs 06-10** : le module combat n'est **plus** entièrement orphelin —
+> les chantiers Combat SP1-4 (2026-06-10/11) ont câblé l'essentiel. Seul
+> `AoEPreviewSystem` reste isolé. Redondance fonctionnelle à arbitrer : **deux UI
+> d'enchères** coexistent et sont toutes deux instanciées (`m_auctionUi` +
+> `m_auctionHouseUi`).
+
+### 1.2 Anomalies
+
+| Constat | Emplacement | Sév. | Conf. |
+|---|---|---|---|
+| **Collisions de raccourcis clavier** : même touche = toggle panneau **+** action gameplay-net dans la même frame. `H`→toggle Hôtel des Ventes + `SendTalkRequest` ; `G`→refresh enchère + toggle BattleGround ; `B`→bid + toggle SkillBook ; `L`→list + toggle LootRoll. Gating incohérent entre le bloc toggles (`inGameNoMenu`) et le bloc net (`!chatBlocks` seul). | `Engine.cpp` 7587-7718 vs 13461-13613 | 🟠 | V |
+| **Ring SSBO bones partagé** (`kFrameSlots=32`, 2 frames en vol) : au-delà de ~16 draws skinnés/frame, un slot encore lu est réécrit → pose corrompue. Aucun garde-fou (limite documentée en commentaire). | `SkinnedRenderer.cpp:565-595`, `.h:171` | 🟠 | V |
+| Logs de diagnostic latchés à vie (`static bool`) — silence trompeur après le 1er event. | `Engine.cpp:12807,12834` | 🟡 | V |
+
+### 1.3 Optimisations
+
+| Constat | Emplacement | Sév. |
+|---|---|---|
+| 3 `std::vector<Mat4>` alloués **par avatar par frame** (Sample→ComputeGlobal→ComputeFinal par valeur). | `Engine.cpp:12933`, `AnimationSampler.h:39` | 🟠 |
+| `vkMapMemory`/`vkUnmapMemory` **par draw** au lieu d'un mapping persistant. | `SkinnedRenderer.cpp:580-595` | 🟠 |
+| `GetRaceMesh` : concat de string allouante + lookup map par avatar par frame. | `Engine.cpp:12877` | 🟡 |
+
+**Négatifs sains** : resize/shutdown GPU rigoureux (LIFO documenté, caches invalidés) ;
+`vkQueueWaitIdle` cantonné à l'init/upload one-shot, aucun stall en boucle de rendu ;
+UDP client propre (Goodbye anti-fantôme) ; RenderState double-bufferisé anti-race.
+
+---
+
+## 2. Serveurs (`masterd` / `shardd` / `shared`)
+
+### 2.1 🆕 Anomalie critique — race oubliée par B1
+
+> 🟠 **V — Data race sur `TradeSessionRegistry`.** `src/masterd/trade/TradeSessionRegistry.h:60-65`
+> mute `m_sessions` + `m_byAccount` **sans mutex**, alors que le pool NetServer
+> dispatche sur 4 workers. Le header affirme à tort « appel synchrone thread
+> principal ». `TradeHandler` appelle `Begin/GetByAccount/End` depuis `HandlePacket`
+> (opcodes 83/86/88/91/93 câblés). Deux `TRADE_BEGIN` concurrents corrompent les
+> `unordered_map`. **B1 a verrouillé Lfg/GmTicket/Quest/Weather mais a manqué Trade.**
+> → Ajouter un `std::mutex` couvrant toutes les opérations (même pattern que B1).
+
+Même classe de risque, moindre criticité : `ReputationManager` (sans verrou, mais
+seul l'opcode lecture est câblé aujourd'hui — piège futur), TOCTOU bénin sur
+`IgnoreListManager::Ignore`.
+
+### 2.2 Anomalies confirmées
+
+| Constat | Emplacement | Sév. | Conf. |
+|---|---|---|---|
+| **Secrets en dur** : `ticket_hmac_secret = "dev_secret_change_in_production"` **identique** dans master+shard → forge de tickets d'admission shard (usurpation `character_id`). `password = "lcdlln_pass_dev"` (BDD). | `deploy/docker/config/{master,shard}.config.json` | 🔴 | V |
+| `DELETE`+`INSERT` sans transaction (régénérable). Constat large : **0 transaction SQL** dans tout le serveur. | `MysqlAccountStore.cpp:373-389` | 🟡 | V |
+| Tables livrées en avance sans lecteur/écrivain runtime : `character_auras`, `spell_proc_template`, `creature_movement`, `groups`/`group_members`/`group_loot_rolls`, `pool_pool`/`pool_member_state`, `conditions`/`graveyards`/`locale_strings`, `phase_1a_test_storage`. | `sql/migrations/` | 🟡 | V |
+
+### 2.3 Code orphelin
+
+- 🟡 V — `src/shared/server_bootstrap/main.cpp` : entrypoint Windows obsolète, hors
+  de toute cible CMake (le boot réel = `shardd/main_win.cpp`). → supprimer.
+- 🟡 V — `ConditionMgr`/`GraveyardManager`/`LocaleStrings` compilés **uniquement**
+  dans les cibles de test, jamais linkés en prod.
+
+### 2.4 Optimisations
+
+- 🟡 V — `/online` portail : N+1 (`SELECT login … WHERE id=?` par compte connecté). → `IN (…)`.
+- 🟡 V — `ChatRelayHandler.cpp:490` : ré-encodage du paquet **par destinataire** en broadcast. → encoder le corps une fois, ne réécrire que l'en-tête.
+- 🟡 S — `TradeHandler::FindConnIdForAccount` O(n) par transition de trade.
+
+**Négatifs sains** : SQL 100 % paramétré (aucune injection) ; thread-safety correcte
+partout sauf Trade ; admission UDP solide (`AdmittedCharacterRegistry` verrouillé,
+TTL pending) ; rate-limit/anti-DDoS câblés en profondeur ; ownership personnage gaté.
+
+---
+
+## 3. Éditeur de carte (`world_editor` + parties éditeur d'`Engine`)
+
+### 3.1 Code orphelin — **le stock reste élevé** (12 sous-systèmes testés mais jamais instanciés)
+
+`TutorialSystem`, `OverlayGuidanceSystem`, `DiagnosticSystem`, `QuickStartWizard`,
+`ZoneValidator`, `InteractivePanel`+`PlacementTool`, `ForestTool`/`FieldTool`/`FoliagePaintTool`,
+`HazardTool`/`WindZoneTool`/`ZoneTool`, `BridgeTool`/`WallTool`/`HamletGeneratorTool`,
+`SelectionTool`, `PlaytestMode` (header seul, 0 référence). **Tous ont un fichier de
+test mais ne sont jamais câblés au Shell** (Phase 12 accessibilité + tools livrés
+« cœur pur » sans passe de câblage). Le menu Help affiche encore un stub bootstrap.
+
+### 3.2 Anomalies — intégrité des données
+
+| Constat | Sév. | Conf. | État |
+|---|---|---|---|
+| **Câblage réel des outils : 4/16 via viewport** (Sculpt, Stamp, MountainRange, ValleyChain). Nuance : les outils **eau** passent par un canvas 2D top-down (utilisables) ; érosion/cave/arch/portal ont un bouton Apply. **Seul `SplatPaint` est vraiment cassé** : `OnMouseDown/Move/Up` conçus pour le viewport mais **jamais appelés**, et son bouton panel est un no-op explicite (« needs Config plumbing — TODO »). | 🔴 | V | ⏳ |
+| **« Double vérité » heightmap** : le pinceau **legacy** (`TerrainEditingTools::ApplyBrush`) écrit directement la heightmap **sans** document/undo → coups **non undoables, non chunk-backed, non persistés** par `SaveTerrainChunks`. | 🟠 | V | ⏳ (non couvert par B3) |
+| 🆕 **Save inconditionnel après échec de load** : un `.bin` corrompu → document vidé + `LOG_WARN`, puis `SaveZoneDocuments` réécrit **sans condition** → le fichier réparable est **écrasé par un fichier vide**. Aucun garde-fou « ne pas sauver si le dernier load a échoué ». | 🟠 | V | ⏳ |
+| `reserve(instanceCount)` non borné (jusqu'à 4 G) sur `.bin` corrompu → DoS mémoire mineur. | 🟡 | V | ⏳ |
+| Reset TerrainDocument + CommandStack au load/new | ✅ | V | **corrigé B3** |
+| Save eau/mesh/portails hors tests | ✅ | V | **corrigé B3** |
+| Namespacing chunks par zone | ✅ | V | **corrigé B3** |
+
+### 3.3 Optimisations
+
+| Constat | Sév. |
+|---|---|
+| 🔴 **Stall GPU par frame de drag (splat/grass)** : `UploadToImage` fait `vkCreateCommandPool`→submit→**`vkQueueWaitIdle`**→`vkDestroyCommandPool` **à chaque frame** où le bouton est maintenu (`FlushSplatMap`/`FlushGrassMask`). → réutiliser un pool long-lived + staging ring + barrière (comme le pinceau hauteur, qui lui est déjà correct). | 🔴 |
+| `LOG_INFO("FlushSplatMap OK")` **par frame de drag**. → LOG_TRACE/supprimer. | 🟠 |
+| `TerrainSculptCommand::TryMerge` concatène `cells` **sans dédupliquer** → enflure mémoire/coût undo (correctness OK car deltas relatifs). | 🟡 |
+| `SyncWorldEditorHeightmapFromDocument` re-parcourt tous les chunks (atténué : flag one-shot, pas par-frame). | 🟡 |
+
+**Négatifs sains** : B3 réellement câblé ; désérialisation bornée (magic+version+readers
+bornés) ; coalescing pile undo O(1) ; pinceau hauteur via staging dirty-flag sans stall ;
+pool eau réutilisé (pattern à répliquer pour splat/grass).
+
+**Doc** : règle `///` respectée sur le Shell/ZonePaths/B3, mais **violée** sur les
+fichiers orphelins (tools racine, InteractivePanel, SelectionTool).
+
+---
+
+## 4. Web-portal (`web-portal/`)
+
+### 4.1 Sécurité (priorité — portail exposé)
+
+| Constat | Emplacement | Sév. | Conf. |
+|---|---|---|---|
+| **Aucun rate-limiting** (grep `rate.?limit\|429` = 0). Login brute-forçable ; `request-email-change` et `parental/request` permettent un envoi SMTP vers adresse arbitraire sans plafond (spam/relais). Seul `passwordRecovery` plafonne (3/h). | login/route.ts, player/* | 🔴 | V |
+| **Oracle temporel d'énumération** : identifiant inconnu → retour immédiat sans Argon2 ; compte connu → hash coûteux. | `lib/auth/portalLogin.ts:51` | 🔴 | V |
+| **Aucun en-tête de sécurité** (CSP/HSTS/X-Frame-Options/X-Content-Type-Options/Referrer-Policy) — ni next.config, ni middleware, ni nginx. | — | 🔴 | V |
+| **Endpoints GET mutants** : `confirm-email` et `parental/validate` font `UPDATE` sur GET (prefetch/CSRF par `<img>`). | player/account, player/parental | 🟠 | V |
+| Défense CSRF limitée à `SameSite=lax` (aucune vérif Origin/token sur les mutations). | — | 🟠 | V |
+| Tokens e-mail (`email_pending_token`, `parental_token`) stockés/comparés **en clair** — alors que le reset password, lui, hache en SHA-256. | request-email-change, parental/request | 🟡 | V |
+| Incohérence `NEXT_PUBLIC_PORTAL_URL` (recovery) vs `PORTAL_URL` (autres senders) — `requireEnv` jette → moitié des flux e-mail casse si une seule est définie. | passwordRecovery.ts:289 vs sender.ts:110 | 🟡 | V |
+
+### 4.2 Code orphelin
+
+- 🟡 V — `lib/exploits/exploitTier.ts` entier (jamais importé ; logique réimplémentée en SQL inline).
+- 🟡 V — 3 senders jamais appelés (`sendVerificationEmail`/`sendWelcome`/`sendAccountConfirmed`) + **8 templates morts** (verification/welcome/account-confirmed ×2 langues + `cgu-accepted.{fr,en}` sans aucun sender).
+- 🟡 V — Hiérarchie de rôles non exploitée (`isPlayer`/`roleLevel`/`hasAtLeast` jamais importés ; autorisation binaire staff/player).
+
+### 4.3 Optimisations
+
+- 🟠 V — `ensurePasswordRecoveryTables()` : **3 `CREATE TABLE IF NOT EXISTS` par requête** sur les 3 routes recovery. → migration SQL au boot.
+- 🟠 V — Pool mysql2 sans `connectionLimit`/`queueLimit` explicites.
+- 🟠 V — Transporter nodemailer recréé à chaque e-mail (pas de pool SMTP). → singleton `pool:true`.
+
+**Négatifs sains** : SQL 100 % paramétré (SET dynamiques via fieldMap codé en dur) ;
+`requireAdmin()` sur 14/14 routes admin, rôle relu en DB ; sessions opaques 256 bits ;
+IDOR scoppés par session ; Argon2id double + comparaisons timing-safe ; aucun secret en dur.
+
+---
+
+## 5. Transversal (build / données / config)
+
+| # | Constat | Sév. | Conf. |
+|---|---|---|---|
+| 5.1 | **`deploy/docker/sql/migrations/` périmé** : 49 fichiers committés, **0050→0071 manquants** (22 migrations). Artefact régénéré par `sync-db-to-docker-deploy.sh` mais suivi git ; un `docker build` manuel **sans** la sync embarque un schéma amputé. | 🔴 | V |
+| 5.2 | **Templates `password-reset` divergents** : « 30 minutes » (game/data/email, lu par masterd) vs « 10 minutes » (web-portal). Au moins un texte utilisateur est faux. | 🔴 | V |
+| 5.3 | **`client.character_creation.default_server_id` jamais lu** : le code lit `character_creation.default_server_id` (sans préfixe `client.`) → valeur admin **silencieusement ignorée**, retombe sur le défaut codé `1`. | 🔴 | V |
+| 5.4 | **`game/data/shaders/luminance_reduce.comp.spv`** : `.spv` suivi par git **sans source ni référence** (le pipeline charge `luminance_histogram*`). | 🔴 | V |
+| 5.5 | `game/data/themes/` : arbre de thèmes orphelin (le live = `game/data/ui/themes/`). | 🟠 | V |
+| 5.6 | `deploy/docker/server-config/` + `Dockerfile.server{,.build}` : topologie de déploiement **legacy** (binaire unique) non utilisée par compose/CI. | 🟠 | V |
+| 5.7 | 38 `.spv` suivis par git alors que `.gitignore` les ignore (`git rm --cached`). | 🟠 | V |
+| 5.8 | `configuration/equipment/*.json` + `animation_sets.json` : aucun loader (pré-provisionné CHAR-MODEL.25). | 🟠 | V |
+| 5.9 | Locales `de/es/it/pl/pt` : pas de catalogue `<locale>.json` → non enregistrées au runtime ; 10 PNG orphelins. | 🟡 | V |
+| 5.10 | `src/world_editor/ui/EditorAudioPanel.{h,cpp}` : sur disque, **hors de toute cible**, jamais référencé. | 🟠 | V |
+| 5.11 | `tools/Migrate-CellNaming.ps1` : one-shot déjà joué. | 🟡 | V |
+| 5.12 | ~14 clés config mortes (jamais lues) : `gi.ddgi.{origin_m,spacing_m,counts,intensity}`, `db.delay_thread_*`, `db.prepared_statement_cache_size_per_conn`, `globals.{default_locale,fallback_locale,...}`, `accounts.{default_new_account_role,role_change_audit}`, `editor.world.camera.fpsSpeed`, `editor.world.terrain.lodWorkers`. | 🟡 | V |
+
+> ⚠️ **Point hors-périmètre relevé par l'agent serveur** : le code et les commentaires
+> contiennent encore **massivement** la référence à l'autre serveur de jeu (préfixes
+> `CMANGOS.xx` dans `main_linux.cpp`, `src/CMakeLists.txt`, headers), en contradiction
+> directe avec la règle projet « ne pas utiliser ce terme ». Candidat à un nettoyage
+> transverse dédié.
+
+---
+
+## 6. Synthèse — thèmes dominants (post B1/B2/B3)
+
+1. **B1/B2/B3 confirmés câblés et efficaces** — mais B1 a laissé **`TradeSessionRegistry`
+   sans mutex** (même classe de bug, oublié) : c'est le constat 🆕 le plus important.
+2. **Le pattern « noyau livré non câblé » reste systémique côté éditeur** : 12 sous-systèmes
+   testés mais jamais instanciés (tutoriel/diagnostic/wizard/validation/tools). Le stock ne
+   se résorbe pas. Côté client il a régressé positivement (combat câblé par SP1-4).
+3. **Intégrité éditeur** : B3 a réglé l'inter-cartes, mais restent ⏳ le SplatPaint inutilisable,
+   la double vérité heightmap (legacy non-undoable), et le 🆕 save-écrase-après-échec-de-load.
+4. **Sécurité portail** : fondamentaux sains, périmètre transverse toujours à faire
+   (rate-limit login, en-têtes, CSRF, GET mutants).
+5. **Secrets de prod en dur** (ticket HMAC + mot de passe DB) : risque concret si déployé tel quel.
+6. **Ménage rentable** : ~50 fichiers orphelins, 4 🔴 transversaux (migrations Docker périmées,
+   templates divergents, mismatch config server_id, shader .spv mort), 14 clés config mortes.
+
+## 7. Propositions de lots (à discuter)
+
+- **Lot B7 — race Trade** (serveur, 🆕) : `std::mutex` sur `TradeSessionRegistry`, sur le modèle exact de B1. **Petit, critique, à faire en priorité.** → **redéploiement master requis.**
+- **Lot F — sécurité portail** : rate-limit login + sends, en-têtes de sécurité, dummy-verify anti-timing, GET→POST + tokens hachés. → redéploiement portail.
+- **Lot G — secrets & déploiement** : externaliser `ticket_hmac_secret`+password, refus de boot si valeur dev ; gitignorer `deploy/docker/sql/` ; harmoniser le délai des templates password-reset. → redéploiement master.
+- **Lot A' — ménage sans risque** : `server_bootstrap/main.cpp`, `EditorAudioPanel`, `game/data/themes/`, `luminance_reduce.comp.spv`, `.spv` `git rm --cached`, `exploitTier.ts`, CSS/templates/senders morts, `Migrate-CellNaming.ps1`, clés config mortes + **fix mismatch `default_server_id`**.
+- **Lot D' — optimisations** : flush splat/grass au mouse-up (éditeur, plus gros gain perçu) ; buffers de pose réutilisables + mapping persistant (client) ; N+1 `/online` + ré-encodage chat (serveur) ; CREATE TABLE hors chemin requête + pool SMTP (portail).
+- **Lot C' — câbler ou supprimer (décision par feature)** : 12 sous-systèmes éditeur, doublon AuctionUi client, AoEPreviewSystem, FXManager, ClientPrediction, ZonePreloadHook.
+- **Lot H — terminologie** : nettoyage transverse des références `CMANGOS` (code/commentaires).
+- **Lot E — process** : « pas de merge d'un sous-système sans sa passe de câblage » + registre central des binds clavier in-game.
+
+---
+
+*Source : 5 audits parallèles indépendants (client, serveur, éditeur, portail, transversal),
+2026-06-13. Aucune modification de code. À lire en complément de
+`2026-06-10-audit-global-4-parties.md` (les deux convergent ; ce rapport ajoute la race
+Trade, le save-après-échec éditeur, et la confirmation post-B1/B2/B3).*
+
+> **Déploiement** : ✅ Audit en lecture seule — aucun redéploiement. Les lots de
+> correction, eux, impacteront : master (B7, G), portail (F), client/éditeur (A'/C'/D').

--- a/docs/audit/2026-06-13-lot-c-cablage.md
+++ b/docs/audit/2026-06-13-lot-c-cablage.md
@@ -1,0 +1,130 @@
+# Lot C — Plan de câblage des sous-systèmes orphelins (2026-06-13)
+
+> Audit de câblage **en lecture seule** (aucun fichier modifié), 4 agents parallèles
+> (éditeur-accessibilité, éditeur-outils, client, serveur+portail). **Aucune
+> suppression** : l'objectif est de déterminer, pour chaque sous-système livré mais
+> non câblé, **ce qu'il faut faire pour le brancher au runtime**. `legacy/`/`external/` exclus.
+>
+> Effort : **S** <½j · **M** 1-2j · **L** >2j. Déploiement noté par fiche.
+
+---
+
+## 0. Faits structurants découverts (à lire avant tout)
+
+1. **Point d'ancrage UI éditeur = `src/world_editor/ui/WorldEditorImGui.cpp`** (menu **français**, propriétaire de `m_shell`). Le menu anglais `M100.1` de `core/WorldEditorShell.cpp:405-517` est **supprimé au boot** (`Engine.cpp:1383 SetMenuBarSuppressed(true)`). Tout nouveau menu/panneau éditeur va dans le menu français.
+2. **`EnterDungeonHandler` master est DÉJÀ câblé et complet** (`main_linux.cpp:452,1129`) — il ne répond *pas* dans le vide ; seul l'**émetteur client** manque. Câblage **100% client** (si migration 0063 déjà appliquée).
+3. **`SkillSystem` n'est PAS instancié dans Engine** (`grep SkillSystem src/client/app/` = 0). C'est le bloqueur racine de l'aperçu AoE.
+4. **Deux pièces éditeur à fort effet de levier** : (a) un **pont SplatMap chunks→GPU** manquant (symétrique de la sync heightmap déjà en place) débloque à lui seul SplatPaint + Cave/Overhang/Arch/Portal + tagging splat Forest/Field ; (b) **un seul élargissement du switch viewport** (`Engine.cpp:9957-10018`) branche d'un coup SplatPaint, RiverNetwork, Coastline et plusieurs outils racine.
+5. **`ClientPrediction` est server-first bloqué** : il dépend de toute la pile réplication UDP Linux + autorité shard + snapshots + envoi d'input UDP (TC.1), non mergée. À traiter en dernier, après les PR serveur.
+
+---
+
+## 1. Quick wins — faible effort, pas (ou peu) de serveur
+
+| Sous-système | Ce qu'il manque | Effort | Déploiement |
+|---|---|---|---|
+| **AutoFitProxy** (client) | 1 seul site d'appel (`CollisionEditorPanel` éditeur, ou import de mesh runtime). Fonction pure testée. | **S** | ✅ client |
+| **Consolidation AuctionUi** (client) | `auction/AuctionHousePresenter` (`m_auctionHouseUi`) est la seule câblée réseau (opcodes 174/176/178/180/181). Rerouter les interactions souris (drop-zone post, hit-test) depuis `economy/AuctionUiPresenter` (`m_auctionUi`, HUD debug) vers elle, puis débrancher `m_auctionUi` de la boucle (sans supprimer les fichiers). | **S-M** | ✅ client |
+| **EnterDungeon émetteur** (client) | Émettre `kOpcodeEnterDungeonRequest(197)` sur interaction portail (patron `LfgUi.cpp:83-92`) + `case kOpcodeEnterDungeonResponse(198)` dans le switch réponses d'`Engine.cpp`. Payloads déjà dans `engine_core`, master déjà câblé. **S** pour l'émission ; **M** avec détection de volume portail in-world. | **S-M** | ✅ client (vérifier migration 0063 déjà jouée) |
+| **exploitTier.ts** (portail) | Importer `bugReportThresholdsEligible` dans `admin/bugs/[id]/route.ts:90`. Option 1 (recommandée, sûre) : garde-fou de cohérence seed-SQL↔constante via `logError`. Option 2 : faire du helper l'autorité (filtre JS) — valider l'alignement des seuils d'abord. | **S** | ✅ portail |
+| **Hiérarchie de rôles** (portail) | Généraliser `requireAdmin()` en `requireRole(min)` (importe `hasAtLeast`), reclasser ~14 routes admin (administrator/game_master/moderator) + gardes de pages. Colonne `accounts.role` (0043) déjà à 4 valeurs. Nécessite une **décision produit** sur le mapping niveau↔route + des comptes réellement seedés aux rôles intermédiaires. | **M** | ✅ portail |
+
+---
+
+## 2. Éditeur — outils (le gros chantier, mais très mutualisable)
+
+### 2.1 Les 2 pièces maîtresses à faire en premier (débloquent le reste)
+
+- 🔧 **Pont SplatMap chunks→GPU** (**M**) : ajouter un callback `m_onSplatChanged` jumeau de `m_onChunkChanged` dans `TerrainDocument` (aujourd'hui `MarkSplatDirty`, `TerrainDocument.cpp:321`, ne notifie rien), l'installer dans `Engine.cpp` (~:13824) pour lever un flag, et au tick (~:8171) un `SyncWorldEditorSplatFromDocument()` calqué sur `SyncWorldEditorHeightmapFromDocument` (`Engine.cpp:13925`) qui écrit dans `TerrainSplatting` + `ReuploadSplatMap`. → **débloque le rendu de SplatPaint, Cave/Overhang/Arch/Portal, et le tagging splat Forest/Field.**
+- 🔧 **Élargir le switch viewport** (`Engine.cpp:9957-10018`) avec un patron unique `else if (tool == ActiveTool::X){ modernEditActive=true; if(freeClick && terrainPick && pressed) MutableXTool().OnMouseDown/AddVertex(...);}`. → branche **SplatPaint** (A), **RiverNetwork + Coastline** (B), et les outils racine qui choisissent le viewport.
+
+### 2.2 SplatPaint — quasi prêt, 3 trous
+
+Instancié, raccourci `P`, entrée ToolProperties OK. Manque : (1) branche dispatch viewport (S), (2) résoudre le « Config plumbing TODO » du bouton auto-rules (`ToolPropertiesPanel.cpp:243-253`, exposer `Config` au panneau ou méthode `shell.ApplySplatAutoRules`) (S), (3) le pont GPU §2.1 (M, sinon peinture invisible).
+
+### 2.3 Outils déjà instanciés, manque juste la branche viewport / vérif bouton Apply
+
+- **RiverNetwork, Coastline** : branche `AddVertex` dans le switch viewport. **S** chacun (mutualisé avec §2.1).
+- **HydraulicErosion, ThermalWindErosion, Cave, Overhang, Arch, DungeonPortal** : pilotés par bouton « Apply » (pas de drag) — vérifier le câblage CommandStack ; Cave/Overhang/Arch/Portal deviennent **visibles** grâce au pont splat §2.1. **S** par outil.
+- **Lake, River** (eau) : déjà câblés via canvas 2D top-down (`ToolPropertiesPanel.cpp:486-496`) — **rien à faire**, ils servent de modèle.
+
+### 2.4 Outils racine non instanciés — câblage complet (5 maillons : membre shell + `enum ActiveTool` + raccourci + entrée ToolProperties + accesseur)
+
+| Outil(s) | Input | Effort | Note |
+|---|---|---|---|
+| **ForestTool, WindZoneTool, ZoneTool, HamletGeneratorTool** | polygone XZ (réutiliser `RenderTopDownCanvas`→`AddPoint`, modèle Lake) | **M** chacun, mais répétitif (helper « enregistrer un outil ») | génération pure déjà testée |
+| **FieldTool** | rectangle 2 coins | **M** | tagging splat → dépend §2.1 |
+| **HazardTool** | clic sol unique (`CreateAt`, modèle TerrainStamp) | **M** (S si réutilise picking sol) | |
+| **BridgeTool, WallTool** | spline (suite de points) | **M** chacun | header-only, génération dans `structures::` |
+| **FoliagePaintTool** | pinceau densité | **L** | **seul outil sans API d'input** : écrire l'API stroke d'abord (patron SplatPaint) |
+| **PlacementTool → InteractivePanel → SelectionTool → PlaytestMode** | placement/sélection (drag-rect, lasso, F5) | **L** (sous-système entier) | InteractivePanel dépend de PlacementTool ; PlaytestMode = touche F5 déjà réservée |
+
+**Déploiement** : ✅ tous les outils éditeur = **100% client** (binaire éditeur), aucun serveur. Rappel : documenter `///` à la création (convention CLAUDE.md).
+
+---
+
+## 3. Éditeur — accessibilité / workflow (5 sous-systèmes, ordre imposé par les dépendances)
+
+Aucune cible de widget n'existe aujourd'hui (`WidgetTargetRegistry` jamais rempli ; les ~13 cibles de `TutorialIo.cpp:45-71` sont fictives). Ordre :
+
+1. **OverlayGuidanceSystem + WidgetTargetRegistry** (`help/`, **M**) — fondation, aucune dépendance. Travail : passe de rendu overlay (voile + rectangle pulsant + bulle) + instrumentation `Register(id, rect)` par frame sur les widgets cibles dans `WorldEditorImGui::Render`.
+2. **ZoneValidator** (`validation/`, **M**) — indépendant ; livre une valeur immédiate (bouton/panneau « Valider ») **et** matérialise les cibles `toolbar.button.validate`/`panel.validation` dont le tutoriel a besoin. Travail : adaptateur Documents→`ValidationContext` + panneau + « Aller à » (caméra) + blocage export sur erreur.
+3. **DiagnosticSystem** (`diagnostic/`, **M**) — indépendant (lien optionnel vers le `ValidationContext` de #2). 10 règles MVP prêtes. Travail : peupler le `DiagnosticContext` (dont **compteurs d'usage neufs** : `secondsSinceToolSelected`, `erosionAppliedAfterRivers`…) + panneau « Pourquoi ça ne marche pas ? ».
+4. **QuickStartWizard** (`wizard/`, **M**, **L avec rollback**) — réutilise le pipeline `ZonePresetExecutor` déjà câblé par `ZonePresetDialog`. ⚠️ **Bloqueur P0** : `ZonePresetExecutor::Execute` fait un **reset destructif sans rollback** (audit 06-05 item 6.1) ; le wizard est un 2e déclencheur de ce flux → **traiter le rollback avant/avec**. De plus 4 opérations (`coastline`, `river_network`, `hydraulic_erosion`, `thermal_wind_erosion`) sont **ignorées silencieusement** par l'executor (`ZonePresetExecutor.h:55-59`).
+5. **TutorialSystem** (`tutorial/`, **L**) — en dernier : dépend de #1, et ses cibles renvoient à #2 (validate) et #4 (zone_preset_dialog). Travail : intro/outro modales, ~13 points `NotifyAction`, persistance flag `first_launch_tutorial_completed` (UserPrefs, neuf), menu « Aide » à créer.
+
+**Déploiement** : ✅ 100% client (éditeur).
+
+---
+
+## 4. Client — gameplay (couplé au serveur, server-first)
+
+| Sous-système | Bloqueur principal | Effort | Déploiement |
+|---|---|---|---|
+| **ZonePreloadHook** (streaming+TAA) | opcode serveur `ZoneChange` à confirmer/produire (sinon wire-breaking). Volet streaming+TAA faisable seul ; flags entités → réplication d'entités (non mergée). | **M** | ⚠️ serveur si l'opcode est neuf |
+| **Chaîne particules** (FXManager + ParticleSystem + ParticleBillboardPass) | étage **GPU entièrement à écrire** (pipeline transparent + shaders billboard + atlas + intégration FrameGraph, modèle `DecalSystem`) + colle FX→émetteurs + assets JSON `game/data/fx/*` à confirmer. CPU prêt. `CombatEvent` probablement déjà reçu (combat livré). | **L** | ✅ client si `CombatEvent` déjà reçu |
+| **AoEPreviewSystem** | **`SkillSystem` à instancier dans Engine d'abord** (bloqueur racine) + déclencheur UI d'armement de sort + validation serveur de l'usage à une position. `DecalSystem` déjà dispo. | **M-L** | ⚠️ serveur si validation sort neuve |
+| **ClientPrediction** | **server-first** : pile réplication UDP Linux + autorité shard + flux de snapshots + envoi input UDP (TC.1) non livrés. `SurfaceQueryService` (multiplicateur) déjà dispo. `ForcePosition` SP1 ≠ snapshots continus. | **L** | ⚠️ serveur (lock-step) |
+
+---
+
+## 5. Serveur — globals data-driven
+
+**ConditionMgr / GraveyardManager / LocaleStrings** (`src/shardd/internals/globals/`) — testés, mais compilés **uniquement** dans les cibles de test. Câblage :
+1. Ajouter les 3 `.cpp` à la liste de sources **`shard_app`** (bloc UNIX, `src/CMakeLists.txt:1097-1173`) — shard-only (namespace shard), pas `server_app`. Aucune nouvelle dépendance de link (ConnectionPool/DbHelpers/MySQL déjà là).
+2. Instancier au boot dans `shardd/main_linux.cpp` sur le patron « Wave » (ex. EventAI :227), `Load(characterDbPool)` sous garde DB configurée, logger les compteurs.
+3. Brancher fonctionnellement : `ClosestGraveyard` au flux mort/respawn (inexistant aujourd'hui), `Evaluate` aux conditions data-driven, `Format` aux messages serveur.
+
+**Bloqueurs** : migration 0042 (idempotente, à rejouer au boot) ; **seeds = données de test** → seeder les **vraies** données prod (graveyards des maps réelles, locale_strings) sinon `ClosestGraveyard`=nullopt / `GetString`=marqueur debug. Convention d'ID : condition ∈[1,9999], group ∈[10000,∞).
+
+**Effort** : **M**. **Déploiement** : ⚠️ **REDÉPLOIEMENT SHARD requis** (nouveaux .cpp + boot + migration + seed). Master non concerné, pas de wire-breaking.
+
+---
+
+## 6. Ordre de bataille recommandé (toutes parties confondues)
+
+**Vague 1 — quick wins, valeur immédiate, risque quasi nul (tous S/M, client/portail)**
+AutoFitProxy · consolidation AuctionUi · émetteur EnterDungeon · exploitTier (option garde-fou) · hiérarchie de rôles portail.
+
+**Vague 2 — fondations éditeur à fort levier**
+Pont SplatMap chunks→GPU + élargissement switch viewport → puis SplatPaint, RiverNetwork, Coastline, et la visibilité de Cave/Overhang/Arch/Portal.
+
+**Vague 3 — outils racine éditeur** (helper « enregistrer un outil » mutualisé)
+Forest/WindZone/Zone/Hamlet (polygone) → Hazard/Field/Bridge/Wall → placement/sélection (Placement→Interactive→Selection→Playtest) → FoliagePaint (API stroke d'abord).
+
+**Vague 4 — accessibilité éditeur** (ordre imposé)
+Overlay+Registry → ZoneValidator → Diagnostic → (P0 rollback executor) Wizard → Tutorial.
+
+**Vague 5 — serveur globals** (shard) : ConditionMgr/Graveyard/LocaleStrings + seed prod → redéploiement shard.
+
+**Vague 6 — gameplay couplé serveur (server-first)**
+ZonePreloadHook (si opcode ZoneChange) · chaîne particules (étage GPU) · SkillSystem+AoEPreview · ClientPrediction (en dernier, après la pile réplication UDP).
+
+---
+
+*Source : 4 plans de câblage parallèles, 2026-06-13. Aucune modification de code, aucune suppression.
+Complète `2026-06-13-audit-global-independant.md` (axe orphelins).*
+
+> **Déploiement (de ce document)** : ✅ lecture seule, aucun redéploiement. Pour l'exécution :
+> Vagues 1-4 = **100% client/portail** ; Vague 5 = **redéploiement shard** ; Vague 6 =
+> **lock-step client+serveur** dès qu'un opcode/flux UDP neuf est requis.

--- a/src/world_editor/panels/CollisionEditorPanel.cpp
+++ b/src/world_editor/panels/CollisionEditorPanel.cpp
@@ -1,6 +1,8 @@
 // src/world_editor/panels/CollisionEditorPanel.cpp
 #include "src/world_editor/panels/CollisionEditorPanel.h"
 #include "src/client/world/collision/ProxyWireframe.h"
+#include "src/client/world/collision/AutoFitProxy.h"
+#include "src/client/world/collision/CollisionMeshCpu.h"
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -17,6 +19,7 @@ namespace engine::editor::world::panels
 		using engine::world::collision::CollisionProxy;
 		using engine::world::collision::ProxyType;
 		using engine::world::collision::Edge3D;
+		using engine::world::collision::CollisionMeshCpu;
 
 		/// Mesh test : cube unitaire centré sur origine (8 verts, 12 arêtes).
 		std::vector<Edge3D> MakeCubeEdges()
@@ -129,6 +132,26 @@ namespace engine::editor::world::panels
 				default: return MakeCubeEdges();
 			}
 		}
+
+		/// Construit un CollisionMeshCpu (sommets seuls) à partir du mesh test
+		/// sélectionné, pour alimenter AutoFit. Les sommets sont dérivés des
+		/// arêtes de preview : les doublons d'extrémités sont tolérés car AutoFit
+		/// ne lit que le nombre de sommets et la bounding box (jamais la topologie).
+		/// \param index 0=Cube, 1=Cylinder, 2=Sphere, 3=Slab (fallback Cube).
+		/// \return Mesh CPU non statique prêt pour engine::world::collision::AutoFit.
+		CollisionMeshCpu BuildTestMeshCpu(int index)
+		{
+			CollisionMeshCpu cpu;
+			const auto edges = GetTestMeshEdges(index);
+			cpu.vertices.reserve(edges.size() * 2);
+			for (const auto& e : edges)
+			{
+				cpu.vertices.push_back(e.first);
+				cpu.vertices.push_back(e.second);
+			}
+			cpu.isStatic = false;
+			return cpu;
+		}
 	}
 #endif // _WIN32
 
@@ -208,12 +231,7 @@ namespace engine::editor::world::panels
 		else if (m_proxy.type == ProxyType::ConvexHull)
 		{
 			ImGui::Text("Vertex count: %zu", m_proxy.vertices.size());
-			ImGui::BeginDisabled(true);
-			ImGui::Button("Re-run AutoFit");
-			ImGui::EndDisabled();
-			// Tooltip sur item disabled : requiert AllowWhenDisabled flag.
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-				ImGui::SetTooltip("Requires mesh CPU data — wired with mesh import (M100.34 ou follow-up)");
+			ImGui::TextDisabled("(AutoFit disponible sous l'apercu)");
 		}
 		else // TriMesh
 		{
@@ -228,6 +246,17 @@ namespace engine::editor::world::panels
 		ImGui::Combo("Test mesh", &m_testMeshIndex, meshNames, 4);
 		ImGui::SameLine();
 		if (ImGui::Button("Reset Camera")) m_camera.Reset();
+		ImGui::SameLine();
+		// Câblage AutoFit (M100.12) : choisit automatiquement un proxy
+		// (Capsule / ConvexHull / TriMesh) depuis le mesh test sélectionné.
+		if (ImGui::Button("AutoFit depuis le mesh test"))
+		{
+			const CollisionMeshCpu cpu = BuildTestMeshCpu(m_testMeshIndex);
+			m_proxy = engine::world::collision::AutoFit(cpu);
+			m_currentPath.clear();  // proxy généré : ne pas écraser un fichier chargé au Save
+			m_status = "AutoFit \xE2\x9C\x93";
+			m_statusFramesLeft = 60;
+		}
 
 		const ImVec2 previewSize{ 300.0f, 200.0f };
 		ImGui::BeginChild("##preview", previewSize, true,

--- a/web-portal/app/api/admin/bugs/[id]/route.ts
+++ b/web-portal/app/api/admin/bugs/[id]/route.ts
@@ -9,10 +9,11 @@
 //  4. Set exploit_awarded = 1 on the bug report.
 
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
+import { bugReportThresholdsEligible } from '@/lib/exploits/exploitTier'
 
 const VALID_STATUSES = ['pending', 'confirmed', 'in_progress', 'resolved', 'not_a_bug'] as const
 type AdminStatus = (typeof VALID_STATUSES)[number]
@@ -36,7 +37,8 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const admin = await requireAdmin()
+  // Résolution de bug + attribution d'exploit = action de contenu modéré : game_master minimum.
+  const admin = await requireRole('game_master')
   if (!admin) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
@@ -104,6 +106,21 @@ export async function PATCH(
          ORDER BY e.threshold_value ASC`,
         [resolvedCount, accountId]
       )
+
+      // Garde-fou de cohérence : la table `exploits` (source de vérité SQL) ne devrait
+      // jamais renvoyer un palier absent de la liste canonique alignée sur le seed 0008.
+      // Une divergence signale une dérive seed SQL ↔ constante applicative (sans changer
+      // le comportement : la requête SQL reste l'autorité).
+      const canonicalThresholds = new Set(bugReportThresholdsEligible(resolvedCount))
+      for (const exploit of eligibleExploits) {
+        if (!canonicalThresholds.has(exploit.threshold_value)) {
+          logError(
+            'PATCH /api/admin/bugs/[id]',
+            'Dérive seed exploits bug_reports : palier SQL hors liste canonique',
+            { thresholdValue: exploit.threshold_value, resolvedCount }
+          )
+        }
+      }
 
       // Unlock each newly eligible exploit
       for (const exploit of eligibleExploits) {

--- a/web-portal/app/api/admin/cgu/[id]/publish/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/publish/route.ts
@@ -1,7 +1,7 @@
 ﻿// POST /api/admin/cgu/[id]/publish
 // Publishes a draft CGU edition
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
@@ -10,7 +10,7 @@ export async function POST(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/[id]/retire/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/retire/route.ts
@@ -2,7 +2,7 @@
 // Body: { reason: string } — required, non-empty
 // Retires a published CGU edition
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
@@ -11,7 +11,7 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/[id]/route.ts
+++ b/web-portal/app/api/admin/cgu/[id]/route.ts
@@ -1,7 +1,7 @@
 // PATCH /api/admin/cgu/[id] — update draft edition
 // DELETE /api/admin/cgu/[id] — delete draft edition
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
@@ -18,7 +18,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('game_master'))) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
@@ -91,7 +91,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('game_master'))) return NextResponse.json({ ok: false }, { status: 403 })
 
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })

--- a/web-portal/app/api/admin/cgu/route.ts
+++ b/web-portal/app/api/admin/cgu/route.ts
@@ -2,13 +2,13 @@
 // Body: { versionLabel, titleFr, contentFr, titleEn?, contentEn? }
 // Creates a new terms_edition (status='draft') + terms_localizations entries
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 import type { ResultSetHeader } from 'mysql2/promise'
 
 export async function POST(request: Request) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('game_master'))) return NextResponse.json({ ok: false }, { status: 403 })
 
   try {
     const body = await request.json() as {

--- a/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
+++ b/web-portal/app/api/admin/characters/[id]/force-rename/route.ts
@@ -1,11 +1,11 @@
 ﻿import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/faq/[id]/route.ts
+++ b/web-portal/app/api/admin/faq/[id]/route.ts
@@ -1,7 +1,7 @@
 // PATCH /api/admin/faq/[id] — update faq item fields
 // DELETE /api/admin/faq/[id] — delete faq item
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
@@ -9,7 +9,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -56,7 +56,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/faq/route.ts
+++ b/web-portal/app/api/admin/faq/route.ts
@@ -1,13 +1,13 @@
 // GET /api/admin/faq — returns all faq items ordered by display_order
 // POST /api/admin/faq — creates a new faq item
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function GET() {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -22,7 +22,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/app/api/admin/players/[id]/activate/route.ts
+++ b/web-portal/app/api/admin/players/[id]/activate/route.ts
@@ -1,10 +1,10 @@
 ﻿import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/players/[id]/characters/route.ts
+++ b/web-portal/app/api/admin/players/[id]/characters/route.ts
@@ -1,11 +1,11 @@
 ﻿import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('moderator'))) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/disable/route.ts
+++ b/web-portal/app/api/admin/players/[id]/disable/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { sendAccountDisabled } from '@/lib/email/sender'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError, logWarn } from '@/lib/log'
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
 

--- a/web-portal/app/api/admin/players/[id]/verify-email/route.ts
+++ b/web-portal/app/api/admin/players/[id]/verify-email/route.ts
@@ -1,10 +1,10 @@
 ﻿import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
 export async function PATCH(_req: Request, { params }: { params: { id: string } }) {
-  if (!(await requireAdmin())) return NextResponse.json({ ok: false }, { status: 403 })
+  if (!(await requireRole('administrator'))) return NextResponse.json({ ok: false }, { status: 403 })
   const id = parseInt(params.id, 10)
   if (isNaN(id)) return NextResponse.json({ ok: false }, { status: 400 })
   try {

--- a/web-portal/app/api/admin/roadmap/[id]/route.ts
+++ b/web-portal/app/api/admin/roadmap/[id]/route.ts
@@ -1,7 +1,7 @@
 // PATCH /api/admin/roadmap/[id] — update roadmap item fields
 // DELETE /api/admin/roadmap/[id] — delete roadmap item
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import { logError } from '@/lib/log'
 
@@ -9,7 +9,7 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)
@@ -56,7 +56,7 @@ export async function DELETE(
   _request: Request,
   { params }: { params: { id: string } }
 ) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   const id = parseInt(params.id, 10)

--- a/web-portal/app/api/admin/roadmap/route.ts
+++ b/web-portal/app/api/admin/roadmap/route.ts
@@ -1,13 +1,13 @@
 // GET /api/admin/roadmap — returns all roadmap items ordered by display_order
 // POST /api/admin/roadmap — creates a new roadmap item
 import { NextResponse } from 'next/server'
-import { requireAdmin } from '@/lib/auth/admin'
+import { requireRole } from '@/lib/auth/admin'
 import { query } from '@/lib/db/connection'
 import type { RowDataPacket } from 'mysql2/promise'
 import { logError } from '@/lib/log'
 
 export async function GET() {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {
@@ -22,7 +22,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!(await requireAdmin())) {
+  if (!(await requireRole('game_master'))) {
     return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
   }
   try {

--- a/web-portal/lib/auth/admin.ts
+++ b/web-portal/lib/auth/admin.ts
@@ -1,5 +1,5 @@
 import { getSession, type Session } from '@/lib/auth/session'
-import { isStaff } from '@/lib/auth/roles'
+import { hasAtLeast, isStaff, type AccountRole } from '@/lib/auth/roles'
 
 // Helper unifié pour les 14 routes /api/admin/*. Avant cette refactor,
 // chaque route déclarait localement un `checkAdmin()` qui faisait
@@ -21,5 +21,22 @@ export async function requireAdmin(): Promise<Session> {
   const session = await getSession()
   if (!session) return null
   if (!isStaff(session.role)) return null
+  return session
+}
+
+// Variante granulaire : exige un rôle >= `minimum` dans la hiérarchie
+// player(0) < moderator(1) < game_master(2) < administrator(3).
+// Le rôle est re-lu en base par getSession() (le cookie ne porte aucune autorité).
+// Durcir une route avec un `minimum` plus élevé ne peut que RESTREINDRE l'accès :
+// les comptes staff hérités sont 'administrator' (migration 0043), donc aucun
+// verrouillage des admins existants ; la granularité ne s'active que pour des
+// comptes explicitement créés en 'moderator'/'game_master'.
+//
+// Retourne null si non authentifié OU rôle insuffisant (le caller renvoie alors
+// un 403), la Session complète sinon.
+export async function requireRole(minimum: AccountRole): Promise<Session> {
+  const session = await getSession()
+  if (!session) return null
+  if (!hasAtLeast(session.role, minimum)) return null
   return session
 }


### PR DESCRIPTION
## Contexte

Première vague du **Lot C** (câbler les sous-systèmes livrés mais jamais branchés au runtime — **aucune suppression**). Référence : `docs/audit/2026-06-13-lot-c-cablage.md`.

## Contenu (Vague 1A — faible risque, portail + éditeur)

### Portail
- **exploitTier.ts** : branche `bugReportThresholdsEligible` comme **garde-fou de cohérence** dans `PATCH /api/admin/bugs/[id]` — journalise une dérive seed SQL ↔ constante applicative. La requête SQL reste l'autorité (non destructif).
- **Hiérarchie de rôles** : ajoute `requireRole(min)` (`player < moderator < game_master < administrator`) à `lib/auth/admin.ts` et **reclasse les 14 routes** `/api/admin/*` :
  - **administrator** : disable / activate / verify-email comptes, force-rename, publish/retire CGU
  - **game_master** : bugs, roadmap, faq, brouillons CGU
  - **moderator** : consultation des personnages
  - `requireAdmin` conservé (alias rétro-compatible). **Durcissement strict** : les comptes staff hérités sont `administrator` (migration 0043) → **aucun verrouillage** d'admin existant ; la granularité ne s'active que pour des comptes explicitement créés `moderator`/`game_master`.

### Éditeur
- **AutoFitProxy (M100.12)** : câblé dans `CollisionEditorPanel` via un bouton « AutoFit depuis le mesh test » (remplace le stub désactivé). `AutoFitProxy.cpp` est déjà dans `engine_core` — pas de changement CMake.

## Déploiement

✅ **Portail + client (éditeur) uniquement — pas de redéploiement serveur master/shard.** Aucun opcode, handler, migration ni config serveur. (Le portail devra être redéployé pour la reclassification des rôles ; le binaire éditeur pour AutoFit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)