### PR TITLE
Lot C — Vague 4 : ZoneValidator + Diagnostic + QuickStartWizard (corrigé)

### DIFF
--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -20,9 +20,6 @@
 #include "src/world_editor/volumes/caves/CaveTool.h"
 #include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
 #include "src/world_editor/volumes/overhangs/OverhangTool.h"
-// Lot C vague 4 — loader du tutoriel « first_launch » (BuildFirstLaunchTutorial
-// via LoadTutorialById). Pur, compilé toutes plateformes.
-#include "src/world_editor/tutorial/TutorialIo.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -404,18 +401,7 @@ namespace engine::editor
 	// être visible ici pour que `std::unique_ptr<ZonePresetDialog>` puisse
 	// générer son cleanup d'exception. L'`#include` au top du fichier
 	// fournit le type complet.
-	WorldEditorImGui::WorldEditorImGui()
-	{
-		// Lot C vague 4 — Charge la définition du tutoriel « first_launch » dès la
-		// construction (logique pure, sans ImGui ni Vulkan : compilée sur toutes les
-		// plateformes). Le tutoriel n'est PAS démarré ici : le lancement est manuel
-		// via le menu « Aide → Lancer le tutoriel ». LoadTutorialById route vers
-		// BuildFirstLaunchTutorial pour le MVP (chargement JSON différé).
-		if (auto def = engine::editor::world::tutorial::LoadTutorialById("first_launch"))
-		{
-			m_tutorial.LoadTutorial(std::move(*def));
-		}
-	}
+	WorldEditorImGui::WorldEditorImGui() = default;
 
 	WorldEditorImGui::~WorldEditorImGui()
 	{
@@ -823,12 +809,6 @@ namespace engine::editor
 				m_widgetTargets.Register("menubar.file.export_runtime",
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
 					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
-				// Tutoriel — étape 8 (« Exporter ») cible l'id `menubar.file.export`
-				// (id exact de TutorialIo). Même widget que l'export runtime : on
-				// enregistre le rectangle sous ce second id pour le surlignage.
-				m_widgetTargets.Register("menubar.file.export",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				if (exportBlocked && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				{
 					ImGui::SetTooltip("Export bloque : corrigez les erreurs de validation (panneau Validation).");
@@ -850,10 +830,6 @@ namespace engine::editor
 					&& m_shell)
 				{
 					m_showWizard = true;
-					// Tutoriel — étape 1 (« Ouvre le dialog ») : l'assistant
-					// « Nouvelle zone » est l'autre porte d'entrée vers la création
-					// de zone ; il valide la même action `zone_preset_dialog.opened`.
-					m_overlay.NotifyAction("zone_preset_dialog.opened");
 				}
 				m_widgetTargets.Register("menubar.file.new_zone_wizard",
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
@@ -866,16 +842,7 @@ namespace engine::editor
 					&& m_shell && m_zonePresetDialog)
 				{
 					m_zonePresetDialog->Open();
-					// Tutoriel — étape 1 (« Ouvre le dialog ») : l'ouverture du
-					// dialog preset valide l'action `zone_preset_dialog.opened`.
-					m_overlay.NotifyAction("zone_preset_dialog.opened");
 				}
-				// Tutoriel — étape 1 cible ce widget (`menubar.file.new_from_preset`,
-				// id exact de TutorialIo). On enregistre son rectangle pour que le
-				// surlignage de l'overlay le pointe.
-				m_widgetTargets.Register("menubar.file.new_from_preset",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
 				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
 					&& m_session && m_cfg)
@@ -1031,17 +998,6 @@ namespace engine::editor
 			{
 				ImGui::MenuItem("Diagnostic (pourquoi ca ne marche pas ?)", nullptr,
 					&m_showDiagnosticPanel);
-				ImGui::Separator();
-				// Lot C vague 4 — Lance MANUELLEMENT le tutoriel interactif
-				// « first_launch » (8 étapes) via l'OverlayGuidanceSystem. Pas
-				// d'auto-lancement au premier démarrage dans cette tranche : la
-				// détection premier-lancement (UserPrefs) reste à câbler
-				// (auto-start différé). L'utilisateur peut TOUJOURS sortir via
-				// le bouton « Passer le tutoriel » du voile (cf. RenderGuidanceOverlay).
-				if (ImGui::MenuItem("Lancer le tutoriel (premier lancement)"))
-				{
-					m_tutorial.Start(m_overlay);
-				}
 				ImGui::EndMenu();
 			}
 			// Barre d'outils rapide a droite du menu : sauvegarde 1-clic + chargement carte.
@@ -1987,9 +1943,6 @@ namespace engine::editor
 			m_lastValidationReport = engine::editor::world::validation::ZoneValidator::Report{};
 			m_validationHasRun = true;
 			m_showValidationPanel = true;
-			// Tutoriel — étape 7 : même sans shell/config, le panneau Validation
-			// s'ouvre -> on valide l'action pour ne pas bloquer la progression.
-			m_overlay.NotifyAction("panel.validation.opened");
 			LOG_WARN(Render,
 				"[WorldEditorImGui] Validation impossible : shell ou config non branche.");
 			return;
@@ -2055,11 +2008,6 @@ namespace engine::editor
 		m_lastValidationReport = m_zoneValidator.Validate(ctx);
 		m_validationHasRun = true;
 		m_showValidationPanel = true;
-		// Tutoriel — étape 7 (« Valide ta zone ») : valider ouvre le panneau
-		// Validation -> valide l'action `panel.validation.opened`. Appel pur
-		// (logique seule) : compilé cross-plateforme comme cette fonction. No-op
-		// si aucune séquence tutoriel n'est active.
-		m_overlay.NotifyAction("panel.validation.opened");
 		LOG_INFO(Render,
 			"[WorldEditorImGui] Validation zone : {} erreur(s), {} avertissement(s), {} indice(s) "
 			"sur {} chunk(s) terrain, {} mesh insert(s).",
@@ -2264,12 +2212,6 @@ namespace engine::editor
 		m_wizardLastPresetId = preset.id;
 		m_wizardHasGenerated = true;
 
-		// Tutoriel — étape 3 (« Crée la zone ») : la génération via l'assistant
-		// produit effectivement la zone -> valide l'action `zone.created`. Appel
-		// pur (logique seule, sans ImGui) : compilé cross-plateforme comme le reste
-		// de cette fonction. No-op si aucune séquence tutoriel n'est active.
-		m_overlay.NotifyAction("zone.created");
-
 		LOG_INFO(Render,
 			"[WorldEditorImGui] Wizard '{}' termine (pushed={}, skipped={}, failed={}, annule={}).",
 			preset.id, m_wizardLastSummary.commandsPushed,
@@ -2423,47 +2365,6 @@ namespace engine::editor
 			ImVec2(bubbleMin.x + pad.x, bubbleMin.y + pad.y * 2.f + titleH),
 			IM_COL32(230, 230, 230, 255),
 			instr.bodyFr.c_str(), nullptr, bubbleW - pad.x * 2.f);
-
-		// ── PRINCIPE DE SÉCURITÉ : sorties manuelles TOUJOURS disponibles ──────
-		// Le voile pourrait sinon piéger l'utilisateur si un `NotifyAction` n'est
-		// jamais émis (étape dont le site UI n'est pas instrumenté). On expose donc
-		// EN PERMANENCE deux boutons cliquables :
-		//   - « Étape suivante » → `m_overlay.AdvanceStep()` (avance même sans action) ;
-		//   - « Passer le tutoriel » → `m_overlay.AbortSequence()` (sort du voile).
-		// Ces boutons sont des widgets ImGui réels (pas du draw-list brut) pour
-		// capter le clic. La fenêtre hôte est sans décoration, ancrée en bas-droite
-		// du viewport, au-dessus du voile (TopMost via le foreground n'étant pas
-		// cliquable, on s'appuie sur l'ordre de rendu : cette fenêtre est dessinée
-		// après le dockspace, donc reçoit les clics).
-		const float kBtnPanelW = 320.f;
-		const float kBtnPanelH = 56.f;
-		ImGui::SetNextWindowPos(
-			ImVec2(vpMax.x - kBtnPanelW - 24.f, vpMax.y - kBtnPanelH - 24.f),
-			ImGuiCond_Always);
-		ImGui::SetNextWindowSize(ImVec2(kBtnPanelW, kBtnPanelH), ImGuiCond_Always);
-		ImGui::SetNextWindowBgAlpha(0.92f);
-		const ImGuiWindowFlags ctrlFlags =
-			ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
-			ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
-			ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavInputs |
-			ImGuiWindowFlags_NoDocking;
-		if (ImGui::Begin("##tutorial_controls", nullptr, ctrlFlags))
-		{
-			// Étape N/Total pour situer l'utilisateur (1-based à l'affichage).
-			ImGui::Text("Etape %zu / %zu",
-				m_overlay.CurrentIndex() + 1u, m_overlay.StepCount());
-			ImGui::SameLine();
-			if (ImGui::Button("Etape suivante"))
-			{
-				m_overlay.AdvanceStep();
-			}
-			ImGui::SameLine();
-			if (ImGui::Button("Passer le tutoriel"))
-			{
-				m_overlay.AbortSequence();
-			}
-		}
-		ImGui::End();
 	}
 
 	void WorldEditorImGui::RenderDiagnosticPanel()

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -11,15 +11,6 @@
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/zone_presets/ZonePresetDialog.h"
-// Lot C vague 4 — assistant « Nouvelle zone » : exécution d'un ZonePreset résolu
-// par le wizard via le MÊME chemin que le ZonePresetDialog (executor + dispatch
-// context construit depuis les outils/catalogs du Shell).
-#include "src/world_editor/zone_presets/OperationDispatcher.h"
-#include "src/world_editor/zone_presets/ZonePreset.h"
-#include "src/world_editor/volumes/arches/ArchTool.h"
-#include "src/world_editor/volumes/caves/CaveTool.h"
-#include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
-#include "src/world_editor/volumes/overhangs/OverhangTool.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -38,7 +29,6 @@
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <utility>
 #include <vector>
 
 #if defined(_WIN32)
@@ -822,18 +812,6 @@ namespace engine::editor
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
 					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
-				// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard).
-				// Désactivé si le Shell n'est pas branché (la génération a besoin
-				// des 4 documents + catalogs + CommandStack, comme le dialog preset).
-				if (ImGui::MenuItem("Nouvelle zone (assistant)...", nullptr, false,
-					m_shell != nullptr)
-					&& m_shell)
-				{
-					m_showWizard = true;
-				}
-				m_widgetTargets.Register("menubar.file.new_zone_wizard",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
 				// Preset. Désactivée si le Shell n'est pas branché (le
 				// dialog a besoin des 4 documents + catalogs).
@@ -1917,10 +1895,6 @@ namespace engine::editor
 		// Rendu avant l'overlay de guidance pour que ce dernier (foreground draw
 		// list) puisse, le cas échéant, le surligner comme cible de tutoriel.
 		RenderDiagnosticPanel();
-		// Lot C vague 4 — Fenêtre de l'assistant « Nouvelle zone » (no-op si
-		// fermée). Rendue avant l'overlay de guidance pour que ce dernier puisse,
-		// le cas échéant, surligner ses widgets comme cibles de tutoriel.
-		RenderWizardWindow();
 		RenderGuidanceOverlay();
 
 		ImGui::Render();
@@ -2130,93 +2104,6 @@ namespace engine::editor
 		// silencieuses (comportement voulu — mieux que des suggestions fantaisistes).
 
 		return ctx;
-	}
-
-	// ─────────────────────────────────────────────────────────────────────────
-	// Lot C vague 4 — Assistant « Nouvelle zone » (QuickStartWizard).
-	// RunWizardGeneration est CROSS-PLATFORM (hors garde _WIN32, comme
-	// RunZoneValidation / BuildDiagnosticContext) : tous les types y sont
-	// pleinement qualifiés (le build Linux compile cette fonction).
-	//
-	// NOTE P0 (rollback transactionnel) — partagée avec le ZonePresetDialog :
-	// `ZonePresetExecutor::Execute` commence par VIDER les 4 documents de la
-	// zone (terrain / water / mesh inserts / portails de donjon) via
-	// `ResetEditedZoneDocuments`. Ce reset est DESTRUCTIF et NON annulable (il
-	// n'est pas poussé comme commande sur le CommandStack). Si l'exécution
-	// échoue en plein milieu, la zone précédente est déjà perdue. Un rollback
-	// transactionnel (snapshot avant reset + restauration sur échec/annulation)
-	// est un follow-up P0 qui bénéficierait aux DEUX points d'entrée — le dialog
-	// preset ET cet assistant — puisqu'ils partagent le même `ZonePresetExecutor`.
-	// En attendant, les deux UI affichent une modale de confirmation explicite
-	// recommandant de sauvegarder d'abord.
-	// ─────────────────────────────────────────────────────────────────────────
-	void WorldEditorImGui::RunWizardGeneration()
-	{
-		// Sans shell branché, aucun document cible : on ne génère rien (le menu
-		// est déjà désactivé dans ce cas, ceci est une garde défensive).
-		if (m_shell == nullptr)
-		{
-			LOG_WARN(Render,
-				"[WorldEditorImGui] Generation wizard impossible : shell non branche.");
-			return;
-		}
-
-		namespace zp     = engine::editor::world::zone_presets;
-		namespace wizard = engine::editor::world::wizard;
-
-		// 1) Choix du wizard → ZonePreset (résolution déterministe, id dérivé des
-		//    choix). Le seed UI est déjà recopié dans le wizard via SetSeed.
-		const wizard::WizardChoices& choices = m_wizard.Choices();
-		const zp::ZonePreset preset = m_wizardResolver.Resolve(choices);
-
-		// 2) Customisation : le wizard ne porte pas de curseurs relief/eau/dryness
-		//    (ils sont encodés dans le template résolu). On laisse les
-		//    multiplicateurs neutres (1.0) et on propage le seed du wizard, comme
-		//    le ZonePresetDialog le fait pour son propre champ seed.
-		zp::CustomizationParams custom;
-		custom.reliefMultiplier       = 1.0f;
-		custom.waterDensityMultiplier = 1.0f;
-		custom.drynessMultiplier      = 1.0f;
-		custom.seed                   = choices.seed;
-
-		// 3) DispatchContext construit EXACTEMENT comme dans
-		//    ZonePresetDialog::RunSelectedPreset (mêmes documents, mêmes catalogs,
-		//    même Config pour les 4 ops simulation). Réutilisation du chemin
-		//    canonique : aucune divergence de câblage entre dialog et wizard.
-		const zp::DispatchContext ctx{
-			m_shell->MutableTerrainDocument(),
-			m_shell->MutableWaterDocument(),
-			m_shell->MutableMeshInsertDocument(),
-			m_shell->MutableDungeonPortalDocument(),
-			m_shell->GetCaveTool().Catalog(),
-			m_shell->GetOverhangTool().Catalog(),
-			m_shell->GetArchTool().Catalog(),
-			m_shell->GetDungeonPortalTool().Catalog(),
-			m_cfg,  // requis par les 4 ops simulation ; si null elles renvoient Failed.
-		};
-
-		LOG_INFO(Render,
-			"[WorldEditorImGui] Wizard genere '{}' (climat={} relief={} cote={} poi={} seed={})",
-			preset.id, choices.climate, choices.relief, choices.coast, choices.poi,
-			choices.seed);
-
-		// 4) Exécution synchrone sur le CommandStack du Shell (main thread bloqué
-		//    le temps de l'exécution — convention single-thread éditeur, cf.
-		//    ZonePresetExecutor.h). Callback de progression inerte (on ne peut pas
-		//    pumper ImGui pendant Execute) ; la progression part au log.
-		zp::ZonePresetExecutor executor;
-		m_wizardLastSummary = executor.Execute(preset, custom,
-			m_shell->MutableCommandStack(), ctx,
-			[](const zp::ExecutionProgress&) { return true; });
-
-		m_wizardLastPresetId = preset.id;
-		m_wizardHasGenerated = true;
-
-		LOG_INFO(Render,
-			"[WorldEditorImGui] Wizard '{}' termine (pushed={}, skipped={}, failed={}, annule={}).",
-			preset.id, m_wizardLastSummary.commandsPushed,
-			m_wizardLastSummary.unsupportedSkipped, m_wizardLastSummary.failed,
-			m_wizardLastSummary.wasCancelled ? "oui" : "non");
 	}
 
 #if defined(_WIN32)
@@ -2454,236 +2341,10 @@ namespace engine::editor
 
 		ImGui::End();
 	}
-
-	namespace
-	{
-		/// Dessine une rangée de cartes de choix pour une étape du wizard.
-		/// Chaque carte est un `Selectable` qui, au clic, applique la valeur
-		/// associée via `SetChoiceForCurrentStep`. La carte correspondant à la
-		/// valeur courante est mise en évidence (cadre actif ImGui).
-		/// \param wizard       machine d'état du wizard (modifiée au clic).
-		/// \param currentValue valeur actuellement retenue pour cette étape
-		///                     (issue de `wizard.Choices()`), pour le surlignage.
-		/// \param options      paires {valeur interne, libellé FR affiché}.
-		/// Effet de bord : appelle `wizard.SetChoiceForCurrentStep` au clic
-		/// (modifie les choix). À appeler en main thread (rendu ImGui).
-		void DrawWizardChoiceCards(
-			engine::editor::world::wizard::QuickStartWizard& wizard,
-			const std::string& currentValue,
-			const std::vector<std::pair<const char*, const char*>>& options)
-		{
-			for (size_t i = 0; i < options.size(); ++i)
-			{
-				const char* value = options[i].first;
-				const char* label = options[i].second;
-				const bool selected = (currentValue == value);
-				ImGui::PushID(static_cast<int>(i));
-				// Carte de largeur fixe, alignées horizontalement (3-4 par étape).
-				if (ImGui::Selectable(label, selected, 0, ImVec2(150.0f, 60.0f)))
-				{
-					(void)wizard.SetChoiceForCurrentStep(value);
-				}
-				ImGui::PopID();
-				if (i + 1 < options.size())
-				{
-					ImGui::SameLine();
-				}
-			}
-		}
-	} // namespace
-
-	/// Rend la fenêtre de l'assistant « Nouvelle zone » (5 étapes) + sa modale
-	/// de confirmation de génération. Doit être appelée chaque frame depuis
-	/// BuildUi. Effet de bord : ImGui state ; déclenche `RunWizardGeneration`
-	/// à la confirmation de la modale.
-	void WorldEditorImGui::RenderWizardWindow()
-	{
-		if (!m_showWizard)
-		{
-			return;
-		}
-
-		namespace wizard = engine::editor::world::wizard;
-
-		ImGui::SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond_FirstUseEver);
-		if (!ImGui::Begin("Nouvelle zone (assistant)", &m_showWizard,
-			ImGuiWindowFlags_NoSavedSettings))
-		{
-			ImGui::End();
-			return;
-		}
-
-		const wizard::WizardStep step = m_wizard.CurrentStep();
-		const wizard::WizardChoices& choices = m_wizard.Choices();
-
-		// En-tête : numéro et nom de l'étape courante (5 étapes au total).
-		static const char* kStepNames[5] = {
-			"1/5 - Climat", "2/5 - Relief", "3/5 - Cote", "4/5 - Points d'interet",
-			"5/5 - Apercu" };
-		const int stepIdx = static_cast<int>(step);
-		ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f), "Etape %s",
-			kStepNames[stepIdx < 0 || stepIdx > 4 ? 4 : stepIdx]);
-		ImGui::Separator();
-
-		// Corps : cartes de choix selon l'étape, ou récapitulatif à l'Aperçu.
-		switch (step)
-		{
-		case wizard::WizardStep::Climate:
-			ImGui::TextWrapped("Choisis le climat dominant de la zone.");
-			ImGui::Spacing();
-			DrawWizardChoiceCards(m_wizard, choices.climate, {
-				{ "temperate", "Tempere" }, { "arid", "Aride" },
-				{ "polar", "Polaire" }, { "tropical", "Tropical" } });
-			break;
-		case wizard::WizardStep::Relief:
-			ImGui::TextWrapped("Choisis le relief general du terrain.");
-			ImGui::Spacing();
-			DrawWizardChoiceCards(m_wizard, choices.relief, {
-				{ "plains", "Plaines" }, { "hills", "Collines" },
-				{ "mountains", "Montagnes" }, { "escarped", "Escarpe" } });
-			break;
-		case wizard::WizardStep::Coast:
-			ImGui::TextWrapped("Quel rapport la zone a-t-elle a la cote ?");
-			ImGui::Spacing();
-			DrawWizardChoiceCards(m_wizard, choices.coast, {
-				{ "interior", "Interieur" }, { "moderate", "Cote moderee" },
-				{ "dramatic", "Cote spectaculaire" } });
-			break;
-		case wizard::WizardStep::Poi:
-			ImGui::TextWrapped("Ajoute un point d'interet principal (optionnel).");
-			ImGui::Spacing();
-			DrawWizardChoiceCards(m_wizard, choices.poi, {
-				{ "none", "Aucun" }, { "cave", "Grotte" },
-				{ "ruin", "Ruine" }, { "dungeon", "Donjon" } });
-			break;
-		case wizard::WizardStep::Preview:
-		default:
-			ImGui::TextWrapped("Recapitulatif des choix. Ajuste le seed puis genere "
-				"la zone.");
-			ImGui::Spacing();
-			ImGui::BulletText("Climat : %s", choices.climate.c_str());
-			ImGui::BulletText("Relief : %s", choices.relief.c_str());
-			ImGui::BulletText("Cote   : %s", choices.coast.c_str());
-			ImGui::BulletText("POI    : %s", choices.poi.c_str());
-			ImGui::Spacing();
-			// Champ seed → SetSeed (le wizard ne valide pas le seed).
-			if (ImGui::InputInt("Seed RNG", &m_wizardSeed, 1, 100))
-			{
-				if (m_wizardSeed < 0) m_wizardSeed = 0;
-				m_wizard.SetSeed(static_cast<uint32_t>(m_wizardSeed));
-			}
-			break;
-		}
-
-		// Pied de page : navigation + (à l'Aperçu) bouton Générer.
-		ImGui::Separator();
-
-		// Précédent : actif sauf à la 1re étape.
-		const bool canPrev = (step != wizard::WizardStep::Climate);
-		if (!canPrev) ImGui::BeginDisabled();
-		if (ImGui::Button("Precedent", ImVec2(120.0f, 0.0f)) && canPrev)
-		{
-			(void)m_wizard.Prev();
-		}
-		if (!canPrev) ImGui::EndDisabled();
-
-		ImGui::SameLine();
-
-		if (step != wizard::WizardStep::Preview)
-		{
-			// Suivant : gardé par CanProceed (choix valide pour l'étape courante).
-			const bool canNext = m_wizard.CanProceed();
-			if (!canNext) ImGui::BeginDisabled();
-			if (ImGui::Button("Suivant", ImVec2(120.0f, 0.0f)) && canNext)
-			{
-				(void)m_wizard.Next();
-			}
-			if (!canNext) ImGui::EndDisabled();
-			if (!canNext && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-			{
-				ImGui::SetTooltip("Selectionne un choix pour continuer.");
-			}
-		}
-		else
-		{
-			// Étape Aperçu : bouton Générer actif seulement si prêt.
-			const bool canGenerate = m_wizard.IsReadyToGenerate();
-			if (!canGenerate) ImGui::BeginDisabled();
-			if (ImGui::Button("Generer", ImVec2(120.0f, 0.0f)) && canGenerate)
-			{
-				// Demande la modale de confirmation (poussée plus bas, hors de la
-				// pile de widgets disabled).
-				m_wizardConfirmRequested = true;
-			}
-			if (!canGenerate) ImGui::EndDisabled();
-		}
-
-		ImGui::SameLine();
-		if (ImGui::Button("Fermer", ImVec2(120.0f, 0.0f)))
-		{
-			m_showWizard = false;
-		}
-
-		// Bandeau de résumé de la dernière génération (sous le pied de page).
-		if (m_wizardHasGenerated)
-		{
-			ImGui::Separator();
-			ImGui::Text("Derniere generation : '%s'", m_wizardLastPresetId.c_str());
-			ImGui::Text("Commandes poussees : %u  -  Ignorees : %u  -  Echecs : %u",
-				m_wizardLastSummary.commandsPushed,
-				m_wizardLastSummary.unsupportedSkipped,
-				m_wizardLastSummary.failed);
-			if (m_wizardLastSummary.unsupportedSkipped > 0u)
-			{
-				ImGui::TextWrapped("Note : %u operation(s) non supportee(s) ont ete "
-					"ignorees (coastline / river_network / hydraulic_erosion / "
-					"thermal_wind_erosion sans chemin d'execution complet ici).",
-					m_wizardLastSummary.unsupportedSkipped);
-			}
-		}
-
-		// Ouverture de la modale de confirmation (au prochain frame après le clic
-		// « Generer »). On la pousse hors de tout bloc disabled.
-		if (m_wizardConfirmRequested)
-		{
-			ImGui::OpenPopup("Confirmer la generation##wizard_confirm");
-			m_wizardConfirmRequested = false;
-		}
-
-		// Modale de confirmation : la génération RÉINITIALISE la zone courante
-		// (reset destructif de l'executor, non annulable — P0 connu partagé avec
-		// le ZonePresetDialog). On recommande de sauvegarder d'abord.
-		if (ImGui::BeginPopupModal("Confirmer la generation##wizard_confirm", nullptr,
-			ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
-		{
-			ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f),
-				"ATTENTION : action destructive et NON annulable.");
-			ImGui::Spacing();
-			ImGui::TextWrapped("La generation VIDE la zone courante (terrain, eau, "
-				"mesh inserts, portails de donjon) avant de la reconstruire. Cette "
-				"reinitialisation n'est pas annulable (Ctrl+Z ne la restaurera pas). "
-				"Sauvegarde la zone avant de continuer si tu veux la conserver.");
-			ImGui::Separator();
-			if (ImGui::Button("Generer (vider et reconstruire)", ImVec2(260.0f, 0.0f)))
-			{
-				RunWizardGeneration();
-				ImGui::CloseCurrentPopup();
-			}
-			ImGui::SameLine();
-			if (ImGui::Button("Annuler", ImVec2(120.0f, 0.0f)))
-			{
-				ImGui::CloseCurrentPopup();
-			}
-			ImGui::EndPopup();
-		}
-
-		ImGui::End();
-	}
 #else
 	void WorldEditorImGui::RenderValidationPanel() {}
 	void WorldEditorImGui::RenderGuidanceOverlay() {}
 	void WorldEditorImGui::RenderDiagnosticPanel() {}
-	void WorldEditorImGui::RenderWizardWindow() {}
 #endif
 
 	bool WorldEditorImGui::WantsCaptureMouse() const

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -11,6 +11,15 @@
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/zone_presets/ZonePresetDialog.h"
+// Lot C vague 4 — assistant « Nouvelle zone » : exécution d'un ZonePreset résolu
+// par le wizard via le MÊME chemin que le ZonePresetDialog (executor + dispatch
+// context construit depuis les outils/catalogs du Shell).
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+#include "src/world_editor/volumes/arches/ArchTool.h"
+#include "src/world_editor/volumes/caves/CaveTool.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
+#include "src/world_editor/volumes/overhangs/OverhangTool.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -29,6 +38,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #if defined(_WIN32)
@@ -812,6 +822,18 @@ namespace engine::editor
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
 					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
+				// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard).
+				// Désactivé si le Shell n'est pas branché (la génération a besoin
+				// des 4 documents + catalogs + CommandStack, comme le dialog preset).
+				if (ImGui::MenuItem("Nouvelle zone (assistant)...", nullptr, false,
+					m_shell != nullptr)
+					&& m_shell)
+				{
+					m_showWizard = true;
+				}
+				m_widgetTargets.Register("menubar.file.new_zone_wizard",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
 				// Preset. Désactivée si le Shell n'est pas branché (le
 				// dialog a besoin des 4 documents + catalogs).
@@ -1895,6 +1917,10 @@ namespace engine::editor
 		// Rendu avant l'overlay de guidance pour que ce dernier (foreground draw
 		// list) puisse, le cas échéant, le surligner comme cible de tutoriel.
 		RenderDiagnosticPanel();
+		// Lot C vague 4 — Fenêtre de l'assistant « Nouvelle zone » (no-op si
+		// fermée). Rendue avant l'overlay de guidance pour que ce dernier puisse,
+		// le cas échéant, surligner ses widgets comme cibles de tutoriel.
+		RenderWizardWindow();
 		RenderGuidanceOverlay();
 
 		ImGui::Render();
@@ -2104,6 +2130,93 @@ namespace engine::editor
 		// silencieuses (comportement voulu — mieux que des suggestions fantaisistes).
 
 		return ctx;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Lot C vague 4 — Assistant « Nouvelle zone » (QuickStartWizard).
+	// RunWizardGeneration est CROSS-PLATFORM (hors garde _WIN32, comme
+	// RunZoneValidation / BuildDiagnosticContext) : tous les types y sont
+	// pleinement qualifiés (le build Linux compile cette fonction).
+	//
+	// NOTE P0 (rollback transactionnel) — partagée avec le ZonePresetDialog :
+	// `ZonePresetExecutor::Execute` commence par VIDER les 4 documents de la
+	// zone (terrain / water / mesh inserts / portails de donjon) via
+	// `ResetEditedZoneDocuments`. Ce reset est DESTRUCTIF et NON annulable (il
+	// n'est pas poussé comme commande sur le CommandStack). Si l'exécution
+	// échoue en plein milieu, la zone précédente est déjà perdue. Un rollback
+	// transactionnel (snapshot avant reset + restauration sur échec/annulation)
+	// est un follow-up P0 qui bénéficierait aux DEUX points d'entrée — le dialog
+	// preset ET cet assistant — puisqu'ils partagent le même `ZonePresetExecutor`.
+	// En attendant, les deux UI affichent une modale de confirmation explicite
+	// recommandant de sauvegarder d'abord.
+	// ─────────────────────────────────────────────────────────────────────────
+	void WorldEditorImGui::RunWizardGeneration()
+	{
+		// Sans shell branché, aucun document cible : on ne génère rien (le menu
+		// est déjà désactivé dans ce cas, ceci est une garde défensive).
+		if (m_shell == nullptr)
+		{
+			LOG_WARN(Render,
+				"[WorldEditorImGui] Generation wizard impossible : shell non branche.");
+			return;
+		}
+
+		namespace zp     = engine::editor::world::zone_presets;
+		namespace wizard = engine::editor::world::wizard;
+
+		// 1) Choix du wizard → ZonePreset (résolution déterministe, id dérivé des
+		//    choix). Le seed UI est déjà recopié dans le wizard via SetSeed.
+		const wizard::WizardChoices& choices = m_wizard.Choices();
+		const zp::ZonePreset preset = m_wizardResolver.Resolve(choices);
+
+		// 2) Customisation : le wizard ne porte pas de curseurs relief/eau/dryness
+		//    (ils sont encodés dans le template résolu). On laisse les
+		//    multiplicateurs neutres (1.0) et on propage le seed du wizard, comme
+		//    le ZonePresetDialog le fait pour son propre champ seed.
+		zp::CustomizationParams custom;
+		custom.reliefMultiplier       = 1.0f;
+		custom.waterDensityMultiplier = 1.0f;
+		custom.drynessMultiplier      = 1.0f;
+		custom.seed                   = choices.seed;
+
+		// 3) DispatchContext construit EXACTEMENT comme dans
+		//    ZonePresetDialog::RunSelectedPreset (mêmes documents, mêmes catalogs,
+		//    même Config pour les 4 ops simulation). Réutilisation du chemin
+		//    canonique : aucune divergence de câblage entre dialog et wizard.
+		const zp::DispatchContext ctx{
+			m_shell->MutableTerrainDocument(),
+			m_shell->MutableWaterDocument(),
+			m_shell->MutableMeshInsertDocument(),
+			m_shell->MutableDungeonPortalDocument(),
+			m_shell->GetCaveTool().Catalog(),
+			m_shell->GetOverhangTool().Catalog(),
+			m_shell->GetArchTool().Catalog(),
+			m_shell->GetDungeonPortalTool().Catalog(),
+			m_cfg,  // requis par les 4 ops simulation ; si null elles renvoient Failed.
+		};
+
+		LOG_INFO(Render,
+			"[WorldEditorImGui] Wizard genere '{}' (climat={} relief={} cote={} poi={} seed={})",
+			preset.id, choices.climate, choices.relief, choices.coast, choices.poi,
+			choices.seed);
+
+		// 4) Exécution synchrone sur le CommandStack du Shell (main thread bloqué
+		//    le temps de l'exécution — convention single-thread éditeur, cf.
+		//    ZonePresetExecutor.h). Callback de progression inerte (on ne peut pas
+		//    pumper ImGui pendant Execute) ; la progression part au log.
+		zp::ZonePresetExecutor executor;
+		m_wizardLastSummary = executor.Execute(preset, custom,
+			m_shell->MutableCommandStack(), ctx,
+			[](const zp::ExecutionProgress&) { return true; });
+
+		m_wizardLastPresetId = preset.id;
+		m_wizardHasGenerated = true;
+
+		LOG_INFO(Render,
+			"[WorldEditorImGui] Wizard '{}' termine (pushed={}, skipped={}, failed={}, annule={}).",
+			preset.id, m_wizardLastSummary.commandsPushed,
+			m_wizardLastSummary.unsupportedSkipped, m_wizardLastSummary.failed,
+			m_wizardLastSummary.wasCancelled ? "oui" : "non");
 	}
 
 #if defined(_WIN32)
@@ -2341,10 +2454,236 @@ namespace engine::editor
 
 		ImGui::End();
 	}
+
+	namespace
+	{
+		/// Dessine une rangée de cartes de choix pour une étape du wizard.
+		/// Chaque carte est un `Selectable` qui, au clic, applique la valeur
+		/// associée via `SetChoiceForCurrentStep`. La carte correspondant à la
+		/// valeur courante est mise en évidence (cadre actif ImGui).
+		/// \param wizard       machine d'état du wizard (modifiée au clic).
+		/// \param currentValue valeur actuellement retenue pour cette étape
+		///                     (issue de `wizard.Choices()`), pour le surlignage.
+		/// \param options      paires {valeur interne, libellé FR affiché}.
+		/// Effet de bord : appelle `wizard.SetChoiceForCurrentStep` au clic
+		/// (modifie les choix). À appeler en main thread (rendu ImGui).
+		void DrawWizardChoiceCards(
+			engine::editor::world::wizard::QuickStartWizard& wizard,
+			const std::string& currentValue,
+			const std::vector<std::pair<const char*, const char*>>& options)
+		{
+			for (size_t i = 0; i < options.size(); ++i)
+			{
+				const char* value = options[i].first;
+				const char* label = options[i].second;
+				const bool selected = (currentValue == value);
+				ImGui::PushID(static_cast<int>(i));
+				// Carte de largeur fixe, alignées horizontalement (3-4 par étape).
+				if (ImGui::Selectable(label, selected, 0, ImVec2(150.0f, 60.0f)))
+				{
+					(void)wizard.SetChoiceForCurrentStep(value);
+				}
+				ImGui::PopID();
+				if (i + 1 < options.size())
+				{
+					ImGui::SameLine();
+				}
+			}
+		}
+	} // namespace
+
+	/// Rend la fenêtre de l'assistant « Nouvelle zone » (5 étapes) + sa modale
+	/// de confirmation de génération. Doit être appelée chaque frame depuis
+	/// BuildUi. Effet de bord : ImGui state ; déclenche `RunWizardGeneration`
+	/// à la confirmation de la modale.
+	void WorldEditorImGui::RenderWizardWindow()
+	{
+		if (!m_showWizard)
+		{
+			return;
+		}
+
+		namespace wizard = engine::editor::world::wizard;
+
+		ImGui::SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond_FirstUseEver);
+		if (!ImGui::Begin("Nouvelle zone (assistant)", &m_showWizard,
+			ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::End();
+			return;
+		}
+
+		const wizard::WizardStep step = m_wizard.CurrentStep();
+		const wizard::WizardChoices& choices = m_wizard.Choices();
+
+		// En-tête : numéro et nom de l'étape courante (5 étapes au total).
+		static const char* kStepNames[5] = {
+			"1/5 - Climat", "2/5 - Relief", "3/5 - Cote", "4/5 - Points d'interet",
+			"5/5 - Apercu" };
+		const int stepIdx = static_cast<int>(step);
+		ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f), "Etape %s",
+			kStepNames[stepIdx < 0 || stepIdx > 4 ? 4 : stepIdx]);
+		ImGui::Separator();
+
+		// Corps : cartes de choix selon l'étape, ou récapitulatif à l'Aperçu.
+		switch (step)
+		{
+		case wizard::WizardStep::Climate:
+			ImGui::TextWrapped("Choisis le climat dominant de la zone.");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.climate, {
+				{ "temperate", "Tempere" }, { "arid", "Aride" },
+				{ "polar", "Polaire" }, { "tropical", "Tropical" } });
+			break;
+		case wizard::WizardStep::Relief:
+			ImGui::TextWrapped("Choisis le relief general du terrain.");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.relief, {
+				{ "plains", "Plaines" }, { "hills", "Collines" },
+				{ "mountains", "Montagnes" }, { "escarped", "Escarpe" } });
+			break;
+		case wizard::WizardStep::Coast:
+			ImGui::TextWrapped("Quel rapport la zone a-t-elle a la cote ?");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.coast, {
+				{ "interior", "Interieur" }, { "moderate", "Cote moderee" },
+				{ "dramatic", "Cote spectaculaire" } });
+			break;
+		case wizard::WizardStep::Poi:
+			ImGui::TextWrapped("Ajoute un point d'interet principal (optionnel).");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.poi, {
+				{ "none", "Aucun" }, { "cave", "Grotte" },
+				{ "ruin", "Ruine" }, { "dungeon", "Donjon" } });
+			break;
+		case wizard::WizardStep::Preview:
+		default:
+			ImGui::TextWrapped("Recapitulatif des choix. Ajuste le seed puis genere "
+				"la zone.");
+			ImGui::Spacing();
+			ImGui::BulletText("Climat : %s", choices.climate.c_str());
+			ImGui::BulletText("Relief : %s", choices.relief.c_str());
+			ImGui::BulletText("Cote   : %s", choices.coast.c_str());
+			ImGui::BulletText("POI    : %s", choices.poi.c_str());
+			ImGui::Spacing();
+			// Champ seed → SetSeed (le wizard ne valide pas le seed).
+			if (ImGui::InputInt("Seed RNG", &m_wizardSeed, 1, 100))
+			{
+				if (m_wizardSeed < 0) m_wizardSeed = 0;
+				m_wizard.SetSeed(static_cast<uint32_t>(m_wizardSeed));
+			}
+			break;
+		}
+
+		// Pied de page : navigation + (à l'Aperçu) bouton Générer.
+		ImGui::Separator();
+
+		// Précédent : actif sauf à la 1re étape.
+		const bool canPrev = (step != wizard::WizardStep::Climate);
+		if (!canPrev) ImGui::BeginDisabled();
+		if (ImGui::Button("Precedent", ImVec2(120.0f, 0.0f)) && canPrev)
+		{
+			(void)m_wizard.Prev();
+		}
+		if (!canPrev) ImGui::EndDisabled();
+
+		ImGui::SameLine();
+
+		if (step != wizard::WizardStep::Preview)
+		{
+			// Suivant : gardé par CanProceed (choix valide pour l'étape courante).
+			const bool canNext = m_wizard.CanProceed();
+			if (!canNext) ImGui::BeginDisabled();
+			if (ImGui::Button("Suivant", ImVec2(120.0f, 0.0f)) && canNext)
+			{
+				(void)m_wizard.Next();
+			}
+			if (!canNext) ImGui::EndDisabled();
+			if (!canNext && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+			{
+				ImGui::SetTooltip("Selectionne un choix pour continuer.");
+			}
+		}
+		else
+		{
+			// Étape Aperçu : bouton Générer actif seulement si prêt.
+			const bool canGenerate = m_wizard.IsReadyToGenerate();
+			if (!canGenerate) ImGui::BeginDisabled();
+			if (ImGui::Button("Generer", ImVec2(120.0f, 0.0f)) && canGenerate)
+			{
+				// Demande la modale de confirmation (poussée plus bas, hors de la
+				// pile de widgets disabled).
+				m_wizardConfirmRequested = true;
+			}
+			if (!canGenerate) ImGui::EndDisabled();
+		}
+
+		ImGui::SameLine();
+		if (ImGui::Button("Fermer", ImVec2(120.0f, 0.0f)))
+		{
+			m_showWizard = false;
+		}
+
+		// Bandeau de résumé de la dernière génération (sous le pied de page).
+		if (m_wizardHasGenerated)
+		{
+			ImGui::Separator();
+			ImGui::Text("Derniere generation : '%s'", m_wizardLastPresetId.c_str());
+			ImGui::Text("Commandes poussees : %u  -  Ignorees : %u  -  Echecs : %u",
+				m_wizardLastSummary.commandsPushed,
+				m_wizardLastSummary.unsupportedSkipped,
+				m_wizardLastSummary.failed);
+			if (m_wizardLastSummary.unsupportedSkipped > 0u)
+			{
+				ImGui::TextWrapped("Note : %u operation(s) non supportee(s) ont ete "
+					"ignorees (coastline / river_network / hydraulic_erosion / "
+					"thermal_wind_erosion sans chemin d'execution complet ici).",
+					m_wizardLastSummary.unsupportedSkipped);
+			}
+		}
+
+		// Ouverture de la modale de confirmation (au prochain frame après le clic
+		// « Generer »). On la pousse hors de tout bloc disabled.
+		if (m_wizardConfirmRequested)
+		{
+			ImGui::OpenPopup("Confirmer la generation##wizard_confirm");
+			m_wizardConfirmRequested = false;
+		}
+
+		// Modale de confirmation : la génération RÉINITIALISE la zone courante
+		// (reset destructif de l'executor, non annulable — P0 connu partagé avec
+		// le ZonePresetDialog). On recommande de sauvegarder d'abord.
+		if (ImGui::BeginPopupModal("Confirmer la generation##wizard_confirm", nullptr,
+			ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f),
+				"ATTENTION : action destructive et NON annulable.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("La generation VIDE la zone courante (terrain, eau, "
+				"mesh inserts, portails de donjon) avant de la reconstruire. Cette "
+				"reinitialisation n'est pas annulable (Ctrl+Z ne la restaurera pas). "
+				"Sauvegarde la zone avant de continuer si tu veux la conserver.");
+			ImGui::Separator();
+			if (ImGui::Button("Generer (vider et reconstruire)", ImVec2(260.0f, 0.0f)))
+			{
+				RunWizardGeneration();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Annuler", ImVec2(120.0f, 0.0f)))
+			{
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+
+		ImGui::End();
+	}
 #else
 	void WorldEditorImGui::RenderValidationPanel() {}
 	void WorldEditorImGui::RenderGuidanceOverlay() {}
 	void WorldEditorImGui::RenderDiagnosticPanel() {}
+	void WorldEditorImGui::RenderWizardWindow() {}
 #endif
 
 	bool WorldEditorImGui::WantsCaptureMouse() const

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -752,6 +752,19 @@ namespace engine::editor
 			return;
 		}
 
+		// Lot C vague 4 — Enregistre les règles de validation MVP une seule fois
+		// (le registre prend l'ownership : réenregistrer empilerait des doublons).
+		if (!m_validationRegistered)
+		{
+			engine::editor::world::validation::RegisterMvpValidationRules(m_validationRegistry);
+			m_validationRegistered = true;
+		}
+
+		// Lot C vague 4 — Début de frame : vide le registre de rectangles-cibles.
+		// Chaque widget-cible (bouton Valider, entrée menu export) réenregistre son
+		// rectangle après son rendu, plus bas dans cette frame.
+		m_widgetTargets.Clear();
+
 		if (ImGui::BeginMainMenuBar())
 		{
 			if (ImGui::BeginMenu("Fichier"))
@@ -761,11 +774,35 @@ namespace engine::editor
 				{
 					(void)m_session->ActionSaveCurrentMap(*m_cfg);
 				}
-				if (ImGui::MenuItem("Exporter en runtime", nullptr, false, m_session != nullptr && m_cfg != nullptr)
-					&& m_session && m_cfg)
+				// Lot C vague 4 — Export runtime BLOQUÉ si la dernière validation a
+				// remonté des erreurs. Le bouton est désactivé tant que
+				// `m_lastValidationReport.HasBlockingErrors()` ; il reste actif si
+				// aucune validation n'a encore tourné (l'utilisateur reste libre,
+				// mais le panneau Validation l'invite à valider avant export).
+				const bool exportBlocked = m_validationHasRun && m_lastValidationReport.HasBlockingErrors();
+				const bool exportEnabled = m_session != nullptr && m_cfg != nullptr && !exportBlocked;
+				if (ImGui::MenuItem("Exporter en runtime", nullptr, false, exportEnabled)
+					&& m_session && m_cfg && !exportBlocked)
 				{
 					(void)m_session->ActionExportRuntime(*m_cfg);
 				}
+				// Enregistre le rectangle de cette entrée menu pour le guidance
+				// overlay (id stable conforme à la convention <panel>.<sous>.<id>).
+				m_widgetTargets.Register("menubar.file.export_runtime",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
+				if (exportBlocked && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				{
+					ImGui::SetTooltip("Export bloque : corrigez les erreurs de validation (panneau Validation).");
+				}
+				// Lot C vague 4 — Bouton de validation de zone dans le menu Fichier.
+				if (ImGui::MenuItem("Valider la zone", nullptr, false, m_shell != nullptr))
+				{
+					RunZoneValidation();
+				}
+				m_widgetTargets.Register("toolbar.button.validate",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
 				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
 				// Preset. Désactivée si le Shell n'est pas branché (le
@@ -864,6 +901,9 @@ namespace engine::editor
 				// position monde, etc. Cachée par défaut pour ne pas
 				// polluer le dock (cf. #629).
 				ImGui::MenuItem("Aide camera (instructions WASD)", nullptr, &m_showCameraHelp);
+				// Lot C vague 4 — toggle du panneau Validation (ouvert aussi
+				// automatiquement à chaque « Valider la zone »).
+				ImGui::MenuItem("Validation de zone", nullptr, &m_showValidationPanel);
 				ImGui::Separator();
 				if (m_cfg)
 				{
@@ -1168,9 +1208,27 @@ namespace engine::editor
 				(void)m_session->ActionSaveCurrentMap(*m_cfg);
 			}
 			ImGui::SameLine();
+			// Lot C vague 4 — Bouton « Valider la zone » dans le panneau Carte.
+			if (m_shell != nullptr && ImGui::Button("Valider la zone"))
+			{
+				RunZoneValidation();
+			}
+			ImGui::SameLine();
+			// Lot C vague 4 — Export runtime bloqué si erreurs bloquantes.
+			const bool exportBlockedMap = m_validationHasRun && m_lastValidationReport.HasBlockingErrors();
+			if (exportBlockedMap)
+			{
+				ImGui::BeginDisabled();
+			}
 			if (ImGui::Button("Exporter runtime"))
 			{
 				(void)m_session->ActionExportRuntime(*m_cfg);
+			}
+			if (exportBlockedMap)
+			{
+				ImGui::EndDisabled();
+				ImGui::TextColored(ImVec4(1.f, 0.4f, 0.35f, 1.f),
+					"Export bloque : corrigez les erreurs (panneau Validation).");
 			}
 			if (!m_session->EditFileAbsolutePath().empty())
 			{
@@ -1810,11 +1868,257 @@ namespace engine::editor
 			engine::editor::DrawTextureLibrary(*m_session, m_texturePreviewCache, m_showTextureLibrary);
 		}
 
+		// Lot C vague 4 — Panneau Validation (rapport trié par sévérité) + voile
+		// de guidance overlay (no-op tant qu'aucune séquence de tutoriel n'est
+		// active). Dessinés en fin de frame : l'overlay est posé tout en haut via
+		// le foreground draw list, par-dessus tous les panneaux ci-dessus.
+		RenderValidationPanel();
+		RenderGuidanceOverlay();
+
 		ImGui::Render();
 #else
 		(void)viewportOverlay;
 #endif
 	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Lot C vague 4 — Validation de zone (ZoneValidator) + guidance overlay.
+	// ─────────────────────────────────────────────────────────────────────────
+
+	void WorldEditorImGui::RunZoneValidation()
+	{
+		// Sans shell branché, aucun document à valider ; sans config, les chunks
+		// terrain ne peuvent pas être chargés depuis le disque (EnsureLoaded en a
+		// besoin). Dans ces deux cas, on produit un rapport vide marqué « lancé ».
+		if (m_shell == nullptr || m_cfg == nullptr)
+		{
+			m_lastValidationReport = engine::editor::world::validation::ZoneValidator::Report{};
+			m_validationHasRun = true;
+			m_showValidationPanel = true;
+			LOG_WARN(Render,
+				"[WorldEditorImGui] Validation impossible : shell ou config non branche.");
+			return;
+		}
+
+		namespace val = engine::editor::world::validation;
+		namespace terr = engine::world::terrain;
+
+		// Adaptateur documents -> ValidationContext (vues lecture seule). Les
+		// chunks terrain proviennent du TerrainDocument (source de vérité de la
+		// zone) : on itère ceux résidents en RAM via ForEachLoadedChunk et on
+		// situe chacun par l'origine monde de son coin (coord.x/z * largeur chunk).
+		// La largeur d'un chunk est (resolution-1) cellules = 256 m (kTerrain*).
+		val::ValidationContext ctx;
+
+		TerrainDocument& terrainDoc = m_shell->MutableTerrainDocument();
+		const float chunkSpanMeters =
+			static_cast<float>(terr::kTerrainResolution - 1u) * terr::kTerrainCellSizeMeters;
+		// Mémorise la coord du 1er chunk chargé pour relier sa splat ensuite.
+		bool hasFirstCoord = false;
+		engine::world::GlobalChunkCoord firstCoord{};
+		engine::math::Vec3 firstOriginWorld{ 0.0f, 0.0f, 0.0f };
+		terrainDoc.ForEachLoadedChunk(
+			[&](engine::world::GlobalChunkCoord coord,
+				const std::shared_ptr<terr::TerrainChunk>& chunk)
+			{
+				if (!chunk)
+				{
+					return;
+				}
+				val::ValidationContext::TerrainEntry entry;
+				entry.chunk = chunk.get();
+				entry.originWorld = engine::math::Vec3{
+					static_cast<float>(coord.x) * chunkSpanMeters,
+					0.0f,
+					static_cast<float>(coord.z) * chunkSpanMeters };
+				if (!hasFirstCoord)
+				{
+					hasFirstCoord = true;
+					firstCoord = coord;
+					firstOriginWorld = entry.originWorld;
+				}
+				ctx.terrainChunks.push_back(entry);
+			});
+
+		// Splat : le TerrainDocument stocke une SplatMap par chunk (pas de splat
+		// global unifié). Le ValidationContext n'expose qu'un seul pointeur splat
+		// (MVP mono-zone) : on relie la splat du 1er chunk chargé si présente,
+		// avec son origine monde. Les chunks sans splat chargée sont ignorés (la
+		// règle splat passe simplement). Le scan multi-chunk est différé (2e passe).
+		if (hasFirstCoord)
+		{
+			if (auto splat = terrainDoc.FindSplat(firstCoord))
+			{
+				ctx.splat = splat.get();
+				ctx.splatOriginWorld = firstOriginWorld;
+			}
+		}
+
+		// Mesh inserts : vue directe sur le vecteur du MeshInsertDocument.
+		ctx.meshInserts = &m_shell->GetMeshInsertDocument().All();
+
+		m_lastValidationReport = m_zoneValidator.Validate(ctx);
+		m_validationHasRun = true;
+		m_showValidationPanel = true;
+		LOG_INFO(Render,
+			"[WorldEditorImGui] Validation zone : {} erreur(s), {} avertissement(s), {} indice(s) "
+			"sur {} chunk(s) terrain, {} mesh insert(s).",
+			m_lastValidationReport.errorCount, m_lastValidationReport.warningCount,
+			m_lastValidationReport.hintCount, ctx.terrainChunks.size(),
+			ctx.meshInserts ? ctx.meshInserts->size() : static_cast<size_t>(0));
+	}
+
+#if defined(_WIN32)
+	void WorldEditorImGui::RenderValidationPanel()
+	{
+		if (!m_showValidationPanel)
+		{
+			return;
+		}
+		namespace val = engine::editor::world::validation;
+
+		ImGui::Begin("Validation", &m_showValidationPanel);
+
+		// Bouton de relance directement dans le panneau (en plus du menu/toolbar).
+		if (ImGui::Button("Revalider la zone"))
+		{
+			RunZoneValidation();
+		}
+		ImGui::SameLine();
+		if (!m_validationHasRun)
+		{
+			ImGui::TextDisabled("Aucune validation lancee.");
+			ImGui::End();
+			return;
+		}
+
+		const val::ZoneValidator::Report& rep = m_lastValidationReport;
+
+		// Compteurs colorés (erreurs rouge / warnings ambre / hints gris).
+		ImGui::TextColored(ImVec4(1.f, 0.4f, 0.35f, 1.f), "Erreurs : %u", rep.errorCount);
+		ImGui::SameLine();
+		ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f), "Avertissements : %u", rep.warningCount);
+		ImGui::SameLine();
+		ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.f), "Indices : %u", rep.hintCount);
+
+		if (rep.HasBlockingErrors())
+		{
+			ImGui::TextColored(ImVec4(1.f, 0.4f, 0.35f, 1.f),
+				"Export runtime BLOQUE tant que des erreurs subsistent.");
+		}
+		ImGui::Separator();
+
+		if (rep.issues.empty())
+		{
+			ImGui::TextColored(ImVec4(0.5f, 0.95f, 0.55f, 1.f),
+				"Aucun probleme detecte. La zone est exportable.");
+			ImGui::End();
+			return;
+		}
+
+		// Liste triée par sévérité décroissante (garanti par ZoneValidator).
+		// Un clic sur un problème logue sa position monde (« Aller a » caméra
+		// complet différé : l'API caméra n'est pas exposée à ce niveau).
+		for (size_t i = 0; i < rep.issues.size(); ++i)
+		{
+			const val::ValidationIssue& issue = rep.issues[i];
+			ImVec4 sevColor;
+			const char* sevLabel;
+			switch (issue.severity)
+			{
+			case val::Severity::Error:   sevColor = ImVec4(1.f, 0.4f, 0.35f, 1.f);  sevLabel = "[ERREUR]";  break;
+			case val::Severity::Warning: sevColor = ImVec4(1.f, 0.82f, 0.35f, 1.f); sevLabel = "[ATTENTION]"; break;
+			default:                     sevColor = ImVec4(0.7f, 0.7f, 0.7f, 1.f);  sevLabel = "[INDICE]";  break;
+			}
+			ImGui::PushID(static_cast<int>(i));
+			ImGui::TextColored(sevColor, "%s", sevLabel);
+			ImGui::SameLine();
+			// Selectable cliquable : logue la position pour situer le problème.
+			if (ImGui::Selectable(issue.title.empty() ? issue.ruleId.c_str() : issue.title.c_str()))
+			{
+				LOG_INFO(Render,
+					"[WorldEditorImGui] Probleme '{}' (regle {}) a la position monde ({:.1f}, {:.1f}, {:.1f}).",
+					issue.title, issue.ruleId,
+					issue.worldPosition.x, issue.worldPosition.y, issue.worldPosition.z);
+			}
+			if (!issue.description.empty())
+			{
+				ImGui::TextWrapped("%s", issue.description.c_str());
+			}
+			if (!issue.suggestedFix.empty())
+			{
+				ImGui::TextDisabled("Correctif suggere : %s", issue.suggestedFix.c_str());
+			}
+			ImGui::PopID();
+			ImGui::Separator();
+		}
+
+		ImGui::End();
+	}
+
+	void WorldEditorImGui::RenderGuidanceOverlay()
+	{
+		// Fondation tutoriel : tant qu'aucune séquence n'est lancée, on ne dessine
+		// strictement rien (pas de voile, pas de surlignage).
+		if (!m_overlay.IsActiveSequence())
+		{
+			return;
+		}
+
+		const engine::editor::world::help::OverlayInstruction& instr =
+			m_overlay.CurrentInstruction();
+
+		ImDrawList* fg = ImGui::GetForegroundDrawList();
+		const ImGuiViewport* vp = ImGui::GetMainViewport();
+		const ImVec2 vpMin = vp->Pos;
+		const ImVec2 vpMax = ImVec2(vp->Pos.x + vp->Size.x, vp->Pos.y + vp->Size.y);
+
+		// Voile semi-transparent plein écran (assombrit le reste de l'UI).
+		fg->AddRectFilled(vpMin, vpMax, IM_COL32(0, 0, 0, 110));
+
+		// Rectangle de surlignage autour de la cible (si le widget est enregistré
+		// cette frame et que son rectangle est valide).
+		bool found = false;
+		const engine::editor::world::help::WidgetRect rect =
+			m_widgetTargets.Get(instr.targetWidget, &found);
+		ImVec2 bubbleAnchor = ImVec2(vpMin.x + 40.f, vpMin.y + 80.f);
+		if (found && rect.Valid())
+		{
+			const ImVec2 rMin(rect.x0 - 4.f, rect.y0 - 4.f);
+			const ImVec2 rMax(rect.x1 + 4.f, rect.y1 + 4.f);
+			// « Trou » lumineux : on redessine la zone cible sans voile en la
+			// surlignant d'un cadre épais ambre.
+			fg->AddRect(rMin, rMax, IM_COL32(255, 209, 89, 255), 4.f, 0, 3.f);
+			bubbleAnchor = ImVec2(rMin.x, rMax.y + 8.f);
+		}
+
+		// Bulle titre/texte ancrée sous la cible (ou en haut-gauche par défaut).
+		const std::string title = instr.iconHint.empty()
+			? instr.titleFr
+			: (instr.iconHint + " " + instr.titleFr);
+		const float bubbleW = 360.f;
+		const ImVec2 pad(10.f, 8.f);
+		const float titleH = ImGui::GetTextLineHeight();
+		// Hauteur approximative : titre + corps wrappé (estimation simple).
+		const ImVec2 bodySize = ImGui::CalcTextSize(
+			instr.bodyFr.c_str(), nullptr, false, bubbleW - pad.x * 2.f);
+		const ImVec2 bubbleMin = bubbleAnchor;
+		const ImVec2 bubbleMax = ImVec2(
+			bubbleMin.x + bubbleW,
+			bubbleMin.y + titleH + bodySize.y + pad.y * 3.f);
+		fg->AddRectFilled(bubbleMin, bubbleMax, IM_COL32(28, 30, 38, 240), 6.f);
+		fg->AddRect(bubbleMin, bubbleMax, IM_COL32(255, 209, 89, 255), 6.f, 0, 1.5f);
+		fg->AddText(ImVec2(bubbleMin.x + pad.x, bubbleMin.y + pad.y),
+			IM_COL32(255, 224, 130, 255), title.c_str());
+		fg->AddText(nullptr, 0.f,
+			ImVec2(bubbleMin.x + pad.x, bubbleMin.y + pad.y * 2.f + titleH),
+			IM_COL32(230, 230, 230, 255),
+			instr.bodyFr.c_str(), nullptr, bubbleW - pad.x * 2.f);
+	}
+#else
+	void WorldEditorImGui::RenderValidationPanel() {}
+	void WorldEditorImGui::RenderGuidanceOverlay() {}
+#endif
 
 	bool WorldEditorImGui::WantsCaptureMouse() const
 	{

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -1910,7 +1910,7 @@ namespace engine::editor
 		// La largeur d'un chunk est (resolution-1) cellules = 256 m (kTerrain*).
 		val::ValidationContext ctx;
 
-		TerrainDocument& terrainDoc = m_shell->MutableTerrainDocument();
+		auto& terrainDoc = m_shell->MutableTerrainDocument();
 		const float chunkSpanMeters =
 			static_cast<float>(terr::kTerrainResolution - 1u) * terr::kTerrainCellSizeMeters;
 		// Mémorise la coord du 1er chunk chargé pour relier sa splat ensuite.

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -760,6 +760,14 @@ namespace engine::editor
 			m_validationRegistered = true;
 		}
 
+		// Lot C vague 4 — Idem pour les règles de diagnostic workflow MVP (mêmes
+		// raisons : ownership pris par le registre, enregistrement idempotent).
+		if (!m_diagnosticRegistered)
+		{
+			engine::editor::world::diagnostic::RegisterMvpDiagnosticRules(m_diagnosticRegistry);
+			m_diagnosticRegistered = true;
+		}
+
 		// Lot C vague 4 — Début de frame : vide le registre de rectangles-cibles.
 		// Chaque widget-cible (bouton Valider, entrée menu export) réenregistre son
 		// rectangle après son rendu, plus bas dans cette frame.
@@ -958,6 +966,16 @@ namespace engine::editor
 					}
 					ImGui::EndMenu();
 				}
+				ImGui::EndMenu();
+			}
+			// Lot C vague 4 — Menu « Aide » : ouvre le panneau Diagnostic
+			// (« Pourquoi ca ne marche pas ? »). Distinct du menu Vue (reserve
+			// aux toggles de panneaux/disposition) car le diagnostic releve de
+			// l'assistance contextuelle (jumeau du futur tutoriel/guidance).
+			if (ImGui::BeginMenu("Aide"))
+			{
+				ImGui::MenuItem("Diagnostic (pourquoi ca ne marche pas ?)", nullptr,
+					&m_showDiagnosticPanel);
 				ImGui::EndMenu();
 			}
 			// Barre d'outils rapide a droite du menu : sauvegarde 1-clic + chargement carte.
@@ -1873,6 +1891,10 @@ namespace engine::editor
 		// active). Dessinés en fin de frame : l'overlay est posé tout en haut via
 		// le foreground draw list, par-dessus tous les panneaux ci-dessus.
 		RenderValidationPanel();
+		// Lot C vague 4 — Panneau Diagnostic (« Pourquoi ça ne marche pas ? »).
+		// Rendu avant l'overlay de guidance pour que ce dernier (foreground draw
+		// list) puisse, le cas échéant, le surligner comme cible de tutoriel.
+		RenderDiagnosticPanel();
 		RenderGuidanceOverlay();
 
 		ImGui::Render();
@@ -1966,6 +1988,122 @@ namespace engine::editor
 			m_lastValidationReport.errorCount, m_lastValidationReport.warningCount,
 			m_lastValidationReport.hintCount, ctx.terrainChunks.size(),
 			ctx.meshInserts ? ctx.meshInserts->size() : static_cast<size_t>(0));
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Lot C vague 4 — Diagnostic « Pourquoi ça ne marche pas ? ».
+	// BuildDiagnosticContext est CROSS-PLATFORM (hors garde _WIN32, comme
+	// RunZoneValidation) : tous les types y sont pleinement qualifiés (le build
+	// Linux compile cette fonction).
+	// ─────────────────────────────────────────────────────────────────────────
+
+	engine::editor::world::diagnostic::DiagnosticContext
+	WorldEditorImGui::BuildDiagnosticContext() const
+	{
+		namespace diag  = engine::editor::world::diagnostic;
+		namespace world = engine::editor::world;
+
+		diag::DiagnosticContext ctx;
+
+		// Sans shell branché : aucun état d'usage à inspecter, on renvoie un
+		// contexte vide (la règle « aucun outil sélectionné » se déclenchera, ce
+		// qui est le bon message dans cet état).
+		if (m_shell == nullptr)
+		{
+			return ctx;
+		}
+
+		// --- Outil actif → bool + identifiant chaîne ---------------------------
+		// On mappe l'enum `ActiveTool` du shell vers les ids attendus par les
+		// règles (chaînes courtes, ex. "coastline"). `None` => pas d'outil actif.
+		const world::ActiveTool tool = m_shell->GetActiveTool();
+		ctx.hasActiveTool = (tool != world::ActiveTool::None);
+		switch (tool)
+		{
+		case world::ActiveTool::TerrainSculpt:      ctx.activeToolId = "terrain_sculpt"; break;
+		case world::ActiveTool::TerrainStamp:       ctx.activeToolId = "terrain_stamp";  break;
+		case world::ActiveTool::SplatPaint:         ctx.activeToolId = "splat_paint";    break;
+		case world::ActiveTool::Lake:               ctx.activeToolId = "lake";           break;
+		case world::ActiveTool::River:              ctx.activeToolId = "river";          break;
+		case world::ActiveTool::MountainRange:      ctx.activeToolId = "mountain_range"; break;
+		case world::ActiveTool::ValleyChain:        ctx.activeToolId = "valley_chain";   break;
+		case world::ActiveTool::RiverNetwork:       ctx.activeToolId = "river_network";  break;
+		case world::ActiveTool::Coastline:          ctx.activeToolId = "coastline";      break;
+		case world::ActiveTool::HydraulicErosion:   ctx.activeToolId = "hydraulic";      break;
+		case world::ActiveTool::ThermalWindErosion: ctx.activeToolId = "thermal_wind";   break;
+		case world::ActiveTool::Cave:               ctx.activeToolId = "cave";           break;
+		case world::ActiveTool::Overhang:           ctx.activeToolId = "overhang";       break;
+		case world::ActiveTool::Arch:               ctx.activeToolId = "arch";           break;
+		case world::ActiveTool::DungeonPortal:      ctx.activeToolId = "dungeon_portal"; break;
+		case world::ActiveTool::None:               break; // ctx.activeToolId reste vide
+		}
+		// Drapeau spécifique consommé par NoSeaLevelSetRule.
+		ctx.coastlineToolActive = (tool == world::ActiveTool::Coastline);
+
+		// --- Nombre de chunks chargés ------------------------------------------
+		// Source fiable : compteur exposé par le TerrainDocument (chunks résidents
+		// en RAM). Lecture seule — pas de chargement disque ici (contrairement à
+		// RunZoneValidation), pour qu'un simple « Analyser » reste sans effet de bord.
+		ctx.chunkCount = static_cast<uint32_t>(
+			m_shell->MutableTerrainDocument().LoadedChunkCount());
+
+		// --- Profondeur undo → proxy de « commandes depuis la dernière save » --
+		// Le CommandStack n'expose AUCUN marqueur de sauvegarde (pas de compteur
+		// « depuis le dernier save »). On utilise `UndoSize()` comme PROXY : c'est
+		// la profondeur totale de la pile undo, pas strictement le nombre de
+		// modifications depuis le dernier save (un save ne réinitialise pas la
+		// pile). Suffisant pour la règle « modifications non sauvegardées » (seuil
+		// > 30) ; un vrai marqueur de save est à instrumenter en 2e passe.
+		ctx.commandsSinceLastSave = static_cast<uint32_t>(
+			m_shell->GetCommandStack().UndoSize());
+
+		// --- Sea level défini --------------------------------------------------
+		// `seaLevelMeters` vaut TOUJOURS 50 par défaut : il n'existe pas d'état
+		// « défini vs non défini » sur cette valeur. On utilise `OceanSettings::
+		// enabled` comme PROXY de « niveau de mer défini » (océan activé = côte a
+		// une référence d'altitude). Heuristique, pas un signal exact — à affiner
+		// en 2e passe si un vrai flag « sea level explicitement posé » est ajouté.
+		ctx.seaLevelSet = m_shell->GetWaterDocument().GetOcean().enabled;
+
+		// --- Mode éditeur Simple/Avancé ----------------------------------------
+		// Source fiable : le singleton EditorModeRegistry (même source que le
+		// toggle « Mode editeur » du menu Options). `attemptedAdvancedFeature` n'a
+		// en revanche PAS de source de suivi — il reste à son défaut neutre (false),
+		// donc SimpleModeAdvancedAttemptedRule ne se déclenchera pas tant que ce
+		// signal n'est pas instrumenté (2e passe).
+		ctx.simpleModeActive =
+			(world::modes::EditorModeRegistry::Instance().GetCurrentMode()
+				== world::modes::EditorMode::Simple);
+
+		// --- Validation (peuple validationErrorCount depuis le dernier rapport) -
+		// On ne relie PAS `ctx.validation` : ce pointeur attend un
+		// `ValidationContext` (vues documents), or on ne conserve entre frames que
+		// le `ZoneValidator::Report` (`m_lastValidationReport`), pas le contexte
+		// source (construit localement et détruit dans RunZoneValidation). On
+		// transfère donc seulement le compteur d'erreurs, suffisant pour
+		// ExportAttemptedWithErrorsRule.
+		if (m_validationHasRun)
+		{
+			ctx.validationErrorCount = m_lastValidationReport.errorCount;
+		}
+
+		// --- Champs SANS source de suivi runtime fiable : défauts neutres ------
+		// Les champs ci-dessous n'ont pas de source d'instrumentation à ce stade ;
+		// on les laisse à leur valeur par défaut sûre (pas de fausse donnée) — à
+		// instrumenter en 2e passe (suivi temporel + journal d'actions d'usage) :
+		//   - hasOpenedDialog               : pas de suivi d'ouverture de dialogue.
+		//   - secondsSinceToolSelected      : pas d'horodatage de sélection d'outil.
+		//   - commandsSinceToolSelected     : pas de compteur ré-armé à la sélection.
+		//   - presetJustAppliedNotSaved     : pas de signal « preset appliqué ».
+		//   - hasUserAttemptedExport        : pas de trace de tentative d'export.
+		//   - erosionAppliedAfterRivers     : pas de suivi d'ordre érosion/rivières.
+		//   - cavePlacedWithoutCamouflage   : pas d'analyse jointure grotte/splat.
+		//   - attemptedAdvancedFeature      : pas de trace d'accès param avancé.
+		//   - recentCommandHistory          : pas d'historique de labels exposé.
+		// Conséquence : les règles dépendant uniquement de ces champs restent
+		// silencieuses (comportement voulu — mieux que des suggestions fantaisistes).
+
+		return ctx;
 	}
 
 #if defined(_WIN32)
@@ -2115,9 +2253,98 @@ namespace engine::editor
 			IM_COL32(230, 230, 230, 255),
 			instr.bodyFr.c_str(), nullptr, bubbleW - pad.x * 2.f);
 	}
+
+	void WorldEditorImGui::RenderDiagnosticPanel()
+	{
+		if (!m_showDiagnosticPanel)
+		{
+			return;
+		}
+		namespace diag = engine::editor::world::diagnostic;
+
+		ImGui::Begin("Diagnostic", &m_showDiagnosticPanel);
+
+		ImGui::TextWrapped(
+			"Analyse l'etat d'usage courant (outil, zone, sauvegarde) et propose "
+			"des pistes pour debloquer ton workflow.");
+		ImGui::Separator();
+
+		// Bouton « Analyser » : (re)calcule le rapport. L'analyse N'A LIEU qu'au
+		// clic (pas chaque frame) pour rester explicite et bon marché.
+		if (ImGui::Button("Analyser"))
+		{
+			m_lastDiagnosticReport = m_diagnosticSystem.Analyze(BuildDiagnosticContext());
+			m_diagnosticHasRun = true;
+			LOG_INFO(Render,
+				"[WorldEditorImGui] Diagnostic : {} critique(s), {} forte(s), {} astuce(s).",
+				m_lastDiagnosticReport.criticalCount, m_lastDiagnosticReport.strongCount,
+				m_lastDiagnosticReport.tipCount);
+		}
+		ImGui::SameLine();
+		if (!m_diagnosticHasRun)
+		{
+			ImGui::TextDisabled("Aucune analyse lancee.");
+			ImGui::End();
+			return;
+		}
+
+		const diag::DiagnosticSystem::Report& rep = m_lastDiagnosticReport;
+
+		// Compteurs colorés par importance (Critical rouge / Strong ambre / Tip gris).
+		ImGui::TextColored(ImVec4(1.f, 0.4f, 0.35f, 1.f), "Critiques : %u", rep.criticalCount);
+		ImGui::SameLine();
+		ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f), "Fortes : %u", rep.strongCount);
+		ImGui::SameLine();
+		ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.f), "Astuces : %u", rep.tipCount);
+		ImGui::Separator();
+
+		if (rep.IsClean())
+		{
+			ImGui::TextColored(ImVec4(0.5f, 0.95f, 0.55f, 1.f),
+				"Tu as l'air sur les bons rails ! Aucune suggestion.");
+			ImGui::End();
+			return;
+		}
+
+		// Liste triée par importance décroissante (garanti par DiagnosticSystem).
+		// AFFICHAGE SEUL : le libellé d'action « one-click » est montré tel quel,
+		// AUCUNE exécution n'est câblée ici (action réelle = passe UI séparée).
+		for (size_t i = 0; i < rep.suggestions.size(); ++i)
+		{
+			const diag::DiagnosticSuggestion& sug = rep.suggestions[i];
+			ImVec4 impColor;
+			const char* impLabel;
+			switch (sug.importance)
+			{
+			case diag::SuggestionImportance::Critical: impColor = ImVec4(1.f, 0.4f, 0.35f, 1.f);  impLabel = "[CRITIQUE]"; break;
+			case diag::SuggestionImportance::Strong:   impColor = ImVec4(1.f, 0.82f, 0.35f, 1.f); impLabel = "[FORT]";     break;
+			default:                                   impColor = ImVec4(0.7f, 0.7f, 0.7f, 1.f);  impLabel = "[ASTUCE]";   break;
+			}
+			ImGui::PushID(static_cast<int>(i));
+			ImGui::TextColored(impColor, "%s", impLabel);
+			ImGui::SameLine();
+			ImGui::TextWrapped("%s", sug.titleFr.c_str());
+			if (!sug.explanationFr.empty())
+			{
+				ImGui::TextWrapped("%s", sug.explanationFr.c_str());
+			}
+			// Libellé d'action PROPOSÉE — affiché en italique grisé, désactivé :
+			// le câblage de l'action effective + la modale de confirmation sont
+			// une passe UI séparée. On ne propose donc PAS de bouton cliquable.
+			if (!sug.oneClickActionLabelFr.empty())
+			{
+				ImGui::TextDisabled("Action proposee : %s", sug.oneClickActionLabelFr.c_str());
+			}
+			ImGui::PopID();
+			ImGui::Separator();
+		}
+
+		ImGui::End();
+	}
 #else
 	void WorldEditorImGui::RenderValidationPanel() {}
 	void WorldEditorImGui::RenderGuidanceOverlay() {}
+	void WorldEditorImGui::RenderDiagnosticPanel() {}
 #endif
 
 	bool WorldEditorImGui::WantsCaptureMouse() const

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -20,6 +20,9 @@
 #include "src/world_editor/volumes/caves/CaveTool.h"
 #include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
 #include "src/world_editor/volumes/overhangs/OverhangTool.h"
+// Lot C vague 4 — loader du tutoriel « first_launch » (BuildFirstLaunchTutorial
+// via LoadTutorialById). Pur, compilé toutes plateformes.
+#include "src/world_editor/tutorial/TutorialIo.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -401,7 +404,18 @@ namespace engine::editor
 	// être visible ici pour que `std::unique_ptr<ZonePresetDialog>` puisse
 	// générer son cleanup d'exception. L'`#include` au top du fichier
 	// fournit le type complet.
-	WorldEditorImGui::WorldEditorImGui() = default;
+	WorldEditorImGui::WorldEditorImGui()
+	{
+		// Lot C vague 4 — Charge la définition du tutoriel « first_launch » dès la
+		// construction (logique pure, sans ImGui ni Vulkan : compilée sur toutes les
+		// plateformes). Le tutoriel n'est PAS démarré ici : le lancement est manuel
+		// via le menu « Aide → Lancer le tutoriel ». LoadTutorialById route vers
+		// BuildFirstLaunchTutorial pour le MVP (chargement JSON différé).
+		if (auto def = engine::editor::world::tutorial::LoadTutorialById("first_launch"))
+		{
+			m_tutorial.LoadTutorial(std::move(*def));
+		}
+	}
 
 	WorldEditorImGui::~WorldEditorImGui()
 	{
@@ -809,6 +823,12 @@ namespace engine::editor
 				m_widgetTargets.Register("menubar.file.export_runtime",
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
 					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
+				// Tutoriel — étape 8 (« Exporter ») cible l'id `menubar.file.export`
+				// (id exact de TutorialIo). Même widget que l'export runtime : on
+				// enregistre le rectangle sous ce second id pour le surlignage.
+				m_widgetTargets.Register("menubar.file.export",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				if (exportBlocked && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				{
 					ImGui::SetTooltip("Export bloque : corrigez les erreurs de validation (panneau Validation).");
@@ -830,6 +850,10 @@ namespace engine::editor
 					&& m_shell)
 				{
 					m_showWizard = true;
+					// Tutoriel — étape 1 (« Ouvre le dialog ») : l'assistant
+					// « Nouvelle zone » est l'autre porte d'entrée vers la création
+					// de zone ; il valide la même action `zone_preset_dialog.opened`.
+					m_overlay.NotifyAction("zone_preset_dialog.opened");
 				}
 				m_widgetTargets.Register("menubar.file.new_zone_wizard",
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
@@ -842,7 +866,16 @@ namespace engine::editor
 					&& m_shell && m_zonePresetDialog)
 				{
 					m_zonePresetDialog->Open();
+					// Tutoriel — étape 1 (« Ouvre le dialog ») : l'ouverture du
+					// dialog preset valide l'action `zone_preset_dialog.opened`.
+					m_overlay.NotifyAction("zone_preset_dialog.opened");
 				}
+				// Tutoriel — étape 1 cible ce widget (`menubar.file.new_from_preset`,
+				// id exact de TutorialIo). On enregistre son rectangle pour que le
+				// surlignage de l'overlay le pointe.
+				m_widgetTargets.Register("menubar.file.new_from_preset",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
 				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
 					&& m_session && m_cfg)
@@ -998,6 +1031,17 @@ namespace engine::editor
 			{
 				ImGui::MenuItem("Diagnostic (pourquoi ca ne marche pas ?)", nullptr,
 					&m_showDiagnosticPanel);
+				ImGui::Separator();
+				// Lot C vague 4 — Lance MANUELLEMENT le tutoriel interactif
+				// « first_launch » (8 étapes) via l'OverlayGuidanceSystem. Pas
+				// d'auto-lancement au premier démarrage dans cette tranche : la
+				// détection premier-lancement (UserPrefs) reste à câbler
+				// (auto-start différé). L'utilisateur peut TOUJOURS sortir via
+				// le bouton « Passer le tutoriel » du voile (cf. RenderGuidanceOverlay).
+				if (ImGui::MenuItem("Lancer le tutoriel (premier lancement)"))
+				{
+					m_tutorial.Start(m_overlay);
+				}
 				ImGui::EndMenu();
 			}
 			// Barre d'outils rapide a droite du menu : sauvegarde 1-clic + chargement carte.
@@ -1943,6 +1987,9 @@ namespace engine::editor
 			m_lastValidationReport = engine::editor::world::validation::ZoneValidator::Report{};
 			m_validationHasRun = true;
 			m_showValidationPanel = true;
+			// Tutoriel — étape 7 : même sans shell/config, le panneau Validation
+			// s'ouvre -> on valide l'action pour ne pas bloquer la progression.
+			m_overlay.NotifyAction("panel.validation.opened");
 			LOG_WARN(Render,
 				"[WorldEditorImGui] Validation impossible : shell ou config non branche.");
 			return;
@@ -2008,6 +2055,11 @@ namespace engine::editor
 		m_lastValidationReport = m_zoneValidator.Validate(ctx);
 		m_validationHasRun = true;
 		m_showValidationPanel = true;
+		// Tutoriel — étape 7 (« Valide ta zone ») : valider ouvre le panneau
+		// Validation -> valide l'action `panel.validation.opened`. Appel pur
+		// (logique seule) : compilé cross-plateforme comme cette fonction. No-op
+		// si aucune séquence tutoriel n'est active.
+		m_overlay.NotifyAction("panel.validation.opened");
 		LOG_INFO(Render,
 			"[WorldEditorImGui] Validation zone : {} erreur(s), {} avertissement(s), {} indice(s) "
 			"sur {} chunk(s) terrain, {} mesh insert(s).",
@@ -2212,6 +2264,12 @@ namespace engine::editor
 		m_wizardLastPresetId = preset.id;
 		m_wizardHasGenerated = true;
 
+		// Tutoriel — étape 3 (« Crée la zone ») : la génération via l'assistant
+		// produit effectivement la zone -> valide l'action `zone.created`. Appel
+		// pur (logique seule, sans ImGui) : compilé cross-plateforme comme le reste
+		// de cette fonction. No-op si aucune séquence tutoriel n'est active.
+		m_overlay.NotifyAction("zone.created");
+
 		LOG_INFO(Render,
 			"[WorldEditorImGui] Wizard '{}' termine (pushed={}, skipped={}, failed={}, annule={}).",
 			preset.id, m_wizardLastSummary.commandsPushed,
@@ -2365,6 +2423,47 @@ namespace engine::editor
 			ImVec2(bubbleMin.x + pad.x, bubbleMin.y + pad.y * 2.f + titleH),
 			IM_COL32(230, 230, 230, 255),
 			instr.bodyFr.c_str(), nullptr, bubbleW - pad.x * 2.f);
+
+		// ── PRINCIPE DE SÉCURITÉ : sorties manuelles TOUJOURS disponibles ──────
+		// Le voile pourrait sinon piéger l'utilisateur si un `NotifyAction` n'est
+		// jamais émis (étape dont le site UI n'est pas instrumenté). On expose donc
+		// EN PERMANENCE deux boutons cliquables :
+		//   - « Étape suivante » → `m_overlay.AdvanceStep()` (avance même sans action) ;
+		//   - « Passer le tutoriel » → `m_overlay.AbortSequence()` (sort du voile).
+		// Ces boutons sont des widgets ImGui réels (pas du draw-list brut) pour
+		// capter le clic. La fenêtre hôte est sans décoration, ancrée en bas-droite
+		// du viewport, au-dessus du voile (TopMost via le foreground n'étant pas
+		// cliquable, on s'appuie sur l'ordre de rendu : cette fenêtre est dessinée
+		// après le dockspace, donc reçoit les clics).
+		const float kBtnPanelW = 320.f;
+		const float kBtnPanelH = 56.f;
+		ImGui::SetNextWindowPos(
+			ImVec2(vpMax.x - kBtnPanelW - 24.f, vpMax.y - kBtnPanelH - 24.f),
+			ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(kBtnPanelW, kBtnPanelH), ImGuiCond_Always);
+		ImGui::SetNextWindowBgAlpha(0.92f);
+		const ImGuiWindowFlags ctrlFlags =
+			ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+			ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
+			ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavInputs |
+			ImGuiWindowFlags_NoDocking;
+		if (ImGui::Begin("##tutorial_controls", nullptr, ctrlFlags))
+		{
+			// Étape N/Total pour situer l'utilisateur (1-based à l'affichage).
+			ImGui::Text("Etape %zu / %zu",
+				m_overlay.CurrentIndex() + 1u, m_overlay.StepCount());
+			ImGui::SameLine();
+			if (ImGui::Button("Etape suivante"))
+			{
+				m_overlay.AdvanceStep();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Passer le tutoriel"))
+			{
+				m_overlay.AbortSequence();
+			}
+		}
+		ImGui::End();
 	}
 
 	void WorldEditorImGui::RenderDiagnosticPanel()

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -11,6 +11,15 @@
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/zone_presets/ZonePresetDialog.h"
+// Lot C vague 4 — assistant « Nouvelle zone » : exécution d'un ZonePreset résolu
+// par le wizard via le MÊME chemin que le ZonePresetDialog (executor + dispatch
+// context construit depuis les outils/catalogs du Shell).
+#include "src/world_editor/zone_presets/OperationDispatcher.h"
+#include "src/world_editor/zone_presets/ZonePreset.h"
+#include "src/world_editor/volumes/arches/ArchTool.h"
+#include "src/world_editor/volumes/caves/CaveTool.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalTool.h"
+#include "src/world_editor/volumes/overhangs/OverhangTool.h"
 #include "src/client/render/DayNightCycle.h"
 #include "src/shared/platform/FileSystem.h"
 #include "src/shared/platform/Window.h"
@@ -29,6 +38,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #if defined(_WIN32)
@@ -812,6 +822,25 @@ namespace engine::editor
 					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
 					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				ImGui::Separator();
+				// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard).
+				// Désactivé si le Shell n'est pas branché (la génération a besoin
+				// des 4 documents + catalogs + CommandStack, comme le dialog preset).
+				if (ImGui::MenuItem("Nouvelle zone (assistant)...", nullptr, false,
+					m_shell != nullptr)
+					&& m_shell)
+				{
+					// Transition fermé→ouvert : on réinitialise l'assistant pour
+					// qu'il reparte de l'étape 1 (Climat), sans état résiduel d'une
+					// session précédente (choix, seed, bandeau de résumé).
+					if (!m_showWizard)
+					{
+						ResetWizardState();
+					}
+					m_showWizard = true;
+				}
+				m_widgetTargets.Register("menubar.file.new_zone_wizard",
+					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
 				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
 				// Preset. Désactivée si le Shell n'est pas branché (le
 				// dialog a besoin des 4 documents + catalogs).
@@ -1895,6 +1924,10 @@ namespace engine::editor
 		// Rendu avant l'overlay de guidance pour que ce dernier (foreground draw
 		// list) puisse, le cas échéant, le surligner comme cible de tutoriel.
 		RenderDiagnosticPanel();
+		// Lot C vague 4 — Fenêtre de l'assistant « Nouvelle zone » (no-op si
+		// fermée). Rendue avant l'overlay de guidance pour que ce dernier puisse,
+		// le cas échéant, surligner ses widgets comme cibles de tutoriel.
+		RenderWizardWindow();
 		RenderGuidanceOverlay();
 
 		ImGui::Render();
@@ -2104,6 +2137,93 @@ namespace engine::editor
 		// silencieuses (comportement voulu — mieux que des suggestions fantaisistes).
 
 		return ctx;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Lot C vague 4 — Assistant « Nouvelle zone » (QuickStartWizard).
+	// RunWizardGeneration est CROSS-PLATFORM (hors garde _WIN32, comme
+	// RunZoneValidation / BuildDiagnosticContext) : tous les types y sont
+	// pleinement qualifiés (le build Linux compile cette fonction).
+	//
+	// NOTE P0 (rollback transactionnel) — partagée avec le ZonePresetDialog :
+	// `ZonePresetExecutor::Execute` commence par VIDER les 4 documents de la
+	// zone (terrain / water / mesh inserts / portails de donjon) via
+	// `ResetEditedZoneDocuments`. Ce reset est DESTRUCTIF et NON annulable (il
+	// n'est pas poussé comme commande sur le CommandStack). Si l'exécution
+	// échoue en plein milieu, la zone précédente est déjà perdue. Un rollback
+	// transactionnel (snapshot avant reset + restauration sur échec/annulation)
+	// est un follow-up P0 qui bénéficierait aux DEUX points d'entrée — le dialog
+	// preset ET cet assistant — puisqu'ils partagent le même `ZonePresetExecutor`.
+	// En attendant, les deux UI affichent une modale de confirmation explicite
+	// recommandant de sauvegarder d'abord.
+	// ─────────────────────────────────────────────────────────────────────────
+	void WorldEditorImGui::RunWizardGeneration()
+	{
+		// Sans shell branché, aucun document cible : on ne génère rien (le menu
+		// est déjà désactivé dans ce cas, ceci est une garde défensive).
+		if (m_shell == nullptr)
+		{
+			LOG_WARN(Render,
+				"[WorldEditorImGui] Generation wizard impossible : shell non branche.");
+			return;
+		}
+
+		namespace zp     = engine::editor::world::zone_presets;
+		namespace wizard = engine::editor::world::wizard;
+
+		// 1) Choix du wizard → ZonePreset (résolution déterministe, id dérivé des
+		//    choix). Le seed UI est déjà recopié dans le wizard via SetSeed.
+		const wizard::WizardChoices& choices = m_wizard.Choices();
+		const zp::ZonePreset preset = m_wizardResolver.Resolve(choices);
+
+		// 2) Customisation : le wizard ne porte pas de curseurs relief/eau/dryness
+		//    (ils sont encodés dans le template résolu). On laisse les
+		//    multiplicateurs neutres (1.0) et on propage le seed du wizard, comme
+		//    le ZonePresetDialog le fait pour son propre champ seed.
+		zp::CustomizationParams custom;
+		custom.reliefMultiplier       = 1.0f;
+		custom.waterDensityMultiplier = 1.0f;
+		custom.drynessMultiplier      = 1.0f;
+		custom.seed                   = choices.seed;
+
+		// 3) DispatchContext construit EXACTEMENT comme dans
+		//    ZonePresetDialog::RunSelectedPreset (mêmes documents, mêmes catalogs,
+		//    même Config pour les 4 ops simulation). Réutilisation du chemin
+		//    canonique : aucune divergence de câblage entre dialog et wizard.
+		const zp::DispatchContext ctx{
+			m_shell->MutableTerrainDocument(),
+			m_shell->MutableWaterDocument(),
+			m_shell->MutableMeshInsertDocument(),
+			m_shell->MutableDungeonPortalDocument(),
+			m_shell->GetCaveTool().Catalog(),
+			m_shell->GetOverhangTool().Catalog(),
+			m_shell->GetArchTool().Catalog(),
+			m_shell->GetDungeonPortalTool().Catalog(),
+			m_cfg,  // requis par les 4 ops simulation ; si null elles renvoient Failed.
+		};
+
+		LOG_INFO(Render,
+			"[WorldEditorImGui] Wizard genere '{}' (climat={} relief={} cote={} poi={} seed={})",
+			preset.id, choices.climate, choices.relief, choices.coast, choices.poi,
+			choices.seed);
+
+		// 4) Exécution synchrone sur le CommandStack du Shell (main thread bloqué
+		//    le temps de l'exécution — convention single-thread éditeur, cf.
+		//    ZonePresetExecutor.h). Callback de progression inerte (on ne peut pas
+		//    pumper ImGui pendant Execute) ; la progression part au log.
+		zp::ZonePresetExecutor executor;
+		m_wizardLastSummary = executor.Execute(preset, custom,
+			m_shell->MutableCommandStack(), ctx,
+			[](const zp::ExecutionProgress&) { return true; });
+
+		m_wizardLastPresetId = preset.id;
+		m_wizardHasGenerated = true;
+
+		LOG_INFO(Render,
+			"[WorldEditorImGui] Wizard '{}' termine (pushed={}, skipped={}, failed={}, annule={}).",
+			preset.id, m_wizardLastSummary.commandsPushed,
+			m_wizardLastSummary.unsupportedSkipped, m_wizardLastSummary.failed,
+			m_wizardLastSummary.wasCancelled ? "oui" : "non");
 	}
 
 #if defined(_WIN32)
@@ -2341,10 +2461,255 @@ namespace engine::editor
 
 		ImGui::End();
 	}
+
+	namespace
+	{
+		/// Dessine une rangée de cartes de choix pour une étape du wizard.
+		/// Chaque carte est un `Selectable` qui, au clic, applique la valeur
+		/// associée via `SetChoiceForCurrentStep`. La carte correspondant à la
+		/// valeur courante est mise en évidence (cadre actif ImGui).
+		/// \param wizard       machine d'état du wizard (modifiée au clic).
+		/// \param currentValue valeur actuellement retenue pour cette étape
+		///                     (issue de `wizard.Choices()`), pour le surlignage.
+		/// \param options      paires {valeur interne, libellé FR affiché}.
+		/// Effet de bord : appelle `wizard.SetChoiceForCurrentStep` au clic
+		/// (modifie les choix). À appeler en main thread (rendu ImGui).
+		void DrawWizardChoiceCards(
+			engine::editor::world::wizard::QuickStartWizard& wizard,
+			const std::string& currentValue,
+			const std::vector<std::pair<const char*, const char*>>& options)
+		{
+			for (size_t i = 0; i < options.size(); ++i)
+			{
+				const char* value = options[i].first;
+				const char* label = options[i].second;
+				const bool selected = (currentValue == value);
+				ImGui::PushID(static_cast<int>(i));
+				// Carte de largeur fixe, alignées horizontalement (3-4 par étape).
+				if (ImGui::Selectable(label, selected, 0, ImVec2(150.0f, 60.0f)))
+				{
+					(void)wizard.SetChoiceForCurrentStep(value);
+				}
+				ImGui::PopID();
+				if (i + 1 < options.size())
+				{
+					ImGui::SameLine();
+				}
+			}
+		}
+	} // namespace
+
+	/// Réinitialise l'assistant à son état initial (étape Climat, choix par
+	/// défaut, seed 42). Voir le `///` de déclaration pour la sémantique et le
+	/// moment d'appel (transition fermé→ouvert uniquement). Effet de bord :
+	/// remplace `m_wizard` par une instance neuve et remet les flags/seed UI.
+	void WorldEditorImGui::ResetWizardState()
+	{
+		// Instance neuve : repart à WizardStep::Climate avec les WizardChoices
+		// par défaut (cf. QuickStartWizard.h : pas de Reset()/Restart() dédié).
+		m_wizard = engine::editor::world::wizard::QuickStartWizard{};
+		// Seed UI ré-aligné sur le défaut des WizardChoices (42), puis recopié
+		// dans le wizard pour que l'étape Aperçu et la génération soient cohérentes.
+		m_wizardSeed = 42;
+		m_wizard.SetSeed(static_cast<uint32_t>(m_wizardSeed));
+		// Flags transitoires : aucune confirmation en attente, pas de bandeau de
+		// résumé d'une génération précédente.
+		m_wizardConfirmRequested = false;
+		m_wizardHasGenerated = false;
+	}
+
+	/// Rend la fenêtre de l'assistant « Nouvelle zone » (5 étapes) + sa modale
+	/// de confirmation de génération. Doit être appelée chaque frame depuis
+	/// BuildUi. Effet de bord : ImGui state ; déclenche `RunWizardGeneration`
+	/// à la confirmation de la modale.
+	void WorldEditorImGui::RenderWizardWindow()
+	{
+		if (!m_showWizard)
+		{
+			return;
+		}
+
+		namespace wizard = engine::editor::world::wizard;
+
+		ImGui::SetNextWindowSize(ImVec2(640.0f, 480.0f), ImGuiCond_FirstUseEver);
+		if (!ImGui::Begin("Nouvelle zone (assistant)", &m_showWizard,
+			ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::End();
+			return;
+		}
+
+		const wizard::WizardStep step = m_wizard.CurrentStep();
+		const wizard::WizardChoices& choices = m_wizard.Choices();
+
+		// En-tête : numéro et nom de l'étape courante (5 étapes au total).
+		static const char* kStepNames[5] = {
+			"1/5 - Climat", "2/5 - Relief", "3/5 - Cote", "4/5 - Points d'interet",
+			"5/5 - Apercu" };
+		const int stepIdx = static_cast<int>(step);
+		ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f), "Etape %s",
+			kStepNames[stepIdx < 0 || stepIdx > 4 ? 4 : stepIdx]);
+		ImGui::Separator();
+
+		// Corps : cartes de choix selon l'étape, ou récapitulatif à l'Aperçu.
+		switch (step)
+		{
+		case wizard::WizardStep::Climate:
+			ImGui::TextWrapped("Choisis le climat dominant de la zone.");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.climate, {
+				{ "temperate", "Tempere" }, { "arid", "Aride" },
+				{ "polar", "Polaire" }, { "tropical", "Tropical" } });
+			break;
+		case wizard::WizardStep::Relief:
+			ImGui::TextWrapped("Choisis le relief general du terrain.");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.relief, {
+				{ "plains", "Plaines" }, { "hills", "Collines" },
+				{ "mountains", "Montagnes" }, { "escarped", "Escarpe" } });
+			break;
+		case wizard::WizardStep::Coast:
+			ImGui::TextWrapped("Quel rapport la zone a-t-elle a la cote ?");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.coast, {
+				{ "interior", "Interieur" }, { "moderate", "Cote moderee" },
+				{ "dramatic", "Cote spectaculaire" } });
+			break;
+		case wizard::WizardStep::Poi:
+			ImGui::TextWrapped("Ajoute un point d'interet principal (optionnel).");
+			ImGui::Spacing();
+			DrawWizardChoiceCards(m_wizard, choices.poi, {
+				{ "none", "Aucun" }, { "cave", "Grotte" },
+				{ "ruin", "Ruine" }, { "dungeon", "Donjon" } });
+			break;
+		case wizard::WizardStep::Preview:
+		default:
+			ImGui::TextWrapped("Recapitulatif des choix. Ajuste le seed puis genere "
+				"la zone.");
+			ImGui::Spacing();
+			ImGui::BulletText("Climat : %s", choices.climate.c_str());
+			ImGui::BulletText("Relief : %s", choices.relief.c_str());
+			ImGui::BulletText("Cote   : %s", choices.coast.c_str());
+			ImGui::BulletText("POI    : %s", choices.poi.c_str());
+			ImGui::Spacing();
+			// Champ seed → SetSeed (le wizard ne valide pas le seed).
+			if (ImGui::InputInt("Seed RNG", &m_wizardSeed, 1, 100))
+			{
+				if (m_wizardSeed < 0) m_wizardSeed = 0;
+				m_wizard.SetSeed(static_cast<uint32_t>(m_wizardSeed));
+			}
+			break;
+		}
+
+		// Pied de page : navigation + (à l'Aperçu) bouton Générer.
+		ImGui::Separator();
+
+		// Précédent : actif sauf à la 1re étape.
+		const bool canPrev = (step != wizard::WizardStep::Climate);
+		if (!canPrev) ImGui::BeginDisabled();
+		if (ImGui::Button("Precedent", ImVec2(120.0f, 0.0f)) && canPrev)
+		{
+			(void)m_wizard.Prev();
+		}
+		if (!canPrev) ImGui::EndDisabled();
+
+		ImGui::SameLine();
+
+		if (step != wizard::WizardStep::Preview)
+		{
+			// Suivant : gardé par CanProceed (choix valide pour l'étape courante).
+			const bool canNext = m_wizard.CanProceed();
+			if (!canNext) ImGui::BeginDisabled();
+			if (ImGui::Button("Suivant", ImVec2(120.0f, 0.0f)) && canNext)
+			{
+				(void)m_wizard.Next();
+			}
+			if (!canNext) ImGui::EndDisabled();
+			if (!canNext && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+			{
+				ImGui::SetTooltip("Selectionne un choix pour continuer.");
+			}
+		}
+		else
+		{
+			// Étape Aperçu : bouton Générer actif seulement si prêt.
+			const bool canGenerate = m_wizard.IsReadyToGenerate();
+			if (!canGenerate) ImGui::BeginDisabled();
+			if (ImGui::Button("Generer", ImVec2(120.0f, 0.0f)) && canGenerate)
+			{
+				// Demande la modale de confirmation (poussée plus bas, hors de la
+				// pile de widgets disabled).
+				m_wizardConfirmRequested = true;
+			}
+			if (!canGenerate) ImGui::EndDisabled();
+		}
+
+		ImGui::SameLine();
+		if (ImGui::Button("Fermer", ImVec2(120.0f, 0.0f)))
+		{
+			m_showWizard = false;
+		}
+
+		// Bandeau de résumé de la dernière génération (sous le pied de page).
+		if (m_wizardHasGenerated)
+		{
+			ImGui::Separator();
+			ImGui::Text("Derniere generation : '%s'", m_wizardLastPresetId.c_str());
+			ImGui::Text("Commandes poussees : %u  -  Ignorees : %u  -  Echecs : %u",
+				m_wizardLastSummary.commandsPushed,
+				m_wizardLastSummary.unsupportedSkipped,
+				m_wizardLastSummary.failed);
+			if (m_wizardLastSummary.unsupportedSkipped > 0u)
+			{
+				ImGui::TextWrapped("Note : %u operation(s) non supportee(s) ont ete "
+					"ignorees (coastline / river_network / hydraulic_erosion / "
+					"thermal_wind_erosion sans chemin d'execution complet ici).",
+					m_wizardLastSummary.unsupportedSkipped);
+			}
+		}
+
+		// Ouverture de la modale de confirmation (au prochain frame après le clic
+		// « Generer »). On la pousse hors de tout bloc disabled.
+		if (m_wizardConfirmRequested)
+		{
+			ImGui::OpenPopup("Confirmer la generation##wizard_confirm");
+			m_wizardConfirmRequested = false;
+		}
+
+		// Modale de confirmation : la génération RÉINITIALISE la zone courante
+		// (reset destructif de l'executor, non annulable — P0 connu partagé avec
+		// le ZonePresetDialog). On recommande de sauvegarder d'abord.
+		if (ImGui::BeginPopupModal("Confirmer la generation##wizard_confirm", nullptr,
+			ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::TextColored(ImVec4(1.f, 0.82f, 0.35f, 1.f),
+				"ATTENTION : action destructive et NON annulable.");
+			ImGui::Spacing();
+			ImGui::TextWrapped("La generation VIDE la zone courante (terrain, eau, "
+				"mesh inserts, portails de donjon) avant de la reconstruire. Cette "
+				"reinitialisation n'est pas annulable (Ctrl+Z ne la restaurera pas). "
+				"Sauvegarde la zone avant de continuer si tu veux la conserver.");
+			ImGui::Separator();
+			if (ImGui::Button("Generer (vider et reconstruire)", ImVec2(260.0f, 0.0f)))
+			{
+				RunWizardGeneration();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Annuler", ImVec2(120.0f, 0.0f)))
+			{
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+
+		ImGui::End();
+	}
 #else
 	void WorldEditorImGui::RenderValidationPanel() {}
 	void WorldEditorImGui::RenderGuidanceOverlay() {}
 	void WorldEditorImGui::RenderDiagnosticPanel() {}
+	void WorldEditorImGui::RenderWizardWindow() {}
 #endif
 
 	bool WorldEditorImGui::WantsCaptureMouse() const

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -24,6 +24,14 @@
 #include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
 #include "src/world_editor/diagnostic/DiagnosticSystem.h"
 #include "src/world_editor/diagnostic/IDiagnosticRule.h"
+// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard) : machine d'état
+// 5 étapes + résolveur de template. Inclus en entier (objets-valeur membres du
+// `WorldEditorImGui`, taille requise à la déclaration). Le résolveur transforme
+// les choix du wizard en `ZonePreset`, exécuté ensuite par le MÊME chemin que le
+// `ZonePresetDialog` (ZonePresetExecutor + CommandStack du Shell).
+#include "src/world_editor/wizard/QuickStartWizard.h"
+#include "src/world_editor/wizard/WizardTemplateResolver.h"
+#include "src/world_editor/zone_presets/ZonePresetExecutor.h" // ExecutionSummary (membre valeur)
 
 namespace engine::core
 {
@@ -264,6 +272,33 @@ namespace engine::editor
 		/// « aucune analyse lancée » plutôt qu'un rapport vide trompeur).
 		bool m_diagnosticHasRun = false;
 
+		// ── Lot C vague 4 : assistant « Nouvelle zone » (QuickStartWizard) ─────
+		/// Machine d'état des 5 étapes guidées (Climat / Relief / Côte / POI /
+		/// Aperçu). Logique pure, sans dépendance ImGui : l'UI ci-dessous ne fait
+		/// que la piloter (SetChoiceForCurrentStep, Next/Prev, SetSeed).
+		engine::editor::world::wizard::QuickStartWizard m_wizard;
+		/// Résolveur choix → `ZonePreset`. Sans état : instancié une fois comme
+		/// membre valeur, `Resolve` appelé au moment de la génération.
+		engine::editor::world::wizard::WizardTemplateResolver m_wizardResolver;
+		/// Flag de visibilité de la fenêtre wizard (ouvert par Fichier > « Nouvelle
+		/// zone (assistant)... », fermé par le bouton Fermer/Annuler ou la croix).
+		bool m_showWizard = false;
+		/// True quand la modale de confirmation de génération est demandée : posée
+		/// par le bouton « Générer » de l'étape Aperçu, consommée une seule fois par
+		/// `RenderWizardWindow` qui pousse l'`ImGui::OpenPopup` correspondant.
+		bool m_wizardConfirmRequested = false;
+		/// Champ seed édité dans l'UI (étape Aperçu). Recopié dans le wizard via
+		/// `SetSeed` à chaque modification — `int` car `ImGui::InputInt` l'exige.
+		int m_wizardSeed = 42;
+		/// Résumé de la dernière génération via le wizard (commandes poussées /
+		/// ignorées / échecs). `totalSteps == 0` → aucune génération encore lancée.
+		engine::editor::world::zone_presets::ExecutionSummary m_wizardLastSummary{};
+		/// True dès qu'une génération a été lancée depuis le wizard (alimente le
+		/// bandeau de résumé en bas de l'étape Aperçu).
+		bool m_wizardHasGenerated = false;
+		/// Id du preset effectivement résolu+exécuté (affiché dans le résumé).
+		std::string m_wizardLastPresetId;
+
 		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
 		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,
 		/// stockant le résultat dans `m_lastValidationReport`. No-op si `m_shell`
@@ -313,6 +348,42 @@ namespace engine::editor
 		/// `m_lastDiagnosticReport`/`m_diagnosticHasRun` à jour au clic « Analyser ».
 		/// Doit être appelée pendant la frame UI (entre NewFrame et Render).
 		void RenderDiagnosticPanel();
+
+		/// Lot C vague 4 — Rend la fenêtre de l'assistant « Nouvelle zone »
+		/// (5 étapes : Climat / Relief / Côte / POI / Aperçu). Cartes de choix
+		/// pilotant `m_wizard.SetChoiceForCurrentStep`, navigation Précédent/
+		/// Suivant gardée par `CanProceed`, champ seed (`SetSeed`). À l'étape
+		/// Aperçu, le bouton « Générer » (actif seulement si `IsReadyToGenerate()`)
+		/// demande la modale de confirmation. No-op si `m_showWizard` est faux.
+		/// Effet de bord : ImGui state ; peut déclencher `RunWizardGeneration` à la
+		/// confirmation. À appeler pendant la frame UI (entre NewFrame et Render).
+		/// Contrainte thread : main thread (ImGui + accès documents au moment de
+		/// la génération).
+		void RenderWizardWindow();
+
+		/// Lot C vague 4 — Réinitialise l'état de l'assistant à son défaut
+		/// (étape 1 = Climat, choix par défaut, seed 42, flags de confirmation
+		/// et bandeau de résumé remis à zéro). Appelée UNIQUEMENT à la transition
+		/// fermé→ouvert de la fenêtre (entrée menu « Nouvelle zone (assistant)… »)
+		/// pour que chaque réouverture reparte du début, jamais à chaque frame.
+		/// Effet de bord : remplace `m_wizard` par une instance neuve et remet
+		/// `m_wizardSeed`/`m_wizardConfirmRequested`/`m_wizardHasGenerated`.
+		void ResetWizardState();
+
+		/// Lot C vague 4 — Résout les choix du wizard en `ZonePreset`
+		/// (`m_wizardResolver.Resolve`) puis l'exécute par le MÊME chemin que le
+		/// `ZonePresetDialog` : construction du `DispatchContext` depuis les refs
+		/// du Shell, `ZonePresetExecutor::Execute` sur le `CommandStack` du Shell.
+		/// DESTRUCTIF : l'executor vide d'abord les 4 documents de la zone
+		/// (`ResetEditedZoneDocuments`) — irréversible, c'est le P0 connu partagé
+		/// avec le dialog (cf. note `///` dans le .cpp). Renseigne
+		/// `m_wizardLastSummary`/`m_wizardLastPresetId`/`m_wizardHasGenerated`.
+		/// No-op si `m_shell` est nul. Effet de bord : vide+repeuple les documents
+		/// terrain/water/mesh/donjon, pousse des commandes sur le CommandStack.
+		/// Compilée CROSS-PLATFORM (hors garde `_WIN32`, comme `RunZoneValidation`)
+		/// : tous les types y sont pleinement qualifiés pour le build Linux.
+		/// Contrainte thread : main thread (accès documents non thread-safe).
+		void RunWizardGeneration();
 
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -18,6 +18,12 @@
 #include "src/world_editor/validation/ZoneValidator.h"
 #include "src/world_editor/help/OverlayGuidanceSystem.h"
 #include "src/world_editor/help/WidgetTargetRegistry.h"
+// Lot C vague 4 — sous-système diagnostic (« Pourquoi ça ne marche pas ? ») :
+// registre de règles workflow + moteur d'analyse. Inclus en entier (objets-valeur
+// membres du `WorldEditorImGui`, taille requise à la déclaration).
+#include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
+#include "src/world_editor/diagnostic/DiagnosticSystem.h"
+#include "src/world_editor/diagnostic/IDiagnosticRule.h"
 
 namespace engine::core
 {
@@ -234,6 +240,30 @@ namespace engine::editor
 		/// après le rendu de chaque widget-cible.
 		engine::editor::world::help::WidgetTargetRegistry m_widgetTargets;
 
+		// ── Lot C vague 4 : diagnostic « Pourquoi ça ne marche pas ? » ─────────
+		/// Registre des règles workflow MVP (10 règles, cf. RegisterMvpDiagnosticRules).
+		/// Rempli une seule fois au premier `BuildUi` (les règles sont sans état,
+		/// le registre prend l'ownership — réenregistrer empilerait des doublons,
+		/// d'où le flag `m_diagnosticRegistered`).
+		engine::editor::world::diagnostic::DiagnosticRuleRegistry m_diagnosticRegistry;
+		/// Moteur d'analyse référençant `m_diagnosticRegistry` (non-owning) ; déclaré
+		/// APRÈS le registre pour que sa durée de vie soit englobée (le système garde
+		/// une référence const sur le registre).
+		engine::editor::world::diagnostic::DiagnosticSystem m_diagnosticSystem{ m_diagnosticRegistry };
+		/// True après le 1er `RegisterMvpDiagnosticRules` — évite de réenregistrer
+		/// les règles à chaque frame.
+		bool m_diagnosticRegistered = false;
+		/// Flag de visibilité du panneau « Diagnostic » (toggle via menu Aide,
+		/// ouvert aussi par le bouton « Analyser »).
+		bool m_showDiagnosticPanel = false;
+		/// Dernier rapport produit par « Analyser ». Conservé entre frames pour
+		/// que le panneau affiche les suggestions sans réanalyser à chaque frame
+		/// (l'analyse n'a lieu qu'au clic sur « Analyser »).
+		engine::editor::world::diagnostic::DiagnosticSystem::Report m_lastDiagnosticReport;
+		/// True dès qu'au moins une analyse a été lancée (sinon le panneau affiche
+		/// « aucune analyse lancée » plutôt qu'un rapport vide trompeur).
+		bool m_diagnosticHasRun = false;
+
 		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
 		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,
 		/// stockant le résultat dans `m_lastValidationReport`. No-op si `m_shell`
@@ -260,6 +290,29 @@ namespace engine::editor
 		/// À appeler en fin de frame UI, juste avant `ImGui::Render`.
 		/// Effet de bord : ImGui foreground draw list uniquement.
 		void RenderGuidanceOverlay();
+
+		/// Lot C vague 4 — Construit un `DiagnosticContext` (état d'USAGE courant)
+		/// depuis l'état runtime accessible via `m_shell` (outil actif, nombre de
+		/// chunks, profondeur undo) + le dernier rapport de validation. Lecture
+		/// seule : ne modifie aucun document (pas de chargement disque, contrairement
+		/// à `RunZoneValidation`). Les champs sans source de suivi fiable (timing,
+		/// pièges d'usage spécifiques, mode Simple) gardent leur défaut neutre — voir
+		/// commentaires inline (« à instrumenter en 2e passe »). Retourne un contexte
+		/// vide (tous champs défaut) si `m_shell` est nul.
+		/// Compilée CROSS-PLATFORM (hors garde `_WIN32`, comme `RunZoneValidation`) :
+		/// tous les types y sont pleinement qualifiés pour le build Linux.
+		/// Contrainte thread : main thread (accès documents du shell).
+		engine::editor::world::diagnostic::DiagnosticContext BuildDiagnosticContext() const;
+
+		/// Lot C vague 4 — Rend le panneau ImGui « Diagnostic » (« Pourquoi ça ne
+		/// marche pas ? ») : bouton « Analyser » (appelle `m_diagnosticSystem.Analyze`
+		/// sur `BuildDiagnosticContext()` et stocke le résultat), puis liste les
+		/// suggestions triées par importance (Critical → Tip) avec leur libellé
+		/// d'action PROPOSÉE — affichage seul, AUCUNE exécution one-click. No-op si
+		/// `m_showDiagnosticPanel` est faux. Effet de bord : ImGui state, met
+		/// `m_lastDiagnosticReport`/`m_diagnosticHasRun` à jour au clic « Analyser ».
+		/// Doit être appelée pendant la frame UI (entre NewFrame et Render).
+		void RenderDiagnosticPanel();
 
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -24,14 +24,6 @@
 #include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
 #include "src/world_editor/diagnostic/DiagnosticSystem.h"
 #include "src/world_editor/diagnostic/IDiagnosticRule.h"
-// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard) : machine d'état
-// 5 étapes + résolveur de template. Inclus en entier (objets-valeur membres du
-// `WorldEditorImGui`, taille requise à la déclaration). Le résolveur transforme
-// les choix du wizard en `ZonePreset`, exécuté ensuite par le MÊME chemin que le
-// `ZonePresetDialog` (ZonePresetExecutor + CommandStack du Shell).
-#include "src/world_editor/wizard/QuickStartWizard.h"
-#include "src/world_editor/wizard/WizardTemplateResolver.h"
-#include "src/world_editor/zone_presets/ZonePresetExecutor.h" // ExecutionSummary (membre valeur)
 
 namespace engine::core
 {
@@ -272,33 +264,6 @@ namespace engine::editor
 		/// « aucune analyse lancée » plutôt qu'un rapport vide trompeur).
 		bool m_diagnosticHasRun = false;
 
-		// ── Lot C vague 4 : assistant « Nouvelle zone » (QuickStartWizard) ─────
-		/// Machine d'état des 5 étapes guidées (Climat / Relief / Côte / POI /
-		/// Aperçu). Logique pure, sans dépendance ImGui : l'UI ci-dessous ne fait
-		/// que la piloter (SetChoiceForCurrentStep, Next/Prev, SetSeed).
-		engine::editor::world::wizard::QuickStartWizard m_wizard;
-		/// Résolveur choix → `ZonePreset`. Sans état : instancié une fois comme
-		/// membre valeur, `Resolve` appelé au moment de la génération.
-		engine::editor::world::wizard::WizardTemplateResolver m_wizardResolver;
-		/// Flag de visibilité de la fenêtre wizard (ouvert par Fichier > « Nouvelle
-		/// zone (assistant)... », fermé par le bouton Fermer/Annuler ou la croix).
-		bool m_showWizard = false;
-		/// True quand la modale de confirmation de génération est demandée : posée
-		/// par le bouton « Générer » de l'étape Aperçu, consommée une seule fois par
-		/// `RenderWizardWindow` qui pousse l'`ImGui::OpenPopup` correspondant.
-		bool m_wizardConfirmRequested = false;
-		/// Champ seed édité dans l'UI (étape Aperçu). Recopié dans le wizard via
-		/// `SetSeed` à chaque modification — `int` car `ImGui::InputInt` l'exige.
-		int m_wizardSeed = 42;
-		/// Résumé de la dernière génération via le wizard (commandes poussées /
-		/// ignorées / échecs). `totalSteps == 0` → aucune génération encore lancée.
-		engine::editor::world::zone_presets::ExecutionSummary m_wizardLastSummary{};
-		/// True dès qu'une génération a été lancée depuis le wizard (alimente le
-		/// bandeau de résumé en bas de l'étape Aperçu).
-		bool m_wizardHasGenerated = false;
-		/// Id du preset effectivement résolu+exécuté (affiché dans le résumé).
-		std::string m_wizardLastPresetId;
-
 		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
 		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,
 		/// stockant le résultat dans `m_lastValidationReport`. No-op si `m_shell`
@@ -348,33 +313,6 @@ namespace engine::editor
 		/// `m_lastDiagnosticReport`/`m_diagnosticHasRun` à jour au clic « Analyser ».
 		/// Doit être appelée pendant la frame UI (entre NewFrame et Render).
 		void RenderDiagnosticPanel();
-
-		/// Lot C vague 4 — Rend la fenêtre de l'assistant « Nouvelle zone »
-		/// (5 étapes : Climat / Relief / Côte / POI / Aperçu). Cartes de choix
-		/// pilotant `m_wizard.SetChoiceForCurrentStep`, navigation Précédent/
-		/// Suivant gardée par `CanProceed`, champ seed (`SetSeed`). À l'étape
-		/// Aperçu, le bouton « Générer » (actif seulement si `IsReadyToGenerate()`)
-		/// demande la modale de confirmation. No-op si `m_showWizard` est faux.
-		/// Effet de bord : ImGui state ; peut déclencher `RunWizardGeneration` à la
-		/// confirmation. À appeler pendant la frame UI (entre NewFrame et Render).
-		/// Contrainte thread : main thread (ImGui + accès documents au moment de
-		/// la génération).
-		void RenderWizardWindow();
-
-		/// Lot C vague 4 — Résout les choix du wizard en `ZonePreset`
-		/// (`m_wizardResolver.Resolve`) puis l'exécute par le MÊME chemin que le
-		/// `ZonePresetDialog` : construction du `DispatchContext` depuis les refs
-		/// du Shell, `ZonePresetExecutor::Execute` sur le `CommandStack` du Shell.
-		/// DESTRUCTIF : l'executor vide d'abord les 4 documents de la zone
-		/// (`ResetEditedZoneDocuments`) — irréversible, c'est le P0 connu partagé
-		/// avec le dialog (cf. note `///` dans le .cpp). Renseigne
-		/// `m_wizardLastSummary`/`m_wizardLastPresetId`/`m_wizardHasGenerated`.
-		/// No-op si `m_shell` est nul. Effet de bord : vide+repeuple les documents
-		/// terrain/water/mesh/donjon, pousse des commandes sur le CommandStack.
-		/// Compilée CROSS-PLATFORM (hors garde `_WIN32`, comme `RunZoneValidation`)
-		/// : tous les types y sont pleinement qualifiés pour le build Linux.
-		/// Contrainte thread : main thread (accès documents non thread-safe).
-		void RunWizardGeneration();
 
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -8,6 +8,16 @@
 #include <vulkan/vulkan_core.h>
 
 #include "src/world_editor/ui/WorldMapEditDocument.h"
+// Lot C vague 4 — sous-systèmes câblés dans l'éditeur monde :
+//   - validation de zone (ZoneValidator) : registre + rapport trié par sévérité ;
+//   - guidance overlay (OverlayGuidanceSystem + WidgetTargetRegistry) : fondation
+//     du tutoriel interactif (rendu du voile/surlignage, aucune séquence lancée).
+// Inclus en entier (pas en forward-decl) car ces membres sont des objets-valeur
+// du `WorldEditorImGui` : leur taille doit être connue à la déclaration.
+#include "src/world_editor/validation/ValidationRuleRegistry.h"
+#include "src/world_editor/validation/ZoneValidator.h"
+#include "src/world_editor/help/OverlayGuidanceSystem.h"
+#include "src/world_editor/help/WidgetTargetRegistry.h"
 
 namespace engine::core
 {
@@ -189,6 +199,68 @@ namespace engine::editor
 		/// un drag de bord de fenetre, donnant une UI vide ou hors viewport).
 		float m_lastDockSpaceWidth  = 0.0f;
 		float m_lastDockSpaceHeight = 0.0f;
+
+		// ── Lot C vague 4 : validation de zone (ZoneValidator) ─────────────────
+		/// Registre des règles MVP (heightmap / splat / mesh inserts). Rempli une
+		/// fois par `RegisterMvpValidationRules` au premier `BuildUi` (les règles
+		/// sont sans état, l'enregistrement est idempotent côté éditeur grâce au
+		/// flag `m_validationRegistered`).
+		engine::editor::world::validation::ValidationRuleRegistry m_validationRegistry;
+		/// Validateur référençant `m_validationRegistry` (non-owning) ; déclaré
+		/// APRÈS le registre pour que sa durée de vie soit englobée (le validateur
+		/// garde une référence const sur le registre).
+		engine::editor::world::validation::ZoneValidator m_zoneValidator{ m_validationRegistry };
+		/// True après le 1er `RegisterMvpValidationRules` — évite de réenregistrer
+		/// les règles à chaque frame (le registre prend l'ownership et empilerait
+		/// des doublons sinon).
+		bool m_validationRegistered = false;
+		/// Dernier rapport produit par « Valider la zone ». Conservé entre frames
+		/// pour alimenter le panneau Validation et le gating de l'export runtime.
+		engine::editor::world::validation::ZoneValidator::Report m_lastValidationReport;
+		/// True dès qu'au moins une validation a été lancée (sinon le panneau
+		/// affiche « aucune validation lancée » plutôt qu'un rapport vide trompeur).
+		bool m_validationHasRun = false;
+		/// Flag de visibilité du panneau « Validation » (toggle via menu Vue et
+		/// ouvert automatiquement par le bouton « Valider la zone »).
+		bool m_showValidationPanel = false;
+
+		// ── Lot C vague 4 : guidance overlay (fondation tutoriel) ──────────────
+		/// Moteur de séquence d'instructions (logique pure). Aucune séquence n'est
+		/// lancée pour l'instant : `RenderGuidanceOverlay` ne dessine rien tant que
+		/// `IsActiveSequence()` est faux. Fondation pour le tutoriel interactif.
+		engine::editor::world::help::OverlayGuidanceSystem m_overlay;
+		/// Registre id → rectangle écran des widgets-cibles, vidé en début de frame
+		/// (`m_widgetTargets.Clear()`) et rerempli depuis les positions ImGui réelles
+		/// après le rendu de chaque widget-cible.
+		engine::editor::world::help::WidgetTargetRegistry m_widgetTargets;
+
+		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
+		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,
+		/// stockant le résultat dans `m_lastValidationReport`. No-op si `m_shell`
+		/// ou `m_cfg` est nul (les chunks terrain ont besoin de la config pour le
+		/// chargement disque). Effet de bord : peut charger des chunks terrain en
+		/// RAM via `TerrainDocument::EnsureLoaded` ; met `m_validationHasRun` à
+		/// true et ouvre le panneau Validation.
+		/// Contrainte thread : main thread (accès documents + ImGui state ensuite).
+		void RunZoneValidation();
+
+		/// Lot C vague 4 — Rend le panneau ImGui « Validation » : compteurs
+		/// erreurs / warnings / hints + liste des problèmes triés par sévérité.
+		/// Un clic sur un problème logue sa position monde (le recentrage caméra
+		/// complet est différé — l'API caméra n'est pas exposée ici). No-op si
+		/// `m_showValidationPanel` est faux. Effet de bord : ImGui state, LOG_INFO
+		/// au clic. Doit être appelée pendant la frame UI (entre NewFrame et Render).
+		void RenderValidationPanel();
+
+		/// Lot C vague 4 — Si une séquence de guidance est active
+		/// (`m_overlay.IsActiveSequence()`), dessine via le foreground draw list :
+		/// un voile semi-transparent plein écran, un rectangle de surlignage autour
+		/// du widget-cible (rect lu dans `m_widgetTargets`), et une bulle
+		/// titre/texte. No-op (ne dessine RIEN) quand aucune séquence n'est active.
+		/// À appeler en fin de frame UI, juste avant `ImGui::Render`.
+		/// Effet de bord : ImGui foreground draw list uniquement.
+		void RenderGuidanceOverlay();
+
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
 #endif

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -18,6 +18,10 @@
 #include "src/world_editor/validation/ZoneValidator.h"
 #include "src/world_editor/help/OverlayGuidanceSystem.h"
 #include "src/world_editor/help/WidgetTargetRegistry.h"
+// Lot C vague 4 — TutorialSystem : pilote le tutoriel interactif « first_launch »
+// via l'OverlayGuidanceSystem ci-dessus. Inclus en entier (objet-valeur membre
+// du `WorldEditorImGui`, taille requise à la déclaration).
+#include "src/world_editor/tutorial/TutorialSystem.h"
 // Lot C vague 4 — sous-système diagnostic (« Pourquoi ça ne marche pas ? ») :
 // registre de règles workflow + moteur d'analyse. Inclus en entier (objets-valeur
 // membres du `WorldEditorImGui`, taille requise à la déclaration).
@@ -247,6 +251,12 @@ namespace engine::editor
 		/// (`m_widgetTargets.Clear()`) et rerempli depuis les positions ImGui réelles
 		/// après le rendu de chaque widget-cible.
 		engine::editor::world::help::WidgetTargetRegistry m_widgetTargets;
+		/// Tutoriel interactif « first_launch » (8 étapes). Chargé une fois dans le
+		/// constructeur (`LoadTutorialById("first_launch")`), démarré MANUELLEMENT
+		/// via le menu « Aide → Lancer le tutoriel » (`m_tutorial.Start(m_overlay)`).
+		/// Aucun auto-lancement au premier démarrage dans cette tranche (la détection
+		/// premier-lancement via UserPrefs reste à câbler — auto-start différé).
+		engine::editor::world::tutorial::TutorialSystem m_tutorial;
 
 		// ── Lot C vague 4 : diagnostic « Pourquoi ça ne marche pas ? » ─────────
 		/// Registre des règles workflow MVP (10 règles, cf. RegisterMvpDiagnosticRules).

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -24,6 +24,14 @@
 #include "src/world_editor/diagnostic/DiagnosticRuleRegistry.h"
 #include "src/world_editor/diagnostic/DiagnosticSystem.h"
 #include "src/world_editor/diagnostic/IDiagnosticRule.h"
+// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard) : machine d'état
+// 5 étapes + résolveur de template. Inclus en entier (objets-valeur membres du
+// `WorldEditorImGui`, taille requise à la déclaration). Le résolveur transforme
+// les choix du wizard en `ZonePreset`, exécuté ensuite par le MÊME chemin que le
+// `ZonePresetDialog` (ZonePresetExecutor + CommandStack du Shell).
+#include "src/world_editor/wizard/QuickStartWizard.h"
+#include "src/world_editor/wizard/WizardTemplateResolver.h"
+#include "src/world_editor/zone_presets/ZonePresetExecutor.h" // ExecutionSummary (membre valeur)
 
 namespace engine::core
 {
@@ -264,6 +272,33 @@ namespace engine::editor
 		/// « aucune analyse lancée » plutôt qu'un rapport vide trompeur).
 		bool m_diagnosticHasRun = false;
 
+		// ── Lot C vague 4 : assistant « Nouvelle zone » (QuickStartWizard) ─────
+		/// Machine d'état des 5 étapes guidées (Climat / Relief / Côte / POI /
+		/// Aperçu). Logique pure, sans dépendance ImGui : l'UI ci-dessous ne fait
+		/// que la piloter (SetChoiceForCurrentStep, Next/Prev, SetSeed).
+		engine::editor::world::wizard::QuickStartWizard m_wizard;
+		/// Résolveur choix → `ZonePreset`. Sans état : instancié une fois comme
+		/// membre valeur, `Resolve` appelé au moment de la génération.
+		engine::editor::world::wizard::WizardTemplateResolver m_wizardResolver;
+		/// Flag de visibilité de la fenêtre wizard (ouvert par Fichier > « Nouvelle
+		/// zone (assistant)... », fermé par le bouton Fermer/Annuler ou la croix).
+		bool m_showWizard = false;
+		/// True quand la modale de confirmation de génération est demandée : posée
+		/// par le bouton « Générer » de l'étape Aperçu, consommée une seule fois par
+		/// `RenderWizardWindow` qui pousse l'`ImGui::OpenPopup` correspondant.
+		bool m_wizardConfirmRequested = false;
+		/// Champ seed édité dans l'UI (étape Aperçu). Recopié dans le wizard via
+		/// `SetSeed` à chaque modification — `int` car `ImGui::InputInt` l'exige.
+		int m_wizardSeed = 42;
+		/// Résumé de la dernière génération via le wizard (commandes poussées /
+		/// ignorées / échecs). `totalSteps == 0` → aucune génération encore lancée.
+		engine::editor::world::zone_presets::ExecutionSummary m_wizardLastSummary{};
+		/// True dès qu'une génération a été lancée depuis le wizard (alimente le
+		/// bandeau de résumé en bas de l'étape Aperçu).
+		bool m_wizardHasGenerated = false;
+		/// Id du preset effectivement résolu+exécuté (affiché dans le résumé).
+		std::string m_wizardLastPresetId;
+
 		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
 		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,
 		/// stockant le résultat dans `m_lastValidationReport`. No-op si `m_shell`
@@ -313,6 +348,33 @@ namespace engine::editor
 		/// `m_lastDiagnosticReport`/`m_diagnosticHasRun` à jour au clic « Analyser ».
 		/// Doit être appelée pendant la frame UI (entre NewFrame et Render).
 		void RenderDiagnosticPanel();
+
+		/// Lot C vague 4 — Rend la fenêtre de l'assistant « Nouvelle zone »
+		/// (5 étapes : Climat / Relief / Côte / POI / Aperçu). Cartes de choix
+		/// pilotant `m_wizard.SetChoiceForCurrentStep`, navigation Précédent/
+		/// Suivant gardée par `CanProceed`, champ seed (`SetSeed`). À l'étape
+		/// Aperçu, le bouton « Générer » (actif seulement si `IsReadyToGenerate()`)
+		/// demande la modale de confirmation. No-op si `m_showWizard` est faux.
+		/// Effet de bord : ImGui state ; peut déclencher `RunWizardGeneration` à la
+		/// confirmation. À appeler pendant la frame UI (entre NewFrame et Render).
+		/// Contrainte thread : main thread (ImGui + accès documents au moment de
+		/// la génération).
+		void RenderWizardWindow();
+
+		/// Lot C vague 4 — Résout les choix du wizard en `ZonePreset`
+		/// (`m_wizardResolver.Resolve`) puis l'exécute par le MÊME chemin que le
+		/// `ZonePresetDialog` : construction du `DispatchContext` depuis les refs
+		/// du Shell, `ZonePresetExecutor::Execute` sur le `CommandStack` du Shell.
+		/// DESTRUCTIF : l'executor vide d'abord les 4 documents de la zone
+		/// (`ResetEditedZoneDocuments`) — irréversible, c'est le P0 connu partagé
+		/// avec le dialog (cf. note `///` dans le .cpp). Renseigne
+		/// `m_wizardLastSummary`/`m_wizardLastPresetId`/`m_wizardHasGenerated`.
+		/// No-op si `m_shell` est nul. Effet de bord : vide+repeuple les documents
+		/// terrain/water/mesh/donjon, pousse des commandes sur le CommandStack.
+		/// Compilée CROSS-PLATFORM (hors garde `_WIN32`, comme `RunZoneValidation`)
+		/// : tous les types y sont pleinement qualifiés pour le build Linux.
+		/// Contrainte thread : main thread (accès documents non thread-safe).
+		void RunWizardGeneration();
 
 #if defined(_WIN32)
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -18,10 +18,6 @@
 #include "src/world_editor/validation/ZoneValidator.h"
 #include "src/world_editor/help/OverlayGuidanceSystem.h"
 #include "src/world_editor/help/WidgetTargetRegistry.h"
-// Lot C vague 4 — TutorialSystem : pilote le tutoriel interactif « first_launch »
-// via l'OverlayGuidanceSystem ci-dessus. Inclus en entier (objet-valeur membre
-// du `WorldEditorImGui`, taille requise à la déclaration).
-#include "src/world_editor/tutorial/TutorialSystem.h"
 // Lot C vague 4 — sous-système diagnostic (« Pourquoi ça ne marche pas ? ») :
 // registre de règles workflow + moteur d'analyse. Inclus en entier (objets-valeur
 // membres du `WorldEditorImGui`, taille requise à la déclaration).
@@ -251,12 +247,6 @@ namespace engine::editor
 		/// (`m_widgetTargets.Clear()`) et rerempli depuis les positions ImGui réelles
 		/// après le rendu de chaque widget-cible.
 		engine::editor::world::help::WidgetTargetRegistry m_widgetTargets;
-		/// Tutoriel interactif « first_launch » (8 étapes). Chargé une fois dans le
-		/// constructeur (`LoadTutorialById("first_launch")`), démarré MANUELLEMENT
-		/// via le menu « Aide → Lancer le tutoriel » (`m_tutorial.Start(m_overlay)`).
-		/// Aucun auto-lancement au premier démarrage dans cette tranche (la détection
-		/// premier-lancement via UserPrefs reste à câbler — auto-start différé).
-		engine::editor::world::tutorial::TutorialSystem m_tutorial;
 
 		// ── Lot C vague 4 : diagnostic « Pourquoi ça ne marche pas ? » ─────────
 		/// Registre des règles workflow MVP (10 règles, cf. RegisterMvpDiagnosticRules).

--- a/src/world_editor/wizard/WizardTemplateResolver.cpp
+++ b/src/world_editor/wizard/WizardTemplateResolver.cpp
@@ -33,6 +33,19 @@ namespace engine::editor::world::wizard
 			return ""; // "none"
 		}
 
+		/// Identifiant catalogue par défaut associé au choix POI. Doit exister
+		/// dans le catalogue correspondant (dungeon/cave/arch) côté
+		/// OperationDispatcher, sinon l'op `place_*` échoue (`catalogId
+		/// introuvable`). MVP : un seul preset de départ par type.
+		/// \return chaîne vide pour "none" (aucune op POI émise).
+		std::string PoiCatalogId(const std::string& poi)
+		{
+			if (poi == "cave")    return "cave_small_01";
+			if (poi == "ruin")    return "arch_small_01";
+			if (poi == "dungeon") return "dungeon_starter_keep";
+			return "";
+		}
+
 		/// Template code-défini (placeholders {{var}} + conditions "if").
 		std::vector<TemplateOp> BuildTemplate(const WizardChoices& c)
 		{
@@ -44,8 +57,10 @@ namespace engine::editor::world::wizard
 			else
 				ops.push_back({ "mountain_macro", "", { "relief" }, "{ \"relief\": \"{{relief}}\", \"seed\": {{seed}} }" });
 
-			// 2. Splat selon climat (toujours).
-			ops.push_back({ "splat_paint", "", { "dryness" }, "{ \"climate\": \"{{climate}}\" }" });
+			// 2. (Retiré) Le splat_paint n'est pas câblé dans l'OperationDispatcher
+			// (skip non-fatal « Unsupported » qui polluait le résumé avec « 1 skipped »).
+			// La splat procédurale par défaut s'applique de toute façon ; on ne
+			// l'émet donc plus dans le template du wizard.
 
 			// 3. Érosion hydraulique (toujours) — eau selon climat.
 			ops.push_back({ "hydraulic_erosion", "", { "water_density" }, "{ \"climate\": \"{{climate}}\" }" });
@@ -53,7 +68,10 @@ namespace engine::editor::world::wizard
 			// 4. Côte (si pas intérieur).
 			ops.push_back({ "coastline", "coast != 'interior'", {}, "{ \"coast\": \"{{coast}}\" }" });
 
-			// 5. Point d'intérêt (si pas none).
+			// 5. Point d'intérêt (si pas none). Le rawJson (catalogId +
+			// worldPosition) est construit dans `Resolve` une fois la polyline
+			// connue (worldPosition = point médian de la polyline) ; on laisse
+			// ici un fragment minimal qui sera ENTIÈREMENT remplacé.
 			const std::string poiType = PoiOpType(c.poi);
 			if (!poiType.empty())
 				ops.push_back({ poiType, "poi != 'none'", {}, "{ \"poi\": \"{{poi}}\" }" });
@@ -86,21 +104,78 @@ namespace engine::editor::world::wizard
 			preset.operations.push_back(std::move(op));
 		}
 
-		// Auto-gen : la polyline du macro relief (déterministe) est calculée ici
-		// pour que l'exécuteur (ou les tests) puisse la consommer. On l'encode
-		// dans le rawJson de la 1re opération (macro) pour rester self-contained.
+		// Auto-gen : la polyline du macro relief (déterministe pour
+		// (relief, seed)) est calculée ici puis injectée dans les ops qui en
+		// dépendent. `GenerateMountainPolyline` renvoie des `Vec3` en
+		// coordonnées MONDE (x/z planaires en mètres, y = hauteur du relief).
 		if (!preset.operations.empty())
 		{
 			const auto polyline = GenerateMountainPolyline(choices.relief, choices.seed);
-			std::string pts = "[";
+
+			// --- 1) Champ "polyline" PLAT [x0,z0,x1,z1,…] (paires x,z, on DROP
+			// le y) injecté DANS l'objet JSON de l'op macro (1re op). Le
+			// dispatcher (BuildMacroParamsFromJson) exige flat.size() >= 4 et
+			// pair. On insère `, "polyline": <flat>` juste avant la dernière `}`.
+			std::string flat = "[";
 			for (size_t i = 0; i < polyline.size(); ++i)
 			{
-				if (i) pts += ",";
-				pts += "[" + std::to_string(polyline[i].x) + "," +
-					std::to_string(polyline[i].y) + "," + std::to_string(polyline[i].z) + "]";
+				if (i) flat += ",";
+				flat += std::to_string(polyline[i].x) + "," +
+					std::to_string(polyline[i].z);
 			}
-			pts += "]";
-			preset.operations.front().rawJson += " /*polyline=*/ " + pts;
+			flat += "]";
+
+			std::string& macroJson = preset.operations.front().rawJson;
+			const size_t closeBrace = macroJson.find_last_of('}');
+			if (closeBrace != std::string::npos)
+			{
+				macroJson.insert(closeBrace, ", \"polyline\": " + flat);
+			}
+
+			// --- 2) Op POI (si présente) : reconstruit ENTIÈREMENT son rawJson
+			// avec catalogId + position. Le point d'ancrage est le point MÉDIAN
+			// de la polyline (même espace de coordonnées que le relief), à y=0
+			// (le client recale au sol). `place_cave`/`place_dungeon` lisent
+			// `worldPosition` (3 floats plats [x,y,z]) ; `place_arch` (= ruine)
+			// exige plutôt `pillarA`/`pillarB` (le dispatcher en dérive le
+			// midpoint/yaw/scale) → on émet deux piliers écartés autour du médian.
+			if (!polyline.empty())
+			{
+				const std::string poiType = PoiOpType(choices.poi);
+				const std::string catalogId = PoiCatalogId(choices.poi);
+				if (!poiType.empty() && !catalogId.empty())
+				{
+					const engine::math::Vec3 mid = polyline[polyline.size() / 2];
+					const std::string mx = std::to_string(mid.x);
+					const std::string mz = std::to_string(mid.z);
+
+					for (ZonePresetOperation& op : preset.operations)
+					{
+						if (op.type != poiType)
+							continue;
+
+						if (poiType == "place_arch")
+						{
+							// Deux piliers espacés de ~20 m sur X autour du médian.
+							constexpr float kHalfSpanMeters = 10.0f;
+							const std::string ax = std::to_string(mid.x - kHalfSpanMeters);
+							const std::string bx = std::to_string(mid.x + kHalfSpanMeters);
+							op.rawJson =
+								"{ \"poi\": \"" + choices.poi + "\""
+								", \"catalogId\": \"" + catalogId + "\""
+								", \"pillarA\": [" + ax + ",0," + mz + "]"
+								", \"pillarB\": [" + bx + ",0," + mz + "] }";
+						}
+						else
+						{
+							op.rawJson =
+								"{ \"poi\": \"" + choices.poi + "\""
+								", \"catalogId\": \"" + catalogId + "\""
+								", \"worldPosition\": [" + mx + ",0," + mz + "] }";
+						}
+					}
+				}
+			}
 		}
 
 		return preset;


### PR DESCRIPTION
## Contexte
Vague 4 du **Lot C** (accessibilité éditeur). 100% UI ImGui éditeur — aucun rendu terrain / pipeline Vulkan touché.

## Contenu
- **ZoneValidator** ✅ validé en jeu — panneau Validation + gating export.
- **DiagnosticSystem** ✅ validé en jeu — menu Aide « Diagnostic ».
- **QuickStartWizard** 🔧 **corrigé** (commit 14d4ac86) après constat en jeu :
  - Polyline du macro relief : était écrite en **commentaire C** hors JSON (jamais lue) → injectée comme vrai champ `"polyline"` **plat** dans l'op macro → relief enfin généré.
  - Ops POI : sans `catalogId`/position → échec. Reconstruites avec catalogId valide + worldPosition (ou pillarA/B pour la ruine), ancrées au point médian de la polyline.
  - `splat_paint` retiré (non câblé). Reset de l'assistant à la **réouverture**.
- **Fondation OverlayGuidance** présente mais dormante.

> TutorialSystem reste descopé (revert 2c1dd1be) — suivi dédié.

## À valider en jeu (Wizard)
Menu Fichier → « Nouvelle zone (assistant) » → étapes → **Générer** : le terrain doit se reconstruire avec **relief** (0 failed dans le bandeau de résultat). Rouvrir l'assistant doit repartir de l'étape 1.

## Déploiement
✅ **Éditeur (client) uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)