### PR TITLE
Lot C — Vague 5 : câblage boot des globals serveur (ConditionMgr/Graveyard/LocaleStrings)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1119,6 +1119,14 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/anticheat/AntiCheatGameplayRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/spell/SpellFamilyRuntime.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/maps/InstanceManagerRuntime.cpp
+    # Lot C (vague 5) : cablage boot des managers globals data-driven (SHARD-ONLY,
+    # namespace engine::server::shard::globals). Charges au boot depuis les tables
+    # de la migration 0042 (conditions/graveyards/locale_strings) si la DB est
+    # configuree. NE PAS ajouter a server_app (master) : symboles shard uniquement.
+    # ConnectionPool/DbHelpers/SqlPreparedStatement sont deja linkes plus bas (TA.4).
+    ${CMAKE_SOURCE_DIR}/src/shardd/internals/globals/ConditionMgr.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/internals/globals/GraveyardManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/internals/globals/LocaleStrings.cpp
     # TA.2 (replication des joueurs) : replication AoI executable sous Linux.
     # On ajoute ServerApp + la grille AoI + le transport UDP (porte POSIX en TA.1)
     # + les systemes gameplay que ServerApp instancie. On N'AJOUTE PAS ce que

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -24,10 +24,16 @@
 #include "src/shardd/anticheat/AntiCheatGameplayRuntime.h"
 #include "src/shardd/spell/SpellFamilyRuntime.h"
 #include "src/shardd/maps/InstanceManagerRuntime.h"
+// Lot C (vague 5) — Cablage boot des managers globals data-driven (chargement
+// defensif depuis la DB de la migration 0042 ; consommation gameplay differee).
+#include "src/shardd/internals/globals/ConditionMgr.h"
+#include "src/shardd/internals/globals/GraveyardManager.h"
+#include "src/shardd/internals/globals/LocaleStrings.h"
 
 #include <csignal>
 #include <chrono>
 #include <algorithm>
+#include <exception>
 #include <memory>
 #include <thread>
 
@@ -199,7 +205,11 @@ int main(int argc, char** argv)
 	// Injecte dans ServerApp pour lire characters.spawn_x/y/z au HandleHello. DB non
 	// configuree => Init false => spawn depuis le fichier (pont inactif, non bloquant).
 	engine::server::db::ConnectionPool characterDbPool;
-	if (characterDbPool.Init(config))
+	// Lot C (vague 5) : on memorise l'etat d'init du pool pour le reutiliser plus
+	// bas (chargement defensif des managers globals — ils n'accedent a la DB que si
+	// elle est reellement configuree).
+	const bool characterDbReady = characterDbPool.Init(config);
+	if (characterDbReady)
 	{
 		gameplayApp.SetCharacterDbPool(&characterDbPool);
 		LOG_INFO(Net, "[ShardMain] Pont position DB actif (spawn depuis characters)");
@@ -264,6 +274,57 @@ int main(int argc, char** argv)
 	engine::server::maps::InstanceManagerRuntime instanceMgr;
 	instanceMgr.SeedV1Maps();
 	LOG_INFO(Maps, "[InstanceManager] {} maps registered at boot", instanceMgr.MapCount());
+
+	// Lot C (vague 5) — Cablage boot des 3 managers globals data-driven :
+	// ConditionMgr, GraveyardManager, LocaleStrings. PERIMETRE STRICT : link +
+	// instanciation + Load() defensif + log de preuve. AUCUNE consommation gameplay
+	// ici (ClosestGraveyard mort/respawn, ConditionMgr quetes/spawns, LocaleStrings
+	// messages = follow-up). Les donnees viennent des tables de la migration 0042.
+	//
+	// DEFENSIF : ces managers sont OPTIONNELS a ce stade. Si la DB n'est pas
+	// configuree => on skip le Load (les compteurs restent a 0). Si un Load echoue
+	// ou leve => on logge et on CONTINUE le boot ; le shard ne doit jamais planter
+	// a cause d'eux. On les declare ici (duree de vie = main()) pour que de futurs
+	// systemes puissent s'y brancher.
+	engine::server::shard::globals::ConditionMgr conditionMgr;
+	engine::server::shard::globals::GraveyardManager graveyardMgr;
+	engine::server::shard::globals::LocaleStrings localeStrings;
+	if (characterDbReady)
+	{
+		// Locale par defaut lue depuis la config (clé server.locale.default) ; 0
+		// (= fr_FR, default LCDLLN) si la clé est absente. On borne a l'octet car
+		// LocaleId est un uint8_t.
+		const auto defaultLocale = static_cast<engine::server::shard::globals::LocaleId>(
+			config.GetInt("server.locale.default", 0) & 0xFF);
+		try
+		{
+			const bool condOk   = conditionMgr.Load(characterDbPool);
+			const bool graveOk  = graveyardMgr.Load(characterDbPool);
+			const bool localeOk = localeStrings.Load(characterDbPool, defaultLocale);
+			LOG_INFO(Globals,
+				"[Globals] charges au boot : ConditionMgr {} conditions / {} groups (ok={}), "
+				"GraveyardManager {} graveyards (ok={}), LocaleStrings {} strings (locale par defaut {}, ok={})",
+				conditionMgr.ConditionCount(), conditionMgr.GroupCount(), condOk,
+				graveyardMgr.Size(), graveOk,
+				localeStrings.Size(), static_cast<unsigned>(defaultLocale), localeOk);
+		}
+		catch (const std::exception& e)
+		{
+			LOG_ERROR(Globals,
+				"[Globals] echec du chargement (exception : {}) — boot poursuivi, managers vides",
+				e.what());
+		}
+		catch (...)
+		{
+			LOG_ERROR(Globals,
+				"[Globals] echec du chargement (exception inconnue) — boot poursuivi, managers vides");
+		}
+	}
+	else
+	{
+		LOG_WARN(Globals,
+			"[Globals] DB non configuree — ConditionMgr/GraveyardManager/LocaleStrings NON charges (skip defensif)");
+	}
 
 	// Tick periodique EventAI : intervalle 1s. La boucle principale tourne
 	// a 100ms (sleep_for(100ms) ci-dessous) donc on filtre via


### PR DESCRIPTION
## Contexte
Vague 5 du **Lot C**. Réf : `docs/audit/2026-06-13-lot-c-cablage.md`. **Câblage de boot uniquement** (link + instanciation + `Load()` défensif) — l'intégration gameplay (respawn / conditions / messages localisés) est un follow-up documenté.

## Contenu
- **CMake** : ajoute `ConditionMgr.cpp` / `GraveyardManager.cpp` / `LocaleStrings.cpp` à `shard_app` (bloc UNIX). **SHARD-ONLY** (namespace `engine::server::shard::globals`) — pas dans `server_app`. Avant : compilés uniquement dans les cibles de test.
- **Boot** (`shardd/main_linux.cpp`) : instanciation sur le pattern « Wave » après l'init DB. `Load()` **défensif** : gaté par `characterDbReady` (skip + `LOG_WARN` si DB non configurée), `try/catch` (`LOG_ERROR` + **le boot continue** — le shard ne plante jamais à cause de ces managers). Log de preuve des compteurs. Locale par défaut via `server.locale.default` (fallback 0).

## Déploiement
⚠️ **REDÉPLOIEMENT SHARD requis** (nouveau code de boot linké dans `shard_app`). Master non concerné.
⚠️ **SEED de données prod requis** : les tables `conditions`/`graveyards`/`locale_strings` viennent de la migration 0042 dont les seeds sont des **données de test** — sans seed prod, les managers chargent 0 entrée (sans planter). SQL non touché.

## Validation
build-linux compile et linke `shard_app` (validation réelle). Le comportement runtime (chargement des tables) nécessite un shard déployé + DB seedée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)