### PR TITLE
fix(client): masquer les marqueurs cimetiere/auberge quand le menu Pause/Options est ouvert

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,7 +7,10 @@ on:
     branches: [main, master]
 jobs:
   build-windows:
-    runs-on: windows-latest
+    # Epingle sur windows-2022 (= Visual Studio 2022 / v17). L'image `windows-latest`
+    # a derive vers Visual Studio 18, que le generateur CMake "Visual Studio 17 2022"
+    # (CMakePresets.json, preset vs2022-x64) ne trouve pas -> echec a la configuration.
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11380,6 +11380,12 @@ namespace engine
 					// réapparition (label + anneau au sol) — rend cimetières et
 					// auberges visibles sur la carte de démo. Couleur : gris pierre
 					// (cimetière) / ambre chaleureux (auberge).
+					// Z-order : ces marqueurs (label + anneau au sol) sont traces sur la
+					// foreground draw list ImGui, qui passe AU-DESSUS de toutes les fenetres
+					// (dont le panneau du menu Pause/Options). On les masque donc quand un menu
+					// modal est ouvert, sinon ils perforent le menu (meme garde que les
+					// interactibles / nameplates plus haut).
+					if (!m_inGamePauseMenuVisible && !m_inGameOptionsPanelVisible)
 					for (const RespawnMarker& marker : m_respawnMarkers)
 					{
 						const float markerGroundY = m_terrain.SampleHeightAtWorldXZ(marker.x, marker.z);


### PR DESCRIPTION
Basée sur `main` à jour (qui contient déjà #898 + le code des marqueurs de réapparition).

## Problème
Les marqueurs de points de réapparition (label « Auberge »/« Cimetière » + anneau au sol) sont tracés sur la **foreground draw list** ImGui — qui passe au-dessus de toutes les fenêtres, donc du panneau du menu Pause/Options. Résultat : ils perforaient le menu.

## Correctif
La boucle de rendu des marqueurs (`m_respawnMarkers`) est gardée par `if (!m_inGamePauseMenuVisible && !m_inGameOptionsPanelVisible)` — même principe que la garde interactibles/nameplates de #898. Les marqueurs disparaissent donc quand le menu est ouvert (confirmé : le test écran-noir a prouvé qu'ils sont bien de l'ImGui foreground).

## Suite (séparée, déjà validée avec l'utilisateur)
Poser un décor cimetière/auberge aux positions de `respawn_points.txt` (cimetière 120,120 ; auberge 88,100) via `world.scenery`, puis retirer ces marqueurs placeholder.

## Déploiement
✅ Client uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
