### PR TITLE
feat: menu d'options unifié (écran auth réutilisé en jeu)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-b2-menu-options-unifie.md
+++ b/docs/superpowers/plans/2026-06-14-b2-menu-options-unifie.md
@@ -1,0 +1,157 @@
+# B2 — Unification du menu d'options (réutiliser l'écran auth en jeu) — Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps en cases à cocher.
+
+**Goal :** Le bouton « Options » du menu Pause en jeu ouvre le **même** écran d'options que l'auth (source unique). Le mini-panneau in-game est supprimé. Le menu Pause (ESC) lui-même reste inchangé.
+
+**Architecture (Approche B — pipeline réutilisable) :** garder le presenter auth comme source unique de vérité, en levant 3 verrous qui ferment l'écran options dès `m_flowComplete` (entrée en jeu) :
+1. **Consume découplé** : l'application réelle des réglages (aujourd'hui sous `authGateActive`) tourne chaque frame.
+2. **Contexte d'options** (`m_optionsOpenInGame`) : assouplit les gardes `Phase` de l'apply/close, en neutralisant le `SetPhase` que déclenche `ApplyLocaleSelection` (sinon corruption session).
+3. **Wrapper de rendu** `RenderOptionsOverlay()` : rend l'écran options sans dépendre de `vs.active`, sans le décor « THÈME DE RACE », appelé en jeu à la place du mini-panneau.
+
+**Décisions produit validées (2026-06-14) :**
+- En jeu : **masquer les onglets Network et Account** (risque : déconnexion gameplay / actions de compte destructrices).
+- **Remap des touches éditable partout** (auth + en jeu) : porter le rebind interactif du mini-panneau dans l'onglet Controls unifié.
+
+**Contraintes :** pas de toolchain locale (build via CI ; items in-game non couverts par ctest → validation manuelle en jeu **indispensable** par l'utilisateur après chaque étape risquée). Réponses/commits FR, code EN. Conventions repo (PascalCase nouveau code, commentaires FR).
+
+**Déploiement :** ✅ 100 % client (UI/options/input). Pas de redéploiement serveur.
+
+**Branche :** `feat/b2-menu-options-unifie` (depuis `main`). Coordination merge : indépendante de la PR #901 (B1) ; régions différentes mais fichiers communs (`Engine.cpp`, `AuthImGuiRenderer.{h,cpp}`) → si #901 merge avant, rebaser B2.
+
+---
+
+## Carte de référence (architecte — fichier:ligne)
+
+- Entrée options auth : `AuthUiPresenterSettings.cpp:125-165` `OpenLanguageOptions()` (sauve `m_phaseBeforeOptions`, `SetPhase(LanguageOptions)`, init des `*Pending` depuis les valeurs live `:136-155`).
+- Mirrors UI : `AuthImGuiRenderer::PullLanguageOptionsFromPresenter()` `AuthImGuiRenderer.cpp:224-262`, source `BuildLanguageOptionsImGuiMirror()` `AuthUiPresenterSettings.cpp:54-79`.
+- Apply : `AuthImGuiOptions.cpp:605-608` → `submitOptionsMirror()` `AuthImGuiOptions.cpp:257-287` → `ImGuiApplyLanguageOptionsMenu()` `AuthUiPresenterSettings.cpp:81-114` (**garde `:83`**) → `CommitLanguageOptionsMenuApply()` `AuthUiPresenterSettings.cpp:213-257` (remplit les 4 commandes pending `:236-255`, puis `ApplyLocaleSelection(false)` `:256`).
+- `ApplyLocaleSelection(false)` : `AuthScreenLanguageSelect.cpp:40-80` — **`:78 SetPhase(m_phaseBeforeOptions)` ⚠️ ferme l'écran / change la phase**.
+- Consume (application réelle) : `Engine.cpp:8356-8439`, sous `authGateActive = IsInitialized() && !IsFlowComplete()` `:8356`. Consomme `ConsumePendingVideo/Audio/Control/GameSettings` (`AuthUiPresenterSettings.cpp:260-265,656-675`, idempotents : `{}` si pas `applyRequested`).
+- Close sans appliquer : `AuthUiPresenterSettings.cpp:116-124` (**garde `:118`**, `:122 m_phase = m_phaseBeforeOptions`).
+- Overlay rendu : `AuthImGuiRenderer::Render()` `:409` (`:411 if (!vs.active) return;`), `BeginFullscreenOverlay` `:499-518`, dispatch options `:461-464`, `End` `:496`. `vs.active = m_initialized && !m_flowComplete && m_authEnabled` `AuthUiPresenterCore.cpp:4426`.
+- `RenderOptionsScreen(const RenderModel&, ...)` : `AuthImGuiOptions.cpp:39`. N'utilise du RenderModel que `rm.authOptionsAccountLogin` `:501` et `rm.authOptionsAccountTagId` `:505` (remplis `AuthScreenOptions.cpp:98-99`). Tout le reste via `m_authPresenter` (toujours vivant en jeu). Appelle `DrawAuthTweaksPanel` en fin `:621` (décor à NE PAS afficher en jeu).
+- Onglets : Graphics `:294-332`, Audio `:333-340`, Controls `:341-366` (keybinds **lecture seule** `:357-365`), Language `:367-398`, UI `:399-443` (thème live `:416-442`), Network `:444-489`, Account `:490-532`.
+- Mini-panneau in-game (à supprimer) : `Engine.cpp` `if (m_inGameOptionsPanelVisible)` ~`11978-12194` ; rebind interactif `~12057-12143` (`m_rebindingAction`, `kRebindableKeys`, `m_keybindWarning`) ; effets live (`m_audioEngine.SetMasterVolume` `~12011`).
+- Menu Pause (NE PAS modifier) : `Engine.cpp` `if (m_inGamePauseMenuVisible)` ~`11888-11977` ; bouton « Options » `~11959-11963` (pose `m_inGameOptionsPanelVisible=true`).
+- NewFrame ImGui in-game inclut déjà `|| m_inGameOptionsPanelVisible` `Engine.cpp:~8898-8904`.
+
+---
+
+## ST1 — Découpler le consume des réglages (additif, faible risque)
+
+**Files:** `src/client/app/Engine.cpp`
+
+**But :** l'application réelle des réglages stagés doit tourner **chaque frame**, pas seulement sous `authGateActive`, pour fonctionner aussi en jeu. Les `ConsumePending*` sont idempotents (retournent `{}` sans `applyRequested`), donc l'appel inconditionnel est sûr.
+
+- [ ] **Step 1 — Lire** `Engine.cpp:8356-8439` (bloc `if (authGateActive) { ConsumePending... + application }`) en entier.
+- [ ] **Step 2 — Extraire** le corps (consume des 4 commandes + leur application : vidéo `:8366-8401`, audio `:8402-8415`, contrôles `:8416-8423`, jeu `:8424-8439`) dans une méthode privée `Engine::ApplyConsumedSettingsCommands()` (déclarée dans `Engine.h`, documentée `///`).
+- [ ] **Step 3 — Appel inconditionnel** : remplacer le bloc `if (authGateActive) {…}` par un appel `ApplyConsumedSettingsCommands();` **chaque frame** (en dehors de la garde `authGateActive`). Vérifier qu'aucune variable locale du bloc ne dépendait de `authGateActive`.
+- [ ] **Step 4 — Garde anti-déconnexion** : dans la partie « jeu » du consume (`InitGameplayNet/ShutdownGameplayNet` `:8432-8435`), n'exécuter ces (ré)initialisations réseau **que si on n'est pas déjà en session** (ou ne pas les déclencher quand l'onglet Network est masqué en jeu — cf. ST6). Documenter le garde-fou.
+- [ ] **Step 5 — Commit** `refactor(client): consume des réglages options exécuté chaque frame (réutilisable en jeu)`.
+
+**Vérif (CI + manuelle) :** à l'auth, changer un réglage + Appliquer fonctionne comme avant (aucune régression). En jeu (avec le mini-panneau encore présent), rien ne casse.
+
+**Risque :** moyen. Bien vérifier qu'aucun réglage ne s'applique deux fois (live + staged).
+
+---
+
+## ST2 — Contexte d'options (lève le verrou Phase)
+
+**Files:** `src/client/auth/AuthUiPresenterSettings.cpp`, `src/client/auth/screens/AuthScreenLanguageSelect.cpp`, header presenter (`AuthUiPresenter.h`).
+
+- [ ] **Step 1 — Membre** : ajouter `bool m_optionsOpenInGame = false;` au presenter (header), documenté.
+- [ ] **Step 2 — Assouplir les gardes** : dans `ImGuiApplyLanguageOptionsMenu` (`:83`) et `ImGuiCloseLanguageOptionsWithoutApply` (`:118`), remplacer `if (m_phase != Phase::LanguageOptions) return;` par `if (m_phase != Phase::LanguageOptions && !m_optionsOpenInGame) return;`.
+- [ ] **Step 3 — Neutraliser le `SetPhase`** : dans `CommitLanguageOptionsMenuApply` (`:256`) et le close (`:122`), **ne pas** restaurer la phase quand `m_optionsOpenInGame` (sinon corruption de l'état auth post-monde). Pour l'apply : extraire l'application de locale de `ApplyLocaleSelection(false)` du `SetPhase` (`AuthScreenLanguageSelect.cpp:78`) — n'appeler `SetPhase(m_phaseBeforeOptions)` que si `!m_optionsOpenInGame`.
+- [ ] **Step 4 — Commit** `feat(client): contexte options in-game (gardes Phase assouplies sans toucher la phase auth)`.
+
+**Risque :** ⚠️ ÉLEVÉ (zone session/phase). Ne JAMAIS modifier `m_phase`/`m_flowComplete` quand `m_optionsOpenInGame`. Validation en jeu obligatoire (ouvrir/fermer options ne doit pas faire réapparaître l'écran auth ni déconnecter).
+
+---
+
+## ST3 — Ouverture/fermeture des options in-game (presenter)
+
+**Files:** `src/client/auth/AuthUiPresenterSettings.cpp` (+ header).
+
+- [ ] **Step 1 — `OpenLanguageOptionsInGame()`** : nouvelle méthode publique qui pose `m_optionsOpenInGame = true` et **initialise les `*Pending` depuis les valeurs live** (réutiliser le corps `OpenLanguageOptions():136-155`) **sans** `SetPhase` ni toucher `m_phaseBeforeOptions`. Documenter.
+- [ ] **Step 2 — `CloseLanguageOptionsInGame()`** : pose `m_optionsOpenInGame = false` (sans toucher la phase).
+- [ ] **Step 3 — Accès mirrors** : s'assurer que `BuildLanguageOptionsImGuiMirror()` fonctionne dans ce contexte (il lit les `*Pending`, déjà initialisés au Step 1).
+- [ ] **Step 4 — Commit** `feat(client): ouverture/fermeture des options en jeu sans transition de phase`.
+
+**Risque :** moyen.
+
+---
+
+## ST4 — Wrapper de rendu `RenderOptionsOverlay` (lève le verrou rendu)
+
+**Files:** `src/client/render/AuthImGuiRenderer.{h,cpp}`, `src/client/render/auth/screens/AuthImGuiOptions.cpp`.
+
+- [ ] **Step 1 — Méthode publique** `bool AuthImGuiRenderer::RenderOptionsOverlay(float vpW, float vpH)` documentée (`///` : rôle, effet de bord ImGui, thread main). Elle :
+  - ouvre une fenêtre overlay propre (réutiliser `BeginFullscreenOverlay` ou une fenêtre centrée modale, **indépendante de `vs.active`**),
+  - appelle `PullLanguageOptionsFromPresenter()` à la première frame d'ouverture (init mirrors),
+  - appelle `RenderOptionsScreen(rmMinimal, vpW, vpH)` avec un **RenderModel minimal** (au moins `authOptionsAccountLogin`/`TagId` vides — l'onglet Account étant masqué en jeu, cf. ST6),
+  - **ne** rend **pas** `DrawAuthTweaksPanel`,
+  - renvoie `true` tant qu'ouvert, `false` quand l'utilisateur ferme (Retour/Échap) — via le close in-game (ST3) ou un retour de `RenderOptionsScreen`.
+- [ ] **Step 2 — Paramétrer `RenderOptionsScreen`** pour : (a) sauter `DrawAuthTweaksPanel` (`:621`) en contexte in-game, (b) signaler la fermeture au caller. Ajouter un paramètre `bool inGame` (ou un membre `m_optionsInGame`).
+- [ ] **Step 3 — Commit** `feat(client): RenderOptionsOverlay réutilisable (écran options sans décor auth)`.
+
+**Risque :** moyen.
+
+---
+
+## ST5 — Câblage Engine (remplacer le mini-panneau)
+
+**Files:** `src/client/app/Engine.cpp` (+ `Engine.h`).
+
+- [ ] **Step 1 — Ouverture** : quand le bouton « Options » du menu Pause est cliqué (`~11959-11963`, **inchangé** : pose `m_inGameOptionsPanelVisible=true`), appeler `m_authUi.OpenLanguageOptionsInGame()` (au passage `false→true` du flag).
+- [ ] **Step 2 — Rendu** : remplacer TOUT le bloc mini-panneau `if (m_inGameOptionsPanelVisible) { … }` (`~11978-12194`) par :
+```cpp
+if (m_inGameOptionsPanelVisible)
+{
+    const bool stillOpen = m_authImGui->RenderOptionsOverlay(dw, dh);
+    if (!stillOpen)
+    {
+        m_inGameOptionsPanelVisible = false;
+        m_authUi.CloseLanguageOptionsInGame();
+        m_inGamePauseMenuVisible = true; // retour au menu Pause
+    }
+}
+```
+- [ ] **Step 3 — Suspension gameplay** : conserver le comportement existant (le gameplay est déjà suspendu quand le panneau est ouvert ; vérifier que les conditions référençant `m_inGameOptionsPanelVisible` restent valides, ex. NewFrame `~8898`).
+- [ ] **Step 4 — Commit** `refactor(client): menu Pause Options ouvre l'écran d'options unifié (mini-panneau supprimé)`.
+
+**Risque :** moyen-élevé. Validation en jeu : ESC → Pause inchangé ; Options → écran complet ; Retour → Pause ; réglages appliqués ; gameplay bien suspendu pendant l'ouverture.
+
+---
+
+## ST6 — Onglets sensibles + keybinds éditables
+
+**Files:** `src/client/render/auth/screens/AuthImGuiOptions.cpp`.
+
+- [ ] **Step 1 — Masquer Network + Account en jeu** : conditionner l'affichage des onglets Network (`:444-489`) et Account (`:490-532`) à `!inGame` (paramètre/membre du ST4). En jeu, n'afficher que Graphics/Audio/Controls/Language/UI. Adapter la barre d'onglets pour ne pas laisser d'onglet vide/sélectionnable.
+- [ ] **Step 2 — Keybinds éditables (partout)** : remplacer l'affichage **lecture seule** des keybinds dans l'onglet Controls (`:357-365`) par le **rebind interactif** porté du mini-panneau (logique `Engine.cpp:~12057-12143` : capture touche, détection conflit, persistance `keybinds.json`). L'exposer à l'auth ET en jeu. Réutiliser/centraliser la liste `kRebindableKeys` (la déplacer dans un en-tête partagé si nécessaire ; éviter la duplication).
+- [ ] **Step 3 — Commit** `feat(client): options unifiées — Network/Account masqués en jeu, remap touches éditable`.
+
+**Risque :** moyen. Attention à la persistance keybinds (format `keybinds.json` existant).
+
+---
+
+## ST7 — Nettoyage du code mort du mini-panneau
+
+**Files:** `src/client/app/Engine.cpp`, `Engine.h`.
+
+- [ ] **Step 1 — Vérifier** par `git grep` les symboles devenus inutilisés après ST5/ST6 : `m_rebindingAction`, `m_keybindWarning` (`Engine.h`). NE PAS retirer `kRebindableKeys` s'il reste utilisé (`Engine.cpp:~436/444` hors mini-panneau) ni `m_inGameOptionsPanelVisible` (toujours déclencheur).
+- [ ] **Step 2 — Retirer** uniquement les symboles sans plus aucun usage.
+- [ ] **Step 3 — Commit** `chore(client): retrait du code mort du mini-panneau options in-game`.
+
+---
+
+## ST8 — Intégration, CI, PR
+
+- [ ] Revue locale (`git diff main..HEAD --stat`), push, CI verte (build-windows ~30 min).
+- [ ] PR `feat: menu d'options unifié (écran auth réutilisé en jeu)`. Déploiement : ✅ client uniquement.
+- [ ] Indiquer à l'utilisateur l'ordre de merge vs PR #901 (régions distinctes ; rebaser si #901 merge en premier).
+
+## Self-review (couverture)
+- Verrou Phase → ST2 ✅ ; Verrou consume → ST1 ✅ ; Verrou rendu → ST4 ✅ ; ouverture/fermeture in-game → ST3 ✅ ; câblage → ST5 ✅ ; onglets masqués + keybinds éditables → ST6 ✅ ; nettoyage → ST7 ✅.
+- **Validation runtime en jeu indispensable** (pas de build local) : surtout après ST2 (phase/session) et ST5 (câblage).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11896,6 +11896,9 @@ namespace engine
 				{
 					m_inGamePauseMenuVisible = false;
 					m_inGameOptionsPanelVisible = true;
+					// B2/ST5 — pose le contexte in-game et initialise les valeurs *Pending
+					// de l'écran d'options unifié (sans toucher la phase auth).
+					m_authUi.OpenLanguageOptionsInGame();
 				}
 				ImGui::Spacing();
 				if (pauseButton("Se deconnecter", false))
@@ -11911,182 +11914,19 @@ namespace engine
 				ImGui::PopStyleVar(2);
 				ImGui::PopStyleColor(2);
 			}
-			// Mini-panel Options in-game (ouvert via le bouton Options du menu pause).
-			// Contient les controles essentiels qu'on veut pouvoir ajuster sans
-			// quitter le jeu : volume master, plein ecran, vsync, sensibilite souris.
-			// Le full panel auth Options reste accessible via Se deconnecter -> Login -> Options.
+			// Menu Options en jeu : on réutilise EXACTEMENT l'écran d'options de l'auth
+			// (source unique, spec B2). Le menu Pause (ESC) reste inchangé ; seul son lien
+			// « Options » mène ici. RenderOptionsOverlay renvoie false à la fermeture.
 			if (m_inGameOptionsPanelVisible)
 			{
-				const float optW = 460.f;
-				const float optH = 560.f;
-				ImGui::SetNextWindowPos(ImVec2((dw - optW) * 0.5f, (dh - optH) * 0.5f), ImGuiCond_Always);
-				ImGui::SetNextWindowSize(ImVec2(optW, optH), ImGuiCond_Always);
-				ImGui::SetNextWindowBgAlpha(0.95f);
-				ImGui::Begin("##ln_ingame_options", nullptr,
-					ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize
-					| ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse
-					| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav);
-				ImGui::SetWindowFontScale(1.15f);
-				const char* optTitle = "OPTIONS";
-				const float optTitleW = ImGui::CalcTextSize(optTitle).x;
-				ImGui::SetCursorPosX((optW - optTitleW) * 0.5f);
-				ImGui::TextUnformatted(optTitle);
-				ImGui::SetWindowFontScale(1.f);
-				ImGui::Separator();
-				ImGui::Spacing();
-
-				// Lecture des valeurs actuelles depuis la config et ecriture in-place.
-				float vol = static_cast<float>(m_cfg.GetDouble("audio.master_volume", 1.0));
-				bool fullscreen = m_cfg.GetBool("video.fullscreen", false);
-				bool vsync = m_cfg.GetBool("render.vsync", true);
-				float sens = static_cast<float>(m_cfg.GetDouble("controls.mouse_sensitivity", 0.002));
-
-				if (ImGui::SliderFloat("Volume general", &vol, 0.0f, 1.0f, "%.2f"))
-				{
-					m_cfg.SetValue("audio.master_volume", static_cast<double>(vol));
-					(void)m_audioEngine.SetMasterVolume(vol);
-				}
-				if (ImGui::Checkbox("Plein ecran", &fullscreen))
-				{
-					m_cfg.SetValue("video.fullscreen", fullscreen);
-					// Nota : changement effectif au prochain restart (toggle live = autre PR).
-				}
-				if (ImGui::Checkbox("VSync", &vsync))
-				{
-					m_cfg.SetValue("render.vsync", vsync);
-				}
-				if (ImGui::SliderFloat("Sensibilite souris", &sens, 0.0005f, 0.01f, "%.4f rad/px"))
-				{
-					m_cfg.SetValue("controls.mouse_sensitivity", static_cast<double>(sens));
-				}
-
-				// --- Thème de l'interface (recolore tout l'UI in-game) ---
-				// Libellés ASCII volontaires : la police in-game (Windlass) n'a
-				// pas tous les glyphes accentués (cf. "Se deconnecter" du menu pause).
-				auto prettyTheme = [](std::string_view n) -> const char* {
-					if (n == "or_royal") return "Or royal";
-					if (n == "sylve_emeraude") return "Sylve emeraude";
-					return "?";
-				};
-				const std::string_view curTheme = LnTheme::ActiveName();
-				if (ImGui::BeginCombo("Theme de l'interface", prettyTheme(curTheme)))
-				{
-					for (std::string_view n : LnTheme::Names())
-					{
-						const bool selected = (n == curTheme);
-						if (ImGui::Selectable(prettyTheme(n), selected) && !selected)
-						{
-							LnTheme::SetActive(n);
-							// Persistance : fichier dédié mergé au boot (comme keybinds.json).
-							const std::string js =
-								std::string("{\n  \"ui\": { \"theme\": \"")
-								+ std::string(LnTheme::ActiveName()) + "\" }\n}\n";
-							if (!engine::platform::FileSystem::WriteAllText("ui_theme.json", js))
-								LOG_WARN(Core, "[Options] ui_theme.json non ecrit (theme non persiste)");
-						}
-						if (selected)
-							ImGui::SetItemDefaultFocus();
-					}
-					ImGui::EndCombo();
-				}
-
-				// --- Controles : touches d'action remappables (controls.keybind.*) ---
-				ImGui::Spacing();
-				ImGui::Separator();
-				ImGui::TextUnformatted("Controles");
-
-				// Capture du rebind en cours : la 1re touche connue pressee est affectee
-				// a l'action ciblee (Echap annule). Le bloc gameplay etant suspendu tant
-				// que ce panneau est ouvert, la touche capturee ne declenche pas l'action.
-				if (m_rebindingAction != 0)
-				{
-					if (m_input.WasPressed(engine::platform::Key::Escape))
-					{
-						m_rebindingAction = 0;
-					}
-					else
-					{
-						for (const auto& rk : kRebindableKeys)
-						{
-							if (m_input.WasPressed(rk.key))
-							{
-								const char* cfgKey =
-									(m_rebindingAction == 1) ? "controls.keybind.sprint"
-									: (m_rebindingAction == 2) ? "controls.keybind.crouch"
-									: (m_rebindingAction == 3) ? "controls.keybind.cast"
-									: (m_rebindingAction == 4) ? "controls.keybind.interact"
-									: "controls.keybind.punch";
-								// Detection de conflit : la touche choisie est-elle deja sur une autre
-								// action ? (doublon autorise, juste signale sous les lignes de rebind).
-								m_keybindWarning.clear();
-								{
-									struct Kb { int act; const char* key; const char* label; };
-									static const Kb kKb[] = {
-										{1,"controls.keybind.sprint","Sprint"}, {2,"controls.keybind.crouch","Accroupi"},
-										{3,"controls.keybind.cast","Sort"}, {4,"controls.keybind.interact","Interagir"},
-										{5,"controls.keybind.punch","Coup de poing"},
-									};
-									for (const auto& kb : kKb)
-										if (kb.act != m_rebindingAction && m_cfg.GetString(kb.key, "") == rk.name)
-										{
-											m_keybindWarning = std::string("Touche '") + rk.name + "' deja utilisee par " + kb.label + " (doublon).";
-											break;
-										}
-								}
-								m_cfg.SetValue(cfgKey, std::string(rk.name));
-								// Persistance : ecrit keybinds.json (fichier dedie, format controle ;
-								// valeurs = noms ASCII de kRebindableKeys -> pas d'echappement JSON requis).
-								{
-									const std::string kb =
-										std::string("{\n  \"controls\": {\n    \"keybind\": {\n")
-										+ "      \"sprint\": \"" + m_cfg.GetString("controls.keybind.sprint", "Alt") + "\",\n"
-										+ "      \"crouch\": \"" + m_cfg.GetString("controls.keybind.crouch", "Ctrl") + "\",\n"
-										+ "      \"cast\": \"" + m_cfg.GetString("controls.keybind.cast", "R") + "\",\n"
-										+ "      \"interact\": \"" + m_cfg.GetString("controls.keybind.interact", "E") + "\",\n"
-										+ "      \"punch\": \"" + m_cfg.GetString("controls.keybind.punch", "X") + "\"\n"
-										+ "    }\n  }\n}\n";
-									if (!engine::platform::FileSystem::WriteAllText("keybinds.json", kb))
-										LOG_WARN(Core, "[Options] keybinds.json non ecrit (rebind non persiste)");
-								}
-								m_rebindingAction = 0;
-								break;
-							}
-						}
-					}
-				}
-
-				auto rebindRow = [&](const char* label, const char* cfgKey,
-					const char* def, int action)
-				{
-					const std::string cur = m_cfg.GetString(cfgKey, def);
-					ImGui::Text("%s : %s", label, cur.c_str());
-					ImGui::SameLine(190.f);
-					ImGui::PushID(action);
-					if (m_rebindingAction == action)
-						ImGui::TextUnformatted("appuyez sur une touche (Echap = annuler)");
-					else if (ImGui::SmallButton("Modifier"))
-						m_rebindingAction = action;
-					ImGui::PopID();
-				};
-				rebindRow("Sprint", "controls.keybind.sprint", "Alt", 1);
-				rebindRow("Accroupi", "controls.keybind.crouch", "Ctrl", 2);
-				rebindRow("Sort", "controls.keybind.cast", "R", 3);
-				rebindRow("Interagir", "controls.keybind.interact", "E", 4);
-				rebindRow("Coup de poing", "controls.keybind.punch", "X", 5);
-				ImGui::TextDisabled("Roulade : double-appui sur la touche Accroupi");
-				ImGui::TextDisabled("Attaque : clic gauche (non remappable)");
-				if (!m_keybindWarning.empty())
-					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "%s", m_keybindWarning.c_str());
-
-				ImGui::Spacing();
-				ImGui::Separator();
-				ImGui::Spacing();
-				const float optBtnW = optW - 40.f;
-				if (ImGui::Button("Fermer", ImVec2(optBtnW, 32.f)))
+				const bool stillOpen = m_authImGui->RenderOptionsOverlay(dw, dh);
+				if (!stillOpen)
 				{
 					m_inGameOptionsPanelVisible = false;
+					m_authUi.CloseLanguageOptionsInGame();
+					m_inGamePauseMenuVisible = true; // retour au menu Pause
+					ReloadKeybindsFromDisk(); // prise d'effet live des rebinds
 				}
-				ImGui::End();
 			}
 			ImGui::Render();
 		}
@@ -13496,6 +13336,18 @@ namespace engine
 	{
 		m_inGamePauseMenuVisible = !m_inGamePauseMenuVisible;
 		LOG_INFO(Core, "[InGamePauseMenu] toggled visible={}", m_inGamePauseMenuVisible);
+	}
+
+	void Engine::ReloadKeybindsFromDisk()
+	{
+		// Même mécanisme qu'au boot (ApplyUserSettingsOverrides) : Config::LoadFromFile
+		// merge (override) les clés du fichier par-dessus m_cfg. Re-charger keybinds.json
+		// réécrit donc controls.keybind.* dans m_cfg -> les binds remappés via l'écran
+		// d'options prennent effet à la frame suivante (BuildMoveInput lit m_cfg).
+		// Fichier absent/malformé -> LoadFromFile renvoie false : on garde les binds
+		// courants (jamais de corruption).
+		if (m_cfg.LoadFromFile("keybinds.json"))
+			LOG_INFO(Core, "[Options] keybinds.json rechargé en jeu (binds clavier live)");
 	}
 
 	void Engine::RequestLogoutToLoginScreen()

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11917,9 +11917,12 @@ namespace engine
 			// Menu Options en jeu : on réutilise EXACTEMENT l'écran d'options de l'auth
 			// (source unique, spec B2). Le menu Pause (ESC) reste inchangé ; seul son lien
 			// « Options » mène ici. RenderOptionsOverlay renvoie false à la fermeture.
+			// Garde m_authImGui : aligne sur la défensive des autres panneaux in-game
+			// du même bloc (m_mailImGui &&, m_gmTicketImGui &&, …). m_authImGui null
+			// (shutdown) -> on referme proprement l'overlay plutôt que de déréférencer.
 			if (m_inGameOptionsPanelVisible)
 			{
-				const bool stillOpen = m_authImGui->RenderOptionsOverlay(dw, dh);
+				const bool stillOpen = m_authImGui && m_authImGui->RenderOptionsOverlay(dw, dh);
 				if (!stillOpen)
 				{
 					m_inGameOptionsPanelVisible = false;

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8359,84 +8359,20 @@ namespace engine
 			LOG_DEBUG(Render, "[DIAG] authUi.Update begin frame={}", m_currentFrame);
 			m_authUi.Update(m_input, static_cast<float>(dt), m_window, m_cfg);
 			LOG_DEBUG(Render, "[DIAG] authUi.Update done frame={}", m_currentFrame);
-			const engine::client::AuthUiPresenter::VideoSettingsCommand videoCmd = m_authUi.ConsumePendingVideoSettings();
-			const engine::client::AuthUiPresenter::AudioSettingsCommand audioCmd = m_authUi.ConsumePendingAudioSettings();
-			const engine::client::AuthUiPresenter::ControlSettingsCommand controlCmd = m_authUi.ConsumePendingControlSettings();
-			const engine::client::AuthUiPresenter::GameSettingsCommand gameCmd = m_authUi.ConsumePendingGameSettings();
-			if (videoCmd.applyRequested)
-			{
-				const bool fullscreenChanged = (videoCmd.fullscreen != m_window.IsFullscreen());
-				const bool vsyncChanged = (videoCmd.vsync != m_vsync);
-				m_cfg.SetValue("render.fullscreen", videoCmd.fullscreen);
-				m_cfg.SetValue("render.vsync", videoCmd.vsync);
-				m_cfg.SetValue("render.resolution_width", static_cast<int64_t>(videoCmd.resolutionWidth));
-				m_cfg.SetValue("render.resolution_height", static_cast<int64_t>(videoCmd.resolutionHeight));
-				m_cfg.SetValue("render.quality_preset", static_cast<int64_t>(videoCmd.qualityPreset));
-				m_cfg.SetValue("render.fov", static_cast<double>(videoCmd.fovDegrees));
-				m_vsync = videoCmd.vsync;
-				if (fullscreenChanged)
-				{
-					m_window.ToggleFullscreen();
-					LOG_INFO(Core, "[Options] Fullscreen applied ({})", videoCmd.fullscreen ? "on" : "off");
-				}
-				if (vsyncChanged)
-				{
-					m_swapchainResizeRequested = true;
-					LOG_INFO(Core, "[Options] VSync applied ({}) -> swapchain recreate requested", videoCmd.vsync ? "on" : "off");
-				}
-				int cw = 0, ch = 0;
-				m_window.GetClientSize(cw, ch);
-				const bool resChanged = (videoCmd.resolutionWidth > 0 && videoCmd.resolutionHeight > 0
-					&& (videoCmd.resolutionWidth != cw || videoCmd.resolutionHeight != ch));
-				if (resChanged)
-				{
-					m_swapchainResizeRequested = true;
-					LOG_INFO(Core, "[Options] Resolution persisted {}x{} (fenêtre actuelle {}x{} ; redimensionnement natif à brancher)",
-						videoCmd.resolutionWidth, videoCmd.resolutionHeight, cw, ch);
-				}
-				if (!fullscreenChanged && !vsyncChanged && !resChanged)
-				{
-					LOG_INFO(Core, "[Options] Video apply requested but window flags unchanged (qualité / FOV enregistrés dans la config)");
-				}
-			}
-			if (audioCmd.applyRequested)
-			{
-				m_cfg.SetValue("audio.master_volume", static_cast<double>(audioCmd.masterVolume));
-				m_cfg.SetValue("audio.music_volume", static_cast<double>(audioCmd.musicVolume));
-				m_cfg.SetValue("audio.sfx_volume", static_cast<double>(audioCmd.sfxVolume));
-				m_cfg.SetValue("audio.ui_volume", static_cast<double>(audioCmd.uiVolume));
-				const bool masterOk = m_audioEngine.SetMasterVolume(audioCmd.masterVolume);
-				const bool musicOk = m_audioEngine.SetBusVolume("Music", audioCmd.musicVolume);
-				const bool sfxOk = m_audioEngine.SetBusVolume("SFX", audioCmd.sfxVolume);
-				const bool uiOk = m_audioEngine.SetBusVolume("UI", audioCmd.uiVolume);
-				LOG_INFO(Core, "[Options] Audio applied (master={:.1f}, music={:.1f}, sfx={:.1f}, ui={:.1f}, ok={})",
-					audioCmd.masterVolume, audioCmd.musicVolume, audioCmd.sfxVolume, audioCmd.uiVolume,
-					(masterOk && musicOk && sfxOk && uiOk) ? "yes" : "partial");
-			}
-			if (controlCmd.applyRequested)
-			{
-				m_cfg.SetValue("camera.mouse_sensitivity", static_cast<double>(controlCmd.mouseSensitivity));
-				m_cfg.SetValue("controls.invert_y", controlCmd.invertY);
-				m_cfg.SetValue("controls.movement_layout", controlCmd.useZqsd ? std::string("zqsd") : std::string("wasd"));
-				LOG_INFO(Core, "[Options] Controls applied (sens={:.4f}, invert_y={}, layout={})",
-					controlCmd.mouseSensitivity, controlCmd.invertY, controlCmd.useZqsd ? "zqsd" : "wasd");
-			}
-			if (gameCmd.applyRequested)
-			{
-				const bool gameplayWasEnabled = m_cfg.GetBool("client.gameplay_udp.enabled", false);
-				m_cfg.SetValue("client.gameplay_udp.enabled", gameCmd.gameplayUdpEnabled);
-				m_cfg.SetValue("client.allow_insecure_dev", gameCmd.allowInsecureDev);
-				m_cfg.SetValue("client.auth_ui.timeout_ms", static_cast<int64_t>(gameCmd.authTimeoutMs));
-				if (gameplayWasEnabled != gameCmd.gameplayUdpEnabled)
-				{
-					if (gameCmd.gameplayUdpEnabled)
-						InitGameplayNet();
-					else
-						ShutdownGameplayNet();
-				}
-				LOG_INFO(Core, "[Options] Game applied (gameplay_udp={}, allow_insecure_dev={}, timeout_ms={})",
-					gameCmd.gameplayUdpEnabled, gameCmd.allowInsecureDev, gameCmd.authTimeoutMs);
-			}
+		}
+
+		// Refactor B2 (ST1) — Le consume/application des réglages d'options doit tourner
+		// CHAQUE FRAME (auth comme in-game) pour pouvoir réutiliser l'écran d'options en
+		// jeu. Les ConsumePending*Settings() sont idempotents (commande vide tant qu'aucun
+		// apply n'est demandé), donc l'appel inconditionnel est sûr et ne ré-applique rien
+		// hors frame d'apply. Placé APRÈS m_authUi.Update pour consommer les commandes
+		// stagées par l'UI au cours de la frame courante (pas un cran de retard). La garde
+		// réseau (Init/ShutdownGameplayNet) reste conditionnée à authGateActive
+		// (cf. ApplyConsumedSettingsCommands).
+		ApplyConsumedSettingsCommands(authGateActive);
+
+		if (authGateActive)
+		{
 			if (m_chatUi.IsInitialized())
 			{
 				// PAS d'update du chat pendant les ecrans d'auth : sinon le Enter
@@ -13808,6 +13744,104 @@ namespace engine
 		m_gameplayVendorTalkTarget.clear();
 		m_gameplayAuctionTalkTarget.clear();
 		LOG_INFO(Core, "[GameplayNet] Shutdown complete");
+	}
+
+	// Refactor B2 (ST1) — Consomme et applique les commandes de réglages stagées par
+	// l'écran d'options (AuthUiPresenter). Idempotent : appelable chaque frame.
+	// Extrait verbatim de l'ancien bloc gardé par authGateActive dans la boucle de rendu,
+	// pour que l'application des options tourne aussi in-game (écran d'options réutilisé).
+	void Engine::ApplyConsumedSettingsCommands(bool authGateActive)
+	{
+		const engine::client::AuthUiPresenter::VideoSettingsCommand videoCmd = m_authUi.ConsumePendingVideoSettings();
+		const engine::client::AuthUiPresenter::AudioSettingsCommand audioCmd = m_authUi.ConsumePendingAudioSettings();
+		const engine::client::AuthUiPresenter::ControlSettingsCommand controlCmd = m_authUi.ConsumePendingControlSettings();
+		const engine::client::AuthUiPresenter::GameSettingsCommand gameCmd = m_authUi.ConsumePendingGameSettings();
+		if (videoCmd.applyRequested)
+		{
+			const bool fullscreenChanged = (videoCmd.fullscreen != m_window.IsFullscreen());
+			const bool vsyncChanged = (videoCmd.vsync != m_vsync);
+			m_cfg.SetValue("render.fullscreen", videoCmd.fullscreen);
+			m_cfg.SetValue("render.vsync", videoCmd.vsync);
+			m_cfg.SetValue("render.resolution_width", static_cast<int64_t>(videoCmd.resolutionWidth));
+			m_cfg.SetValue("render.resolution_height", static_cast<int64_t>(videoCmd.resolutionHeight));
+			m_cfg.SetValue("render.quality_preset", static_cast<int64_t>(videoCmd.qualityPreset));
+			m_cfg.SetValue("render.fov", static_cast<double>(videoCmd.fovDegrees));
+			m_vsync = videoCmd.vsync;
+			if (fullscreenChanged)
+			{
+				m_window.ToggleFullscreen();
+				LOG_INFO(Core, "[Options] Fullscreen applied ({})", videoCmd.fullscreen ? "on" : "off");
+			}
+			if (vsyncChanged)
+			{
+				m_swapchainResizeRequested = true;
+				LOG_INFO(Core, "[Options] VSync applied ({}) -> swapchain recreate requested", videoCmd.vsync ? "on" : "off");
+			}
+			int cw = 0, ch = 0;
+			m_window.GetClientSize(cw, ch);
+			const bool resChanged = (videoCmd.resolutionWidth > 0 && videoCmd.resolutionHeight > 0
+				&& (videoCmd.resolutionWidth != cw || videoCmd.resolutionHeight != ch));
+			if (resChanged)
+			{
+				m_swapchainResizeRequested = true;
+				LOG_INFO(Core, "[Options] Resolution persisted {}x{} (fenêtre actuelle {}x{} ; redimensionnement natif à brancher)",
+					videoCmd.resolutionWidth, videoCmd.resolutionHeight, cw, ch);
+			}
+			if (!fullscreenChanged && !vsyncChanged && !resChanged)
+			{
+				LOG_INFO(Core, "[Options] Video apply requested but window flags unchanged (qualité / FOV enregistrés dans la config)");
+			}
+		}
+		if (audioCmd.applyRequested)
+		{
+			m_cfg.SetValue("audio.master_volume", static_cast<double>(audioCmd.masterVolume));
+			m_cfg.SetValue("audio.music_volume", static_cast<double>(audioCmd.musicVolume));
+			m_cfg.SetValue("audio.sfx_volume", static_cast<double>(audioCmd.sfxVolume));
+			m_cfg.SetValue("audio.ui_volume", static_cast<double>(audioCmd.uiVolume));
+			const bool masterOk = m_audioEngine.SetMasterVolume(audioCmd.masterVolume);
+			const bool musicOk = m_audioEngine.SetBusVolume("Music", audioCmd.musicVolume);
+			const bool sfxOk = m_audioEngine.SetBusVolume("SFX", audioCmd.sfxVolume);
+			const bool uiOk = m_audioEngine.SetBusVolume("UI", audioCmd.uiVolume);
+			LOG_INFO(Core, "[Options] Audio applied (master={:.1f}, music={:.1f}, sfx={:.1f}, ui={:.1f}, ok={})",
+				audioCmd.masterVolume, audioCmd.musicVolume, audioCmd.sfxVolume, audioCmd.uiVolume,
+				(masterOk && musicOk && sfxOk && uiOk) ? "yes" : "partial");
+		}
+		if (controlCmd.applyRequested)
+		{
+			m_cfg.SetValue("camera.mouse_sensitivity", static_cast<double>(controlCmd.mouseSensitivity));
+			m_cfg.SetValue("controls.invert_y", controlCmd.invertY);
+			m_cfg.SetValue("controls.movement_layout", controlCmd.useZqsd ? std::string("zqsd") : std::string("wasd"));
+			LOG_INFO(Core, "[Options] Controls applied (sens={:.4f}, invert_y={}, layout={})",
+				controlCmd.mouseSensitivity, controlCmd.invertY, controlCmd.useZqsd ? "zqsd" : "wasd");
+		}
+		if (gameCmd.applyRequested)
+		{
+			const bool gameplayWasEnabled = m_cfg.GetBool("client.gameplay_udp.enabled", false);
+			m_cfg.SetValue("client.gameplay_udp.enabled", gameCmd.gameplayUdpEnabled);
+			m_cfg.SetValue("client.allow_insecure_dev", gameCmd.allowInsecureDev);
+			m_cfg.SetValue("client.auth_ui.timeout_ms", static_cast<int64_t>(gameCmd.authTimeoutMs));
+			// Garde-fou réseau (ST1, étape 4) : on ne (ré)initialise / n'arrête le réseau
+			// gameplay QUE pendant l'auth. En jeu (session active), appliquer un réglage
+			// "game settings" ne doit PAS couper la session UDP de façon intempestive via
+			// ShutdownGameplayNet (ni rouvrir un socket via InitGameplayNet hors handshake).
+			// La config est tout de même persistée ci-dessus ; le changement effectif de
+			// l'état réseau in-game sera traité par un chemin dédié dans une sous-tâche
+			// ultérieure du refactor B2.
+			if (authGateActive && gameplayWasEnabled != gameCmd.gameplayUdpEnabled)
+			{
+				if (gameCmd.gameplayUdpEnabled)
+					InitGameplayNet();
+				else
+					ShutdownGameplayNet();
+			}
+			else if (gameplayWasEnabled != gameCmd.gameplayUdpEnabled)
+			{
+				LOG_INFO(Core, "[Options] Game: changement gameplay_udp.enabled={} persisté en config mais état réseau inchangé (hors auth, session préservée)",
+					gameCmd.gameplayUdpEnabled);
+			}
+			LOG_INFO(Core, "[Options] Game applied (gameplay_udp={}, allow_insecure_dev={}, timeout_ms={})",
+				gameCmd.gameplayUdpEnabled, gameCmd.allowInsecureDev, gameCmd.authTimeoutMs);
+		}
 	}
 
 	void Engine::PumpGameplayPackets()

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -316,6 +316,20 @@ namespace engine
 		void UpdateGameplayNet(float deltaSeconds);
 		/// Drains non-blocking UDP packets into \ref m_uiModelBinding (Welcome excluded; client id from handshake).
 		void PumpGameplayPackets();
+		/// Consomme et applique les commandes de réglages (vidéo / audio / contrôles / jeu)
+		/// stagées par l'écran d'options (\ref AuthUiPresenter). Idempotent : chaque
+		/// `ConsumePending*Settings()` renvoie une commande vide tant qu'aucun apply n'est
+		/// demandé, donc l'appel est sûr CHAQUE FRAME (auth comme in-game). C'est ce qui
+		/// permet de réutiliser l'écran d'options en jeu (refactor B2).
+		///
+		/// \param authGateActive true tant que le flux d'auth n'est pas terminé. Garde-fou
+		///        réseau : la (ré)initialisation / l'arrêt du réseau gameplay
+		///        (\ref InitGameplayNet / \ref ShutdownGameplayNet) déclenchés par un
+		///        changement de `client.gameplay_udp.enabled` ne sont effectués QUE pendant
+		///        l'auth, pour ne pas couper intempestivement une session gameplay active
+		///        si l'utilisateur applique des réglages en jeu. La persistance config et
+		///        les catégories vidéo/audio/contrôles sont appliquées inconditionnellement.
+		void ApplyConsumedSettingsCommands(bool authGateActive);
 		/// Load optional zone probe and atmosphere assets from content-relative paths.
 		void LoadZoneProbeAssets();
 		/// Charge un .spv terrain (même chargeur que l’éditeur monde).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -984,14 +984,20 @@ namespace engine
 		/// entité distante / pas de mesh / pas de load pass.
 		void RecordRemoteAvatars(VkCommandBuffer cmd, engine::render::Registry& reg,
 		                         const engine::RenderState& rs);
-		/// Action en cours de remappage dans le panneau Options (capture clavier) :
-		/// 0 = aucune, 1 = sprint, 2 = crouch, 3 = sort. Tant que != 0, le panneau
-		/// attend une touche ; le bloc gameplay est suspendu (panneau Options ouvert).
-		int                                                      m_rebindingAction = 0;
-		/// Avertissement de conflit de touches affiché sous les lignes de rebind
-		/// (Options) : non vide si la dernière touche bindée était déjà sur une
-		/// autre action. Le bind reste appliqué (doublon autorisé, juste signalé).
-		std::string                                              m_keybindWarning;
+		/// B2/ST5 — Recharge les binds clavier persistés (keybinds.json) dans la
+		/// config runtime (m_cfg) pour une prise d'effet LIVE des remaps faits via
+		/// l'écran d'options unifié, sans redémarrage du client.
+		///
+		/// L'écran d'options écrit keybinds.json (controls.keybind.*) mais ne touche
+		/// pas m_cfg. Comme BuildMoveInput / la résolution des touches d'action lisent
+		/// m_cfg.GetString("controls.keybind.*") à chaque frame, re-merger le fichier
+		/// dans m_cfg suffit à appliquer les nouveaux binds immédiatement.
+		///
+		/// Réutilise le mécanisme de boot : Config::LoadFromFile merge (override) les
+		/// clés du fichier par-dessus les valeurs existantes — pas de duplication de
+		/// parseur. Fichier absent/malformé -> no-op (les binds courants sont conservés).
+		/// Effet de bord : modifie m_cfg ; à appeler en main thread (fermeture overlay).
+		void ReloadKeybindsFromDisk();
 		/// Instant d'entrée dans l'état courant. Utilisé pour :
 		///   - détecter la fin de StartWalking / Jump / Land (durée écoulée >= clip.duration).
 		///   - tracer la transition Jump -> Fall après 40% du clip Jump (takeoff).

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -594,6 +594,18 @@ namespace engine::client
 		void ImGuiApplyLanguageOptionsMenu(const engine::core::Config& cfg, const LanguageOptionsImGuiMirror& mirror);
 		void ImGuiCloseLanguageOptionsWithoutApply();
 
+		/// Ouvre l'écran d'options en contexte in-game (B2/ST3) : pose
+		/// \c m_optionsOpenInGame et prépare les valeurs affichées (\c *Pending)
+		/// depuis l'état live, SANS aucune transition de phase. Contrairement à
+		/// \c OpenLanguageOptions(), ne touche ni \c m_phase ni \c m_phaseBeforeOptions :
+		/// le presenter reste en état post-monde (\c m_flowComplete == true) pour ne
+		/// pas faire réapparaître l'écran d'auth par-dessus le jeu.
+		void OpenLanguageOptionsInGame();
+		/// Ferme l'écran d'options in-game (B2/ST3) : dépose simplement
+		/// \c m_optionsOpenInGame. Ne touche PAS \c m_phase. Fermeture sans appliquer :
+		/// rien n'est committé (les \c *Pending stagés sont abandonnés tels quels).
+		void CloseLanguageOptionsInGame();
+
 		struct RegisterImGuiSubmit
 		{
 			const char* login = nullptr;
@@ -790,6 +802,12 @@ namespace engine::client
 		/// Persistance ciblée de \c client.locale dans user_settings.json (utilisé par \c ApplyLocaleSelection au premier lancement).
 		bool PatchPersistedLocaleKey(std::string_view locale);
 		void OpenLanguageOptions();
+		/// Initialise tous les réglages \c *Pending (et \c m_languageSelectionIndex)
+		/// depuis l'état live courant, pour que l'écran d'options affiche les valeurs
+		/// actuelles. Bloc commun à \c OpenLanguageOptions() (auth) et
+		/// \c OpenLanguageOptionsInGame() (in-game). Ne touche ni la phase ni
+		/// \c m_phaseBeforeOptions — purement préparation des valeurs affichées.
+		void InitOptionsPendingFromLive();
 		static uint32_t OptionsSubmenuLineCount(OptionsSubMenu sub);
 		void EnterOptionsSubmenuFromRoot(uint32_t categoryIndex);
 		std::string Tr(std::string_view key, const LocalizationService::Params& params = {}) const;

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -606,6 +606,12 @@ namespace engine::client
 		/// rien n'est committé (les \c *Pending stagés sont abandonnés tels quels).
 		void CloseLanguageOptionsInGame();
 
+		/// Indique si l'écran d'options est actuellement ouvert en contexte in-game
+		/// (B2/ST4). Sert au renderer (\c RenderOptionsOverlay) pour savoir si l'écran
+		/// réutilisé en jeu doit rester affiché (true) ou a été fermé par l'utilisateur
+		/// (false, après Retour/Échap). Ne reflète QUE le drapeau in-game, pas la phase auth.
+		bool IsOptionsOpenInGame() const { return m_optionsOpenInGame; }
+
 		struct RegisterImGuiSubmit
 		{
 			const char* login = nullptr;

--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -1002,6 +1002,13 @@ namespace engine::client
 		uint32_t m_optionsRootSelection = 0;
 		uint32_t m_optionsSubSelection = 0;
 		Phase m_phaseBeforeOptions = Phase::Login;
+		/// Vrai quand l'écran d'options est ouvert depuis le menu Pause en jeu
+		/// (auth déjà terminée, m_flowComplete == true). Assouplit les gardes de
+		/// phase des chemins apply/close pour autoriser l'application et la
+		/// fermeture des options sans JAMAIS modifier m_phase ni m_flowComplete
+		/// (sinon l'écran d'auth réapparaîtrait par-dessus le jeu). Posé par
+		/// OpenLanguageOptionsInGame() (ST3) ; reste false en contexte auth.
+		bool m_optionsOpenInGame = false;
 		std::string m_selectedLocale;
 		std::string m_persistedLocale;
 		bool m_videoFullscreen = false;

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -125,10 +125,16 @@ namespace engine::client
 		}
 		// En contexte auth uniquement : restaurer la phase d'avant l'ouverture des
 		// options. En in-game on NE touche PAS m_phase (le presenter reste en état
-		// post-monde) — sinon l'écran d'auth réapparaîtrait par-dessus le jeu.
+		// post-monde) — sinon l'écran d'auth réapparaîtrait par-dessus le jeu — mais
+		// on dépose le drapeau in-game pour que le renderer (RenderOptionsOverlay)
+		// détecte la fermeture (IsOptionsOpenInGame() passe à false).
 		if (!m_optionsOpenInGame)
 		{
 			m_phase = m_phaseBeforeOptions;
+		}
+		else
+		{
+			CloseLanguageOptionsInGame();
 		}
 		LOG_INFO(Core, "[AuthUiPresenter] ImGui: options fermees sans appliquer");
 	}

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -142,6 +142,18 @@ namespace engine::client
 		}
 		m_phaseBeforeOptions = m_phase;
 		SetPhase(Phase::LanguageOptions);
+		InitOptionsPendingFromLive();
+		LOG_INFO(Core, "[AuthUiPresenter] Options opened (locale={}, fullscreen={}, vsync={}, sens={:.4f}, invert_y={}, layout={}, gameplay_udp={}, allow_insecure_dev={}, timeout_ms={})",
+			m_selectedLocale, m_videoFullscreenPending, m_videoVsyncPending,
+			m_mouseSensitivityPending, m_invertYPending, m_useZqsdPending ? "zqsd" : "wasd",
+			m_gameplayUdpEnabledPending, m_allowInsecureDevPending, m_authTimeoutMsPending);
+	}
+
+	// Bloc commun auth/in-game : copie l'état live vers les *Pending et calcule
+	// l'index de langue affiché. Aucune transition de phase ici.
+	void AuthUiPresenter::InitOptionsPendingFromLive()
+	{
+		const auto& locales = m_localization.GetAvailableLocales();
 		m_selectedLocale = CurrentLocale();
 		m_videoFullscreenPending = m_videoFullscreen;
 		m_videoVsyncPending = m_videoVsync;
@@ -168,10 +180,33 @@ namespace engine::client
 		m_optionsSubSelection = 0;
 		auto it = std::find(locales.begin(), locales.end(), m_selectedLocale);
 		m_languageSelectionIndex = it != locales.end() ? static_cast<uint32_t>(std::distance(locales.begin(), it)) : 0u;
-		LOG_INFO(Core, "[AuthUiPresenter] Options opened (locale={}, fullscreen={}, vsync={}, sens={:.4f}, invert_y={}, layout={}, gameplay_udp={}, allow_insecure_dev={}, timeout_ms={})",
+	}
+
+	void AuthUiPresenter::OpenLanguageOptionsInGame()
+	{
+		const auto& locales = m_localization.GetAvailableLocales();
+		if (locales.empty())
+		{
+			LOG_WARN(Core, "[AuthUiPresenter] OpenLanguageOptionsInGame ignored: no locales");
+			return;
+		}
+		// Contexte in-game : on NE touche NI m_phase NI m_phaseBeforeOptions. Le
+		// presenter reste en état post-monde (m_flowComplete == true). On se contente
+		// de poser le drapeau in-game et de préparer les valeurs affichées.
+		m_optionsOpenInGame = true;
+		InitOptionsPendingFromLive();
+		LOG_INFO(Core, "[AuthUiPresenter] Options in-game ouvertes (locale={}, fullscreen={}, vsync={}, sens={:.4f}, invert_y={}, layout={}, gameplay_udp={}, allow_insecure_dev={}, timeout_ms={})",
 			m_selectedLocale, m_videoFullscreenPending, m_videoVsyncPending,
 			m_mouseSensitivityPending, m_invertYPending, m_useZqsdPending ? "zqsd" : "wasd",
 			m_gameplayUdpEnabledPending, m_allowInsecureDevPending, m_authTimeoutMsPending);
+	}
+
+	void AuthUiPresenter::CloseLanguageOptionsInGame()
+	{
+		// Fermeture in-game : on dépose le drapeau, sans toucher m_phase. Pas de
+		// staging à annuler — fermer sans appliquer ne committe rien.
+		m_optionsOpenInGame = false;
+		LOG_INFO(Core, "[AuthUiPresenter] Options in-game fermees (sans appliquer)");
 	}
 
 	uint32_t AuthUiPresenter::OptionsSubmenuLineCount(OptionsSubMenu sub)

--- a/src/client/auth/AuthUiPresenterSettings.cpp
+++ b/src/client/auth/AuthUiPresenterSettings.cpp
@@ -80,7 +80,10 @@ namespace engine::client
 
 	void AuthUiPresenter::ImGuiApplyLanguageOptionsMenu(const engine::core::Config& cfg, const LanguageOptionsImGuiMirror& mirror)
 	{
-		if (m_phase != Phase::LanguageOptions)
+		// En contexte options in-game (m_optionsOpenInGame), la phase reste post-monde
+		// (m_flowComplete == true) : on assouplit la garde pour permettre l'apply sans
+		// jamais toucher m_phase.
+		if (m_phase != Phase::LanguageOptions && !m_optionsOpenInGame)
 		{
 			return;
 		}
@@ -115,11 +118,18 @@ namespace engine::client
 
 	void AuthUiPresenter::ImGuiCloseLanguageOptionsWithoutApply()
 	{
-		if (m_phase != Phase::LanguageOptions)
+		// Idem apply : en in-game la phase reste post-monde, on assouplit la garde.
+		if (m_phase != Phase::LanguageOptions && !m_optionsOpenInGame)
 		{
 			return;
 		}
-		m_phase = m_phaseBeforeOptions;
+		// En contexte auth uniquement : restaurer la phase d'avant l'ouverture des
+		// options. En in-game on NE touche PAS m_phase (le presenter reste en état
+		// post-monde) — sinon l'écran d'auth réapparaîtrait par-dessus le jeu.
+		if (!m_optionsOpenInGame)
+		{
+			m_phase = m_phaseBeforeOptions;
+		}
 		LOG_INFO(Core, "[AuthUiPresenter] ImGui: options fermees sans appliquer");
 	}
 	void AuthUiPresenter::OpenLanguageOptions()

--- a/src/client/auth/screens/AuthScreenLanguageSelect.cpp
+++ b/src/client/auth/screens/AuthScreenLanguageSelect.cpp
@@ -73,8 +73,13 @@ namespace engine::client
 			SetPhase(Phase::Login);
 			m_activeField = 0;
 		}
-		else
+		else if (!m_optionsOpenInGame)
 		{
+			// Chemin apply depuis l'écran d'options (auth) : restaurer la phase
+			// d'avant l'ouverture. En contexte options in-game (m_optionsOpenInGame),
+			// la locale est bien appliquée ci-dessus (SetLocale, sauvegarde, bannière)
+			// mais on NE change PAS la phase : le presenter reste en état post-monde,
+			// sinon l'écran d'auth réapparaîtrait par-dessus le jeu.
 			SetPhase(m_phaseBeforeOptions);
 		}
 	}

--- a/src/client/render/AuthImGuiRenderer.cpp
+++ b/src/client/render/AuthImGuiRenderer.cpp
@@ -459,7 +459,7 @@ namespace engine::render
 		}
 		else if (vs.options || vs.languageOptions)
 		{
-			RenderOptionsScreen(rm, viewportW, viewportH);
+			RenderOptionsScreen(rm, viewportW, viewportH, /*inGame=*/false);
 		}
 		else if (vs.shardPick)
 		{

--- a/src/client/render/AuthImGuiRenderer.h
+++ b/src/client/render/AuthImGuiRenderer.h
@@ -154,6 +154,27 @@ namespace engine::render
 		/// que l'utilisateur ferme l'écran.
 		bool m_optionsOverlayWasOpen = false;
 
+		/// B2/ST6 — Remap des touches (onglet Controls). Index de l'action en cours de
+		/// capture clavier : -1 = aucune capture, sinon 0..4 = indice dans la table des
+		/// actions remappables (cf. \c kRebindActions dans AuthImGuiOptions.cpp :
+		/// Sprint / Accroupi / Sort / Interagir / Coup de poing). En capture, la
+		/// prochaine touche ImGui pressée (hors Échap = annulation) est affectée à
+		/// l'action puis persistée dans \c keybinds.json.
+		int m_rebindActionIdx = -1;
+		/// B2/ST6 — Avertissement de conflit du dernier rebind (touche déjà affectée à
+		/// une autre action). Vide si aucun conflit. Affiché sous les lignes de remap.
+		std::string m_rebindWarning;
+		/// B2/ST6 — Miroirs locaux des touches courantes des 5 actions remappables,
+		/// dans l'ordre de \c kRebindActions. Initialisés depuis \c m_authCfg
+		/// (clés \c controls.keybind.*) au premier rendu de l'onglet, édités en direct
+		/// et persistés dans \c keybinds.json. Indispensables car \c m_authCfg est
+		/// \c const (lecture seule) — l'état d'édition vit ici.
+		std::string m_rebindKeys[5];
+		/// B2/ST6 — Flag « les miroirs \c m_rebindKeys ont été initialisés depuis la
+		/// config ». false force la (re)lecture depuis \c m_authCfg au prochain rendu
+		/// de l'onglet Controls (réinitialisé à l'ouverture de l'overlay in-game).
+		bool m_rebindKeysLoaded = false;
+
 		/// Réglages visuels locaux (maquette « Tweaks ») sur l’écran premier lancement.
 		/// `m_langTweakAnimBg` pilote (à terme) l’animation décorative du fond auth — voir
 		/// CODEBASE_MAP.md §13 « Tweaks d’auth ». Tant que l’animation n’existe pas, ce flag n’a

--- a/src/client/render/AuthImGuiRenderer.h
+++ b/src/client/render/AuthImGuiRenderer.h
@@ -44,6 +44,18 @@ namespace engine::render
 		void BindAuthUiBridge(engine::client::AuthUiPresenter* presenter, const engine::core::Config* cfg,
 			engine::platform::Window* window);
 
+		/// B2/ST4 — Rend l'écran d'options EXISTANT réutilisé EN JEU (menu Pause),
+		/// indépendamment de \c vs.active et SANS le décor auth (« THÈME DE RACE »).
+		/// Ouvre un overlay plein écran opaque, dessine l'écran d'options en mode
+		/// in-game, puis le referme. Effet de bord : émet des commandes ImGui (fenêtre
+		/// ##ln_auth_overlay) ; doit être appelée en MAIN THREAD, à l'intérieur d'une
+		/// frame ImGui déjà ouverte (entre NewFrame et Render). À la première frame
+		/// d'ouverture, initialise les mirrors d'édition depuis les valeurs *Pending
+		/// préparées par \c AuthUiPresenter::OpenLanguageOptionsInGame().
+		/// \return true tant que l'écran reste ouvert ; false dès que l'utilisateur a
+		/// demandé la fermeture (Retour/Échap) ou si aucun presenter n'est branché.
+		bool RenderOptionsOverlay(float vpW, float vpH);
+
 		/// Sous-projet C MVP (Task 12) — Branche le viewport offscreen
 		/// detenu par \c Engine pour l'apercu race dans l'ecran de
 		/// creation de personnage (\c AuthImGuiCharacterCreate). Pointer
@@ -131,6 +143,17 @@ namespace engine::render
 		bool m_optShowTooltipsUi = true;
 		int m_optPreferredServer = 2;
 
+		/// B2/ST4 — Drapeau « écran d'options rendu en contexte in-game » mis à jour
+		/// au début de \c RenderOptionsScreen. En in-game on masque le décor auth
+		/// (\c DrawAuthTweaksPanel) ; le masquage des onglets Network/Account viendra
+		/// au ST6 et s'appuiera sur ce même flag.
+		bool m_optionsInGame = false;
+		/// B2/ST4 — Suivi de l'état d'ouverture de l'overlay d'options in-game entre
+		/// frames. Passe à true à la première frame où \c RenderOptionsOverlay détecte
+		/// l'écran ouvert (déclenche le pull initial des mirrors), repasse à false dès
+		/// que l'utilisateur ferme l'écran.
+		bool m_optionsOverlayWasOpen = false;
+
 		/// Réglages visuels locaux (maquette « Tweaks ») sur l’écran premier lancement.
 		/// `m_langTweakAnimBg` pilote (à terme) l’animation décorative du fond auth — voir
 		/// CODEBASE_MAP.md §13 « Tweaks d’auth ». Tant que l’animation n’existe pas, ce flag n’a
@@ -176,7 +199,7 @@ namespace engine::render
 		void RenderErrorScreen(const RenderModel& rm, float vpW, float vpH);
 		void RenderVerifyScreen(const RenderModel& rm, float vpW, float vpH);
 		void RenderEmailConfirmationScreen(const RenderModel& rm, float vpW, float vpH);
-		void RenderOptionsScreen(const RenderModel& rm, float vpW, float vpH);
+		void RenderOptionsScreen(const RenderModel& rm, float vpW, float vpH, bool inGame = false);
 		void RenderShardScreen(const RenderModel& rm, float vpW, float vpH);
 		void RenderForgotScreen(const RenderModel& rm, float vpW, float vpH);
 		void RenderTermsScreen(const RenderModel& rm, float vpW, float vpH);

--- a/src/client/render/auth/screens/AuthImGuiOptions.cpp
+++ b/src/client/render/auth/screens/AuthImGuiOptions.cpp
@@ -33,6 +33,88 @@ namespace engine::render
 
 		constexpr int kOptionsRes[][2] = {{1280, 720}, {1600, 900}, {1920, 1080}, {2560, 1440}, {3840, 2160}}; ///< Table des resolutions video proposees dans le combo graphique.
 		constexpr int kOptionsResCount = sizeof(kOptionsRes) / sizeof(kOptionsRes[0]); ///< Nombre d'entrees dans kOptionsRes, calcule statiquement.
+
+		/// B2/ST6 — Une action gameplay remappable depuis l'onglet Controls.
+		/// \c cfgKey : cle config \c controls.keybind.* (lue/ecrite, miroir local) ;
+		/// \c def : touche par defaut (nom ASCII) si la cle est absente ;
+		/// \c labelKey / \c labelFallback : libelle i18n affiche (avec repli).
+		struct RebindAction
+		{
+			const char* cfgKey;
+			const char* def;
+			const char* labelKey;
+			const char* labelFallback;
+		};
+
+		/// B2/ST6 — Table figee des 5 actions remappables, ordre = index dans
+		/// \c m_rebindKeys et valeur de \c m_rebindActionIdx. Doit rester aligne sur
+		/// la liste portee depuis le mini-panneau in-game (Engine.cpp) et sur le
+		/// format d'ecriture de keybinds.json (cf. WriteKeybindsJson plus bas).
+		constexpr RebindAction kRebindActions[] = {
+			{"controls.keybind.sprint", "Alt", "options.keybind.sprint", "Sprint"},
+			{"controls.keybind.crouch", "Ctrl", "options.keybind.crouch", "Accroupi"},
+			{"controls.keybind.cast", "R", "options.keybind.cast", "Sort"},
+			{"controls.keybind.interact", "E", "options.keybind.interact", "Interagir"},
+			{"controls.keybind.punch", "X", "options.keybind.punch", "Coup de poing"},
+		};
+		constexpr int kRebindActionCount = sizeof(kRebindActions) / sizeof(kRebindActions[0]); ///< Nombre d'actions remappables (= taille de m_rebindKeys).
+
+		/// B2/ST6 — Correspondance \c ImGuiKey -> nom ASCII attendu par keybinds.json.
+		/// Cohérent avec \c kRebindableKeys (Engine.cpp) : modificateurs gauches
+		/// ("Shift"/"Ctrl"/"Alt"), lettres A..Z, chiffres 0..9, "Espace", "Tab".
+		struct ImGuiKeyName
+		{
+			ImGuiKey key;
+			const char* name;
+		};
+		const ImGuiKeyName kImGuiKeyNames[] = {
+			{ImGuiKey_A, "A"}, {ImGuiKey_B, "B"}, {ImGuiKey_C, "C"}, {ImGuiKey_D, "D"},
+			{ImGuiKey_E, "E"}, {ImGuiKey_F, "F"}, {ImGuiKey_G, "G"}, {ImGuiKey_H, "H"},
+			{ImGuiKey_L, "L"}, {ImGuiKey_M, "M"}, {ImGuiKey_N, "N"}, {ImGuiKey_O, "O"},
+			{ImGuiKey_P, "P"}, {ImGuiKey_Q, "Q"}, {ImGuiKey_R, "R"}, {ImGuiKey_S, "S"},
+			{ImGuiKey_U, "U"}, {ImGuiKey_V, "V"}, {ImGuiKey_W, "W"}, {ImGuiKey_X, "X"},
+			{ImGuiKey_Y, "Y"}, {ImGuiKey_Z, "Z"},
+			{ImGuiKey_0, "0"}, {ImGuiKey_1, "1"}, {ImGuiKey_2, "2"}, {ImGuiKey_3, "3"},
+			{ImGuiKey_4, "4"}, {ImGuiKey_5, "5"}, {ImGuiKey_6, "6"}, {ImGuiKey_7, "7"},
+			{ImGuiKey_8, "8"}, {ImGuiKey_9, "9"},
+			{ImGuiKey_LeftCtrl, "Ctrl"}, {ImGuiKey_RightCtrl, "Ctrl"},
+			{ImGuiKey_LeftAlt, "Alt"}, {ImGuiKey_RightAlt, "Alt"},
+			{ImGuiKey_LeftShift, "Shift"}, {ImGuiKey_RightShift, "Shift"},
+			{ImGuiKey_Space, "Espace"}, {ImGuiKey_Tab, "Tab"},
+		};
+
+		/// B2/ST6 — Balaie les touches connues et renvoie le nom ASCII de la première
+		/// pressée cette frame (front montant, \c repeat=false), ou nullptr si aucune.
+		/// Sert à la capture de rebind via la couche clavier d'ImGui (l'écran d'options
+		/// n'a pas accès à \c m_input, contrairement au mini-panneau in-game).
+		const char* CapturePressedKeyName()
+		{
+			for (const auto& e : kImGuiKeyNames)
+			{
+				if (ImGui::IsKeyPressed(e.key, false))
+				{
+					return e.name;
+				}
+			}
+			return nullptr;
+		}
+
+		/// B2/ST6 — Sérialise les 5 touches remappées au format keybinds.json et l'écrit
+		/// sur disque (fichier dédié mergé au boot, comme ui_theme.json). \c keys est
+		/// indexé comme \c kRebindActions. Les valeurs étant des noms ASCII contrôlés,
+		/// aucun échappement JSON n'est requis. Effet de bord : écriture fichier.
+		void WriteKeybindsJson(const std::string keys[kRebindActionCount])
+		{
+			const std::string js =
+				std::string("{\n  \"controls\": {\n    \"keybind\": {\n")
+				+ "      \"sprint\": \"" + keys[0] + "\",\n"
+				+ "      \"crouch\": \"" + keys[1] + "\",\n"
+				+ "      \"cast\": \"" + keys[2] + "\",\n"
+				+ "      \"interact\": \"" + keys[3] + "\",\n"
+				+ "      \"punch\": \"" + keys[4] + "\"\n"
+				+ "    }\n  }\n}\n";
+			(void)engine::platform::FileSystem::WriteAllText("keybinds.json", js);
+		}
 	} // namespace
 
 	/// Affiche l'overlay Options complet : sidebar de navigation par onglets a gauche, panneau principal a droite avec les reglages de l'onglet actif, et barre de boutons Retour / Annuler / Appliquer en bas.
@@ -41,6 +123,11 @@ namespace engine::render
 	{
 		// B2/ST4 — memorise le contexte pour les helpers internes (masquage onglets ST6).
 		m_optionsInGame = inGame;
+		// B2/ST6 — true si une capture de rebind était active au début de la frame.
+		// Le remap (onglet Controls) traite Échap pour annuler la capture ; on garde
+		// l'info ici pour que le handler Échap global (bas de fonction) ne ferme PAS
+		// l'overlay la même frame qu'une annulation de capture.
+		const bool rebindWasActive = (m_rebindActionIdx >= 0);
 		const auto tr = [this](const char* key, const char* fallback = nullptr) -> std::string {
 			if (m_authPresenter == nullptr)
 			{
@@ -75,6 +162,32 @@ namespace engine::render
 		// Anciennes icones Unicode (carre, note de musique, clavier, etc.) absentes de Windlass
 		// + ProggyClean fallback : rendaient toutes des '?'. Suppression au profit du libelle nu.
 		static constexpr int tabCount = 7;
+		// Indices des onglets : 0 Graphics, 1 Audio, 2 Controls, 3 Lang, 4 UI,
+		// 5 Network, 6 Account.
+		static constexpr int kTabNetwork = 5;
+		static constexpr int kTabAccount = 6;
+
+		// B2/ST6 — Liste des onglets visibles dans le contexte courant. En jeu
+		// (m_optionsInGame) on masque Network et Account : ces onglets dépendent du
+		// flux auth (serveur préféré, latence, compte connecté) sans objet en jeu.
+		// On itère ensuite sur cette liste pour la sidebar ET pour borner m_optionsTab,
+		// de sorte qu'aucun onglet masqué ne reste sélectionnable.
+		std::vector<int> visibleTabs;
+		visibleTabs.reserve(tabCount);
+		for (int i = 0; i < tabCount; ++i)
+		{
+			if (m_optionsInGame && (i == kTabNetwork || i == kTabAccount))
+			{
+				continue;
+			}
+			visibleTabs.push_back(i);
+		}
+		// Si l'onglet courant n'est plus visible (ex. on entre en jeu alors que
+		// l'onglet Account était actif), ramener sur le premier onglet visible.
+		if (std::find(visibleTabs.begin(), visibleTabs.end(), m_optionsTab) == visibleTabs.end())
+		{
+			m_optionsTab = visibleTabs.empty() ? 0 : visibleTabs.front();
+		}
 
 		// Sidebar haute = main haute (alignement vertical du cadre).
 		const float topMargin = 60.f;
@@ -99,7 +212,7 @@ namespace engine::render
 		ImGui::PopStyleColor();
 		DrawSeparator();
 
-		for (int i = 0; i < tabCount; ++i)
+		for (int i : visibleTabs)
 		{
 			const bool active = (m_optionsTab == i);
 			const std::string tabLabel = tr(kTabKeys[i]);
@@ -357,15 +470,102 @@ namespace engine::render
 			toggleRow("options.imgui.zqsd_layout", &m_optUseZqsd, "options.imgui.hint.zqsd");
 
 			sectionTitle("options.imgui.section.keybinds");
-			DrawAuthKeybind(tr("options.keybind.forward", "Avancer"), "Z / W");
-			DrawAuthKeybind(tr("options.keybind.strafe_left", "Gauche"), "Q / A");
-			DrawAuthKeybind(tr("options.keybind.backward", "Reculer"), "S");
-			DrawAuthKeybind(tr("options.keybind.strafe_right", "Droite"), "D");
-			DrawAuthKeybind(tr("options.keybind.interact", "Interagir"), "E");
-			DrawAuthKeybind(tr("options.keybind.spell1", "Sort 1"), "1");
-			DrawAuthKeybind(tr("options.keybind.spell2", "Sort 2"), "2");
-			DrawAuthKeybind(tr("options.keybind.inventory", "Inventaire"), "I");
-			DrawAuthKeybind(tr("options.keybind.map", "Carte"), "M");
+
+			// B2/ST6 — Remap interactif des 5 actions gameplay (Sprint / Accroupi /
+			// Sort / Interagir / Coup de poing), actif à l'auth ET en jeu. Porté du
+			// mini-panneau in-game (Engine.cpp) mais via la capture clavier d'ImGui :
+			// l'écran d'options (couche renderer) n'a pas accès à m_input.
+			//
+			// 1) Charge les miroirs locaux depuis la config au premier passage (m_authCfg
+			//    est const : l'état d'édition vit dans m_rebindKeys). 2) Si une capture
+			//    est en cours, affecte la prochaine touche pressée (Échap annule) et
+			//    persiste keybinds.json. 3) Affiche une ligne « Action : <touche> [Modifier] »
+			//    par action, avec signalement de conflit (touche déjà sur une autre action).
+			if (!m_rebindKeysLoaded)
+			{
+				for (int a = 0; a < kRebindActionCount; ++a)
+				{
+					m_rebindKeys[a] = (m_authCfg != nullptr)
+						? m_authCfg->GetString(kRebindActions[a].cfgKey, kRebindActions[a].def)
+						: std::string(kRebindActions[a].def);
+				}
+				m_rebindKeysLoaded = true;
+			}
+
+			// Capture en cours : balaye le clavier ImGui. Échap annule sans modifier.
+			if (m_rebindActionIdx >= 0 && m_rebindActionIdx < kRebindActionCount)
+			{
+				if (ImGui::IsKeyPressed(ImGuiKey_Escape, false))
+				{
+					m_rebindActionIdx = -1;
+				}
+				else if (const char* pressed = CapturePressedKeyName())
+				{
+					// Détection de conflit : la touche choisie est-elle déjà affectée à
+					// une autre action ? (doublon autorisé, simplement signalé.)
+					m_rebindWarning.clear();
+					for (int a = 0; a < kRebindActionCount; ++a)
+					{
+						if (a != m_rebindActionIdx && m_rebindKeys[a] == pressed)
+						{
+							const std::string other = tr(kRebindActions[a].labelKey, kRebindActions[a].labelFallback);
+							m_rebindWarning = std::string("Touche '") + pressed + "' deja utilisee par " + other + " (doublon).";
+							break;
+						}
+					}
+					m_rebindKeys[m_rebindActionIdx] = pressed;
+					WriteKeybindsJson(m_rebindKeys);
+					m_rebindActionIdx = -1;
+				}
+			}
+
+			// Ligne éditable par action : libellé + touche courante, bouton « Modifier ».
+			const auto rebindRow = [&](int actionIdx) {
+				const RebindAction& act = kRebindActions[actionIdx];
+				const std::string label = tr(act.labelKey, act.labelFallback);
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+				ImGui::AlignTextToFramePadding();
+				ImGui::Text("%s : %s", label.c_str(), m_rebindKeys[actionIdx].c_str());
+				ImGui::PopStyleColor();
+				ImGui::SameLine(220.f);
+				ImGui::PushID(actionIdx);
+				if (m_rebindActionIdx == actionIdx)
+				{
+					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::TextUnformatted(tr("options.keybind.press_key", "appuyez sur une touche (Echap = annuler)").c_str());
+					ImGui::PopStyleColor();
+				}
+				else
+				{
+					// Bouton compact (largeur fixe) : DrawAuthButtonGhost s'étire sur
+					// toute la largeur restante (width -FLT_MIN), inadapté après SameLine.
+					ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kSurface));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.12f)));
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.18f)));
+					ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
+					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
+					if (ImGui::Button(tr("options.keybind.rebind", "Modifier").c_str(), ImVec2(110.f, 28.f)))
+					{
+						m_rebindActionIdx = actionIdx;
+						m_rebindWarning.clear();
+					}
+					ImGui::PopStyleVar(2);
+					ImGui::PopStyleColor(5);
+				}
+				ImGui::PopID();
+			};
+			for (int a = 0; a < kRebindActionCount; ++a)
+			{
+				rebindRow(a);
+			}
+			if (!m_rebindWarning.empty())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kWarning));
+				ImGui::TextWrapped("%s", m_rebindWarning.c_str());
+				ImGui::PopStyleColor();
+			}
 		}
 		else if (m_optionsTab == 3)
 		{
@@ -612,7 +812,10 @@ namespace engine::render
 
 		ImGui::EndChild();
 
-		if (ImGui::IsKeyPressed(ImGuiKey_Escape, false) && m_authPresenter != nullptr)
+		// B2/ST6 — ne pas fermer l'overlay si Échap vient d'annuler une capture de
+		// rebind (le remap a déjà consommé la touche cette frame).
+		if (ImGui::IsKeyPressed(ImGuiKey_Escape, false) && !rebindWasActive && m_rebindActionIdx < 0
+			&& m_authPresenter != nullptr)
 		{
 			m_authPresenter->ImGuiCloseLanguageOptionsWithoutApply();
 		}
@@ -649,6 +852,11 @@ namespace engine::render
 		if (!m_optionsOverlayWasOpen)
 		{
 			PullLanguageOptionsFromPresenter();
+			// B2/ST6 — force la relecture des touches remappables depuis la config à
+			// chaque ouverture in-game (l'utilisateur a pu les changer au clavier ailleurs).
+			m_rebindKeysLoaded = false;
+			m_rebindActionIdx = -1;
+			m_rebindWarning.clear();
 			m_optionsOverlayWasOpen = true;
 		}
 

--- a/src/client/render/auth/screens/AuthImGuiOptions.cpp
+++ b/src/client/render/auth/screens/AuthImGuiOptions.cpp
@@ -36,8 +36,11 @@ namespace engine::render
 	} // namespace
 
 	/// Affiche l'overlay Options complet : sidebar de navigation par onglets a gauche, panneau principal a droite avec les reglages de l'onglet actif, et barre de boutons Retour / Annuler / Appliquer en bas.
-	void AuthImGuiRenderer::RenderOptionsScreen(const RenderModel& rm, float vpW, float vpH)
+	/// \param inGame true quand l'ecran est reutilise en jeu (menu Pause) : on masque alors le decor auth (DrawAuthTweaksPanel « THEME DE RACE »). Le flag est aussi memorise dans m_optionsInGame pour le masquage d'onglets (ST6).
+	void AuthImGuiRenderer::RenderOptionsScreen(const RenderModel& rm, float vpW, float vpH, bool inGame)
 	{
+		// B2/ST4 — memorise le contexte pour les helpers internes (masquage onglets ST6).
+		m_optionsInGame = inGame;
 		const auto tr = [this](const char* key, const char* fallback = nullptr) -> std::string {
 			if (m_authPresenter == nullptr)
 			{
@@ -618,7 +621,51 @@ namespace engine::render
 			submitOptionsMirror();
 		}
 
-		DrawAuthTweaksPanel(vpW, vpH);
+		// Decor auth (« THEME DE RACE ») : uniquement hors contexte in-game.
+		if (!inGame)
+		{
+			DrawAuthTweaksPanel(vpW, vpH);
+		}
+	}
+
+	/// B2/ST4 — Rend l'ecran d'options reutilise EN JEU, independamment de vs.active.
+	/// Voir la doc d'en-tete (AuthImGuiRenderer.h) pour le contrat complet (main thread,
+	/// frame ImGui ouverte, valeur de retour). Detail d'implementation :
+	///  - 1ere frame d'ouverture (m_optionsOverlayWasOpen passe false->true) : on tire les
+	///    mirrors d'edition (m_opt*) depuis les *Pending prepares par OpenLanguageOptionsInGame.
+	///  - overlay opaque via BeginFullscreenOverlay(.., 1.0f), puis RenderOptionsScreen(inGame=true),
+	///    puis ImGui::End() — paire Begin/End equilibree.
+	///  - fermeture detectee via le presenter : RenderOptionsScreen appelle
+	///    ImGuiCloseLanguageOptionsWithoutApply() (Retour/Echap) qui, en in-game, pose
+	///    m_optionsOpenInGame=false ; on relit IsOptionsOpenInGame() pour la valeur de retour.
+	bool AuthImGuiRenderer::RenderOptionsOverlay(float vpW, float vpH)
+	{
+		if (m_authPresenter == nullptr)
+		{
+			return false;
+		}
+		// Premiere frame d'ouverture : initialiser les mirrors d'edition depuis les
+		// valeurs *Pending (deja preparees par OpenLanguageOptionsInGame au ST3).
+		if (!m_optionsOverlayWasOpen)
+		{
+			PullLanguageOptionsFromPresenter();
+			m_optionsOverlayWasOpen = true;
+		}
+
+		// RenderModel minimal : champs par defaut. authOptionsAccountLogin /
+		// authOptionsAccountTagId restent vides — l'onglet Account sera masque en jeu (ST6).
+		RenderModel rmMinimal{};
+		BeginFullscreenOverlay(vpW, vpH, 1.0f);
+		RenderOptionsScreen(rmMinimal, vpW, vpH, /*inGame=*/true);
+		ImGui::End();
+
+		// Etat d'ouverture cote presenter : true = encore ouvert, false = ferme (Retour/Echap).
+		const bool stillOpen = m_authPresenter->IsOptionsOpenInGame();
+		if (!stillOpen)
+		{
+			m_optionsOverlayWasOpen = false;
+		}
+		return stillOpen;
 	}
 } // namespace engine::render
 


### PR DESCRIPTION
B2 de la séance de corrections. Le bouton « Options » du menu Pause en jeu ouvre désormais le **même** écran d'options que l'auth (source unique). L'ancien mini-panneau in-game est supprimé. Le menu Pause (ESC) lui-même est inchangé.

## Approche (refactor « pipeline réutilisable »)
L'écran d'options auth était verrouillé au flux pré-monde par 3 gardes fermées dès l'entrée en jeu. Levées sans jamais toucher `m_phase`/`m_flowComplete` :
- **ST1** — `Engine::ApplyConsumedSettingsCommands()` extrait et appelé **chaque frame** (idempotent) → les réglages s'appliquent aussi en jeu.
- **ST2** — drapeau `m_optionsOpenInGame` : assouplit les gardes `Phase` de l'apply/close, en neutralisant tout `SetPhase` quand on est en jeu (sécurité session vérifiée en revue : aucun `SetPhase` atteignable en contexte in-game).
- **ST3** — `OpenLanguageOptionsInGame()` / `CloseLanguageOptionsInGame()` (sans transition de phase) + helper commun `InitOptionsPendingFromLive()`.
- **ST4** — `AuthImGuiRenderer::RenderOptionsOverlay()` : rend l'écran d'options réutilisé, sans le décor auth, indépendant de `vs.active` ; renvoie l'état ouvert/fermé.
- **ST5** — câblage Engine : bouton Pause → ouverture in-game, mini-panneau supprimé, retour au menu Pause à la fermeture, `ReloadKeybindsFromDisk()` (effet live des rebinds), retrait du code mort.
- **ST6** — onglets **Network et Account masqués en jeu** (risque déconnexion/actions compte) ; **remap des touches éditable** (capture ImGui + `keybinds.json`), actif à l'auth ET en jeu.

## Validation en jeu requise (non testable sans build)
- ESC pendant l'overlay options → ferme l'overlay ET réaffiche le menu Pause (un seul appui).
- Apply en jeu (volume/sensibilité/vsync/fullscreen/FOV) sans casser la session.
- Remap d'une touche (ex. Sprint) → effet **immédiat** en jeu après fermeture (sans redémarrage).
- En jeu : 5 onglets (Graphics/Audio/Controls/Language/UI) ; à l'auth : 7 onglets, décor inchangé.

## Déploiement
✅ **Client uniquement**, pas de redéploiement serveur (UI/presenter/rendu + lecture config client ; aucun opcode/handler/DB/config serveur).

Coordination merge : indépendant de la PR #901 (B1) ; fichiers communs (`Engine.cpp`, `AuthImGuiRenderer.*`) mais régions distinctes — si #901 merge avant, rebaser cette branche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)