### PR TITLE
fix(auth): touche Entree valide le formulaire d'inscription (ImGui)

### DIFF
--- a/src/client/render/auth/screens/AuthImGuiRegister.cpp
+++ b/src/client/render/auth/screens/AuthImGuiRegister.cpp
@@ -371,6 +371,30 @@ namespace engine::render
 			}
 		}
 
+		// Touche Entree (clavier principal ou pave numerique) : declenche le meme chemin que
+		// le bouton « Creer le compte ». Pattern identique a RenderLoginScreen (l.162) et
+		// RenderVerifyEmailScreen. Avant ce correctif, l'ecran Register n'avait AUCUN handler
+		// Entree (le renderer n'en posait pas, Update_Register sort tot en mode ImGui, et le
+		// dispatch clavier global exclut le mode ImGui) : la touche « Valider » annoncee dans
+		// le pied de page restait donc sans effet. dayStr/monStr/yrStr et les buffers m_reg*
+		// sont encore en portee ici (declares plus haut dans la fonction).
+		if (m_authPresenter != nullptr && m_authCfg != nullptr
+			&& (ImGui::IsKeyPressed(ImGuiKey_Enter, false) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter, false)))
+		{
+			engine::client::AuthUiPresenter::RegisterImGuiSubmit form{};
+			form.login = m_regId;
+			form.email = m_regEmail;
+			form.password = m_regPw;
+			form.passwordConfirm = m_regPw2;
+			form.firstName = m_regFirstName;
+			form.lastName = m_regLastName;
+			form.birthDay = dayStr.c_str();
+			form.birthMonth = monStr.c_str();
+			form.birthYear = yrStr.c_str();
+			form.countryIso2 = m_regCountry;
+			m_authPresenter->ImGuiSubmitRegister(*m_authCfg, form);
+		}
+
 		DrawSeparator();
 		DrawRegisterFooterChips(rm);
 		EndPanel();


### PR DESCRIPTION
L'ecran Register etait le seul ecran auth ImGui sans handler de la touche Entree : son renderer n'en posait pas, Update_Register sort tot en mode ImGui, et le dispatch clavier global (AuthUiPresenterCore) exclut le mode ImGui. La touche « Valider » annoncee dans le pied de page restait donc sans effet.

Ajoute dans RenderRegisterScreen le meme handler que RenderLoginScreen (ImGui::IsKeyPressed(ImGuiKey_Enter/KeypadEnter) -> ImGuiSubmitRegister), avec la meme construction de formulaire que le bouton souris « Creer le compte ».

Boutons souris (BACK/SUBMIT) et touche Echap (OnEscape) inchanges : deja cables a l'identique de Login, fonctionnels.

Verification : manuelle en jeu (renderer ImGui Windows-only, non testable en CI).