### PR TITLE
feat(gameplay): meshes/props marchables (le perso se pose dessus, toute hauteur)

### DIFF
--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -417,20 +417,25 @@ namespace engine::gameplay
 		(void)input;
 		(void)dt;
 
-		// Attempt:
-		// 1) Move up by maxStep and sweep horizontally.
-		// 2) If horizontal is clear, sweep downward by maxStep to find landing.
+		// Attempt (« meshes marchables quelle que soit la hauteur ») :
+		// 1) Monter de `maxClimb` (≫ maxStep) et balayer horizontalement.
+		// 2) Si l'horizontal est libre, balayer vers le bas de `maxClimb` pour trouver
+		//    le point de pose sur le dessus de l'obstacle.
+		// On utilise `maxClimb` (et non `maxStep`) afin de pouvoir monter sur le dessus
+		// d'un prop/mesh de hauteur quelconque (dans la limite `maxClimb`) en butant
+		// dedans, au lieu de seulement lisser les marches <= 0,3 m.
+		const float climb = (m_cfg.maxClimb > m_cfg.maxStep) ? m_cfg.maxClimb : m_cfg.maxStep;
 		const engine::math::Vec3 up(0.0f, 1.0f, 0.0f);
-		const engine::math::Vec3 upStart = startPos + up * m_cfg.maxStep;
+		const engine::math::Vec3 upStart = startPos + up * climb;
 		const engine::math::Vec3 upEnd = upStart + horizontalDisp;
 
 		IWorldCollider::SweepHit hit{};
 		if (world.SweepCapsule(m_capsule, upStart, upEnd, hit) && hit.hit && hit.fraction < 1.0f)
 			return false;
 
-		// Now sweep down to land.
+		// Now sweep down to land (jusqu'à `climb` plus bas).
 		const engine::math::Vec3 downStart = upEnd;
-		const engine::math::Vec3 downEnd = downStart + up * (-m_cfg.maxStep);
+		const engine::math::Vec3 downEnd = downStart + up * (-climb);
 		IWorldCollider::SweepHit downHit{};
 		if (!world.SweepCapsule(m_capsule, downStart, downEnd, downHit) || !downHit.hit)
 		{

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -88,7 +88,13 @@ namespace engine::gameplay
 			float gravity = -20.0f; ///< m/s^2
 
 			float maxSlopeDeg = 45.0f; ///< walkable slope
-			float maxStep = 0.3f;      ///< m
+			float maxStep = 0.3f;      ///< m — lissage des petites marches/terrain
+			/// Hauteur max de montée sur un obstacle « solide marchable » (prop/mesh)
+			/// lors d'un step-up. Réglé généreux pour rendre les meshes marchables
+			/// QUELLE QUE SOIT leur hauteur (demande de design) : en butant un prop on
+			/// monte sur son dessus jusqu'à `maxClimb`. Au-delà, le prop reste un mur.
+			/// Tunable : augmenter pour grimper des structures plus hautes.
+			float maxClimb = 3.0f;     ///< m
 
 			// Saut realiste : apex = jumpSpeed^2 / (2*|gravity|). Avec gravity=-20,
 			// jumpSpeed=4.9 -> ~0.60 m (env. 1/3 de la taille 1.8 m, saut humain pose).

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -32,32 +32,65 @@ namespace engine::gameplay
 				best = th;
 		}
 
-		// 2) Cylindres : test 2D cercle (capsule en XZ) contre cercle (cylindre), borné
-		//    en Y. On résout le plus petit t in [0,1] où la distance horizontale entre
-		//    le centre de la capsule et l'axe du cylindre vaut (rCapsule + rCylindre).
+		// 2) Cylindres de props. Chaque prop est désormais SOLIDE et MARCHABLE :
+		//    - capuchon supérieur (2a) : le personnage se pose SUR le mesh (sol,
+		//      plateforme…) comme sur le terrain, au lieu de flotter / d'être bloqué ;
+		//    - flanc (2b) : barrière horizontale (murs, troncs) tant qu'on est À CÔTÉ.
 		const float halfH = capsule.height * 0.5f;
 		const float sx = startCenter.x, sz = startCenter.z;
 		const float dx = endCenter.x - sx, dz = endCenter.z - sz;
 
+		// Tolérance verticale pour considérer la capsule « posée sur le dessus » d'un
+		// prop : tant que ses pieds sont à moins de kStandSkin sous le sommet, on ne
+		// bloque plus latéralement (sinon, une fois debout sur le mesh, le test de
+		// flanc l'empêcherait d'avancer = perso coincé en haut).
+		constexpr float kStandSkin = 0.05f;
+
 		for (const auto& c : m_cylinders)
 		{
+			// --- 2a) Capuchon supérieur : surface marchable au sommet du prop ---
+			// Quand le bas de la capsule descend à travers `topY` au-dessus de
+			// l'empreinte XZ du cylindre, on arrête la descente sur le sommet et on
+			// renvoie une normale verticale (→ IsWalkable côté CharacterController, le
+			// perso se pose dessus). C'est ce qui rend les meshes « marchables ».
+			{
+				const float bottomStart = startCenter.y - halfH - capsule.radius;
+				const float bottomEnd   = endCenter.y   - halfH - capsule.radius;
+				const float denom = bottomStart - bottomEnd;   // > 0 si la capsule descend
+				if (denom > 1e-6f)
+				{
+					const float tc = (bottomStart - c.topY) / denom;  // bas de capsule == topY
+					if (tc >= 0.0f && tc <= 1.0f && tc < best.fraction)
+					{
+						const float px = sx + tc * dx - c.cx;
+						const float pz = sz + tc * dz - c.cz;
+						if (px * px + pz * pz <= c.radius * c.radius)  // au-dessus du disque
+						{
+							best.hit = true;
+							best.fraction = tc;
+							best.normal = engine::math::Vec3{ 0.0f, 1.0f, 0.0f };
+						}
+					}
+				}
+			}
+
+			// --- 2b) Flanc : barrière horizontale (test 2D cercle vs cercle borné en Y) ---
 			const float R = capsule.radius + c.radius;
 
-			// Recouvrement vertical (au point d'arrivée, conservateur) : si la capsule
-			// passe entièrement au-dessus ou en dessous du cylindre, pas de collision.
+			// Recouvrement vertical : pas de blocage latéral si la capsule passe
+			// entièrement sous la base, OU si ses pieds sont au niveau / au-dessus du
+			// sommet (= posée DESSUS — géré par le capuchon ci-dessus, pas à côté).
 			const float capLo = endCenter.y - halfH - capsule.radius;
 			const float capHi = endCenter.y + halfH + capsule.radius;
-			if (capHi < c.baseY || capLo > c.topY) continue;
+			if (capHi < c.baseY || capLo > c.topY - kStandSkin) continue;
 
 			const float fx = sx - c.cx, fz = sz - c.cz;
 			const float a = dx * dx + dz * dz;            // mouvement horizontal au carré
 			const float cc = fx * fx + fz * fz - R * R;   // < 0 => déjà en chevauchement XZ
 
-			// IMPORTANT : la collision contre un prop ne concerne QUE le déplacement
-			// HORIZONTAL entrant dans le cylindre. On ne bloque JAMAIS un sweep vertical
-			// (gravité, sonde de sol, récupération anti-encastrement du CharacterController
-			// qui sonde depuis 50 m au-dessus). Sinon ces sweeps verticaux heurtent le
-			// cylindre et la récupération téléporte le perso au sommet de la sonde.
+			// Le flanc ne concerne QUE le déplacement HORIZONTAL entrant dans le
+			// cylindre ; un sweep purement vertical (descente) est traité par le
+			// capuchon 2a, pas ici.
 			float tHit = -1.0f;
 			if (a >= 1e-8f)
 			{

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -68,15 +68,29 @@ int main()
 		check(!h, "sans_cylindre: pas de hit");
 	}
 
-	// 4bis) RÉGRESSION (téléport en hauteur) : un sweep VERTICAL traversant le
-	// cylindre par son axe (ex. sonde de récupération anti-encastrement qui sonde
-	// depuis 50 m au-dessus) NE DOIT PAS générer de hit. Sinon le CharacterController
-	// téléporte le perso au sommet de la sonde.
+	// 4bis) MARCHABLE — un sweep DESCENDANT au-dessus de l'empreinte du cylindre se
+	// POSE sur le sommet (topY=3) avec une normale verticale. C'est le comportement
+	// voulu (« avancer sur les meshes comme sur le sol ») qui remplace l'ancien
+	// "anti-teleport" : le perso se tient désormais sur le dessus des props.
 	{
 		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
 		IWorldCollider::SweepHit hit;
 		bool h = c.SweepCapsule(cap, Vec3{ 5, 20, 0 }, Vec3{ 5, 1, 0 }, hit);
-		check(!h && !hit.hit, "sweep vertical dans cylindre: pas de hit (anti-teleport)");
+		check(h && hit.hit, "dessus: se pose sur le sommet (hit)");
+		check(hit.normal.y > 0.99f, "dessus: normale verticale (marchable)");
+		// Repos attendu : bas de la capsule sur topY=3 -> centre = 3 + halfH(0.9) + r(0.3) = 4.2.
+		const float restY = 20.0f + hit.fraction * (1.0f - 20.0f);
+		check(std::fabs(restY - 4.2f) < 0.05f, "dessus: repos a topY + demi-capsule");
+	}
+
+	// 4quater) Une fois POSÉ sur le dessus (pieds au niveau topY=3, centre y=4.2),
+	// le déplacement horizontal n'est PLUS bloqué par le flanc (sinon le perso
+	// resterait coincé en haut du mesh).
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 0, 4.2f, 0 }, Vec3{ 10, 4.2f, 0 }, hit);
+		check(!h, "sur le dessus: avance librement (pas de blocage de flanc)");
 	}
 
 	// 4ter) Déjà en chevauchement, mouvement s'ÉLOIGNANT de l'axe : pas de hit


### PR DESCRIPTION
## Résumé

Avant, les props (cylindres de collision) ne bloquaient **que l'horizontal**, sans surface marchable au sommet, et le grounding était terrain-only → le personnage **flottait** sur les meshes de sol / près des murs (step-up qui ne redescend pas). Cette PR rend les meshes **marchables comme le sol**.

**Collision (`CompositeWorldCollider::SweepCapsule`)** — chaque cylindre devient solide + marchable :
- **capuchon supérieur** : une sonde descendante au-dessus de l'empreinte XZ se pose sur `topY` (normale verticale → `IsWalkable`) → le perso se tient sur le mesh ;
- **flanc** : ne bloque plus quand les pieds sont au niveau du sommet (`kStandSkin`), sinon le perso serait coincé une fois monté.

**Déplacement (`CharacterController`)** — meshes marchables **quelle que soit la hauteur** :
- nouveau `Config::maxClimb` (défaut 3 m, **tunable**, séparé de `maxStep`) ;
- `TryStepUp` monte sur le dessus d'un prop jusqu'à `maxClimb` en butant dedans.

## Tests

- Unitaires CI (`CompositeWorldColliderTests`) mis à jour : l'ancien cas « anti-téléport » devient « se pose sur le dessus » + nouveau cas « avance librement une fois posé ».
- ⚠️ **Itération à régler en jeu** : le *feel* du déplacement (et l'effet de bord : ressauts de **terrain** ≤ `maxClimb` deviennent auto-grimpables) doit être validé/tuné en jeu. Dis-moi si ça flotte encore / si on grimpe trop facilement, j'ajuste `maxClimb`.

## Déploiement

✅ **Client uniquement** (collision/déplacement côté client), **pas de redéploiement serveur**. Aucun changement de protocole (position client-autoritaire, validation shard inchangée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)