### PR TITLE
feat(server): cimetière par défaut par zone au respawn (anti-triche position)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-cimetiere-par-zone.md
+++ b/docs/superpowers/plans/2026-06-19-cimetiere-par-zone.md
@@ -1,0 +1,234 @@
+# Cimetière par défaut par zone — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Le respawn au cimetière choisit, de façon déterministe et **indépendante de la position de mort** (client-autoritaire, donc spoofable → anti-triche), le **cimetière par défaut de la zone** du joueur (1er cimetière éligible par propriété de faction).
+
+**Architecture:** Une règle d'éligibilité pure position-indépendante dans le header partagé `RespawnRules.h` ; `ServerApp::HandleRespawnRequest` remplace la sélection « cimetière le plus proche » par « 1er cimetière par défaut éligible de la zone ». L'auberge reste inchangée (le plus proche).
+
+**Tech Stack:** C++17, header-only pur (RespawnRules), serveur UDP (ServerApp), tests `int main()` + macro `REQUIRE`, CMake. Pas de toolchain locale (build/ctest via CI).
+
+**Spec :** [docs/superpowers/specs/2026-06-19-cimetiere-par-zone-design.md](../specs/2026-06-19-cimetiere-par-zone-design.md)
+
+**Rappels projet :** commentaires **français** ; branche `claude/zone-default-graveyard` (worktree `flamboyant-yalow-fda4a5`). ⚠️ **REDÉPLOIEMENT SERVEUR REQUIS** (change la sélection respawn) ; **pas de changement wire** (client compatible).
+
+---
+
+## Structure des fichiers
+
+| Fichier | Action | Rôle |
+|---------|--------|------|
+| `src/shared/world/RespawnRules.h` | Modifier | Ajouter `IsGraveyardEligibleAsZoneDefault` (éligibilité par propriété seule, sans distance) |
+| `src/shared/world/tests/RespawnRulesTests.cpp` | Modifier | Tests de la nouvelle règle (cible CI `respawn_rules_tests` déjà enregistrée) |
+| `src/shared/server_bootstrap/ServerApp.cpp` | Modifier | `HandleRespawnRequest` : sélection cimetière = défaut de zone (position-indépendant) ; auberge inchangée |
+
+> **Données** : aucune modification requise. La zone active (`feyhin`) a déjà son cimetière dans
+> `game/data/zones/feyhin/respawn_points.txt` (`0 graveyard 120.0 1.5 120.0 -`), qui devient son
+> défaut. Convention (forward-looking) : toute future zone jouable doit avoir ≥1 ligne `graveyard`
+> dans son `respawn_points.txt` ; le **premier** cimetière éligible (ordre de fichier) est le défaut.
+> `demo_plains` est un placeholder (`zone.meta` = `ZONE`), pas une zone de respawn → non concerné.
+
+---
+
+## Task 1 : Règle d'éligibilité position-indépendante (`RespawnRules`)
+
+**Files:**
+- Modify: `src/shared/world/RespawnRules.h`
+- Test: `src/shared/world/tests/RespawnRulesTests.cpp`
+
+- [ ] **Step 1 : Écrire les tests (échec attendu)**
+
+Dans `src/shared/world/tests/RespawnRulesTests.cpp`, ajouter le `using` et une fonction de test, puis l'appeler depuis `main()`.
+
+Après la ligne `using engine::world::IsGraveyardEligibleForRespawn;` (ligne 18), ajouter :
+```cpp
+	using engine::world::IsGraveyardEligibleAsZoneDefault;
+```
+
+Avant la fermeture du `namespace` anonyme (avant la ligne `}` qui précède `int main()`, ~ligne 56), ajouter :
+```cpp
+	void Test_ZoneDefaultEligibilityByOwnership()
+	{
+		// Cimetière neutre ("" ou "-") : défaut éligible pour tout le monde.
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("", "alliance") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("-", "horde") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("", "") == true);
+		// Cimetière de faction : défaut éligible UNIQUEMENT pour sa faction (aucune
+		// notion de distance/rayon — anti-triche : indépendant de la position).
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "alliance") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "horde") == false);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "") == false);
+	}
+```
+
+Dans `main()`, après `Test_ZeroRadiusOnlyOwnerBeyondZero();` (ligne 64), ajouter :
+```cpp
+	Test_ZoneDefaultEligibilityByOwnership();
+```
+
+- [ ] **Step 2 : Vérifier l'échec de compilation**
+
+Run: `ctest --test-dir build/vs2022-x64 -C Release -R respawn_rules_tests`
+Expected: échec de build (`IsGraveyardEligibleAsZoneDefault` non déclarée). *(Build local indisponible → vérifié en CI.)*
+
+- [ ] **Step 3 : Implémenter la règle dans le header**
+
+Dans `src/shared/world/RespawnRules.h`, à la fin du `namespace engine::world` (après la fonction `IsGraveyardEligibleForRespawn`, avant la `}` du namespace), ajouter :
+```cpp
+	/// Éligibilité d'un cimetière comme DÉFAUT de zone, INDÉPENDANTE de la position
+	/// (anti-triche : la position de mort est client-autoritaire, donc non fiable).
+	///   - cimetière neutre (`graveyardFaction` vide ou "-") → éligible pour tous ;
+	///   - sinon, éligible UNIQUEMENT pour sa faction propriétaire.
+	/// Aucune notion de distance / rayon neutre (à la différence de
+	/// IsGraveyardEligibleForRespawn, conservée pour l'ancien modèle « plus proche »).
+	///
+	/// \param graveyardFaction id de la faction propriétaire (vide/"-" = neutre).
+	/// \param playerFaction    id de la faction du joueur (peut être vide).
+	/// \return true si ce cimetière peut être le défaut de respawn du joueur.
+	inline bool IsGraveyardEligibleAsZoneDefault(std::string_view graveyardFaction,
+	                                             std::string_view playerFaction)
+	{
+		if (graveyardFaction.empty() || graveyardFaction == "-")
+		{
+			return true;
+		}
+		return graveyardFaction == playerFaction;
+	}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+Run: `ctest --test-dir build/vs2022-x64 -C Release -R respawn_rules_tests --output-on-failure`
+Expected: PASS — `[PASS] RespawnRulesTests`. *(Vérifié en CI.)*
+
+- [ ] **Step 5 : Commit**
+```bash
+git add src/shared/world/RespawnRules.h src/shared/world/tests/RespawnRulesTests.cpp
+git commit -m "feat(world): IsGraveyardEligibleAsZoneDefault (éligibilité cimetière sans position) + tests"
+```
+(Terminer par `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.)
+
+---
+
+## Task 2 : Sélection du cimetière par défaut de zone (`ServerApp::HandleRespawnRequest`)
+
+**Files:**
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` (`HandleRespawnRequest`, bloc lignes ~3159-3196)
+
+- [ ] **Step 1 : Remplacer la sélection « plus proche » par « défaut de zone » pour le cimetière**
+
+Lire `HandleRespawnRequest` autour des lignes 3157-3196. Le code actuel initialise `respawnX/Y/Z`
+sur le point d'entrée puis, dans un bloc `{ ... }`, boucle sur `m_respawnPoints` en gardant le
+**plus proche** (filtre faction par rayon neutre pour le cimetière).
+
+Remplacer **uniquement le bloc interne** (de `{` ligne 3162 à `}` ligne 3196 — le bloc qui
+contient `float bestDistSq = ...` jusqu'au `if (!found) { LOG_INFO(... fallback ...); }`) par :
+```cpp
+		{
+			bool found = false;
+			if (destination == kRespawnDestinationGraveyard)
+			{
+				// Cimetière PAR DÉFAUT de la zone : le PREMIER cimetière éligible par
+				// propriété (neutre ou même faction), INDÉPENDANT de la position de mort.
+				// La position (client->positionMeters) est client-autoritaire donc
+				// spoofable : on ne l'utilise plus pour choisir le cimetière (anti-triche).
+				for (const RespawnPointDefinition& point : m_respawnPoints)
+				{
+					if (point.zoneId != client->zoneId
+						|| point.destinationType != kRespawnDestinationGraveyard)
+					{
+						continue;
+					}
+					if (!engine::world::IsGraveyardEligibleAsZoneDefault(
+							point.ownerFactionId, client->factionId))
+					{
+						continue;
+					}
+					respawnX = point.positionMetersX;
+					respawnY = point.positionMetersY;
+					respawnZ = point.positionMetersZ;
+					found = true;
+					break; // 1er éligible (ordre de fichier) = défaut déterministe de la zone
+				}
+			}
+			else
+			{
+				// Auberge (inn) : comportement INCHANGÉ — le plus proche du lieu de mort.
+				float bestDistSq = std::numeric_limits<float>::max();
+				for (const RespawnPointDefinition& point : m_respawnPoints)
+				{
+					if (point.zoneId != client->zoneId || point.destinationType != destination)
+					{
+						continue;
+					}
+					const float dxr = point.positionMetersX - client->positionMetersX;
+					const float dzr = point.positionMetersZ - client->positionMetersZ;
+					const float distSqR = dxr * dxr + dzr * dzr;
+					if (distSqR < bestDistSq)
+					{
+						bestDistSq = distSqR;
+						respawnX = point.positionMetersX;
+						respawnY = point.positionMetersY;
+						respawnZ = point.positionMetersZ;
+						found = true;
+					}
+				}
+			}
+			if (!found)
+			{
+				LOG_INFO(Net, "[ServerApp] Respawn fallback to enter-world spawn (client_id={}, destination={}, zone_id={})",
+					client->clientId, destination, client->zoneId);
+			}
+		}
+```
+
+Notes pour la revue statique :
+- `respawnX/Y/Z` sont déclarés JUSTE AVANT ce bloc (lignes 3159-3161, initialisés sur
+  `client->spawnPositionMeters*`) — on ne les redéclare pas, on les écrase dans le bloc. Le repli
+  (aucun point trouvé) garde donc le point d'entrée en monde, comme avant.
+- `engine::world::IsGraveyardEligibleAsZoneDefault` vient de Task 1 ; `RespawnRules.h` est **déjà
+  inclus** dans ce fichier (l'ancien code appelait `IsGraveyardEligibleForRespawn`).
+- `std::numeric_limits` / `<limits>` : déjà utilisés dans le bloc d'origine.
+- `kRespawnDestinationGraveyard` / `kRespawnDestinationInn` : constantes déjà utilisées dans ce fichier.
+- Le mot-clé `destination` (paramètre de `HandleRespawnRequest`) vaut graveyard ou inn ; seul le
+  cimetière change de logique.
+
+- [ ] **Step 2 : Vérifier qu'aucune dépendance à `client->positionMeters` ne subsiste pour le cimetière**
+
+Run:
+```bash
+grep -n "positionMetersX\|positionMetersZ" src/shared/server_bootstrap/ServerApp.cpp | sed -n '1,40p'
+```
+Inspecter le voisinage de `HandleRespawnRequest` : dans la branche **graveyard**, il ne doit plus
+y avoir d'usage de `client->positionMetersX/Z` (seule la branche inn — auberge — les utilise encore).
+Expected: les usages restants près de la fonction sont dans la branche `else` (inn) et dans
+l'écriture finale `client->positionMetersX = respawnX;`.
+
+- [ ] **Step 3 : (build/ctest — SKIP, pas de toolchain locale ; validé en CI).**
+
+- [ ] **Step 4 : Commit**
+```bash
+git add src/shared/server_bootstrap/ServerApp.cpp
+git commit -m "feat(server): respawn cimetière = défaut de zone (déterministe, anti-triche position)"
+```
+(Terminer par `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.)
+
+---
+
+## Validation finale (en jeu — hors CI)
+
+L'état serveur UDP n'est pas unit-testable simplement. À valider en jeu :
+- [ ] Mourir à **plusieurs endroits** d'une même zone (loin / près de différents lieux) →
+  réapparaître au cimetière « Cimetière le plus proche » TOUJOURS au **même** cimetière (le défaut
+  de la zone), quelle que soit la position de mort.
+- [ ] L'auberge (si un bouton/flux la propose) reste sur le **plus proche** (inchangé).
+- [ ] Repli : dans une zone sans cimetière, on réapparaît au point d'entrée en monde (inchangé).
+
+---
+
+## Déploiement
+
+> ⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master/shard).** Changement de `ServerApp::HandleRespawnRequest`.
+> **Pas de changement wire** (opcodes/payload respawn v13 inchangés) → un client ancien reste
+> compatible ; mais le binaire serveur doit être rejoué pour appliquer la nouvelle sélection.
+> **Aucun changement / redéploiement client.**

--- a/docs/superpowers/specs/2026-06-19-cimetiere-par-zone-design.md
+++ b/docs/superpowers/specs/2026-06-19-cimetiere-par-zone-design.md
@@ -1,0 +1,115 @@
+# Spec — Cimetière par défaut par zone (respawn déterministe, anti-triche)
+
+**Date :** 2026-06-19
+**Sous-système :** #3 du lot 2026-06-18 (cimetière par-zone)
+**Statut :** Design validé (approche A), en attente de plan d'implémentation
+**Déploiement :** ⚠️ **REDÉPLOIEMENT SERVEUR REQUIS** (master/shard) — change la sélection de respawn
+
+---
+
+## 1. Contexte & problème
+
+À la mort, le client envoie « respawn cimetière » → le serveur (`ServerApp::HandleRespawnRequest`,
+[ServerApp.cpp:3133](../../../src/shared/server_bootstrap/ServerApp.cpp)) choisit, parmi les points de
+respawn de la zone du joueur, **le cimetière le PLUS PROCHE du lieu de mort** :
+
+```cpp
+// boucle 3162-3196 (simplifiée)
+for (const RespawnPointDefinition& point : m_respawnPoints) {
+    if (point.zoneId != client->zoneId || point.destinationType != destination) continue;
+    const float distSq = sq(point.pos - client->positionMeters);   // <-- position de mort
+    if (destination == graveyard && !IsGraveyardEligibleForRespawn(sqrt(distSq), ...)) continue;
+    if (distSq < bestDistSq) { best = point; }                     // <-- LE PLUS PROCHE
+}
+```
+
+**Faille (triche)** : `client->positionMeters` est la position de mort, et le **mouvement est
+client-autoritaire** (cf. commentaire ServerApp:3213). Un client triché peut donc **choisir où
+mourir / fausser sa position** pour contrôler le cimetière où il réapparaît (ex. revenir au plus
+près d'un objectif). La sélection « plus proche » dépend d'une donnée **non fiable**.
+
+Par ailleurs la règle d'éligibilité actuelle `IsGraveyardEligibleForRespawn` (rayon neutre de
+faction) est elle-même **dépendante de la distance** (donc de la position).
+
+## 2. Décision (approche A — cimetière par défaut par zone, serveur-autoritaire)
+
+Choisir, pour la zone du joueur (`client->zoneId`, **autoritaire serveur**), **UN cimetière par
+défaut désigné**, de façon **déterministe et position-indépendante**. La position de mort
+n'entre plus dans le choix → la triche par position est neutralisée.
+
+Approches écartées :
+- **B** (garder « plus proche » mais position serveur) : la position reste client-autoritaire → faille non corrigée.
+- **C** (défaut côté client) : le respawn est serveur-autoritaire ; le client n'est pas fiable pour de l'anti-triche.
+
+## 3. Architecture & composants
+
+### 3.1 Éligibilité position-indépendante (shared `RespawnRules`)
+`IsGraveyardEligibleForRespawn` (distance/rayon neutre) reste pour l'ancien modèle. On AJOUTE une
+règle d'éligibilité **par propriété seule** (sans distance), pour le défaut de zone :
+```cpp
+/// Éligibilité d'un cimetière comme DÉFAUT de zone, indépendante de la position
+/// (anti-triche) : un cimetière neutre est éligible pour tous ; sinon seule sa
+/// faction propriétaire. Pas de notion de rayon/distance.
+inline bool IsGraveyardEligibleAsZoneDefault(std::string_view graveyardFaction,
+                                             std::string_view playerFaction)
+{
+    if (graveyardFaction.empty() || graveyardFaction == "-") return true; // neutre
+    return graveyardFaction == playerFaction;
+}
+```
+Header-only, pur, testable (comme l'existant).
+
+### 3.2 Sélection du défaut (serveur `ServerApp::HandleRespawnRequest`)
+Pour `destination == kRespawnDestinationGraveyard`, **remplacer la boucle « plus proche »** par :
+le **PREMIER** `m_respawnPoints` (ordre de fichier = déterministe) qui satisfait
+`zoneId == client->zoneId`, `destinationType == graveyard`, et
+`IsGraveyardEligibleAsZoneDefault(point.ownerFactionId, client->factionId)`. **Aucune distance,
+aucune dépendance à `client->positionMeters`.** Repli inchangé : si aucun cimetière par défaut
+éligible, repli sur le point d'entrée en monde (`client->spawnPositionMeters`).
+
+> L'**auberge** (`kRespawnDestinationInn`) reste **inchangée** (hors périmètre — la demande vise
+> le cimetière). Possibilité future de lui appliquer le même traitement.
+
+### 3.3 Données — enrichir chaque zone
+Chaque zone doit avoir **au moins un cimetière** dans son `respawn_points.txt` (le défaut).
+Convention : le **premier** cimetière éligible (ordre de fichier) de la zone est le défaut — pas
+de nouvelle syntaxe requise pour les zones à 1 cimetière (cas actuel : `feyhin` = 1 cimetière
+neutre). Enrichir les zones qui en manquent (ex. `demo_plains`). Pour une future zone à plusieurs
+cimetières par faction, l'ordre de déclaration fixe la priorité du défaut.
+
+### 3.4 Client
+**Inchangé** : il envoie « respawn cimetière », reçoit la position imposée (`SendForcePosition`).
+L'affichage d'un marqueur de cimetière par zone est **hors périmètre** (le rendu des marqueurs a
+été retiré au profit du décor physique ; cf. Engine.cpp:11759).
+
+## 4. Flux & anti-triche
+
+```
+Mort → client: « respawn cimetière » → serveur:
+  zone = client->zoneId            (AUTORITAIRE, non spoofable)
+  cimetière = 1er point {zone, graveyard, éligible-par-propriété(faction)}
+  → position imposée                (SendForcePosition)
+La position de mort N'INTERVIENT PLUS.
+```
+
+## 5. Tests
+- **CI** (`RespawnRulesTests`) : `IsGraveyardEligibleAsZoneDefault` — neutre → tous ; faction
+  propriétaire → seulement sa faction ; faction joueur vide vs cimetière neutre/faction.
+- Non-régression : `IsGraveyardEligibleForRespawn` (inchangée) reste verte.
+- La sélection dans `ServerApp` (UDP, état serveur) n'est pas unit-testable simplement →
+  **validation en jeu** : mourir à divers endroits d'une zone → on réapparaît TOUJOURS au même
+  cimetière (le défaut de la zone), quelle que soit la position de mort.
+
+## 6. Déploiement
+
+> ⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master/shard).** Changement de
+> `ServerApp::HandleRespawnRequest` (sélection cimetière) + ajout `RespawnRules`. **Pas de
+> changement wire** (opcodes respawn v13 inchangés, payload identique) → un **client ancien
+> reste compatible** avec le serveur neuf. Mais le binaire serveur DOIT être rejoué pour que la
+> nouvelle sélection s'applique. Côté client : **aucun changement** (ni redéploiement client requis).
+
+## 7. Hors périmètre
+- Auberge (`inn`) : sélection inchangée.
+- `GraveyardManager` (chemin DB, `ClosestGraveyard`) : non utilisé par le respawn UDP actif → non touché.
+- Affichage client d'un marqueur de cimetière par zone.
+- Cimetières multiples par faction dans une même zone (l'ordre de fichier suffit ; pas de flag `default` dédié pour l'instant — YAGNI).

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -3154,8 +3154,10 @@ namespace engine::server
 			return;
 		}
 
-		// Wire v13 — point de réapparition du type demandé (cimetière/auberge)
-		// LE PLUS PROCHE du lieu de mort ; repli : point d'entrée en monde.
+		// Wire v13 — point de réapparition du type demandé. CIMETIÈRE : défaut DÉTERMINISTE
+		// de la zone (1er éligible par faction), INDÉPENDANT de la position de mort
+		// (anti-triche, cf. bloc ci-dessous). AUBERGE : le plus proche du lieu de mort.
+		// Repli (aucun point trouvé) : point d'entrée en monde.
 		float respawnX = client->spawnPositionMetersX;
 		float respawnY = client->spawnPositionMetersY;
 		float respawnZ = client->spawnPositionMetersZ;

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -3160,32 +3160,53 @@ namespace engine::server
 		float respawnY = client->spawnPositionMetersY;
 		float respawnZ = client->spawnPositionMetersZ;
 		{
-			float bestDistSq = std::numeric_limits<float>::max();
 			bool found = false;
-			for (const RespawnPointDefinition& point : m_respawnPoints)
+			if (destination == kRespawnDestinationGraveyard)
 			{
-				if (point.zoneId != client->zoneId || point.destinationType != destination)
-					continue;
-				const float dxr = point.positionMetersX - client->positionMetersX;
-				const float dzr = point.positionMetersZ - client->positionMetersZ;
-				const float distSqR = dxr * dxr + dzr * dzr;
-				// Cimetière : filtre faction (rayon neutre). Auberge : aucune restriction.
-				if (destination == kRespawnDestinationGraveyard)
+				// Cimetière PAR DÉFAUT de la zone : le PREMIER cimetière éligible par
+				// propriété (neutre ou même faction), INDÉPENDANT de la position de mort.
+				// La position (client->positionMeters) est client-autoritaire donc
+				// spoofable : on ne l'utilise plus pour choisir le cimetière (anti-triche).
+				for (const RespawnPointDefinition& point : m_respawnPoints)
 				{
-					const float dist = std::sqrt(distSqR);
-					if (!engine::world::IsGraveyardEligibleForRespawn(
-							dist, point.neutralRadiusM, point.ownerFactionId, client->factionId))
+					if (point.zoneId != client->zoneId
+						|| point.destinationType != kRespawnDestinationGraveyard)
 					{
 						continue;
 					}
-				}
-				if (distSqR < bestDistSq)
-				{
-					bestDistSq = distSqR;
+					if (!engine::world::IsGraveyardEligibleAsZoneDefault(
+							point.ownerFactionId, client->factionId))
+					{
+						continue;
+					}
 					respawnX = point.positionMetersX;
 					respawnY = point.positionMetersY;
 					respawnZ = point.positionMetersZ;
 					found = true;
+					break; // 1er éligible (ordre de fichier) = défaut déterministe de la zone
+				}
+			}
+			else
+			{
+				// Auberge (inn) : comportement INCHANGÉ — le plus proche du lieu de mort.
+				float bestDistSq = std::numeric_limits<float>::max();
+				for (const RespawnPointDefinition& point : m_respawnPoints)
+				{
+					if (point.zoneId != client->zoneId || point.destinationType != destination)
+					{
+						continue;
+					}
+					const float dxr = point.positionMetersX - client->positionMetersX;
+					const float dzr = point.positionMetersZ - client->positionMetersZ;
+					const float distSqR = dxr * dxr + dzr * dzr;
+					if (distSqR < bestDistSq)
+					{
+						bestDistSq = distSqR;
+						respawnX = point.positionMetersX;
+						respawnY = point.positionMetersY;
+						respawnZ = point.positionMetersZ;
+						found = true;
+					}
 				}
 			}
 			if (!found)

--- a/src/shared/world/RespawnRules.h
+++ b/src/shared/world/RespawnRules.h
@@ -43,4 +43,24 @@ namespace engine::world
 		// Au-delà : réservé aux joueurs de la faction propriétaire du cimetière.
 		return graveyardFaction == playerFaction;
 	}
+
+	/// Éligibilité d'un cimetière comme DÉFAUT de zone, INDÉPENDANTE de la position
+	/// (anti-triche : la position de mort est client-autoritaire, donc non fiable).
+	///   - cimetière neutre (`graveyardFaction` vide ou "-") → éligible pour tous ;
+	///   - sinon, éligible UNIQUEMENT pour sa faction propriétaire.
+	/// Aucune notion de distance / rayon neutre (à la différence de
+	/// IsGraveyardEligibleForRespawn, conservée pour l'ancien modèle « plus proche »).
+	///
+	/// \param graveyardFaction id de la faction propriétaire (vide/"-" = neutre).
+	/// \param playerFaction    id de la faction du joueur (peut être vide).
+	/// \return true si ce cimetière peut être le défaut de respawn du joueur.
+	inline bool IsGraveyardEligibleAsZoneDefault(std::string_view graveyardFaction,
+	                                             std::string_view playerFaction)
+	{
+		if (graveyardFaction.empty() || graveyardFaction == "-")
+		{
+			return true;
+		}
+		return graveyardFaction == playerFaction;
+	}
 }

--- a/src/shared/world/tests/RespawnRulesTests.cpp
+++ b/src/shared/world/tests/RespawnRulesTests.cpp
@@ -16,6 +16,7 @@ namespace
 	} while (0)
 
 	using engine::world::IsGraveyardEligibleForRespawn;
+	using engine::world::IsGraveyardEligibleAsZoneDefault;
 
 	void Test_NeutralGraveyardAlwaysEligible()
 	{
@@ -53,6 +54,19 @@ namespace
 		REQUIRE(IsGraveyardEligibleForRespawn(0.0f, 0.0f, "alliance", "horde") == true);
 		REQUIRE(IsGraveyardEligibleForRespawn(0.1f, 0.0f, "alliance", "horde") == false);
 	}
+
+	void Test_ZoneDefaultEligibilityByOwnership()
+	{
+		// Cimetière neutre ("" ou "-") : défaut éligible pour tout le monde.
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("", "alliance") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("-", "horde") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("", "") == true);
+		// Cimetière de faction : défaut éligible UNIQUEMENT pour sa faction (aucune
+		// notion de distance/rayon — anti-triche : indépendant de la position).
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "alliance") == true);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "horde") == false);
+		REQUIRE(IsGraveyardEligibleAsZoneDefault("alliance", "") == false);
+	}
 }
 
 int main()
@@ -62,6 +76,7 @@ int main()
 	Test_BeyondRadiusFactionRestricted();
 	Test_PlayerWithoutFactionBeyondRadius();
 	Test_ZeroRadiusOnlyOwnerBeyondZero();
+	Test_ZoneDefaultEligibilityByOwnership();
 	if (g_failed == 0) { std::printf("[PASS] RespawnRulesTests\n"); return 0; }
 	std::printf("[FAIL] RespawnRulesTests: %d failure(s)\n", g_failed);
 	return 1;


### PR DESCRIPTION
## Résumé

Au respawn « cimetière », le serveur choisissait le cimetière **le plus proche du lieu de mort** (`ServerApp::HandleRespawnRequest`). Or le mouvement est **client-autoritaire** → la position de mort est **spoofable** : un client triché pouvait choisir où mourir pour contrôler son cimetière de réapparition. Cette PR rend le choix **déterministe et indépendant de la position**.

### Changement
- **Nouvelle règle** `engine::world::IsGraveyardEligibleAsZoneDefault(graveyardFaction, playerFaction)` (header-only `RespawnRules.h`) : éligibilité **par propriété seule** (neutre → tous ; sinon même faction), **sans distance/rayon** → position-indépendante. Tests CI (`respawn_rules_tests`).
- **`HandleRespawnRequest`** : pour `destination == graveyard`, sélectionne le **1er cimetière par défaut éligible** de la zone du joueur (`client->zoneId`, **autoritaire serveur**) — **plus aucune dépendance à `client->positionMeters`**. L'**auberge** (`inn`) reste **inchangée** (le plus proche). Repli (aucun cimetière) : point d'entrée en monde (inchangé).

### Données
Aucune modification : la zone active (`feyhin`) a déjà son cimetière (`respawn_points.txt`), qui devient son défaut. Convention (forward-looking) : toute future zone jouable a ≥1 ligne `graveyard` ; le 1er éligible (ordre de fichier) est le défaut.

Spec/plan : `docs/superpowers/specs/2026-06-19-cimetiere-par-zone-design.md`, `docs/superpowers/plans/2026-06-19-cimetiere-par-zone.md`.

## Tests
- CI : `respawn_rules_tests` (nouvelle règle : neutre→tous, faction→même faction seulement) + non-régression `IsGraveyardEligibleForRespawn`.
- ⚠️ **Vérif en jeu** : mourir à divers endroits d'une zone → réapparition TOUJOURS au même cimetière (le défaut de zone), quelle que soit la position de mort.

## Déploiement
> ⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master/shard)** — la sélection du respawn change côté serveur. **Pas de changement wire** (opcodes/payload respawn v13 inchangés) → un client ancien reste compatible. **Aucun redéploiement client.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)