### PR TITLE
fix(i18n): géoloc 1er lancement différée hors boot — corrige le crash au lancement (vkCreateInstance)

### DIFF
--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -1098,6 +1098,10 @@ namespace engine::client
 		// Liste des locales affichées au 1er lancement (union filtrée système+IP+en).
 		// Source unique pour TOUS les sites de l'écran LanguageSelectionFirstRun.
 		std::vector<std::string> m_firstRunLocales;
+		// Garde-fou de démarrage différé de la géoloc : passe à true à la 1re frame de
+		// l'écran de langue (Update_LanguageSelect), où le thread WinHTTP est lancé —
+		// jamais pendant Init()/boot (conflit avec l'init Vulkan = crash au lancement).
+		bool m_firstRunGeoStarted = false;
 
 		std::vector<uint8_t> m_argonSalt{};
 		uint32_t m_viewportW = 0;

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1274,18 +1274,14 @@ namespace engine::client
 			m_languageSelectionIndex = it != locales.end() ? static_cast<uint32_t>(std::distance(locales.begin(), it)) : 0u;
 			SetPhase(Phase::LanguageSelectionFirstRun);
 #if defined(_WIN32)
-			// Charge la table pays->langue et démarre la suggestion (système + géoloc IP).
-			engine::client::CountryLanguageMap countryMap;
-			const std::string mapJson = engine::platform::FileSystem::ReadAllText(
-				engine::platform::FileSystem::ResolveContentPath(cfg, "localization/country_language.json"));
-			if (!mapJson.empty())
-				countryMap.LoadFromJson(mapJson);
-			m_languageSuggestion.BeginDetection(
-				m_selectedLocale,
-				m_localization.GetAvailableLocales(),
-				std::move(countryMap),
-				std::make_unique<engine::client::IpApiGeoProvider>());
-			m_firstRunLocales = m_languageSuggestion.GetSuggestedLocales();
+			// Liste immédiate {système, en} SANS géoloc. Le thread géoloc (réseau WinHTTP)
+			// n'est volontairement PAS lancé ici : le démarrer pendant Init() (boot) le
+			// faisait tourner en parallèle de l'init Vulkan — vkCreateInstance charge les
+			// DLL du driver ICD — ce qui crashait le client ET l'éditeur au lancement.
+			// Il est désormais lancé à la 1re frame de l'écran de langue
+			// (Update_LanguageSelect), donc après l'init moteur (même patron que StatusProbe).
+			m_firstRunLocales = engine::client::ComputeSuggestedLocales(
+				m_selectedLocale, /*ipLocale*/ "", m_localization.GetAvailableLocales());
 			// Recale l'index de sélection sur la liste filtrée (système en tête).
 			{
 				auto it = std::find(m_firstRunLocales.begin(), m_firstRunLocales.end(), m_selectedLocale);

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1268,28 +1268,22 @@ namespace engine::client
 		}
 		if (requestedLocale.empty())
 		{
+			// 1er lancement (aucune locale persistée) : on APPLIQUE directement la langue
+			// détectée du système et on l'écrit dans user_settings.json, puis le flux part
+			// vers l'écran de login (comme une locale déjà retenue). L'écran illustré de
+			// sélection (Phase::LanguageSelectionFirstRun) est volontairement court-circuité :
+			// son rendu ImGui provoquait une faute GPU « device lost » au 1er lancement
+			// (impossible à localiser sans RenderDoc) ; créer user_settings.json suffit à
+			// l'éviter — ce que l'on fait ici automatiquement. La langue reste modifiable
+			// dans les Options (écran fonctionnel). La géoloc IP n'enrichit plus la sélection
+			// (elle servait cet écran) ; la langue système reste le signal principal de #1.
 			m_selectedLocale = m_localization.GetCurrentLocale();
-			const auto& locales = m_localization.GetAvailableLocales();
-			auto it = std::find(locales.begin(), locales.end(), m_selectedLocale);
-			m_languageSelectionIndex = it != locales.end() ? static_cast<uint32_t>(std::distance(locales.begin(), it)) : 0u;
-			SetPhase(Phase::LanguageSelectionFirstRun);
-#if defined(_WIN32)
-			// Liste immédiate {système, en} SANS géoloc. Le thread géoloc (réseau WinHTTP)
-			// n'est volontairement PAS lancé ici : le démarrer pendant Init() (boot) le
-			// faisait tourner en parallèle de l'init Vulkan — vkCreateInstance charge les
-			// DLL du driver ICD — ce qui crashait le client ET l'éditeur au lancement.
-			// Il est désormais lancé à la 1re frame de l'écran de langue
-			// (Update_LanguageSelect), donc après l'init moteur (même patron que StatusProbe).
-			m_firstRunLocales = engine::client::ComputeSuggestedLocales(
-				m_selectedLocale, /*ipLocale*/ "", m_localization.GetAvailableLocales());
-			// Recale l'index de sélection sur la liste filtrée (système en tête).
+			if (PatchPersistedLocaleKey(m_selectedLocale))
 			{
-				auto it = std::find(m_firstRunLocales.begin(), m_firstRunLocales.end(), m_selectedLocale);
-				m_languageSelectionIndex = (it != m_firstRunLocales.end())
-					? static_cast<uint32_t>(std::distance(m_firstRunLocales.begin(), it)) : 0u;
+				m_persistedLocale = m_selectedLocale;
+				m_hasPersistedLocale = true;
 			}
-#endif
-			LOG_INFO(Core, "[AuthUiPresenter] First run locale selection required (detected={})", m_selectedLocale);
+			LOG_INFO(Core, "[AuthUiPresenter] 1er lancement : langue détectée '{}' appliquée + persistée (écran de sélection court-circuité)", m_selectedLocale);
 		}
 		else
 		{

--- a/src/client/auth/screens/AuthScreenLanguageSelect.cpp
+++ b/src/client/auth/screens/AuthScreenLanguageSelect.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -193,6 +194,25 @@ namespace engine::client
 		if (usingNativeAuth || m_phase != Phase::LanguageSelectionFirstRun)
 		{
 			return;
+		}
+		// Démarrage différé de la géoloc : à la 1re frame de l'écran de langue, donc
+		// APRÈS l'init Vulkan du boot. Lancer ce thread réseau WinHTTP pendant Init()
+		// le faisait courir en parallèle du chargement des DLL du driver Vulkan
+		// (vkCreateInstance) → crash au lancement (client ET éditeur). Idempotent via
+		// m_firstRunGeoStarted ; charge la table pays->langue puis lance le worker.
+		if (!m_firstRunGeoStarted)
+		{
+			m_firstRunGeoStarted = true;
+			engine::client::CountryLanguageMap countryMap;
+			const std::string mapJson = engine::platform::FileSystem::ReadAllText(
+				engine::platform::FileSystem::ResolveContentPath(cfg, "localization/country_language.json"));
+			if (!mapJson.empty())
+				countryMap.LoadFromJson(mapJson);
+			m_languageSuggestion.BeginDetection(
+				m_selectedLocale,
+				m_localization.GetAvailableLocales(),
+				std::move(countryMap),
+				std::make_unique<engine::client::IpApiGeoProvider>());
 		}
 		// Intègre la langue déduite de l'IP dès qu'elle arrive (non bloquant).
 		if (m_languageSuggestion.PollGeoUpdate())

--- a/src/client/render/AuthLogoPass.cpp
+++ b/src/client/render/AuthLogoPass.cpp
@@ -58,10 +58,10 @@ namespace engine::render
 
 		VkDescriptorPoolSize poolSize{};
 		poolSize.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-		poolSize.descriptorCount = 1;
+		poolSize.descriptorCount = kDescriptorRingSize;
 		VkDescriptorPoolCreateInfo poolInfo{};
 		poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-		poolInfo.maxSets = 1;
+		poolInfo.maxSets = kDescriptorRingSize;
 		poolInfo.poolSizeCount = 1;
 		poolInfo.pPoolSizes = &poolSize;
 		if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
@@ -70,16 +70,23 @@ namespace engine::render
 			return false;
 		}
 
+		// Tous les sets de l'anneau partagent le même layout.
+		VkDescriptorSetLayout ringLayouts[kDescriptorRingSize];
+		for (uint32_t i = 0; i < kDescriptorRingSize; ++i)
+		{
+			ringLayouts[i] = m_descriptorSetLayout;
+		}
 		VkDescriptorSetAllocateInfo allocInfo{};
 		allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
 		allocInfo.descriptorPool = m_descriptorPool;
-		allocInfo.descriptorSetCount = 1;
-		allocInfo.pSetLayouts = &m_descriptorSetLayout;
-		if (vkAllocateDescriptorSets(device, &allocInfo, &m_descriptorSet) != VK_SUCCESS)
+		allocInfo.descriptorSetCount = kDescriptorRingSize;
+		allocInfo.pSetLayouts = ringLayouts;
+		if (vkAllocateDescriptorSets(device, &allocInfo, m_descriptorSets) != VK_SUCCESS)
 		{
 			Destroy(device);
 			return false;
 		}
+		m_descriptorCursor = 0u;
 
 		VkSamplerCreateInfo samp{};
 		samp.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -235,9 +242,14 @@ namespace engine::render
 		imgInfo.imageView = logoView;
 		imgInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
+		// Prend un set neuf dans l'anneau pour CE draw : on ne réécrit jamais un set
+		// encore référencé par un draw précédent (de cette frame ou de la frame en vol).
+		VkDescriptorSet descriptorSet = m_descriptorSets[m_descriptorCursor];
+		m_descriptorCursor = (m_descriptorCursor + 1u) % kDescriptorRingSize;
+
 		VkWriteDescriptorSet write{};
 		write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-		write.dstSet = m_descriptorSet;
+		write.dstSet = descriptorSet;
 		write.dstBinding = 0;
 		write.descriptorCount = 1;
 		write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -277,7 +289,7 @@ namespace engine::render
 		vkCmdSetScissor(cmd, 0, 1, &scissor);
 
 		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
-		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &m_descriptorSet, 0, nullptr);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &descriptorSet, 0, nullptr);
 
 		LogoPushConstants push{};
 		push.viewportSize[0] = static_cast<float>(extent.width);
@@ -318,10 +330,15 @@ namespace engine::render
 		}
 		if (m_descriptorPool != VK_NULL_HANDLE)
 		{
+			// Détruire le pool libère tous les sets de l'anneau.
 			vkDestroyDescriptorPool(device, m_descriptorPool, nullptr);
 			m_descriptorPool = VK_NULL_HANDLE;
 		}
-		m_descriptorSet = VK_NULL_HANDLE;
+		for (uint32_t i = 0; i < kDescriptorRingSize; ++i)
+		{
+			m_descriptorSets[i] = VK_NULL_HANDLE;
+		}
+		m_descriptorCursor = 0u;
 		if (m_descriptorSetLayout != VK_NULL_HANDLE)
 		{
 			vkDestroyDescriptorSetLayout(device, m_descriptorSetLayout, nullptr);

--- a/src/client/render/AuthLogoPass.h
+++ b/src/client/render/AuthLogoPass.h
@@ -52,11 +52,23 @@ namespace engine::render
 			float sinA;
 		};
 
+		// Anneau de descriptor sets : Record() peut être appelé PLUSIEURS fois dans la
+		// même frame (logo + icônes info + drapeaux FR/EN de l'écran de langue), et
+		// chaque appel réécrit + lie + dessine. Avec un set UNIQUE, le 2e appel
+		// réécrivait (vkUpdateDescriptorSets) le set encore référencé par le draw
+		// précédent du même command buffer → usage Vulkan invalide → faute GPU sans
+		// erreur CPU (crash déterministe sur l'écran de langue, jamais sur Login qui
+		// ne dessine qu'un logo). On prend un set neuf à chaque Record via un curseur
+		// circulaire. kDescriptorRingSize doit couvrir (draws/frame) × (frames in
+		// flight) ; ~6 × 2 ici, 16 laisse une marge confortable.
+		static constexpr uint32_t kDescriptorRingSize = 16u;
+
 		VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
 		VkPipeline m_pipeline = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
-		VkDescriptorSet m_descriptorSet = VK_NULL_HANDLE;
+		VkDescriptorSet m_descriptorSets[kDescriptorRingSize] = {};
+		uint32_t m_descriptorCursor = 0u;
 		VkSampler m_sampler = VK_NULL_HANDLE;
 	};
 }


### PR DESCRIPTION
## Objectif : un PREMIER LANCEMENT qui fonctionne (locale non choisie)

Trois correctifs client, sans changement de protocole, pour qu'un vrai 1er lancement marche.

### 1) Crash au boot — géoloc lancée pendant l'init Vulkan ✅ validé
La PR #909 lançait le thread géoloc WinHTTP depuis `AuthUiPresenter::Init()` (pendant le boot), en parallèle de `vkCreateInstance` → crash client **et** éditeur. Fix : géoloc différée hors de `Init()`. *Validé en jeu : boot complet, login OK frame 51.*

### 2) `AuthLogoPass` : descriptor set unique réécrit en cours de frame
Anneau de 16 descriptor sets (un par `Record`). **Note : ce n'était finalement PAS la cause du crash de l'écran de langue** (ce code n'est pas exécuté — l'écran passe par ImGui), mais c'est une correction Vulkan valide (réécrire un set encore référencé = UB), conservée.

### 3) Écran de langue au 1er lancement : contournement de la faute GPU
Une fois le boot réparé, l'écran illustré de sélection de langue (1er lancement) provoquait une **faute GPU « device lost »** au rendu ImGui — non localisable sans RenderDoc (validation layers = build Debug uniquement). Diagnostic : crash **uniquement** sur le chemin 1er-lancement ; **créer `user_settings.json` suffit à l'éviter**.

**Fix** : au 1er lancement (aucune locale persistée), `Init()` **applique directement la langue système détectée**, **écrit `user_settings.json`**, et va à l'écran **login** (fonctionnel) — l'écran illustré qui faute n'est plus affiché. La langue reste modifiable dans les **Options**. La géoloc IP n'enrichit plus la sélection (elle servait cet écran) ; la langue système reste le signal principal de #1. L'écran illustré pourra être réactivé une fois le draw fautif identifié via RenderDoc.

## Validation
- Boot + login : ✅ confirmés en jeu.
- **À valider** : nouveau build, dossier **sans `user_settings.json`** → le jeu doit aller directement au **login en français, sans crash**, et **recréer `user_settings.json`** à la sortie.

**Déploiement** : ✅ client uniquement, **pas de redéploiement serveur**.