### PR TITLE
DIAG (ne pas merger) : isolation du crash écran de langue 1er lancement

### DIFF
--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1268,22 +1268,16 @@ namespace engine::client
 		}
 		if (requestedLocale.empty())
 		{
-			// 1er lancement (aucune locale persistée) : on APPLIQUE directement la langue
-			// détectée du système et on l'écrit dans user_settings.json, puis le flux part
-			// vers l'écran de login (comme une locale déjà retenue). L'écran illustré de
-			// sélection (Phase::LanguageSelectionFirstRun) est volontairement court-circuité :
-			// son rendu ImGui provoquait une faute GPU « device lost » au 1er lancement
-			// (impossible à localiser sans RenderDoc) ; créer user_settings.json suffit à
-			// l'éviter — ce que l'on fait ici automatiquement. La langue reste modifiable
-			// dans les Options (écran fonctionnel). La géoloc IP n'enrichit plus la sélection
-			// (elle servait cet écran) ; la langue système reste le signal principal de #1.
+			// DIAGNOSTIC (temporaire, branche diag uniquement) : on REACTIVE l'ecran de
+			// selection illustre (court-circuite par #915) afin de pouvoir reproduire et
+			// isoler sa faute GPU "device lost". Le vrai contournement reste sur main.
 			m_selectedLocale = m_localization.GetCurrentLocale();
-			if (PatchPersistedLocaleKey(m_selectedLocale))
-			{
-				m_persistedLocale = m_selectedLocale;
-				m_hasPersistedLocale = true;
-			}
-			LOG_INFO(Core, "[AuthUiPresenter] 1er lancement : langue détectée '{}' appliquée + persistée (écran de sélection court-circuité)", m_selectedLocale);
+			m_firstRunLocales = m_localization.GetAvailableLocales();
+			auto it = std::find(m_firstRunLocales.begin(), m_firstRunLocales.end(), m_selectedLocale);
+			m_languageSelectionIndex = it != m_firstRunLocales.end()
+				? static_cast<uint32_t>(std::distance(m_firstRunLocales.begin(), it)) : 0u;
+			SetPhase(Phase::LanguageSelectionFirstRun);
+			LOG_INFO(Core, "[AuthUiPresenter] DIAG : ecran de langue REACTIVE (detected={})", m_selectedLocale);
 		}
 		else
 		{

--- a/src/client/auth/screens/AuthScreenLanguageSelect.cpp
+++ b/src/client/auth/screens/AuthScreenLanguageSelect.cpp
@@ -200,7 +200,12 @@ namespace engine::client
 		// le faisait courir en parallèle du chargement des DLL du driver Vulkan
 		// (vkCreateInstance) → crash au lancement (client ET éditeur). Idempotent via
 		// m_firstRunGeoStarted ; charge la table pays->langue puis lance le worker.
-		if (!m_firstRunGeoStarted)
+		// DIAG (debug.lang.geoloc) : permet de COUPER le thread géoloc WinHTTP afin
+		// d'isoler s'il est la cause de la faute GPU "device lost" du 1er lancement
+		// (le rendu ImGui de l'écran ayant été disculpé par les autres toggles).
+		// debug.lang.geoloc=false => aucun thread géoloc, la liste reste {système, en}.
+		const bool dbgGeoloc = cfg.GetBool("debug.lang.geoloc", true);
+		if (!m_firstRunGeoStarted && dbgGeoloc)
 		{
 			m_firstRunGeoStarted = true;
 			engine::client::CountryLanguageMap countryMap;

--- a/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
+++ b/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
@@ -60,6 +60,9 @@ namespace engine::render
 	int AuthImGuiRenderer::DrawLanguageFirstRunCards(const RenderModel& rm, int selected)
 	{
 		int clicked = -1;
+		// DIAGNOSTIC (temporaire) : isoler l'element fautif du crash 1er-lancement via config.json.
+		const bool dbgFlags = (m_authCfg == nullptr) || m_authCfg->GetBool("debug.lang.flags", true);
+		const bool dbgCardText = (m_authCfg == nullptr) || m_authCfg->GetBool("debug.lang.cardtext", true);
 		const size_t n = rm.languageFirstRunCards.empty() ? 2u : rm.languageFirstRunCards.size();
 		const float gap = 16.f; ///< Espacement horizontal entre les cartes.
 		// Cartes plus compactes : largeur fixe maxi pour ne pas s'etaler ; centrage horizontal gere ci-dessous.
@@ -127,7 +130,7 @@ namespace engine::render
 			const float flagPadL = 14.f;
 			const float fx = rmin.x + flagPadL;
 			const float fy = rmin.y + (cardSize.y - flagH) * 0.5f;
-			DrawCardFlag(dl, fx, fy, flagW, flagH, locTag);
+			if (dbgFlags) { DrawCardFlag(dl, fx, fy, flagW, flagH, locTag); }
 
 			ImFont* font = ImGui::GetFont();
 			const float nameSize = font->FontSize * 1.05f;
@@ -135,11 +138,13 @@ namespace engine::render
 			const float textBlockH = nameSize + 4.f + nativeSz;
 			const float textX = fx + flagW + 12.f;
 			const float textY = rmin.y + (cardSize.y - textBlockH) * 0.5f;
-			const ImVec2 namePos(textX, textY);
-			dl->AddText(font, nameSize, namePos, U32(LnTheme::kText), nameCaps.data(), nameCaps.data() + static_cast<int>(nameCaps.size()));
-
-			const ImVec2 natPos(textX, textY + nameSize + 4.f);
-			dl->AddText(font, nativeSz, natPos, U32(LnTheme::kMuted), nativeLn.data(), nativeLn.data() + static_cast<int>(nativeLn.size()));
+			if (dbgCardText)
+			{
+				const ImVec2 namePos(textX, textY);
+				dl->AddText(font, nameSize, namePos, U32(LnTheme::kText), nameCaps.data(), nameCaps.data() + static_cast<int>(nameCaps.size()));
+				const ImVec2 natPos(textX, textY + nameSize + 4.f);
+				dl->AddText(font, nativeSz, natPos, U32(LnTheme::kMuted), nativeLn.data(), nativeLn.data() + static_cast<int>(nativeLn.size()));
+			}
 		}
 		return clicked;
 	}
@@ -165,8 +170,15 @@ namespace engine::render
 		// Panneau compact : hauteur calee sur titre + sous-titre + cartes (96px) + bouton + footer + paddings.
 		// On passe titleZoneW (et non vpW) en 2e arg : le panel se centre desormais dans la stage
 		// (BeginChild ##ln_lang_stage), meme logique que l'ecran Login.
-		const float panelFixedH = 340.f;
-		if (!BeginPanel(720.f, titleZoneW, vpH, panelTitle, welcome, ver, true, true, panelFixedH))
+		float panelFixedH = 340.f;
+		bool subtitleAccent = true;
+		// DIAGNOSTIC (temporaire) : court-circuiter par config.json pour isoler le crash 1er-lancement.
+		if (m_authCfg != nullptr)
+		{
+			subtitleAccent = m_authCfg->GetBool("debug.lang.accent", true);
+			if (!m_authCfg->GetBool("debug.lang.fixedheight", true)) { panelFixedH = 0.f; }
+		}
+		if (!BeginPanel(720.f, titleZoneW, vpH, panelTitle, welcome, ver, true, subtitleAccent, panelFixedH))
 		{
 			EndPanel();
 			ImGui::EndChild();
@@ -189,7 +201,9 @@ namespace engine::render
 		}
 		ImGui::Spacing();
 
-		const int clicked = DrawLanguageFirstRunCards(rm, m_selectedLang);
+		const int clicked = (m_authCfg == nullptr || m_authCfg->GetBool("debug.lang.cards", true))
+			? DrawLanguageFirstRunCards(rm, m_selectedLang)
+			: -1;
 		if (clicked >= 0)
 		{
 			m_selectedLang = clicked;
@@ -247,7 +261,10 @@ namespace engine::render
 		EndPanel();
 		ImGui::EndChild();
 
-		DrawAuthTweaksPanel(vpW, vpH);
+		if (m_authCfg == nullptr || m_authCfg->GetBool("debug.lang.tweaks", true))
+		{
+			DrawAuthTweaksPanel(vpW, vpH);
+		}
 	}
 } // namespace engine::render
 


### PR DESCRIPTION
## Build de DIAGNOSTIC — NE PAS MERGER

Sert uniquement à produire un build Windows pour **isoler par bissection** l'élément qui provoque la faute GPU « device lost » au rendu de l'écran de langue au 1er lancement.

Branche basée sur l'état **avant** le contournement (#915), donc l'écran de langue est **actif** (et crashe) — c'est volontaire.

### Comment l'utiliser
Dans `config.json`, mettre **une** clé à `false` à la fois puis relancer `lcdlln.exe` (sans `user_settings.json`). Dès que le crash **disparaît**, l'élément est isolé. Clés (toutes `true` par défaut = rendu normal) :

```
"debug": {
  "lang": {
    "cards": true,        // cartes de langue (grille)
    "flags": true,        // drapeaux procéduraux dans les cartes
    "cardtext": true,     // textes (nom langue) dans les cartes
    "fixedheight": true,  // panneau à hauteur fixe (false = auto comme login)
    "accent": true,       // sous-titre accentué
    "tweaks": true        // panneau "thème de race" en bas
  }
}
```

Ordre suggéré : `cards=false` d'abord. Si ça arrête le crash → tester `flags=false` puis `cardtext=false` (cards à true). Sinon tester `fixedheight=false`, `accent=false`, `tweaks=false`.

Une fois l'élément isolé, le vrai correctif sera fait sur #915 et **la page restaurée**.