### PR TITLE
feat(gameplay): portes franchissables + fix anti-vol le long des murs (Lot 5)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -937,6 +937,12 @@ elseif(UNIX)
   lcdlln_add_simple_test(composite_world_collider_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CompositeWorldColliderTests.cpp)
 
+  # Lot 5 (anti-vol step-up) : un mur (prop normal) n'est PAS escaladable
+  # (step-up plafonne a maxStep) alors qu'un escalier (PropCylinder::stair) reste
+  # gravissable (step-up jusqu'a maxClimb). Integre controller + collider a 60 Hz.
+  lcdlln_add_simple_test(character_controller_stepup_tests
+    ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp)
+
   # Sous-projet C MVP : RaceDefinition.meshPath parsing.
   # Verifie que les 3 races MVP (humains, nains, orcs) exposent un meshPath
   # non vide depuis races.json, et que les races hors-MVP exposent une

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -13423,8 +13423,19 @@ namespace engine
 			{
 				float radius = collisionRadius > 0.0f ? collisionRadius : radiusAuto;
 				if (radius < 0.05f) radius = 0.5f;
-				m_worldCollider.AddCylinder(
-					engine::gameplay::PropCylinder{ wx, wz, radius, groundY, topY });
+				// Porte/escalier reconnus par le nom du mesh (insensible à la casse) :
+				// « door » → passage franchissable (aucune collision) ; « escalier »
+				// (ou « stair ») → surface gravissable. Le décor normal reste un mur plein.
+				std::string meshLower = meshPath;
+				for (char& ch : meshLower)
+				{
+					if (ch >= 'A' && ch <= 'Z') ch = static_cast<char>(ch - 'A' + 'a');
+				}
+				engine::gameplay::PropCylinder cyl{ wx, wz, radius, groundY, topY };
+				cyl.passable = meshLower.find("door") != std::string::npos;
+				cyl.stair = (meshLower.find("escalier") != std::string::npos)
+					|| (meshLower.find("stair") != std::string::npos);
+				m_worldCollider.AddCylinder(cyl);
 			}
 			m_props.push_back(std::move(prop));
 		}
@@ -14211,8 +14222,19 @@ namespace engine
 			{
 				float radius = collisionRadius > 0.0f ? collisionRadius : radiusAuto;
 				if (radius < 0.05f) radius = 0.5f;
-				m_worldCollider.AddCylinder(
-					engine::gameplay::PropCylinder{ cx, cz, radius, minY, maxY });
+				// Pièces de bâtiment : une « door » devient un passage franchissable,
+				// un « escalier » une surface gravissable (cf. PropCylinder). Détection
+				// par le nom du mesh, insensible à la casse. Les murs restent pleins.
+				std::string meshLower = meshPath;
+				for (char& ch : meshLower)
+				{
+					if (ch >= 'A' && ch <= 'Z') ch = static_cast<char>(ch - 'A' + 'a');
+				}
+				engine::gameplay::PropCylinder cyl{ cx, cz, radius, minY, maxY };
+				cyl.passable = meshLower.find("door") != std::string::npos;
+				cyl.stair = (meshLower.find("escalier") != std::string::npos)
+					|| (meshLower.find("stair") != std::string::npos);
+				m_worldCollider.AddCylinder(cyl);
 			}
 			m_props.push_back(std::move(prop));
 		}

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -332,7 +332,7 @@ namespace engine::gameplay
 					engine::math::Vec3 steppedVel;
 					bool steppedGrounded = false;
 					if (TryStepUp(input, dt, timeRemaining, world, pos, Vec3XZ(vel) * (dt * timeRemaining), vel,
-						steppedPos, steppedVel, steppedGrounded))
+						hit.stair, steppedPos, steppedVel, steppedGrounded))
 					{
 						pos = steppedPos;
 						vel = steppedVel;
@@ -410,6 +410,7 @@ namespace engine::gameplay
 		const engine::math::Vec3& startPos,
 		const engine::math::Vec3& horizontalDisp,
 		const engine::math::Vec3& currentVel,
+		bool obstacleIsStair,
 		engine::math::Vec3& outPos,
 		engine::math::Vec3& outVel,
 		bool& outGrounded)
@@ -417,14 +418,18 @@ namespace engine::gameplay
 		(void)input;
 		(void)dt;
 
-		// Attempt (« meshes marchables quelle que soit la hauteur ») :
-		// 1) Monter de `maxClimb` (≫ maxStep) et balayer horizontalement.
-		// 2) Si l'horizontal est libre, balayer vers le bas de `maxClimb` pour trouver
-		//    le point de pose sur le dessus de l'obstacle.
-		// On utilise `maxClimb` (et non `maxStep`) afin de pouvoir monter sur le dessus
-		// d'un prop/mesh de hauteur quelconque (dans la limite `maxClimb`) en butant
-		// dedans, au lieu de seulement lisser les marches <= 0,3 m.
-		const float climb = (m_cfg.maxClimb > m_cfg.maxStep) ? m_cfg.maxClimb : m_cfg.maxStep;
+		// Hauteur de step-up autorisée :
+		// - ESCALIER (mesh « escalier », obstacleIsStair) : on monte jusqu'à `maxClimb`
+		//   (≫ maxStep) pour se poser sur le dessus de la marche/volée.
+		// - SINON (mur, bâtiment, prop normal, micro-marche de terrain) : plafonné à
+		//   `maxStep` (~0,3 m) = simple lissage. On NE grimpe PAS les parois verticales
+		//   (sinon le perso « vole » en se collant à un mur — bug observé sur l'auberge).
+		// Auparavant `maxClimb` s'appliquait à TOUT obstacle (rendait tout mesh
+		// escaladable quelle que soit sa hauteur) → c'était la cause du vol le long
+		// des murs. On réserve désormais la grande montée aux escaliers taggés.
+		const float climb = obstacleIsStair
+			? ((m_cfg.maxClimb > m_cfg.maxStep) ? m_cfg.maxClimb : m_cfg.maxStep)
+			: m_cfg.maxStep;
 		const engine::math::Vec3 up(0.0f, 1.0f, 0.0f);
 		const engine::math::Vec3 upStart = startPos + up * climb;
 		const engine::math::Vec3 upEnd = upStart + horizontalDisp;

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -32,6 +32,10 @@ namespace engine::gameplay
 			bool hit = false;
 			float fraction = 1.0f;     ///< 0..1 where 1 means "no hit"
 			engine::math::Vec3 normal{ 0.0f, 1.0f, 0.0f }; ///< world-space collision normal
+			/// L'obstacle touché est un escalier (mesh « escalier ») : le contrôleur
+			/// autorise alors la montée à grande hauteur (step-up jusqu'à maxClimb),
+			/// contrairement à un mur normal plafonné à maxStep. Cf. PropCylinder::stair.
+			bool stair = false;
 		};
 
 		virtual ~IWorldCollider() = default;
@@ -168,11 +172,16 @@ namespace engine::gameplay
 			return normal.y >= maxSlopeCos;
 		}
 
+		/// \param obstacleIsStair  L'obstacle buté est un escalier (SweepHit::stair) :
+		///        autorise alors un step-up jusqu'à `maxClimb` (montée d'escalier).
+		///        Sinon (mur, bâtiment, prop normal) le step-up est plafonné à
+		///        `maxStep` pour ne PAS grimper les parois verticales (anti-« vol »).
 		bool TryStepUp(const MoveInput& input, float dt, float timeRemaining,
 			const IWorldCollider& world,
 			const engine::math::Vec3& startPos,
 			const engine::math::Vec3& horizontalDisp,
 			const engine::math::Vec3& currentVel,
+			bool obstacleIsStair,
 			engine::math::Vec3& outPos,
 			engine::math::Vec3& outVel,
 			bool& outGrounded);

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -48,6 +48,10 @@ namespace engine::gameplay
 
 		for (const auto& c : m_cylinders)
 		{
+			// Porte (mesh « door ») : passage franchissable → le cylindre n'oppose
+			// AUCUNE collision (ni capuchon ni flanc), le perso traverse l'embrasure.
+			if (c.passable) continue;
+
 			// --- 2a) Capuchon supérieur : surface marchable au sommet du prop ---
 			// Quand le bas de la capsule descend à travers `topY` au-dessus de
 			// l'empreinte XZ du cylindre, on arrête la descente sur le sommet et on
@@ -69,6 +73,7 @@ namespace engine::gameplay
 							best.hit = true;
 							best.fraction = tc;
 							best.normal = engine::math::Vec3{ 0.0f, 1.0f, 0.0f };
+							best.stair = c.stair;
 						}
 					}
 				}
@@ -117,6 +122,7 @@ namespace engine::gameplay
 			{
 				best.hit = true;
 				best.fraction = tHit;
+				best.stair = c.stair;
 				// Normale horizontale : de l'axe du cylindre vers la capsule au contact.
 				const float px = sx + tHit * dx - c.cx;
 				const float pz = sz + tHit * dz - c.cz;

--- a/src/client/gameplay/CompositeWorldCollider.h
+++ b/src/client/gameplay/CompositeWorldCollider.h
@@ -16,6 +16,13 @@ namespace engine::gameplay
 		float radius = 0.5f; ///< rayon (mètres)
 		float baseY = 0.0f;  ///< Y monde du bas du cylindre
 		float topY = 2.0f;   ///< Y monde du haut du cylindre
+		/// Porte (mesh « door ») : passage franchissable. Le cylindre n'oppose
+		/// AUCUNE collision (ni flanc ni capuchon) → le perso traverse l'embrasure.
+		bool passable = false;
+		/// Escalier (mesh « escalier ») : surface gravissable. Le flanc ne bloque
+		/// pas ; on autorise la montée/descente sur son dessus quelle que soit la
+		/// hauteur (le perso s'y pose et la gravit), contrairement à un mur vertical.
+		bool stair = false;
 	};
 
 	/// Collisionneur composite : combine un IWorldCollider de terrain (sol + eau) et

--- a/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
+++ b/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
@@ -1,0 +1,126 @@
+// src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
+//
+// Garde anti-régression du fix « anti-vol » (Lot 5) sur le step-up :
+//   - un MUR / prop normal (PropCylinder sans flag) ne doit PAS être escaladé :
+//     le step-up est plafonné à maxStep (~0,3 m), donc en se collant à une paroi
+//     verticale le perso reste au sol au lieu de « voler » le long du mur ;
+//   - un ESCALIER (PropCylinder::stair) reste gravissable : le step-up monte
+//     jusqu'à maxClimb, le perso se pose sur le dessus.
+//
+// Le test intègre le CharacterController à 60 Hz contre un CompositeWorldCollider
+// (sol plat + un cylindre obstacle de 2 m) en marchant droit dans l'obstacle.
+
+#include "src/client/gameplay/CharacterController.h"
+#include "src/client/gameplay/CompositeWorldCollider.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::gameplay::CharacterController;
+	using engine::gameplay::CompositeWorldCollider;
+	using engine::gameplay::IWorldCollider;
+	using engine::gameplay::MoveInput;
+	using engine::gameplay::PropCylinder;
+	using engine::math::Vec3;
+
+	// Sol plat horizontal à y = floorY (normale +Y). Ne bloque que la descente
+	// franchissant le sol (suffisant : ici le perso reste posé / monte).
+	class FlatFloor final : public IWorldCollider
+	{
+	public:
+		explicit FlatFloor(float floorY) : m_floorY(floorY) {}
+
+		bool SweepCapsule(const Capsule& capsule,
+			const Vec3& startCenter,
+			const Vec3& endCenter,
+			SweepHit& outHit) const override
+		{
+			const float halfH = capsule.height * 0.5f;
+			const float startBottom = startCenter.y - halfH;
+			const float endBottom = endCenter.y - halfH;
+			outHit.normal = Vec3(0.0f, 1.0f, 0.0f);
+			if (endBottom >= m_floorY) { outHit.hit = false; outHit.fraction = 1.0f; return false; }
+			if (startBottom <= m_floorY) { outHit.hit = true; outHit.fraction = 0.0f; return true; }
+			const float denom = (startBottom - endBottom);
+			float frac = (denom > 0.0f) ? (startBottom - m_floorY) / denom : 0.0f;
+			if (frac < 0.0f) frac = 0.0f;
+			if (frac > 1.0f) frac = 1.0f;
+			outHit.hit = true;
+			outHit.fraction = frac;
+			return true;
+		}
+
+	private:
+		float m_floorY = 0.0f;
+	};
+
+	// Marche droit vers +x dans un cylindre obstacle (centre x=2, rayon 0,5, de
+	// y=0 à y=2) pendant ~2 s et renvoie la hauteur des pieds (center.y - halfH).
+	// \param stair  tague l'obstacle comme escalier (gravissable) ou mur (non).
+	float SimulatePushIntoCylinder(bool stair)
+	{
+		CharacterController::Config cfg{};
+		cfg.gravity = -20.0f;
+		cfg.capsule.height = 1.8f;
+		cfg.capsule.radius = 0.3f;
+		cfg.enableFlying = false;
+		cfg.maxStep = 0.3f;
+		cfg.maxClimb = 3.0f;
+		cfg.maxSlopeDeg = 45.0f;
+
+		CharacterController cc(cfg);
+		const float halfH = cfg.capsule.height * 0.5f;
+		cc.Init(Vec3(0.0f, halfH, 0.0f)); // pieds à y=0
+
+		FlatFloor floor(0.0f);
+		CompositeWorldCollider world(&floor);
+		// Obstacle de 2 m : franchissable par maxClimb=3 (lève le bas de capsule
+		// au-dessus de topY=2) mais PAS par maxStep=0,3.
+		PropCylinder obstacle{ 2.0f, 0.0f, 0.5f, 0.0f, 2.0f };
+		obstacle.stair = stair;
+		world.AddCylinder(obstacle);
+
+		const float dt = 1.0f / 60.0f;
+		MoveInput in{};
+		in.moveDirXZ = Vec3(1.0f, 0.0f, 0.0f); // vers le cylindre
+		for (int i = 0; i < 120; ++i)
+			cc.Update(dt, in, world);
+
+		return cc.GetPosition().y - halfH;
+	}
+
+	void Test_Wall_NotClimbed()
+	{
+		const float feetY = SimulatePushIntoCylinder(/*stair*/ false);
+		std::fprintf(stderr, "[INFO] mur: pieds y=%.3f (attendu ~0, plafonne maxStep)\n", feetY);
+		// Anti-vol : le perso reste au sol (jamais hissé au sommet du mur de 2 m).
+		REQUIRE(feetY < 0.5f);
+	}
+
+	void Test_Stair_Climbed()
+	{
+		const float feetY = SimulatePushIntoCylinder(/*stair*/ true);
+		std::fprintf(stderr, "[INFO] escalier: pieds y=%.3f (attendu > 1.5, gravi)\n", feetY);
+		// L'escalier taggé est gravi : le perso se pose sur le dessus (topY=2).
+		REQUIRE(feetY > 1.5f);
+	}
+}
+
+int main()
+{
+	Test_Wall_NotClimbed();
+	Test_Stair_Climbed();
+	if (g_failed == 0) std::fprintf(stderr, "CharacterControllerStepUpTests: OK\n");
+	return g_failed;
+}

--- a/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
+++ b/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
@@ -1,14 +1,22 @@
 // src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
 //
 // Garde anti-régression du fix « anti-vol » (Lot 5) sur le step-up :
-//   - un MUR / prop normal (PropCylinder sans flag) ne doit PAS être escaladé :
-//     le step-up est plafonné à maxStep (~0,3 m), donc en se collant à une paroi
-//     verticale le perso reste au sol au lieu de « voler » le long du mur ;
-//   - un ESCALIER (PropCylinder::stair) reste gravissable : le step-up monte
-//     jusqu'à maxClimb, le perso se pose sur le dessus.
+//   un MUR / prop normal (PropCylinder sans flag) ne doit PAS être escaladé.
+//   Le step-up est plafonné à maxStep (~0,3 m), donc en marchant droit dans une
+//   paroi verticale le perso reste au sol au lieu de « voler » le long du mur
+//   (bug observé en jeu : perso flottant collé au mur de l'auberge).
 //
-// Le test intègre le CharacterController à 60 Hz contre un CompositeWorldCollider
-// (sol plat + un cylindre obstacle de 2 m) en marchant droit dans l'obstacle.
+// Avant le fix, TryStepUp utilisait maxClimb (3 m) pour TOUT obstacle → toute
+// paroi devenait escaladable. On vérifie ici que le perso AVANCE bien jusqu'au
+// mur (preuve qu'il marche) MAIS ne monte pas (les pieds restent au sol).
+//
+// NB : la montée d'ESCALIER fiable n'est PAS couverte ici. Avec un escalier
+// mono-cylindre, le contact latéral se fait à (capRadius+cylRadius) de l'axe
+// alors que se poser sur le dessus exige d'être à moins de cylRadius : l'écart
+// incompressible (= capRadius) empêche un step-up mono-frame fiable. C'est un
+// chantier de modèle de collision séparé (marches discrètes ou rampe inclinée).
+// Le tag PropCylinder::stair existe (propagation vérifiée par
+// CompositeWorldColliderTests) mais ne garantit pas encore une montée lisse.
 
 #include "src/client/gameplay/CharacterController.h"
 #include "src/client/gameplay/CompositeWorldCollider.h"
@@ -35,7 +43,7 @@ namespace
 	using engine::math::Vec3;
 
 	// Sol plat horizontal à y = floorY (normale +Y). Ne bloque que la descente
-	// franchissant le sol (suffisant : ici le perso reste posé / monte).
+	// franchissant le sol (suffisant : ici le perso reste posé / glisse).
 	class FlatFloor final : public IWorldCollider
 	{
 	public:
@@ -66,9 +74,8 @@ namespace
 	};
 
 	// Marche droit vers +x dans un cylindre obstacle (centre x=2, rayon 0,5, de
-	// y=0 à y=2) pendant ~2 s et renvoie la hauteur des pieds (center.y - halfH).
-	// \param stair  tague l'obstacle comme escalier (gravissable) ou mur (non).
-	float SimulatePushIntoCylinder(bool stair)
+	// y=0 à y=2) pendant ~2 s et renvoie la position finale du centre de capsule.
+	Vec3 SimulatePushIntoWall()
 	{
 		CharacterController::Config cfg{};
 		cfg.gravity = -20.0f;
@@ -85,42 +92,38 @@ namespace
 
 		FlatFloor floor(0.0f);
 		CompositeWorldCollider world(&floor);
-		// Obstacle de 2 m : franchissable par maxClimb=3 (lève le bas de capsule
-		// au-dessus de topY=2) mais PAS par maxStep=0,3.
-		PropCylinder obstacle{ 2.0f, 0.0f, 0.5f, 0.0f, 2.0f };
-		obstacle.stair = stair;
-		world.AddCylinder(obstacle);
+		PropCylinder wall{ 2.0f, 0.0f, 0.5f, 0.0f, 2.0f }; // mur de 2 m, non taggé
+		world.AddCylinder(wall);
 
 		const float dt = 1.0f / 60.0f;
+		MoveInput idle{};
+		for (int i = 0; i < 10; ++i) // stabilise l'état "grounded" avant de marcher
+			cc.Update(dt, idle, world);
+
 		MoveInput in{};
-		in.moveDirXZ = Vec3(1.0f, 0.0f, 0.0f); // vers le cylindre
+		in.moveDirXZ = Vec3(1.0f, 0.0f, 0.0f); // marche vers le mur
 		for (int i = 0; i < 120; ++i)
 			cc.Update(dt, in, world);
 
-		return cc.GetPosition().y - halfH;
+		return cc.GetPosition();
 	}
 
-	void Test_Wall_NotClimbed()
+	void Test_Wall_NotClimbed_ButReached()
 	{
-		const float feetY = SimulatePushIntoCylinder(/*stair*/ false);
-		std::fprintf(stderr, "[INFO] mur: pieds y=%.3f (attendu ~0, plafonne maxStep)\n", feetY);
-		// Anti-vol : le perso reste au sol (jamais hissé au sommet du mur de 2 m).
+		const Vec3 pos = SimulatePushIntoWall();
+		const float feetY = pos.y - 0.9f; // halfH = 0.9
+		std::fprintf(stderr, "[INFO] mur: x=%.3f feetY=%.3f (attendu x>0.8 atteint, feetY<0.5 pas de vol)\n",
+			pos.x, feetY);
+		// Le perso a bien AVANCÉ vers le mur (contact ~x=1.2 = axe2 - (cap0.3+cyl0.5)).
+		REQUIRE(pos.x > 0.8f);
+		// ...et n'a PAS été hissé le long de la paroi (anti-vol) : pieds au sol.
 		REQUIRE(feetY < 0.5f);
-	}
-
-	void Test_Stair_Climbed()
-	{
-		const float feetY = SimulatePushIntoCylinder(/*stair*/ true);
-		std::fprintf(stderr, "[INFO] escalier: pieds y=%.3f (attendu > 1.5, gravi)\n", feetY);
-		// L'escalier taggé est gravi : le perso se pose sur le dessus (topY=2).
-		REQUIRE(feetY > 1.5f);
 	}
 }
 
 int main()
 {
-	Test_Wall_NotClimbed();
-	Test_Stair_Climbed();
+	Test_Wall_NotClimbed_ButReached();
 	if (g_failed == 0) std::fprintf(stderr, "CharacterControllerStepUpTests: OK\n");
 	return g_failed;
 }

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -103,6 +103,44 @@ int main()
 		check(!h, "chevauchement + eloignement: pas de hit (peut ressortir)");
 	}
 
+	// 6) PORTE (passable) — le cylindre n'oppose AUCUNE collision : un sweep qui
+	//    le traverserait normalement (cf. test 1) passe librement (on franchit
+	//    l'embrasure). Idem en descente : pas de capuchon.
+	{
+		PropCylinder door = cyl; door.passable = true;
+		CompositeWorldCollider c(&terrain); c.AddCylinder(door);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 0, 1, 0 }, Vec3{ 10, 1, 0 }, hit);
+		check(!h && !hit.hit, "porte: passable -> aucune collision (franchissable)");
+		IWorldCollider::SweepHit hitDown;
+		bool hd = c.SweepCapsule(cap, Vec3{ 5, 20, 0 }, Vec3{ 5, 1, 0 }, hitDown);
+		check(!hd, "porte: passable -> pas de capuchon non plus");
+	}
+
+	// 7) ESCALIER (stair) — collisionne toujours (flanc + capuchon), MAIS le hit est
+	//    marqué stair=true afin que le contrôleur autorise un step-up jusqu'à maxClimb
+	//    (montée d'escalier), au lieu du plafond maxStep réservé aux murs.
+	{
+		PropCylinder st = cyl; st.stair = true;
+		CompositeWorldCollider c(&terrain); c.AddCylinder(st);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 0, 1, 0 }, Vec3{ 10, 1, 0 }, hit);
+		check(h && hit.hit, "escalier: flanc bloque (hit attendu)");
+		check(hit.stair, "escalier: hit marque stair=true (flanc)");
+		IWorldCollider::SweepHit hitTop;
+		c.SweepCapsule(cap, Vec3{ 5, 20, 0 }, Vec3{ 5, 1, 0 }, hitTop);
+		check(hitTop.stair, "escalier: hit marque stair=true (capuchon)");
+	}
+
+	// 8) Prop normal (mur/bâtiment) — hit.stair reste false : le contrôleur ne
+	//    déclenchera PAS la montée haute (anti-« vol » le long des parois).
+	{
+		CompositeWorldCollider c(&terrain); c.AddCylinder(cyl);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 0, 1, 0 }, Vec3{ 10, 1, 0 }, hit);
+		check(h && !hit.stair, "mur normal: hit.stair=false");
+	}
+
 	// 5) QueryWater délégué au terrain.
 	{
 		CompositeWorldCollider c(&terrain);


### PR DESCRIPTION
## Lot 5 — collision props : portes + anti-vol (escaliers : suivi)

Suite du Lot 5 (#912 rendait les meshes marchables ON les objets, en y arrivant par le dessus). Cette PR traite les **deux problèmes rapportés en jeu** de façon fiable et testée, et **descope** la montée d'escalier (voir plus bas).

### 1. ✅ Portes franchissables (mesh « door »)
`PropCylinder::passable` : le cylindre n'oppose **aucune** collision (ni flanc ni capuchon). Le perso traverse l'embrasure.

### 2. ✅ Fix anti-« vol » le long des murs
`TryStepUp` utilisait `maxClimb` (3 m) pour **tout** obstacle → toute paroi devenait escaladable, le perso flottait en se collant à un mur/bâtiment (bug capture utilisateur sur l'auberge). Désormais le step-up est **plafonné à `maxStep`** (~0,3 m) sauf sur un escalier taggé. Un mur vertical n'est plus jamais escaladé. La station debout SUR un prop (atteinte par le dessus, #912) reste intacte.

### Détection
Par sous-chaîne du nom de mesh (insensible à la casse) aux **deux** sites de création de cylindres : `BuildPropFromMesh` (scenery + interactibles) et `BuildPropFromMeshMatrix` (bâtiments / auberge #908).

### Tests (ctest, CI Linux)
- `CompositeWorldColliderTests` : porte = aucune collision (flanc + capuchon) ; tag escalier propagé dans `SweepHit::stair` ; mur normal = `stair=false`.
- `CharacterControllerStepUpTests` (nouveau) : intègre controller+collider à 60 Hz — le perso **avance** jusqu'au mur (preuve qu'il marche) mais n'est **pas** hissé le long de la paroi (anti-vol).

### ⏳ Escaliers (mesh « escalier ») — best-effort, montée fiable = chantier séparé
Le tag `PropCylinder::stair` est en place (les escaliers conservent le step-up généreux `maxClimb`, **sans régression** vs #912). **Mais** la montée fiable n'est PAS garantie : avec un escalier **mono-cylindre**, le contact latéral se fait à `capRadius+cylRadius` de l'axe alors que se poser sur le dessus exige d'être à moins de `cylRadius` — un écart incompressible (= `capRadius`) qu'un step-up mono-frame ne franchit pas de façon fiable (ctest : escalier `pieds y=0.000`).

Une montée d'escalier **lisse et fiable** demande un autre modèle de collision (marches discrètes ≤ 0,3 m — déjà gravissables via `maxStep` — **ou** une primitive de rampe inclinée) **et** un asset d'animation dédié, absent du catalogue (`animation_sets.json` = idle/walk/run/sprint/jump). → **chantier séparé** (brainstorm + spec).

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (collision 100 % client).