### PR TITLE
fix(i18n): restaure l'écran de langue 1er lancement + géoloc différée (anti device-lost)

### DIFF
--- a/src/client/auth/AuthUi.h
+++ b/src/client/auth/AuthUi.h
@@ -1098,10 +1098,16 @@ namespace engine::client
 		// Liste des locales affichées au 1er lancement (union filtrée système+IP+en).
 		// Source unique pour TOUS les sites de l'écran LanguageSelectionFirstRun.
 		std::vector<std::string> m_firstRunLocales;
-		// Garde-fou de démarrage différé de la géoloc : passe à true à la 1re frame de
-		// l'écran de langue (Update_LanguageSelect), où le thread WinHTTP est lancé —
-		// jamais pendant Init()/boot (conflit avec l'init Vulkan = crash au lancement).
+		// Garde-fou de démarrage différé de la géoloc : passe à true une fois le thread
+		// WinHTTP lancé (Update_LanguageSelect), APRÈS chauffe du pipeline de rendu —
+		// jamais pendant Init()/boot ni sur les toutes premières frames (init réseau
+		// concurrente du pilote GPU = faute « device lost »).
 		bool m_firstRunGeoStarted = false;
+		// Horloge de chauffe : instant d'entrée sur l'écran de langue. La géoloc n'est
+		// lancée qu'après client.first_run.geoip_delay_ms (défaut 2500) écoulées, le temps
+		// que le GPU/swapchain/StatusProbe se stabilisent.
+		std::chrono::steady_clock::time_point m_firstRunGeoClock{};
+		bool m_firstRunGeoClockSet = false;
 
 		std::vector<uint8_t> m_argonSalt{};
 		uint32_t m_viewportW = 0;

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -1268,22 +1268,29 @@ namespace engine::client
 		}
 		if (requestedLocale.empty())
 		{
-			// 1er lancement (aucune locale persistée) : on APPLIQUE directement la langue
-			// détectée du système et on l'écrit dans user_settings.json, puis le flux part
-			// vers l'écran de login (comme une locale déjà retenue). L'écran illustré de
-			// sélection (Phase::LanguageSelectionFirstRun) est volontairement court-circuité :
-			// son rendu ImGui provoquait une faute GPU « device lost » au 1er lancement
-			// (impossible à localiser sans RenderDoc) ; créer user_settings.json suffit à
-			// l'éviter — ce que l'on fait ici automatiquement. La langue reste modifiable
-			// dans les Options (écran fonctionnel). La géoloc IP n'enrichit plus la sélection
-			// (elle servait cet écran) ; la langue système reste le signal principal de #1.
+			// 1er lancement (aucune locale persistée) : on affiche l'écran illustré de
+			// sélection de langue (Phase::LanguageSelectionFirstRun) avec la liste filtrée
+			// {système, en} calculée IMMÉDIATEMENT par ComputeSuggestedLocales (fonction
+			// PURE, aucun réseau). La langue déduite de l'IP enrichira la liste plus tard,
+			// via PollGeoUpdate, quand la géoloc aura répondu.
+			//
+			// IMPORTANT — anti « device lost » : la géoloc (thread WinHTTP vers ip-api.com)
+			// n'est PLUS démarrée ici. Lancée pendant le boot (#909) elle crashait
+			// vkCreateInstance ; déplacée à la 1re frame de l'écran (#915) elle crashait
+			// quand même le GPU (init réseau concurrente des toutes premières frames du
+			// pilote → faute « device lost », diagnostic confirmé par bisection). Elle est
+			// désormais démarrée DE MANIÈRE DIFFÉRÉE dans Update_LanguageSelect, après
+			// chauffe du pipeline de rendu (cf. AuthScreenLanguageSelect.cpp). Le bypass
+			// #915 (qui sautait cet écran) est donc retiré : l'écran refait ses propositions.
 			m_selectedLocale = m_localization.GetCurrentLocale();
-			if (PatchPersistedLocaleKey(m_selectedLocale))
-			{
-				m_persistedLocale = m_selectedLocale;
-				m_hasPersistedLocale = true;
-			}
-			LOG_INFO(Core, "[AuthUiPresenter] 1er lancement : langue détectée '{}' appliquée + persistée (écran de sélection court-circuité)", m_selectedLocale);
+			m_firstRunLocales = engine::client::ComputeSuggestedLocales(
+				m_selectedLocale, /*ipLocale (encore inconnue)*/ "", m_localization.GetAvailableLocales());
+			auto it = std::find(m_firstRunLocales.begin(), m_firstRunLocales.end(), m_selectedLocale);
+			m_languageSelectionIndex = (it != m_firstRunLocales.end())
+				? static_cast<uint32_t>(std::distance(m_firstRunLocales.begin(), it)) : 0u;
+			SetPhase(Phase::LanguageSelectionFirstRun);
+			LOG_INFO(Core, "[AuthUiPresenter] 1er lancement : écran de langue (detected={}, {} proposition(s) immédiate(s) ; géoloc différée hors premières frames)",
+				m_selectedLocale, m_firstRunLocales.size());
 		}
 		else
 		{

--- a/src/client/auth/screens/AuthScreenLanguageSelect.cpp
+++ b/src/client/auth/screens/AuthScreenLanguageSelect.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -195,14 +196,28 @@ namespace engine::client
 		{
 			return;
 		}
-		// Démarrage différé de la géoloc : à la 1re frame de l'écran de langue, donc
-		// APRÈS l'init Vulkan du boot. Lancer ce thread réseau WinHTTP pendant Init()
-		// le faisait courir en parallèle du chargement des DLL du driver Vulkan
-		// (vkCreateInstance) → crash au lancement (client ET éditeur). Idempotent via
-		// m_firstRunGeoStarted ; charge la table pays->langue puis lance le worker.
-		if (!m_firstRunGeoStarted)
+		// Démarrage DIFFÉRÉ de la géoloc (thread WinHTTP vers ip-api.com).
+		// Lancée pendant Init() (#909) elle crashait vkCreateInstance ; lancée à la 1re
+		// frame de l'écran (#915) elle crashait QUAND MÊME le GPU : l'init réseau WinHTTP
+		// concurrente des toutes premières frames du pilote déclenche une faute « device
+		// lost » (diagnostic confirmé par bisection : écran de langue OK dès que la géoloc
+		// est coupée). Parade : on attend que le pipeline de rendu soit CHAUD (quelques
+		// secondes ; StatusProbe terminé, swapchain cyclée) avant de lancer le worker.
+		// Délai réglable sans recompiler via client.first_run.geoip_delay_ms (défaut 2500).
+		// Best-effort : si l'utilisateur valide sa langue avant l'arrivée géo, aucun impact
+		// (la liste {système, en} est déjà juste ; la langue IP n'aurait fait que l'enrichir).
+		if (!m_firstRunGeoClockSet)
+		{
+			m_firstRunGeoClock = std::chrono::steady_clock::now();
+			m_firstRunGeoClockSet = true;
+		}
+		const long long geoElapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now() - m_firstRunGeoClock).count();
+		const long long geoDelayMs = static_cast<long long>(cfg.GetInt("client.first_run.geoip_delay_ms", 2500));
+		if (!m_firstRunGeoStarted && geoElapsedMs >= geoDelayMs)
 		{
 			m_firstRunGeoStarted = true;
+			LOG_INFO(Core, "[AuthUiPresenter] géoloc 1er lancement démarrée (après {} ms de chauffe pipeline)", geoElapsedMs);
 			engine::client::CountryLanguageMap countryMap;
 			const std::string mapJson = engine::platform::FileSystem::ReadAllText(
 				engine::platform::FileSystem::ResolveContentPath(cfg, "localization/country_language.json"));


### PR DESCRIPTION
## Lot 1 (#1) — vrai fix : écran de langue restauré + crash géoloc corrigé

### Diagnostic (fiable, par bisection)
Le crash du 1er lancement était une **faute GPU « device lost »**. Le build diagnostic #916 (toggle `debug.lang.geoloc`) a **isolé la cause de façon reproductible** : dès que le thread géoloc WinHTTP (`IpApiGeoProvider` → ip-api.com) est coupé, l'écran de langue s'affiche, se navigue, valide et bascule au login **sans crash** (validé en jeu RTX 3080, 248 frames, arrêt propre). Tous les éléments de rendu ImGui de l'écran avaient été disculpés avant (les 6 toggles `debug.lang.*` à `false` crashaient quand même).

**Mécanisme** : l'init réseau WinHTTP lancée sur les toutes premières frames du pilote GPU (en plus de StatusProbe) déclenche le device-lost — même famille que le crash de boot de #909/#915, mais au 1er rendu.

### Historique
- **#909** : géoloc lancée dans `Init()` → crash `vkCreateInstance` au boot.
- **#915** : géoloc déplacée à la 1re frame (toujours trop tôt → device lost) **puis** écran entièrement contourné (langue système auto-appliquée, **plus de propositions**). Ce bypass ne correspondait pas à la demande #1 (l'écran doit **proposer** système + langue pays-IP + anglais).

### Fix
- **`AuthUiPresenterCore::Init`** : `SetPhase(LanguageSelectionFirstRun)` rétabli (**bypass #915 retiré**). La liste filtrée `{système, en}` est calculée **immédiatement** par `ComputeSuggestedLocales` (fonction pure, **aucun réseau**). Aucune géoloc ici.
- **`Update_LanguageSelect`** : la géoloc n'est lancée qu'**après chauffe du pipeline** (`client.first_run.geoip_delay_ms`, **défaut 2500 ms**), via une horloge `steady_clock` d'entrée d'écran. La langue pays-IP **enrichit** la liste à l'arrivée (`PollGeoUpdate`), best-effort. **Délai réglable sans recompiler.**

### Éditeur monde — non impacté
`BypassAuthGateForWorldEditor()` met `m_flowComplete=true` → `AuthUiPresenter::Update` retourne tôt (ligne 2943) → `Update_LanguageSelect` jamais atteint → ni écran ni géoloc côté éditeur.

### Validation
- Diagnostic confirmé en jeu (écran OK sans géoloc).
- ⚠️ **À valider en jeu** : 1er lancement avec ce fix → écran de langue affiché **et** stable même quand la géoloc démarre (~2,5 s). Si une machine reste sensible, augmenter `client.first_run.geoip_delay_ms` sans rebuild.

**Déploiement** : ✅ client uniquement, **pas de redéploiement serveur**.