### PR TITLE
fix(gameplay): mur de bâtiment sans dessus marchable (anti-vol auberge)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -14234,6 +14234,11 @@ namespace engine
 				cyl.passable = meshLower.find("door") != std::string::npos;
 				cyl.stair = (meshLower.find("escalier") != std::string::npos)
 					|| (meshLower.find("stair") != std::string::npos);
+				// Pièce de bâtiment = MUR (barrière latérale pure, pas de dessus
+				// marchable), SAUF un escalier qui doit garder son dessus pour être
+				// gravi. Évite le « vol » : la sonde anti-encastrement ne peut plus
+				// remonter le perso au sommet du gros cylindre englobant de la pièce.
+				cyl.wall = !cyl.stair;
 				m_worldCollider.AddCylinder(cyl);
 			}
 			m_props.push_back(std::move(prop));

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -57,6 +57,13 @@ namespace engine::gameplay
 			// l'empreinte XZ du cylindre, on arrête la descente sur le sommet et on
 			// renvoie une normale verticale (→ IsWalkable côté CharacterController, le
 			// perso se pose dessus). C'est ce qui rend les meshes « marchables ».
+			//
+			// EXCEPTION mur (c.wall) : pas de dessus marchable. Un mur de bâtiment est
+			// un gros cylindre englobant ; son capuchon faisait accrocher la sonde
+			// anti-encastrement du contrôleur (balayage du haut vers le bas) et
+			// remontait le perso au sommet du mur = « vol contre le mur ». On saute
+			// donc 2a pour les murs : ils ne font que bloquer latéralement (2b).
+			if (!c.wall)
 			{
 				const float bottomStart = startCenter.y - halfH - capsule.radius;
 				const float bottomEnd   = endCenter.y   - halfH - capsule.radius;

--- a/src/client/gameplay/CompositeWorldCollider.h
+++ b/src/client/gameplay/CompositeWorldCollider.h
@@ -23,6 +23,15 @@ namespace engine::gameplay
 		/// pas ; on autorise la montée/descente sur son dessus quelle que soit la
 		/// hauteur (le perso s'y pose et la gravit), contrairement à un mur vertical.
 		bool stair = false;
+		/// Pièce de bâtiment (mur, paroi) : BARRIÈRE LATÉRALE PURE, SANS dessus
+		/// marchable. Les bâtiments (#908) sont approximés par un gros cylindre
+		/// englobant PAR pièce ; rendre leur dessus marchable faisait remonter le
+		/// perso au SOMMET du mur (la sonde anti-encastrement du contrôleur balaie
+		/// depuis le haut et accrochait ce capuchon) = bug « vol contre le mur ».
+		/// wall=true désactive le capuchon (2a) : le mur ne fait plus que bloquer
+		/// horizontalement. (Les props de décor — arbres, coffres — restent
+		/// marchables sur le dessus, eux.)
+		bool wall = false;
 	};
 
 	/// Collisionneur composite : combine un IWorldCollider de terrain (sol + eau) et

--- a/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
+++ b/src/client/gameplay/tests/CharacterControllerStepUpTests.cpp
@@ -119,11 +119,51 @@ namespace
 		// ...et n'a PAS été hissé le long de la paroi (anti-vol) : pieds au sol.
 		REQUIRE(feetY < 0.5f);
 	}
+
+	// Garde du fix « vol contre le mur de bâtiment » : un perso DANS l'empreinte
+	// d'un gros cylindre de mur (wall=true, comme l'auberge) ne doit PAS être
+	// remonté à son sommet par la sonde anti-encastrement du contrôleur. Sans le
+	// flag wall (capuchon marchable), la sonde — qui balaie du haut vers le bas —
+	// accrochait le sommet (topY) et collait le perso à la hauteur du mur.
+	void Test_BuildingWall_NoFloatSnap()
+	{
+		CharacterController::Config cfg{};
+		cfg.gravity = -20.0f;
+		cfg.capsule.height = 1.8f;
+		cfg.capsule.radius = 0.3f;
+		cfg.enableFlying = false;
+		cfg.maxStep = 0.3f;
+		cfg.maxClimb = 3.0f;
+		cfg.maxSlopeDeg = 45.0f;
+
+		CharacterController cc(cfg);
+		const float halfH = cfg.capsule.height * 0.5f;
+		cc.Init(Vec3(0.0f, halfH, 0.0f)); // pieds à y=0, DANS l'empreinte du mur
+
+		FlatFloor floor(0.0f);
+		CompositeWorldCollider world(&floor);
+		// Gros cylindre de mur de 3 m, rayon 3 m (englobant grossier d'une pièce
+		// de bâtiment), centré sur le perso. wall=true => pas de dessus marchable.
+		PropCylinder wall{ 0.0f, 0.0f, 3.0f, 0.0f, 3.0f };
+		wall.wall = true;
+		world.AddCylinder(wall);
+
+		const float dt = 1.0f / 60.0f;
+		MoveInput idle{};
+		for (int i = 0; i < 30; ++i)
+			cc.Update(dt, idle, world);
+
+		const float feetY = cc.GetPosition().y - halfH;
+		std::fprintf(stderr, "[INFO] mur batiment: feetY=%.3f (attendu ~0, PAS remonte a topY=3)\n", feetY);
+		// Reste au sol : la sonde ne l'a pas collé au sommet du mur (sinon feetY ~3).
+		REQUIRE(feetY < 0.5f);
+	}
 }
 
 int main()
 {
 	Test_Wall_NotClimbed_ButReached();
+	Test_BuildingWall_NoFloatSnap();
 	if (g_failed == 0) std::fprintf(stderr, "CharacterControllerStepUpTests: OK\n");
 	return g_failed;
 }

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -141,6 +141,25 @@ int main()
 		check(h && !hit.stair, "mur normal: hit.stair=false");
 	}
 
+	// 9) MUR de bâtiment (wall) — PAS de dessus marchable : un sweep DESCENDANT
+	//    au-dessus de l'empreinte ne s'accroche PAS au sommet (contrairement au
+	//    prop normal, cf. test 4bis). C'est ce qui tue le « vol » : la sonde
+	//    anti-encastrement du contrôleur ne peut plus remonter le perso au sommet
+	//    du mur. Le flanc, lui, bloque toujours horizontalement.
+	{
+		PropCylinder wall = cyl; wall.wall = true;
+		CompositeWorldCollider c(&terrain); c.AddCylinder(wall);
+		// Descente au-dessus du disque : AUCUN capuchon (le prop normal, lui, posait).
+		IWorldCollider::SweepHit down;
+		bool hd = c.SweepCapsule(cap, Vec3{ 5, 20, 0 }, Vec3{ 5, 1, 0 }, down);
+		check(!hd, "mur: pas de dessus marchable (sweep descendant ne s'accroche pas)");
+		// Flanc toujours bloquant : entrée horizontale arrêtée, normale horizontale.
+		IWorldCollider::SweepHit side;
+		bool hs = c.SweepCapsule(cap, Vec3{ 0, 1, 0 }, Vec3{ 10, 1, 0 }, side);
+		check(hs && side.hit, "mur: flanc bloque toujours (hit)");
+		check(std::fabs(side.normal.y) < 1e-3f, "mur: normale de flanc horizontale");
+	}
+
 	// 5) QueryWater délégué au terrain.
 	{
 		CompositeWorldCollider c(&terrain);


### PR DESCRIPTION
## (1) Fix ciblé du « vol contre le mur » de l'auberge

### Diagnostic (validation Lot 5 en jeu)
Le « vol » n'était **pas** le step-up (visé à tort par #917) mais la **collision des bâtiments (#908)** : chaque pièce devient un **gros cylindre englobant** (rayon = empreinte XZ de la pièce). La **sonde anti-encastrement** du `CharacterController` balaie depuis 50 m au-dessus **vers le bas** pour retrouver la hauteur de repos ; sur l'empreinte d'un mur, elle **accroche le capuchon supérieur** (à `topY` = sommet du mur) et **remonte le perso au sommet** = vol. Idem en franchissant la porte (l'embrasure est dans l'empreinte du gros cylindre de mur).

### Fix
`PropCylinder.wall` = **barrière latérale pure** (capuchon `2a` désactivé). Posé sur toutes les pièces de bâtiment **sauf escalier** (`BuildPropFromMeshMatrix`). Les murs ne font plus que bloquer horizontalement → la sonde ne peut plus les escalader. Les **props de décor** (arbres, coffres) gardent leur dessus marchable (#912 intact).

### Tests
- `CompositeWorldColliderTests` : mur = aucun capuchon sur sweep descendant ; flanc bloque toujours.
- `CharacterControllerStepUpTests` : perso dans l'empreinte d'un gros mur reste au sol (pas remonté au sommet).

### ⏳ Suite — chantier (2)
La **porte** reste à finir : le gros cylindre de mur **couvre encore l'embrasure**, donc la traverser proprement demande une collision bâtiment **par pièce plus fine** (mur fin + porte dégagée). → brainstorm collision bâtiments (#908), en cours.

**Déploiement** : ✅ client uniquement.