### PR TITLE
feat(camera): anti-occlusion 3e personne — fondu tramé des props + clamp terrain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,7 @@ add_library(engine_core
   src/client/render/PsoKey.cpp
   src/client/render/PipelineCache.cpp
   src/client/render/GeometryPass.cpp
+  src/client/render/CameraOcclusionFade.cpp
   src/client/render/TerrainChunkPipeline.cpp
   src/client/render/terrain_chunk/ChunkRuntime.cpp
   src/client/render/terrain_chunk/DescriptorSetPool.cpp

--- a/docs/superpowers/plans/2026-06-21-camera-occlusion-fade.md
+++ b/docs/superpowers/plans/2026-06-21-camera-occlusion-fade.md
@@ -446,8 +446,11 @@ comportement inchangé.)
 
 - [ ] **Step 3 : `GeometryPass.h` — ajouter `float fade` à `Record`**
 
-Dans la signature de `Record` (lignes 46-53), ajouter un paramètre `float fade = 1.0f`
-juste après `uint32_t materialIndex = 0,` :
+Dans la signature de `Record` (lignes 46-53), ajouter `float fade = 1.0f` en **DERNIER
+paramètre** (après `bool loadExistingGbuffer`). ⚠️ Ne PAS l'insérer avant
+`loadExistingGbuffer` : un appelant existant ([Engine.cpp:5488](src/client/app/Engine.cpp))
+passe un `bool` (`terrainBeforeGeometry`) en dernier argument positionnel ; le mettre en
+dernier avec un défaut `1.0f` laisse tous les appels actuels inchangés.
 
 ```cpp
 		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
@@ -457,16 +460,16 @@ juste après `uint32_t materialIndex = 0,` :
 		            VkDescriptorSet materialDescriptorSet = VK_NULL_HANDLE,
 		            const float* instanceMatrix = nullptr,
 		            uint32_t materialIndex = 0,
-		            float fade = 1.0f,
-		            bool loadExistingGbuffer = false);
+		            bool loadExistingGbuffer = false,
+		            float fade = 1.0f);
 ```
 
 - [ ] **Step 4 : `GeometryPass.cpp` — propager `fade` dans `Record`**
 
 Mettre à jour la **définition** de `Record` pour accepter le même paramètre
-`float fade = 1.0f` (même position, juste avant `bool loadExistingGbuffer`), puis dans
-le corps de `Record` (au site push-constant ~ligne 669) ajouter après
-`pushConstants.materialIndex = materialIndex;` :
+`float fade = 1.0f` **en dernier** (après `bool loadExistingGbuffer`, identique à la
+déclaration), puis dans le corps de `Record` (au site push-constant ~ligne 669) ajouter
+après `pushConstants.materialIndex = materialIndex;` :
 
 ```cpp
 		pushConstants.fade = fade;
@@ -644,15 +647,15 @@ Dans `RecordPropsGeometry`, rendre l'index de prop disponible et passer le fondu
 				/* ... params inchangés jusqu'à materialIndex ... */
 				prop.modelMatrix.m,
 				highlight ? part.highlightMaterialIndex : part.materialIndex,
-				fade,          // <-- nouveau : fondu d'occlusion de ce prop
-				true);         // loadExistingGbuffer
+				true,          // loadExistingGbuffer (inchangé)
+				fade);         // <-- nouveau : fondu d'occlusion de ce prop (DERNIER param)
 		}
 	}
 ```
 
 > Conserver tel quel le reste du corps de la boucle (sélection LOD/impostor, etc.).
 > Seuls changent : l'itération indexée, le calcul `fade`, et l'argument `fade` ajouté à
-> `geom.Record` (juste avant le `true` final `loadExistingGbuffer`). L'index `propIndex`
+> `geom.Record` **en dernier** (après `true` = `loadExistingGbuffer`). L'index `propIndex`
 > est exactement l'`id` utilisé en Step 4 → correspondance garantie.
 
 - [ ] **Step 6 : Vérifier (CI) — build client OK**

--- a/docs/superpowers/plans/2026-06-21-camera-occlusion-fade.md
+++ b/docs/superpowers/plans/2026-06-21-camera-occlusion-fade.md
@@ -1,0 +1,693 @@
+# Anti-occlusion caméra — fondu tramé + clamp terrain — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Quand un prop ou un mur de bâtiment passe entre la caméra et le joueur, le
+fondre (transparence tramée) pour garder le perso visible ; empêcher la caméra de
+passer sous le terrain.
+
+**Architecture:** Nouveau module math pur `CameraOcclusionFade` (testable hors Vulkan)
+qui calcule un fondu lissé par objet. Le fondu est poussé au G-buffer via un champ
+`fade` ajouté au push-constant partagé (réutilise un padding → taille 144 o inchangée),
+et le fragment shader `gbuffer_geometry.frag` applique un screen-door dither. `Engine`
+collecte les occulteurs depuis `m_props`, appelle le module chaque frame, transmet le
+fondu par-prop à `GeometryPass::Record`, et clampe `camera.y` au-dessus du sol.
+
+**Tech Stack:** C++17, Vulkan (deferred G-buffer), GLSL→SPIR-V (compilé par la CI),
+`engine::core::Config`, ctest via `lcdlln_add_simple_test`. **100 % client.**
+
+Spec de référence : [docs/superpowers/specs/2026-06-21-camera-occlusion-fade-design.md](2026-06-21-camera-occlusion-fade-design.md).
+
+**Contraintes repo :** PascalCase pour nouveaux fichiers/classes ; commentaires en
+français ; pas de toolchain locale (build/ctest via CI) ; les `.spv` ne sont pas
+versionnés (la CI recompile le GLSL). Module **client-only** (pas d'ajout à server_app).
+
+---
+
+## File Structure
+
+| Fichier | Rôle |
+|---|---|
+| `src/client/render/CameraOcclusionFade.h` (créer) | Interface du module : `OccluderSphere`, `Config`, `CameraOcclusionFade` |
+| `src/client/render/CameraOcclusionFade.cpp` (créer) | Logique : cible de fondu par occulteur + lissage temporel + purge |
+| `src/client/render/tests/CameraOcclusionFadeTests.cpp` (créer) | ctest math pur (9 cas) |
+| `src/CMakeLists.txt` (modifier) | Enregistrer le test ; ajouter le .cpp au target client |
+| `game/data/shaders/gbuffer_geometry.frag` (modifier) | Champ `fade` + screen-door dither |
+| `src/client/render/GeometryPass.cpp` (modifier) | `padding0`→`fade` ; param `fade` de `Record` |
+| `src/client/render/GeometryPass.h` (modifier) | Signature de `Record` (+ `float fade`) |
+| `src/client/render/skinned/SkinnedRenderer.cpp` (modifier) | `fade=1.0f` (avatar jamais fondu) |
+| `src/client/app/Engine.h` (modifier) | Membre `m_cameraOcclusionFade` ; champs occulteur dans `PropRenderable` |
+| `src/client/app/Engine.cpp` (modifier) | Init module, collecte occulteurs, fondu par-prop, clamp terrain, config |
+
+---
+
+## Task 1 : Module `CameraOcclusionFade` (+ tests)
+
+**Files:**
+- Create: `src/client/render/CameraOcclusionFade.h`
+- Create: `src/client/render/CameraOcclusionFade.cpp`
+- Test: `src/client/render/tests/CameraOcclusionFadeTests.cpp`
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1 : Écrire le header**
+
+Créer `src/client/render/CameraOcclusionFade.h` :
+
+```cpp
+#pragma once
+
+#include "src/shared/math/Math.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::render
+{
+	/// Sphère englobante d'un occulteur potentiel (prop, pièce de bâtiment).
+	struct OccluderSphere
+	{
+		std::uint32_t id = 0;         ///< identifiant stable de l'objet (clé de suivi du fondu)
+		engine::math::Vec3 center{};  ///< centre monde de la sphère
+		float radius = 0.5f;          ///< rayon monde (m)
+	};
+
+	/// Calcule, par frame, un facteur de fondu (transparence tramée) pour chaque
+	/// objet occultant la vue entre la caméra et le joueur, avec lissage temporel.
+	/// Math pure (aucune dépendance Vulkan) → testable en ctest.
+	class CameraOcclusionFade
+	{
+	public:
+		struct Config
+		{
+			float fadeMin = 0.15f;            ///< opacité mini au cœur de l'occlusion (0 = invisible)
+			float radiusMargin = 0.5f;        ///< marge ajoutée au rayon pour la transition (m)
+			float fadeInPerSec = 6.0f;        ///< vitesse de retour vers l'opaque (1.0)
+			float fadeOutPerSec = 8.0f;       ///< vitesse de passage vers fadeMin
+			float playerProtectRadius = 0.6f; ///< occulteur à moins de ça du joueur : jamais fondu
+		};
+
+		/// Configure le module (réinitialise l'état de fondu).
+		void Init(const Config& cfg);
+
+		/// Met à jour les fondus. \p occluders est reconstruite chaque frame ;
+		/// \p focusPoint = point regardé (tête joueur) ; \p dt en secondes.
+		/// Effet de bord : met à jour la table interne id→fondu.
+		void Update(const engine::math::Vec3& cameraPos,
+			const engine::math::Vec3& focusPoint,
+			const std::vector<OccluderSphere>& occluders,
+			float dt);
+
+		/// Fondu lissé courant d'un objet ; 1.0 (opaque) si l'id est inconnu.
+		float FadeFor(std::uint32_t id) const;
+
+	private:
+		Config m_cfg{};
+		std::unordered_map<std::uint32_t, float> m_fade; ///< id -> fondu lissé ∈ [fadeMin,1]
+	};
+}
+```
+
+- [ ] **Step 2 : Écrire les tests (ils ne compilent pas encore — pas de .cpp)**
+
+Créer `src/client/render/tests/CameraOcclusionFadeTests.cpp` :
+
+```cpp
+#include "src/client/render/CameraOcclusionFade.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using engine::render::CameraOcclusionFade;
+using engine::render::OccluderSphere;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_fail = 0;
+	void check(bool cond, const char* msg)
+	{ if (!cond) { std::printf("FAIL: %s\n", msg); ++g_fail; } }
+
+	CameraOcclusionFade::Config DefaultCfg()
+	{
+		CameraOcclusionFade::Config c{};
+		c.fadeMin = 0.15f; c.radiusMargin = 0.5f;
+		c.fadeInPerSec = 6.0f; c.fadeOutPerSec = 8.0f;
+		c.playerProtectRadius = 0.6f;
+		return c;
+	}
+
+	// Fait converger le lissage : N updates de dt fixe avec la même scène.
+	float Converge(CameraOcclusionFade& f, const Vec3& cam, const Vec3& focus,
+		const std::vector<OccluderSphere>& occ, std::uint32_t id, int frames, float dt)
+	{
+		for (int i = 0; i < frames; ++i) f.Update(cam, focus, occ, dt);
+		return f.FadeFor(id);
+	}
+}
+
+int main()
+{
+	const Vec3 cam{ 0, 0, 0 };
+	const Vec3 focus{ 10, 0, 0 };
+
+	// 1) Occulteur pile sur le segment, au centre -> converge vers fadeMin.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 1, Vec3{ 5, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 1, 100, 0.1f);
+		check(std::fabs(v - 0.15f) < 0.02f, "1: coeur d'occlusion -> fadeMin");
+	}
+
+	// 2) Occulteur derrière le joueur (proj > segLen) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 2, Vec3{ 12, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 2, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "2: derriere le joueur -> opaque");
+	}
+
+	// 3) Occulteur derrière la caméra (proj < 0) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 3, Vec3{ -2, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 3, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "3: derriere la camera -> opaque");
+	}
+
+	// 4) Occulteur latéral (d > radius+margin) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 4, Vec3{ 5, 0, 3 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 4, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "4: lateral hors zone -> opaque");
+	}
+
+	// 5) Zone de transition : fade strictement entre fadeMin et 1.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		// d=0.75, r0=0.5, r1=1.0 -> target = 0.15 + 0.85*0.5 = 0.575.
+		std::vector<OccluderSphere> occ{ { 5, Vec3{ 5, 0, 0.75f }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 5, 100, 0.1f);
+		check(v > 0.16f && v < 0.99f, "5: transition -> fade intermediaire");
+		check(std::fabs(v - 0.575f) < 0.03f, "5: transition -> valeur attendue ~0.575");
+	}
+
+	// 6) Garde joueur : occulteur collé au joueur -> jamais fondu.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 6, Vec3{ 9.8f, 0, 0 }, 0.5f } }; // |toFocus|=0.2<0.6
+		const float v = Converge(f, cam, focus, occ, 6, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "6: garde joueur -> opaque");
+	}
+
+	// 7) Lissage : un seul petit dt ne saute pas directement à fadeMin.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 7, Vec3{ 5, 0, 0 }, 0.5f } };
+		f.Update(cam, focus, occ, 0.01f); // 1 - 8*0.01 = 0.92
+		const float v = f.FadeFor(7);
+		check(v > 0.15f + 0.01f && v < 1.0f, "7: lissage progressif (pas de saut)");
+	}
+
+	// 8) Purge : occulteur présent puis absent -> revient à 1.0 et FadeFor=1.0.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 8, Vec3{ 5, 0, 0 }, 0.5f } };
+		Converge(f, cam, focus, occ, 8, 100, 0.1f); // converge à fadeMin
+		const float back = Converge(f, cam, focus, {}, 8, 100, 0.1f); // plus d'occulteur
+		check(std::fabs(back - 1.0f) < 1e-3f, "8: purge -> revient opaque");
+	}
+
+	// 9) Id inconnu -> 1.0.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		check(std::fabs(f.FadeFor(999) - 1.0f) < 1e-6f, "9: inconnu -> opaque");
+	}
+
+	if (g_fail == 0) std::printf("CameraOcclusionFadeTests: OK\n");
+	return g_fail == 0 ? 0 : 1;
+}
+```
+
+- [ ] **Step 3 : Écrire l'implémentation**
+
+Créer `src/client/render/CameraOcclusionFade.cpp` :
+
+```cpp
+#include "src/client/render/CameraOcclusionFade.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::render
+{
+	namespace
+	{
+		float Dot(const engine::math::Vec3& a, const engine::math::Vec3& b)
+		{ return a.x * b.x + a.y * b.y + a.z * b.z; }
+
+		float Length(const engine::math::Vec3& v)
+		{ return std::sqrt(Dot(v, v)); }
+
+		float Clamp01(float v)
+		{ return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); }
+	}
+
+	void CameraOcclusionFade::Init(const Config& cfg)
+	{
+		m_cfg = cfg;
+		m_fade.clear();
+	}
+
+	void CameraOcclusionFade::Update(const engine::math::Vec3& cameraPos,
+		const engine::math::Vec3& focusPoint,
+		const std::vector<OccluderSphere>& occluders,
+		float dt)
+	{
+		if (dt < 0.0f) dt = 0.0f;
+
+		const engine::math::Vec3 seg = focusPoint - cameraPos;
+		const float segLen = Length(seg);
+		const engine::math::Vec3 dir = (segLen > 1e-4f)
+			? engine::math::Vec3{ seg.x / segLen, seg.y / segLen, seg.z / segLen }
+			: engine::math::Vec3{ 0.0f, 0.0f, 1.0f };
+
+		// Nouvelle table : on n'y garde que les ids encore "vivants" (vus cette
+		// frame, ou en train de revenir à l'opaque). Évite la croissance mémoire.
+		std::unordered_map<std::uint32_t, float> next;
+		next.reserve(occluders.size());
+
+		for (const auto& occ : occluders)
+		{
+			float target = 1.0f; // opaque par défaut
+
+			// Garde joueur : occulteur collé au joueur -> jamais fondu.
+			const float distToFocus = Length(occ.center - focusPoint);
+			if (distToFocus >= m_cfg.playerProtectRadius)
+			{
+				// Projection sur le segment caméra->joueur.
+				const engine::math::Vec3 toOcc = occ.center - cameraPos;
+				const float proj = Dot(toOcc, dir);
+				if (segLen > 1e-4f && proj > 0.0f && proj < segLen)
+				{
+					const engine::math::Vec3 closest{
+						cameraPos.x + dir.x * proj,
+						cameraPos.y + dir.y * proj,
+						cameraPos.z + dir.z * proj };
+					const float d = Length(occ.center - closest);
+					const float r0 = occ.radius;
+					const float r1 = occ.radius + m_cfg.radiusMargin;
+					if (d <= r0)
+						target = m_cfg.fadeMin;
+					else if (d < r1)
+						target = m_cfg.fadeMin + (1.0f - m_cfg.fadeMin) * ((d - r0) / (r1 - r0));
+					// d >= r1 -> target reste 1.0
+				}
+			}
+
+			float current = 1.0f;
+			auto it = m_fade.find(occ.id);
+			if (it != m_fade.end()) current = it->second;
+
+			if (target < current)
+				current = std::max(target, current - m_cfg.fadeOutPerSec * dt);
+			else if (target > current)
+				current = std::min(target, current + m_cfg.fadeInPerSec * dt);
+
+			next[occ.id] = Clamp01(current);
+		}
+
+		// Ids non vus cette frame : on les ramène vers l'opaque ; une fois ~opaques
+		// on les laisse tomber (purge) pour que FadeFor renvoie 1.0 par défaut.
+		for (const auto& kv : m_fade)
+		{
+			if (next.find(kv.first) != next.end()) continue;
+			const float current = std::min(1.0f, kv.second + m_cfg.fadeInPerSec * dt);
+			if (current < 1.0f - 1e-3f)
+				next[kv.first] = current;
+		}
+
+		m_fade.swap(next);
+	}
+
+	float CameraOcclusionFade::FadeFor(std::uint32_t id) const
+	{
+		auto it = m_fade.find(id);
+		return (it != m_fade.end()) ? it->second : 1.0f;
+	}
+}
+```
+
+- [ ] **Step 4 : Enregistrer le test + ajouter le .cpp au client dans `src/CMakeLists.txt`**
+
+Repérer la ligne existante qui enregistre `CompositeWorldColliderTests` (recherche
+`composite_world_collider` ou `CompositeWorldColliderTests`) et, juste après, ajouter
+le même style d'enregistrement :
+
+```cmake
+lcdlln_add_simple_test(camera_occlusion_fade_tests
+    src/client/render/tests/CameraOcclusionFadeTests.cpp
+    src/client/render/CameraOcclusionFade.cpp)
+```
+
+Puis ajouter `src/client/render/CameraOcclusionFade.cpp` à la **liste des sources du
+target client** (là où figurent `src/client/render/GeometryPass.cpp` et les autres
+`src/client/render/*.cpp`), pour que le jeu le linke.
+
+- [ ] **Step 5 : Vérifier (CI) — les tests passent**
+
+Pousser la branche ; sur la CI, le job `build-linux` exécute ctest. Attendu :
+`camera_occlusion_fade_tests` → `CameraOcclusionFadeTests: OK`, 9/9 cas verts.
+(Pas de toolchain locale : la validation des tests passe par la CI.)
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add src/client/render/CameraOcclusionFade.h src/client/render/CameraOcclusionFade.cpp \
+        src/client/render/tests/CameraOcclusionFadeTests.cpp src/CMakeLists.txt
+git commit -m "feat(camera): module CameraOcclusionFade (fondu occlusion + tests)"
+```
+
+---
+
+## Task 2 : Champ `fade` dans le push-constant + dither shader
+
+**Files:**
+- Modify: `game/data/shaders/gbuffer_geometry.frag`
+- Modify: `src/client/render/GeometryPass.cpp:19-27` (struct) + `:46-53`/`:669`/`:789`/`:1061`
+- Modify: `src/client/render/GeometryPass.h:46-53` (signature `Record`)
+- Modify: `src/client/render/skinned/SkinnedRenderer.cpp:633-641` (struct) + sites de push
+
+> ⚠️ Le fragment shader est **partagé** entre `GeometryPass` (props/bâtiments) et
+> `SkinnedRenderer` (avatar). Le layout binaire du push-constant doit rester identique
+> (144 o). On réutilise le **1er padding** (offset 132) comme `float fade`. Sans mise à
+> jour de `SkinnedRenderer`, le slot vaudrait 0 → **avatar tramé/invisible** : c'est
+> pourquoi l'étape SkinnedRenderer est obligatoire.
+
+- [ ] **Step 1 : Shader — déclarer `fade` et ajouter le screen-door dither**
+
+Dans `game/data/shaders/gbuffer_geometry.frag`, remplacer le bloc push_constant
+(lignes 33-40) par (renomme `_pad0` en `fade`) :
+
+```glsl
+layout(push_constant) uniform PushConstants {
+    mat4 prevViewProj;
+    mat4 viewProj;
+    uint materialIndex;
+    float fade;     // 1.0 = opaque (anti-occlusion caméra)
+    uint _pad1;
+    uint _pad2;
+} pc;
+```
+
+Puis, tout en haut de `main()` (juste après `void main() {`), avant la lecture du
+matériau, ajouter :
+
+```glsl
+    // Anti-occlusion caméra : transparence tramée (screen-door). fade=1 -> rien.
+    if (pc.fade < 0.999) {
+        const float bayer[16] = float[16](
+            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
+            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0);
+        ivec2 p = ivec2(gl_FragCoord.xy) & 3;
+        if (pc.fade < bayer[p.y * 4 + p.x])
+            discard;
+    }
+```
+
+(Les `.spv` ne sont pas versionnés : la CI recompile via `compile_game_shaders.ps1`.)
+
+- [ ] **Step 2 : `GeometryPass.cpp` — renommer le padding en `fade`**
+
+Dans la struct `GeometryPushConstants` (lignes 19-27), remplacer `uint32_t padding0 = 0;`
+par `float fade = 1.0f;` :
+
+```cpp
+		struct GeometryPushConstants
+		{
+			float prevViewProj[16]{};
+			float viewProj[16]{};
+			uint32_t materialIndex = 0;
+			float    fade = 1.0f;   // 1.0 = opaque (anti-occlusion caméra)
+			uint32_t padding1 = 0;
+			uint32_t padding2 = 0;
+		};
+```
+
+(`kPushConstantSize` reste `144u`. Les sites `RecordInstanced`/`RecordIndirect`
+construisent `GeometryPushConstants pushConstants{};` → `fade` vaut 1.0 par défaut,
+comportement inchangé.)
+
+- [ ] **Step 3 : `GeometryPass.h` — ajouter `float fade` à `Record`**
+
+Dans la signature de `Record` (lignes 46-53), ajouter un paramètre `float fade = 1.0f`
+juste après `uint32_t materialIndex = 0,` :
+
+```cpp
+		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
+		            ResourceId idA, ResourceId idB, ResourceId idC, ResourceId idVelocity, ResourceId idDepth,
+		            const float* prevViewProjMat4, const float* viewProjMat4, const MeshAsset* mesh,
+		            uint32_t lodLevel = 0,
+		            VkDescriptorSet materialDescriptorSet = VK_NULL_HANDLE,
+		            const float* instanceMatrix = nullptr,
+		            uint32_t materialIndex = 0,
+		            float fade = 1.0f,
+		            bool loadExistingGbuffer = false);
+```
+
+- [ ] **Step 4 : `GeometryPass.cpp` — propager `fade` dans `Record`**
+
+Mettre à jour la **définition** de `Record` pour accepter le même paramètre
+`float fade = 1.0f` (même position, juste avant `bool loadExistingGbuffer`), puis dans
+le corps de `Record` (au site push-constant ~ligne 669) ajouter après
+`pushConstants.materialIndex = materialIndex;` :
+
+```cpp
+		pushConstants.fade = fade;
+```
+
+(Ne pas toucher `RecordInstanced`/`RecordIndirect` : `fade` y reste 1.0 par défaut.)
+
+- [ ] **Step 5 : `SkinnedRenderer.cpp` — forcer `fade=1.0f` (avatar jamais fondu)**
+
+Dans la struct locale `PushConstants` (lignes 633-641), remplacer le 1er champ de
+padding (celui à l'offset 132, juste après `uint32_t materialIndex;`) par
+`float fade;`, en conservant `static_assert(sizeof(PushConstants) == 144, ...)`. Par
+ex. :
+
+```cpp
+	struct PushConstants {
+		float prevViewProj[16];
+		float viewProj[16];
+		uint32_t materialIndex;
+		float    fade;      // toujours 1.0 : l'avatar n'est jamais fondu
+		uint32_t _pad1;
+		uint32_t _pad2;
+	};
+	static_assert(sizeof(PushConstants) == 144, "PushConstants must match shader layout");
+```
+
+Puis, là où `pc` est initialisé (avant les `vkCmdPushConstants`, sites ~679 et ~688),
+poser explicitement `pc.fade = 1.0f;` (une fois après la construction de `pc` suffit si
+`pc` est réutilisé ; sinon le poser à chaque site). Vérifier que `pc` est bien
+zéro-initialisé ailleurs et que `fade` n'est jamais laissé à 0.
+
+> Si d'autres champs de la struct portent déjà des noms (`prevViewProj`/`viewProj`),
+> garder l'ordre exact existant ; seul le **1er padding** devient `fade`. L'important :
+> offset 132 = `fade` = 1.0f, identique au layout de `GeometryPushConstants` et du shader.
+
+- [ ] **Step 6 : Vérifier (CI) — build + compilation shader OK**
+
+Pousser ; la CI doit : compiler le GLSL (`gbuffer_geometry.frag` → `.spv`) sans erreur,
+et builder client. Pas de test unitaire ici (chemin GPU) — validation visuelle en
+Task 3.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add game/data/shaders/gbuffer_geometry.frag src/client/render/GeometryPass.h \
+        src/client/render/GeometryPass.cpp src/client/render/skinned/SkinnedRenderer.cpp
+git commit -m "feat(render): push-constant fade + screen-door dither (avatar opaque)"
+```
+
+---
+
+## Task 3 : Intégration `Engine` — occulteurs, fondu par-prop, clamp terrain
+
+**Files:**
+- Modify: `src/client/app/Engine.h:889-910` (PropRenderable + membre module)
+- Modify: `src/client/app/Engine.cpp` : bake props (~13248 `BuildPropFromMesh`,
+  ~14019 `BuildPropFromMeshMatrix`), boucle Update (~9895), `RecordPropsGeometry`
+  (~14317), init (où les autres systèmes s'initialisent)
+
+- [ ] **Step 1 : `Engine.h` — champs occulteur + membre module**
+
+Dans `struct PropRenderable` (lignes 889-907), ajouter :
+
+```cpp
+		engine::math::Vec3 occluderCenter{ 0.0f, 0.0f, 0.0f }; ///< centre monde sphère englobante (anti-occlusion)
+		float occluderRadius = 0.0f;                            ///< rayon monde ; 0 = non occulteur
+```
+
+Ajouter l'include en tête de `Engine.h` (près des autres render includes) :
+
+```cpp
+#include "src/client/render/CameraOcclusionFade.h"
+```
+
+Et un membre (près de `m_orbitalCameraController`, ligne ~1537) :
+
+```cpp
+		engine::render::CameraOcclusionFade m_cameraOcclusionFade;
+```
+
+- [ ] **Step 2 : Calculer la sphère englobante au bake des props**
+
+Dans `BuildPropFromMesh` (~13248) **et** `BuildPropFromMeshMatrix` (~14019), repérer la
+boucle qui calcule les positions de sommets **en espace monde** (les sommets « cuits »).
+Y suivre min/max, et après la boucle, renseigner le prop :
+
+```cpp
+		// (avant la boucle de bake des sommets)
+		engine::math::Vec3 bbMin{ 1e30f, 1e30f, 1e30f };
+		engine::math::Vec3 bbMax{ -1e30f, -1e30f, -1e30f };
+		// (dans la boucle, pour chaque position monde `p`)
+		bbMin.x = std::min(bbMin.x, p.x); bbMin.y = std::min(bbMin.y, p.y); bbMin.z = std::min(bbMin.z, p.z);
+		bbMax.x = std::max(bbMax.x, p.x); bbMax.y = std::max(bbMax.y, p.y); bbMax.z = std::max(bbMax.z, p.z);
+		// (après la boucle, une fois `prop` construit)
+		prop.occluderCenter = engine::math::Vec3{
+			(bbMin.x + bbMax.x) * 0.5f, (bbMin.y + bbMax.y) * 0.5f, (bbMin.z + bbMax.z) * 0.5f };
+		const engine::math::Vec3 ext{ bbMax.x - bbMin.x, bbMax.y - bbMin.y, bbMax.z - bbMin.z };
+		prop.occluderRadius = 0.5f * std::sqrt(ext.x * ext.x + ext.y * ext.y + ext.z * ext.z);
+```
+
+> Si la fonction ne réitère pas explicitement les sommets monde (ex. transform appliqué
+> en lot), utiliser à la place les bornes du `MeshAsset` baké : `mesh->localBoundsMin`
+> / `mesh->localBoundsMax` (qui, pour un prop aux sommets cuits en monde, sont déjà en
+> espace monde) pour remplir `occluderCenter`/`occluderRadius` de la même façon. Garder
+> `<algorithm>` et `<cmath>` inclus dans Engine.cpp (déjà le cas).
+
+- [ ] **Step 3 : Initialiser le module (lecture config)**
+
+Là où les sous-systèmes s'initialisent au boot (près de l'init caméra / gameplay),
+ajouter :
+
+```cpp
+		engine::render::CameraOcclusionFade::Config occCfg{};
+		occCfg.fadeMin             = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_min", 0.15));
+		occCfg.radiusMargin        = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.radius_margin", 0.5));
+		occCfg.fadeInPerSec        = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_in_per_sec", 6.0));
+		occCfg.fadeOutPerSec       = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_out_per_sec", 8.0));
+		occCfg.playerProtectRadius = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.player_protect_radius", 0.6));
+		m_cameraOcclusionFade.Init(occCfg);
+```
+
+- [ ] **Step 4 : Mettre à jour le fondu + clamper le terrain (boucle Update, ~9895)**
+
+Juste après `m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook, out.camera);`
+(ligne ~9895), ajouter :
+
+```cpp
+				// --- Clamp anti-sous-sol : la caméra ne descend pas sous le terrain. ---
+				const bool occEnabled = m_cfg.GetBool("client.camera.occlusion_fade.enabled", true);
+				const float clampMargin = static_cast<float>(
+					m_cfg.GetDouble("client.camera.terrain_clamp_margin", 0.5));
+				const float groundY = m_terrain.SampleHeightAtWorldXZ(
+					out.camera.position.x, out.camera.position.z);
+				const float minCamY = groundY + clampMargin;
+				if (out.camera.position.y < minCamY)
+					out.camera.position.y = minCamY;
+
+				// --- Fondu d'occlusion : collecte des occulteurs (props + bâtiments). ---
+				if (occEnabled)
+				{
+					std::vector<engine::render::OccluderSphere> occluders;
+					occluders.reserve(m_props.size());
+					for (std::size_t i = 0; i < m_props.size(); ++i)
+					{
+						const auto& prop = m_props[i];
+						if (prop.occluderRadius <= 0.0f) continue;
+						occluders.push_back({ static_cast<std::uint32_t>(i),
+							prop.occluderCenter, prop.occluderRadius });
+					}
+					const engine::math::Vec3 focus = m_orbitalCameraController.GetTargetPosition();
+					m_cameraOcclusionFade.Update(out.camera.position, focus,
+						occluders, static_cast<float>(dt));
+				}
+```
+
+> Vérifier le nom exact du membre TerrainRenderer (`m_terrain`, cf. `m_terrain.Record`
+> ligne 5441) et que `SampleHeightAtWorldXZ` est public (il l'est :
+> `TerrainRenderer.h:185`). `dt` est disponible dans cette fonction (déjà passé à
+> `m_orbitalCameraController.Update`).
+
+- [ ] **Step 5 : Appliquer le fondu par-prop dans `RecordPropsGeometry` (~14317)**
+
+Dans `RecordPropsGeometry`, rendre l'index de prop disponible et passer le fondu à
+`Record`. Remplacer la boucle `for (const auto& prop : m_props)` par une boucle indexée :
+
+```cpp
+	for (std::size_t propIndex = 0; propIndex < m_props.size(); ++propIndex)
+	{
+		const auto& prop = m_props[propIndex];
+		const float fade = m_cameraOcclusionFade.FadeFor(static_cast<std::uint32_t>(propIndex));
+		// ... (culling distance / impostor inchangés) ...
+		for (const auto& part : prop.parts)
+		{
+			geom.Record(
+				/* ... params inchangés jusqu'à materialIndex ... */
+				prop.modelMatrix.m,
+				highlight ? part.highlightMaterialIndex : part.materialIndex,
+				fade,          // <-- nouveau : fondu d'occlusion de ce prop
+				true);         // loadExistingGbuffer
+		}
+	}
+```
+
+> Conserver tel quel le reste du corps de la boucle (sélection LOD/impostor, etc.).
+> Seuls changent : l'itération indexée, le calcul `fade`, et l'argument `fade` ajouté à
+> `geom.Record` (juste avant le `true` final `loadExistingGbuffer`). L'index `propIndex`
+> est exactement l'`id` utilisé en Step 4 → correspondance garantie.
+
+- [ ] **Step 6 : Vérifier (CI) — build client OK**
+
+Pousser ; la CI doit builder client sans erreur (signatures `Record` cohérentes,
+includes en place).
+
+- [ ] **Step 7 : Validation en jeu (manuelle, utilisateur)**
+
+- Entrer dans l'auberge, tourner la caméra derrière un mur → le mur se **trame** et le
+  perso reste visible ; en s'éloignant, le mur **redevient opaque** en douceur.
+- Reculer la caméra dans une pente / coller un mur → la caméra ne **plonge plus sous le
+  sol** (1re capture corrigée).
+- L'avatar n'est **jamais** tramé.
+- Réglages possibles sans recompiler via `config.json` :
+  `client.camera.occlusion_fade.fade_min` (opacité résiduelle), `radius_margin`,
+  `fade_out_per_sec` / `fade_in_per_sec`, `client.camera.terrain_clamp_margin`.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(camera): occlusion fade par-prop + clamp terrain (config client.camera.*)"
+```
+
+---
+
+## Notes de déploiement
+
+✅ **Client uniquement** — rendu + caméra. Aucun opcode, payload, handler ni migration.
+**Pas de redéploiement serveur.**
+
+## Récapitulatif des tâches
+
+1. **Task 1** — Module `CameraOcclusionFade` + 9 tests ctest (math pur). *Testable CI.*
+2. **Task 2** — `fade` dans push-constant (144 o inchangé) + dither shader + avatar opaque. *Build/compil shader CI.*
+3. **Task 3** — Intégration Engine : sphères englobantes au bake, collecte occulteurs,
+   fondu par-prop, clamp terrain, config. *Build CI + validation en jeu.*

--- a/docs/superpowers/specs/2026-06-21-camera-occlusion-fade-design.md
+++ b/docs/superpowers/specs/2026-06-21-camera-occlusion-fade-design.md
@@ -1,0 +1,283 @@
+# Anti-occlusion caméra — fondu tramé des props + clamp terrain
+
+> Design validé le 2026-06-21. Chantier **100 % client** (rendu/caméra). Indépendant
+> du chantier collision bâtiments (#919 / building-collision-catalog).
+
+## Problème
+
+En vue 3e personne, quand un élément du décor (mur de l'auberge, prop) ou le terrain
+passe **entre le joueur et la caméra**, il bouche la vue et gâche l'expérience
+(constaté en jeu, 2 captures : caméra sous le terrain ; mur d'auberge plein écran).
+
+### Cause racine
+
+Il existe **deux** caméras 3e personne dans le code :
+
+- `engine::gameplay::ThirdPersonCamera` (`src/client/gameplay/ThirdPersonCamera.cpp`)
+  possède un anti-occlusion complet (`SweepSphere` tête→caméra) **mais n'est jamais
+  instanciée** dans `Engine`.
+- `engine::render::OrbitalCameraController` (`src/client/render/Camera.cpp`) est la
+  caméra **réellement utilisée en jeu** (`Engine::m_orbitalCameraController`) et fait
+  un simple `position = cible − direction × distance`, **sans aucun test de
+  collision** (le commentaire `Camera.cpp:228` l'avoue : « la collision camera-decor
+  … reviendra … un futur module collision camera »).
+
+On comble ce manque, sans réveiller `ThirdPersonCamera` (swap d'API risqué pour le
+mouvement, qui dépend de `GetForwardXZ/GetRightXZ/GetYawRad`).
+
+## Décision de design
+
+Deux traitements complémentaires, choisis avec l'utilisateur :
+
+1. **Props + pièces de bâtiment** (tout ce qui passe par `GeometryPass`) :
+   **fondu tramé** (screen-door / dither) quand l'objet occulte le joueur. Le perso
+   reste visible « à travers » l'obstacle.
+2. **Terrain** : **pas** de transparence (rendrait une colline « trouée » sur le
+   ciel/vide). À la place, un **clamp anti-sous-sol** : la caméra ne descend jamais
+   sous la surface du terrain.
+
+L'avatar du joueur n'est **jamais** fondu.
+
+## Architecture
+
+Tout se passe **côté client**, dans la boucle de frame de `Engine`, **après**
+`m_orbitalCameraController.Update(...)` qui produit `out.camera`.
+
+### Flux par frame
+
+```
+out.camera = OrbitalCameraController.Update(...)          // position caméra brute
+        │
+        ├─ [1] clamp terrain : cam.y = max(cam.y, SampleHeightAtWorldXZ(cam.xz) + marge)
+        │
+        ├─ [2] CameraOcclusionFade.Update(cam.position, focusPoint, occluders, dt)
+        │         → met à jour un fade lissé ∈ [fadeMin, 1] par occulteur
+        │
+        └─ [3] au rendu des props/bâtiments : GeometryPass reçoit le fade par draw
+                  → fragment shader : screen-door discard
+```
+
+### Composant 1 — `CameraOcclusionFade` (nouveau, testable sans Vulkan)
+
+Fichiers : `src/client/render/CameraOcclusionFade.{h,cpp}`.
+
+Rôle : à partir de la position caméra, du point focal (tête joueur) et d'une liste
+d'occulteurs (sphères englobantes monde), calculer un **fade cible** par occulteur,
+puis le **lisser temporellement** vers ce cible.
+
+Type d'entrée (un occulteur) :
+
+```cpp
+struct OccluderSphere
+{
+    std::uint32_t id = 0;   ///< identifiant stable de l'objet (clé de suivi du fade)
+    engine::math::Vec3 center{}; ///< centre monde de la sphère englobante
+    float radius = 0.5f;    ///< rayon monde
+};
+```
+
+Configuration :
+
+```cpp
+struct Config
+{
+    float fadeMin = 0.15f;        ///< opacité minimale d'un occulteur au cœur de l'occlusion (0 = invisible)
+    float radiusMargin = 0.5f;    ///< marge ajoutée au rayon pour la zone de transition (m)
+    float fadeInPerSec = 6.0f;    ///< vitesse de retour à l'opaque (1.0) quand non occultant
+    float fadeOutPerSec = 8.0f;   ///< vitesse de passage vers fadeMin quand occultant
+    float playerProtectRadius = 0.6f; ///< un occulteur dont le centre est à moins de ça du focal n'est pas fondu (évite de fondre ce qui touche le joueur)
+};
+```
+
+API :
+
+```cpp
+class CameraOcclusionFade
+{
+public:
+    void Init(const Config& cfg);
+
+    /// Met à jour les fades. \p occluders : liste reconstruite chaque frame.
+    /// \p dt en secondes. Après l'appel, FadeFor(id) renvoie le fade lissé courant.
+    void Update(const engine::math::Vec3& cameraPos,
+                const engine::math::Vec3& focusPoint,
+                const std::vector<OccluderSphere>& occluders,
+                float dt);
+
+    /// Fade lissé courant d'un objet (1.0 = opaque par défaut si inconnu).
+    float FadeFor(std::uint32_t id) const;
+
+private:
+    Config m_cfg{};
+    std::unordered_map<std::uint32_t, float> m_fade; ///< id -> fade lissé courant
+};
+```
+
+Calcul du fade cible d'un occulteur (par frame) :
+
+1. **Profondeur** : projeter `center` sur le segment `camera → focus`. Soit
+   `t = clamp(dot(center - camera, dir) / segLen, 0, 1)` avec `dir` unitaire et
+   `segLen = |focus - camera|`. Si `t <= 0` ou `t >= 1`, l'objet n'est **pas entre**
+   les deux → cible = 1.0 (opaque).
+2. **Garde joueur** : si `|center - focus| < playerProtectRadius` → cible = 1.0.
+3. **Distance latérale** : `closest = camera + dir * (t * segLen)` ;
+   `d = |center - closest|`. Zone : `r0 = radius` (cœur), `r1 = radius + radiusMargin`
+   (bord).
+   - `d <= r0` → cible = `fadeMin` (occlusion forte).
+   - `d >= r1` → cible = 1.0 (pas d'occlusion).
+   - entre les deux → interpolation linéaire : `cible = lerp(fadeMin, 1, (d - r0)/(r1 - r0))`.
+
+Lissage temporel (par id) :
+
+- vers une cible **plus opaque** (cible > courant) : `courant += fadeInPerSec * dt`,
+  borné à cible.
+- vers une cible **plus transparente** (cible < courant) : `courant -= fadeOutPerSec * dt`,
+  borné à cible.
+- ids absents de `occluders` cette frame : on les fait **revenir à 1.0** au rythme
+  `fadeInPerSec` puis on purge l'entrée une fois à 1.0 (évite la croissance mémoire).
+
+`FadeFor(id)` : renvoie le fade lissé, ou **1.0** si l'id est inconnu.
+
+### Composant 2 — Collecte des occulteurs (`Engine`)
+
+Les occulteurs réutilisent les **données de collision déjà construites** : chaque prop
+a un `PropCylinder` (centre `cx,cz`, `radius`, `baseY..topY`) et chaque pièce de
+bâtiment idem (et, à terme, des `PropBox`). On en dérive une `OccluderSphere` :
+
+- `center = (cx, (baseY+topY)/2, cz)`
+- `radius = max(radius_xz, (topY-baseY)/2)` (sphère englobant le cylindre)
+- `id` = identifiant stable de l'objet (indice de prop / pièce). Cet id doit être
+  **le même** que celui passé au draw `GeometryPass` correspondant, pour relier le
+  fade calculé au bon objet rendu.
+
+Le terrain et l'avatar ne sont **pas** des occulteurs.
+
+> Détail d'implémentation (à câbler dans le plan) : `Engine` tient déjà la liste des
+> props/pièces rendus et leurs transforms. On ajoute, à la construction de ces objets,
+> la mémorisation `(id, OccluderSphere)` ; à chaque frame on rebâtit le `std::vector`
+> d'occulteurs (positions statiques → on peut le bâtir une fois et le réutiliser, mais
+> un rebuild par frame reste trivial pour quelques centaines d'objets).
+
+### Composant 3 — Propagation du fade au rendu (`GeometryPass` + shader)
+
+Push-constants (`GeometryPass.cpp`) : on **réutilise un `uint` de padding** comme
+`float fade`. La taille reste **144 octets**, le `VkPipelineLayout` est **inchangé**.
+
+```cpp
+struct GeometryPushConstants
+{
+    float prevViewProj[16]{};
+    float viewProj[16]{};
+    uint32_t materialIndex = 0;
+    float    fade = 1.0f;   // <-- ex-padding0 : 1.0 = opaque (défaut)
+    uint32_t padding1 = 0;
+    uint32_t padding2 = 0;
+};
+```
+
+Les méthodes de draw de `GeometryPass` gagnent un paramètre `float fade = 1.0f`
+(défaut → comportement actuel pour tous les appelants non modifiés : terrain
+n'utilise pas GeometryPass ; avatar et props non-occultants passent 1.0).
+
+Shader [`game/data/shaders/gbuffer_geometry.frag`] — bloc `push_constant` aligné :
+
+```glsl
+layout(push_constant) uniform PushConstants {
+    mat4 prevViewProj;
+    mat4 viewProj;
+    uint materialIndex;
+    float fade;     // 1.0 = opaque
+    uint _pad1;
+    uint _pad2;
+} pc;
+```
+
+Tout en haut de `main()`, avant le travail coûteux :
+
+```glsl
+// Anti-occlusion : transparence tramée (screen-door). fade=1 -> rien à faire.
+if (pc.fade < 0.999) {
+    // matrice de Bayer 4x4 normalisée (seuils 0/16 .. 15/16)
+    const float bayer[16] = float[16](
+        0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+       12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
+        3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+       15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0);
+    ivec2 p = ivec2(gl_FragCoord.xy) & 3;
+    if (pc.fade < bayer[p.y * 4 + p.x])
+        discard;
+}
+```
+
+Recompilation SPIR-V via la CI (pas de toolchain locale).
+
+### Composant 4 — Clamp terrain (`Engine`)
+
+Après `m_orbitalCameraController.Update(...)`, avant d'utiliser `out.camera` :
+
+```cpp
+const float groundY = m_terrainRenderer.SampleHeightAtWorldXZ(out.camera.position.x,
+                                                              out.camera.position.z);
+const float minCamY = groundY + cfg.terrainClampMargin; // ex. 0.5 m
+if (out.camera.position.y < minCamY)
+    out.camera.position.y = minCamY;
+```
+
+(Le chemin d'accès exact à `SampleHeightAtWorldXZ` — via `m_terrainRenderer` ou un
+accesseur — est à confirmer dans le plan ; la fonction existe et est déjà utilisée
+par `TargetReticleSystem`.)
+
+## Configuration (`config.json`, préfixe `client.camera.*`)
+
+| Clé | Défaut | Rôle |
+|---|---|---|
+| `client.camera.occlusion_fade.enabled` | `true` | Active le fondu tramé |
+| `client.camera.occlusion_fade.fade_min` | `0.15` | Opacité mini d'un occulteur |
+| `client.camera.occlusion_fade.radius_margin` | `0.5` | Marge de transition (m) |
+| `client.camera.occlusion_fade.fade_in_per_sec` | `6.0` | Vitesse retour opaque |
+| `client.camera.occlusion_fade.fade_out_per_sec` | `8.0` | Vitesse passage transparent |
+| `client.camera.occlusion_fade.player_protect_radius` | `0.6` | Rayon de garde joueur (m) |
+| `client.camera.terrain_clamp_margin` | `0.5` | Marge anti-sous-sol (m) |
+
+Lues via `engine::core::Config` (`GetBool/GetDouble`). Valeurs par défaut si absentes →
+rétro-compatible.
+
+## Tests
+
+`src/client/render/tests/CameraOcclusionFadeTests.cpp`, enregistré via
+`lcdlln_add_simple_test` dans `src/CMakeLists.txt`. Aucune dépendance Vulkan (math pur).
+
+Cas couverts :
+
+1. **Occulteur pile sur le segment** caméra→focus, proche → cible = `fadeMin`
+   (après convergence du lissage sur plusieurs `Update`).
+2. **Occulteur derrière le joueur** (`t >= 1`) → reste 1.0 (opaque).
+3. **Occulteur derrière la caméra** (`t <= 0`) → reste 1.0.
+4. **Occulteur latéral** (au-delà de `radius + margin`) → reste 1.0.
+5. **Zone de transition** : `d` entre `r0` et `r1` → fade intermédiaire strictement
+   entre `fadeMin` et 1.
+6. **Garde joueur** : occulteur dont le centre touche le focal → 1.0 (jamais fondu).
+7. **Lissage** : un occulteur qui apparaît ne saute pas instantanément à `fadeMin`
+   (un seul `Update` court ne suffit pas à atteindre la cible) ; après assez de temps,
+   il converge.
+8. **Purge** : un id absent revient à 1.0 puis `FadeFor` renvoie 1.0 (et la map ne
+   grossit pas indéfiniment).
+9. **Inconnu** : `FadeFor(id jamais vu)` = 1.0.
+
+Validation **en jeu** (visuel) : entrer dans l'auberge, faire tourner la caméra
+derrière un mur → le mur se trame et le perso reste visible ; reculer la caméra dans
+une pente → elle ne plonge plus sous le sol.
+
+## Hors périmètre (YAGNI)
+
+- Pas de fondu du terrain (décidé).
+- Pas de vraie transparence triée / alpha-blend (le screen-door suffit en pipeline
+  deferred opaque).
+- Pas de réveil de `ThirdPersonCamera` ni de refonte de la caméra.
+- Pas de fade des PNJ/mobs distants à ce stade (les occulteurs = props + bâtiments ;
+  extensible plus tard si besoin).
+
+## Déploiement
+
+✅ **Client uniquement** — rendu + caméra. Aucun opcode, payload, handler ni migration.
+**Pas de redéploiement serveur.**

--- a/game/data/shaders/gbuffer_geometry.frag
+++ b/game/data/shaders/gbuffer_geometry.frag
@@ -34,7 +34,7 @@ layout(push_constant) uniform PushConstants {
     mat4 prevViewProj;
     mat4 viewProj;
     uint materialIndex;
-    uint _pad0;
+    float fade;     // 1.0 = opaque (anti-occlusion caméra)
     uint _pad1;
     uint _pad2;
 } pc;
@@ -46,6 +46,18 @@ layout(location = 3) out vec4 outVelocity; // GBufferVelocity (M07.3, .rg = curr
 
 void main()
 {
+    // Anti-occlusion caméra : transparence tramée (screen-door). fade=1 -> rien.
+    if (pc.fade < 0.999) {
+        const float bayer[16] = float[16](
+            0.0/16.0,  8.0/16.0,  2.0/16.0, 10.0/16.0,
+           12.0/16.0,  4.0/16.0, 14.0/16.0,  6.0/16.0,
+            3.0/16.0, 11.0/16.0,  1.0/16.0,  9.0/16.0,
+           15.0/16.0,  7.0/16.0, 13.0/16.0,  5.0/16.0);
+        ivec2 p = ivec2(gl_FragCoord.xy) & 3;
+        if (pc.fade < bayer[p.y * 4 + p.x])
+            discard;
+    }
+
     MaterialGpuData mat = uMaterialBuffer.materials[pc.materialIndex];
     vec2 tiledUv = vUv * mat.tiling;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -937,6 +937,13 @@ elseif(UNIX)
   lcdlln_add_simple_test(composite_world_collider_tests
     ${CMAKE_SOURCE_DIR}/src/client/gameplay/tests/CompositeWorldColliderTests.cpp)
 
+  # Anti-occlusion caméra : module math pur CameraOcclusionFade (fondu tramé
+  # par occulteur + lissage temporel + purge). 9 cas : cœur, derrière joueur,
+  # derrière caméra, latéral, transition, garde joueur, lissage, purge, id inconnu.
+  lcdlln_add_simple_test(camera_occlusion_fade_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/tests/CameraOcclusionFadeTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/client/render/CameraOcclusionFade.cpp)
+
   # Lot 5 (anti-vol step-up) : un mur (prop normal) n'est PAS escaladable
   # (step-up plafonne a maxStep) alors qu'un escalier (PropCylinder::stair) reste
   # gravissable (step-up jusqu'a maxClimb). Integre controller + collider a 60 Hz.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1216,6 +1216,18 @@ namespace engine
 	// The definitions JSON path defaults to "lights/dynamic_lights.json" relative to
 	// paths.content, overridable via "world.dynamic_lights_path" in config.json.
 	m_dynamicLights.Init(m_cfg);
+
+	// Anti-occlusion caméra — fondu tramé des props occultant la vue caméra→joueur.
+	// Réglable sans recompiler via les clés client.camera.occlusion_fade.* du config.
+	{
+		engine::render::CameraOcclusionFade::Config occCfg{};
+		occCfg.fadeMin             = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_min", 0.15));
+		occCfg.radiusMargin        = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.radius_margin", 0.5));
+		occCfg.fadeInPerSec        = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_in_per_sec", 6.0));
+		occCfg.fadeOutPerSec       = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.fade_out_per_sec", 8.0));
+		occCfg.playerProtectRadius = static_cast<float>(m_cfg.GetDouble("client.camera.occlusion_fade.player_protect_radius", 0.6));
+		m_cameraOcclusionFade.Init(occCfg);
+	}
 }
 
 	Engine::Engine(int argc, char** argv)
@@ -9893,6 +9905,36 @@ namespace engine
 
 				const bool rmbLook = m_input.IsMouseDown(engine::platform::MouseButton::Right);
 				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook, out.camera);
+
+				// --- Clamp anti-sous-sol : la caméra ne descend pas sous le terrain. ---
+				const bool occEnabled = m_cfg.GetBool("client.camera.occlusion_fade.enabled", true);
+				const float clampMargin = static_cast<float>(
+					m_cfg.GetDouble("client.camera.terrain_clamp_margin", 0.5));
+				const float groundY = m_terrain.SampleHeightAtWorldXZ(
+					out.camera.position.x, out.camera.position.z);
+				const float minCamY = groundY + clampMargin;
+				if (out.camera.position.y < minCamY)
+					out.camera.position.y = minCamY;
+
+				// --- Fondu d'occlusion : collecte des occulteurs (props + bâtiments). ---
+				// L'index `i` ci-dessous est l'identifiant d'occulteur ; il DOIT
+				// correspondre à l'index utilisé pour FadeFor dans RecordPropsGeometry
+				// (même conteneur m_props, même ordre dans la même frame).
+				if (occEnabled)
+				{
+					std::vector<engine::render::OccluderSphere> occluders;
+					occluders.reserve(m_props.size());
+					for (std::size_t i = 0; i < m_props.size(); ++i)
+					{
+						const auto& prop = m_props[i];
+						if (prop.occluderRadius <= 0.0f) continue;
+						occluders.push_back({ static_cast<std::uint32_t>(i),
+							prop.occluderCenter, prop.occluderRadius });
+					}
+					const engine::math::Vec3 focus = m_orbitalCameraController.GetTargetPosition();
+					m_cameraOcclusionFade.Update(out.camera.position, focus,
+						occluders, static_cast<float>(dt));
+				}
 			}
 
 			// Chat update : uniquement post-EnterWorld. Le rendu pre-game est desactive
@@ -13301,6 +13343,9 @@ namespace engine
 		{
 			const float* M = bakeM.m;  // column-major : M[col*4+row]
 			float minY = 1e30f, maxY = -1e30f;
+			// AABB monde complète (anti-occlusion caméra) — XZ figés ici (le lift
+			// ne décale que Y, appliqué plus bas aux bornes minY/maxY).
+			float bbMinX = 1e30f, bbMaxX = -1e30f, bbMinZ = 1e30f, bbMaxZ = -1e30f;
 			for (auto& v : cpu->vertices)
 			{
 				const float px = v.pos[0], py = v.pos[1], pz = v.pos[2];
@@ -13309,6 +13354,10 @@ namespace engine
 				v.pos[2] = M[2]*px + M[6]*py + M[10]*pz + M[14];
 				if (v.pos[1] < minY) minY = v.pos[1];
 				if (v.pos[1] > maxY) maxY = v.pos[1];
+				if (v.pos[0] < bbMinX) bbMinX = v.pos[0];
+				if (v.pos[0] > bbMaxX) bbMaxX = v.pos[0];
+				if (v.pos[2] < bbMinZ) bbMinZ = v.pos[2];
+				if (v.pos[2] > bbMaxZ) bbMaxZ = v.pos[2];
 				const float nx = v.normal[0], ny = v.normal[1], nz = v.normal[2];
 				float rnx = M[0]*nx + M[4]*ny + M[8]*nz;
 				float rny = M[1]*nx + M[5]*ny + M[9]*nz;
@@ -13325,6 +13374,18 @@ namespace engine
 				for (auto& v : cpu->vertices)
 					v.pos[1] += lift;
 			topY = maxY + lift;
+			// Anti-occlusion caméra — sphère englobante monde (AABB des sommets
+			// bakés, Y décalé du lift). Sert d'occulteur dans CameraOcclusionFade.
+			{
+				const float wMinY = minY + lift, wMaxY = maxY + lift;
+				prop.occluderCenter = engine::math::Vec3{
+					0.5f * (bbMinX + bbMaxX), 0.5f * (wMinY + wMaxY),
+					0.5f * (bbMinZ + bbMaxZ) };
+				const engine::math::Vec3 ext{
+					bbMaxX - bbMinX, wMaxY - wMinY, bbMaxZ - bbMinZ };
+				prop.occluderRadius =
+					0.5f * std::sqrt(ext.x * ext.x + ext.y * ext.y + ext.z * ext.z);
+			}
 			// Empreinte XZ auto (rayon max des sommets autour de l'axe (wx,wz)).
 			for (const auto& v : cpu->vertices)
 			{
@@ -14097,6 +14158,17 @@ namespace engine
 			if (prop.impostorRadius < 0.05f) prop.impostorRadius = 0.5f;
 		}
 
+		// Anti-occlusion caméra — sphère englobante monde (AABB des sommets bakés,
+		// déjà en espace monde car modelMatrix = identité). Sert d'occulteur dans
+		// CameraOcclusionFade. Si l'empreinte est dégénérée, le rayon reste positif.
+		{
+			prop.occluderCenter = engine::math::Vec3{
+				0.5f * (minX + maxX), 0.5f * (minY + maxY), 0.5f * (minZ + maxZ) };
+			const engine::math::Vec3 ext{ maxX - minX, maxY - minY, maxZ - minZ };
+			prop.occluderRadius =
+				0.5f * std::sqrt(ext.x * ext.x + ext.y * ext.y + ext.z * ext.z);
+		}
+
 		for (const auto& kv : idxByMat)
 		{
 			const std::string& matName = kv.first;
@@ -14314,8 +14386,12 @@ namespace engine
 		std::unordered_map<std::string, std::vector<engine::render::ImpostorInstance>> impostorBatches;
 
 		int drawn = 0, culled = 0, impostored = 0;
-		for (const auto& prop : m_props)
+		// Boucle indexée : propIndex sert de clé FadeFor (anti-occlusion caméra). Cet
+		// index DOIT correspondre à l'id d'occulteur poussé dans la boucle Update
+		// (même conteneur m_props, même ordre → même frame).
+		for (std::size_t propIndex = 0; propIndex < m_props.size(); ++propIndex)
 		{
+			const auto& prop = m_props[propIndex];
 			const float dxp = prop.worldPos.x - camPos.x;
 			const float dzp = prop.worldPos.z - camPos.z;
 			const float dist2 = dxp * dxp + dzp * dzp;
@@ -14370,6 +14446,9 @@ namespace engine
 			// dessine ses parties avec la variante de materiau Highlight (teinte).
 			const bool highlight =
 				(prop.interactableIndex >= 0 && prop.interactableIndex == m_interactableInRange);
+			// Fondu d'occlusion de ce prop (1.0 = opaque si non occulteur / inconnu).
+			const float occFade =
+				m_cameraOcclusionFade.FadeFor(static_cast<std::uint32_t>(propIndex));
 			for (const auto& part : prop.parts)
 			{
 				engine::render::MeshAsset* mesh = part.mesh.Get();
@@ -14382,7 +14461,8 @@ namespace engine
 					materialCache.GetDescriptorSet(),
 					prop.modelMatrix.m,
 					highlight ? part.highlightMaterialIndex : part.materialIndex,
-					true);
+					true,
+					occFade);
 			}
 		}
 

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -52,6 +52,7 @@
 #include "src/shared/platform/Input.h"
 #include "src/shared/platform/Window.h"
 #include "src/client/render/AssetRegistry.h"
+#include "src/client/render/CameraOcclusionFade.h"
 #include "src/client/render/ImpostorAsset.h"
 #include "src/client/render/DecalSystem.h"
 #include "src/client/render/FrameGraph.h"
@@ -904,6 +905,11 @@ namespace engine
 			engine::math::Vec3 impostorCenter{ 0.0f, 0.0f, 0.0f };
 			/// M45.5 — rayon (m) de la sphère englobante (demi-taille du billboard).
 			float impostorRadius = 0.0f;
+			/// Anti-occlusion caméra — centre monde de la sphère englobante (AABB des
+			/// sommets cuits). Utilisé par CameraOcclusionFade pour le fondu.
+			engine::math::Vec3 occluderCenter{ 0.0f, 0.0f, 0.0f };
+			/// Anti-occlusion caméra — rayon monde de la sphère ; 0 = non occulteur.
+			float occluderRadius = 0.0f;
 		};
 		/// Props statiques rendus (chantier B), construits au boot depuis les
 		/// interactibles ayant un meshPath. Cf. LoadInteractableProps / RecordPropsGeometry.
@@ -1535,6 +1541,9 @@ namespace engine
 		/// Controleur camera 3eme personne post-EnterWorld (vue orbitale arriere).
 		/// Utilise UNIQUEMENT in-game (post-auth, pas en mode --editor / --world-editor).
 		engine::render::OrbitalCameraController m_orbitalCameraController;
+		/// Anti-occlusion caméra — calcule par frame le fondu tramé des props
+		/// occultant la vue caméra→joueur. Math pure, alimenté dans la boucle Update.
+		engine::render::CameraOcclusionFade m_cameraOcclusionFade;
 		engine::world::World m_world;
 		engine::world::StreamingScheduler m_streamingScheduler;
 		engine::world::StreamCache m_streamCache;

--- a/src/client/render/CameraOcclusionFade.cpp
+++ b/src/client/render/CameraOcclusionFade.cpp
@@ -1,0 +1,102 @@
+#include "src/client/render/CameraOcclusionFade.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::render
+{
+	namespace
+	{
+		float Dot(const engine::math::Vec3& a, const engine::math::Vec3& b)
+		{ return a.x * b.x + a.y * b.y + a.z * b.z; }
+
+		float Length(const engine::math::Vec3& v)
+		{ return std::sqrt(Dot(v, v)); }
+
+		float Clamp01(float v)
+		{ return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); }
+	}
+
+	void CameraOcclusionFade::Init(const Config& cfg)
+	{
+		m_cfg = cfg;
+		m_fade.clear();
+	}
+
+	void CameraOcclusionFade::Update(const engine::math::Vec3& cameraPos,
+		const engine::math::Vec3& focusPoint,
+		const std::vector<OccluderSphere>& occluders,
+		float dt)
+	{
+		if (dt < 0.0f) dt = 0.0f;
+
+		const engine::math::Vec3 seg = focusPoint - cameraPos;
+		const float segLen = Length(seg);
+		const engine::math::Vec3 dir = (segLen > 1e-4f)
+			? engine::math::Vec3{ seg.x / segLen, seg.y / segLen, seg.z / segLen }
+			: engine::math::Vec3{ 0.0f, 0.0f, 1.0f };
+
+		// Nouvelle table : on n'y garde que les ids encore "vivants" (vus cette
+		// frame, ou en train de revenir à l'opaque). Évite la croissance mémoire.
+		std::unordered_map<std::uint32_t, float> next;
+		next.reserve(occluders.size());
+
+		for (const auto& occ : occluders)
+		{
+			float target = 1.0f; // opaque par défaut
+
+			// Garde joueur : occulteur collé au joueur -> jamais fondu.
+			const float distToFocus = Length(occ.center - focusPoint);
+			if (distToFocus >= m_cfg.playerProtectRadius)
+			{
+				// Projection sur le segment caméra->joueur.
+				const engine::math::Vec3 toOcc = occ.center - cameraPos;
+				const float proj = Dot(toOcc, dir);
+				if (segLen > 1e-4f && proj > 0.0f && proj < segLen)
+				{
+					const engine::math::Vec3 closest{
+						cameraPos.x + dir.x * proj,
+						cameraPos.y + dir.y * proj,
+						cameraPos.z + dir.z * proj };
+					const float d = Length(occ.center - closest);
+					const float r0 = occ.radius;
+					const float r1 = occ.radius + m_cfg.radiusMargin;
+					if (d <= r0)
+						target = m_cfg.fadeMin;
+					else if (d < r1)
+						target = m_cfg.fadeMin + (1.0f - m_cfg.fadeMin) * ((d - r0) / (r1 - r0));
+					// d >= r1 -> target reste 1.0
+				}
+			}
+
+			float current = 1.0f;
+			auto it = m_fade.find(occ.id);
+			if (it != m_fade.end()) current = it->second;
+
+			if (target < current)
+				current = std::max(target, current - m_cfg.fadeOutPerSec * dt);
+			else if (target > current)
+				current = std::min(target, current + m_cfg.fadeInPerSec * dt);
+
+			next[occ.id] = Clamp01(current);
+		}
+
+		// Ids non vus cette frame : on les ramène vers l'opaque ; une fois ~opaques
+		// on les laisse tomber (purge) pour que FadeFor renvoie 1.0 par défaut.
+		for (const auto& kv : m_fade)
+		{
+			if (next.find(kv.first) != next.end()) continue;
+			const float current = std::min(1.0f, kv.second + m_cfg.fadeInPerSec * dt);
+			if (current < 1.0f - 1e-3f)
+				next[kv.first] = current;
+		}
+
+		m_fade.swap(next);
+	}
+
+	float CameraOcclusionFade::FadeFor(std::uint32_t id) const
+	{
+		auto it = m_fade.find(id);
+		return (it != m_fade.end()) ? it->second : 1.0f;
+	}
+}

--- a/src/client/render/CameraOcclusionFade.h
+++ b/src/client/render/CameraOcclusionFade.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "src/shared/math/Math.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::render
+{
+	/// Sphère englobante d'un occulteur potentiel (prop, pièce de bâtiment).
+	struct OccluderSphere
+	{
+		std::uint32_t id = 0;         ///< identifiant stable de l'objet (clé de suivi du fondu)
+		engine::math::Vec3 center{};  ///< centre monde de la sphère
+		float radius = 0.5f;          ///< rayon monde (m)
+	};
+
+	/// Calcule, par frame, un facteur de fondu (transparence tramée) pour chaque
+	/// objet occultant la vue entre la caméra et le joueur, avec lissage temporel.
+	/// Math pure (aucune dépendance Vulkan) → testable en ctest.
+	class CameraOcclusionFade
+	{
+	public:
+		struct Config
+		{
+			float fadeMin = 0.15f;            ///< opacité mini au cœur de l'occlusion (0 = invisible)
+			float radiusMargin = 0.5f;        ///< marge ajoutée au rayon pour la transition (m)
+			float fadeInPerSec = 6.0f;        ///< vitesse de retour vers l'opaque (1.0)
+			float fadeOutPerSec = 8.0f;       ///< vitesse de passage vers fadeMin
+			float playerProtectRadius = 0.6f; ///< occulteur à moins de ça du joueur : jamais fondu
+		};
+
+		/// Configure le module (réinitialise l'état de fondu).
+		void Init(const Config& cfg);
+
+		/// Met à jour les fondus. \p occluders est reconstruite chaque frame ;
+		/// \p focusPoint = point regardé (tête joueur) ; \p dt en secondes.
+		/// Effet de bord : met à jour la table interne id→fondu.
+		void Update(const engine::math::Vec3& cameraPos,
+			const engine::math::Vec3& focusPoint,
+			const std::vector<OccluderSphere>& occluders,
+			float dt);
+
+		/// Fondu lissé courant d'un objet ; 1.0 (opaque) si l'id est inconnu.
+		float FadeFor(std::uint32_t id) const;
+
+	private:
+		Config m_cfg{};
+		std::unordered_map<std::uint32_t, float> m_fade; ///< id -> fondu lissé ∈ [fadeMin,1]
+	};
+}

--- a/src/client/render/GeometryPass.cpp
+++ b/src/client/render/GeometryPass.cpp
@@ -21,7 +21,7 @@ namespace engine::render
 			float prevViewProj[16]{};
 			float viewProj[16]{};
 			uint32_t materialIndex = 0;
-			uint32_t padding0 = 0;
+			float    fade = 1.0f;   // 1.0 = opaque (anti-occlusion caméra)
 			uint32_t padding1 = 0;
 			uint32_t padding2 = 0;
 		};
@@ -593,7 +593,8 @@ namespace engine::render
 	    VkDescriptorSet materialDescriptorSet,
 	    const float* instanceMatrix,
 	    uint32_t materialIndex,
-	    bool loadExistingGbuffer)
+	    bool loadExistingGbuffer,
+	    float fade)
 	{
 		if (!IsValid() || extent.width == 0 || extent.height == 0)
 			return;
@@ -672,6 +673,7 @@ namespace engine::render
 		if (viewProjMat4)
 			std::memcpy(pushConstants.viewProj, viewProjMat4, sizeof(pushConstants.viewProj));
 		pushConstants.materialIndex = materialIndex;
+		pushConstants.fade = fade;
 		vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
 			kPushConstantSize, &pushConstants);
 

--- a/src/client/render/GeometryPass.h
+++ b/src/client/render/GeometryPass.h
@@ -50,7 +50,8 @@ namespace engine::render
 		            VkDescriptorSet materialDescriptorSet = VK_NULL_HANDLE,
 		            const float* instanceMatrix = nullptr,
 		            uint32_t materialIndex = 0,
-		            bool loadExistingGbuffer = false);
+		            bool loadExistingGbuffer = false,
+		            float fade = 1.0f);
 
 		/// M09.3: Records instanced draws for batches (mesh+material key). instanceBuffer holds mat4s at each batch's instanceBufferOffset.
 		void RecordInstanced(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,

--- a/src/client/render/skinned/SkinnedRenderer.cpp
+++ b/src/client/render/skinned/SkinnedRenderer.cpp
@@ -634,14 +634,15 @@ void SkinnedRenderer::Record(VkDevice device, VkCommandBuffer cmd,
         float prevViewProj[16];
         float viewProj[16];
         uint32_t materialIndex;
-        uint32_t pad0;
+        float    fade;      // toujours 1.0 : l'avatar n'est jamais fondu
         uint32_t pad1;
         uint32_t pad2;
     } pc;
     static_assert(sizeof(PushConstants) == 144, "PushConstants must match shader layout");
     std::memcpy(pc.prevViewProj, prevViewProj, sizeof(float) * 16);
     std::memcpy(pc.viewProj, viewProj, sizeof(float) * 16);
-    pc.pad0 = pc.pad1 = pc.pad2 = 0;
+    pc.fade = 1.0f;
+    pc.pad1 = pc.pad2 = 0;
 
     // 7. Bind des vertex buffers : per-vertex @ binding 0 (mesh), per-instance
     //    @ binding 1 (matrice modèle). Cf. layout vertex input dans Init.

--- a/src/client/render/tests/CameraOcclusionFadeTests.cpp
+++ b/src/client/render/tests/CameraOcclusionFadeTests.cpp
@@ -1,0 +1,116 @@
+#include "src/client/render/CameraOcclusionFade.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using engine::render::CameraOcclusionFade;
+using engine::render::OccluderSphere;
+using engine::math::Vec3;
+
+namespace
+{
+	int g_fail = 0;
+	void check(bool cond, const char* msg)
+	{ if (!cond) { std::printf("FAIL: %s\n", msg); ++g_fail; } }
+
+	CameraOcclusionFade::Config DefaultCfg()
+	{
+		CameraOcclusionFade::Config c{};
+		c.fadeMin = 0.15f; c.radiusMargin = 0.5f;
+		c.fadeInPerSec = 6.0f; c.fadeOutPerSec = 8.0f;
+		c.playerProtectRadius = 0.6f;
+		return c;
+	}
+
+	// Fait converger le lissage : N updates de dt fixe avec la même scène.
+	float Converge(CameraOcclusionFade& f, const Vec3& cam, const Vec3& focus,
+		const std::vector<OccluderSphere>& occ, std::uint32_t id, int frames, float dt)
+	{
+		for (int i = 0; i < frames; ++i) f.Update(cam, focus, occ, dt);
+		return f.FadeFor(id);
+	}
+}
+
+int main()
+{
+	const Vec3 cam{ 0, 0, 0 };
+	const Vec3 focus{ 10, 0, 0 };
+
+	// 1) Occulteur pile sur le segment, au centre -> converge vers fadeMin.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 1, Vec3{ 5, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 1, 100, 0.1f);
+		check(std::fabs(v - 0.15f) < 0.02f, "1: coeur d'occlusion -> fadeMin");
+	}
+
+	// 2) Occulteur derrière le joueur (proj > segLen) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 2, Vec3{ 12, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 2, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "2: derriere le joueur -> opaque");
+	}
+
+	// 3) Occulteur derrière la caméra (proj < 0) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 3, Vec3{ -2, 0, 0 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 3, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "3: derriere la camera -> opaque");
+	}
+
+	// 4) Occulteur latéral (d > radius+margin) -> opaque.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 4, Vec3{ 5, 0, 3 }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 4, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "4: lateral hors zone -> opaque");
+	}
+
+	// 5) Zone de transition : fade strictement entre fadeMin et 1.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		// d=0.75, r0=0.5, r1=1.0 -> target = 0.15 + 0.85*0.5 = 0.575.
+		std::vector<OccluderSphere> occ{ { 5, Vec3{ 5, 0, 0.75f }, 0.5f } };
+		const float v = Converge(f, cam, focus, occ, 5, 100, 0.1f);
+		check(v > 0.16f && v < 0.99f, "5: transition -> fade intermediaire");
+		check(std::fabs(v - 0.575f) < 0.03f, "5: transition -> valeur attendue ~0.575");
+	}
+
+	// 6) Garde joueur : occulteur collé au joueur -> jamais fondu.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 6, Vec3{ 9.8f, 0, 0 }, 0.5f } }; // |toFocus|=0.2<0.6
+		const float v = Converge(f, cam, focus, occ, 6, 100, 0.1f);
+		check(std::fabs(v - 1.0f) < 1e-3f, "6: garde joueur -> opaque");
+	}
+
+	// 7) Lissage : un seul petit dt ne saute pas directement à fadeMin.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 7, Vec3{ 5, 0, 0 }, 0.5f } };
+		f.Update(cam, focus, occ, 0.01f); // 1 - 8*0.01 = 0.92
+		const float v = f.FadeFor(7);
+		check(v > 0.15f + 0.01f && v < 1.0f, "7: lissage progressif (pas de saut)");
+	}
+
+	// 8) Purge : occulteur présent puis absent -> revient à 1.0 et FadeFor=1.0.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		std::vector<OccluderSphere> occ{ { 8, Vec3{ 5, 0, 0 }, 0.5f } };
+		Converge(f, cam, focus, occ, 8, 100, 0.1f); // converge à fadeMin
+		const float back = Converge(f, cam, focus, {}, 8, 100, 0.1f); // plus d'occulteur
+		check(std::fabs(back - 1.0f) < 1e-3f, "8: purge -> revient opaque");
+	}
+
+	// 9) Id inconnu -> 1.0.
+	{
+		CameraOcclusionFade f; f.Init(DefaultCfg());
+		check(std::fabs(f.FadeFor(999) - 1.0f) < 1e-6f, "9: inconnu -> opaque");
+	}
+
+	if (g_fail == 0) std::printf("CameraOcclusionFadeTests: OK\n");
+	return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problème

En vue 3e personne, le décor (murs de l'auberge, props) ou le terrain qui passe **entre le joueur et la caméra** bouchait la vue (constaté en jeu). Cause : la caméra réelle (`OrbitalCameraController`) n'avait **aucun** anti-occlusion — un `ThirdPersonCamera` plus complet existe mais n'est jamais instancié.

## Solution (100 % client)

- **Props + pièces de bâtiment** (`GeometryPass`) → **fondu tramé screen-door** quand l'objet occulte le joueur. Le perso reste visible « à travers ».
- **Terrain** → **clamp anti-sous-sol** (`SampleHeightAtWorldXZ`) : la caméra ne plonge plus sous le sol.
- L'**avatar n'est jamais fondu**.

## Implémentation (3 tasks TDD)

1. **`CameraOcclusionFade`** — module math pur (sphère-vs-segment, lissage temporel, purge) + **9 tests ctest** (`camera_occlusion_fade_tests`).
2. **Push-constant `fade`** — réutilise un padding → **layout 144 o inchangé** ; fragment shader `gbuffer_geometry.frag` applique un dither Bayer 4×4 (`discard`) ; `SkinnedRenderer` force `fade=1.0f`. `fade` est le **dernier** paramètre de `GeometryPass::Record` → aucun appelant existant cassé.
3. **Intégration `Engine`** — sphères englobantes calculées au bake des props, collecte des occulteurs depuis `m_props`, fondu par-prop, clamp terrain.

## Configuration (`config.json`, réglable sans recompiler)

`client.camera.occlusion_fade.{enabled,fade_min,radius_margin,fade_in_per_sec,fade_out_per_sec,player_protect_radius}` + `client.camera.terrain_clamp_margin`.

## Validation

- ✅ Tests unitaires : `camera_occlusion_fade_tests` (job build-linux / ctest).
- ⏳ **À valider en jeu** : entrer dans l'auberge, tourner la caméra derrière un mur (le mur se trame, le perso reste visible) ; reculer dans une pente (la caméra ne passe plus sous le sol).

Spec : `docs/superpowers/specs/2026-06-21-camera-occlusion-fade-design.md` · Plan : `docs/superpowers/plans/2026-06-21-camera-occlusion-fade.md`

**Déploiement** : ✅ client uniquement, pas de redéploiement serveur (rendu + caméra, aucun opcode/payload/handler/migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)