### PR TITLE
refactor(ui): helpers couleur thème partagés ToImVec4/ToU32 (LnThemeImGui.h)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,7 @@ add_library(engine_core
   src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
   src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
   src/client/render/LnTheme.h
+  src/client/render/LnThemeImGui.h
   src/client/render/AuthImGuiRenderer.cpp
   src/client/render/ChatImGuiRenderer.cpp
   src/client/render/DialogueImGuiRenderer.cpp

--- a/src/client/render/AuthImGuiRenderer.cpp
+++ b/src/client/render/AuthImGuiRenderer.cpp
@@ -18,20 +18,14 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
-
-		ImU32 U32(const LnTheme::Rgba& c)
-		{
-			return ImGui::ColorConvertFloat4ToU32(IV(c));
-		}
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
 
 		void StrCopyTrunc(char* dst, size_t dstSz, const std::string& s)
 		{
@@ -486,7 +480,7 @@ namespace engine::render
 		{
 			if (BeginPanel(420.f, viewportW, viewportH, rm.sectionTitle.c_str(), "", ""))
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextWrapped("%s", rm.infoBanner.c_str());
 				ImGui::PopStyleColor();
 				EndPanel();
@@ -504,7 +498,7 @@ namespace engine::render
 		// Fond plein écran FIGÉ sur le thème par défaut (or_royal), invariant au
 		// thème actif : changer de thème de race ne doit recolorer que les
 		// panneaux, pas le fond (demande utilisateur). Cf. LnTheme::AuthBackdrop.
-		ImVec4 bg = IV(LnTheme::AuthBackdrop());
+		ImVec4 bg = ToImVec4(LnTheme::AuthBackdrop());
 		bg.w = windowBgAlpha;
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, bg);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
@@ -534,7 +528,7 @@ namespace engine::render
 		const float topMargin = (std::max)(24.f, vpH * 0.05f);
 		ImGui::SetCursorPosY(topMargin);
 		ImGui::SetWindowFontScale(5.0f);
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		const float w1 = ImGui::CalcTextSize(h1.c_str()).x;
 		ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w1) * 0.5f));
 		ImGui::TextUnformatted(h1.c_str());
@@ -545,7 +539,7 @@ namespace engine::render
 		{
 			ImGui::Dummy(ImVec2(0.f, 28.f));
 			ImGui::SetWindowFontScale(2.5f);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			const float w2 = ImGui::CalcTextSize(rm.titleLine2.c_str()).x;
 			ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w2) * 0.5f));
 			ImGui::TextUnformatted(rm.titleLine2.c_str());
@@ -568,8 +562,8 @@ namespace engine::render
 			: (vpH * 0.28f);
 		ImGui::SetCursorPos(ImVec2(panelX, panelY));
 
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::PanelBg()));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::PanelBg()));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.f, 18.f));
@@ -601,7 +595,7 @@ namespace engine::render
 		}
 		if (!title.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::SetWindowFontScale(1.15f);
 			ImGui::TextUnformatted(title.data(), title.data() + static_cast<int>(title.size()));
 			ImGui::SetWindowFontScale(1.f);
@@ -621,12 +615,12 @@ namespace engine::render
 				const float r = side * 0.42f;
 				const ImVec2 center(ip.x + side * 0.5f, ip.y + side * 0.5f);
 				ImDrawList* dl = ImGui::GetWindowDrawList();
-				dl->AddCircle(center, r, U32(LnTheme::kMuted), 0, 1.25f);
-				dl->AddText(ImVec2(center.x - ImGui::CalcTextSize("i").x * 0.5f, ip.y + 1.f), U32(LnTheme::kMuted), "i");
+				dl->AddCircle(center, r, ToU32(LnTheme::kMuted), 0, 1.25f);
+				dl->AddText(ImVec2(center.x - ImGui::CalcTextSize("i").x * 0.5f, ip.y + 1.f), ToU32(LnTheme::kMuted), "i");
 				ImGui::Dummy(ImVec2(side, side));
 				ImGui::SameLine(0.f, gap);
 			}
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::TextUnformatted(versionLabel.data(), versionLabel.data() + static_cast<int>(versionLabel.size()));
 			ImGui::PopStyleColor();
 		}
@@ -637,7 +631,7 @@ namespace engine::render
 			ImGui::Dummy(ImVec2(0.f, 6.f));
 			if (subtitleWelcomeAccent)
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
 				ImGui::SetWindowFontScale(0.95f);
 				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
@@ -647,12 +641,12 @@ namespace engine::render
 			}
 			else
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
 				ImGui::PopStyleColor();
 			}
 		}
-		ImGui::PushStyleColor(ImGuiCol_Separator, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
 		ImGui::Separator();
 		ImGui::PopStyleColor();
 		// Anciennement : ImGui::Spacing() (= Dummy(0, 8)) apres le Separator. Total
@@ -673,7 +667,7 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawLangFooterHints(std::string_view left, std::string_view right)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(0.88f);
 		if (!left.empty() && !right.empty())
 		{
@@ -705,7 +699,7 @@ namespace engine::render
 				ch = static_cast<char>(ch - 'a' + 'A');
 			}
 		}
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 		ImGui::TextUnformatted(lab.c_str());
 		ImGui::PopStyleColor();
 
@@ -716,10 +710,10 @@ namespace engine::render
 			ImGui::Dummy(ImVec2(0.f, extraSpacingPx));
 		}
 
-		ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 		// FramePadding.y bumpe de 3 (defaut ImGui) a 8 px > InputText  13 + 16 = 29 px
@@ -817,17 +811,17 @@ namespace engine::render
 		const ImU32 fillOff = IM_COL32(40, 48, 62, 255);
 		const ImU32 fillOn = IM_COL32(72, 90, 48, 255);
 		dl->AddRectFilled(a, b, on ? fillOn : fillOff, trackH * 0.5f);
-		dl->AddRect(a, b, U32(LnTheme::kBorder), trackH * 0.5f, 0, 1.f);
+		dl->AddRect(a, b, ToU32(LnTheme::kBorder), trackH * 0.5f, 0, 1.f);
 		const float thumbR = (trackH - pad * 2.f) * 0.5f;
 		const float cx = on ? (b.x - pad - thumbR) : (a.x + pad + thumbR);
 		const float cy = (a.y + b.y) * 0.5f;
-		dl->AddCircleFilled(ImVec2(cx, cy), thumbR, U32(LnTheme::kAccent));
+		dl->AddCircleFilled(ImVec2(cx, cy), thumbR, ToU32(LnTheme::kAccent));
 		// Libelle dessine via la draw list par-dessus la zone invisible (pas de SameLine + Text qui
 		// deplacerait le curseur d'une ligne et casserait le hit-test ci-dessus).
 		const float labelX = b.x + 12.f;
 		const ImVec2 ts = ImGui::CalcTextSize(rememberTitle.c_str());
 		const float labelY = (a.y + b.y) * 0.5f - ts.y * 0.5f;
-		dl->AddText(ImVec2(labelX, labelY), U32(LnTheme::kText), rememberTitle.c_str());
+		dl->AddText(ImVec2(labelX, labelY), ToU32(LnTheme::kText), rememberTitle.c_str());
 	}
 
 	void AuthImGuiRenderer::DrawLoginFooterChips(const RenderModel& rm)
@@ -852,8 +846,8 @@ namespace engine::render
 			const float keyW = ImGui::CalcTextSize(chip.first.c_str()).x + 16.f;
 			const float descW = ImGui::CalcTextSize(chip.second.c_str()).x + 12.f;
 			const float chipW = keyW + descW + 8.f;
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 			char cid[48];
@@ -861,12 +855,12 @@ namespace engine::render
 			ImGui::BeginChild(cid, ImVec2(chipW, 40.f), true, ImGuiWindowFlags_NoScrollbar);
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(2);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::SetWindowFontScale(0.92f);
 			ImGui::TextUnformatted(chip.first.c_str());
 			ImGui::PopStyleColor();
 			ImGui::SameLine(0.f, 6.f);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.78f);
 			ImGui::TextUnformatted(chip.second.c_str());
 			ImGui::SetWindowFontScale(1.f);
@@ -902,14 +896,14 @@ namespace engine::render
 			if (i > 0u)
 			{
 				ImGui::SameLine(0.f, 0.f);
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextUnformatted(" \xE2\x80\x94 ");
 				ImGui::PopStyleColor();
 				ImGui::SameLine(0.f, 0.f);
 			}
 			const bool done = static_cast<int>(i) < cur;
 			const bool active = static_cast<int>(i) == cur;
-			const ImVec4 col = done ? IV(LnTheme::kSuccess) : (active ? IV(LnTheme::kAccent) : IV(LnTheme::kMuted));
+			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
 			ImGui::PushStyleColor(ImGuiCol_Text, col);
 			if (active)
 			{
@@ -975,14 +969,14 @@ namespace engine::render
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(badgePadX, badgePadY));
 		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, alpha);
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.92f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.92f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kAccent));
 		ImGui::Begin("##ln_login_lang_badge",
 			nullptr,
 			ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove
 				| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoInputs
 				| ImGuiWindowFlags_NoScrollbar);
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 		ImGui::TextUnformatted(m_loginLangBadgeText.c_str());
 		ImGui::PopStyleColor();
 		ImGui::End();
@@ -1013,8 +1007,8 @@ namespace engine::render
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(12.f, 12.f));
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.78f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.78f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::Begin("##ln_auth_tweaks",
 			nullptr,
 			ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove
@@ -1024,7 +1018,7 @@ namespace engine::render
 		// 0.85x compense le titre login agrandi, en gardant les boutons cliquables.
 		ImGui::SetWindowFontScale(0.85f);
 
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::TextUnformatted("THEME DE RACE");
 		ImGui::PopStyleColor();
 		ImGui::Spacing();
@@ -1042,10 +1036,10 @@ namespace engine::render
 				if (cur == order[i]) { m_langTweakRace = i; break; }
 		}
 
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.12f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.18f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.12f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.18f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 		// Grille 3x2 (6 races). Etat selectionne : on reprend le style VALIDE du menu Pause
@@ -1061,7 +1055,7 @@ namespace engine::render
 				}
 				const int idx = r * 3 + c;
 				const bool sel = (m_langTweakRace == idx);
-				ImGui::PushStyleColor(ImGuiCol_Text, sel ? IV(LnTheme::kAccent) : IV(LnTheme::kText));
+				ImGui::PushStyleColor(ImGuiCol_Text, sel ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kText));
 				char id[40];
 				std::snprintf(id, sizeof(id), "%s##race_%d", kRaceLabels[idx], idx);
 				if (ImGui::Button(id, ImVec2(btnW, 0.f)))
@@ -1080,7 +1074,7 @@ namespace engine::render
 				if (sel)
 				{
 					ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
-						ImGui::ColorConvertFloat4ToU32(IV(LnTheme::kAccent)), 4.f, 0, 1.5f);
+						ImGui::ColorConvertFloat4ToU32(ToImVec4(LnTheme::kAccent)), 4.f, 0, 1.5f);
 				}
 				ImGui::PopStyleColor(1);
 			}
@@ -1089,14 +1083,14 @@ namespace engine::render
 		ImGui::PopStyleColor(4);
 
 		ImGui::Spacing();
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::TextUnformatted("FOND ANIME");
 		ImGui::PopStyleColor();
 		ImGui::Spacing();
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.12f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.18f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.12f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.18f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 		{
@@ -1106,12 +1100,12 @@ namespace engine::render
 			// Meme style selectionne que la grille de races : contour dore AddRect + texte accent.
 			const float half = (ImGui::GetContentRegionAvail().x - 6.f) * 0.5f;
 			const auto drawToggle = [&](const char* label, bool active) -> bool {
-				ImGui::PushStyleColor(ImGuiCol_Text, active ? IV(LnTheme::kAccent) : IV(LnTheme::kText));
+				ImGui::PushStyleColor(ImGuiCol_Text, active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kText));
 				const bool clicked = ImGui::Button(label, ImVec2(half, 0.f));
 				if (active)
 				{
 					ImGui::GetWindowDrawList()->AddRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
-						ImGui::ColorConvertFloat4ToU32(IV(LnTheme::kAccent)), 4.f, 0, 1.5f);
+						ImGui::ColorConvertFloat4ToU32(ToImVec4(LnTheme::kAccent)), 4.f, 0, 1.5f);
 				}
 				ImGui::PopStyleColor(1);
 				return clicked;
@@ -1137,14 +1131,14 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawField(std::string_view label, char* buf, int bufSz, bool password)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::TextUnformatted(label.data(), label.data() + static_cast<int>(label.size()));
 		ImGui::PopStyleColor();
 
-		ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 
@@ -1188,7 +1182,7 @@ namespace engine::render
 		ImGui::PopStyleColor();
 		if (!msg.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::TextWrapped("%.*s", static_cast<int>(msg.size()), msg.data());
 			ImGui::PopStyleColor();
 		}
@@ -1198,7 +1192,7 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawKeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		bool first = true;
 		for (const auto& kv : hints)
 		{
@@ -1218,10 +1212,10 @@ namespace engine::render
 		{
 			ImGui::BeginDisabled();
 		}
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
 		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.39f, 0.58f, 0.82f, 1.f));
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.19f, 0.38f, 0.62f, 1.f));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		char id[160];
 		std::snprintf(id, sizeof(id), "%.*s##primary", static_cast<int>(label.size()), label.data());
@@ -1242,10 +1236,10 @@ namespace engine::render
 			ImGui::BeginDisabled();
 		}
 		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 		char id[160];
@@ -1262,7 +1256,7 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawSeparator()
 	{
-		ImGui::PushStyleColor(ImGuiCol_Separator, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
 		ImGui::Separator();
 		ImGui::PopStyleColor();
 		ImGui::Spacing();
@@ -1275,7 +1269,7 @@ namespace engine::render
 		{
 			const bool done = i < current;
 			const bool active = i == current;
-			const ImVec4 col = done ? IV(LnTheme::kSuccess) : (active ? IV(LnTheme::kAccent) : IV(LnTheme::kMuted));
+			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
 			ImGui::PushStyleColor(ImGuiCol_Text, col);
 			ImGui::Text("%02d %s", i + 1, s);
 			ImGui::PopStyleColor();
@@ -1298,7 +1292,7 @@ namespace engine::render
 		{
 			const bool done = i < current;
 			const bool active = i == current;
-			const ImVec4 col = done ? IV(LnTheme::kSuccess) : (active ? IV(LnTheme::kAccent) : IV(LnTheme::kMuted));
+			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
 			ImGui::PushStyleColor(ImGuiCol_Text, col);
 			ImGui::Text("%02d %s", i + 1, steps[static_cast<size_t>(i)].c_str());
 			ImGui::PopStyleColor();

--- a/src/client/render/LnThemeImGui.h
+++ b/src/client/render/LnThemeImGui.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Pont ImGui du thème : convertit les couleurs LnTheme::Rgba (0–1, sans
+// dépendance ImGui) vers les types ImGui. Volontairement séparé de LnTheme.h
+// pour que ce dernier reste PUR (aucun #include ImGui, inclus très largement,
+// y compris par des cibles sans ImGui comme ln_theme_tests). N'inclure ce
+// header QUE depuis des blocs `#if defined(_WIN32)` où imgui.h est déjà présent.
+//
+// Ces deux helpers remplacent les couples IV()/U32() historiquement redéfinis à
+// l'identique dans chaque renderer. Sémantique inchangée (bit-à-bit).
+//
+// Couverture de test : PAS de test unitaire dédié. ToU32 délègue à
+// ImGui::ColorConvertFloat4ToU32, indisponible sur la cible ctest (Linux, où
+// engine_core est compilé sans ImGui) ; un test réencodant la formule de packing
+// ne testerait qu'une copie de la logique (fausse assurance en cas de divergence
+// BGRA/arrondi). La non-régression est assurée par la validation visuelle des
+// écrans d'auth (le rename est mécanique : s'il compile, le rendu est identique
+// par construction).
+
+#include "imgui.h"
+
+#include "src/client/render/LnTheme.h"
+
+namespace LnTheme
+{
+	/// Convertit une couleur thème (RGBA 0–1) en ImVec4 pour les appels de style ImGui.
+	inline ImVec4 ToImVec4(const Rgba& c)
+	{
+		return ImVec4(c.r, c.g, c.b, c.a);
+	}
+
+	/// Convertit une couleur thème en ImU32 packé pour les primitives du DrawList.
+	/// Identique à l'ancien U32() : packing/arrondi délégués à ImGui (source de vérité).
+	inline ImU32 ToU32(const Rgba& c)
+	{
+		return ImGui::ColorConvertFloat4ToU32(ToImVec4(c));
+	}
+} // namespace LnTheme

--- a/src/client/render/auth/screens/AuthImGuiError.cpp
+++ b/src/client/render/auth/screens/AuthImGuiError.cpp
@@ -10,22 +10,14 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur theme en ImVec4 pour ImGui::PushStyleColor.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
-
-		/// Convertit une couleur theme en ImU32 pour les primitives du DrawList (AddRectFilled, etc.).
-		ImU32 U32(const LnTheme::Rgba& c)
-		{
-			return ImGui::ColorConvertFloat4ToU32(IV(c));
-		}
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
 
 		/// Pastilles de variante d'erreur : desactive en production (maquette AUTH-UI.4).
 		constexpr bool kAuthErrorVariantPillsDemo = false;
@@ -85,8 +77,8 @@ namespace engine::render
 					}
 					const bool sel = i == shown;
 					const auto& pv = rm.authRegisterErrorVariants[static_cast<size_t>(i)];
-					ImGui::PushStyleColor(ImGuiCol_Text, sel ? IV(LnTheme::kAccent) : IV(LnTheme::kMuted));
-					ImGui::PushStyleColor(ImGuiCol_Border, sel ? IV(LnTheme::kAccent) : IV(LnTheme::kBorder));
+					ImGui::PushStyleColor(ImGuiCol_Text, sel ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
+					ImGui::PushStyleColor(ImGuiCol_Border, sel ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kBorder));
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, sel ? 1.5f : 1.f);
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 					char pid[96]{};
@@ -116,38 +108,38 @@ namespace engine::render
 			if (!v.fieldLabel.empty() && !rm.authErrorHideFieldBox)
 			{
 				ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(10.f / 255.f, 13.f / 255.f, 18.f / 255.f, 0.5f));
-				ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+				ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.f);
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 				ImGui::BeginChild("##err_field", ImVec2(-FLT_MIN, 0.f), true, ImGuiWindowFlags_NoScrollbar);
 				ImGui::PopStyleVar(2);
 				ImGui::PopStyleColor(2);
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.78f);
 				const std::string& flab =
 					rm.authErrorFieldSectionLabel.empty() ? std::string("CHAMP A CORRIGER") : rm.authErrorFieldSectionLabel;
 				ImGui::TextUnformatted(flab.c_str());
 				ImGui::SetWindowFontScale(1.f);
 				ImGui::PopStyleColor();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted(v.fieldLabel.c_str());
 				ImGui::PopStyleColor();
 				ImGui::EndChild();
 				ImGui::Spacing();
 			}
 
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::AccentDim(0.04f)));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::AccentDim(0.04f)));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
 			ImGui::BeginChild("##err_fix", ImVec2(-FLT_MIN, 0.f), false, ImGuiWindowFlags_NoScrollbar);
 			const ImVec2 child0 = ImGui::GetWindowPos();
 			const ImVec2 pad = ImGui::GetStyle().WindowPadding;
 			const float fixH = ImGui::GetFontSize() * 4.f + 24.f;
 			ImGui::GetWindowDrawList()->AddRectFilled(ImVec2(child0.x + pad.x, child0.y + pad.y),
-				ImVec2(child0.x + pad.x + 3.f, child0.y + pad.y + fixH), U32(LnTheme::kAccent));
+				ImVec2(child0.x + pad.x + 3.f, child0.y + pad.y + fixH), ToU32(LnTheme::kAccent));
 			ImGui::PopStyleVar(1);
 			ImGui::PopStyleColor(1);
 			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 8.f);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::SetWindowFontScale(0.78f);
 			const std::string& hfix =
 				rm.authErrorFixSectionLabel.empty() ? std::string("COMMENT CORRIGER") : rm.authErrorFixSectionLabel;
@@ -155,7 +147,7 @@ namespace engine::render
 			ImGui::SetWindowFontScale(1.f);
 			ImGui::PopStyleColor();
 			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 8.f);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.95f);
 			ImGui::SetWindowFontScale(0.92f);
 			ImGui::TextWrapped("%s", v.fixHint.c_str());
@@ -179,14 +171,14 @@ namespace engine::render
 			if (btnW >= 120.f)
 			{
 				ImGui::SameLine(0.f, 10.f);
-				ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
-				ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+				ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
+				ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 				ImGui::BeginChild("##err_keycap", ImVec2(capW, 36.f), true, ImGuiWindowFlags_NoScrollbar);
 				ImGui::PopStyleVar(2);
 				ImGui::PopStyleColor(2);
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				const float tx = (capW - ImGui::CalcTextSize(kcap.c_str()).x) * 0.5f;
 				ImGui::SetCursorPosX(tx);
 				ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 6.f);

--- a/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
+++ b/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
@@ -14,22 +14,14 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur LnTheme::Rgba en ImVec4 pour les appels de style ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
-
-		/// Convertit une couleur LnTheme::Rgba en ImU32 pour les appels de draw list ImGui.
-		ImU32 U32(const LnTheme::Rgba& c)
-		{
-			return ImGui::ColorConvertFloat4ToU32(IV(c));
-		}
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
 
 		/// Retourne vrai si le tag de locale correspond a une variante anglaise (en, en-GB, en_US...).
 		bool IsEnglishLocaleTag(std::string_view tag)
@@ -50,8 +42,8 @@ namespace engine::render
 			}
 			else
 			{
-				dl->AddRectFilled(ImVec2(x, y), ImVec2(x + fw, y + fh), U32(LnTheme::kSurface));
-				dl->AddRect(ImVec2(x, y), ImVec2(x + fw, y + fh), U32(LnTheme::kBorder), 2.f, 0, 1.f);
+				dl->AddRectFilled(ImVec2(x, y), ImVec2(x + fw, y + fh), ToU32(LnTheme::kSurface));
+				dl->AddRect(ImVec2(x, y), ImVec2(x + fw, y + fh), ToU32(LnTheme::kBorder), 2.f, 0, 1.f);
 			}
 		}
 	} // namespace
@@ -117,7 +109,7 @@ namespace engine::render
 			}
 
 			const ImU32 borderCol =
-				isSelected ? U32(LnTheme::kAccent) : (itemHovered ? U32(LnTheme::kPrimary) : U32(LnTheme::kBorder));
+				isSelected ? ToU32(LnTheme::kAccent) : (itemHovered ? ToU32(LnTheme::kPrimary) : ToU32(LnTheme::kBorder));
 			const float borderThick = isSelected ? 2.f : 1.f;
 			dl->AddRect(rmin, rmax, borderCol, 8.f, 0, borderThick);
 
@@ -136,10 +128,10 @@ namespace engine::render
 			const float textX = fx + flagW + 12.f;
 			const float textY = rmin.y + (cardSize.y - textBlockH) * 0.5f;
 			const ImVec2 namePos(textX, textY);
-			dl->AddText(font, nameSize, namePos, U32(LnTheme::kText), nameCaps.data(), nameCaps.data() + static_cast<int>(nameCaps.size()));
+			dl->AddText(font, nameSize, namePos, ToU32(LnTheme::kText), nameCaps.data(), nameCaps.data() + static_cast<int>(nameCaps.size()));
 
 			const ImVec2 natPos(textX, textY + nameSize + 4.f);
-			dl->AddText(font, nativeSz, natPos, U32(LnTheme::kMuted), nativeLn.data(), nativeLn.data() + static_cast<int>(nativeLn.size()));
+			dl->AddText(font, nativeSz, natPos, ToU32(LnTheme::kMuted), nativeLn.data(), nativeLn.data() + static_cast<int>(nativeLn.size()));
 		}
 		return clicked;
 	}
@@ -178,7 +170,7 @@ namespace engine::render
 			const std::string info = m_authPresenter->UiTranslate("language.first_run.info_popup");
 			if (!info.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.82f);
 				ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 680.f);
 				ImGui::TextWrapped("%s", info.c_str());
@@ -219,10 +211,10 @@ namespace engine::render
 
 		const float btnW = 200.f;
 		ImGui::SetCursorPosX(ImGui::GetContentRegionAvail().x - btnW + ImGui::GetCursorPosX());
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
 		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.39f, 0.58f, 0.82f, 1.f));
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.19f, 0.38f, 0.62f, 1.f));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		char contId[256];
 		std::snprintf(contId, sizeof(contId), "%s##lang_continue", contLabel.c_str());

--- a/src/client/render/auth/screens/AuthImGuiOptions.cpp
+++ b/src/client/render/auth/screens/AuthImGuiOptions.cpp
@@ -14,22 +14,14 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur LnTheme::Rgba en ImVec4 pour les appels de style ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
-
-		/// Convertit une couleur LnTheme::Rgba en ImU32 pour les appels de draw list ImGui.
-		ImU32 U32(const LnTheme::Rgba& c)
-		{
-			return ImGui::ColorConvertFloat4ToU32(IV(c));
-		}
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
 
 		constexpr int kOptionsRes[][2] = {{1280, 720}, {1600, 900}, {1920, 1080}, {2560, 1440}, {3840, 2160}}; ///< Table des resolutions video proposees dans le combo graphique.
 		constexpr int kOptionsResCount = sizeof(kOptionsRes) / sizeof(kOptionsRes[0]); ///< Nombre d'entrees dans kOptionsRes, calcule statiquement.
@@ -194,15 +186,15 @@ namespace engine::render
 		const float bottomMargin = 60.f;
 		const float panelH = (std::max)(560.f, vpH - topMargin - bottomMargin);
 		ImGui::SetCursorPos(ImVec2(0.f, topMargin));
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kPanel));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kPanel));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 		ImGui::BeginChild("##opts_sidebar", ImVec2(sideW, panelH),
 			ImGuiChildFlags_Borders, ImGuiWindowFlags_None);
 		ImGui::PopStyleVar(1);
 		ImGui::PopStyleColor(2);
 
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(1.08f);
 		{
 			const std::string sideTitle = tr("options.imgui.sidebar_title");
@@ -216,10 +208,10 @@ namespace engine::render
 		{
 			const bool active = (m_optionsTab == i);
 			const std::string tabLabel = tr(kTabKeys[i]);
-			ImGui::PushStyleColor(ImGuiCol_Button, active ? IV(LnTheme::AccentDim(0.12f)) : ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_Text, active ? IV(LnTheme::kAccent) : IV(LnTheme::kText));
-			ImGui::PushStyleColor(ImGuiCol_Border, active ? IV(LnTheme::kAccent) : IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Button, active ? ToImVec4(LnTheme::AccentDim(0.12f)) : ImVec4(0.f, 0.f, 0.f, 0.f));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_Text, active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Border, active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, active ? 1.5f : 0.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 			char btnLine[192];
@@ -233,7 +225,7 @@ namespace engine::render
 				ImDrawList* dl = ImGui::GetWindowDrawList();
 				const ImVec2 rmin = ImGui::GetItemRectMin();
 				const ImVec2 rmax = ImGui::GetItemRectMax();
-				dl->AddRectFilled(ImVec2(rmin.x, rmin.y), ImVec2(rmin.x + 3.f, rmax.y), U32(LnTheme::kAccent));
+				dl->AddRectFilled(ImVec2(rmin.x, rmin.y), ImVec2(rmin.x + 3.f, rmax.y), ToU32(LnTheme::kAccent));
 			}
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(4);
@@ -248,7 +240,7 @@ namespace engine::render
 		{
 			ImGui::Dummy(ImVec2(1.f, sidebarSpacerH));
 		}
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(0.82f);
 		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
 		ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + sideW - 24.f);
@@ -263,8 +255,8 @@ namespace engine::render
 		// panelH. Le contenu commence dans le coin haut-gauche du child et le
 		// scroll interne (##opts_body) prend le relais si trop d'options.
 		ImGui::SetCursorPos(ImVec2(mainOriginX, topMargin));
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kBackground));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kBackground));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 		ImGui::BeginChild("##opts_main", ImVec2(mainW, panelH),
 			ImGuiChildFlags_Borders, ImGuiWindowFlags_None);
@@ -274,12 +266,12 @@ namespace engine::render
 		// Header inline : pas de BeginChild wrapper qui consommait trop de hauteur
 		// (ImGui::BeginChild avec hauteur 0 sans flag AutoResizeY peut prendre 100%
 		// de la zone disponible -> body invisible, retour utilisateur 'cadre vide').
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(0.78f);
 		ImGui::TextUnformatted(tr("options.imgui.category_label").c_str());
 		ImGui::SetWindowFontScale(1.f);
 		ImGui::PopStyleColor();
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::SetWindowFontScale(1.12f);
 		{
 			const std::string mainTabTitle = tr(kTabKeys[m_optionsTab]);
@@ -290,7 +282,7 @@ namespace engine::render
 		if (m_optDirty)
 		{
 			ImGui::SameLine(0.f, 18.f);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kWarning));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kWarning));
 			ImGui::TextUnformatted(tr("options.imgui.dirty_banner_title").c_str());
 			ImGui::PopStyleColor();
 		}
@@ -318,7 +310,7 @@ namespace engine::render
 		const auto sectionTitle = [&](const char* key) {
 			ImGui::Spacing();
 			const std::string t = tr(key);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.82f);
 			ImGui::TextUnformatted(t.c_str());
 			ImGui::SetWindowFontScale(1.f);
@@ -332,7 +324,7 @@ namespace engine::render
 			{
 				return;
 			}
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.78f);
 			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.9f);
 			ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + ImGui::GetContentRegionAvail().x);
@@ -346,11 +338,11 @@ namespace engine::render
 		const auto toggleRow = [&](const char* labelKey, bool* v, const char* hintKey) {
 			const float fullW = ImGui::GetContentRegionAvail().x;
 			const std::string lbl = tr(labelKey);
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::AccentDim(0.12f)));
-			ImGui::PushStyleColor(ImGuiCol_CheckMark, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::AccentDim(0.12f)));
+			ImGui::PushStyleColor(ImGuiCol_CheckMark, ToImVec4(LnTheme::kAccent));
 			ImGui::BeginGroup();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::AlignTextToFramePadding();
 			ImGui::TextUnformatted(lbl.c_str());
 			ImGui::PopStyleColor();
@@ -402,10 +394,10 @@ namespace engine::render
 			m_optDirty = false;
 		};
 
-		ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::AccentDim(0.12f)));
-		ImGui::PushStyleColor(ImGuiCol_SliderGrab, IV(LnTheme::kAccent));
-		ImGui::PushStyleColor(ImGuiCol_SliderGrabActive, IV(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::AccentDim(0.12f)));
+		ImGui::PushStyleColor(ImGuiCol_SliderGrab, ToImVec4(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_SliderGrabActive, ToImVec4(LnTheme::kAccent));
 
 		if (m_optionsTab == 0)
 		{
@@ -523,7 +515,7 @@ namespace engine::render
 			const auto rebindRow = [&](int actionIdx) {
 				const RebindAction& act = kRebindActions[actionIdx];
 				const std::string label = tr(act.labelKey, act.labelFallback);
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 				ImGui::AlignTextToFramePadding();
 				ImGui::Text("%s : %s", label.c_str(), m_rebindKeys[actionIdx].c_str());
 				ImGui::PopStyleColor();
@@ -531,7 +523,7 @@ namespace engine::render
 				ImGui::PushID(actionIdx);
 				if (m_rebindActionIdx == actionIdx)
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 					ImGui::TextUnformatted(tr("options.keybind.press_key", "appuyez sur une touche (Echap = annuler)").c_str());
 					ImGui::PopStyleColor();
 				}
@@ -539,11 +531,11 @@ namespace engine::render
 				{
 					// Bouton compact (largeur fixe) : DrawAuthButtonGhost s'étire sur
 					// toute la largeur restante (width -FLT_MIN), inadapté après SameLine.
-					ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kSurface));
-					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.12f)));
-					ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.18f)));
-					ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+					ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kSurface));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.12f)));
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.18f)));
+					ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 					if (ImGui::Button(tr("options.keybind.rebind", "Modifier").c_str(), ImVec2(110.f, 28.f)))
@@ -562,7 +554,7 @@ namespace engine::render
 			}
 			if (!m_rebindWarning.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kWarning));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kWarning));
 				ImGui::TextWrapped("%s", m_rebindWarning.c_str());
 				ImGui::PopStyleColor();
 			}
@@ -664,13 +656,13 @@ namespace engine::render
 				}
 			}
 			ImGui::Spacing();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::TextUnformatted(tr("options.imgui.latency_label").c_str());
 			ImGui::SameLine(0.f, 12.f);
 			if (m_authPresenter != nullptr)
 			{
 				const auto& sc = m_authPresenter->GetStatusCache();
-				ImGui::PushStyleColor(ImGuiCol_Text, sc.authOk ? IV(LnTheme::kSuccess) : IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, sc.authOk ? ToImVec4(LnTheme::kSuccess) : ToImVec4(LnTheme::kMuted));
 				const std::string lat = sc.authOk ? tr("options.imgui.latency_ok") : std::string("--");
 				ImGui::TextUnformatted(lat.c_str());
 				ImGui::PopStyleColor();
@@ -693,18 +685,18 @@ namespace engine::render
 		else if (m_optionsTab == 6)
 		{
 			sectionTitle("options.imgui.account.section");
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 			ImGui::BeginChild("##acct_card", ImVec2(-FLT_MIN, 92.f), true, ImGuiWindowFlags_None);
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(2);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			const std::string& loginDisp = rm.authOptionsAccountLogin.empty() ? tr("options.imgui.account_anon") : rm.authOptionsAccountLogin;
 			ImGui::TextUnformatted(loginDisp.c_str());
 			ImGui::PopStyleColor();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			const std::string& tagDisp = rm.authOptionsAccountTagId.empty() ? std::string("-") : rm.authOptionsAccountTagId;
 			ImGui::TextUnformatted(tagDisp.c_str());
 			ImGui::PopStyleColor();
@@ -750,10 +742,10 @@ namespace engine::render
 				ImGui::BeginDisabled();
 			}
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			const bool c = ImGui::Button(label, ImVec2(w, 32.f));
@@ -785,13 +777,13 @@ namespace engine::render
 		}
 		else
 		{
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kAccent));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2.f);
 		}
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.25f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.35f)));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.25f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.35f)));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		const bool applyClick = ImGui::Button(applyStr.c_str(), ImVec2(btnW, 32.f));
 		ImGui::PopStyleVar(1);

--- a/src/client/render/auth/screens/AuthImGuiShardPick.cpp
+++ b/src/client/render/auth/screens/AuthImGuiShardPick.cpp
@@ -18,22 +18,14 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur LnTheme::Rgba en ImVec4 pour les appels de style ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
-
-		/// Convertit une couleur LnTheme::Rgba en ImU32 pour les appels de draw list ImGui.
-		ImU32 U32(const LnTheme::Rgba& c)
-		{
-			return ImGui::ColorConvertFloat4ToU32(IV(c));
-		}
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
 
 		/// Retourne la premiere lettre alphabetique (majuscule) d'une chaine (nom public
 		/// du serveur), utilisee comme avatar textuel dans la carte de shard. '?' si aucune.
@@ -105,7 +97,7 @@ namespace engine::render
 		const std::string infoStr = tr("auth.shard_pick.footer_info");
 		if (!infoStr.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.82f);
 			ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 760.f);
 			ImGui::TextWrapped("%s", infoStr.c_str());
@@ -120,7 +112,7 @@ namespace engine::render
 
 		if (entries.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::TextWrapped("%s", tr("auth.shard_pick.none_online").c_str());
 			ImGui::PopStyleColor();
 		}
@@ -177,7 +169,7 @@ namespace engine::render
 						? tr("auth.shard_pick.desc_offline")
 						: std::string{};
 
-				const ImVec4 borderCol = isSelected ? IV(LnTheme::kAccent) : IV(LnTheme::kBorder);
+				const ImVec4 borderCol = isSelected ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kBorder);
 				const float dim = (rowSelectable || e.status == 2u) ? 1.f : 0.48f;
 
 				// On pousse 3 StyleVar (Alpha + ChildRounding + ChildBorderSize) et 2 StyleColor
@@ -187,7 +179,7 @@ namespace engine::render
 				// Avant : on poppait les 3 StyleVar ici ET 1 StyleVar apres EndChild > assertion ImGui
 				// " PopStyleVar() too many times ".
 				ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * dim);
-				ImGui::PushStyleColor(ImGuiCol_ChildBg, isSelected ? IV(LnTheme::AccentDim(0.1f)) : IV(LnTheme::kSurface));
+				ImGui::PushStyleColor(ImGuiCol_ChildBg, isSelected ? ToImVec4(LnTheme::AccentDim(0.1f)) : ToImVec4(LnTheme::kSurface));
 				ImGui::PushStyleColor(ImGuiCol_Border, borderCol);
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.f);
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, isSelected ? 2.f : 1.f);
@@ -234,14 +226,14 @@ namespace engine::render
 				const ImVec2 flagP0 = ImGui::GetCursorScreenPos();
 				const ImVec2 flagP1 = ImVec2(flagP0.x + kFlag, flagP0.y + kFlag);
 				ImDrawList* dl = ImGui::GetWindowDrawList();
-				dl->AddRectFilled(flagP0, flagP1, U32(LnTheme::kPanel), 6.f);
-				dl->AddRect(flagP0, flagP1, isSelected ? U32(LnTheme::kAccent) : U32(LnTheme::kBorder), 6.f, 0, 1.5f);
+				dl->AddRectFilled(flagP0, flagP1, ToU32(LnTheme::kPanel), 6.f);
+				dl->AddRect(flagP0, flagP1, isSelected ? ToU32(LnTheme::kAccent) : ToU32(LnTheme::kBorder), 6.f, 0, 1.5f);
 				{
 					ImFont* font = ImGui::GetFont();
 					const ImVec2 ts = font->CalcTextSizeA(kInitFontPx, FLT_MAX, 0.f, initialBuf);
 					dl->AddText(font, kInitFontPx,
 						ImVec2(flagP0.x + (kFlag - ts.x) * 0.5f, flagP0.y + (kFlag - ts.y) * 0.5f),
-						U32(LnTheme::kText), initialBuf);
+						ToU32(LnTheme::kText), initialBuf);
 				}
 
 				// --- Colonne nom (nom + [desc] + mode + [event]), centree verticalement -
@@ -253,14 +245,14 @@ namespace engine::render
 					nameBlockH += sp + fs * 0.76f;
 				ImGui::SetCursorPos(ImVec2(nameX, centeredY(nameBlockH)));
 				ImGui::BeginGroup();
-				ImGui::PushStyleColor(ImGuiCol_Text, isSelected ? IV(LnTheme::kAccent) : IV(LnTheme::kText));
+				ImGui::PushStyleColor(ImGuiCol_Text, isSelected ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kText));
 				ImGui::SetWindowFontScale(1.05f);
 				ImGui::TextUnformatted(nameUpper.c_str());
 				ImGui::SetWindowFontScale(1.f);
 				ImGui::PopStyleColor();
 				if (!descLine.empty())
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 					ImGui::SetWindowFontScale(0.82f);
 					ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + nameW);
 					ImGui::TextWrapped("%s", descLine.c_str());
@@ -268,7 +260,7 @@ namespace engine::render
 					ImGui::SetWindowFontScale(1.f);
 					ImGui::PopStyleColor();
 				}
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.76f);
 				// Ligne « MODE  REGLE » construite a partir des enums (game_mode + ruleset),
 				// localisee. Remplace le texte « PvE  COOPERATIVE » fige. tr() prend un
@@ -281,7 +273,7 @@ namespace engine::render
 				{
 					const std::string ev = tr("auth.shard_pick.event_characters",
 						P{{"count", std::to_string(e.character_count)}});
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 					ImGui::TextUnformatted(ev.c_str());
 					ImGui::PopStyleColor();
 				}
@@ -294,19 +286,19 @@ namespace engine::render
 				ImGui::SetCursorPos(ImVec2(loadX, centeredY(loadBlockH)));
 				ImGui::BeginGroup();
 				const std::string loadLbl = tr("auth.shard_pick.load_line", P{{"percent", std::to_string(pct)}});
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.72f);
 				ImGui::TextUnformatted(loadLbl.c_str());
 				ImGui::SetWindowFontScale(1.f);
 				ImGui::PopStyleColor();
 				const LnTheme::Rgba barCol = (vis == RowVis::Offline) ? LnTheme::kMuted
 					: (vis == RowVis::Saturated) ? LnTheme::kWarning : LnTheme::kSuccess;
-				ImGui::PushStyleColor(ImGuiCol_PlotHistogram, IV(barCol));
+				ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ToImVec4(barCol));
 				ImGui::ProgressBar(loadFrac, ImVec2(kLoadW, kBarH), "");
 				ImGui::PopStyleColor();
 				const std::string pl = tr("auth.shard_pick.players",
 					P{{"current", std::to_string(e.current_load)}, {"max", std::to_string(e.max_capacity)}});
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.78f);
 				ImGui::TextUnformatted(pl.c_str());
 				ImGui::SetWindowFontScale(1.f);
@@ -335,14 +327,14 @@ namespace engine::render
 				};
 				// Ligne 1 : etat.
 				ImGui::SetCursorPos(ImVec2(rightAlignX(0.78f, statStr.c_str()), statusTopY));
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(stCol));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(stCol));
 				ImGui::SetWindowFontScale(0.78f);
 				ImGui::TextUnformatted(statStr.c_str());
 				ImGui::SetWindowFontScale(1.f);
 				ImGui::PopStyleColor();
 				// Ligne 2 : latence master, sous l'etat, plus petite et discrete.
 				ImGui::SetCursorPos(ImVec2(rightAlignX(0.72f, latStr.c_str()), statusTopY + fs * 0.78f + sp));
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.72f);
 				ImGui::TextUnformatted(latStr.c_str());
 				ImGui::SetWindowFontScale(1.f);
@@ -379,10 +371,10 @@ namespace engine::render
 				ImGui::BeginDisabled();
 			}
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			const bool c = ImGui::Button(label, ImVec2(w, 32.f));
@@ -402,7 +394,7 @@ namespace engine::render
 		ImGui::SameLine(0.f, 14.f);
 		{
 			const std::string navRow = tr("auth.shard_pick.hint_nav_row");
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.82f);
 			ImGui::AlignTextToFramePadding();
 			ImGui::TextUnformatted(navRow.c_str());
@@ -416,10 +408,10 @@ namespace engine::render
 		{
 			ImGui::BeginDisabled();
 		}
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.25f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.35f)));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.25f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.35f)));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		const bool enterClick = ImGui::Button(enterStr.c_str(), ImVec2(enterW, 32.f));
 		ImGui::PopStyleVar(1);


### PR DESCRIPTION
## Objectif

Supprimer la duplication du couple de conversion couleur `Rgba → ImVec4 / ImU32`
(`IV()`/`U32()`) redéfini à l'identique dans chaque renderer ImGui, en l'exposant
une seule fois. Changement isolé, **aucun changement de rendu** (bit-à-bit).

## Approche (option B)

Nouvel en-tête compagnon `src/client/render/LnThemeImGui.h` exposant
`LnTheme::ToImVec4(const Rgba&)` et `LnTheme::ToU32(const Rgba&)`. `LnTheme.h`
reste **pur** (aucune dépendance ImGui, inclus par des cibles sans ImGui comme
`ln_theme_tests`) ; le compagnon n'est inclus que dans les blocs
`#if defined(_WIN32)`. `ToU32` délègue à `ImGui::ColorConvertFloat4ToU32` (source
de vérité du packing → identité garantie).

Dans chaque renderer : `#include` du compagnon, `using LnTheme::ToImVec4;`
(+ `ToU32`), et rename mécanique des sites d'appel `IV(`→`ToImVec4(`,
`U32(`→`ToU32(`.

## Découpage (relecture en 2 lots)

- **Lot 1/2 (ce commit)** — 5 fichiers qui définissaient `IV` **ET** `U32`
  (AuthImGuiRenderer, AuthImGuiOptions, AuthImGuiShardPick, AuthImGuiError,
  AuthImGuiLanguageSelect) + câblage CMake du header.
- **Lot 2/2 (à venir)** — les 22 fichiers restants (`IV` seul).

> **Draft** : ouverte pour valider le pattern via la CI Windows sur le lot 1
> avant de généraliser au lot 2. Le lot 2 emploie exactement le même mécanisme.

## Tests

Pas de nouvelle cible de test : `ToU32` dépend d'ImGui, absent de la cible ctest
(Linux, `engine_core` sans ImGui). Non-régression assurée par la validation
visuelle des écrans d'auth (rename mécanique : s'il compile, le rendu est
identique par construction).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)