### PR TITLE
refactor(ui): généralise ToImVec4 aux 22 renderers restants (lot 2/2)

### DIFF
--- a/src/client/render/ArenaImGuiRenderer.cpp
+++ b/src/client/render/ArenaImGuiRenderer.cpp
@@ -11,12 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Libelle FR pour une taille d'arene.
 		const char* SizeLabel(uint8_t size)
@@ -58,8 +59,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Arene (F8)##ln_arena_panel", nullptr, flags))
@@ -189,8 +190,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(modalW, modalH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.97f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.97f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.97f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
 			| ImGuiWindowFlags_NoResize

--- a/src/client/render/AuctionImGuiRenderer.cpp
+++ b/src/client/render/AuctionImGuiRenderer.cpp
@@ -13,12 +13,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Retourne le steady_clock now en ms (pour les toasts 5s).
 		uint64_t SteadyNowMs()
@@ -62,8 +63,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Hotel des ventes (F6)##ln_auction_panel", nullptr, flags))

--- a/src/client/render/BattleGroundImGuiRenderer.cpp
+++ b/src/client/render/BattleGroundImGuiRenderer.cpp
@@ -11,12 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Libelle FR pour une faction.
 		const char* FactionLabel(uint8_t fac)
@@ -70,8 +71,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Champ de bataille (F9)##ln_bg_panel", nullptr, flags))
@@ -221,8 +222,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
 			| ImGuiWindowFlags_NoResize

--- a/src/client/render/CharacterSheetImGuiRenderer.cpp
+++ b/src/client/render/CharacterSheetImGuiRenderer.cpp
@@ -11,12 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Transforme une cle de ressource snake_case en libelle affichable :
 		/// chaque '_' devient une espace, la premiere lettre passe en majuscule,
@@ -68,8 +69,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Personnage##ln_character_sheet", nullptr, flags))

--- a/src/client/render/ChatImGuiRenderer.cpp
+++ b/src/client/render/ChatImGuiRenderer.cpp
@@ -15,12 +15,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Convertit ARGB8888 (cf. \ref engine::net::ChannelColorArgb) en ImVec4.
 		/// ImGui n'a pas d'overload qui prend un ARGB direct ; on décompose via masques.
@@ -78,8 +79,8 @@ namespace engine::render
 		// Background opaque (alpha=0.95) au lieu de 0.78 pour bien le voir sur fonds clairs et sombres.
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		// inWorldShard ignore : le chat n'est rendu que post-EnterWorld (gating cote
 		// Engine.cpp), donc inWorldShard est toujours true ici en pratique. On garde
@@ -120,8 +121,8 @@ namespace engine::render
 				: (sizeof(kChannelsPostAuth) / sizeof(kChannelsPostAuth[0]));
 			const uint16_t mask = m_chat->ChannelFilterMask();
 			ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.20f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive,  IV(LnTheme::AccentDim(0.35f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.20f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ToImVec4(LnTheme::AccentDim(0.35f)));
 			for (size_t k = 0; k < kVisibleChannelsCount; ++k)
 			{
 				const uint8_t i = kVisibleChannels[k];
@@ -129,7 +130,7 @@ namespace engine::render
 				const bool visible = (mask & (1u << i)) != 0u;
 				const ImVec4 color = visible
 					? ArgbToIm(engine::net::ChannelColorArgb(static_cast<engine::net::ChatChannel>(i)))
-					: IV(LnTheme::kMuted);
+					: ToImVec4(LnTheme::kMuted);
 				ImGui::PushStyleColor(ImGuiCol_Text, color);
 				char buttonId[32];
 				// Pas de crochets [ ] autour du tag : Windlass.ttf n'a pas ces glyphes et
@@ -233,9 +234,9 @@ namespace engine::render
 					ImGui::SetKeyboardFocusHere();
 				}
 
-				ImGui::PushStyleColor(ImGuiCol_Text,    IV(LnTheme::kAccent));
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-				ImGui::PushStyleColor(ImGuiCol_Border,  IV(LnTheme::kBorder));
+				ImGui::PushStyleColor(ImGuiCol_Text,    ToImVec4(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+				ImGui::PushStyleColor(ImGuiCol_Border,  ToImVec4(LnTheme::kBorder));
 				ImGui::Text("> ");
 				ImGui::SameLine(0.f, 4.f);
 				ImGui::SetNextItemWidth(-FLT_MIN); // remplit la ligne restante
@@ -256,7 +257,7 @@ namespace engine::render
 			}
 			else
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextUnformatted("/ pour tchatter  -  1..0 filtres canal");
 				ImGui::PopStyleColor();
 			}

--- a/src/client/render/EditorHubImGuiRenderer.cpp
+++ b/src/client/render/EditorHubImGuiRenderer.cpp
@@ -5,12 +5,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 	}
 
 	void EditorHubImGuiRenderer::Render(float viewportW, float viewportH)
@@ -25,8 +26,8 @@ namespace engine::render
 		ImGui::SetNextWindowPos(ImVec2(margin, margin));
 		ImGui::SetNextWindowBgAlpha(0.78f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.78f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.78f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
 			| ImGuiWindowFlags_NoMove
@@ -38,7 +39,7 @@ namespace engine::render
 		if (ImGui::Begin("##ln_editor_hub", nullptr, flags))
 		{
 			// Header LCDLLN Editor + indicator dirty.
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			if (m_editor->IsDirty())
 				ImGui::TextUnformatted("[LCDLLN Editor] *dirty*");
 			else
@@ -52,13 +53,13 @@ namespace engine::render
 			const std::string& title = m_editor->GetHubTitle();
 			if (!title.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 				ImGui::TextWrapped("%s", title.c_str());
 				ImGui::PopStyleColor();
 			}
 			else
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextUnformatted("(en attente du premier RefreshShell...)");
 				ImGui::PopStyleColor();
 			}

--- a/src/client/render/GameEventImGuiRenderer.cpp
+++ b/src/client/render/GameEventImGuiRenderer.cpp
@@ -12,12 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Couleur ImGui par etat (Active=vert, Inactive=gris). Inputs
 		/// invalides -> gris fonce.
@@ -93,8 +94,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Game Events##ln_gameevents_panel", nullptr, flags))

--- a/src/client/render/GmTicketImGuiRenderer.cpp
+++ b/src/client/render/GmTicketImGuiRenderer.cpp
@@ -13,12 +13,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Rend une chaine "il y a X minutes/heures/jours" a partir d'un timestamp UTC ms.
 		/// Pour V1 on reste simple : pas d'i18n, hardcode FR. Si timestamp vide ou futur,
@@ -99,8 +100,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Support GM##ln_gmtickets_panel", nullptr, flags))

--- a/src/client/render/GuildImGuiRenderer.cpp
+++ b/src/client/render/GuildImGuiRenderer.cpp
@@ -12,12 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Couleur de l'indicateur online (vert) / offline (gris).
 		ImVec4 OnlineColor(bool online)
@@ -67,8 +68,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Guildes (F5)##ln_guilds_panel", nullptr, flags))

--- a/src/client/render/LfgImGuiRenderer.cpp
+++ b/src/client/render/LfgImGuiRenderer.cpp
@@ -11,12 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// V1 : catalogue dungeon hardcode cote client. Le master n'a pas de
 		/// catalogue centralise (tout dungeonId > 0 est accepte). Le ticket
@@ -84,8 +85,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("LFG##ln_lfg_panel", nullptr, flags))
@@ -182,8 +183,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(modalW, modalH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.97f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.97f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.97f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
 			| ImGuiWindowFlags_NoResize

--- a/src/client/render/LootRollImGuiRenderer.cpp
+++ b/src/client/render/LootRollImGuiRenderer.cpp
@@ -12,12 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Couleur pour un choice (0=Pass=gris, 1=Greed=vert, 2=Need=violet).
 		ImVec4 ChoiceColor(uint8_t choice)
@@ -72,8 +73,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Tirage de butin (F7)##ln_loot_panel", nullptr, flags))

--- a/src/client/render/MailImGuiRenderer.cpp
+++ b/src/client/render/MailImGuiRenderer.cpp
@@ -14,12 +14,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Rend une chaine "il y a X minutes/heures/jours" a partir d'un timestamp UTC ms.
 		/// Pour V1 on reste simple : pas d'i18n, hardcode FR. Si timestamp vide ou futur,
@@ -86,8 +87,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Boite mail##ln_mail_panel", nullptr, flags))
@@ -208,7 +209,7 @@ namespace engine::render
 					ImGui::Spacing();
 					if (it->bodyLoaded)
 					{
-						ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
+						ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
 						ImGui::BeginChild("##ln_mail_body", ImVec2(0.f, 100.f), true,
 							ImGuiWindowFlags_HorizontalScrollbar);
 						ImGui::TextWrapped("%s", it->body.c_str());

--- a/src/client/render/OutdoorPvpImGuiRenderer.cpp
+++ b/src/client/render/OutdoorPvpImGuiRenderer.cpp
@@ -12,12 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Libelle FR pour une faction.
 		const char* FactionLabel(uint8_t fac)
@@ -78,8 +79,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("PvP exterieur (F10)##ln_outdoorpvp_panel", nullptr, flags))

--- a/src/client/render/ReputationImGuiRenderer.cpp
+++ b/src/client/render/ReputationImGuiRenderer.cpp
@@ -13,12 +13,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Bornes par standing (synchronise avec ReputationManager::StandingFor).
 		/// Retourne la valeur min de l'intervalle pour le standing donne.
@@ -139,8 +140,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Reputation##ln_reputation_panel", nullptr, flags))
@@ -243,8 +244,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.85f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.85f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.85f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar
 			| ImGuiWindowFlags_NoResize

--- a/src/client/render/SkillBookImGuiRenderer.cpp
+++ b/src/client/render/SkillBookImGuiRenderer.cpp
@@ -12,12 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Couleur du texte / barre selon le ratio value/cap.
 		ImVec4 SkillProgressColor(uint16_t value, uint16_t cap)
@@ -84,8 +85,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Livre de competences (F2)##ln_skillbook_panel", nullptr, flags))
@@ -210,8 +211,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(toastW, toastH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.85f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.85f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.85f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar
 			| ImGuiWindowFlags_NoResize

--- a/src/client/render/WeatherImGuiRenderer.cpp
+++ b/src/client/render/WeatherImGuiRenderer.cpp
@@ -11,12 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c) { return ImVec4(c.r, c.g, c.b, c.a); }
+		using LnTheme::ToImVec4;
 
 		/// Couleur ImGui par WeatherKind pour le texte (intensifie le visuel
 		/// de la liste / HUD). Inputs invalides -> gris.
@@ -84,8 +85,8 @@ namespace engine::render
 		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, IV(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Meteo##ln_weather_panel", nullptr, flags))

--- a/src/client/render/auth/AuthImGuiCommon.cpp
+++ b/src/client/render/auth/AuthImGuiCommon.cpp
@@ -12,16 +12,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur thème en ImVec4 pour ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 	}
 
 	/// Dessine une bannière colorée avec un titre accentué et un message de corps enroulé.
@@ -51,7 +48,7 @@ namespace engine::render
 		ImGui::PopStyleColor();
 		if (!message.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::TextWrapped("%.*s", static_cast<int>(message.size()), message.data());
 			ImGui::PopStyleColor();
 		}
@@ -84,20 +81,20 @@ namespace engine::render
 		const ImU32 fillOff = IM_COL32(40, 48, 62, 255);
 		const ImU32 fillOn = IM_COL32(72, 90, 48, 255);
 		dl->AddRectFilled(a, b, on ? fillOn : fillOff, trackH * 0.5f);
-		dl->AddRect(a, b, ImGui::ColorConvertFloat4ToU32(IV(LnTheme::kBorder)), trackH * 0.5f, 0, 1.f);
+		dl->AddRect(a, b, ImGui::ColorConvertFloat4ToU32(ToImVec4(LnTheme::kBorder)), trackH * 0.5f, 0, 1.f);
 		const float thumbR = (trackH - pad * 2.f) * 0.5f;
 		const float cx = on ? (b.x - pad - thumbR) : (a.x + pad + thumbR);
 		const float cy = (a.y + b.y) * 0.5f;
-		dl->AddCircleFilled(ImVec2(cx, cy), thumbR, ImGui::ColorConvertFloat4ToU32(IV(LnTheme::kAccent)));
+		dl->AddCircleFilled(ImVec2(cx, cy), thumbR, ImGui::ColorConvertFloat4ToU32(ToImVec4(LnTheme::kAccent)));
 
 		ImGui::SameLine(0.f, 12.f);
 		ImGui::BeginGroup();
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::TextUnformatted(label.data(), label.data() + static_cast<int>(label.size()));
 		ImGui::PopStyleColor();
 		if (!hint.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.82f);
 			ImGui::TextWrapped("%.*s", static_cast<int>(hint.size()), hint.data());
 			ImGui::SetWindowFontScale(1.f);
@@ -119,9 +116,9 @@ namespace engine::render
 		id.append(label.data(), label.size());
 		id.append(idSuffix.data(), idSuffix.size());
 		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.10f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.18f)));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.10f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.18f)));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.f, 8.f));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 4.f);
 		const bool pressed = ImGui::Button(id.c_str());
@@ -137,10 +134,10 @@ namespace engine::render
 		{
 			ImGui::BeginDisabled();
 		}
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
 		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.39f, 0.58f, 0.82f, 1.f));
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.19f, 0.38f, 0.62f, 1.f));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		std::string id;
 		id.append(label.data(), label.size());
@@ -158,11 +155,11 @@ namespace engine::render
 	/// Dessine un bouton fantôme (fond surface, bordure texte) occupant toute la largeur disponible.
 	bool DrawAuthButtonGhost(std::string_view label, std::string_view idSuffix)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.1f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.16f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kText));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.1f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.16f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		std::string id;
@@ -178,7 +175,7 @@ namespace engine::render
 	void DrawAuthKeycapRow(std::string_view leftKey, std::string_view leftDesc, std::string_view midKey, std::string_view midDesc,
 		std::string_view rightKey, std::string_view rightDesc)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::Text("[%.*s] %.*s", static_cast<int>(leftKey.size()), leftKey.data(), static_cast<int>(leftDesc.size()), leftDesc.data());
 		ImGui::SameLine(0.f, 14.f);
 		ImGui::Text("[%.*s] %.*s", static_cast<int>(midKey.size()), midKey.data(), static_cast<int>(midDesc.size()), midDesc.data());
@@ -194,15 +191,15 @@ namespace engine::render
 		const float avail = ImGui::GetContentRegionAvail().x;
 		ImGui::Columns(2, "##auth_keybind", false);
 		ImGui::SetColumnWidth(0, (std::max)(120.f, avail * 0.55f));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::TextUnformatted(actionName.data(), actionName.data() + static_cast<int>(actionName.size()));
 		ImGui::PopStyleColor();
 		ImGui::NextColumn();
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 		ImGui::TextUnformatted(keyLabel.data(), keyLabel.data() + static_cast<int>(keyLabel.size()));
 		ImGui::PopStyleColor();
 		ImGui::Columns(1);
-		ImGui::PushStyleColor(ImGuiCol_Separator, IV(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
 		ImGui::Separator();
 		ImGui::PopStyleColor();
 		ImGui::PopID();
@@ -211,10 +208,10 @@ namespace engine::render
 	/// Dessine un bouton d'action destructrice (fond rouge erreur) pleine largeur.
 	bool DrawAuthButtonDanger(std::string_view label, std::string_view idSuffix)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kErrorCol));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.18f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::kErrorCol));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kErrorCol));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.18f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::kErrorCol));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		std::string id;
 		id.append(label.data(), label.size());

--- a/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
@@ -23,16 +23,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur LnTheme::Rgba en ImVec4 pour les appels de style ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 	} // namespace
 
 	/// Affiche l'ecran de creation de personnage en 2 colonnes : apercu 3D a
@@ -102,7 +99,7 @@ namespace engine::render
 
 			// ---------------- Colonne gauche : apercu visuel ----------------
 			ImGui::TableSetColumnIndex(0);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::TextUnformatted("APERCU");
 			ImGui::PopStyleColor();
 			if (m_racePreview && m_racePreview->IsValid())
@@ -127,7 +124,7 @@ namespace engine::render
 			DrawField(nameLabel.c_str(), m_charName, static_cast<int>(sizeof(m_charName)));
 			for (const auto& line : rm.bodyLines)
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextWrapped("%s", line.text.c_str());
 				ImGui::PopStyleColor();
 			}
@@ -148,7 +145,7 @@ namespace engine::render
 			{
 				// ---- Combo FACTION (seulement les factions selectionnables) ----
 				ImGui::Spacing();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted("FACTION");
 				ImGui::PopStyleColor();
 
@@ -186,7 +183,7 @@ namespace engine::render
 				// Affiche la race deduite en lecture seule (pas de combo race).
 				if (hasRaces && m_charRaceIdx >= 0 && m_charRaceIdx < static_cast<int>(races->size()))
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 					ImGui::Text("Race : %s", (*races)[m_charRaceIdx].displayName.c_str());
 					ImGui::PopStyleColor();
 				}
@@ -195,7 +192,7 @@ namespace engine::render
 				const std::vector<engine::client::FactionClass>* facClasses =
 					ccPresenter->GetFactionClasses(realFactionIdx);
 				ImGui::Spacing();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted("CLASSE");
 				ImGui::PopStyleColor();
 				if (facClasses && !facClasses->empty())
@@ -240,7 +237,7 @@ namespace engine::render
 				if (!facDesc.empty() || !clsDesc.empty())
 				{
 					ImGui::Spacing();
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 					if (!facDesc.empty())
 						ImGui::TextWrapped("%s", facDesc.c_str());
 					if (!facDesc.empty() && !clsDesc.empty())
@@ -254,7 +251,7 @@ namespace engine::render
 			{
 				// Repli : ancien combo RACE pur (aucune faction chargee).
 				ImGui::Spacing();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted("RACE");
 				ImGui::PopStyleColor();
 				std::vector<const char*> labels;
@@ -268,7 +265,7 @@ namespace engine::render
 			else
 			{
 				ImGui::Spacing();
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted("RACE");
 				ImGui::PopStyleColor();
 				ImGui::TextDisabled("(liste des races indisponible)");
@@ -279,7 +276,7 @@ namespace engine::render
 			// Genre : 0 = Masculin (male), 1 = Feminin (female). Deux RadioButtons cote
 			// a cote. La bascule met a jour l'apercu 3D (mesh genre) plus bas.
 			ImGui::Spacing();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::TextUnformatted("GENRE");
 			ImGui::PopStyleColor();
 			ImGui::RadioButton("Masculin", &m_charGender, 0);
@@ -289,7 +286,7 @@ namespace engine::render
 			// Teinte de peau : 0 = Claire, 1 = Foncée. Visible sur les parties de
 			// peau exposées (mains avec le Ranger ; corps entier avec un futur mesh).
 			ImGui::Spacing();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::TextUnformatted("TEINTE DE PEAU");
 			ImGui::PopStyleColor();
 			ImGui::RadioButton("Claire", &m_charSkinTone, 0);
@@ -327,7 +324,7 @@ namespace engine::render
 					}
 
 					ImGui::Spacing();
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 					ImGui::TextUnformatted("APPARENCE PHYSIQUE");
 					ImGui::PopStyleColor();
 

--- a/src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
@@ -16,15 +16,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 	}
 
 	void AuthImGuiRenderer::RenderCharacterSelectScreen(const RenderModel& rm, float vpW, float vpH)
@@ -60,7 +58,7 @@ namespace engine::render
 		const std::string hintStr = tr("auth.character_select.hint");
 		if (!hintStr.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.85f);
 			ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + 620.f);
 			ImGui::TextWrapped("%s", hintStr.c_str());
@@ -75,7 +73,7 @@ namespace engine::render
 
 		if (entries.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::TextWrapped("%s", tr("auth.character_select.empty").c_str());
 			ImGui::PopStyleColor();
 		}
@@ -88,9 +86,9 @@ namespace engine::render
 				const bool isSelected = (static_cast<int>(i) == selected);
 
 				ImGui::PushStyleColor(ImGuiCol_ChildBg,
-					isSelected ? IV(LnTheme::AccentDim(0.1f)) : IV(LnTheme::kSurface));
+					isSelected ? ToImVec4(LnTheme::AccentDim(0.1f)) : ToImVec4(LnTheme::kSurface));
 				ImGui::PushStyleColor(ImGuiCol_Border,
-					isSelected ? IV(LnTheme::kAccent) : IV(LnTheme::kBorder));
+					isSelected ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kBorder));
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.f);
 				ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, isSelected ? 2.f : 1.f);
 				char rowId[40];
@@ -101,7 +99,7 @@ namespace engine::render
 
 				const std::string nameUpper = c.name.empty() ? std::string("?") : c.name;
 				ImGui::PushStyleColor(ImGuiCol_Text,
-					isSelected ? IV(LnTheme::kAccent) : IV(LnTheme::kText));
+					isSelected ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kText));
 				ImGui::SetWindowFontScale(1.05f);
 				ImGui::TextUnformatted(nameUpper.c_str());
 				ImGui::SetWindowFontScale(1.f);
@@ -162,7 +160,7 @@ namespace engine::render
 				// Symbole race (lettre) en accent juste avant la subline si dispo.
 				if (raceSym != '\0')
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 					ImGui::SetWindowFontScale(0.95f);
 					char symBuf[2] = { raceSym, '\0' };
 					ImGui::TextUnformatted(symBuf);
@@ -170,7 +168,7 @@ namespace engine::render
 					ImGui::PopStyleColor();
 					ImGui::SameLine(0.f, 8.f);
 				}
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.82f);
 				ImGui::TextUnformatted(sub.c_str());
 				ImGui::SetWindowFontScale(1.f);
@@ -187,10 +185,10 @@ namespace engine::render
 				ImGui::SetCursorPos(ImVec2(btnX, (kRowH - 28.f) * 0.5f));
 				if (isConfirming)
 				{
-					ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kErrorCol));
-					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::kErrorCol));
-					ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::kErrorCol));
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+					ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kErrorCol));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::kErrorCol));
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::kErrorCol));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 					char btnId[48];
 					std::snprintf(btnId, sizeof(btnId), "%s##chardel_confirm%zu",
 						tr("auth.character_select.delete_confirm").c_str(), i);
@@ -204,9 +202,9 @@ namespace engine::render
 				else
 				{
 					ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-					ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kErrorCol));
-					ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kErrorCol));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+					ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kErrorCol));
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kErrorCol));
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 					char btnId[48];
@@ -255,10 +253,10 @@ namespace engine::render
 			if (disabled)
 				ImGui::BeginDisabled();
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			const bool clicked = ImGui::Button(label, ImVec2(w, 32.f));
@@ -287,10 +285,10 @@ namespace engine::render
 		ImGui::SameLine(0.f, 0.f);
 		if (!canPlay)
 			ImGui::BeginDisabled();
-		ImGui::PushStyleColor(ImGuiCol_Button, IV(LnTheme::kPrimary));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.25f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.35f)));
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.25f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.35f)));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 		const bool playClick = ImGui::Button(playStr.c_str(), ImVec2(playW, 32.f));
 		ImGui::PopStyleVar(1);

--- a/src/client/render/auth/screens/AuthImGuiRegister.cpp
+++ b/src/client/render/auth/screens/AuthImGuiRegister.cpp
@@ -10,16 +10,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur theme en ImVec4 pour ImGui::PushStyleColor.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 	}
 
 	/// Affiche le formulaire d'inscription : identifiant, e-mail, mots de passe, date de naissance, pays, nom/prenom, et boutons Retour/Creer.
@@ -77,7 +74,7 @@ namespace engine::render
 			DrawAuthGoldField(rm.fields[4], m_regEmail, static_cast<int>(sizeof(m_regEmail)), false);
 			if (!rm.authRegisterEmailHint.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.82f);
 				ImGui::TextWrapped("%s", rm.authRegisterEmailHint.c_str());
 				ImGui::SetWindowFontScale(1.f);
@@ -132,7 +129,7 @@ namespace engine::render
 			const std::string& dayLab = rm.dropdowns[0].label.empty() ? std::string("JOUR") : rm.dropdowns[0].label;
 			const std::string& monLab = rm.dropdowns[1].label.empty() ? std::string("MOIS") : rm.dropdowns[1].label;
 			const std::string& yrLab = rm.dropdowns[2].label.empty() ? std::string("ANNEE") : rm.dropdowns[2].label;
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::TextUnformatted(dayLab.c_str());
 			ImGui::SameLine();
 			ImGui::SetCursorPosX(ddStartX + ddW + ddGap);
@@ -141,8 +138,8 @@ namespace engine::render
 			ImGui::SetCursorPosX(ddStartX + (ddW + ddGap) * 2.f);
 			ImGui::TextUnformatted(yrLab.c_str());
 			ImGui::PopStyleColor();
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::SetNextItemWidth(ddW);
 			if (!dayPtrs.empty())
@@ -174,7 +171,7 @@ namespace engine::render
 						ch = static_cast<char>(ch - 'a' + 'A');
 					}
 				}
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 				ImGui::TextUnformatted(lab.c_str());
 				ImGui::PopStyleColor();
 				if (!rm.authRegisterCountryPick.empty())
@@ -182,8 +179,8 @@ namespace engine::render
 					m_regCountryComboIdx =
 						std::clamp(m_regCountryComboIdx, 0, static_cast<int>(rm.authRegisterCountryPick.size()) - 1);
 					const std::string& preview = rm.authRegisterCountryPick[static_cast<size_t>(m_regCountryComboIdx)].second;
-					ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-					ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+					ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+					ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 					ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 					if (ImGui::BeginCombo("##reg_country", preview.c_str()))
 					{
@@ -242,7 +239,7 @@ namespace engine::render
 		auto drawRule = [this, &tr](int32_t state, const char* key, const char* fallback) {
 			if (state < 0) return;                       // non évalué (champ vide)
 			const bool ok = (state == 1);
-			ImGui::PushStyleColor(ImGuiCol_Text, ok ? IV(LnTheme::kAccent) : IV(LnTheme::kErrorCol));
+			ImGui::PushStyleColor(ImGuiCol_Text, ok ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kErrorCol));
 			ImGui::Text("%s %s", ok ? "[v]" : "[x]", tr(key, fallback).c_str());
 			ImGui::PopStyleColor();
 		};
@@ -300,7 +297,7 @@ namespace engine::render
 			if (!rm.authRegisterShowErrorsLabel.empty() && !canSubmit)
 			{
 				ImGui::SameLine(0.f, 18.f);
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				if (ImGui::SmallButton(rm.authRegisterShowErrorsLabel.c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
 				{
 					m_authPresenter->ImGuiRegisterPreviewValidationErrors(*m_authCfg);

--- a/src/client/render/auth/screens/AuthImGuiTerms.cpp
+++ b/src/client/render/auth/screens/AuthImGuiTerms.cpp
@@ -9,16 +9,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur LnTheme::Rgba en ImVec4 pour les appels de style ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 	} // namespace
 
 	/// Affiche l'ecran des CGU : metadonnees en en-tete, texte integral defilant, case a cocher d'acquittement, et boutons Refuser / Accepter.
@@ -56,7 +53,7 @@ namespace engine::render
 				{
 					continue;
 				}
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextWrapped("%s", line.text.c_str());
 				ImGui::PopStyleColor();
 			}
@@ -70,7 +67,7 @@ namespace engine::render
 		if (m_authPresenter != nullptr)
 		{
 			const std::string& full = m_authPresenter->TermsFullTextForImGui();
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::TextUnformatted(full.c_str());
 			ImGui::PopStyleColor();
 			const float scrollY = ImGui::GetScrollY();

--- a/src/client/render/auth/screens/AuthImGuiVerifyEmail.cpp
+++ b/src/client/render/auth/screens/AuthImGuiVerifyEmail.cpp
@@ -11,16 +11,13 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
 {
 	namespace
 	{
-		/// Convertit une couleur theme en ImVec4 pour ImGui.
-		ImVec4 IV(const LnTheme::Rgba& c)
-		{
-			return ImVec4(c.r, c.g, c.b, c.a);
-		}
+		using LnTheme::ToImVec4;
 
 		/// Concatene dans l'ordre les chiffres valides des 6 cases de saisie.
 		std::string PackVerifySlotsInOrder(const char slots[7])
@@ -91,7 +88,7 @@ namespace engine::render
 
 		const std::string& digitLab =
 			rm.authVerifyDigitLabel.empty() ? std::string("CODE DE VERIFICATION") : rm.authVerifyDigitLabel;
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(0.78f);
 		ImGui::TextUnformatted(digitLab.c_str());
 		ImGui::SetWindowFontScale(1.f);
@@ -123,10 +120,10 @@ namespace engine::render
 				one[0] = m_verifyCode[i];
 			}
 			ImGui::SetNextItemWidth(boxW);
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, borderActive ? IV(LnTheme::kPrimary) : IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, borderActive ? ToImVec4(LnTheme::kPrimary) : ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			ImGui::SetWindowFontScale((std::min)(1.28f, (std::max)(1.f, vpW * 0.0022f)));
@@ -169,10 +166,10 @@ namespace engine::render
 			const std::string& chmail = rm.authVerifyChangeEmailLabel;
 			const float lw = ImGui::CalcTextSize(resend.c_str()).x + 20.f + ImGui::CalcTextSize(chmail.c_str()).x;
 			ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - lw) * 0.5f + ImGui::GetCursorPosX());
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.06f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.10f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.06f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.10f)));
 			if (ImGui::SmallButton((resend + "##resend").c_str()) && m_authPresenter != nullptr)
 			{
 				std::memset(m_verifyCode, 0, sizeof(m_verifyCode));
@@ -201,10 +198,10 @@ namespace engine::render
 			const float colW = ImGui::GetContentRegionAvail().x;
 			const float backBtnW = (std::max)(80.f, colW - capW - 10.f);
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			if (ImGui::Button(backLbl.c_str(), ImVec2(backBtnW, 36.f)) && m_authPresenter != nullptr)
@@ -214,14 +211,14 @@ namespace engine::render
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(5);
 			ImGui::SameLine(0.f, 8.f);
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 			ImGui::BeginChild("##verify_keycap", ImVec2(capW, 36.f), true, ImGuiWindowFlags_NoScrollbar);
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(2);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			const float tcx = (capW - ImGui::CalcTextSize(kcap.c_str()).x) * 0.5f;
 			ImGui::SetCursorPosX(tcx);
 			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 6.f);
@@ -238,7 +235,7 @@ namespace engine::render
 			}
 			if (!rm.authVerifySubmitKeycap.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.82f);
 				const float sk = ImGui::CalcTextSize(rm.authVerifySubmitKeycap.c_str()).x;
 				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - sk) * 0.5f);
@@ -254,7 +251,7 @@ namespace engine::render
 
 		if (!rm.authVerifyDevHint.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.88f);
 			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
 			const float hintW = (std::min)(560.f, vpW * 0.92f);
@@ -316,7 +313,7 @@ namespace engine::render
 
 		const std::string& digitLab =
 			rm.authVerifyDigitLabel.empty() ? std::string("CODE DE VERIFICATION") : rm.authVerifyDigitLabel;
-		ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 		ImGui::SetWindowFontScale(0.78f);
 		ImGui::TextUnformatted(digitLab.c_str());
 		ImGui::SetWindowFontScale(1.f);
@@ -348,10 +345,10 @@ namespace engine::render
 				one[0] = m_verifyCode[i];
 			}
 			ImGui::SetNextItemWidth(boxW);
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, borderActive ? IV(LnTheme::kPrimary) : IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, borderActive ? ToImVec4(LnTheme::kPrimary) : ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			ImGui::SetWindowFontScale((std::min)(1.28f, (std::max)(1.f, vpW * 0.0022f)));
@@ -393,7 +390,7 @@ namespace engine::render
 		{
 			if (!rm.authVerifyCodeExpiredMessage.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kErrorCol));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kErrorCol));
 				ImGui::SetWindowFontScale(0.88f);
 				const float msgW = ImGui::CalcTextSize(rm.authVerifyCodeExpiredMessage.c_str()).x;
 				ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - msgW) * 0.5f + ImGui::GetCursorPosX());
@@ -403,10 +400,10 @@ namespace engine::render
 				ImGui::Spacing();
 			}
 			const std::string resendLbl = rm.authVerifyResendLabel.empty() ? std::string("Renvoyer le code") : rm.authVerifyResendLabel;
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kAccent));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.06f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.10f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.06f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.10f)));
 			const float resendW = ImGui::CalcTextSize(resendLbl.c_str()).x + 16.f;
 			ImGui::SetCursorPosX((ImGui::GetContentRegionAvail().x - resendW) * 0.5f + ImGui::GetCursorPosX());
 			if (ImGui::SmallButton((resendLbl + "##resend_conf").c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
@@ -433,10 +430,10 @@ namespace engine::render
 			const float colW = ImGui::GetContentRegionAvail().x;
 			const float backBtnW = (std::max)(80.f, colW - capW - 10.f);
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IV(LnTheme::AccentDim(0.08f)));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, IV(LnTheme::AccentDim(0.15f)));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kText));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
 			if (ImGui::Button(backLbl.c_str(), ImVec2(backBtnW, 36.f)) && m_authPresenter != nullptr)
@@ -446,14 +443,14 @@ namespace engine::render
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(5);
 			ImGui::SameLine(0.f, 8.f);
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, IV(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, IV(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
 			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
 			ImGui::BeginChild("##emailconf_keycap", ImVec2(capW, 36.f), true, ImGuiWindowFlags_NoScrollbar);
 			ImGui::PopStyleVar(2);
 			ImGui::PopStyleColor(2);
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			const float tcx = (capW - ImGui::CalcTextSize(kcap.c_str()).x) * 0.5f;
 			ImGui::SetCursorPosX(tcx);
 			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 6.f);
@@ -470,7 +467,7 @@ namespace engine::render
 			}
 			if (!rm.authVerifySubmitKeycap.empty())
 			{
-				ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::SetWindowFontScale(0.82f);
 				const float sk = ImGui::CalcTextSize(rm.authVerifySubmitKeycap.c_str()).x;
 				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (ImGui::GetContentRegionAvail().x - sk) * 0.5f);
@@ -486,7 +483,7 @@ namespace engine::render
 
 		if (!rm.authVerifyDevHint.empty())
 		{
-			ImGui::PushStyleColor(ImGuiCol_Text, IV(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 			ImGui::SetWindowFontScale(0.88f);
 			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
 			const float hintW = (std::min)(560.f, vpW * 0.92f);


### PR DESCRIPTION
## Objectif

Suite et fin de la dé-duplication du couple de conversion couleur
`Rgba → ImVec4` dans les renderers ImGui. Le **lot 1** (helper partagé
`LnTheme::ToImVec4`/`ToU32` dans `src/client/render/LnThemeImGui.h` + les 5
fichiers qui définissaient `IV` **et** `U32`) est déjà mergé dans `main`
via #923 (squash `8c8a4c80`, CI verte).

Cette PR applique **le même mécanisme** aux **22 fichiers restants** qui ne
définissaient que `IV()` :

- include du compagnon `LnThemeImGui.h` dans le bloc `#if defined(_WIN32)` ;
- définition locale de `IV()` → `using LnTheme::ToImVec4;` ;
- rename mécanique des sites d'appel `IV(` → `ToImVec4(`.

Aucun de ces fichiers n'appelle `U32()` → seul le `using ToImVec4` est ajouté.
Après cette PR, **plus aucune redéfinition locale de `IV()`/`U32()` dans
`src/client/render`**.

## Périmètre

22 fichiers, tous sous `src/client/render/` (6 écrans auth + 16 renderers
in-game). Diff `origin/main..HEAD` = 22 fichiers, +199/−200 (net −1 : defs
locales retirées, `using` ajouté). **Aucun changement de rendu** (bit-à-bit :
`ToImVec4` construit le même `ImVec4`).

## Tests

Pas de nouvelle cible de test (cf. lot 1) : la conversion dépend d'ImGui,
absent de la cible ctest Linux. Non-régression assurée par la validation
visuelle des écrans + le fait que le rename est mécanique (s'il compile, le
rendu est identique par construction). Le pattern est déjà prouvé par la CI
verte du lot 1 (#923).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)