### PR TITLE
refactor(ui): extraction des primitives partagées LnWidgets (0c)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,8 @@ add_library(engine_core
   src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
   src/client/render/LnTheme.h
   src/client/render/LnThemeImGui.h
+  src/client/render/LnWidgets.h
+  src/client/render/LnWidgets.cpp
   src/client/render/AuthImGuiRenderer.cpp
   src/client/render/ChatImGuiRenderer.cpp
   src/client/render/DialogueImGuiRenderer.cpp

--- a/src/client/render/AuthImGuiRenderer.cpp
+++ b/src/client/render/AuthImGuiRenderer.cpp
@@ -19,6 +19,7 @@
 #if defined(_WIN32)
 #	include "imgui.h"
 #	include "src/client/render/LnThemeImGui.h"
+#	include "src/client/render/LnWidgets.h"
 
 namespace engine::render
 {
@@ -492,200 +493,33 @@ namespace engine::render
 
 	void AuthImGuiRenderer::BeginFullscreenOverlay(float vpW, float vpH, float windowBgAlpha)
 	{
-		ImGui::SetNextWindowPos(ImVec2(0.f, 0.f));
-		ImGui::SetNextWindowSize(ImVec2(vpW, vpH));
-		ImGui::SetNextWindowBgAlpha(1.f);
-		// Fond plein écran FIGÉ sur le thème par défaut (or_royal), invariant au
-		// thème actif : changer de thème de race ne doit recolorer que les
-		// panneaux, pas le fond (demande utilisateur). Cf. LnTheme::AuthBackdrop.
-		ImVec4 bg = ToImVec4(LnTheme::AuthBackdrop());
-		bg.w = windowBgAlpha;
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, bg);
-		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
-		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
-		ImGui::Begin("##ln_auth_overlay",
-			nullptr,
-			ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus
-				| ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
-		ImGui::PopStyleVar(2);
-		ImGui::PopStyleColor(1);
+		LnWidgets::BeginFullscreenOverlay(vpW, vpH, windowBgAlpha);
 	}
 
 	void AuthImGuiRenderer::DrawAuthBigTitle(const RenderModel& rm, float vpW, float vpH, const char* screenId)
 	{
-		// Pattern de reference cale sur l'ecran Login : BeginChild stage 96 % vpW pour
-		// permettre au titre 5.0x (720 px) de tenir, h1 centre scale 5.0x, Dummy 28 px
-		// pour passer sous la jambe oblique du R de " CHRONIQUES ", h2 centre scale 2.5x.
-		// Le caller doit appeler ImGui::EndChild() apres EndPanel.
-		const float titleZoneW = vpW * 0.96f;
-		ImGui::SetCursorPosX((vpW - titleZoneW) * 0.5f);
-		char childId[64];
-		std::snprintf(childId, sizeof(childId), "##ln_%s_stage", screenId);
-		ImGui::BeginChild(childId, ImVec2(titleZoneW, 0.f), false, ImGuiWindowFlags_NoScrollbar);
-
-		const std::string& h1 = rm.titleLine1.empty() ? std::string("Les Chroniques de la Lune Noire") : rm.titleLine1;
-
-		const float topMargin = (std::max)(24.f, vpH * 0.05f);
-		ImGui::SetCursorPosY(topMargin);
-		ImGui::SetWindowFontScale(5.0f);
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-		const float w1 = ImGui::CalcTextSize(h1.c_str()).x;
-		ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w1) * 0.5f));
-		ImGui::TextUnformatted(h1.c_str());
-		ImGui::SetWindowFontScale(1.f);
-		ImGui::PopStyleColor();
-
-		if (!rm.titleLine2.empty())
-		{
-			ImGui::Dummy(ImVec2(0.f, 28.f));
-			ImGui::SetWindowFontScale(2.5f);
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
-			const float w2 = ImGui::CalcTextSize(rm.titleLine2.c_str()).x;
-			ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w2) * 0.5f));
-			ImGui::TextUnformatted(rm.titleLine2.c_str());
-			ImGui::PopStyleColor();
-			ImGui::SetWindowFontScale(1.f);
-		}
+		// Le repli métier (titre par défaut du jeu) reste CÔTÉ AUTH : LnWidgets::BigTitle
+		// ne connaît pas le RenderModel et reçoit les lignes déjà résolues.
+		const std::string h1 = rm.titleLine1.empty() ? std::string("Les Chroniques de la Lune Noire") : rm.titleLine1;
+		LnWidgets::BigTitle(h1, rm.titleLine2, vpW, vpH, screenId);
 	}
 
 	bool AuthImGuiRenderer::BeginPanel(float width, float vpW, float vpH, std::string_view title,
 		std::string_view subtitle, std::string_view versionLabel, bool versionLeadingInfoGlyph, bool subtitleWelcomeAccent,
 		float fixedHeight)
 	{
-		const float panelX = (vpW - width) * 0.5f;
-		// Quand fixedHeight > 0 (panel a hauteur fixe connue), on centre verticalement
-		// la fenetre dans la viewport. Sinon (auto-resize), on garde l'ancien
-		// comportement (panelY = vpH * 0.28) qui laisse de la place pour le titre
-		// 'LES CHRONIQUES' au-dessus.
-		const float panelY = (fixedHeight > 0.f)
-			? (std::max)(0.f, (vpH - fixedHeight) * 0.5f)
-			: (vpH * 0.28f);
-		ImGui::SetCursorPos(ImVec2(panelX, panelY));
-
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::PanelBg()));
-		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
-		ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.f);
-		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
-		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.f, 18.f));
-		// ItemSpacing.y bumpe de 4 (defaut ImGui) a 8 px pour aerer les lignes de texte
-		// et de widgets dans tous les panneaux auth (reference visuelle Login).
-
-		// Si fixedHeight > 0 : le panneau a une hauteur figee. Sinon AutoResizeY : la hauteur s'aligne
-		// sur le contenu reel - evite les enormes panneaux vides qui poussaient les champs et boutons
-		// hors de l'ecran (ex. login apres banniere info, choix de langue).
-		const ImVec2 panelSize(width, fixedHeight > 0.f ? fixedHeight : 0.f);
-		const ImGuiChildFlags childFlags = (fixedHeight > 0.f)
-			? ImGuiChildFlags_Borders
-			: (ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
-		const bool open = ImGui::BeginChild("##ln_panel", panelSize, childFlags,
-			ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
-
-		ImGui::PopStyleVar(3);
-		ImGui::PopStyleColor(2);
-
-		// ItemSpacing.y bumpe a 8 px (defaut 4) pour aerer les lignes de texte et de
-		// widgets dans tous les panneaux auth - pope dans EndPanel. Pushe meme si
-		// !open : EndPanel doit etre appele dans tous les cas (cf. callers), et le
-		// push/pop doit donc rester equilibre.
-		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(ImGui::GetStyle().ItemSpacing.x, 8.f));
-
-		if (!open)
-		{
-			return false;
-		}
-		if (!title.empty())
-		{
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-			ImGui::SetWindowFontScale(1.15f);
-			ImGui::TextUnformatted(title.data(), title.data() + static_cast<int>(title.size()));
-			ImGui::SetWindowFontScale(1.f);
-			ImGui::PopStyleColor();
-		}
-		if (!versionLabel.empty())
-		{
-			const float vw = ImGui::CalcTextSize(versionLabel.data(), versionLabel.data() + versionLabel.size()).x;
-			const float badge = versionLeadingInfoGlyph ? (ImGui::GetFontSize() + 6.f) : 0.f;
-			const float gap = 4.f;
-			const float slack = ImGui::GetContentRegionAvail().x - vw - badge - gap;
-			ImGui::SameLine(0.f, (slack > 0.f) ? slack : 4.f);
-			if (versionLeadingInfoGlyph)
-			{
-				const ImVec2 ip = ImGui::GetCursorScreenPos();
-				const float side = ImGui::GetFontSize() * 0.92f;
-				const float r = side * 0.42f;
-				const ImVec2 center(ip.x + side * 0.5f, ip.y + side * 0.5f);
-				ImDrawList* dl = ImGui::GetWindowDrawList();
-				dl->AddCircle(center, r, ToU32(LnTheme::kMuted), 0, 1.25f);
-				dl->AddText(ImVec2(center.x - ImGui::CalcTextSize("i").x * 0.5f, ip.y + 1.f), ToU32(LnTheme::kMuted), "i");
-				ImGui::Dummy(ImVec2(side, side));
-				ImGui::SameLine(0.f, gap);
-			}
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-			ImGui::TextUnformatted(versionLabel.data(), versionLabel.data() + static_cast<int>(versionLabel.size()));
-			ImGui::PopStyleColor();
-		}
-		if (!subtitle.empty())
-		{
-			// Petit espace vertical entre le title du panel et son subtitle (welcome) - sans
-			// ce Dummy, ItemSpacing.y (4 px) seul collait visuellement les deux lignes.
-			ImGui::Dummy(ImVec2(0.f, 6.f));
-			if (subtitleWelcomeAccent)
-			{
-				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
-				ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
-				ImGui::SetWindowFontScale(0.95f);
-				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
-				ImGui::SetWindowFontScale(1.f);
-				ImGui::PopStyleVar(1);
-				ImGui::PopStyleColor();
-			}
-			else
-			{
-				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
-				ImGui::PopStyleColor();
-			}
-		}
-		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
-		ImGui::Separator();
-		ImGui::PopStyleColor();
-		// Anciennement : ImGui::Spacing() (= Dummy(0, 8)) apres le Separator. Total
-		// title>content etait  17 px, le retour utilisateur demande ~10 px avec le trait
-		// au milieu. ItemSpacing.y (4) est applique automatiquement avant ET apres le
-		// Separator par ImGui : 4 + 1 (sep) + 4 = ~9 px > cible quasi atteinte sans
-		// supplement. On laisse donc ce bloc nu.
-		return true;
+		return LnWidgets::BeginPanel(width, vpW, vpH, title, subtitle, versionLabel, versionLeadingInfoGlyph,
+			subtitleWelcomeAccent, fixedHeight);
 	}
 
 	void AuthImGuiRenderer::EndPanel()
 	{
-		// Pop ItemSpacing pushe dans BeginPanel (uniquement si le panel a ete ouvert
-		// avec succes - sinon BeginPanel a return false avant le push).
-		ImGui::PopStyleVar(1);
-		ImGui::EndChild();
+		LnWidgets::EndPanel();
 	}
 
 	void AuthImGuiRenderer::DrawLangFooterHints(std::string_view left, std::string_view right)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-		ImGui::SetWindowFontScale(0.88f);
-		if (!left.empty() && !right.empty())
-		{
-			ImGui::TextUnformatted(left.data(), left.data() + static_cast<int>(left.size()));
-			const float rw = ImGui::CalcTextSize(right.data(), right.data() + right.size()).x;
-			ImGui::SameLine(ImGui::GetWindowContentRegionMax().x - rw - ImGui::GetScrollX());
-			ImGui::TextUnformatted(right.data(), right.data() + static_cast<int>(right.size()));
-		}
-		else if (!left.empty())
-		{
-			ImGui::TextUnformatted(left.data(), left.data() + static_cast<int>(left.size()));
-		}
-		else if (!right.empty())
-		{
-			ImGui::TextUnformatted(right.data(), right.data() + static_cast<int>(right.size()));
-		}
-		ImGui::SetWindowFontScale(1.f);
-		ImGui::PopStyleColor();
+		LnWidgets::FooterHints(left, right);
 	}
 
 	void AuthImGuiRenderer::DrawAuthGoldField(const engine::client::AuthUiPresenter::RenderField& spec, char* buf, int bufSz,
@@ -836,37 +670,7 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawFooterChipRow(const std::vector<std::pair<std::string, std::string>>& chips)
 	{
-		for (size_t ci = 0; ci < chips.size(); ++ci)
-		{
-			if (ci > 0u)
-			{
-				ImGui::SameLine(0.f, 8.f);
-			}
-			const auto& chip = chips[ci];
-			const float keyW = ImGui::CalcTextSize(chip.first.c_str()).x + 16.f;
-			const float descW = ImGui::CalcTextSize(chip.second.c_str()).x + 12.f;
-			const float chipW = keyW + descW + 8.f;
-			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
-			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
-			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
-			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
-			char cid[48];
-			std::snprintf(cid, sizeof(cid), "##fchip_%zu", ci);
-			ImGui::BeginChild(cid, ImVec2(chipW, 40.f), true, ImGuiWindowFlags_NoScrollbar);
-			ImGui::PopStyleVar(2);
-			ImGui::PopStyleColor(2);
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-			ImGui::SetWindowFontScale(0.92f);
-			ImGui::TextUnformatted(chip.first.c_str());
-			ImGui::PopStyleColor();
-			ImGui::SameLine(0.f, 6.f);
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-			ImGui::SetWindowFontScale(0.78f);
-			ImGui::TextUnformatted(chip.second.c_str());
-			ImGui::SetWindowFontScale(1.f);
-			ImGui::PopStyleColor();
-			ImGui::EndChild();
-		}
+		LnWidgets::FooterChipRow(chips);
 	}
 
 	void AuthImGuiRenderer::DrawRegisterFlowHeader(const RenderModel& rm, float vpW)
@@ -1131,179 +935,42 @@ namespace engine::render
 
 	void AuthImGuiRenderer::DrawField(std::string_view label, char* buf, int bufSz, bool password)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-		ImGui::TextUnformatted(label.data(), label.data() + static_cast<int>(label.size()));
-		ImGui::PopStyleColor();
-
-		ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
-		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
-		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
-		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
-
-		char inputId[48];
-		std::snprintf(inputId, sizeof(inputId), "##f_%p", static_cast<void*>(buf));
-		ImGuiInputTextFlags flags = ImGuiInputTextFlags_None;
-		if (password)
-		{
-			flags |= ImGuiInputTextFlags_Password;
-		}
-		ImGui::SetNextItemWidth(-FLT_MIN);
-		ImGui::InputText(inputId, buf, static_cast<size_t>(bufSz), flags);
-
-		ImGui::PopStyleVar(2);
-		ImGui::PopStyleColor(4);
-		ImGui::Spacing();
+		LnWidgets::Field(label, buf, bufSz, password);
 	}
 
 	void AuthImGuiRenderer::DrawBanner(std::string_view title, std::string_view msg, float r, float g, float b)
 	{
-		ImVec4 bg(r, g, b, 0.12f);
-		ImVec4 bd(r, g, b, 1.f);
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, bg);
-		ImGui::PushStyleColor(ImGuiCol_Border, bd);
-		ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.f);
-		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
-		std::string bannerId = "##banner_";
-		bannerId.append(title.data(), title.size());
-		// AutoResizeY : la banniere s'adapte a la hauteur reelle du texte au lieu de remplir tout le panneau.
-		ImGui::BeginChild(bannerId.c_str(), ImVec2(-FLT_MIN, 0.f),
-			ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
-			ImGuiWindowFlags_NoScrollbar);
-		ImGui::PopStyleVar(2);
-		ImGui::PopStyleColor(2);
-
-		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(r, g, b, 1.f));
-		if (!title.empty())
-		{
-			ImGui::TextUnformatted(title.data(), title.data() + static_cast<int>(title.size()));
-		}
-		ImGui::PopStyleColor();
-		if (!msg.empty())
-		{
-			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-			ImGui::TextWrapped("%.*s", static_cast<int>(msg.size()), msg.data());
-			ImGui::PopStyleColor();
-		}
-		ImGui::EndChild();
-		ImGui::Spacing();
+		LnWidgets::Banner(title, msg, r, g, b);
 	}
 
 	void AuthImGuiRenderer::DrawKeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints)
 	{
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
-		bool first = true;
-		for (const auto& kv : hints)
-		{
-			if (!first)
-			{
-				ImGui::SameLine(0.f, 14.f);
-			}
-			ImGui::Text("[%s] %s", kv.first, kv.second);
-			first = false;
-		}
-		ImGui::PopStyleColor();
+		LnWidgets::KeycapHints(hints);
 	}
 
 	bool AuthImGuiRenderer::DrawPrimaryButton(std::string_view label, bool disabled, float width)
 	{
-		if (disabled)
-		{
-			ImGui::BeginDisabled();
-		}
-		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.39f, 0.58f, 0.82f, 1.f));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.19f, 0.38f, 0.62f, 1.f));
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
-		char id[160];
-		std::snprintf(id, sizeof(id), "%.*s##primary", static_cast<int>(label.size()), label.data());
-		const bool clicked = ImGui::Button(id, ImVec2(width, 32.f));
-		ImGui::PopStyleVar(1);
-		ImGui::PopStyleColor(4);
-		if (disabled)
-		{
-			ImGui::EndDisabled();
-		}
-		return clicked;
+		return LnWidgets::PrimaryButton(label, disabled, width);
 	}
 
 	bool AuthImGuiRenderer::DrawGhostButton(std::string_view label, bool disabled, float width)
 	{
-		if (disabled)
-		{
-			ImGui::BeginDisabled();
-		}
-		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
-		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
-		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
-		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
-		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
-		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
-		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
-		char id[160];
-		std::snprintf(id, sizeof(id), "%.*s##ghost", static_cast<int>(label.size()), label.data());
-		const bool clicked = ImGui::Button(id, ImVec2(width, 32.f));
-		ImGui::PopStyleVar(2);
-		ImGui::PopStyleColor(5);
-		if (disabled)
-		{
-			ImGui::EndDisabled();
-		}
-		return clicked;
+		return LnWidgets::GhostButton(label, disabled, width);
 	}
 
 	void AuthImGuiRenderer::DrawSeparator()
 	{
-		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
-		ImGui::Separator();
-		ImGui::PopStyleColor();
-		ImGui::Spacing();
+		LnWidgets::Separator();
 	}
 
 	void AuthImGuiRenderer::DrawBreadcrumb(std::initializer_list<const char*> steps, int current)
 	{
-		int i = 0;
-		for (const char* s : steps)
-		{
-			const bool done = i < current;
-			const bool active = i == current;
-			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
-			ImGui::PushStyleColor(ImGuiCol_Text, col);
-			ImGui::Text("%02d %s", i + 1, s);
-			ImGui::PopStyleColor();
-			++i;
-			const int total = static_cast<int>(steps.size());
-			if (i < total)
-			{
-				ImGui::SameLine(0.f, 12.f);
-				ImGui::TextUnformatted(">");
-				ImGui::SameLine(0.f, 12.f);
-			}
-		}
-		ImGui::Spacing();
+		LnWidgets::Breadcrumb(steps, current);
 	}
 
 	void AuthImGuiRenderer::DrawBreadcrumb(const std::vector<std::string>& steps, int current)
 	{
-		const int total = static_cast<int>(steps.size());
-		for (int i = 0; i < total; ++i)
-		{
-			const bool done = i < current;
-			const bool active = i == current;
-			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
-			ImGui::PushStyleColor(ImGuiCol_Text, col);
-			ImGui::Text("%02d %s", i + 1, steps[static_cast<size_t>(i)].c_str());
-			ImGui::PopStyleColor();
-			if (i + 1 < total)
-			{
-				ImGui::SameLine(0.f, 12.f);
-				ImGui::TextUnformatted(">");
-				ImGui::SameLine(0.f, 12.f);
-			}
-		}
-		ImGui::Spacing();
+		LnWidgets::Breadcrumb(steps, current);
 	}
 
 } // namespace engine::render

--- a/src/client/render/LnWidgets.cpp
+++ b/src/client/render/LnWidgets.cpp
@@ -1,0 +1,429 @@
+#include "src/client/render/LnWidgets.h"
+
+#include "src/client/render/LnTheme.h"
+
+#include <algorithm>
+#include <cstdio>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#	include "src/client/render/LnThemeImGui.h"
+
+namespace LnWidgets
+{
+	namespace
+	{
+		using LnTheme::ToImVec4;
+		using LnTheme::ToU32;
+	}
+
+	void BeginFullscreenOverlay(float vpW, float vpH, float windowBgAlpha)
+	{
+		ImGui::SetNextWindowPos(ImVec2(0.f, 0.f));
+		ImGui::SetNextWindowSize(ImVec2(vpW, vpH));
+		ImGui::SetNextWindowBgAlpha(1.f);
+		// Fond plein écran FIGÉ sur le thème par défaut (or_royal), invariant au
+		// thème actif : changer de thème de race ne doit recolorer que les
+		// panneaux, pas le fond (demande utilisateur). Cf. LnTheme::AuthBackdrop.
+		ImVec4 bg = ToImVec4(LnTheme::AuthBackdrop());
+		bg.w = windowBgAlpha;
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, bg);
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
+		ImGui::Begin("##ln_auth_overlay",
+			nullptr,
+			ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus
+				| ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+		ImGui::PopStyleVar(2);
+		ImGui::PopStyleColor(1);
+	}
+
+	void BigTitle(std::string_view line1, std::string_view line2, float vpW, float vpH, const char* stageId)
+	{
+		// Pattern de reference cale sur l'ecran Login : BeginChild stage 96 % vpW pour
+		// permettre au titre 5.0x (720 px) de tenir, h1 centre scale 5.0x, Dummy 28 px
+		// pour passer sous la jambe oblique du R de " CHRONIQUES ", h2 centre scale 2.5x.
+		// Le caller doit appeler ImGui::EndChild() apres EndPanel.
+		const float titleZoneW = vpW * 0.96f;
+		ImGui::SetCursorPosX((vpW - titleZoneW) * 0.5f);
+		char childId[64];
+		std::snprintf(childId, sizeof(childId), "##ln_%s_stage", stageId);
+		ImGui::BeginChild(childId, ImVec2(titleZoneW, 0.f), false, ImGuiWindowFlags_NoScrollbar);
+
+		const float topMargin = (std::max)(24.f, vpH * 0.05f);
+		ImGui::SetCursorPosY(topMargin);
+		ImGui::SetWindowFontScale(5.0f);
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+		const float w1 = ImGui::CalcTextSize(line1.data(), line1.data() + line1.size()).x;
+		ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w1) * 0.5f));
+		ImGui::TextUnformatted(line1.data(), line1.data() + static_cast<int>(line1.size()));
+		ImGui::SetWindowFontScale(1.f);
+		ImGui::PopStyleColor();
+
+		if (!line2.empty())
+		{
+			ImGui::Dummy(ImVec2(0.f, 28.f));
+			ImGui::SetWindowFontScale(2.5f);
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
+			const float w2 = ImGui::CalcTextSize(line2.data(), line2.data() + line2.size()).x;
+			ImGui::SetCursorPosX((std::max)(0.f, (titleZoneW - w2) * 0.5f));
+			ImGui::TextUnformatted(line2.data(), line2.data() + static_cast<int>(line2.size()));
+			ImGui::PopStyleColor();
+			ImGui::SetWindowFontScale(1.f);
+		}
+	}
+
+	bool BeginPanel(float width, float vpW, float vpH, std::string_view title,
+		std::string_view subtitle, std::string_view versionLabel, bool versionLeadingInfoGlyph, bool subtitleWelcomeAccent,
+		float fixedHeight)
+	{
+		const float panelX = (vpW - width) * 0.5f;
+		// Quand fixedHeight > 0 (panel a hauteur fixe connue), on centre verticalement
+		// la fenetre dans la viewport. Sinon (auto-resize), on garde l'ancien
+		// comportement (panelY = vpH * 0.28) qui laisse de la place pour le titre
+		// 'LES CHRONIQUES' au-dessus.
+		const float panelY = (fixedHeight > 0.f)
+			? (std::max)(0.f, (vpH - fixedHeight) * 0.5f)
+			: (vpH * 0.28f);
+		ImGui::SetCursorPos(ImVec2(panelX, panelY));
+
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::PanelBg()));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+		ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.f);
+		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.f, 18.f));
+		// ItemSpacing.y bumpe de 4 (defaut ImGui) a 8 px pour aerer les lignes de texte
+		// et de widgets dans tous les panneaux auth (reference visuelle Login).
+
+		// Si fixedHeight > 0 : le panneau a une hauteur figee. Sinon AutoResizeY : la hauteur s'aligne
+		// sur le contenu reel - evite les enormes panneaux vides qui poussaient les champs et boutons
+		// hors de l'ecran (ex. login apres banniere info, choix de langue).
+		const ImVec2 panelSize(width, fixedHeight > 0.f ? fixedHeight : 0.f);
+		const ImGuiChildFlags childFlags = (fixedHeight > 0.f)
+			? ImGuiChildFlags_Borders
+			: (ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
+		const bool open = ImGui::BeginChild("##ln_panel", panelSize, childFlags,
+			ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+		ImGui::PopStyleVar(3);
+		ImGui::PopStyleColor(2);
+
+		// ItemSpacing.y bumpe a 8 px (defaut 4) pour aerer les lignes de texte et de
+		// widgets dans tous les panneaux auth - pope dans EndPanel. Pushe meme si
+		// !open : EndPanel doit etre appele dans tous les cas (cf. callers), et le
+		// push/pop doit donc rester equilibre.
+		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(ImGui::GetStyle().ItemSpacing.x, 8.f));
+
+		if (!open)
+		{
+			return false;
+		}
+		if (!title.empty())
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+			ImGui::SetWindowFontScale(1.15f);
+			ImGui::TextUnformatted(title.data(), title.data() + static_cast<int>(title.size()));
+			ImGui::SetWindowFontScale(1.f);
+			ImGui::PopStyleColor();
+		}
+		if (!versionLabel.empty())
+		{
+			const float vw = ImGui::CalcTextSize(versionLabel.data(), versionLabel.data() + versionLabel.size()).x;
+			const float badge = versionLeadingInfoGlyph ? (ImGui::GetFontSize() + 6.f) : 0.f;
+			const float gap = 4.f;
+			const float slack = ImGui::GetContentRegionAvail().x - vw - badge - gap;
+			ImGui::SameLine(0.f, (slack > 0.f) ? slack : 4.f);
+			if (versionLeadingInfoGlyph)
+			{
+				const ImVec2 ip = ImGui::GetCursorScreenPos();
+				const float side = ImGui::GetFontSize() * 0.92f;
+				const float r = side * 0.42f;
+				const ImVec2 center(ip.x + side * 0.5f, ip.y + side * 0.5f);
+				ImDrawList* dl = ImGui::GetWindowDrawList();
+				dl->AddCircle(center, r, ToU32(LnTheme::kMuted), 0, 1.25f);
+				dl->AddText(ImVec2(center.x - ImGui::CalcTextSize("i").x * 0.5f, ip.y + 1.f), ToU32(LnTheme::kMuted), "i");
+				ImGui::Dummy(ImVec2(side, side));
+				ImGui::SameLine(0.f, gap);
+			}
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+			ImGui::TextUnformatted(versionLabel.data(), versionLabel.data() + static_cast<int>(versionLabel.size()));
+			ImGui::PopStyleColor();
+		}
+		if (!subtitle.empty())
+		{
+			// Petit espace vertical entre le title du panel et son subtitle (welcome) - sans
+			// ce Dummy, ItemSpacing.y (4 px) seul collait visuellement les deux lignes.
+			ImGui::Dummy(ImVec2(0.f, 6.f));
+			if (subtitleWelcomeAccent)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kAccent));
+				ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.92f);
+				ImGui::SetWindowFontScale(0.95f);
+				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
+				ImGui::SetWindowFontScale(1.f);
+				ImGui::PopStyleVar(1);
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+				ImGui::TextWrapped("%.*s", static_cast<int>(subtitle.size()), subtitle.data());
+				ImGui::PopStyleColor();
+			}
+		}
+		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
+		ImGui::Separator();
+		ImGui::PopStyleColor();
+		// Anciennement : ImGui::Spacing() (= Dummy(0, 8)) apres le Separator. Total
+		// title>content etait  17 px, le retour utilisateur demande ~10 px avec le trait
+		// au milieu. ItemSpacing.y (4) est applique automatiquement avant ET apres le
+		// Separator par ImGui : 4 + 1 (sep) + 4 = ~9 px > cible quasi atteinte sans
+		// supplement. On laisse donc ce bloc nu.
+		return true;
+	}
+
+	void EndPanel()
+	{
+		// Pop ItemSpacing pushe dans BeginPanel (uniquement si le panel a ete ouvert
+		// avec succes - sinon BeginPanel a return false avant le push).
+		ImGui::PopStyleVar(1);
+		ImGui::EndChild();
+	}
+
+	void FooterHints(std::string_view left, std::string_view right)
+	{
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+		ImGui::SetWindowFontScale(0.88f);
+		if (!left.empty() && !right.empty())
+		{
+			ImGui::TextUnformatted(left.data(), left.data() + static_cast<int>(left.size()));
+			const float rw = ImGui::CalcTextSize(right.data(), right.data() + right.size()).x;
+			ImGui::SameLine(ImGui::GetWindowContentRegionMax().x - rw - ImGui::GetScrollX());
+			ImGui::TextUnformatted(right.data(), right.data() + static_cast<int>(right.size()));
+		}
+		else if (!left.empty())
+		{
+			ImGui::TextUnformatted(left.data(), left.data() + static_cast<int>(left.size()));
+		}
+		else if (!right.empty())
+		{
+			ImGui::TextUnformatted(right.data(), right.data() + static_cast<int>(right.size()));
+		}
+		ImGui::SetWindowFontScale(1.f);
+		ImGui::PopStyleColor();
+	}
+
+	void FooterChipRow(const std::vector<std::pair<std::string, std::string>>& chips)
+	{
+		for (size_t ci = 0; ci < chips.size(); ++ci)
+		{
+			if (ci > 0u)
+			{
+				ImGui::SameLine(0.f, 8.f);
+			}
+			const auto& chip = chips[ci];
+			const float keyW = ImGui::CalcTextSize(chip.first.c_str()).x + 16.f;
+			const float descW = ImGui::CalcTextSize(chip.second.c_str()).x + 12.f;
+			const float chipW = keyW + descW + 8.f;
+			ImGui::PushStyleColor(ImGuiCol_ChildBg, ToImVec4(LnTheme::kSurface));
+			ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.f);
+			ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
+			char cid[48];
+			std::snprintf(cid, sizeof(cid), "##fchip_%zu", ci);
+			ImGui::BeginChild(cid, ImVec2(chipW, 40.f), true, ImGuiWindowFlags_NoScrollbar);
+			ImGui::PopStyleVar(2);
+			ImGui::PopStyleColor(2);
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+			ImGui::SetWindowFontScale(0.92f);
+			ImGui::TextUnformatted(chip.first.c_str());
+			ImGui::PopStyleColor();
+			ImGui::SameLine(0.f, 6.f);
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+			ImGui::SetWindowFontScale(0.78f);
+			ImGui::TextUnformatted(chip.second.c_str());
+			ImGui::SetWindowFontScale(1.f);
+			ImGui::PopStyleColor();
+			ImGui::EndChild();
+		}
+	}
+
+	void Field(std::string_view label, char* buf, int bufSz, bool password)
+	{
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+		ImGui::TextUnformatted(label.data(), label.data() + static_cast<int>(label.size()));
+		ImGui::PopStyleColor();
+
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ToImVec4(LnTheme::kSurface));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
+		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
+
+		char inputId[48];
+		std::snprintf(inputId, sizeof(inputId), "##f_%p", static_cast<void*>(buf));
+		ImGuiInputTextFlags flags = ImGuiInputTextFlags_None;
+		if (password)
+		{
+			flags |= ImGuiInputTextFlags_Password;
+		}
+		ImGui::SetNextItemWidth(-FLT_MIN);
+		ImGui::InputText(inputId, buf, static_cast<size_t>(bufSz), flags);
+
+		ImGui::PopStyleVar(2);
+		ImGui::PopStyleColor(4);
+		ImGui::Spacing();
+	}
+
+	void Banner(std::string_view title, std::string_view msg, float r, float g, float b)
+	{
+		ImVec4 bg(r, g, b, 0.12f);
+		ImVec4 bd(r, g, b, 1.f);
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, bg);
+		ImGui::PushStyleColor(ImGuiCol_Border, bd);
+		ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 6.f);
+		ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.f);
+		std::string bannerId = "##banner_";
+		bannerId.append(title.data(), title.size());
+		// AutoResizeY : la banniere s'adapte a la hauteur reelle du texte au lieu de remplir tout le panneau.
+		ImGui::BeginChild(bannerId.c_str(), ImVec2(-FLT_MIN, 0.f),
+			ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+			ImGuiWindowFlags_NoScrollbar);
+		ImGui::PopStyleVar(2);
+		ImGui::PopStyleColor(2);
+
+		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(r, g, b, 1.f));
+		if (!title.empty())
+		{
+			ImGui::TextUnformatted(title.data(), title.data() + static_cast<int>(title.size()));
+		}
+		ImGui::PopStyleColor();
+		if (!msg.empty())
+		{
+			ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+			ImGui::TextWrapped("%.*s", static_cast<int>(msg.size()), msg.data());
+			ImGui::PopStyleColor();
+		}
+		ImGui::EndChild();
+		ImGui::Spacing();
+	}
+
+	void KeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints)
+	{
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+		bool first = true;
+		for (const auto& kv : hints)
+		{
+			if (!first)
+			{
+				ImGui::SameLine(0.f, 14.f);
+			}
+			ImGui::Text("[%s] %s", kv.first, kv.second);
+			first = false;
+		}
+		ImGui::PopStyleColor();
+	}
+
+	bool PrimaryButton(std::string_view label, bool disabled, float width)
+	{
+		if (disabled)
+		{
+			ImGui::BeginDisabled();
+		}
+		ImGui::PushStyleColor(ImGuiCol_Button, ToImVec4(LnTheme::kPrimary));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.39f, 0.58f, 0.82f, 1.f));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.19f, 0.38f, 0.62f, 1.f));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
+		char id[160];
+		std::snprintf(id, sizeof(id), "%.*s##primary", static_cast<int>(label.size()), label.data());
+		const bool clicked = ImGui::Button(id, ImVec2(width, 32.f));
+		ImGui::PopStyleVar(1);
+		ImGui::PopStyleColor(4);
+		if (disabled)
+		{
+			ImGui::EndDisabled();
+		}
+		return clicked;
+	}
+
+	bool GhostButton(std::string_view label, bool disabled, float width)
+	{
+		if (disabled)
+		{
+			ImGui::BeginDisabled();
+		}
+		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.f, 0.f, 0.f, 0.f));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ToImVec4(LnTheme::AccentDim(0.08f)));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ToImVec4(LnTheme::AccentDim(0.15f)));
+		ImGui::PushStyleColor(ImGuiCol_Border, ToImVec4(LnTheme::kBorder));
+		ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kText));
+		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.f);
+		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.f);
+		char id[160];
+		std::snprintf(id, sizeof(id), "%.*s##ghost", static_cast<int>(label.size()), label.data());
+		const bool clicked = ImGui::Button(id, ImVec2(width, 32.f));
+		ImGui::PopStyleVar(2);
+		ImGui::PopStyleColor(5);
+		if (disabled)
+		{
+			ImGui::EndDisabled();
+		}
+		return clicked;
+	}
+
+	void Separator()
+	{
+		ImGui::PushStyleColor(ImGuiCol_Separator, ToImVec4(LnTheme::kBorder));
+		ImGui::Separator();
+		ImGui::PopStyleColor();
+		ImGui::Spacing();
+	}
+
+	void Breadcrumb(std::initializer_list<const char*> steps, int current)
+	{
+		int i = 0;
+		for (const char* s : steps)
+		{
+			const bool done = i < current;
+			const bool active = i == current;
+			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, col);
+			ImGui::Text("%02d %s", i + 1, s);
+			ImGui::PopStyleColor();
+			++i;
+			const int total = static_cast<int>(steps.size());
+			if (i < total)
+			{
+				ImGui::SameLine(0.f, 12.f);
+				ImGui::TextUnformatted(">");
+				ImGui::SameLine(0.f, 12.f);
+			}
+		}
+		ImGui::Spacing();
+	}
+
+	void Breadcrumb(const std::vector<std::string>& steps, int current)
+	{
+		const int total = static_cast<int>(steps.size());
+		for (int i = 0; i < total; ++i)
+		{
+			const bool done = i < current;
+			const bool active = i == current;
+			const ImVec4 col = done ? ToImVec4(LnTheme::kSuccess) : (active ? ToImVec4(LnTheme::kAccent) : ToImVec4(LnTheme::kMuted));
+			ImGui::PushStyleColor(ImGuiCol_Text, col);
+			ImGui::Text("%02d %s", i + 1, steps[static_cast<size_t>(i)].c_str());
+			ImGui::PopStyleColor();
+			if (i + 1 < total)
+			{
+				ImGui::SameLine(0.f, 12.f);
+				ImGui::TextUnformatted(">");
+				ImGui::SameLine(0.f, 12.f);
+			}
+		}
+		ImGui::Spacing();
+	}
+} // namespace LnWidgets
+
+#endif

--- a/src/client/render/LnWidgets.h
+++ b/src/client/render/LnWidgets.h
@@ -1,0 +1,87 @@
+#pragma once
+
+// Primitives de widgets ImGui partagées, lisant le thème actif via LnTheme.
+// Extraites d'AuthImGuiRenderer (étape 0c) pour être consommées DIRECTEMENT par
+// tous les écrans (auth aujourd'hui, in-game demain), sans passer par l'auth.
+//
+// Ces fonctions sont sans état : elles ne dépendent que de leurs paramètres, du
+// thème actif (LnTheme) et de la pile ImGui courante. Les déclarations n'ont
+// aucune dépendance ImGui (types simples) ; les corps (LnWidgets.cpp) sont sous
+// #if defined(_WIN32), où ImGui est présent.
+//
+// Contrat de rendu : ces primitives reproduisent à l'identique le rendu des
+// anciennes méthodes privées d'AuthImGuiRenderer (mêmes couleurs, mêmes
+// constantes de style, mêmes identifiants ImGui). Ne pas modifier les valeurs
+// sans validation visuelle.
+
+#include <cfloat>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace LnWidgets
+{
+	/// Ouvre la fenêtre overlay plein écran (fond figé sur le thème par défaut via
+	/// LnTheme::AuthBackdrop, invariant au thème actif). \param windowBgAlpha alpha
+	/// du fond. Le caller doit refermer avec ImGui::End().
+	/// NOTE (IDs fixes) : utilise l'ID ImGui fixe "##ln_auth_overlay" — correct tant
+	/// qu'un seul overlay est à l'écran. Paramétrer un id avant tout usage
+	/// multi-fenêtres concurrent (écrans à onglets in-game).
+	void BeginFullscreenOverlay(float vpW, float vpH, float windowBgAlpha = 1.f);
+
+	/// Grand titre centré (h1 scale 5.0x + h2 scale 2.5x) dans un BeginChild de
+	/// stage 96 % vpW. \param line1 \param line2 fournis par le caller (toute
+	/// logique de repli métier reste côté appelant). \param stageId suffixe d'ID du
+	/// child ("##ln_<stageId>_stage"). Le caller doit appeler ImGui::EndChild()
+	/// après EndPanel.
+	void BigTitle(std::string_view line1, std::string_view line2, float vpW, float vpH, const char* stageId);
+
+	/// Ouvre le panneau standard (fond PanelBg, bordure, titre/sous-titre/version
+	/// optionnels + séparateur). \return true si ouvert ; EndPanel doit être appelé
+	/// dans TOUS les cas (le push de style est équilibré même si false).
+	/// NOTE (IDs fixes) : utilise l'ID ImGui fixe "##ln_panel" — correct tant qu'un
+	/// seul panneau est à l'écran. Paramétrer un id avant l'usage multi-panneaux
+	/// in-game (on heurtera cette limite dès les écrans à onglets).
+	bool BeginPanel(float width, float vpW, float vpH, std::string_view title,
+		std::string_view subtitle, std::string_view versionLabel = {}, bool versionLeadingInfoGlyph = false,
+		bool subtitleWelcomeAccent = false, float fixedHeight = 0.f);
+
+	/// Referme le panneau ouvert par BeginPanel (pop du style + EndChild).
+	void EndPanel();
+
+	/// Champ de saisie standard : libellé muté + InputText pleine largeur.
+	/// \param buf tampon éditable, \param bufSz sa taille, \param password masque la saisie.
+	void Field(std::string_view label, char* buf, int bufSz, bool password = false);
+
+	/// Bannière colorée (titre + message). \param r \param g \param b couleur brute
+	/// (sémantique warning/error décidée par le caller).
+	/// NOTE : signature en r,g,b bruts conservée pour l'identité bit-à-bit ; une
+	/// variante Banner(std::string_view, std::string_view, LnTheme::Rgba) pourra
+	/// venir plus tard.
+	void Banner(std::string_view title, std::string_view msg, float r, float g, float b);
+
+	/// Séparateur horizontal teinté (kBorder) suivi d'un espacement.
+	void Separator();
+
+	/// Rangée d'indices « [touche] libellé » alignés horizontalement.
+	void KeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints);
+
+	/// Bouton d'action principal (fond kPrimary). \return true si cliqué.
+	bool PrimaryButton(std::string_view label, bool disabled = false, float width = -FLT_MIN);
+
+	/// Bouton secondaire « fantôme » (fond transparent + bordure). \return true si cliqué.
+	bool GhostButton(std::string_view label, bool disabled = false, float width = -FLT_MIN);
+
+	/// Fil d'Ariane numéroté ; \param current index de l'étape active (les étapes
+	/// avant sont en kSuccess, l'active en kAccent, les suivantes en kMuted).
+	void Breadcrumb(std::initializer_list<const char*> steps, int current);
+	void Breadcrumb(const std::vector<std::string>& steps, int current);
+
+	/// Rangée de « chips » de pied de page : chaque paire = (clé accentuée, description).
+	void FooterChipRow(const std::vector<std::pair<std::string, std::string>>& chips);
+
+	/// Indices de pied de panneau : \param left aligné à gauche, \param right aligné à droite.
+	void FooterHints(std::string_view left, std::string_view right);
+} // namespace LnWidgets


### PR DESCRIPTION
## Objectif

Étape 0c : extraire les primitives de widgets ImGui — aujourd'hui **méthodes
privées d'AuthImGuiRenderer, sans état de classe** — en fonctions libres
`namespace LnWidgets` (`src/client/render/LnWidgets.{h,cpp}`), lisant le thème
actif via `LnTheme` (`ToImVec4`/`ToU32`). But : une base réutilisable
**directement** par les futurs écrans in-game, plus seulement par l'auth.

## Découpage (relecture en 2 lots)

- **Lot 1/2 (ce commit) — socle** : corps déplacés **verbatim** dans `LnWidgets` ;
  les méthodes d'`AuthImGuiRenderer` deviennent de **fines délégations
  transitoires** → les ~78 sites d'appel des écrans restent inchangés et
  compilent. Valide que le socle (`LnWidgets` + auth qui délègue) tient.
- **Lot 2/2 (à venir)** : suppression des délégations + renommage des ~78 sites
  en `LnWidgets::` directs (état final = Option 1, appels directs).

## Points de vigilance intégrés dans le code

- **`BigTitle` découplé du `RenderModel`** : le repli métier (« Les Chroniques… »)
  reste **côté auth** (`DrawAuthBigTitle` résout `h1` puis appelle
  `LnWidgets::BigTitle`). C'est le seul point non-purement-déplacement.
- **IDs ImGui fixes** conservés (rendu identique) + commentaire signalant la
  limite avant usage multi-panneaux in-game (écrans à onglets).
- **`Banner(r,g,b)`** : signature brute conservée (bit-à-bit) ; variante `Rgba`
  notée pour plus tard.

## Tests / non-régression

Pas de nouvelle cible de test (primitives ImGui, non liables sur la cible ctest
Linux). Extraction = déplacement pur (mêmes couleurs, constantes, IDs, push/pop)
→ rendu des écrans d'auth **identique par construction**. Filet : validation
visuelle auth avant merge.

> **Draft** : ouverte pour valider le socle via CI avant le lot 2. PR laissée
> ouverte jusqu'au feu vert (pas de merge anticipé).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)