### PR TITLE
refactor(ui): appels directs LnWidgets:: + retrait des délégations (0c lot 2/2)

### DIFF
--- a/src/client/render/AuthImGuiRenderer.cpp
+++ b/src/client/render/AuthImGuiRenderer.cpp
@@ -424,7 +424,7 @@ namespace engine::render
 									   || vs.shardPick)
 			? 0.22f
 			: 1.f;
-		BeginFullscreenOverlay(viewportW, viewportH, overlayAlpha);
+		LnWidgets::BeginFullscreenOverlay(viewportW, viewportH, overlayAlpha);
 
 		if (vs.languageSelection)
 		{
@@ -479,21 +479,16 @@ namespace engine::render
 		}
 		else if (vs.submitting)
 		{
-			if (BeginPanel(420.f, viewportW, viewportH, rm.sectionTitle.c_str(), "", ""))
+			if (LnWidgets::BeginPanel(420.f, viewportW, viewportH, rm.sectionTitle.c_str(), "", ""))
 			{
 				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 				ImGui::TextWrapped("%s", rm.infoBanner.c_str());
 				ImGui::PopStyleColor();
-				EndPanel();
+				LnWidgets::EndPanel();
 			}
 		}
 
 		ImGui::End();
-	}
-
-	void AuthImGuiRenderer::BeginFullscreenOverlay(float vpW, float vpH, float windowBgAlpha)
-	{
-		LnWidgets::BeginFullscreenOverlay(vpW, vpH, windowBgAlpha);
 	}
 
 	void AuthImGuiRenderer::DrawAuthBigTitle(const RenderModel& rm, float vpW, float vpH, const char* screenId)
@@ -502,24 +497,6 @@ namespace engine::render
 		// ne connaît pas le RenderModel et reçoit les lignes déjà résolues.
 		const std::string h1 = rm.titleLine1.empty() ? std::string("Les Chroniques de la Lune Noire") : rm.titleLine1;
 		LnWidgets::BigTitle(h1, rm.titleLine2, vpW, vpH, screenId);
-	}
-
-	bool AuthImGuiRenderer::BeginPanel(float width, float vpW, float vpH, std::string_view title,
-		std::string_view subtitle, std::string_view versionLabel, bool versionLeadingInfoGlyph, bool subtitleWelcomeAccent,
-		float fixedHeight)
-	{
-		return LnWidgets::BeginPanel(width, vpW, vpH, title, subtitle, versionLabel, versionLeadingInfoGlyph,
-			subtitleWelcomeAccent, fixedHeight);
-	}
-
-	void AuthImGuiRenderer::EndPanel()
-	{
-		LnWidgets::EndPanel();
-	}
-
-	void AuthImGuiRenderer::DrawLangFooterHints(std::string_view left, std::string_view right)
-	{
-		LnWidgets::FooterHints(left, right);
 	}
 
 	void AuthImGuiRenderer::DrawAuthGoldField(const engine::client::AuthUiPresenter::RenderField& spec, char* buf, int bufSz,
@@ -662,15 +639,10 @@ namespace engine::render
 	{
 		if (rm.authLoginFooterChips.empty())
 		{
-			DrawKeycapHints({{"Tab", "champ suivant"}, {"Entree", "se connecter"}, {"Echap", "quitter"}});
+			LnWidgets::KeycapHints({{"Tab", "champ suivant"}, {"Entree", "se connecter"}, {"Echap", "quitter"}});
 			return;
 		}
-		DrawFooterChipRow(rm.authLoginFooterChips);
-	}
-
-	void AuthImGuiRenderer::DrawFooterChipRow(const std::vector<std::pair<std::string, std::string>>& chips)
-	{
-		LnWidgets::FooterChipRow(chips);
+		LnWidgets::FooterChipRow(rm.authLoginFooterChips);
 	}
 
 	void AuthImGuiRenderer::DrawRegisterFlowHeader(const RenderModel& rm, float vpW)
@@ -727,10 +699,10 @@ namespace engine::render
 	{
 		if (rm.authRegisterFooterChips.empty())
 		{
-			DrawKeycapHints({{"Entree", "valider"}, {"Echap", "retour"}});
+			LnWidgets::KeycapHints({{"Entree", "valider"}, {"Echap", "retour"}});
 			return;
 		}
-		DrawFooterChipRow(rm.authRegisterFooterChips);
+		LnWidgets::FooterChipRow(rm.authRegisterFooterChips);
 	}
 
 	void AuthImGuiRenderer::DrawLoginLanguageBadge(float vpW, float vpH)
@@ -933,46 +905,6 @@ namespace engine::render
 		ImGui::PopStyleVar(3);
 	}
 
-	void AuthImGuiRenderer::DrawField(std::string_view label, char* buf, int bufSz, bool password)
-	{
-		LnWidgets::Field(label, buf, bufSz, password);
-	}
-
-	void AuthImGuiRenderer::DrawBanner(std::string_view title, std::string_view msg, float r, float g, float b)
-	{
-		LnWidgets::Banner(title, msg, r, g, b);
-	}
-
-	void AuthImGuiRenderer::DrawKeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints)
-	{
-		LnWidgets::KeycapHints(hints);
-	}
-
-	bool AuthImGuiRenderer::DrawPrimaryButton(std::string_view label, bool disabled, float width)
-	{
-		return LnWidgets::PrimaryButton(label, disabled, width);
-	}
-
-	bool AuthImGuiRenderer::DrawGhostButton(std::string_view label, bool disabled, float width)
-	{
-		return LnWidgets::GhostButton(label, disabled, width);
-	}
-
-	void AuthImGuiRenderer::DrawSeparator()
-	{
-		LnWidgets::Separator();
-	}
-
-	void AuthImGuiRenderer::DrawBreadcrumb(std::initializer_list<const char*> steps, int current)
-	{
-		LnWidgets::Breadcrumb(steps, current);
-	}
-
-	void AuthImGuiRenderer::DrawBreadcrumb(const std::vector<std::string>& steps, int current)
-	{
-		LnWidgets::Breadcrumb(steps, current);
-	}
-
 } // namespace engine::render
 
 #else
@@ -997,7 +929,6 @@ namespace engine::render
 
 	void AuthImGuiRenderer::SyncTransientFromModel(const VisualState&, const RenderModel&) {}
 
-	void AuthImGuiRenderer::DrawBreadcrumb(const std::vector<std::string>&, int) {}
 } // namespace engine::render
 
 #endif

--- a/src/client/render/AuthImGuiRenderer.h
+++ b/src/client/render/AuthImGuiRenderer.h
@@ -227,42 +227,23 @@ namespace engine::render
 		void RenderCharCreateScreen(const RenderModel& rm, float vpW, float vpH);
 		void RenderCharacterSelectScreen(const RenderModel& rm, float vpW, float vpH);
 
-		void BeginFullscreenOverlay(float vpW, float vpH, float windowBgAlpha = 1.f);
 		/// Helper unifié pour le rendu du grand titre « LES CHRONIQUES » + sous-titre
 		/// « DE LA LUNE NOIRE » sur tous les écrans auth — pattern de référence calé
 		/// sur l'écran Login (h1 scale 5.0x, Dummy 28 px pour passer sous la jambe du R,
 		/// h2 scale 2.5x). Ouvre un BeginChild "##ln_<screenId>_stage" 96 % vpW que le
 		/// caller doit refermer via ImGui::EndChild() après EndPanel.
 		void DrawAuthBigTitle(const RenderModel& rm, float vpW, float vpH, const char* screenId);
-		bool BeginPanel(float width, float vpW, float vpH, std::string_view title, std::string_view subtitle,
-			std::string_view versionLabel = {}, bool versionLeadingInfoGlyph = false, bool subtitleWelcomeAccent = false,
-			float fixedHeight = 0.f);
-		void EndPanel();
 		int DrawLanguageFirstRunCards(const RenderModel& rm, int selected);
 		void DrawAuthTweaksPanel(float vpW, float vpH);
 		/// Affiche au-dessus du cadre login le badge « Langue : … » capturé lors de la transition
 		/// depuis l'écran de sélection de langue. Disparaît automatiquement après quelques secondes.
 		void DrawLoginLanguageBadge(float vpW, float vpH);
-		void DrawLangFooterHints(std::string_view left, std::string_view right);
 		void DrawAuthGoldField(const engine::client::AuthUiPresenter::RenderField& spec, char* buf, int bufSz, bool password,
 			float extraSpacingPx = 0.f);
 		void DrawLoginRememberRow(const RenderModel& rm);
 		void DrawLoginFooterChips(const RenderModel& rm);
-		void DrawFooterChipRow(const std::vector<std::pair<std::string, std::string>>& chips);
 		void DrawRegisterFlowHeader(const RenderModel& rm, float vpW);
 		void DrawRegisterFooterChips(const RenderModel& rm);
-		void DrawField(std::string_view label, char* buf, int bufSz, bool password = false);
-		void DrawBanner(std::string_view title, std::string_view msg, float r, float g, float b);
-		void DrawKeycapHints(std::initializer_list<std::pair<const char*, const char*>> hints);
-		// width = -FLT_MIN (défaut) = pleine largeur. Quand on place plusieurs de ces boutons sur
-		// la même ligne avec SameLine, il faut donner une largeur finie à chacun pour éviter que
-		// leur rectangle de hit-test ne se chevauche (cas vu dans Terms : Refuser couvrait toute
-		// la largeur, donc cliquer sur Accepter déclenchait Refuser → fermeture de l'app).
-		bool DrawPrimaryButton(std::string_view label, bool disabled = false, float width = -FLT_MIN);
-		bool DrawGhostButton(std::string_view label, bool disabled = false, float width = -FLT_MIN);
-		void DrawSeparator();
-		void DrawBreadcrumb(std::initializer_list<const char*> steps, int current);
-		void DrawBreadcrumb(const std::vector<std::string>& steps, int current);
 
 		void SyncTransientFromModel(const VisualState& vs, const RenderModel& rm);
 		void PullLanguageOptionsFromPresenter();

--- a/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterCreate.cpp
@@ -23,6 +23,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -48,9 +49,9 @@ namespace engine::render
 
 		const std::string panelTitle =
 			rm.sectionTitle.empty() ? std::string("Creation de personnage") : rm.sectionTitle;
-		if (!BeginPanel(panelW, titleZoneW, vpH, panelTitle.c_str(), "", ""))
+		if (!LnWidgets::BeginPanel(panelW, titleZoneW, vpH, panelTitle.c_str(), "", ""))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
@@ -121,7 +122,7 @@ namespace engine::render
 
 			const std::string& nameLabel =
 				rm.fields.empty() ? std::string("Nom du personnage") : rm.fields[0].label;
-			DrawField(nameLabel.c_str(), m_charName, static_cast<int>(sizeof(m_charName)));
+			LnWidgets::Field(nameLabel.c_str(), m_charName, static_cast<int>(sizeof(m_charName)));
 			for (const auto& line : rm.bodyLines)
 			{
 				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
@@ -399,7 +400,7 @@ namespace engine::render
 		ImGui::Spacing();
 		const float ccGap  = 8.f;
 		const float ccBtnW = (ImGui::GetContentRegionAvail().x - ccGap) * 0.5f;
-		if (DrawGhostButton("Annuler", false, ccBtnW) && m_authPresenter != nullptr)
+		if (LnWidgets::GhostButton("Annuler", false, ccBtnW) && m_authPresenter != nullptr)
 		{
 			m_authPresenter->ImGuiCancelCharacterCreateReturnToLogin();
 		}
@@ -413,7 +414,7 @@ namespace engine::render
 				break;
 			}
 		}
-		if (DrawPrimaryButton(submitLabel.c_str(), false, ccBtnW) && m_authPresenter != nullptr &&
+		if (LnWidgets::PrimaryButton(submitLabel.c_str(), false, ccBtnW) && m_authPresenter != nullptr &&
 		    m_authCfg != nullptr)
 		{
 			// Resout le raceId depuis le presenter (fallback "humains").
@@ -458,7 +459,7 @@ namespace engine::render
 			const uint8_t skinTone = static_cast<uint8_t>((m_charSkinTone == 1) ? 1 : 0);
 				m_authPresenter->ImGuiSubmitCharacterCreate(*m_authCfg, m_charName, raceId.c_str(), genderId, skinTone, factionId.c_str(), classId.c_str());
 		}
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 	}
 } // namespace engine::render

--- a/src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
+++ b/src/client/render/auth/screens/AuthImGuiCharacterSelect.cpp
@@ -16,6 +16,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -48,9 +49,9 @@ namespace engine::render
 			? m_authPresenter->CharacterListEntries() : kEmpty;
 		const int selected = m_authPresenter ? m_authPresenter->CharacterSelectIndex() : -1;
 
-		if (!BeginPanel(680.f, titleZoneW, vpH, std::string_view(titleStr), std::string_view(subStr), std::string_view(""), true, false))
+		if (!LnWidgets::BeginPanel(680.f, titleZoneW, vpH, std::string_view(titleStr), std::string_view(subStr), std::string_view(""), true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
@@ -300,7 +301,7 @@ namespace engine::render
 			m_authPresenter->ImGuiActivateSelectedCharacter();
 		}
 
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 	}
 } // namespace engine::render

--- a/src/client/render/auth/screens/AuthImGuiError.cpp
+++ b/src/client/render/auth/screens/AuthImGuiError.cpp
@@ -10,6 +10,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -53,9 +54,9 @@ namespace engine::render
 			const std::string_view sub = rm.authErrorPanelSubtitle;
 			const std::string& ver =
 				rm.authErrorVersionBadge.empty() ? std::string("Erreur") : rm.authErrorVersionBadge;
-			if (!BeginPanel(640.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
+			if (!LnWidgets::BeginPanel(640.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
 			{
-				EndPanel();
+				LnWidgets::EndPanel();
 				ImGui::EndChild();
 				DrawAuthTweaksPanel(vpW, vpH);
 				return;
@@ -192,13 +193,13 @@ namespace engine::render
 				ImGui::Spacing();
 				const std::string& retry =
 					rm.authErrorRetryButtonLabel.empty() ? std::string("Retry") : rm.authErrorRetryButtonLabel;
-				if (DrawPrimaryButton(retry) && m_authPresenter != nullptr && m_authCfg != nullptr)
+				if (LnWidgets::PrimaryButton(retry) && m_authPresenter != nullptr && m_authCfg != nullptr)
 				{
 					m_authPresenter->ImGuiAcknowledgeErrorScreen(*m_authCfg);
 				}
 			}
 
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			DrawAuthTweaksPanel(vpW, vpH);
 
@@ -218,9 +219,9 @@ namespace engine::render
 			}
 		}
 		const std::string& ver = rm.authErrorVersionBadge.empty() ? std::string("Erreur") : rm.authErrorVersionBadge;
-		if (!BeginPanel(560.f, titleZoneW, vpH, panelTitle, "", ver, true, false))
+		if (!LnWidgets::BeginPanel(560.f, titleZoneW, vpH, panelTitle, "", ver, true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			DrawAuthTweaksPanel(vpW, vpH);
 			return;
@@ -231,11 +232,11 @@ namespace engine::render
 
 		const std::string& backLbl2 =
 			rm.authErrorBackButtonLabel.empty() ? std::string("RETOUR AU FORMULAIRE") : rm.authErrorBackButtonLabel;
-		if (DrawGhostButton(backLbl2.c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
+		if (LnWidgets::GhostButton(backLbl2.c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
 		{
 			m_authPresenter->ImGuiAcknowledgeErrorScreen(*m_authCfg);
 		}
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 		DrawAuthTweaksPanel(vpW, vpH);
 

--- a/src/client/render/auth/screens/AuthImGuiForgotPassword.cpp
+++ b/src/client/render/auth/screens/AuthImGuiForgotPassword.cpp
@@ -6,6 +6,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 
 namespace engine::render
 {
@@ -26,13 +27,13 @@ namespace engine::render
 		};
 
 		const std::string title = rm.sectionTitle.empty() ? tr("auth.section.forgot_password", "Password recovery") : rm.sectionTitle;
-		if (!BeginPanel(460.f, vpW, vpH, title.c_str(), "", ""))
+		if (!LnWidgets::BeginPanel(460.f, vpW, vpH, title.c_str(), "", ""))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			return;
 		}
 		const std::string emailLabel = rm.fields.empty() ? tr("common.email", "Email") : rm.fields[0].label;
-		DrawField(emailLabel.c_str(), m_forgotEmail, static_cast<int>(sizeof(m_forgotEmail)));
+		LnWidgets::Field(emailLabel.c_str(), m_forgotEmail, static_cast<int>(sizeof(m_forgotEmail)));
 
 		std::string submitLabel = tr("common.submit", "Submit");
 		std::string backLabel = tr("common.back", "Back");
@@ -48,16 +49,16 @@ namespace engine::render
 			}
 		}
 
-		if (DrawPrimaryButton(submitLabel.c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
+		if (LnWidgets::PrimaryButton(submitLabel.c_str()) && m_authPresenter != nullptr && m_authCfg != nullptr)
 		{
 			m_authPresenter->ImGuiSubmitForgotPassword(*m_authCfg, m_forgotEmail);
 		}
 		ImGui::SameLine(0.f, 8.f);
-		if (DrawGhostButton(backLabel.c_str()) && m_authPresenter != nullptr)
+		if (LnWidgets::GhostButton(backLabel.c_str()) && m_authPresenter != nullptr)
 		{
 			m_authPresenter->ImGuiBackFromForgotToLogin();
 		}
-		EndPanel();
+		LnWidgets::EndPanel();
 	}
 } // namespace engine::render
 

--- a/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
+++ b/src/client/render/auth/screens/AuthImGuiLanguageSelect.cpp
@@ -14,6 +14,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -158,9 +159,9 @@ namespace engine::render
 		// On passe titleZoneW (et non vpW) en 2e arg : le panel se centre desormais dans la stage
 		// (BeginChild ##ln_lang_stage), meme logique que l'ecran Login.
 		const float panelFixedH = 340.f;
-		if (!BeginPanel(720.f, titleZoneW, vpH, panelTitle, welcome, ver, true, true, panelFixedH))
+		if (!LnWidgets::BeginPanel(720.f, titleZoneW, vpH, panelTitle, welcome, ver, true, true, panelFixedH))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
@@ -230,13 +231,13 @@ namespace engine::render
 		ImGui::PopStyleVar(1);
 		ImGui::PopStyleColor(4);
 
-		DrawSeparator();
+		LnWidgets::Separator();
 		const std::string& footL =
 			rm.languageFooterLeft.empty() ? std::string("Fleches : naviguer") : rm.languageFooterLeft;
 		const std::string& footR = rm.languageFooterRight.empty() ? std::string("Entree : valider") : rm.languageFooterRight;
-		DrawLangFooterHints(footL, footR);
+		LnWidgets::FooterHints(footL, footR);
 
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 
 		DrawAuthTweaksPanel(vpW, vpH);

--- a/src/client/render/auth/screens/AuthImGuiLogin.cpp
+++ b/src/client/render/auth/screens/AuthImGuiLogin.cpp
@@ -8,6 +8,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 
 namespace engine::render
 {
@@ -52,9 +53,9 @@ namespace engine::render
 		// sommes desormais dans un BeginChild de largeur titleZoneW ( vpW), il faut passer
 		// titleZoneW - sinon le calcul `(stageW - stageW) / 2 = 0` poussait le panneau contre
 		// le bord gauche de la stage (bug observe en revue UX).
-		if (!BeginPanel(stageW, titleZoneW, vpH, panelTitle, "", ver, true, false))
+		if (!LnWidgets::BeginPanel(stageW, titleZoneW, vpH, panelTitle, "", ver, true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
@@ -94,8 +95,8 @@ namespace engine::render
 		}
 		else
 		{
-			DrawField(tr("auth.label.login", "Login").c_str(), m_loginId, static_cast<int>(sizeof(m_loginId)), false);
-			DrawField(tr("auth.label.password", "Password").c_str(), m_loginPw, static_cast<int>(sizeof(m_loginPw)), true);
+			LnWidgets::Field(tr("auth.label.login", "Login").c_str(), m_loginId, static_cast<int>(sizeof(m_loginId)), false);
+			LnWidgets::Field(tr("auth.label.password", "Password").c_str(), m_loginPw, static_cast<int>(sizeof(m_loginPw)), true);
 		}
 
 		DrawLoginRememberRow(rm);
@@ -169,7 +170,7 @@ namespace engine::render
 			m_authPresenter->ImGuiSubmitLogin(*m_authCfg, m_loginId, m_loginPw, m_rememberMe);
 		}
 
-		// Anciennement : DrawSeparator() + DrawLoginFooterChips(rm) qui affichaient les chips
+		// Anciennement : LnWidgets::Separator() + DrawLoginFooterChips(rm) qui affichaient les chips
 		// [Tab] champ suivant | [Entree] se connecter | [Echap] quitter. L'utilisateur veut ces
 		// rappels masques (les touches restent actives via ImGui InputText nav et le handler
 		// d'entree du presenter), mais la zone visuelle disparait pour epurer le panneau.
@@ -179,7 +180,7 @@ namespace engine::render
 		// (suite au retour utilisateur : " il faudrait l'agrandir en hauteur ").
 		ImGui::Dummy(ImVec2(0.f, 30.f));
 
-		EndPanel();
+		LnWidgets::EndPanel();
 
 		ImGui::EndChild();
 

--- a/src/client/render/auth/screens/AuthImGuiOptions.cpp
+++ b/src/client/render/auth/screens/AuthImGuiOptions.cpp
@@ -14,6 +14,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -202,7 +203,7 @@ namespace engine::render
 		}
 		ImGui::SetWindowFontScale(1.f);
 		ImGui::PopStyleColor();
-		DrawSeparator();
+		LnWidgets::Separator();
 
 		for (int i : visibleTabs)
 		{
@@ -286,7 +287,7 @@ namespace engine::render
 			ImGui::TextUnformatted(tr("options.imgui.dirty_banner_title").c_str());
 			ImGui::PopStyleColor();
 		}
-		DrawSeparator();
+		LnWidgets::Separator();
 
 		// Body : hauteur 0 = remplit l'espace restant du panel main (ImGui calcule
 		// auto en retranchant la taille deja consommee par header + separator).
@@ -730,7 +731,7 @@ namespace engine::render
 
 		ImGui::EndChild();
 
-		DrawSeparator();
+		LnWidgets::Separator();
 		const float btnW = 128.f;
 		const std::string backStr = tr("options.imgui.button.back");
 		const std::string cancelStr = tr("common.cancel");
@@ -828,7 +829,7 @@ namespace engine::render
 	/// frame ImGui ouverte, valeur de retour). Detail d'implementation :
 	///  - 1ere frame d'ouverture (m_optionsOverlayWasOpen passe false->true) : on tire les
 	///    mirrors d'edition (m_opt*) depuis les *Pending prepares par OpenLanguageOptionsInGame.
-	///  - overlay opaque via BeginFullscreenOverlay(.., 1.0f), puis RenderOptionsScreen(inGame=true),
+	///  - overlay opaque via LnWidgets::BeginFullscreenOverlay(.., 1.0f), puis RenderOptionsScreen(inGame=true),
 	///    puis ImGui::End() — paire Begin/End equilibree.
 	///  - fermeture detectee via le presenter : RenderOptionsScreen appelle
 	///    ImGuiCloseLanguageOptionsWithoutApply() (Retour/Echap) qui, en in-game, pose
@@ -855,7 +856,7 @@ namespace engine::render
 		// RenderModel minimal : champs par defaut. authOptionsAccountLogin /
 		// authOptionsAccountTagId restent vides — l'onglet Account sera masque en jeu (ST6).
 		RenderModel rmMinimal{};
-		BeginFullscreenOverlay(vpW, vpH, 1.0f);
+		LnWidgets::BeginFullscreenOverlay(vpW, vpH, 1.0f);
 		RenderOptionsScreen(rmMinimal, vpW, vpH, /*inGame=*/true);
 		ImGui::End();
 

--- a/src/client/render/auth/screens/AuthImGuiRegister.cpp
+++ b/src/client/render/auth/screens/AuthImGuiRegister.cpp
@@ -10,6 +10,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -55,16 +56,16 @@ namespace engine::render
 			rm.authRegisterPanelBadge.empty() ? std::string("2 / 4") : rm.authRegisterPanelBadge;
 		// Panel elargi 760 > 880 px : avec 760, le bouton " CREER LE COMPTE " a droite etait
 		// coupe en bord de cadre. Cf retour utilisateur sur la maquette.
-		if (!BeginPanel(880.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
+		if (!LnWidgets::BeginPanel(880.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
 
 		if (!rm.errorText.empty())
 		{
-			DrawBanner("Echec", rm.errorText, LnTheme::kErrorCol.r, LnTheme::kErrorCol.g, LnTheme::kErrorCol.b);
+			LnWidgets::Banner("Echec", rm.errorText, LnTheme::kErrorCol.r, LnTheme::kErrorCol.g, LnTheme::kErrorCol.b);
 		}
 
 		const bool haveModel = (rm.fields.size() >= 10u && rm.dropdowns.size() >= 3u);
@@ -208,7 +209,7 @@ namespace engine::render
 				}
 				else
 				{
-					DrawField(tr("auth.label.country", "Country").c_str(), m_regCountry, static_cast<int>(sizeof(m_regCountry)), false);
+					LnWidgets::Field(tr("auth.label.country", "Country").c_str(), m_regCountry, static_cast<int>(sizeof(m_regCountry)), false);
 				}
 				ImGui::Spacing();
 			}
@@ -224,11 +225,11 @@ namespace engine::render
 		}
 		else
 		{
-			DrawField(tr("auth.label.login", "Login").c_str(), m_regId, static_cast<int>(sizeof(m_regId)));
-			DrawField(tr("common.email", "Email").c_str(), m_regEmail, static_cast<int>(sizeof(m_regEmail)));
-			DrawField(tr("auth.label.first_name", "First name").c_str(), m_regFirstName, static_cast<int>(sizeof(m_regFirstName)));
-			DrawField(tr("auth.label.last_name", "Last name").c_str(), m_regLastName, static_cast<int>(sizeof(m_regLastName)));
-			DrawField(tr("auth.label.country", "Country").c_str(), m_regCountry, static_cast<int>(sizeof(m_regCountry)));
+			LnWidgets::Field(tr("auth.label.login", "Login").c_str(), m_regId, static_cast<int>(sizeof(m_regId)));
+			LnWidgets::Field(tr("common.email", "Email").c_str(), m_regEmail, static_cast<int>(sizeof(m_regEmail)));
+			LnWidgets::Field(tr("auth.label.first_name", "First name").c_str(), m_regFirstName, static_cast<int>(sizeof(m_regFirstName)));
+			LnWidgets::Field(tr("auth.label.last_name", "Last name").c_str(), m_regLastName, static_cast<int>(sizeof(m_regLastName)));
+			LnWidgets::Field(tr("auth.label.country", "Country").c_str(), m_regCountry, static_cast<int>(sizeof(m_regCountry)));
 		}
 
 		// Checklist mot de passe LIVE, alignée sur la politique serveur (ValidatePassword) :
@@ -326,12 +327,12 @@ namespace engine::render
 		}
 		else
 		{
-			if (DrawGhostButton(tr("auth.register.footer.back", "Back").c_str()) && m_authPresenter != nullptr)
+			if (LnWidgets::GhostButton(tr("auth.register.footer.back", "Back").c_str()) && m_authPresenter != nullptr)
 			{
 				m_authPresenter->ImGuiBackFromRegisterToLogin();
 			}
 			ImGui::SameLine(ImGui::GetContentRegionAvail().x * 0.55f);
-			if (DrawPrimaryButton(tr("auth.register.submit_create", "CREATE ACCOUNT").c_str(), !canSubmit) && m_authPresenter != nullptr && m_authCfg != nullptr)
+			if (LnWidgets::PrimaryButton(tr("auth.register.submit_create", "CREATE ACCOUNT").c_str(), !canSubmit) && m_authPresenter != nullptr && m_authCfg != nullptr)
 			{
 				engine::client::AuthUiPresenter::RegisterImGuiSubmit form{};
 				form.login = m_regId;
@@ -372,9 +373,9 @@ namespace engine::render
 			m_authPresenter->ImGuiSubmitRegister(*m_authCfg, form);
 		}
 
-		DrawSeparator();
+		LnWidgets::Separator();
 		DrawRegisterFooterChips(rm);
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 
 		DrawAuthTweaksPanel(vpW, vpH);

--- a/src/client/render/auth/screens/AuthImGuiShardPick.cpp
+++ b/src/client/render/auth/screens/AuthImGuiShardPick.cpp
@@ -18,6 +18,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -87,9 +88,9 @@ namespace engine::render
 		const std::string verStr = tr("auth.shard_pick.version_online",
 			P{{"online", std::to_string(onlineCount)}, {"total", std::to_string(entries.size())}});
 
-		if (!BeginPanel(820.f, titleZoneW, vpH, std::string_view(titleStr), std::string_view(subStr), std::string_view(verStr), true, false))
+		if (!LnWidgets::BeginPanel(820.f, titleZoneW, vpH, std::string_view(titleStr), std::string_view(subStr), std::string_view(verStr), true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			return;
 		}
@@ -425,7 +426,7 @@ namespace engine::render
 			m_authPresenter->ImGuiSubmitShardPick(*m_authCfg);
 		}
 
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 
 		DrawAuthTweaksPanel(vpW, vpH);

--- a/src/client/render/auth/screens/AuthImGuiTerms.cpp
+++ b/src/client/render/auth/screens/AuthImGuiTerms.cpp
@@ -9,6 +9,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -39,9 +40,9 @@ namespace engine::render
 		const std::string title = rm.sectionTitle.empty() ? tr("auth.panel.terms", "Terms of use") : rm.sectionTitle;
 		const float termsW = (std::min)(960.f, vpW * 0.92f);
 		const float termsPanelH = (std::min)(820.f, vpH * 0.78f);
-		if (!BeginPanel(termsW, vpW, vpH, title.c_str(), "", "", false, false, termsPanelH))
+		if (!LnWidgets::BeginPanel(termsW, vpW, vpH, title.c_str(), "", "", false, false, termsPanelH))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			return;
 		}
 		{
@@ -96,7 +97,7 @@ namespace engine::render
 				m_authPresenter->ImGuiSetTermsAcknowledgeChecked(termsAckChecked);
 			}
 		}
-		DrawSeparator();
+		LnWidgets::Separator();
 		// Largeurs finies : avant, DrawGhostButton et DrawPrimaryButton utilisaient -FLT_MIN
 		// (pleine largeur), donc Refuser couvrait toute la ligne et son rectangle de hit-test
 		// englobait celui d'Accepter. ImGui choisit le premier item dessine en cas de chevauchement
@@ -104,16 +105,16 @@ namespace engine::render
 		// fermeture immediate du jeu (" le jeu plante ").
 		const float btnGap = 14.f;
 		const float btnW = (ImGui::GetContentRegionAvail().x - btnGap) * 0.5f;
-		if (DrawGhostButton("Refuser", false, btnW) && m_authPresenter != nullptr && m_authWindow != nullptr)
+		if (LnWidgets::GhostButton("Refuser", false, btnW) && m_authPresenter != nullptr && m_authWindow != nullptr)
 		{
 			m_authPresenter->ImGuiTermsDecline(*m_authWindow);
 		}
 		ImGui::SameLine(0.f, btnGap);
-		if (DrawPrimaryButton("Accepter / continuer", false, btnW) && m_authPresenter != nullptr && m_authCfg != nullptr)
+		if (LnWidgets::PrimaryButton("Accepter / continuer", false, btnW) && m_authPresenter != nullptr && m_authCfg != nullptr)
 		{
 			m_authPresenter->ImGuiTermsPrimaryClick(*m_authCfg);
 		}
-		EndPanel();
+		LnWidgets::EndPanel();
 	}
 } // namespace engine::render
 

--- a/src/client/render/auth/screens/AuthImGuiVerifyEmail.cpp
+++ b/src/client/render/auth/screens/AuthImGuiVerifyEmail.cpp
@@ -11,6 +11,7 @@
 
 #if defined(_WIN32)
 #	include "imgui.h"
+#	include "src/client/render/LnWidgets.h"
 #	include "src/client/render/LnThemeImGui.h"
 
 namespace engine::render
@@ -73,9 +74,9 @@ namespace engine::render
 			rm.authVerifyPanelSubtitle.empty() ? std::string("NOUS AVONS ENVOYE UN CODE A 6 CHIFFRES.") : rm.authVerifyPanelSubtitle;
 		const std::string& ver =
 			rm.authVerifyPanelBadge.empty() ? std::string("3 / 4") : rm.authVerifyPanelBadge;
-		if (!BeginPanel(560.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
+		if (!LnWidgets::BeginPanel(560.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			DrawAuthTweaksPanel(vpW, vpH);
 			return;
@@ -228,7 +229,7 @@ namespace engine::render
 		}
 		ImGui::NextColumn();
 		{
-			if (DrawPrimaryButton(submitLbl, !codeComplete) && m_authPresenter != nullptr && m_authCfg != nullptr)
+			if (LnWidgets::PrimaryButton(submitLbl, !codeComplete) && m_authPresenter != nullptr && m_authCfg != nullptr)
 			{
 				const std::string p = PackVerifySlotsInOrder(m_verifyCode);
 				m_authPresenter->ImGuiSubmitVerifyEmailCode(*m_authCfg, p.c_str());
@@ -246,7 +247,7 @@ namespace engine::render
 		}
 		ImGui::Columns(1);
 
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 
 		if (!rm.authVerifyDevHint.empty())
@@ -297,9 +298,9 @@ namespace engine::render
 		const std::string& sub = rm.authVerifyPanelSubtitle;
 		const std::string& ver =
 			rm.authVerifyPanelBadge.empty() ? std::string("3 / 4") : rm.authVerifyPanelBadge;
-		if (!BeginPanel(560.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
+		if (!LnWidgets::BeginPanel(560.f, titleZoneW, vpH, panelTitle, sub, ver, true, false))
 		{
-			EndPanel();
+			LnWidgets::EndPanel();
 			ImGui::EndChild();
 			DrawAuthTweaksPanel(vpW, vpH);
 			return;
@@ -460,7 +461,7 @@ namespace engine::render
 		}
 		ImGui::NextColumn();
 		{
-			if (DrawPrimaryButton(submitLbl, !codeComplete) && m_authPresenter != nullptr && m_authCfg != nullptr)
+			if (LnWidgets::PrimaryButton(submitLbl, !codeComplete) && m_authPresenter != nullptr && m_authCfg != nullptr)
 			{
 				const std::string p = PackVerifySlotsInOrder(m_verifyCode);
 				m_authPresenter->ImGuiSubmitVerifyEmailCode(*m_authCfg, p.c_str());
@@ -478,7 +479,7 @@ namespace engine::render
 		}
 		ImGui::Columns(1);
 
-		EndPanel();
+		LnWidgets::EndPanel();
 		ImGui::EndChild();
 
 		if (!rm.authVerifyDevHint.empty())


### PR DESCRIPTION
## Objectif

Finalise l'étape **0c**. Le socle (`LnWidgets.{h,cpp}` + les 14 délégations
transitoires dans l'auth) est déjà dans `main` via #925 (squash `6a79b4f9`). Cette
PR enlève l'échafaudage et bascule sur des **appels directs** (Option 1).

## Changements

- **Suppression des 13 délégations** d'`AuthImGuiRenderer` (méthodes `.cpp` +
  déclarations `.h`) + retrait du stub `#else` de `DrawBreadcrumb`.
- **Renommage des ~78 sites d'appel** vers les fonctions libres : `BeginPanel` →
  `LnWidgets::BeginPanel`, `DrawPrimaryButton` → `LnWidgets::PrimaryButton`,
  `DrawField` → `LnWidgets::Field`, etc. (mapping ancien nom → nom `LnWidgets`
  sans préfixe `Draw`). Inclut les appels internes du Groupe B (`FooterChipRow`)
  et le dispatch de `Render()`.
- **Include `LnWidgets.h`** ajouté aux 11 fichiers d'écran.
- **`DrawAuthBigTitle` conservée** (méthode auth : elle porte le repli métier
  « Les Chroniques… ») et délègue à `LnWidgets::BigTitle`.

## Vérifications (avant push)

- **0** définition/déclaration primitive résiduelle dans `AuthImGuiRenderer`
  (hors `DrawAuthBigTitle`).
- **0** appel non-qualifié résiduel (les seules occurrences non préfixées sont
  les définitions des fonctions dans `LnWidgets` lui-même). **78** appels
  `LnWidgets::`, 0 double-qualification.
- Périmètre : 13 fichiers, tous sous `src/client/render/`.

## Rendu / tests

Renommage **pur** : aucun code exécuté ne change → rendu des écrans d'auth
identique. Pas de nouvelle cible de test (primitives ImGui, non liables sur la
cible ctest Linux). La validation visuelle peut se faire dès maintenant sur
`main` (le code exécuté y est déjà le code final).

## Déploiement

✅ **Client uniquement — pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)