### PR TITLE
feat(quests): SP1 — cycle de vie des quêtes piloté par le joueur (shard)

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2431,3 +2431,14 @@ cast ; le combat reste sur les kits profil jusqu'à SP-C).
   (cf. spec §6).
 - **Déploiement** : ⚠️ redéploiement **shardd** (nouveau `ClassSkillLibrary` au
   boot) mais **inerte** → pas de lock-step.
+
+## Quêtes — cycle de vie piloté par le joueur (SP1)
+
+Le système de quêtes du shard (`src/shardd/gameplay/quest/QuestRuntime`) suit une machine d'états par personnage : `Locked → Offered → Active → ReadyToTurnIn → Completed`.
+
+- **Offered** : pré-requis remplis ; la quête est proposée par son PNJ `giver` (visible via la giver-list au Talk, pas dans le journal).
+- **Active** : le joueur a accepté (message `QuestAcceptRequest`, opcode 93) ; la progression avance via les events gameplay (`Kill/Collect/Talk/Enter`).
+- **ReadyToTurnIn** : toutes les étapes remplies ; **aucune récompense encore**.
+- **Completed** : le joueur a rendu la quête à son PNJ `turnIn` (message `QuestTurnInRequest`, opcode 94) → **récompenses versées à ce moment** (XP/or/items).
+
+Au `Talk` sur un PNJ, le shard renvoie `QuestGiverList` (opcode 92) listant ses quêtes proposées/rendables pour ce joueur, en plus de l'event d'étape `Talk`. Le contenu est data-driven (`game/data/quests/quest_definitions.json`, champs `giver`/`turnIn`). Wire : `kProtocolVersion` 14. Persistance : `CharacterPersistence` sérialise statut + `stepProgressCounts` + `quests.format_version` par personnage. Détails : `docs/superpowers/specs/2026-07-02-quest-*`.

--- a/docs/superpowers/plans/2026-07-02-quest-sp1-player-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-02-quest-sp1-player-lifecycle.md
@@ -1,0 +1,1066 @@
+# SP1 — Cycle de vie des quêtes piloté par le joueur — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transformer le système de quêtes shard « tout automatique » en un cycle piloté par le joueur (accept explicite au PNJ → progression → turn-in explicite au PNJ, récompenses versées au turn-in).
+
+**Architecture:** Le shard (`QuestRuntime`) reste la source de vérité data-driven. On étend l'enum d'états (`Offered`, `ReadyToTurnIn`), on ajoute les champs `giver`/`turnIn` au JSON de contenu, trois nouveaux messages wire (giver-list, accept, turn-in), les handlers `ServerApp` correspondants, et une table de compat au chargement des personnages. Le versement des récompenses migre de la complétion auto vers le handler de turn-in.
+
+**Tech Stack:** C++20, `src/shardd/gameplay/quest/QuestRuntime`, `src/shared/network/ServerProtocol`, `src/shardd/gameplay/character/CharacterPersistence`, `src/shared/server_bootstrap/ServerApp`. Tests via CTest (`lcdlln_add_simple_test`).
+
+## Global Constraints
+
+- **Commentaires en français**, clarté > brièveté (convention repo).
+- **PascalCase** pour tout nouveau symbole/fichier ; les `m_camelCase` / `kPascalCase` existants sont conservés.
+- **Ne jamais employer le terme « CMANGOS »** dans le code, commits, docs ou messages.
+- **Pas de build local** (cmake/MSVC/vcpkg absents des shells) : la vérification des tests se fait **via la CI** — `build-linux.yml` exécute `ctest`. Les étapes « run test » décrivent la commande `ctest` attendue en CI ; l'agent ne compile pas en local, il pousse et lit la CI.
+- **Pas de `assert()` nu dans les tests** : la CI `build-linux` compile en `NDEBUG` → les `assert` sont retirés. Utiliser le style d'assertion des tests existants (ex. `CreatureArchetypeLibraryTests.cpp` : conditions + `std::cerr` + `return 1`).
+- **Wire-breaking** : ce SP bumpe `kProtocolVersion` de **13 → 14** (`src/shared/network/ServerProtocol.h:62`). ⚠️ **REDÉPLOIEMENT SHARD requis**, en lock-step avec le client SP2.
+- **`questId` = `std::string`** partout côté système B (ne pas réintroduire d'`uint32`).
+- Aucun nouveau `.cpp` partagé n'est créé (on modifie des fichiers existants) → pas d'ajout à la liste `server_app` du `CMakeLists`. Seuls des fichiers de **test** sont créés (registrés via `lcdlln_add_simple_test`).
+
+---
+
+## Structure de fichiers
+
+**Modifiés :**
+- `src/shardd/gameplay/quest/QuestRuntime.h` — enum `QuestStatus` étendu ; champs `giverId`/`turnInId` ; nouvelles méthodes pures.
+- `src/shardd/gameplay/quest/QuestRuntime.cpp` — parse `giver`/`turnIn` ; `SyncQuestStates`→`Offered` ; `ApplyEvent`→`ReadyToTurnIn` sans reward ; helpers `CanAccept`/`CanTurnIn`/`TakeRewardOnTurnIn`.
+- `game/data/quests/quest_definitions.json` — migration : ajouter `giver`/`turnIn`.
+- `src/shared/network/ServerProtocol.h` — bump version ; 3 `MessageKind` ; 3 structs ; déclarations encode/decode.
+- `src/shared/network/ServerProtocol.cpp` — encode/decode des 3 messages.
+- `src/shardd/gameplay/character/CharacterPersistence.cpp` — map de compat au load ; save enum étendu.
+- `src/shared/server_bootstrap/ServerApp.h` — déclarations `HandleAcceptQuest`/`HandleTurnInQuest` + helper giver-list.
+- `src/shared/server_bootstrap/ServerApp.cpp` — dispatch + handlers ; retrait du reward de `ApplyQuestEvent` ; émission giver-list au `Talk`.
+
+**Créés (tests) :**
+- `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`
+- `src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp`
+- Ajouts wire dans le test existant `src/shared/network/ServerProtocolTests.cpp`.
+- Enregistrements CTest dans `src/CMakeLists.txt`.
+
+---
+
+## Task 1 : Enum d'états étendu + champs giver/turnIn + parse JSON
+
+**Files:**
+- Modify: `src/shardd/gameplay/quest/QuestRuntime.h` (enum `QuestStatus` ~L23-28 ; struct `QuestDefinition` ~L47-53)
+- Modify: `src/shardd/gameplay/quest/QuestRuntime.cpp` (`GetQuestStatusName` ~L486-497 ; `LoadDefinitions` boucle quête ~L845-932)
+- Modify: `game/data/quests/quest_definitions.json`
+- Create: `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`
+- Modify: `src/CMakeLists.txt`
+
+**Interfaces:**
+- Produces:
+  - `enum class QuestStatus : uint8_t { Locked=0, Offered=1, Active=2, ReadyToTurnIn=3, Completed=4 }`
+  - `QuestDefinition` gagne `std::string giverId;` et `std::string turnInId;`
+  - `const char* GetQuestStatusName(QuestStatus)` gère les 5 valeurs.
+
+- [ ] **Step 1 : Écrire le test de chargement (échec attendu)**
+
+Créer `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`. S'inspirer du style de `src/shardd/gameplay/creature/CreatureArchetypeLibraryTests.cpp` pour charger un JSON de fixture (écrire un fichier temporaire + `Config` pointant `server.quest_definitions_path` dessus, puis `Init()`).
+
+```cpp
+// Tests du QuestRuntime — cycle de vie piloté par le joueur (SP1).
+#include "src/shardd/gameplay/quest/QuestRuntime.h"
+#include "src/shared/core/Config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using engine::server::QuestRuntime;
+using engine::server::QuestStatus;
+using engine::server::QuestState;
+using engine::server::QuestStepType;
+using engine::server::QuestProgressDelta;
+
+namespace
+{
+    int g_failures = 0;
+
+    void Check(bool condition, const char* label)
+    {
+        if (!condition)
+        {
+            std::cerr << "[FAIL] " << label << "\n";
+            ++g_failures;
+        }
+    }
+
+    // Écrit un JSON de définitions dans un fichier temporaire relatif au content root
+    // de test, et construit un QuestRuntime initialisé dessus.
+    // Retourne le runtime prêt (Init() déjà appelé). Le fichier reste sur disque
+    // pour la durée du test (nettoyé par l'OS / non critique).
+    std::string WriteFixture(const std::string& jsonBody)
+    {
+        const std::string relPath = "quests/quest_definitions_test.json";
+        // NB : suivre CreatureArchetypeLibraryTests pour la résolution du content root.
+        std::ofstream out("game/data/" + relPath, std::ios::binary | std::ios::trunc);
+        out << jsonBody;
+        out.close();
+        return relPath;
+    }
+}
+
+int main()
+{
+    // Une définition minimale avec giver/turnIn.
+    const std::string json = R"JSON({
+      "quests": [
+        { "id": "q1", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [], "steps": [ { "type": "kill", "target": "mob:1", "requiredCount": 2 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } }
+      ]
+    })JSON";
+
+    engine::core::Config config;
+    const std::string relPath = WriteFixture(json);
+    config.SetString("server.quest_definitions_path", relPath);
+
+    QuestRuntime runtime(config);
+    Check(runtime.Init(), "Init charge une définition avec giver/turnIn");
+
+    const auto* def = runtime.FindQuestDefinition("q1");
+    Check(def != nullptr, "q1 trouvée");
+    if (def != nullptr)
+    {
+        Check(def->giverId == "npc:marn", "giver parsé");
+        Check(def->turnInId == "npc:marn", "turnIn parsé");
+    }
+
+    if (g_failures != 0)
+    {
+        std::cerr << g_failures << " assertion(s) échouée(s)\n";
+        return 1;
+    }
+    std::cout << "OK\n";
+    return 0;
+}
+```
+
+- [ ] **Step 2 : Enregistrer le test dans CMake**
+
+Dans `src/CMakeLists.txt`, après le bloc `quest_state_tests` (~L584-586), ajouter :
+
+```cmake
+  # SP1 : QuestRuntime — cycle de vie piloté par le joueur (parse giver/turnIn, transitions).
+  lcdlln_add_simple_test(quest_runtime_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp)
+```
+
+Et l'`add_test` correspondant à côté des autres (le helper `lcdlln_add_simple_test` s'en charge s'il génère l'`add_test` ; sinon suivre le pattern des voisins).
+
+- [ ] **Step 3 : Vérifier l'échec en CI**
+
+Run (CI build-linux) : `ctest -R quest_runtime_tests --output-on-failure`
+Expected : **FAIL** — `QuestDefinition` n'a pas encore `giverId`/`turnInId` → erreur de compilation.
+
+- [ ] **Step 4 : Étendre l'enum et la struct**
+
+Dans `src/shardd/gameplay/quest/QuestRuntime.h`, remplacer l'enum `QuestStatus` :
+
+```cpp
+	/// Statut runtime d'une quête pour un joueur. L'ordre est significatif
+	/// (persisté et transmis wire) : ne pas réordonner sans migration.
+	enum class QuestStatus : uint8_t
+	{
+		Locked        = 0,   ///< pré-requis non remplis (interne, non affiché)
+		Offered       = 1,   ///< proposée au PNJ giver, pas encore acceptée
+		Active        = 2,   ///< acceptée, en cours
+		ReadyToTurnIn = 3,   ///< étapes remplies, à rendre (pas encore récompensée)
+		Completed     = 4,   ///< rendue + récompensée (terminal)
+	};
+```
+
+Dans `struct QuestDefinition`, ajouter après `questId` :
+
+```cpp
+		std::string giverId;    ///< PNJ qui propose la quête (même espace que targetId du Talk)
+		std::string turnInId;   ///< PNJ où rendre la quête (souvent = giverId)
+```
+
+- [ ] **Step 5 : Mettre à jour `GetQuestStatusName`**
+
+Dans `QuestRuntime.cpp` (~L486), couvrir les 5 valeurs :
+
+```cpp
+	const char* GetQuestStatusName(QuestStatus status)
+	{
+		switch (status)
+		{
+		case QuestStatus::Locked:        return "locked";
+		case QuestStatus::Offered:       return "offered";
+		case QuestStatus::Active:        return "active";
+		case QuestStatus::ReadyToTurnIn: return "ready_to_turn_in";
+		case QuestStatus::Completed:     return "completed";
+		}
+		return "unknown";
+	}
+```
+
+- [ ] **Step 6 : Parser `giver`/`turnIn` (obligatoires) dans `LoadDefinitions`**
+
+Dans `QuestRuntime.cpp`, juste après `definition.questId = idValue->stringValue;` (~L846), ajouter la validation :
+
+```cpp
+			const JsonValue* giverValue  = FindObjectMember(questValue, "giver");
+			const JsonValue* turnInValue = FindObjectMember(questValue, "turnIn");
+			if (giverValue == nullptr || giverValue->type != JsonType::String || giverValue->stringValue.empty())
+			{
+				LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.giver must be a non-empty string", definition.questId);
+				m_definitions.clear();
+				return false;
+			}
+			if (turnInValue == nullptr || turnInValue->type != JsonType::String || turnInValue->stringValue.empty())
+			{
+				LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.turnIn must be a non-empty string", definition.questId);
+				m_definitions.clear();
+				return false;
+			}
+			definition.giverId  = giverValue->stringValue;
+			definition.turnInId = turnInValue->stringValue;
+```
+
+- [ ] **Step 7 : Migrer le JSON de contenu**
+
+Remplacer `game/data/quests/quest_definitions.json` pour ajouter `giver`/`turnIn` à chaque quête :
+
+```json
+{
+  "quests": [
+    {
+      "id": "hunt_collect_enter",
+      "giver": "npc:elder_marn",
+      "turnIn": "npc:elder_marn",
+      "prereqs": [],
+      "steps": [
+        { "type": "kill", "target": "mob:100", "requiredCount": 1 },
+        { "type": "collect", "target": "item:2001", "requiredCount": 1 },
+        { "type": "enter", "target": "zone:2", "requiredCount": 1 }
+      ],
+      "rewards": { "xp": 100, "gold": 25, "items": [ { "itemId": 3001, "quantity": 1 } ] }
+    },
+    {
+      "id": "report_to_guard",
+      "giver": "npc:guard_captain",
+      "turnIn": "npc:guard_captain",
+      "prereqs": ["hunt_collect_enter"],
+      "steps": [ { "type": "talk", "target": "npc:guard_captain", "requiredCount": 1 } ],
+      "rewards": { "xp": 25, "gold": 5, "items": [] }
+    }
+  ]
+}
+```
+
+- [ ] **Step 8 : Ajouter un test de rejet (giver manquant)**
+
+Dans `QuestRuntimeTests.cpp` `main()`, avant le bloc final, ajouter un cas :
+
+```cpp
+    {
+        const std::string bad = R"JSON({ "quests": [
+          { "id": "nogiver", "turnIn": "npc:x", "prereqs": [],
+            "steps": [ { "type": "talk", "target": "npc:x", "requiredCount": 1 } ],
+            "rewards": { "xp": 1, "gold": 0, "items": [] } } ] })JSON";
+        engine::core::Config badCfg;
+        const std::string p = WriteFixture(bad);
+        badCfg.SetString("server.quest_definitions_path", p);
+        QuestRuntime badRuntime(badCfg);
+        Check(!badRuntime.Init(), "Init rejette une quête sans giver");
+    }
+```
+
+- [ ] **Step 9 : Vérifier le succès en CI**
+
+Run : `ctest -R quest_runtime_tests --output-on-failure`
+Expected : **PASS**.
+
+- [ ] **Step 10 : Commit**
+
+```bash
+git add src/shardd/gameplay/quest/QuestRuntime.h src/shardd/gameplay/quest/QuestRuntime.cpp \
+        src/shardd/gameplay/quest/QuestRuntimeTests.cpp src/CMakeLists.txt \
+        game/data/quests/quest_definitions.json
+git commit -m "feat(quests): enum d'états étendu (Offered/ReadyToTurnIn) + giver/turnIn au JSON"
+```
+
+---
+
+## Task 2 : Transitions pilotées par le joueur (Sync→Offered, ApplyEvent→ReadyToTurnIn) + helpers purs
+
+**Files:**
+- Modify: `src/shardd/gameplay/quest/QuestRuntime.h` (déclarations `CanAccept`/`CanTurnIn`/`TakeRewardOnTurnIn`)
+- Modify: `src/shardd/gameplay/quest/QuestRuntime.cpp` (`SyncQuestStates` ~L610-613 ; `ApplyEvent` complétion ~L733-746 ; définitions des helpers)
+- Modify: `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`
+
+**Interfaces:**
+- Consumes: `QuestStatus`, `QuestDefinition`, `QuestState` (Task 1).
+- Produces (méthodes membres `const` de `QuestRuntime`) :
+  - `bool CanAccept(const QuestState& state, const QuestDefinition& def, std::string_view giverTargetId) const;`
+  - `bool CanTurnIn(const QuestState& state, const QuestDefinition& def, std::string_view npcTargetId) const;`
+  - `const QuestReward* TakeRewardOnTurnIn(const QuestDefinition& def) const;` (pointeur vers `def.rewards`, jamais nul)
+
+- [ ] **Step 1 : Écrire le test des transitions (échec attendu)**
+
+Ajouter dans `QuestRuntimeTests.cpp` `main()` (fixture `q1`, kill mob:1 x2) :
+
+```cpp
+    {
+        std::vector<QuestState> states;
+        std::vector<QuestProgressDelta> deltas;
+        Check(runtime.SyncQuestStates(states, deltas), "sync OK");
+        // q1 sans prérequis → Offered (PAS Active).
+        Check(states.size() == 1 && states[0].status == QuestStatus::Offered,
+              "prérequis remplis → Offered");
+
+        const auto* def = runtime.FindQuestDefinition("q1");
+        Check(def != nullptr, "def q1");
+        Check(runtime.CanAccept(states[0], *def, "npc:marn"), "accept au bon giver");
+        Check(!runtime.CanAccept(states[0], *def, "npc:autre"), "refus mauvais giver");
+
+        // Simuler l'accept : Offered → Active.
+        states[0].status = QuestStatus::Active;
+
+        // Progresser : 1 kill (pas assez) reste Active.
+        deltas.clear();
+        runtime.ApplyEvent(states, QuestStepType::Kill, "mob:1", 1, deltas);
+        Check(states[0].status == QuestStatus::Active, "1/2 kill → reste Active");
+
+        // 2e kill → ReadyToTurnIn, SANS reward dans le delta.
+        deltas.clear();
+        runtime.ApplyEvent(states, QuestStepType::Kill, "mob:1", 1, deltas);
+        Check(states[0].status == QuestStatus::ReadyToTurnIn, "2/2 kill → ReadyToTurnIn");
+        bool anyReward = false;
+        for (const auto& d : deltas)
+            if (d.rewardExperience != 0 || d.rewardGold != 0 || !d.rewardItems.empty()) anyReward = true;
+        Check(!anyReward, "aucune récompense au passage ReadyToTurnIn");
+
+        Check(runtime.CanTurnIn(states[0], *def, "npc:marn"), "turn-in au bon PNJ");
+        Check(!runtime.CanTurnIn(states[0], *def, "npc:autre"), "refus turn-in mauvais PNJ");
+
+        const auto* reward = runtime.TakeRewardOnTurnIn(*def);
+        Check(reward != nullptr && reward->experience == 10, "reward exposé au turn-in");
+    }
+```
+
+- [ ] **Step 2 : Vérifier l'échec en CI**
+
+Run : `ctest -R quest_runtime_tests --output-on-failure`
+Expected : **FAIL** (méthodes inexistantes + `SyncQuestStates` produit encore `Active`).
+
+- [ ] **Step 3 : `SyncQuestStates` → `Offered`**
+
+Dans `QuestRuntime.cpp` (~L610-613), remplacer :
+
+```cpp
+			if (prerequisitesComplete)
+			{
+				desiredStatus = QuestStatus::Offered;
+			}
+```
+
+Et protéger les états déjà avancés : au-dessus, la garde `if (state.status == QuestStatus::Completed) continue;` (~L593) doit aussi ignorer `Active` et `ReadyToTurnIn` pour ne pas rétrograder une quête acceptée :
+
+```cpp
+			if (state.status == QuestStatus::Completed
+				|| state.status == QuestStatus::Active
+				|| state.status == QuestStatus::ReadyToTurnIn)
+			{
+				continue;
+			}
+```
+
+- [ ] **Step 4 : `ApplyEvent` → `ReadyToTurnIn` sans reward**
+
+Dans `QuestRuntime.cpp` (~L733-746), remplacer le bloc de complétion :
+
+```cpp
+				if (AreAllStepsComplete(definition, state))
+				{
+					state.status = QuestStatus::ReadyToTurnIn;
+					delta.status = QuestStatus::ReadyToTurnIn;
+					LOG_INFO(Net,
+						"[QuestRuntime] Quest ready to turn in (quest_id={})",
+						definition.questId);
+				}
+```
+
+(Les champs `delta.rewardExperience/Gold/Items` ne sont plus renseignés ici.)
+
+- [ ] **Step 5 : Ajouter les helpers purs**
+
+Déclarer dans `QuestRuntime.h` (section publique) :
+
+```cpp
+		/// Vrai si \p state peut être accepté au PNJ \p giverTargetId : quête Offered
+		/// et \p giverTargetId == def.giverId. Pur, sans effet de bord.
+		bool CanAccept(const QuestState& state, const QuestDefinition& def, std::string_view giverTargetId) const;
+
+		/// Vrai si \p state peut être rendu au PNJ \p npcTargetId : quête ReadyToTurnIn
+		/// et \p npcTargetId == def.turnInId. Pur, sans effet de bord.
+		bool CanTurnIn(const QuestState& state, const QuestDefinition& def, std::string_view npcTargetId) const;
+
+		/// Retourne le bundle de récompense à verser au turn-in (jamais nul).
+		const QuestReward* TakeRewardOnTurnIn(const QuestDefinition& def) const;
+```
+
+Définir dans `QuestRuntime.cpp` (près de `FindQuestDefinition`) :
+
+```cpp
+	bool QuestRuntime::CanAccept(const QuestState& state, const QuestDefinition& def, std::string_view giverTargetId) const
+	{
+		return state.questId == def.questId
+			&& state.status == QuestStatus::Offered
+			&& giverTargetId == def.giverId;
+	}
+
+	bool QuestRuntime::CanTurnIn(const QuestState& state, const QuestDefinition& def, std::string_view npcTargetId) const
+	{
+		return state.questId == def.questId
+			&& state.status == QuestStatus::ReadyToTurnIn
+			&& npcTargetId == def.turnInId;
+	}
+
+	const engine::server::QuestReward* QuestRuntime::TakeRewardOnTurnIn(const QuestDefinition& def) const
+	{
+		return &def.rewards;
+	}
+```
+
+- [ ] **Step 6 : Vérifier le succès en CI**
+
+Run : `ctest -R quest_runtime_tests --output-on-failure`
+Expected : **PASS**.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/shardd/gameplay/quest/QuestRuntime.h src/shardd/gameplay/quest/QuestRuntime.cpp \
+        src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+git commit -m "feat(quests): Sync→Offered, ApplyEvent→ReadyToTurnIn (reward différé) + helpers accept/turn-in"
+```
+
+---
+
+## Task 3 : Messages wire (giver-list, accept, turn-in) + bump version
+
+**Files:**
+- Modify: `src/shared/network/ServerProtocol.h` (`kProtocolVersion` L62 ; enum `MessageKind` ; structs ; déclarations)
+- Modify: `src/shared/network/ServerProtocol.cpp` (encode/decode)
+- Modify: `src/shared/network/ServerProtocolTests.cpp`
+
+**Interfaces:**
+- Produces :
+  - `struct QuestGiverEntry { std::string questId; uint8_t role = 0; };` (role : 0=offer, 1=turnin)
+  - `struct QuestGiverListMessage { uint32_t clientId = 0; std::string npcTargetId; std::vector<QuestGiverEntry> entries; };`
+  - `struct QuestAcceptRequestMessage { uint32_t clientId = 0; std::string questId; std::string giverTargetId; };`
+  - `struct QuestTurnInRequestMessage { uint32_t clientId = 0; std::string questId; std::string npcTargetId; };`
+  - Fonctions : `Encode*` / `Decode*` pour les trois, mêmes conventions que `EncodeTalkRequest`/`DecodeTalkRequest`.
+  - `kProtocolVersion == 14`.
+
+- [ ] **Step 1 : Écrire les tests round-trip (échec attendu)**
+
+Dans `src/shared/network/ServerProtocolTests.cpp`, ajouter (suivre le style des tests round-trip existants du fichier) :
+
+```cpp
+    {
+        engine::server::QuestAcceptRequestMessage msg{};
+        msg.clientId = 7; msg.questId = "q1"; msg.giverTargetId = "npc:marn";
+        auto packet = engine::server::EncodeQuestAcceptRequest(msg);
+        engine::server::QuestAcceptRequestMessage out{};
+        Check(engine::server::DecodeQuestAcceptRequest(packet, out), "decode accept");
+        Check(out.clientId == 7 && out.questId == "q1" && out.giverTargetId == "npc:marn", "accept round-trip");
+    }
+    {
+        engine::server::QuestTurnInRequestMessage msg{};
+        msg.clientId = 9; msg.questId = "q2"; msg.npcTargetId = "npc:guard";
+        auto packet = engine::server::EncodeQuestTurnInRequest(msg);
+        engine::server::QuestTurnInRequestMessage out{};
+        Check(engine::server::DecodeQuestTurnInRequest(packet, out), "decode turnin");
+        Check(out.clientId == 9 && out.questId == "q2" && out.npcTargetId == "npc:guard", "turnin round-trip");
+    }
+    {
+        engine::server::QuestGiverListMessage msg{};
+        msg.clientId = 3; msg.npcTargetId = "npc:marn";
+        msg.entries.push_back({ "q1", 0 });
+        msg.entries.push_back({ "q2", 1 });
+        auto packet = engine::server::EncodeQuestGiverList(msg);
+        engine::server::QuestGiverListMessage out{};
+        Check(engine::server::DecodeQuestGiverList(packet, out), "decode giverlist");
+        Check(out.entries.size() == 2 && out.entries[0].questId == "q1" && out.entries[1].role == 1,
+              "giverlist round-trip");
+    }
+```
+
+- [ ] **Step 2 : Vérifier l'échec en CI**
+
+Run : `ctest -R server_protocol_tests --output-on-failure`
+Expected : **FAIL** (symboles inexistants).
+
+- [ ] **Step 3 : Bumper la version + ajouter les `MessageKind`**
+
+Dans `ServerProtocol.h`, L62 : `inline constexpr uint16_t kProtocolVersion = 14;`
+
+Dans l'enum `MessageKind`, **repérer la plus grande valeur actuellement définie** (les kinds M32/M33… vont au-delà de 24) et ajouter les trois nouveaux comme les **trois entiers séquentiels suivants** (remplacer `<N>` par la valeur trouvée +1/+2/+3) :
+
+```cpp
+		/// SP1 quêtes — liste des quêtes offertes/rendables d'un PNJ (serveur→client).
+		QuestGiverList = <N>,
+		/// SP1 quêtes — le joueur accepte une quête au PNJ giver (client→serveur).
+		QuestAcceptRequest = <N+1>,
+		/// SP1 quêtes — le joueur rend une quête au PNJ turn-in (client→serveur).
+		QuestTurnInRequest = <N+2>,
+```
+
+- [ ] **Step 4 : Ajouter les structs**
+
+Dans `ServerProtocol.h`, après `QuestDeltaMessage` (~L578) :
+
+```cpp
+	/// Une entrée de la liste de quêtes d'un PNJ (offer ou turn-in).
+	struct QuestGiverEntry
+	{
+		std::string questId;
+		uint8_t role = 0;   ///< 0 = offer (Offered), 1 = turnin (ReadyToTurnIn)
+	};
+
+	/// Réponse au Talk : quêtes qu'un PNJ propose / que le joueur peut y rendre.
+	struct QuestGiverListMessage
+	{
+		uint32_t clientId = 0;
+		std::string npcTargetId;
+		std::vector<QuestGiverEntry> entries;
+	};
+
+	/// Le joueur accepte une quête au PNJ giver.
+	struct QuestAcceptRequestMessage
+	{
+		uint32_t clientId = 0;
+		std::string questId;
+		std::string giverTargetId;
+	};
+
+	/// Le joueur rend une quête au PNJ turn-in.
+	struct QuestTurnInRequestMessage
+	{
+		uint32_t clientId = 0;
+		std::string questId;
+		std::string npcTargetId;
+	};
+```
+
+Et les déclarations près des autres (~L748-757) :
+
+```cpp
+	std::vector<std::byte> EncodeQuestGiverList(const QuestGiverListMessage& message);
+	bool DecodeQuestGiverList(std::span<const std::byte> packet, QuestGiverListMessage& outMessage);
+	std::vector<std::byte> EncodeQuestAcceptRequest(const QuestAcceptRequestMessage& message);
+	bool DecodeQuestAcceptRequest(std::span<const std::byte> packet, QuestAcceptRequestMessage& outMessage);
+	std::vector<std::byte> EncodeQuestTurnInRequest(const QuestTurnInRequestMessage& message);
+	bool DecodeQuestTurnInRequest(std::span<const std::byte> packet, QuestTurnInRequestMessage& outMessage);
+```
+
+- [ ] **Step 5 : Implémenter encode/decode**
+
+Dans `ServerProtocol.cpp`, après `DecodeQuestDelta` (~L1200), suivre le modèle `EncodeTalkRequest`/`DecodeTalkRequest` (`BeginPacket`, `WriteU32`, `WriteSizedString`, `DecodeHeader`, lecteurs symétriques). Les deux requêtes (accept/turn-in) ont la forme `u32 clientId + string + string` :
+
+```cpp
+	std::vector<std::byte> EncodeQuestAcceptRequest(const QuestAcceptRequestMessage& message)
+	{
+		const size_t payloadSize = 4u + 2u + message.questId.size() + 2u + message.giverTargetId.size();
+		std::vector<std::byte> packet = BeginPacket(MessageKind::QuestAcceptRequest, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.questId);
+		WriteSizedString(packet, message.giverTargetId);
+		return packet;
+	}
+
+	bool DecodeQuestAcceptRequest(std::span<const std::byte> packet, QuestAcceptRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::QuestAcceptRequest, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		if (!ReadSizedString(payload, offset, outMessage.questId)) return false;
+		if (!ReadSizedString(payload, offset, outMessage.giverTargetId)) return false;
+		return true;
+	}
+```
+
+Répliquer `QuestTurnInRequest` à l'identique (champ `npcTargetId` au lieu de `giverTargetId`, `MessageKind::QuestTurnInRequest`). Pour `QuestGiverList`, encoder `u32 clientId`, `string npcTargetId`, `u16 count`, puis pour chaque entrée `string questId` + `u8 role` :
+
+```cpp
+	std::vector<std::byte> EncodeQuestGiverList(const QuestGiverListMessage& message)
+	{
+		size_t payloadSize = 4u + 2u + message.npcTargetId.size() + 2u;
+		for (const QuestGiverEntry& e : message.entries)
+			payloadSize += 2u + e.questId.size() + 1u;
+		std::vector<std::byte> packet = BeginPacket(MessageKind::QuestGiverList, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.npcTargetId);
+		WriteU16(packet, static_cast<uint16_t>(message.entries.size()));
+		for (const QuestGiverEntry& e : message.entries)
+		{
+			WriteSizedString(packet, e.questId);
+			packet.push_back(static_cast<std::byte>(e.role));
+		}
+		return packet;
+	}
+
+	bool DecodeQuestGiverList(std::span<const std::byte> packet, QuestGiverListMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::QuestGiverList, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		if (!ReadSizedString(payload, offset, outMessage.npcTargetId)) return false;
+		uint16_t count = ReadU16(payload, offset);
+		outMessage.entries.clear();
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			QuestGiverEntry e{};
+			if (!ReadSizedString(payload, offset, e.questId)) return false;
+			if (offset >= payload.size()) return false;
+			e.role = static_cast<uint8_t>(payload[offset++]);
+			outMessage.entries.push_back(std::move(e));
+		}
+		return true;
+	}
+```
+
+> ⚠️ Vérifier les noms exacts des helpers (`ReadU32`, `ReadU16`, `WriteU16`, `ReadSizedString`) dans `ServerProtocol.cpp` et les employer tels quels (ne pas en inventer). S'ils diffèrent, aligner sur ceux utilisés par `DecodeQuestDelta`.
+
+- [ ] **Step 6 : Vérifier le succès en CI**
+
+Run : `ctest -R server_protocol_tests --output-on-failure`
+Expected : **PASS**.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/shared/network/ServerProtocol.h src/shared/network/ServerProtocol.cpp \
+        src/shared/network/ServerProtocolTests.cpp
+git commit -m "feat(quests): messages wire accept/turn-in/giver-list + bump kProtocolVersion 13->14"
+```
+
+---
+
+## Task 4 : Compat persistance (ancien enum 0/1/2 → nouveau) + save étendu
+
+**Files:**
+- Modify: `src/shardd/gameplay/character/CharacterPersistence.cpp` (load quête ~L126-138 ; save quête ~L268)
+- Create: `src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp`
+- Modify: `src/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `QuestStatus` (Task 1).
+- Produces: fonction libre `engine::server::QuestStatus MapPersistedQuestStatus(int64_t persistedValue, uint32_t formatVersion)` déclarée/définie en tête de `CharacterPersistence.cpp` (anonymous namespace) et **exposée pour test** via un petit header `CharacterPersistenceQuestCompat.h` (déclaration seule).
+
+- [ ] **Step 1 : Écrire le test de compat (échec attendu)**
+
+Créer `src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp` :
+
+```cpp
+// Test de la table de compat des statuts de quête persistés (SP1).
+#include "src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h"
+
+#include <iostream>
+
+using engine::server::QuestStatus;
+using engine::server::MapPersistedQuestStatus;
+
+int main()
+{
+    int failures = 0;
+    auto expect = [&](QuestStatus got, QuestStatus want, const char* label) {
+        if (got != want) { std::cerr << "[FAIL] " << label << "\n"; ++failures; }
+    };
+
+    // Ancien format (version 0) : 0=Locked, 1=Active, 2=Completed.
+    expect(MapPersistedQuestStatus(0, 0), QuestStatus::Locked,    "old 0 -> Locked");
+    expect(MapPersistedQuestStatus(1, 0), QuestStatus::Active,    "old 1 -> Active");
+    expect(MapPersistedQuestStatus(2, 0), QuestStatus::Completed, "old 2 -> Completed");
+
+    // Nouveau format (version 1) : valeurs 0..4 = enum direct.
+    expect(MapPersistedQuestStatus(1, 1), QuestStatus::Offered,       "new 1 -> Offered");
+    expect(MapPersistedQuestStatus(3, 1), QuestStatus::ReadyToTurnIn, "new 3 -> ReadyToTurnIn");
+    expect(MapPersistedQuestStatus(4, 1), QuestStatus::Completed,     "new 4 -> Completed");
+
+    // Valeur hors plage → Locked (dégradation sûre).
+    expect(MapPersistedQuestStatus(99, 1), QuestStatus::Locked, "out of range -> Locked");
+
+    if (failures) { std::cerr << failures << " échec(s)\n"; return 1; }
+    std::cout << "OK\n";
+    return 0;
+}
+```
+
+- [ ] **Step 2 : Enregistrer le test**
+
+Dans `src/CMakeLists.txt`, après `quest_runtime_tests` :
+
+```cmake
+  # SP1 : compat des statuts de quête persistés (ancien enum 0/1/2 -> nouveau).
+  lcdlln_add_simple_test(character_persistence_quest_compat_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistence.cpp)
+```
+
+- [ ] **Step 3 : Vérifier l'échec en CI**
+
+Run : `ctest -R character_persistence_quest_compat_tests --output-on-failure`
+Expected : **FAIL** (header/fonction inexistants).
+
+- [ ] **Step 4 : Créer le header de compat**
+
+Créer `src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h` :
+
+```cpp
+#pragma once
+// SP1 — Table de compat des statuts de quête persistés. L'ancien format
+// (formatVersion 0) sérialisait 0=Locked/1=Active/2=Completed ; le nouveau
+// (formatVersion >= 1) sérialise directement l'enum QuestStatus (0..4).
+
+#include "src/shardd/gameplay/quest/QuestRuntime.h"  // engine::server::QuestStatus
+
+#include <cstdint>
+
+namespace engine::server
+{
+	/// Convertit une valeur de statut persistée en QuestStatus.
+	/// \param persistedValue valeur brute lue du fichier de personnage.
+	/// \param formatVersion 0 = ancien schéma (0/1/2), >=1 = enum direct.
+	/// \return QuestStatus mappé ; Locked pour toute valeur hors plage.
+	QuestStatus MapPersistedQuestStatus(int64_t persistedValue, uint32_t formatVersion);
+}
+```
+
+- [ ] **Step 5 : Implémenter la fonction + brancher le load/save**
+
+En haut de `CharacterPersistence.cpp` (après les includes), ajouter :
+
+```cpp
+#include "src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h"
+
+namespace engine::server
+{
+	QuestStatus MapPersistedQuestStatus(int64_t persistedValue, uint32_t formatVersion)
+	{
+		if (formatVersion == 0u)
+		{
+			switch (persistedValue)
+			{
+			case 0: return QuestStatus::Locked;
+			case 1: return QuestStatus::Active;
+			case 2: return QuestStatus::Completed;
+			default: return QuestStatus::Locked;
+			}
+		}
+		if (persistedValue >= 0 && persistedValue <= 4)
+			return static_cast<QuestStatus>(static_cast<uint8_t>(persistedValue));
+		return QuestStatus::Locked;
+	}
+}
+```
+
+Dans le **load** (~L126-138), lire un champ de version de format (clé `quests.format_version`, défaut `0` pour les persos existants) et remplacer le bloc `if/else if/else` de conversion par :
+
+```cpp
+			const uint32_t questFormatVersion =
+				static_cast<uint32_t>(persisted.GetInt("quests.format_version", 0));
+			const int64_t persistedStatus =
+				persisted.GetInt("quests." + std::to_string(questIndex) + ".status", 0);
+			questState.status = MapPersistedQuestStatus(persistedStatus, questFormatVersion);
+```
+
+Dans le **save** (~L264, juste avant `quests.count`), écrire la version de format courante :
+
+```cpp
+		output << "quests.format_version=1\n";
+```
+
+(Le reste du save — `.status=` avec `static_cast<uint32_t>(status)` — reste correct : il écrit désormais 0..4.)
+
+- [ ] **Step 6 : Vérifier le succès en CI**
+
+Run : `ctest -R character_persistence_quest_compat_tests --output-on-failure`
+Expected : **PASS**.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h \
+        src/shardd/gameplay/character/CharacterPersistence.cpp \
+        src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp src/CMakeLists.txt
+git commit -m "feat(quests): compat persistance des statuts (ancien 0/1/2 -> nouvel enum) + format_version"
+```
+
+---
+
+## Task 5 : Handlers ServerApp (accept, turn-in) + reward au turn-in + giver-list au Talk
+
+**Files:**
+- Modify: `src/shared/server_bootstrap/ServerApp.h` (déclarations privées)
+- Modify: `src/shared/server_bootstrap/ServerApp.cpp` (dispatch ~L860 ; `HandleTalkRequest` ~L3367-3423 ; `ApplyQuestEvent` ~L5208-5270 ; nouveaux handlers)
+
+**Interfaces:**
+- Consumes: `QuestRuntime::CanAccept/CanTurnIn/TakeRewardOnTurnIn` (Task 2) ; `Decode*` / `EncodeQuestGiverList` (Task 3) ; le bloc de grant XP/or/items (`ApplyLevelUpsAfterXp` / `m_playerWallet.AddCurrency` / `AddItemToInventory`).
+- Produces (méthodes privées de `ServerApp`) :
+  - `void HandleAcceptQuest(const Endpoint& endpoint, const QuestAcceptRequestMessage& msg);`
+  - `void HandleTurnInQuest(const Endpoint& endpoint, const QuestTurnInRequestMessage& msg);`
+  - `void SendQuestGiverList(const ConnectedClient& receiver, std::string_view npcTargetId);`
+
+> **Note test** : `ServerApp` est une classe d'intégration non couverte par des tests unitaires directs dans ce repo (comme les autres handlers UDP). La logique testable a été isolée dans `QuestRuntime` (Task 2) et le wire (Task 3). Cette tâche est validée par la **compilation CI** + la revue ; pas de nouveau test unitaire. Un smoke test manuel figure dans la checklist finale.
+
+- [ ] **Step 1 : Retirer le versement de récompense de `ApplyQuestEvent`**
+
+Dans `ServerApp.cpp` (~L5221-5251), supprimer le bloc `if (delta.rewardExperience != 0 || …) { … }` (grant XP/or/items) et le `rewardedItems` associé. `ApplyQuestEvent` ne fait plus que propager les deltas au client :
+
+```cpp
+		for (const QuestProgressDelta& delta : deltas)
+		{
+			(void)SendQuestDelta(client, delta);
+		}
+		SaveConnectedClient(client, reason);
+```
+
+(Conserver le log final. Retirer l'appel `SendInventoryDelta(rewardedItems)` et `SendWalletUpdate` de ce chemin — ils reviennent dans le turn-in.)
+
+- [ ] **Step 2 : Déclarer les handlers dans `ServerApp.h`**
+
+Près des autres `Handle*` privés :
+
+```cpp
+		/// SP1 quêtes — le joueur accepte une quête au PNJ giver (Offered -> Active).
+		void HandleAcceptQuest(const engine::server::Endpoint& endpoint, const engine::server::QuestAcceptRequestMessage& msg);
+		/// SP1 quêtes — le joueur rend une quête (ReadyToTurnIn -> Completed) : récompenses versées ici.
+		void HandleTurnInQuest(const engine::server::Endpoint& endpoint, const engine::server::QuestTurnInRequestMessage& msg);
+		/// SP1 quêtes — envoie la liste des quêtes offertes/rendables d'un PNJ au client.
+		void SendQuestGiverList(const engine::server::ConnectedClient& receiver, std::string_view npcTargetId);
+```
+
+- [ ] **Step 3 : Brancher le dispatch**
+
+Dans la chaîne de décodage (~L860, après le bloc `TalkRequest`), ajouter :
+
+```cpp
+		QuestAcceptRequestMessage questAccept{};
+		if (DecodeQuestAcceptRequest(packetBytes, questAccept))
+		{
+			HandleAcceptQuest(datagram.endpoint, questAccept);
+			return;
+		}
+
+		QuestTurnInRequestMessage questTurnIn{};
+		if (DecodeQuestTurnInRequest(packetBytes, questTurnIn))
+		{
+			HandleTurnInQuest(datagram.endpoint, questTurnIn);
+			return;
+		}
+```
+
+- [ ] **Step 4 : Émettre la giver-list au `Talk`**
+
+Dans `HandleTalkRequest`, juste avant l'appel final `ApplyQuestEvent(*client, QuestStepType::Talk, …)` (~L3422), ajouter :
+
+```cpp
+		SendQuestGiverList(*client, targetId);
+```
+
+Puis définir `SendQuestGiverList` : parcourir `client.questStates`, pour chaque état, récupérer la définition (`m_questRuntime.FindQuestDefinition`) et ajouter une entrée si `status == Offered && def->giverId == npcTargetId` (role 0) ou `status == ReadyToTurnIn && def->turnInId == npcTargetId` (role 1). N'envoyer que si non vide :
+
+```cpp
+	void ServerApp::SendQuestGiverList(const ConnectedClient& receiver, std::string_view npcTargetId)
+	{
+		QuestGiverListMessage msg{};
+		msg.clientId = receiver.clientId;
+		msg.npcTargetId = std::string(npcTargetId);
+		for (const QuestState& state : receiver.questStates)
+		{
+			const QuestDefinition* def = m_questRuntime.FindQuestDefinition(state.questId);
+			if (def == nullptr) continue;
+			if (state.status == QuestStatus::Offered && def->giverId == npcTargetId)
+				msg.entries.push_back({ state.questId, 0 });
+			else if (state.status == QuestStatus::ReadyToTurnIn && def->turnInId == npcTargetId)
+				msg.entries.push_back({ state.questId, 1 });
+		}
+		if (msg.entries.empty()) return;
+		const auto packet = EncodeQuestGiverList(msg);
+		SendToClient(receiver, packet);   // suivre le helper d'envoi utilisé par SendQuestDelta
+	}
+```
+
+> ⚠️ Utiliser le **même helper d'envoi** que `SendQuestDelta` (repérer son nom exact : `SendToClient` / `SendPacket` / `m_transport.Send…`). Ne pas inventer.
+
+- [ ] **Step 5 : Implémenter `HandleAcceptQuest`**
+
+Résoudre le client depuis l'endpoint (suivre `HandleTalkRequest` pour la résolution `endpoint → ConnectedClient*` + garde). Puis :
+
+```cpp
+	void ServerApp::HandleAcceptQuest(const Endpoint& endpoint, const QuestAcceptRequestMessage& msg)
+	{
+		ConnectedClient* client = /* résolution comme HandleTalkRequest */;
+		if (client == nullptr) return;
+
+		const QuestDefinition* def = m_questRuntime.FindQuestDefinition(msg.questId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest: quête inconnue (client_id={}, quest_id={})", client->clientId, msg.questId);
+			return;
+		}
+		const size_t idx = FindClientQuestStateIndex(*client, msg.questId); // helper : cf. Step 6
+		if (idx == kInvalidQuestIndex) return;
+		QuestState& state = client->questStates[idx];
+
+		if (!m_questRuntime.CanAccept(state, *def, msg.giverTargetId))
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest refusé (client_id={}, quest_id={}, giver={})",
+				client->clientId, msg.questId, msg.giverTargetId);
+			return;
+		}
+		if (!IsClientNearNpc(*client, msg.giverTargetId)) return;  // contrôle de portée (cf. Step 6)
+
+		state.status = QuestStatus::Active;
+		state.stepProgressCounts.assign(def->steps.size(), 0u);
+
+		QuestProgressDelta delta{};
+		delta.questId = state.questId;
+		delta.status = state.status;
+		delta.stepProgressCounts = state.stepProgressCounts;
+		(void)SendQuestDelta(*client, delta);
+		SaveConnectedClient(*client, "quest_accept");
+		LOG_INFO(Net, "[ServerApp] Quest accepted (client_id={}, quest_id={})", client->clientId, msg.questId);
+	}
+```
+
+- [ ] **Step 6 : Ajouter les helpers manquants**
+
+Si `FindClientQuestStateIndex`, `kInvalidQuestIndex` et `IsClientNearNpc` n'existent pas :
+- `FindClientQuestStateIndex(client, questId)` : boucle linéaire sur `client.questStates`, renvoie l'index ou une sentinelle.
+- **Portée** : réutiliser le contrôle déjà appliqué aux interactions PNJ. Si le `Talk` actuel n'impose pas de portée serveur (il route par `targetId` sans distance — cf. `HandleTalkRequest`), alors `IsClientNearNpc` renvoie `true` pour V1 (la portée est déjà garantie par le client qui n'émet le Talk qu'à proximité) et un `// TODO SP-ultérieur` documente le durcissement. **Documenter ce choix** dans le commentaire de la fonction (ne pas prétendre valider une portée non vérifiée).
+
+- [ ] **Step 7 : Implémenter `HandleTurnInQuest` (récompenses ici)**
+
+```cpp
+	void ServerApp::HandleTurnInQuest(const Endpoint& endpoint, const QuestTurnInRequestMessage& msg)
+	{
+		ConnectedClient* client = /* résolution comme HandleTalkRequest */;
+		if (client == nullptr) return;
+
+		const QuestDefinition* def = m_questRuntime.FindQuestDefinition(msg.questId);
+		if (def == nullptr) return;
+		const size_t idx = FindClientQuestStateIndex(*client, msg.questId);
+		if (idx == kInvalidQuestIndex) return;
+		QuestState& state = client->questStates[idx];
+
+		if (!m_questRuntime.CanTurnIn(state, *def, msg.npcTargetId))
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest refusé (client_id={}, quest_id={}, npc={})",
+				client->clientId, msg.questId, msg.npcTargetId);
+			return;
+		}
+		if (!IsClientNearNpc(*client, msg.npcTargetId)) return;
+
+		// Verser les récompenses (bloc déplacé depuis l'ancien ApplyQuestEvent).
+		const QuestReward* reward = m_questRuntime.TakeRewardOnTurnIn(*def);
+		std::vector<ItemStack> rewardedItems;
+		if (reward != nullptr)
+		{
+			ApplyLevelUpsAfterXp(*client, reward->experience);
+			if (reward->gold != 0u)
+			{
+				std::string walletErr;
+				if (!m_playerWallet.AddCurrency(*client, kCurrencyGold, reward->gold, walletErr))
+					LOG_WARN(Net, "[ServerApp] Quest gold grant blocked (client_id={}, err={})", client->clientId, walletErr);
+			}
+			for (const ItemStack& item : reward->items)
+			{
+				AddItemToInventory(*client, item);
+				rewardedItems.push_back(item);
+			}
+		}
+
+		state.status = QuestStatus::Completed;
+
+		QuestProgressDelta delta{};
+		delta.questId = state.questId;
+		delta.status = state.status;
+		delta.stepProgressCounts = state.stepProgressCounts;
+		if (reward != nullptr)
+		{
+			delta.rewardExperience = reward->experience;
+			delta.rewardGold = reward->gold;
+			delta.rewardItems = reward->items;
+		}
+		(void)SendQuestDelta(*client, delta);
+		if (!rewardedItems.empty()) (void)SendInventoryDelta(*client, rewardedItems);
+		(void)SendWalletUpdate(*client);
+		SaveConnectedClient(*client, "quest_turnin");
+		LOG_INFO(Net, "[ServerApp] Quest turned in (client_id={}, quest_id={}, xp={}, gold={})",
+			client->clientId, msg.questId, reward ? reward->experience : 0u, reward ? reward->gold : 0u);
+	}
+```
+
+- [ ] **Step 8 : Vérifier la compilation en CI**
+
+Run : `ctest --output-on-failure` (suite complète — pas de test unitaire ServerApp, mais la compilation CI doit passer et les tests Task 1-4 rester verts).
+Expected : **PASS** (compilation + tests quêtes/wire/persistance).
+
+- [ ] **Step 9 : Commit**
+
+```bash
+git add src/shared/server_bootstrap/ServerApp.h src/shared/server_bootstrap/ServerApp.cpp
+git commit -m "feat(quests): handlers accept/turn-in (reward au turn-in) + giver-list au Talk"
+```
+
+---
+
+## Task 6 : Documentation CODEBASE_MAP + rapport de déploiement
+
+**Files:**
+- Modify: `docs/CODEBASE_MAP.md` (ou l'équivalent existant) — section quêtes.
+
+- [ ] **Step 1 : Documenter le cycle de vie**
+
+Ajouter une courte section « Quêtes — cycle de vie piloté par le joueur (SP1) » décrivant la machine d'états (`Offered/Active/ReadyToTurnIn/Completed`), le rôle du `Talk` (event + giver-list), les 3 messages wire, et le fait que **les récompenses sont versées au turn-in**. Renvoyer aux specs `docs/superpowers/specs/2026-07-02-quest-*`.
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/CODEBASE_MAP.md
+git commit -m "docs(quests): cycle de vie SP1 dans CODEBASE_MAP"
+```
+
+---
+
+## Checklist finale (DoD SP1)
+
+- [ ] Enum `QuestStatus` étendu + réordonné ; `GetQuestStatusName` couvre 5 valeurs.
+- [ ] `giver`/`turnIn` parsés ; définition sans ces champs **rejetée** au load ; JSON exemple migré.
+- [ ] `SyncQuestStates` → `Offered` ; ne rétrograde pas `Active`/`ReadyToTurnIn`/`Completed`.
+- [ ] `ApplyEvent` → `ReadyToTurnIn` **sans** reward.
+- [ ] 3 messages wire (giver-list / accept / turn-in) + round-trip verts ; `kProtocolVersion == 14`.
+- [ ] `Talk` renvoie la giver-list en plus de l'event d'étape.
+- [ ] Récompenses versées **au turn-in uniquement** (retirées de `ApplyQuestEvent`).
+- [ ] Compat persistance : `MapPersistedQuestStatus` testée (ancien 0/1/2 + nouveau 0..4 + hors plage) ; `quests.format_version=1` écrit.
+- [ ] Tous les tests CI verts (`quest_runtime_tests`, `character_persistence_quest_compat_tests`, `server_protocol_tests`).
+- [ ] Fonctions nouvelles/modifiées documentées en français.
+- [ ] **Smoke test manuel** (après déploiement shard) : accepter une quête au PNJ → progresser (kill) → état `ReadyToTurnIn` sans récompense → rendre au PNJ → récompenses reçues + `Completed` ; survit à un restart shard (persistance).
+- [ ] Rapport final incluant : **⚠️ REDÉPLOIEMENT SHARD requis** (wire-breaking, `kProtocolVersion` 13→14), lock-step avec le client SP2.
+
+---
+
+## Self-review (effectuée)
+
+- **Couverture spec** : §2 machine d'états → Tasks 1-2, 5 ; §3 JSON → Task 1 ; §4 wire+flux → Tasks 3, 5 ; §5 refonte QuestRuntime → Task 2 ; §6 persistance → Task 4 ; §7 tests → Tasks 1-4 ; §8 DoD → checklist finale.
+- **Points d'attention laissés explicites** (à vérifier dans le code voisin, pas inventés) : valeurs numériques exactes des nouveaux `MessageKind` (Task 3 Step 3) ; noms exacts des helpers wire `ReadU16/WriteU16/ReadSizedString` ; nom exact du helper d'envoi paquet (`SendToClient` vs autre) ; résolution `endpoint → ConnectedClient*` (calquée sur `HandleTalkRequest`) ; existence de `IsClientNearNpc` (sinon V1 = `true` documenté).
+- **Cohérence de types** : `questId` = `std::string` partout ; `QuestStatus` 5 valeurs ; helpers `CanAccept/CanTurnIn/TakeRewardOnTurnIn` signatures identiques entre Task 2 (déclaration) et Task 5 (consommation).

--- a/docs/superpowers/specs/2026-07-02-quest-sp1-player-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-02-quest-sp1-player-lifecycle-design.md
@@ -1,0 +1,210 @@
+# SP1 — Shard : cycle de vie des quêtes piloté par le joueur
+
+**Date** : 2026-07-02
+**Statut** : validé (brainstorming), prêt pour plan d'implémentation
+**Doc parent** : `2026-07-02-quest-system-overview-design.md`
+**Portée** : premier sous-projet. Transforme le système B (shard) « tout
+automatique » en un cycle « bornes pilotées par le joueur » (accept + turn-in).
+
+> ⚠️ **Déploiement** : wire-breaking (nouveaux opcodes + bump `kProtocolVersion`)
+> → **REDÉPLOIEMENT SHARD requis**. Aucun changement master. Lock-step avec SP2
+> côté client (le client neuf ne doit pas parler à un shard ancien).
+
+---
+
+## 1. Objectif
+
+Aujourd'hui (`src/shardd/gameplay/quest/QuestRuntime.cpp`) :
+- `SyncQuestStates` : pré-requis remplis → `Active` (auto). (`:610-618`)
+- `ApplyEvent` : étapes remplies → `Completed` + récompenses versées auto.
+  (`:733-746`, versement dans `ServerApp.cpp:5226-5240`)
+
+Cible : introduire deux états intermédiaires (`Offered`, `ReadyToTurnIn`) et deux
+gestes joueur (Accept au giver, TurnIn au turn-in NPC), avec versement des
+récompenses **au turn-in uniquement**.
+
+---
+
+## 2. Machine d'états
+
+Enum `QuestStatus` (actuellement `Locked=0 / Active=1 / Completed=2`) étendu et
+**réordonné** :
+
+```cpp
+enum class QuestStatus : uint8_t
+{
+    Locked        = 0,   // pré-requis non remplis (interne, non affiché)
+    Offered       = 1,   // proposée au PNJ giver (non encore acceptée)
+    Active        = 2,   // acceptée, en cours
+    ReadyToTurnIn = 3,   // étapes remplies, à rendre (pas encore récompensée)
+    Completed     = 4,   // rendue + récompensée (terminal)
+};
+```
+
+Transitions :
+
+| De | Vers | Déclencheur | Où |
+|----|------|-------------|-----|
+| Locked | Offered | pré-requis tous `Completed` | `SyncQuestStates` |
+| Offered | Active | `AcceptQuest` (valide) | nouveau handler |
+| Active | ReadyToTurnIn | toutes les étapes remplies | `ApplyEvent` |
+| Active | Active | progression partielle | `ApplyEvent` |
+| ReadyToTurnIn | Completed | `TurnInQuest` (valide) → **récompenses** | nouveau handler |
+
+> **Compat persistance** : l'ancien format sérialisait `0/1/2` =
+> `Locked/Active/Completed`. Au **load**, mapper les anciennes valeurs :
+> `0→Locked`, `1→Active`, `2→Completed` (les persos existants n'ont ni `Offered`
+> ni `ReadyToTurnIn`). Comme l'ancien `Completed` valait `2` et le nouveau vaut
+> `4`, la relecture DOIT passer par une **table de compat** au chargement
+> (`CharacterPersistence`), pas par un cast brut. Voir §6.
+
+---
+
+## 3. Schéma de données / JSON
+
+`QuestDefinition` (struct C++) + `game/data/quests/quest_definitions.json` gagnent
+deux champs :
+
+```jsonc
+{
+  "id": "hunt_collect_enter",
+  "giver":  "npc:elder_marn",     // NOUVEAU — PNJ qui propose (targetId Talk)
+  "turnIn": "npc:elder_marn",     // NOUVEAU — PNJ où rendre (souvent = giver)
+  "prereqs": [],
+  "steps": [ { "type": "kill", "target": "mob:100", "requiredCount": 1 } ],
+  "rewards": { "xp": 100, "gold": 25, "items": [ { "itemId": 3001, "quantity": 1 } ] }
+}
+```
+
+- `giver` / `turnIn` : chaînes dans **le même espace de nommage que le `targetId`
+  du `Talk`** (ex. `npc:<slug>`). Obligatoires (acquisition explicite).
+- Rétrocompat de chargement : une quête sans `giver`/`turnIn` est **rejetée au load**
+  avec un log d'erreur clair (le contenu doit être migré). Le JSON exemple existant
+  (`hunt_collect_enter`, `report_to_guard`) sera mis à jour avec des giver/turnIn.
+- Champs `steps`/`prereqs`/`rewards` : inchangés.
+
+---
+
+## 4. Réseau (wire) & flux gameplay
+
+### 4.1 Nouveaux opcodes (shard ↔ client)
+
+| Opcode | Sens | Payload | Rôle |
+|--------|------|---------|------|
+| `QuestGiverList` | shard→client | `{ npcTargetId, entries[]: {questId, role: offer\|turnin} }` | Réponse au Talk : quêtes offertes/rendables de ce PNJ |
+| `AcceptQuest` | client→shard | `{ questId, giverEntityId }` | Le joueur accepte |
+| `TurnInQuest` | client→shard | `{ questId, npcEntityId }` | Le joueur rend |
+
+- Le **delta existant** (`QuestDelta` / bootstrap) est étendu pour transporter le
+  nouvel enum `status` (5 valeurs). Le format de `stepProgressCounts` ne change pas.
+- Bump `kProtocolVersion` (gameplay UDP).
+
+### 4.2 Flux au `Talk` (`ServerApp::HandleTalkRequest`, `:3421`)
+
+Comportement conservé **et enrichi** :
+1. Continuer à tirer l'event d'étape `Talk` (`ApplyQuestEvent(Talk, targetId, 1)`) —
+   une étape « parler à X » reste possible.
+2. **En plus** : calculer pour ce joueur les quêtes dont `giver == targetId` et
+   `status == Offered`, et celles dont `turnIn == targetId` et
+   `status == ReadyToTurnIn`. Si non vide → envoyer `QuestGiverList`.
+
+### 4.3 Handler `AcceptQuest`
+
+Validations (anti-exploit, toutes avant mutation) :
+1. la quête existe (définition chargée) ;
+2. `status == Offered` pour ce joueur ;
+3. `giverEntityId` résout un PNJ dont `giver == ` l'id de cette quête ;
+4. joueur **à portée** du PNJ (réutiliser le contrôle de portée du Talk / interaction).
+
+Si OK → `Offered → Active`, réinitialiser `stepProgressCounts` à 0, émettre un delta,
+`SaveConnectedClient`.
+
+### 4.4 Handler `TurnInQuest`
+
+Validations symétriques :
+1. la quête existe ; 2. `status == ReadyToTurnIn` ; 3. `npcEntityId` = `turnIn` de la
+quête ; 4. joueur à portée.
+
+Si OK → **verser les récompenses** (déplacer ici le bloc XP/or/items de
+`ServerApp.cpp:5226-5240`) → `ReadyToTurnIn → Completed`, émettre delta,
+`SaveConnectedClient`.
+
+> Le versement de récompense est **retiré** de `ApplyEvent` (il n'y crée plus le
+> `Completed` ni les `reward*` du delta). `ApplyEvent` s'arrête à `ReadyToTurnIn`.
+
+---
+
+## 5. Refonte de `QuestRuntime`
+
+- `SyncQuestStates` : `desiredStatus` passe de `Active` à **`Offered`** quand les
+  pré-requis sont remplis. Une quête déjà `Active`/`ReadyToTurnIn`/`Completed` n'est
+  pas rétrogradée.
+- `ApplyEvent` : ne progresse que les quêtes `Active` (déjà le cas, `:691`). À
+  `AreAllStepsComplete` → `Active → ReadyToTurnIn` **sans** remplir `reward*` dans le
+  delta.
+- Nouvelles méthodes pures/testables :
+  - `bool CanAccept(state, def, giverTargetId) const`
+  - `bool CanTurnIn(state, def, npcTargetId) const`
+  - `QuestReward TakeRewardOnTurnIn(def) const` (retourne le bundle à verser).
+- Chargement : rejet des définitions sans `giver`/`turnIn` ; parse des 2 champs.
+
+Toute fonction ajoutée/modifiée est documentée (`///`, FR) — convention repo.
+
+---
+
+## 6. Persistance
+
+- `CharacterPersistence` : format clé-valeur inchangé (`quests.N.id`,
+  `quests.N.status`, `quests.N.step_count`, `quests.N.step.M.progress`).
+- **Pas de migration DB** (blob clé-valeur), mais **map de compat au load** :
+  - Nouveau save : écrit l'enum étendu (0..4).
+  - Ancien load : `0→Locked, 1→Active, 2→Completed` (mapping explicite, pas de cast).
+  - Un `Offered` persisté qui n'aurait plus de définition, ou dont le giver a changé,
+    est re-synchronisé par `SyncQuestStates` au login.
+
+---
+
+## 7. Tests
+
+- **Transitions** : `Locked→Offered` (sync), `Offered→Active` (accept OK),
+  `Active→ReadyToTurnIn` (étapes finies), `ReadyToTurnIn→Completed` (turn-in OK).
+- **Anti-exploit** :
+  - accept d'une quête non `Offered` → refus ;
+  - accept au mauvais giver → refus ;
+  - accept/turn-in hors portée → refus ;
+  - turn-in d'une quête `Active` (étapes non finies) → refus ;
+  - turn-in au mauvais PNJ → refus.
+- **Récompense** : versée **une seule fois**, **au turn-in**, jamais à
+  `ReadyToTurnIn`.
+- **Persistance** : round-trip avec les 5 états ; relecture de l'**ancien format**
+  (0/1/2) correcte.
+- **Sync** : quête dont le pré-requis n'est pas `Completed` reste `Locked`
+  (n'apparaît pas comme `Offered`).
+- **Chargement** : définition sans `giver`/`turnIn` rejetée avec log.
+
+---
+
+## 8. Definition of Done
+
+- [ ] Build Linux OK (shard).
+- [ ] Enum `QuestStatus` étendu + réordonné + map de compat au load.
+- [ ] `giver`/`turnIn` parsés ; définitions sans ces champs rejetées ; JSON exemple migré.
+- [ ] `SyncQuestStates` → `Offered` ; `ApplyEvent` → `ReadyToTurnIn` sans reward.
+- [ ] Opcodes `QuestGiverList` / `AcceptQuest` / `TurnInQuest` + bump `kProtocolVersion`.
+- [ ] `Talk` renvoie la giver-list (offer + turn-in) en plus de l'event d'étape.
+- [ ] Récompenses versées au turn-in uniquement.
+- [ ] Persistance : round-trip 5 états + compat ancien format.
+- [ ] Tous les tests §7 passent.
+- [ ] Fonctions nouvelles/modifiées documentées (FR).
+- [ ] Rapport final + mention **REDÉPLOIEMENT SHARD requis**.
+
+---
+
+## 9. Hors périmètre SP1 (rappel)
+
+- Rendu client ImGui (→ SP2).
+- Texte lisible `quest_texts.<lang>.json` (→ SP2 / SP4).
+- Éditeur d'authoring (→ SP4).
+- POI minimap (→ SP3).
+- Choix de récompense au turn-in (post-V1).
+- Retrait du système A master (→ Cleanup).

--- a/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
+++ b/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
@@ -68,6 +68,17 @@ client. **La « sauvegarde du suivi » que l'on croyait manquante existe déjà.
 | 4 | Périmètre UI V1 | Journal + Tracker HUD + Dialogue PNJ accept/turn-in + POI minimap. |
 | 5 | Authoring GM | **Panneau dans l'éditeur monde** (hors-ligne, écrit le JSON de contenu). |
 | 6 | Texte de quête | Fichier compagnon localisé `quest_texts.<lang>.json` (client-side), **pas** transporté par le wire. |
+| 7 | Interaction PNJ donneur | **Les deux** : dialogue existant (`accept_quest`/`complete_quest` → Accept/TurnIn de SP1) **et** panneau donneur dynamique piloté par `QuestGiverList`. |
+| 8 | Tranche verticale jouable | Un **PNJ dans la carte actuelle** donne une quête « tuer 10 sangliers » (archétype existant `mob:100`), validée puis rendue au PNJ pour la récompense. Capstone d'acceptation. |
+
+### Note d'impédance : `questId` numérique (dialogue) ↔ `string` (système B)
+
+Le dialogue (`game/data/dialogues/*.json`, `DialogueChoice.questId` **int**) et le
+système B (`questId` **string**) ne partagent pas le même espace d'identifiants.
+SP2 devra introduire une correspondance : soit un champ `questKey` (string) ajouté
+aux choix de dialogue, soit une table de mapping `int → string`. À trancher au
+design SP2 ; **le champ `questKey` string est la piste recommandée** (explicite,
+pas de table parallèle à maintenir).
 
 ---
 
@@ -113,14 +124,46 @@ Chaque SP a son propre cycle spec → plan → implémentation.
 | SP | Contenu | Déploiement | Dépend de |
 |----|---------|-------------|-----------|
 | **SP1** | Shard : cycle de vie joueur (Offered/ReadyToTurnIn ; accept/turn-in ; reward au turn-in ; schéma `giver`/`turnIn`) | ⚠️ redéploiement **shard** (wire-breaking) | — |
-| **SP2** | Client : renderer ImGui (journal, tracker HUD, dialogue PNJ) + lecture `quest_texts` | client, **lock-step SP1** | SP1 (wire) |
+| **SP2** | Client : renderer ImGui (journal, tracker HUD) + câblage **dialogue** (`accept_quest`/`complete_quest`) **et** panneau donneur (`QuestGiverList`) + `questKey` + lecture `quest_texts` | client, **lock-step SP1** | SP1 (wire) |
 | **SP4** | Éditeur monde : panneau d'authoring (mécanique + texte) | outillage client ; contenu → restart shard | SP1 (schéma + `quest_texts`) |
 | **SP3** | Client : POI minimap/carte | client (+ contenu localisation objectifs) | SP1, SP2 |
+| **SP5** | **Tranche verticale jouable** : PNJ dans la carte + quête « tuer 10 sangliers » (`mob:100` ×10) + texte + branchement dialogue giver/turnIn | contenu ; **restart shard** pour charger la quête | SP1, SP2 |
 | **Cleanup** | Retrait système A (master : tracker, handler, opcodes 59-67, migration 0048, cache A du presenter) | petit redéploiement **master** | — |
 
 **Ordre de merge / déploiement** :
 `SP1` (shard, déployé en premier) → `SP2` + `SP4` (parallèles, consomment le schéma
-figé par SP1 ; SP2 lock-step avec le déploiement shard SP1) → `SP3` → `Cleanup`.
+figé par SP1 ; SP2 lock-step avec le déploiement shard SP1) → `SP5` (tranche
+verticale, dès que SP1+SP2 sont en place) → `SP3` → `Cleanup`.
+
+### SP5 — Tranche verticale jouable (détail)
+
+Capstone d'acceptation, entièrement **contenu + branchement** (pas de nouveau wire) :
+
+- **Créature** : réutiliser l'archétype existant `mob:100` (« Sanglier des collines »,
+  `game/data/creatures/archetypes.json`) — déjà tuable, émet l'event `Kill` avec
+  `target = "mob:100"`. Vérifier qu'au moins ~10 sangliers **spawnent** dans une zone
+  accessible de la carte actuelle (sinon ajouter des points de spawn).
+- **PNJ donneur** : ajouter un PNJ interactif dans la carte via
+  `config.json world.interactables.<i>` (position + `dialogue_id`) + un fichier
+  `game/data/dialogues/<pnj>.json` avec un choix `accept_quest` (au début) et
+  `complete_quest` (au retour), tous deux liés à la quête via `questKey`.
+- **Définition de quête** (`game/data/quests/quest_definitions.json`) :
+  ```jsonc
+  { "id": "kill_10_boars", "giver": "npc:<pnj>", "turnIn": "npc:<pnj>",
+    "prereqs": [],
+    "steps": [ { "type": "kill", "target": "mob:100", "requiredCount": 10 } ],
+    "rewards": { "xp": 200, "gold": 50, "items": [] } }
+  ```
+- **Texte** : entrée `kill_10_boars` dans `quest_texts.<lang>.json` (titre, description,
+  libellé d'étape « Sangliers tués : X/10 »).
+- **Correspondance** : le `questKey` du dialogue = `"kill_10_boars"` (string système B).
+- **Critère d'acceptation** = le smoke test du DoD SP1, mais joué en vrai :
+  parler au PNJ → accepter → tuer 10 `mob:100` (tracker 0/10 → 10/10) → retourner au
+  PNJ → « Terminer » → +200 XP / +50 or → quête `Completed` ; survit à un restart shard.
+
+> **Identité/emplacement du PNJ** : à préciser au moment de SP5 (nom, position dans
+> la carte actuelle — vraisemblablement Feyhin Lokcthat). Choix laissé ouvert ici car
+> non bloquant pour SP1.
 
 > ⚠️ **Déploiement (global)** : le chantier introduit du **wire-breaking** en SP1
 > (nouveaux opcodes accept/turn-in/giver-list + bump `kProtocolVersion`). Un client
@@ -133,4 +176,4 @@ figé par SP1 ; SP2 lock-step avec le déploiement shard SP1) → `SP3` → `Cle
 ## 5. Specs détaillées par sous-projet
 
 - **SP1** : `2026-07-02-quest-sp1-player-lifecycle-design.md` (ci-joint).
-- SP2 / SP4 / SP3 / Cleanup : specs à écrire au fil du chantier, après SP1.
+- SP2 / SP4 / SP3 / SP5 / Cleanup : specs à écrire au fil du chantier, après SP1.

--- a/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
+++ b/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
@@ -70,6 +70,24 @@ client. **La « sauvegarde du suivi » que l'on croyait manquante existe déjà.
 | 6 | Texte de quête | Fichier compagnon localisé `quest_texts.<lang>.json` (client-side), **pas** transporté par le wire. |
 | 7 | Interaction PNJ donneur | **Les deux** : dialogue existant (`accept_quest`/`complete_quest` → Accept/TurnIn de SP1) **et** panneau donneur dynamique piloté par `QuestGiverList`. |
 | 8 | Tranche verticale jouable | Un **PNJ dans la carte actuelle** donne une quête « tuer 10 sangliers » (archétype existant `mob:100`), validée puis rendue au PNJ pour la récompense. Capstone d'acceptation. |
+| 9 | Marqueur au-dessus des PNJ donneurs | **Rune/glyphe du jeu** (asset dédié, **≠ « ! »**), **deux variantes** : `Offered` = doré plein (venir chercher) / `ReadyToTurnIn` = variante distincte (venir rendre). **Culling par distance** (config) pour ne pas polluer le HUD. Feature **SP2**. |
+
+### Marqueur PNJ donneur (SP2) — détail
+
+- **Rendu** : petit **billboard texturé world-space** ancré au-dessus du PNJ (pas un
+  glyphe de police — la police Windlass est ASCII-only, cf. atlas). Réutiliser le
+  précédent des marqueurs de réapparition (overlays ImGui foreground world-space,
+  `Engine.cpp`). Deux teintes/variantes selon l'état (doré plein `Offered` /
+  variante `ReadyToTurnIn`).
+- **Visibilité** : n'apparaît que si le joueur est à **≤ distance seuil** du PNJ
+  (clé config `client.quest.giver_marker_distance_m`, défaut à fixer en SP2) ET si
+  ce PNJ a, **pour ce joueur**, une quête `Offered` (role offer) ou `ReadyToTurnIn`
+  (role turnin).
+- **Donnée nécessaire côté client** : la table `npcTargetId → quêtes (giver/turnIn)`.
+  Elle vient d'un **fichier de contenu client** (le compagnon `quest_texts` ou une
+  petite table `quest_givers`), **sans nouveau wire** — le client croise cette table
+  avec les états de quête déjà reçus (`UIModel.quests`) pour décider quel marqueur
+  afficher. À figer au design SP2.
 
 ### Note d'impédance : `questId` numérique (dialogue) ↔ `string` (système B)
 

--- a/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
+++ b/docs/superpowers/specs/2026-07-02-quest-system-overview-design.md
@@ -1,0 +1,136 @@
+# Système de quêtes — Design d'ensemble & découpage
+
+**Date** : 2026-07-02
+**Statut** : validé (brainstorming), spec de découpage
+**Portée** : cycle de vie complet des quêtes (récupération → suivi → réalisation →
+terminé) côté client, persistance côté serveur, + authoring GM.
+
+---
+
+## 1. Contexte : l'existant réel (audit code du 2026-07-02)
+
+Contrairement à l'impression initiale (« il manque toute la gestion des quêtes »),
+il existe en réalité **deux systèmes de quêtes parallèles et déconnectés**.
+
+### Système A — master (status-machine)
+
+- `src/masterd/quests/QuestState.h` : `QuestStateTracker`, machine d'états par
+  **compte** (`None/Available/Accepted/Completed/Rewarded/Failed`), **statut seul**.
+- `src/masterd/quests/MysqlQuestStateStore.h/.cpp` : persistance du statut
+  (table `account_quest_state`, migration 0048). `Load()` **jamais rappelé au login**.
+- `src/masterd/handlers/quest/QuestHandler.cpp` : opcodes 59-67
+  (Accept/Complete/Reward/List + push), câblés.
+- Wire `src/shared/network/QuestPayloads.h` : `questId` (uint32) + `status` (uint8),
+  **aucun texte, aucune progression, aucune récompense**.
+- Client `src/client/quest/QuestUi.h/.cpp` : `QuestUiPresenter` (cache statut A).
+
+**Verdict** : pauvre (statut seul), redondant, à moitié mort. → **retiré** (cleanup).
+
+### Système B — shard (data-driven, riche) — le vrai système, qui MARCHE
+
+- `src/shardd/gameplay/quest/QuestRuntime.h/.cpp` : définitions chargées depuis
+  `game/data/quests/quest_definitions.json` (clé config `server.quest_definitions_path`).
+  Étapes typées (`Kill/Collect/Talk/Enter`), progression par étape
+  (`stepProgressCounts`), récompenses (xp/gold/items), sync de pré-requis.
+- **Alimenté par le vrai gameplay** : `ApplyQuestEvent` (wrapper de
+  `QuestRuntime::ApplyEvent`) appelé sur Kill (`ServerApp.cpp:3111`),
+  Collect/pickup (`:3361`), Talk (`:3422`), auto-loot (`:3676`), Enter zone (`:2929`).
+- **Complétion + récompenses automatiques** : à étapes remplies → `Completed`, puis
+  XP (`ApplyLevelUpsAfterXp`), or (`m_playerWallet.AddCurrency`), items
+  (`AddItemToInventory`) — `ServerApp.cpp:5226-5240`.
+- **Persistance du suivi DÉJÀ FAITE** : `CharacterPersistence` sérialise
+  `questId` + `status` + `stepProgressCounts` par personnage (`:264-274`).
+- **Bootstrap client** : `SendQuestStateBootstrap` au login + `SendQuestDelta` →
+  `UIModel.quests` (`UIQuestEntry` avec steps + rewards) → `ApplyQuestDelta` client.
+
+**Verdict** : cycle complet fonctionnel côté serveur, données qui atteignent le
+client. **La « sauvegarde du suivi » que l'on croyait manquante existe déjà.**
+
+### Le vrai manque
+
+1. **🔴 Rendu client ImGui absent.** La data riche arrive dans `UIModel.quests`,
+   `QuestUiPresenter` prépare même `QuestUiState`… mais **aucun renderer ne dessine**.
+   Le joueur est aveugle. (Aucun `*QuestRenderer*`.)
+2. **🟠 Deux systèmes concurrents** (A pauvre vs B riche) — à rationaliser.
+3. **🟡 Pas de « récupération » ni de « turn-in » pilotés par le joueur** — B fait
+   tout automatiquement (déblocage par pré-requis, récompense à étapes finies).
+4. **🟡 Pas d'authoring GM** — le JSON de contenu s'édite à la main, sans outil.
+
+---
+
+## 2. Décisions de design (validées)
+
+| # | Décision | Choix |
+|---|----------|-------|
+| 1 | Source de vérité | **Système B (shard, data-driven)**. Système A retiré. |
+| 2 | Récupération | **Accept explicite** chez un PNJ (nouvel état `Offered`). |
+| 3 | Fin de quête | **Turn-in explicite** chez un PNJ ; récompenses versées au turn-in ; **sans** choix de récompense (V1). |
+| 4 | Périmètre UI V1 | Journal + Tracker HUD + Dialogue PNJ accept/turn-in + POI minimap. |
+| 5 | Authoring GM | **Panneau dans l'éditeur monde** (hors-ligne, écrit le JSON de contenu). |
+| 6 | Texte de quête | Fichier compagnon localisé `quest_texts.<lang>.json` (client-side), **pas** transporté par le wire. |
+
+---
+
+## 3. Nouvelle machine d'états (système B étendu)
+
+```
+Locked                 (pré-requis non remplis — interne, non affiché)
+  │ prérequis Completed (SyncQuestStates)
+  ▼
+Offered                (proposée : visible SEULEMENT dans le dialogue du PNJ giver)
+  │ AcceptQuest (joueur clique « Accepter » au PNJ)
+  ▼
+Active                 (en cours : journal + tracker ; events progressent)
+  │ toutes les étapes remplies (ApplyEvent)
+  ▼
+ReadyToTurnIn          (à rendre : PAS de récompense encore ; marqueur au PNJ turn-in)
+  │ TurnInQuest (joueur clique « Terminer » au PNJ) → récompenses versées ICI
+  ▼
+Completed              (terminée, récompensée — persistée définitivement)
+```
+
+Changements clés vs l'existant :
+- `SyncQuestStates` : prérequis remplis → **`Offered`** (au lieu d'`Active`).
+- `ApplyEvent` : étapes remplies → **`ReadyToTurnIn`** (au lieu de `Completed`),
+  **sans** verser les récompenses.
+- Le **versement des récompenses migre** dans le handler `TurnInQuest`.
+
+### Règles UI validées
+
+- **Journal ≠ Offered** : le journal affiche `Active` + `ReadyToTurnIn` ; les quêtes
+  `Offered` n'apparaissent que dans le dialogue du PNJ.
+- **`Talk` garde son double rôle** : il tire l'event d'étape `Talk` **et** ouvre la
+  giver-list si le PNJ a des quêtes `Offered`/`ReadyToTurnIn` pour ce joueur.
+- **`giverId`/`turnInId` = mêmes chaînes que le `targetId` du `Talk`** (pas un
+  nouvel espace d'identifiants d'entité).
+
+---
+
+## 4. Découpage en sous-projets
+
+Chaque SP a son propre cycle spec → plan → implémentation.
+
+| SP | Contenu | Déploiement | Dépend de |
+|----|---------|-------------|-----------|
+| **SP1** | Shard : cycle de vie joueur (Offered/ReadyToTurnIn ; accept/turn-in ; reward au turn-in ; schéma `giver`/`turnIn`) | ⚠️ redéploiement **shard** (wire-breaking) | — |
+| **SP2** | Client : renderer ImGui (journal, tracker HUD, dialogue PNJ) + lecture `quest_texts` | client, **lock-step SP1** | SP1 (wire) |
+| **SP4** | Éditeur monde : panneau d'authoring (mécanique + texte) | outillage client ; contenu → restart shard | SP1 (schéma + `quest_texts`) |
+| **SP3** | Client : POI minimap/carte | client (+ contenu localisation objectifs) | SP1, SP2 |
+| **Cleanup** | Retrait système A (master : tracker, handler, opcodes 59-67, migration 0048, cache A du presenter) | petit redéploiement **master** | — |
+
+**Ordre de merge / déploiement** :
+`SP1` (shard, déployé en premier) → `SP2` + `SP4` (parallèles, consomment le schéma
+figé par SP1 ; SP2 lock-step avec le déploiement shard SP1) → `SP3` → `Cleanup`.
+
+> ⚠️ **Déploiement (global)** : le chantier introduit du **wire-breaking** en SP1
+> (nouveaux opcodes accept/turn-in/giver-list + bump `kProtocolVersion`). Un client
+> SP2 neuf parlerait dans le vide à un shard SP1 ancien → **SP1 doit être déployé
+> avant/avec SP2**. SP4 (éditeur) ne redéploie pas le jeu, mais toute quête créée
+> nécessite un **restart shard** pour être chargée.
+
+---
+
+## 5. Specs détaillées par sous-projet
+
+- **SP1** : `2026-07-02-quest-sp1-player-lifecycle-design.md` (ci-joint).
+- SP2 / SP4 / SP3 / Cleanup : specs à écrire au fil du chantier, après SP1.

--- a/game/data/quests/quest_definitions.json
+++ b/game/data/quests/quest_definitions.json
@@ -2,6 +2,8 @@
   "quests": [
     {
       "id": "hunt_collect_enter",
+      "giver": "npc:elder_marn",
+      "turnIn": "npc:elder_marn",
       "prereqs": [],
       "steps": [
         { "type": "kill", "target": "mob:100", "requiredCount": 1 },
@@ -18,6 +20,8 @@
     },
     {
       "id": "report_to_guard",
+      "giver": "npc:guard_captain",
+      "turnIn": "npc:guard_captain",
       "prereqs": ["hunt_collect_enter"],
       "steps": [
         { "type": "talk", "target": "npc:guard_captain", "requiredCount": 1 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -584,6 +584,10 @@ elseif(UNIX)
   # CMANGOS.23 (Phase 3.23a) : QuestStateTracker (header-only state machine).
   lcdlln_add_simple_test(quest_state_tests
     ${CMAKE_SOURCE_DIR}/src/masterd/quests/QuestStateTests.cpp)
+  # SP1 : QuestRuntime — cycle de vie piloté par le joueur (parse giver/turnIn, transitions).
+  lcdlln_add_simple_test(quest_runtime_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp)
   # CMANGOS.33 (Phase 5.33a) : LfgQueue header-only.
   lcdlln_add_simple_test(lfg_queue_tests
     ${CMAKE_SOURCE_DIR}/src/masterd/lfg/LfgQueueTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -588,6 +588,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(quest_runtime_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp)
+  # SP1 : compat des statuts de quête persistés (ancien enum 0/1/2 -> nouveau).
+  lcdlln_add_simple_test(character_persistence_quest_compat_tests
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/character/CharacterPersistence.cpp)
   # CMANGOS.33 (Phase 5.33a) : LfgQueue header-only.
   lcdlln_add_simple_test(lfg_queue_tests
     ${CMAKE_SOURCE_DIR}/src/masterd/lfg/LfgQueueTests.cpp)

--- a/src/shardd/gameplay/character/CharacterPersistence.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistence.cpp
@@ -1,5 +1,6 @@
 #include "src/shardd/gameplay/character/CharacterPersistence.h"
 
+#include "src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h"
 #include "src/shared/network/ServerProtocol.h"
 
 #include "src/shared/core/Log.h"
@@ -10,6 +11,29 @@
 
 namespace engine::server
 {
+	/// SP1 — Convertit une valeur de statut de quête persistée en QuestStatus.
+	/// L'ancien format (formatVersion 0) sérialisait 0=Locked/1=Active/2=Completed ;
+	/// le nouveau (formatVersion >= 1) sérialise directement l'enum QuestStatus (0..4).
+	/// \param persistedValue valeur brute lue du fichier de personnage.
+	/// \param formatVersion 0 = ancien schéma (0/1/2), >=1 = enum direct.
+	/// \return QuestStatus mappé ; Locked pour toute valeur hors plage.
+	QuestStatus MapPersistedQuestStatus(int64_t persistedValue, uint32_t formatVersion)
+	{
+		if (formatVersion == 0u)
+		{
+			switch (persistedValue)
+			{
+			case 0: return QuestStatus::Locked;
+			case 1: return QuestStatus::Active;
+			case 2: return QuestStatus::Completed;
+			default: return QuestStatus::Locked;
+			}
+		}
+		if (persistedValue >= 0 && persistedValue <= 4)
+			return static_cast<QuestStatus>(static_cast<uint8_t>(persistedValue));
+		return QuestStatus::Locked;
+	}
+
 	CharacterPersistenceStore::CharacterPersistenceStore(const engine::core::Config& config)
 		: m_config(config)
 		, m_schemaRelativePath(m_config.GetString(
@@ -123,19 +147,11 @@ namespace engine::server
 				continue;
 			}
 
+			// SP1 — quests.format_version absent = personnages existants (schéma legacy).
+			const uint32_t questFormatVersion =
+				static_cast<uint32_t>(persisted.GetInt("quests.format_version", 0));
 			const int64_t persistedStatus = persisted.GetInt("quests." + std::to_string(questIndex) + ".status", 0);
-			if (persistedStatus <= 0)
-			{
-				questState.status = QuestStatus::Locked;
-			}
-			else if (persistedStatus == 1)
-			{
-				questState.status = QuestStatus::Active;
-			}
-			else
-			{
-				questState.status = QuestStatus::Completed;
-			}
+			questState.status = MapPersistedQuestStatus(persistedStatus, questFormatVersion);
 
 			const uint32_t stepCount = static_cast<uint32_t>(persisted.GetInt("quests." + std::to_string(questIndex) + ".step_count", 0));
 			questState.stepProgressCounts.reserve(stepCount);
@@ -261,6 +277,8 @@ namespace engine::server
 			output << "inventory." << index << ".item_id=" << state.inventory[index].itemId << "\n";
 			output << "inventory." << index << ".quantity=" << state.inventory[index].quantity << "\n";
 		}
+		// SP1 — format_version=1 : quests.*.status écrit désormais l'enum QuestStatus direct (0..4).
+		output << "quests.format_version=1\n";
 		output << "quests.count=" << state.questStates.size() << "\n";
 		for (size_t questIndex = 0; questIndex < state.questStates.size(); ++questIndex)
 		{

--- a/src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h
+++ b/src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h
@@ -1,0 +1,17 @@
+#pragma once
+// SP1 — Table de compat des statuts de quête persistés. L'ancien format
+// (formatVersion 0) sérialisait 0=Locked/1=Active/2=Completed ; le nouveau
+// (formatVersion >= 1) sérialise directement l'enum QuestStatus (0..4).
+
+#include "src/shardd/gameplay/quest/QuestRuntime.h"  // engine::server::QuestStatus
+
+#include <cstdint>
+
+namespace engine::server
+{
+	/// Convertit une valeur de statut persistée en QuestStatus.
+	/// \param persistedValue valeur brute lue du fichier de personnage.
+	/// \param formatVersion 0 = ancien schéma (0/1/2), >=1 = enum direct.
+	/// \return QuestStatus mappé ; Locked pour toute valeur hors plage.
+	QuestStatus MapPersistedQuestStatus(int64_t persistedValue, uint32_t formatVersion);
+}

--- a/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
@@ -1,0 +1,32 @@
+// Test de la table de compat des statuts de quête persistés (SP1).
+#include "src/shardd/gameplay/character/CharacterPersistenceQuestCompat.h"
+
+#include <iostream>
+
+using engine::server::QuestStatus;
+using engine::server::MapPersistedQuestStatus;
+
+int main()
+{
+    int failures = 0;
+    auto expect = [&](QuestStatus got, QuestStatus want, const char* label) {
+        if (got != want) { std::cerr << "[FAIL] " << label << "\n"; ++failures; }
+    };
+
+    // Ancien format (version 0) : 0=Locked, 1=Active, 2=Completed.
+    expect(MapPersistedQuestStatus(0, 0), QuestStatus::Locked,    "old 0 -> Locked");
+    expect(MapPersistedQuestStatus(1, 0), QuestStatus::Active,    "old 1 -> Active");
+    expect(MapPersistedQuestStatus(2, 0), QuestStatus::Completed, "old 2 -> Completed");
+
+    // Nouveau format (version 1) : valeurs 0..4 = enum direct.
+    expect(MapPersistedQuestStatus(1, 1), QuestStatus::Offered,       "new 1 -> Offered");
+    expect(MapPersistedQuestStatus(3, 1), QuestStatus::ReadyToTurnIn, "new 3 -> ReadyToTurnIn");
+    expect(MapPersistedQuestStatus(4, 1), QuestStatus::Completed,     "new 4 -> Completed");
+
+    // Valeur hors plage → Locked (dégradation sûre).
+    expect(MapPersistedQuestStatus(99, 1), QuestStatus::Locked, "out of range -> Locked");
+
+    if (failures) { std::cerr << failures << " échec(s)\n"; return 1; }
+    std::cout << "OK\n";
+    return 0;
+}

--- a/src/shardd/gameplay/quest/QuestRuntime.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntime.cpp
@@ -487,15 +487,13 @@ namespace engine::server
 	{
 		switch (status)
 		{
-		case QuestStatus::Locked:
-			return "locked";
-		case QuestStatus::Active:
-			return "active";
-		case QuestStatus::Completed:
-			return "completed";
-		default:
-			return "locked";
+		case QuestStatus::Locked:        return "locked";
+		case QuestStatus::Offered:       return "offered";
+		case QuestStatus::Active:        return "active";
+		case QuestStatus::ReadyToTurnIn: return "ready_to_turn_in";
+		case QuestStatus::Completed:     return "completed";
 		}
+		return "unknown";
 	}
 
 	QuestRuntime::QuestRuntime(const engine::core::Config& config)
@@ -844,6 +842,23 @@ namespace engine::server
 
 			QuestDefinition definition{};
 			definition.questId = idValue->stringValue;
+
+			const JsonValue* giverValue  = FindObjectMember(questValue, "giver");
+			const JsonValue* turnInValue = FindObjectMember(questValue, "turnIn");
+			if (giverValue == nullptr || giverValue->type != JsonType::String || giverValue->stringValue.empty())
+			{
+				LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.giver must be a non-empty string", definition.questId);
+				m_definitions.clear();
+				return false;
+			}
+			if (turnInValue == nullptr || turnInValue->type != JsonType::String || turnInValue->stringValue.empty())
+			{
+				LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.turnIn must be a non-empty string", definition.questId);
+				m_definitions.clear();
+				return false;
+			}
+			definition.giverId  = giverValue->stringValue;
+			definition.turnInId = turnInValue->stringValue;
 
 			if (const JsonValue* prereqsValue = FindObjectMember(questValue, "prereqs");
 				prereqsValue != nullptr)

--- a/src/shardd/gameplay/quest/QuestRuntime.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntime.cpp
@@ -588,7 +588,11 @@ namespace engine::server
 			}
 
 			QuestState& state = states[stateIndex];
-			if (state.status == QuestStatus::Completed)
+			// Une quête déjà acceptée (Active) ou prête à rendre (ReadyToTurnIn) ne doit
+			// jamais être rétrogradée par la sync de prérequis ; Completed est terminal.
+			if (state.status == QuestStatus::Completed
+				|| state.status == QuestStatus::Active
+				|| state.status == QuestStatus::ReadyToTurnIn)
 			{
 				continue;
 			}
@@ -607,7 +611,9 @@ namespace engine::server
 
 			if (prerequisitesComplete)
 			{
-				desiredStatus = QuestStatus::Active;
+				// La quête est proposée au joueur (Offered) ; l'acceptation explicite
+				// au PNJ giver (CanAccept) la fait ensuite passer à Active.
+				desiredStatus = QuestStatus::Offered;
 			}
 
 			if (state.status != desiredStatus)
@@ -730,17 +736,14 @@ namespace engine::server
 			delta.stepProgressCounts = state.stepProgressCounts;
 			if (AreAllStepsComplete(definition, state))
 			{
-				state.status = QuestStatus::Completed;
-				delta.status = QuestStatus::Completed;
-				delta.rewardExperience = definition.rewards.experience;
-				delta.rewardGold = definition.rewards.gold;
-				delta.rewardItems = definition.rewards.items;
+				// La récompense n'est PAS versée ici : elle est différée au turn-in
+				// explicite au PNJ (TakeRewardOnTurnIn), pour éviter un octroi silencieux
+				// dès la dernière étape complétée.
+				state.status = QuestStatus::ReadyToTurnIn;
+				delta.status = QuestStatus::ReadyToTurnIn;
 				LOG_INFO(Net,
-					"[QuestRuntime] Quest completed (quest_id={}, reward_xp={}, reward_gold={}, reward_items={})",
-					definition.questId,
-					delta.rewardExperience,
-					delta.rewardGold,
-					delta.rewardItems.size());
+					"[QuestRuntime] Quest ready to turn in (quest_id={})",
+					definition.questId);
 			}
 
 			UpsertDelta(outDeltas, std::move(delta));
@@ -779,6 +782,25 @@ namespace engine::server
 		}
 
 		return nullptr;
+	}
+
+	bool QuestRuntime::CanAccept(const QuestState& state, const QuestDefinition& def, std::string_view giverTargetId) const
+	{
+		return state.questId == def.questId
+			&& state.status == QuestStatus::Offered
+			&& giverTargetId == def.giverId;
+	}
+
+	bool QuestRuntime::CanTurnIn(const QuestState& state, const QuestDefinition& def, std::string_view npcTargetId) const
+	{
+		return state.questId == def.questId
+			&& state.status == QuestStatus::ReadyToTurnIn
+			&& npcTargetId == def.turnInId;
+	}
+
+	const QuestReward* QuestRuntime::TakeRewardOnTurnIn(const QuestDefinition& def) const
+	{
+		return &def.rewards;
 	}
 
 	bool QuestRuntime::LoadDefinitions()

--- a/src/shardd/gameplay/quest/QuestRuntime.h
+++ b/src/shardd/gameplay/quest/QuestRuntime.h
@@ -112,6 +112,17 @@ namespace engine::server
 		/// Find one quest definition by id, or return `nullptr` when it is absent.
 		const QuestDefinition* FindQuestDefinition(std::string_view questId) const;
 
+		/// Vrai si \p state peut être accepté au PNJ \p giverTargetId : quête Offered
+		/// et \p giverTargetId == def.giverId. Pur, sans effet de bord.
+		bool CanAccept(const QuestState& state, const QuestDefinition& def, std::string_view giverTargetId) const;
+
+		/// Vrai si \p state peut être rendu au PNJ \p npcTargetId : quête ReadyToTurnIn
+		/// et \p npcTargetId == def.turnInId. Pur, sans effet de bord.
+		bool CanTurnIn(const QuestState& state, const QuestDefinition& def, std::string_view npcTargetId) const;
+
+		/// Retourne le bundle de récompense à verser au turn-in (jamais nul).
+		const QuestReward* TakeRewardOnTurnIn(const QuestDefinition& def) const;
+
 	private:
 		/// Load every quest definition from the configured JSON content file.
 		bool LoadDefinitions();

--- a/src/shardd/gameplay/quest/QuestRuntime.h
+++ b/src/shardd/gameplay/quest/QuestRuntime.h
@@ -19,12 +19,15 @@ namespace engine::server
 		Enter = 4
 	};
 
-	/// Runtime status stored for one quest on one player.
+	/// Runtime status stored for one quest on one player. L'ordre est
+	/// significatif (persisté et transmis wire) : ne pas réordonner sans migration.
 	enum class QuestStatus : uint8_t
 	{
-		Locked = 0,
-		Active = 1,
-		Completed = 2
+		Locked        = 0,   ///< pré-requis non remplis (interne, non affiché)
+		Offered       = 1,   ///< proposée au PNJ giver, pas encore acceptée
+		Active        = 2,   ///< acceptée, en cours
+		ReadyToTurnIn = 3,   ///< étapes remplies, à rendre (pas encore récompensée)
+		Completed     = 4,   ///< rendue + récompensée (terminal)
 	};
 
 	/// One typed step loaded from the quest definitions JSON.
@@ -47,6 +50,8 @@ namespace engine::server
 	struct QuestDefinition
 	{
 		std::string questId;
+		std::string giverId;    ///< PNJ qui propose la quête (même espace que targetId du Talk)
+		std::string turnInId;   ///< PNJ où rendre la quête (souvent = giverId)
 		std::vector<std::string> prerequisiteQuestIds;
 		std::vector<QuestStepDefinition> steps;
 		QuestReward rewards;

--- a/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
@@ -123,6 +123,56 @@ int main()
 		Check(!badRuntime.Init(), "Init rejette une quête sans turnIn");
 	}
 
+	// Transitions pilotées par le joueur : Offered → Active (accept) →
+	// ReadyToTurnIn (dernière étape complétée, sans récompense auto) → turn-in.
+	{
+		const std::string json = R"JSON({
+      "quests": [
+        { "id": "q1", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [], "steps": [ { "type": "kill", "target": "mob:1", "requiredCount": 2 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } }
+      ]
+    })JSON";
+
+		QuestRuntime runtime = MakeRuntimeWithFixture(json);
+		Check(runtime.Init(), "Init charge q1 pour le test de transitions");
+
+		std::vector<QuestState> states;
+		std::vector<QuestProgressDelta> deltas;
+		Check(runtime.SyncQuestStates(states, deltas), "sync OK");
+		// q1 sans prérequis → Offered (PAS Active).
+		Check(states.size() == 1 && states[0].status == QuestStatus::Offered,
+		      "prérequis remplis → Offered");
+
+		const auto* def = runtime.FindQuestDefinition("q1");
+		Check(def != nullptr, "def q1");
+		Check(runtime.CanAccept(states[0], *def, "npc:marn"), "accept au bon giver");
+		Check(!runtime.CanAccept(states[0], *def, "npc:autre"), "refus mauvais giver");
+
+		// Simuler l'accept : Offered → Active.
+		states[0].status = QuestStatus::Active;
+
+		// Progresser : 1 kill (pas assez) reste Active.
+		deltas.clear();
+		runtime.ApplyEvent(states, QuestStepType::Kill, "mob:1", 1, deltas);
+		Check(states[0].status == QuestStatus::Active, "1/2 kill → reste Active");
+
+		// 2e kill → ReadyToTurnIn, SANS reward dans le delta.
+		deltas.clear();
+		runtime.ApplyEvent(states, QuestStepType::Kill, "mob:1", 1, deltas);
+		Check(states[0].status == QuestStatus::ReadyToTurnIn, "2/2 kill → ReadyToTurnIn");
+		bool anyReward = false;
+		for (const auto& d : deltas)
+			if (d.rewardExperience != 0 || d.rewardGold != 0 || !d.rewardItems.empty()) anyReward = true;
+		Check(!anyReward, "aucune récompense au passage ReadyToTurnIn");
+
+		Check(runtime.CanTurnIn(states[0], *def, "npc:marn"), "turn-in au bon PNJ");
+		Check(!runtime.CanTurnIn(states[0], *def, "npc:autre"), "refus turn-in mauvais PNJ");
+
+		const auto* reward = runtime.TakeRewardOnTurnIn(*def);
+		Check(reward != nullptr && reward->experience == 10, "reward exposé au turn-in");
+	}
+
 	if (g_failures != 0)
 	{
 		std::cerr << g_failures << " assertion(s) échouée(s)\n";

--- a/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
@@ -1,0 +1,133 @@
+// Tests du QuestRuntime — cycle de vie piloté par le joueur (SP1).
+//
+// Écrit une fixture JSON dans un répertoire temporaire unique (isolé du vrai
+// contenu du dépôt) et pointe `paths.content` dessus via Config::SetValue,
+// à l'instar de WorldEditorSessionTests.cpp (MakeTempContentDir). QuestRuntime
+// n'expose pas de LoadFromText comme CreatureArchetypeLibrary : Init() lit
+// toujours un fichier via FileSystem::ReadAllTextContent, donc le test passe
+// par une vraie E/S disque (déterministe : un dossier temporaire par appel).
+
+#include "src/shardd/gameplay/quest/QuestRuntime.h"
+#include "src/shared/core/Config.h"
+#include "src/shared/platform/FileSystem.h"
+
+#include <filesystem>
+#include <iostream>
+#include <random>
+#include <string>
+
+using engine::server::QuestRuntime;
+using engine::server::QuestStatus;
+using engine::server::QuestState;
+using engine::server::QuestStepType;
+using engine::server::QuestProgressDelta;
+
+namespace
+{
+	int g_failures = 0;
+
+	void Check(bool condition, const char* label)
+	{
+		if (!condition)
+		{
+			std::cerr << "[FAIL] " << label << "\n";
+			++g_failures;
+		}
+	}
+
+	/// Construit un répertoire temporaire unique sous temp_directory_path.
+	/// Abort si la création échoue (test invalide sinon).
+	std::filesystem::path MakeTempContentDir()
+	{
+		std::random_device rd;
+		std::mt19937_64 rng(rd());
+		const std::filesystem::path base = std::filesystem::temp_directory_path()
+			/ ("lcdlln_quest_runtime_test_" + std::to_string(rng()));
+		std::error_code ec;
+		std::filesystem::create_directories(base, ec);
+		if (ec)
+		{
+			std::cerr << "[FATAL] cannot create temp dir " << base.string() << ": " << ec.message() << "\n";
+			std::abort();
+		}
+		return base;
+	}
+
+	/// Écrit `jsonBody` comme définitions de quêtes dans un content root
+	/// temporaire isolé, construit une Config pointant dessus (`paths.content`)
+	/// et retourne un QuestRuntime prêt à appeler Init(). Le chemin relatif
+	/// reste le défaut (`quests/quest_definitions.json`) : seul le content
+	/// root change, donc on ne touche pas server.quest_definitions_path.
+	QuestRuntime MakeRuntimeWithFixture(const std::string& jsonBody)
+	{
+		const std::filesystem::path contentRoot = MakeTempContentDir();
+
+		engine::core::Config config;
+		config.SetValue("paths.content", engine::core::Config::Value{ contentRoot.string() });
+
+		const bool written = engine::platform::FileSystem::WriteAllTextContent(
+			config, "quests/quest_definitions.json", jsonBody);
+		if (!written)
+		{
+			std::cerr << "[FATAL] cannot write quest fixture under " << contentRoot.string() << "\n";
+			std::abort();
+		}
+
+		return QuestRuntime(config);
+	}
+}
+
+int main()
+{
+	// Une définition minimale avec giver/turnIn.
+	{
+		const std::string json = R"JSON({
+      "quests": [
+        { "id": "q1", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [], "steps": [ { "type": "kill", "target": "mob:1", "requiredCount": 2 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } }
+      ]
+    })JSON";
+
+		QuestRuntime runtime = MakeRuntimeWithFixture(json);
+		Check(runtime.Init(), "Init charge une définition avec giver/turnIn");
+
+		const auto* def = runtime.FindQuestDefinition("q1");
+		Check(def != nullptr, "q1 trouvée");
+		if (def != nullptr)
+		{
+			Check(def->giverId == "npc:marn", "giver parsé");
+			Check(def->turnInId == "npc:marn", "turnIn parsé");
+		}
+	}
+
+	// Rejet : quête sans giver.
+	{
+		const std::string bad = R"JSON({ "quests": [
+          { "id": "nogiver", "turnIn": "npc:x", "prereqs": [],
+            "steps": [ { "type": "talk", "target": "npc:x", "requiredCount": 1 } ],
+            "rewards": { "xp": 1, "gold": 0, "items": [] } } ] })JSON";
+
+		QuestRuntime badRuntime = MakeRuntimeWithFixture(bad);
+		Check(!badRuntime.Init(), "Init rejette une quête sans giver");
+	}
+
+	// Rejet : quête sans turnIn.
+	{
+		const std::string bad = R"JSON({ "quests": [
+          { "id": "noturnin", "giver": "npc:x", "prereqs": [],
+            "steps": [ { "type": "talk", "target": "npc:x", "requiredCount": 1 } ],
+            "rewards": { "xp": 1, "gold": 0, "items": [] } } ] })JSON";
+
+		QuestRuntime badRuntime = MakeRuntimeWithFixture(bad);
+		Check(!badRuntime.Init(), "Init rejette une quête sans turnIn");
+	}
+
+	if (g_failures != 0)
+	{
+		std::cerr << g_failures << " assertion(s) échouée(s)\n";
+		return 1;
+	}
+	std::cout << "OK\n";
+	return 0;
+}

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -1261,6 +1261,140 @@ namespace engine::server
 		return true;
 	}
 
+	// SP1 quêtes — cycle de vie complet (giver-list, accept, turn-in). Wire v13->v14.
+
+	std::vector<std::byte> EncodeQuestAcceptRequest(const QuestAcceptRequestMessage& message)
+	{
+		const size_t payloadSize = 4u + 2u + message.questId.size() + 2u + message.giverTargetId.size();
+		std::vector<std::byte> packet = BeginPacket(MessageKind::QuestAcceptRequest, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.questId);
+		WriteSizedString(packet, message.giverTargetId);
+		return packet;
+	}
+
+	bool DecodeQuestAcceptRequest(std::span<const std::byte> packet, QuestAcceptRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::QuestAcceptRequest, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.questId))
+		{
+			return false;
+		}
+		if (!ReadSizedString(payload, offset, outMessage.giverTargetId) || offset != payload.size())
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	std::vector<std::byte> EncodeQuestTurnInRequest(const QuestTurnInRequestMessage& message)
+	{
+		const size_t payloadSize = 4u + 2u + message.questId.size() + 2u + message.npcTargetId.size();
+		std::vector<std::byte> packet = BeginPacket(MessageKind::QuestTurnInRequest, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.questId);
+		WriteSizedString(packet, message.npcTargetId);
+		return packet;
+	}
+
+	bool DecodeQuestTurnInRequest(std::span<const std::byte> packet, QuestTurnInRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::QuestTurnInRequest, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.questId))
+		{
+			return false;
+		}
+		if (!ReadSizedString(payload, offset, outMessage.npcTargetId) || offset != payload.size())
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	std::vector<std::byte> EncodeQuestGiverList(const QuestGiverListMessage& message)
+	{
+		size_t payloadSize = 4u + 2u + message.npcTargetId.size() + 2u;
+		for (const QuestGiverEntry& entry : message.entries)
+		{
+			payloadSize += 2u + entry.questId.size() + 1u;
+		}
+
+		std::vector<std::byte> packet = BeginPacket(MessageKind::QuestGiverList, payloadSize);
+		WriteU32(packet, message.clientId);
+		WriteSizedString(packet, message.npcTargetId);
+		WriteU16(packet, static_cast<uint16_t>(message.entries.size()));
+		for (const QuestGiverEntry& entry : message.entries)
+		{
+			WriteSizedString(packet, entry.questId);
+			packet.push_back(static_cast<std::byte>(entry.role));
+		}
+		return packet;
+	}
+
+	bool DecodeQuestGiverList(std::span<const std::byte> packet, QuestGiverListMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::QuestGiverList, payload) || payload.size() < 8)
+		{
+			return false;
+		}
+
+		size_t offset = 0;
+		outMessage.clientId = ReadU32(payload, offset);
+		offset += 4;
+		if (!ReadSizedString(payload, offset, outMessage.npcTargetId))
+		{
+			return false;
+		}
+
+		if ((offset + 2) > payload.size())
+		{
+			return false;
+		}
+		const uint16_t count = ReadU16(payload, offset);
+		offset += 2;
+
+		outMessage.entries.clear();
+		outMessage.entries.reserve(count);
+		for (uint16_t index = 0; index < count; ++index)
+		{
+			QuestGiverEntry entry{};
+			if (!ReadSizedString(payload, offset, entry.questId))
+			{
+				outMessage.entries.clear();
+				return false;
+			}
+			if (offset >= payload.size())
+			{
+				outMessage.entries.clear();
+				return false;
+			}
+			entry.role = static_cast<uint8_t>(payload[offset]);
+			offset += 1;
+			outMessage.entries.push_back(std::move(entry));
+		}
+
+		return offset == payload.size();
+	}
+
 	std::vector<std::byte> EncodeEventState(const EventStateMessage& message)
 	{
 		size_t payloadSize = 4 + 1 + 2 + 2 + 4 + 4 + 2 + message.eventId.size() + 2 + message.notificationText.size() + 4 + 4 + 2;

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -59,7 +59,7 @@ namespace engine::server
 	/// 4 → 5). Les kinds ForcePosition (86) et LootNotify (87) ajoutés pendant
 	/// la fenêtre v12 restaient rétro-additifs ; ce changement-ci modifie un
 	/// payload existant → wire-breaking : lock-step master + shardd + client.
-	inline constexpr uint16_t kProtocolVersion = 13;
+	inline constexpr uint16_t kProtocolVersion = 14;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -278,7 +278,16 @@ namespace engine::server
 		/// poussé à l'enter-world et après chaque choix. Rétro-additif.
 		ClassProgressionUpdate = 90,
 		/// SP-B — client → shard : le joueur choisit 1 skill (parmi 3) à un niveau donné.
-		ChooseClassSkillRequest = 91
+		ChooseClassSkillRequest = 91,
+
+		// SP1 quêtes — cycle de vie complet (giver-list, accept, turn-in) — bump v13->v14.
+
+		/// SP1 quêtes — liste des quêtes offertes/rendables d'un PNJ (serveur→client).
+		QuestGiverList = 92,
+		/// SP1 quêtes — le joueur accepte une quête au PNJ giver (client→serveur).
+		QuestAcceptRequest = 93,
+		/// SP1 quêtes — le joueur rend une quête au PNJ turn-in (client→serveur).
+		QuestTurnInRequest = 94
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -577,6 +586,38 @@ namespace engine::server
 		std::vector<ItemStack> rewardItems;
 	};
 
+	/// Une entrée de la liste de quêtes d'un PNJ (offer ou turn-in).
+	struct QuestGiverEntry
+	{
+		std::string questId;
+		uint8_t role = 0;   ///< 0 = offer (Offered), 1 = turnin (ReadyToTurnIn)
+	};
+
+	/// SP1 quêtes — réponse au Talk : quêtes qu'un PNJ propose / que le joueur peut y rendre
+	/// (serveur→client).
+	struct QuestGiverListMessage
+	{
+		uint32_t clientId = 0;
+		std::string npcTargetId;
+		std::vector<QuestGiverEntry> entries;
+	};
+
+	/// SP1 quêtes — le joueur accepte une quête au PNJ giver (client→serveur).
+	struct QuestAcceptRequestMessage
+	{
+		uint32_t clientId = 0;
+		std::string questId;
+		std::string giverTargetId;
+	};
+
+	/// SP1 quêtes — le joueur rend une quête au PNJ turn-in (client→serveur).
+	struct QuestTurnInRequestMessage
+	{
+		uint32_t clientId = 0;
+		std::string questId;
+		std::string npcTargetId;
+	};
+
 	/// Client chat send request (parsed prefixes applied client-side; server validates + routes).
 	struct ChatSendRequestMessage
 	{
@@ -755,6 +796,18 @@ namespace engine::server
 
 	/// Decode a quest delta packet and validate the protocol header.
 	bool DecodeQuestDelta(std::span<const std::byte> packet, QuestDeltaMessage& outMessage);
+
+	/// SP1 quêtes — encode/decode de la liste des quêtes offertes/rendables d'un PNJ (serveur→client).
+	std::vector<std::byte> EncodeQuestGiverList(const QuestGiverListMessage& message);
+	bool DecodeQuestGiverList(std::span<const std::byte> packet, QuestGiverListMessage& outMessage);
+
+	/// SP1 quêtes — encode/decode de l'acceptation d'une quête (client→serveur).
+	std::vector<std::byte> EncodeQuestAcceptRequest(const QuestAcceptRequestMessage& message);
+	bool DecodeQuestAcceptRequest(std::span<const std::byte> packet, QuestAcceptRequestMessage& outMessage);
+
+	/// SP1 quêtes — encode/decode du rendu d'une quête (client→serveur).
+	std::vector<std::byte> EncodeQuestTurnInRequest(const QuestTurnInRequestMessage& message);
+	bool DecodeQuestTurnInRequest(std::span<const std::byte> packet, QuestTurnInRequestMessage& outMessage);
 
 	/// Encode a dynamic event state packet with the protocol header.
 	std::vector<std::byte> EncodeEventState(const EventStateMessage& message);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -673,6 +673,86 @@ namespace
 		std::puts("[OK] TestLootNotifyRoundTrip");
 	}
 
+	/// SP1 quêtes — round-trip QuestAcceptRequest (client→serveur) + rejet tronqué.
+	void TestQuestAcceptRequestRoundTrip()
+	{
+		engine::server::QuestAcceptRequestMessage in{};
+		in.clientId = 7u;
+		in.questId = "q1";
+		in.giverTargetId = "npc:marn";
+
+		const std::vector<std::byte> packet = engine::server::EncodeQuestAcceptRequest(in);
+		assert(!packet.empty());
+
+		engine::server::QuestAcceptRequestMessage out{};
+		assert(engine::server::DecodeQuestAcceptRequest(packet, out));
+		assert(out.clientId == 7u);
+		assert(out.questId == "q1");
+		assert(out.giverTargetId == "npc:marn");
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeQuestAcceptRequest(truncated, out));
+		std::puts("[OK] TestQuestAcceptRequestRoundTrip");
+	}
+
+	/// SP1 quêtes — round-trip QuestTurnInRequest (client→serveur) + rejet tronqué.
+	void TestQuestTurnInRequestRoundTrip()
+	{
+		engine::server::QuestTurnInRequestMessage in{};
+		in.clientId = 9u;
+		in.questId = "q2";
+		in.npcTargetId = "npc:guard";
+
+		const std::vector<std::byte> packet = engine::server::EncodeQuestTurnInRequest(in);
+		assert(!packet.empty());
+
+		engine::server::QuestTurnInRequestMessage out{};
+		assert(engine::server::DecodeQuestTurnInRequest(packet, out));
+		assert(out.clientId == 9u);
+		assert(out.questId == "q2");
+		assert(out.npcTargetId == "npc:guard");
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeQuestTurnInRequest(truncated, out));
+		std::puts("[OK] TestQuestTurnInRequestRoundTrip");
+	}
+
+	/// SP1 quêtes — round-trip QuestGiverList (serveur→client) : 2 entrées (offer + turnin),
+	/// liste vide valide, et rejet d'un paquet tronqué.
+	void TestQuestGiverListRoundTrip()
+	{
+		engine::server::QuestGiverListMessage in{};
+		in.clientId = 3u;
+		in.npcTargetId = "npc:marn";
+		in.entries.push_back(engine::server::QuestGiverEntry{ "q1", 0u });
+		in.entries.push_back(engine::server::QuestGiverEntry{ "q2", 1u });
+
+		const std::vector<std::byte> packet = engine::server::EncodeQuestGiverList(in);
+		assert(!packet.empty());
+
+		engine::server::QuestGiverListMessage out{};
+		assert(engine::server::DecodeQuestGiverList(packet, out));
+		assert(out.clientId == 3u);
+		assert(out.npcTargetId == "npc:marn");
+		assert(out.entries.size() == 2u);
+		assert(out.entries[0].questId == "q1" && out.entries[0].role == 0u);
+		assert(out.entries[1].questId == "q2" && out.entries[1].role == 1u);
+
+		// Liste vide : valide (PNJ sans quête à offrir/rendre pour ce joueur).
+		engine::server::QuestGiverListMessage empty{};
+		empty.clientId = 3u;
+		empty.npcTargetId = "npc:marn";
+		assert(engine::server::DecodeQuestGiverList(engine::server::EncodeQuestGiverList(empty), out));
+		assert(out.entries.empty());
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeQuestGiverList(truncated, out));
+		std::puts("[OK] TestQuestGiverListRoundTrip");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
@@ -698,6 +778,9 @@ int main()
 	TestPlayerStatsRoundTripWithProfile();
 	TestForcePositionRoundTrip();
 	TestLootNotifyRoundTrip();
+	TestQuestAcceptRequestRoundTrip();
+	TestQuestTurnInRequestRoundTrip();
+	TestQuestGiverListRoundTrip();
 	std::puts("All ServerProtocol tests passed");
 	return 0;
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -864,6 +864,22 @@ namespace engine::server
 			return;
 		}
 
+		// SP1 quêtes — accepter une quête proposée par un PNJ giver.
+		QuestAcceptRequestMessage questAccept{};
+		if (DecodeQuestAcceptRequest(packetBytes, questAccept))
+		{
+			HandleAcceptQuest(datagram.endpoint, questAccept);
+			return;
+		}
+
+		// SP1 quêtes — rendre une quête (récompense versée ici).
+		QuestTurnInRequestMessage questTurnIn{};
+		if (DecodeQuestTurnInRequest(packetBytes, questTurnIn))
+		{
+			HandleTurnInQuest(datagram.endpoint, questTurnIn);
+			return;
+		}
+
 		ShopBuyRequestMessage shopBuy{};
 		if (DecodeShopBuyRequest(packetBytes, shopBuy))
 		{
@@ -3419,6 +3435,7 @@ namespace engine::server
 		}
 
 		LOG_INFO(Net, "[ServerApp] TalkRequest accepted (client_id={}, target={})", client->clientId, targetId);
+		SendQuestGiverList(*client, targetId);
 		ApplyQuestEvent(*client, QuestStepType::Talk, targetId, 1, "talk");
 	}
 
@@ -5218,47 +5235,14 @@ namespace engine::server
 			return;
 		}
 
-		std::vector<ItemStack> rewardedItems;
+		// SP1 quêtes — les récompenses ne sont plus versées ici : elles le sont
+		// désormais au turn-in explicite (HandleTurnInQuest). Ce chemin ne fait
+		// que propager les deltas de progression au client.
 		for (const QuestProgressDelta& delta : deltas)
 		{
-			if (delta.rewardExperience != 0 || delta.rewardGold != 0 || !delta.rewardItems.empty())
-			{
-				ApplyLevelUpsAfterXp(client, delta.rewardExperience);
-				if (delta.rewardGold != 0u)
-				{
-					std::string walletErr;
-					if (!m_playerWallet.AddCurrency(client, kCurrencyGold, delta.rewardGold, walletErr))
-					{
-						LOG_WARN(Net,
-							"[ServerApp] Quest gold grant blocked (client_id={}, err={})",
-							client.clientId,
-							walletErr);
-					}
-				}
-				for (const ItemStack& rewardItem : delta.rewardItems)
-				{
-					AddItemToInventory(client, rewardItem);
-					rewardedItems.push_back(rewardItem);
-				}
-
-				LOG_INFO(Net,
-					"[ServerApp] Quest rewards granted (client_id={}, quest_id={}, xp={}, gold={}, items={})",
-					client.clientId,
-					delta.questId,
-					delta.rewardExperience,
-					delta.rewardGold,
-					delta.rewardItems.size());
-			}
-
 			(void)SendQuestDelta(client, delta);
 		}
 
-		if (!rewardedItems.empty())
-		{
-			(void)SendInventoryDelta(client, rewardedItems);
-		}
-
-		(void)SendWalletUpdate(client);
 		SaveConnectedClient(client, reason);
 		LOG_INFO(Net,
 			"[ServerApp] Quest event applied (client_id={}, type={}, target={}, deltas={}, reason={})",
@@ -5267,6 +5251,221 @@ namespace engine::server
 			targetId,
 			deltas.size(),
 			reason);
+	}
+
+	size_t ServerApp::FindClientQuestStateIndex(const ConnectedClient& client, std::string_view questId)
+	{
+		for (size_t i = 0; i < client.questStates.size(); ++i)
+		{
+			if (client.questStates[i].questId == questId)
+			{
+				return i;
+			}
+		}
+		return kInvalidQuestIndex;
+	}
+
+	bool ServerApp::IsClientNearNpc(const ConnectedClient& client, std::string_view npcTargetId) const
+	{
+		// V1 : aucune vérification de distance serveur. Le Talk (HandleTalkRequest)
+		// route aujourd'hui uniquement par targetId, sans contrôle de portée côté
+		// serveur ; la proximité est garantie côté client (le Talk n'est émis que
+		// lorsque le joueur est à portée du PNJ). TODO SP-ultérieur : durcir avec
+		// une vraie distance joueur/PNJ une fois les positions PNJ exposées ici.
+		(void)client;
+		(void)npcTargetId;
+		return true;
+	}
+
+	void ServerApp::SendQuestGiverList(const ConnectedClient& receiver, std::string_view npcTargetId)
+	{
+		QuestGiverListMessage msg{};
+		msg.clientId = receiver.clientId;
+		msg.npcTargetId = std::string(npcTargetId);
+		for (const QuestState& state : receiver.questStates)
+		{
+			const QuestDefinition* def = m_questRuntime.FindQuestDefinition(state.questId);
+			if (def == nullptr)
+			{
+				continue;
+			}
+			if (state.status == QuestStatus::Offered && def->giverId == npcTargetId)
+			{
+				msg.entries.push_back(QuestGiverEntry{ state.questId, 0u });
+			}
+			else if (state.status == QuestStatus::ReadyToTurnIn && def->turnInId == npcTargetId)
+			{
+				msg.entries.push_back(QuestGiverEntry{ state.questId, 1u });
+			}
+		}
+
+		if (msg.entries.empty())
+		{
+			return;
+		}
+
+		const std::vector<std::byte> packet = EncodeQuestGiverList(msg);
+		if (!m_transport.Send(receiver.endpoint, packet))
+		{
+			LOG_WARN(Net, "[ServerApp] QuestGiverList send failed (client_id={}, npc={})",
+				receiver.clientId,
+				npcTargetId);
+			return;
+		}
+
+		LOG_INFO(Net, "[ServerApp] QuestGiverList sent (client_id={}, npc={}, entries={})",
+			receiver.clientId,
+			npcTargetId,
+			msg.entries.size());
+	}
+
+	void ServerApp::HandleAcceptQuest(const Endpoint& endpoint, const QuestAcceptRequestMessage& msg)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != msg.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest ignored: client_id mismatch (expected={}, got={}, endpoint={})",
+				client->clientId,
+				msg.clientId,
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		const QuestDefinition* def = m_questRuntime.FindQuestDefinition(msg.questId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest: quête inconnue (client_id={}, quest_id={})", client->clientId, msg.questId);
+			return;
+		}
+
+		const size_t idx = FindClientQuestStateIndex(*client, msg.questId);
+		if (idx == kInvalidQuestIndex)
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest: état de quête absent (client_id={}, quest_id={})", client->clientId, msg.questId);
+			return;
+		}
+		QuestState& state = client->questStates[idx];
+
+		if (!m_questRuntime.CanAccept(state, *def, msg.giverTargetId))
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest refusé (client_id={}, quest_id={}, giver={})",
+				client->clientId, msg.questId, msg.giverTargetId);
+			return;
+		}
+
+		if (!IsClientNearNpc(*client, msg.giverTargetId))
+		{
+			return;
+		}
+
+		state.status = QuestStatus::Active;
+		state.stepProgressCounts.assign(def->steps.size(), 0u);
+
+		QuestProgressDelta delta{};
+		delta.questId = state.questId;
+		delta.status = state.status;
+		delta.stepProgressCounts = state.stepProgressCounts;
+		(void)SendQuestDelta(*client, delta);
+		SaveConnectedClient(*client, "quest_accept");
+		LOG_INFO(Net, "[ServerApp] Quest accepted (client_id={}, quest_id={})", client->clientId, msg.questId);
+	}
+
+	void ServerApp::HandleTurnInQuest(const Endpoint& endpoint, const QuestTurnInRequestMessage& msg)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		if (client->clientId != msg.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest ignored: client_id mismatch (expected={}, got={}, endpoint={})",
+				client->clientId,
+				msg.clientId,
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+
+		const QuestDefinition* def = m_questRuntime.FindQuestDefinition(msg.questId);
+		if (def == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest: quête inconnue (client_id={}, quest_id={})", client->clientId, msg.questId);
+			return;
+		}
+
+		const size_t idx = FindClientQuestStateIndex(*client, msg.questId);
+		if (idx == kInvalidQuestIndex)
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest: état de quête absent (client_id={}, quest_id={})", client->clientId, msg.questId);
+			return;
+		}
+		QuestState& state = client->questStates[idx];
+
+		if (!m_questRuntime.CanTurnIn(state, *def, msg.npcTargetId))
+		{
+			LOG_WARN(Net, "[ServerApp] TurnInQuest refusé (client_id={}, quest_id={}, npc={})",
+				client->clientId, msg.questId, msg.npcTargetId);
+			return;
+		}
+
+		if (!IsClientNearNpc(*client, msg.npcTargetId))
+		{
+			return;
+		}
+
+		// Verser les récompenses (bloc déplacé depuis l'ancien ApplyQuestEvent —
+		// désormais le turn-in explicite est le seul chemin de versement).
+		const QuestReward* reward = m_questRuntime.TakeRewardOnTurnIn(*def);
+		std::vector<ItemStack> rewardedItems;
+		if (reward != nullptr)
+		{
+			ApplyLevelUpsAfterXp(*client, reward->experience);
+			if (reward->gold != 0u)
+			{
+				std::string walletErr;
+				if (!m_playerWallet.AddCurrency(*client, kCurrencyGold, reward->gold, walletErr))
+				{
+					LOG_WARN(Net, "[ServerApp] Quest gold grant blocked (client_id={}, err={})", client->clientId, walletErr);
+				}
+			}
+			for (const ItemStack& item : reward->items)
+			{
+				AddItemToInventory(*client, item);
+				rewardedItems.push_back(item);
+			}
+		}
+
+		state.status = QuestStatus::Completed;
+
+		QuestProgressDelta delta{};
+		delta.questId = state.questId;
+		delta.status = state.status;
+		delta.stepProgressCounts = state.stepProgressCounts;
+		if (reward != nullptr)
+		{
+			delta.rewardExperience = reward->experience;
+			delta.rewardGold = reward->gold;
+			delta.rewardItems = reward->items;
+		}
+		(void)SendQuestDelta(*client, delta);
+		if (!rewardedItems.empty())
+		{
+			(void)SendInventoryDelta(*client, rewardedItems);
+		}
+		(void)SendWalletUpdate(*client);
+		SaveConnectedClient(*client, "quest_turnin");
+		LOG_INFO(Net, "[ServerApp] Quest turned in (client_id={}, quest_id={}, xp={}, gold={})",
+			client->clientId, msg.questId, reward ? reward->experience : 0u, reward ? reward->gold : 0u);
 	}
 
 	void ServerApp::SendQuestStateBootstrap(const ConnectedClient& receiver)

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -685,6 +685,29 @@ namespace engine::server
 		/// Send the current quest journal state after the client handshake succeeds.
 		void SendQuestStateBootstrap(const ConnectedClient& receiver);
 
+		/// SP1 quêtes — le joueur accepte une quête au PNJ giver (Offered -> Active).
+		void HandleAcceptQuest(const Endpoint& endpoint, const QuestAcceptRequestMessage& msg);
+
+		/// SP1 quêtes — le joueur rend une quête (ReadyToTurnIn -> Completed) : récompenses versées ici.
+		void HandleTurnInQuest(const Endpoint& endpoint, const QuestTurnInRequestMessage& msg);
+
+		/// SP1 quêtes — envoie la liste des quêtes offertes/rendables d'un PNJ au client.
+		void SendQuestGiverList(const ConnectedClient& receiver, std::string_view npcTargetId);
+
+		/// SP1 quêtes — sentinelle « non trouvé » pour FindClientQuestStateIndex.
+		static constexpr size_t kInvalidQuestIndex = static_cast<size_t>(-1);
+
+		/// SP1 quêtes — retrouve l'index de l'état de quête \p questId dans
+		/// \p client.questStates. Renvoie kInvalidQuestIndex si absent.
+		static size_t FindClientQuestStateIndex(const ConnectedClient& client, std::string_view questId);
+
+		/// SP1 quêtes — contrôle de portée joueur/PNJ pour accept/turn-in.
+		/// V1 : renvoie toujours true — la portée est aujourd'hui garantie côté
+		/// client (le Talk n'est émis qu'à proximité du PNJ) ; le Talk serveur
+		/// actuel route uniquement par targetId, sans vérifier de distance.
+		/// TODO SP-ultérieur : durcir côté serveur (distance réelle joueur/PNJ).
+		bool IsClientNearNpc(const ConnectedClient& client, std::string_view npcTargetId) const;
+
 		/// Send the current event state snapshot for the receiver's zone.
 		void SendDynamicEventBootstrap(const ConnectedClient& receiver);
 


### PR DESCRIPTION
## Résumé

SP1 du chantier quêtes : transforme le système de quêtes du shard (`QuestRuntime`, data-driven) de « tout automatique » en **cycle piloté par le joueur**.

Machine d'états par personnage : `Locked → Offered → Active → ReadyToTurnIn → Completed`.
- **Offered** : pré-requis remplis ; proposée par le PNJ `giver` (giver-list au Talk, pas dans le journal).
- **Active** : accepté (`QuestAcceptRequest`, opcode 93) ; progression via events gameplay (Kill/Collect/Talk/Enter).
- **ReadyToTurnIn** : étapes remplies, **aucune récompense encore**.
- **Completed** : rendu au PNJ `turnIn` (`QuestTurnInRequest`, opcode 94) → **récompenses versées au turn-in** (XP/or/items).
- Au `Talk`, le shard renvoie `QuestGiverList` (opcode 92) **en plus** de l'event d'étape Talk.

## Tâches (6, TDD, revues une à une + revue finale de branche)

1. Enum `QuestStatus` étendu (`Offered`/`ReadyToTurnIn`) + champs `giver`/`turnIn` au JSON (rejet si absents) + tests.
2. `SyncQuestStates→Offered`, `ApplyEvent→ReadyToTurnIn` (reward différé) + helpers `CanAccept`/`CanTurnIn`/`TakeRewardOnTurnIn`.
3. Messages wire `QuestGiverList`/`QuestAcceptRequest`/`QuestTurnInRequest` (opcodes 92/93/94) + bump `kProtocolVersion` 13→14 + round-trip.
4. Compat persistance (ancien enum 0/1/2 → nouveau) + `quests.format_version`.
5. Handlers `ServerApp` accept/turn-in (reward déplacé au turn-in) + giver-list au Talk + dispatch.
6. Doc CODEBASE_MAP.

## Déploiement

> ⚠️ **REDÉPLOIEMENT SHARD requis** — wire-breaking : `kProtocolVersion` 13→14, nouveaux opcodes 92/93/94, nouveaux handlers. À déployer **en lock-step avec le client SP2** (un client neuf parlerait dans le vide à un shard ancien, et inversement). Aucun changement master. Aucune migration DB (persistance clé-valeur, gérée par `format_version`).

## Suivis à tracer (hors périmètre SP1)

- **Portée serveur accept/turn-in** : `IsClientNearNpc` est un stub V1 (`true`) → pas de gate de distance côté serveur (cohérent avec le handler `Talk` existant, exploit borné : on ne peut agir que sur ses propres quêtes dans le bon état). Durcissement à faire avec la même passe pour `Talk`.
- Nettoyages mineurs : `reward != nullptr` mort, guard `FindClient` dupliqué (×3), `format_version` relu en boucle.

## Note CI

Aucun build local possible dans l'environnement de dev (toolchain absente) : cette PR déclenche `build-linux` (ctest) + `build-windows`, qui sont le **gate final**. La revue a confirmé la compile-plausibilité (symboles, signatures, topologie de link CMake, sémantique des helpers wire).

Specs & plan : `docs/superpowers/specs/2026-07-02-quest-*`, `docs/superpowers/plans/2026-07-02-quest-sp1-player-lifecycle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)