### PR TITLE
feat(quests): SP5 — tranche verticale « tuer 10 sangliers » (contenu shard)

### DIFF
--- a/game/data/quests/quest_definitions.json
+++ b/game/data/quests/quest_definitions.json
@@ -1,6 +1,20 @@
 {
   "quests": [
     {
+      "id": "kill_10_boars",
+      "giver": "npc:elder_marn",
+      "turnIn": "npc:elder_marn",
+      "prereqs": [],
+      "steps": [
+        { "type": "kill", "target": "mob:100", "requiredCount": 10 }
+      ],
+      "rewards": {
+        "xp": 200,
+        "gold": 50,
+        "items": []
+      }
+    },
+    {
       "id": "hunt_collect_enter",
       "giver": "npc:elder_marn",
       "turnIn": "npc:elder_marn",

--- a/game/data/zones/feyhin/spawners.json
+++ b/game/data/zones/feyhin/spawners.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "SP5 — Sangliers (archetype 100, 'Sanglier des collines') pour la quete kill_10_boars donnee par le villageois npc:elder_marn. zoneId = 1 : c'est la zone gameplay du joueur en feyhin (ServerApp defaut client.zoneId = 1) ; les spawners ne spawnent que si client.zoneId == spawner.zoneId. Places au NORD du spawn joueur (0,0,0), a l'ecart du bassin d'eau (a l'est). ~12 sangliers pour permettre d'en tuer 10 avec du respawn. Positions/hauteurs (y=0, ground-snap serveur) A AFFINER en jeu apres deploiement (terrain feyhin non verifie ici).",
+  "zoneId": 1,
+  "spawners": [
+    {
+      "id": "feyhin_boars_north_01",
+      "archetypeId": 100,
+      "position": [12.0, 0.0, -28.0],
+      "count": 3,
+      "respawnSec": 15,
+      "leashDistanceMeters": 24.0
+    },
+    {
+      "id": "feyhin_boars_north_02",
+      "archetypeId": 100,
+      "position": [-10.0, 0.0, -34.0],
+      "count": 3,
+      "respawnSec": 15,
+      "leashDistanceMeters": 24.0
+    },
+    {
+      "id": "feyhin_boars_north_03",
+      "archetypeId": 100,
+      "position": [22.0, 0.0, -40.0],
+      "count": 3,
+      "respawnSec": 15,
+      "leashDistanceMeters": 24.0
+    },
+    {
+      "id": "feyhin_boars_north_04",
+      "archetypeId": 100,
+      "position": [-18.0, 0.0, -22.0],
+      "count": 3,
+      "respawnSec": 15,
+      "leashDistanceMeters": 24.0
+    }
+  ]
+}


### PR DESCRIPTION
## Résumé

Capstone du chantier quêtes : le contenu qui rend la boucle **jouable de bout en bout**. Un PNJ (le villageois **`npc:elder_marn`**) donne la quête **« tuer 10 sangliers »**, validée en tuant les sangliers, puis rendue au PNJ pour la récompense.

- **`quest_definitions.json`** (shard) : nouvelle quête `kill_10_boars` — `giver`/`turnIn` = `npc:elder_marn`, step `kill mob:100 ×10`, récompense xp 200 / or 50.
- **`game/data/zones/feyhin/spawners.json`** (nouveau) : ~12 sangliers (`archetypeId 100` = « Sanglier des collines », existant) en **`zoneId 1`** (la zone gameplay du joueur en feyhin), en cluster au nord du spawn.

Le **contenu client** de cette quête (`quest_texts.fr.json`, `quest_givers.json`, `questKey` du dialogue villageois, `npc_target_id` = `npc:elder_marn`) a déjà été livré par **SP2 (#928)**.

## Déploiement

> ⚠️ **Contenu SHARD → redéploiement/restart shard requis** pour charger la nouvelle quête + les spawners (`QuestRuntime`/`SpawnerRuntime` chargent au boot). Aucun changement de code, aucun wire, aucune migration DB.

Validation en jeu possible **une fois SP1 (mergé) + SP2 (#928) déployés** (client + shard en lock-step).

## Critère d'acceptation (smoke test en jeu, après déploiement)

Parler au villageois → **Accepter** « tuer 10 sangliers » → tuer 10 `mob:100` (tracker 0/10 → 10/10) → retourner au villageois → **Terminer** → +200 XP / +50 or → quête `Completed` ; survit à un restart shard (persistance SP1).

## À affiner en jeu

Les **positions/hauteurs** des sangliers (`y=0`, ground-snap serveur supposé ; terrain feyhin non vérifié ici) sont à ajuster après un premier passage en jeu — flaggé en commentaire dans `spawners.json`.

Specs : `docs/superpowers/specs/2026-07-02-quest-system-overview-design.md` (§ SP5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)